### PR TITLE
[OPs] Skip DeepEP build and enable ccache for wheel builds

### DIFF
--- a/.github/workflows/Test-release.yml
+++ b/.github/workflows/Test-release.yml
@@ -247,6 +247,10 @@ jobs:
       TASK: fleet-ci-paddle-release-build-whl-${{ github.event.pull_request.number }}
       PIP_CACHE_DIR: /home/.cache/pip
       CACHE_DIR: /home/.cache
+      CCACHE_DIR: "/home/data/shared/.ccache/l1" # L1 cache on machine shared dir
+      CCACHE_SECONDARY_STORAGE: "file:///home/data/cfs/.ccache/l2" # L2 cache on cfs
+      CCACHE_MAXSIZE: 50G
+      CCACHE_LIMIT_MULTIPLE: 0.8
       UV_HTTP_TIMEOUT: 600
       no_proxy: ".bcebos.com,bcebos.com,apiin.im.baidu.com,gitee.com,aliyun.com,.baidu.com,.tuna.tsinghua.edu.cn"
     steps:
@@ -258,12 +262,17 @@ jobs:
           docker run -d -t --name ${container_name} \
             -v "/home/data/cfs:/home/data/cfs" \
             -v "/home/data/cfs/.cache:/home/.cache" \
+            -v "/home/data/shared:/home/data/shared" \
             -v ${{ github.workspace }}/../../..:/root \
             -v ${{ github.workspace }}/../../../proxy:/root/proxy \
             -v ${{ github.workspace }}:/paddle \
             -e no_proxy \
             -e CACHE_DIR \
             -e PIP_CACHE_DIR \
+            -e CCACHE_DIR \
+            -e CCACHE_SECONDARY_STORAGE \
+            -e CCACHE_MAXSIZE \
+            -e CCACHE_LIMIT_MULTIPLE \
             -e UV_HTTP_TIMEOUT \
             -e PR_ID \
             -e COMMIT_ID \

--- a/.github/workflows/Test-release.yml
+++ b/.github/workflows/Test-release.yml
@@ -119,6 +119,10 @@ jobs:
       TASK: fleet-ci-paddle-release-build-whl-${{ github.event.pull_request.number }}
       PIP_CACHE_DIR: /home/.cache/pip
       CACHE_DIR: /home/.cache
+      CCACHE_DIR: "/home/data/shared/.ccache/l1" # L1 cache on machine shared dir
+      CCACHE_SECONDARY_STORAGE: "file:///home/data/cfs/.ccache/l2" # L2 cache on cfs
+      CCACHE_MAXSIZE: 50G
+      CCACHE_LIMIT_MULTIPLE: 0.8
       UV_HTTP_TIMEOUT: 600
       no_proxy: ".bcebos.com,bcebos.com,apiin.im.baidu.com,gitee.com,aliyun.com,.baidu.com,.tuna.tsinghua.edu.cn"
     steps:
@@ -130,12 +134,17 @@ jobs:
           docker run -d -t --name ${container_name} \
             -v "/home/data/cfs:/home/data/cfs" \
             -v "/home/data/cfs/.cache:/home/.cache" \
+            -v "/home/data/shared:/home/data/shared" \
             -v ${{ github.workspace }}/../../..:/root \
             -v ${{ github.workspace }}/../../../proxy:/root/proxy \
             -v ${{ github.workspace }}:/paddle \
             -e no_proxy \
             -e CACHE_DIR \
             -e PIP_CACHE_DIR \
+            -e CCACHE_DIR \
+            -e CCACHE_SECONDARY_STORAGE \
+            -e CCACHE_MAXSIZE \
+            -e CCACHE_LIMIT_MULTIPLE \
             -e UV_HTTP_TIMEOUT \
             -e PR_ID \
             -e COMMIT_ID \

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -44,6 +44,10 @@ jobs:
       group: GZ_BD-CPU
     env:
       TASK: fleet-ci-build-whl-${{ github.event.pull_request.number }}
+      CCACHE_DIR: "/home/data/shared/.ccache/l1" # L1 cache on machine shared dir
+      CCACHE_SECONDARY_STORAGE: "file:///home/data/cfs/.ccache/l2" # L2 cache on cfs
+      CCACHE_MAXSIZE: 50G
+      CCACHE_LIMIT_MULTIPLE: 0.8
     steps:
       - name: Check docker image and run container
         run: |
@@ -53,6 +57,7 @@ jobs:
           docker run -d -t --name ${container_name} \
             -v "/dev/shm:/dev/shm"  \
             -v "/home/data/cfs:/home/data/cfs" \
+            -v "/home/data/shared:/home/data/shared" \
             -v ${{ github.workspace }}/../../..:${{ github.workspace }}/../../.. \
             -v ${{ github.workspace }}:/paddle \
             -e BRANCH \
@@ -62,6 +67,10 @@ jobs:
             -e ci_scripts \
             -e no_proxy \
             -e CI_name \
+            -e CCACHE_DIR \
+            -e CCACHE_SECONDARY_STORAGE \
+            -e CCACHE_MAXSIZE \
+            -e CCACHE_LIMIT_MULTIPLE \
             -w /paddle --network host ${docker_image}
 
       - name: uv build whl

--- a/.github/workflows/manual_build_wheel.yml
+++ b/.github/workflows/manual_build_wheel.yml
@@ -52,6 +52,10 @@ jobs:
       TASK: PaddleFleet-manual
       PIP_CACHE_DIR: /home/.cache/pip
       CACHE_DIR: /home/.cache
+      CCACHE_DIR: "/home/data/shared/.ccache/l1" # L1 cache on machine shared dir
+      CCACHE_SECONDARY_STORAGE: "file:///home/data/cfs/.ccache/l2" # L2 cache on cfs
+      CCACHE_MAXSIZE: 50G
+      CCACHE_LIMIT_MULTIPLE: 0.8
       UV_HTTP_TIMEOUT: 600
       no_proxy: ".bcebos.com,bcebos.com,apiin.im.baidu.com,gitee.com,aliyun.com,.baidu.com,.tuna.tsinghua.edu.cn"
     steps:
@@ -65,12 +69,17 @@ jobs:
           docker run -d -t --name ${container_name} \
             -v "/home/data/cfs:/home/data/cfs" \
             -v "/home/data/cfs/.cache:/home/.cache" \
+            -v "/home/data/shared:/home/data/shared" \
             -v ${{ github.workspace }}/../../..:/root \
             -v ${{ github.workspace }}/../../../proxy:/root/proxy \
             -v ${{ github.workspace }}:/workspace \
             -e no_proxy \
             -e CACHE_DIR \
             -e PIP_CACHE_DIR \
+            -e CCACHE_DIR \
+            -e CCACHE_SECONDARY_STORAGE \
+            -e CCACHE_MAXSIZE \
+            -e CCACHE_LIMIT_MULTIPLE \
             -e UV_HTTP_TIMEOUT \
             -e PR_ID \
             -e COMMIT_ID \

--- a/.github/workflows/manual_build_wheel_ops.yml
+++ b/.github/workflows/manual_build_wheel_ops.yml
@@ -79,6 +79,10 @@ jobs:
       TASK: PaddleFleet-ops-${{ matrix.cuda.CUDA_VERSION }}-${{ matrix.python_version }}
       PIP_CACHE_DIR: /home/.cache/pip
       CACHE_DIR: /home/.cache
+      CCACHE_DIR: "/home/data/shared/.ccache/l1" # L1 cache on machine shared dir
+      CCACHE_SECONDARY_STORAGE: "file:///home/data/cfs/.ccache/l2" # L2 cache on cfs
+      CCACHE_MAXSIZE: 50G
+      CCACHE_LIMIT_MULTIPLE: 0.8
       UV_HTTP_TIMEOUT: 600
       no_proxy: ".bcebos.com,bcebos.com,apiin.im.baidu.com,gitee.com,aliyun.com,.baidu.com,.tuna.tsinghua.edu.cn"
     steps:
@@ -96,12 +100,17 @@ jobs:
           docker run -d -t --name ${container_name} \
             -v "/home/data/cfs:/home/data/cfs" \
             -v "/home/data/cfs/.cache:/home/.cache" \
+            -v "/home/data/shared:/home/data/shared" \
             -v ${{ github.workspace }}/../../..:/root \
             -v ${{ github.workspace }}/../../../proxy:/root/proxy \
             -v ${{ github.workspace }}:/workspace \
             -e no_proxy \
             -e CACHE_DIR \
             -e PIP_CACHE_DIR \
+            -e CCACHE_DIR \
+            -e CCACHE_SECONDARY_STORAGE \
+            -e CCACHE_MAXSIZE \
+            -e CCACHE_LIMIT_MULTIPLE \
             -e UV_HTTP_TIMEOUT \
             -e PR_ID \
             -e PADDLE_CUDA_ARCH_LIST="${{ matrix.cuda.CUDA_ARCH_LIST }}" \
@@ -202,6 +211,10 @@ jobs:
       TASK: PaddleFleet-ops-${{ matrix.cuda.CUDA_VERSION }}-${{ matrix.python_version }}
       PIP_CACHE_DIR: /home/.cache/pip
       CACHE_DIR: /home/.cache
+      CCACHE_DIR: "/home/data/shared/.ccache/l1" # L1 cache on machine shared dir
+      CCACHE_SECONDARY_STORAGE: "file:///home/data/cfs/.ccache/l2" # L2 cache on cfs
+      CCACHE_MAXSIZE: 50G
+      CCACHE_LIMIT_MULTIPLE: 0.8
       UV_HTTP_TIMEOUT: 600
       no_proxy: ".bcebos.com,bcebos.com,apiin.im.baidu.com,gitee.com,aliyun.com,.baidu.com,.tuna.tsinghua.edu.cn"
     steps:
@@ -219,12 +232,17 @@ jobs:
           docker run -d -t --name ${container_name} \
             -v "/home/data/cfs:/home/data/cfs" \
             -v "/home/data/cfs/.cache:/home/.cache" \
+            -v "/home/data/shared:/home/data/shared" \
             -v ${{ github.workspace }}/../../..:/root \
             -v ${{ github.workspace }}/../../../proxy:/root/proxy \
             -v ${{ github.workspace }}:/workspace \
             -e no_proxy \
             -e CACHE_DIR \
             -e PIP_CACHE_DIR \
+            -e CCACHE_DIR \
+            -e CCACHE_SECONDARY_STORAGE \
+            -e CCACHE_MAXSIZE \
+            -e CCACHE_LIMIT_MULTIPLE \
             -e UV_HTTP_TIMEOUT \
             -e PR_ID \
             -e PADDLE_CUDA_ARCH_LIST="${{ matrix.cuda.CUDA_ARCH_LIST }}" \

--- a/.github/workflows/pr_update_ops.yml
+++ b/.github/workflows/pr_update_ops.yml
@@ -116,6 +116,10 @@ jobs:
       TASK: PR-PaddleFleet-ops-${{ matrix.cuda.CUDA_VERSION }}-${{ matrix.python_version }}
       PIP_CACHE_DIR: /home/.cache/pip
       CACHE_DIR: /home/.cache
+      CCACHE_DIR: "/home/data/shared/.ccache/l1" # L1 cache on machine shared dir
+      CCACHE_SECONDARY_STORAGE: "file:///home/data/cfs/.ccache/l2" # L2 cache on cfs
+      CCACHE_MAXSIZE: 50G
+      CCACHE_LIMIT_MULTIPLE: 0.8
       UV_HTTP_TIMEOUT: 600
       no_proxy: ".bcebos.com,bcebos.com,apiin.im.baidu.com,gitee.com,aliyun.com,.baidu.com,.tuna.tsinghua.edu.cn"
     steps:
@@ -128,12 +132,17 @@ jobs:
           docker run -d -t --name ${container_name} \
             -v "/home/data/cfs:/home/data/cfs" \
             -v "/home/data/cfs/.cache:/home/.cache" \
+            -v "/home/data/shared:/home/data/shared" \
             -v ${{ github.workspace }}/../../..:/root \
             -v ${{ github.workspace }}/../../../proxy:/root/proxy \
             -v ${{ github.workspace }}:/workspace \
             -e no_proxy \
             -e CACHE_DIR \
             -e PIP_CACHE_DIR \
+            -e CCACHE_DIR \
+            -e CCACHE_SECONDARY_STORAGE \
+            -e CCACHE_MAXSIZE \
+            -e CCACHE_LIMIT_MULTIPLE \
             -e UV_HTTP_TIMEOUT \
             -e PADDLE_CUDA_ARCH_LIST="${{ matrix.cuda.CUDA_ARCH_LIST }}" \
             -e PR_ID \
@@ -252,6 +261,10 @@ jobs:
       TASK: PR-PaddleFleet-ops-${{ matrix.cuda.CUDA_VERSION }}-${{ matrix.python_version }}
       PIP_CACHE_DIR: /home/.cache/pip
       CACHE_DIR: /home/.cache
+      CCACHE_DIR: "/home/data/shared/.ccache/l1" # L1 cache on machine shared dir
+      CCACHE_SECONDARY_STORAGE: "file:///home/data/cfs/.ccache/l2" # L2 cache on cfs
+      CCACHE_MAXSIZE: 50G
+      CCACHE_LIMIT_MULTIPLE: 0.8
       UV_HTTP_TIMEOUT: 600
       no_proxy: ".bcebos.com,bcebos.com,apiin.im.baidu.com,gitee.com,aliyun.com,.baidu.com,.tuna.tsinghua.edu.cn"
     steps:
@@ -264,12 +277,17 @@ jobs:
           docker run -d -t --name ${container_name} \
             -v "/home/data/cfs:/home/data/cfs" \
             -v "/home/data/cfs/.cache:/home/.cache" \
+            -v "/home/data/shared:/home/data/shared" \
             -v ${{ github.workspace }}/../../..:/root \
             -v ${{ github.workspace }}/../../../proxy:/root/proxy \
             -v ${{ github.workspace }}:/workspace \
             -e no_proxy \
             -e CACHE_DIR \
             -e PIP_CACHE_DIR \
+            -e CCACHE_DIR \
+            -e CCACHE_SECONDARY_STORAGE \
+            -e CCACHE_MAXSIZE \
+            -e CCACHE_LIMIT_MULTIPLE \
             -e UV_HTTP_TIMEOUT \
             -e PADDLE_CUDA_ARCH_LIST="${{ matrix.cuda.CUDA_ARCH_LIST }}" \
             -e PR_ID \
@@ -372,6 +390,10 @@ jobs:
       TASK: PaddleFleet-nightly-arm-${{ matrix.cuda.CUDA_VERSION }}
       PIP_CACHE_DIR: /home/.cache/pip
       CACHE_DIR: /home/.cache
+      CCACHE_DIR: "/home/data/shared/.ccache/l1" # L1 cache on machine shared dir
+      CCACHE_SECONDARY_STORAGE: "file:///home/data/cfs/.ccache/l2" # L2 cache on cfs
+      CCACHE_MAXSIZE: 50G
+      CCACHE_LIMIT_MULTIPLE: 0.8
       UV_HTTP_TIMEOUT: 600
       no_proxy: ".bcebos.com,bcebos.com,apiin.im.baidu.com,gitee.com,aliyun.com,.baidu.com,.tuna.tsinghua.edu.cn"
     steps:
@@ -384,12 +406,17 @@ jobs:
           docker run -d -t --name ${container_name} \
             -v "/home/data/cfs:/home/data/cfs" \
             -v "/home/data/cfs/.cache:/home/.cache" \
+            -v "/home/data/shared:/home/data/shared" \
             -v ${{ github.workspace }}/../../..:/root \
             -v ${{ github.workspace }}/../../../proxy:/root/proxy \
             -v ${{ github.workspace }}:/workspace \
             -e no_proxy \
             -e CACHE_DIR \
             -e PIP_CACHE_DIR \
+            -e CCACHE_DIR \
+            -e CCACHE_SECONDARY_STORAGE \
+            -e CCACHE_MAXSIZE \
+            -e CCACHE_LIMIT_MULTIPLE \
             -e UV_HTTP_TIMEOUT \
             -e PR_ID \
             -e COMMIT_ID \

--- a/.github/workflows/precision_publish_wheel.yml
+++ b/.github/workflows/precision_publish_wheel.yml
@@ -28,6 +28,10 @@ jobs:
       TASK: PaddleFleet-nightly-${{ matrix.CUDA_VERSION }}
       PIP_CACHE_DIR: /root/.cache/pip
       CACHE_DIR: /root/.cache
+      CCACHE_DIR: "/home/data/shared/.ccache/l1" # L1 cache on machine shared dir
+      CCACHE_SECONDARY_STORAGE: "file:///home/data/cfs/.ccache/l2" # L2 cache on cfs
+      CCACHE_MAXSIZE: 50G
+      CCACHE_LIMIT_MULTIPLE: 0.8
       UV_HTTP_TIMEOUT: 600
       no_proxy: ".bcebos.com,bcebos.com,apiin.im.baidu.com,gitee.com,aliyun.com,.baidu.com,.tuna.tsinghua.edu.cn"
     steps:
@@ -40,11 +44,16 @@ jobs:
           docker run -d -t --name ${container_name} \
             -v "/home/data/cfs:/home/data/cfs" \
             -v "/home/data/cfs/.cache:/root/.cache" \
+            -v "/home/data/shared:/home/data/shared" \
             -v ${{ github.workspace }}/../../../proxy:/root/proxy \
             -v ${{ github.workspace }}:/workspace \
             -e no_proxy \
             -e CACHE_DIR \
             -e PIP_CACHE_DIR \
+            -e CCACHE_DIR \
+            -e CCACHE_SECONDARY_STORAGE \
+            -e CCACHE_MAXSIZE \
+            -e CCACHE_LIMIT_MULTIPLE \
             -e UV_HTTP_TIMEOUT \
             -e AK=${{ secrets.BOS_CREDENTIAL_AK }} \
             -e SK=${{ secrets.BOS_CREDENTIAL_SK }} \

--- a/.github/workflows/publish_wheel_nightly.yml
+++ b/.github/workflows/publish_wheel_nightly.yml
@@ -49,6 +49,10 @@ jobs:
       TASK: PaddleFleet-nightly
       PIP_CACHE_DIR: /home/.cache/pip
       CACHE_DIR: /home/.cache
+      CCACHE_DIR: "/home/data/shared/.ccache/l1" # L1 cache on machine shared dir
+      CCACHE_SECONDARY_STORAGE: "file:///home/data/cfs/.ccache/l2" # L2 cache on cfs
+      CCACHE_MAXSIZE: 50G
+      CCACHE_LIMIT_MULTIPLE: 0.8
       UV_HTTP_TIMEOUT: 600
       no_proxy: ".bcebos.com,bcebos.com,apiin.im.baidu.com,gitee.com,aliyun.com,.baidu.com,.tuna.tsinghua.edu.cn"
     steps:
@@ -61,12 +65,17 @@ jobs:
           docker run -d -t --name ${container_name} \
             -v "/home/data/cfs:/home/data/cfs" \
             -v "/home/data/cfs/.cache:/home/.cache" \
+            -v "/home/data/shared:/home/data/shared" \
             -v ${{ github.workspace }}/../../..:/root \
             -v ${{ github.workspace }}/../../../proxy:/root/proxy \
             -v ${{ github.workspace }}:/workspace \
             -e no_proxy \
             -e CACHE_DIR \
             -e PIP_CACHE_DIR \
+            -e CCACHE_DIR \
+            -e CCACHE_SECONDARY_STORAGE \
+            -e CCACHE_MAXSIZE \
+            -e CCACHE_LIMIT_MULTIPLE \
             -e UV_HTTP_TIMEOUT \
             -e PADDLE_CUDA_ARCH_LIST="${{ matrix.cuda.CUDA_ARCH_LIST }}" \
             -e PR_ID \
@@ -167,6 +176,10 @@ jobs:
       TASK: PaddleFleet-nightly-arm-${{ matrix.cuda.CUDA_VERSION }}
       PIP_CACHE_DIR: /home/.cache/pip
       CACHE_DIR: /home/.cache
+      CCACHE_DIR: "/home/data/shared/.ccache/l1" # L1 cache on machine shared dir
+      CCACHE_SECONDARY_STORAGE: "file:///home/data/cfs/.ccache/l2" # L2 cache on cfs
+      CCACHE_MAXSIZE: 50G
+      CCACHE_LIMIT_MULTIPLE: 0.8
       UV_HTTP_TIMEOUT: 600
       no_proxy: ".bcebos.com,bcebos.com,apiin.im.baidu.com,gitee.com,aliyun.com,.baidu.com,.tuna.tsinghua.edu.cn"
     steps:
@@ -179,12 +192,17 @@ jobs:
           docker run -d -t --name ${container_name} \
             -v "/home/data/cfs:/home/data/cfs" \
             -v "/home/data/cfs/.cache:/home/.cache" \
+            -v "/home/data/shared:/home/data/shared" \
             -v ${{ github.workspace }}/../../..:/root \
             -v ${{ github.workspace }}/../../../proxy:/root/proxy \
             -v ${{ github.workspace }}:/workspace \
             -e no_proxy \
             -e CACHE_DIR \
             -e PIP_CACHE_DIR \
+            -e CCACHE_DIR \
+            -e CCACHE_SECONDARY_STORAGE \
+            -e CCACHE_MAXSIZE \
+            -e CCACHE_LIMIT_MULTIPLE \
             -e UV_HTTP_TIMEOUT \
             -e PR_ID \
             -e COMMIT_ID \

--- a/.github/workflows/publish_wheel_nightly_xpu.yml
+++ b/.github/workflows/publish_wheel_nightly_xpu.yml
@@ -50,6 +50,10 @@ jobs:
       TASK: PaddleFleet-nightly-${{ matrix.xpu.XPU_VERSION }}
       PIP_CACHE_DIR: /home/.cache/pip
       CACHE_DIR: /home/.cache
+      CCACHE_DIR: "/home/data/shared/.ccache/l1" # L1 cache on machine shared dir
+      CCACHE_SECONDARY_STORAGE: "file:///home/data/cfs/.ccache/l2" # L2 cache on cfs
+      CCACHE_MAXSIZE: 50G
+      CCACHE_LIMIT_MULTIPLE: 0.8
       UV_HTTP_TIMEOUT: 600
       no_proxy: ".bcebos.com,bcebos.com,apiin.im.baidu.com,gitee.com,aliyun.com,.baidu.com,.tuna.tsinghua.edu.cn"
     steps:
@@ -62,12 +66,17 @@ jobs:
           docker run -d -t --name ${container_name} \
             -v "/home/data/cfs:/home/data/cfs" \
             -v "/home/data/cfs/.cache:/home/.cache" \
+            -v "/home/data/shared:/home/data/shared" \
             -v ${{ github.workspace }}/../../..:/root \
             -v ${{ github.workspace }}/../../../proxy:/root/proxy \
             -v ${{ github.workspace }}:/workspace \
             -e no_proxy \
             -e CACHE_DIR \
             -e PIP_CACHE_DIR \
+            -e CCACHE_DIR \
+            -e CCACHE_SECONDARY_STORAGE \
+            -e CCACHE_MAXSIZE \
+            -e CCACHE_LIMIT_MULTIPLE \
             -e UV_HTTP_TIMEOUT \
             -e PR_ID \
             -e COMMIT_ID \

--- a/packages/paddlefleet_ops/build_utils.py
+++ b/packages/paddlefleet_ops/build_utils.py
@@ -414,6 +414,7 @@ def get_libs():
                 ],
                 extra_env={
                     "HYBRID_EP_MULTINODE": "1",
+                    "HYBRID_EP_SKIP_DEEP_EP": "1",
                     "PADDLE_CUDA_ARCH_LIST": _deep_ep_arch,
                 },
             ),

--- a/packages/paddlefleet_ops/src/paddlefleet_ops/__init__.py
+++ b/packages/paddlefleet_ops/src/paddlefleet_ops/__init__.py
@@ -266,7 +266,7 @@ if paddle.is_compiled_with_cuda():
 
     if is_hybrid_ep_available():
         paddle.enable_compat(scope={"hybrid_ep"}, silent=True)
-        os.environ.setdefault("HYBRID_EP_SKIP_DEEP_EP", "1")
+        os.environ["HYBRID_EP_SKIP_DEEP_EP"] = "1"
         _safe_load_ecosystem_lib("hybrid_ep", ops_dir, globals())
     else:
         warning, error = _hopper_requirement(

--- a/packages/paddlefleet_ops/src/paddlefleet_ops/__init__.py
+++ b/packages/paddlefleet_ops/src/paddlefleet_ops/__init__.py
@@ -15,6 +15,7 @@
 import ctypes
 import importlib.util
 import logging
+import os
 import sys
 from pathlib import Path
 from typing import Any
@@ -265,6 +266,7 @@ if paddle.is_compiled_with_cuda():
 
     if is_hybrid_ep_available():
         paddle.enable_compat(scope={"hybrid_ep"}, silent=True)
+        os.environ.setdefault("HYBRID_EP_SKIP_DEEP_EP", "1")
         _safe_load_ecosystem_lib("hybrid_ep", ops_dir, globals())
     else:
         warning, error = _hopper_requirement(


### PR DESCRIPTION
## 背景

PaddleFleet 现在会分别 vendor DeepEP 和 HybridEP。HybridEP upstream 已支持 `HYBRID_EP_SKIP_DEEP_EP=1`，用于在 HybridEP-only 集成场景下跳过 `deep_ep_cpp` 编译和运行时 DeepEP 符号导入。

本 PR 将 PaddleFleet 的 HybridEP submodule 更新到包含该能力的提交，并在 Fleet 集成层设置对应环境变量，避免 HybridEP 构建时重复编译 DeepEP。默认行为仍然是 DeepEP 走 `paddlefleet_ops.deep_ep`，只有选择 HybridEP 时才加载 `paddlefleet_ops.hybrid_ep`。

同时参考 `773282bd22ba4aed022e83cfcba495a1d64c1115`，给 wheel / ops wheel 构建流程补充 ccache 环境变量，让包含 `uv build` 和 `pip wheel` 的构建容器复用机器共享目录上的 L1 cache 和 CFS 上的 L2 cache。

## 改动

- 更新 `packages/paddlefleet_ops/third_party/HybridEP` 到 `3be69b9`。
- HybridEP ecosystem build 的 `extra_env` 增加 `HYBRID_EP_SKIP_DEEP_EP=1`。
- 运行时加载 `paddlefleet_ops.hybrid_ep` 前设置 `HYBRID_EP_SKIP_DEEP_EP=1`，确保只导入 HybridEP 相关符号。
- 给 `Test`、`Test-release`、`pr_update_ops`、manual build、nightly、precision、XPU wheel 构建 workflow 增加 `CCACHE_DIR`、`CCACHE_SECONDARY_STORAGE`、`CCACHE_MAXSIZE` 和 `CCACHE_LIMIT_MULTIPLE`。
- 对应 Docker 构建容器挂载 `/home/data/shared`，并透传 ccache 环境变量到 `uv build` / `pip wheel` 流程。

## 验证

- `git diff --check`
- Ruby YAML parser 解析更新过的 8 个 workflow 文件

<div align="right">
   <sup>This PR is co-authored with @codex (gpt-5.5 xhigh)</sup>
</div>