### PR TITLE
Update paddlepaddle-gpu dependency to version 260319

### DIFF
--- a/build_utils.py
+++ b/build_utils.py
@@ -223,7 +223,7 @@ def get_special_build_deps():
         major = sys.version_info.major
         minor = sys.version_info.minor
         deps = [
-            "paddlepaddle-gpu==3.3.0.post20260317+38eee703e79",
+            "paddlepaddle-gpu==3.3.0.post20260319+7688495538f",
         ]
         if cuda_major == 12:
             deps.append(


### PR DESCRIPTION
Update paddlepaddle-gpu dependency to version 260319 (after release3.3.1 tag)