### PR TITLE
[Build] Improve XPU build dependency version handling

### DIFF
--- a/build_utils.py
+++ b/build_utils.py
@@ -21,6 +21,7 @@ import shutil
 import subprocess
 import sys
 from dataclasses import dataclass
+from importlib.metadata import version as get_pkg_version
 from pathlib import Path
 
 import backends
@@ -240,9 +241,25 @@ def get_special_build_deps():
             )
         return deps
     elif backends.IS_XPU:
-        deps = [
-            "paddlepaddle-xpu>=3.3.0",
-        ]
+        try:
+            xpu_version = get_pkg_version("paddlepaddle-xpu")
+        except Exception:
+            xpu_version = None
+
+        if xpu_version is not None:
+            m = re.match(r"(\d+)\.(\d+)\.(\d+)", xpu_version)
+            if not m:
+                raise ValueError(
+                    f"Cannot parse paddlepaddle-xpu version: {xpu_version}"
+                )
+            major, minor, patch = map(int, m.groups())
+            if (major, minor, patch) < (3, 3, 0):
+                raise ValueError(
+                    f"paddlepaddle-xpu {xpu_version} is too old, >=3.3.0 required."
+                )
+            deps = [f"paddlepaddle-xpu=={xpu_version}"]
+        else:
+            deps = ["paddlepaddle-xpu>=3.3.0"]
         return deps
     else:
         return []

--- a/build_utils.py
+++ b/build_utils.py
@@ -21,8 +21,10 @@ import shutil
 import subprocess
 import sys
 from dataclasses import dataclass
-from importlib.metadata import version as get_pkg_version
+from importlib.metadata import PackageNotFoundError, version as get_pkg_version
 from pathlib import Path
+
+from packaging.version import Version
 
 import backends
 
@@ -243,17 +245,11 @@ def get_special_build_deps():
     elif backends.IS_XPU:
         try:
             xpu_version = get_pkg_version("paddlepaddle-xpu")
-        except Exception:
+        except PackageNotFoundError:
             xpu_version = None
 
         if xpu_version is not None:
-            m = re.match(r"(\d+)\.(\d+)\.(\d+)", xpu_version)
-            if not m:
-                raise ValueError(
-                    f"Cannot parse paddlepaddle-xpu version: {xpu_version}"
-                )
-            major, minor, patch = map(int, m.groups())
-            if (major, minor, patch) < (3, 3, 0):
+            if Version(xpu_version) < Version("3.3.0"):
                 raise ValueError(
                     f"paddlepaddle-xpu {xpu_version} is too old, >=3.3.0 required."
                 )


### PR DESCRIPTION
- Add version detection for installed paddlepaddle-xpu
- Use exact version if installed, otherwise use >=3.3.0
- Add version parsing and minimum version check