### PR TITLE
Update RoPE and add unittest

### DIFF
--- a/fleet/core/models/common/embeddings/rope_utils.py
+++ b/fleet/core/models/common/embeddings/rope_utils.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -26,8 +25,6 @@ import logging
 
 import paddle
 from paddle import Tensor
-
-from fleet.core import parallel_state
 
 logger = logging.getLogger(__name__)
 
@@ -261,62 +258,22 @@ def apply_rotary_pos_emb(
     Reroute to the appropriate apply_rotary_pos_emb function depending on
     fused/unfused kernels, or bshd (conventional) / thd (packed seq) format
     """
-    global fused_apply_rotary_pos_emb, fused_apply_rotary_pos_emb_thd
 
-    # Keep for backward compatibility. Will deprecate in the future.
-    if cp_group is None:
-        cp_group = parallel_state.get_context_parallel_group()
-
-    if config.apply_rope_fusion:
-        if cu_seqlens is None:
-            # NOTE: TE backends do not support mRoPE in bshd format when bs > 1.
-            if config.mrope_section is not None and freqs.shape[1] > 1:
-                # TODO: Add a check in TransformerConfig and remove this unfused implementation.
-                warnings.warn(
-                    "apply_rope_fusion does not support mRoPE in bshd format when bs > 1. "
-                    "Please set apply_rope_fusion to false. This will become an error in v0.16."
-                )
-                return _apply_rotary_pos_emb_bshd(
-                    t,
-                    freqs,
-                    rotary_interleaved=config.rotary_interleaved,
-                    multi_latent_attention=config.multi_latent_attention,
-                    mscale=mscale,
-                )
-            else:
-                assert fused_apply_rotary_pos_emb is not None, (
-                    "apply_rope_fusion is not available."
-                )
-                return fused_apply_rotary_pos_emb(
-                    t, freqs, interleaved=config.rotary_interleaved
-                )
-        else:
-            assert fused_apply_rotary_pos_emb_thd is not None, (
-                "apply_rope_fusion is not available."
-            )
-            return fused_apply_rotary_pos_emb_thd(
-                t,
-                cu_seqlens,
-                freqs,
-                cp_size=cp_group.size(),
-                cp_rank=cp_group.rank(),
-            )
+    if cu_seqlens is None:
+        return _apply_rotary_pos_emb_bshd(
+            t,
+            freqs,
+            rotary_interleaved=config.rotary_interleaved,
+            multi_latent_attention=config.multi_latent_attention,
+            mscale=mscale,
+        )
     else:
-        if cu_seqlens is None:
-            return _apply_rotary_pos_emb_bshd(
-                t,
-                freqs,
-                rotary_interleaved=config.rotary_interleaved,
-                multi_latent_attention=config.multi_latent_attention,
-                mscale=mscale,
-            )
-        else:
-            return _apply_rotary_pos_emb_thd(
-                t,
-                cu_seqlens,
-                freqs,
-                rotary_interleaved=config.rotary_interleaved,
-                multi_latent_attention=config.multi_latent_attention,
-                mscale=mscale,
-                cp_group=cp_group,
-            )
+        return _apply_rotary_pos_emb_thd(
+            t,
+            cu_seqlens,
+            freqs,
+            rotary_interleaved=config.rotary_interleaved,
+            multi_latent_attention=config.multi_latent_attention,
+            mscale=mscale,
+            cp_group=cp_group,
+        )

--- a/fleet/core/models/common/embeddings/yarn_rotary_pos_embedding.py
+++ b/fleet/core/models/common/embeddings/yarn_rotary_pos_embedding.py
@@ -20,16 +20,11 @@ from functools import lru_cache
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from paddle.distributed.communication.group import Group
-
     from fleet.core.transformer import TransformerConfig
 
 import paddle
 from paddle import Tensor
 
-from fleet.core.models.common.embeddings.rope_utils import (
-    get_pos_emb_on_this_cp_rank,
-)
 from fleet.core.models.common.embeddings.rotary_pos_embedding import (
     RotaryEmbedding,
 )
@@ -50,8 +45,6 @@ class YarnRotaryEmbedding(RotaryEmbedding):
             longer sequences. The value must be a float larger than 1.0. Defaults to None
         rotary_base (float, optional): Base period for rotary position embeddings. Defaults to
             10000.
-        use_cpu_initialization (bool, optional): If False, initialize the inv_freq directly on
-            the GPU. Defaults to False.
         scaling_factor (float, optional): Scaling factor for Yarn RoPE. Defaults to 1.0.
         original_max_position_embeddings (int, optional): Original maximum position embeddings
             length. Defaults to 4096.
@@ -61,8 +54,6 @@ class YarnRotaryEmbedding(RotaryEmbedding):
         mscale_all_dim (float, optional): Mscale all dim value for Yarn RoPE. Defaults to 0.
         correction_range_round_to_int (bool): Whether to round dim range bounds to integer.
             Defaults to True
-        cp_group (Group, optional): Process group for context parallel.
-            Defaults to None.
     """
 
     def __init__(
@@ -72,7 +63,6 @@ class YarnRotaryEmbedding(RotaryEmbedding):
         rotary_interleaved: bool = False,
         seq_len_interpolation_factor: float | None = None,
         rotary_base: float = 10000.0,
-        use_cpu_initialization: bool = False,
         scaling_factor: float = 1.0,
         original_max_position_embeddings: int = 4096,
         beta_fast: float = 32.0,
@@ -80,7 +70,6 @@ class YarnRotaryEmbedding(RotaryEmbedding):
         mscale: float = 1.0,
         mscale_all_dim: float = 0.0,
         correction_range_round_to_int: bool = True,
-        cp_group: Group | None = None,
     ):
         self.dim = kv_channels
         self.rotary_base = rotary_base
@@ -92,43 +81,28 @@ class YarnRotaryEmbedding(RotaryEmbedding):
         self.mscale_all_dim = mscale_all_dim
         self.correction_range_round_to_int = correction_range_round_to_int
 
-        device = "cpu" if use_cpu_initialization else paddle.get_device()
+        super().__init__(
+            kv_channels=kv_channels,
+            rotary_percent=rotary_percent,
+            rotary_interleaved=rotary_interleaved,
+            seq_len_interpolation_factor=seq_len_interpolation_factor,
+            rotary_base=rotary_base,
+        )
 
-        with paddle.device_guard(device):
-            self.inv_freq_extra = 1.0 / (
-                self.rotary_base
-                ** (
-                    paddle.arange(
-                        0, self.dim, 2, dtype=paddle.float32, device=device
-                    )
-                    / self.dim
-                )
-            )
-            self.inv_freq_inter = 1.0 / (
-                self.scaling_factor
-                * self.rotary_base
-                ** (
-                    paddle.arange(
-                        0, self.dim, 2, dtype=paddle.float32, device=device
-                    )
-                    / self.dim
-                )
-            )
-            super().__init__(
-                kv_channels=kv_channels,
-                rotary_percent=rotary_percent,
-                rotary_interleaved=rotary_interleaved,
-                seq_len_interpolation_factor=seq_len_interpolation_factor,
-                rotary_base=rotary_base,
-                use_cpu_initialization=use_cpu_initialization,
-                cp_group=cp_group,
-            )
-
-            self._set_cos_sin_cache(
-                self.original_max_position_embeddings,
-                offset=0,
-                dtype=paddle.get_default_dtype(),
-            )
+        self.inv_freq_extra = 1.0 / (
+            self.rotary_base
+            ** (paddle.arange(0, self.dim, 2).astype(paddle.float32) / self.dim)
+        )
+        self.inv_freq_inter = 1.0 / (
+            self.scaling_factor
+            * self.rotary_base
+            ** (paddle.arange(0, self.dim, 2).astype(paddle.float32) / self.dim)
+        )
+        self._set_cos_sin_cache(
+            self.original_max_position_embeddings,
+            offset=0,
+            dtype=paddle.get_default_dtype(),
+        )
 
     def forward(
         self, max_seq_len: int, offset: int = 0, packed_seq: bool = False
@@ -147,18 +121,6 @@ class YarnRotaryEmbedding(RotaryEmbedding):
             "Yarn RoPE does not support interleaved rotary embeddings"
         )
 
-        if self.inv_freq_extra.place.is_cpu_place():
-            # move `inv_freq_extra` to GPU once at the first micro-batch forward pass
-            self.inv_freq_extra = self.inv_freq_extra.to(
-                device=paddle.get_device()
-            )
-
-        if self.inv_freq_inter.place.is_cpu_place():
-            # move `inv_freq_inter` to GPU once at the first micro-batch forward pass
-            self.inv_freq_inter = self.inv_freq_inter.to(
-                device=paddle.get_device()
-            )
-
         low, high = _yarn_find_correction_range(
             self.beta_fast,
             self.beta_slow,
@@ -168,7 +130,7 @@ class YarnRotaryEmbedding(RotaryEmbedding):
             self.correction_range_round_to_int,
         )
         inv_freq_mask = 1.0 - _yarn_linear_ramp_mask(
-            low, high, self.dim // 2, device=self.inv_freq_extra.place
+            low, high, self.dim // 2
         ).to(dtype=paddle.float32)
         inv_freq = (
             self.inv_freq_inter * (1 - inv_freq_mask)
@@ -178,9 +140,7 @@ class YarnRotaryEmbedding(RotaryEmbedding):
         seq = (
             paddle.arange(
                 max_seq_len,
-                device=self.inv_freq_extra.place,
-                dtype=self.inv_freq_extra.dtype,
-            )
+            ).astype(self.inv_freq_extra.dtype)
             + offset
         )
 
@@ -193,14 +153,6 @@ class YarnRotaryEmbedding(RotaryEmbedding):
         emb = paddle.cat((freqs, freqs), axis=-1)
         # emb [seq_length, .., dim]
         emb = emb[:, None, None, :]
-        if (
-            self.cp_group is not None
-            and self.cp_group.size() > 1
-            and not packed_seq
-        ):
-            # slice rotary_pos_emb along sequence dimension
-            # and select the partition of the current CP rank
-            emb = get_pos_emb_on_this_cp_rank(emb, 0, self.cp_group)
         return emb, _mscale
 
     def _set_cos_sin_cache(self, seq_len, offset, dtype, packed_seq=False):
@@ -213,12 +165,12 @@ class YarnRotaryEmbedding(RotaryEmbedding):
         self.register_buffer(
             "cos_cached",
             (emb.cos() * _mscale).to(dtype).contiguous(),
-            persistent=False,
+            persistable=False,
         )
         self.register_buffer(
             "sin_cached",
             (emb.sin() * _mscale).to(dtype).contiguous(),
-            persistent=False,
+            persistable=False,
         )
 
     def get_cached_cos_sin(
@@ -272,15 +224,13 @@ def _yarn_find_correction_range(
     return max(low, 0), min(high, dim - 1)  # Clamp values just in case
 
 
-def _yarn_linear_ramp_mask(
-    min: float, max: float, dim: int, device: paddle.device
-) -> Tensor:
+def _yarn_linear_ramp_mask(min: float, max: float, dim: int) -> Tensor:
     if min == max:
         max += 0.001  # Prevent singularity
 
-    linear_func = (
-        paddle.arange(dim, dtype=paddle.float32, device=device) - min
-    ) / (max - min)
+    linear_func = (paddle.arange(dim).astype(paddle.float32) - min) / (
+        max - min
+    )
     ramp_func = paddle.clamp(linear_func, 0, 1)
     return ramp_func
 

--- a/tests/unit_tests/transformer/test_attention.py
+++ b/tests/unit_tests/transformer/test_attention.py
@@ -66,6 +66,8 @@ class TestSelfAttention(unittest.TestCase):
         self.config.no_rope_freq = None
         self.config.recompute_granularity = None
         self.config.fused_single_qkv_rope = False
+        self.config.rotary_interleaved = False
+        self.config.multi_latent_attention = True
         self.config.init_method = init_method_normal(0.02)
         self.config.output_layer_init_method = scaled_init_method_normal(
             0.02, 1, 2.0
@@ -100,13 +102,17 @@ class TestSelfAttention(unittest.TestCase):
         micro_batch_size = 2
         hidden_size = self.self_attention.config.hidden_size
 
-        hidden_states = paddle.ones(
+        hidden_states = paddle.randn(
             (sequence_length, micro_batch_size, hidden_size),
         )
+        rotary_pos_emb = paddle.randn(
+            (sequence_length, 1, 1, self.config.kv_channels)
+        )
 
-        output, bias = self.self_attention(hidden_states, attention_mask=None)
+        output, bias = self.self_attention(
+            hidden_states, attention_mask=None, rotary_pos_emb=rotary_pos_emb
+        )
 
-        assert config.recompute_granularity is None
         # Check if output and bias have the correct shape
         assert output.shape[0] == sequence_length
         assert output.shape[1] == micro_batch_size

--- a/tests/unit_tests/transformer/test_rope.py
+++ b/tests/unit_tests/transformer/test_rope.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import paddle
+
+from fleet.core.models.common.embeddings import (
+    RotaryEmbedding,
+    YarnRotaryEmbedding,
+)
+
+
+class TestRotaryEmbedding(unittest.TestCase):
+    def setUp(self):
+        self.kv_channels = 8
+        self.rotary_percent = 1.0
+        self.rope = RotaryEmbedding(self.kv_channels, self.rotary_percent)
+
+    def test_forward(self):
+        output = self.rope(64)
+        assert output.shape[0] == 64
+        assert output.shape[1] == 1
+        assert output.shape[2] == 1
+        assert output.shape[3] == self.kv_channels
+        assert output.dtype == paddle.float32
+        assert output.place.is_gpu_place()
+
+
+class TestYarnRotaryEmbedding(unittest.TestCase):
+    def setUp(self):
+        self.kv_channels = 8
+        self.rotary_percent = 1.0
+        self.rope = YarnRotaryEmbedding(self.kv_channels, self.rotary_percent)
+
+    def test_forward(self):
+        output, mscale = self.rope(64)
+        assert output.shape[0] == 64
+        assert output.shape[1] == 1
+        assert output.shape[2] == 1
+        assert output.shape[3] == self.kv_channels
+        assert output.dtype == paddle.float32
+        assert output.place.is_gpu_place()
+        assert mscale == 1.0
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### 更新RoPE相关代码并增加单测

修改如下内容以更好地适配 Paddle 生态：
* 删除一些不会被访问的 fusion 分支
* 删除所有 cp_group 相关逻辑
* 删除所有 cpu 使用，全部在 gpu 上完成
* 将所有 arange(float) 改成先 arange(int64) 再 astype(float)，防止精度误差

新增可运行的单测：
```bash
python tests/unit_tests/transformer/test_rope.py
```