### PR TITLE
[Cherry-pick] Fix: skip rope fusion when high_precision_rope is enabled

### DIFF
--- a/src/paddlefleet/transformer/attention.py
+++ b/src/paddlefleet/transformer/attention.py
@@ -311,6 +311,7 @@ class Attention(FleetLayer, ABC):
 
             if (
                 self.config.apply_rope_fusion
+                and not self.config.high_precision_rope
                 and q_pos_emb is not None
                 and k_pos_emb is not None
             ):


### PR DESCRIPTION
## Summary
- Cherry-pick #782 到 `release/0.2` 分支
- 当 `high_precision_rope` 启用时，跳过标准的 fused RoPE 路径，避免走到不支持高精度的 fusion 分支导致计算结果不正确

## Test plan
- [ ] 验证 `high_precision_rope=True` 时不再走 fused RoPE 路径
- [ ] 验证 `high_precision_rope=False` 时行为不变

Merged in dev: #782