### PR TITLE
[ThirdParty] [FA] update flash-attention to support use_varlen in flashmask and add several bug fix.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ src/paddlefleet/ops/deep_ep
 src/paddlefleet/ops/deep_ep_cpp.so
 src/paddlefleet/ops/sonicmoe
 src/paddlefleet/ops/quack
+src/paddlefleet/ops/flash_mask
 
 # Generated version files
 src/paddlefleet/version.py

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ def get_special_setup_deps():
         deps = [
             "triton",  # for deep_gemm, flashmask
             "nvidia-cutlass-dsl==4.4.1",  # for sonic_moe and flash_attention
+            "apache-tvm-ffi >= 0.1.5, < 0.2.0",  # for sonic_moe and flash_attention
             "filelock",  # for sonic_moe
         ]
         return deps


### PR DESCRIPTION
Update flash-attention submodule from 4c84f74 to 37a2126ec3ebfef86c6aaf9fb84e96a877ef55eb, including following changes:

1. Support use_varlen: https://github.com/PaddlePaddle/flash-attention/pull/129 https://github.com/PaddlePaddle/flash-attention/pull/135
2. Support hdim 256: https://github.com/PaddlePaddle/flash-attention/pull/130
3. Bug fixes: https://github.com/PaddlePaddle/flash-attention/pull/137 https://github.com/PaddlePaddle/flash-attention/pull/138
