### PR TITLE
Add Moe balanced logging and module profiler

### DIFF
--- a/src/paddlefleet/training/global_vars.py
+++ b/src/paddlefleet/training/global_vars.py
@@ -18,6 +18,8 @@ from paddlefleet.timers import Timers
 
 _GLOBAL_ARGS = None
 _GLOBAL_TIMERS = None
+_GLOBAL_PROFILE_TIMERS = None
+_GLOBAL_TRAINING_LOGS = None
 
 
 def get_args():
@@ -32,9 +34,31 @@ def get_timers() -> Timers:
     return _GLOBAL_TIMERS
 
 
+def get_profile_timers():
+    """Return the active profile timers object if available."""
+    return _GLOBAL_PROFILE_TIMERS
+
+
+def get_global_training_logs():
+    """Return the active training logs object if one has been registered."""
+    return _GLOBAL_TRAINING_LOGS
+
+
 def set_args(args):
     global _GLOBAL_ARGS
     _GLOBAL_ARGS = args
+
+
+def set_global_training_logs(logs):
+    """Set the active training logs object."""
+    global _GLOBAL_TRAINING_LOGS
+    _GLOBAL_TRAINING_LOGS = logs
+
+
+def set_profile_timers(timers):
+    """Set the active timers object used by transformer profile scopes."""
+    global _GLOBAL_PROFILE_TIMERS
+    _GLOBAL_PROFILE_TIMERS = timers
 
 
 def _set_timers():
@@ -61,6 +85,12 @@ def destroy_global_vars():
     global _GLOBAL_TIMERS
     _GLOBAL_TIMERS = None
 
+    global _GLOBAL_PROFILE_TIMERS
+    _GLOBAL_PROFILE_TIMERS = None
+
+    global _GLOBAL_TRAINING_LOGS
+    _GLOBAL_TRAINING_LOGS = None
+
 
 def set_global_variables(args):
     """Set args, timers etc."""
@@ -75,5 +105,9 @@ def set_global_variables(args):
 def unset_global_variables():
     global _GLOBAL_ARGS
     global _GLOBAL_TIMERS
+    global _GLOBAL_PROFILE_TIMERS
+    global _GLOBAL_TRAINING_LOGS
     _GLOBAL_ARGS = None
     _GLOBAL_TIMERS = None
+    _GLOBAL_PROFILE_TIMERS = None
+    _GLOBAL_TRAINING_LOGS = None

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -22,8 +22,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import paddle
-from paddle import framework
-from paddle import nn
+from paddle import framework, nn
 from paddle.autograd import PyLayer
 from paddle.distributed.fleet.utils.sequence_parallel_utils import (
     GatherOp,

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -22,6 +22,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import paddle
+from paddle import framework
 from paddle import nn
 from paddle.autograd import PyLayer
 from paddle.distributed.fleet.utils.sequence_parallel_utils import (
@@ -38,6 +39,7 @@ if TYPE_CHECKING:
     from paddlefleet.transformer.transformer_config import TransformerConfig
 
 from paddlefleet import utils
+from paddlefleet.transformer.utils import profile
 
 from .fp8_utils import fused_stack_quant_without_cache
 from .fusion_layer_utils import FusionMoePyLayer
@@ -88,6 +90,8 @@ from .moe_utils import (
     count_cumsum,
     filter_scores,
     fused_expert_parallel_TC_topk_router_metadata,
+    global_moe_balance_training_logs_enabled,
+    log_moe_balance,
     permute,
     unpermute,
 )
@@ -466,9 +470,21 @@ class MoELayer(nn.Layer):
         probs: paddle.Tensor,
         routing_map: paddle.Tensor,
     ):
-        hidden_states, _ = self.dispatch(hidden_states, probs, routing_map)
-        hidden_states = self.routed_experts_compute(hidden_states)
-        return self.combine(hidden_states)
+        should_log_balance = framework._dygraph_tracer()._has_grad
+        with profile("dispatch"):
+            hidden_states, _ = self.dispatch(hidden_states, probs, routing_map)
+        if should_log_balance and global_moe_balance_training_logs_enabled():
+            log_moe_balance(
+                self.layer_number,
+                self.moe_group,
+                self.num_experts_per_tok,
+                self.token_dispatcher._comm_manager.tokens_per_expert,
+            )
+        with profile("fusion_mlp"):
+            hidden_states = self.routed_experts_compute(hidden_states)
+        with profile("combine"):
+            hidden_states = self.combine(hidden_states)
+        return hidden_states
 
     def fusion_moe_forward(
         self,
@@ -478,96 +494,109 @@ class MoELayer(nn.Layer):
         combine_overlap_handle: dict,
     ):
         # TODO(deepllz): add fp8 dispatch config && implementation
-        dispatched_hidden_states, fp8_dispatched_handle = self.dispatch(
-            hidden_states, probs, routing_map
-        )
+        should_log_balance = framework._dygraph_tracer()._has_grad
+        with profile("dispatch"):
+            dispatched_hidden_states, fp8_dispatched_handle = self.dispatch(
+                hidden_states, probs, routing_map
+            )
+        if should_log_balance and global_moe_balance_training_logs_enabled():
+            log_moe_balance(
+                self.layer_number,
+                self.moe_group,
+                self.num_experts_per_tok,
+                self.token_dispatcher._comm_manager.tokens_per_expert,
+            )
         dispatched_indices = (
             self.token_dispatcher._comm_manager.dispatched_indices
         )
         dispatched_probs = self.token_dispatcher._comm_manager.dispatched_probs
 
-        if self.using_sonic_moe:
-            T = dispatched_hidden_states.shape[0]
-            K = self.num_experts_per_tok
-            stream_id = paddle.device.cuda.current_stream().cuda_stream
-            topk_scores = filter_scores(
-                dispatched_probs,
-                dispatched_indices,
-            )
-            expert_frequency, expert_frequency_offset = count_cumsum(
-                dispatched_indices, self.num_experts_per_device, do_cumsum=True
-            )
-            activation_type = ActivationType("swiglu")
+        with profile("fusion_mlp"):
+            if self.using_sonic_moe:
+                T = dispatched_hidden_states.shape[0]
+                K = self.num_experts_per_tok
+                stream_id = paddle.device.cuda.current_stream().cuda_stream
+                topk_scores = filter_scores(
+                    dispatched_probs,
+                    dispatched_indices,
+                )
+                expert_frequency, expert_frequency_offset = count_cumsum(
+                    dispatched_indices,
+                    self.num_experts_per_device,
+                    do_cumsum=True,
+                )
+                activation_type = ActivationType("swiglu")
 
-            (
-                expert_frequency_offset,
-                x_gather_idx,
-                s_scatter_idx,
-                s_reverse_scatter_idx,
-                num_activated_expert_per_token_offset,
-            ) = fused_expert_parallel_TC_topk_router_metadata(
-                dispatched_indices,
-                expert_frequency_offset,
-                K,
-            )
+                (
+                    expert_frequency_offset,
+                    x_gather_idx,
+                    s_scatter_idx,
+                    s_reverse_scatter_idx,
+                    num_activated_expert_per_token_offset,
+                ) = fused_expert_parallel_TC_topk_router_metadata(
+                    dispatched_indices,
+                    expert_frequency_offset,
+                    K,
+                )
 
-            TK = s_scatter_idx.shape[0]
-            is_varlen_K = True
-            w1 = self.grouped_gemm_experts.weight1
-            y1, z = _UpProjection.apply(
-                dispatched_hidden_states,
-                w1.permute(1, 2, 0),
-                None,
-                expert_frequency_offset,
-                TK,
-                K,
-                stream_id,
-                x_gather_idx,
-                s_scatter_idx,
-                s_reverse_scatter_idx,
-                num_activated_expert_per_token_offset,
-                is_varlen_K,
-                activation_type,
-                is_inference_mode_enabled=False,
-            )
+                TK = s_scatter_idx.shape[0]
+                is_varlen_K = True
+                w1 = self.grouped_gemm_experts.weight1
+                y1, z = _UpProjection.apply(
+                    dispatched_hidden_states,
+                    w1.permute(1, 2, 0),
+                    None,
+                    expert_frequency_offset,
+                    TK,
+                    K,
+                    stream_id,
+                    x_gather_idx,
+                    s_scatter_idx,
+                    s_reverse_scatter_idx,
+                    num_activated_expert_per_token_offset,
+                    is_varlen_K,
+                    activation_type,
+                    is_inference_mode_enabled=False,
+                )
 
-            w2 = self.grouped_gemm_experts.weight2
-            hidden_states = _DownProjection.apply(
-                y1,
-                z,
-                w2.permute(1, 2, 0),
-                None,
-                topk_scores,
-                expert_frequency_offset,
-                T,
-                K,
-                stream_id,
-                x_gather_idx,
-                s_scatter_idx,
-                s_reverse_scatter_idx,
-                num_activated_expert_per_token_offset,
-                is_varlen_K,
-                activation_type,
-            )
-        else:
-            hidden_states = FusionMoePyLayer.apply(
-                dispatched_hidden_states,
-                dispatched_probs,
-                dispatched_indices,
-                self,
-                self.num_experts_per_tok,
-                use_fp8_mlp=self.fp8,
-                moe_deep_gemm=self.moe_deep_gemm,
-                moe_grouped_gemm=self.moe_grouped_gemm,
-                recompute_moe_gate_up=self.recompute_moe_gate_up,
-                recompute_moe_premute=self.recompute_moe_premute,
-                fp8_dispatched_handle=fp8_dispatched_handle,
-                use_bf16_gemm_weight_grad=not self.fp8_wgrad,
-            )
+                w2 = self.grouped_gemm_experts.weight2
+                hidden_states = _DownProjection.apply(
+                    y1,
+                    z,
+                    w2.permute(1, 2, 0),
+                    None,
+                    topk_scores,
+                    expert_frequency_offset,
+                    T,
+                    K,
+                    stream_id,
+                    x_gather_idx,
+                    s_scatter_idx,
+                    s_reverse_scatter_idx,
+                    num_activated_expert_per_token_offset,
+                    is_varlen_K,
+                    activation_type,
+                )
+            else:
+                hidden_states = FusionMoePyLayer.apply(
+                    dispatched_hidden_states,
+                    dispatched_probs,
+                    dispatched_indices,
+                    self,
+                    self.num_experts_per_tok,
+                    use_fp8_mlp=self.fp8,
+                    moe_deep_gemm=self.moe_deep_gemm,
+                    moe_grouped_gemm=self.moe_grouped_gemm,
+                    recompute_moe_gate_up=self.recompute_moe_gate_up,
+                    recompute_moe_premute=self.recompute_moe_premute,
+                    fp8_dispatched_handle=fp8_dispatched_handle,
+                    use_bf16_gemm_weight_grad=not self.fp8_wgrad,
+                )
 
-        hidden_states = self.token_dispatcher._comm_manager.combine(
-            hidden_states, combine_overlap_handle
-        )
+        with profile("combine"):
+            hidden_states = self.token_dispatcher._comm_manager.combine(
+                hidden_states, combine_overlap_handle
+            )
 
         return hidden_states
 

--- a/src/paddlefleet/transformer/moe/moe_utils.py
+++ b/src/paddlefleet/transformer/moe/moe_utils.py
@@ -30,6 +30,7 @@ except ImportError:
     scatter_add_ = None
 import paddle.distributed as dist
 from paddle.autograd.py_layer import PyLayer
+
 from paddlefleet.training.global_vars import get_global_training_logs
 from paddlefleet.utils import get_pg_size
 
@@ -256,11 +257,7 @@ def global_moe_balance_training_logs_enabled():
 
 def _all_gather_local_tokens(local_tokens_per_expert, group):
     local_tokens_per_expert = local_tokens_per_expert.reshape([-1])
-    if (
-        group is None
-        or get_pg_size(group) <= 1
-        or not group.is_member()
-    ):
+    if group is None or get_pg_size(group) <= 1 or not group.is_member():
         return local_tokens_per_expert.reshape([1, -1])
 
     if local_tokens_per_expert.place.is_cpu_place():

--- a/src/paddlefleet/transformer/moe/moe_utils.py
+++ b/src/paddlefleet/transformer/moe/moe_utils.py
@@ -30,6 +30,8 @@ except ImportError:
     scatter_add_ = None
 import paddle.distributed as dist
 from paddle.autograd.py_layer import PyLayer
+from paddlefleet.training.global_vars import get_global_training_logs
+from paddlefleet.utils import get_pg_size
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -241,6 +243,141 @@ def apply_random_logits(logits):
     Apply the RandomSTE function to the logits.
     """
     return RandomSTE.apply(logits)
+
+
+def global_moe_balance_training_logs_enabled():
+    logs = get_global_training_logs()
+    if logs is None:
+        return False
+
+    is_enabled = getattr(logs, "is_moe_balance_logs_enabled", None)
+    return callable(is_enabled) and is_enabled()
+
+
+def _all_gather_local_tokens(local_tokens_per_expert, group):
+    local_tokens_per_expert = local_tokens_per_expert.reshape([-1])
+    if (
+        group is None
+        or get_pg_size(group) <= 1
+        or not group.is_member()
+    ):
+        return local_tokens_per_expert.reshape([1, -1])
+
+    if local_tokens_per_expert.place.is_cpu_place():
+        gathered = []
+        dist.all_gather_object(
+            gathered,
+            local_tokens_per_expert.tolist(),
+            group=group,
+        )
+        return paddle.to_tensor(
+            gathered,
+            dtype=local_tokens_per_expert.dtype,
+            place=paddle.CPUPlace(),
+        ).reshape([get_pg_size(group), -1])
+
+    output_shape = local_tokens_per_expert.shape
+    output_shape[0] *= get_pg_size(group)
+    output = paddle.empty(output_shape, dtype=local_tokens_per_expert.dtype)
+    dist.stream.all_gather(
+        output,
+        local_tokens_per_expert,
+        group=group,
+        use_calc_stream=True,
+    )
+    return output.reshape([get_pg_size(group), -1])
+
+
+def _log_summary(key, layer_number, summary_data):
+    logs = get_global_training_logs()
+    if logs is None or not hasattr(logs, "update"):
+        return
+
+    summary_data = summary_data.detach()
+    if summary_data.numel() == 0:
+        return
+
+    summary_data = summary_data.astype("float32")
+    max_value = float(paddle.max(summary_data).item())
+    min_value = float(paddle.min(summary_data).item())
+    var_value = float(paddle.var(summary_data).item())
+    median_value = float(paddle.median(summary_data).item())
+    mean_value = float(paddle.mean(summary_data).item())
+    max_mean_ratio = max_value / mean_value if mean_value != 0 else 1.0
+    min_mean_ratio = min_value / mean_value if mean_value != 0 else 1.0
+
+    prefix = f"{key}_layer_{layer_number}"
+    logs.update(
+        **{
+            f"{prefix}_max": max_value,
+            f"{prefix}_min": min_value,
+            f"{prefix}_var": var_value,
+            f"{prefix}_median": median_value,
+            f"{prefix}_mean": mean_value,
+            f"{prefix}_max_mean_ratio": max_mean_ratio,
+            f"{prefix}_min_mean_ratio": min_mean_ratio,
+        }
+    )
+
+
+def _log_tokens_per_expert(layer_number, key, summary_data, count):
+    count = count.reshape([1]).astype("float32")
+    count = paddle.ones_like(count) if count.item() == 0 else count
+    avg_data = summary_data.astype("float32") / count
+
+    _log_summary(f"{key}_avg", layer_number, avg_data)
+    _log_summary(key, layer_number, summary_data)
+
+
+def _log_local_tokens_per_card(layer_number, local_tokens_by_rank):
+    card_totals = local_tokens_by_rank.sum(axis=1)
+    _log_summary(
+        "local_tokens_per_card",
+        layer_number,
+        card_totals,
+    )
+
+
+def log_moe_balance(
+    layer_number,
+    moe_group,
+    num_experts_per_tok,
+    tokens_per_expert,
+):
+    """Log fixed-topk MoE balance summaries from dispatched expert counts."""
+    if tokens_per_expert is None:
+        return
+
+    with paddle.no_grad():
+        if not isinstance(tokens_per_expert, paddle.Tensor):
+            tokens_per_expert = paddle.to_tensor(
+                tokens_per_expert,
+                dtype="int64",
+                place=paddle.CPUPlace(),
+            )
+        else:
+            tokens_per_expert = tokens_per_expert.detach()
+            if not tokens_per_expert.place.is_cpu_place():
+                # Moving a GPU tensor to CPU here introduces a synchronization
+                # point, so this path is slower and can affect training
+                # performance.
+                tokens_per_expert = tokens_per_expert.cpu()
+
+        local_tokens_by_rank = _all_gather_local_tokens(
+            tokens_per_expert,
+            moe_group,
+        )
+        topk = max(int(num_experts_per_tok or 1), 1)
+        summary = local_tokens_by_rank.reshape([-1])
+        count = summary.astype("float32").sum().reshape([1]) / topk
+
+        _log_tokens_per_expert(
+            layer_number,
+            "tokens_per_expert",
+            summary.clone() if isinstance(summary, paddle.Tensor) else summary,
+            count,
+        )
+        _log_local_tokens_per_card(layer_number, local_tokens_by_rank)
 
 
 def is_tensor(data):

--- a/src/paddlefleet/transformer/transformer_layer.py
+++ b/src/paddlefleet/transformer/transformer_layer.py
@@ -929,9 +929,7 @@ class TransformerLayerWithOverlap(TransformerLayer):
     def compute_mlp(self, hidden_states, is_first_fwd=False):
         timer_name = "moe-mlp" if isinstance(self.mlp, MoELayer) else "mlp"
         with profile(timer_name):
-            return self._forward_mlp(
-                hidden_states, is_first_fwd=is_first_fwd
-            )
+            return self._forward_mlp(hidden_states, is_first_fwd=is_first_fwd)
 
     def pre_process_compute(self, hidden_states):
         residual = hidden_states

--- a/src/paddlefleet/transformer/transformer_layer.py
+++ b/src/paddlefleet/transformer/transformer_layer.py
@@ -41,6 +41,7 @@ from paddlefleet.recompute_utils import (
 from paddlefleet.transformer.identity_op import IdentityFuncOp, IdentityOp
 from paddlefleet.transformer.mlp import MLP
 from paddlefleet.transformer.moe.moe_layer import MoELayer
+from paddlefleet.transformer.utils import profile
 from paddlefleet.utils import log_single_rank
 
 if is_deep_ep_available():
@@ -581,7 +582,7 @@ class TransformerLayer(nn.Layer):
         packed_seq_params: PackedSeqParams | None = None,
         **kwargs,
     ):
-        # breakpoint()
+        timer_name = "moe-mlp" if isinstance(self.mlp, MoELayer) else "mlp"
         if self.config.block_attention_residuals:
             blocks = kwargs.get("blocks", [])
             partial_block = hidden_states
@@ -597,20 +598,21 @@ class TransformerLayer(nn.Layer):
                 partial_block = None
 
             # Self-attention (skip internal bda residual)
-            hidden_states, context = self._forward_attention(
-                hidden_states=hidden_states,
-                attention_mask=attention_mask,
-                attn_mask_startend_row_indices=attn_mask_startend_row_indices,
-                context=context,
-                context_mask=context_mask,
-                rotary_pos_emb=rotary_pos_emb,
-                rotary_pos_cos=rotary_pos_cos,
-                rotary_pos_sin=rotary_pos_sin,
-                position_ids=position_ids,
-                attention_bias=attention_bias,
-                packed_seq_params=packed_seq_params,
-                block_attention_residuals=True,
-            )
+            with profile("attn"):
+                hidden_states, context = self._forward_attention(
+                    hidden_states=hidden_states,
+                    attention_mask=attention_mask,
+                    attn_mask_startend_row_indices=attn_mask_startend_row_indices,
+                    context=context,
+                    context_mask=context_mask,
+                    rotary_pos_emb=rotary_pos_emb,
+                    rotary_pos_cos=rotary_pos_cos,
+                    rotary_pos_sin=rotary_pos_sin,
+                    position_ids=position_ids,
+                    attention_bias=attention_bias,
+                    packed_seq_params=packed_seq_params,
+                    block_attention_residuals=True,
+                )
 
             # Accumulate attn output into partial_block
             if (
@@ -630,35 +632,37 @@ class TransformerLayer(nn.Layer):
             )
 
             # MLP (skip internal bda residual)
-            mlp_out = self._forward_mlp(
-                hidden_states,
-                block_attention_residuals=True,
-            )
+            with profile(timer_name):
+                mlp_out = self._forward_mlp(
+                    hidden_states,
+                    block_attention_residuals=True,
+                )
 
             # Accumulate mlp output into partial_block
             output = partial_block + mlp_out
         else:
             self._log_md5(hidden_states, "input", self.layer_number)
-            hidden_states, context = self._forward_attention(
-                hidden_states=hidden_states,
-                attention_mask=attention_mask,
-                attn_mask_startend_row_indices=attn_mask_startend_row_indices,
-                context=context,
-                context_mask=context_mask,
-                rotary_pos_emb=rotary_pos_emb,
-                rotary_pos_cos=rotary_pos_cos,
-                rotary_pos_sin=rotary_pos_sin,
-                position_ids=position_ids,
-                attention_bias=attention_bias,
-                packed_seq_params=packed_seq_params,
-                in_recompute=self.full_recompute,
-            )
+            with profile("attn"):
+                hidden_states, context = self._forward_attention(
+                    hidden_states=hidden_states,
+                    attention_mask=attention_mask,
+                    attn_mask_startend_row_indices=attn_mask_startend_row_indices,
+                    context=context,
+                    context_mask=context_mask,
+                    rotary_pos_emb=rotary_pos_emb,
+                    rotary_pos_cos=rotary_pos_cos,
+                    rotary_pos_sin=rotary_pos_sin,
+                    position_ids=position_ids,
+                    attention_bias=attention_bias,
+                    packed_seq_params=packed_seq_params,
+                    in_recompute=self.full_recompute,
+                )
             self._log_md5(
                 hidden_states, "post_attn_residual", self.layer_number
             )
-            output = self._forward_mlp(hidden_states)
+            with profile(timer_name):
+                output = self._forward_mlp(hidden_states)
             self._log_md5(output, "layer_output", self.layer_number)
-
         if context is not None:
             return output, context
         return output
@@ -917,10 +921,17 @@ class TransformerLayerWithOverlap(TransformerLayer):
             )
 
     def compute_attention(self, dict_args, is_first_fwd=False):
-        return self._forward_attention(**dict_args, is_first_fwd=is_first_fwd)
+        with profile("attn"):
+            return self._forward_attention(
+                **dict_args, is_first_fwd=is_first_fwd
+            )
 
     def compute_mlp(self, hidden_states, is_first_fwd=False):
-        return self._forward_mlp(hidden_states, is_first_fwd=is_first_fwd)
+        timer_name = "moe-mlp" if isinstance(self.mlp, MoELayer) else "mlp"
+        with profile(timer_name):
+            return self._forward_mlp(
+                hidden_states, is_first_fwd=is_first_fwd
+            )
 
     def pre_process_compute(self, hidden_states):
         residual = hidden_states

--- a/src/paddlefleet/transformer/utils.py
+++ b/src/paddlefleet/transformer/utils.py
@@ -16,9 +16,12 @@
 
 from __future__ import annotations
 
+import contextlib
 from functools import lru_cache
 
 import paddle
+
+from paddlefleet.training.global_vars import get_profile_timers
 
 
 @lru_cache(maxsize=32)
@@ -41,6 +44,24 @@ def get_sliding_window_causal_mask(sq, skv, sliding_window):
 def attention_mask_func(attention_scores, attention_mask):
     attention_scores.masked_fill_(attention_mask, -10000.0)
     return attention_scores
+
+
+@contextlib.contextmanager
+def profile(name, use_event=True):
+    """Record a timer scope when profile timers are available."""
+    if not name:
+        yield
+        return
+
+    timers = get_profile_timers()
+    timer = timers(name, use_event=use_event) if timers is not None else None
+    if timer is not None:
+        timer.start()
+    try:
+        yield
+    finally:
+        if timer is not None:
+            timer.stop()
 
 
 def is_layer_window_attention(

--- a/tests/single_card_tests/transformer/test_moe_log_balance.py
+++ b/tests/single_card_tests/transformer/test_moe_log_balance.py
@@ -1,0 +1,153 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import paddle
+
+from paddlefleet.training.global_vars import (
+    get_global_training_logs,
+    set_global_training_logs,
+    set_profile_timers,
+    unset_global_variables,
+)
+import paddlefleet.transformer.moe.moe_utils as moe_utils
+from paddlefleet.transformer.moe.moe_utils import (
+    _all_gather_local_tokens,
+    global_moe_balance_training_logs_enabled,
+    log_moe_balance,
+)
+from paddlefleet.transformer.utils import profile
+
+
+class DummyLogs(dict):
+    def is_moe_balance_logs_enabled(self):
+        return True
+
+
+class TestMoeBalanceLogging(unittest.TestCase):
+    def setUp(self):
+        unset_global_variables()
+        set_global_training_logs(DummyLogs())
+
+    def tearDown(self):
+        unset_global_variables()
+
+    def test_alltoall_tensor_tokens_per_expert(self):
+        tokens_per_expert = paddle.to_tensor([2, 4, 6, 8], dtype="int64")
+
+        gathered = _all_gather_local_tokens(tokens_per_expert, None)
+        self.assertEqual(gathered.dtype, paddle.int64)
+        self.assertEqual(list(gathered.shape), [1, 4])
+
+        log_moe_balance(
+            layer_number=0,
+            moe_group=None,
+            num_experts_per_tok=2,
+            tokens_per_expert=tokens_per_expert,
+        )
+        logs = get_global_training_logs()
+
+        self.assertAlmostEqual(logs["tokens_per_expert_layer_0_mean"], 5.0)
+        self.assertAlmostEqual(logs["tokens_per_expert_layer_0_max"], 8.0)
+        self.assertAlmostEqual(
+            logs["tokens_per_expert_layer_0_max_mean_ratio"], 1.6
+        )
+        self.assertAlmostEqual(logs["tokens_per_expert_avg_layer_0_mean"], 0.5)
+        self.assertAlmostEqual(
+            logs["local_tokens_per_card_layer_0_mean"], 20.0
+        )
+        self.assertAlmostEqual(
+            logs["local_tokens_per_card_layer_0_max_mean_ratio"], 1.0
+        )
+
+    def test_deepep_python_int_list_tokens_per_expert(self):
+        tokens_per_expert = [3, 1, 5, 7]
+
+        captured = {}
+        orig_all_gather_local_tokens = moe_utils._all_gather_local_tokens
+
+        def wrapped_all_gather_local_tokens(local_tokens_per_expert, group):
+            captured["is_tensor"] = isinstance(local_tokens_per_expert, paddle.Tensor)
+            captured["is_cpu"] = local_tokens_per_expert.place.is_cpu_place()
+            captured["dtype"] = local_tokens_per_expert.dtype
+            captured["shape"] = list(local_tokens_per_expert.shape)
+            return orig_all_gather_local_tokens(local_tokens_per_expert, group)
+
+        moe_utils._all_gather_local_tokens = wrapped_all_gather_local_tokens
+
+        try:
+            log_moe_balance(
+                layer_number=1,
+                moe_group=None,
+                num_experts_per_tok=4,
+                tokens_per_expert=tokens_per_expert,
+            )
+        finally:
+            moe_utils._all_gather_local_tokens = orig_all_gather_local_tokens
+
+        self.assertTrue(captured["is_tensor"])
+        self.assertTrue(captured["is_cpu"])
+        self.assertEqual(captured["dtype"], paddle.int64)
+        self.assertEqual(captured["shape"], [4])
+
+        logs = get_global_training_logs()
+
+        self.assertAlmostEqual(logs["tokens_per_expert_layer_1_mean"], 4.0)
+        self.assertAlmostEqual(logs["tokens_per_expert_layer_1_min"], 1.0)
+        self.assertAlmostEqual(logs["tokens_per_expert_layer_1_max"], 7.0)
+        self.assertAlmostEqual(
+            logs["tokens_per_expert_layer_1_max_mean_ratio"], 1.75
+        )
+        self.assertAlmostEqual(logs["tokens_per_expert_avg_layer_1_mean"], 1.0)
+        self.assertAlmostEqual(
+            logs["local_tokens_per_card_layer_1_mean"], 16.0
+        )
+        self.assertAlmostEqual(
+            logs["local_tokens_per_card_layer_1_max_mean_ratio"], 1.0
+        )
+
+    def test_logs_object_enable_balance_gate(self):
+        self.assertTrue(global_moe_balance_training_logs_enabled())
+
+    def test_profile_stops_timer_on_exception(self):
+        events = []
+
+        class DummyTimer:
+            def start(self):
+                events.append("start")
+
+            def stop(self):
+                events.append("stop")
+
+        class DummyTimers:
+            def __call__(self, name, use_event=True):
+                events.append(("timer", name, use_event))
+                return DummyTimer()
+
+        unset_global_variables()
+        set_profile_timers(DummyTimers())
+
+        with self.assertRaisesRegex(RuntimeError, "boom"):
+            with profile("attn"):
+                raise RuntimeError("boom")
+
+        self.assertEqual(
+            events,
+            [("timer", "attn", True), "start", "stop"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/transformer/test_moe_log_balance.py
+++ b/tests/single_card_tests/transformer/test_moe_log_balance.py
@@ -22,7 +22,7 @@ from paddlefleet.training.global_vars import (
     set_profile_timers,
     unset_global_variables,
 )
-import paddlefleet.transformer.moe.moe_utils as moe_utils
+from paddlefleet.transformer.moe import moe_utils
 from paddlefleet.transformer.moe.moe_utils import (
     _all_gather_local_tokens,
     global_moe_balance_training_logs_enabled,
@@ -65,9 +65,7 @@ class TestMoeBalanceLogging(unittest.TestCase):
             logs["tokens_per_expert_layer_0_max_mean_ratio"], 1.6
         )
         self.assertAlmostEqual(logs["tokens_per_expert_avg_layer_0_mean"], 0.5)
-        self.assertAlmostEqual(
-            logs["local_tokens_per_card_layer_0_mean"], 20.0
-        )
+        self.assertAlmostEqual(logs["local_tokens_per_card_layer_0_mean"], 20.0)
         self.assertAlmostEqual(
             logs["local_tokens_per_card_layer_0_max_mean_ratio"], 1.0
         )
@@ -79,7 +77,9 @@ class TestMoeBalanceLogging(unittest.TestCase):
         orig_all_gather_local_tokens = moe_utils._all_gather_local_tokens
 
         def wrapped_all_gather_local_tokens(local_tokens_per_expert, group):
-            captured["is_tensor"] = isinstance(local_tokens_per_expert, paddle.Tensor)
+            captured["is_tensor"] = isinstance(
+                local_tokens_per_expert, paddle.Tensor
+            )
             captured["is_cpu"] = local_tokens_per_expert.place.is_cpu_place()
             captured["dtype"] = local_tokens_per_expert.dtype
             captured["shape"] = list(local_tokens_per_expert.shape)
@@ -111,9 +111,7 @@ class TestMoeBalanceLogging(unittest.TestCase):
             logs["tokens_per_expert_layer_1_max_mean_ratio"], 1.75
         )
         self.assertAlmostEqual(logs["tokens_per_expert_avg_layer_1_mean"], 1.0)
-        self.assertAlmostEqual(
-            logs["local_tokens_per_card_layer_1_mean"], 16.0
-        )
+        self.assertAlmostEqual(logs["local_tokens_per_card_layer_1_mean"], 16.0)
         self.assertAlmostEqual(
             logs["local_tokens_per_card_layer_1_max_mean_ratio"], 1.0
         )
@@ -139,9 +137,8 @@ class TestMoeBalanceLogging(unittest.TestCase):
         unset_global_variables()
         set_profile_timers(DummyTimers())
 
-        with self.assertRaisesRegex(RuntimeError, "boom"):
-            with profile("attn"):
-                raise RuntimeError("boom")
+        with self.assertRaisesRegex(RuntimeError, "boom"), profile("attn"):
+            raise RuntimeError("boom")
 
         self.assertEqual(
             events,


### PR DESCRIPTION
## Summary

为 PaddleFleet Transformer 层和 MoE 模块添加**模块级 profile 计时**与 **MoE 负载均衡日志**能力。

### 1. Profile 计时
- 在 `transformer/utils.py` 中新增 `profile(name)` 上下文管理器，自动从全局变量获取 profile timers，在进入/退出时调用 `start()`/`stop()`
- 在 `training/global_vars.py` 中注册两个新的全局变量：`_GLOBAL_PROFILE_TIMERS`（profile 计时器）和 `_GLOBAL_TRAINING_LOGS`（训练日志对象），并提供对应的 get/set 接口
- 在 `transformer_layer.py` 中为 `_forward_impl` 和 `compute_attention`/`compute_mlp` 的 attention、mlp/moe-mlp 阶段包裹 `profile()` scope
- 在 `moe_layer.py` 中为 dispatch、fusion_mlp、combine 三个阶段分别包裹 `profile()` scope

### 2. MoE 负载均衡日志
- 在 `moe/moe_utils.py` 中新增：
  - `global_moe_balance_training_logs_enabled()`：检查全局训练日志对象是否开启了 MoE balance 日志
  - `_all_gather_local_tokens()`：在 MoE group 内 all-gather 每张卡的 tokens_per_expert 分布
  - `log_moe_balance()`：在每次 dispatch 后记录各 expert 的 token 分配统计（max/min/var/median/mean 及 max_mean_ratio/min_mean_ratio），同时记录每张卡的 local token 总量分布
  - `_log_summary()` / `_log_tokens_per_expert()` / `_log_local_tokens_per_card()`：统计计算与日志写入的辅助函数
- 在 `moe_layer.py` 的 `custom_forward` 和 `fusion_moe_forward` 中，dispatch 后、仅在训练模式（`has_grad=True`）且日志开关打开时调用 `log_moe_balance()`

### 3. 单测
- 新增 `tests/single_card_tests/transformer/test_moe_log_balance.py`，覆盖：
  - Tensor 输入和 Python list 输入两种 tokens_per_expert 格式的日志正确性
  - `global_moe_balance_training_logs_enabled()` 开关判断
  - `profile()` 上下文管理器在异常时仍能正确 stop timer
