### PR TITLE
[Devs] fix coverage path mapping in CI

### DIFF
--- a/.github/workflows/Test-release.yml
+++ b/.github/workflows/Test-release.yml
@@ -1466,9 +1466,6 @@ jobs:
                 filename="${config%%:*}"
                 filepath="${config#*:}"
                 wget "${base_url}/${filepath}" -O "$filename" --no-proxy
-                sed -i "s|<source></source>|<source>paddlefleet</source>|" "$filename"
-                sed -i "s|/usr/local/lib/python3.12/site-packages/|src/|" "$filename"
-                sed -i "s|.usr.local.lib.python3.12.site-packages|src|" "$filename"
             fi
           done
           git diff origin/${{ github.event.pull_request.base.ref }}...HEAD  --unified=0 > diff.txt

--- a/ci/.coveragerc
+++ b/ci/.coveragerc
@@ -6,3 +6,8 @@ patch = subprocess
 parallel = True
 omit =
     **/sonicmoe/**
+
+[paths]
+source =
+    src/paddlefleet
+    */site-packages/paddlefleet


### PR DESCRIPTION
### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library  | Environment Adaptation ] -->
Execute Infrastructure
### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Devs
### Description
<!-- Describe what you've done -->
移除 `.github/workflows/Test-release.yml` 中通过 `sed` 手动修改覆盖率 XML 路径的三条命令（`<source>` 标签注入、site-packages 路径替换），改为在 `ci/.coveragerc` 中增加 `[paths]` section，配置 `src/paddlefleet` 与 `*/site-packages/paddlefleet` 的路径映射，使用 coverage.py 的标准机制合并不同安装位置的覆盖率数据。

