### PR TITLE
[large tensor] fix CUDA extensions int64 overflow for large tensor dimensions

### DIFF
--- a/src/paddlefleet/_extensions/count_cumsum.cu
+++ b/src/paddlefleet/_extensions/count_cumsum.cu
@@ -248,6 +248,11 @@ std::vector<paddle::Tensor> CountCumsumCuda(const paddle::Tensor& x,
   }
 
   if (N == 0) {
+    // For N == 0, semantics require all-zero outputs instead of uninitialized memory.
+    count_output.zero_();
+    if (do_cumsum) {
+      cumsum_output.zero_();
+    }
     return {count_output, cumsum_output};
   }
 

--- a/src/paddlefleet/_extensions/count_cumsum.cu
+++ b/src/paddlefleet/_extensions/count_cumsum.cu
@@ -247,16 +247,6 @@ std::vector<paddle::Tensor> CountCumsumCuda(const paddle::Tensor& x,
     cumsum_output = paddle::empty({0}, paddle::DataType::INT32, place);
   }
 
-  if (N == 0) {
-    // For N == 0, semantics require all-zero outputs instead of uninitialized
-    // memory.
-    count_output.zero_();
-    if (do_cumsum) {
-      cumsum_output.zero_();
-    }
-    return {count_output, cumsum_output};
-  }
-
   if (x.dtype() == paddle::DataType::INT32) {
     count_cumsum_cuda_impl<int>(
         x, count_output, cumsum_output, do_cumsum, N, E, stream);

--- a/src/paddlefleet/_extensions/count_cumsum.cu
+++ b/src/paddlefleet/_extensions/count_cumsum.cu
@@ -248,7 +248,8 @@ std::vector<paddle::Tensor> CountCumsumCuda(const paddle::Tensor& x,
   }
 
   if (N == 0) {
-    // For N == 0, semantics require all-zero outputs instead of uninitialized memory.
+    // For N == 0, semantics require all-zero outputs instead of uninitialized
+    // memory.
     count_output.zero_();
     if (do_cumsum) {
       cumsum_output.zero_();

--- a/src/paddlefleet/_extensions/count_cumsum.cu
+++ b/src/paddlefleet/_extensions/count_cumsum.cu
@@ -27,16 +27,16 @@ namespace cg = cooperative_groups;
 
 using BlockScan = cub::BlockScan<uint32_t, BLOCK_SIZE>;
 
-template <typename T>
-inline __device__ void load_128_bits(const T* src, T* dst, uint32_t idx) {
-  uint32_t num_elements = 16 / sizeof(T);
+template <typename T, typename IdxT>
+inline __device__ void load_128_bits(const T* src, T* dst, IdxT idx) {
+  constexpr int num_elements = 16 / sizeof(T);
   float4 vec = *reinterpret_cast<const float4*>(src + idx * num_elements);
   *reinterpret_cast<float4*>(dst) = vec;
 }
 
-template <typename T>
-inline __device__ void store_128_bits(const T* src, T* dst, uint32_t idx) {
-  uint32_t num_elements = 16 / sizeof(T);
+template <typename T, typename IdxT>
+inline __device__ void store_128_bits(const T* src, T* dst, IdxT idx) {
+  constexpr int num_elements = 16 / sizeof(T);
   float4 vec = *reinterpret_cast<const float4*>(src);
   *reinterpret_cast<float4*>(dst + idx * num_elements) = vec;
 }
@@ -45,12 +45,13 @@ template <typename scalar_t>
 inline __device__ void _update_local_count(const scalar_t* x,
                                            int32_t* shared_memory,
                                            const int64_t& N,
-                                           const uint32_t& global_thread_id,
-                                           const uint32_t& grid_size) {
+                                           const uint32_t global_thread_id,
+                                           const uint32_t grid_size) {
   constexpr uint32_t N_per_thread = 16 / sizeof(scalar_t);
-  const uint32_t N_vec = N / N_per_thread;
+  const int64_t N_vec = N / N_per_thread;
+  const int64_t vec_covered = N_vec * N_per_thread;
 
-  for (uint32_t i = global_thread_id; i < N_vec; i += grid_size) {
+  for (int64_t i = global_thread_id; i < N_vec; i += grid_size) {
     scalar_t x_vec[N_per_thread];
     load_128_bits<scalar_t>(x, x_vec, i);
 
@@ -59,7 +60,7 @@ inline __device__ void _update_local_count(const scalar_t* x,
     }
   }
 
-  const uint32_t i = (N_vec * N_per_thread) + global_thread_id;
+  const int64_t i = vec_covered + global_thread_id;
   if (i < N) {
     atomicAdd(&shared_memory[x[i]], 1);
   }
@@ -111,6 +112,8 @@ __global__ void count_cumsum_cuda_kernel(const scalar_t* x,
                                          int32_t* cumsum_output,
                                          const int64_t N,
                                          const uint32_t E) {
+  // NOTE: gridDim = num_SMs is small (<256), grid_size and global_thread_id
+  // never exceed int range.
   const uint32_t global_thread_id = blockIdx.x * blockDim.x + threadIdx.x;
   const uint32_t grid_size = gridDim.x * blockDim.x;
 
@@ -242,6 +245,10 @@ std::vector<paddle::Tensor> CountCumsumCuda(const paddle::Tensor& x,
     cumsum_output = paddle::empty({E}, paddle::DataType::INT32, place);
   } else {
     cumsum_output = paddle::empty({0}, paddle::DataType::INT32, place);
+  }
+
+  if (N == 0) {
+    return {count_output, cumsum_output};
   }
 
   if (x.dtype() == paddle::DataType::INT32) {

--- a/src/paddlefleet/_extensions/filter_scores.cu
+++ b/src/paddlefleet/_extensions/filter_scores.cu
@@ -16,6 +16,7 @@
 #include <cuda_runtime.h>
 #include <paddle/extension.h>
 #include <cub/cub.cuh>
+#include <limits>
 #include <vector>
 
 __global__ void count_valid_kernel(const int64_t* indices,
@@ -25,7 +26,7 @@ __global__ void count_valid_kernel(const int64_t* indices,
            static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
            static_cast<int64_t>(threadIdx.x);
        i < total_elements;
-       i += gridDim.x * blockDim.x) {
+       i += static_cast<int64_t>(gridDim.x) * blockDim.x) {
     if (indices[i] != -1) {
       atomicAdd(valid_count, 1);
     }
@@ -39,7 +40,7 @@ __global__ void create_mask_kernel(const int64_t* indices,
            static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
            static_cast<int64_t>(threadIdx.x);
        i < total_elements;
-       i += gridDim.x * blockDim.x) {
+       i += static_cast<int64_t>(gridDim.x) * blockDim.x) {
     mask[i] = (indices[i] != -1) ? 1 : 0;
   }
 }
@@ -54,7 +55,7 @@ __global__ void scatter_scores_kernel(const scalar_t* probs,
            static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
            static_cast<int64_t>(threadIdx.x);
        i < total_elements;
-       i += gridDim.x * blockDim.x) {
+       i += static_cast<int64_t>(gridDim.x) * blockDim.x) {
     if (indices[i] != -1) {
       int write_idx = write_indices[i];
       output_scores[write_idx] = probs[i];
@@ -72,7 +73,7 @@ __global__ void scatter_grad_kernel(const scalar_t* grad_topk,
            static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
            static_cast<int64_t>(threadIdx.x);
        i < total_elements;
-       i += gridDim.x * blockDim.x) {
+       i += static_cast<int64_t>(gridDim.x) * blockDim.x) {
     if (indices[i] != -1) {
       int write_idx = write_indices[i];
       grad_probs[i] = grad_topk[write_idx];
@@ -86,8 +87,8 @@ void count_valid_cuda_launcher(const int64_t* indices,
                                cudaStream_t stream) {
   if (total_elements == 0) return;
   int block_size = 256;
-  int grid_size = (total_elements + block_size - 1) / block_size;
-  grid_size = std::min(grid_size, 4096);
+  int64_t grid_size64 = (total_elements + block_size - 1) / block_size;
+  int grid_size = static_cast<int>(std::min<int64_t>(grid_size64, 4096));
   count_valid_kernel<<<grid_size, block_size, 0, stream>>>(
       indices, valid_count, total_elements);
 }
@@ -107,6 +108,9 @@ std::vector<paddle::Tensor> FilterScoresGPU(const paddle::Tensor& probs,
   if (total_elements == 0) {
     return {paddle::empty({0}, probs.dtype(), probs.place())};
   }
+  PD_CHECK(
+      total_elements <= static_cast<int64_t>(std::numeric_limits<int>::max()),
+      "total_elements exceeds INT_MAX in filter_scores.");
   auto valid_count_tensor =
       paddle::full({1}, 0, paddle::DataType::INT32, probs.place());
   count_valid_cuda_launcher(indices.data<int64_t>(),
@@ -131,8 +135,8 @@ std::vector<paddle::Tensor> FilterScoresGPU(const paddle::Tensor& probs,
   auto write_indices =
       paddle::empty({total_elements}, paddle::DataType::INT32, probs.place());
   int block_size = 256;
-  int grid_size = (total_elements + block_size - 1) / block_size;
-  grid_size = std::min(grid_size, 4096);
+  int64_t grid_size64 = (total_elements + block_size - 1) / block_size;
+  int grid_size = static_cast<int>(std::min<int64_t>(grid_size64, 4096));
   create_mask_kernel<<<grid_size, block_size, 0, stream>>>(
       indices.data<int64_t>(), mask.data<int>(), total_elements);
   void* d_temp_storage = nullptr;
@@ -175,9 +179,14 @@ std::vector<paddle::Tensor> FilterScoresGradGPU(
            "indices must be of type int64.");
   cudaStream_t stream = indices.stream();
   const int64_t total_elements = indices.numel();
+  PD_CHECK(
+      total_elements <= static_cast<int64_t>(std::numeric_limits<int>::max()),
+      "total_elements exceeds INT_MAX in filter_scores_grad.");
   auto grad_probs = paddle::full(
       indices.shape(), 0, grad_topk_scores.dtype(), grad_topk_scores.place());
   const int64_t total_valid = grad_topk_scores.numel();
+  PD_CHECK(total_valid <= static_cast<int64_t>(std::numeric_limits<int>::max()),
+           "total_valid exceeds INT_MAX in filter_scores_grad.");
   if (total_elements == 0 || total_valid == 0) {
     return {grad_probs};
   }
@@ -186,8 +195,8 @@ std::vector<paddle::Tensor> FilterScoresGradGPU(
   auto write_indices = paddle::empty(
       {total_elements}, paddle::DataType::INT32, grad_topk_scores.place());
   int block_size = 256;
-  int grid_size = (total_elements + block_size - 1) / block_size;
-  grid_size = std::min(grid_size, 4096);
+  int64_t grid_size64 = (total_elements + block_size - 1) / block_size;
+  int grid_size = static_cast<int>(std::min<int64_t>(grid_size64, 4096));
   create_mask_kernel<<<grid_size, block_size, 0, stream>>>(
       indices.data<int64_t>(), mask.data<int>(), total_elements);
   void* d_temp_storage = nullptr;

--- a/src/paddlefleet/_extensions/fuse_stack_transpose_fp8_quant.cu
+++ b/src/paddlefleet/_extensions/fuse_stack_transpose_fp8_quant.cu
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <limits>
+
 #include "paddle/phi/kernels/funcs/fast_divmod.h"
 #include "paddle/phi/kernels/funcs/segmented_array.h"
 #include "paddle/phi/kernels/fusion/gpu/quant_utils.h"
@@ -458,7 +460,13 @@ std::vector<paddle::Tensor> fuse_stack_transpose_fp8_quant_fleet_custom(
   }
 
   // Launch kernel
-  dim3 grid((M / 128) * (K / 128), 1, N);
+  int64_t grid_x = (M / 128) * (K / 128);
+  PADDLE_ENFORCE_LE(
+      grid_x,
+      static_cast<int64_t>(std::numeric_limits<int>::max()),
+      common::errors::InvalidArgument(
+          "grid.x exceeds INT_MAX in fuse_stack_transpose_fp8_quant."));
+  dim3 grid(static_cast<uint32_t>(grid_x), 1, N);
   dim3 block(32, 16);
 
   FastDivMod K_div_128(K / 128);

--- a/src/paddlefleet/_extensions/fuse_swiglu_scale.cu
+++ b/src/paddlefleet/_extensions/fuse_swiglu_scale.cu
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <cuda_bf16.h>
+#include <limits>
 #include <vector>
 #include "paddle/extension.h"
 
@@ -162,6 +163,16 @@ std::vector<paddle::Tensor> FusedSwiGLUScaleForward(
   auto hidden_size = hidden2 / 2;
   auto out = paddle::empty({rows, hidden_size}, x.dtype(), x.place());
 
+  if (rows == 0 || hidden_size == 0) {
+    return {out};
+  }
+
+  PADDLE_ENFORCE_LE(
+      rows * hidden2,
+      static_cast<int64_t>(std::numeric_limits<int>::max()),
+      common::errors::InvalidArgument(
+          "rows * hidden2 must be <= INT_MAX for fused_swiglu_scale."));
+
   int grid_size = rows;
   int block_size = 256;
   auto stream = x.stream();
@@ -206,6 +217,16 @@ std::vector<paddle::Tensor> FusedSwiGLUScaleBackward(
   auto hidden_size = hidden2 / 2;
   auto d_x = paddle::empty_like(x);
   auto d_scale = paddle::empty_like(scale);
+
+  if (rows == 0 || hidden_size == 0) {
+    return {d_x, d_scale};
+  }
+
+  PADDLE_ENFORCE_LE(
+      rows * hidden2,
+      static_cast<int64_t>(std::numeric_limits<int>::max()),
+      common::errors::InvalidArgument(
+          "rows * hidden2 must be <= INT_MAX for fused_swiglu_scale."));
 
   int grid_size = rows;
   int block_size = 256;

--- a/src/paddlefleet/_extensions/router_metadata.cu
+++ b/src/paddlefleet/_extensions/router_metadata.cu
@@ -15,6 +15,7 @@
 #include <cuda_runtime.h>
 #include <paddle/extension.h>
 #include <cub/cub.cuh>
+#include <limits>
 
 __global__ void simple_arange_kernel(int* output, int64_t N) {
   for (int64_t idx =
@@ -103,15 +104,15 @@ std::vector<paddle::Tensor> RouterMetadataCuda(
     const paddle::Tensor& topk_router_indices,
     const paddle::Tensor& expert_frequency_offset,
     int K) {
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
   int64_t num_tokens = topk_router_indices.shape()[0];
-
-  // TODO(large-tensor): downstream functors may still use int; guard until
-  // upgraded.
   int64_t num_experts = expert_frequency_offset.shape()[0];
+  PADDLE_ENFORCE_LE(
+      num_tokens * K,
+      static_cast<int64_t>(std::numeric_limits<int>::max()),
+      common::errors::InvalidArgument(
+          "num_tokens * K must be <= INT_MAX for router_metadata kernels."));
 
-  const int total_elements = num_tokens * K;
+  const int total_elements = static_cast<int>(num_tokens * K);
   auto place = topk_router_indices.place();
   cudaStream_t stream = topk_router_indices.stream();
 
@@ -125,7 +126,7 @@ std::vector<paddle::Tensor> RouterMetadataCuda(
   auto num_activated_per_token_offset =
       paddle::empty({num_tokens + 1}, paddle::DataType::INT32, place);
   int threads = 256;
-  int blocks = (num_tokens + threads - 1) / threads;
+  int blocks = static_cast<int>((num_tokens + threads - 1) / threads);
 
   if (num_tokens > 0) {
     CountValidExpertsKernel<T>

--- a/src/paddlefleet/_extensions/swiglu_kernel.cu
+++ b/src/paddlefleet/_extensions/swiglu_kernel.cu
@@ -14,6 +14,7 @@
 
 // swiglu_kernel.cu
 #include <cuda_bf16.h>
+#include <limits>
 #include <vector>
 #include "paddle/extension.h"
 
@@ -81,12 +82,22 @@ __global__ void VectorizedSwiGLUBackKernel(const T* __restrict__ g,
 std::vector<paddle::Tensor> SwiGLUBackward(const paddle::Tensor& g,
                                            const paddle::Tensor& y) {
   auto y_shape = y.shape();
-  int rows = y.numel() / y_shape.back();
-  int input_dim = y_shape.back();
-  int hidden_size = input_dim / 2;
+  int64_t rows = y.numel() / y_shape.back();
+  int64_t input_dim = y_shape.back();
+  int64_t hidden_size = input_dim / 2;
   auto dx = paddle::empty_like(y);
 
-  int grid_size = rows;
+  if (rows == 0 || hidden_size == 0) {
+    return {dx};
+  }
+
+  PADDLE_ENFORCE_LE(
+      rows * input_dim,
+      static_cast<int64_t>(std::numeric_limits<int>::max()),
+      common::errors::InvalidArgument(
+          "rows * input_dim must be <= INT_MAX for fused_swiglu_bwd."));
+
+  int grid_size = static_cast<int>(rows);
   int block_size = 256;
   auto stream = y.stream();
 

--- a/src/paddlefleet/_extensions/tokens_unzip_gather.cu
+++ b/src/paddlefleet/_extensions/tokens_unzip_gather.cu
@@ -81,14 +81,16 @@ std::vector<paddle::Tensor> tokens_unzip_gather(
   int64_t zipped_rows = x_shape[0];
   int hidden_size = x_shape[1];
 
-  std::vector<int64_t> x_scale_shape;
-  int quanted_hidden_size = 0;
   bool has_scale = (x_scale.get_ptr() != nullptr);
+  int quanted_hidden_size = 0;
   if (has_scale) {
-    x_scale_shape = x_scale.get().shape();
+    auto x_scale_shape = x_scale.get().shape();
     PD_CHECK(x_scale_shape.size() == 2);
     PD_CHECK(x_scale_shape[0] == x_shape[0]);
     quanted_hidden_size = x_scale_shape[1];
+  } else {
+    PD_CHECK(hidden_size % 128 == 0);
+    quanted_hidden_size = hidden_size / 128;
   }
 
   auto x_unzipped =
@@ -98,12 +100,9 @@ std::vector<paddle::Tensor> tokens_unzip_gather(
     x_scale_unzipped = paddle::zeros(
         {padded_num_tokens, quanted_hidden_size}, x_scale.get().dtype(), place);
   } else {
-    PD_CHECK(hidden_size % 128 == 0);
-    quanted_hidden_size = hidden_size / 128;
     x_scale_unzipped = paddle::empty(
         {0, quanted_hidden_size}, paddle::DataType::FLOAT32, place);
   }
-
   auto index_unzipped = paddle::empty(
       {tokens_per_expert[expert_id]}, paddle::DataType::INT64, place);
 
@@ -145,7 +144,10 @@ std::vector<paddle::Tensor> tokens_unzip_gather(
     }                                                                     \
   } while (0)
 
-  if (grid > 0) {
+  // Skip kernel when expert has no tokens: unzipped_rows=0 causes the kernel to
+  // always hit `unzipped_row_idx >= unzipped_rows` and continue, so avoid the
+  // wasteful launch.
+  if (grid > 0 && tokens_per_expert[expert_id] > 0) {
     if (has_scale) {
       LAUNCH_TOKENS_UNZIP_GATHER_KERNEL(phi::float8_e4m3fn);
     } else {

--- a/src/paddlefleet/_extensions/tokens_unzip_slice.cu
+++ b/src/paddlefleet/_extensions/tokens_unzip_slice.cu
@@ -34,7 +34,7 @@ __global__ void tokens_unzip_slice_kernel(
            static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
            static_cast<int64_t>(threadIdx.x);
        elem < total;
-       elem += blockDim.x * gridDim.x) {
+       elem += static_cast<int64_t>(blockDim.x) * gridDim.x) {
     int64_t row = elem / num_experts;
     int64_t u = zipped_expertwise_rowmap[elem];
     if (u < 0) continue;
@@ -60,6 +60,9 @@ std::vector<paddle::Tensor> tokens_unzip_slice(
 
   auto index_unzipped =
       paddle::full({total_unzipped_rows}, -1, paddle::DataType::INT64, place);
+  if (total_zipped_rows == 0) {
+    return {index_unzipped};
+  }
   int block = 1024;
   int grid = LimitGridDim(total_zipped_rows);
 

--- a/src/paddlefleet/_extensions/tokens_zip_prob.cu
+++ b/src/paddlefleet/_extensions/tokens_zip_prob.cu
@@ -73,7 +73,8 @@ std::vector<paddle::Tensor> tokens_zip_prob_impl(
            "num_expert must be <= INT_MAX for tokens_zip_prob.");
   PD_CHECK(topk <= static_cast<int64_t>(std::numeric_limits<int>::max()),
            "topk must be <= INT_MAX for tokens_zip_prob.");
-  PD_CHECK(unzipped_probs.size() == static_cast<size_t>(num_expert),
+  PD_CHECK(unzipped_probs.size() == static_cast<size_t>(num_expert) &&
+               num_expert > 0,
            "unzipped_probs.size() must equal num_expert.");
   int num_expert_int = static_cast<int>(num_expert);
   int topk_int = static_cast<int>(topk);

--- a/src/paddlefleet/_extensions/tokens_zip_prob.cu
+++ b/src/paddlefleet/_extensions/tokens_zip_prob.cu
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <limits>
+
 #include "paddle/common/array.h"
 #include "paddle/phi/kernels/funcs/aligned_vector.h"
 #include "utils.h"  // NOLINT
@@ -65,18 +67,25 @@ std::vector<paddle::Tensor> tokens_zip_prob_impl(
   PD_CHECK(zipped_expertwise_rowmap_shape[0] == dispatched_indices_shape[0]);
 
   int64_t zipped_rows = zipped_expertwise_rowmap_shape[0];
-  int num_expert = zipped_expertwise_rowmap_shape[1];
-  int topk = dispatched_indices_shape[1];
-  PD_CHECK(unzipped_probs.size() == num_expert);
+  int64_t num_expert = zipped_expertwise_rowmap_shape[1];
+  int64_t topk = dispatched_indices_shape[1];
+  PD_CHECK(num_expert <= static_cast<int64_t>(std::numeric_limits<int>::max()),
+           "num_expert must be <= INT_MAX for tokens_zip_prob.");
+  PD_CHECK(topk <= static_cast<int64_t>(std::numeric_limits<int>::max()),
+           "topk must be <= INT_MAX for tokens_zip_prob.");
+  PD_CHECK(unzipped_probs.size() == static_cast<size_t>(num_expert),
+           "unzipped_probs.size() must equal num_expert.");
+  int num_expert_int = static_cast<int>(num_expert);
+  int topk_int = static_cast<int>(topk);
 
   auto zipped_probs =
       paddle::empty({zipped_rows, topk}, dtype, unzipped_probs[0].place());
 
   PD_SWITCH_NUM_EXPERTS(
-      num_expert, ([&] {
+      static_cast<int>(num_expert), ([&] {
         phi::Array<UnzippedProbInfo<T>, MAX_NUM_EXPERTS_C> unzipped_probs_info;
         int64_t offset = 0;
-        for (int i = 0; i < num_expert; ++i) {
+        for (int i = 0; i < num_expert_int; ++i) {
           auto shape = unzipped_probs[i].shape();
           PD_CHECK(shape.size() == 1);
           unzipped_probs_info[i].data = unzipped_probs[i].data<T>();
@@ -85,7 +94,8 @@ std::vector<paddle::Tensor> tokens_zip_prob_impl(
         }
 
         int thread = 1024;
-        int grid = LimitGridDim((zipped_rows * topk + thread - 1) / thread);
+        int64_t total_items = zipped_rows * topk;
+        int grid = LimitGridDim((total_items + thread - 1) / thread);
 
         if (grid > 0) {
           tokens_zip_prob_kernel<T, MAX_NUM_EXPERTS_C>
@@ -95,8 +105,8 @@ std::vector<paddle::Tensor> tokens_zip_prob_impl(
                   dispatched_indices.data<int>(),
                   zipped_probs.data<T>(),
                   zipped_rows,
-                  topk,
-                  num_expert);
+                  topk_int,
+                  num_expert_int);
         }
       }));
   return {zipped_probs};
@@ -167,13 +177,20 @@ std::vector<paddle::Tensor> tokens_zip_prob_seq_subbatch_impl(
   PD_CHECK(zipped_expertwise_rowmap_shape[0] == dispatched_indices_shape[0]);
 
   int64_t zipped_rows = zipped_expertwise_rowmap_shape[0];
-  int num_expert = zipped_expertwise_rowmap_shape[1];
-  int topk = dispatched_indices_shape[1];
+  int64_t num_expert = zipped_expertwise_rowmap_shape[1];
+  int64_t topk = dispatched_indices_shape[1];
+  PD_CHECK(num_expert <= static_cast<int64_t>(std::numeric_limits<int>::max()),
+           "num_expert must be <= INT_MAX for tokens_zip_prob_seq_subbatch.");
+  PD_CHECK(topk <= static_cast<int64_t>(std::numeric_limits<int>::max()),
+           "topk must be <= INT_MAX for tokens_zip_prob_seq_subbatch.");
+  int num_expert_int = static_cast<int>(num_expert);
+  int topk_int = static_cast<int>(topk);
 
   auto zipped_probs =
       paddle::empty({zipped_rows, topk}, dtype, unzipped_probs[0].place());
   int thread = 1024;
-  int grid = LimitGridDim((zipped_rows * topk + thread - 1) / thread);
+  int64_t total_items = zipped_rows * topk;
+  int grid = LimitGridDim((total_items + thread - 1) / thread);
 
 #define LAUNCH_TOKENS_ZIP_PROB_SEQ_SUBBATCH_FIX_CASE(__T, __num_split)       \
   if (unzipped_probs.size() <= __num_split) {                                \
@@ -209,8 +226,8 @@ std::vector<paddle::Tensor> tokens_zip_prob_seq_subbatch_impl(
               dispatched_indices.data<int>(),                                \
               zipped_probs.data<__T>(),                                      \
               zipped_rows,                                                   \
-              topk,                                                          \
-              num_expert,                                                    \
+              topk_int,                                                      \
+              num_expert_int,                                                \
               subbatch_rows);                                                \
     }                                                                        \
   } while (0)

--- a/src/paddlefleet/_extensions/tokens_zip_unique_add.cu
+++ b/src/paddlefleet/_extensions/tokens_zip_unique_add.cu
@@ -31,8 +31,9 @@ __global__ void tokens_zip_unique_add_kernel(
     auto* zipped_ptr = zipped_ptrs[zipped_row / subbatch_rows] +
                        (zipped_row % subbatch_rows) * hidden_size;
     const auto* unzipped_ptr = unzipped + unzipped_row * hidden_size;
-    for (int i = threadIdx.x * VecSize; i < hidden_size;
-         i += blockDim.x * VecSize) {
+    for (int64_t i = static_cast<int64_t>(threadIdx.x) * VecSize;
+         i < hidden_size;
+         i += static_cast<int64_t>(blockDim.x) * VecSize) {
       phi::AlignedVector<ZipT, VecSize> zipped_tmp;
       phi::AlignedVector<UnzipT, VecSize> unzipped_tmp;
       phi::Load(zipped_ptr + i, &zipped_tmp);

--- a/src/paddlefleet/_extensions/utils.h
+++ b/src/paddlefleet/_extensions/utils.h
@@ -119,9 +119,9 @@ struct alignas(16) VectorType<uint8_t, 16> {
 template <typename T>
 __device__ __forceinline__ void unrolled_memcpy(const T* src,
                                                 T* dst,
-                                                const int num_elements) {
+                                                const int64_t num_elements) {
 #pragma unroll
-  for (int idx = threadIdx.x; idx < num_elements; idx += blockDim.x) {
+  for (int64_t idx = threadIdx.x; idx < num_elements; idx += blockDim.x) {
     dst[idx] = src[idx];
   }
 }
@@ -130,34 +130,33 @@ __device__ __forceinline__ void unrolled_memcpy(const T* src,
 template <typename T>
 __device__ __forceinline__ void vectorized_memcpy(const T* src,
                                                   T* dst,
-                                                  const int num_elements) {
+                                                  const int64_t num_elements) {
   constexpr int vector_size_in_bytes = 16;
-  const int elements_per_vector = vector_size_in_bytes / sizeof(T);
+  const int64_t elements_per_vector = vector_size_in_bytes / sizeof(T);
 
-  int num_vectors = num_elements / elements_per_vector;
-  int remaining_elements = num_elements % elements_per_vector;
+  int64_t num_vectors = num_elements / elements_per_vector;
+  int64_t remaining_elements = num_elements % elements_per_vector;
 
   using VecType = VectorType<T, elements_per_vector>;
   const VecType* src_vec = reinterpret_cast<const VecType*>(src);
   VecType* dst_vec = reinterpret_cast<VecType*>(dst);
 
 #pragma unroll
-  for (int idx = threadIdx.x; idx < num_vectors; idx += blockDim.x) {
+  for (int64_t idx = threadIdx.x; idx < num_vectors; idx += blockDim.x) {
     dst_vec[idx] = src_vec[idx];
   }
 
   if (remaining_elements > 0) {
-    int offset = num_vectors * elements_per_vector;
-    for (int i = threadIdx.x; i < remaining_elements; i += blockDim.x) {
+    int64_t offset = num_vectors * elements_per_vector;
+    for (int64_t i = threadIdx.x; i < remaining_elements; i += blockDim.x) {
       dst[offset + i] = src[offset + i];
     }
   }
 }
 
 template <typename T>
-__device__ __forceinline__ void try_vectorized_memcpy(const T* src,
-                                                      T* dst,
-                                                      const int num_elements) {
+__device__ __forceinline__ void try_vectorized_memcpy(
+    const T* src, T* dst, const int64_t num_elements) {
   bool is_aligned_128bit =
       ((uintptr_t)src & 0xF) == 0 && ((uintptr_t)dst & 0xF) == 0;
   if (is_aligned_128bit) {


### PR DESCRIPTION
主要修复 **CUDA 扩展在支持大张量时的 int32 溢出问题**，修改涉及多个 `.cu` 和 `utils.h` 文件：

1. **count_cumsum.cu**  
   - `load_128_bits` / `store_128_bits` 增加 `IdxT` 模板参数，支持 `int64_t` 索引  
   - 循环变量 `N_vec`、`i` 改为 `int64_t`，避免大 N 溢出  
   - 增加 `N == 0` 的提前返回

2. **filter_scores.cu**  
   - 循环步长 `gridDim.x * blockDim.x` 使用 `static_cast<int64_t>` 避免溢出  
   - `grid_size` 先用 `int64_t` 计算再转成 `int`  
   - 增加 `PD_CHECK`，检查 `total_elements` / `total_valid` 不超过 `INT_MAX`

3. **fuse_stack_transpose_fp8_quant.cu**  
   - `grid_x` 使用 `int64_t` 计算  
   - 增加 `PADDLE_ENFORCE_LE`，保证 `grid.x <= INT_MAX`

4. **fuse_swiglu_scale.cu / swiglu_kernel.cu**  
   - 对 `rows == 0` 或 `hidden_size == 0` 做提前返回  
   - 增加 `rows * hidden2` / `rows * input_dim <= INT_MAX` 的检查

5. **router_metadata.cu**  
   - 用 `PADDLE_ENFORCE_LE` 替代 TODO，检查 `num_tokens * K <= INT_MAX`

6. **tokens_unzip_gather.cu**  
   - 调整 `quanted_hidden_size` 逻辑  
   - 当 expert 无 token 时跳过 kernel 启动

7. **tokens_unzip_slice.cu**  
   - 循环步长使用 `static_cast<int64_t>(blockDim.x) * gridDim.x`  
   - 对 `total_zipped_rows == 0` 提前返回

8. **tokens_zip_prob.cu**  
   - `num_expert`、`topk` 改为 `int64_t`，并增加 `INT_MAX` 检查  
   - `total_items` 与 grid 计算改为使用 `int64_t` 再转 `int`

9. **tokens_zip_unique_add.cu**  
   - 循环索引与步长改为 `int64_t`，避免 `hidden_size` 溢出

10. **utils.h**  
    - `unrolled_memcpy`、`vectorized_memcpy`、`try_vectorized_memcpy` 的 `num_elements` 改为 `int64_t`
