### PR TITLE
[Performance Optimization] Migrate CSA indexer backward to cuDNN frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ packages/paddlefleet_ops/src/paddlefleet_ops/hybrid_ep_cpp.so
 packages/paddlefleet_ops/src/paddlefleet_ops/flash_mask
 packages/paddlefleet_ops/src/paddlefleet_ops/sonicmoe
 packages/paddlefleet_ops/src/paddlefleet_ops/quack
+packages/paddlefleet_ops/src/paddlefleet_ops/cudnn
 
 # Generated version files
 # Both version.py files are auto-generated at build time by build_backend.py.

--- a/src/paddlefleet/cudnn_ops/__init__.py
+++ b/src/paddlefleet/cudnn_ops/__init__.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""cuDNN frontend ops bridged into PaddleFleet via dlpack."""
+
+__all__ = ["csa_indexer_bwd"]
+
+
+def __getattr__(name):
+    if name == "csa_indexer_bwd":
+        from .indexer.csa_indexer_bwd_cudnn import csa_indexer_bwd
+
+        globals()[name] = csa_indexer_bwd
+        return csa_indexer_bwd
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/paddlefleet/cudnn_ops/__init__.py
+++ b/src/paddlefleet/cudnn_ops/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""cuDNN frontend ops bridged into PaddleFleet via dlpack."""
+"""cuDNN frontend ops bridged into PaddleFleet."""
 
 __all__ = ["csa_indexer_bwd"]
 

--- a/src/paddlefleet/cudnn_ops/indexer/__init__.py
+++ b/src/paddlefleet/cudnn_ops/indexer/__init__.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .csa_indexer_bwd_cudnn import csa_indexer_bwd
+
+__all__ = ["csa_indexer_bwd"]

--- a/src/paddlefleet/cudnn_ops/indexer/csa_indexer_bwd_cudnn.py
+++ b/src/paddlefleet/cudnn_ops/indexer/csa_indexer_bwd_cudnn.py
@@ -14,15 +14,11 @@
 
 """Paddle wrapper around the cuDNN-frontend DSA indexer backward.
 
-This bridges the Python API
-``cudnn.deepseek_sparse_attention.indexer_backward.indexer_backward_wrapper``
-(distributed inside ``nvidia-cudnn-frontend``) into PaddleFleet via dlpack
-zero-copy.
-
-It is a drop-in replacement for ``paddlefleet.tilelang_ops.csa_indexer_bwd``,
-but exposes the *raw* (target, predict) pair instead of pre-computed
-``grad_scores``: cuDNN performs the score-gradient precompute kernel itself,
-matching Megatron's ``FusedIndexerSparseAttnFunc`` data flow.
+Calls ``paddlefleet_ops.cudnn.deepseek_sparse_attention.indexer_backward.api
+.indexer_backward_wrapper`` directly on Paddle tensors. The wrapper performs
+the score-gradient precompute kernel internally, matching Megatron's
+``FusedIndexerSparseAttnFunc`` data flow, so this entry point exposes the
+*raw* (target, predict) pair instead of pre-computed ``grad_scores``.
 
 Returns d_index_q / d_weights / d_index_k_comp matching input dtypes/shapes.
 """
@@ -30,69 +26,9 @@ Returns d_index_q / d_weights / d_index_k_comp matching input dtypes/shapes.
 from __future__ import annotations
 
 import paddle
-
-_CUDNN_API_IMPORT_ERROR: str | None = None
-
-
-def _lazy_import_cudnn():
-    """Import the cuDNN-frontend DSA indexer-backward API on first use."""
-    global _CUDNN_API_IMPORT_ERROR
-    try:
-        from cudnn.deepseek_sparse_attention.indexer_backward.api import (
-            indexer_backward_wrapper,
-        )
-
-        return indexer_backward_wrapper
-    except Exception as exc:  # pragma: no cover - environment-specific
-        _CUDNN_API_IMPORT_ERROR = str(exc)
-        raise RuntimeError(
-            "csa_indexer_bwd requires the `nvidia-cudnn-frontend` "
-            "Python package (provides `cudnn.deepseek_sparse_attention`). "
-            f"Import failed: {exc}"
-        ) from exc
-
-
-def _lazy_import_torch():
-    try:
-        import torch
-
-        return torch
-    except Exception as exc:  # pragma: no cover
-        raise RuntimeError(
-            "csa_indexer_bwd requires `torch` to be importable so that "
-            "tensors can be exchanged with cuDNN frontend via dlpack."
-        ) from exc
-
-
-def _paddle_to_torch(t: paddle.Tensor):
-    """Bridge paddle.Tensor -> torch.Tensor via dlpack.
-
-    Zero-copy in the common case (input already contiguous): the returned
-    tensor aliases the same GPU memory and mutating it mutates the original.
-
-    Falls back to ``t.contiguous()`` when the input has non-trivial stride.
-    In that case a fresh contiguous copy is allocated and the returned
-    tensor does **not** alias ``t`` -- callers that rely on aliasing must
-    ensure the input is contiguous before invoking.
-    """
-    torch = _lazy_import_torch()
-    if not t.is_contiguous():
-        t = t.contiguous()
-    # paddle.Tensor implements __dlpack__ (PEP 3118); torch.from_dlpack
-    # accepts either a capsule or an object with __dlpack__.
-    return torch.from_dlpack(t)
-
-
-def _torch_to_paddle(t) -> paddle.Tensor:
-    """Bridge torch.Tensor -> paddle.Tensor via dlpack.
-
-    Zero-copy when the input is contiguous (cuDNN-allocated outputs always
-    are). Otherwise falls back to ``t.contiguous()``, which allocates a
-    fresh buffer and breaks aliasing with ``t``.
-    """
-    if not t.is_contiguous():
-        t = t.contiguous()
-    return paddle.utils.dlpack.from_dlpack(t)
+from paddlefleet_ops.cudnn.deepseek_sparse_attention.indexer_backward.api import (
+    indexer_backward_wrapper,
+)
 
 
 def _to_bf16(t: paddle.Tensor) -> paddle.Tensor:
@@ -134,9 +70,6 @@ def csa_indexer_bwd(
         as the corresponding inputs and dtypes restored to the original
         ``weights`` dtype.
     """
-    indexer_backward_wrapper = _lazy_import_cudnn()
-    torch = _lazy_import_torch()
-
     orig_weights_dtype = weights.dtype
     orig_q_dtype = index_q.dtype
     orig_k_dtype = index_k_comp.dtype
@@ -147,13 +80,17 @@ def csa_indexer_bwd(
 
     # cuDNN overwrites attn_score (target) and index_score (topk_probs)
     # in-place during the score-grad precompute. Clone so the saved
-    # forward tensors are untouched.
-    target_buf = target.clone()
-    predict_buf = topk_probs.clone()
-    if target_buf.dtype != paddle.float32:
-        target_buf = target_buf.cast(paddle.float32)
-    if predict_buf.dtype != paddle.float32:
-        predict_buf = predict_buf.cast(paddle.float32)
+    # forward tensors are untouched, casting to fp32 in one step.
+    target_buf = (
+        target.cast(paddle.float32)
+        if target.dtype != paddle.float32
+        else target.clone()
+    )
+    predict_buf = (
+        topk_probs.cast(paddle.float32)
+        if topk_probs.dtype != paddle.float32
+        else topk_probs.clone()
+    )
     if topk_indices.dtype != paddle.int32:
         topk_indices = topk_indices.cast(paddle.int32)
 
@@ -165,37 +102,22 @@ def csa_indexer_bwd(
         if grad_loss_paddle.dtype != paddle.float32:
             grad_loss_paddle = grad_loss_paddle.cast(paddle.float32)
 
-    # Move every tensor over to torch via dlpack (same GPU memory).
-    t_index_q = _paddle_to_torch(index_q_bf)
-    t_weights = _paddle_to_torch(weights_bf)
-    t_index_k = _paddle_to_torch(index_k_bf)
-    t_attn = _paddle_to_torch(target_buf)
-    t_index_score = _paddle_to_torch(predict_buf)
-    t_topk = _paddle_to_torch(topk_indices)
-    t_grad_loss = _paddle_to_torch(grad_loss_paddle)
+    out = indexer_backward_wrapper(
+        index_q_bf,
+        weights_bf,
+        index_k_bf,
+        target_buf,
+        predict_buf,
+        topk_indices,
+        sm_scale=float(index_q_bf.shape[-1]) ** -0.5,
+        loss_coeff=float(loss_coeff),
+        grad_loss=grad_loss_paddle,
+        block_I=int(block_I),
+    )
 
-    # Make sure cuDNN executes on Paddle's current CUDA stream so that the
-    # output tensors are visible to subsequent paddle ops without an
-    # explicit synchronize.
-    cur_stream_handle = paddle.device.current_stream().stream_base.cuda_stream
-    torch_stream = torch.cuda.ExternalStream(cur_stream_handle)
-    with torch.cuda.stream(torch_stream):
-        out = indexer_backward_wrapper(
-            t_index_q,
-            t_weights,
-            t_index_k,
-            t_attn,
-            t_index_score,
-            t_topk,
-            sm_scale=float(index_q_bf.shape[-1]) ** -0.5,
-            loss_coeff=float(loss_coeff),
-            grad_loss=t_grad_loss,
-            block_I=int(block_I),
-        )
-
-    grad_q = _torch_to_paddle(out["d_index_q"])
-    grad_weights = _torch_to_paddle(out["d_weights"])
-    grad_k = _torch_to_paddle(out["d_index_k"])
+    grad_q = out["d_index_q"]
+    grad_weights = out["d_weights"]
+    grad_k = out["d_index_k"]
 
     if grad_q.dtype != orig_q_dtype:
         grad_q = grad_q.cast(orig_q_dtype)

--- a/src/paddlefleet/cudnn_ops/indexer/csa_indexer_bwd_cudnn.py
+++ b/src/paddlefleet/cudnn_ops/indexer/csa_indexer_bwd_cudnn.py
@@ -1,0 +1,207 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Paddle wrapper around the cuDNN-frontend DSA indexer backward.
+
+This bridges the Python API
+``cudnn.deepseek_sparse_attention.indexer_backward.indexer_backward_wrapper``
+(distributed inside ``nvidia-cudnn-frontend``) into PaddleFleet via dlpack
+zero-copy.
+
+It is a drop-in replacement for ``paddlefleet.tilelang_ops.csa_indexer_bwd``,
+but exposes the *raw* (target, predict) pair instead of pre-computed
+``grad_scores``: cuDNN performs the score-gradient precompute kernel itself,
+matching Megatron's ``FusedIndexerSparseAttnFunc`` data flow.
+
+Returns d_index_q / d_weights / d_index_k_comp matching input dtypes/shapes.
+"""
+
+from __future__ import annotations
+
+import paddle
+
+_CUDNN_API_IMPORT_ERROR: str | None = None
+
+
+def _lazy_import_cudnn():
+    """Import the cuDNN-frontend DSA indexer-backward API on first use."""
+    global _CUDNN_API_IMPORT_ERROR
+    try:
+        from cudnn.deepseek_sparse_attention.indexer_backward.api import (
+            indexer_backward_wrapper,
+        )
+
+        return indexer_backward_wrapper
+    except Exception as exc:  # pragma: no cover - environment-specific
+        _CUDNN_API_IMPORT_ERROR = str(exc)
+        raise RuntimeError(
+            "csa_indexer_bwd requires the `nvidia-cudnn-frontend` "
+            "Python package (provides `cudnn.deepseek_sparse_attention`). "
+            f"Import failed: {exc}"
+        ) from exc
+
+
+def _lazy_import_torch():
+    try:
+        import torch
+
+        return torch
+    except Exception as exc:  # pragma: no cover
+        raise RuntimeError(
+            "csa_indexer_bwd requires `torch` to be importable so that "
+            "tensors can be exchanged with cuDNN frontend via dlpack."
+        ) from exc
+
+
+def _paddle_to_torch(t: paddle.Tensor):
+    """Bridge paddle.Tensor -> torch.Tensor via dlpack.
+
+    Zero-copy in the common case (input already contiguous): the returned
+    tensor aliases the same GPU memory and mutating it mutates the original.
+
+    Falls back to ``t.contiguous()`` when the input has non-trivial stride.
+    In that case a fresh contiguous copy is allocated and the returned
+    tensor does **not** alias ``t`` -- callers that rely on aliasing must
+    ensure the input is contiguous before invoking.
+    """
+    torch = _lazy_import_torch()
+    if not t.is_contiguous():
+        t = t.contiguous()
+    # paddle.Tensor implements __dlpack__ (PEP 3118); torch.from_dlpack
+    # accepts either a capsule or an object with __dlpack__.
+    return torch.from_dlpack(t)
+
+
+def _torch_to_paddle(t) -> paddle.Tensor:
+    """Bridge torch.Tensor -> paddle.Tensor via dlpack.
+
+    Zero-copy when the input is contiguous (cuDNN-allocated outputs always
+    are). Otherwise falls back to ``t.contiguous()``, which allocates a
+    fresh buffer and breaks aliasing with ``t``.
+    """
+    if not t.is_contiguous():
+        t = t.contiguous()
+    return paddle.utils.dlpack.from_dlpack(t)
+
+
+def _to_bf16(t: paddle.Tensor) -> paddle.Tensor:
+    if t.dtype != paddle.bfloat16:
+        return t.cast(paddle.bfloat16)
+    return t
+
+
+def csa_indexer_bwd(
+    index_q: paddle.Tensor,
+    weights: paddle.Tensor,
+    index_k_comp: paddle.Tensor,
+    target: paddle.Tensor,
+    topk_probs: paddle.Tensor,
+    topk_indices: paddle.Tensor,
+    loss_coeff: float,
+    grad_loss: paddle.Tensor | None = None,
+    block_I: int = 128,
+) -> tuple[paddle.Tensor, paddle.Tensor, paddle.Tensor]:
+    """Run cuDNN-frontend DSA indexer backward on Paddle tensors.
+
+    Args:
+        index_q:       [B, S, H, D] bf16, indexer queries.
+        weights:       [B, S, H], per-head weights. bf16 expected; fp32 is
+            cast to bf16 internally and the gradient cast back.
+        index_k_comp:  [B, S_comp, D] bf16, compressed indexer keys.
+        target:        [B, S, topk] fp32, multi-head aggregated attention
+            target (probability over selected slots).
+        topk_probs:    [B, S, topk] fp32, indexer post-softmax probs over the
+            same selected slots.
+        topk_indices:  [B, S, topk] int32, selected positions (-1 = invalid).
+        loss_coeff:    scalar, KL loss coefficient (e.g. 0.01).
+        grad_loss:     0-D fp32 paddle tensor, upstream gradient w.r.t. the
+            scalar KL loss. ``None`` is treated as 1.0.
+        block_I:       cuDNN tile size. 128 matches Megatron production.
+
+    Returns:
+        (grad_index_q, grad_weights, grad_index_k_comp) with the same shapes
+        as the corresponding inputs and dtypes restored to the original
+        ``weights`` dtype.
+    """
+    indexer_backward_wrapper = _lazy_import_cudnn()
+    torch = _lazy_import_torch()
+
+    orig_weights_dtype = weights.dtype
+    orig_q_dtype = index_q.dtype
+    orig_k_dtype = index_k_comp.dtype
+
+    index_q_bf = _to_bf16(index_q)
+    weights_bf = _to_bf16(weights)
+    index_k_bf = _to_bf16(index_k_comp)
+
+    # cuDNN overwrites attn_score (target) and index_score (topk_probs)
+    # in-place during the score-grad precompute. Clone so the saved
+    # forward tensors are untouched.
+    target_buf = target.clone()
+    predict_buf = topk_probs.clone()
+    if target_buf.dtype != paddle.float32:
+        target_buf = target_buf.cast(paddle.float32)
+    if predict_buf.dtype != paddle.float32:
+        predict_buf = predict_buf.cast(paddle.float32)
+    if topk_indices.dtype != paddle.int32:
+        topk_indices = topk_indices.cast(paddle.int32)
+
+    # grad_loss as a 0-D fp32 tensor.
+    if grad_loss is None:
+        grad_loss_paddle = paddle.ones([], dtype=paddle.float32)
+    else:
+        grad_loss_paddle = grad_loss
+        if grad_loss_paddle.dtype != paddle.float32:
+            grad_loss_paddle = grad_loss_paddle.cast(paddle.float32)
+
+    # Move every tensor over to torch via dlpack (same GPU memory).
+    t_index_q = _paddle_to_torch(index_q_bf)
+    t_weights = _paddle_to_torch(weights_bf)
+    t_index_k = _paddle_to_torch(index_k_bf)
+    t_attn = _paddle_to_torch(target_buf)
+    t_index_score = _paddle_to_torch(predict_buf)
+    t_topk = _paddle_to_torch(topk_indices)
+    t_grad_loss = _paddle_to_torch(grad_loss_paddle)
+
+    # Make sure cuDNN executes on Paddle's current CUDA stream so that the
+    # output tensors are visible to subsequent paddle ops without an
+    # explicit synchronize.
+    cur_stream_handle = paddle.device.current_stream().stream_base.cuda_stream
+    torch_stream = torch.cuda.ExternalStream(cur_stream_handle)
+    with torch.cuda.stream(torch_stream):
+        out = indexer_backward_wrapper(
+            t_index_q,
+            t_weights,
+            t_index_k,
+            t_attn,
+            t_index_score,
+            t_topk,
+            sm_scale=float(index_q_bf.shape[-1]) ** -0.5,
+            loss_coeff=float(loss_coeff),
+            grad_loss=t_grad_loss,
+            block_I=int(block_I),
+        )
+
+    grad_q = _torch_to_paddle(out["d_index_q"])
+    grad_weights = _torch_to_paddle(out["d_weights"])
+    grad_k = _torch_to_paddle(out["d_index_k"])
+
+    if grad_q.dtype != orig_q_dtype:
+        grad_q = grad_q.cast(orig_q_dtype)
+    if grad_weights.dtype != orig_weights_dtype:
+        grad_weights = grad_weights.cast(orig_weights_dtype)
+    if grad_k.dtype != orig_k_dtype:
+        grad_k = grad_k.cast(orig_k_dtype)
+
+    return grad_q, grad_weights, grad_k

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -51,6 +51,7 @@ if TYPE_CHECKING:
     from paddlefleet.transformer.enums import AttnMaskType
     from paddlefleet.transformer.transformer_config import TransformerConfig
 
+
 # ---------------------------------------------------------------------------
 # Helper functions for index computation
 # ---------------------------------------------------------------------------
@@ -498,6 +499,7 @@ class TileLangCSAIndexerLoss(paddle.autograd.PyLayer):
         softmax_scale: float,
         loss_coeff: float,
         tp_group=None,
+        indexer_backend: str = "tilelang",
     ) -> Tensor:
         # The TileLang kernel applies its own ``dim**-0.5`` scale on index_q
         # and consumes raw weights, so we pass them through unmodified. The
@@ -528,15 +530,13 @@ class TileLangCSAIndexerLoss(paddle.autograd.PyLayer):
             target.detach(),
         )
         ctx.loss_coeff = float(loss_coeff)
-        ctx.num_rows = float(target.shape[0] * target.shape[1])
+        ctx.indexer_backend = str(indexer_backend)
+        if ctx.indexer_backend == "tilelang":
+            ctx.num_rows = float(target.shape[0] * target.shape[1])
         return loss, topk_indices.detach()
 
     @staticmethod
     def backward(ctx, grad_loss: Tensor, grad_topk_indices: Tensor = None):
-        from paddlefleet.tilelang_ops import (
-            csa_indexer_bwd,
-        )
-
         (
             index_q,
             weights,
@@ -546,20 +546,44 @@ class TileLangCSAIndexerLoss(paddle.autograd.PyLayer):
             target,
         ) = ctx.saved_tensor()
 
-        # Treat the forward eps as numerical protection only and use the
-        # fused softmax + KL gradient w.r.t. the selected logits.
-        scale = ctx.loss_coeff / max(ctx.num_rows, 1.0)
-        grad_index_scores = (topk_probs - target) * scale
-        if grad_loss is not None:
-            grad_index_scores = grad_index_scores * grad_loss
+        if ctx.indexer_backend == "cudnn":
+            from paddlefleet.cudnn_ops import csa_indexer_bwd
 
-        grad_q, grad_weights, grad_k = csa_indexer_bwd(
-            index_q,
-            weights,
-            index_k_comp,
-            topk_indices,
-            grad_index_scores,
-        )
+            # cuDNN does the (predict - target) * (loss_coeff/(B*Sq)) score-grad
+            # precompute internally and multiplies the result by ``grad_loss``
+            # in the GEMM kernel. ``num_rows == B * Sq`` matches cuDNN's
+            # built-in ``grad_scale = loss_coeff / (B*Sq)``.
+            grad_q, grad_weights, grad_k = csa_indexer_bwd(
+                index_q,
+                weights,
+                index_k_comp,
+                target,
+                topk_probs,
+                topk_indices,
+                loss_coeff=ctx.loss_coeff,
+                grad_loss=grad_loss,
+            )
+        elif ctx.indexer_backend == "tilelang":
+            from paddlefleet.tilelang_ops import csa_indexer_bwd
+
+            # Treat the forward eps as numerical protection only and use the
+            # fused softmax + KL gradient w.r.t. the selected logits.
+            scale = ctx.loss_coeff / max(ctx.num_rows, 1.0)
+            grad_index_scores = (topk_probs - target) * scale
+            if grad_loss is not None:
+                grad_index_scores = grad_index_scores * grad_loss
+
+            grad_q, grad_weights, grad_k = csa_indexer_bwd(
+                index_q,
+                weights,
+                index_k_comp,
+                topk_indices,
+                grad_index_scores,
+            )
+        else:
+            raise NotImplementedError(
+                f"CSA indexer backend {ctx.indexer_backend!r} not implemented."
+            )
 
         if grad_q.dtype != index_q.dtype:
             grad_q = grad_q.cast(index_q.dtype)
@@ -596,6 +620,7 @@ class TileLangCSAIndexerLossAutoScaler(paddle.autograd.PyLayer):
         topk_probs: Tensor,
         target: Tensor,
         loss_coeff: float,
+        indexer_backend: str = "tilelang",
     ) -> Tensor:
         ctx.save_for_backward(
             index_q.detach(),
@@ -606,13 +631,13 @@ class TileLangCSAIndexerLossAutoScaler(paddle.autograd.PyLayer):
             target.detach(),
         )
         ctx.loss_coeff = float(loss_coeff)
-        ctx.num_rows = float(target.shape[0] * target.shape[1])
+        ctx.indexer_backend = str(indexer_backend)
+        if ctx.indexer_backend == "tilelang":
+            ctx.num_rows = float(target.shape[0] * target.shape[1])
         return output
 
     @staticmethod
     def backward(ctx, grad_output: Tensor):
-        from paddlefleet.tilelang_ops import csa_indexer_bwd
-
         (
             index_q,
             weights,
@@ -622,20 +647,52 @@ class TileLangCSAIndexerLossAutoScaler(paddle.autograd.PyLayer):
             target,
         ) = ctx.saved_tensor()
 
-        grad_index_scores = (topk_probs - target) * (
-            ctx.loss_coeff / max(ctx.num_rows, 1.0)
-        )
         scale = DSAIndexerLossAutoScaler._main_loss_backward_scale
-        if scale is not None:
-            grad_index_scores = grad_index_scores * scale
 
-        grad_q, grad_weights, grad_k = csa_indexer_bwd(
-            index_q,
-            weights,
-            index_k_comp,
-            topk_indices,
-            grad_index_scores,
-        )
+        if ctx.indexer_backend == "cudnn":
+            from paddlefleet.cudnn_ops import csa_indexer_bwd
+
+            # cuDNN multiplies its internal score-grad by ``grad_loss`` in
+            # the GEMM kernel; pass the externally-set scaler as ``grad_loss``.
+            if scale is None:
+                grad_loss_arg = None
+            elif isinstance(scale, paddle.Tensor):
+                grad_loss_arg = scale
+            else:
+                grad_loss_arg = paddle.to_tensor(
+                    float(scale), dtype=paddle.float32
+                )
+
+            grad_q, grad_weights, grad_k = csa_indexer_bwd(
+                index_q,
+                weights,
+                index_k_comp,
+                target,
+                topk_probs,
+                topk_indices,
+                loss_coeff=ctx.loss_coeff,
+                grad_loss=grad_loss_arg,
+            )
+        elif ctx.indexer_backend == "tilelang":
+            from paddlefleet.tilelang_ops import csa_indexer_bwd
+
+            grad_index_scores = (topk_probs - target) * (
+                ctx.loss_coeff / max(ctx.num_rows, 1.0)
+            )
+            if scale is not None:
+                grad_index_scores = grad_index_scores * scale
+
+            grad_q, grad_weights, grad_k = csa_indexer_bwd(
+                index_q,
+                weights,
+                index_k_comp,
+                topk_indices,
+                grad_index_scores,
+            )
+        else:
+            raise NotImplementedError(
+                f"CSA indexer backend {ctx.indexer_backend!r} not implemented."
+            )
 
         if grad_q.dtype != index_q.dtype:
             grad_q = grad_q.cast(index_q.dtype)
@@ -1142,6 +1199,7 @@ class CompressedSparseAttention(FleetLayer):
                 topk_probs,
                 target,
                 float(indexer_loss_coeff),
+                str(getattr(self.config, "csa_indexer_backend", "tilelang")),
             )
             if indexer_loss_coeff > 0:
                 DSAIndexerLossLoggingHelper.save_loss_to_tracker(
@@ -1205,9 +1263,7 @@ class CompressedSparseAttention(FleetLayer):
         # Optionally replace topk producer with TileLang fused compressed
         # indexer forward. This only swaps the indices fed to sparse attention.
         if use_tilelang_indexer and not use_tilelang_loss_path:
-            from paddlefleet.tilelang_ops import (
-                csa_indexer_topk_fwd,
-            )
+            from paddlefleet.tilelang_ops import csa_indexer_topk_fwd
 
             with paddle.no_grad():
                 q_indexer_tl, k_indexer_tl, weights_indexer_tl = (

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -1199,7 +1199,7 @@ class CompressedSparseAttention(FleetLayer):
                 topk_probs,
                 target,
                 float(indexer_loss_coeff),
-                str(getattr(self.config, "csa_indexer_backend", "tilelang")),
+                str(self.config.csa_indexer_backend),
             )
             if indexer_loss_coeff > 0:
                 DSAIndexerLossLoggingHelper.save_loss_to_tracker(

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -829,11 +829,8 @@ class TransformerConfig(ModelParallelConfig):
     csa_indexer_backend: str = "tilelang"
     """CSA indexer backward backend.
 
-    One of {"tilelang", "cudnn"}; "triton" is reserved for future work.
-    Default "tilelang" preserves the legacy path. "cudnn" requires the
-    TileLang indexer forward (csa_tilelang_enable_indexer=True or
-    csa_tilelang_backend='attention_paddle_compat') because the cuDNN
-    backward consumes the TileLang forward's saved tensors.
+    One of {"tilelang", "cudnn"}. Default "tilelang" preserves the legacy
+    path.
     """
 
     o_groups: int = 8
@@ -1128,7 +1125,7 @@ class TransformerConfig(ModelParallelConfig):
                 raise ValueError(
                     "csa_tilelang_enable_sparse_attn=True requires csa_tilelang_backend='attention_paddle_compat'."
                 )
-            if self.csa_indexer_backend not in {"tilelang", "cudnn", "triton"}:
+            if self.csa_indexer_backend not in {"tilelang", "cudnn"}:
                 raise ValueError(
                     f"csa_indexer_backend={self.csa_indexer_backend!r} is invalid. "
                     "Must be one of {'tilelang', 'cudnn'}."

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -826,6 +826,16 @@ class TransformerConfig(ModelParallelConfig):
     final sparse MQA attention TileLang path.
     """
 
+    csa_indexer_backend: str = "tilelang"
+    """CSA indexer backward backend.
+
+    One of {"tilelang", "cudnn"}; "triton" is reserved for future work.
+    Default "tilelang" preserves the legacy path. "cudnn" requires the
+    TileLang indexer forward (csa_tilelang_enable_indexer=True or
+    csa_tilelang_backend='attention_paddle_compat') because the cuDNN
+    backward consumes the TileLang forward's saved tensors.
+    """
+
     o_groups: int = 8
     """Number of groups for grouped low-rank output projection (wo_a) in DSv4 Hybrid.
     Set to 0 to use a single linear output projection instead.
@@ -870,6 +880,7 @@ class TransformerConfig(ModelParallelConfig):
         "csa_tilelang_backend": "csa_tilelang_backend",
         "csa_tilelang_enable_indexer": "csa_tilelang_enable_indexer",
         "csa_tilelang_enable_sparse_attn": "csa_tilelang_enable_sparse_attn",
+        "csa_indexer_backend": "csa_indexer_backend",
         "o_groups": "o_groups",
         "o_lora_rank": "o_lora_rank",
         "qk_pos_emb_head_dim": "qk_pos_emb_head_dim",
@@ -1116,6 +1127,11 @@ class TransformerConfig(ModelParallelConfig):
             ):
                 raise ValueError(
                     "csa_tilelang_enable_sparse_attn=True requires csa_tilelang_backend='attention_paddle_compat'."
+                )
+            if self.csa_indexer_backend not in {"tilelang", "cudnn", "triton"}:
+                raise ValueError(
+                    f"csa_indexer_backend={self.csa_indexer_backend!r} is invalid. "
+                    "Must be one of {'tilelang', 'cudnn'}."
                 )
 
         # Hash-based MoE routing consistency checks.

--- a/tests/single_card_tests/custom_ops/test_cudnn_csa_indexer_bwd.py
+++ b/tests/single_card_tests/custom_ops/test_cudnn_csa_indexer_bwd.py
@@ -1,0 +1,586 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Numerical parity test: cuDNN-frontend indexer backward vs TileLang baseline.
+
+The two implementations consume different gradient signals:
+
+* TileLang ``csa_indexer_bwd`` takes a pre-computed
+  ``grad_scores = (topk_probs - target) * loss_coeff / num_rows * grad_loss``.
+* cuDNN ``indexer_backward_wrapper`` takes the raw ``target`` and ``topk_probs``
+  separately and computes the same score gradient internally
+  (``grad_scale = loss_coeff / (B*Sq)`` * ``grad_loss``).
+
+When both wrappers receive the equivalent inputs they must produce the same
+``d_index_q / d_weights / d_index_k_comp``.
+
+Run a single representative shape; cuDNN kernels are SM-version specific, so
+skip cleanly when the runtime environment cannot supply them.
+"""
+
+import unittest
+
+import paddle
+
+paddle.enable_compat(scope={"tilelang"}, silent=True)
+
+
+def _cuda_or_skip(testcase):
+    if not paddle.device.is_compiled_with_cuda():
+        testcase.skipTest("CUDA build of Paddle is required")
+    if paddle.device.cuda.device_count() == 0:
+        testcase.skipTest("No CUDA device available")
+
+
+def _try_import_cudnn():
+    try:
+        # Trigger the deeper import that talks to nvidia-cudnn-frontend.
+        from cudnn.deepseek_sparse_attention.indexer_backward.api import (
+            indexer_backward_wrapper,  # noqa: F401
+        )
+
+        from paddlefleet.cudnn_ops import csa_indexer_bwd
+
+        return csa_indexer_bwd
+    except Exception as exc:  # pragma: no cover
+        return None, str(exc)
+
+
+def _try_import_tilelang():
+    try:
+        from paddlefleet.tilelang_ops import csa_indexer_bwd
+
+        return csa_indexer_bwd
+    except Exception:
+        return None
+
+
+def _assert_close(actual, expected, rtol, atol, name):
+    a = actual.cast("float32")
+    e = expected.cast("float32")
+    if not paddle.allclose(a, e, rtol=rtol, atol=atol).item():
+        diff = (a - e).abs()
+        denom = e.abs().clip(min=1e-12)
+        raise AssertionError(
+            f"{name} mismatch: max abs={diff.max().item():.4e} "
+            f"max rel={(diff / denom).max().item():.4e}"
+        )
+
+
+class TestCudnnCsaIndexerBwd(unittest.TestCase):
+    def setUp(self):
+        _cuda_or_skip(self)
+
+        cudnn_fn = _try_import_cudnn()
+        if isinstance(cudnn_fn, tuple) or cudnn_fn is None:
+            reason = (
+                cudnn_fn[1]
+                if isinstance(cudnn_fn, tuple)
+                else "csa_indexer_bwd unavailable"
+            )
+            self.skipTest(f"cuDNN frontend unavailable: {reason}")
+        self.cudnn_fn = cudnn_fn
+
+        tilelang_fn = _try_import_tilelang()
+        if tilelang_fn is None:
+            self.skipTest("TileLang baseline csa_indexer_bwd unavailable")
+        self.tilelang_fn = tilelang_fn
+
+    def _make_inputs(self, b, sq, sk, h, d, topk, seed=2026):
+        paddle.seed(seed)
+        index_q = paddle.randn([b, sq, h, d]).astype("bfloat16")
+        index_k = paddle.randn([b, sk, d]).astype("bfloat16")
+        weights = paddle.randn([b, sq, h]).astype("bfloat16")
+        target = paddle.nn.functional.softmax(
+            paddle.randn([b, sq, topk]).astype("float32"), axis=-1
+        )
+        topk_probs = paddle.nn.functional.softmax(
+            paddle.randn([b, sq, topk]).astype("float32"), axis=-1
+        )
+        # Random valid indices into [0, sk); leave a few -1 holes.
+        topk_indices = paddle.randint(0, sk, [b, sq, topk]).astype("int32")
+        mask = paddle.rand([b, sq, topk]) < 0.05
+        topk_indices = paddle.where(
+            mask, paddle.full_like(topk_indices, -1), topk_indices
+        )
+        return index_q, weights, index_k, target, topk_probs, topk_indices
+
+    def test_parity_against_tilelang(self):
+        """Parity at rtol=atol=2e-2.
+
+        Tolerance derivation (conservative upper bound):
+
+        * bf16 mantissa is 7 bits, so a single multiply-add carries a
+          relative error of ``2^-7 ≈ 7.8e-3``.
+        * Both kernels accumulate in fp32 internally; with reduction depth
+          ``N <= topk*D = 128*128``, error grows as ``√N * eps`` rather than
+          ``N * eps``, contributing roughly ``1e-2`` relative.
+        * cuDNN and TileLang use different tile sizes and warp schedules;
+          fp accumulation order is not associative, contributing another
+          ``~5e-3``.
+
+        Sum of the three sources is ``~2e-2``, which we adopt for both
+        ``rtol`` and ``atol``. Empirically this passes across multiple
+        random seeds at this shape; revisit if a future shape regresses.
+        """
+        b, sq, sk, h, d, topk = 1, 1024, 256, 64, 128, 128
+        loss_coeff = 0.01
+        grad_loss_val = 1.0
+
+        (
+            index_q,
+            weights,
+            index_k,
+            target,
+            topk_probs,
+            topk_indices,
+        ) = self._make_inputs(b, sq, sk, h, d, topk)
+
+        try:
+            grad_q_cudnn, grad_w_cudnn, grad_k_cudnn = self.cudnn_fn(
+                index_q.clone(),
+                weights.clone(),
+                index_k.clone(),
+                target.clone(),
+                topk_probs.clone(),
+                topk_indices.clone(),
+                loss_coeff=loss_coeff,
+                grad_loss=paddle.to_tensor(grad_loss_val, dtype="float32"),
+            )
+        except Exception as exc:
+            import traceback
+
+            self.skipTest(
+                f"cuDNN kernel unsupported for shape: {type(exc).__name__}: {exc!r}\n"
+                f"{traceback.format_exc()}"
+            )
+
+        scale = loss_coeff / float(b * sq)
+        grad_scores = (topk_probs - target) * scale * grad_loss_val
+
+        grad_q_tl, grad_w_tl, grad_k_tl = self.tilelang_fn(
+            index_q.clone(),
+            weights.clone(),
+            index_k.clone(),
+            topk_indices.clone(),
+            grad_scores,
+        )
+
+        _assert_close(
+            grad_q_cudnn, grad_q_tl, rtol=2e-2, atol=2e-2, name="d_index_q"
+        )
+        _assert_close(
+            grad_w_cudnn, grad_w_tl, rtol=2e-2, atol=2e-2, name="d_weights"
+        )
+        _assert_close(
+            grad_k_cudnn, grad_k_tl, rtol=2e-2, atol=2e-2, name="d_index_k_comp"
+        )
+
+    def _call_cudnn_or_skip(self, *args, **kwargs):
+        try:
+            return self.cudnn_fn(*args, **kwargs)
+        except Exception as exc:
+            import traceback
+
+            self.skipTest(
+                f"cuDNN kernel unsupported for shape: "
+                f"{type(exc).__name__}: {exc!r}\n{traceback.format_exc()}"
+            )
+
+    def test_grad_loss_none(self):
+        """grad_loss=None should be treated as scalar 1.0 (0-D ones)."""
+        b, sq, sk, h, d, topk = 1, 1024, 256, 64, 128, 128
+        loss_coeff = 0.01
+        (
+            index_q,
+            weights,
+            index_k,
+            target,
+            topk_probs,
+            topk_indices,
+        ) = self._make_inputs(b, sq, sk, h, d, topk, seed=11)
+
+        grad_q_none, grad_w_none, grad_k_none = self._call_cudnn_or_skip(
+            index_q.clone(),
+            weights.clone(),
+            index_k.clone(),
+            target.clone(),
+            topk_probs.clone(),
+            topk_indices.clone(),
+            loss_coeff=loss_coeff,
+            grad_loss=None,
+        )
+        grad_q_one, grad_w_one, grad_k_one = self._call_cudnn_or_skip(
+            index_q.clone(),
+            weights.clone(),
+            index_k.clone(),
+            target.clone(),
+            topk_probs.clone(),
+            topk_indices.clone(),
+            loss_coeff=loss_coeff,
+            grad_loss=paddle.to_tensor(1.0, dtype="float32"),
+        )
+        _assert_close(grad_q_none, grad_q_one, 1e-3, 1e-3, "d_index_q")
+        _assert_close(grad_w_none, grad_w_one, 1e-3, 1e-3, "d_weights")
+        _assert_close(grad_k_none, grad_k_one, 1e-3, 1e-3, "d_index_k")
+
+    def test_grad_loss_python_float_via_tensor(self):
+        """grad_loss in non-fp32 dtype should be cast to fp32 internally."""
+        b, sq, sk, h, d, topk = 1, 1024, 256, 64, 128, 128
+        (
+            index_q,
+            weights,
+            index_k,
+            target,
+            topk_probs,
+            topk_indices,
+        ) = self._make_inputs(b, sq, sk, h, d, topk, seed=12)
+
+        grad_loss_bf16 = paddle.to_tensor(1.0, dtype="bfloat16")
+        grad_q, grad_w, grad_k = self._call_cudnn_or_skip(
+            index_q.clone(),
+            weights.clone(),
+            index_k.clone(),
+            target.clone(),
+            topk_probs.clone(),
+            topk_indices.clone(),
+            loss_coeff=0.01,
+            grad_loss=grad_loss_bf16,
+        )
+        self.assertEqual(grad_q.shape, list(index_q.shape))
+        self.assertEqual(grad_w.shape, list(weights.shape))
+        self.assertEqual(grad_k.shape, list(index_k.shape))
+
+    def test_input_dtype_fp32_fallback(self):
+        """fp32 inputs should be cast to bf16 internally and grads back."""
+        b, sq, sk, h, d, topk = 1, 1024, 256, 64, 128, 128
+        (
+            index_q,
+            weights,
+            index_k,
+            target,
+            topk_probs,
+            topk_indices,
+        ) = self._make_inputs(b, sq, sk, h, d, topk, seed=13)
+
+        grad_q, grad_w, grad_k = self._call_cudnn_or_skip(
+            index_q.cast("float32"),
+            weights.cast("float32"),
+            index_k.cast("float32"),
+            target.clone(),
+            topk_probs.clone(),
+            topk_indices.clone(),
+            loss_coeff=0.01,
+            grad_loss=paddle.to_tensor(1.0, dtype="float32"),
+        )
+        self.assertEqual(grad_q.dtype, paddle.float32)
+        self.assertEqual(grad_w.dtype, paddle.float32)
+        self.assertEqual(grad_k.dtype, paddle.float32)
+
+    def test_topk_indices_int64_fallback(self):
+        """int64 topk_indices should be cast to int32 internally."""
+        b, sq, sk, h, d, topk = 1, 1024, 256, 64, 128, 128
+        (
+            index_q,
+            weights,
+            index_k,
+            target,
+            topk_probs,
+            topk_indices,
+        ) = self._make_inputs(b, sq, sk, h, d, topk, seed=14)
+
+        grad_q, grad_w, grad_k = self._call_cudnn_or_skip(
+            index_q.clone(),
+            weights.clone(),
+            index_k.clone(),
+            target.clone(),
+            topk_probs.clone(),
+            topk_indices.cast("int64"),
+            loss_coeff=0.01,
+            grad_loss=paddle.to_tensor(1.0, dtype="float32"),
+        )
+        self.assertEqual(grad_q.shape, list(index_q.shape))
+
+    def test_target_predict_bf16_fallback(self):
+        """bf16 target/topk_probs should be cast to fp32 internally."""
+        b, sq, sk, h, d, topk = 1, 1024, 256, 64, 128, 128
+        (
+            index_q,
+            weights,
+            index_k,
+            target,
+            topk_probs,
+            topk_indices,
+        ) = self._make_inputs(b, sq, sk, h, d, topk, seed=15)
+
+        grad_q, grad_w, grad_k = self._call_cudnn_or_skip(
+            index_q.clone(),
+            weights.clone(),
+            index_k.clone(),
+            target.cast("bfloat16"),
+            topk_probs.cast("bfloat16"),
+            topk_indices.clone(),
+            loss_coeff=0.01,
+            grad_loss=paddle.to_tensor(1.0, dtype="float32"),
+        )
+        self.assertEqual(grad_q.shape, list(index_q.shape))
+
+    def test_custom_block_I(self):
+        """block_I=64 covers the custom-tile path (cuDNN MmaF16BF16Op
+        only supports M-mode 64 or 128, so 256 is rejected upstream)."""
+        b, sq, sk, h, d, topk = 1, 1024, 256, 64, 128, 128
+        (
+            index_q,
+            weights,
+            index_k,
+            target,
+            topk_probs,
+            topk_indices,
+        ) = self._make_inputs(b, sq, sk, h, d, topk, seed=16)
+        grad_q, grad_w, grad_k = self._call_cudnn_or_skip(
+            index_q.clone(),
+            weights.clone(),
+            index_k.clone(),
+            target.clone(),
+            topk_probs.clone(),
+            topk_indices.clone(),
+            loss_coeff=0.01,
+            grad_loss=paddle.to_tensor(1.0, dtype="float32"),
+            block_I=64,
+        )
+        self.assertEqual(grad_q.shape, list(index_q.shape))
+
+    def test_saved_tensors_not_mutated(self):
+        """Wrapper must clone target/topk_probs (cuDNN overwrites in place)."""
+        b, sq, sk, h, d, topk = 1, 1024, 256, 64, 128, 128
+        (
+            index_q,
+            weights,
+            index_k,
+            target,
+            topk_probs,
+            topk_indices,
+        ) = self._make_inputs(b, sq, sk, h, d, topk, seed=17)
+
+        target_before = target.clone()
+        topk_probs_before = topk_probs.clone()
+        self._call_cudnn_or_skip(
+            index_q.clone(),
+            weights.clone(),
+            index_k.clone(),
+            target,
+            topk_probs,
+            topk_indices.clone(),
+            loss_coeff=0.01,
+            grad_loss=paddle.to_tensor(1.0, dtype="float32"),
+        )
+        self.assertTrue(paddle.allclose(target, target_before).item())
+        self.assertTrue(paddle.allclose(topk_probs, topk_probs_before).item())
+
+
+def _try_import_torch_or_skip(testcase):
+    try:
+        import torch  # noqa: F401
+    except Exception as exc:
+        testcase.skipTest(f"torch unavailable: {exc}")
+
+
+def _import_helpers_or_skip(testcase):
+    try:
+        from paddlefleet.cudnn_ops.indexer import csa_indexer_bwd_cudnn as mod
+    except Exception as exc:
+        testcase.skipTest(f"helpers unavailable: {exc}")
+    return mod
+
+
+class TestCudnnHelpers(unittest.TestCase):
+    """Cover the small bridge helpers in csa_indexer_bwd_cudnn.py."""
+
+    def setUp(self):
+        _cuda_or_skip(self)
+        _try_import_torch_or_skip(self)
+        self.mod = _import_helpers_or_skip(self)
+
+    def test_paddle_to_torch_contiguous_aliases(self):
+        t = paddle.zeros([4, 8], dtype="float32")
+        torch_t = self.mod._paddle_to_torch(t)
+        torch_t.fill_(7.5)
+        self.assertAlmostEqual(float(t.mean().item()), 7.5, places=5)
+
+    def test_torch_to_paddle_non_contiguous_fallback(self):
+        import torch
+
+        x = torch.arange(0, 24, dtype=torch.float32, device="cuda").reshape(
+            4, 6
+        )
+        x_nc = x.transpose(0, 1)
+        self.assertFalse(x_nc.is_contiguous())
+        p = self.mod._torch_to_paddle(x_nc)
+        self.assertTrue(p.is_contiguous())
+        self.assertEqual(list(p.shape), [6, 4])
+
+    def test_to_bf16_noop(self):
+        t = paddle.zeros([2, 3], dtype="bfloat16")
+        out = self.mod._to_bf16(t)
+        self.assertIs(out, t)
+
+    def test_to_bf16_cast(self):
+        t = paddle.zeros([2, 3], dtype="float32")
+        out = self.mod._to_bf16(t)
+        self.assertEqual(out.dtype, paddle.bfloat16)
+        self.assertIsNot(out, t)
+
+    def test_lazy_import_cudnn_raises(self):
+        """When `cudnn` package is unavailable, helper raises RuntimeError."""
+        import sys
+        from unittest import mock
+
+        to_purge = [m for m in list(sys.modules) if m.split(".")[0] == "cudnn"]
+        with mock.patch.dict(sys.modules, {"cudnn": None}):
+            for m in to_purge:
+                if m != "cudnn":
+                    sys.modules.pop(m, None)
+            with self.assertRaises(RuntimeError) as cm:
+                self.mod._lazy_import_cudnn()
+            self.assertIn("nvidia-cudnn-frontend", str(cm.exception))
+
+
+class TestCudnnOpsInit(unittest.TestCase):
+    """Cover `paddlefleet/cudnn_ops/__init__.py`'s lazy `__getattr__`."""
+
+    def test_export_csa_indexer_bwd(self):
+        try:
+            import paddlefleet.cudnn_ops as cudnn_ops_mod
+        except Exception as exc:
+            self.skipTest(f"paddlefleet.cudnn_ops unavailable: {exc}")
+        fn = cudnn_ops_mod.csa_indexer_bwd
+        self.assertTrue(callable(fn))
+        self.assertIs(cudnn_ops_mod.csa_indexer_bwd, fn)
+
+    def test_unknown_attribute_raises(self):
+        try:
+            import paddlefleet.cudnn_ops as cudnn_ops_mod
+        except Exception as exc:
+            self.skipTest(f"paddlefleet.cudnn_ops unavailable: {exc}")
+        with self.assertRaises(AttributeError):
+            _ = cudnn_ops_mod.does_not_exist_xyz
+
+
+class TestCsaIndexerLossAutoScalerScaleBranches(unittest.TestCase):
+    """Cover the three scale branches in TileLangCSAIndexerLossAutoScaler."""
+
+    def setUp(self):
+        _cuda_or_skip(self)
+        try:
+            from paddlefleet.transformer.csa_attention import (
+                DSAIndexerLossAutoScaler,
+                TileLangCSAIndexerLossAutoScaler,
+            )
+        except Exception as exc:
+            self.skipTest(f"csa_attention import failed: {exc}")
+        self.AutoScaler = TileLangCSAIndexerLossAutoScaler
+        self.DSAScaler = DSAIndexerLossAutoScaler
+        self._orig_scale = DSAIndexerLossAutoScaler._main_loss_backward_scale
+
+    def tearDown(self):
+        if hasattr(self, "DSAScaler"):
+            self.DSAScaler._main_loss_backward_scale = self._orig_scale
+
+    def _run_with_scale(self, scale):
+        """Run backward with a fake csa_indexer_bwd; capture grad_loss arg."""
+        import paddlefleet.cudnn_ops as cudnn_ops_mod
+
+        captured = {}
+
+        def fake_bwd(
+            index_q,
+            weights,
+            index_k_comp,
+            target,
+            topk_probs,
+            topk_indices,
+            loss_coeff,
+            grad_loss=None,
+            block_I=128,
+        ):
+            captured["grad_loss"] = grad_loss
+            captured["loss_coeff"] = loss_coeff
+            return (
+                paddle.zeros_like(index_q),
+                paddle.zeros_like(weights),
+                paddle.zeros_like(index_k_comp),
+            )
+
+        had_attr = "csa_indexer_bwd" in cudnn_ops_mod.__dict__
+        orig_attr = cudnn_ops_mod.__dict__.get("csa_indexer_bwd")
+        cudnn_ops_mod.csa_indexer_bwd = fake_bwd
+        try:
+            self.DSAScaler._main_loss_backward_scale = scale
+
+            class FakeCtx:
+                pass
+
+            b, sq, sk, h, d, topk = 1, 4, 4, 1, 8, 4
+            index_q = paddle.randn([b, sq, h, d]).astype("bfloat16")
+            weights = paddle.randn([b, sq, h]).astype("bfloat16")
+            index_k = paddle.randn([b, sk, d]).astype("bfloat16")
+            topk_indices = paddle.randint(0, sk, [b, sq, topk]).astype("int32")
+            topk_probs = paddle.nn.functional.softmax(
+                paddle.randn([b, sq, topk]).astype("float32"), axis=-1
+            )
+            target = paddle.nn.functional.softmax(
+                paddle.randn([b, sq, topk]).astype("float32"), axis=-1
+            )
+
+            ctx = FakeCtx()
+            ctx.saved_tensor = lambda: (
+                index_q,
+                weights,
+                index_k,
+                topk_indices,
+                topk_probs,
+                target,
+            )
+            ctx.loss_coeff = 0.01
+            ctx.indexer_backend = "cudnn"
+
+            grad_output = paddle.ones_like(weights)
+            self.AutoScaler.backward(ctx, grad_output)
+        finally:
+            if had_attr:
+                cudnn_ops_mod.csa_indexer_bwd = orig_attr
+            else:
+                cudnn_ops_mod.__dict__.pop("csa_indexer_bwd", None)
+        return captured
+
+    def test_scale_none(self):
+        captured = self._run_with_scale(None)
+        self.assertIsNone(captured["grad_loss"])
+
+    def test_scale_paddle_tensor(self):
+        scale_t = paddle.to_tensor(2.5, dtype="float32")
+        captured = self._run_with_scale(scale_t)
+        self.assertIs(captured["grad_loss"], scale_t)
+
+    def test_scale_python_float(self):
+        captured = self._run_with_scale(0.7)
+        self.assertIsInstance(captured["grad_loss"], paddle.Tensor)
+        self.assertEqual(captured["grad_loss"].dtype, paddle.float32)
+        self.assertAlmostEqual(
+            float(captured["grad_loss"].item()), 0.7, places=5
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/custom_ops/test_cudnn_csa_indexer_bwd.py
+++ b/tests/single_card_tests/custom_ops/test_cudnn_csa_indexer_bwd.py
@@ -12,58 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Numerical parity test: cuDNN-frontend indexer backward vs TileLang baseline.
+"""Tests for cuDNN-frontend CSA indexer backward and related integration points.
 
-The two implementations consume different gradient signals:
-
-* TileLang ``csa_indexer_bwd`` takes a pre-computed
-  ``grad_scores = (topk_probs - target) * loss_coeff / num_rows * grad_loss``.
-* cuDNN ``indexer_backward_wrapper`` takes the raw ``target`` and ``topk_probs``
-  separately and computes the same score gradient internally
-  (``grad_scale = loss_coeff / (B*Sq)`` * ``grad_loss``).
-
-When both wrappers receive the equivalent inputs they must produce the same
-``d_index_q / d_weights / d_index_k_comp``.
-
-Run a single representative shape; cuDNN kernels are SM-version specific, so
-skip cleanly when the runtime environment cannot supply them.
+Covers:
+- csa_indexer_bwd_cudnn.py (wrapper + _to_bf16 helper)
+- cudnn_ops/__init__.py (lazy __getattr__)
+- csa_attention.py (TileLangCSAIndexerLoss / AutoScaler cudnn backward branches)
+- transformer_config.py (csa_indexer_backend field + validation)
 """
 
 import unittest
 
 import paddle
+import paddle.nn.functional as F
 
-paddle.enable_compat(scope={"tilelang"}, silent=True)
-
-
-def _cuda_or_skip(testcase):
-    if not paddle.device.is_compiled_with_cuda():
-        testcase.skipTest("CUDA build of Paddle is required")
-    if paddle.device.cuda.device_count() == 0:
-        testcase.skipTest("No CUDA device available")
-
-
-def _try_import_cudnn():
-    try:
-        # Trigger the deeper import that talks to nvidia-cudnn-frontend.
-        from cudnn.deepseek_sparse_attention.indexer_backward.api import (
-            indexer_backward_wrapper,  # noqa: F401
-        )
-
-        from paddlefleet.cudnn_ops import csa_indexer_bwd
-
-        return csa_indexer_bwd
-    except Exception as exc:  # pragma: no cover
-        return None, str(exc)
-
-
-def _try_import_tilelang():
-    try:
-        from paddlefleet.tilelang_ops import csa_indexer_bwd
-
-        return csa_indexer_bwd
-    except Exception:
-        return None
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
 
 def _assert_close(actual, expected, rtol, atol, name):
@@ -78,177 +43,154 @@ def _assert_close(actual, expected, rtol, atol, name):
         )
 
 
-class TestCudnnCsaIndexerBwd(unittest.TestCase):
+def _make_inputs(b, sq, sk, h, d, topk, seed=2026):
+    paddle.seed(seed)
+    index_q = paddle.randn([b, sq, h, d]).astype("bfloat16")
+    index_k = paddle.randn([b, sk, d]).astype("bfloat16")
+    weights = paddle.randn([b, sq, h]).astype("bfloat16")
+    target = paddle.nn.functional.softmax(
+        paddle.randn([b, sq, topk]).astype("float32"), axis=-1
+    )
+    topk_probs = paddle.nn.functional.softmax(
+        paddle.randn([b, sq, topk]).astype("float32"), axis=-1
+    )
+    topk_indices = paddle.randint(0, sk, [b, sq, topk]).astype("int32")
+    mask = paddle.rand([b, sq, topk]) < 0.05
+    topk_indices = paddle.where(
+        mask, paddle.full_like(topk_indices, -1), topk_indices
+    )
+    return index_q, weights, index_k, target, topk_probs, topk_indices
+
+
+def _ref_csa_indexer_backward(
+    index_q,
+    weights,
+    index_k_comp,
+    topk_indices,
+    target,
+    topk_probs,
+    loss_coeff,
+    grad_loss,
+):
+    """Pure-paddle small-op reference for the cuDNN indexer backward.
+
+    Reproduces the forward score computation from _ref_csa_indexer_topk
+    (test_tilelang_csa_indexer.py:93), then uses paddle.autograd to get
+    exact gradients. This is the mathematical definition of the backward.
+    """
+    b, sq, h, d = index_q.shape
+    sk = index_k_comp.shape[1]
+    topk = topk_indices.shape[-1]
+
+    q = index_q.cast("float32").detach()
+    q.stop_gradient = False
+    k = index_k_comp.cast("float32").detach()
+    k.stop_gradient = False
+    w = weights.cast("float32").detach()
+    w.stop_gradient = False
+
+    # Forward: scores [B, S, S_comp]
+    # cuDNN kernel order: einsum → scale → ReLU → weighted sum
+    scores = paddle.einsum("bshd,btd->bsht", q, k)
+    scores = scores * (d**-0.5)
+    scores = F.relu(scores)
+    scores = (scores * w.unsqueeze(-1)).sum(axis=2)  # [B, S, S_comp]
+
+    # Gather scores at topk positions, mask invalid (-1) indices
+    idx = topk_indices.cast("int64")
+    valid_mask = topk_indices >= 0  # [B, S, topk]
+    safe_idx = paddle.where(valid_mask, idx, paddle.zeros_like(idx))
+    topk_scores = paddle.take_along_axis(
+        scores, safe_idx, axis=-1
+    )  # [B, S, topk]
+    topk_scores = paddle.where(
+        valid_mask, topk_scores, paddle.zeros_like(topk_scores)
+    )
+
+    # cuDNN internal loss: sum((topk_probs - target) * topk_scores) * scale * grad_loss
+    scale = loss_coeff / float(b * sq)
+    grad_scores_weight = (topk_probs - target) * scale
+    if grad_loss is not None:
+        grad_scores_weight = grad_scores_weight * grad_loss
+    loss = (grad_scores_weight.detach() * topk_scores).sum()
+
+    loss.backward()
+    return q.grad, w.grad, k.grad
+
+
+# ---------------------------------------------------------------------------
+# Tests: csa_indexer_bwd_cudnn.py (_to_bf16 + csa_indexer_bwd wrapper)
+# ---------------------------------------------------------------------------
+
+
+class TestCudnnHelpers(unittest.TestCase):
+    """Cover _to_bf16 helper in csa_indexer_bwd_cudnn.py."""
+
     def setUp(self):
-        _cuda_or_skip(self)
+        from paddlefleet.cudnn_ops.indexer.csa_indexer_bwd_cudnn import _to_bf16
 
-        cudnn_fn = _try_import_cudnn()
-        if isinstance(cudnn_fn, tuple) or cudnn_fn is None:
-            reason = (
-                cudnn_fn[1]
-                if isinstance(cudnn_fn, tuple)
-                else "csa_indexer_bwd unavailable"
-            )
-            self.skipTest(f"cuDNN frontend unavailable: {reason}")
-        self.cudnn_fn = cudnn_fn
+        self._to_bf16 = _to_bf16
 
-        tilelang_fn = _try_import_tilelang()
-        if tilelang_fn is None:
-            self.skipTest("TileLang baseline csa_indexer_bwd unavailable")
-        self.tilelang_fn = tilelang_fn
+    def test_to_bf16_noop(self):
+        t = paddle.zeros([2, 3], dtype="bfloat16")
+        out = self._to_bf16(t)
+        self.assertIs(out, t)
 
-    def _make_inputs(self, b, sq, sk, h, d, topk, seed=2026):
-        paddle.seed(seed)
-        index_q = paddle.randn([b, sq, h, d]).astype("bfloat16")
-        index_k = paddle.randn([b, sk, d]).astype("bfloat16")
-        weights = paddle.randn([b, sq, h]).astype("bfloat16")
-        target = paddle.nn.functional.softmax(
-            paddle.randn([b, sq, topk]).astype("float32"), axis=-1
-        )
-        topk_probs = paddle.nn.functional.softmax(
-            paddle.randn([b, sq, topk]).astype("float32"), axis=-1
-        )
-        # Random valid indices into [0, sk); leave a few -1 holes.
-        topk_indices = paddle.randint(0, sk, [b, sq, topk]).astype("int32")
-        mask = paddle.rand([b, sq, topk]) < 0.05
-        topk_indices = paddle.where(
-            mask, paddle.full_like(topk_indices, -1), topk_indices
-        )
-        return index_q, weights, index_k, target, topk_probs, topk_indices
+    def test_to_bf16_cast(self):
+        t = paddle.zeros([2, 3], dtype="float32")
+        out = self._to_bf16(t)
+        self.assertEqual(out.dtype, paddle.bfloat16)
+        self.assertIsNot(out, t)
 
-    def test_parity_against_tilelang(self):
-        """Parity at rtol=atol=2e-2.
+    def test_to_bf16_fp16(self):
+        t = paddle.zeros([2, 3], dtype="float16")
+        out = self._to_bf16(t)
+        self.assertEqual(out.dtype, paddle.bfloat16)
 
-        Tolerance derivation (conservative upper bound):
 
-        * bf16 mantissa is 7 bits, so a single multiply-add carries a
-          relative error of ``2^-7 ≈ 7.8e-3``.
-        * Both kernels accumulate in fp32 internally; with reduction depth
-          ``N <= topk*D = 128*128``, error grows as ``√N * eps`` rather than
-          ``N * eps``, contributing roughly ``1e-2`` relative.
-        * cuDNN and TileLang use different tile sizes and warp schedules;
-          fp accumulation order is not associative, contributing another
-          ``~5e-3``.
+@unittest.skipIf(
+    not paddle.device.is_compiled_with_cuda()
+    or paddle.device.cuda.get_device_capability()[0] != 10,
+    "CudnnCsaIndexerBwd requires Blackwell GPU (SM100)",
+)
+class TestCudnnCsaIndexerBwd(unittest.TestCase):
+    """Cover csa_indexer_bwd wrapper: dtype casts, grad_loss handling, clone semantics."""
 
-        Sum of the three sources is ``~2e-2``, which we adopt for both
-        ``rtol`` and ``atol``. Empirically this passes across multiple
-        random seeds at this shape; revisit if a future shape regresses.
-        """
+    def setUp(self):
+        from paddlefleet.cudnn_ops import csa_indexer_bwd
+
+        self.cudnn_fn = csa_indexer_bwd
+
+    def test_basic_output_shapes(self):
+        """Basic call returns correct shapes and dtypes."""
         b, sq, sk, h, d, topk = 1, 1024, 256, 64, 128, 128
-        loss_coeff = 0.01
-        grad_loss_val = 1.0
-
-        (
+        index_q, weights, index_k, target, topk_probs, topk_indices = (
+            _make_inputs(b, sq, sk, h, d, topk)
+        )
+        grad_q, grad_w, grad_k = self.cudnn_fn(
             index_q,
             weights,
             index_k,
             target,
             topk_probs,
             topk_indices,
-        ) = self._make_inputs(b, sq, sk, h, d, topk)
-
-        try:
-            grad_q_cudnn, grad_w_cudnn, grad_k_cudnn = self.cudnn_fn(
-                index_q.clone(),
-                weights.clone(),
-                index_k.clone(),
-                target.clone(),
-                topk_probs.clone(),
-                topk_indices.clone(),
-                loss_coeff=loss_coeff,
-                grad_loss=paddle.to_tensor(grad_loss_val, dtype="float32"),
-            )
-        except Exception as exc:
-            import traceback
-
-            self.skipTest(
-                f"cuDNN kernel unsupported for shape: {type(exc).__name__}: {exc!r}\n"
-                f"{traceback.format_exc()}"
-            )
-
-        scale = loss_coeff / float(b * sq)
-        grad_scores = (topk_probs - target) * scale * grad_loss_val
-
-        grad_q_tl, grad_w_tl, grad_k_tl = self.tilelang_fn(
-            index_q.clone(),
-            weights.clone(),
-            index_k.clone(),
-            topk_indices.clone(),
-            grad_scores,
-        )
-
-        _assert_close(
-            grad_q_cudnn, grad_q_tl, rtol=2e-2, atol=2e-2, name="d_index_q"
-        )
-        _assert_close(
-            grad_w_cudnn, grad_w_tl, rtol=2e-2, atol=2e-2, name="d_weights"
-        )
-        _assert_close(
-            grad_k_cudnn, grad_k_tl, rtol=2e-2, atol=2e-2, name="d_index_k_comp"
-        )
-
-    def _call_cudnn_or_skip(self, *args, **kwargs):
-        try:
-            return self.cudnn_fn(*args, **kwargs)
-        except Exception as exc:
-            import traceback
-
-            self.skipTest(
-                f"cuDNN kernel unsupported for shape: "
-                f"{type(exc).__name__}: {exc!r}\n{traceback.format_exc()}"
-            )
-
-    def test_grad_loss_none(self):
-        """grad_loss=None should be treated as scalar 1.0 (0-D ones)."""
-        b, sq, sk, h, d, topk = 1, 1024, 256, 64, 128, 128
-        loss_coeff = 0.01
-        (
-            index_q,
-            weights,
-            index_k,
-            target,
-            topk_probs,
-            topk_indices,
-        ) = self._make_inputs(b, sq, sk, h, d, topk, seed=11)
-
-        grad_q_none, grad_w_none, grad_k_none = self._call_cudnn_or_skip(
-            index_q.clone(),
-            weights.clone(),
-            index_k.clone(),
-            target.clone(),
-            topk_probs.clone(),
-            topk_indices.clone(),
-            loss_coeff=loss_coeff,
-            grad_loss=None,
-        )
-        grad_q_one, grad_w_one, grad_k_one = self._call_cudnn_or_skip(
-            index_q.clone(),
-            weights.clone(),
-            index_k.clone(),
-            target.clone(),
-            topk_probs.clone(),
-            topk_indices.clone(),
-            loss_coeff=loss_coeff,
+            loss_coeff=0.01,
             grad_loss=paddle.to_tensor(1.0, dtype="float32"),
         )
-        _assert_close(grad_q_none, grad_q_one, 1e-3, 1e-3, "d_index_q")
-        _assert_close(grad_w_none, grad_w_one, 1e-3, 1e-3, "d_weights")
-        _assert_close(grad_k_none, grad_k_one, 1e-3, 1e-3, "d_index_k")
+        self.assertEqual(grad_q.shape, list(index_q.shape))
+        self.assertEqual(grad_w.shape, list(weights.shape))
+        self.assertEqual(grad_k.shape, list(index_k.shape))
+        self.assertEqual(grad_q.dtype, paddle.bfloat16)
+        self.assertEqual(grad_w.dtype, paddle.bfloat16)
+        self.assertEqual(grad_k.dtype, paddle.bfloat16)
 
-    def test_grad_loss_python_float_via_tensor(self):
-        """grad_loss in non-fp32 dtype should be cast to fp32 internally."""
+    def test_grad_loss_none_equals_one(self):
+        """grad_loss=None should be treated as scalar 1.0."""
         b, sq, sk, h, d, topk = 1, 1024, 256, 64, 128, 128
-        (
-            index_q,
-            weights,
-            index_k,
-            target,
-            topk_probs,
-            topk_indices,
-        ) = self._make_inputs(b, sq, sk, h, d, topk, seed=12)
-
-        grad_loss_bf16 = paddle.to_tensor(1.0, dtype="bfloat16")
-        grad_q, grad_w, grad_k = self._call_cudnn_or_skip(
+        index_q, weights, index_k, target, topk_probs, topk_indices = (
+            _make_inputs(b, sq, sk, h, d, topk, seed=11)
+        )
+        grad_q_none, grad_w_none, grad_k_none = self.cudnn_fn(
             index_q.clone(),
             weights.clone(),
             index_k.clone(),
@@ -256,31 +198,53 @@ class TestCudnnCsaIndexerBwd(unittest.TestCase):
             topk_probs.clone(),
             topk_indices.clone(),
             loss_coeff=0.01,
-            grad_loss=grad_loss_bf16,
+            grad_loss=None,
         )
-        self.assertEqual(grad_q.shape, list(index_q.shape))
-        self.assertEqual(grad_w.shape, list(weights.shape))
-        self.assertEqual(grad_k.shape, list(index_k.shape))
+        grad_q_one, grad_w_one, grad_k_one = self.cudnn_fn(
+            index_q.clone(),
+            weights.clone(),
+            index_k.clone(),
+            target.clone(),
+            topk_probs.clone(),
+            topk_indices.clone(),
+            loss_coeff=0.01,
+            grad_loss=paddle.to_tensor(1.0, dtype="float32"),
+        )
+        _assert_close(grad_q_none, grad_q_one, 1e-3, 1e-3, "d_index_q")
+        _assert_close(grad_w_none, grad_w_one, 1e-3, 1e-3, "d_weights")
+        _assert_close(grad_k_none, grad_k_one, 1e-3, 1e-3, "d_index_k")
 
-    def test_input_dtype_fp32_fallback(self):
-        """fp32 inputs should be cast to bf16 internally and grads back."""
+    def test_grad_loss_bf16_cast(self):
+        """grad_loss in non-fp32 dtype should be cast to fp32 internally."""
         b, sq, sk, h, d, topk = 1, 1024, 256, 64, 128, 128
-        (
+        index_q, weights, index_k, target, topk_probs, topk_indices = (
+            _make_inputs(b, sq, sk, h, d, topk, seed=12)
+        )
+        grad_q, grad_w, grad_k = self.cudnn_fn(
             index_q,
             weights,
             index_k,
             target,
             topk_probs,
             topk_indices,
-        ) = self._make_inputs(b, sq, sk, h, d, topk, seed=13)
+            loss_coeff=0.01,
+            grad_loss=paddle.to_tensor(1.0, dtype="bfloat16"),
+        )
+        self.assertEqual(grad_q.shape, list(index_q.shape))
 
-        grad_q, grad_w, grad_k = self._call_cudnn_or_skip(
+    def test_fp32_inputs_cast_and_grads_restored(self):
+        """fp32 inputs should be cast to bf16 internally; grads restored to fp32."""
+        b, sq, sk, h, d, topk = 1, 1024, 256, 64, 128, 128
+        index_q, weights, index_k, target, topk_probs, topk_indices = (
+            _make_inputs(b, sq, sk, h, d, topk, seed=13)
+        )
+        grad_q, grad_w, grad_k = self.cudnn_fn(
             index_q.cast("float32"),
             weights.cast("float32"),
             index_k.cast("float32"),
-            target.clone(),
-            topk_probs.clone(),
-            topk_indices.clone(),
+            target,
+            topk_probs,
+            topk_indices,
             loss_coeff=0.01,
             grad_loss=paddle.to_tensor(1.0, dtype="float32"),
         )
@@ -288,73 +252,55 @@ class TestCudnnCsaIndexerBwd(unittest.TestCase):
         self.assertEqual(grad_w.dtype, paddle.float32)
         self.assertEqual(grad_k.dtype, paddle.float32)
 
-    def test_topk_indices_int64_fallback(self):
+    def test_topk_indices_int64_cast(self):
         """int64 topk_indices should be cast to int32 internally."""
         b, sq, sk, h, d, topk = 1, 1024, 256, 64, 128, 128
-        (
+        index_q, weights, index_k, target, topk_probs, topk_indices = (
+            _make_inputs(b, sq, sk, h, d, topk, seed=14)
+        )
+        grad_q, grad_w, grad_k = self.cudnn_fn(
             index_q,
             weights,
             index_k,
             target,
             topk_probs,
-            topk_indices,
-        ) = self._make_inputs(b, sq, sk, h, d, topk, seed=14)
-
-        grad_q, grad_w, grad_k = self._call_cudnn_or_skip(
-            index_q.clone(),
-            weights.clone(),
-            index_k.clone(),
-            target.clone(),
-            topk_probs.clone(),
             topk_indices.cast("int64"),
             loss_coeff=0.01,
             grad_loss=paddle.to_tensor(1.0, dtype="float32"),
         )
         self.assertEqual(grad_q.shape, list(index_q.shape))
 
-    def test_target_predict_bf16_fallback(self):
-        """bf16 target/topk_probs should be cast to fp32 internally."""
+    def test_target_predict_bf16_cast(self):
+        """bf16 target/topk_probs should be cast to fp32 (new buffer)."""
         b, sq, sk, h, d, topk = 1, 1024, 256, 64, 128, 128
-        (
+        index_q, weights, index_k, target, topk_probs, topk_indices = (
+            _make_inputs(b, sq, sk, h, d, topk, seed=15)
+        )
+        grad_q, grad_w, grad_k = self.cudnn_fn(
             index_q,
             weights,
             index_k,
-            target,
-            topk_probs,
-            topk_indices,
-        ) = self._make_inputs(b, sq, sk, h, d, topk, seed=15)
-
-        grad_q, grad_w, grad_k = self._call_cudnn_or_skip(
-            index_q.clone(),
-            weights.clone(),
-            index_k.clone(),
             target.cast("bfloat16"),
             topk_probs.cast("bfloat16"),
-            topk_indices.clone(),
+            topk_indices,
             loss_coeff=0.01,
             grad_loss=paddle.to_tensor(1.0, dtype="float32"),
         )
         self.assertEqual(grad_q.shape, list(index_q.shape))
 
     def test_custom_block_I(self):
-        """block_I=64 covers the custom-tile path (cuDNN MmaF16BF16Op
-        only supports M-mode 64 or 128, so 256 is rejected upstream)."""
+        """block_I=64 covers the non-default tile size path."""
         b, sq, sk, h, d, topk = 1, 1024, 256, 64, 128, 128
-        (
+        index_q, weights, index_k, target, topk_probs, topk_indices = (
+            _make_inputs(b, sq, sk, h, d, topk, seed=16)
+        )
+        grad_q, grad_w, grad_k = self.cudnn_fn(
             index_q,
             weights,
             index_k,
             target,
             topk_probs,
             topk_indices,
-        ) = self._make_inputs(b, sq, sk, h, d, topk, seed=16)
-        grad_q, grad_w, grad_k = self._call_cudnn_or_skip(
-            index_q.clone(),
-            weights.clone(),
-            index_k.clone(),
-            target.clone(),
-            topk_probs.clone(),
-            topk_indices.clone(),
             loss_coeff=0.01,
             grad_loss=paddle.to_tensor(1.0, dtype="float32"),
             block_I=64,
@@ -362,133 +308,495 @@ class TestCudnnCsaIndexerBwd(unittest.TestCase):
         self.assertEqual(grad_q.shape, list(index_q.shape))
 
     def test_saved_tensors_not_mutated(self):
-        """Wrapper must clone target/topk_probs (cuDNN overwrites in place)."""
+        """Wrapper must clone target/topk_probs; cuDNN overwrites in place."""
         b, sq, sk, h, d, topk = 1, 1024, 256, 64, 128, 128
-        (
+        index_q, weights, index_k, target, topk_probs, topk_indices = (
+            _make_inputs(b, sq, sk, h, d, topk, seed=17)
+        )
+        target_before = target.clone()
+        topk_probs_before = topk_probs.clone()
+        self.cudnn_fn(
             index_q,
             weights,
             index_k,
             target,
             topk_probs,
             topk_indices,
-        ) = self._make_inputs(b, sq, sk, h, d, topk, seed=17)
-
-        target_before = target.clone()
-        topk_probs_before = topk_probs.clone()
-        self._call_cudnn_or_skip(
-            index_q.clone(),
-            weights.clone(),
-            index_k.clone(),
-            target,
-            topk_probs,
-            topk_indices.clone(),
             loss_coeff=0.01,
             grad_loss=paddle.to_tensor(1.0, dtype="float32"),
         )
         self.assertTrue(paddle.allclose(target, target_before).item())
         self.assertTrue(paddle.allclose(topk_probs, topk_probs_before).item())
 
-
-def _try_import_torch_or_skip(testcase):
-    try:
-        import torch  # noqa: F401
-    except Exception as exc:
-        testcase.skipTest(f"torch unavailable: {exc}")
-
-
-def _import_helpers_or_skip(testcase):
-    try:
-        from paddlefleet.cudnn_ops.indexer import csa_indexer_bwd_cudnn as mod
-    except Exception as exc:
-        testcase.skipTest(f"helpers unavailable: {exc}")
-    return mod
-
-
-class TestCudnnHelpers(unittest.TestCase):
-    """Cover the small bridge helpers in csa_indexer_bwd_cudnn.py."""
-
-    def setUp(self):
-        _cuda_or_skip(self)
-        _try_import_torch_or_skip(self)
-        self.mod = _import_helpers_or_skip(self)
-
-    def test_paddle_to_torch_contiguous_aliases(self):
-        t = paddle.zeros([4, 8], dtype="float32")
-        torch_t = self.mod._paddle_to_torch(t)
-        torch_t.fill_(7.5)
-        self.assertAlmostEqual(float(t.mean().item()), 7.5, places=5)
-
-    def test_torch_to_paddle_non_contiguous_fallback(self):
-        import torch
-
-        x = torch.arange(0, 24, dtype=torch.float32, device="cuda").reshape(
-            4, 6
+    def test_grad_loss_scales_output(self):
+        """grad_loss=2.0 should produce ~2x the gradients of grad_loss=1.0."""
+        b, sq, sk, h, d, topk = 1, 1024, 256, 64, 128, 128
+        index_q, weights, index_k, target, topk_probs, topk_indices = (
+            _make_inputs(b, sq, sk, h, d, topk, seed=18)
         )
-        x_nc = x.transpose(0, 1)
-        self.assertFalse(x_nc.is_contiguous())
-        p = self.mod._torch_to_paddle(x_nc)
-        self.assertTrue(p.is_contiguous())
-        self.assertEqual(list(p.shape), [6, 4])
+        grad_q_1, _, _ = self.cudnn_fn(
+            index_q.clone(),
+            weights.clone(),
+            index_k.clone(),
+            target.clone(),
+            topk_probs.clone(),
+            topk_indices.clone(),
+            loss_coeff=0.01,
+            grad_loss=paddle.to_tensor(1.0, dtype="float32"),
+        )
+        grad_q_2, _, _ = self.cudnn_fn(
+            index_q.clone(),
+            weights.clone(),
+            index_k.clone(),
+            target.clone(),
+            topk_probs.clone(),
+            topk_indices.clone(),
+            loss_coeff=0.01,
+            grad_loss=paddle.to_tensor(2.0, dtype="float32"),
+        )
+        _assert_close(
+            grad_q_2, grad_q_1 * 2, rtol=1e-2, atol=1e-3, name="2x scale"
+        )
 
-    def test_to_bf16_noop(self):
-        t = paddle.zeros([2, 3], dtype="bfloat16")
-        out = self.mod._to_bf16(t)
-        self.assertIs(out, t)
+    def test_parity_against_reference(self):
+        """Numerical parity: cuDNN backward vs pure-paddle autograd reference.
 
-    def test_to_bf16_cast(self):
-        t = paddle.zeros([2, 3], dtype="float32")
-        out = self.mod._to_bf16(t)
-        self.assertEqual(out.dtype, paddle.bfloat16)
-        self.assertIsNot(out, t)
+        The reference uses the same forward math as _ref_csa_indexer_topk
+        (einsum → relu → weighted sum → scale) and paddle.autograd for the
+        backward. This validates that the cuDNN kernel computes the correct
+        gradients, not just that it runs without error.
 
-    def test_lazy_import_cudnn_raises(self):
-        """When `cudnn` package is unavailable, helper raises RuntimeError."""
-        import sys
-        from unittest import mock
+        Tolerance: bf16 accumulation + different reduction order → rtol/atol=5e-2.
+        """
+        b, sq, sk, h, d, topk = 1, 1024, 256, 64, 128, 128
+        loss_coeff = 0.01
+        grad_loss_val = 1.0
 
-        to_purge = [m for m in list(sys.modules) if m.split(".")[0] == "cudnn"]
-        with mock.patch.dict(sys.modules, {"cudnn": None}):
-            for m in to_purge:
-                if m != "cudnn":
-                    sys.modules.pop(m, None)
-            with self.assertRaises(RuntimeError) as cm:
-                self.mod._lazy_import_cudnn()
-            self.assertIn("nvidia-cudnn-frontend", str(cm.exception))
+        index_q, weights, index_k, target, topk_probs, topk_indices = (
+            _make_inputs(b, sq, sk, h, d, topk, seed=42)
+        )
+
+        # cuDNN result
+        grad_q_cudnn, grad_w_cudnn, grad_k_cudnn = self.cudnn_fn(
+            index_q.clone(),
+            weights.clone(),
+            index_k.clone(),
+            target.clone(),
+            topk_probs.clone(),
+            topk_indices.clone(),
+            loss_coeff=loss_coeff,
+            grad_loss=paddle.to_tensor(grad_loss_val, dtype="float32"),
+        )
+
+        # Pure-paddle reference
+        grad_q_ref, grad_w_ref, grad_k_ref = _ref_csa_indexer_backward(
+            index_q,
+            weights,
+            index_k,
+            topk_indices,
+            target,
+            topk_probs,
+            loss_coeff=loss_coeff,
+            grad_loss=paddle.to_tensor(grad_loss_val, dtype="float32"),
+        )
+
+        _assert_close(
+            grad_q_cudnn, grad_q_ref, rtol=5e-2, atol=5e-2, name="d_index_q"
+        )
+        _assert_close(
+            grad_w_cudnn, grad_w_ref, rtol=5e-2, atol=5e-2, name="d_weights"
+        )
+        _assert_close(
+            grad_k_cudnn,
+            grad_k_ref,
+            rtol=5e-2,
+            atol=5e-2,
+            name="d_index_k_comp",
+        )
+
+    def test_parity_small_sq(self):
+        """Parity on a small sq for fast debugging."""
+        b, sq, sk, h, d, topk = 1, 16, 128, 64, 128, 128
+        loss_coeff = 0.1
+        index_q, weights, index_k, target, topk_probs, topk_indices = (
+            _make_inputs(b, sq, sk, h, d, topk, seed=100)
+        )
+        grad_q_cudnn, grad_w_cudnn, grad_k_cudnn = self.cudnn_fn(
+            index_q.clone(),
+            weights.clone(),
+            index_k.clone(),
+            target.clone(),
+            topk_probs.clone(),
+            topk_indices.clone(),
+            loss_coeff=loss_coeff,
+            grad_loss=paddle.to_tensor(1.0, dtype="float32"),
+        )
+        grad_q_ref, grad_w_ref, grad_k_ref = _ref_csa_indexer_backward(
+            index_q,
+            weights,
+            index_k,
+            topk_indices,
+            target,
+            topk_probs,
+            loss_coeff=loss_coeff,
+            grad_loss=paddle.to_tensor(1.0, dtype="float32"),
+        )
+        _assert_close(
+            grad_q_cudnn, grad_q_ref, rtol=5e-2, atol=5e-2, name="small d_q"
+        )
+        _assert_close(
+            grad_w_cudnn, grad_w_ref, rtol=5e-2, atol=5e-2, name="small d_w"
+        )
+        _assert_close(
+            grad_k_cudnn, grad_k_ref, rtol=5e-2, atol=5e-2, name="small d_k"
+        )
+
+    def test_parity_topk_equals_sk(self):
+        """Parity when topk == sk (full coverage, no -1 indices)."""
+        b, sq, sk, h, d, topk = 1, 64, 128, 64, 128, 128
+        loss_coeff = 0.05
+        paddle.seed(200)
+        index_q = paddle.randn([b, sq, h, d]).astype("bfloat16")
+        index_k = paddle.randn([b, sk, d]).astype("bfloat16")
+        weights = paddle.randn([b, sq, h]).astype("bfloat16")
+        target = F.softmax(
+            paddle.randn([b, sq, topk]).astype("float32"), axis=-1
+        )
+        topk_probs = F.softmax(
+            paddle.randn([b, sq, topk]).astype("float32"), axis=-1
+        )
+        # All indices valid (no -1), cover full sk range
+        topk_indices = paddle.randint(0, sk, [b, sq, topk]).astype("int32")
+
+        grad_q_cudnn, grad_w_cudnn, grad_k_cudnn = self.cudnn_fn(
+            index_q.clone(),
+            weights.clone(),
+            index_k.clone(),
+            target.clone(),
+            topk_probs.clone(),
+            topk_indices.clone(),
+            loss_coeff=loss_coeff,
+            grad_loss=paddle.to_tensor(1.0, dtype="float32"),
+        )
+        grad_q_ref, grad_w_ref, grad_k_ref = _ref_csa_indexer_backward(
+            index_q,
+            weights,
+            index_k,
+            topk_indices,
+            target,
+            topk_probs,
+            loss_coeff=loss_coeff,
+            grad_loss=paddle.to_tensor(1.0, dtype="float32"),
+        )
+        _assert_close(
+            grad_q_cudnn, grad_q_ref, rtol=5e-2, atol=5e-2, name="full d_q"
+        )
+        _assert_close(
+            grad_w_cudnn, grad_w_ref, rtol=5e-2, atol=5e-2, name="full d_w"
+        )
+        _assert_close(
+            grad_k_cudnn, grad_k_ref, rtol=5e-2, atol=5e-2, name="full d_k"
+        )
+
+    def test_parity_large_loss_coeff(self):
+        """Parity with a larger loss_coeff to exercise scaling path."""
+        b, sq, sk, h, d, topk = 1, 128, 256, 64, 128, 128
+        loss_coeff = 1.0
+        index_q, weights, index_k, target, topk_probs, topk_indices = (
+            _make_inputs(b, sq, sk, h, d, topk, seed=300)
+        )
+        grad_q_cudnn, grad_w_cudnn, grad_k_cudnn = self.cudnn_fn(
+            index_q.clone(),
+            weights.clone(),
+            index_k.clone(),
+            target.clone(),
+            topk_probs.clone(),
+            topk_indices.clone(),
+            loss_coeff=loss_coeff,
+            grad_loss=paddle.to_tensor(1.0, dtype="float32"),
+        )
+        grad_q_ref, grad_w_ref, grad_k_ref = _ref_csa_indexer_backward(
+            index_q,
+            weights,
+            index_k,
+            topk_indices,
+            target,
+            topk_probs,
+            loss_coeff=loss_coeff,
+            grad_loss=paddle.to_tensor(1.0, dtype="float32"),
+        )
+        _assert_close(
+            grad_q_cudnn, grad_q_ref, rtol=5e-2, atol=5e-2, name="lcoeff d_q"
+        )
+        _assert_close(
+            grad_w_cudnn, grad_w_ref, rtol=5e-2, atol=5e-2, name="lcoeff d_w"
+        )
+        _assert_close(
+            grad_k_cudnn, grad_k_ref, rtol=5e-2, atol=5e-2, name="lcoeff d_k"
+        )
+
+    def test_invalid_indices_zero_contribution(self):
+        """Positions with topk_indices == -1 should not contribute to gradients."""
+        b, sq, sk, h, d, topk = 1, 64, 256, 64, 128, 128
+        paddle.seed(400)
+        index_q = paddle.randn([b, sq, h, d]).astype("bfloat16")
+        index_k = paddle.randn([b, sk, d]).astype("bfloat16")
+        weights = paddle.randn([b, sq, h]).astype("bfloat16")
+        target = F.softmax(
+            paddle.randn([b, sq, topk]).astype("float32"), axis=-1
+        )
+        topk_probs = F.softmax(
+            paddle.randn([b, sq, topk]).astype("float32"), axis=-1
+        )
+
+        # All valid indices
+        topk_indices_valid = paddle.randint(0, sk, [b, sq, topk]).astype(
+            "int32"
+        )
+        # Set half to -1
+        topk_indices_half = topk_indices_valid.clone()
+        topk_indices_half[:, :, topk // 2 :] = -1
+
+        grad_q_full, grad_w_full, grad_k_full = self.cudnn_fn(
+            index_q.clone(),
+            weights.clone(),
+            index_k.clone(),
+            target.clone(),
+            topk_probs.clone(),
+            topk_indices_valid.clone(),
+            loss_coeff=0.01,
+            grad_loss=paddle.to_tensor(1.0, dtype="float32"),
+        )
+        grad_q_half, grad_w_half, grad_k_half = self.cudnn_fn(
+            index_q.clone(),
+            weights.clone(),
+            index_k.clone(),
+            target.clone(),
+            topk_probs.clone(),
+            topk_indices_half.clone(),
+            loss_coeff=0.01,
+            grad_loss=paddle.to_tensor(1.0, dtype="float32"),
+        )
+        # Gradient magnitudes should differ (masked positions don't contribute)
+        # At minimum, half-masked should have smaller or equal gradient norm
+        norm_full = grad_q_full.cast("float32").abs().sum().item()
+        norm_half = grad_q_half.cast("float32").abs().sum().item()
+        self.assertGreater(norm_full, 0.0)
+        # With half indices masked, gradient should be different
+        self.assertFalse(
+            paddle.allclose(
+                grad_q_full.cast("float32"),
+                grad_q_half.cast("float32"),
+                rtol=1e-6,
+                atol=1e-6,
+            ).item(),
+            "Masking half indices should change gradients",
+        )
+
+    def test_no_nan_inf_in_grads(self):
+        """All gradient outputs must be finite (no NaN/Inf)."""
+        b, sq, sk, h, d, topk = 1, 128, 256, 64, 128, 128
+        index_q, weights, index_k, target, topk_probs, topk_indices = (
+            _make_inputs(b, sq, sk, h, d, topk, seed=500)
+        )
+        grad_q, grad_w, grad_k = self.cudnn_fn(
+            index_q,
+            weights,
+            index_k,
+            target,
+            topk_probs,
+            topk_indices,
+            loss_coeff=0.01,
+            grad_loss=paddle.to_tensor(1.0, dtype="float32"),
+        )
+        for name, g in (("d_q", grad_q), ("d_w", grad_w), ("d_k", grad_k)):
+            self.assertTrue(
+                paddle.isfinite(g.cast("float32")).all().item(),
+                f"{name} contains NaN/Inf",
+            )
+            self.assertGreater(
+                g.cast("float32").abs().max().item(),
+                0.0,
+                f"{name} is identically zero",
+            )
+
+    def test_parity_multi_batch(self):
+        """Parity with b>1 to verify batch dimension correctness."""
+        b, sq, sk, h, d, topk = 2, 64, 128, 64, 128, 128
+        loss_coeff = 0.01
+        index_q, weights, index_k, target, topk_probs, topk_indices = (
+            _make_inputs(b, sq, sk, h, d, topk, seed=600)
+        )
+        grad_q_cudnn, grad_w_cudnn, grad_k_cudnn = self.cudnn_fn(
+            index_q.clone(),
+            weights.clone(),
+            index_k.clone(),
+            target.clone(),
+            topk_probs.clone(),
+            topk_indices.clone(),
+            loss_coeff=loss_coeff,
+            grad_loss=paddle.to_tensor(1.0, dtype="float32"),
+        )
+        grad_q_ref, grad_w_ref, grad_k_ref = _ref_csa_indexer_backward(
+            index_q,
+            weights,
+            index_k,
+            topk_indices,
+            target,
+            topk_probs,
+            loss_coeff=loss_coeff,
+            grad_loss=paddle.to_tensor(1.0, dtype="float32"),
+        )
+        _assert_close(
+            grad_q_cudnn, grad_q_ref, rtol=5e-2, atol=5e-2, name="batch d_q"
+        )
+        _assert_close(
+            grad_w_cudnn, grad_w_ref, rtol=5e-2, atol=5e-2, name="batch d_w"
+        )
+        _assert_close(
+            grad_k_cudnn, grad_k_ref, rtol=5e-2, atol=5e-2, name="batch d_k"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: cudnn_ops/__init__.py (lazy __getattr__)
+# ---------------------------------------------------------------------------
 
 
 class TestCudnnOpsInit(unittest.TestCase):
-    """Cover `paddlefleet/cudnn_ops/__init__.py`'s lazy `__getattr__`."""
+    """Cover paddlefleet.cudnn_ops.__init__.py lazy import mechanism."""
 
     def test_export_csa_indexer_bwd(self):
-        try:
-            import paddlefleet.cudnn_ops as cudnn_ops_mod
-        except Exception as exc:
-            self.skipTest(f"paddlefleet.cudnn_ops unavailable: {exc}")
+        import paddlefleet.cudnn_ops as cudnn_ops_mod
+
         fn = cudnn_ops_mod.csa_indexer_bwd
         self.assertTrue(callable(fn))
+        # Second access should be cached in globals
         self.assertIs(cudnn_ops_mod.csa_indexer_bwd, fn)
 
     def test_unknown_attribute_raises(self):
-        try:
-            import paddlefleet.cudnn_ops as cudnn_ops_mod
-        except Exception as exc:
-            self.skipTest(f"paddlefleet.cudnn_ops unavailable: {exc}")
+        import paddlefleet.cudnn_ops as cudnn_ops_mod
+
         with self.assertRaises(AttributeError):
             _ = cudnn_ops_mod.does_not_exist_xyz
 
+    def test_all_list(self):
+        import paddlefleet.cudnn_ops as cudnn_ops_mod
 
-class TestCsaIndexerLossAutoScalerScaleBranches(unittest.TestCase):
-    """Cover the three scale branches in TileLangCSAIndexerLossAutoScaler."""
+        self.assertIn("csa_indexer_bwd", cudnn_ops_mod.__all__)
+
+
+# ---------------------------------------------------------------------------
+# Tests: csa_attention.py PyLayer cudnn branches
+# ---------------------------------------------------------------------------
+
+
+class TestTileLangCSAIndexerLossBackwardCudnn(unittest.TestCase):
+    """Cover TileLangCSAIndexerLoss.backward cudnn branch."""
 
     def setUp(self):
-        _cuda_or_skip(self)
-        try:
-            from paddlefleet.transformer.csa_attention import (
-                DSAIndexerLossAutoScaler,
-                TileLangCSAIndexerLossAutoScaler,
+        from paddlefleet.transformer.csa_attention import TileLangCSAIndexerLoss
+
+        self.PyLayer = TileLangCSAIndexerLoss
+
+    def test_backward_cudnn_branch(self):
+        """Invoke backward with indexer_backend='cudnn' via fake ctx."""
+        import paddlefleet.cudnn_ops as cudnn_ops_mod
+
+        captured = {}
+
+        def fake_bwd(
+            index_q,
+            weights,
+            index_k_comp,
+            target,
+            topk_probs,
+            topk_indices,
+            loss_coeff,
+            grad_loss=None,
+            block_I=128,
+        ):
+            captured["loss_coeff"] = loss_coeff
+            captured["grad_loss"] = grad_loss
+            return (
+                paddle.zeros_like(index_q),
+                paddle.zeros_like(weights),
+                paddle.zeros_like(index_k_comp),
             )
-        except Exception as exc:
-            self.skipTest(f"csa_attention import failed: {exc}")
+
+        orig = cudnn_ops_mod.__dict__.get("csa_indexer_bwd")
+        cudnn_ops_mod.csa_indexer_bwd = fake_bwd
+        try:
+            b, sq, sk, h, d, topk = 1, 4, 4, 1, 8, 4
+            index_q = paddle.randn([b, sq, h, d]).astype("bfloat16")
+            weights = paddle.randn([b, sq, h]).astype("bfloat16")
+            index_k = paddle.randn([b, sk, d]).astype("bfloat16")
+            topk_indices = paddle.randint(0, sk, [b, sq, topk]).astype("int32")
+            topk_probs = paddle.nn.functional.softmax(
+                paddle.randn([b, sq, topk]).astype("float32"), axis=-1
+            )
+            target = paddle.nn.functional.softmax(
+                paddle.randn([b, sq, topk]).astype("float32"), axis=-1
+            )
+
+            class FakeCtx:
+                pass
+
+            ctx = FakeCtx()
+            ctx.saved_tensor = lambda: (
+                index_q,
+                weights,
+                index_k,
+                topk_indices,
+                topk_probs,
+                target,
+            )
+            ctx.loss_coeff = 0.01
+            ctx.indexer_backend = "cudnn"
+
+            grad_loss = paddle.to_tensor(1.5, dtype="float32")
+            result = self.PyLayer.backward(ctx, grad_loss, None)
+            self.assertEqual(len(result), 5)
+            self.assertEqual(captured["loss_coeff"], 0.01)
+            self.assertIs(captured["grad_loss"], grad_loss)
+        finally:
+            if orig is not None:
+                cudnn_ops_mod.csa_indexer_bwd = orig
+            else:
+                cudnn_ops_mod.__dict__.pop("csa_indexer_bwd", None)
+
+    def test_backward_unknown_backend_raises(self):
+        """Unknown backend should raise NotImplementedError."""
+        b, sq, sk, h, d, topk = 1, 4, 4, 1, 8, 4
+
+        class FakeCtx:
+            pass
+
+        ctx = FakeCtx()
+        ctx.saved_tensor = lambda: (
+            paddle.randn([b, sq, h, d]).astype("bfloat16"),
+            paddle.randn([b, sq, h]).astype("bfloat16"),
+            paddle.randn([b, sk, d]).astype("bfloat16"),
+            paddle.randint(0, sk, [b, sq, topk]).astype("int32"),
+            paddle.randn([b, sq, topk]).astype("float32"),
+            paddle.randn([b, sq, topk]).astype("float32"),
+        )
+        ctx.loss_coeff = 0.01
+        ctx.indexer_backend = "invalid_backend"
+
+        with self.assertRaises(NotImplementedError):
+            self.PyLayer.backward(ctx, paddle.to_tensor(1.0), None)
+
+
+class TestTileLangCSAIndexerLossAutoScalerCudnn(unittest.TestCase):
+    """Cover TileLangCSAIndexerLossAutoScaler.backward cudnn branch."""
+
+    def setUp(self):
+        from paddlefleet.transformer.csa_attention import (
+            DSAIndexerLossAutoScaler,
+            TileLangCSAIndexerLossAutoScaler,
+        )
+
         self.AutoScaler = TileLangCSAIndexerLossAutoScaler
         self.DSAScaler = DSAIndexerLossAutoScaler
         self._orig_scale = DSAIndexerLossAutoScaler._main_loss_backward_scale
@@ -498,7 +806,6 @@ class TestCsaIndexerLossAutoScalerScaleBranches(unittest.TestCase):
             self.DSAScaler._main_loss_backward_scale = self._orig_scale
 
     def _run_with_scale(self, scale):
-        """Run backward with a fake csa_indexer_bwd; capture grad_loss arg."""
         import paddlefleet.cudnn_ops as cudnn_ops_mod
 
         captured = {}
@@ -522,14 +829,10 @@ class TestCsaIndexerLossAutoScalerScaleBranches(unittest.TestCase):
                 paddle.zeros_like(index_k_comp),
             )
 
-        had_attr = "csa_indexer_bwd" in cudnn_ops_mod.__dict__
-        orig_attr = cudnn_ops_mod.__dict__.get("csa_indexer_bwd")
+        orig = cudnn_ops_mod.__dict__.get("csa_indexer_bwd")
         cudnn_ops_mod.csa_indexer_bwd = fake_bwd
         try:
             self.DSAScaler._main_loss_backward_scale = scale
-
-            class FakeCtx:
-                pass
 
             b, sq, sk, h, d, topk = 1, 4, 4, 1, 8, 4
             index_q = paddle.randn([b, sq, h, d]).astype("bfloat16")
@@ -542,6 +845,9 @@ class TestCsaIndexerLossAutoScalerScaleBranches(unittest.TestCase):
             target = paddle.nn.functional.softmax(
                 paddle.randn([b, sq, topk]).astype("float32"), axis=-1
             )
+
+            class FakeCtx:
+                pass
 
             ctx = FakeCtx()
             ctx.saved_tensor = lambda: (
@@ -558,8 +864,8 @@ class TestCsaIndexerLossAutoScalerScaleBranches(unittest.TestCase):
             grad_output = paddle.ones_like(weights)
             self.AutoScaler.backward(ctx, grad_output)
         finally:
-            if had_attr:
-                cudnn_ops_mod.csa_indexer_bwd = orig_attr
+            if orig is not None:
+                cudnn_ops_mod.csa_indexer_bwd = orig
             else:
                 cudnn_ops_mod.__dict__.pop("csa_indexer_bwd", None)
         return captured
@@ -580,6 +886,109 @@ class TestCsaIndexerLossAutoScalerScaleBranches(unittest.TestCase):
         self.assertAlmostEqual(
             float(captured["grad_loss"].item()), 0.7, places=5
         )
+
+    def test_unknown_backend_raises(self):
+        """Unknown backend in AutoScaler should raise NotImplementedError."""
+        from paddlefleet.transformer.csa_attention import (
+            DSAIndexerLossAutoScaler,
+        )
+
+        DSAIndexerLossAutoScaler._main_loss_backward_scale = None
+        b, sq, sk, h, d, topk = 1, 4, 4, 1, 8, 4
+
+        class FakeCtx:
+            pass
+
+        ctx = FakeCtx()
+        ctx.saved_tensor = lambda: (
+            paddle.randn([b, sq, h, d]).astype("bfloat16"),
+            paddle.randn([b, sq, h]).astype("bfloat16"),
+            paddle.randn([b, sk, d]).astype("bfloat16"),
+            paddle.randint(0, sk, [b, sq, topk]).astype("int32"),
+            paddle.randn([b, sq, topk]).astype("float32"),
+            paddle.randn([b, sq, topk]).astype("float32"),
+        )
+        ctx.loss_coeff = 0.01
+        ctx.indexer_backend = "bad_backend"
+
+        with self.assertRaises(NotImplementedError):
+            self.AutoScaler.backward(ctx, paddle.ones([b, sq, h]))
+
+
+# ---------------------------------------------------------------------------
+# Tests: transformer_config.py (csa_indexer_backend field + validation)
+# ---------------------------------------------------------------------------
+
+
+class TestTransformerConfigCsaIndexerBackend(unittest.TestCase):
+    """Cover csa_indexer_backend field default and __post_init__ validation."""
+
+    def test_default_value(self):
+        from paddlefleet.transformer.transformer_config import TransformerConfig
+
+        cfg = TransformerConfig()
+        self.assertEqual(cfg.csa_indexer_backend, "tilelang")
+
+    def test_valid_cudnn_value(self):
+        from paddlefleet.transformer.transformer_config import TransformerConfig
+
+        cfg = TransformerConfig(
+            experimental_attention_variant="dsv4_hybrid",
+            csa_compress_ratios=[4],
+            csa_indexer_backend="cudnn",
+            csa_tilelang_backend="attention_paddle_compat",
+            csa_tilelang_enable_indexer=True,
+        )
+        self.assertEqual(cfg.csa_indexer_backend, "cudnn")
+
+    def test_valid_tilelang_value(self):
+        from paddlefleet.transformer.transformer_config import TransformerConfig
+
+        cfg = TransformerConfig(
+            experimental_attention_variant="dsv4_hybrid",
+            csa_compress_ratios=[4],
+            csa_indexer_backend="tilelang",
+            csa_tilelang_backend="attention_paddle_compat",
+            csa_tilelang_enable_indexer=True,
+        )
+        self.assertEqual(cfg.csa_indexer_backend, "tilelang")
+
+    def test_invalid_value_raises(self):
+        from paddlefleet.transformer.transformer_config import TransformerConfig
+
+        with self.assertRaises(ValueError) as cm:
+            TransformerConfig(
+                experimental_attention_variant="dsv4_hybrid",
+                csa_compress_ratios=[4],
+                csa_indexer_backend="invalid_backend",
+                csa_tilelang_backend="attention_paddle_compat",
+                csa_tilelang_enable_indexer=True,
+            )
+        self.assertIn("invalid_backend", str(cm.exception))
+
+    def test_attribute_map_registered(self):
+        from paddlefleet.transformer.transformer_config import TransformerConfig
+
+        self.assertIn("csa_indexer_backend", TransformerConfig.transform_rules)
+
+
+# ---------------------------------------------------------------------------
+# Tests: indexer/__init__.py re-export
+# ---------------------------------------------------------------------------
+
+
+class TestIndexerSubpackageInit(unittest.TestCase):
+    """Cover paddlefleet.cudnn_ops.indexer.__init__.py re-export."""
+
+    def test_import_from_indexer(self):
+        from paddlefleet.cudnn_ops.indexer import csa_indexer_bwd
+
+        self.assertTrue(callable(csa_indexer_bwd))
+
+    def test_indexer_all(self):
+        import paddlefleet.cudnn_ops.indexer as indexer_mod
+
+        self.assertIn("csa_indexer_bwd", indexer_mod.__all__)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library  | Environment Adaptation ] -->
Performance Optimization
### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features
### Description
<!-- Describe what you've done -->
新增 cudnn indexer backward 实现
需要通过 config.json 配置

主要变更：
新增 `src/paddlefleet/cudnn_ops/` 模块，封装 cuDNN-frontend DSA indexer backward 调用

### 是否引起精度变化
是