### PR TITLE
[MoE Layer] Delete moe_deep_gemm Config

### DIFF
--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -86,7 +86,6 @@ class MoELayer(nn.Layer):
 
         self.router_aux_loss_coef = config.router_aux_loss_coef
         self.moe_grouped_gemm = config.moe_grouped_gemm
-        self.moe_deep_gemm = config.moe_deep_gemm
         self.moe_group = pg_collection.ep
         self.expert_model_parallel_size = (
             utils.get_pg_size(self.moe_group)
@@ -117,6 +116,7 @@ class MoELayer(nn.Layer):
         ):
             routed_expert_config.tensor_model_parallel_size = 1
 
+        self.moe_deep_gemm = True
         if (
             not paddle.device.current_device_is_cpu
             and paddle.device.get_device_capability()[0] < 9

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -351,9 +351,6 @@ class TransformerConfig(ModelParallelConfig):
     moe_shared_expert_overlap: bool = False
     """Enable overlapping between shared expert computations and a2a combinet"""
 
-    moe_deep_gemm: bool = True
-    """Whether to use deep gemm. Only work when moe_grouped_gemm enabled."""
-
     ##################
     # Context Parallel
     ##################

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -327,6 +327,9 @@ class TransformerConfig(ModelParallelConfig):
     moe_dequant_input: bool = False
     """Whether to dequantize input."""
 
+    moe_expert_fusion: bool = True
+    """Whether to fuse experts."""
+
     moe_subbatch_token_num_before_dispatch: int | None = None
     """Whether to enable subbatch before dispatch, the value means the number of tokens in one subbatch."""
 

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -327,9 +327,6 @@ class TransformerConfig(ModelParallelConfig):
     moe_dequant_input: bool = False
     """Whether to dequantize input."""
 
-    moe_expert_fusion: bool = True
-    """Whether to fuse experts."""
-
     moe_subbatch_token_num_before_dispatch: int | None = None
     """Whether to enable subbatch before dispatch, the value means the number of tokens in one subbatch."""
 

--- a/tests/multi_card_tests/moe/test_force_balance.py
+++ b/tests/multi_card_tests/moe/test_force_balance.py
@@ -84,7 +84,6 @@ class TestFusionBF16ExpertParallel(unittest.TestCase):
             moe_router_force_load_balancing=True,
             moe_grouped_gemm=True,
             bias_activation_fusion=True,
-            moe_deep_gemm=True,
         )
 
         transformer_layer_spec = get_gpt_layer_local_spec(

--- a/tests/multi_card_tests/moe/test_grouped_gemm.py
+++ b/tests/multi_card_tests/moe/test_grouped_gemm.py
@@ -81,7 +81,7 @@ class TestFusionBF16ExpertParallel(unittest.TestCase):
             gated_linear_unit=True,
             n_shared_experts=0,
             hidden_act=F.silu,
-            moe_grouped_gemm=False,
+            moe_grouped_gemm=True,
             bias_activation_fusion=True,
         )
 

--- a/tests/multi_card_tests/moe/test_imbalance.py
+++ b/tests/multi_card_tests/moe/test_imbalance.py
@@ -83,7 +83,6 @@ class TestFusionBF16ExpertParallel(unittest.TestCase):
             hidden_act=F.silu,
             moe_grouped_gemm=True,
             bias_activation_fusion=True,
-            moe_deep_gemm=False,
         )
 
         transformer_layer_spec = get_gpt_layer_local_spec(

--- a/tests/multi_card_tests/moe/test_imbalance_no_ep.py
+++ b/tests/multi_card_tests/moe/test_imbalance_no_ep.py
@@ -81,7 +81,6 @@ class TestFusionBF16ExpertParallel(unittest.TestCase):
             n_shared_experts=0,
             hidden_act=F.silu,
             moe_grouped_gemm=True,
-            moe_deep_gemm=False,
             bias_activation_fusion=True,
         )
 

--- a/tests/multi_card_tests/moe/test_imbalance_no_ep.py
+++ b/tests/multi_card_tests/moe/test_imbalance_no_ep.py
@@ -64,7 +64,7 @@ class TestFusionBF16ExpertParallel(unittest.TestCase):
 
     def test_moe_fusion(self):
         n_routed_experts = 8
-        hidden_size = 16
+        hidden_size = 64
         transformer_config_moe = TransformerConfig(
             hidden_size=hidden_size,
             num_attention_heads=4,
@@ -76,7 +76,7 @@ class TestFusionBF16ExpertParallel(unittest.TestCase):
             sequence_parallel=False,
             bf16=True,
             params_dtype=paddle.bfloat16,
-            moe_intermediate_size=24,
+            moe_intermediate_size=128,
             gated_linear_unit=True,
             n_shared_experts=0,
             hidden_act=F.silu,


### PR DESCRIPTION
删除 `moe_deep_gemm` 配置项。

现在在开启 `moe_grouped_gemm` 时，会根据运行环境，如果支持 deepgemm 那么使用 deepgemm；否则退化到框架 batched_gemm。