### PR TITLE
Add Double-scalar-gated(Nanochat-like) embedding injection to final decoder input

### DIFF
--- a/src/paddlefleet/models/gpt/gpt_embedding.py
+++ b/src/paddlefleet/models/gpt/gpt_embedding.py
@@ -450,6 +450,12 @@ class GPTEmbedding(FleetLayer):
             hidden_states_concat = paddle.concat(mtp_emb_res)
             preproc_output["hidden_states"] = hidden_states_concat
 
+        if getattr(self.config, 'use_embedding_gating', False):
+            if mtp_emb_res is not None:
+                preproc_output["embedding_for_gating"] = mtp_emb_res[0]
+            else:
+                preproc_output["embedding_for_gating"] = decoder_input
+
         for key in list(preproc_output.keys()):
             if preproc_output[key] is None:
                 preproc_output.pop(key)

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -88,10 +88,15 @@ class TransformerConfig(ModelParallelConfig):
 
     use_embedding_gating: bool = False
     """When True, apply scalar gating to fuse initial embedding into the last decoder layer input.
-    Formula: h_in^L = alpha * h_out^{L-1} + (1 - alpha) * e_0"""
+    Formula: h_in^L = alpha * h_out^{L-1} + beta * e_0
+    reference for Nanochat: https://github.com/karpathy/nanochat/blob/master/nanochat/gpt.py
+    """
 
-    embedding_gating_alpha_init: float = 1.0
+    embedding_gating_alpha_init: float = 1.05
     """Initial value of the embedding gating alpha parameter."""
+
+    embedding_gating_beta_init: float = 0.05
+    """Initial value of the embedding gating beta parameter."""
 
     # Note: need to implement PipelineParallelLayerLayout and import
     # pipeline_model_parallel_layout: str | list | PipelineParallelLayerLayout = None

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -86,6 +86,13 @@ class TransformerConfig(ModelParallelConfig):
         ..., Decoder, Dcoder, EmptyLayer, EmptyLayer
     0 implies equal layer division across PP ranks."""
 
+    use_embedding_gating: bool = False
+    """When True, apply scalar gating to fuse initial embedding into the last decoder layer input.
+    Formula: h_in^L = alpha * h_out^{L-1} + (1 - alpha) * e_0"""
+
+    embedding_gating_alpha_init: float = 0.95
+    """Initial value of the embedding gating alpha parameter."""
+
     # Note: need to implement PipelineParallelLayerLayout and import
     # pipeline_model_parallel_layout: str | list | PipelineParallelLayerLayout = None
     pipeline_model_parallel_layout: str | list = None

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -90,7 +90,7 @@ class TransformerConfig(ModelParallelConfig):
     """When True, apply scalar gating to fuse initial embedding into the last decoder layer input.
     Formula: h_in^L = alpha * h_out^{L-1} + (1 - alpha) * e_0"""
 
-    embedding_gating_alpha_init: float = 0.95
+    embedding_gating_alpha_init: float = 1.0
     """Initial value of the embedding gating alpha parameter."""
 
     # Note: need to implement PipelineParallelLayerLayout and import

--- a/src/paddlefleet/transformer/transformer_layer.py
+++ b/src/paddlefleet/transformer/transformer_layer.py
@@ -529,10 +529,10 @@ class TransformerLayer(nn.Layer):
                 # mtp masks are in mtp_startend_row_indices_all and will be used by MTP layer directly
                 attn_mask_startend_row_indices_mtp = None
 
-        # --- Embedding Gating: store for use inside _forward_impl ---
+        # --- Embedding Gating: store for use AFTER recompute ---
         if self._is_last_decoder_layer:
             _emb = dict_args.pop("embedding_for_gating", None)
-            self._embedding_for_gating = _emb.detach() if _emb is not None else None
+            self._embedding_for_gating = _emb
 
         if self.config.block_attention_residuals and "blocks" not in dict_args:
             dict_args["blocks"] = []
@@ -584,6 +584,13 @@ class TransformerLayer(nn.Layer):
             output, context = outputs[0], outputs[1]
         else:
             output, context = outputs, None
+
+        # --- Embedding Gating: applied OUTSIDE recompute to avoid SliceGradNode clearing ---
+        if self._is_last_decoder_layer and self._embedding_for_gating is not None:
+            alpha = self.embedding_gate.alpha.astype(output.dtype)
+            output = alpha * output + (1.0 - alpha) * self._embedding_for_gating
+            logger.info(f"[EmbeddingGating] alpha={float(self.embedding_gate.alpha.item()):.8f}")
+            self._embedding_for_gating = None
 
         rst = OrderedDict()
         rst = {"hidden_states": output}
@@ -649,12 +656,6 @@ class TransformerLayer(nn.Layer):
         input_ids: Tensor | None = None,
         **kwargs,
     ):
-        # --- Embedding Gating: fuse initial embedding (accessed via self to work with recompute) ---
-        if self._is_last_decoder_layer and self._embedding_for_gating is not None:
-            alpha = self.embedding_gate.alpha.astype(hidden_states.dtype)
-            hidden_states = alpha * hidden_states + (1.0 - alpha) * self._embedding_for_gating
-            logger.info(f"[EmbeddingGating] alpha={float(self.embedding_gate.alpha.item()):.8f}")
-
         timer_name = "moe-mlp" if isinstance(self.mlp, MoELayer) else "mlp"
         if self.config.block_attention_residuals:
             blocks = kwargs.get("blocks", [])

--- a/src/paddlefleet/transformer/transformer_layer.py
+++ b/src/paddlefleet/transformer/transformer_layer.py
@@ -412,7 +412,8 @@ class TransformerLayer(nn.Layer):
             and self.layer_number == num_empty + self.config.num_hidden_layers - 1
         )
         if self._is_last_decoder_layer:
-            alpha_init = getattr(self.config, 'embedding_gating_alpha_init', 0.95)
+            alpha_init = getattr(self.config, 'embedding_gating_alpha_init', 1.05)
+            beta_init = getattr(self.config, 'embedding_gating_beta_init', 0.05)
             self.embedding_gate = nn.Layer()
             self.embedding_gate._cast_to_low_precision = False
             self.embedding_gate.alpha = paddle.create_parameter(
@@ -420,10 +421,15 @@ class TransformerLayer(nn.Layer):
                 dtype='float32',
                 default_initializer=paddle.nn.initializer.Constant(alpha_init),
             )
+            self.embedding_gate.beta = paddle.create_parameter(
+                shape=[1],
+                dtype='float32',
+                default_initializer=paddle.nn.initializer.Constant(beta_init),
+            )
             self._embedding_for_gating = None
             logger.info(
-                f"[EmbeddingGating] Enabled on layer {self.layer_number} "
-                f"(last decoder layer). alpha_init={alpha_init}"
+                f"[EmbeddingGating(nanochat-like)] Enabled on layer {self.layer_number} "
+                f"alpha_init={alpha_init}, beta_init={beta_init}"
             )
 
     def build_schedule_node(self):
@@ -588,8 +594,12 @@ class TransformerLayer(nn.Layer):
         # --- Embedding Gating: applied OUTSIDE recompute to avoid SliceGradNode clearing ---
         if self._is_last_decoder_layer and self._embedding_for_gating is not None:
             alpha = self.embedding_gate.alpha.astype(output.dtype)
-            output = alpha * output + (1.0 - alpha) * self._embedding_for_gating
-            logger.info(f"[EmbeddingGating] alpha={float(self.embedding_gate.alpha.item()):.8f}")
+            beta = self.embedding_gate.beta.astype(output.dtype)
+            output = alpha * output + beta * self._embedding_for_gating
+            logger.info(
+                f"[EmbeddingGating(nanochat-like)] alpha={float(self.embedding_gate.alpha.item()):.16f},"
+                f" beta={float(self.embedding_gate.beta.item()):.16f}"
+            )
             self._embedding_for_gating = None
 
         rst = OrderedDict()

--- a/src/paddlefleet/transformer/transformer_layer.py
+++ b/src/paddlefleet/transformer/transformer_layer.py
@@ -404,6 +404,28 @@ class TransformerLayer(nn.Layer):
             )
             self.attn_res_block_size = self.config.attn_res_block_size
 
+        # [Layer 11: Embedding Gating] Scalar gate for last decoder layer
+        self.use_embedding_gating = getattr(self.config, 'use_embedding_gating', False)
+        num_empty = getattr(self.config, 'num_empty_layers_add_in_head', 0) or 0
+        self._is_last_decoder_layer = (
+            self.use_embedding_gating
+            and self.layer_number == num_empty + self.config.num_hidden_layers - 1
+        )
+        if self._is_last_decoder_layer:
+            alpha_init = getattr(self.config, 'embedding_gating_alpha_init', 0.95)
+            self.embedding_gate = nn.Layer()
+            self.embedding_gate._cast_to_low_precision = False
+            self.embedding_gate.alpha = paddle.create_parameter(
+                shape=[1],
+                dtype='float32',
+                default_initializer=paddle.nn.initializer.Constant(alpha_init),
+            )
+            self._embedding_for_gating = None
+            logger.info(
+                f"[EmbeddingGating] Enabled on layer {self.layer_number} "
+                f"(last decoder layer). alpha_init={alpha_init}"
+            )
+
     def build_schedule_node(self):
         return TransformerLayerNode(
             self,
@@ -506,6 +528,11 @@ class TransformerLayer(nn.Layer):
                 # New dataflow (experimental_dataflow=True): main mask is already main-seq only,
                 # mtp masks are in mtp_startend_row_indices_all and will be used by MTP layer directly
                 attn_mask_startend_row_indices_mtp = None
+
+        # --- Embedding Gating: store for use inside _forward_impl ---
+        if self._is_last_decoder_layer:
+            _emb = dict_args.pop("embedding_for_gating", None)
+            self._embedding_for_gating = _emb.detach() if _emb is not None else None
 
         if self.config.block_attention_residuals and "blocks" not in dict_args:
             dict_args["blocks"] = []
@@ -622,6 +649,12 @@ class TransformerLayer(nn.Layer):
         input_ids: Tensor | None = None,
         **kwargs,
     ):
+        # --- Embedding Gating: fuse initial embedding (accessed via self to work with recompute) ---
+        if self._is_last_decoder_layer and self._embedding_for_gating is not None:
+            alpha = self.embedding_gate.alpha.astype(hidden_states.dtype)
+            hidden_states = alpha * hidden_states + (1.0 - alpha) * self._embedding_for_gating
+            logger.info(f"[EmbeddingGating] alpha={float(self.embedding_gate.alpha.item()):.8f}")
+
         timer_name = "moe-mlp" if isinstance(self.mlp, MoELayer) else "mlp"
         if self.config.block_attention_residuals:
             blocks = kwargs.get("blocks", [])


### PR DESCRIPTION
Formula:
\textbf{h}^L_{\text{in}} = \alpha \times \textbf{h}^{L-1}_{out} + \beta \times \textbf{e}