### PR TITLE
align back

### DIFF
--- a/src/paddlefleet/fusions/fused_bias_swiglu.py
+++ b/src/paddlefleet/fusions/fused_bias_swiglu.py
@@ -16,6 +16,7 @@
 # pylint: disable=missing-function-docstring, missing-class-docstring
 
 import logging
+import os
 
 import paddle
 import paddle.nn.functional as F
@@ -24,6 +25,25 @@ from paddlefleet.jit import jit_fuser
 from paddlefleet.utils import nvtx_decorator
 
 logger = logging.getLogger(__name__)
+
+
+def _dsv4_megatron_swiglu_wgrad_enabled() -> bool:
+    return os.environ.get("DSV4_FLEET_MEGATRON_SWIGLU_WGRAD", "0") == "1"
+
+
+def _dsv4_sum_like_megatron_for_small_chunks(value: paddle.Tensor) -> paddle.Tensor:
+    if (
+        not _dsv4_megatron_swiglu_wgrad_enabled()
+        or len(value.shape) != 2
+        or value.shape[0] >= 16
+    ):
+        return paddle.sum(value, axis=-1, keepdim=True)
+    pad_rows = 16 - value.shape[0]
+    if pad_rows <= 0:
+        return paddle.sum(value, axis=-1, keepdim=True)
+    padding = paddle.zeros([pad_rows, value.shape[1]], dtype=value.dtype)
+    padded = paddle.concat([value, padding], axis=0)
+    return paddle.sum(padded, axis=-1, keepdim=True)[: value.shape[0]]
 
 ###### BIAS SWIGLU FUSION/ NO AUTOGRAD ################
 
@@ -105,7 +125,7 @@ def weighted_swiglu_back(g, y, weights):
     input_grad = swiglu_back(g * weights, y)
     # precision of w may be higher than y and g, so we need to cast g to w_dtype
     weights_grad = swiglu(y) * g.to(w_dtype)
-    weights_grad = paddle.sum(weights_grad, dim=-1, keepdim=True)
+    weights_grad = _dsv4_sum_like_megatron_for_small_chunks(weights_grad)
     return input_grad.to(input_dtype), weights_grad.to(w_dtype)
 
 
@@ -251,7 +271,7 @@ def clamped_weighted_swiglu_back(g, y, weights, clamp_value):
     w_dtype = weights.dtype
     input_grad = clamped_swiglu_back(g * weights, y, clamp_value)
     weights_grad = clamped_swiglu(y, clamp_value) * g.cast(w_dtype)
-    weights_grad = paddle.sum(weights_grad, axis=-1, keepdim=True)
+    weights_grad = _dsv4_sum_like_megatron_for_small_chunks(weights_grad)
     return input_grad.cast(input_dtype), weights_grad.cast(w_dtype)
 
 

--- a/src/paddlefleet/models/gpt/gpt_embedding.py
+++ b/src/paddlefleet/models/gpt/gpt_embedding.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from __future__ import annotations
 
+import os
 import warnings
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
@@ -227,7 +228,6 @@ class GPTEmbedding(FleetLayer):
                     mtp_input_ids_for_moe_mask = paddle.stack(
                         mtp_ids_list, axis=1
                     )
-
                 if self.config.enable_mtp_magic_send:
                     # Magic send: only truncate, skip shifted embedding pre-computation.
                     # input_ids will be broadcast to the last stage for re-embedding.
@@ -244,7 +244,6 @@ class GPTEmbedding(FleetLayer):
                         decoder_input = ContextParallelScatterOp.apply(
                             decoder_input, axis=1
                         )
-
                     if self.sequence_parallel:
                         batch_size, seq_length, hidden_size = (
                             decoder_input.shape
@@ -289,13 +288,53 @@ class GPTEmbedding(FleetLayer):
                         )  # change to [S, B, H]
                     mtp_emb_res = [inputs_embeds]
                     for depth in range(self.config.num_nextn_predict_layers):
-                        inputs_embeds_mtp = paddle.concat(
-                            [
-                                inputs_embeds_ori[:, (depth + 1) :, :],
-                                inputs_embeds_extra[:, : (depth + 1), :],
-                            ],
-                            axis=1,
-                        )
+                        if (
+                            paddle.core._has_grad()
+                            and os.getenv("DSV4_FLEET_MTP_SEPARATE_EMBEDDING", "0")
+                            == "1"
+                        ):
+                            shifted_input_ids = input_ids[
+                                :, (depth + 1) : seq_length
+                            ]
+                            shifted_position_ids = None
+                            if (
+                                not self.multimodal_embedding
+                                and position_ids is not None
+                            ):
+                                shifted_position_ids = position_ids[
+                                    :, (depth + 1) : seq_length
+                                ]
+                            pad_input_ids = paddle.zeros(
+                                [batch_size, depth + 1], dtype=input_ids.dtype
+                            )
+                            pad_position_ids = None
+                            if (
+                                not self.multimodal_embedding
+                                and position_ids is not None
+                            ):
+                                pad_position_ids = paddle.zeros(
+                                    [batch_size, depth + 1],
+                                    dtype=position_ids.dtype,
+                                )
+                            shifted_embeds = self.embedding(
+                                input_ids=shifted_input_ids,
+                                position_ids=shifted_position_ids,
+                            )
+                            pad_embeds = self.embedding(
+                                input_ids=pad_input_ids,
+                                position_ids=pad_position_ids,
+                            )
+                            inputs_embeds_mtp = paddle.concat(
+                                [shifted_embeds, pad_embeds], axis=1
+                            )
+                        else:
+                            inputs_embeds_mtp = paddle.concat(
+                                [
+                                    inputs_embeds_ori[:, (depth + 1) :, :],
+                                    inputs_embeds_extra[:, : (depth + 1), :],
+                                ],
+                                axis=1,
+                            )
 
                         if (
                             get_context_parallel_world_size() > 1

--- a/src/paddlefleet/tensor_parallel/layers.py
+++ b/src/paddlefleet/tensor_parallel/layers.py
@@ -299,7 +299,7 @@ class VocabParallelEmbedding(paddle.nn.Layer):
         else:
             masked_input = input_
         # Get the embeddings.
-        if self.deterministic_mode:
+        if self.deterministic_mode or os.getenv("DSV4_EMBEDDING_INDEX_BACKWARD", "0") == "1":
             output_parallel = self.weight[masked_input]
         else:
             # F.embedding currently has a non-deterministic backward function

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -26,6 +26,7 @@ Components:
 from __future__ import annotations
 
 import functools
+import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -192,6 +193,75 @@ def _apply_rope(
 # ---------------------------------------------------------------------------
 
 
+def _dsv4_import_torch_for_csa_sink_softmax():
+    site_packages = os.environ.get(
+        "DSV4_FLEET_CSA_TORCH_SITE_PACKAGES",
+        os.environ.get("DSV4_FLEET_TE_SITE_PACKAGES", ""),
+    )
+    if site_packages and site_packages not in os.sys.path:
+        os.sys.path.insert(0, site_packages)
+    import torch
+    import torch.utils.dlpack
+
+    return torch
+
+
+def _dsv4_csa_sink_softmax_torch_bwd_enabled() -> bool:
+    return os.environ.get("DSV4_FLEET_CSA_SINK_SOFTMAX_TORCH_BWD", "0") == "1"
+
+
+def _dsv4_csa_sink_softmax_paddle(scores: Tensor, sink: Tensor) -> Tensor:
+    scores_max = scores.max(axis=-1, keepdim=True)  # [b, np, sq, 1]
+    scores_max = paddle.maximum(scores_max, sink)
+    exp_scores = paddle.exp(scores - scores_max)  # [b, np, sq, topk]
+    exp_sink = paddle.exp(sink - scores_max)  # [b, np, sq, 1]
+    sum_exp = exp_scores.sum(axis=-1, keepdim=True) + exp_sink  # [b, np, sq, 1]
+    return exp_scores / sum_exp  # [b, np, sq, topk]
+
+
+class _DSV4CSASinkSoftmaxTorchBackward(paddle.autograd.PyLayer):
+    @staticmethod
+    def forward(ctx, scores: Tensor, sink: Tensor):
+        ctx.save_for_backward(scores, sink)
+        return _dsv4_csa_sink_softmax_paddle(scores, sink)
+
+    @staticmethod
+    def backward(ctx, grad_attn_weights: Tensor):
+        torch = _dsv4_import_torch_for_csa_sink_softmax()
+        scores, sink = ctx.saved_tensor()
+        scores_t = torch.utils.dlpack.from_dlpack(
+            paddle.utils.dlpack.to_dlpack(scores.detach().contiguous())
+        )
+        sink_t = torch.utils.dlpack.from_dlpack(
+            paddle.utils.dlpack.to_dlpack(sink.detach().contiguous())
+        )
+        grad_t = torch.utils.dlpack.from_dlpack(
+            paddle.utils.dlpack.to_dlpack(
+                grad_attn_weights.detach().contiguous()
+            )
+        )
+
+        with torch.enable_grad():
+            scores_t = scores_t.detach().requires_grad_(True)
+            sink_t = sink_t.detach().requires_grad_(True)
+            scores_max_t = torch.maximum(
+                scores_t.max(dim=-1, keepdim=True).values, sink_t
+            )
+            exp_scores_t = torch.exp(scores_t - scores_max_t)
+            exp_sink_t = torch.exp(sink_t - scores_max_t)
+            sum_exp_t = exp_scores_t.sum(dim=-1, keepdim=True) + exp_sink_t
+            attn_weights_t = exp_scores_t / sum_exp_t
+            attn_weights_t.backward(grad_t)
+
+        grad_scores = paddle.utils.dlpack.from_dlpack(
+            torch.utils.dlpack.to_dlpack(scores_t.grad.contiguous())
+        )
+        grad_sink = paddle.utils.dlpack.from_dlpack(
+            torch.utils.dlpack.to_dlpack(sink_t.grad.contiguous())
+        )
+        return grad_scores, grad_sink
+
+
 def unfused_compressed_sparse_attn(
     query: Tensor,
     kv_full: Tensor,
@@ -241,18 +311,11 @@ def unfused_compressed_sparse_attn(
 
         # Softmax with attention sink
         # sink: [np] -> [1, np, 1, 1]
-        sink = attn_sink.reshape([1, np_heads, 1, 1])
-        # Compute stable softmax: max over scores and sink
-        scores_max = scores.max(axis=-1, keepdim=True)  # [b, np, sq, 1]
-        scores_max = paddle.maximum(scores_max, sink)
-
-        exp_scores = paddle.exp(scores - scores_max)  # [b, np, sq, topk]
-        exp_sink = paddle.exp(sink - scores_max)  # [b, np, sq, 1]
-
-        sum_exp = (
-            exp_scores.sum(axis=-1, keepdim=True) + exp_sink
-        )  # [b, np, sq, 1]
-        attn_weights = exp_scores / sum_exp  # [b, np, sq, topk]
+        sink = attn_sink.reshape([1, np_heads, 1, 1]).cast("float32")
+        if _dsv4_csa_sink_softmax_torch_bwd_enabled():
+            attn_weights = _DSV4CSASinkSoftmaxTorchBackward.apply(scores, sink)
+        else:
+            attn_weights = _dsv4_csa_sink_softmax_paddle(scores, sink)
 
         # Weighted sum: [b, np, sq, topk] x [b, sq, topk, hn] -> [b, np, sq, hn]
         output = paddle.einsum("bnsk,bskh->bnsh", attn_weights, kv_g)
@@ -801,7 +864,7 @@ class Compressor(nn.Layer):
             score = self._overlap_transform(score, fill_value=float("-inf"))
 
         # Gated pooling: softmax over the pool_dim, weighted sum.
-        weights = F.softmax(score, axis=2).cast(kv.dtype)
+        weights = F.softmax(score, axis=2, dtype="float32").cast(kv.dtype)
         kv = (kv * weights).sum(axis=2)  # [b, n_compressed, head_dim]
 
         kv = self.norm(kv.cast(x.dtype))

--- a/src/paddlefleet/transformer/dsa_attention.py
+++ b/src/paddlefleet/transformer/dsa_attention.py
@@ -25,6 +25,7 @@ This module provides:
 from __future__ import annotations
 
 import logging
+import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -57,6 +58,60 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+def _dsv4_torch_dsa_grad_k(grad_scores: Tensor, q: Tensor) -> Tensor | None:
+    if os.environ.get("DSV4_FLEET_DSA_INDEXER_GRAD_K_TORCH_BWD", "0") != "1":
+        return None
+    site_packages = os.environ.get("DSV4_FLEET_TE_SITE_PACKAGES", "")
+    if site_packages and site_packages not in os.sys.path:
+        os.sys.path.insert(0, site_packages)
+    import torch
+    import torch.utils.dlpack
+
+    grad_scores_t = torch.utils.dlpack.from_dlpack(
+        paddle.utils.dlpack.to_dlpack(grad_scores)
+    )
+    q_t = torch.utils.dlpack.from_dlpack(paddle.utils.dlpack.to_dlpack(q))
+    grad_k_t = torch.einsum(
+        "sbht,sbhd->tbd", grad_scores_t, q_t.to(dtype=torch.float32)
+    ).to(dtype=q_t.dtype)
+    return paddle.utils.dlpack.from_dlpack(torch.utils.dlpack.to_dlpack(grad_k_t))
+
+
+def _dsv4_import_torch_for_hadamard():
+    site_packages = os.environ.get(
+        "DSV4_FLEET_HADAMARD_TORCH_SITE_PACKAGES",
+        os.environ.get("DSV4_FLEET_TE_SITE_PACKAGES", ""),
+    )
+    if site_packages and site_packages not in os.sys.path:
+        os.sys.path.insert(0, site_packages)
+    import torch
+    import torch.utils.dlpack
+    from fast_hadamard_transform import hadamard_transform as torch_hadamard_transform
+
+    return torch, torch_hadamard_transform
+
+
+class _DSV4TorchHadamard(paddle.autograd.PyLayer):
+    @staticmethod
+    def forward(ctx, x: Tensor, scale_tensor: Tensor):
+        scale = float(scale_tensor.item())
+        ctx.scale = scale
+        torch, torch_hadamard_transform = _dsv4_import_torch_for_hadamard()
+        x_t = torch.utils.dlpack.from_dlpack(
+            paddle.utils.dlpack.to_dlpack(x.contiguous())
+        )
+        y_t = torch_hadamard_transform(x_t, scale=scale)
+        return paddle.utils.dlpack.from_dlpack(torch.utils.dlpack.to_dlpack(y_t.contiguous()))
+
+    @staticmethod
+    def backward(ctx, grad_output: Tensor):
+        torch, torch_hadamard_transform = _dsv4_import_torch_for_hadamard()
+        grad_t = torch.utils.dlpack.from_dlpack(
+            paddle.utils.dlpack.to_dlpack(grad_output.contiguous())
+        )
+        grad_x_t = torch_hadamard_transform(grad_t, scale=ctx.scale)
+        return paddle.utils.dlpack.from_dlpack(torch.utils.dlpack.to_dlpack(grad_x_t.contiguous())), None
+
 
 def hadamard_transform(x: Tensor, scale: float = 1.0) -> Tensor:
     """Fast Walsh-Hadamard Transform using the butterfly algorithm.
@@ -85,6 +140,10 @@ def hadamard_transform(x: Tensor, scale: float = 1.0) -> Tensor:
     assert dim > 0 and (dim & (dim - 1)) == 0, (
         f"hadamard_transform requires dim to be a power of 2, got {dim}"
     )
+
+    if os.environ.get("DSV4_FLEET_HADAMARD_TORCH", "0") == "1":
+        scale_tensor = paddle.to_tensor([scale], dtype="float32")
+        return _DSV4TorchHadamard.apply(x, scale_tensor)
 
     # Megatron uses fast_hadamard_transform, whose bf16 path accumulates in fp32
     # and casts back to bf16. Keep the same numeric contract here.
@@ -903,9 +962,11 @@ def _bwd_fused_indexer_loss(
         "sbht,tbd->sbhd", grad_scores, k.cast("float32")
     )  # [sq, b, h, d]
     # ∂L/∂k = einsum('sbht,sbhd->tbd', grad_scores, q)
-    grad_k = paddle.einsum(
-        "sbht,sbhd->tbd", grad_scores, q.cast("float32")
-    )  # [sk, b, d]
+    grad_k = _dsv4_torch_dsa_grad_k(grad_scores, q)
+    if grad_k is None:
+        grad_k = paddle.einsum(
+            "sbht,sbhd->tbd", grad_scores, q.cast("float32")
+        )  # [sk, b, d]
     del grad_scores
 
     return (

--- a/src/paddlefleet/transformer/dsv4_hybrid_attention.py
+++ b/src/paddlefleet/transformer/dsv4_hybrid_attention.py
@@ -25,6 +25,7 @@ Components:
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -49,9 +50,45 @@ if TYPE_CHECKING:
     from paddlefleet.transformer.transformer_config import TransformerConfig
 
 
+class _DSV4AttentionInputBranches(paddle.autograd.PyLayer):
+    @staticmethod
+    def forward(ctx, x: Tensor):
+        return x.clone(), x.clone(), x.clone()
+
+    @staticmethod
+    def backward(ctx, q_grad: Tensor, kv_grad: Tensor, core_x_grad: Tensor):
+        return (q_grad + kv_grad) + core_x_grad
+
+
+def _dsv4_attention_split_input_branches(tensor: Tensor):
+    if os.environ.get("DSV4_FLEET_ATTN_INPUT_ORDER", "0") != "1":
+        return tensor, tensor, tensor
+    if tensor is None or not isinstance(tensor, paddle.Tensor) or tensor.stop_gradient:
+        return tensor, tensor, tensor
+    return _DSV4AttentionInputBranches.apply(tensor)
+
+
+class _DSV4QRMSNorm(paddle.autograd.PyLayer):
+    @staticmethod
+    def forward(ctx, q: Tensor, eps: float) -> Tensor:
+        r = paddle.rsqrt(q.square().mean(axis=-1, keepdim=True) + eps)
+        ctx.save_for_backward(q, r)
+        return q * r
+
+    @staticmethod
+    def backward(ctx, grad_output: Tensor):
+        q, r = ctx.saved_tensor()
+        hidden_size = q.shape[-1]
+        grad_r = (grad_output * q).sum(axis=-1, keepdim=True)
+        grad_q = grad_output * r
+        grad_add = grad_r * (-0.5) * (r * r * r)
+        grad_q = grad_q + (paddle.full_like(q, 2.0) * q) * (grad_add / hidden_size)
+        return grad_q
+
+
 def _q_rms_norm(q: Tensor, eps: float) -> Tensor:
     """RMS normalization for query (no learnable weight)."""
-    return q * paddle.rsqrt(q.square().mean(-1, keepdim=True) + eps)
+    return _DSV4QRMSNorm.apply(q, eps)
 
 
 # ---------------------------------------------------------------------------
@@ -212,9 +249,10 @@ class DSv4HybridAttention(Attention):
         Returns:
             (output [b, sq, hidden_size], bias=None)
         """
+        q_input, kv_input, core_x = _dsv4_attention_split_input_branches(hidden_states)
         # Get Q, K, V tensors
         query, key, value, q_compressed, kv_compressed = (
-            self.get_query_key_value_tensors(hidden_states)
+            self.get_query_key_value_tensors(q_input, kv_input=kv_input)
         )
 
         # Core attention (CompressedSparseAttention)
@@ -223,7 +261,7 @@ class DSv4HybridAttention(Attention):
             key,
             value,
             attention_mask,
-            x=hidden_states,
+            x=core_x,
             qr=q_compressed,
         )
         # core_attn_out: [b, sq, np * v_head_dim]
@@ -376,7 +414,7 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
         )
 
     def get_query_key_value_tensors(
-        self, hidden_states: Tensor
+        self, hidden_states: Tensor, kv_input: Tensor | None = None
     ) -> tuple[Tensor, Tensor, Tensor, Tensor, Tensor]:
         """Derive query, key, value from hidden_states.
 
@@ -391,6 +429,7 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
             kv_compressed: [b, sq, hidden_size] (== hidden_states)
         """
         b, sq, _ = hidden_states.shape
+        kv_hidden_states = hidden_states if kv_input is None else kv_input
 
         # Q path
         q_compressed, _ = self.linear_q_down_proj(
@@ -403,7 +442,7 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
         q = _q_rms_norm(q, getattr(self.config, "rms_norm_eps", 1e-5))
 
         # KV path
-        kv, _ = self.linear_kv_proj(hidden_states)  # [b, sq, v_head_dim]
+        kv, _ = self.linear_kv_proj(kv_hidden_states)  # [b, sq, v_head_dim]
         kv = self.kv_layernorm(kv)
 
         # Apply RoPE to both Q and KV

--- a/src/paddlefleet/transformer/hyper_connection.py
+++ b/src/paddlefleet/transformer/hyper_connection.py
@@ -51,6 +51,194 @@ def _use_accuracy_compatible_kernel() -> bool:
     return _ACCURACY_COMPATIBLE_KERNEL
 
 
+def _dsv4_hc_sinkhorn_torch_backward(
+    logits: Tensor, grad_output: Tensor, num_iterations: int, eps: float
+) -> Tensor:
+    if os.environ.get("DSV4_FLEET_HC_SINKHORN_TORCH_BWD", "0") != "1":
+        return None
+    torch_site_packages = os.environ.get(
+        "DSV4_FLEET_HC_SINKHORN_TORCH_SITE_PACKAGES",
+        os.environ.get("DSV4_FLEET_TE_SITE_PACKAGES", ""),
+    )
+    if torch_site_packages:
+        import sys
+
+        if torch_site_packages not in sys.path:
+            sys.path.insert(0, torch_site_packages)
+    import torch
+    import torch.utils.dlpack
+    from paddle.utils import dlpack as paddle_dlpack
+
+    logits_t = torch.utils.dlpack.from_dlpack(
+        paddle_dlpack.to_dlpack(logits.contiguous())
+    ).to(torch.bfloat16)
+    grad_t = torch.utils.dlpack.from_dlpack(
+        paddle_dlpack.to_dlpack(grad_output.contiguous())
+    ).to(torch.bfloat16)
+    # Match Megatron's training graph: Sinkhorn receives a transposed-view grad
+    # from H_res.T @ residual, so the last two dimensions have stride (1, n).
+    grad_t = grad_t.transpose(-1, -2).contiguous().transpose(-1, -2)
+
+    with torch.enable_grad():
+        logits_t = logits_t.detach().requires_grad_(True)
+        row_max = logits_t.max(dim=-1, keepdim=True).values
+        m = torch.exp(logits_t - row_max)
+        for _ in range(num_iterations):
+            m = m / m.sum(dim=-1, keepdim=True).clamp(min=eps)
+            m = m / m.sum(dim=-2, keepdim=True).clamp(min=eps)
+        m.backward(grad_t)
+    grad_input_t = logits_t.grad.contiguous()
+    return paddle_dlpack.from_dlpack(torch.utils.dlpack.to_dlpack(grad_input_t))
+
+
+class _DSV4HCTorchOrderRmsScale(paddle.autograd.PyLayer):
+    @staticmethod
+    def forward(ctx, x: Tensor, eps: float):
+        nC = x.shape[-1]
+        norm = x.norm(axis=-1, keepdim=True)
+        r = 1.0 / (norm / math.sqrt(nC) + eps)
+        r = r.astype(x.dtype)
+        ctx.nC = nC
+        ctx.save_for_backward(x, norm, r)
+        return r
+
+    @staticmethod
+    def backward(ctx, grad: Tensor):
+        x, norm, r = ctx.saved_tensor()
+        grad = grad.astype(x.dtype)
+        # Match Torch norm + reciprocal backward source-order in BF16.
+        scaled = grad * (r * r)
+        scaled = scaled / math.sqrt(ctx.nC)
+        unit = x / norm
+        grad_x = (-scaled) * unit
+        # PyTorch preserves signed zeros in this path. Paddle's multiply tends
+        # to canonicalize the grad==0 row to +0, which is numerically equal but
+        # breaks bitwise grad checks.
+        zero = paddle.zeros_like(unit)
+        torch_zero = paddle.where(
+            x == 0, -paddle.ones_like(unit) * zero, (-unit) * zero
+        )
+        grad_x = paddle.where(scaled == 0, torch_zero, grad_x)
+        return grad_x.astype(x.dtype)
+
+
+class _DSV4LearnedOutputContract(paddle.autograd.PyLayer):
+    @staticmethod
+    def forward(
+        ctx,
+        hidden_states: Tensor,
+        head_fn: Tensor,
+        base: Tensor,
+        scale: Tensor,
+        n: int,
+        eps: float,
+    ):
+        dtype = hidden_states.dtype
+        hidden_fp32 = hidden_states.astype("float32")
+        head_fn_fp32 = head_fn.astype("float32")
+        base_fp32 = base.astype("float32")
+        scale_fp32 = scale.astype("float32")
+
+        rsqrt = paddle.rsqrt(hidden_fp32.square().mean(-1, keepdim=True) + eps)
+        head_fn_out_in = head_fn_fp32.transpose([1, 0]).contiguous()
+        with paddle.amp.auto_cast(False):
+            proj = paddle.matmul(hidden_fp32, head_fn_out_in, transpose_y=True)
+        if os.environ.get("DSV4_FLEET_CONTRACT_MIXES_RSQRT_FIRST", "0") == "1":
+            mixes = rsqrt * proj
+        else:
+            mixes = proj * rsqrt
+        pre_arg = mixes * scale_fp32 + base_fp32
+        sig = F.sigmoid(pre_arg)
+        pre = sig + eps
+        hidden_streams = hidden_fp32.reshape([*hidden_fp32.shape[:-1], n, -1])
+        y = paddle.sum(pre.unsqueeze(-1) * hidden_streams, axis=-2)
+
+        ctx.save_for_backward(
+            hidden_fp32,
+            head_fn_fp32,
+            base_fp32,
+            scale_fp32,
+            rsqrt,
+            proj,
+            mixes,
+            sig,
+            pre,
+        )
+        ctx.n = n
+        ctx.eps = eps
+        ctx.hidden_dtype = dtype
+        ctx.head_fn_dtype = head_fn.dtype
+        ctx.base_dtype = base.dtype
+        ctx.scale_dtype = scale.dtype
+        return y.astype(dtype)
+
+    @staticmethod
+    def backward(ctx, grad_output: Tensor):
+        (
+            hidden_fp32,
+            head_fn_fp32,
+            base_fp32,
+            scale_fp32,
+            rsqrt,
+            proj,
+            mixes,
+            sig,
+            pre,
+        ) = ctx.saved_tensor()
+        n = ctx.n
+        hdim = hidden_fp32.shape[-1]
+        hidden_streams = hidden_fp32.reshape([*hidden_fp32.shape[:-1], n, -1])
+        grad_y = grad_output.astype("float32")
+
+        grad_prod = paddle.expand(
+            grad_y.unsqueeze(-2),
+            [*hidden_streams.shape],
+        )
+        grad_hidden_streams = grad_prod * pre.unsqueeze(-1)
+        grad_hidden_direct = grad_hidden_streams.reshape(hidden_fp32.shape)
+
+        grad_pre = paddle.sum(grad_prod * hidden_streams, axis=-1)
+        grad_pre_arg = grad_pre * sig * (1.0 - sig)
+        grad_mixes = grad_pre_arg * scale_fp32
+        grad_scale = paddle.sum(grad_pre_arg * mixes).reshape(scale_fp32.shape)
+        grad_base = paddle.sum(
+            grad_pre_arg.reshape([-1, grad_pre_arg.shape[-1]]),
+            axis=0,
+        ).reshape(base_fp32.shape)
+
+        grad_proj = grad_mixes * rsqrt
+        grad_rsqrt = paddle.sum(grad_mixes * proj, axis=-1, keepdim=True)
+
+        hidden_2d = hidden_fp32.reshape([-1, hdim])
+        grad_proj_2d = grad_proj.reshape([-1, grad_proj.shape[-1]])
+        grad_head_fn = paddle.matmul(hidden_2d, grad_proj_2d, transpose_x=True)
+        grad_hidden_proj = paddle.matmul(grad_proj, head_fn_fp32, transpose_y=True)
+
+        grad_mean = grad_rsqrt * (-0.5) * rsqrt * rsqrt * rsqrt
+        grad_hidden_rsqrt = hidden_fp32 * grad_mean * (2.0 / float(hdim))
+
+        # Match PyTorch autograd's observed accumulation order for this graph:
+        # direct view branch, projection branch, then rsqrt/mean branch.
+        grad_hidden = (grad_hidden_direct + grad_hidden_proj) + grad_hidden_rsqrt
+
+        return (
+            grad_hidden.astype(ctx.hidden_dtype),
+            grad_head_fn.astype(ctx.head_fn_dtype),
+            grad_base.astype(ctx.base_dtype),
+            grad_scale.astype(ctx.scale_dtype),
+        )
+
+
+class _DSV4ContractBranchSplit(paddle.autograd.PyLayer):
+    @staticmethod
+    def forward(ctx, hidden_states: Tensor):
+        return hidden_states.clone(), hidden_states.clone(), hidden_states.clone()
+
+    @staticmethod
+    def backward(ctx, grad_rsqrt: Tensor, grad_proj: Tensor, grad_direct: Tensor):
+        return (grad_direct + grad_proj) + grad_rsqrt
+
+
 class SinkhornKnopp(paddle.autograd.PyLayer):
     """
     Differentiable Sinkhorn-Knopp algorithm for doubly stochastic projection.
@@ -60,6 +248,27 @@ class SinkhornKnopp(paddle.autograd.PyLayer):
 
     Reference: Eq. (9) in mHC paper - M^{(t)} = T_c(T_r(M^{(t-1)}))
     """
+
+    eps = 1e-6
+
+    class _ExpRowMax(paddle.autograd.PyLayer):
+        @staticmethod
+        def forward(ctx, logits: Tensor) -> Tensor:
+            row_max = logits.max(axis=-1, keepdim=True)
+            out = paddle.exp(logits - row_max)
+            row_argmax = logits.argmax(axis=-1, keepdim=True)
+            ctx.save_for_backward(out, row_argmax)
+            return out
+
+        @staticmethod
+        def backward(ctx, grad_output: Tensor) -> tuple[Tensor]:
+            out, row_argmax = ctx.saved_tensor()
+            grad_z = grad_output * out
+            grad_row_max = grad_z.sum(axis=-1, keepdim=True)
+            row_argmax_mask = F.one_hot(
+                row_argmax.squeeze(-1), num_classes=out.shape[-1]
+            ).astype(out.dtype)
+            return grad_z - row_argmax_mask * grad_row_max
 
     @staticmethod
     def _sinkhorn_normalize(
@@ -98,26 +307,18 @@ class SinkhornKnopp(paddle.autograd.PyLayer):
         Returns:
             H_res: [..., n, n] - doubly stochastic matrix
         """
-        # Stabilized exp: subtract row-wise max to prevent overflow.
-        # Under FLAGS_use_accuracy_compatible_kernel, force this outside AMP
-        # so the Paddle native path preserves the BF16 contract used by
-        # Megatron's torch implementation.
-        if _use_accuracy_compatible_kernel():
-            with paddle.amp.auto_cast(enable=False):
-                M_init = paddle.exp(
-                    H_res_logits - H_res_logits.max(axis=-1, keepdim=True)
-                )
-                M = SinkhornKnopp._sinkhorn_normalize(
-                    M_init, num_iterations, eps
-                )
-        else:
-            M_init = paddle.exp(
-                H_res_logits - H_res_logits.max(axis=-1, keepdim=True)
+        with paddle.amp.auto_cast(enable=False):
+            # Stabilized exp: subtract row-wise max to prevent overflow.
+            # Keep this outside AMP so the Paddle native path preserves the
+            # BF16 contract used by Megatron's torch implementation.
+            M_init = SinkhornKnopp._ExpRowMax.apply(H_res_logits)
+            M = SinkhornKnopp._sinkhorn_normalize(
+                M_init, num_iterations, eps
             )
-            M = SinkhornKnopp._sinkhorn_normalize(M_init, num_iterations, eps)
 
-        # Save initial M for backward recomputation
-        ctx.save_for_backward(M_init)
+        # Save logits instead of M_init so backward recomputes the same graph
+        # as Megatron: exp(logits - row_max) followed by Sinkhorn iterations.
+        ctx.save_for_backward(H_res_logits)
         ctx.num_iterations = num_iterations
         ctx.eps = eps
         return M
@@ -127,30 +328,30 @@ class SinkhornKnopp(paddle.autograd.PyLayer):
         """
         Backward through Sinkhorn-Knopp iterations using recomputation.
         """
-        (M_init,) = ctx.saved_tensor()
+        (H_res_logits,) = ctx.saved_tensor()
         num_iterations = ctx.num_iterations
         eps = ctx.eps
+        torch_grad_input = _dsv4_hc_sinkhorn_torch_backward(
+            H_res_logits, grad_output, num_iterations, eps
+        )
+        if torch_grad_input is not None:
+            return torch_grad_input
 
         with paddle.enable_grad():
-            # Recompute forward with autograd enabled
-            M_input = M_init.detach()
-            M_input.stop_gradient = False
+            logits = H_res_logits.detach()
+            logits.stop_gradient = False
+            with paddle.amp.auto_cast(enable=False):
+                M_current = SinkhornKnopp._ExpRowMax.apply(logits)
+                M_current = SinkhornKnopp._sinkhorn_normalize(
+                    M_current, num_iterations, eps
+                )
 
-            M_current = SinkhornKnopp._sinkhorn_normalize(
-                M_input, num_iterations, eps
-            )
-
-            # Compute dL/dM_input via autograd
-            grad_M_init = paddle.grad(
+            grad_input = paddle.grad(
                 outputs=[M_current],
-                inputs=[M_input],
+                inputs=[logits],
                 grad_outputs=[grad_output],
                 create_graph=False,
             )[0]
-
-        # Apply chain rule: dL/dH = dL/dM_init * dM_init/dH = dL/dM_init * M_init
-        # Since M_init = exp(H_res_logits), d(exp(x))/dx = exp(x) = M_init
-        grad_input = grad_M_init * M_init
 
         return grad_input
 
@@ -332,15 +533,15 @@ class HyperConnectionModule(nn.Layer):
         if _use_accuracy_compatible_kernel():
             nC = x.shape[-1]
             weight = self.mapping_proj.weight
-            r = x.norm(axis=-1, keepdim=True) / math.sqrt(nC)  # [..., 1]
-            r = (1.0 / (r + self.norm_eps)).astype(x.dtype)  # [..., 1]
+            x_2d = x.reshape([-1, nC])
+            r = _DSV4HCTorchOrderRmsScale.apply(x_2d, self.norm_eps)
             # Match Megatron clean path: torch.matmul(x, weight.t()). Paddle
             # nn.Linear uses a different BF16 cuBLAS path for this shape and
             # drifts before the first HC BDA.
-            x_2d = x.reshape([-1, nC])
             weight_out_in = weight.t().contiguous()
             proj_2d = paddle.matmul(x_2d, weight_out_in, transpose_y=True)
             proj = proj_2d.reshape([*x.shape[:-1], weight.shape[-1]])
+            r = r.reshape([*x.shape[:-1], 1])
         else:
             proj, r = self._proj_rms_op(
                 x, self.mapping_proj.weight, self.norm_eps
@@ -398,8 +599,10 @@ class HyperConnectionModule(nn.Layer):
         leading_shape = x.shape[:-1]
         proj, r = self._projection_and_get_norm(x)
         h_pre, h_post, h_res = self._compute_h(proj, r)
+        h_res_logits = h_res
+        h_res_logits_view = h_res_logits.reshape([*leading_shape, self.n, self.n])
         h_res = self._sinkhorn_op(
-            h_res.reshape([*leading_shape, self.n, self.n]),
+            h_res_logits_view,
             self.sinkhorn_iterations,
             self.norm_eps,
         )  # [..., n, n]
@@ -538,13 +741,16 @@ class HyperConnectionModule(nn.Layer):
             h_res: [..., n, n] - residual mixing matrix (for fused kernel)
             h_post: [..., n] - expansion weights
         """
+        mapping_input = hidden_states
+        aggregate_input = hidden_states
+
         # Compute mappings
         if not _use_accuracy_compatible_kernel():
-            hidden_states = hidden_states.astype("float32")
-        h_pre, h_post, h_res = self.compute_mappings(hidden_states)
+            mapping_input = mapping_input.astype("float32")
+        h_pre, h_post, h_res = self.compute_mappings(mapping_input)
 
         # Aggregate for layer input
-        aggregated = self.aggregate(hidden_states, h_pre)
+        aggregated = self.aggregate(aggregate_input, h_pre)
 
         return aggregated, h_res, h_post
 
@@ -618,34 +824,56 @@ class HyperConnectionModule(nn.Layer):
         Returns:
             contracted: [..., h] single-stream output
         """
+        if os.environ.get("DSV4_FLEET_CONTRACT_CUSTOM_BWD", "0") == "1":
+            return _DSV4LearnedOutputContract.apply(
+                hidden_states,
+                head_fn,
+                base,
+                scale,
+                n,
+                eps,
+            )
+
         dtype = hidden_states.dtype
         hidden_states = hidden_states.astype("float32")
         head_fn = head_fn.astype("float32")
         base = base.astype("float32")
         scale = scale.astype("float32")
+        hidden_for_rsqrt = hidden_states
+        hidden_for_proj = hidden_states
+        hidden_for_direct = hidden_states
+        if os.environ.get("DSV4_FLEET_CONTRACT_BRANCH_SPLIT", "0") == "1":
+            hidden_for_rsqrt, hidden_for_proj, hidden_for_direct = _DSV4ContractBranchSplit.apply(
+                hidden_states
+            )
 
         rsqrt = paddle.rsqrt(
-            hidden_states.square().mean(-1, keepdim=True) + eps
+            hidden_for_rsqrt.square().mean(-1, keepdim=True) + eps
         )
-        if _use_accuracy_compatible_kernel():
+        if (
+            _use_accuracy_compatible_kernel()
+            or os.environ.get("DSV4_FLEET_CONTRACT_BRANCH_SPLIT", "0") == "1"
+        ):
             # Match Torch F.linear(x, weight[out,in]) kernel selection. Paddle
             # F.linear(x, weight[in,out]) uses a different cuBLAS path and
             # causes BF16 ulp drift in DSv4 final output contraction.
             head_fn_out_in = head_fn.transpose([1, 0]).contiguous()
             with paddle.amp.auto_cast(False):
                 proj = paddle.matmul(
-                    hidden_states, head_fn_out_in, transpose_y=True
+                    hidden_for_proj, head_fn_out_in, transpose_y=True
                 )
             mixes = proj * rsqrt
         else:
             mixes = F.linear(hidden_states, head_fn) * rsqrt
-        pre = F.sigmoid(mixes * scale + base) + eps
-        y = paddle.sum(
-            pre.unsqueeze(-1)
-            * hidden_states.reshape([*hidden_states.shape[:-1], n, -1]),
-            axis=-2,
+        pre_arg = mixes * scale + base
+        pre = F.sigmoid(pre_arg) + eps
+        hidden_streams = hidden_for_direct.reshape(
+            [*hidden_for_direct.shape[:-1], n, -1]
         )
-        return y.astype(dtype)
+        contract_prod = pre.unsqueeze(-1) * hidden_streams
+        y = paddle.sum(contract_prod, axis=-2)
+        out = y.astype(dtype)
+        return out
 
     # ==================== Fused kernel placeholder ====================
 
@@ -715,7 +943,7 @@ class HyperConnectionModule(nn.Layer):
         out = paddle.nn.functional.dropout(
             x_expanded, p=dropout_prob, training=training
         )
-        output = out + mixed
+        output = mixed + out
 
         return output
 

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -84,6 +84,35 @@ def _log_moe_md5(tensor, name, layer_idx=None):
         )
 
 
+class _DSV4MTPMoEInputBranches(PyLayer):
+    @staticmethod
+    def forward(ctx, x, is_mtp_layer, layer_number):
+        return x.clone(), x.clone(), x.clone()
+
+    @staticmethod
+    def backward(ctx, routed_grad, router_grad, shared_grad):
+        return (routed_grad + router_grad) + shared_grad
+
+
+def _dsv4_mtp_moe_split_input_branches(tensor, is_mtp_layer, layer_number):
+    if is_mtp_layer:
+        enabled = os.environ.get("DSV4_FLEET_MTP_MOE_INPUT_ORDER", "0") == "1"
+    else:
+        enabled = os.environ.get("DSV4_FLEET_MOE_INPUT_ORDER", "0") == "1"
+    if not enabled:
+        return tensor, tensor, tensor
+    if tensor is None or not isinstance(tensor, paddle.Tensor) or tensor.stop_gradient:
+        return tensor, tensor, tensor
+    return _DSV4MTPMoEInputBranches.apply(tensor, is_mtp_layer, layer_number)
+
+
+if paddlefleet_ops.is_sonic_moe_available():
+    from paddlefleet_ops.sonicmoe.enums import ActivationType
+    from paddlefleet_ops.sonicmoe.functional import (
+        _DownProjection,
+        _UpProjection,
+    )
+
 from .moe_utils import (
     global_moe_balance_training_logs_enabled,
     log_moe_balance,
@@ -392,6 +421,7 @@ class MoELayer(nn.Layer):
                     self.num_experts_per_device,
                     local_expert_indices,
                 )
+                self.token_dispatcher.layer_number = layer_number
             else:
                 raise NotImplementedError(
                     f"Unsupported moe_token_dispatcher_type {self.moe_token_dispatcher_type}"
@@ -939,6 +969,9 @@ class MoELayer(nn.Layer):
 
         layer_idx = getattr(self, "layer_number", None)
         _log_moe_md5(hidden_states, "moe_input", layer_idx)
+        routed_input, gate_input, shared_residuals = _dsv4_mtp_moe_split_input_branches(
+            hidden_states, self.is_mtp_layer, self.layer_number
+        )
         (
             capacity,
             topk_weights,
@@ -949,7 +982,7 @@ class MoELayer(nn.Layer):
             aux_loss,
             z_loss,
         ) = self.gate(
-            hidden_states,
+            gate_input,
             input_ids=input_ids,
         )
         # topk_weights, topk_indices: Shape is [seq_len, moe_router_topk]
@@ -970,14 +1003,14 @@ class MoELayer(nn.Layer):
         ):
             combine_overlap_handle = {
                 "fn": self.shared_experts,
-                "fn_args": (residuals,),
+                "fn_args": (shared_residuals,),
             }
         else:
             combine_overlap_handle = None
         if self.expert_model_parallel_size > 1:
             if self.moe_use_fusion_node:
                 output = self.fusion_moe_forward(
-                    hidden_states,
+                    routed_input,
                     probs,
                     mask,
                     combine_overlap_handle,
@@ -986,7 +1019,7 @@ class MoELayer(nn.Layer):
                 )
             else:
                 output = self.custom_forward(
-                    hidden_states,
+                    routed_input,
                     probs,
                     mask,
                     topk_weights=topk_weights,
@@ -1027,7 +1060,7 @@ class MoELayer(nn.Layer):
             if combine_overlap_handle is not None:
                 shared_output = combine_overlap_handle["fn_out"][0]
             else:
-                shared_output = self.shared_experts(residuals)[0]
+                shared_output = self.shared_experts(shared_residuals)[0]
             output = output + shared_output
 
         _log_moe_md5(output, "moe_final_output", layer_idx)

--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -62,6 +62,21 @@ def _get_moe_topk_fusion():
 _moe_router_logger = logging.getLogger(__name__)
 
 
+def _dsv4_router_fp32_wgrad_enabled() -> bool:
+    return os.environ.get("DSV4_FLEET_ROUTER_FP32_WGRAD", "0") == "1"
+
+
+def _dsv4_accumulate_router_fp32_wgrad(weight, w_grad):
+    if not _dsv4_router_fp32_wgrad_enabled() or w_grad is None:
+        return
+    w_grad = w_grad.detach().cast(paddle.float32)
+    prev = getattr(weight, "_dsv4_router_gate_fp32_wgrad", None)
+    if prev is None:
+        weight._dsv4_router_gate_fp32_wgrad = w_grad
+    else:
+        weight._dsv4_router_gate_fp32_wgrad = prev + w_grad
+
+
 def _log_moe_md5(tensor, name, layer_idx=None):
     """Log MD5 of a tensor for MoE precision alignment debugging."""
     from paddlefleet.transformer.transformer_layer import TransformerLayer
@@ -95,6 +110,7 @@ class FusedGateDetachMatmul(paddle.autograd.PyLayer):
         """
         ctx.dw_p2p_overlap = dw_p2p_overlap
         ctx.dtype = paddle.float32
+        ctx.weight_ref = w
         ctx.save_for_backward(x, w)
         w = w.T
         return F.linear(x.cast(ctx.dtype), w.cast(ctx.dtype))
@@ -105,6 +121,7 @@ class FusedGateDetachMatmul(paddle.autograd.PyLayer):
         backward
         """
         x, w = ctx.saved_tensor()
+        weight_ref = getattr(ctx, "weight_ref", w)
         assert ctx.dtype == y_grad.dtype, "dtype not match"
 
         w_stop_grad = w.stop_gradient
@@ -112,9 +129,11 @@ class FusedGateDetachMatmul(paddle.autograd.PyLayer):
 
         def _compute_weight_grad(x_cast, y_grad, weight):
             with paddle.amp.auto_cast(False):
-                w_grad = paddle.matmul(
+                w_grad_fp32 = paddle.matmul(
                     x_cast, y_grad, transpose_x=True
                 ).T  # 始终先算梯度
+                _dsv4_accumulate_router_fp32_wgrad(weight, w_grad_fp32)
+                w_grad = w_grad_fp32.cast("bfloat16").cast(paddle.float32)
 
             if hasattr(weight, "main_grad"):
                 if weight.main_grad is None:
@@ -147,13 +166,14 @@ class FusedGateDetachMatmul(paddle.autograd.PyLayer):
                         _compute_weight_grad,
                         x_cast.detach(),
                         y_grad.detach(),
-                        w,
+                        weight_ref,
                     )
                 )
                 WeightGradStore.enabled = False
                 return x_grad, None
         else:
-            w = w.T
+            weight = weight_ref
+            w = weight.T
             x_g, w_g = matmul_grad(
                 x.cast(ctx.dtype),
                 w.cast(ctx.dtype),
@@ -163,9 +183,11 @@ class FusedGateDetachMatmul(paddle.autograd.PyLayer):
             )
 
             x_grad = x_g.cast(x.dtype) if not x_stop_grad else None
-            w_grad = w_g.cast(w.dtype) if not w_stop_grad else None
-            if w_grad is not None:
-                w_grad = w_grad.T
+            w_grad = None
+            if not w_stop_grad:
+                w_grad_fp32 = w_g.T
+                _dsv4_accumulate_router_fp32_wgrad(weight, w_grad_fp32)
+                w_grad = w_grad_fp32.cast("bfloat16").cast(weight.dtype)
 
             return x_grad, w_grad
 
@@ -222,8 +244,6 @@ class StandardMoERouter(nn.Layer):
         self.topk_method = config.topk_method
         self.num_experts_per_tok = config.num_experts_per_tok
         self.norm_topk_prob = config.norm_topk_prob
-        # force keep in float32 when using amp
-        self._cast_to_low_precision = False
 
         self.n_group = config.n_group
 
@@ -250,7 +270,7 @@ class StandardMoERouter(nn.Layer):
         # Initialize gate weight with Normal distribution aligned with Megatron.
         self.weight = paddle.create_parameter(
             shape=[self.num_experts, self.hidden_size],
-            dtype="float32",
+            dtype=config.params_dtype or "float32",
             default_initializer=paddle.nn.initializer.Constant(0.0),
         )
         config.init_method(self.weight)
@@ -843,6 +863,7 @@ class StandardMoERouter(nn.Layer):
 
     def set_layer_number(self, layer_number, is_mtp_layer: bool = False):
         self.layer_number = layer_number
+        self.is_mtp_layer = is_mtp_layer
         self._setup_hash_layer(layer_number, is_mtp_layer)
 
     def _setup_hash_layer(self, layer_number, is_mtp_layer: bool = False):
@@ -922,6 +943,7 @@ class TopKRouter(StandardMoERouter):
     def set_layer_number(self, layer_number, is_mtp_layer: bool = False):
         self._layer_number = layer_number
         self.layer_number = layer_number
+        self.is_mtp_layer = is_mtp_layer
         self._setup_hash_layer(layer_number, is_mtp_layer=is_mtp_layer)
 
     def forward(self, input, input_ids=None):
@@ -952,6 +974,8 @@ class TopKRouter(StandardMoERouter):
                     f"input_ids=[{batch_size_}, {seq_len_}], "
                     f"expected [batch_size={batch_size}, seq_len={seq_len}]"
                 )
+                if self.is_mtp_layer:
+                    input_ids_none_zero_mask = None
             else:
                 input_ids_none_zero_mask = None
         elif len(input.shape) == 2:

--- a/src/paddlefleet/transformer/moe/moe_utils.py
+++ b/src/paddlefleet/transformer/moe/moe_utils.py
@@ -141,7 +141,12 @@ def permute(
     sorted_indices = token_indices.masked_select(routing_map)
 
     # use the mapping to permute the tokens
-    permuted_input = tokens.index_select(axis=0, index=sorted_indices)
+    if _dsv4_fleet_moe_fp32_accum_enabled():
+        permuted_input = tokens.cast("float32").index_select(
+            axis=0, index=sorted_indices
+        ).cast(tokens.dtype)
+    else:
+        permuted_input = tokens.index_select(axis=0, index=sorted_indices)
 
     return permuted_input, sorted_indices
 


### PR DESCRIPTION
Cherry-pick 47060b940e93cd638c238d7403404b3dc249c574 onto latest upstream/develop.

Resolved conflicts against current develop in DSv4 alignment paths while keeping develop's newer MTP magic-send, CSA, mHC, and MoE structure.

Checks:
- git diff --check upstream/develop..HEAD
- python -m py_compile src/paddlefleet/fusions/fused_bias_swiglu.py src/paddlefleet/models/gpt/gpt_embedding.py src/paddlefleet/tensor_parallel/layers.py src/paddlefleet/transformer/csa_attention.py src/paddlefleet/transformer/dsa_attention.py src/paddlefleet/transformer/dsv4_hybrid_attention.py src/paddlefleet/transformer/hyper_connection.py src/paddlefleet/transformer/moe/moe_layer.py src/paddlefleet/transformer/moe/moe_router.py src/paddlefleet/transformer/moe/moe_utils.py