### PR TITLE
Support per-depth MTP input_ids for MoE routing mask

### DIFF
--- a/src/paddlefleet/models/gpt/gpt_embedding.py
+++ b/src/paddlefleet/models/gpt/gpt_embedding.py
@@ -143,6 +143,9 @@ class GPTEmbedding(FleetLayer):
         # The input_ids_for_moe_mask for moe router is same as input_ids.
         # The moe router will use it to generate the padding mask for the current sequence.
         input_ids_for_moe_mask = None
+        # Per-depth MTP input_ids for MoE routing in MTP layers.
+        # Shape: [B, num_mtp, max_seq] when MTP is enabled, None otherwise.
+        mtp_input_ids_for_moe_mask = None
         if decoder_input is None:
             decoder_input = self.embedding(
                 input_ids=input_ids,
@@ -168,6 +171,26 @@ class GPTEmbedding(FleetLayer):
                 assert not self.multimodal_embedding, (
                     "MTP not support mm for now."
                 )
+                num_nextn_predict_layers = self.config.num_nextn_predict_layers
+                # Split input_ids for MoE mask: main part for backbone, per-depth for MTP
+                if input_ids_for_moe_mask is not None:
+                    # Main backbone input_ids: [B, max_seq]
+                    # Use .contiguous() because slices are non-contiguous and PP P2P send requires contiguous tensors.
+                    input_ids_for_moe_mask = input_ids[
+                        :, :-num_nextn_predict_layers
+                    ].contiguous()
+                    # Construct per-depth MTP input_ids: for depth k, use
+                    # input_ids[:, (k+1):(k+1+max_seq)] matching embedding shift
+                    seq_length = input_ids.shape[1] - num_nextn_predict_layers
+                    mtp_ids_list = []
+                    for depth in range(num_nextn_predict_layers):
+                        mtp_ids_list.append(
+                            input_ids[:, (depth + 1) : (depth + 1 + seq_length)]
+                        )
+                    # [B, num_mtp, max_seq] - paddle.stack creates a new contiguous tensor
+                    mtp_input_ids_for_moe_mask = paddle.stack(
+                        mtp_ids_list, axis=1
+                    )
                 inputs_embeds_extra = decoder_input[
                     :, -self.config.num_nextn_predict_layers :, :
                 ]  # [B, S, H]
@@ -385,6 +408,7 @@ class GPTEmbedding(FleetLayer):
             "visual_pos_masks": visual_pos_masks,
             "labels": labels,
             "input_ids": input_ids_for_moe_mask,
+            "mtp_input_ids_for_moe_mask": mtp_input_ids_for_moe_mask,
         }
         # New dataflow: pass mtp_startend_row_indices_all and mtp_hidden_inputs_mask_all
         # through dict_args to MTP layer. They must both be present or both be absent.

--- a/src/paddlefleet/transformer/multi_token_prediction.py
+++ b/src/paddlefleet/transformer/multi_token_prediction.py
@@ -382,6 +382,7 @@ class MultiTokenPredictionLayer(FleetLayer):
         packed_seq_params: PackedSeqParams | None = None,
         attn_mask_startend_row_indices: paddle.Tensor | None = None,
         mtp_hidden_inputs_mask: paddle.Tensor | None = None,
+        input_ids: paddle.Tensor | None = None,
         **kwargs,
     ) -> paddle.Tensor:
         """
@@ -409,6 +410,7 @@ class MultiTokenPredictionLayer(FleetLayer):
                 "packed_seq_params": packed_seq_params,
                 "attn_mask_startend_row_indices": attn_mask_startend_row_indices,
                 "is_mtp": True,
+                "input_ids": input_ids,
             }
             rst_dict = self.transformer_layer(input_dict)
         if not self.config.gpt_model_use_experimental_version:
@@ -434,6 +436,7 @@ class MultiTokenPredictionLayer(FleetLayer):
             attention_bias = kwargs.get("attention_bias", None)
             packed_seq_params = kwargs.get("packed_seq_params", None)
             mtp_hidden_inputs_mask = kwargs.get("mtp_hidden_inputs_mask", None)
+            input_ids = kwargs.get("input_ids", None)
             return recompute(
                 forward_func,
                 hidden_states=hidden_states
@@ -468,6 +471,7 @@ class MultiTokenPredictionLayer(FleetLayer):
                 mtp_hidden_inputs_mask=mtp_hidden_inputs_mask
                 if mtp_hidden_inputs_mask is not None
                 else None,
+                input_ids=input_ids if input_ids is not None else None,
             )
 
         if self.config.recompute_method == "uniform":
@@ -511,6 +515,13 @@ class MultiTokenPredictionLayer(FleetLayer):
         mtp_hidden_inputs_mask_all = dict_args.pop(
             "mtp_hidden_inputs_mask_all", None
         )
+        # Pop per-depth MTP input_ids for MoE routing mask.
+        # Shape: [B, num_nextn_predict_layers, max_seq] when present, None otherwise.
+        mtp_input_ids_for_moe_mask = dict_args.pop(
+            "mtp_input_ids_for_moe_mask", None
+        )
+        # Save and clear backbone input_ids so it doesn't leak into MTP transformer layers
+        origin_input_ids = dict_args.pop("input_ids", None)
         # Shape check: mtp_startend_row_indices_all [B, num_nextn, S, 1],
         #              mtp_hidden_inputs_mask_all   [B, num_nextn, S]
         if mtp_startend_row_indices_all is not None:
@@ -560,6 +571,14 @@ class MultiTokenPredictionLayer(FleetLayer):
                     dict_args["mtp_hidden_inputs_mask"] = (
                         mtp_hidden_inputs_mask_all[:, i : i + 1, :]
                     )
+
+                # Get per-depth input_ids for MoE routing mask
+                if mtp_input_ids_for_moe_mask is not None:
+                    dict_args["input_ids"] = mtp_input_ids_for_moe_mask[
+                        :, i, :
+                    ].contiguous()
+                else:
+                    dict_args.pop("input_ids", None)
 
                 if (
                     self.config.recompute_granularity == "full"
@@ -612,6 +631,14 @@ class MultiTokenPredictionLayer(FleetLayer):
                     ]
                 )
 
+            # Get per-depth input_ids for MoE routing mask
+            if mtp_input_ids_for_moe_mask is not None:
+                dict_args["input_ids"] = mtp_input_ids_for_moe_mask[
+                    :, self.layer_number, :
+                ].contiguous()
+            else:
+                dict_args.pop("input_ids", None)
+
             # print(dict_args["attn_mask_startend_row_indices"])
             # assert 0
             if self.config.recompute_granularity == "full" and self.training:
@@ -637,6 +664,14 @@ class MultiTokenPredictionLayer(FleetLayer):
         # Restore mtp_hidden_inputs_mask_all for subsequent MTP layers (num_nextn > 1)
         if mtp_hidden_inputs_mask_all is not None:
             dict_args["mtp_hidden_inputs_mask_all"] = mtp_hidden_inputs_mask_all
+        # Restore mtp_input_ids_for_moe_mask for subsequent MTP layers (num_nextn > 1)
+        if mtp_input_ids_for_moe_mask is not None:
+            dict_args["mtp_input_ids_for_moe_mask"] = mtp_input_ids_for_moe_mask
+        # Restore backbone input_ids
+        if origin_input_ids is not None:
+            dict_args["input_ids"] = origin_input_ids
+        else:
+            dict_args.pop("input_ids", None)
         # Clean up per-depth slice key
         dict_args.pop("mtp_hidden_inputs_mask", None)
         if origin_start_row_indices is not None:

--- a/src/paddlefleet/transformer/transformer_layer.py
+++ b/src/paddlefleet/transformer/transformer_layer.py
@@ -460,6 +460,27 @@ class TransformerLayer(nn.Layer):
                     :, -self.config.num_nextn_predict_layers :
                 ]
                 dict_args["position_ids"] = decoder_ids
+
+            # process input_ids (for MoE padding mask): split into main and mtp parts
+            mtp_input_ids = None
+            if (
+                "input_ids" in dict_args.keys()
+                and dict_args["input_ids"] is not None
+            ):
+                full_input_ids = dict_args["input_ids"]
+                if (
+                    full_input_ids.shape[-1]
+                    > hidden_states.shape[
+                        0 if self.config.sequence_parallel else 1
+                    ]
+                ):
+                    decoder_input_ids = full_input_ids[
+                        :, : -self.config.num_nextn_predict_layers
+                    ].contiguous()
+                    mtp_input_ids = full_input_ids[
+                        :, -self.config.num_nextn_predict_layers :
+                    ].contiguous()
+                    dict_args["input_ids"] = decoder_input_ids
             if (
                 not self.config.experimental_dataflow
                 and "attn_mask_startend_row_indices" in dict_args.keys()
@@ -553,6 +574,12 @@ class TransformerLayer(nn.Layer):
                     [dict_args["position_ids"], mtp_ids], axis=1
                 )
                 dict_args["position_ids"] = position_ids
+
+            # Restore input_ids: concatenate main and mtp parts back
+            if mtp_input_ids is not None and "input_ids" in dict_args.keys():
+                dict_args["input_ids"] = paddle.concat(
+                    [dict_args["input_ids"], mtp_input_ids], axis=1
+                )
 
             if (
                 not self.config.experimental_dataflow

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_mtp_mask_experimental_dataflow.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_mtp_mask_experimental_dataflow.py
@@ -1242,5 +1242,274 @@ class TestMTPPerDepthMaskSlicing(unittest.TestCase):
                 )
 
 
+# ---------------------------------------------------------------------------
+# Test: GPTEmbedding — mtp_input_ids_for_moe_mask construction
+# ---------------------------------------------------------------------------
+
+
+class TestGPTEmbeddingMTPInputIdsForMoeMask(unittest.TestCase):
+    """Test GPTEmbedding splits input_ids into backbone and per-depth MTP parts
+    for MoE routing mask when expert_model_parallel_size > 1."""
+
+    def _build_embedding(self, config, B, S, H):
+        from paddlefleet.models.gpt.gpt_embedding import GPTEmbedding
+
+        with patch(
+            "paddlefleet.models.gpt.gpt_embedding.build_spec_layer",
+            side_effect=_mock_build_layer_side_effect,
+        ):
+            mock_spec = MagicMock()
+            mock_spec.rope_embedding = None
+            emb = GPTEmbedding(
+                sublayers_spec=mock_spec,
+                config=config,
+                vocab_size=128,
+                max_sequence_length=32,
+                position_embedding_type="none",
+            )
+            emb.embedding = MagicMock(
+                return_value=paddle.randn([B, S, H])
+            )
+        return emb
+
+    def test_mtp_input_ids_none_when_no_moe(self):
+        """Without expert_model_parallel_size > 1, mtp_input_ids_for_moe_mask is None."""
+        num_nextn = 2
+        B, S_total, H = 2, 10, 64  # S_total = seq_length + num_nextn
+        config = _make_config(
+            num_nextn_predict_layers=num_nextn,
+            expert_model_parallel_size=1,
+        )
+        emb = self._build_embedding(config, B, S_total, H)
+        dict_args = {
+            "input_ids": paddle.randint(0, 128, [B, S_total]),
+            "position_ids": paddle.arange(S_total).unsqueeze(0).expand([B, S_total]),
+        }
+        result = emb.forward(dict_args)
+        self.assertIsNone(result.get("mtp_input_ids_for_moe_mask"))
+
+    def test_mtp_input_ids_shape_and_values(self):
+        """With MoE + MTP, mtp_input_ids_for_moe_mask has [B, num_nextn, seq_length]
+        and each depth k contains input_ids[:, k+1 : k+1+seq_length]."""
+        num_nextn = 2
+        seq_length = 8
+        S_total = seq_length + num_nextn  # 10
+        B, H = 2, 64
+        config = _make_config(
+            num_nextn_predict_layers=num_nextn,
+            expert_model_parallel_size=2,
+            tensor_model_parallel_size=1,
+        )
+        emb = self._build_embedding(config, B, S_total, H)
+
+        input_ids = paddle.arange(S_total).unsqueeze(0).expand([B, S_total])
+        dict_args = {
+            "input_ids": input_ids.clone(),
+            "position_ids": paddle.arange(S_total).unsqueeze(0).expand([B, S_total]),
+        }
+        result = emb.forward(dict_args)
+
+        mtp_ids = result.get("mtp_input_ids_for_moe_mask")
+        self.assertIsNotNone(mtp_ids)
+        self.assertEqual(list(mtp_ids.shape), [B, num_nextn, seq_length])
+
+        # depth 0: input_ids[:, 1:1+8] = [1,2,...,8]
+        expected_d0 = input_ids[:, 1 : 1 + seq_length]
+        self.assertTrue(paddle.equal_all(mtp_ids[:, 0, :], expected_d0))
+        # depth 1: input_ids[:, 2:2+8] = [2,3,...,9]
+        expected_d1 = input_ids[:, 2 : 2 + seq_length]
+        self.assertTrue(paddle.equal_all(mtp_ids[:, 1, :], expected_d1))
+
+    def test_backbone_input_ids_trimmed(self):
+        """With MoE + MTP, backbone input_ids is trimmed to [B, seq_length]."""
+        num_nextn = 2
+        seq_length = 8
+        S_total = seq_length + num_nextn
+        B, H = 2, 64
+        config = _make_config(
+            num_nextn_predict_layers=num_nextn,
+            expert_model_parallel_size=2,
+            tensor_model_parallel_size=1,
+        )
+        emb = self._build_embedding(config, B, S_total, H)
+
+        input_ids = paddle.arange(S_total).unsqueeze(0).expand([B, S_total])
+        dict_args = {
+            "input_ids": input_ids.clone(),
+            "position_ids": paddle.arange(S_total).unsqueeze(0).expand([B, S_total]),
+        }
+        result = emb.forward(dict_args)
+
+        backbone_ids = result.get("input_ids")
+        self.assertIsNotNone(backbone_ids)
+        self.assertEqual(list(backbone_ids.shape), [B, seq_length])
+        expected = input_ids[:, :seq_length]
+        self.assertTrue(paddle.equal_all(backbone_ids, expected))
+
+
+# ---------------------------------------------------------------------------
+# Test: MultiTokenPredictionLayer — mtp_input_ids_for_moe_mask slicing
+# ---------------------------------------------------------------------------
+
+
+class TestMTPForwardInputIdsForMoeMask(unittest.TestCase):
+    """Test MTP forward correctly slices mtp_input_ids_for_moe_mask per-depth
+    and restores dict_args after forward."""
+
+    def _make_dict_args(self, B, S, H, num_nextn, with_moe_mask=True):
+        total_sections = num_nextn + 1
+        hidden_states = paddle.randn([B * total_sections, S, H], dtype="float32")
+        dict_args = {"hidden_states": hidden_states}
+        if with_moe_mask:
+            # Distinct per-depth input_ids: depth k filled with k+10
+            mtp_ids = paddle.zeros([B, num_nextn, S], dtype="int64")
+            for k in range(num_nextn):
+                mtp_ids[:, k, :] = k + 10
+            dict_args["mtp_input_ids_for_moe_mask"] = mtp_ids
+            dict_args["input_ids"] = paddle.ones([B, S], dtype="int64") * 99
+        return dict_args
+
+    def test_single_layer_slices_correct_depth(self):
+        """layer_number=1 should get mtp_input_ids_for_moe_mask[:, 1, :]."""
+        with (
+            _common_patches()[0],
+            _common_patches()[1],
+            _common_patches()[2],
+            _common_patches()[3],
+            _common_patches()[4],
+        ):
+            num_nextn = 2
+            B, S, H = 2, 8, 64
+            config = _make_config(
+                num_nextn_predict_layers=num_nextn,
+                train_mtp_only=False,
+                experimental_dataflow=True,
+            )
+            layer = _build_mtp_layer(config, layer_number=1)
+
+            dict_args = self._make_dict_args(B, S, H, num_nextn)
+
+            captured = []
+
+            def capture_proj(**kwargs):
+                captured.append(dict(kwargs))
+                return kwargs.get("hidden_states", paddle.randn([B, S, H]))
+
+            layer._proj_and_transformer_layer = capture_proj
+            layer.forward(dict_args)
+
+            self.assertEqual(len(captured), 1)
+            passed_ids = captured[0].get("input_ids")
+            self.assertIsNotNone(passed_ids)
+            # depth 1 -> value 11
+            expected = paddle.full([B, S], 11, dtype="int64")
+            self.assertTrue(paddle.equal_all(passed_ids, expected))
+
+    def test_train_mtp_only_each_depth_gets_correct_ids(self):
+        """train_mtp_only loops all depths, each should get its own input_ids slice."""
+        with (
+            _common_patches()[0],
+            _common_patches()[1],
+            _common_patches()[2],
+            _common_patches()[3],
+            _common_patches()[4],
+        ):
+            num_nextn = 3
+            B, S, H = 2, 8, 64
+            config = _make_config(
+                num_nextn_predict_layers=num_nextn,
+                train_mtp_only=True,
+                experimental_dataflow=True,
+            )
+            layer = _build_mtp_layer(config, layer_number=0)
+
+            dict_args = self._make_dict_args(B, S, H, num_nextn)
+
+            captured = []
+
+            def capture_proj(**kwargs):
+                captured.append(dict(kwargs))
+                return kwargs.get("hidden_states", paddle.randn([B, S, H]))
+
+            layer._proj_and_transformer_layer = capture_proj
+            layer.forward(dict_args)
+
+            self.assertEqual(len(captured), num_nextn)
+            for d in range(num_nextn):
+                passed_ids = captured[d].get("input_ids")
+                expected = paddle.full([B, S], d + 10, dtype="int64")
+                self.assertTrue(
+                    paddle.equal_all(passed_ids, expected),
+                    f"Depth {d}: expected {d+10}, got {passed_ids}",
+                )
+
+    def test_restore_after_forward(self):
+        """After forward, mtp_input_ids_for_moe_mask and backbone input_ids are restored."""
+        with (
+            _common_patches()[0],
+            _common_patches()[1],
+            _common_patches()[2],
+            _common_patches()[3],
+            _common_patches()[4],
+        ):
+            num_nextn = 2
+            B, S, H = 2, 8, 64
+            config = _make_config(
+                num_nextn_predict_layers=num_nextn,
+                train_mtp_only=False,
+                experimental_dataflow=True,
+            )
+            layer = _build_mtp_layer(config, layer_number=0)
+
+            dict_args = self._make_dict_args(B, S, H, num_nextn)
+            original_mtp_ids = dict_args["mtp_input_ids_for_moe_mask"].clone()
+            original_backbone_ids = dict_args["input_ids"].clone()
+
+            result = layer.forward(dict_args)
+
+            # mtp_input_ids_for_moe_mask should be restored
+            self.assertIn("mtp_input_ids_for_moe_mask", result)
+            self.assertTrue(
+                paddle.equal_all(result["mtp_input_ids_for_moe_mask"], original_mtp_ids)
+            )
+            # backbone input_ids should be restored
+            self.assertIn("input_ids", result)
+            self.assertTrue(
+                paddle.equal_all(result["input_ids"], original_backbone_ids)
+            )
+
+    def test_no_moe_mask_clears_input_ids(self):
+        """When mtp_input_ids_for_moe_mask is None, input_ids should be cleared for MTP layers."""
+        with (
+            _common_patches()[0],
+            _common_patches()[1],
+            _common_patches()[2],
+            _common_patches()[3],
+            _common_patches()[4],
+        ):
+            num_nextn = 2
+            B, S, H = 2, 8, 64
+            config = _make_config(
+                num_nextn_predict_layers=num_nextn,
+                train_mtp_only=False,
+                experimental_dataflow=True,
+            )
+            layer = _build_mtp_layer(config, layer_number=0)
+
+            dict_args = self._make_dict_args(B, S, H, num_nextn, with_moe_mask=False)
+
+            captured = []
+
+            def capture_proj(**kwargs):
+                captured.append(dict(kwargs))
+                return kwargs.get("hidden_states", paddle.randn([B, S, H]))
+
+            layer._proj_and_transformer_layer = capture_proj
+            layer.forward(dict_args)
+
+            # input_ids should not be passed when no moe mask
+            self.assertIsNone(captured[0].get("input_ids"))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_mtp_mask_experimental_dataflow.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_mtp_mask_experimental_dataflow.py
@@ -1267,9 +1267,7 @@ class TestGPTEmbeddingMTPInputIdsForMoeMask(unittest.TestCase):
                 max_sequence_length=32,
                 position_embedding_type="none",
             )
-            emb.embedding = MagicMock(
-                return_value=paddle.randn([B, S, H])
-            )
+            emb.embedding = MagicMock(return_value=paddle.randn([B, S, H]))
         return emb
 
     def test_mtp_input_ids_none_when_no_moe(self):
@@ -1283,7 +1281,9 @@ class TestGPTEmbeddingMTPInputIdsForMoeMask(unittest.TestCase):
         emb = self._build_embedding(config, B, S_total, H)
         dict_args = {
             "input_ids": paddle.randint(0, 128, [B, S_total]),
-            "position_ids": paddle.arange(S_total).unsqueeze(0).expand([B, S_total]),
+            "position_ids": paddle.arange(S_total)
+            .unsqueeze(0)
+            .expand([B, S_total]),
         }
         result = emb.forward(dict_args)
         self.assertIsNone(result.get("mtp_input_ids_for_moe_mask"))
@@ -1305,7 +1305,9 @@ class TestGPTEmbeddingMTPInputIdsForMoeMask(unittest.TestCase):
         input_ids = paddle.arange(S_total).unsqueeze(0).expand([B, S_total])
         dict_args = {
             "input_ids": input_ids.clone(),
-            "position_ids": paddle.arange(S_total).unsqueeze(0).expand([B, S_total]),
+            "position_ids": paddle.arange(S_total)
+            .unsqueeze(0)
+            .expand([B, S_total]),
         }
         result = emb.forward(dict_args)
 
@@ -1336,7 +1338,9 @@ class TestGPTEmbeddingMTPInputIdsForMoeMask(unittest.TestCase):
         input_ids = paddle.arange(S_total).unsqueeze(0).expand([B, S_total])
         dict_args = {
             "input_ids": input_ids.clone(),
-            "position_ids": paddle.arange(S_total).unsqueeze(0).expand([B, S_total]),
+            "position_ids": paddle.arange(S_total)
+            .unsqueeze(0)
+            .expand([B, S_total]),
         }
         result = emb.forward(dict_args)
 
@@ -1358,7 +1362,9 @@ class TestMTPForwardInputIdsForMoeMask(unittest.TestCase):
 
     def _make_dict_args(self, B, S, H, num_nextn, with_moe_mask=True):
         total_sections = num_nextn + 1
-        hidden_states = paddle.randn([B * total_sections, S, H], dtype="float32")
+        hidden_states = paddle.randn(
+            [B * total_sections, S, H], dtype="float32"
+        )
         dict_args = {"hidden_states": hidden_states}
         if with_moe_mask:
             # Distinct per-depth input_ids: depth k filled with k+10
@@ -1440,7 +1446,7 @@ class TestMTPForwardInputIdsForMoeMask(unittest.TestCase):
                 expected = paddle.full([B, S], d + 10, dtype="int64")
                 self.assertTrue(
                     paddle.equal_all(passed_ids, expected),
-                    f"Depth {d}: expected {d+10}, got {passed_ids}",
+                    f"Depth {d}: expected {d + 10}, got {passed_ids}",
                 )
 
     def test_restore_after_forward(self):
@@ -1470,7 +1476,9 @@ class TestMTPForwardInputIdsForMoeMask(unittest.TestCase):
             # mtp_input_ids_for_moe_mask should be restored
             self.assertIn("mtp_input_ids_for_moe_mask", result)
             self.assertTrue(
-                paddle.equal_all(result["mtp_input_ids_for_moe_mask"], original_mtp_ids)
+                paddle.equal_all(
+                    result["mtp_input_ids_for_moe_mask"], original_mtp_ids
+                )
             )
             # backbone input_ids should be restored
             self.assertIn("input_ids", result)
@@ -1496,7 +1504,9 @@ class TestMTPForwardInputIdsForMoeMask(unittest.TestCase):
             )
             layer = _build_mtp_layer(config, layer_number=0)
 
-            dict_args = self._make_dict_args(B, S, H, num_nextn, with_moe_mask=False)
+            dict_args = self._make_dict_args(
+                B, S, H, num_nextn, with_moe_mask=False
+            )
 
             captured = []
 

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_layer.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_layer.py
@@ -278,7 +278,9 @@ class TestTransformerLayerMTP(unittest.TestCase):
             captured["input_ids"] = kwargs.get("input_ids")
             return kwargs["hidden_states"]
 
-        with patch.object(layer, "_forward_impl", side_effect=mock_forward_impl):
+        with patch.object(
+            layer, "_forward_impl", side_effect=mock_forward_impl
+        ):
             result = layer.forward(dict_args)
 
         # During forward, input_ids should have been trimmed to [B, S]
@@ -320,7 +322,9 @@ class TestTransformerLayerMTP(unittest.TestCase):
             captured["input_ids"] = kwargs.get("input_ids")
             return kwargs["hidden_states"]
 
-        with patch.object(layer, "_forward_impl", side_effect=mock_forward_impl):
+        with patch.object(
+            layer, "_forward_impl", side_effect=mock_forward_impl
+        ):
             layer.forward(dict_args)
 
         # input_ids should be passed through without trimming
@@ -354,7 +358,9 @@ class TestTransformerLayerMTP(unittest.TestCase):
             captured["input_ids"] = kwargs.get("input_ids")
             return kwargs["hidden_states"]
 
-        with patch.object(layer, "_forward_impl", side_effect=mock_forward_impl):
+        with patch.object(
+            layer, "_forward_impl", side_effect=mock_forward_impl
+        ):
             layer.forward(dict_args)
 
         self.assertIsNone(captured["input_ids"])

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_layer.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_layer.py
@@ -25,6 +25,7 @@ sys.path.insert(
 
 
 import unittest
+from unittest.mock import patch
 
 import paddle
 
@@ -241,6 +242,122 @@ class TestTransformerLayerMTP(unittest.TestCase):
     paddle.split(x, num_sections) splits along axis 0 by default.
     So for num_nextn_predict_layers=2, total_sections=3, seq must be divisible by 3.
     """
+
+    def test_input_ids_split_and_concat(self):
+        """When input_ids seq > hidden_states seq, it should be split then restored."""
+        num_nextn = 2
+        B, S, H = 2, 6, 64
+        config = _make_config(
+            num_nextn_predict_layers=num_nextn,
+            mtp_load_weight_only=False,
+            experimental_dataflow=False,
+        )
+        layer = _make_layer(config)
+        layer.eval()
+
+        total_sections = num_nextn + 1
+        # hidden_states: [total_sections * S, B, H] (seq-first for non-SP)
+        hidden_states = paddle.randn([total_sections * S, B, H])
+        # input_ids covers full concat seq: S + num_nextn
+        full_seq = S + num_nextn
+        input_ids = paddle.arange(full_seq).unsqueeze(0).expand([B, full_seq])
+        # attn_mask covers full concat seq along dim 2
+        attn_mask = paddle.randn([B, 1, S * total_sections + num_nextn, 1])
+
+        dict_args = {
+            "hidden_states": hidden_states,
+            "input_ids": input_ids.clone(),
+            "attention_mask": None,
+            "attn_mask_startend_row_indices": attn_mask,
+        }
+
+        # Mock _forward_impl to just return hidden_states unchanged
+        captured = {}
+
+        def mock_forward_impl(**kwargs):
+            captured["input_ids"] = kwargs.get("input_ids")
+            return kwargs["hidden_states"]
+
+        with patch.object(layer, "_forward_impl", side_effect=mock_forward_impl):
+            result = layer.forward(dict_args)
+
+        # During forward, input_ids should have been trimmed to [B, S]
+        self.assertIsNotNone(captured["input_ids"])
+        self.assertEqual(list(captured["input_ids"].shape), [B, S])
+        # After forward, input_ids should be restored to [B, S + num_nextn]
+        restored_ids = dict_args.get("input_ids")
+        self.assertIsNotNone(restored_ids)
+        self.assertEqual(list(restored_ids.shape), [B, full_seq])
+        self.assertTrue(paddle.equal_all(restored_ids, input_ids))
+
+    def test_input_ids_no_split_when_short(self):
+        """When input_ids seq <= hidden_states batch dim, no split should happen."""
+        num_nextn = 2
+        B, S, H = 4, 6, 64  # B=4 so input_ids.shape[-1]=2 <= B
+        config = _make_config(
+            num_nextn_predict_layers=num_nextn,
+            mtp_load_weight_only=False,
+            experimental_dataflow=True,  # skips attn mask split
+        )
+        layer = _make_layer(config)
+        layer.eval()
+
+        total_sections = num_nextn + 1
+        hidden_states = paddle.randn([total_sections * S, B, H])
+        # input_ids with seq_len=2 <= B=4, so condition is false -> no split
+        short_seq = 2
+        input_ids = paddle.arange(short_seq).unsqueeze(0).expand([B, short_seq])
+
+        dict_args = {
+            "hidden_states": hidden_states,
+            "input_ids": input_ids.clone(),
+            "attention_mask": None,
+        }
+
+        captured = {}
+
+        def mock_forward_impl(**kwargs):
+            captured["input_ids"] = kwargs.get("input_ids")
+            return kwargs["hidden_states"]
+
+        with patch.object(layer, "_forward_impl", side_effect=mock_forward_impl):
+            layer.forward(dict_args)
+
+        # input_ids should be passed through without trimming
+        self.assertIsNotNone(captured["input_ids"])
+        self.assertEqual(list(captured["input_ids"].shape), [B, short_seq])
+
+    def test_input_ids_none_no_error(self):
+        """When input_ids is None, no split/concat logic runs."""
+        num_nextn = 2
+        B, S, H = 2, 6, 64
+        config = _make_config(
+            num_nextn_predict_layers=num_nextn,
+            mtp_load_weight_only=False,
+            experimental_dataflow=True,
+        )
+        layer = _make_layer(config)
+        layer.eval()
+
+        total_sections = num_nextn + 1
+        hidden_states = paddle.randn([total_sections * S, B, H])
+
+        dict_args = {
+            "hidden_states": hidden_states,
+            "input_ids": None,
+            "attention_mask": None,
+        }
+
+        captured = {}
+
+        def mock_forward_impl(**kwargs):
+            captured["input_ids"] = kwargs.get("input_ids")
+            return kwargs["hidden_states"]
+
+        with patch.object(layer, "_forward_impl", side_effect=mock_forward_impl):
+            layer.forward(dict_args)
+
+        self.assertIsNone(captured["input_ids"])
 
 
 class TestTransformerLayerBuildScheduleNode(unittest.TestCase):


### PR DESCRIPTION
## Summary
- When MTP + MoE are both enabled, each MTP depth layer now receives its own `input_ids` slice for correct MoE routing padding mask
- `GPTEmbedding`: splits `input_ids` into backbone `[B, seq]` and per-depth `mtp_input_ids_for_moe_mask [B, num_mtp, seq]`
- `MultiTokenPredictionLayer`: pops/slices per-depth `input_ids` for each MTP layer, restores after forward
- `TransformerLayer`: splits `input_ids` into main/mtp parts before forward, concatenates back after

## Test plan
- [x] Added 7 unit tests in `test_ai_mtp_mask_experimental_dataflow.py` covering GPTEmbedding mtp_input_ids construction and MTP layer per-depth slicing/restore
- [x] Added 3 unit tests in `test_ai_transformer_layer.py` covering TransformerLayer input_ids split/concat/edge cases
- [x] All 73 related tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)