### PR TITLE
[Improvements] align MTP loss and mHC kernel with Megatron accuracy-compatible path

### DIFF
--- a/src/paddlefleet/models/common/language_loss/language_loss.py
+++ b/src/paddlefleet/models/common/language_loss/language_loss.py
@@ -14,6 +14,7 @@
 
 
 import functools
+import os
 
 import numpy as np
 import paddle
@@ -37,6 +38,42 @@ from paddlefleet.parallel_state import (
 from paddlefleet.process_groups_config import ProcessGroupCollection
 from paddlefleet.transformer.layer import FleetLayer
 from paddlefleet.transformer.transformer_config import TransformerConfig
+
+
+def _loss_md5_enabled() -> bool:
+    return os.environ.get("LOG_LOSS_MD5", "0") == "1"
+
+
+def _use_accuracy_compatible_kernel() -> bool:
+    """Switch for Megatron-aligned (accuracy-compatible) numeric paths.
+
+    Controlled by the ``FLAGS_use_accuracy_compatible_kernel`` env variable.
+    """
+    return os.environ.get("FLAGS_use_accuracy_compatible_kernel", "0") == "1"
+
+
+def _tensor_md5(tensor: Tensor, dtype: str = "float32") -> str:
+    """Calculate MD5 hash of a tensor, **for debugging only**.
+
+    Note: internally calls .numpy() which triggers GPU→CPU synchronization
+    and blocks the async training pipeline. Do NOT use in the forward pass.
+    """
+    import hashlib
+
+    tensor_for_md5 = tensor.detach().cast(dtype)
+    return hashlib.md5(tensor_for_md5.numpy().tobytes()).hexdigest()
+
+
+def _print_scalar_loss_md5(prefix: str, name: str, loss: Tensor) -> None:
+    if not _loss_md5_enabled():
+        return
+    rank = paddle.distributed.get_rank()
+    loss_tensor = loss.detach().cast("float32").reshape([1])
+    print(
+        f"[{prefix}] rank={rank} {name}={loss_tensor.item():.20f} "
+        f"{name}_md5={_tensor_md5(loss_tensor)}",
+        flush=True,
+    )
 
 
 class DistributedSoftmaxOp(PyLayer):
@@ -546,23 +583,53 @@ class LanguageLoss(FleetLayer):
                 LanguageLoss.mtp_loss_tracker[f"mtp_{i + 1}_loss"] = (
                     loss_val.detach()
                 )
+                _print_scalar_loss_md5(
+                    "MTP_LOSS_PATH_MD5",
+                    f"mtp{i + 1}.final_loss",
+                    loss_val,
+                )
 
             def add_loss(main_loss, loss):
-                if self.config.add_mtp_loss:
-                    return main_loss + loss
+                if _use_accuracy_compatible_kernel():
+                    # Megatron-aligned behavior: don't include MTP loss value in total loss
+                    if self.config.add_mtp_loss:
+                        return main_loss + loss - loss.detach()
+                    else:
+                        return main_loss
                 else:
-                    return main_loss + loss - loss.detach()
+                    # Original behavior
+                    if self.config.add_mtp_loss:
+                        return main_loss + loss
+                    else:
+                        return main_loss + loss - loss.detach()
 
             if self.config.gpt_model_use_experimental_version:
                 # Align with EB: accumulate inside loop to match float32
                 # arithmetic order: loss += scaling * loss_i / N
                 loss = lm_loss
-                num_mtp = len(mtp_loss)
-                for mtp_l in mtp_loss:
-                    loss = add_loss(
-                        loss,
-                        self.config.mtp_loss_scaling_factor * mtp_l / num_mtp,
-                    )
+                if _use_accuracy_compatible_kernel():
+                    # Megatron-aligned: only add MTP loss when add_mtp_loss=True.
+                    # Use loss + val - val.detach() so loss VALUE doesn't increase,
+                    # only gradient flows (matches add_loss() semantics).
+                    if self.config.add_mtp_loss:
+                        num_mtp = len(mtp_loss)
+                        for mtp_l in mtp_loss:
+                            mtp_val = (
+                                self.config.mtp_loss_scaling_factor
+                                * mtp_l
+                                / num_mtp
+                            )
+                            loss = loss + mtp_val - mtp_val.detach()
+                else:
+                    # Original behavior: always use add_loss
+                    num_mtp = len(mtp_loss)
+                    for mtp_l in mtp_loss:
+                        loss = add_loss(
+                            loss,
+                            self.config.mtp_loss_scaling_factor
+                            * mtp_l
+                            / num_mtp,
+                        )
             else:
                 loss = add_loss(
                     lm_loss,
@@ -619,12 +686,25 @@ class MainLanguageLoss(LanguageLoss):
             MainLanguageLoss.mtp_loss_tracker[f"mtp_{i + 1}_loss"] = (
                 loss_val.detach()
             )
+            _print_scalar_loss_md5(
+                "MTP_LOSS_PATH_MD5",
+                f"mtp{i + 1}.final_loss",
+                loss_val,
+            )
 
         def add_loss(main_loss, loss):
-            if self.config.add_mtp_loss:
-                return main_loss + loss
+            if _use_accuracy_compatible_kernel():
+                # Megatron-aligned behavior: don't include MTP loss value in total loss
+                if self.config.add_mtp_loss:
+                    return main_loss + loss - loss.detach()
+                else:
+                    return main_loss
             else:
-                return main_loss + loss - loss.detach()
+                # Original behavior
+                if self.config.add_mtp_loss:
+                    return main_loss + loss
+                else:
+                    return main_loss + loss - loss.detach()
 
         loss = add_loss(
             lm_loss,

--- a/src/paddlefleet/models/common/language_loss/language_loss.py
+++ b/src/paddlefleet/models/common/language_loss/language_loss.py
@@ -14,6 +14,7 @@
 
 
 import functools
+import hashlib
 import os
 
 import numpy as np
@@ -58,8 +59,6 @@ def _tensor_md5(tensor: Tensor, dtype: str = "float32") -> str:
     Note: internally calls .numpy() which triggers GPU→CPU synchronization
     and blocks the async training pipeline. Do NOT use in the forward pass.
     """
-    import hashlib
-
     tensor_for_md5 = tensor.detach().cast(dtype)
     return hashlib.md5(tensor_for_md5.numpy().tobytes()).hexdigest()
 
@@ -591,7 +590,9 @@ class LanguageLoss(FleetLayer):
 
             def add_loss(main_loss, loss):
                 if _use_accuracy_compatible_kernel():
-                    # Megatron-aligned behavior: don't include MTP loss value in total loss
+                    # Megatron-aligned: MTP loss gradient flows but loss scalar unchanged.
+                    # This matches Megatron's behavior where MTP contributes to training
+                    # gradients without affecting the reported loss value.
                     if self.config.add_mtp_loss:
                         return main_loss + loss - loss.detach()
                     else:
@@ -609,8 +610,8 @@ class LanguageLoss(FleetLayer):
                 loss = lm_loss
                 if _use_accuracy_compatible_kernel():
                     # Megatron-aligned: only add MTP loss when add_mtp_loss=True.
-                    # Use loss + val - val.detach() so loss VALUE doesn't increase,
-                    # only gradient flows (matches add_loss() semantics).
+                    # Use add_loss() to keep single maintenance point for compat
+                    # behavior (loss + val - val.detach() for gradient-only flow).
                     if self.config.add_mtp_loss:
                         num_mtp = len(mtp_loss)
                         for mtp_l in mtp_loss:
@@ -619,7 +620,7 @@ class LanguageLoss(FleetLayer):
                                 * mtp_l
                                 / num_mtp
                             )
-                            loss = loss + mtp_val - mtp_val.detach()
+                            loss = add_loss(loss, mtp_val)
                 else:
                     # Original behavior: always use add_loss
                     num_mtp = len(mtp_loss)
@@ -694,7 +695,8 @@ class MainLanguageLoss(LanguageLoss):
 
         def add_loss(main_loss, loss):
             if _use_accuracy_compatible_kernel():
-                # Megatron-aligned behavior: don't include MTP loss value in total loss
+                # Megatron-aligned: MTP loss gradient flows but loss scalar unchanged.
+                # This matches Megatron's behavior
                 if self.config.add_mtp_loss:
                     return main_loss + loss - loss.detach()
                 else:

--- a/src/paddlefleet/transformer/hyper_connection.py
+++ b/src/paddlefleet/transformer/hyper_connection.py
@@ -539,7 +539,8 @@ class HyperConnectionModule(nn.Layer):
             h_post: [..., n] - expansion weights
         """
         # Compute mappings
-        hidden_states = hidden_states.astype("float32")
+        if not _use_accuracy_compatible_kernel():
+            hidden_states = hidden_states.astype("float32")
         h_pre, h_post, h_res = self.compute_mappings(hidden_states)
 
         # Aggregate for layer input
@@ -685,7 +686,10 @@ class HyperConnectionModule(nn.Layer):
         x, bias = layer_output_with_bias
 
         # Fast path: no dropout — use fused/native h_post_bda kernel
-        if dropout_prob == 0.0 or not training:
+        # Only use fast path when accuracy-compatible kernel is NOT enabled
+        if not _use_accuracy_compatible_kernel() and (
+            dropout_prob == 0.0 or not training
+        ):
             leading_shape = original_residual.shape[:-1]
             n = self.n
             C = self.hidden_size
@@ -698,8 +702,9 @@ class HyperConnectionModule(nn.Layer):
             output = self._h_post_bda_op(h_res, orig_reshaped, h_post, x, bias)
             return output.reshape([*leading_shape, n * C])
 
-        # Slow path: dropout required — sequential ops
+        # Sequential path: used when dropout required OR accuracy-compatible kernel enabled
         mixed = self.apply_h_res(h_res, original_residual)
+
         x_expanded = self._apply_h_post(x, h_post)
         bias_expanded = (
             self._apply_h_post(bias, h_post) if bias is not None else None

--- a/src/paddlefleet/transformer/hyper_connection.py
+++ b/src/paddlefleet/transformer/hyper_connection.py
@@ -702,7 +702,7 @@ class HyperConnectionModule(nn.Layer):
             output = self._h_post_bda_op(h_res, orig_reshaped, h_post, x, bias)
             return output.reshape([*leading_shape, n * C])
 
-        # Sequential path: used when dropout required OR accuracy-compatible kernel enabled
+        # Sequential path: used when dropout required OR accuracy-compatible kernel is NOT enabled
         mixed = self.apply_h_res(h_res, original_residual)
 
         x_expanded = self._apply_h_post(x, h_post)


### PR DESCRIPTION
### PR Category
Performance Optimization

### PR Types
Improvements

### Description
1. 在 `language_loss.py` 中新增 `FLAGS_use_accuracy_compatible_kernel` 环境变量开关，控制 MTP 损失计算与 Megatron 精度对齐路径的切换行为：
   - `add_loss()` 函数：开关开启时 MTP loss 仅透传梯度、不改变 loss 数值（`main_loss + loss - loss.detach()`）；关闭时保持原有行为。
   - `gpt_model_use_experimental_version` 路径：开关开启时仅在 `add_mtp_loss=True` 时加 MTP loss，关闭时走原 `add_loss()` 逻辑。
2. 在 `hyper_connection.py` 中：
   - `forward()` 开关开启时跳过 `hidden_states.astype("float32")`，保留原始精度。
   - `fused_h_res_h_post_bda()` 开关开启时禁用 fused 快速路径，改走 sequential 路径。
3. 新增 `_print_scalar_loss_md5` / `_tensor_md5` 调试工具，通过 `LOG_LOSS_MD5=1` 开启 MTP loss 的 MD5 打印，方便精度对齐排查。
