### PR TITLE
add cudagraph demo

### DIFF
--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -36,6 +36,7 @@ from paddle.distributed.fleet.meta_parallel.zero_bubble_utils import (
 )
 
 from paddlefleet.context_parallel_utils import ContextParallelAllGatherOp
+from paddlefleet.cudagraph import autocudagraph
 from paddlefleet.parallel_state import get_context_parallel_world_size
 from paddlefleet.transformer.moe.moe_utils import apply_random_logits
 
@@ -349,8 +350,17 @@ class StandardMoERouter(nn.Layer):
         aux_loss = paddle.sum(me * ce) * float(self.num_experts)
         return aux_loss
 
-    def _cal_seq_aux_loss(
-        self, probs, top_k, routing_map, seq_len, batch_size, input_ids=None
+    @autocudagraph(
+        warmup_steps=1,
+        max_graphs=10,
+        dispatch_key_fn=lambda kw: (
+            kw["seq_len"],
+            kw["batch_size"],
+            paddle.is_grad_enabled(),
+        ),
+    )
+    def _cal_seq_aux_loss_part(
+        self, probs, routing_map, seq_len, batch_size, input_ids=None
     ):
         # all_probs and routing_map should be computed using the runtime local sequence length on each worker.
         if (
@@ -420,6 +430,14 @@ class StandardMoERouter(nn.Layer):
             denom = token_count_per_line + 1e-6 * is_invalid_line_float
         else:
             denom = paddle.to_tensor(float(max_seq_len), dtype="float32")
+        return routing_map, seq_axis, denom, all_probs
+
+    def _cal_seq_aux_loss(
+        self, probs, top_k, routing_map, seq_len, batch_size, input_ids=None
+    ):
+        routing_map, seq_axis, denom, all_probs = self._cal_seq_aux_loss_part(
+            probs, routing_map, seq_len, batch_size, input_ids
+        )
 
         if getattr(self.config, "gpt_model_use_experimental_version", False):
             # Align with ernie: divide by S first, then multiply by E/K (two-step to match float order)


### PR DESCRIPTION
这是一个使用 cudagraph 的极简 demo，将有空泡的小函数抽出来，使用 autocudagraph 装饰器

不开 CUDAGraph，39.2μs

<img width="930" height="248" alt="image" src="https://github.com/user-attachments/assets/38c526ae-5949-45d5-87df-bf5b78d4c620" />


开启 CUDAGraph 之后，17.6μs

<img width="848" height="257" alt="image" src="https://github.com/user-attachments/assets/777ff8ff-7c47-41a6-87b6-fd3cf1ef4a4b" />


可以看到确实降低了 launch 开销，kernel 间更加紧凑，但实际训练场景不建议对这么小的函数使用 cudagraph，在 cudagraph replay 前后会引入 D2D 的 Memcpy 

<img width="751" height="293" alt="image" src="https://github.com/user-attachments/assets/55c41fea-0448-4635-b28e-01659270ae69" />

可以类似 FastDeploy 那样，大幅度该组网，在模型输入前做 Padding，Padding 到一系列固定的长度，然后按这个长度走对应的 cudagraph 图

---

记录一个问题，目前是将 `_cal_seq_aux_loss` 中不包含 `sum` 的部分抽离出来，如果包含 `sum` 部分会报 CUDA700，@lshpku 说可能是因为 Paddle 的 sum 在某些场景是两阶段导致的，但我抽出最简 demo 无法复现这个问题

https://github.com/PaddlePaddle/PaddleFleet/blob/edae399b0fb1d3191a9402949ef7873bad717a8a/src/paddlefleet/transformer/moe/moe_router.py#L441-L450

CUDAGraph 包含如上部分会报 CUDA700