### PR TITLE
[Do Not Merge][MoE] Add auto_subbatch support and static subbatch 

### DIFF
--- a/src/paddlefleet/transformer/moe/fp8_utils.py
+++ b/src/paddlefleet/transformer/moe/fp8_utils.py
@@ -29,6 +29,20 @@ try:
 except (ImportError, RuntimeError):
     pass
 
+# 优先使用 FusedQuantOps.fused_swiglu_probs_bwd（inplace，行为对齐）。
+# inplace 时 do1 与 o1 共用同一块 GPU buffer（data_ptr 相同），del o1 后 refcount
+# 不归零，避免 VMM 提前回收物理页（Bug 2）；同时显存峰值从 7H 降至 5H，
+# subbatch_rows 估算也更准确。
+# 若环境中没有 FusedQuantOps，则回退到 paddle.incubate 的 out-of-place 实现。
+try:
+    import FusedQuantOps as _FQO
+
+    _fused_swiglu_probs_bwd = _FQO.fused_swiglu_probs_bwd
+    USE_INPLACE_SWIGLU_BWD = True
+except (ImportError, AttributeError):
+    _fused_swiglu_probs_bwd = None
+    USE_INPLACE_SWIGLU_BWD = False
+
 try:
     from paddle.nn.functional import swiglu
 except ImportError:
@@ -75,48 +89,75 @@ FP8_ALIGN = 128
 
 def _get_fp8_weight_and_scale(weight, transpose=False):
     """_get_fp8_weight_and_scale"""
+    fp8_weight, fp8_scale = (
+        weight.fp8_weight_stacked,
+        weight.fp8_scale_stacked,
+    )
+
     if transpose:
-        fp8_weight = weight.fp8_weight_stacked_transpose
-        fp8_scale = weight.fp8_scale_stacked_transpose
-    else:
-        fp8_weight, fp8_scale = (
-            weight.fp8_weight_stacked,
-            weight.fp8_scale_stacked,
-        )
+        if (
+            hasattr(weight, "fp8_weight_stacked_transpose")
+            and weight.fp8_weight_stacked_transpose is not None
+        ):
+            fp8_weight = weight.fp8_weight_stacked_transpose
+            fp8_scale = weight.fp8_scale_stacked_transpose
+        else:
+            # 只有非转置版，on-the-fly reshape+transpose
+            assert fp8_weight.shape[0] % weight.shape[0] == 0
+            assert fp8_weight.ndim == 2
+            expert_num = fp8_weight.shape[0] // weight.shape[0]
+
+            def transpose_tensor(tensor):
+                assert tensor.ndim == 2
+                h0 = tensor.shape[0] // expert_num
+                h1 = tensor.shape[1]
+                tensor = tensor.reshape([expert_num, h0, h1])
+                return (
+                    tensor.contiguous()
+                    .transpose([0, 2, 1])
+                    .reshape([-1, h0])
+                    .contiguous()
+                )
+
+            fp8_weight, fp8_scale = (
+                transpose_tensor(fp8_weight),
+                transpose_tensor(fp8_scale),
+            )
 
     return fp8_weight, fp8_scale
 
 
 def fused_stack_quant(expert_weight_list, transpose=False):
-    if transpose is False and hasattr(
-        expert_weight_list[0], "fp8_weight_stacked"
-    ):
+    if hasattr(expert_weight_list[0], "fp8_weight_stacked"):
         w, scale = _get_fp8_weight_and_scale(
-            expert_weight_list[0], transpose=False
-        )
-    elif transpose is True and hasattr(
-        expert_weight_list[0], "fp8_weight_stacked_transpose"
-    ):
-        w, scale = _get_fp8_weight_and_scale(
-            expert_weight_list[0], transpose=True
-        )
-    elif transpose is True and hasattr(
-        expert_weight_list[0], "fp8_weight_stacked"
-    ):
-        w, scale = _get_fp8_weight_and_scale(
-            expert_weight_list[0], transpose=False
-        )
-    elif transpose is False and hasattr(
-        expert_weight_list[0], "fp8_weight_stacked_transpose"
-    ):
-        w, scale = _get_fp8_weight_and_scale(
-            expert_weight_list[0], transpose=True
+            expert_weight_list[0], transpose=transpose
         )
     else:
+        # 无预量化属性，on-the-fly 实时量化
         w, scale = paddle.incubate.nn.functional.fused_stack_transpose_quant(
             expert_weight_list, transpose=transpose
         )
     return w, scale
+
+
+def tilewise_quant(x):
+    """
+    Tile-wise FP8 quantization: quantize input tensor to FP8 with per-tile (1x128) scaling.
+    """
+    if x.shape[0] > 0:
+        return paddle.incubate.nn.functional.fp8_quant_blockwise(
+            x,
+            output_scale_transpose=False,
+            quant_method="1x128",
+            input_transpose=False,
+        )
+    else:
+        shape = list(x.shape)
+        x_fp8 = paddle.empty(x.shape, dtype=paddle.float8_e4m3fn)
+        assert shape[-1] % FP8_ALIGN == 0, shape
+        shape[-1] //= FP8_ALIGN
+        x_scale = paddle.empty(shape, dtype=paddle.float32)
+        return x_fp8, x_scale
 
 
 def split_group_gemm(
@@ -142,11 +183,12 @@ def split_group_gemm(
             continue
         end_idx = start_idx + token_num
 
+        x_i = x_fp8[start_idx:end_idx]
         x_scale_tma_align = x_scale[start_idx:end_idx].T.contiguous().T
 
         deep_gemm.fp8_gemm_nt(
-            (x_fp8[start_idx:end_idx], x_scale_tma_align),
-            (w_fp8[i], w_scale[i]),
+            (x_i, x_scale_tma_align),
+            (w_fp8[i].contiguous(), w_scale[i].contiguous()),
             gemm_out[start_idx:end_idx],
         )
 
@@ -272,6 +314,7 @@ class ExpertsGroupGemmContiguousNode:
         self.use_fp8_mlp = use_fp8_mlp
         self.moe_deep_gemm = moe_deep_gemm
         self.moe_grouped_gemm = moe_grouped_gemm
+        self.is_split_group_gemm = not moe_grouped_gemm
 
     def cached_tensors(self):
         """
@@ -415,16 +458,6 @@ class ExpertsGroupGemmContiguousNode:
         w1_t_quant, w1_t_scale = fused_stack_quant(expert_w1, transpose=True)
         w1_t_quant = w1_t_quant.reshape([num_expert, -1, w1_t_quant.shape[-1]])
         w1_t_scale = w1_t_scale.reshape([num_expert, -1, w1_t_scale.shape[-1]])
-
-        if hasattr(expert_w1[0], "fp8_weight_stacked") and not hasattr(
-            expert_w1[0], "fp8_weight_stacked_transpose"
-        ):
-            w1_t_quant = (
-                w1_t_quant.contiguous().transpose([0, 2, 1]).contiguous()
-            )
-            w1_t_scale = (
-                w1_t_scale.contiguous().transpose([0, 2, 1]).contiguous()
-            )
 
         if x is None:
             x_fp8, x_scale = self.input_fp8, self.input_scale
@@ -570,8 +603,7 @@ class ExpertsGroupGemmContiguousNode:
 
         if clear_o1:
             o1._clear_to_zero_allocation()
-
-        # compute gemm
+        # fused_weighted_swiglu_act_quant 已消费完 o1 产出 o2_fp8，此时 o1 可以安全释放。
         o3_shape = [o2_fp8.shape[0], w2_quant.shape[1]]
         if o3 is not None:
             assert o3.shape == o3_shape, f"{o3.shape} vs {o3_shape}"
@@ -662,6 +694,7 @@ class ExpertsGroupGemmContiguousNode:
         [m_sum, n] = [m_sum, k] * [num_groups, k, n]
         """
         # recompute concated_w2_2d
+        # fp8_gemm_nt(do3[m,k], w2[n,k]) = do3 @ w2^T = do3 @ [k,n]
         bw_w2_quant, bw_w2_scale = fused_stack_quant(expert_w2, transpose=False)
         bw_w2_quant = bw_w2_quant.reshape(
             [len(expert_w2), -1, bw_w2_quant.shape[-1]]
@@ -670,26 +703,15 @@ class ExpertsGroupGemmContiguousNode:
             [len(expert_w2), -1, bw_w2_scale.shape[-1]]
         )
 
-        if hasattr(
-            expert_w2[0], "fp8_weight_stacked_transpose"
-        ) and not hasattr(expert_w2[0], "fp8_weight_stacked"):
-            bw_w2_quant = (
-                bw_w2_quant.contiguous().transpose([0, 2, 1]).contiguous()
-            )
-            bw_w2_scale = (
-                bw_w2_scale.contiguous().transpose([0, 2, 1]).contiguous()
-            )
-
         # compute gemm
         unzipped_grad_fp8, unzipped_grad_scale = (
             paddle.incubate.nn.functional.fp8_quant_blockwise(
                 unzipped_grad,
-                output_scale_transpose=True,
+                output_scale_transpose=False,
                 quant_method="1x128",
                 input_transpose=False,
             )
         )
-        unzipped_grad_scale = unzipped_grad_scale.T
 
         do2_s = paddle.empty(
             [unzipped_grad_fp8.shape[0], bw_w2_quant.shape[1]],
@@ -714,11 +736,25 @@ class ExpertsGroupGemmContiguousNode:
                 )
 
         with paddle.amp.auto_cast(False):
-            do1, probs_grad, o2_s = (
-                paddle.incubate.nn.functional.fused_swiglu_weighted_bwd(
-                    o1, do2_s, unzipped_probs
+            if USE_INPLACE_SWIGLU_BWD:
+                # inplace，do1 复用 o1 的 GPU buffer（data_ptr 相同）。
+                # del o1 后 do1 仍持有引用，refcount 不归零，物理页不会被 VMM 提前回收。
+                # 显存峰值：o1/do1(2H) + do2_s(H) + o2_s(H) = 4H（C 点），
+                #           do1(2H) + o2_s(H) + n2_s(2H) = 5H（D 点峰值）
+                do1, probs_grad, o2_s = _fused_swiglu_probs_bwd(
+                    o1, do2_s, unzipped_probs, True
                 )
-            )
+            else:
+                # out-of-place，do1 是全新分配的 buffer。
+                # del o1 必须推迟到 bwd_gate_up_input_fp8 的 synchronize 之后，
+                # 否则 GPU 异步读 o1 时物理页已被 VMM 回收（Bug 2）。
+                # 显存峰值：o1(2H) + do2_s(H) + do1(2H) + o2_s(H) = 6H（C 点），
+                #           o1(2H) + do1(2H) + o2_s(H) + n2_s(2H) = 7H（D 点峰值）
+                do1, probs_grad, o2_s = (
+                    paddle.incubate.nn.functional.fused_swiglu_weighted_bwd(
+                        o1, do2_s, unzipped_probs
+                    )
+                )
 
         return do1, o2_s, probs_grad
 
@@ -784,24 +820,13 @@ class ExpertsGroupGemmContiguousNode:
             [len(expert_w1), -1, bw_w1_scale.shape[-1]]
         )
 
-        if hasattr(
-            expert_w1[0], "fp8_weight_stacked_transpose"
-        ) and not hasattr(expert_w1[0], "fp8_weight_stacked"):
-            bw_w1_quant = (
-                bw_w1_quant.contiguous().transpose([0, 2, 1]).contiguous()
-            )
-            bw_w1_scale = (
-                bw_w1_scale.contiguous().transpose([0, 2, 1]).contiguous()
-            )
-
         # quant do1
         do1_fp8, do1_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
             do1,
-            output_scale_transpose=True,
+            output_scale_transpose=False,
             quant_method="1x128",
             input_transpose=False,
         )
-        do1_scale = do1_scale.T
 
         # compute gemm
         dx_shape = [do1_fp8.shape[0], bw_w1_quant.shape[1]]
@@ -849,7 +874,6 @@ class ExpertsGroupGemmContiguousNode:
         do3_t_fp8, do3_t_scale = self.fused_transpose_split_quant(
             do3, None, self.tokens_per_expert, True
         )
-
         for i in range(len(expert_w2)):
             if hasattr(expert_w2[i], "main_grad"):
                 if expert_w2[i].main_grad is None:
@@ -922,7 +946,6 @@ class ExpertsGroupGemmContiguousNode:
         do1_t_fp8, do1_t_scale = self.fused_transpose_split_quant(
             do1, None, self.tokens_per_expert, True
         )
-
         for i in range(len(expert_w1)):
             if hasattr(expert_w1[i], "main_grad"):
                 if expert_w1[i].main_grad is None:
@@ -1012,8 +1035,21 @@ class ExpertsGroupGemmContiguousNode:
             clear_o1 = True
 
         # o3
+        # 只有 output 是 bf16/float32 时才传给 fwd_down（auto_subbatch 场景）
+        # FP8 的 output 是复用给 gate_up 的，不应作为 down proj 输出 buffer
+        fwd_down_output = (
+            output
+            if output is not None
+            and output.dtype in (paddle.bfloat16, paddle.float32)
+            else None
+        )
         o3 = self.fwd_down(
-            o1, unzipped_probs, expert_w2, num_expert, clear_o1=clear_o1
+            o1,
+            unzipped_probs,
+            expert_w2,
+            num_expert,
+            o3=fwd_down_output,
+            clear_o1=clear_o1,
         )
         return o3
 
@@ -1354,7 +1390,13 @@ class ExpertsGroupGemmContiguousNode:
         do1, o2_s, probs_grad = self.bwd_down_input_fp8(
             expert_w2, out_grad, o1, unzipped_probs, inplace_swiglu_prob=True
         )
-        del o1
+        # del o1 时机：
+        #   inplace（USE_INPLACE_SWIGLU_BWD=True）：do1 与 o1 共用 buffer，refcount
+        #     不归零，立即 del 安全。
+        #   out-of-place（USE_INPLACE_SWIGLU_BWD=False）：do1 是独立 buffer，GPU 异步
+        #     kernel 仍在读 o1，必须等 bwd_gate_up_input_fp8 的 synchronize 后再 del。
+        if USE_INPLACE_SWIGLU_BWD:
+            del o1
         self.o1 = None
 
         if a2a_async_fn is None:
@@ -1363,6 +1405,10 @@ class ExpertsGroupGemmContiguousNode:
                 self.bf16_weight_grad(do1, None, expert_w1)
             else:
                 self.bwd_gate_up_weight(do1, None, expert_w1, clear_input=True)
+            # 不调用 _record_stream，直接 None。
+            # _record_stream 会触发 VMM 积极回收物理页，在 nparts loop 中
+            # slice 被释放后原始 input_fp8 的物理页可能被提前回收，
+            # 导致后续 npart 访问时 CUDA_ERROR_ILLEGAL_ADDRESS。
             self.input_fp8 = None
             self.input_scale = None
             self.input = None
@@ -1375,6 +1421,11 @@ class ExpertsGroupGemmContiguousNode:
 
             # dx
             dx = self.bwd_gate_up_input_fp8(do1, expert_w1, dx=out_grad)
+            # out-of-place 路径下 fused_swiglu_weighted_bwd 异步读 o1，但此时
+            # 中间已经执行了 dw1、dw2 等多个 GEMM kernel（同一 stream 顺序入队），
+            # 到达此处时 o1 的读取早已完成，del 安全。
+            if not USE_INPLACE_SWIGLU_BWD:
+                del o1
             del do1
         else:
             # 为了更充分地overlap, 将dx提前。不过这样可能会增加峰值显存。
@@ -1400,6 +1451,10 @@ class ExpertsGroupGemmContiguousNode:
                 self.bwd_down_weight(out_grad, o2_s, expert_w2)
 
             task.wait()
+            # task.wait() 后所有异步 kernel（含 out-of-place 路径下
+            # fused_swiglu_weighted_bwd 对 o1 的读取）已完成，安全释放。
+            if not USE_INPLACE_SWIGLU_BWD:
+                del o1
 
         self.reset_state()
         return dx, probs_grad

--- a/src/paddlefleet/transformer/moe/fusion_layer_utils.py
+++ b/src/paddlefleet/transformer/moe/fusion_layer_utils.py
@@ -12,11 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import contextlib
+import copy
+
 import paddle
 
+import paddlefleet
 from paddlefleet.transformer.moe.fp8_utils import ExpertsGroupGemmContiguousNode
 
-from .fp8_utils import FP8_ALIGN
+from .fp8_utils import FP8_ALIGN, USE_INPLACE_SWIGLU_BWD, tilewise_quant
+from .vmm_utils import (
+    find_max_concurrent_subbatch_size,
+    find_max_sequence_subbatch_size,
+    merge_subbatch_cast,
+    tokens_zip_unique_add_with_subbatch,
+)
 
 
 class UnZipNode:
@@ -106,6 +116,7 @@ class UnZipNode:
                 num_experts=num_experts,
                 tokens_per_expert=tokens_per_expert,
                 padding_alignment=FP8_ALIGN,
+                do_gather=fill_output,
             )
 
         if scale is None:
@@ -222,6 +233,7 @@ class ZipNode:
                 num_experts,
                 tokens_per_expert,
                 padding_alignment=FP8_ALIGN,
+                do_gather=fill_output,
             )
         return unzipped_grad
 
@@ -244,12 +256,28 @@ class MlpNode:
         use_fp8_mlp=True,
         moe_deep_gemm=True,
         moe_grouped_gemm=False,
+        use_auto_subbatch=False,
     ):
         """
         Constructor
         """
         self.token_dispatcher = custom_map.token_dispatcher
         self.moe_expert_fusion = moe_expert_fusion
+        self.experts = custom_map.experts
+        # 记录 EP 分片信息，用于计算 experts_group_gemm_node 的索引偏移。
+        # 初始 non-fusion 模式下，experts_group_gemm_node 按全局 ID 构建，
+        # tokens_per_expert 循环变量是本地 ID（0..num_local-1），需要加偏移才能
+        # 正确索引。fallback_to_no_expert_fusion 后列表重建为本地长度，偏移置 0。
+        self.moe_rank = getattr(custom_map, "moe_rank", 0)
+        self.num_experts_per_device = getattr(
+            custom_map, "num_experts_per_device", len(custom_map.experts)
+        )
+        # 初始 non-fusion 时 experts_group_gemm_node 是全局长度列表，需要偏移
+        self._gemm_node_id_offset = (
+            self.moe_rank * self.num_experts_per_device
+            if not moe_expert_fusion
+            else 0
+        )
         if recompute_moe_premute:
             assert not moe_expert_fusion, (
                 "moe_expert_fusion must be disabled when recompute_unzipped = True"
@@ -282,9 +310,20 @@ class MlpNode:
             )
 
         if not self.moe_expert_fusion:
-            raise NotImplementedError(
-                "moe_expert_fusion = False is not supported currently"
-            )
+            self.experts_group_gemm_node = [
+                ExpertsGroupGemmContiguousNode(
+                    custom_map,
+                    recompute_moe_gate_up=recompute_moe_gate_up,
+                    dequant_input=dequant_input,
+                    expert_id=expert_id,
+                    moe_subbatch_token_num_after_dispatch=moe_subbatch_token_num_after_dispatch,
+                    use_bf16_gemm_weight_grad=use_bf16_gemm_weight_grad,
+                    use_fp8_mlp=use_fp8_mlp,
+                    moe_deep_gemm=moe_deep_gemm,
+                    moe_grouped_gemm=moe_grouped_gemm,
+                )
+                for expert_id in range(len(custom_map.experts))
+            ]
         else:
             self.experts_group_gemm_node = ExpertsGroupGemmContiguousNode(
                 custom_map,
@@ -315,6 +354,21 @@ class MlpNode:
             self.token_offsets.append(self.token_offsets[-1] + padding_token)
         self.router_topk = num_experts_per_tok
         self.use_fp8_mlp = use_fp8_mlp
+        self.use_auto_subbatch = use_auto_subbatch
+        if self.use_auto_subbatch:
+            (vmm_flag,) = paddle.framework.get_flags(
+                "FLAGS_use_virtual_memory_auto_growth"
+            ).values()
+            assert vmm_flag, (
+                "use_auto_subbatch requires FLAGS_use_virtual_memory_auto_growth=True"
+            )
+
+        if self.moe_subbatch_token_num_after_dispatch is not None:
+            self.min_auto_subbatch_rows = (
+                self.moe_subbatch_token_num_after_dispatch
+            )
+        else:
+            self.min_auto_subbatch_rows = FP8_ALIGN**2 // 2
 
     def cached_tensors(self):
         """
@@ -428,6 +482,1002 @@ class MlpNode:
             self.experts_group_gemm_node.reset_state()
         self.experts_group_gemm_node = None
 
+    # ==================== auto_subbatch helper methods ====================
+
+    def subbatch_unzip_and_prepare_gemm_node(
+        self, hs_2d_dispatched, zipped_expertwise_rowmap, expert_id
+    ):
+        """
+        zip_unzip_fusion=False 时的单专家输入准备：
+        从 zipped 空间 gather 出该专家的 token，设置到 gemm_node 上。
+        返回 expert_unzipped_idx，供后续 scatter-add回zipped空间使用。
+
+        Example (expert_id=1, tokens_per_expert=[2,3,1], FP8_ALIGN=4):
+
+            zipped 空间 (hs_2d_dispatched):     unzip gather 后 (expert_id=1):
+            ┌─────────────┐                     ┌─────────────┐
+            │ tok0 (E0,E1)│ ──────────────────► │ tok0        │ row 0
+            │ tok1 (E0)   │                     │ tok2        │ row 1
+            │ tok2 (E1,E2)│ ──────────────────► │ tok4        │ row 2
+            │ tok3 (E0)   │                     │ <pad>       │ row 3 (pad to FP8_ALIGN=4)
+            │ tok4 (E1)   │ ──────────────────► └─────────────┘
+            │ tok5 (E2)   │                     gemm_node.input_fp8 = 上面 4 行
+            └─────────────┘                     expert_unzipped_idx = [0, 2, 4]
+        """
+        hs_2d_dispatched, hs_2d_dispatched_scale = hs_2d_dispatched
+        # 从 zipped 空间按 expert_id gather，输出已 pad 到 FP8_ALIGN 对齐
+        (
+            expert_out,
+            expert_out_scale,
+            expert_unzipped_idx,
+        ) = paddlefleet.ops.tokens_unzip_gather(
+            hs_2d_dispatched,
+            hs_2d_dispatched_scale,
+            zipped_expertwise_rowmap,
+            expert_id,
+            self.tokens_per_expert,
+            FP8_ALIGN,
+        )
+        # 将 gather 出的输入设置到对应专家的 gemm_node 上
+        # expert_id 是本地 ID，需加偏移才能索引全局 experts_group_gemm_node
+        gemm_node = self.experts_group_gemm_node[
+            self._gemm_node_id_offset + expert_id
+        ]
+        if self.use_fp8_mlp is not None:
+            gemm_node.input_fp8 = expert_out
+            gemm_node.input_scale = expert_out_scale
+        else:
+            expert_out = paddle.incubate.nn.functional.fused_act_dequant(
+                expert_out, expert_out_scale
+            )
+            gemm_node.input = expert_out
+        return expert_unzipped_idx
+
+    def subbatch_prepare_gemm_node(self, unzipped_hs_2d, expert_id):
+        """
+        Prepare input for this node. Dequant if needed.
+        """
+        input_fp8, input_scale = unzipped_hs_2d
+        gemm_node = self.experts_group_gemm_node[expert_id]
+        if self.use_fp8_mlp is not None:
+            gemm_node.input_fp8 = input_fp8
+            gemm_node.input_scale = input_scale
+        else:
+            gemm_node.input = paddle.incubate.nn.functional.fused_act_dequant(
+                input_fp8, input_scale
+            )
+
+    def gemm_forward_subbatch(
+        self,
+        expert_id,
+        unzipped_probs,
+        unzipped_idx,
+        output,
+        total_zipped_tokens,
+        unzipped_out=None,
+        start_idx=None,
+        end_idx=None,
+    ):
+        """
+        对单个专家执行一次（或一个 subbatch 的）前向 GEMM，并将结果写回输出。
+
+        Example (expert_id=1, 该专家有 300 个 token, subbatch_rows=128):
+
+            gemm_node.input_fp8 (300 tokens, padded to 384):
+            ┌──────────────────────────────────────────────┐
+            │ tok0 ... tok127 │ tok128 ... tok255 │ tok256 ... tok299 + pad │
+            └──────────────────────────────────────────────┘
+                 subbatch 0        subbatch 1         subbatch 2
+              start=0,end=128    start=128,end=256   start=256,end=300
+
+            每个 subbatch 独立执行:
+            1. _slice 截取输入/probs/输出 → 临时替换 gemm_node 上的引用
+            2. gemm_node.forward: gate_up → SwiGLU → down_proj
+            3. 写回结果:
+               - unzipped_out 非 None → in-place 写入预分配 buffer (zip_unzip_fusion)
+               - unzipped_out 为 None → scatter-add 到 float32 累加器 (非 fusion)
+            4. 恢复 gemm_node 的原始引用，下一个 subbatch 再切
+
+        Args:
+            expert_id: 专家编号。
+            unzipped_probs: 该专家的 token 权重。
+            unzipped_idx: scatter-add 回 zipped 空间的索引（zip_unzip_fusion=False 时使用）。
+            output: 累加输出 buffer（float32 累加器或 list[Tensor]）。
+            total_zipped_tokens: zipped 空间的总 token 数。
+            unzipped_out: 预分配的输出 buffer（zip_unzip_fusion=True 时传入，GEMM 结果 in-place 写入）。
+            start_idx/end_idx: subbatch 切片范围。None 表示不切片，整个专家一次算完。
+        """
+        # expert_id 是本地 ID，需加偏移才能索引全局 experts_group_gemm_node
+        gemm_node = self.experts_group_gemm_node[
+            self._gemm_node_id_offset + expert_id
+        ]
+        if start_idx is not None:
+            # --- subbatch 切片：从完整专家的输入/输出中截取 [start_idx, end_idx) ---
+            tokens_per_expert = end_idx - start_idx
+            padding_token_per_experts = (
+                (tokens_per_expert + FP8_ALIGN - 1) // FP8_ALIGN * FP8_ALIGN
+            )
+            padding_end_idx = start_idx + padding_token_per_experts
+
+            unzipped_probs = unzipped_probs._slice(start_idx, padding_end_idx)
+            unzipped_idx = unzipped_idx._slice(start_idx, end_idx)
+            if self.use_fp8_mlp is not None:
+                origin_input_fp8 = gemm_node.input_fp8
+                origin_input_scale = gemm_node.input_scale
+                gemm_node.input_fp8 = origin_input_fp8._slice(
+                    start_idx, padding_end_idx
+                )
+                gemm_node.input_scale = origin_input_scale.contiguous()._slice(
+                    start_idx, padding_end_idx
+                )
+            else:
+                origin_input = gemm_node.input
+                gemm_node.input = origin_input._slice(
+                    start_idx, padding_end_idx
+                )
+            if unzipped_out is not None:
+                unzipped_out = unzipped_out._slice(start_idx, padding_end_idx)
+            gemm_node.tokens_per_expert = [padding_token_per_experts]
+        else:
+            # --- 不切片：整个专家一次算完 ---
+            tokens_per_expert = self.tokens_per_expert[expert_id]
+            padding_token_per_experts = self.padding_token_per_experts[
+                expert_id
+            ]
+
+        # 执行 gate_up → SwiGLU → down_proj GEMM
+        # hs_out=None 表示从 gemm_node.input_fp8 取输入（已在 prepare 阶段设置）
+        expert_out = gemm_node.forward(
+            None,
+            unzipped_probs,
+            [padding_token_per_experts],
+            tokens_per_expert,
+            unzipped_out,
+        )
+
+        # recompute_moe_premute 场景下，forward 完成后释放 input_fp8
+        if start_idx is None and self.recompute_moe_premute:
+            gemm_node.input_fp8 = None
+            gemm_node.input_scale = None
+
+        # zip_unzip_fusion=False 时，需要 scatter-add 到 output 累加器，output是一个list
+        # zip_unzip_fusion=True 时，结果已 in-place 写入 unzipped_out，无需额外操作
+        if unzipped_out is None:
+            output = tokens_zip_unique_add_with_subbatch(
+                output,
+                expert_out,
+                unzipped_idx,
+                zipped_rows=total_zipped_tokens,
+                subbatch_rows=(
+                    self.moe_subbatch_token_num_after_dispatch
+                    if isinstance(output, paddle.Tensor)
+                    else output[0].shape[0]
+                ),
+            )
+
+        # subbatch 切片后恢复 gemm_node 的原始输入引用
+        if start_idx is not None:
+            if self.use_fp8_mlp is not None:
+                gemm_node.input_fp8 = origin_input_fp8
+                gemm_node.input_scale = origin_input_scale
+            else:
+                gemm_node.input = origin_input
+            gemm_node.tokens_per_expert = [
+                self.padding_token_per_experts[expert_id]
+            ]
+
+        return output
+
+    # ==================== forward methods ====================
+
+    def fallback_to_no_expert_fusion(self):
+        """
+        从 expert_fusion=True 回退到 False 模式，将融合的 experts_group_gemm_node 拆成逐专家节点。
+
+        当 auto_subbatch 检测到显存不足以一次做 group_gemm 时调用，通过 copy.copy
+        浅拷贝出每个专家的独立 gemm_node，并将前向保存的 input_fp8/o1 按专家切片。
+        """
+        fused_gemm_node = self.experts_group_gemm_node
+        self.experts_group_gemm_node = []
+        self.moe_expert_fusion = False
+        # 重建后列表为本地长度，local_id 直接索引，不需要偏移
+        self._gemm_node_id_offset = 0
+
+        for local_id, tokens_per_expert in enumerate(
+            self.padding_token_per_experts
+        ):
+            expert_id = self.moe_rank * self.num_experts_per_device + local_id
+            gemm_node = copy.copy(fused_gemm_node)
+            gemm_node.is_split_group_gemm = True
+            gemm_node.recompute_moe_gate_up = fused_gemm_node.o1 is None
+            gemm_node.experts = [fused_gemm_node.experts[expert_id]]
+            gemm_node.expert_id = expert_id
+            gemm_node.tokens_per_expert = [tokens_per_expert]
+            self.experts_group_gemm_node.append(gemm_node)
+
+            start_idx = self.token_offsets[local_id]
+            end_idx = self.token_offsets[local_id + 1]
+
+            # 如果是在反向才 fallback，需要将前向保存的 input_fp8/o1 切分给每个专家
+            if fused_gemm_node.input_fp8 is not None:
+                gemm_node.input_fp8 = fused_gemm_node.input_fp8._slice(
+                    start_idx, end_idx
+                )
+                gemm_node.input_scale = (
+                    fused_gemm_node.input_scale.contiguous()._slice(
+                        start_idx, end_idx
+                    )
+                )
+            if fused_gemm_node.o1 is not None:
+                gemm_node.o1 = fused_gemm_node.o1._slice(start_idx, end_idx)
+
+    @contextlib.contextmanager
+    def slice_fp8_weight(self, expert_id):
+        """
+        当初始为 expert_fusion=True 但回退到逐专家时，临时切片当前专家的 fp8_weight/scale。
+
+        expert_fusion=True 时 FP8 权重以 stacked 形式存在 experts[0] 上（所有专家堆叠），
+        回退后每个专家需要独立的权重切片。此上下文管理器临时设置并在退出时恢复/清理。
+        """
+        if not (
+            len(self.experts) > 1
+            and getattr(
+                self.experts[0].up_gate_proj.weight, "fp8_weight_stacked", None
+            )
+            is not None
+            and getattr(
+                self.experts[1].up_gate_proj.weight, "fp8_weight_stacked", None
+            )
+            is None
+        ):
+            yield
+            return
+
+        w1 = self.experts[0].up_gate_proj.weight
+        w2 = self.experts[0].down_proj.weight
+        w1_weight, w1_scale = w1.fp8_weight_stacked, w1.fp8_scale_stacked
+        w2_weight, w2_scale = w2.fp8_weight_stacked, w2.fp8_scale_stacked
+
+        def slice_expert(t):
+            chunk_size = t.shape[0] // len(self.experts)
+            return t._slice(
+                chunk_size * expert_id, chunk_size * (expert_id + 1)
+            )
+
+        cur_w1 = self.experts[expert_id].up_gate_proj.weight
+        cur_w2 = self.experts[expert_id].down_proj.weight
+        cur_w1.fp8_weight_stacked = slice_expert(w1_weight)
+        cur_w1.fp8_scale_stacked = slice_expert(w1_scale)
+        cur_w1.fp8_weight_stacked_transpose = None
+        cur_w1.fp8_scale_stacked_transpose = None
+        cur_w2.fp8_weight_stacked = slice_expert(w2_weight)
+        cur_w2.fp8_scale_stacked = slice_expert(w2_scale)
+        cur_w2.fp8_weight_stacked_transpose = None
+        cur_w2.fp8_scale_stacked_transpose = None
+
+        try:
+            yield
+        finally:
+            # 对于 0 号专家，需要恢复成融合的 fp8_weight；对于其他专家，直接删除其 fp8_weight
+            if expert_id == 0:
+                w1.fp8_weight_stacked, w1.fp8_scale_stacked = (
+                    w1_weight,
+                    w1_scale,
+                )
+                w2.fp8_weight_stacked, w2.fp8_scale_stacked = (
+                    w2_weight,
+                    w2_scale,
+                )
+            else:
+                del cur_w1.fp8_weight_stacked, cur_w1.fp8_scale_stacked
+                del cur_w2.fp8_weight_stacked, cur_w2.fp8_scale_stacked
+            del (
+                cur_w1.fp8_weight_stacked_transpose,
+                cur_w1.fp8_scale_stacked_transpose,
+            )
+            del (
+                cur_w2.fp8_weight_stacked_transpose,
+                cur_w2.fp8_scale_stacked_transpose,
+            )
+
+    def _prepare_forward(
+        self,
+        hs_2d_dispatched,
+        dispatched_indices,
+        dispatched_probs,
+        fill_output,
+    ):
+        """
+        前向计算的公共预处理，被 forward() 和 forward_auto_subbatch() 共用。
+        完成 4 步操作：cast indices → unzip → record_stream → 条件 quant。
+
+        Example (6 tokens, 3 experts, topk=2, FP8_ALIGN=128):
+
+            输入:
+              hs_2d_dispatched: [6, 4096] (bf16 或 FP8 tuple)
+              dispatched_indices: [6, 2] = [[0,1], [0,-1], [1,2], [0,-1], [1,-1], [2,-1]]
+              dispatched_probs:   [6, 2]
+
+            Step 1 - unzip (moe_permute):
+              按专家分组 + pad 到 FP8_ALIGN 对齐
+              tokens_per_expert = [3, 3, 2]  →  padding 后 = [128, 128, 128]
+
+              fill_output=True 时:
+                unzipped_tokens: [384, 4096]  ← 实际拷贝数据（fusion 路径）
+              fill_output=False 时:
+                unzipped_tokens: [384, 4096]  ← 数据未填充，只计算 rowmap（逐专家 gather 路径）
+
+              zipped_expertwise_rowmap: 索引映射（供后续 gather/scatter 使用）
+              unzipped_probs: [384, 1]
+
+            Step 2 - record_stream:
+              标记输入 tensor 可被 CUDA stream 异步释放
+
+            Step 3 - 条件 FP8 量化:
+              fill_output=False（逐专家路径）:
+                tilewise_quant(hs_2d_dispatched) → hs_2d_dispatched_fp8 [6, 4096] (FP8)
+                                                   hs_2d_dispatched_scale [6, 32]
+                释放原始 bf16 数据
+              fill_output=True（fusion 路径）:
+                不做量化（直接用 unzipped_tokens），fp8/scale = None
+
+            Step 4 - 保存 recompute 输入:
+              recompute_moe_premute=True 时保存 fp8/scale 供反向重算
+
+        Args:
+            hs_2d_dispatched: 输入 token。bf16 Tensor 或 (FP8 Tensor, scale) tuple。
+            dispatched_indices: 专家分配索引 [S, topk]。
+            dispatched_probs: 专家分配权重 [S, topk]。
+            fill_output: 控制 moe_permute 是否实际 gather 数据。
+                True  → unzipped_tokens 有数据（fusion 路径 / zip_unzip_fusion=True）
+                False → 只计算 rowmap（逐专家 gather 路径）
+
+        Returns:
+            tuple:
+                - use_fp8_dispatch_a2a (bool): 输入是否已经是 FP8（a2a 阶段已量化）。
+                - num_experts (int): 专家总数。
+                - num_zipped_tokens (int): zipped 空间的 token 数（即原始序列长度 S）。
+                - hidden_size (int): 隐藏层维度 H。
+                - unzipped_tokens (Tensor): 按专家分组后的 token [N_total_padded, H]。
+                    fill_output=True 时有数据，False 时数据未填充（需后续逐专家 gather）。
+                - zipped_expertwise_rowmap (Tensor): unzip/zip 的索引映射，供 gather/scatter 使用。
+                - unzipped_probs (Tensor): 按专家分组后的权重 [N_total_padded, 1]。
+                - unzipped_scale (Tensor|None): FP8 量化 scale，非 FP8 输入时为 None。
+                - hs_2d_dispatched_fp8 (Tensor|None): zipped 空间的 FP8 数据。
+                    逐专家路径用于后续 gather；fusion 路径为 None。
+                - hs_2d_dispatched_scale (Tensor|None): 对应的 FP8 scale。
+        """
+        use_fp8_dispatch_a2a = isinstance(hs_2d_dispatched, tuple)
+        num_experts = len(self.tokens_per_expert)
+
+        # 1. unzip: 按专家分组 + pad 到 FP8_ALIGN 对齐
+        self.dispatched_indices = dispatched_indices.to(paddle.int32)
+        (
+            unzipped_tokens,
+            zipped_expertwise_rowmap,
+            unzipped_probs,
+            unzipped_scale,
+        ) = self.unzip_node.forward(
+            hs_2d_dispatched,
+            self.dispatched_indices,
+            dispatched_probs,
+            topk=self.router_topk,
+            num_experts=num_experts,
+            tokens_per_expert=self.tokens_per_expert,
+            fill_output=fill_output,
+        )
+        self.unzipped_probs = unzipped_probs
+
+        # 2. 获取 shape 信息 + record_stream（标记 tensor 可被异步释放）
+        if use_fp8_dispatch_a2a:
+            num_zipped_tokens = hs_2d_dispatched[0].shape[0]
+            hidden_size = hs_2d_dispatched[0].shape[-1]
+            hs_2d_dispatched[0]._record_stream()
+            hs_2d_dispatched[1]._record_stream()
+        else:
+            num_zipped_tokens = hs_2d_dispatched.shape[0]
+            hidden_size = hs_2d_dispatched.shape[-1]
+            hs_2d_dispatched._record_stream()
+        dispatched_indices._record_stream()
+        dispatched_probs._record_stream()
+        if self.dispatched_indices.dtype is not dispatched_indices.dtype:
+            dispatched_indices._clear_to_zero_allocation()
+
+        # 3. FP8 量化（逐专家路径需要从 zipped 空间 gather，所以需要量化后的 zipped 数据）
+        #    fusion 路径直接使用 unzipped_tokens，不需要量化 zipped 数据
+        hs_2d_dispatched_fp8, hs_2d_dispatched_scale = None, None
+
+        if use_fp8_dispatch_a2a:
+            hs_2d_dispatched_fp8, hs_2d_dispatched_scale = hs_2d_dispatched
+        elif not fill_output:
+            hs_2d_dispatched_fp8, hs_2d_dispatched_scale = tilewise_quant(
+                hs_2d_dispatched
+            )
+            hs_2d_dispatched._clear_to_zero_allocation()
+
+        # 4. 保存输入供 recompute 使用（仅逐专家路径需要）
+        if self.recompute_moe_premute and hs_2d_dispatched_fp8 is not None:
+            self.hs_2d_dispatched_fp8 = hs_2d_dispatched_fp8
+            self.hs_2d_dispatched_scale = hs_2d_dispatched_scale
+
+        return (
+            use_fp8_dispatch_a2a,
+            num_experts,
+            num_zipped_tokens,
+            hidden_size,
+            unzipped_tokens,
+            zipped_expertwise_rowmap,
+            unzipped_probs,
+            unzipped_scale,
+            hs_2d_dispatched_fp8,
+            hs_2d_dispatched_scale,
+        )
+
+    def forward_auto_subbatch(
+        self, hs_2d_dispatched, dispatched_indices, dispatched_probs
+    ):
+        """
+        AutoSubbatch 前向: 根据 VMM 空闲显存动态决定每次处理多少 token.
+
+        背景
+        ----
+        MoE 前向 = unzip(按专家展开) -> expert_gemm -> zip(合并回原序).
+        expert_gemm 产生大量中间变量 (o1, o2 等), 显存可能不够一次做完,
+        因此需要把 token 切成多个 subbatch 分批计算.
+
+        两个关键决策
+        -----------
+        1) zip_unzip_fusion: 能否一次性分配 unzip 后的完整 buffer?
+           - True:  分配 n2[N,H] + o3[N,H], unzip/zip 各做一次
+           - False: 显存不够, 不分配整块, 每个专家单独 gather/scatter
+        2) subbatch_rows: 每个 subbatch 处理多少 token?
+           由 VMM 空闲显存 / 单个 subbatch 峰值 (o1[2H] + o2[H/2]) 决定.
+           如果 subbatch_rows >= 总token数 且 fusion, 则走 group_gemm 一次算完.
+
+        流程 (S=seq_len, H=hidden_size, N=unzipped_tokens)
+        --------------------------------------------------
+        0. 预分配 n3[S,H] (最终输出, 必须整块), 判断 zip_unzip_fusion
+        1. unzip: 按专家重排 token + FP8 量化
+        2. subbatch planning:
+           - 如果 not zip_unzip_fusion: 预分配 n2 placeholder 占位,
+             分配 n3 累加 buffer
+           - del n3 释放空间给专家计算
+           - 查询 VMM 空闲 -> 算出 subbatch_rows
+        3. expert_gemm:
+           a) group_gemm: subbatch_rows >= N -> 一次完成
+           b) per_expert: 逐专家循环, 每个专家按 subbatch_rows 切片:
+              o1=gate_up(n2), o2=swiglu(o1), o3=down(o2)
+              not zip_unzip_fusion 时: 先 gather n2 再算, 算完 scatter 回 n3
+        4. zip: 合并专家输出回原序 -> 最终 output[S,H]
+        """
+        use_fp8_dispatch_a2a = isinstance(hs_2d_dispatched, tuple)
+
+        # 先分配 n3，因为 n3 必须整个分配，避免先分配了后面的 n2/o3 导致 n3 分配不出来
+        zipped_out = paddle.empty(
+            shape=(
+                hs_2d_dispatched[0].shape
+                if use_fp8_dispatch_a2a
+                else hs_2d_dispatched.shape
+            ),
+            dtype=(
+                paddle.bfloat16
+                if use_fp8_dispatch_a2a
+                else hs_2d_dispatched.dtype
+            ),
+        )
+
+        # 如果能够分配连续的 n2 和 o3，则可以不切 zip/unzip
+        num_unzipped_tokens = self.token_offsets[-1]
+        hidden_size = zipped_out.shape[1]
+        zip_unzip_fusion = (
+            find_max_concurrent_subbatch_size(
+                [
+                    num_unzipped_tokens * zipped_out.shape[1] * 2,
+                    num_unzipped_tokens * zipped_out.shape[1],
+                ],
+                upper=1,
+            )
+            > 0
+        )
+        if zip_unzip_fusion:
+            expert_unzipped_out = paddle.empty(
+                [num_unzipped_tokens, zipped_out.shape[1]], zipped_out.dtype
+            )
+
+        # 1. 公共预处理：unzip → record_stream → quant
+        (
+            use_fp8_dispatch_a2a,
+            num_experts,
+            num_zipped_tokens,
+            hidden_size,
+            unzipped_tokens,
+            zipped_expertwise_rowmap,
+            unzipped_probs,
+            unzipped_scale,
+            hs_2d_dispatched_fp8,
+            hs_2d_dispatched_scale,
+        ) = self._prepare_forward(
+            hs_2d_dispatched,
+            dispatched_indices,
+            dispatched_probs,
+            fill_output=zip_unzip_fusion,
+        )
+
+        # 2. subbatch planning
+        # 分配 n3 的累加 buffer（如需）
+        if zip_unzip_fusion or num_zipped_tokens == 0:
+            output = paddle.empty([0, hidden_size], dtype=paddle.float32)
+        else:
+            # 由于 unzip 必须整专家进行，需要预留 n2 空间，
+            # 若不重计算，则需要预留所有专家的 n2
+            if self.recompute_moe_premute:
+                unzipped_tokens_placeholder = paddle.empty(
+                    [max(self.padding_token_per_experts), hidden_size],
+                    dtype=unzipped_tokens.dtype,
+                )
+            else:
+                unzipped_tokens_placeholder = [
+                    paddle.empty(
+                        [num_tokens, hidden_size],
+                        dtype=unzipped_tokens.dtype,
+                    )
+                    for num_tokens in self.padding_token_per_experts
+                ]
+
+            # 当 zip 不是一次性完成时，需要为 n3 分配更高精度的累加 buffer
+            n3_subbatch_rows = find_max_sequence_subbatch_size(
+                feature_size=hidden_size * 4, length=num_zipped_tokens
+            )
+            n3_subbatch_rows = max(
+                n3_subbatch_rows, self.min_auto_subbatch_rows
+            )
+            output = [
+                paddle.zeros(
+                    [
+                        min(n3_subbatch_rows, num_zipped_tokens - idx),
+                        hidden_size,
+                    ],
+                    dtype=paddle.float32,
+                )
+                for idx in range(0, num_zipped_tokens, n3_subbatch_rows)
+            ]
+
+        # 在专家计算过程中 n3 可以暂时释放，因为 n3 和专家计算的中间变量的生命周期不重叠
+        del zipped_out
+
+        # 找到最大的 subbatch_rows
+        # 只需考虑 o1 和 o2，因为 o3 可复用 o1 或预分配 buffer
+        subbatch_rows = (
+            find_max_concurrent_subbatch_size(
+                [FP8_ALIGN * hidden_size * 2, FP8_ALIGN * hidden_size // 2],
+                upper=self.token_offsets[-1] // FP8_ALIGN,
+            )
+            * FP8_ALIGN
+        )
+        subbatch_rows = max(subbatch_rows, self.min_auto_subbatch_rows)
+
+        # 3. experts
+        fwd_path = "unknown"
+        if (
+            self.moe_expert_fusion
+            and zip_unzip_fusion
+            and subbatch_rows >= self.token_offsets[-1]
+        ):
+            fwd_path = "group_gemm"
+            # 3a) 显存充足, subbatch_rows 大于总 token 数时，直接用 group_gemm 一次计算所有专家
+            self.experts_group_gemm_node.forward(
+                unzipped_tokens,
+                unzipped_probs,
+                self.padding_token_per_experts,
+                self.tokens_per_expert,
+                output=expert_unzipped_out,
+                scale=unzipped_scale,
+            )
+        else:
+            fwd_path = "per_expert"
+            # 3b) 显存不足或非 fusion 模式，回退到 expert_fusion=False, 逐专家处理
+            if self.moe_expert_fusion:
+                self.fallback_to_no_expert_fusion()
+
+            for expert_id, tokens_per_expert in enumerate(
+                self.tokens_per_expert
+            ):
+                gemm_node = self.experts_group_gemm_node[expert_id]
+                start_idx, end_idx = (
+                    self.token_offsets[expert_id],
+                    self.token_offsets[expert_id + 1],
+                )
+                expert_unzipped_idx = paddle.empty(
+                    [tokens_per_expert, 0], dtype=paddle.int64
+                )
+                tmp_unzipped_probs = unzipped_probs[start_idx:end_idx]
+                tmp_expert_unzipped_out = None
+
+                # 如果不切 unzip，则专家输入直接通过切片引用；否则每个专家都要执行一次 unzip (gather)
+                if zip_unzip_fusion:
+                    self.subbatch_prepare_gemm_node(
+                        (
+                            unzipped_tokens[start_idx:end_idx],
+                            unzipped_scale[start_idx:end_idx],
+                        ),
+                        expert_id,
+                    )
+                    tmp_expert_unzipped_out = expert_unzipped_out[
+                        start_idx:end_idx
+                    ]
+                else:
+                    # 释放 placeholder，为实际 n2 buffer 腾出空间
+                    if self.recompute_moe_premute:
+                        unzipped_tokens_placeholder = None
+                    else:
+                        unzipped_tokens_placeholder[expert_id] = None
+                    expert_unzipped_idx = (
+                        self.subbatch_unzip_and_prepare_gemm_node(
+                            (hs_2d_dispatched_fp8, hs_2d_dispatched_scale),
+                            zipped_expertwise_rowmap,
+                            expert_id,
+                        )
+                    )
+
+                # 遍历当前专家的每个 subbatch（可能只有一个subbatch）
+                with self.slice_fp8_weight(expert_id):
+                    for sb_start in range(0, tokens_per_expert, subbatch_rows):
+                        sb_end = min(
+                            sb_start + subbatch_rows, tokens_per_expert
+                        )
+                        if sb_start == 0 and sb_end == tokens_per_expert:
+                            sb_start = sb_end = None
+
+                        output = self.gemm_forward_subbatch(
+                            expert_id,
+                            tmp_unzipped_probs,
+                            expert_unzipped_idx,
+                            output,
+                            num_zipped_tokens,
+                            unzipped_out=tmp_expert_unzipped_out,
+                            start_idx=sb_start,
+                            end_idx=sb_end,
+                        )
+                if self.recompute_moe_premute:
+                    gemm_node.input_fp8 = None
+                    gemm_node.input_scale = None
+                    gemm_node.input = None
+
+                del expert_unzipped_idx
+                del tmp_expert_unzipped_out, tmp_unzipped_probs
+
+        # 4. zip
+        # 如果不切 zip，则在这里做一次完整的 zip；否则 zip 已经在前面分批完成，这里只需合并结果
+        if zip_unzip_fusion:
+            output = self.zip_node.forward(
+                expert_unzipped_out,
+                zipped_expertwise_rowmap,
+                self.dispatched_indices,
+                unzipped_probs,
+                total_zipped_tokens=num_zipped_tokens,
+                num_experts=num_experts,
+            )
+        else:
+            output_dtype = (
+                paddle.bfloat16
+                if use_fp8_dispatch_a2a
+                else hs_2d_dispatched.dtype
+            )
+            output = merge_subbatch_cast(output, output_dtype)
+
+        self.dispatched_probs = dispatched_probs
+        output.stop_gradient = False
+
+        self._fwd_diag = {
+            "total_tokens": num_unzipped_tokens,
+            "subbatch_rows": subbatch_rows,
+            "zip_unzip_fusion": zip_unzip_fusion,
+            "path": fwd_path,
+        }
+
+        return output
+
+    # ==================== backward methods ====================
+
+    def backward_auto_subbatch(self, hidden_states_out_grad):
+        """
+        AutoSubbatch 反向: 与前向对称, 根据 VMM 空闲显存动态决定 subbatch 大小.
+
+        背景
+        ----
+        MoE 反向 = zip_grad(梯度按专家展开) -> expert_bwd -> unzip_grad(合并回原序).
+        与前向对称, 但反向的显存峰值更大 (需要重算前向中间变量 + 存储梯度),
+        因此更需要 subbatch 切分.
+
+        两个关键决策 (与前向相同)
+        -----------------------
+        1) zip_unzip_fusion: 能否一次性分配展开后的完整梯度 buffer?
+           - True:  分配 do3[N,H], zip_grad/unzip_grad 各做一次
+           - False: 显存不够, 每个专家单独 gather/scatter_add
+        2) subbatch_rows: 由 VMM 空闲 / 反向峰值决定.
+           峰值与 swiglu_bwd 是否 inplace 相关:
+             inplace:     o1/do1 共享(2H) + o2_s(H) + n2_s(2H) = 5H
+             out-of-place: o1(2H) + do1(2H) + o2_s(H) + n2_s(2H) = 7H
+
+        流程 (S=seq_len, H=hidden_size, N=unzipped_tokens)
+        --------------------------------------------------
+        0. 判断 zip_unzip_fusion
+        1. zip_grad: dn3[S,H] -> do3[N,H] (梯度按专家展开)
+           如果 recompute_premute + fusion, 同时重算前向的 n2
+        2. subbatch planning:
+           - 如果 not zip_unzip_fusion: 预分配 do3/n2 placeholder 占位,
+             分配 dn1 累加 buffer
+           - 查询 VMM 空闲 -> 算出 subbatch_rows -> 释放 placeholder
+        3. expert_bwd:
+           a) group_gemm: subbatch_rows >= N -> 一次完成
+           b) per_expert: 逐专家循环, 每个专家按 subbatch_rows 切片:
+              do2=do3@W2, do1=swiglu_bwd(o1), dW2=o2^T@do3, dW1=n2^T@do1, dn2=do1@W1
+              not zip_unzip_fusion 时: gather do3 -> 算完 -> scatter_add 回 dn1
+        4. unzip_grad: 合并梯度回原序 -> dn1[S,H]
+           释放 dn3 物理页给 dn1 复用
+        """
+        num_unzipped_tokens = self.token_offsets[-1]
+        num_zipped_tokens = hidden_states_out_grad.shape[0]
+        hidden_size = hidden_states_out_grad.shape[-1]
+        output = paddle.empty([0, hidden_size], dtype=paddle.float32)
+        probs_grad_list = []
+
+        # 如果 do3 和 n2 (如果recompute) 能同时分配，则可以不用切 zip_grad/unzip，避免重复读写
+        zip_unzip_features = [num_unzipped_tokens * hidden_size * 2]
+        if self.recompute_moe_premute:
+            zip_unzip_features.append(num_unzipped_tokens * hidden_size)
+        zip_unzip_fusion = (
+            find_max_concurrent_subbatch_size(zip_unzip_features, upper=1) > 0
+        )
+
+        # 1. zip_grad and unzip (recompute)
+        unzipped_grad = self.zip_node.backward(
+            hidden_states_out_grad,
+            self.dispatched_indices,
+            self.dispatched_probs,
+            top_k=self.router_topk,
+            num_experts=len(self.tokens_per_expert),
+            tokens_per_expert=self.tokens_per_expert,
+            fill_output=zip_unzip_fusion,
+        )
+        if self.recompute_moe_premute and zip_unzip_fusion:
+            (unzipped_tokens, _, _, unzipped_scale) = self.unzip_node.forward(
+                (self.hs_2d_dispatched_fp8, self.hs_2d_dispatched_scale),
+                self.dispatched_indices,
+                self.dispatched_probs,
+                topk=self.router_topk,
+                num_experts=len(self.tokens_per_expert),
+                tokens_per_expert=self.tokens_per_expert,
+                fill_output=True,
+            )
+
+        # 2. subbatch planning
+        # 分配 dn1 的累加 buffer（如需）
+        if not zip_unzip_fusion:
+            # 由于 zip_grad/unzip 不切专家，我们需要保证最大的专家的 unzipped_grad/unzipped_tokens 能够完整分配，
+            # 所以我们先分配两者，再计算 subbatch_rows，避免 subbatch_rows 过大导致两者分配不出来
+            max_unzipped_tokens_per_expert = (
+                (max(self.tokens_per_expert) + FP8_ALIGN - 1)
+                // FP8_ALIGN
+                * FP8_ALIGN
+            )
+            unzipped_grad_placeholder = paddle.empty(
+                [max_unzipped_tokens_per_expert, hidden_size],
+                dtype=hidden_states_out_grad.dtype,
+            )
+            if self.recompute_moe_premute:
+                unzipped_tokens_placeholder = paddle.empty(
+                    [max_unzipped_tokens_per_expert, hidden_size],
+                    dtype=self.hs_2d_dispatched_fp8.dtype,
+                )
+
+            # 当 unzip_grad 不是一次性完成时，需要为 dn1 分配更高精度的的累加 buffer
+            dn1_subbatch_rows = find_max_sequence_subbatch_size(
+                feature_size=hidden_size * 4, length=num_zipped_tokens
+            )
+            dn1_subbatch_rows = max(
+                dn1_subbatch_rows, self.min_auto_subbatch_rows
+            )
+            output = [
+                paddle.zeros(
+                    [
+                        min(dn1_subbatch_rows, num_zipped_tokens - idx),
+                        hidden_size,
+                    ],
+                    dtype=paddle.float32,
+                )
+                for idx in range(0, num_zipped_tokens, dn1_subbatch_rows)
+            ]
+            if num_zipped_tokens == 0:
+                output = paddle.empty([0, hidden_size], dtype=paddle.float32)
+
+        # 找到最大的 subbatch_rows
+        # 反向需要考虑3个临时变量：o1、do2、n2_s；其他：n2、do3 已分配，do1、o2_s、dn2 是原地复用
+        # o1与swiglu_bwd 是否 inplace相关：
+        #
+        # inplace（USE_INPLACE_SWIGLU_BWD=True：
+        #   do1 复用 o1 buffer，峰值在 dw1（D 点）：
+        #   do1/o1(2H) + o2_s(H) + n2_s(2H) = 5H
+        #   → feature_sizes = [2H, H, 2H]
+        #
+        # out-of-place（USE_INPLACE_SWIGLU_BWD=False）：
+        #   do1 是独立新 buffer，o1 延迟释放，峰值在 dw1（D 点）：
+        #   o1(2H) + do1(2H) + o2_s(H) + n2_s(2H) = 7H
+        #   → feature_sizes = [2H, 2H, H, 2H]
+        if USE_INPLACE_SWIGLU_BWD:
+            bwd_feature_sizes = [
+                FP8_ALIGN * hidden_size * 2,  # o1/do1（inplace 共享）
+                FP8_ALIGN * hidden_size,  # o2_s
+                FP8_ALIGN * hidden_size * 2,  # n2_s
+            ]
+        else:
+            bwd_feature_sizes = [
+                FP8_ALIGN * hidden_size * 2,  # o1
+                FP8_ALIGN * hidden_size * 2,  # do1（out-of-place 独立 buffer）
+                FP8_ALIGN * hidden_size,  # o2_s
+                FP8_ALIGN * hidden_size * 2,  # n2_s
+            ]
+        subbatch_rows = (
+            find_max_concurrent_subbatch_size(
+                bwd_feature_sizes,
+                upper=self.token_offsets[-1] // FP8_ALIGN,
+            )
+            * FP8_ALIGN
+        )
+        subbatch_rows = max(subbatch_rows, self.min_auto_subbatch_rows)
+
+        # 确定 subbatch_rows 后，就可以把刚才占位的显存释放了
+        if not zip_unzip_fusion:
+            del unzipped_grad_placeholder
+            if self.recompute_moe_premute:
+                del unzipped_tokens_placeholder
+
+        # 3. experts
+        bwd_path = "unknown"
+        # 3a) 如果前向走了 group_gemm，且当前显存也足够，则反向也使用 group_gemm
+        if self.moe_expert_fusion:
+            if zip_unzip_fusion and subbatch_rows >= self.token_offsets[-1]:
+                bwd_path = "group_gemm"
+                unzipped_grad, unzipped_probs_grad = (
+                    self.experts_group_gemm_node.backward(
+                        unzipped_grad, self.unzipped_probs
+                    )
+                )
+                probs_grad_list.append(unzipped_probs_grad)
+            else:
+                # 显存不够做 group_gemm，回退到回退到 expert_fusion=False，逐专家处理
+                bwd_path = "per_expert (fallback)"
+                self.fallback_to_no_expert_fusion()
+
+        # 3b) 逐专家处理
+        if not self.moe_expert_fusion:
+            if bwd_path == "unknown":
+                bwd_path = "per_expert"
+            for expert_id, tokens_per_expert in enumerate(
+                self.tokens_per_expert
+            ):
+                gemm_node = self.experts_group_gemm_node[expert_id]
+                start_idx, end_idx = (
+                    self.token_offsets[expert_id],
+                    self.token_offsets[expert_id + 1],
+                )
+
+                original_subbatch_rows = (
+                    gemm_node.moe_subbatch_token_num_after_dispatch
+                )
+                gemm_node.moe_subbatch_token_num_after_dispatch = (
+                    subbatch_rows if subbatch_rows < tokens_per_expert else None
+                )
+
+                # 如果前面 zip_grad 一次做完了，这里只需进行切片；否则需要做一次专家级的 zip_grad
+                if zip_unzip_fusion:
+                    expert_unzipped_grad = unzipped_grad[start_idx:end_idx]
+                    if self.recompute_moe_premute:
+                        self.subbatch_prepare_gemm_node(
+                            (
+                                unzipped_tokens[start_idx:end_idx],
+                                unzipped_scale[start_idx:end_idx],
+                            ),
+                            expert_id,
+                        )
+                else:
+                    (
+                        expert_unzipped_grad,
+                        _,
+                        unzipped_grad_idx,
+                    ) = paddlefleet.ops.tokens_unzip_gather(
+                        hidden_states_out_grad,
+                        None,
+                        self.unzip_node.zipped_expertwise_rowmap,
+                        expert_id=expert_id,
+                        tokens_per_expert=self.tokens_per_expert,
+                        padding_multiplex=FP8_ALIGN,
+                    )
+                    if self.recompute_moe_premute:
+                        self.subbatch_unzip_and_prepare_gemm_node(
+                            (
+                                self.hs_2d_dispatched_fp8,
+                                self.hs_2d_dispatched_scale,
+                            ),
+                            self.unzip_node.zipped_expertwise_rowmap,
+                            expert_id,
+                        )
+
+                # 进行单个专家的 backward，注意 expert_unzipped_grad 是原地修改
+                with self.slice_fp8_weight(expert_id):
+                    expert_unzipped_grad, unzipped_probs_grad = (
+                        gemm_node.backward(
+                            expert_unzipped_grad,
+                            self.unzipped_probs[start_idx:end_idx],
+                        )
+                    )
+
+                # 如果 unzip_grad 不是一次做完，则需要每个专家分别做一次 unzip_grad (scatter_add)
+                if not zip_unzip_fusion:
+                    output = tokens_zip_unique_add_with_subbatch(
+                        output,
+                        expert_unzipped_grad,
+                        unzipped_grad_idx,
+                        zipped_rows=num_zipped_tokens,
+                        subbatch_rows=(
+                            None
+                            if isinstance(output, paddle.Tensor)
+                            else output[0].shape[0]
+                        ),
+                    )
+                    del unzipped_grad_idx
+
+                if len(unzipped_probs_grad.shape) > 1:
+                    unzipped_probs_grad = unzipped_probs_grad.squeeze(-1)
+                assert len(unzipped_probs_grad.shape) == 1, (
+                    unzipped_probs_grad.shape
+                )
+                probs_grad_list.append(unzipped_probs_grad)
+
+                gemm_node.moe_subbatch_token_num_after_dispatch = (
+                    original_subbatch_rows
+                )
+
+                del expert_unzipped_grad
+
+        # 4. unzip_grad
+        hidden_states_out_grad._clear_to_zero_allocation()  # dn1 复用 dn3
+        if self.recompute_moe_premute and zip_unzip_fusion:
+            del unzipped_tokens, unzipped_scale
+
+        # 如果不切 unzip_grad，则在这里做一次完整的 unzip_grad；否则 unzip_grad 已经在前面分批完成，这里只需合并结果
+        if zip_unzip_fusion:
+            probs_grad = paddle.concat(probs_grad_list)
+            del probs_grad_list
+            hs_fp8_dispatched_grad, dispatched_probs_grad = (
+                self.unzip_node.backward(
+                    unzipped_grad,
+                    hidden_states_out_grad.shape,
+                    probs_grad,
+                    self.dispatched_indices,
+                    num_experts=len(self.tokens_per_expert),
+                )
+            )
+        else:
+            hs_fp8_dispatched_grad = merge_subbatch_cast(
+                output, hidden_states_out_grad.dtype
+            )
+            del output
+            dispatched_probs_grad = paddlefleet.ops.tokens_zip_prob(
+                probs_grad_list,
+                self.unzip_node.zipped_expertwise_rowmap,
+                self.dispatched_indices,
+            )
+
+        self._bwd_diag = {
+            "total_tokens": num_unzipped_tokens,
+            "subbatch_rows": subbatch_rows,
+            "zip_unzip_fusion": zip_unzip_fusion,
+            "path": bwd_path,
+        }
+
+        return hs_fp8_dispatched_grad, dispatched_probs_grad
+
     @paddle.no_grad()
     def forward(self, hs_2d_dispatched, dispatched_indices, dispatched_probs):
         """
@@ -442,51 +1492,106 @@ class MlpNode:
             Tensor: 经过前向传播计算后的输出数据。
 
         """
-        use_fp8_dispatch_a2a = isinstance(hs_2d_dispatched, tuple)
+        if self.use_auto_subbatch:
+            return self.forward_auto_subbatch(
+                hs_2d_dispatched, dispatched_indices, dispatched_probs
+            )
 
-        num_experts = len(self.tokens_per_expert)
-        # 1 unzip
-        self.dispatched_indices = dispatched_indices.to(paddle.int32)
+        # 1. 公共预处理：unzip → record_stream → quant
         (
+            use_fp8_dispatch_a2a,
+            num_experts,
+            total_zipped_tokens,
+            hidden_size,
             unzipped_tokens,
             zipped_expertwise_rowmap,
             unzipped_probs,
             unzipped_scale,
-        ) = self.unzip_node.forward(
+            hs_2d_dispatched_fp8,
+            hs_2d_dispatched_scale,
+        ) = self._prepare_forward(
             hs_2d_dispatched,
-            self.dispatched_indices,
+            dispatched_indices,
             dispatched_probs,
-            topk=self.router_topk,
-            num_experts=num_experts,
-            tokens_per_expert=self.tokens_per_expert,
             fill_output=self.moe_expert_fusion,
         )
-        self.unzipped_probs = unzipped_probs
-        if not self.moe_expert_fusion:
-            unzipped_tokens = None
-
-        if use_fp8_dispatch_a2a:
-            total_zipped_tokens = hs_2d_dispatched[0].shape[0]
-            hidden_size = hs_2d_dispatched[0].shape[-1]
-            hs_2d_dispatched[0]._record_stream()
-            hs_2d_dispatched[1]._record_stream()
-        else:
-            total_zipped_tokens = hs_2d_dispatched.shape[0]
-            hidden_size = hs_2d_dispatched.shape[-1]
-            hs_2d_dispatched._record_stream()
-        dispatched_indices._record_stream()
-        dispatched_probs._record_stream()
-        if self.dispatched_indices is not dispatched_indices:
-            dispatched_indices._clear_to_zero_allocation()
 
         if not self.moe_expert_fusion:
-            raise NotImplementedError(
-                "moe_expert_fusion = False is not supported currently"
+            # 路径 2：逐专家 gather → 逐专家 GEMM → scatter-add
+            expected_output_dtype = (
+                paddle.bfloat16
+                if use_fp8_dispatch_a2a
+                else hs_2d_dispatched.dtype
             )
+            output = paddle.empty([0, hidden_size], dtype=paddle.float32)
+
+            for expert_id, tokens_per_expert in enumerate(
+                self.tokens_per_expert
+            ):
+                expert_unzipped_idx = self.subbatch_unzip_and_prepare_gemm_node(
+                    (hs_2d_dispatched_fp8, hs_2d_dispatched_scale),
+                    zipped_expertwise_rowmap,
+                    expert_id,
+                )
+
+                if (
+                    self.moe_subbatch_token_num_after_dispatch is not None
+                    and self.moe_subbatch_token_num_after_dispatch > 0
+                    and tokens_per_expert
+                    > self.moe_subbatch_token_num_after_dispatch
+                ):
+                    num_subbatches = (
+                        tokens_per_expert
+                        + self.moe_subbatch_token_num_after_dispatch
+                        - 1
+                    ) // self.moe_subbatch_token_num_after_dispatch
+                    for i in range(num_subbatches):
+                        sb_start = (
+                            i * self.moe_subbatch_token_num_after_dispatch
+                        )
+                        sb_end = min(
+                            sb_start
+                            + self.moe_subbatch_token_num_after_dispatch,
+                            tokens_per_expert,
+                        )
+                        output = self.gemm_forward_subbatch(
+                            expert_id,
+                            unzipped_probs[
+                                self.token_offsets[
+                                    expert_id
+                                ] : self.token_offsets[expert_id + 1]
+                            ],
+                            expert_unzipped_idx,
+                            output,
+                            total_zipped_tokens,
+                            start_idx=sb_start,
+                            end_idx=sb_end,
+                        )
+                    # nparts>1 的 expert 全部 subbatch 跑完后，释放 input_fp8
+                    if self.recompute_moe_premute:
+                        gemm_node = self.experts_group_gemm_node[
+                            self._gemm_node_id_offset + expert_id
+                        ]
+                        gemm_node.input_fp8 = None
+                        gemm_node.input_scale = None
+                else:
+                    output = self.gemm_forward_subbatch(
+                        expert_id,
+                        unzipped_probs[
+                            self.token_offsets[expert_id] : self.token_offsets[
+                                expert_id + 1
+                            ]
+                        ],
+                        expert_unzipped_idx,
+                        output,
+                        total_zipped_tokens,
+                    )
+
+            expert_out = merge_subbatch_cast(output, expected_output_dtype)
         else:
+            # 路径 1：一次性 group GEMM → zip
             if not use_fp8_dispatch_a2a:
                 hs_2d_dispatched._clear_to_zero_allocation()
-            # 2 experts
             expert_out = self.experts_group_gemm_node.forward(
                 unzipped_tokens,
                 unzipped_probs,
@@ -496,7 +1601,6 @@ class MlpNode:
                 scale=unzipped_scale,  # maybe None
             )
 
-            # 3 zip
             expert_out = expert_out.reshape([-1, expert_out.shape[-1]])
 
             expert_out = self.zip_node.forward(
@@ -527,6 +1631,9 @@ class MlpNode:
                 - dispatched_probs_grad (Tensor): 分发概率梯度。
 
         """
+        if self.use_auto_subbatch:
+            return self.backward_auto_subbatch(hidden_states_out_grad)
+
         # zip_grad
         hidden_states_out_grad_shape = hidden_states_out_grad.shape
         unzipped_grad = self.zip_node.backward(
@@ -541,8 +1648,74 @@ class MlpNode:
         hidden_states_out_grad._record_stream()
 
         if not self.moe_expert_fusion:
-            raise NotImplementedError(
-                "moe_expert_fusion = False is not supported currently"
+            # Per-expert backward path (non-fusion)
+            output = paddle.empty(
+                [0, hidden_states_out_grad_shape[-1]], dtype=paddle.float32
+            )
+            probs_grad_list = []
+            for expert_id, tokens_per_expert in enumerate(
+                self.tokens_per_expert
+            ):
+                (
+                    expert_unzipped_grad,
+                    _,
+                    unzipped_grad_idx,
+                ) = paddlefleet.ops.tokens_unzip_gather(
+                    hidden_states_out_grad,
+                    None,
+                    self.unzip_node.zipped_expertwise_rowmap,
+                    expert_id=expert_id,
+                    tokens_per_expert=self.tokens_per_expert,
+                    padding_multiplex=FP8_ALIGN,
+                )
+
+                if self.recompute_moe_premute:
+                    self.subbatch_unzip_and_prepare_gemm_node(
+                        (
+                            self.hs_2d_dispatched_fp8,
+                            self.hs_2d_dispatched_scale,
+                        ),
+                        self.unzip_node.zipped_expertwise_rowmap,
+                        expert_id,
+                    )
+
+                _gn = self.experts_group_gemm_node[
+                    self._gemm_node_id_offset + expert_id
+                ]
+                expert_unzipped_grad, unzipped_probs_grad = _gn.backward(
+                    expert_unzipped_grad,
+                    self.unzipped_probs[
+                        self.token_offsets[expert_id] : self.token_offsets[
+                            expert_id + 1
+                        ]
+                    ],
+                )
+
+                output = tokens_zip_unique_add_with_subbatch(
+                    output,
+                    expert_unzipped_grad,
+                    unzipped_grad_idx,
+                    zipped_rows=hidden_states_out_grad_shape[0],
+                    subbatch_rows=self.moe_subbatch_token_num_after_dispatch,
+                )
+                del unzipped_grad_idx
+
+                if len(unzipped_probs_grad.shape) > 1:
+                    unzipped_probs_grad = unzipped_probs_grad.squeeze(-1)
+                probs_grad_list.append(unzipped_probs_grad)
+
+                del expert_unzipped_grad
+
+            hidden_states_out_grad._clear_to_zero_allocation()
+            hs_fp8_dispatched_grad = merge_subbatch_cast(
+                output, hidden_states_out_grad.dtype
+            )
+            del output
+
+            dispatched_probs_grad = paddlefleet.ops.tokens_zip_prob(
+                probs_grad_list,
+                self.unzip_node.zipped_expertwise_rowmap,
+                self.dispatched_indices,
             )
         else:
             hidden_states_out_grad._clear_to_zero_allocation()
@@ -590,6 +1763,7 @@ class FusionMoePyLayer(paddle.autograd.PyLayer):
         use_bf16_gemm_weight_grad=False,
         is_first_fwd=False,
         fp8_dispatched_handle=None,
+        use_auto_subbatch=False,
     ):
         """
         根据给定的参数执行前向传播操作。
@@ -615,6 +1789,7 @@ class FusionMoePyLayer(paddle.autograd.PyLayer):
             use_fp8_mlp=use_fp8_mlp,
             moe_deep_gemm=moe_deep_gemm,
             moe_grouped_gemm=moe_grouped_gemm,
+            use_auto_subbatch=use_auto_subbatch,
         )
 
         if fp8_dispatched_handle is not None:
@@ -628,6 +1803,9 @@ class FusionMoePyLayer(paddle.autograd.PyLayer):
 
         if is_first_fwd:
             ctx.node.release_mem()
+
+        # Expose node on moe_layer for diagnostic access
+        custom_map._fusion_node = ctx.node
 
         cached_tensors = ctx.node.cached_tensors()
         ctx.save_for_backward(cached_tensors)

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -130,6 +130,10 @@ class MoELayer(nn.Layer):
         self.fp8_dispatch = bool(config.fp8)
         self.fp8_wgrad = config.fp8_wgrad
         self.using_sonic_moe = self.config.using_sonic_moe
+        self.moe_expert_fusion = config.moe_expert_fusion
+        self.moe_subbatch_token_num_after_dispatch = (
+            config.moe_subbatch_token_num_after_dispatch
+        )
         if self.using_sonic_moe:
             assert paddlefleet.ops.is_sonic_moe_available(), (
                 paddlefleet.ops.blocked_import_messages[
@@ -283,13 +287,22 @@ class MoELayer(nn.Layer):
                     f"Unsupported moe_token_dispatcher_type {self.moe_token_dispatcher_type}"
                 )
 
-        self.recompute_moe_gate_up = (
+        self.recompute_moe_gate_up = getattr(
+            self.config, "recompute_moe_gate_up", False
+        ) or (
             self.config.recompute_granularity == "selective"
+            and self.config.recompute_modules is not None
             and "moe_gate_up" in self.config.recompute_modules
         )
-        self.recompute_moe_premute = (
+        self.recompute_moe_premute = getattr(
+            self.config, "recompute_moe_premute", False
+        ) or (
             self.config.recompute_granularity == "selective"
+            and self.config.recompute_modules is not None
             and "moe_premute" in self.config.recompute_modules
+        )
+        self.use_auto_subbatch = getattr(
+            self.config, "use_auto_subbatch", False
         )
 
         if self.expert_model_parallel_size > 1:
@@ -531,6 +544,9 @@ class MoELayer(nn.Layer):
                 recompute_moe_premute=self.recompute_moe_premute,
                 fp8_dispatched_handle=fp8_dispatched_handle,
                 use_bf16_gemm_weight_grad=not self.fp8_wgrad,
+                use_auto_subbatch=self.use_auto_subbatch,
+                moe_expert_fusion=self.moe_expert_fusion,
+                moe_subbatch_token_num_after_dispatch=self.moe_subbatch_token_num_after_dispatch,
             )
 
         hidden_states = self.token_dispatcher._comm_manager.combine(
@@ -622,6 +638,8 @@ class MoELayer(nn.Layer):
                 recompute_moe_premute=self.recompute_moe_premute,
                 fp8_dispatched_handle=fp8_dispatched_handle,
                 use_bf16_gemm_weight_grad=not self.fp8_wgrad,
+                use_auto_subbatch=self.use_auto_subbatch,
+                moe_expert_fusion=self.moe_expert_fusion,
             )
             if is_first_fwd:
                 hidden_states.stop_gradient = False
@@ -905,15 +923,16 @@ class MoELayer(nn.Layer):
             if weight_obj is None:
                 weight_obj = weight_list[0]
 
-            if quant_transpose is None:
-                fp8_weight, fp8_scale = (
-                    paddle.incubate.nn.functional.fused_stack_transpose_quant(
-                        weight_list, transpose=False
-                    )
+            # 始终量化非转置版（行为对齐，fp8_weight_stacked 始终存在）
+            fp8_weight, fp8_scale = (
+                paddle.incubate.nn.functional.fused_stack_transpose_quant(
+                    weight_list, transpose=False
                 )
-                weight_obj.fp8_weight_stacked = fp8_weight
-                weight_obj.fp8_scale_stacked = fp8_scale
+            )
+            weight_obj.fp8_weight_stacked = fp8_weight
+            weight_obj.fp8_scale_stacked = fp8_scale
 
+            if quant_transpose is None or quant_transpose is True:
                 fp8_weight_t, fp8_scale_t = (
                     paddle.incubate.nn.functional.fused_stack_transpose_quant(
                         weight_list, transpose=True
@@ -922,23 +941,8 @@ class MoELayer(nn.Layer):
                 weight_obj.fp8_weight_stacked_transpose = fp8_weight_t
                 weight_obj.fp8_scale_stacked_transpose = fp8_scale_t
             elif quant_transpose is False:
-                # Only quantize without transpose
-                fp8_weight, fp8_scale = (
-                    paddle.incubate.nn.functional.fused_stack_transpose_quant(
-                        weight_list, transpose=False
-                    )
-                )
-                weight_obj.fp8_weight_stacked = fp8_weight
-                weight_obj.fp8_scale_stacked = fp8_scale
-            elif quant_transpose is True:
-                # Only quantize with transpose
-                fp8_weight_t, fp8_scale_t = (
-                    paddle.incubate.nn.functional.fused_stack_transpose_quant(
-                        weight_list, transpose=True
-                    )
-                )
-                weight_obj.fp8_weight_stacked_transpose = fp8_weight_t
-                weight_obj.fp8_scale_stacked_transpose = fp8_scale_t
+                weight_obj.fp8_weight_stacked_transpose = None
+                weight_obj.fp8_scale_stacked_transpose = None
             else:
                 raise ValueError("Invalid value for `quant_transpose`.")
 

--- a/src/paddlefleet/transformer/moe/vmm_utils.py
+++ b/src/paddlefleet/transformer/moe/vmm_utils.py
@@ -1,0 +1,221 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""VMM (Virtual Memory Management) utility functions for auto subbatch."""
+
+import paddle
+from paddle.device.cuda.memory_analyzer import GB, MemoryAnalysisTool
+
+import paddlefleet
+
+
+def vmm_free_and_growable_block_info() -> list[tuple[int, int]]:
+    """
+    获取当前堆中所有 free block 的信息，堆顶可增长的空间也被视为一个 free block。
+    返回列表按照 block size 从小到大排序。
+
+    堆大小的上限由 FLAGS_max_reserved_threshold_in_gb 配置。
+    """
+    all_heaps = MemoryAnalysisTool.vmm_all_block_info()
+    assert all_heaps, (
+        "vmm_all_block_info() returned empty, is FLAGS_use_virtual_memory_auto_growth=True?"
+    )
+    all_blocks = all_heaps[-1]  # sorted by addr
+    (max_reserved,) = paddle.framework.get_flags(
+        "FLAGS_max_reserved_threshold_in_gb"
+    ).values()
+    max_reserved = max_reserved * GB
+
+    free_blocks = [(size, addr) for size, addr, free in all_blocks if free]
+
+    # 堆顶可增长空间即是: 配置的reserved上限 - 当前已reserved的总量
+    growable = max(max_reserved - paddle.cuda.memory_reserved(), 0)
+
+    # 如果最后一个 block 是空闲的，将其与 growable 合并；否则将 growable 单独作为一个 block
+    if growable > 0:
+        if not all_blocks:
+            return [(growable, 0)]
+        if all_blocks[-1][2]:
+            size, addr = free_blocks[-1]
+            free_blocks[-1] = (size + growable, addr)
+        else:
+            size, addr, _ = all_blocks[-1]
+            free_blocks.append((growable, size + addr))
+
+    free_blocks.sort()
+    return free_blocks
+
+
+def find_max_concurrent_subbatch_size(
+    feature_sizes: list[int],
+    upper: int | None = None,
+) -> int:
+    """
+    找到最大的 subbatch_size，使得对于所有 feature_sizes[i] * subbatch_size 的 Tensor 都能同时分配。
+    如果无法分配，返回 0。
+
+    如果指定了 upper，则搜索 subbatch_size 时搜索上限不超过 upper。
+
+    注：这个函数是启发式搜索，总是优先把大的 tensor 分配到大的碎片，虽然这样可能得不到理论最优 subbatch_size，
+    但 VMM 分配器也是这样的策略，如果本函数给出一个过于极限的大小，可能导致 VMM 分配不出来。
+    """
+    feature_sizes = sorted(feature_sizes, reverse=True)  # largest first
+    if not feature_sizes or feature_sizes[0] == 0:
+        return 1
+
+    free_blocks = vmm_free_and_growable_block_info()  # smallest first
+    if not free_blocks:
+        return 0
+
+    # 如果只有1个tensor，只要检查最大的碎片
+    if len(feature_sizes) == 1:
+        max_subbatch_size = free_blocks[-1][0] // feature_sizes[0]
+        return max_subbatch_size
+
+    # 如果有2个tensor，只要检查最大的1或2个碎片
+    if len(feature_sizes) == 2:
+        # 如果都放在同一个碎片里
+        max_subbatch_size = free_blocks[-1][0] // sum(feature_sizes)
+
+        # 如果分别放在两个碎片里
+        if len(free_blocks) > 1:
+            subbatch_size = min(
+                free_blocks[-1][0] // feature_sizes[0],
+                free_blocks[-2][0] // feature_sizes[1],
+            )
+            max_subbatch_size = max(max_subbatch_size, subbatch_size)
+
+        return max_subbatch_size
+
+    def can_pack(subbatch_size):
+        i = 0  # 下一个要分配的 tensor
+
+        for size, _ in reversed(free_blocks):
+            # 如果当前碎片连一个 tensor 都分配不了，那后面的碎片更分配不了，肯定失败
+            if size < feature_sizes[i] * subbatch_size:
+                return False
+
+            # 在当前碎片中分配尽可能多的 tensor
+            consumed = 0
+            while consumed + feature_sizes[i] * subbatch_size <= size:
+                consumed += feature_sizes[i] * subbatch_size
+                i += 1
+                if i == len(feature_sizes):
+                    return True
+
+        # 碎片用完了 tensor 还没分配完，也是失败
+        return False
+
+    # 有3个或以上tensor，使用二分搜索
+    left = 0
+    right = free_blocks[-1][0] // feature_sizes[0] if upper is None else upper
+
+    while left < right:
+        mid = (left + right + 1) // 2
+        if can_pack(mid):
+            left = mid
+        else:
+            right = mid - 1
+
+    return left
+
+
+def find_max_sequence_subbatch_size(feature_size: int, length: int = 1) -> int:
+    """
+    找到最大的 subbatch_size，使得可以将 Tensor [length, feature_size] 在 length 维
+    按照 subbatch_size 切分后能够分配。如果无法分配，返回 0。
+
+    如果不指定 length，相当于分析大小为 feature_size 的 Tensor 能否分配。
+    """
+    free_blocks = vmm_free_and_growable_block_info()  # smallest first
+
+    def can_pack(subbatch_size):
+        num_subbatches = (length + subbatch_size - 1) // subbatch_size
+
+        for size, _ in reversed(free_blocks):
+            # 如果当前碎片连一个 subbatch 都分配不了，那后面的碎片更分配不了，肯定失败
+            if size < feature_size * subbatch_size:
+                return False
+
+            # 在当前碎片中分配尽可能多的 subbatch
+            num_subbatches -= size // (feature_size * subbatch_size)
+            if num_subbatches <= 0:
+                return True
+
+        # 碎片用完了 subbatch 还没分配完，也是失败
+        return False
+
+    # 使用二分搜索
+    left, right = 0, length
+
+    while left < right:
+        mid = (left + right + 1) // 2
+        if can_pack(mid):
+            left = mid
+        else:
+            right = mid - 1
+
+    return left
+
+
+def tokens_zip_unique_add_with_subbatch(
+    zipped, unzipped, index_unzipped, zipped_rows, subbatch_rows=None
+):
+    """
+    tokens_zip_unique_add_with_subbatch
+    """
+    if subbatch_rows is None or subbatch_rows <= 0 or zipped_rows <= 0:
+        return paddlefleet.ops.tokens_zip_unique_add(
+            zipped, unzipped, index_unzipped, zipped_rows
+        )
+    else:
+        if isinstance(zipped, paddle.Tensor):
+            num_split = (zipped_rows + subbatch_rows - 1) // subbatch_rows
+            remainder = zipped_rows % subbatch_rows
+            if remainder == 0:
+                rows = [subbatch_rows] * num_split
+            else:
+                rows = [subbatch_rows] * (num_split - 1) + [remainder]
+
+            if zipped.shape[0] == 0:
+                dtype = zipped.dtype
+                hidden_size = zipped.shape[1]
+                zipped = [
+                    paddle.zeros([r, hidden_size], dtype=dtype) for r in rows
+                ]
+            else:
+                zipped = paddle.split(zipped, rows, axis=0)
+        return paddlefleet.ops.tokens_zip_unique_add_subbatch(
+            zipped, unzipped, index_unzipped, zipped_rows, subbatch_rows
+        )
+
+
+def merge_subbatch_cast(x, dtype):
+    """
+    将 zip_unzip_fusion=False 时的 float32 分块累加器合并为连续 tensor 并 cast 到目标 dtype。
+
+    zip_unzip_fusion=False 时，显存不足以分配完整 [S, H] 的输出 buffer，
+    因此用 list[Tensor] 分块累加（float32 保精度）。所有专家算完后调用此函数：
+      [chunk0_f32, chunk1_f32, ...] → concat + cast → result_bf16 [S, H]
+
+    如果 x 已经是单个 Tensor（zip_unzip_fusion=True 或只有一个分块），直接 cast。
+    """
+    if isinstance(x, (list, tuple)):
+        if len(x) == 1:
+            x = x[0]
+            return x.cast(dtype) if x.dtype != dtype else x
+        else:
+            return paddlefleet.ops.merge_subbatch_cast(x, dtype)
+    else:
+        return x.cast(dtype) if x.dtype != dtype else x

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -407,6 +407,10 @@ class TransformerConfig(ModelParallelConfig):
     moe_subbatch_token_num_after_dispatch: int | None = None
     """Whether to enable subbatch after dispatch, the value means the number of tokens in one subbatch."""
 
+    use_auto_subbatch: bool = False
+    """When True, dynamically determine subbatch sizes based on VMM free block analysis
+    instead of using a fixed moe_subbatch_token_num_after_dispatch value."""
+
     moe_grouped_gemm: bool = False
     """Whether to use grouped gemm."""
 

--- a/tests/single_card_tests/test_moe_auto_subbatch.py
+++ b/tests/single_card_tests/test_moe_auto_subbatch.py
@@ -1,0 +1,394 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Single-card unit tests for auto_subbatch functionality.
+
+Tests:
+  1. test_auto_subbatch_vs_ref: Compare auto_subbatch results against group_gemm reference.
+     - case1-4: split_gemm + selective_recompute (moe_expert_fusion=False),
+                varying tight_forward/tight_backward combinations.
+     - case5-7: group_gemm + selective_recompute (Level 0, moe_expert_fusion=True),
+                varying tight_forward/tight_backward combinations.
+     - case8-10: group_gemm + full_recompute (Level 0, fp8_quant_weight 预量化),
+                 varying tight_forward/tight_backward combinations.
+  2. test_vmm_utils: Unit tests for VMM utility functions.
+
+Note: Ordinary (non-auto) subbatch tests are in test_moe_subbatch.py.
+
+Run with:
+  python tests/single_card_tests/test_moe_auto_subbatch.py
+"""
+
+import contextlib
+import os
+import unittest
+
+import numpy as np
+
+os.environ["FLAGS_use_virtual_memory_auto_growth"] = "True"
+os.environ["FLAGS_cudnn_deterministic"] = "True"
+
+from types import SimpleNamespace
+
+import paddle
+from paddle import nn
+from paddle.device.cuda.memory_analyzer import MemoryAnalysisTool
+
+from paddlefleet.tensor_parallel.layers import (
+    ColumnParallelLinear,
+    RowParallelLinear,
+)
+from paddlefleet.tensor_parallel.random import model_parallel_cuda_manual_seed
+from paddlefleet.transformer.mlp import MLPSublayersSpec
+from paddlefleet.transformer.moe.fp8_utils import tilewise_quant
+from paddlefleet.transformer.moe.fusion_layer_utils import FusionMoePyLayer
+from paddlefleet.transformer.moe.moe_expert import StandardMLPExpert
+from paddlefleet.transformer.moe.moe_layer import MoELayer
+from paddlefleet.transformer.moe.vmm_utils import (
+    find_max_concurrent_subbatch_size,
+    find_max_sequence_subbatch_size,
+    vmm_free_and_growable_block_info,
+)
+from paddlefleet.transformer.transformer_config import TransformerConfig
+
+
+class FakeMOELayer(nn.Layer):
+    """
+    A mock MoE layer that provides the interface expected by FusionMoePyLayer.
+
+    Uses StandardMLPExpert (native PaddleFleet expert) for realistic testing.
+
+    Required attributes:
+      - self.experts: nn.LayerList of expert modules
+      - self.token_dispatcher._comm_manager.tokens_per_expert: list[int]
+    """
+
+    def __init__(
+        self,
+        hidden_size,
+        intermediate_size,
+        n_routed_experts,
+        tokens_per_expert,
+    ):
+        super().__init__()
+        config = TransformerConfig(
+            hidden_size=hidden_size,
+            gated_linear_unit=True,
+        )
+        mlp_spec = MLPSublayersSpec(
+            up_gate_proj=ColumnParallelLinear,
+            down_proj=RowParallelLinear,
+        )
+        self.experts = nn.LayerList(
+            [
+                StandardMLPExpert(
+                    config,
+                    moe_intermediate_size=intermediate_size,
+                    is_expert=True,
+                    mlp_spec=mlp_spec,
+                )
+                for _ in range(n_routed_experts)
+            ]
+        )
+        self.token_dispatcher = SimpleNamespace(
+            _comm_manager=SimpleNamespace(
+                tokens_per_expert=tokens_per_expert,
+            ),
+        )
+
+    def clear_main_grad(self):
+        for expert in self.experts:
+            expert.up_gate_proj.weight.main_grad = None
+            expert.down_proj.weight.main_grad = None
+
+    def fp8_quant_weight(self, batch_mode=False, quant_transpose=True):
+        """借用 MoELayer 的实现，对 expert 权重做 FP8 预量化。"""
+        # MoELayer.fp8_quant_weight 检查 self.moe_use_fusion_node and self.fp8
+        self.moe_use_fusion_node = True
+        self.fp8 = True
+        MoELayer.fp8_quant_weight(
+            self, batch_mode=batch_mode, quant_transpose=quant_transpose
+        )
+
+
+@contextlib.contextmanager
+def vmm_no_free_space():
+    """占用所有的 free block 并且禁止 growable 空间，假装没有多余显存"""
+    (old_value,) = paddle.framework.get_flags(
+        "FLAGS_max_reserved_threshold_in_gb"
+    ).values()
+    paddle.set_flags({"FLAGS_max_reserved_threshold_in_gb": 0})
+    buffers = []
+    for size, _ in MemoryAnalysisTool.vmm_free_block_info()[-1]:
+        buffers.append(paddle.empty([size], dtype="uint8"))
+    try:
+        yield
+    finally:
+        paddle.set_flags({"FLAGS_max_reserved_threshold_in_gb": old_value})
+        del buffers
+
+
+class TestAutoSubbatch(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """设置默认配置"""
+        model_parallel_cuda_manual_seed(1234)
+        cls.seq_len = 1000
+        cls.topk = 4
+        cls.hidden_size = 4096
+        cls.intermediate_size = 1536
+        cls.n_routed_experts = 8
+
+    def setUp(self):
+        """创建测试层和输入数据"""
+        paddle.seed(2026)
+        np.random.seed(2026)
+
+        hidden_states = paddle.randn(
+            [self.seq_len, self.hidden_size], "bfloat16"
+        )
+        hidden_states_out_grad = paddle.randn_like(hidden_states)
+        hidden_states, scale = tilewise_quant(hidden_states)
+        probs = paddle.randn([self.seq_len, self.topk])
+        hidden_states.stop_gradient = False
+        probs.stop_gradient = False
+
+        self.hidden_states = hidden_states
+        self.hidden_states_out_grad = hidden_states_out_grad
+        self.scale = scale
+        self.probs = probs
+
+        # 每个 token 随机分配 1 到 topk 个专家，但总是包括专家0，给专家0增加压力
+        indices_np = np.full([self.seq_len, self.topk], -1, dtype=np.int64)
+        tokens_per_expert = [0] * self.n_routed_experts
+        for i in range(self.seq_len):
+            chosen = np.array([0])
+            n_active = np.random.randint(self.topk)
+            if n_active > 0:
+                chosen = np.append(
+                    chosen,
+                    np.random.choice(
+                        self.n_routed_experts - 1,
+                        size=n_active,
+                        replace=False,
+                    )
+                    + 1,
+                )
+            indices_np[i, : n_active + 1] = np.sort(chosen)
+            for expert_id in chosen:
+                tokens_per_expert[expert_id] += 1
+        self.indices = paddle.to_tensor(indices_np)
+
+        moe_layer = FakeMOELayer(
+            self.hidden_size,
+            self.intermediate_size,
+            self.n_routed_experts,
+            tokens_per_expert,
+        )
+        moe_layer = paddle.amp.decorate(moe_layer, level="O2", dtype="bfloat16")
+        moe_layer.clear_main_grad()
+        self.moe_layer = moe_layer
+
+    def run_moe_layer(
+        self, is_ref=False, tight_forward=False, tight_backward=False, **kwargs
+    ):
+        params = {
+            "use_fp8_mlp": True,
+            "moe_deep_gemm": True,
+            "moe_grouped_gemm": False,
+            "recompute_moe_gate_up": True,
+            "dequant_input": True,
+            "moe_expert_fusion": True,
+            "recompute_moe_premute": False,
+            "use_bf16_gemm_weight_grad": True,
+            "fp8_dispatched_handle": {"scale": self.scale},
+            "use_auto_subbatch": not is_ref,
+        }
+        params.update(kwargs)
+
+        with vmm_no_free_space() if tight_forward else contextlib.nullcontext():
+            hidden_states = FusionMoePyLayer.apply(
+                self.hidden_states,
+                self.probs,
+                self.indices.clone(),
+                self.moe_layer,
+                self.topk,
+                **params,
+            )
+
+        with (
+            vmm_no_free_space() if tight_backward else contextlib.nullcontext()
+        ):
+            paddle.autograd.backward(hidden_states, self.hidden_states_out_grad)
+
+        hidden_states_grad = self.hidden_states.grad
+        probs_grad = self.probs.grad
+        self.hidden_states.clear_grad()
+        self.probs.clear_grad()
+
+        # 专家0最大，只要检查专家0的 weight_grad 即可
+        weight_grad = self.moe_layer.experts[0].down_proj.weight.main_grad
+        self.moe_layer.clear_main_grad()
+
+        # 收集诊断信息（仅 auto_subbatch 模式下有）
+        diag = None
+        node = getattr(self.moe_layer, "_fusion_node", None)
+        if node is not None:
+            diag = {
+                "fwd": getattr(node, "_fwd_diag", None),
+                "bwd": getattr(node, "_bwd_diag", None),
+            }
+
+        return hidden_states, hidden_states_grad, probs_grad, weight_grad, diag
+
+    def compare_results(self, ref_out, tgt_out, loose_weight=False):
+        for i, name in enumerate(
+            ["hidden_states", "hidden_states_grad", "probs_grad"]
+        ):
+            np.testing.assert_equal(
+                ref_out[i].float().numpy(),
+                tgt_out[i].float().numpy(),
+                name,
+            )
+        i += 1  # i = 3 → weight_grad
+        if loose_weight:
+            np.testing.assert_allclose(
+                ref_out[i].numpy(),
+                tgt_out[i].numpy(),
+                atol=0.01,
+                rtol=1e-4,
+            )
+        else:
+            np.testing.assert_equal(ref_out[i].numpy(), tgt_out[i].numpy())
+
+    def test_auto_subbatch_vs_ref(self):
+        """测试 auto_subbatch 的多种情况与 group_gemm 是否对齐"""
+        # group_gemm (reference, no auto_subbatch)
+        ref_out = self.run_moe_layer(is_ref=True)
+
+        cases = {}
+
+        # --- split_gemm + selective_recompute (moe_expert_fusion=False) ---
+        kwargs = {
+            "moe_expert_fusion": False,
+            "recompute_moe_premute": True,
+            "recompute_moe_gate_up": True,
+            "moe_subbatch_token_num_after_dispatch": 512,
+        }
+        # case1: 显存充裕
+        cases["case1 (split, plenty)"] = self.run_moe_layer(**kwargs)
+        # case2: 前向紧张
+        cases["case2 (split, tight_fwd)"] = self.run_moe_layer(
+            tight_forward=True, **kwargs
+        )
+        # case3: 反向紧张
+        cases["case3 (split, tight_bwd)"] = self.run_moe_layer(
+            tight_backward=True, **kwargs
+        )
+        # case4: 前向+反向都紧张
+        cases["case4 (split, tight_both)"] = self.run_moe_layer(
+            tight_forward=True, tight_backward=True, **kwargs
+        )
+
+        # --- group_gemm + selective_recompute (Level 0) ---
+        kwargs = {"recompute_moe_gate_up": True}
+        # case5: 显存充裕 → 走 3a group_gemm
+        cases["case5 (group, plenty)"] = self.run_moe_layer(**kwargs)
+        # case6: 前向紧张 → fallback 到逐专家
+        cases["case6 (group, tight_fwd)"] = self.run_moe_layer(
+            tight_forward=True, **kwargs
+        )
+        # case7: 反向紧张 → 前向 3a, 反向 fallback
+        cases["case7 (group, tight_bwd)"] = self.run_moe_layer(
+            tight_backward=True, **kwargs
+        )
+
+        # --- group_gemm + full_recompute (Level 0, 预量化权重) ---
+        self.moe_layer.fp8_quant_weight(batch_mode=True, quant_transpose=False)
+        # case8: 显存充裕
+        cases["case8 (prequant, plenty)"] = self.run_moe_layer()
+        # case9: 前向紧张
+        cases["case9 (prequant, tight_fwd)"] = self.run_moe_layer(
+            tight_forward=True
+        )
+        # case10: 反向紧张
+        cases["case10 (prequant, tight_bwd)"] = self.run_moe_layer(
+            tight_backward=True
+        )
+
+        # --- 打印诊断表格 ---
+        print("\n" + "=" * 100)
+        print("Auto-subbatch diagnostic summary")
+        print("=" * 100)
+        header = f"{'Case':<30} {'FWD path':<20} {'FWD sub_rows':>12} {'FWD zip':>8} {'BWD path':<25} {'BWD sub_rows':>12} {'BWD zip':>8}"
+        print(header)
+        print("-" * 100)
+        for name, result in cases.items():
+            diag = result[4]
+            if diag is None:
+                print(f"{name:<30} {'(no diag)'}")
+                continue
+            fwd = diag.get("fwd") or {}
+            bwd = diag.get("bwd") or {}
+            print(
+                f"{name:<30} "
+                f"{fwd.get('path', '-'):<20} "
+                f"{fwd.get('subbatch_rows', '-')!s:>12} "
+                f"{fwd.get('zip_unzip_fusion', '-')!s:>8} "
+                f"{bwd.get('path', '-'):<25} "
+                f"{bwd.get('subbatch_rows', '-')!s:>12} "
+                f"{bwd.get('zip_unzip_fusion', '-')!s:>8}"
+            )
+        print("=" * 100)
+
+        # --- 数值对比 ---
+        loose_cases = {
+            "case3 (split, tight_bwd)",
+            "case4 (split, tight_both)",
+        }
+        for name, result in cases.items():
+            with self.subTest(case=name):
+                self.compare_results(
+                    ref_out, result, loose_weight=(name in loose_cases)
+                )
+
+
+class TestVMMUtils(unittest.TestCase):
+    def test_vmm_utils(self):
+        """测试 vmm 相关搜索函数"""
+        old_func = MemoryAnalysisTool.vmm_all_block_info
+
+        # test empty heap
+        MemoryAnalysisTool.vmm_all_block_info = lambda: [[]]
+        info = vmm_free_and_growable_block_info()
+        self.assertEqual(len(info), 1)
+
+        # test heap with separate free blocks
+        MemoryAnalysisTool.vmm_all_block_info = lambda: [
+            [(1024, 0, True), (1024, 1024, False)]
+        ]
+        info = vmm_free_and_growable_block_info()
+        self.assertEqual(len(info), 2)
+
+        # test corner cases
+        self.assertEqual(find_max_concurrent_subbatch_size([]), 1)
+        self.assertEqual(find_max_sequence_subbatch_size(1024, 1), 1)
+
+        MemoryAnalysisTool.vmm_all_block_info = old_func
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/test_moe_subbatch.py
+++ b/tests/single_card_tests/test_moe_subbatch.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Single-card unit tests for ordinary (non-auto) subbatch functionality.
+
+Tests:
+  1. test_subbatch_vs_ref: Compare ordinary subbatch results against group_gemm reference.
+     - split_gemm + selective_recompute (moe_expert_fusion=False,
+       use_auto_subbatch=False).
+
+Run with:
+  python tests/single_card_tests/test_moe_subbatch.py
+"""
+
+import os
+import unittest
+
+import numpy as np
+
+# os.environ["FLAGS_use_virtual_memory_auto_growth"] = "True"
+os.environ["FLAGS_cudnn_deterministic"] = "True"
+
+from types import SimpleNamespace
+
+import paddle
+from paddle import nn
+
+from paddlefleet.tensor_parallel.layers import (
+    ColumnParallelLinear,
+    RowParallelLinear,
+)
+from paddlefleet.tensor_parallel.random import model_parallel_cuda_manual_seed
+from paddlefleet.transformer.mlp import MLPSublayersSpec
+from paddlefleet.transformer.moe.fp8_utils import tilewise_quant
+from paddlefleet.transformer.moe.fusion_layer_utils import FusionMoePyLayer
+from paddlefleet.transformer.moe.moe_expert import StandardMLPExpert
+from paddlefleet.transformer.transformer_config import TransformerConfig
+
+
+class FakeMOELayer(nn.Layer):
+    """
+    A mock MoE layer that provides the interface expected by FusionMoePyLayer.
+
+    Uses StandardMLPExpert (native PaddleFleet expert) for realistic testing.
+
+    Required attributes:
+      - self.experts: nn.LayerList of expert modules
+      - self.token_dispatcher._comm_manager.tokens_per_expert: list[int]
+    """
+
+    def __init__(
+        self,
+        hidden_size,
+        intermediate_size,
+        n_routed_experts,
+        tokens_per_expert,
+    ):
+        super().__init__()
+        config = TransformerConfig(
+            hidden_size=hidden_size,
+            gated_linear_unit=True,
+        )
+        mlp_spec = MLPSublayersSpec(
+            up_gate_proj=ColumnParallelLinear,
+            down_proj=RowParallelLinear,
+        )
+        self.experts = nn.LayerList(
+            [
+                StandardMLPExpert(
+                    config,
+                    moe_intermediate_size=intermediate_size,
+                    is_expert=True,
+                    mlp_spec=mlp_spec,
+                )
+                for _ in range(n_routed_experts)
+            ]
+        )
+        self.token_dispatcher = SimpleNamespace(
+            _comm_manager=SimpleNamespace(
+                tokens_per_expert=tokens_per_expert,
+            ),
+        )
+
+    def clear_main_grad(self):
+        for expert in self.experts:
+            expert.up_gate_proj.weight.main_grad = None
+            expert.down_proj.weight.main_grad = None
+
+
+class TestSubbatch(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """设置默认配置"""
+        model_parallel_cuda_manual_seed(1234)
+        cls.seq_len = 1000
+        cls.topk = 4
+        cls.hidden_size = 4096
+        cls.intermediate_size = 1536
+        cls.n_routed_experts = 8
+
+    def setUp(self):
+        """创建测试层和输入数据"""
+        paddle.seed(2026)
+        np.random.seed(2026)
+
+        hidden_states = paddle.randn(
+            [self.seq_len, self.hidden_size], "bfloat16"
+        )
+        hidden_states_out_grad = paddle.randn_like(hidden_states)
+        hidden_states, scale = tilewise_quant(hidden_states)
+        probs = paddle.randn([self.seq_len, self.topk])
+        hidden_states.stop_gradient = False
+        probs.stop_gradient = False
+
+        self.hidden_states = hidden_states
+        self.hidden_states_out_grad = hidden_states_out_grad
+        self.scale = scale
+        self.probs = probs
+
+        # 每个 token 随机分配 1 到 topk 个专家，但总是包括专家0，给专家0增加压力
+        indices_np = np.full([self.seq_len, self.topk], -1, dtype=np.int64)
+        tokens_per_expert = [0] * self.n_routed_experts
+        for i in range(self.seq_len):
+            chosen = np.array([0])
+            n_active = np.random.randint(self.topk)
+            if n_active > 0:
+                chosen = np.append(
+                    chosen,
+                    np.random.choice(
+                        self.n_routed_experts - 1,
+                        size=n_active,
+                        replace=False,
+                    )
+                    + 1,
+                )
+            indices_np[i, : n_active + 1] = np.sort(chosen)
+            for expert_id in chosen:
+                tokens_per_expert[expert_id] += 1
+        self.indices = paddle.to_tensor(indices_np)
+
+        moe_layer = FakeMOELayer(
+            self.hidden_size,
+            self.intermediate_size,
+            self.n_routed_experts,
+            tokens_per_expert,
+        )
+        moe_layer = paddle.amp.decorate(moe_layer, level="O2", dtype="bfloat16")
+        moe_layer.clear_main_grad()
+        self.moe_layer = moe_layer
+
+    def run_moe_layer(
+        self, is_ref=False, tight_forward=False, tight_backward=False, **kwargs
+    ):
+        params = {
+            "use_fp8_mlp": True,
+            "moe_deep_gemm": True,
+            "moe_grouped_gemm": False,
+            "recompute_moe_gate_up": True,
+            "dequant_input": True,
+            "moe_expert_fusion": True,
+            "recompute_moe_premute": False,
+            "use_bf16_gemm_weight_grad": True,
+            "fp8_dispatched_handle": {"scale": self.scale},
+            "use_auto_subbatch": False,
+        }
+        params.update(kwargs)
+
+        hidden_states = FusionMoePyLayer.apply(
+            self.hidden_states,
+            self.probs,
+            self.indices.clone(),
+            self.moe_layer,
+            self.topk,
+            **params,
+        )
+
+        paddle.autograd.backward(hidden_states, self.hidden_states_out_grad)
+
+        hidden_states_grad = self.hidden_states.grad
+        probs_grad = self.probs.grad
+        self.hidden_states.clear_grad()
+        self.probs.clear_grad()
+
+        # 专家0最大，只要检查专家0的 weight_grad 即可
+        weight_grad = self.moe_layer.experts[0].down_proj.weight.main_grad
+        self.moe_layer.clear_main_grad()
+
+        return hidden_states, hidden_states_grad, probs_grad, weight_grad
+
+    def compare_results(self, ref_out, tgt_out, loose_weight=False):
+        for i, name in enumerate(
+            ["hidden_states", "hidden_states_grad", "probs_grad"]
+        ):
+            np.testing.assert_equal(
+                ref_out[i].float().numpy(),
+                tgt_out[i].float().numpy(),
+                name,
+            )
+        i += 1
+        if loose_weight:
+            np.testing.assert_allclose(
+                ref_out[i].numpy(),
+                tgt_out[i].numpy(),
+                atol=1.0,
+                rtol=1e-5,
+            )
+        else:
+            np.testing.assert_equal(ref_out[i].numpy(), tgt_out[i].numpy())
+
+    def test_subbatch_vs_ref(self):
+        """测试普通 subbatch (非 auto_subbatch) 的多种情况与 group_gemm 是否对齐"""
+        # group_gemm (reference, moe_expert_fusion=True, no subbatch)
+        ref_out = self.run_moe_layer(is_ref=True)
+
+        # --- split_gemm + selective_recompute (普通 subbatch，非 auto_subbatch) ---
+        kwargs = {
+            "moe_expert_fusion": False,
+            "recompute_moe_premute": True,
+            "recompute_moe_gate_up": True,
+            "moe_subbatch_token_num_after_dispatch": 512,
+        }
+        # case: 显存充裕
+        out = self.run_moe_layer(**kwargs)
+
+        # split_gemm vs group_gemm 路径有固有精度差，weight_grad 允许有小误差
+        self.compare_results(ref_out, out, loose_weight=True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

  - 添加subbatch（固定切分）和 auto_subbatch（基于 VMM 空闲显存动态切分）能力到 PaddleFleet，同时在迁移过程中修复部分fp8问题。

  ## Changes

 ### 主要修改

  **1. 新增 auto_subbatch 前向/反向（fusion_layer_utils.py）**

  - 新增 forward_auto_subbatch / backward_auto_subbatch，根据 VMM 空闲 block 动态决定 subbatch 大小，无需用户手动配置 moe_subbatch_token_num_after_dispatch。
  - 新增辅助方法：subbatch_unzip_and_prepare_gemm_node、subbatch_prepare_gemm_node、gemm_forward_subbatch、fallback_to_no_expert_fusion、slice_fp8_weight 等。
  - 支持 moe_expert_fusion=False（split_gemm）路径的 subbatch。

  **2. 新增 vmm_utils.py**
  - vmm_free_and_growable_block_info()：获取当前 VMM 空闲 block + 堆顶可增长空间。
  - find_max_concurrent_subbatch_size(feature_sizes)：启发式搜索最大 subbatch_size，使多个临时 tensor 能同时分配到现有空闲碎片中。
  - find_max_sequence_subbatch_size(feature_size, length)：找到最大 subbatch 使序列维切分后能分配。
  - tokens_zip_unique_add_with_subbatch / merge_subbatch_cast：zip_unzip_fusion=False 时的分块累加与合并。
  
**3. 修复 swiglu backward 相关问题（fp8_utils.py）**
  - inplace swiglu_bwd 支持：优先使用 FusedQuantOps.fused_swiglu_probs_bwd(inplace=True)，do1 与 o1 共用 buffer
  - 移除不必要的 _record_stream()：input_fp8 的 _record_stream() 会触发 VMM 积极回收物理页，在 nparts loop 中可能导致后续 slice 的物理页被提前回收，改为直接 = None。
- [ ] TODO： 后续将fused_swiglu_probs_bwd算子统一到fleet中

**4. FP8 预量化逻辑统一（moe_layer.py + fp8_utils.py）**
  - fp8_quant_weight 重构：始终量化非转置版（fp8_weight_stacked 始终存在），quant_transpose=True/None 时额外量化转置版，quant_transpose=False 时不量化转置版（设为 None）。行为对齐。
  - _get_fp8_weight_and_scale 增强：当需要转置版但只有非转置版时，on-the-fly reshape + transpose。
  - fused_stack_quant 简化：统一从 fp8_weight_stacked 获取，通过 _get_fp8_weight_and_scale(transpose=...) 按需转置。
  - 移除 bwd_down_input_fp8 和 bwd_gate_up_input_fp8 中的 dead transpose guard：原来检查 has fp8_weight_stacked_transpose and not has fp8_weight_stacked 的分支在重构后不可能触发，已删除。
 - fp8_quant_blockwise 的 output_scale_transpose 统一为 False，移除手动 .T 转置。
  - split_group_gemm 中 w_fp8[i] / w_scale[i] 加 .contiguous() 确保内存连续。
  - UnZipNode.forward / ZipNode.backward 新增 do_gather 参数控制是否实际执行 gather。
  - 新增 tilewise_quant 工具函数。

**5. 单测**
  - 新增 test_moe_auto_subbatch.py：10 个子 case 覆盖 split_gemm / group_gemm / 预量化权重 × 显存充裕/前向紧张/反向紧张/双紧张，对比 auto_subbatch vs group_gemm 参考输出。
  - 新增 test_moe_subbatch.py：普通固定 subbatch（非 auto）对比 group_gemm 参考输出。

### 影响范围
 FP8 预量化行为变化：fp8_weight_stacked（非转置版）现在始终被量化，行为对齐。具体影响：
  
<img width="886" height="122" alt="image" src="https://github.com/user-attachments/assets/9f0e942a-4e90-4b39-9a1c-3b9977a62f20" />


