### PR TITLE
Support MLA + SWA to be more flexible.

### DIFF
--- a/src/paddlefleet/fusions/fused_softmax.py
+++ b/src/paddlefleet/fusions/fused_softmax.py
@@ -47,7 +47,7 @@ class SoftmaxOne(nn.Layer):
         # qk: [b, np, sq, sk] --> [b, np, sq, sk+1]
         qk = paddle.concat([x, sink], axis=-1)
         # do softmax, and remove sink token at the end
-        ret = paddle.softmax(qk, axis=-1)[..., :-1]
+        ret = paddle.nn.functional.softmax(qk, axis=-1)[..., :-1]
         return ret
 
 

--- a/src/paddlefleet/gpt_builders.py
+++ b/src/paddlefleet/gpt_builders.py
@@ -99,7 +99,11 @@ def gpt_builder(config, **kwargs):
         position_embedding_type=config.position_embedding_type,
         rotary_percent=config.rotary_percent,
         rotary_base=config.rope_theta,
-        swa_rotary_base=config.swa_rope_theta,
+        swa_rotary_base=(
+            config.swa_rope_theta
+            if config.swa_rope_theta is not None
+            else config.rope_theta
+        ),
         rope_scaling=config.rope_scaling,
         parallel_output=config.parallel_output,
     )

--- a/src/paddlefleet/models/gpt/gpt_embedding.py
+++ b/src/paddlefleet/models/gpt/gpt_embedding.py
@@ -123,10 +123,18 @@ class GPTEmbedding(FleetLayer):
                     )
                 self.swa_rotary_pos_emb = build_spec_layer(
                     sublayers_spec.rope_embedding,
-                    head_dim=config.swa_head_dim,
+                    head_dim=(
+                        config.swa_head_dim
+                        if config.swa_head_dim is not None
+                        else config.head_dim
+                    ),
                     rotary_percent=rotary_percent,
                     rotary_interleaved=config.rotary_interleaved,
-                    rotary_base=swa_rotary_base,
+                    rotary_base=(
+                        swa_rotary_base
+                        if swa_rotary_base is not None
+                        else rotary_base
+                    ),
                     rope_scaling=rope_scaling,
                 )
 

--- a/src/paddlefleet/transformer/attention.py
+++ b/src/paddlefleet/transformer/attention.py
@@ -49,6 +49,7 @@ from paddlefleet.tensor_parallel.mappings import (
 )
 from paddlefleet.transformer.layer import FleetLayer
 from paddlefleet.transformer.utils import (
+    get_real_layer_idx_for_swa,
     is_layer_window_attention,
 )
 from paddlefleet.utils import divide, get_pg_rank, get_pg_size
@@ -224,22 +225,12 @@ class Attention(FleetLayer, ABC):
         self.is_swa = False
 
         if self.config.sliding_window is not None:
-            if self.is_mtp_layer:
-                for_swa_layer_number = (
-                    self.layer_number + self.config.num_hidden_layers
-                )
-            else:
-                # for non-mtp layer, layer_number add num_empty_layers_add_in_head in
-                # src/paddlefleet/models/gpt/gpt_layer_specs.py#L533
-                # real_layer_number = layer_number + config.num_empty_layers_add_in_head
-                for_swa_layer_number = (
-                    self.layer_number - self.config.num_empty_layers_add_in_head
-                )
-                assert for_swa_layer_number >= 0, (
-                    f"for_swa_layer_number must be non-negative, but got {for_swa_layer_number} "
-                    f"(layer_number={self.layer_number}, "
-                    f"num_empty_layers_add_in_head={self.config.num_empty_layers_add_in_head})"
-                )
+            for_swa_layer_number = get_real_layer_idx_for_swa(
+                self.layer_number,
+                self.config.num_empty_layers_add_in_head,
+                is_mtp=self.is_mtp_layer,
+                num_hidden_layers=self.config.num_hidden_layers,
+            )
 
             if is_layer_window_attention(
                 self.config.sliding_window,
@@ -249,11 +240,51 @@ class Attention(FleetLayer, ABC):
                 self.is_swa = True
 
         if self.is_swa:
-            self.head_dim = self.config.swa_head_dim
-            self.v_head_dim = self.config.swa_v_head_dim
-            self.num_attention_heads = self.config.swa_num_attention_heads
-            self.num_key_value_heads = self.config.swa_num_key_value_heads
-            self.rope_theta = self.config.swa_rope_theta
+            if not self.config.multi_latent_attention:
+                self.head_dim = (
+                    self.config.swa_head_dim
+                    if self.config.swa_head_dim is not None
+                    else self.config.head_dim
+                )
+                self.v_head_dim = (
+                    self.config.swa_v_head_dim
+                    if self.config.swa_v_head_dim is not None
+                    else (
+                        self.config.v_head_dim
+                        if isinstance(self.config.v_head_dim, int)
+                        else self.config.head_dim
+                    )
+                )
+                self.num_attention_heads = (
+                    self.config.swa_num_attention_heads
+                    if self.config.swa_num_attention_heads is not None
+                    else self.config.num_attention_heads
+                )
+                self.num_key_value_heads = (
+                    self.config.swa_num_key_value_heads
+                    if self.config.swa_num_key_value_heads is not None
+                    else self.config.num_key_value_heads
+                )
+                self.rope_theta = (
+                    self.config.swa_rope_theta
+                    if self.config.swa_rope_theta is not None
+                    else self.config.rope_theta
+                )
+            else:
+                # MLA-SWA is still an SWA layer for mask/window semantics, but
+                # ordinary swa_* structural overrides are only for non-MLA attention.
+                # Use full-attention defaults here only as temporary base Attention
+                # dims; MultiLatentAttention applies MLA-specific effective dims,
+                # including MLA-SWA overrides, after super().__init__.
+                self.head_dim = self.config.head_dim
+                self.v_head_dim = (
+                    self.config.v_head_dim
+                    if isinstance(self.config.v_head_dim, int)
+                    else self.config.head_dim
+                )
+                self.num_attention_heads = self.config.num_attention_heads
+                self.num_key_value_heads = self.config.num_key_value_heads
+                self.rope_theta = self.config.rope_theta
         else:
             self.head_dim = self.config.head_dim
             self.v_head_dim = (

--- a/src/paddlefleet/transformer/dot_product_attention.py
+++ b/src/paddlefleet/transformer/dot_product_attention.py
@@ -291,6 +291,7 @@ class DotProductAttention(FleetLayer):
             )
 
         use_eager = self.config._attn_implementation == "eager"
+        use_sdpa = self.config._attn_implementation == "sdpa"
 
         if use_eager and packed_seq_params is not None:
             raise ValueError(
@@ -340,6 +341,17 @@ class DotProductAttention(FleetLayer):
             else:
                 flashmask_attention_func = flashmask_attention
 
+            # Apply sliding window to packed sequence path
+            if self.sliding_window is not None:
+                attn_mask_startend_row_indices = (
+                    startend_row_indices_add_sliding_window(
+                        attn_mask_startend_row_indices,
+                        self.sliding_window,
+                        self.head_wise_swa_ratio,
+                        value.shape[2],
+                    )
+                )
+
             attn_output = flashmask_attention_func(
                 query.astype(value.dtype),
                 key.astype(value.dtype),
@@ -354,7 +366,15 @@ class DotProductAttention(FleetLayer):
             (query.dtype == paddle.bfloat16 or query.dtype == paddle.float16)
             and attn_mask_startend_row_indices is None
             and not use_eager
+            and (self.sliding_window is None or use_sdpa)
         ):
+            if self.sliding_window is not None:
+                raise NotImplementedError(
+                    '_attn_implementation="sdpa" does not support SWA because '
+                    "the SDPA path does not construct a sliding-window mask. "
+                    'Use _attn_implementation="default" or "eager" for SWA.'
+                )
+
             # KV cache support for inference
             if use_cache and past_key_values is not None:
                 key, value = past_key_values.update(key, value, layer_idx)
@@ -451,6 +471,12 @@ class DotProductAttention(FleetLayer):
             attn_output = attn_output.reshape([bsz, q_len, -1])
 
             return attn_output
+
+        if self.sliding_window is not None and self.head_wise_swa_ratio != 0.0:
+            raise NotImplementedError(
+                "head-wise SWA is only supported by flashmask startend paths; "
+                "raw attention does not support per-head sliding-window masks."
+            )
 
         # ===================================
         # Raw attention scores. [b, n/p, s, s]

--- a/src/paddlefleet/transformer/multi_latent_attention.py
+++ b/src/paddlefleet/transformer/multi_latent_attention.py
@@ -50,7 +50,7 @@ from paddlefleet.tensor_parallel.mappings import (
 from paddlefleet.transformer.attention import Attention
 from paddlefleet.transformer.enums import AttnMaskType
 from paddlefleet.transformer.transformer_config import TransformerConfig
-from paddlefleet.utils import get_pg_rank, get_pg_size
+from paddlefleet.utils import divide, get_pg_rank, get_pg_size
 
 try:
     from paddlefleet.transformer.dot_product_attention import (
@@ -260,11 +260,34 @@ class MultiLatentAttention(Attention):
             is_mtp_layer=is_mtp_layer,
         )
         self.config: TransformerConfig
+        effective_mla_dims = self.config.get_effective_mla_dims(self.is_swa)
+        self.num_attention_heads = effective_mla_dims["num_attention_heads"]
+        self.num_key_value_heads = effective_mla_dims["num_key_value_heads"]
+        self.qk_nope_head_dim = effective_mla_dims["qk_nope_head_dim"]
+        self.qk_rope_head_dim = effective_mla_dims["qk_rope_head_dim"]
+        self.kv_lora_rank = effective_mla_dims["kv_lora_rank"]
+        self.q_lora_rank = effective_mla_dims["q_lora_rank"]
+        self.v_head_dim = effective_mla_dims["v_head_dim"]
+        self.rope_theta = effective_mla_dims["rope_theta"]
+        self.q_head_dim = self.qk_nope_head_dim + self.qk_rope_head_dim
 
-        self.out_projection_size = self.v_head_dim * self.num_attention_heads
+        self.query_projection_size = self.v_head_dim * self.num_attention_heads
+        self.key_projection_size = self.q_head_dim * self.num_attention_heads
+        self.value_projection_size = self.v_head_dim * self.num_attention_heads
+        self.out_projection_size = self.query_projection_size
 
-        self.q_head_dim = (
-            self.config.qk_nope_head_dim + self.config.qk_rope_head_dim
+        world_size = get_pg_size(self.pg_collection.tp)
+        self.hidden_size_per_attention_head = divide(
+            self.query_projection_size, self.num_attention_heads
+        )
+        self.value_hidden_size_per_attention_head = divide(
+            self.value_projection_size, self.num_attention_heads
+        )
+        self.num_attention_heads_per_partition = divide(
+            self.num_attention_heads, world_size
+        )
+        self.num_query_groups_per_partition = (
+            self.num_attention_heads_per_partition
         )
 
         mscale = _yarn_get_mscale(
@@ -274,7 +297,7 @@ class MultiLatentAttention(Attention):
 
         if self.config.rope_type == "rope":
             self.rotary_pos_emb = RotaryEmbedding(
-                self.config.qk_rope_head_dim,
+                self.qk_rope_head_dim,
                 rotary_interleaved=self.config.rotary_interleaved,
                 rotary_percent=1.0,
                 rotary_base=self.rope_theta,
@@ -282,7 +305,7 @@ class MultiLatentAttention(Attention):
             )
         elif self.config.rope_type == "yarn":
             self.rotary_pos_emb = YarnRotaryEmbedding(
-                self.config.qk_rope_head_dim,
+                self.qk_rope_head_dim,
                 rotary_interleaved=self.config.rotary_interleaved,
                 rotary_base=self.rope_theta,
                 scaling_factor=self.config.rotary_scaling_factor,
@@ -311,7 +334,7 @@ class MultiLatentAttention(Attention):
             k_channels=self.q_head_dim,
             v_channels=self.v_head_dim,
             num_attention_heads=self.num_attention_heads,
-            num_key_value_heads=1,
+            num_key_value_heads=self.num_attention_heads,
             cp_comm_type=cp_comm_type,
             pg_collection=self.pg_collection,
         )
@@ -374,9 +397,19 @@ class MultiLatentAttention(Attention):
             q_absorbed: [b, s, heads, kv_lora_rank + qk_rope_head_dim]
             wv_b: [heads, kv_lora_rank, v_head_dim]
         """
-        qk_nope_head_dim = self.config.qk_nope_head_dim
-        qk_rope_head_dim = self.config.qk_rope_head_dim
-        kv_lora_rank = self.config.kv_lora_rank
+        if self.is_swa:
+            # Q absorption itself is shape-compatible with SWA. Keep SWA disabled
+            # here because the downstream absorbed decode path has no visible
+            # Python-side support for SWA cache cropping/window semantics. Do not
+            # allow SWA layers to enter it until the FD consumer is verified to
+            # apply sliding-window constraints.
+            raise NotImplementedError(
+                "MLA+SWA does not support absorbed decode kernel yet. "
+                "Disable the absorbed decode path or use a non-SWA layer."
+            )
+        qk_nope_head_dim = self.qk_nope_head_dim
+        qk_rope_head_dim = self.qk_rope_head_dim
+        kv_lora_rank = self.kv_lora_rank
         v_head_dim = self.v_head_dim
         num_heads = self.num_attention_heads_per_partition
 
@@ -632,7 +665,7 @@ class MLASelfAttention(MultiLatentAttention):
             is_mtp_layer=is_mtp_layer,
         )
 
-        if self.config.q_lora_rank is None:
+        if self.q_lora_rank is None:
             # Not projecting query
             self.q_proj = build_spec_layer(
                 sublayers_spec.q_proj,
@@ -651,7 +684,7 @@ class MLASelfAttention(MultiLatentAttention):
             self.q_a_proj = build_spec_layer(
                 sublayers_spec.q_a_proj,
                 self.config.hidden_size,
-                self.config.q_lora_rank,
+                self.q_lora_rank,
                 config=self.config,
                 init_method=self.config.init_method,
                 bias=False,
@@ -664,7 +697,7 @@ class MLASelfAttention(MultiLatentAttention):
 
             self.q_b_proj = build_spec_layer(
                 sublayers_spec.q_b_proj,
-                self.config.q_lora_rank,
+                self.q_lora_rank,
                 self.num_attention_heads * self.q_head_dim,
                 config=self.config,
                 init_method=self.config.init_method,
@@ -679,7 +712,7 @@ class MLASelfAttention(MultiLatentAttention):
         self.kv_a_proj_with_mqa = build_spec_layer(
             sublayers_spec.kv_a_proj_with_mqa,
             self.config.hidden_size,
-            self.config.kv_lora_rank + self.config.qk_rope_head_dim,
+            self.kv_lora_rank + self.qk_rope_head_dim,
             config=self.config,
             init_method=self.config.init_method,
             bias=False,
@@ -692,9 +725,9 @@ class MLASelfAttention(MultiLatentAttention):
 
         self.kv_b_proj = build_spec_layer(
             sublayers_spec.kv_b_proj,
-            self.config.kv_lora_rank,
+            self.kv_lora_rank,
             self.num_attention_heads
-            * (self.config.qk_nope_head_dim + self.v_head_dim),
+            * (self.qk_nope_head_dim + self.v_head_dim),
             config=self.config,
             init_method=self.config.init_method,
             gather_output=False,
@@ -705,17 +738,17 @@ class MLASelfAttention(MultiLatentAttention):
             tp_group=pg_collection.tp,
         )
 
-        if self.config.q_lora_rank is not None:
+        if self.q_lora_rank is not None:
             self.q_a_layernorm = build_spec_layer(
                 sublayers_spec.q_a_layernorm,
-                hidden_size=self.config.q_lora_rank,
+                hidden_size=self.q_lora_rank,
                 config=self.config,
                 eps=self.config.rms_norm_eps,
             )
 
         self.kv_a_layernorm = build_spec_layer(
             sublayers_spec.kv_a_layernorm,
-            hidden_size=self.config.kv_lora_rank,
+            hidden_size=self.kv_lora_rank,
             config=self.config,
             eps=self.config.rms_norm_eps,
         )
@@ -802,7 +835,7 @@ class MLASelfAttention(MultiLatentAttention):
         # =========================================
         # QKV down projection and layernorm
         # =========================================
-        if self.config.q_lora_rank is not None:
+        if self.q_lora_rank is not None:
             # if q_a_proj is ColumnParallelLinear:
             #     q_compressed: [b, s, q_lora_rank / TP]
             q_compressed, _ = self.q_a_proj(hidden_states)
@@ -810,7 +843,7 @@ class MLASelfAttention(MultiLatentAttention):
             # When output is sharded (ColumnParallelLinear):
             # Gather output to restore output dim q_lora_rank;
             # Scatter sequence back to s / TP if sequence-parallel
-            if q_compressed.size(-1) != self.config.q_lora_rank:
+            if q_compressed.size(-1) != self.q_lora_rank:
                 q_compressed = gather_from_tensor_model_parallel_region(
                     q_compressed
                 )
@@ -824,16 +857,13 @@ class MLASelfAttention(MultiLatentAttention):
         # if kv_a_proj_with_mqa is ColumnParallelLinear:
         #     kv_combined: [b, s, (kv_lora_rank + qk_rope_head_dim) / TP]
         kv_combined, _ = self.kv_a_proj_with_mqa(hidden_states)
-        if (
-            kv_combined.size(-1)
-            != self.config.kv_lora_rank + self.config.qk_rope_head_dim
-        ):
+        if kv_combined.size(-1) != self.kv_lora_rank + self.qk_rope_head_dim:
             # kv_combined: [b, s, (kv_lora_rank + qk_rope_head_dim)]
             kv_combined = gather_from_tensor_model_parallel_region(kv_combined)
             # kv_compressed:[b, s, kv_lora_rank], k_pos_emb: [b, s, qk_rope_head_dim]
             kv_compressed, k_pos_emb = paddle.split(
                 kv_combined,
-                [self.config.kv_lora_rank, self.config.qk_rope_head_dim],
+                [self.kv_lora_rank, self.qk_rope_head_dim],
                 axis=-1,
             )
             if self.config.sequence_parallel:
@@ -845,7 +875,7 @@ class MLASelfAttention(MultiLatentAttention):
             # kv_compressed:[b, s / TP, kv_lora_rank], k_pos_emb: [b, s / TP, qk_rope_head_dim]
             kv_compressed, k_pos_emb = paddle.split(
                 kv_combined,
-                [self.config.kv_lora_rank, self.config.qk_rope_head_dim],
+                [self.kv_lora_rank, self.qk_rope_head_dim],
                 axis=-1,
             )
             if (
@@ -869,7 +899,7 @@ class MLASelfAttention(MultiLatentAttention):
         # Apply norm
         # =========================================
 
-        if self.config.q_lora_rank is not None:
+        if self.q_lora_rank is not None:
             # q_compressed: [num_tokens, q_lora_rank]
             q_compressed = self.q_a_layernorm(q_compressed)
 
@@ -902,7 +932,7 @@ class MLASelfAttention(MultiLatentAttention):
             otherwise, they maintain the unpacked shape [b, s, ...]. In subsequent code comments,
             we uniformly use [num_tokens, ...] to denote [b, s, ...] or [t, ...] for two cases.
             """
-            if self.config.q_lora_rank is not None:
+            if self.q_lora_rank is not None:
                 # q_compressed: [num_tokens, q_lora_rank]
                 # q: [num_tokens, n * (qk_nope_head_dim + qk_rope_head_dim)]
                 q, _ = self.q_b_proj(q_compressed)
@@ -929,7 +959,7 @@ class MLASelfAttention(MultiLatentAttention):
             kv = kv.view(
                 *kv.size()[:-1],
                 self.num_attention_heads_per_partition,
-                self.config.qk_nope_head_dim + self.v_head_dim,
+                self.qk_nope_head_dim + self.v_head_dim,
             )
 
             # if self.layer_number == 0:
@@ -972,8 +1002,8 @@ class MLASelfAttention(MultiLatentAttention):
                     q,
                     cos,
                     sin,
-                    self.config.qk_nope_head_dim,
-                    self.config.qk_rope_head_dim,
+                    self.qk_nope_head_dim,
+                    self.qk_rope_head_dim,
                     cu_seqlens_q,
                     cp_rank,
                     cp_size,
@@ -983,8 +1013,8 @@ class MLASelfAttention(MultiLatentAttention):
                     k_pos_emb,
                     cos,
                     sin,
-                    self.config.qk_rope_head_dim,
-                    self.config.qk_nope_head_dim,
+                    self.qk_rope_head_dim,
+                    self.qk_nope_head_dim,
                     self.v_head_dim,
                     cu_seqlens_kv,
                     cp_rank,
@@ -997,7 +1027,7 @@ class MLASelfAttention(MultiLatentAttention):
                         "apply_rope_fusion does not support dynamic inference yet."
                     )
 
-                k_pe = None
+                k_pe = key[..., :1, self.qk_nope_head_dim :]
             else:
                 # Determine seq length:
                 #   packed 3D [t, n, d]      -> dim 0
@@ -1046,14 +1076,14 @@ class MLASelfAttention(MultiLatentAttention):
                             )
 
                 # Replace paddle.split with zero-copy slice views.
-                q_no_pe = q[..., : self.config.qk_nope_head_dim]
-                q_pos_emb = q[..., self.config.qk_nope_head_dim :]
+                q_no_pe = q[..., : self.qk_nope_head_dim]
+                q_pos_emb = q[..., self.qk_nope_head_dim :]
 
                 # k_no_pe: [num_tokens, n, qk_nope_head_dim]
                 # value: [num_tokens, n, v_head_dim]
                 k_no_pe, value = paddle.split(
                     kv,
-                    [self.config.qk_nope_head_dim, self.v_head_dim],
+                    [self.qk_nope_head_dim, self.v_head_dim],
                     axis=-1,
                 )
 
@@ -1161,7 +1191,7 @@ class MLASelfAttention(MultiLatentAttention):
 
     def _backward_q_proj(self):
         """Computes weight gradients of Q projection layers"""
-        if self.config.q_lora_rank is None:
+        if self.q_lora_rank is None:
             self.q_proj.backward_dw()
         else:
             self.q_a_proj.backward_dw()

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -218,20 +218,32 @@ class TransformerConfig(ModelParallelConfig):
     """Whether to add a learnable attention sink bias for sliding window attention (SWA) layers.
     When True, softmax_type is promoted to 'learnable' for SWA layers."""
 
-    swa_head_dim: int = 192
-    """Dimension of query/key heads for sliding window attention layers."""
+    swa_head_dim: int | None = None
+    """Dimension of query/key heads for sliding window attention layers. If None, inherit head_dim."""
 
-    swa_v_head_dim: int = 128
-    """Dimension of value heads for sliding window attention layers."""
+    swa_v_head_dim: int | None = None
+    """Dimension of value heads for sliding window attention layers. If None, inherit v_head_dim."""
 
-    swa_num_attention_heads: int = 64
-    """Number of attention heads for sliding window attention layers."""
+    swa_num_attention_heads: int | None = None
+    """Number of attention heads for sliding window attention layers. If None, inherit num_attention_heads."""
 
-    swa_num_key_value_heads: int = 8
-    """Number of key/value heads (GQA groups) for sliding window attention layers."""
+    swa_num_key_value_heads: int | None = None
+    """Number of key/value heads (GQA groups) for sliding window attention layers. If None, inherit num_key_value_heads."""
 
-    swa_rope_theta: float = 10000
-    """The base period of the RoPE embeddings for sliding window attention layers."""
+    swa_rope_theta: float | None = None
+    """The base period of the RoPE embeddings for sliding window attention layers. If None, inherit rope_theta."""
+
+    swa_qk_nope_head_dim: int | None = None
+    """Dimension of non-positional QK heads for MLA sliding window attention layers. If None, inherit qk_nope_head_dim."""
+
+    swa_qk_rope_head_dim: int | None = None
+    """Dimension of RoPE QK heads for MLA sliding window attention layers. If None, inherit qk_rope_head_dim."""
+
+    swa_kv_lora_rank: int | None = None
+    """Rank of KV low-rank representation for MLA sliding window attention layers. If None, inherit kv_lora_rank."""
+
+    swa_q_lora_rank: int | None = None
+    """Rank of Q low-rank representation for MLA sliding window attention layers. If None, inherit q_lora_rank."""
 
     head_wise_swa_ratio: float = 0.0
     """Ratio of KV heads that use sliding window attention within an SWA layer.
@@ -920,6 +932,90 @@ class TransformerConfig(ModelParallelConfig):
     def get(self, key: str, default=None):
         return getattr(self, key, default)
 
+    def get_effective_mla_dims(self, is_swa: bool) -> dict:
+        """Return layer-wise MLA dimensions, with SWA fields inheriting full MLA by default."""
+        if not is_swa:
+            return {
+                "num_attention_heads": self.num_attention_heads,
+                "num_key_value_heads": self.num_key_value_heads,
+                "qk_nope_head_dim": self.qk_nope_head_dim,
+                "qk_rope_head_dim": self.qk_rope_head_dim,
+                "kv_lora_rank": self.kv_lora_rank,
+                "q_lora_rank": self.q_lora_rank,
+                "v_head_dim": self.v_head_dim,
+                "rope_theta": self.rope_theta,
+            }
+
+        def inherit_swa(swa_key: str, full_key: str):
+            value = getattr(self, swa_key)
+            if value is None:
+                return getattr(self, full_key)
+            return value
+
+        return {
+            "num_attention_heads": inherit_swa(
+                "swa_num_attention_heads", "num_attention_heads"
+            ),
+            "num_key_value_heads": inherit_swa(
+                "swa_num_key_value_heads", "num_key_value_heads"
+            ),
+            "qk_nope_head_dim": inherit_swa(
+                "swa_qk_nope_head_dim", "qk_nope_head_dim"
+            ),
+            "qk_rope_head_dim": inherit_swa(
+                "swa_qk_rope_head_dim", "qk_rope_head_dim"
+            ),
+            "kv_lora_rank": inherit_swa("swa_kv_lora_rank", "kv_lora_rank"),
+            "q_lora_rank": inherit_swa("swa_q_lora_rank", "q_lora_rank"),
+            "v_head_dim": inherit_swa("swa_v_head_dim", "v_head_dim"),
+            "rope_theta": inherit_swa("swa_rope_theta", "rope_theta"),
+        }
+
+    def mla_swa_uses_overridden_dims(self) -> bool:
+        full_dims = self.get_effective_mla_dims(is_swa=False)
+        swa_dims = self.get_effective_mla_dims(is_swa=True)
+        return any(full_dims[key] != swa_dims[key] for key in full_dims)
+
+    def _validate_effective_mla_dims(self, is_swa: bool) -> dict:
+        dims = self.get_effective_mla_dims(is_swa=is_swa)
+        layer_type = "SWA" if is_swa else "full"
+        for key in (
+            "num_attention_heads",
+            "num_key_value_heads",
+            "qk_nope_head_dim",
+            "qk_rope_head_dim",
+            "kv_lora_rank",
+            "v_head_dim",
+        ):
+            if dims[key] is None or dims[key] <= 0:
+                raise ValueError(
+                    f"MLA {layer_type} {key} must be positive, got {dims[key]}."
+                )
+        if dims["q_lora_rank"] is not None and dims["q_lora_rank"] <= 0:
+            raise ValueError(
+                f"MLA {layer_type} q_lora_rank must be positive or None, got {dims['q_lora_rank']}."
+            )
+        if dims["rope_theta"] is None or dims["rope_theta"] <= 0:
+            raise ValueError(
+                f"MLA {layer_type} rope_theta must be positive, got {dims['rope_theta']}."
+            )
+        if dims["num_attention_heads"] % self.tensor_model_parallel_size != 0:
+            raise ValueError(
+                f"MLA {layer_type} num_attention_heads ({dims['num_attention_heads']}) must be a multiple of "
+                f"tensor_model_parallel_size ({self.tensor_model_parallel_size})."
+            )
+        if dims["num_key_value_heads"] % self.tensor_model_parallel_size != 0:
+            raise ValueError(
+                f"MLA {layer_type} num_key_value_heads ({dims['num_key_value_heads']}) must be a multiple of "
+                f"tensor_model_parallel_size ({self.tensor_model_parallel_size})."
+            )
+        if dims["num_attention_heads"] % dims["num_key_value_heads"] != 0:
+            raise ValueError(
+                f"MLA {layer_type} num_attention_heads ({dims['num_attention_heads']}) must be divisible by "
+                f"num_key_value_heads ({dims['num_key_value_heads']})."
+            )
+        return dims
+
     def __post_init__(self):
         """Python dataclass method that is used to modify attributes after initialization.
         See https://docs.python.org/3/library/dataclasses.html#post-init-processing for more
@@ -1073,6 +1169,32 @@ class TransformerConfig(ModelParallelConfig):
                 #  init method for this layer. Since we are here after an OR we know that
                 #  init_method is not None
                 self.embedding_init_method = self.init_method
+
+        # MLA + SWA validation and sliding_window normalization
+        if self.sliding_window is not None:
+            left, right = self.sliding_window
+            if left == -1 and right == -1:
+                # Both sides infinite = no window constraint
+                self.sliding_window = None
+
+        if self.multi_latent_attention and self.sliding_window is not None:
+            if self.context_parallel_size > 1:
+                raise NotImplementedError(
+                    "MLA+SWA does not support context parallel yet. "
+                    "Please disable CP or disable sliding_window."
+                )
+            swa_dims = self._validate_effective_mla_dims(is_swa=True)
+            if (
+                self.swa_head_dim is not None
+                and self.swa_head_dim
+                != swa_dims["qk_nope_head_dim"] + swa_dims["qk_rope_head_dim"]
+            ):
+                raise ValueError(
+                    "swa_head_dim must equal effective SWA MLA qk_nope_head_dim + "
+                    "qk_rope_head_dim when configured, but got "
+                    f"{self.swa_head_dim} vs "
+                    f"{swa_dims['qk_nope_head_dim']} + {swa_dims['qk_rope_head_dim']}."
+                )
 
         # DSv4 Hybrid Attention validation
         if self.experimental_attention_variant == "dsv4_hybrid":

--- a/src/paddlefleet/transformer/utils.py
+++ b/src/paddlefleet/transformer/utils.py
@@ -69,7 +69,7 @@ def is_layer_window_attention(
     window_attn_skip_freq: int | list,
     layer_number: int,
 ) -> bool:
-    # layer_number is 0-indexed
+    # layer_number is 0-indexed (the real layer index, without num_empty_layers_add_in_head offset)
     if not sliding_window:
         return False
     if window_attn_skip_freq is None:
@@ -83,6 +83,42 @@ def is_layer_window_attention(
         f"Invalid `window_attn_skip_freq`: {type(window_attn_skip_freq)}, "
         f"{window_attn_skip_freq}"
     )
+
+
+def get_real_layer_idx_for_swa(
+    layer_number: int,
+    num_empty_layers_add_in_head: int,
+    is_mtp: bool = False,
+    num_hidden_layers: int = 0,
+) -> int:
+    """Convert internal layer_number to the 0-indexed real layer index for SWA decisions.
+
+    In Fleet runtime, layer_number includes the num_empty_layers_add_in_head offset
+    (added in gpt_layer_specs.py). This helper strips that offset so that
+    is_layer_window_attention() receives a consistent 0-indexed layer number.
+
+    For MTP layers, layer_number is relative to the MTP block, so we add
+    num_hidden_layers to get the global layer index.
+
+    Args:
+        layer_number: The layer_number as seen in Attention.__init__ (may include offset).
+        num_empty_layers_add_in_head: The offset added in gpt_layer_specs.
+        is_mtp: Whether this is an MTP (multi-token prediction) layer.
+        num_hidden_layers: Total number of hidden layers (needed for MTP offset).
+
+    Returns:
+        0-indexed real layer index for use with is_layer_window_attention().
+    """
+    if is_mtp:
+        return layer_number + num_hidden_layers
+    else:
+        real_idx = layer_number - num_empty_layers_add_in_head
+        assert real_idx >= 0, (
+            f"real_layer_idx must be non-negative, but got {real_idx} "
+            f"(layer_number={layer_number}, "
+            f"num_empty_layers_add_in_head={num_empty_layers_add_in_head})"
+        )
+        return real_idx
 
 
 def startend_row_indices_add_sliding_window(

--- a/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_softmax.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_softmax.py
@@ -75,17 +75,22 @@ class TestSoftmaxOneForward(unittest.TestCase):
                 "paddle.softmax compat API does not accept 'axis' in this version"
             )
 
-    def test_output_sums_approximately_one(self):
-        """Test that output rows sum approximately to 1."""
+    def test_output_sums_exclude_sink_probability(self):
+        """Test that output rows sum to one minus the off-by-one sink probability."""
         np_dim = 1
-        layer = SoftmaxOne(denominator_offset=paddle.to_tensor([1.0] * np_dim))
+        offset = paddle.to_tensor([1.0] * np_dim)
+        layer = SoftmaxOne(denominator_offset=offset)
         x = paddle.randn([1, np_dim, 1, 8])
         try:
             result = layer(x)
-            row_sum = result.sum(axis=-1)
+            sink = offset.reshape([1, -1, 1, 1]).expand([1, np_dim, 1, 1])
+            expected = paddle.nn.functional.softmax(
+                paddle.concat([x, sink], axis=-1), axis=-1
+            )[..., :-1]
             np.testing.assert_allclose(
-                row_sum.numpy(), np.ones([1, np_dim, 1]), atol=1e-5
+                result.numpy(), expected.numpy(), atol=1e-5
             )
+            self.assertTrue((result.sum(axis=-1) < 1.0).all())
         except TypeError:
             self.skipTest(
                 "paddle.softmax compat API does not accept 'axis' in this version"

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_dot_product_attention_4.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_dot_product_attention_4.py
@@ -157,7 +157,7 @@ class TestDotProductAttentionSlidingWindow(unittest.TestCase):
     def test_sliding_window_construction(self):
         """Test construction with sliding window."""
         config = _make_config(
-            sliding_window=2,
+            sliding_window=(2, 0),
             window_attn_skip_freq=None,
         )
         attn = DotProductAttention(

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_multi_latent_attention.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_multi_latent_attention.py
@@ -142,6 +142,17 @@ class TestMultiLatentAttentionRopeTypeValidation(unittest.TestCase):
         config.qk_nope_head_dim = 8
         config.qk_rope_head_dim = 8
         config.q_lora_rank = 8
+        config.hidden_size = 64
+        config.get_effective_mla_dims.return_value = {
+            "num_attention_heads": 4,
+            "num_key_value_heads": 4,
+            "qk_nope_head_dim": 8,
+            "qk_rope_head_dim": 8,
+            "kv_lora_rank": 16,
+            "q_lora_rank": 8,
+            "v_head_dim": 16,
+            "rope_theta": 10000.0,
+        }
 
         spec = MLASelfAttentionSublayersSpec(
             q_a_layernorm=MagicMock(),
@@ -157,6 +168,10 @@ class TestMultiLatentAttentionRopeTypeValidation(unittest.TestCase):
             self_inner.config = config
             self_inner.v_head_dim = config.v_head_dim
             self_inner.num_attention_heads = config.num_attention_heads
+            self_inner.layer_number = 1
+            self_inner.attn_mask_type = MagicMock()
+            self_inner.attention_type = "self"
+            self_inner.pg_collection = MagicMock(tp=None, cp=None)
             self_inner.is_swa = False
             self_inner.is_mtp_layer = False
 

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_multi_latent_attention_2.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_multi_latent_attention_2.py
@@ -83,6 +83,7 @@ class TestMLASelfAttentionBackwardDW(unittest.TestCase):
 
             mla = MLASelfAttention.__new__(MLASelfAttention)
             mla.config = config
+            object.__setattr__(mla, "q_lora_rank", q_lora_rank)
             mla.kv_b_proj = MagicMock()
             mla.kv_a_proj_with_mqa = MagicMock()
             mla.o_proj = MagicMock()

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_multi_latent_attention_4.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_multi_latent_attention_4.py
@@ -44,6 +44,8 @@ def _make_mla_self_attn(**attrs):
         object.__setattr__(attn, "_non_persistable_buffers", set())
         for k, v in attrs.items():
             object.__setattr__(attn, k, v)
+        if "config" in attrs:
+            object.__setattr__(attn, "q_lora_rank", attrs["config"].q_lora_rank)
         return attn
 
 

--- a/tests/single_card_tests/test_swa_gqa.py
+++ b/tests/single_card_tests/test_swa_gqa.py
@@ -293,11 +293,11 @@ class TestTransformerConfigSWAFields(unittest.TestCase):
     def test_default_swa_fields(self):
         """SWA fields should have correct defaults."""
         config = TransformerConfig(num_hidden_layers=4)
-        self.assertEqual(config.swa_head_dim, 192)
-        self.assertEqual(config.swa_v_head_dim, 128)
-        self.assertEqual(config.swa_num_attention_heads, 64)
-        self.assertEqual(config.swa_num_key_value_heads, 8)
-        self.assertEqual(config.swa_rope_theta, 10000)
+        self.assertIsNone(config.swa_head_dim)
+        self.assertIsNone(config.swa_v_head_dim)
+        self.assertIsNone(config.swa_num_attention_heads)
+        self.assertIsNone(config.swa_num_key_value_heads)
+        self.assertIsNone(config.swa_rope_theta)
         self.assertEqual(config.head_wise_swa_ratio, 0.0)
         self.assertIsNone(config.attention_value_scale)
         self.assertFalse(config.add_full_attention_sink_bias)

--- a/tests/single_card_tests/test_swa_mla.py
+++ b/tests/single_card_tests/test_swa_mla.py
@@ -1,0 +1,1091 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for MLA + Sliding Window Attention (SWA) support.
+
+Covers:
+- is_swa propagation to MLA core_attention
+- layer-effective MLA SWA dimension inheritance and overrides
+- SDPA path does not bypass SWA
+- packed path applies SWA
+- TransformerConfig MLA+SWA validation
+- full/SWA pattern consistency
+- attention sink parameter alignment
+- 4-column startend_row_indices sliding window
+- gradient correctness (window outside tokens have zero gradient)
+"""
+
+import unittest
+
+import paddle
+
+from paddlefleet.training.initialize import initialize_fleet
+from paddlefleet.transformer.dot_product_attention import DotProductAttention
+from paddlefleet.transformer.enums import AttnMaskType
+from paddlefleet.transformer.multi_latent_attention import (
+    MLASelfAttention,
+    MLASelfAttentionSublayersSpec,
+)
+from paddlefleet.transformer.transformer_config import TransformerConfig
+from paddlefleet.transformer.utils import (
+    get_real_layer_idx_for_swa,
+    is_layer_window_attention,
+    startend_row_indices_add_sliding_window,
+)
+from paddlefleet.utils import (
+    init_method_normal,
+    scaled_init_method_normal,
+)
+
+strategy = paddle.distributed.fleet.DistributedStrategy()
+initialize_fleet(strategy=strategy)
+
+
+class BiasedLinear(paddle.nn.Layer):
+    def __init__(self, in_features, out_features, **kwargs):
+        super().__init__()
+        self.linear = paddle.nn.Linear(in_features, out_features)
+
+    def forward(self, x):
+        return self.linear(x), self.linear.bias
+
+
+class RMSNorm(paddle.nn.Layer):
+    def __init__(self, **kwargs):
+        super().__init__()
+        hidden_size = kwargs.get("normalized_shape", kwargs.get("hidden_size"))
+        eps = kwargs.get("norm_eps", kwargs.get("eps"))
+        self.weight = paddle.nn.Parameter(paddle.ones([hidden_size]))
+        self.eps = eps
+
+    def forward(self, x):
+        d_norm = paddle.rsqrt(x.pow(2).mean(axis=-1, keepdim=True) + self.eps)
+        return x * d_norm * self.weight
+
+
+# ============================================================================
+# Helper: MLA config factory
+# ============================================================================
+
+
+def _make_mla_config(
+    sliding_window=(4096, 0),
+    window_attn_skip_freq=4,
+    num_hidden_layers=8,
+    add_swa_attention_sink_bias=True,
+    add_full_attention_sink_bias=False,
+    head_wise_swa_ratio=0.0,
+):
+    """Create a TransformerConfig with MLA + SWA enabled."""
+    config = TransformerConfig(
+        num_hidden_layers=num_hidden_layers,
+        hidden_size=256,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        head_dim=64,
+        v_head_dim=64,
+        sliding_window=sliding_window,
+        window_attn_skip_freq=window_attn_skip_freq,
+        # MLA params
+        multi_latent_attention=True,
+        q_lora_rank=128,
+        qk_nope_head_dim=48,
+        qk_rope_head_dim=16,
+        kv_lora_rank=128,
+        rope_type="rope",
+        rope_theta=10000.0,
+        head_wise_swa_ratio=head_wise_swa_ratio,
+        add_swa_attention_sink_bias=add_swa_attention_sink_bias,
+        add_full_attention_sink_bias=add_full_attention_sink_bias,
+    )
+    config.rotary_interleaved = False
+    config.rotary_scaling_factor = 1.0
+    config.original_max_position_embeddings = 4096
+    config.beta_fast = 32.0
+    config.beta_slow = 1.0
+    config.mscale = 1.0
+    config.mscale_all_dim = 0.0
+    config.softmax_scale = None
+    config.use_bias = False
+    config.no_rope_freq = None
+    config.recompute_granularity = None
+    config.fused_single_qkv_rope = False
+    config.init_method = init_method_normal(0.02)
+    config.output_layer_init_method = scaled_init_method_normal(0.02, 1, 2.0)
+    config.rms_norm_eps = 1e-5
+    config.context_parallel_size = 1
+    config.apply_query_key_layer_scaling = False
+    config.fp16 = False
+    config.bf16 = False
+    config.masked_softmax_fusion = False
+    config.attention_softmax_in_fp32 = True
+    config.attention_dropout = 0.0
+    config.softmax_type = "vanilla"
+    config.gated_attention = False
+    config.attention_value_scale = None
+    return config
+
+
+def _mla_sublayers_spec():
+    return MLASelfAttentionSublayersSpec(
+        q_proj=BiasedLinear,
+        q_a_proj=BiasedLinear,
+        q_b_proj=BiasedLinear,
+        kv_a_proj_with_mqa=BiasedLinear,
+        kv_b_proj=BiasedLinear,
+        core_attention=DotProductAttention,
+        o_proj=BiasedLinear,
+        q_a_layernorm=RMSNorm,
+        kv_a_layernorm=RMSNorm,
+        gate_proj=BiasedLinear,
+    )
+
+
+# ============================================================================
+# Test: is_swa propagation to core_attention
+# ============================================================================
+
+
+class TestMLASWAIsSWAPropagation(unittest.TestCase):
+    """Test that is_swa is correctly propagated from MLA to core_attention."""
+
+    def test_mla_swa_layer_core_attention_receives_is_swa(self):
+        """MLA SWA layer's core_attention should have is_swa=True."""
+        config = _make_mla_config(
+            sliding_window=(3, 0),
+            window_attn_skip_freq=None,  # All layers are SWA
+        )
+
+        # DotProductAttention is the core_attention used by MLA
+        # Simulate what MLA does: pass is_swa=True
+        core_attn = DotProductAttention(
+            config=config,
+            layer_number=0,
+            attn_mask_type=AttnMaskType.causal,
+            attention_type="self",
+            is_swa=True,
+            k_channels=64,
+            v_channels=64,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+        )
+
+        self.assertTrue(core_attn.is_swa)
+        self.assertEqual(core_attn.sliding_window, (3, 0))
+
+    def test_mla_full_layer_core_attention_no_swa(self):
+        """MLA full attention layer's core_attention should have is_swa=False."""
+        config = _make_mla_config(
+            sliding_window=(3, 0),
+            window_attn_skip_freq=4,
+        )
+
+        core_attn = DotProductAttention(
+            config=config,
+            layer_number=0,
+            attn_mask_type=AttnMaskType.causal,
+            attention_type="self",
+            is_swa=False,
+            k_channels=64,
+            v_channels=64,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+        )
+
+        self.assertFalse(core_attn.is_swa)
+        self.assertIsNone(core_attn.sliding_window)
+
+
+# ============================================================================
+# Test: MLA layer-effective SWA dimensions
+# ============================================================================
+
+
+class TestMLAEffectiveSWADims(unittest.TestCase):
+    """Test layer-effective MLA dimensions for full and SWA layers."""
+
+    def test_mla_swa_layer_inherits_full_dims_by_default(self):
+        config = TransformerConfig(
+            num_hidden_layers=4,
+            hidden_size=256,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            v_head_dim=64,
+            multi_latent_attention=True,
+            sliding_window=(4096, 0),
+            window_attn_skip_freq=None,
+            qk_nope_head_dim=48,
+            qk_rope_head_dim=16,
+            kv_lora_rank=128,
+            q_lora_rank=96,
+            rope_theta=10000.0,
+            head_wise_swa_ratio=0.0,
+        )
+
+        full_dims = config.get_effective_mla_dims(is_swa=False)
+        swa_dims = config.get_effective_mla_dims(is_swa=True)
+        self.assertEqual(swa_dims, full_dims)
+        self.assertFalse(config.mla_swa_uses_overridden_dims())
+
+    def test_mla_swa_layer_uses_explicit_overrides(self):
+        config = TransformerConfig(
+            num_hidden_layers=4,
+            hidden_size=512,
+            num_attention_heads=8,
+            num_key_value_heads=4,
+            v_head_dim=64,
+            multi_latent_attention=True,
+            sliding_window=(4096, 0),
+            window_attn_skip_freq=None,
+            qk_nope_head_dim=48,
+            qk_rope_head_dim=16,
+            kv_lora_rank=128,
+            q_lora_rank=96,
+            rope_theta=10000.0,
+            swa_num_attention_heads=4,
+            swa_num_key_value_heads=2,
+            swa_v_head_dim=32,
+            swa_rope_theta=20000.0,
+            swa_qk_nope_head_dim=32,
+            swa_qk_rope_head_dim=8,
+            swa_kv_lora_rank=64,
+            swa_q_lora_rank=48,
+            swa_head_dim=40,
+            head_wise_swa_ratio=0.0,
+        )
+
+        self.assertEqual(
+            config.get_effective_mla_dims(is_swa=False),
+            {
+                "num_attention_heads": 8,
+                "num_key_value_heads": 4,
+                "qk_nope_head_dim": 48,
+                "qk_rope_head_dim": 16,
+                "kv_lora_rank": 128,
+                "q_lora_rank": 96,
+                "v_head_dim": 64,
+                "rope_theta": 10000.0,
+            },
+        )
+        self.assertEqual(
+            config.get_effective_mla_dims(is_swa=True),
+            {
+                "num_attention_heads": 4,
+                "num_key_value_heads": 2,
+                "qk_nope_head_dim": 32,
+                "qk_rope_head_dim": 8,
+                "kv_lora_rank": 64,
+                "q_lora_rank": 48,
+                "v_head_dim": 32,
+                "rope_theta": 20000.0,
+            },
+        )
+        self.assertTrue(config.mla_swa_uses_overridden_dims())
+
+    def test_mla_swa_partial_overrides_inherit_remaining_dims(self):
+        config = TransformerConfig(
+            num_hidden_layers=4,
+            hidden_size=512,
+            num_attention_heads=8,
+            num_key_value_heads=4,
+            v_head_dim=64,
+            multi_latent_attention=True,
+            sliding_window=(4096, 0),
+            window_attn_skip_freq=None,
+            qk_nope_head_dim=48,
+            qk_rope_head_dim=16,
+            kv_lora_rank=128,
+            q_lora_rank=96,
+            rope_theta=10000.0,
+            swa_qk_nope_head_dim=32,
+            swa_kv_lora_rank=64,
+            head_wise_swa_ratio=0.0,
+        )
+
+        self.assertEqual(
+            config.get_effective_mla_dims(is_swa=True),
+            {
+                "num_attention_heads": 8,
+                "num_key_value_heads": 4,
+                "qk_nope_head_dim": 32,
+                "qk_rope_head_dim": 16,
+                "kv_lora_rank": 64,
+                "q_lora_rank": 96,
+                "v_head_dim": 64,
+                "rope_theta": 10000.0,
+            },
+        )
+
+
+# ============================================================================
+# Test: full/SWA pattern consistency
+# ============================================================================
+
+
+class TestMLASelfAttentionEffectiveShapes(unittest.TestCase):
+    """Test true MLASelfAttention construction with layer-effective dims."""
+
+    def _build_attn(self, config, layer_number):
+        return MLASelfAttention(
+            config,
+            _mla_sublayers_spec(),
+            layer_number=layer_number,
+            attn_mask_type=AttnMaskType.causal,
+        )
+
+    def _assert_mla_shapes(self, attn, dims):
+        q_head_dim = dims["qk_nope_head_dim"] + dims["qk_rope_head_dim"]
+        self.assertEqual(attn.num_attention_heads, dims["num_attention_heads"])
+        self.assertEqual(attn.num_key_value_heads, dims["num_key_value_heads"])
+        self.assertEqual(attn.qk_nope_head_dim, dims["qk_nope_head_dim"])
+        self.assertEqual(attn.qk_rope_head_dim, dims["qk_rope_head_dim"])
+        self.assertEqual(attn.kv_lora_rank, dims["kv_lora_rank"])
+        self.assertEqual(attn.q_lora_rank, dims["q_lora_rank"])
+        self.assertEqual(attn.v_head_dim, dims["v_head_dim"])
+        self.assertEqual(attn.rope_theta, dims["rope_theta"])
+        self.assertEqual(attn.q_head_dim, q_head_dim)
+        self.assertEqual(
+            attn.query_projection_size,
+            dims["v_head_dim"] * dims["num_attention_heads"],
+        )
+        self.assertEqual(
+            attn.o_proj.linear.weight.shape,
+            [attn.query_projection_size, attn.config.hidden_size],
+        )
+        self.assertEqual(
+            attn.q_a_proj.linear.weight.shape,
+            [attn.config.hidden_size, dims["q_lora_rank"]],
+        )
+        self.assertEqual(
+            attn.q_b_proj.linear.weight.shape,
+            [dims["q_lora_rank"], dims["num_attention_heads"] * q_head_dim],
+        )
+        self.assertEqual(attn.q_a_layernorm.weight.shape, [dims["q_lora_rank"]])
+        self.assertEqual(
+            attn.kv_a_proj_with_mqa.linear.weight.shape,
+            [
+                attn.config.hidden_size,
+                dims["kv_lora_rank"] + dims["qk_rope_head_dim"],
+            ],
+        )
+        self.assertEqual(
+            attn.kv_b_proj.linear.weight.shape,
+            [
+                dims["kv_lora_rank"],
+                dims["num_attention_heads"]
+                * (dims["qk_nope_head_dim"] + dims["v_head_dim"]),
+            ],
+        )
+        self.assertEqual(
+            attn.kv_a_layernorm.weight.shape, [dims["kv_lora_rank"]]
+        )
+        self.assertEqual(attn.core_attention.k_channels, q_head_dim)
+        self.assertEqual(attn.core_attention.v_channels, dims["v_head_dim"])
+        self.assertEqual(
+            attn.core_attention.num_attention_heads, dims["num_attention_heads"]
+        )
+        self.assertEqual(
+            attn.core_attention.num_key_value_heads, dims["num_attention_heads"]
+        )
+
+    def test_full_and_swa_layers_use_layer_effective_shapes(self):
+        config = TransformerConfig(
+            num_hidden_layers=4,
+            hidden_size=512,
+            num_attention_heads=8,
+            num_key_value_heads=4,
+            v_head_dim=64,
+            multi_latent_attention=True,
+            sliding_window=(4096, 0),
+            window_attn_skip_freq=2,
+            qk_nope_head_dim=48,
+            qk_rope_head_dim=16,
+            kv_lora_rank=128,
+            q_lora_rank=96,
+            rope_theta=10000.0,
+            swa_num_attention_heads=4,
+            swa_num_key_value_heads=2,
+            swa_v_head_dim=32,
+            swa_rope_theta=20000.0,
+            swa_qk_nope_head_dim=32,
+            swa_qk_rope_head_dim=8,
+            swa_kv_lora_rank=64,
+            swa_q_lora_rank=48,
+            swa_head_dim=40,
+            head_wise_swa_ratio=0.0,
+            rope_type="rope",
+            gated_attention=True,
+        )
+
+        full_attn = self._build_attn(config, layer_number=0)
+        swa_attn = self._build_attn(config, layer_number=1)
+
+        self.assertFalse(full_attn.is_swa)
+        self.assertTrue(swa_attn.is_swa)
+        self.assertFalse(full_attn.core_attention.is_swa)
+        self.assertTrue(swa_attn.core_attention.is_swa)
+        self._assert_mla_shapes(
+            full_attn, config.get_effective_mla_dims(is_swa=False)
+        )
+        self._assert_mla_shapes(
+            swa_attn, config.get_effective_mla_dims(is_swa=True)
+        )
+        self.assertEqual(
+            swa_attn.gate_proj.linear.weight.shape,
+            [config.hidden_size, 32 * 4],
+        )
+
+    def test_swa_layer_constructs_with_inherited_shapes(self):
+        config = TransformerConfig(
+            num_hidden_layers=2,
+            hidden_size=256,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            v_head_dim=64,
+            multi_latent_attention=True,
+            sliding_window=(4096, 0),
+            window_attn_skip_freq=None,
+            qk_nope_head_dim=48,
+            qk_rope_head_dim=16,
+            kv_lora_rank=128,
+            q_lora_rank=96,
+            rope_theta=10000.0,
+            head_wise_swa_ratio=0.0,
+            rope_type="rope",
+        )
+
+        attn = self._build_attn(config, layer_number=0)
+        self.assertTrue(attn.is_swa)
+        self._assert_mla_shapes(
+            attn, config.get_effective_mla_dims(is_swa=True)
+        )
+
+    def test_absorbed_decode_guard_for_swa_layer(self):
+        config = _make_mla_config(
+            sliding_window=(4, 0), window_attn_skip_freq=None
+        )
+        attn = self._build_attn(config, layer_number=0)
+        query = paddle.randn([1, 1, attn.num_attention_heads, attn.q_head_dim])
+        with self.assertRaises(NotImplementedError):
+            attn._compute_absorbed_q(query)
+
+    def test_fused_rope_matches_unfused_for_hetero_mla_swa(self):
+        def make_config(apply_rope_fusion):
+            config = TransformerConfig(
+                num_hidden_layers=2,
+                hidden_size=256,
+                num_attention_heads=4,
+                num_key_value_heads=2,
+                v_head_dim=64,
+                multi_latent_attention=True,
+                sliding_window=(4096, 0),
+                window_attn_skip_freq=None,
+                qk_nope_head_dim=48,
+                qk_rope_head_dim=16,
+                kv_lora_rank=128,
+                q_lora_rank=96,
+                rope_theta=10000.0,
+                swa_qk_nope_head_dim=32,
+                swa_qk_rope_head_dim=8,
+                swa_kv_lora_rank=64,
+                swa_q_lora_rank=48,
+                swa_v_head_dim=32,
+                swa_head_dim=40,
+                head_wise_swa_ratio=0.0,
+                rope_type="rope",
+                apply_rope_fusion=apply_rope_fusion,
+            )
+            config.rotary_interleaved = False
+            config.use_bias = False
+            config.no_rope_freq = None
+            config.recompute_granularity = None
+            config.fused_single_qkv_rope = False
+            config.init_method = init_method_normal(0.02)
+            config.output_layer_init_method = scaled_init_method_normal(
+                0.02, 1, 2.0
+            )
+            config.rms_norm_eps = 1e-5
+            config.context_parallel_size = 1
+            config.apply_query_key_layer_scaling = False
+            config.fp16 = False
+            config.bf16 = False
+            config.masked_softmax_fusion = False
+            config.attention_softmax_in_fp32 = True
+            config.attention_dropout = 0.0
+            config.softmax_type = "vanilla"
+            config.gated_attention = False
+            config.attention_value_scale = None
+            return config
+
+        paddle.manual_seed(2026)
+        unfused_attn = self._build_attn(make_config(False), layer_number=0)
+        fused_attn = self._build_attn(make_config(True), layer_number=0)
+        fused_attn.set_state_dict(unfused_attn.state_dict())
+        unfused_attn.train()
+        fused_attn.train()
+
+        paddle.manual_seed(2027)
+        hidden_states = paddle.randn([1, 4, 256])
+
+        unfused_outputs = unfused_attn.get_query_key_value_tensors(
+            hidden_states
+        )
+        fused_outputs = fused_attn.get_query_key_value_tensors(hidden_states)
+
+        for name, unfused, fused in zip(
+            ("query", "key", "value"), unfused_outputs[:3], fused_outputs[:3]
+        ):
+            self.assertEqual(unfused.shape, fused.shape, name)
+            self.assertTrue(
+                paddle.allclose(unfused, fused, atol=1e-5, rtol=1e-5).item(),
+                f"{name} max diff: {(unfused - fused).abs().max().item()}",
+            )
+
+
+class TestMLASWAPatternConsistency(unittest.TestCase):
+    """Test that full/SWA pattern is consistent across different callers."""
+
+    def test_window_attn_skip_freq_4_pattern(self):
+        """With skip_freq=4, layer 0,4,8 are full; 1,2,3,5,6,7 are SWA."""
+        sliding_window = (4096, 0)
+        skip_freq = 4
+
+        expected = [
+            False,  # layer 0: full (0 % 4 == 0)
+            True,  # layer 1: SWA
+            True,  # layer 2: SWA
+            True,  # layer 3: SWA
+            False,  # layer 4: full (4 % 4 == 0)
+            True,  # layer 5: SWA
+            True,  # layer 6: SWA
+            True,  # layer 7: SWA
+        ]
+
+        for i in range(8):
+            result = is_layer_window_attention(sliding_window, skip_freq, i)
+            self.assertEqual(
+                result,
+                expected[i],
+                f"Layer {i}: expected is_swa={expected[i]}, got {result}",
+            )
+
+    def test_get_real_layer_idx_for_swa_normal(self):
+        """Normal layer: real_idx = layer_number - num_empty_layers_add_in_head."""
+        # layer_number=5, offset=2 -> real_idx=3
+        self.assertEqual(get_real_layer_idx_for_swa(5, 2), 3)
+        self.assertEqual(get_real_layer_idx_for_swa(0, 0), 0)
+        self.assertEqual(get_real_layer_idx_for_swa(3, 3), 0)
+
+    def test_get_real_layer_idx_for_swa_mtp(self):
+        """MTP layer: real_idx = layer_number + num_hidden_layers."""
+        self.assertEqual(
+            get_real_layer_idx_for_swa(0, 2, is_mtp=True, num_hidden_layers=8),
+            8,
+        )
+        self.assertEqual(
+            get_real_layer_idx_for_swa(1, 2, is_mtp=True, num_hidden_layers=8),
+            9,
+        )
+
+    def test_get_real_layer_idx_for_swa_negative_raises(self):
+        """Negative real_idx should raise AssertionError."""
+        with self.assertRaises(AssertionError):
+            get_real_layer_idx_for_swa(1, 5)  # 1 - 5 = -4
+
+
+# ============================================================================
+# Test: SDPA path does not bypass SWA
+# ============================================================================
+
+
+class TestSDPAPathDoesNotBypassSWA(unittest.TestCase):
+    """Test that SDPA fast path is disabled when sliding_window is set."""
+
+    def test_swa_core_attention_has_sliding_window(self):
+        """Core attention with is_swa=True should store sliding_window."""
+        config = _make_mla_config(sliding_window=(16, 0))
+
+        core_attn = DotProductAttention(
+            config=config,
+            layer_number=0,
+            attn_mask_type=AttnMaskType.causal,
+            attention_type="self",
+            is_swa=True,
+            k_channels=64,
+            v_channels=64,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+        )
+
+        # sliding_window should be set, which will prevent SDPA fast path
+        self.assertIsNotNone(core_attn.sliding_window)
+        self.assertEqual(core_attn.sliding_window, (16, 0))
+
+    def test_explicit_sdpa_with_swa_raises(self):
+        """Explicit SDPA should not silently fall back to raw attention for SWA."""
+        config = _make_mla_config(sliding_window=(16, 0))
+        config._attn_implementation = "sdpa"
+
+        core_attn = DotProductAttention(
+            config=config,
+            layer_number=0,
+            attn_mask_type=AttnMaskType.causal,
+            attention_type="self",
+            is_swa=True,
+            k_channels=64,
+            v_channels=64,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+        )
+        query = paddle.randn([1, 4, 4, 64], dtype=paddle.float16)
+        key = paddle.randn([1, 4, 4, 64], dtype=paddle.float16)
+        value = paddle.randn([1, 4, 4, 64], dtype=paddle.float16)
+
+        with self.assertRaises(NotImplementedError):
+            core_attn(query, key, value, attention_mask=None)
+
+    def test_head_wise_swa_raw_path_raises(self):
+        """Head-wise SWA should not silently run as all-head SWA in raw attention."""
+        config = _make_mla_config(
+            sliding_window=(16, 0), head_wise_swa_ratio=0.5
+        )
+        config._attn_implementation = "eager"
+
+        core_attn = DotProductAttention(
+            config=config,
+            layer_number=0,
+            attn_mask_type=AttnMaskType.causal,
+            attention_type="self",
+            is_swa=True,
+            k_channels=64,
+            v_channels=64,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+        )
+        query = paddle.randn([1, 4, 4, 64])
+        key = paddle.randn([1, 4, 4, 64])
+        value = paddle.randn([1, 4, 4, 64])
+
+        with self.assertRaises(NotImplementedError):
+            core_attn(query, key, value, attention_mask=None)
+
+
+# ============================================================================
+# Test: attention sink parameter alignment
+# ============================================================================
+
+
+class TestAttentionSinkAlignment(unittest.TestCase):
+    """Test that attention sink parameters are created correctly for MLA+SWA."""
+
+    def test_mla_swa_layer_has_softmax_offset(self):
+        """MLA SWA layer with add_swa_attention_sink_bias should have learnable softmax_offset."""
+        config = _make_mla_config(
+            add_swa_attention_sink_bias=True,
+            add_full_attention_sink_bias=False,
+        )
+        config.softmax_type = "vanilla"
+
+        core_attn = DotProductAttention(
+            config=config,
+            layer_number=0,
+            attn_mask_type=AttnMaskType.causal,
+            attention_type="self",
+            is_swa=True,
+            k_channels=64,
+            v_channels=64,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+        )
+
+        # SWA layer should have learnable softmax_offset (promoted to "learnable")
+        self.assertIsNotNone(core_attn.softmax_offset)
+        # It should be a Parameter (learnable)
+        self.assertTrue(hasattr(core_attn.softmax_offset, "stop_gradient"))
+        self.assertFalse(core_attn.softmax_offset.stop_gradient)
+
+    def test_mla_full_layer_no_softmax_offset(self):
+        """MLA full layer without add_full_attention_sink_bias should not have softmax_offset."""
+        config = _make_mla_config(
+            add_swa_attention_sink_bias=True,
+            add_full_attention_sink_bias=False,
+        )
+        config.softmax_type = "vanilla"
+
+        core_attn = DotProductAttention(
+            config=config,
+            layer_number=0,
+            attn_mask_type=AttnMaskType.causal,
+            attention_type="self",
+            is_swa=False,  # Full attention layer
+            k_channels=64,
+            v_channels=64,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+        )
+
+        # Full layer should NOT have softmax_offset (vanilla type)
+        self.assertIsNone(core_attn.softmax_offset)
+
+
+# ============================================================================
+# Test: TransformerConfig MLA+SWA validation
+# ============================================================================
+
+
+class TestTransformerConfigMLASWAValidation(unittest.TestCase):
+    """Test MLA+SWA config validation in __post_init__."""
+
+    def test_mla_swa_head_wise_config_passes(self):
+        """MLA+SWA may configure head-wise SWA for supported flashmask paths."""
+        config = _make_mla_config(head_wise_swa_ratio=0.5)
+        self.assertEqual(config.head_wise_swa_ratio, 0.5)
+
+    def test_mla_swa_cp_raises(self):
+        """MLA+SWA with context_parallel_size > 1 should raise NotImplementedError."""
+        with self.assertRaises(NotImplementedError):
+            TransformerConfig(
+                num_hidden_layers=4,
+                multi_latent_attention=True,
+                sliding_window=(4096, 0),
+                context_parallel_size=2,
+            )
+
+    def test_mla_swa_valid_config_passes(self):
+        """MLA+SWA with valid config should not raise."""
+        config = TransformerConfig(
+            num_hidden_layers=4,
+            hidden_size=256,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            v_head_dim=64,
+            multi_latent_attention=True,
+            sliding_window=(4096, 0),
+            window_attn_skip_freq=4,
+            qk_nope_head_dim=48,
+            qk_rope_head_dim=16,
+            kv_lora_rank=128,
+            q_lora_rank=96,
+            head_wise_swa_ratio=0.0,
+            context_parallel_size=1,
+        )
+        self.assertTrue(config.multi_latent_attention)
+        self.assertEqual(config.sliding_window, (4096, 0))
+
+    def test_sliding_window_both_infinite_normalized_to_none(self):
+        """sliding_window=(-1, -1) should be normalized to None."""
+        config = TransformerConfig(
+            num_hidden_layers=4,
+            sliding_window=(-1, -1),
+        )
+        self.assertIsNone(config.sliding_window)
+
+    def test_sliding_window_single_infinite_preserved(self):
+        """sliding_window=(4096, -1) should be preserved (single-side infinite)."""
+        config = TransformerConfig(
+            num_hidden_layers=4,
+            sliding_window=(4096, -1),
+        )
+        self.assertEqual(config.sliding_window, (4096, -1))
+
+    def test_mla_swa_head_dim_mismatch_raises(self):
+        """swa_head_dim validates the effective SWA MLA qk split when configured."""
+        with self.assertRaises(ValueError):
+            TransformerConfig(
+                num_hidden_layers=4,
+                hidden_size=512,
+                num_attention_heads=8,
+                num_key_value_heads=4,
+                v_head_dim=64,
+                multi_latent_attention=True,
+                sliding_window=(4096, 0),
+                window_attn_skip_freq=None,
+                qk_nope_head_dim=48,
+                qk_rope_head_dim=16,
+                kv_lora_rank=128,
+                q_lora_rank=96,
+                swa_qk_nope_head_dim=32,
+                swa_qk_rope_head_dim=8,
+                swa_head_dim=41,
+                head_wise_swa_ratio=0.0,
+            )
+
+
+# ============================================================================
+# Test: MLA+SWA reference alignment (small scale)
+# ============================================================================
+
+
+class TestMLASWAReferenceAlignment(unittest.TestCase):
+    """Test MLA+SWA output matches manual sliding window mask computation."""
+
+    def _manual_swa_attention(
+        self, query, key, value, window_size, softmax_scale
+    ):
+        """Compute attention with manual sliding window causal mask.
+
+        Fleet's sliding_window[0] semantics: token i can attend [i - window_size, i]
+        (window_size steps to the left, plus self = window_size + 1 tokens total).
+
+        Args:
+            query: [B, S, H, D]
+            key: [B, S, H, D]
+            value: [B, S, H, Dv]
+            window_size: left window size (number of steps to the left)
+            softmax_scale: scaling factor
+
+        Returns:
+            output: [B, S, H, Dv]
+        """
+        B, S, H, D = query.shape
+        Dv = value.shape[-1]
+
+        # Transpose to [B, H, S, D]
+        q = query.transpose([0, 2, 1, 3])
+        k = key.transpose([0, 2, 1, 3])
+        v = value.transpose([0, 2, 1, 3])
+
+        # Compute attention scores [B, H, S, S]
+        scores = paddle.matmul(q, k, transpose_y=True) * softmax_scale
+
+        # Create causal + sliding window mask matching Fleet's get_sliding_window_causal_mask
+        # token i can see [max(0, i - window_size), i] inclusive
+        mask = paddle.full([S, S], float("-inf"))
+        for i in range(S):
+            start = max(0, i - window_size)
+            for j in range(start, i + 1):
+                mask[i, j] = 0.0
+
+        scores = scores + mask.unsqueeze(0).unsqueeze(0)
+
+        # Softmax
+        attn_weights = paddle.nn.functional.softmax(scores, axis=-1)
+
+        # Weighted sum
+        output = paddle.matmul(attn_weights, v)  # [B, H, S, Dv]
+        return output.transpose([0, 2, 1, 3])  # [B, S, H, Dv]
+
+    def test_small_scale_forward_alignment(self):
+        """Small-scale MLA+SWA forward should match manual computation."""
+        B, S, H, D = 1, 8, 2, 16
+        window_size = 3
+        softmax_scale = 1.0 / (D**0.5)
+
+        paddle.seed(42)
+        query = paddle.randn([B, S, H, D])
+        key = paddle.randn([B, S, H, D])
+        value = paddle.randn([B, S, H, D])
+
+        # Manual reference
+        ref_output = self._manual_swa_attention(
+            query, key, value, window_size, softmax_scale
+        )
+
+        # Fleet DotProductAttention (eager path with SWA, no attention sink for fair comparison)
+        config = _make_mla_config(
+            sliding_window=(window_size, 0), add_swa_attention_sink_bias=False
+        )
+        config._attn_implementation = "eager"
+
+        core_attn = DotProductAttention(
+            config=config,
+            layer_number=0,
+            attn_mask_type=AttnMaskType.causal,
+            attention_type="self",
+            is_swa=True,
+            softmax_scale=softmax_scale,
+            k_channels=D,
+            v_channels=D,
+            num_attention_heads=H,
+            num_key_value_heads=H,
+        )
+
+        fleet_output = core_attn(
+            query,
+            key,
+            value,
+            attention_mask=None,
+        )
+
+        # Reshape fleet output to match reference shape
+        fleet_output_reshaped = fleet_output.reshape([B, S, H, D])
+
+        self.assertTrue(
+            paddle.allclose(
+                fleet_output_reshaped, ref_output, atol=1e-5, rtol=1e-5
+            ).item(),
+            f"Max diff: {(fleet_output_reshaped - ref_output).abs().max().item()}",
+        )
+
+    def test_medium_scale_window_outside_zero(self):
+        """S=32, window=8: tokens outside window should not be attended."""
+        B, S, H, D = 2, 32, 4, 16
+        window_size = 8  # token i can see [i-8, i]
+        softmax_scale = 1.0 / (D**0.5)
+
+        paddle.seed(123)
+        query = paddle.randn([B, S, H, D])
+        key = paddle.randn([B, S, H, D])
+        value = paddle.randn([B, S, H, D])
+
+        ref_output = self._manual_swa_attention(
+            query, key, value, window_size, softmax_scale
+        )
+
+        # Verify that for position 20 (window=8), positions 0-11 don't contribute
+        # Position 20 can see [12, 20] (i - window_size = 20 - 8 = 12)
+        self.assertEqual(ref_output.shape, [B, S, H, D])
+
+        # Output at position 20 should be the same whether or not tokens 0-11 exist
+        query2 = query.clone()
+        key2 = key.clone()
+        value2 = value.clone()
+        # Zero out positions 0-11 in key/value (outside window for position 20)
+        key2[:, :12, :, :] = 0.0
+        value2[:, :12, :, :] = 0.0
+
+        ref_output2 = self._manual_swa_attention(
+            query2, key2, value2, window_size, softmax_scale
+        )
+
+        # Position 20 output should be identical (positions 0-11 are outside window)
+        self.assertTrue(
+            paddle.allclose(
+                ref_output[:, 20, :, :],
+                ref_output2[:, 20, :, :],
+                atol=1e-6,
+                rtol=1e-6,
+            ).item(),
+            "Position 20 should not be affected by tokens outside window (0-11)",
+        )
+
+
+# ============================================================================
+# Test: gradient correctness
+# ============================================================================
+
+
+class TestMLASWAGradientCorrectness(unittest.TestCase):
+    """Test that SWA mask is correct in backward pass."""
+
+    def test_gradient_isolation_outside_window(self):
+        """Tokens outside the window should have zero gradient contribution."""
+        B, S, H, D = 1, 16, 2, 8
+        window_size = 4
+        softmax_scale = 1.0 / (D**0.5)
+
+        paddle.seed(42)
+
+        config = _make_mla_config(sliding_window=(window_size, 0))
+        config._attn_implementation = "eager"
+
+        core_attn = DotProductAttention(
+            config=config,
+            layer_number=0,
+            attn_mask_type=AttnMaskType.causal,
+            attention_type="self",
+            is_swa=True,
+            softmax_scale=softmax_scale,
+            k_channels=D,
+            v_channels=D,
+            num_attention_heads=H,
+            num_key_value_heads=H,
+        )
+
+        # Test: perturbing position 0's key should NOT affect position 5+'s output
+        # because window=4 means position 5 can only see [2, 3, 4, 5]
+        key_base = paddle.randn([B, S, H, D])
+        query = paddle.randn([B, S, H, D])
+        value = paddle.randn([B, S, H, D])
+
+        # Run 1: baseline
+        key1 = key_base.clone()
+        key1.stop_gradient = False
+        out1 = core_attn(query, key1, value, attention_mask=None)
+        # Take loss only from position 5+
+        loss1 = out1.reshape([B, S, -1])[:, 5:, :].sum()
+        loss1.backward()
+        grad1_pos0 = key1.grad[:, 0, :, :].clone()
+
+        # Gradient at position 0 w.r.t. loss at position 5+ should be zero
+        # because position 0 is outside the window for all positions >= 5
+        self.assertTrue(
+            paddle.allclose(
+                grad1_pos0, paddle.zeros_like(grad1_pos0), atol=1e-7
+            ).item(),
+            f"Position 0 key gradient should be zero for loss at positions 5+. "
+            f"Max abs grad: {grad1_pos0.abs().max().item()}",
+        )
+
+
+# ============================================================================
+# Test: packed sequence with sliding window
+# ============================================================================
+
+
+class TestPackedSequenceSWA(unittest.TestCase):
+    """Test that packed sequence path correctly applies sliding window."""
+
+    def test_packed_path_swa_applied(self):
+        """Packed sequence path should invoke startend_row_indices_add_sliding_window."""
+        # This is an integration-level attribute test:
+        # When DotProductAttention has sliding_window set, the packed path
+        # should call startend_row_indices_add_sliding_window
+        config = _make_mla_config(sliding_window=(4, 0))
+
+        core_attn = DotProductAttention(
+            config=config,
+            layer_number=0,
+            attn_mask_type=AttnMaskType.causal,
+            attention_type="self",
+            is_swa=True,
+            k_channels=64,
+            v_channels=64,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+        )
+
+        # Verify that sliding_window is stored (prerequisite for packed path SWA)
+        self.assertIsNotNone(core_attn.sliding_window)
+        self.assertEqual(core_attn.sliding_window, (4, 0))
+
+    def test_head_wise_swa_num_vec_1_mask(self):
+        """num_vec=1 flashmask startend path supports MLA-style head-wise SWA."""
+        bsz, seq, num_heads = 1, 8, 4
+        indices = (
+            paddle.ones([bsz, num_heads, seq, 1], dtype=paddle.int32) * 10000
+        )
+
+        result = startend_row_indices_add_sliding_window(
+            indices,
+            (3, 0),
+            0.5,
+            num_heads,
+        )
+
+        self.assertTrue(
+            paddle.equal_all(result[:, :2, :, :], indices[:, :2, :, :]).item()
+        )
+        expected_swa = (
+            paddle.arange(3, seq + 3, dtype=paddle.int32)
+            .reshape([1, 1, seq, 1])
+            .expand([bsz, 2, seq, 1])
+        )
+        self.assertTrue(
+            paddle.equal_all(result[:, 2:, :, :], expected_swa).item()
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
  支持 PaddleFleet MLA + SWA 更灵活的配置与运行路径，使 SWA 层可以使用独立的 MLA config配置，同时完善 SWA 在不同 attention path 下的报错约束。

- 新增 MLA-SWA effective dims 机制，SWA MLA 层可独立配置：
    - `swa_num_attention_heads`
    - `swa_num_key_value_heads`
    - `swa_v_head_dim`
    - `swa_rope_theta`
    - `swa_qk_nope_head_dim`
    - `swa_qk_rope_head_dim`
    - `swa_kv_lora_rank`
    - `swa_q_lora_rank`

 - `swa_*` 默认值改为 `None`，未配置时继承 full attention 对应参数。

- 完善 SWA 相关 unsupported attention path 的显式报错：当前 SWA / head-wise SWA 仅支持 flashmask  路径；sdpa + SWA、raw path
  head-wise SWA、MLA+SWA absorbed decode kernel 等未支持路径均显式报错，避免静默 fallback 或误用。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
 否