### PR TITLE
Fix memory usage issues

### DIFF
--- a/src/paddlefleet/models/common/language_layer/language_layer.py
+++ b/src/paddlefleet/models/common/language_layer/language_layer.py
@@ -131,9 +131,13 @@ class LanguageLayer(FleetLayer):
         if labels.shape[-1] == logits.shape[0]:
             labels = labels.transpose(0, 1).contiguous()
         loss = self.loss_func(logits.cast("float32"), labels)
-        # loss = tensor_parallel.vocab_parallel_cross_entropy(
-        #     logits.cast("float32"), labels
-        # )
+        # loss = []
+        # for subbatch_logits, subbatch_labels in zip(logits, labels):
+        #     subbatch_loss = self.loss_func(
+        #         subbatch_logits[None], subbatch_labels[None]
+        #     )
+        #     loss.append(subbatch_loss)
+        # loss = paddle.cat(loss, axis=0)
 
         lossmask = labels != self.ignored_index
         if (~lossmask).all():  # empty span

--- a/src/paddlefleet/transformer/dot_product_attention.py
+++ b/src/paddlefleet/transformer/dot_product_attention.py
@@ -184,6 +184,29 @@ class DotProductAttention(FleetLayer):
             "Attention bias is not supported for DotProductAttention."
         )
 
+        if query.dtype == paddle.bfloat16 or query.dtype == paddle.float16:
+            # Note:
+            # attention_mask is None in default
+            # is_causal is True in default
+            # training is True in default
+            # Default values above maybe changed in the future
+            attn_output = paddle.nn.functional.scaled_dot_product_attention(
+                query,
+                key,
+                value,
+                None,  # attention_mask
+                self.config.attention_dropout,
+                is_causal=True,
+                training=True,
+            )
+
+            attn_output = paddle.reshape(
+                x=attn_output,
+                shape=[0, 0, attn_output.shape[2] * attn_output.shape[3]],
+            )
+
+            return attn_output
+
         # ===================================
         # Raw attention scores. [b, n/p, s, s]
         # ===================================
@@ -209,28 +232,7 @@ class DotProductAttention(FleetLayer):
                 // self.num_query_groups_per_partition,
                 dim=2,
             )
-        if query.dtype == paddle.bfloat16 or query.dtype == paddle.float16:
-            # Note:
-            # attention_mask is None in default
-            # is_causal is True in default
-            # training is True in default
-            # Default values above maybe changed in the future
-            attn_output = paddle.nn.functional.scaled_dot_product_attention(
-                query,
-                key,
-                value,
-                None,  # attention_mask
-                self.config.attention_dropout,
-                is_causal=True,
-                training=True,
-            )
 
-            attn_output = paddle.reshape(
-                x=attn_output,
-                shape=[0, 0, attn_output.shape[2] * attn_output.shape[3]],
-            )
-
-            return attn_output
         # [b, np, sq, sk]
         output_size = (
             query.shape[0],

--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -113,13 +113,13 @@ class StandardMoERouter(nn.Layer):
             self.weight = paddle.create_parameter(
                 shape=[self.hidden_size, self.num_experts],
                 dtype="float32",
-                default_initializer=paddle.nn.initializer.Uniform(),
+                default_initializer=paddle.nn.initializer.XavierUniform(),
             )
         else:
             self.weight = paddle.create_parameter(
                 shape=[self.num_experts, self.hidden_size],
                 dtype="float32",
-                default_initializer=paddle.nn.initializer.Uniform(),
+                default_initializer=paddle.nn.initializer.XavierUniform(),
             )
 
         if self.topk_method == "noaux_tc":

--- a/src/paddlefleet/transformer/paddle_norm.py
+++ b/src/paddlefleet/transformer/paddle_norm.py
@@ -61,6 +61,7 @@ class RMSNorm(paddle.nn.Layer):
             default_initializer=paddle.nn.initializer.Constant(1.0),
         )
         self.config = config
+        self.config.fuse_rms_norm = True
 
         if input_is_parallel:
             self.enable_sequence_parallel()


### PR DESCRIPTION
### 修复3个显存分配问题

1. 设置`fuse_rms_norm=True`，可以大幅降低 RMSNorm 的显存（所以这个 flag 应该在哪里开？我找了半天没开成功，只能在代码里 hack 了）

2. `scaled_dot_product_attention`不需要手动进行 kv.repeat_interleave，该算子自己会将 kv 与 q 的头数对齐，手动广播只会浪费显存

3. `ParallelCrossEntropy`非常占显存（20GB），我觉得理想做法应该是把它和 LMHead 融合成一个算子，现在暂时手搓了一版 subbatch 可以缩小到 12GB


#### 目前可以跑 Dense 版本的 9 层模型
glm45_provider.py：
```python
class GLM45AirModelDebugProvider(GLM45AirModelProvider106B):
    num_hidden_layers: int = 9
    moe_num_shared_experts: int = 1
    moe_intermediate_size: int = 1408
    num_nextn_predict_layers: Optional[int] = 0
    use_bias: bool = False
```
run_pretrain.py（只改第2行）：
```python
    if hasattr(config, "n_routed_experts") and config.n_routed_experts > 0:
        model_provider.moe_layer_freq = [0] * model_provider.num_hidden_layers
```
glm45.json：
```json
  "per_device_train_batch_size": 8,
```



























































































