### PR TITLE
[FP8] Use `fuse_weighted_swiglu_fp8_quant` in MoELayer

### DIFF
--- a/src/paddlefleet/transformer/moe/fp8_utils.py
+++ b/src/paddlefleet/transformer/moe/fp8_utils.py
@@ -92,6 +92,33 @@ def _get_fp8_weight_and_scale(weight, transpose=False):
     return fp8_weight, fp8_scale
 
 
+def fused_stack_quant_without_cache(
+    expert_weight_list, transpose=False, use_ue8m0=False
+):
+    use_pow2_scale = False
+    if paddle.device.cuda.get_device_capability()[0] == 10:
+        # Blackwell GPUs require the use of pow2_scales quantization.
+        use_pow2_scale = True
+    if transpose:
+        w, scale = fuse_stack_transpose_fp8_quant(
+            expert_weight_list,
+            use_pow2_scale,
+            use_ue8m0,
+            use_ue8m0,
+        )
+    else:
+        w, scale = fuse_stack_fp8_quant(
+            expert_weight_list,
+            use_pow2_scale,
+            use_ue8m0,
+            use_ue8m0,
+        )
+
+    if use_ue8m0:
+        scale = scale.T
+    return w, scale
+
+
 def fused_stack_quant(expert_weight_list, transpose=False, use_ue8m0=False):
     if transpose is False and hasattr(
         expert_weight_list[0], "fp8_weight_stacked"
@@ -118,27 +145,9 @@ def fused_stack_quant(expert_weight_list, transpose=False, use_ue8m0=False):
             expert_weight_list[0], transpose=True
         )
     else:
-        use_pow2_scale = False
-        if paddle.device.cuda.get_device_capability()[0] == 10:
-            # Blackwell GPUs require the use of pow2_scales quantization.
-            use_pow2_scale = True
-        if transpose:
-            w, scale = fuse_stack_transpose_fp8_quant(
-                expert_weight_list,
-                use_pow2_scale,
-                use_ue8m0,
-                use_ue8m0,
-            )
-        else:
-            w, scale = fuse_stack_fp8_quant(
-                expert_weight_list,
-                use_pow2_scale,
-                use_ue8m0,
-                use_ue8m0,
-            )
-
-        if use_ue8m0:
-            scale = scale.T
+        w, scale = fused_stack_quant_without_cache(
+            expert_weight_list, transpose, use_ue8m0
+        )
     return w, scale
 
 

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
 
 from paddlefleet import utils
 
-from .fp8_utils import fused_stack_quant
+from .fp8_utils import fused_stack_quant_without_cache
 from .fusion_layer_utils import FusionMoePyLayer
 from .moe_expert import GroupedMLPExpert, StandardMLPExpert
 from .moe_router import TopKRouter
@@ -907,27 +907,27 @@ class MoELayer(nn.Layer):
                 weight_obj = weight_list[0]
 
             if quant_transpose is None:
-                fp8_weight, fp8_scale = fused_stack_quant(
+                fp8_weight, fp8_scale = fused_stack_quant_without_cache(
                     weight_list, transpose=False
                 )
                 weight_obj.fp8_weight_stacked = fp8_weight
                 weight_obj.fp8_scale_stacked = fp8_scale
 
-                fp8_weight_t, fp8_scale_t = fused_stack_quant(
+                fp8_weight_t, fp8_scale_t = fused_stack_quant_without_cache(
                     weight_list, transpose=True
                 )
                 weight_obj.fp8_weight_stacked_transpose = fp8_weight_t
                 weight_obj.fp8_scale_stacked_transpose = fp8_scale_t
             elif quant_transpose is False:
                 # Only quantize without transpose
-                fp8_weight, fp8_scale = fused_stack_quant(
+                fp8_weight, fp8_scale = fused_stack_quant_without_cache(
                     weight_list, transpose=False
                 )
                 weight_obj.fp8_weight_stacked = fp8_weight
                 weight_obj.fp8_scale_stacked = fp8_scale
             elif quant_transpose is True:
                 # Only quantize with transpose
-                fp8_weight_t, fp8_scale_t = fused_stack_quant(
+                fp8_weight_t, fp8_scale_t = fused_stack_quant_without_cache(
                     weight_list, transpose=True
                 )
                 weight_obj.fp8_weight_stacked_transpose = fp8_weight_t

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -36,6 +36,7 @@ if TYPE_CHECKING:
 
 from paddlefleet import utils
 
+from .fp8_utils import fused_stack_quant
 from .fusion_layer_utils import FusionMoePyLayer
 from .moe_expert import GroupedMLPExpert, StandardMLPExpert
 from .moe_router import TopKRouter
@@ -906,36 +907,28 @@ class MoELayer(nn.Layer):
                 weight_obj = weight_list[0]
 
             if quant_transpose is None:
-                fp8_weight, fp8_scale = (
-                    paddle.incubate.nn.functional.fused_stack_transpose_quant(
-                        weight_list, transpose=False
-                    )
+                fp8_weight, fp8_scale = fused_stack_quant(
+                    weight_list, transpose=False
                 )
                 weight_obj.fp8_weight_stacked = fp8_weight
                 weight_obj.fp8_scale_stacked = fp8_scale
 
-                fp8_weight_t, fp8_scale_t = (
-                    paddle.incubate.nn.functional.fused_stack_transpose_quant(
-                        weight_list, transpose=True
-                    )
+                fp8_weight_t, fp8_scale_t = fused_stack_quant(
+                    weight_list, transpose=True
                 )
                 weight_obj.fp8_weight_stacked_transpose = fp8_weight_t
                 weight_obj.fp8_scale_stacked_transpose = fp8_scale_t
             elif quant_transpose is False:
                 # Only quantize without transpose
-                fp8_weight, fp8_scale = (
-                    paddle.incubate.nn.functional.fused_stack_transpose_quant(
-                        weight_list, transpose=False
-                    )
+                fp8_weight, fp8_scale = fused_stack_quant(
+                    weight_list, transpose=False
                 )
                 weight_obj.fp8_weight_stacked = fp8_weight
                 weight_obj.fp8_scale_stacked = fp8_scale
             elif quant_transpose is True:
                 # Only quantize with transpose
-                fp8_weight_t, fp8_scale_t = (
-                    paddle.incubate.nn.functional.fused_stack_transpose_quant(
-                        weight_list, transpose=True
-                    )
+                fp8_weight_t, fp8_scale_t = fused_stack_quant(
+                    weight_list, transpose=True
                 )
                 weight_obj.fp8_weight_stacked_transpose = fp8_weight_t
                 weight_obj.fp8_scale_stacked_transpose = fp8_scale_t

--- a/tests/single_card_tests/custom_ops/test_fused_stack_quant.py
+++ b/tests/single_card_tests/custom_ops/test_fused_stack_quant.py
@@ -31,7 +31,10 @@ from paddle.base import core
 
 # fused_stack_quant lives in fp8_utils but calls paddlefleet.ops internally.
 # We import it here and rely on the same try/except guard that fp8_utils uses.
-from paddlefleet.transformer.moe.fp8_utils import fused_stack_quant
+from paddlefleet.transformer.moe.fp8_utils import (
+    fused_stack_quant,
+    fused_stack_quant_without_cache,
+)
 
 NUM_EXPERTS = 4
 N, K = 512, 256  # small dims for fast tests
@@ -510,6 +513,76 @@ class TestFusedStackQuantReplacedOps(unittest.TestCase):
             s_fused.numpy(),
             err_msg="use_ue8m0=True (transpose) must return scale.T of the raw op output",
         )
+
+
+class TestFusedStackQuantWithoutCache(unittest.TestCase):
+    """Directly exercise the uncached helper added for MoELayer quantization."""
+
+    def setUp(self):
+        if not core.is_compiled_with_cuda():
+            self.skipTest("CUDA required")
+        try:
+            from paddlefleet.ops import (
+                fuse_stack_fp8_quant,
+                fuse_stack_transpose_fp8_quant,
+            )
+
+            self.fuse_stack_fp8_quant = fuse_stack_fp8_quant
+            self.fuse_stack_transpose_fp8_quant = fuse_stack_transpose_fp8_quant
+        except (ImportError, RuntimeError):
+            self.skipTest("paddlefleet.ops not available")
+        np.random.seed(11)
+        paddle.seed(11)
+
+    def test_nontranspose_matches_direct_op(self):
+        arch = paddle.device.cuda.get_device_capability()[0]
+        use_pow2 = arch == 10
+        weights = _make_weight_list(num_experts=2, shape=(256, 128))
+        weights_copy = [w.clone() for w in weights]
+
+        w_direct, s_direct = self.fuse_stack_fp8_quant(
+            weights_copy, use_pow2, False, False
+        )
+        w_helper, s_helper = fused_stack_quant_without_cache(
+            weights, transpose=False
+        )
+
+        np.testing.assert_array_equal(w_direct.numpy(), w_helper.numpy())
+        np.testing.assert_allclose(
+            s_direct.numpy(), s_helper.numpy(), rtol=0, atol=0
+        )
+
+    def test_transpose_matches_direct_op(self):
+        arch = paddle.device.cuda.get_device_capability()[0]
+        use_pow2 = arch == 10
+        weights = _make_weight_list(num_experts=2, shape=(256, 128))
+        weights_copy = [w.clone() for w in weights]
+
+        w_direct, s_direct = self.fuse_stack_transpose_fp8_quant(
+            weights_copy, use_pow2, False, False
+        )
+        w_helper, s_helper = fused_stack_quant_without_cache(
+            weights, transpose=True
+        )
+
+        np.testing.assert_array_equal(w_direct.numpy(), w_helper.numpy())
+        np.testing.assert_allclose(
+            s_direct.numpy(), s_helper.numpy(), rtol=0, atol=0
+        )
+
+    def test_ue8m0_returns_direct_op_scale_transpose(self):
+        arch = paddle.device.cuda.get_device_capability()[0]
+        if arch < 10:
+            self.skipTest("ue8m0 only supported on SM10+ (Blackwell)")
+        weights = _make_weight_list(num_experts=2, shape=(256, 128))
+        weights_copy = [w.clone() for w in weights]
+
+        _, s_direct = self.fuse_stack_fp8_quant(weights_copy, True, True, True)
+        _, s_helper = fused_stack_quant_without_cache(
+            weights, transpose=False, use_ue8m0=True
+        )
+
+        np.testing.assert_array_equal(s_direct.T.numpy(), s_helper.numpy())
 
 
 class TestFusedWeightedSwigluFp8QuantReplacement(unittest.TestCase):

--- a/tests/single_card_tests/model/test_moe_layer_fp8_quant_weight.py
+++ b/tests/single_card_tests/model/test_moe_layer_fp8_quant_weight.py
@@ -1,0 +1,140 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from types import SimpleNamespace
+
+import paddle
+import paddle.nn.functional as F
+from paddle.base import core
+
+from paddlefleet.tensor_parallel.layers import (
+    ColumnParallelLinear,
+    RowParallelLinear,
+)
+from paddlefleet.tensor_parallel.random import model_parallel_cuda_manual_seed
+from paddlefleet.transformer.mlp import MLPSublayersSpec
+from paddlefleet.transformer.moe.moe_layer import MoELayer, MoESublayers
+from paddlefleet.transformer.transformer_config import TransformerConfig
+
+HIDDEN = 128
+INTERMEDIATE = 128
+NUM_EXPERTS = 2
+
+
+class TestMoELayerFp8QuantWeight(unittest.TestCase):
+    def setUp(self):
+        if not core.is_compiled_with_cuda():
+            self.skipTest("CUDA required")
+        try:
+            from paddlefleet.ops import (
+                fuse_stack_fp8_quant,
+                fuse_stack_transpose_fp8_quant,
+            )
+
+            self.assertTrue(callable(fuse_stack_fp8_quant))
+            self.assertTrue(callable(fuse_stack_transpose_fp8_quant))
+        except (ImportError, RuntimeError):
+            self.skipTest("paddlefleet.ops not available")
+        model_parallel_cuda_manual_seed(1234, tp_rank=0, ep_rank=0, etp_rank=0)
+
+    def _make_layer(self):
+        config = TransformerConfig(
+            num_hidden_layers=1,
+            hidden_size=HIDDEN,
+            num_attention_heads=1,
+            intermediate_size=INTERMEDIATE,
+            n_routed_experts=NUM_EXPERTS,
+            n_shared_experts=0,
+            num_experts_per_tok=1,
+            moe_intermediate_size=INTERMEDIATE,
+            moe_token_dispatcher_type="alltoall",
+            moe_grouped_gemm=False,
+            moe_use_fusion_node=True,
+            fp8=None,
+            gated_linear_unit=True,
+            hidden_act=F.silu,
+            use_bias=False,
+            tensor_model_parallel_size=1,
+            params_dtype=paddle.bfloat16,
+        )
+        mlp_spec = MLPSublayersSpec(
+            up_gate_proj=ColumnParallelLinear,
+            down_proj=RowParallelLinear,
+            hidden_act=None,
+        )
+        layer = MoELayer(
+            config,
+            sublayers=MoESublayers(mlp_spec=mlp_spec),
+            pg_collection=SimpleNamespace(ep=None, expt_dp=None),
+        )
+        layer.moe_use_fusion_node = True
+        layer.fp8 = "e4m3"
+        return layer
+
+    def _expert_weights(self, layer):
+        return [
+            layer.experts[0].up_gate_proj.weight,
+            layer.experts[0].down_proj.weight,
+        ]
+
+    def test_quant_transpose_none_stores_both_layouts(self):
+        layer = self._make_layer()
+        layer.fp8_quant_weight(batch_mode=False, quant_transpose=None)
+
+        for weight in self._expert_weights(layer):
+            self.assertEqual(
+                weight.fp8_weight_stacked.dtype, paddle.float8_e4m3fn
+            )
+            self.assertEqual(weight.fp8_scale_stacked.dtype, paddle.float32)
+            self.assertEqual(
+                weight.fp8_weight_stacked_transpose.dtype,
+                paddle.float8_e4m3fn,
+            )
+            self.assertEqual(
+                weight.fp8_scale_stacked_transpose.dtype,
+                paddle.float32,
+            )
+
+    def test_quant_transpose_false_stores_only_nontranspose_layout(self):
+        layer = self._make_layer()
+        layer.fp8_quant_weight(batch_mode=False, quant_transpose=False)
+
+        for weight in self._expert_weights(layer):
+            self.assertEqual(
+                weight.fp8_weight_stacked.dtype, paddle.float8_e4m3fn
+            )
+            self.assertEqual(weight.fp8_scale_stacked.dtype, paddle.float32)
+            self.assertFalse(hasattr(weight, "fp8_weight_stacked_transpose"))
+            self.assertFalse(hasattr(weight, "fp8_scale_stacked_transpose"))
+
+    def test_quant_transpose_true_stores_only_transpose_layout(self):
+        layer = self._make_layer()
+        layer.fp8_quant_weight(batch_mode=False, quant_transpose=True)
+
+        for weight in self._expert_weights(layer):
+            self.assertFalse(hasattr(weight, "fp8_weight_stacked"))
+            self.assertFalse(hasattr(weight, "fp8_scale_stacked"))
+            self.assertEqual(
+                weight.fp8_weight_stacked_transpose.dtype,
+                paddle.float8_e4m3fn,
+            )
+            self.assertEqual(
+                weight.fp8_scale_stacked_transpose.dtype,
+                paddle.float32,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
同 #768，在 `MoELayer` 同样处理 `use_pow2_scale`，避免 fp8 计算 loss 出 NaN

<sup>This PR is co-authored with @codex (gpt-5.4)</sup>