### PR TITLE
Dsv4 align moe kernel

### DIFF
--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -49,7 +49,7 @@ from .fusion_layer_utils import (
 from .moe_expert import GroupedMLPExpert, SonicMoEExpert, StandardMLPExpert
 from .moe_router import TopKRouter
 from .moe_shared_expert import StandardMLPSharedExpert
-from .moe_utils import AddAuxiliaryLoss
+from .moe_utils import AddAuxiliaryLoss, use_accuracy_compatible_kernel
 from .token_dispatcher import (
     AllToAllTokenDispatcher,
     MoEFlexTokenDispatcher,
@@ -57,6 +57,7 @@ from .token_dispatcher import (
 )
 
 logger = logging.getLogger(__name__)
+
 
 # MD5 logging for MoE precision debugging
 _LOG_LAYER_MD5 = os.environ.get("LOG_LAYER_MD5", "0") == "1"
@@ -549,13 +550,32 @@ class MoELayer(nn.Layer):
         chunks = paddle.split(
             dispatched_input, num_or_sections=tokens_per_expert, axis=0
         )
+        scale_chunks = None
+        if use_accuracy_compatible_kernel():
+            per_token_scale = getattr(
+                self.token_dispatcher, "global_input_probs", None
+            )
+            if per_token_scale is None:
+                raise RuntimeError(
+                    "FLAGS_use_accuracy_compatible_kernel requires dispatched "
+                    "router probabilities from the token dispatcher."
+                )
+            scale_chunks = paddle.split(
+                per_token_scale, num_or_sections=tokens_per_expert, axis=0
+            )
         for i, chunk in enumerate(chunks):
             if tokens_per_expert[i] == 0:
                 continue
             chunk = chunk.contiguous()
             current_expert_idx = i + self.moe_rank * self.num_experts_per_device
             expert = self.experts[current_expert_idx]
-            outputs += [expert(chunk)[0]]
+            if scale_chunks is None:
+                expert_output = expert(chunk)[0]
+            else:
+                expert_output = expert(chunk, per_token_scale=scale_chunks[i])[
+                    0
+                ]
+            outputs += [expert_output]
 
         if not outputs:
             return dispatched_input

--- a/src/paddlefleet/transformer/moe/moe_utils.py
+++ b/src/paddlefleet/transformer/moe/moe_utils.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING, Any
 
 import paddle
@@ -42,6 +43,64 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from paddle.distributed.communication.group import Group
+
+
+_USE_ACCURACY_COMPATIBLE_KERNEL = (
+    os.environ.get("FLAGS_use_accuracy_compatible_kernel", "0") == "1"
+)
+
+
+def use_accuracy_compatible_kernel() -> bool:
+    """Unified switch for accuracy-compatible (Megatron-aligned) numeric paths.
+
+    Controlled via the ``FLAGS_use_accuracy_compatible_kernel`` environment
+    variable. When enabled, modules switch to fp32-accumulating / Torch-aligned
+    kernels at the cost of throughput.
+    """
+    return _USE_ACCURACY_COMPATIBLE_KERNEL
+
+
+def _unpermute_scatter(
+    permuted_tokens: paddle.Tensor, sorted_indices: paddle.Tensor, restore_shape
+) -> paddle.Tensor:
+    output_tokens = paddle.zeros(restore_shape, dtype=permuted_tokens.dtype)
+    output_tokens.scatter_(
+        index=sorted_indices, updates=permuted_tokens, overwrite=False
+    )
+    return output_tokens
+
+
+def _unpermute_fp32_accum(
+    permuted_tokens: paddle.Tensor, sorted_indices: paddle.Tensor, restore_shape
+) -> paddle.Tensor:
+    output_tokens = paddle.zeros(restore_shape, dtype="float32")
+    output_tokens.scatter_(
+        index=sorted_indices,
+        updates=permuted_tokens.cast("float32"),
+        overwrite=False,
+    )
+    return output_tokens.cast(permuted_tokens.dtype)
+
+
+class ApplyPermutedProbs(PyLayer):
+    """tokens * probs with fp32-accumulated probs gradient."""
+
+    @staticmethod
+    def forward(ctx, permuted_tokens, permuted_probs):
+        ctx.input_dtype = permuted_tokens.dtype
+        ctx.save_for_backward(permuted_tokens, permuted_probs)
+        return permuted_tokens * permuted_probs.unsqueeze(-1)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        permuted_tokens, permuted_probs = ctx.saved_tensor()
+        grad_tokens = grad_output * permuted_probs.unsqueeze(-1)
+        grad_probs = (
+            permuted_tokens.cast("float32") * grad_output.cast("float32")
+        ).sum(axis=-1)
+        return grad_tokens.cast(ctx.input_dtype), grad_probs.cast(
+            permuted_probs.dtype
+        )
 
 
 def barrier_ep(ep_group):
@@ -113,7 +172,6 @@ def unpermute(
         paddle.Tensor: The tokens restored to their original order.
     """
     assert not drop_and_pad, "token-drop and pads is not supported"
-    _, hidden = restore_shape
 
     if probs is not None:
         assert routing_map is not None, (
@@ -122,22 +180,22 @@ def unpermute(
         permuted_probs = probs.T.contiguous().masked_select(
             routing_map.T.contiguous().cast(paddle.bool)
         )
-        permuted_tokens = permuted_tokens * permuted_probs.unsqueeze(-1)
+        if use_accuracy_compatible_kernel():
+            permuted_tokens = ApplyPermutedProbs.apply(
+                permuted_tokens, permuted_probs
+            )
+        else:
+            permuted_tokens = permuted_tokens * permuted_probs.unsqueeze(-1)
 
-    # Create an output tensor filled with zeros
-    output_tokens = paddle.zeros(restore_shape, dtype=permuted_tokens.dtype)
-    # Scatter add the permuted_input back to the original positions
-    # if scatter_add_ is not None:
-    #     # NOTE: this expand will cause a big memory usage, so disable this method
-    #     sorted_indices = sorted_indices.unsqueeze(1).expand(-1, hidden)
-    #     output_tokens.scatter_add_(0, sorted_indices, permuted_tokens)
-    # else:
-    # NOTE: Calling multiple times of scatter_ will not accumulate,
-    # Instead, it reset to zero and then accumulated again.
-    # so can't do subbatch here.
-    output_tokens.scatter_(
-        index=sorted_indices, updates=permuted_tokens, overwrite=False
-    )
+    if use_accuracy_compatible_kernel():
+        output_tokens = _unpermute_fp32_accum(
+            permuted_tokens, sorted_indices, restore_shape
+        )
+    else:
+        output_tokens = _unpermute_scatter(
+            permuted_tokens, sorted_indices, restore_shape
+        )
+
     return output_tokens
 
 

--- a/src/paddlefleet/transformer/moe/token_dispatcher.py
+++ b/src/paddlefleet/transformer/moe/token_dispatcher.py
@@ -40,10 +40,21 @@ from .moe_utils import (
     permute,
     sort_chunks_by_idxs,
     unpermute,
+    use_accuracy_compatible_kernel,
 )
 
 HAVE_HYBRID_EP = False
 HYBRID_EP_LOAD_CACHED_KERNELS = True
+
+
+def _sort_chunks_like_tokens(
+    input: paddle.Tensor,
+    split_sizes: list[int],
+    sorted_idxs: list[int],
+) -> paddle.Tensor:
+    chunks = paddle.split(input, split_sizes, axis=0)
+    return paddle.concat([chunks[i] for i in sorted_idxs], axis=0)
+
 
 try:
     from paddlefleet_ops import is_hybrid_ep_available
@@ -966,6 +977,19 @@ class AllToAllTokenDispatcher(nn.Layer):
             permutated_local_input_tokens,
             self.reversed_local_input_permutation_mapping,
         ) = permute(reshaped_input, self.routing_map)
+        if use_accuracy_compatible_kernel():
+            num_routed_tokens = int(tokens_per_expert.sum().item())
+            routing_map = self.routing_map.cast(paddle.bool).T.contiguous()
+            flat_sorted = paddle.argsort(
+                routing_map.reshape([-1]).cast("int32"),
+                descending=True,
+                stable=True,
+            )[:num_routed_tokens]
+            self.permuted_local_probs = paddle.index_select(
+                self.probs.T.contiguous().reshape([-1]),
+                flat_sorted,
+                axis=0,
+            )
         self.permutated_local_input_tokens_shape = (
             permutated_local_input_tokens.shape
         )
@@ -987,6 +1011,17 @@ class AllToAllTokenDispatcher(nn.Layer):
             in_split_sizes=self.input_split_sizes,
             group=self.moe_group,
         )
+        if use_accuracy_compatible_kernel():
+            # Match Megatron's all-to-all backward numerics by routing probs through a
+            # 2D [tokens, 1] tensor, like hidden-state dispatch.
+            global_input_probs_2d = _AllToAll.apply(
+                [self.output_shape_tokens[0], 1],
+                self.permuted_local_probs.unsqueeze(-1),
+                out_split_sizes=self.output_splits,
+                in_split_sizes=self.input_split_sizes,
+                group=self.moe_group,
+            )
+            self.global_input_probs = global_input_probs_2d.squeeze(-1)
 
         return global_input_tokens, None
 
@@ -1005,11 +1040,21 @@ class AllToAllTokenDispatcher(nn.Layer):
         ).T.ravel()
 
         if self.num_local_experts > 1 and not self.is_empty_tokens:
+            split_sizes_list = (
+                self.num_global_tokens_per_local_expert.ravel().tolist()
+            )
+            sorted_idxs_list = self.sort_input_by_local_experts.tolist()
             global_input_tokens, _ = sort_chunks_by_idxs(
                 global_input_tokens,
                 self.num_global_tokens_per_local_expert.ravel(),
                 self.sort_input_by_local_experts,
             )
+            if use_accuracy_compatible_kernel():
+                self.global_input_probs = _sort_chunks_like_tokens(
+                    self.global_input_probs,
+                    split_sizes_list,
+                    sorted_idxs_list,
+                )
         sorted_tokens = global_input_tokens
         self.tokens_per_expert_post_gather = self.tokens_per_expert
         return sorted_tokens, self.tokens_per_expert_post_gather
@@ -1043,7 +1088,7 @@ class AllToAllTokenDispatcher(nn.Layer):
             permutated_local_input_tokens,
             self.reversed_local_input_permutation_mapping,
             restore_shape=self.reshaped_input_shape,
-            probs=self.probs,
+            probs=(None if use_accuracy_compatible_kernel() else self.probs),
             routing_map=self.routing_map,
         )
 


### PR DESCRIPTION
### PR Category
Performance Optimization

### PR Types
New features

### Description
新增 `FLAGS_use_accuracy_compatible_kernel` 环境变量开关，当启用时：
- `token_dispatcher.py`：在 AllToAll dispatch 阶段同步传输 router probs（2D 张量），并在 postprocess 阶段按 expert 顺序重排；
- `moe_layer.py`：将 per-token router prob 作为 `per_token_scale` 参数传给各 expert；
- `moe_utils.py`：`unpermute` 改用 fp32 累积 scatter（`_unpermute_fp32_accum`）及带 fp32 梯度累积的 `ApplyPermutedProbs` PyLayer，对齐 Megatron/DSv4 数值路径。

### 是否引起精度变化
是（仅在 `FLAGS_use_accuracy_compatible_kernel=1` 时生效，默认关闭不影响现有路径）