### PR TITLE
[MoE] Add moe_use_pfcc_deepep flag

### DIFF
--- a/src/paddlefleet/transformer/moe/fused_a2a.py
+++ b/src/paddlefleet/transformer/moe/fused_a2a.py
@@ -21,6 +21,8 @@ try:
 except ImportError:
     HAVE_DEEP_EP = False
 
+import importlib
+
 import paddle
 from paddle import framework
 from paddle.autograd import PyLayer
@@ -29,6 +31,14 @@ from paddle.distributed.communication.group import Group
 from .moe_utils import manual_backward
 
 _buffer = None
+
+
+def set_pfcc_deep_ep_backend():
+    global deep_ep, HAVE_DEEP_EP, _buffer
+    pfcc_deep_ep = importlib.import_module("paddlefleet.ops.deep_ep")
+    deep_ep = pfcc_deep_ep
+    _buffer = None
+    HAVE_DEEP_EP = deep_ep is not None
 
 
 def barrier_ep(ep_group):

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -43,6 +43,9 @@ from .moe_shared_expert import StandardMLPSharedExpert
 from .moe_utils import AddAuxiliaryLoss
 from .token_dispatcher import AllToAllTokenDispatcher, MoEFlexTokenDispatcher
 
+# To avoid repeated imports and backend switching
+_PFCC_DEEP_EP_BACKEND_SET = False
+
 logger = logging.getLogger(__name__)
 
 if paddlefleet.ops.is_sonic_moe_available():
@@ -246,7 +249,8 @@ class MoELayer(nn.Layer):
 
         if self.expert_model_parallel_size > 1:
             if self.moe_token_dispatcher_type == "deepep":
-                if self.moe_use_pfcc_deepep:
+                global _PFCC_DEEP_EP_BACKEND_SET
+                if self.moe_use_pfcc_deepep and not _PFCC_DEEP_EP_BACKEND_SET:
                     from .fused_a2a import (
                         set_pfcc_deep_ep_backend as set_pfcc_deep_ep_backend_a2a,
                     )
@@ -257,6 +261,8 @@ class MoELayer(nn.Layer):
                     )
 
                     set_pfcc_deep_ep_backend_layer()
+                    _PFCC_DEEP_EP_BACKEND_SET = True
+
                 self.token_dispatcher = MoEFlexTokenDispatcher(
                     self.num_experts_per_device,
                     self.num_experts_per_tok,

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -136,7 +136,7 @@ class MoELayer(nn.Layer):
                     "paddlefleet.ops.sonicmoe"
                 ]
             )
-
+        self.moe_use_pfcc_deepep = config.moe_use_pfcc_deepep
         self.router_aux_loss_coef = config.router_aux_loss_coef
         self.moe_grouped_gemm = config.moe_grouped_gemm
         self.moe_ep_barrier = config.moe_ep_barrier
@@ -246,6 +246,17 @@ class MoELayer(nn.Layer):
 
         if self.expert_model_parallel_size > 1:
             if self.moe_token_dispatcher_type == "deepep":
+                if self.moe_use_pfcc_deepep:
+                    from .fused_a2a import (
+                        set_pfcc_deep_ep_backend as set_pfcc_deep_ep_backend_a2a,
+                    )
+
+                    set_pfcc_deep_ep_backend_a2a()
+                    from paddlefleet.transformer.transformer_layer import (
+                        set_pfcc_deep_ep_backend as set_pfcc_deep_ep_backend_layer,
+                    )
+
+                    set_pfcc_deep_ep_backend_layer()
                 self.token_dispatcher = MoEFlexTokenDispatcher(
                     self.num_experts_per_device,
                     self.num_experts_per_tok,

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -313,6 +313,9 @@ class TransformerConfig(ModelParallelConfig):
     """The type of token dispatcher to use. The default is 'allgather'.
     Options are 'allgather','alltoall' and 'deepep'."""
 
+    moe_use_pfcc_deepep: bool = False
+    """Whether to use PFCC DeepEP for the MoE layer. If False, Paddle DeepEP is used. This argument takes effect only when moe_token_dispatcher_type is set to 'deepep'."""
+
     moe_use_fusion_node: bool = True
     """Whether to use fusion node for MoE layer. Default is True"""
 

--- a/src/paddlefleet/transformer/transformer_layer.py
+++ b/src/paddlefleet/transformer/transformer_layer.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+import importlib
 import logging
 from collections import OrderedDict
 from dataclasses import dataclass, field
@@ -76,6 +77,12 @@ def tensors_clone(outputs):
         raise ValueError(
             f"Unsupported data type:{type(outputs)} in tensors_clone"
         )
+
+
+def set_pfcc_deep_ep_backend():
+    global deep_ep
+    pfcc_deep_ep = importlib.import_module("paddlefleet.ops.deep_ep")
+    deep_ep = pfcc_deep_ep
 
 
 @dataclass


### PR DESCRIPTION
添加 moe_use_pfcc_deepep 开关，在 `moe_token_dispatcher_type = "deepep"`, 时如果为 True，会使用 Paddlefleet 中的 deepep，否则使用 paddle 的 deepep