### PR TITLE
[Test] Revert PR #739 to verify qwen3vl_sft_h20_moe precision diff root cause

### DIFF
--- a/src/paddlefleet/models/common/embeddings/rope_utils.py
+++ b/src/paddlefleet/models/common/embeddings/rope_utils.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 import logging
-from contextlib import nullcontext
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -94,66 +93,66 @@ def get_unsqueeze_dim(t, freqs):
     return 2 if t.shape[1] == seq_len else 1
 
 
-def _apply_rotary_pos_emb_bshd(
-    t: Tensor | tuple[Tensor, ...],
-    freqs: Tensor | None,
-    config: TransformerConfig = None,
-    cos: Tensor | None = None,
-    sin: Tensor | None = None,
+def _apply_rotary_pos_emb_bshd_fp32(
+    t: Tensor,
+    t_pass: Tensor,
+    freqs: Tensor,
+    rotary_interleaved: bool = False,
     mscale: float = 1.0,
-    position_ids: Tensor | None = None,
-) -> Tensor | tuple[Tensor, ...]:
+) -> Tensor:
     """Apply rotary positional embedding to input tensor T.
 
     check https://kexue.fm/archives/8265 for detailed formulas
 
     Args:
-        t (Tensor | tuple[Tensor, ...]): Input tensor T is of shape [seq_length, ... , dim],
-            or a tuple of tensors (e.g. (query, key)) for the fused path.
-        freqs (Tensor | None): Rotary Positional embedding tensor freq is of shape
-            [seq_length, ..., dim]. Can be None when using fused path.
-        config (TransformerConfig): Transformer configuration providing
-            apply_rope_fusion, rotary_interleaved, multi_latent_attention,
-            high_precision_rope, rope_theta, sequence_parallel.
-        cos (Tensor | None): Pre-computed cosine values (for fused path).
-        sin (Tensor | None): Pre-computed sine values (for fused path).
-        mscale (float): Scaling factor for rotary embedding.
-        position_ids (Tensor | None): Position indices (for fused path).
+        t (Tensor): Input tensor T is of shape [seq_length, ... , dim]
+        t_pass (Tensor): Rotary Positional embedding tensor freq is of shape [seq_length, ..., dim]
 
     Returns:
-        Tensor | tuple[Tensor, ...]: The input tensor(s) after applying RoPE.
+        Tensor: The input tensor after applying RoPE
     """
-    if config is not None and config.apply_rope_fusion:
-        if config.high_precision_rope:
-            raise NotImplementedError(
-                "high_precision_rope is not yet supported with "
-                "apply_rope_fusion in bshd format"
-            )
-        # Fused path: delegate to Paddle's fused_rope kernel
-        assert isinstance(t, tuple), (
-            "The input for fused_rope should be a tuple of tensors"
-        )
-        return fused_rope(
-            *t,
-            sin=sin,
-            cos=cos,
-            rotary_emb_base=config.rope_theta,
-            position_ids=position_ids,
-            use_neox_rotary_style=config.rotary_interleaved,
-            time_major=config.sequence_parallel,
-        )
 
-    # Unfused path
-    rotary_interleaved = (
-        config.rotary_interleaved if config is not None else False
-    )
-    multi_latent_attention = (
-        config.multi_latent_attention if config is not None else False
-    )
-    high_precision_rope = (
-        config.high_precision_rope if config is not None else False
-    )
+    # first part is cosine component
+    # second part is sine component, need to change signs with _rotate_half method
+    with paddle.amp.auto_cast(False):
+        orig_t_dtype = t.dtype
+        t = t.astype(dtype="float32")
+        t_pass = t_pass.astype(dtype="float32")
+        rotate_t = _rotate_half(t, rotary_interleaved)
+        cos_ = (paddle.cos(freqs) * mscale).to(t.dtype)
+        sin_ = (paddle.sin(freqs) * mscale).to(t.dtype)
 
+        if len(cos_.shape) < len(t.shape):
+            # [b,s,h]->[b,s,1,h]
+            unsqueeze_dim = get_unsqueeze_dim(t, cos_)
+            cos_.unsqueeze_(unsqueeze_dim)
+            sin_.unsqueeze_(unsqueeze_dim)
+        if len(rotate_t.shape) < len(t.shape):
+            rotate_t.reshape_(t.shape)
+
+        t = (t * cos_) + (rotate_t * sin_)
+        return paddle.cat((t, t_pass), axis=-1).astype(orig_t_dtype)
+
+
+def _apply_rotary_pos_emb_bshd(
+    t: Tensor,
+    freqs: Tensor,
+    rotary_interleaved: bool = False,
+    multi_latent_attention: bool = False,
+    mscale: float = 1.0,
+    high_precision_rope: bool = False,
+) -> Tensor:
+    """Apply rotary positional embedding to input tensor T.
+
+    check https://kexue.fm/archives/8265 for detailed formulas
+
+    Args:
+        t (Tensor): Input tensor T is of shape [seq_length, ... , dim]
+        freqs (Tensor): Rotary Positional embedding tensor freq is of shape [seq_length, ..., dim]
+
+    Returns:
+        Tensor: The input tensor after applying RoPE
+    """
     rot_dim = freqs.shape[-1]
 
     # ideally t_pass is empty so rotary pos embedding is applied to all tensor t
@@ -164,35 +163,26 @@ def _apply_rotary_pos_emb_bshd(
         x2 = t[..., 1::2]
         t = paddle.cat((x1, x2), axis=-1)
 
-    # For high_precision_rope, cast to float32 and disable auto_cast to ensure
-    # numerical stability in the rotary computation.
-    orig_t_dtype = t.dtype
-    ctx = paddle.amp.auto_cast(False) if high_precision_rope else nullcontext()
-    with ctx:
-        if high_precision_rope:
-            t = t.astype(dtype="float32")
-            t_pass = t_pass.astype(dtype="float32")
-
-        # first part is cosine component
-        # second part is sine component, need to change signs with _rotate_half method
-        cos_ = (paddle.cos(freqs) * mscale).to(t.dtype)
-        sin_ = (paddle.sin(freqs) * mscale).to(t.dtype)
-        if len(cos_.shape) < len(t.shape):
-            # [b,s,h]->[b,s,1,h]
-            unsqueeze_dim = get_unsqueeze_dim(t, cos_)
-            cos_.unsqueeze_(unsqueeze_dim)
-            sin_.unsqueeze_(unsqueeze_dim)
-
-        rotate_t = _rotate_half(t, rotary_interleaved)
-        if len(rotate_t.shape) < len(t.shape):
-            rotate_t.reshape_(t.shape)
-
-        t = (t * cos_) + (rotate_t * sin_)
-        result = paddle.cat((t, t_pass), axis=-1)
-
     if high_precision_rope:
-        result = result.astype(orig_t_dtype)
-    return result
+        return _apply_rotary_pos_emb_bshd_fp32(
+            t,
+            t_pass=t_pass,
+            freqs=freqs,
+            rotary_interleaved=rotary_interleaved,
+            mscale=mscale,
+        )
+    # first part is cosine component
+    # second part is sine component, need to change signs with _rotate_half method
+    cos_ = (paddle.cos(freqs) * mscale).to(t.dtype)
+    sin_ = (paddle.sin(freqs) * mscale).to(t.dtype)
+    if len(cos_.shape) < len(t.shape):
+        # [b,s,h]->[b,s,1,h]
+        unsqueeze_dim = get_unsqueeze_dim(t, cos_)
+        cos_.unsqueeze_(unsqueeze_dim)
+        sin_.unsqueeze_(unsqueeze_dim)
+
+    t = (t * cos_) + (_rotate_half(t, rotary_interleaved) * sin_)
+    return paddle.cat((t, t_pass), axis=-1)
 
 
 def _get_thd_freqs_on_this_cp_rank(
@@ -247,41 +237,30 @@ def _get_thd_freqs_on_this_cp_rank(
 
 
 def _apply_rotary_pos_emb_thd(
-    t: Tensor | tuple[Tensor, ...],
+    t: Tensor,
     cu_seqlens: Tensor,
     total_seq_len: int | None,
-    freqs: Tensor | None,
-    config: TransformerConfig = None,
-    cos: Tensor | None = None,
-    sin: Tensor | None = None,
+    freqs: Tensor,
+    rotary_interleaved: bool = False,
+    multi_latent_attention: bool = False,
     mscale: float = 1.0,
     cp_group: Group = None,
-    position_ids: Tensor | None = None,
-) -> Tensor | tuple[Tensor, ...]:
+    high_precision_rope: bool = False,
+) -> Tensor:
     """A baseline implementation of applying RoPE for `thd` format.
 
     Args:
-        t (Tensor | tuple[Tensor, ...]): Input tensor T is of shape [t, h, d],
-            or a tuple of tensors (e.g. (query, key)) for the fused path.
+        t (Tensor): Input tensor T is of shape [t, h, d]
         cu_seqlens(Tensor):  Cumulative sum of sequence lengths in a batch for `t`,
-            with shape [b + 1] and dtype paddle.int32.
+        with shape [b + 1] and dtype paddle.int32.
         total_seq_len (int | None): The actual total sequence length before padding.
             When cu_seqlens uses a padded version, this provides the true total length
             for correct frequency tensor selection. If None, falls back to cu_seqlens[-1].
-        freqs (Tensor | None): Rotary Positional embedding tensor freq is of shape
-            [max_s, 1, 1, d]. Can be None when using fused path.
-        config (TransformerConfig): Transformer configuration providing
-            apply_rope_fusion, rotary_interleaved, multi_latent_attention,
-            high_precision_rope, rope_theta, sequence_parallel.
-        cos (Tensor | None): Pre-computed cosine values (for fused path).
-        sin (Tensor | None): Pre-computed sine values (for fused path).
-        mscale (float): Scaling factor for rotary embedding.
-        cp_group (Group): The context parallel group.
-        position_ids (Tensor | None): Position indices (for fused path).
+        freqs (Tensor): Rotary Positional embedding tensor freq is of shape [max_s, 1, 1, d]
+        cp_group (Group): The context parallel group
 
     Returns:
-        Tensor | tuple[Tensor, ...]: Shape [t, h, d]. The input tensor(s) after
-            applying RoPE.
+        Tensor: Shape [t, h, d]. The input tensor after applying RoPE.
     """
     cp_size = get_pg_size(cp_group)
     cp_rank = get_pg_rank(cp_group)
@@ -303,8 +282,10 @@ def _apply_rotary_pos_emb_thd(
             return _apply_rotary_pos_emb_bshd(
                 t,
                 freqs,
-                config,
+                rotary_interleaved=rotary_interleaved,
+                multi_latent_attention=multi_latent_attention,
                 mscale=mscale,
+                high_precision_rope=high_precision_rope,
             )
         seqlens = ((cu_seqlens[1:] - cu_seqlens[:-1]) // cp_size).tolist()
         # Build packed freqs in one pass, then apply once to the whole packed tensor
@@ -325,8 +306,10 @@ def _apply_rotary_pos_emb_thd(
         return _apply_rotary_pos_emb_bshd(
             t,
             freqs_packed,
-            config,
+            rotary_interleaved=rotary_interleaved,
+            multi_latent_attention=multi_latent_attention,
             mscale=mscale,
+            high_precision_rope=high_precision_rope,
         )
     else:
         # CASE 2: Traditional mapping without offsets
@@ -344,14 +327,16 @@ def _apply_rotary_pos_emb_thd(
         return _apply_rotary_pos_emb_bshd(
             t,
             freqs_packed,
-            config,
+            rotary_interleaved=rotary_interleaved,
+            multi_latent_attention=multi_latent_attention,
             mscale=mscale,
+            high_precision_rope=high_precision_rope,
         )
 
 
 def apply_rotary_pos_emb(
-    t: Tensor | tuple[Tensor, ...],
-    freqs: Tensor | None,
+    t: Tensor,
+    freqs: Tensor,
     cos: Tensor | None,
     sin: Tensor | None,
     config: TransformerConfig,
@@ -363,38 +348,50 @@ def apply_rotary_pos_emb(
 ):
     """
     Reroute to the appropriate apply_rotary_pos_emb function depending on
-    bshd (conventional) / thd (packed seq) format.
-
-    The fused/unfused decision is handled internally by each format-specific
-    function based on config.apply_rope_fusion.
+    fused/unfused kernels, or bshd (conventional) / thd (packed seq) format
 
     Args:
-        t (Tensor | tuple[Tensor, ...]): Input tensor, or a tuple of tensors
-            (e.g. (query, key)) for the fused path.
-        freqs (Tensor | None): Rotary positional embedding frequencies.
-            Can be None when using fused path.
-        cos (Tensor | None): Pre-computed cosine values of freqs (used for
-            fused implementation).
-        sin (Tensor | None): Pre-computed sine values of freqs (used for
-            fused implementation).
-        config (TransformerConfig): Transformer configuration.
-        cu_seqlens (Tensor | None): Cumulative sequence lengths.
+        t (Tensor): Input tensor
+        freqs (Tensor): Rotary positional embedding frequencies
+        cos (Tensor | None): Pre-computed cosine values of freqs (used for fused implementation)
+        sin (Tensor | None): Pre-computed sine values of freqs (used for fused implementation)
+        config (TransformerConfig): Transformer configuration
+        cu_seqlens (Tensor | None): Cumulative sequence lengths
         total_seq_len (int | None): The actual total sequence length before padding.
             Used in thd format to correctly select frequency tensor when cu_seqlens
             is padded. If None, falls back to cu_seqlens[-1].
-        mscale (float): Scaling factor.
-        cp_group (Group): Context parallel group.
-        position_ids (Tensor | None): Position indices.
+        mscale (float): Scaling factor
+        cp_group (Group): Context parallel group
     """
+    if config.apply_rope_fusion:
+        # Paddle fused_rope not support cu_seqlens or cp_group
+        if cu_seqlens:
+            raise NotImplementedError(
+                "cu_seqlens not be supported when using fused_rope"
+            )
+        else:
+            assert isinstance(t, tuple), (
+                "The input for fused_rope should be a tuple of tensors"
+            )
+            return fused_rope(
+                *t,
+                sin=sin,
+                cos=cos,
+                rotary_emb_base=config.rope_theta,
+                position_ids=position_ids,
+                use_neox_rotary_style=config.rotary_interleaved,
+                time_major=config.sequence_parallel,
+            )
+
+    # use unfused implementation
     if cu_seqlens is None:
         return _apply_rotary_pos_emb_bshd(
             t,
             freqs,
-            config,
-            cos=cos,
-            sin=sin,
+            rotary_interleaved=config.rotary_interleaved,
+            multi_latent_attention=config.multi_latent_attention,
             mscale=mscale,
-            position_ids=position_ids,
+            high_precision_rope=config.high_precision_rope,
         )
     else:
         return _apply_rotary_pos_emb_thd(
@@ -402,10 +399,9 @@ def apply_rotary_pos_emb(
             cu_seqlens,
             total_seq_len,
             freqs,
-            config,
-            cos=cos,
-            sin=sin,
+            rotary_interleaved=config.rotary_interleaved,
+            multi_latent_attention=config.multi_latent_attention,
             mscale=mscale,
             cp_group=cp_group,
-            position_ids=position_ids,
+            high_precision_rope=config.high_precision_rope,
         )


### PR DESCRIPTION
## Summary
- Revert PR #739 (`Restructure rope_utils.py: consolidate config and inline fp32`) to verify whether it caused the `qwen3vl_sft_h20_moe_multi_card` precision diff seen in PR #761
- If this revert PR **still fails** the same precision check → #739 is NOT the cause (likely #756 `replace matmul_add to linear` which skipped CI)
- If this revert PR **passes** → #739 did introduce the diff

## Context
PR #761 CI failed on `qwen3vl_sft_h20_moe_multi_card`:
- Log Loss: `12.42565727` vs GT Loss: `12.42567158`
- Max absolute difference: `1.431e-05`
- Tolerance: `rtol=0, atol=0`

Commits on `release/0.2` between GT baseline and PR #761 CI:
| PR | Change | CI multi-card |
|---|---|---|
| #756 | `matmul+bias` → `F.linear` in ColumnParallelLinear | **skipped** |
| #755 | Update Paddle version | pass |
| #739 | rope_utils.py refactor | pass |

## Test plan
- [ ] Wait for CI `Integration test (H20, multi-card)` to complete
- [ ] Check if `qwen3vl_sft_h20_moe_multi_card` check_loss passes or fails
- [ ] Compare result with empty PR #765 to isolate root cause
- [ ] Close this PR after verification (do NOT merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)