### PR TITLE
turn off deepep on ampere and fix logging

### DIFF
--- a/src/paddlefleet/models/common/embeddings/rope_utils.py
+++ b/src/paddlefleet/models/common/embeddings/rope_utils.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -23,9 +24,7 @@ if TYPE_CHECKING:
 import paddle
 from paddle import Tensor
 
-from paddlefleet.utils import get_logger
-
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 __all__ = [
     "apply_rotary_pos_emb",

--- a/src/paddlefleet/models/common/embeddings/rotary_pos_embedding.py
+++ b/src/paddlefleet/models/common/embeddings/rotary_pos_embedding.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -27,9 +28,8 @@ import paddle
 from paddle import Tensor, nn
 
 from paddlefleet import parallel_state
-from paddlefleet.utils import get_logger
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 __all__ = ["RotaryEmbedding"]

--- a/src/paddlefleet/models/common/embeddings/yarn_rotary_pos_embedding.py
+++ b/src/paddlefleet/models/common/embeddings/yarn_rotary_pos_embedding.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import logging
 import math
 from functools import lru_cache
 from typing import TYPE_CHECKING
@@ -27,9 +28,8 @@ from paddle import Tensor
 from paddlefleet.models.common.embeddings.rotary_pos_embedding import (
     RotaryEmbedding,
 )
-from paddlefleet.utils import get_logger
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class YarnRotaryEmbedding(RotaryEmbedding):

--- a/src/paddlefleet/models/common/language_layer/language_layer.py
+++ b/src/paddlefleet/models/common/language_layer/language_layer.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 
 import paddle
 from paddle import Tensor
@@ -28,11 +29,10 @@ from paddlefleet.pipeline_parallel.utils import (
 from paddlefleet.process_groups_config import ProcessGroupCollection
 from paddlefleet.transformer.layer import FleetLayer
 from paddlefleet.transformer.transformer_config import TransformerConfig
-from paddlefleet.utils import get_logger
 
 # from paddlefleet.utils import make_tp_sharded_tensor_for_checkpoint
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class LanguageLayer(FleetLayer):

--- a/src/paddlefleet/models/gpt/utils.py
+++ b/src/paddlefleet/models/gpt/utils.py
@@ -13,13 +13,12 @@
 # limitations under the License.
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 
 import paddle
 
-from paddlefleet.utils import get_logger
-
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 @dataclass

--- a/src/paddlefleet/training/initialize.py
+++ b/src/paddlefleet/training/initialize.py
@@ -50,9 +50,8 @@ def set_logging(args):
     logger = logging.getLogger("paddlefleet")
 
     # set logging level
-    logging_level = getattr(args, "logging_level", None)
-    if logging_level is not None:
-        logger.setLevel(logging_level)
+    logging_level = getattr(args, "logging_level", logging.INFO)
+    logger.setLevel(logging_level)
 
     # set logging format
     import colorlog

--- a/src/paddlefleet/transformer/mlp.py
+++ b/src/paddlefleet/transformer/mlp.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+import logging
 import warnings
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -46,13 +47,12 @@ from paddlefleet.transformer.layer import FleetLayer
 if TYPE_CHECKING:
     from paddlefleet.transformer.transformer_config import TransformerConfig
 from paddlefleet.utils import (
-    get_logger,
     get_tensor_model_parallel_group_if_none,
     nvtx_range_pop,
     nvtx_range_push,
 )
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 # pylint: disable=missing-class-docstring

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import logging
 from copy import deepcopy
 from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING
@@ -38,6 +39,8 @@ from .moe_router import StandardMoERouter
 from .moe_shared_expert import StandardMLPSharedExpert
 from .moe_utils import AddAuxiliaryLoss
 from .token_dispatcher import MoEFlexTokenDispatcher
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -154,6 +157,17 @@ class MoELayer(nn.Layer):
             self.shared_experts = self.shared_expert_class(**shared_expert_args)
         else:
             self.shared_experts = None
+
+        if (
+            self.moe_token_dispatcher_type == "deepep"
+            and paddle.device.get_device_capability()[0] < 9
+        ):
+            # TODO: Support Ampere architecture after upgrade deepep in paddlepaddle
+            logger.info(
+                "deepep in paddlepaddle does not support compute capability < 9.0, "
+                "fallback to alltoall token dispatcher."
+            )
+            self.moe_token_dispatcher_type = "alltoall"
 
         if self.expert_parallel_degree > 1:
             if self.moe_token_dispatcher_type == "deepep":

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -160,6 +160,7 @@ class MoELayer(nn.Layer):
 
         if (
             self.moe_token_dispatcher_type == "deepep"
+            and not paddle.device.current_device_is_cpu
             and paddle.device.get_device_capability()[0] < 9
         ):
             # TODO: Support Ampere architecture after upgrade deepep in paddlepaddle

--- a/src/paddlefleet/transformer/transformer_block.py
+++ b/src/paddlefleet/transformer/transformer_block.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+import logging
 from contextlib import nullcontext
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -38,7 +39,6 @@ from paddlefleet.transformer.transformer_layer import (
 )
 from paddlefleet.utils import (
     WrappedTensor,
-    get_logger,
     get_pg_rank,
 )
 
@@ -48,7 +48,7 @@ if TYPE_CHECKING:
 
 LayerNormImpl = WrappedPaddleNorm
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def get_num_layers_to_build(

--- a/src/paddlefleet/transformer/transformer_layer.py
+++ b/src/paddlefleet/transformer/transformer_layer.py
@@ -30,14 +30,13 @@ from paddlefleet.transformer.enums import LayerType
 from paddlefleet.transformer.identity_op import IdentityFuncOp, IdentityOp
 from paddlefleet.transformer.layer import GraphableFleetLayer
 from paddlefleet.transformer.mlp import MLP
-from paddlefleet.utils import get_logger, get_pg_rank, log_single_rank
+from paddlefleet.utils import get_pg_rank, log_single_rank
 
 if TYPE_CHECKING:
     from paddlefleet.packed_seq_params import PackedSeqParams
     from paddlefleet.transformer.transformer_config import TransformerConfig
 
-
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def get_transformer_layer_offset(

--- a/src/paddlefleet/utils.py
+++ b/src/paddlefleet/utils.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import functools
 import inspect
-import logging
 import math
 import operator
 import warnings
@@ -53,6 +52,7 @@ except Exception:
     _paddle_version = PkgVersion("0.0.0") if HAVE_PACKAGING else "0.0.0"
 
 if TYPE_CHECKING:
+    import logging
     from collections.abc import Callable
 
 
@@ -255,10 +255,6 @@ def is_paddle_min_version(version, check_equality=True):
     if check_equality:
         return get_paddle_version() >= PkgVersion(version)
     return get_paddle_version() > PkgVersion(version)
-
-
-def get_logger(name: str):
-    return logging.getLogger("paddlefleet." + name)
 
 
 ######################


### PR DESCRIPTION
- 当 GPU 架构小于 sm90 时将 deepep 退化成 alltoall
- 修复当前框架 logger.info 打印不出来的问题，将默认 logging_level 改为 info，另外因为 initialize_fleet 里配置了 paddlefleet 的 Logger，paddlefleet 里的每个 py 文件的 \_\_name\_\_ 都是 paddlefleet.xxx，所以不需要单独写一个 getlogger 接口，对齐 megatron 使用 logging.getLogger(__name__) 即可