### PR TITLE
[New features][Bug fixes] Add TileLang CSA compressed indexer for DSv4 and fix ColumnLinear stop_gradient backward

### DIFF
--- a/src/paddlefleet/tensor_parallel/layers.py
+++ b/src/paddlefleet/tensor_parallel/layers.py
@@ -485,6 +485,11 @@ class LinearWithGradAccumulationAndAsyncCommunication(paddle.autograd.Function):
         ctx.wgrad_deferral_limit = wgrad_deferral_limit
         ctx.grad_output_buffer = grad_output_buffer
         ctx.tp_group = tp_group
+        # Cache input.stop_gradient: ``_new_shared_tensor()`` does not
+        # necessarily preserve this flag, and Paddle's PyLayer contract
+        # requires backward to return None at position 0 iff the original
+        # forward input had stop_gradient=True.
+        ctx.input_stop_gradient = bool(input.stop_gradient)
 
         if sequence_parallel:
             dim_size = list(input.shape)
@@ -515,6 +520,16 @@ class LinearWithGradAccumulationAndAsyncCommunication(paddle.autograd.Function):
         handle = None
         tp_group = ctx.tp_group
 
+        # Paddle PyLayer contract: when a forward Tensor input has
+        # stop_gradient=True, the corresponding backward return slot MUST be
+        # None. The "input" position (0) is the only one that can carry
+        # stop_gradient=True in normal usage (weight/bias are trainable);
+        # callers that intentionally feed a detached tensor (e.g. for
+        # gradient isolation) rely on this. We must skip grad_input compute
+        # and any input-side collective (all_reduce / reduce_scatter) in
+        # that case, while still computing grad_weight / grad_bias.
+        input_needs_grad = not ctx.input_stop_gradient
+
         if ctx.gradient_accumulation_fusion:
             weight.main_grad = main_grad
 
@@ -544,7 +559,10 @@ class LinearWithGradAccumulationAndAsyncCommunication(paddle.autograd.Function):
                 total_input = all_gather_buffer
             else:
                 total_input = input
-        grad_input = grad_output.matmul(weight.t())
+        if input_needs_grad:
+            grad_input = grad_output.matmul(weight.t())
+        else:
+            grad_input = None
 
         if ctx.sequence_parallel and wgrad_compute:
             # pylint: disable=possibly-used-before-assignment
@@ -555,7 +573,7 @@ class LinearWithGradAccumulationAndAsyncCommunication(paddle.autograd.Function):
                 grad_output, total_input
             )
 
-        if ctx.allreduce_dgrad:
+        if ctx.allreduce_dgrad and input_needs_grad:
             # Asynchronous all-reduce
             handle = dist.all_reduce(grad_input, group=tp_group, sync_op=False)
             # Here we rely on CUDA_DEVICE_MAX_CONNECTIONS=1 to ensure that the
@@ -563,16 +581,19 @@ class LinearWithGradAccumulationAndAsyncCommunication(paddle.autograd.Function):
 
         if ctx.sequence_parallel:
             assert not ctx.allreduce_dgrad
-            dim_size = list(input.shape)
-            sub_grad_input = paddle.empty(
-                dim_size, dtype=input.dtype, requires_grad=False
-            )
-            # reduce_scatter
-            handle = _reduce_scatter_base(
-                sub_grad_input, grad_input, group=tp_group, sync_op=False
-            )
-            # Here we rely on CUDA_DEVICE_MAX_CONNECTIONS=1 to ensure that the
-            # reduce scatter is scheduled before the weight gradient computation
+            if input_needs_grad:
+                dim_size = list(input.shape)
+                sub_grad_input = paddle.empty(
+                    dim_size, dtype=input.dtype, requires_grad=False
+                )
+                # reduce_scatter
+                handle = _reduce_scatter_base(
+                    sub_grad_input, grad_input, group=tp_group, sync_op=False
+                )
+                # Here we rely on CUDA_DEVICE_MAX_CONNECTIONS=1 to ensure that the
+                # reduce scatter is scheduled before the weight gradient computation
+            else:
+                sub_grad_input = None
 
         if ctx.gradient_accumulation_fusion:
             if wgrad_compute:
@@ -617,7 +638,8 @@ class LinearWithGradAccumulationAndAsyncCommunication(paddle.autograd.Function):
         grad_bias = grad_output.sum(dim=0) if use_bias else None
 
         if ctx.sequence_parallel:
-            handle.wait()
+            if input_needs_grad:
+                handle.wait()
             # Need to return None's as gradient has to flow for all the input arguments
             # provided during forward
             if use_bias:
@@ -625,7 +647,7 @@ class LinearWithGradAccumulationAndAsyncCommunication(paddle.autograd.Function):
             else:
                 return sub_grad_input, grad_weight
 
-        if ctx.allreduce_dgrad:
+        if ctx.allreduce_dgrad and input_needs_grad:
             handle.wait()
 
         # PyLayer requires the number of output in backward

--- a/src/paddlefleet/tilelang_ops/__init__.py
+++ b/src/paddlefleet/tilelang_ops/__init__.py
@@ -20,7 +20,7 @@ __all__ = [
     "csa_attn_target_reducesum",
     "csa_indexer_bwd",
     "csa_indexer_topk_fwd",
-    "tilelang_compressed_sparse_attn",
+    "csa_sparse_attn",
 ]
 
 
@@ -43,9 +43,9 @@ def __getattr__(name):
         }
         globals().update(exports)
         return exports[name]
-    if name == "tilelang_compressed_sparse_attn":
-        from .compressed_sparse_attn import tilelang_compressed_sparse_attn
+    if name == "csa_sparse_attn":
+        from .compressed_sparse_attn import csa_sparse_attn
 
-        globals()[name] = tilelang_compressed_sparse_attn
-        return tilelang_compressed_sparse_attn
+        globals()[name] = csa_sparse_attn
+        return csa_sparse_attn
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/paddlefleet/tilelang_ops/__init__.py
+++ b/src/paddlefleet/tilelang_ops/__init__.py
@@ -16,10 +16,36 @@ import paddle
 
 paddle.enable_compat(scope={"tilelang"}, silent=True)
 
-from .compressed_sparse_attn import (
-    tilelang_compressed_sparse_attn,
-)
-
 __all__ = [
+    "csa_attn_target_reducesum",
+    "csa_indexer_bwd",
+    "csa_indexer_topk_fwd",
     "tilelang_compressed_sparse_attn",
 ]
+
+
+def __getattr__(name):
+    if name in {
+        "csa_attn_target_reducesum",
+        "csa_indexer_bwd",
+        "csa_indexer_topk_fwd",
+    }:
+        from .indexer.csa_indexer import (
+            csa_attn_target_reducesum,
+            csa_indexer_bwd,
+            csa_indexer_topk_fwd,
+        )
+
+        exports = {
+            "csa_attn_target_reducesum": csa_attn_target_reducesum,
+            "csa_indexer_bwd": csa_indexer_bwd,
+            "csa_indexer_topk_fwd": csa_indexer_topk_fwd,
+        }
+        globals().update(exports)
+        return exports[name]
+    if name == "tilelang_compressed_sparse_attn":
+        from .compressed_sparse_attn import tilelang_compressed_sparse_attn
+
+        globals()[name] = tilelang_compressed_sparse_attn
+        return tilelang_compressed_sparse_attn
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/paddlefleet/tilelang_ops/compressed_sparse_attn.py
+++ b/src/paddlefleet/tilelang_ops/compressed_sparse_attn.py
@@ -21,7 +21,7 @@ from .attn.sparse_mqa import (
 )
 
 
-class TileLangCompressedSparseAttention(paddle.autograd.PyLayer):
+class CSASparseAttention(paddle.autograd.PyLayer):
     @staticmethod
     def forward(ctx, query, kv_full, attn_sink, topk_idxs, softmax_scale):
         b, sq, np_heads, hn = query.shape
@@ -72,14 +72,14 @@ class TileLangCompressedSparseAttention(paddle.autograd.PyLayer):
         )
 
 
-def tilelang_compressed_sparse_attn(
+def csa_sparse_attn(
     query,
     kv_full,
     attn_sink,
     topk_idxs,
     softmax_scale,
 ):
-    return TileLangCompressedSparseAttention.apply(
+    return CSASparseAttention.apply(
         query,
         kv_full,
         attn_sink,

--- a/src/paddlefleet/tilelang_ops/indexer/__init__.py
+++ b/src/paddlefleet/tilelang_ops/indexer/__init__.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .csa_indexer import (
+    csa_attn_target_reducesum,
+    csa_indexer_bwd,
+    csa_indexer_topk_fwd,
+)
+
+__all__ = [
+    "csa_attn_target_reducesum",
+    "csa_indexer_bwd",
+    "csa_indexer_topk_fwd",
+]

--- a/src/paddlefleet/tilelang_ops/indexer/csa_attn_target.py
+++ b/src/paddlefleet/tilelang_ops/indexer/csa_attn_target.py
@@ -36,6 +36,78 @@ def _tilelang_dtype(tensor):
     )
 
 
+def _shape(tensor):
+    return tuple(tensor.shape)
+
+
+def _require_tensor(name, tensor):
+    if not isinstance(tensor, paddle.Tensor):
+        raise TypeError(f"{name} must be a paddle.Tensor, got {type(tensor)!r}")
+
+
+def _require_contiguous(name, tensor):
+    if not tensor.is_contiguous():
+        raise ValueError(f"{name} must be contiguous")
+
+
+def _validate_interface_inputs(
+    query,
+    key_comp,
+    topk_indices,
+    block_I,
+    num_stages,
+):
+    for name, tensor in (
+        ("query", query),
+        ("key_comp", key_comp),
+        ("topk_indices", topk_indices),
+    ):
+        _require_tensor(name, tensor)
+        _require_contiguous(name, tensor)
+    if query.ndim != 4:
+        raise ValueError(
+            f"query must have shape [B, S, H, D], got {_shape(query)}"
+        )
+    if key_comp.ndim != 3:
+        raise ValueError(
+            f"key_comp must have shape [B, S_comp, D], got {_shape(key_comp)}"
+        )
+    if topk_indices.ndim != 3:
+        raise ValueError(
+            f"topk_indices must have shape [B, S, topk], got {_shape(topk_indices)}"
+        )
+
+    batch, seq_len, heads, dim = _shape(query)
+    batch_k, _, dim_k = _shape(key_comp)
+    batch_i, seq_len_i, topk_effective = _shape(topk_indices)
+    if batch != batch_k or batch != batch_i:
+        raise ValueError(
+            f"batch mismatch: query={_shape(query)}, key_comp={_shape(key_comp)}, topk_indices={_shape(topk_indices)}"
+        )
+    if seq_len != seq_len_i:
+        raise ValueError(
+            f"sequence mismatch: query={_shape(query)}, topk_indices={_shape(topk_indices)}"
+        )
+    if dim != dim_k:
+        raise ValueError(
+            f"dim mismatch: query={_shape(query)}, key_comp={_shape(key_comp)}"
+        )
+    if dim & (dim - 1):
+        raise ValueError(f"dim must be a power of 2, got {dim}")
+    if heads <= 0:
+        raise ValueError(f"heads must be positive, got {heads}")
+    if heads > 64 and heads % 64 != 0:
+        raise ValueError(
+            f"heads must be a multiple of 64 when heads > 64, got {heads}"
+        )
+    if topk_effective <= 0:
+        raise ValueError("topk_indices last dimension must be positive")
+    if int(block_I) <= 0:
+        raise ValueError(f"block_I must be positive, got {block_I}")
+    if int(num_stages) != 0:
+        raise ValueError(f"num_stages must be 0, got {num_stages}")
+
+
 @tilelang.jit(
     pass_configs={
         tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
@@ -235,20 +307,16 @@ def csa_attn_target_reducesum_interface(
     num_stages: int = 0,
     num_threads: int = 128,
 ):
-    assert query.is_contiguous()
-    assert key_comp.is_contiguous()
-    assert topk_indices.is_contiguous()
-    assert query.ndim == 4
-    assert key_comp.ndim == 3
-    assert topk_indices.ndim == 3
+    _validate_interface_inputs(
+        query,
+        key_comp,
+        topk_indices,
+        block_I,
+        num_stages,
+    )
 
     batch, seq_len, heads, dim = query.shape
-    batch_k, seq_len_comp, dim_k = key_comp.shape
-    batch_i, seq_len_i, topk_effective = topk_indices.shape
-    assert batch == batch_k == batch_i
-    assert seq_len == seq_len_i
-    assert dim == dim_k
-    assert topk_effective > 0
+    topk_effective = topk_indices.shape[-1]
 
     padded_topk = (topk_effective + block_I - 1) // block_I * block_I
     if padded_topk != topk_effective:

--- a/src/paddlefleet/tilelang_ops/indexer/csa_attn_target.py
+++ b/src/paddlefleet/tilelang_ops/indexer/csa_attn_target.py
@@ -1,0 +1,282 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# TileLang target-probability kernel for DeepSeek V4 CSA indexer loss.
+#
+# 2-pass online softmax with GEMM-based matmul. Key is [B, S_comp, D] (shared
+# across heads per MLA design).
+#
+# Pass 1: online softmax — stream over topk blocks, maintain running max & sum
+#          via the rescaling trick (2x global memory read vs 3x for 3-pass).
+# Pass 2: recompute exp(logits - max) / sum and reduce over heads.
+
+import paddle
+import tilelang
+from tilelang import language as T
+
+
+def _tilelang_dtype(tensor):
+    if tensor.dtype == paddle.bfloat16:
+        return "bfloat16"
+    if tensor.dtype == paddle.float16:
+        return "float16"
+    raise TypeError(
+        f"TileLang CSA attention target expects bf16/fp16 inputs, got {tensor.dtype}"
+    )
+
+
+@tilelang.jit(
+    pass_configs={
+        tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
+        tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
+    }
+)
+def tl_csa_attn_target_reducesum(
+    heads: int,
+    dim: int,
+    topk: int,
+    block_I: int = 32,
+    dtype: str = "bfloat16",
+    num_stages: int = 0,
+    num_threads: int = 128,
+):
+    assert num_stages == 0
+    assert dim == tilelang.math.next_power_of_2(dim)
+    assert topk % block_I == 0
+    assert heads > 0
+
+    if heads > 64:
+        assert heads % 64 == 0
+        replicate_h = heads // 64
+    else:
+        replicate_h = 1
+    padded_h = max(tilelang.math.next_power_of_2(heads), 16)
+    h_per_block = padded_h if replicate_h == 1 else 64
+
+    batch = T.dynamic("batch")
+    seq_len = T.dynamic("seq_len")
+    seq_len_comp = T.dynamic("seq_len_comp")
+
+    FP32 = "float"
+    INT32 = "int32"
+
+    query_shape = [batch, seq_len, heads, dim]
+    key_shape = [batch, seq_len_comp, dim]
+    topk_indices_shape = [batch, seq_len, topk]
+    partial_shape = [batch, seq_len, replicate_h, topk]
+
+    @T.prim_func
+    def target_kernel(
+        Query: T.Tensor(query_shape, dtype),
+        KeyComp: T.Tensor(key_shape, dtype),
+        TopkIndices: T.Tensor(topk_indices_shape, INT32),
+        SoftmaxScale: T.Tensor([1], FP32),
+        PartialReduceSum: T.Tensor(partial_shape, FP32),
+    ):
+        with T.Kernel(seq_len * replicate_h, batch, threads=num_threads) as (
+            bx,
+            by,
+        ):
+            s_i = bx if replicate_h == 1 else bx // replicate_h
+            r_i = bx % replicate_h
+            h_base = 0 if replicate_h == 1 else r_i * 64
+
+            query_shared = T.alloc_shared([h_per_block, dim], dtype=dtype)
+            key_shared = T.alloc_shared([block_I, dim], dtype=dtype)
+            indices_shared = T.alloc_shared([block_I], dtype=INT32)
+            safe_indices_shared = T.alloc_shared([block_I], dtype=INT32)
+
+            logits = T.alloc_fragment([h_per_block, block_I], dtype=FP32)
+            row_max = T.alloc_fragment([h_per_block], dtype=FP32)
+            block_max = T.alloc_fragment([h_per_block], dtype=FP32)
+            row_sum = T.alloc_fragment([h_per_block], dtype=FP32)
+            block_sum = T.alloc_fragment([h_per_block], dtype=FP32)
+            reduce_sum = T.alloc_fragment([block_I], dtype=FP32)
+
+            # Load query tile
+            for h_i, d_i in T.Parallel(h_per_block, dim):
+                query_shared[h_i, d_i] = T.if_then_else(
+                    h_base + h_i < heads,
+                    Query[by, s_i, h_base + h_i, d_i],
+                    0,
+                )
+            T.sync_threads()
+
+            # Pass 1: online softmax — compute row_max and row_sum in one pass
+            T.fill(row_max, -T.infinity(FP32))
+            T.fill(row_sum, 0)
+            num_blocks = T.ceildiv(topk, block_I)
+            for block_idx in T.Pipelined(num_blocks, num_stages=num_stages):
+                for i in T.Parallel(block_I):
+                    indices_shared[i] = TopkIndices[
+                        by, s_i, block_idx * block_I + i
+                    ]
+                    safe_indices_shared[i] = T.if_then_else(
+                        (indices_shared[i] >= 0)
+                        & (indices_shared[i] < seq_len_comp),
+                        indices_shared[i],
+                        0,
+                    )
+                T.sync_threads()
+
+                for i, d_i in T.Parallel(block_I, dim):
+                    key_shared[i, d_i] = T.if_then_else(
+                        (indices_shared[i] >= 0)
+                        & (indices_shared[i] < seq_len_comp),
+                        KeyComp[by, safe_indices_shared[i], d_i],
+                        0,
+                    )
+                T.sync_threads()
+
+                T.gemm(
+                    query_shared,
+                    key_shared,
+                    logits,
+                    transpose_A=False,
+                    transpose_B=True,
+                    clear_accum=True,
+                )
+                for h_i, i in T.Parallel(h_per_block, block_I):
+                    logits[h_i, i] = T.if_then_else(
+                        ((h_base + h_i) < heads)
+                        & (indices_shared[i] >= 0)
+                        & (indices_shared[i] < seq_len_comp),
+                        logits[h_i, i] * SoftmaxScale[0],
+                        -T.infinity(FP32),
+                    )
+                # Online update: rescale running sum then incorporate new block
+                T.fill(block_max, -T.infinity(FP32))
+                T.reduce_max(logits, block_max, dim=1, clear=False)
+                for h_i in T.Parallel(h_per_block):
+                    row_sum[h_i] *= T.exp(
+                        row_max[h_i] - T.max(row_max[h_i], block_max[h_i])
+                    )
+                    row_max[h_i] = T.max(row_max[h_i], block_max[h_i])
+                for h_i, i in T.Parallel(h_per_block, block_I):
+                    logits[h_i, i] = T.exp(logits[h_i, i] - row_max[h_i])
+                T.fill(block_sum, 0)
+                T.reduce_sum(logits, block_sum, dim=1, clear=False)
+                for h_i in T.Parallel(h_per_block):
+                    row_sum[h_i] += block_sum[h_i]
+
+            # Pass 2: compute normalized probs and reduce over heads
+            for block_idx in T.Pipelined(num_blocks, num_stages=num_stages):
+                for i in T.Parallel(block_I):
+                    indices_shared[i] = TopkIndices[
+                        by, s_i, block_idx * block_I + i
+                    ]
+                    safe_indices_shared[i] = T.if_then_else(
+                        (indices_shared[i] >= 0)
+                        & (indices_shared[i] < seq_len_comp),
+                        indices_shared[i],
+                        0,
+                    )
+                T.sync_threads()
+
+                for i, d_i in T.Parallel(block_I, dim):
+                    key_shared[i, d_i] = T.if_then_else(
+                        (indices_shared[i] >= 0)
+                        & (indices_shared[i] < seq_len_comp),
+                        KeyComp[by, safe_indices_shared[i], d_i],
+                        0,
+                    )
+                T.sync_threads()
+
+                T.gemm(
+                    query_shared,
+                    key_shared,
+                    logits,
+                    transpose_A=False,
+                    transpose_B=True,
+                    clear_accum=True,
+                )
+                for h_i, i in T.Parallel(h_per_block, block_I):
+                    logits[h_i, i] = T.if_then_else(
+                        ((h_base + h_i) < heads)
+                        & (indices_shared[i] >= 0)
+                        & (indices_shared[i] < seq_len_comp)
+                        & (row_sum[h_i] > 0),
+                        T.exp(logits[h_i, i] * SoftmaxScale[0] - row_max[h_i])
+                        / row_sum[h_i],
+                        0,
+                    )
+                T.fill(reduce_sum, 0)
+                T.reduce_sum(logits, reduce_sum, dim=0, clear=False)
+                T.copy(
+                    reduce_sum,
+                    PartialReduceSum[
+                        by,
+                        s_i,
+                        r_i,
+                        block_idx * block_I : block_idx * block_I + block_I,
+                    ],
+                )
+
+    return target_kernel
+
+
+def csa_attn_target_reducesum_interface(
+    query,
+    key_comp,
+    topk_indices,
+    softmax_scale: float,
+    block_I: int = 32,
+    num_stages: int = 0,
+    num_threads: int = 128,
+):
+    assert query.is_contiguous()
+    assert key_comp.is_contiguous()
+    assert topk_indices.is_contiguous()
+    assert query.ndim == 4
+    assert key_comp.ndim == 3
+    assert topk_indices.ndim == 3
+
+    batch, seq_len, heads, dim = query.shape
+    batch_k, seq_len_comp, dim_k = key_comp.shape
+    batch_i, seq_len_i, topk_effective = topk_indices.shape
+    assert batch == batch_k == batch_i
+    assert seq_len == seq_len_i
+    assert dim == dim_k
+    assert topk_effective > 0
+
+    padded_topk = (topk_effective + block_I - 1) // block_I * block_I
+    if padded_topk != topk_effective:
+        pad = paddle.full(
+            [batch, seq_len, padded_topk - topk_effective],
+            -1,
+            dtype=topk_indices.dtype,
+        )
+        topk_indices = paddle.concat([topk_indices, pad], axis=-1).contiguous()
+
+    replicate_h = heads // 64 if heads > 64 else 1
+    kernel = tl_csa_attn_target_reducesum(
+        heads=heads,
+        dim=dim,
+        topk=padded_topk,
+        block_I=block_I,
+        dtype=_tilelang_dtype(query),
+        num_stages=num_stages,
+        num_threads=num_threads,
+    )
+    partial = paddle.empty(
+        [batch, seq_len, replicate_h, padded_topk],
+        dtype="float32",
+    )
+    scale = paddle.full([1], float(softmax_scale), dtype="float32")
+    kernel(query, key_comp, topk_indices, scale, partial)
+    valid = topk_indices[:, :, :topk_effective] >= 0
+    target = partial[:, :, :, :topk_effective].sum(axis=2)
+    target = paddle.where(valid, target, paddle.zeros_like(target))
+    target = target / target.sum(axis=-1, keepdim=True).clip(min=1e-10)
+    return paddle.where(valid, target, paddle.zeros_like(target))

--- a/src/paddlefleet/tilelang_ops/indexer/csa_indexer.py
+++ b/src/paddlefleet/tilelang_ops/indexer/csa_indexer.py
@@ -1,0 +1,418 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import hashlib
+import json
+import os
+
+import paddle
+
+DEFAULT_INDEXER_BLOCK = 32
+_DIGEST_COUNTERS = {}
+
+
+def _digest_enabled():
+    return os.getenv("DSV4_TILELANG_DIGEST", "0").lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _digest_limit():
+    try:
+        return int(os.getenv("DSV4_TILELANG_DIGEST_LIMIT", "40"))
+    except ValueError:
+        return 40
+
+
+def _tensor_digest(name, tensor):
+    tensor_f32 = tensor.detach().cast("float32").cpu()
+    array = tensor_f32.numpy()
+    return {
+        "name": name,
+        "shape": list(tensor.shape),
+        "dtype": str(tensor.dtype),
+        "sha256": hashlib.sha256(array.tobytes()).hexdigest(),
+        "sum_f32": float(array.sum()),
+        "max_abs_f32": float(abs(array).max()) if array.size else 0.0,
+    }
+
+
+def _digest_log(op, **tensors):
+    if not _digest_enabled():
+        return
+    count = _DIGEST_COUNTERS.get(op, 0)
+    if count >= _digest_limit():
+        return
+    _DIGEST_COUNTERS[op] = count + 1
+    payload = {
+        "op": op,
+        "call": count,
+        "tensors": [
+            _tensor_digest(name, tensor) for name, tensor in tensors.items()
+        ],
+    }
+    print("[TileLangDigest] " + json.dumps(payload, sort_keys=True), flush=True)
+
+
+def _get_csa_indexer_topk_fwd_interface():
+    from .csa_indexer_fwd import csa_indexer_topk_fwd_interface
+
+    return csa_indexer_topk_fwd_interface
+
+
+def _get_csa_indexer_bwd_interface():
+    from .csa_indexer_bwd import csa_indexer_bwd_interface
+
+    return csa_indexer_bwd_interface
+
+
+def _get_csa_attn_target_reducesum_interface():
+    from .csa_attn_target import csa_attn_target_reducesum_interface
+
+    return csa_attn_target_reducesum_interface
+
+
+def _contiguous(tensor):
+    return tensor.contiguous()
+
+
+def _cast_int32(tensor):
+    return tensor.cast("int32") if tensor.dtype != paddle.int32 else tensor
+
+
+def _cast_float32(tensor):
+    return tensor.cast("float32") if tensor.dtype != paddle.float32 else tensor
+
+
+def _validate_indexer_inputs(index_q, index_k_comp, weights):
+    if not isinstance(index_q, paddle.Tensor):
+        raise TypeError(
+            f"index_q must be a paddle.Tensor, got {type(index_q)!r}"
+        )
+    if not isinstance(index_k_comp, paddle.Tensor):
+        raise TypeError(
+            f"index_k_comp must be a paddle.Tensor, got {type(index_k_comp)!r}"
+        )
+    if not isinstance(weights, paddle.Tensor):
+        raise TypeError(
+            f"weights must be a paddle.Tensor, got {type(weights)!r}"
+        )
+    if len(index_q.shape) != 4:
+        raise ValueError(
+            f"index_q must have shape [B, S, H_i, D_i], got {tuple(index_q.shape)}"
+        )
+    if len(index_k_comp.shape) != 3:
+        raise ValueError(
+            f"index_k_comp must have shape [B, S_comp, D_i], got {tuple(index_k_comp.shape)}"
+        )
+    if len(weights.shape) != 3:
+        raise ValueError(
+            f"weights must have shape [B, S, H_i], got {tuple(weights.shape)}"
+        )
+
+    batch, seq_len, heads, dim = tuple(index_q.shape)
+    batch_k, _, dim_k = tuple(index_k_comp.shape)
+    batch_w, seq_len_w, heads_w = tuple(weights.shape)
+    if batch != batch_k or batch != batch_w:
+        raise ValueError(
+            f"batch mismatch: index_q={tuple(index_q.shape)}, index_k_comp={tuple(index_k_comp.shape)}, weights={tuple(weights.shape)}"
+        )
+    if seq_len != seq_len_w or heads != heads_w or dim != dim_k:
+        raise ValueError(
+            f"shape mismatch: index_q={tuple(index_q.shape)}, index_k_comp={tuple(index_k_comp.shape)}, weights={tuple(weights.shape)}"
+        )
+
+
+def _validate_topk_and_grad(index_q, topk_indices, grad_scores):
+    if not isinstance(topk_indices, paddle.Tensor):
+        raise TypeError(
+            f"topk_indices must be a paddle.Tensor, got {type(topk_indices)!r}"
+        )
+    if not isinstance(grad_scores, paddle.Tensor):
+        raise TypeError(
+            f"grad_scores must be a paddle.Tensor, got {type(grad_scores)!r}"
+        )
+    if len(topk_indices.shape) != 3:
+        raise ValueError(
+            f"topk_indices must have shape [B, S, topk], got {tuple(topk_indices.shape)}"
+        )
+    if len(grad_scores.shape) != 3:
+        raise ValueError(
+            f"grad_scores must have shape [B, S, topk], got {tuple(grad_scores.shape)}"
+        )
+    batch, seq_len, _, _ = tuple(index_q.shape)
+    topk_shape = tuple(topk_indices.shape)
+    grad_shape = tuple(grad_scores.shape)
+    if topk_shape != grad_shape:
+        raise ValueError(
+            f"topk_indices shape {topk_shape} must match grad_scores shape {grad_shape}"
+        )
+    topk_batch, topk_seq_len, topk_last_dim = topk_shape
+    if topk_batch != batch or topk_seq_len != seq_len:
+        raise ValueError(
+            f"topk_indices shape {topk_shape} is incompatible with index_q shape {tuple(index_q.shape)}"
+        )
+    if topk_last_dim <= 0:
+        raise ValueError("topk_indices last dimension must be positive")
+
+
+def _prepare_forward_inputs(index_q, index_k_comp, weights, topk_effective):
+    _validate_indexer_inputs(index_q, index_k_comp, weights)
+    if int(topk_effective) <= 0:
+        raise ValueError(
+            f"topk_effective must be positive, got {topk_effective}"
+        )
+    batch, seq_len = tuple(index_q.shape)[:2]
+    return (
+        _contiguous(index_q),
+        _contiguous(index_k_comp),
+        _contiguous(_cast_float32(weights)),
+        int(topk_effective),
+    )
+
+
+def _prepare_backward_inputs(
+    index_q, weights, index_k_comp, topk_indices, grad_scores
+):
+    _validate_indexer_inputs(index_q, index_k_comp, weights)
+    _validate_topk_and_grad(index_q, topk_indices, grad_scores)
+    topk_indices = _contiguous(_cast_int32(topk_indices))
+    grad_scores = _contiguous(_cast_float32(grad_scores))
+    grad_scores = paddle.where(
+        topk_indices >= 0, grad_scores, paddle.zeros_like(grad_scores)
+    )
+    return (
+        _contiguous(index_q),
+        _contiguous(_cast_float32(weights)),
+        _contiguous(index_k_comp),
+        topk_indices,
+        _contiguous(grad_scores),
+    )
+
+
+def csa_indexer_topk_fwd(
+    index_q,
+    index_k_comp,
+    weights,
+    ratio: int,
+    topk_effective: int,
+    block_K: int = DEFAULT_INDEXER_BLOCK,
+    num_stages: int = 0,
+    num_threads: int = 128,
+):
+    """Paddle entry for V4 CSA compressed indexer forward.
+
+    Args:
+        index_q: [B, S, H_i, D_i] indexer queries.
+        index_k_comp: [B, S_comp, D_i] compressed indexer keys.
+        weights: [B, S, H_i] per-head weights for score aggregation.
+        ratio: compression ratio (e.g. 4). Causal range: [0, (t+1)//ratio).
+        topk_effective: number of top-k entries to select per query position.
+            - Phase 2 (dsa_indexer_use_sparse_loss=False): set to n_compressed
+              = floor(S / ratio) for full-candidate selection.
+            - Phase 3 (dsa_indexer_use_sparse_loss=True): set to
+              min(index_topk, n_compressed), typically 512.
+        block_K: tile size for streaming over compressed keys (default 32).
+
+    Returns:
+        topk_indices: [B, S, topk_effective] int32, invalid slots are -1.
+        topk_scores: [B, S, topk_effective] fp32 top-k softmax probabilities.
+    """
+    index_q, index_k_comp, weights, topk_effective = _prepare_forward_inputs(
+        index_q,
+        index_k_comp,
+        weights,
+        topk_effective,
+    )
+    csa_indexer_topk_fwd_interface = _get_csa_indexer_topk_fwd_interface()
+    topk_indices, topk_scores = csa_indexer_topk_fwd_interface(
+        index_q,
+        index_k_comp,
+        weights,
+        ratio=int(ratio),
+        topk_effective=topk_effective,
+        block_K=int(block_K),
+        num_stages=int(num_stages),
+        num_threads=int(num_threads),
+    )
+    batch, seq_len = tuple(index_q.shape)[:2]
+    expected_shape = (batch, seq_len, topk_effective)
+    if (
+        tuple(topk_indices.shape) != expected_shape
+        or tuple(topk_scores.shape) != expected_shape
+    ):
+        raise RuntimeError(
+            f"unexpected CSA indexer forward output shapes: indices={tuple(topk_indices.shape)}, scores={tuple(topk_scores.shape)}, expected={expected_shape}"
+        )
+    if not isinstance(topk_indices, paddle.Tensor) or not isinstance(
+        topk_scores, paddle.Tensor
+    ):
+        raise RuntimeError(
+            "TileLang must return Paddle tensors. "
+            "Ensure paddle.enable_compat(scope={'tilelang'}) runs before import tilelang."
+        )
+    return topk_indices, topk_scores
+
+
+def csa_attn_target_reducesum(
+    query_mla,
+    key_comp_mla,
+    topk_indices,
+    softmax_scale: float,
+    block_I: int = DEFAULT_INDEXER_BLOCK,
+    num_stages: int = 0,
+    num_threads: int = 128,
+):
+    """Paddle entry for V4 CSA indexer-loss attention target computation.
+
+    Computes the selected-set multi-head target distribution used by the CSA
+    indexer KL loss. This replaces materializing full [B, H, S, S_comp]
+    attention scores in the Paddle reference path.
+    """
+    if not isinstance(query_mla, paddle.Tensor):
+        raise TypeError(
+            f"query_mla must be a paddle.Tensor, got {type(query_mla)!r}"
+        )
+    if not isinstance(key_comp_mla, paddle.Tensor):
+        raise TypeError(
+            f"key_comp_mla must be a paddle.Tensor, got {type(key_comp_mla)!r}"
+        )
+    if not isinstance(topk_indices, paddle.Tensor):
+        raise TypeError(
+            f"topk_indices must be a paddle.Tensor, got {type(topk_indices)!r}"
+        )
+    if len(query_mla.shape) != 4:
+        raise ValueError(
+            f"query_mla must have shape [B, S, H, D], got {tuple(query_mla.shape)}"
+        )
+    if len(key_comp_mla.shape) != 3:
+        raise ValueError(
+            f"key_comp_mla must have shape [B, S_comp, D], got {tuple(key_comp_mla.shape)}"
+        )
+    if len(topk_indices.shape) != 3:
+        raise ValueError(
+            f"topk_indices must have shape [B, S, topk], got {tuple(topk_indices.shape)}"
+        )
+    query_shape = tuple(query_mla.shape)
+    key_shape = tuple(key_comp_mla.shape)
+    topk_shape = tuple(topk_indices.shape)
+    if query_shape[0] != key_shape[0] or query_shape[0] != topk_shape[0]:
+        raise ValueError(
+            f"batch mismatch: query_mla={tuple(query_mla.shape)}, key_comp_mla={tuple(key_comp_mla.shape)}, topk_indices={tuple(topk_indices.shape)}"
+        )
+    if query_shape[1] != topk_shape[1]:
+        raise ValueError(
+            f"sequence mismatch: query_mla={tuple(query_mla.shape)}, topk_indices={tuple(topk_indices.shape)}"
+        )
+    if query_shape[3] != key_shape[2]:
+        raise ValueError(
+            f"dim mismatch: query_mla={tuple(query_mla.shape)}, key_comp_mla={tuple(key_comp_mla.shape)}"
+        )
+    topk_indices = _contiguous(_cast_int32(topk_indices))
+    csa_attn_target_reducesum_interface = (
+        _get_csa_attn_target_reducesum_interface()
+    )
+    target = csa_attn_target_reducesum_interface(
+        _contiguous(query_mla),
+        _contiguous(key_comp_mla),
+        topk_indices,
+        float(softmax_scale),
+        block_I=int(block_I),
+        num_stages=int(num_stages),
+        num_threads=int(num_threads),
+    )
+    expected_shape = tuple(topk_indices.shape)
+    if tuple(target.shape) != expected_shape:
+        raise RuntimeError(
+            f"unexpected CSA attention target shape: target={tuple(target.shape)}, expected={expected_shape}"
+        )
+    if not isinstance(target, paddle.Tensor):
+        raise RuntimeError(
+            "TileLang must return Paddle tensors. "
+            "Ensure paddle.enable_compat(scope={'tilelang'}) runs before import tilelang."
+        )
+    return target
+
+
+def csa_indexer_bwd(
+    index_q,
+    weights,
+    index_k_comp,
+    topk_indices,
+    grad_scores,
+    block_I: int = DEFAULT_INDEXER_BLOCK,
+    num_stages: int = 0,
+    num_threads: int = 128,
+):
+    """Paddle entry for V4 CSA compressed indexer backward.
+
+    Computes gradients for IndexQ, Weights, and IndexKComp given the selected
+    top-k indices and the gradient of the loss w.r.t. the selected scores.
+
+    Args:
+        index_q: [B, S, H_i, D_i] indexer queries (same as forward input).
+        weights: [B, S, H_i] per-head weights (same as forward input).
+        index_k_comp: [B, S_comp, D_i] compressed indexer keys.
+        topk_indices: [B, S, topk_effective] int32, from forward output.
+            Invalid slots must be -1 (they are masked to zero gradient).
+        grad_scores: [B, S, topk_effective] fp32, gradient of loss w.r.t.
+            the selected indexer scores (typically ``(probs - target) * coeff``).
+
+    Returns:
+        grad_q: [B, S, H_i, D_i] gradient for indexer queries.
+        grad_weights: [B, S, H_i] gradient for per-head weights.
+        grad_k_comp: [B, S_comp, D_i] gradient for compressed indexer keys.
+    """
+    index_q, weights, index_k_comp, topk_indices, grad_scores = (
+        _prepare_backward_inputs(
+            index_q,
+            weights,
+            index_k_comp,
+            topk_indices,
+            grad_scores,
+        )
+    )
+    csa_indexer_bwd_interface = _get_csa_indexer_bwd_interface()
+    grad_q, grad_weights, grad_k_comp = csa_indexer_bwd_interface(
+        index_q,
+        weights,
+        index_k_comp,
+        topk_indices,
+        grad_scores,
+        block_I=int(block_I),
+        num_stages=int(num_stages),
+        num_threads=int(num_threads),
+    )
+    if (
+        tuple(grad_q.shape) != tuple(index_q.shape)
+        or tuple(grad_weights.shape) != tuple(weights.shape)
+        or tuple(grad_k_comp.shape) != tuple(index_k_comp.shape)
+    ):
+        raise RuntimeError(
+            "unexpected CSA indexer backward output shapes: "
+            f"grad_q={tuple(grad_q.shape)}, grad_weights={tuple(grad_weights.shape)}, grad_k_comp={tuple(grad_k_comp.shape)}"
+        )
+    if (
+        not isinstance(grad_q, paddle.Tensor)
+        or not isinstance(grad_weights, paddle.Tensor)
+        or not isinstance(grad_k_comp, paddle.Tensor)
+    ):
+        raise RuntimeError(
+            "TileLang must return Paddle tensors. "
+            "Ensure paddle.enable_compat(scope={'tilelang'}) runs before import tilelang."
+        )
+    return grad_q, grad_weights, grad_k_comp

--- a/src/paddlefleet/tilelang_ops/indexer/csa_indexer.py
+++ b/src/paddlefleet/tilelang_ops/indexer/csa_indexer.py
@@ -12,60 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import hashlib
-import json
-import os
-
 import paddle
 
 DEFAULT_INDEXER_BLOCK = 32
-_DIGEST_COUNTERS = {}
-
-
-def _digest_enabled():
-    return os.getenv("DSV4_TILELANG_DIGEST", "0").lower() in {
-        "1",
-        "true",
-        "yes",
-        "on",
-    }
-
-
-def _digest_limit():
-    try:
-        return int(os.getenv("DSV4_TILELANG_DIGEST_LIMIT", "40"))
-    except ValueError:
-        return 40
-
-
-def _tensor_digest(name, tensor):
-    tensor_f32 = tensor.detach().cast("float32").cpu()
-    array = tensor_f32.numpy()
-    return {
-        "name": name,
-        "shape": list(tensor.shape),
-        "dtype": str(tensor.dtype),
-        "sha256": hashlib.sha256(array.tobytes()).hexdigest(),
-        "sum_f32": float(array.sum()),
-        "max_abs_f32": float(abs(array).max()) if array.size else 0.0,
-    }
-
-
-def _digest_log(op, **tensors):
-    if not _digest_enabled():
-        return
-    count = _DIGEST_COUNTERS.get(op, 0)
-    if count >= _digest_limit():
-        return
-    _DIGEST_COUNTERS[op] = count + 1
-    payload = {
-        "op": op,
-        "call": count,
-        "tensors": [
-            _tensor_digest(name, tensor) for name, tensor in tensors.items()
-        ],
-    }
-    print("[TileLangDigest] " + json.dumps(payload, sort_keys=True), flush=True)
 
 
 def _get_csa_indexer_topk_fwd_interface():
@@ -86,18 +35,6 @@ def _get_csa_attn_target_reducesum_interface():
     return csa_attn_target_reducesum_interface
 
 
-def _contiguous(tensor):
-    return tensor.contiguous()
-
-
-def _cast_int32(tensor):
-    return tensor.cast("int32") if tensor.dtype != paddle.int32 else tensor
-
-
-def _cast_float32(tensor):
-    return tensor.cast("float32") if tensor.dtype != paddle.float32 else tensor
-
-
 def _validate_indexer_inputs(index_q, index_k_comp, weights):
     if not isinstance(index_q, paddle.Tensor):
         raise TypeError(
@@ -113,27 +50,27 @@ def _validate_indexer_inputs(index_q, index_k_comp, weights):
         )
     if len(index_q.shape) != 4:
         raise ValueError(
-            f"index_q must have shape [B, S, H_i, D_i], got {tuple(index_q.shape)}"
+            f"index_q must have shape [B, S, H_i, D_i], got {index_q.shape}"
         )
     if len(index_k_comp.shape) != 3:
         raise ValueError(
-            f"index_k_comp must have shape [B, S_comp, D_i], got {tuple(index_k_comp.shape)}"
+            f"index_k_comp must have shape [B, S_comp, D_i], got {index_k_comp.shape}"
         )
     if len(weights.shape) != 3:
         raise ValueError(
-            f"weights must have shape [B, S, H_i], got {tuple(weights.shape)}"
+            f"weights must have shape [B, S, H_i], got {weights.shape}"
         )
 
-    batch, seq_len, heads, dim = tuple(index_q.shape)
-    batch_k, _, dim_k = tuple(index_k_comp.shape)
-    batch_w, seq_len_w, heads_w = tuple(weights.shape)
+    batch, seq_len, heads, dim = index_q.shape
+    batch_k, _, dim_k = index_k_comp.shape
+    batch_w, seq_len_w, heads_w = weights.shape
     if batch != batch_k or batch != batch_w:
         raise ValueError(
-            f"batch mismatch: index_q={tuple(index_q.shape)}, index_k_comp={tuple(index_k_comp.shape)}, weights={tuple(weights.shape)}"
+            f"batch mismatch: index_q={index_q.shape}, index_k_comp={index_k_comp.shape}, weights={weights.shape}"
         )
     if seq_len != seq_len_w or heads != heads_w or dim != dim_k:
         raise ValueError(
-            f"shape mismatch: index_q={tuple(index_q.shape)}, index_k_comp={tuple(index_k_comp.shape)}, weights={tuple(weights.shape)}"
+            f"shape mismatch: index_q={index_q.shape}, index_k_comp={index_k_comp.shape}, weights={weights.shape}"
         )
 
 
@@ -148,23 +85,21 @@ def _validate_topk_and_grad(index_q, topk_indices, grad_scores):
         )
     if len(topk_indices.shape) != 3:
         raise ValueError(
-            f"topk_indices must have shape [B, S, topk], got {tuple(topk_indices.shape)}"
+            f"topk_indices must have shape [B, S, topk], got {topk_indices.shape}"
         )
     if len(grad_scores.shape) != 3:
         raise ValueError(
-            f"grad_scores must have shape [B, S, topk], got {tuple(grad_scores.shape)}"
+            f"grad_scores must have shape [B, S, topk], got {grad_scores.shape}"
         )
-    batch, seq_len, _, _ = tuple(index_q.shape)
-    topk_shape = tuple(topk_indices.shape)
-    grad_shape = tuple(grad_scores.shape)
-    if topk_shape != grad_shape:
+    batch, seq_len, _, _ = index_q.shape
+    if topk_indices.shape != grad_scores.shape:
         raise ValueError(
-            f"topk_indices shape {topk_shape} must match grad_scores shape {grad_shape}"
+            f"topk_indices shape {topk_indices.shape} must match grad_scores shape {grad_scores.shape}"
         )
-    topk_batch, topk_seq_len, topk_last_dim = topk_shape
+    topk_batch, topk_seq_len, topk_last_dim = topk_indices.shape
     if topk_batch != batch or topk_seq_len != seq_len:
         raise ValueError(
-            f"topk_indices shape {topk_shape} is incompatible with index_q shape {tuple(index_q.shape)}"
+            f"topk_indices shape {topk_indices.shape} is incompatible with index_q shape {index_q.shape}"
         )
     if topk_last_dim <= 0:
         raise ValueError("topk_indices last dimension must be positive")
@@ -176,11 +111,12 @@ def _prepare_forward_inputs(index_q, index_k_comp, weights, topk_effective):
         raise ValueError(
             f"topk_effective must be positive, got {topk_effective}"
         )
-    batch, seq_len = tuple(index_q.shape)[:2]
+    if weights.dtype != paddle.float32:
+        weights = weights.cast("float32")
     return (
-        _contiguous(index_q),
-        _contiguous(index_k_comp),
-        _contiguous(_cast_float32(weights)),
+        index_q.contiguous(),
+        index_k_comp.contiguous(),
+        weights.contiguous(),
         int(topk_effective),
     )
 
@@ -190,17 +126,23 @@ def _prepare_backward_inputs(
 ):
     _validate_indexer_inputs(index_q, index_k_comp, weights)
     _validate_topk_and_grad(index_q, topk_indices, grad_scores)
-    topk_indices = _contiguous(_cast_int32(topk_indices))
-    grad_scores = _contiguous(_cast_float32(grad_scores))
+    if topk_indices.dtype != paddle.int32:
+        topk_indices = topk_indices.cast("int32")
+    if grad_scores.dtype != paddle.float32:
+        grad_scores = grad_scores.cast("float32")
+    if weights.dtype != paddle.float32:
+        weights = weights.cast("float32")
+
+    topk_indices = topk_indices.contiguous()
     grad_scores = paddle.where(
         topk_indices >= 0, grad_scores, paddle.zeros_like(grad_scores)
     )
     return (
-        _contiguous(index_q),
-        _contiguous(_cast_float32(weights)),
-        _contiguous(index_k_comp),
+        index_q.contiguous(),
+        weights.contiguous(),
+        index_k_comp.contiguous(),
         topk_indices,
-        _contiguous(grad_scores),
+        grad_scores.contiguous(),
     )
 
 
@@ -249,14 +191,14 @@ def csa_indexer_topk_fwd(
         num_stages=int(num_stages),
         num_threads=int(num_threads),
     )
-    batch, seq_len = tuple(index_q.shape)[:2]
-    expected_shape = (batch, seq_len, topk_effective)
+    batch, seq_len = index_q.shape[:2]
+    expected_shape = [batch, seq_len, topk_effective]
     if (
-        tuple(topk_indices.shape) != expected_shape
-        or tuple(topk_scores.shape) != expected_shape
+        topk_indices.shape != expected_shape
+        or topk_scores.shape != expected_shape
     ):
         raise RuntimeError(
-            f"unexpected CSA indexer forward output shapes: indices={tuple(topk_indices.shape)}, scores={tuple(topk_scores.shape)}, expected={expected_shape}"
+            f"unexpected CSA indexer forward output shapes: indices={topk_indices.shape}, scores={topk_scores.shape}, expected={expected_shape}"
         )
     if not isinstance(topk_indices, paddle.Tensor) or not isinstance(
         topk_scores, paddle.Tensor
@@ -297,48 +239,50 @@ def csa_attn_target_reducesum(
         )
     if len(query_mla.shape) != 4:
         raise ValueError(
-            f"query_mla must have shape [B, S, H, D], got {tuple(query_mla.shape)}"
+            f"query_mla must have shape [B, S, H, D], got {query_mla.shape}"
         )
     if len(key_comp_mla.shape) != 3:
         raise ValueError(
-            f"key_comp_mla must have shape [B, S_comp, D], got {tuple(key_comp_mla.shape)}"
+            f"key_comp_mla must have shape [B, S_comp, D], got {key_comp_mla.shape}"
         )
     if len(topk_indices.shape) != 3:
         raise ValueError(
-            f"topk_indices must have shape [B, S, topk], got {tuple(topk_indices.shape)}"
+            f"topk_indices must have shape [B, S, topk], got {topk_indices.shape}"
         )
-    query_shape = tuple(query_mla.shape)
-    key_shape = tuple(key_comp_mla.shape)
-    topk_shape = tuple(topk_indices.shape)
-    if query_shape[0] != key_shape[0] or query_shape[0] != topk_shape[0]:
+    if (
+        query_mla.shape[0] != key_comp_mla.shape[0]
+        or query_mla.shape[0] != topk_indices.shape[0]
+    ):
         raise ValueError(
-            f"batch mismatch: query_mla={tuple(query_mla.shape)}, key_comp_mla={tuple(key_comp_mla.shape)}, topk_indices={tuple(topk_indices.shape)}"
+            f"batch mismatch: query_mla={query_mla.shape}, key_comp_mla={key_comp_mla.shape}, topk_indices={topk_indices.shape}"
         )
-    if query_shape[1] != topk_shape[1]:
+    if query_mla.shape[1] != topk_indices.shape[1]:
         raise ValueError(
-            f"sequence mismatch: query_mla={tuple(query_mla.shape)}, topk_indices={tuple(topk_indices.shape)}"
+            f"sequence mismatch: query_mla={query_mla.shape}, topk_indices={topk_indices.shape}"
         )
-    if query_shape[3] != key_shape[2]:
+    if query_mla.shape[3] != key_comp_mla.shape[2]:
         raise ValueError(
-            f"dim mismatch: query_mla={tuple(query_mla.shape)}, key_comp_mla={tuple(key_comp_mla.shape)}"
+            f"dim mismatch: query_mla={query_mla.shape}, key_comp_mla={key_comp_mla.shape}"
         )
-    topk_indices = _contiguous(_cast_int32(topk_indices))
+    if topk_indices.dtype != paddle.int32:
+        topk_indices = topk_indices.cast("int32")
+    topk_indices = topk_indices.contiguous()
     csa_attn_target_reducesum_interface = (
         _get_csa_attn_target_reducesum_interface()
     )
     target = csa_attn_target_reducesum_interface(
-        _contiguous(query_mla),
-        _contiguous(key_comp_mla),
+        query_mla.contiguous(),
+        key_comp_mla.contiguous(),
         topk_indices,
         float(softmax_scale),
         block_I=int(block_I),
         num_stages=int(num_stages),
         num_threads=int(num_threads),
     )
-    expected_shape = tuple(topk_indices.shape)
-    if tuple(target.shape) != expected_shape:
+    expected_shape = topk_indices.shape
+    if target.shape != expected_shape:
         raise RuntimeError(
-            f"unexpected CSA attention target shape: target={tuple(target.shape)}, expected={expected_shape}"
+            f"unexpected CSA attention target shape: target={target.shape}, expected={expected_shape}"
         )
     if not isinstance(target, paddle.Tensor):
         raise RuntimeError(
@@ -398,13 +342,13 @@ def csa_indexer_bwd(
         num_threads=int(num_threads),
     )
     if (
-        tuple(grad_q.shape) != tuple(index_q.shape)
-        or tuple(grad_weights.shape) != tuple(weights.shape)
-        or tuple(grad_k_comp.shape) != tuple(index_k_comp.shape)
+        grad_q.shape != index_q.shape
+        or grad_weights.shape != weights.shape
+        or grad_k_comp.shape != index_k_comp.shape
     ):
         raise RuntimeError(
             "unexpected CSA indexer backward output shapes: "
-            f"grad_q={tuple(grad_q.shape)}, grad_weights={tuple(grad_weights.shape)}, grad_k_comp={tuple(grad_k_comp.shape)}"
+            f"grad_q={grad_q.shape}, grad_weights={grad_weights.shape}, grad_k_comp={grad_k_comp.shape}"
         )
     if (
         not isinstance(grad_q, paddle.Tensor)

--- a/src/paddlefleet/tilelang_ops/indexer/csa_indexer_bwd.py
+++ b/src/paddlefleet/tilelang_ops/indexer/csa_indexer_bwd.py
@@ -1,0 +1,315 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# TileLang backward kernel for DeepSeek V4 CSA compressed indexer.
+#
+# This kernel consumes selected compressed block indices plus OGrad and computes
+# gradients for IndexQ/Weights/IndexKComp without materializing full
+# [B, S, S_comp] indexer logits. OGrad is the gradient w.r.t. selected indexer
+# logits/scores supplied by the loss wrapper.
+#
+# topk_effective semantics (controlled by caller, not by this kernel):
+#   - Phase 2 (sparse warmup, dsa_indexer_use_sparse_loss=False):
+#       topk_effective = n_compressed. The backward covers the full compressed
+#       candidate range, equivalent to full-range KL gradient.
+#   - Phase 3 (sparse, dsa_indexer_use_sparse_loss=True):
+#       topk_effective = min(index_topk, n_compressed), typically 512.
+#       Backward only covers the selected-topk set.
+#   - Phase 1 (csa_dense_mode=True): this kernel is never called.
+#
+# Padding: topk_effective is internally padded to the next power-of-2 that is
+# also divisible by block_I. Padded slots (index == -1) are masked out and
+# contribute zero gradient. The caller pads grad_scores with 0 for invalid
+# slots before calling this kernel.
+
+
+import paddle
+import tilelang
+from tilelang import language as T
+
+
+def _tilelang_dtype(tensor):
+    if tensor.dtype == paddle.bfloat16:
+        return "bfloat16"
+    if tensor.dtype == paddle.float16:
+        return "float16"
+    raise TypeError(
+        f"TileLang CSA indexer backward expects bf16/fp16 inputs, got {tensor.dtype}"
+    )
+
+
+@tilelang.jit(
+    pass_configs={
+        tilelang.PassConfigKey.TL_DISABLE_THREAD_STORAGE_SYNC: True,
+        tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
+        tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
+        tilelang.PassConfigKey.TL_DISABLE_WGMMA: True,
+    }
+)
+def tl_csa_indexer_bwd_impl(
+    heads: int,
+    dim: int,
+    topk: int,
+    block_I: int = 32,
+    dtype: str = "bfloat16",
+    num_stages: int = 0,
+    num_threads: int = 128,
+):
+    assert num_stages == 0
+    assert topk == tilelang.math.next_power_of_2(topk)
+    assert topk % block_I == 0
+    assert heads <= 64 and heads % 8 == 0
+
+    batch = T.dynamic("batch")
+    seq_len = T.dynamic("seq_len")
+    seq_len_comp = T.dynamic("seq_len_comp")
+
+    FP32 = "float"
+    INT32 = "int32"
+    sm_scale = dim**-0.5
+
+    index_q_shape = [batch, seq_len, heads, dim]
+    weights_shape = [batch, seq_len, heads]
+    index_k_shape = [batch, seq_len_comp, dim]
+    topk_indices_shape = [batch, seq_len, topk]
+    grad_scores_shape = [batch, seq_len, topk]
+
+    @T.prim_func
+    def tl_csa_indexer_bwd_kernel(
+        IndexQ: T.Tensor(index_q_shape, dtype),
+        IndexKComp: T.Tensor(index_k_shape, dtype),
+        Weights: T.Tensor(weights_shape, FP32),
+        TopkIndices: T.Tensor(topk_indices_shape, INT32),
+        OGrad: T.Tensor(grad_scores_shape, FP32),
+        dIndexQ: T.Tensor(index_q_shape, dtype),
+        dWeights: T.Tensor(weights_shape, FP32),
+        dIndexKComp: T.Tensor(index_k_shape, FP32),
+    ):
+        with T.Kernel(seq_len, batch, threads=num_threads) as (bx, by):
+            i_t = bx
+            i_b = by
+            index_q_shared = T.alloc_shared([heads, dim], dtype=dtype)
+            index_q_scaled_shared = T.alloc_shared([heads, dim], dtype=dtype)
+            weights_shared = T.alloc_shared([heads], dtype=FP32)
+            indices_shared = T.alloc_shared([block_I], dtype=INT32)
+            grad_shared = T.alloc_shared([block_I], dtype=FP32)
+            index_k_shared = T.alloc_shared([block_I, dim], dtype=dtype)
+
+            d_index_q_frag = T.alloc_fragment([heads, dim], dtype=FP32)
+            d_weights_frag = T.alloc_fragment([heads], dtype=FP32)
+            d_index_k_frag = T.alloc_fragment([block_I, dim], dtype=FP32)
+            logits = T.alloc_fragment((block_I, heads), dtype=FP32)
+            d_logits_qk = T.alloc_shared((block_I, heads), dtype=FP32)
+            d_logits_qk_cast1 = T.alloc_fragment((block_I, heads), dtype=dtype)
+            d_logits_qk_cast2 = T.alloc_fragment((block_I, heads), dtype=dtype)
+
+            T.copy(IndexQ[i_b, i_t, :, :], index_q_shared)
+            T.copy(Weights[i_b, i_t, :], weights_shared)
+            T.sync_threads()
+
+            for i, j in T.Parallel(heads, dim):
+                index_q_scaled_shared[i, j] = index_q_shared[i, j] * sm_scale
+            T.sync_threads()
+
+            T.fill(d_index_q_frag, 0)
+            T.fill(d_weights_frag, 0)
+            num_blocks = T.ceildiv(topk, block_I)
+
+            for bi_i in T.serial(num_blocks):
+                for i in T.Parallel(block_I):
+                    indices_shared[i] = TopkIndices[
+                        i_b, i_t, bi_i * block_I + i
+                    ]
+                    grad_shared[i] = OGrad[i_b, i_t, bi_i * block_I + i]
+                T.sync_threads()
+
+                for i, j in T.Parallel(block_I, dim):
+                    index_k_shared[i, j] = T.if_then_else(
+                        (indices_shared[i] >= 0)
+                        & (indices_shared[i] < seq_len_comp),
+                        IndexKComp[i_b, indices_shared[i], j],
+                        0,
+                    )
+                T.sync_threads()
+
+                T.gemm(
+                    index_k_shared,
+                    index_q_scaled_shared,
+                    logits,
+                    transpose_A=False,
+                    transpose_B=True,
+                    clear_accum=True,
+                )
+                T.sync_threads()
+
+                for i, j in T.Parallel(block_I, heads):
+                    logits[i, j] = T.max(logits[i, j], 0)
+                T.sync_threads()
+
+                d_weights_i = T.alloc_fragment((block_I, heads), dtype=FP32)
+                for i, j in T.Parallel(block_I, heads):
+                    d_weights_i[i, j] = T.if_then_else(
+                        (indices_shared[i] >= 0)
+                        & (indices_shared[i] < seq_len_comp),
+                        grad_shared[i] * logits[i, j],
+                        0,
+                    )
+                T.reduce_sum(d_weights_i, d_weights_frag, dim=0, clear=False)
+
+                for i, j in T.Parallel(block_I, heads):
+                    d_logits_qk[i, j] = T.if_then_else(
+                        (
+                            (indices_shared[i] >= 0)
+                            & (indices_shared[i] < seq_len_comp)
+                        )
+                        & (logits[i, j] > 0),
+                        grad_shared[i] * weights_shared[j],
+                        0,
+                    )
+                T.sync_threads()
+
+                T.copy(d_logits_qk, d_logits_qk_cast1)
+                T.gemm(
+                    d_logits_qk_cast1,
+                    index_k_shared,
+                    d_index_q_frag,
+                    transpose_A=True,
+                    transpose_B=False,
+                    clear_accum=False,
+                )
+
+                T.copy(d_logits_qk, d_logits_qk_cast2)
+                T.gemm(
+                    d_logits_qk_cast2,
+                    index_q_scaled_shared,
+                    d_index_k_frag,
+                    transpose_A=False,
+                    transpose_B=False,
+                    clear_accum=True,
+                )
+
+                for i, j in T.Parallel(block_I, dim):
+                    if (indices_shared[i] >= 0) & (
+                        indices_shared[i] < seq_len_comp
+                    ):
+                        T.atomic_add(
+                            dIndexKComp[i_b, indices_shared[i], j],
+                            d_index_k_frag[i, j],
+                        )
+
+            for i, j in T.Parallel(heads, dim):
+                d_index_q_frag[i, j] = d_index_q_frag[i, j] * sm_scale
+
+            T.copy(d_index_q_frag, dIndexQ[i_b, i_t, :, :])
+            T.copy(d_weights_frag, dWeights[i_b, i_t, :])
+
+    return tl_csa_indexer_bwd_kernel
+
+
+def csa_indexer_bwd_interface(
+    index_q,
+    weights,
+    index_k_comp,
+    topk_indices,
+    grad_scores,
+    block_I: int = 32,
+    num_stages: int = 0,
+    num_threads: int = 128,
+):
+    """Run V4 CSA compressed indexer backward.
+
+    Args:
+        index_q: [B, S, H_i, D_i] bf16/fp16, BSHD layout.
+        weights: [B, S, H_i] fp32 or castable to fp32.
+        index_k_comp: [B, S_comp, D_i] bf16/fp16, BSD layout.
+        topk_indices: [B, S, topk_effective] int32, invalid slots are -1.
+        grad_scores: [B, S, topk_effective] fp32 OGrad for selected logits.
+
+    Returns:
+        grad_q: [B, S, H_i, D_i] same dtype as index_q.
+        grad_weights: [B, S, H_i] fp32.
+        grad_k_comp: [B, S_comp, D_i] fp32.
+    """
+    assert index_q.is_contiguous()
+    assert weights.is_contiguous()
+    assert index_k_comp.is_contiguous()
+    assert topk_indices.is_contiguous()
+    assert grad_scores.is_contiguous()
+    assert index_q.ndim == 4
+    assert weights.ndim == 3
+    assert index_k_comp.ndim == 3
+    assert topk_indices.ndim == 3
+    assert grad_scores.ndim == 3
+
+    batch, seq_len, heads, dim = index_q.shape
+    batch_w, seq_len_w, heads_w = weights.shape
+    batch_k, seq_len_comp, dim_k = index_k_comp.shape
+    batch_i, seq_len_i, topk_effective = topk_indices.shape
+    batch_g, seq_len_g, topk_g = grad_scores.shape
+
+    assert batch == batch_w == batch_k == batch_i == batch_g
+    assert seq_len == seq_len_w == seq_len_i == seq_len_g
+    assert heads == heads_w
+    assert dim == dim_k
+    assert topk_effective == topk_g
+    assert topk_effective > 0
+    padded_topk = 1 << (topk_effective - 1).bit_length()
+    if padded_topk % block_I != 0:
+        padded_topk = ((padded_topk + block_I - 1) // block_I) * block_I
+        padded_topk = 1 << (padded_topk - 1).bit_length()
+
+    if padded_topk != topk_effective:
+        pad = padded_topk - topk_effective
+        topk_pad = paddle.full(
+            [batch, seq_len, pad],
+            -1,
+            topk_indices.dtype,
+        )
+        grad_pad = paddle.zeros(
+            [batch, seq_len, pad],
+            grad_scores.dtype,
+        )
+        topk_indices = paddle.concat(
+            [topk_indices, topk_pad], axis=-1
+        ).contiguous()
+        grad_scores = paddle.concat(
+            [grad_scores, grad_pad], axis=-1
+        ).contiguous()
+
+    kernel = tl_csa_indexer_bwd_impl(
+        heads=heads,
+        dim=dim,
+        topk=padded_topk,
+        block_I=block_I,
+        dtype=_tilelang_dtype(index_q),
+        num_stages=num_stages,
+        num_threads=num_threads,
+    )
+
+    grad_q = paddle.empty_like(index_q)
+    grad_weights = paddle.empty_like(weights, dtype="float32")
+    grad_k_comp = paddle.zeros_like(index_k_comp, dtype="float32")
+
+    kernel(
+        index_q,
+        index_k_comp,
+        weights.cast("float32").contiguous(),
+        topk_indices,
+        grad_scores.cast("float32").contiguous(),
+        grad_q,
+        grad_weights,
+        grad_k_comp,
+    )
+
+    return grad_q, grad_weights, grad_k_comp

--- a/src/paddlefleet/tilelang_ops/indexer/csa_indexer_bwd.py
+++ b/src/paddlefleet/tilelang_ops/indexer/csa_indexer_bwd.py
@@ -49,6 +49,97 @@ def _tilelang_dtype(tensor):
     )
 
 
+def _shape(tensor):
+    return tuple(tensor.shape)
+
+
+def _require_tensor(name, tensor):
+    if not isinstance(tensor, paddle.Tensor):
+        raise TypeError(f"{name} must be a paddle.Tensor, got {type(tensor)!r}")
+
+
+def _require_contiguous(name, tensor):
+    if not tensor.is_contiguous():
+        raise ValueError(f"{name} must be contiguous")
+
+
+def _validate_interface_inputs(
+    index_q,
+    weights,
+    index_k_comp,
+    topk_indices,
+    grad_scores,
+    block_I,
+    num_stages,
+):
+    for name, tensor in (
+        ("index_q", index_q),
+        ("weights", weights),
+        ("index_k_comp", index_k_comp),
+        ("topk_indices", topk_indices),
+        ("grad_scores", grad_scores),
+    ):
+        _require_tensor(name, tensor)
+        _require_contiguous(name, tensor)
+    if index_q.ndim != 4:
+        raise ValueError(
+            f"index_q must have shape [B, S, H_i, D_i], got {_shape(index_q)}"
+        )
+    if weights.ndim != 3:
+        raise ValueError(
+            f"weights must have shape [B, S, H_i], got {_shape(weights)}"
+        )
+    if index_k_comp.ndim != 3:
+        raise ValueError(
+            f"index_k_comp must have shape [B, S_comp, D_i], got {_shape(index_k_comp)}"
+        )
+    if topk_indices.ndim != 3:
+        raise ValueError(
+            f"topk_indices must have shape [B, S, topk], got {_shape(topk_indices)}"
+        )
+    if grad_scores.ndim != 3:
+        raise ValueError(
+            f"grad_scores must have shape [B, S, topk], got {_shape(grad_scores)}"
+        )
+
+    batch, seq_len, heads, dim = _shape(index_q)
+    batch_w, seq_len_w, heads_w = _shape(weights)
+    batch_k, _, dim_k = _shape(index_k_comp)
+    batch_i, seq_len_i, topk_effective = _shape(topk_indices)
+    batch_g, seq_len_g, topk_g = _shape(grad_scores)
+    if not (batch == batch_w == batch_k == batch_i == batch_g):
+        raise ValueError(
+            "batch mismatch: "
+            f"index_q={_shape(index_q)}, weights={_shape(weights)}, index_k_comp={_shape(index_k_comp)}, "
+            f"topk_indices={_shape(topk_indices)}, grad_scores={_shape(grad_scores)}"
+        )
+    if not (seq_len == seq_len_w == seq_len_i == seq_len_g):
+        raise ValueError(
+            "sequence mismatch: "
+            f"index_q={_shape(index_q)}, weights={_shape(weights)}, topk_indices={_shape(topk_indices)}, grad_scores={_shape(grad_scores)}"
+        )
+    if heads != heads_w:
+        raise ValueError(
+            f"heads mismatch: index_q={_shape(index_q)}, weights={_shape(weights)}"
+        )
+    if dim != dim_k:
+        raise ValueError(
+            f"dim mismatch: index_q={_shape(index_q)}, index_k_comp={_shape(index_k_comp)}"
+        )
+    if topk_effective != topk_g:
+        raise ValueError(
+            f"topk mismatch: topk_indices={_shape(topk_indices)}, grad_scores={_shape(grad_scores)}"
+        )
+    if heads > 64 or heads % 8 != 0:
+        raise ValueError(f"heads must be <= 64 and divisible by 8, got {heads}")
+    if topk_effective <= 0:
+        raise ValueError("topk_indices last dimension must be positive")
+    if int(block_I) <= 0:
+        raise ValueError(f"block_I must be positive, got {block_I}")
+    if int(num_stages) != 0:
+        raise ValueError(f"num_stages must be 0, got {num_stages}")
+
+
 @tilelang.jit(
     pass_configs={
         tilelang.PassConfigKey.TL_DISABLE_THREAD_STORAGE_SYNC: True,
@@ -241,29 +332,19 @@ def csa_indexer_bwd_interface(
         grad_weights: [B, S, H_i] fp32.
         grad_k_comp: [B, S_comp, D_i] fp32.
     """
-    assert index_q.is_contiguous()
-    assert weights.is_contiguous()
-    assert index_k_comp.is_contiguous()
-    assert topk_indices.is_contiguous()
-    assert grad_scores.is_contiguous()
-    assert index_q.ndim == 4
-    assert weights.ndim == 3
-    assert index_k_comp.ndim == 3
-    assert topk_indices.ndim == 3
-    assert grad_scores.ndim == 3
+    _validate_interface_inputs(
+        index_q,
+        weights,
+        index_k_comp,
+        topk_indices,
+        grad_scores,
+        block_I,
+        num_stages,
+    )
 
     batch, seq_len, heads, dim = index_q.shape
-    batch_w, seq_len_w, heads_w = weights.shape
-    batch_k, seq_len_comp, dim_k = index_k_comp.shape
-    batch_i, seq_len_i, topk_effective = topk_indices.shape
-    batch_g, seq_len_g, topk_g = grad_scores.shape
-
-    assert batch == batch_w == batch_k == batch_i == batch_g
-    assert seq_len == seq_len_w == seq_len_i == seq_len_g
-    assert heads == heads_w
-    assert dim == dim_k
-    assert topk_effective == topk_g
-    assert topk_effective > 0
+    _, seq_len_comp, _ = index_k_comp.shape
+    topk_effective = topk_indices.shape[-1]
     padded_topk = 1 << (topk_effective - 1).bit_length()
     if padded_topk % block_I != 0:
         padded_topk = ((padded_topk + block_I - 1) // block_I) * block_I

--- a/src/paddlefleet/tilelang_ops/indexer/csa_indexer_bwd.py
+++ b/src/paddlefleet/tilelang_ops/indexer/csa_indexer_bwd.py
@@ -382,12 +382,17 @@ def csa_indexer_bwd_interface(
     grad_weights = paddle.empty_like(weights, dtype="float32")
     grad_k_comp = paddle.zeros_like(index_k_comp, dtype="float32")
 
+    if weights.dtype != paddle.float32:
+        weights = weights.cast("float32").contiguous()
+    if grad_scores.dtype != paddle.float32:
+        grad_scores = grad_scores.cast("float32").contiguous()
+
     kernel(
         index_q,
         index_k_comp,
-        weights.cast("float32").contiguous(),
+        weights,
         topk_indices,
-        grad_scores.cast("float32").contiguous(),
+        grad_scores,
         grad_q,
         grad_weights,
         grad_k_comp,

--- a/src/paddlefleet/tilelang_ops/indexer/csa_indexer_fwd.py
+++ b/src/paddlefleet/tilelang_ops/indexer/csa_indexer_fwd.py
@@ -373,10 +373,13 @@ def csa_indexer_topk_fwd_interface(
     topk_indices = paddle.empty([batch, seq_len, padded_topk], dtype="int32")
     topk_scores = paddle.empty([batch, seq_len, padded_topk], dtype="float32")
 
+    if weights.dtype != paddle.float32:
+        weights = weights.cast("float32").contiguous()
+
     kernel(
         index_q,
         index_k_comp,
-        weights.cast("float32").contiguous(),
+        weights,
         topk_indices,
         topk_scores,
     )

--- a/src/paddlefleet/tilelang_ops/indexer/csa_indexer_fwd.py
+++ b/src/paddlefleet/tilelang_ops/indexer/csa_indexer_fwd.py
@@ -254,6 +254,71 @@ def _tilelang_dtype(tensor):
     )
 
 
+def _shape(tensor):
+    return tuple(tensor.shape)
+
+
+def _require_tensor(name, tensor):
+    if not isinstance(tensor, paddle.Tensor):
+        raise TypeError(f"{name} must be a paddle.Tensor, got {type(tensor)!r}")
+
+
+def _require_contiguous(name, tensor):
+    if not tensor.is_contiguous():
+        raise ValueError(f"{name} must be contiguous")
+
+
+def _validate_interface_inputs(
+    index_q,
+    index_k_comp,
+    weights,
+    topk_effective,
+    block_K,
+    num_stages,
+):
+    for name, tensor in (
+        ("index_q", index_q),
+        ("index_k_comp", index_k_comp),
+        ("weights", weights),
+    ):
+        _require_tensor(name, tensor)
+        _require_contiguous(name, tensor)
+    if index_q.ndim != 4:
+        raise ValueError(
+            f"index_q must have shape [B, S, H_i, D_i], got {_shape(index_q)}"
+        )
+    if index_k_comp.ndim != 3:
+        raise ValueError(
+            f"index_k_comp must have shape [B, S_comp, D_i], got {_shape(index_k_comp)}"
+        )
+    if weights.ndim != 3:
+        raise ValueError(
+            f"weights must have shape [B, S, H_i], got {_shape(weights)}"
+        )
+
+    batch, seq_len, heads, dim = _shape(index_q)
+    batch_k, _, dim_k = _shape(index_k_comp)
+    batch_w, seq_len_w, heads_w = _shape(weights)
+    if batch != batch_k or batch != batch_w:
+        raise ValueError(
+            f"batch mismatch: index_q={_shape(index_q)}, index_k_comp={_shape(index_k_comp)}, weights={_shape(weights)}"
+        )
+    if seq_len != seq_len_w or heads != heads_w or dim != dim_k:
+        raise ValueError(
+            f"shape mismatch: index_q={_shape(index_q)}, index_k_comp={_shape(index_k_comp)}, weights={_shape(weights)}"
+        )
+    if heads > 64 or heads % 8 != 0:
+        raise ValueError(f"heads must be <= 64 and divisible by 8, got {heads}")
+    if int(topk_effective) <= 0:
+        raise ValueError(
+            f"topk_effective must be positive, got {topk_effective}"
+        )
+    if int(block_K) <= 0:
+        raise ValueError(f"block_K must be positive, got {block_K}")
+    if int(num_stages) != 0:
+        raise ValueError(f"num_stages must be 0, got {num_stages}")
+
+
 def csa_indexer_topk_fwd_interface(
     index_q,
     index_k_comp,
@@ -279,21 +344,16 @@ def csa_indexer_topk_fwd_interface(
         topk_indices: [B, S, topk_effective] int32, invalid slots are -1.
         topk_scores: [B, S, topk_effective] fp32 top-k softmax probabilities.
     """
-    assert index_q.is_contiguous()
-    assert index_k_comp.is_contiguous()
-    assert weights.is_contiguous()
-    assert index_q.ndim == 4
-    assert index_k_comp.ndim == 3
-    assert weights.ndim == 3
+    _validate_interface_inputs(
+        index_q,
+        index_k_comp,
+        weights,
+        topk_effective,
+        block_K,
+        num_stages,
+    )
 
     batch, seq_len, heads, dim = index_q.shape
-    batch_k, seq_len_comp, dim_k = index_k_comp.shape
-    batch_w, seq_len_w, heads_w = weights.shape
-    assert batch == batch_k == batch_w
-    assert seq_len == seq_len_w
-    assert heads == heads_w
-    assert dim == dim_k
-    assert topk_effective > 0
     padded_topk = _next_power_of_2(topk_effective)
     if padded_topk % block_K != 0:
         padded_topk = ((padded_topk + block_K - 1) // block_K) * block_K

--- a/src/paddlefleet/tilelang_ops/indexer/csa_indexer_fwd.py
+++ b/src/paddlefleet/tilelang_ops/indexer/csa_indexer_fwd.py
@@ -1,0 +1,324 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# TileLang fused forward kernel for DeepSeek V4 CSA compressed indexer.
+#
+# This kernel produces compressed top-k indices and top-k softmax probabilities
+# directly from IndexQ/IndexKComp/Weights without materializing the full
+# [B, S, S_comp] logits tensor. It follows the Megatron-DSA streaming top-k
+# pattern, adapted to V4 CSA compressed-key semantics and BSHD/BSD layout.
+#
+# topk_effective semantics (controlled by caller, not by this kernel):
+#   - Phase 2 (sparse warmup, dsa_indexer_use_sparse_loss=False):
+#       topk_effective = n_compressed = floor(S / ratio).
+#       The selected set covers the full causal compressed range, enabling
+#       full-range KL loss equivalent to DSA dense warm-up.
+#   - Phase 3 (sparse, dsa_indexer_use_sparse_loss=True):
+#       topk_effective = min(index_topk, n_compressed), typically 512.
+#       Standard selected-topk semantics for sparse training.
+#   - Phase 1 (csa_dense_mode=True): this kernel is never called.
+#
+# Padding: topk_effective is internally padded to the next power-of-2 that is
+# also divisible by block_K (for bitonic sort alignment). Padded slots in the
+# output are filled with -1 (indices) and 0.0 (scores). The caller receives
+# only the first topk_effective columns (padding is stripped).
+
+import math
+
+import paddle
+import tilelang
+from tilelang import language as T
+
+
+@tilelang.jit(
+    pass_configs={
+        tilelang.PassConfigKey.TL_DISABLE_THREAD_STORAGE_SYNC: True,
+        tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
+        tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
+    }
+)
+def tl_csa_indexer_topk_fwd_impl(
+    heads: int,
+    dim: int,
+    topk: int,
+    ratio: int,
+    block_K: int = 32,
+    dtype: str = "bfloat16",
+    num_stages: int = 0,
+    num_threads: int = 128,
+):
+    assert topk == tilelang.math.next_power_of_2(topk)
+    assert topk % block_K == 0
+    assert heads <= 64 and heads % 8 == 0
+    assert num_stages == 0
+
+    batch = T.dynamic("batch")
+    seq_len = T.dynamic("seq_len")
+    seq_len_comp = T.dynamic("seq_len_comp")
+
+    INT32 = "int32"
+    FP32 = "float"
+
+    index_q_shape = [batch, seq_len, heads, dim]
+    weights_shape = [batch, seq_len, heads]
+    index_k_shape = [batch, seq_len_comp, dim]
+    topk_indices_shape = [batch, seq_len, topk]
+    topk_scores_shape = [batch, seq_len, topk]
+
+    N = 2 * topk
+    num_iters = int(round(math.log2(N)))
+    sm_scale = dim**-0.5
+
+    @T.macro
+    def bitonic_sort(
+        topk_index_shared: T.SharedBuffer([N], dtype=INT32),
+        topk_value_shared: T.SharedBuffer([N], dtype=FP32),
+    ):
+        T.sync_threads()
+        for i1 in T.serial(num_iters):
+            for i2 in T.serial(i1 + 1):
+                for i in T.Parallel(N):
+                    ascending = (i & (1 << (i1 + 1))) != 0
+                    j = i ^ (1 << (i1 - i2))
+                    if i < j and (
+                        (
+                            ascending
+                            and topk_value_shared[i] > topk_value_shared[j]
+                        )
+                        or (
+                            not ascending
+                            and topk_value_shared[i] < topk_value_shared[j]
+                        )
+                    ):
+                        val = topk_value_shared[i]
+                        topk_value_shared[i] = topk_value_shared[j]
+                        topk_value_shared[j] = val
+                        idx = topk_index_shared[i]
+                        topk_index_shared[i] = topk_index_shared[j]
+                        topk_index_shared[j] = idx
+                T.sync_threads()
+
+    @T.prim_func
+    def tl_csa_indexer_topk_fwd_kernel(
+        IndexQ: T.Tensor(index_q_shape, dtype),
+        IndexKComp: T.Tensor(index_k_shape, dtype),
+        Weights: T.Tensor(weights_shape, FP32),
+        TopkIndices: T.Tensor(topk_indices_shape, INT32),
+        TopkScores: T.Tensor(topk_scores_shape, FP32),
+    ):
+        with T.Kernel(seq_len, batch, threads=num_threads) as (bx, by):
+            i_t = bx
+            i_b = by
+            valid_end = T.min((i_t + 1) // ratio, seq_len_comp)
+
+            topk_index_shared = T.alloc_shared([N], dtype=INT32)
+            topk_value_shared = T.alloc_shared([N], dtype=FP32)
+            T.fill(topk_index_shared, -1)
+            T.fill(topk_value_shared, float("-inf"))
+            T.sync_threads()
+
+            index_q_shared = T.alloc_shared([heads, dim], dtype=dtype)
+            T.copy(IndexQ[i_b, i_t, :, :], index_q_shared)
+            T.sync_threads()
+
+            weights_shared = T.alloc_shared([heads], dtype=FP32)
+            T.copy(Weights[i_b, i_t, :], weights_shared)
+            T.sync_threads()
+
+            for i, j in T.Parallel(heads, dim):
+                index_q_shared[i, j] = index_q_shared[i, j] * sm_scale
+            T.sync_threads()
+
+            num_blocks = T.ceildiv(valid_end, block_K)
+            for bk_i in T.Pipelined(num_blocks, num_stages=num_stages):
+                k_st = bk_i * block_K
+                k_ed = T.min((bk_i + 1) * block_K, valid_end)
+
+                index_k_shared = T.alloc_shared([block_K, dim], dtype=dtype)
+                for i, j in T.Parallel(block_K, dim):
+                    index_k_shared[i, j] = T.if_then_else(
+                        k_st + i < k_ed,
+                        IndexKComp[i_b, k_st + i, j],
+                        0,
+                    )
+                T.sync_threads()
+
+                logits = T.alloc_fragment((block_K, heads), FP32)
+                T.gemm(
+                    index_k_shared,
+                    index_q_shared,
+                    logits,
+                    transpose_A=False,
+                    transpose_B=True,
+                    clear_accum=True,
+                )
+                T.sync_threads()
+
+                for i, j in T.Parallel(block_K, heads):
+                    logits[i, j] = T.max(logits[i, j], 0) * weights_shared[j]
+                T.sync_threads()
+
+                logits_sum = T.alloc_fragment(block_K, FP32)
+                T.reduce_sum(logits, logits_sum, dim=1)
+                T.sync_threads()
+
+                offset = T.alloc_var(INT32)
+                if k_st >= topk:
+                    offset = topk + (k_st % topk)
+                else:
+                    offset = k_st
+                T.sync_threads()
+
+                for i in T.Parallel(block_K):
+                    if k_st + i >= valid_end:
+                        logits_sum[i] = float("-inf")
+                    j = offset + i
+                    topk_index_shared[j] = T.if_then_else(
+                        k_st + i < valid_end,
+                        k_st + i,
+                        -1,
+                    )
+                    topk_value_shared[j] = logits_sum[i]
+                T.sync_threads()
+
+                if k_ed > topk and k_ed % topk == 0:
+                    bitonic_sort(topk_index_shared, topk_value_shared)
+
+            bitonic_sort(topk_index_shared, topk_value_shared)
+
+            logits_max_frag = T.alloc_fragment([1], dtype=FP32)
+            logits_frag = T.alloc_fragment([topk], dtype=FP32)
+            scores_shared = T.alloc_shared([topk], dtype=FP32)
+
+            T.copy(topk_value_shared[:topk], logits_frag)
+            T.sync_threads()
+            T.reduce_max(logits_frag, logits_max_frag, dim=-1)
+            T.sync_threads()
+
+            for i in T.Parallel(topk):
+                logits_frag[i] = T.if_then_else(
+                    topk_index_shared[i] >= 0,
+                    T.exp(logits_frag[i] - logits_max_frag[0]),
+                    0,
+                )
+            T.sync_threads()
+
+            lse_frag = T.alloc_fragment([1], dtype=FP32)
+            T.reduce_sum(logits_frag, lse_frag)
+            T.sync_threads()
+
+            for i in T.Parallel(topk):
+                scores_shared[i] = T.if_then_else(
+                    topk_index_shared[i] >= 0,
+                    logits_frag[i] / lse_frag[0],
+                    0,
+                )
+            T.sync_threads()
+
+            T.copy(topk_index_shared[:topk], TopkIndices[i_b, i_t, :])
+            T.copy(scores_shared[:topk], TopkScores[i_b, i_t, :])
+
+    return tl_csa_indexer_topk_fwd_kernel
+
+
+def _next_power_of_2(x: int) -> int:
+    if x <= 1:
+        return 1
+    return 1 << (x - 1).bit_length()
+
+
+def _pad_topk_output(indices, scores, topk: int):
+    if indices.shape[-1] == topk:
+        return indices, scores
+    return indices[..., :topk].contiguous(), scores[..., :topk].contiguous()
+
+
+def _tilelang_dtype(tensor):
+    if tensor.dtype == paddle.bfloat16:
+        return "bfloat16"
+    if tensor.dtype == paddle.float16:
+        return "float16"
+    raise TypeError(
+        f"TileLang CSA indexer expects bf16/fp16 inputs, got {tensor.dtype}"
+    )
+
+
+def csa_indexer_topk_fwd_interface(
+    index_q,
+    index_k_comp,
+    weights,
+    ratio: int,
+    topk_effective: int,
+    block_K: int = 32,
+    num_stages: int = 0,
+    num_threads: int = 128,
+):
+    """Run V4 CSA fused compressed indexer forward.
+
+    Args:
+        index_q: [B, S, H_i, D_i] bf16/fp16, BSHD layout.
+        index_k_comp: [B, S_comp, D_i] bf16/fp16, BSD layout.
+        weights: [B, S, H_i] fp32 or castable to fp32.
+        ratio: compression ratio. Valid compressed range for query t is
+            [0, (t + 1) // ratio).
+        topk_effective: requested output top-k. Phase 2 may set this to
+            S_comp; Phase 3 usually sets this to dsa_indexer_topk.
+
+    Returns:
+        topk_indices: [B, S, topk_effective] int32, invalid slots are -1.
+        topk_scores: [B, S, topk_effective] fp32 top-k softmax probabilities.
+    """
+    assert index_q.is_contiguous()
+    assert index_k_comp.is_contiguous()
+    assert weights.is_contiguous()
+    assert index_q.ndim == 4
+    assert index_k_comp.ndim == 3
+    assert weights.ndim == 3
+
+    batch, seq_len, heads, dim = index_q.shape
+    batch_k, seq_len_comp, dim_k = index_k_comp.shape
+    batch_w, seq_len_w, heads_w = weights.shape
+    assert batch == batch_k == batch_w
+    assert seq_len == seq_len_w
+    assert heads == heads_w
+    assert dim == dim_k
+    assert topk_effective > 0
+    padded_topk = _next_power_of_2(topk_effective)
+    if padded_topk % block_K != 0:
+        padded_topk = ((padded_topk + block_K - 1) // block_K) * block_K
+        padded_topk = _next_power_of_2(padded_topk)
+
+    kernel = tl_csa_indexer_topk_fwd_impl(
+        heads=heads,
+        dim=dim,
+        topk=padded_topk,
+        ratio=ratio,
+        block_K=block_K,
+        dtype=_tilelang_dtype(index_q),
+        num_stages=num_stages,
+        num_threads=num_threads,
+    )
+
+    topk_indices = paddle.empty([batch, seq_len, padded_topk], dtype="int32")
+    topk_scores = paddle.empty([batch, seq_len, padded_topk], dtype="float32")
+
+    kernel(
+        index_q,
+        index_k_comp,
+        weights.cast("float32").contiguous(),
+        topk_indices,
+        topk_scores,
+    )
+
+    return _pad_topk_output(topk_indices, topk_scores, topk_effective)

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -515,15 +515,10 @@ class TileLangCSAIndexerLoss(paddle.autograd.PyLayer):
             target,
         ) = ctx.saved_tensor()
 
-        # Match the forward KL smoothing exactly:
-        # loss = target * (log(target + eps) - log(prob + eps)).
-        # First differentiate w.r.t. probabilities, then apply the softmax
-        # Jacobian for the selected logits.
-        eps = 1e-10
+        # Treat the forward eps as numerical protection only and use the
+        # fused softmax + KL gradient w.r.t. the selected logits.
         scale = ctx.loss_coeff / max(ctx.num_rows, 1.0)
-        grad_probs = -target / (topk_probs + eps) * scale
-        sum_grad = (grad_probs * topk_probs).sum(axis=-1, keepdim=True)
-        grad_index_scores = topk_probs * (grad_probs - sum_grad)
+        grad_index_scores = (topk_probs - target) * scale
         if grad_loss is not None:
             grad_index_scores = grad_index_scores * grad_loss
 

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -285,6 +285,17 @@ def _resolve_csa_indexer_topk_effective(
     return int(n_compressed)
 
 
+def _resolve_csa_tilelang_switch(config, field_name: str) -> bool:
+    backend_enabled = (
+        getattr(config, "csa_tilelang_backend", None)
+        == "attention_paddle_compat"
+    )
+    override = getattr(config, field_name, None)
+    if override is None:
+        return backend_enabled
+    return bool(override)
+
+
 def _map_compressed_topk_to_kv_full(
     topk_indices_compressed: Tensor,
     sq: int,
@@ -984,30 +995,16 @@ class CompressedSparseAttention(FleetLayer):
                 # gates which kernel produces the indices, it does not change
                 # phase semantics (csa_dense_mode / dsa_indexer_use_sparse_loss
                 # / dsa_indexer_loss_coeff still own that).
-                use_tilelang_indexer = (
-                    getattr(self.config, "dsv4_tilelang_backend", None)
-                    == "attention_paddle_compat"
-                    and getattr(
-                        self.config,
-                        "dsv4_tilelang_enable_csa_indexer",
-                        None,
-                    )
-                    is not False
-                )
-                enable_tilelang_bwd = bool(
-                    getattr(self.config, "dsv4_tilelang_enable_backward", False)
+                use_tilelang_indexer = _resolve_csa_tilelang_switch(
+                    self.config,
+                    "csa_tilelang_enable_indexer",
                 )
                 # The fused TileLang indexer-loss path is only active during
-                # training and only when backend/indexer and backward are enabled.
+                # training when the CSA TileLang indexer path is enabled.
                 # Otherwise we fall back to:
-                #   * TileLang forward-only override (no_grad TileLang fwd +
-                #     Paddle FusedDSAIndexerLoss backward), or
-                #   * Pure Paddle reference.
-                use_tilelang_loss_path = (
-                    use_tilelang_indexer
-                    and enable_tilelang_bwd
-                    and self.training
-                )
+                #   * Paddle FusedDSAIndexerLoss during training, or
+                #   * Paddle/TileLang forward-only top-k during inference.
+                use_tilelang_loss_path = use_tilelang_indexer and self.training
                 topk_effective = _resolve_csa_indexer_topk_effective(
                     self.config,
                     self.indexer.index_topk,
@@ -1197,10 +1194,13 @@ class CompressedSparseAttention(FleetLayer):
         topk_idxs: Tensor,
         softmax_scale: float,
     ):
-        if self.config.csa_sparse_attn_fusion:
-            from paddlefleet.tilelang_ops import tilelang_compressed_sparse_attn
+        if _resolve_csa_tilelang_switch(
+            self.config,
+            "csa_tilelang_enable_sparse_attn",
+        ):
+            from paddlefleet.tilelang_ops import csa_sparse_attn
 
-            output = tilelang_compressed_sparse_attn(
+            output = csa_sparse_attn(
                 query,
                 kv_full,
                 attn_sink.cast("float32"),

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -402,6 +402,51 @@ def _compute_attn_target_on_selected_set(
     return target
 
 
+def _compute_tilelang_csa_indexer_loss_forward(
+    index_q: Tensor,
+    weights: Tensor,
+    index_k_comp: Tensor,
+    query_mla: Tensor,
+    key_comp_mla: Tensor,
+    ratio: int,
+    topk_effective: int,
+    softmax_scale: float,
+    loss_coeff: float,
+    tp_group=None,
+) -> tuple[Tensor, Tensor, Tensor, Tensor]:
+    from paddlefleet.tilelang_ops import (
+        csa_attn_target_reducesum,
+        csa_indexer_topk_fwd,
+    )
+
+    topk_indices, topk_probs = csa_indexer_topk_fwd(
+        index_q,
+        index_k_comp,
+        weights,
+        ratio=int(ratio),
+        topk_effective=int(topk_effective),
+    )
+
+    if tp_group is not None and getattr(tp_group, "nranks", 1) > 1:
+        target = _compute_attn_target_on_selected_set(
+            query_mla, key_comp_mla, topk_indices, softmax_scale, tp_group
+        )
+    else:
+        target = csa_attn_target_reducesum(
+            query_mla,
+            key_comp_mla,
+            topk_indices,
+            softmax_scale,
+        )
+
+    eps = 1e-10
+    kl_per_elem = target * (
+        paddle.log(target + eps) - paddle.log(topk_probs + eps)
+    )
+    loss = kl_per_elem.sum(axis=-1).mean() * float(loss_coeff)
+    return loss, topk_indices, topk_probs, target
+
+
 class TileLangCSAIndexerLoss(paddle.autograd.PyLayer):
     """Selected-topk KL loss using TileLang CSA Indexer fwd/bwd kernels.
 
@@ -460,41 +505,28 @@ class TileLangCSAIndexerLoss(paddle.autograd.PyLayer):
         # PyLayer treats this as a single fused op: forward materializes only
         # the selected ``[B,S,topk_effective]`` tensors and backward never
         # touches the full ``[B,S,S_comp]`` logits.
-        from paddlefleet.tilelang_ops import (
-            csa_attn_target_reducesum,
-            csa_indexer_topk_fwd,
-        )
-
-        topk_indices, topk_probs = csa_indexer_topk_fwd(
-            index_q,
-            index_k_comp,
-            weights,
-            ratio=int(ratio),
-            topk_effective=int(topk_effective),
-        )
-
-        if tp_group is not None and getattr(tp_group, "nranks", 1) > 1:
-            target = _compute_attn_target_on_selected_set(
-                query_mla, key_comp_mla, topk_indices, softmax_scale, tp_group
-            )
-        else:
-            target = csa_attn_target_reducesum(
+        loss, topk_indices, topk_probs, target = (
+            _compute_tilelang_csa_indexer_loss_forward(
+                index_q,
+                weights,
+                index_k_comp,
                 query_mla,
                 key_comp_mla,
-                topk_indices,
+                ratio,
+                topk_effective,
                 softmax_scale,
+                loss_coeff,
+                tp_group,
             )
-
-        # KL(p || q) on selected set; invalid slots have target == 0 so the
-        # ``target * log(target / q)`` term contributes 0 by convention.
-        eps = 1e-10
-        kl_per_elem = target * (
-            paddle.log(target + eps) - paddle.log(topk_probs + eps)
         )
-        loss = kl_per_elem.sum(axis=-1).mean() * float(loss_coeff)
 
         ctx.save_for_backward(
-            index_q, weights, index_k_comp, topk_indices, topk_probs, target
+            index_q.detach(),
+            weights.detach(),
+            index_k_comp.detach(),
+            topk_indices.detach(),
+            topk_probs.detach(),
+            target.detach(),
         )
         ctx.loss_coeff = float(loss_coeff)
         ctx.num_rows = float(target.shape[0] * target.shape[1])
@@ -530,7 +562,98 @@ class TileLangCSAIndexerLoss(paddle.autograd.PyLayer):
             grad_index_scores,
         )
 
-        return grad_q, grad_weights, grad_k, None, None
+        if grad_q.dtype != index_q.dtype:
+            grad_q = grad_q.cast(index_q.dtype)
+        if grad_weights.dtype != weights.dtype:
+            grad_weights = grad_weights.cast(weights.dtype)
+        if grad_k.dtype != index_k_comp.dtype:
+            grad_k = grad_k.cast(index_k_comp.dtype)
+
+        return (
+            grad_q,
+            grad_weights,
+            grad_k,
+            None,
+            None,
+        )
+
+
+class TileLangCSAIndexerLossAutoScaler(paddle.autograd.PyLayer):
+    """Attach TileLang CSA indexer loss gradients to the main output.
+
+    This is the TileLang analogue of ``DSAIndexerLossAutoScaler``. It avoids
+    chaining a scalar-loss PyLayer behind another PyLayer in the full training
+    graph while preserving the same gradient scale semantics.
+    """
+
+    @staticmethod
+    def forward(
+        ctx,
+        output: Tensor,
+        index_q: Tensor,
+        weights: Tensor,
+        index_k_comp: Tensor,
+        topk_indices: Tensor,
+        topk_probs: Tensor,
+        target: Tensor,
+        loss_coeff: float,
+    ) -> Tensor:
+        ctx.save_for_backward(
+            index_q.detach(),
+            weights.detach(),
+            index_k_comp.detach(),
+            topk_indices.detach(),
+            topk_probs.detach(),
+            target.detach(),
+        )
+        ctx.loss_coeff = float(loss_coeff)
+        ctx.num_rows = float(target.shape[0] * target.shape[1])
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output: Tensor):
+        from paddlefleet.tilelang_ops import csa_indexer_bwd
+
+        (
+            index_q,
+            weights,
+            index_k_comp,
+            topk_indices,
+            topk_probs,
+            target,
+        ) = ctx.saved_tensor()
+
+        grad_index_scores = (topk_probs - target) * (
+            ctx.loss_coeff / max(ctx.num_rows, 1.0)
+        )
+        scale = DSAIndexerLossAutoScaler._main_loss_backward_scale
+        if scale is not None:
+            grad_index_scores = grad_index_scores * scale
+
+        grad_q, grad_weights, grad_k = csa_indexer_bwd(
+            index_q,
+            weights,
+            index_k_comp,
+            topk_indices,
+            grad_index_scores,
+        )
+
+        if grad_q.dtype != index_q.dtype:
+            grad_q = grad_q.cast(index_q.dtype)
+        if grad_weights.dtype != weights.dtype:
+            grad_weights = grad_weights.cast(weights.dtype)
+        if grad_k.dtype != index_k_comp.dtype:
+            grad_k = grad_k.cast(index_k_comp.dtype)
+
+        return (
+            grad_output,
+            grad_q,
+            grad_weights,
+            grad_k,
+            None,
+            None,
+            None,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -979,6 +1102,7 @@ class CompressedSparseAttention(FleetLayer):
 
         # Step 4: Compressed indices
         indexer_loss = None
+        tilelang_indexer_loss_state = None
 
         if self.compress_ratio > 1 and n_compressed > 0:
             if self.indexer is not None:
@@ -999,11 +1123,17 @@ class CompressedSparseAttention(FleetLayer):
                     "csa_tilelang_enable_indexer",
                 )
                 # The fused TileLang indexer-loss path is only active during
-                # training when the CSA TileLang indexer path is enabled.
+                # the grad-enabled forward. Full recompute runs the first
+                # forward under no_grad; that pass should only materialize the
+                # indices consumed by main attention.
                 # Otherwise we fall back to:
                 #   * Paddle FusedDSAIndexerLoss during training, or
                 #   * Paddle/TileLang forward-only top-k during inference.
-                use_tilelang_loss_path = use_tilelang_indexer and self.training
+                use_tilelang_loss_path = (
+                    use_tilelang_indexer
+                    and self.training
+                    and paddle.is_grad_enabled()
+                )
                 loss_topk_effective = _resolve_csa_indexer_loss_topk_effective(
                     self.config,
                     self.indexer.index_topk,
@@ -1037,19 +1167,31 @@ class CompressedSparseAttention(FleetLayer):
                     # materializing [B, S_comp, heads, D]. DETACH keeps the
                     # indexer loss disconnected from the main attention graph.
                     key_comp_mla = compressed_kv.detach()
-                    indexer_loss, topk_indices_compressed = (
-                        TileLangCSAIndexerLoss.apply(
-                            q_indexer_bf,
-                            weights_indexer_bf,
-                            k_indexer_bf,
-                            query.detach(),
-                            key_comp_mla,
-                            int(self.compress_ratio),
-                            int(loss_topk_effective),
-                            float(self.softmax_scale),
-                            float(indexer_loss_coeff),
-                            self.tp_group,
-                        )
+                    (
+                        indexer_loss,
+                        topk_indices_compressed,
+                        topk_probs,
+                        target,
+                    ) = _compute_tilelang_csa_indexer_loss_forward(
+                        q_indexer_bf,
+                        weights_indexer_bf,
+                        k_indexer_bf,
+                        query.detach(),
+                        key_comp_mla,
+                        int(self.compress_ratio),
+                        int(loss_topk_effective),
+                        float(self.softmax_scale),
+                        float(indexer_loss_coeff),
+                        self.tp_group,
+                    )
+                    tilelang_indexer_loss_state = (
+                        q_indexer_bf,
+                        weights_indexer_bf,
+                        k_indexer_bf,
+                        topk_indices_compressed,
+                        topk_probs,
+                        target,
+                        float(indexer_loss_coeff),
                     )
                     if indexer_loss_coeff > 0:
                         DSAIndexerLossLoggingHelper.save_loss_to_tracker(
@@ -1057,7 +1199,7 @@ class CompressedSparseAttention(FleetLayer):
                             layer_number=self.layer_number,
                             num_layers=self.config.num_hidden_layers,
                         )
-                elif self.training:
+                elif self.training and not use_tilelang_indexer:
                     q_indexer, k_indexer, weights_indexer = (
                         self.indexer.forward_before_topk(x_det, qr_det)
                     )
@@ -1113,7 +1255,7 @@ class CompressedSparseAttention(FleetLayer):
                             layer_number=self.layer_number,
                             num_layers=self.config.num_hidden_layers,
                         )
-                else:
+                elif not use_tilelang_indexer:
                     _, topk_indices_compressed = self.indexer(
                         x_det,
                         qr_det,
@@ -1186,7 +1328,12 @@ class CompressedSparseAttention(FleetLayer):
         )
 
         # Step 6: Attach indexer loss
-        if indexer_loss is not None and self.training:
+        if tilelang_indexer_loss_state is not None and self.training:
+            output = TileLangCSAIndexerLossAutoScaler.apply(
+                output,
+                *tilelang_indexer_loss_state,
+            )
+        elif indexer_loss is not None and self.training:
             output = DSAIndexerLossAutoScaler.apply(output, indexer_loss)
 
         return output

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -56,61 +56,11 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 
 
-def _get_doc_start(
-    attn_mask_startend_row_indices: Tensor, seqlen: int
-) -> Tensor:
-    """Derive per-position document start from attn_mask_startend_row_indices.
-
-    Pure tensor operations using cummax, no Python for-loop.
-
-    Logic:
-      1. Detect boundary: where the end-boundary value changes → new doc starts
-      2. Mark boundary positions with their index, non-boundary with 0
-      3. cummax along seqlen propagates each boundary's index to all subsequent
-         positions until the next boundary (since boundaries are monotonically increasing)
-
-    Args:
-        attn_mask_startend_row_indices: [b, seqlen] or [seqlen] tensor where each value
-            is the end boundary (exclusive) of the document that position belongs to.
-
-    Returns:
-        doc_start: [b, seqlen] int64 tensor with start position of each token's document.
-    """
-    mask = attn_mask_startend_row_indices
-    squeeze_batch: bool = mask.ndim == 1
-    if squeeze_batch:
-        mask = mask.unsqueeze(0)  # [1, seqlen]
-
-    # Step 1: 检测文本边界 (相邻值不同 → 新文本开始)
-    changed = paddle.zeros_like(mask, dtype="int64")
-    changed[:, 0] = 1
-    changed[:, 1:] = (mask[:, 1:] != mask[:, :-1]).cast("int64")
-
-    # Step 2: 在边界位置标记其索引，非边界标记0
-    positions = (
-        paddle.arange(seqlen, dtype="int64").unsqueeze(0).expand_as(mask)
-    )
-    start_marker = changed * positions
-    # 例: 两个文本(24+8) → start_marker = [0, 0, ..., 0, 24, 0, ..., 0]
-    #                                       ^pos0(边界)     ^pos24(边界)
-    # 注: pos0 的 changed=1, positions=0, 所以 start_marker[0]=0 是正确的
-
-    # Step 3: cummax 沿 seqlen 方向取累积最大值
-    # 由于文本段起始位置单调递增，cummax 的结果就是每个位置的 doc_start
-    # 例: [0,0,...,0,24,0,...,0] → cummax → [0,0,...,0,24,24,...,24]
-    doc_start = paddle.cummax(start_marker, axis=1).values
-
-    if squeeze_batch:
-        doc_start = doc_start.squeeze(0)
-
-    return doc_start
-
-
 @functools.lru_cache(maxsize=8)
-def _get_window_topk_idxs_no_doc(
+def _get_window_topk_idxs_cached(
     window_size: int, seqlen: int, device_str: str
 ) -> Tensor:
-    """Compute sliding window indices without document mask (cached)."""
+    """Compute sliding window indices for a single sequence (cached)."""
     base = paddle.arange(seqlen).unsqueeze(1)  # [seqlen, 1]
     offsets = paddle.arange(window_size)  # [window_size]
     matrix = paddle.clip(base - window_size + 1, min=0) + offsets
@@ -119,10 +69,10 @@ def _get_window_topk_idxs_no_doc(
 
 
 @functools.lru_cache(maxsize=8)
-def _get_compress_topk_idxs_no_doc(
+def _get_compress_topk_idxs_cached(
     ratio: int, seqlen: int, offset: int, device_str: str
 ) -> Tensor:
-    """Compute compress indices without document mask (cached)."""
+    """Compute compressed indices for a single sequence (cached)."""
     n_compressed = seqlen // ratio
     k_indices = paddle.arange(n_compressed)
     matrix = k_indices.unsqueeze(0).expand([seqlen, -1])
@@ -138,48 +88,28 @@ def get_window_topk_idxs(
     window_size: int,
     batch_size: int,
     seqlen: int,
-    attn_mask_startend_row_indices: Tensor,
     device=None,
 ) -> Tensor:
-    """Get sliding window indices: [b, seqlen, window_size].
+    """Get sliding window indices: [b, seqlen, window_size]."""
+    indices = _get_window_topk_idxs_cached(window_size, seqlen, "gpu")
+    return indices.unsqueeze(0).expand([batch_size, -1, -1])
 
-    Args:
-        attn_mask_startend_row_indices: None for single-document (no mask), or
-            a tensor of shape [b, 1, seqlen, 1] or [b, seqlen] with per-position
-            document end boundaries.
-    """
-    if attn_mask_startend_row_indices is None:
-        indices = _get_window_topk_idxs_no_doc(window_size, seqlen, "gpu")
-        return indices.unsqueeze(0).expand([batch_size, -1, -1])
 
-    # Reshape to [b, seqlen]
-    assert (
-        attn_mask_startend_row_indices.shape[1] == 1
-        and attn_mask_startend_row_indices.shape[3] == 1
-    ), (
-        f"attn_mask_startend_row_indices shape must be [b, 1, seqlen, 1] now, but got {attn_mask_startend_row_indices.shape}"
+def _build_compressed_causal_mask(
+    ratio: int,
+    batch_size: int,
+    seqlen: int,
+    n_compressed: int,
+) -> Tensor:
+    compressed_ids = paddle.arange(n_compressed).unsqueeze(0)
+    positions = paddle.arange(1, seqlen + 1).unsqueeze(1)
+    invalid = compressed_ids >= (positions // ratio)
+    invalid = invalid.unsqueeze(0).expand([batch_size, seqlen, n_compressed])
+    return paddle.where(
+        invalid,
+        paddle.full([1], float("-inf"), dtype="float32"),
+        paddle.zeros([1], dtype="float32"),
     )
-    mask = attn_mask_startend_row_indices.reshape([batch_size, seqlen])
-    doc_start = _get_doc_start(mask, seqlen)  # [b, seqlen]
-
-    # Vectorized computation for all batches at once
-    base = paddle.arange(seqlen).unsqueeze(1)  # [seqlen, 1]
-    offsets = paddle.arange(window_size)  # [window_size]
-
-    # doc_start: [b, seqlen] -> [b, seqlen, 1]
-    doc_start_3d = doc_start.unsqueeze(2)  # [b, seqlen, 1]
-    base_3d = base.unsqueeze(0)  # [1, seqlen, 1]
-
-    win_start = paddle.maximum(
-        base_3d - window_size + 1, doc_start_3d
-    )  # [b, seqlen, 1]
-    matrix = win_start + offsets.unsqueeze(0).unsqueeze(
-        0
-    )  # [b, seqlen, window_size]
-    matrix = paddle.where(
-        matrix > base_3d, paddle.full_like(matrix, -1), matrix
-    )
-    return matrix
 
 
 def get_compress_topk_idxs(
@@ -187,49 +117,11 @@ def get_compress_topk_idxs(
     batch_size: int,
     seqlen: int,
     offset: int,
-    attn_mask_startend_row_indices: Tensor,
     device=None,
 ) -> Tensor:
-    """Get compressed indices: [b, seqlen, seqlen // ratio].
-
-    Args:
-        attn_mask_startend_row_indices: None for single-document (no mask), or
-            a tensor of shape [b, 1, seqlen, 1] or [b, seqlen] with per-position
-            document end boundaries.
-    """
-    if attn_mask_startend_row_indices is None:
-        matrix = _get_compress_topk_idxs_no_doc(ratio, seqlen, offset, "gpu")
-        return matrix.unsqueeze(0).expand([batch_size, -1, -1])
-
-    # Reshape to [b, seqlen]
-    mask = attn_mask_startend_row_indices.reshape([batch_size, seqlen])
-    doc_start = _get_doc_start(mask, seqlen)  # [b, seqlen]
-
-    n_compressed = seqlen // ratio
-    k_indices = paddle.arange(n_compressed)  # [n_compressed]
-
-    # Expand: [b, seqlen, n_compressed]
-    matrix = (
-        k_indices.unsqueeze(0).unsqueeze(0).expand([batch_size, seqlen, -1])
-    )  # [b, seqlen, n_compressed]
-
-    # Causal mask: k >= (i+1) // ratio
-    causal_bound = (
-        paddle.arange(1, seqlen + 1).unsqueeze(1) // ratio
-    ).unsqueeze(0)  # [1, seqlen, 1]
-    causal_invalid = matrix >= causal_bound
-
-    # Document boundary mask: k < ceil(doc_start[i] / ratio)
-    doc_start_compressed = ((doc_start + ratio - 1) // ratio).unsqueeze(
-        2
-    )  # [b, seqlen, 1]
-    doc_invalid = matrix < doc_start_compressed
-
-    invalid = causal_invalid | doc_invalid
-    matrix = paddle.where(
-        invalid, paddle.full_like(matrix, -1), matrix + offset
-    )
-    return matrix
+    """Get compressed indices: [b, seqlen, seqlen // ratio]."""
+    matrix = _get_compress_topk_idxs_cached(ratio, seqlen, offset, "gpu")
+    return matrix.unsqueeze(0).expand([batch_size, -1, -1])
 
 
 # ---------------------------------------------------------------------------
@@ -372,7 +264,260 @@ def unfused_compressed_sparse_attn(
     return output
 
 
-from paddlefleet.tilelang_ops import tilelang_compressed_sparse_attn
+def _resolve_csa_indexer_topk_effective(
+    config, index_topk: int, n_compressed: int
+) -> int:
+    """Return the topk_effective fed to the TileLang CSA Indexer kernel.
+
+    Phase semantics (driven by ``dsa_indexer_use_sparse_loss``, **not** by the
+    new TileLang switches):
+
+    * Phase 3 (``dsa_indexer_use_sparse_loss=True``): ``min(index_topk,
+      n_compressed)`` — selected-topk semantics, same as the existing
+      ``FusedDSAIndexerLoss`` / ``CSAIndexer.forward`` choice.
+    * Phase 2 (``dsa_indexer_use_sparse_loss=False``): ``n_compressed`` — the
+      selected set covers the full compressed candidate range and is later
+      consumed as full-range KL by the indexer loss path.
+    """
+    use_sparse_loss = bool(getattr(config, "dsa_indexer_use_sparse_loss", True))
+    if use_sparse_loss:
+        return min(int(index_topk), int(n_compressed))
+    return int(n_compressed)
+
+
+def _map_compressed_topk_to_kv_full(
+    topk_indices_compressed: Tensor,
+    sq: int,
+    ratio: int,
+    offset: int,
+) -> Tensor:
+    """Map compressed block ids to ``kv_full`` indices.
+
+    For each query position ``t``, only ``(t + 1) // ratio`` compressed blocks
+    are causally valid. Slots whose compressed id is out of that range are
+    written back as ``-1``; valid slots are shifted by ``offset`` (which is
+    the original sequence length so that compressed entries follow the raw
+    KV positions inside ``kv_full``).
+    """
+    n_valid_per_pos = (
+        paddle.arange(1, sq + 1, dtype=topk_indices_compressed.dtype).unsqueeze(
+            1
+        )
+        // ratio
+    ).unsqueeze(0)  # [1, sq, 1]
+    valid = (topk_indices_compressed >= 0) & (
+        topk_indices_compressed < n_valid_per_pos
+    )
+    return paddle.where(
+        valid,
+        topk_indices_compressed + offset,
+        paddle.full_like(topk_indices_compressed, -1),
+    )
+
+
+def _compute_attn_target_on_selected_set(
+    query_mla: Tensor,  # [b, sq, np, hn]  DETACHED
+    key_comp_mla: Tensor,  # [b, sk, hn] shared compressed KV, or legacy [b, sk, np, hn]
+    topk_indices: Tensor,  # [b, sq, topk_eff] int32, -1 for invalid slots
+    softmax_scale: float,
+    tp_group=None,
+) -> Tensor:
+    """Construct attention target ``p[t, S_t]`` on the selected compressed set.
+
+    Mathematically equivalent to ``_compute_dsa_indexer_loss`` with
+    ``sparse_loss=True``, but evaluated only on the selected slots ``S_t``
+    given by ``topk_indices`` instead of materializing the full ``[B,Sq,Sk]``
+    distribution. Invalid (``-1``) slots are masked out before softmax and
+    receive zero target probability after L1 normalization.
+
+    The result has shape ``[b, sq, topk_eff]`` in fp32 and is the multi-head
+    aggregated, L1 normalized target distribution used as the second argument
+    of ``KL(target || index_prob)``.
+    """
+    b, sq, np, hn = query_mla.shape
+    topk_eff = topk_indices.shape[-1]
+
+    # Per-head full attention scores [b, np, sq, sk]. DSv4 compressed KV is
+    # shared across query heads as [b, sk, hn]; the legacy per-head-expanded
+    # [b, sk, np, hn] shape is still accepted for non-TileLang references.
+    q = query_mla.transpose([0, 2, 1, 3]).cast("float32")  # [b, np, sq, hn]
+    if len(key_comp_mla.shape) == 3:
+        k = key_comp_mla.transpose([0, 2, 1]).cast("float32").unsqueeze(1)
+    else:
+        k = key_comp_mla.transpose([0, 2, 3, 1]).cast("float32")
+    attn_scores = paddle.matmul(q, k) * float(softmax_scale)  # [b, np, sq, sk]
+
+    # Replace -1 with 0 for safe gather; then mask back to -inf afterwards.
+    valid = topk_indices >= 0  # [b, sq, topk_eff]
+    safe_indices = paddle.where(
+        valid, topk_indices, paddle.zeros_like(topk_indices)
+    ).cast("int64")
+    safe_indices_exp = safe_indices.unsqueeze(1).expand([b, np, sq, topk_eff])
+    selected_logits = paddle.take_along_axis(
+        attn_scores, safe_indices_exp, axis=-1
+    )  # [b, np, sq, topk_eff]
+
+    # Mask invalid slots so softmax assigns them zero probability.
+    valid_bn = valid.unsqueeze(1)  # [b, 1, sq, topk_eff]
+    neg_inf = paddle.full([1], float("-inf"), dtype="float32")
+    selected_logits = paddle.where(valid_bn, selected_logits, neg_inf)
+
+    # Avoid all-(-inf) rows producing NaN in softmax: zero such rows out.
+    row_valid = valid.any(axis=-1, keepdim=True)  # [b, sq, 1]
+    row_valid_bn = row_valid.unsqueeze(1)  # [b, 1, sq, 1]
+    selected_logits = paddle.where(
+        row_valid_bn, selected_logits, paddle.zeros_like(selected_logits)
+    )
+
+    probs = F.softmax(selected_logits, axis=-1, dtype="float32")
+    # Re-zero fully invalid rows post-softmax (softmax of zeros is uniform).
+    probs = probs * row_valid_bn.cast("float32")
+
+    # Aggregate over heads, optional TP all-reduce, then L1 normalize.
+    target = probs.sum(axis=1)  # [b, sq, topk_eff]
+    if tp_group is not None and getattr(tp_group, "nranks", 1) > 1:
+        paddle.distributed.all_reduce(target.contiguous(), group=tp_group)
+    target = target / target.sum(axis=-1, keepdim=True).clip(min=1e-10)
+
+    # Zero out invalid slots (so they contribute nothing to KL).
+    target = paddle.where(valid, target, paddle.zeros_like(target))
+    return target
+
+
+class TileLangCSAIndexerLoss(paddle.autograd.PyLayer):
+    """Selected-topk KL loss using TileLang CSA Indexer fwd/bwd kernels.
+
+    Forward:
+        1. Calls TileLang fused indexer to obtain
+           ``topk_indices [B, S, topk_effective]`` and post-softmax
+           ``topk_probs [B, S, topk_effective]`` over the selected set.
+        2. Constructs the multi-head aggregated attention target
+           ``p[t, S_t]`` on the same selected set via
+           ``_compute_attn_target_on_selected_set``.
+        3. Returns the scalar KL loss
+           ``KL(p[t,S_t] || softmax(I[t,S_t])) * loss_coeff``.
+
+        ``topk_indices`` is returned alongside the scalar loss so the outer
+        ``CompressedSparseAttention.forward`` can feed it to sparse attention.
+
+    Backward:
+        Following the Megatron / Miles selected-topk convention, the gradient
+        of KL w.r.t. the post-softmax indexer probabilities at the selected
+        slots is ``q - p`` (the fused softmax+KL identity). The kernel then
+        backprops only through the ReLU + per-head weighting + scaled QK GEMM.
+
+        ``grad_index_scores = (topk_probs - target) * loss_coeff / num_rows``
+        is multiplied by the upstream ``grad_loss`` and forwarded to
+        ``csa_indexer_bwd``.
+
+    Phase semantics:
+        * Phase 2 (``dsa_indexer_use_sparse_loss=False``): caller passes
+          ``topk_effective=n_compressed`` so the selected set covers the full
+          causal compressed range — equivalent to the Paddle full-range KL.
+        * Phase 3 (``dsa_indexer_use_sparse_loss=True``): caller passes
+          ``topk_effective=min(index_topk, n_compressed)`` for the standard
+          selected-topk KL semantics.
+
+    Phase 1 (``csa_dense_mode=True``) never reaches this PyLayer because
+    ``self.indexer`` is ``None`` in that configuration.
+    """
+
+    @staticmethod
+    def forward(
+        ctx,
+        index_q: Tensor,  # [b, sq, h_i, d_i]
+        weights: Tensor,  # [b, sq, h_i]   (RAW weights, no softmax_scale baked in)
+        index_k_comp: Tensor,  # [b, sk, d_i]
+        query_mla: Tensor,  # [b, sq, np, hn]      DETACHED MLA query
+        key_comp_mla: Tensor,  # [b, sk, hn]           DETACHED shared compressed KV
+        ratio: int,
+        topk_effective: int,
+        softmax_scale: float,
+        loss_coeff: float,
+        tp_group=None,
+    ) -> Tensor:
+        # The TileLang kernel applies its own ``dim**-0.5`` scale on index_q
+        # and consumes raw weights, so we pass them through unmodified. The
+        # PyLayer treats this as a single fused op: forward materializes only
+        # the selected ``[B,S,topk_effective]`` tensors and backward never
+        # touches the full ``[B,S,S_comp]`` logits.
+        from paddlefleet.tilelang_ops import (
+            csa_attn_target_reducesum,
+            csa_indexer_topk_fwd,
+        )
+
+        topk_indices, topk_probs = csa_indexer_topk_fwd(
+            index_q,
+            index_k_comp,
+            weights,
+            ratio=int(ratio),
+            topk_effective=int(topk_effective),
+        )
+
+        if tp_group is not None and getattr(tp_group, "nranks", 1) > 1:
+            target = _compute_attn_target_on_selected_set(
+                query_mla, key_comp_mla, topk_indices, softmax_scale, tp_group
+            )
+        else:
+            target = csa_attn_target_reducesum(
+                query_mla,
+                key_comp_mla,
+                topk_indices,
+                softmax_scale,
+            )
+
+        # KL(p || q) on selected set; invalid slots have target == 0 so the
+        # ``target * log(target / q)`` term contributes 0 by convention.
+        eps = 1e-10
+        kl_per_elem = target * (
+            paddle.log(target + eps) - paddle.log(topk_probs + eps)
+        )
+        loss = kl_per_elem.sum(axis=-1).mean() * float(loss_coeff)
+
+        ctx.save_for_backward(
+            index_q, weights, index_k_comp, topk_indices, topk_probs, target
+        )
+        ctx.loss_coeff = float(loss_coeff)
+        ctx.num_rows = float(target.shape[0] * target.shape[1])
+        return loss, topk_indices.detach()
+
+    @staticmethod
+    def backward(ctx, grad_loss: Tensor, grad_topk_indices: Tensor = None):
+        from paddlefleet.tilelang_ops import (
+            csa_indexer_bwd,
+        )
+
+        (
+            index_q,
+            weights,
+            index_k_comp,
+            topk_indices,
+            topk_probs,
+            target,
+        ) = ctx.saved_tensor()
+
+        # Match the forward KL smoothing exactly:
+        # loss = target * (log(target + eps) - log(prob + eps)).
+        # First differentiate w.r.t. probabilities, then apply the softmax
+        # Jacobian for the selected logits.
+        eps = 1e-10
+        scale = ctx.loss_coeff / max(ctx.num_rows, 1.0)
+        grad_probs = -target / (topk_probs + eps) * scale
+        sum_grad = (grad_probs * topk_probs).sum(axis=-1, keepdim=True)
+        grad_index_scores = topk_probs * (grad_probs - sum_grad)
+        if grad_loss is not None:
+            grad_index_scores = grad_index_scores * grad_loss
+
+        grad_q, grad_weights, grad_k = csa_indexer_bwd(
+            index_q,
+            weights,
+            index_k_comp,
+            topk_indices,
+            grad_index_scores,
+        )
+
+        return grad_q, grad_weights, grad_k, None, None
+
 
 # ---------------------------------------------------------------------------
 # Compressor
@@ -480,7 +625,10 @@ class Compressor(nn.Layer):
         new_tensor[:, 1:, :ratio, :] = tensor[:, :-1, :, :d]
         return new_tensor
 
-    def forward(self, x: Tensor) -> Tensor | None:
+    def forward(
+        self,
+        x: Tensor,
+    ) -> Tensor | None:
         """Compress hidden states into shorter KV sequence.
 
         Args:
@@ -725,6 +873,14 @@ class CompressedSparseAttention(FleetLayer):
         super().__init__(config)
         self.config = config
         self.layer_number = layer_number
+        self.pg_collection = pg_collection
+        self.tp_group = (
+            pg_collection.tp
+            if pg_collection is not None
+            and pg_collection.tp is not None
+            and getattr(pg_collection.tp, "nranks", 1) > 1
+            else None
+        )
         self.compress_ratio = compress_ratio
         self.window_size = config.csa_window_size
         self.v_head_dim = config.v_head_dim
@@ -770,7 +926,6 @@ class CompressedSparseAttention(FleetLayer):
         attention_mask: Tensor | None,
         x: Tensor = None,
         qr: Tensor = None,
-        attn_mask_startend_row_indices: Tensor = None,
     ) -> Tensor:
         """Forward pass for CompressedSparseAttention.
 
@@ -806,9 +961,7 @@ class CompressedSparseAttention(FleetLayer):
         offset = sq  # compressed indices start after original positions
 
         # Step 3: Window indices
-        window_idxs = get_window_topk_idxs(
-            self.window_size, b, sq, attn_mask_startend_row_indices
-        )
+        window_idxs = get_window_topk_idxs(self.window_size, b, sq)
 
         # Step 4: Compressed indices
         indexer_loss = None
@@ -821,21 +974,93 @@ class CompressedSparseAttention(FleetLayer):
                     x_det.stop_gradient = False
                     qr_det.stop_gradient = False
 
-                # Build causal mask for compressed positions: [b, sq, n_compressed]
-                compressed_ids = paddle.arange(n_compressed).unsqueeze(
-                    0
-                )  # [1, n_compressed]
-                positions = paddle.arange(1, sq + 1).unsqueeze(1)  # [sq, 1]
-                causal_mask = paddle.where(
-                    compressed_ids >= (positions // self.compress_ratio),
-                    paddle.full([1], float("-inf"), dtype="float32"),
-                    paddle.zeros([1], dtype="float32"),
-                )  # [sq, n_compressed]
-                causal_mask = causal_mask.unsqueeze(0).expand(
-                    [b, sq, n_compressed]
-                )  # [b, sq, n_compressed]
+                # Resolve TileLang backend and per-phase topk_effective.
+                # Phase 2 (dsa_indexer_use_sparse_loss=False) uses
+                # topk_effective=n_compressed so that the selected set covers
+                # the full compressed candidate range; Phase 3
+                # (dsa_indexer_use_sparse_loss=True) uses
+                # topk_effective=min(index_topk, n_compressed) and keeps the
+                # existing selected-topk semantics. The TileLang backend only
+                # gates which kernel produces the indices, it does not change
+                # phase semantics (csa_dense_mode / dsa_indexer_use_sparse_loss
+                # / dsa_indexer_loss_coeff still own that).
+                use_tilelang_indexer = (
+                    getattr(self.config, "dsv4_tilelang_backend", None)
+                    == "attention_paddle_compat"
+                    and getattr(
+                        self.config,
+                        "dsv4_tilelang_enable_csa_indexer",
+                        None,
+                    )
+                    is not False
+                )
+                enable_tilelang_bwd = bool(
+                    getattr(self.config, "dsv4_tilelang_enable_backward", False)
+                )
+                # The fused TileLang indexer-loss path is only active during
+                # training and only when backend/indexer and backward are enabled.
+                # Otherwise we fall back to:
+                #   * TileLang forward-only override (no_grad TileLang fwd +
+                #     Paddle FusedDSAIndexerLoss backward), or
+                #   * Pure Paddle reference.
+                use_tilelang_loss_path = (
+                    use_tilelang_indexer
+                    and enable_tilelang_bwd
+                    and self.training
+                )
+                topk_effective = _resolve_csa_indexer_topk_effective(
+                    self.config,
+                    self.indexer.index_topk,
+                    n_compressed,
+                )
 
-                if self.training:
+                causal_mask = _build_compressed_causal_mask(
+                    self.compress_ratio,
+                    b,
+                    sq,
+                    n_compressed,
+                )
+
+                if use_tilelang_loss_path:
+                    # Fused TileLang fwd + selected-set KL + TileLang bwd in
+                    # one PyLayer. This replaces both the Paddle
+                    # FusedDSAIndexerLoss call AND the TileLang forward-only
+                    # no_grad override below, because the PyLayer already
+                    # returns TileLang indices for sparse attention to consume,
+                    # and its backward pipes ``q - p`` through the TileLang
+                    # indexer bwd kernel.
+                    indexer_loss_coeff = getattr(
+                        self.config, "dsa_indexer_loss_coeff", 0.0
+                    )
+                    q_indexer_bf, k_indexer_bf, weights_indexer_bf = (
+                        self.indexer.forward_before_topk(x_det, qr_det)
+                    )
+                    # compressed_kv is shared across query heads; pass it
+                    # directly to the target/reducesum path instead of
+                    # materializing [B, S_comp, heads, D]. DETACH keeps the
+                    # indexer loss disconnected from the main attention graph.
+                    key_comp_mla = compressed_kv.detach()
+                    indexer_loss, topk_indices_compressed = (
+                        TileLangCSAIndexerLoss.apply(
+                            q_indexer_bf,
+                            weights_indexer_bf,
+                            k_indexer_bf,
+                            query.detach(),
+                            key_comp_mla,
+                            int(self.compress_ratio),
+                            int(topk_effective),
+                            float(self.softmax_scale),
+                            float(indexer_loss_coeff),
+                            self.tp_group,
+                        )
+                    )
+                    if indexer_loss_coeff > 0:
+                        DSAIndexerLossLoggingHelper.save_loss_to_tracker(
+                            loss=indexer_loss,
+                            layer_number=self.layer_number,
+                            num_layers=self.config.num_hidden_layers,
+                        )
+                elif self.training:
                     q_indexer, k_indexer, weights_indexer = (
                         self.indexer.forward_before_topk(x_det, qr_det)
                     )
@@ -879,7 +1104,7 @@ class CompressedSparseAttention(FleetLayer):
                         getattr(
                             self.config, "dsa_indexer_use_sparse_loss", True
                         ),
-                        None,  # tp_group
+                        self.tp_group,
                     )
                     topk_indices_compressed = (
                         FusedDSAIndexerLoss._last_topk_indices
@@ -893,19 +1118,42 @@ class CompressedSparseAttention(FleetLayer):
                         )
                 else:
                     _, topk_indices_compressed = self.indexer(
-                        x_det, qr_det, mask=causal_mask
+                        x_det,
+                        qr_det,
+                        mask=causal_mask,
                     )
 
+                # Optionally replace topk producer with TileLang fused
+                # compressed indexer forward. The indexer loss path is left
+                # untouched here; this only swaps the indices fed to sparse
+                # attention. Runs under no_grad so it never enters the
+                # autograd graph. Skipped when the fused TileLang loss path
+                # already produced TileLang indices (use_tilelang_loss_path).
+                if use_tilelang_indexer and not use_tilelang_loss_path:
+                    from paddlefleet.tilelang_ops import (
+                        csa_indexer_topk_fwd,
+                    )
+
+                    with paddle.no_grad():
+                        q_indexer_tl, k_indexer_tl, weights_indexer_tl = (
+                            self.indexer.forward_before_topk(x_det, qr_det)
+                        )
+                        tl_topk_indices, _tl_topk_scores = csa_indexer_topk_fwd(
+                            q_indexer_tl,
+                            k_indexer_tl,
+                            weights_indexer_tl,
+                            ratio=self.compress_ratio,
+                            topk_effective=topk_effective,
+                        )
+
+                    topk_indices_compressed = tl_topk_indices
+
                 # Filter invalid indices and shift to kv_full space
-                n_valid_per_pos = (
-                    paddle.arange(1, sq + 1).unsqueeze(1) // self.compress_ratio
-                )  # [sq, 1]
-                n_valid_per_pos = n_valid_per_pos.unsqueeze(0)  # [1, sq, 1]
-                valid = topk_indices_compressed < n_valid_per_pos
-                compress_topk_idxs = paddle.where(
-                    valid,
-                    topk_indices_compressed + offset,
-                    paddle.full_like(topk_indices_compressed, -1),
+                compress_topk_idxs = _map_compressed_topk_to_kv_full(
+                    topk_indices_compressed,
+                    sq,
+                    self.compress_ratio,
+                    offset,
                 )
             else:
                 # ratio=128: attend to all compressed positions
@@ -914,9 +1162,10 @@ class CompressedSparseAttention(FleetLayer):
                     b,
                     sq,
                     offset,
-                    attn_mask_startend_row_indices,
                 )
 
+            if compress_topk_idxs.dtype != window_idxs.dtype:
+                compress_topk_idxs = compress_topk_idxs.cast(window_idxs.dtype)
             topk_idxs = paddle.concat(
                 [window_idxs, compress_topk_idxs], axis=-1
             )
@@ -949,6 +1198,8 @@ class CompressedSparseAttention(FleetLayer):
         softmax_scale: float,
     ):
         if self.config.csa_sparse_attn_fusion:
+            from paddlefleet.tilelang_ops import tilelang_compressed_sparse_attn
+
             output = tilelang_compressed_sparse_attn(
                 query,
                 kv_full,

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -1055,6 +1055,190 @@ class CompressedSparseAttention(FleetLayer):
         else:
             self.indexer = None
 
+    def _compute_indexer_compressed_topk_idxs(
+        self,
+        query: Tensor,
+        x: Tensor,
+        qr: Tensor,
+        compressed_kv: Tensor,
+        n_compressed: int,
+        offset: int,
+    ) -> tuple[Tensor, Tensor | None, tuple | None]:
+        """Build indexer-selected compressed KV indices and loss state."""
+        b, sq, np_heads, _ = query.shape
+        indexer_loss = None
+        tilelang_indexer_loss_state = None
+
+        x_det = x.detach()
+        qr_det = qr.detach()
+        if self.training:
+            x_det.stop_gradient = False
+            qr_det.stop_gradient = False
+
+        # Loss and main attention intentionally use different top-k widths
+        # during phase 2. ``dsa_indexer_use_sparse_loss=False`` expands only
+        # the indexer loss to the full compressed range; the main CSA attention
+        # remains sparse and consumes ``min(index_topk, n_compressed)``.
+        use_tilelang_indexer = _resolve_csa_tilelang_switch(
+            self.config,
+            "csa_tilelang_enable_indexer",
+        )
+        # The fused TileLang indexer-loss path is only active during the
+        # grad-enabled forward. Full recompute runs the first forward under
+        # no_grad; that pass should only materialize main-attention indices.
+        use_tilelang_loss_path = (
+            use_tilelang_indexer and self.training and paddle.is_grad_enabled()
+        )
+        loss_topk_effective = _resolve_csa_indexer_loss_topk_effective(
+            self.config,
+            self.indexer.index_topk,
+            n_compressed,
+        )
+        attn_topk_effective = _resolve_csa_indexer_attn_topk_effective(
+            self.indexer.index_topk,
+            n_compressed,
+        )
+
+        causal_mask = _build_compressed_causal_mask(
+            self.compress_ratio,
+            b,
+            sq,
+            n_compressed,
+        )
+
+        if use_tilelang_loss_path:
+            # Fused TileLang fwd + selected-set KL + TileLang bwd. The returned
+            # indices may be wider than main attention top-k during phase 2 and
+            # are trimmed below before sparse attention consumes them.
+            indexer_loss_coeff = getattr(
+                self.config, "dsa_indexer_loss_coeff", 0.0
+            )
+            q_indexer_bf, k_indexer_bf, weights_indexer_bf = (
+                self.indexer.forward_before_topk(x_det, qr_det)
+            )
+            # compressed_kv is shared across query heads; pass it directly to
+            # the target/reducesum path instead of materializing [B,S,H,D].
+            key_comp_mla = compressed_kv.detach()
+            (
+                indexer_loss,
+                topk_indices_compressed,
+                topk_probs,
+                target,
+            ) = _compute_tilelang_csa_indexer_loss_forward(
+                q_indexer_bf,
+                weights_indexer_bf,
+                k_indexer_bf,
+                query.detach(),
+                key_comp_mla,
+                int(self.compress_ratio),
+                int(loss_topk_effective),
+                float(self.softmax_scale),
+                float(indexer_loss_coeff),
+                self.tp_group,
+            )
+            tilelang_indexer_loss_state = (
+                q_indexer_bf,
+                weights_indexer_bf,
+                k_indexer_bf,
+                topk_indices_compressed,
+                topk_probs,
+                target,
+                float(indexer_loss_coeff),
+            )
+            if indexer_loss_coeff > 0:
+                DSAIndexerLossLoggingHelper.save_loss_to_tracker(
+                    loss=indexer_loss,
+                    layer_number=self.layer_number,
+                    num_layers=self.config.num_hidden_layers,
+                )
+        elif self.training and not use_tilelang_indexer:
+            q_indexer, k_indexer, weights_indexer = (
+                self.indexer.forward_before_topk(x_det, qr_det)
+            )
+            indexer_loss_coeff = getattr(
+                self.config, "dsa_indexer_loss_coeff", 0.0
+            )
+            key_for_loss = (
+                compressed_kv.transpose([1, 0, 2])
+                .unsqueeze(2)
+                .expand([-1, -1, np_heads, -1])
+            )
+
+            q_sf = q_indexer.transpose([1, 0, 2, 3])
+            k_sf = (
+                k_indexer.transpose([1, 0, 2])
+                if k_indexer.ndim == 3
+                else k_indexer.transpose([1, 0, 2, 3])
+            )
+            weights_sf = (
+                weights_indexer * self.indexer.softmax_scale
+            ).transpose([1, 0, 2])
+            query_sf = query.transpose([1, 0, 2, 3]).detach()
+            mask_for_loss = causal_mask.unsqueeze(1)
+
+            indexer_loss = FusedDSAIndexerLoss.apply(
+                q_sf,
+                weights_sf,
+                k_sf,
+                query_sf,
+                key_for_loss.detach(),
+                self.softmax_scale,
+                min(self.indexer.index_topk, n_compressed),
+                indexer_loss_coeff,
+                mask_for_loss,
+                getattr(self.config, "dsa_indexer_use_sparse_loss", True),
+                self.tp_group,
+            )
+            topk_indices_compressed = FusedDSAIndexerLoss._last_topk_indices
+
+            if indexer_loss_coeff > 0:
+                DSAIndexerLossLoggingHelper.save_loss_to_tracker(
+                    loss=indexer_loss,
+                    layer_number=self.layer_number,
+                    num_layers=self.config.num_hidden_layers,
+                )
+        elif not use_tilelang_indexer:
+            _, topk_indices_compressed = self.indexer(
+                x_det,
+                qr_det,
+                mask=causal_mask,
+            )
+
+        # Optionally replace topk producer with TileLang fused compressed
+        # indexer forward. This only swaps the indices fed to sparse attention.
+        if use_tilelang_indexer and not use_tilelang_loss_path:
+            from paddlefleet.tilelang_ops import (
+                csa_indexer_topk_fwd,
+            )
+
+            with paddle.no_grad():
+                q_indexer_tl, k_indexer_tl, weights_indexer_tl = (
+                    self.indexer.forward_before_topk(x_det, qr_det)
+                )
+                tl_topk_indices, _tl_topk_scores = csa_indexer_topk_fwd(
+                    q_indexer_tl,
+                    k_indexer_tl,
+                    weights_indexer_tl,
+                    ratio=self.compress_ratio,
+                    topk_effective=attn_topk_effective,
+                )
+
+            topk_indices_compressed = tl_topk_indices
+
+        if topk_indices_compressed.shape[-1] > attn_topk_effective:
+            topk_indices_compressed = topk_indices_compressed[
+                ..., :attn_topk_effective
+            ].contiguous()
+
+        compress_topk_idxs = _map_compressed_topk_to_kv_full(
+            topk_indices_compressed,
+            sq,
+            self.compress_ratio,
+            offset,
+        )
+
+        return compress_topk_idxs, indexer_loss, tilelang_indexer_loss_state
+
     def forward(
         self,
         query: Tensor,
@@ -1106,197 +1290,16 @@ class CompressedSparseAttention(FleetLayer):
 
         if self.compress_ratio > 1 and n_compressed > 0:
             if self.indexer is not None:
-                x_det = x.detach()
-                qr_det = qr.detach()
-                if self.training:
-                    x_det.stop_gradient = False
-                    qr_det.stop_gradient = False
-
-                # Loss and main attention intentionally use different top-k
-                # widths during phase 2. ``dsa_indexer_use_sparse_loss=False``
-                # expands only the indexer loss to the full compressed range;
-                # the main CSA attention remains sparse and consumes
-                # ``min(index_topk, n_compressed)`` compressed blocks, matching
-                # the Paddle FusedDSAIndexerLoss path.
-                use_tilelang_indexer = _resolve_csa_tilelang_switch(
-                    self.config,
-                    "csa_tilelang_enable_indexer",
-                )
-                # The fused TileLang indexer-loss path is only active during
-                # the grad-enabled forward. Full recompute runs the first
-                # forward under no_grad; that pass should only materialize the
-                # indices consumed by main attention.
-                # Otherwise we fall back to:
-                #   * Paddle FusedDSAIndexerLoss during training, or
-                #   * Paddle/TileLang forward-only top-k during inference.
-                use_tilelang_loss_path = (
-                    use_tilelang_indexer
-                    and self.training
-                    and paddle.is_grad_enabled()
-                )
-                loss_topk_effective = _resolve_csa_indexer_loss_topk_effective(
-                    self.config,
-                    self.indexer.index_topk,
+                (
+                    compress_topk_idxs,
+                    indexer_loss,
+                    tilelang_indexer_loss_state,
+                ) = self._compute_indexer_compressed_topk_idxs(
+                    query,
+                    x,
+                    qr,
+                    compressed_kv,
                     n_compressed,
-                )
-                attn_topk_effective = _resolve_csa_indexer_attn_topk_effective(
-                    self.indexer.index_topk,
-                    n_compressed,
-                )
-
-                causal_mask = _build_compressed_causal_mask(
-                    self.compress_ratio,
-                    b,
-                    sq,
-                    n_compressed,
-                )
-
-                if use_tilelang_loss_path:
-                    # Fused TileLang fwd + selected-set KL + TileLang bwd in
-                    # one PyLayer. The returned indices may be wider than the
-                    # main attention top-k during phase 2 and are trimmed below
-                    # before sparse attention consumes them.
-                    indexer_loss_coeff = getattr(
-                        self.config, "dsa_indexer_loss_coeff", 0.0
-                    )
-                    q_indexer_bf, k_indexer_bf, weights_indexer_bf = (
-                        self.indexer.forward_before_topk(x_det, qr_det)
-                    )
-                    # compressed_kv is shared across query heads; pass it
-                    # directly to the target/reducesum path instead of
-                    # materializing [B, S_comp, heads, D]. DETACH keeps the
-                    # indexer loss disconnected from the main attention graph.
-                    key_comp_mla = compressed_kv.detach()
-                    (
-                        indexer_loss,
-                        topk_indices_compressed,
-                        topk_probs,
-                        target,
-                    ) = _compute_tilelang_csa_indexer_loss_forward(
-                        q_indexer_bf,
-                        weights_indexer_bf,
-                        k_indexer_bf,
-                        query.detach(),
-                        key_comp_mla,
-                        int(self.compress_ratio),
-                        int(loss_topk_effective),
-                        float(self.softmax_scale),
-                        float(indexer_loss_coeff),
-                        self.tp_group,
-                    )
-                    tilelang_indexer_loss_state = (
-                        q_indexer_bf,
-                        weights_indexer_bf,
-                        k_indexer_bf,
-                        topk_indices_compressed,
-                        topk_probs,
-                        target,
-                        float(indexer_loss_coeff),
-                    )
-                    if indexer_loss_coeff > 0:
-                        DSAIndexerLossLoggingHelper.save_loss_to_tracker(
-                            loss=indexer_loss,
-                            layer_number=self.layer_number,
-                            num_layers=self.config.num_hidden_layers,
-                        )
-                elif self.training and not use_tilelang_indexer:
-                    q_indexer, k_indexer, weights_indexer = (
-                        self.indexer.forward_before_topk(x_det, qr_det)
-                    )
-                    indexer_loss_coeff = getattr(
-                        self.config, "dsa_indexer_loss_coeff", 0.0
-                    )
-                    # compressed_kv: [b, n, hn] -> expand for loss: [n, b, np, hn]
-                    key_for_loss = (
-                        compressed_kv.transpose([1, 0, 2])
-                        .unsqueeze(2)
-                        .expand([-1, -1, np_heads, -1])
-                    )
-
-                    # Convert batch-first to seq-first for FusedDSAIndexerLoss
-                    q_sf = q_indexer.transpose([1, 0, 2, 3])  # [sq, b, h, d]
-                    k_sf = (
-                        k_indexer.transpose([1, 0, 2])
-                        if k_indexer.ndim == 3
-                        else k_indexer.transpose([1, 0, 2, 3])
-                    )  # [n_compressed, b, d]
-                    weights_sf = (
-                        weights_indexer * self.indexer.softmax_scale
-                    ).transpose([1, 0, 2])  # [sq, b, h]
-                    query_sf = query.transpose(
-                        [1, 0, 2, 3]
-                    ).detach()  # [sq, b, np, hn]
-
-                    # causal_mask for FusedDSAIndexerLoss: [b, 1, sq, n_compressed]
-                    mask_for_loss = causal_mask.unsqueeze(1)
-
-                    indexer_loss = FusedDSAIndexerLoss.apply(
-                        q_sf,
-                        weights_sf,
-                        k_sf,
-                        query_sf,
-                        key_for_loss.detach(),
-                        self.softmax_scale,
-                        min(self.indexer.index_topk, n_compressed),
-                        indexer_loss_coeff,
-                        mask_for_loss,
-                        getattr(
-                            self.config, "dsa_indexer_use_sparse_loss", True
-                        ),
-                        self.tp_group,
-                    )
-                    topk_indices_compressed = (
-                        FusedDSAIndexerLoss._last_topk_indices
-                    )
-
-                    if indexer_loss_coeff > 0:
-                        DSAIndexerLossLoggingHelper.save_loss_to_tracker(
-                            loss=indexer_loss,
-                            layer_number=self.layer_number,
-                            num_layers=self.config.num_hidden_layers,
-                        )
-                elif not use_tilelang_indexer:
-                    _, topk_indices_compressed = self.indexer(
-                        x_det,
-                        qr_det,
-                        mask=causal_mask,
-                    )
-
-                # Optionally replace topk producer with TileLang fused
-                # compressed indexer forward. The indexer loss path is left
-                # untouched here; this only swaps the indices fed to sparse
-                # attention. Runs under no_grad so it never enters the
-                # autograd graph. Skipped when the fused TileLang loss path
-                # already produced TileLang indices (use_tilelang_loss_path).
-                if use_tilelang_indexer and not use_tilelang_loss_path:
-                    from paddlefleet.tilelang_ops import (
-                        csa_indexer_topk_fwd,
-                    )
-
-                    with paddle.no_grad():
-                        q_indexer_tl, k_indexer_tl, weights_indexer_tl = (
-                            self.indexer.forward_before_topk(x_det, qr_det)
-                        )
-                        tl_topk_indices, _tl_topk_scores = csa_indexer_topk_fwd(
-                            q_indexer_tl,
-                            k_indexer_tl,
-                            weights_indexer_tl,
-                            ratio=self.compress_ratio,
-                            topk_effective=attn_topk_effective,
-                        )
-
-                    topk_indices_compressed = tl_topk_indices
-
-                if topk_indices_compressed.shape[-1] > attn_topk_effective:
-                    topk_indices_compressed = topk_indices_compressed[
-                        ..., :attn_topk_effective
-                    ].contiguous()
-
-                # Filter invalid indices and shift to kv_full space
-                compress_topk_idxs = _map_compressed_topk_to_kv_full(
-                    topk_indices_compressed,
-                    sq,
-                    self.compress_ratio,
                     offset,
                 )
             else:

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -264,10 +264,10 @@ def unfused_compressed_sparse_attn(
     return output
 
 
-def _resolve_csa_indexer_topk_effective(
+def _resolve_csa_indexer_loss_topk_effective(
     config, index_topk: int, n_compressed: int
 ) -> int:
-    """Return the topk_effective fed to the TileLang CSA Indexer kernel.
+    """Return the TileLang CSA indexer top-k width used by indexer loss.
 
     Phase semantics (driven by ``dsa_indexer_use_sparse_loss``, **not** by the
     new TileLang switches):
@@ -283,6 +283,13 @@ def _resolve_csa_indexer_topk_effective(
     if use_sparse_loss:
         return min(int(index_topk), int(n_compressed))
     return int(n_compressed)
+
+
+def _resolve_csa_indexer_attn_topk_effective(
+    index_topk: int, n_compressed: int
+) -> int:
+    """Return the compressed top-k width consumed by main CSA attention."""
+    return min(int(index_topk), int(n_compressed))
 
 
 def _resolve_csa_tilelang_switch(config, field_name: str) -> bool:
@@ -408,8 +415,9 @@ class TileLangCSAIndexerLoss(paddle.autograd.PyLayer):
         3. Returns the scalar KL loss
            ``KL(p[t,S_t] || softmax(I[t,S_t])) * loss_coeff``.
 
-        ``topk_indices`` is returned alongside the scalar loss so the outer
-        ``CompressedSparseAttention.forward`` can feed it to sparse attention.
+        ``topk_indices`` is returned alongside the scalar loss. The outer
+        ``CompressedSparseAttention.forward`` may trim it back to the main
+        attention top-k width before feeding sparse attention.
 
     Backward:
         Following the Megatron / Miles selected-topk convention, the gradient
@@ -985,16 +993,12 @@ class CompressedSparseAttention(FleetLayer):
                     x_det.stop_gradient = False
                     qr_det.stop_gradient = False
 
-                # Resolve TileLang backend and per-phase topk_effective.
-                # Phase 2 (dsa_indexer_use_sparse_loss=False) uses
-                # topk_effective=n_compressed so that the selected set covers
-                # the full compressed candidate range; Phase 3
-                # (dsa_indexer_use_sparse_loss=True) uses
-                # topk_effective=min(index_topk, n_compressed) and keeps the
-                # existing selected-topk semantics. The TileLang backend only
-                # gates which kernel produces the indices, it does not change
-                # phase semantics (csa_dense_mode / dsa_indexer_use_sparse_loss
-                # / dsa_indexer_loss_coeff still own that).
+                # Loss and main attention intentionally use different top-k
+                # widths during phase 2. ``dsa_indexer_use_sparse_loss=False``
+                # expands only the indexer loss to the full compressed range;
+                # the main CSA attention remains sparse and consumes
+                # ``min(index_topk, n_compressed)`` compressed blocks, matching
+                # the Paddle FusedDSAIndexerLoss path.
                 use_tilelang_indexer = _resolve_csa_tilelang_switch(
                     self.config,
                     "csa_tilelang_enable_indexer",
@@ -1005,8 +1009,12 @@ class CompressedSparseAttention(FleetLayer):
                 #   * Paddle FusedDSAIndexerLoss during training, or
                 #   * Paddle/TileLang forward-only top-k during inference.
                 use_tilelang_loss_path = use_tilelang_indexer and self.training
-                topk_effective = _resolve_csa_indexer_topk_effective(
+                loss_topk_effective = _resolve_csa_indexer_loss_topk_effective(
                     self.config,
+                    self.indexer.index_topk,
+                    n_compressed,
+                )
+                attn_topk_effective = _resolve_csa_indexer_attn_topk_effective(
                     self.indexer.index_topk,
                     n_compressed,
                 )
@@ -1020,12 +1028,9 @@ class CompressedSparseAttention(FleetLayer):
 
                 if use_tilelang_loss_path:
                     # Fused TileLang fwd + selected-set KL + TileLang bwd in
-                    # one PyLayer. This replaces both the Paddle
-                    # FusedDSAIndexerLoss call AND the TileLang forward-only
-                    # no_grad override below, because the PyLayer already
-                    # returns TileLang indices for sparse attention to consume,
-                    # and its backward pipes ``q - p`` through the TileLang
-                    # indexer bwd kernel.
+                    # one PyLayer. The returned indices may be wider than the
+                    # main attention top-k during phase 2 and are trimmed below
+                    # before sparse attention consumes them.
                     indexer_loss_coeff = getattr(
                         self.config, "dsa_indexer_loss_coeff", 0.0
                     )
@@ -1045,7 +1050,7 @@ class CompressedSparseAttention(FleetLayer):
                             query.detach(),
                             key_comp_mla,
                             int(self.compress_ratio),
-                            int(topk_effective),
+                            int(loss_topk_effective),
                             float(self.softmax_scale),
                             float(indexer_loss_coeff),
                             self.tp_group,
@@ -1140,10 +1145,15 @@ class CompressedSparseAttention(FleetLayer):
                             k_indexer_tl,
                             weights_indexer_tl,
                             ratio=self.compress_ratio,
-                            topk_effective=topk_effective,
+                            topk_effective=attn_topk_effective,
                         )
 
                     topk_indices_compressed = tl_topk_indices
+
+                if topk_indices_compressed.shape[-1] > attn_topk_effective:
+                    topk_indices_compressed = topk_indices_compressed[
+                        ..., :attn_topk_effective
+                    ].contiguous()
 
                 # Filter invalid indices and shift to kv_full space
                 compress_topk_idxs = _map_compressed_topk_to_kv_full(

--- a/src/paddlefleet/transformer/dsv4_hybrid_attention.py
+++ b/src/paddlefleet/transformer/dsv4_hybrid_attention.py
@@ -227,9 +227,6 @@ class DSv4HybridAttention(Attention):
             attention_mask,
             x=hidden_states,
             qr=q_compressed,
-            attn_mask_startend_row_indices=kwargs.get(
-                "attn_mask_startend_row_indices", None
-            ),
         )
         # core_attn_out: [b, sq, np * v_head_dim]
 

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -798,6 +798,20 @@ class TransformerConfig(ModelParallelConfig):
     """If True, use fused sparse attention tilelang-kernel for CSA.
     """
 
+    dsv4_tilelang_backend: str | None = None
+    """Optional DSv4 TileLang backend. None keeps the default Paddle indexer path."""
+
+    dsv4_tilelang_enable_backward: bool = False
+    """Enable DSv4 TileLang CSA Indexer backward path."""
+
+    dsv4_tilelang_enable_csa_indexer: bool | None = None
+    """Optional override for TileLang CSA Indexer.
+
+    None follows dsv4_tilelang_backend: enabled when backend is
+    'attention_paddle_compat', disabled when backend is None. False disables
+    only the CSA Indexer TileLang path.
+    """
+
     o_groups: int = 8
     """Number of groups for grouped low-rank output projection (wo_a) in DSv4 Hybrid.
     Set to 0 to use a single linear output projection instead.
@@ -831,6 +845,18 @@ class TransformerConfig(ModelParallelConfig):
         "indexer_use_sparse_loss": "dsa_indexer_use_sparse_loss",
         "indexer_rotary_interleaved": "dsa_indexer_rotary_interleaved",
         "indexer_rope_interleave": "dsa_indexer_rotary_interleaved",
+        # CSA / DSv4 Hybrid field mapping
+        "csa_window_size": "csa_window_size",
+        "csa_compress_ratios": "csa_compress_ratios",
+        "csa_compress_rotary_base": "csa_compress_rotary_base",
+        "csa_dense_mode": "csa_dense_mode",
+        "csa_sparse_attn_fusion": "csa_sparse_attn_fusion",
+        "dsv4_tilelang_backend": "dsv4_tilelang_backend",
+        "dsv4_tilelang_enable_backward": "dsv4_tilelang_enable_backward",
+        "dsv4_tilelang_enable_csa_indexer": "dsv4_tilelang_enable_csa_indexer",
+        "o_groups": "o_groups",
+        "o_lora_rank": "o_lora_rank",
+        "qk_pos_emb_head_dim": "qk_pos_emb_head_dim",
     }
 
     @classmethod
@@ -1048,6 +1074,28 @@ class TransformerConfig(ModelParallelConfig):
                         f"csa_compress_ratios[{i}]={r} is invalid. "
                         f"Must be one of {valid_ratios}."
                     )
+
+            valid_tilelang_backends = {None, "attention_paddle_compat"}
+            if self.dsv4_tilelang_backend not in valid_tilelang_backends:
+                raise ValueError(
+                    f"dsv4_tilelang_backend={self.dsv4_tilelang_backend!r} is invalid. "
+                    f"Must be one of {valid_tilelang_backends}."
+                )
+            if (
+                self.dsv4_tilelang_enable_backward
+                and self.dsv4_tilelang_backend != "attention_paddle_compat"
+            ):
+                raise ValueError(
+                    "dsv4_tilelang_enable_backward requires dsv4_tilelang_backend='attention_paddle_compat'."
+                )
+            if (
+                self.dsv4_tilelang_backend is None
+                and self.dsv4_tilelang_enable_csa_indexer
+            ):
+                raise ValueError(
+                    "dsv4_tilelang_enable_csa_indexer=True requires dsv4_tilelang_backend='attention_paddle_compat'."
+                )
+
         # Hash-based MoE routing consistency checks.
         if self.moe_n_hash_layers > 0:
             if self.actual_vocab_size is None:

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -794,22 +794,28 @@ class TransformerConfig(ModelParallelConfig):
     Useful for debugging or ablation studies.
     """
 
-    csa_sparse_attn_fusion: bool = False
-    """If True, use fused sparse attention tilelang-kernel for CSA.
+    csa_tilelang_backend: str | None = None
+    """Optional CSA TileLang backend.
+
+    None keeps the default Paddle implementation. 'attention_paddle_compat'
+    enables the TileLang indexer and sparse attention paths by default while
+    preserving Paddle-compatible tensor layouts and algorithm semantics.
     """
 
-    dsv4_tilelang_backend: str | None = None
-    """Optional DSv4 TileLang backend. None keeps the default Paddle indexer path."""
+    csa_tilelang_enable_indexer: bool | None = None
+    """Optional override for the CSA TileLang indexer path.
 
-    dsv4_tilelang_enable_backward: bool = False
-    """Enable DSv4 TileLang CSA Indexer backward path."""
+    None follows csa_tilelang_backend. True requires
+    csa_tilelang_backend='attention_paddle_compat'. False disables only the
+    CSA indexer TileLang path.
+    """
 
-    dsv4_tilelang_enable_csa_indexer: bool | None = None
-    """Optional override for TileLang CSA Indexer.
+    csa_tilelang_enable_sparse_attn: bool | None = None
+    """Optional override for the CSA TileLang sparse attention path.
 
-    None follows dsv4_tilelang_backend: enabled when backend is
-    'attention_paddle_compat', disabled when backend is None. False disables
-    only the CSA Indexer TileLang path.
+    None follows csa_tilelang_backend. True requires
+    csa_tilelang_backend='attention_paddle_compat'. False disables only the
+    final sparse MQA attention TileLang path.
     """
 
     o_groups: int = 8
@@ -850,10 +856,9 @@ class TransformerConfig(ModelParallelConfig):
         "csa_compress_ratios": "csa_compress_ratios",
         "csa_compress_rotary_base": "csa_compress_rotary_base",
         "csa_dense_mode": "csa_dense_mode",
-        "csa_sparse_attn_fusion": "csa_sparse_attn_fusion",
-        "dsv4_tilelang_backend": "dsv4_tilelang_backend",
-        "dsv4_tilelang_enable_backward": "dsv4_tilelang_enable_backward",
-        "dsv4_tilelang_enable_csa_indexer": "dsv4_tilelang_enable_csa_indexer",
+        "csa_tilelang_backend": "csa_tilelang_backend",
+        "csa_tilelang_enable_indexer": "csa_tilelang_enable_indexer",
+        "csa_tilelang_enable_sparse_attn": "csa_tilelang_enable_sparse_attn",
         "o_groups": "o_groups",
         "o_lora_rank": "o_lora_rank",
         "qk_pos_emb_head_dim": "qk_pos_emb_head_dim",
@@ -1076,24 +1081,24 @@ class TransformerConfig(ModelParallelConfig):
                     )
 
             valid_tilelang_backends = {None, "attention_paddle_compat"}
-            if self.dsv4_tilelang_backend not in valid_tilelang_backends:
+            if self.csa_tilelang_backend not in valid_tilelang_backends:
                 raise ValueError(
-                    f"dsv4_tilelang_backend={self.dsv4_tilelang_backend!r} is invalid. "
+                    f"csa_tilelang_backend={self.csa_tilelang_backend!r} is invalid. "
                     f"Must be one of {valid_tilelang_backends}."
                 )
             if (
-                self.dsv4_tilelang_enable_backward
-                and self.dsv4_tilelang_backend != "attention_paddle_compat"
+                self.csa_tilelang_backend is None
+                and self.csa_tilelang_enable_indexer
             ):
                 raise ValueError(
-                    "dsv4_tilelang_enable_backward requires dsv4_tilelang_backend='attention_paddle_compat'."
+                    "csa_tilelang_enable_indexer=True requires csa_tilelang_backend='attention_paddle_compat'."
                 )
             if (
-                self.dsv4_tilelang_backend is None
-                and self.dsv4_tilelang_enable_csa_indexer
+                self.csa_tilelang_backend is None
+                and self.csa_tilelang_enable_sparse_attn
             ):
                 raise ValueError(
-                    "dsv4_tilelang_enable_csa_indexer=True requires dsv4_tilelang_backend='attention_paddle_compat'."
+                    "csa_tilelang_enable_sparse_attn=True requires csa_tilelang_backend='attention_paddle_compat'."
                 )
 
         # Hash-based MoE routing consistency checks.

--- a/tests/single_card_tests/custom_ops/test_tilelang_csa_indexer.py
+++ b/tests/single_card_tests/custom_ops/test_tilelang_csa_indexer.py
@@ -12,24 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import sys
 import unittest
-
-_LOCAL_SRC = os.path.abspath(
-    os.path.join(os.path.dirname(__file__), "..", "..", "..", "src")
-)
-if _LOCAL_SRC not in sys.path:
-    sys.path.insert(0, _LOCAL_SRC)
-for _m in [
-    m
-    for m in list(sys.modules)
-    if m == "paddlefleet" or m.startswith("paddlefleet.")
-]:
-    _mod = sys.modules.get(_m)
-    _f = getattr(_mod, "__file__", "") or ""
-    if _LOCAL_SRC not in _f:
-        sys.modules.pop(_m, None)
 
 import paddle
 import paddle.nn.functional as F

--- a/tests/single_card_tests/custom_ops/test_tilelang_csa_indexer.py
+++ b/tests/single_card_tests/custom_ops/test_tilelang_csa_indexer.py
@@ -1,0 +1,1044 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import unittest
+
+_LOCAL_SRC = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..", "src")
+)
+if _LOCAL_SRC not in sys.path:
+    sys.path.insert(0, _LOCAL_SRC)
+for _m in [
+    m
+    for m in list(sys.modules)
+    if m == "paddlefleet" or m.startswith("paddlefleet.")
+]:
+    _mod = sys.modules.get(_m)
+    _f = getattr(_mod, "__file__", "") or ""
+    if _LOCAL_SRC not in _f:
+        sys.modules.pop(_m, None)
+
+import paddle
+import paddle.nn.functional as F
+
+paddle.enable_compat(scope={"tilelang"}, silent=True)
+
+
+# =========================================================================
+# Helpers
+# =========================================================================
+
+
+def _cuda_or_skip(testcase):
+    if not paddle.device.is_compiled_with_cuda():
+        testcase.skipTest("CUDA build of Paddle is required")
+    if paddle.device.cuda.device_count() == 0:
+        testcase.skipTest("No CUDA device available")
+
+
+def _make_indexer_inputs(b, sq, sk, h_i, d_i, dtype="bfloat16", seed=2026):
+    paddle.seed(seed)
+    q = paddle.randn([b, sq, h_i, d_i]).astype(dtype)
+    k = paddle.randn([b, sk, d_i]).astype(dtype)
+    w = paddle.randn([b, sq, h_i]).astype("float32")
+    return q, k, w
+
+
+def _make_loss_inputs(b, sq, sk, h_i, d_i, np_, hn, seed=2027):
+    paddle.seed(seed)
+    q = paddle.randn([b, sq, h_i, d_i]).astype("bfloat16")
+    k = paddle.randn([b, sk, d_i]).astype("bfloat16")
+    weights = paddle.randn([b, sq, h_i]).astype("float32")
+    query_mla = paddle.randn([b, sq, np_, hn]).astype("bfloat16").detach()
+    key_comp_mla = paddle.randn([b, sk, hn]).astype("bfloat16").detach()
+    return q, k, weights, query_mla, key_comp_mla
+
+
+def _build_csa_causal_mask(b, sq, sk, ratio):
+    comp_ids = paddle.arange(sk, dtype="int64").reshape([1, 1, 1, sk])
+    valid_end = (
+        paddle.arange(1, sq + 1, dtype="int64").reshape([1, 1, sq, 1]) // ratio
+    )
+    valid = (comp_ids < valid_end).expand([b, 1, sq, sk])
+    neg_inf = paddle.full([b, 1, sq, sk], float("-inf"), dtype="float32")
+    return paddle.where(valid, paddle.zeros_like(neg_inf), neg_inf)
+
+
+def _all_equal(tensor, value):
+    return bool((tensor == value).all().item())
+
+
+def _sorted_compare_indices(out_indices, ref_indices):
+    out_sorted = paddle.sort(out_indices, axis=-1)
+    ref_sorted = paddle.sort(ref_indices, axis=-1)
+    return bool((out_sorted == ref_sorted).all().item())
+
+
+def _assert_close(actual, expected, rtol, atol, msg):
+    a = actual.cast("float32") if actual.dtype != paddle.float32 else actual
+    e = (
+        expected.cast("float32")
+        if expected.dtype != paddle.float32
+        else expected
+    )
+    if not paddle.allclose(a, e, rtol=rtol, atol=atol).item():
+        diff = (a - e).abs()
+        raise AssertionError(
+            f"{msg}\n  max abs diff: {diff.max().item():.4e}\n"
+            f"  max rel diff: {(diff / e.abs().clip(min=1e-12)).max().item():.4e}"
+        )
+
+
+# =========================================================================
+# Reference implementations
+# =========================================================================
+
+
+def _ref_csa_indexer_topk(
+    index_q, index_k_comp, weights, ratio, topk_effective
+):
+    scores = paddle.einsum(
+        "bshd,btd->bsht", index_q.cast("float32"), index_k_comp.cast("float32")
+    )
+    scores = F.relu(scores)
+    scores = (scores * weights.cast("float32").unsqueeze(-1)).sum(axis=2)
+    scores = scores * (index_q.shape[-1] ** -0.5)
+    batch, seq_len, seq_len_comp = scores.shape
+    comp_ids = paddle.arange(seq_len_comp, dtype="int64").reshape(
+        [1, 1, seq_len_comp]
+    )
+    positions = paddle.arange(1, seq_len + 1, dtype="int64").reshape(
+        [1, seq_len, 1]
+    )
+    valid_end = positions // ratio
+    valid_mask = comp_ids < valid_end
+    scores = paddle.where(
+        valid_mask, scores, paddle.full_like(scores, float("-inf"))
+    )
+    actual_topk = min(topk_effective, seq_len_comp)
+    topk_scores_raw, topk_indices = paddle.topk(scores, k=actual_topk, axis=-1)
+    valid_topk = paddle.take_along_axis(
+        paddle.expand(valid_mask, [batch, seq_len, seq_len_comp]).cast("int32"),
+        topk_indices,
+        axis=-1,
+    ).cast("bool")
+    topk_indices = paddle.where(
+        valid_topk, topk_indices, paddle.full_like(topk_indices, -1)
+    )
+    topk_scores_raw = paddle.where(
+        valid_topk,
+        topk_scores_raw,
+        paddle.full_like(topk_scores_raw, float("-inf")),
+    )
+    topk_probs = F.softmax(topk_scores_raw, axis=-1)
+    topk_probs = paddle.where(
+        valid_topk, topk_probs, paddle.zeros_like(topk_probs)
+    )
+    if topk_effective > actual_topk:
+        pad = topk_effective - actual_topk
+        topk_indices = paddle.concat(
+            [
+                topk_indices,
+                paddle.full(
+                    [batch, seq_len, pad], -1, dtype=topk_indices.dtype
+                ),
+            ],
+            axis=-1,
+        )
+        topk_probs = paddle.concat(
+            [
+                topk_probs,
+                paddle.zeros([batch, seq_len, pad], dtype=topk_probs.dtype),
+            ],
+            axis=-1,
+        )
+    return topk_indices.cast("int32"), topk_probs.cast("float32")
+
+
+def _paddle_ref_csa_indexer_topk(q, k, weights, ratio, topk_effective):
+    from paddlefleet.transformer.dsa_attention import fused_qk_topk_naive
+
+    b, sq, h_i, d_i = q.shape
+    sk = k.shape[1]
+    sm_scale = d_i**-0.5
+    comp_ids = paddle.arange(sk, dtype="int64").reshape([1, 1, sk])
+    valid_end = (
+        paddle.arange(1, sq + 1, dtype="int64").reshape([1, sq, 1]) // ratio
+    )
+    valid_mask = (comp_ids < valid_end).expand([b, sq, sk])
+    neg_inf = paddle.full([b, sq, sk], float("-inf"), dtype="float32")
+    causal_mask = paddle.where(valid_mask, paddle.zeros_like(neg_inf), neg_inf)
+    actual_topk = min(int(topk_effective), int(sk))
+    index_scores, ref_topk_indices = fused_qk_topk_naive(
+        q, k, weights, index_topk=actual_topk, mask=causal_mask
+    )
+    index_scores_scaled = index_scores * sm_scale
+    masked_scaled = index_scores_scaled + causal_mask
+    topk_scores_raw, topk_indices = paddle.topk(
+        masked_scaled, k=actual_topk, axis=-1
+    )
+    topk_indices = paddle.clip(topk_indices, min=0, max=sk - 1)
+    valid_topk = paddle.take_along_axis(
+        valid_mask.cast("int32"), topk_indices, axis=-1
+    ).cast("bool")
+    topk_indices = paddle.where(
+        valid_topk,
+        topk_indices.cast("int32"),
+        paddle.full_like(topk_indices, -1, dtype="int32"),
+    )
+    topk_scores_raw = paddle.where(
+        valid_topk,
+        topk_scores_raw,
+        paddle.full_like(topk_scores_raw, float("-inf")),
+    )
+    row_has_valid = valid_topk.any(axis=-1, keepdim=True)
+    safe_scores = paddle.where(
+        row_has_valid, topk_scores_raw, paddle.zeros_like(topk_scores_raw)
+    )
+    topk_probs = F.softmax(safe_scores.cast("float32"), axis=-1)
+    topk_probs = paddle.where(
+        row_has_valid, topk_probs, paddle.zeros_like(topk_probs)
+    )
+    topk_probs = paddle.where(
+        valid_topk, topk_probs, paddle.zeros_like(topk_probs)
+    )
+    if int(topk_effective) > actual_topk:
+        pad = int(topk_effective) - actual_topk
+        topk_indices = paddle.concat(
+            [topk_indices, paddle.full([b, sq, pad], -1, dtype="int32")],
+            axis=-1,
+        )
+        topk_probs = paddle.concat(
+            [topk_probs, paddle.zeros([b, sq, pad], dtype="float32")], axis=-1
+        )
+    return topk_indices, topk_probs
+
+
+# =========================================================================
+# Kernel tests
+# =========================================================================
+
+
+class TestTileLangCSAIndexerKernel(unittest.TestCase):
+    """Correctness of raw TileLang kernel interfaces."""
+
+    def setUp(self):
+        if not paddle.is_compiled_with_cuda():
+            self.skipTest("CUDA is required")
+        paddle.set_device("gpu")
+
+    def _run_kernel_fwd_case(self, topk_effective):
+        from paddlefleet.tilelang_ops.indexer.csa_indexer_fwd import (
+            csa_indexer_topk_fwd_interface,
+        )
+
+        batch, seq_len, seq_len_comp, heads, dim, ratio = 1, 16, 4, 64, 128, 4
+        q, k, w = _make_indexer_inputs(
+            batch, seq_len, seq_len_comp, heads, dim, seed=2026
+        )
+        out_idx, out_scores = csa_indexer_topk_fwd_interface(
+            q,
+            k,
+            w,
+            ratio=ratio,
+            topk_effective=topk_effective,
+            block_K=32,
+            num_threads=128,
+        )
+        ref_idx, ref_scores = _ref_csa_indexer_topk(
+            q, k, w, ratio, topk_effective
+        )
+        self.assertEqual(tuple(out_idx.shape), (batch, seq_len, topk_effective))
+        self.assertTrue(paddle.all(out_idx.cpu() == ref_idx.cpu()).item())
+        valid = ref_idx >= 0
+        paddle.testing.assert_close(
+            out_scores.cpu()[valid.cpu()],
+            ref_scores.cpu()[valid.cpu()],
+            rtol=6e-2,
+            atol=2e-2,
+        )
+        self.assertTrue(
+            paddle.all(
+                out_scores.cpu()[~valid.cpu()] == ref_scores.cpu()[~valid.cpu()]
+            ).item()
+        )
+        self.assertTrue(paddle.all(out_idx[:, :3, :] == -1).item())
+
+    def test_kernel_fwd_selected_topk(self):
+        self._run_kernel_fwd_case(topk_effective=2)
+
+    def test_kernel_fwd_full_candidate(self):
+        self._run_kernel_fwd_case(topk_effective=4)
+
+    def test_kernel_fwd_output_padding(self):
+        self._run_kernel_fwd_case(topk_effective=6)
+
+    def _ref_csa_indexer_bwd(
+        self, index_q, weights, index_k_comp, topk_indices, grad_scores
+    ):
+        q = index_q.detach().clone()
+        q.stop_gradient = False
+        w = weights.detach().clone()
+        w.stop_gradient = False
+        k = index_k_comp.detach().clone()
+        k.stop_gradient = False
+        scores = paddle.einsum(
+            "bshd,btd->bsht", q.cast("float32"), k.cast("float32")
+        )
+        scores = F.relu(scores * (q.shape[-1] ** -0.5))
+        scores = (scores * w.cast("float32").unsqueeze(-1)).sum(axis=2)
+        valid = topk_indices >= 0
+        safe_indices = paddle.clip(topk_indices, min=0).cast("int64")
+        selected = paddle.take_along_axis(scores, safe_indices, axis=-1)
+        selected = paddle.where(valid, selected, paddle.zeros_like(selected))
+        (selected * grad_scores.cast("float32")).sum().backward()
+        return q.grad, w.grad, k.grad
+
+    def _run_kernel_bwd_case(self, topk_effective):
+        from paddlefleet.tilelang_ops.indexer.csa_indexer_bwd import (
+            csa_indexer_bwd_interface,
+        )
+        from paddlefleet.tilelang_ops.indexer.csa_indexer_fwd import (
+            csa_indexer_topk_fwd_interface,
+        )
+
+        batch, seq_len, seq_len_comp, heads, dim, ratio = 1, 16, 4, 64, 128, 4
+        q, k, w = _make_indexer_inputs(
+            batch, seq_len, seq_len_comp, heads, dim, seed=2027
+        )
+        topk_indices, _ = csa_indexer_topk_fwd_interface(
+            q,
+            k,
+            w,
+            ratio=ratio,
+            topk_effective=topk_effective,
+            block_K=32,
+            num_threads=128,
+        )
+        grad_scores = paddle.randn(
+            [batch, seq_len, topk_effective], dtype="float32"
+        )
+        grad_scores = paddle.where(
+            topk_indices >= 0, grad_scores, paddle.zeros_like(grad_scores)
+        ).contiguous()
+        out_dq, out_dw, out_dk = csa_indexer_bwd_interface(
+            q,
+            w,
+            k,
+            topk_indices.contiguous(),
+            grad_scores,
+            block_I=32,
+            num_threads=128,
+        )
+        ref_dq, ref_dw, ref_dk = self._ref_csa_indexer_bwd(
+            q, w, k, topk_indices, grad_scores
+        )
+        self.assertEqual(tuple(out_dq.shape), tuple(q.shape))
+        paddle.testing.assert_close(
+            out_dq.cast("float32").cpu(),
+            ref_dq.cast("float32").cpu(),
+            rtol=6e-2,
+            atol=2e-2,
+        )
+        paddle.testing.assert_close(
+            out_dw.cpu(), ref_dw.cpu(), rtol=6e-2, atol=3e-2
+        )
+        paddle.testing.assert_close(
+            out_dk.cpu(), ref_dk.cast("float32").cpu(), rtol=6e-2, atol=3e-2
+        )
+
+    def test_kernel_bwd_selected_topk(self):
+        self._run_kernel_bwd_case(topk_effective=2)
+
+    def test_kernel_bwd_full_candidate(self):
+        self._run_kernel_bwd_case(topk_effective=4)
+
+    def test_kernel_bwd_output_padding(self):
+        self._run_kernel_bwd_case(topk_effective=6)
+
+
+# =========================================================================
+# Wrapper tests
+# =========================================================================
+
+
+@unittest.skipUnless(
+    paddle.device.is_compiled_with_cuda()
+    and paddle.device.cuda.device_count() > 0,
+    "TileLang CSA Indexer kernel requires CUDA",
+)
+class TestTileLangCSAIndexerWrapperForward(unittest.TestCase):
+    def setUp(self):
+        from paddlefleet.tilelang_ops import csa_indexer_topk_fwd
+
+        self._kernel = csa_indexer_topk_fwd
+
+    def test_phase3_selected_topk_matches_reference(self):
+        b, sq, sk, h_i, d_i, ratio = 1, 16, 4, 64, 128, 4
+        topk_effective = 2
+        q, k, w = _make_indexer_inputs(b, sq, sk, h_i, d_i)
+        out_idx, out_prob = self._kernel(
+            q, k, w, ratio=ratio, topk_effective=topk_effective
+        )
+        ref_idx, ref_prob = _paddle_ref_csa_indexer_topk(
+            q, k, w, ratio, topk_effective
+        )
+        self.assertEqual(list(out_idx.shape), [b, sq, topk_effective])
+        self.assertTrue(_sorted_compare_indices(out_idx, ref_idx))
+        valid = ref_idx >= 0
+        self.assertTrue(
+            paddle.allclose(
+                paddle.masked_select(out_prob, valid),
+                paddle.masked_select(ref_prob, valid),
+                rtol=8e-2,
+                atol=3e-2,
+            ).item()
+        )
+
+    def test_phase2_full_candidate_matches_reference(self):
+        b, sq, sk, h_i, d_i, ratio = 1, 16, 4, 64, 128, 4
+        topk_effective = sk
+        q, k, w = _make_indexer_inputs(b, sq, sk, h_i, d_i)
+        out_idx, out_prob = self._kernel(
+            q, k, w, ratio=ratio, topk_effective=topk_effective
+        )
+        ref_idx, ref_prob = _paddle_ref_csa_indexer_topk(
+            q, k, w, ratio, topk_effective
+        )
+        self.assertTrue(_sorted_compare_indices(out_idx, ref_idx))
+        valid = ref_idx >= 0
+        self.assertTrue(
+            paddle.allclose(
+                paddle.masked_select(out_prob, valid),
+                paddle.masked_select(ref_prob, valid),
+                rtol=8e-2,
+                atol=3e-2,
+            ).item()
+        )
+
+    def test_padded_n_compressed_matches_reference(self):
+        b, sq, sk, h_i, d_i, ratio = 1, 16, 4, 64, 128, 4
+        topk_effective = 6
+        q, k, w = _make_indexer_inputs(b, sq, sk, h_i, d_i)
+        out_idx, out_prob = self._kernel(
+            q, k, w, ratio=ratio, topk_effective=topk_effective
+        )
+        ref_idx, ref_prob = _paddle_ref_csa_indexer_topk(
+            q, k, w, ratio, topk_effective
+        )
+        self.assertEqual(list(out_idx.shape), [b, sq, topk_effective])
+        self.assertTrue(_all_equal(out_idx[:, :, sk:], -1))
+        self.assertTrue(_all_equal(out_prob[:, :, sk:], 0))
+        self.assertTrue(_sorted_compare_indices(out_idx, ref_idx))
+
+    def test_causal_t0_t1_t2_have_no_compressed_block(self):
+        b, sq, sk, h_i, d_i, ratio = 1, 16, 4, 64, 128, 4
+        q, k, w = _make_indexer_inputs(b, sq, sk, h_i, d_i)
+        out_idx, out_prob = self._kernel(q, k, w, ratio=ratio, topk_effective=4)
+        self.assertTrue(_all_equal(out_idx[:, :3, :], -1))
+        self.assertTrue(_all_equal(out_prob[:, :3, :], 0))
+
+    def test_causal_t3_only_block_zero_visible(self):
+        b, sq, sk, h_i, d_i, ratio = 1, 16, 4, 64, 128, 4
+        q, k, w = _make_indexer_inputs(b, sq, sk, h_i, d_i)
+        out_idx, _ = self._kernel(q, k, w, ratio=ratio, topk_effective=4)
+        row = out_idx[0, 3].numpy().tolist()
+        self.assertIn(0, row)
+        self.assertEqual(sum(int(x == -1) for x in row), 3)
+
+    def test_causal_t7_blocks_zero_and_one_visible(self):
+        b, sq, sk, h_i, d_i, ratio = 1, 16, 4, 64, 128, 4
+        q, k, w = _make_indexer_inputs(b, sq, sk, h_i, d_i)
+        out_idx, _ = self._kernel(q, k, w, ratio=ratio, topk_effective=4)
+        row = sorted(out_idx[0, 7].numpy().tolist())
+        valid = [x for x in row if x != -1]
+        self.assertEqual(sorted(valid), [0, 1])
+
+    def test_short_sequence_with_valid_end_less_than_topk(self):
+        b, sq, sk, h_i, d_i, ratio = 1, 8, 4, 64, 128, 4
+        topk_effective = 4
+        q, k, w = _make_indexer_inputs(b, sq, sk, h_i, d_i)
+        out_idx, _ = self._kernel(
+            q, k, w, ratio=ratio, topk_effective=topk_effective
+        )
+        ref_idx, _ = _paddle_ref_csa_indexer_topk(
+            q, k, w, ratio, topk_effective
+        )
+        for t in range(sq):
+            valid_end = (t + 1) // ratio
+            row = out_idx[0, t].numpy().tolist()
+            n_valid = sum(int(x >= 0) for x in row)
+            self.assertEqual(n_valid, min(valid_end, topk_effective))
+        self.assertTrue(_sorted_compare_indices(out_idx, ref_idx))
+
+
+# =========================================================================
+# PyLayer backward tests
+# =========================================================================
+
+
+@unittest.skipUnless(
+    paddle.device.is_compiled_with_cuda()
+    and paddle.device.cuda.device_count() > 0,
+    "TileLang CSA Indexer kernel requires CUDA",
+)
+class TestTileLangCSAIndexerLossGrad(unittest.TestCase):
+    B, SQ, SK, H_I, D_I, NP, HN, RATIO = 1, 16, 4, 64, 128, 1, 128, 4
+    LOSS_COEFF = 1.0
+
+    def _common_inputs(self, seed=2027):
+        return _make_loss_inputs(
+            self.B,
+            self.SQ,
+            self.SK,
+            self.H_I,
+            self.D_I,
+            self.NP,
+            self.HN,
+            seed=seed,
+        )
+
+    def _assert_grads_close(self, tl_grads, pd_grads, label):
+        tl_dq, tl_dw, tl_dk = tl_grads
+        pd_dq, pd_dw, pd_dk = pd_grads
+        _assert_close(
+            tl_dq, pd_dq, rtol=8e-2, atol=3e-2, msg=f"{label}: dQ mismatch"
+        )
+        _assert_close(
+            tl_dw,
+            pd_dw,
+            rtol=8e-2,
+            atol=3e-2,
+            msg=f"{label}: dWeights mismatch",
+        )
+        _assert_close(
+            tl_dk, pd_dk, rtol=8e-2, atol=3e-2, msg=f"{label}: dKComp mismatch"
+        )
+
+    def _run_tilelang(
+        self,
+        q,
+        k,
+        weights,
+        query_mla,
+        key_comp_mla,
+        ratio,
+        topk_eff,
+        softmax_scale,
+        loss_coeff,
+    ):
+        from paddlefleet.transformer.csa_attention import TileLangCSAIndexerLoss
+
+        qd = q.detach().clone()
+        qd.stop_gradient = False
+        kd = k.detach().clone()
+        kd.stop_gradient = False
+        wd = weights.detach().clone()
+        wd.stop_gradient = False
+        loss, _topk_indices = TileLangCSAIndexerLoss.apply(
+            qd,
+            wd,
+            kd,
+            query_mla,
+            key_comp_mla,
+            int(ratio),
+            int(topk_eff),
+            float(softmax_scale),
+            float(loss_coeff),
+            None,
+        )
+        loss.backward()
+        return loss, qd.grad, wd.grad, kd.grad
+
+    def _run_paddle(
+        self,
+        q,
+        k,
+        weights,
+        query_mla,
+        key_comp_mla,
+        ratio,
+        topk,
+        softmax_scale,
+        loss_coeff,
+        sparse_loss,
+    ):
+        from paddlefleet.transformer.dsa_attention import FusedDSAIndexerLoss
+
+        d_i = q.shape[-1]
+        alpha = d_i**-0.5
+        q_sf = q.detach().transpose([1, 0, 2, 3]).clone()
+        q_sf.stop_gradient = False
+        k_sf = k.detach().transpose([1, 0, 2]).clone()
+        k_sf.stop_gradient = False
+        w_sf = (weights.detach() * alpha).transpose([1, 0, 2]).clone()
+        w_sf.stop_gradient = False
+        query_sf = query_mla.transpose([1, 0, 2, 3]).detach()
+        key_expanded = key_comp_mla.unsqueeze(2).expand(
+            [q.shape[0], k.shape[1], query_mla.shape[2], query_mla.shape[3]]
+        )
+        key_sf = key_expanded.transpose([1, 0, 2, 3]).detach()
+        mask = _build_csa_causal_mask(q.shape[0], q.shape[1], k.shape[1], ratio)
+        loss = FusedDSAIndexerLoss.apply(
+            q_sf,
+            w_sf,
+            k_sf,
+            query_sf,
+            key_sf,
+            float(softmax_scale),
+            int(topk),
+            float(loss_coeff),
+            mask,
+            bool(sparse_loss),
+            None,
+        )
+        loss.backward()
+        dq_bf = q_sf.grad.transpose([1, 0, 2, 3])
+        dk_bf = k_sf.grad.transpose([1, 0, 2])
+        dw_bf = w_sf.grad.transpose([1, 0, 2]) * alpha
+        return loss, dq_bf, dw_bf, dk_bf
+
+    def _assert_attn_target_matches_paddle(
+        self, q, k, w, qm, km, topk_eff, softmax_scale, label
+    ):
+        from paddlefleet.tilelang_ops import (
+            csa_attn_target_reducesum,
+            csa_indexer_topk_fwd,
+        )
+        from paddlefleet.transformer.csa_attention import (
+            _compute_attn_target_on_selected_set,
+        )
+
+        topk_indices, _ = csa_indexer_topk_fwd(
+            q, k, w, ratio=self.RATIO, topk_effective=topk_eff
+        )
+        tl_target = csa_attn_target_reducesum(
+            qm, km, topk_indices, softmax_scale
+        )
+        pd_target = _compute_attn_target_on_selected_set(
+            qm, km, topk_indices, softmax_scale, None
+        )
+        _assert_close(
+            tl_target,
+            pd_target,
+            rtol=6e-2,
+            atol=2e-2,
+            msg=f"{label}: attention target mismatch",
+        )
+
+    def test_attn_target_reducesum_matches_paddle(self):
+        q, k, w, qm, km = self._common_inputs(seed=2032)
+        topk_eff = 2
+        softmax_scale = self.HN**-0.5
+        self._assert_attn_target_matches_paddle(
+            q, k, w, qm, km, topk_eff, softmax_scale, "single-head"
+        )
+
+    def test_attn_target_reducesum_multi_head_matches_paddle(self):
+        q, k, w, qm, km = _make_loss_inputs(
+            self.B,
+            self.SQ,
+            self.SK,
+            self.H_I,
+            self.D_I,
+            128,
+            self.HN,
+            seed=2033,
+        )
+        topk_eff = 2
+        softmax_scale = self.HN**-0.5
+        self._assert_attn_target_matches_paddle(
+            q, k, w, qm, km, topk_eff, softmax_scale, "multi-head"
+        )
+
+    def test_phase3_selected_topk_grad(self):
+        q, k, w, qm, km = self._common_inputs()
+        topk_eff = 2
+        softmax_scale = self.HN**-0.5
+        tl_loss, tl_dq, tl_dw, tl_dk = self._run_tilelang(
+            q,
+            k,
+            w,
+            qm,
+            km,
+            self.RATIO,
+            topk_eff,
+            softmax_scale,
+            self.LOSS_COEFF,
+        )
+        pd_loss, pd_dq, pd_dw, pd_dk = self._run_paddle(
+            q,
+            k,
+            w,
+            qm,
+            km,
+            self.RATIO,
+            topk_eff,
+            softmax_scale,
+            self.LOSS_COEFF,
+            sparse_loss=True,
+        )
+        _assert_close(
+            tl_loss, pd_loss, rtol=5e-2, atol=2e-3, msg="Phase3 loss mismatch"
+        )
+        self._assert_grads_close(
+            (tl_dq, tl_dw, tl_dk), (pd_dq, pd_dw, pd_dk), "Phase3"
+        )
+
+    def test_phase2_full_range_grad(self):
+        q, k, w, qm, km = self._common_inputs(seed=2028)
+        topk_eff = self.SK
+        softmax_scale = self.HN**-0.5
+        tl_loss, tl_dq, tl_dw, tl_dk = self._run_tilelang(
+            q,
+            k,
+            w,
+            qm,
+            km,
+            self.RATIO,
+            topk_eff,
+            softmax_scale,
+            self.LOSS_COEFF,
+        )
+        pd_loss, pd_dq, pd_dw, pd_dk = self._run_paddle(
+            q,
+            k,
+            w,
+            qm,
+            km,
+            self.RATIO,
+            topk_eff,
+            softmax_scale,
+            self.LOSS_COEFF,
+            sparse_loss=False,
+        )
+        _assert_close(
+            tl_loss, pd_loss, rtol=5e-2, atol=2e-3, msg="Phase2 loss mismatch"
+        )
+        self._assert_grads_close(
+            (tl_dq, tl_dw, tl_dk), (pd_dq, pd_dw, pd_dk), "Phase2"
+        )
+
+    def test_invalid_padding_rows_have_zero_grad(self):
+        q, k, w, qm, km = self._common_inputs(seed=2029)
+        topk_eff = 2
+        softmax_scale = self.HN**-0.5
+        _loss, tl_dq, tl_dw, _tl_dk = self._run_tilelang(
+            q,
+            k,
+            w,
+            qm,
+            km,
+            self.RATIO,
+            topk_eff,
+            softmax_scale,
+            self.LOSS_COEFF,
+        )
+        for g, name in ((tl_dq, "dQ"), (tl_dw, "dWeights")):
+            gf = g[:, :3].cast("float32")
+            _assert_close(
+                gf,
+                paddle.zeros_like(gf),
+                rtol=0.0,
+                atol=1e-5,
+                msg=f"{name} on valid_end=0 rows",
+            )
+
+    def test_padded_topk_does_not_change_grad(self):
+        q, k, w, qm, km = self._common_inputs(seed=2030)
+        softmax_scale = self.HN**-0.5
+        _l_full, dq_full, dw_full, dk_full = self._run_tilelang(
+            q, k, w, qm, km, self.RATIO, self.SK, softmax_scale, self.LOSS_COEFF
+        )
+        _l_pad, dq_pad, dw_pad, dk_pad = self._run_tilelang(
+            q,
+            k,
+            w,
+            qm,
+            km,
+            self.RATIO,
+            self.SK + 2,
+            softmax_scale,
+            self.LOSS_COEFF,
+        )
+        _assert_close(
+            dq_full,
+            dq_pad,
+            rtol=1e-3,
+            atol=1e-4,
+            msg="dQ invariant to topk padding",
+        )
+        _assert_close(
+            dw_full,
+            dw_pad,
+            rtol=1e-3,
+            atol=1e-4,
+            msg="dWeights invariant to topk padding",
+        )
+        _assert_close(
+            dk_full,
+            dk_pad,
+            rtol=1e-3,
+            atol=1e-4,
+            msg="dKComp invariant to topk padding",
+        )
+
+    def test_training_step_no_nan_and_loss_backprops(self):
+        q, k, w, qm, km = self._common_inputs(seed=2031)
+        topk_eff = 2
+        softmax_scale = self.HN**-0.5
+        loss, dq, dw, dk = self._run_tilelang(
+            q,
+            k,
+            w,
+            qm,
+            km,
+            self.RATIO,
+            topk_eff,
+            softmax_scale,
+            self.LOSS_COEFF,
+        )
+        loss_fp = loss.cast("float32")
+        self.assertTrue(
+            paddle.isfinite(loss_fp).all().item(), "loss is not finite"
+        )
+        self.assertGreater(loss_fp.item(), 0.0, "KL loss must be positive")
+        for name, g in (("dQ", dq), ("dWeights", dw), ("dKComp", dk)):
+            gf = g.cast("float32")
+            self.assertTrue(
+                paddle.isfinite(gf).all().item(), f"{name} contains NaN/Inf"
+            )
+            self.assertGreater(
+                gf.abs().max().item(), 0.0, f"{name} is identically zero"
+            )
+
+
+@unittest.skipUnless(
+    paddle.device.is_compiled_with_cuda()
+    and paddle.device.cuda.device_count() > 0,
+    "TileLang CSA attn_target kernel requires CUDA",
+)
+class TestCSAAttnTargetReducesum(unittest.TestCase):
+    """Isolated correctness tests for csa_attn_target_reducesum kernel."""
+
+    def _run_and_compare(self, b, sq, sk, np_, hn, topk_eff, ratio, seed=2040):
+        from paddlefleet.tilelang_ops import (
+            csa_attn_target_reducesum,
+            csa_indexer_topk_fwd,
+        )
+        from paddlefleet.transformer.csa_attention import (
+            _compute_attn_target_on_selected_set,
+        )
+
+        paddle.seed(seed)
+        h_i, d_i = 64, 128
+        q = paddle.randn([b, sq, h_i, d_i]).astype("bfloat16")
+        k = paddle.randn([b, sk, d_i]).astype("bfloat16")
+        w = paddle.randn([b, sq, h_i]).astype("float32")
+        query_mla = paddle.randn([b, sq, np_, hn]).astype("bfloat16").detach()
+        # MLA invariant: compressed key is shared across all heads → [B, S_comp, D]
+        key_comp_mla = (
+            paddle.randn([b, sk, hn]).astype("bfloat16").contiguous().detach()
+        )
+        softmax_scale = hn**-0.5
+
+        topk_indices, _ = csa_indexer_topk_fwd(
+            q, k, w, ratio=ratio, topk_effective=topk_eff
+        )
+        tl_target = csa_attn_target_reducesum(
+            query_mla, key_comp_mla, topk_indices, softmax_scale
+        )
+        pd_target = _compute_attn_target_on_selected_set(
+            query_mla, key_comp_mla, topk_indices, softmax_scale, None
+        )
+        _assert_close(
+            tl_target,
+            pd_target,
+            rtol=6e-2,
+            atol=2e-2,
+            msg=f"target mismatch [b={b},sq={sq},sk={sk},np={np_},topk={topk_eff}]",
+        )
+        # L1 normalization: valid rows should sum to ~1
+        valid = topk_indices >= 0
+        row_valid = valid.any(axis=-1)
+        if row_valid.any().item():
+            row_sums = tl_target[row_valid].sum(axis=-1)
+            _assert_close(
+                row_sums,
+                paddle.ones_like(row_sums),
+                rtol=1e-4,
+                atol=1e-4,
+                msg="L1 normalization violated",
+            )
+        # Invalid rows should be all-zero
+        if (~row_valid).any().item():
+            zeros = tl_target[~row_valid]
+            self.assertTrue(
+                (zeros.cast("float32").abs() < 1e-6).all().item(),
+                "invalid rows should be all-zero",
+            )
+
+    def test_multi_head_replicate(self):
+        """heads=128 (>64) triggers REPLICATE_H=2 path in kernel.
+
+        The kernel splits 128 MLA heads into two groups of 64, computes
+        partial softmax per group, then sums and L1-normalizes. Keys are
+        head-shared (MLA invariant) so both groups read the same K vector.
+        A bug would show as broken partial-sum aggregation.
+        """
+        self._run_and_compare(
+            b=1, sq=16, sk=4, np_=128, hn=128, topk_eff=2, ratio=4, seed=2041
+        )
+
+    def test_multi_block_topk_with_padding(self):
+        """topk_eff=48 with block_I=32 → padded to 64 → 2 tile iterations.
+
+        This tests: the online softmax correctly accumulates across
+        multiple K-blocks rather than just one; (2) the interface layer
+        correctly pads topk_indices with -1 to align to block_I and trims
+        back to topk_eff=48 in the output; (3) the pad slots with index=-1
+        are masked to -inf and contribute zero probability.
+        """
+        self._run_and_compare(
+            b=2, sq=32, sk=16, np_=64, hn=128, topk_eff=48, ratio=4, seed=2042
+        )
+
+    def test_online_softmax_numerical_stability(self):
+        """Validate online softmax under adversarial numeric conditions.
+
+        Exercises three properties specific to 2-pass online softmax:
+        1. Cross-block max shift: block 1 has logits ~10x larger than block 0,
+           forcing the rescale exp(old_max - new_max) to a very small value.
+           A bug in the online update would produce incorrect probabilities.
+        2. All-invalid row: a query position with all topk_indices = -1 must
+           produce all-zero output (tests NaN-safe path when row_max = -inf).
+        3. Single valid entry: only 1 valid index per row; output must be 1.0
+           for that entry (tests exact normalization in degenerate case).
+        """
+        from paddlefleet.tilelang_ops import csa_attn_target_reducesum
+        from paddlefleet.transformer.csa_attention import (
+            _compute_attn_target_on_selected_set,
+        )
+
+        _cuda_or_skip(self)
+        paddle.set_device("gpu")
+
+        b, np_, hn = 1, 64, 128
+        sk = 8  # compressed sequence length
+        topk = 64  # 2 blocks of block_I=32
+        softmax_scale = hn**-0.5
+
+        # Construct keys: first 4 keys are "small", last 4 are "large" (10x scale).
+        # This ensures block 1 (indices 4-7) dominates, forcing cross-block rescale.
+        paddle.seed(7777)
+        key_small = paddle.randn([b, 4, hn]).astype("bfloat16") * 0.1
+        key_large = paddle.randn([b, 4, hn]).astype("bfloat16") * 1.0
+        key_comp_mla = (
+            paddle.concat([key_small, key_large], axis=1).contiguous().detach()
+        )
+
+        # --- Case 1: cross-block max shift ---
+        # Place small-key indices (0-3) in block 0 (positions 0-3) and large-key
+        # indices (4-7) in block 1 (positions 32-35), so that the online softmax
+        # must rescale row_sum when it encounters the larger block_max in block 1.
+        sq = 4
+        query_mla = paddle.randn([b, sq, np_, hn]).astype("bfloat16").detach()
+        topk_indices_case1 = paddle.full([b, sq, topk], -1, dtype="int32")
+        for t in range(sq):
+            topk_indices_case1[0, t, 0:4] = paddle.to_tensor(
+                [0, 1, 2, 3], dtype="int32"
+            )
+            topk_indices_case1[0, t, 32:36] = paddle.to_tensor(
+                [4, 5, 6, 7], dtype="int32"
+            )
+        topk_indices_case1 = topk_indices_case1.contiguous()
+        tl_out = csa_attn_target_reducesum(
+            query_mla, key_comp_mla, topk_indices_case1, softmax_scale
+        )
+        pd_out = _compute_attn_target_on_selected_set(
+            query_mla, key_comp_mla, topk_indices_case1, softmax_scale, None
+        )
+        _assert_close(
+            tl_out,
+            pd_out,
+            rtol=5e-3,
+            atol=2e-3,
+            msg="cross-block max shift mismatch",
+        )
+        # L1 check
+        row_sums = tl_out.sum(axis=-1)
+        _assert_close(
+            row_sums,
+            paddle.ones_like(row_sums),
+            rtol=1e-4,
+            atol=1e-4,
+            msg="L1 norm violated (case 1)",
+        )
+
+        # --- Case 2: all-invalid row ---
+        sq = 2
+        query_mla2 = paddle.randn([b, sq, np_, hn]).astype("bfloat16").detach()
+        # Row 0: all invalid; Row 1: has valid entries
+        topk_indices_case2 = paddle.full([b, sq, topk], -1, dtype="int32")
+        topk_indices_case2[0, 1, 0] = 5
+        topk_indices_case2[0, 1, 1] = 6
+        topk_indices_case2 = topk_indices_case2.contiguous()
+        tl_out2 = csa_attn_target_reducesum(
+            query_mla2, key_comp_mla, topk_indices_case2, softmax_scale
+        )
+        # Row 0 must be all-zero
+        self.assertTrue(
+            (tl_out2[0, 0].cast("float32").abs() < 1e-6).all().item(),
+            "all-invalid row should be zero",
+        )
+        # Row 1 must sum to 1
+        row1_sum = tl_out2[0, 1].sum().item()
+        self.assertAlmostEqual(
+            row1_sum, 1.0, places=4, msg=f"single-row L1 violated: {row1_sum}"
+        )
+
+        # --- Case 3: single valid entry → must be exactly 1.0 ---
+        sq = 2
+        query_mla3 = paddle.randn([b, sq, np_, hn]).astype("bfloat16").detach()
+        topk_indices_case3 = paddle.full([b, sq, topk], -1, dtype="int32")
+        topk_indices_case3[0, 0, 0] = 3  # only 1 valid per row
+        topk_indices_case3[0, 1, 0] = 7
+        topk_indices_case3 = topk_indices_case3.contiguous()
+        tl_out3 = csa_attn_target_reducesum(
+            query_mla3, key_comp_mla, topk_indices_case3, softmax_scale
+        )
+        # The single valid slot must have probability = 1.0
+        self.assertAlmostEqual(
+            tl_out3[0, 0, 0].item(),
+            1.0,
+            places=4,
+            msg="single-valid-entry prob should be 1.0",
+        )
+        self.assertAlmostEqual(
+            tl_out3[0, 1, 0].item(),
+            1.0,
+            places=4,
+            msg="single-valid-entry prob should be 1.0",
+        )
+        # All other slots must be 0
+        self.assertTrue(
+            (tl_out3[0, 0, 1:].cast("float32").abs() < 1e-6).all().item(),
+            "non-valid slots should be zero",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/custom_ops/test_tilelang_csa_indexer.py
+++ b/tests/single_card_tests/custom_ops/test_tilelang_csa_indexer.py
@@ -1067,5 +1067,854 @@ class TestCSAAttnTargetReducesum(unittest.TestCase):
         )
 
 
+# =========================================================================
+# Input validation tests (cover error-raising branches in wrapper/interface)
+# =========================================================================
+
+
+class TestCSAIndexerInputValidation(unittest.TestCase):
+    """Cover TypeError/ValueError branches in csa_indexer.py validation."""
+
+    def test_validate_indexer_inputs_non_tensor_q(self):
+        from paddlefleet.tilelang_ops.indexer.csa_indexer import (
+            _validate_indexer_inputs,
+        )
+
+        k = paddle.empty([1, 4, 16])
+        w = paddle.empty([1, 8, 16])
+        with self.assertRaises(TypeError):
+            _validate_indexer_inputs("not_a_tensor", k, w)
+
+    def test_validate_indexer_inputs_non_tensor_k(self):
+        from paddlefleet.tilelang_ops.indexer.csa_indexer import (
+            _validate_indexer_inputs,
+        )
+
+        q = paddle.empty([1, 8, 16, 32])
+        w = paddle.empty([1, 8, 16])
+        with self.assertRaises(TypeError):
+            _validate_indexer_inputs(q, [1, 2, 3], w)
+
+    def test_validate_indexer_inputs_non_tensor_w(self):
+        from paddlefleet.tilelang_ops.indexer.csa_indexer import (
+            _validate_indexer_inputs,
+        )
+
+        q = paddle.empty([1, 8, 16, 32])
+        k = paddle.empty([1, 4, 32])
+        with self.assertRaises(TypeError):
+            _validate_indexer_inputs(q, k, None)
+
+    def test_validate_indexer_inputs_wrong_q_ndim(self):
+        from paddlefleet.tilelang_ops.indexer.csa_indexer import (
+            _validate_indexer_inputs,
+        )
+
+        q = paddle.empty([1, 8, 16])  # 3D instead of 4D
+        k = paddle.empty([1, 4, 16])
+        w = paddle.empty([1, 8, 16])
+        with self.assertRaises(ValueError):
+            _validate_indexer_inputs(q, k, w)
+
+    def test_validate_indexer_inputs_wrong_k_ndim(self):
+        from paddlefleet.tilelang_ops.indexer.csa_indexer import (
+            _validate_indexer_inputs,
+        )
+
+        q = paddle.empty([1, 8, 16, 32])
+        k = paddle.empty([1, 4, 32, 1])  # 4D instead of 3D
+        w = paddle.empty([1, 8, 16])
+        with self.assertRaises(ValueError):
+            _validate_indexer_inputs(q, k, w)
+
+    def test_validate_indexer_inputs_wrong_w_ndim(self):
+        from paddlefleet.tilelang_ops.indexer.csa_indexer import (
+            _validate_indexer_inputs,
+        )
+
+        q = paddle.empty([1, 8, 16, 32])
+        k = paddle.empty([1, 4, 32])
+        w = paddle.empty([1, 8])  # 2D instead of 3D
+        with self.assertRaises(ValueError):
+            _validate_indexer_inputs(q, k, w)
+
+    def test_validate_indexer_inputs_shape_mismatch(self):
+        from paddlefleet.tilelang_ops.indexer.csa_indexer import (
+            _validate_indexer_inputs,
+        )
+
+        q = paddle.empty([1, 8, 16, 32])
+        k = paddle.empty([1, 4, 32])
+        w = paddle.empty([1, 8, 8])  # heads=8 != q heads=16
+        with self.assertRaises(ValueError):
+            _validate_indexer_inputs(q, k, w)
+
+    def test_validate_topk_and_grad_non_tensor_topk(self):
+        from paddlefleet.tilelang_ops.indexer.csa_indexer import (
+            _validate_topk_and_grad,
+        )
+
+        q = paddle.empty([1, 8, 16, 32])
+        grad = paddle.empty([1, 8, 4])
+        with self.assertRaises(TypeError):
+            _validate_topk_and_grad(q, "not_tensor", grad)
+
+    def test_validate_topk_and_grad_non_tensor_grad(self):
+        from paddlefleet.tilelang_ops.indexer.csa_indexer import (
+            _validate_topk_and_grad,
+        )
+
+        q = paddle.empty([1, 8, 16, 32])
+        topk = paddle.empty([1, 8, 4], dtype="int32")
+        with self.assertRaises(TypeError):
+            _validate_topk_and_grad(q, topk, 42)
+
+    def test_validate_topk_and_grad_wrong_topk_ndim(self):
+        from paddlefleet.tilelang_ops.indexer.csa_indexer import (
+            _validate_topk_and_grad,
+        )
+
+        q = paddle.empty([1, 8, 16, 32])
+        topk = paddle.empty([1, 8, 4, 1], dtype="int32")  # 4D
+        grad = paddle.empty([1, 8, 4])
+        with self.assertRaises(ValueError):
+            _validate_topk_and_grad(q, topk, grad)
+
+    def test_validate_topk_and_grad_wrong_grad_ndim(self):
+        from paddlefleet.tilelang_ops.indexer.csa_indexer import (
+            _validate_topk_and_grad,
+        )
+
+        q = paddle.empty([1, 8, 16, 32])
+        topk = paddle.empty([1, 8, 4], dtype="int32")
+        grad = paddle.empty([1, 8])  # 2D
+        with self.assertRaises(ValueError):
+            _validate_topk_and_grad(q, topk, grad)
+
+    def test_validate_topk_and_grad_shape_mismatch(self):
+        from paddlefleet.tilelang_ops.indexer.csa_indexer import (
+            _validate_topk_and_grad,
+        )
+
+        q = paddle.empty([1, 8, 16, 32])
+        topk = paddle.empty([1, 8, 4], dtype="int32")
+        grad = paddle.empty([1, 8, 3])  # topk_dim=3 != 4
+        with self.assertRaises(ValueError):
+            _validate_topk_and_grad(q, topk, grad)
+
+    def test_validate_topk_and_grad_batch_mismatch(self):
+        from paddlefleet.tilelang_ops.indexer.csa_indexer import (
+            _validate_topk_and_grad,
+        )
+
+        q = paddle.empty([1, 8, 16, 32])
+        topk = paddle.empty([2, 8, 4], dtype="int32")  # batch=2 != 1
+        grad = paddle.empty([2, 8, 4])
+        with self.assertRaises(ValueError):
+            _validate_topk_and_grad(q, topk, grad)
+
+    def test_prepare_forward_inputs_zero_topk(self):
+        from paddlefleet.tilelang_ops.indexer.csa_indexer import (
+            _prepare_forward_inputs,
+        )
+
+        q = paddle.empty([1, 8, 16, 32])
+        k = paddle.empty([1, 4, 32])
+        w = paddle.empty([1, 8, 16])
+        with self.assertRaises(ValueError):
+            _prepare_forward_inputs(q, k, w, topk_effective=0)
+
+    def test_prepare_forward_inputs_casts_weights(self):
+        from paddlefleet.tilelang_ops.indexer.csa_indexer import (
+            _prepare_forward_inputs,
+        )
+
+        q = paddle.empty([1, 8, 16, 32])
+        k = paddle.empty([1, 4, 32])
+        w = paddle.empty([1, 8, 16], dtype="float16")  # not fp32
+        _, _, w_out, _ = _prepare_forward_inputs(q, k, w, topk_effective=2)
+        self.assertEqual(w_out.dtype, paddle.float32)
+
+    def test_prepare_backward_inputs_casts_types(self):
+        from paddlefleet.tilelang_ops.indexer.csa_indexer import (
+            _prepare_backward_inputs,
+        )
+
+        q = paddle.empty([1, 8, 16, 32])
+        k = paddle.empty([1, 4, 32])
+        w = paddle.empty([1, 8, 16], dtype="float16")
+        topk = paddle.empty([1, 8, 2], dtype="int64")  # not int32
+        grad = paddle.empty([1, 8, 2], dtype="float16")  # not fp32
+        _, w_out, _, topk_out, grad_out = _prepare_backward_inputs(
+            q, w, k, topk, grad
+        )
+        self.assertEqual(w_out.dtype, paddle.float32)
+        self.assertEqual(topk_out.dtype, paddle.int32)
+        self.assertEqual(grad_out.dtype, paddle.float32)
+
+    def test_csa_attn_target_wrapper_type_checks(self):
+        """Cover TypeError branches in csa_attn_target_reducesum wrapper."""
+        from paddlefleet.tilelang_ops.indexer.csa_indexer import (
+            csa_attn_target_reducesum,
+        )
+
+        q = paddle.empty([1, 4, 8, 32])
+        k = paddle.empty([1, 2, 32])
+        topk = paddle.empty([1, 4, 2], dtype="int32")
+
+        with self.assertRaises(TypeError):
+            csa_attn_target_reducesum("bad", k, topk, 1.0)
+        with self.assertRaises(TypeError):
+            csa_attn_target_reducesum(q, "bad", topk, 1.0)
+        with self.assertRaises(TypeError):
+            csa_attn_target_reducesum(q, k, "bad", 1.0)
+
+    def test_csa_attn_target_wrapper_ndim_checks(self):
+        """Cover ValueError branches for ndim in csa_attn_target_reducesum."""
+        from paddlefleet.tilelang_ops.indexer.csa_indexer import (
+            csa_attn_target_reducesum,
+        )
+
+        with self.assertRaises(ValueError):
+            csa_attn_target_reducesum(
+                paddle.empty([1, 4, 32]),  # 3D query
+                paddle.empty([1, 2, 32]),
+                paddle.empty([1, 4, 2], dtype="int32"),
+                1.0,
+            )
+        with self.assertRaises(ValueError):
+            csa_attn_target_reducesum(
+                paddle.empty([1, 4, 8, 32]),
+                paddle.empty([1, 2, 32, 1]),  # 4D key
+                paddle.empty([1, 4, 2], dtype="int32"),
+                1.0,
+            )
+        with self.assertRaises(ValueError):
+            csa_attn_target_reducesum(
+                paddle.empty([1, 4, 8, 32]),
+                paddle.empty([1, 2, 32]),
+                paddle.empty([1, 4, 2, 1], dtype="int32"),  # 4D topk
+                1.0,
+            )
+
+    def test_csa_attn_target_wrapper_batch_mismatch(self):
+        from paddlefleet.tilelang_ops.indexer.csa_indexer import (
+            csa_attn_target_reducesum,
+        )
+
+        with self.assertRaises(ValueError):
+            csa_attn_target_reducesum(
+                paddle.empty([1, 4, 8, 32]),
+                paddle.empty([2, 2, 32]),  # batch=2
+                paddle.empty([1, 4, 2], dtype="int32"),
+                1.0,
+            )
+
+    def test_csa_attn_target_wrapper_seq_mismatch(self):
+        from paddlefleet.tilelang_ops.indexer.csa_indexer import (
+            csa_attn_target_reducesum,
+        )
+
+        with self.assertRaises(ValueError):
+            csa_attn_target_reducesum(
+                paddle.empty([1, 4, 8, 32]),
+                paddle.empty([1, 2, 32]),
+                paddle.empty([1, 3, 2], dtype="int32"),  # seq=3 != 4
+                1.0,
+            )
+
+    def test_csa_attn_target_wrapper_dim_mismatch(self):
+        from paddlefleet.tilelang_ops.indexer.csa_indexer import (
+            csa_attn_target_reducesum,
+        )
+
+        with self.assertRaises(ValueError):
+            csa_attn_target_reducesum(
+                paddle.empty([1, 4, 8, 32]),
+                paddle.empty([1, 2, 16]),  # dim=16 != 32
+                paddle.empty([1, 4, 2], dtype="int32"),
+                1.0,
+            )
+
+
+class TestCSAIndexerFwdInterfaceValidation(unittest.TestCase):
+    """Cover error branches in csa_indexer_fwd.py interface validation."""
+
+    def test_rejects_non_contiguous(self):
+        from paddlefleet.tilelang_ops.indexer.csa_indexer_fwd import (
+            _validate_interface_inputs,
+        )
+
+        q = paddle.empty([2, 4, 8, 16], dtype="bfloat16").transpose(
+            [0, 2, 1, 3]
+        )  # non-contiguous
+        k = paddle.empty([2, 2, 16], dtype="bfloat16")
+        w = paddle.empty([2, 4, 8], dtype="float32")
+        with self.assertRaises(ValueError):
+            _validate_interface_inputs(q, k, w, 2, 32, 0)
+
+    def test_rejects_wrong_ndim(self):
+        from paddlefleet.tilelang_ops.indexer.csa_indexer_fwd import (
+            _validate_interface_inputs,
+        )
+
+        q = paddle.empty([2, 4, 128], dtype="bfloat16")  # 3D
+        k = paddle.empty([2, 2, 128], dtype="bfloat16")
+        w = paddle.empty([2, 4, 64], dtype="float32")
+        with self.assertRaises(ValueError):
+            _validate_interface_inputs(q, k, w, 2, 32, 0)
+
+    def test_rejects_heads_not_multiple_of_8(self):
+        from paddlefleet.tilelang_ops.indexer.csa_indexer_fwd import (
+            _validate_interface_inputs,
+        )
+
+        q = paddle.empty([1, 4, 7, 16], dtype="bfloat16")  # heads=7
+        k = paddle.empty([1, 2, 16], dtype="bfloat16")
+        w = paddle.empty([1, 4, 7], dtype="float32")
+        with self.assertRaises(ValueError):
+            _validate_interface_inputs(q, k, w, 2, 32, 0)
+
+    def test_rejects_zero_topk(self):
+        from paddlefleet.tilelang_ops.indexer.csa_indexer_fwd import (
+            _validate_interface_inputs,
+        )
+
+        q = paddle.empty([1, 4, 8, 16], dtype="bfloat16")
+        k = paddle.empty([1, 2, 16], dtype="bfloat16")
+        w = paddle.empty([1, 4, 8], dtype="float32")
+        with self.assertRaises(ValueError):
+            _validate_interface_inputs(q, k, w, 0, 32, 0)
+
+    def test_rejects_nonzero_num_stages(self):
+        from paddlefleet.tilelang_ops.indexer.csa_indexer_fwd import (
+            _validate_interface_inputs,
+        )
+
+        q = paddle.empty([1, 4, 8, 16], dtype="bfloat16")
+        k = paddle.empty([1, 2, 16], dtype="bfloat16")
+        w = paddle.empty([1, 4, 8], dtype="float32")
+        with self.assertRaises(ValueError):
+            _validate_interface_inputs(q, k, w, 2, 32, 1)
+
+    def test_tilelang_dtype_fp16(self):
+        from paddlefleet.tilelang_ops.indexer.csa_indexer_fwd import (
+            _tilelang_dtype,
+        )
+
+        t = paddle.empty([1], dtype="float16")
+        self.assertEqual(_tilelang_dtype(t), "float16")
+
+    def test_tilelang_dtype_rejects_fp32(self):
+        from paddlefleet.tilelang_ops.indexer.csa_indexer_fwd import (
+            _tilelang_dtype,
+        )
+
+        t = paddle.empty([1], dtype="float32")
+        with self.assertRaises(TypeError):
+            _tilelang_dtype(t)
+
+    def test_next_power_of_2_edge_cases(self):
+        from paddlefleet.tilelang_ops.indexer.csa_indexer_fwd import (
+            _next_power_of_2,
+        )
+
+        self.assertEqual(_next_power_of_2(0), 1)
+        self.assertEqual(_next_power_of_2(1), 1)
+        self.assertEqual(_next_power_of_2(3), 4)
+        self.assertEqual(_next_power_of_2(32), 32)
+        self.assertEqual(_next_power_of_2(33), 64)
+
+
+class TestCSAIndexerBwdInterfaceValidation(unittest.TestCase):
+    """Cover error branches in csa_indexer_bwd.py interface validation."""
+
+    def test_rejects_non_contiguous(self):
+        from paddlefleet.tilelang_ops.indexer.csa_indexer_bwd import (
+            _validate_interface_inputs,
+        )
+
+        q = paddle.empty([1, 4, 8, 16], dtype="bfloat16").transpose(
+            [0, 2, 1, 3]
+        )
+        w = paddle.empty([1, 4, 8], dtype="float32")
+        k = paddle.empty([1, 2, 16], dtype="bfloat16")
+        topk = paddle.empty([1, 4, 2], dtype="int32")
+        grad = paddle.empty([1, 4, 2], dtype="float32")
+        with self.assertRaises(ValueError):
+            _validate_interface_inputs(q, w, k, topk, grad, 32, 0)
+
+    def test_rejects_wrong_ndim(self):
+        from paddlefleet.tilelang_ops.indexer.csa_indexer_bwd import (
+            _validate_interface_inputs,
+        )
+
+        q = paddle.empty([1, 4, 128], dtype="bfloat16")  # 3D
+        w = paddle.empty([1, 4, 64], dtype="float32")
+        k = paddle.empty([1, 2, 128], dtype="bfloat16")
+        topk = paddle.empty([1, 4, 2], dtype="int32")
+        grad = paddle.empty([1, 4, 2], dtype="float32")
+        with self.assertRaises(ValueError):
+            _validate_interface_inputs(q, w, k, topk, grad, 32, 0)
+
+    def test_rejects_heads_mismatch(self):
+        from paddlefleet.tilelang_ops.indexer.csa_indexer_bwd import (
+            _validate_interface_inputs,
+        )
+
+        q = paddle.empty([1, 4, 8, 16], dtype="bfloat16")
+        w = paddle.empty([1, 4, 16], dtype="float32")  # heads=16 != 8
+        k = paddle.empty([1, 2, 16], dtype="bfloat16")
+        topk = paddle.empty([1, 4, 2], dtype="int32")
+        grad = paddle.empty([1, 4, 2], dtype="float32")
+        with self.assertRaises(ValueError):
+            _validate_interface_inputs(q, w, k, topk, grad, 32, 0)
+
+    def test_rejects_dim_mismatch(self):
+        from paddlefleet.tilelang_ops.indexer.csa_indexer_bwd import (
+            _validate_interface_inputs,
+        )
+
+        q = paddle.empty([1, 4, 8, 16], dtype="bfloat16")
+        w = paddle.empty([1, 4, 8], dtype="float32")
+        k = paddle.empty([1, 2, 32], dtype="bfloat16")  # dim=32 != 16
+        topk = paddle.empty([1, 4, 2], dtype="int32")
+        grad = paddle.empty([1, 4, 2], dtype="float32")
+        with self.assertRaises(ValueError):
+            _validate_interface_inputs(q, w, k, topk, grad, 32, 0)
+
+    def test_rejects_topk_mismatch(self):
+        from paddlefleet.tilelang_ops.indexer.csa_indexer_bwd import (
+            _validate_interface_inputs,
+        )
+
+        q = paddle.empty([1, 4, 8, 16], dtype="bfloat16")
+        w = paddle.empty([1, 4, 8], dtype="float32")
+        k = paddle.empty([1, 2, 16], dtype="bfloat16")
+        topk = paddle.empty([1, 4, 2], dtype="int32")
+        grad = paddle.empty([1, 4, 3], dtype="float32")  # topk=3 != 2
+        with self.assertRaises(ValueError):
+            _validate_interface_inputs(q, w, k, topk, grad, 32, 0)
+
+    def test_rejects_nonzero_num_stages(self):
+        from paddlefleet.tilelang_ops.indexer.csa_indexer_bwd import (
+            _validate_interface_inputs,
+        )
+
+        q = paddle.empty([1, 4, 8, 16], dtype="bfloat16")
+        w = paddle.empty([1, 4, 8], dtype="float32")
+        k = paddle.empty([1, 2, 16], dtype="bfloat16")
+        topk = paddle.empty([1, 4, 2], dtype="int32")
+        grad = paddle.empty([1, 4, 2], dtype="float32")
+        with self.assertRaises(ValueError):
+            _validate_interface_inputs(q, w, k, topk, grad, 32, 1)
+
+    def test_tilelang_dtype_fp16(self):
+        from paddlefleet.tilelang_ops.indexer.csa_indexer_bwd import (
+            _tilelang_dtype,
+        )
+
+        t = paddle.empty([1], dtype="float16")
+        self.assertEqual(_tilelang_dtype(t), "float16")
+
+    def test_tilelang_dtype_rejects_fp32(self):
+        from paddlefleet.tilelang_ops.indexer.csa_indexer_bwd import (
+            _tilelang_dtype,
+        )
+
+        t = paddle.empty([1], dtype="float32")
+        with self.assertRaises(TypeError):
+            _tilelang_dtype(t)
+
+
+class TestCSAAttnTargetInterfaceValidation(unittest.TestCase):
+    """Cover error branches in csa_attn_target.py interface validation."""
+
+    def test_rejects_non_contiguous(self):
+        from paddlefleet.tilelang_ops.indexer.csa_attn_target import (
+            _validate_interface_inputs,
+        )
+
+        q = paddle.empty([1, 4, 8, 32], dtype="bfloat16").transpose(
+            [0, 2, 1, 3]
+        )
+        k = paddle.empty([1, 2, 32], dtype="bfloat16")
+        topk = paddle.empty([1, 4, 2], dtype="int32")
+        with self.assertRaises(ValueError):
+            _validate_interface_inputs(q, k, topk, 32, 0)
+
+    def test_rejects_wrong_ndim(self):
+        from paddlefleet.tilelang_ops.indexer.csa_attn_target import (
+            _validate_interface_inputs,
+        )
+
+        q = paddle.empty([1, 4, 32], dtype="bfloat16")  # 3D
+        k = paddle.empty([1, 2, 32], dtype="bfloat16")
+        topk = paddle.empty([1, 4, 2], dtype="int32")
+        with self.assertRaises(ValueError):
+            _validate_interface_inputs(q, k, topk, 32, 0)
+
+    def test_rejects_dim_mismatch(self):
+        from paddlefleet.tilelang_ops.indexer.csa_attn_target import (
+            _validate_interface_inputs,
+        )
+
+        q = paddle.empty([1, 4, 8, 32], dtype="bfloat16")
+        k = paddle.empty([1, 2, 16], dtype="bfloat16")  # dim=16 != 32
+        topk = paddle.empty([1, 4, 2], dtype="int32")
+        with self.assertRaises(ValueError):
+            _validate_interface_inputs(q, k, topk, 32, 0)
+
+    def test_rejects_batch_mismatch(self):
+        from paddlefleet.tilelang_ops.indexer.csa_attn_target import (
+            _validate_interface_inputs,
+        )
+
+        q = paddle.empty([1, 4, 8, 32], dtype="bfloat16")
+        k = paddle.empty([2, 2, 32], dtype="bfloat16")  # batch=2
+        topk = paddle.empty([1, 4, 2], dtype="int32")
+        with self.assertRaises(ValueError):
+            _validate_interface_inputs(q, k, topk, 32, 0)
+
+    def test_rejects_seq_mismatch(self):
+        from paddlefleet.tilelang_ops.indexer.csa_attn_target import (
+            _validate_interface_inputs,
+        )
+
+        q = paddle.empty([1, 4, 8, 32], dtype="bfloat16")
+        k = paddle.empty([1, 2, 32], dtype="bfloat16")
+        topk = paddle.empty([1, 3, 2], dtype="int32")  # seq=3 != 4
+        with self.assertRaises(ValueError):
+            _validate_interface_inputs(q, k, topk, 32, 0)
+
+    def test_rejects_heads_not_multiple_of_64(self):
+        from paddlefleet.tilelang_ops.indexer.csa_attn_target import (
+            _validate_interface_inputs,
+        )
+
+        q = paddle.empty([1, 4, 65, 32], dtype="bfloat16")  # heads=65
+        k = paddle.empty([1, 2, 32], dtype="bfloat16")
+        topk = paddle.empty([1, 4, 2], dtype="int32")
+        with self.assertRaises(ValueError):
+            _validate_interface_inputs(q, k, topk, 32, 0)
+
+    def test_rejects_nonzero_num_stages(self):
+        from paddlefleet.tilelang_ops.indexer.csa_attn_target import (
+            _validate_interface_inputs,
+        )
+
+        q = paddle.empty([1, 4, 8, 32], dtype="bfloat16")
+        k = paddle.empty([1, 2, 32], dtype="bfloat16")
+        topk = paddle.empty([1, 4, 2], dtype="int32")
+        with self.assertRaises(ValueError):
+            _validate_interface_inputs(q, k, topk, 32, 1)
+
+    def test_tilelang_dtype_fp16(self):
+        from paddlefleet.tilelang_ops.indexer.csa_attn_target import (
+            _tilelang_dtype,
+        )
+
+        t = paddle.empty([1], dtype="float16")
+        self.assertEqual(_tilelang_dtype(t), "float16")
+
+    def test_tilelang_dtype_rejects_fp32(self):
+        from paddlefleet.tilelang_ops.indexer.csa_attn_target import (
+            _tilelang_dtype,
+        )
+
+        t = paddle.empty([1], dtype="float32")
+        with self.assertRaises(TypeError):
+            _tilelang_dtype(t)
+
+
+# =========================================================================
+# TileLangCSAIndexerLossAutoScaler backward path test
+# =========================================================================
+
+
+@unittest.skipUnless(
+    paddle.device.is_compiled_with_cuda()
+    and paddle.device.cuda.device_count() > 0,
+    "TileLang CSA Indexer kernel requires CUDA",
+)
+class TestTileLangCSAIndexerLossAutoScaler(unittest.TestCase):
+    """Test that TileLangCSAIndexerLossAutoScaler correctly backprops.
+
+    This covers the backward() method of TileLangCSAIndexerLossAutoScaler
+    (csa_attention.py lines 609-646) which hooks indexer loss gradients into
+    the main output's backward graph.
+    """
+
+    def test_auto_scaler_backward_produces_correct_grads(self):
+        from paddlefleet.transformer.csa_attention import (
+            TileLangCSAIndexerLossAutoScaler,
+        )
+        from paddlefleet.transformer.dsa_attention import (
+            DSAIndexerLossAutoScaler,
+        )
+
+        paddle.set_device("gpu")
+        b, sq, h_i, d_i, sk = 1, 16, 64, 128, 4
+        ratio = 4
+        loss_coeff = 1.0
+
+        paddle.seed(5050)
+        index_q = paddle.randn([b, sq, h_i, d_i]).astype("bfloat16")
+        index_k_comp = paddle.randn([b, sk, d_i]).astype("bfloat16")
+        weights = paddle.randn([b, sq, h_i]).astype("float32")
+
+        # Get topk and compute target to build the state tuple
+        from paddlefleet.tilelang_ops import csa_indexer_topk_fwd
+
+        topk_indices, topk_probs = csa_indexer_topk_fwd(
+            index_q,
+            index_k_comp,
+            weights,
+            ratio=ratio,
+            topk_effective=sk,
+        )
+
+        # Simulate target (random normalized distribution)
+        paddle.seed(5051)
+        target_raw = paddle.rand([b, sq, sk])
+        target_raw = paddle.where(
+            topk_indices >= 0, target_raw, paddle.zeros_like(target_raw)
+        )
+        target = target_raw / target_raw.sum(axis=-1, keepdim=True).clip(
+            min=1e-10
+        )
+
+        # Make non-leaf tensors by passing through identity ops.
+        # Paddle PyLayer doesn't allow inplace strategy on leaf vars.
+        output_leaf = paddle.randn([b, sq, 128]).astype("bfloat16")
+        output_leaf.stop_gradient = False
+        output = output_leaf + 0  # non-leaf
+
+        index_q_leaf = index_q.detach()
+        index_q_leaf.stop_gradient = False
+        index_q_d = index_q_leaf + 0  # non-leaf
+
+        weights_leaf = weights.detach()
+        weights_leaf.stop_gradient = False
+        weights_d = weights_leaf + 0  # non-leaf
+
+        index_k_leaf = index_k_comp.detach()
+        index_k_leaf.stop_gradient = False
+        index_k_d = index_k_leaf + 0  # non-leaf
+
+        DSAIndexerLossAutoScaler._main_loss_backward_scale = None
+        result = TileLangCSAIndexerLossAutoScaler.apply(
+            output,
+            index_q_d,
+            weights_d,
+            index_k_d,
+            topk_indices.detach(),
+            topk_probs.detach(),
+            target.detach(),
+            loss_coeff,
+        )
+        # Backward through the auto-scaler
+        result.sum().backward()
+
+        # Verify: output grad should be passed through (identity)
+        self.assertTrue(
+            paddle.allclose(
+                output_leaf.grad.cast("float32"),
+                paddle.ones_like(output_leaf).cast("float32"),
+                atol=1e-5,
+            ).item(),
+            "output gradient should be ones (identity pass-through)",
+        )
+        # Verify: indexer param grads should be non-zero
+        self.assertGreater(
+            index_q_leaf.grad.cast("float32").abs().max().item(),
+            0.0,
+            "index_q grad should be non-zero",
+        )
+        self.assertGreater(
+            weights_leaf.grad.cast("float32").abs().max().item(),
+            0.0,
+            "weights grad should be non-zero",
+        )
+        self.assertGreater(
+            index_k_leaf.grad.cast("float32").abs().max().item(),
+            0.0,
+            "index_k grad should be non-zero",
+        )
+        # Verify: no NaN/Inf
+        for name, g in [
+            ("dQ", index_q_leaf.grad),
+            ("dW", weights_leaf.grad),
+            ("dK", index_k_leaf.grad),
+        ]:
+            self.assertTrue(
+                paddle.isfinite(g.cast("float32")).all().item(),
+                f"{name} contains NaN/Inf",
+            )
+
+
+# =========================================================================
+# TileLang forward-only (no loss) path in CompressedSparseAttention.forward()
+# =========================================================================
+
+
+@unittest.skipUnless(
+    paddle.device.is_compiled_with_cuda()
+    and paddle.device.cuda.device_count() > 0,
+    "TileLang CSA kernel requires CUDA",
+)
+class TestCSAForwardTileLangFwdOnlyPath(unittest.TestCase):
+    """Cover the TileLang fwd-only indexer path (csa_attention.py ~1209-1226).
+
+    When csa_tilelang_enable_indexer=True but training=False (or loss_coeff=0),
+    the code enters the fwd-only branch that calls csa_indexer_topk_fwd under
+    no_grad and uses its indices for sparse attention.
+    """
+
+    def test_fwd_only_tilelang_matches_paddle_indexer(self):
+        import types
+
+        from paddle import nn
+        from paddle.distributed.fleet.meta_parallel import LayerSpec
+
+        from paddlefleet.models.common.embeddings.rotary_pos_embedding import (
+            RotaryEmbedding,
+        )
+        from paddlefleet.transformer.csa_attention import (
+            CompressedSparseAttention,
+            CompressedSparseAttentionSublayersSpec,
+            Compressor,
+            CompressorSublayersSpec,
+            CSAIndexer,
+            CSAIndexerSublayersSpec,
+        )
+
+        paddle.set_device("gpu")
+
+        class _Lin(nn.Layer):
+            def __init__(self, input_size, output_size, **kwargs):
+                super().__init__()
+                self.weight = self.create_parameter(
+                    shape=[output_size, input_size],
+                    dtype="bfloat16",
+                    default_initializer=nn.initializer.Normal(std=0.02),
+                )
+
+            def forward(self, x):
+                return paddle.matmul(x, self.weight.T), None
+
+        class _Norm(nn.Layer):
+            def __init__(self, hidden_size=None, **kwargs):
+                super().__init__()
+                self.weight = self.create_parameter(
+                    shape=[hidden_size],
+                    dtype="float32",
+                    default_initializer=nn.initializer.Constant(1.0),
+                )
+
+            def forward(self, x):
+                return (
+                    x
+                    * paddle.rsqrt(x.square().mean(-1, keepdim=True) + 1e-5)
+                    * self.weight.cast(x.dtype)
+                )
+
+        head_dim, hidden_size, ratio = 64, 256, 4
+        config = types.SimpleNamespace(
+            num_attention_heads=8,
+            v_head_dim=head_dim,
+            hidden_size=hidden_size,
+            q_lora_rank=64,
+            qk_pos_emb_head_dim=32,
+            csa_window_size=64,
+            csa_compress_ratios=[ratio],
+            csa_dense_mode=False,
+            dsa_index_n_heads=16,
+            dsa_index_head_dim=32,
+            dsa_index_topk=16,
+            dsa_indexer_loss_coeff=0.0,
+            dsa_indexer_use_sparse_loss=False,
+            csa_tilelang_enable_indexer=True,
+            csa_tilelang_enable_sparse_attn=False,
+            init_method=None,
+            init_method_std=0.02,
+            layernorm_epsilon=1e-5,
+            num_hidden_layers=1,
+        )
+        rope = RotaryEmbedding(32, rotary_percent=1.0, rotary_base=160000)
+
+        comp_spec = CompressorSublayersSpec(
+            linear_wkv=_Lin, linear_wgate=_Lin, norm=_Norm
+        )
+        idx_comp_spec = CompressorSublayersSpec(
+            linear_wkv=_Lin, linear_wgate=_Lin, norm=_Norm
+        )
+        idx_spec = CSAIndexerSublayersSpec(
+            linear_wq_b=_Lin,
+            linear_weights_proj=_Lin,
+            compressor=LayerSpec(
+                layer=Compressor, sublayers_spec=idx_comp_spec
+            ),
+        )
+        attn_spec = CompressedSparseAttentionSublayersSpec(
+            compressor=LayerSpec(layer=Compressor, sublayers_spec=comp_spec),
+            indexer=LayerSpec(layer=CSAIndexer, sublayers_spec=idx_spec),
+        )
+
+        # Build two instances with same seed: one with tilelang, one without
+        paddle.seed(9999)
+        csa_tl = CompressedSparseAttention(
+            config=config,
+            sublayers_spec=attn_spec,
+            layer_number=1,
+            attn_mask_type=None,
+            attention_type="self",
+            k_channels=head_dim,
+            v_channels=head_dim,
+            compress_ratio=ratio,
+            rotary_pos_emb=rope,
+        )
+        csa_tl.eval()
+
+        config_no_tl = types.SimpleNamespace(**vars(config))
+        config_no_tl.csa_tilelang_enable_indexer = False
+
+        paddle.seed(9999)
+        csa_ref = CompressedSparseAttention(
+            config=config_no_tl,
+            sublayers_spec=attn_spec,
+            layer_number=1,
+            attn_mask_type=None,
+            attention_type="self",
+            k_channels=head_dim,
+            v_channels=head_dim,
+            compress_ratio=ratio,
+            rotary_pos_emb=rope,
+        )
+        csa_ref.eval()
+
+        # Run forward
+        b, sq = 1, 64
+        paddle.seed(8888)
+        query = paddle.randn([b, sq, 8, head_dim], dtype="bfloat16")
+        key = paddle.randn([b, sq, 1, head_dim], dtype="bfloat16")
+        x = paddle.randn([b, sq, hidden_size], dtype="bfloat16")
+        qr = paddle.randn([b, sq, 64], dtype="bfloat16")
+
+        out_tl = csa_tl(query, key, key, None, x=x, qr=qr)
+        out_ref = csa_ref(query, key, key, None, x=x, qr=qr)
+
+        # They should match (same indexer weights → same topk → same attention)
+        diff = (
+            (out_tl.cast("float32") - out_ref.cast("float32"))
+            .abs()
+            .max()
+            .item()
+        )
+        self.assertLess(
+            diff, 0.1, f"TileLang fwd-only vs Paddle mismatch: {diff}"
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/single_card_tests/custom_ops/test_tilelang_csa_indexer.py
+++ b/tests/single_card_tests/custom_ops/test_tilelang_csa_indexer.py
@@ -215,6 +215,50 @@ def _paddle_ref_csa_indexer_topk(q, k, weights, ratio, topk_effective):
 # =========================================================================
 
 
+class TestTileLangCSAIndexerInterfaceValidation(unittest.TestCase):
+    """Raw kernel interfaces should fail before TileLang JIT on bad inputs."""
+
+    def test_forward_rejects_shape_mismatch(self):
+        from paddlefleet.tilelang_ops.indexer.csa_indexer_fwd import (
+            csa_indexer_topk_fwd_interface,
+        )
+
+        q = paddle.empty([1, 4, 8, 16], dtype="bfloat16")
+        k = paddle.empty([2, 1, 16], dtype="bfloat16")
+        w = paddle.empty([1, 4, 8], dtype="float32")
+
+        with self.assertRaisesRegex(ValueError, "batch mismatch"):
+            csa_indexer_topk_fwd_interface(q, k, w, ratio=4, topk_effective=1)
+
+    def test_backward_rejects_topk_mismatch(self):
+        from paddlefleet.tilelang_ops.indexer.csa_indexer_bwd import (
+            csa_indexer_bwd_interface,
+        )
+
+        q = paddle.empty([1, 4, 8, 16], dtype="bfloat16")
+        k = paddle.empty([1, 1, 16], dtype="bfloat16")
+        w = paddle.empty([1, 4, 8], dtype="float32")
+        topk_indices = paddle.empty([1, 4, 2], dtype="int32")
+        grad_scores = paddle.empty([1, 4, 1], dtype="float32")
+
+        with self.assertRaisesRegex(ValueError, "topk mismatch"):
+            csa_indexer_bwd_interface(q, w, k, topk_indices, grad_scores)
+
+    def test_attn_target_rejects_non_power_of_two_dim(self):
+        from paddlefleet.tilelang_ops.indexer.csa_attn_target import (
+            csa_attn_target_reducesum_interface,
+        )
+
+        query = paddle.empty([1, 4, 8, 24], dtype="bfloat16")
+        key = paddle.empty([1, 1, 24], dtype="bfloat16")
+        topk_indices = paddle.empty([1, 4, 1], dtype="int32")
+
+        with self.assertRaisesRegex(ValueError, "power of 2"):
+            csa_attn_target_reducesum_interface(
+                query, key, topk_indices, softmax_scale=1.0
+            )
+
+
 class TestTileLangCSAIndexerKernel(unittest.TestCase):
     """Correctness of raw TileLang kernel interfaces."""
 

--- a/tests/single_card_tests/tensor_parallel/test_linear_grad_accum_detached_input.py
+++ b/tests/single_card_tests/tensor_parallel/test_linear_grad_accum_detached_input.py
@@ -1,0 +1,128 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression test: LinearWithGradAccumulationAndAsyncCommunication.backward
+honors Paddle's PyLayer contract when ``input.stop_gradient=True``.
+
+Background
+----------
+``LinearWithGradAccumulationAndAsyncCommunication`` (a ``paddle.autograd.Function``
+used internally by ``ColumnParallelLinear`` / ``RowParallelLinear``) is invoked
+through ``apply`` with three Tensor inputs ``(input, weight, bias)``.
+
+Paddle's PyLayer C++ contract (py_layer_node.cc) is strict:
+
+    For any Tensor input whose stop_gradient was True in forward, the
+    corresponding position in backward's return tuple MUST be None.
+
+Historically this Function computed ``grad_input = grad_output @ weight.t()``
+unconditionally and returned it at position 0, which violated the contract
+whenever a caller passed a detached tensor as ``input`` (e.g. for gradient
+isolation -- the CSA attention indexer training path: ``x_det = x.detach()``
+fed into the indexer's ``ColumnParallelLinear``). That triggered:
+
+    InvalidArgumentError: GradNodePyLayer_LinearWithGradAccumulationAndAsyncCommunication's
+    backward function should return None at 0 position, because it's forward
+    Tensor's stopgradient is true.
+
+(Note: PyTorch's ``torch.autograd.Function`` has a more lenient contract --
+returning a tensor for a non-grad input is silently discarded -- so the same
+code shape works in Megatron-LM upstream but crashed here until fixed.)
+
+What this test does
+-------------------
+Calls the Function directly with a detached input on CPU, no TP, no SP, no
+grad-fusion, and asserts that:
+
+  * ``backward()`` completes cleanly (no PyLayer contract error)
+  * the detached ``input`` does NOT receive a ``.grad``
+  * the trainable ``weight`` DOES receive a finite ``.grad``
+
+Failure modes guarded against:
+
+  * Future regression of the unconditional ``grad_input`` computation.
+  * Accidentally suppressing ``grad_weight`` when input is detached.
+"""
+
+import unittest
+
+import paddle
+
+from paddlefleet.tensor_parallel.layers import (
+    LinearWithGradAccumulationAndAsyncCommunication,
+)
+
+
+class TestLinearGradAccumDetachedInput(unittest.TestCase):
+    """Detached-input backward must skip grad_input but still produce grad_weight."""
+
+    def setUp(self):
+        paddle.seed(0)
+        self.s, self.b, self.h_in, self.h_out = 4, 2, 16, 8
+
+    def _make_inputs(self):
+        # Mimic a typical "gradient isolation" pattern: an upstream tensor is
+        # detached before being fed to a trainable Linear (so gradients should
+        # NOT flow back to the upstream graph through this linear).
+        x = paddle.randn([self.s, self.b, self.h_in], dtype="float32")
+        input_det = x.detach()
+        assert input_det.stop_gradient is True
+
+        # Trainable weight (matches a ColumnParallelLinear weight).
+        weight = paddle.randn([self.h_in, self.h_out], dtype="float32")
+        weight.stop_gradient = False
+        return input_det, weight
+
+    def test_backward_with_detached_input_completes_cleanly(self):
+        input_det, weight = self._make_inputs()
+
+        output = LinearWithGradAccumulationAndAsyncCommunication.apply(
+            input_det,
+            weight,
+            None,  # bias
+            False,  # gradient_accumulation_fusion
+            False,  # allreduce_dgrad
+            False,  # sequence_parallel
+            None,  # grad_output_buffer
+            0,  # wgrad_deferral_limit
+            None,  # tp_group
+        )
+
+        # Must NOT raise: backward must return None at position 0 since
+        # input_det.stop_gradient=True.
+        try:
+            output.sum().backward()
+        except Exception as e:
+            self.fail(
+                f"backward() raised {type(e).__name__}: {e}\n"
+                "Expected clean backward when input.stop_gradient=True; this "
+                "is a regression of the PyLayer contract fix."
+            )
+
+        # Detached input must not receive a gradient.
+        self.assertIsNone(
+            input_det.grad,
+            "input_det.grad must be None (input.stop_gradient was True)",
+        )
+        # Trainable weight must still receive a finite gradient.
+        self.assertIsNotNone(
+            weight.grad,
+            "weight.grad must be computed even when input is detached",
+        )
+        self.assertEqual(list(weight.grad.shape), [self.h_in, self.h_out])
+        self.assertTrue(paddle.isfinite(weight.grad).all().item())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/transformer/test_dsv4_hybrid_attention.py
+++ b/tests/single_card_tests/transformer/test_dsv4_hybrid_attention.py
@@ -26,6 +26,8 @@ from paddlefleet.models.gpt.gpt_layer_specs import (
 from paddlefleet.tilelang_ops import csa_sparse_attn
 from paddlefleet.transformer.csa_attention import (
     CompressedSparseAttention,
+    _resolve_csa_indexer_attn_topk_effective,
+    _resolve_csa_indexer_loss_topk_effective,
     _resolve_csa_tilelang_switch,
     get_compress_topk_idxs,
     get_window_topk_idxs,
@@ -204,6 +206,33 @@ class TestDSv4HybridConfigAndSpec(unittest.TestCase):
             ValueError, "csa_tilelang_enable_sparse_attn=True requires"
         ):
             _make_config(csa_tilelang_enable_sparse_attn=True)
+
+    def test_phase2_loss_topk_does_not_expand_attention_topk(self):
+        config = _make_config(
+            dsa_index_topk=2,
+        )
+        n_compressed = 8
+
+        self.assertEqual(
+            _resolve_csa_indexer_loss_topk_effective(
+                config, config.dsa_index_topk, n_compressed
+            ),
+            n_compressed,
+        )
+        self.assertEqual(
+            _resolve_csa_indexer_attn_topk_effective(
+                config.dsa_index_topk, n_compressed
+            ),
+            config.dsa_index_topk,
+        )
+
+        config.dsa_indexer_use_sparse_loss = True
+        self.assertEqual(
+            _resolve_csa_indexer_loss_topk_effective(
+                config, config.dsa_index_topk, n_compressed
+            ),
+            config.dsa_index_topk,
+        )
 
 
 class TestCSAIndexHelpers(unittest.TestCase):

--- a/tests/single_card_tests/transformer/test_dsv4_hybrid_attention.py
+++ b/tests/single_card_tests/transformer/test_dsv4_hybrid_attention.py
@@ -23,9 +23,10 @@ from paddlefleet.models.gpt.gpt_layer_specs import (
     get_gpt_layer_local_spec,
     get_gpt_mtp_layers_spec,
 )
-from paddlefleet.tilelang_ops import tilelang_compressed_sparse_attn
+from paddlefleet.tilelang_ops import csa_sparse_attn
 from paddlefleet.transformer.csa_attention import (
     CompressedSparseAttention,
+    _resolve_csa_tilelang_switch,
     get_compress_topk_idxs,
     get_window_topk_idxs,
     unfused_compressed_sparse_attn,
@@ -61,7 +62,9 @@ def _make_config(
     apply_rope_fusion=False,
     multi_latent_attention=True,
     num_nextn_predict_layers=0,
-    csa_sparse_attn_fusion=False,
+    csa_tilelang_backend=None,
+    csa_tilelang_enable_indexer=None,
+    csa_tilelang_enable_sparse_attn=None,
 ):
     if csa_compress_ratios is None:
         csa_compress_ratios = [0, 4, 128, 4]
@@ -102,7 +105,9 @@ def _make_config(
         attention_softmax_in_fp32=True,
         masked_softmax_fusion=False,
         softmax_type="vanilla",
-        csa_sparse_attn_fusion=csa_sparse_attn_fusion,
+        csa_tilelang_backend=csa_tilelang_backend,
+        csa_tilelang_enable_indexer=csa_tilelang_enable_indexer,
+        csa_tilelang_enable_sparse_attn=csa_tilelang_enable_sparse_attn,
     )
 
 
@@ -146,6 +151,59 @@ class TestDSv4HybridConfigAndSpec(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "is invalid"):
             _make_config(num_layers=1, csa_compress_ratios=[2])
+
+    def test_csa_tilelang_backend_switches_and_overrides(self):
+        paddle_config = _make_config()
+        self.assertFalse(
+            _resolve_csa_tilelang_switch(
+                paddle_config, "csa_tilelang_enable_indexer"
+            )
+        )
+        self.assertFalse(
+            _resolve_csa_tilelang_switch(
+                paddle_config, "csa_tilelang_enable_sparse_attn"
+            )
+        )
+
+        tilelang_config = _make_config(
+            csa_tilelang_backend="attention_paddle_compat"
+        )
+        self.assertTrue(
+            _resolve_csa_tilelang_switch(
+                tilelang_config, "csa_tilelang_enable_indexer"
+            )
+        )
+        self.assertTrue(
+            _resolve_csa_tilelang_switch(
+                tilelang_config, "csa_tilelang_enable_sparse_attn"
+            )
+        )
+
+        override_config = _make_config(
+            csa_tilelang_backend="attention_paddle_compat",
+            csa_tilelang_enable_indexer=False,
+            csa_tilelang_enable_sparse_attn=False,
+        )
+        self.assertFalse(
+            _resolve_csa_tilelang_switch(
+                override_config, "csa_tilelang_enable_indexer"
+            )
+        )
+        self.assertFalse(
+            _resolve_csa_tilelang_switch(
+                override_config, "csa_tilelang_enable_sparse_attn"
+            )
+        )
+
+        with self.assertRaisesRegex(
+            ValueError, "csa_tilelang_enable_indexer=True requires"
+        ):
+            _make_config(csa_tilelang_enable_indexer=True)
+
+        with self.assertRaisesRegex(
+            ValueError, "csa_tilelang_enable_sparse_attn=True requires"
+        ):
+            _make_config(csa_tilelang_enable_sparse_attn=True)
 
 
 class TestCSAIndexHelpers(unittest.TestCase):
@@ -359,7 +417,7 @@ class TestDSv4HybridFusedSparseAttention(unittest.TestCase):
             query.stop_gradient = False
             kv_full.stop_gradient = False
             attn_sink.stop_gradient = False
-            fused_out = tilelang_compressed_sparse_attn(
+            fused_out = csa_sparse_attn(
                 query, kv_full, attn_sink, topk_idxs, softmax_scale
             )
             fused_loss = fused_out.cast("float32").sum()

--- a/tests/single_card_tests/transformer/test_dsv4_hybrid_attention.py
+++ b/tests/single_card_tests/transformer/test_dsv4_hybrid_attention.py
@@ -26,12 +26,13 @@ from paddlefleet.models.gpt.gpt_layer_specs import (
 from paddlefleet.tilelang_ops import tilelang_compressed_sparse_attn
 from paddlefleet.transformer.csa_attention import (
     CompressedSparseAttention,
-    _get_doc_start,
     get_compress_topk_idxs,
     get_window_topk_idxs,
     unfused_compressed_sparse_attn,
 )
-from paddlefleet.transformer.dsa_attention import fused_qk_topk_naive
+from paddlefleet.transformer.dsa_attention import (
+    fused_qk_topk_naive,
+)
 from paddlefleet.transformer.dsv4_hybrid_attention import (
     DSv4HybridSelfAttention,
 )
@@ -148,72 +149,11 @@ class TestDSv4HybridConfigAndSpec(unittest.TestCase):
 
 
 class TestCSAIndexHelpers(unittest.TestCase):
-    def test_doc_start_accepts_1d_and_2d_masks(self):
-        mask_1d = paddle.to_tensor([4, 4, 4, 4, 8, 8, 8, 8], dtype="int64")
-        doc_start_1d = _get_doc_start(mask_1d, seqlen=8)
-        self.assertEqual(
-            doc_start_1d.numpy().tolist(), [0, 0, 0, 0, 4, 4, 4, 4]
-        )
-
-        mask_2d = paddle.stack([mask_1d, mask_1d])
-        doc_start_2d = _get_doc_start(mask_2d, seqlen=8)
-        self.assertEqual(
-            doc_start_2d.numpy().tolist(),
-            [[0, 0, 0, 0, 4, 4, 4, 4], [0, 0, 0, 0, 4, 4, 4, 4]],
-        )
-
-    def test_window_and_compress_indices_with_document_boundaries(self):
-        boundaries = paddle.to_tensor(
-            [[[[4], [4], [4], [4], [8], [8], [8], [8]]]], dtype="int64"
-        )
-
-        window = get_window_topk_idxs(
-            window_size=3,
-            batch_size=1,
-            seqlen=8,
-            attn_mask_startend_row_indices=boundaries,
-        )
-        self.assertEqual(
-            window.numpy().tolist()[0],
-            [
-                [0, -1, -1],
-                [0, 1, -1],
-                [0, 1, 2],
-                [1, 2, 3],
-                [4, -1, -1],
-                [4, 5, -1],
-                [4, 5, 6],
-                [5, 6, 7],
-            ],
-        )
-
-        compressed = get_compress_topk_idxs(
-            ratio=4,
-            batch_size=1,
-            seqlen=8,
-            offset=8,
-            attn_mask_startend_row_indices=boundaries,
-        )
-        self.assertEqual(
-            compressed.numpy().tolist()[0],
-            [
-                [-1, -1],
-                [-1, -1],
-                [-1, -1],
-                [8, -1],
-                [-1, -1],
-                [-1, -1],
-                [-1, -1],
-                [-1, 9],
-            ],
-        )
-
-    def test_window_and_compress_indices_without_document_boundaries(self):
+    def test_window_and_compress_indices(self):
         window = get_window_topk_idxs(
             window_size=3,
             batch_size=2,
             seqlen=4,
-            attn_mask_startend_row_indices=None,
         )
         self.assertEqual(list(window.shape), [2, 4, 3])
         self.assertEqual(
@@ -226,7 +166,6 @@ class TestCSAIndexHelpers(unittest.TestCase):
             batch_size=2,
             seqlen=8,
             offset=8,
-            attn_mask_startend_row_indices=None,
         )
         self.assertEqual(list(compressed.shape), [2, 8, 2])
         self.assertEqual(

--- a/tests/single_card_tests/transformer/test_fused_indexer_loss_detached_inputs.py
+++ b/tests/single_card_tests/transformer/test_fused_indexer_loss_detached_inputs.py
@@ -1,0 +1,164 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Negative-control test: FusedDSAIndexerLoss is NOT the source of the
+"backward should return None" PyLayer contract crash.
+
+Why this test exists
+--------------------
+``FusedDSAIndexerLoss.backward`` returns ``(grad_q, grad_weights, grad_k,
+None, None, None)`` for its 6 Tensor inputs ``(q, weights, k, query, key, mask)``.
+A natural worry is: if all 6 inputs are passed in with ``stop_gradient=True``,
+positions 0/1/2 would return non-None and violate Paddle's PyLayer contract
+(which requires ``None`` at any position whose forward input had
+``stop_gradient=True``).
+
+This test verifies that worry is unfounded. When every Tensor input is
+stop_gradient=True, the output ``loss`` itself ends up stop_gradient=True too,
+so ``loss.backward()`` is a no-op (no backward node fires) and no contract
+check is ever invoked. The test PASSES, demonstrating that this PyLayer is
+safe to call with all-detached inputs even with the current backward
+implementation.
+
+(The real source of the production "backward should return None at 0
+position" crash for the CSA indexer training path is the TP linear PyLayer
+``LinearWithGradAccumulationAndAsyncCommunication``; see the dedicated
+reproducer in tests/single_card_tests/tensor_parallel/.)
+
+Keep this test as a regression guard: if someone later changes
+FusedDSAIndexerLoss in a way that makes its output stop_gradient=False under
+all-detached inputs, the contract violation will surface and this test will
+fail loudly.
+"""
+
+import unittest
+
+import paddle
+
+from paddlefleet.transformer.dsa_attention import FusedDSAIndexerLoss
+
+
+class TestFusedDSAIndexerLossDetachedInputs(unittest.TestCase):
+    """Verify FusedDSAIndexerLoss is safe under all-detached Tensor inputs.
+
+    Setup mimics a hypothetical caller that detaches every Tensor input
+    before invoking ``FusedDSAIndexerLoss.apply``. Expected behavior:
+
+      * the returned ``loss`` is stop_gradient=True
+      * ``loss.backward()`` is a no-op (no backward node fires)
+      * none of the inputs receive ``.grad``
+
+    See module docstring for full rationale.
+    """
+
+    def setUp(self):
+        paddle.seed(0)
+        # Indexer dims
+        self.sq, self.sk = 8, 8
+        self.b = 2
+        self.h, self.d = 4, 32
+        # MLA dims
+        self.np, self.hn = 4, 64
+        self.topk = 4
+        self.softmax_scale = self.hn**-0.5
+
+    def _make_detached_inputs(self):
+        """Build inputs where every Tensor is stop_gradient=True.
+
+        Returns 6 tensors (q, weights, k, query, key, mask) so PyLayer sees
+        the same 6-tensor signature as the 6 returns from ``backward``.
+        """
+        q = paddle.randn(
+            [self.sq, self.b, self.h, self.d], dtype="float32"
+        ).detach()
+        weights = paddle.randn(
+            [self.sq, self.b, self.h], dtype="float32"
+        ).detach()
+        k = paddle.randn([self.sk, self.b, self.d], dtype="float32").detach()
+        query = paddle.randn(
+            [self.sq, self.b, self.np, self.hn], dtype="float32"
+        ).detach()
+        key = paddle.randn(
+            [self.sk, self.b, self.np, self.hn], dtype="float32"
+        ).detach()
+
+        # Sanity: every tensor input must be stop_gradient=True for this test
+        # to exercise the all-detached topology.
+        for name, t in [
+            ("q", q),
+            ("weights", weights),
+            ("k", k),
+            ("query", query),
+            ("key", key),
+        ]:
+            assert t.stop_gradient is True, (
+                f"{name} should be stop_gradient=True after detach()"
+            )
+
+        causal = paddle.triu(
+            paddle.full([self.sq, self.sk], float("-inf"), dtype="float32"),
+            diagonal=1,
+        )
+        mask = causal.unsqueeze(0).unsqueeze(0)  # [1, 1, sq, sk]
+
+        return q, weights, k, query, key, mask
+
+    def test_backward_with_all_detached_inputs_does_not_violate_pylayer_contract(
+        self,
+    ):
+        q, weights, k, query, key, mask = self._make_detached_inputs()
+
+        loss = FusedDSAIndexerLoss.apply(
+            q,
+            weights,
+            k,
+            query,
+            key,
+            self.softmax_scale,
+            self.topk,
+            1.0,
+            mask,
+            False,
+            None,
+        )
+
+        # When every Tensor input is stop_gradient=True, Paddle propagates
+        # stop_gradient=True onto the output, so backward() is a no-op and
+        # the PyLayer's backward implementation is never called -- hence no
+        # "should return None at X position" check is triggered.
+        try:
+            loss.backward()
+        except Exception as e:
+            self.fail(
+                "FusedDSAIndexerLoss.backward() with all-detached inputs raised "
+                f"{type(e).__name__}: {e}\n"
+                "Expected backward() to be a silent no-op (output should inherit "
+                "stop_gradient=True from all-detached inputs)."
+            )
+
+        # No .grad should have been written to any input.
+        self.assertIsNone(
+            q.grad, "q.grad must be None for stop_gradient=True input"
+        )
+        self.assertIsNone(
+            weights.grad,
+            "weights.grad must be None for stop_gradient=True input",
+        )
+        self.assertIsNone(
+            k.grad, "k.grad must be None for stop_gradient=True input"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
New features, Bug fixes

### Description
1. **Bug fix（`tensor_parallel/layers.py`）**：修复 `ColumnLinearWithGradAccum` PyLayer backward 的合约问题。当 forward 输入 `input.stop_gradient=True` 时，backward 对应位置必须返回 `None`（Paddle PyLayer 合约要求）。在 forward 缓存 `input_stop_gradient` 标志，在 backward 中跳过 `grad_input` 计算及输入侧通信（all_reduce / reduce_scatter）。

2. **新功能（`tilelang_ops/indexer/`）**：新增 DeepSeek V4 CSA 压缩索引器 TileLang 融合算子：
   - `csa_indexer_topk_fwd`：流式 top-k 前向，输出索引和 softmax 概率
   - `csa_indexer_bwd`：融合反向，计算 IndexQ / Weights / IndexKComp 梯度
   - `csa_attn_target_reducesum`：indexer KL loss 的 attention target 分布
   - 新增 `TileLangCSAIndexerLoss` PyLayer 将 fwd/bwd/loss 融合为单一算子

3. **集成（`transformer/csa_attention.py`）**：通过 `dsv4_tilelang_backend` / `dsv4_tilelang_enable_csa_indexer` / `dsv4_tilelang_enable_backward` 三个 TransformerConfig 字段控制 TileLang 路径启用。默认关闭，不影响现有行为。

4. **简化**：移除 `attn_mask_startend_row_indices` 多文档边界支持（目前 DSv4 场景下不使用）。