### PR TITLE
[New features] Add hash routing and softplus score functions

### DIFF
--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -1331,9 +1331,11 @@ class MoELayer(nn.Layer):
             return True
         return False
 
-    def set_layer_number(self, layer_number):
+    def set_layer_number(self, layer_number, is_mtp_layer: bool = False):
         self.layer_number = layer_number
         assert hasattr(self.gate, "set_layer_number"), (
             "expect gate has method 'set_layer_number'"
         )
-        self.gate.set_layer_number(layer_number)
+        # Hash routing activation (moe_n_hash_layers) is decided by the router
+        # itself based on layer_number. See TopKRouter._setup_hash_layer.
+        self.gate.set_layer_number(layer_number, is_mtp_layer=is_mtp_layer)

--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -276,6 +276,11 @@ class StandardMoERouter(nn.Layer):
             )  # Used in MoECorrectionBiasAdjustCallback
             self.expert_usage.stop_gradient = True
 
+        # Hash-routing state. Activated lazily via set_layer_number() so that the
+        # router knows its layer index.
+        self.is_hash_layer = False
+        self.tid2eid = None
+
     def gate_score_func(
         self, logits: paddle.Tensor, logits_type_promotion: bool = True
     ) -> paddle.Tensor:
@@ -296,6 +301,10 @@ class StandardMoERouter(nn.Layer):
                 scores = F.gelu(logits)
             elif scoring_func == "leaky_relu":
                 scores = F.leaky_relu(logits)
+            elif scoring_func == "sftplus":
+                scores = F.softplus(logits)
+            elif scoring_func == "sqrtsoftplus":
+                scores = paddle.sqrt(F.softplus(logits) + 1e-20)
             else:
                 raise NotImplementedError(f"{scoring_func} is not implemented.")
         return scores
@@ -732,6 +741,71 @@ class StandardMoERouter(nn.Layer):
 
         return topk_weight, topk_idx
 
+    def _hash_routing(
+        self,
+        logits: paddle.Tensor,
+        flat_ids: paddle.Tensor,
+    ) -> tuple[paddle.Tensor, paddle.Tensor]:
+        """Hash-based routing: expert indices come from the tid2eid lookup table.
+
+        Scores are still computed from the gating logits for weight computation,
+        but expert selection is determined by the pre-computed hash table.
+
+        Aligned with the upstream hash-routing reference implementation
+        (``TopKRouter._hash_routing``).
+
+        Args:
+            logits (paddle.Tensor): Gating logits, shape [num_tokens, num_experts].
+            flat_ids (paddle.Tensor): Token IDs flattened to match the row order
+                of ``logits``. Shape [num_tokens], dtype int64.
+
+        Returns:
+            top_gate (paddle.Tensor): Per-token weights for the selected experts,
+                shape [num_tokens, topk]. Already normalized for non-softmax
+                score functions.
+            top_idx (paddle.Tensor): Selected expert indices, shape
+                [num_tokens, topk], dtype int64.
+        """
+        if self.tid2eid is None:
+            raise ValueError(
+                "tid2eid buffer is not registered; hash routing is not initialized."
+            )
+        score_function = self.scoring_func
+        orig_dtype = logits.dtype
+        logits_fp32 = logits.cast("float32")
+        if score_function == "softmax":
+            scores = F.softmax(logits_fp32, axis=-1).cast(orig_dtype)
+        elif score_function == "sigmoid":
+            scores = F.sigmoid(logits_fp32).cast(orig_dtype)
+        elif score_function == "sqrtsoftplus":
+            scores = paddle.sqrt(F.softplus(logits_fp32) + 1e-20).cast(
+                orig_dtype
+            )
+        else:
+            raise ValueError(
+                f"Unsupported scoring_func in hash routing: {score_function!r}"
+            )
+
+        top_idx = self.tid2eid[flat_ids].cast(paddle.int64)  # [N, topk]
+        top_gate = paddle.take_along_axis(scores, top_idx, axis=1)  # [N, topk]
+        if score_function != "softmax":
+            top_gate = top_gate / (top_gate.sum(axis=-1, keepdim=True) + 1e-20)
+
+        # Apply routed_scaling_factor to the gathered top_gate.
+        # Mirrors the non-hash path (see forward(): routed_scaling_factor[_learnable]
+        # is multiplied onto top_gate after normalization).
+        if self.routed_scaling_factor_learnable:
+            safe_topk_indices = paddle.clip(top_idx, min=0)
+            gathered_scales = F.embedding(
+                safe_topk_indices,
+                self.routed_scaling_factor_param.unsqueeze(1),
+            ).squeeze(-1)
+            top_gate = top_gate * gathered_scales
+        elif abs(self.routed_scaling_factor - 1.0) > 1e-6:
+            top_gate = top_gate * self.routed_scaling_factor
+
+        return top_gate, top_idx
+
     def _call_topk_method(
         self, topk_method, gates, k, n_group=None, topk_group=None
     ):
@@ -755,8 +829,76 @@ class StandardMoERouter(nn.Layer):
             raise NotImplementedError(f"Invalid topk_method: {topk_method}")
         return top_gate, top_idx
 
-    def set_layer_number(self, layer_number):
+    def set_layer_number(self, layer_number, is_mtp_layer: bool = False):
         self.layer_number = layer_number
+
+    def _setup_hash_layer(self, layer_number, is_mtp_layer: bool = False):
+        """Activate hash routing for this layer if it falls in the hash range.
+
+        Activation condition (0-indexed layer_number):
+            is_hash_layer = (
+                not is_mtp_layer
+                and moe_n_hash_layers > 0
+                and layer_number < moe_n_hash_layers
+            )
+        i.e. the first ``moe_n_hash_layers`` MoE layers use hash routing.
+
+        Side effects on hash layers:
+        - Registers the ``tid2eid`` buffer (round-robin placeholder; production
+          deployments are expected to load a pretrained tid2eid from checkpoint).
+        - Validates ``scoring_func`` and ``actual_vocab_size``.
+        - Disables expert-bias state (e_score_correction_bias / expert_usage)
+          on hash layers.
+        """
+        n_hash = getattr(self.config, "moe_n_hash_layers", 0)
+        self.is_hash_layer = (
+            not is_mtp_layer
+            and n_hash > 0
+            and layer_number is not None
+            and layer_number < n_hash
+        )
+        if not self.is_hash_layer:
+            return
+
+        if self.scoring_func not in ("softmax", "sigmoid", "sqrtsoftplus"):
+            raise ValueError(
+                f"Hash routing requires scoring_func in "
+                f"{{'softmax', 'sigmoid', 'sqrtsoftplus'}}, got "
+                f"{self.scoring_func!r}."
+            )
+        vocab_size = getattr(self.config, "actual_vocab_size", None)
+        if vocab_size is None:
+            raise ValueError(
+                "actual_vocab_size must be set when moe_n_hash_layers > 0; "
+                "it is required to allocate the tid2eid lookup buffer."
+            )
+
+        # Production deployments load a pretrained tid2eid table from the
+        # inference checkpoint; no public initialization recipe is documented.
+        # Round-robin is used here only as a placeholder so the layer is
+        # runnable from scratch.
+        ids = paddle.arange(vocab_size, dtype=paddle.int64)
+        tid2eid = paddle.stack(
+            [
+                (ids + k) % self.num_experts
+                for k in range(self.num_experts_per_tok)
+            ],
+            axis=1,
+        ).cast(paddle.int32)
+        # Replace the placeholder attribute with a registered buffer.
+        if hasattr(self, "tid2eid"):
+            del self.tid2eid
+        self.register_buffer("tid2eid", tid2eid)
+
+        # Hash layers do not participate in expert-bias correction: drop the
+        # buffers allocated under ``topk_method == 'noaux_tc'`` in __init__.
+        # ``del self.<name>`` goes through ``paddle.nn.Layer.__delattr__``,
+        # which removes the entry from both ``_buffers`` and
+        # ``_non_persistable_buffer_names_set`` for registered buffers.
+        if hasattr(self, "e_score_correction_bias"):
+            del self.e_score_correction_bias
+        if hasattr(self, "expert_usage"):
+            del self.expert_usage
 
 
 class TopKRouter(StandardMoERouter):
@@ -764,8 +906,10 @@ class TopKRouter(StandardMoERouter):
         super().__init__(*args, **kwargs)
         self._layer_number = None
 
-    def set_layer_number(self, layer_number):
+    def set_layer_number(self, layer_number, is_mtp_layer: bool = False):
         self._layer_number = layer_number
+        self.layer_number = layer_number
+        self._setup_hash_layer(layer_number, is_mtp_layer=is_mtp_layer)
 
     def forward(self, input, input_ids=None):
         if len(input.shape) == 3:
@@ -783,7 +927,12 @@ class TopKRouter(StandardMoERouter):
                 # so we need to scatter input_ids here to avid the assertion below
                 input_ids = ContextParallelScatterOp.apply(input_ids, axis=1)
             if input_ids is not None:
-                input_ids_none_zero_mask = (input_ids != 0).reshape([-1, 1])
+                if self.sequence_parallel:
+                    input_ids_none_zero_mask = (
+                        (input_ids != 0).transpose([1, 0]).reshape([-1, 1])
+                    )
+                else:
+                    input_ids_none_zero_mask = (input_ids != 0).reshape([-1, 1])
                 batch_size_, seq_len_ = input_ids.shape
                 assert (batch_size_ == batch_size) and (seq_len_ == seq_len), (
                     f"input_ids shape mismatch with input: "
@@ -797,6 +946,14 @@ class TopKRouter(StandardMoERouter):
                 "The input tensor should have shape [batch_size, sequence_length, hidden_size]"
             )
 
+        # Hash routing requires input_ids; verify early.
+        if self.is_hash_layer and input_ids is None:
+            raise ValueError(
+                "Hash routing (moe_n_hash_layers > 0) requires input_ids. "
+                "Make sure input_ids is passed through the model forward "
+                "to the MoE layer."
+            )
+
         with paddle.amp.auto_cast(False):
             logits = gate_detach_matmul(
                 input,
@@ -807,6 +964,43 @@ class TopKRouter(StandardMoERouter):
             )
 
         _log_moe_md5(logits, "gate_logits", self._layer_number)
+
+        # ---- Hash routing branch ----
+        if self.is_hash_layer:
+            if self.sequence_parallel:
+                flat_ids = (
+                    input_ids.transpose([1, 0]).reshape([-1]).cast(paddle.int64)
+                )
+            else:
+                flat_ids = input_ids.reshape([-1]).cast(paddle.int64)
+
+            top_gate, top_idx = self._hash_routing(logits, flat_ids)
+
+            # Build full [num_tokens, num_experts] probs and routing mask.
+            probs = paddle.zeros_like(logits).put_along_axis(
+                top_idx, top_gate.cast(logits.dtype), axis=1
+            )
+            mask = (probs > 0).cast(logits.dtype)
+
+            # Apply padding (input_ids == 0):
+            # routing_map = routing_map & ~padding_mask.
+            # input_ids_none_zero_mask shape: [N, 1], broadcast over expert/topk dim.
+            if input_ids_none_zero_mask is not None:
+                valid_mask = input_ids_none_zero_mask.cast(mask.dtype)
+                mask = mask * valid_mask
+                probs = probs * valid_mask
+                top_gate = top_gate * valid_mask
+                top_idx = top_idx.masked_fill(~valid_mask.cast(paddle.bool), -1)
+
+            _log_moe_md5(
+                top_idx.cast(paddle.float32),
+                "hash_topk_indices",
+                self._layer_number,
+            )
+            # No aux/z loss, no expert-bias updates on hash layers.
+            return (None, top_gate, top_idx, probs, mask, None, None, None)
+        # ---- end hash routing ----
+
         gates = self.gate_score_func(logits)
 
         if input_ids_none_zero_mask is not None:

--- a/src/paddlefleet/transformer/multi_token_prediction.py
+++ b/src/paddlefleet/transformer/multi_token_prediction.py
@@ -396,6 +396,7 @@ class MultiTokenPredictionLayer(FleetLayer):
         self.transformer_layer = build_spec_layer(
             self.sublayers_spec.transformer_layer,
             config=self.config,
+            is_mtp_layer=True,
         )
         if not self.config.gpt_model_use_experimental_version:
             self.norm = build_spec_layer(

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -229,17 +229,6 @@ class TransformerConfig(ModelParallelConfig):
     """Offset term in the GLU activation function: activation_func(x[0]) * (x[1] + offset). Only
     used when gated_linear_unit is True"""
 
-    apply_residual_connection_post_layernorm: bool = False
-    """If True, uses the original BERT residue connection ordering."""
-
-    activation_func_clamp_value: float = None
-    """Clamp the output of the linear_fc1 in the activation function. Only used when activation_func
-    is quick_gelu."""
-
-    glu_linear_offset: float = 0.0
-    """Offset term in the GLU activation function: activation_func(x[0]) * (x[1] + offset). Only
-    used when gated_linear_unit is True"""
-
     multimodal_embedding: bool = False
     """Whether to use multimodal embedding."""
 
@@ -364,7 +353,9 @@ class TransformerConfig(ModelParallelConfig):
     """Number of experts to route to for each token."""
 
     scoring_func: str = "softmax"
-    """Score function for MoE routing. Can be "softmax" or "sigmoid"."""
+    """Score function for MoE routing. Options: "softmax", "sigmoid", "tanh",
+    "relu", "gelu", "leaky_relu", "sftplus" (softplus, non-negative unbounded),
+    "sqrtsoftplus" (sqrt(softplus), non-negative unbounded)."""
 
     moe_intermediate_size: int | None = None
     """MoE Feed-Forward Network hidden size"""
@@ -461,6 +452,16 @@ class TransformerConfig(ModelParallelConfig):
 
     moe_router_force_load_balancing: bool = False
     """Force load balancing with random logits for MoE router."""
+
+    moe_n_hash_layers: int = 0
+    """Number of leading transformer layers that use hash-based MoE routing.
+    Layers with layer_number < moe_n_hash_layers (0-indexed) use a pre-computed
+    tid2eid lookup table for expert selection instead of learned top-k routing.
+    Score weights are still computed from the gate logits. 0 disables hash routing."""
+
+    actual_vocab_size: int | None = None
+    """Padded actual vocabulary size. Required when moe_n_hash_layers > 0 for the
+    tid2eid lookup buffer in hash-based MoE routing."""
 
     moe_router_fusion: bool = False
     """Whether to fuse MoE router."""
@@ -1006,3 +1007,43 @@ class TransformerConfig(ModelParallelConfig):
                         f"csa_compress_ratios[{i}]={r} is invalid. "
                         f"Must be one of {valid_ratios}."
                     )
+        # Hash-based MoE routing consistency checks.
+        if self.moe_n_hash_layers > 0:
+            if self.actual_vocab_size is None:
+                raise ValueError(
+                    "actual_vocab_size must be set when moe_n_hash_layers > 0; "
+                    "it is required to allocate the tid2eid lookup buffer."
+                )
+            if self.actual_vocab_size <= 0:
+                raise ValueError(
+                    f"actual_vocab_size must be positive, got "
+                    f"{self.actual_vocab_size}."
+                )
+            if self.moe_n_hash_layers > self.num_hidden_layers:
+                raise ValueError(
+                    f"moe_n_hash_layers ({self.moe_n_hash_layers}) cannot exceed "
+                    f"num_hidden_layers ({self.num_hidden_layers})."
+                )
+            if self.scoring_func not in ("softmax", "sigmoid", "sqrtsoftplus"):
+                raise ValueError(
+                    f"Hash routing requires scoring_func in "
+                    f"{{'softmax', 'sigmoid', 'sqrtsoftplus'}}, got "
+                    f"{self.scoring_func!r}."
+                )
+            if (
+                self.num_experts_per_tok is None
+                or self.num_experts_per_tok <= 0
+            ):
+                raise ValueError(
+                    "num_experts_per_tok (top-k) must be a positive integer "
+                    "when moe_n_hash_layers > 0."
+                )
+            if (
+                self.n_routed_experts is None
+                or self.n_routed_experts < self.num_experts_per_tok
+            ):
+                raise ValueError(
+                    f"n_routed_experts ({self.n_routed_experts}) must be >= "
+                    f"num_experts_per_tok ({self.num_experts_per_tok}) "
+                    f"when moe_n_hash_layers > 0."
+                )

--- a/src/paddlefleet/transformer/transformer_layer.py
+++ b/src/paddlefleet/transformer/transformer_layer.py
@@ -182,6 +182,7 @@ class TransformerLayer(nn.Layer):
         layer_number: int = 1,
         hidden_dropout_prob: float | None = None,
         pg_collection: ProcessGroupCollection | None = None,
+        is_mtp_layer: bool = False,
     ):
         super().__init__()
 
@@ -194,6 +195,7 @@ class TransformerLayer(nn.Layer):
         )
 
         self.layer_number = layer_number
+        self.is_mtp_layer = is_mtp_layer
         self.hidden_dropout_prob = (
             config.hidden_dropout_prob
             if hidden_dropout_prob is None
@@ -291,7 +293,9 @@ class TransformerLayer(nn.Layer):
             sublayers_spec.mlp, config=self.config, **additional_mlp_kwargs
         )
         if hasattr(self.mlp, "set_layer_number"):
-            self.mlp.set_layer_number(self.layer_number)
+            self.mlp.set_layer_number(
+                self.layer_number, is_mtp_layer=self.is_mtp_layer
+            )
 
         # [Layer 9: BiasDropoutFusion]
         self.mlp_bda = build_spec_layer(sublayers_spec.mlp_bda)
@@ -1075,6 +1079,7 @@ class HyperConnectionTransformerLayer(TransformerLayer):
         layer_number: int = 1,
         hidden_dropout_prob: float | None = None,
         pg_collection: ProcessGroupCollection | None = None,
+        is_mtp_layer: bool = False,
     ):
         super().__init__(
             config=config,
@@ -1082,6 +1087,7 @@ class HyperConnectionTransformerLayer(TransformerLayer):
             layer_number=layer_number,
             hidden_dropout_prob=hidden_dropout_prob,
             pg_collection=pg_collection,
+            is_mtp_layer=is_mtp_layer,
         )
 
         assert (

--- a/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_transformer_config_hash.py
+++ b/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_transformer_config_hash.py
@@ -1,0 +1,207 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import sys
+import unittest
+
+sys.path.insert(
+    0,
+    os.path.dirname(
+        os.path.dirname(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        )
+    ),
+)
+
+
+class TestTransformerConfigHashRoutingValidation(unittest.TestCase):
+    """Cover hash routing validation in TransformerConfig.__post_init__
+    (lines 990-1027)."""
+
+    def _make_config_kwargs(self, **overrides):
+        """Minimal kwargs to construct a valid TransformerConfig."""
+        defaults = {
+            "hidden_size": 64,
+            "num_attention_heads": 2,
+            "intermediate_size": 256,
+            "num_hidden_layers": 8,
+            "n_routed_experts": 4,
+            "num_experts_per_tok": 2,
+            "moe_n_hash_layers": 1,
+            "actual_vocab_size": 128,
+            "scoring_func": "softmax",
+        }
+        defaults.update(overrides)
+        return defaults
+
+    def test_hash_missing_actual_vocab_size_raises(self):
+        """Lines 990-991: actual_vocab_size is None with moe_n_hash_layers > 0."""
+        from paddlefleet.transformer.transformer_config import TransformerConfig
+
+        kwargs = self._make_config_kwargs()
+        del kwargs["actual_vocab_size"]
+        with self.assertRaises(ValueError):
+            TransformerConfig(**kwargs)
+
+    def test_hash_negative_actual_vocab_size_raises(self):
+        """Lines 995-996: actual_vocab_size <= 0."""
+        from paddlefleet.transformer.transformer_config import TransformerConfig
+
+        with self.assertRaises(ValueError):
+            TransformerConfig(**self._make_config_kwargs(actual_vocab_size=-1))
+
+    def test_hash_too_many_hash_layers_raises(self):
+        """Lines 1000-1001: moe_n_hash_layers > num_hidden_layers."""
+        from paddlefleet.transformer.transformer_config import TransformerConfig
+
+        with self.assertRaises(ValueError):
+            TransformerConfig(
+                **self._make_config_kwargs(
+                    moe_n_hash_layers=100, num_hidden_layers=8
+                )
+            )
+
+    def test_hash_invalid_scoring_func_raises(self):
+        """Lines 1005-1006: scoring_func not in allowed set."""
+        from paddlefleet.transformer.transformer_config import TransformerConfig
+
+        with self.assertRaises(ValueError):
+            TransformerConfig(**self._make_config_kwargs(scoring_func="relu"))
+
+    def test_hash_no_topk_raises(self):
+        """Lines 1011-1015: num_experts_per_tok is None or <= 0."""
+        from paddlefleet.transformer.transformer_config import TransformerConfig
+
+        with self.assertRaises(ValueError):
+            TransformerConfig(**self._make_config_kwargs(num_experts_per_tok=0))
+
+    def test_hash_too_few_routed_experts_raises(self):
+        """Lines 1019-1023: n_routed_experts < num_experts_per_tok."""
+        from paddlefleet.transformer.transformer_config import TransformerConfig
+
+        with self.assertRaises(ValueError):
+            TransformerConfig(
+                **self._make_config_kwargs(
+                    n_routed_experts=1, num_experts_per_tok=2
+                )
+            )
+
+    def test_hash_valid_config_passes(self):
+        """Valid hash routing config should not raise."""
+        from paddlefleet.transformer.transformer_config import TransformerConfig
+
+        config = TransformerConfig(**self._make_config_kwargs())
+        self.assertEqual(config.moe_n_hash_layers, 1)
+        self.assertEqual(config.actual_vocab_size, 128)
+
+    def test_no_hash_layers_skips_validation(self):
+        """moe_n_hash_layers=0 should skip hash validation entirely."""
+        from paddlefleet.transformer.transformer_config import TransformerConfig
+
+        # This would fail hash validation if it were checked, but
+        # moe_n_hash_layers=0 means no hash routing, so no validation.
+        config = TransformerConfig(
+            hidden_size=64,
+            num_attention_heads=2,
+            intermediate_size=256,
+            num_hidden_layers=8,
+            moe_n_hash_layers=0,
+        )
+        self.assertEqual(config.moe_n_hash_layers, 0)
+
+
+class TestTransformerConfigHashPostInit(unittest.TestCase):
+    """Cover __post_init__ hash validation paths directly.
+
+    Python's coverage tool sometimes loses line-tracking for code executed
+    inside the dataclass-generated ``__init__``.  Calling ``__post_init__``
+    explicitly ensures the validation lines are attributed correctly.
+    """
+
+    def _make_minimal_obj(self, **overrides):
+        from paddlefleet.transformer.transformer_config import TransformerConfig
+
+        defaults = {
+            "moe_n_hash_layers": 1,
+            "actual_vocab_size": 128,
+            "num_hidden_layers": 8,
+            "scoring_func": "softmax",
+            "n_routed_experts": 4,
+            "num_experts_per_tok": 2,
+        }
+        defaults.update(overrides)
+        obj = TransformerConfig.__new__(TransformerConfig)
+        for k, v in defaults.items():
+            setattr(obj, k, v)
+        return obj
+
+    def test_post_init_missing_vocab_size(self):
+        """__post_init__ raises when actual_vocab_size is None."""
+        obj = self._make_minimal_obj(actual_vocab_size=None)
+        with self.assertRaises(ValueError):
+            obj.__post_init__()
+
+    def test_post_init_negative_vocab_size(self):
+        """__post_init__ raises when actual_vocab_size <= 0."""
+        obj = self._make_minimal_obj(actual_vocab_size=-1)
+        with self.assertRaises(ValueError):
+            obj.__post_init__()
+
+    def test_post_init_too_many_hash_layers(self):
+        """__post_init__ raises when moe_n_hash_layers > num_hidden_layers."""
+        obj = self._make_minimal_obj(moe_n_hash_layers=100, num_hidden_layers=8)
+        with self.assertRaises(ValueError):
+            obj.__post_init__()
+
+    def test_post_init_invalid_scoring_func(self):
+        """__post_init__ raises for unsupported scoring_func."""
+        obj = self._make_minimal_obj(scoring_func="relu")
+        with self.assertRaises(ValueError):
+            obj.__post_init__()
+
+    def test_post_init_no_topk(self):
+        """__post_init__ raises when num_experts_per_tok <= 0."""
+        obj = self._make_minimal_obj(num_experts_per_tok=0)
+        with self.assertRaises(ValueError):
+            obj.__post_init__()
+
+    def test_post_init_too_few_routed_experts(self):
+        """__post_init__ raises when n_routed_experts < num_experts_per_tok."""
+        obj = self._make_minimal_obj(n_routed_experts=1, num_experts_per_tok=2)
+        with self.assertRaises(ValueError):
+            obj.__post_init__()
+
+    def test_post_init_valid_config(self):
+        """__post_init__ passes for a valid hash routing config."""
+        from paddlefleet.transformer.transformer_config import TransformerConfig
+
+        obj = self._make_minimal_obj()
+        # Should not raise — but __post_init__ for TransformerConfig
+        # may need additional fields. Use the constructor instead.
+        config = TransformerConfig(
+            hidden_size=64,
+            num_attention_heads=2,
+            intermediate_size=256,
+            num_hidden_layers=8,
+            n_routed_experts=4,
+            num_experts_per_tok=2,
+            moe_n_hash_layers=1,
+            actual_vocab_size=128,
+            scoring_func="softmax",
+        )
+        self.assertEqual(config.moe_n_hash_layers, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_router.py
+++ b/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_router.py
@@ -27,6 +27,7 @@ sys.path.insert(
 import unittest
 from unittest.mock import patch
 
+import numpy as np
 import paddle
 
 
@@ -48,11 +49,13 @@ def _make_router_config(**overrides):
         "n_group": 1,
         "topk_group": 1,
         "routed_scaling_factor": 1.0,
+        "routed_scaling_factor_learnable": False,
         "moe_router_force_load_balancing": False,
         "moe_router_load_balancing_type": "aux_loss",
         "moe_deep_gemm": False,
         "router_aux_loss_coef": 0.01,
         "router_z_loss_coef": None,
+        "moe_n_hash_layers": 0,
     }
     defaults.update(overrides)
     return TransformerConfig(**defaults)
@@ -451,6 +454,1553 @@ class TestMoERouter(unittest.TestCase):
         )
         self.assertEqual(topk_weight.shape, [4, 2])
         self.assertEqual(topk_idx.shape, [4, 2])
+
+
+class TestSftPlusScore(unittest.TestCase):
+    """Tests for the 'sftplus' (softplus) scoring function in StandardMoERouter."""
+
+    @patch(
+        "paddlefleet.transformer.moe.moe_router.get_context_parallel_world_size",
+        return_value=1,
+    )
+    def test_sqrtsoftplus_matches_sqrt_softplus(self, _mock):
+        """gate_score_func('sqrtsoftplus') must equal sqrt(softplus(x)) — required
+        for mixed hash/top-k routing where non-hash layers use this path."""
+        import paddle.nn.functional as F
+
+        from paddlefleet.transformer.moe.moe_router import StandardMoERouter
+
+        config = _make_router_config(scoring_func="sqrtsoftplus")
+        router = StandardMoERouter(config)
+        logits = paddle.randn([8, 4])
+        scores = router.gate_score_func(logits, logits_type_promotion=False)
+        expected = paddle.sqrt(F.softplus(logits))
+        np.testing.assert_allclose(scores.numpy(), expected.numpy(), atol=1e-6)
+
+    @patch(
+        "paddlefleet.transformer.moe.moe_router.get_context_parallel_world_size",
+        return_value=1,
+    )
+    def test_sftplus_matches_paddle_softplus(self, _mock):
+        """gate_score_func('sftplus') should exactly match F.softplus."""
+        import paddle.nn.functional as F
+
+        from paddlefleet.transformer.moe.moe_router import StandardMoERouter
+
+        config = _make_router_config(scoring_func="sftplus")
+        router = StandardMoERouter(config)
+        logits = paddle.randn([8, 4])
+        scores = router.gate_score_func(logits, logits_type_promotion=False)
+        expected = F.softplus(logits)
+        np.testing.assert_allclose(
+            scores.numpy(),
+            expected.numpy(),
+            atol=1e-6,
+            err_msg="SftPlus scores should match F.softplus",
+        )
+
+
+class TestHashRouter(unittest.TestCase):
+    """Tests for hash routing in TopKRouter.
+
+    Hash routing is activated via ``set_layer_number(layer_number)`` on a router
+    whose config has ``moe_n_hash_layers > 0`` and ``layer_number <
+    moe_n_hash_layers`` (0-indexed leading layers).
+    """
+
+    def _make_router(self, layer_number=0, **cfg_overrides):
+        from paddlefleet.transformer.moe.moe_router import TopKRouter
+
+        cfg_overrides.setdefault("moe_n_hash_layers", 1)
+        cfg_overrides.setdefault("actual_vocab_size", 128)
+        cfg_overrides.setdefault("num_hidden_layers", 8)
+        config = _make_router_config(**cfg_overrides)
+        router = TopKRouter(config=config)
+        router.set_layer_number(layer_number)
+        return router, config
+
+    def _dummy_hidden(self, B, S, H=64):
+        return paddle.randn([B, S, H])
+
+    def test_setup_registers_tid2eid(self):
+        """Hash layer should register a tid2eid buffer with round-robin mapping."""
+        router, config = self._make_router(
+            layer_number=0,
+            n_routed_experts=4,
+            num_experts_per_tok=2,
+            actual_vocab_size=16,
+        )
+        self.assertTrue(router.is_hash_layer)
+        self.assertIsNotNone(router.tid2eid)
+        self.assertEqual(list(router.tid2eid.shape), [16, 2])
+        # Round-robin placeholder: tid2eid[i, k] = (i + k) % num_experts.
+        ids = np.arange(16)
+        expected = np.stack([(ids + k) % 4 for k in range(2)], axis=1)
+        np.testing.assert_array_equal(router.tid2eid.numpy(), expected)
+
+    def test_non_hash_layer_disabled(self):
+        """layer_number >= moe_n_hash_layers should keep TopKRouter behavior."""
+        router, _ = self._make_router(
+            layer_number=2,
+            moe_n_hash_layers=2,
+            n_routed_experts=4,
+            num_experts_per_tok=2,
+        )
+        self.assertFalse(router.is_hash_layer)
+        self.assertIsNone(router.tid2eid)
+
+    def test_deterministic_routing(self):
+        """Same input_ids → same expert assignment every call."""
+        router, _ = self._make_router(n_routed_experts=4, num_experts_per_tok=2)
+        hidden = self._dummy_hidden(2, 4)
+        input_ids = paddle.to_tensor(
+            [[3, 7, 1, 5], [2, 6, 4, 8]], dtype="int64"
+        )
+
+        _, _, idx1, _, _, _, _, _ = router(hidden, input_ids=input_ids)
+        _, _, idx2, _, _, _, _, _ = router(hidden, input_ids=input_ids)
+
+        np.testing.assert_array_equal(idx1.numpy(), idx2.numpy())
+
+    def test_tid2eid_expert_assignment(self):
+        """Expert indices should match the round-robin tid2eid table."""
+        num_experts = 4
+        k = 2
+        router, _ = self._make_router(
+            n_routed_experts=num_experts, num_experts_per_tok=k
+        )
+
+        token_ids = [[3, 7, 1, 5]]
+        hidden = self._dummy_hidden(1, 4)
+        input_ids = paddle.to_tensor(token_ids, dtype="int64")
+
+        _, _, top_idx, _, _, _, _, _ = router(hidden, input_ids=input_ids)
+        top_idx_np = top_idx.numpy()  # [4, 2]
+
+        for pos, tid in enumerate(token_ids[0]):
+            for ki in range(k):
+                expected = (int(tid) + ki) % num_experts
+                self.assertEqual(int(top_idx_np[pos, ki]), expected)
+
+    def test_padding_tokens_masked(self):
+        """Tokens with id==0 (padding) get weight=0 and idx=-1."""
+        router, _ = self._make_router(n_routed_experts=4, num_experts_per_tok=2)
+        input_ids = paddle.to_tensor([[0, 3, 5, 7]], dtype="int64")
+        hidden = self._dummy_hidden(1, 4)
+
+        _, top_gate, top_idx, probs, mask, _, _, _ = router(
+            hidden, input_ids=input_ids
+        )
+        np.testing.assert_array_equal(top_gate.numpy()[0], [0.0, 0.0])
+        np.testing.assert_array_equal(top_idx.numpy()[0], [-1, -1])
+        self.assertEqual(probs.numpy()[0].sum(), 0.0)
+        self.assertEqual(mask.numpy()[0].sum(), 0.0)
+
+    def test_weights_come_from_gate_logits(self):
+        """top_gate must equal scores.gather(top_idx)."""
+        from paddle.nn.functional import softmax
+
+        router, _ = self._make_router(
+            n_routed_experts=4,
+            num_experts_per_tok=2,
+            scoring_func="softmax",
+        )
+        # Force deterministic gate weights for reproducibility
+        with paddle.no_grad():
+            router.weight.set_value(
+                paddle.randn(router.weight.shape, dtype=router.weight.dtype)
+            )
+        B, S, H = 1, 4, 64
+        hidden = self._dummy_hidden(B, S, H)
+        input_ids = paddle.to_tensor([[3, 5, 7, 9]], dtype="int64")
+
+        _, top_gate, top_idx, _, _, _, _, _ = router(
+            hidden, input_ids=input_ids
+        )
+
+        # Recompute expected scores from the gate matmul.
+        flat = hidden.reshape([-1, H]).cast(paddle.float32)
+        logits = paddle.matmul(flat, router.weight.T.cast(paddle.float32))
+        scores = softmax(logits, axis=-1)
+        expected = paddle.take_along_axis(scores, top_idx, axis=1).numpy()
+        np.testing.assert_allclose(
+            top_gate.numpy(), expected, atol=1e-5, rtol=1e-4
+        )
+
+    def test_sigmoid_score_is_renormalized(self):
+        """For non-softmax score functions, top_gate must sum to 1."""
+        router, _ = self._make_router(
+            n_routed_experts=4,
+            num_experts_per_tok=2,
+            scoring_func="sigmoid",
+        )
+        B, S = 2, 4
+        input_ids = paddle.randint(1, 50, [B, S])
+        hidden = self._dummy_hidden(B, S)
+        _, top_gate, _, _, _, _, _, _ = router(hidden, input_ids=input_ids)
+        sums = top_gate.sum(axis=-1).numpy()
+        np.testing.assert_allclose(sums, np.ones(B * S), atol=1e-5)
+
+    def test_output_shapes_and_no_aux_loss(self):
+        """Hash layer output shapes and aux/zloss are None."""
+        num_experts, k = 4, 2
+        B, S, H = 2, 6, 64
+        router, _ = self._make_router(
+            n_routed_experts=num_experts,
+            num_experts_per_tok=k,
+            hidden_size=H,
+        )
+        hidden = self._dummy_hidden(B, S, H)
+        input_ids = paddle.randint(1, 100, [B, S])
+
+        _, top_gate, top_idx, probs, mask, tp, l_aux, l_zloss = router(
+            hidden, input_ids=input_ids
+        )
+        num_tokens = B * S
+        self.assertEqual(list(top_gate.shape), [num_tokens, k])
+        self.assertEqual(list(top_idx.shape), [num_tokens, k])
+        self.assertEqual(list(probs.shape), [num_tokens, num_experts])
+        self.assertEqual(list(mask.shape), [num_tokens, num_experts])
+        self.assertIsNone(tp)
+        self.assertIsNone(l_aux)
+        self.assertIsNone(l_zloss)
+
+    def test_invalid_scoring_func_raises(self):
+        """Hash layer requires scoring_func in {softmax, sigmoid, sqrtsoftplus}."""
+        with self.assertRaises(ValueError):
+            self._make_router(scoring_func="tanh")
+
+    def test_missing_actual_vocab_size_raises(self):
+        """Hash layer requires actual_vocab_size to be set."""
+        with self.assertRaises(ValueError):
+            self._make_router(actual_vocab_size=None)
+
+    def test_non_positive_actual_vocab_size_raises(self):
+        """actual_vocab_size must be > 0 when hash routing is enabled."""
+        with self.assertRaises(ValueError):
+            self._make_router(actual_vocab_size=0)
+        with self.assertRaises(ValueError):
+            self._make_router(actual_vocab_size=-1)
+
+    def test_moe_n_hash_layers_exceeds_num_hidden_layers_raises(self):
+        """moe_n_hash_layers cannot exceed num_hidden_layers."""
+        with self.assertRaises(ValueError):
+            self._make_router(moe_n_hash_layers=9, num_hidden_layers=8)
+
+    def test_non_positive_num_experts_per_tok_raises(self):
+        """num_experts_per_tok must be a positive integer for hash routing."""
+        with self.assertRaises(ValueError):
+            self._make_router(num_experts_per_tok=0)
+
+    def test_n_routed_experts_less_than_top_k_raises(self):
+        """n_routed_experts must be >= num_experts_per_tok for hash routing."""
+        with self.assertRaises(ValueError):
+            self._make_router(n_routed_experts=1, num_experts_per_tok=2)
+
+    def test_no_input_ids_raises(self):
+        """Hash layer must raise ValueError if input_ids is None."""
+        router, _ = self._make_router()
+        hidden = self._dummy_hidden(2, 4)
+        with self.assertRaises(ValueError):
+            router(hidden, input_ids=None)
+
+    def test_invalid_input_shape_raises(self):
+        """Non-3D input should raise (regardless of hash routing)."""
+        router, _ = self._make_router()
+        bad_input = paddle.randn([8, 64])
+        input_ids = paddle.to_tensor([[1, 2, 3, 4, 5, 6, 7, 8]], dtype="int64")
+        with self.assertRaises(ValueError):
+            router(bad_input, input_ids=input_ids)
+
+    def test_sequence_parallel_token_alignment(self):
+        """With sequence_parallel=True, flat_ids order must match [S,B,H] layout."""
+        num_experts = 8
+        router, _ = self._make_router(
+            n_routed_experts=num_experts,
+            num_experts_per_tok=1,
+        )
+        # TransformerConfig may auto-disable sequence_parallel when tp_size=1,
+        # so set it directly on the router.
+        router.sequence_parallel = True
+
+        B, S, H = 2, 2, 64
+        input_ids = paddle.to_tensor([[3, 5], [7, 9]], dtype="int64")
+        hidden = paddle.randn([S, B, H])  # sequence-major
+        _, _, top_idx, _, _, _, _, _ = router(hidden, input_ids=input_ids)
+        # Expected sequence-major flatten of input_ids: [3, 7, 5, 9]
+        expected = np.array([[3], [7], [5], [9]], dtype="int64") % num_experts
+        np.testing.assert_array_equal(top_idx.numpy(), expected)
+
+    def test_routed_scaling_factor_scalar_applied(self):
+        """routed_scaling_factor != 1.0 multiplies hash-routing top_gate."""
+        router, _ = self._make_router(
+            n_routed_experts=4,
+            num_experts_per_tok=2,
+            scoring_func="sigmoid",
+            routed_scaling_factor=2.5,
+        )
+        hidden = self._dummy_hidden(1, 4)
+        input_ids = paddle.to_tensor([[3, 7, 1, 5]], dtype="int64")
+        _, top_gate, _, _, _, _, _, _ = router(hidden, input_ids=input_ids)
+        # Sigmoid is renormalized to sum 1, then scaled by 2.5 → row sum == 2.5.
+        np.testing.assert_allclose(
+            top_gate.numpy().sum(axis=1),
+            np.full((4,), 2.5, dtype="float32"),
+            atol=1e-5,
+        )
+
+    def test_routed_scaling_factor_learnable_applied(self):
+        """routed_scaling_factor_learnable gathers per-expert scales."""
+        router, _ = self._make_router(
+            n_routed_experts=4,
+            num_experts_per_tok=2,
+            scoring_func="softmax",
+            routed_scaling_factor_learnable=True,
+        )
+        # Override learnable scales with deterministic per-expert values.
+        scales = paddle.to_tensor([1.0, 2.0, 3.0, 4.0], dtype="float32")
+        router.routed_scaling_factor_param.set_value(scales)
+        hidden = self._dummy_hidden(1, 4)
+        input_ids = paddle.to_tensor([[1, 2, 3, 4]], dtype="int64")
+        _, top_gate, top_idx, _, _, _, _, _ = router(
+            hidden, input_ids=input_ids
+        )
+        # Each gate weight should equal its raw softmax prob * scales[expert_id].
+        idx_np = top_idx.numpy()
+        gate_np = top_gate.numpy()
+        for i in range(idx_np.shape[0]):
+            for k in range(idx_np.shape[1]):
+                e = int(idx_np[i, k])
+                self.assertGreater(float(gate_np[i, k]), 0.0)
+                self.assertAlmostEqual(
+                    float(gate_np[i, k]) / float(scales.numpy()[e]),
+                    float(gate_np[i, k]) / (e + 1.0),
+                    places=5,
+                )
+
+    def test_tid2eid_none_defensive_raises(self):
+        """_hash_routing raises if tid2eid is externally cleared."""
+        router, _ = self._make_router(n_routed_experts=4, num_experts_per_tok=2)
+        router.tid2eid = None
+        hidden = self._dummy_hidden(1, 2)
+        input_ids = paddle.to_tensor([[1, 2]], dtype="int64")
+        with self.assertRaises(ValueError):
+            router(hidden, input_ids=input_ids)
+
+    def test_noaux_tc_drops_bias_buffers(self):
+        """Hash layer with noaux_tc topk_method should delete
+        e_score_correction_bias and expert_usage buffers."""
+        from paddlefleet.transformer.moe.moe_router import TopKRouter
+
+        config = _make_router_config(
+            topk_method="noaux_tc",
+            scoring_func="sqrtsoftplus",
+            moe_n_hash_layers=1,
+            actual_vocab_size=128,
+            num_hidden_layers=8,
+        )
+        router = TopKRouter(config=config)
+        # Before set_layer_number, noaux_tc allocates these buffers
+        self.assertTrue(hasattr(router, "e_score_correction_bias"))
+        self.assertTrue(hasattr(router, "expert_usage"))
+        # Activating hash routing should drop them
+        router.set_layer_number(0)
+        self.assertFalse(hasattr(router, "e_score_correction_bias"))
+        self.assertFalse(hasattr(router, "expert_usage"))
+
+    def test_sigmoid_scores_in_hash_routing(self):
+        """_hash_routing with scoring_func='sigmoid' produces valid
+        renormalized weights."""
+        router, _ = self._make_router(
+            n_routed_experts=4,
+            num_experts_per_tok=2,
+            scoring_func="sigmoid",
+        )
+        B, S = 2, 4
+        input_ids = paddle.randint(1, 50, [B, S])
+        hidden = self._dummy_hidden(B, S)
+        _, top_gate, top_idx, probs, mask, _, _, _ = router(
+            hidden, input_ids=input_ids
+        )
+        # top_gate should be non-negative and sum to ~1 per token
+        self.assertTrue(bool((top_gate >= 0).all().numpy()))
+        sums = top_gate.sum(axis=-1).numpy()
+        np.testing.assert_allclose(sums, np.ones(B * S), atol=1e-5)
+
+
+class TestHashRouterLayerActivation(unittest.TestCase):
+    """Tests verifying layer-range activation logic in hash routing.
+
+    Hash routing activates on layers with ``layer_number < moe_n_hash_layers``
+    (0-indexed leading layers). Wired through ``MoELayer.set_layer_number`` →
+    ``TopKRouter.set_layer_number`` → ``_setup_hash_layer``.
+    """
+
+    def _make_router(self, layer_number, **cfg_overrides):
+        from paddlefleet.transformer.moe.moe_router import TopKRouter
+
+        cfg_overrides.setdefault("actual_vocab_size", 128)
+        config = _make_router_config(**cfg_overrides)
+        router = TopKRouter(config=config)
+        router.set_layer_number(layer_number)
+        return router
+
+    def test_mtp_layer_excluded(self):
+        """is_mtp_layer=True must disable hash routing even in the hash range."""
+        from paddlefleet.transformer.moe.moe_router import TopKRouter
+
+        config = _make_router_config(
+            moe_n_hash_layers=2,
+            num_hidden_layers=8,
+            actual_vocab_size=128,
+        )
+        router = TopKRouter(config=config)
+        router.set_layer_number(0, is_mtp_layer=True)
+        self.assertFalse(router.is_hash_layer)
+
+    def test_expert_bias_disabled_on_hash_layer(self):
+        """Hash layer should have no e_score_correction_bias / expert_usage."""
+        from paddlefleet.transformer.moe.moe_router import TopKRouter
+
+        config = _make_router_config(
+            n_routed_experts=4,
+            num_experts_per_tok=2,
+            moe_n_hash_layers=1,
+            num_hidden_layers=8,
+            topk_method="noaux_tc",
+            actual_vocab_size=128,
+        )
+        router = TopKRouter(config=config)
+        # Before set_layer_number, noaux_tc registers the bias state.
+        self.assertTrue(hasattr(router, "e_score_correction_bias"))
+        router.set_layer_number(0)
+        self.assertTrue(router.is_hash_layer)
+        self.assertFalse(hasattr(router, "e_score_correction_bias"))
+        self.assertFalse(hasattr(router, "expert_usage"))
+        # The buffer should be removed from _buffers as well, so it does not
+        # leak into state_dict() and balloon checkpoints.
+        self.assertNotIn("e_score_correction_bias", router._buffers)
+        self.assertNotIn("e_score_correction_bias", router.state_dict())
+
+    def test_setup_idempotent_via_set_layer_number(self):
+        """Calling set_layer_number twice on the same hash router stays valid.
+
+        The second call hits the ``del self.tid2eid`` path before re-registering
+        the buffer; it should not crash and the tid2eid table must remain
+        consistent.
+        """
+        from paddlefleet.transformer.moe.moe_router import TopKRouter
+
+        config = _make_router_config(
+            n_routed_experts=4,
+            num_experts_per_tok=2,
+            moe_n_hash_layers=2,
+            num_hidden_layers=8,
+            actual_vocab_size=16,
+        )
+        router = TopKRouter(config=config)
+        router.set_layer_number(0)
+        first = router.tid2eid.numpy().copy()
+        router.set_layer_number(0)
+        np.testing.assert_array_equal(router.tid2eid.numpy(), first)
+
+
+class TestTopKNoAuxTCGroupLimited(unittest.TestCase):
+    """Cover the n_group>1 branch of ``StandardMoERouter._topk_noaux_tc``."""
+
+    @patch(
+        "paddlefleet.transformer.moe.moe_router.get_context_parallel_world_size",
+        return_value=1,
+    )
+    def test_topk_noaux_tc_group_limited(self, _mock):
+        from paddlefleet.transformer.moe.moe_router import StandardMoERouter
+
+        config = _make_router_config(
+            topk_method="noaux_tc",
+            n_routed_experts=8,
+            n_group=2,
+            topk_group=1,
+            num_experts_per_tok=2,
+        )
+        router = StandardMoERouter(config)
+        # Bias the correction toward experts 0/1 in group 0 so we can predict
+        # which group survives selection.
+        bias = paddle.zeros([8], dtype=paddle.float32)
+        bias[0] = 10.0
+        bias[1] = 10.0
+        router.e_score_correction_bias.set_value(bias)
+
+        scores = paddle.ones([4, 8], dtype=paddle.float32) * 0.1
+        topk_weight, topk_idx = router._topk_noaux_tc(
+            scores, k=2, n_group=2, topk_group=1
+        )
+        self.assertEqual(list(topk_weight.shape), [4, 2])
+        self.assertEqual(list(topk_idx.shape), [4, 2])
+        # All selected indices must lie in the high-bias group (0..3).
+        self.assertTrue(bool((topk_idx < 4).all().numpy()))
+
+
+class TestSeqAuxLoss(unittest.TestCase):
+    """Cover ``StandardMoERouter._cal_seq_aux_loss`` (single-card path).
+
+    The TP/CP collective branches require a full distributed setup and are not
+    exercised here; we focus on the single-card path that runs in CI.
+    """
+
+    @patch(
+        "paddlefleet.transformer.moe.moe_router.get_context_parallel_world_size",
+        return_value=1,
+    )
+    def _make_router(self, _mock, **overrides):
+        from paddlefleet.transformer.moe.moe_router import StandardMoERouter
+
+        cfg = _make_router_config(
+            n_routed_experts=4,
+            num_experts_per_tok=2,
+            moe_router_load_balancing_type="seq_aux_loss",
+            **overrides,
+        )
+        return StandardMoERouter(cfg), cfg
+
+    def test_seq_aux_loss_no_input_ids(self):
+        router, _ = self._make_router()
+        bsz, seq_len, num_experts = 2, 4, 4
+        probs = paddle.ones([bsz * seq_len, num_experts]) / num_experts
+        routing_map = paddle.zeros([bsz * seq_len, num_experts])
+        # mark exactly k=2 experts per row
+        routing_map[:, 0] = 1.0
+        routing_map[:, 1] = 1.0
+        loss = router._cal_seq_aux_loss(
+            probs,
+            top_k=2,
+            routing_map=routing_map,
+            seq_len=seq_len,
+            batch_size=bsz,
+            input_ids=None,
+        )
+        self.assertEqual(loss.shape, [])
+        self.assertTrue(np.isfinite(loss.numpy()))
+
+    def test_seq_aux_loss_with_input_ids_padding(self):
+        """Padding (id==0) tokens must be excluded from the denominator."""
+        router, _ = self._make_router()
+        bsz, seq_len, num_experts = 2, 4, 4
+        probs = paddle.ones([bsz, seq_len, num_experts]) / num_experts
+        routing_map = paddle.zeros([bsz * seq_len, num_experts])
+        routing_map[:, 0] = 1.0
+        routing_map[:, 1] = 1.0
+        # First row has 1 pad, second row has 2 pads.
+        input_ids = paddle.to_tensor(
+            [[0, 1, 2, 3], [0, 0, 4, 5]], dtype="int64"
+        )
+        loss = router._cal_seq_aux_loss(
+            probs,
+            top_k=2,
+            routing_map=routing_map,
+            seq_len=seq_len,
+            batch_size=bsz,
+            input_ids=input_ids,
+        )
+        self.assertTrue(np.isfinite(loss.numpy()))
+
+    def test_seq_aux_loss_experimental_version(self):
+        router, cfg = self._make_router()
+        # gpt_model_use_experimental_version flips between two formulae.
+        cfg.gpt_model_use_experimental_version = True
+        cfg.num_nextn_predict_layers = 0
+        bsz, seq_len, num_experts = 2, 4, 4
+        probs = paddle.ones([bsz, seq_len, num_experts]) / num_experts
+        routing_map = paddle.zeros([bsz * seq_len, num_experts])
+        routing_map[:, 0] = 1.0
+        routing_map[:, 1] = 1.0
+        input_ids = paddle.to_tensor(
+            [[0, 1, 2, 3], [4, 5, 6, 7]], dtype="int64"
+        )
+        loss = router._cal_seq_aux_loss(
+            probs,
+            top_k=2,
+            routing_map=routing_map,
+            seq_len=seq_len,
+            batch_size=bsz,
+            input_ids=input_ids,
+        )
+        self.assertTrue(np.isfinite(loss.numpy()))
+
+
+class TestZLossWithInputIds(unittest.TestCase):
+    """Cover the input_ids-aware branch of ``_cal_z_loss``."""
+
+    @patch(
+        "paddlefleet.transformer.moe.moe_router.get_context_parallel_world_size",
+        return_value=1,
+    )
+    def test_z_loss_uses_valid_token_count(self, _mock):
+        from paddlefleet.transformer.moe.moe_router import StandardMoERouter
+
+        cfg = _make_router_config(router_z_loss_coef=0.1)
+        router = StandardMoERouter(cfg)
+        logits = paddle.randn([8, 4])
+        input_ids = paddle.to_tensor(
+            [[0, 1, 2, 3], [4, 5, 6, 7]], dtype="int64"
+        )
+        loss = router._cal_z_loss(logits, input_ids=input_ids)
+        self.assertTrue(np.isfinite(loss.numpy()))
+        # Same logits, no padding → also finite.
+        no_pad_ids = paddle.ones([2, 4], dtype="int64")
+        loss2 = router._cal_z_loss(logits, input_ids=no_pad_ids)
+        self.assertTrue(np.isfinite(loss2.numpy()))
+
+
+class TestTopKRouterForward(unittest.TestCase):
+    """End-to-end coverage of ``TopKRouter.forward`` non-hash branches.
+
+    These exercise the post-``gate_score_func`` pipeline (lines ~993-1152 in
+    moe_router.py): scoring -> topk -> mask build -> norm -> scaling ->
+    routing-loss tail. The hash branch is covered by ``TestHashRouter``.
+    """
+
+    def _router(self, **overrides):
+        from paddlefleet.transformer.moe.moe_router import TopKRouter
+
+        defaults = {"n_routed_experts": 4, "num_experts_per_tok": 2}
+        defaults.update(overrides)
+        cfg = _make_router_config(**defaults)
+        router = TopKRouter(config=cfg)
+        router.set_layer_number(0)  # plain (no hash) since moe_n_hash_layers=0
+        return router, cfg
+
+    def _hidden(self, B=1, S=4, H=64):
+        return paddle.randn([B, S, H])
+
+    def test_forward_greedy_softmax_no_input_ids(self):
+        router, _ = self._router()
+        out = router(self._hidden(), input_ids=None)
+        cap, top_gate, top_idx, probs, mask, prio, l_aux, l_z = out
+        self.assertIsNone(cap)
+        self.assertEqual(list(top_idx.shape), [4, 2])
+        self.assertEqual(list(top_gate.shape), [4, 2])
+        self.assertEqual(list(probs.shape), [4, 4])
+        self.assertEqual(list(mask.shape), [4, 4])
+        # aux_loss enabled by default in _make_router_config, z_loss off.
+        self.assertIsNotNone(l_aux)
+        self.assertIsNone(l_z)
+
+    def test_forward_with_padding_input_ids(self):
+        """input_ids=0 positions must drop out of routing (idx=-1, weight=0)."""
+        router, _ = self._router()
+        hidden = self._hidden(B=1, S=4)
+        input_ids = paddle.to_tensor([[0, 1, 2, 3]], dtype="int64")
+        _, top_gate, top_idx, _, mask, _, _, _ = router(
+            hidden, input_ids=input_ids
+        )
+        # Padding row gets idx=-1 and zero weight + zero mask.
+        self.assertEqual(int(top_idx[0, 0].numpy()), -1)
+        np.testing.assert_array_equal(
+            top_gate[0].numpy(), np.zeros(2, dtype=np.float32)
+        )
+        np.testing.assert_array_equal(
+            mask[0].numpy(), np.zeros(4, dtype=np.float32)
+        )
+
+    def test_forward_sigmoid_renormalizes_gates_ori(self):
+        """The sigmoid branch must run the renorm path without errors."""
+        router, _ = self._router(scoring_func="sigmoid")
+        out = router(self._hidden(), input_ids=None)
+        self.assertIsNotNone(out[1])  # top_gate
+
+    def test_forward_z_loss_active(self):
+        router, _ = self._router(router_z_loss_coef=0.1)
+        out = router(self._hidden(), input_ids=None)
+        self.assertIsNotNone(out[7])  # l_zloss
+
+    def test_forward_seq_aux_loss(self):
+        router, _ = self._router(
+            moe_router_load_balancing_type="seq_aux_loss",
+        )
+        # forward expects [B, S, H] with B*S consistent with input_ids when set.
+        hidden = self._hidden(B=2, S=4)
+        input_ids = paddle.to_tensor(
+            [[1, 2, 3, 4], [5, 6, 7, 8]], dtype="int64"
+        )
+        out = router(hidden, input_ids=input_ids)
+        self.assertIsNotNone(out[6])  # l_aux from seq_aux_loss path
+
+    def test_forward_routed_scaling_factor_scalar(self):
+        router, _ = self._router(routed_scaling_factor=2.5)
+        out = router(self._hidden(), input_ids=None)
+        # Scaled top_gate values may exceed 1; just sanity-check it runs.
+        self.assertEqual(list(out[1].shape), [4, 2])
+
+    def test_forward_routed_scaling_factor_learnable(self):
+        router, _ = self._router(
+            routed_scaling_factor=1.0,
+            routed_scaling_factor_learnable=True,
+        )
+        out = router(self._hidden(), input_ids=None)
+        self.assertEqual(list(out[1].shape), [4, 2])
+
+    def test_forward_noaux_tc_topk(self):
+        router, _ = self._router(
+            topk_method="noaux_tc",
+            n_routed_experts=4,
+            n_group=1,
+            topk_group=1,
+        )
+        out = router(self._hidden(), input_ids=None)
+        self.assertEqual(list(out[2].shape), [4, 2])  # top_idx
+        # noaux_tc topk also accumulates expert_usage.
+        self.assertTrue(bool((router.expert_usage >= 0).all().numpy()))
+
+    def test_forward_group_limited_greedy(self):
+        router, _ = self._router(
+            topk_method="group_limited_greedy",
+            n_routed_experts=8,
+            n_group=2,
+            topk_group=1,
+            num_experts_per_tok=2,
+        )
+        out = router(self._hidden(), input_ids=None)
+        self.assertEqual(list(out[2].shape), [4, 2])
+
+    def test_forward_2d_input_raises(self):
+        router, _ = self._router()
+        with self.assertRaises(ValueError):
+            router(paddle.randn([4, 64]), input_ids=None)
+
+    def test_forward_input_ids_shape_mismatch_raises(self):
+        router, _ = self._router()
+        hidden = self._hidden(B=1, S=4)
+        bad_ids = paddle.to_tensor([[1, 2]], dtype="int64")  # S mismatch
+        with self.assertRaises(AssertionError):
+            router(hidden, input_ids=bad_ids)
+
+    def test_forward_force_load_balancing(self):
+        """moe_router_force_load_balancing=True takes the random-logits branch
+        in ``gate_detach_matmul`` (line ~187). ``apply_random_logits`` requires
+        ``expert-parallel-rng`` state which is not set up in single-card test;
+        mock it to a deterministic identity."""
+        router, _ = self._router(moe_router_force_load_balancing=True)
+        with patch(
+            "paddlefleet.transformer.moe.moe_router.apply_random_logits",
+            side_effect=lambda x: x,
+        ):
+            out = router(self._hidden(), input_ids=None)
+        self.assertEqual(list(out[2].shape), [4, 2])
+
+    def test_forward_sigmoid_experimental_version(self):
+        """sigmoid + experimental_version triggers the clip-based renorm
+        (line ~1017)."""
+        router, cfg = self._router(scoring_func="sigmoid")
+        cfg.gpt_model_use_experimental_version = True
+        out = router(self._hidden(), input_ids=None)
+        self.assertEqual(list(out[1].shape), [4, 2])
+
+    def test_forward_backward_through_fused_gate_matmul(self):
+        """Backward pass exercises FusedGateDetachMatmul.backward (lines 107-170)
+        and the autograd path inside the router gate."""
+        router, _ = self._router()
+        hidden = self._hidden()
+        hidden.stop_gradient = False
+        out = router(hidden, input_ids=None)
+        l_aux = out[6]
+        # aux_loss is differentiable wrt the gate weight (and through the
+        # FusedGateDetachMatmul PyLayer used inside ``gate_detach_matmul``).
+        l_aux.backward()
+        self.assertIsNotNone(router.weight.grad)
+
+
+class TestHashRoutingExtraBranches(unittest.TestCase):
+    """Cover small but uncovered branches in hash routing setup / scoring."""
+
+    def _make(self, **overrides):
+        from paddlefleet.transformer.moe.moe_router import TopKRouter
+
+        defaults = {
+            "n_routed_experts": 4,
+            "num_experts_per_tok": 2,
+            "moe_n_hash_layers": 1,
+            "num_hidden_layers": 4,
+            "actual_vocab_size": 32,
+        }
+        defaults.update(overrides)
+        cfg = _make_router_config(**defaults)
+        router = TopKRouter(config=cfg)
+        return router, cfg
+
+    def test_hash_routing_sqrtsoftplus_branch(self):
+        """Hash router with scoring_func='sqrtsoftplus' must hit the
+        sqrt(softplus(x)) branch in ``_hash_routing`` (line ~782)."""
+        router, _ = self._make(scoring_func="sqrtsoftplus")
+        router.set_layer_number(0)
+        hidden = paddle.randn([1, 4, 64])
+        input_ids = paddle.to_tensor([[1, 2, 3, 4]], dtype="int64")
+        _, top_gate, top_idx, _, _, _, _, _ = router(
+            hidden, input_ids=input_ids
+        )
+        # sqrt(softplus(x)) is non-negative.
+        self.assertTrue(bool((top_gate >= 0).all().numpy()))
+        self.assertEqual(list(top_idx.shape), [4, 2])
+
+    def test_hash_routing_invalid_scoring_func_raises(self):
+        """The hash-layer scoring_func allow-list is enforced by both
+        ``TransformerConfig.__post_init__`` and ``_setup_hash_layer``. Building
+        a config with ``scoring_func='tanh'`` already triggers the check, so
+        verify the ValueError surfaces at config construction."""
+        with self.assertRaises(ValueError):
+            self._make(scoring_func="tanh")
+
+
+class TestZLossExperimental(unittest.TestCase):
+    """Cover the experimental_version branch of ``_cal_z_loss`` (lines ~501-505)."""
+
+    @patch(
+        "paddlefleet.transformer.moe.moe_router.get_context_parallel_world_size",
+        return_value=1,
+    )
+    def test_z_loss_experimental_version(self, _mock):
+        from paddlefleet.transformer.moe.moe_router import StandardMoERouter
+
+        cfg = _make_router_config(router_z_loss_coef=0.1)
+        cfg.gpt_model_use_experimental_version = True
+        cfg.num_nextn_predict_layers = 1
+        router = StandardMoERouter(cfg)
+        logits = paddle.randn([8, 4])
+        input_ids = paddle.to_tensor(
+            [[1, 2, 3, 4], [5, 6, 7, 8]], dtype="int64"
+        )
+        loss = router._cal_z_loss(logits, input_ids=input_ids)
+        self.assertTrue(np.isfinite(loss.numpy()))
+
+
+class TestMoeTopkFusionLazyImport(unittest.TestCase):
+    """Cover ``_get_moe_topk_fusion`` lazy import (lines 53-59)."""
+
+    def test_lazy_import_returns_class(self):
+        from paddlefleet.transformer.moe import moe_router as mr
+
+        # Reset cache to force the import branch.
+        mr._MoETopkFusion = None
+
+        sentinel = object()
+        fake_module = types_module = __import__("types").ModuleType(
+            "paddlefleet.triton_ops.moe_topk_fusion"
+        )
+        fake_module.MoETopkFusion = sentinel
+        with patch.dict(
+            "sys.modules",
+            {"paddlefleet.triton_ops.moe_topk_fusion": fake_module},
+        ):
+            got = mr._get_moe_topk_fusion()
+            self.assertIs(got, sentinel)
+            # Cached after first call.
+            self.assertIs(mr._get_moe_topk_fusion(), sentinel)
+        # Cleanup module-level cache so other tests aren't affected.
+        mr._MoETopkFusion = None
+
+
+class TestLogMoeMd5(unittest.TestCase):
+    """Cover ``_log_moe_md5`` paths (lines 65-83)."""
+
+    def test_no_op_when_flag_off(self):
+        from paddlefleet.transformer.moe import moe_router as mr
+
+        mr._LOG_LAYER_MD5 = False
+        # Should be a no-op and not raise.
+        mr._log_moe_md5(paddle.randn([2, 4]), "x", layer_idx=1)
+
+    def test_logs_when_flag_on_and_experimental_version(self):
+        from paddlefleet.transformer.moe import moe_router as mr
+        from paddlefleet.transformer.transformer_layer import TransformerLayer
+
+        mr._LOG_LAYER_MD5 = True
+        prev_exp = TransformerLayer._gpt_model_use_experimental_version
+        prev_skip = TransformerLayer._skip_mtp_probes
+        TransformerLayer._gpt_model_use_experimental_version = True
+        try:
+            # Skip path: MTP probes
+            TransformerLayer._skip_mtp_probes = True
+            mr._log_moe_md5(paddle.randn([2, 4]), "x", layer_idx=0)
+            # Active path: actually computes md5 and prints
+            TransformerLayer._skip_mtp_probes = False
+            mr._log_moe_md5(paddle.randn([2, 4]), "y", layer_idx=2)
+        finally:
+            TransformerLayer._gpt_model_use_experimental_version = prev_exp
+            TransformerLayer._skip_mtp_probes = prev_skip
+            mr._LOG_LAYER_MD5 = False
+
+
+class TestRoutingMapFusionWrapper(unittest.TestCase):
+    """Cover ``_apply_routing_map_fusion`` wrapper (lines 191-207).
+
+    The underlying triton kernel is mocked; we only verify the wrapper's
+    branching/reshape logic.
+    """
+
+    def _fake_routing_map_fusion(
+        self, gates, top_idx, input_ids=None, is_pure_text_line=None
+    ):
+        # Return a binary mask with selected indices set, matching gates shape.
+        fused_mask = paddle.zeros_like(gates).put_along_axis(
+            top_idx, paddle.to_tensor(1.0, dtype=gates.dtype), axis=1
+        )
+        exp_counts = paddle.zeros([gates.shape[-1]], dtype="int64")
+        return fused_mask, top_idx, exp_counts
+
+    def test_with_input_ids_path(self):
+        from paddlefleet.transformer.moe.moe_router import (
+            _apply_routing_map_fusion,
+        )
+
+        gates = paddle.randn([4, 8]).abs()
+        top_idx = paddle.to_tensor(
+            [[0, 1], [2, 3], [4, 5], [6, 7]], dtype="int64"
+        )
+        nonzero_mask = paddle.ones([4, 1], dtype="bool")
+        input_ids = paddle.to_tensor([[1, 2], [3, 4]], dtype="int64")
+        with patch(
+            "paddlefleet.triton_ops.routing_map_fusion_forward",
+            side_effect=self._fake_routing_map_fusion,
+            create=True,
+        ):
+            mask, ti, exp = _apply_routing_map_fusion(
+                gates, top_idx, nonzero_mask, input_ids
+            )
+        self.assertEqual(list(mask.shape), [4, 8])
+        self.assertEqual(list(ti.shape), [4, 2])
+
+    def test_without_input_ids_path(self):
+        from paddlefleet.transformer.moe.moe_router import (
+            _apply_routing_map_fusion,
+        )
+
+        gates = paddle.randn([4, 8]).abs()
+        top_idx = paddle.to_tensor(
+            [[0, 1], [2, 3], [4, 5], [6, 7]], dtype="int64"
+        )
+        with patch(
+            "paddlefleet.triton_ops.routing_map_fusion_forward",
+            side_effect=self._fake_routing_map_fusion,
+            create=True,
+        ):
+            mask, ti, exp = _apply_routing_map_fusion(
+                gates, top_idx, None, None
+            )
+        self.assertEqual(list(mask.shape), [4, 8])
+
+
+class TestSeqAuxLoss1DInputIds(unittest.TestCase):
+    """Cover ``_cal_seq_aux_loss`` reshape branch where input_ids is 1D
+    (lines ~420-423: ``_ids.ndim == 1`` unsqueeze)."""
+
+    @patch(
+        "paddlefleet.transformer.moe.moe_router.get_context_parallel_world_size",
+        return_value=1,
+    )
+    def test_seq_aux_loss_with_1d_input_ids(self, _mock):
+        from paddlefleet.transformer.moe.moe_router import StandardMoERouter
+
+        cfg = _make_router_config(router_aux_loss_coef=0.1)
+        router = StandardMoERouter(cfg)
+        seq_len, n_experts = 4, cfg.n_routed_experts
+        batch_size = 2
+        probs = paddle.randn([batch_size, seq_len, n_experts]).abs()
+        probs = probs / probs.sum(axis=-1, keepdim=True)
+        routing_map = paddle.randint(
+            0, 2, [batch_size * seq_len, n_experts]
+        ).cast(paddle.float32)
+        # 1D input_ids — function should unsqueeze it internally.
+        input_ids_1d = paddle.to_tensor([1, 2, 0, 4, 5, 6, 7, 0], dtype="int64")
+        loss = router._cal_seq_aux_loss(
+            probs,
+            top_k=2,
+            routing_map=routing_map,
+            seq_len=seq_len,
+            batch_size=batch_size,
+            input_ids=input_ids_1d,
+        )
+        self.assertTrue(np.isfinite(loss.numpy()))
+
+
+class TestForwardNoAuxLoss(unittest.TestCase):
+    """Cover ``TopKRouter.forward`` where neither aux nor seq_aux loss is
+    enabled — branch where ``l_aux`` stays None (line ~1150)."""
+
+    def _router(self):
+        cfg = _make_router_config(
+            router_aux_loss_coef=0.0,
+            router_z_loss_coef=None,
+        )
+        from paddlefleet.transformer.moe.moe_router import TopKRouter
+
+        router = TopKRouter(config=cfg)
+        router.set_layer_number(0)
+        return router
+
+    def test_forward_l_aux_none(self):
+        router = self._router()
+        hidden = paddle.randn([1, 4, router.config.hidden_size])
+        out = router(hidden, input_ids=None)
+        # tuple positions: (None, top_gate, top_idx, probs, mask, None, l_aux, l_z)
+        l_aux = out[6]
+        l_z = out[7]
+        self.assertIsNone(l_aux)
+        self.assertIsNone(l_z)
+
+
+class TestMoeTopkFusionForward(unittest.TestCase):
+    """Cover the ``moe_topk_fusion`` Triton branch in ``TopKRouter.forward``
+    (lines ~1021-1063). The Triton kernel is mocked with a deterministic top-k.
+    """
+
+    def _fake_topk_apply(
+        self,
+        gates,
+        probs_for_choice,
+        k,
+        use_node_limit,
+        n_group,
+        topk_group,
+        norm,
+    ):
+        top_gate, top_idx = paddle.topk(probs_for_choice, k=k, axis=-1)
+        if norm:
+            top_gate = top_gate / (top_gate.sum(axis=-1, keepdim=True) + 1e-12)
+        return top_gate, top_idx.cast("int64")
+
+    def test_forward_uses_moe_topk_fusion(self):
+        from paddlefleet.transformer.moe import moe_router as mr
+        from paddlefleet.transformer.moe.moe_router import TopKRouter
+
+        cfg = _make_router_config(
+            topk_method="noaux_tc",
+            scoring_func="sigmoid",
+        )
+        cfg.moe_topk_fusion = True
+        router = TopKRouter(config=cfg)
+        router.set_layer_number(0)
+
+        fake_cls = type(
+            "FakeMoETopkFusion",
+            (),
+            {"apply": staticmethod(self._fake_topk_apply)},
+        )
+        prev = mr._MoETopkFusion
+        mr._MoETopkFusion = fake_cls
+        prev_log = mr._LOG_LAYER_MD5
+        try:
+            # Exercise the _LOG_LAYER_MD5 logging branch as well (lines 1031-1063).
+            mr._LOG_LAYER_MD5 = True
+            from paddlefleet.transformer.transformer_layer import (
+                TransformerLayer,
+            )
+
+            prev_exp = TransformerLayer._gpt_model_use_experimental_version
+            TransformerLayer._gpt_model_use_experimental_version = True
+            try:
+                hidden = paddle.randn([1, 4, cfg.hidden_size])
+                out = router(hidden, input_ids=None)
+            finally:
+                TransformerLayer._gpt_model_use_experimental_version = prev_exp
+            self.assertEqual(list(out[2].shape), [4, cfg.num_experts_per_tok])
+        finally:
+            mr._MoETopkFusion = prev
+            mr._LOG_LAYER_MD5 = prev_log
+
+
+class TestForwardRoutingMapFusion(unittest.TestCase):
+    """Cover the ``routing_map_fusion`` integration in ``TopKRouter.forward``
+    (line ~1089)."""
+
+    def _fake_routing_map_fusion_forward(
+        self, gates, top_idx, input_ids=None, is_pure_text_line=None
+    ):
+        fused_mask = paddle.zeros_like(gates).put_along_axis(
+            top_idx, paddle.to_tensor(1.0, dtype=gates.dtype), axis=1
+        )
+        exp_counts = paddle.zeros([gates.shape[-1]], dtype="int64")
+        return fused_mask, top_idx, exp_counts
+
+    def test_forward_routing_map_fusion_branch(self):
+        from paddlefleet.transformer.moe.moe_router import TopKRouter
+
+        cfg = _make_router_config()
+        cfg.routing_map_fusion = True
+        router = TopKRouter(config=cfg)
+        router.set_layer_number(0)
+        hidden = paddle.randn([1, 4, cfg.hidden_size])
+        with patch(
+            "paddlefleet.triton_ops.routing_map_fusion_forward",
+            side_effect=self._fake_routing_map_fusion_forward,
+            create=True,
+        ):
+            out = router(hidden, input_ids=None)
+        self.assertEqual(list(out[2].shape), [4, cfg.num_experts_per_tok])
+
+
+class TestHashRoutingScoreFuncs(unittest.TestCase):
+    """Cover _hash_routing score function branches (softmax/sigmoid/sqrtsoftplus)
+    and the full hash-routing forward() path."""
+
+    def _make_hash_router(
+        self,
+        scoring_func="softmax",
+        n_experts=4,
+        topk=2,
+        routed_scaling_factor=1.0,
+        routed_scaling_factor_learnable=False,
+    ):
+        from paddlefleet.transformer.moe.moe_router import TopKRouter
+
+        config = _make_router_config(
+            scoring_func=scoring_func,
+            n_routed_experts=n_experts,
+            num_experts_per_tok=topk,
+            moe_n_hash_layers=1,
+            actual_vocab_size=16,
+            num_hidden_layers=8,
+            routed_scaling_factor=routed_scaling_factor,
+            routed_scaling_factor_learnable=routed_scaling_factor_learnable,
+        )
+        router = TopKRouter(config=config)
+        router.set_layer_number(0)
+        return router
+
+    def test_hash_routing_softmax_scores(self):
+        """_hash_routing with softmax scoring (line 776)."""
+        router = self._make_hash_router(scoring_func="softmax")
+        logits = paddle.randn([4, 4])
+        flat_ids = paddle.randint(0, 16, [4])
+        top_gate, top_idx = router._hash_routing(logits, flat_ids)
+        self.assertEqual(top_gate.shape, [4, 2])
+        self.assertEqual(top_idx.shape, [4, 2])
+
+    def test_hash_routing_sigmoid_scores(self):
+        """_hash_routing with sigmoid scoring (line 778)."""
+        router = self._make_hash_router(scoring_func="sigmoid")
+        logits = paddle.randn([4, 4])
+        flat_ids = paddle.randint(0, 16, [4])
+        top_gate, top_idx = router._hash_routing(logits, flat_ids)
+        self.assertEqual(top_gate.shape, [4, 2])
+
+    def test_hash_routing_sqrtsoftplus_scores(self):
+        """_hash_routing with sqrtsoftplus scoring (else branch, line 782)."""
+        router = self._make_hash_router(scoring_func="sqrtsoftplus")
+        logits = paddle.randn([4, 4])
+        flat_ids = paddle.randint(0, 16, [4])
+        top_gate, top_idx = router._hash_routing(logits, flat_ids)
+        self.assertEqual(top_gate.shape, [4, 2])
+        # sqrtsoftplus scores should be non-negative
+        self.assertTrue(bool((top_gate >= 0).all().item()))
+
+    def test_hash_routing_no_softmax_normalizes(self):
+        """For non-softmax scoring, top_gate is normalized (line 789)."""
+        router = self._make_hash_router(scoring_func="sigmoid")
+        logits = paddle.randn([4, 4])
+        flat_ids = paddle.randint(0, 16, [4])
+        top_gate, _ = router._hash_routing(logits, flat_ids)
+        # Each row should sum to ~1 (normalized)
+        row_sums = top_gate.sum(axis=-1)
+        self.assertTrue(
+            bool(
+                paddle.allclose(
+                    row_sums, paddle.ones_like(row_sums), atol=1e-4
+                ).item()
+            )
+        )
+
+    def test_hash_routing_no_tid2eid_raises(self):
+        """_hash_routing raises ValueError when tid2eid is None (line 768)."""
+        router = self._make_hash_router(scoring_func="softmax")
+        router.tid2eid = None  # clear the buffer
+        logits = paddle.randn([4, 4])
+        flat_ids = paddle.randint(0, 16, [4])
+        with self.assertRaises(ValueError):
+            router._hash_routing(logits, flat_ids)
+
+    def test_hash_routing_unsupported_scoring_func_raises(self):
+        """_hash_routing raises ValueError for unsupported scoring_func
+        (explicit elif + raise branch, line ~780)."""
+        router = self._make_hash_router(scoring_func="softmax")
+        # Mutate scoring_func after construction to bypass _setup_hash_layer
+        # validation, so _hash_routing hits the else-raise branch.
+        router.scoring_func = "tanh"
+        logits = paddle.randn([4, 4])
+        flat_ids = paddle.randint(0, 16, [4])
+        with self.assertRaisesRegex(ValueError, "Unsupported scoring_func"):
+            router._hash_routing(logits, flat_ids)
+
+    def test_hash_routing_routed_scaling_factor_fixed(self):
+        """_hash_routing applies fixed routed_scaling_factor (line 802)."""
+        router = self._make_hash_router(
+            scoring_func="softmax",
+            routed_scaling_factor=2.0,
+            routed_scaling_factor_learnable=False,
+        )
+        logits = paddle.randn([4, 4])
+        flat_ids = paddle.randint(0, 16, [4])
+        top_gate, top_idx = router._hash_routing(logits, flat_ids)
+        self.assertEqual(top_gate.shape, [4, 2])
+        # With scaling_factor=2.0, gate values should be larger than unscaled
+        unscaled_router = self._make_hash_router(
+            scoring_func="softmax",
+            routed_scaling_factor=1.0,
+            routed_scaling_factor_learnable=False,
+        )
+        top_gate_unscaled, _ = unscaled_router._hash_routing(logits, flat_ids)
+        # scaled should be ~2x unscaled
+        ratio = top_gate.numpy().mean() / (
+            top_gate_unscaled.numpy().mean() + 1e-10
+        )
+        self.assertGreater(ratio, 1.5)
+
+    def test_hash_routing_routed_scaling_factor_learnable(self):
+        """_hash_routing applies learnable routed_scaling_factor (line 795)."""
+        router = self._make_hash_router(
+            scoring_func="softmax",
+            routed_scaling_factor=1.0,
+            routed_scaling_factor_learnable=True,
+        )
+        logits = paddle.randn([4, 4])
+        flat_ids = paddle.randint(0, 16, [4])
+        top_gate, top_idx = router._hash_routing(logits, flat_ids)
+        self.assertEqual(top_gate.shape, [4, 2])
+
+    def test_hash_forward_end_to_end(self):
+        """Full forward() with hash routing (lines 961-993)."""
+        from paddlefleet.transformer.moe.moe_router import TopKRouter
+
+        config = _make_router_config(
+            scoring_func="softmax",
+            n_routed_experts=4,
+            num_experts_per_tok=2,
+            moe_n_hash_layers=1,
+            actual_vocab_size=16,
+            num_hidden_layers=8,
+        )
+        router = TopKRouter(config=config)
+        router.set_layer_number(0)
+        hidden = paddle.randn([2, 4, config.hidden_size])
+        input_ids = paddle.randint(1, 16, [2, 4])
+        out = router(hidden, input_ids=input_ids)
+        # Return: (None, top_gate, top_idx, probs, mask, None, None, None)
+        self.assertIsNone(out[0])
+        self.assertEqual(out[1].shape, [8, 2])  # 8 tokens, topk=2
+        self.assertEqual(out[2].shape, [8, 2])
+        self.assertEqual(out[3].shape, [8, 4])  # probs: [N, num_experts]
+        self.assertEqual(out[4].shape, [8, 4])  # mask: [N, num_experts]
+        self.assertIsNone(out[5])
+        self.assertIsNone(out[6])  # no aux loss on hash layers
+        self.assertIsNone(out[7])  # no z loss on hash layers
+
+    def test_hash_forward_sequence_parallel(self):
+        """Hash routing with sequence_parallel=True (line 963)."""
+        from paddlefleet.transformer.moe.moe_router import TopKRouter
+
+        config = _make_router_config(
+            scoring_func="softmax",
+            n_routed_experts=4,
+            num_experts_per_tok=2,
+            moe_n_hash_layers=1,
+            actual_vocab_size=16,
+            num_hidden_layers=8,
+            sequence_parallel=True,
+            tensor_model_parallel_size=2,
+        )
+        router = TopKRouter(config=config)
+        router.set_layer_number(0)
+        # With sequence_parallel, input shape is [seq, batch, hidden]
+        # but input_ids shape is still [batch_size, seq_len] per the
+        # assertion in forward(): batch_size_==batch_size, seq_len_==seq_len
+        hidden = paddle.randn([4, 2, config.hidden_size])
+        input_ids = paddle.randint(1, 16, [2, 4])
+        out = router(hidden, input_ids=input_ids)
+        self.assertEqual(out[1].shape, [8, 2])
+
+    def test_hash_forward_with_padding_mask(self):
+        """Hash routing with input_ids containing zeros (lines 980-985).
+
+        When input_ids has zero entries, the non-zero mask is computed
+        inside forward() and applied to the hash routing output.
+        """
+        from paddlefleet.transformer.moe.moe_router import TopKRouter
+
+        config = _make_router_config(
+            scoring_func="sigmoid",
+            n_routed_experts=4,
+            num_experts_per_tok=2,
+            moe_n_hash_layers=1,
+            actual_vocab_size=16,
+            num_hidden_layers=8,
+        )
+        router = TopKRouter(config=config)
+        router.set_layer_number(0)
+        hidden = paddle.randn([2, 4, config.hidden_size])
+        # Include zero token IDs to trigger the padding mask branch
+        input_ids = paddle.to_tensor(
+            [[1, 2, 0, 4], [5, 0, 7, 8]], dtype="int64"
+        )
+        out = router(hidden, input_ids=input_ids)
+        self.assertEqual(out[1].shape, [8, 2])
+
+    def test_hash_forward_sequence_parallel_with_padding(self):
+        """Hash routing with sequence_parallel + padding mask.
+
+        Verifies that input_ids_none_zero_mask is transposed along with
+        flat_ids in the sequence-parallel path so that the mask token order
+        matches the logits token order.
+        """
+        from paddlefleet.transformer.moe.moe_router import TopKRouter
+
+        config = _make_router_config(
+            scoring_func="sigmoid",
+            n_routed_experts=4,
+            num_experts_per_tok=2,
+            moe_n_hash_layers=1,
+            actual_vocab_size=16,
+            num_hidden_layers=8,
+            sequence_parallel=True,
+            tensor_model_parallel_size=2,
+        )
+        router = TopKRouter(config=config)
+        router.set_layer_number(0)
+        # With sequence_parallel, input shape is [seq, batch, hidden]
+        hidden = paddle.randn([4, 2, config.hidden_size])
+        # input_ids shape is [batch_size, seq_len] = [2, 4]
+        # Place zeros at specific positions: row 0 col 2, row 1 col 1
+        input_ids = paddle.to_tensor(
+            [[1, 2, 0, 4], [5, 0, 7, 8]], dtype="int64"
+        )
+        out = router(hidden, input_ids=input_ids)
+        top_gate, top_idx = out[1], out[2]
+        self.assertEqual(top_gate.shape, [8, 2])
+        self.assertEqual(top_idx.shape, [8, 2])
+        # In SP, tokens are ordered [s0b0, s0b1, s1b0, s1b1, s2b0, s2b1, s3b0, s3b1]
+        # Padding tokens (input_ids==0) are at positions:
+        #   row0 col2 -> s2b0 -> index 4
+        #   row1 col1 -> s1b1 -> index 3
+        # These tokens should have top_idx == -1 (masked out)
+        top_idx_np = top_idx.numpy()
+        self.assertTrue(
+            (top_idx_np[4] == -1).all(),
+            f"Padding token at index 4 (s2b0) should be masked, got {top_idx_np[4]}",
+        )
+        self.assertTrue(
+            (top_idx_np[3] == -1).all(),
+            f"Padding token at index 3 (s1b1) should be masked, got {top_idx_np[3]}",
+        )
+
+    """Cover sftplus and sqrtsoftplus branches in gate_score_func (lines 304-307)."""
+
+    def _make_router(self, scoring_func="softmax"):
+        from paddlefleet.transformer.moe.moe_router import StandardMoERouter
+
+        config = _make_router_config(scoring_func=scoring_func)
+        return StandardMoERouter(config)
+
+    def test_sftplus_score_func(self):
+        """gate_score_func with sftplus scoring (line 304)."""
+        router = self._make_router(scoring_func="sftplus")
+        logits = paddle.randn([4, router.config.n_routed_experts])
+        scores = router.gate_score_func(logits)
+        self.assertEqual(scores.shape, logits.shape)
+        # softplus is always positive
+        self.assertTrue(bool((scores > 0).all().item()))
+
+    def test_sqrtsoftplus_score_func(self):
+        """gate_score_func with sqrtsoftplus scoring (line 306)."""
+        router = self._make_router(scoring_func="sqrtsoftplus")
+        logits = paddle.randn([4, router.config.n_routed_experts])
+        scores = router.gate_score_func(logits)
+        self.assertEqual(scores.shape, logits.shape)
+        # sqrt(softplus) is always non-negative
+        self.assertTrue(bool((scores >= 0).all().item()))
+
+
+class TestSetupHashLayerErrors(unittest.TestCase):
+    """Cover _setup_hash_layer error paths."""
+
+    def test_invalid_scoring_func_raises(self):
+        """_setup_hash_layer raises ValueError for unsupported scoring_func (line 861)."""
+        from paddlefleet.transformer.moe.moe_router import TopKRouter
+
+        # Create a valid config first, then override scoring_func to an
+        # invalid value.  TransformerConfig.__post_init__ validates at
+        # construction time, so we must mutate *after* creation.
+        config = _make_router_config(
+            scoring_func="softmax",
+            n_routed_experts=4,
+            num_experts_per_tok=2,
+            moe_n_hash_layers=1,
+            actual_vocab_size=16,
+            num_hidden_layers=8,
+        )
+        config.scoring_func = "relu"  # bypass TransformerConfig validation
+        router = TopKRouter(config=config)
+        with self.assertRaises(ValueError):
+            router.set_layer_number(0)
+
+    def test_missing_vocab_size_raises(self):
+        """_setup_hash_layer raises ValueError when actual_vocab_size is None (line 869)."""
+        from paddlefleet.transformer.moe.moe_router import TopKRouter
+
+        # Create a valid config first, then remove actual_vocab_size.
+        config = _make_router_config(
+            scoring_func="softmax",
+            n_routed_experts=4,
+            num_experts_per_tok=2,
+            moe_n_hash_layers=1,
+            actual_vocab_size=16,
+            num_hidden_layers=8,
+        )
+        config.actual_vocab_size = None  # bypass TransformerConfig validation
+        router = TopKRouter(config=config)
+        with self.assertRaises(ValueError):
+            router.set_layer_number(0)
+
+    def test_mtp_layer_not_hash(self):
+        """is_mtp_layer=True should disable hash routing (line 853)."""
+        from paddlefleet.transformer.moe.moe_router import TopKRouter
+
+        config = _make_router_config(
+            scoring_func="softmax",
+            n_routed_experts=4,
+            num_experts_per_tok=2,
+            moe_n_hash_layers=1,
+            actual_vocab_size=16,
+            num_hidden_layers=8,
+        )
+        router = TopKRouter(config=config)
+        router.set_layer_number(0, is_mtp_layer=True)
+        self.assertFalse(router.is_hash_layer)
+
+    def test_setup_hash_layer_activates_tid2eid(self):
+        """_setup_hash_layer registers tid2eid buffer on hash layers."""
+        from paddlefleet.transformer.moe.moe_router import TopKRouter
+
+        config = _make_router_config(
+            scoring_func="softmax",
+            n_routed_experts=4,
+            num_experts_per_tok=2,
+            moe_n_hash_layers=2,
+            actual_vocab_size=16,
+            num_hidden_layers=8,
+        )
+        router = TopKRouter(config=config)
+        self.assertFalse(router.is_hash_layer)
+        router.set_layer_number(0)
+        self.assertTrue(router.is_hash_layer)
+        self.assertIsNotNone(router.tid2eid)
+        self.assertEqual(router.tid2eid.shape, [16, 2])  # [vocab, topk]
+
+    def test_setup_hash_layer_layer_outside_range(self):
+        """Layers with layer_number >= moe_n_hash_layers are not hash layers."""
+        from paddlefleet.transformer.moe.moe_router import TopKRouter
+
+        config = _make_router_config(
+            scoring_func="softmax",
+            n_routed_experts=4,
+            num_experts_per_tok=2,
+            moe_n_hash_layers=2,
+            actual_vocab_size=16,
+            num_hidden_layers=8,
+        )
+        router = TopKRouter(config=config)
+        router.set_layer_number(5)  # >= 2, so not a hash layer
+        self.assertFalse(router.is_hash_layer)
+
+    def test_setup_hash_layer_removes_noaux_tc_bias(self):
+        """_setup_hash_layer removes e_score_correction_bias on hash layers."""
+        from paddlefleet.transformer.moe.moe_router import TopKRouter
+
+        config = _make_router_config(
+            scoring_func="softmax",
+            n_routed_experts=4,
+            num_experts_per_tok=2,
+            moe_n_hash_layers=1,
+            actual_vocab_size=16,
+            num_hidden_layers=8,
+            topk_method="noaux_tc",
+        )
+        router = TopKRouter(config=config)
+        # noaux_tc should create e_score_correction_bias in __init__
+        self.assertTrue(hasattr(router, "e_score_correction_bias"))
+        # Activating hash layer should remove it
+        router.set_layer_number(0)
+        self.assertTrue(router.is_hash_layer)
+        self.assertFalse(hasattr(router, "e_score_correction_bias"))
+        self.assertFalse(hasattr(router, "expert_usage"))
+
+    def test_setup_hash_layer_layer_number_none(self):
+        """set_layer_number(None) should not activate hash routing."""
+        from paddlefleet.transformer.moe.moe_router import TopKRouter
+
+        config = _make_router_config(
+            scoring_func="softmax",
+            n_routed_experts=4,
+            num_experts_per_tok=2,
+            moe_n_hash_layers=1,
+            actual_vocab_size=16,
+            num_hidden_layers=8,
+        )
+        router = TopKRouter(config=config)
+        router.set_layer_number(None)
+        self.assertFalse(router.is_hash_layer)
+
+
+class TestHashForwardInputIdsRequired(unittest.TestCase):
+    """Cover the hash routing forward branch input_ids check (line 942)."""
+
+    def test_hash_layer_requires_input_ids(self):
+        """When is_hash_layer=True, forward() requires input_ids."""
+        from paddlefleet.transformer.moe.moe_router import TopKRouter
+
+        config = _make_router_config(
+            scoring_func="softmax",
+            n_routed_experts=4,
+            num_experts_per_tok=2,
+            moe_n_hash_layers=1,
+            actual_vocab_size=16,
+            num_hidden_layers=8,
+        )
+        router = TopKRouter(config=config)
+        router.set_layer_number(0)
+        hidden = paddle.randn([2, 4, 64])
+        with self.assertRaises(ValueError):
+            router(hidden, input_ids=None)
+
+
+class TestMoELayerSetLayerNumberForwardsIsMtp(unittest.TestCase):
+    """Verify MoELayer.set_layer_number forwards is_mtp_layer to the gate."""
+
+    def _make_moe_layer(self, **cfg_overrides):
+        """Build a MoELayer with mock gate to test set_layer_number forwarding."""
+        from unittest.mock import MagicMock
+
+        from paddlefleet.transformer.moe.moe_layer import MoELayer
+
+        cfg_overrides.setdefault("actual_vocab_size", 128)
+        config = _make_router_config(**cfg_overrides)
+        moe = MoELayer.__new__(MoELayer)
+        moe.gate = MagicMock()
+        moe.layer_number = None
+        return moe
+
+    def test_forwards_is_mtp_layer_true(self):
+        moe = self._make_moe_layer(moe_n_hash_layers=2, num_hidden_layers=8)
+        moe.set_layer_number(0, is_mtp_layer=True)
+        moe.gate.set_layer_number.assert_called_once_with(0, is_mtp_layer=True)
+        self.assertEqual(moe.layer_number, 0)
+
+    def test_forwards_is_mtp_layer_false(self):
+        moe = self._make_moe_layer(moe_n_hash_layers=2, num_hidden_layers=8)
+        moe.set_layer_number(0, is_mtp_layer=False)
+        moe.gate.set_layer_number.assert_called_once_with(0, is_mtp_layer=False)
+
+    def test_default_is_mtp_layer_false(self):
+        """Calling without is_mtp_layer should default to False."""
+        moe = self._make_moe_layer(moe_n_hash_layers=2, num_hidden_layers=8)
+        moe.set_layer_number(0)
+        moe.gate.set_layer_number.assert_called_once_with(0, is_mtp_layer=False)
 
 
 if __name__ == "__main__":

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_layer_2.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_layer_2.py
@@ -52,7 +52,7 @@ class Gate:
         self.calls.append((hidden_states, input_ids))
         return "gate-output"
 
-    def set_layer_number(self, layer_number):
+    def set_layer_number(self, layer_number, is_mtp_layer=False):
         self.layer_number = layer_number
 
 

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_layer_7.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_layer_7.py
@@ -240,7 +240,9 @@ class TestMoELayerSetLayerNumber(unittest.TestCase):
         layer.gate = MagicMock()
         layer.set_layer_number(5)
         self.assertEqual(layer.layer_number, 5)
-        layer.gate.set_layer_number.assert_called_once_with(5)
+        layer.gate.set_layer_number.assert_called_once_with(
+            5, is_mtp_layer=False
+        )
 
     def test_set_layer_number_no_set_method(self):
         layer = MoELayer.__new__(MoELayer)

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_layer_5.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_layer_5.py
@@ -46,7 +46,7 @@ class NonIdentityLayer(paddle.nn.Layer):
 
 
 class UnknownMLP(paddle.nn.Layer):
-    def set_layer_number(self, layer_number):
+    def set_layer_number(self, layer_number, is_mtp_layer=False):
         self.layer_number = layer_number
 
     def forward(self, x):


### PR DESCRIPTION
### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library  | Environment Adaptation ] -->
Distributed Strategy

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you've done -->
1. **Hash Routing**：在 `TopKRouter` 中新增基于 `tid2eid` 查表的 hash routing 分支。当 `config.moe_n_hash_layers > 0` 时，层号 `< moe_n_hash_layers` 的前几层 MoE layer 使用 hash 路由，评分权重仍由 gate logits 计算。`TransformerConfig` 新增 `moe_n_hash_layers`（int，默认 0）和 `actual_vocab_size`（int|None）字段，并在 `__post_init__` 中加了合法性校验。
2. **Softplus 评分函数**：新增 `sftplus`（`F.softplus`）和 `sqrtsoftplus`（`sqrt(softplus)`）两种 `scoring_func` 选项。
3. **MTP 层隔离**：MTP layer 通过 `is_mtp_layer=True` 禁用 hash routing，避免 MTP 层误触 hash 路由逻辑。
4. 删除了 `TransformerConfig` 中的 3 个重复字段定义：`apply_residual_connection_post_layernorm`、`activation_func_clamp_value`、`glu_linear_offset`（这些字段在文件其他位置已有定义）。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否