### PR TITLE
Fix auto subbatch expert_id offset calculation

### DIFF
--- a/src/paddlefleet/transformer/moe/fusion_layer_utils.py
+++ b/src/paddlefleet/transformer/moe/fusion_layer_utils.py
@@ -727,33 +727,33 @@ class MlpNode:
         expert_fusion=True 时 FP8 权重以 stacked 形式存在 experts[0] 上（所有专家堆叠），
         回退后每个专家需要独立的权重切片。此上下文管理器临时设置并在退出时恢复/清理。
         """
+        expert_id_offset = self.moe_rank * self.num_experts_per_device
+
+        def has_fp8_weight(expert):
+            weight = expert.up_gate_proj.weight
+            return getattr(weight, "fp8_weight_stacked", None) is not None
+
         if not (
-            len(self.experts) > 1
-            and getattr(
-                self.experts[0].up_gate_proj.weight, "fp8_weight_stacked", None
-            )
-            is not None
-            and getattr(
-                self.experts[1].up_gate_proj.weight, "fp8_weight_stacked", None
-            )
-            is None
+            self.num_experts_per_device > 1
+            and has_fp8_weight(self.experts[expert_id_offset])
+            and not has_fp8_weight(self.experts[expert_id_offset + 1])
         ):
             yield
             return
 
-        w1 = self.experts[0].up_gate_proj.weight
-        w2 = self.experts[0].down_proj.weight
+        w1 = self.experts[expert_id_offset].up_gate_proj.weight
+        w2 = self.experts[expert_id_offset].down_proj.weight
         w1_weight, w1_scale = w1.fp8_weight_stacked, w1.fp8_scale_stacked
         w2_weight, w2_scale = w2.fp8_weight_stacked, w2.fp8_scale_stacked
 
         def slice_expert(t):
-            chunk_size = t.shape[0] // len(self.experts)
+            chunk_size = t.shape[0] // self.num_experts_per_device
             return t._slice(
                 chunk_size * expert_id, chunk_size * (expert_id + 1)
             )
 
-        cur_w1 = self.experts[expert_id].up_gate_proj.weight
-        cur_w2 = self.experts[expert_id].down_proj.weight
+        cur_w1 = self.experts[expert_id_offset + expert_id].up_gate_proj.weight
+        cur_w2 = self.experts[expert_id_offset + expert_id].down_proj.weight
         cur_w1.fp8_weight_stacked = slice_expert(w1_weight)
         cur_w1.fp8_scale_stacked = slice_expert(w1_scale)
         cur_w1.fp8_weight_stacked_transpose = None

--- a/src/paddlefleet/transformer/moe/vmm_utils.py
+++ b/src/paddlefleet/transformer/moe/vmm_utils.py
@@ -40,18 +40,32 @@ def vmm_free_and_growable_block_info() -> list[tuple[int, int]]:
     free_blocks = [(size, addr) for size, addr, free in all_blocks if free]
 
     # 堆顶可增长空间即是: 配置的reserved上限 - 当前已reserved的总量
-    growable = max(max_reserved - paddle.cuda.memory_reserved(), 0)
+    growable = max_reserved - paddle.cuda.memory_reserved()
+
+    if not all_blocks:
+        return [(growable, 0)] if growable > 0 else []
+
+    heap_top = all_blocks[-1][1] + all_blocks[-1][0]
+    heap_limit = heap_top + growable
 
     # 如果最后一个 block 是空闲的，将其与 growable 合并；否则将 growable 单独作为一个 block
     if growable > 0:
-        if not all_blocks:
-            return [(growable, 0)]
         if all_blocks[-1][2]:
             size, addr = free_blocks[-1]
             free_blocks[-1] = (size + growable, addr)
         else:
             size, addr, _ = all_blocks[-1]
             free_blocks.append((growable, size + addr))
+
+    # 移除超过堆大小限制的 block，即使能分配也不使用
+    while free_blocks:
+        size, addr = free_blocks[-1]
+        if addr >= heap_limit:
+            free_blocks.pop()
+            continue
+        if addr + size > heap_limit:
+            free_blocks[-1] = (heap_limit - addr, addr)
+        break
 
     free_blocks.sort()
     return free_blocks


### PR DESCRIPTION
### 修复 AutoSubbatch 在 EP>1 时专家下标偏移的问题

原来 ernie-core 里面每个节点的 self.experts 就是只有本地的 experts，现在变成了全部 experts（不在本地的用 None 填空），因此访问时需要加上 offset

另外，优化了 vmm 函数，让空闲块搜索时更加遵循 max_reserved 上限