### PR TITLE
【moe】add moe_fuse config only lora use

### DIFF
--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -138,11 +138,7 @@ class MoELayer(nn.Layer):
         self.moe_use_fusion_node = False
         if self.expert_model_parallel_size > 1:
             if self.moe_token_dispatcher_type == "deepep":
-                self.moe_use_fusion_node = (
-                    config.moe_use_fusion_node
-                    if config.moe_use_fusion_node is not None
-                    else True
-                )
+                self.moe_use_fusion_node = config.moe_use_fusion_node
             else:
                 if self.moe_grouped_gemm:
                     logger.warning(

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -138,7 +138,11 @@ class MoELayer(nn.Layer):
         self.moe_use_fusion_node = False
         if self.expert_model_parallel_size > 1:
             if self.moe_token_dispatcher_type == "deepep":
-                self.moe_use_fusion_node = True
+                self.moe_use_fusion_node = (
+                    config.moe_use_fusion_node
+                    if config.moe_use_fusion_node is not None
+                    else True
+                )
             else:
                 if self.moe_grouped_gemm:
                     logger.warning(

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -309,11 +309,11 @@ class TransformerConfig(ModelParallelConfig):
     """The type of token dispatcher to use. The default is 'allgather'.
     Options are 'allgather','alltoall' and 'deepep'."""
 
-    moe_use_fusion_node: bool | None = None
-    """Whether to use fusion node for MoE layer. If None, will be set to True when moe_token_dispatcher_type is deepep"""
+    moe_use_fusion_node: bool = True
+    """Whether to use fusion node for MoE layer. Default is True""
 
     moe_router_load_balancing_type: str = "aux_loss"
-    """"Options are aux_loss, seq_aux_loss, global_aux_loss, sinkhorn"""
+    """ "Options are aux_loss, seq_aux_loss, global_aux_loss, sinkhorn" ""
 
     moe_layer_freq: int | list[int] | None = None
     """Frequency between MoE layers and Dense layers. Accepts either:

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -310,10 +310,10 @@ class TransformerConfig(ModelParallelConfig):
     Options are 'allgather','alltoall' and 'deepep'."""
 
     moe_use_fusion_node: bool = True
-    """Whether to use fusion node for MoE layer. Default is True""
+    """Whether to use fusion node for MoE layer. Default is True"""
 
     moe_router_load_balancing_type: str = "aux_loss"
-    """ "Options are aux_loss, seq_aux_loss, global_aux_loss, sinkhorn" ""
+    """"Options are aux_loss, seq_aux_loss, global_aux_loss, sinkhorn"""
 
     moe_layer_freq: int | list[int] | None = None
     """Frequency between MoE layers and Dense layers. Accepts either:

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -309,6 +309,9 @@ class TransformerConfig(ModelParallelConfig):
     """The type of token dispatcher to use. The default is 'allgather'.
     Options are 'allgather','alltoall' and 'deepep'."""
 
+    moe_use_fusion_node: bool | None = None
+    """Whether to use fusion node for MoE layer. If None, will be set to True when moe_token_dispatcher_type is deepep"""
+
     moe_router_load_balancing_type: str = "aux_loss"
     """"Options are aux_loss, seq_aux_loss, global_aux_loss, sinkhorn"""
 


### PR DESCRIPTION
self.moe_use_fusion_node 当moe 通信是deepep 时，lora model 不能使用fused对expert 计算方式, 因此在formers 中将这个开关默认为false 
https://github.com/PaddlePaddle/PaddleFormers/pull/3450/files