### PR TITLE
Update LanguageModelEmbedding and add unittest

### DIFF
--- a/fleet/core/models/common/embeddings/language_model_embedding.py
+++ b/fleet/core/models/common/embeddings/language_model_embedding.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
 
 import paddle
 from paddle import Tensor
+from paddle.distributed.fleet.meta_parallel import VocabParallelEmbedding
 
 from fleet.core import tensor_parallel
 from fleet.core.transformer.layer import FleetLayer
@@ -72,15 +73,18 @@ class LanguageModelEmbedding(FleetLayer):
             and self.config.sequence_parallel
             and self.scatter_to_sequence_parallel
         )
+        assert not self.reduce_scatter_embeddings, (
+            "Currently reduce_scatter_embeddings is not supported."
+        )
 
         # Word embeddings (parallel).
-        self.word_embeddings = tensor_parallel.VocabParallelEmbedding(
+        self.word_embeddings = VocabParallelEmbedding(
             num_embeddings=self.vocab_size,
             embedding_dim=self.config.hidden_size,
-            init_method=self.config.embedding_init_method,
-            reduce_scatter_embeddings=self.reduce_scatter_embeddings,
-            config=self.config,
-            tp_group=self.tp_group,
+            # init_method=self.config.embedding_init_method,
+            # reduce_scatter_embeddings=self.reduce_scatter_embeddings,
+            # deterministic_mode=self.config.deterministic_mode,
+            mp_group=self.tp_group,
         )
 
         # Position embedding (serial).

--- a/tests/unit_tests/models/test_base_embedding.py
+++ b/tests/unit_tests/models/test_base_embedding.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import paddle
+from paddle.distributed import fleet
+
+from fleet.core.models.common.embeddings import LanguageModelEmbedding
+from fleet.core.transformer.transformer_config import TransformerConfig
+from fleet.core.utils import init_method_normal
+
+
+class TestBaseEmbedding(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        fleet.init(is_collective=True)
+
+    def setUp(self):
+        config = TransformerConfig(
+            num_layers=2, hidden_size=12, num_attention_heads=4
+        )
+        config.perform_initialization = True
+        config.embedding_init_method = init_method_normal(1.0)
+        config.hidden_dropout = False
+        config.fp32_residual_connection = False
+        config.sequence_parallel = False
+        self.base_embedding = LanguageModelEmbedding(
+            config=config,
+            vocab_size=100,
+            max_sequence_length=4,
+            position_embedding_type="learned_absolute",
+        )
+
+    def test_constructor(self):
+        assert isinstance(self.base_embedding, LanguageModelEmbedding)
+        num_weights = sum([p.numel() for p in self.base_embedding.parameters()])
+        assert num_weights == 1248
+
+    def test_zero_parameters(self):
+        sum_weights = sum([p.sum() for p in self.base_embedding.parameters()])
+        assert sum_weights != 0
+        self.base_embedding.zero_parameters()
+        sum_weights = sum([p.sum() for p in self.base_embedding.parameters()])
+        assert sum_weights == 0
+
+    def test_forward(self):
+        input_ids = paddle.arange(8).reshape((2, 4))
+        position_ids = paddle.arange(4).repeat((2, 1))
+        embeddings = self.base_embedding(input_ids, position_ids)
+        assert embeddings.place.is_gpu_place()
+        assert embeddings.shape[0] == self.base_embedding.max_sequence_length
+        assert embeddings.shape[1] == input_ids.shape[0]
+        assert embeddings.shape[2] == self.base_embedding.config.hidden_size
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### 更新LanguageModelEmbedding并增加单测

将 LanguageModelEmbedding 所用的 tensor_parallel.VocabParallelEmbedding 修改为框架自带的 paddle.distributed.fleet.meta_parallel.VocabParallelEmbedding，使之可运行

虽然框架的版本少几个参数，不过这些参数目前暂时用不着，之后有需要的话再在套件里实现自己的 VocabParallelEmbedding

新增可运行的单测：
```bash
python tests/unit_tests/models/test_base_embedding.py
```