### PR TITLE
add high_precision_mhc for float32 or bfloat16 calc in mHC

### DIFF
--- a/src/paddlefleet/transformer/hyper_connection.py
+++ b/src/paddlefleet/transformer/hyper_connection.py
@@ -325,12 +325,7 @@ class HyperConnectionModule(nn.Layer):
             ],
             axis=-1,
         )
-        if not self.config.high_precision_mhc:
-            alpha_ = alpha_.astype(proj.dtype)
-            bias = self.bias.astype(proj.dtype)
-        else:
-            bias = self.bias
-        h = r * proj * alpha_ + bias
+        h = r * proj * alpha_ + self.bias
         # H_pre = σ(α_pre * (θ_pre @ x̃) + b_pre)
         h_pre = h[..., : self.n].sigmoid()  # [..., n]
 
@@ -361,8 +356,6 @@ class HyperConnectionModule(nn.Layer):
             self.sinkhorn_iterations,
             self.norm_eps,
         )  # [..., n, n]
-        if not self.config.high_precision_mhc:
-            h_res = h_res.astype(x.dtype)
 
         return h_pre, h_post, h_res
 
@@ -640,8 +633,6 @@ class HyperConnectionModule(nn.Layer):
                 output = self._h_post_bda_op(
                     h_res, orig_reshaped, h_post, x, bias
                 )
-                if not self.config.high_precision_mhc:
-                    output = output.astype(original_residual.dtype)
                 return output.reshape([*leading_shape, n * C])
 
             # Slow path: dropout required — sequential ops

--- a/src/paddlefleet/transformer/hyper_connection.py
+++ b/src/paddlefleet/transformer/hyper_connection.py
@@ -84,12 +84,11 @@ class SinkhornKnopp(paddle.autograd.PyLayer):
             H_res: [..., n, n] - doubly stochastic matrix
         """
         # Stabilized exp: subtract row-wise max to prevent overflow
-        with paddle.amp.auto_cast(enable=False):
-            M_init = paddle.exp(
-                H_res_logits - H_res_logits.max(axis=-1, keepdim=True)
-            )
+        M_init = paddle.exp(
+            H_res_logits - H_res_logits.max(axis=-1, keepdim=True)
+        )
 
-            M = SinkhornKnopp._sinkhorn_normalize(M_init, num_iterations, eps)
+        M = SinkhornKnopp._sinkhorn_normalize(M_init, num_iterations, eps)
 
         # Save initial M for backward recomputation
         ctx.save_for_backward(M_init)
@@ -144,8 +143,7 @@ def native_proj_rms(
     nC = x.shape[-1]
     r = x.norm(axis=-1, keepdim=True) / math.sqrt(nC)
     r = 1.0 / (r + eps)
-    with paddle.amp.auto_cast(enable=False):
-        proj = paddle.matmul(x, weight)
+    proj = paddle.matmul(x, weight)
     return proj, r
 
 
@@ -481,13 +479,14 @@ class HyperConnectionModule(nn.Layer):
             h_res: [..., n, n] - residual mixing matrix (for fused kernel)
             h_post: [..., n] - expansion weights
         """
-        # Compute mappings
-        if self.config.high_precision_mhc:
-            hidden_states = hidden_states.astype("float32")
-        h_pre, h_post, h_res = self.compute_mappings(hidden_states)
+        with paddle.amp.auto_cast(enable=False):
+            # Compute mappings
+            if self.config.high_precision_mhc:
+                hidden_states = hidden_states.astype("float32")
+            h_pre, h_post, h_res = self.compute_mappings(hidden_states)
 
-        # Aggregate for layer input
-        aggregated = self.aggregate(hidden_states, h_pre)
+            # Aggregate for layer input
+            aggregated = self.aggregate(hidden_states, h_pre)
 
         return aggregated, h_res, h_post
 
@@ -615,35 +614,40 @@ class HyperConnectionModule(nn.Layer):
         Returns:
             output: [..., n*C] - final output after all operations
         """
-        x, bias = layer_output_with_bias
+        with paddle.amp.auto_cast(enable=False):
+            x, bias = layer_output_with_bias
 
-        # Fast path: no dropout — use fused/native h_post_bda kernel
-        if dropout_prob == 0.0 or not training:
-            leading_shape = original_residual.shape[:-1]
-            n = self.n
-            C = self.hidden_size
-            orig_reshaped = original_residual.reshape([*leading_shape, n, C])
-            if self.config.high_precision_mhc:
-                orig_reshaped = orig_reshaped.astype("float32")
-                x = x.astype("float32")
-                if bias is not None:
-                    bias = bias.astype("float32")
-            output = self._h_post_bda_op(h_res, orig_reshaped, h_post, x, bias)
-            return output.reshape([*leading_shape, n * C])
+            # Fast path: no dropout — use fused/native h_post_bda kernel
+            if dropout_prob == 0.0 or not training:
+                leading_shape = original_residual.shape[:-1]
+                n = self.n
+                C = self.hidden_size
+                orig_reshaped = original_residual.reshape(
+                    [*leading_shape, n, C]
+                )
+                if self.config.high_precision_mhc:
+                    orig_reshaped = orig_reshaped.astype("float32")
+                    x = x.astype("float32")
+                    if bias is not None:
+                        bias = bias.astype("float32")
+                output = self._h_post_bda_op(
+                    h_res, orig_reshaped, h_post, x, bias
+                )
+                return output.reshape([*leading_shape, n * C])
 
-        # Slow path: dropout required — sequential ops
-        mixed = self.apply_h_res(h_res, original_residual)
-        x_expanded = self._apply_h_post(x, h_post)
-        bias_expanded = (
-            self._apply_h_post(bias, h_post) if bias is not None else None
-        )
+            # Slow path: dropout required — sequential ops
+            mixed = self.apply_h_res(h_res, original_residual)
+            x_expanded = self._apply_h_post(x, h_post)
+            bias_expanded = (
+                self._apply_h_post(bias, h_post) if bias is not None else None
+            )
 
-        if bias_expanded is not None:
-            x_expanded = x_expanded + bias_expanded
-        out = paddle.nn.functional.dropout(
-            x_expanded, p=dropout_prob, training=training
-        )
-        output = out + mixed
+            if bias_expanded is not None:
+                x_expanded = x_expanded + bias_expanded
+            out = paddle.nn.functional.dropout(
+                x_expanded, p=dropout_prob, training=training
+            )
+            output = out + mixed
 
         return output
 

--- a/src/paddlefleet/transformer/hyper_connection.py
+++ b/src/paddlefleet/transformer/hyper_connection.py
@@ -84,11 +84,12 @@ class SinkhornKnopp(paddle.autograd.PyLayer):
             H_res: [..., n, n] - doubly stochastic matrix
         """
         # Stabilized exp: subtract row-wise max to prevent overflow
-        M_init = paddle.exp(
-            H_res_logits - H_res_logits.max(axis=-1, keepdim=True)
-        )
+        with paddle.amp.auto_cast(enable=False):
+            M_init = paddle.exp(
+                H_res_logits - H_res_logits.max(axis=-1, keepdim=True)
+            )
 
-        M = SinkhornKnopp._sinkhorn_normalize(M_init, num_iterations, eps)
+            M = SinkhornKnopp._sinkhorn_normalize(M_init, num_iterations, eps)
 
         # Save initial M for backward recomputation
         ctx.save_for_backward(M_init)
@@ -143,7 +144,8 @@ def native_proj_rms(
     nC = x.shape[-1]
     r = x.norm(axis=-1, keepdim=True) / math.sqrt(nC)
     r = 1.0 / (r + eps)
-    proj = paddle.matmul(x, weight)
+    with paddle.amp.auto_cast(enable=False):
+        proj = paddle.matmul(x, weight)
     return proj, r
 
 
@@ -294,7 +296,12 @@ class HyperConnectionModule(nn.Layer):
         Args:
             x: [..., n*C] - n-stream hidden states
         """
-        proj, r = self._proj_rms_op(x, self.mapping_proj.weight, self.norm_eps)
+        ori_dtype = x.dtype
+        proj, r = self._proj_rms_op(
+            x, self.mapping_proj.weight.astype(ori_dtype), self.norm_eps
+        )
+        if not self.config.high_precision_mhc:
+            r = r.astype(ori_dtype)
         return proj, r
 
     def _compute_h(
@@ -373,7 +380,11 @@ class HyperConnectionModule(nn.Layer):
         # Reshape to [..., n, C]
         x_streams = x.reshape([*leading_shape, self.n, C])
 
-        return self._h_aggregate_op(x_streams, h_pre)
+        aggregated = self._h_aggregate_op(x_streams, h_pre)
+        if aggregated.dtype != x.dtype:
+            aggregated = aggregated.astype(x.dtype)
+
+        return aggregated
 
     def apply_h_res(self, h_res: Tensor, residual: Tensor) -> Tensor:
         """
@@ -471,7 +482,8 @@ class HyperConnectionModule(nn.Layer):
             h_post: [..., n] - expansion weights
         """
         # Compute mappings
-        hidden_states = hidden_states.astype("float32")
+        if self.config.high_precision_mhc:
+            hidden_states = hidden_states.astype("float32")
         h_pre, h_post, h_res = self.compute_mappings(hidden_states)
 
         # Aggregate for layer input
@@ -610,12 +622,12 @@ class HyperConnectionModule(nn.Layer):
             leading_shape = original_residual.shape[:-1]
             n = self.n
             C = self.hidden_size
-            orig_reshaped = original_residual.reshape(
-                [*leading_shape, n, C]
-            ).astype("float32")
-            x = x.astype("float32")
-            if bias is not None:
-                bias = bias.astype("float32")
+            orig_reshaped = original_residual.reshape([*leading_shape, n, C])
+            if self.config.high_precision_mhc:
+                orig_reshaped = orig_reshaped.astype("float32")
+                x = x.astype("float32")
+                if bias is not None:
+                    bias = bias.astype("float32")
             output = self._h_post_bda_op(h_res, orig_reshaped, h_post, x, bias)
             return output.reshape([*leading_shape, n * C])
 

--- a/src/paddlefleet/transformer/hyper_connection.py
+++ b/src/paddlefleet/transformer/hyper_connection.py
@@ -325,7 +325,12 @@ class HyperConnectionModule(nn.Layer):
             ],
             axis=-1,
         )
-        h = r * proj * alpha_ + self.bias
+        if not self.config.high_precision_mhc:
+            alpha_ = alpha_.astype(proj.dtype)
+            bias = self.bias.astype(proj.dtype)
+        else:
+            bias = self.bias
+        h = r * proj * alpha_ + bias
         # H_pre = σ(α_pre * (θ_pre @ x̃) + b_pre)
         h_pre = h[..., : self.n].sigmoid()  # [..., n]
 
@@ -356,6 +361,8 @@ class HyperConnectionModule(nn.Layer):
             self.sinkhorn_iterations,
             self.norm_eps,
         )  # [..., n, n]
+        if not self.config.high_precision_mhc:
+            h_res = h_res.astype(x.dtype)
 
         return h_pre, h_post, h_res
 
@@ -633,6 +640,8 @@ class HyperConnectionModule(nn.Layer):
                 output = self._h_post_bda_op(
                     h_res, orig_reshaped, h_post, x, bias
                 )
+                if not self.config.high_precision_mhc:
+                    output = output.astype(original_residual.dtype)
                 return output.reshape([*leading_shape, n * C])
 
             # Slow path: dropout required — sequential ops

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -594,7 +594,7 @@ class TransformerConfig(ModelParallelConfig):
     """Use fused triton kernels for mHC operations (sinkhorn, h_aggregate, h_post_bda, proj_rms).
     Requires cuTile to be available."""
 
-    high_precision_mhc: bool = False
+    high_precision_mhc: bool = True
     """Use high precision (float32) for mHC forward and backward computation."""
 
     ####################

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -594,6 +594,9 @@ class TransformerConfig(ModelParallelConfig):
     """Use fused triton kernels for mHC operations (sinkhorn, h_aggregate, h_post_bda, proj_rms).
     Requires cuTile to be available."""
 
+    high_precision_mhc: bool = False
+    """Use high precision (float32) for mHC forward and backward computation."""
+
     ####################
     # miscellaneous
     ####################

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_hyper_connection_transformer_layer.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_hyper_connection_transformer_layer.py
@@ -244,6 +244,9 @@ class TestHyperConnectionModule(unittest.TestCase):
             with self.subTest(high_precision_mhc=high_precision_mhc):
                 config = _make_hc_config(high_precision_mhc=high_precision_mhc)
                 module = HyperConnectionModule(config=config, layer_number=1)
+                module = paddle.amp.decorate(
+                    models=module, level="O2", dtype="bfloat16"
+                )
                 x = paddle.randn([2, 4, self.n * self.C]).astype("bfloat16")
 
                 aggregated, h_res, h_post = module(x)
@@ -450,6 +453,9 @@ class TestHyperConnectionModule(unittest.TestCase):
             with self.subTest(high_precision_mhc=high_precision_mhc):
                 config = _make_hc_config(high_precision_mhc=high_precision_mhc)
                 module = HyperConnectionModule(config=config, layer_number=1)
+                module = paddle.amp.decorate(
+                    models=module, level="O2", dtype="bfloat16"
+                )
                 x = paddle.randn([B, S, self.n * self.C]).astype("bfloat16")
                 _, h_res, h_post = module(x)
                 layer_output = paddle.randn([B, S, self.C]).astype("bfloat16")

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_hyper_connection_transformer_layer.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_hyper_connection_transformer_layer.py
@@ -100,6 +100,7 @@ def _make_hc_config(**overrides):
         "num_residual_streams": 4,
         "mhc_sinkhorn_iterations": 5,
         "mhc_init_gating_factor": 0.01,
+        "high_precision_mhc": True,
     }
     hc_defaults.update(overrides)
     return _make_config(**hc_defaults)
@@ -233,20 +234,29 @@ class TestHyperConnectionModule(unittest.TestCase):
         self.assertEqual(list(h_res.shape), [10, self.n, self.n])
         self.assertEqual(list(h_post.shape), [10, self.n])
 
-    def test_forward_high_precision_mhc_casts_to_float32(self):
-        """high_precision_mhc should compute mHC mappings in float32."""
-        config = _make_hc_config(high_precision_mhc=False)
-        module = HyperConnectionModule(config=config, layer_number=1)
-        x = paddle.randn([2, 4, self.n * self.C]).astype("float16")
+    def test_forward_high_precision_mhc_switch(self):
+        """high_precision_mhc should cover both forward branches."""
+        cases = (
+            (True, "float16", paddle.float32),
+            (False, "float32", paddle.float32),
+        )
+        for high_precision_mhc, input_dtype, expected_dtype in cases:
+            with self.subTest(high_precision_mhc=high_precision_mhc):
+                config = _make_hc_config(high_precision_mhc=high_precision_mhc)
+                module = HyperConnectionModule(config=config, layer_number=1)
+                x = paddle.randn([2, 4, self.n * self.C]).astype(input_dtype)
 
-        aggregated, h_res, h_post = module(x)
+                aggregated, h_res, h_post = module(x)
 
-        self.assertEqual(aggregated.dtype, paddle.float32)
-        self.assertEqual(h_res.dtype, paddle.float32)
-        self.assertEqual(h_post.dtype, paddle.float32)
-        self.assertEqual(list(aggregated.shape), [2, 4, self.C])
-        self.assertEqual(list(h_res.shape), [2, 4, self.n, self.n])
-        self.assertEqual(list(h_post.shape), [2, 4, self.n])
+                self.assertEqual(
+                    module.config.high_precision_mhc, high_precision_mhc
+                )
+                self.assertEqual(aggregated.dtype, expected_dtype)
+                self.assertEqual(h_res.dtype, expected_dtype)
+                self.assertEqual(h_post.dtype, expected_dtype)
+                self.assertEqual(list(aggregated.shape), [2, 4, self.C])
+                self.assertEqual(list(h_res.shape), [2, 4, self.n, self.n])
+                self.assertEqual(list(h_post.shape), [2, 4, self.n])
 
     # ---------- compute_mappings ----------
 
@@ -430,28 +440,37 @@ class TestHyperConnectionModule(unittest.TestCase):
         self.assertFalse(paddle.isnan(result).any().item())
 
     def test_fused_h_res_h_post_bda_high_precision_fast_path(self):
-        """high_precision_mhc should cast fast-path BDA inputs to float32."""
+        """high_precision_mhc should cover both fast-path BDA branches."""
         B, S = 2, 4
-        config = _make_hc_config(high_precision_mhc=False)
-        module = HyperConnectionModule(config=config, layer_number=1)
-        x = paddle.randn([B, S, self.n * self.C]).astype("float16")
-        _, h_res, h_post = module(x)
-        layer_output = paddle.randn([B, S, self.C]).astype("float16")
-        bias = paddle.randn([self.C]).astype("float16")
-
-        result = module.fused_h_res_h_post_bda(
-            h_res=h_res,
-            original_residual=x,
-            h_post=h_post,
-            layer_output_with_bias=(layer_output, bias),
-            dropout_prob=0.0,
-            training=False,
-            fused=False,
+        cases = (
+            (True, "float16", paddle.float32),
+            (False, "float32", paddle.float32),
         )
+        for high_precision_mhc, input_dtype, expected_dtype in cases:
+            with self.subTest(high_precision_mhc=high_precision_mhc):
+                config = _make_hc_config(high_precision_mhc=high_precision_mhc)
+                module = HyperConnectionModule(config=config, layer_number=1)
+                x = paddle.randn([B, S, self.n * self.C]).astype(input_dtype)
+                _, h_res, h_post = module(x)
+                layer_output = paddle.randn([B, S, self.C]).astype(input_dtype)
+                bias = paddle.randn([self.C]).astype(input_dtype)
 
-        self.assertEqual(result.dtype, paddle.float32)
-        self.assertEqual(list(result.shape), [B, S, self.n * self.C])
-        self.assertFalse(paddle.isnan(result).any().item())
+                result = module.fused_h_res_h_post_bda(
+                    h_res=h_res,
+                    original_residual=x,
+                    h_post=h_post,
+                    layer_output_with_bias=(layer_output, bias),
+                    dropout_prob=0.0,
+                    training=False,
+                    fused=False,
+                )
+
+                self.assertEqual(
+                    module.config.high_precision_mhc, high_precision_mhc
+                )
+                self.assertEqual(result.dtype, expected_dtype)
+                self.assertEqual(list(result.shape), [B, S, self.n * self.C])
+                self.assertFalse(paddle.isnan(result).any().item())
 
     # ---------- input_expand / output_contract ----------
 

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_hyper_connection_transformer_layer.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_hyper_connection_transformer_layer.py
@@ -233,6 +233,21 @@ class TestHyperConnectionModule(unittest.TestCase):
         self.assertEqual(list(h_res.shape), [10, self.n, self.n])
         self.assertEqual(list(h_post.shape), [10, self.n])
 
+    def test_forward_high_precision_mhc_casts_to_float32(self):
+        """high_precision_mhc should compute mHC mappings in float32."""
+        config = _make_hc_config(high_precision_mhc=False)
+        module = HyperConnectionModule(config=config, layer_number=1)
+        x = paddle.randn([2, 4, self.n * self.C]).astype("float16")
+
+        aggregated, h_res, h_post = module(x)
+
+        self.assertEqual(aggregated.dtype, paddle.float32)
+        self.assertEqual(h_res.dtype, paddle.float32)
+        self.assertEqual(h_post.dtype, paddle.float32)
+        self.assertEqual(list(aggregated.shape), [2, 4, self.C])
+        self.assertEqual(list(h_res.shape), [2, 4, self.n, self.n])
+        self.assertEqual(list(h_post.shape), [2, 4, self.n])
+
     # ---------- compute_mappings ----------
 
     def test_compute_mappings_shapes(self):
@@ -412,6 +427,30 @@ class TestHyperConnectionModule(unittest.TestCase):
             training=False,
             fused=False,
         )
+        self.assertFalse(paddle.isnan(result).any().item())
+
+    def test_fused_h_res_h_post_bda_high_precision_fast_path(self):
+        """high_precision_mhc should cast fast-path BDA inputs to float32."""
+        B, S = 2, 4
+        config = _make_hc_config(high_precision_mhc=False)
+        module = HyperConnectionModule(config=config, layer_number=1)
+        x = paddle.randn([B, S, self.n * self.C]).astype("float16")
+        _, h_res, h_post = module(x)
+        layer_output = paddle.randn([B, S, self.C]).astype("float16")
+        bias = paddle.randn([self.C]).astype("float16")
+
+        result = module.fused_h_res_h_post_bda(
+            h_res=h_res,
+            original_residual=x,
+            h_post=h_post,
+            layer_output_with_bias=(layer_output, bias),
+            dropout_prob=0.0,
+            training=False,
+            fused=False,
+        )
+
+        self.assertEqual(result.dtype, paddle.float32)
+        self.assertEqual(list(result.shape), [B, S, self.n * self.C])
         self.assertFalse(paddle.isnan(result).any().item())
 
     # ---------- input_expand / output_contract ----------

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_hyper_connection_transformer_layer.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_hyper_connection_transformer_layer.py
@@ -235,16 +235,16 @@ class TestHyperConnectionModule(unittest.TestCase):
         self.assertEqual(list(h_post.shape), [10, self.n])
 
     def test_forward_high_precision_mhc_switch(self):
-        """high_precision_mhc should cover both forward branches."""
+        """high_precision_mhc should choose float32 or bfloat16 compute output."""
         cases = (
-            (True, "float16", paddle.float32),
-            (False, "float32", paddle.float32),
+            (True, paddle.float32),
+            (False, paddle.bfloat16),
         )
-        for high_precision_mhc, input_dtype, expected_dtype in cases:
+        for high_precision_mhc, expected_dtype in cases:
             with self.subTest(high_precision_mhc=high_precision_mhc):
                 config = _make_hc_config(high_precision_mhc=high_precision_mhc)
                 module = HyperConnectionModule(config=config, layer_number=1)
-                x = paddle.randn([2, 4, self.n * self.C]).astype(input_dtype)
+                x = paddle.randn([2, 4, self.n * self.C]).astype("bfloat16")
 
                 aggregated, h_res, h_post = module(x)
 
@@ -440,20 +440,20 @@ class TestHyperConnectionModule(unittest.TestCase):
         self.assertFalse(paddle.isnan(result).any().item())
 
     def test_fused_h_res_h_post_bda_high_precision_fast_path(self):
-        """high_precision_mhc should cover both fast-path BDA branches."""
+        """high_precision_mhc should choose float32 or bfloat16 BDA output."""
         B, S = 2, 4
         cases = (
-            (True, "float16", paddle.float32),
-            (False, "float32", paddle.float32),
+            (True, paddle.float32),
+            (False, paddle.bfloat16),
         )
-        for high_precision_mhc, input_dtype, expected_dtype in cases:
+        for high_precision_mhc, expected_dtype in cases:
             with self.subTest(high_precision_mhc=high_precision_mhc):
                 config = _make_hc_config(high_precision_mhc=high_precision_mhc)
                 module = HyperConnectionModule(config=config, layer_number=1)
-                x = paddle.randn([B, S, self.n * self.C]).astype(input_dtype)
+                x = paddle.randn([B, S, self.n * self.C]).astype("bfloat16")
                 _, h_res, h_post = module(x)
-                layer_output = paddle.randn([B, S, self.C]).astype(input_dtype)
-                bias = paddle.randn([self.C]).astype(input_dtype)
+                layer_output = paddle.randn([B, S, self.C]).astype("bfloat16")
+                bias = paddle.randn([self.C]).astype("bfloat16")
 
                 result = module.fused_h_res_h_post_bda(
                     h_res=h_res,
@@ -470,7 +470,9 @@ class TestHyperConnectionModule(unittest.TestCase):
                 )
                 self.assertEqual(result.dtype, expected_dtype)
                 self.assertEqual(list(result.shape), [B, S, self.n * self.C])
-                self.assertFalse(paddle.isnan(result).any().item())
+                self.assertFalse(
+                    paddle.isnan(result.astype("float32")).any().item()
+                )
 
     # ---------- input_expand / output_contract ----------
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
User Experience


### PR Types
Bug fixes


### Description
mHC模块使用开关控制计算的精度，fuse算子只能控制传入的激活精度，内部会使用cuTile自己的精度


### 是否引起精度变化
是
