### PR TITLE
【MLA】support mla down_proj use notplinear

### DIFF
--- a/src/paddlefleet/models/backends.py
+++ b/src/paddlefleet/models/backends.py
@@ -24,6 +24,7 @@ from paddlefleet.parallel_state import (
 )
 from paddlefleet.tensor_parallel.layers import (
     ColumnParallelLinear,
+    Linear,
     RowParallelLinear,
 )
 from paddlefleet.transformer.dot_product_attention import (
@@ -96,6 +97,10 @@ class BackendSpecProvider(Protocol):
 
 class LocalSpecProvider(BackendSpecProvider):
     """A protocol for providing Local sublayers_spec used in Spec building."""
+
+    def linear(self) -> type:
+        """Which linear layer the backend uses"""
+        return Linear
 
     def column_parallel_linear(self) -> type:
         """Which column parallel linear layer the backend uses"""

--- a/src/paddlefleet/models/gpt/gpt_layer_specs.py
+++ b/src/paddlefleet/models/gpt/gpt_layer_specs.py
@@ -133,9 +133,9 @@ def get_gpt_layer_local_spec(
                     extra_kwargs={"attn_mask_type": AttnMaskType.causal},
                     sublayers_spec=MLASelfAttentionSublayersSpec(
                         q_proj=backend.column_parallel_linear(),
-                        q_a_proj=backend.column_parallel_linear(),
+                        q_a_proj=backend.linear(),
                         q_b_proj=backend.column_parallel_linear(),
-                        kv_a_proj_with_mqa=backend.column_parallel_linear(),
+                        kv_a_proj_with_mqa=backend.linear(),
                         kv_b_proj=backend.column_parallel_linear(),
                         core_attention=backend.core_attention(),
                         o_proj=backend.row_parallel_linear(),

--- a/src/paddlefleet/tensor_parallel/__init__.py
+++ b/src/paddlefleet/tensor_parallel/__init__.py
@@ -18,6 +18,7 @@
 from .cross_entropy import vocab_parallel_cross_entropy
 from .layers import (
     ColumnParallelLinear,
+    Linear,
     RowParallelLinear,
     VocabParallelEmbedding,
 )
@@ -34,6 +35,7 @@ __all__ = [
     "vocab_parallel_cross_entropy",
     # layers.py
     "ColumnParallelLinear",
+    "Linear",
     "RowParallelLinear",
     "VocabParallelEmbedding",
     # random.py

--- a/src/paddlefleet/tensor_parallel/layers.py
+++ b/src/paddlefleet/tensor_parallel/layers.py
@@ -758,6 +758,258 @@ def linear_with_grad_accumulation_and_async_allreduce(
 linear_with_grad_accumulation_and_async_allreduce.warned = False
 
 
+class Linear(paddle.nn.Layer):
+    """Linear layer with no tensor parallelism (weight duplicated across TP ranks).
+
+    The linear layer is defined as Y = XA + b. Weight is not split and is
+    replicated on all tensor parallel ranks. Interface is identical to
+    ColumnParallelLinear for drop-in compatibility.
+
+    Refer to Megatron-LM's TELinear with parallel_mode="duplicated" for the
+    equivalent design.
+
+    Args:
+        input_size:
+            first dimension of matrix A.
+        output_size:
+            second dimension of matrix A.
+        bias:
+            If true, add bias.
+        gather_output:
+            Unused. Kept for interface compatibility with ColumnParallelLinear.
+        init_method:
+            method to initialize weights. Note that bias is always set to zero.
+        stride:
+            For the strided linear layers.
+        keep_master_weight_for_test:
+            This was added for testing and should be set to False. It
+            returns the master weights used for initialization.
+        skip_bias_add:
+            If True, do not add the bias term, instead return it to be added by
+            the caller. This enables performance optimizations where bias can be
+            fused with other elementwise operations.
+        skip_weight_param_allocation:
+            If True, weight parameter is not allocated and must be passed as a
+            keyword argument `weight` during the forward pass. Defaults to False.
+        embedding_activation_buffer:
+            This buffer holds the input activations of the final embedding linear
+            layer on the last pipeline stage when defer_embedding_wgrad_compute
+            is enabled.
+        grad_output_buffer:
+            This buffer holds the gradient outputs of the final embedding linear
+            layer on the last pipeline stage when defer_embedding_wgrad_compute
+            is enabled.
+        is_expert:
+            If True, the layer is treated as an MoE expert layer.
+        config:
+            ModelParallelConfig object.
+        tp_comm_buffer_name:
+            Not used. Kept for interface compatibility.
+        disable_grad_reduce:
+            Not used. Weight is replicated so no TP grad reduction is needed.
+        tp_group:
+            Not used. Kept for interface compatibility.
+    """
+
+    def __init__(
+        self,
+        input_size,
+        output_size,
+        *,
+        config: TransformerConfig,
+        init_method: Callable,
+        bias=True,
+        gather_output=False,
+        stride=1,
+        keep_master_weight_for_test=False,
+        skip_bias_add=False,
+        skip_weight_param_allocation: bool = False,
+        embedding_activation_buffer: list[paddle.Tensor] | None = None,
+        grad_output_buffer: list[paddle.Tensor] | None = None,
+        is_expert: bool = False,
+        tp_comm_buffer_name: str | None = None,
+        disable_grad_reduce: bool = False,
+        tp_group: paddle.core.ProcessGroup | None = None,
+    ):
+        super().__init__()
+
+        self.input_size = input_size
+        self.output_size = output_size
+        self.gather_output = gather_output
+        self.skip_bias_add = skip_bias_add
+        self.is_expert = is_expert
+        self.embedding_activation_buffer = embedding_activation_buffer
+        self.grad_output_buffer = grad_output_buffer
+        self.config = config
+        self._dtype = config.params_dtype
+
+        # No TP: output_size_per_partition equals the full output_size.
+        self.output_size_per_partition = output_size
+
+        if not skip_weight_param_allocation:
+            if config.use_cpu_initialization:
+                self.weight = self.create_parameter(
+                    shape=[self.input_size, self.output_size],
+                    dtype=config.params_dtype,
+                    is_bias=False,
+                    default_initializer=paddle.nn.initializer.Constant(0.0),
+                )
+                if config.perform_initialization:
+                    _initialize_affine_weight_cpu(
+                        self.weight,
+                        self.input_size,
+                        self.output_size,
+                        self.output_size,  # full output, no partition
+                        1,
+                        init_method,
+                        stride=stride,
+                        return_master_weight=keep_master_weight_for_test,
+                        rank=0,
+                        world_size=1,
+                    )
+            else:
+                self.weight = self.create_parameter(
+                    shape=[self.input_size, self.output_size],
+                    dtype=config.params_dtype,
+                    is_bias=False,
+                    default_initializer=paddle.nn.initializer.Constant(0.0),
+                )
+                if config.perform_initialization:
+                    _initialize_affine_weight_gpu(
+                        self.weight,
+                        init_method,
+                        partition_dim=0,
+                        stride=stride,
+                        is_expert=self.is_expert,
+                    )
+
+            # Weight is duplicated across TP ranks; reduce gradient on DP group.
+            self.weight.allreduce = True
+            self.weight.is_distributed = False
+        else:
+            self.weight = None
+
+        if bias:
+            self.bias = self.create_parameter(
+                shape=[self.output_size],
+                dtype=config.params_dtype,
+                is_bias=True,
+                default_initializer=paddle.nn.initializer.Constant(0.0),
+            )
+            if config.perform_initialization:
+                with paddle.no_grad():
+                    self.bias.zero_()
+            self.bias.allreduce = True
+            self.bias.is_distributed = False
+        else:
+            self.bias = None
+
+        self._forward_impl = linear_with_grad_accumulation_and_async_allreduce
+
+    def forward(
+        self,
+        input_: paddle.Tensor,
+        weight: paddle.Tensor | None = None,
+        runtime_gather_output: bool | None = None,
+    ):
+        """Forward of Linear (no tensor parallelism).
+
+        Args:
+            input_:
+                3D tensor whose order of dimension is [sequence, batch, hidden].
+            weight (optional):
+                weight tensor to use, compulsory when skip_weight_param_allocation is True.
+            runtime_gather_output (bool): Unused. Kept for interface compatibility.
+
+        Returns:
+            - output
+            - bias
+        """
+        if weight is None:
+            if self.weight is None:
+                raise RuntimeError(
+                    "weight was not supplied to Linear forward pass "
+                    "and skip_weight_param_allocation is True."
+                )
+            weight = self.weight
+        else:
+            expected_shape = [self.input_size, self.output_size]
+            if weight.shape != expected_shape:
+                raise RuntimeError(
+                    f"supplied weight's shape is {tuple(weight.shape)}, "
+                    f"not {expected_shape} as expected"
+                )
+
+        bias = self.bias if not self.skip_bias_add else None
+
+        if self.config.defer_embedding_wgrad_compute:
+            if (
+                self.config.wgrad_deferral_limit == 0
+                or len(self.embedding_activation_buffer)
+                < self.config.wgrad_deferral_limit
+            ):
+                self.embedding_activation_buffer.append(input_)
+
+        if not weight.requires_grad:
+            self._forward_impl = linear_with_frozen_weight
+        else:
+            self._forward_impl = (
+                linear_with_grad_accumulation_and_async_allreduce
+            )
+
+        output = self._forward_impl(
+            input=input_,
+            weight=weight,
+            bias=bias,
+            gradient_accumulation_fusion=False,
+            allreduce_dgrad=False,
+            sequence_parallel=False,
+            grad_output_buffer=(
+                self.grad_output_buffer
+                if self.config.defer_embedding_wgrad_compute
+                else None
+            ),
+            wgrad_deferral_limit=(
+                self.config.wgrad_deferral_limit
+                if self.config.defer_embedding_wgrad_compute
+                else None
+            ),
+            tp_group=None,
+        )
+
+        output_bias = (
+            self.bias.clone()
+            if (self.skip_bias_add and self.bias is not None)
+            else None
+        )
+
+        return output, output_bias
+
+    def sharded_state_dict(
+        self,
+        structured_name_prefix: str = "",
+    ):
+        """Weight is replicated, no sharding rules needed."""
+        state_dict = self.state_dict(structured_name_prefix="")
+        return build_sharded_state_dict(
+            state_dict, None, structured_name_prefix
+        )
+
+    def set_extra_state(self, state):
+        """Extra state is ignored"""
+
+    def get_extra_state(self) -> None:
+        """Keep compatibility with TE state dict."""
+        return None
+
+    def __repr__(self):
+        use_bias = self.bias is not None and self.bias is True
+        return (
+            f"{type(self).__name__}(in_features={self.input_size}, "
+            f"out_features={self.output_size}, bias={use_bias}, TP=1)"
+        )
+
+
 class ColumnParallelLinear(paddle.nn.Layer):
     """Linear layer with column parallelism.
 

--- a/tests/multi_card_tests/disable_multi-card_uts.txt
+++ b/tests/multi_card_tests/disable_multi-card_uts.txt
@@ -1,5 +1,4 @@
 test_mappings.py
-test_layers.py
 test_tensor_parallel_utils.py
 test_cross_entropy.py
 test_data.py

--- a/tests/multi_card_tests/tensor_parallel/test_layers.py
+++ b/tests/multi_card_tests/tensor_parallel/test_layers.py
@@ -260,7 +260,7 @@ def test_RowParallelLinear(
         rank * (in_f // tensor_parallel),
         0,
     )
-    assert bias_shard.global_shape == [out_f]
+    assert bias_shard.global_shape == (out_f,)
     assert bias_shard.local_shape == bias_shard.global_shape
     assert bias_shard.global_offset == (0,)
 

--- a/tests/multi_card_tests/tensor_parallel/test_layers.py
+++ b/tests/multi_card_tests/tensor_parallel/test_layers.py
@@ -20,8 +20,10 @@ import paddle.distributed as dist
 from paddle.distributed import ShardedWeight
 
 import paddlefleet.parallel_state as ps
+from paddlefleet.models.backends import LocalSpecProvider
 from paddlefleet.tensor_parallel.layers import (
     ColumnParallelLinear,
+    Linear,
     RowParallelLinear,
     VocabParallelEmbedding,
     linear_with_frozen_weight,
@@ -344,6 +346,285 @@ def test_VocabParallelEmbedding(
     )
 
 
+# ---------------------------------------------------------------------------
+# Tests for Linear (non-TP, weight replicated across TP ranks).
+# backend.linear() in gpt_layer_specs.py resolves to this class via
+# LocalSpecProvider.linear() -> Linear.
+# ---------------------------------------------------------------------------
+
+
+def _make_linear_config():
+    return TransformerConfig(
+        num_hidden_layers=1,
+        hidden_size=12,
+        num_attention_heads=4,
+        use_cpu_initialization=True,
+    )
+
+
+def test_Linear_forward_basic():
+    """forward(): output shape is correct and backward propagates to input."""
+    config = _make_linear_config()
+    paddle.manual_seed(0)
+    layer = Linear(
+        input_size=8,
+        output_size=6,
+        config=config,
+        init_method=config.init_method,
+        bias=True,
+        skip_bias_add=False,
+    )
+
+    input_data = paddle.randn([4, 8])
+    input_data.requires_grad = True
+
+    output, output_bias = layer(input_data)
+
+    assert output.shape == [4, 6], f"Expected [4,6], got {output.shape}"
+    assert output_bias is None, (
+        "skip_bias_add=False should return None as output_bias"
+    )
+
+    output.sum().backward()
+    assert input_data.grad is not None
+    assert input_data.grad.shape == [4, 8]
+
+
+def test_Linear_skip_bias_add():
+    """forward() with skip_bias_add=True returns (output, bias) instead of adding bias."""
+    config = _make_linear_config()
+    paddle.manual_seed(1)
+    layer = Linear(
+        input_size=8,
+        output_size=6,
+        config=config,
+        init_method=config.init_method,
+        bias=True,
+        skip_bias_add=True,
+    )
+
+    input_data = paddle.randn([4, 8])
+    output, output_bias = layer(input_data)
+
+    assert output.shape == [4, 6]
+    assert output_bias is not None, (
+        "skip_bias_add=True should return the bias tensor"
+    )
+    assert output_bias.shape == [6]
+
+    # Verify: output + broadcast(bias) equals the manually computed result.
+    expected = paddle.matmul(input_data, layer.weight) + output_bias
+    assert paddle.allclose(output + output_bias, expected, atol=1e-5)
+
+
+def test_Linear_no_bias():
+    """forward() with bias=False: layer.bias is None, output_bias is None."""
+    config = _make_linear_config()
+    paddle.manual_seed(2)
+    layer = Linear(
+        input_size=8,
+        output_size=6,
+        config=config,
+        init_method=config.init_method,
+        bias=False,
+        skip_bias_add=False,
+    )
+
+    assert layer.bias is None
+
+    input_data = paddle.randn([4, 8])
+    output, output_bias = layer(input_data)
+
+    assert output.shape == [4, 6]
+    assert output_bias is None
+
+
+def test_Linear_skip_weight_param_allocation():
+    """forward() accepts an externally supplied weight when
+    skip_weight_param_allocation=True."""
+    config = _make_linear_config()
+    paddle.manual_seed(3)
+    layer = Linear(
+        input_size=8,
+        output_size=6,
+        config=config,
+        init_method=config.init_method,
+        bias=False,
+        skip_weight_param_allocation=True,
+    )
+
+    assert layer.weight is None
+
+    ext_weight = paddle.randn([8, 6])
+    input_data = paddle.randn([4, 8])
+    output, _ = layer(input_data, weight=ext_weight)
+
+    assert output.shape == [4, 6]
+    expected = paddle.matmul(input_data, ext_weight)
+    assert paddle.allclose(output, expected, atol=1e-5)
+
+
+def test_Linear_forward_wrong_weight_shape():
+    """forward() raises RuntimeError when supplied weight has wrong shape."""
+    config = _make_linear_config()
+    paddle.manual_seed(4)
+    layer = Linear(
+        input_size=8,
+        output_size=6,
+        config=config,
+        init_method=config.init_method,
+        bias=False,
+        skip_weight_param_allocation=True,
+    )
+
+    bad_weight = paddle.randn([8, 99])  # wrong output dim
+    input_data = paddle.randn([4, 8])
+    try:
+        layer(input_data, weight=bad_weight)
+        raise AssertionError("Expected RuntimeError was not raised")
+    except RuntimeError as e:
+        assert "not" in str(e).lower() or "expected" in str(e).lower()
+
+
+def test_Linear_frozen_weight():
+    """forward() switches to linear_with_frozen_weight when weight.stop_gradient=True."""
+    config = _make_linear_config()
+    paddle.manual_seed(5)
+    layer = Linear(
+        input_size=8,
+        output_size=6,
+        config=config,
+        init_method=config.init_method,
+        bias=True,
+        skip_bias_add=False,
+    )
+    layer.weight.stop_gradient = True
+
+    input_data = paddle.randn([4, 8])
+    input_data.requires_grad = True
+
+    output, _ = layer(input_data)
+    output.sum().backward()
+
+    # Weight gradient must not be computed (frozen).
+    assert layer.weight.grad is None
+    # Input gradient must still exist.
+    assert input_data.grad is not None
+
+
+def test_Linear_sharded_state_dict():
+    """sharded_state_dict(): weight and bias are present; weight is replicated
+    so it should NOT carry per-rank shard offsets (global_offset == (0, 0))."""
+    config = _make_linear_config()
+    paddle.manual_seed(6)
+    layer = Linear(
+        input_size=8,
+        output_size=6,
+        config=config,
+        init_method=config.init_method,
+        bias=True,
+    )
+
+    sharded_dict = layer.sharded_state_dict()
+
+    assert "weight" in sharded_dict
+    assert "bias" in sharded_dict
+
+    weight_entry = sharded_dict["weight"]
+    bias_entry = sharded_dict["bias"]
+
+    # Weight is replicated: either a plain tensor or a ShardedWeight with no
+    # actual sharding (global_offset all-zeros, local == global).
+    if isinstance(weight_entry, ShardedWeight):
+        assert weight_entry.global_shape == (8, 6)
+        assert weight_entry.local_shape == (8, 6)
+        assert weight_entry.global_offset == (0, 0)
+    else:
+        assert list(weight_entry.shape) == [8, 6]
+
+    if isinstance(bias_entry, ShardedWeight):
+        assert bias_entry.global_shape == (6,)
+        assert bias_entry.local_shape == (6,)
+        assert bias_entry.global_offset == (0,)
+    else:
+        assert list(bias_entry.shape) == [6]
+
+
+def test_Linear_extra_state():
+    """get_extra_state() returns None; set_extra_state() is a no-op."""
+    config = _make_linear_config()
+    layer = Linear(
+        input_size=8,
+        output_size=6,
+        config=config,
+        init_method=config.init_method,
+    )
+
+    assert layer.get_extra_state() is None
+    # set_extra_state must not raise.
+    layer.set_extra_state({"some": "state"})
+    layer.set_extra_state(None)
+
+
+def test_Linear_repr():
+    """__repr__() contains the expected fields."""
+    config = _make_linear_config()
+    layer = Linear(
+        input_size=8,
+        output_size=6,
+        config=config,
+        init_method=config.init_method,
+        bias=True,
+    )
+
+    r = repr(layer)
+    assert "Linear" in r
+    assert "8" in r  # in_features
+    assert "6" in r  # out_features
+    assert "TP=1" in r
+
+
+def test_Linear_via_backend_linear():
+    """Verify that LocalSpecProvider().linear() returns the Linear class and
+    that instances built from it behave identically to directly-constructed ones.
+
+    This mirrors how gpt_layer_specs.py uses backend.linear() for
+    q_a_proj / kv_a_proj_with_mqa in the MLA attention path."""
+
+    backend = LocalSpecProvider()
+    LinearCls = backend.linear()
+    assert LinearCls is Linear, (
+        f"backend.linear() should return Linear, got {LinearCls}"
+    )
+
+    config = _make_linear_config()
+    paddle.manual_seed(7)
+    layer = LinearCls(
+        input_size=16,
+        output_size=8,
+        config=config,
+        init_method=config.init_method,
+        bias=True,
+        skip_bias_add=False,
+    )
+
+    # Weight should be replicated (not distributed).
+    assert layer.weight.allreduce is True
+    assert layer.weight.is_distributed is False
+
+    input_data = paddle.randn([3, 16])
+    input_data.requires_grad = True
+    output, output_bias = layer(input_data)
+
+    assert output.shape == [3, 8]
+    assert output_bias is None
+
+    output.sum().backward()
+    assert input_data.grad is not None
+    assert layer.weight.grad is not None
+    assert layer.weight.grad.shape == [16, 8]
+
+
 if __name__ == "__main__":
     tensor_parallel = 4
     Utils.initialize_model_parallel(tensor_parallel, 1)
@@ -370,3 +651,13 @@ if __name__ == "__main__":
     )
     output_tp1, weight_grad_tp1 = embedding_baseline()
     test_VocabParallelEmbedding(4, output_tp1, weight_grad_tp1)
+    test_Linear_forward_basic()
+    test_Linear_skip_bias_add()
+    test_Linear_no_bias()
+    test_Linear_skip_weight_param_allocation()
+    test_Linear_forward_wrong_weight_shape()
+    test_Linear_frozen_weight()
+    test_Linear_sharded_state_dict()
+    test_Linear_extra_state()
+    test_Linear_repr()
+    test_Linear_via_backend_linear()


### PR DESCRIPTION
MLA 中的q_a_proj， kv_a_proj_with_mqa 改为非tp 切分的linear,对齐实现