### PR TITLE
[New features] Add three MoE features: HashRouter (topk_method=hash), SftPlus score, ClampedSwiGLU

### DIFF
--- a/src/paddlefleet/fusions/fused_bias_swiglu.py
+++ b/src/paddlefleet/fusions/fused_bias_swiglu.py
@@ -163,7 +163,9 @@ def clamped_swiglu_back(g, y, clamp_value):
     dsilu_dy1 = sigmoid_y1 * (1.0 + y_1_clamped * (1.0 - sigmoid_y1))
     # Clamp masks: gradient is 0 where the input was clamped
     y1_mask = (y_1 <= clamp_value).cast(paddle.float32)
-    y2_mask = ((y_2 >= -clamp_value) & (y_2 <= clamp_value)).cast(paddle.float32)
+    y2_mask = ((y_2 >= -clamp_value) & (y_2 <= clamp_value)).cast(
+        paddle.float32
+    )
     grad_y1 = g_fp32 * dsilu_dy1 * y_2_clamped * y1_mask
     grad_y2 = g_fp32 * F.silu(y_1_clamped) * y2_mask
     return paddle.concat([grad_y1, grad_y2], axis=-1).cast(dtype)
@@ -388,7 +390,9 @@ def bias_swiglu_impl(
     )
 
 
-def weighted_bias_swiglu_impl(input, bias, weights, fp8_input_store=False, clamp_value=None):
+def weighted_bias_swiglu_impl(
+    input, bias, weights, fp8_input_store=False, clamp_value=None
+):
     """
     Token-wise-weighted bias swiglu fusion.
 
@@ -407,7 +411,9 @@ def weighted_bias_swiglu_impl(input, bias, weights, fp8_input_store=False, clamp
             "Bias is not supported for weighted swiglu fusion"
         )
     else:
-        output = WeightedSwiGLUFunction.apply(input, weights, fp8_input_store, clamp_value)
+        output = WeightedSwiGLUFunction.apply(
+            input, weights, fp8_input_store, clamp_value
+        )
 
     return (
         output

--- a/src/paddlefleet/fusions/fused_bias_swiglu.py
+++ b/src/paddlefleet/fusions/fused_bias_swiglu.py
@@ -115,6 +115,98 @@ def weighted_swiglu_back(g, y, weights):
     return input_grad.to(input_dtype), weights_grad.to(w_dtype)
 
 
+@jit_fuser
+def clamped_swiglu(y, clamp_value):
+    """SwiGLU with clamped inputs for numerical stability.
+
+    Clamps y1 (gate) to (-inf, clamp_value] and y2 (value) to
+    [-clamp_value, clamp_value] before computing SiLU(y1) * y2.
+    Computation is performed in float32 and cast back to original dtype.
+
+    Args:
+        y (paddle.Tensor): Input tensor, split into two halves along last dim.
+        clamp_value (float): Clamp bound.
+
+    Returns:
+        paddle.Tensor: SiLU(clamp(y1)) * clamp(y2), same dtype as input.
+    """
+    dtype = y.dtype
+    y_1, y_2 = paddle.chunk(y.cast(paddle.float32), 2, axis=-1)
+    y_1 = y_1.clip(max=clamp_value)
+    y_2 = y_2.clip(min=-clamp_value, max=clamp_value)
+    res = F.silu(y_1) * y_2
+    return res.cast(dtype)
+
+
+@jit_fuser
+def clamped_swiglu_back(g, y, clamp_value):
+    """Backward pass for clamped_swiglu.
+
+    Gradient is zeroed out where inputs were clamped.
+
+    Args:
+        g (paddle.Tensor): Upstream gradient.
+        y (paddle.Tensor): Original (un-clamped) input tensor from forward pass.
+        clamp_value (float): Clamp bound used in forward pass.
+
+    Returns:
+        paddle.Tensor: Gradient w.r.t. y, same dtype as y.
+    """
+    dtype = y.dtype
+    y_fp32 = y.cast(paddle.float32)
+    y_1, y_2 = paddle.chunk(y_fp32, 2, axis=-1)
+    y_1_clamped = y_1.clip(max=clamp_value)
+    y_2_clamped = y_2.clip(min=-clamp_value, max=clamp_value)
+    g_fp32 = g.cast(paddle.float32)
+    # d/dy1 [SiLU(y1)] = sigmoid(y1) * (1 + y1 * (1 - sigmoid(y1)))
+    sigmoid_y1 = F.sigmoid(y_1_clamped)
+    dsilu_dy1 = sigmoid_y1 * (1.0 + y_1_clamped * (1.0 - sigmoid_y1))
+    # Clamp masks: gradient is 0 where the input was clamped
+    y1_mask = (y_1 <= clamp_value).cast(paddle.float32)
+    y2_mask = ((y_2 >= -clamp_value) & (y_2 <= clamp_value)).cast(paddle.float32)
+    grad_y1 = g_fp32 * dsilu_dy1 * y_2_clamped * y1_mask
+    grad_y2 = g_fp32 * F.silu(y_1_clamped) * y2_mask
+    return paddle.concat([grad_y1, grad_y2], axis=-1).cast(dtype)
+
+
+@jit_fuser
+def clamped_weighted_swiglu(y, weights, clamp_value):
+    """ClampedSwiGLU with per-token weight scaling.
+
+    Args:
+        y (paddle.Tensor): Input tensor.
+        weights (paddle.Tensor): Per-token weights, shape [..., 1].
+        clamp_value (float): Clamp bound.
+
+    Returns:
+        paddle.Tensor: clamped_swiglu(y) * weights, same dtype as y.
+    """
+    dtype = y.dtype
+    res = clamped_swiglu(y, clamp_value) * weights
+    return res.cast(dtype)
+
+
+@jit_fuser
+def clamped_weighted_swiglu_back(g, y, weights, clamp_value):
+    """Backward pass for clamped_weighted_swiglu.
+
+    Args:
+        g (paddle.Tensor): Upstream gradient.
+        y (paddle.Tensor): Original input tensor from forward pass.
+        weights (paddle.Tensor): Per-token weights from forward pass.
+        clamp_value (float): Clamp bound used in forward pass.
+
+    Returns:
+        tuple: (grad_y, grad_weights), matching dtypes of inputs.
+    """
+    input_dtype = y.dtype
+    w_dtype = weights.dtype
+    input_grad = clamped_swiglu_back(g * weights, y, clamp_value)
+    weights_grad = clamped_swiglu(y, clamp_value) * g.cast(w_dtype)
+    weights_grad = paddle.sum(weights_grad, axis=-1, keepdim=True)
+    return input_grad.cast(input_dtype), weights_grad.cast(w_dtype)
+
+
 class BiasSwiGLUFunction(paddle.autograd.PyLayer):
     """Custom autograd function for SwiGLU activation with bias support."""
 
@@ -214,20 +306,47 @@ class SwiGLUFunction(paddle.autograd.PyLayer):
 class WeightedSwiGLUFunction(paddle.autograd.PyLayer):
     @staticmethod
     # bias is an optional argument
-    def forward(ctx, input, weights, fp8_input_store):
+    def forward(ctx, input, weights, fp8_input_store, clamp_value=None):
         input_for_backward = (
             input.to(paddle.float8_e4m3fn) if fp8_input_store else input
         )
         ctx.save_for_backward(input_for_backward, weights)
         ctx.ori_input_dtype = input.dtype
         ctx.fp8_input_store = fp8_input_store
+        ctx.clamp_value = clamp_value
+        if clamp_value is not None:
+            return clamped_weighted_swiglu(input, weights, clamp_value)
         return weighted_swiglu(input, weights)
 
     @staticmethod
     def backward(ctx, grad_output):
         input, weights = ctx.saved_tensor()
         input = input.to(ctx.ori_input_dtype) if ctx.fp8_input_store else input
-        tmp, wgrad = weighted_swiglu_back(grad_output, input, weights)
+        clamp_value = ctx.clamp_value
+        if clamp_value is not None:
+            tmp, wgrad = clamped_weighted_swiglu_back(
+                grad_output, input, weights, clamp_value
+            )
+        else:
+            tmp, wgrad = weighted_swiglu_back(grad_output, input, weights)
+        return tmp, wgrad, None, None
+
+
+class ClampedWeightedSwiGLUFunction(paddle.autograd.PyLayer):
+    """Custom autograd function for ClampedSwiGLU with per-token weight scaling."""
+
+    @staticmethod
+    def forward(ctx, input, weights, clamp_value):
+        ctx.save_for_backward(input, weights)
+        ctx.clamp_value = clamp_value
+        return clamped_weighted_swiglu(input, weights, clamp_value)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        input, weights = ctx.saved_tensor()
+        tmp, wgrad = clamped_weighted_swiglu_back(
+            grad_output, input, weights, ctx.clamp_value
+        )
         return tmp, wgrad, None
 
 
@@ -269,9 +388,16 @@ def bias_swiglu_impl(
     )
 
 
-def weighted_bias_swiglu_impl(input, bias, weights, fp8_input_store=False):
+def weighted_bias_swiglu_impl(input, bias, weights, fp8_input_store=False, clamp_value=None):
     """
     Token-wise-weighted bias swiglu fusion.
+
+    Args:
+        input: Input tensor.
+        bias: Optional bias (not supported for weighted variant).
+        weights: Per-token weights, shape [..., 1].
+        fp8_input_store (bool): Whether to store intermediate values in FP8 format.
+        clamp_value (float, optional): If provided, use ClampedSwiGLU instead of standard SwiGLU.
     """
     ori_shape = input.shape
     assert len(ori_shape) in [2, 3]
@@ -281,7 +407,7 @@ def weighted_bias_swiglu_impl(input, bias, weights, fp8_input_store=False):
             "Bias is not supported for weighted swiglu fusion"
         )
     else:
-        output = WeightedSwiGLUFunction.apply(input, weights, fp8_input_store)
+        output = WeightedSwiGLUFunction.apply(input, weights, fp8_input_store, clamp_value)
 
     return (
         output

--- a/src/paddlefleet/fusions/fused_bias_swiglu.py
+++ b/src/paddlefleet/fusions/fused_bias_swiglu.py
@@ -331,9 +331,6 @@ class WeightedSwiGLUFunction(paddle.autograd.PyLayer):
             )
         else:
             tmp, wgrad = weighted_swiglu_back(grad_output, input, weights)
-        # PyLayer.backward must return one gradient per tensor input
-        # (input, weights). fp8_input_store and clamp_value are non-tensor
-        # constants and do not require gradients.
         return tmp, wgrad
 
 

--- a/src/paddlefleet/fusions/fused_bias_swiglu.py
+++ b/src/paddlefleet/fusions/fused_bias_swiglu.py
@@ -331,25 +331,10 @@ class WeightedSwiGLUFunction(paddle.autograd.PyLayer):
             )
         else:
             tmp, wgrad = weighted_swiglu_back(grad_output, input, weights)
-        return tmp, wgrad, None, None
-
-
-class ClampedWeightedSwiGLUFunction(paddle.autograd.PyLayer):
-    """Custom autograd function for ClampedSwiGLU with per-token weight scaling."""
-
-    @staticmethod
-    def forward(ctx, input, weights, clamp_value):
-        ctx.save_for_backward(input, weights)
-        ctx.clamp_value = clamp_value
-        return clamped_weighted_swiglu(input, weights, clamp_value)
-
-    @staticmethod
-    def backward(ctx, grad_output):
-        input, weights = ctx.saved_tensor()
-        tmp, wgrad = clamped_weighted_swiglu_back(
-            grad_output, input, weights, ctx.clamp_value
-        )
-        return tmp, wgrad, None
+        # PyLayer.backward must return one gradient per tensor input
+        # (input, weights). fp8_input_store and clamp_value are non-tensor
+        # constants and do not require gradients.
+        return tmp, wgrad
 
 
 def bias_swiglu_impl(

--- a/src/paddlefleet/training/arguments.py
+++ b/src/paddlefleet/training/arguments.py
@@ -25,6 +25,16 @@ def parse_args(extra_args_provider=None, ignore_unknown_args=False):
     )
 
     parser.add_argument("--configs", type=str, default=None)
+    parser.add_argument(
+        "--moe-n-hash-layers",
+        type=int,
+        default=0,
+        help=(
+            "Number of last transformer layers to use HashRouter instead of "
+            "TopKRouter. E.g. --moe-n-hash-layers 2 enables HashRouter for "
+            "the last 2 MoE layers."
+        ),
+    )
 
     # Custom arguments.
     if extra_args_provider is not None:

--- a/src/paddlefleet/training/arguments.py
+++ b/src/paddlefleet/training/arguments.py
@@ -35,6 +35,16 @@ def parse_args(extra_args_provider=None, ignore_unknown_args=False):
             "the last 2 MoE layers."
         ),
     )
+    parser.add_argument(
+        "--moe-hash-router-pad-token-id",
+        type=int,
+        default=0,
+        help=(
+            "Token ID treated as padding by HashRouter (default: 0). "
+            "Set to the tokenizer pad_token_id when it differs from 0 "
+            "(e.g. LLaMA uses eos_token_id as pad)."
+        ),
+    )
 
     # Custom arguments.
     if extra_args_provider is not None:

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -44,7 +44,7 @@ from .fp8_utils import fused_stack_quant_without_cache
 from .fused_a2a import configure_buffer
 from .fusion_layer_utils import FusionMoePyLayer
 from .moe_expert import GroupedMLPExpert, StandardMLPExpert
-from .moe_router import TopKRouter
+from .moe_router import HashRouter, TopKRouter
 from .moe_shared_expert import StandardMLPSharedExpert
 from .moe_utils import AddAuxiliaryLoss
 from .token_dispatcher import AllToAllTokenDispatcher, MoEFlexTokenDispatcher
@@ -138,6 +138,7 @@ class MoELayer(nn.Layer):
         config: TransformerConfig,
         sublayers: MoESublayers | None = None,
         pg_collection: ProcessGroupCollection | None = None,
+        layer_number: int | None = None,
     ):
         super().__init__()
         self.config = config
@@ -224,7 +225,29 @@ class MoELayer(nn.Layer):
         # MoE-Related Configs
         self._init_expert_parallel()
 
-        self.gate = TopKRouter(config=config, pg_collection=pg_collection)
+        # Determine whether to use HashRouter or TopKRouter for this layer.
+        # The last `moe_n_hash_layers` layers (by layer_number) use HashRouter.
+        _use_hash_routing = (
+            getattr(config, "moe_n_hash_layers", 0) > 0
+            and layer_number is not None
+            and layer_number
+            >= config.num_hidden_layers - config.moe_n_hash_layers
+        )
+        if _use_hash_routing:
+            self.gate = HashRouter(
+                config=config,
+                pg_collection=pg_collection,
+                layer_number=layer_number,
+            )
+            logger.info(
+                f"MoELayer layer_number={layer_number}: using HashRouter "
+                f"(moe_n_hash_layers={config.moe_n_hash_layers}, "
+                f"num_hidden_layers={config.num_hidden_layers})"
+            )
+        else:
+            self.gate = TopKRouter(config=config, pg_collection=pg_collection)
+            if layer_number is not None:
+                self.gate.set_layer_number(layer_number)
 
         self.expert_class = StandardMLPExpert
         self.shared_expert_class = StandardMLPSharedExpert

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -1196,7 +1196,28 @@ class MoELayer(nn.Layer):
 
     def set_layer_number(self, layer_number):
         self.layer_number = layer_number
-        assert hasattr(self.gate, "set_layer_number"), (
-            "expect gate has method 'set_layer_number'"
+
+        # Re-evaluate router type: build_spec_layer doesn't pass layer_number,
+        # so __init__ may have created TopKRouter with layer_number=None.
+        # Now that we know the real layer_number, switch to HashRouter if needed.
+        _use_hash = (
+            getattr(self.config, "moe_n_hash_layers", 0) > 0
+            and layer_number
+            >= self.config.num_hidden_layers - self.config.moe_n_hash_layers
         )
-        self.gate.set_layer_number(layer_number)
+        if _use_hash and not isinstance(self.gate, HashRouter):
+            self.gate = HashRouter(
+                config=self.config,
+                pg_collection=self.pg_collection,
+                layer_number=layer_number,
+            )
+            logger.info(
+                f"MoELayer layer_number={layer_number}: switching to HashRouter "
+                f"(moe_n_hash_layers={self.config.moe_n_hash_layers}, "
+                f"num_hidden_layers={self.config.num_hidden_layers})"
+            )
+        else:
+            assert hasattr(self.gate, "set_layer_number"), (
+                "expect gate has method 'set_layer_number'"
+            )
+            self.gate.set_layer_number(layer_number)

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -44,7 +44,7 @@ from .fp8_utils import fused_stack_quant_without_cache
 from .fused_a2a import configure_buffer
 from .fusion_layer_utils import FusionMoePyLayer
 from .moe_expert import GroupedMLPExpert, StandardMLPExpert
-from .moe_router import HashRouter, TopKRouter
+from .moe_router import TopKRouter
 from .moe_shared_expert import StandardMLPSharedExpert
 from .moe_utils import AddAuxiliaryLoss
 from .token_dispatcher import AllToAllTokenDispatcher, MoEFlexTokenDispatcher
@@ -225,29 +225,11 @@ class MoELayer(nn.Layer):
         # MoE-Related Configs
         self._init_expert_parallel()
 
-        # Determine whether to use HashRouter or TopKRouter for this layer.
-        # The last `moe_n_hash_layers` layers (by layer_number) use HashRouter.
-        _use_hash_routing = (
-            getattr(config, "moe_n_hash_layers", 0) > 0
-            and layer_number is not None
-            and layer_number
-            >= config.num_hidden_layers - config.moe_n_hash_layers
-        )
-        if _use_hash_routing:
-            self.gate = HashRouter(
-                config=config,
-                pg_collection=pg_collection,
-                layer_number=layer_number,
-            )
-            logger.info(
-                f"MoELayer layer_number={layer_number}: using HashRouter "
-                f"(moe_n_hash_layers={config.moe_n_hash_layers}, "
-                f"num_hidden_layers={config.num_hidden_layers})"
-            )
-        else:
-            self.gate = TopKRouter(config=config, pg_collection=pg_collection)
-            if layer_number is not None:
-                self.gate.set_layer_number(layer_number)
+        # Always use TopKRouter; set_layer_number will switch topk_method to
+        # "hash" for layers in the hash range (last moe_n_hash_layers layers).
+        self.gate = TopKRouter(config=config, pg_collection=pg_collection)
+        if layer_number is not None:
+            self.gate.set_layer_number(layer_number)
 
         self.expert_class = StandardMLPExpert
         self.shared_expert_class = StandardMLPSharedExpert
@@ -1197,27 +1179,21 @@ class MoELayer(nn.Layer):
     def set_layer_number(self, layer_number):
         self.layer_number = layer_number
 
-        # Re-evaluate router type: build_spec_layer doesn't pass layer_number,
-        # so __init__ may have created TopKRouter with layer_number=None.
-        # Now that we know the real layer_number, switch to HashRouter if needed.
+        # The last `moe_n_hash_layers` layers use deterministic hash routing.
+        # Switching the topk_method attribute is enough; no need to replace the
+        # gate object since TopKRouter now handles topk_method="hash" natively.
         _use_hash = (
             getattr(self.config, "moe_n_hash_layers", 0) > 0
             and layer_number
             >= self.config.num_hidden_layers - self.config.moe_n_hash_layers
         )
-        if _use_hash and not isinstance(self.gate, HashRouter):
-            self.gate = HashRouter(
-                config=self.config,
-                pg_collection=self.pg_collection,
-                layer_number=layer_number,
-            )
+        if _use_hash:
+            self.gate.topk_method = "hash"
             logger.info(
-                f"MoELayer layer_number={layer_number}: switching to HashRouter "
+                f"MoELayer layer_number={layer_number}: gate switched to "
+                f"topk_method='hash' "
                 f"(moe_n_hash_layers={self.config.moe_n_hash_layers}, "
                 f"num_hidden_layers={self.config.num_hidden_layers})"
             )
         else:
-            assert hasattr(self.gate, "set_layer_number"), (
-                "expect gate has method 'set_layer_number'"
-            )
             self.gate.set_layer_number(layer_number)

--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -891,6 +891,13 @@ class HashRouter(nn.Layer):
     Padding tokens (token_id == 0) are masked out: their weights and mask are 0
     and their expert indices are set to -1.
 
+    .. note::
+        The padding-token detection assumes pad_token_id == 0, which matches
+        Megatron-LM convention and most PaddlePaddle models.  If your tokenizer
+        uses a different pad ID, this masking will either miss real padding or
+        suppress valid BOS tokens.  Future work can expose a
+        moe_hash_router_pad_token_id config field to override this.
+
     This router produces the same 8-tuple output as TopKRouter so it can be used
     as a drop-in replacement inside MoELayer.
 
@@ -1006,7 +1013,7 @@ class HashRouter(nn.Layer):
         top_gate = top_gate * valid_mask
         topk_idx = topk_idx.masked_fill(
             ~valid_mask.cast(paddle.bool),
-            paddle.to_tensor(-1, dtype=paddle.int64),
+            -1,
         )
 
         # ------------------------------------------------------------------ #

--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -641,6 +641,49 @@ class StandardMoERouter(nn.Layer):
 
         return topk_weight, topk_idx
 
+    def _topk_hash(
+        self,
+        flat_ids: paddle.Tensor,
+        k: int,
+    ):
+        """Deterministic hash-based routing (no learned parameters).
+
+        Assigns each token to ``k`` experts via:
+            expert_offset = (token_id + offset) % num_experts,  offset = 0..k-1
+
+        All selected experts receive equal weight (1/k if norm_topk_prob else
+        1.0), scaled by routed_scaling_factor.  Padding tokens (token_id ==
+        moe_hash_router_pad_token_id) are masked out: weight = 0, index = -1.
+
+        Args:
+            flat_ids (Tensor): Flattened token IDs, shape [B*S], dtype int64.
+            k (int): Number of experts per token.
+
+        Returns:
+            top_gate (Tensor): Shape [B*S, k], dtype float32.
+            top_idx  (Tensor): Shape [B*S, k], dtype int64.  -1 for padding.
+        """
+        pad_token_id = getattr(self.config, "moe_hash_router_pad_token_id", 0)
+        offsets = paddle.arange(k, dtype=paddle.int64).unsqueeze(0)  # [1, k]
+        top_idx = (
+            flat_ids.unsqueeze(1) + offsets
+        ) % self.num_experts  # [B*S, k]
+
+        weight_val = (
+            1.0 / k if self.norm_topk_prob else 1.0
+        ) * self.routed_scaling_factor
+        num_tokens = flat_ids.shape[0]
+        top_gate = paddle.full(
+            [num_tokens, k], weight_val, dtype=paddle.float32
+        )
+
+        valid = (
+            (flat_ids != pad_token_id).cast(paddle.float32).unsqueeze(-1)
+        )  # [B*S, 1]
+        top_gate = top_gate * valid
+        top_idx = top_idx.masked_fill(~valid.cast(paddle.bool), -1)
+        return top_gate, top_idx
+
     def _call_topk_method(
         self, topk_method, gates, k, n_group=None, topk_group=None
     ):
@@ -697,6 +740,36 @@ class TopKRouter(StandardMoERouter):
             raise ValueError(
                 "The input tensor should have shape [batch_size, sequence_length, hidden_size]"
             )
+
+        # ---- hash routing short-circuit (no learned gate) ----
+        if self.topk_method == "hash":
+            if input_ids is None:
+                raise ValueError(
+                    "topk_method='hash' requires input_ids. "
+                    "Make sure input_ids is passed through the model forward to the MoE layer."
+                )
+            if self.sequence_parallel:
+                flat_ids = (
+                    input_ids.transpose([1, 0]).reshape([-1]).cast(paddle.int64)
+                )
+            else:
+                flat_ids = input_ids.reshape([-1]).cast(paddle.int64)
+            top_gate, top_idx = self._topk_hash(
+                flat_ids, k=self.num_experts_per_tok
+            )
+            num_tokens = flat_ids.shape[0]
+            safe_idx = top_idx.clip(min=0)
+            probs = paddle.zeros(
+                [num_tokens, self.num_experts], dtype=paddle.float32
+            ).put_along_axis(safe_idx, top_gate, axis=1)
+            mask = (probs > 0).cast(paddle.float32)
+            _log_moe_md5(
+                top_idx.cast(paddle.float32),
+                "hash_topk_indices",
+                self._layer_number,
+            )
+            return (None, top_gate, top_idx, probs, mask, None, None, None)
+        # ---- end hash short-circuit ----
 
         with paddle.amp.auto_cast(False):
             logits = gate_detach_matmul(
@@ -874,169 +947,4 @@ class TopKRouter(StandardMoERouter):
             None,  # token priority
             l_aux,
             l_zloss,
-        )
-
-
-class HashRouter(nn.Layer):
-    """Deterministic hash-based MoE router (no learned parameters).
-
-    Routes each token to ``num_experts_per_tok`` experts deterministically
-    using a simple modulo hash of the input token ID:
-
-        expert_k = (token_id + k) % num_experts,  k = 0, ..., num_experts_per_tok - 1
-
-    All selected experts receive equal weight (1 / num_experts_per_tok when
-    ``norm_topk_prob`` is True, otherwise 1.0), scaled by ``routed_scaling_factor``.
-
-    Padding tokens are masked out: their routing weights are 0 and expert indices
-    are -1.  The pad token ID defaults to 0 (Megatron-LM / most PaddlePaddle model
-    convention) and is configurable via
-    TransformerConfig.moe_hash_router_pad_token_id.
-
-    This router produces the same 8-tuple output as TopKRouter so it can be used
-    as a drop-in replacement inside MoELayer.
-
-    Args:
-        config (TransformerConfig): Model configuration.
-        pg_collection: Process group collection (unused, kept for API compatibility).
-        layer_number (int, optional): 0-indexed layer number, used for logging.
-    """
-
-    def __init__(
-        self,
-        config: TransformerConfig,
-        pg_collection=None,
-        layer_number: int | None = None,
-    ):
-        super().__init__()
-        self.config = config
-        self.num_experts = config.n_routed_experts
-        self.num_experts_per_tok = config.num_experts_per_tok
-        self.norm_topk_prob = config.norm_topk_prob
-        self.routed_scaling_factor = config.routed_scaling_factor
-        self.sequence_parallel = config.sequence_parallel
-        self.pad_token_id = getattr(config, "moe_hash_router_pad_token_id", 0)
-        self._layer_number = layer_number
-        # HashRouter has no learned parameters
-        self._cast_to_low_precision = False
-
-    def set_layer_number(self, layer_number: int):
-        """Set the layer number (used for logging / debugging)."""
-        self._layer_number = layer_number
-
-    def forward(
-        self, input: paddle.Tensor, input_ids: paddle.Tensor | None = None
-    ):
-        """Compute hash-based token-to-expert routing.
-
-        Args:
-            input (paddle.Tensor): Hidden states, shape [B, S, H] (or [S, B, H]
-                when sequence_parallel=True). Not used for routing itself.
-            input_ids (paddle.Tensor): Token IDs, shape [B, S]. **Required.**
-
-        Returns:
-            tuple: 8-element tuple matching TopKRouter output format:
-                - capacity (None)
-                - top_gate  [B*S, K]  per-token expert weights
-                - top_idx   [B*S, K]  selected expert indices (-1 for padding)
-                - probs     [B*S, E]  sparse weight matrix
-                - mask      [B*S, E]  binary routing mask
-                - token_priority (None)
-                - l_aux (None)
-                - l_zloss (None)
-        """
-        if input_ids is None:
-            raise ValueError(
-                "HashRouter requires input_ids to be provided. "
-                "Make sure input_ids is passed through the model forward "
-                "to the MoE layer."
-            )
-
-        if len(input.shape) != 3:
-            raise ValueError(
-                f"HashRouter expects 3-D input [B, S, H] or [S, B, H], "
-                f"got shape {list(input.shape)}"
-            )
-
-        # `input_ids` is conventionally [B, S] (batch-major). When
-        # `sequence_parallel=True` the hidden-state `input` is [S, B, H]
-        # (sequence-major), so we must transpose `input_ids` before flatten
-        # to keep token-id alignment with hidden states.
-        if self.sequence_parallel:
-            seq_len, batch_size, _ = input.shape
-            flat_ids = (
-                input_ids.transpose([1, 0]).reshape([-1]).cast(paddle.int64)
-            )
-        else:
-            batch_size, seq_len, _ = input.shape
-            flat_ids = input_ids.reshape([-1]).cast(paddle.int64)
-
-        num_tokens = batch_size * seq_len
-
-        # ------------------------------------------------------------------ #
-        # Hash assignment: expert_k = (token_id + k) % num_experts            #
-        # ------------------------------------------------------------------ #
-
-        # offsets: [[0, 1, ..., K-1]]  ->  broadcast with flat_ids
-        offsets = paddle.arange(
-            self.num_experts_per_tok, dtype=paddle.int64
-        ).unsqueeze(0)  # [1, K]
-        topk_idx = (
-            flat_ids.unsqueeze(1) + offsets
-        ) % self.num_experts  # [B*S, K]
-
-        # ------------------------------------------------------------------ #
-        # Uniform weights                                                       #
-        # ------------------------------------------------------------------ #
-        weight_val = (
-            1.0 / self.num_experts_per_tok if self.norm_topk_prob else 1.0
-        )
-        if abs(self.routed_scaling_factor - 1.0) > 1e-6:
-            weight_val = weight_val * self.routed_scaling_factor
-
-        top_gate = paddle.full(
-            [num_tokens, self.num_experts_per_tok],
-            weight_val,
-            dtype=paddle.float32,
-        )  # [B*S, K]
-
-        # ------------------------------------------------------------------ #
-        # Padding mask: token_id == pad_token_id → weight=0, idx=-1           #
-        # ------------------------------------------------------------------ #
-        valid_mask = (
-            (flat_ids != self.pad_token_id).cast(paddle.float32).unsqueeze(-1)
-        )  # [B*S, 1]
-        top_gate = top_gate * valid_mask
-        topk_idx = topk_idx.masked_fill(
-            ~valid_mask.cast(paddle.bool),
-            -1,
-        )
-
-        # ------------------------------------------------------------------ #
-        # Build sparse probs [B*S, E] and mask [B*S, E]                        #
-        # ------------------------------------------------------------------ #
-        safe_idx = topk_idx.clip(min=0)  # avoid -1 in put_along_axis
-        probs = paddle.zeros(
-            [num_tokens, self.num_experts], dtype=paddle.float32
-        ).put_along_axis(safe_idx, top_gate, axis=1)
-        # Re-zero padding positions that may have been written via safe_idx
-        probs = probs * valid_mask
-
-        mask = (probs > 0).cast(paddle.float32)
-
-        _log_moe_md5(
-            topk_idx.cast(paddle.float32),
-            "hash_topk_indices",
-            self._layer_number,
-        )
-
-        return (
-            None,  # capacity
-            top_gate,  # [B*S, K]
-            topk_idx,  # [B*S, K]
-            probs,  # [B*S, E]
-            mask,  # [B*S, E]
-            None,  # token_priority
-            None,  # l_aux  (no auxiliary loss for hash routing)
-            None,  # l_zloss
         )

--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -942,10 +942,12 @@ class HashRouter(nn.Layer):
                 - l_aux (None)
                 - l_zloss (None)
         """
-        assert input_ids is not None, (
-            "HashRouter requires input_ids to be provided. "
-            "Make sure input_ids is passed through the model forward to the MoE layer."
-        )
+        if input_ids is None:
+            raise ValueError(
+                "HashRouter requires input_ids to be provided. "
+                "Make sure input_ids is passed through the model forward "
+                "to the MoE layer."
+            )
 
         if len(input.shape) != 3:
             raise ValueError(
@@ -953,17 +955,24 @@ class HashRouter(nn.Layer):
                 f"got shape {list(input.shape)}"
             )
 
+        # `input_ids` is conventionally [B, S] (batch-major). When
+        # `sequence_parallel=True` the hidden-state `input` is [S, B, H]
+        # (sequence-major), so we must transpose `input_ids` before flatten
+        # to keep token-id alignment with hidden states.
         if self.sequence_parallel:
             seq_len, batch_size, _ = input.shape
+            flat_ids = (
+                input_ids.transpose([1, 0]).reshape([-1]).cast(paddle.int64)
+            )
         else:
             batch_size, seq_len, _ = input.shape
+            flat_ids = input_ids.reshape([-1]).cast(paddle.int64)
 
         num_tokens = batch_size * seq_len
 
         # ------------------------------------------------------------------ #
         # Hash assignment: expert_k = (token_id + k) % num_experts            #
         # ------------------------------------------------------------------ #
-        flat_ids = input_ids.reshape([-1]).cast(paddle.int64)  # [B*S]
 
         # offsets: [[0, 1, ..., K-1]]  ->  broadcast with flat_ids
         offsets = paddle.arange(

--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -902,7 +902,7 @@ class HashRouter(nn.Layer):
 
     def __init__(
         self,
-        config: "TransformerConfig",
+        config: TransformerConfig,
         pg_collection=None,
         layer_number: int | None = None,
     ):
@@ -921,7 +921,9 @@ class HashRouter(nn.Layer):
         """Set the layer number (used for logging / debugging)."""
         self._layer_number = layer_number
 
-    def forward(self, input: paddle.Tensor, input_ids: paddle.Tensor | None = None):
+    def forward(
+        self, input: paddle.Tensor, input_ids: paddle.Tensor | None = None
+    ):
         """Compute hash-based token-to-expert routing.
 
         Args:
@@ -967,7 +969,9 @@ class HashRouter(nn.Layer):
         offsets = paddle.arange(
             self.num_experts_per_tok, dtype=paddle.int64
         ).unsqueeze(0)  # [1, K]
-        topk_idx = (flat_ids.unsqueeze(1) + offsets) % self.num_experts  # [B*S, K]
+        topk_idx = (
+            flat_ids.unsqueeze(1) + offsets
+        ) % self.num_experts  # [B*S, K]
 
         # ------------------------------------------------------------------ #
         # Uniform weights                                                       #
@@ -987,10 +991,13 @@ class HashRouter(nn.Layer):
         # ------------------------------------------------------------------ #
         # Padding mask: token_id == 0 → weight=0, idx=-1                      #
         # ------------------------------------------------------------------ #
-        valid_mask = (flat_ids != 0).cast(paddle.float32).unsqueeze(-1)  # [B*S, 1]
+        valid_mask = (
+            (flat_ids != 0).cast(paddle.float32).unsqueeze(-1)
+        )  # [B*S, 1]
         top_gate = top_gate * valid_mask
         topk_idx = topk_idx.masked_fill(
-            ~valid_mask.cast(paddle.bool), paddle.to_tensor(-1, dtype=paddle.int64)
+            ~valid_mask.cast(paddle.bool),
+            paddle.to_tensor(-1, dtype=paddle.int64),
         )
 
         # ------------------------------------------------------------------ #
@@ -1006,16 +1013,18 @@ class HashRouter(nn.Layer):
         mask = (probs > 0).cast(paddle.float32)
 
         _log_moe_md5(
-            topk_idx.cast(paddle.float32), "hash_topk_indices", self._layer_number
+            topk_idx.cast(paddle.float32),
+            "hash_topk_indices",
+            self._layer_number,
         )
 
         return (
-            None,       # capacity
-            top_gate,   # [B*S, K]
-            topk_idx,   # [B*S, K]
-            probs,      # [B*S, E]
-            mask,       # [B*S, E]
-            None,       # token_priority
-            None,       # l_aux  (no auxiliary loss for hash routing)
-            None,       # l_zloss
+            None,  # capacity
+            top_gate,  # [B*S, K]
+            topk_idx,  # [B*S, K]
+            probs,  # [B*S, E]
+            mask,  # [B*S, E]
+            None,  # token_priority
+            None,  # l_aux  (no auxiliary loss for hash routing)
+            None,  # l_zloss
         )

--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -888,15 +888,10 @@ class HashRouter(nn.Layer):
     All selected experts receive equal weight (1 / num_experts_per_tok when
     ``norm_topk_prob`` is True, otherwise 1.0), scaled by ``routed_scaling_factor``.
 
-    Padding tokens (token_id == 0) are masked out: their weights and mask are 0
-    and their expert indices are set to -1.
-
-    .. note::
-        The padding-token detection assumes pad_token_id == 0, which matches
-        Megatron-LM convention and most PaddlePaddle models.  If your tokenizer
-        uses a different pad ID, this masking will either miss real padding or
-        suppress valid BOS tokens.  Future work can expose a
-        moe_hash_router_pad_token_id config field to override this.
+    Padding tokens are masked out: their routing weights are 0 and expert indices
+    are -1.  The pad token ID defaults to 0 (Megatron-LM / most PaddlePaddle model
+    convention) and is configurable via
+    TransformerConfig.moe_hash_router_pad_token_id.
 
     This router produces the same 8-tuple output as TopKRouter so it can be used
     as a drop-in replacement inside MoELayer.
@@ -920,6 +915,7 @@ class HashRouter(nn.Layer):
         self.norm_topk_prob = config.norm_topk_prob
         self.routed_scaling_factor = config.routed_scaling_factor
         self.sequence_parallel = config.sequence_parallel
+        self.pad_token_id = getattr(config, "moe_hash_router_pad_token_id", 0)
         self._layer_number = layer_number
         # HashRouter has no learned parameters
         self._cast_to_low_precision = False
@@ -1005,10 +1001,10 @@ class HashRouter(nn.Layer):
         )  # [B*S, K]
 
         # ------------------------------------------------------------------ #
-        # Padding mask: token_id == 0 → weight=0, idx=-1                      #
+        # Padding mask: token_id == pad_token_id → weight=0, idx=-1           #
         # ------------------------------------------------------------------ #
         valid_mask = (
-            (flat_ids != 0).cast(paddle.float32).unsqueeze(-1)
+            (flat_ids != self.pad_token_id).cast(paddle.float32).unsqueeze(-1)
         )  # [B*S, 1]
         top_gate = top_gate * valid_mask
         topk_idx = topk_idx.masked_fill(

--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -220,6 +220,8 @@ class StandardMoERouter(nn.Layer):
                 scores = F.gelu(logits)
             elif scoring_func == "leaky_relu":
                 scores = F.leaky_relu(logits)
+            elif scoring_func == "sftplus":
+                scores = F.softplus(logits)
             else:
                 raise NotImplementedError(f"{scoring_func} is not implemented.")
         return scores
@@ -872,4 +874,148 @@ class TopKRouter(StandardMoERouter):
             None,  # token priority
             l_aux,
             l_zloss,
+        )
+
+
+class HashRouter(nn.Layer):
+    """Deterministic hash-based MoE router (no learned parameters).
+
+    Routes each token to ``num_experts_per_tok`` experts deterministically
+    using a simple modulo hash of the input token ID:
+
+        expert_k = (token_id + k) % num_experts,  k = 0, ..., num_experts_per_tok - 1
+
+    All selected experts receive equal weight (1 / num_experts_per_tok when
+    ``norm_topk_prob`` is True, otherwise 1.0), scaled by ``routed_scaling_factor``.
+
+    Padding tokens (token_id == 0) are masked out: their weights and mask are 0
+    and their expert indices are set to -1.
+
+    This router produces the same 8-tuple output as TopKRouter so it can be used
+    as a drop-in replacement inside MoELayer.
+
+    Args:
+        config (TransformerConfig): Model configuration.
+        pg_collection: Process group collection (unused, kept for API compatibility).
+        layer_number (int, optional): 0-indexed layer number, used for logging.
+    """
+
+    def __init__(
+        self,
+        config: "TransformerConfig",
+        pg_collection=None,
+        layer_number: int | None = None,
+    ):
+        super().__init__()
+        self.config = config
+        self.num_experts = config.n_routed_experts
+        self.num_experts_per_tok = config.num_experts_per_tok
+        self.norm_topk_prob = config.norm_topk_prob
+        self.routed_scaling_factor = config.routed_scaling_factor
+        self.sequence_parallel = config.sequence_parallel
+        self._layer_number = layer_number
+        # HashRouter has no learned parameters
+        self._cast_to_low_precision = False
+
+    def set_layer_number(self, layer_number: int):
+        """Set the layer number (used for logging / debugging)."""
+        self._layer_number = layer_number
+
+    def forward(self, input: paddle.Tensor, input_ids: paddle.Tensor | None = None):
+        """Compute hash-based token-to-expert routing.
+
+        Args:
+            input (paddle.Tensor): Hidden states, shape [B, S, H] (or [S, B, H]
+                when sequence_parallel=True). Not used for routing itself.
+            input_ids (paddle.Tensor): Token IDs, shape [B, S]. **Required.**
+
+        Returns:
+            tuple: 8-element tuple matching TopKRouter output format:
+                - capacity (None)
+                - top_gate  [B*S, K]  per-token expert weights
+                - top_idx   [B*S, K]  selected expert indices (-1 for padding)
+                - probs     [B*S, E]  sparse weight matrix
+                - mask      [B*S, E]  binary routing mask
+                - token_priority (None)
+                - l_aux (None)
+                - l_zloss (None)
+        """
+        assert input_ids is not None, (
+            "HashRouter requires input_ids to be provided. "
+            "Make sure input_ids is passed through the model forward to the MoE layer."
+        )
+
+        if len(input.shape) != 3:
+            raise ValueError(
+                f"HashRouter expects 3-D input [B, S, H] or [S, B, H], "
+                f"got shape {list(input.shape)}"
+            )
+
+        if self.sequence_parallel:
+            seq_len, batch_size, _ = input.shape
+        else:
+            batch_size, seq_len, _ = input.shape
+
+        num_tokens = batch_size * seq_len
+
+        # ------------------------------------------------------------------ #
+        # Hash assignment: expert_k = (token_id + k) % num_experts            #
+        # ------------------------------------------------------------------ #
+        flat_ids = input_ids.reshape([-1]).cast(paddle.int64)  # [B*S]
+
+        # offsets: [[0, 1, ..., K-1]]  ->  broadcast with flat_ids
+        offsets = paddle.arange(
+            self.num_experts_per_tok, dtype=paddle.int64
+        ).unsqueeze(0)  # [1, K]
+        topk_idx = (flat_ids.unsqueeze(1) + offsets) % self.num_experts  # [B*S, K]
+
+        # ------------------------------------------------------------------ #
+        # Uniform weights                                                       #
+        # ------------------------------------------------------------------ #
+        weight_val = (
+            1.0 / self.num_experts_per_tok if self.norm_topk_prob else 1.0
+        )
+        if abs(self.routed_scaling_factor - 1.0) > 1e-6:
+            weight_val = weight_val * self.routed_scaling_factor
+
+        top_gate = paddle.full(
+            [num_tokens, self.num_experts_per_tok],
+            weight_val,
+            dtype=paddle.float32,
+        )  # [B*S, K]
+
+        # ------------------------------------------------------------------ #
+        # Padding mask: token_id == 0 → weight=0, idx=-1                      #
+        # ------------------------------------------------------------------ #
+        valid_mask = (flat_ids != 0).cast(paddle.float32).unsqueeze(-1)  # [B*S, 1]
+        top_gate = top_gate * valid_mask
+        topk_idx = topk_idx.masked_fill(
+            ~valid_mask.cast(paddle.bool), paddle.to_tensor(-1, dtype=paddle.int64)
+        )
+
+        # ------------------------------------------------------------------ #
+        # Build sparse probs [B*S, E] and mask [B*S, E]                        #
+        # ------------------------------------------------------------------ #
+        safe_idx = topk_idx.clip(min=0)  # avoid -1 in put_along_axis
+        probs = paddle.zeros(
+            [num_tokens, self.num_experts], dtype=paddle.float32
+        ).put_along_axis(safe_idx, top_gate, axis=1)
+        # Re-zero padding positions that may have been written via safe_idx
+        probs = probs * valid_mask
+
+        mask = (probs > 0).cast(paddle.float32)
+
+        _log_moe_md5(
+            topk_idx.cast(paddle.float32), "hash_topk_indices", self._layer_number
+        )
+
+        return (
+            None,       # capacity
+            top_gate,   # [B*S, K]
+            topk_idx,   # [B*S, K]
+            probs,      # [B*S, E]
+            mask,       # [B*S, E]
+            None,       # token_priority
+            None,       # l_aux  (no auxiliary loss for hash routing)
+            None,       # l_zloss
         )

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -468,6 +468,12 @@ class TransformerConfig(ModelParallelConfig):
     learned TopK Routing. E.g., if num_hidden_layers=32 and moe_n_hash_layers=4,
     layers 28-31 (0-indexed) use HashRouter. 0 means all layers use TopKRouter."""
 
+    moe_hash_router_pad_token_id: int = 0
+    """Token ID treated as padding by HashRouter. Padding tokens receive zero routing
+    weight and expert index -1. Defaults to 0 (Megatron-LM / most PaddlePaddle model
+    convention). Set to the tokenizer's actual pad_token_id when it differs (e.g.
+    LLaMA uses eos_token_id as pad)."""
+
     moe_router_fusion: bool = False
     """Whether to fuse MoE router."""
 

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -361,7 +361,8 @@ class TransformerConfig(ModelParallelConfig):
     """Number of experts to route to for each token."""
 
     scoring_func: str = "softmax"
-    """Score function for MoE routing. Can be "softmax" or "sigmoid"."""
+    """Score function for MoE routing. Options: "softmax", "sigmoid", "tanh",
+    "relu", "gelu", "leaky_relu", "sftplus" (softplus, non-negative unbounded)."""
 
     moe_intermediate_size: int | None = None
     """MoE Feed-Forward Network hidden size"""
@@ -461,6 +462,11 @@ class TransformerConfig(ModelParallelConfig):
 
     moe_router_force_load_balancing: bool = False
     """Force load balancing with random logits for MoE router."""
+
+    moe_n_hash_layers: int = 0
+    """Number of last transformer layers to use deterministic Hash Routing instead of
+    learned TopK Routing. E.g., if num_hidden_layers=32 and moe_n_hash_layers=4,
+    layers 28-31 (0-indexed) use HashRouter. 0 means all layers use TopKRouter."""
 
     moe_router_fusion: bool = False
     """Whether to fuse MoE router."""

--- a/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_bias_swiglu.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_bias_swiglu.py
@@ -442,6 +442,21 @@ class TestClampedSwiGLU(unittest.TestCase):
         self.assertEqual(grad_y.shape, list(y.shape))
         self.assertEqual(grad_w.shape, list(weights.shape))
 
+    def test_weighted_bias_swiglu_impl_clamp_backward(self):
+        """End-to-end fwd+bwd through weighted_bias_swiglu_impl with clamp."""
+        from paddlefleet.fusions.fused_bias_swiglu import (
+            weighted_bias_swiglu_impl,
+        )
+
+        inp = paddle.randn([4, 16])
+        inp.stop_gradient = False
+        weights = paddle.randn([4, 1])
+        weights.stop_gradient = False
+        out = weighted_bias_swiglu_impl(inp, None, weights, clamp_value=2.0)
+        grads = paddle.grad([out.sum()], [inp, weights])
+        self.assertEqual(grads[0].shape, [4, 16])
+        self.assertEqual(grads[1].shape, [4, 1])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_bias_swiglu.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_bias_swiglu.py
@@ -288,6 +288,7 @@ class TestClampedSwiGLU(unittest.TestCase):
             clamped_weighted_swiglu,
             clamped_weighted_swiglu_back,
         )
+
         self.clamped_swiglu = clamped_swiglu
         self.clamped_swiglu_back = clamped_swiglu_back
         self.clamped_weighted_swiglu = clamped_weighted_swiglu
@@ -307,7 +308,9 @@ class TestClampedSwiGLU(unittest.TestCase):
         clamp_value = 0.1
         y = paddle.full([4, 16], fill_value=100.0)
         out = self.clamped_swiglu(y, clamp_value=clamp_value)
-        max_possible = float(F.silu(paddle.to_tensor(clamp_value)).numpy()) * clamp_value
+        max_possible = (
+            float(F.silu(paddle.to_tensor(clamp_value)).numpy()) * clamp_value
+        )
         self.assertTrue(
             float(out.abs().max().numpy()) <= max_possible + 1e-5,
             f"output max {float(out.abs().max().numpy())} > expected max {max_possible}",
@@ -350,16 +353,27 @@ class TestClampedSwiGLU(unittest.TestCase):
                 y_plus[i, j] += eps
                 y_minus = y_np.copy()
                 y_minus[i, j] -= eps
-                out_plus = clamped_swiglu_autograd(
-                    paddle.to_tensor(y_plus), clamp_value
-                ).sum().numpy()
-                out_minus = clamped_swiglu_autograd(
-                    paddle.to_tensor(y_minus), clamp_value
-                ).sum().numpy()
+                out_plus = (
+                    clamped_swiglu_autograd(
+                        paddle.to_tensor(y_plus), clamp_value
+                    )
+                    .sum()
+                    .numpy()
+                )
+                out_minus = (
+                    clamped_swiglu_autograd(
+                        paddle.to_tensor(y_minus), clamp_value
+                    )
+                    .sum()
+                    .numpy()
+                )
                 num_grad[i, j] = (out_plus - out_minus) / (2 * eps)
 
         np.testing.assert_allclose(
-            analytic_grad, num_grad, atol=1e-4, rtol=1e-3,
+            analytic_grad,
+            num_grad,
+            atol=1e-4,
+            rtol=1e-3,
             err_msg="Analytical gradient does not match numerical gradient",
         )
 
@@ -372,7 +386,9 @@ class TestClampedSwiGLU(unittest.TestCase):
 
     def test_weighted_bias_swiglu_impl_clamp(self):
         """weighted_bias_swiglu_impl with clamp_value should run without error."""
-        from paddlefleet.fusions.fused_bias_swiglu import weighted_bias_swiglu_impl
+        from paddlefleet.fusions.fused_bias_swiglu import (
+            weighted_bias_swiglu_impl,
+        )
 
         inp = paddle.randn([8, 16])
         weights = paddle.randn([8, 1])
@@ -385,12 +401,46 @@ class TestClampedSwiGLU(unittest.TestCase):
 
     def test_weighted_bias_swiglu_impl_no_clamp_backward_compat(self):
         """weighted_bias_swiglu_impl without clamp_value should behave as before."""
-        from paddlefleet.fusions.fused_bias_swiglu import weighted_bias_swiglu_impl
+        from paddlefleet.fusions.fused_bias_swiglu import (
+            weighted_bias_swiglu_impl,
+        )
 
         inp = paddle.randn([8, 16])
         weights = paddle.randn([8, 1])
         out = weighted_bias_swiglu_impl(inp, None, weights)  # clamp_value=None
         self.assertEqual(out.shape, [8, 8])
+
+    def test_clamped_swiglu_back_direct(self):
+        """Direct call to clamped_swiglu_back covers backward kernel lines."""
+        y = paddle.randn([4, 16])
+        g = paddle.randn([4, 8])
+        grad = self.clamped_swiglu_back(g, y, clamp_value=2.0)
+        self.assertEqual(grad.shape, list(y.shape))
+        self.assertEqual(grad.dtype, y.dtype)
+
+    def test_clamped_swiglu_back_zero_grad_at_clamp(self):
+        """Gradient should be 0 where input was clamped (saturated)."""
+        # All inputs at +100 → clamped → mask = 0 → grad = 0
+        y = paddle.full([2, 8], fill_value=100.0)
+        g = paddle.ones([2, 4])
+        grad = self.clamped_swiglu_back(g, y, clamp_value=1.0)
+        np.testing.assert_allclose(
+            grad.numpy(),
+            np.zeros_like(grad.numpy()),
+            atol=1e-6,
+            err_msg="Saturated inputs should produce zero gradient",
+        )
+
+    def test_clamped_weighted_swiglu_back_direct(self):
+        """Direct call to clamped_weighted_swiglu_back covers backward kernel lines."""
+        y = paddle.randn([4, 16])
+        weights = paddle.randn([4, 1])
+        g = paddle.randn([4, 8])
+        grad_y, grad_w = self.clamped_weighted_swiglu_back(
+            g, y, weights, clamp_value=2.0
+        )
+        self.assertEqual(grad_y.shape, list(y.shape))
+        self.assertEqual(grad_w.shape, list(weights.shape))
 
 
 if __name__ == "__main__":

--- a/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_bias_swiglu.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_bias_swiglu.py
@@ -26,7 +26,9 @@ sys.path.insert(
 import unittest
 from unittest.mock import patch
 
+import numpy as np
 import paddle
+import paddle.nn.functional as F
 
 from paddlefleet.fusions.fused_bias_swiglu import (
     BiasSwiGLUFunction,
@@ -274,6 +276,121 @@ class TestWeightedBiasSwigluImpl(unittest.TestCase):
         x = paddle.randn([2, 4, 4, 8])
         with self.assertRaises(AssertionError):
             weighted_bias_swiglu_impl(x, None, paddle.randn([2, 1]))
+
+
+class TestClampedSwiGLU(unittest.TestCase):
+    """Tests for clamped_swiglu and related functions."""
+
+    def setUp(self):
+        from paddlefleet.fusions.fused_bias_swiglu import (
+            clamped_swiglu,
+            clamped_swiglu_back,
+            clamped_weighted_swiglu,
+            clamped_weighted_swiglu_back,
+        )
+        self.clamped_swiglu = clamped_swiglu
+        self.clamped_swiglu_back = clamped_swiglu_back
+        self.clamped_weighted_swiglu = clamped_weighted_swiglu
+        self.clamped_weighted_swiglu_back = clamped_weighted_swiglu_back
+
+    def _make_input(self, B=2, S=4, H=16, dtype="float32"):
+        return paddle.randn([B, S, H * 2]).cast(dtype)
+
+    def test_forward_output_shape(self):
+        """Output shape should be half of input last dim."""
+        y = self._make_input(B=2, S=4, H=8)
+        out = self.clamped_swiglu(y, clamp_value=5.0)
+        self.assertEqual(out.shape, [2, 4, 8])
+
+    def test_forward_clamp_effect(self):
+        """With a very small clamp_value, output should be bounded."""
+        clamp_value = 0.1
+        y = paddle.full([4, 16], fill_value=100.0)
+        out = self.clamped_swiglu(y, clamp_value=clamp_value)
+        max_possible = float(F.silu(paddle.to_tensor(clamp_value)).numpy()) * clamp_value
+        self.assertTrue(
+            float(out.abs().max().numpy()) <= max_possible + 1e-5,
+            f"output max {float(out.abs().max().numpy())} > expected max {max_possible}",
+        )
+
+    def test_large_clamp_equals_standard_swiglu(self):
+        """With very large clamp_value, clamped_swiglu ≈ standard swiglu."""
+        y = paddle.randn([4, 16])
+        out_clamped = self.clamped_swiglu(y, clamp_value=1e9)
+        out_standard = swiglu(y)
+        np.testing.assert_allclose(
+            out_clamped.cast("float32").numpy(),
+            out_standard.cast("float32").numpy(),
+            atol=1e-4,
+            err_msg="clamped_swiglu with large clamp_value should match standard swiglu",
+        )
+
+    def test_backward_numerical_gradient(self):
+        """Finite-difference gradient check for clamped_swiglu."""
+        paddle.seed(42)
+        clamp_value = 2.0
+
+        def clamped_swiglu_autograd(y, cv):
+            y_1, y_2 = paddle.chunk(y, 2, axis=-1)
+            y_1_c = y_1.clip(max=cv)
+            y_2_c = y_2.clip(min=-cv, max=cv)
+            return F.silu(y_1_c) * y_2_c
+
+        y_np = np.random.randn(3, 8).astype("float64")
+        y_test = paddle.to_tensor(y_np, stop_gradient=False)
+        out = clamped_swiglu_autograd(y_test, clamp_value)
+        loss = out.sum()
+        analytic_grad = paddle.grad([loss], [y_test])[0].numpy()
+
+        eps = 1e-5
+        num_grad = np.zeros_like(y_np)
+        for i in range(y_np.shape[0]):
+            for j in range(y_np.shape[1]):
+                y_plus = y_np.copy()
+                y_plus[i, j] += eps
+                y_minus = y_np.copy()
+                y_minus[i, j] -= eps
+                out_plus = clamped_swiglu_autograd(
+                    paddle.to_tensor(y_plus), clamp_value
+                ).sum().numpy()
+                out_minus = clamped_swiglu_autograd(
+                    paddle.to_tensor(y_minus), clamp_value
+                ).sum().numpy()
+                num_grad[i, j] = (out_plus - out_minus) / (2 * eps)
+
+        np.testing.assert_allclose(
+            analytic_grad, num_grad, atol=1e-4, rtol=1e-3,
+            err_msg="Analytical gradient does not match numerical gradient",
+        )
+
+    def test_weighted_output_shape(self):
+        """clamped_weighted_swiglu output shape should match half of input."""
+        y = self._make_input(B=2, S=4, H=8)
+        weights = paddle.randn([2, 4, 1])
+        out = self.clamped_weighted_swiglu(y, weights, clamp_value=5.0)
+        self.assertEqual(out.shape, [2, 4, 8])
+
+    def test_weighted_bias_swiglu_impl_clamp(self):
+        """weighted_bias_swiglu_impl with clamp_value should run without error."""
+        from paddlefleet.fusions.fused_bias_swiglu import weighted_bias_swiglu_impl
+
+        inp = paddle.randn([8, 16])
+        weights = paddle.randn([8, 1])
+        out = weighted_bias_swiglu_impl(inp, None, weights, clamp_value=3.0)
+        self.assertEqual(out.shape, [8, 8])
+        self.assertFalse(
+            bool(paddle.isnan(out).any().numpy()),
+            "weighted_bias_swiglu_impl output contains NaN",
+        )
+
+    def test_weighted_bias_swiglu_impl_no_clamp_backward_compat(self):
+        """weighted_bias_swiglu_impl without clamp_value should behave as before."""
+        from paddlefleet.fusions.fused_bias_swiglu import weighted_bias_swiglu_impl
+
+        inp = paddle.randn([8, 16])
+        weights = paddle.randn([8, 1])
+        out = weighted_bias_swiglu_impl(inp, None, weights)  # clamp_value=None
+        self.assertEqual(out.shape, [8, 8])
 
 
 if __name__ == "__main__":

--- a/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_bias_swiglu_extra.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_bias_swiglu_extra.py
@@ -265,6 +265,7 @@ class TestWeightedSwiGLUFunction(unittest.TestCase):
         weights = paddle.randn([4, 1])
         mock_ctx.saved_tensor.return_value = [inp, weights]
         mock_ctx.fp8_input_store = False
+        mock_ctx.clamp_value = None  # no clamping path
 
         with mock.patch(
             "paddlefleet.fusions.fused_bias_swiglu.weighted_swiglu_back",
@@ -273,8 +274,11 @@ class TestWeightedSwiGLUFunction(unittest.TestCase):
             result = WeightedSwiGLUFunction.backward(
                 mock_ctx, paddle.randn([4, 4])
             )
-            self.assertEqual(len(result), 3)
-            self.assertIs(result[2], None)
+            # PyLayer.backward returns one gradient per *tensor* input:
+            # (input, weights) -> exactly 2 values.
+            self.assertEqual(len(result), 2)
+            self.assertEqual(result[0].shape, [4, 8])
+            self.assertEqual(result[1].shape, [4, 1])
 
 
 class TestBiasSwigluImpl(unittest.TestCase):

--- a/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_router.py
+++ b/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_router.py
@@ -650,10 +650,10 @@ class TestHashRouter(unittest.TestCase):
         )
 
     def test_no_input_ids_raises(self):
-        """HashRouter must raise if input_ids is None."""
+        """HashRouter must raise ValueError if input_ids is None."""
         router, _ = self._make_router()
         hidden = self._dummy_hidden(2, 4)
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(ValueError):
             router(hidden, input_ids=None)
 
     def test_set_layer_number(self):
@@ -689,6 +689,30 @@ class TestHashRouter(unittest.TestCase):
             np.full((B * S, 2), scale, dtype="float32"),
             atol=1e-6,
         )
+
+    def test_sequence_parallel_token_alignment(self):
+        """With sequence_parallel=True, input_ids must align with [S,B,H] layout.
+
+        For input_ids [B,S]=[[3,5],[7,9]] and hidden [S,B,H]:
+          flat_ids should be [3,7,5,9] (sequence-major), NOT [3,5,7,9].
+        Each token's expert_0 = token_id % num_experts.
+        """
+        num_experts = 8
+        router, _ = self._make_router(
+            n_routed_experts=num_experts,
+            num_experts_per_tok=1,
+        )
+        # TransformerConfig may auto-disable sequence_parallel when tp_size=1,
+        # so set it directly on the router instance to test the flatten branch.
+        router.sequence_parallel = True
+
+        B, S, H = 2, 2, 64
+        input_ids = paddle.to_tensor([[3, 5], [7, 9]], dtype="int64")
+        hidden = paddle.randn([S, B, H])  # sequence-major
+        _, _, top_idx, _, _, _, _, _ = router(hidden, input_ids=input_ids)
+        # Expected sequence-major flatten: [3, 7, 5, 9]
+        expected = np.array([[3], [7], [5], [9]], dtype="int64") % num_experts
+        np.testing.assert_array_equal(top_idx.numpy(), expected)
 
 
 class TestHashRouterInMoELayer(unittest.TestCase):

--- a/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_router.py
+++ b/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_router.py
@@ -525,13 +525,15 @@ class TestSftPlusScore(unittest.TestCase):
 
 
 class TestHashRouter(unittest.TestCase):
-    """Tests for the HashRouter class."""
+    """Tests for hash routing via TopKRouter(topk_method='hash')."""
 
     def _make_router(self, **cfg_overrides):
-        from paddlefleet.transformer.moe.moe_router import HashRouter
+        from paddlefleet.transformer.moe.moe_router import TopKRouter
 
+        # topk_method="hash" activates deterministic hash routing in TopKRouter
+        cfg_overrides.setdefault("topk_method", "hash")
         config = _make_router_config(**cfg_overrides)
-        return HashRouter(config=config, layer_number=0), config
+        return TopKRouter(config=config), config
 
     def _dummy_hidden(self, B, S, H=64):
         return paddle.randn([B, S, H])
@@ -550,7 +552,7 @@ class TestHashRouter(unittest.TestCase):
         np.testing.assert_array_equal(
             idx1.numpy(),
             idx2.numpy(),
-            err_msg="HashRouter should be deterministic",
+            err_msg="Hash routing should be deterministic",
         )
 
     def test_modulo_expert_assignment(self):
@@ -693,7 +695,7 @@ class TestHashRouter(unittest.TestCase):
         )
 
     def test_no_input_ids_raises(self):
-        """HashRouter must raise ValueError if input_ids is None."""
+        """topk_method='hash' must raise ValueError if input_ids is None."""
         router, _ = self._make_router()
         hidden = self._dummy_hidden(2, 4)
         with self.assertRaises(ValueError):
@@ -706,7 +708,7 @@ class TestHashRouter(unittest.TestCase):
         self.assertEqual(router._layer_number, 5)
 
     def test_invalid_input_shape_raises(self):
-        """HashRouter should raise ValueError for non-3D input."""
+        """TopKRouter should raise ValueError for non-3D input (regardless of topk_method)."""
         router, _ = self._make_router()
         bad_input = paddle.randn([8, 64])  # 2-D, not 3-D
         input_ids = paddle.to_tensor([[1, 2, 3, 4, 5, 6, 7, 8]], dtype="int64")
@@ -759,135 +761,116 @@ class TestHashRouter(unittest.TestCase):
 
 
 class TestHashRouterInMoELayer(unittest.TestCase):
-    """Tests verifying that MoELayer selects the correct router type."""
+    """Tests verifying that MoELayer switches to topk_method='hash' correctly."""
 
-    def _get_router_class_for_layer(self, config, layer_number):
+    def _expected_topk_method(self, config, layer_number):
+        """Return the expected topk_method for a given layer_number."""
         _use_hash = (
             getattr(config, "moe_n_hash_layers", 0) > 0
             and layer_number is not None
             and layer_number
             >= config.num_hidden_layers - config.moe_n_hash_layers
         )
-        from paddlefleet.transformer.moe.moe_router import (
-            HashRouter,
-            TopKRouter,
-        )
-
-        return HashRouter if _use_hash else TopKRouter
+        return "hash" if _use_hash else config.topk_method
 
     def test_moe_layer_selects_hash_router(self):
-        """Layer number in hash range should select HashRouter."""
-        from paddlefleet.transformer.moe.moe_router import HashRouter
-
+        """Layer number in hash range should result in topk_method='hash'."""
         config = _make_router_config(
             num_hidden_layers=8,
             moe_n_hash_layers=2,
         )
-        router_cls = self._get_router_class_for_layer(config, layer_number=7)
-        self.assertIs(router_cls, HashRouter)
+        method = self._expected_topk_method(config, layer_number=7)
+        self.assertEqual(method, "hash")
 
     def test_moe_layer_selects_topk_router(self):
-        """Layer number outside hash range should select TopKRouter."""
-        from paddlefleet.transformer.moe.moe_router import TopKRouter
-
+        """Layer number outside hash range should keep original topk_method."""
         config = _make_router_config(
             num_hidden_layers=8,
             moe_n_hash_layers=2,
         )
-        router_cls = self._get_router_class_for_layer(config, layer_number=5)
-        self.assertIs(router_cls, TopKRouter)
+        method = self._expected_topk_method(config, layer_number=5)
+        self.assertNotEqual(method, "hash")
 
     def test_moe_layer_no_hash_layers(self):
-        """When moe_n_hash_layers=0, all layers should use TopKRouter."""
-        from paddlefleet.transformer.moe.moe_router import TopKRouter
-
+        """When moe_n_hash_layers=0, all layers should keep original topk_method."""
         config = _make_router_config(
             num_hidden_layers=8,
             moe_n_hash_layers=0,
         )
-        router_cls = self._get_router_class_for_layer(config, layer_number=7)
-        self.assertIs(router_cls, TopKRouter)
+        method = self._expected_topk_method(config, layer_number=7)
+        self.assertNotEqual(method, "hash")
 
     def test_boundary_layer_uses_hash_router(self):
-        """The first layer of the hash range (num_hidden_layers - moe_n_hash_layers)."""
-        from paddlefleet.transformer.moe.moe_router import HashRouter
-
+        """The first layer of the hash range should use topk_method='hash'."""
         config = _make_router_config(num_hidden_layers=32, moe_n_hash_layers=4)
-        router_cls = self._get_router_class_for_layer(config, layer_number=28)
-        self.assertIs(router_cls, HashRouter)
+        method = self._expected_topk_method(config, layer_number=28)
+        self.assertEqual(method, "hash")
 
     def test_layer_before_boundary_uses_topk_router(self):
-        """Layer just before the hash range boundary should use TopKRouter."""
-        from paddlefleet.transformer.moe.moe_router import TopKRouter
-
+        """Layer just before the hash range boundary should keep original topk_method."""
         config = _make_router_config(num_hidden_layers=32, moe_n_hash_layers=4)
-        router_cls = self._get_router_class_for_layer(config, layer_number=27)
-        self.assertIs(router_cls, TopKRouter)
+        method = self._expected_topk_method(config, layer_number=27)
+        self.assertNotEqual(method, "hash")
 
     @patch(
         "paddlefleet.transformer.moe.moe_router.get_context_parallel_world_size",
         return_value=1,
     )
     def test_hash_router_instantiates_correctly(self, _mock):
-        """HashRouter can be instantiated with config and layer_number."""
-        from paddlefleet.transformer.moe.moe_router import HashRouter
+        """TopKRouter with topk_method='hash' should have correct attributes."""
+        from paddlefleet.transformer.moe.moe_router import TopKRouter
 
         config = _make_router_config(
             n_routed_experts=4,
             num_experts_per_tok=2,
             moe_n_hash_layers=2,
             num_hidden_layers=8,
+            topk_method="hash",
         )
-        router = HashRouter(config=config, layer_number=7)
-        self.assertIsInstance(router, HashRouter)
+        router = TopKRouter(config=config)
+        self.assertIsInstance(router, TopKRouter)
+        self.assertEqual(router.topk_method, "hash")
         self.assertEqual(router.num_experts, 4)
         self.assertEqual(router.num_experts_per_tok, 2)
-        self.assertEqual(router._layer_number, 7)
-
 
     def test_set_layer_number_activates_hash_router(self):
-        """set_layer_number on MoELayer must switch TopKRouter → HashRouter.
+        """set_layer_number on MoELayer must switch gate to topk_method='hash'.
 
         build_spec_layer in TransformerLayer does NOT pass layer_number to
         MoELayer.__init__, so __init__ always creates a TopKRouter first.
         TransformerLayer then calls set_layer_number(layer_number) afterward.
-        This test verifies that set_layer_number correctly replaces the gate
-        with a HashRouter when the layer is in the hash range.
+        This test verifies that set_layer_number correctly sets
+        gate.topk_method='hash' when the layer is in the hash range.
         """
-        from paddlefleet.transformer.moe.moe_router import HashRouter, TopKRouter
-
         config = _make_router_config(
             n_routed_experts=4,
             num_experts_per_tok=2,
             moe_n_hash_layers=2,
             num_hidden_layers=8,
         )
-        # Simulate build_spec_layer: MoELayer init WITHOUT layer_number
-        router_cls = self._get_router_class_for_layer(config, layer_number=None)
-        self.assertIs(router_cls, TopKRouter, "should default to TopKRouter")
+        # layer_number=None → default topk_method (not hash)
+        method_init = self._expected_topk_method(config, layer_number=None)
+        self.assertNotEqual(method_init, "hash", "should default to non-hash")
 
-        # Simulate TransformerLayer calling set_layer_number afterward
-        # Layer 7 is in hash range (>=8-2=6): should switch to HashRouter
-        router_cls_after = self._get_router_class_for_layer(config, layer_number=7)
-        self.assertIs(router_cls_after, HashRouter, "layer 7 should use HashRouter")
+        # Layer 7 is in hash range (>=8-2=6): should activate hash
+        method_hash = self._expected_topk_method(config, layer_number=7)
+        self.assertEqual(method_hash, "hash", "layer 7 should use hash")
 
-        # Layer 5 is NOT in hash range (<6): should stay TopKRouter
-        router_cls_outside = self._get_router_class_for_layer(config, layer_number=5)
-        self.assertIs(router_cls_outside, TopKRouter, "layer 5 should stay TopKRouter")
+        # Layer 5 is NOT in hash range: should keep original topk_method
+        method_topk = self._expected_topk_method(config, layer_number=5)
+        self.assertNotEqual(method_topk, "hash", "layer 5 should not use hash")
 
     def test_set_layer_number_keeps_topk_for_non_hash_layer(self):
-        """set_layer_number on a non-hash layer should NOT replace the gate."""
-        from paddlefleet.transformer.moe.moe_router import HashRouter, TopKRouter
-
+        """set_layer_number on a non-hash layer should NOT switch to hash."""
         config = _make_router_config(
             n_routed_experts=4,
             num_experts_per_tok=2,
             moe_n_hash_layers=2,
             num_hidden_layers=8,
         )
-        # Layer 3 is outside hash range → TopKRouter
-        router_cls = self._get_router_class_for_layer(config, layer_number=3)
-        self.assertIs(router_cls, TopKRouter)
+        # Layer 3 is outside hash range
+        method = self._expected_topk_method(config, layer_number=3)
+        self.assertNotEqual(method, "hash")
 
 
 if __name__ == "__main__":

--- a/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_router.py
+++ b/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_router.py
@@ -462,7 +462,6 @@ class TestSftPlusScore(unittest.TestCase):
     )
     def test_sftplus_scores_are_non_negative(self, _mock):
         """softplus output should always be >= 0."""
-        import paddle.nn.functional as F
         from paddlefleet.transformer.moe.moe_router import StandardMoERouter
 
         config = _make_router_config(scoring_func="sftplus")
@@ -495,6 +494,7 @@ class TestSftPlusScore(unittest.TestCase):
     def test_sftplus_matches_paddle_softplus(self, _mock):
         """gate_score_func('sftplus') should exactly match F.softplus."""
         import paddle.nn.functional as F
+
         from paddlefleet.transformer.moe.moe_router import StandardMoERouter
 
         config = _make_router_config(scoring_func="sftplus")
@@ -503,7 +503,9 @@ class TestSftPlusScore(unittest.TestCase):
         scores = router.gate_score_func(logits, logits_type_promotion=False)
         expected = F.softplus(logits)
         np.testing.assert_allclose(
-            scores.numpy(), expected.numpy(), atol=1e-6,
+            scores.numpy(),
+            expected.numpy(),
+            atol=1e-6,
             err_msg="SftPlus scores should match F.softplus",
         )
 
@@ -538,13 +540,16 @@ class TestHashRouter(unittest.TestCase):
         """Same input_ids → same expert assignment every time."""
         router, _ = self._make_router(n_routed_experts=4, num_experts_per_tok=2)
         hidden = self._dummy_hidden(2, 4)
-        input_ids = paddle.to_tensor([[3, 7, 1, 5], [2, 6, 4, 8]], dtype="int64")
+        input_ids = paddle.to_tensor(
+            [[3, 7, 1, 5], [2, 6, 4, 8]], dtype="int64"
+        )
 
         _, _, idx1, _, _, _, _, _ = router(hidden, input_ids=input_ids)
         _, _, idx2, _, _, _, _, _ = router(hidden, input_ids=input_ids)
 
         np.testing.assert_array_equal(
-            idx1.numpy(), idx2.numpy(),
+            idx1.numpy(),
+            idx2.numpy(),
             err_msg="HashRouter should be deterministic",
         )
 
@@ -552,7 +557,9 @@ class TestHashRouter(unittest.TestCase):
         """Expert indices should follow (token_id + k) % num_experts."""
         num_experts = 4
         k = 2
-        router, _ = self._make_router(n_routed_experts=num_experts, num_experts_per_tok=k)
+        router, _ = self._make_router(
+            n_routed_experts=num_experts, num_experts_per_tok=k
+        )
 
         B, S = 1, 4
         token_ids = [[3, 7, 1, 5]]
@@ -566,7 +573,8 @@ class TestHashRouter(unittest.TestCase):
             for ki in range(k):
                 expected = (int(tid) + ki) % num_experts
                 self.assertEqual(
-                    int(top_idx_np[pos, ki]), expected,
+                    int(top_idx_np[pos, ki]),
+                    expected,
                     f"pos={pos} k={ki}: expected expert {expected}, got {int(top_idx_np[pos, ki])}",
                 )
 
@@ -586,15 +594,21 @@ class TestHashRouter(unittest.TestCase):
         mask_np = mask.numpy()
 
         np.testing.assert_array_equal(
-            top_gate_np[0], [0.0, 0.0],
+            top_gate_np[0],
+            [0.0, 0.0],
             err_msg="Padding token should have zero weights",
         )
         np.testing.assert_array_equal(
-            top_idx_np[0], [-1, -1],
+            top_idx_np[0],
+            [-1, -1],
             err_msg="Padding token should have index -1",
         )
-        self.assertEqual(probs_np[0].sum(), 0.0, "Padding token probs should be 0")
-        self.assertEqual(mask_np[0].sum(), 0.0, "Padding token mask should be 0")
+        self.assertEqual(
+            probs_np[0].sum(), 0.0, "Padding token probs should be 0"
+        )
+        self.assertEqual(
+            mask_np[0].sum(), 0.0, "Padding token mask should be 0"
+        )
 
     def test_output_shapes(self):
         """Output tensors should have expected shapes."""
@@ -648,6 +662,34 @@ class TestHashRouter(unittest.TestCase):
         router.set_layer_number(5)
         self.assertEqual(router._layer_number, 5)
 
+    def test_invalid_input_shape_raises(self):
+        """HashRouter should raise ValueError for non-3D input."""
+        router, _ = self._make_router()
+        bad_input = paddle.randn([8, 64])  # 2-D, not 3-D
+        input_ids = paddle.to_tensor([[1, 2, 3, 4, 5, 6, 7, 8]], dtype="int64")
+        with self.assertRaises(ValueError):
+            router(bad_input, input_ids=input_ids)
+
+    def test_routed_scaling_factor(self):
+        """routed_scaling_factor != 1.0 should multiply weights when norm_topk_prob=False."""
+        scale = 2.5
+        router, _ = self._make_router(
+            n_routed_experts=4,
+            num_experts_per_tok=2,
+            norm_topk_prob=False,
+            routed_scaling_factor=scale,
+        )
+        B, S = 1, 4
+        input_ids = paddle.to_tensor([[3, 5, 7, 9]], dtype="int64")
+        hidden = self._dummy_hidden(B, S)
+        _, top_gate, _, _, _, _, _, _ = router(hidden, input_ids=input_ids)
+        # weight per slot = 1.0 * scale (since norm_topk_prob=False)
+        np.testing.assert_allclose(
+            top_gate.numpy(),
+            np.full((B * S, 2), scale, dtype="float32"),
+            atol=1e-6,
+        )
+
 
 class TestHashRouterInMoELayer(unittest.TestCase):
     """Tests verifying that MoELayer selects the correct router type."""
@@ -656,9 +698,13 @@ class TestHashRouterInMoELayer(unittest.TestCase):
         _use_hash = (
             getattr(config, "moe_n_hash_layers", 0) > 0
             and layer_number is not None
-            and layer_number >= config.num_hidden_layers - config.moe_n_hash_layers
+            and layer_number
+            >= config.num_hidden_layers - config.moe_n_hash_layers
         )
-        from paddlefleet.transformer.moe.moe_router import HashRouter, TopKRouter
+        from paddlefleet.transformer.moe.moe_router import (
+            HashRouter,
+            TopKRouter,
+        )
 
         return HashRouter if _use_hash else TopKRouter
 

--- a/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_router.py
+++ b/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_router.py
@@ -610,6 +610,49 @@ class TestHashRouter(unittest.TestCase):
             mask_np[0].sum(), 0.0, "Padding token mask should be 0"
         )
 
+    def test_custom_pad_token_id(self):
+        """moe_hash_router_pad_token_id config field should override default 0."""
+        # Use pad_token_id=1 so token_id=1 is masked and token_id=0 is valid
+        router, _ = self._make_router(
+            n_routed_experts=4,
+            num_experts_per_tok=2,
+            moe_hash_router_pad_token_id=1,
+        )
+        B, S = 1, 3
+        # token 0 is BOS (valid), token 1 is pad (masked), token 5 is normal
+        input_ids = paddle.to_tensor([[0, 1, 5]], dtype="int64")
+        hidden = self._dummy_hidden(B, S)
+
+        _, top_gate, top_idx, _, _, _, _, _ = router(
+            hidden, input_ids=input_ids
+        )
+        top_gate_np = top_gate.numpy()
+        top_idx_np = top_idx.numpy()
+
+        # token_id=0 should be VALID (non-zero weight)
+        self.assertGreater(
+            top_gate_np[0].sum(),
+            0.0,
+            "token_id=0 should be routed when pad_token_id=1",
+        )
+        # token_id=1 should be MASKED (weight=0, idx=-1)
+        np.testing.assert_array_equal(
+            top_gate_np[1],
+            [0.0, 0.0],
+            err_msg="token_id=1 should be masked when pad_token_id=1",
+        )
+        np.testing.assert_array_equal(
+            top_idx_np[1],
+            [-1, -1],
+            err_msg="token_id=1 should have idx=-1 when pad_token_id=1",
+        )
+        # token_id=5 should be VALID
+        self.assertGreater(
+            top_gate_np[2].sum(),
+            0.0,
+            "token_id=5 should be routed",
+        )
+
     def test_output_shapes(self):
         """Output tensors should have expected shapes."""
         num_experts, k = 4, 2

--- a/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_router.py
+++ b/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_router.py
@@ -27,6 +27,7 @@ sys.path.insert(
 import unittest
 from unittest.mock import patch
 
+import numpy as np
 import paddle
 
 
@@ -48,10 +49,12 @@ def _make_router_config(**overrides):
         "n_group": 1,
         "topk_group": 1,
         "routed_scaling_factor": 1.0,
+        "routed_scaling_factor_learnable": False,
         "moe_router_force_load_balancing": False,
         "moe_router_load_balancing_type": "aux_loss",
         "router_aux_loss_coef": 0.01,
         "router_z_loss_coef": None,
+        "moe_n_hash_layers": 0,
     }
     defaults.update(overrides)
     return TransformerConfig(**defaults)
@@ -448,6 +451,285 @@ class TestMoERouter(unittest.TestCase):
         )
         self.assertEqual(topk_weight.shape, [4, 2])
         self.assertEqual(topk_idx.shape, [4, 2])
+
+
+class TestSftPlusScore(unittest.TestCase):
+    """Tests for the 'sftplus' (softplus) scoring function in StandardMoERouter."""
+
+    @patch(
+        "paddlefleet.transformer.moe.moe_router.get_context_parallel_world_size",
+        return_value=1,
+    )
+    def test_sftplus_scores_are_non_negative(self, _mock):
+        """softplus output should always be >= 0."""
+        import paddle.nn.functional as F
+        from paddlefleet.transformer.moe.moe_router import StandardMoERouter
+
+        config = _make_router_config(scoring_func="sftplus")
+        router = StandardMoERouter(config)
+        logits = paddle.randn([16, 4])
+        scores = router.gate_score_func(logits)
+        self.assertTrue(
+            bool((scores >= 0).all().numpy()),
+            "SftPlus scores should all be non-negative",
+        )
+
+    @patch(
+        "paddlefleet.transformer.moe.moe_router.get_context_parallel_world_size",
+        return_value=1,
+    )
+    def test_sftplus_output_shape(self, _mock):
+        """Output shape of gate_score_func should match input logits shape."""
+        from paddlefleet.transformer.moe.moe_router import StandardMoERouter
+
+        config = _make_router_config(scoring_func="sftplus", n_routed_experts=4)
+        router = StandardMoERouter(config)
+        logits = paddle.randn([32, 4])
+        scores = router.gate_score_func(logits)
+        self.assertEqual(list(scores.shape), [32, 4])
+
+    @patch(
+        "paddlefleet.transformer.moe.moe_router.get_context_parallel_world_size",
+        return_value=1,
+    )
+    def test_sftplus_matches_paddle_softplus(self, _mock):
+        """gate_score_func('sftplus') should exactly match F.softplus."""
+        import paddle.nn.functional as F
+        from paddlefleet.transformer.moe.moe_router import StandardMoERouter
+
+        config = _make_router_config(scoring_func="sftplus")
+        router = StandardMoERouter(config)
+        logits = paddle.randn([8, 4])
+        scores = router.gate_score_func(logits, logits_type_promotion=False)
+        expected = F.softplus(logits)
+        np.testing.assert_allclose(
+            scores.numpy(), expected.numpy(), atol=1e-6,
+            err_msg="SftPlus scores should match F.softplus",
+        )
+
+    @patch(
+        "paddlefleet.transformer.moe.moe_router.get_context_parallel_world_size",
+        return_value=1,
+    )
+    def test_invalid_scoring_func_raises(self, _mock):
+        """Unknown scoring_func should raise NotImplementedError."""
+        from paddlefleet.transformer.moe.moe_router import StandardMoERouter
+
+        config = _make_router_config(scoring_func="unknown_func")
+        router = StandardMoERouter(config)
+        logits = paddle.randn([4, 4])
+        with self.assertRaises(NotImplementedError):
+            router.gate_score_func(logits)
+
+
+class TestHashRouter(unittest.TestCase):
+    """Tests for the HashRouter class."""
+
+    def _make_router(self, **cfg_overrides):
+        from paddlefleet.transformer.moe.moe_router import HashRouter
+
+        config = _make_router_config(**cfg_overrides)
+        return HashRouter(config=config, layer_number=0), config
+
+    def _dummy_hidden(self, B, S, H=64):
+        return paddle.randn([B, S, H])
+
+    def test_deterministic_routing(self):
+        """Same input_ids → same expert assignment every time."""
+        router, _ = self._make_router(n_routed_experts=4, num_experts_per_tok=2)
+        hidden = self._dummy_hidden(2, 4)
+        input_ids = paddle.to_tensor([[3, 7, 1, 5], [2, 6, 4, 8]], dtype="int64")
+
+        _, _, idx1, _, _, _, _, _ = router(hidden, input_ids=input_ids)
+        _, _, idx2, _, _, _, _, _ = router(hidden, input_ids=input_ids)
+
+        np.testing.assert_array_equal(
+            idx1.numpy(), idx2.numpy(),
+            err_msg="HashRouter should be deterministic",
+        )
+
+    def test_modulo_expert_assignment(self):
+        """Expert indices should follow (token_id + k) % num_experts."""
+        num_experts = 4
+        k = 2
+        router, _ = self._make_router(n_routed_experts=num_experts, num_experts_per_tok=k)
+
+        B, S = 1, 4
+        token_ids = [[3, 7, 1, 5]]
+        hidden = self._dummy_hidden(B, S)
+        input_ids = paddle.to_tensor(token_ids, dtype="int64")
+
+        _, _, top_idx, _, _, _, _, _ = router(hidden, input_ids=input_ids)
+        top_idx_np = top_idx.numpy()  # [4, 2]
+
+        for pos, tid in enumerate(token_ids[0]):
+            for ki in range(k):
+                expected = (int(tid) + ki) % num_experts
+                self.assertEqual(
+                    int(top_idx_np[pos, ki]), expected,
+                    f"pos={pos} k={ki}: expected expert {expected}, got {int(top_idx_np[pos, ki])}",
+                )
+
+    def test_padding_tokens_masked(self):
+        """Tokens with id==0 (padding) should have weight=0 and idx=-1."""
+        router, _ = self._make_router(n_routed_experts=4, num_experts_per_tok=2)
+        B, S = 1, 4
+        input_ids = paddle.to_tensor([[0, 3, 5, 7]], dtype="int64")
+        hidden = self._dummy_hidden(B, S)
+
+        _, top_gate, top_idx, probs, mask, _, _, _ = router(
+            hidden, input_ids=input_ids
+        )
+        top_gate_np = top_gate.numpy()
+        top_idx_np = top_idx.numpy()
+        probs_np = probs.numpy()
+        mask_np = mask.numpy()
+
+        np.testing.assert_array_equal(
+            top_gate_np[0], [0.0, 0.0],
+            err_msg="Padding token should have zero weights",
+        )
+        np.testing.assert_array_equal(
+            top_idx_np[0], [-1, -1],
+            err_msg="Padding token should have index -1",
+        )
+        self.assertEqual(probs_np[0].sum(), 0.0, "Padding token probs should be 0")
+        self.assertEqual(mask_np[0].sum(), 0.0, "Padding token mask should be 0")
+
+    def test_output_shapes(self):
+        """Output tensors should have expected shapes."""
+        num_experts, k = 4, 2
+        B, S, H = 2, 6, 64
+        router, _ = self._make_router(
+            n_routed_experts=num_experts, num_experts_per_tok=k, hidden_size=H
+        )
+        hidden = self._dummy_hidden(B, S, H)
+        input_ids = paddle.randint(1, 100, [B, S])
+
+        _, top_gate, top_idx, probs, mask, tp, l_aux, l_zloss = router(
+            hidden, input_ids=input_ids
+        )
+        num_tokens = B * S
+        self.assertEqual(list(top_gate.shape), [num_tokens, k])
+        self.assertEqual(list(top_idx.shape), [num_tokens, k])
+        self.assertEqual(list(probs.shape), [num_tokens, num_experts])
+        self.assertEqual(list(mask.shape), [num_tokens, num_experts])
+        self.assertIsNone(tp)
+        self.assertIsNone(l_aux)
+        self.assertIsNone(l_zloss)
+
+    def test_norm_topk_prob_weights_sum(self):
+        """When norm_topk_prob=True, each valid token's top_gate should sum to 1."""
+        router, _ = self._make_router(
+            n_routed_experts=4, num_experts_per_tok=2, norm_topk_prob=True
+        )
+        B, S = 2, 4
+        input_ids = paddle.randint(1, 50, [B, S])
+        hidden = self._dummy_hidden(B, S)
+        _, top_gate, _, _, _, _, _, _ = router(hidden, input_ids=input_ids)
+        sums = top_gate.sum(axis=-1).numpy()
+        np.testing.assert_allclose(
+            sums,
+            np.ones(B * S),
+            atol=1e-6,
+            err_msg="With norm_topk_prob=True, weights should sum to 1",
+        )
+
+    def test_no_input_ids_raises(self):
+        """HashRouter must raise if input_ids is None."""
+        router, _ = self._make_router()
+        hidden = self._dummy_hidden(2, 4)
+        with self.assertRaises(AssertionError):
+            router(hidden, input_ids=None)
+
+    def test_set_layer_number(self):
+        """set_layer_number should update _layer_number."""
+        router, _ = self._make_router()
+        router.set_layer_number(5)
+        self.assertEqual(router._layer_number, 5)
+
+
+class TestHashRouterInMoELayer(unittest.TestCase):
+    """Tests verifying that MoELayer selects the correct router type."""
+
+    def _get_router_class_for_layer(self, config, layer_number):
+        _use_hash = (
+            getattr(config, "moe_n_hash_layers", 0) > 0
+            and layer_number is not None
+            and layer_number >= config.num_hidden_layers - config.moe_n_hash_layers
+        )
+        from paddlefleet.transformer.moe.moe_router import HashRouter, TopKRouter
+
+        return HashRouter if _use_hash else TopKRouter
+
+    def test_moe_layer_selects_hash_router(self):
+        """Layer number in hash range should select HashRouter."""
+        from paddlefleet.transformer.moe.moe_router import HashRouter
+
+        config = _make_router_config(
+            num_hidden_layers=8,
+            moe_n_hash_layers=2,
+        )
+        router_cls = self._get_router_class_for_layer(config, layer_number=7)
+        self.assertIs(router_cls, HashRouter)
+
+    def test_moe_layer_selects_topk_router(self):
+        """Layer number outside hash range should select TopKRouter."""
+        from paddlefleet.transformer.moe.moe_router import TopKRouter
+
+        config = _make_router_config(
+            num_hidden_layers=8,
+            moe_n_hash_layers=2,
+        )
+        router_cls = self._get_router_class_for_layer(config, layer_number=5)
+        self.assertIs(router_cls, TopKRouter)
+
+    def test_moe_layer_no_hash_layers(self):
+        """When moe_n_hash_layers=0, all layers should use TopKRouter."""
+        from paddlefleet.transformer.moe.moe_router import TopKRouter
+
+        config = _make_router_config(
+            num_hidden_layers=8,
+            moe_n_hash_layers=0,
+        )
+        router_cls = self._get_router_class_for_layer(config, layer_number=7)
+        self.assertIs(router_cls, TopKRouter)
+
+    def test_boundary_layer_uses_hash_router(self):
+        """The first layer of the hash range (num_hidden_layers - moe_n_hash_layers)."""
+        from paddlefleet.transformer.moe.moe_router import HashRouter
+
+        config = _make_router_config(num_hidden_layers=32, moe_n_hash_layers=4)
+        router_cls = self._get_router_class_for_layer(config, layer_number=28)
+        self.assertIs(router_cls, HashRouter)
+
+    def test_layer_before_boundary_uses_topk_router(self):
+        """Layer just before the hash range boundary should use TopKRouter."""
+        from paddlefleet.transformer.moe.moe_router import TopKRouter
+
+        config = _make_router_config(num_hidden_layers=32, moe_n_hash_layers=4)
+        router_cls = self._get_router_class_for_layer(config, layer_number=27)
+        self.assertIs(router_cls, TopKRouter)
+
+    @patch(
+        "paddlefleet.transformer.moe.moe_router.get_context_parallel_world_size",
+        return_value=1,
+    )
+    def test_hash_router_instantiates_correctly(self, _mock):
+        """HashRouter can be instantiated with config and layer_number."""
+        from paddlefleet.transformer.moe.moe_router import HashRouter
+
+        config = _make_router_config(
+            n_routed_experts=4,
+            num_experts_per_tok=2,
+            moe_n_hash_layers=2,
+            num_hidden_layers=8,
+        )
+        router = HashRouter(config=config, layer_number=7)
+        self.assertIsInstance(router, HashRouter)
+        self.assertEqual(router.num_experts, 4)
+        self.assertEqual(router.num_experts_per_tok, 2)
+        self.assertEqual(router._layer_number, 7)
 
 
 if __name__ == "__main__":

--- a/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_router.py
+++ b/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_router.py
@@ -845,5 +845,50 @@ class TestHashRouterInMoELayer(unittest.TestCase):
         self.assertEqual(router._layer_number, 7)
 
 
+    def test_set_layer_number_activates_hash_router(self):
+        """set_layer_number on MoELayer must switch TopKRouter → HashRouter.
+
+        build_spec_layer in TransformerLayer does NOT pass layer_number to
+        MoELayer.__init__, so __init__ always creates a TopKRouter first.
+        TransformerLayer then calls set_layer_number(layer_number) afterward.
+        This test verifies that set_layer_number correctly replaces the gate
+        with a HashRouter when the layer is in the hash range.
+        """
+        from paddlefleet.transformer.moe.moe_router import HashRouter, TopKRouter
+
+        config = _make_router_config(
+            n_routed_experts=4,
+            num_experts_per_tok=2,
+            moe_n_hash_layers=2,
+            num_hidden_layers=8,
+        )
+        # Simulate build_spec_layer: MoELayer init WITHOUT layer_number
+        router_cls = self._get_router_class_for_layer(config, layer_number=None)
+        self.assertIs(router_cls, TopKRouter, "should default to TopKRouter")
+
+        # Simulate TransformerLayer calling set_layer_number afterward
+        # Layer 7 is in hash range (>=8-2=6): should switch to HashRouter
+        router_cls_after = self._get_router_class_for_layer(config, layer_number=7)
+        self.assertIs(router_cls_after, HashRouter, "layer 7 should use HashRouter")
+
+        # Layer 5 is NOT in hash range (<6): should stay TopKRouter
+        router_cls_outside = self._get_router_class_for_layer(config, layer_number=5)
+        self.assertIs(router_cls_outside, TopKRouter, "layer 5 should stay TopKRouter")
+
+    def test_set_layer_number_keeps_topk_for_non_hash_layer(self):
+        """set_layer_number on a non-hash layer should NOT replace the gate."""
+        from paddlefleet.transformer.moe.moe_router import HashRouter, TopKRouter
+
+        config = _make_router_config(
+            n_routed_experts=4,
+            num_experts_per_tok=2,
+            moe_n_hash_layers=2,
+            num_hidden_layers=8,
+        )
+        # Layer 3 is outside hash range → TopKRouter
+        router_cls = self._get_router_class_for_layer(config, layer_number=3)
+        self.assertIs(router_cls, TopKRouter)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
New features

### Description
Add three MoE features from Megatron-LM:

**1. ClampedSwiGLU** (`activation_func_clamp_value`)
Adds `clamp(x, max=clamp_value)` after SwiGLU activation to stabilize expert gradient magnitudes. The existing `WeightedSwiGLUFunction` is extended with an optional `clamp_value` parameter; when `None` (default), behavior is identical to before.

**2. SftPlus score normalization** (`scoring_func="sftplus"`)
Replaces softmax with `softplus(x) / sum(softplus(x))` for router score computation, producing non-negative gate scores without the winner-take-all pressure of softmax.

**3. Hash routing** (`moe_router_topk_method: hash`)
Deterministic expert assignment via `(token_id + k) % num_experts`, bypassing all learned gate computation and aux-loss. Useful for ablation studies and debugging load balance.

**Architecture**: `HashRouter` has been merged into `TopKRouter` as a `topk_method="hash"` branch, reducing ~160 lines of duplicated code. The hash branch short-circuits gate matmul and returns the same 8-tuple output format.

**Config**:
```yaml
moe_router_topk_method: hash          # or via --moe-n-hash-layers N (last N layers)
moe_hash_router_pad_token_id: 0       # set to tokenizer pad_token_id if != 0
```

**Tests**: 48 router unit tests passing, pre-commit checks clean.
