### PR TITLE
Ignore files generated from `uv sync` for custom ops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ runs/
 **/dist/
 .idea
 log
+
+# Ignore files generated from `uv sync` for custom ops
+src/paddlefleet/extensions/ops_pd_.so
+src/paddlefleet/extensions/ops.py


### PR DESCRIPTION
在 https://github.com/PaddlePaddle/PaddleFleet/pull/48 合入之后，如果使用 `uv sync` 本地开发的时候需要 ignore 生成的一些文件

![image](https://github.com/user-attachments/assets/ab3a00a0-e8f7-48c9-98e4-3bc491280a02)

```
src/paddlefleet/extensions/ops_pd_.so
src/paddlefleet/extensions/ops.py
```
cc @SigureMo 