### PR TITLE
[Cleanup] Replace torch proxy alias with public compat API

### DIFF
--- a/src/paddlefleet/_extensions/flashmask/rr_attn_estimate_triton_op.py
+++ b/src/paddlefleet/_extensions/flashmask/rr_attn_estimate_triton_op.py
@@ -1050,7 +1050,7 @@ def _prepare_stride_maxmin_ptrs(
     )
 
 
-@paddle.compat.use_torch_proxy_guard()
+@paddle.use_compat_guard()
 def rr_attn_estimate_triton_func(
     q: paddle.Tensor,
     k: paddle.Tensor,

--- a/src/paddlefleet/_extensions/flashmask/rr_attn_estimate_triton_op.py
+++ b/src/paddlefleet/_extensions/flashmask/rr_attn_estimate_triton_op.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass
 
 import paddle
 
-# paddle.compat.enable_torch_proxy()
+# paddle.enable_compat()
 import triton
 import triton.language as tl
 

--- a/src/paddlefleet/ops/__init__.py
+++ b/src/paddlefleet/ops/__init__.py
@@ -31,18 +31,18 @@ from .utils import (
     patch_module_namespace,
 )
 
-# paddle.compat.enable_torch_proxy(scope={"triton"}) enables the torch proxy
+# paddle.enable_compat(scope={"triton"}) enables the torch proxy
 # specifically for the 'triton' module. This means `import torch` inside 'triton'
 # will actually import paddle's compatibility layer (acting as torch).
 #
 # 'scope' acts as an allowlist. To add other modules, you can do:
-# paddle.compat.enable_torch_proxy(scope={"triton", "new_module"})
+# paddle.enable_compat(scope={"triton", "new_module"})
 #
 # Note: Ensure that any torch APIs used in 'new_module' are already implemented in Paddle.
 
 if "torch" in sys.modules and sys.modules["torch"] is None:
     # Note: In paddleformer's __init__.py, it will set sys.modules["torch"] to None
-    # We should restore or delete it before enable_torch_proxy
+    # We should restore or delete it before enabling compat mode.
     del sys.modules["torch"]
     if "torch_save" in sys.modules and sys.modules["torch_save"] is not None:
         sys.modules["torch"] = sys.modules["torch_save"]
@@ -224,9 +224,7 @@ blocked_import_messages: dict[str, str] = {}
 
 if paddle.is_compiled_with_cuda():
     if is_deep_gemm_available():
-        paddle.compat.enable_torch_proxy(
-            scope={"deep_gemm", "triton"}, silent=True
-        )
+        paddle.enable_compat(scope={"deep_gemm", "triton"}, silent=True)
         _safe_load_ecosystem_lib("deep_gemm", ops_dir, globals())
     else:
         warning, error = _hopper_requirement(
@@ -236,7 +234,7 @@ if paddle.is_compiled_with_cuda():
         blocked_import_messages["paddlefleet.ops.deep_gemm"] = error
 
     if is_deep_ep_available():
-        paddle.compat.enable_torch_proxy(scope={"deep_ep"}, silent=True)
+        paddle.enable_compat(scope={"deep_ep"}, silent=True)
         # Loading libnvshmem_host.so.* first when use editable install
         _try_load_nvshmem(ops_dir)
         _safe_load_ecosystem_lib("deep_ep", ops_dir, globals())
@@ -248,9 +246,7 @@ if paddle.is_compiled_with_cuda():
         blocked_import_messages["paddlefleet.ops.deep_ep"] = error
 
     if is_sonic_moe_available():
-        paddle.compat.enable_torch_proxy(
-            scope={"sonicmoe", "quack", "triton"}, silent=True
-        )
+        paddle.enable_compat(scope={"sonicmoe", "quack", "triton"}, silent=True)
         _safe_load_ecosystem_lib("sonicmoe", ops_dir, globals(), ["quack"])
     else:
         warning, error = _sonic_moe_requirement(
@@ -274,12 +270,12 @@ if paddle.is_compiled_with_cuda():
         )
 
     try:
-        paddle.compat.enable_torch_proxy(scope={"triton"}, silent=True)
+        paddle.enable_compat(scope={"triton"}, silent=True)
         from .._extensions.flashmask import (
             rr_attn_estimate_triton_func,  # noqa: F401
         )
     finally:
-        paddle.compat.disable_torch_proxy()
+        paddle.disable_compat()
 
 
 def __getattr__(name):

--- a/tests/single_card_tests/custom_ops/deep_gemm/generators.py
+++ b/tests/single_card_tests/custom_ops/deep_gemm/generators.py
@@ -14,7 +14,7 @@
 
 import paddle
 
-paddle.compat.enable_torch_proxy()
+paddle.enable_compat()
 import enum
 import random
 from collections.abc import Generator

--- a/tests/single_card_tests/custom_ops/deep_gemm/test_bf16.py
+++ b/tests/single_card_tests/custom_ops/deep_gemm/test_bf16.py
@@ -14,7 +14,7 @@
 
 import paddle
 
-paddle.compat.enable_torch_proxy()
+paddle.enable_compat()
 import copy
 import random
 

--- a/tests/single_card_tests/custom_ops/deep_gemm/test_fp8.py
+++ b/tests/single_card_tests/custom_ops/deep_gemm/test_fp8.py
@@ -14,7 +14,7 @@
 
 import paddle
 
-paddle.compat.enable_torch_proxy()
+paddle.enable_compat()
 import copy
 import random
 

--- a/tests/single_card_tests/custom_ops/test_fuse_weighted_swiglu_fp8_quant.py
+++ b/tests/single_card_tests/custom_ops/test_fuse_weighted_swiglu_fp8_quant.py
@@ -18,7 +18,7 @@ import numpy as np
 import paddle
 import paddle.incubate.nn.functional as F
 
-paddle.compat.enable_torch_proxy()
+paddle.enable_compat()
 
 from paddlefleet.ops import deep_gemm, fuse_weighted_swiglu_fp8_quant
 from paddlefleet.ops.deep_gemm.testing import (


### PR DESCRIPTION
## 背景
- `paddle.enable_compat` 已经是公开 API。
- 本 PR 将仓库内仍在使用的 `paddle.compat.enable_torch_proxy` 替换为公开 API，避免继续依赖早期开发别名。

## 修改内容
- 将 `src/` 和测试中的 `paddle.compat.enable_torch_proxy` 替换为 `paddle.enable_compat`
- 同步更新相关注释中的旧 API 文案
- 将对应的清理调用从 `paddle.compat.disable_torch_proxy` 调整为 `paddle.disable_compat`，保持公开 API 配对一致

## 验证
- `rg -n "paddle\.compat\.enable_torch_proxy|paddle\.compat\.disable_torch_proxy" .`
- `PYTHONPYCACHEPREFIX=/tmp/paddlefleet-enable-compat-pycache python3 -m compileall -q src/paddlefleet/ops/__init__.py src/paddlefleet/_extensions/flashmask/rr_attn_estimate_triton_op.py tests/single_card_tests/custom_ops/deep_gemm/generators.py tests/single_card_tests/custom_ops/deep_gemm/test_bf16.py tests/single_card_tests/custom_ops/deep_gemm/test_fp8.py tests/single_card_tests/custom_ops/test_fuse_weighted_swiglu_fp8_quant.py`

@SigureMo 麻烦有空 review 一下，感谢～