### PR TITLE
:recycle: refactor: adopt PEP 639 license metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,8 @@ name = "paddlefleet"
 dynamic = ["version", "readme", "dependencies"]
 description = "Fleet Core - Core Functional Library for Large Scale Distributed Training"
 requires-python = ">=3.10"
-license = { text = "Apache 2.0" }
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 authors = [{ name = "PaddlePaddle", email = "Paddle-better@baidu.comm" }]
 maintainers = [{ name = "PaddlePaddle", email = "Paddle-better@baidu.com" }]
 keywords = [
@@ -50,7 +51,7 @@ Download = "https://github.com/PaddlePaddle/PaddleFleet/releases"
 Homepage = "https://github.com/PaddlePaddle/PaddleFleet/src"
 
 [build-system]
-requires = ["setuptools>=66.1.0", "pip", "wheel"]
+requires = ["setuptools>=77.0.0", "pip", "wheel"]
 build-backend = "build_backend"
 backend-path = ["."]
 
@@ -81,7 +82,7 @@ test = [
 ]
 build = [
     "pip",
-    "setuptools>=66.1.0",
+    "setuptools>=77.0.0",
     "packaging>=24.2"
 ]
 linting = [


### PR DESCRIPTION
## 改动动机

当前 `pyproject.toml` 仍使用旧式 `project.license = { text = ... }` 配置。为避免继续依赖已被 PEP 639 替代的 license metadata 表达方式，本 PR 将其迁移为 SPDX license expression，并显式声明 `license-files`。

## PEP 639 说明

PEP 639 建议在项目元数据中使用标准 SPDX license expression，并通过 `license-files` 明确声明许可证文件；同时不再推荐继续使用旧式 license table / license classifier 作为主要许可证声明方式。

参考：https://peps.python.org/pep-0639/

## 变更内容

- 将 `project.license` 从 `{ text = "Apache 2.0" }` 改为 `"Apache-2.0"`
- 新增 `project.license-files = ["LICENSE"]`
- 将 `setuptools` 最低版本提升到 `>=77.0.0`，以支持 PEP 639 / SPDX license metadata

## 验证结果

- `uvx --from 'validate-pyproject[all]' validate-pyproject pyproject.toml` ✅
- `uv build --wheel` ❌：当前环境缺少 `patchelf`，构建在进入原有 wheel 流程时失败；未观察到本次 license metadata 配置导致的新错误
