### PR TITLE
Make SonicMoE's weight layout consistent with GroupedGEMM

### DIFF
--- a/src/paddlefleet/transformer/moe/moe_expert.py
+++ b/src/paddlefleet/transformer/moe/moe_expert.py
@@ -322,17 +322,37 @@ class GroupedMLPExpert(FleetLayer):
         return sharded_dict
 
 
-class SonicMoEExpert(FleetLayer):
+class SonicMoEExpert(GroupedMLPExpert):
+    _GROUPED_LAYOUT = "grouped"
+    _SONIC_LAYOUT = "sonic"
+
     @staticmethod
-    def _split_to_sonic_interleaved(weight):
-        # make the weight tensor of sonicmoe consistent
-        # with the original GroupedGEMM weight.
+    def _grouped_w1_to_sonic(weight):
         gate, up = paddle.chunk(weight, 2, axis=-1)
         gate = gate.transpose([0, 2, 1])
         up = up.transpose([0, 2, 1])
         return paddle.stack([gate, up], axis=2).reshape(
             [weight.shape[0], -1, weight.shape[1]]
         )
+
+    @staticmethod
+    def _sonic_w1_to_grouped(weight):
+        weight = weight.reshape([weight.shape[0], -1, 2, weight.shape[2]])
+        gate = weight[:, :, 0, :].transpose([0, 2, 1])
+        up = weight[:, :, 1, :].transpose([0, 2, 1])
+        return paddle.concat([gate, up], axis=-1)
+
+    @staticmethod
+    def _transpose_w2_layout(weight):
+        return weight.transpose([0, 2, 1])
+
+    @staticmethod
+    def _assign_tensor(tensor, value):
+        if not value.is_contiguous():
+            value = value.contiguous()
+        if list(tensor.shape) != list(value.shape):
+            tensor.reshape_(list(value.shape))
+        tensor[...] = value
 
     def __init__(
         self,
@@ -341,90 +361,64 @@ class SonicMoEExpert(FleetLayer):
         config: TransformerConfig,
         pg_collection: ProcessGroupCollection | None = None,
     ):
-        super().__init__(config=config)
-        self.config: TransformerConfig = config
-        self.config.hidden_act = F.silu
-        self.num_local_experts = num_local_experts
-        self.hidden_size = self.config.hidden_size
-        self.K = topk
         assert config.gated_linear_unit is True, (
             "Sonic MoE must use SwiGLU, i.e. set gated_linear_unit=True."
         )
-        assert not config.use_bias, (
-            "Bias not supported in Grouped GEMM yet, please set 'use_bias' to False."
+        super().__init__(
+            num_local_experts=num_local_experts,
+            config=config,
+            moe_deep_gemm=False,
+            pg_collection=pg_collection,
+        )
+        self.hidden_size = self.config.hidden_size
+        self.K = topk
+        self._weights_layout = self._GROUPED_LAYOUT
+
+    def _convert_grad_layout(self, param, converter):
+        main_grad = getattr(param, "main_grad", None)
+        if main_grad is not None:
+            self._assign_tensor(main_grad, converter(main_grad))
+        if param.grad is not None and (
+            main_grad is None or param.grad.data_ptr() != main_grad.data_ptr()
+        ):
+            self._assign_tensor(param.grad, converter(param.grad))
+
+    def _convert_layout(
+        self, target_layout, weight1_converter, weight2_converter
+    ):
+        if self._weights_layout == target_layout:
+            return
+        with paddle.no_grad():
+            for param, converter in (
+                (self.weight1, weight1_converter),
+                (self.weight2, weight2_converter),
+            ):
+                self._assign_tensor(param, converter(param))
+                self._convert_grad_layout(param, converter)
+        self._weights_layout = target_layout
+
+    def convert_weights_to_sonic_layout(self):
+        self._convert_layout(
+            self._SONIC_LAYOUT,
+            self._grouped_w1_to_sonic,
+            self._transpose_w2_layout,
         )
 
-        self.ep_group = pg_collection.ep if pg_collection else None
-        self.expert_parallel = (
-            utils.get_pg_size(self.ep_group) > 1 if self.ep_group else False
+    def convert_weights_to_grouped_layout(self):
+        self._convert_layout(
+            self._GROUPED_LAYOUT,
+            self._sonic_w1_to_grouped,
+            self._transpose_w2_layout,
         )
 
-        if self.config.gated_linear_unit:
-            if self.config.hidden_act not in [F.silu, F.gelu]:
-                raise ValueError(
-                    "Activation function must be silu or gelu when using SonicMoE."
-                )
+    def flush_to_grouped_layout(self):
+        self.convert_weights_to_grouped_layout()
 
-        # No tensor parallel - full sizes
-        fc1_output_size = self.config.moe_intermediate_size * 2
-        fc2_input_size = self.config.moe_intermediate_size
-
-        dtype = "bfloat16"
-
-        rng_ctx = (
-            get_cuda_rng_tracker().fork(get_expert_parallel_rng_tracker_name())
-            if paddle.distributed.get_world_size() > 1 and self.expert_parallel
-            else nullcontext()
-        )
-
-        with rng_ctx:
-            # NOTE: make the initial weight of sonicmoe consistent with
-            # the original GroupedGEMM implementation for fair comparison.
-            baseline_weight1 = paddle.zeros(
-                shape=[
-                    self.num_local_experts,
-                    self.hidden_size,
-                    fc1_output_size,
-                ],
-                dtype=dtype,
-            )
-            self.config.init_method(baseline_weight1)
-            baseline_weight2 = paddle.zeros(
-                shape=[
-                    self.num_local_experts,
-                    fc2_input_size,
-                    self.hidden_size,
-                ],
-                dtype=dtype,
-            )
-            self.config.output_layer_init_method(baseline_weight2)
-            self.weight1 = paddle.create_parameter(
-                shape=[
-                    self.num_local_experts,
-                    fc1_output_size,
-                    self.hidden_size,
-                ],
-                dtype=dtype,
-                default_initializer=paddle.nn.initializer.Constant(0.0),
-            )
-            self.weight2 = paddle.create_parameter(
-                shape=[
-                    self.num_local_experts,
-                    self.hidden_size,
-                    fc2_input_size,
-                ],
-                dtype=dtype,
-                default_initializer=paddle.nn.initializer.Constant(0.0),
-            )
-            self.weight1.set_value(
-                self._split_to_sonic_interleaved(baseline_weight1)
-            )
-            self.weight2.set_value(baseline_weight2.transpose([0, 2, 1]))
-
-        self.weight1.is_distributed = self.expert_parallel
-        self.weight2.is_distributed = self.expert_parallel
+    def step(self):
+        self.flush_to_grouped_layout()
 
     def forward(self, hidden_states, topk_indices, topk_scores, use_fp8=False):
+        self.convert_weights_to_sonic_layout()
         hidden_states = run_sonic_moe(
             hidden_states,
             topk_indices,
@@ -441,39 +435,8 @@ class SonicMoEExpert(FleetLayer):
         self,
         structured_name_prefix: str = "",
     ):
-        state_dict = self.state_dict(structured_name_prefix="")
-        model_type = getattr(self.config, "model_type", "none")
-        if "qwen3_vl" not in model_type and "qwen3_5" not in model_type:
-            w1 = state_dict["weight1"].reshape(-1, self.weight1.shape[-1])
-            w2 = state_dict["weight2"].reshape(-1, self.weight2.shape[-1])
-            w1.name = self.weight1.name
-            w2.name = self.weight2.name
-            state_dict["weight1"] = w1
-            state_dict["weight2"] = w2
-
-        sharded_dict = {}
-        full_key1 = f"{structured_name_prefix}weight1"
-        full_key2 = f"{structured_name_prefix}weight2"
-        if self.ep_group is None:
-            sharded_dict = build_sharded_state_dict(
-                state_dict, None, structured_name_prefix
-            )
-        else:
-            sharded_dict[full_key1] = shard_weight(
-                key=full_key1,
-                weight=state_dict["weight1"],
-                axis=0,
-                group=self.ep_group,
-            )
-            sharded_dict[full_key1].grouped_gemm_param = True
-            sharded_dict[full_key2] = shard_weight(
-                key=full_key2,
-                weight=state_dict["weight2"],
-                axis=0,
-                group=self.ep_group,
-            )
-            sharded_dict[full_key2].grouped_gemm_param = True
-        return sharded_dict
+        self.convert_weights_to_grouped_layout()
+        return super().sharded_state_dict(structured_name_prefix)
 
 
 class StandardMLPExpert(MLP):

--- a/tests/multi_card_tests/moe/test_sonic_moe_ep.py
+++ b/tests/multi_card_tests/moe/test_sonic_moe_ep.py
@@ -271,52 +271,6 @@ class TestSonicMoEExpertParallelPrecision(unittest.TestCase):
         )
 
     @staticmethod
-    def _split_to_sonic_interleaved(weight):
-        gate, up = paddle.chunk(weight, 2, axis=-1)
-        gate = gate.transpose([0, 2, 1])
-        up = up.transpose([0, 2, 1])
-        return paddle.stack([gate, up], axis=2).reshape(
-            [weight.shape[0], -1, weight.shape[1]]
-        )
-
-    @staticmethod
-    def _sonic_interleaved_to_split_grad(grad):
-        grad = grad.reshape([grad.shape[0], -1, 2, grad.shape[2]])
-        gate = grad[:, :, 0, :].transpose([0, 2, 1])
-        up = grad[:, :, 1, :].transpose([0, 2, 1])
-        return paddle.concat([gate, up], axis=-1)
-
-    @classmethod
-    def _aligned_grad_for_compare(
-        cls, name, grad, transpose_grouped_gemm=False
-    ):
-        if not transpose_grouped_gemm:
-            return grad
-        if "grouped_gemm_experts.weight1" in name:
-            return cls._sonic_interleaved_to_split_grad(grad)
-        if "grouped_gemm_experts.weight2" in name:
-            return grad.transpose([0, 2, 1])
-        return grad
-
-    @classmethod
-    def _copy_weights(cls, src_layer, dst_layer, transpose_grouped_gemm=False):
-        src_params = dict(src_layer.named_parameters())
-        for name, dst_param in dst_layer.named_parameters():
-            src_param = src_params[name]
-            if (
-                transpose_grouped_gemm
-                and "grouped_gemm_experts.weight1" in name
-            ):
-                dst_param.set_value(cls._split_to_sonic_interleaved(src_param))
-            elif (
-                transpose_grouped_gemm
-                and "grouped_gemm_experts.weight2" in name
-            ):
-                dst_param.set_value(src_param.transpose([0, 2, 1]))
-            else:
-                dst_param.set_value(src_param.clone())
-
-    @staticmethod
     def _expert_slice_for_rank(tensor, ep_rank, ep_size):
         chunk_size = tensor.shape[0] // ep_size
         return tensor[ep_rank * chunk_size : (ep_rank + 1) * chunk_size]
@@ -365,6 +319,31 @@ class TestSonicMoEExpertParallelPrecision(unittest.TestCase):
             if param.grad is not None:
                 param.grad.zero_()
 
+    def _flush_sonic_expert_layout(self, moe_layer):
+        expert = getattr(moe_layer, "grouped_gemm_experts", None)
+        if not hasattr(expert, "flush_to_grouped_layout"):
+            return
+
+        weight_ptrs = (expert.weight1.data_ptr(), expert.weight2.data_ptr())
+        grad_ptrs = []
+        for param in (expert.weight1, expert.weight2):
+            grad = getattr(param, "main_grad", None)
+            if grad is None:
+                grad = param.grad
+            grad_ptrs.append(None if grad is None else grad.data_ptr())
+
+        expert.flush_to_grouped_layout()
+
+        self.assertEqual(expert.weight1.data_ptr(), weight_ptrs[0])
+        self.assertEqual(expert.weight2.data_ptr(), weight_ptrs[1])
+        for param, grad_ptr in zip((expert.weight1, expert.weight2), grad_ptrs):
+            if grad_ptr is None:
+                continue
+            grad = getattr(param, "main_grad", None)
+            if grad is None:
+                grad = param.grad
+            self.assertEqual(grad.data_ptr(), grad_ptr)
+
     def _run_forward_backward(self, moe_layer, input_data):
         moe_layer = paddle.amp.decorate(
             models=moe_layer,
@@ -381,6 +360,7 @@ class TestSonicMoEExpertParallelPrecision(unittest.TestCase):
             loss = output.sum()
             # loss = paddle.mean(paddle.square(output.cast("float32")))
         loss.backward()
+        self._flush_sonic_expert_layout(moe_layer)
         return (
             output.detach().clone(),
             loss.item(),
@@ -399,6 +379,7 @@ class TestSonicMoEExpertParallelPrecision(unittest.TestCase):
                 loss = paddle.mean(paddle.square(output.cast("float32")))
             loss.backward()
             outputs.append(output.detach().clone())
+        self._flush_sonic_expert_layout(moe_layer)
         return outputs[-1], self._collect_grads(moe_layer)
 
     def _assert_loss_close(self, lhs, rhs, tol, title):
@@ -421,7 +402,6 @@ class TestSonicMoEExpertParallelPrecision(unittest.TestCase):
         rhs_grads,
         tol,
         title,
-        transpose_grouped_gemm=False,
     ):
         lhs_names = set(lhs_grads)
         rhs_names = set(rhs_grads)
@@ -436,14 +416,9 @@ class TestSonicMoEExpertParallelPrecision(unittest.TestCase):
         )
         self.assertTrue(lhs_names, f"No grad tensors found for {title}")
         for name in sorted(lhs_names):
-            lhs_grad = self._aligned_grad_for_compare(
-                name,
-                lhs_grads[name],
-                transpose_grouped_gemm=transpose_grouped_gemm,
-            )
             grad_tol = tol[name] if isinstance(tol, dict) else tol
             self._assert_tensor_diff_less(
-                lhs_grad,
+                lhs_grads[name],
                 rhs_grads[name],
                 tol=grad_tol,
                 title=f"{title} grad {name}",
@@ -497,7 +472,6 @@ class TestSonicMoEExpertParallelPrecision(unittest.TestCase):
             grads_base,
             tol=1e-2,
             title="Sonic-MoE BF16 vs Baseline accumulated grad",
-            transpose_grouped_gemm=True,
         )
 
         fp8_tol = 5e-3

--- a/tests/single_card_tests/model/test_gpt_model_sonic_moe.py
+++ b/tests/single_card_tests/model/test_gpt_model_sonic_moe.py
@@ -179,25 +179,6 @@ class TestSonicMoELayerPrecision(unittest.TestCase):
         return moe_layer
 
     @staticmethod
-    def _sonic_interleaved_to_split_grad(grad):
-        grad = grad.reshape([grad.shape[0], -1, 2, grad.shape[2]])
-        gate = grad[:, :, 0, :].transpose([0, 2, 1])
-        up = grad[:, :, 1, :].transpose([0, 2, 1])
-        return paddle.concat([gate, up], axis=-1)
-
-    @classmethod
-    def _aligned_grad_for_compare(
-        cls, name, grad, transpose_grouped_gemm=False
-    ):
-        if not transpose_grouped_gemm:
-            return grad
-        if "grouped_gemm_experts.weight1" in name:
-            return cls._sonic_interleaved_to_split_grad(grad)
-        if "grouped_gemm_experts.weight2" in name:
-            return grad.transpose([0, 2, 1])
-        return grad
-
-    @staticmethod
     def _collect_grads(layer):
         grads = {}
         for name, param in layer.named_parameters():
@@ -216,6 +197,31 @@ class TestSonicMoELayerPrecision(unittest.TestCase):
             if param.grad is not None:
                 param.grad.zero_()
 
+    def _flush_sonic_expert_layout(self, moe_layer):
+        expert = getattr(moe_layer, "grouped_gemm_experts", None)
+        if not hasattr(expert, "flush_to_grouped_layout"):
+            return
+
+        weight_ptrs = (expert.weight1.data_ptr(), expert.weight2.data_ptr())
+        grad_ptrs = []
+        for param in (expert.weight1, expert.weight2):
+            grad = getattr(param, "main_grad", None)
+            if grad is None:
+                grad = param.grad
+            grad_ptrs.append(None if grad is None else grad.data_ptr())
+
+        expert.flush_to_grouped_layout()
+
+        self.assertEqual(expert.weight1.data_ptr(), weight_ptrs[0])
+        self.assertEqual(expert.weight2.data_ptr(), weight_ptrs[1])
+        for param, grad_ptr in zip((expert.weight1, expert.weight2), grad_ptrs):
+            if grad_ptr is None:
+                continue
+            grad = getattr(param, "main_grad", None)
+            if grad is None:
+                grad = param.grad
+            self.assertEqual(grad.data_ptr(), grad_ptr)
+
     def _run_accumulated_forward_backward(self, moe_layer, input_data_list):
         self._clear_grads(moe_layer)
         losses = []
@@ -228,6 +234,7 @@ class TestSonicMoELayerPrecision(unittest.TestCase):
                 loss = output.sum()
             loss.backward()
             losses.append(loss.item())
+        self._flush_sonic_expert_layout(moe_layer)
         return (
             losses[-1],
             output.detach().clone(),
@@ -238,9 +245,8 @@ class TestSonicMoELayerPrecision(unittest.TestCase):
         """Test MoELayer precision: BF16 sonic-moe vs baseline, FP8 vs BF16.
 
         Both baseline and sonic layers are built with the same seed.
-        GroupedMLPExpert.__init__ ensures sonic weights are initialized
-        from the same baseline values via _split_to_sonic_interleaved,
-        so the weights are mathematically equivalent.
+        SonicMoEExpert reuses GroupedMLPExpert initialization, so expert
+        weights are initialized in the same layout and values as baseline.
 
         Uses BMMFunction (moe_deep_gemm=False) for the baseline to avoid
         a known bug in DeepGEMMBMMFunction that corrupts expert outputs
@@ -305,7 +311,7 @@ class TestSonicMoELayerPrecision(unittest.TestCase):
             f"(bl={loss_bl}, bf16={loss_bf16})",
         )
 
-        # Gradient comparison (with format conversion for expert weights)
+        # Gradient comparison. Sonic expert params keep GroupedMLP layout.
         gate_key = "gate.weight"
         if gate_key in grads_bl and gate_key in grads_bf16:
             diff = calc_diff(grads_bl[gate_key], grads_bf16[gate_key])
@@ -316,8 +322,7 @@ class TestSonicMoELayerPrecision(unittest.TestCase):
 
         w1_key = "grouped_gemm_experts.weight1"
         if w1_key in grads_bl and w1_key in grads_bf16:
-            g_sonic = self._sonic_interleaved_to_split_grad(grads_bf16[w1_key])
-            diff = calc_diff(grads_bl[w1_key], g_sonic)
+            diff = calc_diff(grads_bl[w1_key], grads_bf16[w1_key])
             print(
                 f"BF16 sonic vs Baseline: grad diff = {diff:.6e} for {w1_key}"
             )
@@ -325,8 +330,7 @@ class TestSonicMoELayerPrecision(unittest.TestCase):
 
         w2_key = "grouped_gemm_experts.weight2"
         if w2_key in grads_bl and w2_key in grads_bf16:
-            g_sonic = grads_bf16[w2_key].transpose([0, 2, 1])
-            diff = calc_diff(grads_bl[w2_key], g_sonic)
+            diff = calc_diff(grads_bl[w2_key], grads_bf16[w2_key])
             print(
                 f"BF16 sonic vs Baseline: grad diff = {diff:.6e} for {w2_key}"
             )


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Distributed Strategy

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
SonicMoE requires a specific weight layout. To make SonicMoE consistent with other parts in PaddleFleet, create the weights in SonicMoEExpert with GroupedGEMM's layout, and convert to SonicMoE's layout in runtime.

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否