### PR TITLE
[align mode] add v11 model

### DIFF
--- a/src/paddlefleet/models/common/language_loss/language_loss.py
+++ b/src/paddlefleet/models/common/language_loss/language_loss.py
@@ -426,9 +426,16 @@ class LanguageLoss(FleetLayer):
                                 labels_cur_depth, axis=1
                             )
 
-                        loss_matrix_cur_depth = self.loss_func(
-                            logits_cur_depth.cast("float32"), labels_cur_depth
-                        )
+                        if self.config.fused_linear_ce_loss_chunk > 0:
+                            loss_matrix_cur_depth = self._forward(
+                                logits_cur_depth,
+                                labels_cur_depth,
+                            )
+                        else:
+                            loss_matrix_cur_depth = self.loss_func(
+                                logits_cur_depth.cast("float32"),
+                                labels_cur_depth,
+                            )
 
                         if get_context_parallel_world_size() > 1:
                             # In EB data flow and CP size > 1, loss and labels need to be gathered back.

--- a/src/paddlefleet/models/gpt/gpt_layer_specs.py
+++ b/src/paddlefleet/models/gpt/gpt_layer_specs.py
@@ -148,6 +148,8 @@ def get_attention_spec(
 
     use_qk_norm = getattr(config, "use_qk_norm", False)
     qk_l2_norm = getattr(config, "qk_l2_norm", False)
+    gated_attention = getattr(config, "gated_attention", False)
+    align_mode = getattr(config, "gpt_model_use_experimental_version", None)
 
     if attention_layer_type == "self_attention":
         return LayerSpec(
@@ -160,6 +162,9 @@ def get_attention_spec(
                 qkv_proj=backend.column_parallel_linear(),
                 core_attention=backend.core_attention(),
                 o_proj=backend.row_parallel_linear(),
+                gate_proj=backend.column_parallel_linear()
+                if gated_attention and align_mode
+                else IdentityOp,
                 q_norm=(
                     L2Norm
                     if qk_l2_norm

--- a/src/paddlefleet/models/gpt/lm_head.py
+++ b/src/paddlefleet/models/gpt/lm_head.py
@@ -41,6 +41,8 @@ class GPTLMHead(ColumnParallelLinear):
         block_attn_res_spec = kwargs.pop("block_attn_res", IdentityOp)
 
         kwargs["skip_weight_param_allocation"] = True
+        if self.config.gpt_model_use_experimental_version:
+            kwargs["bias"] = self.config.use_bias
         super().__init__(**kwargs)
 
         stride = kwargs["stride"] if "stride" in kwargs.keys() else 1

--- a/src/paddlefleet/tensor_parallel/layers.py
+++ b/src/paddlefleet/tensor_parallel/layers.py
@@ -1261,6 +1261,21 @@ class ColumnParallelLinear(paddle.nn.Layer):
         bias = self.bias if not self.skip_bias_add else None
 
         if (
+            getattr(self.config, "gpt_model_use_experimental_version", False)
+            and self.world_size == 1
+            and self.bias is not None
+        ):
+            output = paddle.incubate.nn.functional.fused_linear(
+                input_, weight, self.bias
+            )
+            output_bias = (
+                self.bias.clone()
+                if (self.skip_bias_add and self.bias is not None)
+                else None
+            )
+            return output, output_bias
+
+        if (
             self.allreduce_dgrad
             or self.sequence_parallel
             or self.explicit_expert_comm

--- a/src/paddlefleet/transformer/attention.py
+++ b/src/paddlefleet/transformer/attention.py
@@ -32,11 +32,15 @@ from paddle.distributed.fleet.meta_parallel import LayerSpec, build_spec_layer
 from paddle.distributed.fleet.utils import recompute
 
 from paddlefleet import tensor_parallel
+from paddlefleet.context_parallel_utils import ContextParallelScatterOp
 from paddlefleet.models.common.embeddings import (
     apply_rotary_pos_emb,
 )
 from paddlefleet.models.common.embeddings.yarn_rotary_pos_embedding import (
     _yarn_get_concentration_factor_from_config,
+)
+from paddlefleet.parallel_state import (
+    get_context_parallel_world_size,
 )
 from paddlefleet.process_groups_config import ProcessGroupCollection
 from paddlefleet.recompute_utils import (
@@ -125,7 +129,8 @@ def _apply_ec_complex_3d_mrope(
 
     freqs_cis = paddle.polar(paddle.ones_like(freqs), freqs)
     freqs_cis = freqs_cis.unsqueeze(2)
-
+    if get_context_parallel_world_size() > 1:
+        freqs_cis = ContextParallelScatterOp.apply(freqs_cis, axis=1)
     if _LOG_LAYER_MD5:
         logger = logging.getLogger(__name__)
         rank = paddle.distributed.get_rank()
@@ -177,6 +182,7 @@ class SelfAttentionSublayersSpec:
     o_proj: LayerSpec | type = None
     q_norm: LayerSpec | type = None
     k_norm: LayerSpec | type = None
+    gate_proj: LayerSpec | type = None
 
 
 @dataclass
@@ -785,8 +791,23 @@ class Attention(FleetLayer, ABC):
             logging.getLogger(__name__).info(
                 f"[MD5 Probe PF] Rank={_rank} Layer={self.layer_number} core_attn_out MD5={_ca_md5} shape={list(core_attn_out.shape)}"
             )
-
-        output, bias = self.o_proj(core_attn_out)
+        if (
+            self.config.gpt_model_use_experimental_version
+            and self.o_proj.bias is not None
+            and self.config.tensor_model_parallel_size == 1
+        ):
+            orig_shape = core_attn_out.shape
+            core_attn_out = core_attn_out.reshape([-1, core_attn_out.shape[-1]])
+            # Use fused_linear to match EC's FusedLinear behavior (fused_gemm_epilogue)
+            output = paddle.incubate.nn.functional.fused_linear(
+                core_attn_out, self.o_proj.weight, self.o_proj.bias
+            )
+            output = output.reshape(
+                [orig_shape[0], orig_shape[1], output.shape[-1]]
+            )
+            bias = None
+        else:
+            output, bias = self.o_proj(core_attn_out)
 
         if self.config.gpt_model_use_experimental_version and _LOG_LAYER_MD5:
             _out = output
@@ -836,22 +857,50 @@ class SelfAttention(Attention):
         gate_projection_size = (
             self.out_projection_size if self.gated_attention else 0
         )
-
-        self.qkv_proj = build_spec_layer(
-            sublayers_spec.qkv_proj,
-            self.config.hidden_size,
-            self.query_projection_size
-            + self.key_projection_size
-            + self.value_projection_size
-            + gate_projection_size,
-            config=self.config,
-            init_method=self.config.init_method,
-            gather_output=False,
-            bias=self.config.use_bias or self.config.attention_bias,
-            skip_bias_add=False,
-            is_expert=False,
-            tp_group=self.pg_collection.tp,
-        )
+        if not self.config.gpt_model_use_experimental_version:
+            self.qkv_proj = build_spec_layer(
+                sublayers_spec.qkv_proj,
+                self.config.hidden_size,
+                self.query_projection_size
+                + self.key_projection_size
+                + self.value_projection_size
+                + gate_projection_size,
+                config=self.config,
+                init_method=self.config.init_method,
+                gather_output=False,
+                bias=self.config.use_bias or self.config.attention_bias,
+                skip_bias_add=False,
+                is_expert=False,
+                tp_group=self.pg_collection.tp,
+            )
+        else:
+            self.qkv_proj = build_spec_layer(
+                sublayers_spec.qkv_proj,
+                self.config.hidden_size,
+                self.query_projection_size
+                + self.key_projection_size
+                + self.value_projection_size,
+                config=self.config,
+                init_method=self.config.init_method,
+                gather_output=False,
+                bias=self.config.use_bias or self.config.attention_bias,
+                skip_bias_add=False,
+                is_expert=False,
+                tp_group=self.pg_collection.tp,
+            )
+            if self.gated_attention:
+                self.gate_proj = build_spec_layer(
+                    sublayers_spec.gate_proj,
+                    self.config.hidden_size,
+                    gate_projection_size,
+                    config=self.config,
+                    init_method=self.config.init_method,
+                    gather_output=False,
+                    bias=self.config.use_bias or self.config.attention_bias,
+                    skip_bias_add=False,
+                    is_expert=False,
+                    tp_group=self.pg_collection.tp,
+                )
 
         # For per_layer qk_norm, norm operates on gathered (full) tensors,
         # so input_is_parallel should be False to avoid extra allreduce.
@@ -907,68 +956,102 @@ class SelfAttention(Attention):
         # Attention heads [b, sq, h] --> [b, sq, ng * group_dim]
         mixed_qkv, _ = self.qkv_proj(hidden_states)
 
+        if self.config.gpt_model_use_experimental_version:
+            if self.gated_attention:
+                gate_output = self.gate_proj(hidden_states)
+                gate = (
+                    gate_output[0]
+                    if isinstance(gate_output, tuple)
+                    else gate_output
+                )
+            else:
+                gate = None
+
         heads_per_group = (
             self.num_attention_heads_per_partition
             // self.num_query_groups_per_partition
         )
         q_dim = heads_per_group * self.hidden_size_per_attention_head
 
-        if self.gated_attention:
-            gate_dim = (
-                heads_per_group
-                * (self.num_key_value_heads if self.use_vha_attention else 1)
-                * self.value_hidden_size_per_attention_head
-            )
-
-        if self.gated_attention:
-            # Per group: Q + Gate + K + V
-            group_dim = (
-                q_dim
-                + gate_dim
-                + self.hidden_size_per_attention_head
-                + self.value_hidden_size_per_attention_head
-            )
-        else:
-            # Per group: Q + K + V
-            group_dim = (
-                q_dim
-                + self.hidden_size_per_attention_head
-                + self.value_hidden_size_per_attention_head
-            )
-
-        # [b, sq, hp] --> [b, sq, ng, group_dim]
-        new_tensor_shape = (
-            *mixed_qkv.shape[:-1],
-            self.num_query_groups_per_partition,
-            group_dim,
-        )
-        mixed_qkv = mixed_qkv.reshape(*new_tensor_shape)
-
-        if self.gated_attention:
-            split_arg_list = [
-                q_dim,
-                gate_dim,
+        # EC-compatible QKV split: EC uses non-interleaved layout [all_Q | all_K | all_V]
+        # while PF default uses per-group interleaved layout [G0: Q,K,V | G1: Q,K,V | ...]
+        if self.config.gpt_model_use_experimental_version:
+            # EC-style: reshape to [b, sq, num_heads + 2*num_kv_heads, head_dim], split on axis=2
+            num_heads = self.num_attention_heads_per_partition
+            num_kv_heads = self.num_query_groups_per_partition
+            mixed_qkv = mixed_qkv.reshape(
+                *mixed_qkv.shape[:-1],
+                num_heads + 2 * num_kv_heads,
                 self.hidden_size_per_attention_head,
-                self.value_hidden_size_per_attention_head,
-            ]
+            )
+
+            if not split_qkv:
+                split_arg_list = [num_heads, num_kv_heads, num_kv_heads]
+                return mixed_qkv, split_arg_list
+            query, key, value = paddle.split(
+                mixed_qkv, [num_heads, num_kv_heads, num_kv_heads], axis=2
+            )
         else:
-            split_arg_list = [
-                q_dim,
-                self.hidden_size_per_attention_head,
-                self.value_hidden_size_per_attention_head,
-            ]
+            if self.gated_attention:
+                gate_dim = (
+                    heads_per_group
+                    * (
+                        self.num_key_value_heads
+                        if self.use_vha_attention
+                        else 1
+                    )
+                    * self.value_hidden_size_per_attention_head
+                )
 
-        # Return unsplit mixed_qkv and split_arg_list
-        if not split_qkv:
-            return mixed_qkv, split_arg_list
+            if self.gated_attention:
+                # Per group: Q + Gate + K + V
+                group_dim = (
+                    q_dim
+                    + gate_dim
+                    + self.hidden_size_per_attention_head
+                    + self.value_hidden_size_per_attention_head
+                )
+            else:
+                # Per group: Q + K + V
+                group_dim = (
+                    q_dim
+                    + self.hidden_size_per_attention_head
+                    + self.value_hidden_size_per_attention_head
+                )
 
-        parts = paddle.split(mixed_qkv, split_arg_list, axis=3)
+            # [b, sq, hp] --> [b, sq, ng, group_dim]
+            new_tensor_shape = (
+                *mixed_qkv.shape[:-1],
+                self.num_query_groups_per_partition,
+                group_dim,
+            )
+            mixed_qkv = mixed_qkv.reshape(*new_tensor_shape)
 
-        if self.gated_attention:
-            query, gate, key, value = parts
-        else:
-            query, key, value = parts
-            gate = None
+            if self.gated_attention:
+                split_arg_list = [
+                    q_dim,
+                    gate_dim,
+                    self.hidden_size_per_attention_head,
+                    self.value_hidden_size_per_attention_head,
+                ]
+            else:
+                split_arg_list = [
+                    q_dim,
+                    self.hidden_size_per_attention_head,
+                    self.value_hidden_size_per_attention_head,
+                ]
+
+            # Return unsplit mixed_qkv and split_arg_list
+            if not split_qkv:
+                return mixed_qkv, split_arg_list
+
+            parts = paddle.split(mixed_qkv, split_arg_list, axis=3)
+
+            if self.gated_attention:
+                query, gate, key, value = parts
+            else:
+                query, key, value = parts
+                gate = None
 
         if self.v_scale is not None:
             value = value * self.v_scale

--- a/src/paddlefleet/transformer/mlp.py
+++ b/src/paddlefleet/transformer/mlp.py
@@ -184,6 +184,19 @@ class MLP(FleetLayer):
         _use_paddle_swiglu = getattr(
             self.config, "gpt_model_use_experimental_version", False
         )
+        if (
+            self.config.use_bias
+            and self.config.gpt_model_use_experimental_version
+            and self.config.tensor_model_parallel_size == 1
+        ):
+            hidden_states = paddle.incubate.nn.functional.fused_linear(
+                hidden_states, self.up_gate_proj.weight, self.up_gate_proj.bias
+            )
+            hidden_states = F.swiglu(hidden_states)
+            output = paddle.incubate.nn.functional.fused_linear(
+                hidden_states, self.down_proj.weight, self.down_proj.bias
+            )
+            return output, None
 
         if (
             _use_paddle_swiglu

--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -265,10 +265,16 @@ class StandardMoERouter(nn.Layer):
             )
 
         if self.topk_method == "noaux_tc":
-            self.register_buffer(
-                "e_score_correction_bias",
-                paddle.zeros((self.num_experts,), dtype=paddle.float32),
-            )
+            if not self.config.gpt_model_use_experimental_version:
+                self.register_buffer(
+                    "e_score_correction_bias",
+                    paddle.zeros((self.num_experts,), dtype=paddle.float32),
+                )
+            else:
+                self.register_buffer(
+                    "e_score_correction_bias",
+                    paddle.zeros((1, self.num_experts), dtype=paddle.float32),
+                )
             self._cast_to_low_precision = False
             self.expert_usage = paddle.zeros(
                 shape=[self.num_experts],
@@ -708,9 +714,15 @@ class StandardMoERouter(nn.Layer):
         assert self.e_score_correction_bias is not None, (
             "e_score_correction_bias is None"
         )
-        scores_for_choice = scores.reshape(
-            [bsz_seq_len, -1]
-        ) + self.e_score_correction_bias.detach().unsqueeze(0)
+        if not self.config.gpt_model_use_experimental_version:
+            scores_for_choice = scores.reshape(
+                [bsz_seq_len, -1]
+            ) + self.e_score_correction_bias.detach().unsqueeze(0)
+        else:
+            scores_for_choice = (
+                scores.reshape([bsz_seq_len, -1])
+                + self.e_score_correction_bias.detach()
+            )
         if n_group == 1:
             topk_weight, topk_idx = paddle.topk(
                 scores_for_choice, k=k, axis=-1, sorted=True
@@ -1037,9 +1049,12 @@ class TopKRouter(StandardMoERouter):
             # Triton's scalar loop and Paddle's tensor ops.
             MoETopkFusion = _get_moe_topk_fusion()
             use_node_limit = self.n_group > 1
-            probs_for_choice = (
-                gates + self.e_score_correction_bias.detach().unsqueeze(0)
-            )
+            if not self.config.gpt_model_use_experimental_version:
+                probs_for_choice = (
+                    gates + self.e_score_correction_bias.detach().unsqueeze(0)
+                )
+            else:
+                probs_for_choice = gates + self.e_score_correction_bias.detach()
             if _LOG_LAYER_MD5 and self._layer_number == 0:
                 _log_moe_md5(
                     self.e_score_correction_bias,

--- a/src/paddlefleet/transformer/multi_token_prediction.py
+++ b/src/paddlefleet/transformer/multi_token_prediction.py
@@ -390,6 +390,9 @@ class MultiTokenPredictionLayer(FleetLayer):
             # so the input's shape is [s, b, 2*h].
             # The output will be sent to the following transformer layer,
             # so the output's shape should be [s, b, h].
+            use_bias = False
+            if self.config.gpt_model_use_experimental_version:
+                use_bias = self.config.use_bias
             self.eh_proj = build_spec_layer(
                 self.sublayers_spec.eh_proj,
                 self.config.hidden_size * 2,
@@ -397,7 +400,7 @@ class MultiTokenPredictionLayer(FleetLayer):
                 config=self.config,
                 init_method=self.config.init_method,
                 gather_output=False,
-                bias=False,
+                bias=use_bias,
                 skip_bias_add=False,
                 is_expert=False,
             )
@@ -565,6 +568,7 @@ class MultiTokenPredictionLayer(FleetLayer):
         attn_mask_startend_row_indices: paddle.Tensor | None = None,
         mtp_hidden_inputs_mask: paddle.Tensor | None = None,
         input_ids: paddle.Tensor | None = None,
+        position_ids: paddle.Tensor | None = None,
         **kwargs,
     ) -> paddle.Tensor:
         """
@@ -593,6 +597,7 @@ class MultiTokenPredictionLayer(FleetLayer):
                 "attn_mask_startend_row_indices": attn_mask_startend_row_indices,
                 "is_mtp": True,
                 "input_ids": input_ids,
+                "position_ids": position_ids,
             }
             rst_dict = self.transformer_layer(input_dict)
 
@@ -652,6 +657,7 @@ class MultiTokenPredictionLayer(FleetLayer):
             packed_seq_params = kwargs.get("packed_seq_params", None)
             mtp_hidden_inputs_mask = kwargs.get("mtp_hidden_inputs_mask", None)
             input_ids = kwargs.get("input_ids", None)
+            position_ids = kwargs.get("position_ids", None)
             return recompute(
                 forward_func,
                 hidden_states=hidden_states
@@ -687,6 +693,7 @@ class MultiTokenPredictionLayer(FleetLayer):
                 if mtp_hidden_inputs_mask is not None
                 else None,
                 input_ids=input_ids if input_ids is not None else None,
+                position_ids=position_ids if position_ids is not None else None,
             )
 
         if self.config.recompute_method == "uniform":

--- a/src/paddlefleet/transformer/transformer_layer.py
+++ b/src/paddlefleet/transformer/transformer_layer.py
@@ -467,15 +467,16 @@ class TransformerLayer(nn.Layer):
             dict_args["hidden_states"] = hidden_states
 
             # process position_ids
-            if "position_ids" in dict_args.keys():
-                position_ids = dict_args["position_ids"]
-                decoder_ids = position_ids[
-                    :, : -self.config.num_nextn_predict_layers
-                ]
-                mtp_ids = position_ids[
-                    :, -self.config.num_nextn_predict_layers :
-                ]
-                dict_args["position_ids"] = decoder_ids
+            if not self.config.gpt_model_use_experimental_version:
+                if "position_ids" in dict_args.keys():
+                    position_ids = dict_args["position_ids"]
+                    decoder_ids = position_ids[
+                        :, : -self.config.num_nextn_predict_layers
+                    ]
+                    mtp_ids = position_ids[
+                        :, -self.config.num_nextn_predict_layers :
+                    ]
+                    dict_args["position_ids"] = decoder_ids
 
             # process rotary_pos_emb: trim to main decoder sequence length
             # With SP: rotary_pos_emb is [S, B, head_dim], seq is dim 0
@@ -646,12 +647,12 @@ class TransformerLayer(nn.Layer):
         ):
             hidden_states_concat = paddle.concat([output, *mtp_input])
             rst["hidden_states"] = hidden_states_concat
-
-            if "position_ids" in dict_args.keys():
-                position_ids = paddle.concat(
-                    [dict_args["position_ids"], mtp_ids], axis=1
-                )
-                dict_args["position_ids"] = position_ids
+            if not self.config.gpt_model_use_experimental_version:
+                if "position_ids" in dict_args.keys():
+                    position_ids = paddle.concat(
+                        [dict_args["position_ids"], mtp_ids], axis=1
+                    )
+                    dict_args["position_ids"] = position_ids
 
             # Restore rotary_pos_emb/cos/sin to full length for next layer
             if rotary_pos_emb_full is not None:

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_language_loss_2.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_language_loss_2.py
@@ -171,6 +171,7 @@ class TestLanguageLossForwardWithMTP(unittest.TestCase):
         mock_config.add_mtp_loss = False
         mock_config.mtp_loss_scaling_factor = 1.0
         mock_config.recompute_modules = None
+        mock_config.gpt_model_use_experimental_version = False
 
         loss_fn = LanguageLoss(config=mock_config)
         logits = [

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_language_loss_3.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_language_loss_3.py
@@ -199,6 +199,7 @@ class TestLanguageLossForwardWithListLogits(unittest.TestCase):
         mock_config.add_mtp_loss = True
         mock_config.mtp_loss_scaling_factor = 0.5
         mock_config.gpt_model_use_experimental_version = True
+        mock_config.fused_linear_ce_loss_chunk = 0
 
         loss_fn = LanguageLoss(config=mock_config)
         vocab_size = 128

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_attention_5.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_attention_5.py
@@ -183,6 +183,7 @@ class TestSelfAttentionGetQKVWithGate(unittest.TestCase):
         config.recompute_modules = None
         config.tensor_model_parallel_size = 1
         config.gated_attention = True
+        config.gpt_model_use_experimental_version = False
         config.qk_norm_type = "per_head"
         config.rms_norm_eps = 1e-5
         config.sliding_window = None

--- a/tests/single_card_tests/transformer/test_mla_gate_attn.py
+++ b/tests/single_card_tests/transformer/test_mla_gate_attn.py
@@ -286,12 +286,13 @@ class TestMLAGatedForward(unittest.TestCase):
 
 
 class TestGetAttentionSpecGate(unittest.TestCase):
-    def _make_mock_config(self, gated=False):
+    def _make_mock_config(self, gated=False, align_mode=None):
         config = MagicMock()
         config.gated_attention = gated
         config.normalization = "RMSNorm"
         config.use_qk_norm = False
         config.qk_l2_norm = False
+        config.gpt_model_use_experimental_version = align_mode
         return config
 
     def test_mla_gated_has_gate_proj(self):
@@ -330,13 +331,15 @@ class TestGetAttentionSpecGate(unittest.TestCase):
 
     def test_self_attention_type_unaffected(self):
         from paddlefleet.models.gpt.gpt_layer_specs import get_attention_spec
+        from paddlefleet.transformer.identity_op import IdentityOp
 
         config = self._make_mock_config(gated=True)
         spec = get_attention_spec(
             config=config,
             attention_layer_type="self_attention",
         )
-        self.assertFalse(hasattr(spec.sublayers_spec, "gate_proj"))
+        # When align_mode is None, gate_proj should be IdentityOp (no-op)
+        self.assertEqual(spec.sublayers_spec.gate_proj, IdentityOp)
 
 
 if __name__ == "__main__":

--- a/tests/single_card_tests/transformer/test_router.py
+++ b/tests/single_card_tests/transformer/test_router.py
@@ -61,6 +61,9 @@ class MockTransformerConfig:
         self.context_parallel_size = 1
         self.sequence_parallel = False
 
+        # Experimental version flag
+        self.gpt_model_use_experimental_version = False
+
         # Internal storage to simulate the .get() method behavior
         self._extra_conf = {"seq_aux": False}
 


### PR DESCRIPTION
### PR Category
Distributed Strategy

### PR Types
New features

### Description
为 align mode（`gpt_model_use_experimental_version=True`）添加 v11 模型支持，主要变更包括：

1. **attention.py**：拆分 gated attention 的 gate projection 为独立 `gate_proj` 子层；采用 EC 兼容的非交错 QKV 布局（`[all_Q | all_K | all_V]`）替换原有 per-group 交错布局；在 TP=1 时用 `fused_linear` 替换 `o_proj` 计算。
2. **mlp.py / tensor_parallel/layers.py**：在 `gpt_model_use_experimental_version=True` 且 TP=1 时，用 `paddle.incubate.nn.functional.fused_linear` 替换普通线性层，对齐 EC 的 `FusedLinear` 行为。
3. **moe_router.py**：在 experimental 模式下将 `e_score_correction_bias` shape 从 `(num_experts,)` 改为 `(1, num_experts)`，对齐 EC 的张量布局。
4. **multi_token_prediction.py / transformer_layer.py**：在 experimental 模式下支持 `position_ids` 直接透传（不做 MTP 维度切分），并为 `eh_proj` 添加 bias 支持。
5. **language_loss.py**：MTP 多深度循环中，当 `fused_linear_ce_loss_chunk > 0` 时改用 `_forward` chunked 路径。

### 是否引起精度变化
否
不影响非对齐模式，对齐模式不影响V2