### PR TITLE
fix lora bug

### DIFF
--- a/src/paddlefleet/transformer/transformer_layer.py
+++ b/src/paddlefleet/transformer/transformer_layer.py
@@ -394,6 +394,7 @@ class TransformerLayer(nn.Layer):
             context = attention_output_with_bias["context"]
 
         with paddle.enable_grad():
+            residual.stop_gradient = False
             hidden_states = self.cross_attn_bda(
                 self.training, self.config.bias_dropout_fusion
             )(attention_output_with_bias, residual, self.hidden_dropout_prob)


### PR DESCRIPTION
LORA 开recompute 后报错， 原因是lora 将原始权重都设置为stop_gradient=True, 在pylayer 下输出的stop_gradient 也是True, 动态图断掉。 