### PR TITLE
Add triton fused sigmoid gate for MLA

### DIFF
--- a/src/paddlefleet/ops/triton_ops/__init__.py
+++ b/src/paddlefleet/ops/triton_ops/__init__.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 from .rms_norm_fusion import RMSNormFusionTriton
+from .sigmoid_gate_fusion import SigmoidGateFusionTriton
 
 __all__ = [
     "RMSNormFusionTriton",
+    "SigmoidGateFusionTriton",
 ]

--- a/src/paddlefleet/ops/triton_ops/sigmoid_gate_fusion.py
+++ b/src/paddlefleet/ops/triton_ops/sigmoid_gate_fusion.py
@@ -1,0 +1,154 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Triton sigmoid gate forward + backward kernels.
+
+Features:
+- High performance by combining sigmoid and gate in one pass.
+- Numerically precise sigmoid to match Paddle eager mode exactly.
+- Supports fp16, bf16 and fp32 with deterministic backward.
+"""
+
+import paddle
+
+from paddlefleet.ops.triton_ops.utils import is_torch_compat_available
+
+if is_torch_compat_available():
+    paddle.enable_compat(scope={"triton"})
+
+import triton
+import triton.language as tl
+from triton.language.extra.cuda import libdevice
+
+
+@triton.jit
+def _sigmoid_precise(x):
+    """
+    sigmoid(x) = 1 / (1 + exp(-x))
+    Note: to match paddle eager, use precise exp with rn div.
+    """
+    exp_neg = libdevice.exp(-x)
+    return libdevice.div_rn(1.0, 1.0 + exp_neg)
+
+
+@triton.jit
+def fused_sigmoid_gate_fwd_kernel(
+    attn_out_ptr,
+    gate_ptr,
+    out_ptr,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """
+    out = attn_out * sigmoid(gate)
+    """
+    pid = tl.program_id(0)
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    attn_out = tl.load(attn_out_ptr + offsets, mask=mask, other=0.0)
+    gate = tl.load(gate_ptr + offsets, mask=mask, other=0.0)
+    act_out = _sigmoid_precise(gate.to(tl.float32)).to(gate.dtype)
+    out = attn_out * act_out
+
+    tl.store(out_ptr + offsets, out, mask=mask)
+
+
+@triton.jit
+def fused_sigmoid_gate_bwd_kernel(
+    out_grad_ptr,
+    attn_out_ptr,
+    gate_ptr,
+    attn_out_grad_ptr,
+    gate_grad_ptr,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """
+    d_attn = dout * sigmoid(gate)
+    d_gate = dout * attn_out * (1 - sigmoid(gate)) * sigmoid(gate)
+    """
+    pid = tl.program_id(0)
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    out_grad = tl.load(out_grad_ptr + offsets, mask=mask, other=0.0)
+    attn_out = tl.load(attn_out_ptr + offsets, mask=mask, other=0.0)
+    gate = tl.load(gate_ptr + offsets, mask=mask, other=0.0)
+    act_out = _sigmoid_precise(gate.to(tl.float32)).to(gate.dtype)
+    one = tl.full((BLOCK_SIZE,), 1, act_out.dtype)
+
+    attn_out_grad = act_out * out_grad
+    gate_grad = out_grad * attn_out * (one - act_out) * act_out
+
+    tl.store(attn_out_grad_ptr + offsets, attn_out_grad, mask=mask)
+    tl.store(gate_grad_ptr + offsets, gate_grad, mask=mask)
+
+
+class SigmoidGateFusionTriton(paddle.autograd.PyLayer):
+    """Triton sigmoid gate with autograd support."""
+
+    @staticmethod
+    def forward(ctx, attn_out, gate):
+        """forward"""
+        assert attn_out.shape == gate.shape, (
+            f"attn_out and gate must have the same shape, but got {attn_out.shape} and {gate.shape}"
+        )
+        assert attn_out.dtype == gate.dtype, (
+            f"attn_out and gate must have the same dtype, but got {attn_out.dtype} and {gate.dtype}"
+        )
+        assert attn_out.dtype in (
+            paddle.float16,
+            paddle.bfloat16,
+            paddle.float32,
+        ), f"Unsupported dtype for sigmoid gate: {attn_out.dtype}"
+
+        out = paddle.empty_like(attn_out)
+        n_elements = attn_out.size
+        block_size = 1024
+        grid = (triton.cdiv(n_elements, block_size),)
+
+        fused_sigmoid_gate_fwd_kernel[grid](
+            attn_out,
+            gate,
+            out,
+            n_elements,
+            BLOCK_SIZE=block_size,
+        )
+
+        ctx.save_for_backward(attn_out, gate)
+        ctx.n_elements = n_elements
+        ctx.block_size = block_size
+        return out
+
+    @staticmethod
+    def backward(ctx, out_grad):
+        """backward"""
+        attn_out, gate = ctx.saved_tensor()
+        attn_out_grad = paddle.empty_like(attn_out)
+        gate_grad = paddle.empty_like(gate)
+        grid = (triton.cdiv(ctx.n_elements, ctx.block_size),)
+
+        fused_sigmoid_gate_bwd_kernel[grid](
+            out_grad,
+            attn_out,
+            gate,
+            attn_out_grad,
+            gate_grad,
+            ctx.n_elements,
+            BLOCK_SIZE=ctx.block_size,
+        )
+
+        return attn_out_grad, gate_grad

--- a/src/paddlefleet/transformer/multi_latent_attention.py
+++ b/src/paddlefleet/transformer/multi_latent_attention.py
@@ -33,6 +33,7 @@ from paddlefleet.models.common.embeddings.yarn_rotary_pos_embedding import (
     _yarn_get_mscale,
 )
 from paddlefleet.process_groups_config import ProcessGroupCollection
+from paddlefleet.tensor_parallel import RecomputeWithoutOutput
 from paddlefleet.tensor_parallel.mappings import (
     gather_from_sequence_parallel_region,
     gather_from_tensor_model_parallel_region,
@@ -263,6 +264,12 @@ class MultiLatentAttention(Attention):
             self.gated_attention = False
             self.gate_proj = None
 
+        self.recompute_gated_attn = (
+            self.config.recompute_granularity == "selective"
+            and self.config.recompute_modules is not None
+            and "gated_attn" in self.config.recompute_modules
+        )
+
     def forward(
         self,
         hidden_states,
@@ -369,14 +376,36 @@ class MultiLatentAttention(Attention):
 
         # Apply gated attention
         if self.gated_attention:
-            gate, _ = self.gate_proj(hidden_states)
-            core_attn_out = core_attn_out * paddle.nn.functional.sigmoid(gate)
+            if self.recompute_gated_attn:
+                gate_recompute = RecomputeWithoutOutput()
+                core_attn_out = gate_recompute.recompute(
+                    self._gate,
+                    hidden_states,
+                    core_attn_out,
+                    preserve_rng_state=False,
+                    share_grad_holder=True,
+                )
+            else:
+                core_attn_out = self._gate(hidden_states, core_attn_out)
 
         output, bias = self.o_proj(core_attn_out)
+
+        if self.gated_attention and self.recompute_gated_attn:
+            gate_recompute.discard_output_and_register_recompute(output)
 
         _log(output, "attn_o_proj_out", layer_num)
 
         return output, bias
+
+    def _gate(self, hidden_states, core_attn_out):
+        gate, _ = self.gate_proj(hidden_states)
+        if self.config.sigmoid_gate_fusion:
+            from paddlefleet.ops.triton_ops import SigmoidGateFusionTriton
+
+            core_attn_out = SigmoidGateFusionTriton.apply(core_attn_out, gate)
+        else:
+            core_attn_out = core_attn_out * paddle.nn.functional.sigmoid(gate)
+        return core_attn_out
 
 
 class MLASelfAttention(MultiLatentAttention):

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -306,6 +306,9 @@ class TransformerConfig(ModelParallelConfig):
     apply_rope_fusion: bool = False
     """If True, use fused RoPE kernel."""
 
+    sigmoid_gate_fusion: bool = False
+    """If True, use Triton fused sigmoid gate kernel."""
+
     ####################
     # activation recomputation
     ####################

--- a/tests/single_card_tests/custom_ops/test_sigmoid_gate_fusion_triton.py
+++ b/tests/single_card_tests/custom_ops/test_sigmoid_gate_fusion_triton.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+import paddle
+import paddle.nn.functional as F
+
+from paddlefleet.ops.triton_ops import SigmoidGateFusionTriton
+
+
+class TestSigmoidGateFusionTriton(unittest.TestCase):
+    def setUp(self):
+        self.shape_cases = ([1024], [33, 127], [4, 8, 64])
+        self.dtype_cases = ["float32", "float16"]
+        if paddle.device.cuda.get_device_capability()[0] >= 8:
+            self.dtype_cases.append("bfloat16")
+
+    def _make_inputs(self, shape, dtype):
+        paddle.seed(2026)
+        attn_out = paddle.randn(shape, dtype=dtype)
+        gate = paddle.randn(shape, dtype=dtype)
+        attn_out.stop_gradient = False
+        gate.stop_gradient = False
+        return attn_out, gate
+
+    def _run_triton(self, shape, dtype):
+        attn_out, gate = self._make_inputs(shape, dtype)
+        out = SigmoidGateFusionTriton.apply(attn_out, gate)
+        loss = out.sum()
+        loss.backward()
+        return out, attn_out.grad, gate.grad
+
+    def _run_reference(self, shape, dtype):
+        attn_out, gate = self._make_inputs(shape, dtype)
+        out = attn_out * F.sigmoid(gate)
+        loss = out.sum()
+        loss.backward()
+        return out, attn_out.grad, gate.grad
+
+    def test_forward_backward_matches_reference(self):
+        for shape in self.shape_cases:
+            for dtype in self.dtype_cases:
+                tri_out, tri_attn_grad, tri_gate_grad = self._run_triton(
+                    shape, dtype
+                )
+                ref_out, ref_attn_grad, ref_gate_grad = self._run_reference(
+                    shape, dtype
+                )
+
+                np.testing.assert_allclose(
+                    tri_out.float(), ref_out.float(), atol=0, rtol=0
+                )
+                np.testing.assert_allclose(
+                    tri_attn_grad.float(), ref_attn_grad.float(), atol=0, rtol=0
+                )
+                np.testing.assert_allclose(
+                    tri_gate_grad.float(), ref_gate_grad.float(), atol=0, rtol=0
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/transformer/test_mla_gate_attn.py
+++ b/tests/single_card_tests/transformer/test_mla_gate_attn.py
@@ -249,6 +249,41 @@ class TestMLAGatedForward(unittest.TestCase):
         for param in attn.gate_proj.parameters():
             self.assertIsNotNone(param.grad)
 
+    def test_forward_backward_with_gate_recompute(self):
+        attn = _build_mla(
+            gated_attention=True,
+            sigmoid_gate_fusion=True,
+            recompute_granularity="selective",
+            recompute_modules=["gated_attn"],
+        )
+        attn.train()
+        attn_ref = _build_mla(gated_attention=True)
+        attn_ref.train()
+
+        x = paddle.randn([2, 4, 128])
+        x.stop_gradient = False
+
+        mem0 = paddle.device.memory_allocated()
+        out, _ = attn(x, attention_mask=None)
+        mem1 = paddle.device.memory_allocated()
+        out_ref, _ = attn_ref(x, attention_mask=None)
+        mem2 = paddle.device.memory_allocated()
+
+        # Recomputing gate avoids storing sigmoid_out and mul_out, so the
+        # memory usage should be reduced by both sizes.
+        sigmoid_out_size = out.size * out.itemsize
+        mul_out_size = sigmoid_out_size
+        self.assertGreaterEqual(
+            (mem2 - mem1) - (mem1 - mem0),
+            sigmoid_out_size + mul_out_size,
+        )
+
+        loss = out.sum()
+        loss.backward()
+        self.assertIsNotNone(x.grad)
+        for param in attn.gate_proj.parameters():
+            self.assertIsNotNone(param.grad)
+
 
 class TestGetAttentionSpecGate(unittest.TestCase):
     def _make_mock_config(self, gated=False):


### PR DESCRIPTION
## 新增 SigmoidGate 融合算子，替换 MLA 中的实现

SigmoidGate 在多种精度下均可实现逐位对齐（见单测），因此无需跑收敛

开启方法：
```yaml
model_args:
    ....
    model_config:
        ...
        sigmoid_gate_fusion: True
```

另外，该算子可以搭配 RecomputeWithoutOutput 使用，可以节约两份输出（见单测），recompute 性价比较高：
```yaml
recompute_granularity: "selective"
recompute_modules: ["gated_attn"]
```

ernie-core 中已进行同步修改，根据 nsys timeline 确认，fusion 和 recompute 均可正常工作