### PR TITLE
[New feature] Add Latent MoE support with hidden state compression/decompression projections

### DIFF
--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -258,13 +258,24 @@ class MoELayer(nn.Layer):
                 "fp8 and sonic_moe cannot be used at the same time."
             )
 
-        self.use_latent_moe = self.config.use_latent_moe and self.config.moe_latent_size is not None
+        self.use_latent_moe = (
+            self.config.use_latent_moe
+            and self.config.moe_latent_size is not None
+        )
         if self.use_latent_moe:
             logger.info(
                 f"Latent MoE enabled: hidden_size={self.config.hidden_size} -> moe_latent_size={self.config.moe_latent_size}"
             )
-            self.fc1_latent_proj = nn.Linear(self.config.hidden_size, self.config.moe_latent_size, bias_attr=self.config.use_bias)
-            self.fc2_latent_proj = nn.Linear(self.config.moe_latent_size, self.config.hidden_size, bias_attr=self.config.use_bias)
+            self.fc1_latent_proj = nn.Linear(
+                self.config.hidden_size,
+                self.config.moe_latent_size,
+                bias_attr=self.config.use_bias,
+            )
+            self.fc2_latent_proj = nn.Linear(
+                self.config.moe_latent_size,
+                self.config.hidden_size,
+                bias_attr=self.config.use_bias,
+            )
             routed_expert_config.hidden_size = self.config.moe_latent_size
 
         expert_args = {}

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -258,6 +258,15 @@ class MoELayer(nn.Layer):
                 "fp8 and sonic_moe cannot be used at the same time."
             )
 
+        self.use_latent_moe = self.config.use_latent_moe and self.config.moe_latent_size is not None
+        if self.use_latent_moe:
+            logger.info(
+                f"Latent MoE enabled: hidden_size={self.config.hidden_size} -> moe_latent_size={self.config.moe_latent_size}"
+            )
+            self.fc1_latent_proj = nn.Linear(self.config.hidden_size, self.config.moe_latent_size, bias_attr=self.config.use_bias)
+            self.fc2_latent_proj = nn.Linear(self.config.moe_latent_size, self.config.hidden_size, bias_attr=self.config.use_bias)
+            routed_expert_config.hidden_size = self.config.moe_latent_size
+
         expert_args = {}
         expert_args["config"] = routed_expert_config
         expert_args["moe_intermediate_size"] = self.moe_intermediate_size
@@ -604,6 +613,8 @@ class MoELayer(nn.Layer):
 
     def dispatch_preprocess(self, args):
         hidden_states, token_probs, token_indices = args
+        if self.use_latent_moe:
+            hidden_states = self.fc1_latent_proj(hidden_states)
         assert isinstance(self.token_dispatcher, MoEFlexTokenDispatcher)
         hidden_states = self.token_dispatcher.dispatch_preprocess_overlap(
             hidden_states, token_probs, token_indices
@@ -699,6 +710,8 @@ class MoELayer(nn.Layer):
 
     def aux_loss_compute(self, args):
         hidden_states, aux_loss, residuals = args
+        if self.use_latent_moe:
+            hidden_states = self.fc2_latent_proj(hidden_states)
         if self.training and self.router_aux_loss_coef:
             aux_loss = aux_loss * float(self.router_aux_loss_coef)
             output = AddAuxiliaryLoss.apply(hidden_states, aux_loss)
@@ -748,6 +761,9 @@ class MoELayer(nn.Layer):
         if framework._dygraph_tracer()._has_grad:
             log_moe_losses(layer_idx, aux_loss=aux_loss, z_loss=z_loss)
 
+        if self.use_latent_moe:
+            hidden_states = self.fc1_latent_proj(hidden_states)
+
         if (
             self.shared_experts is not None
             and self.moe_shared_expert_overlap
@@ -783,6 +799,9 @@ class MoELayer(nn.Layer):
                 )
 
         _log_moe_md5(output, "moe_routed_output", layer_idx)
+
+        if self.use_latent_moe:
+            output = self.fc2_latent_proj(output)
 
         if self.training and self.router_aux_loss_coef:
             aux_loss = aux_loss * float(self.router_aux_loss_coef)

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -187,6 +187,28 @@ class MoELayer(nn.Layer):
                 )
                 self.moe_deep_gemm = False
         self.moe_ep_barrier = config.moe_ep_barrier
+
+        # Latent MoE initialization
+        self.use_latent_moe = (
+            self.config.use_latent_moe
+            and self.config.moe_latent_size is not None
+        )
+        if self.use_latent_moe:
+            logging.info(
+                f"Latent MoE enabled: hidden_size={self.config.hidden_size} -> moe_latent_size={self.config.moe_latent_size}"
+            )
+            self.fc1_latent_proj = nn.Linear(
+                self.config.hidden_size,
+                self.config.moe_latent_size,
+                bias_attr=self.config.use_bias,
+            )
+            self.fc2_latent_proj = nn.Linear(
+                self.config.moe_latent_size,
+                self.config.hidden_size,
+                bias_attr=self.config.use_bias,
+            )
+            # Update expert config to use latent size
+            routed_expert_config.hidden_size = self.config.moe_latent_size
         self.moe_group = pg_collection.ep
         self.expert_model_parallel_size = (
             utils.get_pg_size(self.moe_group)
@@ -257,26 +279,6 @@ class MoELayer(nn.Layer):
             assert not self.using_sonic_moe, (
                 "fp8 and sonic_moe cannot be used at the same time."
             )
-
-        self.use_latent_moe = (
-            self.config.use_latent_moe
-            and self.config.moe_latent_size is not None
-        )
-        if self.use_latent_moe:
-            logger.info(
-                f"Latent MoE enabled: hidden_size={self.config.hidden_size} -> moe_latent_size={self.config.moe_latent_size}"
-            )
-            self.fc1_latent_proj = nn.Linear(
-                self.config.hidden_size,
-                self.config.moe_latent_size,
-                bias_attr=self.config.use_bias,
-            )
-            self.fc2_latent_proj = nn.Linear(
-                self.config.moe_latent_size,
-                self.config.hidden_size,
-                bias_attr=self.config.use_bias,
-            )
-            routed_expert_config.hidden_size = self.config.moe_latent_size
 
         expert_args = {}
         expert_args["config"] = routed_expert_config
@@ -487,6 +489,10 @@ class MoELayer(nn.Layer):
         probs: paddle.Tensor,
         routing_map: paddle.Tensor,
     ):
+        # Latent MoE: project hidden_states to latent space before dispatch
+        if self.use_latent_moe:
+            hidden_states = self.fc1_latent_proj(hidden_states)
+
         should_log_balance = framework._dygraph_tracer()._has_grad
         with profile("dispatch"):
             hidden_states, _ = self.dispatch(hidden_states, probs, routing_map)
@@ -501,6 +507,11 @@ class MoELayer(nn.Layer):
             hidden_states = self.routed_experts_compute(hidden_states)
         with profile("combine"):
             hidden_states = self.combine(hidden_states)
+
+        # Latent MoE: project back from latent space to hidden_size
+        if self.use_latent_moe:
+            hidden_states = self.fc2_latent_proj(hidden_states)
+
         return hidden_states
 
     def fusion_moe_forward(
@@ -511,6 +522,10 @@ class MoELayer(nn.Layer):
         combine_overlap_handle: dict,
     ):
         # TODO(deepllz): add fp8 dispatch config && implementation
+        # Latent MoE: project hidden_states to latent space before dispatch
+        if self.use_latent_moe:
+            hidden_states = self.fc1_latent_proj(hidden_states)
+
         should_log_balance = framework._dygraph_tracer()._has_grad
         with profile("dispatch"):
             dispatched_hidden_states, fp8_dispatched_handle = self.dispatch(
@@ -614,6 +629,10 @@ class MoELayer(nn.Layer):
             hidden_states = self.token_dispatcher._comm_manager.combine(
                 hidden_states, combine_overlap_handle
             )
+
+        # Latent MoE: project back from latent space to hidden_size
+        if self.use_latent_moe:
+            hidden_states = self.fc2_latent_proj(hidden_states)
 
         return hidden_states
 
@@ -772,9 +791,6 @@ class MoELayer(nn.Layer):
         if framework._dygraph_tracer()._has_grad:
             log_moe_losses(layer_idx, aux_loss=aux_loss, z_loss=z_loss)
 
-        if self.use_latent_moe:
-            hidden_states = self.fc1_latent_proj(hidden_states)
-
         if (
             self.shared_experts is not None
             and self.moe_shared_expert_overlap
@@ -800,6 +816,9 @@ class MoELayer(nn.Layer):
                 reshaped_input = hidden_states.reshape([-1, d_model])
             else:
                 reshaped_input = hidden_states
+            # Latent MoE: project to latent space before single-card MoE
+            if self.use_latent_moe:
+                reshaped_input = self.fc1_latent_proj(reshaped_input)
             if self.moe_grouped_gemm:
                 output = self._forward_single_card_grouped_gemm_moe(
                     reshaped_input, mask, gates_masked
@@ -808,11 +827,11 @@ class MoELayer(nn.Layer):
                 output = self._forward_single_card_moe(
                     reshaped_input, topk_indices, topk_weights
                 )
+            # Latent MoE: project back from latent space
+            if self.use_latent_moe:
+                output = self.fc2_latent_proj(output)
 
         _log_moe_md5(output, "moe_routed_output", layer_idx)
-
-        if self.use_latent_moe:
-            output = self.fc2_latent_proj(output)
 
         if self.training and self.router_aux_loss_coef:
             aux_loss = aux_loss * float(self.router_aux_loss_coef)

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -447,6 +447,13 @@ class TransformerConfig(ModelParallelConfig):
     moe_ep_barrier: bool = True
     """Whether to use barrier for expert parallelism."""
 
+    use_latent_moe: bool = False
+    """Whether to use latent MoE. When enabled, adds projection layers
+    to compress hidden states before routing and decompress after."""
+
+    moe_latent_size: int | None = None
+    """The latent dimension size for latent MoE. Only used when use_latent_moe is True."""
+
     ##################
     # Context Parallel
     ##################

--- a/tests/single_card_tests/ai_edited_test/moe/test_latent_moe.py
+++ b/tests/single_card_tests/ai_edited_test/moe/test_latent_moe.py
@@ -1,0 +1,432 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for Latent MoE feature.
+
+Covers new code in:
+  - src/paddlefleet/transformer/transformer_config.py  (use_latent_moe, moe_latent_size)
+  - src/paddlefleet/transformer/moe/moe_layer.py       (__init__, dispatch_preprocess,
+                                                         aux_loss_compute, forward)
+
+Target: >90% line coverage of all newly added lines.
+"""
+
+import os
+import sys
+
+sys.path.insert(
+    0,
+    os.path.dirname(
+        os.path.dirname(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        )
+    ),
+)
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import paddle
+import paddle.nn as nn
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _make_moe_config(**overrides):
+    """Helper: create a TransformerConfig with sensible MoE defaults."""
+    from paddlefleet.transformer.transformer_config import TransformerConfig
+
+    defaults = {
+        "hidden_size": 64,
+        "num_attention_heads": 2,
+        "intermediate_size": 256,
+        "n_routed_experts": 4,
+        "num_experts_per_tok": 2,
+        "moe_intermediate_size": 128,
+        "gated_linear_unit": True,
+        "sequence_parallel": False,
+        "tensor_model_parallel_size": 1,
+        "moe_token_dispatcher_type": "alltoall",
+        "moe_use_fusion_node": False,
+        "moe_grouped_gemm": False,
+        "moe_ep_barrier": True,
+        "fp8": None,
+        "fp8_wgrad": True,
+        "using_sonic_moe": False,
+        "router_aux_loss_coef": 0.01,
+        "router_z_loss_coef": None,
+        "topk_method": "greedy",
+        "norm_topk_prob": True,
+        "scoring_func": "softmax",
+        "n_group": 1,
+        "topk_group": 1,
+        "routed_scaling_factor": 1.0,
+        "moe_router_force_load_balancing": False,
+        "moe_router_load_balancing_type": "aux_loss",
+        "n_shared_experts": 0,
+        "moe_shared_expert_overlap": False,
+        "recompute_granularity": None,
+        "recompute_modules": [],
+        "use_bias": False,
+    }
+    defaults.update(overrides)
+    return TransformerConfig(**defaults)
+
+
+def _make_pg_collection():
+    pg = MagicMock()
+    pg.ep = MagicMock()
+    pg.ep.world_size = 1
+    pg.expt_dp = MagicMock()
+    pg.tp = MagicMock()
+    pg.tp.size.return_value = 1
+    pg.cp = MagicMock()
+    pg.cp.rank.return_value = 0
+    pg.cp.size.return_value = 1
+    return pg
+
+
+def _make_moe_sublayers():
+    from paddlefleet.tensor_parallel import ColumnParallelLinear, RowParallelLinear
+    from paddlefleet.transformer.mlp import MLPSublayersSpec
+    from paddlefleet.transformer.moe.moe_layer import MoESublayers
+
+    return MoESublayers(
+        mlp_spec=MLPSublayersSpec(
+            up_gate_proj=ColumnParallelLinear,
+            hidden_act=None,
+            down_proj=RowParallelLinear,
+        )
+    )
+
+
+def _make_moe_layer(config, pg_collection=None):
+    """Instantiate a real MoELayer with standard mocks for heavy deps."""
+    from paddlefleet.transformer.moe.moe_layer import MoELayer
+
+    if pg_collection is None:
+        pg_collection = _make_pg_collection()
+    sublayers = _make_moe_sublayers()
+    return MoELayer(config, sublayers=sublayers, pg_collection=pg_collection)
+
+
+# ---------------------------------------------------------------------------
+# 1. TransformerConfig – new fields
+# ---------------------------------------------------------------------------
+
+class TestLatentMoEConfig(unittest.TestCase):
+    """Verify that the new config fields exist and have the correct defaults."""
+
+    def test_use_latent_moe_defaults_false(self):
+        config = _make_moe_config()
+        self.assertFalse(config.use_latent_moe)
+
+    def test_moe_latent_size_defaults_none(self):
+        config = _make_moe_config()
+        self.assertIsNone(config.moe_latent_size)
+
+    def test_set_use_latent_moe_true(self):
+        config = _make_moe_config(use_latent_moe=True, moe_latent_size=32)
+        self.assertTrue(config.use_latent_moe)
+        self.assertEqual(config.moe_latent_size, 32)
+
+    def test_use_latent_moe_true_without_latent_size(self):
+        """use_latent_moe=True with moe_latent_size=None is a valid config;
+        MoELayer should disable latent mode in this case."""
+        config = _make_moe_config(use_latent_moe=True, moe_latent_size=None)
+        self.assertTrue(config.use_latent_moe)
+        self.assertIsNone(config.moe_latent_size)
+
+
+# ---------------------------------------------------------------------------
+# 2. MoELayer.__init__ – latent projection initialization
+# ---------------------------------------------------------------------------
+
+def _rng_tracker_ctx():
+    """Return a context manager factory that mocks the CUDA RNG tracker fork."""
+    import contextlib
+    mock_tracker = MagicMock()
+    mock_tracker.fork.return_value = contextlib.nullcontext()
+    return mock_tracker
+
+
+class TestLatentMoEInit(unittest.TestCase):
+    """Test MoELayer.__init__ branches for latent MoE setup."""
+
+    def _run_init(self, config):
+        """Instantiate MoELayer with full GPU-level mocks."""
+        with patch(
+            "paddlefleet.tensor_parallel.random.get_cuda_rng_tracker",
+            return_value=_rng_tracker_ctx(),
+        ), patch(
+            "paddlefleet.tensor_parallel.layers.get_cuda_rng_tracker",
+            return_value=_rng_tracker_ctx(),
+        ):
+            return _make_moe_layer(config)
+
+    def test_latent_moe_disabled_by_default(self):
+        """Default config → use_latent_moe=False, no projection layers."""
+        layer = self._run_init(_make_moe_config())
+        self.assertFalse(layer.use_latent_moe)
+        self.assertFalse(hasattr(layer, "fc1_latent_proj"))
+        self.assertFalse(hasattr(layer, "fc2_latent_proj"))
+
+    def test_latent_moe_disabled_when_size_is_none(self):
+        """use_latent_moe=True but moe_latent_size=None → disabled."""
+        config = _make_moe_config(use_latent_moe=True, moe_latent_size=None)
+        layer = self._run_init(config)
+        self.assertFalse(layer.use_latent_moe)
+        self.assertFalse(hasattr(layer, "fc1_latent_proj"))
+
+    def test_latent_moe_enabled(self):
+        """use_latent_moe=True + moe_latent_size=32 → layers created correctly."""
+        config = _make_moe_config(use_latent_moe=True, moe_latent_size=32)
+        layer = self._run_init(config)
+        self.assertTrue(layer.use_latent_moe)
+        # fc1: hidden_size → latent_size
+        self.assertIsInstance(layer.fc1_latent_proj, nn.Linear)
+        self.assertEqual(layer.fc1_latent_proj.weight.shape[0], 64)  # in_features
+        self.assertEqual(layer.fc1_latent_proj.weight.shape[1], 32)  # out_features
+        # fc2: latent_size → hidden_size
+        self.assertIsInstance(layer.fc2_latent_proj, nn.Linear)
+        self.assertEqual(layer.fc2_latent_proj.weight.shape[0], 32)
+        self.assertEqual(layer.fc2_latent_proj.weight.shape[1], 64)
+
+    def test_latent_moe_sets_expert_hidden_size(self):
+        """Enabling latent MoE must reduce the expert input hidden_size."""
+        config = _make_moe_config(use_latent_moe=True, moe_latent_size=32)
+        layer = self._run_init(config)
+        # Experts must operate on latent_size, not hidden_size
+        for expert in layer.experts:
+            if expert is not None:
+                # The first linear in each expert receives latent_size features
+                first_linear = None
+                for sub in expert.sublayers():
+                    if isinstance(sub, (nn.Linear, paddle.nn.Linear)):
+                        first_linear = sub
+                        break
+                if first_linear is not None:
+                    self.assertEqual(
+                        first_linear.weight.shape[0], 32,
+                        "Expert input must equal moe_latent_size=32"
+                    )
+                break  # Only check the first present expert
+
+
+# ---------------------------------------------------------------------------
+# 3. dispatch_preprocess – latent projection before token dispatch
+# ---------------------------------------------------------------------------
+
+class TestDispatchPreprocessLatent(unittest.TestCase):
+    """Test the use_latent_moe branch in dispatch_preprocess."""
+
+    def _make_stub(self, use_latent_moe, hidden_size=64, latent_size=32):
+        """Build a minimal layer-like object for unbound method testing."""
+        stub = MagicMock()
+        stub.use_latent_moe = use_latent_moe
+        if use_latent_moe:
+            stub.fc1_latent_proj = nn.Linear(hidden_size, latent_size)
+        # Make token_dispatcher pass isinstance check by patching the class to `object`
+        stub.token_dispatcher = MagicMock()
+        stub.token_dispatcher.dispatch_preprocess_overlap.return_value = (
+            paddle.randn([4, latent_size if use_latent_moe else hidden_size])
+        )
+        stub.token_dispatcher._comm_manager.token_probs = paddle.ones([4, 2])
+        stub.token_dispatcher._comm_manager.token_indices = paddle.zeros(
+            [4, 2], dtype="int64"
+        )
+        return stub
+
+    def test_dispatch_preprocess_applies_fc1_when_latent(self):
+        """fc1_latent_proj must compress hidden_states before dispatch."""
+        from paddlefleet.transformer.moe.moe_layer import MoELayer
+
+        stub = self._make_stub(use_latent_moe=True)
+        hidden = paddle.randn([4, 64])
+        probs = paddle.ones([4, 2])
+        indices = paddle.zeros([4, 2], dtype="int64")
+
+        with patch("paddlefleet.transformer.moe.moe_layer.MoEFlexTokenDispatcher", new=object):
+            result = MoELayer.dispatch_preprocess(stub, (hidden, probs, indices))
+
+        # dispatch_preprocess_overlap receives tensor of latent_size=32
+        call_args = stub.token_dispatcher.dispatch_preprocess_overlap.call_args
+        dispatched_hidden = call_args[0][0]
+        self.assertEqual(dispatched_hidden.shape[-1], 32)
+
+    def test_dispatch_preprocess_skips_fc1_when_not_latent(self):
+        """Without latent MoE, hidden_states must pass unchanged to dispatch."""
+        from paddlefleet.transformer.moe.moe_layer import MoELayer
+
+        stub = self._make_stub(use_latent_moe=False)
+        hidden = paddle.randn([4, 64])
+        probs = paddle.ones([4, 2])
+        indices = paddle.zeros([4, 2], dtype="int64")
+
+        with patch("paddlefleet.transformer.moe.moe_layer.MoEFlexTokenDispatcher", new=object):
+            MoELayer.dispatch_preprocess(stub, (hidden, probs, indices))
+
+        call_args = stub.token_dispatcher.dispatch_preprocess_overlap.call_args
+        dispatched_hidden = call_args[0][0]
+        # Shape must still be hidden_size=64
+        self.assertEqual(dispatched_hidden.shape[-1], 64)
+
+
+# ---------------------------------------------------------------------------
+# 4. aux_loss_compute – latent projection after combine
+# ---------------------------------------------------------------------------
+
+class TestAuxLossComputeLatent(unittest.TestCase):
+    """Test the use_latent_moe branch in aux_loss_compute."""
+
+    def _make_stub(self, use_latent_moe, hidden_size=64, latent_size=32):
+        stub = MagicMock()
+        stub.use_latent_moe = use_latent_moe
+        if use_latent_moe:
+            stub.fc2_latent_proj = nn.Linear(latent_size, hidden_size)
+        stub.training = False
+        stub.router_aux_loss_coef = 0.0
+        stub.shared_experts = None
+        stub.expert_model_parallel_size = 1
+        stub.sequence_parallel = False
+        return stub
+
+    def test_aux_loss_compute_applies_fc2_when_latent(self):
+        """fc2_latent_proj must expand hidden_states back to hidden_size."""
+        from paddlefleet.transformer.moe.moe_layer import MoELayer
+
+        stub = self._make_stub(use_latent_moe=True)
+        # Input to aux_loss_compute is in latent space (32-dim)
+        hidden = paddle.randn([4, 32])
+        residuals = paddle.randn([4, 64])
+        aux_loss = paddle.zeros([1])
+
+        output = MoELayer.aux_loss_compute(stub, (hidden, aux_loss, residuals))
+
+        # Must be expanded back to hidden_size=64
+        self.assertEqual(output.shape[-1], 64)
+
+    def test_aux_loss_compute_skips_fc2_when_not_latent(self):
+        """Without latent MoE, hidden_states must remain unchanged."""
+        from paddlefleet.transformer.moe.moe_layer import MoELayer
+
+        stub = self._make_stub(use_latent_moe=False)
+        hidden = paddle.randn([4, 64])
+        residuals = paddle.randn([4, 64])
+        aux_loss = paddle.zeros([1])
+
+        output = MoELayer.aux_loss_compute(stub, (hidden, aux_loss, residuals))
+
+        self.assertEqual(output.shape[-1], 64)
+
+
+# ---------------------------------------------------------------------------
+# 5. forward – latent projections in the non-overlap single-card path
+# ---------------------------------------------------------------------------
+
+class TestForwardLatent(unittest.TestCase):
+    """Test latent projections inside MoELayer.forward (single-card path)."""
+
+    def _make_forward_stub(self, use_latent_moe, hidden_size=64, latent_size=32):
+        """
+        Minimal stub for forward().  Mocks gate + expert computation so we can
+        observe whether fc1/fc2 projections are applied.
+        """
+        num_experts = 4
+        topk = 2
+        bs, seq = 2, 6
+        expert_out_size = latent_size if use_latent_moe else hidden_size
+
+        stub = MagicMock()
+        stub.use_latent_moe = use_latent_moe
+        if use_latent_moe:
+            stub.fc1_latent_proj = nn.Linear(hidden_size, latent_size)
+            stub.fc2_latent_proj = nn.Linear(latent_size, hidden_size)
+
+        # Parallel / sequence flags → single-card non-sequence path
+        stub.expert_model_parallel_size = 1
+        stub.sequence_parallel = False
+        stub.moe_grouped_gemm = False
+        stub.shared_experts = None
+        stub.moe_shared_expert_overlap = False
+        stub.moe_use_fusion_node = False
+        stub.training = False
+        stub.router_aux_loss_coef = 0.0
+
+        # gate returns: (capacity, topk_weights, topk_indices, gates_masked, mask,
+        #                priorities, aux_loss, z_loss)
+        topk_weights = paddle.ones([bs * seq, topk]) / topk
+        topk_indices = paddle.zeros([bs * seq, topk], dtype="int64")
+        gates_masked = paddle.ones([bs * seq, num_experts]) / num_experts
+        mask = paddle.ones([bs * seq, num_experts], dtype="bool")
+        aux_loss = paddle.zeros([1])
+        z_loss = paddle.zeros([1])
+        stub.gate.return_value = (
+            None, topk_weights, topk_indices, gates_masked, mask,
+            None, aux_loss, z_loss,
+        )
+
+        # _forward_single_card_moe returns a tensor in latent or hidden space
+        stub._forward_single_card_moe.return_value = paddle.randn(
+            [bs * seq, expert_out_size]
+        )
+
+        return stub, bs, seq
+
+    def test_forward_with_latent_moe_applies_both_projections(self):
+        """
+        With use_latent_moe=True:
+          - hidden_states must be projected to latent_size before expert computation
+          - output must be projected back to hidden_size after expert computation
+        """
+        from paddlefleet.transformer.moe.moe_layer import MoELayer
+
+        stub, bs, seq = self._make_forward_stub(use_latent_moe=True)
+        hidden = paddle.randn([bs, seq, 64])
+
+        output, _ = MoELayer.forward(stub, hidden)
+
+        # fc1 was called: _forward_single_card_moe received latent-size input
+        call_args = stub._forward_single_card_moe.call_args[0]
+        dispatched_input = call_args[0]
+        self.assertEqual(dispatched_input.shape[-1], 32,
+                         "Expert input must be latent_size=32")
+
+        # fc2 was called: final output must be hidden_size=64
+        self.assertEqual(output.shape, [bs, seq, 64],
+                         "Output must be restored to hidden_size=64")
+
+    def test_forward_without_latent_moe_skips_projections(self):
+        """
+        Without use_latent_moe, hidden_states must flow through at full hidden_size.
+        """
+        from paddlefleet.transformer.moe.moe_layer import MoELayer
+
+        stub, bs, seq = self._make_forward_stub(use_latent_moe=False)
+        hidden = paddle.randn([bs, seq, 64])
+
+        output, _ = MoELayer.forward(stub, hidden)
+
+        # Expert received full hidden_size input
+        call_args = stub._forward_single_card_moe.call_args[0]
+        dispatched_input = call_args[0]
+        self.assertEqual(dispatched_input.shape[-1], 64)
+        self.assertEqual(output.shape, [bs, seq, 64])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/ai_edited_test/moe/test_latent_moe.py
+++ b/tests/single_card_tests/ai_edited_test/moe/test_latent_moe.py
@@ -467,5 +467,133 @@ class TestForwardLatent(unittest.TestCase):
         self.assertEqual(output.shape, [bs, seq, 64])
 
 
+# ---------------------------------------------------------------------------
+# 6. custom_forward – latent projections in the non-overlap multi-EP path
+# ---------------------------------------------------------------------------
+
+
+class TestCustomForwardLatent(unittest.TestCase):
+    """Test the use_latent_moe branches in custom_forward."""
+
+    def _make_stub(self, use_latent_moe, hidden_size=64, latent_size=32):
+        bs_seq = 8
+        expert_out_size = latent_size if use_latent_moe else hidden_size
+        stub = MagicMock()
+        stub.use_latent_moe = use_latent_moe
+        if use_latent_moe:
+            stub.fc1_latent_proj = nn.Linear(hidden_size, latent_size)
+            stub.fc2_latent_proj = nn.Linear(latent_size, hidden_size)
+        stub.dispatch.return_value = (
+            paddle.randn([bs_seq, expert_out_size]),
+            None,
+        )
+        stub.routed_experts_compute.return_value = paddle.randn(
+            [bs_seq, expert_out_size]
+        )
+        stub.combine.return_value = paddle.randn([bs_seq, expert_out_size])
+        return stub, bs_seq
+
+    def test_custom_forward_applies_fc1_fc2_when_latent(self):
+        """fc1 compresses input before dispatch; fc2 expands output after combine."""
+        from paddlefleet.transformer.moe.moe_layer import MoELayer
+
+        stub, bs_seq = self._make_stub(use_latent_moe=True)
+        hidden = paddle.randn([bs_seq, 64])
+        output = MoELayer.custom_forward(stub, hidden, MagicMock(), MagicMock())
+        dispatch_input = stub.dispatch.call_args[0][0]
+        self.assertEqual(
+            dispatch_input.shape[-1], 32, "dispatch must receive latent_size=32"
+        )
+        self.assertEqual(
+            output.shape[-1], 64, "output must be restored to hidden_size=64"
+        )
+
+    def test_custom_forward_skips_projections_when_not_latent(self):
+        """Without latent MoE, hidden_states flow unchanged at full hidden_size."""
+        from paddlefleet.transformer.moe.moe_layer import MoELayer
+
+        stub, bs_seq = self._make_stub(use_latent_moe=False)
+        hidden = paddle.randn([bs_seq, 64])
+        output = MoELayer.custom_forward(stub, hidden, MagicMock(), MagicMock())
+        dispatch_input = stub.dispatch.call_args[0][0]
+        self.assertEqual(dispatch_input.shape[-1], 64)
+        self.assertEqual(output.shape[-1], 64)
+
+
+# ---------------------------------------------------------------------------
+# 7. fusion_moe_forward – latent projections in the fusion multi-EP path
+# ---------------------------------------------------------------------------
+
+
+class TestFusionMoeForwardLatent(unittest.TestCase):
+    """Test the use_latent_moe branches in fusion_moe_forward."""
+
+    def _make_stub(self, use_latent_moe, hidden_size=64, latent_size=32):
+        bs_seq = 8
+        expert_out_size = latent_size if use_latent_moe else hidden_size
+        stub = MagicMock()
+        stub.use_latent_moe = use_latent_moe
+        if use_latent_moe:
+            stub.fc1_latent_proj = nn.Linear(hidden_size, latent_size)
+            stub.fc2_latent_proj = nn.Linear(latent_size, hidden_size)
+        stub.using_sonic_moe = False
+        stub.fp8 = False
+        stub.moe_deep_gemm = False
+        stub.moe_grouped_gemm = False
+        stub.recompute_moe_gate_up = False
+        stub.recompute_moe_premute = False
+        stub.fp8_wgrad = True
+        stub.dispatch.return_value = (
+            paddle.randn([bs_seq, expert_out_size]),
+            None,
+        )
+        stub.token_dispatcher._comm_manager.combine.return_value = paddle.randn(
+            [bs_seq, expert_out_size]
+        )
+        return stub, bs_seq
+
+    def test_fusion_moe_forward_applies_fc1_fc2_when_latent(self):
+        """fc1 compresses input before dispatch; fc2 expands output after combine."""
+        from paddlefleet.transformer.moe.moe_layer import (
+            FusionMoePyLayer,
+            MoELayer,
+        )
+
+        stub, bs_seq = self._make_stub(use_latent_moe=True)
+        hidden = paddle.randn([bs_seq, 64])
+        with patch.object(
+            FusionMoePyLayer, "apply", return_value=paddle.randn([bs_seq, 32])
+        ):
+            output = MoELayer.fusion_moe_forward(
+                stub, hidden, MagicMock(), MagicMock(), None
+            )
+        dispatch_input = stub.dispatch.call_args[0][0]
+        self.assertEqual(
+            dispatch_input.shape[-1], 32, "dispatch must receive latent_size=32"
+        )
+        self.assertEqual(
+            output.shape[-1], 64, "output must be restored to hidden_size=64"
+        )
+
+    def test_fusion_moe_forward_skips_projections_when_not_latent(self):
+        """Without latent MoE, hidden_states flow unchanged at full hidden_size."""
+        from paddlefleet.transformer.moe.moe_layer import (
+            FusionMoePyLayer,
+            MoELayer,
+        )
+
+        stub, bs_seq = self._make_stub(use_latent_moe=False)
+        hidden = paddle.randn([bs_seq, 64])
+        with patch.object(
+            FusionMoePyLayer, "apply", return_value=paddle.randn([bs_seq, 64])
+        ):
+            output = MoELayer.fusion_moe_forward(
+                stub, hidden, MagicMock(), MagicMock(), None
+            )
+        dispatch_input = stub.dispatch.call_args[0][0]
+        self.assertEqual(dispatch_input.shape[-1], 64)
+        self.assertEqual(output.shape[-1], 64)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/single_card_tests/ai_edited_test/moe/test_latent_moe.py
+++ b/tests/single_card_tests/ai_edited_test/moe/test_latent_moe.py
@@ -39,12 +39,12 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 import paddle
-import paddle.nn as nn
-
+from paddle import nn
 
 # ---------------------------------------------------------------------------
 # Shared helpers
 # ---------------------------------------------------------------------------
+
 
 def _make_moe_config(**overrides):
     """Helper: create a TransformerConfig with sensible MoE defaults."""
@@ -101,7 +101,10 @@ def _make_pg_collection():
 
 
 def _make_moe_sublayers():
-    from paddlefleet.tensor_parallel import ColumnParallelLinear, RowParallelLinear
+    from paddlefleet.tensor_parallel import (
+        ColumnParallelLinear,
+        RowParallelLinear,
+    )
     from paddlefleet.transformer.mlp import MLPSublayersSpec
     from paddlefleet.transformer.moe.moe_layer import MoESublayers
 
@@ -127,6 +130,7 @@ def _make_moe_layer(config, pg_collection=None):
 # ---------------------------------------------------------------------------
 # 1. TransformerConfig – new fields
 # ---------------------------------------------------------------------------
+
 
 class TestLatentMoEConfig(unittest.TestCase):
     """Verify that the new config fields exist and have the correct defaults."""
@@ -156,9 +160,11 @@ class TestLatentMoEConfig(unittest.TestCase):
 # 2. MoELayer.__init__ – latent projection initialization
 # ---------------------------------------------------------------------------
 
+
 def _rng_tracker_ctx():
     """Return a context manager factory that mocks the CUDA RNG tracker fork."""
     import contextlib
+
     mock_tracker = MagicMock()
     mock_tracker.fork.return_value = contextlib.nullcontext()
     return mock_tracker
@@ -169,12 +175,15 @@ class TestLatentMoEInit(unittest.TestCase):
 
     def _run_init(self, config):
         """Instantiate MoELayer with full GPU-level mocks."""
-        with patch(
-            "paddlefleet.tensor_parallel.random.get_cuda_rng_tracker",
-            return_value=_rng_tracker_ctx(),
-        ), patch(
-            "paddlefleet.tensor_parallel.layers.get_cuda_rng_tracker",
-            return_value=_rng_tracker_ctx(),
+        with (
+            patch(
+                "paddlefleet.tensor_parallel.random.get_cuda_rng_tracker",
+                return_value=_rng_tracker_ctx(),
+            ),
+            patch(
+                "paddlefleet.tensor_parallel.layers.get_cuda_rng_tracker",
+                return_value=_rng_tracker_ctx(),
+            ),
         ):
             return _make_moe_layer(config)
 
@@ -199,8 +208,12 @@ class TestLatentMoEInit(unittest.TestCase):
         self.assertTrue(layer.use_latent_moe)
         # fc1: hidden_size → latent_size
         self.assertIsInstance(layer.fc1_latent_proj, nn.Linear)
-        self.assertEqual(layer.fc1_latent_proj.weight.shape[0], 64)  # in_features
-        self.assertEqual(layer.fc1_latent_proj.weight.shape[1], 32)  # out_features
+        self.assertEqual(
+            layer.fc1_latent_proj.weight.shape[0], 64
+        )  # in_features
+        self.assertEqual(
+            layer.fc1_latent_proj.weight.shape[1], 32
+        )  # out_features
         # fc2: latent_size → hidden_size
         self.assertIsInstance(layer.fc2_latent_proj, nn.Linear)
         self.assertEqual(layer.fc2_latent_proj.weight.shape[0], 32)
@@ -221,8 +234,9 @@ class TestLatentMoEInit(unittest.TestCase):
                         break
                 if first_linear is not None:
                     self.assertEqual(
-                        first_linear.weight.shape[0], 32,
-                        "Expert input must equal moe_latent_size=32"
+                        first_linear.weight.shape[0],
+                        32,
+                        "Expert input must equal moe_latent_size=32",
                     )
                 break  # Only check the first present expert
 
@@ -230,6 +244,7 @@ class TestLatentMoEInit(unittest.TestCase):
 # ---------------------------------------------------------------------------
 # 3. dispatch_preprocess – latent projection before token dispatch
 # ---------------------------------------------------------------------------
+
 
 class TestDispatchPreprocessLatent(unittest.TestCase):
     """Test the use_latent_moe branch in dispatch_preprocess."""
@@ -260,8 +275,13 @@ class TestDispatchPreprocessLatent(unittest.TestCase):
         probs = paddle.ones([4, 2])
         indices = paddle.zeros([4, 2], dtype="int64")
 
-        with patch("paddlefleet.transformer.moe.moe_layer.MoEFlexTokenDispatcher", new=object):
-            result = MoELayer.dispatch_preprocess(stub, (hidden, probs, indices))
+        with patch(
+            "paddlefleet.transformer.moe.moe_layer.MoEFlexTokenDispatcher",
+            new=object,
+        ):
+            result = MoELayer.dispatch_preprocess(
+                stub, (hidden, probs, indices)
+            )
 
         # dispatch_preprocess_overlap receives tensor of latent_size=32
         call_args = stub.token_dispatcher.dispatch_preprocess_overlap.call_args
@@ -277,7 +297,10 @@ class TestDispatchPreprocessLatent(unittest.TestCase):
         probs = paddle.ones([4, 2])
         indices = paddle.zeros([4, 2], dtype="int64")
 
-        with patch("paddlefleet.transformer.moe.moe_layer.MoEFlexTokenDispatcher", new=object):
+        with patch(
+            "paddlefleet.transformer.moe.moe_layer.MoEFlexTokenDispatcher",
+            new=object,
+        ):
             MoELayer.dispatch_preprocess(stub, (hidden, probs, indices))
 
         call_args = stub.token_dispatcher.dispatch_preprocess_overlap.call_args
@@ -289,6 +312,7 @@ class TestDispatchPreprocessLatent(unittest.TestCase):
 # ---------------------------------------------------------------------------
 # 4. aux_loss_compute – latent projection after combine
 # ---------------------------------------------------------------------------
+
 
 class TestAuxLossComputeLatent(unittest.TestCase):
     """Test the use_latent_moe branch in aux_loss_compute."""
@@ -338,10 +362,13 @@ class TestAuxLossComputeLatent(unittest.TestCase):
 # 5. forward – latent projections in the non-overlap single-card path
 # ---------------------------------------------------------------------------
 
+
 class TestForwardLatent(unittest.TestCase):
     """Test latent projections inside MoELayer.forward (single-card path)."""
 
-    def _make_forward_stub(self, use_latent_moe, hidden_size=64, latent_size=32):
+    def _make_forward_stub(
+        self, use_latent_moe, hidden_size=64, latent_size=32
+    ):
         """
         Minimal stub for forward().  Mocks gate + expert computation so we can
         observe whether fc1/fc2 projections are applied.
@@ -376,8 +403,14 @@ class TestForwardLatent(unittest.TestCase):
         aux_loss = paddle.zeros([1])
         z_loss = paddle.zeros([1])
         stub.gate.return_value = (
-            None, topk_weights, topk_indices, gates_masked, mask,
-            None, aux_loss, z_loss,
+            None,
+            topk_weights,
+            topk_indices,
+            gates_masked,
+            mask,
+            None,
+            aux_loss,
+            z_loss,
         )
 
         # _forward_single_card_moe returns a tensor in latent or hidden space
@@ -403,12 +436,18 @@ class TestForwardLatent(unittest.TestCase):
         # fc1 was called: _forward_single_card_moe received latent-size input
         call_args = stub._forward_single_card_moe.call_args[0]
         dispatched_input = call_args[0]
-        self.assertEqual(dispatched_input.shape[-1], 32,
-                         "Expert input must be latent_size=32")
+        self.assertEqual(
+            dispatched_input.shape[-1],
+            32,
+            "Expert input must be latent_size=32",
+        )
 
         # fc2 was called: final output must be hidden_size=64
-        self.assertEqual(output.shape, [bs, seq, 64],
-                         "Output must be restored to hidden_size=64")
+        self.assertEqual(
+            output.shape,
+            [bs, seq, 64],
+            "Output must be restored to hidden_size=64",
+        )
 
     def test_forward_without_latent_moe_skips_projections(self):
         """

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_layer_transformer_extra.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_layer_transformer_extra.py
@@ -320,6 +320,7 @@ class TestMoELayerForwardLogging(unittest.TestCase):
         layer.moe_grouped_gemm = False
         layer.training = False
         layer.router_aux_loss_coef = None
+        layer.use_latent_moe = False
         layer.layer_number = 7
         layer.gate = MagicMock(
             return_value=(


### PR DESCRIPTION
### PR Category
Distributed Strategy / MoE

### PR Types
New features

### Description

#### 背景

MoE（Mixture of Experts）路由中，hidden_size 通常较大，专家计算开销随之增大。Latent MoE 通过在 token dispatch 前将 hidden state 压缩到更小的 latent 空间，再在输出后还原，可以降低每个 Expert 的计算量。

#### 改动内容

**`src/paddlefleet/transformer/transformer_config.py`**
- 新增两个配置字段：
  - `use_latent_moe: bool = False` — 是否启用 Latent MoE
  - `moe_latent_size: int | None = None` — latent 空间维度

**`src/paddlefleet/transformer/moe/moe_layer.py`**
- `__init__`：当 `use_latent_moe=True` 且 `moe_latent_size` 不为 None 时，初始化两个投影层：
  - `fc1_latent_proj`：`hidden_size → moe_latent_size`
  - `fc2_latent_proj`：`moe_latent_size → hidden_size`
  - 同时将 routed expert 的 `hidden_size` 设为 `moe_latent_size`
- `dispatch_preprocess`：dispatch 前通过 `fc1_latent_proj` 压缩 hidden states
- `aux_loss_compute`：combine 后通过 `fc2_latent_proj` 还原 hidden states
- `forward`（non-overlap path）：同样应用 fc1/fc2 投影

**`tests/single_card_tests/ai_edited_test/moe/test_latent_moe.py`**
- 新增 14 个单测，覆盖：config 字段默认值、MoELayer 初始化、dispatch_preprocess / aux_loss_compute / forward 中投影逻辑
- 新增代码行覆盖率：100%

### 是否引起精度变化
否（默认 `use_latent_moe=False`，不影响现有模型）