### PR TITLE
【Fix Tests】test_layers 单测在CI并行环境下的修复

### DIFF
--- a/src/paddlefleet/tensor_parallel/layers.py
+++ b/src/paddlefleet/tensor_parallel/layers.py
@@ -1004,7 +1004,7 @@ class Linear(paddle.nn.Layer):
         return None
 
     def __repr__(self):
-        use_bias = self.bias is not None and self.bias is True
+        use_bias = self.bias is not None
         return (
             f"{type(self).__name__}(in_features={self.input_size}, "
             f"out_features={self.output_size}, bias={use_bias}, TP=1)"
@@ -1347,7 +1347,7 @@ class ColumnParallelLinear(paddle.nn.Layer):
 
     def __repr__(self):
         tp = self.output_size // self.output_size_per_partition
-        use_bias = self.bias is not None and self.bias is True
+        use_bias = self.bias is not None
         return (
             f"{type(self).__name__}(in_features={self.input_size}, "
             f"out_features={self.output_size}, bias={use_bias}, TP={tp})"
@@ -1601,7 +1601,7 @@ class RowParallelLinear(paddle.nn.Layer):
 
     def __repr__(self):
         tp = self.input_size // self.input_size_per_partition
-        use_bias = self.bias is not None and self.bias is True
+        use_bias = self.bias is not None
         return (
             f"{type(self).__name__}(in_features={self.input_size}, "
             f"out_features={self.output_size}, bias={use_bias}, TP={tp})"

--- a/tests/multi_card_tests/tensor_parallel/test_layers.py
+++ b/tests/multi_card_tests/tensor_parallel/test_layers.py
@@ -593,6 +593,7 @@ def test_Linear_repr():
     assert "Linear" in r
     assert "8" in r  # in_features
     assert "6" in r  # out_features
+    assert "bias=True" in r  # bias is enabled
     assert "TP=1" in r
 
 
@@ -673,3 +674,10 @@ if __name__ == "__main__":
     test_Linear_extra_state()
     test_Linear_repr()
     test_Linear_via_backend_linear()
+
+    # Synchronize all ranks and destroy process groups to ensure clean NCCL
+    # shutdown. Without this, concurrent launches sharing the same GPUs may
+    # cause SIGSEGV during process exit due to NCCL communicator teardown
+    # races.
+    dist.barrier()
+    dist.destroy_process_group()


### PR DESCRIPTION
修复 repr error

测试中 column_parallel_baseline()、row_parallel_baseline()、embedding_baseline() 各自调用了 dist.new_group([dist.get_rank()]) 创建新的 NCCL communicator。测试完成后，进程正常退出（exit code 0），Python 解释器在 atexit / GC 阶段析构，当多个 paddle.distributed.launch 并发执行、共享同一组 GPU 时，两个进程的 NCCL communicator 同时访问相同的 GPU 资源进行析构时，造成 NCCL 内部的 GPU 资源竞争，引发 SIGSEGV（信号 -11）