### PR TITLE
[bugfix] fix pp empty layer config bug

### DIFF
--- a/src/paddlefleet/gpt_builders.py
+++ b/src/paddlefleet/gpt_builders.py
@@ -40,7 +40,7 @@ def gpt_builder(config, **kwargs):
         transformer_layers_spec = []
         for layer_number in range(config.num_hidden_layers):
             real_layer_number = (
-                layer_number + config.num_empty_layers_add_in_tail
+                layer_number + config.num_empty_layers_add_in_head
             )
             transformer_layers_spec.append(
                 transformer_layer_spec_func(layer_number=real_layer_number)

--- a/tests/multi_card_tests/pipeline_parallel/test_gpt_pp.py
+++ b/tests/multi_card_tests/pipeline_parallel/test_gpt_pp.py
@@ -157,8 +157,8 @@ class TestPP(unittest.TestCase):
                 paddle.nn.init.xavier_uniform_, gain=1.0
             ),
             use_qk_norm=True,
-            num_empty_layers_add_in_head=2,
-            num_empty_layers_add_in_tail=1,
+            num_empty_layers_add_in_head=1,
+            num_empty_layers_add_in_tail=2,
             pipeline_model_parallel_size=PP_DEGREE,
         )
 

--- a/tests/single_card_tests/test_need_recompute.py
+++ b/tests/single_card_tests/test_need_recompute.py
@@ -141,8 +141,8 @@ class TestNeedRescompute(unittest.TestCase):
         config_4 = TransformerConfig(
             num_hidden_layers=9,
             pipeline_model_parallel_size=4,
-            num_empty_layers_add_in_head=2,
-            num_empty_layers_add_in_tail=1,
+            num_empty_layers_add_in_head=1,
+            num_empty_layers_add_in_tail=2,
             recompute_granularity="full",
             recompute_method="block",
             recompute_num_layers=1,


### PR DESCRIPTION
num_hidden_layers = 9
num_layers_in_first_pipeline_stage = 2
num_layers_in_last_pipeline_stage = 1
pipeline_model_parallel_size = 4
各层分配结果为：
pp0: 2
ppN-1: 1
其他pp = 剩余层数/剩余pp阶段数 =  (9 - 1 - 2) / (4 - 1 - 1) = 6 / 2 = 3
结果：| 2 | 3 | 3 | 1 |

----

在新配置设定下等价于
num_hidden_layers = 9
num_empty_layers_add_in_head = 1
num_empty_layers_add_in_tail = 2
pipeline_model_parallel_size = 4
empty + 9个decoder + empty + empty
每个pp层数 = (9 + 1 + 2) / 4 = 3
| 2 (1个empty) | 3 | 3 | 1 (+2个empty) |