### PR TITLE
Fix bias grad reduction of bias_geglu_back

### DIFF
--- a/src/paddlefleet/fusions/fused_bias_geglu.py
+++ b/src/paddlefleet/fusions/fused_bias_geglu.py
@@ -132,7 +132,7 @@ class BiasGeGLUFunction(paddle.autograd.PyLayer):
         """
         input, bias = ctx.saved_tensor()
         tmp = bias_geglu_back(grad_output, input, bias)
-        return tmp, tmp
+        return tmp, tmp.reduce_as(bias)
 
 
 class GeGLUFunction(paddle.autograd.PyLayer):

--- a/tests/single_card_tests/transformer/test_mlp.py
+++ b/tests/single_card_tests/transformer/test_mlp.py
@@ -15,98 +15,65 @@
 
 from __future__ import annotations
 
+import unittest
+
 import paddle
 
-# (TODO): need add tp case
-# from paddlefleet.models.gpt.gpt_layer_specs import get_gpt_layer_local_spec
-# from paddlefleet.tensor_parallel.random import model_parallel_cuda_manual_seed
-# from tests.unit_tests.test_utilities import Utils
-from paddlefleet.spec_utils import LayerSpec
-from paddlefleet.transformer.mlp import MLP, MLPSublayersSpec
+from paddlefleet.models.gpt.gpt_layer_specs import get_gpt_layer_local_spec
+from paddlefleet.transformer.mlp import MLP
 from paddlefleet.transformer.transformer_config import TransformerConfig
 
 
-class Linear(paddle.nn.Linear):
-    def __init__(
-        self,
-        input_size: int,
-        output_size: int,
-        *,
-        config: None,
-        init_method: None,
-        bias: bool = True,
-        gather_output: bool = False,
-        input_is_parallel: bool = False,
-        stride: int = 1,
-        keep_master_weight_for_test: bool = False,
-        skip_bias_add: bool = False,
-        skip_weight_param_allocation: bool = False,
-        embedding_activation_buffer=None,
-        grad_output_buffer=None,
-        is_expert: bool = False,
-        disable_grad_reduce: bool = False,
-        tp_group: None,
-    ):
-        super().__init__(
-            in_features=input_size, out_features=output_size, bias_attr=bias
+class TestParallelMLP(unittest.TestCase):
+    transformer_config = TransformerConfig(
+        num_hidden_layers=2,
+        hidden_size=12,
+        intermediate_size=48,
+        num_attention_heads=4,
+    )
+    expected_num_weights = 1212
+
+    def setUp(self):
+        self.mlp = MLP(
+            self.transformer_config,
+            get_gpt_layer_local_spec().sublayers_spec.mlp.sublayers_spec,
         )
-
-    def forward(self, x):
-        """Forward."""
-        out = super().forward(x)
-        return out, None
-
-
-class TestParallelMLP:
-    def setup_method(self, method):
-        # Utils.initialize_model_parallel(1, 1)
-        # model_parallel_cuda_manual_seed(123)
-        transformer_config = TransformerConfig(
-            num_hidden_layers=2,
-            hidden_size=12,
-            intermediate_size=48,
-            num_attention_heads=4,
-        )
-        # (TODO): need replace with gpt_model.mlp later,now temp use a simple mlp
-        # mlp_spec =  get_gpt_layer_local_spec().submodules.mlp.submodules
-        mlp_spec = LayerSpec(
-            MLP,
-            sublayers_spec=MLPSublayersSpec(
-                up_gate_proj=Linear, down_proj=Linear
-            ),
-        )
-        self.mlp = MLP(transformer_config, mlp_spec.sublayers_spec)
-
-    def teardown_method(self, method):
-        # Utils.destroy_model_parallel()
-        pass
 
     def test_constructor(self):
         assert isinstance(self.mlp, MLP)
 
         num_weights = sum([p.numel() for p in self.mlp.parameters()])
-        assert num_weights == 1212
+        assert num_weights == self.expected_num_weights
 
-    """
-    def test_cpu_forward(self, mlp):
-        # [sequence length, micro batch size, hidden size]
-        hidden_states = paddle.ones((32, 2, mlp.config.hidden_size))
-        output, output_bias = mlp(hidden_states)
-        assert output.shape[0] == 32
-        assert output.shape[1] == 2
-        assert output.shape[2] == mlp.config.hidden_size
-        assert output_bias.shape[0] == mlp.config.hidden_size
-        assert output.dtype == paddle.float32
-    """
-
-    def test_gpu_forward(self):
+    def test_forward_backward(self):
         mlp = self.mlp
         # [sequence length, batch size, hidden size]
         hidden_states = paddle.ones((32, 12, mlp.config.hidden_size))
-        hidden_states = hidden_states.cuda()
-        output, output_bias = mlp(hidden_states)
-        print(output.shape)
+        hidden_states.stop_gradient = False
+
+        # add 0.0 to make hidden_states non-leaf
+        output, output_bias = mlp(hidden_states + 0.0)
         assert output.shape[0] == 32
         assert output.shape[1] == 12
         assert output.shape[2] == mlp.config.hidden_size
         assert output.dtype == paddle.float32
+        assert output_bias.shape[0] == mlp.config.hidden_size
+
+        paddle.autograd.backward((output, output_bias))
+        assert hidden_states.grad is not None
+
+
+class TestBiasFusedGatedMLP(TestParallelMLP):
+    transformer_config = TransformerConfig(
+        num_hidden_layers=2,
+        hidden_size=12,
+        intermediate_size=48,
+        num_attention_heads=4,
+        bias_activation_fusion=True,
+        gated_linear_unit=True,
+    )
+    expected_num_weights = 1836
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### 修复 BiasGeGLUFunction 反向梯度 reduce 问题

torch 的 autograd.Function 自带梯度 reduce_as 功能，输出 shape 不匹配时会自动 reduce_as，我们不支持，需要手动写上

现在可以开启 `use_bias=True` 跑 GLM 模型

规范化和启用了 test_mlp.py 单测（之前只是搬了个壳子，没开unittest），满足覆盖率要求

#### 精度对比

```python
import paddle, torch, numpy as np
x = np.random.normal(size=[2, 1000, 64])
bias = np.random.normal(size=[64])

from paddlefleet.fusions.fused_bias_geglu import BiasGeGLUFunction
pd_x = paddle.tensor(x, 'bfloat16', requires_grad=True)
pd_bias = paddle.tensor(bias, 'bfloat16', requires_grad=True)
pd_out = BiasGeGLUFunction.apply(pd_x, pd_bias)
pd_out.backward()

from megatron.core.fusions.fused_bias_geglu import BiasGeGLUFunction
tc_x = torch.tensor(x, dtype=torch.bfloat16, device='cuda', requires_grad=True)
tc_bias = torch.tensor(bias, dtype=torch.bfloat16, device='cuda', requires_grad=True)
tc_out = BiasGeGLUFunction.apply(tc_x, tc_bias)
tc_out.sum().backward()

abs_mean = lambda p, t: np.abs(p.float().numpy() - t.detach().float().cpu().numpy()).mean()
print('diff out      :', abs_mean(pd_out, tc_out))
print('diff x_grad   :', abs_mean(pd_x.grad, tc_x.grad))
print('diff bias_grad:', abs_mean(pd_bias.grad, tc_bias.grad))
```
float32 结果：
```python
diff out      : 4.5992965e-10
diff x_grad   : 5.227006e-09
diff bias_grad: 6.067753e-05
```
bfloat16 结果：
```python
diff out      : 0.002137818
diff x_grad   : 0.0019343053
diff bias_grad: 0.23925781
```
<b>注：</b>bfloat16 的 bias_grad 误差很大是因为在我手动构造的例子里 bias 的梯度很大，导致绝对误差很大，实际上在一个合理的模型中 bias 不会有那么大的梯度：
```python
pd_bias.grad: [-2256.0, 49.25, -868.0, 362.0, -350.0, -5.0625, -2096.0, 1472.0, -1864.0, 2000.0, -1232.0, 780.0, -1040.0, -10.4375, -556.0, 2224.0, 197.0, -152.0, 628.0, -572.0, 2384.0, 141.0, -544.0, -752.0, -69.5, -2336.0, -336.0, -57.75, 2432.0, -1752.0, -14.6875, -470.0, 2128.0, 2272.0, 1616.0, 39.5, 636.0, -109.0, 1376.0, 164.0, 2000.0, 2048.0, 3632.0, 2480.0, 1688.0, -73.5, 234.0, 992.0, 2480.0, -47.0, 2064.0, 29.125, 3376.0, 1224.0, 165.0, 137.0, 370.0, 808.0, -37.5, 268.0, 1392.0, 480.0, -106.0, 69.0]
tc_bias.grad: [-2256.0, 50.25, -868.0, 362.0, -350.0, -5.1875, -2096.0, 1472.0, -1864.0, 2000.0, -1232.0, 780.0, -1040.0, -10.5,    -556.0, 2224.0, 198.0, -152.0, 628.0, -572.0, 2384.0, 142.0, -544.0, -752.0, -69.5, -2336.0, -334.0, -57.75, 2432.0, -1752.0, -14.1875, -470.0, 2128.0, 2272.0, 1616.0, 39.5, 636.0, -109.0, 1376.0, 165.0, 2000.0, 2048.0, 3632.0, 2480.0, 1688.0, -74.0, 234.0, 992.0, 2480.0, -47.0, 2064.0, 29.25,  3376.0, 1224.0, 165.0, 137.0, 370.0, 808.0, -37.5, 268.0, 1384.0, 480.0, -106.0, 69.0]
```