### PR TITLE
Fix typo, premute->permute

### DIFF
--- a/src/paddlefleet/transformer/moe/fp8_utils.py
+++ b/src/paddlefleet/transformer/moe/fp8_utils.py
@@ -34,13 +34,12 @@ try:
 except (ImportError, RuntimeError):
     pass
 
-# 优先使用 FusedQuantOps.fused_swiglu_probs_bwd（inplace，行为对齐）。
-# 若环境中没有 FusedQuantOps，则回退到 paddle.incubate 的 out-of-place 实现。
-# TODO: 迁移fused_swiglu_probs_bwd至paddlefleet.ops
+# 优先使用 fused_swiglu_probs_bwd（inplace）。
+# 若环境中没有，则回退到 paddle.incubate 的 out-of-place 实现。
 try:
-    import FusedQuantOps as _FQO
+    from paddlefleet.ops import fused_swiglu_probs_bwd
 
-    _fused_swiglu_probs_bwd = _FQO.fused_swiglu_probs_bwd
+    _fused_swiglu_probs_bwd = fused_swiglu_probs_bwd
     USE_INPLACE_SWIGLU_BWD = True
 except (ImportError, AttributeError):
     _fused_swiglu_probs_bwd = None
@@ -135,7 +134,6 @@ def fused_stack_quant_without_cache(
 ):
     use_pow2_scale = False
     if paddle.device.cuda.get_device_capability()[0] == 10:
-        # Blackwell GPUs require the use of pow2_scales quantization.
         use_pow2_scale = True
     if transpose:
         w, scale = fuse_stack_transpose_fp8_quant(
@@ -175,7 +173,6 @@ def tilewise_quant(x):
     """
     pow_2_scales = False
     if paddle.device.cuda.get_device_capability()[0] == 10:
-        # Blackwell GPUs require the use of pow2_scales quantization.
         pow_2_scales = True
     if x.shape[0] > 0:
         return paddle.incubate.nn.functional.fp8_quant_blockwise(
@@ -776,7 +773,7 @@ class ExpertsGroupGemmContiguousNode:
         with paddle.amp.auto_cast(False):
             if USE_INPLACE_SWIGLU_BWD:
                 # inplace，do1 复用 o1 的 GPU buffer（data_ptr 相同）。
-                # del o1 后 do1 仍持有引用，refcount 不归零，物理页不会被 VMM 提前回收。
+                # del o1 后 do1 仍持有引用，refcount 不归零，物理页不会被提前回收。
                 # 显存峰值：o1/do1(2H) + do2_s(H) + o2_s(H) = 4H（C 点），
                 #           do1(2H) + o2_s(H) + n2_s(2H) = 5H（D 点峰值）
                 do1, probs_grad, o2_s = _fused_swiglu_probs_bwd(
@@ -784,8 +781,7 @@ class ExpertsGroupGemmContiguousNode:
                 )
             else:
                 # out-of-place，do1 是全新分配的 buffer。
-                # del o1 必须推迟到 bwd_gate_up_input_fp8 的 synchronize 之后，
-                # 否则 GPU 异步读 o1 时物理页已被 VMM 回收（Bug 2）。
+                # del o1 推迟到 bwd_gate_up_input_fp8 之后，
                 # 显存峰值：o1(2H) + do2_s(H) + do1(2H) + o2_s(H) = 6H（C 点），
                 #           o1(2H) + do1(2H) + o2_s(H) + n2_s(2H) = 7H（D 点峰值）
                 do1, probs_grad, o2_s = (
@@ -1430,10 +1426,10 @@ class ExpertsGroupGemmContiguousNode:
             expert_w2, out_grad, o1, unzipped_probs, inplace_swiglu_prob=True
         )
         # del o1 时机：
-        #   inplace（USE_INPLACE_SWIGLU_BWD=True）：do1 与 o1 共用 buffer，refcount
-        #     不归零，立即 del 安全。
+        #   inplace（USE_INPLACE_SWIGLU_BWD=True）：do1 与 o1 共用 buffer（data_ptr
+        #     相同，不同 Python 对象），buffer 引用计数不归零，立即 del 安全。
         #   out-of-place（USE_INPLACE_SWIGLU_BWD=False）：do1 是独立 buffer，GPU 异步
-        #     kernel 仍在读 o1，必须等 bwd_gate_up_input_fp8 的 synchronize 后再 del。
+        #     kernel 仍在读 o1，必须等后续 GEMM 入队后再 del。
         if USE_INPLACE_SWIGLU_BWD:
             del o1
         self.o1 = None
@@ -1444,10 +1440,6 @@ class ExpertsGroupGemmContiguousNode:
                 self.bf16_weight_grad(do1, None, expert_w1)
             else:
                 self.bwd_gate_up_weight(do1, None, expert_w1, clear_input=True)
-            # 不调用 _record_stream，直接 None。
-            # _record_stream 会触发 VMM 积极回收物理页，在 nparts loop 中
-            # slice 被释放后原始 input_fp8 的物理页可能被提前回收，
-            # 导致后续 npart 访问时 CUDA_ERROR_ILLEGAL_ADDRESS。
             self.input_fp8 = None
             self.input_scale = None
             self.input = None

--- a/src/paddlefleet/transformer/moe/fusion_layer_utils.py
+++ b/src/paddlefleet/transformer/moe/fusion_layer_utils.py
@@ -253,7 +253,7 @@ class MlpNode:
         recompute_moe_gate_up=False,
         dequant_input=False,
         moe_expert_fusion=True,
-        recompute_moe_premute=False,
+        recompute_moe_permute=False,
         moe_subbatch_token_num_after_dispatch=None,
         use_bf16_gemm_weight_grad=False,
         use_fp8_mlp=True,
@@ -284,17 +284,17 @@ class MlpNode:
             if not moe_expert_fusion
             else 0
         )
-        if recompute_moe_premute:
+        if recompute_moe_permute:
             assert not moe_expert_fusion, (
                 "moe_expert_fusion must be disabled when recompute_unzipped = True"
             )
             assert recompute_moe_gate_up, (
-                "recompute_moe_gate_up must be enabled when recompute_moe_premute = True"
+                "recompute_moe_gate_up must be enabled when recompute_moe_permute = True"
             )
             assert dequant_input, (
-                "dequant_input must be enabled with recompute_moe_premute = True"
+                "dequant_input must be enabled with recompute_moe_permute = True"
             )
-        self.recompute_moe_premute = recompute_moe_premute
+        self.recompute_moe_permute = recompute_moe_permute
 
         self.moe_subbatch_token_num_after_dispatch = (
             moe_subbatch_token_num_after_dispatch
@@ -642,8 +642,8 @@ class MlpNode:
             unzipped_out,
         )
 
-        # recompute_moe_premute 场景下，forward 完成后释放 input_fp8
-        if start_idx is None and self.recompute_moe_premute:
+        # recompute_moe_permute 场景下，forward 完成后释放 input_fp8
+        if start_idx is None and self.recompute_moe_permute:
             gemm_node.input_fp8 = None
             gemm_node.input_scale = None
 
@@ -830,7 +830,7 @@ class MlpNode:
                 不做量化（直接用 unzipped_tokens），fp8/scale = None
 
             Step 4 - 保存 recompute 输入:
-              recompute_moe_premute=True 时保存 fp8/scale 供反向重算
+              recompute_moe_permute=True 时保存 fp8/scale 供反向重算
 
         Args:
             hs_2d_dispatched: 输入 token。bf16 Tensor 或 (FP8 Tensor, scale) tuple。
@@ -905,7 +905,7 @@ class MlpNode:
             hs_2d_dispatched._clear_to_zero_allocation()
 
             # 4. 保存输入供 recompute 使用（仅逐专家路径需要）
-        if self.recompute_moe_premute and hs_2d_dispatched_fp8 is not None:
+        if self.recompute_moe_permute and hs_2d_dispatched_fp8 is not None:
             self.hs_2d_dispatched_fp8 = hs_2d_dispatched_fp8
             self.hs_2d_dispatched_scale = hs_2d_dispatched_scale
 
@@ -1019,7 +1019,7 @@ class MlpNode:
         else:
             # 由于 unzip 必须整专家进行，需要预留 n2 空间，
             # 若不重计算，则需要预留所有专家的 n2
-            if self.recompute_moe_premute:
+            if self.recompute_moe_permute:
                 unzipped_tokens_placeholder = paddle.empty(
                     [max(self.padding_token_per_experts), hidden_size],
                     dtype=unzipped_tokens.dtype,
@@ -1115,7 +1115,7 @@ class MlpNode:
                     ]
                 else:
                     # 释放 placeholder，为实际 n2 buffer 腾出空间
-                    if self.recompute_moe_premute:
+                    if self.recompute_moe_permute:
                         unzipped_tokens_placeholder = None
                     else:
                         unzipped_tokens_placeholder[expert_id] = None
@@ -1146,7 +1146,7 @@ class MlpNode:
                             start_idx=sb_start,
                             end_idx=sb_end,
                         )
-                if self.recompute_moe_premute:
+                if self.recompute_moe_permute:
                     gemm_node.input_fp8 = None
                     gemm_node.input_scale = None
                     gemm_node.input = None
@@ -1214,7 +1214,7 @@ class MlpNode:
         --------------------------------------------------
         0. 判断 zip_unzip_fusion
         1. zip_grad: dn3[S,H] -> do3[N,H] (梯度按专家展开)
-           如果 recompute_premute + fusion, 同时重算前向的 n2
+           如果 recompute_permute + fusion, 同时重算前向的 n2
         2. subbatch planning:
            - 如果 not zip_unzip_fusion: 预分配 do3/n2 placeholder 占位,
              分配 dn1 累加 buffer
@@ -1235,7 +1235,7 @@ class MlpNode:
 
         # 如果 do3 和 n2 (如果recompute) 能同时分配，则可以不用切 zip_grad/unzip，避免重复读写
         zip_unzip_features = [num_unzipped_tokens * hidden_size * 2]
-        if self.recompute_moe_premute:
+        if self.recompute_moe_permute:
             zip_unzip_features.append(num_unzipped_tokens * hidden_size)
         zip_unzip_fusion = (
             find_max_concurrent_subbatch_size(zip_unzip_features, upper=1) > 0
@@ -1251,7 +1251,7 @@ class MlpNode:
             tokens_per_expert=self.tokens_per_expert,
             fill_output=zip_unzip_fusion,
         )
-        if self.recompute_moe_premute and zip_unzip_fusion:
+        if self.recompute_moe_permute and zip_unzip_fusion:
             (unzipped_tokens, _, _, unzipped_scale) = self.unzip_node.forward(
                 (self.hs_2d_dispatched_fp8, self.hs_2d_dispatched_scale),
                 self.dispatched_indices,
@@ -1276,7 +1276,7 @@ class MlpNode:
                 [max_unzipped_tokens_per_expert, hidden_size],
                 dtype=hidden_states_out_grad.dtype,
             )
-            if self.recompute_moe_premute:
+            if self.recompute_moe_permute:
                 unzipped_tokens_placeholder = paddle.empty(
                     [max_unzipped_tokens_per_expert, hidden_size],
                     dtype=self.hs_2d_dispatched_fp8.dtype,
@@ -1340,7 +1340,7 @@ class MlpNode:
         # 确定 subbatch_rows 后，就可以把刚才占位的显存释放了
         if not zip_unzip_fusion:
             del unzipped_grad_placeholder
-            if self.recompute_moe_premute:
+            if self.recompute_moe_permute:
                 del unzipped_tokens_placeholder
 
         # 3. experts
@@ -1380,7 +1380,7 @@ class MlpNode:
                 # 如果前面 zip_grad 一次做完了，这里只需进行切片；否则需要做一次专家级的 zip_grad
                 if zip_unzip_fusion:
                     expert_unzipped_grad = unzipped_grad[start_idx:end_idx]
-                    if self.recompute_moe_premute:
+                    if self.recompute_moe_permute:
                         self.subbatch_prepare_gemm_node(
                             (
                                 unzipped_tokens[start_idx:end_idx],
@@ -1401,7 +1401,7 @@ class MlpNode:
                         tokens_per_expert=self.tokens_per_expert,
                         padding_multiplex=FP8_ALIGN,
                     )
-                    if self.recompute_moe_premute:
+                    if self.recompute_moe_permute:
                         self.subbatch_unzip_and_prepare_gemm_node(
                             (
                                 self.hs_2d_dispatched_fp8,
@@ -1450,7 +1450,7 @@ class MlpNode:
 
         # 4. unzip_grad
         hidden_states_out_grad._clear_to_zero_allocation()  # dn1 复用 dn3
-        if self.recompute_moe_premute and zip_unzip_fusion:
+        if self.recompute_moe_permute and zip_unzip_fusion:
             del unzipped_tokens, unzipped_scale
 
         # 如果不切 unzip_grad，则在这里做一次完整的 unzip_grad；否则 unzip_grad 已经在前面分批完成，这里只需合并结果
@@ -1579,7 +1579,7 @@ class MlpNode:
                             end_idx=sb_end,
                         )
                     # nparts>1 的 expert 全部 subbatch 跑完后，释放 input_fp8
-                    if self.recompute_moe_premute:
+                    if self.recompute_moe_permute:
                         gemm_node = self.experts_group_gemm_node[
                             self._gemm_node_id_offset + expert_id
                         ]
@@ -1688,7 +1688,7 @@ class MlpNode:
                     padding_multiplex=FP8_ALIGN,
                 )
 
-                if self.recompute_moe_premute:
+                if self.recompute_moe_permute:
                     self.subbatch_unzip_and_prepare_gemm_node(
                         (
                             self.hs_2d_dispatched_fp8,
@@ -1786,7 +1786,7 @@ class FusionMoePyLayer(paddle.autograd.PyLayer):
         recompute_moe_gate_up=False,
         dequant_input=True,
         moe_expert_fusion=True,
-        recompute_moe_premute=False,
+        recompute_moe_permute=False,
         moe_subbatch_token_num_after_dispatch=None,
         use_bf16_gemm_weight_grad=False,
         is_first_fwd=False,
@@ -1812,7 +1812,7 @@ class FusionMoePyLayer(paddle.autograd.PyLayer):
             recompute_moe_gate_up=recompute_moe_gate_up,
             dequant_input=dequant_input,
             moe_expert_fusion=moe_expert_fusion,
-            recompute_moe_premute=recompute_moe_premute,
+            recompute_moe_permute=recompute_moe_permute,
             moe_subbatch_token_num_after_dispatch=moe_subbatch_token_num_after_dispatch,
             use_bf16_gemm_weight_grad=use_bf16_gemm_weight_grad,
             use_fp8_mlp=use_fp8_mlp,

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -352,12 +352,12 @@ class MoELayer(nn.Layer):
             and self.config.recompute_modules is not None
             and "moe_gate_up" in self.config.recompute_modules
         )
-        self.recompute_moe_premute = getattr(
-            self.config, "recompute_moe_premute", False
+        self.recompute_moe_permute = getattr(
+            self.config, "recompute_moe_permute", False
         ) or (
             self.config.recompute_granularity == "selective"
             and self.config.recompute_modules is not None
-            and "moe_premute" in self.config.recompute_modules
+            and "moe_permute" in self.config.recompute_modules
         )
         self.use_auto_subbatch = getattr(
             self.config, "use_auto_subbatch", False
@@ -647,7 +647,7 @@ class MoELayer(nn.Layer):
                     moe_deep_gemm=self.moe_deep_gemm,
                     moe_grouped_gemm=self.moe_grouped_gemm,
                     recompute_moe_gate_up=self.recompute_moe_gate_up,
-                    recompute_moe_premute=self.recompute_moe_premute,
+                    recompute_moe_permute=self.recompute_moe_permute,
                     fp8_dispatched_handle=fp8_dispatched_handle,
                     use_bf16_gemm_weight_grad=not self.fp8_wgrad,
                     use_auto_subbatch=self.use_auto_subbatch,
@@ -749,7 +749,7 @@ class MoELayer(nn.Layer):
                 moe_deep_gemm=self.moe_deep_gemm,
                 moe_grouped_gemm=self.moe_grouped_gemm,
                 recompute_moe_gate_up=self.recompute_moe_gate_up,
-                recompute_moe_premute=self.recompute_moe_premute,
+                recompute_moe_permute=self.recompute_moe_permute,
                 fp8_dispatched_handle=fp8_dispatched_handle,
                 use_bf16_gemm_weight_grad=not self.fp8_wgrad,
                 use_auto_subbatch=self.use_auto_subbatch,

--- a/tests/single_card_tests/ai_edited_test/moe/test_ai_fusion_layer_utils.py
+++ b/tests/single_card_tests/ai_edited_test/moe/test_ai_fusion_layer_utils.py
@@ -200,12 +200,12 @@ class TestFusionLayerUtils(unittest.TestCase):
 
         mock_custom_map = _make_mock_custom_map()
 
-        # recompute_moe_premute requires moe_expert_fusion=False
+        # recompute_moe_permute requires moe_expert_fusion=False
         with self.assertRaises(AssertionError):
             MlpNode(
                 mock_custom_map,
                 2,
-                recompute_moe_premute=True,
+                recompute_moe_permute=True,
                 recompute_moe_gate_up=True,
                 dequant_input=True,
                 moe_expert_fusion=True,

--- a/tests/single_card_tests/ai_edited_test/moe/test_latent_moe.py
+++ b/tests/single_card_tests/ai_edited_test/moe/test_latent_moe.py
@@ -797,7 +797,7 @@ class TestFusionMoeForwardLatent(unittest.TestCase):
         stub.moe_deep_gemm = False
         stub.moe_grouped_gemm = False
         stub.recompute_moe_gate_up = False
-        stub.recompute_moe_premute = False
+        stub.recompute_moe_permute = False
         stub.fp8_wgrad = True
         stub.dispatch.return_value = (
             paddle.randn([bs_seq, expert_out_size]),

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_fusion_layer_utils_extra.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_fusion_layer_utils_extra.py
@@ -139,7 +139,7 @@ class TestMlpNodeConstruction(unittest.TestCase):
             num_experts_per_tok=2,
         )
         self.assertTrue(node.moe_expert_fusion)
-        self.assertFalse(node.recompute_moe_premute)
+        self.assertFalse(node.recompute_moe_permute)
         self.assertIsNotNone(node.experts_group_gemm_node)
         self.assertIsNotNone(node.unzip_node)
         self.assertIsNotNone(node.zip_node)

--- a/tests/single_card_tests/test_moe_auto_subbatch.py
+++ b/tests/single_card_tests/test_moe_auto_subbatch.py
@@ -212,7 +212,7 @@ class TestAutoSubbatch(unittest.TestCase):
             "recompute_moe_gate_up": True,
             "dequant_input": True,
             "moe_expert_fusion": is_ref,
-            "recompute_moe_premute": False,
+            "recompute_moe_permute": False,
             "use_bf16_gemm_weight_grad": True,
             "fp8_dispatched_handle": {"scale": self.scale},
             "use_auto_subbatch": not is_ref,
@@ -277,7 +277,7 @@ class TestAutoSubbatch(unittest.TestCase):
         # --- group_gemm + no_recompute (moe_expert_fusion=False) ---
         kwargs = {
             "moe_expert_fusion": True,
-            "recompute_moe_premute": False,
+            "recompute_moe_permute": False,
             "recompute_moe_gate_up": False,
             "moe_grouped_gemm": True,
         }
@@ -303,7 +303,7 @@ class TestAutoSubbatch(unittest.TestCase):
 
         kwargs = {
             "moe_expert_fusion": True,
-            "recompute_moe_premute": False,
+            "recompute_moe_permute": False,
             "recompute_moe_gate_up": True,
             "moe_grouped_gemm": True,
             # "recompute_unzipped": True,
@@ -328,17 +328,17 @@ class TestAutoSubbatch(unittest.TestCase):
             tight_forward=True, tight_backward=True, **kwargs
         )
 
-        # --- group_gemm + selective_recompute (recompute_moe_gate_up + recompute_moe_premute) ---
-        # when recompute_moe_premute is True. recompute_moe_gate_up must be true
+        # --- group_gemm + selective_recompute (recompute_moe_gate_up + recompute_moe_permute) ---
+        # when recompute_moe_permute is True. recompute_moe_gate_up must be true
         kwargs = {
             "moe_expert_fusion": True,
-            "recompute_moe_premute": False,
+            "recompute_moe_permute": False,
             "recompute_moe_gate_up": False,
             "moe_grouped_gemm": True,
         }
         # case9: 显存充裕 → 走 3a group_gemm
         logging.info(
-            "case9 (recompute_moe_gate_up,recompute_moe_premute, group, plenty)"
+            "case9 (recompute_moe_gate_up,recompute_moe_permute, group, plenty)"
         )
         cases["case9 (group, plenty)"] = self.run_moe_layer(**kwargs)
         # case10: 前向紧张 → fallback 到逐专家
@@ -347,14 +347,14 @@ class TestAutoSubbatch(unittest.TestCase):
         )
         # case11: 反向紧张 → 前向 3a, 反向 fallback
         logging.info(
-            "case11 (recompute_moe_gate_up,recompute_moe_premute, group, tight_bwd)"
+            "case11 (recompute_moe_gate_up,recompute_moe_permute, group, tight_bwd)"
         )
         cases["case11 (group, tight_bwd)"] = self.run_moe_layer(
             tight_backward=True, **kwargs
         )
         # case12: 向+反向都紧张, fallback
         logging.info(
-            "case12 (recompute_moe_gate_up,recompute_moe_premute, group, tight_both)"
+            "case12 (recompute_moe_gate_up,recompute_moe_permute, group, tight_both)"
         )
         cases["case12 (group, tight_both)"] = self.run_moe_layer(
             tight_forward=True, tight_backward=True, **kwargs
@@ -363,7 +363,7 @@ class TestAutoSubbatch(unittest.TestCase):
         # split gemm + no moe_subbatch_token_num_after_dispatch ---
         kwargs = {
             "moe_expert_fusion": False,
-            "recompute_moe_premute": False,
+            "recompute_moe_permute": False,
             "recompute_moe_gate_up": False,
             "moe_grouped_gemm": False,
         }
@@ -389,7 +389,7 @@ class TestAutoSubbatch(unittest.TestCase):
         # split gemm + moe_subbatch_token_num_after_dispatch 512 ---
         kwargs = {
             "moe_expert_fusion": False,
-            "recompute_moe_premute": False,
+            "recompute_moe_permute": False,
             "recompute_moe_gate_up": True,
             "moe_grouped_gemm": False,
             "moe_subbatch_token_num_after_dispatch": 512,
@@ -416,7 +416,7 @@ class TestAutoSubbatch(unittest.TestCase):
         # group gemm + 预量化
         kwargs = {
             "moe_expert_fusion": True,
-            "recompute_moe_premute": False,
+            "recompute_moe_permute": False,
             "recompute_moe_gate_up": False,
             "moe_grouped_gemm": True,
         }
@@ -439,7 +439,7 @@ class TestAutoSubbatch(unittest.TestCase):
         # split gemm + recompute + moe_subbatch_token_num_after_dispatch 512 ---
         kwargs = {
             "moe_expert_fusion": False,
-            "recompute_moe_premute": True,
+            "recompute_moe_permute": True,
             "recompute_moe_gate_up": True,
             "moe_grouped_gemm": False,
             "moe_subbatch_token_num_after_dispatch": 512,

--- a/tests/single_card_tests/test_moe_subbatch.py
+++ b/tests/single_card_tests/test_moe_subbatch.py
@@ -171,7 +171,7 @@ class TestSubbatch(unittest.TestCase):
             "recompute_moe_gate_up": True,
             "dequant_input": True,
             "moe_expert_fusion": True,
-            "recompute_moe_premute": False,
+            "recompute_moe_permute": False,
             "use_bf16_gemm_weight_grad": True,
             "fp8_dispatched_handle": {"scale": self.scale},
             "use_auto_subbatch": False,
@@ -228,7 +228,7 @@ class TestSubbatch(unittest.TestCase):
         # --- split_gemm + selective_recompute (普通 subbatch，非 auto_subbatch) ---
         kwargs = {
             "moe_expert_fusion": False,
-            "recompute_moe_premute": True,
+            "recompute_moe_permute": True,
             "recompute_moe_gate_up": True,
             "moe_subbatch_token_num_after_dispatch": 512,
         }


### PR DESCRIPTION
  Summary                                                                                                                                                                                                                                                                                
  - 修复参数名拼写错误：recompute_moe_**pre**mute → recompute_moe_**per**mute                                                                                                                                                                                                                   
  - 更新 fused_swiglu_probs_bwd 的导入路径，当前算子已迁移至fleet，从 FusedQuantOps 改为 paddlefleet.ops，https://github.com/PaddlePaddle/PaddleFleet/pull/833
  - 清理subbatch错误注释