### PR TITLE
[BugFix] Add nvidia-nvshmem-cu12 limit to avoid multiple definitions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ Homepage = "https://github.com/PaddlePaddle/PaddleFleet/src"
 
 
 [build-system]
-requires = ["setuptools>=61.0.0","paddlepaddle-gpu>=3.3.0.dev", "setuptools-scm>=8", "nvidia-nvshmem-cu12>=3.3.9,<3.5"] # nvshmem max version is limited to avoid multiple definitions
+requires = ["setuptools>=61.0.0", "paddlepaddle-gpu>=3.3.0.dev", "setuptools-scm>=8", "nvidia-nvshmem-cu12>=3.3.9,<3.5"] # nvshmem max version is limited to avoid multiple definitions
 build-backend = "build_backend"
 backend-path = ["."]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
     "colorlog>=6.10.1",
     "paddlepaddle-gpu>=3.3.0.dev",
     "triton",
-    "nvidia-nvshmem-cu12>=3.3.9", # for deep_ep build
+    "nvidia-nvshmem-cu12>=3.3.9,<3.5", # for deep_ep build
 ]
 
 [project.urls]
@@ -60,7 +60,7 @@ Homepage = "https://github.com/PaddlePaddle/PaddleFleet/src"
 
 
 [build-system]
-requires = ["setuptools>=61.0.0", "pybind11", "wheel", "packaging>=24.2", "paddlepaddle-gpu>=3.3.0.dev", "setuptools-scm>=8", "nvidia-nvshmem-cu12>=3.3.9"]
+requires = ["setuptools>=61.0.0","paddlepaddle-gpu>=3.3.0.dev", "setuptools-scm>=8", "nvidia-nvshmem-cu12>=3.3.9,<3.5"] # nvshmem max version is limited to avoid multiple definitions
 build-backend = "build_backend"
 backend-path = ["."]
 

--- a/uv.lock
+++ b/uv.lock
@@ -321,26 +321,23 @@ wheels = [
 [[package]]
 name = "cuda-bindings"
 version = "12.9.5"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }
 dependencies = [
     { name = "cuda-pathfinder" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/a1/86f1709105b0efa981619cd9f26890ed034ee9320e6527434afb10249a5d/cuda_bindings-12.9.5-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b2eb7041101f6386ac49f2bc0b4b194ac705d02c1b75a42a72e77f1be8d0bb6a", size = 16124212, upload-time = "2025-12-18T16:30:52.252Z" },
-    { url = "https://files.pythonhosted.org/packages/34/4a/f323d52849e4a85ea7ebbff0625c9c6297e35f0e91ce5e2d1cff4731bd1b/cuda_bindings-12.9.5-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:819f38fe6f3f8ea28f772e61c2583dd10152ee81051a970a291b7f916973729e", size = 16149366, upload-time = "2025-12-18T16:30:58.942Z" },
-    { url = "https://files.pythonhosted.org/packages/10/5c/dd3cac662aad06e5b8661749b403cb6dc8359506a79e387ffc497cd25902/cuda_bindings-12.9.5-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5218388042d3415fba74030600fa25d59e3ec4183c344f227d43df52ca53f408", size = 15918529, upload-time = "2025-12-18T16:31:06.25Z" },
-    { url = "https://files.pythonhosted.org/packages/68/b7/19ff68738d7397bdd58b5feb8385d5fbe14903ce9b60b3e772a5f25ea0ec/cuda_bindings-12.9.5-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:da37458f8c5074d59040deddbd005460c0cf70d1ef90dd7d2c816e4686038e87", size = 15752484, upload-time = "2025-12-18T16:31:13.251Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/17/5c5063639de93a27ba67fd9c12f7663014010b1fb50990399c923cafa8d3/cuda_bindings-12.9.5-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5f5ee48922d723c626549b5644f69adcbf7537499a42963cc39d328319ff44ed", size = 15709656, upload-time = "2025-12-18T16:31:20.056Z" },
-    { url = "https://files.pythonhosted.org/packages/94/4c/6d2e59c2321efe9f219ba5eb5063a61facfe527655fe3ad7bdaafda1da1a/cuda_bindings-12.9.5-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:40dc79c8cbf663e24d2607b2a979787e0d6840b624a4da48cd5303acb8482ad2", size = 15789364, upload-time = "2025-12-18T16:31:27.1Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/9f/582ee268a5ebb96a643c29c69354b0c2d9634cd98deda1c5bd4abe4f61c8/cuda_bindings-12.9.5-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:77964179bc62504dc6bdba745bd594652233ec7796af8adce10edc0dfaf1ed95", size = 15740980, upload-time = "2025-12-18T16:31:33.972Z" },
+    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/cuda-bindings/cuda_bindings-12.9.5-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/cuda-bindings/cuda_bindings-12.9.5-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/cuda-bindings/cuda_bindings-12.9.5-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/cuda-bindings/cuda_bindings-12.9.5-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl" },
 ]
 
 [[package]]
 name = "cuda-pathfinder"
 version = "1.3.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/02/4dbe7568a42e46582248942f54dc64ad094769532adbe21e525e4edf7bc4/cuda_pathfinder-1.3.3-py3-none-any.whl", hash = "sha256:9984b664e404f7c134954a771be8775dfd6180ea1e1aef4a5a37d4be05d9bbb1", size = 27154, upload-time = "2025-12-04T22:35:08.996Z" },
+    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/cuda-pathfinder/cuda_pathfinder-1.3.3-py3-none-any.whl" },
 ]
 
 [[package]]
@@ -368,7 +365,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 wheels = [
     { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/exceptiongroup/exceptiongroup-1.3.1-py3-none-any.whl" },
@@ -688,14 +685,13 @@ wheels = [
 [[package]]
 name = "networkx"
 version = "3.6.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }
 resolution-markers = [
     "python_full_version >= '3.12'",
     "python_full_version == '3.11.*'",
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
+    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/networkx/networkx-3.6.1-py3-none-any.whl" },
 ]
 
 [[package]]
@@ -921,7 +917,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "colorlog", specifier = ">=6.10.1" },
-    { name = "nvidia-nvshmem-cu12", specifier = ">=3.3.9" },
+    { name = "nvidia-nvshmem-cu12", specifier = ">=3.3.9,<3.5" },
     { name = "paddlepaddle-gpu", specifier = ">=3.3.0.dev0" },
     { name = "triton" },
 ]
@@ -952,7 +948,7 @@ dependencies = [
     { name = "cuda-python", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "httpx" },
     { name = "networkx", version = "3.4.2", source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }, marker = "python_full_version < '3.11'" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }, marker = "python_full_version >= '3.11'" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.5", source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }, marker = "python_full_version >= '3.11'" },
     { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
@@ -990,8 +986,11 @@ version = "12.0.0"
 source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }
 wheels = [
     { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/pillow/pillow-12.0.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/pillow/pillow-12.0.0-cp310-cp310-win_amd64.whl" },
     { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/pillow/pillow-12.0.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/pillow/pillow-12.0.0-cp311-cp311-win_amd64.whl" },
     { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/pillow/pillow-12.0.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/pillow/pillow-12.0.0-cp312-cp312-win_amd64.whl" },
     { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/pillow/pillow-12.0.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl" },
 ]
 
@@ -1016,16 +1015,11 @@ wheels = [
 [[package]]
 name = "protobuf"
 version = "6.33.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/34/44/e49ecff446afeec9d1a66d6bbf9adc21e3c7cea7803a920ca3773379d4f6/protobuf-6.33.2.tar.gz", hash = "sha256:56dc370c91fbb8ac85bc13582c9e373569668a290aa2e66a590c2a0d35ddb9e4", size = 444296, upload-time = "2025-12-06T00:17:53.311Z" }
+source = { registry = "https://www.paddlepaddle.org.cn/packages/nightly/cu129/" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/91/1e3a34881a88697a7354ffd177e8746e97a722e5e8db101544b47e84afb1/protobuf-6.33.2-cp310-abi3-win32.whl", hash = "sha256:87eb388bd2d0f78febd8f4c8779c79247b26a5befad525008e49a6955787ff3d", size = 425603, upload-time = "2025-12-06T00:17:41.114Z" },
-    { url = "https://files.pythonhosted.org/packages/64/20/4d50191997e917ae13ad0a235c8b42d8c1ab9c3e6fd455ca16d416944355/protobuf-6.33.2-cp310-abi3-win_amd64.whl", hash = "sha256:fc2a0e8b05b180e5fc0dd1559fe8ebdae21a27e81ac77728fb6c42b12c7419b4", size = 436930, upload-time = "2025-12-06T00:17:43.278Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/ca/7e485da88ba45c920fb3f50ae78de29ab925d9e54ef0de678306abfbb497/protobuf-6.33.2-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:d9b19771ca75935b3a4422957bc518b0cecb978b31d1dd12037b088f6bcc0e43", size = 427621, upload-time = "2025-12-06T00:17:44.445Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/4f/f743761e41d3b2b2566748eb76bbff2b43e14d5fcab694f494a16458b05f/protobuf-6.33.2-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:b5d3b5625192214066d99b2b605f5783483575656784de223f00a8d00754fc0e", size = 324460, upload-time = "2025-12-06T00:17:45.678Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/fa/26468d00a92824020f6f2090d827078c09c9c587e34cbfd2d0c7911221f8/protobuf-6.33.2-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:8cd7640aee0b7828b6d03ae518b5b4806fdfc1afe8de82f79c3454f8aef29872", size = 339168, upload-time = "2025-12-06T00:17:46.813Z" },
-    { url = "https://files.pythonhosted.org/packages/56/13/333b8f421738f149d4fe5e49553bc2a2ab75235486259f689b4b91f96cec/protobuf-6.33.2-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:1f8017c48c07ec5859106533b682260ba3d7c5567b1ca1f24297ce03384d1b4f", size = 323270, upload-time = "2025-12-06T00:17:48.253Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/15/4f02896cc3df04fc465010a4c6a0cd89810f54617a32a70ef531ed75d61c/protobuf-6.33.2-py3-none-any.whl", hash = "sha256:7636aad9bb01768870266de5dc009de2d1b936771b38a793f73cbbf279c91c5c", size = 170501, upload-time = "2025-12-06T00:17:52.211Z" },
+    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/protobuf/protobuf-6.33.2-cp310-abi3-win_amd64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/protobuf/protobuf-6.33.2-cp39-abi3-manylinux2014_x86_64.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/protobuf/protobuf-6.33.2-py3-none-any.whl" },
 ]
 
 [[package]]
@@ -1210,6 +1204,7 @@ wheels = [
     { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/safetensors/safetensors-0.7.0-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl" },
     { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/safetensors/safetensors-0.7.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl" },
     { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/safetensors/safetensors-0.7.0-cp38-abi3-win32.whl" },
+    { url = "https://paddle-whl.bj.bcebos.com/nightly/cu129/safetensors/safetensors-0.7.0-cp38-abi3-win_amd64.whl" },
 ]
 
 [[package]]


### PR DESCRIPTION
ref: https://github.com/PaddlePaddle/Paddle/pull/77167#issuecomment-3706085209
```
[2026-01-02 18:59:09,184] [    INFO] spawn.py:77 - x86_64-linux-gnu-g++
      -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall
      -g -fstack-protector-strong -Wformat -Werror=format-security
      -g -fwrapv -O2 -shared -Wl,-O1 -Wl,-Bsymbolic-functions
      /paddle/third_party/DeepEP/build/lib.linux-x86_64-cpython-310/build/temp.linux-x86_64-cpython-310/csrc/deep_ep.o
      /paddle/third_party/DeepEP/build/lib.linux-x86_64-cpython-310/build/temp.linux-x86_64-cpython-310/csrc/kernels/internode.cu.o
      /paddle/third_party/DeepEP/build/lib.linux-x86_64-cpython-310/build/temp.linux-x86_64-cpython-310/csrc/kernels/internode_ll.cu.o
      /paddle/third_party/DeepEP/build/lib.linux-x86_64-cpython-310/build/temp.linux-x86_64-cpython-310/csrc/kernels/intranode.cu.o
      /paddle/third_party/DeepEP/build/lib.linux-x86_64-cpython-310/build/temp.linux-x86_64-cpython-310/csrc/kernels/layout.cu.o
      /paddle/third_party/DeepEP/build/lib.linux-x86_64-cpython-310/build/temp.linux-x86_64-cpython-310/csrc/kernels/runtime.cu.o
      /paddle/third_party/DeepEP/build/lib.linux-x86_64-cpython-310/build/temp.linux-x86_64-cpython-310/csrc/dlink.o
      -L/root/.cache/uv/builds-v0/.tmpSx5shf/lib/python3.10/site-packages/nvidia/nvshmem/lib
      -L/root/.cache/uv/builds-v0/.tmpSx5shf/lib/python3.10/site-packages/paddle/libs
      -L/usr/local/cuda-12.9/lib64
      -L/root/.cache/uv/builds-v0/.tmpSx5shf/lib/python3.10/site-packages/paddle/base
      -L/usr/lib/x86_64-linux-gnu
      -Wl,--enable-new-dtags,-rpath,/root/.cache/uv/builds-v0/.tmpSx5shf/lib/python3.10/site-packages/paddle/libs
      -Wl,--enable-new-dtags,-rpath,/usr/local/cuda-12.9/lib64
      -Wl,--enable-new-dtags,-rpath,/root/.cache/uv/builds-v0/.tmpSx5shf/lib/python3.10/site-packages/paddle/base
      -o build/lib.linux-x86_64-cpython-310/deep_ep_cpp.so
      -lcuda -l:libnvshmem_host.so.3 -l:libnvshmem_device.a
      -Wl,-rpath,/root/.cache/uv/builds-v0/.tmpSx5shf/lib/python3.10/site-packages/nvidia/nvshmem/lib
      -Wl,--no-as-needed -l:libpaddle.so -Wl,--as-needed -lcudart
      /usr/bin/ld:
      /root/.cache/uv/builds-v0/.tmpSx5shf/lib/python3.10/site-packages/nvidia/nvshmem/lib/libnvshmem_device.a(init_device.cu.o):(.bss+0x380):
      multiple definition of `nvshmemi_ibgda_device_state_d';
      /paddle/third_party/DeepEP/build/lib.linux-x86_64-cpython-310/build/temp.linux-x86_64-cpython-310/csrc/deep_ep.o:/root/.cache/uv/builds-v0/.tmpSx5shf/lib/python3.10/site-packages/nvidia/nvshmem/include/device_host_transport/nvshmem_common_ibgda.h:351:
      first defined here
      collect2: error: ld returned 1 exit status
      error: command '/usr/bin/x86_64-linux-gnu-g++' failed with exit code 1
      Failed to build DeepEP: Command
      '['/root/.cache/uv/builds-v0/.tmpSx5shf/bin/python',
      'setup.py', 'install', '--install-lib',
      '/paddle/src/_third_party_install_temp/DeepEP', '--no-compile']'
      returned non-zero exit status 1.
```
3.5.19 版本在编译 deepep 时会出现 multiple definitions 的问题
may be limited by https://github.com/NVIDIA/nvshmem/pull/50