### PR TITLE
Fix gates accumulation seq mismatch with ec

### DIFF
--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -615,9 +615,9 @@ class TopKRouter(StandardMoERouter):
                     gates_ori.sum(axis=-1, keepdim=True) + 1e-20
                 )
             else:
-                # Using the clone to ensure that the execution order of the  gradnodes is consistent with EC
+                # Use clone() to ensure that the execution order of the grad nodes is consistent with EC.
                 gates_ori = gates_ori.clone()
-                # Using Clip for ensure the compute logic is consistent with EC, it maybe useful when grad is very small
+                # Use clip() to ensure the computation logic is consistent with EC; it may be useful when gradients are very small.
                 gates_ori = gates_ori / paddle.clip(
                     gates_ori.sum(-1, keepdim=True), min=1e-12
                 )

--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -693,20 +693,21 @@ class TopKRouter(StandardMoERouter):
         gates_masked = gates * mask
 
         # norm
-        if not getattr(
-            self.config, "gpt_model_use_experimental_version", False
-        ):
-            # When gpt_model_use_experimental_version is True, top_gate is already normalized by FusedMoETopk
-            if self.norm_topk_prob:
+
+        if self.norm_topk_prob:
+            if not getattr(
+                self.config, "gpt_model_use_experimental_version", False
+            ):
                 denominator = top_gate.sum(axis=-1, keepdim=True) + 1e-20
                 top_gate = top_gate / denominator
-        # Reconstruct gates_masked from top_gate  to ensure
-        # bit-exact alignment. Instead of normalizing gates_masked independently
-        # (which uses different FP32 reduction over E=32 elements vs K=8),
-        # scatter the already-normalized top_gate values back to [S, E] layout.
-        gates_masked = paddle.zeros_like(gates).put_along_axis(
-            top_idx, top_gate, axis=1
-        )
+            # When gpt_model_use_experimental_version is True, top_gate is already normalized by FusedMoETopk
+            # Reconstruct gates_masked from top_gate  to ensure
+            # bit-exact alignment. Instead of normalizing gates_masked independently
+            # (which uses different FP32 reduction over E=32 elements vs K=8),
+            # scatter the already-normalized top_gate values back to [S, E] layout.
+            gates_masked = paddle.zeros_like(gates).put_along_axis(
+                top_idx, top_gate, axis=1
+            )
 
         if abs(self.routed_scaling_factor - 1.0) > 1e-6:
             top_gate = top_gate * self.routed_scaling_factor

--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -608,9 +608,19 @@ class TopKRouter(StandardMoERouter):
 
         gates_ori = gates
         if self.scoring_func == "sigmoid":
-            gates_ori = gates_ori / (
-                gates_ori.sum(axis=-1, keepdim=True) + 1e-20
-            )
+            if not getattr(
+                self.config, "gpt_model_use_experimental_version", False
+            ):
+                gates_ori = gates_ori / (
+                    gates_ori.sum(axis=-1, keepdim=True) + 1e-20
+                )
+            else:
+                # Using the clone to ensure that the execution order of the  gradnodes is consistent with EC
+                gates_ori = gates_ori.clone()
+                # Using Clip for ensure the compute logic is consistent with EC, it maybe useful when grad is very small
+                gates_ori = gates_ori / paddle.clip(
+                    gates_ori.sum(-1, keepdim=True), min=1e-12
+                )
 
         if getattr(self.config, "gpt_model_use_experimental_version", False):
             # Use EC's FusedMoETopk Triton kernel for bit-exact alignment.

--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -603,10 +603,9 @@ class TopKRouter(StandardMoERouter):
         _log_moe_md5(logits, "gate_logits", self._layer_number)
 
         gates = self.gate_score_func(logits)
-
         _log_moe_md5(gates, "gate_probs_sigmoid", self._layer_number)
-
-        gates_ori = gates
+        # Use clone() to ensure that the execution order of the grad nodes is consistent with EC.
+        gates_ori = gates.clone()
         if self.scoring_func == "sigmoid":
             if not getattr(
                 self.config, "gpt_model_use_experimental_version", False
@@ -615,8 +614,6 @@ class TopKRouter(StandardMoERouter):
                     gates_ori.sum(axis=-1, keepdim=True) + 1e-20
                 )
             else:
-                # Use clone() to ensure that the execution order of the grad nodes is consistent with EC.
-                gates_ori = gates_ori.clone()
                 # Use clip() to ensure the computation logic is consistent with EC; it may be useful when gradients are very small.
                 gates_ori = gates_ori / paddle.clip(
                     gates_ori.sum(-1, keepdim=True), min=1e-12

--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -700,20 +700,13 @@ class TopKRouter(StandardMoERouter):
             if self.norm_topk_prob:
                 denominator = top_gate.sum(axis=-1, keepdim=True) + 1e-20
                 top_gate = top_gate / denominator
-                if self.num_experts_per_tok > 1:
-                    gates_s = paddle.sum(gates_masked, axis=-1, keepdim=True)
-                    denom_s = paddle.clip(
-                        gates_s, min=paddle.finfo(gates_masked.dtype).eps
-                    )
-                    gates_masked = gates_masked / denom_s
-        else:
-            # Reconstruct gates_masked from top_gate (Triton kernel output) to ensure
-            # bit-exact alignment. Instead of normalizing gates_masked independently
-            # (which uses different FP32 reduction over E=32 elements vs K=8),
-            # scatter the already-normalized top_gate values back to [S, E] layout.
-            gates_masked = paddle.zeros_like(gates).put_along_axis(
-                top_idx, top_gate, axis=1
-            )
+        # Reconstruct gates_masked from top_gate  to ensure
+        # bit-exact alignment. Instead of normalizing gates_masked independently
+        # (which uses different FP32 reduction over E=32 elements vs K=8),
+        # scatter the already-normalized top_gate values back to [S, E] layout.
+        gates_masked = paddle.zeros_like(gates).put_along_axis(
+            top_idx, top_gate, axis=1
+        )
 
         if abs(self.routed_scaling_factor - 1.0) > 1e-6:
             top_gate = top_gate * self.routed_scaling_factor


### PR DESCRIPTION
# 修复aux loss对gate的梯度的累加顺序和EC不一致的问题

## 修复前前向逻辑
<img width="488" height="224" alt="image" src="https://github.com/user-attachments/assets/89f2f4c5-6407-4243-93b2-ec10a22a7ba2" />

## 修复后前向逻辑
<img width="388" height="272" alt="image" src="https://github.com/user-attachments/assets/28ed2680-d272-4f02-97c7-47da4aa37e28" />


# 问题：
- 修复前的反向时FusedMoETopk、Div、Sum对gates的梯度的累加顺序和EC中的累加顺序不同，导致gates的梯度无法逐位对齐。可以使用clone保证 Div和Sum的Grad先加，加完之后再和FusedMoETopk反向的Grad相加（使用clone这个行为和EC保持一致）
- EC中在sum之后做了次clip 会将小于1e-12的的数值，反向时如果grad的数值小于1e-12的话也会裁切掉

## 修改gates_mask的计算方式
使用 
```
gates_masked = paddle.zeros_like(gates).put_along_axis(
                top_idx, top_gate, axis=1
            )
```
代替

```
                    gates_s = paddle.sum(gates_masked, axis=-1, keepdim=True)
                    denom_s = paddle.clip(
                        gates_s, min=paddle.finfo(gates_masked.dtype).eps
                    )
                    gates_masked = gates_masked / denom_s
```
计算gates_masked，会有一定的精度变化