### PR TITLE
[Improvements] Support large tensor indexing in router metadata and filter scores

### DIFF
--- a/packages/paddlefleet_ops/src/paddlefleet_ops/_extensions/filter_scores.cu
+++ b/packages/paddlefleet_ops/src/paddlefleet_ops/_extensions/filter_scores.cu
@@ -16,11 +16,10 @@
 #include <cuda_runtime.h>
 #include <paddle/extension.h>
 #include <cub/cub.cuh>
-#include <limits>
 #include <vector>
 
 __global__ void count_valid_kernel(const int64_t* indices,
-                                   int* valid_count,
+                                   int64_t* valid_count,
                                    const int64_t total_elements) {
   for (int64_t i =
            static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
@@ -28,13 +27,14 @@ __global__ void count_valid_kernel(const int64_t* indices,
        i < total_elements;
        i += static_cast<int64_t>(gridDim.x) * blockDim.x) {
     if (indices[i] != -1) {
-      atomicAdd(valid_count, 1);
+      atomicAdd(reinterpret_cast<unsigned long long*>(valid_count),
+                static_cast<unsigned long long>(1));
     }
   }
 }
 
 __global__ void create_mask_kernel(const int64_t* indices,
-                                   int* mask,
+                                   int64_t* mask,
                                    const int64_t total_elements) {
   for (int64_t i =
            static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
@@ -48,7 +48,7 @@ __global__ void create_mask_kernel(const int64_t* indices,
 template <typename scalar_t>
 __global__ void scatter_scores_kernel(const scalar_t* probs,
                                       const int64_t* indices,
-                                      const int* write_indices,
+                                      const int64_t* write_indices,
                                       scalar_t* output_scores,
                                       const int64_t total_elements) {
   for (int64_t i =
@@ -57,7 +57,7 @@ __global__ void scatter_scores_kernel(const scalar_t* probs,
        i < total_elements;
        i += static_cast<int64_t>(gridDim.x) * blockDim.x) {
     if (indices[i] != -1) {
-      int write_idx = write_indices[i];
+      int64_t write_idx = write_indices[i];
       output_scores[write_idx] = probs[i];
     }
   }
@@ -66,7 +66,7 @@ __global__ void scatter_scores_kernel(const scalar_t* probs,
 template <typename scalar_t>
 __global__ void scatter_grad_kernel(const scalar_t* grad_topk,
                                     const int64_t* indices,
-                                    const int* write_indices,
+                                    const int64_t* write_indices,
                                     scalar_t* grad_probs,
                                     const int64_t total_elements) {
   for (int64_t i =
@@ -75,14 +75,14 @@ __global__ void scatter_grad_kernel(const scalar_t* grad_topk,
        i < total_elements;
        i += static_cast<int64_t>(gridDim.x) * blockDim.x) {
     if (indices[i] != -1) {
-      int write_idx = write_indices[i];
+      int64_t write_idx = write_indices[i];
       grad_probs[i] = grad_topk[write_idx];
     }
   }
 }
 
 void count_valid_cuda_launcher(const int64_t* indices,
-                               int* valid_count,
+                               int64_t* valid_count,
                                const int64_t total_elements,
                                cudaStream_t stream) {
   if (total_elements == 0) return;
@@ -108,19 +108,16 @@ std::vector<paddle::Tensor> FilterScoresGPU(const paddle::Tensor& probs,
   if (total_elements == 0) {
     return {paddle::empty({0}, probs.dtype(), probs.place())};
   }
-  PD_CHECK(
-      total_elements <= static_cast<int64_t>(std::numeric_limits<int>::max()),
-      "total_elements exceeds INT_MAX in filter_scores.");
   auto valid_count_tensor =
-      paddle::full({1}, 0, paddle::DataType::INT32, probs.place());
+      paddle::full({1}, 0, paddle::DataType::INT64, probs.place());
   count_valid_cuda_launcher(indices.data<int64_t>(),
-                            valid_count_tensor.data<int>(),
+                            valid_count_tensor.data<int64_t>(),
                             total_elements,
                             stream);
-  int total_valid = 0;
+  int64_t total_valid = 0;
   PD_CHECK(cudaMemcpyAsync(&total_valid,
-                           valid_count_tensor.data<int>(),
-                           sizeof(int),
+                           valid_count_tensor.data<int64_t>(),
+                           sizeof(int64_t),
                            cudaMemcpyDeviceToHost,
                            stream) == cudaSuccess,
            "cudaMemcpyAsync total_valid_experts failed.");
@@ -131,20 +128,20 @@ std::vector<paddle::Tensor> FilterScoresGPU(const paddle::Tensor& probs,
   }
   auto topk_scores = paddle::empty({total_valid}, probs.dtype(), probs.place());
   auto mask =
-      paddle::empty({total_elements}, paddle::DataType::INT32, probs.place());
+      paddle::empty({total_elements}, paddle::DataType::INT64, probs.place());
   auto write_indices =
-      paddle::empty({total_elements}, paddle::DataType::INT32, probs.place());
+      paddle::empty({total_elements}, paddle::DataType::INT64, probs.place());
   int block_size = 256;
   int64_t grid_size64 = (total_elements + block_size - 1) / block_size;
   int grid_size = static_cast<int>(std::min<int64_t>(grid_size64, 4096));
   create_mask_kernel<<<grid_size, block_size, 0, stream>>>(
-      indices.data<int64_t>(), mask.data<int>(), total_elements);
+      indices.data<int64_t>(), mask.data<int64_t>(), total_elements);
   void* d_temp_storage = nullptr;
   size_t temp_storage_bytes = 0;
   cub::DeviceScan::ExclusiveSum(d_temp_storage,
                                 temp_storage_bytes,
-                                mask.data<int>(),
-                                write_indices.data<int>(),
+                                mask.data<int64_t>(),
+                                write_indices.data<int64_t>(),
                                 total_elements);
   auto temp_storage = paddle::empty({static_cast<int64_t>(temp_storage_bytes)},
                                     paddle::DataType::UINT8,
@@ -152,8 +149,8 @@ std::vector<paddle::Tensor> FilterScoresGPU(const paddle::Tensor& probs,
   d_temp_storage = temp_storage.data<uint8_t>();
   cub::DeviceScan::ExclusiveSum(d_temp_storage,
                                 temp_storage_bytes,
-                                mask.data<int>(),
-                                write_indices.data<int>(),
+                                mask.data<int64_t>(),
+                                write_indices.data<int64_t>(),
                                 total_elements,
                                 stream);
 
@@ -162,7 +159,7 @@ std::vector<paddle::Tensor> FilterScoresGPU(const paddle::Tensor& probs,
                                    <<<grid_size, block_size, 0, stream>>>(
                                        probs.data<data_t>(),
                                        indices.data<int64_t>(),
-                                       write_indices.data<int>(),
+                                       write_indices.data<int64_t>(),
                                        topk_scores.data<data_t>(),
                                        total_elements);
                              }));
@@ -179,32 +176,27 @@ std::vector<paddle::Tensor> FilterScoresGradGPU(
            "indices must be of type int64.");
   cudaStream_t stream = indices.stream();
   const int64_t total_elements = indices.numel();
-  PD_CHECK(
-      total_elements <= static_cast<int64_t>(std::numeric_limits<int>::max()),
-      "total_elements exceeds INT_MAX in filter_scores_grad.");
   auto grad_probs = paddle::full(
       indices.shape(), 0, grad_topk_scores.dtype(), grad_topk_scores.place());
   const int64_t total_valid = grad_topk_scores.numel();
-  PD_CHECK(total_valid <= static_cast<int64_t>(std::numeric_limits<int>::max()),
-           "total_valid exceeds INT_MAX in filter_scores_grad.");
   if (total_elements == 0 || total_valid == 0) {
     return {grad_probs};
   }
   auto mask = paddle::empty(
-      {total_elements}, paddle::DataType::INT32, grad_topk_scores.place());
+      {total_elements}, paddle::DataType::INT64, grad_topk_scores.place());
   auto write_indices = paddle::empty(
-      {total_elements}, paddle::DataType::INT32, grad_topk_scores.place());
+      {total_elements}, paddle::DataType::INT64, grad_topk_scores.place());
   int block_size = 256;
   int64_t grid_size64 = (total_elements + block_size - 1) / block_size;
   int grid_size = static_cast<int>(std::min<int64_t>(grid_size64, 4096));
   create_mask_kernel<<<grid_size, block_size, 0, stream>>>(
-      indices.data<int64_t>(), mask.data<int>(), total_elements);
+      indices.data<int64_t>(), mask.data<int64_t>(), total_elements);
   void* d_temp_storage = nullptr;
   size_t temp_storage_bytes = 0;
   cub::DeviceScan::ExclusiveSum(d_temp_storage,
                                 temp_storage_bytes,
-                                mask.data<int>(),
-                                write_indices.data<int>(),
+                                mask.data<int64_t>(),
+                                write_indices.data<int64_t>(),
                                 total_elements);
   auto temp_storage = paddle::empty({static_cast<int64_t>(temp_storage_bytes)},
                                     paddle::DataType::UINT8,
@@ -212,8 +204,8 @@ std::vector<paddle::Tensor> FilterScoresGradGPU(
   d_temp_storage = temp_storage.data<uint8_t>();
   cub::DeviceScan::ExclusiveSum(d_temp_storage,
                                 temp_storage_bytes,
-                                mask.data<int>(),
-                                write_indices.data<int>(),
+                                mask.data<int64_t>(),
+                                write_indices.data<int64_t>(),
                                 total_elements,
                                 stream);
   PD_DISPATCH_FLOATING_TYPES(
@@ -221,7 +213,7 @@ std::vector<paddle::Tensor> FilterScoresGradGPU(
         scatter_grad_kernel<data_t><<<grid_size, block_size, 0, stream>>>(
             grad_topk_scores.data<data_t>(),
             indices.data<int64_t>(),
-            write_indices.data<int>(),
+            write_indices.data<int64_t>(),
             grad_probs.data<data_t>(),
             total_elements);
       }));

--- a/packages/paddlefleet_ops/src/paddlefleet_ops/_extensions/filter_scores.cu
+++ b/packages/paddlefleet_ops/src/paddlefleet_ops/_extensions/filter_scores.cu
@@ -18,6 +18,8 @@
 #include <cub/cub.cuh>
 #include <vector>
 
+using AtomicUint64 = unsigned long long;  // NOLINT(runtime/int)
+
 __global__ void count_valid_kernel(const int64_t* indices,
                                    int64_t* valid_count,
                                    const int64_t total_elements) {
@@ -25,10 +27,11 @@ __global__ void count_valid_kernel(const int64_t* indices,
            static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
            static_cast<int64_t>(threadIdx.x);
        i < total_elements;
-       i += static_cast<int64_t>(gridDim.x) * blockDim.x) {
+       i +=
+       static_cast<int64_t>(gridDim.x) * static_cast<int64_t>(blockDim.x)) {
     if (indices[i] != -1) {
-      atomicAdd(reinterpret_cast<unsigned long long*>(valid_count),
-                static_cast<unsigned long long>(1));
+      atomicAdd(reinterpret_cast<AtomicUint64*>(valid_count),
+                static_cast<AtomicUint64>(1));
     }
   }
 }
@@ -40,7 +43,8 @@ __global__ void create_mask_kernel(const int64_t* indices,
            static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
            static_cast<int64_t>(threadIdx.x);
        i < total_elements;
-       i += static_cast<int64_t>(gridDim.x) * blockDim.x) {
+       i +=
+       static_cast<int64_t>(gridDim.x) * static_cast<int64_t>(blockDim.x)) {
     mask[i] = (indices[i] != -1) ? 1 : 0;
   }
 }
@@ -55,7 +59,8 @@ __global__ void scatter_scores_kernel(const scalar_t* probs,
            static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
            static_cast<int64_t>(threadIdx.x);
        i < total_elements;
-       i += static_cast<int64_t>(gridDim.x) * blockDim.x) {
+       i +=
+       static_cast<int64_t>(gridDim.x) * static_cast<int64_t>(blockDim.x)) {
     if (indices[i] != -1) {
       int64_t write_idx = write_indices[i];
       output_scores[write_idx] = probs[i];
@@ -73,7 +78,8 @@ __global__ void scatter_grad_kernel(const scalar_t* grad_topk,
            static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
            static_cast<int64_t>(threadIdx.x);
        i < total_elements;
-       i += static_cast<int64_t>(gridDim.x) * blockDim.x) {
+       i +=
+       static_cast<int64_t>(gridDim.x) * static_cast<int64_t>(blockDim.x)) {
     if (indices[i] != -1) {
       int64_t write_idx = write_indices[i];
       grad_probs[i] = grad_topk[write_idx];

--- a/packages/paddlefleet_ops/src/paddlefleet_ops/_extensions/fuse_swiglu_scale.cu
+++ b/packages/paddlefleet_ops/src/paddlefleet_ops/_extensions/fuse_swiglu_scale.cu
@@ -13,11 +13,10 @@
 // limitations under the License.
 
 #include <cuda_bf16.h>
-#include <algorithm>
 #include <cstdint>
-#include <limits>
 #include <vector>
 #include "paddle/extension.h"
+#include "swiglu_utils.h"
 
 // ==========================================================================
 // Utils: Packed Memory Access (128-bit Vectorization)
@@ -36,18 +35,6 @@ __device__ __forceinline__ float precise_sigmoid(T x) {
 }
 
 constexpr int kFusedSwiGLUScaleBlockSize = 256;
-
-inline bool ShouldUseInt64Index(int64_t rows, int64_t row_stride) {
-  // This predicate protects X/DX offsets:
-  //   row * row_stride + col
-  // Out/DOut offsets use row * hidden_size + col, and row_stride is
-  // 2 * hidden_size for fused_swiglu_scale, so the X/DX offset range is the
-  // larger one. Rows beyond INT_MAX also require int64_t row iteration because
-  // the kernels use a capped CUDA grid and grid-stride over rows.
-  return rows > static_cast<int64_t>(std::numeric_limits<int>::max()) ||
-         rows >=
-             static_cast<int64_t>(std::numeric_limits<int>::max()) / row_stride;
-}
 
 // ==========================================================================
 // Optimized Forward Kernel
@@ -110,6 +97,7 @@ __global__ void VectorizedFusedSwiGLUBwd(const T* __restrict__ x,
                                          IndexT hidden_size,
                                          IndexT row_stride) {
   int tid = threadIdx.x;
+  __shared__ float shared_sum[kFusedSwiGLUScaleBlockSize];
 
   for (int64_t row = static_cast<int64_t>(blockIdx.x); row < rows;
        row += static_cast<int64_t>(gridDim.x)) {
@@ -164,12 +152,13 @@ __global__ void VectorizedFusedSwiGLUBwd(const T* __restrict__ x,
           *reinterpret_cast<Packed128*>(dv_buffer);
     }
 
-    static __shared__ float shared_sum[256];
-    if (tid < 256) shared_sum[tid] = local_d_scale_sum;
+    if (tid < kFusedSwiGLUScaleBlockSize) {
+      shared_sum[tid] = local_d_scale_sum;
+    }
     __syncthreads();
 
     for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
-      if (tid < stride && (tid + stride) < 256) {
+      if (tid < stride && (tid + stride) < kFusedSwiGLUScaleBlockSize) {
         shared_sum[tid] += shared_sum[tid + stride];
       }
       __syncthreads();
@@ -214,7 +203,7 @@ void DispatchFusedSwiGLUScaleFwd(const T* x,
                                  int64_t hidden_size,
                                  int64_t row_stride,
                                  StreamT stream) {
-  if (ShouldUseInt64Index(rows, row_stride)) {
+  if (paddlefleet::extensions::ShouldUseInt64Index(rows, row_stride)) {
     LaunchFusedSwiGLUScaleFwd<T, ScaleT, VEC_SIZE, int64_t>(
         x, scale, out, grid_size, rows, hidden_size, row_stride, stream);
   } else {
@@ -261,7 +250,7 @@ void DispatchFusedSwiGLUScaleBwd(const T* x,
                                  int64_t hidden_size,
                                  int64_t row_stride,
                                  StreamT stream) {
-  if (ShouldUseInt64Index(rows, row_stride)) {
+  if (paddlefleet::extensions::ShouldUseInt64Index(rows, row_stride)) {
     LaunchFusedSwiGLUScaleBwd<T, ScaleT, VEC_SIZE, int64_t>(x,
                                                             scale,
                                                             d_out,
@@ -301,8 +290,7 @@ std::vector<paddle::Tensor> FusedSwiGLUScaleForward(
     return {out};
   }
 
-  constexpr int64_t kMaxGridX = 65535;
-  int grid_size = static_cast<int>(std::min(rows, kMaxGridX));
+  int grid_size = paddlefleet::extensions::GetSwiGLURowGridSize(rows);
   auto stream = x.stream();
 
   if (x.dtype() == paddle::DataType::BFLOAT16) {
@@ -356,8 +344,7 @@ std::vector<paddle::Tensor> FusedSwiGLUScaleBackward(
     return {d_x, d_scale};
   }
 
-  constexpr int64_t kMaxGridX = 65535;
-  int grid_size = static_cast<int>(std::min(rows, kMaxGridX));
+  int grid_size = paddlefleet::extensions::GetSwiGLURowGridSize(rows);
   auto stream = x.stream();
 
   if (x.dtype() == paddle::DataType::BFLOAT16) {

--- a/packages/paddlefleet_ops/src/paddlefleet_ops/_extensions/fuse_swiglu_scale.cu
+++ b/packages/paddlefleet_ops/src/paddlefleet_ops/_extensions/fuse_swiglu_scale.cu
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <cuda_bf16.h>
+#include <algorithm>
 #include <cstdint>
 #include <limits>
 #include <vector>
@@ -55,21 +56,22 @@ template <typename T, typename ScaleT, int VEC_SIZE, typename IndexT>
 __global__ void VectorizedFusedSwiGLUFwd(const T* __restrict__ x,
                                          const ScaleT* __restrict__ scale,
                                          T* __restrict__ out,
-                                         IndexT rows,
+                                         int64_t rows,
                                          IndexT hidden_size,
                                          IndexT row_stride) {
-  for (IndexT row = static_cast<IndexT>(blockIdx.x); row < rows;
-       row += static_cast<IndexT>(gridDim.x)) {
+  for (int64_t row = static_cast<int64_t>(blockIdx.x); row < rows;
+       row += static_cast<int64_t>(gridDim.x)) {
     int tid = threadIdx.x;
+    IndexT row_index = static_cast<IndexT>(row);
     IndexT lane_idx = static_cast<IndexT>(tid) * VEC_SIZE;
 
     float s = static_cast<float>(scale[row]);
 
     for (IndexT col = lane_idx; col < hidden_size;
          col += static_cast<IndexT>(blockDim.x) * VEC_SIZE) {
-      IndexT gate_offset = row * row_stride + col;
+      IndexT gate_offset = row_index * row_stride + col;
       IndexT val_offset = gate_offset + hidden_size;
-      IndexT out_offset = row * hidden_size + col;
+      IndexT out_offset = row_index * hidden_size + col;
 
       Packed128 gate_pack =
           *reinterpret_cast<const Packed128*>(&x[gate_offset]);
@@ -104,13 +106,14 @@ __global__ void VectorizedFusedSwiGLUBwd(const T* __restrict__ x,
                                          const T* __restrict__ d_out,
                                          T* __restrict__ d_x,
                                          ScaleT* __restrict__ d_scale,
-                                         IndexT rows,
+                                         int64_t rows,
                                          IndexT hidden_size,
                                          IndexT row_stride) {
   int tid = threadIdx.x;
 
-  for (IndexT row = static_cast<IndexT>(blockIdx.x); row < rows;
-       row += static_cast<IndexT>(gridDim.x)) {
+  for (int64_t row = static_cast<int64_t>(blockIdx.x); row < rows;
+       row += static_cast<int64_t>(gridDim.x)) {
+    IndexT row_index = static_cast<IndexT>(row);
     IndexT lane_idx = static_cast<IndexT>(tid) * VEC_SIZE;
 
     float local_d_scale_sum = 0.0f;
@@ -118,9 +121,9 @@ __global__ void VectorizedFusedSwiGLUBwd(const T* __restrict__ x,
 
     for (IndexT col = lane_idx; col < hidden_size;
          col += static_cast<IndexT>(blockDim.x) * VEC_SIZE) {
-      IndexT gate_offset = row * row_stride + col;
+      IndexT gate_offset = row_index * row_stride + col;
       IndexT val_offset = gate_offset + hidden_size;
-      IndexT out_offset = row * hidden_size + col;
+      IndexT out_offset = row_index * hidden_size + col;
 
       Packed128 gate_pack =
           *reinterpret_cast<const Packed128*>(&x[gate_offset]);
@@ -197,7 +200,7 @@ void LaunchFusedSwiGLUScaleFwd(const T* x,
           x,
           scale,
           out,
-          static_cast<IndexT>(rows),
+          rows,
           static_cast<IndexT>(hidden_size),
           static_cast<IndexT>(row_stride));
 }
@@ -242,7 +245,7 @@ void LaunchFusedSwiGLUScaleBwd(const T* x,
           d_out,
           d_x,
           d_scale,
-          static_cast<IndexT>(rows),
+          rows,
           static_cast<IndexT>(hidden_size),
           static_cast<IndexT>(row_stride));
 }
@@ -298,7 +301,7 @@ std::vector<paddle::Tensor> FusedSwiGLUScaleForward(
     return {out};
   }
 
-  constexpr int64_t kMaxGridX = std::numeric_limits<int>::max();
+  constexpr int64_t kMaxGridX = 65535;
   int grid_size = static_cast<int>(std::min(rows, kMaxGridX));
   auto stream = x.stream();
 
@@ -353,7 +356,7 @@ std::vector<paddle::Tensor> FusedSwiGLUScaleBackward(
     return {d_x, d_scale};
   }
 
-  constexpr int64_t kMaxGridX = std::numeric_limits<int>::max();
+  constexpr int64_t kMaxGridX = 65535;
   int grid_size = static_cast<int>(std::min(rows, kMaxGridX));
   auto stream = x.stream();
 

--- a/packages/paddlefleet_ops/src/paddlefleet_ops/_extensions/fuse_swiglu_scale.cu
+++ b/packages/paddlefleet_ops/src/paddlefleet_ops/_extensions/fuse_swiglu_scale.cu
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <cuda_bf16.h>
+#include <cstdint>
 #include <limits>
 #include <vector>
 #include "paddle/extension.h"
@@ -33,122 +34,252 @@ __device__ __forceinline__ float precise_sigmoid(T x) {
   return 1.0f / (1.0f + expf(-static_cast<float>(x)));
 }
 
+constexpr int kFusedSwiGLUScaleBlockSize = 256;
+
+inline bool ShouldUseInt64Index(int64_t rows, int64_t row_stride) {
+  // This predicate protects X/DX offsets:
+  //   row * row_stride + col
+  // Out/DOut offsets use row * hidden_size + col, and row_stride is
+  // 2 * hidden_size for fused_swiglu_scale, so the X/DX offset range is the
+  // larger one. Rows beyond INT_MAX also require int64_t row iteration because
+  // the kernels use a capped CUDA grid and grid-stride over rows.
+  return rows > static_cast<int64_t>(std::numeric_limits<int>::max()) ||
+         rows >=
+             static_cast<int64_t>(std::numeric_limits<int>::max()) / row_stride;
+}
+
 // ==========================================================================
 // Optimized Forward Kernel
 // ==========================================================================
-template <typename T, typename ScaleT, int VEC_SIZE>
+template <typename T, typename ScaleT, int VEC_SIZE, typename IndexT>
 __global__ void VectorizedFusedSwiGLUFwd(const T* __restrict__ x,
                                          const ScaleT* __restrict__ scale,
                                          T* __restrict__ out,
-                                         int hidden_size,
-                                         int row_stride) {
-  int row = blockIdx.x;
-  int tid = threadIdx.x;
-  int lane_idx = tid * VEC_SIZE;
+                                         IndexT rows,
+                                         IndexT hidden_size,
+                                         IndexT row_stride) {
+  for (IndexT row = static_cast<IndexT>(blockIdx.x); row < rows;
+       row += static_cast<IndexT>(gridDim.x)) {
+    int tid = threadIdx.x;
+    IndexT lane_idx = static_cast<IndexT>(tid) * VEC_SIZE;
 
-  float s = static_cast<float>(scale[row]);
+    float s = static_cast<float>(scale[row]);
 
-  for (int col = lane_idx; col < hidden_size; col += blockDim.x * VEC_SIZE) {
-    int gate_offset = row * row_stride + col;
-    int val_offset = gate_offset + hidden_size;
-    int out_offset = row * hidden_size + col;
+    for (IndexT col = lane_idx; col < hidden_size;
+         col += static_cast<IndexT>(blockDim.x) * VEC_SIZE) {
+      IndexT gate_offset = row * row_stride + col;
+      IndexT val_offset = gate_offset + hidden_size;
+      IndexT out_offset = row * hidden_size + col;
 
-    Packed128 gate_pack = *reinterpret_cast<const Packed128*>(&x[gate_offset]);
-    Packed128 val_pack = *reinterpret_cast<const Packed128*>(&x[val_offset]);
+      Packed128 gate_pack =
+          *reinterpret_cast<const Packed128*>(&x[gate_offset]);
+      Packed128 val_pack = *reinterpret_cast<const Packed128*>(&x[val_offset]);
 
-    T* gate_ptr = reinterpret_cast<T*>(&gate_pack);
-    T* val_ptr = reinterpret_cast<T*>(&val_pack);
+      T* gate_ptr = reinterpret_cast<T*>(&gate_pack);
+      T* val_ptr = reinterpret_cast<T*>(&val_pack);
 
-    T res_buffer[VEC_SIZE];
+      T res_buffer[VEC_SIZE];
 
 #pragma unroll
-    for (int i = 0; i < VEC_SIZE; ++i) {
-      float g = static_cast<float>(gate_ptr[i]);
-      float v = static_cast<float>(val_ptr[i]);
+      for (int i = 0; i < VEC_SIZE; ++i) {
+        float g = static_cast<float>(gate_ptr[i]);
+        float v = static_cast<float>(val_ptr[i]);
 
-      float swiglu = (g * precise_sigmoid(g)) * v;
-      res_buffer[i] = static_cast<T>(swiglu * s);
+        float swiglu = (g * precise_sigmoid(g)) * v;
+        res_buffer[i] = static_cast<T>(swiglu * s);
+      }
+
+      *reinterpret_cast<Packed128*>(&out[out_offset]) =
+          *reinterpret_cast<Packed128*>(res_buffer);
     }
-
-    *reinterpret_cast<Packed128*>(&out[out_offset]) =
-        *reinterpret_cast<Packed128*>(res_buffer);
   }
 }
 
 // ==========================================================================
 // Optimized Backward Kernel
 // ==========================================================================
-template <typename T, typename ScaleT, int VEC_SIZE>
+template <typename T, typename ScaleT, int VEC_SIZE, typename IndexT>
 __global__ void VectorizedFusedSwiGLUBwd(const T* __restrict__ x,
                                          const ScaleT* __restrict__ scale,
                                          const T* __restrict__ d_out,
                                          T* __restrict__ d_x,
                                          ScaleT* __restrict__ d_scale,
-                                         int hidden_size,
-                                         int row_stride) {
-  int row = blockIdx.x;
+                                         IndexT rows,
+                                         IndexT hidden_size,
+                                         IndexT row_stride) {
   int tid = threadIdx.x;
-  int lane_idx = tid * VEC_SIZE;
 
-  float local_d_scale_sum = 0.0f;
-  float s = static_cast<float>(scale[row]);
+  for (IndexT row = static_cast<IndexT>(blockIdx.x); row < rows;
+       row += static_cast<IndexT>(gridDim.x)) {
+    IndexT lane_idx = static_cast<IndexT>(tid) * VEC_SIZE;
 
-  for (int col = lane_idx; col < hidden_size; col += blockDim.x * VEC_SIZE) {
-    int gate_offset = row * row_stride + col;
-    int val_offset = gate_offset + hidden_size;
-    int out_offset = row * hidden_size + col;
+    float local_d_scale_sum = 0.0f;
+    float s = static_cast<float>(scale[row]);
 
-    Packed128 gate_pack = *reinterpret_cast<const Packed128*>(&x[gate_offset]);
-    Packed128 val_pack = *reinterpret_cast<const Packed128*>(&x[val_offset]);
-    Packed128 dout_pack =
-        *reinterpret_cast<const Packed128*>(&d_out[out_offset]);
+    for (IndexT col = lane_idx; col < hidden_size;
+         col += static_cast<IndexT>(blockDim.x) * VEC_SIZE) {
+      IndexT gate_offset = row * row_stride + col;
+      IndexT val_offset = gate_offset + hidden_size;
+      IndexT out_offset = row * hidden_size + col;
 
-    T* gate_ptr = reinterpret_cast<T*>(&gate_pack);
-    T* val_ptr = reinterpret_cast<T*>(&val_pack);
-    T* dout_ptr = reinterpret_cast<T*>(&dout_pack);
+      Packed128 gate_pack =
+          *reinterpret_cast<const Packed128*>(&x[gate_offset]);
+      Packed128 val_pack = *reinterpret_cast<const Packed128*>(&x[val_offset]);
+      Packed128 dout_pack =
+          *reinterpret_cast<const Packed128*>(&d_out[out_offset]);
 
-    T dg_buffer[VEC_SIZE];
-    T dv_buffer[VEC_SIZE];
+      T* gate_ptr = reinterpret_cast<T*>(&gate_pack);
+      T* val_ptr = reinterpret_cast<T*>(&val_pack);
+      T* dout_ptr = reinterpret_cast<T*>(&dout_pack);
+
+      T dg_buffer[VEC_SIZE];
+      T dv_buffer[VEC_SIZE];
 
 #pragma unroll
-    for (int i = 0; i < VEC_SIZE; ++i) {
-      float g = static_cast<float>(gate_ptr[i]);
-      float v = static_cast<float>(val_ptr[i]);
-      float dout = static_cast<float>(dout_ptr[i]);
+      for (int i = 0; i < VEC_SIZE; ++i) {
+        float g = static_cast<float>(gate_ptr[i]);
+        float v = static_cast<float>(val_ptr[i]);
+        float dout = static_cast<float>(dout_ptr[i]);
 
-      float sig_g = precise_sigmoid(g);
-      float swiglu_val = (g * sig_g) * v;
+        float sig_g = precise_sigmoid(g);
+        float swiglu_val = (g * sig_g) * v;
 
-      local_d_scale_sum += dout * swiglu_val;
+        local_d_scale_sum += dout * swiglu_val;
 
-      float d_u = dout * s;
-      float silu_g = g * sig_g;
+        float d_u = dout * s;
+        float silu_g = g * sig_g;
 
-      dv_buffer[i] = static_cast<T>(d_u * silu_g);
+        dv_buffer[i] = static_cast<T>(d_u * silu_g);
 
-      float d_g_val = d_u * v * sig_g * (1.0f + g * (1.0f - sig_g));
-      dg_buffer[i] = static_cast<T>(d_g_val);
+        float d_g_val = d_u * v * sig_g * (1.0f + g * (1.0f - sig_g));
+        dg_buffer[i] = static_cast<T>(d_g_val);
+      }
+
+      *reinterpret_cast<Packed128*>(&d_x[gate_offset]) =
+          *reinterpret_cast<Packed128*>(dg_buffer);
+      *reinterpret_cast<Packed128*>(&d_x[val_offset]) =
+          *reinterpret_cast<Packed128*>(dv_buffer);
     }
 
-    *reinterpret_cast<Packed128*>(&d_x[gate_offset]) =
-        *reinterpret_cast<Packed128*>(dg_buffer);
-    *reinterpret_cast<Packed128*>(&d_x[val_offset]) =
-        *reinterpret_cast<Packed128*>(dv_buffer);
-  }
+    static __shared__ float shared_sum[256];
+    if (tid < 256) shared_sum[tid] = local_d_scale_sum;
+    __syncthreads();
 
-  static __shared__ float shared_sum[256];
-  if (tid < 256) shared_sum[tid] = local_d_scale_sum;
-  __syncthreads();
+    for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+      if (tid < stride && (tid + stride) < 256) {
+        shared_sum[tid] += shared_sum[tid + stride];
+      }
+      __syncthreads();
+    }
 
-  for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
-    if (tid < stride && (tid + stride) < 256) {
-      shared_sum[tid] += shared_sum[tid + stride];
+    if (tid == 0) {
+      d_scale[row] = static_cast<ScaleT>(shared_sum[0]);
     }
     __syncthreads();
   }
+}
 
-  if (tid == 0) {
-    d_scale[row] = static_cast<ScaleT>(shared_sum[0]);
+template <typename T,
+          typename ScaleT,
+          int VEC_SIZE,
+          typename IndexT,
+          typename StreamT>
+void LaunchFusedSwiGLUScaleFwd(const T* x,
+                               const ScaleT* scale,
+                               T* out,
+                               int grid_size,
+                               int64_t rows,
+                               int64_t hidden_size,
+                               int64_t row_stride,
+                               StreamT stream) {
+  VectorizedFusedSwiGLUFwd<T, ScaleT, VEC_SIZE, IndexT>
+      <<<grid_size, kFusedSwiGLUScaleBlockSize, 0, stream>>>(
+          x,
+          scale,
+          out,
+          static_cast<IndexT>(rows),
+          static_cast<IndexT>(hidden_size),
+          static_cast<IndexT>(row_stride));
+}
+
+template <typename T, typename ScaleT, int VEC_SIZE, typename StreamT>
+void DispatchFusedSwiGLUScaleFwd(const T* x,
+                                 const ScaleT* scale,
+                                 T* out,
+                                 int grid_size,
+                                 int64_t rows,
+                                 int64_t hidden_size,
+                                 int64_t row_stride,
+                                 StreamT stream) {
+  if (ShouldUseInt64Index(rows, row_stride)) {
+    LaunchFusedSwiGLUScaleFwd<T, ScaleT, VEC_SIZE, int64_t>(
+        x, scale, out, grid_size, rows, hidden_size, row_stride, stream);
+  } else {
+    LaunchFusedSwiGLUScaleFwd<T, ScaleT, VEC_SIZE, int>(
+        x, scale, out, grid_size, rows, hidden_size, row_stride, stream);
+  }
+}
+
+template <typename T,
+          typename ScaleT,
+          int VEC_SIZE,
+          typename IndexT,
+          typename StreamT>
+void LaunchFusedSwiGLUScaleBwd(const T* x,
+                               const ScaleT* scale,
+                               const T* d_out,
+                               T* d_x,
+                               ScaleT* d_scale,
+                               int grid_size,
+                               int64_t rows,
+                               int64_t hidden_size,
+                               int64_t row_stride,
+                               StreamT stream) {
+  VectorizedFusedSwiGLUBwd<T, ScaleT, VEC_SIZE, IndexT>
+      <<<grid_size, kFusedSwiGLUScaleBlockSize, 0, stream>>>(
+          x,
+          scale,
+          d_out,
+          d_x,
+          d_scale,
+          static_cast<IndexT>(rows),
+          static_cast<IndexT>(hidden_size),
+          static_cast<IndexT>(row_stride));
+}
+
+template <typename T, typename ScaleT, int VEC_SIZE, typename StreamT>
+void DispatchFusedSwiGLUScaleBwd(const T* x,
+                                 const ScaleT* scale,
+                                 const T* d_out,
+                                 T* d_x,
+                                 ScaleT* d_scale,
+                                 int grid_size,
+                                 int64_t rows,
+                                 int64_t hidden_size,
+                                 int64_t row_stride,
+                                 StreamT stream) {
+  if (ShouldUseInt64Index(rows, row_stride)) {
+    LaunchFusedSwiGLUScaleBwd<T, ScaleT, VEC_SIZE, int64_t>(x,
+                                                            scale,
+                                                            d_out,
+                                                            d_x,
+                                                            d_scale,
+                                                            grid_size,
+                                                            rows,
+                                                            hidden_size,
+                                                            row_stride,
+                                                            stream);
+  } else {
+    LaunchFusedSwiGLUScaleBwd<T, ScaleT, VEC_SIZE, int>(x,
+                                                        scale,
+                                                        d_out,
+                                                        d_x,
+                                                        d_scale,
+                                                        grid_size,
+                                                        rows,
+                                                        hidden_size,
+                                                        row_stride,
+                                                        stream);
   }
 }
 
@@ -167,43 +298,43 @@ std::vector<paddle::Tensor> FusedSwiGLUScaleForward(
     return {out};
   }
 
-  PADDLE_ENFORCE_LE(
-      rows * hidden2,
-      static_cast<int64_t>(std::numeric_limits<int>::max()),
-      common::errors::InvalidArgument(
-          "rows * hidden2 must be <= INT_MAX for fused_swiglu_scale."));
-
-  int grid_size = rows;
-  int block_size = 256;
+  constexpr int64_t kMaxGridX = std::numeric_limits<int>::max();
+  int grid_size = static_cast<int>(std::min(rows, kMaxGridX));
   auto stream = x.stream();
 
   if (x.dtype() == paddle::DataType::BFLOAT16) {
     using paddle_bf16 = paddle::bfloat16;
     using cuda_bf16 = __nv_bfloat16;
     if (scale.dtype() == paddle::DataType::FLOAT32) {
-      VectorizedFusedSwiGLUFwd<cuda_bf16, float, 8>
-          <<<grid_size, block_size, 0, stream>>>(
-              reinterpret_cast<const cuda_bf16*>(x.data<paddle_bf16>()),
-              scale.data<float>(),
-              reinterpret_cast<cuda_bf16*>(out.data<paddle_bf16>()),
-              hidden_size,
-              hidden2);
+      DispatchFusedSwiGLUScaleFwd<cuda_bf16, float, 8>(
+          reinterpret_cast<const cuda_bf16*>(x.data<paddle_bf16>()),
+          scale.data<float>(),
+          reinterpret_cast<cuda_bf16*>(out.data<paddle_bf16>()),
+          grid_size,
+          rows,
+          hidden_size,
+          hidden2,
+          stream);
     } else {
-      VectorizedFusedSwiGLUFwd<cuda_bf16, cuda_bf16, 8>
-          <<<grid_size, block_size, 0, stream>>>(
-              reinterpret_cast<const cuda_bf16*>(x.data<paddle_bf16>()),
-              reinterpret_cast<const cuda_bf16*>(scale.data<paddle_bf16>()),
-              reinterpret_cast<cuda_bf16*>(out.data<paddle_bf16>()),
-              hidden_size,
-              hidden2);
+      DispatchFusedSwiGLUScaleFwd<cuda_bf16, cuda_bf16, 8>(
+          reinterpret_cast<const cuda_bf16*>(x.data<paddle_bf16>()),
+          reinterpret_cast<const cuda_bf16*>(scale.data<paddle_bf16>()),
+          reinterpret_cast<cuda_bf16*>(out.data<paddle_bf16>()),
+          grid_size,
+          rows,
+          hidden_size,
+          hidden2,
+          stream);
     }
   } else if (x.dtype() == paddle::DataType::FLOAT32) {
-    VectorizedFusedSwiGLUFwd<float, float, 4>
-        <<<grid_size, block_size, 0, stream>>>(x.data<float>(),
-                                               scale.data<float>(),
-                                               out.data<float>(),
-                                               hidden_size,
-                                               hidden2);
+    DispatchFusedSwiGLUScaleFwd<float, float, 4>(x.data<float>(),
+                                                 scale.data<float>(),
+                                                 out.data<float>(),
+                                                 grid_size,
+                                                 rows,
+                                                 hidden_size,
+                                                 hidden2,
+                                                 stream);
   }
   return {out};
 }
@@ -222,49 +353,49 @@ std::vector<paddle::Tensor> FusedSwiGLUScaleBackward(
     return {d_x, d_scale};
   }
 
-  PADDLE_ENFORCE_LE(
-      rows * hidden2,
-      static_cast<int64_t>(std::numeric_limits<int>::max()),
-      common::errors::InvalidArgument(
-          "rows * hidden2 must be <= INT_MAX for fused_swiglu_scale."));
-
-  int grid_size = rows;
-  int block_size = 256;
+  constexpr int64_t kMaxGridX = std::numeric_limits<int>::max();
+  int grid_size = static_cast<int>(std::min(rows, kMaxGridX));
   auto stream = x.stream();
 
   if (x.dtype() == paddle::DataType::BFLOAT16) {
     using paddle_bf16 = paddle::bfloat16;
     using cuda_bf16 = __nv_bfloat16;
     if (scale.dtype() == paddle::DataType::FLOAT32) {
-      VectorizedFusedSwiGLUBwd<cuda_bf16, float, 8>
-          <<<grid_size, block_size, 0, stream>>>(
-              reinterpret_cast<const cuda_bf16*>(x.data<paddle_bf16>()),
-              scale.data<float>(),
-              reinterpret_cast<const cuda_bf16*>(d_out.data<paddle_bf16>()),
-              reinterpret_cast<cuda_bf16*>(d_x.data<paddle_bf16>()),
-              d_scale.data<float>(),
-              hidden_size,
-              hidden2);
+      DispatchFusedSwiGLUScaleBwd<cuda_bf16, float, 8>(
+          reinterpret_cast<const cuda_bf16*>(x.data<paddle_bf16>()),
+          scale.data<float>(),
+          reinterpret_cast<const cuda_bf16*>(d_out.data<paddle_bf16>()),
+          reinterpret_cast<cuda_bf16*>(d_x.data<paddle_bf16>()),
+          d_scale.data<float>(),
+          grid_size,
+          rows,
+          hidden_size,
+          hidden2,
+          stream);
     } else {
-      VectorizedFusedSwiGLUBwd<cuda_bf16, cuda_bf16, 8>
-          <<<grid_size, block_size, 0, stream>>>(
-              reinterpret_cast<const cuda_bf16*>(x.data<paddle_bf16>()),
-              reinterpret_cast<const cuda_bf16*>(scale.data<paddle_bf16>()),
-              reinterpret_cast<const cuda_bf16*>(d_out.data<paddle_bf16>()),
-              reinterpret_cast<cuda_bf16*>(d_x.data<paddle_bf16>()),
-              reinterpret_cast<cuda_bf16*>(d_scale.data<paddle_bf16>()),
-              hidden_size,
-              hidden2);
+      DispatchFusedSwiGLUScaleBwd<cuda_bf16, cuda_bf16, 8>(
+          reinterpret_cast<const cuda_bf16*>(x.data<paddle_bf16>()),
+          reinterpret_cast<const cuda_bf16*>(scale.data<paddle_bf16>()),
+          reinterpret_cast<const cuda_bf16*>(d_out.data<paddle_bf16>()),
+          reinterpret_cast<cuda_bf16*>(d_x.data<paddle_bf16>()),
+          reinterpret_cast<cuda_bf16*>(d_scale.data<paddle_bf16>()),
+          grid_size,
+          rows,
+          hidden_size,
+          hidden2,
+          stream);
     }
   } else if (x.dtype() == paddle::DataType::FLOAT32) {
-    VectorizedFusedSwiGLUBwd<float, float, 4>
-        <<<grid_size, block_size, 0, stream>>>(x.data<float>(),
-                                               scale.data<float>(),
-                                               d_out.data<float>(),
-                                               d_x.data<float>(),
-                                               d_scale.data<float>(),
-                                               hidden_size,
-                                               hidden2);
+    DispatchFusedSwiGLUScaleBwd<float, float, 4>(x.data<float>(),
+                                                 scale.data<float>(),
+                                                 d_out.data<float>(),
+                                                 d_x.data<float>(),
+                                                 d_scale.data<float>(),
+                                                 grid_size,
+                                                 rows,
+                                                 hidden_size,
+                                                 hidden2,
+                                                 stream);
   }
   return {d_x, d_scale};
 }

--- a/packages/paddlefleet_ops/src/paddlefleet_ops/_extensions/fuse_weighted_swiglu_fp8_quant.cu
+++ b/packages/paddlefleet_ops/src/paddlefleet_ops/_extensions/fuse_weighted_swiglu_fp8_quant.cu
@@ -12,13 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <algorithm>
+#include <cstdint>
+
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/tensor_utils.h"
 #include "paddle/phi/kernels/funcs/aligned_vector.h"
 #include "paddle/phi/kernels/fusion/gpu/quant_utils.h"
 
-__host__ __device__ __forceinline__ int ceil_div(int x, int y) {
+__host__ __device__ __forceinline__ int64_t ceil_div(int64_t x, int64_t y) {
   return (x + y - 1) / y;
 }
 
@@ -162,7 +165,8 @@ __global__ void FusedSPAQKernelVec4(const phi::bfloat16* __restrict__ Xin,
       static_cast<int64_t>(threadIdx.x) * elements_per_thread;
   const unsigned int mask = 0xffffffff;  // whole warp mask
 
-  for (int64_t base_y = blockIdx.y; base_y < rows; base_y += gridDim.y) {
+  for (int64_t base_y = static_cast<int64_t>(blockIdx.y); base_y < rows;
+       base_y += static_cast<int64_t>(gridDim.y)) {
     const int64_t in_y_idx = base_y;
     const int64_t in_x_idx = static_cast<int64_t>(blockIdx.x) *
                                  static_cast<int64_t>(blockDim.x) *
@@ -265,7 +269,8 @@ __global__ void FusedSPAQKernelVec8(const phi::bfloat16* __restrict__ Xin,
       static_cast<int64_t>(threadIdx.x) * elements_per_thread;
   const unsigned int mask = 0xffffffff;
 
-  for (int64_t base_y = blockIdx.y; base_y < rows; base_y += gridDim.y) {
+  for (int64_t base_y = static_cast<int64_t>(blockIdx.y); base_y < rows;
+       base_y += static_cast<int64_t>(gridDim.y)) {
     const int64_t in_x_idx =
         ((static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x)) *
          elements_per_thread) +
@@ -370,8 +375,8 @@ __global__ void FusedSPAQKernel(const phi::bfloat16* __restrict__ Xin,
                                 const float* __restrict__ prob,
                                 phi::float8_e4m3fn* __restrict__ out,
                                 ScaleT* __restrict__ scales,
-                                const int rows,
-                                const int cols) {
+                                const int64_t rows,
+                                const int64_t cols) {
   // Configure shared memory
   __shared__ float smem_tile[256];  // Shared memory for activation values
   __shared__ float warp_max[2][4];  // Shared memory for warp maxima (2 quant
@@ -380,100 +385,107 @@ __global__ void FusedSPAQKernel(const phi::bfloat16* __restrict__ Xin,
       quant_block_amax[2];  // Shared memory for quant block maxima
 
   const __nv_bfloat16* X = reinterpret_cast<const __nv_bfloat16*>(Xin);
-  const int x_offset = threadIdx.x;
+  const int64_t x_offset = static_cast<int64_t>(threadIdx.x);
   const int quant_block_idx =
       threadIdx.x / 128;  // 0 or 1, two quant blocks per block
-  const int in_y_idx = blockIdx.y;
-  const int in_x_idx = blockIdx.x * blockDim.x + x_offset;
-  const int src_idx = in_y_idx * cols + in_x_idx;
+  const int64_t in_x_idx =
+      static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
+      x_offset;
+  const int64_t scale_stride = (cols / 2 + 127) / 128;
 
-  // Load data and compute swiGLU activation
-  if (in_x_idx < cols / 2) [[likely]] {        // NOLINT
-    __nv_bfloat16 x1 = X[src_idx];             // First half of the input
-    __nv_bfloat16 x2 = X[src_idx + cols / 2];  // Second half of the input
+  for (int64_t in_y_idx = static_cast<int64_t>(blockIdx.y); in_y_idx < rows;
+       in_y_idx += static_cast<int64_t>(gridDim.y)) {
+    const int64_t src_idx = in_y_idx * cols + in_x_idx;
 
-    if constexpr (with_prob) {
-      float row_prob = prob[in_y_idx];
-      smem_tile[x_offset] = fast_swiglu(x1, x2) * row_prob;
-    } else {
-      smem_tile[x_offset] = fast_swiglu(x1, x2);
-    }
-  }
+    // Load data and compute swiGLU activation
+    if (in_x_idx < cols / 2) [[likely]] {        // NOLINT
+      __nv_bfloat16 x1 = X[src_idx];             // First half of the input
+      __nv_bfloat16 x2 = X[src_idx + cols / 2];  // Second half of the input
 
-  __syncthreads();  // Ensure all threads have loaded their data
-
-  // Phase 2: Block Reduction to find per-quant block absolute maximums
-  float local_max = (in_x_idx < (cols / 2)) ? fabsf(smem_tile[x_offset]) : 0.0f;
-
-  // Warp-level reduction
-  unsigned int mask = 0xffffffff;
-  int lane = threadIdx.x % 32;
-  int warp_id =
-      (threadIdx.x % 128) / 32;  // Warp ID within the quant block (0-3)
-
-  // Reduce within the warp
-  for (int offset = 16; offset > 0; offset /= 2) {
-    float val = __shfl_down_sync(mask, local_max, offset);
-    local_max = fmaxf(local_max, val);
-  }
-
-  // Store warp maxima
-  if (lane == 0) {
-    warp_max[quant_block_idx][warp_id] = local_max;
-  }
-
-  __syncthreads();
-
-  // Reduce warp maxima to get quant block maxima
-  if (warp_id == 0 && lane < 4) {
-    if (threadIdx.x < 256) {  // Ensure only valid threads participate
-      float block_max = warp_max[quant_block_idx][lane];
-      // Reduce over the 4 warp maxima
-      if (lane == 0) {
-        block_max = fmaxf(block_max, warp_max[quant_block_idx][1]);
-        block_max = fmaxf(block_max, warp_max[quant_block_idx][2]);
-        block_max = fmaxf(block_max, warp_max[quant_block_idx][3]);
-        quant_block_amax[quant_block_idx] = __float2bfloat16(block_max);
-      }
-    }
-  }
-
-  __syncthreads();
-
-  // Phase 3: Compute scales and quantize the outputs
-  const float block_max_float =
-      static_cast<float>(quant_block_amax[quant_block_idx]);
-  const int scale_stride = (cols / 2 + 127) / 128;
-
-  float scale = ComputeScale<float, __nv_fp8_e4m3, using_pow2_scaling>(
-      block_max_float, 0.0f);
-  float inv_scale = __frcp_rn(scale);
-
-  // Quantize
-  float output_scaled_fp32 = smem_tile[x_offset] * scale;
-
-  const int g_output_y_offset = in_y_idx;
-  const int g_output_x_offset = in_x_idx;
-
-  // Write output and scales
-  if (g_output_y_offset < rows && g_output_x_offset < cols / 2) {
-    out[g_output_y_offset * (cols / 2) + g_output_x_offset] =
-        static_cast<phi::float8_e4m3fn>(output_scaled_fp32);
-    if (x_offset % 128 == 0) {
-      if constexpr (ue8m0) {
-        const size_t row_idx = g_output_y_offset;
-        const size_t col_idx = in_x_idx >> 7;
-        const size_t idx =
-            (col_idx >> 2) * (rows << 2) + row_idx * 4 + (col_idx & 0x3);
-        const uint8_t exp =
-            (reinterpret_cast<const int&>(inv_scale) >> 23) & 0xFF;
-        uint8_t* const dst = reinterpret_cast<uint8_t*>(scales) + idx;
-        *dst = exp;
+      if constexpr (with_prob) {
+        float row_prob = prob[in_y_idx];
+        smem_tile[x_offset] = fast_swiglu(x1, x2) * row_prob;
       } else {
-        // Only one thread per quant block writes the scale
-        scales[g_output_y_offset * scale_stride + in_x_idx / 128] = inv_scale;
+        smem_tile[x_offset] = fast_swiglu(x1, x2);
       }
     }
+
+    __syncthreads();  // Ensure all threads have loaded their data
+
+    // Phase 2: Block Reduction to find per-quant block absolute maximums
+    float local_max =
+        (in_x_idx < (cols / 2)) ? fabsf(smem_tile[x_offset]) : 0.0f;
+
+    // Warp-level reduction
+    unsigned int mask = 0xffffffff;
+    int lane = threadIdx.x % 32;
+    int warp_id =
+        (threadIdx.x % 128) / 32;  // Warp ID within the quant block (0-3)
+
+    // Reduce within the warp
+    for (int offset = 16; offset > 0; offset /= 2) {
+      float val = __shfl_down_sync(mask, local_max, offset);
+      local_max = fmaxf(local_max, val);
+    }
+
+    // Store warp maxima
+    if (lane == 0) {
+      warp_max[quant_block_idx][warp_id] = local_max;
+    }
+
+    __syncthreads();
+
+    // Reduce warp maxima to get quant block maxima
+    if (warp_id == 0 && lane < 4) {
+      if (threadIdx.x < 256) {  // Ensure only valid threads participate
+        float block_max = warp_max[quant_block_idx][lane];
+        // Reduce over the 4 warp maxima
+        if (lane == 0) {
+          block_max = fmaxf(block_max, warp_max[quant_block_idx][1]);
+          block_max = fmaxf(block_max, warp_max[quant_block_idx][2]);
+          block_max = fmaxf(block_max, warp_max[quant_block_idx][3]);
+          quant_block_amax[quant_block_idx] = __float2bfloat16(block_max);
+        }
+      }
+    }
+
+    __syncthreads();
+
+    // Phase 3: Compute scales and quantize the outputs
+    const float block_max_float =
+        static_cast<float>(quant_block_amax[quant_block_idx]);
+
+    float scale = ComputeScale<float, __nv_fp8_e4m3, using_pow2_scaling>(
+        block_max_float, 0.0f);
+    float inv_scale = __frcp_rn(scale);
+
+    // Quantize
+    float output_scaled_fp32 = smem_tile[x_offset] * scale;
+
+    const int64_t g_output_y_offset = in_y_idx;
+    const int64_t g_output_x_offset = in_x_idx;
+
+    // Write output and scales
+    if (g_output_y_offset < rows && g_output_x_offset < cols / 2) {
+      out[g_output_y_offset * (cols / 2) + g_output_x_offset] =
+          static_cast<phi::float8_e4m3fn>(output_scaled_fp32);
+      if (x_offset % 128 == 0) {
+        if constexpr (ue8m0) {
+          const size_t row_idx = g_output_y_offset;
+          const size_t col_idx = in_x_idx >> 7;
+          const size_t idx =
+              (col_idx >> 2) * (rows << 2) + row_idx * 4 + (col_idx & 0x3);
+          const uint8_t exp =
+              (reinterpret_cast<const int&>(inv_scale) >> 23) & 0xFF;
+          uint8_t* const dst = reinterpret_cast<uint8_t*>(scales) + idx;
+          *dst = exp;
+        } else {
+          // Only one thread per quant block writes the scale
+          scales[g_output_y_offset * scale_stride + in_x_idx / 128] = inv_scale;
+        }
+      }
+    }
+    __syncthreads();
   }
 }
 
@@ -483,8 +495,8 @@ void dispatch_fused_spaq(const phi::bfloat16* x_data,
                          phi::float8_e4m3fn* out_data,
                          void* void_scale_data,
                          cudaStream_t stream,
-                         const int rows,
-                         const int cols,
+                         const int64_t rows,
+                         const int64_t cols,
                          const bool& using_pow2_scaling,
                          const bool& with_prob) {
   constexpr int thread_per_block = 256;
@@ -496,12 +508,14 @@ void dispatch_fused_spaq(const phi::bfloat16* x_data,
   if (cols % 16 == 0) {
     block.x = thread_per_block;
     constexpr int vec_numel = 8;
-    const int scale_cols = (cols / 2 + 127) / 128;
+    const int64_t scale_cols = (cols / 2 + 127) / 128;
     DISPATCH_BOOL(
         using_pow2_scaling,
         k_using_pow2_scaling,
         DISPATCH_BOOL(
-            with_prob, k_with_prob, grid.y = rows > 65535 ? 65535 : rows;
+            with_prob,
+            k_with_prob,
+            grid.y = static_cast<uint32_t>(std::min<int64_t>(rows, 65535));
             grid.x =
                 ((cols / 2) + block.x * vec_numel - 1) / (block.x * vec_numel);
             LAUNCH_FUSED_SPAQ_VEC8(k_using_pow2_scaling, k_with_prob);))
@@ -512,12 +526,14 @@ void dispatch_fused_spaq(const phi::bfloat16* x_data,
     // of input vector
     block.x = thread_per_block;
     constexpr int vec_numel = 4;
-    const int scale_cols = (cols / 2 + 127) / 128;
+    const int64_t scale_cols = (cols / 2 + 127) / 128;
     DISPATCH_BOOL(
         using_pow2_scaling,
         k_using_pow2_scaling,
         DISPATCH_BOOL(
-            with_prob, k_with_prob, grid.y = rows > 65535 ? 65535 : rows;
+            with_prob,
+            k_with_prob,
+            grid.y = static_cast<uint32_t>(std::min<int64_t>(rows, 65535));
             grid.x =
                 ((cols / 2) + block.x * vec_numel - 1) / (block.x * vec_numel);
             LAUNCH_FUSED_SPAQ_VEC4(k_using_pow2_scaling, k_with_prob);))
@@ -529,7 +545,9 @@ void dispatch_fused_spaq(const phi::bfloat16* x_data,
         using_pow2_scaling,
         k_using_pow2_scaling,
         DISPATCH_BOOL(
-            with_prob, k_with_prob, grid.y = rows > 65535 ? 65535 : rows;
+            with_prob,
+            k_with_prob,
+            grid.y = static_cast<uint32_t>(std::min<int64_t>(rows, 65535));
             grid.x = ((cols / 2) + block.x - 1) / block.x;
             LAUNCH_FUSED_SPAQ(k_using_pow2_scaling, k_with_prob);))
   }
@@ -585,18 +603,18 @@ std::vector<paddle::Tensor> FusedWeightedSwigluActQuantKernel(
 
   if (use_ue8m0) {
     auto input_dim = x.dims();
-    const int token_num = input_dim[0];
-    const int hidden_size = input_dim[1];
+    const int64_t token_num = input_dim[0];
+    const int64_t hidden_size = input_dim[1];
 
     PADDLE_ENFORCE(hidden_size % 1024 == 0,
                    "hidden_size must be divisible by 1024");
-    const int hidden_size_scale = hidden_size / 2 / 128;
+    const int64_t hidden_size_scale = hidden_size / 2 / 128;
     out = GetEmptyTensor(
         {token_num, hidden_size / 2}, phi::DataType::FLOAT8_E4M3FN, x.place());
     const int tma_alignment_bytes = 16;
     const int tma_alignment_elements = tma_alignment_bytes / sizeof(float);
 
-    int padded_token_num =
+    int64_t padded_token_num =
         ((token_num + tma_alignment_elements - 1) / tma_alignment_elements) *
         tma_alignment_elements;
     scale = GetEmptyTensor({padded_token_num, ceil_div(hidden_size_scale, 4)},

--- a/packages/paddlefleet_ops/src/paddlefleet_ops/_extensions/fuse_weighted_swiglu_fp8_quant.cu
+++ b/packages/paddlefleet_ops/src/paddlefleet_ops/_extensions/fuse_weighted_swiglu_fp8_quant.cu
@@ -14,6 +14,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <limits>
 
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
@@ -236,8 +237,8 @@ __global__ void FusedSPAQKernelVec4(const phi::bfloat16* __restrict__ Xin,
       if constexpr (ue8m0) {
         const size_t row_idx = in_y_idx;
         const size_t col_idx = in_x_idx >> 7;
-        const size_t idx =
-            (col_idx >> 2) * (rows << 2) + row_idx * 4 + (col_idx & 0x3);
+        const size_t idx = (col_idx >> 2) * (static_cast<size_t>(rows) * 4) +
+                           row_idx * 4 + (col_idx & 0x3);
         const uint8_t exp =
             (reinterpret_cast<const int&>(inv_scale) >> 23) & 0xFF;
         uint8_t* const dst = reinterpret_cast<uint8_t*>(scales) + idx;
@@ -356,8 +357,8 @@ __global__ void FusedSPAQKernelVec8(const phi::bfloat16* __restrict__ Xin,
       const float inv_scale = __frcp_rn(scale);
       if constexpr (ue8m0) {
         const size_t col_idx = in_x_idx >> 7;
-        const size_t idx =
-            (col_idx >> 2) * (rows << 2) + base_y * 4 + (col_idx & 0x3);
+        const size_t idx = (col_idx >> 2) * (static_cast<size_t>(rows) * 4) +
+                           static_cast<size_t>(base_y) * 4 + (col_idx & 0x3);
         const uint8_t exp =
             (reinterpret_cast<const int&>(inv_scale) >> 23) & 0xFF;
         uint8_t* const dst = reinterpret_cast<uint8_t*>(scales) + idx;
@@ -473,8 +474,8 @@ __global__ void FusedSPAQKernel(const phi::bfloat16* __restrict__ Xin,
         if constexpr (ue8m0) {
           const size_t row_idx = g_output_y_offset;
           const size_t col_idx = in_x_idx >> 7;
-          const size_t idx =
-              (col_idx >> 2) * (rows << 2) + row_idx * 4 + (col_idx & 0x3);
+          const size_t idx = (col_idx >> 2) * (static_cast<size_t>(rows) * 4) +
+                             row_idx * 4 + (col_idx & 0x3);
           const uint8_t exp =
               (reinterpret_cast<const int&>(inv_scale) >> 23) & 0xFF;
           uint8_t* const dst = reinterpret_cast<uint8_t*>(scales) + idx;
@@ -605,6 +606,15 @@ std::vector<paddle::Tensor> FusedWeightedSwigluActQuantKernel(
     auto input_dim = x.dims();
     const int64_t token_num = input_dim[0];
     const int64_t hidden_size = input_dim[1];
+
+    constexpr int64_t kMaxRowsForUe8m0ScaleIndex =
+        static_cast<int64_t>(std::numeric_limits<size_t>::max() / 4);
+    PADDLE_ENFORCE_LE(
+        rows,
+        kMaxRowsForUe8m0ScaleIndex,
+        common::errors::InvalidArgument(
+            "rows is too large for ue8m0 scale index calculation, got %d.",
+            rows));
 
     PADDLE_ENFORCE(hidden_size % 1024 == 0,
                    "hidden_size must be divisible by 1024");

--- a/packages/paddlefleet_ops/src/paddlefleet_ops/_extensions/router_metadata.cu
+++ b/packages/paddlefleet_ops/src/paddlefleet_ops/_extensions/router_metadata.cu
@@ -19,9 +19,11 @@
 template <typename IndexT>
 __global__ void simple_arange_kernel(IndexT* output, int64_t N) {
   for (int64_t idx =
-           static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+           static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
+           static_cast<int64_t>(threadIdx.x);
        idx < N;
-       idx += static_cast<int64_t>(blockDim.x) * gridDim.x) {
+       idx +=
+       static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(gridDim.x)) {
     output[idx] = static_cast<IndexT>(idx);
   }
 }
@@ -31,9 +33,12 @@ __global__ void CountValidExpertsKernel(const T* topk_router_indices,
                                         int64_t* num_activated_per_token,
                                         int64_t num_tokens,
                                         int K) {
-  int64_t token_idx =
-      static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
-  if (token_idx < num_tokens) {
+  for (int64_t token_idx =
+           static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
+           static_cast<int64_t>(threadIdx.x);
+       token_idx < num_tokens;
+       token_idx +=
+       static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(gridDim.x)) {
     int count = 0;
     for (int k = 0; k < K; ++k) {
       if (topk_router_indices[token_idx * K + k] > -1) {
@@ -51,9 +56,12 @@ __global__ void PopulateValidInfoKernel(const T* topk_router_indices,
                                         int64_t* original_token_indices,
                                         int64_t num_tokens,
                                         int K) {
-  int64_t token_idx =
-      static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
-  if (token_idx < num_tokens) {
+  for (int64_t token_idx =
+           static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
+           static_cast<int64_t>(threadIdx.x);
+       token_idx < num_tokens;
+       token_idx +=
+       static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(gridDim.x)) {
     int64_t base_offset = num_activated_offset[token_idx];
     int64_t current_offset = 0;
     for (int k = 0; k < K; ++k) {
@@ -72,8 +80,12 @@ __global__ void GenerateReverseScatterKernel(
     const int64_t* s_scatter_idx_valid,
     int64_t* s_reverse_scatter_idx_valid,
     int64_t total_valid_experts) {
-  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
-  if (idx < total_valid_experts) {
+  for (int64_t idx =
+           static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
+           static_cast<int64_t>(threadIdx.x);
+       idx < total_valid_experts;
+       idx +=
+       static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(gridDim.x)) {
     s_reverse_scatter_idx_valid[s_scatter_idx_valid[idx]] = idx;
   }
 }
@@ -82,8 +94,12 @@ __global__ void ComputeXGatherIdxKernel(const int64_t* s_scatter_idx_all,
                                         int64_t* x_gather_idx_all,
                                         int K,
                                         int64_t n) {
-  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
-  if (idx < n) {
+  for (int64_t idx =
+           static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
+           static_cast<int64_t>(threadIdx.x);
+       idx < n;
+       idx +=
+       static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(gridDim.x)) {
     x_gather_idx_all[idx] = s_scatter_idx_all[idx] / K;
   }
 }

--- a/packages/paddlefleet_ops/src/paddlefleet_ops/_extensions/router_metadata.cu
+++ b/packages/paddlefleet_ops/src/paddlefleet_ops/_extensions/router_metadata.cu
@@ -15,23 +15,24 @@
 #include <cuda_runtime.h>
 #include <paddle/extension.h>
 #include <cub/cub.cuh>
-#include <limits>
 
-__global__ void simple_arange_kernel(int* output, int64_t N) {
+template <typename IndexT>
+__global__ void simple_arange_kernel(IndexT* output, int64_t N) {
   for (int64_t idx =
            static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
        idx < N;
        idx += static_cast<int64_t>(blockDim.x) * gridDim.x) {
-    output[idx] = static_cast<int>(idx);
+    output[idx] = static_cast<IndexT>(idx);
   }
 }
 
 template <typename T>
 __global__ void CountValidExpertsKernel(const T* topk_router_indices,
-                                        int* num_activated_per_token,
-                                        int num_tokens,
+                                        int64_t* num_activated_per_token,
+                                        int64_t num_tokens,
                                         int K) {
-  int token_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  int64_t token_idx =
+      static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   if (token_idx < num_tokens) {
     int count = 0;
     for (int k = 0; k < K; ++k) {
@@ -45,19 +46,20 @@ __global__ void CountValidExpertsKernel(const T* topk_router_indices,
 
 template <typename T>
 __global__ void PopulateValidInfoKernel(const T* topk_router_indices,
-                                        const int* num_activated_offset,
+                                        const int64_t* num_activated_offset,
                                         T* valid_expert_ids,
-                                        int* original_token_indices,
-                                        int num_tokens,
+                                        int64_t* original_token_indices,
+                                        int64_t num_tokens,
                                         int K) {
-  int token_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  int64_t token_idx =
+      static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   if (token_idx < num_tokens) {
-    int base_offset = num_activated_offset[token_idx];
-    int current_offset = 0;
+    int64_t base_offset = num_activated_offset[token_idx];
+    int64_t current_offset = 0;
     for (int k = 0; k < K; ++k) {
       T expert_id = topk_router_indices[token_idx * K + k];
       if (expert_id > -1) {
-        int flat_idx = base_offset + current_offset;
+        int64_t flat_idx = base_offset + current_offset;
         valid_expert_ids[flat_idx] = expert_id;
         original_token_indices[flat_idx] = token_idx;
         current_offset++;
@@ -66,36 +68,39 @@ __global__ void PopulateValidInfoKernel(const T* topk_router_indices,
   }
 }
 
-__global__ void GenerateReverseScatterKernel(const int* s_scatter_idx_valid,
-                                             int* s_reverse_scatter_idx_valid,
-                                             int total_valid_experts) {
-  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+__global__ void GenerateReverseScatterKernel(
+    const int64_t* s_scatter_idx_valid,
+    int64_t* s_reverse_scatter_idx_valid,
+    int64_t total_valid_experts) {
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   if (idx < total_valid_experts) {
     s_reverse_scatter_idx_valid[s_scatter_idx_valid[idx]] = idx;
   }
 }
 
-__global__ void ComputeXGatherIdxKernel(const int* s_scatter_idx_all,
-                                        int* x_gather_idx_all,
+__global__ void ComputeXGatherIdxKernel(const int64_t* s_scatter_idx_all,
+                                        int64_t* x_gather_idx_all,
                                         int K,
-                                        int n) {
-  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+                                        int64_t n) {
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   if (idx < n) {
     x_gather_idx_all[idx] = s_scatter_idx_all[idx] / K;
   }
 }
 
-cudaError_t launch_simple_arange(int* output,
+template <typename IndexT>
+cudaError_t launch_simple_arange(IndexT* output,
                                  int64_t N,
                                  cudaStream_t stream = nullptr) {
   if (N <= 0) return cudaSuccess;
   const int threads_per_block = 256;
   const int max_blocks = 1024;
-  const int needed_blocks =
-      static_cast<int>((N + threads_per_block - 1) / threads_per_block);
-  const int blocks = (needed_blocks < max_blocks) ? needed_blocks : max_blocks;
+  const int64_t needed_blocks = (N + threads_per_block - 1) / threads_per_block;
+  const int blocks =
+      static_cast<int>(std::min<int64_t>(needed_blocks, max_blocks));
 
-  simple_arange_kernel<<<blocks, threads_per_block, 0, stream>>>(output, N);
+  simple_arange_kernel<IndexT>
+      <<<blocks, threads_per_block, 0, stream>>>(output, N);
   return cudaGetLastError();
 }
 
@@ -106,13 +111,7 @@ std::vector<paddle::Tensor> RouterMetadataCuda(
     int K) {
   int64_t num_tokens = topk_router_indices.shape()[0];
   int64_t num_experts = expert_frequency_offset.shape()[0];
-  PADDLE_ENFORCE_LE(
-      num_tokens * K,
-      static_cast<int64_t>(std::numeric_limits<int>::max()),
-      common::errors::InvalidArgument(
-          "num_tokens * K must be <= INT_MAX for router_metadata kernels."));
-
-  const int total_elements = static_cast<int>(num_tokens * K);
+  const int64_t total_elements = num_tokens * static_cast<int64_t>(K);
   auto place = topk_router_indices.place();
   cudaStream_t stream = topk_router_indices.stream();
 
@@ -122,18 +121,19 @@ std::vector<paddle::Tensor> RouterMetadataCuda(
       .copy_(expert_frequency_offset, place, false);
 
   auto num_activated_per_token =
-      paddle::empty({num_tokens}, paddle::DataType::INT32, place);
+      paddle::empty({num_tokens}, paddle::DataType::INT64, place);
   auto num_activated_per_token_offset =
-      paddle::empty({num_tokens + 1}, paddle::DataType::INT32, place);
+      paddle::empty({num_tokens + 1}, paddle::DataType::INT64, place);
   int threads = 256;
-  int blocks = static_cast<int>((num_tokens + threads - 1) / threads);
+  int blocks = static_cast<int>(
+      std::min<int64_t>((num_tokens + threads - 1) / threads, 4096));
 
   if (num_tokens > 0) {
-    CountValidExpertsKernel<T>
-        <<<blocks, threads, 0, stream>>>(topk_router_indices.template data<T>(),
-                                         num_activated_per_token.data<int>(),
-                                         num_tokens,
-                                         K);
+    CountValidExpertsKernel<T><<<blocks, threads, 0, stream>>>(
+        topk_router_indices.template data<T>(),
+        num_activated_per_token.data<int64_t>(),
+        num_tokens,
+        K);
     PD_CHECK(cudaGetLastError() == cudaSuccess,
              "CountValidExpertsKernel failed.");
   }
@@ -144,8 +144,8 @@ std::vector<paddle::Tensor> RouterMetadataCuda(
     cub::DeviceScan::InclusiveSum(
         nullptr,
         scan_temp_storage_bytes,
-        num_activated_per_token.data<int>(),
-        num_activated_per_token_offset.slice(1, num_tokens + 1).data<int>(),
+        num_activated_per_token.data<int64_t>(),
+        num_activated_per_token_offset.slice(1, num_tokens + 1).data<int64_t>(),
         num_tokens,
         stream);
 
@@ -155,30 +155,30 @@ std::vector<paddle::Tensor> RouterMetadataCuda(
                       place);
     scan_temp_storage = scan_temp_storage_tensor.data();
 
-    PD_CHECK(cudaMemsetAsync(num_activated_per_token_offset.data<int>(),
+    PD_CHECK(cudaMemsetAsync(num_activated_per_token_offset.data<int64_t>(),
                              0,
-                             sizeof(int),
+                             sizeof(int64_t),
                              stream) == cudaSuccess,
              "cudaMemsetAsync failed.");
 
     cub::DeviceScan::InclusiveSum(
         scan_temp_storage,
         scan_temp_storage_bytes,
-        num_activated_per_token.data<int>(),
-        num_activated_per_token_offset.slice(1, num_tokens + 1).data<int>(),
+        num_activated_per_token.data<int64_t>(),
+        num_activated_per_token_offset.slice(1, num_tokens + 1).data<int64_t>(),
         num_tokens,
         stream);
     PD_CHECK(cudaGetLastError() == cudaSuccess,
              "cub::DeviceScan::InclusiveSum failed.");
   }
 
-  int total_valid_experts = 0;
+  int64_t total_valid_experts = 0;
   if (num_tokens > 0) {
     PD_CHECK(cudaMemcpyAsync(&total_valid_experts,
                              num_activated_per_token_offset
                                  .slice(num_tokens, num_tokens + 1)
-                                 .data<int>(),
-                             sizeof(int),
+                                 .data<int64_t>(),
+                             sizeof(int64_t),
                              cudaMemcpyDeviceToHost,
                              stream) == cudaSuccess,
              "cudaMemcpyAsync total_valid_experts failed.");
@@ -187,7 +187,7 @@ std::vector<paddle::Tensor> RouterMetadataCuda(
            "cudaStreamSynchronize failed for total_valid_experts.");
 
   if (total_valid_experts == 0) {
-    auto empty_indices = paddle::empty({0}, paddle::DataType::INT32, place);
+    auto empty_indices = paddle::empty({0}, paddle::DataType::INT64, place);
     return {padded_expert_frequency_offset,
             empty_indices,
             empty_indices,
@@ -198,37 +198,37 @@ std::vector<paddle::Tensor> RouterMetadataCuda(
   auto valid_expert_ids =
       paddle::empty({total_valid_experts}, topk_router_indices.dtype(), place);
   auto original_token_indices =
-      paddle::empty({total_valid_experts}, paddle::DataType::INT32, place);
+      paddle::empty({total_valid_experts}, paddle::DataType::INT64, place);
 
   PopulateValidInfoKernel<T><<<blocks, threads, 0, stream>>>(
       topk_router_indices.template data<T>(),
-      num_activated_per_token_offset.data<int>(),
+      num_activated_per_token_offset.data<int64_t>(),
       valid_expert_ids.template data<T>(),
-      original_token_indices.data<int>(),
+      original_token_indices.data<int64_t>(),
       num_tokens,
       K);
   PD_CHECK(cudaGetLastError() == cudaSuccess,
            "PopulateValidInfoKernel failed.");
 
   auto original_flat_indices_valid =
-      paddle::empty({total_valid_experts}, paddle::DataType::INT32, place);
-  PD_CHECK(launch_simple_arange(original_flat_indices_valid.data<int>(),
+      paddle::empty({total_valid_experts}, paddle::DataType::INT64, place);
+  PD_CHECK(launch_simple_arange(original_flat_indices_valid.data<int64_t>(),
                                 total_valid_experts,
                                 stream) == cudaSuccess,
            "launch_simple_arange for valid failed.");
   auto sorted_valid_expert_ids = paddle::empty_like(valid_expert_ids);
   auto s_scatter_idx_valid =
-      paddle::empty({total_valid_experts}, paddle::DataType::INT32, place);
+      paddle::empty({total_valid_experts}, paddle::DataType::INT64, place);
 
   void* sort_temp_storage = nullptr;
   size_t sort_temp_bytes = 0;
-  cub::DeviceRadixSort::SortPairs<T, int>(
+  cub::DeviceRadixSort::SortPairs<T, int64_t>(
       nullptr,
       sort_temp_bytes,
       valid_expert_ids.template data<T>(),
       sorted_valid_expert_ids.template data<T>(),
-      original_flat_indices_valid.data<int>(),
-      s_scatter_idx_valid.data<int>(),
+      original_flat_indices_valid.data<int64_t>(),
+      s_scatter_idx_valid.data<int64_t>(),
       total_valid_experts,
       0,
       sizeof(T) * 8,
@@ -236,13 +236,13 @@ std::vector<paddle::Tensor> RouterMetadataCuda(
   auto sort_temp_storage_tensor = paddle::empty(
       {static_cast<int64_t>(sort_temp_bytes)}, paddle::DataType::UINT8, place);
   sort_temp_storage = sort_temp_storage_tensor.data();
-  cub::DeviceRadixSort::SortPairs<T, int>(
+  cub::DeviceRadixSort::SortPairs<T, int64_t>(
       sort_temp_storage,
       sort_temp_bytes,
       valid_expert_ids.template data<T>(),
       sorted_valid_expert_ids.template data<T>(),
-      original_flat_indices_valid.data<int>(),
-      s_scatter_idx_valid.data<int>(),
+      original_flat_indices_valid.data<int64_t>(),
+      s_scatter_idx_valid.data<int64_t>(),
       total_valid_experts,
       0,
       sizeof(T) * 8,
@@ -251,36 +251,37 @@ std::vector<paddle::Tensor> RouterMetadataCuda(
            "cub::DeviceRadixSort::SortPairs for valid failed.");
 
   auto s_reverse_scatter_idx_valid =
-      paddle::empty({total_valid_experts}, paddle::DataType::INT32, place);
-  int blocks_valid_out = (total_valid_experts + threads - 1) / threads;
+      paddle::empty({total_valid_experts}, paddle::DataType::INT64, place);
+  int blocks_valid_out = static_cast<int>(
+      std::min<int64_t>((total_valid_experts + threads - 1) / threads, 4096));
   GenerateReverseScatterKernel<<<blocks_valid_out, threads, 0, stream>>>(
-      s_scatter_idx_valid.data<int>(),
-      s_reverse_scatter_idx_valid.data<int>(),
+      s_scatter_idx_valid.data<int64_t>(),
+      s_reverse_scatter_idx_valid.data<int64_t>(),
       total_valid_experts);
   PD_CHECK(cudaGetLastError() == cudaSuccess,
            "GenerateReverseScatterKernel failed.");
 
   auto original_full_indices =
-      paddle::empty({total_elements}, paddle::DataType::INT32, place);
-  PD_CHECK(launch_simple_arange(original_full_indices.data<int>(),
+      paddle::empty({total_elements}, paddle::DataType::INT64, place);
+  PD_CHECK(launch_simple_arange(original_full_indices.data<int64_t>(),
                                 total_elements,
                                 stream) == cudaSuccess,
            "launch_simple_arange for full failed.");
   auto s_scatter_idx_all =
-      paddle::empty({total_elements}, paddle::DataType::INT32, place);
+      paddle::empty({total_elements}, paddle::DataType::INT64, place);
   auto topk_router_indices_flat =
       paddle::reshape(topk_router_indices, {total_elements});
   auto sorted_topk_indices_temp = paddle::empty_like(topk_router_indices_flat);
 
   size_t sort_all_bytes = 0;
   void* sort_all_temp_storage = nullptr;
-  cub::DeviceRadixSort::SortPairs<T, int>(
+  cub::DeviceRadixSort::SortPairs<T, int64_t>(
       nullptr,
       sort_all_bytes,
       topk_router_indices_flat.template data<T>(),
       sorted_topk_indices_temp.template data<T>(),
-      original_full_indices.data<int>(),
-      s_scatter_idx_all.data<int>(),
+      original_full_indices.data<int64_t>(),
+      s_scatter_idx_all.data<int64_t>(),
       total_elements,
       0,
       sizeof(T) * 8,
@@ -288,13 +289,13 @@ std::vector<paddle::Tensor> RouterMetadataCuda(
   auto sort_all_temp_storage_tensor = paddle::empty(
       {static_cast<int64_t>(sort_all_bytes)}, paddle::DataType::UINT8, place);
   sort_all_temp_storage = sort_all_temp_storage_tensor.data();
-  cub::DeviceRadixSort::SortPairs<T, int>(
+  cub::DeviceRadixSort::SortPairs<T, int64_t>(
       sort_all_temp_storage,
       sort_all_bytes,
       topk_router_indices_flat.template data<T>(),
       sorted_topk_indices_temp.template data<T>(),
-      original_full_indices.data<int>(),
-      s_scatter_idx_all.data<int>(),
+      original_full_indices.data<int64_t>(),
+      s_scatter_idx_all.data<int64_t>(),
       total_elements,
       0,
       sizeof(T) * 8,
@@ -303,17 +304,18 @@ std::vector<paddle::Tensor> RouterMetadataCuda(
            "cub::DeviceRadixSort::SortPairs for all failed.");
 
   auto x_gather_idx_all =
-      paddle::empty({total_elements}, paddle::DataType::INT32, place);
-  int blocks_all_out = (total_elements + threads - 1) / threads;
+      paddle::empty({total_elements}, paddle::DataType::INT64, place);
+  int blocks_all_out = static_cast<int>(
+      std::min<int64_t>((total_elements + threads - 1) / threads, 4096));
   ComputeXGatherIdxKernel<<<blocks_all_out, threads, 0, stream>>>(
-      s_scatter_idx_all.data<int>(),
-      x_gather_idx_all.data<int>(),
+      s_scatter_idx_all.data<int64_t>(),
+      x_gather_idx_all.data<int64_t>(),
       K,
       total_elements);
   PD_CHECK(cudaGetLastError() == cudaSuccess,
            "ComputeXGatherIdxKernel failed.");
 
-  int invalid_tokens = total_elements - total_valid_experts;
+  int64_t invalid_tokens = total_elements - total_valid_experts;
   auto x_gather_idx = x_gather_idx_all.slice(invalid_tokens, total_elements);
 
   return {padded_expert_frequency_offset,

--- a/packages/paddlefleet_ops/src/paddlefleet_ops/_extensions/swiglu_kernel.cu
+++ b/packages/paddlefleet_ops/src/paddlefleet_ops/_extensions/swiglu_kernel.cu
@@ -14,6 +14,7 @@
 
 // swiglu_kernel.cu
 #include <cuda_bf16.h>
+#include <algorithm>
 #include <cstdint>
 #include <limits>
 #include <vector>
@@ -36,9 +37,12 @@ inline bool ShouldUseInt64Index(int64_t rows, int64_t row_stride) {
   //   row * row_stride + col
   // The G offset uses row * hidden_size + col. For fused_swiglu_bwd,
   // row_stride is 2 * hidden_size after shape checks, so any int32-safe Y/DX
-  // offset range also bounds the G offset range.
-  return rows >=
-         static_cast<int64_t>(std::numeric_limits<int>::max()) / row_stride;
+  // offset range also bounds the G offset range. Rows beyond INT_MAX also
+  // require int64_t row iteration because the kernel uses a capped CUDA grid
+  // and grid-stride over rows.
+  return rows > static_cast<int64_t>(std::numeric_limits<int>::max()) ||
+         rows >=
+             static_cast<int64_t>(std::numeric_limits<int>::max()) / row_stride;
 }
 
 inline void CheckSwiGLUBackShape(const paddle::Tensor& g,
@@ -116,50 +120,54 @@ template <typename T, int VEC_SIZE, typename IndexT>
 __global__ void VectorizedSwiGLUBackKernel(const T* __restrict__ g,
                                            const T* __restrict__ y,
                                            T* __restrict__ dx,
+                                           int64_t rows,
                                            IndexT hidden_size,
                                            IndexT input_stride) {
-  IndexT row = static_cast<IndexT>(blockIdx.x);
   int tid = threadIdx.x;
   IndexT lane_idx = static_cast<IndexT>(tid) * VEC_SIZE;
 
-  for (IndexT col = lane_idx; col < hidden_size;
-       col += static_cast<IndexT>(blockDim.x) * VEC_SIZE) {
-    IndexT g_offset = row * hidden_size + col;
-    IndexT y1_offset = row * input_stride + col;
-    IndexT y2_offset = y1_offset + hidden_size;
+  for (int64_t row = static_cast<int64_t>(blockIdx.x); row < rows;
+       row += static_cast<int64_t>(gridDim.x)) {
+    IndexT row_index = static_cast<IndexT>(row);
+    for (IndexT col = lane_idx; col < hidden_size;
+         col += static_cast<IndexT>(blockDim.x) * VEC_SIZE) {
+      IndexT g_offset = row_index * hidden_size + col;
+      IndexT y1_offset = row_index * input_stride + col;
+      IndexT y2_offset = y1_offset + hidden_size;
 
-    Packed128 g_pack = *reinterpret_cast<const Packed128*>(&g[g_offset]);
-    Packed128 y1_pack = *reinterpret_cast<const Packed128*>(&y[y1_offset]);
-    Packed128 y2_pack = *reinterpret_cast<const Packed128*>(&y[y2_offset]);
+      Packed128 g_pack = *reinterpret_cast<const Packed128*>(&g[g_offset]);
+      Packed128 y1_pack = *reinterpret_cast<const Packed128*>(&y[y1_offset]);
+      Packed128 y2_pack = *reinterpret_cast<const Packed128*>(&y[y2_offset]);
 
-    const T* g_ptr = reinterpret_cast<const T*>(&g_pack);
-    const T* y1_ptr = reinterpret_cast<const T*>(&y1_pack);
-    const T* y2_ptr = reinterpret_cast<const T*>(&y2_pack);
+      const T* g_ptr = reinterpret_cast<const T*>(&g_pack);
+      const T* y1_ptr = reinterpret_cast<const T*>(&y1_pack);
+      const T* y2_ptr = reinterpret_cast<const T*>(&y2_pack);
 
-    T dx1_buffer[VEC_SIZE];
-    T dx2_buffer[VEC_SIZE];
+      T dx1_buffer[VEC_SIZE];
+      T dx2_buffer[VEC_SIZE];
 
 #pragma unroll
-    for (int i = 0; i < VEC_SIZE; ++i) {
-      float val_g = static_cast<float>(g_ptr[i]);
-      float val_y1 = static_cast<float>(y1_ptr[i]);
-      float val_y2 = static_cast<float>(y2_ptr[i]);
+      for (int i = 0; i < VEC_SIZE; ++i) {
+        float val_g = static_cast<float>(g_ptr[i]);
+        float val_y1 = static_cast<float>(y1_ptr[i]);
+        float val_y2 = static_cast<float>(y2_ptr[i]);
 
-      float sig_y1 = precise_sigmoid(val_y1);
-      float silu_y1 = val_y1 * sig_y1;
+        float sig_y1 = precise_sigmoid(val_y1);
+        float silu_y1 = val_y1 * sig_y1;
 
-      dx2_buffer[i] = static_cast<T>(val_g * silu_y1);
+        dx2_buffer[i] = static_cast<T>(val_g * silu_y1);
 
-      float d_silu = sig_y1 * (1.0f + val_y1 * (1.0f - sig_y1));
-      float grad_y1 = val_g * val_y2 * d_silu;
+        float d_silu = sig_y1 * (1.0f + val_y1 * (1.0f - sig_y1));
+        float grad_y1 = val_g * val_y2 * d_silu;
 
-      dx1_buffer[i] = static_cast<T>(grad_y1);
+        dx1_buffer[i] = static_cast<T>(grad_y1);
+      }
+
+      *reinterpret_cast<Packed128*>(&dx[y1_offset]) =
+          *reinterpret_cast<Packed128*>(dx1_buffer);
+      *reinterpret_cast<Packed128*>(&dx[y2_offset]) =
+          *reinterpret_cast<Packed128*>(dx2_buffer);
     }
-
-    *reinterpret_cast<Packed128*>(&dx[y1_offset]) =
-        *reinterpret_cast<Packed128*>(dx1_buffer);
-    *reinterpret_cast<Packed128*>(&dx[y2_offset]) =
-        *reinterpret_cast<Packed128*>(dx2_buffer);
   }
 }
 
@@ -168,6 +176,7 @@ void LaunchSwiGLUBackKernel(const T* g,
                             const T* y,
                             T* dx,
                             int grid_size,
+                            int64_t rows,
                             int64_t hidden_size,
                             int64_t input_stride,
                             StreamT stream) {
@@ -176,6 +185,7 @@ void LaunchSwiGLUBackKernel(const T* g,
           g,
           y,
           dx,
+          rows,
           static_cast<IndexT>(hidden_size),
           static_cast<IndexT>(input_stride));
 }
@@ -191,10 +201,10 @@ void DispatchSwiGLUBackKernel(const T* g,
                               StreamT stream) {
   if (ShouldUseInt64Index(rows, input_stride)) {
     LaunchSwiGLUBackKernel<T, VEC_SIZE, int64_t>(
-        g, y, dx, grid_size, hidden_size, input_stride, stream);
+        g, y, dx, grid_size, rows, hidden_size, input_stride, stream);
   } else {
     LaunchSwiGLUBackKernel<T, VEC_SIZE, int>(
-        g, y, dx, grid_size, hidden_size, input_stride, stream);
+        g, y, dx, grid_size, rows, hidden_size, input_stride, stream);
   }
 }
 
@@ -232,14 +242,8 @@ std::vector<paddle::Tensor> SwiGLUBackward(const paddle::Tensor& g,
 
   CheckSwiGLUBackPackedAccess(y.dtype(), hidden_size);
 
-  PADDLE_ENFORCE_LE(
-      rows,
-      static_cast<int64_t>(std::numeric_limits<int>::max()),
-      common::errors::InvalidArgument(
-          "rows must be <= INT_MAX for fused_swiglu_bwd because one CUDA "
-          "block is launched per row."));
-
-  int grid_size = static_cast<int>(rows);
+  constexpr int64_t kMaxGridX = 65535;
+  int grid_size = static_cast<int>(std::min(rows, kMaxGridX));
   auto stream = y.stream();
 
   if (y.dtype() == paddle::DataType::BFLOAT16) {

--- a/packages/paddlefleet_ops/src/paddlefleet_ops/_extensions/swiglu_kernel.cu
+++ b/packages/paddlefleet_ops/src/paddlefleet_ops/_extensions/swiglu_kernel.cu
@@ -14,11 +14,10 @@
 
 // swiglu_kernel.cu
 #include <cuda_bf16.h>
-#include <algorithm>
 #include <cstdint>
-#include <limits>
 #include <vector>
 #include "paddle/extension.h"
+#include "swiglu_utils.h"
 
 // 128-bit memory alignment struct
 struct __align__(16) Packed128 {
@@ -31,19 +30,6 @@ __device__ __forceinline__ float precise_sigmoid(T x) {
 }
 
 constexpr int kSwiGLUBackBlockSize = 256;
-
-inline bool ShouldUseInt64Index(int64_t rows, int64_t row_stride) {
-  // This predicate protects Y/DX offsets:
-  //   row * row_stride + col
-  // The G offset uses row * hidden_size + col. For fused_swiglu_bwd,
-  // row_stride is 2 * hidden_size after shape checks, so any int32-safe Y/DX
-  // offset range also bounds the G offset range. Rows beyond INT_MAX also
-  // require int64_t row iteration because the kernel uses a capped CUDA grid
-  // and grid-stride over rows.
-  return rows > static_cast<int64_t>(std::numeric_limits<int>::max()) ||
-         rows >=
-             static_cast<int64_t>(std::numeric_limits<int>::max()) / row_stride;
-}
 
 inline void CheckSwiGLUBackShape(const paddle::Tensor& g,
                                  const paddle::Tensor& y,
@@ -199,7 +185,7 @@ void DispatchSwiGLUBackKernel(const T* g,
                               int64_t hidden_size,
                               int64_t input_stride,
                               StreamT stream) {
-  if (ShouldUseInt64Index(rows, input_stride)) {
+  if (paddlefleet::extensions::ShouldUseInt64Index(rows, input_stride)) {
     LaunchSwiGLUBackKernel<T, VEC_SIZE, int64_t>(
         g, y, dx, grid_size, rows, hidden_size, input_stride, stream);
   } else {
@@ -242,8 +228,7 @@ std::vector<paddle::Tensor> SwiGLUBackward(const paddle::Tensor& g,
 
   CheckSwiGLUBackPackedAccess(y.dtype(), hidden_size);
 
-  constexpr int64_t kMaxGridX = 65535;
-  int grid_size = static_cast<int>(std::min(rows, kMaxGridX));
+  int grid_size = paddlefleet::extensions::GetSwiGLURowGridSize(rows);
   auto stream = y.stream();
 
   if (y.dtype() == paddle::DataType::BFLOAT16) {

--- a/packages/paddlefleet_ops/src/paddlefleet_ops/_extensions/swiglu_utils.h
+++ b/packages/paddlefleet_ops/src/paddlefleet_ops/_extensions/swiglu_utils.h
@@ -1,0 +1,49 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <limits>
+
+namespace paddlefleet {
+namespace extensions {
+
+constexpr int64_t kSwiGLUMaxRowGridSize = 65535;
+
+inline int GetSwiGLURowGridSize(int64_t rows) {
+  if (rows <= 0) {
+    return 0;
+  }
+  return static_cast<int>(rows < kSwiGLUMaxRowGridSize ? rows
+                                                       : kSwiGLUMaxRowGridSize);
+}
+
+inline bool ShouldUseInt64Index(int64_t rows, int64_t row_stride) {
+  if (rows <= 0 || row_stride <= 0) {
+    return false;
+  }
+
+  // The int32 path stores row_stride in IndexT, so row_stride itself must fit.
+  // It is safe for offsets iff the largest linear offset is <= INT_MAX:
+  //   rows * row_stride - 1 <= INT_MAX
+  // Use division instead of multiplying to avoid int64 overflow.
+  constexpr int64_t kIntMax =
+      static_cast<int64_t>(std::numeric_limits<int>::max());
+  constexpr int64_t kIntMaxPlusOne = kIntMax + 1;
+  return row_stride > kIntMax || rows > kIntMaxPlusOne / row_stride;
+}
+
+}  // namespace extensions
+}  // namespace paddlefleet


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Improvements

### Description
- Remove the `INT_MAX` element-count guards in `filter_scores`/`filter_scores_grad` by switching valid counts, scan masks, and write indices to int64.
- Remove the `num_tokens * K <= INT_MAX` guard in `router_metadata` by switching intermediate offsets/scatter indices to int64 and using int64 CUB sort pairs.
- Clamp launch grid sizes while keeping kernel loops and offsets in int64.
- Support row counts beyond int32 range in `fuse_swiglu_scale.cu`, `swiglu_kernel.cu`, and `fuse_weighted_swiglu_fp8_quant.cu` with grid-stride row iteration.
- Note: `tokens_stable_unzip.cu` still has deeper int32 design constraints; `fuse_stack_transpose_fp8_quant.cu` and `fused_apply_rotary_pos_emb_vision.cu` are mainly CUDA launch-topology constraints, not addressed here.
