### PR TITLE
Fix rope dim order

### DIFF
--- a/src/paddlefleet/models/common/embeddings/rotary_pos_embedding.py
+++ b/src/paddlefleet/models/common/embeddings/rotary_pos_embedding.py
@@ -97,6 +97,8 @@ class RotaryEmbedding(nn.Layer):
             )
         )
 
+        self._cast_to_low_precision = False
+
     def _apply_scaling(
         self,
         freqs,
@@ -186,8 +188,8 @@ class RotaryEmbedding(nn.Layer):
             emb = paddle.stack(
                 (freqs.reshape((-1, 1)), freqs.reshape((-1, 1))), axis=-1
             ).reshape((freqs.shape[0], -1))
-        # emb [seq_length, .., dim]
-        emb = emb[:, None, None, :]
+        # emb [1, seq_len, 1, dim]
+        emb = emb[None, :, None, :]
         return emb
 
     def get_rotary_seq_len(
@@ -218,9 +220,9 @@ class RotaryEmbedding(nn.Layer):
             )
         else:
             if transformer is not None and transformer.input_tensor is not None:
-                rotary_seq_len = transformer.input_tensor.shape[0]
+                rotary_seq_len = transformer.input_tensor.shape[1]
             else:
-                rotary_seq_len = transformer_input.shape[0]
+                rotary_seq_len = transformer_input.shape[1]
 
             if transformer_config.sequence_parallel:
                 rotary_seq_len *= transformer_config.tensor_model_parallel_size

--- a/src/paddlefleet/models/common/embeddings/yarn_rotary_pos_embedding.py
+++ b/src/paddlefleet/models/common/embeddings/yarn_rotary_pos_embedding.py
@@ -151,8 +151,8 @@ class YarnRotaryEmbedding(RotaryEmbedding):
         )
 
         emb = paddle.cat((freqs, freqs), axis=-1)
-        # emb [seq_length, .., dim]
-        emb = emb[:, None, None, :]
+        # emb [1, seq_len, 1, dim]
+        emb = emb[None, :, None, :]
         return emb, _mscale
 
     def _set_cos_sin_cache(self, seq_len, offset, dtype, packed_seq=False):

--- a/tests/single_card_tests/transformer/test_rope.py
+++ b/tests/single_card_tests/transformer/test_rope.py
@@ -30,8 +30,8 @@ class TestRotaryEmbedding(unittest.TestCase):
 
     def test_forward(self):
         output = self.rope(64)
-        assert output.shape[0] == 64
-        assert output.shape[1] == 1
+        assert output.shape[0] == 1
+        assert output.shape[1] == 64
         assert output.shape[2] == 1
         assert output.shape[3] == self.kv_channels
         assert output.dtype == paddle.float32
@@ -46,8 +46,8 @@ class TestYarnRotaryEmbedding(unittest.TestCase):
 
     def test_forward(self):
         output, mscale = self.rope(64)
-        assert output.shape[0] == 64
-        assert output.shape[1] == 1
+        assert output.shape[0] == 1
+        assert output.shape[1] == 64
         assert output.shape[2] == 1
         assert output.shape[3] == self.kv_channels
         assert output.dtype == paddle.float32


### PR DESCRIPTION
### 将RoPE的维度顺序修改为bshd

按照 Paddle 的规范，将 RoPE forward 输出的维度顺序修改为 [batch_size, seq_len, num_heads, head_dim]

修复了之前 GLM4.5 中 RoPE 不生效的问题，原因是之前把 batch_size 当成 seq_len 了，batch_id=0 的数据被当成 seq_id=0，由于 seq_id=0 对应的 embedding 恰好均为0，所以整个 batch 都不生效

将 RotaryEmbedding 模块设置为 cast_to_low_precision=False，避免 inv_freq 被 amp 为低精度，该变量必须为 float32，否则长句子下靠后的 token 的位置编码将无法区分

#### 精度对拍
模拟了 rope+apply 的场景，与 Megatron 进行对比，可以做到逐位对齐：
```python
class config:
    rotary_interleaved = False
    multi_latent_attention = False
    apply_rope_fusion = False

bs, seq_len, num_heads, kv_channels = 2, 100, 4, 128
rotary_percent = 0.5

####################  Paddle  ####################
import paddle
from paddlefleet.models.common.embeddings import apply_rotary_pos_emb, RotaryEmbedding

rope = RotaryEmbedding(kv_channels, rotary_percent)
emb = rope(seq_len)
t = paddle.randn([bs, seq_len, num_heads, kv_channels])
paddle_out = apply_rotary_pos_emb(t, emb, config, cu_seqlens=None, mscale=1.0)

####################  Torch  ####################
import torch
from megatron.core.models.common.embeddings import apply_rotary_pos_emb, RotaryEmbedding

rope = RotaryEmbedding(kv_channels, rotary_percent)
emb = rope(seq_len)
t = torch.tensor(t.numpy(), device='cuda').transpose(0, 1)
torch_out = apply_rotary_pos_emb(t, emb, config, cu_seqlens=None, mscale=1.0, cp_group=-1)

import numpy as np
np.testing.assert_array_equal(paddle_out, torch_out.transpose(0, 1).cpu())
```