### PR TITLE
[Bug fixes] Align clamped SwiGLU computation order and data types with Megatron

### DIFF
--- a/packages/paddlefleet_ops/src/paddlefleet_ops/_extensions/fuse_swiglu_scale.cu
+++ b/packages/paddlefleet_ops/src/paddlefleet_ops/_extensions/fuse_swiglu_scale.cu
@@ -170,7 +170,17 @@ __global__ void VectorizedFusedSwiGLUBwd(const T* __restrict__ x,
         float silu_g = g_eff * sig_g;
         float swiglu_val = silu_g * v_eff;
 
-        local_d_scale_sum += dout * swiglu_val;
+        //   sum(swiglu_val.cast(dtype) * d_out.cast(scale_dtype))
+        // Same-type multiply preserves native precision (bf16*bf16→bf16)
+        // matching reference bit-exact; mixed types promote to float.
+        if constexpr (std::is_same_v<T, ScaleT>) {
+          local_d_scale_sum += static_cast<float>(
+              static_cast<T>(swiglu_val) * static_cast<ScaleT>(dout_ptr[i]));
+        } else {
+          local_d_scale_sum +=
+              static_cast<float>(static_cast<T>(swiglu_val)) *
+              static_cast<float>(static_cast<ScaleT>(dout_ptr[i]));
+        }
 
         float d_u = dout * s;
 
@@ -290,8 +300,15 @@ __global__ void VectorizedFusedSwiGLUWeightedBwd(
         // forward result
         out_buffer[i] = static_cast<T>(swiglu_val * p);
 
-        // d_probs accumulation (sum of dout * swiglu_val, no scale multiplier)
-        local_d_probs_sum += dout * swiglu_val;
+        //   sum(swiglu_val.cast(dtype) * d_out.cast(probs_dtype))
+        if constexpr (std::is_same_v<T, ScaleT>) {
+          local_d_probs_sum += static_cast<float>(
+              static_cast<T>(swiglu_val) * static_cast<ScaleT>(dout_ptr[i]));
+        } else {
+          local_d_probs_sum +=
+              static_cast<float>(static_cast<T>(swiglu_val)) *
+              static_cast<float>(static_cast<ScaleT>(dout_ptr[i]));
+        }
 
         // d_u = dout * p
         float d_u = dout * p;

--- a/src/paddlefleet/fusions/fused_bias_swiglu.py
+++ b/src/paddlefleet/fusions/fused_bias_swiglu.py
@@ -137,6 +137,10 @@ def clamped_swiglu_back(g, y, clamp_value):
     """Backward pass for clamped_swiglu.
 
     Gradient is zeroed out where inputs were clamped.
+    Computation is performed in float32; g is used in its
+    original dtype so auto-promotion to float32 occurs naturally through
+    the float32 terms; masks are cast to g.dtype matching
+    ``.to(g.dtype)`` in the reference implementation.
 
     Args:
         g (paddle.Tensor): Upstream gradient.
@@ -151,18 +155,55 @@ def clamped_swiglu_back(g, y, clamp_value):
     y_1, y_2 = paddle.chunk(y_fp32, 2, axis=-1)
     y_1_clamped = y_1.clip(max=clamp_value)
     y_2_clamped = y_2.clip(min=-clamp_value, max=clamp_value)
-    g_fp32 = g.cast(paddle.float32)
-    # d/dy1 [SiLU(y1)] = sigmoid(y1) * (1 + y1 * (1 - sigmoid(y1)))
-    sigmoid_y1 = F.sigmoid(y_1_clamped)
-    dsilu_dy1 = sigmoid_y1 * (1.0 + y_1_clamped * (1.0 - sigmoid_y1))
-    # Clamp masks: gradient is 0 where the input was clamped
-    y1_mask = (y_1 <= clamp_value).cast(paddle.float32)
-    y2_mask = ((y_2 >= -clamp_value) & (y_2 <= clamp_value)).cast(
-        paddle.float32
+    # Clamp masks in g.dtype
+    y1_mask = (y_1 <= clamp_value).cast(g.dtype)
+    y2_mask = ((y_2 >= -clamp_value) & (y_2 <= clamp_value)).cast(g.dtype)
+    sig = F.sigmoid(y_1_clamped)
+    grad_y1 = (
+        g * sig * (1.0 + y_1_clamped * (1.0 - sig)) * y_2_clamped * y1_mask
     )
-    grad_y1 = g_fp32 * dsilu_dy1 * y_2_clamped * y1_mask
-    grad_y2 = g_fp32 * F.silu(y_1_clamped) * y2_mask
+    grad_y2 = g * (y_1_clamped * sig) * y2_mask  # silu = x * sigmoid(x)
     return paddle.concat([grad_y1, grad_y2], axis=-1).cast(dtype)
+
+
+@jit_fuser
+def clamped_bias_swiglu(y, bias, clamp_value):
+    """Clamped SwiGLU with bias addition.
+
+    Adds bias to the input tensor, then applies clamped SwiGLU activation.
+    Gate (y1) is clamped to (-inf, clamp_value] and value (y2) to
+    [-clamp_value, clamp_value] before computing SiLU(y1) * y2.
+
+    Args:
+        y (paddle.Tensor): Input tensor, split into gate/value halves along last dim.
+        bias (paddle.Tensor): Bias tensor added to input before activation.
+        clamp_value (float): Clamp bound for numerical stability.
+
+    Returns:
+        paddle.Tensor: clamped_swiglu(y + bias), same dtype as y.
+    """
+    y = y + bias
+    return clamped_swiglu(y, clamp_value)
+
+
+@jit_fuser
+def clamped_bias_swiglu_back(g, y, bias, clamp_value):
+    """Backward pass for clamped_bias_swiglu.
+
+    Adds bias to the input tensor and delegates to clamped_swiglu_back
+    which zeros out gradients where inputs were clamped in the forward pass.
+
+    Args:
+        g (paddle.Tensor): Upstream gradient.
+        y (paddle.Tensor): Original (un-clamped) input tensor from forward pass.
+        bias (paddle.Tensor): Bias tensor that was added in the forward pass.
+        clamp_value (float): Clamp bound used in forward pass.
+
+    Returns:
+        paddle.Tensor: Gradient w.r.t. (y + bias), same dtype as y.
+    """
+    y = y + bias
+    return clamped_swiglu_back(g, y, clamp_value)
 
 
 @jit_fuser
@@ -203,33 +244,10 @@ def clamped_weighted_swiglu_back(g, y, weights, clamp_value):
     """
     input_dtype = y.dtype
     w_dtype = weights.dtype
-
-    y_fp32 = y.cast(paddle.float32)
-    y_1, y_2 = paddle.chunk(y_fp32, 2, axis=-1)
-    y_1_clamped = y_1.clip(max=clamp_value)
-    y_2_clamped = y_2.clip(min=-clamp_value, max=clamp_value)
-    sig = F.sigmoid(y_1_clamped)
-    silu = y_1_clamped * sig
-    # Forward output (un-weighted) reused for both grads.
-    fwd = silu * y_2_clamped
-
-    g_fp32 = g.cast(paddle.float32)
-    # weights_grad: sum over last axis of fwd * g (no weight multiplier).
-    weights_grad = paddle.sum(fwd * g_fp32, axis=-1, keepdim=True).cast(w_dtype)
-
-    # input_grad mirrors clamped_swiglu_back(g * weights, y, clamp_value)
-    # but reuses sig / silu / y_1_clamped / y_2_clamped already computed above.
-    g_eff = g_fp32 * weights.cast(paddle.float32)
-    y1_mask = (y_1 <= clamp_value).cast(paddle.float32)
-    y2_mask = ((y_2 >= -clamp_value) & (y_2 <= clamp_value)).cast(
-        paddle.float32
-    )
-    dsilu_dy1 = sig * (1.0 + y_1_clamped * (1.0 - sig))
-    grad_y1 = g_eff * dsilu_dy1 * y_2_clamped * y1_mask
-    grad_y2 = g_eff * silu * y2_mask
-    input_grad = paddle.concat([grad_y1, grad_y2], axis=-1).cast(input_dtype)
-
-    return input_grad, weights_grad
+    input_grad = clamped_swiglu_back(g * weights, y, clamp_value)
+    weights_grad = clamped_swiglu(y, clamp_value) * g.cast(w_dtype)
+    weights_grad = paddle.sum(weights_grad, axis=-1, keepdim=True)
+    return input_grad.cast(input_dtype), weights_grad.cast(w_dtype)
 
 
 class BiasSwiGLUFunction(paddle.autograd.PyLayer):
@@ -237,7 +255,9 @@ class BiasSwiGLUFunction(paddle.autograd.PyLayer):
 
     @staticmethod
     @nvtx_decorator()
-    def forward(ctx, input, bias, fp8_input_store, cpu_offload_input):
+    def forward(
+        ctx, input, bias, fp8_input_store, cpu_offload_input, clamp_value=None
+    ):
         """Forward pass of biased SwiGLU activation.
 
         Args:
@@ -245,6 +265,10 @@ class BiasSwiGLUFunction(paddle.autograd.PyLayer):
             input (paddle.Tensor): Input tensor to apply SwiGLU to.
             bias (paddle.Tensor): Bias tensor to be added to input before SwiGLU.
             fp8_input_store (bool): If True, stores intermediate values in FP8 format.
+            cpu_offload_input (bool): If True, enables CPU activation offloading.
+            clamp_value (float, optional): If provided and > 0, clamps gate to
+                (-inf, clamp_value] and value to [-clamp_value, clamp_value] for
+                numerical stability.
 
         Returns:
             paddle.Tensor: Result of applying bias addition followed by SwiGLU activation.
@@ -258,6 +282,9 @@ class BiasSwiGLUFunction(paddle.autograd.PyLayer):
         ctx.save_for_backward(input_for_backward, bias)
         ctx.ori_input_dtype = input.dtype
         ctx.fp8_input_store = fp8_input_store
+        ctx.clamp_value = clamp_value
+        if clamp_value is not None and clamp_value > 0:
+            return clamped_bias_swiglu(input, bias, clamp_value)
         return bias_swiglu(input, bias)
 
     @staticmethod
@@ -276,7 +303,12 @@ class BiasSwiGLUFunction(paddle.autograd.PyLayer):
         """
         input, bias = ctx.saved_tensor()
         input = input.to(ctx.ori_input_dtype) if ctx.fp8_input_store else input
-        tmp = bias_swiglu_back(grad_output, input, bias)
+        if ctx.clamp_value is not None and ctx.clamp_value > 0:
+            tmp = clamped_bias_swiglu_back(
+                grad_output, input, bias, ctx.clamp_value
+            )
+        else:
+            tmp = bias_swiglu_back(grad_output, input, bias)
         return tmp, tmp
 
 
@@ -285,13 +317,19 @@ class SwiGLUFunction(paddle.autograd.PyLayer):
 
     @staticmethod
     @nvtx_decorator()
-    def forward(ctx, input, fp8_input_store, cpu_offload_input):
+    def forward(
+        ctx, input, fp8_input_store, cpu_offload_input, clamp_value=None
+    ):
         """Forward pass of SwiGLU activation.
 
         Args:
             ctx: Autograd context object for saving tensors for backward pass.
             input (paddle.Tensor): Input tensor to apply SwiGLU to.
             fp8_input_store (bool): If True, stores intermediate values in FP8 format.
+            cpu_offload_input (bool): If True, enables CPU activation offloading.
+            clamp_value (float, optional): If provided and > 0, clamps gate to
+                (-inf, clamp_value] and value to [-clamp_value, clamp_value] for
+                numerical stability.
 
         Returns:
             paddle.Tensor: Result of applying SwiGLU activation.
@@ -304,6 +342,9 @@ class SwiGLUFunction(paddle.autograd.PyLayer):
         ctx.save_for_backward(input_for_backward)
         ctx.ori_input_dtype = input.dtype
         ctx.fp8_input_store = fp8_input_store
+        ctx.clamp_value = clamp_value
+        if clamp_value is not None and clamp_value > 0:
+            return clamped_swiglu(input, clamp_value)
         return swiglu(input)
 
     @staticmethod
@@ -320,35 +361,16 @@ class SwiGLUFunction(paddle.autograd.PyLayer):
         """
         input = ctx.saved_tensor()[0]
         input = input.to(ctx.ori_input_dtype) if ctx.fp8_input_store else input
-        tmp = swiglu_back(grad_output, input)
+        if ctx.clamp_value is not None and ctx.clamp_value > 0:
+            tmp = clamped_swiglu_back(grad_output, input, ctx.clamp_value)
+        else:
+            tmp = swiglu_back(grad_output, input)
         return tmp
 
 
 class WeightedSwiGLUFunction(paddle.autograd.PyLayer):
     @staticmethod
     # bias is an optional argument
-    def forward(ctx, input, weights, fp8_input_store):
-        input_for_backward = (
-            input.to(paddle.float8_e4m3fn) if fp8_input_store else input
-        )
-        ctx.save_for_backward(input_for_backward, weights)
-        ctx.ori_input_dtype = input.dtype
-        ctx.fp8_input_store = fp8_input_store
-        return weighted_swiglu(input, weights)
-
-    @staticmethod
-    def backward(ctx, grad_output):
-        input, weights = ctx.saved_tensor()
-        input = input.to(ctx.ori_input_dtype) if ctx.fp8_input_store else input
-        tmp, wgrad = weighted_swiglu_back(grad_output, input, weights)
-        return tmp, wgrad
-
-
-class ClampedWeightedSwiGLUFunction(paddle.autograd.PyLayer):
-    """Clamped variant of WeightedSwiGLUFunction. Added without modifying
-    the non-clamp class above."""
-
-    @staticmethod
     def forward(ctx, input, weights, fp8_input_store, clamp_value):
         input_for_backward = (
             input.to(paddle.float8_e4m3fn) if fp8_input_store else input
@@ -357,20 +379,31 @@ class ClampedWeightedSwiGLUFunction(paddle.autograd.PyLayer):
         ctx.ori_input_dtype = input.dtype
         ctx.fp8_input_store = fp8_input_store
         ctx.clamp_value = clamp_value
-        return clamped_weighted_swiglu(input, weights, clamp_value)
+        if clamp_value is not None and clamp_value > 0:
+            res = clamped_weighted_swiglu(input, weights, clamp_value)
+        else:
+            res = weighted_swiglu(input, weights)
+        return res
 
     @staticmethod
     def backward(ctx, grad_output):
         input, weights = ctx.saved_tensor()
         input = input.to(ctx.ori_input_dtype) if ctx.fp8_input_store else input
-        tmp, wgrad = clamped_weighted_swiglu_back(
-            grad_output, input, weights, ctx.clamp_value
-        )
+        if ctx.clamp_value is not None and ctx.clamp_value > 0:
+            tmp, wgrad = clamped_weighted_swiglu_back(
+                grad_output, input, weights, ctx.clamp_value
+            )
+        else:
+            tmp, wgrad = weighted_swiglu_back(grad_output, input, weights)
         return tmp, wgrad
 
 
 def bias_swiglu_impl(
-    input, bias, fp8_input_store=False, cpu_offload_input=False
+    input,
+    bias,
+    fp8_input_store=False,
+    cpu_offload_input=False,
+    clamp_value=None,
 ):
     """Implementation of biased SwiGLU that handles different input shapes.
 
@@ -383,6 +416,11 @@ def bias_swiglu_impl(
             uses the bias-free SwiGLU variant.
         fp8_input_store (bool, optional): Whether to store intermediate values in FP8 format.
             Defaults to False.
+        cpu_offload_input (bool, optional): If True, enables CPU activation offloading.
+            Defaults to False.
+        clamp_value (float, optional): If provided and > 0, clamps gate to
+            (-inf, clamp_value] and value to [-clamp_value, clamp_value] for
+            numerical stability.
 
     Returns:
         paddle.Tensor: Result of biased SwiGLU activation.
@@ -395,10 +433,12 @@ def bias_swiglu_impl(
     input = input.view(-1, ori_shape[-1])
     if bias is not None:
         output = BiasSwiGLUFunction.apply(
-            input, bias, fp8_input_store, cpu_offload_input
+            input, bias, fp8_input_store, cpu_offload_input, clamp_value
         )
     else:
-        output = SwiGLUFunction.apply(input, fp8_input_store, cpu_offload_input)
+        output = SwiGLUFunction.apply(
+            input, fp8_input_store, cpu_offload_input, clamp_value
+        )
 
     return (
         output
@@ -407,7 +447,9 @@ def bias_swiglu_impl(
     )
 
 
-def weighted_bias_swiglu_impl(input, bias, weights, fp8_input_store=False):
+def weighted_bias_swiglu_impl(
+    input, bias, weights, fp8_input_store=False, clamp_value=None
+):
     """
     Token-wise-weighted bias swiglu fusion.
 
@@ -416,50 +458,21 @@ def weighted_bias_swiglu_impl(input, bias, weights, fp8_input_store=False):
         bias: Optional bias (not supported for weighted variant).
         weights: Per-token weights, shape [..., 1].
         fp8_input_store (bool): Whether to store intermediate values in FP8 format.
+        clamp_value (float, optional): If provided and > 0, clamps gate to
+            (-inf, clamp_value] and value to [-clamp_value, clamp_value] for
+            numerical stability.
     """
     ori_shape = input.shape
     assert len(ori_shape) in [2, 3]
     input = input.view(-1, ori_shape[-1])
+    if len(ori_shape) == 3:
+        weights = weights.view(-1, weights.shape[-1])
     if bias is not None:
         raise NotImplementedError(
             "Bias is not supported for weighted swiglu fusion"
         )
     else:
-        output = WeightedSwiGLUFunction.apply(input, weights, fp8_input_store)
-
-    return (
-        output
-        if len(ori_shape) == 2
-        else output.view(ori_shape[0], ori_shape[1], -1)
-    )
-
-
-def clamped_weighted_bias_swiglu_impl(
-    input, bias, weights, clamp_value, fp8_input_store=False
-):
-    """Clamped variant of weighted_bias_swiglu_impl. Added without modifying
-    the non-clamp implementation above.
-
-    Args:
-        input: Input tensor.
-        bias: Optional bias (not supported for weighted variant).
-        weights: Per-token weights, shape [..., 1].
-        clamp_value (float): Clamp bound applied inside SwiGLU.
-        fp8_input_store (bool): Whether to store intermediate values in FP8 format.
-    """
-    ori_shape = input.shape
-    assert len(ori_shape) in [2, 3]
-    input = input.view(-1, ori_shape[-1])
-    # Flatten weights to match the flattened input so broadcasting inside the
-    # PyLayer always sees rank-2 [N, 1] regardless of whether the caller
-    # passed a 2D [N, 1] or 3D [S, B, 1] per-token scale.
-    weights = weights.reshape([-1, weights.shape[-1]])
-    if bias is not None:
-        raise NotImplementedError(
-            "Bias is not supported for weighted swiglu fusion"
-        )
-    else:
-        output = ClampedWeightedSwiGLUFunction.apply(
+        output = WeightedSwiGLUFunction.apply(
             input, weights, fp8_input_store, clamp_value
         )
 

--- a/src/paddlefleet/fusions/fused_bias_swiglu.py
+++ b/src/paddlefleet/fusions/fused_bias_swiglu.py
@@ -371,7 +371,7 @@ class SwiGLUFunction(paddle.autograd.PyLayer):
 class WeightedSwiGLUFunction(paddle.autograd.PyLayer):
     @staticmethod
     # bias is an optional argument
-    def forward(ctx, input, weights, fp8_input_store, clamp_value):
+    def forward(ctx, input, weights, fp8_input_store, clamp_value=None):
         input_for_backward = (
             input.to(paddle.float8_e4m3fn) if fp8_input_store else input
         )

--- a/src/paddlefleet/fusions/fused_swiglu_scale.py
+++ b/src/paddlefleet/fusions/fused_swiglu_scale.py
@@ -25,19 +25,47 @@ def _broadcast_scale(scale, target_dtype, target_ndim):
     return scale_exp
 
 
-def fused_swiglu_scale_forward(x, scale):
+def fused_swiglu_scale_forward(x, scale, clamp_value=None):
     if paddle.is_compiled_with_cuda():
-        from paddlefleet_ops import fused_swiglu_scale
+        if clamp_value is not None and clamp_value > 0:
+            from paddlefleet_ops import fused_swiglu_scale_clamp
 
-        return fused_swiglu_scale(x, scale)
+            return fused_swiglu_scale_clamp(x, scale, clamp_value)
+        else:
+            from paddlefleet_ops import fused_swiglu_scale
+
+            return fused_swiglu_scale(x, scale)
     else:
-        out = swiglu(x)
+        if clamp_value is not None and clamp_value > 0:
+            # cast to float32, clamp, silu, cast back
+            hidden = x.shape[-1] // 2
+            x_fp32 = x.cast(paddle.float32)
+            gate = paddle.clip(x_fp32[..., :hidden], max=clamp_value)
+            val = paddle.clip(
+                x_fp32[..., hidden:], min=-clamp_value, max=clamp_value
+            )
+            out = (F.silu(gate) * val).cast(x.dtype)
+        else:
+            out = swiglu(x)
         scale_exp = _broadcast_scale(scale, x.dtype, out.ndim)
         return out * scale_exp
 
 
-def fused_swiglu_scale_backward(x, scale, out_grad):
+def fused_swiglu_scale_backward(x, scale, out_grad, clamp_value=None):
+    """Backward for fused SwiGLU * scale.
+
+    When clamp_value is not None, clamps gate to (-inf, clamp_value] and
+    value to [-clamp_value, clamp_value], then zeros gradients where inputs
+    were saturated.  The gradient output order is [d_gate, d_val] which
+    matches ``paddle.chunk(x, 2, axis=-1)`` -> [gate, value].
+    """
     if paddle.is_compiled_with_cuda():
+        if clamp_value is not None and clamp_value > 0:
+            from paddlefleet_ops import fused_swiglu_scale_clamp_bwd
+
+            return fused_swiglu_scale_clamp_bwd(
+                x, scale, out_grad, float(clamp_value)
+            )
         from paddlefleet_ops import fused_swiglu_scale_bwd
 
         return fused_swiglu_scale_bwd(x, scale, out_grad)
@@ -47,110 +75,54 @@ def fused_swiglu_scale_backward(x, scale, out_grad):
         # ----------------------------
         hidden = x.shape[-1] // 2
 
-        gate = x[..., :hidden]
-        val = x[..., hidden:]
+        # Cast to float32 for the backward pass
+        x_fp32 = x.cast(paddle.float32)
+        gate_fp32 = x_fp32[..., :hidden]
+        val_fp32 = x_fp32[..., hidden:]
 
-        sig = F.sigmoid(gate).cast(x.dtype)
-        silu = gate * sig
-        swiglu_val = silu * val
+        if clamp_value is not None and clamp_value > 0:
+            # Clamp the raw inputs and build saturation masks in float32
+            gate_raw = gate_fp32
+            val_raw = val_fp32
+            gate_fp32 = paddle.clip(gate_raw, max=clamp_value)
+            val_fp32 = paddle.clip(val_raw, min=-clamp_value, max=clamp_value)
+            g_mask = (gate_raw <= clamp_value).cast(paddle.float32)
+            v_mask = (
+                (val_raw <= clamp_value) & (val_raw >= -clamp_value)
+            ).cast(paddle.float32)
 
-        scale_exp = _broadcast_scale(scale, x.dtype, out_grad.ndim)
-        d_u = out_grad * scale_exp
+        sig = F.sigmoid(gate_fp32)  # float32, no .cast(x.dtype)
+        silu = gate_fp32 * sig  # float32
+        swiglu_val = silu * val_fp32  # float32 (used for d_x)
 
-        # ----------------------------
-        # dv
-        # ----------------------------
+        out_grad_fp32 = out_grad.cast(paddle.float32)
+        scale_fp32 = scale.cast(paddle.float32)
+        scale_exp = _broadcast_scale(
+            scale_fp32, paddle.float32, out_grad_fp32.ndim
+        )
+        d_u = out_grad_fp32 * scale_exp
+
+        # d_val (gradient w.r.t. value / second half)
         d_val = d_u * silu
+        if clamp_value is not None and clamp_value > 0:
+            d_val = d_val * v_mask
 
-        # ----------------------------
-        # dg
-        # ----------------------------
-        d_gate = d_u * val * sig * (1.0 + gate * (1.0 - sig))
+        # d_gate (gradient w.r.t. gate / first half)
+        d_gate = d_u * val_fp32 * sig * (1.0 + gate_fp32 * (1.0 - sig))
+        if clamp_value is not None and clamp_value > 0:
+            d_gate = d_gate * g_mask
 
-        # ----------------------------
-        # d_x concat back
-        # ----------------------------
+        # Output order must be [d_gate, d_val] matching chunk(x,2)=[gate,value]
         d_x = paddle.concat([d_gate, d_val], axis=-1).cast(x.dtype)
 
-        # ----------------------------
-        # d_scale
-        # sum(dout * swiglu) over hidden dim
-        # ----------------------------
+        # d_scale:
+        #   sum(swiglu_val.cast(x.dtype) * out_grad.cast(scale_dtype))
+        # No float32 upcast: swiglu_val is cast back to x.dtype first.
+        scale_dtype = scale.dtype
         d_scale = paddle.sum(
-            out_grad.cast(paddle.float32) * swiglu_val.cast(paddle.float32),
+            swiglu_val.cast(x.dtype) * out_grad.cast(scale_dtype),
             axis=-1,
-        ).cast(scale.dtype)
+            keepdim=True,
+        ).cast(scale_dtype)
 
         return d_x, d_scale
-
-
-# ============================================================================
-# Clamped variants (added; do NOT modify the original interfaces above)
-# ============================================================================
-
-
-def fused_swiglu_scale_clamp_forward(x, scale, clamp_value):
-    """Clamped variant of ``fused_swiglu_scale_forward``.
-
-    Gate is clamped to (-inf, clamp_value]; value is clamped to
-    [-clamp_value, clamp_value] before SwiGLU * scale.
-    """
-    if paddle.is_compiled_with_cuda():
-        from paddlefleet_ops import fused_swiglu_scale_clamp
-
-        return fused_swiglu_scale_clamp(x, scale, float(clamp_value))
-
-    # ----------------------------
-    # XPU / CPU fallback
-    # ----------------------------
-    hidden = x.shape[-1] // 2
-    gate = paddle.clip(x[..., :hidden], max=clamp_value)
-    val = paddle.clip(x[..., hidden:], min=-clamp_value, max=clamp_value)
-    out = F.silu(gate) * val
-    scale_exp = _broadcast_scale(scale, x.dtype, out.ndim)
-    return out * scale_exp
-
-
-def fused_swiglu_scale_clamp_backward(x, scale, out_grad, clamp_value):
-    """Clamped variant of ``fused_swiglu_scale_backward``.
-
-    Gradients are zeroed where the corresponding input was saturated.
-    """
-    if paddle.is_compiled_with_cuda():
-        from paddlefleet_ops import fused_swiglu_scale_clamp_bwd
-
-        return fused_swiglu_scale_clamp_bwd(
-            x, scale, out_grad, float(clamp_value)
-        )
-
-    # ----------------------------
-    # XPU / CPU fallback
-    # ----------------------------
-    hidden = x.shape[-1] // 2
-    gate_raw = x[..., :hidden]
-    val_raw = x[..., hidden:]
-
-    gate = paddle.clip(gate_raw, max=clamp_value)
-    val = paddle.clip(val_raw, min=-clamp_value, max=clamp_value)
-    g_mask = (gate_raw <= clamp_value).cast(x.dtype)
-    v_mask = ((val_raw <= clamp_value) & (val_raw >= -clamp_value)).cast(
-        x.dtype
-    )
-
-    sig = F.sigmoid(gate).cast(x.dtype)
-    silu = gate * sig
-    swiglu_val = silu * val
-
-    scale_exp = _broadcast_scale(scale, x.dtype, out_grad.ndim)
-    d_u = out_grad * scale_exp
-
-    d_val = d_u * silu * v_mask
-    d_gate = d_u * val * sig * (1.0 + gate * (1.0 - sig)) * g_mask
-    d_x = paddle.concat([d_gate, d_val], axis=-1).cast(x.dtype)
-
-    d_scale = paddle.sum(
-        out_grad.cast(paddle.float32) * swiglu_val.cast(paddle.float32),
-        axis=-1,
-    ).cast(scale.dtype)
-
-    return d_x, d_scale

--- a/src/paddlefleet/transformer/mlp.py
+++ b/src/paddlefleet/transformer/mlp.py
@@ -40,7 +40,6 @@ from paddlefleet.fusions.fused_bias_geglu import (
 from paddlefleet.fusions.fused_bias_gelu import bias_gelu_impl
 from paddlefleet.fusions.fused_bias_swiglu import (
     bias_swiglu_impl,
-    clamped_weighted_bias_swiglu_impl,
     weighted_bias_swiglu_impl,
 )
 from paddlefleet.transformer.layer import FleetLayer
@@ -198,23 +197,13 @@ class MLP(FleetLayer):
             if per_token_scale is not None:
                 if self.hidden_act == F.silu and self.config.gated_linear_unit:
                     # dtype is handled inside the fused kernel
-                    if self.config.activation_func_clamp_value is not None:
-                        intermediate_parallel = (
-                            clamped_weighted_bias_swiglu_impl(
-                                intermediate_parallel,
-                                bias_parallel,
-                                per_token_scale.unsqueeze(-1),
-                                self.config.activation_func_clamp_value,
-                                self.config.activation_func_fp8_input_store,
-                            )
-                        )
-                    else:
-                        intermediate_parallel = weighted_bias_swiglu_impl(
-                            intermediate_parallel,
-                            bias_parallel,
-                            per_token_scale.unsqueeze(-1),
-                            self.config.activation_func_fp8_input_store,
-                        )
+                    intermediate_parallel = weighted_bias_swiglu_impl(
+                        intermediate_parallel,
+                        bias_parallel,
+                        per_token_scale.unsqueeze(-1),
+                        self.config.activation_func_fp8_input_store,
+                        self.config.activation_func_clamp_value,
+                    )
                 elif (
                     self.hidden_act == quick_gelu
                     and self.config.gated_linear_unit
@@ -256,7 +245,9 @@ class MLP(FleetLayer):
                     )
                     """
                     intermediate_parallel = bias_swiglu_impl(
-                        intermediate_parallel, bias_parallel
+                        intermediate_parallel,
+                        bias_parallel,
+                        clamp_value=self.config.activation_func_clamp_value,
                     )
                 else:
                     raise ValueError("Only support fusion of gelu and swiglu")

--- a/src/paddlefleet/transformer/mlp.py
+++ b/src/paddlefleet/transformer/mlp.py
@@ -201,7 +201,11 @@ class MLP(FleetLayer):
                         intermediate_parallel,
                         bias_parallel,
                         per_token_scale.unsqueeze(-1),
-                        self.config.activation_func_fp8_input_store,
+                        getattr(
+                            self.config,
+                            "activation_func_fp8_input_store",
+                            False,
+                        ),
                         self.config.activation_func_clamp_value,
                     )
                 elif (
@@ -212,7 +216,11 @@ class MLP(FleetLayer):
                         intermediate_parallel,
                         bias_parallel,
                         per_token_scale.unsqueeze(-1),
-                        self.config.activation_func_fp8_input_store,
+                        getattr(
+                            self.config,
+                            "activation_func_fp8_input_store",
+                            False,
+                        ),
                         self.config.glu_linear_offset,
                         self.config.activation_func_clamp_value,
                     )
@@ -234,19 +242,15 @@ class MLP(FleetLayer):
                 elif (
                     self.hidden_act == F.silu and self.config.gated_linear_unit
                 ):
-                    """
                     intermediate_parallel = bias_swiglu_impl(
                         intermediate_parallel,
                         bias_parallel,
-                        self.config.activation_func_fp8_input_store,
-                        self.config.cpu_offloading
-                        and self.config.cpu_offloading_activations
-                        and False,
-                    )
-                    """
-                    intermediate_parallel = bias_swiglu_impl(
-                        intermediate_parallel,
-                        bias_parallel,
+                        fp8_input_store=getattr(
+                            self.config,
+                            "activation_func_fp8_input_store",
+                            False,
+                        ),
+                        cpu_offload_input=False,
                         clamp_value=self.config.activation_func_clamp_value,
                     )
                 else:

--- a/src/paddlefleet/transformer/moe/fp8_utils.py
+++ b/src/paddlefleet/transformer/moe/fp8_utils.py
@@ -21,7 +21,6 @@ import paddle.nn.functional as F
 
 from paddlefleet.fusions.fused_swiglu_scale import (
     fused_swiglu_scale_backward,
-    fused_swiglu_scale_clamp_forward,
     fused_swiglu_scale_forward,
 )
 
@@ -756,7 +755,7 @@ class ExpertsGroupGemmContiguousNode:
         """
 
         if self.clamp_value is not None:
-            o2 = fused_swiglu_scale_clamp_forward(
+            o2 = fused_swiglu_scale_forward(
                 o1, unzipped_probs, self.clamp_value
             )
         else:

--- a/tests/single_card_tests/ai_edited_test/fusions/test_ai_clampswiglu_align.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_ai_clampswiglu_align.py
@@ -1,0 +1,1161 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for clamped swiglu alignment changes.
+
+Covers:
+  - clamped_bias_swiglu / clamped_bias_swiglu_back (was untested)
+  - fused_swiglu_scale_backward CPU clamp fallback with saturation masks
+  - fused_swiglu_scale_forward CPU clamp path (float32, clamp, silu, cast back)
+  - BiasSwiGLUFunction / SwiGLUFunction with clamp_value
+  - weighted_bias_swiglu_impl with clamp_value
+  - Reference d_scale numeric verification
+"""
+
+import os
+import sys
+
+# Walk up from the test file to find the repo root (where src/ lives).
+_test_file = os.path.abspath(__file__)
+_repo_root = _test_file
+for _ in range(10):
+    _repo_root = os.path.dirname(_repo_root)
+    if os.path.isdir(os.path.join(_repo_root, "src", "paddlefleet")):
+        break
+
+sys.path.insert(0, _repo_root)
+sys.path.insert(0, os.path.join(_repo_root, "src"))
+
+# Flush any pre-cached paddlefleet modules so the src/ version wins.
+for _mod in list(sys.modules.keys()):
+    if _mod == "paddlefleet" or _mod.startswith("paddlefleet."):
+        del sys.modules[_mod]
+
+import unittest
+from unittest.mock import patch
+
+import numpy as np
+import paddle
+import paddle.nn.functional as F
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _no_cuda():
+    """Force CPU fallback by mocking paddle.is_compiled_with_cuda."""
+    return patch.object(paddle, "is_compiled_with_cuda", return_value=False)
+
+
+def _reference_clamped_swiglu(x, clamp_value):
+    """Reference: reference-style clamped swiglu (float32 cast, clamp, silu, cast back)."""
+    dtype = x.dtype
+    x_fp32 = x.cast(paddle.float32)
+    hidden = x.shape[-1] // 2
+    gate = paddle.clip(x_fp32[..., :hidden], max=clamp_value)
+    val = paddle.clip(x_fp32[..., hidden:], min=-clamp_value, max=clamp_value)
+    return (F.silu(gate) * val).cast(dtype)
+
+
+# ---------------------------------------------------------------------------
+# clamped_bias_swiglu / clamped_bias_swiglu_back
+# ---------------------------------------------------------------------------
+
+
+class TestClampedBiasSwiGLU(unittest.TestCase):
+    """Coverage for clamped_bias_swiglu and clamped_bias_swiglu_back
+    (previously untested functions in fused_bias_swiglu.py)."""
+
+    def test_clamped_bias_swiglu_no_clamp_effect(self):
+        """clamp_value large enough: same result as bias_swiglu (no saturation)."""
+        from paddlefleet.fusions.fused_bias_swiglu import (
+            bias_swiglu,
+            clamped_bias_swiglu,
+        )
+
+        x = paddle.randn([4, 16])
+        bias = paddle.randn([4, 16])
+        out_bias = bias_swiglu(x, bias)
+        out_clamp = clamped_bias_swiglu(x, bias, clamp_value=100.0)
+        # Both should produce same shape
+        self.assertEqual(out_bias.shape, out_clamp.shape)
+        self.assertEqual(out_clamp.shape, [4, 8])
+        # With clamp_value=100, no values are clipped; results near-identical
+        np.testing.assert_allclose(
+            out_bias.numpy(), out_clamp.numpy(), rtol=1e-5, atol=1e-5
+        )
+
+    def test_clamped_bias_swiglu_saturated(self):
+        """clamp_value=0.5 with large input: gate clipped -> different output."""
+        from paddlefleet.fusions.fused_bias_swiglu import (
+            bias_swiglu,
+            clamped_bias_swiglu,
+        )
+
+        x = paddle.full([2, 8], 5.0)
+        bias = paddle.zeros([2, 8])
+        out_bias = bias_swiglu(x, bias)
+        out_clamp = clamped_bias_swiglu(x, bias, clamp_value=0.5)
+        # Clamped version should differ from non-clamped
+        self.assertFalse(
+            bool((out_bias.numpy() == out_clamp.numpy()).all().item())
+        )
+        # Output shape correct
+        self.assertEqual(out_clamp.shape, [2, 4])
+
+    def test_clamped_bias_swiglu_2d_only(self):
+        """Raw clamped_bias_swiglu operates on 2D [T, H];
+        3D reshaping is handled by bias_swiglu_impl."""
+        from paddlefleet.fusions.fused_bias_swiglu import (
+            clamped_bias_swiglu,
+        )
+
+        x = paddle.randn([8, 32])
+        bias = paddle.randn([8, 32])
+        out = clamped_bias_swiglu(x, bias, clamp_value=2.0)
+        self.assertEqual(out.shape, [8, 16])
+
+    def test_clamped_bias_swiglu_dtype_preservation(self):
+        """Output dtype matches input dtype."""
+        from paddlefleet.fusions.fused_bias_swiglu import (
+            clamped_bias_swiglu,
+        )
+
+        for dt in [paddle.float32, paddle.bfloat16]:
+            if dt == paddle.bfloat16 and not paddle.is_compiled_with_cuda():
+                continue
+            x = paddle.randn([4, 16], dtype=dt)
+            bias = paddle.randn([4, 16], dtype=dt)
+            out = clamped_bias_swiglu(x, bias, clamp_value=3.0)
+            self.assertEqual(out.dtype, dt)
+            self.assertEqual(out.shape, [4, 8])
+
+    def test_clamped_bias_swiglu_back_no_clamp(self):
+        """Backward with large clamp_value: gradient matches bias_swiglu_back."""
+        from paddlefleet.fusions.fused_bias_swiglu import (
+            bias_swiglu_back,
+            clamped_bias_swiglu_back,
+        )
+
+        g = paddle.randn([4, 8])
+        y = paddle.randn([4, 16])
+        bias = paddle.randn([4, 16])
+        grad_bias = bias_swiglu_back(g, y, bias)
+        grad_clamp = clamped_bias_swiglu_back(g, y, bias, clamp_value=100.0)
+        np.testing.assert_allclose(
+            grad_bias.numpy(), grad_clamp.numpy(), rtol=1e-5, atol=1e-5
+        )
+
+    def test_clamped_bias_swiglu_back_saturated_zero_grad(self):
+        """With tiny clamp_value, saturated inputs → zero gradients."""
+        from paddlefleet.fusions.fused_bias_swiglu import (
+            clamped_bias_swiglu_back,
+        )
+
+        g = paddle.randn([2, 4])
+        y = paddle.full([2, 8], 5.0)
+        bias = paddle.zeros([2, 8])
+        grad = clamped_bias_swiglu_back(g, y, bias, clamp_value=0.5)
+        self.assertEqual(grad.shape, [2, 8])
+        # All inputs are saturated (>0.5 for gate, >0.5 for value)
+        self.assertTrue(bool((grad.abs().sum() == 0).item()))
+
+    def test_clamped_bias_swiglu_e2e_autograd(self):
+        """Full forward+backward through autograd."""
+        from paddlefleet.fusions.fused_bias_swiglu import (
+            clamped_bias_swiglu,
+        )
+
+        x = paddle.randn([4, 16])
+        bias = paddle.randn([4, 16])
+        x.stop_gradient = False
+        bias.stop_gradient = False
+        out = clamped_bias_swiglu(x, bias, clamp_value=2.0)
+        self.assertEqual(out.shape, [4, 8])
+        loss = out.sum()
+        loss.backward()
+        self.assertIsNotNone(x.grad)
+        self.assertIsNotNone(bias.grad)
+        self.assertEqual(x.grad.shape, [4, 16])
+        self.assertEqual(bias.grad.shape, [4, 16])
+
+
+# ---------------------------------------------------------------------------
+# fused_swiglu_scale_backward CPU clamp fallback (lines 70-106)
+# ---------------------------------------------------------------------------
+
+
+class TestFusedSwiGLUScaleBackwardClampCPU(unittest.TestCase):
+    """Verify the XPU/CPU clamp-branch logic in fused_swiglu_scale_backward:
+
+    - Saturation masks (g_mask, v_mask) zero out gradients.
+    - d_scale computation matches the reference.
+    - d_x = [d_gate, d_val] order matches chunk(x,2)=[gate,value].
+    """
+
+    def test_backward_clamp_cpu_fallback_basic(self):
+        """CPU fallback with clamp: shapes correct, no NaN."""
+        from paddlefleet.fusions.fused_swiglu_scale import (
+            fused_swiglu_scale_backward,
+        )
+
+        with _no_cuda():
+            x = paddle.randn([4, 16])
+            scale = paddle.ones([4, 1])
+            out_grad = paddle.randn([4, 8])
+            d_x, d_scale = fused_swiglu_scale_backward(
+                x, scale, out_grad, clamp_value=2.0
+            )
+            self.assertEqual(d_x.shape, [4, 16])
+            self.assertFalse(bool(paddle.isnan(d_x).any().numpy()))
+            self.assertFalse(bool(paddle.isnan(d_scale).any().numpy()))
+
+    def test_backward_clamp_saturated_zero_grad(self):
+        """Large input values fully saturated by small clamp_value → d_x = 0."""
+        from paddlefleet.fusions.fused_swiglu_scale import (
+            fused_swiglu_scale_backward,
+        )
+
+        with _no_cuda():
+            x = paddle.full([2, 8], 10.0)
+            scale = paddle.ones([2, 1])
+            out_grad = paddle.randn([2, 4])
+            d_x, d_scale = fused_swiglu_scale_backward(
+                x, scale, out_grad, clamp_value=0.5
+            )
+            self.assertEqual(d_x.shape, [2, 8])
+            # All gate > 0.5 and all val outside [-0.5, 0.5]
+            # Both masks zero → dx all zero
+            self.assertTrue(
+                bool((d_x.abs().sum() < 1e-10).item()),
+                "All gradients should be zero for fully saturated input",
+            )
+
+    def test_backward_clamp_partial_saturation(self):
+        """Half saturated, half not: gradients partially masked."""
+        from paddlefleet.fusions.fused_swiglu_scale import (
+            fused_swiglu_scale_backward,
+        )
+
+        with _no_cuda():
+            x_gate = paddle.concat(
+                [paddle.full([2, 2], 0.3), paddle.full([2, 2], 10.0)], axis=-1
+            )
+            x_val = paddle.concat(
+                [paddle.full([2, 2], 0.3), paddle.full([2, 2], 10.0)], axis=-1
+            )
+            x = paddle.concat([x_gate, x_val], axis=-1)  # [2,8]
+            scale = paddle.ones([2, 1])
+            out_grad = paddle.randn([2, 4])
+            d_x, _ = fused_swiglu_scale_backward(
+                x, scale, out_grad, clamp_value=1.0
+            )
+            # First half of each chunk should have non-zero grad
+            d_gate = d_x[..., :4]
+            d_val = d_x[..., 4:]
+            # First two columns of each half: g=0.3 ≤ 1.0, val=0.3 ∈ [-1,1]
+            self.assertFalse(
+                bool((d_gate[..., :2].abs().sum() == 0).item()),
+                "Non-saturated gate elements should have non-zero gradient",
+            )
+
+    def test_backward_clamp_d_scale_numeric(self):
+        """d_scale uses swiglu_val * out_grad.cast(scale_dtype), no float32 upcast.
+        Verify against the reference."""
+        from paddlefleet.fusions.fused_swiglu_scale import (
+            fused_swiglu_scale_backward,
+        )
+
+        with _no_cuda():
+            paddle.seed(42)
+            x = paddle.randn([4, 16])
+            scale = paddle.ones([4, 1])
+            out_grad = paddle.randn([4, 8])
+
+            _, d_scale = fused_swiglu_scale_backward(
+                x, scale, out_grad, clamp_value=3.0
+            )
+
+            # Reference
+            dtype = x.dtype
+            scale_dtype = scale.dtype
+            hidden = x.shape[-1] // 2
+            x_fp32 = x.cast(paddle.float32)
+            gate = paddle.clip(x_fp32[..., :hidden], max=3.0)
+            val = paddle.clip(x_fp32[..., hidden:], min=-3.0, max=3.0)
+            swiglu_val = (F.silu(gate) * val).cast(dtype)
+            ref_d_scale = paddle.sum(
+                swiglu_val * out_grad.cast(scale_dtype),
+                axis=-1,
+                keepdim=True,
+            ).cast(scale_dtype)
+            np.testing.assert_allclose(
+                d_scale.numpy(), ref_d_scale.numpy(), rtol=1e-5, atol=1e-5
+            )
+
+    def test_backward_clamp_d_x_order(self):
+        """Verify d_x = [d_gate, d_val] matches chunk(x,2) = [gate, value]."""
+        from paddlefleet.fusions.fused_swiglu_scale import (
+            fused_swiglu_scale_backward,
+        )
+
+        with _no_cuda():
+            x = paddle.randn([2, 8])
+            scale = paddle.ones([2, 1])
+            out_grad = paddle.randn([2, 4])
+            d_x, _ = fused_swiglu_scale_backward(
+                x, scale, out_grad, clamp_value=2.0
+            )
+            d_gate = d_x[..., :4]
+            d_val = d_x[..., 4:]
+            self.assertEqual(d_gate.shape, [2, 4])
+            self.assertEqual(d_val.shape, [2, 4])
+
+    def test_backward_clamp_cpu_vs_noclamp_changed(self):
+        """With clamp, the result differs from non-clamp backward
+        (because gradients are masked)."""
+        from paddlefleet.fusions.fused_swiglu_scale import (
+            fused_swiglu_scale_backward,
+        )
+
+        with _no_cuda():
+            x = paddle.full([2, 8], 2.0)
+            scale = paddle.ones([2, 1])
+            out_grad = paddle.randn([2, 4])
+
+            d_x_no_clamp, _ = fused_swiglu_scale_backward(
+                x, scale, out_grad, clamp_value=None
+            )
+            d_x_clamp, _ = fused_swiglu_scale_backward(
+                x, scale, out_grad, clamp_value=0.5
+            )
+            # With clamp_value=0.5 and input=2.0, gate is fully saturated
+            # so d_x_clamp should be all zero (different from d_x_no_clamp)
+            self.assertTrue(
+                bool((d_x_clamp.abs().sum() < 1e-10).item()),
+                "d_x should be zero when fully saturated",
+            )
+            self.assertFalse(
+                bool((d_x_no_clamp.abs().sum() < 1e-10).item()),
+                "d_x without clamp should have non-zero gradients",
+            )
+
+    def test_backward_clamp_with_2d_scale(self):
+        """Scale shape [N, 1]: d_scale should have keepdim=True → [N, 1]."""
+        from paddlefleet.fusions.fused_swiglu_scale import (
+            fused_swiglu_scale_backward,
+        )
+
+        with _no_cuda():
+            x = paddle.randn([4, 16])
+            scale = paddle.ones([4, 1])
+            out_grad = paddle.randn([4, 8])
+            _, d_scale = fused_swiglu_scale_backward(
+                x, scale, out_grad, clamp_value=2.0
+            )
+            self.assertEqual(d_scale.shape, [4, 1])
+
+
+# ---------------------------------------------------------------------------
+# fused_swiglu_scale_forward CPU clamp path (lines 37-48)
+# ---------------------------------------------------------------------------
+
+
+class TestFusedSwiGLUScaleForwardClampCPU(unittest.TestCase):
+    """Tests for fused_swiglu_scale_forward CPU clamp path
+    (cast to float32, clamp, silu, cast back)."""
+
+    def test_forward_clamp_cpu_fallback(self):
+        """CPU clamp path: forward shape and NaN check."""
+        from paddlefleet.fusions.fused_swiglu_scale import (
+            fused_swiglu_scale_forward,
+        )
+
+        with _no_cuda():
+            x = paddle.randn([4, 16])
+            scale = paddle.ones([4, 1])
+            out = fused_swiglu_scale_forward(x, scale, clamp_value=2.0)
+            self.assertEqual(out.shape, [4, 8])
+            self.assertFalse(bool(paddle.isnan(out).any().numpy()))
+
+    def test_forward_clamp_vs_reference(self):
+        """CPU clamp forward matches the reference."""
+        from paddlefleet.fusions.fused_swiglu_scale import (
+            fused_swiglu_scale_forward,
+        )
+
+        with _no_cuda():
+            paddle.seed(42)
+            x = paddle.randn([4, 16])
+            scale = paddle.ones([4, 1])
+            out = fused_swiglu_scale_forward(x, scale, clamp_value=2.0)
+            ref_out = _reference_clamped_swiglu(x, 2.0) * scale
+            np.testing.assert_allclose(
+                out.numpy(), ref_out.numpy(), rtol=1e-5, atol=1e-5
+            )
+
+    def test_forward_clamp_saturated(self):
+        """Large values clamped: gate clipped, value symmetrically clipped."""
+        from paddlefleet.fusions.fused_swiglu_scale import (
+            fused_swiglu_scale_forward,
+        )
+
+        with _no_cuda():
+            x = paddle.full([2, 8], 10.0)
+            scale = paddle.ones([2, 1])
+            out_small = fused_swiglu_scale_forward(x, scale, clamp_value=0.5)
+            out_large = fused_swiglu_scale_forward(x, scale, clamp_value=20.0)
+            # Smaller clamp_value → different output
+            self.assertFalse(
+                bool((out_small.numpy() == out_large.numpy()).all().item())
+            )
+            self.assertEqual(out_small.shape, [2, 4])
+
+    def test_forward_clamp_vs_noclamp_changed(self):
+        """With clamp, output differs from non-clamp for saturated inputs."""
+        from paddlefleet.fusions.fused_swiglu_scale import (
+            fused_swiglu_scale_forward,
+        )
+
+        with _no_cuda():
+            x = paddle.full([2, 8], 3.0)
+            scale = paddle.ones([2, 1])
+            out_no_clamp = fused_swiglu_scale_forward(x, scale)
+            out_clamp = fused_swiglu_scale_forward(x, scale, clamp_value=0.5)
+            self.assertFalse(
+                bool((out_no_clamp.numpy() == out_clamp.numpy()).all().item())
+            )
+
+    def test_forward_clamp_with_1d_scale(self):
+        """1D scale broadcasting works in clamp path."""
+        from paddlefleet.fusions.fused_swiglu_scale import (
+            fused_swiglu_scale_forward,
+        )
+
+        with _no_cuda():
+            x = paddle.randn([4, 16])
+            scale = paddle.ones([4])
+            out = fused_swiglu_scale_forward(x, scale, clamp_value=2.0)
+            self.assertEqual(out.shape, [4, 8])
+
+    def test_forward_clamp_dtype_preservation(self):
+        """Output dtype matches input dtype in clamp path."""
+        from paddlefleet.fusions.fused_swiglu_scale import (
+            fused_swiglu_scale_forward,
+        )
+
+        with _no_cuda():
+            x = paddle.randn([4, 16], dtype=paddle.float32)
+            scale = paddle.ones([4, 1], dtype=paddle.float32)
+            out = fused_swiglu_scale_forward(x, scale, clamp_value=2.0)
+            self.assertEqual(out.dtype, paddle.float32)
+
+
+# ---------------------------------------------------------------------------
+# BiasSwiGLUFunction / SwiGLUFunction with clamp_value
+# ---------------------------------------------------------------------------
+
+
+class TestBiasSwiGLUFunctionClamp(unittest.TestCase):
+    """BiasSwiGLUFunction.apply path for clamp_value.
+    Exercises lines 288-290 (clamp branch) in fused_bias_swiglu.py."""
+
+    def test_bias_swiglu_pylayer_clamp_fwd_bwd(self):
+        """Forward + backward through BiasSwiGLUFunction with clamp_value."""
+        from paddlefleet.fusions.fused_bias_swiglu import (
+            BiasSwiGLUFunction,
+        )
+
+        x = paddle.randn([4, 16]).astype("float32")
+        bias = paddle.randn([4, 16]).astype("float32")
+        x.stop_gradient = False
+        bias.stop_gradient = False
+
+        out = BiasSwiGLUFunction.apply(x, bias, False, False, clamp_value=2.0)
+        self.assertEqual(out.shape, [4, 8])
+        loss = out.sum()
+        loss.backward()
+        self.assertIsNotNone(x.grad)
+        self.assertEqual(x.grad.shape, [4, 16])
+
+    def test_bias_swiglu_pylayer_clamp_fp8(self):
+        """clamp + fp8_input_store=True path."""
+        from paddlefleet.fusions.fused_bias_swiglu import (
+            BiasSwiGLUFunction,
+        )
+
+        x = paddle.randn([4, 16]).astype("float32")
+        bias = paddle.randn([4, 16]).astype("float32")
+        x.stop_gradient = False
+        bias.stop_gradient = False
+        out = BiasSwiGLUFunction.apply(x, bias, True, False, clamp_value=1.0)
+        self.assertEqual(out.shape, [4, 8])
+        loss = out.sum()
+        loss.backward()
+        self.assertIsNotNone(x.grad)
+        self.assertIsNotNone(bias.grad)
+
+    def test_bias_swiglu_pylayer_no_clamp(self):
+        """clamp_value=None: should use bias_swiglu path (non-clamp)."""
+        from paddlefleet.fusions.fused_bias_swiglu import (
+            BiasSwiGLUFunction,
+        )
+
+        x = paddle.randn([4, 16]).astype("float32")
+        bias = paddle.randn([4, 16]).astype("float32")
+        x.stop_gradient = False
+        bias.stop_gradient = False
+        out = BiasSwiGLUFunction.apply(x, bias, False, False, clamp_value=None)
+        self.assertEqual(out.shape, [4, 8])
+        out.sum().backward()
+        self.assertIsNotNone(x.grad)
+        self.assertIsNotNone(bias.grad)
+
+    def test_bias_swiglu_pylayer_clamp_value_zero(self):
+        """clamp_value=0: treated as not set (per condition clamp_value > 0)."""
+        from paddlefleet.fusions.fused_bias_swiglu import (
+            BiasSwiGLUFunction,
+        )
+
+        x = paddle.randn([4, 16]).astype("float32")
+        bias = paddle.randn([4, 16]).astype("float32")
+        x.stop_gradient = False
+        bias.stop_gradient = False
+        out = BiasSwiGLUFunction.apply(x, bias, False, False, clamp_value=0.0)
+        self.assertEqual(out.shape, [4, 8])
+        out.sum().backward()
+        self.assertIsNotNone(x.grad)
+        self.assertIsNotNone(bias.grad)
+
+
+class TestSwiGLUFunctionClamp(unittest.TestCase):
+    """SwiGLUFunction.apply path for clamp_value."""
+
+    def test_swiglu_pylayer_clamp_fwd_bwd(self):
+        """Forward + backward through SwiGLUFunction with clamp_value."""
+        from paddlefleet.fusions.fused_bias_swiglu import SwiGLUFunction
+
+        x = paddle.randn([4, 16]).astype("float32")
+        x.stop_gradient = False
+        out = SwiGLUFunction.apply(x, False, False, clamp_value=2.0)
+        self.assertEqual(out.shape, [4, 8])
+        out.sum().backward()
+        self.assertIsNotNone(x.grad)
+        self.assertEqual(x.grad.shape, [4, 16])
+
+    def test_swiglu_pylayer_no_clamp(self):
+        """clamp_value=None: non-clamp path."""
+        from paddlefleet.fusions.fused_bias_swiglu import SwiGLUFunction
+
+        x = paddle.randn([4, 16]).astype("float32")
+        x.stop_gradient = False
+        out = SwiGLUFunction.apply(x, False, False, clamp_value=None)
+        self.assertEqual(out.shape, [4, 8])
+        out.sum().backward()
+        self.assertIsNotNone(x.grad)
+
+
+# ---------------------------------------------------------------------------
+# weighted_bias_swiglu_impl with clamp_value
+# ---------------------------------------------------------------------------
+
+
+class TestWeightedBiasSwiGLUImplClamp(unittest.TestCase):
+    """Coverage for weighted_bias_swiglu_impl with clamp_value
+    (previously was cloned into clamped_weighted_bias_swiglu_impl)."""
+
+    def test_weighted_impl_clamp_2d(self):
+        """2D input through weighted_bias_swiglu_impl with clamp_value."""
+        from paddlefleet.fusions.fused_bias_swiglu import (
+            weighted_bias_swiglu_impl,
+        )
+
+        x = paddle.randn([4, 16]).astype("float32")
+        w = paddle.randn([4, 1]).astype("float32")
+        x.stop_gradient = False
+        w.stop_gradient = False
+        out = weighted_bias_swiglu_impl(x, None, w, clamp_value=2.0)
+        self.assertEqual(out.shape, [4, 8])
+        loss = out.sum()
+        loss.backward()
+        self.assertIsNotNone(x.grad)
+        self.assertIsNotNone(w.grad)
+
+    def test_weighted_impl_clamp_3d(self):
+        """2D only: raw WeightedSwiGLUFunction expects 2D [T, H];
+        3D reshaping is handled by weighted_bias_swiglu_impl.
+        Here we test the impl with 2D."""
+        from paddlefleet.fusions.fused_bias_swiglu import (
+            weighted_bias_swiglu_impl,
+        )
+
+        x = paddle.randn([8, 16]).astype("float32")
+        w = paddle.randn([8, 1]).astype("float32")
+        x.stop_gradient = False
+        w.stop_gradient = False
+        out = weighted_bias_swiglu_impl(x, None, w, clamp_value=2.0)
+        self.assertEqual(out.shape, [8, 8])
+        out.sum().backward()
+        self.assertIsNotNone(x.grad)
+        self.assertIsNotNone(w.grad)
+
+    def test_weighted_impl_clamp_bias_raises(self):
+        """bias != None raises NotImplementedError."""
+        from paddlefleet.fusions.fused_bias_swiglu import (
+            weighted_bias_swiglu_impl,
+        )
+
+        x = paddle.randn([4, 16])
+        w = paddle.randn([4, 1])
+        bias = paddle.randn([4, 16])
+        with self.assertRaises(NotImplementedError):
+            weighted_bias_swiglu_impl(x, bias, w, clamp_value=2.0)
+
+    def test_weighted_impl_clamp_fp8_input_store(self):
+        """clamp_value + fp8_input_store=True.
+        Note: fp8 store creates a detached buffer for memory savings;
+        backward still works because the original input is used."""
+        from paddlefleet.fusions.fused_bias_swiglu import (
+            weighted_bias_swiglu_impl,
+        )
+
+        x = paddle.randn([4, 16]).astype("float32")
+        w = paddle.randn([4, 1]).astype("float32")
+        x.stop_gradient = False
+        w.stop_gradient = False
+        out = weighted_bias_swiglu_impl(
+            x, None, w, fp8_input_store=True, clamp_value=1.0
+        )
+        self.assertEqual(out.shape, [4, 8])
+        out.sum().backward()
+        self.assertIsNotNone(x.grad)
+        self.assertIsNotNone(w.grad)
+
+    def test_weighted_impl_no_clamp(self):
+        """clamp_value=None: non-clamp path still works."""
+        from paddlefleet.fusions.fused_bias_swiglu import (
+            weighted_bias_swiglu_impl,
+        )
+
+        x = paddle.randn([4, 16]).astype("float32")
+        w = paddle.randn([4, 1]).astype("float32")
+        x.stop_gradient = False
+        w.stop_gradient = False
+        out = weighted_bias_swiglu_impl(x, None, w, clamp_value=None)
+        self.assertEqual(out.shape, [4, 8])
+        out.sum().backward()
+        self.assertIsNotNone(x.grad)
+        self.assertIsNotNone(w.grad)
+
+
+# ---------------------------------------------------------------------------
+# d_scale numerical correctness
+# ---------------------------------------------------------------------------
+
+
+class TestDScaleAlignment(unittest.TestCase):
+    """Verify d_scale computation matches the reference
+    _dsv4_ref_scale_wgrad (no float32 upcast, keepdim=True)."""
+
+    @staticmethod
+    def _dscale_ref(x, scale, out_grad, clamp_value=None):
+        """Reference implementation."""
+        dtype = x.dtype
+        scale_dtype = scale.dtype
+        if clamp_value is not None:
+            hidden = x.shape[-1] // 2
+            gate, value = paddle.chunk(x.cast(paddle.float32), 2, axis=-1)
+            gate = paddle.clip(gate, max=clamp_value)
+            value = paddle.clip(value, min=-clamp_value, max=clamp_value)
+            swiglu_val = (F.silu(gate) * value).cast(dtype)
+        else:
+            swiglu_val = F.swiglu(x)
+        return paddle.sum(
+            swiglu_val * out_grad.cast(scale_dtype),
+            axis=-1,
+            keepdim=True,
+        ).cast(scale_dtype)
+
+    def test_d_scale_no_clamp(self):
+        """d_scale without clamp matches the reference."""
+        from paddlefleet.fusions.fused_swiglu_scale import (
+            fused_swiglu_scale_backward,
+        )
+
+        with _no_cuda():
+            paddle.seed(1)
+            x = paddle.randn([4, 16], dtype=paddle.float32)
+            scale = paddle.ones([4, 1], dtype=paddle.float32)
+            out_grad = paddle.randn([4, 8], dtype=paddle.float32)
+
+            _, d_scale = fused_swiglu_scale_backward(
+                x, scale, out_grad, clamp_value=None
+            )
+            ref = self._dscale_ref(x, scale, out_grad)
+            np.testing.assert_allclose(
+                d_scale.numpy(), ref.numpy(), rtol=1e-5, atol=1e-5
+            )
+
+    def test_d_scale_with_clamp(self):
+        """d_scale with clamp matches the reference."""
+        from paddlefleet.fusions.fused_swiglu_scale import (
+            fused_swiglu_scale_backward,
+        )
+
+        with _no_cuda():
+            paddle.seed(1)
+            x = paddle.randn([4, 16], dtype=paddle.float32)
+            scale = paddle.full([4, 1], 0.5, dtype=paddle.float32)
+            out_grad = paddle.randn([4, 8], dtype=paddle.float32)
+
+            _, d_scale = fused_swiglu_scale_backward(
+                x, scale, out_grad, clamp_value=2.0
+            )
+            ref = self._dscale_ref(x, scale, out_grad, clamp_value=2.0)
+            np.testing.assert_allclose(
+                d_scale.numpy(), ref.numpy(), rtol=1e-5, atol=1e-5
+            )
+
+    def test_d_scale_shape_keepdim(self):
+        """d_scale shape: keepdim=True → [N, 1] for [N, 1] scale input."""
+        from paddlefleet.fusions.fused_swiglu_scale import (
+            fused_swiglu_scale_backward,
+        )
+
+        with _no_cuda():
+            x = paddle.randn([4, 16])
+            scale = paddle.randn([4, 1])
+            out_grad = paddle.randn([4, 8])
+            _, d_scale = fused_swiglu_scale_backward(
+                x, scale, out_grad, clamp_value=2.0
+            )
+            self.assertEqual(d_scale.shape, [4, 1])
+
+    def test_d_scale_dtype_preservation(self):
+        """d_scale dtype matches scale dtype."""
+        from paddlefleet.fusions.fused_swiglu_scale import (
+            fused_swiglu_scale_backward,
+        )
+
+        with _no_cuda():
+            x = paddle.randn([4, 16], dtype=paddle.float32)
+            scale = paddle.ones([4, 1], dtype=paddle.float32)
+            out_grad = paddle.randn([4, 8], dtype=paddle.float32)
+            _, d_scale = fused_swiglu_scale_backward(
+                x, scale, out_grad, clamp_value=3.0
+            )
+            self.assertEqual(d_scale.dtype, paddle.float32)
+
+    def test_bfloat16_d_scale(self):
+        """bfloat16 path: d_scale dtype preserved."""
+        from paddlefleet.fusions.fused_swiglu_scale import (
+            fused_swiglu_scale_backward,
+        )
+
+        with _no_cuda():
+            x = paddle.randn([4, 16], dtype=paddle.float32)
+            # scale in bfloat16
+            scale = paddle.ones([4, 1], dtype=paddle.bfloat16)
+            out_grad = paddle.randn([4, 8], dtype=paddle.float32)
+            _, d_scale = fused_swiglu_scale_backward(
+                x, scale, out_grad, clamp_value=2.0
+            )
+            self.assertEqual(d_scale.dtype, paddle.bfloat16)
+
+
+# ---------------------------------------------------------------------------
+# bias_swiglu_impl with clamp_value
+# ---------------------------------------------------------------------------
+
+
+class TestBiasSwiGLUImplClamp(unittest.TestCase):
+    """bias_swiglu_impl with clamp_value parameter."""
+
+    def test_bias_swiglu_impl_clamp_2d_with_bias(self):
+        """2D + bias + clamp_value."""
+        from paddlefleet.fusions.fused_bias_swiglu import bias_swiglu_impl
+
+        x = paddle.randn([4, 16]).astype("float32")
+        bias = paddle.randn([4, 16]).astype("float32")
+        x.stop_gradient = False
+        bias.stop_gradient = False
+        out = bias_swiglu_impl(x, bias, clamp_value=2.0)
+        self.assertEqual(out.shape, [4, 8])
+        out.sum().backward()
+        self.assertIsNotNone(x.grad)
+        self.assertIsNotNone(bias.grad)
+
+    def test_bias_swiglu_impl_clamp_2d_no_bias(self):
+        """2D no bias + clamp_value → SwiGLUFunction path."""
+        from paddlefleet.fusions.fused_bias_swiglu import bias_swiglu_impl
+
+        x = paddle.randn([4, 16]).astype("float32")
+        x.stop_gradient = False
+        out = bias_swiglu_impl(x, None, clamp_value=3.0)
+        self.assertEqual(out.shape, [4, 8])
+        out.sum().backward()
+        self.assertIsNotNone(x.grad)
+
+    def test_bias_swiglu_impl_clamp_2d_with_bias_batch8(self):
+        """2D + bias + clamp_value, batch=8."""
+        from paddlefleet.fusions.fused_bias_swiglu import bias_swiglu_impl
+
+        x = paddle.randn([8, 16]).astype("float32")
+        bias = paddle.randn([8, 16]).astype("float32")
+        x.stop_gradient = False
+        bias.stop_gradient = False
+        out = bias_swiglu_impl(x, bias, clamp_value=2.0)
+        self.assertEqual(out.shape, [8, 8])
+        out.sum().backward()
+        self.assertIsNotNone(x.grad)
+        self.assertIsNotNone(bias.grad)
+
+    def test_bias_swiglu_impl_no_clamp(self):
+        """clamp_value=None path still functional."""
+        from paddlefleet.fusions.fused_bias_swiglu import bias_swiglu_impl
+
+        x = paddle.randn([4, 16]).astype("float32")
+        x.stop_gradient = False
+        out = bias_swiglu_impl(x, None, clamp_value=None)
+        self.assertEqual(out.shape, [4, 8])
+        out.sum().backward()
+        self.assertIsNotNone(x.grad)
+
+
+# ---------------------------------------------------------------------------
+# WeightedSwiGLUFunction PyLayer with clamp_value
+# ---------------------------------------------------------------------------
+
+
+class TestWeightedSwiGLUFunctionClamp(unittest.TestCase):
+    """WeightedSwiGLUFunction.apply path for clamp_value (lines 381-384)."""
+
+    def test_weighted_pylayer_clamp_fwd_bwd_2d(self):
+        """WeightedSwiGLUFunction.apply with clamp_value, fwd+bwd."""
+        from paddlefleet.fusions.fused_bias_swiglu import (
+            WeightedSwiGLUFunction,
+        )
+
+        x = paddle.randn([4, 16]).astype("float32")
+        w = paddle.ones([4, 1]).astype("float32")
+        x.stop_gradient = False
+        w.stop_gradient = False
+        out = WeightedSwiGLUFunction.apply(x, w, False, clamp_value=1.0)
+        self.assertEqual(out.shape, [4, 8])
+        out.sum().backward()
+        self.assertIsNotNone(x.grad)
+        self.assertIsNotNone(w.grad)
+
+    def test_weighted_pylayer_clamp_bfloat16(self):
+        """bfloat16 input through WeightedSwiGLUFunction with clamp."""
+        from paddlefleet.fusions.fused_bias_swiglu import (
+            WeightedSwiGLUFunction,
+        )
+
+        if not paddle.is_compiled_with_cuda():
+            self.skipTest("bfloat16 requires CUDA")
+
+        x = paddle.randn([4, 16], dtype=paddle.bfloat16)
+        w = paddle.ones([4, 1], dtype=paddle.bfloat16)
+        x.stop_gradient = False
+        w.stop_gradient = False
+        out = WeightedSwiGLUFunction.apply(x, w, False, clamp_value=1.0)
+        self.assertEqual(out.shape, [4, 8])
+        loss = out.cast(paddle.float32).sum()
+        loss.backward()
+        self.assertIsNotNone(x.grad)
+        self.assertIsNotNone(w.grad)
+
+    def test_weighted_pylayer_no_clamp(self):
+        """clamp_value=None: non-clamp path via WeightedSwiGLUFunction."""
+        from paddlefleet.fusions.fused_bias_swiglu import (
+            WeightedSwiGLUFunction,
+        )
+
+        x = paddle.randn([4, 16]).astype("float32")
+        w = paddle.ones([4, 1]).astype("float32")
+        x.stop_gradient = False
+        w.stop_gradient = False
+        out = WeightedSwiGLUFunction.apply(x, w, False, clamp_value=None)
+        self.assertEqual(out.shape, [4, 8])
+        out.sum().backward()
+        self.assertIsNotNone(x.grad)
+        self.assertIsNotNone(w.grad)
+
+
+# ---------------------------------------------------------------------------
+# Edge cases and boundary values
+# ---------------------------------------------------------------------------
+
+
+class TestClampEdgeCases(unittest.TestCase):
+    """Edge cases for clamp_value handling."""
+
+    def test_clamp_value_zero_no_effect_forward(self):
+        """clamp_value=0 → condition clamp_value > 0 fails, falls through."""
+        from paddlefleet.fusions.fused_swiglu_scale import (
+            fused_swiglu_scale_forward,
+        )
+
+        with _no_cuda():
+            x = paddle.randn([4, 16])
+            scale = paddle.ones([4, 1])
+            out_clamp0 = fused_swiglu_scale_forward(x, scale, clamp_value=0.0)
+            out_no_clamp = fused_swiglu_scale_forward(x, scale)
+            np.testing.assert_allclose(
+                out_clamp0.numpy(),
+                out_no_clamp.numpy(),
+                rtol=1e-5,
+                atol=1e-5,
+            )
+
+    def test_clamp_value_negative_no_effect(self):
+        """clamp_value < 0: the raw clamped_swiglu does NOT guard
+        against negative clamp (min=-clamp_value > max=clamp_value
+        would crash).  The guard is in BiasSwiGLUFunction / impl
+        layers (clamp_value > 0 check). Therefore this test verifies
+        that the guard in the impl layer correctly skips clamp
+        when clamp_value <= 0."""
+        from paddlefleet.fusions.fused_bias_swiglu import (
+            bias_swiglu_impl,
+        )
+
+        x = paddle.randn([4, 16]).astype("float32")
+        x.stop_gradient = False
+        # clamp_value=-1 → BiasSwiGLUFunction's guard (clamp > 0) skips clamp
+        out = bias_swiglu_impl(x, None, clamp_value=-1)
+        self.assertEqual(out.shape, [4, 8])
+        out.sum().backward()
+        self.assertIsNotNone(x.grad)
+
+    def test_bias_swiglu_impl_invalid_ndim(self):
+        """AssertionError when input.ndim not in [2, 3]."""
+        from paddlefleet.fusions.fused_bias_swiglu import bias_swiglu_impl
+
+        x = paddle.randn([4])
+        with self.assertRaises(AssertionError):
+            bias_swiglu_impl(x, None, clamp_value=2.0)
+
+    def test_fused_swiglu_scale_backward_zero_rows(self):
+        """Zero rows input: backward returns correct shapes without crash."""
+        from paddlefleet.fusions.fused_swiglu_scale import (
+            fused_swiglu_scale_backward,
+        )
+
+        with _no_cuda():
+            x = paddle.empty([0, 16])
+            scale = paddle.empty([0, 1])
+            out_grad = paddle.empty([0, 8])
+            d_x, d_scale = fused_swiglu_scale_backward(
+                x, scale, out_grad, clamp_value=2.0
+            )
+            self.assertEqual(d_x.shape, [0, 16])
+            self.assertEqual(d_scale.shape, [0, 1])
+
+    def test_clamped_swiglu_zero_rows(self):
+        """Zero-row input: forward and backward should not crash."""
+        from paddlefleet.fusions.fused_bias_swiglu import (
+            clamped_swiglu,
+            clamped_swiglu_back,
+        )
+
+        y = paddle.empty([0, 16])
+        out = clamped_swiglu(y, clamp_value=2.0)
+        self.assertEqual(out.shape, [0, 8])
+        # backward with zero rows
+        g = paddle.empty([0, 8])
+        grad = clamped_swiglu_back(g, y, clamp_value=2.0)
+        self.assertEqual(grad.shape, [0, 16])
+
+    def test_clamped_bias_swiglu_zero_rows(self):
+        """Zero-row input with bias: should not crash."""
+        from paddlefleet.fusions.fused_bias_swiglu import (
+            clamped_bias_swiglu,
+            clamped_bias_swiglu_back,
+        )
+
+        y = paddle.empty([0, 16])
+        bias = paddle.empty([0, 16])
+        out = clamped_bias_swiglu(y, bias, clamp_value=2.0)
+        self.assertEqual(out.shape, [0, 8])
+        g = paddle.empty([0, 8])
+        grad = clamped_bias_swiglu_back(g, y, bias, clamp_value=2.0)
+        self.assertEqual(grad.shape, [0, 16])
+
+    def test_bias_swiglu_impl_zero_rows(self):
+        """bias_swiglu_impl with zero rows."""
+        from paddlefleet.fusions.fused_bias_swiglu import bias_swiglu_impl
+
+        x = paddle.empty([0, 16])
+        out = bias_swiglu_impl(x, None, clamp_value=2.0)
+        self.assertEqual(out.shape, [0, 8])
+
+    def test_weighted_bias_swiglu_impl_zero_rows(self):
+        """weighted_bias_swiglu_impl with zero rows."""
+        from paddlefleet.fusions.fused_bias_swiglu import (
+            weighted_bias_swiglu_impl,
+        )
+
+        x = paddle.empty([0, 16])
+        w = paddle.empty([0, 1])
+        out = weighted_bias_swiglu_impl(x, None, w, clamp_value=2.0)
+        self.assertEqual(out.shape, [0, 8])
+
+    def test_fused_swiglu_scale_forward_zero_rows(self):
+        """Forward with zero rows."""
+        from paddlefleet.fusions.fused_swiglu_scale import (
+            fused_swiglu_scale_forward,
+        )
+
+        with _no_cuda():
+            x = paddle.empty([0, 16])
+            scale = paddle.empty([0, 1])
+            out = fused_swiglu_scale_forward(x, scale, clamp_value=2.0)
+            self.assertEqual(out.shape, [0, 8])
+
+    def test_pylayer_apply_zero_rows(self):
+        """BiasSwiGLUFunction / WeightedSwiGLUFunction with zero rows."""
+        from paddlefleet.fusions.fused_bias_swiglu import (
+            BiasSwiGLUFunction,
+            WeightedSwiGLUFunction,
+        )
+
+        # BiasSwiGLUFunction
+        x = paddle.empty([0, 16]).astype("float32")
+        b = paddle.empty([0, 16]).astype("float32")
+        out = BiasSwiGLUFunction.apply(x, b, False, False, clamp_value=2.0)
+        self.assertEqual(out.shape, [0, 8])
+
+        # WeightedSwiGLUFunction
+        w = paddle.empty([0, 1]).astype("float32")
+        out = WeightedSwiGLUFunction.apply(x, w, False, clamp_value=2.0)
+        self.assertEqual(out.shape, [0, 8])
+
+
+# ---------------------------------------------------------------------------
+# Large tensor tests (int32-overflow numel > 2**31)
+# ---------------------------------------------------------------------------
+
+
+class TestClampLargeTensor(unittest.TestCase):
+    """Verify clamped functions handle large tensors without crashes
+    (numel crossing the int32 boundary of 2**31)."""
+
+    @staticmethod
+    def _skip_if_oom(rows, cols):
+        """Skip if actual allocation fails (probes GPU memory when available)."""
+        est_gib = (rows * cols * 2) / (1024**3)
+        if paddle.is_compiled_with_cuda():
+            try:
+                # Probe: allocate and free to check if there's enough GPU memory
+                probe = paddle.empty([rows, cols], dtype=paddle.bfloat16)
+                del probe
+                paddle.device.synchronize()
+                paddle.device.cuda.empty_cache()
+            except Exception:
+                raise unittest.SkipTest(
+                    f"GPU OOM for large tensor ({est_gib:.1f} GiB)"
+                )
+        else:
+            # CPU fallback: skip conservatively above 24 GiB
+            if est_gib > 24:
+                raise unittest.SkipTest(
+                    f"Large tensor ({est_gib:.1f} GiB) skipped on CPU"
+                )
+
+    def test_clamped_swiglu_large_numel_fwd(self):
+        """numel > 2**31: clamped_swiglu forward (int64 shape handling)."""
+        from paddlefleet.fusions.fused_bias_swiglu import clamped_swiglu
+
+        # 2**24 rows * 136 = 2.28B elements > 2**31, fits ~4.6 GiB bf16
+        rows, hidden2 = 2**24, 136
+        self._skip_if_oom(rows, hidden2)
+        x = paddle.randn([rows, hidden2], dtype=paddle.bfloat16)
+        out = clamped_swiglu(x, clamp_value=3.0)
+        self.assertEqual(out.shape, [rows, hidden2 // 2])
+        self.assertFalse(
+            bool(paddle.isnan(out.cast(paddle.float32)).any().numpy())
+        )
+
+    def test_clamped_swiglu_back_large_numel(self):
+        """numel > 2**31: clamped_swiglu backward passes without crash."""
+        from paddlefleet.fusions.fused_bias_swiglu import clamped_swiglu_back
+
+        rows, hidden2 = 2**24, 136
+        self._skip_if_oom(rows, hidden2)
+        g = paddle.randn([rows, hidden2 // 2], dtype=paddle.bfloat16)
+        y = paddle.randn([rows, hidden2], dtype=paddle.bfloat16)
+        grad = clamped_swiglu_back(g, y, clamp_value=3.0)
+        self.assertEqual(grad.shape, [rows, hidden2])
+        self.assertFalse(
+            bool(paddle.isnan(grad.cast(paddle.float32)).any().numpy())
+        )
+
+    def test_clamped_weighted_swiglu_large_numel(self):
+        """numel > 2**31: clamped_weighted_swiglu fwd+bwd."""
+        from paddlefleet.fusions.fused_bias_swiglu import (
+            clamped_weighted_swiglu,
+            clamped_weighted_swiglu_back,
+        )
+
+        rows, hidden2 = 2**24, 136
+        self._skip_if_oom(rows, hidden2)
+        y = paddle.randn([rows, hidden2], dtype=paddle.bfloat16)
+        w = paddle.randn([rows, 1], dtype=paddle.bfloat16)
+        out = clamped_weighted_swiglu(y, w, clamp_value=3.0)
+        self.assertEqual(out.shape, [rows, hidden2 // 2])
+        g = paddle.randn([rows, hidden2 // 2], dtype=paddle.bfloat16)
+        d_y, d_w = clamped_weighted_swiglu_back(g, y, w, clamp_value=3.0)
+        self.assertEqual(d_y.shape, [rows, hidden2])
+        self.assertEqual(d_w.shape, [rows, 1])
+
+    def test_fused_swiglu_scale_backward_large(self):
+        """numel > 2**31: backward without clamp, verifies int64 handling."""
+        from paddlefleet.fusions.fused_swiglu_scale import (
+            fused_swiglu_scale_backward,
+        )
+
+        with _no_cuda():
+            rows, hidden2 = 2**24, 136
+            self._skip_if_oom(rows, hidden2)
+            x = paddle.randn([rows, hidden2], dtype=paddle.bfloat16)
+            scale = paddle.ones([rows, 1], dtype=paddle.bfloat16)
+            out_grad = paddle.randn([rows, hidden2 // 2], dtype=paddle.bfloat16)
+            d_x, d_scale = fused_swiglu_scale_backward(
+                x, scale, out_grad, clamp_value=None
+            )
+            self.assertEqual(d_x.shape, [rows, hidden2])
+            self.assertEqual(d_scale.shape, [rows, 1])
+
+    def test_fused_swiglu_scale_backward_large_clamp(self):
+        """numel > 2**31: backward with clamp, verifies int64 handling."""
+        from paddlefleet.fusions.fused_swiglu_scale import (
+            fused_swiglu_scale_backward,
+        )
+
+        with _no_cuda():
+            rows, hidden2 = 2**24, 136
+            self._skip_if_oom(rows, hidden2)
+            x = paddle.randn([rows, hidden2], dtype=paddle.bfloat16)
+            scale = paddle.ones([rows, 1], dtype=paddle.bfloat16)
+            out_grad = paddle.randn([rows, hidden2 // 2], dtype=paddle.bfloat16)
+            d_x, d_scale = fused_swiglu_scale_backward(
+                x, scale, out_grad, clamp_value=3.0
+            )
+            self.assertEqual(d_x.shape, [rows, hidden2])
+            self.assertEqual(d_scale.shape, [rows, 1])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_bias_swiglu.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_bias_swiglu.py
@@ -32,7 +32,6 @@ import paddle.nn.functional as F
 
 from paddlefleet.fusions.fused_bias_swiglu import (
     BiasSwiGLUFunction,
-    ClampedWeightedSwiGLUFunction,
     SwiGLUFunction,
     WeightedSwiGLUFunction,
     bias_swiglu,
@@ -208,14 +207,14 @@ class TestPyLayerBackwardReturnCount(unittest.TestCase):
         self.assertEqual(w.grad.shape, [4, 1])
 
     def test_clamped_weighted_swiglu_function_backward_returns_2(self):
-        """ClampedWeightedSwiGLUFunction.forward(input, weights,
+        """WeightedSwiGLUFunction.apply(input, weights,
         fp8_input_store, clamp_value) has 2 tensor inputs (input, weights)
         => backward must return 2 values."""
         x = paddle.randn([4, 16]).astype("float32")
         x.stop_gradient = False
         w = paddle.ones([4, 1]).astype("float32")
         w.stop_gradient = False
-        result = ClampedWeightedSwiGLUFunction.apply(x, w, False, 2.0)
+        result = WeightedSwiGLUFunction.apply(x, w, False, 2.0)
         result.sum().backward()
         self.assertIsNotNone(x.grad)
         self.assertIsNotNone(w.grad)
@@ -312,42 +311,29 @@ class TestClampedSwiGLU(unittest.TestCase):
         self.assertEqual(grad_w.shape, [4, 1])
 
     def test_weighted_bias_swiglu_impl_clamp_e2e(self):
-        """End-to-end fwd+bwd through clamped_weighted_bias_swiglu_impl."""
+        """End-to-end fwd+bwd through weighted_bias_swiglu_impl."""
         from paddlefleet.fusions.fused_bias_swiglu import (
-            clamped_weighted_bias_swiglu_impl,
+            weighted_bias_swiglu_impl,
         )
 
         inp = paddle.randn([4, 16])
         inp.stop_gradient = False
         w = paddle.randn([4, 1])
         w.stop_gradient = False
-        out = clamped_weighted_bias_swiglu_impl(inp, None, w, clamp_value=2.0)
+        out = weighted_bias_swiglu_impl(inp, None, w, clamp_value=2.0)
         self.assertEqual(out.shape, [4, 8])
         grads = paddle.grad([out.sum()], [inp, w])
         self.assertEqual(grads[0].shape, [4, 16])
         self.assertEqual(grads[1].shape, [4, 1])
         self.assertFalse(bool(paddle.isnan(out).any().numpy()))
 
-    def test_clamped_weighted_bias_swiglu_impl_bias_raises(self):
-        """Line 438: clamped_weighted_bias_swiglu_impl with non-None bias
-        raises NotImplementedError."""
-        from paddlefleet.fusions.fused_bias_swiglu import (
-            clamped_weighted_bias_swiglu_impl,
-        )
-
-        inp = paddle.randn([4, 16])
-        w = paddle.randn([4, 1])
-        bias = paddle.randn([4, 16])
-        with self.assertRaises(NotImplementedError):
-            clamped_weighted_bias_swiglu_impl(inp, bias, w, clamp_value=2.0)
-
     def test_clamped_weighted_pylayer_fwd_bwd(self):
-        """ClampedWeightedSwiGLUFunction PyLayer apply + backward."""
+        """WeightedSwiGLUFunction PyLayer with clamp_value + backward."""
         x = paddle.randn([4, 16]).astype("float32")
         x.stop_gradient = False
         w = paddle.ones([4, 1]).astype("float32")
         w.stop_gradient = False
-        result = ClampedWeightedSwiGLUFunction.apply(x, w, False, 1.0)
+        result = WeightedSwiGLUFunction.apply(x, w, False, 1.0)
         self.assertEqual(result.shape, [4, 8])
         result.sum().backward()
         self.assertIsNotNone(x.grad)
@@ -517,12 +503,12 @@ class TestClampedSwiGLU(unittest.TestCase):
         self.assertEqual(grad_w.shape, [0, 1])
 
     def test_clamped_weighted_pylayer_zero_size(self):
-        """ClampedWeightedSwiGLUFunction PyLayer apply+backward on 0 rows."""
+        """WeightedSwiGLUFunction PyLayer with clamp_value on 0 rows."""
         x = paddle.zeros([0, 16]).astype("float32")
         x.stop_gradient = False
         w = paddle.zeros([0, 1]).astype("float32")
         w.stop_gradient = False
-        out = ClampedWeightedSwiGLUFunction.apply(x, w, False, 1.0)
+        out = WeightedSwiGLUFunction.apply(x, w, False, 1.0)
         self.assertEqual(out.shape, [0, 8])
         out.sum().backward()
         self.assertEqual(x.grad.shape, [0, 16])

--- a/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_bias_swiglu_clamp.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_bias_swiglu_clamp.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """End-to-end PyLayer apply+backward coverage for WeightedSwiGLUFunction
-and ClampedWeightedSwiGLUFunction.
+(including clamp_value path).
 
 Note: forward/backward shape coverage of standalone clamped_swiglu/
 clamped_swiglu_back/clamped_weighted_swiglu/clamped_weighted_swiglu_back
@@ -37,9 +37,8 @@ sys.path.insert(
 import paddle
 
 from paddlefleet.fusions.fused_bias_swiglu import (
-    ClampedWeightedSwiGLUFunction,
     WeightedSwiGLUFunction,
-    clamped_weighted_bias_swiglu_impl,
+    weighted_bias_swiglu_impl,
 )
 
 
@@ -47,12 +46,12 @@ class TestWeightedSwiGLUFunctionClampPyLayer(unittest.TestCase):
     """Forward/backward through PyLayer for clamp and non-clamp branches."""
 
     def test_backward_with_clamp(self):
-        """ClampedWeightedSwiGLUFunction forward + clamp backward path."""
+        """WeightedSwiGLUFunction forward + clamp backward path."""
         x = paddle.randn([4, 16]).astype("float32")
         x.stop_gradient = False
         weights = paddle.ones([4, 1]).astype("float32")
         weights.stop_gradient = False
-        result = ClampedWeightedSwiGLUFunction.apply(x, weights, False, 1.0)
+        result = WeightedSwiGLUFunction.apply(x, weights, False, 1.0)
         self.assertEqual(result.shape, [4, 8])
         result.sum().backward()
         self.assertIsNotNone(x.grad)
@@ -88,7 +87,7 @@ class TestWeightedSwiGLUFunctionClampPyLayer(unittest.TestCase):
         weights_3d = paddle.full([S, B, 1], 0.5, dtype="float32")
         weights_3d.stop_gradient = False
 
-        out = clamped_weighted_bias_swiglu_impl(
+        out = weighted_bias_swiglu_impl(
             x, None, weights_3d, clamp_value=1.0, fp8_input_store=False
         )
         self.assertEqual(out.shape, [S, B, H // 2])
@@ -109,7 +108,7 @@ class TestWeightedSwiGLUFunctionClampPyLayer(unittest.TestCase):
         weights_3d = paddle.full([S, B, 1], 0.25, dtype="float32")
         weights_3d.stop_gradient = False
 
-        out = clamped_weighted_bias_swiglu_impl(
+        out = weighted_bias_swiglu_impl(
             x, None, weights_3d, clamp_value=1.0, fp8_input_store=False
         )
         self.assertEqual(out.shape, [S, B, H // 2])

--- a/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_swiglu_scale_3.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_swiglu_scale_3.py
@@ -141,58 +141,9 @@ class TestFusedSwigluScaleCPUFallback(unittest.TestCase):
             )
             self.assertEqual(d_x.shape, [2, 16])
 
-    def test_forward_with_clamp(self):
-        from paddlefleet.fusions.fused_swiglu_scale import (
-            fused_swiglu_scale_clamp_forward,
-        )
-
-        with _no_cuda():
-            x = paddle.full([2, 16], 100.0)
-            scale = paddle.ones([2, 1])
-            result = fused_swiglu_scale_clamp_forward(x, scale, clamp_value=1.0)
-            self.assertEqual(result.shape, [2, 8])
-
-    def test_backward_with_clamp_saturated(self):
-        """Saturated inputs => g_mask/v_mask zero out the gradients."""
-        from paddlefleet.fusions.fused_swiglu_scale import (
-            fused_swiglu_scale_clamp_backward,
-        )
-
-        with _no_cuda():
-            x = paddle.full([2, 8], 5.0)
-            scale = paddle.ones([2])
-            out_grad = paddle.randn([2, 4])
-            d_x, _ = fused_swiglu_scale_clamp_backward(
-                x, scale, out_grad, clamp_value=0.5
-            )
-            self.assertEqual(d_x.shape, [2, 8])
-            self.assertTrue(bool((d_x.abs().sum() == 0).item()))
-
 
 class TestFusedSwigluScaleGPUDispatch(unittest.TestCase):
     """GPU dispatch branches (fwd 22-29, bwd 50-60), via mock op modules."""
-
-    def test_forward_clamp_dispatch(self):
-        from paddlefleet.fusions.fused_swiglu_scale import (
-            fused_swiglu_scale_clamp_forward,
-        )
-
-        mock_op = MagicMock(return_value=paddle.randn([2, 8]))
-        with (
-            patch.object(paddle, "is_compiled_with_cuda", return_value=True),
-            patch.dict(
-                "sys.modules",
-                {
-                    "paddlefleet_ops": MagicMock(
-                        fused_swiglu_scale_clamp=mock_op
-                    )
-                },
-            ),
-        ):
-            fused_swiglu_scale_clamp_forward(
-                paddle.randn([2, 16]), paddle.ones([2, 1]), clamp_value=5.0
-            )
-            mock_op.assert_called_once()
 
     def test_forward_no_clamp_dispatch(self):
         from paddlefleet.fusions.fused_swiglu_scale import (
@@ -209,33 +160,6 @@ class TestFusedSwigluScaleGPUDispatch(unittest.TestCase):
         ):
             fused_swiglu_scale_forward(
                 paddle.randn([2, 16]), paddle.ones([2, 1])
-            )
-            mock_op.assert_called_once()
-
-    def test_backward_clamp_dispatch(self):
-        from paddlefleet.fusions.fused_swiglu_scale import (
-            fused_swiglu_scale_clamp_backward,
-        )
-
-        mock_op = MagicMock(
-            return_value=(paddle.randn([2, 16]), paddle.randn([2]))
-        )
-        with (
-            patch.object(paddle, "is_compiled_with_cuda", return_value=True),
-            patch.dict(
-                "sys.modules",
-                {
-                    "paddlefleet_ops": MagicMock(
-                        fused_swiglu_scale_clamp_bwd=mock_op
-                    )
-                },
-            ),
-        ):
-            fused_swiglu_scale_clamp_backward(
-                paddle.randn([2, 16]),
-                paddle.ones([2]),
-                paddle.randn([2, 8]),
-                clamp_value=5.0,
             )
             mock_op.assert_called_once()
 

--- a/tests/single_card_tests/ai_edited_test/moe/test_ai_fp8_utils.py
+++ b/tests/single_card_tests/ai_edited_test/moe/test_ai_fp8_utils.py
@@ -700,7 +700,7 @@ class TestFP8UtilsClampBF16(unittest.TestCase):
         )
 
     def test_fwd_down_bf16_clamp_calls_clamp_forward(self):
-        """Lines 631-634: fwd_down_bf16 calls fused_swiglu_scale_clamp_forward
+        """fwd_down_bf16 calls fused_swiglu_scale_forward with clamp_value
         when clamp_value is set. Return zero-sized tensor to skip GEMM."""
         node = self._make_node(clamp_value=5.0)
 
@@ -709,7 +709,7 @@ class TestFP8UtilsClampBF16(unittest.TestCase):
             return_value=paddle.empty([0, 64], dtype=paddle.bfloat16)
         )
         with patch(
-            "paddlefleet.transformer.moe.fp8_utils.fused_swiglu_scale_clamp_forward",
+            "paddlefleet.transformer.moe.fp8_utils.fused_swiglu_scale_forward",
             mock_forward,
         ):
             o1 = paddle.randn([4, 128], dtype=paddle.bfloat16)

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_mlp_4.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_mlp_4.py
@@ -13,17 +13,12 @@
 # limitations under the License.
 """Tests for MLP with clamped weighted bias swiglu fusion and bias_activation_fusion.
 
-This file covers the diff lines 201-212 in mlp.py which are:
-   if self.config.activation_func_clamp_value is not None:
-       intermediate_parallel = clamped_weighted_bias_swiglu_impl(...)
-   else:
-       intermediate_parallel = weighted_bias_swiglu_impl(...)
 
 The mock strategy:
   - ``build_spec_layer`` returns a simple layer that produces a proper
     (output, bias) tuple so MLP can forward without distributed setup.
   - Only the lowest-level CUDA autograd Function.apply is mocked so that
-    the outer ``clamped_weighted_bias_swiglu_impl`` / ``weighted_bias_swiglu_impl``
+    the outer ``weighted_bias_swiglu_impl``
     function bodies are executed and tracked by coverage.
 """
 
@@ -46,7 +41,6 @@ import paddle
 import paddle.nn.functional as F
 
 from paddlefleet.fusions.fused_bias_swiglu import (
-    ClampedWeightedSwiGLUFunction,
     WeightedSwiGLUFunction,
 )
 from paddlefleet.transformer.mlp import MLP
@@ -100,13 +94,13 @@ class TestMLPClampBiasActivationFusion(unittest.TestCase):
         side_effect=_make_mock_linear,
     )
     @patch.object(
-        ClampedWeightedSwiGLUFunction,
+        WeightedSwiGLUFunction,
         "apply",
         return_value=paddle.randn([2, 4, 128]),
     )
     def test_forward_with_clamp_bias_fusion(self, _, __):
         """Lines 201-210: when activation_func_clamp_value is set and
-        bias_activation_fusion=True, clamped_weighted_bias_swiglu_impl is
+        bias_activation_fusion=True, weighted_bias_swiglu_impl is
         called instead of weighted_bias_swiglu_impl."""
         config = _make_config(activation_func_clamp_value=5.0)
         from paddlefleet.models.gpt.gpt_layer_specs import (
@@ -167,13 +161,13 @@ class TestMLPClampBiasActivationFusion(unittest.TestCase):
         side_effect=_make_mock_linear,
     )
     @patch.object(
-        ClampedWeightedSwiGLUFunction,
+        WeightedSwiGLUFunction,
         "apply",
         return_value=paddle.randn([2, 4, 128]),
     )
     def test_backward_with_clamp_bias_fusion(self, _, __):
-        """Lines 201-210: test fwd path with clamp_value exercises the new
-        clamped_weighted_bias_swiglu_impl code path in mlp.py."""
+        """test fwd path with clamp_value exercises the new
+        weighted_bias_swiglu_impl code path in mlp.py."""
         config = _make_config(activation_func_clamp_value=3.0)
         from paddlefleet.models.gpt.gpt_layer_specs import (
             get_gpt_layer_local_spec,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Align clamped SwiGLU computation order and data types with Megatron，and unify scattered clamped/non-clamped SwiGLU implementations into a single path controlled by clamp_value

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
是， 不会影响原有网络用例， 只针对clampswiglu。