### PR TITLE
[MoE Layer] Add moe_ep_barrier configuration

### DIFF
--- a/src/paddlefleet/transformer/moe/fused_a2a.py
+++ b/src/paddlefleet/transformer/moe/fused_a2a.py
@@ -101,9 +101,11 @@ def fused_dispatch_forward_func(
     previous_event=None,
     async_finish=False,
     allocate_on_comm_stream=False,
+    moe_ep_barrier: bool = True,
 ):
     """Forward pass of fused dispatch."""
-    barrier_ep(group)
+    if moe_ep_barrier:
+        barrier_ep(group)
     # Calculate layout before actual dispatch
     if isinstance(x, tuple):
         buffer = get_buffer(group, get_hidden_bytes(x[0]))
@@ -163,9 +165,11 @@ def fused_dispatch_backward_func(
     previous_event=None,
     async_finish=False,
     allocate_on_comm_stream=False,
+    moe_ep_barrier: bool = True,
 ):
     """Backward pass of fused dispatch."""
-    barrier_ep(group)
+    if moe_ep_barrier:
+        barrier_ep(group)
 
     buffer = get_buffer(group, get_hidden_bytes(grad_output))
 
@@ -187,9 +191,11 @@ def fused_combine_forward_func(
     previous_event=None,
     async_finish=False,
     allocate_on_comm_stream=False,
+    moe_ep_barrier: bool = True,
 ):
     """Forward pass of fused combine."""
-    barrier_ep(group)
+    if moe_ep_barrier:
+        barrier_ep(group)
 
     handle = states["handle"]
     buffer = get_buffer(group, get_hidden_bytes(x))
@@ -210,9 +216,11 @@ def fused_combine_backward_func(
     previous_event=None,
     async_finish=False,
     allocate_on_comm_stream=False,
+    moe_ep_barrier: bool = True,
 ):
     """Backward pass of fused combine."""
-    barrier_ep(group)
+    if moe_ep_barrier:
+        barrier_ep(group)
 
     if isinstance(grad_output, tuple):
         buffer = get_buffer(group, get_hidden_bytes(grad_output[0]))
@@ -248,6 +256,7 @@ class FusedDispatch(PyLayer):
         group,
         previous_event=None,
         fp8_dispatch: bool = False,
+        moe_ep_barrier: bool = True,
     ):
         """Forward pass of fused dispatch."""
         if fp8_dispatch:
@@ -261,13 +270,20 @@ class FusedDispatch(PyLayer):
             scale = scale.T
             x = (x_fp8, scale)
         recv_x, recv_token_probs, states, event = fused_dispatch_forward_func(
-            x, token_indices, token_probs, num_experts, group, previous_event
+            x,
+            token_indices,
+            token_probs,
+            num_experts,
+            group,
+            previous_event,
+            moe_ep_barrier=moe_ep_barrier,
         )
 
         ctx.group = group
         ctx.handle = states["handle"]
         ctx.event = event
         ctx.set_grad_in_dtype_consistent(False)
+        ctx.moe_ep_barrier = moe_ep_barrier
         if fp8_dispatch:
             recv_x, scale = recv_x
             return recv_x, recv_token_probs, states, {"scale": scale}
@@ -277,7 +293,11 @@ class FusedDispatch(PyLayer):
     def backward(ctx, grad_output, grad_token_probs):
         """Backward pass of fused dispatch."""
         return fused_dispatch_backward_func(
-            grad_output, grad_token_probs, ctx.group, ctx.handle
+            grad_output,
+            grad_token_probs,
+            ctx.group,
+            ctx.handle,
+            moe_ep_barrier=ctx.moe_ep_barrier,
         )
 
 
@@ -285,15 +305,18 @@ class FusedCombine(PyLayer):
     """Fused combine operation for MoE output combining computation and communication."""
 
     @staticmethod
-    def forward(ctx, x, group, states, previous_event=None):
+    def forward(
+        ctx, x, group, states, previous_event=None, moe_ep_barrier: bool = True
+    ):
         """Forward pass of fused combine."""
         combined_x = fused_combine_forward_func(
-            x, group, states, previous_event
+            x, group, states, previous_event, moe_ep_barrier=moe_ep_barrier
         )
 
         ctx.handle = states["handle"]
         ctx.group = group
         ctx.previous_event = previous_event
+        ctx.moe_ep_barrier = moe_ep_barrier
 
         return combined_x
 
@@ -301,7 +324,11 @@ class FusedCombine(PyLayer):
     def backward(ctx, grad_output):
         """Backward pass of fused combine."""
         return fused_combine_backward_func(
-            grad_output, ctx.group, ctx.handle, ctx.previous_event
+            grad_output,
+            ctx.group,
+            ctx.handle,
+            ctx.previous_event,
+            moe_ep_barrier=ctx.moe_ep_barrier,
         )
 
 
@@ -362,6 +389,7 @@ if HAVE_DEEP_EP:
         group: Group,
         previous_event=None,
         fp8_dispatch: bool = False,
+        moe_ep_barrier: bool = True,
     ):
         """Perform fused dispatch operation if deep_ep is available.
 
@@ -372,6 +400,7 @@ if HAVE_DEEP_EP:
             num_experts: Number of experts
             group: Process group
             previous_event: Previous CUDA event
+            moe_ep_barrier: Whether to use barrier for expert parallelism
 
         Returns:
             Result of FusedDispatch
@@ -384,10 +413,16 @@ if HAVE_DEEP_EP:
             group,
             previous_event,
             fp8_dispatch,
+            moe_ep_barrier,
         )
 
     def fused_combine(
-        x, group, handle, previous_event=None, combine_overlap_handle=None
+        x,
+        group,
+        handle,
+        previous_event=None,
+        combine_overlap_handle=None,
+        moe_ep_barrier: bool = True,
     ):
         """Perform fused combine operation if deep_ep is available.
 
@@ -396,6 +431,8 @@ if HAVE_DEEP_EP:
             group: Process group
             handle: Communication handle
             previous_event: Previous CUDA event
+            combine_overlap_handle: Handle for overlapping with shared experts
+            moe_ep_barrier: Whether to use barrier for expert parallelism
 
         Returns:
             Result of FusedCombine
@@ -403,7 +440,9 @@ if HAVE_DEEP_EP:
         states = {}
         states["handle"] = handle
         if combine_overlap_handle is None:
-            return FusedCombine.apply(x, group, states, previous_event)
+            return FusedCombine.apply(
+                x, group, states, previous_event, moe_ep_barrier
+            )
         else:
             assert previous_event is None
             assert isinstance(combine_overlap_handle, dict)

--- a/src/paddlefleet/transformer/moe/fused_a2a.py
+++ b/src/paddlefleet/transformer/moe/fused_a2a.py
@@ -440,7 +440,7 @@ if HAVE_DEEP_EP:
             fp8_dispatch,
             async_finish,
             allocate_on_comm_stream,
-            moe_ep_barrier,
+            moe_ep_barrier=moe_ep_barrier,
         )
 
     def fused_combine(
@@ -469,7 +469,12 @@ if HAVE_DEEP_EP:
         states["handle"] = handle
         if combine_overlap_handle is None:
             return FusedCombine.apply(
-                x, group, states, previous_event, async_finish, moe_ep_barrier
+                x,
+                group,
+                states,
+                previous_event,
+                async_finish,
+                moe_ep_barrier=moe_ep_barrier,
             )
         else:
             assert previous_event is None

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -86,6 +86,7 @@ class MoELayer(nn.Layer):
 
         self.router_aux_loss_coef = config.router_aux_loss_coef
         self.moe_grouped_gemm = config.moe_grouped_gemm
+        self.moe_ep_barrier = config.moe_ep_barrier
         self.moe_group = pg_collection.ep
         self.expert_model_parallel_size = (
             utils.get_pg_size(self.moe_group)
@@ -197,6 +198,7 @@ class MoELayer(nn.Layer):
                     self.num_experts_per_tok,
                     self.num_experts,
                     self.moe_group,
+                    self.moe_ep_barrier,
                 )
             elif self.moe_token_dispatcher_type == "alltoall":
                 self.token_dispatcher = AllToAllTokenDispatcher(

--- a/src/paddlefleet/transformer/moe/token_dispatcher.py
+++ b/src/paddlefleet/transformer/moe/token_dispatcher.py
@@ -109,11 +109,13 @@ class _DeepepManager(_DispatchManager):
         router_topk: int,
         num_experts: int | None = None,
         num_local_experts: int | None = None,
+        moe_ep_barrier: bool = True,
     ):
         self.group = group
         self.router_topk = router_topk
         self.num_experts = num_experts
         self.num_local_experts = num_local_experts
+        self.moe_ep_barrier = moe_ep_barrier
 
         # Metadata
         self.token_indices = None
@@ -146,6 +148,7 @@ class _DeepepManager(_DispatchManager):
             self.num_experts,
             self.group,
             fp8_dispatch=fp8_dispatch,
+            moe_ep_barrier=self.moe_ep_barrier,
         )
         self.handle = states["handle"]
         self.tokens_per_expert = states["tokens_per_expert"]
@@ -200,7 +203,12 @@ class _DeepepManager(_DispatchManager):
         combine_overlap_handle: dict | None = None,
     ) -> paddle.Tensor:
         hidden_states = fused_combine(
-            hidden_states, self.group, self.handle, None, combine_overlap_handle
+            hidden_states,
+            self.group,
+            self.handle,
+            None,
+            combine_overlap_handle,
+            moe_ep_barrier=self.moe_ep_barrier,
         )
         # Release the handle after combine operation
         self.handle = None
@@ -306,6 +314,7 @@ class MoEFlexTokenDispatcher(MoETokenDispatcher):
         num_experts_per_tok: int,
         n_routed_experts: int,
         ep_group: Group,
+        moe_ep_barrier: bool = True,
     ):
         super().__init__(ep_group)
 
@@ -316,6 +325,7 @@ class MoEFlexTokenDispatcher(MoETokenDispatcher):
             router_topk=num_experts_per_tok,
             num_experts=n_routed_experts,
             num_local_experts=self.num_local_experts,
+            moe_ep_barrier=moe_ep_barrier,
         )
 
     def dispatch_preprocess(

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -382,6 +382,9 @@ class TransformerConfig(ModelParallelConfig):
     moe_shared_expert_overlap: bool = False
     """Enable overlapping between shared expert computations and a2a combinet"""
 
+    moe_ep_barrier: bool = True
+    """Whether to use barrier for expert parallelism."""
+
     ##################
     # Context Parallel
     ##################


### PR DESCRIPTION
添加 ep_barrier 可配置项。

**测试**

测试 Qwen3 标准测试结果如下：

<img width="356" height="236" alt="image" src="https://github.com/user-attachments/assets/143758e8-31b5-4b56-8ec5-c5fad77a66c0" />

平均tokens/second/device: 6826.56个（开 barrier） / 6939.84个（关 barrier）

**注意**

- 不同模型、配置对于开/关 barrier 的性能变化会有不同。

- moe_ep_barrier 开关默认开启，冷启建议保持开启；热启只有当确定模型已进入稳定训练状态后才建议关闭。

本 PR 需要等待 https://github.com/PaddlePaddle/PaddleFormers/pull/3498 合入后，再合入。