### PR TITLE
[Bug fixes] pass fa_version from forward to backward to keep fwd/bwd consistent

### DIFF
--- a/src/paddlefleet/context_parallel_utils.py
+++ b/src/paddlefleet/context_parallel_utils.py
@@ -562,7 +562,10 @@ def cp_flashmask_allgatherkv_balance_forward(
         causal (bool): Whether to use causal attention
         is_training (bool): Whether in training mode
     Returns:
-        tuple: (output, log_sum_exp, processed_indices)
+        tuple: (output, log_sum_exp, processed_indices, fa_version)
+            ``fa_version`` is the effective FlashAttention version actually
+            used by the forward kernel and must be passed to the backward
+            counterpart to keep fwd/bwd consistent.
     """
     paddle.base.core.nvprof_nvtx_push(
         "cp_flashmask_allgatherkv_balance_forward"
@@ -593,6 +596,18 @@ def cp_flashmask_allgatherkv_balance_forward(
     fa_version = paddle.base.framework.get_flags(["FLAGS_flash_attn_version"])[
         "FLAGS_flash_attn_version"
     ]
+    # Apply deterministic override here so forward and backward use the same
+    # effective fa_version (mirrors backward's previous logic and the
+    # framework flashmask_attention's internal deterministic fallback).
+    deterministic = paddle.get_flags(["FLAGS_cudnn_deterministic"])[
+        "FLAGS_cudnn_deterministic"
+    ]
+    if "block_mask" in inspect.signature(flashmask_attention).parameters:
+        if deterministic and query.shape[-1] > 128:
+            fa_version = 2
+    elif deterministic:
+        fa_version = 2
+
     if fa_version == 4 and _flash_mask_available:
         output, log_sum_exp = _flash_attn_fwd(
             query,
@@ -615,11 +630,10 @@ def cp_flashmask_allgatherkv_balance_forward(
         )
 
     paddle.base.core.nvprof_nvtx_pop()
-    return output, log_sum_exp, startend_row_indices
+    return output, log_sum_exp, startend_row_indices, fa_version
 
 
 def cp_flashmask_allgatherkv_balance_backward(
-    config,
     query,
     key,
     value,
@@ -629,6 +643,7 @@ def cp_flashmask_allgatherkv_balance_backward(
     output_grad,
     group,
     causal,
+    fa_version: int,
 ):
     """
     Backward pass of context parallel flashmask attention with balanced all-gather strategy.
@@ -644,6 +659,9 @@ def cp_flashmask_allgatherkv_balance_backward(
         output_grad (paddle.Tensor): Gradient of output
         group (paddle.distributed.Group): Communication group
         causal (bool): Whether causal attention was used
+        fa_version (int): FlashAttention version that was actually used by the
+            forward kernel. Must be propagated from the forward call to keep
+            fwd/bwd consistent (do not re-derive from external config here).
     Returns:
         tuple: (query_grad, key_grad, value_grad)
     """
@@ -655,12 +673,6 @@ def cp_flashmask_allgatherkv_balance_backward(
     key_gathered = all_gather_balance(key, axis=1, group=group)
     value_gathered = all_gather_balance(value, axis=1, group=group)
 
-    fa_version = config.fa_version
-    if "block_mask" in inspect.signature(flashmask_attention).parameters:
-        if config.deterministic_mode and query.shape[-1] > 128:
-            fa_version = 2
-    elif config.deterministic_mode:
-        fa_version = 2
     if fa_version == 2:
         # Create seed offset tensor (required for gradient computation)
         seed_offset = paddle.zeros(
@@ -951,7 +963,7 @@ class FlashMaskContextParallel(PyLayer):
         )
 
         # Perform forward pass
-        output, log_sum_exp, startend_row_indices = (
+        output, log_sum_exp, startend_row_indices, fa_version = (
             cp_flashmask_allgatherkv_balance_forward(
                 query, key, value, startend_row_indices, group, causal, training
             )
@@ -963,7 +975,7 @@ class FlashMaskContextParallel(PyLayer):
         )
         ctx.group = group
         ctx.causal = causal
-        ctx.config = config
+        ctx.fa_version = fa_version
 
         return output
 
@@ -983,12 +995,11 @@ class FlashMaskContextParallel(PyLayer):
         )
         group = ctx.group
         causal = ctx.causal
-        config = ctx.config
+        fa_version = ctx.fa_version
 
         # Compute gradients
         query_grad, key_grad, value_grad = (
             cp_flashmask_allgatherkv_balance_backward(
-                config,
                 query,
                 key,
                 value,
@@ -998,6 +1009,7 @@ class FlashMaskContextParallel(PyLayer):
                 output_grad,
                 group,
                 causal,
+                fa_version,
             )
         )
 

--- a/src/paddlefleet/refined_recompute/flash_attn.py
+++ b/src/paddlefleet/refined_recompute/flash_attn.py
@@ -820,11 +820,12 @@ class FlashMaskAttnCpFunctor(PyLayer):
         result_attention = hold_tensors["result_attention"]
         softmax_lse = hold_tensors["softmax_lse"]
         startend_row_indices = hold_tensors["startend_row_indices"]
+        fa_version = hold_tensors["fa_version"]
         group = hold_tensors["group"]
         causal = hold_tensors["causal"]
 
+        ctx.fa_version = fa_version
         ctx.save_for_backward(
-            config,
             q,
             k,
             v,
@@ -845,7 +846,6 @@ class FlashMaskAttnCpFunctor(PyLayer):
         """
         # Retrieve saved tensors
         (
-            config,
             q,
             k,
             v,
@@ -855,11 +855,11 @@ class FlashMaskAttnCpFunctor(PyLayer):
             group,
             causal,
         ) = ctx.saved_tensor()
+        fa_version = ctx.fa_version
 
         # Compute gradients
         query_grad, key_grad, value_grad = (
             cp_flashmask_allgatherkv_balance_backward(
-                config,
                 q,
                 k,
                 v,
@@ -869,6 +869,7 @@ class FlashMaskAttnCpFunctor(PyLayer):
                 grad,
                 group,
                 causal,
+                fa_version,
             )
         )
 
@@ -976,7 +977,7 @@ class RefinedRcomputeFlashMaskCpAttention:
             f"Current query sequence length: {query_states.shape[1]}"
         )
 
-        result_attention, softmax_lse, startend_row_indices = (
+        result_attention, softmax_lse, startend_row_indices, fa_version = (
             cp_flashmask_allgatherkv_balance_forward(
                 query_states,
                 key_states,
@@ -992,6 +993,7 @@ class RefinedRcomputeFlashMaskCpAttention:
             "result_attention": result_attention,
             "softmax_lse": softmax_lse,
             "startend_row_indices": startend_row_indices,
+            "fa_version": fa_version,
             "group": group,
             "causal": causal,
         }

--- a/tests/single_card_tests/ai_edited_test/distributed/test_ai_context_parallel_utils_3.py
+++ b/tests/single_card_tests/ai_edited_test/distributed/test_ai_context_parallel_utils_3.py
@@ -168,6 +168,7 @@ class TestFlashMaskContextParallelForward(unittest.TestCase):
                     mock_output,
                     mock_lse,
                     mock_processed_indices,
+                    2,
                 ),
             ):
                 result = FlashMaskContextParallel.forward(
@@ -180,7 +181,7 @@ class TestFlashMaskContextParallelForward(unittest.TestCase):
                 )
                 mock_ctx.save_for_backward.assert_called_once()
                 self.assertEqual(mock_ctx.group, mock_group)
-                self.assertEqual(mock_ctx.config, mock_config)
+                self.assertEqual(mock_ctx.fa_version, 2)
 
 
 class TestFlashMaskContextParallelBackward(unittest.TestCase):
@@ -207,7 +208,7 @@ class TestFlashMaskContextParallelBackward(unittest.TestCase):
         )
         mock_ctx.group = mock.MagicMock()
         mock_ctx.causal = False
-        mock_ctx.config = mock.MagicMock()
+        mock_ctx.fa_version = 2
 
         grad = paddle.randn([2, 8, 4, 16])
 
@@ -218,10 +219,11 @@ class TestFlashMaskContextParallelBackward(unittest.TestCase):
             result = FlashMaskContextParallel.backward(mock_ctx, grad)
             mock_bwd.assert_called_once()
             call_args = mock_bwd.call_args[0]
-            # Check first few args
-            self.assertIs(call_args[0], mock_ctx.config)
-            self.assertIs(call_args[1], query)
-            self.assertIs(call_args[2], key)
+            # First args are tensors (query/key/value); fa_version is the last arg.
+            self.assertIs(call_args[0], query)
+            self.assertIs(call_args[1], key)
+            self.assertIs(call_args[2], value)
+            self.assertEqual(call_args[-1], mock_ctx.fa_version)
 
 
 class TestFlashmaskAttentionCP(unittest.TestCase):
@@ -342,6 +344,109 @@ class TestPreprocessIndexDualChunks(unittest.TestCase):
             max_seqlen_q=16,
         )
         self.assertEqual(result.shape, indices.shape)
+
+
+class TestCpFlashmaskForwardDeterministicOverride(unittest.TestCase):
+    """Tests covering the deterministic fa_version override in
+    cp_flashmask_allgatherkv_balance_forward (lines around 595-609).
+
+    Four branches are covered:
+      A) block_mask in signature, deterministic + hdim>128 -> override to 2
+      B) block_mask in signature, deterministic but hdim<=128 -> no override
+      C) block_mask NOT in signature, deterministic -> override to 2
+      D) block_mask NOT in signature, no deterministic -> no override
+    """
+
+    def _run_forward(self, *, has_block_mask, deterministic, hdim, fa_flag=3):
+        from paddlefleet import context_parallel_utils as cpu
+
+        group = mock.MagicMock()
+        group.rank = 0
+        group.world_size = 1
+
+        query = paddle.randn([1, 4, 1, hdim])
+        key = paddle.randn([1, 4, 1, hdim])
+        value = paddle.randn([1, 4, 1, hdim])
+        indices = paddle.randint(0, 4, [4, 2])
+
+        # Build a fake flashmask_attention whose inspect.signature carries or
+        # omits the `block_mask` parameter.
+        if has_block_mask:
+
+            def fake_flashmask(
+                q,
+                k,
+                v,
+                startend_row_indices=None,
+                causal=False,
+                return_softmax_lse=False,
+                training=False,
+                block_mask=None,
+            ):
+                return paddle.zeros_like(q), paddle.zeros([1, 1, 4])
+        else:
+
+            def fake_flashmask(
+                q,
+                k,
+                v,
+                startend_row_indices=None,
+                causal=False,
+                return_softmax_lse=False,
+                training=False,
+            ):
+                return paddle.zeros_like(q), paddle.zeros([1, 1, 4])
+
+        flags_base = {"FLAGS_flash_attn_version": fa_flag}
+        flags_det = {"FLAGS_cudnn_deterministic": deterministic}
+
+        with (
+            mock.patch.object(cpu, "flashmask_attention", fake_flashmask),
+            mock.patch.object(
+                cpu, "all_gather_balance", side_effect=lambda t, axis, group: t
+            ),
+            mock.patch.object(
+                cpu,
+                "preprocess_index_dual_chunks",
+                side_effect=lambda idx, **kw: idx,
+            ),
+            mock.patch.object(
+                paddle.base.framework, "get_flags", return_value=flags_base
+            ),
+            mock.patch.object(paddle, "get_flags", return_value=flags_det),
+        ):
+            out = cpu.cp_flashmask_allgatherkv_balance_forward(
+                query, key, value, indices, group, False, True
+            )
+        return out[-1]  # fa_version
+
+    def test_branch_a_block_mask_det_hdim_gt_128(self):
+        """A) block_mask in sig, deterministic + hdim>128 -> 2."""
+        fa = self._run_forward(
+            has_block_mask=True, deterministic=True, hdim=192, fa_flag=3
+        )
+        self.assertEqual(fa, 2)
+
+    def test_branch_b_block_mask_det_hdim_le_128(self):
+        """B) block_mask in sig, deterministic but hdim<=128 -> no override."""
+        fa = self._run_forward(
+            has_block_mask=True, deterministic=True, hdim=128, fa_flag=3
+        )
+        self.assertEqual(fa, 3)
+
+    def test_branch_c_no_block_mask_deterministic(self):
+        """C) block_mask NOT in sig, deterministic -> override to 2."""
+        fa = self._run_forward(
+            has_block_mask=False, deterministic=True, hdim=64, fa_flag=3
+        )
+        self.assertEqual(fa, 2)
+
+    def test_branch_d_no_block_mask_no_deterministic(self):
+        """D) block_mask NOT in sig, no deterministic -> no override."""
+        fa = self._run_forward(
+            has_block_mask=False, deterministic=False, hdim=64, fa_flag=3
+        )
+        self.assertEqual(fa, 3)
 
 
 if __name__ == "__main__":

--- a/tests/single_card_tests/ai_edited_test/distributed/test_ai_flash_attn.py
+++ b/tests/single_card_tests/ai_edited_test/distributed/test_ai_flash_attn.py
@@ -74,7 +74,6 @@ class TestCpFlashmaskBackwardDispatch(unittest.TestCase):
         ):
             mock_sig.return_value.parameters = sig_params
             cp_flashmask_allgatherkv_balance_backward(
-                config,
                 q,
                 k,
                 v,
@@ -84,6 +83,7 @@ class TestCpFlashmaskBackwardDispatch(unittest.TestCase):
                 out_grad,
                 group,
                 False,
+                config.fa_version,
             )
 
         return mock_v2_grad

--- a/tests/single_card_tests/ai_edited_test/recompute/test_ai_flash_attn_8.py
+++ b/tests/single_card_tests/ai_edited_test/recompute/test_ai_flash_attn_8.py
@@ -197,6 +197,7 @@ class TestFlashMaskAttnFunctorCpForward(unittest.TestCase):
             "result_attention": result_attn,
             "softmax_lse": softmax_lse,
             "startend_row_indices": startend,
+            "fa_version": 2,
             "group": group,
             "causal": causal,
         }
@@ -233,6 +234,7 @@ class TestFlashMaskAttnCpFunctorBackward(unittest.TestCase):
             "result_attention": result_attn,
             "softmax_lse": softmax_lse,
             "startend_row_indices": startend,
+            "fa_version": 2,
             "group": group,
             "causal": causal,
         }

--- a/tests/single_card_tests/ai_edited_test/recompute/test_ai_flash_attn_9.py
+++ b/tests/single_card_tests/ai_edited_test/recompute/test_ai_flash_attn_9.py
@@ -75,6 +75,7 @@ class TestRefinedRcomputeFlashMaskCpAttentionForward(unittest.TestCase):
             paddle.randn([2, 4, 8], dtype=paddle.bfloat16),
             paddle.randn([2, 4], dtype=paddle.float32),
             paddle.to_tensor([0, 4, 8], dtype=paddle.int32),
+            2,
         )
 
         attn = RefinedRcomputeFlashMaskCpAttention()
@@ -103,6 +104,7 @@ class TestRefinedRcomputeFlashMaskCpAttentionForward(unittest.TestCase):
             ),
             "group": MagicMock(),
             "causal": False,
+            "fa_version": 2,
         }
         attn._hold_tensors_queue.put(hold_tensors)
 
@@ -284,6 +286,7 @@ class TestFlashMaskAttnCpFunctorForwardAndBackward(unittest.TestCase):
             ),
             "group": MagicMock(),
             "causal": False,
+            "fa_version": 2,
         }
 
         result = FlashMaskAttnCpFunctor.apply(config, q, k, v, hold_tensors)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Operator Mechanism


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features


### Description
<!-- Describe what you’ve done -->
pass fa_version from forward to backward to keep fwd/bwd consistent

问题：
cp模式下， trainer_args.fa_version 影响 fwd 的 fa 版本，model_args.model_config.fa_version  影响 bwd 的 fa 版本。存在两个配置参数，且存在 fwd_fa_version != bwd_fa_version。

修复方式：
1. 消除 model_args.model_config.fa_version  对 fa 版本的影响
2. fa 版本只由 trainer_args.fa_version 决定，并显示传递给 bwd，fwd 和 bwd 的 fa 版本永远一致。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否