### PR TITLE
[DotProductAttention] Support _attn_implementation config for eager attn

### DIFF
--- a/src/paddlefleet/transformer/dot_product_attention.py
+++ b/src/paddlefleet/transformer/dot_product_attention.py
@@ -279,6 +279,8 @@ class DotProductAttention(FleetLayer):
             from paddle.nn.functional.flash_attention import (
                 flashmask_attention as _flashmask_attention,
             )
+        use_eager = self.config._attn_implementation == "eager"
+
         if packed_seq_params is not None:
             assert (
                 query.dtype == paddle.bfloat16 or query.dtype == paddle.float16
@@ -329,8 +331,10 @@ class DotProductAttention(FleetLayer):
             attn_output = attn_output.reshape([0, 0, -1])
             return attn_output
         if (
-            query.dtype == paddle.bfloat16 or query.dtype == paddle.float16
-        ) and attn_mask_startend_row_indices is None:
+            (query.dtype == paddle.bfloat16 or query.dtype == paddle.float16)
+            and attn_mask_startend_row_indices is None
+            and not use_eager
+        ):
             # Note:
             # attention_mask is None in default
             # is_causal is True in default
@@ -354,8 +358,10 @@ class DotProductAttention(FleetLayer):
             return attn_output
 
         elif (
-            query.dtype == paddle.bfloat16 or query.dtype == paddle.float16
-        ) and attn_mask_startend_row_indices is not None:
+            (query.dtype == paddle.bfloat16 or query.dtype == paddle.float16)
+            and attn_mask_startend_row_indices is not None
+            and not use_eager
+        ):
             # Note:
             # attn_mask_startend_row_indices is not None for flashmask
             flashmask_attention_func = (

--- a/src/paddlefleet/transformer/dot_product_attention.py
+++ b/src/paddlefleet/transformer/dot_product_attention.py
@@ -281,6 +281,11 @@ class DotProductAttention(FleetLayer):
             )
         use_eager = self.config._attn_implementation == "eager"
 
+        if use_eager and packed_seq_params is not None:
+            raise ValueError(
+                'packed_seq_params does not support _attn_implementation="eager"; '
+                "please disable packed sequence inputs or use a fused attention implementation."
+            )
         if packed_seq_params is not None:
             assert (
                 query.dtype == paddle.bfloat16 or query.dtype == paddle.float16

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -146,6 +146,9 @@ class TransformerConfig(ModelParallelConfig):
     attention_dropout: float = 0.0
     """Post attention dropout probability."""
 
+    _attn_implementation: str = "default"
+    """Attention implementation to use."""
+
     intermediate_size: int | None = None
     """Transformer Feed-Forward Network hidden size. This is set to 4*hidden_size
     if not provided."""

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_dot_product_attention.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_dot_product_attention.py
@@ -288,6 +288,26 @@ class TestDotProductAttentionBF16(unittest.TestCase):
         paddle.device.set_device("cpu")
 
 
+class TestDotProductAttentionEager(unittest.TestCase):
+    """Tests for DotProductAttention with _attn_implementation='eager'."""
+
+    def test_eager_forward_fp32(self):
+        config = _make_config()
+        config._attn_implementation = "eager"
+        attn = DotProductAttention(
+            config=config,
+            layer_number=1,
+            attn_mask_type=AttnMaskType.causal,
+            attention_type="self",
+        )
+        attn.eval()
+        q = paddle.randn([2, 4, 4, 32], dtype=paddle.float32)
+        k = paddle.randn([2, 4, 4, 32], dtype=paddle.float32)
+        v = paddle.randn([2, 4, 4, 32], dtype=paddle.float32)
+        out = attn(q, k, v, None)
+        self.assertEqual(out.shape, [2, 4, 128])
+
+
 class TestCPDotProductAttention(unittest.TestCase):
     """Tests for CPDotProductAttention."""
 

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_dot_product_attention.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_dot_product_attention.py
@@ -291,9 +291,13 @@ class TestDotProductAttentionBF16(unittest.TestCase):
 class TestDotProductAttentionEager(unittest.TestCase):
     """Tests for DotProductAttention with _attn_implementation='eager'."""
 
-    def test_eager_forward_fp32(self):
-        config = _make_config()
+    def _make_eager_config(self, **overrides):
+        config = _make_config(**overrides)
         config._attn_implementation = "eager"
+        return config
+
+    def test_eager_forward_fp32(self):
+        config = self._make_eager_config()
         attn = DotProductAttention(
             config=config,
             layer_number=1,
@@ -306,6 +310,48 @@ class TestDotProductAttentionEager(unittest.TestCase):
         v = paddle.randn([2, 4, 4, 32], dtype=paddle.float32)
         out = attn(q, k, v, None)
         self.assertEqual(out.shape, [2, 4, 128])
+
+    @unittest.skipIf(not paddle.is_compiled_with_cuda(), "Requires CUDA")
+    def test_eager_fp16_skips_sdpa(self):
+        """fp16 + eager should bypass scaled_dot_product_attention."""
+        config = self._make_eager_config()
+        attn = DotProductAttention(
+            config=config,
+            layer_number=1,
+            attn_mask_type=AttnMaskType.causal,
+            attention_type="self",
+        )
+        attn.eval()
+        paddle.device.set_device("gpu:0")
+        q = paddle.randn([2, 4, 4, 32], dtype=paddle.float16)
+        k = paddle.randn([2, 4, 4, 32], dtype=paddle.float16)
+        v = paddle.randn([2, 4, 4, 32], dtype=paddle.float16)
+        with patch(
+            "paddle.nn.functional.scaled_dot_product_attention",
+            side_effect=AssertionError(
+                "SDPA should not be called in eager mode"
+            ),
+        ) as mock_sdpa:
+            out = attn(q, k, v, None)
+            mock_sdpa.assert_not_called()
+        self.assertEqual(out.shape, [2, 4, 128])
+        paddle.device.set_device("cpu")
+
+    def test_eager_packed_seq_raises(self):
+        """eager + packed_seq_params should raise ValueError."""
+        config = self._make_eager_config()
+        attn = DotProductAttention(
+            config=config,
+            layer_number=1,
+            attn_mask_type=AttnMaskType.causal,
+            attention_type="self",
+        )
+        q = paddle.randn([2, 4, 4, 32])
+        k = paddle.randn([2, 4, 4, 32])
+        v = paddle.randn([2, 4, 4, 32])
+        with self.assertRaises(ValueError) as ctx:
+            attn(q, k, v, None, packed_seq_params=MagicMock())
+        self.assertIn("packed_seq_params", str(ctx.exception))
 
 
 class TestCPDotProductAttention(unittest.TestCase):


### PR DESCRIPTION
paddlefleet 中增加 eager attn 控制，方便后续与竞品进行模型逐位对齐。