### PR TITLE
[MoE Layer] Fix Router topk_weigtht in noaux_tc Method

### DIFF
--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -501,11 +501,7 @@ class StandardMoERouter(nn.Layer):
 
         # The bias term b is used only to adjust affinity scores for Top-K expert selection (routing); it does not affect gating.
         # The gate applied during dispatch and to weight the FFN output is computed from the original affinity score s_{i,t} (without the bias).
-        topk_weight = (
-            scores.take_along_axis(topk_idx, axis=1)
-            if not self.training
-            else topk_weight
-        )
+        topk_weight = scores.take_along_axis(topk_idx, axis=1)
 
         return topk_weight, topk_idx
 


### PR DESCRIPTION
使用 noaux_tc 的 Router 时，topk_weight 使用不加 correction_bias 的路由分数。对齐 PaddleFormers 和 Hugging Face 实现。