### PR TITLE
Fix the bug of block attention residuals in AMP

### DIFF
--- a/src/paddlefleet/models/gpt/gpt_layer_specs.py
+++ b/src/paddlefleet/models/gpt/gpt_layer_specs.py
@@ -256,6 +256,7 @@ def get_gpt_layer_local_spec(
             post_attention_layernorm=layer_norm,
             mlp=mlp,
             mlp_bda=get_bias_dropout_add,
+            block_attn_res=block_attn_res,
             sharded_state_dict_keys_map={
                 "input_layernorm.": "self_attn.qkv_proj.layer_norm_",
                 "post_attention_layernorm.": "mlp.up_gate_proj.layer_norm_",

--- a/src/paddlefleet/transformer/block_attn_res.py
+++ b/src/paddlefleet/transformer/block_attn_res.py
@@ -132,4 +132,7 @@ class BlockAttnRes(FleetLayer):
         # Equivalent to einsum("n b s, n b s d -> b s d", weights, V)
         h = (weights.unsqueeze(-1) * V).sum(axis=0)
 
+        if partial_block is not None and h.dtype != partial_block.dtype:
+            h = h.to(partial_block.dtype)
+
         return h

--- a/src/paddlefleet/transformer/transformer_layer.py
+++ b/src/paddlefleet/transformer/transformer_layer.py
@@ -568,6 +568,11 @@ class TransformerLayer(nn.Layer):
             )
 
             # Accumulate attn output into partial_block
+            if (
+                partial_block is not None
+                and partial_block.dtype != hidden_states.dtype
+            ):
+                partial_block = partial_block.to(hidden_states.dtype)
             partial_block = (
                 partial_block + hidden_states
                 if partial_block is not None


### PR DESCRIPTION
Fix the bug of block attention residuals in AMP. When embedding output is float32 and pushed into the block list, block attention residuals will get a float32-type output, causing a type mismatch error in LinearWithGradAccumulationAndAsyncCommunication backward function.