### PR TITLE
Recover test_tokens_unzip_gather

### DIFF
--- a/tests/single_card_tests/custom_ops/test_tokens_unzip_gather.py
+++ b/tests/single_card_tests/custom_ops/test_tokens_unzip_gather.py
@@ -92,8 +92,8 @@ class TestTokensUnzipGatherUE8M0Scale(unittest.TestCase):
         SEQLEN = 16384
         TOKEN_LEN = 7168
         DTYPES = ["float8_e4m3fn"]
-        EXPERT_NUMS = [4, 8, 16]
-        TOPKS = [4, 8, 16]
+        EXPERT_NUMS = [16]
+        TOPKS = [8]
         # Generate test data
         for dt, expert_num, topk in itertools.product(
             DTYPES, EXPERT_NUMS, TOPKS

--- a/tests/single_card_tests/disable_single_card_uts.txt
+++ b/tests/single_card_tests/disable_single_card_uts.txt
@@ -4,4 +4,3 @@ test_clip_vit_model.py
 test_moe.py
 test_count_cumsum.py
 test_rr_attn_estimate_triton_op.py
-test_tokens_unzip_gather.py


### PR DESCRIPTION
-  恢复test_tokens_unzip_gather 这个单测
- 减小 test_tokens_unzip_gather 里面的测试任务量来降低这个单测的耗时。
本地测试耗时20s左右
<img width="1400" height="172" alt="image" src="https://github.com/user-attachments/assets/4b249dc3-c75c-4845-8215-630c76bcc6cd" />
