### PR TITLE
[JIT] disable dy2st in fleet only

### DIFF
--- a/src/paddlefleet/jit.py
+++ b/src/paddlefleet/jit.py
@@ -15,7 +15,6 @@
 
 import paddle
 
-jit_fuser = paddle.jit.to_static(backend="CINN")
-
-# TODO(Ruibiao): enable to_static later
-paddle.jit.enable_to_static(False)
+# TODO(Ruibiao): enable to_static later, just return original function now.
+# jit_fuser = paddle.jit.to_static(backend="CINN")
+jit_fuser = lambda fn: fn

--- a/src/paddlefleet/jit.py
+++ b/src/paddlefleet/jit.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 # Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
 
-import paddle
-
 # TODO(Ruibiao): enable to_static later, just return original function now.
 # jit_fuser = paddle.jit.to_static(backend="CINN")
 jit_fuser = lambda fn: fn


### PR DESCRIPTION
直接让 `jit_fuser` 返回原来的函数，避免 `paddle.jit.enable_to_static(False)` 的副作用扩散到其他模块