### PR TITLE
【fd】support decode rope_emb

### DIFF
--- a/src/paddlefleet/models/common/embeddings/rotary_pos_embedding.py
+++ b/src/paddlefleet/models/common/embeddings/rotary_pos_embedding.py
@@ -149,8 +149,18 @@ class RotaryEmbedding(nn.Layer):
         self, max_seq_len: int, offset: int = 0, position_ids: Tensor = None
     ) -> Tensor:
         """Generates matrix of frequencies based on positions in the sequence,
-        used to create positional encodings"""
-        seq = paddle.arange(max_seq_len).astype(self.inv_freq.dtype) + offset
+        used to create positional encodings
+
+        If position_ids is provided, it will be used instead of generating
+        positions from 0..max_seq_len-1, which is useful for inference with KV cache.
+        """
+        if position_ids is not None:
+            seq = position_ids[0] if position_ids.ndim == 2 else position_ids
+            seq = seq.astype(self.inv_freq.dtype)
+        else:
+            seq = (
+                paddle.arange(max_seq_len).astype(self.inv_freq.dtype) + offset
+            )
 
         if self.seq_len_interpolation_factor is not None:
             seq *= 1 / self.seq_len_interpolation_factor

--- a/src/paddlefleet/models/common/embeddings/rotary_pos_embedding.py
+++ b/src/paddlefleet/models/common/embeddings/rotary_pos_embedding.py
@@ -154,6 +154,8 @@ class RotaryEmbedding(nn.Layer):
         If position_ids is provided, it will be used instead of generating
         positions from 0..max_seq_len-1, which is useful for inference with KV cache.
         """
+        print("offset: ", offset)
+        print("position_ids: ", position_ids)
         if position_ids is not None:
             seq = position_ids[0] if position_ids.ndim == 2 else position_ids
             seq = seq.astype(self.inv_freq.dtype)

--- a/tests/single_card_tests/ai_edited_test/embeddings/test_ai_rotary_pos_embedding.py
+++ b/tests/single_card_tests/ai_edited_test/embeddings/test_ai_rotary_pos_embedding.py
@@ -272,6 +272,118 @@ class TestRotaryEmbeddingGetFreqsNonRepeated(unittest.TestCase):
         freqs = rope.get_freqs_non_repeated(max_seq_len=32, offset=5)
         self.assertEqual(freqs.shape, [32, 32])
 
+    @patch(
+        "paddlefleet.models.common.embeddings.rotary_pos_embedding.parallel_state"
+    )
+    def test_get_freqs_with_1d_position_ids(self, mock_ps):
+        """Test get_freqs_non_repeated with 1D position_ids tensor."""
+        from paddlefleet.models.common.embeddings.rotary_pos_embedding import (
+            RotaryEmbedding,
+        )
+
+        mock_ps.get_context_parallel_group.return_value = None
+        rope = RotaryEmbedding(head_dim=64, rotary_percent=1.0)
+
+        # Create 1D position_ids
+        position_ids = paddle.arange(0, 16, dtype="int64")
+        freqs = rope.get_freqs_non_repeated(
+            max_seq_len=32, position_ids=position_ids
+        )
+
+        # Output shape should be [seq_len, dim] = [16, 32]
+        self.assertEqual(freqs.shape, [16, 32])
+        # Verify dtype matches inv_freq.dtype
+        self.assertEqual(freqs.dtype, rope.inv_freq.dtype)
+
+    @patch(
+        "paddlefleet.models.common.embeddings.rotary_pos_embedding.parallel_state"
+    )
+    def test_get_freqs_with_2d_position_ids(self, mock_ps):
+        """Test get_freqs_non_repeated with 2D position_ids tensor (takes first row)."""
+        from paddlefleet.models.common.embeddings.rotary_pos_embedding import (
+            RotaryEmbedding,
+        )
+
+        mock_ps.get_context_parallel_group.return_value = None
+        rope = RotaryEmbedding(head_dim=64, rotary_percent=1.0)
+
+        # Create 2D position_ids with different rows
+        # First row: [0, 1, 2, 3, ...]
+        # Second row: [10, 11, 12, 13, ...]
+        position_ids = paddle.to_tensor(
+            [
+                paddle.arange(0, 16, dtype="int64"),
+                paddle.arange(10, 26, dtype="int64"),
+            ]
+        )
+        freqs = rope.get_freqs_non_repeated(
+            max_seq_len=32, position_ids=position_ids
+        )
+
+        # Should use first row [0, 1, 2, 3, ...], so output shape is [16, 32]
+        self.assertEqual(freqs.shape, [16, 32])
+        # Verify dtype matches inv_freq.dtype
+        self.assertEqual(freqs.dtype, rope.inv_freq.dtype)
+
+    @patch(
+        "paddlefleet.models.common.embeddings.rotary_pos_embedding.parallel_state"
+    )
+    def test_get_freqs_position_ids_dtype_conversion(self, mock_ps):
+        """Test that position_ids is cast to match inv_freq.dtype."""
+        from paddlefleet.models.common.embeddings.rotary_pos_embedding import (
+            RotaryEmbedding,
+        )
+
+        mock_ps.get_context_parallel_group.return_value = None
+        rope = RotaryEmbedding(head_dim=64, rotary_percent=1.0)
+
+        # Create position_ids with different dtype (int64)
+        position_ids_1d = paddle.arange(0, 8, dtype="int64")
+        freqs_1d = rope.get_freqs_non_repeated(
+            max_seq_len=16, position_ids=position_ids_1d
+        )
+        self.assertEqual(freqs_1d.dtype, rope.inv_freq.dtype)
+
+        # Same for 2D
+        position_ids_2d = paddle.to_tensor([paddle.arange(0, 8, dtype="int64")])
+        freqs_2d = rope.get_freqs_non_repeated(
+            max_seq_len=16, position_ids=position_ids_2d
+        )
+        self.assertEqual(freqs_2d.dtype, rope.inv_freq.dtype)
+
+    @patch(
+        "paddlefleet.models.common.embeddings.rotary_pos_embedding.parallel_state"
+    )
+    def test_get_freqs_position_ids_with_interpolation(self, mock_ps):
+        """Test position_ids with seq_len_interpolation_factor."""
+        from paddlefleet.models.common.embeddings.rotary_pos_embedding import (
+            RotaryEmbedding,
+        )
+
+        mock_ps.get_context_parallel_group.return_value = None
+        rope = RotaryEmbedding(
+            head_dim=64,
+            rotary_percent=1.0,
+            seq_len_interpolation_factor=2.0,
+        )
+
+        # Create position_ids
+        position_ids = paddle.arange(0, 16, dtype="int64")
+        freqs = rope.get_freqs_non_repeated(
+            max_seq_len=32, position_ids=position_ids
+        )
+
+        # With interpolation factor 2.0, positions are scaled by 1/2
+        # Output shape should still be [16, 32]
+        self.assertEqual(freqs.shape, [16, 32])
+        # Values should be different from no-interpolation case
+        rope_no_interp = RotaryEmbedding(head_dim=64, rotary_percent=1.0)
+        freqs_no_interp = rope_no_interp.get_freqs_non_repeated(
+            max_seq_len=32, position_ids=position_ids
+        )
+        # Frequencies should differ due to interpolation
+        self.assertFalse(paddle.allclose(freqs, freqs_no_interp))
+
 
 class TestRotaryEmbeddingApplyScaling(unittest.TestCase):
     """Tests for RotaryEmbedding._apply_scaling method."""


### PR DESCRIPTION
为支持推理使用kv_cache, 需要适配计算rope_emb 的方法，根据position_id 修改seq
