### PR TITLE
[CI] Add `reopened` activity to trigger `pull_request` event in `Approval.yml`

### DIFF
--- a/.github/workflows/Approval.yml
+++ b/.github/workflows/Approval.yml
@@ -2,7 +2,7 @@ name: Approval
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, reopened]
 
 env:
   BRANCH: ${{ github.base_ref }}


### PR DESCRIPTION
Add `reopened` activity to trigger `pull_request` event in `Approval.yml`. So we can close and reopen the PR(which use `secrets.GITHUB_TOKEN` in `update_dependencies` workflow) to trigger all ci.

- Test in #235