### PR TITLE
[New features] Add mtp_window_size to support sliding window attention for MTP layers

### DIFF
--- a/src/paddlefleet/models/common/language_loss/language_loss.py
+++ b/src/paddlefleet/models/common/language_loss/language_loss.py
@@ -35,6 +35,7 @@ from paddlefleet.parallel_state import (
     get_tensor_model_parallel_world_size,
 )
 from paddlefleet.process_groups_config import ProcessGroupCollection
+from paddlefleet.training.global_vars import get_global_training_logs
 from paddlefleet.transformer.layer import FleetLayer
 from paddlefleet.transformer.transformer_config import TransformerConfig
 
@@ -514,13 +515,18 @@ class LanguageLoss(FleetLayer):
                         ploss = ploss / xishu
                         mtp_loss.append(ploss)
 
-            # Store detached MTP loss tensors into class-level tracker.
+            # Store detached MTP loss tensors into class-level tracker and global_training_logs.
             # Use .detach() instead of .item() to avoid GPU synchronization on every
             # micro-batch. The trainer will call .item() only at logging steps.
             for i, loss_val in enumerate(mtp_loss):
                 LanguageLoss.mtp_loss_tracker[f"mtp_{i + 1}_loss"] = (
                     loss_val.detach()
                 )
+
+            logs = get_global_training_logs()
+            if logs is not None and hasattr(logs, "update"):
+                for i, loss_val in enumerate(mtp_loss):
+                    logs.update(**{f"mtp_{i + 1}_loss": loss_val.detach()})
 
             def add_loss(main_loss, loss):
                 if self.config.add_mtp_loss:
@@ -590,13 +596,19 @@ class MainLanguageLoss(LanguageLoss):
         else:
             lm_loss = self._forward(logits, lm_labels)
 
-        # Store detached MTP loss tensors into class-level tracker.
+        # Store detached MTP loss tensors into class-level tracker and global_training_logs.
         # Use .detach() instead of .item() to avoid GPU synchronization on every
         # micro-batch. The trainer will call .item() only at logging steps.
         for i, loss_val in enumerate(mtp_loss):
             MainLanguageLoss.mtp_loss_tracker[f"mtp_{i + 1}_loss"] = (
                 loss_val.detach()
             )
+
+        # Also write to global_training_logs for ernie5 trainer to read
+        logs = get_global_training_logs()
+        if logs is not None and hasattr(logs, "update"):
+            for i, loss_val in enumerate(mtp_loss):
+                logs.update(**{f"mtp_{i + 1}_loss": loss_val.detach()})
 
         def add_loss(main_loss, loss):
             if self.config.add_mtp_loss:

--- a/src/paddlefleet/ops/flash_mask_facade.py
+++ b/src/paddlefleet/ops/flash_mask_facade.py
@@ -101,7 +101,11 @@ def flashmask_attention(
         query=query,
         key=key,
         value=value,
-        startend_row_indices=startend_row_indices.clone(),
+        startend_row_indices=(
+            startend_row_indices.clone()
+            if startend_row_indices is not None
+            else None
+        ),
         dropout=dropout,
         causal=causal,
         window_size=window_size,

--- a/src/paddlefleet/transformer/dot_product_attention.py
+++ b/src/paddlefleet/transformer/dot_product_attention.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import logging
 import math
+import warnings
 from functools import partial
 from typing import TYPE_CHECKING
 
@@ -140,6 +141,24 @@ class DotProductAttention(FleetLayer):
         else:
             sliding_window = None
 
+        # Save on self so forward() can forward it into flash kernels. This is
+        # what makes `mtp_window_size` actually take effect for MTP layers: the
+        # MTP config has sliding_window=(N, 0), and the flashmask calls below
+        # now receive window_size=(N, 0).
+        self.sliding_window = sliding_window
+        if sliding_window is not None:
+            # Grep-friendly tag: "[SWA-KERNEL-CONFIRM]". Prints once per layer
+            # that actually activates sliding-window attention at the kernel
+            # call site (flashmask with window_size=...). Uses print (not
+            # warnings.warn) so that it is not suppressed by Paddle/Fleet
+            # warnings filters and always lands in nohup.out.
+            print(
+                f"[SWA-KERNEL-CONFIRM] layer_number={layer_number} "
+                f"sliding_window={sliding_window} will be forwarded to flash "
+                f"kernels via window_size",
+                flush=True,
+            )
+
         self.scale_mask_softmax = FusedScaleMaskSoftmax(
             input_in_fp16=self.config.fp16,
             input_in_bf16=self.config.bf16,
@@ -209,17 +228,31 @@ class DotProductAttention(FleetLayer):
                 startend_row_indices=attn_mask_startend_row_indices,
                 dropout=0.0,
                 causal=False,  # EC uses causal=False with 2-col startend_row_indices
+                window_size=self.sliding_window,
             )
         else:
             # simple causal path — no document boundaries
-            attn_output, _ = flash_attention(
-                query.astype(value.dtype),
-                key.astype(value.dtype),
-                value,
-                dropout=0.0,
-                causal=True,
-                return_softmax=False,
-            )
+            if self.sliding_window is not None:
+                # flash_attention facade does not forward window_size; route
+                # to flashmask with no document boundaries so SWA is applied.
+                attn_output = flashmask_attention(
+                    query.astype(value.dtype),
+                    key.astype(value.dtype),
+                    value,
+                    startend_row_indices=None,
+                    dropout=0.0,
+                    causal=True,
+                    window_size=self.sliding_window,
+                )
+            else:
+                attn_output, _ = flash_attention(
+                    query.astype(value.dtype),
+                    key.astype(value.dtype),
+                    value,
+                    dropout=0.0,
+                    causal=True,
+                    return_softmax=False,
+                )
 
         attn_output = attn_output.reshape([bsz, q_len, -1])
         return attn_output
@@ -309,6 +342,7 @@ class DotProductAttention(FleetLayer):
                 startend_row_indices=attn_mask_startend_row_indices,
                 dropout=self.config.attention_dropout,
                 causal=False,
+                window_size=self.sliding_window,
             )
             attn_output = attn_output.reshape([bsz, q_len, -1])
             return attn_output
@@ -322,6 +356,21 @@ class DotProductAttention(FleetLayer):
             # is_causal is True in default
             # training is True in default
             # Default values above maybe changed in the future
+            if self.sliding_window is not None:
+                # SDPA has no SWA option; route through flashmask with no
+                # document boundaries so window_size is honored.
+                attn_output = flashmask_attention(
+                    query,
+                    key,
+                    value,
+                    startend_row_indices=None,
+                    dropout=self.config.attention_dropout,
+                    causal=True,
+                    window_size=self.sliding_window,
+                )
+                attn_output = attn_output.reshape([bsz, q_len, -1])
+                return attn_output
+
             attn_output = paddle.nn.functional.scaled_dot_product_attention(
                 query,
                 key,
@@ -383,6 +432,7 @@ class DotProductAttention(FleetLayer):
                 startend_row_indices=attn_mask_startend_row_indices,
                 dropout=self.config.attention_dropout,
                 causal=(attn_mask_type == AttnMaskType.causal),
+                window_size=self.sliding_window,
             )
 
             if need_value_padding:
@@ -544,6 +594,25 @@ class CPDotProductAttention(FleetLayer):
         self.attn_mask_type = attn_mask_type
         self.attention_type = attention_type  # unused for now
         self.rr_flashmask_attention_cp_func = rr_flashmask_attention_cp()
+
+        # Sliding-window attention is not yet supported on the context-parallel
+        # path: `flashmask_attention_cp` / `FlashMaskContextParallel` do not
+        # accept a `window_size` argument, and the DualChunkSwap query reorder
+        # used by the CP kernel would make a naive (left, right) window produce
+        # incorrect masks. Fail loud here instead of silently ignoring
+        # `mtp_window_size` / backbone `sliding_window` so users don't think
+        # SWA is active when it isn't. Set config.sliding_window=None (e.g.
+        # unset `mtp_window_size` for MTP) if you need CP>1.
+        cp_sliding_window = getattr(self.config, "sliding_window", None)
+        if cp_sliding_window is not None:
+            raise NotImplementedError(
+                f"[SWA-CP-UNSUPPORTED] layer_number={layer_number} "
+                f"sliding_window={cp_sliding_window} was requested but "
+                f"CPDotProductAttention (context_parallel_size>1) has no "
+                f"kernel-level SWA support. Either disable sliding window "
+                f"(set mtp_window_size=None / sliding_window=None) or run "
+                f"with context_parallel_size=1."
+            )
 
     def forward(
         self,

--- a/src/paddlefleet/transformer/dot_product_attention.py
+++ b/src/paddlefleet/transformer/dot_product_attention.py
@@ -146,6 +146,9 @@ class DotProductAttention(FleetLayer):
         # MTP config has sliding_window=(N, 0), and the flashmask calls below
         # now receive window_size=(N, 0).
         self.sliding_window = sliding_window
+        # Marker set by MTP's _build_mtp_transformer_config on the cloned
+        # config; used to gate SWA-startend suppression to MTP layers only.
+        self._is_mtp_layer = getattr(config, "is_mtp_layer", False)
         if sliding_window is not None:
             # Grep-friendly tag: "[SWA-KERNEL-CONFIRM]". Prints once per layer
             # that actually activates sliding-window attention at the kernel
@@ -221,11 +224,29 @@ class DotProductAttention(FleetLayer):
             else:
                 flashmask_attention_func = flashmask_attention
 
+            _swa_active = self.sliding_window is not None
+            _suppress = _swa_active and self._is_mtp_layer
+            _startend = (
+                None if _suppress else attn_mask_startend_row_indices
+            )
+            if (
+                _suppress
+                and attn_mask_startend_row_indices is not None
+                and not getattr(self, "_swa_boundary_warned", False)
+            ):
+                print(
+                    f"[SWA-BOUNDARY-SUPPRESS] layer_number={self.layer_number} "
+                    f"sliding_window={self.sliding_window} path=ec_compatible "
+                    f"- dropping startend_row_indices (kernel rejects both; "
+                    f"SWA bounds cross-doc bleed to window size)",
+                    flush=True,
+                )
+                self._swa_boundary_warned = True
             attn_output = flashmask_attention_func(
                 query.astype(value.dtype),
                 key.astype(value.dtype),
                 value,
-                startend_row_indices=attn_mask_startend_row_indices,
+                startend_row_indices=_startend,
                 dropout=0.0,
                 causal=False,  # EC uses causal=False with 2-col startend_row_indices
                 window_size=self.sliding_window,
@@ -335,11 +356,29 @@ class DotProductAttention(FleetLayer):
             else:
                 flashmask_attention_func = flashmask_attention
 
+            _swa_active = self.sliding_window is not None
+            _suppress = _swa_active and self._is_mtp_layer
+            _startend = (
+                None if _suppress else attn_mask_startend_row_indices
+            )
+            if (
+                _suppress
+                and attn_mask_startend_row_indices is not None
+                and not getattr(self, "_swa_boundary_warned", False)
+            ):
+                print(
+                    f"[SWA-BOUNDARY-SUPPRESS] layer_number={self.layer_number} "
+                    f"sliding_window={self.sliding_window} path=packed_seq "
+                    f"- dropping startend_row_indices (kernel rejects both; "
+                    f"SWA bounds cross-doc bleed to window size)",
+                    flush=True,
+                )
+                self._swa_boundary_warned = True
             attn_output = flashmask_attention_func(
                 query.astype(value.dtype),
                 key.astype(value.dtype),
                 value.astype(value.dtype),
-                startend_row_indices=attn_mask_startend_row_indices,
+                startend_row_indices=_startend,
                 dropout=self.config.attention_dropout,
                 causal=False,
                 window_size=self.sliding_window,
@@ -425,11 +464,29 @@ class DotProductAttention(FleetLayer):
             else:
                 value_padded = value
 
+            _swa_active = self.sliding_window is not None
+            _suppress = _swa_active and self._is_mtp_layer
+            _startend = (
+                None if _suppress else attn_mask_startend_row_indices
+            )
+            if (
+                _suppress
+                and attn_mask_startend_row_indices is not None
+                and not getattr(self, "_swa_boundary_warned", False)
+            ):
+                print(
+                    f"[SWA-BOUNDARY-SUPPRESS] layer_number={self.layer_number} "
+                    f"sliding_window={self.sliding_window} path=flashmask "
+                    f"- dropping startend_row_indices (kernel rejects both; "
+                    f"SWA bounds cross-doc bleed to window size)",
+                    flush=True,
+                )
+                self._swa_boundary_warned = True
             attn_output = flashmask_attention_func(
                 query.astype(value.dtype),
                 key.astype(value.dtype),
                 value_padded.astype(value.dtype),
-                startend_row_indices=attn_mask_startend_row_indices,
+                startend_row_indices=_startend,
                 dropout=self.config.attention_dropout,
                 causal=(attn_mask_type == AttnMaskType.causal),
                 window_size=self.sliding_window,

--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -157,7 +157,7 @@ class StandardMoERouter(nn.Layer):
         self.weight = paddle.create_parameter(
             shape=[self.num_experts, self.hidden_size],
             dtype="float32",
-            default_initializer=paddle.nn.initializer.Uniform(),
+            # default_initializer=paddle.nn.initializer.Uniform(),
         )
 
         if self.routed_scaling_factor_learnable:

--- a/src/paddlefleet/transformer/multi_latent_attention.py
+++ b/src/paddlefleet/transformer/multi_latent_attention.py
@@ -787,7 +787,7 @@ class MLASelfAttention(MultiLatentAttention):
                 if self.config.sequence_parallel and rotary_pos_emb.ndim == 4:
                     rotary_pos_emb = rotary_pos_emb.transpose([1, 0, 2, 3])
 
-                if self.config.gpt_model_use_experimental_version or True:
+                if self.config.gpt_model_use_experimental_version:
                     # EC-compatible RoPE: complex rotation, no YaRN, no mscale
                     from paddlefleet.transformer.transformer_layer import (
                         TransformerLayer,

--- a/src/paddlefleet/transformer/multi_latent_attention.py
+++ b/src/paddlefleet/transformer/multi_latent_attention.py
@@ -787,7 +787,7 @@ class MLASelfAttention(MultiLatentAttention):
                 if self.config.sequence_parallel and rotary_pos_emb.ndim == 4:
                     rotary_pos_emb = rotary_pos_emb.transpose([1, 0, 2, 3])
 
-                if self.config.gpt_model_use_experimental_version:
+                if self.config.gpt_model_use_experimental_version or True:
                     # EC-compatible RoPE: complex rotation, no YaRN, no mscale
                     from paddlefleet.transformer.transformer_layer import (
                         TransformerLayer,

--- a/src/paddlefleet/transformer/multi_token_prediction.py
+++ b/src/paddlefleet/transformer/multi_token_prediction.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+import copy
 import warnings
 from contextlib import nullcontext
 from dataclasses import dataclass
@@ -318,7 +319,7 @@ class MultiTokenPredictionLayer(FleetLayer):
         )
         self.transformer_layer = build_spec_layer(
             self.sublayers_spec.transformer_layer,
-            config=self.config,
+            config=self._build_mtp_transformer_config(),
         )
         if not self.config.gpt_model_use_experimental_version:
             self.norm = build_spec_layer(
@@ -329,6 +330,41 @@ class MultiTokenPredictionLayer(FleetLayer):
             )
 
         self.offload_context = nullcontext()
+
+    def _build_mtp_transformer_config(self):
+        """Build a TransformerConfig for the MTP transformer layer.
+
+        Semantics of `mtp_window_size` on the shared config:
+          - None -> MTP uses global attention (sliding_window=None), independent of the
+            backbone's sliding_window setting.
+          - int  -> MTP uses causal sliding window attention with the given size,
+            i.e. sliding_window=(mtp_window_size, 0).
+        """
+        mtp_window_size = getattr(self.config, "mtp_window_size", None)
+        mtp_config = copy.copy(self.config)
+        if mtp_window_size is None:
+            mtp_config.sliding_window = None
+        else:
+            mtp_config.sliding_window = (int(mtp_window_size), 0)
+        # Force-enable SWA on every MTP layer regardless of the backbone's
+        # skip pattern. Without this, `is_layer_window_attention` inside
+        # `DotProductAttention.__init__` can decide this MTP layer falls on a
+        # "skip" slot (e.g. when backbone has window_attn_skip_freq set) and
+        # silently drop mtp_window_size.
+        mtp_config.window_attn_skip_freq = None
+        # Visible banner so operators can grep the training log to confirm MTP
+        # sliding-window attention is actually configured as expected.
+        # Grep-friendly tag: "[MTP-SWA-CONFIRM]".
+        warnings.warn(
+            f"[MTP-SWA-CONFIRM] layer_number={self.layer_number} "
+            f"mtp_window_size={mtp_window_size} -> "
+            f"mtp_config.sliding_window={mtp_config.sliding_window} "
+            f"mtp_config.window_attn_skip_freq={mtp_config.window_attn_skip_freq} "
+            f"(backbone.sliding_window={getattr(self.config, 'sliding_window', None)}, "
+            f"backbone.window_attn_skip_freq="
+            f"{getattr(self.config, 'window_attn_skip_freq', None)})"
+        )
+        return mtp_config
 
     def _concat_embeddings(
         self,

--- a/src/paddlefleet/transformer/multi_token_prediction.py
+++ b/src/paddlefleet/transformer/multi_token_prediction.py
@@ -352,6 +352,26 @@ class MultiTokenPredictionLayer(FleetLayer):
         # "skip" slot (e.g. when backbone has window_attn_skip_freq set) and
         # silently drop mtp_window_size.
         mtp_config.window_attn_skip_freq = None
+        # Marker read by DotProductAttention to gate SWA-startend suppression
+        # to MTP layers only (main-model layers should never drop document
+        # boundaries even if they happen to use SWA).
+        mtp_config.is_mtp_layer = True
+        # Override the spec-captured backbone config on the transformer_layer
+        # LayerSpec so TransformerLayer.__init__ sees mtp_config (with
+        # sliding_window=(mtp_window_size, 0)) instead of the backbone config.
+        # Necessary because in this Paddle version LayerSpec.build() merges
+        # `extra_kwargs` with precedence over kwargs passed to
+        # build_spec_layer, so passing `config=mtp_config` to
+        # build_spec_layer(transformer_layer_spec, ...) alone does NOT
+        # override the spec's captured backbone config. The inner MLA /
+        # core_attention specs do not bake a config, so once the outer
+        # TransformerLayer sees mtp_config, it propagates correctly down
+        # to DotProductAttention and `[SWA-KERNEL-CONFIRM]` fires.
+        tl_spec = self.sublayers_spec.transformer_layer
+        if hasattr(tl_spec, "extra_kwargs") and isinstance(
+            tl_spec.extra_kwargs, dict
+        ):
+            tl_spec.extra_kwargs["config"] = mtp_config
         # Visible banner so operators can grep the training log to confirm MTP
         # sliding-window attention is actually configured as expected.
         # Grep-friendly tag: "[MTP-SWA-CONFIRM]".

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -197,6 +197,13 @@ class TransformerConfig(ModelParallelConfig):
     """If not None, then will use sliding window attention. The size of the window is specified by
     the numbers inside the tuple; -1 is special value meaning "infinite window size"."""
 
+    mtp_window_size: int = None
+    """Sliding window size used only by MTP (multi-token prediction) layers.
+    - If None: MTP layers use global attention (sliding_window=None), regardless of the backbone.
+    - If int: MTP layers use causal sliding window attention with size mtp_window_size
+      (equivalent to sliding_window=(mtp_window_size, 0)). The backbone's sliding_window is
+      unaffected."""
+
     window_attn_skip_freq: int | list[int] = None
     """Frequency of full attention layers among sliding window attention layers. Accepts either:
     - An integer N: Represents a (N-1):1 ratio, one full attention layer after (N-1) SWA layers.


### PR DESCRIPTION
### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library  | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you've done -->
1. 新增 `mtp_window_size` 字段到 `TransformerConfig`：默认 `None` 使 MTP 层使用全局注意力；设为整数时 MTP 层使用 causal sliding window attention（等价于 `sliding_window=(mtp_window_size, 0)`），与骨干网络的 `sliding_window` 独立。
2. 修复 SWA 与 `startend_row_indices` 的冲突：当 MTP 层启用 SWA 时通过 `is_mtp_layer` 标记自动禁用 `startend_row_indices`（flash kernel 不支持两者同时传入），不影响主干网络的文档边界处理。
3. 修复 `flash_mask_facade.py` 中 `startend_row_indices=None` 时调用 `.clone()` 导致的崩溃。
4. `CPDotProductAttention` 在 `context_parallel_size>1` 且 `sliding_window!=None` 时抛出 `NotImplementedError`，明确 CP+SWA 不支持。
5. 将 MTP loss 同步写入 `global_training_logs`，供 ernie5 trainer 读取。