### PR TITLE
[Fix] Add PADDLE_WITH_DNNL macro detection in PaddleFleet build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -104,11 +104,15 @@ class CustomBdistWheel(_bdist_wheel):
 
 
 def setup_ops_extension():
+    from paddle.base.core import is_compiled_with_onednn
     from paddle.utils.cpp_extension import CUDAExtension, setup
 
     from build_utils import get_cuda_version
 
-    # 定义 NVCC 编译参数
+    # Detect Paddle build config to ensure ABI compatibility
+    paddle_compiled_with_onednn = is_compiled_with_onednn()
+
+    # Define NVCC compile flags
     nvcc_args = [
         "-O3",
         "-U__CUDA_NO_HALF_OPERATORS__",
@@ -127,10 +131,28 @@ def setup_ops_extension():
         "-gencode=arch=compute_100,code=sm_100",
         "-DNDEBUG",
     ]
+
+    # Define PADDLE_WITH_DNNL if Paddle was built with OneDNN,
+    # to ensure ABI compatibility for DenseTensor, etc.
+    if paddle_compiled_with_onednn:
+        nvcc_args.append("-DPADDLE_WITH_DNNL")
+
     cuda_major, cuda_minor = get_cuda_version()
 
     if cuda_major == 12 and cuda_minor < 8:
         nvcc_args = [arg for arg in nvcc_args if "compute_100" not in arg]
+
+    # Add oneDNN include path if Paddle was built with OneDNN,
+    # otherwise Paddle headers that #include "dnnl.hpp" will fail
+    extra_include_dirs = []
+    if paddle_compiled_with_onednn:
+        import paddle
+        paddle_include_dir = os.path.join(os.path.dirname(paddle.__file__), "include")
+        onednn_include_dir = os.path.join(
+            paddle_include_dir, "third_party", "install", "onednn", "include"
+        )
+        if os.path.exists(onednn_include_dir):
+            extra_include_dirs.append(onednn_include_dir)
 
     ext_module = CUDAExtension(
         sources=[
@@ -153,7 +175,7 @@ def setup_ops_extension():
         ],
         include_dirs=[
             os.path.join(os.getcwd(), "src/paddlefleet/_extensions"),
-        ],
+        ] + extra_include_dirs,
         extra_compile_args={
             "cxx": [
                 "-O3",
@@ -161,7 +183,7 @@ def setup_ops_extension():
                 "-Wno-abi",
                 "-fPIC",
                 "-std=c++17",
-            ],
+            ] + (["-DPADDLE_WITH_DNNL"] if paddle_compiled_with_onednn else []),
             "nvcc": nvcc_args,
         },
     )


### PR DESCRIPTION
- 功能

消除eb 代码必须要paddle wheel包with_mkl=off的限制，这个限制会导致编包成本大，paddle官网的wheel包（with_mkl=on）和EB 业务的包（with_mkl=off）不能统一，此PR合入之后，业务可以直接用官网的包，有助于发版镜像提速，减小编包维护成本

- 问题描述

当 Paddle 使用 `WITH_MKL=ON` 编译时，会启用 OneDNN 库并定义 `PADDLE_WITH_DNNL` 宏。这会影响 `DenseTensor` 的内存布局，具体代码见：

```
// paddle/phi/core/storage_properties.h
#ifdef PADDLE_WITH_DNNL
struct OneDNNStorageProperties : public StorageProperties {
  dnnl::memory::format_tag format;  // 4 bytes
  dnnl::memory::desc mem_desc;       // 696 bytes
};
#endif
DenseTensor::storage_properties_ 指针在 Paddle 和 PaddleFleet 编译时指向的对象大小不同：

Paddle 端：可能指向 OneDNNStorageProperties（708 bytes）
PaddleFleet 端：只认识基类 StorageProperties（8 bytes）
这导致 ABI 不一致，PaddleFleet 自定义算子访问 Paddle 传入的 DenseTensor 时可能崩溃或出现未定义行为。
```

- 修复方案

在 setup.py 的 nvcc_args 和 cxx_args 中同步添加 -DPADDLE_WITH_DNNL 宏定义，
