### PR TITLE
[DotProductAttention] Support _attn_implementation config for eager attn

### DIFF
--- a/src/paddlefleet/transformer/dot_product_attention.py
+++ b/src/paddlefleet/transformer/dot_product_attention.py
@@ -279,6 +279,13 @@ class DotProductAttention(FleetLayer):
             from paddle.nn.functional.flash_attention import (
                 flashmask_attention as _flashmask_attention,
             )
+        use_eager = getattr(self.config, '_attn_implementation', 'default') == 'eager'
+
+        if use_eager and packed_seq_params is not None:
+            raise ValueError(
+                "packed_seq_params is not supported when _attn_implementation='eager'. "
+            )
+
         if packed_seq_params is not None:
             assert (
                 query.dtype == paddle.bfloat16 or query.dtype == paddle.float16
@@ -328,7 +335,11 @@ class DotProductAttention(FleetLayer):
             )
             attn_output = attn_output.reshape([0, 0, -1])
             return attn_output
-        use_eager = getattr(self.config, '_attn_implementation', 'default') == 'eager'
+        if use_eager and attn_mask_startend_row_indices is not None:
+            raise ValueError(
+                "attn_mask_startend_row_indices is not supported when _attn_implementation='eager'. "
+            )
+
         if (
             query.dtype == paddle.bfloat16 or query.dtype == paddle.float16
         ) and attn_mask_startend_row_indices is None and not use_eager:

--- a/src/paddlefleet/transformer/dot_product_attention.py
+++ b/src/paddlefleet/transformer/dot_product_attention.py
@@ -328,9 +328,10 @@ class DotProductAttention(FleetLayer):
             )
             attn_output = attn_output.reshape([0, 0, -1])
             return attn_output
+        use_eager = getattr(self.config, '_attn_implementation', 'default') == 'eager'
         if (
             query.dtype == paddle.bfloat16 or query.dtype == paddle.float16
-        ) and attn_mask_startend_row_indices is None:
+        ) and attn_mask_startend_row_indices is None and not use_eager:
             # Note:
             # attention_mask is None in default
             # is_causal is True in default
@@ -355,7 +356,7 @@ class DotProductAttention(FleetLayer):
 
         elif (
             query.dtype == paddle.bfloat16 or query.dtype == paddle.float16
-        ) and attn_mask_startend_row_indices is not None:
+        ) and attn_mask_startend_row_indices is not None and not use_eager:
             # Note:
             # attn_mask_startend_row_indices is not None for flashmask
             flashmask_attention_func = (


### PR DESCRIPTION
paddlefleet 中增加 eager attn 控制，方便后续与竞品进行模型逐位对齐。