### PR TITLE
改动预览

### DIFF
--- a/src/paddlefleet/model_parallel_config.py
+++ b/src/paddlefleet/model_parallel_config.py
@@ -147,9 +147,9 @@ class ModelParallelConfig:
        be synchronized.
     """
 
-    deterministic_mode: bool = False
+    deterministic_mode: bool = True
     """If true, code that has deterministic execution will be chosen. This usually
-       means slower execution, but is good for debugging and testing. Defaults to False."""
+       means slower execution, but is good for debugging and testing. Defaults to True."""
 
     enable_autocast: bool = False
     """If true runs the forward step function inside paddle.amp.autocast context."""

--- a/src/paddlefleet/tensor_parallel/layers.py
+++ b/src/paddlefleet/tensor_parallel/layers.py
@@ -501,7 +501,10 @@ class LinearWithGradAccumulationAndAsyncCommunication(paddle.autograd.Function):
         if bias is not None:
             output = paddle.nn.functional.linear(total_input, weight, bias)
         else:
-            output = paddle.matmul(total_input, weight)
+            # Use F.linear (aligns with Torch NT cuBLAS path for RowParallelLinear
+            # layers such as attention o_proj; MoE expert GEMM does not go through
+            # this function so V12/V13 small-M per-expert concerns do not apply here).
+            output = paddle.nn.functional.linear(total_input, weight)
         return output
 
     @staticmethod

--- a/src/paddlefleet/transformer/dot_product_attention.py
+++ b/src/paddlefleet/transformer/dot_product_attention.py
@@ -46,6 +46,35 @@ from paddlefleet.transformer.utils import (
 from paddlefleet.utils import divide
 
 
+class _EagerQKScoresFn(paddle.autograd.PyLayer):
+    """Compute QK scores with baddbmm forward and explicit matmul backward."""
+
+    @staticmethod
+    def forward(ctx, query, key_t, scale):  # noqa: N805
+        matmul_input_buffer = paddle.empty(
+            (query.shape[0], query.shape[1], key_t.shape[2]),
+            dtype=query.dtype,
+        )
+        scores = paddle.baddbmm(
+            matmul_input_buffer,
+            query,
+            key_t,
+            beta=0.0,
+            alpha=scale,
+        )
+        ctx.save_for_backward(query, key_t)
+        ctx.scale = scale
+        return scores
+
+    @staticmethod
+    def backward(ctx, d_scores):  # noqa: N805
+        query, key_t = ctx.saved_tensor()
+        scale = ctx.scale
+        d_query = paddle.matmul(d_scores, key_t, transpose_y=True) * scale
+        d_key_t = paddle.matmul(query, d_scores, transpose_x=True) * scale
+        return d_query, d_key_t
+
+
 class DotProductAttention(FleetLayer):
     """
     Region where selective activation recomputation is applied.
@@ -450,20 +479,26 @@ class DotProductAttention(FleetLayer):
             output_size[0] * output_size[1], -1, output_size[3]
         )
 
-        # preallocting input tensor: [b * np, sq, sk]
-        matmul_input_buffer = paddle.empty(
-            (output_size[0] * output_size[1], output_size[2], output_size[3]),
-            query.dtype,
-        )
-
         # Raw attention scores. [b * np, sq, sk]
-        matmul_result = paddle.baddbmm(
-            matmul_input_buffer,
-            query,
-            key,
-            beta=0.0,
-            alpha=self.softmax_scale,
-        )
+        if use_eager:
+            matmul_result = _EagerQKScoresFn.apply(query, key, self.softmax_scale)
+        else:
+            # preallocating input tensor: [b * np, sq, sk]
+            matmul_input_buffer = paddle.empty(
+                (
+                    output_size[0] * output_size[1],
+                    output_size[2],
+                    output_size[3],
+                ),
+                query.dtype,
+            )
+            matmul_result = paddle.baddbmm(
+                matmul_input_buffer,
+                query,
+                key,
+                beta=0.0,
+                alpha=self.softmax_scale,
+            )
 
         # change view to [b, np, sq, sk]
         attention_scores = matmul_result.reshape(*output_size)
@@ -471,6 +506,25 @@ class DotProductAttention(FleetLayer):
         # ===========================
         # Attention probs and dropout
         # ===========================
+
+        if use_eager:
+            if hasattr(self.scale_mask_softmax, "softmax_in_fp32"):
+                self.scale_mask_softmax.softmax_in_fp32 = True
+            if hasattr(self.config, "attention_softmax_in_fp32"):
+                self.config.attention_softmax_in_fp32 = True
+            if hasattr(self.scale_mask_softmax, "input_in_bf16"):
+                if attention_scores.dtype == paddle.bfloat16:
+                    self.scale_mask_softmax.input_in_fp16 = False
+                    self.scale_mask_softmax.input_in_bf16 = True
+                    self.scale_mask_softmax.input_in_float16 = True
+                elif attention_scores.dtype == paddle.float16:
+                    self.scale_mask_softmax.input_in_fp16 = True
+                    self.scale_mask_softmax.input_in_bf16 = False
+                    self.scale_mask_softmax.input_in_float16 = True
+                else:
+                    self.scale_mask_softmax.input_in_fp16 = False
+                    self.scale_mask_softmax.input_in_bf16 = False
+                    self.scale_mask_softmax.input_in_float16 = False
 
         # attention scores and attention mask [b, np, sq, sk]
         attention_probs: Tensor = self.scale_mask_softmax(

--- a/src/paddlefleet/transformer/dot_product_attention.py
+++ b/src/paddlefleet/transformer/dot_product_attention.py
@@ -70,7 +70,10 @@ class _EagerQKScoresFn(paddle.autograd.PyLayer):
     def backward(ctx, d_scores):  # noqa: N805
         query, key_t = ctx.saved_tensor()
         scale = ctx.scale
-        d_query = paddle.matmul(d_scores, key_t, transpose_y=True) * scale
+        # Match Torch autograd of `matmul(Q, K.transpose(-1,-2)) * scale`: d_Q = matmul(d_scores, K) as NN-GEMM.
+        # Using transpose_y=True here picks a TN-GEMM cuBLAS algorithm and loses 1 ULP at bf16.
+        key = paddle.transpose(key_t, perm=[0, 2, 1]).contiguous()
+        d_query = paddle.matmul(d_scores, key) * scale
         d_key_t = paddle.matmul(query, d_scores, transpose_x=True) * scale
         return d_query, d_key_t
 

--- a/src/paddlefleet/transformer/moe/fp8_utils.py
+++ b/src/paddlefleet/transformer/moe/fp8_utils.py
@@ -1632,14 +1632,24 @@ class ExpertsGroupGemmContiguousNode:
                         * self.token_padding_alignment
                     )
                     end_idx = start_idx + n
-                    paddle._C_ops.fused_linear_param_grad_add(
-                        x._slice(start_idx, end_idx),
-                        dy._slice(start_idx, end_idx),
-                        grad_attr,
-                        None,
-                        True,
-                        False,
-                    )
+                    if self.use_fp8_mlp:
+                        paddle._C_ops.fused_linear_param_grad_add(
+                            x._slice(start_idx, end_idx),
+                            dy._slice(start_idx, end_idx),
+                            grad_attr,
+                            None,
+                            True,
+                            False,
+                        )
+                    else:
+                        paddle._C_ops.fused_linear_param_grad_add(
+                            x._slice(start_idx, end_idx).astype("float32"),
+                            dy._slice(start_idx, end_idx).astype("float32"),
+                            grad_attr,
+                            None,
+                            True,
+                            False,
+                        )
                     start_idx = end_idx
 
                 if (

--- a/src/paddlefleet/transformer/moe/fp8_utils.py
+++ b/src/paddlefleet/transformer/moe/fp8_utils.py
@@ -565,7 +565,15 @@ class ExpertsGroupGemmContiguousNode:
         fwd_down_bf16
         """
 
-        o2 = fused_swiglu_scale_forward(o1, unzipped_probs)
+        x_glu, x_linear = paddle.chunk(o1, chunks=2, axis=-1)
+        probs = unzipped_probs
+        if len(probs.shape) == 1:
+            probs = probs.unsqueeze(-1)
+        o2 = (
+            F.silu(x_glu.astype("float32"))
+            * x_linear.astype("float32")
+            * probs.astype("float32")
+        ).astype(o1.dtype)
 
         if clear_o1:
             o1._clear_to_zero_allocation()
@@ -705,7 +713,7 @@ class ExpertsGroupGemmContiguousNode:
                     ].contiguous()
                     expert_w2_i = expert_w2[i].T.contiguous()
                     do2_s_list.append(
-                        F.linear(x=unzipped_grad_i, weight=expert_w2_i)
+                        paddle.matmul(unzipped_grad_i, expert_w2_i)
                     )
                     start_idx = end_idx
                 do2_s = paddle.concat(do2_s_list, axis=0)
@@ -716,8 +724,32 @@ class ExpertsGroupGemmContiguousNode:
                 do2_s_shape = [unzipped_grad.shape[0], expert_w2[0].shape[1]]
             do2_s = paddle.empty(do2_s_shape, dtype=unzipped_grad.dtype)
 
-        o2_s = fused_swiglu_scale_forward(o1, unzipped_probs)
-        do1, probs_grad = fused_swiglu_scale_backward(o1, unzipped_probs, do2_s)
+        if not self.moe_grouped_gemm and numpy.prod(unzipped_grad.shape) != 0:
+            x_glu, x_linear = paddle.chunk(o1, chunks=2, axis=-1)
+            probs_v = (
+                unzipped_probs
+                if unzipped_probs.ndim > 1
+                else unzipped_probs.unsqueeze(-1)
+            )
+            with paddle.enable_grad():
+                gate_g = x_glu.astype("float32").detach()
+                val_g = x_linear.astype("float32").detach()
+                scale_g = probs_v.astype("float32").detach()
+                gate_g.stop_gradient = False
+                val_g.stop_gradient = False
+                scale_g.stop_gradient = False
+                o2_f32 = F.silu(gate_g) * val_g * scale_g
+                paddle.autograd.backward([o2_f32], [do2_s.astype("float32").detach()])
+                d_gate_f32 = gate_g.grad
+                d_up_f32 = val_g.grad
+                d_scale_f32 = scale_g.grad.reshape(unzipped_probs.shape).astype("float32")
+
+            do1 = paddle.concat([d_gate_f32, d_up_f32], axis=-1).astype(o1.dtype)
+            o2_s = o2_f32.detach().astype(o1.dtype)
+            probs_grad = d_scale_f32.astype(unzipped_probs.dtype)
+        else:
+            o2_s = fused_swiglu_scale_forward(o1, unzipped_probs)
+            do1, probs_grad = fused_swiglu_scale_backward(o1, unzipped_probs, do2_s)
 
         return do1, o2_s, probs_grad
 
@@ -844,7 +876,7 @@ class ExpertsGroupGemmContiguousNode:
                     end_idx = start_idx + token_num
                     do1_i = do1[start_idx:end_idx].contiguous()
                     expert_w1_i = expert_w1[i].T.contiguous()
-                    dx_list.append(F.linear(x=do1_i, weight=expert_w1_i))
+                    dx_list.append(paddle.matmul(do1_i, expert_w1_i))
                     start_idx = end_idx
                 dx = paddle.concat(dx_list, axis=0)
         else:

--- a/src/paddlefleet/transformer/moe/fp8_utils.py
+++ b/src/paddlefleet/transformer/moe/fp8_utils.py
@@ -87,7 +87,15 @@ __all__ = [
 ]
 
 
-FP8_ALIGN = 128
+FP8_ALIGN = 1
+
+
+def moe_token_padding_alignment(
+    *, use_fp8_mlp: bool, moe_grouped_gemm: bool
+) -> int:
+    if not use_fp8_mlp and not moe_grouped_gemm:
+        return 1
+    return FP8_ALIGN
 
 
 def _get_fp8_weight_and_scale(weight, transpose=False):
@@ -348,6 +356,9 @@ class ExpertsGroupGemmContiguousNode:
         self.moe_deep_gemm = moe_deep_gemm
         self.moe_grouped_gemm = moe_grouped_gemm
         self.is_split_group_gemm = not moe_grouped_gemm
+        self.token_padding_alignment = moe_token_padding_alignment(
+            use_fp8_mlp=use_fp8_mlp, moe_grouped_gemm=moe_grouped_gemm
+        )
 
     def cached_tensors(self):
         """
@@ -1583,7 +1594,11 @@ class ExpertsGroupGemmContiguousNode:
                     grad_attr = weights[i].grad
 
                 if n > 0:
-                    n = (n + FP8_ALIGN - 1) // FP8_ALIGN * FP8_ALIGN
+                    n = (
+                        (n + self.token_padding_alignment - 1)
+                        // self.token_padding_alignment
+                        * self.token_padding_alignment
+                    )
                     end_idx = start_idx + n
                     paddle._C_ops.fused_linear_param_grad_add(
                         x._slice(start_idx, end_idx),

--- a/src/paddlefleet/transformer/moe/fusion_layer_utils.py
+++ b/src/paddlefleet/transformer/moe/fusion_layer_utils.py
@@ -21,7 +21,7 @@ import paddle
 import paddlefleet
 from paddlefleet.transformer.moe.fp8_utils import ExpertsGroupGemmContiguousNode
 
-from .fp8_utils import FP8_ALIGN, USE_INPLACE_SWIGLU_BWD, tilewise_quant
+from .fp8_utils import FP8_ALIGN, USE_INPLACE_SWIGLU_BWD, moe_token_padding_alignment, tilewise_quant
 from .vmm_utils import (
     find_max_concurrent_subbatch_size,
     find_max_sequence_subbatch_size,
@@ -85,6 +85,7 @@ class UnZipNode:
         num_experts,
         tokens_per_expert,
         fill_output=True,
+        padding_alignment=FP8_ALIGN,
     ):
         """
         前向传播函数，用于解压输入的张量。
@@ -118,7 +119,7 @@ class UnZipNode:
                 dispatched_probs,
                 num_experts=num_experts,
                 tokens_per_expert=tokens_per_expert,
-                padding_alignment=FP8_ALIGN,
+                padding_alignment=padding_alignment,
                 do_gather=fill_output,
             )
 
@@ -221,6 +222,7 @@ class ZipNode:
         num_experts,
         tokens_per_expert,
         fill_output=True,
+        padding_alignment=FP8_ALIGN,
     ):
         with paddle.amp.auto_cast(False):
             (
@@ -235,7 +237,7 @@ class ZipNode:
                 dispatched_probs,
                 num_experts,
                 tokens_per_expert,
-                padding_alignment=FP8_ALIGN,
+                padding_alignment=padding_alignment,
                 do_gather=fill_output,
             )
         return unzipped_grad
@@ -351,8 +353,13 @@ class MlpNode:
         self.tokens_per_expert = (
             self.token_dispatcher._comm_manager.tokens_per_expert
         )
+        self.moe_permute_padding_alignment = moe_token_padding_alignment(
+            use_fp8_mlp=use_fp8_mlp, moe_grouped_gemm=moe_grouped_gemm
+        )
         self.padding_token_per_experts = [
-            (x + FP8_ALIGN - 1) // FP8_ALIGN * FP8_ALIGN
+            (x + self.moe_permute_padding_alignment - 1)
+            // self.moe_permute_padding_alignment
+            * self.moe_permute_padding_alignment
             for x in self.tokens_per_expert
         ]
         self.token_offsets = [0]
@@ -794,6 +801,7 @@ class MlpNode:
         dispatched_indices,
         dispatched_probs,
         fill_output,
+        padding_alignment=None,
     ):
         """
         前向计算的公共预处理，被 forward() 和 forward_auto_subbatch() 共用。
@@ -873,6 +881,7 @@ class MlpNode:
             num_experts=num_experts,
             tokens_per_expert=self.tokens_per_expert,
             fill_output=fill_output,
+            **({} if padding_alignment is None else {"padding_alignment": padding_alignment}),
         )
         self.unzipped_probs = unzipped_probs
 
@@ -1525,6 +1534,7 @@ class MlpNode:
             dispatched_indices,
             dispatched_probs,
             fill_output=self.moe_expert_fusion,
+            padding_alignment=self.moe_permute_padding_alignment,
         )
 
         if not self.moe_expert_fusion:
@@ -1663,6 +1673,7 @@ class MlpNode:
             num_experts=len(self.tokens_per_expert),
             tokens_per_expert=self.tokens_per_expert,
             fill_output=self.moe_expert_fusion,
+            padding_alignment=self.moe_permute_padding_alignment,
         )
         hidden_states_out_grad._record_stream()
 

--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -585,7 +585,10 @@ class StandardMoERouter(nn.Layer):
 
         # The bias term b is used only to adjust affinity scores for Top-K expert selection (routing); it does not affect gating.
         # The gate applied during dispatch and to weight the FFN output is computed from the original affinity score s_{i,t} (without the bias).
-        topk_weight = scores.take_along_axis(topk_idx, axis=1)
+        row_idx = paddle.arange(bsz_seq_len, dtype=topk_idx.dtype).unsqueeze(-1)
+        row_idx = row_idx.expand(topk_idx.shape)
+        gather_idx = paddle.stack([row_idx, topk_idx], axis=-1)
+        topk_weight = paddle.gather_nd(scores, gather_idx)
 
         return topk_weight, topk_idx
 

--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -41,6 +41,37 @@ _LOG_LAYER_MD5 = os.environ.get("LOG_LAYER_MD5", "0") == "1"
 # Lazy-loaded EC FusedMoETopk Triton kernel for bit-exact alignment
 _FusedMoETopk = None
 
+# MiniMax alignment side-channel: FusedGateDetachMatmul.backward stores the
+# raw fp32 router gate wgrad here so the PaddleFormers optimizer wrapper can
+# replay the gate AdamW step in fp32 before bf16 copyback.  The runtime
+# workspace patch used an equivalent module-level dict; source owns it now.
+_MINIMAX_ROUTER_GATE_FP32_WGRAD = {}
+
+
+def _minimax_env_flag(name, default=True):
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.lower() not in {"0", "false", "off", "no"}
+
+
+def _minimax_router_source_alignment_enabled():
+    return _minimax_env_flag("MINIMAX_PADDLE_ROUTER_SOURCE_ALIGNMENT", True)
+
+
+def _minimax_router_gate_wgrad_alignment_enabled():
+    return _minimax_env_flag("MINIMAX_PADDLE_ROUTER_GATE_FP32_WGRAD", True)
+
+
+def _minimax_peek_router_gate_fp32_wgrad():
+    if not _MINIMAX_ROUTER_GATE_FP32_WGRAD:
+        return None
+    return next(iter(_MINIMAX_ROUTER_GATE_FP32_WGRAD.values()))
+
+
+def _minimax_clear_router_gate_fp32_wgrad():
+    _MINIMAX_ROUTER_GATE_FP32_WGRAD.clear()
+
 
 def _get_fused_moe_topk():
     global _FusedMoETopk
@@ -86,6 +117,29 @@ class FusedGateDetachMatmul(paddle.autograd.PyLayer):
     def backward(ctx, y_grad):
         x, w = ctx.saved_tensor()
         assert ctx.dtype == y_grad.dtype, "dtype not match"
+
+        if _minimax_router_gate_wgrad_alignment_enabled():
+            x_fp32 = x.cast(ctx.dtype)
+            w_fp32 = w.cast(ctx.dtype)
+            if not x.stop_gradient:
+                # Forward is y = x @ w.  Use explicit NN-GEMM for dx to match
+                # Torch's router gate backward kernel choice.
+                x_g = paddle.matmul(y_grad, w_fp32.T.contiguous())
+                x_grad = x_g.cast(x.dtype)
+            else:
+                x_grad = None
+
+            if not w.stop_gradient:
+                # Store raw fp32 wgrad [E, H] for source-owned optimizer replay.
+                wgrad_for_param = paddle.matmul(y_grad.cast("float32").T, x_fp32)
+                _MINIMAX_ROUTER_GATE_FP32_WGRAD[w.data_ptr()] = wgrad_for_param
+                # Autograd bookkeeping still receives a dtype-compatible grad
+                # for the saved transposed weight tensor [H, E].
+                w_grad = paddle.transpose(wgrad_for_param, [1, 0]).cast(w.dtype)
+            else:
+                w_grad = None
+            return x_grad, w_grad
+
         x_g, w_g = matmul_grad(
             x.cast(ctx.dtype),
             w.cast(ctx.dtype),
@@ -627,7 +681,118 @@ class TopKRouter(StandardMoERouter):
     def set_layer_number(self, layer_number):
         self._layer_number = layer_number
 
+    def _minimax_unified_forward(self, input, input_ids=None):
+        """MiniMax Paddle↔Megatron alignment router path.
+
+        This source-owned path mirrors Megatron's sparse-first routing op tree
+        for the current MiniMax config and returns the same tuple contract as
+        the native TopKRouter.forward.  It intentionally deposits tracked
+        tensors on the router instance for workspace probes; those attributes do
+        not affect training semantics.
+        """
+        if len(input.shape) == 3:
+            _, _, d_model = input.shape
+            input = input.reshape([-1, d_model])
+        elif len(input.shape) == 2:
+            raise ValueError(
+                "The input tensor must have 3 dimensions "
+                "[batch_size, sequence_length, hidden_size], "
+                f"got shape {input.shape}"
+            )
+
+        with paddle.amp.auto_cast(False):
+            # Torch stores the router gate model weight in bf16 after optimizer
+            # copyback and casts to fp32 for matmul.  Paddle keeps this param in
+            # fp32, so simulate bf16 copyback before the fp32 matmul.
+            weight_bf16_sim = self.weight.cast("bfloat16").cast(self.weight.dtype)
+            logits = gate_detach_matmul(
+                input,
+                weight_bf16_sim.T,
+                True,
+                self.config.moe_router_force_load_balancing,
+            )
+
+        if logits.dtype != paddle.float32:
+            logits = logits.cast("float32")
+
+        expert_bias = None
+        if self.topk_method == "noaux_tc":
+            expert_bias = getattr(self, "e_score_correction_bias", None)
+
+        topk = int(self.num_experts_per_tok)
+        with paddle.amp.auto_cast(False):
+            scores_full = self.gate_score_func(logits)
+            if expert_bias is not None:
+                bias_detached = expert_bias.detach()
+                if bias_detached.dtype != paddle.float32:
+                    bias_detached = bias_detached.cast("float32")
+                scores_for_choice = scores_full + bias_detached.unsqueeze(0)
+                _, top_idx = paddle.topk(scores_for_choice, k=topk, axis=-1, sorted=True)
+                scores = paddle.take_along_axis(scores_full, top_idx, axis=1)
+            else:
+                scores, top_idx = paddle.topk(scores_full, k=topk, axis=-1, sorted=True)
+
+            if self.norm_topk_prob and topk > 1:
+                denom = scores.sum(axis=-1, keepdim=True) + 1e-20
+                top_gate = scores / denom
+            else:
+                top_gate = scores
+
+            if abs(float(self.routed_scaling_factor) - 1.0) > 1e-6:
+                top_gate = top_gate * float(self.routed_scaling_factor)
+
+            probs_preorder = top_gate
+            top_idx_preorder = top_idx
+
+            if topk > 1:
+                reorder = paddle.argsort(top_gate, axis=-1, descending=True)
+                top_idx = paddle.take_along_axis(top_idx, reorder, axis=1)
+                top_gate = paddle.take_along_axis(top_gate, reorder, axis=1)
+
+            probs = paddle.zeros_like(logits).put_along_axis(top_idx, top_gate, axis=1)
+            mask = paddle.zeros_like(logits).put_along_axis(
+                top_idx, paddle.ones_like(top_gate), axis=1
+            )
+
+        if self.topk_method == "noaux_tc":
+            exp_counts = paddle.sum(mask.cast(paddle.int64), axis=0)
+            with paddle.no_grad():
+                self.expert_usage += exp_counts
+
+        # Probe-only side channel consumed by workspace observers.
+        self._minimax_router_side_channel = {
+            "logits": logits,
+            "scores_full": scores_full,
+            "probs_preorder": probs_preorder,
+            "top_idx_preorder": top_idx_preorder,
+        }
+
+        return (
+            None,
+            top_gate,
+            top_idx,
+            probs,
+            mask,
+            None,
+            None,
+            None,
+        )
+
     def forward(self, input, input_ids=None):
+        eligible = (
+            _minimax_router_source_alignment_enabled()
+            and self.scoring_func == "sigmoid"
+            and bool(self.norm_topk_prob)
+            and self.topk_method in {"greedy", "noaux_tc"}
+            and int(self.n_group or 1) == 1
+            and int(self.topk_group if self.topk_group is not None else 1) in {0, 1}
+            and float(getattr(self.config, "router_aux_loss_coef", 0.0) or 0.0) == 0.0
+            and float(getattr(self.config, "router_z_loss_coef", 0.0) or 0.0) == 0.0
+            and not self.routed_scaling_factor_learnable
+        )
+        if eligible:
+            return self._minimax_unified_forward(input, input_ids=input_ids)
+
         if len(input.shape) == 3:
             if not self.sequence_parallel:
                 batch_size, seq_len, d_model = input.shape


### PR DESCRIPTION
- **align: explicit matmul backward for QK scores via _EagerQKScoresFn**
- **align: use F.linear for LinearWithGradAccumAndAsyncComm forward**
- **align: decouple MoE token padding alignment from FP8_ALIGN**
- **align: use gather_nd for topk_weight lookup in StandardMoERouter**
- **align: use NN-GEMM for QK scores d_query to match Torch autograd**
- **align: enable deterministic model-parallel paths by default**
- **align: use plain bf16 expert MLP math**
- **align: use fp32 matmul for expert wgrad**
