### PR TITLE
[release/0.2] Fast path for rope when cp_size==1

### DIFF
--- a/src/paddlefleet/models/common/embeddings/rope_utils.py
+++ b/src/paddlefleet/models/common/embeddings/rope_utils.py
@@ -270,12 +270,24 @@ def _apply_rotary_pos_emb_thd(
     #    -> Use traditional mapping without offsets (map first :seqlen part)
     if freqs.dim() >= 1 and freqs.size(1) == cu_seqlens[-1]:
         # CASE 1: Exact mapping with offsets
+        # When cp_size==1, every per-segment slice concatenates back to the original freqs.
+        # Skip the split+cat and call bshd directly with the original freqs.
+        if cp_size == 1:
+            return _apply_rotary_pos_emb_bshd(
+                t,
+                freqs,
+                rotary_interleaved=rotary_interleaved,
+                multi_latent_attention=multi_latent_attention,
+                mscale=mscale,
+                high_precision_rope=high_precision_rope,
+            )
         # Build packed freqs in one pass, then apply once to the whole packed tensor
+        cu_seqlens_list = cu_seqlens.tolist()
         sequence_splits = paddle.split(t, seqlens, axis=1 if t.ndim == 4 else 0)
         freq_slices = []
         for i, x in enumerate(sequence_splits):
             # cu_seqlens[i] is the starting offset of this sequence in the original batch
-            seq_start_offset = cu_seqlens[i].item()
+            seq_start_offset = cu_seqlens_list[i]
             freq_slices.append(
                 _get_thd_freqs_on_this_cp_rank(
                     cp_rank, cp_size, x, freqs, seq_start_offset

--- a/src/paddlefleet/transformer/attention.py
+++ b/src/paddlefleet/transformer/attention.py
@@ -322,13 +322,15 @@ class Attention(FleetLayer, ABC):
                     mscale=None,
                     cp_group=self.pg_collection.cp,
                 )
+            # elif self.config.apply_vision_rope:
+            #     query, key = apply_rotary_pos_emb_vision(query,key,rotary_pos_cos,rotary_pos_sin)
             else:
                 if q_pos_emb is not None:
                     query = apply_rotary_pos_emb(
                         query,
                         q_pos_emb,
-                        rotary_pos_cos,
-                        rotary_pos_sin,
+                        None,
+                        None,
                         config=self.config,
                         cu_seqlens=cu_seqlens_q,
                         position_ids=position_ids,
@@ -342,8 +344,8 @@ class Attention(FleetLayer, ABC):
                     key = apply_rotary_pos_emb(
                         key,
                         k_pos_emb,
-                        rotary_pos_cos,
-                        rotary_pos_sin,
+                        None,
+                        None,
                         config=self.config,
                         cu_seqlens=cu_seqlens_kv,
                         position_ids=position_ids,


### PR DESCRIPTION
Fast path for rope when cp_size==1

新增fast path（已覆盖） 导致 原始slow path 代码未被执行。slow path 中修改仅更换 H2D 操作位置（将多次H2D合为1次）。退化到 slow path 需要增加 context parallel case，申请豁免。

Cherry-pick of #647 to `release/0.2`.

Merged in dev: #647  <!-- For pass CI -->