### PR TITLE
[CI] Remove cherry-pick labels after workflow completion

### DIFF
--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -186,3 +186,21 @@ jobs:
               git branch -D "$NEW_BRANCH"
             fi
           done <<< "$LABELS"
+
+      - name: Remove Cherry Pick Labels
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO_NAME: ${{ github.repository }}
+        run: |
+          LABELS=$(gh pr view "$PR_NUMBER" --repo "$REPO_NAME" --json labels --jq '.labels[].name')
+          if [ -z "$LABELS" ]; then
+            exit 0
+          fi
+          while read -r label; do
+            if [[ "$label" == cherry-pick:* ]]; then
+              echo "Removing label: $label"
+              gh pr edit "$PR_NUMBER" --repo "$REPO_NAME" --remove-label "$label"
+            fi
+          done <<< "$LABELS"
+

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -203,4 +203,3 @@ jobs:
               gh pr edit "$PR_NUMBER" --repo "$REPO_NAME" --remove-label "$label"
             fi
           done <<< "$LABELS"
-


### PR DESCRIPTION
### Description
Add a final step to .github/workflows/cherry-pick.yml to automatically remove all cherry-pick:* labels from the source PR after cherry-pick handling finishes, avoiding accidental retrigger by unrelated label changes.

@SigureMo Please review this PR when you have time. Thanks!