### PR TITLE
Add align mode for aux_loss when enable mtp

### DIFF
--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -798,38 +798,8 @@ class TopKRouter(StandardMoERouter):
             with paddle.no_grad():
                 self.expert_usage += exp_counts
 
-        def _log_aux_md5(tensor, name, layer_idx=None):
-            """Log MD5 of a tensor for MoE precision alignment debugging."""
-            from paddlefleet.transformer.transformer_layer import (
-                TransformerLayer,
-            )
-
-            if tensor is None:
-                print(f"[MD5 MoE aux loss] {name} is None")
-                return
-
-            if False and TransformerLayer._gpt_model_use_experimental_version:
-                if TransformerLayer._skip_mtp_probes:
-                    return  # Skip MTP passes — EC has no MTP
-                md5 = tensor._md5sum()
-                rank = (
-                    paddle.distributed.get_rank()
-                    if paddle.distributed.is_initialized()
-                    else 0
-                )
-                layer_str = (
-                    f" Layer={layer_idx}" if layer_idx is not None else ""
-                )
-                print(
-                    f"[MD5 MoE aux loss] Rank={rank}{layer_str} {name} MD5={md5} shape={list(tensor.shape)}",
-                    flush=True,
-                )
-
         # aux_loss
         if self.config.router_aux_loss_coef:
-            _log_aux_md5(gates_ori, "gates", self._layer_number)
-            _log_aux_md5(input_ids, "input_ids", self._layer_number)
-
             if self.routing_type == "seq_aux_loss":
                 l_aux = self._cal_seq_aux_loss(
                     gates_ori,
@@ -838,11 +808,6 @@ class TopKRouter(StandardMoERouter):
                     seq_len,
                     batch_size,
                     input_ids=input_ids,
-                )
-                _log_aux_md5(l_aux, "l_aux", self._layer_number)
-                print(
-                    f"Layer {self._layer_number} l_aux: {l_aux.sum().item()}",
-                    flush=True,
                 )
 
             else:

--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -313,7 +313,17 @@ class StandardMoERouter(nn.Layer):
             if _ids.ndim == 1:
                 _ids = _ids.unsqueeze(axis=0)
             origin_valid_mask = (_ids != 0).astype(paddle.float32)
-            token_count_per_line = origin_valid_mask.sum(axis=-1, keepdim=True)
+            if getattr(
+                self.config, "gpt_model_use_experimental_version", False
+            ):
+                token_count_per_line = (
+                    origin_valid_mask.sum(axis=-1, keepdim=True)
+                    + self.config.num_nextn_predict_layers
+                )
+            else:
+                token_count_per_line = origin_valid_mask.sum(
+                    axis=-1, keepdim=True
+                )
             is_invalid_line_float = (token_count_per_line == 0).astype(
                 paddle.float32
             )
@@ -788,8 +798,38 @@ class TopKRouter(StandardMoERouter):
             with paddle.no_grad():
                 self.expert_usage += exp_counts
 
+        def _log_aux_md5(tensor, name, layer_idx=None):
+            """Log MD5 of a tensor for MoE precision alignment debugging."""
+            from paddlefleet.transformer.transformer_layer import (
+                TransformerLayer,
+            )
+
+            if tensor is None:
+                print(f"[MD5 MoE aux loss] {name} is None")
+                return
+
+            if False and TransformerLayer._gpt_model_use_experimental_version:
+                if TransformerLayer._skip_mtp_probes:
+                    return  # Skip MTP passes — EC has no MTP
+                md5 = tensor._md5sum()
+                rank = (
+                    paddle.distributed.get_rank()
+                    if paddle.distributed.is_initialized()
+                    else 0
+                )
+                layer_str = (
+                    f" Layer={layer_idx}" if layer_idx is not None else ""
+                )
+                print(
+                    f"[MD5 MoE aux loss] Rank={rank}{layer_str} {name} MD5={md5} shape={list(tensor.shape)}",
+                    flush=True,
+                )
+
         # aux_loss
         if self.config.router_aux_loss_coef:
+            _log_aux_md5(gates_ori, "gates", self._layer_number)
+            _log_aux_md5(input_ids, "input_ids", self._layer_number)
+
             if self.routing_type == "seq_aux_loss":
                 l_aux = self._cal_seq_aux_loss(
                     gates_ori,
@@ -799,6 +839,12 @@ class TopKRouter(StandardMoERouter):
                     batch_size,
                     input_ids=input_ids,
                 )
+                _log_aux_md5(l_aux, "l_aux", self._layer_number)
+                print(
+                    f"Layer {self._layer_number} l_aux: {l_aux.sum().item()}",
+                    flush=True,
+                )
+
             else:
                 l_aux = self._cal_aux_loss(gates, mask)
         else:

--- a/tests/single_card_tests/transformer/test_router.py
+++ b/tests/single_card_tests/transformer/test_router.py
@@ -368,6 +368,7 @@ class TestTopKRouter(unittest.TestCase):
         """Cover gpt_model_use_experimental_version=True branch in _cal_seq_aux_loss."""
         self.config.topk_method = "greedy"
         self.config.gpt_model_use_experimental_version = True
+        self.config.num_nextn_predict_layers = 0
         router = TopKRouter(self.config)
 
         batch_size, seq_len = 2, 4


### PR DESCRIPTION
当启用mtp后aux loss的计算在对齐模式下 token的总数是seq_len +  num_nextn_predict_layers ，保持和EC一致