### PR TITLE
[FA] add clone for startend_row_indices

### DIFF
--- a/src/paddlefleet/ops/flash_mask_facade.py
+++ b/src/paddlefleet/ops/flash_mask_facade.py
@@ -101,7 +101,7 @@ def flashmask_attention(
         query=query,
         key=key,
         value=value,
-        startend_row_indices=startend_row_indices,
+        startend_row_indices=startend_row_indices.clone(),
         dropout=dropout,
         causal=causal,
         window_size=window_size,


### PR DESCRIPTION
clone when passing `startend_row_indices` in `flash_mask_facade.py` to avoid it being released