### PR TITLE
[release/0.2] Temporary disable gpt_pp test

### DIFF
--- a/tests/multi_card_tests/pipeline_parallel/test_gpt_pp.py
+++ b/tests/multi_card_tests/pipeline_parallel/test_gpt_pp.py
@@ -142,6 +142,12 @@ def run_pp(
     return loss, gpt_pipe_model
 
 
+# NOTE(Pan Zhaowu): Temporary disable this test case due to PaddlePaddle PR78746
+# RE-enable this test case when PR78746 and related cherry-picks is merged
+@unittest.skipIf(
+    SKIP_TESTS,
+    f"Skipping tests: repo_flag={REPO_FLAG} (not 'paddlefleet')",
+)
 class TestPP(unittest.TestCase):
     def setUp(self):
         self.seed = 46


### PR DESCRIPTION
Temporary disable gpt_pp test

RE-enable these test cases when PR78746 and related cherry-picks is merged

devPR:https://github.com/PaddlePaddle/Paddle/pull/78746

Cherry-pick of #834 to `release/0.2`.

Merged in dev: #834  <!-- For pass CI -->