### PR TITLE
[CI] nightly group

### DIFF
--- a/.github/workflows/publish_wheel_nightly.yml
+++ b/.github/workflows/publish_wheel_nightly.yml
@@ -21,7 +21,7 @@ on:
 permissions: read-all
 
 concurrency:
-  group: ${{ github.workflow }}-all
+  group: ${{ github.workflow }}-all-${{ github.ref_type }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
使用同一个分组名会导致nightly编包和push到release编包冲突，先触发任务会被取消