### PR TITLE
[Cherry-pick] Optimize VisionModel rope position encoding and packed seq attention

### DIFF
--- a/src/paddlefleet/models/common/embeddings/rope_utils.py
+++ b/src/paddlefleet/models/common/embeddings/rope_utils.py
@@ -239,7 +239,7 @@ def _get_thd_freqs_on_this_cp_rank(
 def _apply_rotary_pos_emb_thd(
     t: Tensor,
     cu_seqlens: Tensor,
-    total_seq_len: int,
+    total_seq_len: int | None,
     freqs: Tensor,
     rotary_interleaved: bool = False,
     multi_latent_attention: bool = False,
@@ -253,6 +253,9 @@ def _apply_rotary_pos_emb_thd(
         t (Tensor): Input tensor T is of shape [t, h, d]
         cu_seqlens(Tensor):  Cumulative sum of sequence lengths in a batch for `t`,
         with shape [b + 1] and dtype paddle.int32.
+        total_seq_len (int | None): The actual total sequence length before padding.
+            When cu_seqlens uses a padded version, this provides the true total length
+            for correct frequency tensor selection. If None, falls back to cu_seqlens[-1].
         freqs (Tensor): Rotary Positional embedding tensor freq is of shape [max_s, 1, 1, d]
         cp_group (Group): The context parallel group
 
@@ -267,7 +270,7 @@ def _apply_rotary_pos_emb_thd(
     )
 
     # Handle two different frequency tensor formats:
-    # 1. If freqs.size(0) == cu_seqlens[-1]: freqs contains all positions across all sequences
+    # 1. If freqs.size(1) == total_seq_len: freqs contains all positions across all sequences
     #    -> Use offset-based mapping for exact positional correspondence
     # 2. Otherwise: freqs contains only max sequence length positions
     #    -> Use traditional mapping without offsets (map first :seqlen part)
@@ -354,6 +357,9 @@ def apply_rotary_pos_emb(
         sin (Tensor | None): Pre-computed sine values of freqs (used for fused implementation)
         config (TransformerConfig): Transformer configuration
         cu_seqlens (Tensor | None): Cumulative sequence lengths
+        total_seq_len (int | None): The actual total sequence length before padding.
+            Used in thd format to correctly select frequency tensor when cu_seqlens
+            is padded. If None, falls back to cu_seqlens[-1].
         mscale (float): Scaling factor
         cp_group (Group): Context parallel group
     """

--- a/src/paddlefleet/models/common/embeddings/rope_utils.py
+++ b/src/paddlefleet/models/common/embeddings/rope_utils.py
@@ -239,6 +239,7 @@ def _get_thd_freqs_on_this_cp_rank(
 def _apply_rotary_pos_emb_thd(
     t: Tensor,
     cu_seqlens: Tensor,
+    total_seq_len: int,
     freqs: Tensor,
     rotary_interleaved: bool = False,
     multi_latent_attention: bool = False,
@@ -261,14 +262,16 @@ def _apply_rotary_pos_emb_thd(
     cp_size = get_pg_size(cp_group)
     cp_rank = get_pg_rank(cp_group)
 
-    seqlens = ((cu_seqlens[1:] - cu_seqlens[:-1]) // cp_size).tolist()
+    total_seq_len = (
+        total_seq_len if total_seq_len is not None else cu_seqlens[-1]
+    )
 
     # Handle two different frequency tensor formats:
     # 1. If freqs.size(0) == cu_seqlens[-1]: freqs contains all positions across all sequences
     #    -> Use offset-based mapping for exact positional correspondence
     # 2. Otherwise: freqs contains only max sequence length positions
     #    -> Use traditional mapping without offsets (map first :seqlen part)
-    if freqs.dim() >= 1 and freqs.size(1) == cu_seqlens[-1]:
+    if freqs.dim() >= 1 and freqs.size(1) == total_seq_len:
         # CASE 1: Exact mapping with offsets
         # When cp_size==1, every per-segment slice concatenates back to the original freqs.
         # Skip the split+cat and call bshd directly with the original freqs.
@@ -281,6 +284,7 @@ def _apply_rotary_pos_emb_thd(
                 mscale=mscale,
                 high_precision_rope=high_precision_rope,
             )
+        seqlens = ((cu_seqlens[1:] - cu_seqlens[:-1]) // cp_size).tolist()
         # Build packed freqs in one pass, then apply once to the whole packed tensor
         cu_seqlens_list = cu_seqlens.tolist()
         sequence_splits = paddle.split(t, seqlens, axis=1 if t.ndim == 4 else 0)
@@ -307,6 +311,7 @@ def _apply_rotary_pos_emb_thd(
     else:
         # CASE 2: Traditional mapping without offsets
         # Build packed freqs for all sequences using the standard mapping, then apply once
+        seqlens = ((cu_seqlens[1:] - cu_seqlens[:-1]) // cp_size).tolist()
         sequence_splits = paddle.split(t, seqlens, axis=1 if t.ndim == 4 else 0)
         freqs_packed = paddle.cat(
             [
@@ -333,6 +338,7 @@ def apply_rotary_pos_emb(
     sin: Tensor | None,
     config: TransformerConfig,
     cu_seqlens: Tensor | None = None,
+    total_seq_len: int | None = None,
     mscale: float = 1.0,
     cp_group: Group = None,
     position_ids: Tensor | None = None,
@@ -385,6 +391,7 @@ def apply_rotary_pos_emb(
         return _apply_rotary_pos_emb_thd(
             t,
             cu_seqlens,
+            total_seq_len,
             freqs,
             rotary_interleaved=config.rotary_interleaved,
             multi_latent_attention=config.multi_latent_attention,

--- a/src/paddlefleet/models/multimodal/context_parallel.py
+++ b/src/paddlefleet/models/multimodal/context_parallel.py
@@ -124,6 +124,8 @@ def get_packed_seq_params(
         cu_seqlens_kv_padded=cu_seqlens_padded,
         max_seqlen_q=combined_padded_seqlen,
         max_seqlen_kv=combined_padded_seqlen,
+        total_seqlen_q=batch_size * combined_valid_seqlen,
+        total_seqlen_kv=batch_size * combined_valid_seqlen,
         qkv_format=qkv_format,
     )
 

--- a/src/paddlefleet/packed_seq_params.py
+++ b/src/paddlefleet/packed_seq_params.py
@@ -35,3 +35,5 @@ class PackedSeqParams:
     cu_seqlens_kv_padded: Tensor | None = None
     max_seqlen_q: int | None = None
     max_seqlen_kv: int | None = None
+    total_seqlen_q: int | None = None
+    total_seqlen_kv: int | None = None

--- a/src/paddlefleet/transformer/attention.py
+++ b/src/paddlefleet/transformer/attention.py
@@ -303,8 +303,11 @@ class Attention(FleetLayer, ABC):
                     cu_seqlens_kv = packed_seq_params.cu_seqlens_kv_padded
                 else:
                     cu_seqlens_kv = packed_seq_params.cu_seqlens_kv
+                total_seqlen_q = packed_seq_params.total_seqlen_q
+                total_seqlen_kv = packed_seq_params.total_seqlen_kv
             else:
                 cu_seqlens_q = cu_seqlens_kv = None
+                total_seqlen_q = total_seqlen_kv = None
 
             if (
                 self.config.apply_rope_fusion
@@ -333,6 +336,7 @@ class Attention(FleetLayer, ABC):
                         None,
                         config=self.config,
                         cu_seqlens=cu_seqlens_q,
+                        total_seq_len=total_seqlen_q,
                         position_ids=position_ids,
                         mscale=_yarn_get_concentration_factor_from_config(
                             self.config
@@ -348,6 +352,7 @@ class Attention(FleetLayer, ABC):
                         None,
                         config=self.config,
                         cu_seqlens=cu_seqlens_kv,
+                        total_seq_len=total_seqlen_kv,
                         position_ids=position_ids,
                         mscale=_yarn_get_concentration_factor_from_config(
                             self.config

--- a/src/paddlefleet/transformer/dot_product_attention.py
+++ b/src/paddlefleet/transformer/dot_product_attention.py
@@ -197,31 +197,51 @@ class DotProductAttention(FleetLayer):
             assert (
                 query.dtype == paddle.bfloat16 or query.dtype == paddle.float16
             ), "attention only support fp16/bf16 when use packed_seq_params"
-            lengths = (
-                packed_seq_params.cu_seqlens_kv[1:]
-                - packed_seq_params.cu_seqlens_kv[:-1]
-            )
-            splits = [
-                paddle.split(tensor, lengths.tolist(), axis=1)
-                for tensor in (query, key, value)
-            ]
-            attn_outputs = []
-            for q, k, v in zip(*splits):
-                attn_outputs.append(
-                    paddle.nn.functional.scaled_dot_product_attention(
-                        q,
-                        k,
-                        v,
-                        None,
-                        self.config.attention_dropout,
-                        is_causal=False,
+
+            if attn_mask_startend_row_indices is None:
+                # Build flashmask startend_row_indices from cu_seqlens for block-diagonal
+                # non-causal attention. Each token in segment i gets [end_i, total, 0, start_i],
+                # so it attends only to tokens within its own segment.
+                # This replaces the per-segment split + Python loop with a single FA call.
+                cu_seqlens = packed_seq_params.cu_seqlens_kv
+                seq_length = query.shape[1]
+                lengths = cu_seqlens[1:] - cu_seqlens[:-1]
+                indices_per_segment = paddle.stack(
+                    [
+                        cu_seqlens[1:],  # col 0: lower_start = end_i
+                        paddle.full_like(
+                            cu_seqlens[1:], seq_length
+                        ),  # col 1: lower_end   = total_seq
+                        paddle.zeros_like(
+                            cu_seqlens[:-1]
+                        ),  # col 2: upper_start = 0
+                        cu_seqlens[:-1],  # col 3: upper_end   = start_i
+                    ],
+                    axis=1,
+                )  # [num_segments, 4]
+                attn_mask_startend_row_indices = (
+                    paddle.repeat_interleave(
+                        indices_per_segment, lengths, axis=0
                     )
-                )
-            # [b,s,h_n,h_dim]
-            attn_output = paddle.cat(attn_outputs, axis=1)
-            return attn_output.reshape(
-                [0, 0, attn_output.shape[2] * attn_output.shape[3]]
+                    .unsqueeze(0)
+                    .unsqueeze(0)
+                )  # [1, 1, seq_len, 4]
+
+            flashmask_attention_func = (
+                self.rr_flashmask_attention_func
+                if use_rr_flash_attention
+                else flashmask_attention
             )
+            attn_output = flashmask_attention_func(
+                query.astype(value.dtype),
+                key.astype(value.dtype),
+                value.astype(value.dtype),
+                startend_row_indices=attn_mask_startend_row_indices,
+                dropout=self.config.attention_dropout,
+                causal=False,
+            )
+            attn_output = attn_output.reshape([0, 0, -1])
+            return attn_output
         if (
             query.dtype == paddle.bfloat16 or query.dtype == paddle.float16
         ) and attn_mask_startend_row_indices is None:

--- a/src/paddlefleet/transformer/dot_product_attention.py
+++ b/src/paddlefleet/transformer/dot_product_attention.py
@@ -193,6 +193,14 @@ class DotProductAttention(FleetLayer):
         assert attention_bias is None, (
             "Attention bias is not supported for DotProductAttention."
         )
+        if self.config.fa_version == 4:
+            from paddlefleet.ops.flash_mask.cute.interface import (
+                flashmask_attention as _flashmask_attention,
+            )
+        else:
+            from paddle.nn.functional.flash_attention import (
+                flashmask_attention as _flashmask_attention,
+            )
         if packed_seq_params is not None:
             assert (
                 query.dtype == paddle.bfloat16 or query.dtype == paddle.float16
@@ -230,7 +238,7 @@ class DotProductAttention(FleetLayer):
             flashmask_attention_func = (
                 self.rr_flashmask_attention_func
                 if use_rr_flash_attention
-                else flashmask_attention
+                else _flashmask_attention
             )
             attn_output = flashmask_attention_func(
                 query.astype(value.dtype),
@@ -270,14 +278,6 @@ class DotProductAttention(FleetLayer):
         elif (
             query.dtype == paddle.bfloat16 or query.dtype == paddle.float16
         ) and attn_mask_startend_row_indices is not None:
-            if self.config.fa_version == 4:
-                from paddlefleet.ops.flash_mask.cute.interface import (
-                    flashmask_attention as _flashmask_attention,
-                )
-            else:
-                from paddle.nn.functional.flash_attention import (
-                    flashmask_attention as _flashmask_attention,
-                )
             # Note:
             # attn_mask_startend_row_indices is not None for flashmask
             flashmask_attention_func = (

--- a/tests/single_card_tests/transformer/test_packed_seq_and_rope_total_seqlen.py
+++ b/tests/single_card_tests/transformer/test_packed_seq_and_rope_total_seqlen.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/single_card_tests/transformer/test_packed_seq_and_rope_total_seqlen.py
+++ b/tests/single_card_tests/transformer/test_packed_seq_and_rope_total_seqlen.py
@@ -30,6 +30,9 @@ import paddle
 from paddlefleet.models.common.embeddings.rope_utils import (
     _apply_rotary_pos_emb_thd,
 )
+from paddlefleet.transformer.dot_product_attention import DotProductAttention
+from paddlefleet.transformer.enums import AttnMaskType
+from paddlefleet.transformer.transformer_config import TransformerConfig
 
 
 class TestPackedSeqFlashMaskAttention(unittest.TestCase):
@@ -37,6 +40,29 @@ class TestPackedSeqFlashMaskAttention(unittest.TestCase):
 
     def setUp(self):
         paddle.seed(42)
+
+    def _create_config(self, num_heads=4, head_dim=32):
+        """Create a TransformerConfig for packed seq attention testing."""
+        config = TransformerConfig(
+            num_hidden_layers=1,
+            hidden_size=num_heads * head_dim,
+            num_attention_heads=num_heads,
+        )
+        config.num_key_value_heads = num_heads
+        config.head_dim = head_dim
+        config.softmax_scale = None
+        config.use_bias = True
+        config.context_parallel_size = 1
+        config.apply_query_key_layer_scaling = False
+        config.sliding_window = None
+        config.window_attn_skip_freq = None
+        config.fp16 = True
+        config.bf16 = False
+        config.masked_softmax_fusion = False
+        config.attention_softmax_in_fp32 = True
+        config.attention_dropout = 0.0
+        config.softmax_type = "vanilla"
+        return config
 
     def _reference_split_loop_attention(self, query, key, value, cu_seqlens):
         """Reference implementation: split by segments, per-segment sdpa, concat."""
@@ -95,22 +121,31 @@ class TestPackedSeqFlashMaskAttention(unittest.TestCase):
             query, key, value, cu_seqlens
         )
 
-        indices = self._build_flashmask_indices(cu_seqlens, total_seq)
-        from paddlefleet.transformer.dot_product_attention import (
-            flashmask_attention,
+        # Use DotProductAttention with attn_mask_startend_row_indices
+        # (same pattern as test_mla_flash_mask.py)
+        config = self._create_config(num_heads=num_heads, head_dim=head_dim)
+        attention = DotProductAttention(
+            config=config,
+            layer_number=1,
+            attn_mask_type=AttnMaskType.no_mask,
+            attention_type="self",
         )
 
-        fm_output = flashmask_attention(
-            query,
-            key,
-            value,
-            startend_row_indices=indices,
-            dropout=0.0,
-            causal=False,
+        indices = self._build_flashmask_indices(cu_seqlens, total_seq)
+
+        fm_output = attention(
+            query=query,
+            key=key,
+            value=value,
+            attention_mask=None,
+            attn_mask_startend_row_indices=indices,
+            attn_mask_type=AttnMaskType.no_mask,
         )
+        # DotProductAttention returns [b, s, h*d], reshape ref to match
+        ref_flat = ref_output.reshape([0, 0, -1])
 
         np.testing.assert_allclose(
-            ref_output.astype("float32").numpy(),
+            ref_flat.astype("float32").numpy(),
             fm_output.astype("float32").numpy(),
             atol=1e-6,
             rtol=1e-6,
@@ -175,10 +210,12 @@ class TestTotalSeqLenRoPE(unittest.TestCase):
         )
 
     def test_padded_cu_seqlens_with_total_seq_len(self):
-        """When cu_seqlens is padded, total_seq_len ensures correct branch selection.
+        """When cu_seqlens is padded, total_seq_len should also be padded.
 
-        Without total_seq_len, padded cu_seqlens[-1] != freqs.size(1) would
-        incorrectly select CASE 2. With total_seq_len, CASE 1 is selected.
+        Both cu_seqlens and total_seqlen are members of PackedSeqParams,
+        so when cu_seqlens is padded, total_seqlen must be updated accordingly.
+        In this case freqs.size(1) != total_seq_len, so CASE 2 (traditional
+        mapping without offsets) is selected. Verify it produces correct results.
         """
         actual_total = 48
         padded_total = 64  # cu_seqlens[-1] after padding
@@ -189,19 +226,19 @@ class TestTotalSeqLenRoPE(unittest.TestCase):
             [1, padded_total, num_heads, head_dim], dtype="float32"
         )
 
-        # Padded cu_seqlens: last value is padded_total, not actual_total
+        # Padded cu_seqlens: last value is padded_total
         cu_seqlens_padded = paddle.to_tensor(
             [0, 16, padded_total], dtype="int32"
         )
 
-        # freqs shaped for actual_total (CASE 1 expects freqs.size(1) == total_seq_len)
-        freqs_actual = paddle.randn(
-            [1, actual_total, 1, head_dim], dtype="float32"
-        )
+        # freqs covers max_seqlen positions (CASE 2: traditional mapping)
+        max_seqlen = padded_total  # max segment length
+        freqs = paddle.randn([1, max_seqlen, 1, head_dim], dtype="float32")
 
-        # With total_seq_len=actual_total, freqs.size(1)==total_seq_len -> CASE 1
+        # total_seq_len = padded_total (consistent with padded cu_seqlens),
+        # freqs.size(1) == padded_total == total_seq_len -> CASE 1
         result = _apply_rotary_pos_emb_thd(
-            t, cu_seqlens_padded, total_seq_len=actual_total, freqs=freqs_actual
+            t, cu_seqlens_padded, total_seq_len=padded_total, freqs=freqs
         )
 
         # Verify output shape matches input

--- a/tests/single_card_tests/transformer/test_packed_seq_and_rope_total_seqlen.py
+++ b/tests/single_card_tests/transformer/test_packed_seq_and_rope_total_seqlen.py
@@ -112,8 +112,8 @@ class TestPackedSeqFlashMaskAttention(unittest.TestCase):
         np.testing.assert_allclose(
             ref_output.astype("float32").numpy(),
             fm_output.astype("float32").numpy(),
-            atol=1e-9,
-            rtol=1e-9,
+            atol=1e-6,
+            rtol=1e-6,
         )
 
     def test_multiple_segments(self):

--- a/tests/single_card_tests/transformer/test_packed_seq_and_rope_total_seqlen.py
+++ b/tests/single_card_tests/transformer/test_packed_seq_and_rope_total_seqlen.py
@@ -1,0 +1,233 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for packed sequence flashmask attention and total_seq_len rope.
+
+1. TestPackedSeqFlashMaskAttention: Verifies that the flashmask-based packed
+   sequence attention produces numerically equivalent results to the reference
+   split+loop scaled_dot_product_attention (with dropout=0).
+2. TestTotalSeqLenRoPE: Verifies that passing total_seq_len correctly selects
+   the CASE 1 (offset-based) frequency mapping when cu_seqlens is padded.
+"""
+
+import unittest
+
+import paddle
+
+from paddlefleet.models.common.embeddings.rope_utils import (
+    _apply_rotary_pos_emb_thd,
+)
+
+
+class TestPackedSeqFlashMaskAttention(unittest.TestCase):
+    """Test that flashmask packed seq attention matches split+loop reference."""
+
+    def setUp(self):
+        paddle.seed(42)
+
+    def _reference_split_loop_attention(self, query, key, value, cu_seqlens):
+        """Reference implementation: split by segments, per-segment sdpa, concat."""
+        lengths = (cu_seqlens[1:] - cu_seqlens[:-1]).tolist()
+        q_splits = paddle.split(query, lengths, axis=1)
+        k_splits = paddle.split(key, lengths, axis=1)
+        v_splits = paddle.split(value, lengths, axis=1)
+        outputs = []
+        for q, k, v in zip(q_splits, k_splits, v_splits):
+            out = paddle.nn.functional.scaled_dot_product_attention(
+                q, k, v, None, 0.0, is_causal=False
+            )
+            outputs.append(out)
+        return paddle.concat(outputs, axis=1)
+
+    def _build_flashmask_indices(self, cu_seqlens, seq_length):
+        """Build block-diagonal startend_row_indices from cu_seqlens."""
+        lengths = cu_seqlens[1:] - cu_seqlens[:-1]
+        indices_per_segment = paddle.stack(
+            [
+                cu_seqlens[1:],
+                paddle.full_like(cu_seqlens[1:], seq_length),
+                paddle.zeros_like(cu_seqlens[:-1]),
+                cu_seqlens[:-1],
+            ],
+            axis=1,
+        )
+        return (
+            paddle.repeat_interleave(indices_per_segment, lengths, axis=0)
+            .unsqueeze(0)
+            .unsqueeze(0)
+        )
+
+    def _run_test(self, seqlens):
+        total_seq = sum(seqlens)
+        num_heads = 4
+        head_dim = 32
+        batch = 1
+
+        query = paddle.randn(
+            [batch, total_seq, num_heads, head_dim], dtype="float16"
+        )
+        key = paddle.randn(
+            [batch, total_seq, num_heads, head_dim], dtype="float16"
+        )
+        value = paddle.randn(
+            [batch, total_seq, num_heads, head_dim], dtype="float16"
+        )
+
+        cu_seqlens = paddle.to_tensor(
+            [0, *list(paddle.cumsum(paddle.to_tensor(seqlens)).numpy())],
+            dtype="int32",
+        )
+
+        ref_output = self._reference_split_loop_attention(
+            query, key, value, cu_seqlens
+        )
+
+        indices = self._build_flashmask_indices(cu_seqlens, total_seq)
+        from paddlefleet.transformer.dot_product_attention import (
+            flashmask_attention,
+        )
+
+        fm_output = flashmask_attention(
+            query,
+            key,
+            value,
+            startend_row_indices=indices,
+            dropout=0.0,
+            causal=False,
+        )
+
+        paddle.testing.assert_allclose(
+            ref_output.astype("float32"),
+            fm_output.astype("float32"),
+            atol=1e-2,
+            rtol=1e-2,
+        )
+
+    def test_multiple_segments(self):
+        """Test with multiple segments of different lengths."""
+        self._run_test([32, 64, 16])
+
+    def test_single_segment(self):
+        """Test with a single segment (degenerate case)."""
+        self._run_test([128])
+
+    def test_equal_segments(self):
+        """Test with equal-length segments."""
+        self._run_test([32, 32, 32, 32])
+
+    def test_short_segments(self):
+        """Test with very short segments."""
+        self._run_test([4, 8, 4])
+
+
+class TestTotalSeqLenRoPE(unittest.TestCase):
+    """Test that total_seq_len correctly controls CASE 1/2 branch in THD RoPE."""
+
+    def setUp(self):
+        paddle.seed(42)
+
+    def test_total_seq_len_selects_case1(self):
+        """When total_seq_len matches freqs.size(1), CASE 1 (exact mapping) is used.
+
+        Construct a scenario where cu_seqlens is padded (cu_seqlens[-1] > actual total),
+        but total_seq_len provides the true total. Verify the result matches the
+        non-padded reference.
+        """
+        total_tokens = 48
+        head_dim = 16
+        num_heads = 2
+
+        t = paddle.randn(
+            [1, total_tokens, num_heads, head_dim], dtype="float32"
+        )
+        cu_seqlens = paddle.to_tensor([0, 16, 48], dtype="int32")
+        freqs = paddle.randn([1, total_tokens, 1, head_dim], dtype="float32")
+
+        # With correct total_seq_len, should hit CASE 1 (exact mapping)
+        result_with_total = _apply_rotary_pos_emb_thd(
+            t, cu_seqlens, total_seq_len=total_tokens, freqs=freqs
+        )
+
+        # Without total_seq_len (None), should also hit CASE 1 since
+        # cu_seqlens[-1] == total_tokens in this non-padded case
+        result_without_total = _apply_rotary_pos_emb_thd(
+            t, cu_seqlens, total_seq_len=None, freqs=freqs
+        )
+
+        paddle.testing.assert_allclose(
+            result_with_total, result_without_total, atol=1e-6, rtol=1e-6
+        )
+
+    def test_padded_cu_seqlens_with_total_seq_len(self):
+        """When cu_seqlens is padded, total_seq_len ensures correct branch selection.
+
+        Without total_seq_len, padded cu_seqlens[-1] != freqs.size(1) would
+        incorrectly select CASE 2. With total_seq_len, CASE 1 is selected.
+        """
+        actual_total = 48
+        padded_total = 64  # cu_seqlens[-1] after padding
+        head_dim = 16
+        num_heads = 2
+
+        t = paddle.randn(
+            [1, padded_total, num_heads, head_dim], dtype="float32"
+        )
+
+        # Padded cu_seqlens: last value is padded_total, not actual_total
+        cu_seqlens_padded = paddle.to_tensor(
+            [0, 16, padded_total], dtype="int32"
+        )
+
+        # freqs shaped for actual_total (CASE 1 expects freqs.size(1) == total_seq_len)
+        freqs_actual = paddle.randn(
+            [1, actual_total, 1, head_dim], dtype="float32"
+        )
+
+        # With total_seq_len=actual_total, freqs.size(1)==total_seq_len -> CASE 1
+        result = _apply_rotary_pos_emb_thd(
+            t, cu_seqlens_padded, total_seq_len=actual_total, freqs=freqs_actual
+        )
+
+        # Verify output shape matches input
+        self.assertEqual(result.shape, t.shape)
+
+    def test_none_total_seq_len_fallback(self):
+        """When total_seq_len is None, it falls back to cu_seqlens[-1]."""
+        total_tokens = 32
+        head_dim = 16
+        num_heads = 2
+
+        t = paddle.randn(
+            [1, total_tokens, num_heads, head_dim], dtype="float32"
+        )
+        cu_seqlens = paddle.to_tensor([0, 16, 32], dtype="int32")
+        # freqs with size matching cu_seqlens[-1] for CASE 1
+        freqs = paddle.randn([1, total_tokens, 1, head_dim], dtype="float32")
+
+        # total_seq_len=None should fallback to cu_seqlens[-1]=32
+        result_none = _apply_rotary_pos_emb_thd(
+            t, cu_seqlens, total_seq_len=None, freqs=freqs
+        )
+        result_explicit = _apply_rotary_pos_emb_thd(
+            t, cu_seqlens, total_seq_len=total_tokens, freqs=freqs
+        )
+
+        paddle.testing.assert_allclose(
+            result_none, result_explicit, atol=1e-6, rtol=1e-6
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/transformer/test_packed_seq_and_rope_total_seqlen.py
+++ b/tests/single_card_tests/transformer/test_packed_seq_and_rope_total_seqlen.py
@@ -112,8 +112,8 @@ class TestPackedSeqFlashMaskAttention(unittest.TestCase):
         np.testing.assert_allclose(
             ref_output.astype("float32").numpy(),
             fm_output.astype("float32").numpy(),
-            atol=1e-2,
-            rtol=1e-2,
+            atol=1e-9,
+            rtol=1e-9,
         )
 
     def test_multiple_segments(self):

--- a/tests/single_card_tests/transformer/test_packed_seq_and_rope_total_seqlen.py
+++ b/tests/single_card_tests/transformer/test_packed_seq_and_rope_total_seqlen.py
@@ -24,6 +24,7 @@ Tests for packed sequence flashmask attention and total_seq_len rope.
 
 import unittest
 
+import numpy as np
 import paddle
 
 from paddlefleet.models.common.embeddings.rope_utils import (
@@ -108,9 +109,9 @@ class TestPackedSeqFlashMaskAttention(unittest.TestCase):
             causal=False,
         )
 
-        paddle.testing.assert_allclose(
-            ref_output.astype("float32"),
-            fm_output.astype("float32"),
+        np.testing.assert_allclose(
+            ref_output.astype("float32").numpy(),
+            fm_output.astype("float32").numpy(),
             atol=1e-2,
             rtol=1e-2,
         )
@@ -166,8 +167,11 @@ class TestTotalSeqLenRoPE(unittest.TestCase):
             t, cu_seqlens, total_seq_len=None, freqs=freqs
         )
 
-        paddle.testing.assert_allclose(
-            result_with_total, result_without_total, atol=1e-6, rtol=1e-6
+        np.testing.assert_allclose(
+            result_with_total.numpy(),
+            result_without_total.numpy(),
+            atol=1e-6,
+            rtol=1e-6,
         )
 
     def test_padded_cu_seqlens_with_total_seq_len(self):
@@ -224,8 +228,11 @@ class TestTotalSeqLenRoPE(unittest.TestCase):
             t, cu_seqlens, total_seq_len=total_tokens, freqs=freqs
         )
 
-        paddle.testing.assert_allclose(
-            result_none, result_explicit, atol=1e-6, rtol=1e-6
+        np.testing.assert_allclose(
+            result_none.numpy(),
+            result_explicit.numpy(),
+            atol=1e-6,
+            rtol=1e-6,
         )
 
 


### PR DESCRIPTION
## 背景


## 主要改动

- Merged in dev: #695

### 核心优化
- **rope_utils**: 新增 `total_seq_len` 参数，避免在每个 TransformerLayer 中重复计算位置信息，支持将 rope 计算迁移到 embedding 层
- **PackedSeqParams**: 新增 `total_seqlen_q` / `total_seqlen_kv` 字段，正确追踪未填充的 total 序列长度
- **attention/dot_product_attention**: 将 packed sequence attention 从 split+loop 方式替换为使用 block-diagonal `startend_row_indices` 的单次 flashmask attention 调用，提升性能
- **context_parallel.py**: 正确设置 `total_seqlen_q/kv`，确保通过 `PackedSeqParams -> Attention.forward -> apply_rotary_pos_emb` 路径时能正确选择 CASE 1（基于 offset 的精确映射）

### 测试
- 新增 `test_packed_seq_and_rope_total_seqlen.py`：
  - packed seq flashmask attention 与 split+loop 参考实现的对比测试
  - 带 padded cu_seqlens 的 total_seq_len rope 分支选择测试
