### PR TITLE
Support k_grouped_gemm in auto_subbatch fallback

### DIFF
--- a/src/paddlefleet/transformer/moe/fp8_utils.py
+++ b/src/paddlefleet/transformer/moe/fp8_utils.py
@@ -1405,7 +1405,7 @@ class ExpertsGroupGemmContiguousNode:
         subbatch_rows = self.moe_subbatch_token_num_after_dispatch
         if subbatch_rows is None:
             self.tokens_per_expert_tensor = paddle.to_tensor(
-                self.tokens_per_expert, dtype="int64"
+                self.tokens_per_expert, dtype="int32"
             )
             return self.backward_impl(
                 out_grad, unzipped_probs, a2a_async_fn=a2a_async_fn
@@ -1420,7 +1420,7 @@ class ExpertsGroupGemmContiguousNode:
         nparts = (rows + subbatch_rows - 1) // subbatch_rows
         if nparts <= 1:
             self.tokens_per_expert_tensor = paddle.to_tensor(
-                self.tokens_per_expert, dtype="int64"
+                self.tokens_per_expert, dtype="int32"
             )
             return self.backward_impl(
                 out_grad, unzipped_probs, a2a_async_fn=a2a_async_fn
@@ -1447,13 +1447,14 @@ class ExpertsGroupGemmContiguousNode:
                 self.o1 = o1._slice(s_idx, e_idx)
             self.tokens_per_expert = [e_idx - s_idx]
             self.tokens_per_expert_tensor = paddle.to_tensor(
-                self.tokens_per_expert, dtype="int64"
+                self.tokens_per_expert, dtype="int32"
             )
             if self.moe_deep_gemm:
                 self.tokens_per_expert_indices = paddle.repeat_interleave(
                     paddle.arange(len(self.tokens_per_expert)),
                     paddle.to_tensor(self.tokens_per_expert),
                 ).cast("int32")
+                self.m_indices = self.gen_m_indices(self.tokens_per_expert)
 
             tmp_out_grad = out_grad._slice(s_idx, e_idx)
             tmp_unzipped_probs = unzipped_probs._slice(s_idx, e_idx)

--- a/src/paddlefleet/transformer/moe/fusion_layer_utils.py
+++ b/src/paddlefleet/transformer/moe/fusion_layer_utils.py
@@ -683,12 +683,73 @@ class MlpNode:
 
     # ==================== forward methods ====================
 
+    def _ensure_weight_grad(self):
+        """Pre-allocate weight grads so VMM free-memory query reflects true availability."""
+        if self.experts is not None:
+            for expert in self.experts:
+                if expert is None:
+                    continue
+                for weight in (
+                    expert.up_gate_proj.weight,
+                    expert.down_proj.weight,
+                ):
+                    grad_attr = (
+                        "main_grad" if hasattr(weight, "main_grad") else "grad"
+                    )
+                    if getattr(weight, grad_attr) is None:
+                        setattr(
+                            weight,
+                            grad_attr,
+                            paddle.zeros(weight.shape, dtype=paddle.float32),
+                        )
+            return
+
+        # deep_gemm: stacked weight
+        nodes = self.experts_group_gemm_node
+        if isinstance(nodes, list):
+            first_sliced = getattr(nodes[0], "grouped_gemm_experts", None)
+            if first_sliced is None or not hasattr(first_sliced, "_parent"):
+                return
+            parent = first_sliced._parent
+        else:
+            parent = getattr(nodes, "grouped_gemm_experts", None)
+            if parent is None:
+                return
+
+        for attr in ("weight1", "weight2"):
+            pw = getattr(parent, attr)
+            grad_attr = "main_grad" if hasattr(pw, "main_grad") else "grad"
+            if getattr(pw, grad_attr) is None:
+                setattr(
+                    pw, grad_attr, paddle.zeros(pw.shape, dtype=paddle.float32)
+                )
+
+    def _slice_weight_grad(self):
+        """Set up grad views on sliced weights pointing back to parent grad."""
+        for gemm_node in self.experts_group_gemm_node:
+            sliced = getattr(gemm_node, "grouped_gemm_experts", None)
+            if sliced is None or not hasattr(sliced, "_parent"):
+                continue
+            parent = sliced._parent
+            lid = sliced._local_id
+            for attr in ("weight1", "weight2"):
+                pw = getattr(parent, attr)
+                sw = getattr(sliced, attr)
+                grad_attr = "main_grad" if hasattr(pw, "main_grad") else "grad"
+                if getattr(sw, grad_attr, None) is None:
+                    setattr(
+                        sw,
+                        grad_attr,
+                        getattr(pw, grad_attr)._slice(lid, lid + 1),
+                    )
+
     def fallback_to_no_expert_fusion(self):
         """
-        从 expert_fusion=True 回退到 False 模式，将融合的 experts_group_gemm_node 拆成逐专家节点。
+        Fallback from expert_fusion=True to per-expert mode, splitting the fused
+        experts_group_gemm_node into individual per-expert nodes.
 
-        当 auto_subbatch 检测到显存不足以一次做 group_gemm 时调用，通过 copy.copy
-        浅拷贝出每个专家的独立 gemm_node，并将前向保存的 input_fp8/o1 按专家切片。
+        Called by auto_subbatch when free memory is insufficient for a single group_gemm.
+        Shallow-copies the fused node for each expert and slices forward-saved tensors.
         """
         fused_gemm_node = self.experts_group_gemm_node
         self.experts_group_gemm_node = []
@@ -700,11 +761,29 @@ class MlpNode:
             global_expert_id = self._global_expert_id(local_id)
             gemm_node = copy.copy(fused_gemm_node)
             gemm_node.is_split_group_gemm = True
-            gemm_node.moe_expert_fusion = False
             gemm_node.recompute_moe_gate_up = fused_gemm_node.o1 is None
-            gemm_node.experts = [self.experts[global_expert_id]]
             gemm_node.expert_id = global_expert_id
             gemm_node.tokens_per_expert = [tokens_per_expert]
+
+            if self.experts is not None:
+                # Non deep_gemm: per-expert weight list
+                gemm_node.moe_expert_fusion = False
+                gemm_node.experts = [self.experts[global_expert_id]]
+            else:
+                # deep_gemm: slice stacked weight to [1, K, N]
+                gemm_node.moe_expert_fusion = True
+                parent = fused_gemm_node.grouped_gemm_experts
+                sliced = type("_SlicedGroupedExpert", (), {})()
+                sliced.weight1 = parent.weight1._slice(local_id, local_id + 1)
+                sliced.weight2 = parent.weight2._slice(local_id, local_id + 1)
+                sliced._parent = parent
+                sliced._local_id = local_id
+                gemm_node.grouped_gemm_experts = sliced
+                # Regenerate m_indices for single expert; global m_indices has wrong range
+                gemm_node.m_indices = gemm_node.gen_m_indices(
+                    [tokens_per_expert]
+                )
+
             self.experts_group_gemm_node.append(gemm_node)
 
             start_idx = self.token_offsets[local_id]
@@ -726,11 +805,16 @@ class MlpNode:
     @contextlib.contextmanager
     def slice_fp8_weight(self, expert_id):
         """
-        当初始为 expert_fusion=True 但回退到逐专家时，临时切片当前专家的 fp8_weight/scale。
+        Temporarily slice FP8 stacked weights for a single expert during per-expert fallback.
 
-        expert_fusion=True 时 FP8 权重以 stacked 形式存在 experts[0] 上（所有专家堆叠），
-        回退后每个专家需要独立的权重切片。此上下文管理器临时设置并在退出时恢复/清理。
+        When expert_fusion=True, FP8 weights are stacked on experts[0]. After fallback,
+        each expert needs its own weight slice. This context manager sets up and restores them.
         """
+        # deep_gemm: weights already sliced in fallback_to_no_expert_fusion
+        if self.experts is None:
+            yield
+            return
+
         # Stacked FP8 weights live on local expert 0; slice them for the current expert.
         stacked_weight_owner_global_id = self._global_expert_id(0)
         current_expert_global_id = self._global_expert_id(expert_id)
@@ -1321,6 +1405,10 @@ class MlpNode:
         #   do1 是独立新 buffer，o1 延迟释放，峰值在 dw1（D 点）：
         #   o1(2H) + do1(2H) + o2_s(H) + n2_s(2H) = 7H
         #   → feature_sizes = [2H, 2H, H, 2H]
+
+        # Pre-allocate grads before subbatch decision so VMM query accounts for grad memory
+        self._ensure_weight_grad()
+
         if USE_INPLACE_SWIGLU_BWD:
             bwd_feature_sizes = [
                 FP8_ALIGN * hidden_size * 2,  # o1/do1（inplace 共享）
@@ -1370,6 +1458,7 @@ class MlpNode:
         if not self.moe_expert_fusion:
             if bwd_path == "unknown":
                 bwd_path = "per_expert"
+            self._slice_weight_grad()
             for expert_id, tokens_per_expert in enumerate(
                 self.tokens_per_expert
             ):

--- a/tests/single_card_tests/test_moe_auto_subbatch_deep_gemm.py
+++ b/tests/single_card_tests/test_moe_auto_subbatch_deep_gemm.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Single-card unit tests for auto_subbatch with moe_deep_gemm=True.
+
+Tests auto_subbatch fallback correctness when using GroupedMLPExpert (stacked weights)
+instead of per-expert weight lists.
+
+Run with:
+  python tests/single_card_tests/test_moe_auto_subbatch_deep_gemm.py
+"""
+
+import contextlib
+import logging
+import os
+import unittest
+
+import numpy as np
+
+os.environ["FLAGS_use_virtual_memory_auto_growth"] = "True"
+os.environ["FLAGS_cudnn_deterministic"] = "True"
+
+from types import SimpleNamespace
+
+import paddle
+from paddle import nn
+from paddle.device.cuda.memory_analyzer import MemoryAnalysisTool
+
+from paddlefleet.tensor_parallel.random import model_parallel_cuda_manual_seed
+from paddlefleet.transformer.moe.fp8_utils import tilewise_quant
+from paddlefleet.transformer.moe.fusion_layer_utils import (
+    FusionMoePyLayer,
+    MlpNode,
+)
+from paddlefleet.transformer.moe.moe_expert import GroupedMLPExpert
+from paddlefleet.transformer.transformer_config import TransformerConfig
+
+# hack: lower min_auto_subbatch_rows so small seq_len can trigger multi-chunk subbatch
+_orig_mlpnode_init = MlpNode.__init__
+
+
+def _patched_mlpnode_init(self, *args, **kwargs):
+    _orig_mlpnode_init(self, *args, **kwargs)
+    self.min_auto_subbatch_rows = 256
+
+
+MlpNode.__init__ = _patched_mlpnode_init
+
+
+class FakeDeepGemmMOELayer(nn.Layer):
+    """
+    A mock MoE layer for deep_gemm mode using GroupedMLPExpert (stacked weights).
+
+    In deep_gemm mode, MoELayer creates grouped_gemm_experts instead of per-expert list.
+    This fake layer mimics that structure.
+    """
+
+    def __init__(
+        self,
+        hidden_size,
+        intermediate_size,
+        n_routed_experts,
+        tokens_per_expert,
+    ):
+        super().__init__()
+        config = TransformerConfig(
+            hidden_size=hidden_size,
+            moe_intermediate_size=intermediate_size,
+            gated_linear_unit=True,
+        )
+        self.grouped_gemm_experts = GroupedMLPExpert(
+            num_local_experts=n_routed_experts,
+            config=config,
+            moe_deep_gemm=True,
+        )
+        # Initialize weights with small random values for numerical stability
+        with paddle.no_grad():
+            self.grouped_gemm_experts.weight1.set_value(
+                paddle.randn(
+                    self.grouped_gemm_experts.weight1.shape, dtype="bfloat16"
+                )
+                * 0.01
+            )
+            self.grouped_gemm_experts.weight2.set_value(
+                paddle.randn(
+                    self.grouped_gemm_experts.weight2.shape, dtype="bfloat16"
+                )
+                * 0.01
+            )
+        self.token_dispatcher = SimpleNamespace(
+            _comm_manager=SimpleNamespace(
+                tokens_per_expert=tokens_per_expert,
+            ),
+        )
+        # deep_gemm mode has no per-expert list
+        self.experts = None
+
+    def clear_main_grad(self):
+        self.grouped_gemm_experts.weight1.main_grad = None
+        self.grouped_gemm_experts.weight2.main_grad = None
+
+
+@contextlib.contextmanager
+def vmm_no_free_space():
+    """Occupy all free blocks and disable growable space to simulate tight memory."""
+    (old_value,) = paddle.framework.get_flags(
+        "FLAGS_max_reserved_threshold_in_gb"
+    ).values()
+    paddle.set_flags({"FLAGS_max_reserved_threshold_in_gb": 0})
+    buffers = []
+    for size, _ in MemoryAnalysisTool.vmm_free_block_info()[-1]:
+        buffers.append(paddle.empty([size], dtype="uint8"))
+    try:
+        yield
+    finally:
+        paddle.set_flags({"FLAGS_max_reserved_threshold_in_gb": old_value})
+        del buffers
+
+
+class TestAutoSubbatchDeepGemm(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        model_parallel_cuda_manual_seed(1234)
+        cls.seq_len = 1024
+        cls.topk = 4
+        cls.hidden_size = 4096
+        cls.intermediate_size = 1536
+        cls.n_routed_experts = 8
+
+    def setUp(self):
+        paddle.seed(2026)
+        np.random.seed(2026)
+
+        hidden_states = paddle.randn(
+            [self.seq_len, self.hidden_size], "bfloat16"
+        )
+        hidden_states_out_grad = paddle.randn_like(hidden_states)
+        hidden_states, scale = tilewise_quant(hidden_states)
+        probs = paddle.randn([self.seq_len, self.topk])
+        hidden_states.stop_gradient = False
+        probs.stop_gradient = False
+
+        self.hidden_states = hidden_states
+        self.hidden_states_out_grad = hidden_states_out_grad
+        self.scale = scale
+        self.probs = probs
+
+        # Each token is assigned 1 to topk experts, always including expert 0
+        indices_np = np.full([self.seq_len, self.topk], -1, dtype=np.int64)
+        tokens_per_expert = [0] * self.n_routed_experts
+        for i in range(self.seq_len):
+            chosen = np.array([0])
+            n_active = np.random.randint(self.topk)
+            if n_active > 0:
+                chosen = np.append(
+                    chosen,
+                    np.random.choice(
+                        self.n_routed_experts - 1,
+                        size=n_active,
+                        replace=False,
+                    )
+                    + 1,
+                )
+            indices_np[i, : n_active + 1] = np.sort(chosen)
+            for expert_id in chosen:
+                tokens_per_expert[expert_id] += 1
+        self.indices = paddle.to_tensor(indices_np)
+
+        moe_layer = FakeDeepGemmMOELayer(
+            self.hidden_size,
+            self.intermediate_size,
+            self.n_routed_experts,
+            tokens_per_expert,
+        )
+        moe_layer = paddle.amp.decorate(moe_layer, level="O2", dtype="bfloat16")
+        moe_layer.clear_main_grad()
+        self.moe_layer = moe_layer
+
+    def run_moe_layer(
+        self, is_ref=False, tight_forward=False, tight_backward=False, **kwargs
+    ):
+        params = {
+            "use_fp8_mlp": True,
+            "moe_deep_gemm": True,
+            "recompute_moe_gate_up": False,
+            "dequant_input": True,
+            "moe_expert_fusion": True,
+            "recompute_moe_premute": False,
+            "use_bf16_gemm_weight_grad": True,
+            "fp8_dispatched_handle": {"scale": self.scale},
+            "use_auto_subbatch": not is_ref,
+            "moe_subbatch_diag": True,
+        }
+        params.update(kwargs)
+
+        with vmm_no_free_space() if tight_forward else contextlib.nullcontext():
+            hidden_states = FusionMoePyLayer.apply(
+                self.hidden_states,
+                self.probs,
+                self.indices.clone(),
+                self.moe_layer,
+                self.topk,
+                **params,
+            )
+
+        with (
+            vmm_no_free_space() if tight_backward else contextlib.nullcontext()
+        ):
+            paddle.autograd.backward(hidden_states, self.hidden_states_out_grad)
+
+        hidden_states_grad = self.hidden_states.grad
+        probs_grad = self.probs.grad
+        self.hidden_states.clear_grad()
+        self.probs.clear_grad()
+
+        weight_grad = self.moe_layer.grouped_gemm_experts.weight2.main_grad
+        self.moe_layer.clear_main_grad()
+
+        return hidden_states, hidden_states_grad, probs_grad, weight_grad
+
+    def compare_results(self, ref_out, tgt_out):
+        names = [
+            "hidden_states",
+            "hidden_states_grad",
+            "probs_grad",
+            "weight_grad",
+        ]
+        # First three must be bitwise equal; weight_grad allows FP8 accumulation order diff
+        tolerances = {
+            "weight_grad": {"atol": 1e-4, "rtol": 1e-5},
+        }
+        for i, name in enumerate(names):
+            ref_np = ref_out[i].float().numpy()
+            tgt_np = tgt_out[i].float().numpy()
+            tol = tolerances.get(name)
+            if tol is None:
+                np.testing.assert_equal(ref_np, tgt_np, err_msg=name)
+            else:
+                diff = np.abs(ref_np - tgt_np)
+                max_diff = diff.max()
+                if max_diff > tol["atol"]:
+                    # Print top diffs on failure for debugging
+                    flat = diff.flatten()
+                    top_idx = np.argsort(flat)[-10:][::-1]
+                    lines = [
+                        f"\n=== {name} FAILED: max_abs_diff={max_diff:.6g} ==="
+                    ]
+                    for rank, idx in enumerate(top_idx):
+                        coords = np.unravel_index(idx, ref_np.shape)
+                        lines.append(
+                            f"  #{rank} {coords} ref={ref_np.flat[idx]:.6g}, "
+                            f"tgt={tgt_np.flat[idx]:.6g}, diff={flat[idx]:.6g}"
+                        )
+                    self.fail("\n".join(lines))
+                np.testing.assert_allclose(ref_np, tgt_np, **tol, err_msg=name)
+
+    def test_auto_subbatch_deep_gemm_no_recompute(self):
+        """deep_gemm + no_recompute: auto_subbatch vs group_gemm reference"""
+        ref_out = self.run_moe_layer(is_ref=True)
+
+        cases = {}
+        kwargs = {"recompute_moe_gate_up": False}
+
+        logging.info("case1 (deep_gemm, plenty)")
+        cases["case1 (plenty)"] = self.run_moe_layer(**kwargs)
+        logging.info("case2 (deep_gemm, tight_fwd)")
+        cases["case2 (tight_fwd)"] = self.run_moe_layer(
+            tight_forward=True, **kwargs
+        )
+
+        logging.info("case3 (deep_gemm, tight_bwd)")
+        cases["case3 (tight_bwd)"] = self.run_moe_layer(
+            tight_backward=True, **kwargs
+        )
+        logging.info("case4 (deep_gemm, tight_both)")
+        cases["case4 (tight_both)"] = self.run_moe_layer(
+            tight_forward=True, tight_backward=True, **kwargs
+        )
+
+        for name, result in cases.items():
+            with self.subTest(case=name):
+                self.compare_results(ref_out, result)
+
+    def test_auto_subbatch_deep_gemm_recompute(self):
+        """deep_gemm + recompute_moe_gate_up: auto_subbatch vs group_gemm reference"""
+        ref_out = self.run_moe_layer(is_ref=True, recompute_moe_gate_up=True)
+
+        cases = {}
+        kwargs = {"recompute_moe_gate_up": True}
+
+        logging.info("case5 (deep_gemm recompute, plenty)")
+        cases["case5 (plenty)"] = self.run_moe_layer(**kwargs)
+        logging.info("case6 (deep_gemm recompute, tight_fwd)")
+        cases["case6 (tight_fwd)"] = self.run_moe_layer(
+            tight_forward=True, **kwargs
+        )
+
+        logging.info("case7 (deep_gemm recompute, tight_bwd)")
+        cases["case7 (tight_bwd)"] = self.run_moe_layer(
+            tight_backward=True, **kwargs
+        )
+        logging.info("case8 (deep_gemm recompute, tight_both)")
+        cases["case8 (tight_both)"] = self.run_moe_layer(
+            tight_forward=True, tight_backward=True, **kwargs
+        )
+
+        for name, result in cases.items():
+            with self.subTest(case=name):
+                self.compare_results(ref_out, result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Distributed Strategy

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
支持 auto_subbatch backward fallback 在 k_grouped_gemm(GroupedMLPExpert 堆叠权重)模式下正确工作。此前 auto_subbatch 仅支持 per-expert权重列表。

主要改动：

  fusion_layer_utils.py：
  - 新增 _ensure_weight_grad()：在 subbatch 显存决策前预分配 weight grad（支持 per-expert 和 stacked 两种模式），使 VMM 空闲显存查询结果更准确
  - 新增 _slice_weight_grad()：为逐 expert fallback 时的 sliced weight 设置指向 parent grad 的 view
  - 扩展 fallback_to_no_expert_fusion() 支持 deep_gemm 模式：将堆叠权重切片为 [1, K, N] 并为单专家重新生成 m_indices
  - _setup_fp8_weight_for_expert 对 deep_gemm 模式提前返回（权重已在 fallback 时切片完毕）

  fp8_utils.py：
  - 修复 subbatch 循环中 nparts > 1 时 m_indices 未重新生成导致的 shape mismatch 断言失败
  - 修复 tokens_per_expert_tensor dtype 从 int64 改为 int32，与 tokens_per_expert_indices 保持一致
  - 移除调试 print

  test_moe_auto_subbatch_deep_gemm.py（新增）：
  - 单卡单测，覆盖 4 种显存场景（充裕 / tight_fwd / tight_bwd / tight_both）× 2 种 recompute 模式，共 8 个 case
  - 前向输出和梯度要求 bitwise 一致；weight_grad 允许 atol=1e-4 的误差（FP8 累加顺序差异）

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否
auto_subbatch fallback 路径的 weight_grad 存在 FP8 累加顺序差异导致的 ~1e-5 级别数值差异，属于预期行为，不影响训练精度