### PR TITLE
add moe_routed_expert_use_bias to TransformerConfig

### DIFF
--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -148,6 +148,16 @@ class MoELayer(nn.Layer):
         self.sublayers = sublayers
         routed_expert_config = deepcopy(config)
         shared_expert_config = deepcopy(config)
+        global_use_bias = routed_expert_config.use_bias
+        moe_routed_expert_use_bias = config.moe_routed_expert_use_bias
+        if moe_routed_expert_use_bias is not None:
+            routed_expert_config.use_bias = moe_routed_expert_use_bias
+            logger.info(
+                "PaddleFleet MoELayer moe_routed_expert_use_bias overrides "
+                "routed_expert_config.use_bias: global_use_bias=%s moe_routed_expert_use_bias=%s",
+                global_use_bias,
+                moe_routed_expert_use_bias,
+            )
         self.pg_collection = pg_collection
         self.hidden_size = config.hidden_size
         self.moe_intermediate_size = config.moe_intermediate_size
@@ -329,6 +339,7 @@ class MoELayer(nn.Layer):
                     self.experts.append(None)
 
         shared_expert_args = deepcopy(expert_args)
+        shared_expert_args["config"].use_bias = shared_expert_config.use_bias
         shared_expert_args["config"].hidden_size = self.config.hidden_size
         shared_expert_args["moe_intermediate_size"] = (
             self.moe_shared_expert_intermediate_size

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -175,6 +175,9 @@ class TransformerConfig(ModelParallelConfig):
     """Include a bias term in all linear layers (QKV projections and Output projections, after core attention, and two in
     MLP layer)."""
 
+    moe_routed_expert_use_bias: bool | None = None
+    """Override whether routed MoE expert MLP layers include bias terms. If None, use use_bias."""
+
     attention_bias: bool = False
     """Include a bias term in QKV projections."""
 

--- a/tests/single_card_tests/model/test_moe_layer_routed_expert_use_bias.py
+++ b/tests/single_card_tests/model/test_moe_layer_routed_expert_use_bias.py
@@ -1,0 +1,80 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from types import SimpleNamespace
+
+import paddle.nn.functional as F
+
+from paddlefleet.tensor_parallel.layers import (
+    ColumnParallelLinear,
+    RowParallelLinear,
+)
+from paddlefleet.transformer.mlp import MLPSublayersSpec
+from paddlefleet.transformer.moe.moe_layer import MoELayer, MoESublayers
+from paddlefleet.transformer.transformer_config import TransformerConfig
+
+
+def _make_layer(use_bias=False, moe_routed_expert_use_bias=None):
+    config = TransformerConfig(
+        num_hidden_layers=1,
+        hidden_size=16,
+        num_attention_heads=2,
+        intermediate_size=32,
+        n_routed_experts=2,
+        n_shared_experts=1,
+        num_experts_per_tok=1,
+        moe_intermediate_size=16,
+        moe_token_dispatcher_type="alltoall",
+        moe_grouped_gemm=False,
+        fp8=None,
+        gated_linear_unit=True,
+        hidden_act=F.silu,
+        use_bias=use_bias,
+        moe_routed_expert_use_bias=moe_routed_expert_use_bias,
+        tensor_model_parallel_size=1,
+    )
+    mlp_spec = MLPSublayersSpec(
+        up_gate_proj=ColumnParallelLinear,
+        down_proj=RowParallelLinear,
+    )
+    return MoELayer(
+        config,
+        sublayers=MoESublayers(mlp_spec=mlp_spec),
+        pg_collection=SimpleNamespace(ep=None, expt_dp=None),
+    )
+
+
+class TestMoELayerRoutedExpertUseBias(unittest.TestCase):
+    def test_none_follows_global_use_bias(self):
+        layer = _make_layer(use_bias=True, moe_routed_expert_use_bias=None)
+
+        self.assertTrue(layer.experts[0].config.use_bias)
+        self.assertTrue(layer.shared_experts.config.use_bias)
+
+    def test_true_overrides_global_use_bias(self):
+        layer = _make_layer(use_bias=False, moe_routed_expert_use_bias=True)
+
+        self.assertTrue(layer.experts[0].config.use_bias)
+        self.assertFalse(layer.shared_experts.config.use_bias)
+
+    def test_false_overrides_global_use_bias(self):
+        layer = _make_layer(use_bias=True, moe_routed_expert_use_bias=False)
+
+        self.assertFalse(layer.experts[0].config.use_bias)
+        self.assertTrue(layer.shared_experts.config.use_bias)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
New features

### Description
- 新增 `moe_routed_expert_use_bias` 配置，用于单独控制 routed expert MLP 的 bias。
- 默认值为 `None`，保持原有全局 `use_bias` 行为不变。
- 该配置只影响 routed expert，不影响 shared expert；shared expert 继续使用全局 `use_bias`。
- 补充单卡 UT，覆盖 `None`、`True`、`False` 以及 shared expert 不受影响的场景。

### Validation
- `python3 -m py_compile src/paddlefleet/transformer/transformer_config.py src/paddlefleet/transformer/moe/moe_layer.py tests/single_card_tests/model/test_moe_layer_routed_expert_use_bias.py`
- `git diff --check upstream/develop...HEAD`
- `git diff --check`

本地环境未安装 `paddle`，因此未直接运行新增单测。
