### PR TITLE
Add `third_party/DeepGEMM/third-party/cutlass/include` in `MANIFEST.in`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,4 @@ include build_utils.py
 graft third_party/DeepGEMM
 prune third_party/DeepGEMM/deep_gemm_cpp.egg-info
 prune third_party/DeepGEMM/build
+graft third_party/DeepGEMM/third-party/cutlass/include

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,4 +4,3 @@ include build_utils.py
 graft third_party/DeepGEMM
 prune third_party/DeepGEMM/deep_gemm_cpp.egg-info
 prune third_party/DeepGEMM/build
-graft third_party/DeepGEMM/third-party/cutlass/include

--- a/build_backend.py
+++ b/build_backend.py
@@ -14,35 +14,7 @@
 
 from setuptools import build_meta as orig
 
-from build_utils import (
-    Artifact,
-    EcosystemLibrary,
-    check_submodule_updated,
-    create_symlink,
-    remove_path,
-)
-
-
-def prepare_deepgemm(lib: EcosystemLibrary) -> None:
-    """Pre-build hook for DeepGEMM: Links CUTLASS headers."""
-    cutlass_root = lib.source_dir / "third-party" / "cutlass" / "include"
-    target_include_dir = lib.source_dir / "deep_gemm" / "include"
-    target_include_dir.mkdir(parents=True, exist_ok=True)
-
-    links = {
-        cutlass_root / "cutlass": target_include_dir / "cutlass",
-        cutlass_root / "cute": target_include_dir / "cute",
-    }
-    for src, dst in links.items():
-        create_symlink(src, dst)
-
-
-def cleanup_deepgemm(lib: EcosystemLibrary) -> None:
-    """Cleanup hook for DeepGEMM: Removes linked headers."""
-    base_include = lib.source_dir / "deep_gemm" / "include"
-    remove_path(base_include / "cute")
-    remove_path(base_include / "cutlass")
-
+from build_utils import Artifact, EcosystemLibrary, check_submodule_updated
 
 LIBRARIES: list[EcosystemLibrary] = [
     EcosystemLibrary(
@@ -53,8 +25,6 @@ LIBRARIES: list[EcosystemLibrary] = [
             Artifact("deep_gemm", "deep_gemm"),
             Artifact("deep_gemm_cpp", "deep_gemm_cpp"),
         ],
-        pre_build_func=prepare_deepgemm,
-        cleanup_func=cleanup_deepgemm,
     ),
 ]
 
@@ -64,12 +34,6 @@ def _prepare_ecosystem(use_symlinks: bool):
     for lib in LIBRARIES:
         lib.build()
         lib.install(use_symlinks=use_symlinks)
-
-
-def _cleanup_ecosystem():
-    """Cleans up all registered libraries."""
-    for lib in LIBRARIES:
-        lib.cleanup()
 
 
 def get_requires_for_build_wheel(config_settings=None):
@@ -118,5 +82,4 @@ def build_editable(
 
 def build_sdist(sdist_directory, config_settings=None):
     check_submodule_updated()
-    _cleanup_ecosystem()
     return orig.build_sdist(sdist_directory, config_settings)

--- a/build_backend.py
+++ b/build_backend.py
@@ -14,7 +14,35 @@
 
 from setuptools import build_meta as orig
 
-from build_utils import Artifact, EcosystemLibrary, check_submodule_updated
+from build_utils import (
+    Artifact,
+    EcosystemLibrary,
+    check_submodule_updated,
+    create_symlink,
+    remove_path,
+)
+
+
+def prepare_deepgemm(lib: EcosystemLibrary) -> None:
+    """Pre-build hook for DeepGEMM: Links CUTLASS headers."""
+    cutlass_root = lib.source_dir / "third-party" / "cutlass" / "include"
+    target_include_dir = lib.source_dir / "deep_gemm" / "include"
+    target_include_dir.mkdir(parents=True, exist_ok=True)
+
+    links = {
+        cutlass_root / "cutlass": target_include_dir / "cutlass",
+        cutlass_root / "cute": target_include_dir / "cute",
+    }
+    for src, dst in links.items():
+        create_symlink(src, dst)
+
+
+def cleanup_deepgemm(lib: EcosystemLibrary) -> None:
+    """Cleanup hook for DeepGEMM: Removes linked headers."""
+    base_include = lib.source_dir / "deep_gemm" / "include"
+    remove_path(base_include / "cute")
+    remove_path(base_include / "cutlass")
+
 
 LIBRARIES: list[EcosystemLibrary] = [
     EcosystemLibrary(
@@ -25,6 +53,8 @@ LIBRARIES: list[EcosystemLibrary] = [
             Artifact("deep_gemm", "deep_gemm"),
             Artifact("deep_gemm_cpp", "deep_gemm_cpp"),
         ],
+        pre_build_func=prepare_deepgemm,
+        cleanup_func=cleanup_deepgemm,
     ),
 ]
 
@@ -34,6 +64,12 @@ def _prepare_ecosystem(use_symlinks: bool):
     for lib in LIBRARIES:
         lib.build()
         lib.install(use_symlinks=use_symlinks)
+
+
+def _cleanup_ecosystem():
+    """Cleans up all registered libraries."""
+    for lib in LIBRARIES:
+        lib.cleanup()
 
 
 def get_requires_for_build_wheel(config_settings=None):
@@ -82,4 +118,5 @@ def build_editable(
 
 def build_sdist(sdist_directory, config_settings=None):
     check_submodule_updated()
+    _cleanup_ecosystem()
     return orig.build_sdist(sdist_directory, config_settings)

--- a/build_utils.py
+++ b/build_utils.py
@@ -12,19 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import annotations
-
 import logging
-import os
 import shutil
 import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 logger = logging.getLogger(__name__)
 
@@ -42,13 +35,6 @@ def remove_path(path: Path) -> None:
             path.unlink()
 
 
-def create_symlink(src: Path, dst: Path) -> None:
-    """Creates a symlink from src to dst, overwriting dst if it exists."""
-    remove_path(dst)
-    logger.info(f"Symlinking {src} -> {dst}")
-    dst.symlink_to(src, target_is_directory=src.is_dir())
-
-
 def copy_path(src: Path, dst: Path) -> None:
     """Copies a path (file or directory) to dst, overwriting if it exists."""
     remove_path(dst)
@@ -57,6 +43,18 @@ def copy_path(src: Path, dst: Path) -> None:
         shutil.copytree(src, dst, symlinks=False)
     else:
         shutil.copy(src, dst)
+
+
+def create_symlink(src: Path, dst: Path) -> None:
+    """Creates a symlink from src to dst, overwriting dst if it exists."""
+    if not src.exists():
+        logger.warning(
+            f"Source path {src} does not exist. Skip create symlink."
+        )
+        return
+    remove_path(dst)
+    logger.info(f"Symlinking {src} -> {dst}")
+    dst.symlink_to(src, target_is_directory=src.is_dir())
 
 
 @dataclass
@@ -79,31 +77,34 @@ class EcosystemLibrary:
     """
 
     def __init__(
-        self,
-        name: str,
-        source_rel_path: str,
-        artifacts: list[Artifact],
-        pre_build_func: Callable[[EcosystemLibrary], None] | None = None,
-        cleanup_func: Callable[[EcosystemLibrary], None] | None = None,
-        extra_env: dict[str, str] | None = None,
+        self, name: str, source_rel_path: str, artifacts: list[Artifact]
     ):
         self.name = name
         self.source_dir = ROOT_DIR / source_rel_path
         # Install into a subdirectory named after the library
         self.install_dir = THIRD_PARTY_INSTALL_TEMP / name
         self.artifacts = artifacts
-        self._pre_build_func = pre_build_func
-        self._cleanup_func = cleanup_func
-        self._extra_env = extra_env or {}
 
     def build(self) -> None:
         """Builds the library."""
         logger.info(f"Building ecosystem library: {self.name}")
         self.install_dir.mkdir(parents=True, exist_ok=True)
 
-        if self._pre_build_func:
-            logger.info(f"Running pre-build hook for {self.name}")
-            self._pre_build_func(self)
+        # Special pre-build step for DeepGEMM: link CUTLASS headers into deep_gemm/include
+        if self.name.lower() == "deepgemm":
+            cutlass_root = (
+                self.source_dir / "third-party" / "cutlass" / "include"
+            )
+            target_include_dir = self.source_dir / "deep_gemm" / "include"
+            target_include_dir.mkdir(parents=True, exist_ok=True)
+
+            links = {
+                cutlass_root / "cutlass": target_include_dir / "cutlass",
+                cutlass_root / "cute": target_include_dir / "cute",
+            }
+
+            for src, dst in links.items():
+                create_symlink(src, dst)
 
         # Default build command: python setup.py install --install-lib <install_dir>
         cmd = [
@@ -116,9 +117,7 @@ class EcosystemLibrary:
         ]
 
         try:
-            _env = os.environ.copy()
-            _env.update(self._extra_env)
-            subprocess.check_call(cmd, cwd=self.source_dir, env=_env)
+            subprocess.check_call(cmd, cwd=self.source_dir)
         except subprocess.CalledProcessError as e:
             logger.error(f"Failed to build {self.name}: {e}")
             raise
@@ -131,12 +130,6 @@ class EcosystemLibrary:
             src = self.install_dir / artifact.source_rel_path
             dst = OPS_DIR / artifact.target_name
             install_strategy(src, dst)
-
-    def cleanup(self) -> None:
-        """Executes injected cleanup logic."""
-        if self._cleanup_func:
-            logger.info(f"Running cleanup hook for {self.name}")
-            self._cleanup_func(self)
 
 
 def check_submodule_updated():

--- a/build_utils.py
+++ b/build_utils.py
@@ -12,12 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import logging
+import os
 import shutil
 import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +49,16 @@ def create_symlink(src: Path, dst: Path) -> None:
     dst.symlink_to(src, target_is_directory=src.is_dir())
 
 
+def copy_path(src: Path, dst: Path) -> None:
+    """Copies a path (file or directory) to dst, overwriting if it exists."""
+    remove_path(dst)
+    logger.info(f"Copying {src} -> {dst}")
+    if src.is_dir():
+        shutil.copytree(src, dst, symlinks=False)
+    else:
+        shutil.copy(src, dst)
+
+
 @dataclass
 class Artifact:
     """
@@ -62,34 +79,31 @@ class EcosystemLibrary:
     """
 
     def __init__(
-        self, name: str, source_rel_path: str, artifacts: list[Artifact]
+        self,
+        name: str,
+        source_rel_path: str,
+        artifacts: list[Artifact],
+        pre_build_func: Callable[[EcosystemLibrary], None] | None = None,
+        cleanup_func: Callable[[EcosystemLibrary], None] | None = None,
+        extra_env: dict[str, str] | None = None,
     ):
         self.name = name
         self.source_dir = ROOT_DIR / source_rel_path
         # Install into a subdirectory named after the library
         self.install_dir = THIRD_PARTY_INSTALL_TEMP / name
         self.artifacts = artifacts
+        self._pre_build_func = pre_build_func
+        self._cleanup_func = cleanup_func
+        self._extra_env = extra_env or {}
 
     def build(self) -> None:
         """Builds the library."""
         logger.info(f"Building ecosystem library: {self.name}")
         self.install_dir.mkdir(parents=True, exist_ok=True)
 
-        # Special pre-build step for DeepGEMM: link CUTLASS headers into deep_gemm/include
-        if self.name.lower() == "deepgemm":
-            cutlass_root = (
-                self.source_dir / "third-party" / "cutlass" / "include"
-            )
-            target_include_dir = self.source_dir / "deep_gemm" / "include"
-            target_include_dir.mkdir(parents=True, exist_ok=True)
-
-            links = {
-                cutlass_root / "cutlass": target_include_dir / "cutlass",
-                cutlass_root / "cute": target_include_dir / "cute",
-            }
-
-            for src, dst in links.items():
-                create_symlink(src, dst)
+        if self._pre_build_func:
+            logger.info(f"Running pre-build hook for {self.name}")
+            self._pre_build_func(self)
 
         # Default build command: python setup.py install --install-lib <install_dir>
         cmd = [
@@ -102,29 +116,27 @@ class EcosystemLibrary:
         ]
 
         try:
-            subprocess.check_call(cmd, cwd=self.source_dir)
+            _env = os.environ.copy()
+            _env.update(self._extra_env)
+            subprocess.check_call(cmd, cwd=self.source_dir, env=_env)
         except subprocess.CalledProcessError as e:
             logger.error(f"Failed to build {self.name}: {e}")
             raise
 
     def install(self, use_symlinks: bool = False) -> None:
         """Installs artifacts to the ops directory via symlink or copy."""
+        install_strategy = create_symlink if use_symlinks else copy_path
         for artifact in self.artifacts:
             # Artifact source path is relative to the installation directory
             src = self.install_dir / artifact.source_rel_path
             dst = OPS_DIR / artifact.target_name
+            install_strategy(src, dst)
 
-            if use_symlinks:
-                create_symlink(src, dst)
-            else:
-                remove_path(dst)
-                logger.info(f"Copying {src} -> {dst}")
-                if src.is_dir():
-                    shutil.copytree(
-                        src, dst, symlinks=False, dirs_exist_ok=True
-                    )
-                else:
-                    shutil.copy(src, dst)
+    def cleanup(self) -> None:
+        """Executes injected cleanup logic."""
+        if self._cleanup_func:
+            logger.info(f"Running cleanup hook for {self.name}")
+            self._cleanup_func(self)
 
 
 def check_submodule_updated():


### PR DESCRIPTION
修复，`uv sync` 之后 `uv build` 的报错

实际测试，配置了 `graft third_party/DeepGEMM`，如果里面包含软连接目录，默认只会把一个打包到 sdist 源码包当中，好像是路径最短的会被打包。DeepGEMM 直接 `python setup.py install` 需要
```bash
# Link CUTLASS includes
ln -sf $script_dir/third-party/cutlass/include/cutlass deep_gemm/include
ln -sf $script_dir/third-party/cutlass/include/cute deep_gemm/include
```
导致 `deep_gemm/include/cutlass` 会被打包进去，`$script_dir/third-party/cutlass/include/cutlass` 不会，后续 https://github.com/PaddlePaddle/PaddleFleet/pull/207/changes#diff-11f83d4ae694fa78e78d6612ae7289fe4501eced0ac1a86fc41562ce5bbf19cfL82 编译过程会把不存在的目录软连过去，导致已有的 `deep_gemm/include/cutlass` 也被搞没了缺少文件
现在显式包含 `third_party/DeepGEMM/third-party/cutlass/include`
