### PR TITLE
Fix: skip  qk fuse rope when high_precision_rope is enabled

### DIFF
--- a/src/paddlefleet/transformer/attention.py
+++ b/src/paddlefleet/transformer/attention.py
@@ -341,6 +341,7 @@ class Attention(FleetLayer, ABC):
 
             if (
                 self.config.apply_rope_fusion
+                and not self.config.high_precision_rope
                 and q_pos_emb is not None
                 and k_pos_emb is not None
             ):


### PR DESCRIPTION
## Summary
- 当 `high_precision_rope` 启用时，跳过 qk fuse RoPE 路径，因为高精度 fused_rope 需要传 freq
