### PR TITLE
[Cherry-Pick | MoE Layer] Fix moe_use_fusion_node Setting when EP==

### DIFF
--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -201,6 +201,8 @@ class MoELayer(nn.Layer):
                     False  # TODO: Support EP>1 alltoall moe_grouped_gemm
                 )
                 self.fp8_dispatch = False
+        else:
+            self.moe_use_fusion_node = config.moe_use_fusion_node
 
         if self.fp8:
             if paddle.version.cuda() == "12.6":


### PR DESCRIPTION
修复当 EP 为 1 时 moe_use_fusion_node 未设置的问题
merged in dev: https://github.com/PaddlePaddle/PaddleFleet/pull/722