### PR TITLE
Fix bugs in vocab_parallel_cross_entropy and VocabParallelEmbedding

### DIFF
--- a/src/paddlefleet/models/common/embeddings/language_model_embedding.py
+++ b/src/paddlefleet/models/common/embeddings/language_model_embedding.py
@@ -78,7 +78,7 @@ class LanguageModelEmbedding(FleetLayer):
         )
 
         # Word embeddings (parallel).
-        self.word_embeddings = tensor_parallel.VocabParallelEmbedding(
+        self.embed_tokens = tensor_parallel.VocabParallelEmbedding(
             num_embeddings=self.vocab_size,
             embedding_dim=self.config.hidden_size,
             init_method=self.config.embedding_init_method,
@@ -147,12 +147,12 @@ class LanguageModelEmbedding(FleetLayer):
         Returns:
             Tensor: The output embeddings
         """
-        embed_tokens = self.embed_tokens(input_ids)
+        word_embeddings = self.embed_tokens(input_ids)
         if self.add_position_embedding:
             position_embeddings = self.position_embeddings(position_ids)
-            embeddings = embed_tokens + position_embeddings
+            embeddings = word_embeddings + position_embeddings
         else:
-            embeddings = embed_tokens
+            embeddings = word_embeddings
 
         # if not self.reduce_scatter_embeddings:
         #     # Data format change to avoid explicit transposes : [b s h] --> [s b h].

--- a/src/paddlefleet/models/common/embeddings/language_model_embedding.py
+++ b/src/paddlefleet/models/common/embeddings/language_model_embedding.py
@@ -23,10 +23,10 @@ if TYPE_CHECKING:
 
 import paddle
 from paddle import Tensor
-from paddle.nn import Embedding
 
 from paddlefleet import tensor_parallel
 from paddlefleet.transformer.layer import FleetLayer
+from paddlefleet.utils import get_tensor_model_parallel_group_if_none
 
 
 class LanguageModelEmbedding(FleetLayer):
@@ -66,7 +66,7 @@ class LanguageModelEmbedding(FleetLayer):
         )
         self.num_tokentypes = num_tokentypes
         self.scatter_to_sequence_parallel = scatter_to_sequence_parallel
-        self.tp_group = tp_group
+        self.tp_group = get_tensor_model_parallel_group_if_none(tp_group)
         self.reduce_scatter_embeddings = (
             (not self.add_position_embedding)
             and self.num_tokentypes <= 0
@@ -77,21 +77,19 @@ class LanguageModelEmbedding(FleetLayer):
             "Currently reduce_scatter_embeddings is not supported."
         )
 
-        """ TODO: Support TP embedding
         # Word embeddings (parallel).
-        self.embed_tokens = VocabParallelEmbedding(
+        self.word_embeddings = tensor_parallel.VocabParallelEmbedding(
             num_embeddings=self.vocab_size,
             embedding_dim=self.config.hidden_size,
-            # init_method=self.config.embedding_init_method,
-            # reduce_scatter_embeddings=self.reduce_scatter_embeddings,
-            # deterministic_mode=self.config.deterministic_mode,
-            mp_group=self.tp_group,
+            init_method=self.config.embedding_init_method,
+            reduce_scatter_embeddings=self.reduce_scatter_embeddings,
+            config=self.config,
+            tp_group=self.tp_group,
         )
-        """
-        self.embed_tokens = Embedding(
-            num_embeddings=self.vocab_size,
-            embedding_dim=self.config.hidden_size,
-        )
+        # self.word_embeddings = Embedding(
+        #     num_embeddings=self.vocab_size,
+        #     embedding_dim=self.config.hidden_size,
+        # )
 
         # Position embedding (serial).
         if self.add_position_embedding:
@@ -156,16 +154,22 @@ class LanguageModelEmbedding(FleetLayer):
         else:
             embeddings = embed_tokens
 
+        # if not self.reduce_scatter_embeddings:
+        #     # Data format change to avoid explicit transposes : [b s h] --> [s b h].
+        #     embeddings = embeddings.transpose(0, 1).contiguous()
+
         if tokentype_ids is not None:
             assert self.tokentype_embeddings is not None
+            # [b s h] -> [s b h] (So that it can be added with embeddings)
+            # tokentype_embedding = self.tokentype_embeddings(tokentype_ids).permute(1, 0, 2)
             tokentype_embedding = self.tokentype_embeddings(tokentype_ids)
             embeddings = embeddings + tokentype_embedding
         else:
             assert self.tokentype_embeddings is None
 
         # If the input flag for fp32 residual connection is set, convert for float.
-        # if self.config.fp32_residual_connection:
-        #    embeddings = embeddings.float()
+        if self.config.fp32_residual_connection:
+            embeddings = embeddings.float()
 
         # Dropout.
         if self.config.sequence_parallel:

--- a/src/paddlefleet/models/common/language_layer/language_layer.py
+++ b/src/paddlefleet/models/common/language_layer/language_layer.py
@@ -17,9 +17,9 @@ import logging
 import paddle
 from paddle import Tensor
 
-from paddlefleet.parallel_state import get_tensor_model_parallel_world_size
-
 # from paddlefleet.dist_checkpointing.mapping import ShardedStateDict
+from paddlefleet import tensor_parallel
+from paddlefleet.parallel_state import get_tensor_model_parallel_world_size
 from paddlefleet.pipeline_parallel.utils import (
     is_pp_first_stage,
     is_pp_last_stage,
@@ -124,16 +124,10 @@ class LanguageLayer(FleetLayer):
         Returns:
             Tensor: Loss tensor of dimensions [batch size, sequence_length]
         """
-        # TODO(pkuzyc): check the difference between vocab_parallel_cross_entropy
-        # and paddle.nn.CrossEntropy, and use vocab_parallel_cross_entropy as loss func.
-
-        # logits: [s,b,h] labels: [b,s] -> logits: [s,b,h] labels: [s,b]
-        if labels.shape[-1] == logits.shape[0]:
-            labels = labels.transpose(0, 1).contiguous()
-        loss = self.loss_func(logits.cast("float32"), labels)
-        # loss = tensor_parallel.vocab_parallel_cross_entropy(
-        #     logits.cast("float32"), labels
-        # )
+        # loss = self.loss_func(logits.cast("float32"), labels)
+        loss = tensor_parallel.vocab_parallel_cross_entropy(
+            logits.cast("float32"), labels
+        )
 
         lossmask = labels != self.ignored_index
         if (~lossmask).all():  # empty span

--- a/src/paddlefleet/models/multimodal/llava_model.py
+++ b/src/paddlefleet/models/multimodal/llava_model.py
@@ -955,6 +955,7 @@ class LLaVAModel(FleetLayer):
                 packed_seq_params,
             )
 
+        new_labels = new_labels.transpose([1, 0]).contiguous()
         # TODO(zhangweilong): need support mamba model.now only support gpt model
         output = self.language_model(
             input_ids=None,

--- a/src/paddlefleet/parallel_state.py
+++ b/src/paddlefleet/parallel_state.py
@@ -147,7 +147,7 @@ def get_tensor_model_parallel_world_size():
     global _MPU_TENSOR_MODEL_PARALLEL_WORLD_SIZE
     if _MPU_TENSOR_MODEL_PARALLEL_WORLD_SIZE is not None:
         return _MPU_TENSOR_MODEL_PARALLEL_WORLD_SIZE
-    return get_tensor_model_parallel_group().world_size
+    return get_tensor_model_parallel_group().nranks
 
 
 def get_tensor_model_parallel_rank():
@@ -155,6 +155,8 @@ def get_tensor_model_parallel_rank():
     global _MPU_TENSOR_MODEL_PARALLEL_RANK
     if _MPU_TENSOR_MODEL_PARALLEL_RANK is not None:
         return _MPU_TENSOR_MODEL_PARALLEL_RANK
+    if get_tensor_model_parallel_world_size() == 1:
+        return 0
     return get_tensor_model_parallel_group().rank
 
 

--- a/src/paddlefleet/tensor_parallel/cross_entropy.py
+++ b/src/paddlefleet/tensor_parallel/cross_entropy.py
@@ -41,7 +41,7 @@ class VocabParallelCrossEntropy:
 
         vocab_parallel_logits = vocab_parallel_logits.float()
         # Maximum value along vocab dimension across all GPUs.
-        logits_max = paddle.max(vocab_parallel_logits, axis=-1)[0]
+        logits_max = paddle.max(vocab_parallel_logits, axis=-1)
 
         return vocab_parallel_logits, logits_max
 

--- a/src/paddlefleet/tensor_parallel/layers.py
+++ b/src/paddlefleet/tensor_parallel/layers.py
@@ -271,7 +271,6 @@ class VocabParallelEmbedding(paddle.nn.Layer):
             self.weight = Parameter(
                 paddle.empty(
                     [self.num_embeddings_per_partition, self.embedding_dim],
-                    device=paddle.cuda.current_device(),
                     dtype=config.params_dtype,
                 )
             )
@@ -286,7 +285,7 @@ class VocabParallelEmbedding(paddle.nn.Layer):
         Args:
             input_ (paddle.Tensor): Input tensor.
         """
-        if self.tp_group.world_size > 1:
+        if get_pg_size(self.tp_group) > 1:
             # Build the mask.
             input_mask = (input_ < self.vocab_start_index) | (
                 input_ >= self.vocab_end_index
@@ -303,7 +302,7 @@ class VocabParallelEmbedding(paddle.nn.Layer):
             # F.embedding currently has a non-deterministic backward function
             output_parallel = F.embedding(masked_input, self.weight)
         # Mask the output embedding.
-        if self.tp_group.world_size > 1:
+        if get_pg_size(self.tp_group) > 1:
             output_parallel[input_mask, :] = 0.0
 
         if self.reduce_scatter_embeddings:

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -166,6 +166,9 @@ class TransformerConfig(ModelParallelConfig):
     """Whether cross entropy loss is calculated over the actual number of non-padded tokens in the
     global batch, versus the default behavior of assuming all tokens are non-padded."""
 
+    fp32_residual_connection: bool = False
+    """If true, move residual connections to fp32."""
+
     ####################
     # mixed-precision
     ####################
@@ -299,6 +302,18 @@ class TransformerConfig(ModelParallelConfig):
     """Standard deviation of the zero mean normal for the default initialization method, not used if
     init_method and output_layer_init_method are provided."""
 
+    embedding_init_method: callable = None
+    """
+    Method to initialize weights of the embedding layer. If None, will be set as described
+    in init_method above.
+    """
+
+    embedding_init_method_std: float = None
+    """
+    Standard deviation of the zero mean normal for the default initialization method for the
+    embedding layer. If None, will be set to init_method_std.
+    """
+
     init_model_with_meta_device: bool = False
     """
     If True, initializes the model with the meta device. This is helpful for
@@ -333,6 +348,27 @@ class TransformerConfig(ModelParallelConfig):
 
         if self.apply_query_key_layer_scaling:
             self.attention_softmax_in_fp32 = True
+
+        # Set the embedding init method
+        if self.embedding_init_method_std is None:
+            # By default, use the same init std as you use for every other non-output layer.
+            self.embedding_init_method_std = self.init_method_std
+
+        if self.embedding_init_method is None:
+            if self.init_method is None or (
+                self.embedding_init_method_std != self.init_method_std
+            ):
+                # In this case, we set both the init method and the embedding init method to
+                #  whatever std value requested (or defaulted) for the embedding_init_layer
+                self.embedding_init_method = init_method_normal(
+                    self.embedding_init_method_std
+                )
+            else:
+                # Replicate the current behavior where if you are not changing the std of the
+                #  embedding init differently and the init method is set, we fallback to the
+                #  init method for this layer. Since we are here after an OR we know that
+                #  init_method is not None
+                self.embedding_init_method = self.init_method
 
         if self.init_method is None:
             self.init_method = init_method_normal(self.init_method_std)

--- a/tests/single_card_tests/model/test_gpt_model_moe.py
+++ b/tests/single_card_tests/model/test_gpt_model_moe.py
@@ -200,8 +200,8 @@ class TestGPTModel(unittest.TestCase):
                 f"grad norm of word_embeddingsnot not equal ({word_embeddings_grad_norm} != 6.112863540649414), please check your modify"
             )
         elif judge_machine_type() == "V":
-            assert word_embeddings_grad_norm == 9.869551658630371, (
-                f"grad norm of word_embeddingsnot not equal ({word_embeddings_grad_norm} != 9.869551658630371, please check your modify"
+            assert word_embeddings_grad_norm == 9.869550704956055, (
+                f"grad norm of word_embeddingsnot not equal ({word_embeddings_grad_norm} != 9.869550704956055, please check your modify"
             )
 
 


### PR DESCRIPTION
Fix bugs in vocab_parallel_cross_entropy and VocabParallelEmbedding. Replace the loss function in language layer with vocab_parallel_cross_entropy, and replace the embedding function with tensor_parallel.VocabParallelEmbedding