### PR TITLE
[CI] Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/Approval.yml
+++ b/.github/workflows/Approval.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 200
 

--- a/.github/workflows/Codestyle-Check.yml
+++ b/.github/workflows/Codestyle-Check.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout base repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           fetch-depth: 1000
@@ -37,7 +37,7 @@ jobs:
 
       - name: Setup python3.12
         if: steps.check-bypass.outputs.can-skip != 'true'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           cache: 'pip'

--- a/.github/workflows/Test-release3.3.yml
+++ b/.github/workflows/Test-release3.3.yml
@@ -1293,10 +1293,10 @@ jobs:
       GITHUB_REPO_NAME: ${{ github.repository }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - name: coverage file download
@@ -1463,7 +1463,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: always()
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           files: |
             ./multi_coverage.xml,

--- a/.github/workflows/_clone.yml
+++ b/.github/workflows/_clone.yml
@@ -38,7 +38,7 @@ jobs:
       group: HK-Clone
     steps:
       - name: Clone paddle
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
           submodules: 'recursive'
@@ -48,8 +48,6 @@ jobs:
         id: check-execution
         if: ${{ inputs.is_pr == 'true' }}
         run: |
-          git config --unset http.https://github.com/.extraheader
-          git submodule foreach --recursive sh -c "git config --local --unset-all 'http.https://github.com/.extraheader'"
           git submodule foreach --recursive sh -c "git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'"
           git switch ${{ github.event.pull_request.base.ref }}
           set +e

--- a/.github/workflows/check-release-pr.yml
+++ b/.github/workflows/check-release-pr.yml
@@ -17,7 +17,7 @@ jobs:
     name: Validate Dev PR
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Check if PR description contains dev PR link
         run: |
           echo "Checking PR body: $PR_BODY"

--- a/.github/workflows/remove-skip-ci-labels.yml
+++ b/.github/workflows/remove-skip-ci-labels.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Get PR labels
         id: get-labels
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -34,7 +34,7 @@ jobs:
 
       - name: Remove skip-ci labels
         if: steps.get-labels.outputs.has-skip-ci-labels == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Rerun all failed jobs
         if: ${{ contains(github.event.comment.body, 'all-failed') }}

--- a/.github/workflows/update-precision.yml
+++ b/.github/workflows/update-precision.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup python3.10
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 

--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -32,7 +32,7 @@ jobs:
           swap-storage: true
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Get current date
         id: date


### PR DESCRIPTION
## 改动动机

参考 Paddle 主仓的以下 PR：

- PaddlePaddle/Paddle#78079
- PaddlePaddle/Paddle#78080

这两个 PR 的核心目标是升级 GitHub Actions 版本，以兼容 GitHub Actions runner 后续默认切换到 Node 24，并同步跟进部分 action 的最新大版本。

PaddleFleet 当前 workflow 中仍保留多处旧版本 action，因此需要做对应的最小必要适配；同时，`actions/checkout@v6` 升级后，`_clone.yml` 中原先用于清理 `extraheader` 的旧兼容逻辑也应一并移除。

## 参考来源

- https://github.com/PaddlePaddle/Paddle/pull/78079
- https://github.com/PaddlePaddle/Paddle/pull/78080

## 改动内容

仅对 PaddleFleet 中实际存在、且与参考 PR 相关的 action 做对应升级：

- `actions/checkout`：`v4` -> `v6`
- `actions/setup-python`：`v5` -> `v6`
- `actions/github-script`：`v7` -> `v8`
- `codecov/codecov-action`：`v4` -> `v5`

另外：

- 在 `.github/workflows/_clone.yml` 中移除旧的 `http.https://github.com/.extraheader` 清理逻辑，和 Paddle#78079 保持一致，避免继续依赖 `checkout` 旧版本兼容路径。

本仓库中不存在 Paddle#78079 / #78080 里涉及的 `download-artifact`、`upload-artifact`、`create-or-update-comment` 等对应使用点，因此未做无关改动。

## 验证结果

- `ruby` 解析全部 workflow YAML 成功
- `grep` 确认本次涉及的旧版本引用已完成替换
- `actionlint` 针对本次修改的 workflow 运行后，仍仅报出 upstream `develop` 已存在的历史问题（如 `check-bypass` / `can-skip` 表达式静态检查告警、部分 `github.head_ref` 安全提示），未引入新的本次改动相关诊断

@SigureMo Please review this PR when you have time. Thanks!
