### PR TITLE
[DeepGEMM] Support `DeepGEMM` as a submodule

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -100,6 +100,7 @@ jobs:
           echo "Install uv"
           pip install uv
           echo "uv sync"
+          git submodule update --init --recursive
           uv sync --group ci -v > /dev/null
           '
 
@@ -211,6 +212,7 @@ jobs:
           echo "Install uv"
           pip install uv
           echo "uv sync"
+          git submodule update --init --recursive
           uv sync --group ci -v > /dev/null
           wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/local/bin/yq
           chmod +x /usr/local/bin/yq
@@ -337,6 +339,7 @@ jobs:
           echo "Install uv"
           pip install uv
           echo "uv sync"
+          git submodule update --init --recursive
           uv sync --group ci -v > /dev/null
           export UV_SKIP_WHEEL_FILENAME_CHECK=1
           uv pip install https://paddle-qa.bj.bcebos.com/paddle-pipeline/Develop-GpuAll-LinuxCentos-Gcc11-Cuda129-Cudnn99-Trt105-Py310-Compile/latest/paddlepaddle_gpu-0.0.0-cp310-cp310-linux_x86_64.whl --index-url=https://www.paddlepaddle.org.cn/packages/nightly/cu129/ --force-reinstall
@@ -504,6 +507,7 @@ jobs:
           echo "Install uv"
           pip install uv
           echo "uv sync"
+          git submodule update --init --recursive
           uv sync --group ci -v > /dev/null
           export UV_SKIP_WHEEL_FILENAME_CHECK=1
           uv pip install https://paddle-qa.bj.bcebos.com/paddle-pipeline/Develop-GpuAll-LinuxCentos-Gcc11-Cuda129-Cudnn99-Trt105-Py310-Compile/latest/paddlepaddle_gpu-0.0.0-cp310-cp310-linux_x86_64.whl --index-url=https://www.paddlepaddle.org.cn/packages/nightly/cu129/ --force-reinstall
@@ -672,6 +676,7 @@ jobs:
           echo "Install uv"
           pip install uv
           echo "uv sync"
+          git submodule update --init --recursive
           uv sync --group ci > /dev/null
           export UV_SKIP_WHEEL_FILENAME_CHECK=1
           uv pip install https://paddle-qa.bj.bcebos.com/paddle-pipeline/Develop-GpuAll-LinuxCentos-Gcc11-Cuda129-Cudnn99-Trt105-Py310-Compile/latest/paddlepaddle_gpu-0.0.0-cp310-cp310-linux_x86_64.whl --index-url=https://www.paddlepaddle.org.cn/packages/nightly/cu129/ --force-reinstall

--- a/.github/workflows/publish_wheel_nightly.yml
+++ b/.github/workflows/publish_wheel_nightly.yml
@@ -76,7 +76,6 @@ jobs:
           pip cache dir
           pip install --upgrade pip
           pip install uv
-          uv sync -v
           python -m pip install bce-python-sdk==0.8.74
           '
 
@@ -86,6 +85,7 @@ jobs:
           export LD_LIBRARY_PATH=/opt/_internal/cpython-3.10.0/lib/:${LD_LIBRARY_PATH}
           export PATH=/opt/_internal/cpython-3.10.0/bin/:${PATH}
           source /root/proxy
+          git submodule update --init --recursive
           uv build
           '
 

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,9 @@ log
 # Ignore files generated from `uv sync` for custom ops
 src/paddlefleet/_extensions/ops_pd_.so
 src/paddlefleet/_extensions/ops.py
+
+# Ignore build artifacts for submodule
+third_party
+src/_third_party_install_temp/
+src/paddlefleet/ops/deep_gemm/
+src/paddlefleet/ops/deep_gemm_cpp/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "third_party/DeepGEMM"]
+	path = third_party/DeepGEMM
+	url = https://github.com/PFCCLab/DeepGEMM.git

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,6 @@
 include src/paddlefleet/_extensions/*.h
+include build_backend.py
+include build_utils.py
+graft third_party/DeepGEMM
+prune third_party/DeepGEMM/deep_gemm_cpp.egg-info
+prune third_party/DeepGEMM/build

--- a/build_backend.py
+++ b/build_backend.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from setuptools import build_meta as orig
+
+from build_utils import Artifact, EcosystemLibrary
+
+LIBRARIES: list[EcosystemLibrary] = [
+    EcosystemLibrary(
+        name="DeepGEMM",
+        source_rel_path="third_party/DeepGEMM",
+        artifacts=[
+            # Updated paths to point to the installation directory
+            Artifact("deep_gemm", "deep_gemm"),
+            Artifact("deep_gemm_cpp", "deep_gemm_cpp"),
+        ],
+    ),
+]
+
+
+def _prepare_ecosystem(use_symlinks: bool):
+    """Iterates over all registered libraries and prepares them."""
+    for lib in LIBRARIES:
+        lib.build()
+        lib.install(use_symlinks=use_symlinks)
+
+
+def get_requires_for_build_wheel(config_settings=None):
+    return orig.get_requires_for_build_wheel(config_settings)
+
+
+def get_requires_for_build_sdist(config_settings=None):
+    return orig.get_requires_for_build_sdist(config_settings)
+
+
+def get_requires_for_build_editable(config_settings=None):
+    return orig.get_requires_for_build_editable(config_settings)
+
+
+def prepare_metadata_for_build_wheel(metadata_directory, config_settings=None):
+    return orig.prepare_metadata_for_build_wheel(
+        metadata_directory, config_settings
+    )
+
+
+def prepare_metadata_for_build_editable(
+    metadata_directory, config_settings=None
+):
+    return orig.prepare_metadata_for_build_editable(
+        metadata_directory, config_settings
+    )
+
+
+def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
+    _prepare_ecosystem(use_symlinks=False)
+    return orig.build_wheel(
+        wheel_directory, config_settings, metadata_directory
+    )
+
+
+def build_editable(
+    wheel_directory, config_settings=None, metadata_directory=None
+):
+    _prepare_ecosystem(use_symlinks=True)
+    return orig.build_editable(
+        wheel_directory, config_settings, metadata_directory
+    )
+
+
+def build_sdist(sdist_directory, config_settings=None):
+    return orig.build_sdist(sdist_directory, config_settings)

--- a/build_utils.py
+++ b/build_utils.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+ROOT_DIR = Path(__file__).parent.resolve()
+OPS_DIR = ROOT_DIR / "src" / "paddlefleet" / "ops"
+THIRD_PARTY_INSTALL_TEMP = ROOT_DIR / "src" / "_third_party_install_temp"
+
+
+@dataclass
+class Artifact:
+    """
+    Defines a mapping from a path in the installation directory to a target name in the ops directory.
+
+    source_rel_path: Relative path from the library's installation directory (e.g., 'deep_gemm').
+    target_name: Name of the symlink/directory to create in 'src/paddlefleet/ops' (e.g., 'deep_gemm').
+    """
+
+    source_rel_path: str
+    target_name: str
+
+
+class EcosystemLibrary:
+    """
+    Represents an external ecosystem operator library.
+    Encapsulates the logic for building and installing the library.
+    """
+
+    def __init__(
+        self, name: str, source_rel_path: str, artifacts: list[Artifact]
+    ):
+        self.name = name
+        self.source_dir = ROOT_DIR / source_rel_path
+        # Install into a subdirectory named after the library
+        self.install_dir = THIRD_PARTY_INSTALL_TEMP / name
+        self.artifacts = artifacts
+
+    def build(self) -> None:
+        """Builds the library."""
+        logger.info(f"Building ecosystem library: {self.name}")
+        self.install_dir.mkdir(parents=True, exist_ok=True)
+
+        # Default build command: python setup.py install --install-lib <install_dir>
+        cmd = [
+            sys.executable,
+            "setup.py",
+            "install",
+            "--install-lib",
+            str(self.install_dir),
+            "--no-compile",
+        ]
+
+        try:
+            subprocess.check_call(cmd, cwd=self.source_dir)
+        except subprocess.CalledProcessError as e:
+            logger.error(f"Failed to build {self.name}: {e}")
+            raise
+
+    def clean(self) -> None:
+        """Cleans up existing artifacts in the ops directory."""
+        for artifact in self.artifacts:
+            target_path = OPS_DIR / artifact.target_name
+            if target_path.exists():
+                if target_path.is_symlink():
+                    target_path.unlink()
+                elif target_path.is_dir():
+                    shutil.rmtree(target_path)
+                else:
+                    target_path.unlink()
+
+    def install(self, use_symlinks: bool = False) -> None:
+        """Installs artifacts to the ops directory via symlink or copy."""
+        self.clean()  # Ensure clean state first
+
+        for artifact in self.artifacts:
+            # Artifact source path is relative to the installation directory
+            src = self.install_dir / artifact.source_rel_path
+            dst = OPS_DIR / artifact.target_name
+
+            if not src.exists():
+                logger.warning(f"Artifact source not found: {src}")
+                continue
+
+            if use_symlinks:
+                logger.info(f"Symlinking {src} -> {dst}")
+                dst.symlink_to(src, target_is_directory=src.is_dir())
+            else:
+                logger.info(f"Copying {src} -> {dst}")
+                if src.is_dir():
+                    shutil.copytree(
+                        src, dst, symlinks=False, dirs_exist_ok=True
+                    )
+                else:
+                    shutil.copy(src, dst)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ classifiers = [
 dependencies = [
     "colorlog>=6.10.1",
     "paddlepaddle-gpu>=3.3.0.dev",
+    "triton==3.4.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ classifiers = [
 dependencies = [
     "colorlog>=6.10.1",
     "paddlepaddle-gpu>=3.3.0.dev",
-    "triton==3.4.0",
+    "triton",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,13 +59,19 @@ Homepage = "https://github.com/PaddlePaddle/PaddleFleet/src"
 
 [build-system]
 requires = ["setuptools>=61.0.0", "pybind11", "wheel", "packaging>=24.2", "paddlepaddle-gpu>=3.3.0.dev", "setuptools-scm>=8"]
-build-backend = "setuptools.build_meta"
+build-backend = "build_backend"
+backend-path = ["."]
+
 
 [tool.setuptools]
 include-package-data = true
 
+[tool.setuptools.package-data]
+"paddlefleet.ops" = ["*", "**/*"]
+
 [tool.setuptools.packages.find]
 where = ["src"]
+include = ["paddlefleet*"]
 
 [tool.setuptools.dynamic]
 readme = { file = "README.md", content-type = "text/markdown" }

--- a/setup.py
+++ b/setup.py
@@ -132,8 +132,6 @@ def setup_ops_extension():
         },
     )
 
-    ext_module.py_limited_api = True
-
     change_pwd()
     setup(
         name="paddlefleet._extensions.ops",

--- a/setup.py
+++ b/setup.py
@@ -97,9 +97,6 @@ def setup_ops_extension():
         "-gencode=arch=compute_90a,code=sm_90a",
         "-gencode=arch=compute_100,code=sm_100",
         "-DNDEBUG",
-        "-DPADDLE_NO_PYTHON",
-        # Limited API Macro for NVCC
-        "-DPy_LIMITED_API=0x030A0000",
     ]
     if cuda_major < 12:
         raise ValueError(
@@ -130,33 +127,17 @@ def setup_ops_extension():
                 "-Wno-abi",
                 "-fPIC",
                 "-std=c++17",
-                "-DPADDLE_NO_PYTHON",
-                "-DPy_LIMITED_API=0x030A0000",
             ],
             "nvcc": nvcc_args,
         },
-        py_limited_api=True,
     )
 
     ext_module.py_limited_api = True
-
-    cmdclass = {}
-    if bdist_wheel:
-
-        class ABI3Wheel(bdist_wheel):
-            def get_tag(self):
-                python, abi, plat = super().get_tag()
-                if python.startswith("cp"):
-                    return python, "abi3", plat
-                return python, abi, plat
-
-        cmdclass["bdist_wheel"] = ABI3Wheel
 
     change_pwd()
     setup(
         name="paddlefleet._extensions.ops",
         ext_modules=[ext_module],
-        cmdclass=cmdclass,
         use_scm_version={
             "version_scheme": custom_version_scheme,
             "local_scheme": no_local_scheme,

--- a/src/paddlefleet/ops/__init__.py
+++ b/src/paddlefleet/ops/__init__.py
@@ -12,12 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .utils import import_custom_ops
-
-import_custom_ops(
-    package="paddlefleet._extensions", module_name=".ops", global_ns=globals()
-)
-
 import logging
 import sys
 from pathlib import Path
@@ -25,7 +19,13 @@ from typing import Any
 
 import paddle
 
+from .utils import import_custom_ops
+
 logger = logging.getLogger(__name__)
+
+import_custom_ops(
+    package="paddlefleet._extensions", module_name=".ops", global_ns=globals()
+)
 
 
 class ModuleContext:

--- a/src/paddlefleet/ops/__init__.py
+++ b/src/paddlefleet/ops/__init__.py
@@ -17,3 +17,73 @@ from .utils import import_custom_ops
 import_custom_ops(
     package="paddlefleet._extensions", module_name=".ops", global_ns=globals()
 )
+
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+import paddle
+
+logger = logging.getLogger(__name__)
+
+
+class ModuleContext:
+    """
+    Manages the context for loading a module, including:
+    1. Stashing existing modules to prevent conflicts.
+    2. Managing sys.path.
+    3. Restoring stashed modules upon exit.
+    """
+
+    def __init__(self, module_names: list[str], path: Path):
+        self.module_names = module_names
+        self.path = str(path)
+        self._stash: dict[str, Any] = {}
+
+    def _stash_modules(self):
+        """Moves modules matching module_name from sys.modules to stash."""
+        for name in list(sys.modules.keys()):
+            for module_name in self.module_names:
+                if name == module_name or name.startswith(module_name + "."):
+                    self._stash[name] = sys.modules.pop(name)
+
+    def _restore_modules(self):
+        """Restores stashed modules to sys.modules."""
+        sys.modules.update(self._stash)
+        self._stash.clear()
+
+    def __enter__(self):
+        self._stash_modules()
+        sys.path.insert(0, self.path)
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self.path in sys.path:
+            sys.path.remove(self.path)
+        self._restore_modules()
+
+
+def patch_module_namespace(source_name: str, target_prefix: str):
+    """
+    Moves loaded modules from source_name to target_prefix + source_name.
+    Effectively 'installs' the module into the new namespace.
+    """
+    for name in list(sys.modules.keys()):
+        if name == source_name or name.startswith(source_name + "."):
+            module = sys.modules.pop(name)
+            new_name = target_prefix + name
+            sys.modules[new_name] = module
+
+
+ops_dir = Path(__file__).parent
+
+with ModuleContext(["deep_gemm"], ops_dir):
+    paddle.compat.enable_torch_proxy(scope={"deep_gemm"})
+    try:
+        import deep_gemm  # noqa: F401
+
+        patch_module_namespace("deep_gemm", "paddlefleet.ops.")
+        logger.info("Successfully loaded ecosystem library: deep_gemm")
+    except ImportError as e:
+        logger.warning(f"Ecosystem library 'deep_gemm' not found: {e}")

--- a/src/paddlefleet/ops/utils.py
+++ b/src/paddlefleet/ops/utils.py
@@ -28,7 +28,7 @@ def import_custom_ops(package, module_name, global_ns):
     """
     try:
         module = importlib.import_module(module_name, package=package)
-        functions = inspect.getmembers(module)
+        functions = inspect.getmembers(module, inspect.isfunction)
         for func_name, func in functions:
             if func_name.startswith("__") or func_name == "_C_ops":
                 continue

--- a/tests/single_card_tests/custom_ops/test_ops_import.py
+++ b/tests/single_card_tests/custom_ops/test_ops_import.py
@@ -73,5 +73,17 @@ class TestOpsImport(unittest.TestCase):
             )
 
 
+class TestDeeGEMMImport(unittest.TestCase):
+    def test_deep_gemm_import(self):
+        from paddlefleet.ops.deep_gemm import (  # noqa: F401
+            cublaslt_gemm_tn,
+            set_num_sms,
+        )
+
+    def test_error_import(self):
+        with self.assertRaises(ImportError):
+            from paddlefleet.ops.deep_gemm import xxxx  # noqa: F401
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -365,7 +365,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 wheels = [
     { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/exceptiongroup/exceptiongroup-1.3.1-py3-none-any.whl" },
@@ -882,6 +882,7 @@ source = { editable = "." }
 dependencies = [
     { name = "colorlog" },
     { name = "paddlepaddle-gpu" },
+    { name = "triton" },
 ]
 
 [package.dev-dependencies]
@@ -908,6 +909,7 @@ test = [
 requires-dist = [
     { name = "colorlog", specifier = ">=6.10.1" },
     { name = "paddlepaddle-gpu", specifier = ">=3.3.0.dev0" },
+    { name = "triton", specifier = "==3.4.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -1264,6 +1266,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/46/cc36c679f09f27ded940281c38607716c86cf8ba4a518d524e349c8b4874/tomli-2.3.0-cp314-cp314t-win32.whl", hash = "sha256:a1f7f282fe248311650081faafa5f4732bdbfef5d45fe3f2e702fbc6f2d496e0", size = 107563, upload-time = "2025-10-08T22:01:44.233Z" },
     { url = "https://files.pythonhosted.org/packages/84/ff/426ca8683cf7b753614480484f6437f568fd2fda2edbdf57a2d3d8b27a0b/tomli-2.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:70a251f8d4ba2d9ac2542eecf008b3c8a9fc5c3f9f02c56a9d7952612be2fdba", size = 119756, upload-time = "2025-10-08T22:01:45.234Z" },
     { url = "https://files.pythonhosted.org/packages/77/b8/0135fadc89e73be292b473cb820b4f5a08197779206b33191e801feeae40/tomli-2.3.0-py3-none-any.whl", hash = "sha256:e95b1af3c5b07d9e643909b5abbec77cd9f1217e6d0bca72b0234736b9fb1f1b", size = 14408, upload-time = "2025-10-08T22:01:46.04Z" },
+]
+
+[[package]]
+name = "triton"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "setuptools" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/ee/0ee5f64a87eeda19bbad9bc54ae5ca5b98186ed00055281fd40fb4beb10e/triton-3.4.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7ff2785de9bc02f500e085420273bb5cc9c9bb767584a4aa28d6e360cec70128", size = 155430069, upload-time = "2025-07-30T19:58:21.715Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/39/43325b3b651d50187e591eefa22e236b2981afcebaefd4f2fc0ea99df191/triton-3.4.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7b70f5e6a41e52e48cfc087436c8a28c17ff98db369447bcaff3b887a3ab4467", size = 155531138, upload-time = "2025-07-30T19:58:29.908Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/66/b1eb52839f563623d185f0927eb3530ee4d5ffe9d377cdaf5346b306689e/triton-3.4.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:31c1d84a5c0ec2c0f8e8a072d7fd150cab84a9c239eaddc6706c081bfae4eb04", size = 155560068, upload-time = "2025-07-30T19:58:37.081Z" },
+    { url = "https://files.pythonhosted.org/packages/30/7b/0a685684ed5322d2af0bddefed7906674f67974aa88b0fae6e82e3b766f6/triton-3.4.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00be2964616f4c619193cb0d1b29a99bd4b001d7dc333816073f92cf2a8ccdeb", size = 155569223, upload-time = "2025-07-30T19:58:44.017Z" },
+    { url = "https://files.pythonhosted.org/packages/20/63/8cb444ad5cdb25d999b7d647abac25af0ee37d292afc009940c05b82dda0/triton-3.4.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7936b18a3499ed62059414d7df563e6c163c5e16c3773678a3ee3d417865035d", size = 155659780, upload-time = "2025-07-30T19:58:51.171Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -909,7 +909,7 @@ test = [
 requires-dist = [
     { name = "colorlog", specifier = ">=6.10.1" },
     { name = "paddlepaddle-gpu", specifier = ">=3.3.0.dev0" },
-    { name = "triton", specifier = "==3.4.0" },
+    { name = "triton" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
将 `DeepGEMM` 作为 third_party 与 paddlefleet 进行联合编译，用法是 `paddlefleet.ops.deep_gemm.xxx`，需要从 `paddlefleet.ops.deep_gemm` 下进行调用

实现方案：
1. 自定义 `build-backend`，进行预处理操作
  a. 实现在 build_wheel 和 build_editable 的时候，先对 third_party 中的 DeepGemm 单独进行编译并安装在 `src/_third_party_install_temp` 下
  b. 把 `src/_third_party_install_temp` 下安装完的产物 `deep_gemm`, `deep_gemm_cpp` 复制或软链到 `src/paddlefleet/ops` 目录下
2. 加载 `deep_gemm` 替换为新的命名空间 `paddlefleet.ops.deep_gemm`
  a. 利用 `ModuleContext` 上下文管理，用于保留已有的 `deep_gemm.*` 命名空间的 sys.module，并临时将 `src/paddlefleet/ops` 加入 sys.path。
  b. `patch_module_namespace` 实现命名空间的替换
3. 删除 paddlefleet setup.py 中的 `-DPy_LIMITED_API`，因为 deep_gemm 会 `#include <pybind11/pybind11.h>`，pybind11 不支持 py_limited_api，所以联合发包时需要删除 paddlefleet 里面的配置

### TOOD
- [ ] @zhangbo9674 @hushenwei2000 需要补充 deep_gemm 相应的单测