### PR TITLE
Fix FP8Linear scale error in blackwell

### DIFF
--- a/src/paddlefleet/fp8/linear.py
+++ b/src/paddlefleet/fp8/linear.py
@@ -27,7 +27,9 @@ class _FP8Gemm(paddle.autograd.Function):
     """Forward and backward function for FP8 GEMM"""
 
     @staticmethod
-    def forward(ctx, inp, weight, inp_quant_func, weight_quant_func):
+    def forward(
+        ctx, inp, weight, inp_quant_func, weight_quant_func, use_pow2_scale
+    ):
         """
         Forward pass for FP8 GEMM.
 
@@ -56,6 +58,7 @@ class _FP8Gemm(paddle.autograd.Function):
         ctx.save_for_backward(
             inp_t_fp8, inp_t_scale, weight, weight_fp8, weight_scale
         )
+        ctx.use_pow2_scale = use_pow2_scale
         out = paddle.empty(
             [inp_fp8.shape[0], weight_fp8.shape[0]], dtype=paddle.bfloat16
         )
@@ -102,6 +105,7 @@ class _FP8Gemm(paddle.autograd.Function):
                 output_scale_transpose=False,
                 quant_method="1x128",
                 input_transpose=True,
+                using_pow2_scale=ctx.use_pow2_scale,
             )
         )
 
@@ -194,13 +198,23 @@ class FP8Linear(ColumnParallelLinear):
         # print("==== self.weight after ====")
         # print(self.weight.strides)
 
+        self.use_pow2_scale = (
+            paddle.device.cuda.get_device_capability()[0] == 10
+        )
         self.inp_quant_func, self.weight_quant_func = get_quant_func(
-            config.fp8_recipe, input_trans=True, out_scale_trans=False
+            config.fp8_recipe,
+            input_trans=True,
+            out_scale_trans=False,
+            pow2_scale=self.use_pow2_scale,
         )
 
     def forward(self, inp):
         out = _FP8Gemm.apply(
-            inp, self.weight, self.inp_quant_func, self.weight_quant_func
+            inp,
+            self.weight,
+            self.inp_quant_func,
+            self.weight_quant_func,
+            self.use_pow2_scale,
         )
         if self.bias is not None:
             out = out + self.bias

--- a/src/paddlefleet/fp8/linear.py
+++ b/src/paddlefleet/fp8/linear.py
@@ -28,7 +28,12 @@ class _FP8Gemm(paddle.autograd.Function):
 
     @staticmethod
     def forward(
-        ctx, inp, weight, inp_quant_func, weight_quant_func, use_pow2_scale
+        ctx,
+        inp,
+        weight,
+        inp_quant_func,
+        weight_quant_func,
+        use_pow2_scale=False,
     ):
         """
         Forward pass for FP8 GEMM.


### PR DESCRIPTION
# 问题：
在 Blackwell，compute capability 10+ 上运行 test_fp8_linear.py 时，out_diff 为 nan。

# 根因：
Blackwell GPU 的 FP8 量化要求使用 pow2 scale，但 FP8Linear 中的两处 quant 调用均未启用该选项：

FP8Linear.__init__ 调用 get_quant_func 时未传 pow2_scale（默认 False）
_FP8Gemm.backward 对 grad_output 直接调用 fp8_quant_blockwise 时未传 using_pow2_scale
# 修复:（仅改动 src/paddlefleet/fp8/linear.py）：

FP8Linear.__init__：按 paddle.device.cuda.get_device_capability()[0] == 10 自动判定，保存到 self.use_pow2_scale，并传入 get_quant_func(..., pow2_scale=self.use_pow2_scale)
FP8Linear.forward：将 self.use_pow2_scale 传入 _FP8Gemm.apply
_FP8Gemm.forward：新增参数 use_pow2_scale，保存到 ctx.use_pow2_scale
_FP8Gemm.backward：对 grad_output 的 fp8_quant_blockwise 调用增加 using_pow2_scale=ctx.use_pow2_scale
# 参照模式:
与 src/paddlefleet/transformer/moe/fp8_utils.py:98-101 的 Blackwell 检测一致。

# 验证：
pytest tests/single_card_tests/transformer/test_fp8_linear.py 2 passed。

<img width="2014" height="1112" alt="image" src="https://github.com/user-attachments/assets/ef5669b3-31dc-4695-a47d-e6533a247822" />
