### PR TITLE
[Feature] Support fused vision RoPE kernel for high_precision_rope

### DIFF
--- a/src/paddlefleet/models/common/embeddings/rope_utils.py
+++ b/src/paddlefleet/models/common/embeddings/rope_utils.py
@@ -137,11 +137,13 @@ def _apply_rotary_pos_emb_bshd(
     # Normalize mscale to avoid TypeError when None is passed
     mscale = mscale if mscale is not None else 1.0
 
-    # Fused vision RoPE CUDA kernel path:
-    # - internally computes cos/sin in fp32, equivalent to high_precision_rope
-    # - only supports single Tensor input with explicit freqs
-    # - only supports non-interleaved mode and mscale=1.0
-    # - freqs must be reshaped to [s, dim//2]
+    if apply_rope_fusion:
+        if high_precision_rope:
+            # Fused vision RoPE CUDA kernel path:
+            # - internally computes cos/sin in fp32, equivalent to high_precision_rope
+            # - only supports single Tensor input with explicit freqs
+            # - only supports non-interleaved mode and mscale=1.0
+            # - freqs must be reshaped to [s, dim//2]
             if (
                 not rotary_interleaved
                 and mscale == 1.0

--- a/src/paddlefleet/models/common/embeddings/rope_utils.py
+++ b/src/paddlefleet/models/common/embeddings/rope_utils.py
@@ -141,8 +141,8 @@ def _apply_rotary_pos_emb_bshd(
         if high_precision_rope:
             # Fused vision RoPE CUDA kernel path:
             # - internally computes cos/sin in fp32, equivalent to high_precision_rope
+            # - only supports single Tensor input with explicit freqs
             # - only supports non-interleaved mode and mscale=1.0
-            # - requires a single Tensor input and explicit freqs
             # - freqs must be reshaped to [s, dim//2]
             if (
                 not rotary_interleaved
@@ -159,8 +159,7 @@ def _apply_rotary_pos_emb_bshd(
                 freqs_half = freqs_2d[..., : freqs_2d.shape[-1] // 2]
                 t = fused_apply_rotary_pos_emb_vision(t, freqs_half)
                 return paddle.cat((t, t_pass), axis=-1)
-            # Fall through to unfused path for interleaved, tuple input,
-            # or non-unit mscale
+            # Fall through to unfused path for unsupported cases
         # Fused path: delegate to Paddle's fused_rope kernel
         assert isinstance(t, tuple), (
             "The input for fused_rope should be a tuple of tensors"

--- a/src/paddlefleet/models/common/embeddings/rope_utils.py
+++ b/src/paddlefleet/models/common/embeddings/rope_utils.py
@@ -160,19 +160,20 @@ def _apply_rotary_pos_emb_bshd(
                 t = fused_apply_rotary_pos_emb_vision(t, freqs_half)
                 return paddle.cat((t, t_pass), axis=-1)
             # Fall through to unfused path for unsupported cases
-        # Fused path: delegate to Paddle's fused_rope kernel
-        assert isinstance(t, tuple), (
-            "The input for fused_rope should be a tuple of tensors"
-        )
-        return fused_rope(
-            *t,
-            sin=sin,
-            cos=cos,
-            rotary_emb_base=rope_theta,
-            position_ids=position_ids,
-            use_neox_rotary_style=rotary_interleaved,
-            time_major=time_major,
-        )
+        else:
+            # Fused path: delegate to Paddle's fused_rope kernel
+            assert isinstance(t, tuple), (
+                "The input for fused_rope should be a tuple of tensors"
+            )
+            return fused_rope(
+                *t,
+                sin=sin,
+                cos=cos,
+                rotary_emb_base=rope_theta,
+                position_ids=position_ids,
+                use_neox_rotary_style=rotary_interleaved,
+                time_major=time_major,
+            )
 
     rot_dim = freqs.shape[-1]
 

--- a/src/paddlefleet/models/common/embeddings/rope_utils.py
+++ b/src/paddlefleet/models/common/embeddings/rope_utils.py
@@ -28,6 +28,7 @@ from paddle.incubate.nn.functional import (
     fused_rotary_position_embedding as fused_rope,
 )
 
+from paddlefleet.ops import fused_apply_rotary_pos_emb_vision
 from paddlefleet.utils import get_pg_rank, get_pg_size
 
 logger = logging.getLogger(__name__)
@@ -133,12 +134,33 @@ def _apply_rotary_pos_emb_bshd(
     Returns:
         Tensor | tuple[Tensor, ...]: The input tensor(s) after applying RoPE.
     """
+    # Normalize mscale to avoid TypeError when None is passed
+    mscale = mscale if mscale is not None else 1.0
+
     if apply_rope_fusion:
         if high_precision_rope:
-            raise NotImplementedError(
-                "high_precision_rope is not yet supported with "
-                "apply_rope_fusion in bshd format"
-            )
+            # Fused vision RoPE CUDA kernel path:
+            # - internally computes cos/sin in fp32, equivalent to high_precision_rope
+            # - only supports non-interleaved mode and mscale=1.0
+            # - requires a single Tensor input and explicit freqs
+            # - freqs must be reshaped to [s, dim//2]
+            if (
+                not rotary_interleaved
+                and mscale == 1.0
+                and freqs is not None
+                and not isinstance(t, tuple)
+            ):
+                rot_dim = freqs.shape[-1]
+                t, t_pass = t[..., :rot_dim], t[..., rot_dim:]
+                if freqs.ndim == 3:
+                    freqs_2d = freqs.reshape([-1, freqs.shape[-1]])
+                else:
+                    freqs_2d = freqs
+                freqs_half = freqs_2d[..., : freqs_2d.shape[-1] // 2]
+                t = fused_apply_rotary_pos_emb_vision(t, freqs_half)
+                return paddle.cat((t, t_pass), axis=-1)
+            # Fall through to unfused path for interleaved, tuple input,
+            # or non-unit mscale
         # Fused path: delegate to Paddle's fused_rope kernel
         assert isinstance(t, tuple), (
             "The input for fused_rope should be a tuple of tensors"

--- a/src/paddlefleet/models/common/embeddings/rope_utils.py
+++ b/src/paddlefleet/models/common/embeddings/rope_utils.py
@@ -137,13 +137,11 @@ def _apply_rotary_pos_emb_bshd(
     # Normalize mscale to avoid TypeError when None is passed
     mscale = mscale if mscale is not None else 1.0
 
-    if apply_rope_fusion:
-        if high_precision_rope:
-            # Fused vision RoPE CUDA kernel path:
-            # - internally computes cos/sin in fp32, equivalent to high_precision_rope
-            # - only supports single Tensor input with explicit freqs
-            # - only supports non-interleaved mode and mscale=1.0
-            # - freqs must be reshaped to [s, dim//2]
+    # Fused vision RoPE CUDA kernel path:
+    # - internally computes cos/sin in fp32, equivalent to high_precision_rope
+    # - only supports single Tensor input with explicit freqs
+    # - only supports non-interleaved mode and mscale=1.0
+    # - freqs must be reshaped to [s, dim//2]
             if (
                 not rotary_interleaved
                 and mscale == 1.0

--- a/tests/single_card_tests/transformer/test_rope.py
+++ b/tests/single_card_tests/transformer/test_rope.py
@@ -22,9 +22,9 @@ from paddle.incubate.nn.functional import (
 )
 
 from paddlefleet.models.common.embeddings import (
-    apply_rotary_pos_emb,
     RotaryEmbedding,
     YarnRotaryEmbedding,
+    apply_rotary_pos_emb,
 )
 
 
@@ -64,17 +64,14 @@ class TestYarnRotaryEmbedding(unittest.TestCase):
 class TestYarnRotaryEmbeddingInterleaved(unittest.TestCase):
     def test_forward_raises_when_interleaved(self):
         with self.assertRaises(AssertionError):
-            rope = YarnRotaryEmbedding(
-                8, 1.0, rotary_interleaved=True
-            )
+            rope = YarnRotaryEmbedding(8, 1.0, rotary_interleaved=True)
             rope(64)
 
 
 def build_freqs_half(seq_len, rot_dim, rope_theta=10000.0):
     positions = paddle.arange(seq_len, dtype="float32")
     inv_freq = 1.0 / (
-        rope_theta
-        ** (paddle.arange(0, rot_dim, 2, dtype="float32") / rot_dim)
+        rope_theta ** (paddle.arange(0, rot_dim, 2, dtype="float32") / rot_dim)
     )
     return paddle.outer(positions, inv_freq)
 
@@ -89,7 +86,9 @@ def build_cos_sin(freqs):
     return cos, sin
 
 
-def make_config(apply_rope_fusion, high_precision_rope, rotary_interleaved=False):
+def make_config(
+    apply_rope_fusion, high_precision_rope, rotary_interleaved=False
+):
     return SimpleNamespace(
         apply_rope_fusion=apply_rope_fusion,
         rotary_interleaved=rotary_interleaved,
@@ -101,7 +100,9 @@ def make_config(apply_rope_fusion, high_precision_rope, rotary_interleaved=False
 
 
 def apply_fused_rope_reference(x, freqs):
-    freqs_2d = freqs.reshape([-1, freqs.shape[-1]]) if freqs.ndim == 3 else freqs
+    freqs_2d = (
+        freqs.reshape([-1, freqs.shape[-1]]) if freqs.ndim == 3 else freqs
+    )
     rot_dim = freqs_2d.shape[-1]
     cos, sin = build_cos_sin(freqs_2d)
     rotated, _, _ = fused_rope(
@@ -132,7 +133,9 @@ class TestApplyRotaryPosEmbFusedHighPrecision(unittest.TestCase):
         ).astype("bfloat16")
         freqs = build_freqs(build_freqs_half(seq_len, rot_dim))
 
-        fused_config = make_config(apply_rope_fusion=True, high_precision_rope=True)
+        fused_config = make_config(
+            apply_rope_fusion=True, high_precision_rope=True
+        )
         fused_out = apply_rotary_pos_emb(
             x,
             freqs,
@@ -154,7 +157,9 @@ class TestApplyRotaryPosEmbFusedHighPrecision(unittest.TestCase):
         ).astype("bfloat16")
         freqs = build_freqs(build_freqs_half(seq_len, hidden_dim)).unsqueeze(0)
 
-        fused_config = make_config(apply_rope_fusion=True, high_precision_rope=True)
+        fused_config = make_config(
+            apply_rope_fusion=True, high_precision_rope=True
+        )
         fused_out = apply_rotary_pos_emb(
             x,
             freqs,
@@ -176,7 +181,9 @@ class TestApplyRotaryPosEmbFusedHighPrecision(unittest.TestCase):
         ).astype("bfloat16")
         freqs = build_freqs(build_freqs_half(seq_len, hidden_dim))
 
-        fused_config = make_config(apply_rope_fusion=True, high_precision_rope=True)
+        fused_config = make_config(
+            apply_rope_fusion=True, high_precision_rope=True
+        )
         ref_config = make_config(
             apply_rope_fusion=False, high_precision_rope=False
         )

--- a/tests/single_card_tests/transformer/test_rope.py
+++ b/tests/single_card_tests/transformer/test_rope.py
@@ -13,10 +13,16 @@
 # limitations under the License.
 
 import unittest
+from types import SimpleNamespace
 
+import numpy as np
 import paddle
+from paddle.incubate.nn.functional import (
+    fused_rotary_position_embedding as fused_rope,
+)
 
 from paddlefleet.models.common.embeddings import (
+    apply_rotary_pos_emb,
     RotaryEmbedding,
     YarnRotaryEmbedding,
 )
@@ -56,15 +62,192 @@ class TestYarnRotaryEmbedding(unittest.TestCase):
 
 
 class TestYarnRotaryEmbeddingInterleaved(unittest.TestCase):
+    def test_forward_raises_when_interleaved(self):
+        with self.assertRaises(AssertionError):
+            rope = YarnRotaryEmbedding(
+                8, 1.0, rotary_interleaved=True
+            )
+            rope(64)
+
+
+def build_freqs_half(seq_len, rot_dim, rope_theta=10000.0):
+    positions = paddle.arange(seq_len, dtype="float32")
+    inv_freq = 1.0 / (
+        rope_theta
+        ** (paddle.arange(0, rot_dim, 2, dtype="float32") / rot_dim)
+    )
+    return paddle.outer(positions, inv_freq)
+
+
+def build_freqs(freqs_half):
+    return paddle.concat([freqs_half, freqs_half], axis=-1)
+
+
+def build_cos_sin(freqs):
+    cos = paddle.cos(freqs).reshape([1, freqs.shape[0], 1, freqs.shape[-1]])
+    sin = paddle.sin(freqs).reshape([1, freqs.shape[0], 1, freqs.shape[-1]])
+    return cos, sin
+
+
+def make_config(apply_rope_fusion, high_precision_rope, rotary_interleaved=False):
+    return SimpleNamespace(
+        apply_rope_fusion=apply_rope_fusion,
+        rotary_interleaved=rotary_interleaved,
+        multi_latent_attention=False,
+        high_precision_rope=high_precision_rope,
+        rope_theta=10000.0,
+        sequence_parallel=False,
+    )
+
+
+def apply_fused_rope_reference(x, freqs):
+    freqs_2d = freqs.reshape([-1, freqs.shape[-1]]) if freqs.ndim == 3 else freqs
+    rot_dim = freqs_2d.shape[-1]
+    cos, sin = build_cos_sin(freqs_2d)
+    rotated, _, _ = fused_rope(
+        x[..., :rot_dim].astype("float32"),
+        sin=sin,
+        cos=cos,
+        use_neox_rotary_style=False,
+    )
+    rotated = rotated.astype(x.dtype)
+    return paddle.cat((rotated, x[..., rot_dim:]), axis=-1)
+
+
+class TestApplyRotaryPosEmbFusedHighPrecision(unittest.TestCase):
     def setUp(self):
-        self.head_dim = 8
-        self.rotary_percent = 1.0
-        self.rope = YarnRotaryEmbedding(
-            self.head_dim, self.rotary_percent, rotary_interleaved=True
+        if not paddle.is_compiled_with_cuda():
+            self.skipTest("CUDA is not available")
+        paddle.set_device("gpu")
+        paddle.seed(2026)
+
+    def assertTensorExactEqual(self, actual, expected):
+        np.testing.assert_array_equal(actual.numpy(), expected.numpy())
+
+    def test_high_precision_fused_matches_fp32_cast_for_2d_freqs(self):
+        batch_size, seq_len, num_heads, hidden_dim = 2, 128, 8, 88
+        rot_dim = 72
+        x = paddle.randn(
+            [batch_size, seq_len, num_heads, hidden_dim], dtype="float32"
+        ).astype("bfloat16")
+        freqs = build_freqs(build_freqs_half(seq_len, rot_dim))
+
+        fused_config = make_config(apply_rope_fusion=True, high_precision_rope=True)
+        fused_out = apply_rotary_pos_emb(
+            x,
+            freqs,
+            cos=None,
+            sin=None,
+            config=fused_config,
+            mscale=1.0,
+        )
+        ref_out = apply_fused_rope_reference(x, freqs)
+
+        self.assertTensorExactEqual(fused_out, ref_out)
+
+    def test_high_precision_fused_matches_fp32_cast_for_3d_freqs_and_none_mscale(
+        self,
+    ):
+        batch_size, seq_len, num_heads, hidden_dim = 1, 256, 16, 72
+        x = paddle.randn(
+            [batch_size, seq_len, num_heads, hidden_dim], dtype="float32"
+        ).astype("bfloat16")
+        freqs = build_freqs(build_freqs_half(seq_len, hidden_dim)).unsqueeze(0)
+
+        fused_config = make_config(apply_rope_fusion=True, high_precision_rope=True)
+        fused_out = apply_rotary_pos_emb(
+            x,
+            freqs,
+            cos=None,
+            sin=None,
+            config=fused_config,
+            mscale=None,
+        )
+        ref_out = apply_fused_rope_reference(x, freqs)
+
+        self.assertTensorExactEqual(fused_out, ref_out)
+
+    def test_high_precision_fused_falls_back_to_unfused_path_when_mscale_changes(
+        self,
+    ):
+        batch_size, seq_len, num_heads, hidden_dim = 1, 96, 4, 72
+        x = paddle.randn(
+            [batch_size, seq_len, num_heads, hidden_dim], dtype="float32"
+        ).astype("bfloat16")
+        freqs = build_freqs(build_freqs_half(seq_len, hidden_dim))
+
+        fused_config = make_config(apply_rope_fusion=True, high_precision_rope=True)
+        ref_config = make_config(
+            apply_rope_fusion=False, high_precision_rope=False
         )
 
-    def test_forward_raises_when_interleaved(self):
-        self.rope(64)
+        fused_out = apply_rotary_pos_emb(
+            x,
+            freqs,
+            cos=None,
+            sin=None,
+            config=fused_config,
+            mscale=0.5,
+        )
+        ref_out = apply_rotary_pos_emb(
+            x.astype("float32"),
+            freqs,
+            cos=None,
+            sin=None,
+            config=ref_config,
+            mscale=0.5,
+        ).astype(x.dtype)
+
+        self.assertTensorExactEqual(fused_out, ref_out)
+
+    def test_non_high_precision_fused_delegates_to_paddle_fused_rope(self):
+        batch_size, seq_len, num_heads, hidden_dim = 2, 64, 8, 72
+        q = paddle.randn(
+            [batch_size, seq_len, num_heads, hidden_dim], dtype="float32"
+        )
+        k = paddle.randn(
+            [batch_size, seq_len, num_heads, hidden_dim], dtype="float32"
+        )
+        freqs = build_freqs(build_freqs_half(seq_len, hidden_dim))
+        cos, sin = build_cos_sin(freqs)
+
+        config = make_config(apply_rope_fusion=True, high_precision_rope=False)
+
+        fused_q, fused_k, _ = apply_rotary_pos_emb(
+            (q, k),
+            freqs=None,
+            cos=cos,
+            sin=sin,
+            config=config,
+        )
+        ref_q, ref_k, _ = fused_rope(
+            q,
+            k,
+            sin=sin,
+            cos=cos,
+            use_neox_rotary_style=False,
+        )
+
+        self.assertTensorExactEqual(fused_q, ref_q)
+        self.assertTensorExactEqual(fused_k, ref_k)
+
+    def test_non_high_precision_fused_requires_tuple_input(self):
+        x = paddle.randn([1, 32, 4, 72], dtype="float32")
+        freqs = build_freqs(build_freqs_half(32, 72))
+        cos, sin = build_cos_sin(freqs)
+        config = make_config(apply_rope_fusion=True, high_precision_rope=False)
+
+        with self.assertRaisesRegex(
+            AssertionError,
+            "The input for fused_rope should be a tuple of tensors",
+        ):
+            apply_rotary_pos_emb(
+                x,
+                freqs=None,
+                cos=cos,
+                sin=sin,
+                config=config,
+            )
 
 
 if __name__ == "__main__":

--- a/tests/single_card_tests/transformer/test_rope.py
+++ b/tests/single_card_tests/transformer/test_rope.py
@@ -62,10 +62,20 @@ class TestYarnRotaryEmbedding(unittest.TestCase):
 
 
 class TestYarnRotaryEmbeddingInterleaved(unittest.TestCase):
-    def test_forward_raises_when_interleaved(self):
-        with self.assertRaises(AssertionError):
-            rope = YarnRotaryEmbedding(8, 1.0, rotary_interleaved=True)
-            rope(64)
+    def test_forward_returns_interleaved_freqs(self):
+        rope = YarnRotaryEmbedding(8, 1.0, rotary_interleaved=True)
+        output, mscale = rope(64)
+        assert output.shape[0] == 1
+        assert output.shape[1] == 64
+        assert output.shape[2] == 1
+        assert output.shape[3] == 8
+        assert output.dtype == paddle.float32
+        assert output.place.is_gpu_place()
+        assert mscale == 1.0
+        np.testing.assert_array_equal(
+            output[0, :, 0, 0::2].numpy(),
+            output[0, :, 0, 1::2].numpy(),
+        )
 
 
 def build_freqs_half(seq_len, rot_dim, rope_theta=10000.0):
@@ -185,7 +195,7 @@ class TestApplyRotaryPosEmbFusedHighPrecision(unittest.TestCase):
             apply_rope_fusion=True, high_precision_rope=True
         )
         ref_config = make_config(
-            apply_rope_fusion=False, high_precision_rope=False
+            apply_rope_fusion=False, high_precision_rope=True
         )
 
         fused_out = apply_rotary_pos_emb(
@@ -197,13 +207,52 @@ class TestApplyRotaryPosEmbFusedHighPrecision(unittest.TestCase):
             mscale=0.5,
         )
         ref_out = apply_rotary_pos_emb(
-            x.astype("float32"),
+            x,
             freqs,
             cos=None,
             sin=None,
             config=ref_config,
             mscale=0.5,
-        ).astype(x.dtype)
+        )
+
+        self.assertTensorExactEqual(fused_out, ref_out)
+
+    def test_high_precision_fused_falls_back_to_unfused_path_when_interleaved(
+        self,
+    ):
+        batch_size, seq_len, num_heads, hidden_dim = 1, 96, 4, 72
+        x = paddle.randn(
+            [batch_size, seq_len, num_heads, hidden_dim], dtype="float32"
+        ).astype("bfloat16")
+        freqs = build_freqs(build_freqs_half(seq_len, hidden_dim))
+
+        fused_config = make_config(
+            apply_rope_fusion=True,
+            high_precision_rope=True,
+            rotary_interleaved=True,
+        )
+        ref_config = make_config(
+            apply_rope_fusion=False,
+            high_precision_rope=True,
+            rotary_interleaved=True,
+        )
+
+        fused_out = apply_rotary_pos_emb(
+            x,
+            freqs,
+            cos=None,
+            sin=None,
+            config=fused_config,
+            mscale=1.0,
+        )
+        ref_out = apply_rotary_pos_emb(
+            x,
+            freqs,
+            cos=None,
+            sin=None,
+            config=ref_config,
+            mscale=1.0,
+        )
 
         self.assertTensorExactEqual(fused_out, ref_out)
 


### PR DESCRIPTION
## Summary
- 将 `apply_rope_fusion + high_precision_rope` 分支从 `NotImplementedError` 替换为 `fused_apply_rotary_pos_emb_vision` CUDA kernel 调用
- 该 kernel 内部以 fp32 精度计算 cos/sin，等价于 `high_precision_rope` 的语义，但性能更优
- 仅在 `rotary_interleaved=False` 且 `mscale=1.0` 时走 fused 路径，否则 fall through 到 unfused fp32 路径

## Test plan
- [ ] `python -m py_compile` 通过
- [ ] 单卡 Qwen-VL 训练验证 fused vision RoPE 路径正确性

🤖 Generated with [Claude Code](https://claude.com/claude-code)