### PR TITLE
add_recompute_modules

### DIFF
--- a/src/paddlefleet/recompute_utils.py
+++ b/src/paddlefleet/recompute_utils.py
@@ -1,0 +1,128 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from itertools import chain
+
+
+def need_recompute_in_block(layer_number, config, recompute_num_layers):
+    assert recompute_num_layers is not None, (
+        "recompute_num_layers cannot be none"
+    )
+    total_num_hidden_layers = (
+        config.remove_head_layers
+        + config.num_hidden_layers
+        + config.remove_tail_layers
+    )
+    vpp_size = (
+        config.virtual_pipeline_model_parallel_size
+        if config.virtual_pipeline_model_parallel_size
+        else 1
+    )
+    parallel_size = config.pipeline_model_parallel_size * vpp_size
+    assert total_num_hidden_layers % parallel_size == 0, (
+        "num_hidden_layers must be divided by parallel_size"
+    )
+    chunk_size = int(total_num_hidden_layers / parallel_size)
+    assert recompute_num_layers <= chunk_size
+    layers = list(range(total_num_hidden_layers))
+    recompute_layers = list(
+        chain.from_iterable(
+            [
+                layers[i : i + recompute_num_layers]
+                for i in range(0, len(layers), chunk_size)
+            ]
+        )
+    )
+    if layer_number in recompute_layers:
+        return True
+    return False
+
+
+def need_recompute_in_first_n(layer_number, config, recompute_num_layers):
+    assert recompute_num_layers is not None, (
+        "recompute_num_layers cannot be none"
+    )
+    total_num_hidden_layers = (
+        config.remove_head_layers
+        + config.num_hidden_layers
+        + config.remove_tail_layers
+    )
+    vpp_size = (
+        config.virtual_pipeline_model_parallel_size
+        if config.virtual_pipeline_model_parallel_size
+        else 1
+    )
+    parallel_size = config.pipeline_model_parallel_size * vpp_size
+    assert total_num_hidden_layers % parallel_size == 0, (
+        "num_hidden_layers must be divided by parallel_size"
+    )
+    chunk_size = int(total_num_hidden_layers / parallel_size)
+    num_layers_in_each_stage = (
+        total_num_hidden_layers / config.pipeline_model_parallel_size
+    )
+    assert recompute_num_layers <= num_layers_in_each_stage, (
+        "recompute_num_layers cannot be greater than num_layers_in_each_stage"
+    )
+    if vpp_size > 1:
+        layers = range(total_num_hidden_layers)
+        chunks = [
+            layers[i * chunk_size : (i + 1) * chunk_size]
+            for i in range(0, len(layers), chunk_size)
+        ]
+        recompute_layers = []
+        for pp_stage in range(config.pipeline_model_parallel_size):
+            recompute_layers_in_curr_stage = list(
+                chain.from_iterable(
+                    chunks[pp_stage :: config.pipeline_model_parallel_size]
+                )
+            )[:recompute_num_layers]
+            recompute_layers += recompute_layers_in_curr_stage
+    else:
+        recompute_layers = []
+        layers = list(range(total_num_hidden_layers))
+        if config.pipeline_model_parallel_size > 1:
+            for recompute_layer_id in range(recompute_num_layers):
+                recompute_layers_in_curr_stage = list(
+                    layers[recompute_layer_id::chunk_size]
+                )
+                recompute_layers += recompute_layers_in_curr_stage
+        else:
+            recompute_layers = list(
+                range(
+                    config.pipeline_model_parallel_size * recompute_num_layers
+                )
+            )
+    if layer_number in recompute_layers:
+        return True
+    return False
+
+
+def need_full_recompute(layer_number, config):
+    if config.recompute_granularity == "full":
+        if config.recompute_method == "uniform":
+            assert config.recompute_num_layers == 1, (
+                "don't support recompute_method=uniform wihile recompute_num_layers != 1"
+            )
+            return True
+        elif config.recompute_method == "first_n":
+            return need_recompute_in_first_n(
+                layer_number, config, config.recompute_num_layers
+            )
+        elif config.recompute_method == "block":
+            return need_recompute_in_block(
+                layer_number, config, config.recompute_num_layers
+            )
+    return False

--- a/src/paddlefleet/tensor_parallel/layers.py
+++ b/src/paddlefleet/tensor_parallel/layers.py
@@ -993,6 +993,7 @@ class ColumnParallelLinear(paddle.nn.Layer):
             or self.explicit_expert_comm
             or self.disable_grad_reduce
             or (self.tp_group is not None and self.tp_group.world_size == -1)
+            or self.tp_group is None
         ):
             input_parallel = input_
         else:

--- a/src/paddlefleet/tensor_parallel/random.py
+++ b/src/paddlefleet/tensor_parallel/random.py
@@ -21,7 +21,6 @@ import contextlib
 import logging
 
 import paddle
-from paddle.distributed.fleet.utils import recompute
 
 from ..parallel_state import (
     get_expert_model_parallel_rank,
@@ -391,7 +390,7 @@ def _fork_rng():
 
 def checkpoint(function, *args, **kwargs):
     """Checkpoint a model or part of the model."""
-    return recompute(function, *args, **kwargs)
+    pass
 
 
 class CheckpointWithoutOutputFunction(paddle.autograd.Function):

--- a/src/paddlefleet/transformer/attention.py
+++ b/src/paddlefleet/transformer/attention.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
 
 import paddle
 from paddle import Tensor
+from paddle.distributed.fleet.utils import recompute
 
 from paddlefleet import tensor_parallel
 from paddlefleet.models.common.embeddings import (
@@ -138,7 +139,7 @@ class Attention(FleetLayer, ABC):
             pg_collection=self.pg_collection,
         )
 
-        self.checkpoint_core_attention = (
+        self.recompute_core_attention = (
             self.config.recompute_granularity == "selective"
             and "core_attn" in self.config.recompute_modules
         )
@@ -156,58 +157,6 @@ class Attention(FleetLayer, ABC):
             is_expert=False,
             tp_group=self.pg_collection.tp,
         )
-
-    def _checkpointed_attention_forward(
-        self,
-        query,
-        key,
-        value,
-        attention_mask,
-        attn_mask_startend_row_indices=None,
-        rotary_pos_emb=None,
-        attn_mask_type=None,
-        attention_bias=None,
-        packed_seq_params=None,
-    ):
-        """Forward method with selective activation checkpointing."""
-
-        def custom_forward(*inputs):
-            query = inputs[0]
-            key = inputs[1]
-            value = inputs[2]
-            attention_mask = inputs[3]
-            attn_mask_type = inputs[5]
-            attn_mask_type = AttnMaskType(attn_mask_type.item())
-            output_ = self.core_attention(
-                query,
-                key,
-                value,
-                attention_mask,
-                attn_mask_startend_row_indices,
-                attn_mask_type=attn_mask_type,
-                attention_bias=attention_bias,
-                packed_seq_params=packed_seq_params,
-            )
-            return output_
-
-        if attn_mask_type is None:
-            attn_mask_type = self.attn_mask_type
-        attn_mask_type = paddle.to_tensor(
-            [attn_mask_type.value], dtype=paddle.int
-        )
-        hidden_states = tensor_parallel.checkpoint(
-            custom_forward,
-            False,
-            query,
-            key,
-            value,
-            attention_mask,
-            attn_mask_startend_row_indices,
-            rotary_pos_emb,
-            attn_mask_type,
-        )
-
-        return hidden_states
 
     @abstractmethod
     def get_query_key_value_tensors(
@@ -357,8 +306,9 @@ class Attention(FleetLayer, ABC):
             key = key.transpose([1, 0, 2, 3]).contiguous()
             value = value.transpose([1, 0, 2, 3]).contiguous()
 
-        if self.checkpoint_core_attention and self.training:
-            core_attn_out = self._checkpointed_attention_forward(
+        if self.recompute_core_attention and self.training:
+            core_attn_out = recompute(
+                self.core_attention,
                 query,
                 key,
                 value,

--- a/src/paddlefleet/transformer/moe/fp8_utils.py
+++ b/src/paddlefleet/transformer/moe/fp8_utils.py
@@ -212,7 +212,7 @@ class ExpertsGroupGemmContiguousNode:
     def __init__(
         self,
         custom_map,
-        recompute_fwd_gate_up=False,
+        recompute_moe_gate_up=False,
         dequant_input=False,
         group=None,
         name="experts_group_gemm_contiguous_node",
@@ -226,7 +226,7 @@ class ExpertsGroupGemmContiguousNode:
 
         Args:
             custom_map (CustomMapping): Custom mapping for the model.
-            recompute_fwd_gate_up (bool, optional): Whether to recompute forward gate up. Defaults to False.
+            recompute_moe_gate_up (bool, optional): Whether to recompute forward gate up. Defaults to False.
             dequant_input (bool, optional): Whether to dequantize input. Defaults to False.
             name (str, optional): Name of the node. Defaults to "experts_group_gemm_contiguous_node".
         """
@@ -235,7 +235,7 @@ class ExpertsGroupGemmContiguousNode:
         else:
             self.experts = [custom_map.experts[expert_id]]
         self.expert_id = expert_id
-        self.recompute_fwd_gate_up = recompute_fwd_gate_up
+        self.recompute_moe_gate_up = recompute_moe_gate_up
         self.dequant_input = dequant_input
         self.tokens_per_expert = None
         self.m_indices = None
@@ -884,7 +884,7 @@ class ExpertsGroupGemmContiguousNode:
         o1 = self.fwd_gate_up(
             hs_out, expert_w1, num_expert, tokens_per_expert, scale=scale
         )
-        if not self.recompute_fwd_gate_up:
+        if not self.recompute_moe_gate_up:
             self.o1 = o1
             clear_o1 = False
         else:
@@ -1026,7 +1026,7 @@ class ExpertsGroupGemmContiguousNode:
         expert_w1 = [
             x.up_gate_proj.weight for x in self.experts if x is not None
         ]
-        if self.recompute_fwd_gate_up:
+        if self.recompute_moe_gate_up:
             o1 = self.fwd_gate_up(
                 None, expert_w1, len(expert_w1), self.tokens_per_expert
             )
@@ -1072,7 +1072,7 @@ class ExpertsGroupGemmContiguousNode:
             x.up_gate_proj.weight for x in self.experts if x is not None
         ]
 
-        if self.recompute_fwd_gate_up:
+        if self.recompute_moe_gate_up:
             o1 = self.fwd_gate_up(
                 None, expert_w1, len(expert_w1), self.tokens_per_expert
             )

--- a/src/paddlefleet/transformer/moe/fusion_layer_utils.py
+++ b/src/paddlefleet/transformer/moe/fusion_layer_utils.py
@@ -235,10 +235,10 @@ class MlpNode:
         self,
         custom_map,
         num_experts_per_tok,
-        recompute_fwd_gate_up=False,
+        recompute_moe_gate_up=False,
         dequant_input=False,
-        use_expert_subbatch=False,
-        recompute_unzipped=False,
+        moe_expert_fusion=False,
+        recompute_moe_premute=False,
         tokens_zip_unique_add_subbatch_rows=None,
         use_forward_subbatch=False,
         backward_subbatch_rows=None,
@@ -249,19 +249,19 @@ class MlpNode:
         Constructor
         """
         self.token_dispatcher = custom_map.token_dispatcher
-        self.use_expert_subbatch = use_expert_subbatch
+        self.moe_expert_fusion = moe_expert_fusion
         self.experts = custom_map.experts
-        if recompute_unzipped:
-            assert use_expert_subbatch, (
-                "use_expert_subbatch must be enabled when recompute_unzipped = True"
+        if recompute_moe_premute:
+            assert moe_expert_fusion, (
+                "moe_expert_fusion must be enabled when recompute_moe_premute = True"
             )
-            assert recompute_fwd_gate_up, (
-                "recompute_fwd_gate_up must be enabled when recompute_unzipped = True"
+            assert recompute_moe_gate_up, (
+                "recompute_moe_gate_up must be enabled when recompute_moe_premute = True"
             )
             assert dequant_input, (
-                "dequant_input must be enabled with recompute_unzipped = True"
+                "dequant_input must be enabled with recompute_moe_premute = True"
             )
-        self.recompute_unzipped = recompute_unzipped
+        self.recompute_moe_premute = recompute_moe_premute
 
         self.use_forward_subbatch = use_forward_subbatch
         self.tokens_zip_unique_add_subbatch_rows = (
@@ -280,32 +280,32 @@ class MlpNode:
             )
 
         if backward_subbatch_rows is not None and backward_subbatch_rows > 0:
-            assert use_expert_subbatch, (
-                "use_expert_subbatch must be enabled when backward_subbatch_rows > 0"
+            assert moe_expert_fusion, (
+                "moe_expert_fusion must be enabled when backward_subbatch_rows > 0"
             )
             assert backward_subbatch_rows % FP8_ALIGN == 0, (
                 backward_subbatch_rows
             )
 
         if self.use_forward_subbatch:
-            assert use_expert_subbatch, (
-                "use_expert_subbatch must be enabled when use_forward_subbatch = True"
+            assert moe_expert_fusion, (
+                "moe_expert_fusion must be enabled when use_forward_subbatch = True"
             )
-            assert recompute_fwd_gate_up, (
-                "recompute_fwd_gate_up must be enabled when use_forward_subbatch = True"
+            assert recompute_moe_gate_up, (
+                "recompute_moe_gate_up must be enabled when use_forward_subbatch = True"
             )
             assert dequant_input, (
                 "dequant_input must be enabled when use_forward_subbatch = True"
             )
 
-        if self.use_expert_subbatch:
+        if self.moe_expert_fusion:
             raise NotImplementedError(
-                "use_expert_subbatch = True is not supported currently"
+                "moe_expert_fusion = True is not supported currently"
             )
         else:
             self.experts_group_gemm_node = ExpertsGroupGemmContiguousNode(
                 custom_map,
-                recompute_fwd_gate_up=recompute_fwd_gate_up,
+                recompute_moe_gate_up=recompute_moe_gate_up,
                 dequant_input=dequant_input,
                 backward_subbatch_rows=backward_subbatch_rows,
                 use_bf16_gemm_weight_grad=use_bf16_gemm_weight_grad,
@@ -336,7 +336,7 @@ class MlpNode:
         cached tensors
         """
         if self.experts_group_gemm_node is not None:
-            if self.use_expert_subbatch:
+            if self.moe_expert_fusion:
                 gemm_node_tensors = []
                 for gemm_node in self.experts_group_gemm_node:
                     gemm_node_tensors.extend(gemm_node.cached_tensors())
@@ -368,7 +368,7 @@ class MlpNode:
         """
         idx = 0
         if self.experts_group_gemm_node is not None:
-            if self.use_expert_subbatch:
+            if self.moe_expert_fusion:
                 for expert_id, gemm_node in enumerate(
                     self.experts_group_gemm_node
                 ):
@@ -436,7 +436,7 @@ class MlpNode:
         Returns:
             无返回值，直接修改了类实例中的变量。
         """
-        if self.use_expert_subbatch:
+        if self.moe_expert_fusion:
             for node in self.experts_group_gemm_node:
                 node.reset_state()
         else:
@@ -474,10 +474,10 @@ class MlpNode:
             topk=self.router_topk,
             num_experts=num_experts,
             tokens_per_expert=self.tokens_per_expert,
-            fill_output=not self.use_expert_subbatch,
+            fill_output=not self.moe_expert_fusion,
         )
         self.unzipped_probs = unzipped_probs
-        if self.use_expert_subbatch:
+        if self.moe_expert_fusion:
             unzipped_tokens = None
 
         if use_fp8_dispatch_a2a:
@@ -494,9 +494,9 @@ class MlpNode:
         if self.dispatched_indices.dtype is not dispatched_indices:
             dispatched_indices._clear_to_zero_allocation()
 
-        if self.use_expert_subbatch:
+        if self.moe_expert_fusion:
             raise NotImplementedError(
-                "use_expert_subbatch = True is not supported currently"
+                "moe_expert_fusion = True is not supported currently"
             )
         else:
             if not use_fp8_dispatch_a2a:
@@ -551,13 +551,13 @@ class MlpNode:
             top_k=self.router_topk,
             num_experts=len(self.tokens_per_expert),
             tokens_per_expert=self.tokens_per_expert,
-            fill_output=not self.use_expert_subbatch,
+            fill_output=not self.moe_expert_fusion,
         )
         hidden_states_out_grad._record_stream()
 
-        if self.use_expert_subbatch:
+        if self.moe_expert_fusion:
             raise NotImplementedError(
-                "use_expert_subbatch = True is not supported currently"
+                "moe_expert_fusion = True is not supported currently"
             )
         else:
             hidden_states_out_grad._clear_to_zero_allocation()
@@ -595,10 +595,10 @@ class FusionMoePyLayer(paddle.autograd.PyLayer):
         custom_map,
         num_experts_per_tok,
         use_fp8_mlp=True,
-        recompute_fwd_gate_up=False,
+        recompute_moe_gate_up=False,
         dequant_input=True,
-        use_expert_subbatch=False,
-        use_recompute_unzipped=False,
+        moe_expert_fusion=False,
+        recompute_moe_premute=False,
         tokens_zip_unique_add_subbatch_rows=None,
         use_forward_subbatch=False,
         backward_subbatch_rows=None,
@@ -621,10 +621,10 @@ class FusionMoePyLayer(paddle.autograd.PyLayer):
         ctx.node = MlpNode(
             custom_map,
             num_experts_per_tok,
-            recompute_fwd_gate_up=recompute_fwd_gate_up,
+            recompute_moe_gate_up=recompute_moe_gate_up,
             dequant_input=dequant_input,
-            use_expert_subbatch=use_expert_subbatch,
-            recompute_unzipped=use_recompute_unzipped,
+            moe_expert_fusion=moe_expert_fusion,
+            recompute_moe_premute=recompute_moe_premute,
             tokens_zip_unique_add_subbatch_rows=tokens_zip_unique_add_subbatch_rows,
             use_forward_subbatch=use_forward_subbatch,
             backward_subbatch_rows=backward_subbatch_rows,

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -191,6 +191,15 @@ class MoELayer(nn.Layer):
                     f"Unsupported moe_token_dispatcher_type {self.moe_token_dispatcher_type}"
                 )
 
+        self.recompute_moe_gate_up = (
+            self.config.recompute_granularity == "selective"
+            and "moe_gate_up" in self.config.recompute_modules
+        )
+        self.recompute_moe_premute = (
+            self.config.recompute_granularity == "selective"
+            and "moe_premute" in self.config.recompute_modules
+        )
+
         if self.expert_model_parallel_size > 1:
             self.is_mp_moe = False
             self.is_ep_moe = True
@@ -340,6 +349,8 @@ class MoELayer(nn.Layer):
             self,
             self.num_experts_per_tok,
             use_fp8_mlp=self.fp8,
+            recompute_moe_gate_up=self.recompute_moe_gate_up,
+            recompute_moe_premute=self.recompute_moe_premute,
             fp8_dispatched_handle=fp8_dispatched_handle,
             use_bf16_gemm_weight_grad=not self.fp8_wgrad,
         )

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -244,6 +244,12 @@ class TransformerConfig(ModelParallelConfig):
     the number of transformer layers to recompute within each pipeline stage.  Must be None for
     'selective' activation checkpointing."""
 
+    recompute_modules: list[str] | dict = None
+    """The submodules to recompute.
+    list: contains all submodule need recompute
+    dict: keys contains all submodule need recompute, value means submodule in which layers need recompute
+    """
+
     ####################
     # MoE related
     ####################
@@ -521,6 +527,34 @@ class TransformerConfig(ModelParallelConfig):
             self.moe_layer_freq = [0] * self.first_k_dense_replace + [1] * (
                 self.num_hidden_layers - self.first_k_dense_replace
             )
+        if self.recompute_granularity == "":
+            self.recompute_granularity = None
+
+        # recompute config check
+        if self.recompute_granularity is not None:
+            assert self.recompute_granularity in ["full", "selective"], (
+                "recompute_granularity must be one of full and selective"
+            )
+            if self.recompute_granularity == "full":
+                assert self.recompute_method in [
+                    "block",
+                    "first_n",
+                    "uniform",
+                ], (
+                    "when recompute_granularity=full, recompute_method must be one of block, first_n and uniform"
+                )
+                assert self.recompute_num_layers is not None, (
+                    "when recompute_granularity=full, recompute_num_layers mustn't be None"
+                )
+            elif self.recompute_granularity == "selective":
+                assert self.recompute_method in ["block", "first_n", None], (
+                    "when recompute_granularity=selective, recompute_method must be one of block and first_n"
+                )
+                assert self.recompute_modules is not None
+            else:
+                raise ValueError(
+                    "recompute_granularity must be one of full and selective"
+                )
 
         if self.output_layer_init_method is None:
             self.output_layer_init_method = scaled_init_method_normal(

--- a/src/paddlefleet/transformer/transformer_layer.py
+++ b/src/paddlefleet/transformer/transformer_layer.py
@@ -24,7 +24,6 @@ import paddle
 from paddle import Tensor, nn
 from paddle.distributed.fleet.utils import recompute
 
-from paddlefleet import tensor_parallel
 from paddlefleet.process_groups_config import ProcessGroupCollection
 from paddlefleet.recompute_utils import need_full_recompute
 from paddlefleet.spec_utils import LayerSpec, build_layer
@@ -203,22 +202,23 @@ class TransformerLayer(nn.Layer):
         self.mlp_bda = build_layer(sublayers_spec.mlp_bda)
 
         self.full_recompute = False
-        if self.config.recompute_granularity != "full":
-            self.full_recompute = need_full_recompute(
-                self.layer_number, self.config
-            )
-
         self.recompute_input_layernorm = False
         self.recompute_post_attention_layernorm = False
         self.recompute_mlp = False
-        if self.config.recompute_granularity == "selective":
-            if "layernorm" in self.config.recompute_modules:
+        if self.config.recompute_granularity == "full":
+            self.full_recompute = need_full_recompute(
+                self.layer_number, self.config
+            )
+        elif self.config.recompute_granularity == "selective":
+            if "norm" in self.config.recompute_modules:
+                if not isinstance(self.input_layernorm, IdentityOp):
+                    self.recompute_input_layernorm = True
+
                 if not isinstance(self.post_attention_layernorm, IdentityOp):
                     self.recompute_post_attention_layernorm = True
 
             if "mlp" in self.config.recompute_modules:
-                if not isinstance(self.mlp, MoELayer):
-                    self.recompute_mlp = True
+                self.recompute_mlp = True
 
     def forward(
         self,
@@ -347,10 +347,7 @@ class TransformerLayer(nn.Layer):
 
         # Optional Input Layer norm
         if self.recompute_input_layernorm:
-            self.input_layernorm_checkpoint = (
-                tensor_parallel.CheckpointWithoutOutput()
-            )
-            input_layernorm_output = self.input_layernorm_checkpoint.checkpoint(
+            input_layernorm_output = recompute(
                 self.input_layernorm, hidden_states
             )
         else:
@@ -367,13 +364,6 @@ class TransformerLayer(nn.Layer):
             attention_bias=attention_bias,
             packed_seq_params=packed_seq_params,
         )
-
-        if self.recompute_input_layernorm:
-            # discard the output of the input layernorm and register the recompute
-            # as a gradient hook of attention_output_with_bias[0]
-            self.input_layernorm_checkpoint.discard_output_and_register_recompute(
-                attention_output_with_bias[0]
-            )
 
         with paddle.enable_grad():
             hidden_states = self.self_attn_bda(
@@ -424,13 +414,8 @@ class TransformerLayer(nn.Layer):
 
         # Optional Layer norm post the cross-attention.
         if self.recompute_post_attention_layernorm:
-            self.pre_mlp_norm_checkpoint = (
-                tensor_parallel.CheckpointWithoutOutput()
-            )
-            post_attention_layernorm_output = (
-                self.pre_mlp_norm_checkpoint.checkpoint(
-                    self.post_attention_layernorm, hidden_states
-                )
+            post_attention_layernorm_output = recompute(
+                self.post_attention_layernorm, hidden_states
             )
         else:
             post_attention_layernorm_output = self.post_attention_layernorm(
@@ -438,18 +423,23 @@ class TransformerLayer(nn.Layer):
             )
 
         if self.recompute_mlp:
-            mlp_output_with_bias = tensor_parallel.checkpoint(
-                self.mlp, False, post_attention_layernorm_output
+
+            def recompute_handler(post_attention_layernorm_output):
+                mlp_output, bias = self.mlp(post_attention_layernorm_output)
+                if bias is None:
+                    return mlp_output
+                return mlp_output, bias
+
+            mlp_output_with_bias = recompute(
+                recompute_handler, post_attention_layernorm_output
             )
+            if not isinstance(mlp_output_with_bias, tuple):
+                mlp_output_with_bias = (
+                    mlp_output_with_bias,
+                    None,
+                )  # bias is None
         else:
             mlp_output_with_bias = self.mlp(post_attention_layernorm_output)
-
-        if self.recompute_post_attention_layernorm:
-            # discard the output of the pre-mlp layernorm and register the recompute
-            # as a gradient hook of mlp_output_with_bias[0]
-            self.pre_mlp_norm_checkpoint.discard_output_and_register_recompute(
-                mlp_output_with_bias[0]
-            )
 
         with paddle.enable_grad():
             hidden_states = self.mlp_bda(

--- a/src/paddlefleet/transformer/transformer_layer.py
+++ b/src/paddlefleet/transformer/transformer_layer.py
@@ -18,16 +18,16 @@ from __future__ import annotations
 import logging
 from collections import OrderedDict
 from dataclasses import dataclass, field
-from itertools import chain
 from typing import TYPE_CHECKING
 
 import paddle
 from paddle import Tensor, nn
+from paddle.distributed.fleet.utils import recompute
 
 from paddlefleet import tensor_parallel
 from paddlefleet.process_groups_config import ProcessGroupCollection
+from paddlefleet.recompute_utils import need_full_recompute
 from paddlefleet.spec_utils import LayerSpec, build_layer
-from paddlefleet.tensor_parallel import checkpoint
 from paddlefleet.transformer.identity_op import IdentityFuncOp, IdentityOp
 from paddlefleet.transformer.mlp import MLP
 from paddlefleet.transformer.moe.moe_layer import MoELayer
@@ -38,76 +38,6 @@ if TYPE_CHECKING:
     from paddlefleet.transformer.transformer_config import TransformerConfig
 
 logger = logging.getLogger(__name__)
-
-
-def need_full_recompute(layer_number, config):
-    if config.recompute_granularity == "full":
-        assert config.recompute_method in [
-            "uniform",
-            "first_n",
-            "block",
-            "manual",
-        ], "recompute_method must be one of uniform, first_n, block, manual"
-        if config.recompute_method == "uniform":
-            assert config.recompute_num_layers == 1, (
-                "don't support recompute_method=uniform wihile recompute_num_layers != 1"
-            )
-            return True
-        elif config.recompute_method == "first_n":
-            assert config.recompute_num_layers is not None, (
-                "recompute_num_layers cannot be none"
-            )
-            vpp_size = (
-                config.virtual_pipeline_model_parallel_size
-                if config.virtual_pipeline_model_parallel_size
-                else 1
-            )
-            parallel_size = config.pipeline_model_parallel_size * vpp_size
-            assert config.num_hidden_layers % parallel_size == 0, (
-                "num_hidden_layers must be divided by parallel_size"
-            )
-            chunk_size = int(config.num_hidden_layers / parallel_size)
-            num_layers_in_each_stage = (
-                config.num_hidden_layers / config.pipeline_model_parallel_size
-            )
-            assert config.recompute_num_layers <= num_layers_in_each_stage, (
-                "recompute_num_layers cannot be greater than num_layers_in_each_stage"
-            )
-            if vpp_size > 1:
-                layers = range(config.num_hidden_layers)
-                chunks = [
-                    layers[i * chunk_size : (i + 1) * chunk_size]
-                    for i in range(0, len(layers), chunk_size)
-                ]
-                recompute_layers = []
-                for pp_stage in range(config.pipeline_model_parallel_size):
-                    recompute_layers_in_curr_stage = list(
-                        chain.from_iterable(
-                            chunks[
-                                pp_stage :: config.pipeline_model_parallel_size
-                            ]
-                        )
-                    )[: config.recompute_num_layers]
-                    recompute_layers += recompute_layers_in_curr_stage
-            else:
-                recompute_layers = []
-                layers = list(range(config.num_hidden_layers))
-                if config.pipeline_model_parallel_size > 1:
-                    for recompute_layer_id in range(
-                        config.recompute_num_layers
-                    ):
-                        recompute_layers_in_curr_stage = list(
-                            layers[recompute_layer_id::chunk_size]
-                        )
-                        recompute_layers += recompute_layers_in_curr_stage
-                else:
-                    recompute_layers = range(
-                        config.pipeline_model_parallel_size
-                        * config.recompute_num_layers
-                    )
-            if layer_number in recompute_layers:
-                return True
-    return False
 
 
 @dataclass
@@ -272,19 +202,21 @@ class TransformerLayer(nn.Layer):
         # [Layer 9: BiasDropoutFusion]
         self.mlp_bda = build_layer(sublayers_spec.mlp_bda)
 
-        self.full_recompute = need_full_recompute(
-            self.layer_number, self.config
-        )
+        self.full_recompute = False
+        if self.config.recompute_granularity != "full":
+            self.full_recompute = need_full_recompute(
+                self.layer_number, self.config
+            )
 
         self.recompute_input_layernorm = False
         self.recompute_post_attention_layernorm = False
         self.recompute_mlp = False
         if self.config.recompute_granularity == "selective":
-            if "layernorm" in self.config.recompute_layers:
+            if "layernorm" in self.config.recompute_modules:
                 if not isinstance(self.post_attention_layernorm, IdentityOp):
                     self.recompute_post_attention_layernorm = True
 
-            if "mlp" in self.config.recompute_layers:
+            if "mlp" in self.config.recompute_modules:
                 if not isinstance(self.mlp, MoELayer):
                     self.recompute_mlp = True
 
@@ -316,7 +248,7 @@ class TransformerLayer(nn.Layer):
             rotary_pos_emb = dict_args.get("rotary_pos_emb", None)
             attention_bias = dict_args.get("attention_bias", None)
             packed_seq_params = dict_args.get("packed_seq_params", None)
-            outputs = checkpoint(
+            outputs = recompute(
                 self._forward_impl,
                 hidden_states=hidden_states,
                 attention_mask=attention_mask,

--- a/tests/multi_card_tests/pipeline_parallel/test_gpt_pp_with_recompute.py
+++ b/tests/multi_card_tests/pipeline_parallel/test_gpt_pp_with_recompute.py
@@ -198,6 +198,7 @@ class TestPPWithRecompute(unittest.TestCase):
             num_hidden_layers=4,
             hidden_size=512,
             num_attention_heads=4,
+            first_k_dense_replace=1,
             intermediate_size=1024,
             normalization="RMSNorm",
             hidden_dropout_prob=0.0,

--- a/tests/single_card_tests/model/test_gpt_model_recompute.py
+++ b/tests/single_card_tests/model/test_gpt_model_recompute.py
@@ -1,0 +1,270 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import functools
+import random
+import subprocess
+import unittest
+
+import numpy as np
+import paddle
+from paddle.distributed import fleet
+
+# from tests.unit_tests.test_utilities import Utils
+import paddlefleet.parallel_state as ps
+
+# from paddlefleet.tensor_parallel.random import model_parallel_cuda_manual_seed
+from paddlefleet.gpt_builders import gpt_builder
+from paddlefleet.models.gpt import GPTConfig
+from paddlefleet.pipeline_parallel import NoPipelineParallel
+
+
+def get_gpu_models_via_nvidia_smi():
+    try:
+        output = subprocess.check_output(
+            "nvidia-smi --query-gpu=name --format=csv,noheader", shell=True
+        )
+        models = output.decode().strip().split("\n")
+        return models
+    except Exception as e:
+        return ["Unknown"]
+
+
+def judge_machine_type():
+    if not paddle.is_compiled_with_cuda():
+        return "No CUDA GPU"
+    models = get_gpu_models_via_nvidia_smi()
+    for model in models:
+        name = model.upper().replace("NVIDIA", "")
+        if "V" in name:
+            return "V"
+        elif "H" in name:
+            return "H"
+
+
+result = judge_machine_type()
+print("Your machine type is:", result)
+
+
+class TestGPTModel(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """Initialize distributed environment, only need to execute once"""
+        seed = 46
+        random.seed(seed)
+        np.random.seed(seed)
+        paddle.manual_seed(seed)
+        strategy = fleet.DistributedStrategy()
+        strategy.hybrid_configs = {
+            "dp_degree": 1,
+            "mp_degree": 1,
+            "pp_degree": 1,
+            "sharding_degree": 1,
+            "sep_degree": 1,
+            "cp_degree": 1,
+            "ep_degree": 1,
+            "moe_sharding_degree": 1,
+            "order": [
+                "sharding",
+                "moe_sharding",
+                "pp",
+                "sep",
+                "cp",
+                "dp",
+                "ep",
+                "mp",
+            ],
+        }
+        fleet.init(is_collective=True, strategy=strategy)
+        hcg = fleet.get_hybrid_communicate_group()
+        ps.initialize_model_parallel(hcg)
+
+    def setUp(self):
+        """Reset random seed before each test case"""
+        seed = 46
+        random.seed(seed)
+        np.random.seed(seed)
+        paddle.manual_seed(seed)
+        fleet_env = fleet.fleet
+        self.strategy = fleet_env._user_defined_strategy
+
+    def _create_transformer_configs(self):
+        """Create multiple different transformer configurations for testing"""
+        configs = []
+
+        config1 = GPTConfig(
+            num_hidden_layers=2,
+            hidden_size=512,
+            vocab_size=100,
+            max_sequence_length=64,
+            num_attention_heads=4,
+            intermediate_size=1024,
+            normalization="RMSNorm",
+            hidden_dropout_prob=0.0,
+            attention_dropout=0.0,
+            n_routed_experts=8,
+            use_bias=False,
+            rotary_percent=1.0,
+            rotary_base=10000,
+            rope_scaling=1.0,
+            moe_intermediate_size=1024,
+            moe_token_dispatcher_type="alltoall",
+            n_shared_experts=1,
+            init_method=functools.partial(
+                paddle.nn.init.xavier_uniform_, gain=1.0
+            ),
+            output_layer_init_method=functools.partial(
+                paddle.nn.init.xavier_uniform_, gain=1.0
+            ),
+            share_embeddings_and_output_weights=True,
+            use_qk_norm=True,
+            recompute_granularity="selective",
+            recompute_modules=["core_attn"],
+        )
+        config1.name = "config_1"
+        configs.append(config1)
+
+        return configs
+
+    def _create_gpt_model(self, config):
+        """Create GPT model based on given configuration"""
+        self.gpt_model = gpt_builder(config, num_stages=1)
+        return self.gpt_model
+
+    def _get_expected_values(self, config_name, machine_type):
+        """Return expected values based on configuration name and machine type"""
+        # Define expected values for different configurations on different machines
+        expectations = {
+            "config_1": {
+                "H": {
+                    "loss": 5.153511047363281,
+                    "grad_norm": 11.278331756591797,
+                },
+                "V": {
+                    "loss": 5.212523937225342,
+                    "grad_norm": 6.811282634735107,
+                },
+            },
+        }
+
+        return expectations.get(config_name, {}).get(machine_type, {})
+
+    def test_multiple_configurations(self):
+        """Test multiple transformer configurations"""
+        configs = self._create_transformer_configs()
+        machine_type = judge_machine_type()
+
+        for config in configs:
+            with self.subTest(config_name=config.name):
+                # Explicitly call setUp to ensure initialization for each config
+                self.setUp()
+
+                print(f"\nTesting configuration: {config.name}")
+                print(
+                    f"hidden_size: {config.hidden_size}, num_layers: {config.num_hidden_layers}"
+                )
+
+                # Create and test model
+                gpt_model = self._create_gpt_model(config)
+
+                # Run forward and backward propagation
+                sequence_length = config.max_sequence_length
+                micro_batch_size = 1
+
+                data = list(range(sequence_length))
+                input_ids = paddle.to_tensor(data, dtype=paddle.int64).repeat(
+                    (micro_batch_size, 1)
+                )
+                position_ids = paddle.to_tensor(
+                    data, dtype=paddle.int64
+                ).repeat((micro_batch_size, 1))
+                attention_mask = paddle.ones(
+                    (micro_batch_size, 1, sequence_length, sequence_length),
+                    dtype=bool,
+                )
+                labels = paddle.to_tensor(
+                    list(range(1, sequence_length + 1)), dtype=paddle.int64
+                ).repeat((micro_batch_size, 1))
+
+                data = (
+                    {
+                        "input_ids": [input_ids],
+                        "position_ids": [position_ids],
+                        "attention_mask": [attention_mask],
+                    },
+                    [labels],
+                )
+
+                gpt_pipe_model = NoPipelineParallel(
+                    self.gpt_model, self.strategy
+                )
+                loss = gpt_pipe_model.forward_backward_pipeline(data)
+
+                for name, param in self.gpt_model.named_parameters():
+                    # 计算 L2 范数
+                    if param.grad is None:
+                        print(f"{name}: 0.000000, 0.000000")
+                        continue
+                    grad_norm = param.grad.detach().norm().item()
+                    grad_abssum = param.grad.detach().abs().sum().item()
+                    print(f"{name}: {grad_norm:.6f}, {grad_abssum:.6f}")
+                    if name == "0.embedding.embed_tokens.weight":
+                        embed_tokens_grad_norm = grad_norm
+
+                print(f"{config.name} loss: {loss.item()}")
+
+                # Get expected values
+                print("machine_type: ", machine_type)
+                expected_values = self._get_expected_values(
+                    config.name, machine_type
+                )
+
+                # If expected values exist, verify them
+                if expected_values.get("loss") is not None:
+                    self.assertAlmostEqual(
+                        loss.item(),
+                        expected_values["loss"],
+                        places=5,
+                        msg=f"{config.name} loss not equal ({loss.item()} != {expected_values['loss']})",
+                    )
+                else:
+                    print(
+                        f"Note: Expected loss value for {config.name} is not set, current loss: {loss.item()}"
+                    )
+
+                if embed_tokens_grad_norm is not None:
+                    print(
+                        f"{config.name} embed_tokens_grad_norm: {embed_tokens_grad_norm}"
+                    )
+
+                    if expected_values.get("grad_norm") is not None:
+                        self.assertAlmostEqual(
+                            embed_tokens_grad_norm,
+                            expected_values["grad_norm"],
+                            places=5,
+                            msg=f"{config.name} grad norm not equal ({embed_tokens_grad_norm} != {expected_values['grad_norm']})",
+                        )
+                    else:
+                        print(
+                            f"Note: Expected grad_norm value for {config.name} is not set, current grad_norm: {embed_tokens_grad_norm}"
+                        )
+                else:
+                    print(
+                        f"Warning: Failed to get word_embeddings gradient for {config.name}"
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/model/test_gpt_model_recompute.py
+++ b/tests/single_card_tests/model/test_gpt_model_recompute.py
@@ -113,6 +113,7 @@ class TestGPTModel(unittest.TestCase):
             intermediate_size=1024,
             normalization="RMSNorm",
             hidden_dropout_prob=0.0,
+            first_k_dense_replace=1,
             attention_dropout=0.0,
             n_routed_experts=8,
             use_bias=False,
@@ -131,7 +132,7 @@ class TestGPTModel(unittest.TestCase):
             share_embeddings_and_output_weights=True,
             use_qk_norm=True,
             recompute_granularity="selective",
-            recompute_modules=["core_attn"],
+            recompute_modules=["core_attn", "norm", "mlp"],
         )
         config1.name = "config_1"
         configs.append(config1)
@@ -149,12 +150,12 @@ class TestGPTModel(unittest.TestCase):
         expectations = {
             "config_1": {
                 "H": {
-                    "loss": 5.153511047363281,
-                    "grad_norm": 11.278331756591797,
+                    "loss": 5.668004035949707,
+                    "grad_norm": 6.991505146026611,
                 },
                 "V": {
-                    "loss": 5.212523937225342,
-                    "grad_norm": 6.811282634735107,
+                    "loss": 5.3251447677612305,
+                    "grad_norm": 5.3691630363464355,
                 },
             },
         }

--- a/tests/single_card_tests/test_need_recompute.py
+++ b/tests/single_card_tests/test_need_recompute.py
@@ -14,11 +14,11 @@
 
 import unittest
 
+from paddlefleet.recompute_utils import need_full_recompute
 from paddlefleet.transformer.transformer_config import TransformerConfig
-from paddlefleet.transformer.transformer_layer import need_full_recompute
 
 
-class TestSelectiveRescompute(unittest.TestCase):
+class TestNeedRescompute(unittest.TestCase):
     def test_recompute_no_pp(self):
         config_1 = TransformerConfig(
             num_hidden_layers=8,
@@ -57,6 +57,25 @@ class TestSelectiveRescompute(unittest.TestCase):
         }
         for layer_id, res in res_2.items():
             assert need_full_recompute(layer_id, config_2) == res
+
+        config_3 = TransformerConfig(
+            num_hidden_layers=8,
+            recompute_granularity="full",
+            recompute_method="block",
+            recompute_num_layers=4,
+        )
+        res_3 = {
+            0: True,
+            1: True,
+            2: True,
+            3: True,
+            4: False,
+            5: False,
+            6: False,
+            7: False,
+        }
+        for layer_id, res in res_3.items():
+            assert need_full_recompute(layer_id, config_3) == res
 
     def test_recompute_with_pp(self):
         config_1 = TransformerConfig(
@@ -98,6 +117,49 @@ class TestSelectiveRescompute(unittest.TestCase):
         }
         for layer_id, res in res_2.items():
             assert need_full_recompute(layer_id, config_2) == res
+
+        config_3 = TransformerConfig(
+            num_hidden_layers=8,
+            pipeline_model_parallel_size=4,
+            recompute_granularity="full",
+            recompute_method="block",
+            recompute_num_layers=1,
+        )
+        res_3 = {
+            0: True,
+            1: False,
+            2: True,
+            3: False,
+            4: True,
+            5: False,
+            6: True,
+            7: False,
+        }
+        for layer_id, res in res_3.items():
+            assert need_full_recompute(layer_id, config_3) == res
+
+        config_4 = TransformerConfig(
+            num_hidden_layers=9,
+            pipeline_model_parallel_size=4,
+            num_layers_in_first_pipeline_stage=2,
+            num_layers_in_last_pipeline_stage=1,
+            recompute_granularity="full",
+            recompute_method="block",
+            recompute_num_layers=1,
+        )
+        res_4 = {
+            1: False,
+            2: False,
+            3: True,
+            4: False,
+            5: False,
+            6: True,
+            7: False,
+            8: True,
+            9: False,
+        }
+        for layer_id, res in res_3.items():
+            assert need_full_recompute(layer_id, config_3) == res
 
     def test_recompute_with_vpp(self):
         config_1 = TransformerConfig(
@@ -141,6 +203,27 @@ class TestSelectiveRescompute(unittest.TestCase):
         }
         for layer_id, res in res_2.items():
             assert need_full_recompute(layer_id, config_2) == res
+
+        config_3 = TransformerConfig(
+            num_hidden_layers=8,
+            pipeline_model_parallel_size=2,
+            virtual_pipeline_model_parallel_size=4,
+            recompute_granularity="full",
+            recompute_method="block",
+            recompute_num_layers=1,
+        )
+        res_3 = {
+            0: True,
+            1: True,
+            2: True,
+            3: True,
+            4: True,
+            5: True,
+            6: True,
+            7: True,
+        }
+        for layer_id, res in res_3.items():
+            assert need_full_recompute(layer_id, config_3) == res
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
添加recompute_modules选项
添加block模式recompute选层策略，每个model_chunk中选择一定数量的层recompute
以及attn、norm、mlp模块的recompute和单测