### PR TITLE
[XPU][CI] inject paddlepaddle-xpu version in publish_wheel_nightly_xpu…

### DIFF
--- a/.github/workflows/publish_wheel_nightly_xpu.yml
+++ b/.github/workflows/publish_wheel_nightly_xpu.yml
@@ -98,6 +98,9 @@ jobs:
           rm PaddleFleet.tar.gz
           git config --global --add safe.directory /workspace
           sed -i "s#packages/nightly/cu129#packages/nightly/${{ matrix.xpu.bos_XPU }}#g" pyproject.toml
+
+          sed -i "s/paddlepaddle-gpu==[^\"]*/paddlepaddle-xpu>=3.5.0.dev20260501/" pyproject.toml
+
           cat pyproject.toml
           # mkdir -p /root/.cache/pip
           # pip cache dir


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Improvements

### Description
在 XPU nightly wheel 发布流水线 `.github/workflows/publish_wheel_nightly_xpu.yml` 中，新增 `sed` 命令动态替换 `pyproject.toml` 中的 paddlepaddle 依赖：

- 将 `dependencies` 中的 `paddlepaddle-gpu==...` 替换为 `paddlepaddle-xpu>=3.5.0.dev20260501`
- 与已有的索引源替换（cu129 → xpu-p800）配合，确保 XPU 构建时使用正确的 paddlepaddle-xpu 版本范围
- 不在代码仓库中硬编码 XPU 版本，仅通过 CI 注入，保持 GPU 构建逻辑不变

### 是否引起精度变化
否