### PR TITLE
[MoE Layer] Fix AllToAll Implementation when TP > 1

### DIFF
--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -199,10 +199,17 @@ class MoELayer(nn.Layer):
                     self.moe_group,
                 )
             elif self.moe_token_dispatcher_type == "alltoall":
+                local_expert_indices = list(
+                    range(
+                        self.moe_rank * self.num_experts_per_device,
+                        (self.moe_rank + 1) * self.num_experts_per_device,
+                    )
+                )
                 self.token_dispatcher = AllToAllTokenDispatcher(
                     self.moe_group,
                     self.expert_model_parallel_size,
                     self.num_experts_per_device,
+                    local_expert_indices,
                 )
             else:
                 raise NotImplementedError(

--- a/src/paddlefleet/transformer/moe/moe_utils.py
+++ b/src/paddlefleet/transformer/moe/moe_utils.py
@@ -415,13 +415,8 @@ def sort_chunks_by_idxs(
     """Split and sort the input tensor based on the split_sizes and sorted indices."""
     input = paddle.split(input, split_sizes.tolist(), axis=0)
     output = paddle.cat([input[i] for i in sorted_idxs.tolist()], axis=0)
-    if probs is not None:
-        probs = paddle.split(probs, split_sizes.tolist(), axis=0)
-        permuted_probs = paddle.cat(
-            [probs[i] for i in sorted_idxs.tolist()], axis=0
-        )
-    else:
-        permuted_probs = None
+    # TODO: support probs is not None
+    permuted_probs = None
     return output, permuted_probs
 
 
@@ -443,24 +438,15 @@ def all_gather_group(input, group=None, axis=0):
                 - When axis=0: shape [D*N, ...] (N = group size)
                 - Otherwise:   shape [..., D*N, ...] along specified axis
     """
-    if group is None:
-        hcg = paddle.distributed.fleet.get_hybrid_communicate_group()
-        group = hcg.get_model_parallel_group()
     parallelism = group.nranks
     if parallelism == 1:
         return input.clone()
     output_shape = input.shape
-    if axis == 0:
-        output_shape[axis] = output_shape[axis] * parallelism
-        output = paddle.empty(shape=output_shape, dtype=input.dtype)
-        dist.stream.all_gather(output, input, group=group, use_calc_stream=True)
-        return output
-    outputs = [
-        paddle.empty(output_shape, dtype=input.dtype)
-        for _ in range(parallelism)
-    ]
-    dist.stream.all_gather(outputs, input, group=group, use_calc_stream=True)
-    output = paddle.concat(outputs, axis=axis)
+    # TODO: Support only axis != 0
+    assert axis == 0
+    output_shape[axis] = output_shape[axis] * parallelism
+    output = paddle.empty(shape=output_shape, dtype=input.dtype)
+    dist.stream.all_gather(output, input, group=group, use_calc_stream=True)
     return output
 
 
@@ -479,9 +465,6 @@ def reduce_scatter_group(input, group=None):
     Returns:
         Tensor: Scattered portion of reduced tensor with shape [K, ...]
     """
-    if group is None:
-        hcg = paddle.distributed.fleet.get_hybrid_communicate_group()
-        group = hcg.get_model_parallel_group()
     parallelism = group.nranks
     if parallelism == 1:
         return input.clone()

--- a/src/paddlefleet/transformer/moe/moe_utils.py
+++ b/src/paddlefleet/transformer/moe/moe_utils.py
@@ -396,3 +396,127 @@ def k_grouped_bf16_gemm_tn_contiguous_aligned(a, b, d, ks, ks_tensor, c):
     )
 
     del a_padded, b_padded
+
+
+def sort_chunks_by_idxs(
+    input: paddle.Tensor,
+    split_sizes: paddle.Tensor,
+    sorted_idxs: paddle.Tensor,
+    probs: paddle.Tensor | None = None,
+    fused: bool = False,
+):
+    """Split and sort the input tensor based on the split_sizes and sorted indices."""
+    input = paddle.split(input, split_sizes.tolist(), axis=0)
+    output = paddle.cat([input[i] for i in sorted_idxs.tolist()], axis=0)
+    if probs is not None:
+        probs = paddle.split(probs, split_sizes.tolist(), axis=0)
+        permuted_probs = paddle.cat(
+            [probs[i] for i in sorted_idxs.tolist()], axis=0
+        )
+    else:
+        permuted_probs = None
+    return output, permuted_probs
+
+
+def all_gather_group(input, group=None, axis=0):
+    """Perform collective all-gather operation across a process group with axis control.
+
+    Functional Behavior:
+      - Aggregates input tensors from all processes in the specified group
+      - Supports concatenation along arbitrary dimensions (axis parameter)
+      - Optimizes for axis=0 via direct shape expansion to avoid concatenation overhead
+
+    Args:
+        input (Tensor):        Local tensor to be gathered (shape: [..., D, ...])
+        group (ProcessGroup):  Communication group (defaults to model parallel group)
+        axis (int):            Concatenation dimension (default=0)
+
+    Returns:
+        Tensor: Concatenated tensor combining inputs from all processes:
+                - When axis=0: shape [D*N, ...] (N = group size)
+                - Otherwise:   shape [..., D*N, ...] along specified axis
+    """
+    if group is None:
+        hcg = paddle.distributed.fleet.get_hybrid_communicate_group()
+        group = hcg.get_model_parallel_group()
+    parallelism = group.nranks
+    if parallelism == 1:
+        return input.clone()
+    output_shape = input.shape
+    if axis == 0:
+        output_shape[axis] = output_shape[axis] * parallelism
+        output = paddle.empty(shape=output_shape, dtype=input.dtype)
+        dist.stream.all_gather(output, input, group=group, use_calc_stream=True)
+        return output
+    outputs = [
+        paddle.empty(output_shape, dtype=input.dtype)
+        for _ in range(parallelism)
+    ]
+    dist.stream.all_gather(outputs, input, group=group, use_calc_stream=True)
+    output = paddle.concat(outputs, axis=axis)
+    return output
+
+
+def reduce_scatter_group(input, group=None):
+    """Perform reduce-scatter collective operation across a process group.
+
+    Functional Behavior:
+      - Aggregates (sums) input tensors across all processes in the group
+      - Scatters the reduced result equally to all participants
+      - Operates along the first dimension (axis=0) of the input tensor
+
+    Args:
+        input (Tensor):        Local tensor to reduce (shape: [N*K, ...] where N=group_size)
+        group (ProcessGroup): Communication group (defaults to model parallel group)
+
+    Returns:
+        Tensor: Scattered portion of reduced tensor with shape [K, ...]
+    """
+    if group is None:
+        hcg = paddle.distributed.fleet.get_hybrid_communicate_group()
+        group = hcg.get_model_parallel_group()
+    parallelism = group.nranks
+    if parallelism == 1:
+        return input.clone()
+    output_shape = input.shape
+    assert input.shape[0] % parallelism == 0, (
+        f"Input sequence length {input.shape[0]} can't be divided exactly by sequence parallelism {parallelism}"
+    )
+    output_shape[0] = output_shape[0] // parallelism
+    output = paddle.empty(shape=output_shape, dtype=input.dtype)
+    dist.stream.reduce_scatter(
+        output, input, op=dist.ReduceOp.SUM, group=group, use_calc_stream=True
+    )
+    return output
+
+
+class AllGatherGroupOp(paddle.autograd.PyLayer):
+    """
+    Perform group allgather.
+    """
+
+    @staticmethod
+    def forward(ctx, input, group=None):
+        """Forward pass: All-Gather operation
+        Args:
+            input (Tensor):  Partitioned tensor with shape [s/n, b, h]
+                            The 's' dimension is distributed across devices
+            group (ProcessGroup): Model parallel process group,
+                                uses global group by default
+        Returns:
+            Tensor: Assembled tensor after All-Gather with shape [s, b, h],
+                   containing full parameter from all devices
+        """
+        ctx.group = group
+        return all_gather_group(input, group=group)
+
+    @staticmethod
+    def backward(ctx, grad):
+        """Backward pass: Reduce-Scatter operation
+        Args:
+            grad (Tensor): Full gradient tensor with shape [s, b, h]
+        Returns:
+            Tensor: Scattered gradient with shape [s/n, b, h],
+                   distributing reduced gradients to each device
+        """
+        return reduce_scatter_group(grad, group=ctx.group)

--- a/src/paddlefleet/transformer/moe/moe_utils.py
+++ b/src/paddlefleet/transformer/moe/moe_utils.py
@@ -36,6 +36,11 @@ if TYPE_CHECKING:
     from paddle.distributed.communication.group import Group
 
 
+def barrier_ep(ep_group):
+    """barrier_ep"""
+    paddle.distributed.barrier(ep_group)
+
+
 def permute(
     tokens,
     routing_map,
@@ -184,6 +189,7 @@ class _AllToAll(paddle.autograd.PyLayer):
         output = paddle.empty(
             output_shape, dtype=input.dtype, requires_grad=True
         )
+        paddle.distributed.barrier(group)
         task = dist.alltoall_single(
             output,
             input,
@@ -207,6 +213,7 @@ class _AllToAll(paddle.autograd.PyLayer):
             tuple[Tensor]: A tuple containing a tensor that holds the gradients of all input tensors.
         """
         # return grad_output
+        paddle.distributed.barrier(ctx.group)
         return _AllToAll.apply(
             ctx.input_shape,
             *grad_output,
@@ -507,6 +514,7 @@ class AllGatherGroupOp(paddle.autograd.PyLayer):
             Tensor: Assembled tensor after All-Gather with shape [s, b, h],
                    containing full parameter from all devices
         """
+        paddle.distributed.barrier(group)
         ctx.group = group
         return all_gather_group(input, group=group)
 
@@ -519,4 +527,5 @@ class AllGatherGroupOp(paddle.autograd.PyLayer):
             Tensor: Scattered gradient with shape [s/n, b, h],
                    distributing reduced gradients to each device
         """
+        paddle.distributed.barrier(ctx.group)
         return reduce_scatter_group(grad, group=ctx.group)

--- a/src/paddlefleet/transformer/moe/token_dispatcher.py
+++ b/src/paddlefleet/transformer/moe/token_dispatcher.py
@@ -458,6 +458,11 @@ class AllToAllTokenDispatcher(nn.Layer):
         # )
         # num_global_tokens_per_local_expert = global_tokens_per_expert.reshape(self.expert_model_parallel_size, self.num_local_experts)
 
+        if num_global_tokens_per_local_expert.sum().item() == 0:
+            self.is_empty_tokens = True
+        else:
+            self.is_empty_tokens = False
+
         self.tokens_per_expert = num_global_tokens_per_local_expert.sum(axis=0)
 
         num_global_tokens_per_rank = num_global_tokens_per_local_expert.sum(
@@ -520,19 +525,19 @@ class AllToAllTokenDispatcher(nn.Layer):
             self.num_local_experts, -1
         ).T.ravel()
 
-        global_input_tokens, global_probs = sort_chunks_by_idxs(
-            global_input_tokens,
-            self.num_global_tokens_per_local_expert.ravel(),
-            self.sort_input_by_local_experts,
-            probs=None,
-        )
+        if self.num_local_experts > 1 and not self.is_empty_tokens:
+            global_input_tokens, global_probs = sort_chunks_by_idxs(
+                global_input_tokens,
+                self.num_global_tokens_per_local_expert.ravel(),
+                self.sort_input_by_local_experts,
+                probs=None,
+            )
         sorted_tokens = global_input_tokens
         self.tokens_per_expert_post_gather = self.tokens_per_expert
-
         return sorted_tokens, self.tokens_per_expert_post_gather
 
     def combine_preprocess(self, hidden_states: paddle.Tensor):
-        if self.num_local_experts > 1:
+        if self.num_local_experts > 1 and not self.is_empty_tokens:
             hidden_states, _ = sort_chunks_by_idxs(
                 hidden_states,
                 self.num_global_tokens_per_local_expert.T.ravel(),

--- a/src/paddlefleet/transformer/moe/token_dispatcher.py
+++ b/src/paddlefleet/transformer/moe/token_dispatcher.py
@@ -24,10 +24,15 @@ from paddle import nn
 if TYPE_CHECKING:
     from paddle.distributed.communication.group import Group
 
-import numpy as np
 
 from .fused_a2a import fused_combine, fused_dispatch
-from .moe_utils import _AllToAll, permute, unpermute
+from .moe_utils import (
+    AllGatherGroupOp,
+    _AllToAll,
+    permute,
+    sort_chunks_by_idxs,
+    unpermute,
+)
 
 
 class _DispatchManager(ABC):
@@ -401,11 +406,14 @@ class AllToAllTokenDispatcher(nn.Layer):
         moe_group: Group,
         expert_model_parallel_size: int,
         num_experts_per_device: int,
+        local_expert_indices: list,
     ):
         nn.Layer.__init__(self)
         self.moe_group = moe_group
         self.expert_model_parallel_size = expert_model_parallel_size
         self.num_experts_per_device = num_experts_per_device
+        self.local_expert_indices = local_expert_indices
+        self.num_local_experts = len(local_expert_indices)
 
     def dispatch_preprocess(
         self,
@@ -413,9 +421,11 @@ class AllToAllTokenDispatcher(nn.Layer):
         gates_masked: paddle.Tensor,  # probs
         mask: paddle.Tensor,  # routing_map
     ) -> tuple[paddle.Tensor, paddle.Tensor]:
+        self.routing_map = mask
         self.gates_masked = gates_masked
-        if self.expert_model_parallel_size <= 1:
-            return hidden_states
+        self.num_experts = (
+            self.num_experts_per_device * self.expert_model_parallel_size
+        )
         mask = mask.to(paddle.int64)
 
         if len(hidden_states.shape) == 3:
@@ -426,142 +436,131 @@ class AllToAllTokenDispatcher(nn.Layer):
         self.d_model = d_model
         self.reshaped_input_shape = reshaped_input.shape
         tokens_per_expert = mask.sum(axis=0)  # Shape: [num_experts]
-        token_indices, expert_indices = paddle.where(mask == 1)
-        combined_key = expert_indices * seq_len + token_indices
-        sort_indices = paddle.argsort(combined_key)
-        self.sorted_token_indices = token_indices[sort_indices]
-        self.sorted_expert_indices = expert_indices[sort_indices]
-        # `sorted_tokens` are tokens that sorted by expert id.
-        # First `tokens_per_expert[0]` tokens belong to expert 0, next `tokens_per_expert[1]` tokens belong to expert 1, etc.
-        # Shape: [batch_size * seq_len * num_experts_per_token, d_model]
-        sorted_tokens = reshaped_input[self.sorted_token_indices]
-
         tokens_per_expert = tokens_per_expert.detach()
-        self.sorted_tokens_shape = sorted_tokens.shape
-
         tokens_per_ep_rank = tokens_per_expert.reshape(
             [self.expert_model_parallel_size, -1]
         ).sum(axis=1)
         # First All-to-All: Exchange expert token counts across ranks
-        # Returns `self.global_tokens_per_expert` is for current rank
-        self.global_tokens_per_expert = _AllToAll.apply(
-            [tokens_per_expert.shape[0]],
-            tokens_per_expert,
-            group=self.moe_group,
+        # Returns `tokens_per_expert_group` is for current rank
+        num_global_tokens_per_expert = AllGatherGroupOp.apply(
+            tokens_per_expert, group=self.moe_group
+        ).reshape(self.expert_model_parallel_size, self.num_experts)
+        num_global_tokens_per_local_expert = num_global_tokens_per_expert[
+            :, self.local_expert_indices[0] : self.local_expert_indices[-1] + 1
+        ].contiguous()
+
+        # Can also use the two AllToAll functions below instead of the above AllGather
+        # It will be a little bit faster , but also has a little more accuracy diff with DeepEP version
+        # global_tokens_per_expert = _AllToAll.apply(
+        #     [tokens_per_expert.shape[0]],
+        #     tokens_per_expert,
+        #     group=self.moe_group,
+        # )
+        # num_global_tokens_per_local_expert = global_tokens_per_expert.reshape(self.expert_model_parallel_size, self.num_local_experts)
+
+        self.tokens_per_expert = num_global_tokens_per_local_expert.sum(axis=0)
+
+        num_global_tokens_per_rank = num_global_tokens_per_local_expert.sum(
+            axis=1
         )
 
-        if self.global_tokens_per_expert.sum().item() == 0:
-            self.is_empty_tokens = True
-        else:
-            self.is_empty_tokens = False
+        self.num_global_tokens_per_local_expert = (
+            num_global_tokens_per_local_expert.reshape(
+                -1, self.num_local_experts
+            )
+        )
 
-        tokens_per_expert_group_sum = self.global_tokens_per_expert.reshape(
-            [self.expert_model_parallel_size, -1]
-        )
-        self.output_splits = (
-            tokens_per_expert_group_sum.sum(axis=1).cpu().tolist()
-        )
-        self.input_split_sizes = tokens_per_ep_rank.cpu().tolist()
-        self.dispatch_output_shape = [
-            self.global_tokens_per_expert.sum(axis=0).cpu().item(),
-            sorted_tokens.shape[1],
+        self.output_splits = num_global_tokens_per_rank.cpu().tolist()
+        num_local_tokens_per_expert = self.routing_map.sum(dim=0).long()
+        self.input_split_sizes = num_local_tokens_per_expert.reshape(
+            self.expert_model_parallel_size, self.num_local_experts
+        ).sum(axis=1)
+        self.output_shape_tokens = [
+            num_global_tokens_per_rank.sum().cpu().item(),
+            d_model,
         ]
 
-        return sorted_tokens
+        (
+            permutated_local_input_tokens,
+            self.reversed_local_input_permutation_mapping,
+        ) = permute(reshaped_input, self.routing_map)
+        self.permutated_local_input_tokens_shape = (
+            permutated_local_input_tokens.shape
+        )
+
+        return permutated_local_input_tokens
 
     def token_dispatch(
-        self, sorted_tokens: paddle.Tensor, fp8_dispatch: bool = False
+        self,
+        permutated_local_input_tokens: paddle.Tensor,
+        fp8_dispatch: bool = False,
     ):
         # Second All-to-All: Exchange expert tokens across ranks. `gathered_tokens` are the tokens that will be processed by current rank
-        gathered_tokens = _AllToAll.apply(
-            self.dispatch_output_shape,
-            sorted_tokens,
+        global_input_tokens = _AllToAll.apply(
+            self.output_shape_tokens,
+            permutated_local_input_tokens,  # sorted_tokens,
             out_split_sizes=self.output_splits,
             in_split_sizes=self.input_split_sizes,
             group=self.moe_group,
         )
-        return gathered_tokens, None
+
+        return global_input_tokens, None
 
     def dispatch_postprocess(
         self,
-        gathered_tokens: paddle.Tensor,
+        global_input_tokens: paddle.Tensor,
     ):
-        # Next, we should sort `gathered_tokens` by expert ids, so that the tokens for the same expert are contiguous.
-        tokens_per_expert_post_gather = self.global_tokens_per_expert.reshape(
-            [self.expert_model_parallel_size, self.num_experts_per_device]
-        ).sum(axis=0)
-        gatherd_idxs = np.zeros(
-            shape=(gathered_tokens.shape[0],), dtype=np.int32
+        input_chunk_idxs = paddle.arange(self.num_experts)
+        # [num_local_experts, ep_size]. Sort the input chunks by local experts.
+        self.sort_input_by_local_experts = input_chunk_idxs.reshape(
+            -1, self.num_local_experts
+        ).T.ravel()
+        # [ep_size, num_local_experts]. Restore the output chunks by local experts.
+        self.restore_output_by_local_experts = input_chunk_idxs.reshape(
+            self.num_local_experts, -1
+        ).T.ravel()
+
+        global_input_tokens, global_probs = sort_chunks_by_idxs(
+            global_input_tokens,
+            self.num_global_tokens_per_local_expert.ravel(),
+            self.sort_input_by_local_experts,
+            probs=None,
         )
-        s = 0
-        for i, k in enumerate(self.global_tokens_per_expert.cpu().numpy()):
-            gatherd_idxs[s : s + k] = i % self.num_experts_per_device
-            s += k
-        self.gatherd_idxs = gatherd_idxs.argsort()
-        sorted_tokens = gathered_tokens[self.gatherd_idxs]
+        sorted_tokens = global_input_tokens
+        self.tokens_per_expert_post_gather = self.tokens_per_expert
 
-        return sorted_tokens, tokens_per_expert_post_gather
+        return sorted_tokens, self.tokens_per_expert_post_gather
 
-    def combine_preprocess(self, expert_outs: paddle.Tensor):
-        # Restore the original order of tokens, prepare for the third All-to-All.
-        if self.is_empty_tokens:
-            new_x = expert_outs
-        else:
-            new_x = paddle.empty_like(expert_outs)
-            new_x[self.gatherd_idxs] = expert_outs
-        return new_x
+    def combine_preprocess(self, hidden_states: paddle.Tensor):
+        if self.num_local_experts > 1:
+            hidden_states, _ = sort_chunks_by_idxs(
+                hidden_states,
+                self.num_global_tokens_per_local_expert.T.ravel(),
+                self.restore_output_by_local_experts,
+            )
+        return hidden_states
 
     def token_combine(
-        self, new_x: paddle.Tensor, combine_overlap_handle: dict | None = None
+        self,
+        hidden_states: paddle.Tensor,
+        combine_overlap_handle: dict | None = None,
     ):
-        # Third All-to-All: Exchange expert outputs back to original rank. `gathered_tokens` are the tokens that originally belong to current rank
-        gathered_tokens = _AllToAll.apply(
-            self.sorted_tokens_shape,
-            new_x,
+        permutated_local_input_tokens = _AllToAll.apply(
+            self.permutated_local_input_tokens_shape,
+            hidden_states,
             out_split_sizes=self.input_split_sizes,
             in_split_sizes=self.output_splits,
             group=self.moe_group,
         )
-        return gathered_tokens
+        return permutated_local_input_tokens
 
-    def combine_postprocess(self, gathered_tokens: paddle.Tensor):
-        # For every processed token, need to multiply the expert weight.
-        expert_major_weights = self.gates_masked[
-            self.sorted_token_indices, self.sorted_expert_indices
-        ]  # shape [batch_size * seq_len * num_experts_per_token]
-        weighted_gathered_tokens = (
-            gathered_tokens
-            * expert_major_weights.unsqueeze(-1).to(gathered_tokens.dtype)
-        )  # shape [batch_size * seq_len * num_experts_per_token, d_model]
-
-        final_output_empty = paddle.zeros(
-            self.reshaped_input_shape, dtype=gathered_tokens.dtype
-        )
-        token_indices_for_scatter = self.sorted_token_indices.unsqueeze(
-            -1
-        ).expand(
-            -1, self.d_model
-        )  # shape [batch_size * seq_len * num_experts_per_token, d_model]
-
-        token_indices_for_scatter_single = token_indices_for_scatter[
-            :, 0:1
-        ].squeeze()  # shape [batch_size * seq_len * num_experts_per_token, 1]
-
-        final_output = paddle.scatter(
-            final_output_empty,
-            token_indices_for_scatter_single,
-            weighted_gathered_tokens,
-            overwrite=False,
+    def combine_postprocess(self, permutated_local_input_tokens: paddle.Tensor):
+        output = unpermute(
+            permutated_local_input_tokens,
+            self.reversed_local_input_permutation_mapping,
+            restore_shape=self.reshaped_input_shape,
+            probs=self.gates_masked,
+            routing_map=self.routing_map,
         )
 
-        # When using non-deterministic mode, index_add and scatter give similar precision.
-        # In deterministic mode, index_add yields more precise results — but it is significantly slower.
-        # For most use cases (where ultra-high precision isn’t required), scatter is recommended for better performance.
-        # final_output = paddle.index_add(
-        #     x=final_output_empty,
-        #     index=token_indices_for_scatter_single,
-        #     axis=0,
-        #     value=weighted_gathered_tokens,
-        # )
-
-        return final_output
+        return output

--- a/src/paddlefleet/transformer/moe/token_dispatcher.py
+++ b/src/paddlefleet/transformer/moe/token_dispatcher.py
@@ -426,7 +426,7 @@ class AllToAllTokenDispatcher(nn.Layer):
         self.num_experts = (
             self.num_experts_per_device * self.expert_model_parallel_size
         )
-        mask = mask.to(paddle.int64)
+        mask = mask.to(paddle.int32)
 
         if len(hidden_states.shape) == 3:
             batch_size, seq_len, d_model = hidden_states.shape
@@ -447,10 +447,10 @@ class AllToAllTokenDispatcher(nn.Layer):
         ).reshape(self.expert_model_parallel_size, self.num_experts)
         num_global_tokens_per_local_expert = num_global_tokens_per_expert[
             :, self.local_expert_indices[0] : self.local_expert_indices[-1] + 1
-        ].contiguous()
+        ].clone()
 
         # Can also use the two AllToAll functions below instead of the above AllGather
-        # It will be a little bit faster , but also has a little more accuracy diff with DeepEP version
+        # It will save memory , but also has more accuracy diff with DeepEP version
         # global_tokens_per_expert = _AllToAll.apply(
         #     [tokens_per_expert.shape[0]],
         #     tokens_per_expert,
@@ -471,7 +471,7 @@ class AllToAllTokenDispatcher(nn.Layer):
         )
 
         self.output_splits = num_global_tokens_per_rank.cpu().tolist()
-        num_local_tokens_per_expert = self.routing_map.sum(dim=0).long()
+        num_local_tokens_per_expert = self.routing_map.sum(dim=0)
         self.input_split_sizes = num_local_tokens_per_expert.reshape(
             self.expert_model_parallel_size, self.num_local_experts
         ).sum(axis=1)

--- a/src/paddlefleet/transformer/moe/token_dispatcher.py
+++ b/src/paddlefleet/transformer/moe/token_dispatcher.py
@@ -601,11 +601,10 @@ class AllToAllTokenDispatcher(nn.Layer):
         ).T.ravel()
 
         if self.num_local_experts > 1 and not self.is_empty_tokens:
-            global_input_tokens, global_probs = sort_chunks_by_idxs(
+            global_input_tokens, _ = sort_chunks_by_idxs(
                 global_input_tokens,
                 self.num_global_tokens_per_local_expert.ravel(),
                 self.sort_input_by_local_experts,
-                probs=None,
             )
         sorted_tokens = global_input_tokens
         self.tokens_per_expert_post_gather = self.tokens_per_expert


### PR DESCRIPTION
目前当设置 `moe_token_dispatcher_type: "alltoall"` 时，如果 EP > 1 且 TP > 1 会导致 loss 计算错误。

<img width="336" height="221" alt="image" src="https://github.com/user-attachments/assets/87d2c6cf-3467-482d-bc15-9cb3355216e6" />


本次修复修改了 AllToAll 的实现。

## ⚠️ 注意

AllToAll  显存占用较高，如在训练中出现 OOM 或 hang 住的问题，可以考虑修改并行策略减少显存。

## GLM 测试

完整 benchmark 四机测试结果

| 指标                     | 概览        | loss diff      | 
|--------------------------|--------------------|--------------------|
|                | <img width="420" height="277" alt="image" src="https://github.com/user-attachments/assets/3808d104-90f5-42bd-a446-fe6932fa4407" /> |  <img width="420" height="277" alt="image" src="https://github.com/user-attachments/assets/1655022f-cf41-4358-911c-7ea05ce6dc15" />  | 

缩小 acc=1，四机，运行 100 步测试结果

| 指标                     | 概览        | loss diff      | 
|--------------------------|--------------------|--------------------|
|                | <img width="420" height="277" alt="image" src="https://github.com/user-attachments/assets/3c6e9122-bb58-4303-b82c-cab016c75f0f" /> |  <img width="420" height="277" alt="image" src="https://github.com/user-attachments/assets/0f5904dc-c2c0-49da-96c6-a85a0cdbf66d" />  | 


## Qwen 测试

完整 benchmark ，缩小 acc=1，TP=4，单机，运行 100 步测试结果


| 指标                     | 概览        | loss diff      | 
|--------------------------|--------------------|--------------------|
|                |  <img width="420" height="277" alt="image" src="https://github.com/user-attachments/assets/f6320e76-b1f1-4f0f-8a9a-ca532ffd17c1" />   |   <img width="420" height="277" alt="image" src="https://github.com/user-attachments/assets/a3f4a387-0822-4158-8aee-acb91cc56dde" />   | 
