### PR TITLE
Scalar-Gated Embedding for Final Decoder Layer

### DIFF
--- a/src/paddlefleet/models/gpt/gpt_embedding.py
+++ b/src/paddlefleet/models/gpt/gpt_embedding.py
@@ -450,6 +450,12 @@ class GPTEmbedding(FleetLayer):
             hidden_states_concat = paddle.concat(mtp_emb_res)
             preproc_output["hidden_states"] = hidden_states_concat
 
+        if getattr(self.config, 'use_embedding_gating', False):
+            if mtp_emb_res is not None:
+                preproc_output["embedding_for_gating"] = mtp_emb_res[0]
+            else:
+                preproc_output["embedding_for_gating"] = decoder_input
+
         for key in list(preproc_output.keys()):
             if preproc_output[key] is None:
                 preproc_output.pop(key)

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -87,16 +87,12 @@ class TransformerConfig(ModelParallelConfig):
     0 implies equal layer division across PP ranks."""
 
     use_embedding_gating: bool = False
-    """When True, apply scalar gating to fuse initial embedding into the last decoder layer input.
-    Formula: h_in^L = alpha * h_out^{L-1} + beta * e_0
-    reference for Nanochat: https://github.com/karpathy/nanochat/blob/master/nanochat/gpt.py
-    """
+    """When True, apply sigmoid gating to fuse initial embedding into the last decoder layer output.
+    Formula: h_out = h_in + h_in * sigmoid(W @ e), where W is a learnable matrix of shape [hidden_size, hidden_size]."""
 
-    embedding_gating_alpha_init: float = 1.05
-    """Initial value of the embedding gating alpha parameter."""
-
-    embedding_gating_beta_init: float = 0.05
-    """Initial value of the embedding gating beta parameter."""
+    embedding_gating_gate_zero_init: bool = True
+    """If True, initialize gate weight matrix W to zero so gate = sigmoid(0) ≈ 0.5 initially.
+    This minimizes disruption at the start of training."""
 
     # Note: need to implement PipelineParallelLayerLayout and import
     # pipeline_model_parallel_layout: str | list | PipelineParallelLayerLayout = None

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -88,10 +88,15 @@ class TransformerConfig(ModelParallelConfig):
 
     use_embedding_gating: bool = False
     """When True, apply scalar gating to fuse initial embedding into the last decoder layer input.
-    Formula: h_in^L = alpha * h_out^{L-1} + (1 - alpha) * e_0"""
+    Formula: h_in^L = alpha * h_out^{L-1} + beta * e_0
+    reference for Nanochat: https://github.com/karpathy/nanochat/blob/master/nanochat/gpt.py
+    """
 
-    embedding_gating_alpha_init: float = 1.0
+    embedding_gating_alpha_init: float = 1.05
     """Initial value of the embedding gating alpha parameter."""
+
+    embedding_gating_beta_init: float = 0.05
+    """Initial value of the embedding gating beta parameter."""
 
     # Note: need to implement PipelineParallelLayerLayout and import
     # pipeline_model_parallel_layout: str | list | PipelineParallelLayerLayout = None

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -86,6 +86,13 @@ class TransformerConfig(ModelParallelConfig):
         ..., Decoder, Dcoder, EmptyLayer, EmptyLayer
     0 implies equal layer division across PP ranks."""
 
+    use_embedding_gating: bool = False
+    """When True, apply scalar gating to fuse initial embedding into the last decoder layer input.
+    Formula: h_in^L = alpha * h_out^{L-1} + (1 - alpha) * e_0"""
+
+    embedding_gating_alpha_init: float = 0.95
+    """Initial value of the embedding gating alpha parameter."""
+
     # Note: need to implement PipelineParallelLayerLayout and import
     # pipeline_model_parallel_layout: str | list | PipelineParallelLayerLayout = None
     pipeline_model_parallel_layout: str | list = None

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -90,7 +90,7 @@ class TransformerConfig(ModelParallelConfig):
     """When True, apply scalar gating to fuse initial embedding into the last decoder layer input.
     Formula: h_in^L = alpha * h_out^{L-1} + (1 - alpha) * e_0"""
 
-    embedding_gating_alpha_init: float = 0.95
+    embedding_gating_alpha_init: float = 1.0
     """Initial value of the embedding gating alpha parameter."""
 
     # Note: need to implement PipelineParallelLayerLayout and import

--- a/src/paddlefleet/transformer/transformer_layer.py
+++ b/src/paddlefleet/transformer/transformer_layer.py
@@ -56,6 +56,39 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+import paddle.nn.functional as F
+
+
+class SigmoidGate(nn.Layer):
+    """Per-token sigmoid gate for embedding fusion with full matrix.
+
+    Formula: gate = sigmoid(W @ e)
+    Output: h_out = h_in + h_in * gate
+
+    Args:
+        hidden_size: Hidden dimension of the model
+        zero_init: If True, initialize W to zero for gate ≈ 0.5
+    """
+
+    def __init__(self, hidden_size: int, zero_init: bool = True):
+        super().__init__()
+        self.W = nn.Linear(hidden_size, hidden_size, bias_attr=False)
+        self._cast_to_low_precision = False
+
+        if zero_init:
+            nn.initializer.Constant(0.0)(self.W.weight)
+
+    def forward(self, embedding: paddle.Tensor) -> paddle.Tensor:
+        """Compute gate values from embedding.
+
+        Args:
+            embedding: [B, S, H] or [S, B, H]
+
+        Returns:
+            gate: Same shape as embedding, values in [0, 1]
+        """
+        return F.sigmoid(self.W(embedding))
+
 
 def tensors_clone(outputs):
     """
@@ -404,7 +437,7 @@ class TransformerLayer(nn.Layer):
             )
             self.attn_res_block_size = self.config.attn_res_block_size
 
-        # [Layer 11: Embedding Gating] Scalar gate for last decoder layer
+        # [Layer 11: Embedding Gating] Sigmoid gate for last decoder layer
         self.use_embedding_gating = getattr(self.config, 'use_embedding_gating', False)
         num_empty = getattr(self.config, 'num_empty_layers_add_in_head', 0) or 0
         self._is_last_decoder_layer = (
@@ -412,24 +445,13 @@ class TransformerLayer(nn.Layer):
             and self.layer_number == num_empty + self.config.num_hidden_layers - 1
         )
         if self._is_last_decoder_layer:
-            alpha_init = getattr(self.config, 'embedding_gating_alpha_init', 1.05)
-            beta_init = getattr(self.config, 'embedding_gating_beta_init', 0.05)
-            self.embedding_gate = nn.Layer()
-            self.embedding_gate._cast_to_low_precision = False
-            self.embedding_gate.alpha = paddle.create_parameter(
-                shape=[1],
-                dtype='float32',
-                default_initializer=paddle.nn.initializer.Constant(alpha_init),
-            )
-            self.embedding_gate.beta = paddle.create_parameter(
-                shape=[1],
-                dtype='float32',
-                default_initializer=paddle.nn.initializer.Constant(beta_init),
-            )
+            zero_init = getattr(self.config, 'embedding_gating_gate_zero_init', True)
+            hidden_size = self.config.hidden_size
+            self.embedding_gate = SigmoidGate(hidden_size, zero_init)
             self._embedding_for_gating = None
             logger.info(
-                f"[EmbeddingGating(nanochat-like)] Enabled on layer {self.layer_number} "
-                f"alpha_init={alpha_init}, beta_init={beta_init}"
+                f"[EmbeddingGating(Sigmoid)] Enabled on layer {self.layer_number}. "
+                f"hidden_size={hidden_size}, zero_init={zero_init}"
             )
 
     def build_schedule_node(self):
@@ -638,12 +660,13 @@ class TransformerLayer(nn.Layer):
 
         # --- Embedding Gating: applied OUTSIDE recompute to avoid SliceGradNode clearing ---
         if self._is_last_decoder_layer and self._embedding_for_gating is not None:
-            alpha = self.embedding_gate.alpha.astype(output.dtype)
-            beta = self.embedding_gate.beta.astype(output.dtype)
-            output = alpha * output + beta * self._embedding_for_gating
+            dtype = output.dtype
+            emb = self._embedding_for_gating.astype(dtype)
+            gate = self.embedding_gate(emb)
+            output = output + output * gate
             logger.info(
-                f"[EmbeddingGating(nanochat-like)] alpha={float(self.embedding_gate.alpha.item()):.16f},"
-                f" beta={float(self.embedding_gate.beta.item()):.16f}"
+                f"[EmbeddingGating] gate_mean={float(gate.mean()):.6f}, "
+                f"gate_std={float(gate.std()):.6f}"
             )
             self._embedding_for_gating = None
 

--- a/src/paddlefleet/transformer/transformer_layer.py
+++ b/src/paddlefleet/transformer/transformer_layer.py
@@ -404,6 +404,28 @@ class TransformerLayer(nn.Layer):
             )
             self.attn_res_block_size = self.config.attn_res_block_size
 
+        # [Layer 11: Embedding Gating] Scalar gate for last decoder layer
+        self.use_embedding_gating = getattr(self.config, 'use_embedding_gating', False)
+        num_empty = getattr(self.config, 'num_empty_layers_add_in_head', 0) or 0
+        self._is_last_decoder_layer = (
+            self.use_embedding_gating
+            and self.layer_number == num_empty + self.config.num_hidden_layers - 1
+        )
+        if self._is_last_decoder_layer:
+            alpha_init = getattr(self.config, 'embedding_gating_alpha_init', 0.95)
+            self.embedding_gate = nn.Layer()
+            self.embedding_gate._cast_to_low_precision = False
+            self.embedding_gate.alpha = paddle.create_parameter(
+                shape=[1],
+                dtype='float32',
+                default_initializer=paddle.nn.initializer.Constant(alpha_init),
+            )
+            self._embedding_for_gating = None
+            logger.info(
+                f"[EmbeddingGating] Enabled on layer {self.layer_number} "
+                f"(last decoder layer). alpha_init={alpha_init}"
+            )
+
     def build_schedule_node(self):
         return TransformerLayerNode(
             self,
@@ -552,6 +574,11 @@ class TransformerLayer(nn.Layer):
                 # mtp masks are in mtp_startend_row_indices_all and will be used by MTP layer directly
                 attn_mask_startend_row_indices_mtp = None
 
+        # --- Embedding Gating: store for use inside _forward_impl ---
+        if self._is_last_decoder_layer:
+            _emb = dict_args.pop("embedding_for_gating", None)
+            self._embedding_for_gating = _emb.detach() if _emb is not None else None
+
         if self.config.block_attention_residuals and "blocks" not in dict_args:
             dict_args["blocks"] = []
 
@@ -678,6 +705,12 @@ class TransformerLayer(nn.Layer):
         input_ids: Tensor | None = None,
         **kwargs,
     ):
+        # --- Embedding Gating: fuse initial embedding (accessed via self to work with recompute) ---
+        if self._is_last_decoder_layer and self._embedding_for_gating is not None:
+            alpha = self.embedding_gate.alpha.astype(hidden_states.dtype)
+            hidden_states = alpha * hidden_states + (1.0 - alpha) * self._embedding_for_gating
+            logger.info(f"[EmbeddingGating] alpha={float(self.embedding_gate.alpha.item()):.8f}")
+
         timer_name = "moe-mlp" if isinstance(self.mlp, MoELayer) else "mlp"
         if self.config.block_attention_residuals:
             blocks = kwargs.get("blocks", [])

--- a/src/paddlefleet/transformer/transformer_layer.py
+++ b/src/paddlefleet/transformer/transformer_layer.py
@@ -574,10 +574,10 @@ class TransformerLayer(nn.Layer):
                 # mtp masks are in mtp_startend_row_indices_all and will be used by MTP layer directly
                 attn_mask_startend_row_indices_mtp = None
 
-        # --- Embedding Gating: store for use inside _forward_impl ---
+        # --- Embedding Gating: store for use AFTER recompute ---
         if self._is_last_decoder_layer:
             _emb = dict_args.pop("embedding_for_gating", None)
-            self._embedding_for_gating = _emb.detach() if _emb is not None else None
+            self._embedding_for_gating = _emb
 
         if self.config.block_attention_residuals and "blocks" not in dict_args:
             dict_args["blocks"] = []
@@ -629,6 +629,13 @@ class TransformerLayer(nn.Layer):
             output, context = outputs[0], outputs[1]
         else:
             output, context = outputs, None
+
+        # --- Embedding Gating: applied OUTSIDE recompute to avoid SliceGradNode clearing ---
+        if self._is_last_decoder_layer and self._embedding_for_gating is not None:
+            alpha = self.embedding_gate.alpha.astype(output.dtype)
+            output = alpha * output + (1.0 - alpha) * self._embedding_for_gating
+            logger.info(f"[EmbeddingGating] alpha={float(self.embedding_gate.alpha.item()):.8f}")
+            self._embedding_for_gating = None
 
         rst = OrderedDict()
         rst = {"hidden_states": output}
@@ -705,12 +712,6 @@ class TransformerLayer(nn.Layer):
         input_ids: Tensor | None = None,
         **kwargs,
     ):
-        # --- Embedding Gating: fuse initial embedding (accessed via self to work with recompute) ---
-        if self._is_last_decoder_layer and self._embedding_for_gating is not None:
-            alpha = self.embedding_gate.alpha.astype(hidden_states.dtype)
-            hidden_states = alpha * hidden_states + (1.0 - alpha) * self._embedding_for_gating
-            logger.info(f"[EmbeddingGating] alpha={float(self.embedding_gate.alpha.item()):.8f}")
-
         timer_name = "moe-mlp" if isinstance(self.mlp, MoELayer) else "mlp"
         if self.config.block_attention_residuals:
             blocks = kwargs.get("blocks", [])

--- a/src/paddlefleet/transformer/transformer_layer.py
+++ b/src/paddlefleet/transformer/transformer_layer.py
@@ -412,7 +412,8 @@ class TransformerLayer(nn.Layer):
             and self.layer_number == num_empty + self.config.num_hidden_layers - 1
         )
         if self._is_last_decoder_layer:
-            alpha_init = getattr(self.config, 'embedding_gating_alpha_init', 0.95)
+            alpha_init = getattr(self.config, 'embedding_gating_alpha_init', 1.05)
+            beta_init = getattr(self.config, 'embedding_gating_beta_init', 0.05)
             self.embedding_gate = nn.Layer()
             self.embedding_gate._cast_to_low_precision = False
             self.embedding_gate.alpha = paddle.create_parameter(
@@ -420,10 +421,15 @@ class TransformerLayer(nn.Layer):
                 dtype='float32',
                 default_initializer=paddle.nn.initializer.Constant(alpha_init),
             )
+            self.embedding_gate.beta = paddle.create_parameter(
+                shape=[1],
+                dtype='float32',
+                default_initializer=paddle.nn.initializer.Constant(beta_init),
+            )
             self._embedding_for_gating = None
             logger.info(
-                f"[EmbeddingGating] Enabled on layer {self.layer_number} "
-                f"(last decoder layer). alpha_init={alpha_init}"
+                f"[EmbeddingGating(nanochat-like)] Enabled on layer {self.layer_number} "
+                f"alpha_init={alpha_init}, beta_init={beta_init}"
             )
 
     def build_schedule_node(self):
@@ -633,8 +639,12 @@ class TransformerLayer(nn.Layer):
         # --- Embedding Gating: applied OUTSIDE recompute to avoid SliceGradNode clearing ---
         if self._is_last_decoder_layer and self._embedding_for_gating is not None:
             alpha = self.embedding_gate.alpha.astype(output.dtype)
-            output = alpha * output + (1.0 - alpha) * self._embedding_for_gating
-            logger.info(f"[EmbeddingGating] alpha={float(self.embedding_gate.alpha.item()):.8f}")
+            beta = self.embedding_gate.beta.astype(output.dtype)
+            output = alpha * output + beta * self._embedding_for_gating
+            logger.info(
+                f"[EmbeddingGating(nanochat-like)] alpha={float(self.embedding_gate.alpha.item()):.16f},"
+                f" beta={float(self.embedding_gate.beta.item()):.16f}"
+            )
             self._embedding_for_gating = None
 
         rst = OrderedDict()


### PR DESCRIPTION
## Summary                                                                                                      
                                                                                                                 
Add a learnable scalar gate that fuses the initial embedding back into the last decoder layer's input, enabling the model to retain a direct residual connection to the original token representation through training.       
                                                                                                                 
Formula: h_in^L = alpha * h_out^{L-1} + (1 - alpha) * e_0                                                      
   
Where alpha is a learnable scalar parameter initialized to 1.0 (i.e., no-op at initialization, gradually blending in embedding signal as training progresses).     
                                                                                                                 
## Changes                                                                                                        
   
- transformer_config.py: Add use_embedding_gating (bool) and embedding_gating_alpha_init (float, default 1.0) config fields.
- gpt_embedding.py: Pass embedding_for_gating (the initial embedding tensor) through preproc_output so it's available to downstream layers. Uses mtp_emb_res[0] when MTP is active, otherwise decoder_input.               
- transformer_layer.py:
    - Create a learnable alpha parameter on the last decoder layer (determined by num_hidden_layers + num_empty_layers_add_in_head).                                                                                 
    - Apply the gating operation outside the recompute() scope to avoid SliceGradNode tensor wrapper clearing during recompute's forward replay.                                                                             
                                                            
## Why gating is placed outside recompute                                                                         
                                                            
When recompute_granularity=full, the _forward_impl function runs twice (once for forward, once for gradient recomputation). The embedding_for_gating tensor originates from a slice operation in the embedding layer. If gating is applied inside _forward_impl, the slice op's tensor wrappers get cleared after the first forward pass, causing a SliceGradNode crash during backward. Moving the gating to after the recompute call avoids this entirely — the embedding tensor's computation graph remains intact.

## Configuration                                                                                                  

```yaml
model_config:                                                                                                  
    use_embedding_gating: true                                                                                 
    embedding_gating_alpha_init: 1.0                                                                           
```