### PR TITLE
[CI]fix precision update

### DIFF
--- a/.github/workflows/update-precision.yml
+++ b/.github/workflows/update-precision.yml
@@ -57,7 +57,8 @@ jobs:
           mkdir bos
           tar xf bos_new.tar.gz -C bos
           export step="fleet"
-          git clone https://github.com/PaddlePaddle/PaddleFormers.git .
+          git clone https://github.com/PaddlePaddle/PaddleFormers.git
+          cd PaddleFormers
           bash -x tests/integration_test/update_precision.sh
 
   # update-precision-formers:


### PR DESCRIPTION
精度更新脚本在下载Formers仓库到当前目录时，遇到目录不为空的问题