### PR TITLE
use paddle12.6 in single card test

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -79,9 +79,8 @@ jobs:
 
       - name: Clone PaddleFleet
         run: |
-          docker exec -t ${{ env.container_name }} /bin/bash -c '
+          docker exec -t ${{ env.container_name }} /bin/bash -ce '
           rm -rf * .[^.]*
-          set -e
           source /root/proxy
           git clone https://github.com/PaddlePaddle/PaddleFleet.git .
           git config --global --add safe.directory /paddle
@@ -101,7 +100,7 @@ jobs:
       - name: Single card test
         if: steps.check-bypass.outputs.can-skip != 'true'
         run: |
-          docker exec -t ${{ env.container_name }} /bin/bash -xc '
+          docker exec -t ${{ env.container_name }} /bin/bash -xce '
           source $HOME/.local/bin/env
           pwd
           export COVERAGE_FILE=/paddle/coveragedata/.coverage
@@ -128,7 +127,7 @@ jobs:
       - name: Single card Coverage Upload to BOS
         if: steps.check-bypass.outputs.can-skip != 'true'
         run: |
-          docker exec -t ${{ env.container_name }} /bin/bash -xc '
+          docker exec -t ${{ env.container_name }} /bin/bash -xce '
           source $HOME/.local/bin/env
           export COVERAGE_FILE=/paddle/coveragedata/.coverage
           export COVERAGE_RCFILE=/paddle/ci/.coveragerc
@@ -194,9 +193,8 @@ jobs:
 
       - name: Clone PaddleFleet
         run: |
-          docker exec -t ${{ env.container_name }} /bin/bash -c '
+          docker exec -t ${{ env.container_name }} /bin/bash -ce '
           rm -rf * .[^.]*
-          set -e
           source /root/proxy
           git clone https://github.com/PaddlePaddle/PaddleFleet.git .
           git config --global --add safe.directory /paddle
@@ -216,7 +214,7 @@ jobs:
       - name: Multi-card test
         if: steps.check-bypass.outputs.can-skip != 'true'
         run: |
-          docker exec -t ${{ env.container_name }} /bin/bash -c '
+          docker exec -t ${{ env.container_name }} /bin/bash -ce '
           source $HOME/.local/bin/env
           export COVERAGE_FILE=/paddle/coveragedata/.coverage
           export COVERAGE_RCFILE=/paddle/ci/.coveragerc
@@ -243,7 +241,7 @@ jobs:
       - name: Multi-card Coverage Upload to BOS
         if: steps.check-bypass.outputs.can-skip != 'true'
         run: |
-          docker exec -t ${{ env.container_name }} /bin/bash -xc '
+          docker exec -t ${{ env.container_name }} /bin/bash -xce '
           source $HOME/.local/bin/env
           export COVERAGE_FILE=/paddle/coveragedata/.coverage
           export COVERAGE_RCFILE=/paddle/ci/.coveragerc

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -210,7 +210,7 @@ jobs:
           curl -LsSf https://astral.sh/uv/install.sh | sh
           source $HOME/.local/bin/env
           echo "uv sync"
-          uv sync --group ci -v --extra-index-url="https://www.paddlepaddle.org.cn/packages/nightly/cu126/" > /dev/null
+          uv sync --group ci -v" > /dev/null
           '
 
       - name: Multi-card test
@@ -223,7 +223,7 @@ jobs:
           export WITH_COVERAGE=ON
           export UV_SKIP_WHEEL_FILENAME_CHECK=1 #This environment variable allows installing the latest commit-level whl package of Paddle.
           export UV_NO_SYNC=1 # This environment variable prevents 'uv sync' from being executed when running 'un run'.
-          uv pip install https://paddle-qa.bj.bcebos.com/paddle-pipeline/Develop-TagBuild-Training-Linux-Gpu-Cuda12.6-Cudnn9.5-Trt10.5-Mkl-Avx-Gcc11-SelfBuiltPypiUse/latest/paddlepaddle_gpu-0.0.0-cp310-cp310-linux_x86_64.whl
+          uv pip install https://paddle-qa.bj.bcebos.com/paddle-pipeline/Develop-TagBuild-Training-Linux-Gpu-Cuda12.9-Cudnn9.9-Trt10.5-Mkl-Avx-Gcc11-SelfBuiltPypiUse/latest/paddlepaddle_gpu-0.0.0-cp310-cp310-linux_x86_64.whl
           bash ci/multi-card_test.sh
           multi_card_exit_code=$?
           ls -a /paddle/coveragedata/

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -109,7 +109,8 @@ jobs:
           export WITH_COVERAGE=ON
           export UV_SKIP_WHEEL_FILENAME_CHECK=1 #This environment variable allows installing the latest commit-level whl package of Paddle.
           export UV_NO_SYNC=1 # This environment variable prevents uv sync from being executed when running un run.
-          uv pip install https://paddle-qa.bj.bcebos.com/paddle-pipeline/Develop-TagBuild-Training-Linux-Gpu-Cuda12.6-Cudnn9.5-Trt10.5-Mkl-Avx-Gcc11-SelfBuiltPypiUse/latest/paddlepaddle_gpu-0.0.0-cp310-cp310-linux_x86_64.whl
+          export UV_HTTP_TIMEOUT=300
+          uv pip install https://paddle-qa.bj.bcebos.com/paddle-pipeline/Develop-GpuAll-LinuxCentos-Gcc11-Cuda126-Cudnn95-Trt105-Py310-Compile/latest/paddlepaddle_gpu-0.0.0-cp310-cp310-linux_x86_64.whl
           bash ci/single_card_test.sh
           single_card_exit_code=$?
           ls -a /paddle/coveragedata/
@@ -222,7 +223,8 @@ jobs:
           export WITH_COVERAGE=ON
           export UV_SKIP_WHEEL_FILENAME_CHECK=1 #This environment variable allows installing the latest commit-level whl package of Paddle.
           export UV_NO_SYNC=1 # This environment variable prevents uv sync from being executed when running un run.
-          uv pip install https://paddle-qa.bj.bcebos.com/paddle-pipeline/Develop-TagBuild-Training-Linux-Gpu-Cuda12.9-Cudnn9.9-Trt10.5-Mkl-Avx-Gcc11-SelfBuiltPypiUse/latest/paddlepaddle_gpu-0.0.0-cp310-cp310-linux_x86_64.whl
+          export UV_HTTP_TIMEOUT=300
+          uv pip install https://paddle-qa.bj.bcebos.com/paddle-pipeline/Develop-GpuAll-LinuxCentos-Gcc11-Cuda126-Cudnn95-Trt105-Py310-Compile/latest/paddlepaddle_gpu-0.0.0-cp310-cp310-linux_x86_64.whl
           bash ci/multi-card_test.sh
           multi_card_exit_code=$?
           ls -a /paddle/coveragedata/

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -107,7 +107,9 @@ jobs:
           export COVERAGE_FILE=/paddle/coveragedata/.coverage
           export COVERAGE_RCFILE=/paddle/ci/.coveragerc
           export WITH_COVERAGE=ON
-
+          export UV_SKIP_WHEEL_FILENAME_CHECK=1 #This environment variable allows installing the latest commit-level whl package of Paddle.
+          export UV_NO_SYNC=1 # This environment variable prevents 'uv sync' from being executed when running 'un run'.
+          uv pip install https://paddle-qa.bj.bcebos.com/paddle-pipeline/Develop-TagBuild-Training-Linux-Gpu-Cuda12.6-Cudnn9.5-Trt10.5-Mkl-Avx-Gcc11-SelfBuiltPypiUse/latest/paddlepaddle_gpu-0.0.0-cp310-cp310-linux_x86_64.whl
           bash ci/single_card_test.sh
           single_card_exit_code=$?
           ls -a /paddle/coveragedata/
@@ -130,7 +132,9 @@ jobs:
           export COVERAGE_FILE=/paddle/coveragedata/.coverage
           export COVERAGE_RCFILE=/paddle/ci/.coveragerc
           export WITH_COVERAGE=ON
-
+          export UV_SKIP_WHEEL_FILENAME_CHECK=1 #This environment variable allows installing the latest commit-level whl package of Paddle.
+          export UV_NO_SYNC=1 # This environment variable prevents 'uv sync' from being executed when running 'un run'.
+          uv pip install https://paddle-qa.bj.bcebos.com/paddle-pipeline/Develop-TagBuild-Training-Linux-Gpu-Cuda12.6-Cudnn9.5-Trt10.5-Mkl-Avx-Gcc11-SelfBuiltPypiUse/latest/paddlepaddle_gpu-0.0.0-cp310-cp310-linux_x86_64.whl
           wget -q --no-proxy --no-check-certificate \
             https://paddle-qa.bj.bcebos.com/CodeSync/develop/PaddlePaddle/PaddleTest/tools/bos_tools.py \
             -O bos_tools.py
@@ -217,7 +221,9 @@ jobs:
           export COVERAGE_FILE=/paddle/coveragedata/.coverage
           export COVERAGE_RCFILE=/paddle/ci/.coveragerc
           export WITH_COVERAGE=ON
-
+          export UV_SKIP_WHEEL_FILENAME_CHECK=1 #This environment variable allows installing the latest commit-level whl package of Paddle.
+          export UV_NO_SYNC=1 # This environment variable prevents 'uv sync' from being executed when running 'un run'.
+          uv pip install https://paddle-qa.bj.bcebos.com/paddle-pipeline/Develop-TagBuild-Training-Linux-Gpu-Cuda12.6-Cudnn9.5-Trt10.5-Mkl-Avx-Gcc11-SelfBuiltPypiUse/latest/paddlepaddle_gpu-0.0.0-cp310-cp310-linux_x86_64.whl
           bash ci/multi-card_test.sh
           multi_card_exit_code=$?
           ls -a /paddle/coveragedata/
@@ -241,7 +247,9 @@ jobs:
           export COVERAGE_FILE=/paddle/coveragedata/.coverage
           export COVERAGE_RCFILE=/paddle/ci/.coveragerc
           export WITH_COVERAGE=ON
-
+          export UV_SKIP_WHEEL_FILENAME_CHECK=1 #This environment variable allows installing the latest commit-level whl package of Paddle.
+          export UV_NO_SYNC=1 # This environment variable prevents 'uv sync' from being executed when running 'un run'.
+          uv pip install https://paddle-qa.bj.bcebos.com/paddle-pipeline/Develop-TagBuild-Training-Linux-Gpu-Cuda12.6-Cudnn9.5-Trt10.5-Mkl-Avx-Gcc11-SelfBuiltPypiUse/latest/paddlepaddle_gpu-0.0.0-cp310-cp310-linux_x86_64.whl
           wget -q --no-proxy --no-check-certificate \
             https://paddle-qa.bj.bcebos.com/CodeSync/develop/PaddlePaddle/PaddleTest/tools/bos_tools.py \
             -O bos_tools.py

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -108,7 +108,7 @@ jobs:
           export COVERAGE_RCFILE=/paddle/ci/.coveragerc
           export WITH_COVERAGE=ON
           export UV_SKIP_WHEEL_FILENAME_CHECK=1 #This environment variable allows installing the latest commit-level whl package of Paddle.
-          export UV_NO_SYNC=1 # This environment variable prevents 'uv sync' from being executed when running 'un run'.
+          export UV_NO_SYNC=1 # This environment variable prevents uv sync from being executed when running un run.
           uv pip install https://paddle-qa.bj.bcebos.com/paddle-pipeline/Develop-TagBuild-Training-Linux-Gpu-Cuda12.6-Cudnn9.5-Trt10.5-Mkl-Avx-Gcc11-SelfBuiltPypiUse/latest/paddlepaddle_gpu-0.0.0-cp310-cp310-linux_x86_64.whl
           bash ci/single_card_test.sh
           single_card_exit_code=$?
@@ -133,7 +133,7 @@ jobs:
           export COVERAGE_RCFILE=/paddle/ci/.coveragerc
           export WITH_COVERAGE=ON
           export UV_SKIP_WHEEL_FILENAME_CHECK=1 #This environment variable allows installing the latest commit-level whl package of Paddle.
-          export UV_NO_SYNC=1 # This environment variable prevents 'uv sync' from being executed when running 'un run'.
+          export UV_NO_SYNC=1 # This environment variable prevents uv sync from being executed when running un run.
           wget -q --no-proxy --no-check-certificate \
             https://paddle-qa.bj.bcebos.com/CodeSync/develop/PaddlePaddle/PaddleTest/tools/bos_tools.py \
             -O bos_tools.py
@@ -221,7 +221,7 @@ jobs:
           export COVERAGE_RCFILE=/paddle/ci/.coveragerc
           export WITH_COVERAGE=ON
           export UV_SKIP_WHEEL_FILENAME_CHECK=1 #This environment variable allows installing the latest commit-level whl package of Paddle.
-          export UV_NO_SYNC=1 # This environment variable prevents 'uv sync' from being executed when running 'un run'.
+          export UV_NO_SYNC=1 # This environment variable prevents uv sync from being executed when running un run.
           uv pip install https://paddle-qa.bj.bcebos.com/paddle-pipeline/Develop-TagBuild-Training-Linux-Gpu-Cuda12.9-Cudnn9.9-Trt10.5-Mkl-Avx-Gcc11-SelfBuiltPypiUse/latest/paddlepaddle_gpu-0.0.0-cp310-cp310-linux_x86_64.whl
           bash ci/multi-card_test.sh
           multi_card_exit_code=$?
@@ -247,7 +247,7 @@ jobs:
           export COVERAGE_RCFILE=/paddle/ci/.coveragerc
           export WITH_COVERAGE=ON
           export UV_SKIP_WHEEL_FILENAME_CHECK=1 #This environment variable allows installing the latest commit-level whl package of Paddle.
-          export UV_NO_SYNC=1 # This environment variable prevents 'uv sync' from being executed when running 'un run'.
+          export UV_NO_SYNC=1 # This environment variable prevents uv sync from being executed when running un run.
           wget -q --no-proxy --no-check-certificate \
             https://paddle-qa.bj.bcebos.com/CodeSync/develop/PaddlePaddle/PaddleTest/tools/bos_tools.py \
             -O bos_tools.py

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -206,7 +206,7 @@ jobs:
           curl -LsSf https://astral.sh/uv/install.sh | sh
           source $HOME/.local/bin/env
           echo "uv sync"
-          uv sync --group ci -v > /dev/null
+          uv sync --group ci -v --extra-index-url="https://www.paddlepaddle.org.cn/packages/nightly/cu126/" > /dev/null
           '
 
       - name: Multi-card test

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -109,7 +109,7 @@ jobs:
           export UV_SKIP_WHEEL_FILENAME_CHECK=1 #This environment variable allows installing the latest commit-level whl package of Paddle.
           export UV_NO_SYNC=1 # This environment variable prevents uv sync from being executed when running un run.
           export UV_HTTP_TIMEOUT=300
-          uv pip install https://paddle-qa.bj.bcebos.com/paddle-pipeline/Develop-GpuAll-LinuxCentos-Gcc11-Cuda126-Cudnn95-Trt105-Py310-Compile/latest/paddlepaddle_gpu-0.0.0-cp310-cp310-linux_x86_64.whl
+          uv pip install https://paddle-qa.bj.bcebos.com/paddle-pipeline/Develop-GpuAll-LinuxCentos-Gcc11-Cuda126-Cudnn95-Trt105-Py310-Compile/latest/paddlepaddle_gpu-0.0.0-cp310-cp310-linux_x86_64.whl --index-url=https://www.paddlepaddle.org.cn/packages/nightly/cu126/
           bash ci/single_card_test.sh
           single_card_exit_code=$?
           ls -a /paddle/coveragedata/
@@ -222,7 +222,7 @@ jobs:
           export UV_SKIP_WHEEL_FILENAME_CHECK=1 #This environment variable allows installing the latest commit-level whl package of Paddle.
           export UV_NO_SYNC=1 # This environment variable prevents uv sync from being executed when running un run.
           export UV_HTTP_TIMEOUT=300
-          uv pip install https://paddle-qa.bj.bcebos.com/paddle-pipeline/Develop-GpuAll-LinuxCentos-Gcc11-Cuda126-Cudnn95-Trt105-Py310-Compile/latest/paddlepaddle_gpu-0.0.0-cp310-cp310-linux_x86_64.whl
+          uv pip install https://paddle-qa.bj.bcebos.com/paddle-pipeline/Develop-GpuAll-LinuxCentos-Gcc11-Cuda129-Cudnn99-Trt105-Py310-Compile/latest/paddlepaddle_gpu-0.0.0-cp310-cp310-linux_x86_64.whl --index-url=https://www.paddlepaddle.org.cn/packages/nightly/cu129/
           bash ci/multi-card_test.sh
           multi_card_exit_code=$?
           ls -a /paddle/coveragedata/

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -210,7 +210,7 @@ jobs:
           curl -LsSf https://astral.sh/uv/install.sh | sh
           source $HOME/.local/bin/env
           echo "uv sync"
-          uv sync --group ci -v" > /dev/null
+          uv sync --group ci -v > /dev/null
           '
 
       - name: Multi-card test

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -134,7 +134,6 @@ jobs:
           export WITH_COVERAGE=ON
           export UV_SKIP_WHEEL_FILENAME_CHECK=1 #This environment variable allows installing the latest commit-level whl package of Paddle.
           export UV_NO_SYNC=1 # This environment variable prevents 'uv sync' from being executed when running 'un run'.
-          uv pip install https://paddle-qa.bj.bcebos.com/paddle-pipeline/Develop-TagBuild-Training-Linux-Gpu-Cuda12.6-Cudnn9.5-Trt10.5-Mkl-Avx-Gcc11-SelfBuiltPypiUse/latest/paddlepaddle_gpu-0.0.0-cp310-cp310-linux_x86_64.whl
           wget -q --no-proxy --no-check-certificate \
             https://paddle-qa.bj.bcebos.com/CodeSync/develop/PaddlePaddle/PaddleTest/tools/bos_tools.py \
             -O bos_tools.py
@@ -249,7 +248,6 @@ jobs:
           export WITH_COVERAGE=ON
           export UV_SKIP_WHEEL_FILENAME_CHECK=1 #This environment variable allows installing the latest commit-level whl package of Paddle.
           export UV_NO_SYNC=1 # This environment variable prevents 'uv sync' from being executed when running 'un run'.
-          uv pip install https://paddle-qa.bj.bcebos.com/paddle-pipeline/Develop-TagBuild-Training-Linux-Gpu-Cuda12.6-Cudnn9.5-Trt10.5-Mkl-Avx-Gcc11-SelfBuiltPypiUse/latest/paddlepaddle_gpu-0.0.0-cp310-cp310-linux_x86_64.whl
           wget -q --no-proxy --no-check-certificate \
             https://paddle-qa.bj.bcebos.com/CodeSync/develop/PaddlePaddle/PaddleTest/tools/bos_tools.py \
             -O bos_tools.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 
-dependencies = ["paddlepaddle-gpu>=3.3.0.dev"]
+dependencies = ["paddlepaddle-gpu==3.2.2; sys_platform == 'linux' and platform_machine == 'x86_64'"]
 
 [project.urls]
 Download = "https://github.com/PaddlePaddle/PaddleFleet/releases"
@@ -55,7 +55,7 @@ Homepage = "https://github.com/PaddlePaddle/PaddleFleet/fleet/core"
 
 
 [build-system]
-requires = ["setuptools>=61.0.0,<80.0.0", "pybind11", "packaging>=24.2","paddlepaddle-gpu>=3.3.0.dev"]
+requires = ["setuptools>=61.0.0,<80.0.0", "pybind11", "packaging>=24.2","paddlepaddle-gpu==3.2.2; sys_platform == 'linux' and platform_machine == 'x86_64'"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
@@ -90,7 +90,7 @@ ci = [
 [tool.uv]
 default-groups = ["build", "test"]
 link-mode = "copy"
-extra-index-url = ["https://www.paddlepaddle.org.cn/packages/nightly/cu129/"]
+extra-index-url = ["https://www.paddlepaddle.org.cn/packages/stable/cu129/"]
 index-strategy = "unsafe-best-match"
 
 [tool.uv.pip]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 
-dependencies = ["paddlepaddle-gpu==3.2.2; sys_platform == 'linux' and platform_machine == 'x86_64'"]
+dependencies = ["paddlepaddle-gpu==3.2.2"]
 
 [project.urls]
 Download = "https://github.com/PaddlePaddle/PaddleFleet/releases"
@@ -55,7 +55,7 @@ Homepage = "https://github.com/PaddlePaddle/PaddleFleet/fleet/core"
 
 
 [build-system]
-requires = ["setuptools>=61.0.0,<80.0.0", "pybind11", "packaging>=24.2","paddlepaddle-gpu==3.2.2; sys_platform == 'linux' and platform_machine == 'x86_64'"]
+requires = ["setuptools>=61.0.0,<80.0.0", "pybind11", "packaging>=24.2","paddlepaddle-gpu==3.2.2"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ ci = [
 [tool.uv]
 default-groups = ["build", "test"]
 link-mode = "copy"
-extra-index-url = ["https://www.paddlepaddle.org.cn/packages/nightly/cu126/"]
+extra-index-url = ["https://www.paddlepaddle.org.cn/packages/nightly/cu129/"]
 index-strategy = "unsafe-best-match"
 
 [tool.uv.pip]

--- a/src/paddlefleet/__init__.py
+++ b/src/paddlefleet/__init__.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from . import parallel_state as parallel_state, training as training
+from paddlefleet import parallel_state as parallel_state, training as training
+
 from .package_info import (
     __contact_emails__,
     __contact_names__,

--- a/src/paddlefleet/training/__init__.py
+++ b/src/paddlefleet/training/__init__.py
@@ -25,9 +25,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from paddlefleet.training.initialize import initialize_fleet as initialize_fleet
 
 from .global_vars import get_args, get_timers
-from .initialize import initialize_fleet as initialize_fleet
 
 __all__ = [
     "initialize_fleet",

--- a/src/paddlefleet/training/arguments.py
+++ b/src/paddlefleet/training/arguments.py
@@ -15,7 +15,7 @@
 import argparse
 import dataclasses
 
-from ..transformer import TransformerConfig
+from paddlefleet.transformer import TransformerConfig
 
 
 def parse_args(extra_args_provider=None, ignore_unknown_args=False):

--- a/src/paddlefleet/training/global_vars.py
+++ b/src/paddlefleet/training/global_vars.py
@@ -14,7 +14,7 @@
 
 """PaddleFleet global variables."""
 
-from ..timers import Timers
+from paddlefleet.timers import Timers
 
 _GLOBAL_ARGS = None
 _GLOBAL_TIMERS = None

--- a/src/paddlefleet/training/initialize.py
+++ b/src/paddlefleet/training/initialize.py
@@ -15,9 +15,9 @@
 import paddle.distributed as dist
 from paddle.distributed import fleet
 
-from .. import parallel_state as ps
-from .arguments import parse_args
-from .global_vars import set_global_variables
+from paddlefleet import parallel_state as ps
+from paddlefleet.training.arguments import parse_args
+from paddlefleet.training.global_vars import set_global_variables
 
 
 def initialize_fleet(

--- a/src/paddlefleet/transformer/layer.py
+++ b/src/paddlefleet/transformer/layer.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import paddle
 
-from .transformer_config import TransformerConfig
+from paddlefleet.transformer.transformer_config import TransformerConfig
 
 
 class FleetLayer(paddle.nn.Layer):

--- a/src/paddlefleet/utils.py
+++ b/src/paddlefleet/utils.py
@@ -28,7 +28,7 @@ import warnings
 
 import paddle
 
-from . import parallel_state
+from paddlefleet import parallel_state
 
 try:
     from packaging.version import Version as PkgVersion

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 [[package]]
 name = "anyio"
 version = "4.11.0"
-source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu126/" }
+source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }
 dependencies = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "idna" },
@@ -17,7 +17,7 @@ dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 wheels = [
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu126/anyio/anyio-4.11.0-py3-none-any.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/anyio/anyio-4.11.0-py3-none-any.whl" },
 ]
 
 [[package]]
@@ -60,7 +60,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu126/" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -318,12 +318,12 @@ wheels = [
 [[package]]
 name = "exceptiongroup"
 version = "1.3.0"
-source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu126/" }
+source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 wheels = [
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu126/exceptiongroup/exceptiongroup-1.3.0-py3-none-any.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/exceptiongroup/exceptiongroup-1.3.0-py3-none-any.whl" },
 ]
 
 [[package]]
@@ -395,27 +395,27 @@ wheels = [
 [[package]]
 name = "h11"
 version = "0.16.0"
-source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu126/" }
+source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }
 wheels = [
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu126/h11/h11-0.16.0-py3-none-any.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/h11/h11-0.16.0-py3-none-any.whl" },
 ]
 
 [[package]]
 name = "httpcore"
 version = "1.0.9"
-source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu126/" }
+source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }
 dependencies = [
     { name = "certifi" },
     { name = "h11" },
 ]
 wheels = [
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu126/httpcore/httpcore-1.0.9-py3-none-any.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/httpcore/httpcore-1.0.9-py3-none-any.whl" },
 ]
 
 [[package]]
 name = "httpx"
 version = "0.28.1"
-source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu126/" }
+source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }
 dependencies = [
     { name = "anyio" },
     { name = "certifi" },
@@ -423,15 +423,15 @@ dependencies = [
     { name = "idna" },
 ]
 wheels = [
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu126/httpx/httpx-0.28.1-py3-none-any.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/httpx/httpx-0.28.1-py3-none-any.whl" },
 ]
 
 [[package]]
 name = "idna"
 version = "3.11"
-source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu126/" }
+source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }
 wheels = [
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu126/idna/idna-3.11-py3-none-any.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/idna/idna-3.11-py3-none-any.whl" },
 ]
 
 [[package]]
@@ -561,7 +561,7 @@ dependencies = [
     { name = "cycler" },
     { name = "fonttools" },
     { name = "kiwisolver" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu126/" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "packaging" },
     { name = "pillow" },
@@ -629,21 +629,21 @@ wheels = [
 [[package]]
 name = "networkx"
 version = "3.4.2"
-source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu126/" }
+source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }
 wheels = [
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu126/networkx/networkx-3.4.2-py3-none-any.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/networkx/networkx-3.4.2-py3-none-any.whl" },
 ]
 
 [[package]]
 name = "numpy"
 version = "2.2.6"
-source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu126/" }
+source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }
 resolution-markers = [
     "python_full_version < '3.11'",
 ]
 wheels = [
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu126/numpy/numpy-2.2.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl" },
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu126/numpy/numpy-2.2.6-cp310-cp310-win_amd64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/numpy/numpy-2.2.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/numpy/numpy-2.2.6-cp310-cp310-win_amd64.whl" },
 ]
 
 [[package]]
@@ -732,148 +732,99 @@ wheels = [
 
 [[package]]
 name = "nvidia-cublas-cu12"
-version = "12.6.4.1"
-source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu126/" }
+version = "12.9.0.13"
+source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }
 wheels = [
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu126/nvidia-cublas-cu12/nvidia_cublas_cu12-12.6.4.1-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl" },
-]
-
-[[package]]
-name = "nvidia-cuda-cccl-cu12"
-version = "12.6.77"
-source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu126/" }
-wheels = [
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu126/nvidia-cuda-cccl-cu12/nvidia_cuda_cccl_cu12-12.6.77-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl" },
-]
-
-[[package]]
-name = "nvidia-cuda-cupti-cu12"
-version = "12.6.80"
-source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu126/" }
-wheels = [
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu126/nvidia-cuda-cupti-cu12/nvidia_cuda_cupti_cu12-12.6.80-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl" },
-]
-
-[[package]]
-name = "nvidia-cuda-nvrtc-cu12"
-version = "12.6.77"
-source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu126/" }
-wheels = [
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu126/nvidia-cuda-nvrtc-cu12/nvidia_cuda_nvrtc_cu12-12.6.77-py3-none-manylinux2014_x86_64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/nvidia-cublas-cu12/nvidia_cublas_cu12-12.9.0.13-py3-none-manylinux_2_27_x86_64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/nvidia-cublas-cu12/nvidia_cublas_cu12-12.9.0.13-py3-none-win_amd64.whl" },
 ]
 
 [[package]]
 name = "nvidia-cuda-runtime-cu12"
-version = "12.6.77"
-source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu126/" }
+version = "12.9.37"
+source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }
 wheels = [
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu126/nvidia-cuda-runtime-cu12/nvidia_cuda_runtime_cu12-12.6.77-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/nvidia-cuda-runtime-cu12/nvidia_cuda_runtime_cu12-12.9.37-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/nvidia-cuda-runtime-cu12/nvidia_cuda_runtime_cu12-12.9.37-py3-none-win_amd64.whl" },
 ]
 
 [[package]]
 name = "nvidia-cudnn-cu12"
-version = "9.5.1.17"
-source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu126/" }
+version = "9.9.0.52"
+source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }
 dependencies = [
     { name = "nvidia-cublas-cu12" },
 ]
 wheels = [
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu126/nvidia-cudnn-cu12/nvidia_cudnn_cu12-9.5.1.17-py3-none-manylinux_2_28_x86_64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/nvidia-cudnn-cu12/nvidia_cudnn_cu12-9.9.0.52-py3-none-manylinux_2_27_x86_64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/nvidia-cudnn-cu12/nvidia_cudnn_cu12-9.9.0.52-py3-none-win_amd64.whl" },
 ]
 
 [[package]]
 name = "nvidia-cufft-cu12"
-version = "11.3.0.4"
-source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu126/" }
+version = "11.4.0.6"
+source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }
 dependencies = [
     { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu126/nvidia-cufft-cu12/nvidia_cufft_cu12-11.3.0.4-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl" },
-]
-
-[[package]]
-name = "nvidia-cufile-cu12"
-version = "1.11.1.6"
-source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu126/" }
-wheels = [
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu126/nvidia-cufile-cu12/nvidia_cufile_cu12-1.11.1.6-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/nvidia-cufft-cu12/nvidia_cufft_cu12-11.4.0.6-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/nvidia-cufft-cu12/nvidia_cufft_cu12-11.4.0.6-py3-none-win_amd64.whl" },
 ]
 
 [[package]]
 name = "nvidia-curand-cu12"
-version = "10.3.7.77"
-source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu126/" }
+version = "10.3.10.19"
+source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }
 wheels = [
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu126/nvidia-curand-cu12/nvidia_curand_cu12-10.3.7.77-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/nvidia-curand-cu12/nvidia_curand_cu12-10.3.10.19-py3-none-manylinux_2_27_x86_64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/nvidia-curand-cu12/nvidia_curand_cu12-10.3.10.19-py3-none-win_amd64.whl" },
 ]
 
 [[package]]
 name = "nvidia-cusolver-cu12"
-version = "11.7.1.2"
-source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu126/" }
+version = "11.7.4.40"
+source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }
 dependencies = [
     { name = "nvidia-cublas-cu12" },
     { name = "nvidia-cusparse-cu12" },
     { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu126/nvidia-cusolver-cu12/nvidia_cusolver_cu12-11.7.1.2-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/nvidia-cusolver-cu12/nvidia_cusolver_cu12-11.7.4.40-py3-none-manylinux_2_27_x86_64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/nvidia-cusolver-cu12/nvidia_cusolver_cu12-11.7.4.40-py3-none-win_amd64.whl" },
 ]
 
 [[package]]
 name = "nvidia-cusparse-cu12"
-version = "12.5.4.2"
-source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu126/" }
+version = "12.5.9.5"
+source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }
 dependencies = [
     { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu126/nvidia-cusparse-cu12/nvidia_cusparse_cu12-12.5.4.2-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl" },
-]
-
-[[package]]
-name = "nvidia-cusparselt-cu12"
-version = "0.6.3"
-source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu126/" }
-wheels = [
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu126/nvidia-cusparselt-cu12/nvidia_cusparselt_cu12-0.6.3-py3-none-manylinux2014_x86_64.whl" },
-]
-
-[[package]]
-name = "nvidia-nccl-cu12"
-version = "2.25.1"
-source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu126/" }
-wheels = [
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu126/nvidia-nccl-cu12/nvidia_nccl_cu12-2.25.1-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/nvidia-cusparse-cu12/nvidia_cusparse_cu12-12.5.9.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/nvidia-cusparse-cu12/nvidia_cusparse_cu12-12.5.9.5-py3-none-win_amd64.whl" },
 ]
 
 [[package]]
 name = "nvidia-nvjitlink-cu12"
 version = "12.6.85"
-source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu126/" }
+source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }
 wheels = [
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu126/nvidia-nvjitlink-cu12/nvidia_nvjitlink_cu12-12.6.85-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl" },
-]
-
-[[package]]
-name = "nvidia-nvtx-cu12"
-version = "12.6.77"
-source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu126/" }
-wheels = [
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu126/nvidia-nvtx-cu12/nvidia_nvtx_cu12-12.6.77-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/nvidia-nvjitlink-cu12/nvidia_nvjitlink_cu12-12.6.85-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl" },
 ]
 
 [[package]]
 name = "opt-einsum"
 version = "3.3.0"
-source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu126/" }
+source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu126/" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 wheels = [
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu126/opt-einsum/opt_einsum-3.3.0-py3-none-any.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/opt-einsum/opt_einsum-3.3.0-py3-none-any.whl" },
 ]
 
 [[package]]
@@ -934,27 +885,19 @@ test = [
 [[package]]
 name = "paddlepaddle-gpu"
 version = "3.3.0.dev20251116"
-source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu126/" }
+source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }
 dependencies = [
     { name = "httpx" },
     { name = "networkx" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu126/" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-cccl-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-cupti-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-runtime-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cudnn-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cufft-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cufile-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-curand-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusolver-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparselt-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nccl-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvtx-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cuda-runtime-cu12" },
+    { name = "nvidia-cudnn-cu12" },
+    { name = "nvidia-cufft-cu12" },
+    { name = "nvidia-curand-cu12" },
+    { name = "nvidia-cusolver-cu12" },
+    { name = "nvidia-cusparse-cu12" },
     { name = "opt-einsum" },
     { name = "pillow" },
     { name = "protobuf" },
@@ -962,25 +905,21 @@ dependencies = [
     { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu126/paddlepaddle-gpu/paddlepaddle_gpu-3.3.0.dev20251116-cp310-cp310-linux_x86_64.whl" },
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu126/paddlepaddle-gpu/paddlepaddle_gpu-3.3.0.dev20251116-cp310-cp310-win_amd64.whl" },
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu126/paddlepaddle-gpu/paddlepaddle_gpu-3.3.0.dev20251116-cp311-cp311-linux_x86_64.whl" },
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu126/paddlepaddle-gpu/paddlepaddle_gpu-3.3.0.dev20251116-cp311-cp311-win_amd64.whl" },
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu126/paddlepaddle-gpu/paddlepaddle_gpu-3.3.0.dev20251116-cp312-cp312-linux_x86_64.whl" },
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu126/paddlepaddle-gpu/paddlepaddle_gpu-3.3.0.dev20251116-cp312-cp312-win_amd64.whl" },
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu126/paddlepaddle-gpu/paddlepaddle_gpu-3.3.0.dev20251116-cp313-cp313-linux_x86_64.whl" },
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu126/paddlepaddle-gpu/paddlepaddle_gpu-3.3.0.dev20251116-cp313-cp313-win_amd64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/paddlepaddle-gpu/paddlepaddle_gpu-3.3.0.dev20251116-cp310-cp310-win_amd64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/paddlepaddle-gpu/paddlepaddle_gpu-3.3.0.dev20251116-cp311-cp311-win_amd64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/paddlepaddle-gpu/paddlepaddle_gpu-3.3.0.dev20251116-cp312-cp312-win_amd64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/paddlepaddle-gpu/paddlepaddle_gpu-3.3.0.dev20251116-cp313-cp313-win_amd64.whl" },
 ]
 
 [[package]]
 name = "pillow"
 version = "12.0.0"
-source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu126/" }
+source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }
 wheels = [
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu126/pillow/pillow-12.0.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl" },
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu126/pillow/pillow-12.0.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl" },
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu126/pillow/pillow-12.0.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl" },
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu126/pillow/pillow-12.0.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/pillow/pillow-12.0.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/pillow/pillow-12.0.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/pillow/pillow-12.0.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/pillow/pillow-12.0.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl" },
 ]
 
 [[package]]
@@ -1183,9 +1122,9 @@ wheels = [
 [[package]]
 name = "safetensors"
 version = "0.6.2"
-source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu126/" }
+source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }
 wheels = [
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu126/safetensors/safetensors-0.6.2-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/safetensors/safetensors-0.6.2-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl" },
 ]
 
 [[package]]
@@ -1209,9 +1148,9 @@ wheels = [
 [[package]]
 name = "sniffio"
 version = "1.3.1"
-source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu126/" }
+source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }
 wheels = [
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu126/sniffio/sniffio-1.3.1-py3-none-any.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/sniffio/sniffio-1.3.1-py3-none-any.whl" },
 ]
 
 [[package]]
@@ -1266,9 +1205,9 @@ wheels = [
 [[package]]
 name = "typing-extensions"
 version = "4.15.0"
-source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu126/" }
+source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }
 wheels = [
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu126/typing-extensions/typing_extensions-4.15.0-py3-none-any.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/typing-extensions/typing_extensions-4.15.0-py3-none-any.whl" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 [[package]]
 name = "anyio"
 version = "4.11.0"
-source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }
+source = { registry = "https://www.paddlepaddle.org.cn/packages/stable/cu129/" }
 dependencies = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "idna" },
@@ -17,7 +17,7 @@ dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 wheels = [
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/anyio/anyio-4.11.0-py3-none-any.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/stable/cu129/anyio/anyio-4.11.0-py3-none-any.whl" },
 ]
 
 [[package]]
@@ -60,7 +60,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://www.paddlepaddle.org.cn/packages/stable/cu129/" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -318,12 +318,12 @@ wheels = [
 [[package]]
 name = "exceptiongroup"
 version = "1.3.0"
-source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }
+source = { registry = "https://www.paddlepaddle.org.cn/packages/stable/cu129/" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 wheels = [
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/exceptiongroup/exceptiongroup-1.3.0-py3-none-any.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/stable/cu129/exceptiongroup/exceptiongroup-1.3.0-py3-none-any.whl" },
 ]
 
 [[package]]
@@ -395,27 +395,27 @@ wheels = [
 [[package]]
 name = "h11"
 version = "0.16.0"
-source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }
+source = { registry = "https://www.paddlepaddle.org.cn/packages/stable/cu129/" }
 wheels = [
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/h11/h11-0.16.0-py3-none-any.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/stable/cu129/h11/h11-0.16.0-py3-none-any.whl" },
 ]
 
 [[package]]
 name = "httpcore"
 version = "1.0.9"
-source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }
+source = { registry = "https://www.paddlepaddle.org.cn/packages/stable/cu129/" }
 dependencies = [
     { name = "certifi" },
     { name = "h11" },
 ]
 wheels = [
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/httpcore/httpcore-1.0.9-py3-none-any.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/stable/cu129/httpcore/httpcore-1.0.9-py3-none-any.whl" },
 ]
 
 [[package]]
 name = "httpx"
 version = "0.28.1"
-source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }
+source = { registry = "https://www.paddlepaddle.org.cn/packages/stable/cu129/" }
 dependencies = [
     { name = "anyio" },
     { name = "certifi" },
@@ -423,15 +423,15 @@ dependencies = [
     { name = "idna" },
 ]
 wheels = [
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/httpx/httpx-0.28.1-py3-none-any.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/stable/cu129/httpx/httpx-0.28.1-py3-none-any.whl" },
 ]
 
 [[package]]
 name = "idna"
 version = "3.11"
-source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }
+source = { registry = "https://www.paddlepaddle.org.cn/packages/stable/cu129/" }
 wheels = [
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/idna/idna-3.11-py3-none-any.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/stable/cu129/idna/idna-3.11-py3-none-any.whl" },
 ]
 
 [[package]]
@@ -561,7 +561,7 @@ dependencies = [
     { name = "cycler" },
     { name = "fonttools" },
     { name = "kiwisolver" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://www.paddlepaddle.org.cn/packages/stable/cu129/" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "packaging" },
     { name = "pillow" },
@@ -629,21 +629,21 @@ wheels = [
 [[package]]
 name = "networkx"
 version = "3.4.2"
-source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }
+source = { registry = "https://www.paddlepaddle.org.cn/packages/stable/cu129/" }
 wheels = [
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/networkx/networkx-3.4.2-py3-none-any.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/stable/cu129/networkx/networkx-3.4.2-py3-none-any.whl" },
 ]
 
 [[package]]
 name = "numpy"
 version = "2.2.6"
-source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }
+source = { registry = "https://www.paddlepaddle.org.cn/packages/stable/cu129/" }
 resolution-markers = [
     "python_full_version < '3.11'",
 ]
 wheels = [
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/numpy/numpy-2.2.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl" },
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/numpy/numpy-2.2.6-cp310-cp310-win_amd64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/stable/cu129/numpy/numpy-2.2.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/stable/cu129/numpy/numpy-2.2.6-cp310-cp310-win_amd64.whl" },
 ]
 
 [[package]]
@@ -733,98 +733,147 @@ wheels = [
 [[package]]
 name = "nvidia-cublas-cu12"
 version = "12.9.0.13"
-source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }
+source = { registry = "https://www.paddlepaddle.org.cn/packages/stable/cu129/" }
 wheels = [
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/nvidia-cublas-cu12/nvidia_cublas_cu12-12.9.0.13-py3-none-manylinux_2_27_x86_64.whl" },
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/nvidia-cublas-cu12/nvidia_cublas_cu12-12.9.0.13-py3-none-win_amd64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/stable/cu129/nvidia-cublas-cu12/nvidia_cublas_cu12-12.9.0.13-py3-none-manylinux_2_27_x86_64.whl" },
+]
+
+[[package]]
+name = "nvidia-cuda-cccl-cu12"
+version = "12.9.27"
+source = { registry = "https://www.paddlepaddle.org.cn/packages/stable/cu129/" }
+wheels = [
+    { url = "https://paddle-whl.bj.bcebos.com/stable/cu129/nvidia-cuda-cccl-cu12/nvidia_cuda_cccl_cu12-12.9.27-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl" },
+]
+
+[[package]]
+name = "nvidia-cuda-cupti-cu12"
+version = "12.9.19"
+source = { registry = "https://www.paddlepaddle.org.cn/packages/stable/cu129/" }
+wheels = [
+    { url = "https://paddle-whl.bj.bcebos.com/stable/cu129/nvidia-cuda-cupti-cu12/nvidia_cuda_cupti_cu12-12.9.19-py3-none-manylinux_2_25_x86_64.whl" },
+]
+
+[[package]]
+name = "nvidia-cuda-nvrtc-cu12"
+version = "12.9.41"
+source = { registry = "https://www.paddlepaddle.org.cn/packages/stable/cu129/" }
+wheels = [
+    { url = "https://paddle-whl.bj.bcebos.com/stable/cu129/nvidia-cuda-nvrtc-cu12/nvidia_cuda_nvrtc_cu12-12.9.41-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl" },
 ]
 
 [[package]]
 name = "nvidia-cuda-runtime-cu12"
 version = "12.9.37"
-source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }
+source = { registry = "https://www.paddlepaddle.org.cn/packages/stable/cu129/" }
 wheels = [
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/nvidia-cuda-runtime-cu12/nvidia_cuda_runtime_cu12-12.9.37-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl" },
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/nvidia-cuda-runtime-cu12/nvidia_cuda_runtime_cu12-12.9.37-py3-none-win_amd64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/stable/cu129/nvidia-cuda-runtime-cu12/nvidia_cuda_runtime_cu12-12.9.37-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl" },
 ]
 
 [[package]]
 name = "nvidia-cudnn-cu12"
 version = "9.9.0.52"
-source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }
+source = { registry = "https://www.paddlepaddle.org.cn/packages/stable/cu129/" }
 dependencies = [
     { name = "nvidia-cublas-cu12" },
 ]
 wheels = [
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/nvidia-cudnn-cu12/nvidia_cudnn_cu12-9.9.0.52-py3-none-manylinux_2_27_x86_64.whl" },
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/nvidia-cudnn-cu12/nvidia_cudnn_cu12-9.9.0.52-py3-none-win_amd64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/stable/cu129/nvidia-cudnn-cu12/nvidia_cudnn_cu12-9.9.0.52-py3-none-manylinux_2_27_x86_64.whl" },
 ]
 
 [[package]]
 name = "nvidia-cufft-cu12"
 version = "11.4.0.6"
-source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }
+source = { registry = "https://www.paddlepaddle.org.cn/packages/stable/cu129/" }
 dependencies = [
     { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/nvidia-cufft-cu12/nvidia_cufft_cu12-11.4.0.6-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl" },
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/nvidia-cufft-cu12/nvidia_cufft_cu12-11.4.0.6-py3-none-win_amd64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/stable/cu129/nvidia-cufft-cu12/nvidia_cufft_cu12-11.4.0.6-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl" },
+]
+
+[[package]]
+name = "nvidia-cufile-cu12"
+version = "1.14.0.30"
+source = { registry = "https://www.paddlepaddle.org.cn/packages/stable/cu129/" }
+wheels = [
+    { url = "https://paddle-whl.bj.bcebos.com/stable/cu129/nvidia-cufile-cu12/nvidia_cufile_cu12-1.14.0.30-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl" },
 ]
 
 [[package]]
 name = "nvidia-curand-cu12"
 version = "10.3.10.19"
-source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }
+source = { registry = "https://www.paddlepaddle.org.cn/packages/stable/cu129/" }
 wheels = [
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/nvidia-curand-cu12/nvidia_curand_cu12-10.3.10.19-py3-none-manylinux_2_27_x86_64.whl" },
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/nvidia-curand-cu12/nvidia_curand_cu12-10.3.10.19-py3-none-win_amd64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/stable/cu129/nvidia-curand-cu12/nvidia_curand_cu12-10.3.10.19-py3-none-manylinux_2_27_x86_64.whl" },
 ]
 
 [[package]]
 name = "nvidia-cusolver-cu12"
 version = "11.7.4.40"
-source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }
+source = { registry = "https://www.paddlepaddle.org.cn/packages/stable/cu129/" }
 dependencies = [
     { name = "nvidia-cublas-cu12" },
     { name = "nvidia-cusparse-cu12" },
     { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/nvidia-cusolver-cu12/nvidia_cusolver_cu12-11.7.4.40-py3-none-manylinux_2_27_x86_64.whl" },
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/nvidia-cusolver-cu12/nvidia_cusolver_cu12-11.7.4.40-py3-none-win_amd64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/stable/cu129/nvidia-cusolver-cu12/nvidia_cusolver_cu12-11.7.4.40-py3-none-manylinux_2_27_x86_64.whl" },
 ]
 
 [[package]]
 name = "nvidia-cusparse-cu12"
 version = "12.5.9.5"
-source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }
+source = { registry = "https://www.paddlepaddle.org.cn/packages/stable/cu129/" }
 dependencies = [
     { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/nvidia-cusparse-cu12/nvidia_cusparse_cu12-12.5.9.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl" },
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/nvidia-cusparse-cu12/nvidia_cusparse_cu12-12.5.9.5-py3-none-win_amd64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/stable/cu129/nvidia-cusparse-cu12/nvidia_cusparse_cu12-12.5.9.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl" },
+]
+
+[[package]]
+name = "nvidia-cusparselt-cu12"
+version = "0.7.1"
+source = { registry = "https://www.paddlepaddle.org.cn/packages/stable/cu129/" }
+wheels = [
+    { url = "https://paddle-whl.bj.bcebos.com/stable/cu129/nvidia-cusparselt-cu12/nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_x86_64.whl" },
+]
+
+[[package]]
+name = "nvidia-nccl-cu12"
+version = "2.27.3"
+source = { registry = "https://www.paddlepaddle.org.cn/packages/stable/cu129/" }
+wheels = [
+    { url = "https://paddle-whl.bj.bcebos.com/stable/cu129/nvidia-nccl-cu12/nvidia_nccl_cu12-2.27.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl" },
 ]
 
 [[package]]
 name = "nvidia-nvjitlink-cu12"
-version = "12.6.85"
-source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }
+version = "12.9.41"
+source = { registry = "https://www.paddlepaddle.org.cn/packages/stable/cu129/" }
 wheels = [
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/nvidia-nvjitlink-cu12/nvidia_nvjitlink_cu12-12.6.85-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/stable/cu129/nvidia-nvjitlink-cu12/nvidia_nvjitlink_cu12-12.9.41-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl" },
+]
+
+[[package]]
+name = "nvidia-nvtx-cu12"
+version = "12.9.19"
+source = { registry = "https://www.paddlepaddle.org.cn/packages/stable/cu129/" }
+wheels = [
+    { url = "https://paddle-whl.bj.bcebos.com/stable/cu129/nvidia-nvtx-cu12/nvidia_nvtx_cu12-12.9.19-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl" },
 ]
 
 [[package]]
 name = "opt-einsum"
 version = "3.3.0"
-source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }
+source = { registry = "https://www.paddlepaddle.org.cn/packages/stable/cu129/" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://www.paddlepaddle.org.cn/packages/stable/cu129/" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 wheels = [
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/opt-einsum/opt_einsum-3.3.0-py3-none-any.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/stable/cu129/opt-einsum/opt_einsum-3.3.0-py3-none-any.whl" },
 ]
 
 [[package]]
@@ -840,7 +889,7 @@ wheels = [
 name = "paddlefleet"
 source = { editable = "." }
 dependencies = [
-    { name = "paddlepaddle-gpu" },
+    { name = "paddlepaddle-gpu", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 
 [package.dev-dependencies]
@@ -863,7 +912,7 @@ test = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "paddlepaddle-gpu", specifier = ">=3.3.0.dev0" }]
+requires-dist = [{ name = "paddlepaddle-gpu", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'", specifier = "==3.2.2" }]
 
 [package.metadata.requires-dev]
 build = [
@@ -884,20 +933,28 @@ test = [
 
 [[package]]
 name = "paddlepaddle-gpu"
-version = "3.3.0.dev20251116"
-source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }
+version = "3.2.2"
+source = { registry = "https://www.paddlepaddle.org.cn/packages/stable/cu129/" }
 dependencies = [
     { name = "httpx" },
     { name = "networkx" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://www.paddlepaddle.org.cn/packages/stable/cu129/" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cuda-runtime-cu12" },
-    { name = "nvidia-cudnn-cu12" },
-    { name = "nvidia-cufft-cu12" },
-    { name = "nvidia-curand-cu12" },
-    { name = "nvidia-cusolver-cu12" },
-    { name = "nvidia-cusparse-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cccl-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cudnn-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cufft-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cufile-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-curand-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusolver-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusparselt-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvtx-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "opt-einsum" },
     { name = "pillow" },
     { name = "protobuf" },
@@ -905,21 +962,21 @@ dependencies = [
     { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/paddlepaddle-gpu/paddlepaddle_gpu-3.3.0.dev20251116-cp310-cp310-win_amd64.whl" },
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/paddlepaddle-gpu/paddlepaddle_gpu-3.3.0.dev20251116-cp311-cp311-win_amd64.whl" },
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/paddlepaddle-gpu/paddlepaddle_gpu-3.3.0.dev20251116-cp312-cp312-win_amd64.whl" },
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/paddlepaddle-gpu/paddlepaddle_gpu-3.3.0.dev20251116-cp313-cp313-win_amd64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/stable/cu129/paddlepaddle-gpu/paddlepaddle_gpu-3.2.2-cp310-cp310-linux_x86_64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/stable/cu129/paddlepaddle-gpu/paddlepaddle_gpu-3.2.2-cp311-cp311-linux_x86_64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/stable/cu129/paddlepaddle-gpu/paddlepaddle_gpu-3.2.2-cp312-cp312-linux_x86_64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/stable/cu129/paddlepaddle-gpu/paddlepaddle_gpu-3.2.2-cp313-cp313-linux_x86_64.whl" },
 ]
 
 [[package]]
 name = "pillow"
 version = "12.0.0"
-source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }
+source = { registry = "https://www.paddlepaddle.org.cn/packages/stable/cu129/" }
 wheels = [
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/pillow/pillow-12.0.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl" },
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/pillow/pillow-12.0.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl" },
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/pillow/pillow-12.0.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl" },
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/pillow/pillow-12.0.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/stable/cu129/pillow/pillow-12.0.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/stable/cu129/pillow/pillow-12.0.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/stable/cu129/pillow/pillow-12.0.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/stable/cu129/pillow/pillow-12.0.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl" },
 ]
 
 [[package]]
@@ -937,10 +994,6 @@ version = "6.33.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0a/03/a1440979a3f74f16cab3b75b0da1a1a7f922d56a8ddea96092391998edc0/protobuf-6.33.1.tar.gz", hash = "sha256:97f65757e8d09870de6fd973aeddb92f85435607235d20b2dfed93405d00c85b", size = 443432, upload-time = "2025-11-13T16:44:18.895Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/06/f1/446a9bbd2c60772ca36556bac8bfde40eceb28d9cc7838755bc41e001d8f/protobuf-6.33.1-cp310-abi3-win32.whl", hash = "sha256:f8d3fdbc966aaab1d05046d0240dd94d40f2a8c62856d41eaa141ff64a79de6b", size = 425593, upload-time = "2025-11-13T16:44:06.275Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/79/8780a378c650e3df849b73de8b13cf5412f521ca2ff9b78a45c247029440/protobuf-6.33.1-cp310-abi3-win_amd64.whl", hash = "sha256:923aa6d27a92bf44394f6abf7ea0500f38769d4b07f4be41cb52bd8b1123b9ed", size = 436883, upload-time = "2025-11-13T16:44:09.222Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/93/26213ff72b103ae55bb0d73e7fb91ea570ef407c3ab4fd2f1f27cac16044/protobuf-6.33.1-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:fe34575f2bdde76ac429ec7b570235bf0c788883e70aee90068e9981806f2490", size = 427522, upload-time = "2025-11-13T16:44:10.475Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/32/df4a35247923393aa6b887c3b3244a8c941c32a25681775f96e2b418f90e/protobuf-6.33.1-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:f8adba2e44cde2d7618996b3fc02341f03f5bc3f2748be72dc7b063319276178", size = 324445, upload-time = "2025-11-13T16:44:11.869Z" },
     { url = "https://files.pythonhosted.org/packages/8e/d0/d796e419e2ec93d2f3fa44888861c3f88f722cde02b7c3488fcc6a166820/protobuf-6.33.1-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:0f4cf01222c0d959c2b399142deb526de420be8236f22c71356e2a544e153c53", size = 339161, upload-time = "2025-11-13T16:44:12.778Z" },
     { url = "https://files.pythonhosted.org/packages/1d/2a/3c5f05a4af06649547027d288747f68525755de692a26a7720dced3652c0/protobuf-6.33.1-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:8fd7d5e0eb08cd5b87fd3df49bc193f5cfd778701f47e11d127d0afc6c39f1d1", size = 323171, upload-time = "2025-11-13T16:44:14.035Z" },
     { url = "https://files.pythonhosted.org/packages/08/b4/46310463b4f6ceef310f8348786f3cff181cea671578e3d9743ba61a459e/protobuf-6.33.1-py3-none-any.whl", hash = "sha256:d595a9fd694fdeb061a62fbe10eb039cc1e444df81ec9bb70c7fc59ebcb1eafa", size = 170477, upload-time = "2025-11-13T16:44:17.633Z" },
@@ -1122,9 +1175,9 @@ wheels = [
 [[package]]
 name = "safetensors"
 version = "0.6.2"
-source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }
+source = { registry = "https://www.paddlepaddle.org.cn/packages/stable/cu129/" }
 wheels = [
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/safetensors/safetensors-0.6.2-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/stable/cu129/safetensors/safetensors-0.6.2-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl" },
 ]
 
 [[package]]
@@ -1148,9 +1201,9 @@ wheels = [
 [[package]]
 name = "sniffio"
 version = "1.3.1"
-source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }
+source = { registry = "https://www.paddlepaddle.org.cn/packages/stable/cu129/" }
 wheels = [
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/sniffio/sniffio-1.3.1-py3-none-any.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/stable/cu129/sniffio/sniffio-1.3.1-py3-none-any.whl" },
 ]
 
 [[package]]
@@ -1205,9 +1258,9 @@ wheels = [
 [[package]]
 name = "typing-extensions"
 version = "4.15.0"
-source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }
+source = { registry = "https://www.paddlepaddle.org.cn/packages/stable/cu129/" }
 wheels = [
-    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/typing-extensions/typing_extensions-4.15.0-py3-none-any.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/stable/cu129/typing-extensions/typing_extensions-4.15.0-py3-none-any.whl" },
 ]
 
 [[package]]


### PR DESCRIPTION
1 修改import pkg的路径，建议import pkg，不用相对 import这种方式

2 CI single card test使用的v100卡，需要使用cuda12.6的包，因为cuda12.9的包不支持volta

3 CI改成PR级别的paddle whl包