### PR TITLE
[CI] Fix ARM ops package build

### DIFF
--- a/.github/workflows/pr_update_ops.yml
+++ b/.github/workflows/pr_update_ops.yml
@@ -464,6 +464,7 @@ jobs:
       - name: Build wheel
         run: |
           docker exec -t ${{ env.container_name }} /bin/bash -xc '
+          set -e
           export UV_PYTHON=${{ matrix.python_version }}
           source /root/proxy
           git submodule update --init --recursive
@@ -473,8 +474,11 @@ jobs:
             export PADDLEFLEET_VERSION=$VERSION
           fi
           export IS_NVIDIA=True
-          pip install packaging "setuptools>=66.1.0" wheel
-          pip install "paddle-nvidia-nvshmem-cu13>=3.3.9,<3.5" --extra-index-url=https://www.paddlepaddle.org.cn/packages/nightly/cu130/
+          /usr/bin/python -m pip install --break-system-packages packaging "setuptools>=66.1.0" wheel
+          /usr/bin/python -m pip install --break-system-packages "nvidia-nvshmem-cu13>=3.3.9,<3.5"
+          # HybridEP links against NVML by soname; install dev stubs for libnvidia-ml.so.1.
+          apt-get update && apt-get install -y --no-install-recommends libnvidia-ml-dev
+          rm -rf /var/lib/apt/lists/*
           uv build --wheel --package paddlefleet-ops --out-dir dist --no-build-isolation -v --python /usr/bin/python
           '
 
@@ -495,7 +499,7 @@ jobs:
             PY_VERSION="${{ matrix.python_version }}"
             PY_VERSION_SHORT="${PY_VERSION//./}"
             mv paddlefleet_ops-*.whl paddlefleet_ops-0.0.0-cp${PY_VERSION_SHORT}-cp${PY_VERSION_SHORT}-linux_aarch64.whl
-            python ../bos/BosClient.py paddlefleet-0.0.0-cp${PY_VERSION_SHORT}-cp${PY_VERSION_SHORT}-linux_aarch64.whl paddle-github-action/PaddleFleet/${BRANCH}/latest/${{ matrix.cuda.bos_CUDA }}
+            python ../bos/BosClient.py paddlefleet_ops-0.0.0-cp${PY_VERSION_SHORT}-cp${PY_VERSION_SHORT}-linux_aarch64.whl paddle-github-action/PaddleFleet/${BRANCH}/latest/${{ matrix.cuda.bos_CUDA }}
           fi
           curl https://www.paddlepaddle.org.cn/inner/whl/update/path/new
           '


### PR DESCRIPTION
### PR Category
Execute Infrastructure


### PR Types
Bug fixes


### Description
修复 `PR update ops` 中 `publish-ops-wheel-arm` 的 ARM paddlefleet-ops 编包路径：

- ARM 镜像是 PEP 668 externally managed environment，`--no-build-isolation` 前的 `/usr/bin/python` 依赖安装改为显式使用 `--break-system-packages`，避免 `packaging` 未安装导致 build backend 导入失败。
- ARM 上按 `packages/paddlefleet_ops/build_utils.py` 的 aarch64 分支安装 `nvidia-nvshmem-cu13`。
- HybridEP multinode 链接阶段需要 `libnvidia-ml.so.1`，在 ARM 构建容器内安装 `libnvidia-ml-dev` 提供 NVML dev stubs。
- 修正 ARM 上传 latest wheel 时的文件名 typo：`paddlefleet_ops-...linux_aarch64.whl`。

参考失败：

- https://github.com/PaddlePaddle/PaddleFleet/actions/runs/26622535587/job/78455725881 ：`ModuleNotFoundError: No module named 'packaging'`
- https://github.com/PaddlePaddle/PaddleFleet/actions/runs/25844619495/job/75937267244 ：`/usr/bin/ld: cannot find -l:libnvidia-ml.so.1`

未加入永久 `pull_request` 调试触发。

### 是否引起精度变化
否

### Validation

- `git diff --check`
- Ruby YAML parse for `.github/workflows/pr_update_ops.yml`
- `bash -n` on extracted workflow `run:` scripts with GitHub expressions sanitized

本地无法执行 ARM CUDA Docker 编包；需依赖 GitHub self-hosted `npu-arm` runner 验证。
