### PR TITLE
Refactor: Remove all redundant code related to moe_use_pfcc_deepep

### DIFF
--- a/src/paddlefleet/transformer/moe/fused_a2a.py
+++ b/src/paddlefleet/transformer/moe/fused_a2a.py
@@ -14,31 +14,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    from paddle.distributed.communication import deep_ep
-
-    HAVE_DEEP_EP = True
-except ImportError:
-    HAVE_DEEP_EP = False
-
-import importlib
-
 import paddle
 from paddle import framework
 from paddle.autograd import PyLayer
 from paddle.distributed.communication.group import Group
 
+import paddlefleet.ops.deep_ep as deep_ep
+
 from .moe_utils import manual_backward
 
 _buffer = None
-
-
-def set_pfcc_deep_ep_backend():
-    global deep_ep, HAVE_DEEP_EP, _buffer
-    pfcc_deep_ep = importlib.import_module("paddlefleet.ops.deep_ep")
-    deep_ep = pfcc_deep_ep
-    _buffer = None
-    HAVE_DEEP_EP = deep_ep is not None
+HAVE_DEEP_EP = deep_ep is not None
 
 
 def barrier_ep(ep_group):

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -43,9 +43,6 @@ from .moe_shared_expert import StandardMLPSharedExpert
 from .moe_utils import AddAuxiliaryLoss
 from .token_dispatcher import AllToAllTokenDispatcher, MoEFlexTokenDispatcher
 
-# To avoid repeated imports and backend switching
-_PFCC_DEEP_EP_BACKEND_SET = False
-
 logger = logging.getLogger(__name__)
 
 if paddlefleet.ops.is_sonic_moe_available():
@@ -139,7 +136,6 @@ class MoELayer(nn.Layer):
                     "paddlefleet.ops.sonicmoe"
                 ]
             )
-        self.moe_use_pfcc_deepep = config.moe_use_pfcc_deepep
         self.router_aux_loss_coef = config.router_aux_loss_coef
         self.moe_grouped_gemm = config.moe_grouped_gemm
         self.moe_ep_barrier = config.moe_ep_barrier
@@ -248,20 +244,6 @@ class MoELayer(nn.Layer):
 
         if self.expert_model_parallel_size > 1:
             if self.moe_token_dispatcher_type == "deepep":
-                global _PFCC_DEEP_EP_BACKEND_SET
-                if self.moe_use_pfcc_deepep and not _PFCC_DEEP_EP_BACKEND_SET:
-                    from .fused_a2a import (
-                        set_pfcc_deep_ep_backend as set_pfcc_deep_ep_backend_a2a,
-                    )
-
-                    set_pfcc_deep_ep_backend_a2a()
-                    from paddlefleet.transformer.transformer_layer import (
-                        set_pfcc_deep_ep_backend as set_pfcc_deep_ep_backend_layer,
-                    )
-
-                    set_pfcc_deep_ep_backend_layer()
-                    _PFCC_DEEP_EP_BACKEND_SET = True
-
                 self.token_dispatcher = MoEFlexTokenDispatcher(
                     self.num_experts_per_device,
                     self.num_experts_per_tok,

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -313,9 +313,6 @@ class TransformerConfig(ModelParallelConfig):
     """The type of token dispatcher to use. The default is 'deepep'.
     Options are 'allgather','alltoall' and 'deepep'."""
 
-    moe_use_pfcc_deepep: bool = True
-    """Whether to use PFCC DeepEP for the MoE layer. If False, Paddle DeepEP is used. This argument takes effect only when moe_token_dispatcher_type is set to 'deepep'."""
-
     moe_use_fusion_node: bool = True
     """Whether to use fusion node for MoE layer. Default is True"""
 

--- a/src/paddlefleet/transformer/transformer_layer.py
+++ b/src/paddlefleet/transformer/transformer_layer.py
@@ -15,7 +15,6 @@
 
 from __future__ import annotations
 
-import importlib
 import logging
 from collections import OrderedDict
 from dataclasses import dataclass, field
@@ -23,7 +22,7 @@ from typing import TYPE_CHECKING
 
 import paddle
 from paddle import Tensor, nn
-from paddle.distributed.communication import deep_ep
+import paddlefleet.ops.deep_ep as deep_ep
 from paddle.distributed.fleet.utils import recompute
 
 from paddlefleet.pipeline_parallel import ScheduleNode
@@ -77,12 +76,6 @@ def tensors_clone(outputs):
         raise ValueError(
             f"Unsupported data type:{type(outputs)} in tensors_clone"
         )
-
-
-def set_pfcc_deep_ep_backend():
-    global deep_ep
-    pfcc_deep_ep = importlib.import_module("paddlefleet.ops.deep_ep")
-    deep_ep = pfcc_deep_ep
 
 
 @dataclass


### PR DESCRIPTION
### PR Category

Code Refactoring

### PR Types

Others

### Description

This PR completes the cleanup of redundant code related to `moe_use_pfcc_deepep`, addressing the feedback that more redundant code needed to be removed beyond just the configuration option.

**Changes made:**

1. Remove `moe_use_pfcc_deepep` configuration from `TransformerConfig`
2. Remove `_PFCC_DEEP_EP_BACKEND_SET` global variable from `moe_layer.py`
3. Remove `set_pfcc_deep_ep_backend()` functions from both `fused_a2a.py` and `transformer_layer.py`
4. Always import `deep_ep` from `paddlefleet.ops.deep_ep` instead of `paddle.distributed.communication`
5. Remove the conditional backend switching logic in `MoELayer.__init__()`

**Rationale:**

Since we're now always using PFCC DeepEP (as indicated by @SigureMo's feedback that `_PFCC_DEEP_EP_BACKEND_SET` would always be `True`), the dynamic backend switching mechanism is no longer needed. This PR removes all the redundant code that was added in PR #473 to support the toggle between Paddle DeepEP and PFCC DeepEP.

Closes #538