### PR TITLE
Add pure text loss metrics to LanguageLoss

### DIFF
--- a/src/paddlefleet/models/common/language_loss/language_loss.py
+++ b/src/paddlefleet/models/common/language_loss/language_loss.py
@@ -377,9 +377,7 @@ class LanguageLoss(FleetLayer):
             # EC's ErniemmPretrainingCriterion recomputes loss as line-wise when task_id
             # is present, which changes the value due to division by (count + 1e-6).
             if self.config.gpt_model_use_experimental_version:
-                loss_2d = loss_fp32 * lossmask.reshape(
-                    labels.shape
-                )
+                loss_2d = loss_fp32 * lossmask.reshape(labels.shape)
                 lossmask_2d = lossmask.reshape(labels.shape)
                 token_count_per_line = lossmask_2d.sum(-1)
                 is_invalid_line_float = (token_count_per_line == 0).astype(

--- a/src/paddlefleet/models/common/language_loss/language_loss.py
+++ b/src/paddlefleet/models/common/language_loss/language_loss.py
@@ -18,7 +18,7 @@ import functools
 import numpy as np
 import paddle
 import paddle.distributed as dist
-from paddle import Tensor, nn
+from paddle import Tensor, framework, nn
 from paddle.autograd import PyLayer
 from paddle.distributed import fleet
 from paddle.distributed.fleet.layers.mpu import mp_ops
@@ -35,6 +35,7 @@ from paddlefleet.parallel_state import (
     get_tensor_model_parallel_world_size,
 )
 from paddlefleet.process_groups_config import ProcessGroupCollection
+from paddlefleet.training.global_vars import get_global_training_logs
 from paddlefleet.transformer.layer import FleetLayer
 from paddlefleet.transformer.transformer_config import TransformerConfig
 
@@ -196,7 +197,29 @@ class LanguageLoss(FleetLayer):
         )
         self.use_subbatch = self.loss_subbatch_sequence_length > 0
 
-    def forward_impl(self, logits: Tensor | tuple, labels: Tensor) -> Tensor:
+    def _record_text_loss_logs(
+        self, loss_fp32: Tensor, lossmask: Tensor
+    ) -> None:
+        training_logs = get_global_training_logs()
+        if training_logs is None:
+            return
+
+        token_num = lossmask.sum()
+        text_loss = (loss_fp32 * lossmask).sum() / paddle.maximum(
+            token_num, paddle.ones_like(token_num)
+        )
+        text_loss = text_loss.detach()
+        training_logs.update(
+            stem_loss=text_loss,
+            pure_text_loss=text_loss,
+        )
+
+    def forward_impl(
+        self,
+        logits: Tensor | tuple,
+        labels: Tensor,
+        enable_text_loss_logs: bool = True,
+    ) -> Tensor:
         # Fused linear + cross-entropy path: `logits` is actually a
         # (hidden_states, weight, bias) tuple emitted by GPTLMHead when
         # config.fused_linear_ce_loss_chunk > 0. Dispatch to the fused kernel
@@ -236,10 +259,13 @@ class LanguageLoss(FleetLayer):
             if (~lossmask).all():
                 return paddle.mean(loss) * 0.0
 
-            lossmask = lossmask.reshape([-1]).cast(paddle.float32)
-            loss = paddle.sum(
-                loss.cast(paddle.float32).reshape([-1]) * lossmask
-            )
+            loss_fp32 = loss.cast(paddle.float32)
+            lossmask = lossmask.cast(paddle.float32)
+            if enable_text_loss_logs and framework._dygraph_tracer()._has_grad:
+                self._record_text_loss_logs(loss_fp32, lossmask)
+
+            lossmask = lossmask.reshape([-1])
+            loss = paddle.sum(loss_fp32.reshape([-1]) * lossmask)
             loss = loss / lossmask.sum()
             return loss
 
@@ -293,8 +319,13 @@ class LanguageLoss(FleetLayer):
         lossmask = labels != self.ignored_index
         if (~lossmask).all():
             loss = paddle.mean(loss) * 0.0
+            loss_fp32 = loss.cast(paddle.float32)
         else:
-            lossmask = lossmask.reshape([-1]).cast(paddle.float32)
+            loss_fp32 = loss.cast(paddle.float32)
+            lossmask = lossmask.cast(paddle.float32)
+            if enable_text_loss_logs and framework._dygraph_tracer()._has_grad:
+                self._record_text_loss_logs(loss_fp32, lossmask)
+            lossmask = lossmask.reshape([-1])
 
             # Loss-path MD5 probe: per-token loss and lossmask
             if (
@@ -305,12 +336,12 @@ class LanguageLoss(FleetLayer):
 
                 rank = paddle.distributed.get_rank()
                 pt_md5 = hashlib.md5(
-                    loss.cast("float32").reshape([-1]).numpy().tobytes()
+                    loss_fp32.reshape([-1]).numpy().tobytes()
                 ).hexdigest()
                 lm_md5 = hashlib.md5(lossmask.numpy().tobytes()).hexdigest()
                 valid_count = lossmask.sum().item()
                 loss_sum_val = paddle.sum(
-                    loss.cast("float32").reshape([-1]) * lossmask
+                    loss_fp32.reshape([-1]) * lossmask
                 ).item()
                 print(
                     f"[LOSS_PATH_MD5] rank={rank} per_token_loss md5={pt_md5}",
@@ -326,9 +357,7 @@ class LanguageLoss(FleetLayer):
                 )
                 # Also compute line-wise loss (matches EC's _line_wise_loss) for exact comparison
                 if self.config.gpt_model_use_experimental_version:
-                    _probe_loss_2d = loss.cast(
-                        paddle.float32
-                    ) * lossmask.reshape(labels.shape)
+                    _probe_loss_2d = loss_fp32 * lossmask.reshape(labels.shape)
                     _probe_lm_2d = lossmask.reshape(labels.shape)
                     _probe_tc = _probe_lm_2d.sum(-1)
                     _probe_inv = (_probe_tc == 0).astype(paddle.float32)
@@ -348,7 +377,7 @@ class LanguageLoss(FleetLayer):
             # EC's ErniemmPretrainingCriterion recomputes loss as line-wise when task_id
             # is present, which changes the value due to division by (count + 1e-6).
             if self.config.gpt_model_use_experimental_version:
-                loss_2d = loss.cast(paddle.float32) * lossmask.reshape(
+                loss_2d = loss_fp32 * lossmask.reshape(
                     labels.shape
                 )
                 lossmask_2d = lossmask.reshape(labels.shape)
@@ -364,20 +393,32 @@ class LanguageLoss(FleetLayer):
                     (1 - is_invalid_line_float).sum() + 1e-6
                 )
             else:
-                loss = paddle.sum(
-                    loss.cast(paddle.float32).reshape([-1]) * lossmask
-                )
+                loss = paddle.sum(loss_fp32.reshape([-1]) * lossmask)
                 loss = loss / lossmask.sum()
 
         return loss
 
-    def _forward(self, logits: Tensor | tuple, labels: Tensor):
+    def _forward(
+        self,
+        logits: Tensor | tuple,
+        labels: Tensor,
+        enable_text_loss_logs: bool = True,
+    ):
         if (
             self.config.recompute_modules is not None
             and "loss_fn" in self.config.recompute_modules
         ):
-            return recompute(self.forward_impl, logits, labels)
-        return self.forward_impl(logits, labels)
+            return recompute(
+                self.forward_impl,
+                logits,
+                labels,
+                enable_text_loss_logs,
+            )
+        return self.forward_impl(
+            logits,
+            labels,
+            enable_text_loss_logs=enable_text_loss_logs,
+        )
 
     def forward(self, logits: Tensor | list, labels: Tensor) -> Tensor:
         if isinstance(logits, list):
@@ -429,6 +470,7 @@ class LanguageLoss(FleetLayer):
                         loss_cur_depth = self._forward(
                             logits_cur_depth,
                             labels_cur_depth,
+                            enable_text_loss_logs=False,
                         )
                     mtp_loss.append(loss_cur_depth)
                     paddle.device.cuda.empty_cache()
@@ -650,6 +692,7 @@ class MTPLanguageLoss(LanguageLoss):
             loss_cur_depth = self._forward(
                 logits_cur_depth,
                 labels_cur_depth,
+                enable_text_loss_logs=False,
             )
             mtp_loss.append(loss_cur_depth)
             paddle.device.cuda.empty_cache()

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_language_loss.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_language_loss.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import os
 import sys
+import types
 
 sys.path.insert(
     0,
@@ -27,6 +28,7 @@ sys.path.insert(
 # Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
 
 import unittest
+from unittest import mock
 
 import numpy as np
 import paddle
@@ -36,6 +38,11 @@ import paddlefleet.parallel_state as ps
 from paddlefleet.models.common.language_loss.language_loss import (
     LanguageLoss,
     subbatch,
+)
+from paddlefleet.training.global_vars import (
+    get_global_training_logs,
+    set_global_training_logs,
+    unset_global_variables,
 )
 from paddlefleet.transformer.transformer_config import TransformerConfig
 
@@ -70,6 +77,186 @@ def _init_fleet():
         fleet.init(is_collective=True, strategy=strategy)
         hcg = fleet.get_hybrid_communicate_group()
         ps.initialize_model_parallel(hcg)
+
+
+class TestLanguageLossTextLossLogs(unittest.TestCase):
+    """Test LanguageLoss text loss logs without fleet init."""
+
+    class _CountingLogs:
+        def __init__(self):
+            self.updates = []
+
+        def update(self, **kwargs):
+            self.updates.append(kwargs)
+
+    def tearDown(self):
+        unset_global_variables()
+
+    def _make_config(self):
+        config = TransformerConfig(
+            num_hidden_layers=2,
+            hidden_size=64,
+            num_attention_heads=4,
+            use_cpu_initialization=True,
+            parallel_output=False,
+            loss_subbatch_sequence_length=0,
+        )
+        config.recompute_modules = None
+        config.gpt_model_use_experimental_version = False
+        return config
+
+    def _make_loss_fn(self):
+        loss_fn = LanguageLoss.__new__(LanguageLoss)
+        loss_fn.config = self._make_config()
+        loss_fn.ignored_index = -100
+        loss_fn.enable_parallel_cross_entropy = False
+        loss_fn.use_subbatch = False
+        loss_matrix = paddle.to_tensor(
+            [[1.0, 2.0, 0.0], [10.0, 3.0, 4.0]], dtype="float32"
+        )
+        loss_fn.loss_func = lambda logits, labels: loss_matrix
+        return loss_fn
+
+    def _init_text_logs(self):
+        set_global_training_logs({})
+
+    def test_updates_text_loss_logs_from_lossmask(self):
+        """Test pure-text and stem metrics are accumulated from lossmask."""
+        self._init_text_logs()
+
+        loss_fn = self._make_loss_fn()
+        logits = paddle.zeros([2, 3, 1106], dtype="float32")
+        labels = paddle.to_tensor(
+            [[1, 2, -100], [1002, 3, 4]], dtype="int64"
+        )
+
+        loss = loss_fn.forward(logits, labels)
+        logs = get_global_training_logs()
+
+        self.assertAlmostEqual(loss.item(), 4.0)
+        self.assertEqual(set(logs), {"pure_text_loss", "stem_loss"})
+        self.assertAlmostEqual(logs["pure_text_loss"].item(), 4.0)
+        self.assertAlmostEqual(logs["stem_loss"].item(), 4.0)
+
+    def test_text_loss_logs_skip_without_global_logs(self):
+        """Test text loss logs are skipped when no global logs are registered."""
+        loss_fn = self._make_loss_fn()
+        logits = paddle.zeros([2, 3, 1106], dtype="float32")
+        labels = paddle.to_tensor(
+            [[1, 2, -100], [1002, 3, 4]], dtype="int64"
+        )
+
+        loss_fn.forward(logits, labels)
+
+        self.assertIsNone(get_global_training_logs())
+
+    def test_recompute_updates_text_loss_logs_once(self):
+        """Test recompute backward replay does not duplicate text loss logs."""
+        logs = self._CountingLogs()
+        set_global_training_logs(logs)
+
+        loss_fn = self._make_loss_fn()
+        loss_fn.config.recompute_modules = ["loss_fn"]
+        loss_matrix = paddle.to_tensor(
+            [[1.0, 2.0, 0.0], [10.0, 3.0, 4.0]], dtype="float32"
+        )
+        loss_fn.loss_func = (
+            lambda logits, labels: logits[:, :, 0] + loss_matrix
+        )
+        logits = paddle.zeros([2, 3, 1106], dtype="float32")
+        logits.stop_gradient = False
+        labels = paddle.to_tensor(
+            [[1, 2, -100], [1002, 3, 4]], dtype="int64"
+        )
+
+        loss = loss_fn.forward(logits, labels)
+        self.assertEqual(len(logs.updates), 0)
+
+        loss.backward()
+        self.assertEqual(len(logs.updates), 1)
+        self.assertAlmostEqual(
+            logs.updates[0]["pure_text_loss"].item(),
+            4.0,
+        )
+
+    def test_fused_tuple_logits_updates_text_loss_logs(self):
+        """Test fused CE tuple path records text metrics from lossmask."""
+        self._init_text_logs()
+
+        loss_fn = self._make_loss_fn()
+        loss_fn.config.fused_linear_ce_loss_chunk = 1
+        fake_module = types.ModuleType(
+            "paddlefleet.ops.triton_ops.fused_linear_cross_entropy"
+        )
+
+        class _FakeFusedLinearCrossEntropyFunction:
+            @staticmethod
+            def apply(
+                _input,
+                weight,
+                labels,
+                bias,
+                ignored_index,
+                reduction,
+                chunk_size,
+            ):
+                del weight, labels, bias, ignored_index, reduction, chunk_size
+                loss_1d = paddle.to_tensor(
+                    [1.0, 2.0, 0.0, 10.0, 3.0, 4.0],
+                    dtype="float32",
+                )
+                return loss_1d + _input[:, 0] * 0.0
+
+        fake_module.LigerFusedLinearCrossEntropyFunction = (
+            _FakeFusedLinearCrossEntropyFunction
+        )
+
+        hidden_states = paddle.zeros([2, 3, 4], dtype="float32")
+        weight = paddle.zeros([8, 4], dtype="float32")
+        labels = paddle.to_tensor(
+            [[1, 2, -100], [1002, 3, 4]], dtype="int64"
+        )
+        with mock.patch.dict(sys.modules, {fake_module.__name__: fake_module}):
+            loss = loss_fn.forward((hidden_states, weight, None), labels)
+
+        logs = get_global_training_logs()
+        self.assertAlmostEqual(loss.item(), 4.0)
+        self.assertAlmostEqual(logs["pure_text_loss"].item(), 4.0)
+        self.assertAlmostEqual(logs["stem_loss"].item(), 4.0)
+
+    def test_all_ignored_labels_skip_text_loss_logs(self):
+        """Test all ignored labels return zero loss without text metrics."""
+        self._init_text_logs()
+
+        loss_fn = self._make_loss_fn()
+        logits = paddle.zeros([2, 3, 1106], dtype="float32")
+        labels = paddle.full([2, 3], -100, dtype="int64")
+
+        loss = loss_fn.forward(logits, labels)
+
+        self.assertAlmostEqual(loss.item(), 0.0)
+        self.assertEqual(get_global_training_logs(), {})
+
+    def test_experimental_line_wise_loss_keeps_text_loss_token_mean(self):
+        """Test experimental loss and text metrics use their own reductions."""
+        self._init_text_logs()
+
+        loss_fn = self._make_loss_fn()
+        loss_fn.config.gpt_model_use_experimental_version = True
+        logits = paddle.zeros([2, 3, 1106], dtype="float32")
+        labels = paddle.to_tensor(
+            [[1, 2, -100], [1002, 3, 4]], dtype="int64"
+        )
+
+        loss = loss_fn.forward(logits, labels)
+        logs = get_global_training_logs()
+
+        expected_line_wise = (
+            (1.0 + 2.0) / 2.0 + (10.0 + 3.0 + 4.0) / 3.0
+        ) / (2.0 + 1e-6)
+        self.assertAlmostEqual(loss.item(), expected_line_wise)
+        self.assertAlmostEqual(logs["pure_text_loss"].item(), 4.0)
+        self.assertAlmostEqual(logs["stem_loss"].item(), 4.0)
 
 
 class TestSubbatch(unittest.TestCase):

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_language_loss.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_language_loss.py
@@ -126,9 +126,7 @@ class TestLanguageLossTextLossLogs(unittest.TestCase):
 
         loss_fn = self._make_loss_fn()
         logits = paddle.zeros([2, 3, 1106], dtype="float32")
-        labels = paddle.to_tensor(
-            [[1, 2, -100], [1002, 3, 4]], dtype="int64"
-        )
+        labels = paddle.to_tensor([[1, 2, -100], [1002, 3, 4]], dtype="int64")
 
         loss = loss_fn.forward(logits, labels)
         logs = get_global_training_logs()
@@ -142,9 +140,7 @@ class TestLanguageLossTextLossLogs(unittest.TestCase):
         """Test text loss logs are skipped when no global logs are registered."""
         loss_fn = self._make_loss_fn()
         logits = paddle.zeros([2, 3, 1106], dtype="float32")
-        labels = paddle.to_tensor(
-            [[1, 2, -100], [1002, 3, 4]], dtype="int64"
-        )
+        labels = paddle.to_tensor([[1, 2, -100], [1002, 3, 4]], dtype="int64")
 
         loss_fn.forward(logits, labels)
 
@@ -160,14 +156,10 @@ class TestLanguageLossTextLossLogs(unittest.TestCase):
         loss_matrix = paddle.to_tensor(
             [[1.0, 2.0, 0.0], [10.0, 3.0, 4.0]], dtype="float32"
         )
-        loss_fn.loss_func = (
-            lambda logits, labels: logits[:, :, 0] + loss_matrix
-        )
+        loss_fn.loss_func = lambda logits, labels: logits[:, :, 0] + loss_matrix
         logits = paddle.zeros([2, 3, 1106], dtype="float32")
         logits.stop_gradient = False
-        labels = paddle.to_tensor(
-            [[1, 2, -100], [1002, 3, 4]], dtype="int64"
-        )
+        labels = paddle.to_tensor([[1, 2, -100], [1002, 3, 4]], dtype="int64")
 
         loss = loss_fn.forward(logits, labels)
         self.assertEqual(len(logs.updates), 0)
@@ -213,9 +205,7 @@ class TestLanguageLossTextLossLogs(unittest.TestCase):
 
         hidden_states = paddle.zeros([2, 3, 4], dtype="float32")
         weight = paddle.zeros([8, 4], dtype="float32")
-        labels = paddle.to_tensor(
-            [[1, 2, -100], [1002, 3, 4]], dtype="int64"
-        )
+        labels = paddle.to_tensor([[1, 2, -100], [1002, 3, 4]], dtype="int64")
         with mock.patch.dict(sys.modules, {fake_module.__name__: fake_module}):
             loss = loss_fn.forward((hidden_states, weight, None), labels)
 
@@ -244,16 +234,14 @@ class TestLanguageLossTextLossLogs(unittest.TestCase):
         loss_fn = self._make_loss_fn()
         loss_fn.config.gpt_model_use_experimental_version = True
         logits = paddle.zeros([2, 3, 1106], dtype="float32")
-        labels = paddle.to_tensor(
-            [[1, 2, -100], [1002, 3, 4]], dtype="int64"
-        )
+        labels = paddle.to_tensor([[1, 2, -100], [1002, 3, 4]], dtype="int64")
 
         loss = loss_fn.forward(logits, labels)
         logs = get_global_training_logs()
 
-        expected_line_wise = (
-            (1.0 + 2.0) / 2.0 + (10.0 + 3.0 + 4.0) / 3.0
-        ) / (2.0 + 1e-6)
+        expected_line_wise = ((1.0 + 2.0) / 2.0 + (10.0 + 3.0 + 4.0) / 3.0) / (
+            2.0 + 1e-6
+        )
         self.assertAlmostEqual(loss.item(), expected_line_wise)
         self.assertAlmostEqual(logs["pure_text_loss"].item(), 4.0)
         self.assertAlmostEqual(logs["stem_loss"].item(), 4.0)


### PR DESCRIPTION
## Summary
- record `pure_text_loss` and `stem_loss` from `LanguageLoss` using the existing loss mask
- gate text-loss logging through `get_global_training_logs()` and avoid duplicate recompute/MTP logging
- add focused single-card tests for regular, fused tuple, recompute, all-ignored, and experimental reduction paths

## Test plan
- `python3 -m py_compile src/paddlefleet/models/common/language_loss/language_loss.py tests/single_card_tests/ai_edited_test/models/test_ai_language_loss.py`
- `git diff --check -- src/paddlefleet/models/common/language_loss/language_loss.py tests/single_card_tests/ai_edited_test/models/test_ai_language_loss.py`
- `PYTHONPATH=src:$PYTHONPATH python3 -m pytest tests/single_card_tests/ai_edited_test/models/test_ai_language_loss.py::TestLanguageLossTextLossLogs -q`
- diff coverage for `language_loss.py` changed executable lines: `28/29 = 96.55%`
- `bash script/run_compare_fleet_ec.sh` in erniebot: EC and PaddleFleet 10-step loss matched exactly; `pure_text_loss` and `stem_loss` max diff `0`
