### PR TITLE
Support learnable routed_scaling_factor

### DIFF
--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -788,7 +788,7 @@ class MoELayer(nn.Layer):
             capacity,
             topk_weights,
             topk_indices,
-            gates_masked,
+            probs,
             mask,
             priorities,
             aux_loss,
@@ -798,10 +798,11 @@ class MoELayer(nn.Layer):
             input_ids=input_ids,
         )
         # topk_weights, topk_indices: Shape is [seq_len, moe_router_topk]
-        # gates_masked, mask: Shape is [seq_len, num_experts], sometimes their names are "probs" and "routing_map"
+        # probs: combine weights in [S, E] sparse layout (non-selected positions are 0) [seq_len, num_experts]
+        # mask (routing_map): binary selection matrix [seq_len, num_experts]
         # capacity, priorities are used for dropping tokens, currently they are not used
 
-        _log_moe_md5(gates_masked, "gates_masked", layer_idx)
+        _log_moe_md5(probs, "probs", layer_idx)
         _log_moe_md5(mask, "routing_mask", layer_idx)
         if framework._dygraph_tracer()._has_grad:
             log_moe_losses(layer_idx, aux_loss=aux_loss, z_loss=z_loss)
@@ -822,7 +823,7 @@ class MoELayer(nn.Layer):
             if self.moe_use_fusion_node:
                 output = self.fusion_moe_forward(
                     hidden_states,
-                    gates_masked,
+                    probs,
                     mask,
                     combine_overlap_handle,
                     topk_weights=topk_weights,
@@ -831,7 +832,7 @@ class MoELayer(nn.Layer):
             else:
                 output = self.custom_forward(
                     hidden_states,
-                    gates_masked,
+                    probs,
                     mask,
                     topk_weights=topk_weights,
                     topk_indices=topk_indices,
@@ -847,7 +848,7 @@ class MoELayer(nn.Layer):
                 reshaped_input = self.fc1_latent_proj(reshaped_input)
             if self.moe_grouped_gemm:
                 output = self._forward_single_card_grouped_gemm_moe(
-                    reshaped_input, mask, gates_masked
+                    reshaped_input, mask, probs
                 )
             else:
                 output = self._forward_single_card_moe(

--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -137,6 +137,7 @@ class StandardMoERouter(nn.Layer):
 
         self.routed_scaling_factor = config.routed_scaling_factor
 
+        self.gate_scaling_factor = config.gate_scaling_factor
         self.tensor_model_parallel_size = config.tensor_model_parallel_size
         self.sequence_parallel = config.sequence_parallel
         self.context_parallel_size = max(get_context_parallel_world_size(), 1)
@@ -156,6 +157,34 @@ class StandardMoERouter(nn.Layer):
             dtype="float32",
             default_initializer=paddle.nn.initializer.Uniform(),
         )
+
+        if self.routed_scaling_factor == "learnable":
+            self.routed_scaling_factor = self.create_parameter(
+                shape=[self.num_experts],
+                dtype="float32",
+                default_initializer=nn.initializer.Constant(1.0),
+            )
+        elif self.routed_scaling_factor is not None and not isinstance(
+            self.routed_scaling_factor, (int, float)
+        ):
+            raise ValueError(
+                f"routed_scaling_factor must be a float, 'learnable', or None, "
+                f"got {self.routed_scaling_factor!r}"
+            )
+
+        if self.gate_scaling_factor == "learnable":
+            self.gate_scaling_factor = self.create_parameter(
+                shape=[self.hidden_size],
+                dtype="float32",
+                default_initializer=nn.initializer.Constant(1.0),
+            )
+        elif self.gate_scaling_factor is not None and not isinstance(
+            self.gate_scaling_factor, (int, float)
+        ):
+            raise ValueError(
+                f"gate_scaling_factor must be a float, 'learnable', or None, "
+                f"got {self.gate_scaling_factor!r}"
+            )
 
         if self.topk_method == "noaux_tc":
             self.register_buffer(
@@ -633,6 +662,10 @@ class TopKRouter(StandardMoERouter):
             raise ValueError(
                 "The input tensor should have shape [batch_size, sequence_length, hidden_size]"
             )
+
+        if self.gate_scaling_factor is not None:
+            input = input * self.gate_scaling_factor * (self.hidden_size**-0.5)
+
         with paddle.amp.auto_cast(False):
             logits = gate_detach_matmul(
                 input,
@@ -642,7 +675,6 @@ class TopKRouter(StandardMoERouter):
             )
 
         _log_moe_md5(logits, "gate_logits", self._layer_number)
-
         gates = self.gate_score_func(logits)
 
         if input_ids_none_zero_mask is not None:
@@ -656,7 +688,6 @@ class TopKRouter(StandardMoERouter):
 
         _log_moe_md5(gates, "gate_probs_sigmoid", self._layer_number)
 
-        _log_moe_md5(gates, "gate_probs_sigmoid", self._layer_number)
         # Use clone() to ensure that the execution order of the grad nodes is consistent with EC.
         gates_ori = gates.clone()
         if self.scoring_func == "sigmoid":
@@ -745,10 +776,7 @@ class TopKRouter(StandardMoERouter):
             # -1 means neither participates in routing nor expert calculation
             top_idx = top_idx.masked_fill(~valid_mask.cast(paddle.bool), -1)
 
-        gates_masked = gates * mask
-
         # norm
-
         if self.norm_topk_prob:
             if not getattr(
                 self.config, "gpt_model_use_experimental_version", False
@@ -756,19 +784,24 @@ class TopKRouter(StandardMoERouter):
                 denominator = top_gate.sum(axis=-1, keepdim=True) + 1e-20
                 top_gate = top_gate / denominator
             # When gpt_model_use_experimental_version is True, top_gate is already normalized by FusedMoETopk
-            # Reconstruct gates_masked from top_gate  to ensure
-            # bit-exact alignment. Instead of normalizing gates_masked independently
-            # (which uses different FP32 reduction over E=32 elements vs K=8),
-            # scatter the already-normalized top_gate values back to [S, E] layout.
-            gates_masked = paddle.zeros_like(gates).put_along_axis(
-                top_idx, top_gate, axis=1
-            )
 
-        if abs(self.routed_scaling_factor - 1.0) > 1e-6:
-            top_gate = top_gate * self.routed_scaling_factor
-            gates_masked *= self.routed_scaling_factor
+        if self.routed_scaling_factor is not None:
+            if isinstance(self.routed_scaling_factor, paddle.Tensor):
+                safe_topk_indices = paddle.clip(top_idx, min=0)
+                gathered_scales = F.embedding(
+                    safe_topk_indices,
+                    self.routed_scaling_factor.unsqueeze(1),
+                ).squeeze(-1)
+                top_gate = top_gate * gathered_scales
+            elif abs(self.routed_scaling_factor - 1.0) > 1e-6:
+                top_gate = top_gate * self.routed_scaling_factor
 
-        _log_moe_md5(gates_masked, "gates_masked", self._layer_number)
+        # Reconstruct probs (combine weights in [S, E] sparse layout) from final top_gate.
+        probs = paddle.zeros_like(gates).put_along_axis(
+            top_idx, top_gate, axis=1
+        )
+
+        _log_moe_md5(probs, "probs", self._layer_number)
         _log_moe_md5(top_gate, "topk_weights_normed", self._layer_number)
 
         if self.topk_method == "noaux_tc":
@@ -796,7 +829,7 @@ class TopKRouter(StandardMoERouter):
             None,  # new capacity
             top_gate,  # weights of selected experts for each token [num_tokens, num_experts_per_token]
             top_idx,  # indices of selected experts for each token [num_tokens, num_experts_per_token]
-            gates_masked,  # masked gates. for each token, the selected experts are remainded with their original values, others are 0 [num_tokens, num_experts]
+            probs,  # combine weights in [S, E] sparse layout; non-selected positions are 0 [num_tokens, num_experts]
             mask,  # mask. for each token, the selected experts are marked with 1s [num_tokens, num_experts]
             None,  # token priority
             l_aux,

--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -136,8 +136,10 @@ class StandardMoERouter(nn.Layer):
         self.topk_group = config.topk_group
 
         self.routed_scaling_factor = config.routed_scaling_factor
+        self.routed_scaling_factor_learnable = (
+            config.routed_scaling_factor_learnable
+        )
 
-        self.gate_scaling_factor = config.gate_scaling_factor
         self.tensor_model_parallel_size = config.tensor_model_parallel_size
         self.sequence_parallel = config.sequence_parallel
         self.context_parallel_size = max(get_context_parallel_world_size(), 1)
@@ -158,32 +160,13 @@ class StandardMoERouter(nn.Layer):
             default_initializer=paddle.nn.initializer.Uniform(),
         )
 
-        if self.routed_scaling_factor == "learnable":
-            self.routed_scaling_factor = self.create_parameter(
+        if self.routed_scaling_factor_learnable:
+            self.routed_scaling_factor_param = self.create_parameter(
                 shape=[self.num_experts],
                 dtype="float32",
-                default_initializer=nn.initializer.Constant(1.0),
-            )
-        elif self.routed_scaling_factor is not None and not isinstance(
-            self.routed_scaling_factor, (int, float)
-        ):
-            raise ValueError(
-                f"routed_scaling_factor must be a float, 'learnable', or None, "
-                f"got {self.routed_scaling_factor!r}"
-            )
-
-        if self.gate_scaling_factor == "learnable":
-            self.gate_scaling_factor = self.create_parameter(
-                shape=[self.hidden_size],
-                dtype="float32",
-                default_initializer=nn.initializer.Constant(1.0),
-            )
-        elif self.gate_scaling_factor is not None and not isinstance(
-            self.gate_scaling_factor, (int, float)
-        ):
-            raise ValueError(
-                f"gate_scaling_factor must be a float, 'learnable', or None, "
-                f"got {self.gate_scaling_factor!r}"
+                default_initializer=nn.initializer.Constant(
+                    self.routed_scaling_factor
+                ),
             )
 
         if self.topk_method == "noaux_tc":
@@ -663,9 +646,6 @@ class TopKRouter(StandardMoERouter):
                 "The input tensor should have shape [batch_size, sequence_length, hidden_size]"
             )
 
-        if self.gate_scaling_factor is not None:
-            input = input * self.gate_scaling_factor * (self.hidden_size**-0.5)
-
         with paddle.amp.auto_cast(False):
             logits = gate_detach_matmul(
                 input,
@@ -785,16 +765,15 @@ class TopKRouter(StandardMoERouter):
                 top_gate = top_gate / denominator
             # When gpt_model_use_experimental_version is True, top_gate is already normalized by FusedMoETopk
 
-        if self.routed_scaling_factor is not None:
-            if isinstance(self.routed_scaling_factor, paddle.Tensor):
-                safe_topk_indices = paddle.clip(top_idx, min=0)
-                gathered_scales = F.embedding(
-                    safe_topk_indices,
-                    self.routed_scaling_factor.unsqueeze(1),
-                ).squeeze(-1)
-                top_gate = top_gate * gathered_scales
-            elif abs(self.routed_scaling_factor - 1.0) > 1e-6:
-                top_gate = top_gate * self.routed_scaling_factor
+        if self.routed_scaling_factor_learnable:
+            safe_topk_indices = paddle.clip(top_idx, min=0)
+            gathered_scales = F.embedding(
+                safe_topk_indices,
+                self.routed_scaling_factor_param.unsqueeze(1),
+            ).squeeze(-1)
+            top_gate = top_gate * gathered_scales
+        elif abs(self.routed_scaling_factor - 1.0) > 1e-6:
+            top_gate = top_gate * self.routed_scaling_factor
 
         # Reconstruct probs (combine weights in [S, E] sparse layout) from final top_gate.
         probs = paddle.zeros_like(gates).put_along_axis(

--- a/src/paddlefleet/transformer/moe/token_dispatcher.py
+++ b/src/paddlefleet/transformer/moe/token_dispatcher.py
@@ -534,13 +534,13 @@ class AllToAllTokenDispatcher(nn.Layer):
     def dispatch_preprocess(
         self,
         hidden_states: paddle.Tensor,
-        gates_masked: paddle.Tensor,  # probs
+        probs: paddle.Tensor,
         mask: paddle.Tensor,  # routing_map
         topk_weights: paddle.Tensor | None = None,
         topk_indices: paddle.Tensor | None = None,
     ) -> tuple[paddle.Tensor, paddle.Tensor]:
         self.routing_map = mask
-        self.gates_masked = gates_masked
+        self.probs = probs
         self.num_experts = (
             self.num_experts_per_device * self.expert_model_parallel_size
         )
@@ -683,7 +683,7 @@ class AllToAllTokenDispatcher(nn.Layer):
             permutated_local_input_tokens,
             self.reversed_local_input_permutation_mapping,
             restore_shape=self.reshaped_input_shape,
-            probs=self.gates_masked,
+            probs=self.probs,
             routing_map=self.routing_map,
         )
 

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -406,9 +406,26 @@ class TransformerConfig(ModelParallelConfig):
     topk_group: int = 1
     """Number of selected groups per token for expert selection."""
 
-    routed_scaling_factor: float = 1.0
-    """Scaling factor for routing score in top-k selection, only works when moe_router_pre_softmax
-    enabled. Defaults to None, which means no scaling."""
+    gate_scaling_factor: float | str | None = None
+    """Per-dimension scaling factor applied to the router input hidden states before the gate
+    linear projection, combined with a ``hidden_size ** -0.5`` normalization.
+
+    Supported values:
+    - ``None`` (default): disable feature scaling and normalization entirely.
+    - ``"learnable"``: create a trainable parameter of shape ``[hidden_size]``, initialized to 1.0.
+    - ``float``: apply a fixed scalar multiplier (combined with ``hidden_size ** -0.5``)."""
+
+    routed_scaling_factor: float | str | None = None
+    """Scaling factor applied to the selected top-k routing weights after expert selection.
+    The final scaled weights are used in ``top_gate`` (``[S, K]``) , which is passed to the
+    dispatch/combine flow for expert output weighting.
+
+    Supported values:
+    - ``None`` (default): disable routing weight scaling entirely.
+    - ``float``: fixed global scalar applied uniformly (e.g. ``2.5`` in DeepSeek-V3 to
+      compensate for sigmoid scores not summing to 1 after top-k selection).
+    - ``"learnable"``: create a trainable per-expert parameter of shape ``[num_experts]``,
+      initialized to 1.0."""
 
     moe_dequant_input: bool = False
     """Whether to dequantize input."""

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -406,26 +406,23 @@ class TransformerConfig(ModelParallelConfig):
     topk_group: int = 1
     """Number of selected groups per token for expert selection."""
 
-    gate_scaling_factor: float | str | None = None
-    """Per-dimension scaling factor applied to the router input hidden states before the gate
-    linear projection, combined with a ``hidden_size ** -0.5`` normalization.
-
-    Supported values:
-    - ``None`` (default): disable feature scaling and normalization entirely.
-    - ``"learnable"``: create a trainable parameter of shape ``[hidden_size]``, initialized to 1.0.
-    - ``float``: apply a fixed scalar multiplier (combined with ``hidden_size ** -0.5``)."""
-
-    routed_scaling_factor: float | str | None = None
-    """Scaling factor applied to the selected top-k routing weights after expert selection.
-    The final scaled weights are used in ``top_gate`` (``[S, K]``) , which is passed to the
+    routed_scaling_factor: float = 1.0
+    """Scalar multiplier applied to the selected top-k routing weights after expert selection.
+    The final scaled weights are used in ``top_gate`` (``[S, K]``), which is passed to the
     dispatch/combine flow for expert output weighting.
 
-    Supported values:
-    - ``None`` (default): disable routing weight scaling entirely.
-    - ``float``: fixed global scalar applied uniformly (e.g. ``2.5`` in DeepSeek-V3 to
-      compensate for sigmoid scores not summing to 1 after top-k selection).
-    - ``"learnable"``: create a trainable per-expert parameter of shape ``[num_experts]``,
-      initialized to 1.0."""
+    Default is ``1.0`` (no scaling effect). For example, set to ``2.5`` for DeepSeek-V3 to
+    compensate for sigmoid scores not summing to 1 after top-k selection.
+
+    When ``routed_scaling_factor_learnable=True``, this value is used as the initialization
+    value for the per-expert learnable parameter."""
+
+    routed_scaling_factor_learnable: bool = False
+    """Whether to use a learnable per-expert scaling parameter instead of a fixed scalar.
+
+    - ``False`` (default): apply ``routed_scaling_factor`` as a fixed scalar uniformly.
+    - ``True``: create a trainable parameter of shape ``[num_experts]``, initialized to
+      ``routed_scaling_factor``, and apply it via per-expert lookup after top-k selection."""
 
     moe_dequant_input: bool = False
     """Whether to dequantize input."""

--- a/tests/single_card_tests/ai_edited_test/moe/test_ai_token_dispatcher.py
+++ b/tests/single_card_tests/ai_edited_test/moe/test_ai_token_dispatcher.py
@@ -230,10 +230,10 @@ class TestTokenDispatcher(unittest.TestCase):
         routing_map[1, 0] = 1.0
         routing_map[2, 1] = 1.0
         routing_map[3, 1] = 1.0
-        gates_masked = routing_map.clone()
+        probs = routing_map.clone()
         dispatcher.reshaped_input_shape = hidden.shape
         dispatcher.routing_map = routing_map
-        dispatcher.gates_masked = gates_masked
+        dispatcher.probs = probs
 
         _, dispatcher.reversed_local_input_permutation_mapping = permute(
             hidden, routing_map

--- a/tests/single_card_tests/test_transformer_config.py
+++ b/tests/single_card_tests/test_transformer_config.py
@@ -145,31 +145,19 @@ class TestMoeLayerFreqAndFirstKDenseReplace(unittest.TestCase):
         self.assertEqual(config.moe_layer_freq, expected)
 
 
-class TestRoutedAndGateScalingFactorConfig(unittest.TestCase):
-    """Tests for the new gate_scaling_factor and routed_scaling_factor field types
-    introduced in TransformerConfig."""
+class TestRoutedScalingFactorConfig(unittest.TestCase):
+    """Tests for the routed_scaling_factor and routed_scaling_factor_learnable fields
+    in TransformerConfig."""
 
-    def test_gate_scaling_factor_default_is_none(self):
-        """gate_scaling_factor defaults to None when not specified."""
+    def test_routed_scaling_factor_default_is_1(self):
+        """routed_scaling_factor defaults to 1.0 when not specified."""
         config = TransformerConfig(num_hidden_layers=4)
-        self.assertIsNone(config.gate_scaling_factor)
+        self.assertAlmostEqual(config.routed_scaling_factor, 1.0)
 
-    def test_gate_scaling_factor_float(self):
-        """gate_scaling_factor accepts a float value."""
-        config = TransformerConfig(num_hidden_layers=4, gate_scaling_factor=0.5)
-        self.assertAlmostEqual(config.gate_scaling_factor, 0.5)
-
-    def test_gate_scaling_factor_learnable_string(self):
-        """gate_scaling_factor accepts the string 'learnable'."""
-        config = TransformerConfig(
-            num_hidden_layers=4, gate_scaling_factor="learnable"
-        )
-        self.assertEqual(config.gate_scaling_factor, "learnable")
-
-    def test_routed_scaling_factor_default_is_none(self):
-        """routed_scaling_factor defaults to None when not specified (new default)."""
+    def test_routed_scaling_factor_learnable_default_is_false(self):
+        """routed_scaling_factor_learnable defaults to False when not specified."""
         config = TransformerConfig(num_hidden_layers=4)
-        self.assertIsNone(config.routed_scaling_factor)
+        self.assertFalse(config.routed_scaling_factor_learnable)
 
     def test_routed_scaling_factor_float(self):
         """routed_scaling_factor accepts a float value (e.g., 2.5 for DeepSeek-V3)."""
@@ -178,22 +166,15 @@ class TestRoutedAndGateScalingFactorConfig(unittest.TestCase):
         )
         self.assertAlmostEqual(config.routed_scaling_factor, 2.5)
 
-    def test_routed_scaling_factor_learnable_string(self):
-        """routed_scaling_factor accepts the string 'learnable'."""
-        config = TransformerConfig(
-            num_hidden_layers=4, routed_scaling_factor="learnable"
-        )
-        self.assertEqual(config.routed_scaling_factor, "learnable")
-
-    def test_both_scaling_factors_can_be_set_together(self):
-        """Both gate_scaling_factor and routed_scaling_factor can be set simultaneously."""
+    def test_routed_scaling_factor_learnable_true(self):
+        """routed_scaling_factor_learnable can be set to True."""
         config = TransformerConfig(
             num_hidden_layers=4,
-            gate_scaling_factor="learnable",
             routed_scaling_factor=2.5,
+            routed_scaling_factor_learnable=True,
         )
-        self.assertEqual(config.gate_scaling_factor, "learnable")
         self.assertAlmostEqual(config.routed_scaling_factor, 2.5)
+        self.assertTrue(config.routed_scaling_factor_learnable)
 
 
 if __name__ == "__main__":

--- a/tests/single_card_tests/test_transformer_config.py
+++ b/tests/single_card_tests/test_transformer_config.py
@@ -145,5 +145,56 @@ class TestMoeLayerFreqAndFirstKDenseReplace(unittest.TestCase):
         self.assertEqual(config.moe_layer_freq, expected)
 
 
+class TestRoutedAndGateScalingFactorConfig(unittest.TestCase):
+    """Tests for the new gate_scaling_factor and routed_scaling_factor field types
+    introduced in TransformerConfig."""
+
+    def test_gate_scaling_factor_default_is_none(self):
+        """gate_scaling_factor defaults to None when not specified."""
+        config = TransformerConfig(num_hidden_layers=4)
+        self.assertIsNone(config.gate_scaling_factor)
+
+    def test_gate_scaling_factor_float(self):
+        """gate_scaling_factor accepts a float value."""
+        config = TransformerConfig(num_hidden_layers=4, gate_scaling_factor=0.5)
+        self.assertAlmostEqual(config.gate_scaling_factor, 0.5)
+
+    def test_gate_scaling_factor_learnable_string(self):
+        """gate_scaling_factor accepts the string 'learnable'."""
+        config = TransformerConfig(
+            num_hidden_layers=4, gate_scaling_factor="learnable"
+        )
+        self.assertEqual(config.gate_scaling_factor, "learnable")
+
+    def test_routed_scaling_factor_default_is_none(self):
+        """routed_scaling_factor defaults to None when not specified (new default)."""
+        config = TransformerConfig(num_hidden_layers=4)
+        self.assertIsNone(config.routed_scaling_factor)
+
+    def test_routed_scaling_factor_float(self):
+        """routed_scaling_factor accepts a float value (e.g., 2.5 for DeepSeek-V3)."""
+        config = TransformerConfig(
+            num_hidden_layers=4, routed_scaling_factor=2.5
+        )
+        self.assertAlmostEqual(config.routed_scaling_factor, 2.5)
+
+    def test_routed_scaling_factor_learnable_string(self):
+        """routed_scaling_factor accepts the string 'learnable'."""
+        config = TransformerConfig(
+            num_hidden_layers=4, routed_scaling_factor="learnable"
+        )
+        self.assertEqual(config.routed_scaling_factor, "learnable")
+
+    def test_both_scaling_factors_can_be_set_together(self):
+        """Both gate_scaling_factor and routed_scaling_factor can be set simultaneously."""
+        config = TransformerConfig(
+            num_hidden_layers=4,
+            gate_scaling_factor="learnable",
+            routed_scaling_factor=2.5,
+        )
+        self.assertEqual(config.gate_scaling_factor, "learnable")
+        self.assertAlmostEqual(config.routed_scaling_factor, 2.5)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/single_card_tests/transformer/test_router.py
+++ b/tests/single_card_tests/transformer/test_router.py
@@ -44,7 +44,8 @@ class MockTransformerConfig:
         # Router Specific Parameters
         self.topk_method = "noaux_tc"
         self.norm_topk_prob = True
-        self.routed_scaling_factor = 1.0
+        self.routed_scaling_factor = None
+        self.gate_scaling_factor = None
         self.scoring_func = "softmax"
         self.moe_router_load_balancing_type = "aux_loss"
         self.moe_router_force_load_balancing = False
@@ -389,6 +390,379 @@ class TestTopKRouter(unittest.TestCase):
         )
         self.assertEqual(loss.shape, [])
         self.assertGreater(loss.item(), 0.0)
+
+
+class TestScalingFactorInit(unittest.TestCase):
+    """Test initialization behavior for gate_scaling_factor and routed_scaling_factor."""
+
+    def setUp(self):
+        self.config = MockTransformerConfig()
+        patcher = patch(
+            "paddlefleet.transformer.moe.moe_router.get_context_parallel_world_size",
+            return_value=1,
+        )
+        self.mock_cp = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    # ---- routed_scaling_factor ----
+
+    def test_routed_scaling_factor_none(self):
+        """routed_scaling_factor=None: stored as None, not a Parameter."""
+        self.config.routed_scaling_factor = None
+        router = TopKRouter(self.config)
+        self.assertIsNone(router.routed_scaling_factor)
+
+    def test_routed_scaling_factor_float(self):
+        """routed_scaling_factor=2.5 (float): stored as float."""
+        self.config.routed_scaling_factor = 2.5
+        router = TopKRouter(self.config)
+        self.assertIsInstance(router.routed_scaling_factor, float)
+        self.assertAlmostEqual(router.routed_scaling_factor, 2.5)
+
+    def test_routed_scaling_factor_learnable(self):
+        """routed_scaling_factor='learnable': creates a trainable Parameter of shape [num_experts]."""
+        self.config.routed_scaling_factor = "learnable"
+        router = TopKRouter(self.config)
+        self.assertIsInstance(router.routed_scaling_factor, paddle.Tensor)
+        self.assertEqual(
+            list(router.routed_scaling_factor.shape),
+            [self.config.n_routed_experts],
+        )
+        # Initialized to 1.0
+        np.testing.assert_allclose(
+            router.routed_scaling_factor.numpy(),
+            np.ones(self.config.n_routed_experts, dtype="float32"),
+        )
+        # Should be a trainable parameter
+        self.assertFalse(router.routed_scaling_factor.stop_gradient)
+
+    def test_routed_scaling_factor_invalid_raises(self):
+        """routed_scaling_factor with an invalid type (e.g., a list) should raise ValueError."""
+        self.config.routed_scaling_factor = [1.0, 2.0]
+        with self.assertRaises(ValueError):
+            TopKRouter(self.config)
+
+    def test_routed_scaling_factor_invalid_string_raises(self):
+        """routed_scaling_factor='unknown' should raise ValueError."""
+        self.config.routed_scaling_factor = "unknown"
+        with self.assertRaises(ValueError):
+            TopKRouter(self.config)
+
+    # ---- gate_scaling_factor ----
+
+    def test_gate_scaling_factor_none(self):
+        """gate_scaling_factor=None: stored as None."""
+        self.config.gate_scaling_factor = None
+        router = TopKRouter(self.config)
+        self.assertIsNone(router.gate_scaling_factor)
+
+    def test_gate_scaling_factor_float(self):
+        """gate_scaling_factor=0.5 (float): stored as float."""
+        self.config.gate_scaling_factor = 0.5
+        router = TopKRouter(self.config)
+        self.assertIsInstance(router.gate_scaling_factor, float)
+        self.assertAlmostEqual(router.gate_scaling_factor, 0.5)
+
+    def test_gate_scaling_factor_learnable(self):
+        """gate_scaling_factor='learnable': creates a trainable Parameter of shape [hidden_size]."""
+        self.config.gate_scaling_factor = "learnable"
+        router = TopKRouter(self.config)
+        self.assertIsInstance(router.gate_scaling_factor, paddle.Tensor)
+        self.assertEqual(
+            list(router.gate_scaling_factor.shape), [self.config.hidden_size]
+        )
+        # Initialized to 1.0
+        np.testing.assert_allclose(
+            router.gate_scaling_factor.numpy(),
+            np.ones(self.config.hidden_size, dtype="float32"),
+        )
+        self.assertFalse(router.gate_scaling_factor.stop_gradient)
+
+    def test_gate_scaling_factor_invalid_raises(self):
+        """gate_scaling_factor with an invalid type (e.g., a list) should raise ValueError."""
+        self.config.gate_scaling_factor = [1.0]
+        with self.assertRaises(ValueError):
+            TopKRouter(self.config)
+
+    def test_gate_scaling_factor_invalid_string_raises(self):
+        """gate_scaling_factor='bad_value' should raise ValueError."""
+        self.config.gate_scaling_factor = "bad_value"
+        with self.assertRaises(ValueError):
+            TopKRouter(self.config)
+
+
+class TestGateScalingFactorForward(unittest.TestCase):
+    """Test that gate_scaling_factor correctly scales input before the gate projection."""
+
+    def setUp(self):
+        self.config = MockTransformerConfig()
+        self.config.topk_method = "greedy"
+        self.config.norm_topk_prob = False
+        self.config.router_aux_loss_coef = 0.0
+        self.config.router_z_loss_coef = 0.0
+        patcher = patch(
+            "paddlefleet.transformer.moe.moe_router.get_context_parallel_world_size",
+            return_value=1,
+        )
+        self.mock_cp = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_gate_scaling_none_no_effect(self):
+        """gate_scaling_factor=None: forward should succeed and output shapes should be correct."""
+        self.config.gate_scaling_factor = None
+        router = TopKRouter(self.config)
+        hidden = paddle.randn([2, 4, self.config.hidden_size])
+        outputs = router(hidden)
+        self.assertIsNotNone(outputs)
+        _, top_gate, top_idx, probs, mask, _, _, _ = outputs
+        self.assertEqual(top_gate.shape, [8, self.config.num_experts_per_tok])
+        self.assertEqual(probs.shape, [8, self.config.n_routed_experts])
+
+    def test_gate_scaling_float_changes_logits(self):
+        """gate_scaling_factor=float: the scaled path should produce different top_gate than unscaled."""
+        paddle.seed(42)
+        hidden = paddle.randn([2, 4, self.config.hidden_size])
+
+        self.config.gate_scaling_factor = None
+        router_no_scale = TopKRouter(self.config)
+
+        self.config.gate_scaling_factor = 2.0
+        router_scaled = TopKRouter(self.config)
+        # Copy same weights so only the scaling differs
+        router_scaled.weight.set_value(router_no_scale.weight.clone())
+
+        _, top_gate_no, top_idx_no, _, _, _, _, _ = router_no_scale(hidden)
+        _, top_gate_yes, top_idx_yes, _, _, _, _, _ = router_scaled(hidden)
+
+        # At least some routing weights should differ
+        self.assertFalse(
+            np.allclose(top_gate_no.numpy(), top_gate_yes.numpy(), atol=1e-5),
+            "gate_scaling_factor=2.0 should change the routing weights",
+        )
+
+    def test_gate_scaling_learnable_forward(self):
+        """gate_scaling_factor='learnable': forward runs without error and output shapes are correct."""
+        self.config.gate_scaling_factor = "learnable"
+        router = TopKRouter(self.config)
+        hidden = paddle.randn([2, 4, self.config.hidden_size])
+        outputs = router(hidden)
+        self.assertIsNotNone(outputs)
+        _, top_gate, top_idx, probs, mask, _, _, _ = outputs
+        self.assertEqual(probs.shape, [8, self.config.n_routed_experts])
+
+
+class TestRoutedScalingFactorForward(unittest.TestCase):
+    """Test that routed_scaling_factor correctly scales top_gate after top-k selection."""
+
+    def setUp(self):
+        self.config = MockTransformerConfig()
+        self.config.topk_method = "greedy"
+        self.config.norm_topk_prob = False
+        self.config.router_aux_loss_coef = 0.0
+        self.config.router_z_loss_coef = 0.0
+        patcher = patch(
+            "paddlefleet.transformer.moe.moe_router.get_context_parallel_world_size",
+            return_value=1,
+        )
+        self.mock_cp = patcher.start()
+        self.addCleanup(patcher.stop)
+        paddle.seed(99)
+        self.hidden = paddle.randn([2, 4, self.config.hidden_size])
+
+    def _make_router(self, rsf):
+        self.config.routed_scaling_factor = rsf
+        return TopKRouter(self.config)
+
+    def test_none_no_scaling(self):
+        """routed_scaling_factor=None: top_gate should NOT be additionally scaled."""
+        router_none = self._make_router(None)
+        self.config.routed_scaling_factor = 1.0
+        router_one = self._make_router(1.0)
+        # Copy same weights
+        router_one.weight.set_value(router_none.weight.clone())
+
+        _, top_gate_none, _, _, _, _, _, _ = router_none(self.hidden)
+        _, top_gate_one, _, _, _, _, _, _ = router_one(self.hidden)
+
+        # routed_scaling_factor=1.0 should be a no-op (abs(1.0-1.0)<=1e-6), so results equal
+        np.testing.assert_allclose(
+            top_gate_none.numpy(),
+            top_gate_one.numpy(),
+            atol=1e-5,
+            err_msg="None and 1.0 routed_scaling_factor should yield identical top_gate",
+        )
+
+    def test_float_scaling(self):
+        """routed_scaling_factor=2.5 (DeepSeek-V3 style): top_gate should be multiplied by 2.5."""
+        router_none = self._make_router(None)
+        router_25 = self._make_router(2.5)
+        router_25.weight.set_value(router_none.weight.clone())
+
+        _, top_gate_none, _, _, _, _, _, _ = router_none(self.hidden)
+        _, top_gate_25, _, _, _, _, _, _ = router_25(self.hidden)
+
+        np.testing.assert_allclose(
+            top_gate_25.numpy(),
+            top_gate_none.numpy() * 2.5,
+            rtol=1e-5,
+            err_msg="routed_scaling_factor=2.5 should multiply top_gate by 2.5",
+        )
+
+    def test_float_scaling_one_is_noop(self):
+        """routed_scaling_factor=1.0 (abs diff <= 1e-6): top_gate unchanged compared to None."""
+        router_none = self._make_router(None)
+        router_one = self._make_router(1.0)
+        router_one.weight.set_value(router_none.weight.clone())
+
+        _, top_gate_none, _, _, _, _, _, _ = router_none(self.hidden)
+        _, top_gate_one, _, _, _, _, _, _ = router_one(self.hidden)
+
+        np.testing.assert_allclose(
+            top_gate_none.numpy(),
+            top_gate_one.numpy(),
+            atol=1e-5,
+        )
+
+    def test_learnable_scaling(self):
+        """routed_scaling_factor='learnable': per-expert scaling via embedding lookup."""
+        router = self._make_router("learnable")
+        hidden = paddle.randn([2, 4, self.config.hidden_size])
+        outputs = router(hidden)
+        self.assertIsNotNone(outputs)
+        _, top_gate, top_idx, probs, mask, _, _, _ = outputs
+
+        # Learnable scales are initialized to 1.0, so top_gate == scaled_by_1_top_gate
+        router_none = self._make_router(None)
+        router_none.weight.set_value(router.weight.clone())
+        _, top_gate_none, _, _, _, _, _, _ = router_none(hidden)
+
+        np.testing.assert_allclose(
+            top_gate.numpy(),
+            top_gate_none.numpy(),
+            atol=1e-5,
+            err_msg="learnable scales init=1.0 should give same result as no scaling",
+        )
+
+    def test_probs_sparse_layout_consistency(self):
+        """probs[S, E] should be 0 for non-selected experts and equal to top_gate for selected ones."""
+        router = self._make_router(2.5)
+        hidden = paddle.randn([1, 6, self.config.hidden_size])
+        _, top_gate, top_idx, probs, mask, _, _, _ = router(hidden)
+
+        num_tokens = 6
+        k = self.config.num_experts_per_tok
+
+        # For each token, gather the probs values at the selected expert indices
+        for t in range(num_tokens):
+            for ki in range(k):
+                expert_id = top_idx[t, ki].item()
+                self.assertGreaterEqual(
+                    expert_id, 0, "Expert index should be non-negative"
+                )
+                self.assertAlmostEqual(
+                    probs[t, expert_id].item(),
+                    top_gate[t, ki].item(),
+                    places=5,
+                    msg=f"probs[{t},{expert_id}] should equal top_gate[{t},{ki}]",
+                )
+
+
+class TestForwardOutputRenaming(unittest.TestCase):
+    """Test that the return tuple at position 3 is 'probs' (formerly 'gates_masked')."""
+
+    def setUp(self):
+        self.config = MockTransformerConfig()
+        patcher = patch(
+            "paddlefleet.transformer.moe.moe_router.get_context_parallel_world_size",
+            return_value=1,
+        )
+        self.mock_cp = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_probs_output_shape_and_sparsity(self):
+        """
+        Return value at index 3 (probs) should have shape [S, E].
+        Non-selected expert positions should be exactly 0.
+        """
+        self.config.topk_method = "noaux_tc"
+        router = TopKRouter(self.config)
+        batch_size, seq_len = 2, 5
+        hidden = paddle.randn([batch_size, seq_len, self.config.hidden_size])
+
+        (_, top_gate, top_idx, probs, mask, _, _, _) = router(hidden)
+
+        num_tokens = batch_size * seq_len
+        k = self.config.num_experts_per_tok
+        n_e = self.config.n_routed_experts
+
+        self.assertEqual(probs.shape, [num_tokens, n_e])
+
+        # Count non-zero entries per token; should equal k (num_experts_per_tok)
+        probs_np = probs.numpy()
+        for t in range(num_tokens):
+            nnz = np.count_nonzero(probs_np[t])
+            self.assertEqual(
+                nnz,
+                k,
+                f"Token {t}: expected {k} non-zero probs, got {nnz}",
+            )
+
+    def test_probs_consistent_with_mask(self):
+        """
+        probs non-zero positions should exactly match mask==1 positions.
+        """
+        self.config.topk_method = "greedy"
+        self.config.norm_topk_prob = False
+        self.config.router_aux_loss_coef = 0.0
+        self.config.router_z_loss_coef = 0.0
+        router = TopKRouter(self.config)
+
+        hidden = paddle.randn([2, 4, self.config.hidden_size])
+        (_, _, _, probs, mask, _, _, _) = router(hidden)
+
+        probs_np = probs.numpy()
+        mask_np = mask.numpy()
+
+        # Where mask==0, probs must be 0
+        np.testing.assert_array_equal(
+            (probs_np != 0).astype(int),
+            mask_np.astype(int),
+            err_msg="probs non-zero pattern must match mask",
+        )
+
+    def test_forward_with_input_ids_probs_name(self):
+        """
+        With input_ids masking, padding tokens' probs row should be all zeros.
+        This replaces the old gates_masked variable name check.
+        """
+        self.config.topk_method = "noaux_tc"
+        router = TopKRouter(self.config)
+
+        batch_size, seq_len = 2, 4
+        paddle.seed(42)
+        hidden = paddle.randn([batch_size, seq_len, self.config.hidden_size])
+        input_ids = paddle.to_tensor([[1, 2, 0, 0], [3, 4, 5, 0]])
+
+        _, top_gate, top_idx, probs, mask, _, _, _ = router(
+            hidden, input_ids=input_ids
+        )
+
+        # Padding flat positions: 2, 3, 7
+        for p in [2, 3, 7]:
+            self.assertAlmostEqual(
+                probs[p].sum().item(),
+                0.0,
+                places=5,
+                msg=f"probs at padding position {p} should be 0",
+            )
+
+        # Valid flat positions must have non-zero probs rows
+        for p in [0, 1, 4, 5, 6]:
+            self.assertGreater(
+                probs[p].sum().item(),
+                0.0,
+                msg=f"probs at valid position {p} should be non-zero",
+            )
 
 
 if __name__ == "__main__":

--- a/tests/single_card_tests/transformer/test_router.py
+++ b/tests/single_card_tests/transformer/test_router.py
@@ -44,8 +44,8 @@ class MockTransformerConfig:
         # Router Specific Parameters
         self.topk_method = "noaux_tc"
         self.norm_topk_prob = True
-        self.routed_scaling_factor = None
-        self.gate_scaling_factor = None
+        self.routed_scaling_factor = 1.0
+        self.routed_scaling_factor_learnable = False
         self.scoring_func = "softmax"
         self.moe_router_load_balancing_type = "aux_loss"
         self.moe_router_force_load_balancing = False
@@ -393,7 +393,7 @@ class TestTopKRouter(unittest.TestCase):
 
 
 class TestScalingFactorInit(unittest.TestCase):
-    """Test initialization behavior for gate_scaling_factor and routed_scaling_factor."""
+    """Test initialization behavior for routed_scaling_factor and routed_scaling_factor_learnable."""
 
     def setUp(self):
         self.config = MockTransformerConfig()
@@ -404,13 +404,14 @@ class TestScalingFactorInit(unittest.TestCase):
         self.mock_cp = patcher.start()
         self.addCleanup(patcher.stop)
 
-    # ---- routed_scaling_factor ----
+    # ---- routed_scaling_factor (scalar) ----
 
-    def test_routed_scaling_factor_none(self):
-        """routed_scaling_factor=None: stored as None, not a Parameter."""
-        self.config.routed_scaling_factor = None
+    def test_routed_scaling_factor_default(self):
+        """routed_scaling_factor=1.0 (default): stored as float, no learnable param."""
         router = TopKRouter(self.config)
-        self.assertIsNone(router.routed_scaling_factor)
+        self.assertIsInstance(router.routed_scaling_factor, float)
+        self.assertAlmostEqual(router.routed_scaling_factor, 1.0)
+        self.assertFalse(hasattr(router, "routed_scaling_factor_param"))
 
     def test_routed_scaling_factor_float(self):
         """routed_scaling_factor=2.5 (float): stored as float."""
@@ -418,137 +419,35 @@ class TestScalingFactorInit(unittest.TestCase):
         router = TopKRouter(self.config)
         self.assertIsInstance(router.routed_scaling_factor, float)
         self.assertAlmostEqual(router.routed_scaling_factor, 2.5)
+        self.assertFalse(hasattr(router, "routed_scaling_factor_param"))
 
-    def test_routed_scaling_factor_learnable(self):
-        """routed_scaling_factor='learnable': creates a trainable Parameter of shape [num_experts]."""
-        self.config.routed_scaling_factor = "learnable"
+    # ---- routed_scaling_factor_learnable ----
+
+    def test_routed_scaling_factor_learnable_default_init(self):
+        """routed_scaling_factor_learnable=True with default 1.0: creates Parameter of shape [num_experts], init 1.0."""
+        self.config.routed_scaling_factor_learnable = True
         router = TopKRouter(self.config)
-        self.assertIsInstance(router.routed_scaling_factor, paddle.Tensor)
-        self.assertEqual(
-            list(router.routed_scaling_factor.shape),
-            [self.config.n_routed_experts],
-        )
-        # Initialized to 1.0
+        self.assertTrue(hasattr(router, "routed_scaling_factor_param"))
+        param = router.routed_scaling_factor_param
+        self.assertIsInstance(param, paddle.Tensor)
+        self.assertEqual(list(param.shape), [self.config.n_routed_experts])
         np.testing.assert_allclose(
-            router.routed_scaling_factor.numpy(),
+            param.numpy(),
             np.ones(self.config.n_routed_experts, dtype="float32"),
         )
-        # Should be a trainable parameter
-        self.assertFalse(router.routed_scaling_factor.stop_gradient)
+        self.assertFalse(param.stop_gradient)
 
-    def test_routed_scaling_factor_invalid_raises(self):
-        """routed_scaling_factor with an invalid type (e.g., a list) should raise ValueError."""
-        self.config.routed_scaling_factor = [1.0, 2.0]
-        with self.assertRaises(ValueError):
-            TopKRouter(self.config)
-
-    def test_routed_scaling_factor_invalid_string_raises(self):
-        """routed_scaling_factor='unknown' should raise ValueError."""
-        self.config.routed_scaling_factor = "unknown"
-        with self.assertRaises(ValueError):
-            TopKRouter(self.config)
-
-    # ---- gate_scaling_factor ----
-
-    def test_gate_scaling_factor_none(self):
-        """gate_scaling_factor=None: stored as None."""
-        self.config.gate_scaling_factor = None
+    def test_routed_scaling_factor_learnable_custom_init(self):
+        """routed_scaling_factor_learnable=True with routed_scaling_factor=2.5: Parameter initialized to 2.5."""
+        self.config.routed_scaling_factor = 2.5
+        self.config.routed_scaling_factor_learnable = True
         router = TopKRouter(self.config)
-        self.assertIsNone(router.gate_scaling_factor)
-
-    def test_gate_scaling_factor_float(self):
-        """gate_scaling_factor=0.5 (float): stored as float."""
-        self.config.gate_scaling_factor = 0.5
-        router = TopKRouter(self.config)
-        self.assertIsInstance(router.gate_scaling_factor, float)
-        self.assertAlmostEqual(router.gate_scaling_factor, 0.5)
-
-    def test_gate_scaling_factor_learnable(self):
-        """gate_scaling_factor='learnable': creates a trainable Parameter of shape [hidden_size]."""
-        self.config.gate_scaling_factor = "learnable"
-        router = TopKRouter(self.config)
-        self.assertIsInstance(router.gate_scaling_factor, paddle.Tensor)
-        self.assertEqual(
-            list(router.gate_scaling_factor.shape), [self.config.hidden_size]
-        )
-        # Initialized to 1.0
+        param = router.routed_scaling_factor_param
         np.testing.assert_allclose(
-            router.gate_scaling_factor.numpy(),
-            np.ones(self.config.hidden_size, dtype="float32"),
+            param.numpy(),
+            np.full(self.config.n_routed_experts, 2.5, dtype="float32"),
+            rtol=1e-5,
         )
-        self.assertFalse(router.gate_scaling_factor.stop_gradient)
-
-    def test_gate_scaling_factor_invalid_raises(self):
-        """gate_scaling_factor with an invalid type (e.g., a list) should raise ValueError."""
-        self.config.gate_scaling_factor = [1.0]
-        with self.assertRaises(ValueError):
-            TopKRouter(self.config)
-
-    def test_gate_scaling_factor_invalid_string_raises(self):
-        """gate_scaling_factor='bad_value' should raise ValueError."""
-        self.config.gate_scaling_factor = "bad_value"
-        with self.assertRaises(ValueError):
-            TopKRouter(self.config)
-
-
-class TestGateScalingFactorForward(unittest.TestCase):
-    """Test that gate_scaling_factor correctly scales input before the gate projection."""
-
-    def setUp(self):
-        self.config = MockTransformerConfig()
-        self.config.topk_method = "greedy"
-        self.config.norm_topk_prob = False
-        self.config.router_aux_loss_coef = 0.0
-        self.config.router_z_loss_coef = 0.0
-        patcher = patch(
-            "paddlefleet.transformer.moe.moe_router.get_context_parallel_world_size",
-            return_value=1,
-        )
-        self.mock_cp = patcher.start()
-        self.addCleanup(patcher.stop)
-
-    def test_gate_scaling_none_no_effect(self):
-        """gate_scaling_factor=None: forward should succeed and output shapes should be correct."""
-        self.config.gate_scaling_factor = None
-        router = TopKRouter(self.config)
-        hidden = paddle.randn([2, 4, self.config.hidden_size])
-        outputs = router(hidden)
-        self.assertIsNotNone(outputs)
-        _, top_gate, top_idx, probs, mask, _, _, _ = outputs
-        self.assertEqual(top_gate.shape, [8, self.config.num_experts_per_tok])
-        self.assertEqual(probs.shape, [8, self.config.n_routed_experts])
-
-    def test_gate_scaling_float_changes_logits(self):
-        """gate_scaling_factor=float: the scaled path should produce different top_gate than unscaled."""
-        paddle.seed(42)
-        hidden = paddle.randn([2, 4, self.config.hidden_size])
-
-        self.config.gate_scaling_factor = None
-        router_no_scale = TopKRouter(self.config)
-
-        self.config.gate_scaling_factor = 2.0
-        router_scaled = TopKRouter(self.config)
-        # Copy same weights so only the scaling differs
-        router_scaled.weight.set_value(router_no_scale.weight.clone())
-
-        _, top_gate_no, top_idx_no, _, _, _, _, _ = router_no_scale(hidden)
-        _, top_gate_yes, top_idx_yes, _, _, _, _, _ = router_scaled(hidden)
-
-        # At least some routing weights should differ
-        self.assertFalse(
-            np.allclose(top_gate_no.numpy(), top_gate_yes.numpy(), atol=1e-5),
-            "gate_scaling_factor=2.0 should change the routing weights",
-        )
-
-    def test_gate_scaling_learnable_forward(self):
-        """gate_scaling_factor='learnable': forward runs without error and output shapes are correct."""
-        self.config.gate_scaling_factor = "learnable"
-        router = TopKRouter(self.config)
-        hidden = paddle.randn([2, 4, self.config.hidden_size])
-        outputs = router(hidden)
-        self.assertIsNotNone(outputs)
-        _, top_gate, top_idx, probs, mask, _, _, _ = outputs
-        self.assertEqual(probs.shape, [8, self.config.n_routed_experts])
 
 
 class TestRoutedScalingFactorForward(unittest.TestCase):
@@ -569,78 +468,59 @@ class TestRoutedScalingFactorForward(unittest.TestCase):
         paddle.seed(99)
         self.hidden = paddle.randn([2, 4, self.config.hidden_size])
 
-    def _make_router(self, rsf):
+    def _make_router(self, rsf, learnable=False):
         self.config.routed_scaling_factor = rsf
+        self.config.routed_scaling_factor_learnable = learnable
         return TopKRouter(self.config)
 
-    def test_none_no_scaling(self):
-        """routed_scaling_factor=None: top_gate should NOT be additionally scaled."""
-        router_none = self._make_router(None)
+    def test_scalar_one_is_noop(self):
+        """routed_scaling_factor=1.0 (default): top_gate should be unchanged."""
+        router = self._make_router(1.0)
+        _, top_gate_1, _, _, _, _, _, _ = router(self.hidden)
+
         self.config.routed_scaling_factor = 1.0
-        router_one = self._make_router(1.0)
-        # Copy same weights
-        router_one.weight.set_value(router_none.weight.clone())
+        self.config.routed_scaling_factor_learnable = False
+        router2 = TopKRouter(self.config)
+        router2.weight.set_value(router.weight.clone())
+        _, top_gate_2, _, _, _, _, _, _ = router2(self.hidden)
 
-        _, top_gate_none, _, _, _, _, _, _ = router_none(self.hidden)
-        _, top_gate_one, _, _, _, _, _, _ = router_one(self.hidden)
-
-        # routed_scaling_factor=1.0 should be a no-op (abs(1.0-1.0)<=1e-6), so results equal
         np.testing.assert_allclose(
-            top_gate_none.numpy(),
-            top_gate_one.numpy(),
+            top_gate_1.numpy(),
+            top_gate_2.numpy(),
             atol=1e-5,
-            err_msg="None and 1.0 routed_scaling_factor should yield identical top_gate",
+            err_msg="routed_scaling_factor=1.0 should be a no-op",
         )
 
     def test_float_scaling(self):
-        """routed_scaling_factor=2.5 (DeepSeek-V3 style): top_gate should be multiplied by 2.5."""
-        router_none = self._make_router(None)
+        """routed_scaling_factor=2.5: top_gate should be multiplied by 2.5."""
+        router_1 = self._make_router(1.0)
         router_25 = self._make_router(2.5)
-        router_25.weight.set_value(router_none.weight.clone())
+        router_25.weight.set_value(router_1.weight.clone())
 
-        _, top_gate_none, _, _, _, _, _, _ = router_none(self.hidden)
+        _, top_gate_1, _, _, _, _, _, _ = router_1(self.hidden)
         _, top_gate_25, _, _, _, _, _, _ = router_25(self.hidden)
 
         np.testing.assert_allclose(
             top_gate_25.numpy(),
-            top_gate_none.numpy() * 2.5,
+            top_gate_1.numpy() * 2.5,
             rtol=1e-5,
             err_msg="routed_scaling_factor=2.5 should multiply top_gate by 2.5",
         )
 
-    def test_float_scaling_one_is_noop(self):
-        """routed_scaling_factor=1.0 (abs diff <= 1e-6): top_gate unchanged compared to None."""
-        router_none = self._make_router(None)
-        router_one = self._make_router(1.0)
-        router_one.weight.set_value(router_none.weight.clone())
+    def test_learnable_scaling_init_equal_to_scalar(self):
+        """routed_scaling_factor_learnable=True, init=2.5: at init equals scalar 2.5."""
+        router_scalar = self._make_router(2.5, learnable=False)
+        router_learn = self._make_router(2.5, learnable=True)
+        router_learn.weight.set_value(router_scalar.weight.clone())
 
-        _, top_gate_none, _, _, _, _, _, _ = router_none(self.hidden)
-        _, top_gate_one, _, _, _, _, _, _ = router_one(self.hidden)
-
-        np.testing.assert_allclose(
-            top_gate_none.numpy(),
-            top_gate_one.numpy(),
-            atol=1e-5,
-        )
-
-    def test_learnable_scaling(self):
-        """routed_scaling_factor='learnable': per-expert scaling via embedding lookup."""
-        router = self._make_router("learnable")
-        hidden = paddle.randn([2, 4, self.config.hidden_size])
-        outputs = router(hidden)
-        self.assertIsNotNone(outputs)
-        _, top_gate, top_idx, probs, mask, _, _, _ = outputs
-
-        # Learnable scales are initialized to 1.0, so top_gate == scaled_by_1_top_gate
-        router_none = self._make_router(None)
-        router_none.weight.set_value(router.weight.clone())
-        _, top_gate_none, _, _, _, _, _, _ = router_none(hidden)
+        _, top_gate_scalar, _, _, _, _, _, _ = router_scalar(self.hidden)
+        _, top_gate_learn, _, _, _, _, _, _ = router_learn(self.hidden)
 
         np.testing.assert_allclose(
-            top_gate.numpy(),
-            top_gate_none.numpy(),
+            top_gate_learn.numpy(),
+            top_gate_scalar.numpy(),
             atol=1e-5,
-            err_msg="learnable scales init=1.0 should give same result as no scaling",
+            err_msg="learnable scales init=2.5 should give same result as scalar 2.5",
         )
 
     def test_probs_sparse_layout_consistency(self):
@@ -652,7 +532,6 @@ class TestRoutedScalingFactorForward(unittest.TestCase):
         num_tokens = 6
         k = self.config.num_experts_per_tok
 
-        # For each token, gather the probs values at the selected expert indices
         for t in range(num_tokens):
             for ki in range(k):
                 expert_id = top_idx[t, ki].item()


### PR DESCRIPTION
支持可学习的`routed_scaling_factor`参数，优化router中`gates_mask`相关代码逻辑，避免`probs`和`gates`冗余处理scale。