### PR TITLE
log MoE aux/zloss into balance logs

### DIFF
--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -86,6 +86,7 @@ from .moe_utils import (
     count_cumsum,
     filter_scores,
     fused_expert_parallel_TC_topk_router_metadata,
+    log_moe_losses,
     global_moe_balance_training_logs_enabled,
     log_moe_balance,
     permute,
@@ -744,6 +745,8 @@ class MoELayer(nn.Layer):
 
         _log_moe_md5(gates_masked, "gates_masked", layer_idx)
         _log_moe_md5(mask, "routing_mask", layer_idx)
+        if framework._dygraph_tracer()._has_grad:
+            log_moe_losses(layer_idx, aux_loss=aux_loss, z_loss=z_loss)
 
         if (
             self.shared_experts is not None

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -86,9 +86,9 @@ from .moe_utils import (
     count_cumsum,
     filter_scores,
     fused_expert_parallel_TC_topk_router_metadata,
-    log_moe_losses,
     global_moe_balance_training_logs_enabled,
     log_moe_balance,
+    log_moe_losses,
     permute,
     unpermute,
 )

--- a/src/paddlefleet/transformer/moe/moe_utils.py
+++ b/src/paddlefleet/transformer/moe/moe_utils.py
@@ -255,6 +255,29 @@ def global_moe_balance_training_logs_enabled():
     return callable(is_enabled) and is_enabled()
 
 
+def log_moe_losses(layer_number, aux_loss=None, z_loss=None):
+    if not global_moe_balance_training_logs_enabled():
+        return
+    logs = get_global_training_logs()
+    if logs is None or not hasattr(logs, "update"):
+        return
+
+    log = {}
+    if aux_loss is not None:
+        aux_loss = aux_loss.detach()
+        log["aux_loss"] = aux_loss
+        if layer_number is not None:
+            log[f"aux_loss_layer_{layer_number}"] = aux_loss
+
+    if z_loss is not None:
+        z_loss = z_loss.detach()
+        log["zloss"] = z_loss
+        if layer_number is not None:
+            log[f"zloss_layer_{layer_number}"] = z_loss
+
+    logs.update(**log)
+
+
 def _all_gather_local_tokens(local_tokens_per_expert, group):
     local_tokens_per_expert = local_tokens_per_expert.reshape([-1])
     if group is None or get_pg_size(group) <= 1 or not group.is_member():

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_layer_transformer_extra.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_layer_transformer_extra.py
@@ -297,5 +297,55 @@ class TestMoELayerFp8QuantWeight(unittest.TestCase):
         layer.fp8_quant_weight()
 
 
+class TestMoELayerForwardLogging(unittest.TestCase):
+    """Test forward loss logging hooks."""
+
+    @patch("paddlefleet.transformer.moe.moe_layer.framework._dygraph_tracer")
+    @patch("paddlefleet.transformer.moe.moe_layer.log_moe_losses")
+    @patch("paddlefleet.transformer.moe.moe_layer._log_moe_md5")
+    def test_forward_logs_aux_and_zloss_when_has_grad(
+        self, mock_log_md5, mock_log_moe_losses, mock_tracer
+    ):
+        del mock_log_md5
+        hidden_states = paddle.randn([4, 64], dtype="float32")
+        aux_loss = paddle.to_tensor(1.5, dtype="float32")
+        z_loss = paddle.to_tensor(2.5, dtype="float32")
+
+        layer = MoELayer.__new__(MoELayer)
+        layer.sequence_parallel = False
+        layer.expert_model_parallel_size = 1
+        layer.shared_experts = None
+        layer.moe_shared_expert_overlap = False
+        layer.moe_use_fusion_node = False
+        layer.moe_grouped_gemm = False
+        layer.training = False
+        layer.router_aux_loss_coef = None
+        layer.layer_number = 7
+        layer.gate = MagicMock(
+            return_value=(
+                None,
+                paddle.randn([4, 2], dtype="float32"),
+                paddle.randint(0, 4, [4, 2], dtype="int64"),
+                paddle.randn([4, 4], dtype="float32"),
+                paddle.randint(0, 2, [4, 4], dtype="int64"),
+                None,
+                aux_loss,
+                z_loss,
+            )
+        )
+        layer._forward_single_card_moe = MagicMock(return_value=hidden_states)
+        tracer = MagicMock()
+        tracer._has_grad = True
+        mock_tracer.return_value = tracer
+
+        output, bias = layer.forward(hidden_states)
+
+        mock_log_moe_losses.assert_called_once_with(
+            7, aux_loss=aux_loss, z_loss=z_loss
+        )
+        self.assertEqual(list(output.shape), [4, 64])
+        self.assertIsNone(bias)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/single_card_tests/transformer/test_moe_log_balance.py
+++ b/tests/single_card_tests/transformer/test_moe_log_balance.py
@@ -148,6 +148,18 @@ class TestMoeBalanceLogging(unittest.TestCase):
         self.assertAlmostEqual(logs["zloss"].item(), 3.5)
         self.assertAlmostEqual(logs["zloss_layer_5"].item(), 3.5)
 
+    def test_log_moe_losses_without_layer_number_only_logs_global_keys(self):
+        aux_loss = paddle.to_tensor(1.0, dtype="float32")
+        z_loss = paddle.to_tensor(2.0, dtype="float32")
+
+        log_moe_losses(layer_number=None, aux_loss=aux_loss, z_loss=z_loss)
+        logs = get_global_training_logs()
+
+        self.assertAlmostEqual(logs["aux_loss"].item(), 1.0)
+        self.assertAlmostEqual(logs["zloss"].item(), 2.0)
+        self.assertNotIn("aux_loss_layer_None", logs)
+        self.assertNotIn("zloss_layer_None", logs)
+
     def test_log_moe_losses_respects_balance_gate(self):
         unset_global_variables()
         set_global_training_logs(DummyDisabledLogs())

--- a/tests/single_card_tests/transformer/test_moe_log_balance.py
+++ b/tests/single_card_tests/transformer/test_moe_log_balance.py
@@ -27,6 +27,7 @@ from paddlefleet.transformer.moe.moe_utils import (
     _all_gather_local_tokens,
     global_moe_balance_training_logs_enabled,
     log_moe_balance,
+    log_moe_losses,
 )
 from paddlefleet.transformer.utils import profile
 
@@ -34,6 +35,11 @@ from paddlefleet.transformer.utils import profile
 class DummyLogs(dict):
     def is_moe_balance_logs_enabled(self):
         return True
+
+
+class DummyDisabledLogs(dict):
+    def is_moe_balance_logs_enabled(self):
+        return False
 
 
 class TestMoeBalanceLogging(unittest.TestCase):
@@ -118,6 +124,41 @@ class TestMoeBalanceLogging(unittest.TestCase):
 
     def test_logs_object_enable_balance_gate(self):
         self.assertTrue(global_moe_balance_training_logs_enabled())
+
+    def test_log_moe_losses_logs_non_none_values(self):
+        aux_loss = paddle.to_tensor(1.25, dtype="float32")
+        z_loss = paddle.to_tensor(2.5, dtype="float32")
+
+        log_moe_losses(layer_number=3, aux_loss=aux_loss, z_loss=z_loss)
+        logs = get_global_training_logs()
+
+        self.assertAlmostEqual(logs["aux_loss"].item(), 1.25)
+        self.assertAlmostEqual(logs["aux_loss_layer_3"].item(), 1.25)
+        self.assertAlmostEqual(logs["zloss"].item(), 2.5)
+        self.assertAlmostEqual(logs["zloss_layer_3"].item(), 2.5)
+
+    def test_log_moe_losses_skips_none_values(self):
+        z_loss = paddle.to_tensor(3.5, dtype="float32")
+
+        log_moe_losses(layer_number=5, aux_loss=None, z_loss=z_loss)
+        logs = get_global_training_logs()
+
+        self.assertNotIn("aux_loss", logs)
+        self.assertNotIn("aux_loss_layer_5", logs)
+        self.assertAlmostEqual(logs["zloss"].item(), 3.5)
+        self.assertAlmostEqual(logs["zloss_layer_5"].item(), 3.5)
+
+    def test_log_moe_losses_respects_balance_gate(self):
+        unset_global_variables()
+        set_global_training_logs(DummyDisabledLogs())
+
+        log_moe_losses(
+            layer_number=1,
+            aux_loss=paddle.to_tensor(1.0, dtype="float32"),
+            z_loss=paddle.to_tensor(2.0, dtype="float32"),
+        )
+
+        self.assertEqual(get_global_training_logs(), {})
 
     def test_profile_stops_timer_on_exception(self):
         events = []


### PR DESCRIPTION
This PR reopens #823 from a fork branch because the previous PR was created from a branch in `PaddlePaddle/PaddleFleet` instead of `huangjiyi/PaddleFleet`.

## Summary
- add a shared `log_moe_losses` helper under the existing MoE balance logging gate
- record `aux_loss` and per-layer `aux_loss_layer_*` when the values are already computed
- record `zloss` and per-layer `zloss_layer_*` when the values are already computed
- keep the compute contract unchanged: this PR only logs existing values and does not force extra aux/z-loss computation

## Test plan
- `python -m py_compile src/paddlefleet/transformer/moe/moe_layer.py src/paddlefleet/transformer/moe/moe_utils.py`
- integration smoke verified from the erniebot fleet training path before publishing this PR
