### PR TITLE
Add attention sink support to DotProductAttention.

### DIFF
--- a/src/paddlefleet/fusions/fused_softmax.py
+++ b/src/paddlefleet/fusions/fused_softmax.py
@@ -47,7 +47,7 @@ class SoftmaxOne(nn.Layer):
         # qk: [b, np, sq, sk] --> [b, np, sq, sk+1]
         qk = paddle.concat([x, sink], axis=-1)
         # do softmax, and remove sink token at the end
-        ret = paddle.softmax(qk, axis=-1)[..., :-1]
+        ret = paddle.nn.functional.softmax(qk, axis=-1)[..., :-1]
         return ret
 
 

--- a/src/paddlefleet/transformer/attention.py
+++ b/src/paddlefleet/transformer/attention.py
@@ -353,6 +353,7 @@ class Attention(FleetLayer, ABC):
         attention_bias: Tensor | None = None,
         packed_seq_params: Tensor | None = None,
         in_recompute: bool = False,
+        sink: Tensor | None = None,
     ) -> tuple[Tensor, Tensor]:
         """
         Perform a forward pass through the attention layer.
@@ -565,6 +566,7 @@ class Attention(FleetLayer, ABC):
                 attention_bias=attention_bias,
                 packed_seq_params=packed_seq_params,
                 use_rr_flash_attention=self.use_rr_flash_attention,
+                sink=sink,
             )
         else:
             # Static batching attention kernel.
@@ -579,6 +581,7 @@ class Attention(FleetLayer, ABC):
                 packed_seq_params=packed_seq_params,
                 use_rr_flash_attention=self.use_rr_flash_attention
                 and in_recompute,
+                sink=sink,
             )
         # =================
         # Output. [b, sq, h]

--- a/src/paddlefleet/transformer/attention.py
+++ b/src/paddlefleet/transformer/attention.py
@@ -353,7 +353,6 @@ class Attention(FleetLayer, ABC):
         attention_bias: Tensor | None = None,
         packed_seq_params: Tensor | None = None,
         in_recompute: bool = False,
-        sink: Tensor | None = None,
     ) -> tuple[Tensor, Tensor]:
         """
         Perform a forward pass through the attention layer.
@@ -566,7 +565,6 @@ class Attention(FleetLayer, ABC):
                 attention_bias=attention_bias,
                 packed_seq_params=packed_seq_params,
                 use_rr_flash_attention=self.use_rr_flash_attention,
-                sink=sink,
             )
         else:
             # Static batching attention kernel.
@@ -581,7 +579,6 @@ class Attention(FleetLayer, ABC):
                 packed_seq_params=packed_seq_params,
                 use_rr_flash_attention=self.use_rr_flash_attention
                 and in_recompute,
-                sink=sink,
             )
         # =================
         # Output. [b, sq, h]

--- a/src/paddlefleet/transformer/dot_product_attention.py
+++ b/src/paddlefleet/transformer/dot_product_attention.py
@@ -323,6 +323,8 @@ class DotProductAttention(FleetLayer):
                 )  # [1, 1, seq_len, 4]
 
             if sink is not None:
+                # causal=False because 4-bound startend_row_indices already
+                # encodes the full bidirectional mask (SWA / non-causal FlashMask).
                 return self._sink_forward(
                     query,
                     key,

--- a/src/paddlefleet/transformer/dot_product_attention.py
+++ b/src/paddlefleet/transformer/dot_product_attention.py
@@ -44,6 +44,7 @@ from paddlefleet.refined_recompute import (
 )
 from paddlefleet.transformer.enums import AttnMaskType
 from paddlefleet.transformer.layer import FleetLayer
+from paddlefleet.transformer.sink_impl import sink_attention_forward
 from paddlefleet.transformer.utils import (
     attention_mask_func,
     is_layer_window_attention,
@@ -182,6 +183,32 @@ class DotProductAttention(FleetLayer):
             raise ValueError("Softmax type not supported")
         self.rr_flashmask_attention_func = rr_flashmask_attention()
 
+    def _sink_forward(
+        self,
+        query,
+        key,
+        value,
+        sink,
+        *,
+        attention_mask=None,
+        startend_row_indices=None,
+        causal: bool,
+    ):
+        """Shared sink dispatch for packed / SDPA / FlashMask paths."""
+        bsz, q_len = query.shape[0], query.shape[1]
+        out = sink_attention_forward(
+            query.astype(value.dtype),
+            key.astype(value.dtype),
+            value.astype(value.dtype),
+            sink,
+            attention_mask=attention_mask,
+            startend_row_indices=startend_row_indices,
+            dropout_p=self.config.attention_dropout,
+            softmax_scale=self.softmax_scale,
+            causal=causal,
+        )
+        return out.reshape([bsz, q_len, -1])
+
     def _ec_compatible_flash_attention(
         self, query, key, value, attn_mask_startend_row_indices=None
     ):
@@ -235,6 +262,7 @@ class DotProductAttention(FleetLayer):
         attention_bias: Tensor = None,
         packed_seq_params: PackedSeqParams | None = None,
         use_rr_flash_attention: bool = False,
+        sink: Tensor | None = None,
     ):
         """Forward."""
         assert attention_bias is None, (
@@ -247,6 +275,13 @@ class DotProductAttention(FleetLayer):
         v_head_dim = value.shape[-1]
 
         use_eager = self.config._attn_implementation == "eager"
+
+        if sink is not None and self.softmax_offset is not None:
+            raise ValueError(
+                "sink (forward arg) conflicts with softmax_offset "
+                f"(softmax_type={self.config.softmax_type!r}); "
+                "both map to the same SoftmaxOne mechanism. Choose one."
+            )
 
         if use_eager and packed_seq_params is not None:
             raise ValueError(
@@ -287,6 +322,16 @@ class DotProductAttention(FleetLayer):
                     .unsqueeze(0)
                 )  # [1, 1, seq_len, 4]
 
+            if sink is not None:
+                return self._sink_forward(
+                    query,
+                    key,
+                    value,
+                    sink,
+                    startend_row_indices=attn_mask_startend_row_indices,
+                    causal=False,
+                )
+
             if use_rr_flash_attention:
                 flashmask_attention_func = self.rr_flashmask_attention_func
             elif self.config.flashmask_use_varlen:
@@ -316,6 +361,16 @@ class DotProductAttention(FleetLayer):
             # is_causal is True in default
             # training is True in default
             # Default values above maybe changed in the future
+            if sink is not None:
+                return self._sink_forward(
+                    query,
+                    key,
+                    value,
+                    sink,
+                    attention_mask=attention_mask,
+                    causal=True,
+                )
+
             attn_output = paddle.nn.functional.scaled_dot_product_attention(
                 query,
                 key,
@@ -340,6 +395,16 @@ class DotProductAttention(FleetLayer):
         ):
             # Note:
             # attn_mask_startend_row_indices is not None for flashmask
+            if sink is not None:
+                return self._sink_forward(
+                    query,
+                    key,
+                    value,
+                    sink,
+                    startend_row_indices=attn_mask_startend_row_indices,
+                    causal=(attn_mask_type == AttnMaskType.causal),
+                )
+
             if use_rr_flash_attention:
                 flashmask_attention_func = self.rr_flashmask_attention_func
             elif self.config.flashmask_use_varlen:
@@ -457,8 +522,13 @@ class DotProductAttention(FleetLayer):
         # ===========================
 
         # attention scores and attention mask [b, np, sq, sk]
+        # softmax_offset and external sink both drive the same SoftmaxOne path
+        # (concat sink logit -> softmax -> drop sink column). The conflict
+        # between them is rejected at the top of forward().
         attention_probs: Tensor = self.scale_mask_softmax(
-            attention_scores, attention_mask, self.softmax_offset
+            attention_scores,
+            attention_mask,
+            sink if sink is not None else self.softmax_offset,
         )
 
         # This is actually dropping out entire tokens to attend to, which might
@@ -550,8 +620,12 @@ class CPDotProductAttention(FleetLayer):
         attention_bias: Tensor = None,
         packed_seq_params: PackedSeqParams | None = None,
         use_rr_flash_attention: bool = False,
+        sink: Tensor | None = None,
     ):
         """Forward."""
+        assert sink is None, (
+            "sink is not supported by CPDotProductAttention yet."
+        )
         assert packed_seq_params is None, (
             "Packed sequence is not supported by CPDotProductAttention now."
         )

--- a/src/paddlefleet/transformer/dot_product_attention.py
+++ b/src/paddlefleet/transformer/dot_product_attention.py
@@ -178,7 +178,8 @@ class DotProductAttention(FleetLayer):
                 ),
             )
             if config.perform_initialization:
-                self.softmax_offset = config.init_method(self.softmax_offset)
+                # in-place init
+                config.init_method(self.softmax_offset)
         else:
             raise ValueError("Softmax type not supported")
         self.rr_flashmask_attention_func = rr_flashmask_attention()
@@ -188,7 +189,6 @@ class DotProductAttention(FleetLayer):
         query,
         key,
         value,
-        sink,
         *,
         attention_mask=None,
         startend_row_indices=None,
@@ -200,7 +200,7 @@ class DotProductAttention(FleetLayer):
             query.astype(value.dtype),
             key.astype(value.dtype),
             value.astype(value.dtype),
-            sink,
+            self.softmax_offset,
             attention_mask=attention_mask,
             startend_row_indices=startend_row_indices,
             dropout_p=self.config.attention_dropout,
@@ -262,7 +262,6 @@ class DotProductAttention(FleetLayer):
         attention_bias: Tensor = None,
         packed_seq_params: PackedSeqParams | None = None,
         use_rr_flash_attention: bool = False,
-        sink: Tensor | None = None,
     ):
         """Forward."""
         assert attention_bias is None, (
@@ -275,13 +274,6 @@ class DotProductAttention(FleetLayer):
         v_head_dim = value.shape[-1]
 
         use_eager = self.config._attn_implementation == "eager"
-
-        if sink is not None and self.softmax_offset is not None:
-            raise ValueError(
-                "sink (forward arg) conflicts with softmax_offset "
-                f"(softmax_type={self.config.softmax_type!r}); "
-                "both map to the same SoftmaxOne mechanism. Choose one."
-            )
 
         if use_eager and packed_seq_params is not None:
             raise ValueError(
@@ -322,14 +314,13 @@ class DotProductAttention(FleetLayer):
                     .unsqueeze(0)
                 )  # [1, 1, seq_len, 4]
 
-            if sink is not None:
+            if self.softmax_offset is not None:
                 # causal=False because 4-bound startend_row_indices already
                 # encodes the full bidirectional mask (SWA / non-causal FlashMask).
                 return self._sink_forward(
                     query,
                     key,
                     value,
-                    sink,
                     startend_row_indices=attn_mask_startend_row_indices,
                     causal=False,
                 )
@@ -363,12 +354,11 @@ class DotProductAttention(FleetLayer):
             # is_causal is True in default
             # training is True in default
             # Default values above maybe changed in the future
-            if sink is not None:
+            if self.softmax_offset is not None:
                 return self._sink_forward(
                     query,
                     key,
                     value,
-                    sink,
                     attention_mask=attention_mask,
                     causal=True,
                 )
@@ -397,12 +387,11 @@ class DotProductAttention(FleetLayer):
         ):
             # Note:
             # attn_mask_startend_row_indices is not None for flashmask
-            if sink is not None:
+            if self.softmax_offset is not None:
                 return self._sink_forward(
                     query,
                     key,
                     value,
-                    sink,
                     startend_row_indices=attn_mask_startend_row_indices,
                     causal=(attn_mask_type == AttnMaskType.causal),
                 )
@@ -524,13 +513,10 @@ class DotProductAttention(FleetLayer):
         # ===========================
 
         # attention scores and attention mask [b, np, sq, sk]
-        # softmax_offset and external sink both drive the same SoftmaxOne path
-        # (concat sink logit -> softmax -> drop sink column). The conflict
-        # between them is rejected at the top of forward().
         attention_probs: Tensor = self.scale_mask_softmax(
             attention_scores,
             attention_mask,
-            sink if sink is not None else self.softmax_offset,
+            self.softmax_offset,
         )
 
         # This is actually dropping out entire tokens to attend to, which might
@@ -622,12 +608,8 @@ class CPDotProductAttention(FleetLayer):
         attention_bias: Tensor = None,
         packed_seq_params: PackedSeqParams | None = None,
         use_rr_flash_attention: bool = False,
-        sink: Tensor | None = None,
     ):
         """Forward."""
-        assert sink is None, (
-            "sink is not supported by CPDotProductAttention yet."
-        )
         assert packed_seq_params is None, (
             "Packed sequence is not supported by CPDotProductAttention now."
         )

--- a/src/paddlefleet/transformer/sink_impl.py
+++ b/src/paddlefleet/transformer/sink_impl.py
@@ -134,15 +134,22 @@ def _repeat_kv(hidden_states: paddle.Tensor, n_rep: int) -> paddle.Tensor:
     )
 
 
-def _get_fa_version():
+def _get_fa_version(head_dim: int = 0):
     """Get the FlashAttention version based on environment flags."""
-    if paddle.get_flags(["FLAGS_cudnn_deterministic"])[
-        "FLAGS_cudnn_deterministic"
-    ]:
+    if "xpu" in paddle.get_device():
         return 2
-    return paddle.base.framework.get_flags(["FLAGS_flash_attn_version"])[
+    fa_version = paddle.base.framework.get_flags(["FLAGS_flash_attn_version"])[
         "FLAGS_flash_attn_version"
     ]
+    if (
+        fa_version == 3
+        and paddle.base.framework.get_flags(["FLAGS_cudnn_deterministic"])[
+            "FLAGS_cudnn_deterministic"
+        ]
+        and head_dim > 128
+    ):
+        return 2
+    return fa_version
 
 
 def _flash_attention_forward_dispatch(
@@ -168,7 +175,7 @@ def _flash_attention_forward_dispatch(
         f"FlashAttention requires equal sequence lengths: seq_k={seq_k}, seq_v={seq_v}"
     )
 
-    fa_version = _get_fa_version()
+    fa_version = _get_fa_version(query.shape[-1])
 
     if fa_version == 2:
         softmax_scale = softmax_scale or 1.0 / (query.shape[-1] ** 0.5)
@@ -238,7 +245,7 @@ def _flash_attention_backward_dispatch(
     softmax_scale=None,
 ):
     """Dispatch FlashAttention backward based on version."""
-    fa_version = _get_fa_version()
+    fa_version = _get_fa_version(query.shape[-1])
 
     if fa_version == 2:
         seed_offset = paddle.zeros(shape=[2], dtype="int64")
@@ -302,7 +309,7 @@ def _flashmask_attention_forward_dispatch(
     """Dispatch FlashMask attention forward. Only FlashMask v1 doesn't support
     custom softmax_scale.
     """
-    fa_version = _get_fa_version()
+    fa_version = _get_fa_version(query.shape[-1])
 
     if fa_version == 2:
         if softmax_scale is not None and softmax_scale != 1.0 / (
@@ -352,7 +359,7 @@ def _flashmask_attention_backward_dispatch(
     softmax_scale=None,
 ):
     """Dispatch FlashMask attention backward based on version."""
-    fa_version = _get_fa_version()
+    fa_version = _get_fa_version(query.shape[-1])
     if fa_version == 2:
         seed_offset = paddle.zeros(shape=[2], dtype="int64")
         if hasattr(paddle.base.libpaddle.pir.ops, "flashmask_attention_grad"):

--- a/src/paddlefleet/transformer/sink_impl.py
+++ b/src/paddlefleet/transformer/sink_impl.py
@@ -1,0 +1,751 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import numpy as np
+import paddle
+from paddle.autograd.py_layer import PyLayer
+
+_C_ops = paddle._C_ops
+
+
+def gen_dense_mask_from_startend_row_indices(
+    attn_mask_startend_row_indices: paddle.Tensor,
+    dtype: paddle.dtype = paddle.bfloat16,
+    is_causal: bool | None = None,
+):
+    """Recover a 4-D dense attention mask from FlashMask's
+    ``startend_row_indices`` representation.
+    """
+    if (
+        attn_mask_startend_row_indices is not None
+        and attn_mask_startend_row_indices.ndim == 3
+    ):
+        attn_mask_startend_row_indices = (
+            attn_mask_startend_row_indices.unsqueeze(-1)
+        )
+    if (
+        attn_mask_startend_row_indices is not None
+        and attn_mask_startend_row_indices.shape[-1] == 1
+    ):
+        is_causal = True
+    if (
+        attn_mask_startend_row_indices is not None
+        and attn_mask_startend_row_indices.shape[-1] == 4
+    ):
+        is_causal = False
+
+    if is_causal is None:
+        raise ValueError(
+            "The `is_causal` argument must be specified when recovering the "
+            "dense attention mask from the column-wise sparse attention mask "
+            "row indices."
+        )
+
+    batch_size, num_head, seq_len, bound_num = (
+        attn_mask_startend_row_indices.shape
+    )
+    has_end = (is_causal and bound_num == 2) or (
+        (not is_causal) and bound_num == 4
+    )
+
+    attention_mask = paddle.ones([seq_len, seq_len], dtype="bool").expand(
+        [batch_size, num_head, seq_len, seq_len]
+    )
+    if is_causal:
+        attention_mask = paddle.tril(attention_mask)
+
+    base = (
+        paddle.arange(seq_len, dtype="int32")
+        .unsqueeze(1)
+        .expand([batch_size, num_head, -1, seq_len])
+    )
+
+    mask_indices = attn_mask_startend_row_indices.transpose([0, 1, 3, 2])
+
+    downstart_mask_indices = mask_indices[:, :, 0:1, :]
+    downstart_mask_indices = downstart_mask_indices.expand(
+        [batch_size, num_head, seq_len, -1]
+    )
+    lower_tri = base < downstart_mask_indices
+    if has_end:
+        downend_mask_indices = mask_indices[:, :, 1:2, :]
+        downend_mask_indices = downend_mask_indices.expand(
+            [batch_size, num_head, seq_len, -1]
+        )
+        lower_tri = paddle.logical_or(lower_tri, base >= downend_mask_indices)
+
+    attention_mask = paddle.logical_and(attention_mask, lower_tri)
+
+    if not is_causal:
+        if has_end:
+            upstart_mask_indices = mask_indices[:, :, 2:3, :]
+            upstart_mask_indices = upstart_mask_indices.expand(
+                [batch_size, num_head, seq_len, -1]
+            )
+            upend_mask_indices = mask_indices[:, :, 3:4, :]
+            upend_mask_indices = upend_mask_indices.expand(
+                [batch_size, num_head, seq_len, -1]
+            )
+            upper_tri = base >= upend_mask_indices
+            upper_tri = paddle.logical_or(
+                upper_tri, base < upstart_mask_indices
+            )
+        else:
+            upend_mask_indices = mask_indices[:, :, 1:2, :]
+            upend_mask_indices = upend_mask_indices.expand(
+                [batch_size, num_head, seq_len, -1]
+            )
+            upper_tri = base >= upend_mask_indices
+
+        attention_mask = paddle.logical_and(attention_mask, upper_tri)
+
+    attention_mask = paddle.scale(
+        x=attention_mask.astype(dtype),
+        scale=1000000.0,
+        bias=-1.0,
+        bias_after_scale=False,
+    )
+    return attention_mask
+
+
+def _repeat_kv(hidden_states: paddle.Tensor, n_rep: int) -> paddle.Tensor:
+    """Equivalent of ``paddle.repeat_interleave(hidden_states, n_rep, axis=2)``
+    for tensors with layout ``[batch, seq_len, num_kv_heads, head_dim]``.
+    """
+    batch, slen, num_key_value_heads, head_dim = hidden_states.shape
+    if n_rep == 1:
+        return hidden_states
+
+    hidden_states = hidden_states.unsqueeze(-2).tile([1, 1, 1, n_rep, 1])
+    return hidden_states.reshape(
+        [batch, slen, num_key_value_heads * n_rep, head_dim]
+    )
+
+
+def _get_fa_version():
+    """Get the FlashAttention version based on environment flags."""
+    if paddle.get_flags(["FLAGS_cudnn_deterministic"])[
+        "FLAGS_cudnn_deterministic"
+    ]:
+        return 2
+    return paddle.base.framework.get_flags(["FLAGS_flash_attn_version"])[
+        "FLAGS_flash_attn_version"
+    ]
+
+
+def _flash_attention_forward_dispatch(
+    query,
+    key,
+    value,
+    dropout=0.0,
+    causal=False,
+    return_softmax=False,
+    attention_mask: paddle.Tensor | None = None,
+    *,
+    fixed_seed_offset=None,
+    rng_name="",
+    training=True,
+    name=None,
+    softmax_scale=None,
+):
+    """Dispatch FlashAttention forward based on version. seq_k must equal seq_v."""
+    assert not return_softmax, "return_softmax must be false"
+
+    seq_k, seq_v = key.shape[1], value.shape[1]
+    assert seq_k == seq_v, (
+        f"FlashAttention requires equal sequence lengths: seq_k={seq_k}, seq_v={seq_v}"
+    )
+
+    fa_version = _get_fa_version()
+
+    if fa_version == 2:
+        softmax_scale = softmax_scale or 1.0 / (query.shape[-1] ** 0.5)
+        if hasattr(paddle.base.libpaddle.pir.ops, "flash_attn"):
+            out, _, lse, _ = _C_ops.flash_attn(
+                query,
+                key,
+                value,
+                fixed_seed_offset,
+                attention_mask,
+                dropout,
+                causal,
+                False,
+                not training,
+                rng_name,
+            )
+        else:
+            raise AssertionError(
+                "flash_attn_v2 is not supported, may be due to paddle version"
+            )
+        lse = lse[:, :, : query.shape[1]]
+    elif fa_version == 3:
+        softmax_scale = softmax_scale or 1.0 / (query.shape[-1] ** 0.5)
+        if hasattr(paddle.base.libpaddle.pir.ops, "flash_attn_v3"):
+            out, lse = _C_ops.flash_attn_v3(
+                query,
+                key,
+                value,
+                None,
+                None,
+                None,
+                None,
+                softmax_scale,
+                causal,
+                -1,
+                -1,
+                0.0,
+                1,
+                False,
+                False,
+                0,
+            )
+        else:
+            raise AssertionError(
+                "flash_attn_v3 is not supported, may be due to paddle version"
+            )
+
+        assert attention_mask is None, (
+            "FA3 do not support dense mask(attention_mask)"
+        )
+    else:
+        raise ValueError(f"Unsupported FlashAttention version: {fa_version}")
+
+    return out, lse
+
+
+def _flash_attention_backward_dispatch(
+    grad_output,
+    query,
+    key,
+    value,
+    output,
+    lse,
+    dropout=0.0,
+    attention_mask: paddle.Tensor | None = None,
+    causal=False,
+    softmax_scale=None,
+):
+    """Dispatch FlashAttention backward based on version."""
+    fa_version = _get_fa_version()
+
+    if fa_version == 2:
+        seed_offset = paddle.zeros(shape=[2], dtype="int64")
+        if hasattr(paddle.base.libpaddle.pir.ops, "flash_attn_grad"):
+            grad_q, grad_k, grad_v = _C_ops.flash_attn_grad(
+                query,
+                key,
+                value,
+                output,
+                lse,
+                seed_offset,
+                attention_mask,
+                grad_output,
+                dropout,
+                causal,
+            )
+        else:
+            raise AssertionError(
+                "flash_attn_v2_grad is not supported, may be due to paddle version"
+            )
+    elif fa_version == 3:
+        softmax_scale = softmax_scale or 1.0 / (query.shape[-1] ** 0.5)
+        if hasattr(paddle.base.libpaddle.pir.ops, "flash_attn_v3_grad"):
+            grad_q, grad_k, grad_v = _C_ops.flash_attn_v3_grad(
+                query,
+                key,
+                value,
+                output,
+                lse,
+                grad_output,
+                softmax_scale,
+                causal,
+                -1,
+                -1,
+                0.0,
+                0,
+            )
+        else:
+            raise AssertionError(
+                "flash_attn_v3_grad is not supported, may be due to paddle version"
+            )
+        assert attention_mask is None, (
+            "FA3 do not support dense mask(attention_mask)"
+        )
+    else:
+        raise ValueError(f"Unsupported FlashAttention version: {fa_version}")
+
+    return grad_q, grad_k, grad_v
+
+
+def _flashmask_attention_forward_dispatch(
+    query,
+    key,
+    value,
+    startend_row_indices,
+    dropout=0.0,
+    causal=False,
+    training=True,
+    softmax_scale=None,
+):
+    """Dispatch FlashMask attention forward. Only FlashMask v1 doesn't support
+    custom softmax_scale.
+    """
+    fa_version = _get_fa_version()
+
+    if fa_version == 2:
+        if softmax_scale is not None and softmax_scale != 1.0 / (
+            query.shape[-1] ** 0.5
+        ):
+            print(
+                f"Warning: FlashMask v1 doesn't support custom softmax_scale, "
+                f"ignoring provided value: {softmax_scale}"
+            )
+
+        output, log_sum_exp = paddle.nn.functional.flashmask_attention(
+            query,
+            key,
+            value,
+            startend_row_indices=startend_row_indices,
+            causal=causal,
+            dropout=dropout,
+            return_softmax_lse=True,
+            training=training,
+        )
+    else:
+        output, log_sum_exp = paddle.nn.functional.flashmask_attention(
+            query,
+            key,
+            value,
+            startend_row_indices=startend_row_indices,
+            causal=causal,
+            dropout=dropout,
+            softmax_scale=softmax_scale,
+            return_softmax_lse=True,
+            training=training,
+        )
+
+    return output, log_sum_exp
+
+
+def _flashmask_attention_backward_dispatch(
+    grad_output,
+    query,
+    key,
+    value,
+    output,
+    lse,
+    startend_row_indices,
+    dropout=0.0,
+    causal=False,
+    softmax_scale=None,
+):
+    """Dispatch FlashMask attention backward based on version."""
+    fa_version = _get_fa_version()
+    if fa_version == 2:
+        seed_offset = paddle.zeros(shape=[2], dtype="int64")
+        if hasattr(paddle.base.libpaddle.pir.ops, "flashmask_attention_grad"):
+            grad_q, grad_k, grad_v = _C_ops.flashmask_attention_grad(
+                query,
+                key,
+                value,
+                startend_row_indices,
+                output,
+                lse,
+                seed_offset,
+                grad_output,
+                dropout,
+                causal,
+            )
+        else:
+            raise AssertionError(
+                "flashmask_attention_grad is not supported, may be due to paddle version"
+            )
+    elif fa_version == 3:
+        softmax_scale = softmax_scale or 1.0 / (query.shape[-1] ** 0.5)
+        if hasattr(
+            paddle.base.libpaddle.pir.ops, "flashmask_attention_v2_grad"
+        ):
+            block_mask = None
+            grad_q, grad_k, grad_v = _C_ops.flashmask_attention_v2_grad(
+                query,
+                key,
+                value,
+                output,
+                lse,
+                startend_row_indices,
+                block_mask,
+                grad_output,
+                softmax_scale,
+                causal,
+                0,  # rank
+                1,  # nranks
+            )
+        else:
+            raise AssertionError(
+                "flashmask_attention_v2_grad is not supported, may be due to paddle version"
+            )
+    else:
+        raise ValueError(f"Unsupported FlashAttention version: {fa_version}")
+
+    return grad_q, grad_k, grad_v
+
+
+class FlashMaskSinkPyLayer(PyLayer):
+    """FlashAttention/FlashMask with Sink mechanism."""
+
+    @staticmethod
+    def forward(
+        ctx,
+        query,
+        key,
+        value,
+        sink,
+        startend_row_indices,
+        attention_mask: paddle.Tensor | None = None,
+        dropout=0.0,
+        causal=False,
+        return_softmax=False,
+        *,
+        fixed_seed_offset=None,
+        rng_name="",
+        training=True,
+        name=None,
+        softmax_scale=None,
+    ):
+        assert query.ndim == 4, f"Query must be 4D tensor, got {query.ndim}D"
+        assert key.ndim == 4, f"Key must be 4D tensor, got {key.ndim}D"
+        assert value.ndim == 4, f"Value must be 4D tensor, got {value.ndim}D"
+        assert sink.ndim == 1, f"Sink must be 1D tensor, got {sink.ndim}D"
+
+        batch_q, seq_q, num_q_heads, head_dim_q = query.shape
+        batch_k, seq_k, num_kv_heads, head_dim_k = key.shape
+        batch_v, seq_v, num_kv_heads_v, head_dim_v = value.shape
+
+        assert batch_q == batch_k == batch_v, (
+            f"Batch sizes must match: query={batch_q}, key={batch_k}, value={batch_v}"
+        )
+        assert head_dim_q == head_dim_k == head_dim_v, (
+            f"Head dimensions must match: query={head_dim_q}, key={head_dim_k}, value={head_dim_v}"
+        )
+        assert num_kv_heads == num_kv_heads_v, (
+            f"Key and value must have same number of heads: key={num_kv_heads}, value={num_kv_heads_v}"
+        )
+        assert num_q_heads % num_kv_heads == 0, (
+            f"Query heads ({num_q_heads}) must be divisible by key/value heads ({num_kv_heads})"
+        )
+        assert sink.shape[0] == num_q_heads, (
+            f"Sink parameter size ({sink.shape[0]}) must match number of query heads ({num_q_heads})"
+        )
+
+        if startend_row_indices is None:
+            assert seq_q == seq_k == seq_v, (
+                f"FlashAttention requires equal sequence lengths: seq_q={seq_q}, seq_k={seq_k}, seq_v={seq_v}"
+            )
+        else:
+            assert seq_k == seq_v, (
+                f"Key and value sequence lengths must match: seq_k={seq_k}, seq_v={seq_v}"
+            )
+            assert attention_mask is None, (
+                "Flashmask do not support dense mask(attention_mask)"
+            )
+
+        num_attention_heads = query.shape[2]
+        num_key_value_heads = key.shape[2]
+        num_key_value_groups = num_attention_heads // num_key_value_heads
+        if startend_row_indices is None:
+            key_states = _repeat_kv(key, num_key_value_groups)
+            value_states = _repeat_kv(value, num_key_value_groups)
+        else:
+            key_states = key
+            value_states = value
+
+        if startend_row_indices is None:
+            raw_output, lse_original = _flash_attention_forward_dispatch(
+                query,
+                key_states,
+                value_states,
+                dropout,
+                causal,
+                attention_mask=attention_mask,
+                fixed_seed_offset=fixed_seed_offset,
+                rng_name=rng_name,
+                training=training,
+                name=name,
+                softmax_scale=softmax_scale,
+            )
+        else:
+            raw_output, lse_original = _flashmask_attention_forward_dispatch(
+                query,
+                key_states,
+                value_states,
+                startend_row_indices,
+                dropout,
+                causal,
+                training=training,
+                softmax_scale=softmax_scale,
+            )
+
+        origin_dtype = raw_output.dtype
+        scale = softmax_scale or 1.0 / (query.shape[-1] ** 0.5)
+        batch_size, seq_len, num_heads, _ = query.shape
+
+        # Compat with old LSE shape (seqlen_q_rounded)
+        if lse_original.shape[-1] != seq_len:
+            new_shape = (lse_original.shape[0], lse_original.shape[1], seq_len)
+            num = np.prod(lse_original.shape[:2]) * seq_len
+            lse_original = lse_original.flatten()[:num].reshape(new_shape)
+
+        lse_transposed = lse_original.transpose(perm=[0, 2, 1]).unsqueeze(-1)
+        sink_reshaped = sink.reshape(shape=[1, 1, -1, 1])
+        sink_expanded = sink_reshaped.expand(
+            [batch_size, seq_len, num_heads, 1]
+        )
+
+        # 1 / (exp(sink - lse) + 1)
+        multiplier = 1 / (paddle.exp(sink_expanded - lse_transposed) + 1)
+        final_out = (raw_output * multiplier).to(origin_dtype)
+
+        ctx.save_for_backward(
+            query,
+            key,
+            value,
+            sink,
+            attention_mask,
+            raw_output,
+            lse_original,
+            multiplier,
+            startend_row_indices,
+        )
+        ctx.dropout = dropout
+        ctx.causal = causal
+        ctx.softmax_scale = scale
+        ctx.fixed_seed_offset = fixed_seed_offset
+        ctx.rng_name = rng_name
+        ctx.training = training
+        ctx.name = name
+        ctx.num_key_value_groups = num_key_value_groups
+
+        return final_out
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        (
+            query,
+            key,
+            value,
+            sink,
+            attention_mask,
+            raw_output,
+            lse_original,
+            multiplier,
+            startend_row_indices,
+        ) = ctx.saved_tensor()
+
+        num_key_value_groups = ctx.num_key_value_groups
+        if startend_row_indices is None:
+            key_states = _repeat_kv(key, num_key_value_groups)
+            value_states = _repeat_kv(value, num_key_value_groups)
+        else:
+            key_states = key
+            value_states = value
+
+        dropout, causal, scale = ctx.dropout, ctx.causal, ctx.softmax_scale
+        fixed_seed_offset, rng_name = ctx.fixed_seed_offset, ctx.rng_name
+        training, name = ctx.training, ctx.name
+
+        grad_raw_output = (grad_output * multiplier).to(query.dtype)
+
+        if startend_row_indices is None:
+            grad_q_main, grad_k_repeated, grad_v_repeated = (
+                _flash_attention_backward_dispatch(
+                    grad_raw_output,
+                    query,
+                    key_states,
+                    value_states,
+                    raw_output,
+                    lse_original,
+                    dropout=dropout,
+                    attention_mask=attention_mask,
+                    causal=causal,
+                    softmax_scale=scale,
+                )
+            )
+        else:
+            grad_q_main, grad_k_repeated, grad_v_repeated = (
+                _flashmask_attention_backward_dispatch(
+                    grad_raw_output,
+                    query,
+                    key_states,
+                    value_states,
+                    raw_output,
+                    lse_original,
+                    startend_row_indices,
+                    dropout,
+                    causal,
+                    scale,
+                )
+            )
+
+        if (
+            num_key_value_groups > 1
+            and grad_k_repeated.shape[2] == key.shape[2] * num_key_value_groups
+        ):
+            batch, seq_len, num_kv_heads, head_dim = key.shape
+            grad_k_main = grad_k_repeated.reshape(
+                [batch, seq_len, num_kv_heads, num_key_value_groups, head_dim]
+            ).sum(axis=3)
+            grad_v = grad_v_repeated.reshape(
+                [batch, seq_len, num_kv_heads, num_key_value_groups, head_dim]
+            ).sum(axis=3)
+        else:
+            grad_k_main = grad_k_repeated
+            grad_v = grad_v_repeated
+
+        g_r = paddle.sum(grad_output * raw_output, axis=-1)
+        multiplier_for_grad = multiplier.squeeze(-1)
+        g_ell = g_r * multiplier_for_grad * (1 - multiplier_for_grad)
+
+        grad_sink_temp = -paddle.sum(g_ell, axis=1)
+        grad_sink = grad_sink_temp.sum(axis=0)
+
+        if startend_row_indices is None:
+            mu_k, lse_k = _flash_attention_forward_dispatch(
+                query,
+                key_states,
+                key_states,
+                dropout,
+                causal,
+                attention_mask=attention_mask,
+                fixed_seed_offset=fixed_seed_offset,
+                rng_name=rng_name,
+                training=training,
+                name=name,
+                softmax_scale=scale,
+            )
+            x = (g_ell.unsqueeze(-1) * query).to(query.dtype)
+            _, grad_k_extra_repeated, _ = _flash_attention_backward_dispatch(
+                x,
+                query,
+                key_states,
+                key_states,
+                mu_k,
+                lse_k,
+                dropout=dropout,
+                attention_mask=attention_mask,
+                causal=causal,
+                softmax_scale=scale,
+            )
+        else:
+            mu_k, lse_k = _flashmask_attention_forward_dispatch(
+                query,
+                key_states,
+                key_states,
+                startend_row_indices,
+                dropout,
+                causal,
+                training=training,
+                softmax_scale=scale,
+            )
+            x = (g_ell.unsqueeze(-1) * query).to(query.dtype)
+            _, grad_k_extra_repeated, _ = (
+                _flashmask_attention_backward_dispatch(
+                    x,
+                    query,
+                    key_states,
+                    key_states,
+                    mu_k,
+                    lse_k,
+                    startend_row_indices,
+                    dropout,
+                    causal,
+                    scale,
+                )
+            )
+
+        grad_q_extra = scale * g_ell.unsqueeze(-1) * mu_k
+
+        if (
+            num_key_value_groups > 1
+            and grad_k_extra_repeated.shape[2]
+            == key.shape[2] * num_key_value_groups
+        ):
+            batch, seq_len, num_kv_heads, head_dim = key.shape
+            grad_k_extra_repeated = grad_k_extra_repeated.reshape(
+                [batch, seq_len, num_kv_heads, num_key_value_groups, head_dim]
+            )
+            grad_k_extra = scale * grad_k_extra_repeated.sum(axis=3)
+        else:
+            grad_k_extra = scale * grad_k_extra_repeated
+
+        grad_q = grad_q_main + grad_q_extra
+        grad_k = grad_k_main + grad_k_extra
+        if query.dtype != grad_q.dtype:
+            grad_q = grad_q.cast(query.dtype)
+        if key.dtype != grad_k.dtype:
+            grad_k = grad_k.cast(key.dtype)
+        if value.dtype != grad_v.dtype:
+            grad_v = grad_v.cast(value.dtype)
+        if sink.stop_gradient:
+            if startend_row_indices is None:
+                return grad_q, grad_k, grad_v, None
+            else:
+                return grad_q, grad_k, grad_v, None, None
+        else:
+            if startend_row_indices is None:
+                return grad_q, grad_k, grad_v, grad_sink
+            else:
+                return grad_q, grad_k, grad_v, grad_sink, None
+
+
+def sink_attention_forward(
+    q,
+    k,
+    v,
+    sink: paddle.Tensor,
+    attention_mask: paddle.Tensor | None = None,
+    startend_row_indices: paddle.Tensor | None = None,
+    dropout_p=0.0,
+    softmax_scale=None,
+    causal=False,
+):
+    """Unified attention forward with Sink mechanism.
+
+    Automatically chooses between FlashAttention and FlashMask based on
+    ``startend_row_indices``. Shapes follow the ``[B, S, H, D]`` layout
+    (same as paddlefleet's ``DotProductAttention``).
+
+    Args:
+        q: Query tensor ``[B, S, H_q, D]``
+        k: Key tensor ``[B, S, H_kv, D]``
+        v: Value tensor ``[B, S, H_kv, D]``
+        sink: Sink parameter tensor ``[H_q]``
+        attention_mask: Dense mask, only supported for FA2 path.
+        startend_row_indices: If given, route to FlashMask.
+        dropout_p: Dropout probability.
+        softmax_scale: Custom softmax scaling factor.
+        causal: Whether to apply causal masking.
+    """
+    return FlashMaskSinkPyLayer.apply(
+        q,
+        k,
+        v,
+        sink,
+        startend_row_indices,
+        attention_mask=attention_mask,
+        dropout=dropout_p,
+        causal=causal,
+        return_softmax=False,
+        softmax_scale=softmax_scale,
+    )

--- a/src/paddlefleet/transformer/sink_impl.py
+++ b/src/paddlefleet/transformer/sink_impl.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 
-import numpy as np
 import paddle
 from paddle.autograd.py_layer import PyLayer
 
@@ -510,9 +509,7 @@ class FlashMaskSinkPyLayer(PyLayer):
 
         # Compat with old LSE shape (seqlen_q_rounded)
         if lse_original.shape[-1] != seq_len:
-            new_shape = (lse_original.shape[0], lse_original.shape[1], seq_len)
-            num = np.prod(lse_original.shape[:2]) * seq_len
-            lse_original = lse_original.flatten()[:num].reshape(new_shape)
+            lse_original = lse_original[:, :, :seq_len]
 
         lse_transposed = lse_original.transpose(perm=[0, 2, 1]).unsqueeze(-1)
         sink_reshaped = sink.reshape(shape=[1, 1, -1, 1])
@@ -627,6 +624,8 @@ class FlashMaskSinkPyLayer(PyLayer):
         grad_sink_temp = -paddle.sum(g_ell, axis=1)
         grad_sink = grad_sink_temp.sum(axis=0)
 
+        # Extra forward pass to compute mu_k = softmax(Q @ K^T) @ K, which is
+        # required for the sink gradient. This adds ~1x forward cost to backward.
         if startend_row_indices is None:
             mu_k, lse_k = _flash_attention_forward_dispatch(
                 query,

--- a/src/paddlefleet/transformer/sink_impl.py
+++ b/src/paddlefleet/transformer/sink_impl.py
@@ -18,6 +18,15 @@ from paddle.autograd.py_layer import PyLayer
 
 _C_ops = paddle._C_ops
 
+if paddle.cuda.get_device_capability()[0] == 10:
+    from paddlefleet.ops.flash_mask.cute.flashmask_utils import (
+        FlashMaskInfoPaddle,
+    )
+    from paddlefleet.ops.flash_mask.cute.interface import (
+        _flash_attn_bwd,
+        _flash_attn_fwd,
+    )
+
 
 def gen_dense_mask_from_startend_row_indices(
     attn_mask_startend_row_indices: paddle.Tensor,
@@ -225,6 +234,20 @@ def _flash_attention_forward_dispatch(
         assert attention_mask is None, (
             "FA3 do not support dense mask(attention_mask)"
         )
+    elif fa_version == 4:
+        out, lse = _flash_attn_fwd(
+            query,
+            key,
+            value,
+            softmax_scale=softmax_scale,
+            causal=causal,
+            return_lse=True,
+            startend_row_indices=None,
+            pack_gqa=False,
+        )
+        assert attention_mask is None, (
+            "FA4 do not support dense mask(attention_mask)"
+        )
     else:
         raise ValueError(f"Unsupported FlashAttention version: {fa_version}")
 
@@ -289,6 +312,26 @@ def _flash_attention_backward_dispatch(
         assert attention_mask is None, (
             "FA3 do not support dense mask(attention_mask)"
         )
+    elif fa_version == 4:
+        grad_q, grad_k, grad_v = _flash_attn_bwd(
+            query,
+            key,
+            value,
+            output,
+            grad_output,
+            lse,
+            None,  # flashmask_info, startend_row_indices is not None
+            softmax_scale=softmax_scale,
+            causal=causal,
+            deterministic=bool(
+                paddle.get_flags(["FLAGS_cudnn_deterministic"])[
+                    "FLAGS_cudnn_deterministic"
+                ]
+            ),
+        )
+        assert attention_mask is None, (
+            "FA4 do not support dense mask(attention_mask)"
+        )
     else:
         raise ValueError(f"Unsupported FlashAttention version: {fa_version}")
 
@@ -329,7 +372,7 @@ def _flashmask_attention_forward_dispatch(
             return_softmax_lse=True,
             training=training,
         )
-    else:
+    elif fa_version == 3:
         output, log_sum_exp = paddle.nn.functional.flashmask_attention(
             query,
             key,
@@ -341,6 +384,19 @@ def _flashmask_attention_forward_dispatch(
             return_softmax_lse=True,
             training=training,
         )
+    elif fa_version == 4:
+        output, log_sum_exp = _flash_attn_fwd(
+            query,
+            key,
+            value,
+            softmax_scale=softmax_scale,
+            causal=causal,
+            return_lse=True,
+            startend_row_indices=startend_row_indices,
+            pack_gqa=False,
+        )
+    else:
+        raise ValueError(f"Unsupported FlashAttention version: {fa_version}")
 
     return output, log_sum_exp
 
@@ -402,6 +458,30 @@ def _flashmask_attention_backward_dispatch(
             raise AssertionError(
                 "flashmask_attention_v2_grad is not supported, may be due to paddle version"
             )
+    elif fa_version == 4:
+        if startend_row_indices is not None:
+            flashmask_info = FlashMaskInfoPaddle(
+                startend_row_indices=startend_row_indices,
+                is_causal=causal,
+            )
+        else:
+            flashmask_info = None
+        grad_q, grad_k, grad_v = _flash_attn_bwd(
+            query,
+            key,
+            value,
+            output,
+            grad_output,
+            lse,
+            flashmask_info,
+            softmax_scale=softmax_scale,
+            causal=causal,
+            deterministic=bool(
+                paddle.get_flags(["FLAGS_cudnn_deterministic"])[
+                    "FLAGS_cudnn_deterministic"
+                ]
+            ),
+        )
     else:
         raise ValueError(f"Unsupported FlashAttention version: {fa_version}")
 

--- a/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_softmax.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_softmax.py
@@ -65,44 +65,35 @@ class TestSoftmaxOneForward(unittest.TestCase):
         np_dim = 4
         layer = SoftmaxOne(denominator_offset=paddle.to_tensor([1.0] * np_dim))
         x = paddle.randn([2, np_dim, 8, 16])
-        try:
-            result = layer(x)
-            self.assertEqual(result.shape, [2, np_dim, 8, 16])
-        except TypeError:
-            # paddle.softmax(qk, axis=-1) uses compat API which rejects 'axis'
-            # in this Paddle version; source code needs paddle.nn.functional.softmax
-            self.skipTest(
-                "paddle.softmax compat API does not accept 'axis' in this version"
-            )
+        result = layer(x)
+        self.assertEqual(result.shape, [2, np_dim, 8, 16])
 
     def test_output_sums_approximately_one(self):
-        """Test that output rows sum approximately to 1."""
+        """Row sum of SoftmaxOne output equals 1 - P(sink); strictly < 1 when
+        sink logit is finite (attention-sink semantics: the sink column absorbs
+        some probability mass and is then dropped)."""
         np_dim = 1
-        layer = SoftmaxOne(denominator_offset=paddle.to_tensor([1.0] * np_dim))
+        sink_val = 1.0
+        layer = SoftmaxOne(
+            denominator_offset=paddle.to_tensor([sink_val] * np_dim)
+        )
         x = paddle.randn([1, np_dim, 1, 8])
-        try:
-            result = layer(x)
-            row_sum = result.sum(axis=-1)
-            np.testing.assert_allclose(
-                row_sum.numpy(), np.ones([1, np_dim, 1]), atol=1e-5
-            )
-        except TypeError:
-            self.skipTest(
-                "paddle.softmax compat API does not accept 'axis' in this version"
-            )
+        result = layer(x)
+        row_sum = result.sum(axis=-1)
+
+        # row_sum = Σ exp(x) / (Σ exp(x) + exp(sink)) = sigmoid(logsumexp(x) - sink)
+        expected = paddle.nn.functional.sigmoid(
+            paddle.logsumexp(x, axis=-1) - sink_val
+        ).numpy()
+        np.testing.assert_allclose(row_sum.numpy(), expected, atol=1e-5)
 
     def test_output_positive(self):
         """Test that output values are non-negative."""
         np_dim = 4
         layer = SoftmaxOne(denominator_offset=paddle.to_tensor([1.0] * np_dim))
         x = paddle.randn([2, np_dim, 8, 16])
-        try:
-            result = layer(x)
-            self.assertTrue((result >= 0).all())
-        except TypeError:
-            self.skipTest(
-                "paddle.softmax compat API does not accept 'axis' in this version"
-            )
+        result = layer(x)
+        self.assertTrue((result >= 0).all())
 
 
 class TestFusedScaleMaskSoftmaxInit(unittest.TestCase):
@@ -262,14 +253,9 @@ class TestFusedScaleMaskSoftmaxWithSoftmaxOffset(unittest.TestCase):
         x = paddle.randn([2, np_dim, 8, 16])
         # softmax_offset must have shape [np] for SoftmaxOne to work with 4D input
         offset = paddle.to_tensor([1.0] * np_dim)
-        try:
-            result = layer(x, None, softmax_offset=offset)
-            self.assertEqual(result.shape, [2, np_dim, 8, 16])
-        except TypeError:
-            # paddle.softmax compat API does not accept 'axis' in this version
-            self.skipTest(
-                "paddle.softmax compat API does not accept 'axis' in this version"
-            )
+
+        result = layer(x, None, softmax_offset=offset)
+        self.assertEqual(result.shape, [2, np_dim, 8, 16])
 
 
 if __name__ == "__main__":

--- a/tests/single_card_tests/transformer/test_attention_sink.py
+++ b/tests/single_card_tests/transformer/test_attention_sink.py
@@ -18,7 +18,15 @@ import numpy as np
 import paddle
 from paddle import nn
 
-from paddlefleet.transformer.sink_impl import sink_attention_forward
+from paddlefleet.transformer.sink_impl import (
+    gen_dense_mask_from_startend_row_indices,
+    sink_attention_forward,
+    _get_fa_version,
+    _flash_attention_forward_dispatch,
+    _flash_attention_backward_dispatch,
+    _flashmask_attention_forward_dispatch,
+    _flashmask_attention_backward_dispatch,
+)
 
 
 def eager_attention_forward(module, query, key, value, scaling, **kwargs):
@@ -155,6 +163,83 @@ def flashmask_to_densemask(
 
     # The final mask shape is [B, H, S, S] to match the attention weights matrix.
     return m
+
+
+class TestGenDenseMask(unittest.TestCase):
+    """Tests for gen_dense_mask_from_startend_row_indices."""
+
+    def test_causal_1_bound(self):
+        """Test causal mask with single start bound (ndim=3 input)."""
+        batch, num_head, seq_len = 1, 2, 8
+        # Create startend_row_indices with shape [B, H, S] (ndim=3)
+        indices = paddle.zeros([batch, num_head, seq_len], dtype="int32")
+        # Set start indices at or below diagonal
+        for j in range(seq_len):
+            indices[:, :, j] = j
+
+        mask = gen_dense_mask_from_startend_row_indices(
+            indices, dtype=paddle.float32
+        )
+        self.assertEqual(mask.shape, [batch, num_head, seq_len, seq_len])
+        # For causal with start at diagonal, should be a standard causal mask
+        # Check that upper triangle is masked (negative values)
+        for i in range(seq_len):
+            for j in range(i + 1, seq_len):
+                self.assertTrue(mask[0, 0, i, j].item() < 0)
+
+    def test_causal_2_bounds(self):
+        """Test causal mask with start and end bounds."""
+        batch, num_head, seq_len = 1, 2, 8
+        # Shape [B, H, S, 2]: start and end
+        indices = paddle.zeros([batch, num_head, seq_len, 2], dtype="int32")
+        for j in range(seq_len):
+            indices[:, :, j, 0] = j  # start at diagonal
+            indices[:, :, j, 1] = min(j + 3, seq_len)  # end 3 after
+
+        mask = gen_dense_mask_from_startend_row_indices(
+            indices, dtype=paddle.float32, is_causal=True
+        )
+        self.assertEqual(mask.shape, [batch, num_head, seq_len, seq_len])
+
+    def test_non_causal_2_bounds(self):
+        """Test non-causal mask with 2 bounds (down_start + up_end)."""
+        batch, num_head, seq_len = 1, 2, 8
+        # Shape [B, H, S, 2]: down_start and up_end
+        indices = paddle.zeros([batch, num_head, seq_len, 2], dtype="int32")
+        for j in range(seq_len):
+            indices[:, :, j, 0] = max(0, j - 2)  # down_start
+            indices[:, :, j, 1] = max(0, j - 1)  # up_end
+
+        mask = gen_dense_mask_from_startend_row_indices(
+            indices, dtype=paddle.float32, is_causal=False
+        )
+        self.assertEqual(mask.shape, [batch, num_head, seq_len, seq_len])
+
+    def test_non_causal_4_bounds(self):
+        """Test non-causal mask with 4 bounds."""
+        batch, num_head, seq_len = 1, 2, 8
+        # Shape [B, H, S, 4]: down_start, down_end, up_start, up_end
+        indices = paddle.zeros([batch, num_head, seq_len, 4], dtype="int32")
+        for j in range(seq_len):
+            indices[:, :, j, 0] = j  # down_start
+            indices[:, :, j, 1] = min(j + 2, seq_len)  # down_end
+            indices[:, :, j, 2] = max(0, j - 2)  # up_start
+            indices[:, :, j, 3] = j  # up_end
+
+        mask = gen_dense_mask_from_startend_row_indices(
+            indices, dtype=paddle.float32, is_causal=False
+        )
+        self.assertEqual(mask.shape, [batch, num_head, seq_len, seq_len])
+
+    def test_raises_without_is_causal(self):
+        """Test that ValueError is raised when is_causal is not specified and can't be inferred."""
+        batch, num_head, seq_len = 1, 2, 8
+        # 2 bounds could be causal or non-causal, so is_causal must be given
+        indices = paddle.zeros([batch, num_head, seq_len, 2], dtype="int32")
+        with self.assertRaises(ValueError):
+            gen_dense_mask_from_startend_row_indices(
+                indices, dtype=paddle.float32
+            )
 
 
 class TestAttentionInterface(unittest.TestCase):
@@ -440,6 +525,697 @@ class TestAttentionInterface(unittest.TestCase):
 
         # Compare the results
         self.assert_tensor_close(flashmask_output, eager_output_flashmask)
+
+
+class TestBackward(unittest.TestCase):
+    """Tests for backward pass through FlashMaskSinkPyLayer."""
+
+    def setUp(self):
+        paddle.seed(42)
+        self.batch_size = 1
+        self.seq_len = 128
+        self.num_heads = 8
+        self.head_dim = 64
+        self.dtype = "bfloat16"
+        self.scaling = self.head_dim**-0.5
+
+    def _make_tensors(self, num_kv_heads=None, stop_gradient_sink=False):
+        """Create tensors with gradients enabled."""
+        if num_kv_heads is None:
+            num_kv_heads = self.num_heads
+
+        query = paddle.rand(
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+            dtype=self.dtype,
+        )
+        key = paddle.rand(
+            [self.batch_size, self.seq_len, num_kv_heads, self.head_dim],
+            dtype=self.dtype,
+        )
+        value = paddle.rand(
+            [self.batch_size, self.seq_len, num_kv_heads, self.head_dim],
+            dtype=self.dtype,
+        )
+        sink = paddle.rand([self.num_heads], dtype=self.dtype)
+
+        query.stop_gradient = False
+        key.stop_gradient = False
+        value.stop_gradient = False
+        sink.stop_gradient = stop_gradient_sink
+
+        return query, key, value, sink
+
+    def test_backward_causal_mha(self):
+        """Test backward pass with causal MHA (covers FA backward dispatch, LSE compat, dtype cast)."""
+        query, key, value, sink = self._make_tensors()
+
+        out = sink_attention_forward(
+            query, key, value, sink,
+            causal=True,
+            softmax_scale=self.scaling,
+        )
+        loss = out.sum()
+        loss.backward()
+
+        self.assertIsNotNone(query.grad)
+        self.assertIsNotNone(key.grad)
+        self.assertIsNotNone(value.grad)
+        self.assertIsNotNone(sink.grad)
+        self.assertEqual(query.grad.shape, query.shape)
+        self.assertEqual(key.grad.shape, key.shape)
+        self.assertEqual(value.grad.shape, value.shape)
+
+    def test_backward_sink_stop_gradient(self):
+        """Test backward when sink has stop_gradient=True returns None for sink grad."""
+        query, key, value, sink = self._make_tensors(stop_gradient_sink=True)
+
+        out = sink_attention_forward(
+            query, key, value, sink,
+            causal=True,
+            softmax_scale=self.scaling,
+        )
+        loss = out.sum()
+        loss.backward()
+
+        self.assertIsNotNone(query.grad)
+        self.assertIsNotNone(key.grad)
+        self.assertIsNotNone(value.grad)
+        # sink should have no gradient since stop_gradient=True
+        self.assertIsNone(sink.grad)
+
+    def test_backward_flashmask(self):
+        """Test backward with FlashMask path (covers flashmask backward dispatch)."""
+        query, key, value, sink = self._make_tensors()
+
+        # Generate non-causal flashmask indices
+        indices = np.zeros(
+            (self.batch_size, self.num_heads, self.seq_len, 2), dtype="int32"
+        )
+        diag = np.arange(self.seq_len).reshape((1, 1, self.seq_len))
+        indices[:, :, :, 0] = diag  # down_start at diagonal
+        indices[:, :, :, 1] = 0  # up_end at 0
+        startend_row_indices = paddle.to_tensor(indices, dtype="int32")
+
+        out = sink_attention_forward(
+            query, key, value, sink,
+            startend_row_indices=startend_row_indices,
+            causal=False,
+            softmax_scale=self.scaling,
+        )
+        loss = out.sum()
+        loss.backward()
+
+        self.assertIsNotNone(query.grad)
+        self.assertIsNotNone(key.grad)
+        self.assertIsNotNone(value.grad)
+        self.assertIsNotNone(sink.grad)
+
+    def test_backward_flashmask_sink_stop_gradient(self):
+        """Test backward FlashMask path with sink stop_gradient=True."""
+        query, key, value, sink = self._make_tensors(stop_gradient_sink=True)
+
+        indices = np.zeros(
+            (self.batch_size, self.num_heads, self.seq_len, 2), dtype="int32"
+        )
+        diag = np.arange(self.seq_len).reshape((1, 1, self.seq_len))
+        indices[:, :, :, 0] = diag
+        indices[:, :, :, 1] = 0
+        startend_row_indices = paddle.to_tensor(indices, dtype="int32")
+
+        out = sink_attention_forward(
+            query, key, value, sink,
+            startend_row_indices=startend_row_indices,
+            causal=False,
+            softmax_scale=self.scaling,
+        )
+        loss = out.sum()
+        loss.backward()
+
+        self.assertIsNotNone(query.grad)
+        self.assertIsNone(sink.grad)
+
+    def test_backward_gqa(self):
+        """Test backward with GQA (num_q_heads > num_kv_heads) computes correct grad shapes."""
+        num_kv_heads = self.num_heads // 4  # 2 KV heads for 8 Q heads
+        query, key, value, sink = self._make_tensors(num_kv_heads=num_kv_heads)
+
+        out = sink_attention_forward(
+            query, key, value, sink,
+            causal=True,
+            softmax_scale=self.scaling,
+        )
+        loss = out.sum()
+        loss.backward()
+
+        self.assertIsNotNone(query.grad)
+        self.assertIsNotNone(key.grad)
+        self.assertIsNotNone(value.grad)
+        self.assertEqual(key.grad.shape, key.shape)
+        self.assertEqual(value.grad.shape, value.shape)
+
+
+def _is_sm90_or_above():
+    """Check if the GPU supports SM90+ (Hopper), required for FA3."""
+    if not paddle.is_compiled_with_cuda():
+        return False
+    try:
+        cap = paddle.device.cuda.get_device_capability()
+        return cap[0] >= 9
+    except Exception:
+        return False
+
+
+class TestFA3Path(unittest.TestCase):
+    """Tests for the FA3 code path on Hopper GPUs."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.has_fa3 = (
+            hasattr(paddle.base.libpaddle.pir.ops, "flash_attn_v3")
+            and _is_sm90_or_above()
+        )
+
+    def setUp(self):
+        if not self.has_fa3:
+            self.skipTest("flash_attn_v3 requires Hopper GPU (SM90+)")
+        paddle.seed(42)
+        self.batch_size = 1
+        self.seq_len = 128
+        self.num_heads = 8
+        self.head_dim = 64
+        self.dtype = "bfloat16"
+        self.scaling = self.head_dim**-0.5
+        # Set FA version to 3
+        paddle.base.framework.set_flags({"FLAGS_flash_attn_version": 3})
+
+    def tearDown(self):
+        # Restore default
+        paddle.base.framework.set_flags({"FLAGS_flash_attn_version": 2})
+
+    def test_fa3_forward_causal(self):
+        """Test FA3 causal forward produces correct output shape."""
+        query = paddle.rand(
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+            dtype=self.dtype,
+        )
+        key = paddle.rand(
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+            dtype=self.dtype,
+        )
+        value = paddle.rand(
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+            dtype=self.dtype,
+        )
+        sink = paddle.rand([self.num_heads], dtype=self.dtype)
+
+        out = sink_attention_forward(
+            query, key, value, sink,
+            causal=True,
+            softmax_scale=self.scaling,
+        )
+        self.assertEqual(
+            out.shape,
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+        )
+
+    def test_fa3_backward(self):
+        """Test FA3 backward produces gradients for all inputs."""
+        query = paddle.rand(
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+            dtype=self.dtype,
+        )
+        key = paddle.rand(
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+            dtype=self.dtype,
+        )
+        value = paddle.rand(
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+            dtype=self.dtype,
+        )
+        sink = paddle.rand([self.num_heads], dtype=self.dtype)
+        query.stop_gradient = False
+        key.stop_gradient = False
+        value.stop_gradient = False
+        sink.stop_gradient = False
+
+        out = sink_attention_forward(
+            query, key, value, sink,
+            causal=True,
+            softmax_scale=self.scaling,
+        )
+        loss = out.sum()
+        loss.backward()
+
+        self.assertIsNotNone(query.grad)
+        self.assertIsNotNone(key.grad)
+        self.assertIsNotNone(value.grad)
+
+    def test_fa3_flashmask_forward(self):
+        """Test FlashMask with FA3 forward produces correct output shape."""
+        has_flashmask_v2 = hasattr(
+            paddle.base.libpaddle.pir.ops, "flashmask_attention_v2"
+        ) or hasattr(
+            paddle.nn.functional, "flashmask_attention"
+        )
+        if not has_flashmask_v2:
+            self.skipTest("flashmask_attention not available for FA3")
+
+        query = paddle.rand(
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+            dtype=self.dtype,
+        )
+        key = paddle.rand(
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+            dtype=self.dtype,
+        )
+        value = paddle.rand(
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+            dtype=self.dtype,
+        )
+        sink = paddle.rand([self.num_heads], dtype=self.dtype)
+
+        # Non-causal flashmask indices
+        indices = np.zeros(
+            (self.batch_size, self.num_heads, self.seq_len, 2), dtype="int32"
+        )
+        diag = np.arange(self.seq_len).reshape((1, 1, self.seq_len))
+        indices[:, :, :, 0] = diag
+        indices[:, :, :, 1] = 0
+        startend_row_indices = paddle.to_tensor(indices, dtype="int32")
+
+        out = sink_attention_forward(
+            query, key, value, sink,
+            startend_row_indices=startend_row_indices,
+            causal=False,
+            softmax_scale=self.scaling,
+        )
+        self.assertEqual(
+            out.shape,
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+        )
+
+    def test_fa3_flashmask_backward(self):
+        """Test FlashMask with FA3 backward produces gradients."""
+        has_flashmask_v2_grad = hasattr(
+            paddle.base.libpaddle.pir.ops, "flashmask_attention_v2_grad"
+        )
+        if not has_flashmask_v2_grad:
+            self.skipTest("flashmask_attention_v2_grad not available")
+
+        query = paddle.rand(
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+            dtype=self.dtype,
+        )
+        key = paddle.rand(
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+            dtype=self.dtype,
+        )
+        value = paddle.rand(
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+            dtype=self.dtype,
+        )
+        sink = paddle.rand([self.num_heads], dtype=self.dtype)
+        query.stop_gradient = False
+        key.stop_gradient = False
+        value.stop_gradient = False
+        sink.stop_gradient = False
+
+        indices = np.zeros(
+            (self.batch_size, self.num_heads, self.seq_len, 2), dtype="int32"
+        )
+        diag = np.arange(self.seq_len).reshape((1, 1, self.seq_len))
+        indices[:, :, :, 0] = diag
+        indices[:, :, :, 1] = 0
+        startend_row_indices = paddle.to_tensor(indices, dtype="int32")
+
+        out = sink_attention_forward(
+            query, key, value, sink,
+            startend_row_indices=startend_row_indices,
+            causal=False,
+            softmax_scale=self.scaling,
+        )
+        loss = out.sum()
+        loss.backward()
+
+        self.assertIsNotNone(query.grad)
+        self.assertIsNotNone(key.grad)
+
+
+class TestGetFaVersion(unittest.TestCase):
+    """Tests for _get_fa_version logic."""
+
+    def test_deterministic_fallback_fa3_large_head_dim(self):
+        """When FA3 + deterministic + head_dim > 128, should fall back to version 2."""
+        original_fa = paddle.base.framework.get_flags(["FLAGS_flash_attn_version"])[
+            "FLAGS_flash_attn_version"
+        ]
+        original_det = paddle.base.framework.get_flags(["FLAGS_cudnn_deterministic"])[
+            "FLAGS_cudnn_deterministic"
+        ]
+        try:
+            paddle.base.framework.set_flags({
+                "FLAGS_flash_attn_version": 3,
+                "FLAGS_cudnn_deterministic": 1,
+            })
+            # head_dim > 128 should trigger fallback to v2
+            self.assertEqual(_get_fa_version(head_dim=256), 2)
+            # head_dim <= 128 should not trigger fallback
+            self.assertEqual(_get_fa_version(head_dim=128), 3)
+            self.assertEqual(_get_fa_version(head_dim=64), 3)
+        finally:
+            paddle.base.framework.set_flags({
+                "FLAGS_flash_attn_version": original_fa,
+                "FLAGS_cudnn_deterministic": original_det,
+            })
+
+    def test_no_fallback_when_not_deterministic(self):
+        """When deterministic is off, FA3 should be returned as-is."""
+        original_fa = paddle.base.framework.get_flags(["FLAGS_flash_attn_version"])[
+            "FLAGS_flash_attn_version"
+        ]
+        original_det = paddle.base.framework.get_flags(["FLAGS_cudnn_deterministic"])[
+            "FLAGS_cudnn_deterministic"
+        ]
+        try:
+            paddle.base.framework.set_flags({
+                "FLAGS_flash_attn_version": 3,
+                "FLAGS_cudnn_deterministic": 0,
+            })
+            self.assertEqual(_get_fa_version(head_dim=256), 3)
+        finally:
+            paddle.base.framework.set_flags({
+                "FLAGS_flash_attn_version": original_fa,
+                "FLAGS_cudnn_deterministic": original_det,
+            })
+
+
+class TestFA3PathMocked(unittest.TestCase):
+    """Test FA3 code paths using mocks (for non-Hopper machines)."""
+
+    def setUp(self):
+        paddle.seed(42)
+        self.batch_size = 1
+        self.seq_len = 64
+        self.num_heads = 4
+        self.head_dim = 64
+        self.dtype = "bfloat16"
+        self.scaling = self.head_dim**-0.5
+
+    def test_fa3_forward_dispatch(self):
+        """Test FA3 forward path by mocking _C_ops.flash_attn_v3."""
+        from unittest.mock import patch
+        query = paddle.rand(
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+            dtype=self.dtype,
+        )
+        key = paddle.rand(
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+            dtype=self.dtype,
+        )
+        value = paddle.rand(
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+            dtype=self.dtype,
+        )
+
+        # Create mock output tensors
+        mock_out = paddle.rand(
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+            dtype=self.dtype,
+        )
+        mock_lse = paddle.rand(
+            [self.batch_size, self.num_heads, self.seq_len], dtype="float32"
+        )
+
+        original_fa = paddle.base.framework.get_flags(["FLAGS_flash_attn_version"])[
+            "FLAGS_flash_attn_version"
+        ]
+        try:
+            paddle.base.framework.set_flags({"FLAGS_flash_attn_version": 3})
+            with patch.object(
+                paddle._C_ops, "flash_attn_v3", return_value=(mock_out, mock_lse)
+            ):
+                out, lse = _flash_attention_forward_dispatch(
+                    query, key, value, causal=True, softmax_scale=self.scaling
+                )
+                self.assertEqual(out.shape, mock_out.shape)
+                self.assertEqual(lse.shape, mock_lse.shape)
+        finally:
+            paddle.base.framework.set_flags({"FLAGS_flash_attn_version": original_fa})
+
+    def test_fa3_backward_dispatch(self):
+        """Test FA3 backward path by mocking _C_ops.flash_attn_v3_grad."""
+        from unittest.mock import patch
+
+        query = paddle.rand(
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+            dtype=self.dtype,
+        )
+        key = paddle.rand(
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+            dtype=self.dtype,
+        )
+        value = paddle.rand(
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+            dtype=self.dtype,
+        )
+        output = paddle.rand(
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+            dtype=self.dtype,
+        )
+        lse = paddle.rand(
+            [self.batch_size, self.num_heads, self.seq_len], dtype="float32"
+        )
+        grad_output = paddle.rand(
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+            dtype=self.dtype,
+        )
+
+        mock_grad_q = paddle.rand_like(query)
+        mock_grad_k = paddle.rand_like(key)
+        mock_grad_v = paddle.rand_like(value)
+
+        original_fa = paddle.base.framework.get_flags(["FLAGS_flash_attn_version"])[
+            "FLAGS_flash_attn_version"
+        ]
+        try:
+            paddle.base.framework.set_flags({"FLAGS_flash_attn_version": 3})
+            with patch.object(
+                paddle._C_ops,
+                "flash_attn_v3_grad",
+                return_value=(mock_grad_q, mock_grad_k, mock_grad_v),
+            ):
+                grad_q, grad_k, grad_v = _flash_attention_backward_dispatch(
+                    grad_output, query, key, value, output, lse,
+                    causal=True, softmax_scale=self.scaling,
+                )
+                self.assertEqual(grad_q.shape, query.shape)
+                self.assertEqual(grad_k.shape, key.shape)
+                self.assertEqual(grad_v.shape, value.shape)
+        finally:
+            paddle.base.framework.set_flags({"FLAGS_flash_attn_version": original_fa})
+
+    def test_fa3_flashmask_forward_dispatch(self):
+        """Test FlashMask with FA3 forward produces correct output shape."""
+        from unittest.mock import patch
+
+        query = paddle.rand(
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+            dtype=self.dtype,
+        )
+        key = paddle.rand(
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+            dtype=self.dtype,
+        )
+        value = paddle.rand(
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+            dtype=self.dtype,
+        )
+
+        indices = np.zeros(
+            (self.batch_size, self.num_heads, self.seq_len, 2), dtype="int32"
+        )
+        diag = np.arange(self.seq_len).reshape((1, 1, self.seq_len))
+        indices[:, :, :, 0] = diag
+        indices[:, :, :, 1] = 0
+        startend_row_indices = paddle.to_tensor(indices, dtype="int32")
+
+        mock_out = paddle.rand(
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+            dtype=self.dtype,
+        )
+        mock_lse = paddle.rand(
+            [self.batch_size, self.num_heads, self.seq_len], dtype="float32"
+        )
+
+        original_fa = paddle.base.framework.get_flags(["FLAGS_flash_attn_version"])[
+            "FLAGS_flash_attn_version"
+        ]
+        try:
+            paddle.base.framework.set_flags({"FLAGS_flash_attn_version": 3})
+            with patch(
+                "paddle.nn.functional.flashmask_attention",
+                return_value=(mock_out, mock_lse),
+            ):
+                out, lse = _flashmask_attention_forward_dispatch(
+                    query, key, value, startend_row_indices,
+                    causal=False, softmax_scale=self.scaling,
+                )
+                self.assertEqual(out.shape, mock_out.shape)
+        finally:
+            paddle.base.framework.set_flags({"FLAGS_flash_attn_version": original_fa})
+
+    def test_fa3_flashmask_backward_dispatch(self):
+        """Test FlashMask FA3 backward dispatch via mock."""
+        from unittest.mock import patch
+
+        query = paddle.rand(
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+            dtype=self.dtype,
+        )
+        key = paddle.rand(
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+            dtype=self.dtype,
+        )
+        value = paddle.rand(
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+            dtype=self.dtype,
+        )
+        output = paddle.rand(
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+            dtype=self.dtype,
+        )
+        lse = paddle.rand(
+            [self.batch_size, self.num_heads, self.seq_len], dtype="float32"
+        )
+        grad_output = paddle.rand(
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+            dtype=self.dtype,
+        )
+
+        indices = np.zeros(
+            (self.batch_size, self.num_heads, self.seq_len, 2), dtype="int32"
+        )
+        diag = np.arange(self.seq_len).reshape((1, 1, self.seq_len))
+        indices[:, :, :, 0] = diag
+        indices[:, :, :, 1] = 0
+        startend_row_indices = paddle.to_tensor(indices, dtype="int32")
+
+        mock_grad_q = paddle.rand_like(query)
+        mock_grad_k = paddle.rand_like(key)
+        mock_grad_v = paddle.rand_like(value)
+
+        original_fa = paddle.base.framework.get_flags(["FLAGS_flash_attn_version"])[
+            "FLAGS_flash_attn_version"
+        ]
+        try:
+            paddle.base.framework.set_flags({"FLAGS_flash_attn_version": 3})
+            with patch.object(
+                paddle._C_ops,
+                "flashmask_attention_v2_grad",
+                return_value=(mock_grad_q, mock_grad_k, mock_grad_v),
+            ):
+                grad_q, grad_k, grad_v = _flashmask_attention_backward_dispatch(
+                    grad_output, query, key, value, output, lse,
+                    startend_row_indices, causal=False, softmax_scale=self.scaling,
+                )
+                self.assertEqual(grad_q.shape, query.shape)
+        finally:
+            paddle.base.framework.set_flags({"FLAGS_flash_attn_version": original_fa})
+
+
+class TestLSEShapeCompat(unittest.TestCase):
+    """Test LSE shape compatibility when kernel returns rounded sequence length."""
+
+    def test_lse_rounded_shape(self):
+        """Test that rounded LSE shape is handled correctly in forward."""
+        from unittest.mock import patch
+
+        paddle.seed(42)
+        batch, seq, heads, dim = 1, 100, 4, 64
+        dtype = "bfloat16"
+
+        query = paddle.rand([batch, seq, heads, dim], dtype=dtype)
+        key = paddle.rand([batch, seq, heads, dim], dtype=dtype)
+        value = paddle.rand([batch, seq, heads, dim], dtype=dtype)
+        sink = paddle.rand([heads], dtype=dtype)
+
+        # Mock _flash_attention_forward_dispatch to return a rounded LSE
+        mock_out = paddle.rand([batch, seq, heads, dim], dtype=dtype)
+        # Simulate a rounded LSE (e.g., 128 instead of 100)
+        rounded_seq = 128
+        mock_lse = paddle.rand([batch, heads, rounded_seq], dtype="float32")
+
+        with patch(
+            "paddlefleet.transformer.sink_impl._flash_attention_forward_dispatch",
+            return_value=(mock_out, mock_lse),
+        ):
+            out = sink_attention_forward(
+                query, key, value, sink, causal=True, softmax_scale=dim**-0.5
+            )
+            self.assertEqual(out.shape, [batch, seq, heads, dim])
+
+
+class TestFlashMaskSoftmaxScaleWarning(unittest.TestCase):
+    """Test that FlashMask v1 (FA2) prints warning for custom softmax_scale."""
+
+    def setUp(self):
+        paddle.seed(42)
+        self.batch_size = 1
+        self.seq_len = 128
+        self.num_heads = 8
+        self.head_dim = 64
+        self.dtype = "bfloat16"
+        # Ensure FA version is 2
+        paddle.base.framework.set_flags({"FLAGS_flash_attn_version": 2})
+
+    def tearDown(self):
+        paddle.base.framework.set_flags({"FLAGS_flash_attn_version": 2})
+
+    def test_custom_softmax_scale_warning(self):
+        """Test that custom softmax_scale triggers warning in FlashMask FA2 path."""
+        import io
+        import sys
+
+        query = paddle.rand(
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+            dtype=self.dtype,
+        )
+        key = paddle.rand(
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+            dtype=self.dtype,
+        )
+        value = paddle.rand(
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+            dtype=self.dtype,
+        )
+        sink = paddle.rand([self.num_heads], dtype=self.dtype)
+
+        # Non-causal flashmask indices
+        indices = np.zeros(
+            (self.batch_size, self.num_heads, self.seq_len, 2), dtype="int32"
+        )
+        diag = np.arange(self.seq_len).reshape((1, 1, self.seq_len))
+        indices[:, :, :, 0] = diag
+        indices[:, :, :, 1] = 0
+        startend_row_indices = paddle.to_tensor(indices, dtype="int32")
+
+        # Use a non-default softmax_scale to trigger the warning
+        custom_scale = 0.5  # Different from 1/sqrt(head_dim)
+
+        captured = io.StringIO()
+        sys.stdout = captured
+        try:
+            out = sink_attention_forward(
+                query, key, value, sink,
+                startend_row_indices=startend_row_indices,
+                causal=False,
+                softmax_scale=custom_scale,
+            )
+        finally:
+            sys.stdout = sys.__stdout__
+
+        output = captured.getvalue()
+        self.assertIn("FlashMask v1 doesn't support custom softmax_scale", output)
 
 
 # Standard entry point to run the tests when the script is executed directly

--- a/tests/single_card_tests/transformer/test_attention_sink.py
+++ b/tests/single_card_tests/transformer/test_attention_sink.py
@@ -23,7 +23,6 @@ from paddlefleet.transformer.sink_impl import (
     _flash_attention_forward_dispatch,
     _flashmask_attention_backward_dispatch,
     _flashmask_attention_forward_dispatch,
-    _get_fa_version,
     gen_dense_mask_from_startend_row_indices,
     sink_attention_forward,
 )
@@ -689,13 +688,27 @@ class TestBackward(unittest.TestCase):
         self.assertEqual(value.grad.shape, value.shape)
 
 
-def _is_sm90_or_above():
-    """Check if the GPU supports SM90+ (Hopper), required for FA3."""
+def _is_sm90():
+    """Check if the GPU is Hopper (SM90), required for FA3.
+
+    FA3 kernels target Hopper only; on Blackwell (SM100) FA3 will not run.
+    """
     if not paddle.is_compiled_with_cuda():
         return False
     try:
         cap = paddle.device.cuda.get_device_capability()
-        return cap[0] >= 9
+        return cap[0] == 9
+    except Exception:
+        return False
+
+
+def _is_sm100():
+    """Check if the GPU is Blackwell (SM100), required for FA4."""
+    if not paddle.is_compiled_with_cuda():
+        return False
+    try:
+        cap = paddle.device.cuda.get_device_capability()
+        return cap[0] == 10
     except Exception:
         return False
 
@@ -707,12 +720,12 @@ class TestFA3Path(unittest.TestCase):
     def setUpClass(cls):
         cls.has_fa3 = (
             hasattr(paddle.base.libpaddle.pir.ops, "flash_attn_v3")
-            and _is_sm90_or_above()
+            and _is_sm90()
         )
 
     def setUp(self):
         if not self.has_fa3:
-            self.skipTest("flash_attn_v3 requires Hopper GPU (SM90+)")
+            self.skipTest("flash_attn_v3 requires Hopper GPU (SM90)")
         paddle.seed(42)
         self.batch_size = 1
         self.seq_len = 128
@@ -886,66 +899,188 @@ class TestFA3Path(unittest.TestCase):
         self.assertIsNotNone(key.grad)
 
 
-class TestGetFaVersion(unittest.TestCase):
-    """Tests for _get_fa_version logic."""
+class TestFA4Path(unittest.TestCase):
+    """Tests for the FA4 code path on Blackwell GPUs (SM100, e.g. B100)."""
 
-    def test_deterministic_fallback_fa3_large_head_dim(self):
-        """When FA3 + deterministic + head_dim > 128, should fall back to version 2."""
-        original_fa = paddle.base.framework.get_flags(
-            ["FLAGS_flash_attn_version"]
-        )["FLAGS_flash_attn_version"]
-        original_det = paddle.base.framework.get_flags(
-            ["FLAGS_cudnn_deterministic"]
-        )["FLAGS_cudnn_deterministic"]
-        try:
-            paddle.base.framework.set_flags(
-                {
-                    "FLAGS_flash_attn_version": 3,
-                    "FLAGS_cudnn_deterministic": 1,
-                }
-            )
-            # head_dim > 128 should trigger fallback to v2
-            self.assertEqual(_get_fa_version(head_dim=256), 2)
-            # head_dim <= 128 should not trigger fallback
-            self.assertEqual(_get_fa_version(head_dim=128), 3)
-            self.assertEqual(_get_fa_version(head_dim=64), 3)
-        finally:
-            paddle.base.framework.set_flags(
-                {
-                    "FLAGS_flash_attn_version": original_fa,
-                    "FLAGS_cudnn_deterministic": original_det,
-                }
-            )
+    @classmethod
+    def setUpClass(cls):
+        cls.has_fa4 = _is_sm100()
+        if cls.has_fa4:
+            try:
+                from paddlefleet.ops.flash_mask.cute.interface import (  # noqa: F401
+                    _flash_attn_bwd,
+                    _flash_attn_fwd,
+                )
+            except Exception:
+                cls.has_fa4 = False
 
-    def test_no_fallback_when_not_deterministic(self):
-        """When deterministic is off, FA3 should be returned as-is."""
-        original_fa = paddle.base.framework.get_flags(
-            ["FLAGS_flash_attn_version"]
-        )["FLAGS_flash_attn_version"]
-        original_det = paddle.base.framework.get_flags(
-            ["FLAGS_cudnn_deterministic"]
-        )["FLAGS_cudnn_deterministic"]
-        try:
-            paddle.base.framework.set_flags(
-                {
-                    "FLAGS_flash_attn_version": 3,
-                    "FLAGS_cudnn_deterministic": 0,
-                }
-            )
-            self.assertEqual(_get_fa_version(head_dim=256), 3)
-        finally:
-            paddle.base.framework.set_flags(
-                {
-                    "FLAGS_flash_attn_version": original_fa,
-                    "FLAGS_cudnn_deterministic": original_det,
-                }
-            )
+    def setUp(self):
+        if not self.has_fa4:
+            self.skipTest("FA4 requires Blackwell GPU (SM100)")
+        paddle.seed(42)
+        self.batch_size = 1
+        self.seq_len = 128
+        self.num_heads = 8
+        self.head_dim = 64
+        self.dtype = "bfloat16"
+        self.scaling = self.head_dim**-0.5
+        paddle.base.framework.set_flags({"FLAGS_flash_attn_version": 4})
+
+    def tearDown(self):
+        paddle.base.framework.set_flags({"FLAGS_flash_attn_version": 2})
+
+    def test_fa4_forward_causal(self):
+        """Test FA4 causal forward produces correct output shape."""
+        query = paddle.rand(
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+            dtype=self.dtype,
+        )
+        key = paddle.rand(
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+            dtype=self.dtype,
+        )
+        value = paddle.rand(
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+            dtype=self.dtype,
+        )
+        sink = paddle.rand([self.num_heads], dtype=self.dtype)
+
+        out = sink_attention_forward(
+            query,
+            key,
+            value,
+            sink,
+            causal=True,
+            softmax_scale=self.scaling,
+        )
+        self.assertEqual(
+            out.shape,
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+        )
+
+    def test_fa4_backward(self):
+        """Test FA4 backward produces gradients for all inputs."""
+        query = paddle.rand(
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+            dtype=self.dtype,
+        )
+        key = paddle.rand(
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+            dtype=self.dtype,
+        )
+        value = paddle.rand(
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+            dtype=self.dtype,
+        )
+        sink = paddle.rand([self.num_heads], dtype=self.dtype)
+        query.stop_gradient = False
+        key.stop_gradient = False
+        value.stop_gradient = False
+        sink.stop_gradient = False
+
+        out = sink_attention_forward(
+            query,
+            key,
+            value,
+            sink,
+            causal=True,
+            softmax_scale=self.scaling,
+        )
+        loss = out.sum()
+        loss.backward()
+
+        self.assertIsNotNone(query.grad)
+        self.assertIsNotNone(key.grad)
+        self.assertIsNotNone(value.grad)
+
+    def test_fa4_flashmask_forward(self):
+        """Test FlashMask with FA4 forward produces correct output shape."""
+        query = paddle.rand(
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+            dtype=self.dtype,
+        )
+        key = paddle.rand(
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+            dtype=self.dtype,
+        )
+        value = paddle.rand(
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+            dtype=self.dtype,
+        )
+        sink = paddle.rand([self.num_heads], dtype=self.dtype)
+
+        indices = np.zeros(
+            (self.batch_size, self.num_heads, self.seq_len, 2), dtype="int32"
+        )
+        diag = np.arange(self.seq_len).reshape((1, 1, self.seq_len))
+        indices[:, :, :, 0] = diag
+        indices[:, :, :, 1] = 0
+        startend_row_indices = paddle.to_tensor(indices, dtype="int32")
+
+        out = sink_attention_forward(
+            query,
+            key,
+            value,
+            sink,
+            startend_row_indices=startend_row_indices,
+            causal=False,
+            softmax_scale=self.scaling,
+        )
+        self.assertEqual(
+            out.shape,
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+        )
+
+    def test_fa4_flashmask_backward(self):
+        """Test FlashMask with FA4 backward produces gradients."""
+        query = paddle.rand(
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+            dtype=self.dtype,
+        )
+        key = paddle.rand(
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+            dtype=self.dtype,
+        )
+        value = paddle.rand(
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+            dtype=self.dtype,
+        )
+        sink = paddle.rand([self.num_heads], dtype=self.dtype)
+        query.stop_gradient = False
+        key.stop_gradient = False
+        value.stop_gradient = False
+        sink.stop_gradient = False
+
+        indices = np.zeros(
+            (self.batch_size, self.num_heads, self.seq_len, 2), dtype="int32"
+        )
+        diag = np.arange(self.seq_len).reshape((1, 1, self.seq_len))
+        indices[:, :, :, 0] = diag
+        indices[:, :, :, 1] = 0
+        startend_row_indices = paddle.to_tensor(indices, dtype="int32")
+
+        out = sink_attention_forward(
+            query,
+            key,
+            value,
+            sink,
+            startend_row_indices=startend_row_indices,
+            causal=False,
+            softmax_scale=self.scaling,
+        )
+        loss = out.sum()
+        loss.backward()
+
+        self.assertIsNotNone(query.grad)
+        self.assertIsNotNone(key.grad)
 
 
 class TestFA3PathMocked(unittest.TestCase):
     """Test FA3 code paths using mocks (for non-Hopper machines)."""
 
     def setUp(self):
+        if not _is_sm90():
+            self.skipTest("FA3 only available on Hopper (SM90)")
         paddle.seed(42)
         self.batch_size = 1
         self.seq_len = 64

--- a/tests/single_card_tests/transformer/test_attention_sink.py
+++ b/tests/single_card_tests/transformer/test_attention_sink.py
@@ -19,13 +19,13 @@ import paddle
 from paddle import nn
 
 from paddlefleet.transformer.sink_impl import (
+    _flash_attention_backward_dispatch,
+    _flash_attention_forward_dispatch,
+    _flashmask_attention_backward_dispatch,
+    _flashmask_attention_forward_dispatch,
+    _get_fa_version,
     gen_dense_mask_from_startend_row_indices,
     sink_attention_forward,
-    _get_fa_version,
-    _flash_attention_forward_dispatch,
-    _flash_attention_backward_dispatch,
-    _flashmask_attention_forward_dispatch,
-    _flashmask_attention_backward_dispatch,
 )
 
 
@@ -570,7 +570,10 @@ class TestBackward(unittest.TestCase):
         query, key, value, sink = self._make_tensors()
 
         out = sink_attention_forward(
-            query, key, value, sink,
+            query,
+            key,
+            value,
+            sink,
             causal=True,
             softmax_scale=self.scaling,
         )
@@ -590,7 +593,10 @@ class TestBackward(unittest.TestCase):
         query, key, value, sink = self._make_tensors(stop_gradient_sink=True)
 
         out = sink_attention_forward(
-            query, key, value, sink,
+            query,
+            key,
+            value,
+            sink,
             causal=True,
             softmax_scale=self.scaling,
         )
@@ -617,7 +623,10 @@ class TestBackward(unittest.TestCase):
         startend_row_indices = paddle.to_tensor(indices, dtype="int32")
 
         out = sink_attention_forward(
-            query, key, value, sink,
+            query,
+            key,
+            value,
+            sink,
             startend_row_indices=startend_row_indices,
             causal=False,
             softmax_scale=self.scaling,
@@ -643,7 +652,10 @@ class TestBackward(unittest.TestCase):
         startend_row_indices = paddle.to_tensor(indices, dtype="int32")
 
         out = sink_attention_forward(
-            query, key, value, sink,
+            query,
+            key,
+            value,
+            sink,
             startend_row_indices=startend_row_indices,
             causal=False,
             softmax_scale=self.scaling,
@@ -660,7 +672,10 @@ class TestBackward(unittest.TestCase):
         query, key, value, sink = self._make_tensors(num_kv_heads=num_kv_heads)
 
         out = sink_attention_forward(
-            query, key, value, sink,
+            query,
+            key,
+            value,
+            sink,
             causal=True,
             softmax_scale=self.scaling,
         )
@@ -729,7 +744,10 @@ class TestFA3Path(unittest.TestCase):
         sink = paddle.rand([self.num_heads], dtype=self.dtype)
 
         out = sink_attention_forward(
-            query, key, value, sink,
+            query,
+            key,
+            value,
+            sink,
             causal=True,
             softmax_scale=self.scaling,
         )
@@ -759,7 +777,10 @@ class TestFA3Path(unittest.TestCase):
         sink.stop_gradient = False
 
         out = sink_attention_forward(
-            query, key, value, sink,
+            query,
+            key,
+            value,
+            sink,
             causal=True,
             softmax_scale=self.scaling,
         )
@@ -774,9 +795,7 @@ class TestFA3Path(unittest.TestCase):
         """Test FlashMask with FA3 forward produces correct output shape."""
         has_flashmask_v2 = hasattr(
             paddle.base.libpaddle.pir.ops, "flashmask_attention_v2"
-        ) or hasattr(
-            paddle.nn.functional, "flashmask_attention"
-        )
+        ) or hasattr(paddle.nn.functional, "flashmask_attention")
         if not has_flashmask_v2:
             self.skipTest("flashmask_attention not available for FA3")
 
@@ -804,7 +823,10 @@ class TestFA3Path(unittest.TestCase):
         startend_row_indices = paddle.to_tensor(indices, dtype="int32")
 
         out = sink_attention_forward(
-            query, key, value, sink,
+            query,
+            key,
+            value,
+            sink,
             startend_row_indices=startend_row_indices,
             causal=False,
             softmax_scale=self.scaling,
@@ -849,7 +871,10 @@ class TestFA3Path(unittest.TestCase):
         startend_row_indices = paddle.to_tensor(indices, dtype="int32")
 
         out = sink_attention_forward(
-            query, key, value, sink,
+            query,
+            key,
+            value,
+            sink,
             startend_row_indices=startend_row_indices,
             causal=False,
             softmax_scale=self.scaling,
@@ -866,47 +891,55 @@ class TestGetFaVersion(unittest.TestCase):
 
     def test_deterministic_fallback_fa3_large_head_dim(self):
         """When FA3 + deterministic + head_dim > 128, should fall back to version 2."""
-        original_fa = paddle.base.framework.get_flags(["FLAGS_flash_attn_version"])[
-            "FLAGS_flash_attn_version"
-        ]
-        original_det = paddle.base.framework.get_flags(["FLAGS_cudnn_deterministic"])[
-            "FLAGS_cudnn_deterministic"
-        ]
+        original_fa = paddle.base.framework.get_flags(
+            ["FLAGS_flash_attn_version"]
+        )["FLAGS_flash_attn_version"]
+        original_det = paddle.base.framework.get_flags(
+            ["FLAGS_cudnn_deterministic"]
+        )["FLAGS_cudnn_deterministic"]
         try:
-            paddle.base.framework.set_flags({
-                "FLAGS_flash_attn_version": 3,
-                "FLAGS_cudnn_deterministic": 1,
-            })
+            paddle.base.framework.set_flags(
+                {
+                    "FLAGS_flash_attn_version": 3,
+                    "FLAGS_cudnn_deterministic": 1,
+                }
+            )
             # head_dim > 128 should trigger fallback to v2
             self.assertEqual(_get_fa_version(head_dim=256), 2)
             # head_dim <= 128 should not trigger fallback
             self.assertEqual(_get_fa_version(head_dim=128), 3)
             self.assertEqual(_get_fa_version(head_dim=64), 3)
         finally:
-            paddle.base.framework.set_flags({
-                "FLAGS_flash_attn_version": original_fa,
-                "FLAGS_cudnn_deterministic": original_det,
-            })
+            paddle.base.framework.set_flags(
+                {
+                    "FLAGS_flash_attn_version": original_fa,
+                    "FLAGS_cudnn_deterministic": original_det,
+                }
+            )
 
     def test_no_fallback_when_not_deterministic(self):
         """When deterministic is off, FA3 should be returned as-is."""
-        original_fa = paddle.base.framework.get_flags(["FLAGS_flash_attn_version"])[
-            "FLAGS_flash_attn_version"
-        ]
-        original_det = paddle.base.framework.get_flags(["FLAGS_cudnn_deterministic"])[
-            "FLAGS_cudnn_deterministic"
-        ]
+        original_fa = paddle.base.framework.get_flags(
+            ["FLAGS_flash_attn_version"]
+        )["FLAGS_flash_attn_version"]
+        original_det = paddle.base.framework.get_flags(
+            ["FLAGS_cudnn_deterministic"]
+        )["FLAGS_cudnn_deterministic"]
         try:
-            paddle.base.framework.set_flags({
-                "FLAGS_flash_attn_version": 3,
-                "FLAGS_cudnn_deterministic": 0,
-            })
+            paddle.base.framework.set_flags(
+                {
+                    "FLAGS_flash_attn_version": 3,
+                    "FLAGS_cudnn_deterministic": 0,
+                }
+            )
             self.assertEqual(_get_fa_version(head_dim=256), 3)
         finally:
-            paddle.base.framework.set_flags({
-                "FLAGS_flash_attn_version": original_fa,
-                "FLAGS_cudnn_deterministic": original_det,
-            })
+            paddle.base.framework.set_flags(
+                {
+                    "FLAGS_flash_attn_version": original_fa,
+                    "FLAGS_cudnn_deterministic": original_det,
+                }
+            )
 
 
 class TestFA3PathMocked(unittest.TestCase):
@@ -924,6 +957,7 @@ class TestFA3PathMocked(unittest.TestCase):
     def test_fa3_forward_dispatch(self):
         """Test FA3 forward path by mocking _C_ops.flash_attn_v3."""
         from unittest.mock import patch
+
         query = paddle.rand(
             [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
             dtype=self.dtype,
@@ -946,13 +980,15 @@ class TestFA3PathMocked(unittest.TestCase):
             [self.batch_size, self.num_heads, self.seq_len], dtype="float32"
         )
 
-        original_fa = paddle.base.framework.get_flags(["FLAGS_flash_attn_version"])[
-            "FLAGS_flash_attn_version"
-        ]
+        original_fa = paddle.base.framework.get_flags(
+            ["FLAGS_flash_attn_version"]
+        )["FLAGS_flash_attn_version"]
         try:
             paddle.base.framework.set_flags({"FLAGS_flash_attn_version": 3})
             with patch.object(
-                paddle._C_ops, "flash_attn_v3", return_value=(mock_out, mock_lse)
+                paddle._C_ops,
+                "flash_attn_v3",
+                return_value=(mock_out, mock_lse),
             ):
                 out, lse = _flash_attention_forward_dispatch(
                     query, key, value, causal=True, softmax_scale=self.scaling
@@ -960,7 +996,9 @@ class TestFA3PathMocked(unittest.TestCase):
                 self.assertEqual(out.shape, mock_out.shape)
                 self.assertEqual(lse.shape, mock_lse.shape)
         finally:
-            paddle.base.framework.set_flags({"FLAGS_flash_attn_version": original_fa})
+            paddle.base.framework.set_flags(
+                {"FLAGS_flash_attn_version": original_fa}
+            )
 
     def test_fa3_backward_dispatch(self):
         """Test FA3 backward path by mocking _C_ops.flash_attn_v3_grad."""
@@ -994,9 +1032,9 @@ class TestFA3PathMocked(unittest.TestCase):
         mock_grad_k = paddle.rand_like(key)
         mock_grad_v = paddle.rand_like(value)
 
-        original_fa = paddle.base.framework.get_flags(["FLAGS_flash_attn_version"])[
-            "FLAGS_flash_attn_version"
-        ]
+        original_fa = paddle.base.framework.get_flags(
+            ["FLAGS_flash_attn_version"]
+        )["FLAGS_flash_attn_version"]
         try:
             paddle.base.framework.set_flags({"FLAGS_flash_attn_version": 3})
             with patch.object(
@@ -1005,14 +1043,22 @@ class TestFA3PathMocked(unittest.TestCase):
                 return_value=(mock_grad_q, mock_grad_k, mock_grad_v),
             ):
                 grad_q, grad_k, grad_v = _flash_attention_backward_dispatch(
-                    grad_output, query, key, value, output, lse,
-                    causal=True, softmax_scale=self.scaling,
+                    grad_output,
+                    query,
+                    key,
+                    value,
+                    output,
+                    lse,
+                    causal=True,
+                    softmax_scale=self.scaling,
                 )
                 self.assertEqual(grad_q.shape, query.shape)
                 self.assertEqual(grad_k.shape, key.shape)
                 self.assertEqual(grad_v.shape, value.shape)
         finally:
-            paddle.base.framework.set_flags({"FLAGS_flash_attn_version": original_fa})
+            paddle.base.framework.set_flags(
+                {"FLAGS_flash_attn_version": original_fa}
+            )
 
     def test_fa3_flashmask_forward_dispatch(self):
         """Test FlashMask with FA3 forward produces correct output shape."""
@@ -1047,9 +1093,9 @@ class TestFA3PathMocked(unittest.TestCase):
             [self.batch_size, self.num_heads, self.seq_len], dtype="float32"
         )
 
-        original_fa = paddle.base.framework.get_flags(["FLAGS_flash_attn_version"])[
-            "FLAGS_flash_attn_version"
-        ]
+        original_fa = paddle.base.framework.get_flags(
+            ["FLAGS_flash_attn_version"]
+        )["FLAGS_flash_attn_version"]
         try:
             paddle.base.framework.set_flags({"FLAGS_flash_attn_version": 3})
             with patch(
@@ -1057,12 +1103,18 @@ class TestFA3PathMocked(unittest.TestCase):
                 return_value=(mock_out, mock_lse),
             ):
                 out, lse = _flashmask_attention_forward_dispatch(
-                    query, key, value, startend_row_indices,
-                    causal=False, softmax_scale=self.scaling,
+                    query,
+                    key,
+                    value,
+                    startend_row_indices,
+                    causal=False,
+                    softmax_scale=self.scaling,
                 )
                 self.assertEqual(out.shape, mock_out.shape)
         finally:
-            paddle.base.framework.set_flags({"FLAGS_flash_attn_version": original_fa})
+            paddle.base.framework.set_flags(
+                {"FLAGS_flash_attn_version": original_fa}
+            )
 
     def test_fa3_flashmask_backward_dispatch(self):
         """Test FlashMask FA3 backward dispatch via mock."""
@@ -1104,9 +1156,9 @@ class TestFA3PathMocked(unittest.TestCase):
         mock_grad_k = paddle.rand_like(key)
         mock_grad_v = paddle.rand_like(value)
 
-        original_fa = paddle.base.framework.get_flags(["FLAGS_flash_attn_version"])[
-            "FLAGS_flash_attn_version"
-        ]
+        original_fa = paddle.base.framework.get_flags(
+            ["FLAGS_flash_attn_version"]
+        )["FLAGS_flash_attn_version"]
         try:
             paddle.base.framework.set_flags({"FLAGS_flash_attn_version": 3})
             with patch.object(
@@ -1115,12 +1167,21 @@ class TestFA3PathMocked(unittest.TestCase):
                 return_value=(mock_grad_q, mock_grad_k, mock_grad_v),
             ):
                 grad_q, grad_k, grad_v = _flashmask_attention_backward_dispatch(
-                    grad_output, query, key, value, output, lse,
-                    startend_row_indices, causal=False, softmax_scale=self.scaling,
+                    grad_output,
+                    query,
+                    key,
+                    value,
+                    output,
+                    lse,
+                    startend_row_indices,
+                    causal=False,
+                    softmax_scale=self.scaling,
                 )
                 self.assertEqual(grad_q.shape, query.shape)
         finally:
-            paddle.base.framework.set_flags({"FLAGS_flash_attn_version": original_fa})
+            paddle.base.framework.set_flags(
+                {"FLAGS_flash_attn_version": original_fa}
+            )
 
 
 class TestLSEShapeCompat(unittest.TestCase):
@@ -1206,7 +1267,10 @@ class TestFlashMaskSoftmaxScaleWarning(unittest.TestCase):
         sys.stdout = captured
         try:
             out = sink_attention_forward(
-                query, key, value, sink,
+                query,
+                key,
+                value,
+                sink,
                 startend_row_indices=startend_row_indices,
                 causal=False,
                 softmax_scale=custom_scale,
@@ -1215,7 +1279,9 @@ class TestFlashMaskSoftmaxScaleWarning(unittest.TestCase):
             sys.stdout = sys.__stdout__
 
         output = captured.getvalue()
-        self.assertIn("FlashMask v1 doesn't support custom softmax_scale", output)
+        self.assertIn(
+            "FlashMask v1 doesn't support custom softmax_scale", output
+        )
 
 
 # Standard entry point to run the tests when the script is executed directly

--- a/tests/single_card_tests/transformer/test_attention_sink.py
+++ b/tests/single_card_tests/transformer/test_attention_sink.py
@@ -1,0 +1,447 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+import paddle
+from paddle import nn
+
+from paddlefleet.transformer.sink_impl import sink_attention_forward
+
+
+def eager_attention_forward(module, query, key, value, scaling, **kwargs):
+    """
+    Minimal eager-path implementation: naive matmul softmax for the smoke test only.
+    Inputs are [B, H, S, D]; returns (attn_output[B, S, H*D], None).
+    """
+    k_t = paddle.transpose(key, perm=[0, 1, 3, 2])
+    attn_weights = paddle.matmul(query, k_t) * scaling
+    probs = nn.functional.softmax(
+        attn_weights, axis=-1, dtype=attn_weights.dtype
+    )
+    out = paddle.matmul(probs, value)
+    out = paddle.transpose(out, perm=[0, 2, 1, 3]).contiguous()
+    out = paddle.reshape(x=out, shape=[0, 0, out.shape[2] * out.shape[3]])
+    return out, None
+
+
+def sdpa_attention_forward(
+    module, query, key, value, scaling, is_causal=False, sink=None, **kwargs
+):
+    """
+    SDPA-style attention entry. Inputs are [B, H, S, D]; forwards to
+    sink_attention_forward (which expects [B, S, H, D]). When sink is None,
+    falls back to native SDPA.
+    """
+    q = paddle.transpose(query, perm=[0, 2, 1, 3])
+    k = paddle.transpose(key, perm=[0, 2, 1, 3])
+    v = paddle.transpose(value, perm=[0, 2, 1, 3])
+    if sink is None:
+        out = paddle.nn.functional.scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            attn_mask=None,
+            dropout_p=0.0,
+            is_causal=is_causal,
+            training=True,
+        )
+    else:
+        out = sink_attention_forward(
+            q,
+            k,
+            v,
+            sink,
+            startend_row_indices=None,
+            softmax_scale=scaling,
+            causal=is_causal,
+        )
+    out = paddle.reshape(x=out, shape=[0, 0, out.shape[2] * out.shape[3]])
+    return out, None
+
+
+def flashmask_attention_forward(
+    module,
+    query,
+    key,
+    value,
+    scaling,
+    attn_mask_startend_row_indices,
+    sink=None,
+    is_causal=False,
+    **kwargs,
+):
+    """FlashMask-style attention entry that routes through sink_attention_forward."""
+    q = paddle.transpose(query, perm=[0, 2, 1, 3])
+    k = paddle.transpose(key, perm=[0, 2, 1, 3])
+    v = paddle.transpose(value, perm=[0, 2, 1, 3])
+    out = sink_attention_forward(
+        q,
+        k,
+        v,
+        sink,
+        startend_row_indices=attn_mask_startend_row_indices,
+        softmax_scale=scaling,
+        causal=is_causal,
+    )
+    out = paddle.reshape(x=out, shape=[0, 0, out.shape[2] * out.shape[3]])
+    return out, None
+
+
+# Minimal dict-based registry of attention implementations, used by the tests
+# below to drive each path through a single dispatch table.
+ALL_ATTENTION_FUNCTIONS = {
+    "eager": eager_attention_forward,
+    "sdpa": sdpa_attention_forward,
+    "flashmask": flashmask_attention_forward,
+}
+
+
+def flashmask_to_densemask(
+    startend_row_indices, num_key_value_groups, dtype, causal=True
+):
+    """
+    Helper function to convert the sparse `startend_row_indices` format, used by FlashMask,
+    into a dense attention mask tensor that can be used by naive attention implementations.
+    """
+    bz, num_head, seq_len, bound_num = startend_row_indices.shape
+    m = paddle.zeros((bz, num_head, seq_len, seq_len), dtype=dtype)
+    has_end = (causal and bound_num == 2) or ((not causal) and bound_num == 4)
+
+    # Iterate through batch, heads, and sequence length to build the dense mask
+    for bi in range(bz):
+        for hi in range(num_head):
+            for j in range(seq_len):  # j represents the key/column index
+                downstart = startend_row_indices[bi, hi, j, 0].item()
+                if has_end:
+                    downend = startend_row_indices[bi, hi, j, 1].item()
+                    m[bi, hi, downstart:downend, j] = -np.inf
+                else:
+                    m[bi, hi, downstart:, j] = -np.inf
+
+                if causal:
+                    # For causal attention, mask out all future tokens
+                    m[bi, hi, j + 1 :, j] = -np.inf
+                else:
+                    # For non-causal, use the provided upper bounds
+                    if has_end:
+                        upstart = startend_row_indices[bi, hi, j, 2].item()
+                        upend = startend_row_indices[bi, hi, j, 3].item()
+                        m[bi, hi, upstart:upend, j] = -np.inf
+                    else:
+                        upend = startend_row_indices[bi, hi, j, 1].item()
+                        m[bi, hi, :upend, j] = -np.inf
+
+    # If using Grouped-Query Attention (GQA), the mask for KV heads must be
+    # expanded to match the number of Query heads.
+    if num_key_value_groups > 1:
+        m = m.unsqueeze(2).expand(
+            [bz, num_head, num_key_value_groups, seq_len, seq_len]
+        )
+        num_q_heads = num_head * num_key_value_groups
+        m = m.reshape([bz, num_q_heads, seq_len, seq_len])
+
+    # The final mask shape is [B, H, S, S] to match the attention weights matrix.
+    return m
+
+
+class TestAttentionInterface(unittest.TestCase):
+    """
+    Unit tests for the high-level attention dispatch helpers defined above.
+    This class tests both the callability and numerical correctness of different
+    attention implementations (e.g., sdpa, flashmask) against a naive reference.
+    """
+
+    def gen_random_flashmask(self, bz, num_head, seqlen, has_end, causal):
+        """Generates a random sparse mask in the FlashMask format [start, end]."""
+        mask_num = 1
+        if not causal:
+            mask_num *= 2
+        if has_end:
+            mask_num *= 2
+
+        m = np.random.randint(0, seqlen, (bz, num_head, seqlen, mask_num))
+        diag = np.arange(seqlen).reshape((1, 1, seqlen))
+
+        # Ensure start index is not after the diagonal
+        m[:, :, :, 0] = np.maximum(diag, m[:, :, :, 0])
+
+        if not causal:
+            if has_end:
+                raise NotImplementedError
+            # Ensure end index is after the start index
+            m[:, :, :, 1] = np.minimum(diag + 1, m[:, :, :, 1])
+        else:
+            m[:, :, :, 0] = diag  # For causal, start is always the diagonal
+            if has_end:
+                m[:, :, :, 1] = m[:, :, :, 0] + np.random.randint(
+                    1, seqlen, m[:, :, :, 0].shape
+                )
+                m[:, :, :, 1] = np.minimum(seqlen, m[:, :, :, 1])
+
+        return paddle.to_tensor(m, dtype="int32")
+
+    def setUp(self):
+        """Set up common parameters and tensors for all tests in this class."""
+        paddle.seed(92)  # Set a fixed seed for reproducibility
+        self.batch_size = 1
+        self.seq_len = 512
+        self.num_heads = 64
+        self.head_dim = 64
+
+        self.scaling = self.head_dim**-0.5
+        self.training = True
+        self.dtype = "bfloat16"
+
+        # Tensors are created in the [batch, seq_len, num_heads, head_dim] layout.
+        # This setup configures a Multi-Head Attention (MHA) scenario because the
+        # number of heads for key and value is the same as for query.
+        self.query = paddle.rand(
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+            dtype=self.dtype,
+        )
+        self.key = paddle.rand(
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+            dtype=self.dtype,
+        )
+        self.value = paddle.rand(
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+            dtype=self.dtype,
+        )
+        self.sink = paddle.rand([self.num_heads], dtype=self.dtype)
+
+        # Flashmask is generated based on the number of attention heads.
+        self.startend_row_indices = self.gen_random_flashmask(
+            self.batch_size,
+            self.num_heads,
+            self.seq_len,
+            has_end=False,
+            causal=False,
+        )
+
+    def assert_tensor_close(self, a, b, atol=1e-2, rtol=1e-2):
+        """
+        Assert that two tensors are close within specified tolerances.
+        Converts tensors to float32 before comparison for better stability.
+        """
+        # Cast to float32 to avoid precision issues with bfloat16 during comparison
+        a = a.to("float32")
+        b = b.to("float32")
+        self.assertTrue(
+            paddle.allclose(a, b, rtol=rtol, atol=atol, equal_nan=True),
+            f"Tensors are not close.\n"
+            f"Max Abs Error: {paddle.max(paddle.abs(a - b)).item()}\n"
+            f"Max Rel Error: {paddle.max(paddle.abs(a - b) / (paddle.abs(b) + 1e-9)).item()}",
+        )
+
+    def naive_attn_sink(
+        self,
+        query: paddle.Tensor,
+        key: paddle.Tensor,
+        value: paddle.Tensor,
+        sink: paddle.Tensor,
+        attention_mask: paddle.Tensor | None,
+        scaling: float,
+        dropout: float = 0.0,
+        num_key_value_groups: int = 1,
+        **kwargs,
+    ):
+        """
+        A naive reference implementation of attention with a 'sink' mechanism.
+        This serves as the ground truth for correctness validation. It follows the
+        standard attention formula step-by-step.
+        """
+        # Step 1: Reshape tensors from [B, S, H, D] to [B, H, S, D] for matrix multiplication
+        query_states = paddle.transpose(query, perm=[0, 2, 1, 3])
+        key_states = paddle.transpose(key, perm=[0, 2, 1, 3])
+        value_states = paddle.transpose(value, perm=[0, 2, 1, 3])
+
+        # Step 2: Transpose key for matmul: [B, H, S, D] -> [B, H, D, S]
+        key_states = paddle.transpose(key_states, perm=[0, 1, 3, 2])
+
+        # Step 3: Calculate attention scores (Query @ Key^T) and apply scaling
+        attn_weights = paddle.matmul(query_states, key_states) * scaling
+
+        # Step 4: Apply the attention mask if provided
+        if attention_mask is not None:
+            causal_mask = attention_mask[:, :, :, : key_states.shape[-1]]
+            attn_weights = attn_weights + causal_mask
+
+        # Step 5: Prepare and concatenate the sink logits. The sink is a special token
+        # that every other token can attend to, preventing the attention from collapsing.
+        sinks = sink.reshape(shape=[1, -1, 1, 1]).expand(
+            shape=[query_states.shape[0], -1, query_states.shape[-2], -1]
+        )
+        combined_logits = paddle.cat(x=[attn_weights, sinks], axis=-1)
+
+        # Step 6: Apply softmax over the combined logits (scores + sink)
+        combined_logits = combined_logits - paddle.max(
+            combined_logits, axis=-1, keepdim=True
+        )
+        probs = nn.functional.softmax(
+            combined_logits, axis=-1, dtype=combined_logits.dtype
+        )
+
+        # Step 7: Separate the attention probabilities from the sink probabilities
+        scores = probs[..., :-1]
+
+        # Step 8: Apply dropout to the scores
+        attn_weights = nn.functional.dropout(scores, p=dropout, training=True)
+
+        # Step 9: Compute the weighted sum of values (Scores @ Value)
+        attn_output = paddle.matmul(attn_weights, value_states)
+
+        # Step 10: Reshape the output back to [B, S, H, D] and flatten the head dimension
+        attn_output = paddle.transpose(
+            attn_output, perm=[0, 2, 1, 3]
+        ).contiguous()
+        attn_output = paddle.reshape(
+            x=attn_output,
+            shape=[0, 0, attn_output.shape[2] * attn_output.shape[3]],
+        )
+
+        return attn_output
+
+    def test_forward_calls_correct_function(self):
+        """
+        A simple 'smoke test' to ensure that all attention interfaces can be
+        called with the configured tensors without raising an error.
+        """
+        # Test the basic eager implementation
+        eager_interface = ALL_ATTENTION_FUNCTIONS["eager"]
+        eager_interface(
+            self,
+            self.query.transpose([0, 2, 1, 3]),
+            self.key.transpose([0, 2, 1, 3]),
+            self.value.transpose([0, 2, 1, 3]),
+            scaling=self.scaling,
+        )
+
+        # Test the SDPA implementation (without and with sink)
+        sdpa_interface = ALL_ATTENTION_FUNCTIONS["sdpa"]
+        sdpa_interface(
+            self,
+            self.query.transpose([0, 2, 1, 3]),
+            self.key.transpose([0, 2, 1, 3]),
+            self.value.transpose([0, 2, 1, 3]),
+            scaling=self.scaling,
+        )
+        sdpa_interface(
+            self,
+            self.query.transpose([0, 2, 1, 3]),
+            self.key.transpose([0, 2, 1, 3]),
+            self.value.transpose([0, 2, 1, 3]),
+            sink=self.sink,
+            scaling=self.scaling,
+        )
+
+        # Test the FlashMask implementation with its specific arguments
+        flashmask_interface = ALL_ATTENTION_FUNCTIONS["flashmask"]
+        flashmask_interface(
+            self,
+            self.query.transpose([0, 2, 1, 3]),
+            self.key.transpose([0, 2, 1, 3]),
+            self.value.transpose([0, 2, 1, 3]),
+            scaling=self.scaling,
+            attn_mask_startend_row_indices=self.startend_row_indices,
+            sink=self.sink,
+        )
+
+    def test_correctness(self):
+        """
+        Verifies the numerical correctness of optimized attention implementations
+        against the naive reference implementation.
+        """
+        # --- Test 1: SDPA with Causal Mask and Sink ---
+
+        # Get the output from the optimized SDPA implementation
+        sdpa_interface = ALL_ATTENTION_FUNCTIONS["sdpa"]
+        sdpa_output, _ = sdpa_interface(
+            self,
+            self.query.transpose([0, 2, 1, 3]),
+            self.key.transpose([0, 2, 1, 3]),
+            self.value.transpose([0, 2, 1, 3]),
+            sink=self.sink,
+            scaling=self.scaling,
+            is_causal=True,
+        )
+
+        # Create the ground truth dense causal mask for the naive implementation
+        causal_mask = paddle.triu(
+            paddle.full(
+                shape=[self.seq_len, self.seq_len],
+                fill_value=float("-inf"),
+                dtype=self.dtype,
+            ),
+            diagonal=1,
+        )
+        causal_mask = (
+            causal_mask.unsqueeze(0)
+            .unsqueeze(0)
+            .expand(shape=[self.batch_size, self.num_heads, -1, -1])
+        )
+
+        # Get the output from the naive reference implementation
+        eager_output_causal = self.naive_attn_sink(
+            self.query,
+            self.key,
+            self.value,
+            self.sink,
+            causal_mask,
+            self.scaling,
+        )
+
+        # Compare the results from the optimized and naive implementations
+        self.assert_tensor_close(sdpa_output, eager_output_causal)
+
+        # --- Test 2: FlashMask with Non-Causal Mask and Sink ---
+
+        # Get the output from the optimized FlashMask implementation
+        flashmask_interface = ALL_ATTENTION_FUNCTIONS["flashmask"]
+        flashmask_output, _ = flashmask_interface(
+            self,
+            self.query.transpose([0, 2, 1, 3]),
+            self.key.transpose([0, 2, 1, 3]),
+            self.value.transpose([0, 2, 1, 3]),
+            scaling=self.scaling,
+            attn_mask_startend_row_indices=self.startend_row_indices,
+            sink=self.sink,
+            is_causal=False,
+        )
+
+        # Create the ground truth dense mask from the FlashMask sparse format
+        dense_mask = flashmask_to_densemask(
+            self.startend_row_indices,
+            num_key_value_groups=1,
+            dtype=self.dtype,
+            causal=False,
+        )
+        # Get the output from the naive reference implementation
+        eager_output_flashmask = self.naive_attn_sink(
+            self.query,
+            self.key,
+            self.value,
+            self.sink,
+            dense_mask,
+            self.scaling,
+        )
+
+        # Compare the results
+        self.assert_tensor_close(flashmask_output, eager_output_flashmask)
+
+
+# Standard entry point to run the tests when the script is executed directly
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/transformer/test_dot_product_attention_sink.py
+++ b/tests/single_card_tests/transformer/test_dot_product_attention_sink.py
@@ -14,7 +14,7 @@
 
 """
 Module-level unit tests for DotProductAttention with the attention-sink
-mechanism enabled.
+mechanism enabled via softmax_type configuration.
 
 Unlike test_attention_sink.py which exercises the lower-level
 sink_attention_forward helper, this file instantiates
@@ -25,11 +25,10 @@ Covered:
 
 * forward numerical correctness on every path (bf16 on fused paths, fp32 on
   the eager path) against a naive concat-softmax-drop reference;
-* backward gradient flow on every path (q/k/v/sink all receive non-None
-  grads) plus numerical grad match on SDPA & FlashMask;
-* sink=None regression (unchanged behaviour and interaction with the
-  pre-existing softmax_offset Parameter);
-* sink / softmax_offset mutual-exclusion ValueError;
+* backward gradient flow on every path (q/k/v/softmax_offset all receive
+  non-None grads) plus numerical grad match on SDPA & FlashMask;
+* softmax_type='vanilla' regression (no sink behaviour);
+* softmax_type='off-by-one' consumes internal softmax_offset;
 * grouped-query attention with sink;
 * shape / dtype boundaries.
 """
@@ -200,9 +199,18 @@ class _SinkTestBase(unittest.TestCase):
         return q, k, v
 
     def _make_sink(self, dtype, num_heads=None):
+        """Generate a random sink value and return it (for reference computation)."""
         s = paddle.randn([num_heads or self.NUM_HEADS], dtype=dtype)
         s.stop_gradient = False
         return s
+
+    def _set_sink(self, attn, sink_value):
+        """Inject a sink value into attn.softmax_offset for testing."""
+        with paddle.no_grad():
+            attn.softmax_offset.set_value(
+                sink_value.clone().astype(attn.softmax_offset.dtype)
+            )
+        attn.softmax_offset.stop_gradient = False
 
     def _causal_mask(self, dtype):
         m = paddle.triu(
@@ -229,13 +237,14 @@ class TestDPASinkForwardFusedPaths(_SinkTestBase):
 
     def test_path_B_sdpa_causal(self):
         """Path B: bf16, no startend_row_indices, not eager -> SDPA branch."""
-        config = _make_config(bf16=True)
+        config = _make_config(bf16=True, softmax_type="learnable")
         attn = _make_attn(config)
 
         q, k, v = self._make_qkv(paddle.bfloat16)
         sink = self._make_sink(paddle.bfloat16)
+        self._set_sink(attn, sink)
 
-        out = attn(q, k, v, None, sink=sink)
+        out = attn(q, k, v, None)
         self.assertEqual(
             out.shape, [self.BATCH, self.SEQ, self.NUM_HEADS * self.HEAD_DIM]
         )
@@ -246,10 +255,15 @@ class TestDPASinkForwardFusedPaths(_SinkTestBase):
         )
         assert_close(out, ref, atol=1e-2, rtol=1e-2, msg="SDPA+sink fwd")
 
-        # backward: all inputs including sink must receive non-None gradients
+        # backward: all inputs including softmax_offset must receive non-None gradients
         loss = out.astype("float32").mean()
         loss.backward()
-        for name, t in [("q", q), ("k", k), ("v", v), ("sink", sink)]:
+        for name, t in [
+            ("q", q),
+            ("k", k),
+            ("v", v),
+            ("softmax_offset", attn.softmax_offset),
+        ]:
             self.assertIsNotNone(t.grad, f"{name}.grad is None")
             self.assertEqual(list(t.grad.shape), list(t.shape))
             self.assertFalse(
@@ -258,11 +272,12 @@ class TestDPASinkForwardFusedPaths(_SinkTestBase):
 
     def test_path_C_flashmask_causal(self):
         """Path C: bf16 + startend_row_indices (causal 2-col format)."""
-        config = _make_config(bf16=True)
+        config = _make_config(bf16=True, softmax_type="learnable")
         attn = _make_attn(config, attn_mask_type=AttnMaskType.causal)
 
         q, k, v = self._make_qkv(paddle.bfloat16)
         sink = self._make_sink(paddle.bfloat16)
+        self._set_sink(attn, sink)
 
         # 1-column startend_row_indices, causal=True -> every token attends
         # up to itself (full causal).
@@ -279,7 +294,6 @@ class TestDPASinkForwardFusedPaths(_SinkTestBase):
             None,
             attn_mask_startend_row_indices=idx,
             attn_mask_type=AttnMaskType.causal,
-            sink=sink,
         )
         self.assertEqual(
             out.shape, [self.BATCH, self.SEQ, self.NUM_HEADS * self.HEAD_DIM]
@@ -293,7 +307,12 @@ class TestDPASinkForwardFusedPaths(_SinkTestBase):
 
         loss = out.astype("float32").mean()
         loss.backward()
-        for name, t in [("q", q), ("k", k), ("v", v), ("sink", sink)]:
+        for name, t in [
+            ("q", q),
+            ("k", k),
+            ("v", v),
+            ("softmax_offset", attn.softmax_offset),
+        ]:
             self.assertIsNotNone(t.grad, f"{name}.grad is None")
             self.assertFalse(
                 paddle.isnan(t.grad).any().item(), f"{name}.grad has NaN"
@@ -307,11 +326,12 @@ class TestDPASinkForwardFusedPaths(_SinkTestBase):
         other). This is what the PackedSeqParams branch constructs via
         startend_row_indices derived from cu_seqlens.
         """
-        config = _make_config(bf16=True)
+        config = _make_config(bf16=True, softmax_type="learnable")
         attn = _make_attn(config, attn_mask_type=AttnMaskType.no_mask)
 
         q, k, v = self._make_qkv(paddle.bfloat16)
         sink = self._make_sink(paddle.bfloat16)
+        self._set_sink(attn, sink)
 
         # one segment covering [0, SEQ)
         cu = paddle.to_tensor([0, self.SEQ], dtype=paddle.int32)
@@ -325,7 +345,7 @@ class TestDPASinkForwardFusedPaths(_SinkTestBase):
             total_seqlen_kv=self.SEQ,
         )
 
-        out = attn(q, k, v, None, packed_seq_params=packed, sink=sink)
+        out = attn(q, k, v, None, packed_seq_params=packed)
         self.assertEqual(
             out.shape, [self.BATCH, self.SEQ, self.NUM_HEADS * self.HEAD_DIM]
         )
@@ -338,7 +358,12 @@ class TestDPASinkForwardFusedPaths(_SinkTestBase):
 
         loss = out.astype("float32").mean()
         loss.backward()
-        for name, t in [("q", q), ("k", k), ("v", v), ("sink", sink)]:
+        for name, t in [
+            ("q", q),
+            ("k", k),
+            ("v", v),
+            ("softmax_offset", attn.softmax_offset),
+        ]:
             self.assertIsNotNone(t.grad, f"{name}.grad is None")
 
 
@@ -347,13 +372,16 @@ class TestDPASinkForwardEager(_SinkTestBase):
 
     def test_path_D_eager_fp32(self):
         """fp32 naturally falls through to the eager matmul path."""
-        config = _make_config()  # fp32, not eager explicitly, but fp32 gates
+        config = _make_config(
+            softmax_type="learnable"
+        )  # fp32, not eager explicitly, but fp32 gates
         attn = _make_attn(config)
 
         q, k, v = self._make_qkv(paddle.float32)
         sink = self._make_sink(paddle.float32)
+        self._set_sink(attn, sink)
 
-        out = attn(q, k, v, self._causal_mask(paddle.float32), sink=sink)
+        out = attn(q, k, v, self._causal_mask(paddle.float32))
         self.assertEqual(
             out.shape, [self.BATCH, self.SEQ, self.NUM_HEADS * self.HEAD_DIM]
         )
@@ -365,21 +393,27 @@ class TestDPASinkForwardEager(_SinkTestBase):
 
         loss = out.mean()
         loss.backward()
-        for name, t in [("q", q), ("k", k), ("v", v), ("sink", sink)]:
+        for name, t in [
+            ("q", q),
+            ("k", k),
+            ("v", v),
+            ("softmax_offset", attn.softmax_offset),
+        ]:
             self.assertIsNotNone(t.grad, f"{name}.grad is None")
             self.assertEqual(list(t.grad.shape), list(t.shape))
 
     def test_path_D_eager_via_flag(self):
         """fp32 + _attn_implementation='eager' explicitly takes the eager path."""
-        config = _make_config()
+        config = _make_config(softmax_type="learnable")
         config._attn_implementation = "eager"
         attn = _make_attn(config)
 
         q, k, v = self._make_qkv(paddle.float32)
         sink = self._make_sink(paddle.float32)
+        self._set_sink(attn, sink)
         mask = self._causal_mask(paddle.float32)
 
-        out = attn(q, k, v, mask, sink=sink)
+        out = attn(q, k, v, mask)
         ref = naive_attn_sink(q, k, v, sink, mask, self.scaling)
         assert_close(out, ref, atol=1e-4, rtol=1e-4, msg="eager flag+sink fwd")
 
@@ -401,19 +435,20 @@ class TestDPASinkGradEager(_SinkTestBase):
     """Exact gradient match on the fp32 eager path against naive reference."""
 
     def test_eager_grad_match_fp32(self):
-        config = _make_config()  # fp32 -> Path D
+        config = _make_config(softmax_type="learnable")  # fp32 -> Path D
         attn = _make_attn(config)
 
         q, k, v = self._make_qkv(paddle.float32)
         sink = self._make_sink(paddle.float32)
+        self._set_sink(attn, sink)
         mask = self._causal_mask(paddle.float32)
 
-        out = attn(q, k, v, mask, sink=sink)
+        out = attn(q, k, v, mask)
         paddle.seed(0)
         upstream = paddle.randn(out.shape, dtype=out.dtype)
         grads = paddle.grad(
             outputs=[out],
-            inputs=[q, k, v, sink],
+            inputs=[q, k, v, attn.softmax_offset],
             grad_outputs=[upstream],
         )
 
@@ -443,27 +478,26 @@ class TestDPASinkGradEager(_SinkTestBase):
 
 
 # ---------------------------------------------------------------------------
-# TestDPASinkRegression — sink=None must not perturb the existing behaviour.
+# TestDPASinkRegression — softmax_type='vanilla' must not trigger sink path.
 # ---------------------------------------------------------------------------
 
 
 class TestDPASinkRegression(_SinkTestBase):
-    def test_sink_none_matches_omitted(self):
-        """Passing sink=None explicitly equals not passing sink at all."""
-        config = _make_config()
+    def test_vanilla_no_sink(self):
+        """softmax_type='vanilla' -> softmax_offset is None -> no sink path."""
+        config = _make_config(softmax_type="vanilla")
         attn = _make_attn(config)
+        self.assertIsNone(attn.softmax_offset)
         q, k, v = self._make_qkv(paddle.float32)
         mask = self._causal_mask(paddle.float32)
+        out = attn(q, k, v, mask)
+        self.assertEqual(
+            out.shape, [self.BATCH, self.SEQ, self.NUM_HEADS * self.HEAD_DIM]
+        )
 
-        out_a = attn(q, k, v, mask, sink=None)
-        out_b = attn(q, k, v, mask)
-        # bitwise identical — same code path, same inputs.
-        self.assertTrue(paddle.equal_all(out_a, out_b).item())
-
-    def test_sink_none_with_softmax_offset_consumed(self):
-        """When softmax_type is learnable/off-by-one, the softmax_offset
-        Parameter must still be consumed when the external sink argument
-        is None (the eager branch should route self.softmax_offset)."""
+    def test_off_by_one_softmax_offset_consumed(self):
+        """When softmax_type is off-by-one, the softmax_offset
+        must be consumed (the eager branch should route self.softmax_offset)."""
         config = _make_config(softmax_type="off-by-one")
         attn = _make_attn(config)
         self.assertIsNotNone(attn.softmax_offset)
@@ -472,66 +506,21 @@ class TestDPASinkRegression(_SinkTestBase):
         # produce a different output than a vanilla attention.
         with paddle.no_grad():
             new_offset = paddle.ones_like(attn.softmax_offset) * 2.5
-            # softmax_offset for "off-by-one" is a plain Tensor, not Parameter
             attn.softmax_offset = new_offset
 
         q, k, v = self._make_qkv(paddle.float32)
         mask = self._causal_mask(paddle.float32)
 
-        out_with_offset = attn(q, k, v, mask, sink=None)
+        out_with_offset = attn(q, k, v, mask)
 
-        # Compare against vanilla (no offset, no sink)
+        # Compare against vanilla (no offset)
         vanilla_cfg = _make_config(softmax_type="vanilla")
         vanilla_attn = _make_attn(vanilla_cfg)
-        # Align weights by re-seeding and rebuilding — here both are fp32
-        # matmul-based eager, and since we only care that the two outputs
-        # *differ*, no weight alignment is needed (attn has no learned params
-        # in this path beyond softmax_offset itself).
         out_vanilla = vanilla_attn(q, k, v, mask)
 
         self.assertFalse(
             paddle.allclose(out_with_offset, out_vanilla).item(),
             "softmax_offset was not consumed (output matches vanilla)",
-        )
-
-
-# ---------------------------------------------------------------------------
-# TestDPASinkConflict — mutual exclusion between sink and softmax_offset.
-# ---------------------------------------------------------------------------
-
-
-class TestDPASinkConflict(_SinkTestBase):
-    def _run_forward_expecting_valueerror(self, softmax_type):
-        config = _make_config(softmax_type=softmax_type)
-        attn = _make_attn(config)
-        q, k, v = self._make_qkv(paddle.float32)
-        sink = self._make_sink(paddle.float32)
-        with self.assertRaises(ValueError) as ctx:
-            attn(q, k, v, self._causal_mask(paddle.float32), sink=sink)
-        self.assertIn("softmax_offset", str(ctx.exception))
-
-    def test_sink_and_off_by_one_raises(self):
-        self._run_forward_expecting_valueerror("off-by-one")
-
-    # NOTE: softmax_type='learnable' would conceptually also conflict with
-    # sink, but an unrelated pre-existing issue in DotProductAttention
-    # leaves self.softmax_offset as None for the learnable branch when
-    # config.perform_initialization is engaged (paddle.nn.init.normal_
-    # returns None in the current paddle version, silently overwriting the
-    # registered Parameter). Until that is fixed in dot_product_attention.py
-    # the learnable conflict cannot actually be triggered, so we only test
-    # the off-by-one variant here.
-
-    def test_sink_with_vanilla_ok(self):
-        """softmax_type='vanilla' -> softmax_offset is None -> sink works."""
-        config = _make_config(softmax_type="vanilla")
-        attn = _make_attn(config)
-        self.assertIsNone(attn.softmax_offset)
-        q, k, v = self._make_qkv(paddle.float32)
-        sink = self._make_sink(paddle.float32)
-        out = attn(q, k, v, self._causal_mask(paddle.float32), sink=sink)
-        self.assertEqual(
-            out.shape, [self.BATCH, self.SEQ, self.NUM_HEADS * self.HEAD_DIM]
         )
 
 
@@ -547,14 +536,19 @@ class TestDPASinkGQA(_SinkTestBase):
     NUM_KV_HEADS = 2  # 4 query heads / 2 kv heads -> GQA groups = 2
 
     def test_sdpa_gqa(self):
-        config = _make_config(bf16=True, num_key_value_heads=self.NUM_KV_HEADS)
+        config = _make_config(
+            bf16=True,
+            num_key_value_heads=self.NUM_KV_HEADS,
+            softmax_type="learnable",
+        )
         attn = _make_attn(config)
         q, k, v = self._make_qkv(
             paddle.bfloat16, num_kv_heads=self.NUM_KV_HEADS
         )
         sink = self._make_sink(paddle.bfloat16)
+        self._set_sink(attn, sink)
 
-        out = attn(q, k, v, None, sink=sink)
+        out = attn(q, k, v, None)
         self.assertEqual(
             out.shape, [self.BATCH, self.SEQ, self.NUM_HEADS * self.HEAD_DIM]
         )
@@ -571,12 +565,17 @@ class TestDPASinkGQA(_SinkTestBase):
         assert_close(out, ref, atol=2e-2, rtol=2e-2, msg="GQA SDPA+sink")
 
     def test_flashmask_gqa(self):
-        config = _make_config(bf16=True, num_key_value_heads=self.NUM_KV_HEADS)
+        config = _make_config(
+            bf16=True,
+            num_key_value_heads=self.NUM_KV_HEADS,
+            softmax_type="learnable",
+        )
         attn = _make_attn(config, attn_mask_type=AttnMaskType.causal)
         q, k, v = self._make_qkv(
             paddle.bfloat16, num_kv_heads=self.NUM_KV_HEADS
         )
         sink = self._make_sink(paddle.bfloat16)
+        self._set_sink(attn, sink)
 
         # flashmask uses 1 "kv-head" row (broadcast) by convention
         idx = paddle.full(
@@ -591,7 +590,6 @@ class TestDPASinkGQA(_SinkTestBase):
             None,
             attn_mask_startend_row_indices=idx,
             attn_mask_type=AttnMaskType.causal,
-            sink=sink,
         )
         self.assertEqual(
             out.shape, [self.BATCH, self.SEQ, self.NUM_HEADS * self.HEAD_DIM]
@@ -606,25 +604,132 @@ class TestDPASinkGQA(_SinkTestBase):
 
 class TestDPASinkShape(_SinkTestBase):
     def test_fp32_sink_goes_eager(self):
-        """fp32 inputs with sink land in the eager branch (Path D)."""
-        config = _make_config()
+        """fp32 inputs with sink (softmax_type=learnable) land in the eager branch (Path D)."""
+        config = _make_config(softmax_type="learnable")
         attn = _make_attn(config)
         q, k, v = self._make_qkv(paddle.float32)
         sink = self._make_sink(paddle.float32)
-        out = attn(q, k, v, self._causal_mask(paddle.float32), sink=sink)
+        self._set_sink(attn, sink)
+        out = attn(q, k, v, self._causal_mask(paddle.float32))
         self.assertEqual(
             out.shape, [self.BATCH, self.SEQ, self.NUM_HEADS * self.HEAD_DIM]
         )
 
-    @unittest.skipIf(not _has_cuda(), "Requires CUDA for fused attention.")
-    def test_sink_shape_mismatch_raises(self):
-        """sink.shape[0] != num_query_heads triggers sink_impl assertion."""
-        config = _make_config(bf16=True)
-        attn = _make_attn(config)
+
+# ---------------------------------------------------------------------------
+# TestDPASinkFlashMaskNonCausal — FlashMask + sink with causal=False.
+# ---------------------------------------------------------------------------
+
+
+@unittest.skipIf(not _has_cuda(), "Requires CUDA for fused attention paths.")
+class TestDPASinkFlashMaskNonCausal(_SinkTestBase):
+    """FlashMask path with sink and non-causal attn_mask_type."""
+
+    def test_flashmask_non_causal(self):
+        """Path C variant: startend_row_indices + attn_mask_type != causal."""
+        config = _make_config(bf16=True, softmax_type="learnable")
+        attn = _make_attn(config, attn_mask_type=AttnMaskType.no_mask)
+
         q, k, v = self._make_qkv(paddle.bfloat16)
-        bad_sink = paddle.randn([self.NUM_HEADS + 1], dtype=paddle.bfloat16)
-        with self.assertRaises(AssertionError):
-            attn(q, k, v, None, sink=bad_sink)
+        sink = self._make_sink(paddle.bfloat16)
+        self._set_sink(attn, sink)
+
+        # 4-column startend_row_indices for non-causal (full attention)
+        idx = paddle.stack(
+            [
+                paddle.full([self.SEQ], self.SEQ, dtype=paddle.int32),  # lower_start
+                paddle.full([self.SEQ], self.SEQ, dtype=paddle.int32),  # lower_end
+                paddle.zeros([self.SEQ], dtype=paddle.int32),           # upper_start
+                paddle.zeros([self.SEQ], dtype=paddle.int32),           # upper_end
+            ],
+            axis=-1,
+        ).unsqueeze(0).unsqueeze(0)  # [1, 1, SEQ, 4]
+
+        out = attn(
+            q,
+            k,
+            v,
+            None,
+            attn_mask_startend_row_indices=idx,
+            attn_mask_type=AttnMaskType.no_mask,
+        )
+        self.assertEqual(
+            out.shape, [self.BATCH, self.SEQ, self.NUM_HEADS * self.HEAD_DIM]
+        )
+        self.assertFalse(paddle.isnan(out).any().item())
+
+        # Non-causal full attention ref (no mask)
+        ref = naive_attn_sink(q, k, v, sink, None, self.scaling)
+        assert_close(out, ref, atol=2e-2, rtol=2e-2, msg="FlashMask non-causal+sink")
+
+
+# ---------------------------------------------------------------------------
+# TestDPASinkOffByOneFused — off-by-one on the fused bf16 SDPA path.
+# ---------------------------------------------------------------------------
+
+
+@unittest.skipIf(not _has_cuda(), "Requires CUDA for fused attention paths.")
+class TestDPASinkOffByOneFused(_SinkTestBase):
+    """Verify off-by-one (zero sink) routes through fused bf16 paths."""
+
+    def test_off_by_one_sdpa_bf16(self):
+        """off-by-one with bf16 SDPA path — zero sink equals SoftmaxOne."""
+        config = _make_config(bf16=True, softmax_type="off-by-one")
+        attn = _make_attn(config)
+        # off-by-one creates zeros, equivalent to sink=0 for all heads
+        self.assertIsNotNone(attn.softmax_offset)
+        self.assertTrue(
+            paddle.equal_all(
+                attn.softmax_offset,
+                paddle.zeros_like(attn.softmax_offset),
+            ).item()
+        )
+
+        q, k, v = self._make_qkv(paddle.bfloat16)
+        out = attn(q, k, v, None)
+        self.assertEqual(
+            out.shape, [self.BATCH, self.SEQ, self.NUM_HEADS * self.HEAD_DIM]
+        )
+        self.assertFalse(paddle.isnan(out).any().item())
+
+        # With sink=0, the SoftmaxOne formula is:
+        # prob_i = exp(s_i) / (1 + sum_j exp(s_j))
+        # Verify it differs from vanilla (which has no +1 in denominator)
+        vanilla_config = _make_config(bf16=True, softmax_type="vanilla")
+        vanilla_attn = _make_attn(vanilla_config)
+        out_vanilla = vanilla_attn(q, k, v, None)
+        self.assertFalse(
+            paddle.allclose(
+                out.astype("float32"), out_vanilla.astype("float32")
+            ).item(),
+            "off-by-one output should differ from vanilla on SDPA path",
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestDPASinkInit — verify learnable init correctness after bug fix.
+# ---------------------------------------------------------------------------
+
+
+class TestDPASinkInit(_SinkTestBase):
+    """Regression: softmax_type='learnable' + perform_initialization=True
+    must produce a valid (non-None) Parameter."""
+
+    def test_learnable_init_produces_valid_parameter(self):
+        """After bug fix, init_method should in-place initialize softmax_offset."""
+        config = _make_config(softmax_type="learnable")
+        # perform_initialization defaults to True
+        attn = _make_attn(config)
+
+        self.assertIsNotNone(attn.softmax_offset)
+        self.assertIsInstance(attn.softmax_offset, paddle.nn.Parameter)
+        self.assertEqual(
+            list(attn.softmax_offset.shape), [self.NUM_HEADS]
+        )
+        # Should be initialized (not all zeros since normal_ was applied)
+        # Note: with very small sigma there's a tiny chance of all zeros,
+        # but practically this never happens.
+        self.assertEqual(attn.softmax_offset.dtype, paddle.float32)
 
 
 if __name__ == "__main__":

--- a/tests/single_card_tests/transformer/test_dot_product_attention_sink.py
+++ b/tests/single_card_tests/transformer/test_dot_product_attention_sink.py
@@ -1,0 +1,631 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Module-level unit tests for DotProductAttention with the attention-sink
+mechanism enabled.
+
+Unlike test_attention_sink.py which exercises the lower-level
+sink_attention_forward helper, this file instantiates
+DotProductAttention directly so that the forward routing — packed /
+SDPA / FlashMask / eager — is part of the contract under test.
+
+Covered:
+
+* forward numerical correctness on every path (bf16 on fused paths, fp32 on
+  the eager path) against a naive concat-softmax-drop reference;
+* backward gradient flow on every path (q/k/v/sink all receive non-None
+  grads) plus numerical grad match on SDPA & FlashMask;
+* sink=None regression (unchanged behaviour and interaction with the
+  pre-existing softmax_offset Parameter);
+* sink / softmax_offset mutual-exclusion ValueError;
+* grouped-query attention with sink;
+* shape / dtype boundaries.
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(
+    0,
+    os.path.dirname(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    ),
+)
+
+import numpy as np
+import paddle
+from paddle import nn
+
+from paddlefleet.packed_seq_params import PackedSeqParams
+from paddlefleet.transformer.dot_product_attention import DotProductAttention
+from paddlefleet.transformer.enums import AttnMaskType
+from paddlefleet.transformer.transformer_config import TransformerConfig
+from paddlefleet.utils import init_method_normal, scaled_init_method_normal
+
+# ---------------------------------------------------------------------------
+# Helpers (mirrored from test_attention_sink.py by intent; kept local to
+# avoid introducing a shared test-utilities module).
+# ---------------------------------------------------------------------------
+
+
+def _make_config(**overrides) -> TransformerConfig:
+    defaults = {
+        "num_hidden_layers": 2,
+        "hidden_size": 128,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 4,
+        "head_dim": 64,
+        "softmax_scale": None,
+        "use_bias": True,
+        "recompute_granularity": None,
+        "recompute_modules": None,
+        "init_method": init_method_normal(0.02),
+        "output_layer_init_method": scaled_init_method_normal(0.02, 1, 2.0),
+        "rms_norm_eps": 1e-5,
+        "context_parallel_size": 1,
+        "sequence_parallel": False,
+        "apply_query_key_layer_scaling": False,
+        "sliding_window": None,
+        "window_attn_skip_freq": None,
+        "fp16": False,
+        "bf16": False,
+        "masked_softmax_fusion": False,
+        "attention_softmax_in_fp32": True,
+        "attention_dropout": 0.0,
+        "softmax_type": "vanilla",
+        "fa_version": None,
+    }
+    defaults.update(overrides)
+    return TransformerConfig(**defaults)
+
+
+def _make_attn(config, attn_mask_type=AttnMaskType.causal):
+    attn = DotProductAttention(
+        config=config,
+        layer_number=1,
+        attn_mask_type=attn_mask_type,
+        attention_type="self",
+    )
+    attn.eval()  # deterministic: dropout off regardless of attention_dropout.
+    return attn
+
+
+def naive_attn_sink(
+    query: paddle.Tensor,
+    key: paddle.Tensor,
+    value: paddle.Tensor,
+    sink: paddle.Tensor,
+    attention_mask: paddle.Tensor | None,
+    scaling: float,
+    num_key_value_groups: int = 1,
+) -> paddle.Tensor:
+    """Reference attention-with-sink (concat sink logit, softmax, drop).
+
+    Inputs are [B, S, H, D]; output is [B, S, H*D]. attention_mask is an
+    additive mask already broadcast to [B, H_q, S_q, S_k] (0 for keep,
+    -inf for block).
+    """
+    q = paddle.transpose(query, perm=[0, 2, 1, 3])  # [B, Hq, Sq, D]
+    k = paddle.transpose(key, perm=[0, 2, 1, 3])  # [B, Hkv, Sk, D]
+    v = paddle.transpose(value, perm=[0, 2, 1, 3])
+
+    if num_key_value_groups > 1:
+        k = k.repeat_interleave(num_key_value_groups, axis=1)
+        v = v.repeat_interleave(num_key_value_groups, axis=1)
+
+    k_t = paddle.transpose(k, perm=[0, 1, 3, 2])  # [B, Hq, D, Sk]
+    attn_weights = paddle.matmul(q, k_t) * scaling
+
+    if attention_mask is not None:
+        attn_weights = attn_weights + attention_mask[:, :, :, : k_t.shape[-1]]
+
+    # concat per-head sink logit as an extra "key" column
+    sinks = sink.reshape([1, -1, 1, 1]).expand(
+        [q.shape[0], q.shape[1], q.shape[2], 1]
+    )
+    combined = paddle.cat([attn_weights, sinks], axis=-1)
+    combined = combined - paddle.max(combined, axis=-1, keepdim=True)
+    probs = nn.functional.softmax(combined, axis=-1, dtype=combined.dtype)
+    scores = probs[..., :-1]  # drop sink column
+
+    out = paddle.matmul(scores, v)  # [B, Hq, Sq, D]
+    out = paddle.transpose(out, perm=[0, 2, 1, 3]).contiguous()
+    return paddle.reshape(out, shape=[0, 0, out.shape[2] * out.shape[3]])
+
+
+def assert_close(a, b, atol=1e-2, rtol=1e-2, msg=""):
+    a = a.astype("float32")
+    b = b.astype("float32")
+    diff = paddle.max(paddle.abs(a - b)).item()
+    assert paddle.allclose(a, b, rtol=rtol, atol=atol, equal_nan=True), (
+        f"{msg}: max abs error = {diff} (atol={atol}, rtol={rtol})"
+    )
+
+
+def _has_cuda() -> bool:
+    return paddle.is_compiled_with_cuda()
+
+
+# ---------------------------------------------------------------------------
+# Base class providing shared fixture data.
+# ---------------------------------------------------------------------------
+
+
+class _SinkTestBase(unittest.TestCase):
+    """Shared test parameters. Sized small to keep single-card tests cheap."""
+
+    BATCH = 1
+    SEQ = 64
+    NUM_HEADS = 4
+    HEAD_DIM = 64
+    SEED = 92
+
+    @classmethod
+    def setUpClass(cls):
+        if _has_cuda():
+            paddle.device.set_device("gpu:0")
+
+    def setUp(self):
+        paddle.seed(self.SEED)
+        np.random.seed(self.SEED)
+        self.scaling = self.HEAD_DIM**-0.5
+
+    def _make_qkv(self, dtype, num_kv_heads=None):
+        num_kv = num_kv_heads or self.NUM_HEADS
+        q = paddle.randn(
+            [self.BATCH, self.SEQ, self.NUM_HEADS, self.HEAD_DIM], dtype=dtype
+        )
+        k = paddle.randn(
+            [self.BATCH, self.SEQ, num_kv, self.HEAD_DIM], dtype=dtype
+        )
+        v = paddle.randn(
+            [self.BATCH, self.SEQ, num_kv, self.HEAD_DIM], dtype=dtype
+        )
+        q.stop_gradient = False
+        k.stop_gradient = False
+        v.stop_gradient = False
+        return q, k, v
+
+    def _make_sink(self, dtype, num_heads=None):
+        s = paddle.randn([num_heads or self.NUM_HEADS], dtype=dtype)
+        s.stop_gradient = False
+        return s
+
+    def _causal_mask(self, dtype):
+        m = paddle.triu(
+            paddle.full(
+                [self.SEQ, self.SEQ], fill_value=float("-inf"), dtype=dtype
+            ),
+            diagonal=1,
+        )
+        return (
+            m.unsqueeze(0)
+            .unsqueeze(0)
+            .expand([self.BATCH, self.NUM_HEADS, self.SEQ, self.SEQ])
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestDPASinkForward — one method per forward path.
+# ---------------------------------------------------------------------------
+
+
+@unittest.skipIf(not _has_cuda(), "Requires CUDA for fused attention paths.")
+class TestDPASinkForwardFusedPaths(_SinkTestBase):
+    """bf16 paths go through fused kernels. Validate forward + grad flow."""
+
+    def test_path_B_sdpa_causal(self):
+        """Path B: bf16, no startend_row_indices, not eager -> SDPA branch."""
+        config = _make_config(bf16=True)
+        attn = _make_attn(config)
+
+        q, k, v = self._make_qkv(paddle.bfloat16)
+        sink = self._make_sink(paddle.bfloat16)
+
+        out = attn(q, k, v, None, sink=sink)
+        self.assertEqual(
+            out.shape, [self.BATCH, self.SEQ, self.NUM_HEADS * self.HEAD_DIM]
+        )
+
+        # numerical vs naive
+        ref = naive_attn_sink(
+            q, k, v, sink, self._causal_mask(paddle.bfloat16), self.scaling
+        )
+        assert_close(out, ref, atol=1e-2, rtol=1e-2, msg="SDPA+sink fwd")
+
+        # backward: all inputs including sink must receive non-None gradients
+        loss = out.astype("float32").mean()
+        loss.backward()
+        for name, t in [("q", q), ("k", k), ("v", v), ("sink", sink)]:
+            self.assertIsNotNone(t.grad, f"{name}.grad is None")
+            self.assertEqual(list(t.grad.shape), list(t.shape))
+            self.assertFalse(
+                paddle.isnan(t.grad).any().item(), f"{name}.grad has NaN"
+            )
+
+    def test_path_C_flashmask_causal(self):
+        """Path C: bf16 + startend_row_indices (causal 2-col format)."""
+        config = _make_config(bf16=True)
+        attn = _make_attn(config, attn_mask_type=AttnMaskType.causal)
+
+        q, k, v = self._make_qkv(paddle.bfloat16)
+        sink = self._make_sink(paddle.bfloat16)
+
+        # 1-column startend_row_indices, causal=True -> every token attends
+        # up to itself (full causal).
+        idx = paddle.full(
+            [self.BATCH, 1, self.SEQ, 1],
+            fill_value=self.SEQ,
+            dtype=paddle.int32,
+        )
+
+        out = attn(
+            q,
+            k,
+            v,
+            None,
+            attn_mask_startend_row_indices=idx,
+            attn_mask_type=AttnMaskType.causal,
+            sink=sink,
+        )
+        self.assertEqual(
+            out.shape, [self.BATCH, self.SEQ, self.NUM_HEADS * self.HEAD_DIM]
+        )
+
+        # With causal=True + full-sequence indices, ref is a simple causal mask.
+        ref = naive_attn_sink(
+            q, k, v, sink, self._causal_mask(paddle.bfloat16), self.scaling
+        )
+        assert_close(out, ref, atol=2e-2, rtol=2e-2, msg="FlashMask+sink fwd")
+
+        loss = out.astype("float32").mean()
+        loss.backward()
+        for name, t in [("q", q), ("k", k), ("v", v), ("sink", sink)]:
+            self.assertIsNotNone(t.grad, f"{name}.grad is None")
+            self.assertFalse(
+                paddle.isnan(t.grad).any().item(), f"{name}.grad has NaN"
+            )
+
+    def test_path_A_packed_seq(self):
+        """Path A: packed_seq_params triggers block-diagonal flashmask.
+
+        With a single segment covering the whole batch, the attention pattern
+        is non-causal over the full sequence (every token attends to every
+        other). This is what the PackedSeqParams branch constructs via
+        startend_row_indices derived from cu_seqlens.
+        """
+        config = _make_config(bf16=True)
+        attn = _make_attn(config, attn_mask_type=AttnMaskType.no_mask)
+
+        q, k, v = self._make_qkv(paddle.bfloat16)
+        sink = self._make_sink(paddle.bfloat16)
+
+        # one segment covering [0, SEQ)
+        cu = paddle.to_tensor([0, self.SEQ], dtype=paddle.int32)
+        packed = PackedSeqParams(
+            qkv_format="bshd",
+            cu_seqlens_q=cu,
+            cu_seqlens_kv=cu,
+            max_seqlen_q=self.SEQ,
+            max_seqlen_kv=self.SEQ,
+            total_seqlen_q=self.SEQ,
+            total_seqlen_kv=self.SEQ,
+        )
+
+        out = attn(q, k, v, None, packed_seq_params=packed, sink=sink)
+        self.assertEqual(
+            out.shape, [self.BATCH, self.SEQ, self.NUM_HEADS * self.HEAD_DIM]
+        )
+        self.assertFalse(paddle.isnan(out).any().item(), "packed+sink has NaN")
+
+        # A single segment over the full sequence + causal=False is
+        # equivalent to full attention (no mask).
+        ref = naive_attn_sink(q, k, v, sink, None, self.scaling)
+        assert_close(out, ref, atol=2e-2, rtol=2e-2, msg="packed+sink fwd")
+
+        loss = out.astype("float32").mean()
+        loss.backward()
+        for name, t in [("q", q), ("k", k), ("v", v), ("sink", sink)]:
+            self.assertIsNotNone(t.grad, f"{name}.grad is None")
+
+
+class TestDPASinkForwardEager(_SinkTestBase):
+    """Path D: fp32 or _attn_implementation='eager' -> baddbmm+softmax_one."""
+
+    def test_path_D_eager_fp32(self):
+        """fp32 naturally falls through to the eager matmul path."""
+        config = _make_config()  # fp32, not eager explicitly, but fp32 gates
+        attn = _make_attn(config)
+
+        q, k, v = self._make_qkv(paddle.float32)
+        sink = self._make_sink(paddle.float32)
+
+        out = attn(q, k, v, self._causal_mask(paddle.float32), sink=sink)
+        self.assertEqual(
+            out.shape, [self.BATCH, self.SEQ, self.NUM_HEADS * self.HEAD_DIM]
+        )
+
+        ref = naive_attn_sink(
+            q, k, v, sink, self._causal_mask(paddle.float32), self.scaling
+        )
+        assert_close(out, ref, atol=1e-4, rtol=1e-4, msg="eager fp32+sink fwd")
+
+        loss = out.mean()
+        loss.backward()
+        for name, t in [("q", q), ("k", k), ("v", v), ("sink", sink)]:
+            self.assertIsNotNone(t.grad, f"{name}.grad is None")
+            self.assertEqual(list(t.grad.shape), list(t.shape))
+
+    def test_path_D_eager_via_flag(self):
+        """fp32 + _attn_implementation='eager' explicitly takes the eager path."""
+        config = _make_config()
+        config._attn_implementation = "eager"
+        attn = _make_attn(config)
+
+        q, k, v = self._make_qkv(paddle.float32)
+        sink = self._make_sink(paddle.float32)
+        mask = self._causal_mask(paddle.float32)
+
+        out = attn(q, k, v, mask, sink=sink)
+        ref = naive_attn_sink(q, k, v, sink, mask, self.scaling)
+        assert_close(out, ref, atol=1e-4, rtol=1e-4, msg="eager flag+sink fwd")
+
+
+# ---------------------------------------------------------------------------
+# TestDPASinkGradEager — numerical backward agreement on the eager (fp32) path.
+#
+# NOTE: we do NOT validate numerical gradient equality on the fused bf16 paths.
+# FlashMaskSinkPyLayer.backward (PR #2461) implements a mu_k-refined
+# gradient formulation that intentionally differs from the straightforward
+# autograd of concat-softmax-drop. So bf16 fused-path grads are checked for
+# shape / non-NaN / non-zero only (inside TestDPASinkForwardFusedPaths);
+# the eager (fp32) path goes through plain autograd via SoftmaxOne and
+# must match the naive reference closely.
+# ---------------------------------------------------------------------------
+
+
+class TestDPASinkGradEager(_SinkTestBase):
+    """Exact gradient match on the fp32 eager path against naive reference."""
+
+    def test_eager_grad_match_fp32(self):
+        config = _make_config()  # fp32 -> Path D
+        attn = _make_attn(config)
+
+        q, k, v = self._make_qkv(paddle.float32)
+        sink = self._make_sink(paddle.float32)
+        mask = self._causal_mask(paddle.float32)
+
+        out = attn(q, k, v, mask, sink=sink)
+        paddle.seed(0)
+        upstream = paddle.randn(out.shape, dtype=out.dtype)
+        grads = paddle.grad(
+            outputs=[out],
+            inputs=[q, k, v, sink],
+            grad_outputs=[upstream],
+        )
+
+        q_ref = q.detach().clone()
+        k_ref = k.detach().clone()
+        v_ref = v.detach().clone()
+        s_ref = sink.detach().clone()
+        for t in (q_ref, k_ref, v_ref, s_ref):
+            t.stop_gradient = False
+        ref_out = naive_attn_sink(
+            q_ref, k_ref, v_ref, s_ref, mask, self.scaling
+        )
+        ref_grads = paddle.grad(
+            outputs=[ref_out],
+            inputs=[q_ref, k_ref, v_ref, s_ref],
+            grad_outputs=[upstream],
+        )
+
+        for name, a, b in zip(["dq", "dk", "dv", "dsink"], grads, ref_grads):
+            assert_close(
+                a,
+                b,
+                atol=1e-4,
+                rtol=1e-4,
+                msg=f"eager {name}",
+            )
+
+
+# ---------------------------------------------------------------------------
+# TestDPASinkRegression — sink=None must not perturb the existing behaviour.
+# ---------------------------------------------------------------------------
+
+
+class TestDPASinkRegression(_SinkTestBase):
+    def test_sink_none_matches_omitted(self):
+        """Passing sink=None explicitly equals not passing sink at all."""
+        config = _make_config()
+        attn = _make_attn(config)
+        q, k, v = self._make_qkv(paddle.float32)
+        mask = self._causal_mask(paddle.float32)
+
+        out_a = attn(q, k, v, mask, sink=None)
+        out_b = attn(q, k, v, mask)
+        # bitwise identical — same code path, same inputs.
+        self.assertTrue(paddle.equal_all(out_a, out_b).item())
+
+    def test_sink_none_with_softmax_offset_consumed(self):
+        """When softmax_type is learnable/off-by-one, the softmax_offset
+        Parameter must still be consumed when the external sink argument
+        is None (the eager branch should route self.softmax_offset)."""
+        config = _make_config(softmax_type="off-by-one")
+        attn = _make_attn(config)
+        self.assertIsNotNone(attn.softmax_offset)
+
+        # Drive the offset away from zero so any failure to consume it would
+        # produce a different output than a vanilla attention.
+        with paddle.no_grad():
+            new_offset = paddle.ones_like(attn.softmax_offset) * 2.5
+            # softmax_offset for "off-by-one" is a plain Tensor, not Parameter
+            attn.softmax_offset = new_offset
+
+        q, k, v = self._make_qkv(paddle.float32)
+        mask = self._causal_mask(paddle.float32)
+
+        out_with_offset = attn(q, k, v, mask, sink=None)
+
+        # Compare against vanilla (no offset, no sink)
+        vanilla_cfg = _make_config(softmax_type="vanilla")
+        vanilla_attn = _make_attn(vanilla_cfg)
+        # Align weights by re-seeding and rebuilding — here both are fp32
+        # matmul-based eager, and since we only care that the two outputs
+        # *differ*, no weight alignment is needed (attn has no learned params
+        # in this path beyond softmax_offset itself).
+        out_vanilla = vanilla_attn(q, k, v, mask)
+
+        self.assertFalse(
+            paddle.allclose(out_with_offset, out_vanilla).item(),
+            "softmax_offset was not consumed (output matches vanilla)",
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestDPASinkConflict — mutual exclusion between sink and softmax_offset.
+# ---------------------------------------------------------------------------
+
+
+class TestDPASinkConflict(_SinkTestBase):
+    def _run_forward_expecting_valueerror(self, softmax_type):
+        config = _make_config(softmax_type=softmax_type)
+        attn = _make_attn(config)
+        q, k, v = self._make_qkv(paddle.float32)
+        sink = self._make_sink(paddle.float32)
+        with self.assertRaises(ValueError) as ctx:
+            attn(q, k, v, self._causal_mask(paddle.float32), sink=sink)
+        self.assertIn("softmax_offset", str(ctx.exception))
+
+    def test_sink_and_off_by_one_raises(self):
+        self._run_forward_expecting_valueerror("off-by-one")
+
+    # NOTE: softmax_type='learnable' would conceptually also conflict with
+    # sink, but an unrelated pre-existing issue in DotProductAttention
+    # leaves self.softmax_offset as None for the learnable branch when
+    # config.perform_initialization is engaged (paddle.nn.init.normal_
+    # returns None in the current paddle version, silently overwriting the
+    # registered Parameter). Until that is fixed in dot_product_attention.py
+    # the learnable conflict cannot actually be triggered, so we only test
+    # the off-by-one variant here.
+
+    def test_sink_with_vanilla_ok(self):
+        """softmax_type='vanilla' -> softmax_offset is None -> sink works."""
+        config = _make_config(softmax_type="vanilla")
+        attn = _make_attn(config)
+        self.assertIsNone(attn.softmax_offset)
+        q, k, v = self._make_qkv(paddle.float32)
+        sink = self._make_sink(paddle.float32)
+        out = attn(q, k, v, self._causal_mask(paddle.float32), sink=sink)
+        self.assertEqual(
+            out.shape, [self.BATCH, self.SEQ, self.NUM_HEADS * self.HEAD_DIM]
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestDPASinkGQA — grouped-query attention with sink.
+# ---------------------------------------------------------------------------
+
+
+@unittest.skipIf(not _has_cuda(), "Requires CUDA for fused attention paths.")
+class TestDPASinkGQA(_SinkTestBase):
+    """num_query_heads > num_kv_heads on bf16 paths. Sink is per query head."""
+
+    NUM_KV_HEADS = 2  # 4 query heads / 2 kv heads -> GQA groups = 2
+
+    def test_sdpa_gqa(self):
+        config = _make_config(bf16=True, num_key_value_heads=self.NUM_KV_HEADS)
+        attn = _make_attn(config)
+        q, k, v = self._make_qkv(
+            paddle.bfloat16, num_kv_heads=self.NUM_KV_HEADS
+        )
+        sink = self._make_sink(paddle.bfloat16)
+
+        out = attn(q, k, v, None, sink=sink)
+        self.assertEqual(
+            out.shape, [self.BATCH, self.SEQ, self.NUM_HEADS * self.HEAD_DIM]
+        )
+
+        ref = naive_attn_sink(
+            q,
+            k,
+            v,
+            sink,
+            self._causal_mask(paddle.bfloat16),
+            self.scaling,
+            num_key_value_groups=self.NUM_HEADS // self.NUM_KV_HEADS,
+        )
+        assert_close(out, ref, atol=2e-2, rtol=2e-2, msg="GQA SDPA+sink")
+
+    def test_flashmask_gqa(self):
+        config = _make_config(bf16=True, num_key_value_heads=self.NUM_KV_HEADS)
+        attn = _make_attn(config, attn_mask_type=AttnMaskType.causal)
+        q, k, v = self._make_qkv(
+            paddle.bfloat16, num_kv_heads=self.NUM_KV_HEADS
+        )
+        sink = self._make_sink(paddle.bfloat16)
+
+        # flashmask uses 1 "kv-head" row (broadcast) by convention
+        idx = paddle.full(
+            [self.BATCH, 1, self.SEQ, 1],
+            fill_value=self.SEQ,
+            dtype=paddle.int32,
+        )
+        out = attn(
+            q,
+            k,
+            v,
+            None,
+            attn_mask_startend_row_indices=idx,
+            attn_mask_type=AttnMaskType.causal,
+            sink=sink,
+        )
+        self.assertEqual(
+            out.shape, [self.BATCH, self.SEQ, self.NUM_HEADS * self.HEAD_DIM]
+        )
+        self.assertFalse(paddle.isnan(out).any().item())
+
+
+# ---------------------------------------------------------------------------
+# TestDPASinkShape — shape / dtype boundaries.
+# ---------------------------------------------------------------------------
+
+
+class TestDPASinkShape(_SinkTestBase):
+    def test_fp32_sink_goes_eager(self):
+        """fp32 inputs with sink land in the eager branch (Path D)."""
+        config = _make_config()
+        attn = _make_attn(config)
+        q, k, v = self._make_qkv(paddle.float32)
+        sink = self._make_sink(paddle.float32)
+        out = attn(q, k, v, self._causal_mask(paddle.float32), sink=sink)
+        self.assertEqual(
+            out.shape, [self.BATCH, self.SEQ, self.NUM_HEADS * self.HEAD_DIM]
+        )
+
+    @unittest.skipIf(not _has_cuda(), "Requires CUDA for fused attention.")
+    def test_sink_shape_mismatch_raises(self):
+        """sink.shape[0] != num_query_heads triggers sink_impl assertion."""
+        config = _make_config(bf16=True)
+        attn = _make_attn(config)
+        q, k, v = self._make_qkv(paddle.bfloat16)
+        bad_sink = paddle.randn([self.NUM_HEADS + 1], dtype=paddle.bfloat16)
+        with self.assertRaises(AssertionError):
+            attn(q, k, v, None, sink=bad_sink)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
New features

### Description
Add attention sink support to PaddleFleet.

1. Add src/paddlefleet/transformer/sink_impl.py, implementing attention sink based on FlashAttention / FlashMask.
2. Add sink parameter to DotProductAttention.forward, integrating sink_attention_forward into FlashMask packed-seq path, SDPA path, and FlashMask standard path.
3. Pass sink parameter down through Attention.forward.
4. Fix API compatibility issue in fused_softmax.py where SoftmaxOne used paddle.softmax, replaced with paddle.nn.functional.softmax.
5. Add test_attention_sink.py and test_dot_product_attention_sink.py for single-card testing; update test_ai_fused_softmax.py.
