### PR TITLE
[XPU] add xpu ops build

### DIFF
--- a/.github/workflows/publish_wheel_nightly_xpu.yml
+++ b/.github/workflows/publish_wheel_nightly_xpu.yml
@@ -126,6 +126,22 @@ jobs:
           python -m pip wheel . --no-deps --no-build-isolation -w dist/
           '
 
+      - name: Build paddlefleet-ops wheel
+        run: |
+          docker exec -t ${{ env.container_name }} /bin/bash -xc '
+          source /root/proxy
+          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref_type }}" == "branch" ]]; then
+            export PADDLEFLEET_VERSION=$(cat version.txt).post$(git log -1 --format=%cd --date=format:%Y%m%d)+$(git rev-parse --short=8 HEAD)
+          elif [[ "${{ github.event_name }}" == "push" && "${{ github.ref_type }}" == "tag" ]]; then
+            TAG_NAME="${{ github.ref_name }}"
+            VERSION="${TAG_NAME#v}"
+            export PADDLEFLEET_VERSION=$VERSION
+          fi
+          export IS_XPU=1
+          cd packages/paddlefleet_ops
+          python -m pip wheel . --no-deps --no-build-isolation -w ../../dist_ops/
+          '
+
       - name: Upload wheel
         run: |
           docker exec -t ${{ env.container_name }} /bin/bash -xc '
@@ -155,6 +171,37 @@ jobs:
             PY_VERSION_SHORT="${PY_VERSION//./}"
             mv paddlefleet-*.whl paddlefleet-0.0.0-cp${PY_VERSION_SHORT}-cp${PY_VERSION_SHORT}-linux_x86_64.whl
             python ../bos/BosClient.py paddlefleet-0.0.0-cp${PY_VERSION_SHORT}-cp${PY_VERSION_SHORT}-linux_x86_64.whl paddle-github-action/PaddleFleet/${BRANCH}/latest/${{ matrix.xpu.bos_XPU }}
+            python ../bos/BosClient.py commitid paddle-github-action/PaddleFleet/${BRANCH}/latest/${{ matrix.xpu.bos_XPU }}
+          fi
+          curl https://www.paddlepaddle.org.cn/inner/whl/update/path/new
+          '
+
+      - name: Upload paddlefleet-ops wheel
+        run: |
+          docker exec -t ${{ env.container_name }} /bin/bash -xc '
+          cd dist_ops
+          git rev-parse HEAD > commitid
+          if [[ "${{ github.event_name }}" != "push" ]]; then
+            python ../bos/BosClient.py paddlefleet_ops-*.whl paddle-whl/nightly/${{ matrix.xpu.bos_XPU }}/paddlefleet-ops
+            export AK=paddle
+            export SK=paddle
+            python ../bos/BosClient.py paddlefleet_ops-*.whl paddle-github-action/PaddleFleet/${BRANCH}/${COMMIT_ID}/${{ matrix.xpu.bos_XPU }}
+            PY_VERSION="${{ matrix.python_version }}"
+            PY_VERSION_SHORT="${PY_VERSION//./}"
+            cp paddlefleet_ops-*.whl paddlefleet_ops-0.0.0-cp${PY_VERSION_SHORT}-cp${PY_VERSION_SHORT}-linux_x86_64.whl
+            python ../bos/BosClient.py paddlefleet_ops-0.0.0-cp${PY_VERSION_SHORT}-cp${PY_VERSION_SHORT}-linux_x86_64.whl paddle-github-action/PaddleFleet/${BRANCH}/latest/${{ matrix.xpu.bos_XPU }}
+            python ../bos/BosClient.py commitid paddle-github-action/PaddleFleet/${BRANCH}/latest/${{ matrix.xpu.bos_XPU }}
+          elif [[ "${{ github.ref_type }}" == "tag" ]]; then
+            python ../bos/BosClient.py paddlefleet_ops-*.whl paddle-whl/stable/${{ matrix.xpu.bos_XPU }}/paddlefleet-ops
+          else
+            python ../bos/BosClient.py paddlefleet_ops-*.whl paddle-whl/nightly/${{ matrix.xpu.bos_XPU }}/paddlefleet-ops
+            export AK=paddle
+            export SK=paddle
+            python ../bos/BosClient.py paddlefleet_ops-*.whl paddle-github-action/PaddleFleet/${BRANCH}/${COMMIT_ID}/${{ matrix.xpu.bos_XPU }}
+            PY_VERSION="${{ matrix.python_version }}"
+            PY_VERSION_SHORT="${PY_VERSION//./}"
+            cp paddlefleet_ops-*.whl paddlefleet_ops-0.0.0-cp${PY_VERSION_SHORT}-cp${PY_VERSION_SHORT}-linux_x86_64.whl
+            python ../bos/BosClient.py paddlefleet_ops-0.0.0-cp${PY_VERSION_SHORT}-cp${PY_VERSION_SHORT}-linux_x86_64.whl paddle-github-action/PaddleFleet/${BRANCH}/latest/${{ matrix.xpu.bos_XPU }}
             python ../bos/BosClient.py commitid paddle-github-action/PaddleFleet/${BRANCH}/latest/${{ matrix.xpu.bos_XPU }}
           fi
           curl https://www.paddlepaddle.org.cn/inner/whl/update/path/new


### PR DESCRIPTION
### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library  | Environment Adaptation ] -->
Environment Adaptation
### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features
### Description
<!-- Describe what you've done -->
在 XPU nightly wheel 发布 workflow（publish_wheel_nightly_xpu.yml）中新增 paddlefleet-ops wheel 的构建和上传步骤，使 XPU 平台的自定义算子包能够独立发布到 nightly/stable BOS 路径。

主要变更：
- 新增 "Build paddlefleet-ops wheel" step：设置版本号、启用 IS_XPU=1 环境变量，在 packages/paddlefleet_ops 目录下构建 wheel 并输出到 dist_ops/
- 新增 "Upload paddlefleet-ops wheel" step：根据触发事件类型（push/tag/其他）上传 wheel 到对应 BOS 路径