### PR TITLE
[DotProductAttention] Support _attn_implementation config for eager attn

### DIFF
--- a/src/paddlefleet/transformer/dot_product_attention.py
+++ b/src/paddlefleet/transformer/dot_product_attention.py
@@ -279,15 +279,12 @@ class DotProductAttention(FleetLayer):
             from paddle.nn.functional.flash_attention import (
                 flashmask_attention as _flashmask_attention,
             )
-        use_eager = (
-            getattr(self.config, "_attn_implementation", "default") == "eager"
-        )
+        use_eager = self.config._attn_implementation == "eager"
 
         if use_eager and packed_seq_params is not None:
             raise ValueError(
                 "packed_seq_params is not supported when "
-                "_attn_implementation='eager'. Supported values: "
-                "'default', 'eager'."
+                "_attn_implementation='eager'."
             )
 
         if packed_seq_params is not None:

--- a/src/paddlefleet/transformer/dot_product_attention.py
+++ b/src/paddlefleet/transformer/dot_product_attention.py
@@ -279,6 +279,15 @@ class DotProductAttention(FleetLayer):
             from paddle.nn.functional.flash_attention import (
                 flashmask_attention as _flashmask_attention,
             )
+        use_eager = (
+            getattr(self.config, "_attn_implementation", "default") == "eager"
+        )
+
+        if use_eager and packed_seq_params is not None:
+            raise ValueError(
+                "packed_seq_params is not supported when _attn_implementation='eager'. "
+            )
+
         if packed_seq_params is not None:
             assert (
                 query.dtype == paddle.bfloat16 or query.dtype == paddle.float16
@@ -328,9 +337,16 @@ class DotProductAttention(FleetLayer):
             )
             attn_output = attn_output.reshape([0, 0, -1])
             return attn_output
+        if use_eager and attn_mask_startend_row_indices is not None:
+            raise ValueError(
+                "attn_mask_startend_row_indices is not supported when _attn_implementation='eager'. "
+            )
+
         if (
-            query.dtype == paddle.bfloat16 or query.dtype == paddle.float16
-        ) and attn_mask_startend_row_indices is None:
+            (query.dtype == paddle.bfloat16 or query.dtype == paddle.float16)
+            and attn_mask_startend_row_indices is None
+            and not use_eager
+        ):
             # Note:
             # attention_mask is None in default
             # is_causal is True in default
@@ -354,8 +370,10 @@ class DotProductAttention(FleetLayer):
             return attn_output
 
         elif (
-            query.dtype == paddle.bfloat16 or query.dtype == paddle.float16
-        ) and attn_mask_startend_row_indices is not None:
+            (query.dtype == paddle.bfloat16 or query.dtype == paddle.float16)
+            and attn_mask_startend_row_indices is not None
+            and not use_eager
+        ):
             # Note:
             # attn_mask_startend_row_indices is not None for flashmask
             flashmask_attention_func = (

--- a/src/paddlefleet/transformer/dot_product_attention.py
+++ b/src/paddlefleet/transformer/dot_product_attention.py
@@ -285,7 +285,9 @@ class DotProductAttention(FleetLayer):
 
         if use_eager and packed_seq_params is not None:
             raise ValueError(
-                "packed_seq_params is not supported when _attn_implementation='eager'. "
+                "packed_seq_params is not supported when "
+                "_attn_implementation='eager'. Supported values: "
+                "'default', 'eager'."
             )
 
         if packed_seq_params is not None:

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -146,6 +146,9 @@ class TransformerConfig(ModelParallelConfig):
     attention_dropout: float = 0.0
     """Post attention dropout probability."""
 
+    _attn_implementation: str = "default"
+    """Attention implementation to use."""
+
     intermediate_size: int | None = None
     """Transformer Feed-Forward Network hidden size. This is set to 4*hidden_size
     if not provided."""


### PR DESCRIPTION
paddlefleet 中增加 eager attn 控制，方便后续与竞品进行模型逐位对齐。