### PR TITLE
[Config] add mtp loss

### DIFF
--- a/src/paddlefleet/models/common/language_loss/language_loss.py
+++ b/src/paddlefleet/models/common/language_loss/language_loss.py
@@ -549,23 +549,20 @@ class LanguageLoss(FleetLayer):
 
             def add_loss(main_loss, loss):
                 if self.config.add_mtp_loss:
-                    return main_loss + loss - loss.detach()
+                    return main_loss + loss
                 else:
-                    return main_loss
+                    return main_loss + loss - loss.detach()
 
             if self.config.gpt_model_use_experimental_version:
                 # Align with EB: accumulate inside loop to match float32
                 # arithmetic order: loss += scaling * loss_i / N
                 loss = lm_loss
-                if self.config.add_mtp_loss:
-                    num_mtp = len(mtp_loss)
-                    for mtp_l in mtp_loss:
-                        loss = (
-                            loss
-                            + self.config.mtp_loss_scaling_factor
-                            * mtp_l
-                            / num_mtp
-                        )
+                num_mtp = len(mtp_loss)
+                for mtp_l in mtp_loss:
+                    loss = add_loss(
+                        loss,
+                        self.config.mtp_loss_scaling_factor * mtp_l / num_mtp,
+                    )
             else:
                 loss = add_loss(
                     lm_loss,
@@ -625,9 +622,9 @@ class MainLanguageLoss(LanguageLoss):
 
         def add_loss(main_loss, loss):
             if self.config.add_mtp_loss:
-                return main_loss + loss - loss.detach()
+                return main_loss + loss
             else:
-                return main_loss
+                return main_loss + loss - loss.detach()
 
         loss = add_loss(
             lm_loss,

--- a/tests/multi_card_tests/pipeline_parallel/test_gpt_pp_with_moe_with_mtp.py
+++ b/tests/multi_card_tests/pipeline_parallel/test_gpt_pp_with_moe_with_mtp.py
@@ -241,7 +241,7 @@ class TestPP(unittest.TestCase):
 
         if judge_machine_type() == "H":
             actual_md5 = overlap_loss._md5sum()
-            expected_md5 = "e7c0a0f5d64bccfdb11d2c7ef5ebda6c"
+            expected_md5 = "e5fdb6c3bc189ea3e4f2235f0e73353d"
             print(
                 f"PP loss MD5 - Actual: {actual_md5}, Expected: {expected_md5}"
             )

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_language_loss_7.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_language_loss_7.py
@@ -120,7 +120,7 @@ class TestMainLanguageLoss(unittest.TestCase):
         out = layer.forward({"mtp_loss": mtp_loss, "logits": logits}, labels)
 
         # lm_loss(10) + scale*mean(mtp)(2*2=4) - 其 detach = 10 + 0 = 10 (因 detach 抵消梯度但值上 =10+4-4=10)
-        self.assertAlmostEqual(float(out.numpy()), 10.0, places=4)
+        self.assertAlmostEqual(float(out.numpy()), 14.0, places=4)
         # tracker 填充
         self.assertIn("mtp_1_loss", cls.mtp_loss_tracker)
         self.assertIn("mtp_2_loss", cls.mtp_loss_tracker)
@@ -135,7 +135,7 @@ class TestMainLanguageLoss(unittest.TestCase):
             {"mtp_loss": mtp_loss, "logits": paddle.zeros([1, 4, 8])}, labels
         )
         # lm=0, add loss-detach -> 数值 = 0
-        self.assertAlmostEqual(float(out.numpy()), 0.0, places=4)
+        self.assertAlmostEqual(float(out.numpy()), 4.0, places=4)
         layer._forward.assert_not_called()
 
     def test_forward_without_add_mtp_loss(self):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
原始行为
add_mtp_loss=false:  total_loss = lm_loss
add_mtp_loss=true:  total_loss = lm_loss + mtp_loss - mtp_loss.detach()

合入本PR后
add_mtp_loss=false:  total_loss = lm_loss + mtp_loss - mtp_loss.detach()
add_mtp_loss=true:  total_loss = lm_loss + mtp_loss
### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
是

影响所有开MTP的模型