### PR TITLE
Use Abi3 for building whl

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,11 @@ def change_pwd():
 
 
 def setup_ops_extension():
-    """setup_ops_extension"""
     from paddle.utils.cpp_extension import CUDAExtension, setup
+    try:
+        from wheel.bdist_wheel import bdist_wheel
+    except ImportError:
+        bdist_wheel = None
 
     nvcc_path = shutil.which("nvcc")
     if nvcc_path is None:
@@ -52,6 +55,7 @@ def setup_ops_extension():
     cuda_major = int(match.group(1))
     cuda_minor = int(match.group(2))
 
+    # 定义 NVCC 编译参数
     nvcc_args = [
         "-O3",
         "-U__CUDA_NO_HALF_OPERATORS__",
@@ -70,6 +74,7 @@ def setup_ops_extension():
         "-gencode=arch=compute_100,code=sm_100",
         "-DNDEBUG",
         "-DPADDLE_NO_PYTHON",
+        # Limited API Macro for NVCC
         "-DPy_LIMITED_API=0x030A0000",
     ]
     if cuda_major < 12:
@@ -79,28 +84,39 @@ def setup_ops_extension():
     if cuda_major == 12 and cuda_minor < 8:
         nvcc_args = [arg for arg in nvcc_args if "compute_100" not in arg]
 
+    ext_module = CUDAExtension(
+        sources=[
+            "./src/paddlefleet/extensions/tokens_stable_unzip.cu",
+        ],
+        include_dirs=[
+            os.path.join(os.getcwd(), "src/paddlefleet/extensions"),
+        ],
+        extra_compile_args={
+            "cxx": ["-O3", "-w", "-Wno-abi", "-fPIC", "-std=c++17", "-DPy_LIMITED_API=0x030A0000"],
+            "nvcc": nvcc_args,
+        },
+        py_limited_api=True, 
+    )
+
+    ext_module.py_limited_api = True
+
+    cmdclass = {}
+    if bdist_wheel:
+        class ABI3Wheel(bdist_wheel):
+            def get_tag(self):
+                python, abi, plat = super().get_tag()
+                if python.startswith("cp"):
+                    return python, "abi3", plat
+                return python, abi, plat
+        
+        cmdclass['bdist_wheel'] = ABI3Wheel
+
     change_pwd()
+    
     setup(
         name="paddlefleet.extensions.ops",
-        ext_modules=CUDAExtension(
-            sources=[
-                "./src/paddlefleet/extensions/tokens_stable_unzip.cu",
-            ],
-            include_dirs=[
-                os.path.join(os.getcwd(), "src/paddlefleet/extensions"),
-            ],
-            extra_compile_args={
-                "cxx": [
-                    "-O3",
-                    "-w",
-                    "-Wno-abi",
-                    "-fPIC",
-                    "-std=c++17",
-                    "-DPy_LIMITED_API=0x030A0000",
-                ],
-                "nvcc": nvcc_args,
-            },
-        ),
+        ext_modules=[ext_module],
+        cmdclass=cmdclass,
     )
 
 

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ def change_pwd():
 
 def setup_ops_extension():
     from paddle.utils.cpp_extension import CUDAExtension, setup
+
     try:
         from wheel.bdist_wheel import bdist_wheel
     except ImportError:
@@ -92,27 +93,34 @@ def setup_ops_extension():
             os.path.join(os.getcwd(), "src/paddlefleet/extensions"),
         ],
         extra_compile_args={
-            "cxx": ["-O3", "-w", "-Wno-abi", "-fPIC", "-std=c++17", "-DPy_LIMITED_API=0x030A0000"],
+            "cxx": [
+                "-O3",
+                "-w",
+                "-Wno-abi",
+                "-fPIC",
+                "-std=c++17",
+                "-DPy_LIMITED_API=0x030A0000",
+            ],
             "nvcc": nvcc_args,
         },
-        py_limited_api=True, 
+        py_limited_api=True,
     )
 
     ext_module.py_limited_api = True
 
     cmdclass = {}
     if bdist_wheel:
+
         class ABI3Wheel(bdist_wheel):
             def get_tag(self):
                 python, abi, plat = super().get_tag()
                 if python.startswith("cp"):
                     return python, "abi3", plat
                 return python, abi, plat
-        
-        cmdclass['bdist_wheel'] = ABI3Wheel
+
+        cmdclass["bdist_wheel"] = ABI3Wheel
 
     change_pwd()
-    
     setup(
         name="paddlefleet.extensions.ops",
         ext_modules=[ext_module],


### PR DESCRIPTION
支持paddlefleet的whl包可以多个python(3.10~3.13)都能安装，编译出来的whl包名字是paddlefleet-0.0.1a0-cp310-abi3-linux_x86_64.whl，在 CPython 3.10 环境中编译，适用于 Linux x86-64 架构，使用了 Python 的稳定 ABI (abi3)，所以它可以在任何3.x 版本的 Python 环境中运行，而不仅仅是python3.10，cp310和abi3的意义如下：

- cp310: 指 CPython，即官方标准的 Python 解释器。
- abi3：在 C/C++ 代码中使用 -DPy_LIMITED_API 宏并设置 py_limited_api=True 时，您告诉构建系统：C 扩展代码中只使用了 Python 官方保证其二进制兼容性的 API（即“稳定 API”）。因此，该 .so 文件兼容 Python3.x 系列中所有支持 Limited ABI 的版本


 修改whl包名字：直接拦截了 bdist_wheel 命令，直接重写 bdist_wheel 命令的标签生成逻辑，会强行把 ABI 部分替换为 "abi3"