### PR TITLE
[FIX] Add CUDA check for fused RoPE ops to support non-CUDA devices

### DIFF
--- a/src/paddlefleet/models/common/embeddings/rope_utils.py
+++ b/src/paddlefleet/models/common/embeddings/rope_utils.py
@@ -29,7 +29,18 @@ from paddle.incubate.nn.functional import (
 )
 
 if paddle.is_compiled_with_cuda():
-    from paddlefleet.ops import fused_apply_rotary_pos_emb_vision
+    try:
+        from paddlefleet.ops import fused_apply_rotary_pos_emb_vision
+    except ImportError:
+        logging.getLogger(__name__).warning(
+            "Failed to import optional CUDA op "
+            "'fused_apply_rotary_pos_emb_vision'; falling back to the "
+            "non-fused rotary position embedding path."
+        )
+        fused_apply_rotary_pos_emb_vision = None
+else:
+    fused_apply_rotary_pos_emb_vision = None
+
 from paddlefleet.utils import get_pg_rank, get_pg_size
 
 logger = logging.getLogger(__name__)
@@ -146,7 +157,7 @@ def _apply_rotary_pos_emb_bshd(
             # - only supports non-interleaved mode and mscale=1.0
             # - freqs must be reshaped to [s, dim//2]
             if (
-                paddle.is_compiled_with_cuda()
+                fused_apply_rotary_pos_emb_vision is not None
                 and not rotary_interleaved
                 and mscale == 1.0
                 and freqs is not None

--- a/src/paddlefleet/models/common/embeddings/rope_utils.py
+++ b/src/paddlefleet/models/common/embeddings/rope_utils.py
@@ -28,7 +28,8 @@ from paddle.incubate.nn.functional import (
     fused_rotary_position_embedding as fused_rope,
 )
 
-from paddlefleet.ops import fused_apply_rotary_pos_emb_vision
+if paddle.is_compiled_with_cuda():
+    from paddlefleet.ops import fused_apply_rotary_pos_emb_vision
 from paddlefleet.utils import get_pg_rank, get_pg_size
 
 logger = logging.getLogger(__name__)
@@ -138,7 +139,7 @@ def _apply_rotary_pos_emb_bshd(
     mscale = mscale if mscale is not None else 1.0
 
     if apply_rope_fusion:
-        if high_precision_rope:
+        if high_precision_rope and paddle.is_compiled_with_cuda():
             # Fused vision RoPE CUDA kernel path:
             # - internally computes cos/sin in fp32, equivalent to high_precision_rope
             # - only supports single Tensor input with explicit freqs

--- a/src/paddlefleet/models/common/embeddings/rope_utils.py
+++ b/src/paddlefleet/models/common/embeddings/rope_utils.py
@@ -139,14 +139,15 @@ def _apply_rotary_pos_emb_bshd(
     mscale = mscale if mscale is not None else 1.0
 
     if apply_rope_fusion:
-        if high_precision_rope and paddle.is_compiled_with_cuda():
+        if high_precision_rope:
             # Fused vision RoPE CUDA kernel path:
             # - internally computes cos/sin in fp32, equivalent to high_precision_rope
             # - only supports single Tensor input with explicit freqs
             # - only supports non-interleaved mode and mscale=1.0
             # - freqs must be reshaped to [s, dim//2]
             if (
-                not rotary_interleaved
+                paddle.is_compiled_with_cuda()
+                and not rotary_interleaved
                 and mscale == 1.0
                 and freqs is not None
                 and not isinstance(t, tuple)


### PR DESCRIPTION
## Summary

  - Add `paddle.is_compiled_with_cuda()` check before importing
  `fused_apply_rotary_pos_emb_vision`
  - Add CUDA check condition for `high_precision_rope` path in
  `_apply_rotary_pos_emb_bshd`
  - Enables compatibility with XPU and other non-CUDA backends

  ## Motivation

  The `fused_apply_rotary_pos_emb_vision` operator is a CUDA-specific
  kernel. In non-CUDA environments (e.g., XPU), importing this module
  causes import errors and the `high_precision_rope` path fails during
  execution.

  ## Changes

  | File | Change |
  |------|--------|
  | `src/paddlefleet/models/common/embeddings/rope_utils.py` | Added CUDA compile check for conditional import and execution |
