### PR TITLE
[MoE Layer] Change moe_grouped_gemm Not Support Warning to Error

### DIFF
--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -198,12 +198,9 @@ class MoELayer(nn.Layer):
                 self.moe_use_fusion_node = config.moe_use_fusion_node
             else:
                 if self.moe_grouped_gemm:
-                    logger.warning(
-                        "moe_grouped_gemm is not supported when moe_token_dispatcher_type != 'deepep'."
+                    raise ValueError(
+                        "moe_grouped_gemm is only supported when moe_token_dispatcher_type is 'deepep' and on GPU architecture SM90 or higher. If these conditions are not met, please set it to false in the configuration yaml."
                     )
-                self.moe_grouped_gemm = (
-                    False  # TODO: Support EP>1 alltoall moe_grouped_gemm
-                )
                 self.fp8_dispatch = False
 
         if self.fp8:

--- a/tests/multi_card_tests/moe/test_grouped_gemm_error.py
+++ b/tests/multi_card_tests/moe/test_grouped_gemm_error.py
@@ -63,10 +63,10 @@ class TestFusionBF16ExpertParallel(unittest.TestCase):
         model_parallel_cuda_manual_seed(seed)
         self.pg_collection = ProcessGroupCollection.use_mpu_process_groups()
 
-    def test_moe_fusion(self):
+    def test_moe_grouped_gemm(self):
         n_routed_experts = 64
-        hidden_size = 64
-        transformer_config_moe = TransformerConfig(
+        hidden_size = 256
+        transformer_config = TransformerConfig(
             hidden_size=hidden_size,
             num_attention_heads=4,
             n_routed_experts=n_routed_experts,
@@ -77,30 +77,34 @@ class TestFusionBF16ExpertParallel(unittest.TestCase):
             sequence_parallel=False,
             bf16=True,
             params_dtype=paddle.bfloat16,
-            moe_intermediate_size=64,
+            moe_intermediate_size=128,
             gated_linear_unit=True,
             n_shared_experts=0,
             hidden_act=F.silu,
-            moe_grouped_gemm=False,
-            moe_token_dispatcher_type="alltoall",
+            moe_grouped_gemm=True,
             bias_activation_fusion=True,
+            moe_token_dispatcher_type="alltoall",
         )
 
         transformer_layer_spec = get_gpt_layer_local_spec(
             num_experts=n_routed_experts
         )
 
-        moe_layer = MoELayer(
-            transformer_config_moe,
-            transformer_layer_spec.sublayers_spec.mlp.extra_kwargs["sublayers"],
-            self.pg_collection,
-        )
+        # This configuration should raise a ValueError because:
+        # moe_grouped_gemm=True is only supported when moe_token_dispatcher_type is 'deepep'
+        # but current moe_token_dispatcher_type='alltoall'
+        with self.assertRaises(ValueError) as context:
+            moe_layer = MoELayer(
+                transformer_config,
+                transformer_layer_spec.sublayers_spec.mlp.extra_kwargs[
+                    "sublayers"
+                ],
+                self.pg_collection,
+            )
 
-        input_data = paddle.randn(4, 64, hidden_size, dtype=paddle.bfloat16)
-
-        output = moe_layer(input_data)[0]
-
-        assert output.shape == (4, 64, hidden_size)
+        # Verify the error message contains the expected content
+        expected_error_msg = "moe_grouped_gemm is only supported when moe_token_dispatcher_type is"
+        self.assertIn(expected_error_msg, str(context.exception))
 
     def tearDown(self):
         pass


### PR DESCRIPTION
当 moe_grouped_gemm 在机器上不支持或因为非 deepep 时，会自动 fallback 即关闭 moe_grouped_gemm。

但是在 PaddleFormers 中是通过 config.moe_grouped_gemm 来判断是否走 grouped gemm 的 AOA Config；现在在 Fleet 里关闭后，Formers 并不会感知到，导致最后 AOA 报错，导致用户困惑找不到真实原因。

因此将 fallback 逻辑去除，强制让用户在 config 里设置 moe_grouped_gemm 为 false，这样 PaddleFormers 里获取的 config.moe_grouped_gemm 就为真实运行的配置。