### PR TITLE
Fix attention dim order

### DIFF
--- a/src/paddlefleet/transformer/attention.py
+++ b/src/paddlefleet/transformer/attention.py
@@ -255,7 +255,7 @@ class Attention(FleetLayer, ABC):
         if no_rope:
             rotary_pos_emb = None
 
-        # hidden_states: [sq, b, h]
+        # hidden_states: [b, sq, h]
 
         # For self attention we just duplicate the rotary_pos_emb if it isn't already
         if rotary_pos_emb is not None and not isinstance(rotary_pos_emb, tuple):

--- a/src/paddlefleet/transformer/dot_product_attention.py
+++ b/src/paddlefleet/transformer/dot_product_attention.py
@@ -188,7 +188,7 @@ class DotProductAttention(FleetLayer):
         # Raw attention scores. [b, n/p, s, s]
         # ===================================
 
-        # expand the key and value [sk, b, ng, hn] -> [sk, b, np, hn]
+        # expand the key and value [b, sk, ng, hn] -> [b, sk, np, hn]
         # This is a noop for normal attention where ng == np. When using group query attention this
         # creates a view that has the keys and values virtually repeated along their dimension to
         # match the number of queries.
@@ -212,21 +212,23 @@ class DotProductAttention(FleetLayer):
 
         # [b, np, sq, sk]
         output_size = (
-            query.shape[1],
-            query.shape[2],
             query.shape[0],
-            key.shape[0],
+            query.shape[2],
+            query.shape[1],
+            key.shape[1],
         )
 
-        # [sq, b, np, hn] -> [sq, b * np, hn]
+        # [b, sq, np, hn] -> [b * np, sq, hn]
         # This will be a simple view when doing normal attention, but in group query attention
         # the key and value tensors are repeated to match the queries so you can't use
         # simple strides to extract the queries.
-        query = query.reshape(
-            output_size[2], output_size[0] * output_size[1], -1
+        query = query.transpose([0, 2, 1, 3]).reshape(
+            output_size[0] * output_size[1], output_size[2], -1
         )
-        # [sk, b, np, hn] -> [sk, b * np, hn]
-        key = key.view(output_size[3], output_size[0] * output_size[1], -1)
+        # [b, sk, np, hn] -> [b * np, hn, sk]
+        key = key.transpose([0, 2, 3, 1]).reshape(
+            output_size[0] * output_size[1], -1, output_size[3]
+        )
 
         # preallocting input tensor: [b * np, sq, sk]
         matmul_input_buffer = paddle.empty(
@@ -237,14 +239,14 @@ class DotProductAttention(FleetLayer):
         # Raw attention scores. [b * np, sq, sk]
         matmul_result = paddle.baddbmm(
             matmul_input_buffer,
-            query.transpose(0, 1),  # [b * np, sq, hn]
-            key.transpose(0, 1).transpose(1, 2),  # [b * np, hn, sk]
+            query,
+            key,
             beta=0.0,
             alpha=self.softmax_scale,
         )
 
         # change view to [b, np, sq, sk]
-        attention_scores = matmul_result.view(*output_size)
+        attention_scores = matmul_result.reshape(*output_size)
 
         # ===========================
         # Attention probs and dropout
@@ -264,38 +266,40 @@ class DotProductAttention(FleetLayer):
         # =========================
 
         # value -> context layer.
-        # [sk, b, np, hn] --> [b, np, sq, hn]
+        # [b, sk, np, hn] --> [b, np, sq, hn]
 
         # context layer shape: [b, np, sq, hn]
         output_size = (
-            value.shape[1],
+            value.shape[0],
             value.shape[2],
-            query.shape[0],
+            query.shape[1],
             value.shape[3],
         )
 
-        # change view [sk, b * np, hn]
-        value = value.view(value.shape[0], output_size[0] * output_size[1], -1)
+        # change view [b * np, sk, hn]
+        value = value.transpose([0, 2, 1, 3]).reshape(
+            output_size[0] * output_size[1], value.shape[1], -1
+        )
 
         # change view [b * np, sq, sk]
-        attention_probs = attention_probs.view(
+        attention_probs = attention_probs.reshape(
             output_size[0] * output_size[1], output_size[2], -1
         )
 
         # matmul: [b * np, sq, hn]
-        context = paddle.bmm(attention_probs, value.transpose(0, 1))
+        context = paddle.bmm(attention_probs, value)
 
         # change view [b, np, sq, hn]
-        context = context.view(*output_size)
+        context = context.reshape(*output_size)
 
-        # [b, np, sq, hn] --> [sq, b, np, hn]
-        context = context.permute(2, 0, 1, 3).contiguous()
+        # [b, np, sq, hn] --> [b, sq, np, hn]
+        context = context.transpose([0, 2, 1, 3]).contiguous()
 
-        # [sq, b, np, hn] --> [sq, b, hp]
+        # [b, sq, np, hn] --> [b, sq, hp]
         new_context_shape = (
             *context.shape[:-2],
             self.hidden_size_per_partition,
         )
-        context = context.view(*new_context_shape)
+        context = context.reshape(*new_context_shape)
 
         return context

--- a/tests/single_card_tests/transformer/test_attention.py
+++ b/tests/single_card_tests/transformer/test_attention.py
@@ -21,6 +21,7 @@ from paddlefleet.transformer.attention import (
     SelfAttentionSublayersSpec,
 )
 from paddlefleet.transformer.dot_product_attention import DotProductAttention
+from paddlefleet.transformer.enums import AttnMaskType
 from paddlefleet.transformer.transformer_config import TransformerConfig
 from paddlefleet.utils import (
     init_method_normal,
@@ -67,7 +68,7 @@ class TestSelfAttention(unittest.TestCase):
         self.config.recompute_granularity = None
         self.config.fused_single_qkv_rope = False
         self.config.rotary_interleaved = False
-        self.config.multi_latent_attention = True
+        self.config.multi_latent_attention = False
         self.config.init_method = init_method_normal(0.02)
         self.config.output_layer_init_method = scaled_init_method_normal(
             0.02, 1, 2.0
@@ -93,6 +94,7 @@ class TestSelfAttention(unittest.TestCase):
                 q_layernorm=RMSNorm,
                 k_layernorm=RMSNorm,
             ),
+            attn_mask_type=AttnMaskType.causal,
             layer_number=1,
         )
 
@@ -103,10 +105,10 @@ class TestSelfAttention(unittest.TestCase):
         hidden_size = self.self_attention.config.hidden_size
 
         hidden_states = paddle.randn(
-            (sequence_length, micro_batch_size, hidden_size),
+            (micro_batch_size, sequence_length, hidden_size),
         )
         rotary_pos_emb = paddle.randn(
-            (sequence_length, 1, 1, self.config.kv_channels)
+            (1, sequence_length, 1, self.config.kv_channels)
         )
 
         output, bias = self.self_attention(
@@ -114,8 +116,8 @@ class TestSelfAttention(unittest.TestCase):
         )
 
         # Check if output and bias have the correct shape
-        assert output.shape[0] == sequence_length
-        assert output.shape[1] == micro_batch_size
+        assert output.shape[0] == micro_batch_size
+        assert output.shape[1] == sequence_length
         assert output.shape[2] == config.hidden_size
         assert bias.shape[0] == config.hidden_size
 


### PR DESCRIPTION
### 对齐Attention维度顺序

在 Attention 中统一使用 [batch_size, seq_len, num_heads, head_dim] 的维度顺序

注释和单测也一并进行了修改

#### 精度对齐
使用 test_attention.py 单测与 Megatron 进行了精度对拍，使用 numpy.save/load 让两边的权重和输入完全相同
<b>输出误差：平均 1.02e-6，最大 2.13e-5</b>，误差来自 baddbmm 和 bmm

Megatron保存权重和输入：
```python

class TestSelfAttention:

    def run_self_attention(self, pg_collection):
        tensor_model_parallel_size = torch.distributed.get_world_size(pg_collection.tp)
        self.transformer_config = TransformerConfig(
            num_layers=2,
            hidden_size=128,
            num_attention_heads=4,
            tensor_model_parallel_size=tensor_model_parallel_size,
            use_cpu_initialization=False,
            attention_dropout=0.0,
        )
        submodules = get_gpt_layer_with_transformer_engine_spec().submodules.self_attention.submodules
        submodules.linear_qkv = TEColumnParallelLinear
        submodules.core_attention = DotProductAttention
        self.self_attention = SelfAttention(
            self.transformer_config,
            submodules,
            layer_number=1,
            attn_mask_type=AttnMaskType.causal,
            pg_collection=pg_collection,
        )

        config = self.self_attention.config
        sequence_length = 127
        micro_batch_size = 2

        self.self_attention.cuda()

        np.save('linear_qkv.weight.npy', self.self_attention.linear_qkv.weight.detach().cpu())
        np.save('linear_proj.weight.npy', self.self_attention.linear_proj.weight.detach().cpu())

        # [sequence length, batch size, hidden size]
        hidden_states = torch.randn(
            (sequence_length, micro_batch_size, self.self_attention.config.hidden_size),
            device='cuda',
        )
        rotary_pos_emb = (
            torch.arange(sequence_length * self.transformer_config.kv_channels)
            .cuda().float().sin()
            .reshape((sequence_length, 1, 1, self.transformer_config.kv_channels))
        )

        np.save('hidden_states.npy', hidden_states.cpu())
        hidden_states_ref = copy.deepcopy(hidden_states)

        output, bias = self.self_attention(hidden_states, None, rotary_pos_emb=rotary_pos_emb)
        np.save('attn_output.npy', output.detach().cpu())
        np.save('attn_bias.npy', bias.detach().cpu())
```

