### PR TITLE
【kimi】fix kimik2 yarn rope

### DIFF
--- a/src/paddlefleet/transformer/multi_latent_attention.py
+++ b/src/paddlefleet/transformer/multi_latent_attention.py
@@ -114,7 +114,7 @@ class MultiLatentAttention(Attention):
         elif self.config.rope_type == "yarn":
             self.rotary_pos_emb = YarnRotaryEmbedding(
                 self.config.qk_rope_head_dim,
-                rotary_base=self.config.rotary_base,
+                rotary_base=self.config.rope_theta,
                 scaling_factor=self.config.rotary_scaling_factor,
                 original_max_position_embeddings=self.config.original_max_position_embeddings,
                 beta_fast=self.config.beta_fast,
@@ -581,10 +581,9 @@ class MLASelfAttention(MultiLatentAttention):
                     cp_size,
                 )
             else:
-                q_len = q.size()[0]
-                # rotary_pos_emb: [seq_len, 1, 64]
-                # squeeze [1, seq_len, 1, 64] -> [seq_len, 1, 64]
-                rotary_pos_emb = rotary_pos_emb.squeeze(0)
+                q_len = q.size()[1]
+                # rotary_pos_emb: squeeze [1, seq_len, 1, headdim]
+
                 if (
                     packed_seq_params is None
                     or self.config.context_parallel_size == 1


### PR DESCRIPTION
kimi 纯文模型rope 采用yarn 类型，传递base 参数有误
非fuse apply_rope的路径，将rotary_emb 的shape 处理成3维导致apply rope 内部进行了不准确的broadcast , qlen 虽然没用到，但是取的维度是batch 维，不是seq 维