### PR TITLE
Add dedicated FusedRMSNorm class

### DIFF
--- a/src/paddlefleet/models/backends.py
+++ b/src/paddlefleet/models/backends.py
@@ -43,7 +43,10 @@ class SequentialMLP:
     pass
 
 
-from paddlefleet.transformer.paddle_norm import WrappedPaddleNorm
+from paddlefleet.transformer.paddle_norm import (
+    WrappedFusedNorm,
+    WrappedPaddleNorm,
+)
 
 LNImpl = WrappedPaddleNorm
 
@@ -113,13 +116,15 @@ class LocalSpecProvider(BackendSpecProvider):
         """Which layer for sequential layernorm and linear"""
         return None
 
-    def layer_norm(self, rms_norm: bool = False, for_qk: bool = False) -> type:
+    def layer_norm(
+        self, rms_norm: bool = False, for_qk: bool = False, fused: bool = True
+    ) -> type:
         """Which module to use for layer norm"""
         if rms_norm:
             # Matching get_gpt_layer_local_spec.
             # Why does the global need to be updated?
             global LNImpl
-            LNImpl = WrappedPaddleNorm
+            LNImpl = WrappedFusedNorm if fused else WrappedPaddleNorm
         return LNImpl
 
     def core_attention(self) -> type:

--- a/src/paddlefleet/transformer/paddle_norm.py
+++ b/src/paddlefleet/transformer/paddle_norm.py
@@ -66,14 +66,6 @@ class RMSNorm(paddle.nn.Layer):
             self.enable_sequence_parallel()
 
     def forward(self, hidden_states):
-        if self.config.fuse_rms_norm:
-            assert fused_rms_norm_ext is not None, (
-                "Enable fuse rms norm but paddle version is incorrect."
-            )
-            return fused_rms_norm_ext(
-                hidden_states, self.weight, self.variance_epsilon
-            )[0].astype(self.weight.dtype)
-
         if paddle.in_dynamic_mode():
             with paddle.amp.auto_cast(False):
                 variance = (
@@ -101,6 +93,16 @@ class RMSNorm(paddle.nn.Layer):
         mark_as_sequence_parallel_parameter(self.weight)
 
 
+class FusedRMSNorm(RMSNorm):
+    def forward(self, hidden_states):
+        assert fused_rms_norm_ext is not None, (
+            "Enable fuse rms norm but paddle version is incorrect."
+        )
+        return fused_rms_norm_ext(
+            hidden_states, self.weight, self.variance_epsilon
+        )[0].astype(self.weight.dtype)
+
+
 class WrappedPaddleNorm:
     def __new__(
         cls,
@@ -120,6 +122,27 @@ class WrappedPaddleNorm:
             normalized_shape=hidden_size,
             norm_eps=eps,
             input_is_parallel=input_is_parallel,
+        )
+
+
+class WrappedFusedNorm:
+    def __new__(
+        cls,
+        config: TransformerConfig,
+        hidden_size: int,
+        eps: float = 1e-5,
+        input_is_parallel: bool = False,
+    ):
+        if config.normalization == "RMSNorm":
+            norm_cls = FusedRMSNorm
+        else:
+            raise Exception("Only supports RMSNorm now.")
+
+        return norm_cls(
+            config=config,
+            normalized_shape=hidden_size,
+            norm_eps=eps,
+            input_is_parallel=config.sequence_parallel,
         )
 
 

--- a/tests/single_card_tests/model/test_gpt_model_moe.py
+++ b/tests/single_card_tests/model/test_gpt_model_moe.py
@@ -200,8 +200,8 @@ class TestGPTModel(unittest.TestCase):
                 f"grad norm of word_embeddingsnot not equal ({word_embeddings_grad_norm} != 6.112863540649414), please check your modify"
             )
         elif judge_machine_type() == "V":
-            assert word_embeddings_grad_norm == 8.235458374023438, (
-                f"grad norm of word_embeddingsnot not equal ({word_embeddings_grad_norm} != 8.235458374023438, please check your modify"
+            assert word_embeddings_grad_norm == 8.2354097366333, (
+                f"grad norm of word_embeddingsnot not equal ({word_embeddings_grad_norm} != 8.2354097366333), please check your modify"
             )
 
 


### PR DESCRIPTION
### 将FusedRMSNorm变成独立的类，无需开关

相当于 config.fuse_rms_norm 这项配置废弃了，用户如果要指定是否使用 fused_rms_norm，应该在写模型调用 backend.layer_norm 时指定是否为 fused，或直接调用 WrappedFusedNorm，例如：
```python
layer_norm = backend.layer_norm(rms_norm=True, for_qk=False, fused=True)
```
或
```pyhon
layer_norm = WrappedFusedNorm
```