### PR TITLE
[MoE Layer] Fix Deep GEMM k_group Kernel Calling

### DIFF
--- a/src/paddlefleet/transformer/moe/fp8_utils.py
+++ b/src/paddlefleet/transformer/moe/fp8_utils.py
@@ -1335,7 +1335,9 @@ class ExpertsGroupGemmContiguousNode:
                         b=dy,
                         d=weights.main_grad,
                         ks=self.tokens_per_expert,
-                        ks_tensor=paddle.to_tensor(self.tokens_per_expert),
+                        ks_tensor=paddle.to_tensor(
+                            self.tokens_per_expert, dtype="int32"
+                        ),
                         c=weights.main_grad,
                     )
                 else:
@@ -1359,7 +1361,9 @@ class ExpertsGroupGemmContiguousNode:
                         b=dy,
                         d=weights.grad,
                         ks=self.tokens_per_expert,
-                        ks_tensor=paddle.to_tensor(self.tokens_per_expert),
+                        ks_tensor=paddle.to_tensor(
+                            self.tokens_per_expert, dtype="int32"
+                        ),
                         c=weights.grad,
                     )
                 else:

--- a/src/paddlefleet/transformer/moe/moe_expert.py
+++ b/src/paddlefleet/transformer/moe/moe_expert.py
@@ -105,7 +105,7 @@ class DeepGEMMBMMFunction(paddle.autograd.PyLayer):
             b=grad,
             d=dy,
             ks=paddle.tolist(batch_sizes),
-            ks_tensor=batch_sizes,
+            ks_tensor=batch_sizes.cast("int32"),
             c=paddle.zeros_like(y, dtype=paddle.float),
         )
 


### PR DESCRIPTION
修复开启 deepgemm 时存在的精度问题。


采用标准 4 机测试，修改 acc=8，热启 10 步。

| 指标                        | for-loop | batchedgemm | deepgemm-fixed |
|-----------------------------|----------|-------------|----------------|
| 统计step数 (从step 0开始)   | 10       | 10          | 10             |
| 平均loss                    | 2.9370   | 2.9369      | 2.9371         |
| 最后一步loss                    | 2.5517292   | 2.55179787      | 2.55243158         |

--- 对比: for-loop vs batchedgemm loss 指标 (从step 0开始) ---
平均绝对误差: 0.000202
最大绝对误差: 0.000618

--- 对比: for-loop vs deepgemm-fixed loss 指标 (从step 0开始) ---
平均绝对误差: 0.000296
最大绝对误差: 0.000702

--- 对比: batchedgemm vs deepgemm-fixed loss 指标 (从step 0开始) ---
平均绝对误差: 0.000226
最大绝对误差: 0.000634
