### PR TITLE
Support static subbatch (moe_subbatch_token_num_after_dispatch) with moe_deep_gemm=True

### DIFF
--- a/src/paddlefleet/transformer/moe/fp8_utils.py
+++ b/src/paddlefleet/transformer/moe/fp8_utils.py
@@ -321,6 +321,112 @@ def kitchen_gemm(
     return y
 
 
+class _PerExpertWeightView:
+    """A lightweight view into a single expert's slice of the stacked fp8 weight.
+
+    After offline fp8 quant, the original bf16 weight storage is cleared.
+    This view provides the same interface that ``_get_fp8_weight_and_scale``
+    expects (``fp8_weight_stacked``, ``fp8_scale_stacked``, etc.) by slicing
+    the parent's stacked fp8 tensors for a single expert.
+
+    The ``shape`` property reports ``[1, K, N]`` so that downstream code
+    (e.g., ``_get_fp8_weight_and_scale``) correctly infers ``num_expert = 1``.
+    """
+
+    def __init__(self, parent_weight, local_id, num_experts):
+        self._parent = parent_weight
+        self._local_id = local_id
+        self._num_experts = num_experts
+        self._shape = [1, *list(parent_weight.shape[1:])]
+
+    def _slice_stacked(self, attr_name):
+        """Slice a 2D stacked tensor [E*rows, cols] to this expert's rows."""
+        t = getattr(self._parent, attr_name, None)
+        if t is None:
+            return None
+        rows_per_expert = t.shape[0] // self._num_experts
+        start = self._local_id * rows_per_expert
+        return t._slice(start, start + rows_per_expert)
+
+    @property
+    def shape(self):
+        return self._shape
+
+    def __len__(self):
+        return self._shape[0]
+
+    @property
+    def dtype(self):
+        return self._parent.dtype
+
+    @property
+    def fp8_weight_stacked(self):
+        return self._slice_stacked("fp8_weight_stacked")
+
+    @property
+    def fp8_scale_stacked(self):
+        return self._slice_stacked("fp8_scale_stacked")
+
+    @property
+    def fp8_weight_stacked_transpose(self):
+        return self._slice_stacked("fp8_weight_stacked_transpose")
+
+    @property
+    def fp8_scale_stacked_transpose(self):
+        return self._slice_stacked("fp8_scale_stacked_transpose")
+
+    @property
+    def main_grad(self):
+        mg = getattr(self._parent, "main_grad", None)
+        if mg is None:
+            return None
+        return mg._slice(self._local_id, self._local_id + 1)
+
+    @main_grad.setter
+    def main_grad(self, value):
+        # When backward tries to allocate main_grad, ensure parent has it
+        if getattr(self._parent, "main_grad", None) is None:
+            self._parent.main_grad = paddle.zeros(
+                self._parent.shape, dtype=paddle.float32
+            )
+
+    @property
+    def grad(self):
+        g = self._parent.grad
+        if g is None:
+            return None
+        return g._slice(self._local_id, self._local_id + 1)
+
+    @grad.setter
+    def grad(self, value):
+        pass
+
+    def _apply_backward_hook(self):
+        if hasattr(self._parent, "_apply_backward_hook"):
+            self._parent._apply_backward_hook()
+
+    @property
+    def stop_gradient(self):
+        return self._parent.stop_gradient
+
+
+class _PerExpertWeightProxy:
+    """Proxy for grouped_gemm_experts that provides per-expert weight views.
+
+    Holds ``weight1`` and ``weight2`` as ``_PerExpertWeightView`` instances
+    that lazily slice from the parent's fp8 stacked weights.
+    """
+
+    def __init__(self, parent, local_id):
+        num_experts = parent.weight1.shape[0]
+        self.weight1 = _PerExpertWeightView(
+            parent.weight1, local_id, num_experts
+        )
+        self.weight2 = _PerExpertWeightView(
+            parent.weight2, local_id, num_experts
+        )
+
+
 class ExpertsGroupGemmContiguousNode:
     """ExpertsGroupGemmContiguousNode"""
 
@@ -350,12 +456,30 @@ class ExpertsGroupGemmContiguousNode:
             dequant_input (bool, optional): Whether to dequantize input. Defaults to False.
             name (str, optional): Name of the node. Defaults to "experts_group_gemm_contiguous_node".
         """
-        # 两条路径：
-        #   split path (self.experts): 权重为 list，支持 auto_subbatch 逐专家 fallback
-        #     条件: moe_expert_fusion=False, 或 use_fp8_mlp=True & moe_deep_gemm=False
-        #   grouped path (self.grouped_gemm_experts): 权重为 stacked tensor，走批量 gemm
-        #     条件: moe_expert_fusion=True & (use_fp8_mlp=False 或 moe_deep_gemm=True)
-        if not moe_expert_fusion or (use_fp8_mlp and not moe_deep_gemm):
+        if moe_deep_gemm and expert_id is not None:
+            # Per-expert node for deep_gemm: slice stacked weight to [1, K, N]
+            parent = custom_map.grouped_gemm_experts
+            moe_rank = getattr(custom_map, "moe_rank", 0)
+            num_experts_per_device = getattr(
+                custom_map, "num_experts_per_device", parent.weight1.shape[0]
+            )
+            local_id = expert_id - moe_rank * num_experts_per_device
+            if hasattr(parent.weight1, "fp8_weight_stacked"):
+                # Offline quant: bf16 weight may have been cleared, use proxy
+                self.grouped_gemm_experts = _PerExpertWeightProxy(
+                    parent, local_id
+                )
+            else:
+                # Normal: bf16 weight is valid, slice directly
+                sliced = type("_SlicedGroupedExpert", (), {})()
+                sliced.weight1 = parent.weight1._slice(local_id, local_id + 1)
+                sliced.weight2 = parent.weight2._slice(local_id, local_id + 1)
+                sliced._parent = parent
+                sliced._local_id = local_id
+                self.grouped_gemm_experts = sliced
+            self.experts = None
+            moe_expert_fusion = True
+        elif not moe_expert_fusion or (use_fp8_mlp and not moe_deep_gemm):
             if expert_id is None:
                 self.experts = custom_map.experts
             else:

--- a/src/paddlefleet/transformer/moe/fusion_layer_utils.py
+++ b/src/paddlefleet/transformer/moe/fusion_layer_utils.py
@@ -300,8 +300,9 @@ class MlpNode:
             len(self.tokens_per_expert),
         )
         if recompute_moe_premute:
-            assert not moe_expert_fusion, (
-                "moe_expert_fusion must be disabled when recompute_unzipped = True"
+            assert moe_expert_fusion == moe_deep_gemm, (
+                f"recompute_moe_premute requires moe_expert_fusion == moe_deep_gemm"
+                f" (got moe_expert_fusion={moe_expert_fusion}, moe_deep_gemm={moe_deep_gemm})"
             )
             assert recompute_moe_gate_up, (
                 "recompute_moe_gate_up must be enabled when recompute_moe_premute = True"
@@ -314,30 +315,44 @@ class MlpNode:
         self.moe_subbatch_token_num_after_dispatch = (
             moe_subbatch_token_num_after_dispatch
         )
+        _has_static_subbatch = (
+            self.moe_subbatch_token_num_after_dispatch is not None
+            and self.moe_subbatch_token_num_after_dispatch > 0
+        )
 
-        if self.moe_subbatch_token_num_after_dispatch is not None:
+        if _has_static_subbatch:
             assert (
-                self.moe_subbatch_token_num_after_dispatch > 0
-                and self.moe_subbatch_token_num_after_dispatch % FP8_ALIGN == 0
+                self.moe_subbatch_token_num_after_dispatch % FP8_ALIGN == 0
             ), self.moe_subbatch_token_num_after_dispatch
-            assert not moe_expert_fusion, (
-                "moe_expert_fusion must be disabled when moe_subbatch_token_num_after_dispatch > 0"
-            )
-            assert recompute_moe_gate_up, (
-                "recompute_moe_gate_up must be enabled when moe_subbatch_token_num_after_dispatch > 0"
+            assert moe_expert_fusion == moe_deep_gemm, (
+                "static subbatch requires moe_expert_fusion == moe_deep_gemm"
+                f" (got moe_expert_fusion={moe_expert_fusion}, moe_deep_gemm={moe_deep_gemm})"
             )
             assert dequant_input, (
                 "dequant_input must be enabled when moe_subbatch_token_num_after_dispatch > 0"
             )
+            if not recompute_moe_gate_up:
+                logger.warning(
+                    "Auto-enabling recompute_moe_gate_up: static subbatch splits"
+                    " forward into multiple chunks that overwrite intermediate"
+                    " activations (o1), recompute is required to reconstruct them"
+                    " during backward."
+                )
+                recompute_moe_gate_up = True
 
-        if not self.moe_expert_fusion and (
-            (
-                self.moe_subbatch_token_num_after_dispatch is not None
-                and self.moe_subbatch_token_num_after_dispatch > 0
-            )
-            or use_auto_subbatch
-        ):
-            # Keep per-expert gemm nodes local-indexed.
+        # Per-expert gemm node list is needed when:
+        #   no subbatch:     never
+        #   static subbatch: always (regardless of deep_gemm)
+        #   auto_subbatch:   only when moe_expert_fusion=False (fusion mode uses runtime fallback)
+        _need_per_expert_nodes = _has_static_subbatch or (
+            use_auto_subbatch and not moe_expert_fusion
+        )
+        if _need_per_expert_nodes:
+            # For deep_gemm: set moe_expert_fusion=False at MlpNode level to route into
+            # per-expert loop; each node internally keeps moe_expert_fusion=True for
+            # grouped gemm API with sliced [1,K,N] weight.
+            if moe_deep_gemm:
+                self.moe_expert_fusion = False
             self.experts_group_gemm_node = [
                 ExpertsGroupGemmContiguousNode(
                     custom_map,
@@ -791,12 +806,25 @@ class MlpNode:
                 # deep_gemm: slice stacked weight to [1, K, N]
                 gemm_node.moe_expert_fusion = True
                 parent = fused_gemm_node.grouped_gemm_experts
-                sliced = type("_SlicedGroupedExpert", (), {})()
-                sliced.weight1 = parent.weight1._slice(local_id, local_id + 1)
-                sliced.weight2 = parent.weight2._slice(local_id, local_id + 1)
-                sliced._parent = parent
-                sliced._local_id = local_id
-                gemm_node.grouped_gemm_experts = sliced
+                if hasattr(parent.weight1, "fp8_weight_stacked"):
+                    from paddlefleet.transformer.moe.fp8_utils import (
+                        _PerExpertWeightProxy,
+                    )
+
+                    gemm_node.grouped_gemm_experts = _PerExpertWeightProxy(
+                        parent, local_id
+                    )
+                else:
+                    sliced = type("_SlicedGroupedExpert", (), {})()
+                    sliced.weight1 = parent.weight1._slice(
+                        local_id, local_id + 1
+                    )
+                    sliced.weight2 = parent.weight2._slice(
+                        local_id, local_id + 1
+                    )
+                    sliced._parent = parent
+                    sliced._local_id = local_id
+                    gemm_node.grouped_gemm_experts = sliced
                 # Regenerate m_indices for single expert; global m_indices has wrong range
                 gemm_node.m_indices = gemm_node.gen_m_indices(
                     [tokens_per_expert]
@@ -1804,6 +1832,8 @@ class MlpNode:
         ):
             # Per-expert backward path (non-fusion)
             bwd_path = "per_expert"
+            self._ensure_weight_grad()
+            self._slice_weight_grad()
             output = paddle.empty(
                 [0, hidden_states_out_grad_shape[-1]], dtype=paddle.float32
             )
@@ -1970,14 +2000,18 @@ class FusionMoePyLayer(paddle.autograd.PyLayer):
         )
 
         if is_first_fwd:
+            # Under full recompute's first forward (no_grad), the inner PyLayer's
+            # backward will never be called. Release intermediate state immediately.
             ctx.node.release_mem()
 
         # Expose node on moe_layer for diagnostic access
         custom_map._fusion_node = ctx.node
 
-        cached_tensors = ctx.node.cached_tensors()
-        ctx.save_for_backward(cached_tensors)
-        ctx.node.clear_cached_tensors()
+        if not is_first_fwd:
+            # Normal forward with grad: save state for backward.
+            cached_tensors = ctx.node.cached_tensors()
+            ctx.save_for_backward(cached_tensors)
+            ctx.node.clear_cached_tensors()
         return out
 
     @staticmethod

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -712,6 +712,7 @@ class MoELayer(nn.Layer):
                     use_ue8m0=self.use_ue8m0,
                     dw_p2p_overlap=self.dw_p2p_overlap,
                     clamp_value=self.config.activation_func_clamp_value,
+                    is_first_fwd=not framework._dygraph_tracer()._has_grad,
                 )
 
         with profile("combine"):

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_fp8_utils_4.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_fp8_utils_4.py
@@ -48,6 +48,9 @@ class TensorBox:
     def _apply_backward_hook(self):
         self.hook_called = True
 
+    def _slice(self, start, end):
+        return TensorBox(self.tensor[start:end], hasattr(self, "main_grad"))
+
 
 class Projection:
     def __init__(self, shape, with_main_grad=False):

--- a/tests/single_card_tests/test_moe_subbatch_deep_gemm.py
+++ b/tests/single_card_tests/test_moe_subbatch_deep_gemm.py
@@ -14,16 +14,16 @@
 # limitations under the License.
 
 """
-Single-card unit tests for auto_subbatch with moe_deep_gemm=True.
+Single-card unit tests for static subbatch (moe_subbatch_token_num_after_dispatch)
+with moe_deep_gemm=True.
 
-Tests auto_subbatch fallback correctness when using GroupedMLPExpert (stacked weights)
-instead of per-expert weight lists.
+Tests that per-expert static subbatch produces the same results as the
+full group_gemm reference when using GroupedMLPExpert (stacked weights).
 
 Run with:
-  python tests/single_card_tests/test_moe_auto_subbatch_deep_gemm.py
+  python tests/single_card_tests/test_moe_static_subbatch_deep_gemm.py
 """
 
-import contextlib
 import logging
 import os
 import unittest
@@ -37,39 +37,19 @@ from types import SimpleNamespace
 
 import paddle
 from paddle import nn
-from paddle.device.cuda.memory_analyzer import MemoryAnalysisTool
 
 from paddlefleet.tensor_parallel.random import model_parallel_cuda_manual_seed
 from paddlefleet.transformer.moe.fp8_utils import (
     fused_stack_quant_without_cache,
     tilewise_quant,
 )
-from paddlefleet.transformer.moe.fusion_layer_utils import (
-    FusionMoePyLayer,
-    MlpNode,
-)
+from paddlefleet.transformer.moe.fusion_layer_utils import FusionMoePyLayer
 from paddlefleet.transformer.moe.moe_expert import GroupedMLPExpert
 from paddlefleet.transformer.transformer_config import TransformerConfig
 
-# hack: lower min_auto_subbatch_rows so small seq_len can trigger multi-chunk subbatch
-_orig_mlpnode_init = MlpNode.__init__
-
-
-def _patched_mlpnode_init(self, *args, **kwargs):
-    _orig_mlpnode_init(self, *args, **kwargs)
-    self.min_auto_subbatch_rows = 256
-
-
-MlpNode.__init__ = _patched_mlpnode_init
-
 
 class FakeDeepGemmMOELayer(nn.Layer):
-    """
-    A mock MoE layer for deep_gemm mode using GroupedMLPExpert (stacked weights).
-
-    In deep_gemm mode, MoELayer creates grouped_gemm_experts instead of per-expert list.
-    This fake layer mimics that structure.
-    """
+    """Mock MoE layer for deep_gemm mode using GroupedMLPExpert (stacked weights)."""
 
     def __init__(
         self,
@@ -89,7 +69,6 @@ class FakeDeepGemmMOELayer(nn.Layer):
             config=config,
             moe_deep_gemm=True,
         )
-        # Initialize weights with small random values for numerical stability
         with paddle.no_grad():
             self.grouped_gemm_experts.weight1.set_value(
                 paddle.randn(
@@ -108,7 +87,6 @@ class FakeDeepGemmMOELayer(nn.Layer):
                 tokens_per_expert=tokens_per_expert,
             ),
         )
-        # deep_gemm mode has no per-expert list
         self.experts = None
 
     def clear_main_grad(self):
@@ -123,7 +101,6 @@ class FakeDeepGemmMOELayer(nn.Layer):
         w1_list = [w1[i, :, :] for i in range(local_expert_num)]
         w2_list = [w2[i, :, :] for i in range(local_expert_num)]
 
-        # Non-transpose version
         fp8_w1, fp8_s1 = fused_stack_quant_without_cache(
             w1_list, transpose=False
         )
@@ -136,7 +113,6 @@ class FakeDeepGemmMOELayer(nn.Layer):
         w2.fp8_weight_stacked = fp8_w2
         w2.fp8_scale_stacked = fp8_s2
 
-        # Transpose version
         if quant_transpose:
             fp8_w1_t, fp8_s1_t = fused_stack_quant_without_cache(
                 w1_list, transpose=True
@@ -161,24 +137,7 @@ class FakeDeepGemmMOELayer(nn.Layer):
         self.grouped_gemm_experts.weight2._clear_to_zero_allocation()
 
 
-@contextlib.contextmanager
-def vmm_no_free_space():
-    """Occupy all free blocks and disable growable space to simulate tight memory."""
-    (old_value,) = paddle.framework.get_flags(
-        "FLAGS_max_reserved_threshold_in_gb"
-    ).values()
-    paddle.set_flags({"FLAGS_max_reserved_threshold_in_gb": 0})
-    buffers = []
-    for size, _ in MemoryAnalysisTool.vmm_free_block_info()[-1]:
-        buffers.append(paddle.empty([size], dtype="uint8"))
-    try:
-        yield
-    finally:
-        paddle.set_flags({"FLAGS_max_reserved_threshold_in_gb": old_value})
-        del buffers
-
-
-class TestAutoSubbatchDeepGemm(unittest.TestCase):
+class TestStaticSubbatchDeepGemm(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         model_parallel_cuda_manual_seed(1234)
@@ -206,7 +165,6 @@ class TestAutoSubbatchDeepGemm(unittest.TestCase):
         self.scale = scale
         self.probs = probs
 
-        # Each token is assigned 1 to topk experts, always including expert 0
         indices_np = np.full([self.seq_len, self.topk], -1, dtype=np.int64)
         tokens_per_expert = [0] * self.n_routed_experts
         for i in range(self.seq_len):
@@ -237,37 +195,35 @@ class TestAutoSubbatchDeepGemm(unittest.TestCase):
         moe_layer.clear_main_grad()
         self.moe_layer = moe_layer
 
-    def run_moe_layer(
-        self, is_ref=False, tight_forward=False, tight_backward=False, **kwargs
-    ):
+    def run_moe_layer(self, is_ref=False, **kwargs):
         params = {
             "use_fp8_mlp": True,
             "moe_deep_gemm": True,
-            "recompute_moe_gate_up": False,
+            "recompute_moe_gate_up": True,
             "dequant_input": True,
             "moe_expert_fusion": True,
             "recompute_moe_premute": False,
             "use_bf16_gemm_weight_grad": True,
             "fp8_dispatched_handle": {"scale": self.scale},
-            "use_auto_subbatch": not is_ref,
+            "use_auto_subbatch": False,
             "moe_subbatch_diag": True,
         }
+        if not is_ref:
+            params["moe_subbatch_token_num_after_dispatch"] = kwargs.pop(
+                "moe_subbatch_token_num_after_dispatch", 256
+            )
         params.update(kwargs)
 
-        with vmm_no_free_space() if tight_forward else contextlib.nullcontext():
-            hidden_states = FusionMoePyLayer.apply(
-                self.hidden_states,
-                self.probs,
-                self.indices.clone(),
-                self.moe_layer,
-                self.topk,
-                **params,
-            )
+        hidden_states = FusionMoePyLayer.apply(
+            self.hidden_states,
+            self.probs,
+            self.indices.clone(),
+            self.moe_layer,
+            self.topk,
+            **params,
+        )
 
-        with (
-            vmm_no_free_space() if tight_backward else contextlib.nullcontext()
-        ):
-            paddle.autograd.backward(hidden_states, self.hidden_states_out_grad)
+        paddle.autograd.backward(hidden_states, self.hidden_states_out_grad)
 
         hidden_states_grad = self.hidden_states.grad
         probs_grad = self.probs.grad
@@ -286,7 +242,6 @@ class TestAutoSubbatchDeepGemm(unittest.TestCase):
             "probs_grad",
             "weight_grad",
         ]
-        # First three must be bitwise equal; weight_grad allows FP8 accumulation order diff
         tolerances = {
             "weight_grad": {"atol": 1e-4, "rtol": 1e-5},
         }
@@ -300,7 +255,6 @@ class TestAutoSubbatchDeepGemm(unittest.TestCase):
                 diff = np.abs(ref_np - tgt_np)
                 max_diff = diff.max()
                 if max_diff > tol["atol"]:
-                    # Print top diffs on failure for debugging
                     flat = diff.flatten()
                     top_idx = np.argsort(flat)[-10:][::-1]
                     lines = [
@@ -315,162 +269,80 @@ class TestAutoSubbatchDeepGemm(unittest.TestCase):
                     self.fail("\n".join(lines))
                 np.testing.assert_allclose(ref_np, tgt_np, **tol, err_msg=name)
 
-    def test_auto_subbatch_deep_gemm_no_recompute(self):
-        """deep_gemm + no_recompute: auto_subbatch vs group_gemm reference"""
+    def test_static_subbatch_deep_gemm(self):
+        """deep_gemm + static subbatch vs group_gemm reference"""
         ref_out = self.run_moe_layer(is_ref=True)
 
         cases = {}
-        kwargs = {"recompute_moe_gate_up": False}
-
-        logging.info("case1 (deep_gemm, plenty)")
-        cases["case1 (plenty)"] = self.run_moe_layer(**kwargs)
-        logging.info("case2 (deep_gemm, tight_fwd)")
-        cases["case2 (tight_fwd)"] = self.run_moe_layer(
-            tight_forward=True, **kwargs
+        logging.info("case1 (subbatch=256)")
+        cases["subbatch=256"] = self.run_moe_layer(
+            moe_subbatch_token_num_after_dispatch=256
         )
-
-        logging.info("case3 (deep_gemm, tight_bwd)")
-        cases["case3 (tight_bwd)"] = self.run_moe_layer(
-            tight_backward=True, **kwargs
-        )
-        logging.info("case4 (deep_gemm, tight_both)")
-        cases["case4 (tight_both)"] = self.run_moe_layer(
-            tight_forward=True, tight_backward=True, **kwargs
+        logging.info("case2 (subbatch=512)")
+        cases["subbatch=512"] = self.run_moe_layer(
+            moe_subbatch_token_num_after_dispatch=512
         )
 
         for name, result in cases.items():
             with self.subTest(case=name):
                 self.compare_results(ref_out, result)
 
-    def test_auto_subbatch_deep_gemm_recompute(self):
-        """deep_gemm + recompute_moe_gate_up: auto_subbatch vs group_gemm reference"""
-        ref_out = self.run_moe_layer(is_ref=True, recompute_moe_gate_up=True)
+    def test_static_subbatch_deep_gemm_recompute_premute(self):
+        """deep_gemm + static subbatch + recompute_moe_premute"""
+        ref_out = self.run_moe_layer(is_ref=True, recompute_moe_premute=True)
 
         cases = {}
-        kwargs = {"recompute_moe_gate_up": True}
+        kwargs = {"recompute_moe_premute": True}
 
-        logging.info("case5 (deep_gemm recompute, plenty)")
-        cases["case5 (plenty)"] = self.run_moe_layer(**kwargs)
-        logging.info("case6 (deep_gemm recompute, tight_fwd)")
-        cases["case6 (tight_fwd)"] = self.run_moe_layer(
-            tight_forward=True, **kwargs
+        logging.info("case3 (recompute_premute, subbatch=256)")
+        cases["recompute_premute, subbatch=256"] = self.run_moe_layer(
+            moe_subbatch_token_num_after_dispatch=256, **kwargs
         )
-
-        logging.info("case7 (deep_gemm recompute, tight_bwd)")
-        cases["case7 (tight_bwd)"] = self.run_moe_layer(
-            tight_backward=True, **kwargs
-        )
-        logging.info("case8 (deep_gemm recompute, tight_both)")
-        cases["case8 (tight_both)"] = self.run_moe_layer(
-            tight_forward=True, tight_backward=True, **kwargs
+        logging.info("case4 (recompute_premute, subbatch=512)")
+        cases["recompute_premute, subbatch=512"] = self.run_moe_layer(
+            moe_subbatch_token_num_after_dispatch=512, **kwargs
         )
 
         for name, result in cases.items():
             with self.subTest(case=name):
                 self.compare_results(ref_out, result)
 
-    def test_auto_subbatch_deep_gemm_offline_quant(self):
-        """deep_gemm + offline fp8 quant + clear bf16 weight: simulates FP8QuantWeightCallback.
-
-        After offline quant, bf16 weight memory is cleared (memory_size=0).
-        Forward/backward must work using only fp8_weight_stacked attributes.
-        """
-        # First get reference output BEFORE clearing weight
+    def test_static_subbatch_deep_gemm_offline_quant(self):
+        """deep_gemm + static subbatch + offline fp8 quant + clear bf16 weight."""
         ref_out = self.run_moe_layer(is_ref=True)
 
-        # Now simulate FP8QuantWeightCallback: quant + clear bf16
         self.moe_layer.fp8_quant_weight(quant_transpose=False)
         self.moe_layer.clear_weight_storage()
 
         cases = {}
-        # no recompute
-        kwargs = {"recompute_moe_gate_up": False}
-
-        logging.info("case9 (offline_quant, plenty)")
-        cases["case9 (plenty)"] = self.run_moe_layer(**kwargs)
-        logging.info("case10 (offline_quant, tight_fwd)")
-        cases["case10 (tight_fwd)"] = self.run_moe_layer(
-            tight_forward=True, **kwargs
+        logging.info("case5 (offline_quant, subbatch=256)")
+        cases["offline_quant, subbatch=256"] = self.run_moe_layer(
+            moe_subbatch_token_num_after_dispatch=256
         )
-        logging.info("case11 (offline_quant, tight_bwd)")
-        cases["case11 (tight_bwd)"] = self.run_moe_layer(
-            tight_backward=True, **kwargs
-        )
-        logging.info("case12 (offline_quant, tight_both)")
-        cases["case12 (tight_both)"] = self.run_moe_layer(
-            tight_forward=True, tight_backward=True, **kwargs
-        )
-
-        # with recompute
-        kwargs_rc = {"recompute_moe_gate_up": True}
-
-        logging.info("case9r (offline_quant+recompute, plenty)")
-        cases["case9r (plenty)"] = self.run_moe_layer(**kwargs_rc)
-        logging.info("case10r (offline_quant+recompute, tight_fwd)")
-        cases["case10r (tight_fwd)"] = self.run_moe_layer(
-            tight_forward=True, **kwargs_rc
-        )
-        logging.info("case11r (offline_quant+recompute, tight_bwd)")
-        cases["case11r (tight_bwd)"] = self.run_moe_layer(
-            tight_backward=True, **kwargs_rc
-        )
-        logging.info("case12r (offline_quant+recompute, tight_both)")
-        cases["case12r (tight_both)"] = self.run_moe_layer(
-            tight_forward=True, tight_backward=True, **kwargs_rc
+        logging.info("case6 (offline_quant, subbatch=512)")
+        cases["offline_quant, subbatch=512"] = self.run_moe_layer(
+            moe_subbatch_token_num_after_dispatch=512
         )
 
         for name, result in cases.items():
             with self.subTest(case=name):
                 self.compare_results(ref_out, result)
 
-    def test_auto_subbatch_deep_gemm_offline_quant_transpose(self):
-        """deep_gemm + offline fp8 quant with quant_transpose=True + clear bf16 weight.
-
-        When quant_transpose=True, fp8_weight_stacked_transpose is pre-computed.
-        The per-expert fallback should use the pre-computed transpose directly.
-        """
-        # First get reference output BEFORE clearing weight
+    def test_static_subbatch_deep_gemm_offline_quant_transpose(self):
+        """deep_gemm + static subbatch + offline fp8 quant with quant_transpose=True."""
         ref_out = self.run_moe_layer(is_ref=True)
 
-        # Simulate FP8QuantWeightCallback with quant_transpose=True
         self.moe_layer.fp8_quant_weight(quant_transpose=True)
         self.moe_layer.clear_weight_storage()
 
         cases = {}
-        # no recompute
-        kwargs = {"recompute_moe_gate_up": False}
-
-        logging.info("case13 (offline_quant_transpose, plenty)")
-        cases["case13 (plenty)"] = self.run_moe_layer(**kwargs)
-        logging.info("case14 (offline_quant_transpose, tight_fwd)")
-        cases["case14 (tight_fwd)"] = self.run_moe_layer(
-            tight_forward=True, **kwargs
+        logging.info("case7 (offline_quant_transpose, subbatch=256)")
+        cases["offline_quant_transpose, subbatch=256"] = self.run_moe_layer(
+            moe_subbatch_token_num_after_dispatch=256
         )
-        logging.info("case15 (offline_quant_transpose, tight_bwd)")
-        cases["case15 (tight_bwd)"] = self.run_moe_layer(
-            tight_backward=True, **kwargs
-        )
-        logging.info("case16 (offline_quant_transpose, tight_both)")
-        cases["case16 (tight_both)"] = self.run_moe_layer(
-            tight_forward=True, tight_backward=True, **kwargs
-        )
-
-        # with recompute
-        kwargs_rc = {"recompute_moe_gate_up": True}
-
-        logging.info("case13r (offline_quant_transpose+recompute, plenty)")
-        cases["case13r (plenty)"] = self.run_moe_layer(**kwargs_rc)
-        logging.info("case14r (offline_quant_transpose+recompute, tight_fwd)")
-        cases["case14r (tight_fwd)"] = self.run_moe_layer(
-            tight_forward=True, **kwargs_rc
-        )
-        logging.info("case15r (offline_quant_transpose+recompute, tight_bwd)")
-        cases["case15r (tight_bwd)"] = self.run_moe_layer(
-            tight_backward=True, **kwargs_rc
-        )
-        logging.info("case16r (offline_quant_transpose+recompute, tight_both)")
-        cases["case16r (tight_both)"] = self.run_moe_layer(
-            tight_forward=True, tight_backward=True, **kwargs_rc
+        logging.info("case8 (offline_quant_transpose, subbatch=512)")
+        cases["offline_quant_transpose, subbatch=512"] = self.run_moe_layer(
+            moe_subbatch_token_num_after_dispatch=512
         )
 
         for name, result in cases.items():


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
支持 moe_subbatch_token_num_after_dispatch（静态 subbatch）及 use_auto_subbatch（动态 subbatch）与 moe_deep_gemm=True 同时开启，并兼容 offline FP8 quant（_clear_to_zero_allocation 清除 bf16 权重后仅保留 fp8 权重）场景。

  **核心思路**：per-expert fallback 时，根据权重状态选择两种代理模式：
  - 正常路径（bf16 权重有效）：_SlicedGroupedExpert —— 通过 _slice 取 [1, K, N] view，grad 通过 _slice_weight_grad 映射回 parent
  - offline quant 路径（bf16 已清除）：_PerExpertWeightProxy / _PerExpertWeightView —— Virtual Proxy 模式，通过property 转发 fp8_weight_stacked / fp8_scale_stacked 的单专家切片，避免访问已释放的 bf16 数据
 
**改动**：

  - fusion_layer_utils.py：
    - 放开断言，约束改为 moe_expert_fusion == moe_deep_gemm（同开同关）
    - 静态 subbatch backward 路径调用 _ensure_weight_grad() + _slice_weight_grad()，确保 grad 正确路由回 parent
    - fallback_to_no_expert_fusion() 增加 hasattr(weight1, "fp8_weight_stacked") 分支判断
  - fp8_utils.py：
    - 新增 _PerExpertWeightView / _PerExpertWeightProxy 类，支持 offline quant 场景下的 per-expert 接口
    - _PerExpertWeightView.main_grad setter：backward 时自动在 parent 上分配 grad buffer
    - ExpertsGroupGemmContiguousNode.__init__ 新增 moe_deep_gemm + expert_id 分支，根据是否有 fp8_weight_stacked 选择 proxy 或 slice
  - moe_layer.py：
    - recompute_moe_gate_up / recompute_moe_premute 统一为 recompute_modules 单一入口
  - 新增单测：
    - test_moe_subbatch_deep_gemm.py：静态 subbatch + deep_gemm（含 offline quant / quant_transpose / recompute_premute）
    - test_moe_auto_subbatch_deep_gemm.py：动态 subbatch + deep_gemm（含 offline quant / quant_transpose / tight memory / recompute）

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否