### PR TITLE
【BugFix】refine moe_layer.py

### DIFF
--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -650,7 +650,6 @@ class MoELayer(nn.Layer):
             output = AddAuxiliaryLoss.apply(hidden_states, aux_loss)
         else:
             output = hidden_states
-
         output = output.reshape(residuals.shape)
         if self.shared_experts is not None:
             shared_output = self.shared_experts(residuals)[0]

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -646,8 +646,10 @@ class MoELayer(nn.Layer):
     def aux_loss_compute(self, args):
         hidden_states, aux_loss, residuals = args
         if self.training and self.router_aux_loss_coef:
-            aux_loss = aux_loss * float(self.router_aux_loss_coef)
+            aux_loss = aux_loss * self.router_aux_loss_coef
             output = AddAuxiliaryLoss.apply(hidden_states, aux_loss)
+        else:
+            output = hidden_states
 
         output = output.reshape(residuals.shape)
         if self.shared_experts is not None:

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -646,7 +646,7 @@ class MoELayer(nn.Layer):
     def aux_loss_compute(self, args):
         hidden_states, aux_loss, residuals = args
         if self.training and self.router_aux_loss_coef:
-            aux_loss = aux_loss * self.router_aux_loss_coef
+            aux_loss = aux_loss * float(self.router_aux_loss_coef)
             output = AddAuxiliaryLoss.apply(hidden_states, aux_loss)
         else:
             output = hidden_states

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -646,7 +646,7 @@ class MoELayer(nn.Layer):
     def aux_loss_compute(self, args):
         hidden_states, aux_loss, residuals = args
         if self.training and self.router_aux_loss_coef:
-            aux_loss = aux_loss * self.router_aux_loss_coef
+            aux_loss = aux_loss * float(self.router_aux_loss_coef)
             output = AddAuxiliaryLoss.apply(hidden_states, aux_loss)
 
         output = output.reshape(residuals.shape)


### PR DESCRIPTION
- 背景

框架PR[#77710](https://github.com/PaddlePaddle/Paddle/pull/77710)，在张量与字符串对象进行乘法运算时和torch对齐

- 对齐前老paddle：paddle.to_tensor(2) * "0.001"，"0.001"是一个str，系统不会报错，会先对str进行转换，然后再乘；

- 对齐torch后新paddle：根据 Python 的数据模型，如果两个类型之间的运算不被支持，应当返回 NotImplemented。


PR合入后PaddleFLeet CE 单机单机GLM PT报错，原因是在moe_layers.py 中的 AddAuxiliaryLoss.apply(output, aux_loss)，把 MoE 的辅助损失加到主损失上这里的 aux_loss（辅助损失）本应是一个数值张量，但因为对齐torch，aux_loss = aux_loss * self.router_aux_loss_coef，aux_loss变成了一个字符串，然后paddle.numl需要一个tensor，但是接收到了字符串，故抛错
<img width="1440" height="756" alt="3a85404a9ce89c3feab93dda03b6e18c" src="https://github.com/user-attachments/assets/62a91e15-ffd8-418a-99dc-2b7866a43c66" />


此PR修复这个问题
