### PR TITLE
[release/0.2] 【BugFix】refine moe_layer.py

### DIFF
--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -649,9 +649,10 @@ class MoELayer(nn.Layer):
     def aux_loss_compute(self, args):
         hidden_states, aux_loss, residuals = args
         if self.training and self.router_aux_loss_coef:
-            aux_loss = aux_loss * self.router_aux_loss_coef
+            aux_loss = aux_loss * float(self.router_aux_loss_coef)
             output = AddAuxiliaryLoss.apply(hidden_states, aux_loss)
-
+        else:
+            output = hidden_states
         output = output.reshape(residuals.shape)
         if self.shared_experts is not None:
             shared_output = self.shared_experts(residuals)[0]


### PR DESCRIPTION
- 背景

框架PR 77710（https://github.com/PaddlePaddle/Paddle/pull/77710），在张量与字符串对象进行乘法运算时和 torch 对齐。

- 对齐前老 paddle：`paddle.to_tensor(2) * "0.001"`，`"0.001"` 是一个 str，系统不会报错，会先对 str 进行转换，然后再乘；
- 对齐 torch 后新 paddle：根据 Python 的数据模型，如果两个类型之间的运算不被支持，应当返回 NotImplemented。

PR 合入后 PaddleFleet CE 单机 GLM PT 报错，原因是在 `moe_layers.py` 中的 `AddAuxiliaryLoss.apply(output, aux_loss)`：
`aux_loss = aux_loss * self.router_aux_loss_coef` 后 `aux_loss` 变成字符串，后续 `paddle.numel` 需要 tensor，导致报错。

此 PR 修复该问题。

Cherry-pick of #540 to release/0.2.

Merged in dev: #540
