### PR TITLE
fix seq_aux_loss

### DIFF
--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -205,22 +205,17 @@ class StandardMoERouter(nn.Layer):
         aux_loss = paddle.sum(me * ce) * float(self.num_experts)
         return aux_loss
 
-    def _cal_seq_aux_loss(self, probs, top_k, routing_map, max_seq_len):
+    def _cal_seq_aux_loss(self, probs, top_k, routing_map, seq_len):
         # all_probs and routing_map should be computed using the runtime local sequence length on each worker.
         if (
             self.tensor_model_parallel_size > 1
             or self.context_parallel_size > 1
         ):
-            local_seq_len = max_seq_len
-            if self.sequence_parallel and self.tensor_model_parallel_size > 1:
-                assert local_seq_len % self.tensor_model_parallel_size == 0
-                local_seq_len = local_seq_len // self.tensor_model_parallel_size
-            if self.context_parallel_size > 1:
-                assert local_seq_len % self.context_parallel_size == 0
-                local_seq_len = local_seq_len // self.context_parallel_size
+            local_seq_len = seq_len
             # [B*S, E]
             if self.sequence_parallel and self.tensor_model_parallel_size > 1:
                 all_probs = AllGatherOp.apply(probs)
+                local_seq_len = local_seq_len * self.tensor_model_parallel_size
             else:
                 all_probs = probs
             # [B, S, E]
@@ -228,20 +223,22 @@ class StandardMoERouter(nn.Layer):
                 all_probs = all_probs.reshape(
                     [
                         -1,
-                        max_seq_len // self.context_parallel_size,
+                        local_seq_len,
                         self.num_experts,
                     ]
                 )
                 # [B, S, E]
                 all_probs = ContextParallelAllGatherOp.apply(all_probs, axis=1)
+                local_seq_len = local_seq_len * self.context_parallel_size
             else:
                 # [B, S, E]
                 all_probs = all_probs.reshape(
-                    [-1, max_seq_len, self.num_experts]
+                    [-1, local_seq_len, self.num_experts]
                 )
             batch_size = all_probs.shape[0]
             # [B, S, E]
-            routing_map = routing_map.reshape([batch_size, local_seq_len, -1])
+            routing_map = routing_map.reshape([batch_size, seq_len, -1])
+            max_seq_len = local_seq_len
         else:
             # [B, S, E]
             if len(probs.shape) == 2:
@@ -249,6 +246,7 @@ class StandardMoERouter(nn.Layer):
             batch_size, local_seq_len, _ = probs.shape
             all_probs = probs
             routing_map = routing_map.reshape([batch_size, local_seq_len, -1])
+            max_seq_len = local_seq_len
 
         seq_axis = 1
         # Both cost_coeff and seq_aux_loss must be computed with the global sequence length visible to all workers.


### PR DESCRIPTION
paddlefleet组网中seq_aux_loss传入的是local_seq_len，但是计算seq_aux_loss使用的是max_seq_aux，传参对不上，这里做修复