### PR TITLE
Disable rr_attn_estimate_triton_op test

### DIFF
--- a/tests/single_card_tests/disable_single_card_uts.txt
+++ b/tests/single_card_tests/disable_single_card_uts.txt
@@ -3,3 +3,4 @@ test_llava_model.py
 test_clip_vit_model.py
 test_moe.py
 test_count_cumsum.py
+test_rr_attn_estimate_triton_op.py


### PR DESCRIPTION
暂时禁用test_rr_attn_estimate_triton_op单测，解决Paddle单测耗时过久的问题。