### PR TITLE
Add Attention and RoPE classes

### DIFF
--- a/fleet/core/fusions/fused_softmax.py
+++ b/fleet/core/fusions/fused_softmax.py
@@ -1,0 +1,143 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import paddle
+from paddle import Tensor, nn
+
+from fleet.core.transformer.enums import AttnMaskType
+from fleet.core.transformer.utils import (
+    get_default_causal_mask,
+    get_sliding_window_causal_mask,
+)
+
+
+class SoftmaxOne(nn.Layer):
+    r"""
+    Softmax-off-by-one function as introduced in
+    https://www.evanmiller.org/attention-is-off-by-one.html
+    Supports fixed or learnable offset
+    """
+
+    def __init__(
+        self, dim: int | None = None, denominator_offset: Tensor | float = 1.0
+    ) -> None:
+        super().__init__()
+        self.dim = dim
+        self.denominator_offset = denominator_offset
+
+    def forward(self, x: Tensor) -> Tensor:
+        """forward pass"""
+        # sink: [np] --> [1, np, 1, 1] --> [b, np, sq, 1]
+        sink = self.denominator_offset.reshape(1, -1, 1, 1).expand(
+            x.size(0), -1, x.size(2), -1
+        )
+        # qk: [b, np, sq, sk] --> [b, np, sq, sk+1]
+        qk = paddle.concat([x, sink], axis=-1)
+        # do softmax, and remove sink token at the end
+        ret = paddle.softmax(qk, axis=-1)[..., :-1]
+        return ret
+
+
+class FusedScaleMaskSoftmax(nn.Layer):
+    """
+    fused operation: scaling + mask + softmax
+
+    Args:
+        input_in_fp16: flag to indicate if input in fp16 data format.
+        input_in_bf16: flag to indicate if input in bf16 data format.
+        attn_mask_type: attention mask type (pad or causal)
+        scaled_masked_softmax_fusion: flag to indicate user want to use softmax fusion
+        mask_func: mask function to be applied.
+        softmax_in_fp32: if true, softmax in performed at fp32 precision.
+        scale: scaling factor used in input tensor scaling.
+    """
+
+    def __init__(
+        self,
+        input_in_fp16,
+        input_in_bf16,
+        attn_mask_type,
+        scaled_masked_softmax_fusion,
+        mask_func,
+        softmax_in_fp32,
+        scale,
+        window_size=None,
+    ):
+        super().__init__()
+        self.input_in_fp16 = input_in_fp16
+        self.input_in_bf16 = input_in_bf16
+        assert not (self.input_in_fp16 and self.input_in_bf16), (
+            "both fp16 and bf16 flags cannot be active at the same time."
+        )
+        self.input_in_float16 = self.input_in_fp16 or self.input_in_bf16
+        self.attn_mask_type = attn_mask_type
+        self.scaled_masked_softmax_fusion = scaled_masked_softmax_fusion
+        self.mask_func = mask_func
+        self.softmax_in_fp32 = softmax_in_fp32
+        self.scale = scale
+        self.window_size = window_size
+        assert self.scale is None or softmax_in_fp32, (
+            "softmax should be in fp32 when scaled"
+        )
+
+    def forward(
+        self,
+        input: Tensor,
+        mask: Tensor | None,
+        softmax_offset: Tensor | None = None,
+    ):
+        """Forward pass of softmax with masked input.
+
+        In case attn_mask_type is causal the mask is generated and None can be passed.
+        A user-defined mask is only needed when attn_mask_type is not causal.
+        """
+        # [b, np, sq, sk]
+        assert input.dim() == 4
+
+        if self.input_in_float16 and self.softmax_in_fp32:
+            input = input.float()
+
+        if self.scale is not None:
+            input = input * self.scale
+
+        # Generate causal mask if not given
+        sq, sk = input.size(2), input.size(3)
+        if self.window_size is not None:
+            mask = get_sliding_window_causal_mask(sq, sk, self.window_size)
+        elif (
+            self.attn_mask_type == AttnMaskType.causal
+            and mask is None
+            and sq > 1
+        ):
+            # If sq == 1 then either KV cache is used or one-element context is passed
+            # so keeping mask=None in this case; subsequent code should handle it
+            assert sq == sk, "causal mask is only for self attention"
+            mask = get_default_causal_mask(sq)
+
+        mask_output = self.mask_func(input, mask) if mask is not None else input
+        if softmax_offset is None:
+            softmax_fn = paddle.nn.Softmax(axis=-1)
+        else:
+            softmax_fn = SoftmaxOne(-1, softmax_offset.to(input.place))
+
+        probs = softmax_fn(mask_output)
+        if self.input_in_float16 and self.softmax_in_fp32:
+            if self.input_in_fp16:
+                probs = probs.half()
+            else:
+                probs = probs.bfloat16()
+
+        return probs

--- a/fleet/core/models/common/embeddings/__init__.py
+++ b/fleet/core/models/common/embeddings/__init__.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .language_model_embedding import (
+    LanguageModelEmbedding as LanguageModelEmbedding,
+)
+from .rope_utils import apply_rotary_pos_emb as apply_rotary_pos_emb
+from .rotary_pos_embedding import RotaryEmbedding as RotaryEmbedding
+from .yarn_rotary_pos_embedding import (
+    YarnRotaryEmbedding as YarnRotaryEmbedding,
+)

--- a/fleet/core/models/common/embeddings/language_model_embedding.py
+++ b/fleet/core/models/common/embeddings/language_model_embedding.py
@@ -1,0 +1,189 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from paddle.distributed.communication.group import Group
+
+    from fleet.core.transformer.transformer_config import TransformerConfig
+
+import paddle
+from paddle import Tensor
+
+from fleet.core import tensor_parallel
+from fleet.core.transformer.layer import FleetLayer
+
+
+class LanguageModelEmbedding(FleetLayer):
+    """Language model embeddings.
+
+    Args:
+        config (TransformerConfig): config object with all necessary configs for TransformerBlock
+        vocab_size (int): vocabulary size
+        max_sequence_length (int): maximum size of sequence. This
+                             is used for positional embedding
+        add_position_embedding (bool): Add a position embedding.
+        embedding_dropout_prob (float): dropout probability for embeddings
+        num_tokentypes (int): Set to 0 without binary head, and 2 with a binary head. Defaults to 0.
+        scatter_to_sequence_parallel (bool): Set to False to disable scatter of embedding
+            across sequence parallel region. Defaults to True.
+    """
+
+    def __init__(
+        self,
+        config: TransformerConfig,
+        vocab_size: int,
+        max_sequence_length: int,
+        position_embedding_type: Literal[
+            "learned_absolute", "rope", "none"
+        ] = "learned_absolute",
+        num_tokentypes: int = 0,
+        scatter_to_sequence_parallel: bool = True,
+        tp_group: Group | None = None,
+    ):
+        super().__init__(config=config)
+
+        self.config: TransformerConfig = config
+        self.vocab_size: int = vocab_size
+        self.max_sequence_length: int = max_sequence_length
+        self.add_position_embedding: bool = (
+            position_embedding_type == "learned_absolute"
+        )
+        self.num_tokentypes = num_tokentypes
+        self.scatter_to_sequence_parallel = scatter_to_sequence_parallel
+        self.tp_group = tp_group
+        self.reduce_scatter_embeddings = (
+            (not self.add_position_embedding)
+            and self.num_tokentypes <= 0
+            and self.config.sequence_parallel
+            and self.scatter_to_sequence_parallel
+        )
+
+        # Word embeddings (parallel).
+        self.word_embeddings = tensor_parallel.VocabParallelEmbedding(
+            num_embeddings=self.vocab_size,
+            embedding_dim=self.config.hidden_size,
+            init_method=self.config.embedding_init_method,
+            reduce_scatter_embeddings=self.reduce_scatter_embeddings,
+            config=self.config,
+            tp_group=self.tp_group,
+        )
+
+        # Position embedding (serial).
+        if self.add_position_embedding:
+            self.position_embeddings = paddle.nn.Embedding(
+                self.max_sequence_length, self.config.hidden_size
+            )
+
+            # Initialize the position embeddings.
+            if self.config.perform_initialization:
+                self.config.embedding_init_method(
+                    self.position_embeddings.weight
+                )
+
+        if self.num_tokentypes > 0:
+            self.tokentype_embeddings = paddle.nn.Embedding(
+                self.num_tokentypes, self.config.hidden_size
+            )
+            # Initialize the token-type embeddings.
+            if self.config.perform_initialization:
+                self.config.embedding_init_method(
+                    self.tokentype_embeddings.weight
+                )
+        else:
+            self.tokentype_embeddings = None
+
+        # Embeddings dropout
+        self.embedding_dropout = paddle.nn.Dropout(self.config.hidden_dropout)
+
+    def zero_parameters(self):
+        """Zero out all parameters in embedding."""
+        self.word_embeddings.weight.data.fill_(0)
+        self.word_embeddings.weight.shared = True
+        self.position_embeddings.weight.data.fill_(0)
+        self.position_embeddings.weight.shared = True
+        if self.num_tokentypes > 0:
+            self.tokentype_embeddings.weight.data.fill_(0)
+            self.tokentype_embeddings.weight.shared = True
+
+    def forward(
+        self,
+        input_ids: Tensor,
+        position_ids: Tensor,
+        tokentype_ids: int | None = None,
+    ) -> Tensor:
+        """Forward pass of the embedding layer.
+
+        Args:
+            input_ids (Tensor): The input tokens
+            position_ids (Tensor): The position id's used to calculate position embeddings
+            tokentype_ids (int): The token type ids. Used when args.bert_binary_head is
+                set to True. Defaults to None
+
+        Returns:
+            Tensor: The output embeddings
+        """
+        word_embeddings = self.word_embeddings(input_ids)
+        if self.add_position_embedding:
+            position_embeddings = self.position_embeddings(position_ids)
+            embeddings = word_embeddings + position_embeddings
+        else:
+            embeddings = word_embeddings
+
+        if not self.reduce_scatter_embeddings:
+            # Data format change to avoid explicit transposes : [b s h] --> [s b h].
+            embeddings = embeddings.transpose(0, 1).contiguous()
+
+        if tokentype_ids is not None:
+            assert self.tokentype_embeddings is not None
+            # [b s h] -> [s b h] (So that it can be added with embeddings)
+            tokentype_embedding = self.tokentype_embeddings(
+                tokentype_ids
+            ).permute(1, 0, 2)
+            embeddings = embeddings + tokentype_embedding
+        else:
+            assert self.tokentype_embeddings is None
+
+        # If the input flag for fp32 residual connection is set, convert for float.
+        if self.config.fp32_residual_connection:
+            embeddings = embeddings.float()
+
+        # Dropout.
+        if self.config.sequence_parallel:
+            if (
+                not self.reduce_scatter_embeddings
+                and self.scatter_to_sequence_parallel
+            ):
+                embeddings = (
+                    tensor_parallel.scatter_to_sequence_parallel_region(
+                        embeddings, group=self.tp_group
+                    )
+                )
+            # `scatter_to_sequence_parallel_region` returns a view, which prevents
+            # the original tensor from being garbage collected. Clone to facilitate GC.
+            # Has a small runtime cost (~0.5%).
+            if (
+                self.config.clone_scatter_output_in_embedding
+                and self.scatter_to_sequence_parallel
+            ):
+                embeddings = embeddings.clone()
+            with tensor_parallel.get_cuda_rng_tracker().fork():
+                embeddings = self.embedding_dropout(embeddings)
+        else:
+            embeddings = self.embedding_dropout(embeddings)
+
+        return embeddings

--- a/fleet/core/models/common/embeddings/rope_utils.py
+++ b/fleet/core/models/common/embeddings/rope_utils.py
@@ -1,0 +1,322 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import warnings
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from paddle.distributed.communication.group import Group
+
+    from fleet.core.transformer.transformer_config import TransformerConfig
+
+import logging
+
+import paddle
+from paddle import Tensor
+
+from fleet.core import parallel_state
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "apply_rotary_pos_emb",
+    "get_pos_emb_on_this_cp_rank",
+]
+
+
+def get_pos_emb_on_this_cp_rank(
+    pos_emb: Tensor, seq_dim: int, cp_group: Group
+) -> Tensor:
+    """Get the position embedding on the current context parallel rank.
+
+    Args:
+        pos_emb (Tensor): Positional embedding tensor
+        seq_dim (int): Sequence dimension
+        cp_group (Group): The context parallel group
+    """
+    if cp_group is None:
+        raise ValueError(
+            "cp_group must be provided to get positional embedding per CP rank"
+        )
+    cp_size = cp_group.size()
+    cp_rank = cp_group.rank()
+    cp_idx = paddle.to_tensor([cp_rank, (2 * cp_size - cp_rank - 1)])
+    pos_emb = pos_emb.view(
+        *pos_emb.shape[:seq_dim],
+        2 * cp_size,
+        -1,
+        *pos_emb.shape[(seq_dim + 1) :],
+    )
+    pos_emb = pos_emb.index_select(seq_dim, cp_idx)
+    pos_emb = pos_emb.view(
+        *pos_emb.shape[:seq_dim], -1, *pos_emb.shape[(seq_dim + 2) :]
+    )
+    return pos_emb
+
+
+def _rotate_half(x: Tensor, rotary_interleaved: bool) -> Tensor:
+    """Change sign so the last dimension becomes [-odd, +even]
+
+    Args:
+        x (Tensor): Input tensor
+
+    Returns:
+        Tensor: Tensor rotated half
+    """
+    if not rotary_interleaved:
+        x1, x2 = paddle.chunk(x, 2, axis=-1)
+        return paddle.cat((-x2, x1), axis=-1)
+    else:
+        x1 = x[:, :, :, ::2]
+        x2 = x[:, :, :, 1::2]
+        x_new = paddle.stack((-x2, x1), axis=-1)
+        return x_new.view(x_new.shape[0], x_new.shape[1], x_new.shape[2], -1)
+
+
+def _apply_rotary_pos_emb_bshd(
+    t: Tensor,
+    freqs: Tensor,
+    rotary_interleaved: bool = False,
+    multi_latent_attention: bool = False,
+    mscale: float = 1.0,
+) -> Tensor:
+    """Apply rotary positional embedding to input tensor T.
+
+    check https://kexue.fm/archives/8265 for detailed formulas
+
+    Args:
+        t (Tensor): Input tensor T is of shape [seq_length, ... , dim]
+        freqs (Tensor): Rotary Positional embedding tensor freq is of shape [seq_length, ..., dim]
+
+    Returns:
+        Tensor: The input tensor after applying RoPE
+    """
+    rot_dim = freqs.shape[-1]
+
+    # ideally t_pass is empty so rotary pos embedding is applied to all tensor t
+    t, t_pass = t[..., :rot_dim], t[..., rot_dim:]
+
+    if multi_latent_attention:
+        x1 = t[..., 0::2]
+        x2 = t[..., 1::2]
+        t = paddle.cat((x1, x2), axis=-1)
+
+    # first part is cosine component
+    # second part is sine component, need to change signs with _rotate_half method
+    cos_ = (paddle.cos(freqs) * mscale).to(t.dtype)
+    sin_ = (paddle.sin(freqs) * mscale).to(t.dtype)
+
+    t = (t * cos_) + (_rotate_half(t, rotary_interleaved) * sin_)
+    return paddle.cat((t, t_pass), axis=-1)
+
+
+def _get_thd_freqs_on_this_cp_rank(
+    cp_rank: int, cp_size: int, x: Tensor, freqs: Tensor, offset: int = 0
+) -> Tensor:
+    """Get the correct frequency slice for this context parallel rank with optional sequence offset.
+
+    Args:
+        cp_rank: Current context parallel rank
+        cp_size: Total context parallel size
+        x: Input tensor for current sequence
+        freqs: Frequency tensor - either full batch positions or max sequence length
+        offset: Starting position offset for this sequence in the original batch (default: 0)
+
+    Returns:
+        Tensor: Frequency slice corresponding to this CP rank's portion of the sequence
+
+    Note:
+        This function supports two modes based on the offset parameter:
+        1. offset > 0: Exact mapping mode - freqs contains all positions across all sequences.
+           The offset ensures each sequence gets frequencies from its actual position within
+           the overall batch. Critical for non-1D RoPE in VLMs where spatial positions matter.
+        2. offset = 0: Traditional mode - freqs contains only max sequence length positions.
+           All sequences use frequencies starting from position 0, preserving backward
+           compatibility.
+    """
+    if cp_size > 1:
+        cp_seg = x.size(0) // 2
+        full_seqlen = cp_size * x.size(0)
+        # Apply offset to both forward and backward segments for context parallelism
+        # offset=0: traditional behavior, freqs[0:cp_seg] and freqs[...]
+        # offset>0: exact mapping, freqs[offset+0:offset+cp_seg] and freqs[offset+...]
+        return paddle.cat(
+            [
+                freqs[
+                    offset + cp_rank * cp_seg : offset + (cp_rank + 1) * cp_seg
+                ],
+                freqs[
+                    offset + full_seqlen - (cp_rank + 1) * cp_seg : offset
+                    + full_seqlen
+                    - cp_rank * cp_seg
+                ],
+            ]
+        )
+    else:
+        # For single context parallel rank:
+        # offset=0: use freqs[0:x.size(0)] (traditional)
+        # offset>0: use freqs[offset:offset+x.size(0)] (exact mapping)
+        return freqs[offset : offset + x.size(0)]
+
+
+def _apply_rotary_pos_emb_thd(
+    t: Tensor,
+    cu_seqlens: Tensor,
+    freqs: Tensor,
+    rotary_interleaved: bool = False,
+    multi_latent_attention: bool = False,
+    mscale: float = 1.0,
+    cp_group: Group = None,
+) -> Tensor:
+    """A baseline implementation of applying RoPE for `thd` format.
+
+    Args:
+        t (Tensor): Input tensor T is of shape [t, h, d]
+        cu_seqlens(Tensor):  Cumulative sum of sequence lengths in a batch for `t`,
+        with shape [b + 1] and dtype paddle.int32.
+        freqs (Tensor): Rotary Positional embedding tensor freq is of shape [max_s, 1, 1, d]
+        cp_group (Group): The context parallel group
+
+    Returns:
+        Tensor: Shape [t, h, d]. The input tensor after applying RoPE.
+    """
+
+    if cp_group is None:
+        raise ValueError("cp_group must be provided for THD format RoPE")
+    cp_size = cp_group.size()
+    cp_rank = cp_group.rank()
+    seqlens = ((cu_seqlens[1:] - cu_seqlens[:-1]) // cp_size).tolist()
+
+    # Handle two different frequency tensor formats:
+    # 1. If freqs.size(0) == cu_seqlens[-1]: freqs contains all positions across all sequences
+    #    -> Use offset-based mapping for exact positional correspondence
+    # 2. Otherwise: freqs contains only max sequence length positions
+    #    -> Use traditional mapping without offsets (map first :seqlen part)
+    if freqs.dim() >= 1 and freqs.size(0) == cu_seqlens[-1]:
+        # CASE 1: Exact mapping with offsets
+        # Build packed freqs in one pass, then apply once to the whole packed tensor
+        sequence_splits = paddle.split(t, seqlens)
+        freq_slices = []
+        for i, x in enumerate(sequence_splits):
+            # cu_seqlens[i] is the starting offset of this sequence in the original batch
+            seq_start_offset = cu_seqlens[i].item()
+            freq_slices.append(
+                _get_thd_freqs_on_this_cp_rank(
+                    cp_rank, cp_size, x, freqs, seq_start_offset
+                )
+            )
+
+        freqs_packed = paddle.cat(freq_slices, axis=0)
+
+        return _apply_rotary_pos_emb_bshd(
+            t.unsqueeze(1),
+            freqs_packed,
+            rotary_interleaved=rotary_interleaved,
+            multi_latent_attention=multi_latent_attention,
+            mscale=mscale,
+        ).squeeze(1)
+    else:
+        # CASE 2: Traditional mapping without offsets
+        # Build packed freqs for all sequences using the standard mapping, then apply once
+        sequence_splits = paddle.split(t, seqlens)
+        freqs_packed = paddle.cat(
+            [
+                _get_thd_freqs_on_this_cp_rank(cp_rank, cp_size, x, freqs)
+                for x in sequence_splits
+            ],
+            axis=0,
+        )
+
+        return _apply_rotary_pos_emb_bshd(
+            t.unsqueeze(1),
+            freqs_packed,
+            rotary_interleaved=rotary_interleaved,
+            multi_latent_attention=multi_latent_attention,
+            mscale=mscale,
+        ).squeeze(1)
+
+
+def apply_rotary_pos_emb(
+    t: Tensor,
+    freqs: Tensor,
+    config: TransformerConfig,
+    cu_seqlens: Tensor | None = None,
+    mscale: float = 1.0,
+    cp_group: Group = None,
+):
+    """
+    Reroute to the appropriate apply_rotary_pos_emb function depending on
+    fused/unfused kernels, or bshd (conventional) / thd (packed seq) format
+    """
+    global fused_apply_rotary_pos_emb, fused_apply_rotary_pos_emb_thd
+
+    # Keep for backward compatibility. Will deprecate in the future.
+    if cp_group is None:
+        cp_group = parallel_state.get_context_parallel_group()
+
+    if config.apply_rope_fusion:
+        if cu_seqlens is None:
+            # NOTE: TE backends do not support mRoPE in bshd format when bs > 1.
+            if config.mrope_section is not None and freqs.shape[1] > 1:
+                # TODO: Add a check in TransformerConfig and remove this unfused implementation.
+                warnings.warn(
+                    "apply_rope_fusion does not support mRoPE in bshd format when bs > 1. "
+                    "Please set apply_rope_fusion to false. This will become an error in v0.16."
+                )
+                return _apply_rotary_pos_emb_bshd(
+                    t,
+                    freqs,
+                    rotary_interleaved=config.rotary_interleaved,
+                    multi_latent_attention=config.multi_latent_attention,
+                    mscale=mscale,
+                )
+            else:
+                assert fused_apply_rotary_pos_emb is not None, (
+                    "apply_rope_fusion is not available."
+                )
+                return fused_apply_rotary_pos_emb(
+                    t, freqs, interleaved=config.rotary_interleaved
+                )
+        else:
+            assert fused_apply_rotary_pos_emb_thd is not None, (
+                "apply_rope_fusion is not available."
+            )
+            return fused_apply_rotary_pos_emb_thd(
+                t,
+                cu_seqlens,
+                freqs,
+                cp_size=cp_group.size(),
+                cp_rank=cp_group.rank(),
+            )
+    else:
+        if cu_seqlens is None:
+            return _apply_rotary_pos_emb_bshd(
+                t,
+                freqs,
+                rotary_interleaved=config.rotary_interleaved,
+                multi_latent_attention=config.multi_latent_attention,
+                mscale=mscale,
+            )
+        else:
+            return _apply_rotary_pos_emb_thd(
+                t,
+                cu_seqlens,
+                freqs,
+                rotary_interleaved=config.rotary_interleaved,
+                multi_latent_attention=config.multi_latent_attention,
+                mscale=mscale,
+                cp_group=cp_group,
+            )

--- a/fleet/core/models/common/embeddings/rotary_pos_embedding.py
+++ b/fleet/core/models/common/embeddings/rotary_pos_embedding.py
@@ -1,0 +1,262 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from paddle.distributed.communication.group import Group
+
+    from fleet.core.packed_seq_params import PackedSeqParams
+    from fleet.core.transformer.transformer_block import TransformerBlock
+    from fleet.core.transformer.transformer_config import TransformerConfig
+
+import logging
+import math
+
+import paddle
+from paddle import Tensor, nn
+
+from fleet.core import parallel_state
+from fleet.core.models.common.embeddings.rope_utils import (
+    get_pos_emb_on_this_cp_rank,
+)
+
+logger = logging.getLogger(__name__)
+
+
+__all__ = ["RotaryEmbedding"]
+
+
+class RotaryEmbedding(nn.Layer):
+    """Rotary Embedding for language model.
+
+    Args:
+        kv_channels (int): Projection weights dimension in multi-head attention. Obtained
+            from transformer config
+        rotary_percent (float): Percent of rotary dimension to use for rotary position
+            embeddings.
+        rotary_interleaved (bool, optional): If True, interleaved rotary position embeddings.
+            Defaults to False.
+        seq_len_interpolation_factor (float, optional): scale of linearly interpolating RoPE
+            for longer sequences. The value must be a float larger than 1.0. Defaults to None
+        rotary_base (int, optional): Base period for rotary position embeddings. Defaults to
+            10000.
+        rope_scaling (bool, optional): Apply rope scaling as used in llama 3.x.
+        rope_scaling_factor (float, optional): rope scaling factor in llama 3.x. Defaults to 8.
+        use_cpu_initialization (bool, optional): If False, initialize the inv_freq directly
+            on the GPU. Defaults to False
+        cp_group (Group, optional): Process group for context parallel.
+            Defaults to None.
+    """
+
+    def __init__(
+        self,
+        kv_channels: int,
+        rotary_percent: float,
+        rotary_interleaved: bool = False,
+        seq_len_interpolation_factor: float | None = None,
+        rotary_base: int = 10000,
+        rope_scaling: bool = False,
+        rope_scaling_factor: float = 8.0,
+        use_cpu_initialization: bool = False,
+        cp_group: Group | None = None,
+    ) -> None:
+        super().__init__()
+
+        dim = kv_channels
+        if rotary_percent < 1.0:
+            dim = int(dim * rotary_percent)
+        self.rotary_interleaved = rotary_interleaved
+
+        self.seq_len_interpolation_factor = seq_len_interpolation_factor
+        device = "cpu" if use_cpu_initialization else paddle.get_device()
+        self.inv_freq = 1.0 / (
+            rotary_base
+            ** (
+                paddle.arange(0, dim, 2, dtype=paddle.float32, device=device)
+                / dim
+            )
+        )
+
+        if rope_scaling:
+            self.inv_freq = self._apply_scaling(
+                self.inv_freq, factor=rope_scaling_factor
+            )
+
+        self.cp_group = (
+            cp_group
+            if cp_group is not None
+            else parallel_state.get_context_parallel_group(
+                check_initialized=False
+            )
+        )
+
+    def _apply_scaling(
+        self,
+        freqs,
+        factor=8,
+        low_freq_factor=1,
+        high_freq_factor=4,
+        original_max_position_embeddings=8192,
+    ):
+        # This implementation is adapted from:
+        # https://github.com/huggingface/transformers/blob/2a5a6ad18aa22e98429bb5ecb880660328030ea0/src/transformers/modeling_rope_utils.py#L303-L343
+
+        factor = factor  # `8` in the original implementation
+        low_freq_factor = low_freq_factor  # `1` in the original implementation
+        high_freq_factor = (
+            high_freq_factor  # `4` in the original implementation
+        )
+        old_context_len = original_max_position_embeddings  # `8192` in the original implementation
+
+        low_freq_wavelen = old_context_len / low_freq_factor
+        high_freq_wavelen = old_context_len / high_freq_factor
+
+        wavelen = 2 * math.pi / freqs
+        # wavelen < high_freq_wavelen: do nothing
+        # wavelen > low_freq_wavelen: divide by factor
+        inv_freq_llama = paddle.where(
+            wavelen > low_freq_wavelen, freqs / factor, freqs
+        )
+        # otherwise: interpolate between the two, using a smooth factor
+        smooth_factor = (old_context_len / wavelen - low_freq_factor) / (
+            high_freq_factor - low_freq_factor
+        )
+        smoothed_inv_freq = (
+            1 - smooth_factor
+        ) * inv_freq_llama / factor + smooth_factor * inv_freq_llama
+        is_medium_freq = ~(wavelen < high_freq_wavelen) * ~(
+            wavelen > low_freq_wavelen
+        )
+        inv_freq_llama = paddle.where(
+            is_medium_freq, smoothed_inv_freq, inv_freq_llama
+        )
+
+        return inv_freq_llama
+
+    def get_freqs_non_repeated(
+        self, max_seq_len: int, offset: int = 0
+    ) -> Tensor:
+        """Generates matrix of frequencies based on positions in the sequence,
+        used to create positional encodings"""
+        seq = (
+            paddle.arange(
+                max_seq_len,
+                device=self.inv_freq.place,
+                dtype=self.inv_freq.dtype,
+            )
+            + offset
+        )
+
+        if self.seq_len_interpolation_factor is not None:
+            seq *= 1 / self.seq_len_interpolation_factor
+
+        freqs = paddle.outer(seq, self.inv_freq)  # [seq len, dim]
+
+        return freqs
+
+    def get_cos_sin(
+        self, max_seq_len: int, offset: int = 0
+    ) -> (Tensor, Tensor):
+        """Cosine and sine values for RoPE are precomputed for all positions up to the maximum
+        sequence length"""
+        freqs = self.get_freqs_non_repeated(max_seq_len, offset)
+        cos = paddle.cos(freqs)
+        sin = paddle.sin(freqs)
+        return cos, sin
+
+    def forward(
+        self, max_seq_len: int, offset: int = 0, packed_seq: bool = False
+    ) -> Tensor:
+        """Forward pass of RoPE embedding.
+
+        Args:
+            max_seq_len (int): Maximum size of sequence
+            offset (int, optional): RoPE offset. Defaults to 0.
+            packed_seq (bool, optional): Whether to use packed sequence. Defaults to False.
+
+        Returns:
+            Tensor: Embeddings after applying RoPE.
+        """
+        if self.inv_freq.place.is_cpu_place():
+            # move `inv_freq` to GPU once at the first micro-batch forward pass
+            self.inv_freq = self.inv_freq.to(device=paddle.get_device())
+
+        freqs = self.get_freqs_non_repeated(max_seq_len, offset)
+        # first part even vector components, second part odd vector components,
+        #  2 * dim in dimension size
+        if not self.rotary_interleaved:
+            emb = paddle.cat((freqs, freqs), axis=-1)
+        else:
+            emb = paddle.stack(
+                (freqs.view(-1, 1), freqs.view(-1, 1)), axis=-1
+            ).view(freqs.shape[0], -1)
+        # emb [seq_length, .., dim]
+        emb = emb[:, None, None, :]
+        if (
+            self.cp_group is not None
+            and self.cp_group.size() > 1
+            and not packed_seq
+        ):
+            # slice rotary_pos_emb along sequence dimension and select the partition of the current
+            # CP rank
+            emb = get_pos_emb_on_this_cp_rank(emb, 0, self.cp_group)
+        return emb
+
+    def _load_from_state_dict(self, state_dict, prefix, *args, **kwargs):
+        state_dict.pop(f"{prefix}inv_freq", None)
+        return super()._load_from_state_dict(
+            state_dict, prefix, *args, **kwargs
+        )
+
+    def get_rotary_seq_len(
+        self,
+        transformer: TransformerBlock,
+        transformer_input: Tensor,
+        transformer_config: TransformerConfig,
+        packed_seq_params: PackedSeqParams | None = None,
+    ) -> int:
+        """Function to get the rotary sequence length.
+
+        Args:
+            transformer (TransformerBlock): The transformer block (decoder/encoder) used
+                by the model
+            transformer_input (Tensor): Input tensor to the transformer
+            transformer_config (TransformerConfig): Transformer config used by the model
+            packed_seq_params (PackedSeqParams): Packed sequence params
+
+        Returns:
+            int: The rotary sequence length
+        """
+
+        if packed_seq_params is not None:
+            # max_seqlen are the max sequence length in the packed sequence before being divived
+            # by the tp and cp size.
+            return max(
+                packed_seq_params.max_seqlen_q, packed_seq_params.max_seqlen_kv
+            )
+        else:
+            if transformer is not None and transformer.input_tensor is not None:
+                rotary_seq_len = transformer.input_tensor.size(0)
+            else:
+                rotary_seq_len = transformer_input.size(0)
+
+            if transformer_config.sequence_parallel:
+                rotary_seq_len *= transformer_config.tensor_model_parallel_size
+
+        rotary_seq_len *= transformer_config.context_parallel_size
+
+        return rotary_seq_len

--- a/fleet/core/models/common/embeddings/yarn_rotary_pos_embedding.py
+++ b/fleet/core/models/common/embeddings/yarn_rotary_pos_embedding.py
@@ -1,0 +1,323 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import logging
+import math
+from functools import lru_cache
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from paddle.distributed.communication.group import Group
+
+    from fleet.core.transformer import TransformerConfig
+
+import paddle
+from paddle import Tensor
+
+from fleet.core.models.common.embeddings.rope_utils import (
+    get_pos_emb_on_this_cp_rank,
+)
+from fleet.core.models.common.embeddings.rotary_pos_embedding import (
+    RotaryEmbedding,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class YarnRotaryEmbedding(RotaryEmbedding):
+    """Yarn Rotary Embedding for language model.
+
+    Args:
+        kv_channels (int): Projection weights dimension in multi-head attention. Obtained from
+            transformer config.
+        rotary_percent (float): Percent of rotary dimension to use for rotary position embeddings.
+        rotary_interleaved (bool, optional): If True, interleaved rotary position embeddings.
+            Defaults to False.
+        seq_len_interpolation_factor (float, optional): scale of linearly interpolating RoPE for
+            longer sequences. The value must be a float larger than 1.0. Defaults to None
+        rotary_base (float, optional): Base period for rotary position embeddings. Defaults to
+            10000.
+        use_cpu_initialization (bool, optional): If False, initialize the inv_freq directly on
+            the GPU. Defaults to False.
+        scaling_factor (float, optional): Scaling factor for Yarn RoPE. Defaults to 1.0.
+        original_max_position_embeddings (int, optional): Original maximum position embeddings
+            length. Defaults to 4096.
+        beta_fast (float, optional): Fast beta value for Yarn RoPE. Defaults to 32.
+        beta_slow (float, optional): Slow beta value for Yarn RoPE. Defaults to 1.
+        mscale (float, optional): Mscale value for Yarn RoPE. Defaults to 1.
+        mscale_all_dim (float, optional): Mscale all dim value for Yarn RoPE. Defaults to 0.
+        correction_range_round_to_int (bool): Whether to round dim range bounds to integer.
+            Defaults to True
+        cp_group (Group, optional): Process group for context parallel.
+            Defaults to None.
+    """
+
+    def __init__(
+        self,
+        kv_channels: int,
+        rotary_percent: float = 1.0,
+        rotary_interleaved: bool = False,
+        seq_len_interpolation_factor: float | None = None,
+        rotary_base: float = 10000.0,
+        use_cpu_initialization: bool = False,
+        scaling_factor: float = 1.0,
+        original_max_position_embeddings: int = 4096,
+        beta_fast: float = 32.0,
+        beta_slow: float = 1.0,
+        mscale: float = 1.0,
+        mscale_all_dim: float = 0.0,
+        correction_range_round_to_int: bool = True,
+        cp_group: Group | None = None,
+    ):
+        self.dim = kv_channels
+        self.rotary_base = rotary_base
+        self.scaling_factor = scaling_factor
+        self.original_max_position_embeddings = original_max_position_embeddings
+        self.beta_fast = beta_fast
+        self.beta_slow = beta_slow
+        self.mscale = mscale
+        self.mscale_all_dim = mscale_all_dim
+        self.correction_range_round_to_int = correction_range_round_to_int
+
+        device = "cpu" if use_cpu_initialization else paddle.get_device()
+
+        with paddle.device_guard(device):
+            self.inv_freq_extra = 1.0 / (
+                self.rotary_base
+                ** (
+                    paddle.arange(
+                        0, self.dim, 2, dtype=paddle.float32, device=device
+                    )
+                    / self.dim
+                )
+            )
+            self.inv_freq_inter = 1.0 / (
+                self.scaling_factor
+                * self.rotary_base
+                ** (
+                    paddle.arange(
+                        0, self.dim, 2, dtype=paddle.float32, device=device
+                    )
+                    / self.dim
+                )
+            )
+            super().__init__(
+                kv_channels=kv_channels,
+                rotary_percent=rotary_percent,
+                rotary_interleaved=rotary_interleaved,
+                seq_len_interpolation_factor=seq_len_interpolation_factor,
+                rotary_base=rotary_base,
+                use_cpu_initialization=use_cpu_initialization,
+                cp_group=cp_group,
+            )
+
+            self._set_cos_sin_cache(
+                self.original_max_position_embeddings,
+                offset=0,
+                dtype=paddle.get_default_dtype(),
+            )
+
+    def forward(
+        self, max_seq_len: int, offset: int = 0, packed_seq: bool = False
+    ) -> Tensor:
+        """Forward pass of Yarn Rotary Embedding.
+
+        Args:
+            max_seq_len (int): Maximum size of sequence
+            offset (int, optional): RoPE offset. Defaults to 0.
+            packed_seq (bool, optional): Whether to use packed sequence. Defaults to False.
+
+        Returns:
+            Tensor: Embeddings after applying Yarn RoPE.
+        """
+        assert not self.rotary_interleaved, (
+            "Yarn RoPE does not support interleaved rotary embeddings"
+        )
+
+        if self.inv_freq_extra.place.is_cpu_place():
+            # move `inv_freq_extra` to GPU once at the first micro-batch forward pass
+            self.inv_freq_extra = self.inv_freq_extra.to(
+                device=paddle.get_device()
+            )
+
+        if self.inv_freq_inter.place.is_cpu_place():
+            # move `inv_freq_inter` to GPU once at the first micro-batch forward pass
+            self.inv_freq_inter = self.inv_freq_inter.to(
+                device=paddle.get_device()
+            )
+
+        low, high = _yarn_find_correction_range(
+            self.beta_fast,
+            self.beta_slow,
+            self.dim,
+            self.rotary_base,
+            self.original_max_position_embeddings,
+            self.correction_range_round_to_int,
+        )
+        inv_freq_mask = 1.0 - _yarn_linear_ramp_mask(
+            low, high, self.dim // 2, device=self.inv_freq_extra.place
+        ).to(dtype=paddle.float32)
+        inv_freq = (
+            self.inv_freq_inter * (1 - inv_freq_mask)
+            + self.inv_freq_extra * inv_freq_mask
+        )
+
+        seq = (
+            paddle.arange(
+                max_seq_len,
+                device=self.inv_freq_extra.place,
+                dtype=self.inv_freq_extra.dtype,
+            )
+            + offset
+        )
+
+        freqs = paddle.outer(seq, inv_freq)
+
+        _mscale = _yarn_get_concentration_factor(
+            self.scaling_factor, self.mscale, self.mscale_all_dim
+        )
+
+        emb = paddle.cat((freqs, freqs), axis=-1)
+        # emb [seq_length, .., dim]
+        emb = emb[:, None, None, :]
+        if (
+            self.cp_group is not None
+            and self.cp_group.size() > 1
+            and not packed_seq
+        ):
+            # slice rotary_pos_emb along sequence dimension
+            # and select the partition of the current CP rank
+            emb = get_pos_emb_on_this_cp_rank(emb, 0, self.cp_group)
+        return emb, _mscale
+
+    def _set_cos_sin_cache(self, seq_len, offset, dtype, packed_seq=False):
+        self.max_seq_len_cached = seq_len
+        self.offset_cached = offset
+        self.dtype_cached = dtype
+        self.packed_seq_cached = packed_seq
+
+        emb, _mscale = self.forward(seq_len, offset, packed_seq)
+        self.register_buffer(
+            "cos_cached",
+            (emb.cos() * _mscale).to(dtype).contiguous(),
+            persistent=False,
+        )
+        self.register_buffer(
+            "sin_cached",
+            (emb.sin() * _mscale).to(dtype).contiguous(),
+            persistent=False,
+        )
+
+    def get_cached_cos_sin(
+        self,
+        seq_len,
+        offset=0,
+        dtype=paddle.get_default_dtype(),
+        packed_seq=False,
+    ):
+        """Get cached cos and sin values."""
+        if (
+            seq_len > self.max_seq_len_cached
+            or offset != self.offset_cached
+            or dtype != self.dtype_cached
+            or packed_seq != self.packed_seq_cached
+        ):
+            self._set_cos_sin_cache(seq_len, offset, dtype, packed_seq)
+        return (self.cos_cached[:seq_len, ...], self.sin_cached[:seq_len, ...])
+
+
+# Inverse dim formula to find dim based on number of rotations
+def _yarn_find_correction_dim(
+    num_rotations: float,
+    dim: int,
+    rotary_base: float = 10000,
+    max_position_embeddings: int = 2048,
+) -> float:
+    return (
+        dim * math.log(max_position_embeddings / (num_rotations * 2 * math.pi))
+    ) / (2 * math.log(rotary_base))
+
+
+# Find dim range bounds based on rotations
+def _yarn_find_correction_range(
+    low_rot: float,
+    high_rot: float,
+    dim: int,
+    rotary_base: float = 10000,
+    max_position_embeddings: int = 2048,
+    round_to_int: bool = True,
+) -> tuple[int, int]:
+    low = _yarn_find_correction_dim(
+        low_rot, dim, rotary_base, max_position_embeddings
+    )
+    high = _yarn_find_correction_dim(
+        high_rot, dim, rotary_base, max_position_embeddings
+    )
+    if round_to_int:
+        low = math.floor(low)
+        high = math.ceil(high)
+    return max(low, 0), min(high, dim - 1)  # Clamp values just in case
+
+
+def _yarn_linear_ramp_mask(
+    min: float, max: float, dim: int, device: paddle.device
+) -> Tensor:
+    if min == max:
+        max += 0.001  # Prevent singularity
+
+    linear_func = (
+        paddle.arange(dim, dtype=paddle.float32, device=device) - min
+    ) / (max - min)
+    ramp_func = paddle.clamp(linear_func, 0, 1)
+    return ramp_func
+
+
+def _yarn_get_mscale(scale: float = 1, mscale: float = 1) -> float:
+    if scale <= 1:
+        return 1.0
+    return 0.1 * mscale * math.log(scale) + 1.0
+
+
+@lru_cache(maxsize=8)
+def _yarn_get_concentration_factor(
+    scaling_factor: float, mscale: float, mscale_all_dim: float
+) -> float:
+    """
+    Get the concentration factor (factor multiplied to the sine and cosine components of the
+    embedding). This factor is also known as attention factor, and sometimes homonymously known as
+    "mscale"
+    """
+    return float(
+        _yarn_get_mscale(scaling_factor, mscale)
+        / _yarn_get_mscale(scaling_factor, mscale_all_dim)
+    )
+
+
+def _yarn_get_concentration_factor_from_config(
+    config: TransformerConfig,
+) -> float:
+    fields = [
+        "yarn_rotary_scaling_factor",
+        "yarn_mscale",
+        "yarn_mscale_all_dim",
+    ]
+    if all(hasattr(config, f) for f in fields):
+        return _yarn_get_concentration_factor(
+            config.yarn_rotary_scaling_factor,
+            config.yarn_mscale,
+            config.yarn_mscale_all_dim,
+        )
+    return 1.0

--- a/fleet/core/transformer/attention.py
+++ b/fleet/core/transformer/attention.py
@@ -1,0 +1,593 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, NoReturn
+
+if TYPE_CHECKING:
+    from .transformer_config import TransformerConfig
+
+import paddle
+from paddle import Tensor
+
+from fleet.core import tensor_parallel
+from fleet.core.models.common.embeddings import (
+    apply_rotary_pos_emb,
+)
+from fleet.core.models.common.embeddings.yarn_rotary_pos_embedding import (
+    _yarn_get_concentration_factor_from_config,
+)
+from fleet.core.process_groups_config import ProcessGroupCollection
+from fleet.core.transformer.layer import FleetLayer
+from fleet.core.transformer.spec_utils import LayerSpec, build_layer
+from fleet.core.utils import divide, get_pg_size
+
+from .enums import AttnMaskType
+
+
+@dataclass
+class SelfAttentionSublayers:
+    """
+    Configuration class for specifying the sublayers of a self-attention.
+    """
+
+    linear_qkv: LayerSpec | type = None
+    core_attention: LayerSpec | type = None
+    linear_proj: LayerSpec | type = None
+    q_layernorm: LayerSpec | type = None
+    k_layernorm: LayerSpec | type = None
+
+
+@dataclass
+class CrossAttentionSublayers:
+    """
+    Configuration class for specifying the sublayers of a cross-attention.
+    """
+
+    linear_q: LayerSpec | type = None
+    linear_kv: LayerSpec | type = None
+    core_attention: LayerSpec | type = None
+    linear_proj: LayerSpec | type = None
+
+
+class Attention(FleetLayer, ABC):
+    """Attention layer abstract class.
+
+    This layer only contains common layers required for the "self attn" and
+    "cross attn" specializations.
+    """
+
+    def __init__(
+        self,
+        config: TransformerConfig,
+        sublayers: SelfAttentionSublayers | CrossAttentionSublayers,
+        layer_number: int,
+        attn_mask_type: AttnMaskType,
+        attention_type: str,
+        cp_comm_type: str | None = None,
+        pg_collection: ProcessGroupCollection = None,
+    ):
+        super().__init__(config=config)
+
+        self.config = config
+        self.layer_number = layer_number
+        self.attn_mask_type = attn_mask_type
+        self.attention_type = attention_type
+
+        # For normal attention without groups, num_query_groups == num_attention_heads,
+        # so these two will be the same
+        self.query_projection_size = (
+            self.config.kv_channels * self.config.num_attention_heads
+        )
+        self.kv_projection_size = (
+            self.config.kv_channels * self.config.num_query_groups
+        )
+
+        if pg_collection is None:
+            pg_collection = ProcessGroupCollection.use_mpu_process_groups(
+                required_pgs=["tp", "cp"]
+            )
+        else:
+            assert hasattr(pg_collection, "tp"), (
+                "Attention pg_collection must have tp process group"
+            )
+            assert hasattr(pg_collection, "cp"), (
+                "Attention pg_collection must have cp process group"
+            )
+        self.pg_collection = pg_collection
+
+        # Per attention head and per partition values
+        world_size = get_pg_size(self.pg_collection.tp)
+        self.hidden_size_per_attention_head = divide(
+            self.query_projection_size, self.config.num_attention_heads
+        )
+        self.num_attention_heads_per_partition = divide(
+            self.config.num_attention_heads, world_size
+        )
+        self.num_query_groups_per_partition = divide(
+            self.config.num_query_groups, world_size
+        )
+
+        # To support both CUDA Graphs and key value with different hidden size
+        self.key_hidden_size = self.hidden_size_per_attention_head
+        self.val_hidden_size = self.hidden_size_per_attention_head
+
+        self.core_attention = build_layer(
+            sublayers.core_attention,
+            config=self.config,
+            layer_number=self.layer_number,
+            attn_mask_type=self.attn_mask_type,
+            attention_type=self.attention_type,
+            cp_comm_type=cp_comm_type,
+            softmax_scale=self.config.softmax_scale,
+            pg_collection=self.pg_collection,
+        )
+
+        self.checkpoint_core_attention = (
+            self.config.recompute_granularity == "selective"
+            and "core_attn" in self.config.recompute_modules
+        )
+
+        # Output.
+        self.linear_proj = build_layer(
+            sublayers.linear_proj,
+            self.query_projection_size,
+            self.config.hidden_size,
+            config=self.config,
+            init_method=self.config.output_layer_init_method,
+            bias=self.config.add_bias_linear,
+            input_is_parallel=True,
+            skip_bias_add=True,
+            is_expert=False,
+            tp_comm_buffer_name="proj",
+            tp_group=self.pg_collection.tp,
+        )
+
+    def _checkpointed_attention_forward(
+        self,
+        query,
+        key,
+        value,
+        attention_mask,
+        rotary_pos_emb=None,
+        attn_mask_type=None,
+        attention_bias=None,
+        packed_seq_params=None,
+    ):
+        """Forward method with selective activation checkpointing."""
+
+        def custom_forward(*inputs):
+            query = inputs[0]
+            key = inputs[1]
+            value = inputs[2]
+            attention_mask = inputs[3]
+            attn_mask_type = inputs[5]
+            attn_mask_type = AttnMaskType(attn_mask_type.item())
+            output_ = self.core_attention(
+                query,
+                key,
+                value,
+                attention_mask,
+                attn_mask_type=attn_mask_type,
+                attention_bias=attention_bias,
+                packed_seq_params=packed_seq_params,
+            )
+            return output_
+
+        if attn_mask_type is None:
+            attn_mask_type = self.attn_mask_type
+        attn_mask_type = paddle.to_tensor(
+            [attn_mask_type.value], dtype=paddle.int
+        )
+        hidden_states = tensor_parallel.checkpoint(
+            custom_forward,
+            False,
+            query,
+            key,
+            value,
+            attention_mask,
+            rotary_pos_emb,
+            attn_mask_type,
+        )
+
+        return hidden_states
+
+    @abstractmethod
+    def get_query_key_value_tensors(
+        self, hidden_states, key_value_states, split_qkv=True
+    ):
+        """
+        This method needs to be implemented based on whether the derived class
+        is "self-attn" or "cross-attn".
+        """
+
+    def forward(
+        self,
+        hidden_states: Tensor,
+        attention_mask: Tensor,
+        key_value_states: Tensor | None = None,
+        rotary_pos_emb: Tensor | tuple[Tensor, Tensor] | None = None,
+        attention_bias: Tensor | None = None,
+        packed_seq_params: Tensor | None = None,
+    ) -> tuple[Tensor, Tensor]:
+        """
+        Perform a forward pass through the attention layer.
+
+        Args:
+            hidden_states (Tensor): Hidden states.
+            attention_mask (Tensor): Attention mask.
+            key_value_states (Optional[Tensor]): Key/value states (for cross attention).
+            rotary_pos_emb (Optional[Union[Tensor, tuple[Tensor, Tensor]]]): Rotary
+                embedding tensor(s).
+            attention_bias (Optional[Tensor]): Attention bias.
+            packed_seq_params (Optional[PackedSeqparams]): Parameters used for THD format.
+
+        Return:
+            (tuple[Tensor, Tensor]) Attention output and bias.
+
+        """
+        # Check if we need to skip RoPE
+        # no_rope is 0-indexed array and self.layer_number is 1-indexed
+        no_rope = (
+            self.config.no_rope_freq[self.layer_number - 1]
+            if self.config.no_rope_freq
+            else False
+        )
+        if no_rope:
+            rotary_pos_emb = None
+
+        # hidden_states: [sq, b, h]
+
+        # For self attention we just duplicate the rotary_pos_emb if it isn't already
+        if rotary_pos_emb is not None and not isinstance(rotary_pos_emb, tuple):
+            rotary_pos_emb = (rotary_pos_emb,) * 2
+
+        # =====================
+        # Query, Key, and Value
+        # =====================
+        # Check if fused_single_qkv_rope is requested but either unavailable or not
+        # supported for the current use case.
+        if self.attention_type != "cross":
+            assert not (self.config.fused_single_qkv_rope), (
+                "fused_single_qkv_rope requested but not available/supported for the config."
+            )
+
+        # Get the query, key and value tensors based on the type of attention -
+        # self or cross attn.
+        qkv_output = self.get_query_key_value_tensors(
+            hidden_states, key_value_states, split_qkv=True
+        )
+        attn_mask_type = self.attn_mask_type
+        block_table = None
+        query, key, value = qkv_output
+
+        # ================================================
+        # relative positional embedding (rotary embedding)
+        # ================================================
+        if rotary_pos_emb is not None:
+            q_pos_emb, k_pos_emb = rotary_pos_emb
+
+            if packed_seq_params is not None:
+                if packed_seq_params.cu_seqlens_q_padded is not None:
+                    cu_seqlens_q = packed_seq_params.cu_seqlens_q_padded
+                else:
+                    cu_seqlens_q = packed_seq_params.cu_seqlens_q
+                if packed_seq_params.cu_seqlens_kv_padded is not None:
+                    cu_seqlens_kv = packed_seq_params.cu_seqlens_kv_padded
+                else:
+                    cu_seqlens_kv = packed_seq_params.cu_seqlens_kv
+            else:
+                cu_seqlens_q = cu_seqlens_kv = None
+
+            if q_pos_emb is not None:
+                query = apply_rotary_pos_emb(
+                    query,
+                    q_pos_emb,
+                    config=self.config,
+                    cu_seqlens=cu_seqlens_q,
+                    mscale=_yarn_get_concentration_factor_from_config(
+                        self.config
+                    ),
+                    cp_group=self.pg_collection.cp,
+                )
+
+            if k_pos_emb is not None:
+                key = apply_rotary_pos_emb(
+                    key,
+                    k_pos_emb,
+                    config=self.config,
+                    cu_seqlens=cu_seqlens_kv,
+                    mscale=_yarn_get_concentration_factor_from_config(
+                        self.config
+                    ),
+                    cp_group=self.pg_collection.cp,
+                )
+
+        # ==================================
+        # core attention computation
+        # ==================================
+
+        if self.checkpoint_core_attention and self.training:
+            core_attn_out = self._checkpointed_attention_forward(
+                query,
+                key,
+                value,
+                attention_mask,
+                attn_mask_type=attn_mask_type,
+                attention_bias=attention_bias,
+                packed_seq_params=packed_seq_params,
+            )
+        else:
+            # Static batching attention kernel.
+            core_attn_out = self.core_attention(
+                query,
+                key,
+                value,
+                attention_mask,
+                attn_mask_type=attn_mask_type,
+                attention_bias=attention_bias,
+                packed_seq_params=packed_seq_params,
+            )
+
+        if (
+            packed_seq_params is not None
+            and packed_seq_params.qkv_format == "thd"
+        ):
+            # reshape to same output shape as unpacked case
+            # (t, np, hn) -> (t, b=1, h=np*hn)
+            # t is the pack size = sum (sq_i)
+            # note that batch is a dummy dimension in the packed case
+            core_attn_out = core_attn_out.reshape(core_attn_out.size(0), 1, -1)
+
+        # =================
+        # Output. [sq, b, h]
+        # =================
+
+        output, bias = self.linear_proj(core_attn_out)
+
+        return output, bias
+
+    def set_for_recompute_input_layernorm(self):
+        """Set the attention layer for recompute input_layernorm. Only needed for fp8."""
+        raise NotImplementedError(
+            "set_for_recompute_input_layernorm is not implemented."
+        )
+
+
+class SelfAttention(Attention):
+    """Self-attention layer class
+
+    Self-attention layer takes input with size [s, b, h]
+    and returns output of the same size.
+    """
+
+    def __init__(
+        self,
+        config: TransformerConfig,
+        sublayers: SelfAttentionSublayers,
+        layer_number: int,
+        attn_mask_type=AttnMaskType.padding,
+        cp_comm_type: str | None = None,
+        pg_collection: ProcessGroupCollection = None,
+    ):
+        super().__init__(
+            config=config,
+            sublayers=sublayers,
+            layer_number=layer_number,
+            attn_mask_type=attn_mask_type,
+            attention_type="self",
+            cp_comm_type=cp_comm_type,
+            pg_collection=pg_collection,
+        )
+
+        self.linear_qkv = build_layer(
+            sublayers.linear_qkv,
+            self.config.hidden_size,
+            self.query_projection_size + 2 * self.kv_projection_size,
+            config=self.config,
+            init_method=self.config.init_method,
+            gather_output=False,
+            bias=self.config.add_bias_linear or self.config.add_qkv_bias,
+            skip_bias_add=False,
+            is_expert=False,
+            tp_comm_buffer_name="qkv",
+            tp_group=self.pg_collection.tp,
+        )
+
+        if sublayers.q_layernorm is not None:
+            self.q_layernorm = build_layer(
+                sublayers.q_layernorm,
+                hidden_size=self.hidden_size_per_attention_head,
+                config=self.config,
+                eps=self.config.layernorm_epsilon,
+            )
+        else:
+            self.q_layernorm = None
+
+        if sublayers.k_layernorm is not None:
+            self.k_layernorm = build_layer(
+                sublayers.k_layernorm,
+                hidden_size=self.hidden_size_per_attention_head,
+                config=self.config,
+                eps=self.config.layernorm_epsilon,
+            )
+        else:
+            self.k_layernorm = None
+
+    def get_query_key_value_tensors(
+        self, hidden_states, key_value_states=None, split_qkv=True
+    ):
+        """
+        Derives `query`, `key` and `value` tensors from `hidden_states`. If `split_qkv=False`, then
+        the unsplit mixed_qkv tensor is returned.
+        """
+        # Attention heads [sq, b, h] --> [sq, b, ng * (np/ng + 2) * hn)]
+        mixed_qkv, _ = self.linear_qkv(hidden_states)
+
+        # [sq, b, hp] --> [sq, b, ng, (np/ng + 2) * hn]
+        new_tensor_shape = (
+            *mixed_qkv.size()[:-1],
+            self.num_query_groups_per_partition,
+            (
+                (
+                    self.num_attention_heads_per_partition
+                    // self.num_query_groups_per_partition
+                    + 2
+                )
+                * self.hidden_size_per_attention_head
+            ),
+        )
+        mixed_qkv = mixed_qkv.view(*new_tensor_shape)
+
+        split_arg_list = [
+            (
+                self.num_attention_heads_per_partition
+                // self.num_query_groups_per_partition
+                * self.hidden_size_per_attention_head
+            ),
+            self.hidden_size_per_attention_head,
+            self.hidden_size_per_attention_head,
+        ]
+
+        # Return unsplit mixed_qkv and split_arg_list
+        if not split_qkv:
+            return mixed_qkv, split_arg_list
+
+        # [sq, b, ng, (np/ng + 2) * hn]
+        # --> [sq, b, ng, np/ng * hn], [sq, b, ng, hn], [sq, b, ng, hn]
+        (query, key, value) = paddle.split(mixed_qkv, split_arg_list, axis=3)
+
+        # [sq, b, ng, np/ng * hn] -> [sq, b, np, hn]
+        query = query.reshape(
+            query.size(0),
+            query.size(1),
+            -1,
+            self.hidden_size_per_attention_head,
+        )
+
+        if self.q_layernorm is not None:
+            query = self.q_layernorm(query)
+
+        if self.k_layernorm is not None:
+            key = self.k_layernorm(key)
+
+        return query, key, value
+
+    def backward_dw(self) -> NoReturn:
+        """Execute weight update operations"""
+        self._backward_qkv_proj()
+        self._backward_output_proj()
+
+    def _backward_qkv_proj(self):
+        """Update weights for QKV projection layer"""
+        self.linear_qkv.backward_dw()
+
+    def _backward_output_proj(self):
+        """Update weights for output projection layer"""
+        self.linear_proj.backward_dw()
+
+
+class CrossAttention(Attention):
+    """Cross-attention layer class
+
+    Cross-attention layer takes input with size [s, b, h] and context with size
+    [s, b, h] and returns output of the same size.
+    """
+
+    def __init__(
+        self,
+        config: TransformerConfig,
+        sublayers: CrossAttentionSublayers,
+        layer_number: int,
+        attn_mask_type=AttnMaskType.padding,
+        cp_comm_type: str | None = None,
+        pg_collection: ProcessGroupCollection = None,
+    ):
+        super().__init__(
+            config=config,
+            sublayers=sublayers,
+            layer_number=layer_number,
+            attn_mask_type=attn_mask_type,
+            attention_type="cross",
+            cp_comm_type=cp_comm_type,
+            pg_collection=pg_collection,
+        )
+
+        if self.config.num_query_groups != self.config.num_attention_heads:
+            raise ValueError(
+                "Group query attention is not currently supported in cross attention."
+            )
+        assert self.query_projection_size == self.kv_projection_size
+
+        self.linear_q = build_layer(
+            sublayers.linear_q,
+            self.config.hidden_size,
+            self.query_projection_size,
+            config=self.config,
+            init_method=self.config.init_method,
+            gather_output=False,
+            bias=self.config.add_bias_linear,
+            skip_bias_add=False,
+            is_expert=False,
+        )
+
+        self.linear_kv = build_layer(
+            sublayers.linear_kv,
+            self.config.hidden_size,
+            2 * self.kv_projection_size,
+            config=self.config,
+            init_method=self.config.init_method,
+            gather_output=False,
+            bias=self.config.add_bias_linear,
+            skip_bias_add=False,
+            is_expert=False,
+        )
+
+    def get_query_key_value_tensors(
+        self, hidden_states, key_value_states, split_qkv=True
+    ):
+        """
+        Derives `query` tensor from `hidden_states`, and `key`/`value` tensors
+        from `key_value_states`.
+        """
+        assert split_qkv, "split_qkv must be True for CrossAttention"
+        # Attention heads [sk, b, h] --> [sk, b, (np * 2 * hn)]
+        mixed_kv, _ = self.linear_kv(key_value_states)
+
+        # [sk, b, (np * 2 * hn)] --> [sk, b, np, 2 * hn]
+        new_tensor_shape = (
+            *mixed_kv.size()[:-1],
+            self.num_attention_heads_per_partition,
+            2 * self.hidden_size_per_attention_head,
+        )
+        mixed_kv = mixed_kv.view(*new_tensor_shape)
+
+        # [sk, b, np, 2 * hn] --> 2 [sk, b, np, hn]
+        (key, value) = tensor_parallel.split_tensor_along_last_dim(mixed_kv, 2)
+
+        # Attention head [sq, b, h] --> [sq, b, hp]
+        query, _ = self.linear_q(hidden_states)
+
+        # [sq, b, hp] --> [sq, b, np, hn]
+        new_tensor_shape = (
+            *query.size()[:-1],
+            self.num_attention_heads_per_partition,
+            self.hidden_size_per_attention_head,
+        )
+        query = query.view(*new_tensor_shape)
+
+        return query, key, value

--- a/fleet/core/transformer/dot_product_attention.py
+++ b/fleet/core/transformer/dot_product_attention.py
@@ -1,0 +1,296 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from fleet.core.packed_seq_params import PackedSeqParams
+    from fleet.core.transformer.enums import AttnMaskType
+    from fleet.core.transformer.transformer_config import TransformerConfig
+
+import paddle
+from paddle import Tensor
+
+from fleet.core.fusions.fused_softmax import FusedScaleMaskSoftmax
+from fleet.core.process_groups_config import ProcessGroupCollection
+from fleet.core.transformer.layer import FleetLayer
+from fleet.core.transformer.utils import (
+    attention_mask_func,
+    is_layer_window_attention,
+)
+from fleet.core.utils import divide
+
+
+class DotProductAttention(FleetLayer):
+    """
+    Region where selective activation recomputation is applied.
+    This region is memory intensive but less compute intensive which
+    makes activation checkpointing more efficient for LLMs (20B+).
+    See Reducing Activation Recomputation in Large Transformer Models:
+    https://arxiv.org/abs/2205.05198 for more details.
+
+    We use the following notation:
+     h: hidden size
+     n: number of attention heads
+     p: number of tensor model parallel partitions
+     b: batch size
+     s: sequence length
+    """
+
+    def __init__(
+        self,
+        config: TransformerConfig,
+        layer_number: int,
+        attn_mask_type: AttnMaskType,
+        attention_type: str,
+        attention_dropout: float | None = None,
+        softmax_scale: float | None = None,
+        cp_comm_type: str | None = None,
+        pg_collection: ProcessGroupCollection = None,
+        **kwargs,
+    ):
+        super().__init__(config=config)
+
+        self.config: TransformerConfig = config
+
+        assert self.config.context_parallel_size == 1, (
+            "Context parallelism is only supported by TEDotProductAttention!"
+        )
+
+        self.layer_number = max(1, layer_number)
+        self.attn_mask_type = attn_mask_type
+        self.attention_type = attention_type  # unused for now
+
+        projection_size = (
+            self.config.kv_channels * self.config.num_attention_heads
+        )
+
+        # Per attention head and per partition values.
+        if pg_collection is None:
+            pg_collection = ProcessGroupCollection.use_mpu_process_groups(
+                required_pgs=["tp"]
+            )
+        else:
+            assert hasattr(pg_collection, "tp"), (
+                "DotProductAttention pg_collection must have tp process group"
+            )
+
+        world_size = (
+            pg_collection.tp.size() if pg_collection.tp is not None else 1
+        )
+        self.hidden_size_per_partition = divide(projection_size, world_size)
+        self.hidden_size_per_attention_head = divide(
+            projection_size, config.num_attention_heads
+        )
+        self.num_attention_heads_per_partition = divide(
+            self.config.num_attention_heads, world_size
+        )
+        self.num_query_groups_per_partition = divide(
+            self.config.num_query_groups, world_size
+        )
+
+        coeff = None
+        if softmax_scale is None:
+            self.softmax_scale = 1.0 / math.sqrt(
+                self.hidden_size_per_attention_head
+            )
+        else:
+            self.softmax_scale = softmax_scale
+
+        if self.config.apply_query_key_layer_scaling:
+            coeff = self.layer_number
+            self.softmax_scale /= coeff
+
+        if is_layer_window_attention(
+            self.config.window_size,
+            self.config.window_attn_skip_freq,
+            layer_number,
+        ):
+            window_size = self.config.window_size
+        else:
+            window_size = None
+
+        self.scale_mask_softmax = FusedScaleMaskSoftmax(
+            input_in_fp16=self.config.fp16,
+            input_in_bf16=self.config.bf16,
+            attn_mask_type=self.attn_mask_type,
+            scaled_masked_softmax_fusion=self.config.masked_softmax_fusion,
+            mask_func=attention_mask_func,
+            softmax_in_fp32=self.config.attention_softmax_in_fp32,
+            scale=coeff,
+            window_size=window_size,
+        )
+
+        # Dropout. Note that for a single iteration, this layer will generate
+        # different outputs on different number of parallel partitions but
+        # on average it should not be partition dependent.
+        self.attention_dropout = paddle.nn.Dropout(
+            self.config.attention_dropout
+            if attention_dropout is None
+            else attention_dropout
+        )
+
+        if self.config.softmax_type == "vanilla":
+            self.softmax_offset = None
+        elif self.config.softmax_type == "off-by-one":
+            self.softmax_offset = paddle.zeros(
+                self.num_attention_heads_per_partition
+            )
+        elif self.config.softmax_type == "learnable":
+            self.register_parameter(
+                "softmax_offset",
+                paddle.nn.Parameter(
+                    paddle.empty(
+                        self.num_attention_heads_per_partition,
+                        dtype=self.config.params_dtype,
+                    )
+                ),
+            )
+            if config.perform_initialization:
+                self.softmax_offset = config.init_method(self.softmax_offset)
+        else:
+            raise ValueError("Softmax type not supported")
+
+    def forward(
+        self,
+        query: Tensor,
+        key: Tensor,
+        value: Tensor,
+        attention_mask: Tensor,
+        attn_mask_type: AttnMaskType = None,
+        attention_bias: Tensor = None,
+        packed_seq_params: PackedSeqParams | None = None,
+    ):
+        """Forward."""
+        assert packed_seq_params is None, (
+            "Packed sequence is not supported by DotProductAttention."
+            "Please use TEDotProductAttention instead."
+        )
+        assert attention_bias is None, (
+            "Attention bias is not supported for DotProductAttention."
+        )
+
+        # ===================================
+        # Raw attention scores. [b, n/p, s, s]
+        # ===================================
+
+        # expand the key and value [sk, b, ng, hn] -> [sk, b, np, hn]
+        # This is a noop for normal attention where ng == np. When using group query attention this
+        # creates a view that has the keys and values virtually repeated along their dimension to
+        # match the number of queries.
+
+        # attn_mask_type is not used.
+        if (
+            self.num_attention_heads_per_partition
+            // self.num_query_groups_per_partition
+            > 1
+        ):
+            key = key.repeat_interleave(
+                self.num_attention_heads_per_partition
+                // self.num_query_groups_per_partition,
+                dim=2,
+            )
+            value = value.repeat_interleave(
+                self.num_attention_heads_per_partition
+                // self.num_query_groups_per_partition,
+                dim=2,
+            )
+
+        # [b, np, sq, sk]
+        output_size = (query.size(1), query.size(2), query.size(0), key.size(0))
+
+        # [sq, b, np, hn] -> [sq, b * np, hn]
+        # This will be a simple view when doing normal attention, but in group query attention
+        # the key and value tensors are repeated to match the queries so you can't use
+        # simple strides to extract the queries.
+        query = query.reshape(
+            output_size[2], output_size[0] * output_size[1], -1
+        )
+        # [sk, b, np, hn] -> [sk, b * np, hn]
+        key = key.view(output_size[3], output_size[0] * output_size[1], -1)
+
+        # preallocting input tensor: [b * np, sq, sk]
+        matmul_input_buffer = paddle.empty(
+            (output_size[0] * output_size[1], output_size[2], output_size[3]),
+            query.dtype,
+        )
+
+        # Raw attention scores. [b * np, sq, sk]
+        matmul_result = paddle.baddbmm(
+            matmul_input_buffer,
+            query.transpose(0, 1),  # [b * np, sq, hn]
+            key.transpose(0, 1).transpose(1, 2),  # [b * np, hn, sk]
+            beta=0.0,
+            alpha=self.softmax_scale,
+        )
+
+        # change view to [b, np, sq, sk]
+        attention_scores = matmul_result.view(*output_size)
+
+        # ===========================
+        # Attention probs and dropout
+        # ===========================
+
+        # attention scores and attention mask [b, np, sq, sk]
+        attention_probs: Tensor = self.scale_mask_softmax(
+            attention_scores, attention_mask, self.softmax_offset
+        )
+        # This is actually dropping out entire tokens to attend to, which might
+        # seem a bit unusual, but is taken from the original Transformer paper.
+
+        attention_probs = self.attention_dropout(attention_probs)
+
+        # =========================
+        # Context layer. [sq, b, hp]
+        # =========================
+
+        # value -> context layer.
+        # [sk, b, np, hn] --> [b, np, sq, hn]
+
+        # context layer shape: [b, np, sq, hn]
+        output_size = (
+            value.size(1),
+            value.size(2),
+            query.size(0),
+            value.size(3),
+        )
+
+        # change view [sk, b * np, hn]
+        value = value.view(value.size(0), output_size[0] * output_size[1], -1)
+
+        # change view [b * np, sq, sk]
+        attention_probs = attention_probs.view(
+            output_size[0] * output_size[1], output_size[2], -1
+        )
+
+        # matmul: [b * np, sq, hn]
+        context = paddle.bmm(attention_probs, value.transpose(0, 1))
+
+        # change view [b, np, sq, hn]
+        context = context.view(*output_size)
+
+        # [b, np, sq, hn] --> [sq, b, np, hn]
+        context = context.permute(2, 0, 1, 3).contiguous()
+
+        # [sq, b, np, hn] --> [sq, b, hp]
+        new_context_shape = (
+            *context.size()[:-2],
+            self.hidden_size_per_partition,
+        )
+        context = context.view(*new_context_shape)
+
+        return context

--- a/fleet/core/transformer/utils.py
+++ b/fleet/core/transformer/utils.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utilities for transformer layers."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+import paddle
+
+
+@lru_cache(maxsize=32)
+def get_default_causal_mask(sq: int) -> paddle.Tensor:
+    """Return the causal upper triangular mask for softmax input."""
+    return paddle.triu(paddle.ones(sq, sq), diagonal=1).bool()
+
+
+@lru_cache(maxsize=32)
+def get_sliding_window_causal_mask(sq, skv, window_size):
+    """Create the equivalent attention mask for SWA in [sq, skv] shape"""
+    m = paddle.ones(sq, skv, dtype=paddle.bool)
+    mu = paddle.triu(m, diagonal=skv - sq - window_size[0])
+    ml = paddle.tril(mu, diagonal=skv - sq + window_size[1])
+    ml = ~ml
+
+    return ml
+
+
+def attention_mask_func(attention_scores, attention_mask):
+    attention_scores.masked_fill_(attention_mask, -10000.0)
+    return attention_scores
+
+
+def is_layer_window_attention(
+    window_size: tuple[int, int] | None,
+    window_attn_skip_freq: int | list,
+    layer_number: int,
+) -> bool:
+    # layer_number is 1-indexed
+    if not window_size:
+        return False
+    if window_attn_skip_freq is None:
+        return True
+    if isinstance(window_attn_skip_freq, int):
+        return layer_number % window_attn_skip_freq != 0
+    if isinstance(window_attn_skip_freq, list):
+        return bool(window_attn_skip_freq[layer_number - 1])
+
+    raise ValueError(
+        f"Invalid `window_attn_skip_freq`: {type(window_attn_skip_freq)}, "
+        f"{window_attn_skip_freq}"
+    )

--- a/fleet/core/utils.py
+++ b/fleet/core/utils.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 # Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
 
+import functools
 import logging
+import math
 from typing import Any
 
 import paddle
@@ -37,6 +39,46 @@ class WrappedTensor:
         if len(self._wrapper) == 0:
             raise RuntimeError("WrappedTensor has already been unwrapped")
         return self._wrapper.pop(0)
+
+
+def ensure_divisibility(numerator, denominator):
+    """Ensure that numerator is divisible by the denominator."""
+    assert numerator % denominator == 0, (
+        f"{numerator} is not divisible by {denominator}"
+    )
+
+
+def divide(numerator, denominator):
+    """Ensure that numerator is divisible by the denominator and return
+    the division value."""
+    ensure_divisibility(numerator, denominator)
+    return numerator // denominator
+
+
+def init_method_normal(sigma):
+    """Init method based on N(0, sigma)."""
+    return functools.partial(paddle.nn.init.normal_, mean=0.0, std=sigma)
+
+
+def scaled_init_method_normal(sigma, num_layers, multiplier=2.0):
+    """Init method based on N(0, sigma/sqrt(2*num_layers)."""
+    std = sigma / math.sqrt(multiplier * num_layers)
+
+    return functools.partial(paddle.nn.init.normal_, mean=0.0, std=std)
+
+
+def get_pg_size(group=None):
+    """Get world size for a distributed group.
+
+    Args:
+        group: Process group to get world size for. If None, uses default group.
+
+    Returns:
+        int: World size (1 if distributed not initialized or group is None, else group.size())
+    """
+    if not paddle.distributed.is_initialized() or group is None:
+        return 1
+    return group.size()
 
 
 def get_pg_rank(group=None):

--- a/tests/unit_tests/transformer/test_attention.py
+++ b/tests/unit_tests/transformer/test_attention.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import paddle
+
+from fleet.core.transformer.attention import (
+    SelfAttention,
+    SelfAttentionSublayers,
+)
+from fleet.core.transformer.dot_product_attention import DotProductAttention
+from fleet.core.transformer.transformer_config import TransformerConfig
+from fleet.core.utils import (
+    init_method_normal,
+    scaled_init_method_normal,
+)
+
+
+class BiasedLinear(paddle.nn.Layer):
+    def __init__(self, in_features, out_features, **kwargs):
+        super().__init__()
+        self.linear = paddle.nn.Linear(in_features, out_features)
+
+    def forward(self, x):
+        return self.linear(x), self.linear.bias
+
+
+class RMSNorm(paddle.nn.Layer):
+    def __init__(self, hidden_size, eps, **kwargs):
+        super().__init__()
+        self.weight = paddle.nn.Parameter(paddle.zeros([hidden_size]))
+        self.eps = eps
+
+    def forward(self, x):
+        d_norm = paddle.rsqrt(x.pow(2).mean(axis=-1, keepdim=True) + self.eps)
+        return x * d_norm * self.weight
+
+
+class TestSelfAttention(unittest.TestCase):
+    def setUp(self):
+        self.config = TransformerConfig(
+            num_layers=1,
+            hidden_size=128,
+            num_attention_heads=4,
+        )
+
+        # TODO(liangshuhao): make these args formal
+        self.config.num_query_groups = self.config.num_attention_heads
+        self.config.kv_channels = (
+            self.config.hidden_size // self.config.num_attention_heads
+        )
+        self.config.softmax_scale = None
+        self.config.add_bias_linear = True
+        self.config.no_rope_freq = None
+        self.config.recompute_granularity = None
+        self.config.fused_single_qkv_rope = False
+        self.config.init_method = init_method_normal(0.02)
+        self.config.output_layer_init_method = scaled_init_method_normal(
+            0.02, 1, 2.0
+        )
+        self.config.layernorm_epsilon = 1e-5
+        self.config.context_parallel_size = 1
+        self.config.apply_query_key_layer_scaling = False
+        self.config.window_size = None
+        self.config.window_attn_skip_freq = None
+        self.config.fp16 = False
+        self.config.bf16 = False
+        self.config.masked_softmax_fusion = False
+        self.config.attention_softmax_in_fp32 = True
+        self.config.attention_dropout = 0.1
+        self.config.softmax_type = "vanilla"
+
+        self.self_attention = SelfAttention(
+            self.config,
+            SelfAttentionSublayers(
+                linear_qkv=BiasedLinear,
+                core_attention=DotProductAttention,
+                linear_proj=BiasedLinear,
+                q_layernorm=RMSNorm,
+                k_layernorm=RMSNorm,
+            ),
+            layer_number=1,
+        )
+
+    def test_self_attention(self):
+        config = self.self_attention.config
+        sequence_length = 127
+        micro_batch_size = 2
+        hidden_size = self.self_attention.config.hidden_size
+
+        hidden_states = paddle.ones(
+            (sequence_length, micro_batch_size, hidden_size),
+        )
+
+        output, bias = self.self_attention(hidden_states, attention_mask=None)
+
+        assert config.recompute_granularity is None
+        # Check if output and bias have the correct shape
+        assert output.shape[0] == sequence_length
+        assert output.shape[1] == micro_batch_size
+        assert output.shape[2] == config.hidden_size
+        assert bias.shape[0] == config.hidden_size
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### 新增Attention及其相关的RoPE类
新增内容如下：
```c
fleet.core.transformer.attention:
    class Attention
    class SelfAttentionSublayers
    class CrossAttentionSublayers
    class SelfAttention
    class CrossAttention

fleet.core.transformer.dot_product_attention:
    class DotProductAttention

fleet.core.models.common.embeddings.language_model_embedding:
    class LanguageModelEmbedding

fleet.core.models.common.embeddings.rotary_pos_embedding:
    class RotaryEmbedding

fleet.core.models.common.embeddings.yarn_rotary_pos_embedding:
    class YarnRotaryEmbedding

fleet.core.models.common.embeddings.rope_utils:
    def apply_rotary_pos_emb
    def get_pos_emb_on_this_cp_rank

fleet.core.transformer.utils:
    def get_default_causal_mask
    def get_sliding_window_causal_mask
    def attention_mask_func
    def is_layer_window_attention
```

新增单测（可正常运行）：
```
python tests/unit_tests/transformer/test_attention.py
```
