### PR TITLE
[FIX] Fix import path for swiglu function

### DIFF
--- a/src/paddlefleet/transformer/moe/fp8_utils.py
+++ b/src/paddlefleet/transformer/moe/fp8_utils.py
@@ -20,7 +20,7 @@ import paddle
 import paddle.nn.functional as F
 
 try:
-    from paddle.incubate.nn.functional import swiglu
+    from paddle.nn.functional import swiglu
 except ImportError:
 
     def swiglu(x, y=None):


### PR DESCRIPTION
Paddle 3.3.0 has moved `swiglu` into `paddle.nn.functional`.