### PR TITLE
update ops whl

### DIFF
--- a/.github/workflows/Test-release.yml
+++ b/.github/workflows/Test-release.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Check if packages directory changed
         id: check
         run: |
-          git log
+          git  log
           if [[ "${{ github.ref_type }}" == "tag" ]]; then
             echo "packages_changed=true" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/Test-release.yml
+++ b/.github/workflows/Test-release.yml
@@ -82,10 +82,157 @@ jobs:
           fi
           echo "is_md_only: $(cat $GITHUB_OUTPUT | grep is_md_only || echo '未找到')"
 
+  check-packages-changes:
+    name: Check packages directory changes
+    runs-on: ubuntu-latest
+    outputs:
+      packages_changed: ${{ steps.check.outputs.packages_changed }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - name: Check if packages directory changed
+        id: check
+        run: |
+          if [[ "${{ github.ref_type }}" == "tag" ]]; then
+            echo "packages_changed=true" >> $GITHUB_OUTPUT
+          else
+            if git diff --name-only HEAD~1 HEAD -- packages/ | grep -q .; then
+              echo "packages_changed=true" >> $GITHUB_OUTPUT
+            else
+              echo "packages_changed=false" >> $GITHUB_OUTPUT
+            fi
+          fi
+
+  build_whl-310:
+    name: Build Fleet whl
+    needs: [check-bypass, check_documents_type, check-packages-changes]
+    if: ${{ needs.check-bypass.outputs.can-skip != 'true' && needs.check_documents_type.outputs.is_md_only != 'true' && needs.check-packages-changes.outputs.packages_changed == 'true' }}
+    runs-on:
+      group: GZ_BD-CPU
+    outputs:
+      root_whl_name: ${{ steps.save_whl_names.outputs.root_whl }}
+      ops_whl_name: ${{ steps.save_whl_names.outputs.ops_whl }}
+    env:
+      TASK: fleet-ci-paddle-release-build-whl-${{ github.event.pull_request.number }}
+      PIP_CACHE_DIR: /home/.cache/pip
+      CACHE_DIR: /home/.cache
+      UV_HTTP_TIMEOUT: 600
+      no_proxy: ".bcebos.com,bcebos.com,apiin.im.baidu.com,gitee.com,aliyun.com,.baidu.com,.tuna.tsinghua.edu.cn"
+    steps:
+      - name: Check docker image and run container
+        run: |
+          container_name=${TASK}-$(date +%Y%m%d-%H%M%S)
+          echo "container_name=${container_name}" >> ${{ github.env }}
+          docker pull $build_image
+          docker run -d -t --name ${container_name} \
+            -v "/home/data/cfs:/home/data/cfs" \
+            -v "/home/data/cfs/.cache:/home/.cache" \
+            -v ${{ github.workspace }}/../../..:/root \
+            -v ${{ github.workspace }}/../../../proxy:/root/proxy \
+            -v ${{ github.workspace }}:/paddle \
+            -e no_proxy \
+            -e CACHE_DIR \
+            -e PIP_CACHE_DIR \
+            -e UV_HTTP_TIMEOUT \
+            -e PR_ID \
+            -e COMMIT_ID \
+            -e PADDLE_CUDA_ARCH_LIST="8.0;9.0" \
+            -e BRANCH \
+            -e AK=${{ secrets.BOS_CREDENTIAL_AK }} \
+            -e SK=${{ secrets.BOS_CREDENTIAL_SK }} \
+            -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
+            -e GITHUB_REPO_NAME=${{ github.repository }} \
+            -w /paddle --network=host $build_image
+
+      - name: uv build whl
+        run: |
+          docker exec -t ${{ env.container_name }} /bin/bash -ce '
+          rm -rf * .[^.]*
+          set -x
+          source /root/proxy
+          git clone https://github.com/PaddlePaddle/PaddleFleet.git .
+          git config --global --add safe.directory /paddle
+          git config user.name "PaddleCI"
+          git config user.email "paddle_ci@example.com"
+          git config pull.rebase false
+          git checkout ${BRANCH}
+          git log -1
+          git pull --no-edit origin pull/${PR_ID}/head
+          git submodule update --init --recursive
+          export UV_HTTP_TIMEOUT=300
+          echo "uv build"
+          export LD_LIBRARY_PATH=/opt/_internal/cpython-3.10.0/lib/:${LD_LIBRARY_PATH}
+          export PATH=/opt/_internal/cpython-3.10.0/bin/:${PATH}
+          export UV_PYTHON=3.10
+          export IS_NVIDIA=True
+          mkdir -p /root/.cache/pip
+          pip cache dir
+          pip install --upgrade pip
+          pip install uv coverage==7.13.0 bce-python-sdk==0.8.74 wrapt
+          uv build --wheel --package paddlefleet --out-dir dist --clear -v
+          ROOT_WHL=$(ls dist/paddlefleet-*.whl | head -n1)
+          echo "ROOT_WHL=$(basename $ROOT_WHL)" > dist/whl_names.txt
+          ls -lh dist
+          cat dist/whl_names.txt
+          '
+
+      - name: uv build ops whl
+        run: |
+          docker exec -t ${{ env.container_name }} /bin/bash -ce '
+          set -x
+          export LD_LIBRARY_PATH=/opt/_internal/cpython-3.10.0/lib/:${LD_LIBRARY_PATH}
+          export PATH=/opt/_internal/cpython-3.10.0/bin/:${PATH}
+          export UV_PYTHON=3.10
+          export IS_NVIDIA=True
+          export UV_HTTP_TIMEOUT=300
+          uv build --wheel --package paddlefleet-ops --out-dir dist -v
+          OPS_WHL=$(ls dist/paddlefleet_ops-*.whl | head -n1)
+          echo "OPS_WHL=$(basename $OPS_WHL)" >> dist/whl_names.txt
+          ls -lh dist
+          cat dist/whl_names.txt
+          '
+
+      - name: Save wheel file names as outputs
+        id: save_whl_names
+        run: |
+          docker exec -t ${{ env.container_name }} /bin/bash -c 'cat /paddle/dist/whl_names.txt'
+          ROOT_WHL=$(docker exec -t ${{ env.container_name }} /bin/bash -c 'grep ROOT_WHL /paddle/dist/whl_names.txt | cut -d= -f2' | tr -d '\r')
+          OPS_WHL=$(docker exec -t ${{ env.container_name }} /bin/bash -c 'grep OPS_WHL /paddle/dist/whl_names.txt 2>/dev/null | cut -d= -f2' | tr -d '\r')
+          echo "ROOT_WHL: $ROOT_WHL"
+          echo "OPS_WHL: $OPS_WHL"
+          echo "root_whl=$ROOT_WHL" >> $GITHUB_OUTPUT
+          echo "ops_whl=$OPS_WHL" >> $GITHUB_OUTPUT
+
+      - name: upload whl to BOS
+        run: |
+          docker exec -t ${{ env.container_name }} /bin/bash -ce '
+          export AK=paddle
+          export SK=paddle
+          export LD_LIBRARY_PATH=/opt/_internal/cpython-3.12.0/lib/:${LD_LIBRARY_PATH}
+          export PATH=/opt/_internal/cpython-3.12.0/bin/:${PATH}
+          export UV_PYTHON=3.12
+          cd /
+          if [ ! -f "bos/BosClient.py" ]; then
+            wget -q --no-proxy -O bos_new.tar.gz https://xly-devops.bj.bcebos.com/home/bos_new.tar.gz --no-check-certificate
+            mkdir bos
+            tar xf bos_new.tar.gz -C bos
+          fi
+          target_path="paddle-github-action/PaddleFleet/PR/${PR_ID}/${COMMIT_ID}/${BRANCH}"
+          tar zcf paddldfleet-310.tar.gz paddle
+          python /bos/BosClient.py paddldfleet-310.tar.gz ${target_path}
+          '
+      - name: Terminate and delete the container
+        if: ${{ always() }}
+        run: |
+          set +e
+          docker exec -t ${{ env.container_name }} /bin/bash -c 'bash ci/clean_uv_cache.sh; rm -rf * .[^.]*'
+          docker rm -f ${{ env.container_name }}
 
   build_whl:
     name: Build Fleet whl
-    needs: [check-bypass, check_documents_type]
+    needs: [check-bypass, check_documents_type, check-packages-changes]
     if: ${{ needs.check-bypass.outputs.can-skip != 'true' && needs.check_documents_type.outputs.is_md_only != 'true' }}
     runs-on:
       group: GZ_BD-CPU
@@ -150,10 +297,24 @@ jobs:
           pip install --upgrade pip
           pip install uv coverage==7.13.0 bce-python-sdk==0.8.74 wrapt
           uv build --wheel --package paddlefleet --out-dir dist --clear -v
-          uv build --wheel --package paddlefleet-ops --out-dir dist -v
           ROOT_WHL=$(ls dist/paddlefleet-*.whl | head -n1)
-          OPS_WHL=$(ls dist/paddlefleet_ops-*.whl | head -n1)
           echo "ROOT_WHL=$(basename $ROOT_WHL)" > dist/whl_names.txt
+          ls -lh dist
+          cat dist/whl_names.txt
+          '
+
+      - name: uv build ops whl
+        if: needs.check-packages-changes.outputs.packages_changed == 'true'
+        run: |
+          docker exec -t ${{ env.container_name }} /bin/bash -ce '
+          set -x
+          export LD_LIBRARY_PATH=/opt/_internal/cpython-3.12.0/lib/:${LD_LIBRARY_PATH}
+          export PATH=/opt/_internal/cpython-3.12.0/bin/:${PATH}
+          export UV_PYTHON=3.12
+          export IS_NVIDIA=True
+          export UV_HTTP_TIMEOUT=300
+          uv build --wheel --package paddlefleet-ops --out-dir dist -v
+          OPS_WHL=$(ls dist/paddlefleet_ops-*.whl | head -n1)
           echo "OPS_WHL=$(basename $OPS_WHL)" >> dist/whl_names.txt
           ls -lh dist
           cat dist/whl_names.txt
@@ -164,7 +325,7 @@ jobs:
         run: |
           docker exec -t ${{ env.container_name }} /bin/bash -c 'cat /paddle/dist/whl_names.txt'
           ROOT_WHL=$(docker exec -t ${{ env.container_name }} /bin/bash -c 'grep ROOT_WHL /paddle/dist/whl_names.txt | cut -d= -f2' | tr -d '\r')
-          OPS_WHL=$(docker exec -t ${{ env.container_name }} /bin/bash -c 'grep OPS_WHL /paddle/dist/whl_names.txt | cut -d= -f2' | tr -d '\r')
+          OPS_WHL=$(docker exec -t ${{ env.container_name }} /bin/bash -c 'grep OPS_WHL /paddle/dist/whl_names.txt 2>/dev/null | cut -d= -f2' | tr -d '\r')
           echo "ROOT_WHL: $ROOT_WHL"
           echo "OPS_WHL: $OPS_WHL"
           echo "root_whl=$ROOT_WHL" >> $GITHUB_OUTPUT

--- a/.github/workflows/Test-release.yml
+++ b/.github/workflows/Test-release.yml
@@ -106,7 +106,7 @@ jobs:
           fi
 
   build_whl-310:
-    name: Build Fleet whl
+    name: Build Fleet whl py310
     needs: [check-bypass, check_documents_type, check-packages-changes]
     if: ${{ needs.check-bypass.outputs.can-skip != 'true' && needs.check_documents_type.outputs.is_md_only != 'true' && needs.check-packages-changes.outputs.packages_changed == 'true' }}
     runs-on:
@@ -418,7 +418,7 @@ jobs:
           git config --global --add safe.directory /paddle
           git checkout ${BRANCH}
           pip install uv coverage==7.13.0 bce-python-sdk==0.8.74 wrapt pytest matplotlib
-          pip install dist/${{ needs.build_whl.outputs.ops_whl_name }} --extra-index-url=https://www.paddlepaddle.org.cn/packages/nightly/cu129/ --extra-index-url=https://www.paddlepaddle.org.cn/packages/stable/cu129/
+          if [ -n "${{ needs.build_whl.outputs.ops_whl_name }}" ]; then pip install dist/${{ needs.build_whl.outputs.ops_whl_name }} --extra-index-url=https://www.paddlepaddle.org.cn/packages/nightly/cu129/ --extra-index-url=https://www.paddlepaddle.org.cn/packages/stable/cu129/; fi
           pip install dist/${{ needs.build_whl.outputs.root_whl_name }} --extra-index-url=https://www.paddlepaddle.org.cn/packages/nightly/cu129/ --extra-index-url=https://www.paddlepaddle.org.cn/packages/stable/cu129/
           echo "paddlefleet commit:"
           python -c "import paddlefleet; print(paddlefleet.version.commit)"
@@ -523,7 +523,7 @@ jobs:
           tar -xf paddldfleet.tar.gz --strip-components=1
           git config --global --add safe.directory /paddle
           pip install uv coverage==7.13.0 bce-python-sdk==0.8.74 wrapt pytest
-          pip install dist/${{ needs.build_whl.outputs.ops_whl_name }} --extra-index-url=https://www.paddlepaddle.org.cn/packages/nightly/cu129/ --extra-index-url=https://www.paddlepaddle.org.cn/packages/stable/cu129/
+          if [ -n "${{ needs.build_whl.outputs.ops_whl_name }}" ]; then pip install dist/${{ needs.build_whl.outputs.ops_whl_name }} --extra-index-url=https://www.paddlepaddle.org.cn/packages/nightly/cu129/ --extra-index-url=https://www.paddlepaddle.org.cn/packages/stable/cu129/; fi
           pip install dist/${{ needs.build_whl.outputs.root_whl_name }} --extra-index-url=https://www.paddlepaddle.org.cn/packages/nightly/cu129/ --extra-index-url=https://www.paddlepaddle.org.cn/packages/stable/cu129/
           echo "paddlefleet commit:"
           python -c "import paddlefleet; print(paddlefleet.version.commit)"
@@ -643,7 +643,7 @@ jobs:
           git config --global --add safe.directory /workspace/PaddleFleet
           git checkout ${BRANCH}
           pip install uv coverage==7.13.0 bce-python-sdk==0.8.74 wrapt
-          pip install dist/${{ needs.build_whl.outputs.ops_whl_name }} --extra-index-url=https://www.paddlepaddle.org.cn/packages/nightly/cu129/ --extra-index-url=https://www.paddlepaddle.org.cn/packages/stable/cu129/
+          if [ -n "${{ needs.build_whl.outputs.ops_whl_name }}" ]; then pip install dist/${{ needs.build_whl.outputs.ops_whl_name }} --extra-index-url=https://www.paddlepaddle.org.cn/packages/nightly/cu129/ --extra-index-url=https://www.paddlepaddle.org.cn/packages/stable/cu129/; fi
           pip install dist/${{ needs.build_whl.outputs.root_whl_name }} --extra-index-url=https://www.paddlepaddle.org.cn/packages/nightly/cu129/ --extra-index-url=https://www.paddlepaddle.org.cn/packages/stable/cu129/
           wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/local/bin/yq
           chmod +x /usr/local/bin/yq
@@ -836,7 +836,7 @@ jobs:
           git config --global --add safe.directory /workspace/PaddleFleet
           git checkout ${BRANCH}
           pip install uv coverage==7.13.0 bce-python-sdk==0.8.74 wrapt
-          pip install dist/${{ needs.build_whl.outputs.ops_whl_name }} --extra-index-url=https://www.paddlepaddle.org.cn/packages/nightly/cu129/ --extra-index-url=https://www.paddlepaddle.org.cn/packages/stable/cu129/
+          if [ -n "${{ needs.build_whl.outputs.ops_whl_name }}" ]; then pip install dist/${{ needs.build_whl.outputs.ops_whl_name }} --extra-index-url=https://www.paddlepaddle.org.cn/packages/nightly/cu129/ --extra-index-url=https://www.paddlepaddle.org.cn/packages/stable/cu129/; fi
           pip install dist/${{ needs.build_whl.outputs.root_whl_name }} --extra-index-url=https://www.paddlepaddle.org.cn/packages/nightly/cu129/ --extra-index-url=https://www.paddlepaddle.org.cn/packages/stable/cu129/
           wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/local/bin/yq
           chmod +x /usr/local/bin/yq
@@ -1181,7 +1181,7 @@ jobs:
           git config --global --add safe.directory /workspace/PaddleFleet
           git checkout ${BRANCH}
           pip install uv coverage==7.13.0 bce-python-sdk==0.8.74 wrapt
-          pip install dist/${{ needs.build_whl.outputs.ops_whl_name }} --extra-index-url=https://www.paddlepaddle.org.cn/packages/nightly/cu129/ --extra-index-url=https://www.paddlepaddle.org.cn/packages/stable/cu129/
+          if [ -n "${{ needs.build_whl.outputs.ops_whl_name }}" ]; then pip install dist/${{ needs.build_whl.outputs.ops_whl_name }} --extra-index-url=https://www.paddlepaddle.org.cn/packages/nightly/cu129/ --extra-index-url=https://www.paddlepaddle.org.cn/packages/stable/cu129/; fi
           pip install dist/${{ needs.build_whl.outputs.root_whl_name }} --extra-index-url=https://www.paddlepaddle.org.cn/packages/nightly/cu129/ --extra-index-url=https://www.paddlepaddle.org.cn/packages/stable/cu129/
           wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/local/bin/yq
           chmod +x /usr/local/bin/yq

--- a/.github/workflows/Test-release.yml
+++ b/.github/workflows/Test-release.yml
@@ -91,10 +91,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 100
       - name: Check if packages directory changed
         id: check
         run: |
+          git log
           if [[ "${{ github.ref_type }}" == "tag" ]]; then
             echo "packages_changed=true" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/manual_build_wheel.yml
+++ b/.github/workflows/manual_build_wheel.yml
@@ -46,7 +46,7 @@ jobs:
       matrix:
         python_version: ["3.12"]
         cuda:
-          - {CUDA_VERSION: CUDA13.0, IMAGE_TAG: cuda13.0-cudnn9.13-trt10.13-gcc11, bos_CUDA: cu130, CUDA_ARCH_LIST: "8.0;9.0;10.0;10.3"}
+          - {CUDA_VERSION: CUDA13.0, IMAGE_TAG: cuda13.0-cudnn9.13-trt10.13-gcc11, bos_CUDA: cu130}
     env:
       TASK: PaddleFleet-nightly
       PIP_CACHE_DIR: /home/.cache/pip
@@ -72,7 +72,6 @@ jobs:
             -e PIP_CACHE_DIR \
             -e UV_HTTP_TIMEOUT \
             -e PR_ID \
-            -e PADDLE_CUDA_ARCH_LIST="${{ matrix.cuda.CUDA_ARCH_LIST }}" \
             -e COMMIT_ID \
             -e BRANCH \
             -e AK=paddle \

--- a/.github/workflows/manual_build_wheel.yml
+++ b/.github/workflows/manual_build_wheel.yml
@@ -12,34 +12,15 @@ on:
       commit:
         required: true
         type: string
-      cuda:
-        required: false
-        type: choice
-        default: 'ALL'
-        options:
-          - ALL
-          - "CUDA12.6"
-          - "CUDA12.9"
-          - "CUDA13.0"
-      python:
-        required: false
-        type: choice
-        default: 'ALL'
-        options:
-          - ALL
-          - "3.10"
-          - "3.11"
-          - "3.12"
-          - "3.13"
 
 
 permissions: read-all
 
 
 env:
-  PR_ID: ${{ github.event.pull_request.number || '0' }}
-  COMMIT_ID: ${{ github.event.pull_request.head.sha || github.sha }}
-  BRANCH: ${{ github.event.pull_request.base.ref || github.ref_name }}
+  PR_ID: 'manual_clone'
+  COMMIT_ID: ${{ github.sha }}
+  BRANCH: ${{ github.ref_name }}
 
 defaults:
   run:
@@ -63,13 +44,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: ["3.10", "3.11", "3.12", "3.13"]
+        python_version: ["3.12"]
         cuda:
-          - {CUDA_VERSION: CUDA12.6, IMAGE_TAG: cuda12.6-cudnn9.5-trt10.5-gcc11, bos_CUDA: cu126, CUDA_ARCH_LIST: "8.0;9.0"}
-          - {CUDA_VERSION: CUDA12.9, IMAGE_TAG: cuda12.9-cudnn9.9-trt10.5-gcc11, bos_CUDA: cu129, CUDA_ARCH_LIST: "8.0;9.0;10.0;10.3"}
           - {CUDA_VERSION: CUDA13.0, IMAGE_TAG: cuda13.0-cudnn9.13-trt10.13-gcc11, bos_CUDA: cu130, CUDA_ARCH_LIST: "8.0;9.0;10.0;10.3"}
     env:
-      TASK: PaddleFleet-nightly-${{ matrix.cuda.CUDA_VERSION }}
+      TASK: PaddleFleet-nightly
       PIP_CACHE_DIR: /home/.cache/pip
       CACHE_DIR: /home/.cache
       UV_HTTP_TIMEOUT: 600
@@ -78,10 +57,6 @@ jobs:
       - name: Check docker image and run container
         id: check-skip
         run: |
-          if ! [[ ( "${{ inputs.python }}" == "ALL" || "${{ inputs.python }}" == "${{ matrix.python_version }}" ) && ( "${{ inputs.cuda }}" == "ALL" || "${{ inputs.cuda }}" == "${{ matrix.cuda.CUDA_VERSION }}" ) ]]; then
-            echo "no_build=true" >> $GITHUB_OUTPUT
-            exit 0
-          fi
           docker_image="ccr-2vdh3abv-pub.cnc.bj.baidubce.com/paddlepaddle/paddle_manylinux_devel:${{ matrix.cuda.IMAGE_TAG }}"
           docker pull $docker_image
           container_name=${TASK}-${{ matrix.python_version }}-$(date +%Y%m%d-%H%M%S)
@@ -107,7 +82,6 @@ jobs:
             -w /workspace --network=host $docker_image
 
       - name: Install PaddleFleet
-        if: steps.check-skip.outputs.no_build != 'true'
         run: |
           docker exec -t ${{ env.container_name }} /bin/bash -xc '
           rm -rf * .[^.]*
@@ -129,7 +103,6 @@ jobs:
           '
 
       - name: Build wheel
-        if: steps.check-skip.outputs.no_build != 'true'
         run: |
           docker exec -t ${{ env.container_name }} /bin/bash -xc '
           export LD_LIBRARY_PATH=/opt/_internal/cpython-${{ matrix.python_version }}.0/lib/:${LD_LIBRARY_PATH}
@@ -143,7 +116,6 @@ jobs:
           '
 
       - name: Upload wheel
-        if: steps.check-skip.outputs.no_build != 'true'
         run: |
           docker exec -t ${{ env.container_name }} /bin/bash -xc '
           export LD_LIBRARY_PATH=/opt/_internal/cpython-${{ matrix.python_version }}.0/lib/:${LD_LIBRARY_PATH}

--- a/.github/workflows/manual_build_wheel.yml
+++ b/.github/workflows/manual_build_wheel.yml
@@ -112,7 +112,7 @@ jobs:
           git submodule update --init --recursive
           export IS_NVIDIA=True
           uv build --wheel -v
-          uv build --wheel --package paddlefleet-ops -v
+          # uv build --wheel --package paddlefleet-ops -v
           '
 
       - name: Upload wheel

--- a/.github/workflows/manual_build_wheel_ops.yml
+++ b/.github/workflows/manual_build_wheel_ops.yml
@@ -1,0 +1,168 @@
+name: Manual build wheel with ops
+
+on:
+  workflow_dispatch:
+    inputs:
+      job-name:
+        required: true
+        default: 'publish-wheel'
+        type: choice
+        options:
+          - publish-wheel
+      commit:
+        required: true
+        type: string
+      cuda:
+        required: false
+        type: choice
+        default: 'ALL'
+        options:
+          - ALL
+          - "CUDA12.6"
+          - "CUDA12.9"
+          - "CUDA13.0"
+      python:
+        required: false
+        type: choice
+        default: 'ALL'
+        options:
+          - ALL
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+
+
+permissions: read-all
+
+
+env:
+  PR_ID: ${{ github.event.pull_request.number || '0' }}
+  COMMIT_ID: ${{ github.event.pull_request.head.sha || github.sha }}
+  BRANCH: ${{ github.event.pull_request.base.ref || github.ref_name }}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  clone:
+    name: Clone PaddleFleet
+    uses: ./.github/workflows/_clone.yml
+    with:
+      clone_dir: manual
+      ref: ${{ inputs.commit }}
+      commit: ${{ inputs.commit }}
+
+  publish-wheel:
+    name: Publish wheel nightly (${{ matrix.cuda.CUDA_VERSION }}, python${{ matrix.python_version }})
+    needs: clone
+    if: github.repository == 'PaddlePaddle/PaddleFleet'
+    runs-on:
+      group: GZ_BD-CPU
+    strategy:
+      fail-fast: false
+      matrix:
+        python_version: ["3.10", "3.11", "3.12", "3.13"]
+        cuda:
+          - {CUDA_VERSION: CUDA12.6, IMAGE_TAG: cuda12.6-cudnn9.5-trt10.5-gcc11, bos_CUDA: cu126, CUDA_ARCH_LIST: "8.0;9.0"}
+          - {CUDA_VERSION: CUDA12.9, IMAGE_TAG: cuda12.9-cudnn9.9-trt10.5-gcc11, bos_CUDA: cu129, CUDA_ARCH_LIST: "8.0;9.0;10.0;10.3"}
+          - {CUDA_VERSION: CUDA13.0, IMAGE_TAG: cuda13.0-cudnn9.13-trt10.13-gcc11, bos_CUDA: cu130, CUDA_ARCH_LIST: "8.0;9.0;10.0;10.3"}
+    env:
+      TASK: PaddleFleet-nightly-${{ matrix.cuda.CUDA_VERSION }}
+      PIP_CACHE_DIR: /home/.cache/pip
+      CACHE_DIR: /home/.cache
+      UV_HTTP_TIMEOUT: 600
+      no_proxy: ".bcebos.com,bcebos.com,apiin.im.baidu.com,gitee.com,aliyun.com,.baidu.com,.tuna.tsinghua.edu.cn"
+    steps:
+      - name: Check docker image and run container
+        id: check-skip
+        run: |
+          if ! [[ ( "${{ inputs.python }}" == "ALL" || "${{ inputs.python }}" == "${{ matrix.python_version }}" ) && ( "${{ inputs.cuda }}" == "ALL" || "${{ inputs.cuda }}" == "${{ matrix.cuda.CUDA_VERSION }}" ) ]]; then
+            echo "no_build=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          docker_image="ccr-2vdh3abv-pub.cnc.bj.baidubce.com/paddlepaddle/paddle_manylinux_devel:${{ matrix.cuda.IMAGE_TAG }}"
+          docker pull $docker_image
+          container_name=${TASK}-${{ matrix.python_version }}-$(date +%Y%m%d-%H%M%S)
+          echo "container_name=${container_name}" >> ${{ github.env }}
+          docker run -d -t --name ${container_name} \
+            -v "/home/data/cfs:/home/data/cfs" \
+            -v "/home/data/cfs/.cache:/home/.cache" \
+            -v ${{ github.workspace }}/../../..:/root \
+            -v ${{ github.workspace }}/../../../proxy:/root/proxy \
+            -v ${{ github.workspace }}:/workspace \
+            -e no_proxy \
+            -e CACHE_DIR \
+            -e PIP_CACHE_DIR \
+            -e UV_HTTP_TIMEOUT \
+            -e PR_ID \
+            -e PADDLE_CUDA_ARCH_LIST="${{ matrix.cuda.CUDA_ARCH_LIST }}" \
+            -e COMMIT_ID \
+            -e BRANCH \
+            -e AK=paddle \
+            -e SK=paddle \
+            -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
+            -e GITHUB_REPO_NAME=${{ github.repository }} \
+            -w /workspace --network=host $docker_image
+
+      - name: Install PaddleFleet
+        if: steps.check-skip.outputs.no_build != 'true'
+        run: |
+          docker exec -t ${{ env.container_name }} /bin/bash -xc '
+          rm -rf * .[^.]*
+          export LD_LIBRARY_PATH=/opt/_internal/cpython-${{ matrix.python_version }}.0/lib/:${LD_LIBRARY_PATH}
+          export PATH=/opt/_internal/cpython-${{ matrix.python_version }}.0/bin/:${PATH}
+          source /root/proxy
+          wget -q --tries=5 --no-proxy https://paddle-github-action.bj.bcebos.com/PaddleFleet/manual/${PR_ID}/${{ inputs.commit }}/PaddleFleet.tar.gz --no-check-certificate
+          echo "Extracting PaddleFleet.tar.gz"
+          tar -xf PaddleFleet.tar.gz --strip-components=1
+          rm PaddleFleet.tar.gz
+          git config --global --add safe.directory /workspace
+          sed -i "s#packages/nightly/cu129#packages/nightly/${{ matrix.cuda.bos_CUDA }}#g" pyproject.toml
+          cat pyproject.toml
+          mkdir -p /root/.cache/pip
+          pip cache dir
+          pip install --upgrade pip
+          pip install uv
+          python -m pip install bce-python-sdk==0.8.74
+          '
+
+      - name: Build wheel
+        if: steps.check-skip.outputs.no_build != 'true'
+        run: |
+          docker exec -t ${{ env.container_name }} /bin/bash -xc '
+          export LD_LIBRARY_PATH=/opt/_internal/cpython-${{ matrix.python_version }}.0/lib/:${LD_LIBRARY_PATH}
+          export PATH=/opt/_internal/cpython-${{ matrix.python_version }}.0/bin/:${PATH}
+          export UV_PYTHON=${{ matrix.python_version }}
+          source /root/proxy
+          git submodule update --init --recursive
+          export IS_NVIDIA=True
+          uv build --wheel -v
+          uv build --wheel --package paddlefleet-ops -v
+          '
+
+      - name: Upload wheel
+        if: steps.check-skip.outputs.no_build != 'true'
+        run: |
+          docker exec -t ${{ env.container_name }} /bin/bash -xc '
+          export LD_LIBRARY_PATH=/opt/_internal/cpython-${{ matrix.python_version }}.0/lib/:${LD_LIBRARY_PATH}
+          export PATH=/opt/_internal/cpython-${{ matrix.python_version }}.0/bin/:${PATH}
+          wget -q --no-proxy https://xly-devops.bj.bcebos.com/home/bos_new.tar.gz --no-check-certificate
+          mkdir bos
+          tar -xf bos_new.tar.gz -C bos
+          cd dist
+          for whl in paddlefleet-*.whl paddlefleet_ops-*.whl; do
+            echo "Uploading ${whl}"
+            python ../bos/BosClient.py ${whl} paddle-github-action/PaddleFleet/manual/${{ inputs.commit }}/${{ matrix.cuda.bos_CUDA }}
+            echo "https://paddle-github-action.bj.bcebos.com/PaddleFleet/manual/${{ inputs.commit }}/${{ matrix.cuda.bos_CUDA }}/${whl}"
+          done
+          '
+
+      - name: Cleanup
+        if: ${{ always() }}
+        run: |
+          set +e
+          docker exec -t ${{ env.container_name }} /bin/bash -c 'bash ci/clean_uv_cache.sh; rm -rf * .[^.]*'
+          docker rm -f ${{ env.container_name }}
+          exit 0

--- a/.github/workflows/pr_update_ops.yml
+++ b/.github/workflows/pr_update_ops.yml
@@ -1,0 +1,352 @@
+name: Publish wheel nightly
+
+on:
+  push:
+    branches:
+      - 'release/**'
+      - 'develop'
+    tags:
+      - 'v*'
+
+
+permissions: read-all
+
+# concurrency:
+#   group: ${{ github.workflow }}-all-${{ github.sha }}-ops
+#   cancel-in-progress: true
+
+env:
+  PR_ID: 'ops'
+  COMMIT_ID: ${{ github.sha }}
+  BRANCH: ${{ github.ref_name }}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  check-packages-changes:
+    name: Check packages directory changes
+    runs-on: ubuntu-latest
+    outputs:
+      packages_changed: ${{ steps.check.outputs.packages_changed }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - name: Check if packages directory changed
+        id: check
+        run: |
+          if [[ "${{ github.ref_type }}" == "tag" ]]; then
+            echo "packages_changed=true" >> $GITHUB_OUTPUT
+          else
+            if git diff --name-only HEAD~1 HEAD -- packages/ | grep -q .; then
+              echo "packages_changed=true" >> $GITHUB_OUTPUT
+            else
+              echo "packages_changed=false" >> $GITHUB_OUTPUT
+            fi
+          fi
+
+  upload-pr-ops:
+    name: Upload PR ops whl
+    needs: check-packages-changes
+    if: needs.check-packages-changes.outputs.packages_changed == 'true'
+    runs-on: ubuntu-latest
+    env:
+      AK: ${{ secrets.BOS_CREDENTIAL_AK }}
+      SK: ${{ secrets.BOS_CREDENTIAL_SK }}
+    steps:
+      - name: Setup Python 3.10
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.10'
+
+      - name: Upload PR ops whl to paddle
+        run: |
+          set -x
+          wget -q --no-proxy https://xly-devops.bj.bcebos.com/home/bos_new.tar.gz --no-check-certificate
+          mkdir bos
+          tar -xf bos_new.tar.gz -C bos
+          pip install bce-python-sdk==0.8.74
+          response=$(curl -L \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ github.token }}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos/PaddlePaddle/PaddleFleet/commits/${{ github.sha }}/pulls)
+          pr_number=$(echo $response | jq -r '.[0].url' | awk -F'/' '{print $NF}')
+          pr_last_commit=$(echo $response | jq -r '.[0].head.sha')
+          mkdir fleet-312 && cd fleet-312
+          wget https://paddle-github-action.cdn.bcebos.com/PaddleFleet/PR/${pr_number}/${pr_last_commit}/${BRANCH}/paddldfleet.tar.gz
+          tar -xf paddldfleet.tar.gz --strip-components=1
+          git config --global --add safe.directory .
+          cd dist
+          python ../../bos/BosClient.py paddlefleet_ops-*.whl paddle-whl/nightly/cu129/paddlefleet-ops
+          cd ../.. && mkdir fleet-310 && cd fleet-310
+          wget https://paddle-github-action.cdn.bcebos.com/PaddleFleet/PR/${pr_number}/${pr_last_commit}/${BRANCH}/paddlefleet-310.tar.gz
+          tar -xf paddldfleet.tar.gz --strip-components=1
+          git config --global --add safe.directory .
+          cd dist
+          python ../../bos/BosClient.py paddlefleet_ops-*.whl paddle-whl/nightly/cu129/paddlefleet-ops
+
+  clone:
+    name: Clone PaddleFleet
+    needs: check-packages-changes
+    if: needs.check-packages-changes.outputs.packages_changed == 'true'
+    uses: ./.github/workflows/_clone.yml
+    with:
+      clone_dir: $BRANCH
+      ref: ${{ github.event.pull_request.base.ref }}
+
+  publish-ops-wheel:
+    name: Publish wheel nightly (${{ matrix.cuda.CUDA_VERSION }}, python${{ matrix.python_version }})
+    needs: clone
+    if: github.repository == 'PaddlePaddle/PaddleFleet'
+    runs-on:
+      group: GZ_BD-CPU
+    strategy:
+      fail-fast: false
+      matrix:
+        python_version: ["3.10", "3.11", "3.12", "3.13"]
+        cuda:
+          - {CUDA_VERSION: CUDA12.6, IMAGE_TAG: cuda12.6-cudnn9.5-trt10.5-gcc11, bos_CUDA: cu126, CUDA_ARCH_LIST: "8.0;9.0"}
+          - {CUDA_VERSION: CUDA12.9, IMAGE_TAG: cuda12.9-cudnn9.9-trt10.5-gcc11, bos_CUDA: cu129, CUDA_ARCH_LIST: "8.0;9.0;10.0;10.3"}
+          - {CUDA_VERSION: CUDA13.0, IMAGE_TAG: cuda13.0-cudnn9.13-trt10.13-gcc11, bos_CUDA: cu130, CUDA_ARCH_LIST: "8.0;9.0;10.0;10.3"}
+    env:
+      TASK: PaddleFleet-nightly-${{ matrix.cuda.CUDA_VERSION }}
+      PIP_CACHE_DIR: /home/.cache/pip
+      CACHE_DIR: /home/.cache
+      UV_HTTP_TIMEOUT: 600
+      no_proxy: ".bcebos.com,bcebos.com,apiin.im.baidu.com,gitee.com,aliyun.com,.baidu.com,.tuna.tsinghua.edu.cn"
+    steps:
+      - name: Check docker image and run container
+        run: |
+          docker_image="ccr-2vdh3abv-pub.cnc.bj.baidubce.com/paddlepaddle/paddle_manylinux_devel:${{ matrix.cuda.IMAGE_TAG }}"
+          docker pull $docker_image
+          container_name=${TASK}-${{ matrix.python_version }}-$(date +%Y%m%d-%H%M%S)
+          echo "container_name=${container_name}" >> ${{ github.env }}
+          docker run -d -t --name ${container_name} \
+            -v "/home/data/cfs:/home/data/cfs" \
+            -v "/home/data/cfs/.cache:/home/.cache" \
+            -v ${{ github.workspace }}/../../..:/root \
+            -v ${{ github.workspace }}/../../../proxy:/root/proxy \
+            -v ${{ github.workspace }}:/workspace \
+            -e no_proxy \
+            -e CACHE_DIR \
+            -e PIP_CACHE_DIR \
+            -e UV_HTTP_TIMEOUT \
+            -e PADDLE_CUDA_ARCH_LIST="${{ matrix.cuda.CUDA_ARCH_LIST }}" \
+            -e PR_ID \
+            -e COMMIT_ID \
+            -e BRANCH \
+            -e AK=${{ secrets.BOS_CREDENTIAL_AK }} \
+            -e SK=${{ secrets.BOS_CREDENTIAL_SK }} \
+            -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
+            -e GITHUB_REPO_NAME=${{ github.repository }} \
+            -w /workspace --network=host $docker_image
+
+      - name: Download PaddleFleet
+        run: |
+          docker exec -t ${{ env.container_name }} /bin/bash -xc '
+          rm -rf * .[^.]*
+          export LD_LIBRARY_PATH=/opt/_internal/cpython-${{ matrix.python_version }}.0/lib/:${LD_LIBRARY_PATH}
+          export PATH=/opt/_internal/cpython-${{ matrix.python_version }}.0/bin/:${PATH}
+          source /root/proxy
+          wget -q --tries=5 --no-proxy https://paddle-github-action.bj.bcebos.com/PaddleFleet/${BRANCH}/${PR_ID}/${COMMIT_ID}/PaddleFleet.tar.gz --no-check-certificate
+          echo "Extracting PaddleFleet.tar.gz"
+          tar -xf PaddleFleet.tar.gz --strip-components=1
+          rm PaddleFleet.tar.gz
+          git config --global --add safe.directory /workspace
+          sed -i "s#packages/nightly/cu129#packages/nightly/${{ matrix.cuda.bos_CUDA }}#g" pyproject.toml
+          cat pyproject.toml
+          mkdir -p /root/.cache/pip
+          pip cache dir
+          pip install --upgrade pip
+          pip install uv
+          python -m pip install bce-python-sdk==0.8.74
+          '
+
+      - name: Build wheel
+        run: |
+          docker exec -t ${{ env.container_name }} /bin/bash -xc '
+          export LD_LIBRARY_PATH=/opt/_internal/cpython-${{ matrix.python_version }}.0/lib/:${LD_LIBRARY_PATH}
+          export PATH=/opt/_internal/cpython-${{ matrix.python_version }}.0/bin/:${PATH}
+          export UV_PYTHON=${{ matrix.python_version }}
+          source /root/proxy
+          git submodule update --init --recursive
+          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref_type }}" == "tag" ]]; then
+            TAG_NAME="${{ github.ref_name }}"
+            VERSION="${TAG_NAME#v}"
+            export PADDLEFLEET_VERSION=$VERSION
+          fi
+          export IS_NVIDIA=True
+          # Enable ccache for C++/CUDA compilation if available in the image.
+          # CCACHE_DIR points to CFS so the cache persists across CI runs.
+          if command -v ccache &>/dev/null; then
+            export CCACHE_DIR=/home/.cache/ccache
+            export CCACHE_MAXSIZE=20G
+            mkdir -p "${CCACHE_DIR}"
+            export CC="ccache gcc"
+            export CXX="ccache g++"
+            ccache --zero-stats
+            echo "[build] ccache enabled, CCACHE_DIR=${CCACHE_DIR}"
+          fi
+          # uv build --wheel --package paddlefleet --out-dir dist --clear -v
+          uv build --wheel --package paddlefleet-ops --out-dir dist -v
+          '
+
+      - name: Upload wheel
+        run: |
+          docker exec -t ${{ env.container_name }} /bin/bash -xc '
+          export LD_LIBRARY_PATH=/opt/_internal/cpython-${{ matrix.python_version }}.0/lib/:${LD_LIBRARY_PATH}
+          export PATH=/opt/_internal/cpython-${{ matrix.python_version }}.0/bin/:${PATH}
+          wget -q --no-proxy https://xly-devops.bj.bcebos.com/home/bos_new.tar.gz --no-check-certificate
+          mkdir bos
+          tar -xf bos_new.tar.gz -C bos
+          cd dist
+          PY_VERSION="${{ matrix.python_version }}"
+          PY_VERSION_SHORT="${PY_VERSION//./}"
+          if [[ "${{ github.ref_type }}" == "tag" ]]; then
+            python ../bos/BosClient.py paddlefleet_ops-*.whl paddle-whl/stable/${{ matrix.cuda.bos_CUDA }}/paddlefleet-ops
+          else
+            python ../bos/BosClient.py paddlefleet_ops-*.whl paddle-whl/nightly/${{ matrix.cuda.bos_CUDA }}/paddlefleet-ops
+            export AK=paddle
+            export SK=paddle
+            python ../bos/BosClient.py paddlefleet_ops-*.whl paddle-github-action/PaddleFleet/${BRANCH}/${COMMIT_ID}/${{ matrix.cuda.bos_CUDA }}
+            mv paddlefleet_ops-*.whl paddlefleet_ops-0.0.0-cp${PY_VERSION_SHORT}-cp${PY_VERSION_SHORT}-linux_x86_64.whl
+            python ../bos/BosClient.py paddlefleet_ops-*.whl paddle-github-action/PaddleFleet/${BRANCH}/latest/${{ matrix.cuda.bos_CUDA }}
+          fi
+          curl https://www.paddlepaddle.org.cn/inner/whl/update/path/new
+          '
+
+      - name: Cleanup
+        if: ${{ always() }}
+        run: |
+          set +e
+          docker exec -t ${{ env.container_name }} /bin/bash -c 'bash ci/clean_uv_cache.sh; rm -rf * .[^.]*'
+          docker rm -f ${{ env.container_name }}
+
+  publish-ops-wheel-arm:
+    name: Publish arm wheel nightly (${{ matrix.cuda.CUDA_VERSION }}, python${{ matrix.python_version }})
+    needs: clone
+    if: github.repository == 'PaddlePaddle/PaddleFleet'
+    runs-on:
+      group: npu-arm
+    strategy:
+      fail-fast: false
+      matrix:
+        python_version: ["3.12"]
+        cuda:
+          - {CUDA_VERSION: CUDA13.0, bos_CUDA: cu130}
+    env:
+      TASK: PaddleFleet-nightly-arm-${{ matrix.cuda.CUDA_VERSION }}
+      PIP_CACHE_DIR: /home/.cache/pip
+      CACHE_DIR: /home/.cache
+      UV_HTTP_TIMEOUT: 600
+      no_proxy: ".bcebos.com,bcebos.com,apiin.im.baidu.com,gitee.com,aliyun.com,.baidu.com,.tuna.tsinghua.edu.cn"
+    steps:
+      - name: Check docker image and run container
+        run: |
+          docker_image="ccr-2vdh3abv-pub.cnc.bj.baidubce.com/paddlepaddle/paddle:cuda130-dev-arm-py312"
+          docker pull $docker_image
+          container_name=${TASK}-${{ matrix.python_version }}-$(date +%Y%m%d-%H%M%S)
+          echo "container_name=${container_name}" >> ${{ github.env }}
+          docker run -d -t --name ${container_name} \
+            -v "/home/data/cfs:/home/data/cfs" \
+            -v "/home/data/cfs/.cache:/home/.cache" \
+            -v ${{ github.workspace }}/../../..:/root \
+            -v ${{ github.workspace }}/../../../proxy:/root/proxy \
+            -v ${{ github.workspace }}:/workspace \
+            -e no_proxy \
+            -e CACHE_DIR \
+            -e PIP_CACHE_DIR \
+            -e UV_HTTP_TIMEOUT \
+            -e PR_ID \
+            -e COMMIT_ID \
+            -e BRANCH \
+            --shm-size 128G \
+            --ulimit core=-1 \
+            --cap-add SYS_ADMIN \
+            --privileged=true \
+            -v /ssd1:/ssd1 \
+            -v /ssd2:/ssd2 \
+            -v /ssd3:/ssd3 \
+            -e AK=${{ secrets.BOS_CREDENTIAL_AK }} \
+            -e SK=${{ secrets.BOS_CREDENTIAL_SK }} \
+            -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
+            -e GITHUB_REPO_NAME=${{ github.repository }} \
+            -w /workspace --network=host $docker_image
+
+      - name: Install PaddleFleet
+        run: |
+          docker exec -t ${{ env.container_name }} /bin/bash -xc '
+          rm -rf * .[^.]*
+          source /root/proxy
+          wget -q --tries=5 --no-proxy https://paddle-github-action.bj.bcebos.com/PaddleFleet/${BRANCH}/${PR_ID}/${COMMIT_ID}/PaddleFleet.tar.gz --no-check-certificate
+          echo "Extracting PaddleFleet.tar.gz"
+          tar -xf PaddleFleet.tar.gz --strip-components=1
+          rm PaddleFleet.tar.gz
+          git config --global --add safe.directory /workspace
+          sed -i "s#packages/nightly/cu129#packages/nightly/${{ matrix.cuda.bos_CUDA }}#g" pyproject.toml
+          cat pyproject.toml
+          mkdir -p /root/.cache/pip
+          pip cache dir
+          pip install --break-system-packages --upgrade pip
+          pip install --break-system-packages uv
+          python -m pip install --break-system-packages bce-python-sdk==0.8.74
+          '
+
+      - name: Build wheel
+        run: |
+          docker exec -t ${{ env.container_name }} /bin/bash -xc '
+          export UV_PYTHON=${{ matrix.python_version }}
+          source /root/proxy
+          git submodule update --init --recursive
+          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref_type }}" == "tag" ]]; then
+            TAG_NAME="${{ github.ref_name }}"
+            VERSION="${TAG_NAME#v}"
+            export PADDLEFLEET_VERSION=$VERSION
+          fi
+          export IS_NVIDIA=True
+          # Enable ccache for C++/CUDA compilation if available in the image.
+          # CCACHE_DIR points to CFS so the cache persists across CI runs.
+          if command -v ccache &>/dev/null; then
+            export CCACHE_DIR=/home/.cache/ccache
+            export CCACHE_MAXSIZE=20G
+            mkdir -p "${CCACHE_DIR}"
+            export CC="ccache gcc"
+            export CXX="ccache g++"
+            ccache --zero-stats
+            echo "[build] ccache enabled, CCACHE_DIR=${CCACHE_DIR}"
+          fi
+          uv build --wheel --package paddlefleet-ops -v --python /usr/bin/python
+          '
+
+      - name: Upload wheel
+        run: |
+          docker exec -t ${{ env.container_name }} /bin/bash -xc '
+          wget -q --no-proxy https://xly-devops.bj.bcebos.com/home/bos_new.tar.gz --no-check-certificate
+          mkdir bos
+          tar -xf bos_new.tar.gz -C bos
+          cd dist
+          if [[ "${{ github.ref_type }}" == "tag" ]]; then
+            python ../bos/BosClient.py paddlefleet_ops-*.whl paddle-whl/stable/${{ matrix.cuda.bos_CUDA }}/paddlefleet-ops
+          else
+            python ../bos/BosClient.py paddlefleet_ops-*.whl paddle-whl/nightly/${{ matrix.cuda.bos_CUDA }}/paddlefleet-ops
+            export AK=paddle
+            export SK=paddle
+            python ../bos/BosClient.py paddlefleet_ops-*.whl paddle-github-action/PaddleFleet/${BRANCH}/${COMMIT_ID}/${{ matrix.cuda.bos_CUDA }}
+            PY_VERSION="${{ matrix.python_version }}"
+            PY_VERSION_SHORT="${PY_VERSION//./}"
+            mv paddlefleet_ops-*.whl paddlefleet_ops-0.0.0-cp${PY_VERSION_SHORT}-cp${PY_VERSION_SHORT}-linux_aarch64.whl
+            python ../bos/BosClient.py paddlefleet-0.0.0-cp${PY_VERSION_SHORT}-cp${PY_VERSION_SHORT}-linux_aarch64.whl paddle-github-action/PaddleFleet/${BRANCH}/latest/${{ matrix.cuda.bos_CUDA }}
+          fi
+          curl https://www.paddlepaddle.org.cn/inner/whl/update/path/new
+          '
+
+      - name: Cleanup
+        if: ${{ always() }}
+        run: |
+          set +e
+          docker exec -t ${{ env.container_name }} /bin/bash -c 'bash ci/clean_uv_cache.sh; rm -rf * .[^.]*'
+          docker rm -f ${{ env.container_name }}

--- a/.github/workflows/pr_update_ops.yml
+++ b/.github/workflows/pr_update_ops.yml
@@ -1,4 +1,4 @@
-name: Publish wheel nightly
+name: PR update ops
 
 on:
   push:
@@ -11,9 +11,6 @@ on:
 
 permissions: read-all
 
-# concurrency:
-#   group: ${{ github.workflow }}-all-${{ github.sha }}-ops
-#   cancel-in-progress: true
 
 env:
   PR_ID: 'ops'
@@ -180,8 +177,6 @@ jobs:
             export PADDLEFLEET_VERSION=$VERSION
           fi
           export IS_NVIDIA=True
-          # Enable ccache for C++/CUDA compilation if available in the image.
-          # CCACHE_DIR points to CFS so the cache persists across CI runs.
           if command -v ccache &>/dev/null; then
             export CCACHE_DIR=/home/.cache/ccache
             export CCACHE_MAXSIZE=20G
@@ -191,7 +186,6 @@ jobs:
             ccache --zero-stats
             echo "[build] ccache enabled, CCACHE_DIR=${CCACHE_DIR}"
           fi
-          # uv build --wheel --package paddlefleet --out-dir dist --clear -v
           uv build --wheel --package paddlefleet-ops --out-dir dist -v
           '
 
@@ -308,8 +302,6 @@ jobs:
             export PADDLEFLEET_VERSION=$VERSION
           fi
           export IS_NVIDIA=True
-          # Enable ccache for C++/CUDA compilation if available in the image.
-          # CCACHE_DIR points to CFS so the cache persists across CI runs.
           if command -v ccache &>/dev/null; then
             export CCACHE_DIR=/home/.cache/ccache
             export CCACHE_MAXSIZE=20G

--- a/.github/workflows/publish_wheel_nightly.yml
+++ b/.github/workflows/publish_wheel_nightly.yml
@@ -113,8 +113,6 @@ jobs:
             export PADDLEFLEET_VERSION=$VERSION
           fi
           export IS_NVIDIA=True
-          # Enable ccache for C++/CUDA compilation if available in the image.
-          # CCACHE_DIR points to CFS so the cache persists across CI runs.
           if command -v ccache &>/dev/null; then
             export CCACHE_DIR=/home/.cache/ccache
             export CCACHE_MAXSIZE=20G
@@ -144,11 +142,11 @@ jobs:
             python ../bos/BosClient.py paddlefleet-*.whl paddle-whl/nightly/cu130/paddlefleet
             export AK=paddle
             export SK=paddle
-            python ../bos/BosClient.py paddlefleet-*.whl paddle-github-action/PaddleFleet/${BRANCH}/${COMMIT_ID}/${{ matrix.cuda.bos_CUDA }}
+            python ../bos/BosClient.py paddlefleet-*.whl paddle-github-action/PaddleFleet/${BRANCH}/${COMMIT_ID}
             # Rename to stable "latest" filenames for compatibility
             mv paddlefleet-*.whl paddlefleet-0.0.0-cp${PY_VERSION_SHORT}-cp${PY_VERSION_SHORT}-linux_x86_64.whl
             for whl in *-0.0.0-cp${PY_VERSION_SHORT}-cp${PY_VERSION_SHORT}-linux_x86_64.whl; do
-              python ../bos/BosClient.py ${whl} paddle-github-action/PaddleFleet/${BRANCH}/latest/${{ matrix.cuda.bos_CUDA }}
+              python ../bos/BosClient.py ${whl} paddle-github-action/PaddleFleet/${BRANCH}/latest
             done
           elif [[ "${{ github.ref_type }}" == "tag" ]]; then
             python ../bos/BosClient.py paddlefleet-*.whl paddle-whl/stable/cu126/paddlefleet
@@ -160,9 +158,9 @@ jobs:
             python ../bos/BosClient.py paddlefleet-*.whl paddle-whl/nightly/cu130/paddlefleet
             export AK=paddle
             export SK=paddle
-            python ../bos/BosClient.py paddlefleet-*.whl paddle-github-action/PaddleFleet/${BRANCH}/${COMMIT_ID}/${{ matrix.cuda.bos_CUDA }}
+            python ../bos/BosClient.py paddlefleet-*.whl paddle-github-action/PaddleFleet/${BRANCH}/${COMMIT_ID}
             mv paddlefleet-*.whl paddlefleet-0.0.0-cp${PY_VERSION_SHORT}-cp${PY_VERSION_SHORT}-linux_x86_64.whl
-            python ../bos/BosClient.py paddlefleet-*.whl paddle-github-action/PaddleFleet/${BRANCH}/latest/${{ matrix.cuda.bos_CUDA }}
+            python ../bos/BosClient.py paddlefleet-*.whl paddle-github-action/PaddleFleet/${BRANCH}/latest
           fi
           curl https://www.paddlepaddle.org.cn/inner/whl/update/path/new
           '
@@ -281,11 +279,11 @@ jobs:
             python ../bos/BosClient.py paddlefleet-*.whl paddle-whl/nightly/${{ matrix.cuda.bos_CUDA }}/paddlefleet
             export AK=paddle
             export SK=paddle
-            python ../bos/BosClient.py paddlefleet-*.whl paddle-github-action/PaddleFleet/${BRANCH}/${COMMIT_ID}/${{ matrix.cuda.bos_CUDA }}
+            python ../bos/BosClient.py paddlefleet-*.whl paddle-github-action/PaddleFleet/${BRANCH}/${COMMIT_ID}
             PY_VERSION="${{ matrix.python_version }}"
             PY_VERSION_SHORT="${PY_VERSION//./}"
             mv paddlefleet-*.whl paddlefleet-0.0.0-cp${PY_VERSION_SHORT}-cp${PY_VERSION_SHORT}-linux_aarch64.whl
-            python ../bos/BosClient.py paddlefleet-0.0.0-cp${PY_VERSION_SHORT}-cp${PY_VERSION_SHORT}-linux_aarch64.whl paddle-github-action/PaddleFleet/${BRANCH}/latest/${{ matrix.cuda.bos_CUDA }}
+            python ../bos/BosClient.py paddlefleet-0.0.0-cp${PY_VERSION_SHORT}-cp${PY_VERSION_SHORT}-linux_aarch64.whl paddle-github-action/PaddleFleet/${BRANCH}/latest
           fi
           curl https://www.paddlepaddle.org.cn/inner/whl/update/path/new
           '

--- a/.github/workflows/publish_wheel_nightly.yml
+++ b/.github/workflows/publish_wheel_nightly.yml
@@ -107,8 +107,6 @@ jobs:
           export UV_PYTHON=${{ matrix.python_version }}
           source /root/proxy
           git submodule update --init --recursive
-          # if [[ "${{ github.event_name }}" == "push" && "${{ github.ref_type }}" == "branch" ]]; then
-          #   export PADDLEFLEET_VERSION=$(cat version.txt).post$(git log -1 --format=%cd --date=format:%Y%m%d)+${{ matrix.cuda.bos_CUDA }}.$(git rev-parse --short=11 HEAD)
           if [[ "${{ github.event_name }}" == "push" && "${{ github.ref_type }}" == "tag" ]]; then
             TAG_NAME="${{ github.ref_name }}"
             VERSION="${TAG_NAME#v}"
@@ -127,7 +125,6 @@ jobs:
             echo "[build] ccache enabled, CCACHE_DIR=${CCACHE_DIR}"
           fi
           uv build --wheel --package paddlefleet --out-dir dist --clear -v
-          # uv build --wheel --package paddlefleet-ops --out-dir dist -v
           '
 
       - name: Upload wheel
@@ -143,8 +140,8 @@ jobs:
           PY_VERSION_SHORT="${PY_VERSION//./}"
           if [[ "${{ github.event_name }}" != "push" ]]; then
             python ../bos/BosClient.py paddlefleet-*.whl paddle-whl/nightly/cu126/paddlefleet
-            python ../bos/BosClient.py paddlefleet-*.whl paddle-whl/nightly/cu126/paddlefleet
-            python ../bos/BosClient.py paddlefleet-*.whl paddle-whl/nightly/cu126/paddlefleet
+            python ../bos/BosClient.py paddlefleet-*.whl paddle-whl/nightly/cu129/paddlefleet
+            python ../bos/BosClient.py paddlefleet-*.whl paddle-whl/nightly/cu130/paddlefleet
             export AK=paddle
             export SK=paddle
             python ../bos/BosClient.py paddlefleet-*.whl paddle-github-action/PaddleFleet/${BRANCH}/${COMMIT_ID}/${{ matrix.cuda.bos_CUDA }}
@@ -253,8 +250,6 @@ jobs:
           export UV_PYTHON=${{ matrix.python_version }}
           source /root/proxy
           git submodule update --init --recursive
-          # if [[ "${{ github.event_name }}" == "push" && "${{ github.ref_type }}" == "branch" ]]; then
-          #   export PADDLEFLEET_VERSION=$(cat version.txt).post$(git log -1 --format=%cd --date=format:%Y%m%d)+$(git rev-parse --short=11 HEAD)
           if [[ "${{ github.event_name }}" == "push" && "${{ github.ref_type }}" == "tag" ]]; then
             TAG_NAME="${{ github.ref_name }}"
             VERSION="${TAG_NAME#v}"

--- a/.github/workflows/publish_wheel_nightly.yml
+++ b/.github/workflows/publish_wheel_nightly.yml
@@ -142,7 +142,9 @@ jobs:
           PY_VERSION="${{ matrix.python_version }}"
           PY_VERSION_SHORT="${PY_VERSION//./}"
           if [[ "${{ github.event_name }}" != "push" ]]; then
-            python ../bos/BosClient.py paddlefleet-*.whl paddle-whl/nightly/${{ matrix.cuda.bos_CUDA }}/paddlefleet
+            python ../bos/BosClient.py paddlefleet-*.whl paddle-whl/nightly/cu126/paddlefleet
+            python ../bos/BosClient.py paddlefleet-*.whl paddle-whl/nightly/cu126/paddlefleet
+            python ../bos/BosClient.py paddlefleet-*.whl paddle-whl/nightly/cu126/paddlefleet
             export AK=paddle
             export SK=paddle
             python ../bos/BosClient.py paddlefleet-*.whl paddle-github-action/PaddleFleet/${BRANCH}/${COMMIT_ID}/${{ matrix.cuda.bos_CUDA }}
@@ -152,9 +154,13 @@ jobs:
               python ../bos/BosClient.py ${whl} paddle-github-action/PaddleFleet/${BRANCH}/latest/${{ matrix.cuda.bos_CUDA }}
             done
           elif [[ "${{ github.ref_type }}" == "tag" ]]; then
-            python ../bos/BosClient.py paddlefleet-*.whl paddle-whl/stable/${{ matrix.cuda.bos_CUDA }}/paddlefleet
+            python ../bos/BosClient.py paddlefleet-*.whl paddle-whl/stable/cu126/paddlefleet
+            python ../bos/BosClient.py paddlefleet-*.whl paddle-whl/stable/cu129/paddlefleet
+            python ../bos/BosClient.py paddlefleet-*.whl paddle-whl/stable/cu130/paddlefleet
           else
-            python ../bos/BosClient.py paddlefleet-*.whl paddle-whl/nightly/${{ matrix.cuda.bos_CUDA }}/paddlefleet
+            python ../bos/BosClient.py paddlefleet-*.whl paddle-whl/nightly/cu126/paddlefleet
+            python ../bos/BosClient.py paddlefleet-*.whl paddle-whl/nightly/cu129/paddlefleet
+            python ../bos/BosClient.py paddlefleet-*.whl paddle-whl/nightly/cu130/paddlefleet
             export AK=paddle
             export SK=paddle
             python ../bos/BosClient.py paddlefleet-*.whl paddle-github-action/PaddleFleet/${BRANCH}/${COMMIT_ID}/${{ matrix.cuda.bos_CUDA }}

--- a/.github/workflows/publish_wheel_nightly.yml
+++ b/.github/workflows/publish_wheel_nightly.yml
@@ -1,14 +1,6 @@
 name: Publish wheel nightly
 
 on:
-  # workflow_dispatch:
-  #   inputs:
-  #     job-name:
-  #       required: true
-  #       default: 'publish-wheel'
-  #       type: choice
-  #       options:
-  #         - publish-wheel
   schedule:
     - cron: '0 16 * * *'
   push:
@@ -50,13 +42,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: ["3.10", "3.11", "3.12", "3.13"]
+        python_version: ["3.12"]
         cuda:
-          - {CUDA_VERSION: CUDA12.6, IMAGE_TAG: cuda12.6-cudnn9.5-trt10.5-gcc11, bos_CUDA: cu126, CUDA_ARCH_LIST: "8.0;9.0"}
-          - {CUDA_VERSION: CUDA12.9, IMAGE_TAG: cuda12.9-cudnn9.9-trt10.5-gcc11, bos_CUDA: cu129, CUDA_ARCH_LIST: "8.0;9.0;10.0;10.3"}
           - {CUDA_VERSION: CUDA13.0, IMAGE_TAG: cuda13.0-cudnn9.13-trt10.13-gcc11, bos_CUDA: cu130, CUDA_ARCH_LIST: "8.0;9.0;10.0;10.3"}
     env:
-      TASK: PaddleFleet-nightly-${{ matrix.cuda.CUDA_VERSION }}
+      TASK: PaddleFleet-nightly
       PIP_CACHE_DIR: /home/.cache/pip
       CACHE_DIR: /home/.cache
       UV_HTTP_TIMEOUT: 600
@@ -117,9 +107,9 @@ jobs:
           export UV_PYTHON=${{ matrix.python_version }}
           source /root/proxy
           git submodule update --init --recursive
-          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref_type }}" == "branch" ]]; then
-            export PADDLEFLEET_VERSION=$(cat version.txt).post$(git log -1 --format=%cd --date=format:%Y%m%d)+${{ matrix.cuda.bos_CUDA }}.$(git rev-parse --short=11 HEAD)
-          elif [[ "${{ github.event_name }}" == "push" && "${{ github.ref_type }}" == "tag" ]]; then
+          # if [[ "${{ github.event_name }}" == "push" && "${{ github.ref_type }}" == "branch" ]]; then
+          #   export PADDLEFLEET_VERSION=$(cat version.txt).post$(git log -1 --format=%cd --date=format:%Y%m%d)+${{ matrix.cuda.bos_CUDA }}.$(git rev-parse --short=11 HEAD)
+          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref_type }}" == "tag" ]]; then
             TAG_NAME="${{ github.ref_name }}"
             VERSION="${TAG_NAME#v}"
             export PADDLEFLEET_VERSION=$VERSION
@@ -137,7 +127,7 @@ jobs:
             echo "[build] ccache enabled, CCACHE_DIR=${CCACHE_DIR}"
           fi
           uv build --wheel --package paddlefleet --out-dir dist --clear -v
-          uv build --wheel --package paddlefleet-ops --out-dir dist -v
+          # uv build --wheel --package paddlefleet-ops --out-dir dist -v
           '
 
       - name: Upload wheel
@@ -152,39 +142,24 @@ jobs:
           PY_VERSION="${{ matrix.python_version }}"
           PY_VERSION_SHORT="${PY_VERSION//./}"
           if [[ "${{ github.event_name }}" != "push" ]]; then
-            # Upload both paddlefleet and paddlefleet_ops wheels
-            for whl in paddlefleet-*.whl paddlefleet_ops-*.whl; do
-              python ../bos/BosClient.py ${whl} paddle-whl/nightly/${{ matrix.cuda.bos_CUDA }}/paddlefleet
-            done
+            python ../bos/BosClient.py paddlefleet-*.whl paddle-whl/nightly/${{ matrix.cuda.bos_CUDA }}/paddlefleet
             export AK=paddle
             export SK=paddle
-            for whl in paddlefleet-*.whl paddlefleet_ops-*.whl; do
-              python ../bos/BosClient.py ${whl} paddle-github-action/PaddleFleet/${BRANCH}/${COMMIT_ID}/${{ matrix.cuda.bos_CUDA }}
-            done
+            python ../bos/BosClient.py paddlefleet-*.whl paddle-github-action/PaddleFleet/${BRANCH}/${COMMIT_ID}/${{ matrix.cuda.bos_CUDA }}
             # Rename to stable "latest" filenames for compatibility
             mv paddlefleet-*.whl paddlefleet-0.0.0-cp${PY_VERSION_SHORT}-cp${PY_VERSION_SHORT}-linux_x86_64.whl
-            mv paddlefleet_ops-*.whl paddlefleet_ops-0.0.0-cp${PY_VERSION_SHORT}-cp${PY_VERSION_SHORT}-linux_x86_64.whl
             for whl in *-0.0.0-cp${PY_VERSION_SHORT}-cp${PY_VERSION_SHORT}-linux_x86_64.whl; do
               python ../bos/BosClient.py ${whl} paddle-github-action/PaddleFleet/${BRANCH}/latest/${{ matrix.cuda.bos_CUDA }}
             done
           elif [[ "${{ github.ref_type }}" == "tag" ]]; then
-            for whl in paddlefleet-*.whl paddlefleet_ops-*.whl; do
-              python ../bos/BosClient.py ${whl} paddle-whl/stable/${{ matrix.cuda.bos_CUDA }}/paddlefleet
-            done
+            python ../bos/BosClient.py paddlefleet-*.whl paddle-whl/stable/${{ matrix.cuda.bos_CUDA }}/paddlefleet
           else
-            for whl in paddlefleet-*.whl paddlefleet_ops-*.whl; do
-              python ../bos/BosClient.py ${whl} paddle-whl/nightly/${{ matrix.cuda.bos_CUDA }}/paddlefleet
-            done
+            python ../bos/BosClient.py paddlefleet-*.whl paddle-whl/nightly/${{ matrix.cuda.bos_CUDA }}/paddlefleet
             export AK=paddle
             export SK=paddle
-            for whl in paddlefleet-*.whl paddlefleet_ops-*.whl; do
-              python ../bos/BosClient.py ${whl} paddle-github-action/PaddleFleet/${BRANCH}/${COMMIT_ID}/${{ matrix.cuda.bos_CUDA }}
-            done
+            python ../bos/BosClient.py paddlefleet-*.whl paddle-github-action/PaddleFleet/${BRANCH}/${COMMIT_ID}/${{ matrix.cuda.bos_CUDA }}
             mv paddlefleet-*.whl paddlefleet-0.0.0-cp${PY_VERSION_SHORT}-cp${PY_VERSION_SHORT}-linux_x86_64.whl
-            mv paddlefleet_ops-*.whl paddlefleet_ops-0.0.0-cp${PY_VERSION_SHORT}-cp${PY_VERSION_SHORT}-linux_x86_64.whl
-            for whl in *-0.0.0-cp${PY_VERSION_SHORT}-cp${PY_VERSION_SHORT}-linux_x86_64.whl; do
-              python ../bos/BosClient.py ${whl} paddle-github-action/PaddleFleet/${BRANCH}/latest/${{ matrix.cuda.bos_CUDA }}
-            done
+            python ../bos/BosClient.py paddlefleet-*.whl paddle-github-action/PaddleFleet/${BRANCH}/latest/${{ matrix.cuda.bos_CUDA }}
           fi
           curl https://www.paddlepaddle.org.cn/inner/whl/update/path/new
           '
@@ -272,9 +247,9 @@ jobs:
           export UV_PYTHON=${{ matrix.python_version }}
           source /root/proxy
           git submodule update --init --recursive
-          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref_type }}" == "branch" ]]; then
-            export PADDLEFLEET_VERSION=$(cat version.txt).post$(git log -1 --format=%cd --date=format:%Y%m%d)+$(git rev-parse --short=11 HEAD)
-          elif [[ "${{ github.event_name }}" == "push" && "${{ github.ref_type }}" == "tag" ]]; then
+          # if [[ "${{ github.event_name }}" == "push" && "${{ github.ref_type }}" == "branch" ]]; then
+          #   export PADDLEFLEET_VERSION=$(cat version.txt).post$(git log -1 --format=%cd --date=format:%Y%m%d)+$(git rev-parse --short=11 HEAD)
+          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref_type }}" == "tag" ]]; then
             TAG_NAME="${{ github.ref_name }}"
             VERSION="${TAG_NAME#v}"
             export PADDLEFLEET_VERSION=$VERSION


### PR DESCRIPTION
适配ops编包
手动编包删除多余逻辑，只生成python包
PR更新ops时，合入后把CI里的包上传到源暂时给后续PR用，同时触发全cuda全python ops更新，最终更新源
nightly编包只生成python包
CI检查是否修改了ops，修改的话则编，且编一份py310的包给paddle流水线用