### PR TITLE
[Sonic MoE] Support Sonic MoE Router

### DIFF
--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -23,6 +23,13 @@ import paddle.nn.functional as F
 from paddle import nn
 from paddle.distributed.fleet.utils.sequence_parallel_utils import AllGatherOp
 
+paddle.enable_compat(
+    scope={"sonicmoe", "quack", "triton"}
+)  # Enable torch proxy before importing sonicmoe
+from sonicmoe.functional import (
+    TC_Softmax_Topk_Router_Function,
+)
+
 if TYPE_CHECKING:
     from paddlefleet.process_groups_config import ProcessGroupCollection
     from paddlefleet.transformer.transformer_config import TransformerConfig
@@ -562,12 +569,19 @@ class TopKRouter(StandardMoERouter):
         gates = self.gate_score_func(logits)
 
         # top_gate: [B*S, K], top_idx: [B*S, K]
-        top_gate, top_idx = self._call_topk_method(
-            self.topk_method,
-            gates,
-            k=self.num_experts_per_tok,
-            n_group=self.n_group,
-            topk_group=self.topk_group,
+
+        ######## Option1: Origin Code
+        # top_gate, top_idx = self._call_topk_method(
+        #     self.topk_method,
+        #     gates,
+        #     k=self.num_experts_per_tok,
+        #     n_group=self.n_group,
+        #     topk_group=self.topk_group,
+        # )
+
+        ######## Option2: Sonic MoE
+        top_gate, top_idx = TC_Softmax_Topk_Router_Function.apply(
+            logits, self.weight.T.size(0), self.num_experts_per_tok
         )
 
         # z-loss


### PR DESCRIPTION
需要拉取 https://github.com/hushenwei2000/sonic-moe/commit/5e80341c18dd77fcbceb84f18b0902689be66e4a 更改了 Sonic MoE 源码的：
1. 先进行激活函数（softmax/sigmoid），再进行 TopK
2. 支持 sigmoid 激活函数

目前仅测试了 GLM4.5 标准测试。测试结果

<img width="3569" height="2365" alt="image" src="https://github.com/user-attachments/assets/65a0e627-caee-4ddd-85ea-99e1fef8f1f1" />



