### PR TITLE
Support configure deep_ep num_sms and buffer size

### DIFF
--- a/src/paddlefleet/transformer/moe/fused_a2a.py
+++ b/src/paddlefleet/transformer/moe/fused_a2a.py
@@ -60,6 +60,31 @@ def get_hidden_bytes(x: paddle.Tensor) -> int:
     return x.shape[1] * max(x.element_size(), 2)
 
 
+def configure_buffer(num_sms=None, dispatch_config=None, combine_config=None):
+    """
+    Configure the runtime parameters for deep_ep kernels.
+    Must be called before calling get_buffer() to take effect.
+
+    Args:
+        num_sms (int): Number of SMs allocated to deep_ep kernels.
+        dispatch_config (List[int]):
+            Token capacity parameters for dispatch kernels, in the form
+            [nvl_send_tokens, nvl_recv_tokens, rdma_send_tokens, rdma_recv_tokens].
+            Trailing values may be omitted to use the defaults.
+        combine_config (List[int]): Same as above, but for combine kernels.
+    """
+    if num_sms is not None:
+        deep_ep.Buffer.set_num_sms(num_sms)
+    if dispatch_config is not None:
+        deep_ep.Buffer.get_dispatch_config = staticmethod(
+            lambda _: deep_ep.Config(deep_ep.Buffer.num_sms, *dispatch_config)
+        )
+    if combine_config is not None:
+        deep_ep.Buffer.get_combine_config = staticmethod(
+            lambda _: deep_ep.Config(deep_ep.Buffer.num_sms, *combine_config)
+        )
+
+
 def get_buffer(group: Group, hidden_bytes: int):
     """Get or create a buffer for all-to-all communication.
 

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -41,6 +41,7 @@ from paddlefleet import utils
 from paddlefleet.transformer.utils import profile
 
 from .fp8_utils import fused_stack_quant_without_cache
+from .fused_a2a import configure_buffer
 from .fusion_layer_utils import FusionMoePyLayer
 from .moe_expert import GroupedMLPExpert, StandardMLPExpert
 from .moe_router import TopKRouter
@@ -324,6 +325,8 @@ class MoELayer(nn.Layer):
                     self.moe_group,
                     self.moe_ep_barrier,
                 )
+                if getattr(config, "deepep_buffer_configs", None) is not None:
+                    configure_buffer(**config.deepep_buffer_configs)
             elif self.moe_token_dispatcher_type == "alltoall":
                 local_expert_indices = list(
                     range(

--- a/tests/multi_card_tests/moe/test_fusion_ep.py
+++ b/tests/multi_card_tests/moe/test_fusion_ep.py
@@ -84,6 +84,11 @@ class TestFusionBF16ExpertParallel(unittest.TestCase):
             moe_grouped_gemm=True,
             bias_activation_fusion=True,
         )
+        transformer_config_moe_use_fusion_node.deepep_buffer_configs = {
+            "num_sms": 20,
+            "dispatch_config": [6, 256],
+            "combine_config": [6, 256],
+        }
 
         transformer_layer_spec = get_gpt_layer_local_spec(
             transformer_config_moe_use_fusion_node, num_experts=n_routed_experts


### PR DESCRIPTION
支持在 yaml 中通过如下方式配置 DeepEP 的参数：
```yaml
model_args:
    ...
    model_config:
        ...
        deepep_buffer_configs:
            num_sms: 20
            dispatch_config: [4, 256]
            combine_config: [8, 256]
```