### PR TITLE
feat: add SmearGate embedding enhancement

### DIFF
--- a/src/paddlefleet/models/common/embeddings/language_model_embedding.py
+++ b/src/paddlefleet/models/common/embeddings/language_model_embedding.py
@@ -73,11 +73,21 @@ class LanguageModelEmbedding(FleetLayer):
                 "must be set to True."
             )
         self.tp_group = get_tensor_model_parallel_group_if_none(tp_group)
+
+        # SmearGate flag (read early for reduce_scatter decision)
+        self.smear_gate_enabled = getattr(config, "smear_gate_enabled", False)
+
+        # When SmearGate is enabled, we must disable the early reduce_scatter
+        # inside VocabParallelEmbedding, because SmearGate operates on [B, S, H]
+        # layout (shifts along sequence dim). If reduce_scatter runs first,
+        # the output becomes [S/TP, B, H] and SmearGate would incorrectly
+        # operate on the batch dimension.
         self.reduce_scatter_embeddings = (
             (not self.add_position_embedding)
             and self.num_tokentypes <= 0
             and self.sequence_parallel
             and self.scatter_to_sequence_parallel
+            and not self.smear_gate_enabled
         )
 
         # Word embeddings (parallel).
@@ -113,6 +123,14 @@ class LanguageModelEmbedding(FleetLayer):
                 )
         else:
             self.tokentype_embeddings = None
+
+        # SmearGate
+        if self.smear_gate_enabled:
+            from paddlefleet.models.common.embeddings.smear_gate import SmearGate
+            self.smear_gate = SmearGate(
+                hidden_size=config.hidden_size,
+                init_value=getattr(config, "smear_gate_init_value", 3.0),
+            )
 
         # Embeddings dropout
         self.embedding_dropout = paddle.nn.Dropout(
@@ -151,6 +169,11 @@ class LanguageModelEmbedding(FleetLayer):
             Tensor: The output embeddings
         """
         embed_tokens = self.embed_tokens(input_ids)
+
+        # SmearGate (applied before position embedding)
+        if self.smear_gate_enabled:
+            embed_tokens = self.smear_gate(embed_tokens)
+
         if self.add_position_embedding:
             position_embeddings = self.position_embeddings(position_ids)
             embeddings = embed_tokens + position_embeddings

--- a/src/paddlefleet/models/common/embeddings/smear_gate.py
+++ b/src/paddlefleet/models/common/embeddings/smear_gate.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+SmearGate: per-dimension gated blending of current and previous token embeddings.
+
+output[t] = gate * emb[t] + (1 - gate) * emb[t-1]
+
+Reference: OpenAI parameter-golf (SmearGate + OrthoInit + Muon WD)
+https://github.com/openai/parameter-golf
+"""
+
+import paddle
+import paddle.nn as nn
+from paddle import Tensor
+
+
+class SmearGate(nn.Layer):
+    """Per-dimension gated blending of current and previous token embeddings.
+
+    Args:
+        hidden_size: model hidden dimension (D)
+        init_value: initial gate logit value. sigmoid(3.0) ≈ 0.95 (near-identity)
+    """
+
+    def __init__(self, hidden_size: int, init_value: float = 3.0):
+        super().__init__()
+        self.gate_logit = self.create_parameter(
+            shape=[hidden_size],
+            default_initializer=nn.initializer.Constant(init_value),
+        )
+
+    def forward(self, embeddings: Tensor) -> Tensor:
+        """
+        Args:
+            embeddings: [B, S, D]
+        Returns:
+            [B, S, D] smeared embeddings
+        """
+        gate = paddle.sigmoid(self.gate_logit)
+        shifted = paddle.concat(
+            [paddle.zeros_like(embeddings[:, :1, :]), embeddings[:, :-1, :]],
+            axis=1,
+        )
+        return gate * embeddings + (1 - gate) * shifted

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -573,6 +573,15 @@ class TransformerConfig(ModelParallelConfig):
     """When using_sonic_moe is enabled, the computation part of the moelayer will use the implementation provided by SonicMoE."""
 
     ####################
+    # SmearGate
+    ####################
+    smear_gate_enabled: bool = False
+    """Enable SmearGate: per-dim gated blending of current and previous token embeddings."""
+
+    smear_gate_init_value: float = 3.0
+    """Initial gate logit value. sigmoid(3.0) ≈ 0.95 (near-identity start)."""
+
+    ####################
     # MLA
     ####################
     """Configuration object for paddlefleet Multi-Latent Attention (MLA) transformers.


### PR DESCRIPTION
## Summary

- Add SmearGate: per-dimension gated blending of current and previous token embeddings to the embedding layer
- Inspired by OpenAI parameter-golf approach: `output[t] = gate * emb[t] + (1 - gate) * emb[t-1]`
- Purely additive: controlled by `smear_gate_enabled` switch, zero overhead when disabled

## Configuration

```yaml
smear_gate_enabled: True
smear_gate_init_value: 3.0    # sigmoid(3.0) ≈ 0.95, near-identity initialization
```

## Design Rationale

- Gate logit initialized to 3.0 so sigmoid(3.0) ≈ 0.95, making the initial behavior near-identity (mostly passes current embedding through)
- Learnable per-dimension gate allows the model to adaptively decide how much context from the previous token to blend
- Adds only `hidden_size` trainable parameters (extremely lightweight)
- Applied after token embedding lookup but before position embedding addition

🤖 Generated with [Claude Code](https://claude.com/claude-code)