### PR TITLE
[CI]fix coverage

### DIFF
--- a/.github/workflows/Test-release3.3.yml
+++ b/.github/workflows/Test-release3.3.yml
@@ -1352,9 +1352,11 @@ jobs:
           cat diff.txt
           echo "================="
           python -m pip install diff-cover
+          echo "=== 覆盖率文件 ==="
+          ls *.xml
+          echo "================="
           COVERAGE_EXIT_CODE=0
-          diff-cover multi_coverage.xml single_coverage.xml h20_multi_pt_coverage.xml h20_multi_sft_coverage.xml h20_multi_lora_coverage.xml h20_multi_dpo_coverage.xml h20_multi_fp8_coverage.xml h20_multi_grouped_gemm_coverage.xml \
-          h20_single_coverage.xml h20_qwen_coverage.xml a100_pt_coverage.xml h20_qwen_multi_pt_coverage.xml h20_qwen_multi_sft_coverage.xml h20_qwen_multi_lora_coverage.xml --diff-file=diff.txt --fail-under=90 || COVERAGE_EXIT_CODE=9
+          diff-cover *.xml --diff-file=diff.txt --fail-under=90 || COVERAGE_EXIT_CODE=9
           exit ${COVERAGE_EXIT_CODE}
 
       - name: filter coverage files and remove backup files


### PR DESCRIPTION
覆盖率文件检测文件需要覆盖全部下载文件，之前添加的时候总会遗漏一些文件，这里变成*匹配