### PR TITLE
fix MLA

### DIFF
--- a/src/paddlefleet/models/common/embeddings/rope_utils.py
+++ b/src/paddlefleet/models/common/embeddings/rope_utils.py
@@ -158,11 +158,6 @@ def _apply_rotary_pos_emb_bshd(
     # ideally t_pass is empty so rotary pos embedding is applied to all tensor t
     t, t_pass = t[..., :rot_dim], t[..., rot_dim:]
 
-    if multi_latent_attention:
-        x1 = t[..., 0::2]
-        x2 = t[..., 1::2]
-        t = paddle.cat((x1, x2), axis=-1)
-
     if high_precision_rope:
         return _apply_rotary_pos_emb_bshd_fp32(
             t,
@@ -283,7 +278,7 @@ def _apply_rotary_pos_emb_thd(
             )
 
         freqs_packed = paddle.cat(freq_slices, axis=1)
-        # [seq,bs,num_heads,head_dim]
+        # [b,seq,num_heads,head_dim]
         return _apply_rotary_pos_emb_bshd(
             t,
             freqs_packed,

--- a/src/paddlefleet/transformer/multi_latent_attention.py
+++ b/src/paddlefleet/transformer/multi_latent_attention.py
@@ -108,7 +108,7 @@ class MultiLatentAttention(Attention):
             self.rotary_pos_emb = RotaryEmbedding(
                 self.config.qk_rope_head_dim,
                 rotary_percent=self.config.rotary_percent,
-                rotary_base=self.config.rotary_base,
+                rotary_base=self.config.rope_theta,
                 cp_group=self.pg_collection.cp,
             )
         elif self.config.rope_type == "yarn":
@@ -244,7 +244,7 @@ class MultiLatentAttention(Attention):
             )
 
         # =================
-        # Output. [sq, b, h]
+        # Output. [b, sq, h]
         # =================
         if self.config.sequence_parallel:
             core_attn_out = core_attn_out.transpose([1, 0, 2]).contiguous()
@@ -256,7 +256,7 @@ class MultiLatentAttention(Attention):
 class MLASelfAttention(MultiLatentAttention):
     """MLA Self-attention layer class
 
-    Self-attention layer takes input with size [s, b, h]
+    Self-attention layer takes input with size [b, s, h]
     and returns output of the same size.
     """
 
@@ -380,11 +380,17 @@ class MLASelfAttention(MultiLatentAttention):
         """
         Derives `query`, `key` and `value` tensors from `hidden_states`.
         """
-        # s = sequence length, b = batch size, h = hidden size, n = num attention heads
-        # Attention heads [s, b, n*h]
+        # b = batch size, s = sequence length, h = hidden size, n = num attention heads
+        # Attention heads [b, s, n*h]
         assert hidden_states.ndim == 3, (
-            f"hidden_states should be 3D, [s, b, n*h], got {hidden_states.ndim}D"
+            f"hidden_states should be 3D, [b, s, n*h], got {hidden_states.ndim}D"
         )
+
+        if packed_seq_params is not None:
+            assert packed_seq_params.local_cp_size is None, (
+                "hybrid_context_parallel is not supported with MLA yet and is planned for future. "
+                "Please disable hybrid_context_parallel."
+            )
 
         # =========================================
         # Prepare RoPE and seqlen related params
@@ -393,7 +399,7 @@ class MLASelfAttention(MultiLatentAttention):
             hidden_states, self.config, packed_seq_params
         )
 
-        # rotary_pos_emb:[s, b, 1, 64]
+        # rotary_pos_emb:[1, s, 1, 64]
         mscale = 1.0
         rotary_pos_cos = None
         rotary_pos_sin = None
@@ -423,6 +429,8 @@ class MLASelfAttention(MultiLatentAttention):
                 rotary_pos_emb, mscale = self.rotary_pos_emb(
                     rotary_seq_len, packed_seq=packed_seq
                 )
+                # mscale is already accounted for in self.softmax_scale; set to 1.0 to avoid double-applying
+                # mscale = 1.0
 
         if (
             packed_seq_params is not None
@@ -444,7 +452,7 @@ class MLASelfAttention(MultiLatentAttention):
         # =========================================
         if self.config.q_lora_rank is not None:
             # if q_a_proj is ColumnParallelLinear:
-            #     q_compressed: [s, b, q_lora_rank / TP]
+            #     q_compressed: [b, s, q_lora_rank / TP]
             q_compressed, _ = self.q_a_proj(hidden_states)
 
             # When output is sharded (ColumnParallelLinear):
@@ -462,27 +470,27 @@ class MLASelfAttention(MultiLatentAttention):
             q_compressed = hidden_states
 
         # if kv_a_proj_with_mqa is ColumnParallelLinear:
-        #     kv_combined: [s, b, (kv_lora_rank + qk_rope_head_dim) / TP]
+        #     kv_combined: [b, s, (kv_lora_rank + qk_rope_head_dim) / TP]
         kv_combined, _ = self.kv_a_proj_with_mqa(hidden_states)
         if (
             kv_combined.size(-1)
             != self.config.kv_lora_rank + self.config.qk_rope_head_dim
         ):
-            # kv_combined: [s, b, (kv_lora_rank + qk_rope_head_dim)]
+            # kv_combined: [b, s, (kv_lora_rank + qk_rope_head_dim)]
             kv_combined = gather_from_tensor_model_parallel_region(kv_combined)
-            # kv_compressed:[s, b, kv_lora_rank], k_pos_emb: [s, b, qk_rope_head_dim]
+            # kv_compressed:[b, s, kv_lora_rank], k_pos_emb: [b, s, qk_rope_head_dim]
             kv_compressed, k_pos_emb = paddle.split(
                 kv_combined,
                 [self.config.kv_lora_rank, self.config.qk_rope_head_dim],
                 axis=-1,
             )
             if self.config.sequence_parallel:
-                # kv_compressed:[s / TP, b, kv_lora_rank]
+                # kv_compressed:[b, s / TP, kv_lora_rank]
                 kv_compressed = scatter_to_sequence_parallel_region(
                     kv_compressed
                 )
         else:
-            # kv_compressed:[s / TP, b, kv_lora_rank], k_pos_emb: [s / TP, b, qk_rope_head_dim]
+            # kv_compressed:[b, s / TP, kv_lora_rank], k_pos_emb: [b, s / TP, qk_rope_head_dim]
             kv_compressed, k_pos_emb = paddle.split(
                 kv_combined,
                 [self.config.kv_lora_rank, self.config.qk_rope_head_dim],
@@ -492,16 +500,18 @@ class MLASelfAttention(MultiLatentAttention):
                 get_pg_size(self.pg_collection.tp) > 1
                 and self.config.sequence_parallel
             ):
-                # k_pos_emb: [s, b, qk_rope_head_dim]
+                # k_pos_emb: [b, s, qk_rope_head_dim]
                 k_pos_emb = gather_from_sequence_parallel_region(
                     k_pos_emb, group=self.pg_collection.tp
                 )
 
         if packed_seq_params is not None:
-            # If sequence packing, reshape qkv from [t, 1, h, d] to [t, h, d].
-            q_compressed = q_compressed.squeeze(1)
-            kv_compressed = kv_compressed.squeeze(1)
-            k_pos_emb = k_pos_emb.squeeze(1)
+            # PaddleFleet batch-first: [b=1, t, h] -> squeeze dim0 (batch) -> [t, h]
+            # (SP seq-first: [t, b=1, h] -> squeeze dim1 (batch) -> [t, h])
+            batch_dim = 1 if self.config.sequence_parallel else 0
+            q_compressed = q_compressed.squeeze(batch_dim)
+            kv_compressed = kv_compressed.squeeze(batch_dim)
+            k_pos_emb = k_pos_emb.squeeze(batch_dim)
 
         # =========================================
         # Apply norm
@@ -523,8 +533,8 @@ class MLASelfAttention(MultiLatentAttention):
             """
             Apply the up projection and RoPE to the query and key.
             When sequence packing enabled, the input tensors adopt a packed shape of [t, ...];
-            otherwise, they maintain the unpacked shape [s, b, ...]. In subsequent code comments,
-            we uniformly use [num_tokens, ...] to denote [s, b, ...] or [t, ...] for two cases.
+            otherwise, they maintain the unpacked shape [b, s, ...]. In subsequent code comments,
+            we uniformly use [num_tokens, ...] to denote [b, s, ...] or [t, ...] for two cases.
             """
             if self.config.q_lora_rank is not None:
                 # q_compressed: [num_tokens, q_lora_rank]
@@ -581,7 +591,14 @@ class MLASelfAttention(MultiLatentAttention):
                     cp_size,
                 )
             else:
-                q_len = q.size()[1]
+                # Determine seq length:
+                #   packed 3D [t, n, d]      -> dim 0
+                #   SP     4D [s, b, n, d]   -> dim 0
+                #   normal 4D [b, s, n, d]   -> dim 1
+                if q.ndim == 3 or self.config.sequence_parallel:
+                    q_len = q.size(0)
+                else:
+                    q_len = q.size(1)
                 # rotary_pos_emb: squeeze [1, seq_len, 1, headdim]
 
                 if (
@@ -592,7 +609,7 @@ class MLASelfAttention(MultiLatentAttention):
                     # the full rotary_pos_emb length, except for sequence packing + CP.
                     # We need the full rotary_pos_emb to cover the full sequence,
                     # so we do not shorten it here.
-                    rotary_pos_emb = rotary_pos_emb[0:q_len]
+                    rotary_pos_emb = rotary_pos_emb[:, 0:q_len]
 
                 # q_no_pe: [num_tokens, n, qk_nope_head_dim]
                 # q_pos_emb: [num_tokens, n, qk_rope_head_dim]

--- a/src/paddlefleet/transformer/multi_latent_attention.py
+++ b/src/paddlefleet/transformer/multi_latent_attention.py
@@ -630,6 +630,13 @@ class MLASelfAttention(MultiLatentAttention):
                     axis=-1,
                 )
 
+                # When sequence_parallel is enabled and not packed,
+                # q/k are seq-first [s, b, n, d] but rotary_pos_emb is
+                # batch-first [1, s, 1, d]. Transpose to [s, 1, 1, d]
+                # so broadcasting aligns correctly in _apply_rotary_pos_emb_bshd.
+                if self.config.sequence_parallel and rotary_pos_emb.ndim == 4:
+                    rotary_pos_emb = rotary_pos_emb.transpose([1, 0, 2, 3])
+
                 # q_pos_emb: [num_tokens, n, qk_rope_head_dim]
                 q_pos_emb = apply_rotary_pos_emb(
                     q_pos_emb,

--- a/src/paddlefleet/transformer/multi_latent_attention.py
+++ b/src/paddlefleet/transformer/multi_latent_attention.py
@@ -386,12 +386,6 @@ class MLASelfAttention(MultiLatentAttention):
             f"hidden_states should be 3D, [b, s, n*h], got {hidden_states.ndim}D"
         )
 
-        if packed_seq_params is not None:
-            assert packed_seq_params.local_cp_size is None, (
-                "hybrid_context_parallel is not supported with MLA yet and is planned for future. "
-                "Please disable hybrid_context_parallel."
-            )
-
         # =========================================
         # Prepare RoPE and seqlen related params
         # =========================================
@@ -505,13 +499,13 @@ class MLASelfAttention(MultiLatentAttention):
                     k_pos_emb, group=self.pg_collection.tp
                 )
 
-        if packed_seq_params is not None:
-            # PaddleFleet batch-first: [b=1, t, h] -> squeeze dim0 (batch) -> [t, h]
-            # (SP seq-first: [t, b=1, h] -> squeeze dim1 (batch) -> [t, h])
-            batch_dim = 1 if self.config.sequence_parallel else 0
-            q_compressed = q_compressed.squeeze(batch_dim)
-            kv_compressed = kv_compressed.squeeze(batch_dim)
-            k_pos_emb = k_pos_emb.squeeze(batch_dim)
+        # if packed_seq_params is not None:
+        #     # PaddleFleet batch-first: [b=1, t, h] -> squeeze dim0 (batch) -> [t, h]
+        #     # (SP seq-first: [t, b=1, h] -> squeeze dim1 (batch) -> [t, h])
+        #     batch_dim = 1 if self.config.sequence_parallel else 0
+        #     q_compressed = q_compressed.squeeze(batch_dim)
+        #     kv_compressed = kv_compressed.squeeze(batch_dim)
+        #     k_pos_emb = k_pos_emb.squeeze(batch_dim)
 
         # =========================================
         # Apply norm

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -503,9 +503,6 @@ class TransformerConfig(ModelParallelConfig):
     rope_type: str = "yarn"
     """Type of RoPE to use. Default to yarn, options are rope and yarn."""
 
-    rotary_base: float = 10000
-    """Rotary base for the rotary embeddings, used by rope and yarn."""
-
     rotary_percent: float = 1.0
     """Rotary percent for the rotary embeddings, used by rope."""
 

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -503,6 +503,9 @@ class TransformerConfig(ModelParallelConfig):
     rope_type: str = "yarn"
     """Type of RoPE to use. Default to yarn, options are rope and yarn."""
 
+    rotary_base: float = 10000
+    """Rotary base for the rotary embeddings, used by rope and yarn."""
+
     rotary_percent: float = 1.0
     """Rotary percent for the rotary embeddings, used by rope."""
 

--- a/tests/single_card_tests/transformer/test_attention.py
+++ b/tests/single_card_tests/transformer/test_attention.py
@@ -161,6 +161,7 @@ class TestMLASelfAttention(unittest.TestCase):
         self.config.attention_dropout = 0.1
         self.config.softmax_type = "vanilla"
 
+    def test_self_attention(self):
         self.self_attn = MLASelfAttention(
             self.config,
             MLASelfAttentionSublayersSpec(
@@ -177,8 +178,44 @@ class TestMLASelfAttention(unittest.TestCase):
             attn_mask_type=AttnMaskType.causal,
             layer_number=1,
         )
+        config = self.self_attn.config
+        sequence_length = 127
+        micro_batch_size = 2
+        hidden_size = self.self_attn.config.hidden_size
 
-    def test_self_attention(self):
+        hidden_states = paddle.randn(
+            (micro_batch_size, sequence_length, hidden_size),
+        )
+
+        output, bias = self.self_attn(
+            hidden_states,
+            attention_mask=None,
+        )
+
+        # Check if output and bias have the correct shape
+        assert output.shape[0] == micro_batch_size
+        assert output.shape[1] == sequence_length
+        assert output.shape[2] == config.hidden_size
+        assert bias.shape[0] == config.hidden_size
+
+    def test_self_attention_sp(self):
+        self.config.sequence_parallel = True
+        self.self_attn = MLASelfAttention(
+            self.config,
+            MLASelfAttentionSublayersSpec(
+                q_proj=BiasedLinear,
+                q_a_proj=BiasedLinear,
+                q_b_proj=BiasedLinear,
+                kv_a_proj_with_mqa=BiasedLinear,
+                kv_b_proj=BiasedLinear,
+                core_attention=DotProductAttention,
+                o_proj=BiasedLinear,
+                q_a_layernorm=RMSNorm,
+                kv_a_layernorm=RMSNorm,
+            ),
+            attn_mask_type=AttnMaskType.causal,
+            layer_number=1,
+        )
         config = self.self_attn.config
         sequence_length = 127
         micro_batch_size = 2


### PR DESCRIPTION
修复seq_first布局导致的bug，统一为batch first:
1. **rotary_base 参数错误** : `config.rotary_base` → `config.rope_theta`（rope 类型分支）
2. **形状注释全部修正**: `[s, b, ...]` → `[b, s, ...]`（batch-first）
3. 去掉 multi_latent_attention deinterleave
4. **packed seq squeeze 维度**: `squeeze(1)` → `squeeze(batch_dim)`，batch_dim 根据 SP 决定
5. **sequence parallel 维度**: sp下`[1, s, 1, d]` → ` [s, 1, 1, d]` (batch-first → sequence-first0
6. **q_len 计算**: `q.size()[1]` → ndim 感知（3D packed→dim0, SP→dim0, normal 4D→dim1）
7. **rotary_pos_emb 裁切轴**: `rotary_pos_emb[0:q_len]` → `rotary_pos_emb[:, 0:q_len]`