### PR TITLE
[DeepSeekV4] Add flash_mla for CSA forward

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ packages/paddlefleet_ops/src/paddlefleet_ops/deep_ep_cpp.so
 packages/paddlefleet_ops/src/paddlefleet_ops/hybrid_ep
 packages/paddlefleet_ops/src/paddlefleet_ops/hybrid_ep_cpp.so
 packages/paddlefleet_ops/src/paddlefleet_ops/flash_mask
+packages/paddlefleet_ops/src/paddlefleet_ops/flash_mla
 packages/paddlefleet_ops/src/paddlefleet_ops/sonicmoe
 packages/paddlefleet_ops/src/paddlefleet_ops/quack
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "packages/paddlefleet_ops/third_party/cudnn-frontend"]
 	path = packages/paddlefleet_ops/third_party/cudnn-frontend
 	url = https://github.com/PFCCLab/cudnn-frontend.git
+[submodule "packages/paddlefleet_ops/third_party/FlashMLA"]
+	path = packages/paddlefleet_ops/third_party/FlashMLA
+	url = https://github.com/PFCCLab/FlashMLA.git

--- a/packages/paddlefleet_ops/build_utils.py
+++ b/packages/paddlefleet_ops/build_utils.py
@@ -201,6 +201,7 @@ def check_submodule_updated():
             and (PKG_ROOT / "third_party" / "quack" / ".git").exists()
             and (PKG_ROOT / "third_party" / "sonic-moe" / ".git").exists()
             and (PKG_ROOT / "third_party" / "flash-attention" / ".git").exists()
+            and (PKG_ROOT / "third_party" / "FlashMLA" / ".git").exists()
         ):
             logger.error(
                 "\033[91m Found uninitialized submodules. Please use 'git submodule update --init --recursive' to fix!\033[0m"
@@ -411,6 +412,20 @@ def get_libs():
                 "flash_mask/flashmask_attention_v3",
                 "flash_mask/flashmask_attention_v3/cutlass/include",
             ],
+        ),
+        EcosystemLibrary(
+            name="FlashMLA",
+            source_rel_path="third_party/FlashMLA",
+            artifacts=[
+                Artifact("flash_mla", "flash_mla"),
+            ],
+            extra_env={
+                "PADDLE_CUDA_ARCH_LIST": "",
+                "FLASH_MLA_DISABLE_SM90": str("9.0" not in _deep_ep_arch),
+                "FLASH_MLA_DISABLE_SM100": str(
+                    (cuda_major, cuda_minor) <= (12, 8)
+                ),
+            },
         ),
     ]
     if (cuda_major, cuda_minor) >= (12, 9):

--- a/packages/paddlefleet_ops/src/paddlefleet_ops/__init__.py
+++ b/packages/paddlefleet_ops/src/paddlefleet_ops/__init__.py
@@ -88,12 +88,18 @@ if paddle.is_compiled_with_cuda():
     )
 
     CUDNN_FRONTEND_HINT = "For developers: guard imports with `is_cudnn_frontend_available()` and only call `paddlefleet_ops.cudnn` when flag branch enabled."
+
+    FLASH_MLA_HINT = (
+        "For developers: guard imports with `is_flash_mla_available()` and only call `paddlefleet_ops.flash_mla` when flag branch enabled.\n"
+        "For users: use a GPU with compute capability >= 9.0 (Hopper or Blackwell) to enable."
+    )
 else:
     DEEP_GEMM_HINT = "deep_gemm is not supported on XPU backend."
     DEEP_EP_HINT = "deep_ep is not supported on XPU backend."
     HYBRID_EP_HINT = "hybrid_ep is not supported on XPU backend."
     SONIC_MOE_HINT = "sonicmoe is not supported on XPU backend."
     CUDNN_FRONTEND_HINT = "cudnn frontend is not supported on XPU backend."
+    FLASH_MLA_HINT = "flash_mla is not supported on XPU backend."
 
 FLASH_MASK_HINT = (
     "For developers: guard imports with `is_flash_mask_available()` and only call `paddlefleet_ops.flash_mask` when flag branch enabled.\n"
@@ -160,6 +166,7 @@ _DEEP_GEMM_AVAILABLE = False
 _DEEP_EP_AVAILABLE = False
 _HYBRID_EP_AVAILABLE = False
 _SONIC_MOE_AVAILABLE = False
+_FLASH_MLA_AVAILABLE = False
 _FLASH_MASK_AVAILABLE = False
 _CUDNN_FRONTEND_AVAILABLE = False
 
@@ -167,6 +174,7 @@ if paddle.is_compiled_with_cuda():
     if paddle.cuda.get_device_capability()[0] >= 9:
         _DEEP_GEMM_AVAILABLE = True
         _DEEP_EP_AVAILABLE = True
+        _FLASH_MLA_AVAILABLE = True
         if _cuda_version >= (12, 9):
             _HYBRID_EP_AVAILABLE = True
     if paddle.cuda.get_device_capability()[0] >= 10:
@@ -198,6 +206,10 @@ def is_hybrid_ep_available():
 
 def is_sonic_moe_available():
     return _SONIC_MOE_AVAILABLE
+
+
+def is_flash_mla_available():
+    return _FLASH_MLA_AVAILABLE
 
 
 def is_flash_mask_available():
@@ -311,6 +323,16 @@ if paddle.is_compiled_with_cuda():
         )
         logger.warning(warning)
         blocked_import_messages["paddlefleet_ops.sonicmoe"] = error
+
+    if is_flash_mla_available():
+        paddle.enable_compat(scope={"flash_mla"}, silent=True)
+        _safe_load_ecosystem_lib("flash_mla", ops_dir, globals())
+    else:
+        warning, error = _hopper_requirement(
+            "paddlefleet_ops.flash_mla", hint=FLASH_MLA_HINT
+        )
+        logger.warning(warning)
+        blocked_import_messages["paddlefleet_ops.flash_mla"] = error
 
     if is_flash_mask_available():
         _safe_load_ecosystem_lib("flash_mask", ops_dir, globals())

--- a/src/paddlefleet/tilelang_ops/attn/sparse_mqa.py
+++ b/src/paddlefleet/tilelang_ops/attn/sparse_mqa.py
@@ -12,9 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 import paddle
+import paddle.nn.functional as F
+from paddle.utils import strtobool
 
 from . import sparse_mqa_fwd
+
+_USE_FLASH_MLA = strtobool(os.getenv("USE_FLASH_MLA", "0"))
+
+if _USE_FLASH_MLA:
+    try:
+        from paddlefleet_ops.flash_mla import (
+            flash_mla_sparse_fwd as _flash_mla_sparse_fwd,
+        )
+    except (ImportError, RuntimeError):
+        _flash_mla_sparse_fwd = None
 
 
 def _prepare_inputs(q, kv, attn_sink, topk_idxs):
@@ -35,11 +49,104 @@ def _prepare_inputs(q, kv, attn_sink, topk_idxs):
     return q, kv, attn_sink, topk_idxs
 
 
+def _get_topk_alignment() -> int:
+    """Minimum ``TopK`` alignment required by the current GPU architecture.
+
+    * SM90 : dual-warpgroup loop steps by 2 blocks → ``2 * B_TOPK = 128``
+    * SM100: single-pipeline loop steps by 1 block → ``B_TOPK`` (64 for
+      head64, 128 for head128). DSA uses ``D = 512`` which maps to the
+      head64 kernel path → 64.
+    """
+    sm = paddle.cuda.get_device_capability()
+    if sm[0] >= 10:
+        return 64
+    return 128
+
+
+def _local_to_global_flat(local_idxs, seqlen_kv: int):
+    """Convert local per-batch indices to Paddle batch-first flat indices.
+
+    Follows the Paddle layout used by this module: tensors are flattened from
+    ``[B, S, ...]`` to ``[B * S, ...]`` in batch-first row order. The global KV
+    index is ``batch_id * seqlen_kv + local`` for valid entries and ``-1``
+    otherwise.
+
+    Args:
+        local_idxs: ``(B, S, topk)`` int, values in ``[0, seqlen_kv)`` or -1.
+        seqlen_kv: KV sequence length per batch.
+
+    Returns:
+        ``(B * S, topk)`` int32.
+    """
+    b, sq, topk = local_idxs.shape
+    idxs_flat = local_idxs.reshape([b * sq, topk])
+    valid = idxs_flat >= 0
+    batch_ids = (
+        paddle.arange(b, dtype=idxs_flat.dtype)
+        .unsqueeze(1)
+        .expand([b, sq])
+        .reshape([b * sq])
+    )
+    batch_offsets = (batch_ids * seqlen_kv).unsqueeze(1)
+    return paddle.where(valid, idxs_flat + batch_offsets, idxs_flat).cast(
+        "int32"
+    )
+
+
+def flash_mla_sparse_attn(
+    q, kv, attn_sink, topk_idxs, sm_scale=None, indexer_topk: int = 0
+):
+    if _flash_mla_sparse_fwd is None:
+        raise RuntimeError("flash_mla is not available")
+
+    b, sq, h, d = q.shape
+    _, skv, _ = kv.shape
+    topk = topk_idxs.shape[-1]
+
+    q_flat = q.reshape([b * sq, h, d])
+    kv_flat = kv.reshape([b * skv, d])
+    global_idxs = _local_to_global_flat(topk_idxs, skv)
+
+    topk_align = _get_topk_alignment()
+    topk_padded = (topk + topk_align - 1) // topk_align * topk_align
+    if topk_padded != topk:
+        global_idxs = F.pad(global_idxs, (0, topk_padded - topk), value=-1)
+
+    res = _flash_mla_sparse_fwd(
+        q_flat,
+        kv_flat.unsqueeze(1),
+        global_idxs.unsqueeze(1),
+        sm_scale,
+        d_v=d,
+        attn_sink=attn_sink,
+        topk_length=None,
+        indexer_topk=indexer_topk,
+    )
+    if indexer_topk > 0:
+        out_flat, _max_logits, lse, lse_indexer = res
+        lse_indexer = lse_indexer.reshape([b, sq, h])
+    else:
+        out_flat, _max_logits, lse = res
+        lse_indexer = None
+    return out_flat.reshape([b, sq, h, d]), lse.reshape([b, sq, h]), lse_indexer
+
+
 def sparse_attn(q, kv, attn_sink, topk_idxs, sm_scale=None):
     q, kv, attn_sink, topk_idxs = _prepare_inputs(q, kv, attn_sink, topk_idxs)
-    out, lse = sparse_mqa_fwd.sparse_mqa_fwd_interface(
-        q, kv, attn_sink, topk_idxs, sm_scale=sm_scale
-    )
+
+    if _USE_FLASH_MLA:
+        out, lse, _ = flash_mla_sparse_attn(
+            q,
+            kv,
+            attn_sink,
+            topk_idxs,
+            sm_scale=sm_scale,
+        )
+    else:
+        out, lse = sparse_mqa_fwd.sparse_mqa_fwd_interface(
+            q, kv, attn_sink, topk_idxs, sm_scale=sm_scale
+        )
+
     if not isinstance(out, paddle.Tensor) or not isinstance(lse, paddle.Tensor):
         raise RuntimeError(
             f"TileLang must return Paddle tensors, got output={type(out)!r}, lse={type(lse)!r}. "

--- a/tests/single_card_tests/custom_ops/test_sparse_mqa_flash_mla.py
+++ b/tests/single_card_tests/custom_ops/test_sparse_mqa_flash_mla.py
@@ -1,0 +1,156 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+import os
+import unittest
+from unittest import mock
+
+import numpy as np
+import paddle
+
+os.environ["USE_FLASH_MLA"] = "1"
+
+try:
+    import paddlefleet_ops
+
+    from paddlefleet.tilelang_ops.attn import sparse_mqa
+
+    _HAS_FLASH_MLA = (
+        paddlefleet_ops.is_flash_mla_available()
+        and sparse_mqa._flash_mla_sparse_fwd is not None
+    )
+except (ImportError, RuntimeError):
+    _HAS_FLASH_MLA = False
+
+
+@unittest.skipUnless(
+    paddle.is_compiled_with_cuda() and _HAS_FLASH_MLA,
+    "FlashMLA sparse attention requires CUDA and flash_mla",
+)
+class TestSparseMQAFlashMLAForward(unittest.TestCase):
+    def setUp(self):
+        paddle.seed(2026)
+        self.batch_size = 2
+        self.seq_len = 1024
+        self.num_heads = 64
+        self.head_dim = 512
+        self.topk = 128
+        self.softmax_scale = self.head_dim**-0.5
+
+    def _make_inputs(self):
+        q = paddle.randn(
+            [
+                self.batch_size,
+                self.seq_len,
+                self.num_heads,
+                self.head_dim,
+            ],
+            dtype=paddle.bfloat16,
+        )
+        kv = paddle.randn(
+            [self.batch_size, self.seq_len, self.head_dim],
+            dtype=paddle.bfloat16,
+        )
+        attn_sink = paddle.randn([self.num_heads], dtype=paddle.float32)
+        topk_idxs = (
+            paddle.arange(self.topk, dtype="int32")
+            .reshape([1, 1, self.topk])
+            .expand([self.batch_size, self.seq_len, self.topk])
+        )
+        return q, kv, attn_sink, topk_idxs
+
+    def test_flash_mla_forward_matches_tilelang(self):
+        q, kv, attn_sink, topk_idxs = self._make_inputs()
+
+        old_use_flash_mla = sparse_mqa._USE_FLASH_MLA
+
+        try:
+            sparse_mqa._USE_FLASH_MLA = False
+            tile_out, tile_lse = sparse_mqa.sparse_attn(
+                q, kv, attn_sink, topk_idxs, sm_scale=self.softmax_scale
+            )
+
+            sparse_mqa._USE_FLASH_MLA = True
+            flash_out, flash_lse = sparse_mqa.sparse_attn(
+                q, kv, attn_sink, topk_idxs, sm_scale=self.softmax_scale
+            )
+
+            # flash_mla uses a different lse computation from tilelang
+            flash_lse = paddle.logaddexp(flash_lse, attn_sink) / math.log(2.0)
+        finally:
+            sparse_mqa._USE_FLASH_MLA = old_use_flash_mla
+
+        np.testing.assert_allclose(
+            flash_out.float(),
+            tile_out.float(),
+            rtol=5e-2,
+            atol=1e-2,
+        )
+        np.testing.assert_allclose(
+            flash_lse,
+            tile_lse,
+            rtol=1e-6,
+            atol=1e-6,
+        )
+
+    def test_flash_mla_forward_with_indexer_lse(self):
+        q, kv, attn_sink, topk_idxs = self._make_inputs()
+        topk_idxs = topk_idxs[:, :, :96]
+
+        out, lse, lse_indexer = sparse_mqa.flash_mla_sparse_attn(
+            q,
+            kv,
+            attn_sink,
+            topk_idxs,
+            sm_scale=self.softmax_scale,
+            indexer_topk=512,
+        )
+
+        self.assertEqual(
+            out.shape,
+            [self.batch_size, self.seq_len, self.num_heads, self.head_dim],
+        )
+        self.assertEqual(
+            lse.shape,
+            [self.batch_size, self.seq_len, self.num_heads],
+        )
+        self.assertEqual(
+            lse_indexer.shape,
+            [self.batch_size, self.seq_len, self.num_heads],
+        )
+
+    def test_fallback_path(self):
+        old_flash_mla_sparse_fwd = getattr(
+            sparse_mqa, "_flash_mla_sparse_fwd", None
+        )
+        try:
+            sparse_mqa._flash_mla_sparse_fwd = None
+            with self.assertRaisesRegex(
+                RuntimeError, "flash_mla is not available"
+            ):
+                sparse_mqa.flash_mla_sparse_attn(None, None, None, None)
+        finally:
+            sparse_mqa._flash_mla_sparse_fwd = old_flash_mla_sparse_fwd
+
+        with mock.patch.object(
+            sparse_mqa.paddle.cuda,
+            "get_device_capability",
+            return_value=(10, 0),
+        ):
+            self.assertEqual(sparse_mqa._get_topk_alignment(), 64)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
Operator Mechanism


### PR Types
New features


### Description
新增 [FlashMLA](https://github.com/PFCCLab/FlashMLA) 库，使用 flash_mla_sparse_fwd kernel 替换原有的 tilelang 前向实现（反向见 https://github.com/PaddlePaddle/PaddleFleet/pull/1101 ）

<b>使用方法：</b>
* 通过环境变量开启：`export USE_FLASH_MLA=1`; `export USE_CUDNN_DSA=1`
* <b>注：</b>以上两个开关需要同时开启，因为 flash_mla 和 cudnn DSA 是配套的，它们的 lse 和原来的 tilelang 的定义不同，只开前向或者反向会导致 lse 值域错误，loss 起飞

* 以上环境变量生效的前提是开启了 tilelang，参考 json 配置：
```json
  "csa_tilelang_backend": "attention_paddle_compat",
  "csa_tilelang_enable_indexer": true,
  "csa_tilelang_enable_sparse_attn": true,
```

### 是否引起精度变化
是
