### PR TITLE
[CI] Increase single-card test timeout

### DIFF
--- a/.github/workflows/Test-release.yml
+++ b/.github/workflows/Test-release.yml
@@ -332,7 +332,7 @@ jobs:
           '
 
       - name: Single card test
-        timeout-minutes: 50
+        timeout-minutes: 60
         run: |
           docker exec -t ${{ env.container_name }} /bin/bash -xce '
           pwd


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Devs

### Description
This PR increases only the `Unit test (single card)` / `Single card test` step timeout in `.github/workflows/Test-release.yml` from 50 minutes to 60 minutes.

Evidence from recent `Test-release` runs:
- #1114 current head run `26910308750` timed out twice in `Unit test (single card)`: attempt 1 job `79388489465` and attempt 2 job `79427043813` both report `The action 'Single card test' has timed out after 50 minutes`.
- Recent successful samples are already close to the 50-minute step budget, for example run `26900748451` job `79375588838` finished `Single card test` in about 42.2 minutes (job about 44.8 minutes), and run `26889245008` job `79335766594` finished the step in about 40.9 minutes.
- Other sampled failures such as run `26890510742` job `79318110833` and run `26888821065` job `79335473658` were real test failures (`Process completed with exit code 1` / `Some single card tests failed`), not timeout, so this PR changes only the timeout that is currently being hit.

Validation:
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/Test-release.yml"); puts "YAML parse OK"'`
- `git diff --check`
- `rg -n -C 4 "name: Single card test|timeout-minutes: (50|60)|name: Multi-card test|timeout-minutes: 30" .github/workflows/Test-release.yml`

@SigureMo Please review this PR when you have time. Thanks!

### 是否引起精度变化
否
