### PR TITLE
[New features] MoE: add AllGather + ReduceScatter dispatcher with intermediate-dim EP sharding

### DIFF
--- a/packages/paddlefleet_ops/setup.py
+++ b/packages/paddlefleet_ops/setup.py
@@ -37,7 +37,7 @@ def get_special_setup_deps():
     if backends.IS_NVIDIA:
         deps = [
             "triton",  # for deep_gemm, flashmask
-            "nvidia-cutlass-dsl[cu13]==4.4.1",  # for sonic_moe and flash_attention
+            "nvidia-cutlass-dsl[cu13]==4.5.0",  # for sonic_moe and flash_attention
             "filelock",  # for sonic_moe
             "apache-tvm-ffi>=0.1.3,<0.1.12",  # for supersonic_moe
         ]

--- a/src/paddlefleet/transformer/moe/fusion_layer_utils.py
+++ b/src/paddlefleet/transformer/moe/fusion_layer_utils.py
@@ -2232,6 +2232,18 @@ def run_sonic_moe(
             paddle.int32
         )
 
+    # Cast topk_indices to int32 ONCE and reuse for both the metadata kernel
+    # and the differentiable router scores. ``paddle.cast`` is NOT a no-op for a
+    # matching dtype (it allocates + copies), so the two separate casts below
+    # previously launched two redundant copy kernels. With a dtype guard, the
+    # allgather path (which already feeds int32 indices) pays zero copies, and
+    # the deepep path (int64 indices) pays one instead of two.
+    topk_indices_i32 = (
+        topk_indices
+        if topk_indices.dtype == paddle.int32
+        else topk_indices.cast(paddle.int32)
+    )
+
     (
         expert_frequency_offset,
         x_gather_idx,
@@ -2244,7 +2256,7 @@ def run_sonic_moe(
         _N_recv,
         _score_src_idx,
     ) = deepep_topk_to_sonic_metadata(
-        topk_indices.cast(paddle.int32),
+        topk_indices_i32,
         topk_scores,
         tokens_per_expert,
         E,
@@ -2257,7 +2269,7 @@ def run_sonic_moe(
     total_expert_freq = TK_padded
     scores_for_down = _differentiable_router_scores(
         topk_scores,
-        topk_indices.cast(paddle.int32),
+        topk_indices_i32,
         num_activated_expert_per_token_offset,
         TK_padded - total_pad_rows,
         TK_padded,

--- a/src/paddlefleet/transformer/moe/moe_expert.py
+++ b/src/paddlefleet/transformer/moe/moe_expert.py
@@ -140,12 +140,22 @@ class GroupedMLPExpert(FleetLayer):
         config: TransformerConfig,
         moe_deep_gemm,
         pg_collection: ProcessGroupCollection | None = None,
+        intermediate_size_per_partition: int | None = None,
     ):
         super().__init__(config=config)
         self.config: TransformerConfig = config
         self.config.hidden_act = F.silu
         self.num_local_experts = num_local_experts
         self.moe_deep_gemm = moe_deep_gemm
+        # Intermediate size for the local shard of every expert. When using the
+        # 'allgather' MoE dispatcher every expert is sharded along its
+        # intermediate dim across the EP group, so this can be smaller than
+        # ``config.moe_intermediate_size``.
+        self.intermediate_size_per_partition = (
+            intermediate_size_per_partition
+            if intermediate_size_per_partition is not None
+            else self.config.moe_intermediate_size
+        )
         assert not config.use_bias, (
             "Bias not supported in Grouped GEMM yet, please set 'use_bias' to False."
         )
@@ -178,13 +188,13 @@ class GroupedMLPExpert(FleetLayer):
             )
 
         # No tensor parallel - full sizes
-        fc1_output_size = self.config.moe_intermediate_size
+        fc1_output_size = self.intermediate_size_per_partition
         if config.gated_linear_unit:
             # Project to 4h. If using swiglu double the output width,
             # see https://arxiv.org/pdf/2002.05202.pdf
             fc1_output_size *= 2
 
-        fc2_input_size = self.config.moe_intermediate_size
+        fc2_input_size = self.intermediate_size_per_partition
 
         dtype = "bfloat16"
         w1_shape = [
@@ -290,7 +300,95 @@ class GroupedMLPExpert(FleetLayer):
         self,
         structured_name_prefix: str = "",
     ):
+        # Two distinct EP weight layouts coexist:
+        #
+        # * Standard: every rank owns a disjoint subset of experts at full
+        #   intermediate width. ``weight1`` is ``[E_local, H, 2*I_full]``
+        #   and ``weight2`` is ``[E_local, I_full, H]``. Sharding axis=0
+        #   stitches the per-rank slabs along the expert dim into the
+        #   global tensor.
+        #
+        # * AllGather token dispatcher: every rank owns *every* expert
+        #   with the intermediate dim sharded across EP. ``weight1`` is
+        #   ``[E, H, 2*I_local]`` and ``weight2`` is ``[E, I_local, H]``.
+        #   Sharding must therefore happen along the intermediate dim,
+        #   not the expert dim. ``weight1``'s last dim is the gated
+        #   ``[gate_r(I_local) ; up_r(I_local)]`` concat — naively
+        #   AllGathering it would interleave gate/up chunks per rank
+        #   (``[gate_r0; up_r0; gate_r1; up_r1; ...]``) rather than
+        #   producing the canonical ``[gate_full; up_full]`` order. We
+        #   reshape to expose the gate/up split as its own axis before
+        #   sharding so flex_checkpoint reassembles the global tensor as
+        #   ``[E, H, 2, I_full]``; loaders can reshape that to
+        #   ``[E, H, 2*I_full]`` losslessly.
+        is_intermediate_sharded = (
+            self.intermediate_size_per_partition
+            != self.config.moe_intermediate_size
+        )
+
         state_dict = self.state_dict(structured_name_prefix="")
+
+        if is_intermediate_sharded:
+            if self.ep_group is None:
+                raise ValueError(
+                    "intermediate-sharded layout requires an EP group; "
+                    f"got ep_group=None. Check moe_token_dispatcher_type "
+                    f"({self.config.moe_token_dispatcher_type!r}) and EP "
+                    f"initialisation."
+                )
+            if not self.config.gated_linear_unit:
+                raise ValueError(
+                    "intermediate-sharded layout currently assumes a gated "
+                    "linear unit (weight1 last dim = 2 * intermediate); "
+                    "non-gated MLP support is not implemented."
+                )
+            ep_size = self.ep_group.nranks
+            if (
+                self.intermediate_size_per_partition * ep_size
+                != self.config.moe_intermediate_size
+            ):
+                raise ValueError(
+                    "intermediate-sharded layout inconsistency: "
+                    f"intermediate_size_per_partition="
+                    f"{self.intermediate_size_per_partition} * ep_size="
+                    f"{ep_size} != moe_intermediate_size="
+                    f"{self.config.moe_intermediate_size}"
+                )
+            E = state_dict["weight1"].shape[0]
+            H = state_dict["weight1"].shape[1]
+            I_local = self.intermediate_size_per_partition
+            expected_last = 2 * I_local
+            if state_dict["weight1"].shape[-1] != expected_last:
+                raise ValueError(
+                    f"weight1 last dim {state_dict['weight1'].shape[-1]} "
+                    f"!= 2 * intermediate_size_per_partition "
+                    f"({expected_last}); cannot reshape to [E, H, 2, "
+                    f"I_local]"
+                )
+            w1 = state_dict["weight1"].reshape([E, H, 2, I_local])
+            w1.name = self.weight1.name
+            w2 = state_dict["weight2"]  # [E, I_local, H]
+            w2.name = self.weight2.name
+
+            sharded_dict = {}
+            full_key1 = f"{structured_name_prefix}weight1"
+            full_key2 = f"{structured_name_prefix}weight2"
+            sharded_dict[full_key1] = shard_weight(
+                key=full_key1,
+                weight=w1,
+                axis=3,  # I_local — intermediate dim per rank
+                group=self.ep_group,
+            )
+            sharded_dict[full_key1].grouped_gemm_param = True
+            sharded_dict[full_key2] = shard_weight(
+                key=full_key2,
+                weight=w2,
+                axis=1,  # I_local — intermediate dim per rank
+                group=self.ep_group,
+            )
+            sharded_dict[full_key2].grouped_gemm_param = True
+            return sharded_dict
+
         model_type = getattr(self.config, "model_type", "none")
         if "qwen3_vl" not in model_type and "qwen3_5" not in model_type:
             w1 = state_dict["weight1"].reshape(-1, self.weight1.shape[-1])
@@ -374,6 +472,7 @@ class SonicMoEExpert(GroupedMLPExpert):
         topk: int,
         config: TransformerConfig,
         pg_collection: ProcessGroupCollection | None = None,
+        intermediate_size_per_partition: int | None = None,
     ):
         assert config.gated_linear_unit is True, (
             "Sonic MoE must use SwiGLU, i.e. set gated_linear_unit=True."
@@ -383,6 +482,7 @@ class SonicMoEExpert(GroupedMLPExpert):
             config=config,
             moe_deep_gemm=False,
             pg_collection=pg_collection,
+            intermediate_size_per_partition=intermediate_size_per_partition,
         )
         self.hidden_size = self.config.hidden_size
         self.K = topk

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -52,6 +52,7 @@ from .moe_router import TopKRouter
 from .moe_shared_expert import StandardMLPSharedExpert
 from .moe_utils import AddAuxiliaryLoss, use_accuracy_compatible_kernel
 from .token_dispatcher import (
+    AllGatherTokenDispatcher,
     AllToAllTokenDispatcher,
     MoEFlexTokenDispatcher,
     is_hybrid_ep_backend_selected,
@@ -290,6 +291,8 @@ class MoELayer(nn.Layer):
                         "HybridEP backend does not support moe_shared_expert_overlap; disabling it."
                     )
                     self.moe_shared_expert_overlap = False
+            elif self.moe_token_dispatcher_type == "allgather":
+                self._validate_allgather_config()
             else:
                 logger.info(
                     "moe_use_fusion_node is only supported when moe_token_dispatcher_type is 'deepep' or 'hybridep'; disabling it."
@@ -343,7 +346,25 @@ class MoELayer(nn.Layer):
             )
 
         if use_fused_weight:
-            if self.using_sonic_moe:
+            if (
+                self.moe_token_dispatcher_type == "allgather"
+                and self.expert_model_parallel_size > 1
+            ):
+                # AllGather (EP>1): every rank holds a shard of every expert
+                # along the intermediate dim; SonicMoEExpert must allocate
+                # weights for all experts (not num_local_experts) with the
+                # per-EP-rank shard size.
+                self.grouped_gemm_experts = SonicMoEExpert(
+                    self.num_experts,
+                    self.num_experts_per_tok,
+                    routed_expert_config,
+                    pg_collection,
+                    intermediate_size_per_partition=(
+                        self.moe_intermediate_size
+                        // self.expert_model_parallel_size
+                    ),
+                )
+            elif self.using_sonic_moe:
                 # TODO: replace grouped_gemm_experts with fusion_experts
                 self.grouped_gemm_experts = SonicMoEExpert(
                     self.num_local_experts,
@@ -437,6 +458,14 @@ class MoELayer(nn.Layer):
                     self.expert_model_parallel_size,
                     self.num_experts_per_device,
                     local_expert_indices,
+                )
+            elif self.moe_token_dispatcher_type == "allgather":
+                self.token_dispatcher = AllGatherTokenDispatcher(
+                    self.moe_group,
+                    self.expert_model_parallel_size,
+                    self.num_experts,
+                    fp8_dispatch=self.fp8_dispatch,
+                    use_ue8m0=self.use_ue8m0,
                 )
             else:
                 raise NotImplementedError(
@@ -573,9 +602,13 @@ class MoELayer(nn.Layer):
             self.moe_grad_group = self.pg_collection.expt_dp
             self.moe_rank = utils.get_pg_rank(self.moe_group)
             self.moe_rank = max(self.moe_rank, 0)
-            self.num_experts_per_device = _parse_moe_expert_parallel(
-                self.num_experts, self.expert_model_parallel_size
-            )
+            if self.moe_token_dispatcher_type == "allgather":
+                # AllGather: every rank holds a shard of every expert.
+                self.num_experts_per_device = self.num_experts
+            else:
+                self.num_experts_per_device = _parse_moe_expert_parallel(
+                    self.num_experts, self.expert_model_parallel_size
+                )
         else:
             self.moe_group = None
             self.moe_rank = 0
@@ -660,9 +693,26 @@ class MoELayer(nn.Layer):
     def unpermute(self, hidden_states: paddle.Tensor):
         return self.token_dispatcher.combine_preprocess(hidden_states)
 
-    def combine(self, hidden_states: paddle.Tensor, async_finish: bool = False):
+    def combine(
+        self,
+        hidden_states: paddle.Tensor,
+        combine_overlap_handle: dict | None = None,
+        async_finish: bool = False,
+        fp8_combine_grad_handle: dict | None = None,
+    ):
+        """Combine expert outputs back to the local token shard.
+
+        Delegates to the underlying ``token_dispatcher``: ``token_combine``
+        either issues a (possibly fused) ReduceScatter, then
+        ``combine_postprocess`` finalizes it. When
+        ``combine_overlap_handle`` is provided the ReduceScatter overlaps
+        with a user-supplied subgraph (typically the shared-expert MLP).
+        """
         hidden_states = self.token_dispatcher.token_combine(
-            hidden_states, async_finish=async_finish
+            hidden_states,
+            combine_overlap_handle=combine_overlap_handle,
+            async_finish=async_finish,
+            fp8_combine_grad_handle=fp8_combine_grad_handle,
         )
         return self.token_dispatcher.combine_postprocess(hidden_states)
 
@@ -677,6 +727,80 @@ class MoELayer(nn.Layer):
         )
         return self.unpermute(expert_outs)
 
+    def _maybe_pre_allgather_overlap(self, hidden_states: paddle.Tensor):
+        """Issue the async AllGather before gate so it overlaps with gate compute.
+
+        Always-on for the 'allgather' dispatcher when EP > 1: AllGather runs on
+        the comm stream while gate MLP runs on the calc stream; the result is
+        consumed inside ``dispatch_preprocess`` via ``_PreAllGatherResult``
+        (or ``_PreAllGatherFP8Result`` when ``fp8_dispatch=True``). For latent
+        MoE, ``fc1_latent_proj`` is hoisted here so the AllGather targets the
+        latent-space tensor; gate still runs on the original hidden_states.
+        """
+        if (
+            self.moe_token_dispatcher_type == "allgather"
+            and self.expert_model_parallel_size > 1
+        ):
+            if self.use_latent_moe:
+                self._latent_hidden = self.fc1_latent_proj(hidden_states)
+                self.token_dispatcher.pre_allgather(self._latent_hidden)
+            else:
+                self._latent_hidden = None
+                self.token_dispatcher.pre_allgather(hidden_states)
+        else:
+            self._latent_hidden = None
+
+    def _validate_allgather_config(self):
+        """Validate and force-correct config flags for the allgather dispatcher.
+
+        AllGather + ReduceScatter EP pattern: every expert is sharded along its
+        intermediate dim across the EP group.  Requires SonicMoE fused kernels;
+        fp8 is handled by ``run_sonic_moe`` internally.
+        """
+        if not self.using_sonic_moe:
+            raise ValueError(
+                "moe_token_dispatcher_type='allgather' requires "
+                "using_sonic_moe=True; the allgather path is only "
+                "implemented for SonicMoE fused kernels."
+            )
+        if not self.moe_use_fusion_node:
+            logger.warning(
+                "moe_token_dispatcher_type='allgather' only "
+                "support moe_use_fusion_node; forcing moe_use_fusion_node=True."
+            )
+            self.moe_use_fusion_node = True
+        if not self.moe_expert_fusion:
+            logger.warning(
+                "moe_token_dispatcher_type='allgather' requires "
+                "fused expert weights; forcing moe_expert_fusion=True."
+            )
+            self.moe_expert_fusion = True
+        if self.moe_deep_gemm:
+            logger.warning(
+                "moe_token_dispatcher_type='allgather' does not "
+                "support moe_deep_gemm; forcing moe_deep_gemm=False."
+            )
+            self.moe_deep_gemm = False
+        if self.moe_intermediate_size % self.expert_model_parallel_size != 0:
+            raise ValueError(
+                f"moe_intermediate_size={self.moe_intermediate_size} "
+                f"must be divisible by EP="
+                f"{self.expert_model_parallel_size} in 'allgather' mode."
+            )
+
+    def _project_to_latent(self, hidden_states: paddle.Tensor) -> paddle.Tensor:
+        """Project hidden_states to latent space, consuming any cached
+        projection from the AllGather overlap path if available.
+        """
+        if not self.use_latent_moe:
+            return hidden_states
+        if self._latent_hidden is not None:
+            hidden_states = self._latent_hidden
+            self._latent_hidden = None
+        else:
+            hidden_states = self.fc1_latent_proj(hidden_states)
+        return hidden_states
+
     # MoE forward: dispatch -> permute -> compute ->unpermute -> combine
     def custom_forward(
         self,
@@ -685,6 +809,7 @@ class MoELayer(nn.Layer):
         routing_map: paddle.Tensor,
         topk_weights: paddle.Tensor | None = None,
         topk_indices: paddle.Tensor | None = None,
+        combine_overlap_handle: dict | None = None,
     ):
         # Latent MoE: project hidden_states to latent space before dispatch
         if self.use_latent_moe:
@@ -705,7 +830,9 @@ class MoELayer(nn.Layer):
         with profile("fusion_mlp"):
             hidden_states = self.routed_experts_compute(hidden_states)
         with profile("combine"):
-            hidden_states = self.combine(hidden_states)
+            hidden_states = self.combine(
+                hidden_states, combine_overlap_handle=combine_overlap_handle
+            )
 
         # Latent MoE: project back from latent space to hidden_size
         if self.use_latent_moe:
@@ -722,10 +849,7 @@ class MoELayer(nn.Layer):
         topk_weights: paddle.Tensor | None = None,
         topk_indices: paddle.Tensor | None = None,
     ):
-        # TODO(deepllz): add fp8 dispatch config && implementation
-        # Latent MoE: project hidden_states to latent space before dispatch
-        if self.use_latent_moe:
-            hidden_states = self.fc1_latent_proj(hidden_states)
+        hidden_states = self._project_to_latent(hidden_states)
 
         should_log_balance = framework._dygraph_tracer()._has_grad
         with profile("dispatch"):
@@ -733,21 +857,19 @@ class MoELayer(nn.Layer):
                 hidden_states, probs, routing_map, topk_weights, topk_indices
             )
 
+        dispatched_indices, dispatched_probs, tokens_per_expert = (
+            self.token_dispatcher.get_dispatched_routing()
+        )
         if should_log_balance and global_moe_balance_training_logs_enabled():
             log_moe_balance(
                 self.layer_number,
                 self.moe_group,
                 self.num_experts_per_tok,
-                self.token_dispatcher._comm_manager.tokens_per_expert,
+                tokens_per_expert,
             )
-        dispatched_indices = (
-            self.token_dispatcher._comm_manager.dispatched_indices
-        )
-        dispatched_probs = self.token_dispatcher._comm_manager.dispatched_probs
         fp8_combine_grad_handle = (
             {} if self.fp8_dispatch and self.using_sonic_moe else None
         )
-        # fp8_combine_grad_handle = None
 
         with profile("fusion_mlp"):
             if self._use_hybrid_ep_fusion():
@@ -766,7 +888,7 @@ class MoELayer(nn.Layer):
                     dispatched_indices,
                     dispatched_probs,
                     use_fp8,
-                    tokens_per_expert=self.token_dispatcher._comm_manager.tokens_per_expert,
+                    tokens_per_expert=tokens_per_expert,
                     fp8_scale=fp8_scale,
                     fp8_combine_grad_handle=fp8_combine_grad_handle,
                 )
@@ -794,13 +916,20 @@ class MoELayer(nn.Layer):
                 )
 
         with profile("combine"):
-            hidden_states = self.token_dispatcher._comm_manager.combine(
-                hidden_states,
-                combine_overlap_handle,
-                use_rr_deepep_combine=self.use_rr_deepep_combine,
-                fp8_dispatch=self.fp8_dispatch and self.using_sonic_moe,
-                combine_grad_handle=fp8_combine_grad_handle,
-            )
+            if self.moe_token_dispatcher_type == "allgather":
+                hidden_states = self.combine(
+                    hidden_states,
+                    combine_overlap_handle=combine_overlap_handle,
+                    fp8_combine_grad_handle=fp8_combine_grad_handle,
+                )
+            else:
+                hidden_states = self.token_dispatcher._comm_manager.combine(
+                    hidden_states,
+                    combine_overlap_handle,
+                    use_rr_deepep_combine=self.use_rr_deepep_combine,
+                    fp8_dispatch=self.fp8_dispatch and self.using_sonic_moe,
+                    combine_grad_handle=fp8_combine_grad_handle,
+                )
 
         # Latent MoE: project back from latent space to hidden_size
         if self.use_latent_moe:
@@ -1000,6 +1129,9 @@ class MoELayer(nn.Layer):
 
         layer_idx = getattr(self, "layer_number", None)
         _log_moe_md5(hidden_states, "moe_input", layer_idx)
+
+        self._maybe_pre_allgather_overlap(hidden_states)
+
         (
             capacity,
             topk_weights,

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -169,6 +169,7 @@ class MoELayer(nn.Layer):
         self.sequence_parallel = config.sequence_parallel
         self.tensor_model_parallel_size = config.tensor_model_parallel_size
         self.moe_token_dispatcher_type = config.moe_token_dispatcher_type
+        self.moe_allgather_gate_overlap = config.moe_allgather_gate_overlap
         self.use_hybrid_ep_backend = False
         self.moe_shared_expert_overlap = config.moe_shared_expert_overlap
         self.fp8 = config.fp8
@@ -730,16 +731,18 @@ class MoELayer(nn.Layer):
     def _maybe_pre_allgather_overlap(self, hidden_states: paddle.Tensor):
         """Issue the async AllGather before gate so it overlaps with gate compute.
 
-        Always-on for the 'allgather' dispatcher when EP > 1: AllGather runs on
-        the comm stream while gate MLP runs on the calc stream; the result is
-        consumed inside ``dispatch_preprocess`` via ``_PreAllGatherResult``
-        (or ``_PreAllGatherFP8Result`` when ``fp8_dispatch=True``). For latent
-        MoE, ``fc1_latent_proj`` is hoisted here so the AllGather targets the
+        Enabled for the 'allgather' dispatcher when EP > 1 and
+        ``moe_allgather_gate_overlap=True``: AllGather runs on the comm stream
+        while gate MLP runs on the calc stream; the result is consumed inside
+        ``dispatch_preprocess`` via ``_PreAllGatherResult`` (or
+        ``_PreAllGatherFP8Result`` when ``fp8_dispatch=True``). For latent MoE,
+        ``fc1_latent_proj`` is hoisted here so the AllGather targets the
         latent-space tensor; gate still runs on the original hidden_states.
         """
         if (
             self.moe_token_dispatcher_type == "allgather"
             and self.expert_model_parallel_size > 1
+            and self.moe_allgather_gate_overlap
         ):
             if self.use_latent_moe:
                 self._latent_hidden = self.fc1_latent_proj(hidden_states)

--- a/src/paddlefleet/transformer/moe/moe_utils.py
+++ b/src/paddlefleet/transformer/moe/moe_utils.py
@@ -789,3 +789,24 @@ class AllGatherGroupOp(paddle.autograd.PyLayer):
         """
         paddle.distributed.barrier(ctx.group)
         return reduce_scatter_group(grad, group=ctx.group)
+
+
+class ReduceScatterGroupOp(paddle.autograd.PyLayer):
+    """
+    Perform group reduce-scatter (sum). Backward pass is an all-gather.
+
+    This is the dual of :class:`AllGatherGroupOp` and is used by the
+    'allgather' MoE token dispatcher to combine partial expert outputs along
+    the EP group: forward sums across EP ranks while scattering along the
+    leading (token) dimension; backward replicates the gradient via
+    all-gather.
+    """
+
+    @staticmethod
+    def forward(ctx, input, group=None):
+        ctx.group = group
+        return reduce_scatter_group(input, group=group)
+
+    @staticmethod
+    def backward(ctx, grad):
+        return all_gather_group(grad, group=ctx.group)

--- a/src/paddlefleet/transformer/moe/token_dispatcher.py
+++ b/src/paddlefleet/transformer/moe/token_dispatcher.py
@@ -1213,8 +1213,12 @@ class _RouterAllGather(paddle.autograd.PyLayer):
                     f"{global_shape})."
                 )
             grad = grad.reshape(global_shape)
-        chunks = paddle.split(grad, num_or_sections=group.nranks, axis=0)
-        out = chunks[group.rank].contiguous()
+        # Slice out only this rank's segment instead of splitting into all
+        # nranks chunks and discarding the rest (scatter — no cross-rank
+        # reduction). Avoids constructing nranks-1 unused views.
+        seg = local_shape[0]
+        start = group.rank * seg
+        out = grad[start : start + seg].contiguous()
         if list(out.shape) != local_shape:
             out = out.reshape(local_shape)
         return out

--- a/src/paddlefleet/transformer/moe/token_dispatcher.py
+++ b/src/paddlefleet/transformer/moe/token_dispatcher.py
@@ -1374,6 +1374,53 @@ def _all_gather_async(input, group):
     return output, task
 
 
+def _all_gather_grad_fp8_async(grad, group):
+    """fp8 counterpart of :func:`_all_gather_async` for the combine backward.
+
+    Quantizes the **local** combine gradient to fp8 e4m3 + int32 1x128 block
+    scale on the calc stream, then issues two async AllGathers (uint8 data +
+    int32 scale, axis 0 row-concat) on the comm stream. Because the combine
+    backward collective is a *lossless row concat* (AllGather, no reduction)
+    and the 1x128 block scale lives entirely within a single token's hidden
+    vector, quantize-before-AllGather is **bit-identical** to the bf16-then-
+    self-quantize path used previously — it just halves the on-wire bytes
+    (1B vs 2B) and matches deepep+sonic's ``DeepEPCombine.backward``.
+
+    Returns ``(data_e4m3_global, scale_global, task_x, task_s)`` where
+    ``data_e4m3_global`` is the gathered fp8 tensor viewed back to
+    ``float8_e4m3fn`` (shape ``[global_T, H]``) and ``scale_global`` the
+    gathered int32 block scales (shape ``[global_T, H//128]``).
+    """
+    assert quantize_activation_blockscaled_fast is not None, (
+        "Cannot find quantize_activation_blockscaled_fast, please update sonicmoe."
+    )
+    grad = grad.contiguous()
+    x_fp8, scale = quantize_activation_blockscaled_fast(
+        grad, scale_dtype=paddle.int32
+    )
+    T_local, H = x_fp8.shape
+    nranks = group.nranks
+    T_global = T_local * nranks
+    H128 = scale.shape[1]
+    data_global_u8 = paddle.empty([T_global, H], dtype="uint8")
+    task_x = paddle.distributed.stream.all_gather(
+        data_global_u8,
+        x_fp8.view("uint8"),
+        group=group,
+        sync_op=False,
+        use_calc_stream=False,
+    )
+    scale_global = paddle.empty([T_global, H128], dtype=scale.dtype)
+    task_s = paddle.distributed.stream.all_gather(
+        scale_global,
+        scale.contiguous(),
+        group=group,
+        sync_op=False,
+        use_calc_stream=False,
+    )
+    return data_global_u8.view("float8_e4m3fn"), scale_global, task_x, task_s
+
+
 class _AllGatherCombineAsync(paddle.autograd.PyLayer):
     """ReduceScatter combine fused with a user-supplied subgraph (e.g. shared experts).
 
@@ -1394,10 +1441,18 @@ class _AllGatherCombineAsync(paddle.autograd.PyLayer):
     compute has no data dependency on the in-flight combine collective — the
     same precondition that makes ``DeepEPCombineAsync`` correct. Async only
     changes the execution stream/timing; the ReduceScatter/AllGather semantics
-    (and thus numerics) are identical to the synchronous path, and combine
-    stays bf16 in both directions to match deepep — ``_DownProjection.backward``
-    self-quantizes ``dout`` to fp8, which (since AllGather is a lossless row
-    concat) is numerically identical to quantizing before the collective.
+    (and thus numerics) are identical to the synchronous path.
+
+    Combine forward stays bf16 in both paths. Combine **backward** is fp8 when
+    ``fp8_combine_grad_handle`` is supplied (``fp8_dispatch and
+    using_sonic_moe``): the local gradient is quantized to fp8 e4m3 + int32
+    block scale *before* the AllGather (1B/elem vs 2B), the gathered fp8
+    data+scale are written into the handle and consumed directly by
+    ``_DownProjection.backward`` (skipping its internal re-quantization).
+    Because the combine-backward AllGather is a lossless row concat and the
+    1x128 scale lives within a single token's hidden vector, this is
+    bit-identical to the bf16-then-self-quantize path while matching
+    deepep+sonic's ``DeepEPCombine.backward`` bandwidth.
     """
 
     @staticmethod
@@ -1408,12 +1463,14 @@ class _AllGatherCombineAsync(paddle.autograd.PyLayer):
         *fn_args,
         fn,
         is_first_fwd=False,
+        fp8_combine_grad_handle=None,
     ):
         if fn is None:
             raise ValueError(
                 "_AllGatherCombineAsync requires a non-None fn for overlap."
             )
         ctx.group = group
+        ctx.fp8_combine_grad_handle = fp8_combine_grad_handle
 
         if group is None or group.nranks == 1:
             combined_x = x.clone()
@@ -1435,10 +1492,27 @@ class _AllGatherCombineAsync(paddle.autograd.PyLayer):
     @staticmethod
     def backward(ctx, grad_output, *fn_out_grads):
         group = ctx.group
+        handle = ctx.fp8_combine_grad_handle
         if group is None or group.nranks == 1:
             grad_x = grad_output.clone()
             fn_args_grads = ctx.bwf(*fn_out_grads)
             return (grad_x,) + fn_args_grads  # noqa: RUF005
+
+        if handle is not None:
+            # fp8 combine backward: quantize the local grad to fp8 e4m3 +
+            # int32 scale, AllGather both on the comm stream (async) while the
+            # shared-expert backward runs on the calc stream, then wait. The
+            # gathered fp8 data+scale are handed to ``_DownProjection.backward``
+            # via the handle; the returned ``grad_x`` is the fp8 data edge.
+            data_e4m3, scale_global, task_x, task_s = _all_gather_grad_fp8_async(
+                grad_output, group
+            )
+            fn_args_grads = ctx.bwf(*fn_out_grads)
+            task_x.wait()
+            task_s.wait()
+            handle["data"] = data_e4m3
+            handle["scale"] = scale_global
+            return (data_e4m3,) + fn_args_grads  # noqa: RUF005
 
         # Dual of forward: AllGather the gradient on the comm stream (async)
         # while the shared-expert backward runs on the calc stream, then wait.
@@ -1882,16 +1956,19 @@ class AllGatherTokenDispatcher(nn.Layer):
         Args:
             combine_overlap_handle: dict with keys ``fn`` (callable) and
                 ``fn_args`` (tuple). On return, ``fn_out`` is populated.
-            fp8_combine_grad_handle: accepted for caller-signature parity but
-                unused on the allgather path. The combine collectives stay
-                bf16 in both directions; ``_DownProjection.backward`` quantizes
-                ``dout`` itself. Since the backward AllGather is a lossless row
-                concat (no reduction), self-quant-after-AllGather is numerically
-                identical to quant-before — so this path already matches
-                deepep+sonic precision without any extra fp8 collective.
+            fp8_combine_grad_handle: when non-None (``fp8_dispatch and
+                using_sonic_moe``), the combine **backward** quantizes the
+                gradient to fp8 e4m3 + int32 block scale *before* the AllGather
+                (1B/elem vs bf16's 2B) and writes the gathered fp8 data+scale
+                into this dict (keys ``data``/``scale``) for
+                ``_DownProjection.backward`` to consume directly — matching
+                deepep+sonic's ``DeepEPCombine.backward`` bandwidth. Because the
+                backward AllGather is a lossless row concat and the 1x128 scale
+                lives within a single token's hidden vector, this is bit-identical
+                to quant-after-AllGather. Forward stays bf16. Only used on the
+                overlap path; the non-overlap ``combine_postprocess`` path leaves
+                the handle empty so down-proj falls back to bf16 self-quant.
         """
-        del fp8_combine_grad_handle
-
         if combine_overlap_handle is None:
             self._overlap_combined = None
             return hidden_states
@@ -1920,6 +1997,7 @@ class AllGatherTokenDispatcher(nn.Layer):
             *(combine_overlap_handle["fn_args"]),
             fn=combine_overlap_handle["fn"],
             is_first_fwd=not _framework._dygraph_tracer()._has_grad,
+            fp8_combine_grad_handle=fp8_combine_grad_handle,
         )
         combine_overlap_handle["fn_out"] = tuple(fn_out)
         self._overlap_combined = combined_x

--- a/src/paddlefleet/transformer/moe/token_dispatcher.py
+++ b/src/paddlefleet/transformer/moe/token_dispatcher.py
@@ -1147,29 +1147,52 @@ class AllToAllTokenDispatcher(nn.Layer):
 
 
 class _RouterAllGather(paddle.autograd.PyLayer):
-    """AllGather for router-local tensors (allgather dispatcher only).
+    """AllGather for router routing weights (allgather dispatcher only).
 
-    Forward: same as ``AllGatherGroupOp`` — concatenates the local
-    ``[seq_local, ...]`` tensor across the EP group along axis 0 to
-    ``[seq_global, ...]``.
+    Forward: concatenates the local ``[seq_local, K]`` routing-weight tensor
+    across the EP group along axis 0 to ``[seq_global, K]``.
 
-    Backward: **scatter (not reduce-scatter)**. Each token has exactly one
-    origin rank — its router lives there and only there. Only the slice owned
-    by the current rank is a valid gradient for *this* rank's router; the rest
-    belongs to other ranks' routers and must not be summed in.
-    ``AllGatherGroupOp`` was designed for hidden_states (unique-per-rank
-    pre-AllGather, hence reduce-scatter on backward); reusing it for
-    router-local metadata is a semantics mismatch.
+    Backward: **reduce-scatter** (sum across the EP group, then take this
+    rank's token segment).
+
+    Why reduce-scatter and not plain scatter:
+    in the allgather dispatcher every expert is sharded along its
+    *intermediate* dim, so **every** EP rank holds a shard of *every* expert
+    and recomputes a partial expert output for the *entire* global token list
+    using the same all-gathered routing weight ``w_t``. The combined output is
+
+        out_t = w_t * sum_i(down_proj_shard_i(t))          (sum over EP ranks i)
+
+    so the gradient that token ``t``'s router must receive is
+
+        d_loss/d_w_t = grad_out_t · sum_i(down_proj_shard_i(t))
+                     = sum_i ( grad_out_t · down_proj_shard_i(t) )
+                     = sum_i ds_i(t)
+
+    Each rank ``i`` only computes its own term ``ds_i(t)`` locally (via
+    SonicMoE's ``_DownProjection`` over its intermediate shard); the autograd
+    engine therefore delivers, on each rank, a ``[T_global, K]`` gradient
+    holding *that rank's* partial ``ds_i``. The router for token ``t`` lives on
+    a single origin rank, but its correct gradient is the **sum over all
+    ranks** of those partials — i.e. reduce (sum) then scatter to the origin
+    segment. This is exactly the standard backward of an all-gather whose
+    output is independently consumed on every rank.
+
+    A plain scatter (the previous implementation) kept only the origin rank's
+    own shard term ``ds_origin(t)`` and dropped ``ds_{j != origin}(t)``,
+    delivering ~1/nranks of the true router gradient (half of it at EP=2). That
+    under-trained the router and made the allgather path converge measurably
+    worse than the deepep+sonic path, which does not shard experts along the
+    intermediate dim and so gives its router the full single-rank gradient.
+    Reduce-scatter makes the two numerically equivalent: ``sum_i ds_i(t)``
+    equals deepep's single ``grad_out_t · full_down_value(t)``.
 
     Gradient shape: this layer's output (``_global_topk_weights``, shape
-    ``[T_global, K]``) is consumed downstream *only* through
-    ``_differentiable_router_scores``, which gathers it via
-    ``dispatched_probs.reshape(-1)[gather_idx]``. SonicMoE's ``_DownProjection``
-    emits a 1-D ``ds`` over the gathered/padded layout, but that flows back
-    through ``_GatherRouterScores`` (scatter into a flat ``[T_global*K]``
-    buffer) and the ``reshape(-1)`` op, whose autograd restores the original
-    2-D ``[T_global, K]`` shape. So the gradient arriving here matches the
-    forward output shape exactly; no flattening reaches this edge.
+    ``[T_global, K]``) is consumed downstream only through
+    ``_differentiable_router_scores`` -> ``_GatherRouterScores`` -> a
+    ``reshape(-1)``, whose autograd restores the original 2-D ``[T_global, K]``
+    layout, so the gradient arriving here matches the forward output shape; no
+    flattening reaches this edge.
     """
 
     @staticmethod
@@ -1196,8 +1219,10 @@ class _RouterAllGather(paddle.autograd.PyLayer):
             return grad
         # The incoming grad matches the forward output shape
         # ([T_global, *trailing]); see class docstring for why no flattening
-        # reaches this edge. Split along axis 0 and take this rank's segment
-        # (scatter — no cross-rank reduction).
+        # reaches this edge. Reduce-scatter (sum across EP, then take this
+        # rank's segment) — every rank contributed a partial router-weight
+        # gradient for the global token list, so the per-token gradient is the
+        # cross-rank sum, not just this rank's own slice.
         global_shape = [local_shape[0] * group.nranks, *local_shape[1:]]
         if list(grad.shape) != global_shape:
             # Defensive: a downstream kernel emitted an unexpected layout.
@@ -1213,12 +1238,7 @@ class _RouterAllGather(paddle.autograd.PyLayer):
                     f"{global_shape})."
                 )
             grad = grad.reshape(global_shape)
-        # Slice out only this rank's segment instead of splitting into all
-        # nranks chunks and discarding the rest (scatter — no cross-rank
-        # reduction). Avoids constructing nranks-1 unused views.
-        seg = local_shape[0]
-        start = group.rank * seg
-        out = grad[start : start + seg].contiguous()
+        out = reduce_scatter_group(grad.contiguous(), group=group)
         if list(out.shape) != local_shape:
             out = out.reshape(local_shape)
         return out

--- a/src/paddlefleet/transformer/moe/token_dispatcher.py
+++ b/src/paddlefleet/transformer/moe/token_dispatcher.py
@@ -1282,8 +1282,7 @@ class _PreAllGatherFP8Result(paddle.autograd.PyLayer):
         # bf16 dx for its activation input). Tell Paddle not to coerce the
         # incoming grad to the fp8 output dtype, and not to materialize a zero
         # fp8 grad buffer if the edge is unused.
-        if hasattr(ctx, "set_grad_in_dtype_consistent"):
-            ctx.set_grad_in_dtype_consistent(False)
+        ctx.set_grad_in_dtype_consistent(False)
         ctx.set_materialize_grads(False)
         return x_fp8_global, scale_global
 

--- a/src/paddlefleet/transformer/moe/token_dispatcher.py
+++ b/src/paddlefleet/transformer/moe/token_dispatcher.py
@@ -1680,13 +1680,37 @@ class AllGatherTokenDispatcher(nn.Layer):
         # int32 covers the range with room to spare (num_experts << 2^31) while
         # halving the AllGather payload vs int64. The downstream SonicMoE
         # metadata kernel (deepep_topk_to_sonic_metadata) casts to int32 anyway.
-        self._global_topk_indices = AllGatherGroupOp.apply(
-            topk_indices.detach().cast("int32"), self.moe_group
-        )
-        # Padding tokens have topk_indices == -1 (set by TopKRouter).
-        # Keep the sentinel in indices so SonicMoE metadata can treat those
-        # slots as masked; only zero the corresponding routing weights below.
-        self._padding_mask = self._global_topk_indices < 0
+        #
+        # The indices are integer routing IDs with no gradient (``.detach()``),
+        # so there is no need for the autograd-aware ``AllGatherGroupOp``
+        # PyLayer — which additionally issues a full-group
+        # ``paddle.distributed.barrier`` before *every* AllGather. NCCL's
+        # collective is already ordered on the comm stream, so that barrier is
+        # pure latency on the dispatch critical path.
+        #
+        # Issue the indices AllGather **async on the comm stream** so it runs
+        # concurrently with the router-weights AllGather below (the weights
+        # path also does a ``.cast`` on the calc stream first). Both gathers
+        # are independent; we only ``.wait()`` on the indices result right
+        # before its first consumer (the padding mask). This overlaps two
+        # small-but-serialized collectives that previously ran back-to-back.
+        topk_indices_i32 = topk_indices.detach().cast("int32").contiguous()
+        if self.moe_group is None or self.moe_group.nranks == 1:
+            self._global_topk_indices = topk_indices_i32.clone()
+            _idx_task = None
+        else:
+            _idx_out_shape = list(topk_indices_i32.shape)
+            _idx_out_shape[0] *= self.moe_group.nranks
+            self._global_topk_indices = paddle.empty(
+                shape=_idx_out_shape, dtype=topk_indices_i32.dtype
+            )
+            _idx_task = paddle.distributed.stream.all_gather(
+                self._global_topk_indices,
+                topk_indices_i32,
+                group=self.moe_group,
+                sync_op=False,
+                use_calc_stream=False,
+            )
         # Router-local AllGather: every token has exactly one origin rank,
         # so the topk_weights gradient flowing back from sonic-moe's
         # _DownProjection (shape [seq_global, K]) must be *scattered* (slice
@@ -1696,9 +1720,22 @@ class AllGatherTokenDispatcher(nn.Layer):
         # gradients on this rank — matching the alltoall/deepep contract
         # where router weights are also trained by the main loss via the
         # unpermute(probs=...) multiplication.
+        #
+        # Issue this *after* the async indices AllGather above so the two
+        # collectives are both in flight together: _RouterAllGather runs on
+        # the calc stream while the indices gather runs on the comm stream.
         self._global_topk_weights = _RouterAllGather.apply(
             topk_weights.cast(probs.dtype), self.moe_group
         )
+        # Now consume the async indices gather — wait only here, right before
+        # its first reader (the padding mask). By this point the weights
+        # AllGather has already been launched, so the wait overlaps the two.
+        if _idx_task is not None:
+            _idx_task.wait()
+        # Padding tokens have topk_indices == -1 (set by TopKRouter).
+        # Keep the sentinel in indices so SonicMoE metadata can treat those
+        # slots as masked; only zero the corresponding routing weights below.
+        self._padding_mask = self._global_topk_indices < 0
         # Zero out weights for padding tokens (indices were clipped above).
         # Apply the mask unconditionally: a ``.any()`` guard would force a
         # GPU->CPU sync every step just to decide whether to run the where.

--- a/src/paddlefleet/transformer/moe/token_dispatcher.py
+++ b/src/paddlefleet/transformer/moe/token_dispatcher.py
@@ -1648,10 +1648,17 @@ class AllGatherTokenDispatcher(nn.Layer):
                 )
             self._pre_ag_handle = None
         elif self.fp8_dispatch:
-            raise RuntimeError(
-                "AllGatherTokenDispatcher.fp8_dispatch=True requires "
-                "pre_allgather() to be issued before dispatch_preprocess."
+            # Overlap disabled (moe_allgather_gate_overlap=False): no handle was
+            # pre-issued before gate. Issue the fp8 AllGather synchronously here
+            # and consume it immediately, so fp8 dispatch still works without the
+            # gate-overlap optimization.
+            self.pre_allgather(reshaped_input)
+            global_hidden_states, self._fp8_dispatch_scale = (
+                _PreAllGatherFP8Result.apply(
+                    reshaped_input, self._pre_ag_handle
+                )
             )
+            self._pre_ag_handle = None
         else:
             global_hidden_states = AllGatherGroupOp.apply(
                 reshaped_input, self.moe_group

--- a/src/paddlefleet/transformer/moe/token_dispatcher.py
+++ b/src/paddlefleet/transformer/moe/token_dispatcher.py
@@ -1170,6 +1170,15 @@ class _RouterAllGather(paddle.autograd.PyLayer):
         output_shape = list(input.shape)
         output_shape[0] = output_shape[0] * group.nranks
         output = paddle.empty(shape=output_shape, dtype=input.dtype)
+        # NOTE on stream placement (measured, see allgather perf optimization):
+        # The topk_weights AllGather intentionally runs on the CALC stream
+        # (synchronous) rather than the comm stream.  The indices AllGather runs
+        # async on the comm stream; issuing BOTH on the comm stream would
+        # serialize the small weights gather behind the much larger fused
+        # fp8-data AllGather already queued there, increasing dispatch latency
+        # (measured +~4ms/step).  Keeping weights on calc lets it overlap with
+        # the in-flight comm-stream gathers.  Backward (reduce-scatter) is on
+        # the comm stream and unchanged.
         paddle.distributed.stream.all_gather(
             output, input, group=group, use_calc_stream=True
         )
@@ -1226,9 +1235,10 @@ class _PreAllGatherResult(paddle.autograd.PyLayer):
 class _PreAllGatherFP8Result(paddle.autograd.PyLayer):
     """FP8 variant of _PreAllGatherResult.
 
-    Forward waits for two async AllGather tasks (fp8 data + block scale) and
-    returns ``(x_fp8_global, scale_global)``.  The fp8 tensor is consumed
-    directly by SonicMoE's _UpProjection via prequant_activation_payload.
+    Forward waits for the single fused async AllGather task (fp8 data ++ block
+    scale packed per token) and returns ``(x_fp8_global, scale_global)`` after
+    splitting.  The fp8 tensor is consumed directly by SonicMoE's _UpProjection
+    via prequant_activation_payload.
 
     _UpProjection.backward produces a bf16 dx for the activation input, but
     the forward output here is fp8.  set_grad_in_dtype_consistent(False) and
@@ -1239,11 +1249,12 @@ class _PreAllGatherFP8Result(paddle.autograd.PyLayer):
 
     @staticmethod
     def forward(ctx, hidden_states, handle):
-        handle["task_x"].wait()
-        handle["task_s"].wait()
+        handle["task"].wait()
         ctx.group = handle["group"]
-        x_fp8_global = handle["x_fp8_global_uint8"].view("float8_e4m3fn")
-        scale_global = handle["scale_global"]
+        x_fp8_global, scale_global = _split_fused_fp8_gather(
+            handle["fused_global"], handle["H"], handle["H128"],
+            handle["scale_dtype"],
+        )
         ctx.set_grad_in_dtype_consistent(False)
         ctx.set_materialize_grads(False)
         return x_fp8_global, scale_global
@@ -1300,14 +1311,23 @@ def _all_gather_async(input, group):
 
 
 def _all_gather_grad_fp8_async(grad, group):
-    """Quantize local grad to fp8 e4m3 + int32 1x128 block scale, then async
-    AllGather both on the comm stream.  Returns
-    ``(data_e4m3_global, scale_global, task_x, task_s)``.
+    """Quantize local grad to fp8 e4m3 + int32 1x128 block scale, then a SINGLE
+    async AllGather of the fused (fp8-data-as-uint8 ++ scale-as-uint8) per-token
+    byte row on the comm stream.  Returns
+    ``(fused_global, H, H128, scale_dtype, task)``.
+
+    Fusing data and scale into one AllGather (vs two back-to-back collectives)
+    is bit-identical: AllGather concatenates rows along axis 0 and every rank
+    carries an identical ``T_local``, so packing the two payloads along axis 1
+    before the gather yields the same per-rank bytes as gathering them
+    separately.  It removes one NCCL kernel launch (and its peer-wait fixed
+    cost) per combine backward.
 
     Used by the combine backward to halve on-wire bytes vs bf16 AllGather.
-    Because AllGather is a lossless row concat and the 1x128 scale lives
-    within a single token's hidden vector, this is bit-identical to
-    bf16-AllGather-then-quantize.
+    Because AllGather is a lossless row concat and the 1x128 scale lives within
+    a single token's hidden vector, this is bit-identical to
+    bf16-AllGather-then-quantize.  The caller waits ``task`` and then calls
+    :func:`_split_fused_fp8_gather` to recover ``(data_e4m3_global, scale_global)``.
     """
     assert quantize_activation_blockscaled_fast is not None, (
         "Cannot find quantize_activation_blockscaled_fast, please update sonicmoe."
@@ -1320,23 +1340,39 @@ def _all_gather_grad_fp8_async(grad, group):
     nranks = group.nranks
     T_global = T_local * nranks
     H128 = scale.shape[1]
-    data_global_u8 = paddle.empty([T_global, H], dtype="uint8")
-    task_x = paddle.distributed.stream.all_gather(
-        data_global_u8,
-        x_fp8.view("uint8"),
+    scale_dtype = scale.dtype
+    # Pack fp8 data (uint8) and scale bytes into one contiguous per-token row,
+    # then AllGather once instead of twice.
+    fused_local = paddle.concat(
+        [x_fp8.view("uint8"), scale.view("uint8")], axis=1
+    ).contiguous()  # [T_local, H + 4*H128]
+    fused_global = paddle.empty(
+        [T_global, fused_local.shape[1]], dtype="uint8"
+    )
+    task = paddle.distributed.stream.all_gather(
+        fused_global,
+        fused_local,
         group=group,
         sync_op=False,
         use_calc_stream=False,
     )
-    scale_global = paddle.empty([T_global, H128], dtype=scale.dtype)
-    task_s = paddle.distributed.stream.all_gather(
-        scale_global,
-        scale.contiguous(),
-        group=group,
-        sync_op=False,
-        use_calc_stream=False,
+    return fused_global, H, H128, scale_dtype, task
+
+
+def _split_fused_fp8_gather(fused_global, H, H128, scale_dtype):
+    """Recover ``(data_e4m3_global, scale_global)`` from a fused gather buffer.
+
+    Inverse of the packing in :func:`_all_gather_grad_fp8_async` /
+    :meth:`AllGatherTokenDispatcher.pre_allgather`. Must be called only after the
+    gather task has completed.
+    """
+    T_global = fused_global.shape[0]
+    data_global_u8 = fused_global[:, :H].contiguous()
+    scale_global = fused_global[:, H:].contiguous().view(scale_dtype)
+    return (
+        data_global_u8.view("float8_e4m3fn"),
+        scale_global.reshape([T_global, H128]),
     )
-    return data_global_u8.view("float8_e4m3fn"), scale_global, task_x, task_s
 
 
 class _AllGatherCombineAsync(paddle.autograd.PyLayer):
@@ -1395,12 +1431,14 @@ class _AllGatherCombineAsync(paddle.autograd.PyLayer):
             return (grad_x,) + fn_args_grads  # noqa: RUF005
 
         if handle is not None:
-            data_e4m3, scale_global, task_x, task_s = _all_gather_grad_fp8_async(
+            fused_global, _H, _H128, _sdt, task = _all_gather_grad_fp8_async(
                 grad_output, group
             )
             fn_args_grads = ctx.bwf(*fn_out_grads)
-            task_x.wait()
-            task_s.wait()
+            task.wait()
+            data_e4m3, scale_global = _split_fused_fp8_gather(
+                fused_global, _H, _H128, _sdt
+            )
             handle["data"] = data_e4m3
             handle["scale"] = scale_global
             return (data_e4m3,) + fn_args_grads  # noqa: RUF005
@@ -1410,6 +1448,34 @@ class _AllGatherCombineAsync(paddle.autograd.PyLayer):
         task.wait()
         return (grad_x,) + fn_args_grads  # noqa: RUF005
 
+
+@paddle.no_grad()
+def _tokens_per_expert_histogram(indices, num_experts):
+    """Count tokens per expert WITHOUT any GPU->CPU synchronization.
+
+    ``indices`` is the [..., K] routing tensor that may contain ``-1`` for
+    padding tokens.  The result is an int32 ``[num_experts]`` histogram.
+
+    This replaces ``masked_select`` + ``bincount``: ``masked_select`` produces a
+    *variable-length* output (its size is data-dependent), which forces Paddle
+    to copy the element count back to the CPU, stalling the host.  ``bincount``
+    likewise must resolve ``max(input)+1`` on the CPU to size its output.  Both
+    serialize the pipeline.
+
+    Instead we build a fixed-size one-hot histogram: padding (-1) is sent to a
+    sink column ``== num_experts`` so it is dropped, and every other value is in
+    ``[0, num_experts)``.  All shapes are known a priori, so no host sync occurs.
+    Numerically identical to ``bincount(masked_select(indices, indices>=0),
+    minlength=num_experts)``.
+    """
+    flat = indices.reshape([-1]).cast("int64")
+    sink = paddle.full_like(flat, num_experts)
+    clamped = paddle.where(flat >= 0, flat, sink)
+    onehot = paddle.nn.functional.one_hot(
+        clamped, num_classes=num_experts + 1
+    )
+    counts = onehot.cast("int32").sum(axis=0)
+    return counts[:num_experts]
 
 
 class AllGatherTokenDispatcher(nn.Layer):
@@ -1467,11 +1533,7 @@ class AllGatherTokenDispatcher(nn.Layer):
         # Drain leftover handle from a possibly-aborted previous forward.
         if self._pre_ag_handle is not None:
             try:
-                if "task" in self._pre_ag_handle:
-                    self._pre_ag_handle["task"].wait()
-                else:
-                    self._pre_ag_handle["task_x"].wait()
-                    self._pre_ag_handle["task_s"].wait()
+                self._pre_ag_handle["task"].wait()
             except (RuntimeError, OSError) as _e:
                 logger.warning(
                     "pre_allgather: leftover async task wait failed (%s), "
@@ -1497,27 +1559,29 @@ class AllGatherTokenDispatcher(nn.Layer):
             T_local, H = x_fp8.shape
             T_global = T_local * self.moe_group.nranks
             H128 = scale.shape[1]
-            x_fp8_global_uint8 = paddle.empty([T_global, H], dtype="uint8")
-            task_x = paddle.distributed.stream.all_gather(
-                x_fp8_global_uint8,
-                x_fp8.view("uint8"),
-                group=self.moe_group,
-                sync_op=False,
-                use_calc_stream=False,
+            scale_dtype = scale.dtype
+            # Pack fp8 data (uint8) and scale bytes into one contiguous per-token
+            # row, then AllGather once instead of twice. Bit-identical to two
+            # separate gathers (AllGather is a lossless row concat).
+            fused_local = paddle.concat(
+                [x_fp8.view("uint8"), scale.view("uint8")], axis=1
+            ).contiguous()  # [T_local, H + 4*H128]
+            fused_global = paddle.empty(
+                [T_global, fused_local.shape[1]], dtype="uint8"
             )
-            scale_global = paddle.empty([T_global, H128], dtype=scale.dtype)
-            task_s = paddle.distributed.stream.all_gather(
-                scale_global,
-                scale,
+            task = paddle.distributed.stream.all_gather(
+                fused_global,
+                fused_local,
                 group=self.moe_group,
                 sync_op=False,
                 use_calc_stream=False,
             )
             self._pre_ag_handle = {
-                "x_fp8_global_uint8": x_fp8_global_uint8,
-                "scale_global": scale_global,
-                "task_x": task_x,
-                "task_s": task_s,
+                "fused_global": fused_global,
+                "H": H,
+                "H128": H128,
+                "scale_dtype": scale_dtype,
+                "task": task,
                 "group": self.moe_group,
                 "fp8": True,
             }
@@ -1664,19 +1728,17 @@ class AllGatherTokenDispatcher(nn.Layer):
 
     def get_dispatched_routing(self):
         """Return (global_indices, global_weights, tokens_per_expert).
-        tokens_per_expert is computed on demand via bincount."""
-        indices = self._global_topk_indices
-        flat_indices = indices.reshape([-1])
-        valid_indices = paddle.masked_select(
-            flat_indices,
-            flat_indices >= 0,
+
+        tokens_per_expert is computed on demand via a sync-free one-hot
+        histogram (see :func:`_tokens_per_expert_histogram`).  Unlike
+        ``masked_select`` + ``bincount`` this never forces a GPU->CPU sync, so
+        it does not stall the pipeline on every forward / recompute.
+        """
+        tokens_per_expert = _tokens_per_expert_histogram(
+            self._global_topk_indices, self.num_experts
         )
-        tokens_per_expert = paddle.bincount(
-            valid_indices,
-            minlength=self.num_experts,
-        ).cast("int32")
         return (
-            indices,
+            self._global_topk_indices,
             self._global_topk_weights,
             tokens_per_expert,
         )

--- a/src/paddlefleet/transformer/moe/token_dispatcher.py
+++ b/src/paddlefleet/transformer/moe/token_dispatcher.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 from __future__ import annotations
 
+import logging
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
@@ -24,6 +25,7 @@ from paddle import nn
 if TYPE_CHECKING:
     from paddle.distributed.communication.group import Group
 
+logger = logging.getLogger(__name__)
 
 from .fp8_utils import FP8_ALIGN
 from .fused_a2a import (
@@ -33,11 +35,16 @@ from .fused_a2a import (
     get_hybrid_ep_buffer,
     hybrid_ep_combine,
     hybrid_ep_dispatch,
+    quantize_activation_blockscaled_fast,
 )
 from .moe_utils import (
     AllGatherGroupOp,
+    ReduceScatterGroupOp,
     _AllToAll,
+    all_gather_group,
+    manual_backward,
     permute,
+    reduce_scatter_group,
     sort_chunks_by_idxs,
     unpermute,
     use_accuracy_compatible_kernel,
@@ -857,13 +864,33 @@ class MoEFlexTokenDispatcher(MoETokenDispatcher):
             hidden_states
         )
 
-    def token_combine(self, hidden_states: paddle.Tensor, async_finish=False):
+    def token_combine(
+        self,
+        hidden_states: paddle.Tensor,
+        combine_overlap_handle: dict | None = None,
+        async_finish=False,
+        fp8_combine_grad_handle: dict | None = None,
+    ):
+        del fp8_combine_grad_handle
+        if combine_overlap_handle is not None:
+            raise ValueError(
+                "MoEFlexTokenDispatcher (alltoall) does not support "
+                "combine_overlap_handle"
+            )
         return self._comm_manager.combine(
             hidden_states, async_finish=async_finish
         )
 
     def combine_postprocess(self, hidden_states: paddle.Tensor):
         return hidden_states.reshape(self.hidden_shape)
+
+    def get_dispatched_routing(self):
+        """Return (dispatched_indices, dispatched_probs, tokens_per_expert)."""
+        return (
+            self._comm_manager.dispatched_indices,
+            self._comm_manager.dispatched_probs,
+            self._comm_manager.tokens_per_expert,
+        )
 
     def token_permutation(
         self,
@@ -1096,7 +1123,9 @@ class AllToAllTokenDispatcher(nn.Layer):
         hidden_states: paddle.Tensor,
         combine_overlap_handle: dict | None = None,
         async_finish: bool = False,
+        fp8_combine_grad_handle: dict | None = None,
     ):
+        del combine_overlap_handle, async_finish, fp8_combine_grad_handle
         permutated_local_input_tokens = _AllToAll.apply(
             self.permutated_local_input_tokens_shape,
             hidden_states,
@@ -1114,5 +1143,736 @@ class AllToAllTokenDispatcher(nn.Layer):
             probs=(None if use_accuracy_compatible_kernel() else self.probs),
             routing_map=self.routing_map,
         )
-
         return output
+
+
+class _RouterAllGather(paddle.autograd.PyLayer):
+    """AllGather for router-local tensors (allgather dispatcher only).
+
+    Forward: same as ``AllGatherGroupOp`` — concatenates the local
+    ``[seq_local, ...]`` tensor across the EP group along axis 0 to
+    ``[seq_global, ...]``.
+
+    Backward: **scatter (not reduce-scatter)**. Each token has exactly one
+    origin rank — its router lives there and only there. Only the slice owned
+    by the current rank is a valid gradient for *this* rank's router; the rest
+    belongs to other ranks' routers and must not be summed in.
+    ``AllGatherGroupOp`` was designed for hidden_states (unique-per-rank
+    pre-AllGather, hence reduce-scatter on backward); reusing it for
+    router-local metadata is a semantics mismatch.
+
+    Gradient shape: this layer's output (``_global_topk_weights``, shape
+    ``[T_global, K]``) is consumed downstream *only* through
+    ``_differentiable_router_scores``, which gathers it via
+    ``dispatched_probs.reshape(-1)[gather_idx]``. SonicMoE's ``_DownProjection``
+    emits a 1-D ``ds`` over the gathered/padded layout, but that flows back
+    through ``_GatherRouterScores`` (scatter into a flat ``[T_global*K]``
+    buffer) and the ``reshape(-1)`` op, whose autograd restores the original
+    2-D ``[T_global, K]`` shape. So the gradient arriving here matches the
+    forward output shape exactly; no flattening reaches this edge.
+    """
+
+    @staticmethod
+    def forward(ctx, input, group):
+        ctx.group = group
+        ctx.input_shape = list(input.shape)
+        if group is None or group.nranks == 1:
+            return input.clone()
+        output_shape = list(input.shape)
+        output_shape[0] = output_shape[0] * group.nranks
+        output = paddle.empty(shape=output_shape, dtype=input.dtype)
+        paddle.distributed.stream.all_gather(
+            output, input, group=group, use_calc_stream=True
+        )
+        return output
+
+    @staticmethod
+    def backward(ctx, grad):
+        group = ctx.group
+        local_shape = ctx.input_shape
+        if group is None or group.nranks == 1:
+            if list(grad.shape) != local_shape:
+                grad = grad.reshape(local_shape)
+            return grad
+        # The incoming grad matches the forward output shape
+        # ([T_global, *trailing]); see class docstring for why no flattening
+        # reaches this edge. Split along axis 0 and take this rank's segment
+        # (scatter — no cross-rank reduction).
+        global_shape = [local_shape[0] * group.nranks, *local_shape[1:]]
+        if list(grad.shape) != global_shape:
+            # Defensive: a downstream kernel emitted an unexpected layout.
+            # Reshape only if the element count still matches, else fail loud.
+            expected_numel = 1
+            for _d in global_shape:
+                expected_numel *= _d
+            if int(grad.numel()) != expected_numel:
+                raise ValueError(
+                    "_RouterAllGather.backward: incoming grad has "
+                    f"{int(grad.numel())} elements but the AllGather'd router "
+                    f"tensor requires {expected_numel} (global_shape="
+                    f"{global_shape})."
+                )
+            grad = grad.reshape(global_shape)
+        chunks = paddle.split(grad, num_or_sections=group.nranks, axis=0)
+        out = chunks[group.rank].contiguous()
+        if list(out.shape) != local_shape:
+            out = out.reshape(local_shape)
+        return out
+
+
+class _PreAllGatherResult(paddle.autograd.PyLayer):
+    """Wraps a pre-issued async AllGather result with proper autograd.
+
+    Used by :class:`AllGatherTokenDispatcher` to overlap the hidden_states
+    AllGather (issued on the comm stream before gate) with gate computation
+    (on the calc stream).  This layer ``task.wait()``-s for the async
+    AllGather to complete and returns the pre-filled output buffer.
+    Backward is ReduceScatter (same as ``AllGatherGroupOp`` backward).
+    """
+
+    @staticmethod
+    def forward(ctx, hidden_states, handle):
+        # handle: dict {"output": Tensor, "task": Task, "group": Group}
+        handle["task"].wait()
+        ctx.group = handle["group"]
+        return handle["output"]
+
+    @staticmethod
+    def backward(ctx, grad):
+        # Backward of AllGather is ReduceScatter.
+        # ``handle`` is a plain dict (not a Tensor): Paddle's PyLayer
+        # counts only tensor positional args when matching backward
+        # returns to forward inputs, so backward must return exactly 1
+        # value (the grad for ``hidden_states``). Adding a ``None`` for
+        # ``handle`` would raise a tuple-arity mismatch on current
+        # Paddle. Verified by ``test_consumes_fake_handle``.
+        grad_input = ReduceScatterGroupOp.apply(grad, ctx.group)
+        return grad_input
+
+
+class _PreAllGatherFP8Result(paddle.autograd.PyLayer):
+    """FP8 counterpart of :class:`_PreAllGatherResult`.
+
+    Consumes a handle pre-issued by ``AllGatherTokenDispatcher.pre_allgather``
+    when ``fp8_dispatch=True``: local quantize ran on calc stream before this,
+    and two async AllGathers (fp8 uint8 view + fp32 scale) were launched on
+    the comm stream so they overlap with gate compute. Forward waits both
+    tasks and returns ``(fp8_global, scale_global)``.
+
+    The fp8 output is fed straight into SonicMoE's fused ``_UpProjection`` as
+    ``prequant_activation_payload=(x_fp8_global, scale_global)``. On backward,
+    ``_UpProjection`` produces a **bf16** ``dx`` for that activation input,
+    which the autograd engine delivers here as ``grad_output`` on the fp8
+    output edge (Paddle would normally try to materialize an fp8-typed grad to
+    match the fp8 forward output dtype; ``set_grad_in_dtype_consistent(False)``
+    + ``set_materialize_grads(False)`` disable that so we receive the native
+    bf16 grad untouched). Backward then ReduceScatters that bf16 ``dx`` back to
+    the local token shard — the dual of the forward AllGather — without any
+    fp8 reduction or dtype cast.
+    """
+
+    @staticmethod
+    def forward(ctx, hidden_states, handle):
+        handle["task_x"].wait()
+        handle["task_s"].wait()
+        ctx.group = handle["group"]
+        x_fp8_global = handle["x_fp8_global_uint8"].view("float8_e4m3fn")
+        scale_global = handle["scale_global"]
+        # The fp8 output carries a bf16 gradient (SonicMoE's _UpProjection emits
+        # bf16 dx for its activation input). Tell Paddle not to coerce the
+        # incoming grad to the fp8 output dtype, and not to materialize a zero
+        # fp8 grad buffer if the edge is unused.
+        if hasattr(ctx, "set_grad_in_dtype_consistent"):
+            ctx.set_grad_in_dtype_consistent(False)
+        ctx.set_materialize_grads(False)
+        return x_fp8_global, scale_global
+
+    @staticmethod
+    def backward(ctx, grad_output, grad_scale=None):
+        # grad_output: bf16 dx [T_global, H] from _UpProjection.backward.
+        # grad_scale: gradient for the AllGather'd scale tensor — the scale is
+        # consumed only as a non-differentiable prequant payload, so it is None.
+        del grad_scale
+        group = ctx.group
+        if grad_output is None:
+            # No gradient reached the fp8 activation edge (e.g. recompute warm-up
+            # / inference). Nothing to scatter back.
+            return None
+        if group is None or group.nranks == 1:
+            return grad_output
+        grad_input = ReduceScatterGroupOp.apply(grad_output, group)
+        return grad_input
+
+
+def _reduce_scatter_async(input, group):
+    """Async ReduceScatter (sum, axis 0) on the comm stream. Returns ``(output, task)``.
+
+    Issues a non-blocking ReduceScatter on the dedicated NCCL comm stream so
+    the caller can run independent compute on the calc stream and only
+    ``task.wait()`` right before consuming ``output``. Mirrors the async
+    AllGather pattern used by ``pre_allgather``.
+    """
+    input = input.contiguous()
+    out_shape = list(input.shape)
+    assert out_shape[0] % group.nranks == 0, (
+        f"ReduceScatter input rows {out_shape[0]} not divisible by "
+        f"nranks {group.nranks}"
+    )
+    out_shape[0] //= group.nranks
+    output = paddle.empty(shape=out_shape, dtype=input.dtype)
+    task = paddle.distributed.stream.reduce_scatter(
+        output,
+        input,
+        op=paddle.distributed.ReduceOp.SUM,
+        group=group,
+        sync_op=False,
+        use_calc_stream=False,
+    )
+    return output, task
+
+
+def _all_gather_async(input, group):
+    """Async AllGather (axis 0) on the comm stream. Returns ``(output, task)``.
+
+    Dual of :func:`_reduce_scatter_async`; used by the combine backward to
+    overlap the gradient AllGather with the shared-expert backward compute.
+    """
+    input = input.contiguous()
+    out_shape = list(input.shape)
+    out_shape[0] *= group.nranks
+    output = paddle.empty(shape=out_shape, dtype=input.dtype)
+    task = paddle.distributed.stream.all_gather(
+        output,
+        input,
+        group=group,
+        sync_op=False,
+        use_calc_stream=False,
+    )
+    return output, task
+
+
+class _AllGatherCombineAsync(paddle.autograd.PyLayer):
+    """ReduceScatter combine fused with a user-supplied subgraph (e.g. shared experts).
+
+    AllGather-path counterpart of :class:`DeepEPCombineAsync`. Forward issues
+    the combine ReduceScatter on the **comm stream** (async), then runs
+    ``fn(*fn_args)`` (the shared-expert subgraph) on the **calc stream** via
+    :func:`manual_backward` so the two genuinely overlap, and only waits on the
+    collective right before returning. Backward mirrors this: the gradient
+    AllGather (dual of ReduceScatter) is issued async on the comm stream while
+    ``bwf`` runs the shared-expert backward on the calc stream, then waits.
+
+    Forward signature: ``(x, group, *fn_args, fn, is_first_fwd)``.
+    Backward returns ``(grad_x, *fn_args_grads)`` — Paddle's PyLayer
+    skips non-tensor positional args (``group``) when matching arity.
+
+    Overlap is valid because ``fn``'s inputs (local hidden states) are
+    independent of ``x`` (the gathered expert outputs), so the shared-expert
+    compute has no data dependency on the in-flight combine collective — the
+    same precondition that makes ``DeepEPCombineAsync`` correct. Async only
+    changes the execution stream/timing; the ReduceScatter/AllGather semantics
+    (and thus numerics) are identical to the synchronous path, and combine
+    stays bf16 in both directions to match deepep — ``_DownProjection.backward``
+    self-quantizes ``dout`` to fp8, which (since AllGather is a lossless row
+    concat) is numerically identical to quantizing before the collective.
+    """
+
+    @staticmethod
+    def forward(
+        ctx,
+        x,
+        group,
+        *fn_args,
+        fn,
+        is_first_fwd=False,
+    ):
+        if fn is None:
+            raise ValueError(
+                "_AllGatherCombineAsync requires a non-None fn for overlap."
+            )
+        ctx.group = group
+
+        if group is None or group.nranks == 1:
+            combined_x = x.clone()
+            ctx.bwf, fn_out = manual_backward(fn, is_first_fwd, *fn_args)
+            return (combined_x,) + fn_out  # noqa: RUF005
+
+        # 1) Issue the combine ReduceScatter on the comm stream (async). NCCL
+        #    inserts the cross-stream dependency on ``x`` (produced on calc
+        #    stream) automatically.
+        combined_x, task = _reduce_scatter_async(x, group)
+        # 2) Run the shared-expert subgraph on the calc stream so it overlaps
+        #    with the in-flight ReduceScatter (its inputs are independent of x).
+        ctx.bwf, fn_out = manual_backward(fn, is_first_fwd, *fn_args)
+        # 3) Synchronize before the combined output is consumed downstream.
+        task.wait()
+
+        return (combined_x,) + fn_out  # noqa: RUF005
+
+    @staticmethod
+    def backward(ctx, grad_output, *fn_out_grads):
+        group = ctx.group
+        if group is None or group.nranks == 1:
+            grad_x = grad_output.clone()
+            fn_args_grads = ctx.bwf(*fn_out_grads)
+            return (grad_x,) + fn_args_grads  # noqa: RUF005
+
+        # Dual of forward: AllGather the gradient on the comm stream (async)
+        # while the shared-expert backward runs on the calc stream, then wait.
+        grad_x, task = _all_gather_async(grad_output, group)
+        fn_args_grads = ctx.bwf(*fn_out_grads)
+        task.wait()
+        return (grad_x,) + fn_args_grads  # noqa: RUF005
+
+
+
+class AllGatherTokenDispatcher(nn.Layer):
+    """
+    AllGather + ReduceScatter EP dispatcher (fused-kernel only).
+
+    Every expert is sharded along its ``intermediate`` dim into ``ep_size``
+    partitions; every rank therefore holds one shard of *every* expert. The
+    forward path is:
+
+        [seq/ep, h] --AllGather(ep)--> [seq, h]
+                  --SonicMoE fused _UpProjection / _DownProjection
+                    (gather + grouped GEMM + activation + scatter, no
+                    explicit permute / unpermute)-->
+                  [seq, h] --ReduceScatter(ep, sum)--> [seq/ep, h]
+
+    Routing is computed *before* the AllGather, so each rank only knows its
+    local routing map. The dispatcher AllGathers ``hidden_states`` plus the
+    compact ``[N, topk]`` routing tensors so that every rank performs the
+    same expert compute on the global token list (saving bandwidth versus
+    AllGathering the full ``[N, num_experts]`` sparse tensors).
+
+    This dispatcher only reuses SonicMoE's fused expert-compute kernels; it
+    does not engage any other SonicMoE component (router, dispatcher, fp8
+    protocol).
+    """
+
+    def __init__(
+        self,
+        moe_group: Group,
+        expert_model_parallel_size: int,
+        num_experts: int,
+        fp8_dispatch: bool = False,
+        use_ue8m0: bool = False,
+    ):
+        nn.Layer.__init__(self)
+        self.moe_group = moe_group
+        self.ep_size = expert_model_parallel_size
+        self.num_experts = num_experts
+        # In allgather mode every rank holds a shard of every expert.
+        self.num_local_experts = num_experts
+        # fp8 dispatch quantizes hidden_states to fp8 *before* the AllGather so
+        # the inter-rank communication carries fp8 bytes (plus a compact
+        # blockwise scale) instead of bf16, mirroring DeepEP. The fp8 activation
+        # is consumed directly by SonicMoE's fused ``_UpProjection`` via
+        # ``prequant_activation_payload=(x_fp8, scale)`` (no re-quantization).
+        # Backward: ``_UpProjection`` emits a bf16 ``dx`` for its activation
+        # input — which is exactly ``_PreAllGatherFP8Result``'s fp8 output edge.
+        # ``_PreAllGatherFP8Result`` declares grad-dtype inconsistency so it can
+        # receive that bf16 grad on its fp8 output and ReduceScatter it back to
+        # the local shard.
+        self.fp8_dispatch = fp8_dispatch
+        self.use_ue8m0 = use_ue8m0
+        # Handle for a pre-issued async AllGather of hidden_states (set by
+        # ``pre_allgather``, consumed by ``dispatch_preprocess``).
+        self._pre_ag_handle: dict | None = None
+        # Populated by ``dispatch_preprocess`` — global routing metadata
+        # after AllGather across the EP group.
+        self._global_topk_indices = None
+        self._global_topk_weights = None
+        # Populated by ``dispatch_preprocess`` when fp8_dispatch is active —
+        # the AllGather'd blockwise scale tensor, reused by downstream fused
+        # kernels (``run_sonic_moe``) as ``prequant_activation_payload`` to
+        # skip redundant re-quantization, mirroring DeepEP's contract.
+        self._fp8_dispatch_scale = None
+        # Cache for the overlap-combine path (set by ``token_combine``,
+        # consumed by ``combine_postprocess``).
+        self._overlap_combined = None
+
+    def pre_allgather(self, hidden_states: paddle.Tensor):
+        """Issue an async AllGather for *hidden_states* on the comm stream.
+
+        Called **before** gate computation so that the AllGather runs on the
+        dedicated NCCL comm stream while the gate MLP runs on the calc stream.
+        The result is stored in ``self._pre_ag_handle`` and consumed by
+        :meth:`dispatch_preprocess`.
+
+        Two flavors:
+        - bf16 path: a single async AllGather on the comm stream.
+        - fp8 path (``fp8_dispatch=True``): quantize locally (calc stream),
+          then issue two async AllGathers (fp8 uint8 view + fp32 scale) on
+          the comm stream so both overlap with gate compute. Consumed via
+          :class:`_PreAllGatherFP8Result`.
+        """
+        if self.moe_group is None or self.moe_group.nranks == 1:
+            self._pre_ag_handle = None
+            return
+
+        # Drain any leftover handle from a previous (possibly aborted)
+        # forward, so its NCCL task and output buffer are released before
+        # we issue a new one. This protects against OOM retries / aborted
+        # iterations where ``dispatch_preprocess`` never consumed the
+        # previous handle.
+        if self._pre_ag_handle is not None:
+            try:
+                if "task" in self._pre_ag_handle:
+                    self._pre_ag_handle["task"].wait()
+                else:
+                    self._pre_ag_handle["task_x"].wait()
+                    self._pre_ag_handle["task_s"].wait()
+            except (RuntimeError, OSError) as _e:
+                logger.warning(
+                    "pre_allgather: leftover async task wait failed (%s), "
+                    "discarding handle.",
+                    _e,
+                )
+            self._pre_ag_handle = None
+
+        if len(hidden_states.shape) == 3:
+            _, _, d_model = hidden_states.shape
+        else:
+            _, d_model = hidden_states.shape
+        reshaped_input = hidden_states.reshape([-1, d_model]).contiguous()
+
+        if self.fp8_dispatch:
+            # FP8 async path: quantize on calc stream, then issue both
+            # AllGathers (fp8 data + scale) on the comm stream so they
+            # overlap with gate MLP. quantize_activation_blockscaled_fast
+            # itself runs on the calc stream and finishes before the
+            # comm-stream collectives consume its outputs (NCCL handles
+            # the cross-stream sync).
+            assert quantize_activation_blockscaled_fast is not None, (
+                "Cannot find quantize_activation_blockscaled_fast, "
+                "please update sonicmoe."
+            )
+            x_fp8, scale = quantize_activation_blockscaled_fast(
+                reshaped_input, scale_dtype=paddle.int32
+            )
+            T_local, H = x_fp8.shape
+            T_global = T_local * self.moe_group.nranks
+            H128 = scale.shape[1]
+            x_fp8_global_uint8 = paddle.empty([T_global, H], dtype="uint8")
+            task_x = paddle.distributed.stream.all_gather(
+                x_fp8_global_uint8,
+                x_fp8.view("uint8"),
+                group=self.moe_group,
+                sync_op=False,
+                use_calc_stream=False,
+            )
+            scale_global = paddle.empty([T_global, H128], dtype=scale.dtype)
+            task_s = paddle.distributed.stream.all_gather(
+                scale_global,
+                scale,
+                group=self.moe_group,
+                sync_op=False,
+                use_calc_stream=False,
+            )
+            self._pre_ag_handle = {
+                "x_fp8_global_uint8": x_fp8_global_uint8,
+                "scale_global": scale_global,
+                "task_x": task_x,
+                "task_s": task_s,
+                "group": self.moe_group,
+                "fp8": True,
+            }
+            return
+
+        output_shape = list(reshaped_input.shape)
+        output_shape[0] = output_shape[0] * self.moe_group.nranks
+        global_hidden_states = paddle.empty(
+            shape=output_shape, dtype=reshaped_input.dtype
+        )
+        task = paddle.distributed.stream.all_gather(
+            global_hidden_states,
+            reshaped_input,
+            group=self.moe_group,
+            sync_op=False,
+            use_calc_stream=False,
+        )
+
+        self._pre_ag_handle = {
+            "output": global_hidden_states,
+            "task": task,
+            "group": self.moe_group,
+        }
+
+    def dispatch_preprocess(
+        self,
+        hidden_states: paddle.Tensor,
+        probs: paddle.Tensor,
+        mask: paddle.Tensor,  # routing_map
+        topk_weights: paddle.Tensor | None = None,
+        topk_indices: paddle.Tensor | None = None,
+    ) -> paddle.Tensor:
+        """AllGather hidden_states and topk metadata across the EP group.
+
+        Reuses ``_pre_ag_handle`` if :meth:`pre_allgather` was called;
+        otherwise performs a sync AllGather (FP8 path when ``fp8_dispatch``
+        is on, plain bf16 otherwise). The unpermuted global hidden states
+        are returned — fused SonicMoE kernels handle gather/scatter inside
+        the expert compute, so no explicit permute happens here.
+
+        Side effects: caches ``_global_topk_indices`` and
+        ``_global_topk_weights`` for the fused expert compute, and sets
+        ``tokens_per_expert = None`` (the consumer recomputes it).
+
+        Raises:
+            ValueError: if ``topk_indices`` or ``topk_weights`` is None.
+        """
+        if len(hidden_states.shape) == 3:
+            _, _, d_model = hidden_states.shape
+        else:
+            _, d_model = hidden_states.shape
+        reshaped_input = hidden_states.reshape([-1, d_model]).contiguous()
+
+        # Reset fp8 dispatch state — will be set below only when fp8 path is taken.
+        self._fp8_dispatch_scale = None
+
+        # AllGather hidden_states along token dim across the EP group.
+        # If pre_allgather() was called before gate, reuse the async result;
+        # otherwise fall back to the synchronous path.
+        if self._pre_ag_handle is not None:
+            if self._pre_ag_handle.get("fp8", False):
+                global_hidden_states, self._fp8_dispatch_scale = (
+                    _PreAllGatherFP8Result.apply(
+                        reshaped_input, self._pre_ag_handle
+                    )
+                )
+            else:
+                global_hidden_states = _PreAllGatherResult.apply(
+                    reshaped_input, self._pre_ag_handle
+                )
+            self._pre_ag_handle = None
+        elif self.fp8_dispatch:
+            raise RuntimeError(
+                "AllGatherTokenDispatcher.fp8_dispatch=True requires "
+                "pre_allgather() to be issued before dispatch_preprocess."
+            )
+        else:
+            global_hidden_states = AllGatherGroupOp.apply(
+                reshaped_input, self.moe_group
+            )
+
+        # Memory-saving fused path: skip permute entirely; the fused SonicMoE
+        # kernels (_UpProjection/_DownProjection) handle gather/scatter
+        # internally. We only AllGather the topk metadata and return the
+        # unpermuted global hidden states.
+        if topk_indices is None or topk_weights is None:
+            raise ValueError(
+                "AllGatherTokenDispatcher requires topk_indices and "
+                "topk_weights to be provided."
+            )
+        # Indices are routing IDs in [0, num_experts) (or -1 for padding), so
+        # int32 covers the range with room to spare (num_experts << 2^31) while
+        # halving the AllGather payload vs int64. The downstream SonicMoE
+        # metadata kernel (deepep_topk_to_sonic_metadata) casts to int32 anyway.
+        self._global_topk_indices = AllGatherGroupOp.apply(
+            topk_indices.detach().cast("int32"), self.moe_group
+        )
+        # Padding tokens have topk_indices == -1 (set by TopKRouter).
+        # Keep the sentinel in indices so SonicMoE metadata can treat those
+        # slots as masked; only zero the corresponding routing weights below.
+        self._padding_mask = self._global_topk_indices < 0
+        # Router-local AllGather: every token has exactly one origin rank,
+        # so the topk_weights gradient flowing back from sonic-moe's
+        # _DownProjection (shape [seq_global, K]) must be *scattered* (slice
+        # this rank's segment), not reduce-scattered. _RouterAllGather
+        # implements scatter on backward, which is the correct semantics
+        # for router-owned tensors and lets the router receive main-loss
+        # gradients on this rank — matching the alltoall/deepep contract
+        # where router weights are also trained by the main loss via the
+        # unpermute(probs=...) multiplication.
+        self._global_topk_weights = _RouterAllGather.apply(
+            topk_weights.cast(probs.dtype), self.moe_group
+        )
+        # Zero out weights for padding tokens (indices were clipped above).
+        # Apply the mask unconditionally: a ``.any()`` guard would force a
+        # GPU->CPU sync every step just to decide whether to run the where.
+        # ``_padding_mask`` is already a bool tensor (``< 0``), so feed it to
+        # ``paddle.where`` directly — the previous bool->float->bool cast was a
+        # no-op roundtrip. Numerically identical (all-False mask leaves the
+        # weights untouched).
+        self._global_topk_weights = paddle.where(
+            self._padding_mask,
+            paddle.zeros_like(self._global_topk_weights),
+            self._global_topk_weights,
+        )
+        # NOTE: tokens_per_expert is intentionally NOT computed here.
+        # The allgather branch of fusion_moe_forward (moe_layer.py) passes
+        # `_global_topk_indices` directly to `SonicMoEExpert.forward()` /
+        # `run_sonic_moe`, which internally computes the token counts and
+        # cumsum offsets needed by the fused kernels. A bincount here would
+        # be pure waste. We return None to keep the dispatcher contract
+        # `(global_input_tokens, tokens_per_expert)` but the consumer
+        # ignores it on this path.
+        self.tokens_per_expert = None
+        # Return unpermuted global hidden states — fused kernels do the rest
+        return global_hidden_states
+
+    def token_dispatch(
+        self,
+        permuted_global_input_tokens: paddle.Tensor,
+        fp8_dispatch: bool = False,
+        async_finish: bool = False,
+        use_ue8m0: bool = False,
+        using_sonic_moe: bool = True,
+    ):
+        """No-op pass-through for the AllGather path.
+
+        After :meth:`dispatch_preprocess`, every rank already holds the full
+        global token list, so no further inter-rank communication is needed.
+        ``fp8_dispatch`` / ``async_finish`` / ``use_ue8m0`` are accepted for
+        signature compatibility with other dispatchers; the actual FP8
+        quantization is handled inside ``dispatch_preprocess``.
+
+        ``using_sonic_moe`` must be True on this path: the AllGather
+        dispatcher feeds ``_global_topk_indices`` directly into
+        ``SonicMoEExpert.forward`` / ``run_sonic_moe`` (see
+        ``dispatch_preprocess``). Any other expert path is unsupported here.
+
+        Returns:
+            tuple: ``(global_tokens, fp8_handle)``. When ``_fp8_dispatch_scale``
+            was captured during :meth:`dispatch_preprocess` (fp8 path), the handle
+            is ``{"scale": scale}`` matching DeepEP's contract so downstream
+            fused kernels can reuse the dispatch scale as
+            ``prequant_activation_payload``.
+        """
+        if not using_sonic_moe:
+            raise ValueError(
+                "AllGatherTokenDispatcher requires using_sonic_moe=True; "
+                "the AllGather path is only wired for the fused SonicMoE "
+                "expert kernels. Switch dispatcher type or enable SonicMoE."
+            )
+        fp8_handle = (
+            {"scale": self._fp8_dispatch_scale}
+            if self._fp8_dispatch_scale is not None
+            else None
+        )
+        return permuted_global_input_tokens, fp8_handle
+
+    def get_dispatched_routing(self):
+        """Return (dispatched_indices, dispatched_probs, tokens_per_expert).
+
+        For AllGather, tokens_per_expert is computed on demand via bincount
+        since every rank holds all experts and the global token counts are
+        already complete. ``paddle.bincount`` defaults to int64; cast to
+        int32 to match the dtype contract expected by the downstream
+        SonicMoE metadata kernel (``deepep_topk_to_sonic_metadata``).
+        """
+        indices = self._global_topk_indices
+        flat_indices = indices.reshape([-1])
+        valid_indices = paddle.masked_select(
+            flat_indices,
+            flat_indices >= 0,
+        )
+        tokens_per_expert = paddle.bincount(
+            valid_indices,
+            minlength=self.num_experts,
+        ).cast("int32")
+        return (
+            indices,
+            self._global_topk_weights,
+            tokens_per_expert,
+        )
+
+    def dispatch_postprocess(
+        self,
+        global_input_tokens: paddle.Tensor,
+    ):
+        """Return the cached ``(global_tokens, tokens_per_expert)`` tuple.
+
+        Mirrors the dispatcher protocol; ``tokens_per_expert`` is ``None``
+        on this path because the fused SonicMoE kernels recompute it from
+        ``_global_topk_indices``.
+        """
+        return global_input_tokens, self.tokens_per_expert
+
+    def combine_preprocess(self, hidden_states: paddle.Tensor):
+        """No-op pass-through (no unpermute on the fused path)."""
+        return hidden_states
+
+    def token_combine(
+        self,
+        hidden_states: paddle.Tensor,
+        combine_overlap_handle: dict | None = None,
+        async_finish: bool = False,
+        fp8_combine_grad_handle: dict | None = None,
+    ):
+        """ReduceScatter the expert outputs back to the local token shard.
+
+        When ``combine_overlap_handle`` is None this is a no-op; the actual
+        ReduceScatter is deferred to :meth:`combine_postprocess`. When it
+        is provided, the ReduceScatter is fused with a user-supplied
+        subgraph (typically the shared-expert MLP) via
+        :class:`_AllGatherCombineAsync` and the combined output is cached
+        for ``combine_postprocess`` to return as-is. The handle dict is
+        mutated in place: ``fn_out`` receives the subgraph outputs.
+
+        Args:
+            combine_overlap_handle: dict with keys ``fn`` (callable) and
+                ``fn_args`` (tuple). On return, ``fn_out`` is populated.
+            fp8_combine_grad_handle: accepted for caller-signature parity but
+                unused on the allgather path. The combine collectives stay
+                bf16 in both directions; ``_DownProjection.backward`` quantizes
+                ``dout`` itself. Since the backward AllGather is a lossless row
+                concat (no reduction), self-quant-after-AllGather is numerically
+                identical to quant-before — so this path already matches
+                deepep+sonic precision without any extra fp8 collective.
+        """
+        del fp8_combine_grad_handle
+
+        if combine_overlap_handle is None:
+            self._overlap_combined = None
+            return hidden_states
+        if not isinstance(combine_overlap_handle, dict):
+            raise TypeError(
+                "combine_overlap_handle must be a dict, got "
+                f"{type(combine_overlap_handle).__name__}"
+            )
+        if (
+            "fn" not in combine_overlap_handle
+            or "fn_args" not in combine_overlap_handle
+        ):
+            raise ValueError(
+                "combine_overlap_handle must contain 'fn' and 'fn_args' keys"
+            )
+        if not isinstance(combine_overlap_handle["fn_args"], tuple):
+            raise TypeError(
+                "combine_overlap_handle['fn_args'] must be a tuple, got "
+                f"{type(combine_overlap_handle['fn_args']).__name__}"
+            )
+        from paddle import framework as _framework
+
+        combined_x, *fn_out = _AllGatherCombineAsync.apply(
+            hidden_states,
+            self.moe_group,
+            *(combine_overlap_handle["fn_args"]),
+            fn=combine_overlap_handle["fn"],
+            is_first_fwd=not _framework._dygraph_tracer()._has_grad,
+        )
+        combine_overlap_handle["fn_out"] = tuple(fn_out)
+        self._overlap_combined = combined_x
+        return combined_x
+
+    def combine_postprocess(self, hidden_states: paddle.Tensor):
+        """ReduceScatter the partial-sum expert outputs to the local shard.
+
+        The fused ``_DownProjection`` already scattered back to
+        ``[global_T, h]`` with topk weights applied, but the result is a
+        partial sum across the EP-sharded intermediate dim. This step sums
+        across EP ranks and slices to the per-rank token segment.
+
+        If :meth:`token_combine` already performed the ReduceScatter (the
+        overlap path), the cached output is returned and the cache cleared.
+        """
+        if getattr(self, "_overlap_combined", None) is not None:
+            # ReduceScatter was already performed (fused with shared experts) in
+            # ``token_combine``; pass the cached output through.
+            out = self._overlap_combined
+            self._overlap_combined = None
+            return out
+        return ReduceScatterGroupOp.apply(hidden_states, self.moe_group)

--- a/src/paddlefleet/transformer/moe/token_dispatcher.py
+++ b/src/paddlefleet/transformer/moe/token_dispatcher.py
@@ -1147,52 +1147,18 @@ class AllToAllTokenDispatcher(nn.Layer):
 
 
 class _RouterAllGather(paddle.autograd.PyLayer):
-    """AllGather for router routing weights (allgather dispatcher only).
+    """AllGather for router topk weights, used only by the allgather dispatcher.
 
-    Forward: concatenates the local ``[seq_local, K]`` routing-weight tensor
-    across the EP group along axis 0 to ``[seq_global, K]``.
+    Forward:  [T_local, K] --AllGather(EP)--> [T_global, K]  (identical on all ranks)
+    Backward: [T_global, K] --ReduceScatter(EP, SUM)--> [T_local, K]
 
-    Backward: **reduce-scatter** (sum across the EP group, then take this
-    rank's token segment).
-
-    Why reduce-scatter and not plain scatter:
-    in the allgather dispatcher every expert is sharded along its
-    *intermediate* dim, so **every** EP rank holds a shard of *every* expert
-    and recomputes a partial expert output for the *entire* global token list
-    using the same all-gathered routing weight ``w_t``. The combined output is
-
-        out_t = w_t * sum_i(down_proj_shard_i(t))          (sum over EP ranks i)
-
-    so the gradient that token ``t``'s router must receive is
-
-        d_loss/d_w_t = grad_out_t · sum_i(down_proj_shard_i(t))
-                     = sum_i ( grad_out_t · down_proj_shard_i(t) )
-                     = sum_i ds_i(t)
-
-    Each rank ``i`` only computes its own term ``ds_i(t)`` locally (via
-    SonicMoE's ``_DownProjection`` over its intermediate shard); the autograd
-    engine therefore delivers, on each rank, a ``[T_global, K]`` gradient
-    holding *that rank's* partial ``ds_i``. The router for token ``t`` lives on
-    a single origin rank, but its correct gradient is the **sum over all
-    ranks** of those partials — i.e. reduce (sum) then scatter to the origin
-    segment. This is exactly the standard backward of an all-gather whose
-    output is independently consumed on every rank.
-
-    A plain scatter (the previous implementation) kept only the origin rank's
-    own shard term ``ds_origin(t)`` and dropped ``ds_{j != origin}(t)``,
-    delivering ~1/nranks of the true router gradient (half of it at EP=2). That
-    under-trained the router and made the allgather path converge measurably
-    worse than the deepep+sonic path, which does not shard experts along the
-    intermediate dim and so gives its router the full single-rank gradient.
-    Reduce-scatter makes the two numerically equivalent: ``sum_i ds_i(t)``
-    equals deepep's single ``grad_out_t · full_down_value(t)``.
-
-    Gradient shape: this layer's output (``_global_topk_weights``, shape
-    ``[T_global, K]``) is consumed downstream only through
-    ``_differentiable_router_scores`` -> ``_GatherRouterScores`` -> a
-    ``reshape(-1)``, whose autograd restores the original 2-D ``[T_global, K]``
-    layout, so the gradient arriving here matches the forward output shape; no
-    flattening reaches this edge.
+    In the allgather dispatcher every EP rank holds an intermediate-dim shard
+    of every expert and computes a partial expert output for ALL global tokens
+    using the same all-gathered router weights.  Each rank therefore produces
+    its own partial gradient for the shared weight tensor; the backward must
+    sum these partials (reduce) and return each rank its own token segment
+    (scatter).  A plain scatter would keep only the origin rank's partial and
+    discard the rest, under-training the router by ~1/nranks.
     """
 
     @staticmethod
@@ -1217,16 +1183,8 @@ class _RouterAllGather(paddle.autograd.PyLayer):
             if list(grad.shape) != local_shape:
                 grad = grad.reshape(local_shape)
             return grad
-        # The incoming grad matches the forward output shape
-        # ([T_global, *trailing]); see class docstring for why no flattening
-        # reaches this edge. Reduce-scatter (sum across EP, then take this
-        # rank's segment) — every rank contributed a partial router-weight
-        # gradient for the global token list, so the per-token gradient is the
-        # cross-rank sum, not just this rank's own slice.
         global_shape = [local_shape[0] * group.nranks, *local_shape[1:]]
         if list(grad.shape) != global_shape:
-            # Defensive: a downstream kernel emitted an unexpected layout.
-            # Reshape only if the element count still matches, else fail loud.
             expected_numel = 1
             for _d in global_shape:
                 expected_numel *= _d
@@ -1245,54 +1203,38 @@ class _RouterAllGather(paddle.autograd.PyLayer):
 
 
 class _PreAllGatherResult(paddle.autograd.PyLayer):
-    """Wraps a pre-issued async AllGather result with proper autograd.
+    """Consume a pre-issued async AllGather of hidden_states.
 
-    Used by :class:`AllGatherTokenDispatcher` to overlap the hidden_states
-    AllGather (issued on the comm stream before gate) with gate computation
-    (on the calc stream).  This layer ``task.wait()``-s for the async
-    AllGather to complete and returns the pre-filled output buffer.
-    Backward is ReduceScatter (same as ``AllGatherGroupOp`` backward).
+    Forward waits for the async NCCL task and returns the filled buffer.
+    Backward is ReduceScatter (dual of AllGather).
+    The ``handle`` is a plain dict, not a tensor, so Paddle's PyLayer does not
+    expect a gradient for it — backward returns only one value.
     """
 
     @staticmethod
     def forward(ctx, hidden_states, handle):
-        # handle: dict {"output": Tensor, "task": Task, "group": Group}
         handle["task"].wait()
         ctx.group = handle["group"]
         return handle["output"]
 
     @staticmethod
     def backward(ctx, grad):
-        # Backward of AllGather is ReduceScatter.
-        # ``handle`` is a plain dict (not a Tensor): Paddle's PyLayer
-        # counts only tensor positional args when matching backward
-        # returns to forward inputs, so backward must return exactly 1
-        # value (the grad for ``hidden_states``). Adding a ``None`` for
-        # ``handle`` would raise a tuple-arity mismatch on current
-        # Paddle. Verified by ``test_consumes_fake_handle``.
         grad_input = ReduceScatterGroupOp.apply(grad, ctx.group)
         return grad_input
 
 
 class _PreAllGatherFP8Result(paddle.autograd.PyLayer):
-    """FP8 counterpart of :class:`_PreAllGatherResult`.
+    """FP8 variant of _PreAllGatherResult.
 
-    Consumes a handle pre-issued by ``AllGatherTokenDispatcher.pre_allgather``
-    when ``fp8_dispatch=True``: local quantize ran on calc stream before this,
-    and two async AllGathers (fp8 uint8 view + fp32 scale) were launched on
-    the comm stream so they overlap with gate compute. Forward waits both
-    tasks and returns ``(fp8_global, scale_global)``.
+    Forward waits for two async AllGather tasks (fp8 data + block scale) and
+    returns ``(x_fp8_global, scale_global)``.  The fp8 tensor is consumed
+    directly by SonicMoE's _UpProjection via prequant_activation_payload.
 
-    The fp8 output is fed straight into SonicMoE's fused ``_UpProjection`` as
-    ``prequant_activation_payload=(x_fp8_global, scale_global)``. On backward,
-    ``_UpProjection`` produces a **bf16** ``dx`` for that activation input,
-    which the autograd engine delivers here as ``grad_output`` on the fp8
-    output edge (Paddle would normally try to materialize an fp8-typed grad to
-    match the fp8 forward output dtype; ``set_grad_in_dtype_consistent(False)``
-    + ``set_materialize_grads(False)`` disable that so we receive the native
-    bf16 grad untouched). Backward then ReduceScatters that bf16 ``dx`` back to
-    the local token shard — the dual of the forward AllGather — without any
-    fp8 reduction or dtype cast.
+    _UpProjection.backward produces a bf16 dx for the activation input, but
+    the forward output here is fp8.  set_grad_in_dtype_consistent(False) and
+    set_materialize_grads(False) tell Paddle to pass the bf16 grad through
+    without dtype coercion.  Backward then ReduceScatters that bf16 grad back
+    to the local token shard.
     """
 
     @staticmethod
@@ -1302,24 +1244,15 @@ class _PreAllGatherFP8Result(paddle.autograd.PyLayer):
         ctx.group = handle["group"]
         x_fp8_global = handle["x_fp8_global_uint8"].view("float8_e4m3fn")
         scale_global = handle["scale_global"]
-        # The fp8 output carries a bf16 gradient (SonicMoE's _UpProjection emits
-        # bf16 dx for its activation input). Tell Paddle not to coerce the
-        # incoming grad to the fp8 output dtype, and not to materialize a zero
-        # fp8 grad buffer if the edge is unused.
         ctx.set_grad_in_dtype_consistent(False)
         ctx.set_materialize_grads(False)
         return x_fp8_global, scale_global
 
     @staticmethod
     def backward(ctx, grad_output, grad_scale=None):
-        # grad_output: bf16 dx [T_global, H] from _UpProjection.backward.
-        # grad_scale: gradient for the AllGather'd scale tensor — the scale is
-        # consumed only as a non-differentiable prequant payload, so it is None.
         del grad_scale
         group = ctx.group
         if grad_output is None:
-            # No gradient reached the fp8 activation edge (e.g. recompute warm-up
-            # / inference). Nothing to scatter back.
             return None
         if group is None or group.nranks == 1:
             return grad_output
@@ -1328,13 +1261,8 @@ class _PreAllGatherFP8Result(paddle.autograd.PyLayer):
 
 
 def _reduce_scatter_async(input, group):
-    """Async ReduceScatter (sum, axis 0) on the comm stream. Returns ``(output, task)``.
-
-    Issues a non-blocking ReduceScatter on the dedicated NCCL comm stream so
-    the caller can run independent compute on the calc stream and only
-    ``task.wait()`` right before consuming ``output``. Mirrors the async
-    AllGather pattern used by ``pre_allgather``.
-    """
+    """Async ReduceScatter (SUM, axis 0) on the comm stream.
+    Returns (output, task)."""
     input = input.contiguous()
     out_shape = list(input.shape)
     assert out_shape[0] % group.nranks == 0, (
@@ -1355,11 +1283,8 @@ def _reduce_scatter_async(input, group):
 
 
 def _all_gather_async(input, group):
-    """Async AllGather (axis 0) on the comm stream. Returns ``(output, task)``.
-
-    Dual of :func:`_reduce_scatter_async`; used by the combine backward to
-    overlap the gradient AllGather with the shared-expert backward compute.
-    """
+    """Async AllGather (axis 0) on the comm stream.
+    Returns (output, task)."""
     input = input.contiguous()
     out_shape = list(input.shape)
     out_shape[0] *= group.nranks
@@ -1375,21 +1300,14 @@ def _all_gather_async(input, group):
 
 
 def _all_gather_grad_fp8_async(grad, group):
-    """fp8 counterpart of :func:`_all_gather_async` for the combine backward.
+    """Quantize local grad to fp8 e4m3 + int32 1x128 block scale, then async
+    AllGather both on the comm stream.  Returns
+    ``(data_e4m3_global, scale_global, task_x, task_s)``.
 
-    Quantizes the **local** combine gradient to fp8 e4m3 + int32 1x128 block
-    scale on the calc stream, then issues two async AllGathers (uint8 data +
-    int32 scale, axis 0 row-concat) on the comm stream. Because the combine
-    backward collective is a *lossless row concat* (AllGather, no reduction)
-    and the 1x128 block scale lives entirely within a single token's hidden
-    vector, quantize-before-AllGather is **bit-identical** to the bf16-then-
-    self-quantize path used previously — it just halves the on-wire bytes
-    (1B vs 2B) and matches deepep+sonic's ``DeepEPCombine.backward``.
-
-    Returns ``(data_e4m3_global, scale_global, task_x, task_s)`` where
-    ``data_e4m3_global`` is the gathered fp8 tensor viewed back to
-    ``float8_e4m3fn`` (shape ``[global_T, H]``) and ``scale_global`` the
-    gathered int32 block scales (shape ``[global_T, H//128]``).
+    Used by the combine backward to halve on-wire bytes vs bf16 AllGather.
+    Because AllGather is a lossless row concat and the 1x128 scale lives
+    within a single token's hidden vector, this is bit-identical to
+    bf16-AllGather-then-quantize.
     """
     assert quantize_activation_blockscaled_fast is not None, (
         "Cannot find quantize_activation_blockscaled_fast, please update sonicmoe."
@@ -1422,37 +1340,21 @@ def _all_gather_grad_fp8_async(grad, group):
 
 
 class _AllGatherCombineAsync(paddle.autograd.PyLayer):
-    """ReduceScatter combine fused with a user-supplied subgraph (e.g. shared experts).
+    """Fuse the combine ReduceScatter with a shared-expert subgraph for overlap.
 
-    AllGather-path counterpart of :class:`DeepEPCombineAsync`. Forward issues
-    the combine ReduceScatter on the **comm stream** (async), then runs
-    ``fn(*fn_args)`` (the shared-expert subgraph) on the **calc stream** via
-    :func:`manual_backward` so the two genuinely overlap, and only waits on the
-    collective right before returning. Backward mirrors this: the gradient
-    AllGather (dual of ReduceScatter) is issued async on the comm stream while
-    ``bwf`` runs the shared-expert backward on the calc stream, then waits.
+    Forward:
+      1. Issue async ReduceScatter of expert output on comm stream.
+      2. Run shared-expert subgraph on calc stream (concurrent with step 1).
+      3. Wait for ReduceScatter, return (combined_x,) + fn_out.
 
-    Forward signature: ``(x, group, *fn_args, fn, is_first_fwd)``.
-    Backward returns ``(grad_x, *fn_args_grads)`` — Paddle's PyLayer
-    skips non-tensor positional args (``group``) when matching arity.
+    Backward (dual):
+      - bf16 path: async AllGather of grad on comm stream while shared-expert
+        backward runs on calc stream.
+      - fp8 path (fp8_combine_grad_handle != None): quantize local grad to fp8,
+        async AllGather both data and scale on comm stream, write results into
+        the handle for _DownProjection.backward to consume directly.
 
-    Overlap is valid because ``fn``'s inputs (local hidden states) are
-    independent of ``x`` (the gathered expert outputs), so the shared-expert
-    compute has no data dependency on the in-flight combine collective — the
-    same precondition that makes ``DeepEPCombineAsync`` correct. Async only
-    changes the execution stream/timing; the ReduceScatter/AllGather semantics
-    (and thus numerics) are identical to the synchronous path.
-
-    Combine forward stays bf16 in both paths. Combine **backward** is fp8 when
-    ``fp8_combine_grad_handle`` is supplied (``fp8_dispatch and
-    using_sonic_moe``): the local gradient is quantized to fp8 e4m3 + int32
-    block scale *before* the AllGather (1B/elem vs 2B), the gathered fp8
-    data+scale are written into the handle and consumed directly by
-    ``_DownProjection.backward`` (skipping its internal re-quantization).
-    Because the combine-backward AllGather is a lossless row concat and the
-    1x128 scale lives within a single token's hidden vector, this is
-    bit-identical to the bf16-then-self-quantize path while matching
-    deepep+sonic's ``DeepEPCombine.backward`` bandwidth.
+    Overlap is safe because fn's inputs are independent of x (expert output).
     """
 
     @staticmethod
@@ -1477,14 +1379,8 @@ class _AllGatherCombineAsync(paddle.autograd.PyLayer):
             ctx.bwf, fn_out = manual_backward(fn, is_first_fwd, *fn_args)
             return (combined_x,) + fn_out  # noqa: RUF005
 
-        # 1) Issue the combine ReduceScatter on the comm stream (async). NCCL
-        #    inserts the cross-stream dependency on ``x`` (produced on calc
-        #    stream) automatically.
         combined_x, task = _reduce_scatter_async(x, group)
-        # 2) Run the shared-expert subgraph on the calc stream so it overlaps
-        #    with the in-flight ReduceScatter (its inputs are independent of x).
         ctx.bwf, fn_out = manual_backward(fn, is_first_fwd, *fn_args)
-        # 3) Synchronize before the combined output is consumed downstream.
         task.wait()
 
         return (combined_x,) + fn_out  # noqa: RUF005
@@ -1499,11 +1395,6 @@ class _AllGatherCombineAsync(paddle.autograd.PyLayer):
             return (grad_x,) + fn_args_grads  # noqa: RUF005
 
         if handle is not None:
-            # fp8 combine backward: quantize the local grad to fp8 e4m3 +
-            # int32 scale, AllGather both on the comm stream (async) while the
-            # shared-expert backward runs on the calc stream, then wait. The
-            # gathered fp8 data+scale are handed to ``_DownProjection.backward``
-            # via the handle; the returned ``grad_x`` is the fp8 data edge.
             data_e4m3, scale_global, task_x, task_s = _all_gather_grad_fp8_async(
                 grad_output, group
             )
@@ -1514,8 +1405,6 @@ class _AllGatherCombineAsync(paddle.autograd.PyLayer):
             handle["scale"] = scale_global
             return (data_e4m3,) + fn_args_grads  # noqa: RUF005
 
-        # Dual of forward: AllGather the gradient on the comm stream (async)
-        # while the shared-expert backward runs on the calc stream, then wait.
         grad_x, task = _all_gather_async(grad_output, group)
         fn_args_grads = ctx.bwf(*fn_out_grads)
         task.wait()
@@ -1524,28 +1413,20 @@ class _AllGatherCombineAsync(paddle.autograd.PyLayer):
 
 
 class AllGatherTokenDispatcher(nn.Layer):
-    """
-    AllGather + ReduceScatter EP dispatcher (fused-kernel only).
+    """AllGather + ReduceScatter EP dispatcher (SonicMoE fused-kernel only).
 
-    Every expert is sharded along its ``intermediate`` dim into ``ep_size``
-    partitions; every rank therefore holds one shard of *every* expert. The
-    forward path is:
+    Every expert is sharded along its intermediate dim into EP partitions;
+    every rank holds all experts but only its I/EP shard of each.  The forward
+    data flow is:
 
-        [seq/ep, h] --AllGather(ep)--> [seq, h]
-                  --SonicMoE fused _UpProjection / _DownProjection
-                    (gather + grouped GEMM + activation + scatter, no
-                    explicit permute / unpermute)-->
-                  [seq, h] --ReduceScatter(ep, sum)--> [seq/ep, h]
+        [T_local, H] --AllGather--> [T_global, H] --SonicMoE fused
+        _UpProjection / _DownProjection (all tokens, partial I)-->
+        [T_global, H] --ReduceScatter(SUM)--> [T_local, H]
 
-    Routing is computed *before* the AllGather, so each rank only knows its
-    local routing map. The dispatcher AllGathers ``hidden_states`` plus the
-    compact ``[N, topk]`` routing tensors so that every rank performs the
-    same expert compute on the global token list (saving bandwidth versus
-    AllGathering the full ``[N, num_experts]`` sparse tensors).
-
-    This dispatcher only reuses SonicMoE's fused expert-compute kernels; it
-    does not engage any other SonicMoE component (router, dispatcher, fp8
-    protocol).
+    Routing metadata (topk_indices, topk_weights) is also AllGathered so every
+    rank sees the same global token assignments.  No explicit permute/unpermute
+    is needed — the SonicMoE fused kernels handle token gather/scatter
+    internally based on the indices.
     """
 
     def __init__(
@@ -1560,60 +1441,30 @@ class AllGatherTokenDispatcher(nn.Layer):
         self.moe_group = moe_group
         self.ep_size = expert_model_parallel_size
         self.num_experts = num_experts
-        # In allgather mode every rank holds a shard of every expert.
-        self.num_local_experts = num_experts
-        # fp8 dispatch quantizes hidden_states to fp8 *before* the AllGather so
-        # the inter-rank communication carries fp8 bytes (plus a compact
-        # blockwise scale) instead of bf16, mirroring DeepEP. The fp8 activation
-        # is consumed directly by SonicMoE's fused ``_UpProjection`` via
-        # ``prequant_activation_payload=(x_fp8, scale)`` (no re-quantization).
-        # Backward: ``_UpProjection`` emits a bf16 ``dx`` for its activation
-        # input — which is exactly ``_PreAllGatherFP8Result``'s fp8 output edge.
-        # ``_PreAllGatherFP8Result`` declares grad-dtype inconsistency so it can
-        # receive that bf16 grad on its fp8 output and ReduceScatter it back to
-        # the local shard.
+        self.num_local_experts = num_experts  # every rank holds all experts
         self.fp8_dispatch = fp8_dispatch
         self.use_ue8m0 = use_ue8m0
-        # Handle for a pre-issued async AllGather of hidden_states (set by
-        # ``pre_allgather``, consumed by ``dispatch_preprocess``).
         self._pre_ag_handle: dict | None = None
-        # Populated by ``dispatch_preprocess`` — global routing metadata
-        # after AllGather across the EP group.
         self._global_topk_indices = None
         self._global_topk_weights = None
-        # Populated by ``dispatch_preprocess`` when fp8_dispatch is active —
-        # the AllGather'd blockwise scale tensor, reused by downstream fused
-        # kernels (``run_sonic_moe``) as ``prequant_activation_payload`` to
-        # skip redundant re-quantization, mirroring DeepEP's contract.
         self._fp8_dispatch_scale = None
-        # Cache for the overlap-combine path (set by ``token_combine``,
-        # consumed by ``combine_postprocess``).
         self._overlap_combined = None
 
     def pre_allgather(self, hidden_states: paddle.Tensor):
-        """Issue an async AllGather for *hidden_states* on the comm stream.
+        """Issue an async AllGather of hidden_states on the comm stream.
 
-        Called **before** gate computation so that the AllGather runs on the
-        dedicated NCCL comm stream while the gate MLP runs on the calc stream.
-        The result is stored in ``self._pre_ag_handle`` and consumed by
-        :meth:`dispatch_preprocess`.
+        Called before gate computation so the AllGather overlaps with the gate
+        MLP on the calc stream.  Result is stored in self._pre_ag_handle and
+        consumed by dispatch_preprocess.
 
-        Two flavors:
-        - bf16 path: a single async AllGather on the comm stream.
-        - fp8 path (``fp8_dispatch=True``): quantize locally (calc stream),
-          then issue two async AllGathers (fp8 uint8 view + fp32 scale) on
-          the comm stream so both overlap with gate compute. Consumed via
-          :class:`_PreAllGatherFP8Result`.
+        bf16 path: single async AllGather.
+        fp8 path: quantize locally, then two async AllGathers (fp8 data + scale).
         """
         if self.moe_group is None or self.moe_group.nranks == 1:
             self._pre_ag_handle = None
             return
 
-        # Drain any leftover handle from a previous (possibly aborted)
-        # forward, so its NCCL task and output buffer are released before
-        # we issue a new one. This protects against OOM retries / aborted
-        # iterations where ``dispatch_preprocess`` never consumed the
-        # previous handle.
+        # Drain leftover handle from a possibly-aborted previous forward.
         if self._pre_ag_handle is not None:
             try:
                 if "task" in self._pre_ag_handle:
@@ -1636,12 +1487,6 @@ class AllGatherTokenDispatcher(nn.Layer):
         reshaped_input = hidden_states.reshape([-1, d_model]).contiguous()
 
         if self.fp8_dispatch:
-            # FP8 async path: quantize on calc stream, then issue both
-            # AllGathers (fp8 data + scale) on the comm stream so they
-            # overlap with gate MLP. quantize_activation_blockscaled_fast
-            # itself runs on the calc stream and finishes before the
-            # comm-stream collectives consume its outputs (NCCL handles
-            # the cross-stream sync).
             assert quantize_activation_blockscaled_fast is not None, (
                 "Cannot find quantize_activation_blockscaled_fast, "
                 "please update sonicmoe."
@@ -1705,20 +1550,18 @@ class AllGatherTokenDispatcher(nn.Layer):
         topk_weights: paddle.Tensor | None = None,
         topk_indices: paddle.Tensor | None = None,
     ) -> paddle.Tensor:
-        """AllGather hidden_states and topk metadata across the EP group.
+        """AllGather hidden_states and routing metadata across the EP group.
 
-        Reuses ``_pre_ag_handle`` if :meth:`pre_allgather` was called;
-        otherwise performs a sync AllGather (FP8 path when ``fp8_dispatch``
-        is on, plain bf16 otherwise). The unpermuted global hidden states
-        are returned — fused SonicMoE kernels handle gather/scatter inside
-        the expert compute, so no explicit permute happens here.
+        Steps:
+        1. Reshape to [T_local, H].
+        2. AllGather hidden_states (reuse pre-issued async handle if available).
+        3. AllGather topk_indices async on comm stream (int32, no gradient).
+        4. AllGather topk_weights via _RouterAllGather on calc stream (has
+           gradient, backward = reduce-scatter).
+        5. Wait for indices, build padding mask (indices < 0), zero padding weights.
+        6. Return global hidden_states (unpermuted — SonicMoE handles gather).
 
-        Side effects: caches ``_global_topk_indices`` and
-        ``_global_topk_weights`` for the fused expert compute, and sets
-        ``tokens_per_expert = None`` (the consumer recomputes it).
-
-        Raises:
-            ValueError: if ``topk_indices`` or ``topk_weights`` is None.
+        Caches _global_topk_indices, _global_topk_weights for downstream use.
         """
         if len(hidden_states.shape) == 3:
             _, _, d_model = hidden_states.shape
@@ -1726,12 +1569,8 @@ class AllGatherTokenDispatcher(nn.Layer):
             _, d_model = hidden_states.shape
         reshaped_input = hidden_states.reshape([-1, d_model]).contiguous()
 
-        # Reset fp8 dispatch state — will be set below only when fp8 path is taken.
         self._fp8_dispatch_scale = None
 
-        # AllGather hidden_states along token dim across the EP group.
-        # If pre_allgather() was called before gate, reuse the async result;
-        # otherwise fall back to the synchronous path.
         if self._pre_ag_handle is not None:
             if self._pre_ag_handle.get("fp8", False):
                 global_hidden_states, self._fp8_dispatch_scale = (
@@ -1745,10 +1584,6 @@ class AllGatherTokenDispatcher(nn.Layer):
                 )
             self._pre_ag_handle = None
         elif self.fp8_dispatch:
-            # Overlap disabled (moe_allgather_gate_overlap=False): no handle was
-            # pre-issued before gate. Issue the fp8 AllGather synchronously here
-            # and consume it immediately, so fp8 dispatch still works without the
-            # gate-overlap optimization.
             self.pre_allgather(reshaped_input)
             global_hidden_states, self._fp8_dispatch_scale = (
                 _PreAllGatherFP8Result.apply(
@@ -1761,33 +1596,13 @@ class AllGatherTokenDispatcher(nn.Layer):
                 reshaped_input, self.moe_group
             )
 
-        # Memory-saving fused path: skip permute entirely; the fused SonicMoE
-        # kernels (_UpProjection/_DownProjection) handle gather/scatter
-        # internally. We only AllGather the topk metadata and return the
-        # unpermuted global hidden states.
         if topk_indices is None or topk_weights is None:
             raise ValueError(
                 "AllGatherTokenDispatcher requires topk_indices and "
                 "topk_weights to be provided."
             )
-        # Indices are routing IDs in [0, num_experts) (or -1 for padding), so
-        # int32 covers the range with room to spare (num_experts << 2^31) while
-        # halving the AllGather payload vs int64. The downstream SonicMoE
-        # metadata kernel (deepep_topk_to_sonic_metadata) casts to int32 anyway.
-        #
-        # The indices are integer routing IDs with no gradient (``.detach()``),
-        # so there is no need for the autograd-aware ``AllGatherGroupOp``
-        # PyLayer — which additionally issues a full-group
-        # ``paddle.distributed.barrier`` before *every* AllGather. NCCL's
-        # collective is already ordered on the comm stream, so that barrier is
-        # pure latency on the dispatch critical path.
-        #
-        # Issue the indices AllGather **async on the comm stream** so it runs
-        # concurrently with the router-weights AllGather below (the weights
-        # path also does a ``.cast`` on the calc stream first). Both gathers
-        # are independent; we only ``.wait()`` on the indices result right
-        # before its first consumer (the padding mask). This overlaps two
-        # small-but-serialized collectives that previously ran back-to-back.
+        # AllGather indices as int32 on comm stream (async, no gradient).
+        # Issued before weights AllGather so both collectives are in flight.
         topk_indices_i32 = topk_indices.detach().cast("int32").contiguous()
         if self.moe_group is None or self.moe_group.nranks == 1:
             self._global_topk_indices = topk_indices_i32.clone()
@@ -1805,53 +1620,21 @@ class AllGatherTokenDispatcher(nn.Layer):
                 sync_op=False,
                 use_calc_stream=False,
             )
-        # Router-local AllGather: every token has exactly one origin rank,
-        # so the topk_weights gradient flowing back from sonic-moe's
-        # _DownProjection (shape [seq_global, K]) must be *scattered* (slice
-        # this rank's segment), not reduce-scattered. _RouterAllGather
-        # implements scatter on backward, which is the correct semantics
-        # for router-owned tensors and lets the router receive main-loss
-        # gradients on this rank — matching the alltoall/deepep contract
-        # where router weights are also trained by the main loss via the
-        # unpermute(probs=...) multiplication.
-        #
-        # Issue this *after* the async indices AllGather above so the two
-        # collectives are both in flight together: _RouterAllGather runs on
-        # the calc stream while the indices gather runs on the comm stream.
+        # AllGather router weights on calc stream (has gradient).
         self._global_topk_weights = _RouterAllGather.apply(
             topk_weights.cast(probs.dtype), self.moe_group
         )
-        # Now consume the async indices gather — wait only here, right before
-        # its first reader (the padding mask). By this point the weights
-        # AllGather has already been launched, so the wait overlaps the two.
+        # Wait for indices AllGather right before its first consumer.
         if _idx_task is not None:
             _idx_task.wait()
-        # Padding tokens have topk_indices == -1 (set by TopKRouter).
-        # Keep the sentinel in indices so SonicMoE metadata can treat those
-        # slots as masked; only zero the corresponding routing weights below.
+        # Build padding mask and zero corresponding weights.
         self._padding_mask = self._global_topk_indices < 0
-        # Zero out weights for padding tokens (indices were clipped above).
-        # Apply the mask unconditionally: a ``.any()`` guard would force a
-        # GPU->CPU sync every step just to decide whether to run the where.
-        # ``_padding_mask`` is already a bool tensor (``< 0``), so feed it to
-        # ``paddle.where`` directly — the previous bool->float->bool cast was a
-        # no-op roundtrip. Numerically identical (all-False mask leaves the
-        # weights untouched).
         self._global_topk_weights = paddle.where(
             self._padding_mask,
             paddle.zeros_like(self._global_topk_weights),
             self._global_topk_weights,
         )
-        # NOTE: tokens_per_expert is intentionally NOT computed here.
-        # The allgather branch of fusion_moe_forward (moe_layer.py) passes
-        # `_global_topk_indices` directly to `SonicMoEExpert.forward()` /
-        # `run_sonic_moe`, which internally computes the token counts and
-        # cumsum offsets needed by the fused kernels. A bincount here would
-        # be pure waste. We return None to keep the dispatcher contract
-        # `(global_input_tokens, tokens_per_expert)` but the consumer
-        # ignores it on this path.
         self.tokens_per_expert = None
-        # Return unpermuted global hidden states — fused kernels do the rest
         return global_hidden_states
 
     def token_dispatch(
@@ -1862,26 +1645,10 @@ class AllGatherTokenDispatcher(nn.Layer):
         use_ue8m0: bool = False,
         using_sonic_moe: bool = True,
     ):
-        """No-op pass-through for the AllGather path.
-
-        After :meth:`dispatch_preprocess`, every rank already holds the full
-        global token list, so no further inter-rank communication is needed.
-        ``fp8_dispatch`` / ``async_finish`` / ``use_ue8m0`` are accepted for
-        signature compatibility with other dispatchers; the actual FP8
-        quantization is handled inside ``dispatch_preprocess``.
-
-        ``using_sonic_moe`` must be True on this path: the AllGather
-        dispatcher feeds ``_global_topk_indices`` directly into
-        ``SonicMoEExpert.forward`` / ``run_sonic_moe`` (see
-        ``dispatch_preprocess``). Any other expert path is unsupported here.
-
-        Returns:
-            tuple: ``(global_tokens, fp8_handle)``. When ``_fp8_dispatch_scale``
-            was captured during :meth:`dispatch_preprocess` (fp8 path), the handle
-            is ``{"scale": scale}`` matching DeepEP's contract so downstream
-            fused kernels can reuse the dispatch scale as
-            ``prequant_activation_payload``.
-        """
+        """No-op pass-through.  AllGather already happened in dispatch_preprocess,
+        so every rank already holds the full global token list.  Returns
+        (tokens, fp8_handle) where fp8_handle carries the dispatch scale if
+        fp8_dispatch is active."""
         if not using_sonic_moe:
             raise ValueError(
                 "AllGatherTokenDispatcher requires using_sonic_moe=True; "
@@ -1896,14 +1663,8 @@ class AllGatherTokenDispatcher(nn.Layer):
         return permuted_global_input_tokens, fp8_handle
 
     def get_dispatched_routing(self):
-        """Return (dispatched_indices, dispatched_probs, tokens_per_expert).
-
-        For AllGather, tokens_per_expert is computed on demand via bincount
-        since every rank holds all experts and the global token counts are
-        already complete. ``paddle.bincount`` defaults to int64; cast to
-        int32 to match the dtype contract expected by the downstream
-        SonicMoE metadata kernel (``deepep_topk_to_sonic_metadata``).
-        """
+        """Return (global_indices, global_weights, tokens_per_expert).
+        tokens_per_expert is computed on demand via bincount."""
         indices = self._global_topk_indices
         flat_indices = indices.reshape([-1])
         valid_indices = paddle.masked_select(
@@ -1924,16 +1685,12 @@ class AllGatherTokenDispatcher(nn.Layer):
         self,
         global_input_tokens: paddle.Tensor,
     ):
-        """Return the cached ``(global_tokens, tokens_per_expert)`` tuple.
-
-        Mirrors the dispatcher protocol; ``tokens_per_expert`` is ``None``
-        on this path because the fused SonicMoE kernels recompute it from
-        ``_global_topk_indices``.
-        """
+        """Return (global_tokens, tokens_per_expert). tokens_per_expert is None
+        on this path — SonicMoE kernels recompute it from indices."""
         return global_input_tokens, self.tokens_per_expert
 
     def combine_preprocess(self, hidden_states: paddle.Tensor):
-        """No-op pass-through (no unpermute on the fused path)."""
+        """No-op pass-through."""
         return hidden_states
 
     def token_combine(
@@ -1943,31 +1700,15 @@ class AllGatherTokenDispatcher(nn.Layer):
         async_finish: bool = False,
         fp8_combine_grad_handle: dict | None = None,
     ):
-        """ReduceScatter the expert outputs back to the local token shard.
+        """Combine expert outputs via ReduceScatter.
 
-        When ``combine_overlap_handle`` is None this is a no-op; the actual
-        ReduceScatter is deferred to :meth:`combine_postprocess`. When it
-        is provided, the ReduceScatter is fused with a user-supplied
-        subgraph (typically the shared-expert MLP) via
-        :class:`_AllGatherCombineAsync` and the combined output is cached
-        for ``combine_postprocess`` to return as-is. The handle dict is
-        mutated in place: ``fn_out`` receives the subgraph outputs.
+        If combine_overlap_handle is provided, fuse the ReduceScatter with the
+        shared-expert subgraph via _AllGatherCombineAsync for overlap.  The
+        combined output is cached for combine_postprocess to return.
 
-        Args:
-            combine_overlap_handle: dict with keys ``fn`` (callable) and
-                ``fn_args`` (tuple). On return, ``fn_out`` is populated.
-            fp8_combine_grad_handle: when non-None (``fp8_dispatch and
-                using_sonic_moe``), the combine **backward** quantizes the
-                gradient to fp8 e4m3 + int32 block scale *before* the AllGather
-                (1B/elem vs bf16's 2B) and writes the gathered fp8 data+scale
-                into this dict (keys ``data``/``scale``) for
-                ``_DownProjection.backward`` to consume directly — matching
-                deepep+sonic's ``DeepEPCombine.backward`` bandwidth. Because the
-                backward AllGather is a lossless row concat and the 1x128 scale
-                lives within a single token's hidden vector, this is bit-identical
-                to quant-after-AllGather. Forward stays bf16. Only used on the
-                overlap path; the non-overlap ``combine_postprocess`` path leaves
-                the handle empty so down-proj falls back to bf16 self-quant.
+        fp8_combine_grad_handle, when non-None, enables fp8 quantization of the
+        combine backward gradient (halves bandwidth vs bf16).  The gathered fp8
+        data+scale are written into the handle for _DownProjection.backward.
         """
         if combine_overlap_handle is None:
             self._overlap_combined = None
@@ -2004,19 +1745,12 @@ class AllGatherTokenDispatcher(nn.Layer):
         return combined_x
 
     def combine_postprocess(self, hidden_states: paddle.Tensor):
-        """ReduceScatter the partial-sum expert outputs to the local shard.
+        """ReduceScatter expert outputs to the local token shard.
 
-        The fused ``_DownProjection`` already scattered back to
-        ``[global_T, h]`` with topk weights applied, but the result is a
-        partial sum across the EP-sharded intermediate dim. This step sums
-        across EP ranks and slices to the per-rank token segment.
-
-        If :meth:`token_combine` already performed the ReduceScatter (the
-        overlap path), the cached output is returned and the cache cleared.
+        If token_combine already did the ReduceScatter (overlap path), return
+        the cached result.  Otherwise perform ReduceScatter here.
         """
         if getattr(self, "_overlap_combined", None) is not None:
-            # ReduceScatter was already performed (fused with shared experts) in
-            # ``token_combine``; pass the cached output through.
             out = self._overlap_combined
             self._overlap_combined = None
             return out

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -449,7 +449,18 @@ class TransformerConfig(ModelParallelConfig):
 
     moe_token_dispatcher_type: str = "deepep"
     """The type of token dispatcher to use. The default is 'deepep'.
-    Options are 'allgather', 'alltoall', 'deepep', and 'hybridep'."""
+    Options are 'allgather', 'alltoall', 'deepep', and 'hybridep'.
+
+    - 'allgather': every expert is sharded along ``moe_intermediate_size``
+      into ``EP`` partitions and every rank holds one shard of every expert.
+      Inputs are AllGathered across the EP group before expert compute and
+      partial outputs are ReduceScattered back. Requires ``EP > 1``,
+      ``moe_grouped_gemm=True`` and ``moe_intermediate_size % EP == 0``."""
+
+    moe_allgather_gate_overlap: bool = False
+    """Whether to issue the AllGather before the gate so it overlaps with gate
+    compute. Only honoured when ``moe_token_dispatcher_type='allgather'`` and
+    ``expert_model_parallel_size > 1``; ignored (with a warning) otherwise."""
 
     moe_use_fusion_node: bool = True
     """Whether to use fusion node for MoE layer. Default is True"""


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Distributed Strategy

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
Introduce a new MoE token dispatcher — `allgather` — alongside the existing
`deepep` / `alltoall` / `hybridep` options. Semantic difference:

- Existing dispatchers: each EP rank holds *a subset of experts* at full intermediate width
- AllGather dispatcher: each EP rank holds *every expert*, with the intermediate dim sharded across EP


### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否