### PR TITLE
Add the RecomputeWithoutOutput util

### DIFF
--- a/src/paddlefleet/tensor_parallel/__init__.py
+++ b/src/paddlefleet/tensor_parallel/__init__.py
@@ -23,7 +23,7 @@ from .layers import (
     VocabParallelEmbedding,
 )
 from .random import (
-    CheckpointWithoutOutput,
+    RecomputeWithoutOutput,
     checkpoint,
     get_cuda_rng_tracker,
     get_expert_parallel_rng_tracker_name,
@@ -43,5 +43,5 @@ __all__ = [
     "get_cuda_rng_tracker",
     "model_parallel_cuda_manual_seed",
     "get_expert_parallel_rng_tracker_name",
-    "CheckpointWithoutOutput",
+    "RecomputeWithoutOutput",
 ]

--- a/src/paddlefleet/tensor_parallel/random.py
+++ b/src/paddlefleet/tensor_parallel/random.py
@@ -19,8 +19,17 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import random
 
+import numpy as np
 import paddle
+from paddle.distributed.fleet.layers.mpu.random import get_rng_state_tracker
+from paddle.distributed.fleet.recompute.recompute import (
+    custom_state_manager,
+    detach_variable,
+    switch_rng_state_tracker,
+)
+from paddle.framework import core
 
 from ..parallel_state import (
     get_expert_model_parallel_rank,
@@ -395,58 +404,174 @@ def checkpoint(function, *args, **kwargs):
     pass
 
 
-class CheckpointWithoutOutputFunction(paddle.autograd.Function):
-    """
-    Checkpoint Function Helper for CheckpointWithoutOutput.
-    Save context for recompute.
-    """
+@contextlib.contextmanager
+def enable_share_grad_holder():
+    """Temporarily enable grad-holder sharing instead of copying the grad."""
+    flag = "FLAGS_share_tensor_for_grad_tensor_holder"
+    old_value = paddle.get_flags([flag])[flag]
+    if not old_value:
+        paddle.set_flags({flag: True})
+    try:
+        yield
+    finally:
+        if not old_value:
+            paddle.set_flags({flag: False})
+
+
+class RecomputeWithoutOutputFunction(paddle.autograd.PyLayer):
+    """Autograd wrapper for RecomputeWithoutOutput."""
 
     @staticmethod
-    def forward(ctx, run_function, checkpoint_without_output_obj, *args):
-        """Forward pass."""
-        pass
+    def forward(ctx, run_function, owner, *args):
+        """forward"""
+        with paddle.no_grad():
+            outputs = run_function(*args)
+        ctx.save_for_backward(*detach_variable(args))
+        owner.ctx = ctx
+        return outputs
 
     @staticmethod
-    def backward(ctx, *args):
-        """Backward pass."""
-        pass
+    def backward(ctx, *output_grads):
+        """backward"""
+        inputs = ctx.inputs
+        outputs = ctx.outputs
+        share_grad_holder = (
+            enable_share_grad_holder()
+            if ctx.share_grad_holder
+            else contextlib.nullcontext()
+        )
+        with paddle.amp.auto_cast(enable=False), share_grad_holder:
+            paddle.autograd.backward(outputs, output_grads)
+        ctx.outputs = None
+        ctx.inputs = None
+        grads = tuple(
+            inp.grad for inp in inputs if isinstance(inp, paddle.Tensor)
+        )
+        return grads
 
 
-class CheckpointWithoutOutput:
-    """
-    Checkpoint a model or part of the model and release the output.
+class RecomputeWithoutOutput:
+    """Manage forward-output discard and backward-time recompute to save memory."""
 
-    For the normal 'checkpoint` function, the outputs of it may be cached by the following
-    operations for its backward computation. However, the output of the checkpointed function is
-    re-generated at recomputation, so the output store is not technically needed. This method can
-    manually discard the output in the forward pass and restore it by recomputation in the
-    backward pass to reduce the memory usage.
-    """
-
-    def __init__(self, fp8=False):
-        self.fp8 = fp8 is not None
+    def __init__(self):
         self.run_function = None
-        self.fwd_cpu_rng_state = None
-        self.fwd_cuda_rng_state = None
-        self.fwd_cuda_rng_state_tracker = None
         self.ctx = None
         self.outputs = None
 
-    def checkpoint(self, run_function, *args):
-        """Checkpoint function."""
-        pass
+    def recompute(
+        self,
+        run_function,
+        *args,
+        preserve_rng_state=True,
+        share_grad_holder=False,
+    ):
+        """
+        Recompute without saving outputs to save memory.
 
-    def _recompute(self, _):
-        """Used as a hook to recompute the output."""
-        pass
+        Args:
+            run_function: The forward function that will be executed again during backward.
+            *args: Positional tensor and non-tensor inputs passed to `run_function`.
+            preserve_rng_state: Whether to preserve RNG states for deterministic recomputation.
+            share_grad_holder: Whether to share the grad holder instead of copying the grad in backward.
+        """
+        self.run_function = run_function
+        self.preserve_rng_state = preserve_rng_state
+
+        if preserve_rng_state:
+            self.fw_rng_state = paddle.get_rng_state()
+            self.fwd_rng_state_tracker = (
+                get_rng_state_tracker().get_states_tracker()
+            )
+            self.fwd_numpy_state = np.random.get_state()
+            self.fwd_random_state = random.getstate()
+
+            if custom_state_manager.custom_get_state_func is None:
+                assert custom_state_manager.custom_set_state_func is None
+                custom_get_state_func = lambda x=None: None
+                custom_set_state_func = lambda x=None: None
+            else:
+                custom_get_state_func = (
+                    custom_state_manager.custom_get_state_func
+                )
+                custom_set_state_func = (
+                    custom_state_manager.custom_set_state_func
+                )
+
+            self.fwd_custom_state = custom_get_state_func()
+            self.custom_get_state_func = custom_get_state_func
+            self.custom_set_state_func = custom_set_state_func
+
+        tracer = paddle.base.framework._dygraph_tracer()
+        self.is_fw_autocast = (
+            False if tracer._amp_level == core.AmpLevel.O0 else True
+        )
+        if tracer._amp_level == core.AmpLevel.O2:
+            self.amp_level = "O2"
+        elif tracer._amp_level in (core.AmpLevel.O1, core.AmpLevel.O0):
+            self.amp_level = "O1"
+        else:
+            raise ValueError(f"unsupported amp level: {tracer._amp_level}")
+
+        if tracer._amp_dtype == "float16":
+            self.amp_dtype = "float16"
+        elif tracer._amp_dtype in ("bfloat16", "float32"):
+            self.amp_dtype = "bfloat16"
+        else:
+            raise ValueError(f"unsupported amp dtype: {tracer._amp_dtype}")
+
+        self.amp_white_list, self.amp_black_list = tracer._get_amp_op_list()
+
+        outputs = RecomputeWithoutOutputFunction.apply(
+            run_function, self, *args
+        )
+        self.outputs = outputs if isinstance(outputs, tuple) else (outputs,)
+        self.ctx.share_grad_holder = share_grad_holder
+        return outputs
+
+    def _recompute(self, grad):
+        """Re-run the saved forward under restored states when the backward hook is triggered."""
+        if self.preserve_rng_state:
+            rng_ctx = switch_rng_state_tracker(
+                self.fw_rng_state,
+                self.fwd_rng_state_tracker,
+                self.fwd_numpy_state,
+                self.fwd_random_state,
+                self.fwd_custom_state,
+                self.custom_get_state_func,
+                self.custom_set_state_func,
+            )
+        else:
+            rng_ctx = contextlib.nullcontext()
+
+        amp_ctx = paddle.amp.auto_cast(
+            enable=self.is_fw_autocast,
+            custom_white_list=self.amp_white_list,
+            custom_black_list=self.amp_black_list,
+            level=self.amp_level,
+            dtype=self.amp_dtype,
+        )
+
+        inputs = detach_variable(self.ctx.saved_tensor())
+
+        with rng_ctx, amp_ctx:
+            outputs = self.run_function(*inputs)
+
+        if isinstance(outputs, paddle.Tensor):
+            outputs = (outputs,)
+
+        for stale_output, recomputed_output in zip(self.outputs, outputs):
+            recomputed_output._share_buffer_to(stale_output)
+
+        self.ctx.inputs = inputs
+        self.ctx.outputs = outputs
+        self.outputs = None
+        self.ctx = None
+        self.run_function = None
 
     def discard_output_and_register_recompute(self, hook_tensor):
-        """
-        Release the output tensor storages and register the recompute function as a grad hook of
-        the hook_tensor.
+        """Clear saved output data and register the recomputation hook on the target tensor."""
+        for output in self.outputs:
+            output._clear_data()
 
-        Note: the caller should make sure that the output tensors are no longer used
-        in the forward pass and the gradient of the hook_tensor is computed before the recomputed
-        tensors are used.
-        """
-        pass
+        if not hook_tensor.stop_gradient:
+            hook_tensor.register_hook(self._recompute)

--- a/tests/single_card_tests/test_recompute_without_output.py
+++ b/tests/single_card_tests/test_recompute_without_output.py
@@ -1,0 +1,148 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+import paddle
+from paddle import nn
+from paddle.distributed.fleet.recompute.recompute import custom_state_manager
+
+from paddlefleet.tensor_parallel import RecomputeWithoutOutput
+
+
+class TestRecomputeWithoutOutput(unittest.TestCase):
+    def test_pure_tensors_with_grad(self):
+        fc1 = nn.Linear(32, 64)
+        fc2 = nn.Linear(64, 32)
+
+        a = paddle.randn([8, 32])
+        a.stop_gradient = False
+
+        ctx = RecomputeWithoutOutput()
+        b = ctx.recompute(fc1, a, preserve_rng_state=False)
+
+        c = fc2(b)
+        mem_before_discard = paddle.device.memory_allocated()
+        ctx.discard_output_and_register_recompute(c)
+        mem_after_discard = paddle.device.memory_allocated()
+        c.backward()
+
+        self.assertIsNotNone(a.grad)
+        self.assertEqual(
+            mem_before_discard - mem_after_discard, b.size * b.itemsize
+        )
+
+    def test_non_tensor_input(self):
+        a = paddle.randn([8, 16, 32])
+        a.stop_gradient = False
+
+        ctx = RecomputeWithoutOutput()
+        b = ctx.recompute(paddle.nn.functional.layer_norm, a, a.shape[1:])
+
+        c = paddle.sum(b)
+        ctx.discard_output_and_register_recompute(c)
+        c.backward()
+
+        self.assertIsNotNone(a.grad)
+
+    def test_no_grad_input(self):
+        a = paddle.randn([16, 32])
+        a.stop_gradient = False
+        b = paddle.randn([32, 48])
+        b.stop_gradient = False
+        c = paddle.randn([16, 1])
+
+        def scale_matmul(x, y, z):
+            x = x * z["scale"]
+            return paddle.matmul(x, y)
+
+        ctx = RecomputeWithoutOutput()
+        d = ctx.recompute(scale_matmul, a, b, {"scale": c})
+
+        e = d.sum()
+        ctx.discard_output_and_register_recompute(e)
+        e.backward()
+
+        self.assertIsNotNone(a.grad)
+        self.assertIsNotNone(b.grad)
+
+    def test_rng_consistency(self):
+        a = paddle.randn([32])
+        a.stop_gradient = False
+
+        custom_state_manager.set_custom_get_state_func(lambda x=None: None)
+        custom_state_manager.set_custom_set_state_func(lambda x=None: None)
+
+        def random_mul(x):
+            return x * paddle.randn_like(x)
+
+        paddle.seed(2026)
+        b = random_mul(a)
+        c = b.sum()
+        c.backward()
+        a_grad_ref = a.grad.clone()
+        a.clear_grad()
+
+        paddle.seed(2026)
+        ctx = RecomputeWithoutOutput()
+        b = ctx.recompute(random_mul, a)
+        c = paddle.sum(b)
+        ctx.discard_output_and_register_recompute(c)
+        c.backward()
+
+        np.testing.assert_allclose(a.grad, a_grad_ref, atol=0, rtol=0)
+
+    def test_amp(self):
+        fc = nn.Linear(16, 32)
+        fc = paddle.amp.decorate(fc, level="O2", dtype="float16")
+
+        a = paddle.randn([8, 16])
+        a.stop_gradient = False
+
+        with paddle.amp.auto_cast(level="O2", dtype="float16"):
+            ctx = RecomputeWithoutOutput()
+            b = ctx.recompute(fc, a)
+            c = paddle.sum(b)
+            ctx.discard_output_and_register_recompute(c)
+            c.backward()
+
+        self.assertEqual(c.dtype, paddle.float16)
+        self.assertIsNotNone(a.grad)
+
+    def test_multiple_outputs(self):
+        a = paddle.randn([8, 32])
+        a.stop_gradient = False
+
+        def split_mul(x):
+            p, q = x.split(2, axis=-1)
+            return p.sin() * q, p * q.cos()
+
+        b, c = split_mul(a)
+        d = b + c
+        d.backward()
+        a_grad_ref = a.grad.clone()
+        a.clear_grad()
+
+        ctx = RecomputeWithoutOutput()
+        b, c = ctx.recompute(split_mul, a, share_grad_holder=True)
+        d = b + c
+        ctx.discard_output_and_register_recompute(d)
+        d.backward()
+
+        np.testing.assert_allclose(a.grad, a_grad_ref, atol=0, rtol=0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
新增 RecomputeWithoutOutput 工具类

这是一个完备的 recompute 描述方式，可以通过重计算节省输出的显存

使用方式示例：

```python
from paddlefleet.tensor_parallel import RecomputeWithoutOutput

# func1/func2 是串联的前向函数，inp 是输入，想通过重计算 func1 节省 func1 输出 (mid) 的显存

ctx = RecomputeWithoutOutput()
mid = ctx.recompute(func1, inp, preserve_rng_state=False)
out = func2(mid)
ctx.discard_output_and_register_recompute(out)
```