### PR TITLE
fix: ensure shared_experts use original hidden_size in Latent MoE

### DIFF
--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -307,6 +307,7 @@ class MoELayer(nn.Layer):
                     self.experts.append(None)
 
         shared_expert_args = deepcopy(expert_args)
+        shared_expert_args["config"].hidden_size = self.config.hidden_size
         shared_expert_args["moe_intermediate_size"] = (
             self.moe_shared_expert_intermediate_size
         )

--- a/tests/single_card_tests/ai_edited_test/moe/test_latent_moe.py
+++ b/tests/single_card_tests/ai_edited_test/moe/test_latent_moe.py
@@ -240,6 +240,27 @@ class TestLatentMoEInit(unittest.TestCase):
                     )
                 break  # Only check the first present expert
 
+    def test_latent_moe_shared_experts_use_original_hidden_size(self):
+        """shared_experts must use original hidden_size, not moe_latent_size."""
+        config = _make_moe_config(
+            use_latent_moe=True,
+            moe_latent_size=32,
+            n_shared_experts=2,
+        )
+        layer = self._run_init(config)
+        # shared_experts should NOT be affected by latent MoE
+        # It must still use hidden_size=64, not moe_latent_size=32
+        self.assertIsNotNone(layer.shared_experts)
+        # Check that shared_experts operates on hidden_size=64
+        for sub in layer.shared_experts.sublayers():
+            if isinstance(sub, (nn.Linear, paddle.nn.Linear)):
+                self.assertEqual(
+                    sub.weight.shape[1],
+                    64,
+                    "shared_experts input must equal hidden_size=64, not moe_latent_size=32",
+                )
+                break
+
 
 # ---------------------------------------------------------------------------
 # 3. dispatch_preprocess – latent projection before token dispatch


### PR DESCRIPTION
### PR Category

Distributed Strategy / MoE

### PR Types

Bug Fix

### Description
处理共享专家参数被latent_size改写的场景

#### 背景

在 Latent MoE（``use_latent_moe=True``）中，``__init__`` 会将``routed_expert_config.hidden_size`` 覆盖为 ``moe_latent_size``，以让 routed experts 在压缩后的 latent 空间计算。

然而 ``shared_expert_args`` 是通过 ``deepcopy(expert_args)`` 创建的，``expert_args`` 中的 ``config`` 已经是被修改后的 ``routed_expert_config``，因此 ``shared_experts`` 会错误地使用 ``moe_latent_size`` 作为 ``hidden_size``，导致维度不匹配。

#### 改动内容

**``src/paddlefleet/transformer/moe/moe_layer.py``**

在 ``deepcopy(expert_args)`` 之后，显式将 ``shared_expert_args["config"].hidden_size`` 重置为原始 ``config.hidden_size``，确保 ``shared_experts`` 始终使用正确的输入维度。