### PR TITLE
[CI] Avoid approval false positives from base drift

### DIFF
--- a/ci/check_approval.sh
+++ b/ci/check_approval.sh
@@ -12,23 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if [ -z ${BRANCH} ]; then
+if [ -z "${BRANCH:-}" ]; then
     BRANCH="develop"
 fi
 
 PADDLE_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}")/../" && pwd )"
 # If you want to add monitoring file modifications, please perform the. github/CODEOWNERS operation
 
-approval_line=`curl -H "Authorization: token ${GITHUB_TOKEN}" https://api.github.com/repos/PaddlePaddle/PaddleFleet/pulls/${PR_ID}/reviews?per_page=10000`
-git_files=`git diff --numstat upstream/$BRANCH| wc -l`
-git_count=`git diff --numstat upstream/$BRANCH| awk '{sum+=$1}END{print sum}'`
+UPSTREAM_BRANCH="upstream/${BRANCH}"
+if ! DIFF_BASE=$(git merge-base HEAD "${UPSTREAM_BRANCH}"); then
+    echo "Unable to find merge base between HEAD and ${UPSTREAM_BRANCH}." >&2
+    exit 1
+fi
+
+approval_line=$(curl -H "Authorization: token ${GITHUB_TOKEN}" "https://api.github.com/repos/PaddlePaddle/PaddleFleet/pulls/${PR_ID}/reviews?per_page=10000")
+git_files=$(git diff --numstat "${DIFF_BASE}" HEAD -- | wc -l)
+git_count=$(git diff --numstat "${DIFF_BASE}" HEAD -- | awk '{sum+=$1}END{print sum}')
 failed_num=1
 echo_list=()
 
 
 function check_approval(){
-    person_num=`echo $@|awk '{for (i=2;i<=NF;i++)print $i}'`
-    APPROVALS=`echo ${approval_line}|python ${PADDLE_ROOT}/ci/check_pr_approval.py $1 $person_num`
+    APPROVALS=$(echo "${approval_line}" | python "${PADDLE_ROOT}/ci/check_pr_approval.py" "$@")
     if [[ "${APPROVALS}" == "FALSE" && "${echo_line}" != "" ]]; then
         add_failed "${failed_num}. ${echo_line}"
     fi
@@ -42,9 +47,9 @@ function add_failed(){
 
 function run_tools_test() {
     CUR_PWD=$(pwd)
-    cd ${PADDLE_ROOT}/tools
-    python $1
-    cd ${CUR_PWD}
+    cd "${PADDLE_ROOT}/tools"
+    python "$1"
+    cd "${CUR_PWD}"
 }
 
 
@@ -60,7 +65,7 @@ CODESTYLE_FILES=(
     "pyproject.toml"
 )
 for FILE in "${CODESTYLE_FILES[@]}"; do
-    HAS_MODIFIED=$(git diff --name-only upstream/$BRANCH | grep "^${FILE}" || true)
+    HAS_MODIFIED=$(git diff --name-only "${DIFF_BASE}" HEAD -- | grep "^${FILE}" || true)
     if [ "${HAS_MODIFIED}" != "" ] && [ "${PR_ID}" != "" ]; then
         echo_line="You must be approved by one of ${CODESTYLE_APPROVERS} for changes in ${FILE}.\n"
         APPROVER_LIST=(${CODESTYLE_APPROVERS})
@@ -76,7 +81,7 @@ MODELCONFIG_FILES=(
     "src/paddlefleet/transformer/transformer_config.py"
 )
 for FILE in "${MODELCONFIG_FILES[@]}"; do
-    HAS_MODIFIED=$(git diff --name-only upstream/$BRANCH | grep "^${FILE}" || true)
+    HAS_MODIFIED=$(git diff --name-only "${DIFF_BASE}" HEAD -- | grep "^${FILE}" || true)
     if [ "${HAS_MODIFIED}" != "" ] && [ "${PR_ID}" != "" ]; then
         echo_line="You must be approved by two of ${MODELCONFIG_APPROVERS} for changes in ${FILE}.\n"
         APPROVER_LIST=(${MODELCONFIG_APPROVERS})
@@ -87,7 +92,7 @@ done
 
 CUSTOMOP_APPROVERS="risemeup1 From00"
 CUSTOMOP_DIR="packages/paddlefleet_ops/src/paddlefleet_ops/_extensions"
-HAS_MODIFIED_CUSTOMOP=$(git diff --name-only upstream/$BRANCH | grep "^${CUSTOMOP_DIR}/" || true)
+HAS_MODIFIED_CUSTOMOP=$(git diff --name-only "${DIFF_BASE}" HEAD -- | grep "^${CUSTOMOP_DIR}/" || true)
 if [ "${HAS_MODIFIED_CUSTOMOP}" != "" ] && [ "${PR_ID}" != "" ]; then
     echo_line="You must be approved by one of ${CUSTOMOP_APPROVERS} for changes in ${CUSTOMOP_DIR}.\n"
     APPROVER_LIST=(${CUSTOMOP_APPROVERS})
@@ -97,7 +102,7 @@ fi
 
 
 CHECKREQ_APPROVERS="risemeup1 swgu98"
-files=$(git diff --name-status upstream/$BRANCH)
+files=$(git diff --name-status "${DIFF_BASE}" HEAD --)
 while read -r status file; do
     if [[ "$status" == "A" ]] && [[ "$(basename "$file")" == "requirements.txt" ]]; then
         echo_line="You must be approved by one of ${CHECKREQ_APPROVERS} for newly added \"$file\".\n"
@@ -114,7 +119,7 @@ PACKAGING_PATTERNS=(
     "^pyproject\.toml$"
 )
 for PATTERN in "${PACKAGING_PATTERNS[@]}"; do
-    HAS_MODIFIED=$(git diff --name-only upstream/$BRANCH | grep "${PATTERN}" || true)
+    HAS_MODIFIED=$(git diff --name-only "${DIFF_BASE}" HEAD -- | grep "${PATTERN}" || true)
     if [ "${HAS_MODIFIED}" != "" ] && [ "${PR_ID}" != "" ]; then
         echo_line="You must be approved by one of ${PACKAGING_APPROVERS} for changes in packaging-related files (${PATTERN}).\n"
         APPROVER_LIST=(${PACKAGING_APPROVERS})


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Bug fixes

### Description

修复 `ci/check_approval.sh` 在目标分支推进后可能误判 PR 修改范围的问题。

当前脚本直接用 `git diff upstream/$BRANCH` 判断 approval-gated 文件。Approval workflow 检出 `refs/pull/$PR_ID/merge`，如果该 merge ref 生成后 `develop` 继续前进，直接和最新 `upstream/develop` 做 two-dot diff 会把 upstream-only 的新增内容误判为 PR 删除，从而要求与当前 PR 无关的 approver。

本 PR 改为先计算 `HEAD` 与 `upstream/$BRANCH` 的 merge base，再用 `DIFF_BASE..HEAD` 判断 PR 实际变更文件范围，保持现有 approval 规则和 approver 列表不变。

验证：

```bash
bash -n ci/check_approval.sh
```

并用 PR #1011 的 merge ref 本地复现：旧直接 diff 会包含 `src/paddlefleet/transformer/transformer_config.py`，新 merge-base diff 只包含该 PR 实际修改的 `packages/paddlefleet_ops/.../_extensions` 文件。

Ref: #1011

### 是否引起精度变化
否
