### PR TITLE
[codex] Adapt DSv4 backward alignment to latest Fleet

### DIFF
--- a/packages/paddlefleet_ops/src/paddlefleet_ops/utils.py
+++ b/packages/paddlefleet_ops/src/paddlefleet_ops/utils.py
@@ -92,12 +92,13 @@ class ModuleContext:
 
 def patch_module_namespace(source_name: str, target_prefix: str):
     """
-    Moves loaded modules from source_name to target_prefix + source_name.
-    Effectively 'installs' the module into the new namespace.
+    Copies loaded modules from source_name to target_prefix + source_name.
+    Effectively 'installs' the module into the new namespace while keeping
+    the original name so that internal absolute imports still resolve.
     """
     for name in list(sys.modules.keys()):
         if name == source_name or name.startswith(source_name + "."):
-            module = sys.modules.pop(name)
+            module = sys.modules[name]
             new_name = target_prefix + name
             sys.modules[new_name] = module
 

--- a/src/paddlefleet/fusions/fused_bias_swiglu.py
+++ b/src/paddlefleet/fusions/fused_bias_swiglu.py
@@ -16,6 +16,7 @@
 # pylint: disable=missing-function-docstring, missing-class-docstring
 
 import logging
+import os
 
 import paddle
 import paddle.nn.functional as F
@@ -24,6 +25,29 @@ from paddlefleet.jit import jit_fuser
 from paddlefleet.utils import nvtx_decorator
 
 logger = logging.getLogger(__name__)
+
+
+def _dsv4_megatron_swiglu_enabled() -> bool:
+    return os.environ.get("DSV4_FLEET_MEGATRON_SWIGLU", "0") == "1"
+
+
+def _dsv4_megatron_swiglu_wgrad_enabled() -> bool:
+    return os.environ.get("DSV4_FLEET_MEGATRON_SWIGLU_WGRAD", "0") == "1"
+
+
+def _dsv4_sum_like_megatron_for_small_chunks(value: paddle.Tensor) -> paddle.Tensor:
+    if (
+        not _dsv4_megatron_swiglu_wgrad_enabled()
+        or len(value.shape) != 2
+        or value.shape[0] >= 16
+    ):
+        return paddle.sum(value, axis=-1, keepdim=True)
+    pad_rows = 16 - value.shape[0]
+    if pad_rows <= 0:
+        return paddle.sum(value, axis=-1, keepdim=True)
+    padding = paddle.zeros([pad_rows, value.shape[1]], dtype=value.dtype)
+    padded = paddle.concat([value, padding], axis=0)
+    return paddle.sum(padded, axis=-1, keepdim=True)[: value.shape[0]]
 
 ###### BIAS SWIGLU FUSION/ NO AUTOGRAD ################
 
@@ -37,6 +61,9 @@ def swiglu(y):
     Returns:
         paddle.Tensor: Result of SwiGLU activation: SiLU(y1) * y2, where y1, y2 are the split halves.
     """
+    if _dsv4_megatron_swiglu_enabled():
+        y_1, y_2 = paddle.chunk(y, 2, axis=-1)
+        return F.silu(y_1) * y_2
     return F.swiglu(y)
 
 
@@ -75,10 +102,19 @@ def swiglu_back(g, y):
 
     Returns:
         paddle.Tensor: Gradient with respect to the input tensor, computed using the
-            Paddle native SwiGLU gradient operator.
+            chain rule and the derivative of the SiLU activation function.
     """
-    dx, _ = paddle._C_ops.swiglu_grad(y, None, g)
-    return dx
+    if paddle.is_compiled_with_cuda():
+        from paddlefleet_ops import fused_swiglu_bwd
+
+        return fused_swiglu_bwd(g, y)
+    elif paddle.is_compiled_with_xpu():
+        dx, _ = paddle._C_ops.swiglu_grad(y, None, g)
+        return dx
+    else:
+        raise NotImplementedError(
+            "fused_swiglu_bwd is not implemented for non-CUDA backends."
+        )
 
 
 @jit_fuser
@@ -105,7 +141,7 @@ def weighted_swiglu_back(g, y, weights):
     input_grad = swiglu_back(g * weights, y)
     # precision of w may be higher than y and g, so we need to cast g to w_dtype
     weights_grad = swiglu(y) * g.to(w_dtype)
-    weights_grad = paddle.sum(weights_grad, dim=-1, keepdim=True)
+    weights_grad = _dsv4_sum_like_megatron_for_small_chunks(weights_grad)
     return input_grad.to(input_dtype), weights_grad.to(w_dtype)
 
 
@@ -137,10 +173,6 @@ def clamped_swiglu_back(g, y, clamp_value):
     """Backward pass for clamped_swiglu.
 
     Gradient is zeroed out where inputs were clamped.
-    Computation is performed in float32; g is used in its
-    original dtype so auto-promotion to float32 occurs naturally through
-    the float32 terms; masks are cast to g.dtype matching
-    ``.to(g.dtype)`` in the reference implementation.
 
     Args:
         g (paddle.Tensor): Upstream gradient.
@@ -155,55 +187,21 @@ def clamped_swiglu_back(g, y, clamp_value):
     y_1, y_2 = paddle.chunk(y_fp32, 2, axis=-1)
     y_1_clamped = y_1.clip(max=clamp_value)
     y_2_clamped = y_2.clip(min=-clamp_value, max=clamp_value)
-    # Clamp masks in g.dtype
-    y1_mask = (y_1 <= clamp_value).cast(g.dtype)
-    y2_mask = ((y_2 >= -clamp_value) & (y_2 <= clamp_value)).cast(g.dtype)
-    sig = F.sigmoid(y_1_clamped)
-    grad_y1 = (
-        g * sig * (1.0 + y_1_clamped * (1.0 - sig)) * y_2_clamped * y1_mask
+    g_fp32 = g.cast(paddle.float32)
+    # Clamp masks: gradient is 0 where the input was clamped
+    y1_mask = (y_1 <= clamp_value).cast(paddle.float32)
+    y2_mask = ((y_2 >= -clamp_value) & (y_2 <= clamp_value)).cast(
+        paddle.float32
     )
-    grad_y2 = g * (y_1_clamped * sig) * y2_mask  # silu = x * sigmoid(x)
+    grad_y1 = (
+        g_fp32
+        * F.sigmoid(y_1_clamped)
+        * (1.0 + y_1_clamped * (1.0 - F.sigmoid(y_1_clamped)))
+        * y_2_clamped
+        * y1_mask
+    )
+    grad_y2 = g_fp32 * F.silu(y_1_clamped) * y2_mask
     return paddle.concat([grad_y1, grad_y2], axis=-1).cast(dtype)
-
-
-@jit_fuser
-def clamped_bias_swiglu(y, bias, clamp_value):
-    """Clamped SwiGLU with bias addition.
-
-    Adds bias to the input tensor, then applies clamped SwiGLU activation.
-    Gate (y1) is clamped to (-inf, clamp_value] and value (y2) to
-    [-clamp_value, clamp_value] before computing SiLU(y1) * y2.
-
-    Args:
-        y (paddle.Tensor): Input tensor, split into gate/value halves along last dim.
-        bias (paddle.Tensor): Bias tensor added to input before activation.
-        clamp_value (float): Clamp bound for numerical stability.
-
-    Returns:
-        paddle.Tensor: clamped_swiglu(y + bias), same dtype as y.
-    """
-    y = y + bias
-    return clamped_swiglu(y, clamp_value)
-
-
-@jit_fuser
-def clamped_bias_swiglu_back(g, y, bias, clamp_value):
-    """Backward pass for clamped_bias_swiglu.
-
-    Adds bias to the input tensor and delegates to clamped_swiglu_back
-    which zeros out gradients where inputs were clamped in the forward pass.
-
-    Args:
-        g (paddle.Tensor): Upstream gradient.
-        y (paddle.Tensor): Original (un-clamped) input tensor from forward pass.
-        bias (paddle.Tensor): Bias tensor that was added in the forward pass.
-        clamp_value (float): Clamp bound used in forward pass.
-
-    Returns:
-        paddle.Tensor: Gradient w.r.t. (y + bias), same dtype as y.
-    """
-    y = y + bias
-    return clamped_swiglu_back(g, y, clamp_value)
 
 
 @jit_fuser
@@ -227,21 +225,10 @@ def clamped_weighted_swiglu(y, weights, clamp_value):
 def clamped_weighted_swiglu_back(g, y, weights, clamp_value):
     """Backward pass for clamped_weighted_swiglu.
 
-    Delegates to clamped_swiglu_back for input grad and recomputes
-    clamped_swiglu(y) for weights grad. This re-executes one SwiGLU forward
-    (clip + sigmoid + silu) in the backward — a conscious trade-off:
-    correctness and code clarity take priority over the marginal FLOPs,
-    matching the reference implementation structure. The overhead is ~1
-    SwiGLU forward which is negligible compared to the main matmul.
-
-    Precision note: ``paddle.sum`` internally accumulates bf16 inputs in
-    float32, matching the CUDA kernel's ``float`` accumulation for
-    ``local_d_probs_sum`` in the same-type branch.
-
     Args:
         g (paddle.Tensor): Upstream gradient.
         y (paddle.Tensor): Original input tensor from forward pass.
-        weights (paddle.Tensor): Per-token weights, broadcastable to g's shape.
+        weights (paddle.Tensor): Per-token weights from forward pass.
         clamp_value (float): Clamp bound used in forward pass.
 
     Returns:
@@ -251,7 +238,7 @@ def clamped_weighted_swiglu_back(g, y, weights, clamp_value):
     w_dtype = weights.dtype
     input_grad = clamped_swiglu_back(g * weights, y, clamp_value)
     weights_grad = clamped_swiglu(y, clamp_value) * g.cast(w_dtype)
-    weights_grad = paddle.sum(weights_grad, axis=-1, keepdim=True)
+    weights_grad = _dsv4_sum_like_megatron_for_small_chunks(weights_grad)
     return input_grad.cast(input_dtype), weights_grad.cast(w_dtype)
 
 
@@ -260,9 +247,7 @@ class BiasSwiGLUFunction(paddle.autograd.PyLayer):
 
     @staticmethod
     @nvtx_decorator()
-    def forward(
-        ctx, input, bias, fp8_input_store, cpu_offload_input, clamp_value=None
-    ):
+    def forward(ctx, input, bias, fp8_input_store, cpu_offload_input, clamp_value=None):
         """Forward pass of biased SwiGLU activation.
 
         Args:
@@ -270,10 +255,6 @@ class BiasSwiGLUFunction(paddle.autograd.PyLayer):
             input (paddle.Tensor): Input tensor to apply SwiGLU to.
             bias (paddle.Tensor): Bias tensor to be added to input before SwiGLU.
             fp8_input_store (bool): If True, stores intermediate values in FP8 format.
-            cpu_offload_input (bool): If True, enables CPU activation offloading.
-            clamp_value (float, optional): If provided and > 0, clamps gate to
-                (-inf, clamp_value] and value to [-clamp_value, clamp_value] for
-                numerical stability.
 
         Returns:
             paddle.Tensor: Result of applying bias addition followed by SwiGLU activation.
@@ -289,7 +270,7 @@ class BiasSwiGLUFunction(paddle.autograd.PyLayer):
         ctx.fp8_input_store = fp8_input_store
         ctx.clamp_value = clamp_value
         if clamp_value is not None and clamp_value > 0:
-            return clamped_bias_swiglu(input, bias, clamp_value)
+            return clamped_swiglu(input + bias, clamp_value)
         return bias_swiglu(input, bias)
 
     @staticmethod
@@ -305,16 +286,15 @@ class BiasSwiGLUFunction(paddle.autograd.PyLayer):
             tuple: Tuple containing:
                 - Gradient with respect to the input tensor
                 - Gradient with respect to the bias tensor
+                - None for fp8_input_store parameter
         """
         input, bias = ctx.saved_tensor()
         input = input.to(ctx.ori_input_dtype) if ctx.fp8_input_store else input
         if ctx.clamp_value is not None and ctx.clamp_value > 0:
-            tmp = clamped_bias_swiglu_back(
-                grad_output, input, bias, ctx.clamp_value
-            )
+            tmp = clamped_swiglu_back(grad_output, input + bias, ctx.clamp_value)
         else:
             tmp = bias_swiglu_back(grad_output, input, bias)
-        return tmp, tmp
+        return tmp, tmp, None, None, None
 
 
 class SwiGLUFunction(paddle.autograd.PyLayer):
@@ -322,19 +302,13 @@ class SwiGLUFunction(paddle.autograd.PyLayer):
 
     @staticmethod
     @nvtx_decorator()
-    def forward(
-        ctx, input, fp8_input_store, cpu_offload_input, clamp_value=None
-    ):
+    def forward(ctx, input, fp8_input_store, cpu_offload_input, clamp_value=None):
         """Forward pass of SwiGLU activation.
 
         Args:
             ctx: Autograd context object for saving tensors for backward pass.
             input (paddle.Tensor): Input tensor to apply SwiGLU to.
             fp8_input_store (bool): If True, stores intermediate values in FP8 format.
-            cpu_offload_input (bool): If True, enables CPU activation offloading.
-            clamp_value (float, optional): If provided and > 0, clamps gate to
-                (-inf, clamp_value] and value to [-clamp_value, clamp_value] for
-                numerical stability.
 
         Returns:
             paddle.Tensor: Result of applying SwiGLU activation.
@@ -362,7 +336,9 @@ class SwiGLUFunction(paddle.autograd.PyLayer):
             grad_output (paddle.Tensor): Gradient of the loss with respect to the output.
 
         Returns:
-            paddle.Tensor: Gradient with respect to the input tensor.
+            tuple: Tuple containing:
+                - Gradient with respect to the input tensor
+                - None for fp8_input_store parameter
         """
         input = ctx.saved_tensor()[0]
         input = input.to(ctx.ori_input_dtype) if ctx.fp8_input_store else input
@@ -370,6 +346,7 @@ class SwiGLUFunction(paddle.autograd.PyLayer):
             tmp = clamped_swiglu_back(grad_output, input, ctx.clamp_value)
         else:
             tmp = swiglu_back(grad_output, input)
+        # return tmp, None, None
         return tmp
 
 
@@ -384,19 +361,18 @@ class WeightedSwiGLUFunction(paddle.autograd.PyLayer):
         ctx.ori_input_dtype = input.dtype
         ctx.fp8_input_store = fp8_input_store
         ctx.clamp_value = clamp_value
-        if clamp_value is not None and clamp_value > 0:
-            res = clamped_weighted_swiglu(input, weights, clamp_value)
-        else:
-            res = weighted_swiglu(input, weights)
-        return res
+        if clamp_value is not None:
+            return clamped_weighted_swiglu(input, weights, clamp_value)
+        return weighted_swiglu(input, weights)
 
     @staticmethod
     def backward(ctx, grad_output):
         input, weights = ctx.saved_tensor()
         input = input.to(ctx.ori_input_dtype) if ctx.fp8_input_store else input
-        if ctx.clamp_value is not None and ctx.clamp_value > 0:
+        clamp_value = ctx.clamp_value
+        if clamp_value is not None:
             tmp, wgrad = clamped_weighted_swiglu_back(
-                grad_output, input, weights, ctx.clamp_value
+                grad_output, input, weights, clamp_value
             )
         else:
             tmp, wgrad = weighted_swiglu_back(grad_output, input, weights)
@@ -404,11 +380,7 @@ class WeightedSwiGLUFunction(paddle.autograd.PyLayer):
 
 
 def bias_swiglu_impl(
-    input,
-    bias,
-    fp8_input_store=False,
-    cpu_offload_input=False,
-    clamp_value=None,
+    input, bias, fp8_input_store=False, cpu_offload_input=False, clamp_value=None
 ):
     """Implementation of biased SwiGLU that handles different input shapes.
 
@@ -421,11 +393,6 @@ def bias_swiglu_impl(
             uses the bias-free SwiGLU variant.
         fp8_input_store (bool, optional): Whether to store intermediate values in FP8 format.
             Defaults to False.
-        cpu_offload_input (bool, optional): If True, enables CPU activation offloading.
-            Defaults to False.
-        clamp_value (float, optional): If provided and > 0, clamps gate to
-            (-inf, clamp_value] and value to [-clamp_value, clamp_value] for
-            numerical stability.
 
     Returns:
         paddle.Tensor: Result of biased SwiGLU activation.
@@ -441,9 +408,7 @@ def bias_swiglu_impl(
             input, bias, fp8_input_store, cpu_offload_input, clamp_value
         )
     else:
-        output = SwiGLUFunction.apply(
-            input, fp8_input_store, cpu_offload_input, clamp_value
-        )
+        output = SwiGLUFunction.apply(input, fp8_input_store, cpu_offload_input, clamp_value)
 
     return (
         output
@@ -463,15 +428,11 @@ def weighted_bias_swiglu_impl(
         bias: Optional bias (not supported for weighted variant).
         weights: Per-token weights, shape [..., 1].
         fp8_input_store (bool): Whether to store intermediate values in FP8 format.
-        clamp_value (float, optional): If provided and > 0, clamps gate to
-            (-inf, clamp_value] and value to [-clamp_value, clamp_value] for
-            numerical stability.
+        clamp_value (float, optional): If provided, use ClampedSwiGLU instead of standard SwiGLU.
     """
     ori_shape = input.shape
     assert len(ori_shape) in [2, 3]
     input = input.view(-1, ori_shape[-1])
-    if len(ori_shape) == 3:
-        weights = weights.view(-1, weights.shape[-1])
     if bias is not None:
         raise NotImplementedError(
             "Bias is not supported for weighted swiglu fusion"

--- a/src/paddlefleet/models/common/language_loss/language_loss.py
+++ b/src/paddlefleet/models/common/language_loss/language_loss.py
@@ -51,96 +51,6 @@ def _dsv4_tensor_md5(tensor: Tensor, dtype: str = "float32") -> str:
     return hashlib.md5(tensor_for_md5.numpy().tobytes()).hexdigest()
 
 
-_DSV4_LOSS_GRAD_COUNTS = {}
-
-
-def _dsv4_loss_grad_rank_enabled(rank: int) -> bool:
-    ranks = os.environ.get("DSV4_LOSS_GRAD_RANKS", "0")
-    if ranks.strip().lower() == "all":
-        return True
-    return str(rank) in {item.strip() for item in ranks.split(",") if item.strip()}
-
-
-def _dsv4_register_loss_grad_hook(name: str, tensor: Tensor):
-    if os.environ.get("DSV4_LOG_LOSS_GRADS", "0") != "1":
-        return tensor
-    if not isinstance(tensor, paddle.Tensor) or tensor.stop_gradient:
-        return tensor
-    rank = paddle.distributed.get_rank()
-    if not _dsv4_loss_grad_rank_enabled(rank):
-        return tensor
-    occurrence = _DSV4_LOSS_GRAD_COUNTS.get(name, 0)
-    _DSV4_LOSS_GRAD_COUNTS[name] = occurrence + 1
-    max_numel = int(os.environ.get("DSV4_LOSS_GRAD_MD5_MAX_NUMEL", "600000000"))
-
-    def _hook(grad):
-        grad_fp32 = grad.detach().cast("float32")
-        norm = paddle.linalg.norm(grad_fp32).item()
-        md5 = _dsv4_tensor_md5(grad_fp32) if grad_fp32.numel() <= max_numel else "SKIP"
-        print(
-            f"[DSV4_LOSS_GRAD] framework=fleet rank={rank} name={name} "
-            f"occurrence={occurrence} shape={list(grad.shape)} dtype={grad.dtype} "
-            f"numel={grad.numel()} norm={norm:.20f} md5_float32={md5}",
-            flush=True,
-        )
-        return grad
-
-    tensor.register_hook(_hook)
-    return tensor
-
-
-def _dsv4_register_loss_logits_grad_hook(name: str, logits: Tensor, labels: Tensor):
-    if os.environ.get("DSV4_LOG_LOSS_GRADS", "0") != "1":
-        return logits
-    if os.environ.get("DSV4_LOG_LOSS_LOGITS_GRADS", "1") == "0":
-        return logits
-    if not isinstance(logits, paddle.Tensor) or logits.stop_gradient:
-        return logits
-    rank = paddle.distributed.get_rank()
-    if not _dsv4_loss_grad_rank_enabled(rank):
-        return logits
-    occurrence = _DSV4_LOSS_GRAD_COUNTS.get(name, 0)
-    _DSV4_LOSS_GRAD_COUNTS[name] = occurrence + 1
-    max_numel = int(os.environ.get("DSV4_LOSS_GRAD_MD5_MAX_NUMEL", "600000000"))
-    valid_mask = labels != -100
-
-    def _hook(grad):
-        grad_fp32 = grad.detach().cast("float32").cpu()
-        norm = paddle.linalg.norm(grad_fp32).item()
-        md5 = _dsv4_tensor_md5(grad_fp32) if grad_fp32.numel() <= max_numel else "SKIP"
-        valid_mask_cpu = valid_mask.cpu()
-        invalid_mask_cpu = paddle.logical_not(valid_mask_cpu)
-        flat_grad = grad_fp32.reshape([-1, grad_fp32.shape[-1]])
-        valid = flat_grad[valid_mask_cpu.reshape([-1])]
-        invalid = flat_grad[invalid_mask_cpu.reshape([-1])]
-        valid_norm = paddle.linalg.norm(valid).item() if valid.numel() else 0.0
-        invalid_norm = paddle.linalg.norm(invalid).item() if invalid.numel() else 0.0
-        valid_md5 = _dsv4_tensor_md5(valid) if valid.numel() <= max_numel else "SKIP"
-        invalid_md5 = _dsv4_tensor_md5(invalid) if invalid.numel() <= max_numel else "EMPTY"
-        prefix = grad_fp32[:, :-1, :].reshape([-1, grad_fp32.shape[-1]])
-        last = grad_fp32[:, -1:, :].reshape([-1, grad_fp32.shape[-1]])
-        prefix_norm = paddle.linalg.norm(prefix).item() if prefix.numel() else 0.0
-        last_norm = paddle.linalg.norm(last).item() if last.numel() else 0.0
-        prefix_md5 = _dsv4_tensor_md5(prefix) if prefix.numel() <= max_numel else "SKIP"
-        last_md5 = _dsv4_tensor_md5(last) if last.numel() <= max_numel else "EMPTY"
-        print(
-            f"[DSV4_LOSS_GRAD] framework=fleet rank={rank} name={name} "
-            f"occurrence={occurrence} shape={list(grad.shape)} dtype={grad.dtype} "
-            f"numel={grad.numel()} norm={norm:.20f} md5_float32={md5} "
-            f"valid_numel={valid.numel()} valid_norm={valid_norm:.20f} "
-            f"valid_md5_float32={valid_md5} invalid_numel={invalid.numel()} "
-            f"invalid_norm={invalid_norm:.20f} invalid_md5_float32={invalid_md5} "
-            f"prefix_no_last_numel={prefix.numel()} prefix_no_last_norm={prefix_norm:.20f} "
-            f"prefix_no_last_md5_float32={prefix_md5} last_token_numel={last.numel()} "
-            f"last_token_norm={last_norm:.20f} last_token_md5_float32={last_md5}",
-            flush=True,
-        )
-        return grad
-
-    logits.register_hook(_hook)
-    return logits
-
-
 def _dsv4_print_scalar_loss_md5(prefix: str, name: str, loss: Tensor) -> None:
     if not _dsv4_loss_md5_enabled():
         return
@@ -361,35 +271,6 @@ class LanguageLoss(FleetLayer):
             return loss
 
         seq_len = logits.shape[1]
-        logits = _dsv4_register_loss_logits_grad_hook(
-            "loss_input_logits", logits, labels
-        )
-
-        # Loss-path MD5 probe: logits and labels before cross-entropy
-        import os
-
-        if (
-            os.environ.get("LOG_LAYER_MD5", "0") == "1"
-            or os.environ.get("LOG_LOSS_MD5", "0") == "1"
-        ):
-            import hashlib
-
-            rank = paddle.distributed.get_rank()
-            lg_md5 = hashlib.md5(
-                logits.cast("float32").numpy().tobytes()
-            ).hexdigest()
-            lb_md5 = hashlib.md5(
-                labels.cast("int64").numpy().tobytes()
-            ).hexdigest()
-            print(
-                f"[LOSS_PATH_MD5] rank={rank} loss_input_logits shape={list(logits.shape)} md5={lg_md5}",
-                flush=True,
-            )
-            print(
-                f"[LOSS_PATH_MD5] rank={rank} loss_input_labels shape={list(labels.shape)} md5={lb_md5}",
-                flush=True,
-            )
-
         if self.use_subbatch and seq_len > self.loss_subbatch_sequence_length:
 
             def _cast_loss_func(logits, labels):
@@ -409,61 +290,11 @@ class LanguageLoss(FleetLayer):
         if get_context_parallel_world_size() > 1:
             loss = ContextParallelGatherOp.apply(loss, axis=1)
             labels = ContextParallelGatherOp.apply(labels, axis=1)
-        loss = _dsv4_register_loss_grad_hook("per_token_loss", loss)
-
         lossmask = labels != self.ignored_index
         if (~lossmask).all():
             loss = paddle.mean(loss) * 0.0
         else:
             lossmask = lossmask.reshape([-1]).cast(paddle.float32)
-
-            # Loss-path MD5 probe: per-token loss and lossmask
-            if (
-                os.environ.get("LOG_LAYER_MD5", "0") == "1"
-                or os.environ.get("LOG_LOSS_MD5", "0") == "1"
-            ):
-                import hashlib
-
-                rank = paddle.distributed.get_rank()
-                pt_md5 = hashlib.md5(
-                    loss.cast("float32").reshape([-1]).numpy().tobytes()
-                ).hexdigest()
-                lm_md5 = hashlib.md5(lossmask.numpy().tobytes()).hexdigest()
-                valid_count = lossmask.sum().item()
-                loss_sum_val = paddle.sum(
-                    loss.cast("float32").reshape([-1]) * lossmask
-                ).item()
-                print(
-                    f"[LOSS_PATH_MD5] rank={rank} per_token_loss md5={pt_md5}",
-                    flush=True,
-                )
-                print(
-                    f"[LOSS_PATH_MD5] rank={rank} lossmask md5={lm_md5} valid_tokens={valid_count}",
-                    flush=True,
-                )
-                print(
-                    f"[LOSS_PATH_MD5] rank={rank} loss_sum={loss_sum_val} final_loss={loss_sum_val / valid_count}",
-                    flush=True,
-                )
-                # Also compute line-wise loss (matches EC's _line_wise_loss) for exact comparison
-                if self.config.gpt_model_use_experimental_version:
-                    _probe_loss_2d = loss.cast(
-                        paddle.float32
-                    ) * lossmask.reshape(labels.shape)
-                    _probe_lm_2d = lossmask.reshape(labels.shape)
-                    _probe_tc = _probe_lm_2d.sum(-1)
-                    _probe_inv = (_probe_tc == 0).astype(paddle.float32)
-                    _probe_lpl = _probe_loss_2d.sum(-1) / (
-                        _probe_tc + 1e-6 * _probe_inv
-                    )
-                    _probe_lpl = _probe_lpl * (1 - _probe_inv)
-                    _probe_lw = _probe_lpl.sum() / (
-                        (1 - _probe_inv).sum() + 1e-6
-                    )
-                    print(
-                        f"[LOSS_PATH_MD5] rank={rank} line_wise_loss={_probe_lw.item():.20f}",
-                        flush=True,
-                    )
 
             if _dsv4_loss_md5_enabled():
                 rank = paddle.distributed.get_rank()

--- a/src/paddlefleet/models/common/language_loss/language_loss.py
+++ b/src/paddlefleet/models/common/language_loss/language_loss.py
@@ -14,7 +14,6 @@
 
 
 import functools
-import hashlib
 import os
 
 import numpy as np
@@ -37,41 +36,119 @@ from paddlefleet.parallel_state import (
     get_tensor_model_parallel_world_size,
 )
 from paddlefleet.process_groups_config import ProcessGroupCollection
-from paddlefleet.training.global_vars import get_global_training_logs
 from paddlefleet.transformer.layer import FleetLayer
 from paddlefleet.transformer.transformer_config import TransformerConfig
 
 
-def _loss_md5_enabled() -> bool:
+def _dsv4_loss_md5_enabled() -> bool:
     return os.environ.get("LOG_LOSS_MD5", "0") == "1"
 
 
-def _use_accuracy_compatible_kernel() -> bool:
-    """Switch for Megatron-aligned (accuracy-compatible) numeric paths.
+def _dsv4_tensor_md5(tensor: Tensor, dtype: str = "float32") -> str:
+    import hashlib
 
-    Controlled by the ``FLAGS_use_accuracy_compatible_kernel`` env variable.
-    """
-    return os.environ.get("FLAGS_use_accuracy_compatible_kernel", "0") == "1"
-
-
-def _tensor_md5(tensor: Tensor, dtype: str = "float32") -> str:
-    """Calculate MD5 hash of a tensor, **for debugging only**.
-
-    Note: internally calls .numpy() which triggers GPU→CPU synchronization
-    and blocks the async training pipeline. Do NOT use in the forward pass.
-    """
     tensor_for_md5 = tensor.detach().cast(dtype)
     return hashlib.md5(tensor_for_md5.numpy().tobytes()).hexdigest()
 
 
-def _print_scalar_loss_md5(prefix: str, name: str, loss: Tensor) -> None:
-    if not _loss_md5_enabled():
+_DSV4_LOSS_GRAD_COUNTS = {}
+
+
+def _dsv4_loss_grad_rank_enabled(rank: int) -> bool:
+    ranks = os.environ.get("DSV4_LOSS_GRAD_RANKS", "0")
+    if ranks.strip().lower() == "all":
+        return True
+    return str(rank) in {item.strip() for item in ranks.split(",") if item.strip()}
+
+
+def _dsv4_register_loss_grad_hook(name: str, tensor: Tensor):
+    if os.environ.get("DSV4_LOG_LOSS_GRADS", "0") != "1":
+        return tensor
+    if not isinstance(tensor, paddle.Tensor) or tensor.stop_gradient:
+        return tensor
+    rank = paddle.distributed.get_rank()
+    if not _dsv4_loss_grad_rank_enabled(rank):
+        return tensor
+    occurrence = _DSV4_LOSS_GRAD_COUNTS.get(name, 0)
+    _DSV4_LOSS_GRAD_COUNTS[name] = occurrence + 1
+    max_numel = int(os.environ.get("DSV4_LOSS_GRAD_MD5_MAX_NUMEL", "600000000"))
+
+    def _hook(grad):
+        grad_fp32 = grad.detach().cast("float32")
+        norm = paddle.linalg.norm(grad_fp32).item()
+        md5 = _dsv4_tensor_md5(grad_fp32) if grad_fp32.numel() <= max_numel else "SKIP"
+        print(
+            f"[DSV4_LOSS_GRAD] framework=fleet rank={rank} name={name} "
+            f"occurrence={occurrence} shape={list(grad.shape)} dtype={grad.dtype} "
+            f"numel={grad.numel()} norm={norm:.20f} md5_float32={md5}",
+            flush=True,
+        )
+        return grad
+
+    tensor.register_hook(_hook)
+    return tensor
+
+
+def _dsv4_register_loss_logits_grad_hook(name: str, logits: Tensor, labels: Tensor):
+    if os.environ.get("DSV4_LOG_LOSS_GRADS", "0") != "1":
+        return logits
+    if os.environ.get("DSV4_LOG_LOSS_LOGITS_GRADS", "1") == "0":
+        return logits
+    if not isinstance(logits, paddle.Tensor) or logits.stop_gradient:
+        return logits
+    rank = paddle.distributed.get_rank()
+    if not _dsv4_loss_grad_rank_enabled(rank):
+        return logits
+    occurrence = _DSV4_LOSS_GRAD_COUNTS.get(name, 0)
+    _DSV4_LOSS_GRAD_COUNTS[name] = occurrence + 1
+    max_numel = int(os.environ.get("DSV4_LOSS_GRAD_MD5_MAX_NUMEL", "600000000"))
+    valid_mask = labels != -100
+
+    def _hook(grad):
+        grad_fp32 = grad.detach().cast("float32").cpu()
+        norm = paddle.linalg.norm(grad_fp32).item()
+        md5 = _dsv4_tensor_md5(grad_fp32) if grad_fp32.numel() <= max_numel else "SKIP"
+        valid_mask_cpu = valid_mask.cpu()
+        invalid_mask_cpu = paddle.logical_not(valid_mask_cpu)
+        flat_grad = grad_fp32.reshape([-1, grad_fp32.shape[-1]])
+        valid = flat_grad[valid_mask_cpu.reshape([-1])]
+        invalid = flat_grad[invalid_mask_cpu.reshape([-1])]
+        valid_norm = paddle.linalg.norm(valid).item() if valid.numel() else 0.0
+        invalid_norm = paddle.linalg.norm(invalid).item() if invalid.numel() else 0.0
+        valid_md5 = _dsv4_tensor_md5(valid) if valid.numel() <= max_numel else "SKIP"
+        invalid_md5 = _dsv4_tensor_md5(invalid) if invalid.numel() <= max_numel else "EMPTY"
+        prefix = grad_fp32[:, :-1, :].reshape([-1, grad_fp32.shape[-1]])
+        last = grad_fp32[:, -1:, :].reshape([-1, grad_fp32.shape[-1]])
+        prefix_norm = paddle.linalg.norm(prefix).item() if prefix.numel() else 0.0
+        last_norm = paddle.linalg.norm(last).item() if last.numel() else 0.0
+        prefix_md5 = _dsv4_tensor_md5(prefix) if prefix.numel() <= max_numel else "SKIP"
+        last_md5 = _dsv4_tensor_md5(last) if last.numel() <= max_numel else "EMPTY"
+        print(
+            f"[DSV4_LOSS_GRAD] framework=fleet rank={rank} name={name} "
+            f"occurrence={occurrence} shape={list(grad.shape)} dtype={grad.dtype} "
+            f"numel={grad.numel()} norm={norm:.20f} md5_float32={md5} "
+            f"valid_numel={valid.numel()} valid_norm={valid_norm:.20f} "
+            f"valid_md5_float32={valid_md5} invalid_numel={invalid.numel()} "
+            f"invalid_norm={invalid_norm:.20f} invalid_md5_float32={invalid_md5} "
+            f"prefix_no_last_numel={prefix.numel()} prefix_no_last_norm={prefix_norm:.20f} "
+            f"prefix_no_last_md5_float32={prefix_md5} last_token_numel={last.numel()} "
+            f"last_token_norm={last_norm:.20f} last_token_md5_float32={last_md5}",
+            flush=True,
+        )
+        return grad
+
+    logits.register_hook(_hook)
+    return logits
+
+
+def _dsv4_print_scalar_loss_md5(prefix: str, name: str, loss: Tensor) -> None:
+    if not _dsv4_loss_md5_enabled():
         return
     rank = paddle.distributed.get_rank()
     loss_tensor = loss.detach().cast("float32").reshape([1])
     print(
         f"[{prefix}] rank={rank} {name}={loss_tensor.item():.20f} "
-        f"{name}_md5={_tensor_md5(loss_tensor)}",
+        f"{name}_md5={_dsv4_tensor_md5(loss_tensor)}",
         flush=True,
     )
 
@@ -284,6 +361,9 @@ class LanguageLoss(FleetLayer):
             return loss
 
         seq_len = logits.shape[1]
+        logits = _dsv4_register_loss_logits_grad_hook(
+            "loss_input_logits", logits, labels
+        )
 
         # Loss-path MD5 probe: logits and labels before cross-entropy
         import os
@@ -329,6 +409,7 @@ class LanguageLoss(FleetLayer):
         if get_context_parallel_world_size() > 1:
             loss = ContextParallelGatherOp.apply(loss, axis=1)
             labels = ContextParallelGatherOp.apply(labels, axis=1)
+        loss = _dsv4_register_loss_grad_hook("per_token_loss", loss)
 
         lossmask = labels != self.ignored_index
         if (~lossmask).all():
@@ -383,6 +464,29 @@ class LanguageLoss(FleetLayer):
                         f"[LOSS_PATH_MD5] rank={rank} line_wise_loss={_probe_lw.item():.20f}",
                         flush=True,
                     )
+
+            if _dsv4_loss_md5_enabled():
+                rank = paddle.distributed.get_rank()
+                loss_float = loss.cast("float32").reshape([-1])
+                valid_count = lossmask.sum().item()
+                loss_sum_tensor = paddle.sum(
+                    loss_float * lossmask
+                ).detach().cast("float32").reshape([1])
+                valid_count_tensor = lossmask.sum().detach().cast("float32").reshape([1])
+                final_loss_tensor = (
+                    loss_sum_tensor / valid_count_tensor
+                    if valid_count
+                    else paddle.full([1], float("nan"), dtype="float32")
+                )
+                loss_sum_val = loss_sum_tensor.item()
+                final_loss_val = final_loss_tensor.item()
+                print(
+                    f"[LOSS_PATH_MD5] rank={rank} loss_sum={loss_sum_val:.20f} "
+                    f"loss_sum_md5={_dsv4_tensor_md5(loss_sum_tensor)} "
+                    f"final_loss={final_loss_val:.20f} "
+                    f"final_loss_md5={_dsv4_tensor_md5(final_loss_tensor)}",
+                    flush=True,
+                )
 
             # EC-compat: line-wise loss (per-sample mean then average across samples)
             # EC's ErniemmPretrainingCriterion recomputes loss as line-wise when task_id
@@ -463,16 +567,9 @@ class LanguageLoss(FleetLayer):
                                 labels_cur_depth, axis=1
                             )
 
-                        if self.config.fused_linear_ce_loss_chunk > 0:
-                            loss_matrix_cur_depth = self._forward(
-                                logits_cur_depth,
-                                labels_cur_depth,
-                            )
-                        else:
-                            loss_matrix_cur_depth = self.loss_func(
-                                logits_cur_depth.cast("float32"),
-                                labels_cur_depth,
-                            )
+                        loss_matrix_cur_depth = self.loss_func(
+                            logits_cur_depth.cast("float32"), labels_cur_depth
+                        )
 
                         if get_context_parallel_world_size() > 1:
                             # In EB data flow and CP size > 1, loss and labels need to be gathered back.
@@ -583,66 +680,37 @@ class LanguageLoss(FleetLayer):
                         ploss = ploss / xishu
                         mtp_loss.append(ploss)
 
-            # Store detached MTP loss tensors into class-level tracker and global_training_logs.
+            # Store detached MTP loss tensors into class-level tracker.
             # Use .detach() instead of .item() to avoid GPU synchronization on every
             # micro-batch. The trainer will call .item() only at logging steps.
             for i, loss_val in enumerate(mtp_loss):
                 LanguageLoss.mtp_loss_tracker[f"mtp_{i + 1}_loss"] = (
                     loss_val.detach()
                 )
-                _print_scalar_loss_md5(
+                _dsv4_print_scalar_loss_md5(
                     "MTP_LOSS_PATH_MD5",
                     f"mtp{i + 1}.final_loss",
                     loss_val,
                 )
 
-            logs = get_global_training_logs()
-            if logs is not None and hasattr(logs, "update"):
-                for i, loss_val in enumerate(mtp_loss):
-                    logs.update(**{f"mtp_{i + 1}_loss": loss_val.detach()})
-
             def add_loss(main_loss, loss):
-                if _use_accuracy_compatible_kernel():
-                    # Megatron-aligned: MTP loss gradient flows but loss scalar unchanged.
-                    # This matches Megatron's behavior where MTP contributes to training
-                    # gradients without affecting the reported loss value.
-                    if self.config.add_mtp_loss:
-                        return main_loss + loss - loss.detach()
-                    else:
-                        return main_loss
+                if self.config.add_mtp_loss:
+                    return main_loss + loss - loss.detach()
                 else:
-                    # Original behavior
-                    if self.config.add_mtp_loss:
-                        return main_loss + loss
-                    else:
-                        return main_loss + loss - loss.detach()
+                    return main_loss
 
             if self.config.gpt_model_use_experimental_version:
                 # Align with EB: accumulate inside loop to match float32
                 # arithmetic order: loss += scaling * loss_i / N
                 loss = lm_loss
-                if _use_accuracy_compatible_kernel():
-                    # Megatron-aligned: only add MTP loss when add_mtp_loss=True.
-                    # Use add_loss() to keep single maintenance point for compat
-                    # behavior (loss + val - val.detach() for gradient-only flow).
-                    if self.config.add_mtp_loss:
-                        num_mtp = len(mtp_loss)
-                        for mtp_l in mtp_loss:
-                            mtp_val = (
-                                self.config.mtp_loss_scaling_factor
-                                * mtp_l
-                                / num_mtp
-                            )
-                            loss = add_loss(loss, mtp_val)
-                else:
-                    # Original behavior: always use add_loss
+                if self.config.add_mtp_loss:
                     num_mtp = len(mtp_loss)
                     for mtp_l in mtp_loss:
-                        loss = add_loss(
-                            loss,
-                            self.config.mtp_loss_scaling_factor
+                        loss = (
+                            loss
+                            + self.config.mtp_loss_scaling_factor
                             * mtp_l
-                            / num_mtp,
+                            / num_mtp
                         )
             else:
                 loss = add_loss(
@@ -693,39 +761,24 @@ class MainLanguageLoss(LanguageLoss):
         else:
             lm_loss = self._forward(logits, lm_labels)
 
-        # Store detached MTP loss tensors into class-level tracker and global_training_logs.
+        # Store detached MTP loss tensors into class-level tracker.
         # Use .detach() instead of .item() to avoid GPU synchronization on every
         # micro-batch. The trainer will call .item() only at logging steps.
         for i, loss_val in enumerate(mtp_loss):
             MainLanguageLoss.mtp_loss_tracker[f"mtp_{i + 1}_loss"] = (
                 loss_val.detach()
             )
-            _print_scalar_loss_md5(
+            _dsv4_print_scalar_loss_md5(
                 "MTP_LOSS_PATH_MD5",
                 f"mtp{i + 1}.final_loss",
                 loss_val,
             )
 
-        # Also write to global_training_logs to read
-        logs = get_global_training_logs()
-        if logs is not None and hasattr(logs, "update"):
-            for i, loss_val in enumerate(mtp_loss):
-                logs.update(**{f"mtp_{i + 1}_loss": loss_val.detach()})
-
         def add_loss(main_loss, loss):
-            if _use_accuracy_compatible_kernel():
-                # Megatron-aligned: MTP loss gradient flows but loss scalar unchanged.
-                # This matches Megatron's behavior
-                if self.config.add_mtp_loss:
-                    return main_loss + loss - loss.detach()
-                else:
-                    return main_loss
+            if self.config.add_mtp_loss:
+                return main_loss + loss - loss.detach()
             else:
-                # Original behavior
-                if self.config.add_mtp_loss:
-                    return main_loss + loss
-                else:
-                    return main_loss + loss - loss.detach()
+                return main_loss
 
         loss = add_loss(
             lm_loss,

--- a/src/paddlefleet/models/gpt/gpt_embedding.py
+++ b/src/paddlefleet/models/gpt/gpt_embedding.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from __future__ import annotations
 
-import warnings
+import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 
@@ -65,7 +65,6 @@ class GPTEmbedding(FleetLayer):
         ] = "learned_absolute",
         rotary_percent: float = 1.0,
         rotary_base: int = 10000,
-        swa_rotary_base: int = 10000,
         rope_scaling: bool = False,
         mrope_section: list[int] | None = None,
     ):
@@ -101,7 +100,6 @@ class GPTEmbedding(FleetLayer):
             )
 
         self.rotary_pos_emb = None
-        self.swa_rotary_pos_emb = None
         self.mrope_section = mrope_section
         self.position_embedding_type = position_embedding_type
         if sublayers_spec.rope_embedding is not None:
@@ -113,22 +111,6 @@ class GPTEmbedding(FleetLayer):
                 rotary_base=rotary_base,
                 rope_scaling=rope_scaling,
             )
-
-            if config.sliding_window is not None:
-                if config.window_attn_skip_freq is None:
-                    warnings.warn(
-                        "sliding_window is set but window_attn_skip_freq is None. "
-                        "is_layer_window_attention() will return True for all layers, "
-                        "meaning all layers will use sliding window attention (SWA)."
-                    )
-                self.swa_rotary_pos_emb = build_spec_layer(
-                    sublayers_spec.rope_embedding,
-                    head_dim=config.swa_head_dim,
-                    rotary_percent=rotary_percent,
-                    rotary_interleaved=config.rotary_interleaved,
-                    rotary_base=swa_rotary_base,
-                    rope_scaling=rope_scaling,
-                )
 
     @property
     def embedding_weight(self):
@@ -205,122 +187,128 @@ class GPTEmbedding(FleetLayer):
                 assert not self.multimodal_embedding, (
                     "MTP not support mm for now."
                 )
+                num_nextn_predict_layers = self.config.num_nextn_predict_layers
                 # Split input_ids for MoE mask: main part for backbone, per-depth for MTP
                 if input_ids_for_moe_mask is not None:
                     # Main backbone input_ids: [B, max_seq]
                     # Use .contiguous() because slices are non-contiguous and PP P2P send requires contiguous tensors.
                     input_ids_for_moe_mask = input_ids[
-                        :, : -self.config.num_nextn_predict_layers
+                        :, :-num_nextn_predict_layers
                     ].contiguous()
                     # Construct per-depth MTP input_ids: for depth k, use
                     # input_ids[:, (k+1):(k+1+max_seq)] matching embedding shift
-                    seq_length = (
-                        input_ids.shape[1]
-                        - self.config.num_nextn_predict_layers
-                    )
+                    seq_length = input_ids.shape[1] - num_nextn_predict_layers
                     mtp_ids_list = []
-                    for depth in range(self.config.num_nextn_predict_layers):
+                    for depth in range(num_nextn_predict_layers):
+                        pad_ids = paddle.zeros(
+                            [input_ids.shape[0], depth + 1],
+                            dtype=input_ids.dtype,
+                        )
                         mtp_ids_list.append(
-                            input_ids[:, (depth + 1) : (depth + 1 + seq_length)]
+                            paddle.concat(
+                                [input_ids[:, depth + 1 : seq_length], pad_ids],
+                                axis=1,
+                            )
                         )
                     # [B, num_mtp, max_seq] - paddle.stack creates a new contiguous tensor
                     mtp_input_ids_for_moe_mask = paddle.stack(
                         mtp_ids_list, axis=1
                     )
+                inputs_embeds_extra = decoder_input[
+                    :, -self.config.num_nextn_predict_layers :, :
+                ]  # [B, S, H]
+                inputs_embeds = decoder_input[
+                    :, : -self.config.num_nextn_predict_layers, :
+                ]
+                batch_size, seq_length, hidden_size = inputs_embeds.shape
 
-                if self.config.enable_mtp_magic_send:
-                    # Magic send: only truncate, skip shifted embedding pre-computation.
-                    # input_ids will be broadcast to the last stage for re-embedding.
-                    decoder_input = decoder_input[
-                        :, : -self.config.num_nextn_predict_layers, :
-                    ]
+                if (
+                    get_context_parallel_world_size() > 1
+                    and self.config.experimental_dataflow
+                ):
+                    # In EB data flow, main input embed apply CP scatter here
+                    inputs_embeds = ContextParallelScatterOp.apply(
+                        inputs_embeds, axis=1
+                    )
 
-                    # Apply the same SP scatter as the non-magic-send path to ensure
-                    # bit-for-bit identical main embedding output.
+                if self.sequence_parallel:
+                    inputs_embeds = inputs_embeds.reshape(
+                        [-1, inputs_embeds.shape[-1]]
+                    )
+                    inputs_embeds = ScatterOp.apply(inputs_embeds)
+                    inputs_embeds = (
+                        inputs_embeds.reshape([batch_size, -1, hidden_size])
+                        .permute(1, 0, 2)
+                        .contiguous()
+                    )  # change to [S, B, H]
+                mtp_emb_res = [inputs_embeds]
+                for depth in range(self.config.num_nextn_predict_layers):
+                    pad_input_ids = paddle.zeros(
+                        [batch_size, depth + 1], dtype=input_ids.dtype
+                    )
+                    pad_position_ids = None
+                    if not self.multimodal_embedding and position_ids is not None:
+                        pad_position_ids = paddle.zeros(
+                            [batch_size, depth + 1], dtype=position_ids.dtype
+                        )
+                    pad_embeds = self.embedding(
+                        input_ids=pad_input_ids,
+                        position_ids=pad_position_ids,
+                    )
                     if (
-                        get_context_parallel_world_size() > 1
-                        and self.config.experimental_dataflow
+                        paddle.core._has_grad()
+                        and os.getenv("DSV4_FLEET_MTP_SEPARATE_EMBEDDING", "0")
+                        == "1"
                     ):
-                        decoder_input = ContextParallelScatterOp.apply(
-                            decoder_input, axis=1
+                        shifted_input_ids = input_ids[
+                            :, (depth + 1) : seq_length
+                        ]
+                        shifted_position_ids = None
+                        if (
+                            not self.multimodal_embedding
+                            and position_ids is not None
+                        ):
+                            shifted_position_ids = position_ids[
+                                :, (depth + 1) : seq_length
+                            ]
+                        shifted_embeds = self.embedding(
+                            input_ids=shifted_input_ids,
+                            position_ids=shifted_position_ids,
                         )
-
-                    if self.sequence_parallel:
-                        batch_size, seq_length, hidden_size = (
-                            decoder_input.shape
+                        inputs_embeds_mtp = paddle.concat(
+                            [shifted_embeds, pad_embeds], axis=1
                         )
-                        decoder_input = decoder_input.reshape(
-                            [-1, decoder_input.shape[-1]]
-                        )
-                        decoder_input = ScatterOp.apply(decoder_input)
-                        decoder_input = (
-                            decoder_input.reshape([batch_size, -1, hidden_size])
-                            .permute(1, 0, 2)
-                            .contiguous()
-                        )  # change to [S/tp, B, H]
-                else:
-                    inputs_embeds_extra = decoder_input[
-                        :, -self.config.num_nextn_predict_layers :, :
-                    ]  # [B, S, H]
-                    inputs_embeds = decoder_input[
-                        :, : -self.config.num_nextn_predict_layers, :
-                    ]
-                    inputs_embeds_ori = inputs_embeds
-                    batch_size, seq_length, hidden_size = inputs_embeds.shape
-
-                    if (
-                        get_context_parallel_world_size() > 1
-                        and self.config.experimental_dataflow
-                    ):
-                        # In EB data flow, main input embed apply CP scatter here
-                        inputs_embeds = ContextParallelScatterOp.apply(
-                            inputs_embeds, axis=1
-                        )
-
-                    if self.sequence_parallel:
-                        inputs_embeds = inputs_embeds.reshape(
-                            [-1, inputs_embeds.shape[-1]]
-                        )
-                        inputs_embeds = ScatterOp.apply(inputs_embeds)
-                        inputs_embeds = (
-                            inputs_embeds.reshape([batch_size, -1, hidden_size])
-                            .permute(1, 0, 2)
-                            .contiguous()
-                        )  # change to [S, B, H]
-                    mtp_emb_res = [inputs_embeds]
-                    for depth in range(self.config.num_nextn_predict_layers):
+                    else:
                         inputs_embeds_mtp = paddle.concat(
                             [
-                                inputs_embeds_ori[:, (depth + 1) :, :],
-                                inputs_embeds_extra[:, : (depth + 1), :],
+                                inputs_embeds[:, (depth + 1) :, :],
+                                pad_embeds,
                             ],
                             axis=1,
                         )
 
-                        if (
-                            get_context_parallel_world_size() > 1
-                            and self.config.experimental_dataflow
-                        ):
-                            # In EB data flow, mtp input embed apply CP scatter here
-                            inputs_embeds_mtp = ContextParallelScatterOp.apply(
-                                inputs_embeds_mtp, axis=1
-                            )
+                    if (
+                        get_context_parallel_world_size() > 1
+                        and self.config.experimental_dataflow
+                    ):
+                        # In EB data flow, mtp input embed apply CP scatter here
+                        inputs_embeds_mtp = ContextParallelScatterOp.apply(
+                            inputs_embeds_mtp, axis=1
+                        )
 
-                        if self.sequence_parallel:
-                            inputs_embeds_mtp = inputs_embeds_mtp.reshape(
-                                [-1, inputs_embeds_mtp.shape[-1]]
+                    if self.sequence_parallel:
+                        inputs_embeds_mtp = inputs_embeds_mtp.reshape(
+                            [-1, inputs_embeds_mtp.shape[-1]]
+                        )
+                        inputs_embeds_mtp = ScatterOp.apply(inputs_embeds_mtp)
+                        inputs_embeds_mtp = (
+                            inputs_embeds_mtp.reshape(
+                                [batch_size, -1, hidden_size]
                             )
-                            inputs_embeds_mtp = ScatterOp.apply(
-                                inputs_embeds_mtp
-                            )
-                            inputs_embeds_mtp = (
-                                inputs_embeds_mtp.reshape(
-                                    [batch_size, -1, hidden_size]
-                                )
-                                .permute(1, 0, 2)
-                                .contiguous()
-                            )  # change to [S, B, H]
-                        mtp_emb_res.append(inputs_embeds_mtp)
+                            .permute(1, 0, 2)
+                            .contiguous()
+                        )  # change to [S, B, H]
+                    mtp_emb_res.append(inputs_embeds_mtp)
 
             if self.multimodal_embedding:
                 image_embeds = dict_args.get("image_embeds", None)
@@ -443,23 +431,6 @@ class GPTEmbedding(FleetLayer):
         rotary_pos_emb = None
         rotary_pos_cos = None
         rotary_pos_sin = None
-        swa_rotary_pos_emb = None
-        swa_rotary_pos_cos = None
-        swa_rotary_pos_sin = None
-
-        # For MTP mode: truncate position_ids to match the actual sequence length
-        # MTP reduces sequence length by num_nextn_predict_layers
-        mtp_position_ids = position_ids
-        if (
-            mtp_emb_res is not None
-            and position_ids is not None
-            and self.config.num_nextn_predict_layers is not None
-            and self.config.num_nextn_predict_layers > 0
-        ):
-            # mtp_emb_res[0] has shape [B, seq_len - num_nextn_predict_layers, H]
-            actual_seq_len = mtp_emb_res[0].shape[1]
-            if position_ids.shape[1] > actual_seq_len:
-                mtp_position_ids = position_ids[:, :actual_seq_len]
 
         if (
             self.position_embedding_type == "rope"
@@ -473,7 +444,7 @@ class GPTEmbedding(FleetLayer):
                 rotary_seq_len,
                 packed_seq=packed_seq_params is not None
                 and packed_seq_params.qkv_format == "thd",
-                position_ids=None if self.training else mtp_position_ids,
+                position_ids=position_ids,
             )
         elif (
             self.position_embedding_type == "mrope"
@@ -499,76 +470,8 @@ class GPTEmbedding(FleetLayer):
                         [1, 0, 2, 3]
                     ).contiguous()
 
-        if (
-            self.position_embedding_type == "rope"
-            and self.swa_rotary_pos_emb is not None
-        ):
-            rope_base = decoder_input if mtp_emb_res is None else mtp_emb_res[0]
-            rotary_seq_len = self.swa_rotary_pos_emb.get_rotary_seq_len(
-                rope_base, self.config, packed_seq_params
-            )
-            swa_rotary_pos_emb = self.swa_rotary_pos_emb(
-                rotary_seq_len,
-                packed_seq=packed_seq_params is not None
-                and packed_seq_params.qkv_format == "thd",
-                position_ids=position_ids,
-            )
-
-        elif (
-            self.position_embedding_type == "mrope"
-            and self.swa_rotary_pos_emb is not None
-        ):
-            swa_rotary_pos_emb = self.swa_rotary_pos_emb(
-                position_ids, self.mrope_section
-            )
-
-        if swa_rotary_pos_emb is not None:
-            if self.config.apply_rope_fusion:
-                swa_rotary_pos_cos = paddle.cos(swa_rotary_pos_emb)
-                swa_rotary_pos_sin = paddle.sin(swa_rotary_pos_emb)
-            if self.config.sequence_parallel:
-                if self.position_embedding_type == "mrope":
-                    # MRoPE: [B, S, head_dim] -> [S, B, head_dim]
-                    swa_rotary_pos_emb = swa_rotary_pos_emb.transpose(
-                        [1, 0, 2]
-                    ).contiguous()
-                else:
-                    # RoPE: [1, S, 1, head_dim] -> [S, 1, 1, head_dim]
-                    swa_rotary_pos_emb = swa_rotary_pos_emb.transpose(
-                        [1, 0, 2, 3]
-                    ).contiguous()
-
         if paddle.core._has_grad():
             decoder_input.stop_gradient = False  # Prevent errors in recompute_pylayer during LoRA training caused by base_weight lacking gradients.
-
-        if (
-            get_context_parallel_world_size() > 1
-            and self.config.experimental_dataflow
-        ):
-            if rotary_pos_emb is not None:
-                rotary_pos_emb = ContextParallelScatterOp.apply(
-                    rotary_pos_emb, axis=1
-                )
-            if swa_rotary_pos_emb is not None:
-                swa_rotary_pos_emb = ContextParallelScatterOp.apply(
-                    swa_rotary_pos_emb, axis=1
-                )
-            if rotary_pos_cos is not None:
-                rotary_pos_cos = ContextParallelScatterOp.apply(
-                    rotary_pos_cos, axis=1
-                )
-            if rotary_pos_sin is not None:
-                rotary_pos_sin = ContextParallelScatterOp.apply(
-                    rotary_pos_sin, axis=1
-                )
-            if swa_rotary_pos_cos is not None:
-                swa_rotary_pos_cos = ContextParallelScatterOp.apply(
-                    swa_rotary_pos_cos, axis=1
-                )
-            if swa_rotary_pos_sin is not None:
-                swa_rotary_pos_sin = ContextParallelScatterOp.apply(
-                    swa_rotary_pos_sin, axis=1
-                )
 
         preproc_output = {
             "hidden_states": decoder_input,
@@ -577,9 +480,6 @@ class GPTEmbedding(FleetLayer):
             "rotary_pos_emb": rotary_pos_emb,
             "rotary_pos_cos": rotary_pos_cos,
             "rotary_pos_sin": rotary_pos_sin,
-            "swa_rotary_pos_emb": swa_rotary_pos_emb,
-            "swa_rotary_pos_cos": swa_rotary_pos_cos,
-            "swa_rotary_pos_sin": swa_rotary_pos_sin,
             "position_ids": position_ids,
             "deepstack_visual_emb": deepstack_visual_embeds,
             "visual_pos_masks": visual_pos_masks,
@@ -626,11 +526,6 @@ class GPTEmbedding(FleetLayer):
             assert len(mtp_emb_res) == self.config.num_nextn_predict_layers + 1
             hidden_states_concat = paddle.concat(mtp_emb_res)
             preproc_output["hidden_states"] = hidden_states_concat
-
-        # Pass through KV cache kwargs for inference
-        for key in ("past_key_values", "use_cache"):
-            if key in dict_args and key not in preproc_output:
-                preproc_output[key] = dict_args[key]
 
         for key in list(preproc_output.keys()):
             if preproc_output[key] is None:

--- a/src/paddlefleet/models/gpt/lm_head.py
+++ b/src/paddlefleet/models/gpt/lm_head.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
 import paddle
 from paddle.distributed.fleet.meta_parallel import (
     ScheduleNode,
@@ -29,51 +27,6 @@ from paddlefleet.tensor_parallel.layers import (
     _initialize_affine_weight_gpu,
 )
 from paddlefleet.transformer.identity_op import IdentityOp
-
-_DSV4_LOSS_GRAD_COUNTS = {}
-
-
-def _dsv4_loss_grad_rank_enabled(rank: int) -> bool:
-    ranks = os.environ.get("DSV4_LOSS_GRAD_RANKS", "0")
-    if ranks.strip().lower() == "all":
-        return True
-    return str(rank) in {item.strip() for item in ranks.split(",") if item.strip()}
-
-
-def _dsv4_tensor_md5_float32(tensor: paddle.Tensor) -> str:
-    import hashlib
-
-    tensor = tensor.detach().cast("float32")
-    return hashlib.md5(tensor.numpy().tobytes()).hexdigest()
-
-
-def _dsv4_register_loss_grad_hook(name: str, tensor: paddle.Tensor):
-    if os.environ.get("DSV4_LOG_LOSS_GRADS", "0") != "1":
-        return tensor
-    if not isinstance(tensor, paddle.Tensor) or tensor.stop_gradient:
-        return tensor
-    rank = paddle.distributed.get_rank()
-    if not _dsv4_loss_grad_rank_enabled(rank):
-        return tensor
-    occurrence = _DSV4_LOSS_GRAD_COUNTS.get(name, 0)
-    _DSV4_LOSS_GRAD_COUNTS[name] = occurrence + 1
-    max_numel = int(os.environ.get("DSV4_LOSS_GRAD_MD5_MAX_NUMEL", "600000000"))
-
-    def _hook(grad):
-        grad_fp32 = grad.detach().cast("float32")
-        norm = paddle.linalg.norm(grad_fp32).item()
-        md5 = _dsv4_tensor_md5_float32(grad_fp32) if grad_fp32.numel() <= max_numel else "SKIP"
-        print(
-            f"[DSV4_LOSS_GRAD] framework=fleet rank={rank} name={name} "
-            f"occurrence={occurrence} shape={list(grad.shape)} dtype={grad.dtype} "
-            f"numel={grad.numel()} norm={norm:.20f} md5_float32={md5}",
-            flush=True,
-        )
-        return grad
-
-    tensor.register_hook(_hook)
-    return tensor
-
 
 class GPTLMHead(ColumnParallelLinear):
     def __init__(self, **kwargs):
@@ -147,7 +100,6 @@ class GPTLMHead(ColumnParallelLinear):
         return ScheduleNode(self.forward, name="GPTLMHead")
 
     def _forward(self, hidden_states: paddle.Tensor):
-        hidden_states = _dsv4_register_loss_grad_hook("lm_head_input", hidden_states)
         # Fused linear + cross-entropy path: skip materializing [B, S, V] logits
         # and delegate the linear projection into LanguageLoss, which will call
         # LigerFusedLinearCrossEntropyFunction.
@@ -173,37 +125,6 @@ class GPTLMHead(ColumnParallelLinear):
             logits, _ = super().forward(hidden_states, self.weight.T)
         if self.config.sequence_parallel:
             logits = logits.transpose([1, 0, 2]).contiguous()
-        logits = _dsv4_register_loss_grad_hook("lm_head_logits", logits)
-
-        # Loss-path MD5 probe: lm_head weight and logits
-        if (
-            os.environ.get("LOG_LAYER_MD5", "0") == "1"
-            or os.environ.get("LOG_LOSS_MD5", "0") == "1"
-        ):
-            import hashlib
-
-            rank = paddle.distributed.get_rank()
-            w_md5 = hashlib.md5(
-                self.weight.cast("float32").numpy().tobytes()
-            ).hexdigest()
-            h_md5 = hashlib.md5(
-                hidden_states.cast("float32").numpy().tobytes()
-            ).hexdigest()
-            l_md5 = hashlib.md5(
-                logits.cast("float32").numpy().tobytes()
-            ).hexdigest()
-            print(
-                f"[LOSS_PATH_MD5] rank={rank} lm_head_weight shape={list(self.weight.shape)} md5={w_md5}",
-                flush=True,
-            )
-            print(
-                f"[LOSS_PATH_MD5] rank={rank} lm_head_input shape={list(hidden_states.shape)} md5={h_md5}",
-                flush=True,
-            )
-            print(
-                f"[LOSS_PATH_MD5] rank={rank} lm_head_logits shape={list(logits.shape)} md5={l_md5}",
-                flush=True,
-            )
 
         return logits
 

--- a/src/paddlefleet/models/gpt/lm_head.py
+++ b/src/paddlefleet/models/gpt/lm_head.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 import paddle
 from paddle.distributed.fleet.meta_parallel import (
     ScheduleNode,
@@ -27,6 +29,50 @@ from paddlefleet.tensor_parallel.layers import (
     _initialize_affine_weight_gpu,
 )
 from paddlefleet.transformer.identity_op import IdentityOp
+
+_DSV4_LOSS_GRAD_COUNTS = {}
+
+
+def _dsv4_loss_grad_rank_enabled(rank: int) -> bool:
+    ranks = os.environ.get("DSV4_LOSS_GRAD_RANKS", "0")
+    if ranks.strip().lower() == "all":
+        return True
+    return str(rank) in {item.strip() for item in ranks.split(",") if item.strip()}
+
+
+def _dsv4_tensor_md5_float32(tensor: paddle.Tensor) -> str:
+    import hashlib
+
+    tensor = tensor.detach().cast("float32")
+    return hashlib.md5(tensor.numpy().tobytes()).hexdigest()
+
+
+def _dsv4_register_loss_grad_hook(name: str, tensor: paddle.Tensor):
+    if os.environ.get("DSV4_LOG_LOSS_GRADS", "0") != "1":
+        return tensor
+    if not isinstance(tensor, paddle.Tensor) or tensor.stop_gradient:
+        return tensor
+    rank = paddle.distributed.get_rank()
+    if not _dsv4_loss_grad_rank_enabled(rank):
+        return tensor
+    occurrence = _DSV4_LOSS_GRAD_COUNTS.get(name, 0)
+    _DSV4_LOSS_GRAD_COUNTS[name] = occurrence + 1
+    max_numel = int(os.environ.get("DSV4_LOSS_GRAD_MD5_MAX_NUMEL", "600000000"))
+
+    def _hook(grad):
+        grad_fp32 = grad.detach().cast("float32")
+        norm = paddle.linalg.norm(grad_fp32).item()
+        md5 = _dsv4_tensor_md5_float32(grad_fp32) if grad_fp32.numel() <= max_numel else "SKIP"
+        print(
+            f"[DSV4_LOSS_GRAD] framework=fleet rank={rank} name={name} "
+            f"occurrence={occurrence} shape={list(grad.shape)} dtype={grad.dtype} "
+            f"numel={grad.numel()} norm={norm:.20f} md5_float32={md5}",
+            flush=True,
+        )
+        return grad
+
+    tensor.register_hook(_hook)
+    return tensor
 
 
 class GPTLMHead(ColumnParallelLinear):
@@ -101,6 +147,7 @@ class GPTLMHead(ColumnParallelLinear):
         return ScheduleNode(self.forward, name="GPTLMHead")
 
     def _forward(self, hidden_states: paddle.Tensor):
+        hidden_states = _dsv4_register_loss_grad_hook("lm_head_input", hidden_states)
         # Fused linear + cross-entropy path: skip materializing [B, S, V] logits
         # and delegate the linear projection into LanguageLoss, which will call
         # LigerFusedLinearCrossEntropyFunction.
@@ -126,10 +173,9 @@ class GPTLMHead(ColumnParallelLinear):
             logits, _ = super().forward(hidden_states, self.weight.T)
         if self.config.sequence_parallel:
             logits = logits.transpose([1, 0, 2]).contiguous()
+        logits = _dsv4_register_loss_grad_hook("lm_head_logits", logits)
 
         # Loss-path MD5 probe: lm_head weight and logits
-        import os
-
         if (
             os.environ.get("LOG_LAYER_MD5", "0") == "1"
             or os.environ.get("LOG_LOSS_MD5", "0") == "1"
@@ -261,7 +307,10 @@ class GPTMTPLMHead(GPTLMHead):
 
         mtp_logits = []
         for i in range(num_mtp):
-            mtp_logits.append(self._forward(tensor_list[i + 1]))
+            mtp_input = _dsv4_register_loss_grad_hook(
+                "mtp_lm_head_input", tensor_list[i + 1]
+            )
+            mtp_logits.append(self._forward(mtp_input))
 
         dict_args["mtp_logits"] = mtp_logits
         return dict_args

--- a/src/paddlefleet/tensor_parallel/layers.py
+++ b/src/paddlefleet/tensor_parallel/layers.py
@@ -102,7 +102,6 @@ def _dsv4_te_dgrad_enabled(
 def _dsv4_te_dgrad(
     grad_output: paddle.Tensor, weight: paddle.Tensor
 ) -> paddle.Tensor:
-    import hashlib
     import sys
 
     te_site_packages = os.getenv("DSV4_FLEET_TE_SITE_PACKAGES", "")
@@ -127,29 +126,6 @@ def _dsv4_te_dgrad(
         layout="NN",
         grad=True,
     )
-
-    if os.getenv("DSV4_FLEET_TE_DGRAD_LOG", "0") == "1":
-        rank = paddle.distributed.get_rank() if dist.is_initialized() else 0
-        rank_filter = os.getenv("DSV4_FLEET_TE_DGRAD_LOG_RANKS", "0")
-        allowed_ranks = {x.strip() for x in rank_filter.split(",")}
-        if rank_filter == "all" or str(rank) in allowed_ranks:
-            grad32 = grad_input_torch.detach().float()
-            flat = grad32.reshape(-1)
-            max_numel = int(
-                os.getenv("DSV4_FLEET_TE_DGRAD_LOG_MAX_NUMEL", "600000000")
-            )
-            count = min(flat.numel(), max_numel)
-            md5 = hashlib.md5(
-                flat[:count].cpu().numpy().tobytes()
-            ).hexdigest()
-            print(
-                "[DSV4_FLEET_TE_DGRAD] "
-                f"rank={rank} grad_output_shape={tuple(grad_output.shape)} "
-                f"weight_shape={tuple(weight.shape)} "
-                f"grad_input_shape={tuple(grad_input_torch.shape)} "
-                f"norm={grad32.norm().item():.12f} md5_first_{count}={md5}",
-                flush=True,
-            )
 
     return paddle_dlpack.from_dlpack(
         torch.utils.dlpack.to_dlpack(grad_input_torch.contiguous())

--- a/src/paddlefleet/tensor_parallel/layers.py
+++ b/src/paddlefleet/tensor_parallel/layers.py
@@ -299,7 +299,7 @@ class VocabParallelEmbedding(paddle.nn.Layer):
         else:
             masked_input = input_
         # Get the embeddings.
-        if self.deterministic_mode:
+        if self.deterministic_mode or os.getenv("DSV4_EMBEDDING_INDEX_BACKWARD", "0") == "1":
             output_parallel = self.weight[masked_input]
         else:
             # F.embedding currently has a non-deterministic backward function

--- a/src/paddlefleet/tensor_parallel/layers.py
+++ b/src/paddlefleet/tensor_parallel/layers.py
@@ -325,7 +325,10 @@ class VocabParallelEmbedding(paddle.nn.Layer):
         self.num_embeddings_per_partition = (
             self.vocab_end_index - self.vocab_start_index
         )
-        self.deterministic_mode = config.deterministic_mode
+        self.deterministic_mode = (
+            config.deterministic_mode
+            or os.environ.get("DSV4_EMBEDDING_INDEX_BACKWARD", "0") == "1"
+        )
         self.world_size = get_pg_size(self.tp_group)
 
         # Allocate weights and initialize.

--- a/src/paddlefleet/tensor_parallel/layers.py
+++ b/src/paddlefleet/tensor_parallel/layers.py
@@ -77,6 +77,85 @@ _MODEL_PARALLEL_ATTRIBUTE_DEFAULTS = {
 }
 
 
+def _dsv4_te_dgrad_enabled(
+    grad_output: paddle.Tensor, weight: paddle.Tensor
+) -> bool:
+    if os.getenv("DSV4_FLEET_TE_DGRAD", "0") != "1":
+        return False
+    shape_filter = os.getenv("DSV4_FLEET_TE_DGRAD_WEIGHT_SHAPES", "")
+    if shape_filter:
+        allowed = {
+            item.strip() for item in shape_filter.split(",") if item.strip()
+        }
+        if "x".join(str(dim) for dim in weight.shape) not in allowed:
+            return False
+    out_filter = os.getenv("DSV4_FLEET_TE_DGRAD_OUT_FEATURES", "")
+    if out_filter:
+        allowed_out = {
+            item.strip() for item in out_filter.split(",") if item.strip()
+        }
+        if str(grad_output.shape[-1]) not in allowed_out:
+            return False
+    return weight.dtype == paddle.bfloat16 and grad_output.dtype == paddle.bfloat16
+
+
+def _dsv4_te_dgrad(
+    grad_output: paddle.Tensor, weight: paddle.Tensor
+) -> paddle.Tensor:
+    import hashlib
+    import sys
+
+    te_site_packages = os.getenv("DSV4_FLEET_TE_SITE_PACKAGES", "")
+    if te_site_packages and te_site_packages not in sys.path:
+        sys.path.insert(0, te_site_packages)
+
+    import torch
+    import torch.utils.dlpack
+    from paddle.utils import dlpack as paddle_dlpack
+    from transformer_engine.pytorch.cpp_extensions.gemm import general_gemm
+
+    grad_output_torch = torch.utils.dlpack.from_dlpack(
+        paddle_dlpack.to_dlpack(grad_output.contiguous())
+    )
+    weight_oi_torch = torch.utils.dlpack.from_dlpack(
+        paddle_dlpack.to_dlpack(weight.t().contiguous())
+    )
+    grad_input_torch, *_ = general_gemm(
+        weight_oi_torch,
+        grad_output_torch,
+        out_dtype=torch.bfloat16,
+        layout="NN",
+        grad=True,
+    )
+
+    if os.getenv("DSV4_FLEET_TE_DGRAD_LOG", "0") == "1":
+        rank = paddle.distributed.get_rank() if dist.is_initialized() else 0
+        rank_filter = os.getenv("DSV4_FLEET_TE_DGRAD_LOG_RANKS", "0")
+        allowed_ranks = {x.strip() for x in rank_filter.split(",")}
+        if rank_filter == "all" or str(rank) in allowed_ranks:
+            grad32 = grad_input_torch.detach().float()
+            flat = grad32.reshape(-1)
+            max_numel = int(
+                os.getenv("DSV4_FLEET_TE_DGRAD_LOG_MAX_NUMEL", "600000000")
+            )
+            count = min(flat.numel(), max_numel)
+            md5 = hashlib.md5(
+                flat[:count].cpu().numpy().tobytes()
+            ).hexdigest()
+            print(
+                "[DSV4_FLEET_TE_DGRAD] "
+                f"rank={rank} grad_output_shape={tuple(grad_output.shape)} "
+                f"weight_shape={tuple(weight.shape)} "
+                f"grad_input_shape={tuple(grad_input_torch.shape)} "
+                f"norm={grad32.norm().item():.12f} md5_first_{count}={md5}",
+                flush=True,
+            )
+
+    return paddle_dlpack.from_dlpack(
+        torch.utils.dlpack.to_dlpack(grad_input_torch.contiguous())
+    )
+
+
 def param_is_not_tensor_parallel_duplicate(param):
     """Returns true if the passed-in parameter is not a duplicate parameter
     on another TP rank."""
@@ -347,7 +426,7 @@ class LinearWithFrozenWeight(paddle.autograd.Function):
         ctx.save_for_backward(weight, bias)
         ctx.allreduce_dgrad = allreduce_dgrad
         ctx.tp_group = tp_group
-        output = paddle.matmul(input, weight)
+        output = paddle.matmul(input, weight.t().contiguous(), transpose_y=True)
 
         if bias is not None:
             output = output + bias
@@ -357,7 +436,10 @@ class LinearWithFrozenWeight(paddle.autograd.Function):
     def backward(ctx, grad_output):
         """Backward with frozen weight."""
         (weight, bias) = ctx.saved_tensor()
-        grad_input = grad_output.matmul(weight.t())
+        if _dsv4_te_dgrad_enabled(grad_output, weight):
+            grad_input = _dsv4_te_dgrad(grad_output, weight)
+        else:
+            grad_input = grad_output.matmul(weight.t())
 
         if ctx.allreduce_dgrad:
             # All-reduce. Note: here async and sync are effectively the same.
@@ -485,11 +567,6 @@ class LinearWithGradAccumulationAndAsyncCommunication(paddle.autograd.Function):
         ctx.wgrad_deferral_limit = wgrad_deferral_limit
         ctx.grad_output_buffer = grad_output_buffer
         ctx.tp_group = tp_group
-        # Cache input.stop_gradient: ``_new_shared_tensor()`` does not
-        # necessarily preserve this flag, and Paddle's PyLayer contract
-        # requires backward to return None at position 0 iff the original
-        # forward input had stop_gradient=True.
-        ctx.input_stop_gradient = bool(input.stop_gradient)
 
         if sequence_parallel:
             dim_size = list(input.shape)
@@ -506,7 +583,9 @@ class LinearWithGradAccumulationAndAsyncCommunication(paddle.autograd.Function):
         if bias is not None:
             output = paddle.nn.functional.linear(total_input, weight, bias)
         else:
-            output = paddle.matmul(total_input, weight)
+            output = paddle.matmul(
+                total_input, weight.t().contiguous(), transpose_y=True
+            )
         return output
 
     @staticmethod
@@ -519,16 +598,6 @@ class LinearWithGradAccumulationAndAsyncCommunication(paddle.autograd.Function):
         wgrad_deferral_limit = ctx.wgrad_deferral_limit
         handle = None
         tp_group = ctx.tp_group
-
-        # Paddle PyLayer contract: when a forward Tensor input has
-        # stop_gradient=True, the corresponding backward return slot MUST be
-        # None. The "input" position (0) is the only one that can carry
-        # stop_gradient=True in normal usage (weight/bias are trainable);
-        # callers that intentionally feed a detached tensor (e.g. for
-        # gradient isolation) rely on this. We must skip grad_input compute
-        # and any input-side collective (all_reduce / reduce_scatter) in
-        # that case, while still computing grad_weight / grad_bias.
-        input_needs_grad = not ctx.input_stop_gradient
 
         if ctx.gradient_accumulation_fusion:
             weight.main_grad = main_grad
@@ -559,10 +628,10 @@ class LinearWithGradAccumulationAndAsyncCommunication(paddle.autograd.Function):
                 total_input = all_gather_buffer
             else:
                 total_input = input
-        if input_needs_grad:
-            grad_input = grad_output.matmul(weight.t())
+        if _dsv4_te_dgrad_enabled(grad_output, weight):
+            grad_input = _dsv4_te_dgrad(grad_output, weight)
         else:
-            grad_input = None
+            grad_input = grad_output.matmul(weight.t())
 
         if ctx.sequence_parallel and wgrad_compute:
             # pylint: disable=possibly-used-before-assignment
@@ -573,7 +642,7 @@ class LinearWithGradAccumulationAndAsyncCommunication(paddle.autograd.Function):
                 grad_output, total_input
             )
 
-        if ctx.allreduce_dgrad and input_needs_grad:
+        if ctx.allreduce_dgrad:
             # Asynchronous all-reduce
             handle = dist.all_reduce(grad_input, group=tp_group, sync_op=False)
             # Here we rely on CUDA_DEVICE_MAX_CONNECTIONS=1 to ensure that the
@@ -581,19 +650,16 @@ class LinearWithGradAccumulationAndAsyncCommunication(paddle.autograd.Function):
 
         if ctx.sequence_parallel:
             assert not ctx.allreduce_dgrad
-            if input_needs_grad:
-                dim_size = list(input.shape)
-                sub_grad_input = paddle.empty(
-                    dim_size, dtype=input.dtype, requires_grad=False
-                )
-                # reduce_scatter
-                handle = _reduce_scatter_base(
-                    sub_grad_input, grad_input, group=tp_group, sync_op=False
-                )
-                # Here we rely on CUDA_DEVICE_MAX_CONNECTIONS=1 to ensure that the
-                # reduce scatter is scheduled before the weight gradient computation
-            else:
-                sub_grad_input = None
+            dim_size = list(input.shape)
+            sub_grad_input = paddle.empty(
+                dim_size, dtype=input.dtype, requires_grad=False
+            )
+            # reduce_scatter
+            handle = _reduce_scatter_base(
+                sub_grad_input, grad_input, group=tp_group, sync_op=False
+            )
+            # Here we rely on CUDA_DEVICE_MAX_CONNECTIONS=1 to ensure that the
+            # reduce scatter is scheduled before the weight gradient computation
 
         if ctx.gradient_accumulation_fusion:
             if wgrad_compute:
@@ -638,8 +704,7 @@ class LinearWithGradAccumulationAndAsyncCommunication(paddle.autograd.Function):
         grad_bias = grad_output.sum(dim=0) if use_bias else None
 
         if ctx.sequence_parallel:
-            if input_needs_grad:
-                handle.wait()
+            handle.wait()
             # Need to return None's as gradient has to flow for all the input arguments
             # provided during forward
             if use_bias:
@@ -647,7 +712,7 @@ class LinearWithGradAccumulationAndAsyncCommunication(paddle.autograd.Function):
             else:
                 return sub_grad_input, grad_weight
 
-        if ctx.allreduce_dgrad and input_needs_grad:
+        if ctx.allreduce_dgrad:
             handle.wait()
 
         # PyLayer requires the number of output in backward
@@ -1259,21 +1324,6 @@ class ColumnParallelLinear(paddle.nn.Layer):
                 )
 
         bias = self.bias if not self.skip_bias_add else None
-
-        if (
-            getattr(self.config, "gpt_model_use_experimental_version", False)
-            and self.world_size == 1
-            and self.bias is not None
-        ):
-            output = paddle.incubate.nn.functional.fused_linear(
-                input_, weight, self.bias
-            )
-            output_bias = (
-                self.bias.clone()
-                if (self.skip_bias_add and self.bias is not None)
-                else None
-            )
-            return output, output_bias
 
         if (
             self.allreduce_dgrad

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -26,6 +26,7 @@ Components:
 from __future__ import annotations
 
 import functools
+import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -56,11 +57,61 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 
 
+def _get_doc_start(
+    attn_mask_startend_row_indices: Tensor, seqlen: int
+) -> Tensor:
+    """Derive per-position document start from attn_mask_startend_row_indices.
+
+    Pure tensor operations using cummax, no Python for-loop.
+
+    Logic:
+      1. Detect boundary: where the end-boundary value changes → new doc starts
+      2. Mark boundary positions with their index, non-boundary with 0
+      3. cummax along seqlen propagates each boundary's index to all subsequent
+         positions until the next boundary (since boundaries are monotonically increasing)
+
+    Args:
+        attn_mask_startend_row_indices: [b, seqlen] or [seqlen] tensor where each value
+            is the end boundary (exclusive) of the document that position belongs to.
+
+    Returns:
+        doc_start: [b, seqlen] int64 tensor with start position of each token's document.
+    """
+    mask = attn_mask_startend_row_indices
+    squeeze_batch: bool = mask.ndim == 1
+    if squeeze_batch:
+        mask = mask.unsqueeze(0)  # [1, seqlen]
+
+    # Step 1: 检测文本边界 (相邻值不同 → 新文本开始)
+    changed = paddle.zeros_like(mask, dtype="int64")
+    changed[:, 0] = 1
+    changed[:, 1:] = (mask[:, 1:] != mask[:, :-1]).cast("int64")
+
+    # Step 2: 在边界位置标记其索引，非边界标记0
+    positions = (
+        paddle.arange(seqlen, dtype="int64").unsqueeze(0).expand_as(mask)
+    )
+    start_marker = changed * positions
+    # 例: 两个文本(24+8) → start_marker = [0, 0, ..., 0, 24, 0, ..., 0]
+    #                                       ^pos0(边界)     ^pos24(边界)
+    # 注: pos0 的 changed=1, positions=0, 所以 start_marker[0]=0 是正确的
+
+    # Step 3: cummax 沿 seqlen 方向取累积最大值
+    # 由于文本段起始位置单调递增，cummax 的结果就是每个位置的 doc_start
+    # 例: [0,0,...,0,24,0,...,0] → cummax → [0,0,...,0,24,24,...,24]
+    doc_start = paddle.cummax(start_marker, axis=1).values
+
+    if squeeze_batch:
+        doc_start = doc_start.squeeze(0)
+
+    return doc_start
+
+
 @functools.lru_cache(maxsize=8)
-def _get_window_topk_idxs_cached(
+def _get_window_topk_idxs_no_doc(
     window_size: int, seqlen: int, device_str: str
 ) -> Tensor:
-    """Compute sliding window indices for a single sequence (cached)."""
+    """Compute sliding window indices without document mask (cached)."""
     base = paddle.arange(seqlen).unsqueeze(1)  # [seqlen, 1]
     offsets = paddle.arange(window_size)  # [window_size]
     matrix = paddle.clip(base - window_size + 1, min=0) + offsets
@@ -69,10 +120,10 @@ def _get_window_topk_idxs_cached(
 
 
 @functools.lru_cache(maxsize=8)
-def _get_compress_topk_idxs_cached(
+def _get_compress_topk_idxs_no_doc(
     ratio: int, seqlen: int, offset: int, device_str: str
 ) -> Tensor:
-    """Compute compressed indices for a single sequence (cached)."""
+    """Compute compress indices without document mask (cached)."""
     n_compressed = seqlen // ratio
     k_indices = paddle.arange(n_compressed)
     matrix = k_indices.unsqueeze(0).expand([seqlen, -1])
@@ -88,28 +139,48 @@ def get_window_topk_idxs(
     window_size: int,
     batch_size: int,
     seqlen: int,
+    attn_mask_startend_row_indices: Tensor,
     device=None,
 ) -> Tensor:
-    """Get sliding window indices: [b, seqlen, window_size]."""
-    indices = _get_window_topk_idxs_cached(window_size, seqlen, "gpu")
-    return indices.unsqueeze(0).expand([batch_size, -1, -1])
+    """Get sliding window indices: [b, seqlen, window_size].
 
+    Args:
+        attn_mask_startend_row_indices: None for single-document (no mask), or
+            a tensor of shape [b, 1, seqlen, 1] or [b, seqlen] with per-position
+            document end boundaries.
+    """
+    if attn_mask_startend_row_indices is None:
+        indices = _get_window_topk_idxs_no_doc(window_size, seqlen, "gpu")
+        return indices.unsqueeze(0).expand([batch_size, -1, -1])
 
-def _build_compressed_causal_mask(
-    ratio: int,
-    batch_size: int,
-    seqlen: int,
-    n_compressed: int,
-) -> Tensor:
-    compressed_ids = paddle.arange(n_compressed).unsqueeze(0)
-    positions = paddle.arange(1, seqlen + 1).unsqueeze(1)
-    invalid = compressed_ids >= (positions // ratio)
-    invalid = invalid.unsqueeze(0).expand([batch_size, seqlen, n_compressed])
-    return paddle.where(
-        invalid,
-        paddle.full([1], float("-inf"), dtype="float32"),
-        paddle.zeros([1], dtype="float32"),
+    # Reshape to [b, seqlen]
+    assert (
+        attn_mask_startend_row_indices.shape[1] == 1
+        and attn_mask_startend_row_indices.shape[3] == 1
+    ), (
+        f"attn_mask_startend_row_indices shape must be [b, 1, seqlen, 1] now, but got {attn_mask_startend_row_indices.shape}"
     )
+    mask = attn_mask_startend_row_indices.reshape([batch_size, seqlen])
+    doc_start = _get_doc_start(mask, seqlen)  # [b, seqlen]
+
+    # Vectorized computation for all batches at once
+    base = paddle.arange(seqlen).unsqueeze(1)  # [seqlen, 1]
+    offsets = paddle.arange(window_size)  # [window_size]
+
+    # doc_start: [b, seqlen] -> [b, seqlen, 1]
+    doc_start_3d = doc_start.unsqueeze(2)  # [b, seqlen, 1]
+    base_3d = base.unsqueeze(0)  # [1, seqlen, 1]
+
+    win_start = paddle.maximum(
+        base_3d - window_size + 1, doc_start_3d
+    )  # [b, seqlen, 1]
+    matrix = win_start + offsets.unsqueeze(0).unsqueeze(
+        0
+    )  # [b, seqlen, window_size]
+    matrix = paddle.where(
+        matrix > base_3d, paddle.full_like(matrix, -1), matrix
+    )
+    return matrix
 
 
 def get_compress_topk_idxs(
@@ -117,11 +188,49 @@ def get_compress_topk_idxs(
     batch_size: int,
     seqlen: int,
     offset: int,
+    attn_mask_startend_row_indices: Tensor,
     device=None,
 ) -> Tensor:
-    """Get compressed indices: [b, seqlen, seqlen // ratio]."""
-    matrix = _get_compress_topk_idxs_cached(ratio, seqlen, offset, "gpu")
-    return matrix.unsqueeze(0).expand([batch_size, -1, -1])
+    """Get compressed indices: [b, seqlen, seqlen // ratio].
+
+    Args:
+        attn_mask_startend_row_indices: None for single-document (no mask), or
+            a tensor of shape [b, 1, seqlen, 1] or [b, seqlen] with per-position
+            document end boundaries.
+    """
+    if attn_mask_startend_row_indices is None:
+        matrix = _get_compress_topk_idxs_no_doc(ratio, seqlen, offset, "gpu")
+        return matrix.unsqueeze(0).expand([batch_size, -1, -1])
+
+    # Reshape to [b, seqlen]
+    mask = attn_mask_startend_row_indices.reshape([batch_size, seqlen])
+    doc_start = _get_doc_start(mask, seqlen)  # [b, seqlen]
+
+    n_compressed = seqlen // ratio
+    k_indices = paddle.arange(n_compressed)  # [n_compressed]
+
+    # Expand: [b, seqlen, n_compressed]
+    matrix = (
+        k_indices.unsqueeze(0).unsqueeze(0).expand([batch_size, seqlen, -1])
+    )  # [b, seqlen, n_compressed]
+
+    # Causal mask: k >= (i+1) // ratio
+    causal_bound = (
+        paddle.arange(1, seqlen + 1).unsqueeze(1) // ratio
+    ).unsqueeze(0)  # [1, seqlen, 1]
+    causal_invalid = matrix >= causal_bound
+
+    # Document boundary mask: k < ceil(doc_start[i] / ratio)
+    doc_start_compressed = ((doc_start + ratio - 1) // ratio).unsqueeze(
+        2
+    )  # [b, seqlen, 1]
+    doc_invalid = matrix < doc_start_compressed
+
+    invalid = causal_invalid | doc_invalid
+    matrix = paddle.where(
+        invalid, paddle.full_like(matrix, -1), matrix + offset
+    )
+    return matrix
 
 
 # ---------------------------------------------------------------------------
@@ -192,6 +301,75 @@ def _apply_rope(
 # ---------------------------------------------------------------------------
 
 
+def _dsv4_import_torch_for_csa_sink_softmax():
+    site_packages = os.environ.get(
+        "DSV4_FLEET_CSA_TORCH_SITE_PACKAGES",
+        os.environ.get("DSV4_FLEET_TE_SITE_PACKAGES", ""),
+    )
+    if site_packages and site_packages not in os.sys.path:
+        os.sys.path.insert(0, site_packages)
+    import torch
+    import torch.utils.dlpack
+
+    return torch
+
+
+def _dsv4_csa_sink_softmax_torch_bwd_enabled() -> bool:
+    return os.environ.get("DSV4_FLEET_CSA_SINK_SOFTMAX_TORCH_BWD", "0") == "1"
+
+
+def _dsv4_csa_sink_softmax_paddle(scores: Tensor, sink: Tensor) -> Tensor:
+    scores_max = scores.max(axis=-1, keepdim=True)  # [b, np, sq, 1]
+    scores_max = paddle.maximum(scores_max, sink)
+    exp_scores = paddle.exp(scores - scores_max)  # [b, np, sq, topk]
+    exp_sink = paddle.exp(sink - scores_max)  # [b, np, sq, 1]
+    sum_exp = exp_scores.sum(axis=-1, keepdim=True) + exp_sink  # [b, np, sq, 1]
+    return exp_scores / sum_exp  # [b, np, sq, topk]
+
+
+class _DSV4CSASinkSoftmaxTorchBackward(paddle.autograd.PyLayer):
+    @staticmethod
+    def forward(ctx, scores: Tensor, sink: Tensor):
+        ctx.save_for_backward(scores, sink)
+        return _dsv4_csa_sink_softmax_paddle(scores, sink)
+
+    @staticmethod
+    def backward(ctx, grad_attn_weights: Tensor):
+        torch = _dsv4_import_torch_for_csa_sink_softmax()
+        scores, sink = ctx.saved_tensor()
+        scores_t = torch.utils.dlpack.from_dlpack(
+            paddle.utils.dlpack.to_dlpack(scores.detach().contiguous())
+        )
+        sink_t = torch.utils.dlpack.from_dlpack(
+            paddle.utils.dlpack.to_dlpack(sink.detach().contiguous())
+        )
+        grad_t = torch.utils.dlpack.from_dlpack(
+            paddle.utils.dlpack.to_dlpack(
+                grad_attn_weights.detach().contiguous()
+            )
+        )
+
+        with torch.enable_grad():
+            scores_t = scores_t.detach().requires_grad_(True)
+            sink_t = sink_t.detach().requires_grad_(True)
+            scores_max_t = torch.maximum(
+                scores_t.max(dim=-1, keepdim=True).values, sink_t
+            )
+            exp_scores_t = torch.exp(scores_t - scores_max_t)
+            exp_sink_t = torch.exp(sink_t - scores_max_t)
+            sum_exp_t = exp_scores_t.sum(dim=-1, keepdim=True) + exp_sink_t
+            attn_weights_t = exp_scores_t / sum_exp_t
+            attn_weights_t.backward(grad_t)
+
+        grad_scores = paddle.utils.dlpack.from_dlpack(
+            torch.utils.dlpack.to_dlpack(scores_t.grad.contiguous())
+        )
+        grad_sink = paddle.utils.dlpack.from_dlpack(
+            torch.utils.dlpack.to_dlpack(sink_t.grad.contiguous())
+        )
+        return grad_scores, grad_sink
+
+
 def unfused_compressed_sparse_attn(
     query: Tensor,
     kv_full: Tensor,
@@ -241,18 +419,11 @@ def unfused_compressed_sparse_attn(
 
         # Softmax with attention sink
         # sink: [np] -> [1, np, 1, 1]
-        sink = attn_sink.reshape([1, np_heads, 1, 1])
-        # Compute stable softmax: max over scores and sink
-        scores_max = scores.max(axis=-1, keepdim=True)  # [b, np, sq, 1]
-        scores_max = paddle.maximum(scores_max, sink)
-
-        exp_scores = paddle.exp(scores - scores_max)  # [b, np, sq, topk]
-        exp_sink = paddle.exp(sink - scores_max)  # [b, np, sq, 1]
-
-        sum_exp = (
-            exp_scores.sum(axis=-1, keepdim=True) + exp_sink
-        )  # [b, np, sq, 1]
-        attn_weights = exp_scores / sum_exp  # [b, np, sq, topk]
+        sink = attn_sink.reshape([1, np_heads, 1, 1]).cast("float32")
+        if _dsv4_csa_sink_softmax_torch_bwd_enabled():
+            attn_weights = _DSV4CSASinkSoftmaxTorchBackward.apply(scores, sink)
+        else:
+            attn_weights = _dsv4_csa_sink_softmax_paddle(scores, sink)
 
         # Weighted sum: [b, np, sq, topk] x [b, sq, topk, hn] -> [b, np, sq, hn]
         output = paddle.einsum("bnsk,bskh->bnsh", attn_weights, kv_g)
@@ -261,398 +432,6 @@ def unfused_compressed_sparse_attn(
     # Reshape: [b, np, sq, hn] -> [b, sq, np * hn]
     output = output.transpose([0, 2, 1, 3]).reshape([b, sq, np_heads * hn])
     return output
-
-
-def _resolve_csa_indexer_loss_topk_effective(
-    config, index_topk: int, n_compressed: int
-) -> int:
-    """Return the TileLang CSA indexer top-k width used by indexer loss.
-
-    Phase semantics (driven by ``dsa_indexer_use_sparse_loss``, **not** by the
-    new TileLang switches):
-
-    * Phase 3 (``dsa_indexer_use_sparse_loss=True``): ``min(index_topk,
-      n_compressed)`` — selected-topk semantics, same as the existing
-      ``FusedDSAIndexerLoss`` / ``CSAIndexer.forward`` choice.
-    * Phase 2 (``dsa_indexer_use_sparse_loss=False``): ``n_compressed`` — the
-      selected set covers the full compressed candidate range and is later
-      consumed as full-range KL by the indexer loss path.
-    """
-    use_sparse_loss = bool(getattr(config, "dsa_indexer_use_sparse_loss", True))
-    if use_sparse_loss:
-        return min(int(index_topk), int(n_compressed))
-    return int(n_compressed)
-
-
-def _resolve_csa_indexer_attn_topk_effective(
-    index_topk: int, n_compressed: int
-) -> int:
-    """Return the compressed top-k width consumed by main CSA attention."""
-    return min(int(index_topk), int(n_compressed))
-
-
-def _resolve_csa_tilelang_switch(config, field_name: str) -> bool:
-    backend_enabled = (
-        getattr(config, "csa_tilelang_backend", None)
-        == "attention_paddle_compat"
-    )
-    override = getattr(config, field_name, None)
-    if override is None:
-        return backend_enabled
-    return bool(override)
-
-
-def _map_compressed_topk_to_kv_full(
-    topk_indices_compressed: Tensor,
-    sq: int,
-    ratio: int,
-    offset: int,
-) -> Tensor:
-    """Map compressed block ids to ``kv_full`` indices.
-
-    For each query position ``t``, only ``(t + 1) // ratio`` compressed blocks
-    are causally valid. Slots whose compressed id is out of that range are
-    written back as ``-1``; valid slots are shifted by ``offset`` (which is
-    the original sequence length so that compressed entries follow the raw
-    KV positions inside ``kv_full``).
-    """
-    n_valid_per_pos = (
-        paddle.arange(1, sq + 1, dtype=topk_indices_compressed.dtype).unsqueeze(
-            1
-        )
-        // ratio
-    ).unsqueeze(0)  # [1, sq, 1]
-    valid = (topk_indices_compressed >= 0) & (
-        topk_indices_compressed < n_valid_per_pos
-    )
-    return paddle.where(
-        valid,
-        topk_indices_compressed + offset,
-        paddle.full_like(topk_indices_compressed, -1),
-    )
-
-
-def _compute_attn_target_on_selected_set(
-    query_mla: Tensor,  # [b, sq, np, hn]  DETACHED
-    key_comp_mla: Tensor,  # [b, sk, hn] shared compressed KV, or legacy [b, sk, np, hn]
-    topk_indices: Tensor,  # [b, sq, topk_eff] int32, -1 for invalid slots
-    softmax_scale: float,
-    tp_group=None,
-) -> Tensor:
-    """Construct attention target ``p[t, S_t]`` on the selected compressed set.
-
-    Mathematically equivalent to ``_compute_dsa_indexer_loss`` with
-    ``sparse_loss=True``, but evaluated only on the selected slots ``S_t``
-    given by ``topk_indices`` instead of materializing the full ``[B,Sq,Sk]``
-    distribution. Invalid (``-1``) slots are masked out before softmax and
-    receive zero target probability after L1 normalization.
-
-    The result has shape ``[b, sq, topk_eff]`` in fp32 and is the multi-head
-    aggregated, L1 normalized target distribution used as the second argument
-    of ``KL(target || index_prob)``.
-    """
-    b, sq, np, hn = query_mla.shape
-    topk_eff = topk_indices.shape[-1]
-
-    # Per-head full attention scores [b, np, sq, sk]. DSv4 compressed KV is
-    # shared across query heads as [b, sk, hn]; the legacy per-head-expanded
-    # [b, sk, np, hn] shape is still accepted for non-TileLang references.
-    q = query_mla.transpose([0, 2, 1, 3]).cast("float32")  # [b, np, sq, hn]
-    if len(key_comp_mla.shape) == 3:
-        k = key_comp_mla.transpose([0, 2, 1]).cast("float32").unsqueeze(1)
-    else:
-        k = key_comp_mla.transpose([0, 2, 3, 1]).cast("float32")
-    attn_scores = paddle.matmul(q, k) * float(softmax_scale)  # [b, np, sq, sk]
-
-    # Replace -1 with 0 for safe gather; then mask back to -inf afterwards.
-    valid = topk_indices >= 0  # [b, sq, topk_eff]
-    safe_indices = paddle.where(
-        valid, topk_indices, paddle.zeros_like(topk_indices)
-    ).cast("int64")
-    safe_indices_exp = safe_indices.unsqueeze(1).expand([b, np, sq, topk_eff])
-    selected_logits = paddle.take_along_axis(
-        attn_scores, safe_indices_exp, axis=-1
-    )  # [b, np, sq, topk_eff]
-
-    # Mask invalid slots so softmax assigns them zero probability.
-    valid_bn = valid.unsqueeze(1)  # [b, 1, sq, topk_eff]
-    neg_inf = paddle.full([1], float("-inf"), dtype="float32")
-    selected_logits = paddle.where(valid_bn, selected_logits, neg_inf)
-
-    # Avoid all-(-inf) rows producing NaN in softmax: zero such rows out.
-    row_valid = valid.any(axis=-1, keepdim=True)  # [b, sq, 1]
-    row_valid_bn = row_valid.unsqueeze(1)  # [b, 1, sq, 1]
-    selected_logits = paddle.where(
-        row_valid_bn, selected_logits, paddle.zeros_like(selected_logits)
-    )
-
-    probs = F.softmax(selected_logits, axis=-1, dtype="float32")
-    # Re-zero fully invalid rows post-softmax (softmax of zeros is uniform).
-    probs = probs * row_valid_bn.cast("float32")
-
-    # Aggregate over heads, optional TP all-reduce, then L1 normalize.
-    target = probs.sum(axis=1)  # [b, sq, topk_eff]
-    if tp_group is not None and getattr(tp_group, "nranks", 1) > 1:
-        paddle.distributed.all_reduce(target.contiguous(), group=tp_group)
-    target = target / target.sum(axis=-1, keepdim=True).clip(min=1e-10)
-
-    # Zero out invalid slots (so they contribute nothing to KL).
-    target = paddle.where(valid, target, paddle.zeros_like(target))
-    return target
-
-
-def _compute_tilelang_csa_indexer_loss_forward(
-    index_q: Tensor,
-    weights: Tensor,
-    index_k_comp: Tensor,
-    query_mla: Tensor,
-    key_comp_mla: Tensor,
-    ratio: int,
-    topk_effective: int,
-    softmax_scale: float,
-    loss_coeff: float,
-    tp_group=None,
-) -> tuple[Tensor, Tensor, Tensor, Tensor]:
-    from paddlefleet.tilelang_ops import (
-        csa_attn_target_reducesum,
-        csa_indexer_topk_fwd,
-    )
-
-    topk_indices, topk_probs = csa_indexer_topk_fwd(
-        index_q,
-        index_k_comp,
-        weights,
-        ratio=int(ratio),
-        topk_effective=int(topk_effective),
-    )
-
-    if tp_group is not None and getattr(tp_group, "nranks", 1) > 1:
-        target = _compute_attn_target_on_selected_set(
-            query_mla, key_comp_mla, topk_indices, softmax_scale, tp_group
-        )
-    else:
-        target = csa_attn_target_reducesum(
-            query_mla,
-            key_comp_mla,
-            topk_indices,
-            softmax_scale,
-        )
-
-    eps = 1e-10
-    kl_per_elem = target * (
-        paddle.log(target + eps) - paddle.log(topk_probs + eps)
-    )
-    loss = kl_per_elem.sum(axis=-1).mean() * float(loss_coeff)
-    return loss, topk_indices, topk_probs, target
-
-
-class TileLangCSAIndexerLoss(paddle.autograd.PyLayer):
-    """Selected-topk KL loss using TileLang CSA Indexer fwd/bwd kernels.
-
-    Forward:
-        1. Calls TileLang fused indexer to obtain
-           ``topk_indices [B, S, topk_effective]`` and post-softmax
-           ``topk_probs [B, S, topk_effective]`` over the selected set.
-        2. Constructs the multi-head aggregated attention target
-           ``p[t, S_t]`` on the same selected set via
-           ``_compute_attn_target_on_selected_set``.
-        3. Returns the scalar KL loss
-           ``KL(p[t,S_t] || softmax(I[t,S_t])) * loss_coeff``.
-
-        ``topk_indices`` is returned alongside the scalar loss. The outer
-        ``CompressedSparseAttention.forward`` may trim it back to the main
-        attention top-k width before feeding sparse attention.
-
-    Backward:
-        Following the Megatron / Miles selected-topk convention, the gradient
-        of KL w.r.t. the post-softmax indexer probabilities at the selected
-        slots is ``q - p`` (the fused softmax+KL identity). The kernel then
-        backprops only through the ReLU + per-head weighting + scaled QK GEMM.
-
-        ``grad_index_scores = (topk_probs - target) * loss_coeff / num_rows``
-        is multiplied by the upstream ``grad_loss`` and forwarded to
-        ``csa_indexer_bwd``.
-
-    Phase semantics:
-        * Phase 2 (``dsa_indexer_use_sparse_loss=False``): caller passes
-          ``topk_effective=n_compressed`` so the selected set covers the full
-          causal compressed range — equivalent to the Paddle full-range KL.
-        * Phase 3 (``dsa_indexer_use_sparse_loss=True``): caller passes
-          ``topk_effective=min(index_topk, n_compressed)`` for the standard
-          selected-topk KL semantics.
-
-    Phase 1 (``csa_dense_mode=True``) never reaches this PyLayer because
-    ``self.indexer`` is ``None`` in that configuration.
-    """
-
-    @staticmethod
-    def forward(
-        ctx,
-        index_q: Tensor,  # [b, sq, h_i, d_i]
-        weights: Tensor,  # [b, sq, h_i]   (RAW weights, no softmax_scale baked in)
-        index_k_comp: Tensor,  # [b, sk, d_i]
-        query_mla: Tensor,  # [b, sq, np, hn]      DETACHED MLA query
-        key_comp_mla: Tensor,  # [b, sk, hn]           DETACHED shared compressed KV
-        ratio: int,
-        topk_effective: int,
-        softmax_scale: float,
-        loss_coeff: float,
-        tp_group=None,
-    ) -> Tensor:
-        # The TileLang kernel applies its own ``dim**-0.5`` scale on index_q
-        # and consumes raw weights, so we pass them through unmodified. The
-        # PyLayer treats this as a single fused op: forward materializes only
-        # the selected ``[B,S,topk_effective]`` tensors and backward never
-        # touches the full ``[B,S,S_comp]`` logits.
-        loss, topk_indices, topk_probs, target = (
-            _compute_tilelang_csa_indexer_loss_forward(
-                index_q,
-                weights,
-                index_k_comp,
-                query_mla,
-                key_comp_mla,
-                ratio,
-                topk_effective,
-                softmax_scale,
-                loss_coeff,
-                tp_group,
-            )
-        )
-
-        ctx.save_for_backward(
-            index_q.detach(),
-            weights.detach(),
-            index_k_comp.detach(),
-            topk_indices.detach(),
-            topk_probs.detach(),
-            target.detach(),
-        )
-        ctx.loss_coeff = float(loss_coeff)
-        ctx.num_rows = float(target.shape[0] * target.shape[1])
-        return loss, topk_indices.detach()
-
-    @staticmethod
-    def backward(ctx, grad_loss: Tensor, grad_topk_indices: Tensor = None):
-        from paddlefleet.tilelang_ops import (
-            csa_indexer_bwd,
-        )
-
-        (
-            index_q,
-            weights,
-            index_k_comp,
-            topk_indices,
-            topk_probs,
-            target,
-        ) = ctx.saved_tensor()
-
-        # Treat the forward eps as numerical protection only and use the
-        # fused softmax + KL gradient w.r.t. the selected logits.
-        scale = ctx.loss_coeff / max(ctx.num_rows, 1.0)
-        grad_index_scores = (topk_probs - target) * scale
-        if grad_loss is not None:
-            grad_index_scores = grad_index_scores * grad_loss
-
-        grad_q, grad_weights, grad_k = csa_indexer_bwd(
-            index_q,
-            weights,
-            index_k_comp,
-            topk_indices,
-            grad_index_scores,
-        )
-
-        if grad_q.dtype != index_q.dtype:
-            grad_q = grad_q.cast(index_q.dtype)
-        if grad_weights.dtype != weights.dtype:
-            grad_weights = grad_weights.cast(weights.dtype)
-        if grad_k.dtype != index_k_comp.dtype:
-            grad_k = grad_k.cast(index_k_comp.dtype)
-
-        return (
-            grad_q,
-            grad_weights,
-            grad_k,
-            None,
-            None,
-        )
-
-
-class TileLangCSAIndexerLossAutoScaler(paddle.autograd.PyLayer):
-    """Attach TileLang CSA indexer loss gradients to the main output.
-
-    This is the TileLang analogue of ``DSAIndexerLossAutoScaler``. It avoids
-    chaining a scalar-loss PyLayer behind another PyLayer in the full training
-    graph while preserving the same gradient scale semantics.
-    """
-
-    @staticmethod
-    def forward(
-        ctx,
-        output: Tensor,
-        index_q: Tensor,
-        weights: Tensor,
-        index_k_comp: Tensor,
-        topk_indices: Tensor,
-        topk_probs: Tensor,
-        target: Tensor,
-        loss_coeff: float,
-    ) -> Tensor:
-        ctx.save_for_backward(
-            index_q.detach(),
-            weights.detach(),
-            index_k_comp.detach(),
-            topk_indices.detach(),
-            topk_probs.detach(),
-            target.detach(),
-        )
-        ctx.loss_coeff = float(loss_coeff)
-        ctx.num_rows = float(target.shape[0] * target.shape[1])
-        return output
-
-    @staticmethod
-    def backward(ctx, grad_output: Tensor):
-        from paddlefleet.tilelang_ops import csa_indexer_bwd
-
-        (
-            index_q,
-            weights,
-            index_k_comp,
-            topk_indices,
-            topk_probs,
-            target,
-        ) = ctx.saved_tensor()
-
-        grad_index_scores = (topk_probs - target) * (
-            ctx.loss_coeff / max(ctx.num_rows, 1.0)
-        )
-        scale = DSAIndexerLossAutoScaler._main_loss_backward_scale
-        if scale is not None:
-            grad_index_scores = grad_index_scores * scale
-
-        grad_q, grad_weights, grad_k = csa_indexer_bwd(
-            index_q,
-            weights,
-            index_k_comp,
-            topk_indices,
-            grad_index_scores,
-        )
-
-        if grad_q.dtype != index_q.dtype:
-            grad_q = grad_q.cast(index_q.dtype)
-        if grad_weights.dtype != weights.dtype:
-            grad_weights = grad_weights.cast(weights.dtype)
-        if grad_k.dtype != index_k_comp.dtype:
-            grad_k = grad_k.cast(index_k_comp.dtype)
-
-        return (
-            grad_output,
-            grad_q,
-            grad_weights,
-            grad_k,
-            None,
-            None,
-            None,
-        )
 
 
 # ---------------------------------------------------------------------------
@@ -734,7 +513,6 @@ class Compressor(nn.Layer):
                 else 0.02
             ),
         )
-        self._cast_to_low_precision = False
 
         self.norm = build_spec_layer(
             sublayers_spec.norm,
@@ -762,10 +540,7 @@ class Compressor(nn.Layer):
         new_tensor[:, 1:, :ratio, :] = tensor[:, :-1, :, :d]
         return new_tensor
 
-    def forward(
-        self,
-        x: Tensor,
-    ) -> Tensor | None:
+    def forward(self, x: Tensor) -> Tensor | None:
         """Compress hidden states into shorter KV sequence.
 
         Args:
@@ -802,7 +577,7 @@ class Compressor(nn.Layer):
             score = self._overlap_transform(score, fill_value=float("-inf"))
 
         # Gated pooling: softmax over the pool_dim, weighted sum.
-        weights = F.softmax(score, axis=2).cast(kv.dtype)
+        weights = F.softmax(score, axis=2, dtype="float32").cast(kv.dtype)
         kv = (kv * weights).sum(axis=2)  # [b, n_compressed, head_dim]
 
         kv = self.norm(kv.cast(x.dtype))
@@ -997,10 +772,6 @@ class CompressedSparseAttention(FleetLayer):
         softmax_scale: float | None = None,
         k_channels: int | None = None,
         v_channels: int | None = None,
-        is_mtp_layer: bool = False,
-        is_swa: bool = False,
-        num_attention_heads: int | None = None,
-        num_key_value_heads: int | None = None,
         cp_comm_type: str = "p2p",
         pg_collection: ProcessGroupCollection = None,
         rotary_pos_emb: nn.Layer = None,
@@ -1009,14 +780,6 @@ class CompressedSparseAttention(FleetLayer):
         super().__init__(config)
         self.config = config
         self.layer_number = layer_number
-        self.pg_collection = pg_collection
-        self.tp_group = (
-            pg_collection.tp
-            if pg_collection is not None
-            and pg_collection.tp is not None
-            and getattr(pg_collection.tp, "nranks", 1) > 1
-            else None
-        )
         self.compress_ratio = compress_ratio
         self.window_size = config.csa_window_size
         self.v_head_dim = config.v_head_dim
@@ -1029,7 +792,6 @@ class CompressedSparseAttention(FleetLayer):
             dtype="float32",
             default_initializer=nn.initializer.Constant(0.0),
         )
-        self._cast_to_low_precision = False
 
         # Conditionally build Compressor (ratio > 1)
         if self.compress_ratio > 1:
@@ -1055,190 +817,6 @@ class CompressedSparseAttention(FleetLayer):
         else:
             self.indexer = None
 
-    def _compute_indexer_compressed_topk_idxs(
-        self,
-        query: Tensor,
-        x: Tensor,
-        qr: Tensor,
-        compressed_kv: Tensor,
-        n_compressed: int,
-        offset: int,
-    ) -> tuple[Tensor, Tensor | None, tuple | None]:
-        """Build indexer-selected compressed KV indices and loss state."""
-        b, sq, np_heads, _ = query.shape
-        indexer_loss = None
-        tilelang_indexer_loss_state = None
-
-        x_det = x.detach()
-        qr_det = qr.detach()
-        if self.training:
-            x_det.stop_gradient = False
-            qr_det.stop_gradient = False
-
-        # Loss and main attention intentionally use different top-k widths
-        # during phase 2. ``dsa_indexer_use_sparse_loss=False`` expands only
-        # the indexer loss to the full compressed range; the main CSA attention
-        # remains sparse and consumes ``min(index_topk, n_compressed)``.
-        use_tilelang_indexer = _resolve_csa_tilelang_switch(
-            self.config,
-            "csa_tilelang_enable_indexer",
-        )
-        # The fused TileLang indexer-loss path is only active during the
-        # grad-enabled forward. Full recompute runs the first forward under
-        # no_grad; that pass should only materialize main-attention indices.
-        use_tilelang_loss_path = (
-            use_tilelang_indexer and self.training and paddle.is_grad_enabled()
-        )
-        loss_topk_effective = _resolve_csa_indexer_loss_topk_effective(
-            self.config,
-            self.indexer.index_topk,
-            n_compressed,
-        )
-        attn_topk_effective = _resolve_csa_indexer_attn_topk_effective(
-            self.indexer.index_topk,
-            n_compressed,
-        )
-
-        causal_mask = _build_compressed_causal_mask(
-            self.compress_ratio,
-            b,
-            sq,
-            n_compressed,
-        )
-
-        if use_tilelang_loss_path:
-            # Fused TileLang fwd + selected-set KL + TileLang bwd. The returned
-            # indices may be wider than main attention top-k during phase 2 and
-            # are trimmed below before sparse attention consumes them.
-            indexer_loss_coeff = getattr(
-                self.config, "dsa_indexer_loss_coeff", 0.0
-            )
-            q_indexer_bf, k_indexer_bf, weights_indexer_bf = (
-                self.indexer.forward_before_topk(x_det, qr_det)
-            )
-            # compressed_kv is shared across query heads; pass it directly to
-            # the target/reducesum path instead of materializing [B,S,H,D].
-            key_comp_mla = compressed_kv.detach()
-            (
-                indexer_loss,
-                topk_indices_compressed,
-                topk_probs,
-                target,
-            ) = _compute_tilelang_csa_indexer_loss_forward(
-                q_indexer_bf,
-                weights_indexer_bf,
-                k_indexer_bf,
-                query.detach(),
-                key_comp_mla,
-                int(self.compress_ratio),
-                int(loss_topk_effective),
-                float(self.softmax_scale),
-                float(indexer_loss_coeff),
-                self.tp_group,
-            )
-            tilelang_indexer_loss_state = (
-                q_indexer_bf,
-                weights_indexer_bf,
-                k_indexer_bf,
-                topk_indices_compressed,
-                topk_probs,
-                target,
-                float(indexer_loss_coeff),
-            )
-            if indexer_loss_coeff > 0:
-                DSAIndexerLossLoggingHelper.save_loss_to_tracker(
-                    loss=indexer_loss,
-                    layer_number=self.layer_number,
-                    num_layers=self.config.num_hidden_layers,
-                )
-        elif self.training and not use_tilelang_indexer:
-            q_indexer, k_indexer, weights_indexer = (
-                self.indexer.forward_before_topk(x_det, qr_det)
-            )
-            indexer_loss_coeff = getattr(
-                self.config, "dsa_indexer_loss_coeff", 0.0
-            )
-            key_for_loss = (
-                compressed_kv.transpose([1, 0, 2])
-                .unsqueeze(2)
-                .expand([-1, -1, np_heads, -1])
-            )
-
-            q_sf = q_indexer.transpose([1, 0, 2, 3])
-            k_sf = (
-                k_indexer.transpose([1, 0, 2])
-                if k_indexer.ndim == 3
-                else k_indexer.transpose([1, 0, 2, 3])
-            )
-            weights_sf = (
-                weights_indexer * self.indexer.softmax_scale
-            ).transpose([1, 0, 2])
-            query_sf = query.transpose([1, 0, 2, 3]).detach()
-            mask_for_loss = causal_mask.unsqueeze(1)
-
-            indexer_loss = FusedDSAIndexerLoss.apply(
-                q_sf,
-                weights_sf,
-                k_sf,
-                query_sf,
-                key_for_loss.detach(),
-                self.softmax_scale,
-                min(self.indexer.index_topk, n_compressed),
-                indexer_loss_coeff,
-                mask_for_loss,
-                getattr(self.config, "dsa_indexer_use_sparse_loss", True),
-                self.tp_group,
-            )
-            topk_indices_compressed = FusedDSAIndexerLoss._last_topk_indices
-
-            if indexer_loss_coeff > 0:
-                DSAIndexerLossLoggingHelper.save_loss_to_tracker(
-                    loss=indexer_loss,
-                    layer_number=self.layer_number,
-                    num_layers=self.config.num_hidden_layers,
-                )
-        elif not use_tilelang_indexer:
-            _, topk_indices_compressed = self.indexer(
-                x_det,
-                qr_det,
-                mask=causal_mask,
-            )
-
-        # Optionally replace topk producer with TileLang fused compressed
-        # indexer forward. This only swaps the indices fed to sparse attention.
-        if use_tilelang_indexer and not use_tilelang_loss_path:
-            from paddlefleet.tilelang_ops import (
-                csa_indexer_topk_fwd,
-            )
-
-            with paddle.no_grad():
-                q_indexer_tl, k_indexer_tl, weights_indexer_tl = (
-                    self.indexer.forward_before_topk(x_det, qr_det)
-                )
-                tl_topk_indices, _tl_topk_scores = csa_indexer_topk_fwd(
-                    q_indexer_tl,
-                    k_indexer_tl,
-                    weights_indexer_tl,
-                    ratio=self.compress_ratio,
-                    topk_effective=attn_topk_effective,
-                )
-
-            topk_indices_compressed = tl_topk_indices
-
-        if topk_indices_compressed.shape[-1] > attn_topk_effective:
-            topk_indices_compressed = topk_indices_compressed[
-                ..., :attn_topk_effective
-            ].contiguous()
-
-        compress_topk_idxs = _map_compressed_topk_to_kv_full(
-            topk_indices_compressed,
-            sq,
-            self.compress_ratio,
-            offset,
-        )
-
-        return compress_topk_idxs, indexer_loss, tilelang_indexer_loss_state
-
     def forward(
         self,
         query: Tensor,
@@ -1247,6 +825,7 @@ class CompressedSparseAttention(FleetLayer):
         attention_mask: Tensor | None,
         x: Tensor = None,
         qr: Tensor = None,
+        attn_mask_startend_row_indices: Tensor = None,
     ) -> Tensor:
         """Forward pass for CompressedSparseAttention.
 
@@ -1282,25 +861,106 @@ class CompressedSparseAttention(FleetLayer):
         offset = sq  # compressed indices start after original positions
 
         # Step 3: Window indices
-        window_idxs = get_window_topk_idxs(self.window_size, b, sq)
+        window_idxs = get_window_topk_idxs(
+            self.window_size, b, sq, attn_mask_startend_row_indices
+        )
 
         # Step 4: Compressed indices
         indexer_loss = None
-        tilelang_indexer_loss_state = None
 
         if self.compress_ratio > 1 and n_compressed > 0:
             if self.indexer is not None:
-                (
-                    compress_topk_idxs,
-                    indexer_loss,
-                    tilelang_indexer_loss_state,
-                ) = self._compute_indexer_compressed_topk_idxs(
-                    query,
-                    x,
-                    qr,
-                    compressed_kv,
-                    n_compressed,
-                    offset,
+                x_det = x.detach()
+                qr_det = qr.detach()
+                if self.training:
+                    x_det.stop_gradient = False
+                    qr_det.stop_gradient = False
+
+                # Build causal mask for compressed positions: [b, sq, n_compressed]
+                compressed_ids = paddle.arange(n_compressed).unsqueeze(
+                    0
+                )  # [1, n_compressed]
+                positions = paddle.arange(1, sq + 1).unsqueeze(1)  # [sq, 1]
+                causal_mask = paddle.where(
+                    compressed_ids >= (positions // self.compress_ratio),
+                    paddle.full([1], float("-inf"), dtype="float32"),
+                    paddle.zeros([1], dtype="float32"),
+                )  # [sq, n_compressed]
+                causal_mask = causal_mask.unsqueeze(0).expand(
+                    [b, sq, n_compressed]
+                )  # [b, sq, n_compressed]
+
+                if self.training:
+                    q_indexer, k_indexer, weights_indexer = (
+                        self.indexer.forward_before_topk(x_det, qr_det)
+                    )
+                    indexer_loss_coeff = getattr(
+                        self.config, "dsa_indexer_loss_coeff", 0.0
+                    )
+                    # compressed_kv: [b, n, hn] -> expand for loss: [n, b, np, hn]
+                    key_for_loss = (
+                        compressed_kv.transpose([1, 0, 2])
+                        .unsqueeze(2)
+                        .expand([-1, -1, np_heads, -1])
+                    )
+
+                    # Convert batch-first to seq-first for FusedDSAIndexerLoss
+                    q_sf = q_indexer.transpose([1, 0, 2, 3])  # [sq, b, h, d]
+                    k_sf = (
+                        k_indexer.transpose([1, 0, 2])
+                        if k_indexer.ndim == 3
+                        else k_indexer.transpose([1, 0, 2, 3])
+                    )  # [n_compressed, b, d]
+                    weights_sf = (
+                        weights_indexer * self.indexer.softmax_scale
+                    ).transpose([1, 0, 2])  # [sq, b, h]
+                    query_sf = query.transpose(
+                        [1, 0, 2, 3]
+                    ).detach()  # [sq, b, np, hn]
+
+                    # causal_mask for FusedDSAIndexerLoss: [b, 1, sq, n_compressed]
+                    mask_for_loss = causal_mask.unsqueeze(1)
+
+                    indexer_loss = FusedDSAIndexerLoss.apply(
+                        q_sf,
+                        weights_sf,
+                        k_sf,
+                        query_sf,
+                        key_for_loss.detach(),
+                        self.softmax_scale,
+                        min(self.indexer.index_topk, n_compressed),
+                        indexer_loss_coeff,
+                        mask_for_loss,
+                        getattr(
+                            self.config, "dsa_indexer_use_sparse_loss", True
+                        ),
+                        None,  # tp_group
+                    )
+                    topk_indices_compressed = (
+                        FusedDSAIndexerLoss._last_topk_indices
+                    )
+
+                    if indexer_loss_coeff > 0:
+                        DSAIndexerLossLoggingHelper.save_loss_to_tracker(
+                            loss=indexer_loss,
+                            layer_number=self.layer_number,
+                            num_layers=self.config.num_hidden_layers,
+                        )
+                else:
+                    _, topk_indices_compressed = self.indexer(
+                        x_det, qr_det, mask=causal_mask
+                    )
+
+                # Filter invalid indices and shift to kv_full space
+                n_valid_per_pos = (
+                    paddle.arange(1, sq + 1).unsqueeze(1) // self.compress_ratio
+                )  # [sq, 1]
+                n_valid_per_pos = n_valid_per_pos.unsqueeze(0)  # [1, sq, 1]
+                valid = topk_indices_compressed < n_valid_per_pos
+                compress_topk_idxs = paddle.where(
+                    valid,
+                    topk_indices_compressed + offset,
+                    paddle.full_like(topk_indices_compressed, -1),
                 )
             else:
                 # ratio=128: attend to all compressed positions
@@ -1309,10 +969,9 @@ class CompressedSparseAttention(FleetLayer):
                     b,
                     sq,
                     offset,
+                    attn_mask_startend_row_indices,
                 )
 
-            if compress_topk_idxs.dtype != window_idxs.dtype:
-                compress_topk_idxs = compress_topk_idxs.cast(window_idxs.dtype)
             topk_idxs = paddle.concat(
                 [window_idxs, compress_topk_idxs], axis=-1
             )
@@ -1322,52 +981,16 @@ class CompressedSparseAttention(FleetLayer):
         topk_idxs = topk_idxs.cast("int32")
 
         # Step 5: Sparse attention
-        output = self.compressed_sparse_attn(
+        output = unfused_compressed_sparse_attn(
             query,
             kv_full,
-            self.attn_sink,
+            self.attn_sink.cast("float32"),
             topk_idxs,
             self.softmax_scale,
         )
 
         # Step 6: Attach indexer loss
-        if tilelang_indexer_loss_state is not None and self.training:
-            output = TileLangCSAIndexerLossAutoScaler.apply(
-                output,
-                *tilelang_indexer_loss_state,
-            )
-        elif indexer_loss is not None and self.training:
+        if indexer_loss is not None and self.training:
             output = DSAIndexerLossAutoScaler.apply(output, indexer_loss)
 
-        return output
-
-    def compressed_sparse_attn(
-        self,
-        query: Tensor,
-        kv_full: Tensor,
-        attn_sink: Tensor,
-        topk_idxs: Tensor,
-        softmax_scale: float,
-    ):
-        if _resolve_csa_tilelang_switch(
-            self.config,
-            "csa_tilelang_enable_sparse_attn",
-        ):
-            from paddlefleet.tilelang_ops import csa_sparse_attn
-
-            output = csa_sparse_attn(
-                query,
-                kv_full,
-                attn_sink.cast("float32"),
-                topk_idxs,
-                softmax_scale,
-            )
-        else:
-            output = unfused_compressed_sparse_attn(
-                query,
-                kv_full,
-                attn_sink.cast("float32"),
-                topk_idxs,
-                softmax_scale,
-            )
         return output

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -776,6 +776,9 @@ class CompressedSparseAttention(FleetLayer):
         pg_collection: ProcessGroupCollection = None,
         rotary_pos_emb: nn.Layer = None,
         compress_ratio: int = 0,
+        is_mtp_layer: bool = False,
+        is_swa: bool = False,
+        **kwargs,
     ):
         super().__init__(config)
         self.config = config

--- a/src/paddlefleet/transformer/dsa_attention.py
+++ b/src/paddlefleet/transformer/dsa_attention.py
@@ -25,6 +25,7 @@ This module provides:
 from __future__ import annotations
 
 import logging
+import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -57,6 +58,60 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+def _dsv4_torch_dsa_grad_k(grad_scores: Tensor, q: Tensor) -> Tensor | None:
+    if os.environ.get("DSV4_FLEET_DSA_INDEXER_GRAD_K_TORCH_BWD", "0") != "1":
+        return None
+    site_packages = os.environ.get("DSV4_FLEET_TE_SITE_PACKAGES", "")
+    if site_packages and site_packages not in os.sys.path:
+        os.sys.path.insert(0, site_packages)
+    import torch
+    import torch.utils.dlpack
+
+    grad_scores_t = torch.utils.dlpack.from_dlpack(
+        paddle.utils.dlpack.to_dlpack(grad_scores)
+    )
+    q_t = torch.utils.dlpack.from_dlpack(paddle.utils.dlpack.to_dlpack(q))
+    grad_k_t = torch.einsum(
+        "sbht,sbhd->tbd", grad_scores_t, q_t.to(dtype=torch.float32)
+    ).to(dtype=q_t.dtype)
+    return paddle.utils.dlpack.from_dlpack(torch.utils.dlpack.to_dlpack(grad_k_t))
+
+
+def _dsv4_import_torch_for_hadamard():
+    site_packages = os.environ.get(
+        "DSV4_FLEET_HADAMARD_TORCH_SITE_PACKAGES",
+        os.environ.get("DSV4_FLEET_TE_SITE_PACKAGES", ""),
+    )
+    if site_packages and site_packages not in os.sys.path:
+        os.sys.path.insert(0, site_packages)
+    import torch
+    import torch.utils.dlpack
+    from fast_hadamard_transform import hadamard_transform as torch_hadamard_transform
+
+    return torch, torch_hadamard_transform
+
+
+class _DSV4TorchHadamard(paddle.autograd.PyLayer):
+    @staticmethod
+    def forward(ctx, x: Tensor, scale_tensor: Tensor):
+        scale = float(scale_tensor.item())
+        ctx.scale = scale
+        torch, torch_hadamard_transform = _dsv4_import_torch_for_hadamard()
+        x_t = torch.utils.dlpack.from_dlpack(
+            paddle.utils.dlpack.to_dlpack(x.contiguous())
+        )
+        y_t = torch_hadamard_transform(x_t, scale=scale)
+        return paddle.utils.dlpack.from_dlpack(torch.utils.dlpack.to_dlpack(y_t.contiguous()))
+
+    @staticmethod
+    def backward(ctx, grad_output: Tensor):
+        torch, torch_hadamard_transform = _dsv4_import_torch_for_hadamard()
+        grad_t = torch.utils.dlpack.from_dlpack(
+            paddle.utils.dlpack.to_dlpack(grad_output.contiguous())
+        )
+        grad_x_t = torch_hadamard_transform(grad_t, scale=ctx.scale)
+        return paddle.utils.dlpack.from_dlpack(torch.utils.dlpack.to_dlpack(grad_x_t.contiguous())), None
+
 
 def hadamard_transform(x: Tensor, scale: float = 1.0) -> Tensor:
     """Fast Walsh-Hadamard Transform using the butterfly algorithm.
@@ -85,6 +140,10 @@ def hadamard_transform(x: Tensor, scale: float = 1.0) -> Tensor:
     assert dim > 0 and (dim & (dim - 1)) == 0, (
         f"hadamard_transform requires dim to be a power of 2, got {dim}"
     )
+
+    if os.environ.get("DSV4_FLEET_HADAMARD_TORCH", "0") == "1":
+        scale_tensor = paddle.to_tensor([scale], dtype="float32")
+        return _DSV4TorchHadamard.apply(x, scale_tensor)
 
     # Megatron uses fast_hadamard_transform, whose bf16 path accumulates in fp32
     # and casts back to bf16. Keep the same numeric contract here.
@@ -903,9 +962,11 @@ def _bwd_fused_indexer_loss(
         "sbht,tbd->sbhd", grad_scores, k.cast("float32")
     )  # [sq, b, h, d]
     # ∂L/∂k = einsum('sbht,sbhd->tbd', grad_scores, q)
-    grad_k = paddle.einsum(
-        "sbht,sbhd->tbd", grad_scores, q.cast("float32")
-    )  # [sk, b, d]
+    grad_k = _dsv4_torch_dsa_grad_k(grad_scores, q)
+    if grad_k is None:
+        grad_k = paddle.einsum(
+            "sbht,sbhd->tbd", grad_scores, q.cast("float32")
+        )  # [sk, b, d]
     del grad_scores
 
     return (

--- a/src/paddlefleet/transformer/dsv4_hybrid_attention.py
+++ b/src/paddlefleet/transformer/dsv4_hybrid_attention.py
@@ -25,7 +25,6 @@ Components:
 
 from __future__ import annotations
 
-import hashlib
 import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -67,29 +66,6 @@ def _dsv4_attention_split_input_branches(tensor: Tensor):
     if tensor is None or not isinstance(tensor, paddle.Tensor) or tensor.stop_gradient:
         return tensor, tensor, tensor
     return _DSV4AttentionInputBranches.apply(tensor)
-
-
-def _dsv4_register_mtp_attn_grad(name: str, tensor: Tensor, is_mtp_layer: bool) -> None:
-    if not is_mtp_layer or os.environ.get("DSV4_LOG_MTP_GRADS", "0") != "1":
-        return
-    if tensor is None or not isinstance(tensor, paddle.Tensor) or tensor.stop_gradient:
-        return
-
-    def _hook(grad: Tensor) -> None:
-        rank = (
-            paddle.distributed.get_rank()
-            if paddle.distributed.is_initialized()
-            else 0
-        )
-        if rank != int(os.environ.get("DSV4_LOSS_PATH_RANK", "0")):
-            return
-        md5 = hashlib.md5(grad.cast("float32").numpy().tobytes()).hexdigest()
-        print(
-            f"[MTP_ATTN_GRAD_MD5] rank={rank} {name}.grad shape={list(grad.shape)} md5={md5}",
-            flush=True,
-        )
-
-    tensor.register_hook(_hook)
 
 
 class _DSV4QRMSNorm(paddle.autograd.PyLayer):
@@ -273,18 +249,11 @@ class DSv4HybridAttention(Attention):
         Returns:
             (output [b, sq, hidden_size], bias=None)
         """
-        _dsv4_register_mtp_attn_grad("mtp_attn_input", hidden_states, self.is_mtp_layer)
         q_input, kv_input, core_x = _dsv4_attention_split_input_branches(hidden_states)
         # Get Q, K, V tensors
         query, key, value, q_compressed, kv_compressed = (
             self.get_query_key_value_tensors(q_input, kv_input=kv_input)
         )
-        _dsv4_register_mtp_attn_grad("mtp_attn_query", query, self.is_mtp_layer)
-        _dsv4_register_mtp_attn_grad("mtp_attn_key", key, self.is_mtp_layer)
-        _dsv4_register_mtp_attn_grad("mtp_attn_value", value, self.is_mtp_layer)
-        _dsv4_register_mtp_attn_grad("mtp_attn_q_compressed", q_compressed, self.is_mtp_layer)
-        _dsv4_register_mtp_attn_grad("mtp_attn_kv_compressed", kv_compressed, self.is_mtp_layer)
-
         # Core attention (CompressedSparseAttention)
         core_attn_out = self.core_attention(
             query,
@@ -294,7 +263,6 @@ class DSv4HybridAttention(Attention):
             x=core_x,
             qr=q_compressed,
         )
-        _dsv4_register_mtp_attn_grad("mtp_attn_core_out", core_attn_out, self.is_mtp_layer)
         # core_attn_out: [b, sq, np * v_head_dim]
 
         # Inverse RoPE on last qk_pos_emb_head_dim of each head
@@ -329,8 +297,6 @@ class DSv4HybridAttention(Attention):
             )
             core_attn_out = paddle.concat([content_part, rot_part], axis=-1)
             core_attn_out = core_attn_out.reshape([b, sq, -1])
-        _dsv4_register_mtp_attn_grad("mtp_attn_inv_rope_out", core_attn_out, self.is_mtp_layer)
-
         # Grouped output projection
         core_attn_out = core_attn_out.reshape([b, sq, self.o_local_groups, -1])
         wo_a_weight = self.linear_o_group_proj.reshape(
@@ -340,12 +306,8 @@ class DSv4HybridAttention(Attention):
             "...gd,grd->...gr", core_attn_out, wo_a_weight
         )
         core_attn_out = core_attn_out.reshape([b, sq, -1])
-        _dsv4_register_mtp_attn_grad("mtp_attn_o_group_out", core_attn_out, self.is_mtp_layer)
-
         # Output projection
-        _dsv4_register_mtp_attn_grad("mtp_attn_o_proj_input", core_attn_out, self.is_mtp_layer)
         output, bias = self.o_proj(core_attn_out)
-        _dsv4_register_mtp_attn_grad("mtp_attn_o_proj_out", output, self.is_mtp_layer)
 
         return output, bias
 
@@ -470,23 +432,15 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
         q_compressed, _ = self.linear_q_down_proj(
             hidden_states
         )  # [b, sq, q_lora_rank]
-        _dsv4_register_mtp_attn_grad("mtp_attn_q_down_out", q_compressed, self.is_mtp_layer)
         q_compressed = self.q_layernorm(q_compressed)
-        _dsv4_register_mtp_attn_grad(
-            "mtp_attn_q_layernorm_out", q_compressed, self.is_mtp_layer
-        )
 
         q, _ = self.linear_q_up_proj(q_compressed)  # [b, sq, n * v_head_dim]
-        _dsv4_register_mtp_attn_grad("mtp_attn_q_up_out", q, self.is_mtp_layer)
         q = q.reshape([b, sq, self.num_attention_heads, self.v_head_dim])
         q = _q_rms_norm(q, getattr(self.config, "rms_norm_eps", 1e-5))
-        _dsv4_register_mtp_attn_grad("mtp_attn_q_rms_out", q, self.is_mtp_layer)
 
         # KV path
         kv, _ = self.linear_kv_proj(kv_hidden_states)  # [b, sq, v_head_dim]
-        _dsv4_register_mtp_attn_grad("mtp_attn_kv_proj_out", kv, self.is_mtp_layer)
         kv = self.kv_layernorm(kv)
-        _dsv4_register_mtp_attn_grad("mtp_attn_kv_norm_out", kv, self.is_mtp_layer)
 
         # Apply RoPE to both Q and KV
         pos_dim = self.qk_pos_emb_head_dim

--- a/src/paddlefleet/transformer/dsv4_hybrid_attention.py
+++ b/src/paddlefleet/transformer/dsv4_hybrid_attention.py
@@ -25,6 +25,7 @@ Components:
 
 from __future__ import annotations
 
+import hashlib
 import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -66,6 +67,29 @@ def _dsv4_attention_split_input_branches(tensor: Tensor):
     if tensor is None or not isinstance(tensor, paddle.Tensor) or tensor.stop_gradient:
         return tensor, tensor, tensor
     return _DSV4AttentionInputBranches.apply(tensor)
+
+
+def _dsv4_register_mtp_attn_grad(name: str, tensor: Tensor, is_mtp_layer: bool) -> None:
+    if not is_mtp_layer or os.environ.get("DSV4_LOG_MTP_GRADS", "0") != "1":
+        return
+    if tensor is None or not isinstance(tensor, paddle.Tensor) or tensor.stop_gradient:
+        return
+
+    def _hook(grad: Tensor) -> None:
+        rank = (
+            paddle.distributed.get_rank()
+            if paddle.distributed.is_initialized()
+            else 0
+        )
+        if rank != int(os.environ.get("DSV4_LOSS_PATH_RANK", "0")):
+            return
+        md5 = hashlib.md5(grad.cast("float32").numpy().tobytes()).hexdigest()
+        print(
+            f"[MTP_ATTN_GRAD_MD5] rank={rank} {name}.grad shape={list(grad.shape)} md5={md5}",
+            flush=True,
+        )
+
+    tensor.register_hook(_hook)
 
 
 class _DSV4QRMSNorm(paddle.autograd.PyLayer):
@@ -249,11 +273,17 @@ class DSv4HybridAttention(Attention):
         Returns:
             (output [b, sq, hidden_size], bias=None)
         """
+        _dsv4_register_mtp_attn_grad("mtp_attn_input", hidden_states, self.is_mtp_layer)
         q_input, kv_input, core_x = _dsv4_attention_split_input_branches(hidden_states)
         # Get Q, K, V tensors
         query, key, value, q_compressed, kv_compressed = (
             self.get_query_key_value_tensors(q_input, kv_input=kv_input)
         )
+        _dsv4_register_mtp_attn_grad("mtp_attn_query", query, self.is_mtp_layer)
+        _dsv4_register_mtp_attn_grad("mtp_attn_key", key, self.is_mtp_layer)
+        _dsv4_register_mtp_attn_grad("mtp_attn_value", value, self.is_mtp_layer)
+        _dsv4_register_mtp_attn_grad("mtp_attn_q_compressed", q_compressed, self.is_mtp_layer)
+        _dsv4_register_mtp_attn_grad("mtp_attn_kv_compressed", kv_compressed, self.is_mtp_layer)
 
         # Core attention (CompressedSparseAttention)
         core_attn_out = self.core_attention(
@@ -264,6 +294,7 @@ class DSv4HybridAttention(Attention):
             x=core_x,
             qr=q_compressed,
         )
+        _dsv4_register_mtp_attn_grad("mtp_attn_core_out", core_attn_out, self.is_mtp_layer)
         # core_attn_out: [b, sq, np * v_head_dim]
 
         # Inverse RoPE on last qk_pos_emb_head_dim of each head
@@ -298,6 +329,7 @@ class DSv4HybridAttention(Attention):
             )
             core_attn_out = paddle.concat([content_part, rot_part], axis=-1)
             core_attn_out = core_attn_out.reshape([b, sq, -1])
+        _dsv4_register_mtp_attn_grad("mtp_attn_inv_rope_out", core_attn_out, self.is_mtp_layer)
 
         # Grouped output projection
         core_attn_out = core_attn_out.reshape([b, sq, self.o_local_groups, -1])
@@ -308,9 +340,12 @@ class DSv4HybridAttention(Attention):
             "...gd,grd->...gr", core_attn_out, wo_a_weight
         )
         core_attn_out = core_attn_out.reshape([b, sq, -1])
+        _dsv4_register_mtp_attn_grad("mtp_attn_o_group_out", core_attn_out, self.is_mtp_layer)
 
         # Output projection
+        _dsv4_register_mtp_attn_grad("mtp_attn_o_proj_input", core_attn_out, self.is_mtp_layer)
         output, bias = self.o_proj(core_attn_out)
+        _dsv4_register_mtp_attn_grad("mtp_attn_o_proj_out", output, self.is_mtp_layer)
 
         return output, bias
 
@@ -435,15 +470,23 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
         q_compressed, _ = self.linear_q_down_proj(
             hidden_states
         )  # [b, sq, q_lora_rank]
+        _dsv4_register_mtp_attn_grad("mtp_attn_q_down_out", q_compressed, self.is_mtp_layer)
         q_compressed = self.q_layernorm(q_compressed)
+        _dsv4_register_mtp_attn_grad(
+            "mtp_attn_q_layernorm_out", q_compressed, self.is_mtp_layer
+        )
 
         q, _ = self.linear_q_up_proj(q_compressed)  # [b, sq, n * v_head_dim]
+        _dsv4_register_mtp_attn_grad("mtp_attn_q_up_out", q, self.is_mtp_layer)
         q = q.reshape([b, sq, self.num_attention_heads, self.v_head_dim])
         q = _q_rms_norm(q, getattr(self.config, "rms_norm_eps", 1e-5))
+        _dsv4_register_mtp_attn_grad("mtp_attn_q_rms_out", q, self.is_mtp_layer)
 
         # KV path
         kv, _ = self.linear_kv_proj(kv_hidden_states)  # [b, sq, v_head_dim]
+        _dsv4_register_mtp_attn_grad("mtp_attn_kv_proj_out", kv, self.is_mtp_layer)
         kv = self.kv_layernorm(kv)
+        _dsv4_register_mtp_attn_grad("mtp_attn_kv_norm_out", kv, self.is_mtp_layer)
 
         # Apply RoPE to both Q and KV
         pos_dim = self.qk_pos_emb_head_dim

--- a/src/paddlefleet/transformer/dsv4_hybrid_attention.py
+++ b/src/paddlefleet/transformer/dsv4_hybrid_attention.py
@@ -25,6 +25,7 @@ Components:
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -49,9 +50,45 @@ if TYPE_CHECKING:
     from paddlefleet.transformer.transformer_config import TransformerConfig
 
 
+class _DSV4AttentionInputBranches(paddle.autograd.PyLayer):
+    @staticmethod
+    def forward(ctx, x: Tensor):
+        return x.clone(), x.clone(), x.clone()
+
+    @staticmethod
+    def backward(ctx, q_grad: Tensor, kv_grad: Tensor, core_x_grad: Tensor):
+        return (q_grad + kv_grad) + core_x_grad
+
+
+def _dsv4_attention_split_input_branches(tensor: Tensor):
+    if os.environ.get("DSV4_FLEET_ATTN_INPUT_ORDER", "0") != "1":
+        return tensor, tensor, tensor
+    if tensor is None or not isinstance(tensor, paddle.Tensor) or tensor.stop_gradient:
+        return tensor, tensor, tensor
+    return _DSV4AttentionInputBranches.apply(tensor)
+
+
+class _DSV4QRMSNorm(paddle.autograd.PyLayer):
+    @staticmethod
+    def forward(ctx, q: Tensor, eps: float) -> Tensor:
+        r = paddle.rsqrt(q.square().mean(axis=-1, keepdim=True) + eps)
+        ctx.save_for_backward(q, r)
+        return q * r
+
+    @staticmethod
+    def backward(ctx, grad_output: Tensor):
+        q, r = ctx.saved_tensor()
+        hidden_size = q.shape[-1]
+        grad_r = (grad_output * q).sum(axis=-1, keepdim=True)
+        grad_q = grad_output * r
+        grad_add = grad_r * (-0.5) * (r * r * r)
+        grad_q = grad_q + (paddle.full_like(q, 2.0) * q) * (grad_add / hidden_size)
+        return grad_q
+
+
 def _q_rms_norm(q: Tensor, eps: float) -> Tensor:
     """RMS normalization for query (no learnable weight)."""
-    return q * paddle.rsqrt(q.square().mean(-1, keepdim=True) + eps)
+    return _DSV4QRMSNorm.apply(q, eps)
 
 
 # ---------------------------------------------------------------------------
@@ -212,9 +249,10 @@ class DSv4HybridAttention(Attention):
         Returns:
             (output [b, sq, hidden_size], bias=None)
         """
+        q_input, kv_input, core_x = _dsv4_attention_split_input_branches(hidden_states)
         # Get Q, K, V tensors
         query, key, value, q_compressed, kv_compressed = (
-            self.get_query_key_value_tensors(hidden_states)
+            self.get_query_key_value_tensors(q_input, kv_input=kv_input)
         )
 
         # Core attention (CompressedSparseAttention)
@@ -223,7 +261,7 @@ class DSv4HybridAttention(Attention):
             key,
             value,
             attention_mask,
-            x=hidden_states,
+            x=core_x,
             qr=q_compressed,
         )
         # core_attn_out: [b, sq, np * v_head_dim]
@@ -376,7 +414,7 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
         )
 
     def get_query_key_value_tensors(
-        self, hidden_states: Tensor
+        self, hidden_states: Tensor, kv_input: Tensor | None = None
     ) -> tuple[Tensor, Tensor, Tensor, Tensor, Tensor]:
         """Derive query, key, value from hidden_states.
 
@@ -391,6 +429,7 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
             kv_compressed: [b, sq, hidden_size] (== hidden_states)
         """
         b, sq, _ = hidden_states.shape
+        kv_hidden_states = hidden_states if kv_input is None else kv_input
 
         # Q path
         q_compressed, _ = self.linear_q_down_proj(
@@ -403,7 +442,7 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
         q = _q_rms_norm(q, getattr(self.config, "rms_norm_eps", 1e-5))
 
         # KV path
-        kv, _ = self.linear_kv_proj(hidden_states)  # [b, sq, v_head_dim]
+        kv, _ = self.linear_kv_proj(kv_hidden_states)  # [b, sq, v_head_dim]
         kv = self.kv_layernorm(kv)
 
         # Apply RoPE to both Q and KV

--- a/src/paddlefleet/transformer/hyper_connection.py
+++ b/src/paddlefleet/transformer/hyper_connection.py
@@ -37,185 +37,6 @@ if TYPE_CHECKING:
     from paddlefleet.transformer.transformer_config import TransformerConfig
 
 
-_DSV4_HC_COMPONENT_STORE: dict[str, dict[str, Tensor]] = {}
-
-
-def _dsv4_log_loss_path_tensor(name: str, tensor: Tensor) -> None:
-    if (
-        os.environ.get("LOG_LAYER_MD5", "0") != "1"
-        and os.environ.get("LOG_LOSS_MD5", "0") != "1"
-    ):
-        return
-    if tensor is None:
-        return
-    import hashlib
-
-    rank = paddle.distributed.get_rank()
-    md5 = hashlib.md5(tensor.cast("float32").numpy().tobytes()).hexdigest()
-    print(
-        f"[LOSS_PATH_MD5] rank={rank} {name} shape={list(tensor.shape)} md5={md5}",
-        flush=True,
-    )
-
-
-def _dsv4_log_contract_grad(name: str, tensor: Tensor) -> None:
-    if os.environ.get("DSV4_LOG_CONTRACT_GRADS", "0") != "1":
-        return
-    _dsv4_log_loss_path_tensor(f"{name}.grad", tensor)
-
-
-def _dsv4_register_contract_grad(name: str, tensor: Tensor) -> None:
-    if os.environ.get("DSV4_LOG_CONTRACT_GRADS", "0") != "1":
-        return
-    if tensor is None or tensor.stop_gradient:
-        return
-
-    def _hook(grad: Tensor):
-        _dsv4_log_contract_grad(name, grad)
-
-    tensor.register_hook(_hook)
-
-
-def _dsv4_register_contract_split_grad(name: str, tensor: Tensor, parts: int) -> None:
-    if os.environ.get("DSV4_LOG_CONTRACT_GRADS", "0") != "1":
-        return
-    if tensor is None or tensor.stop_gradient:
-        return
-
-    def _hook(grad: Tensor):
-        _dsv4_log_contract_grad(name, grad)
-        for idx, grad_chunk in enumerate(paddle.split(grad, parts)):
-            _dsv4_log_contract_grad(f"{name}_chunk{idx}", grad_chunk)
-
-    tensor.register_hook(_hook)
-
-
-def _dsv4_register_hc_grad(name: str, tensor: Tensor) -> None:
-    if os.environ.get("DSV4_LOG_HC_GRADS", "0") != "1":
-        return
-    if tensor is None or tensor.stop_gradient:
-        return
-
-    def _hook(grad: Tensor):
-        import hashlib
-
-        rank = paddle.distributed.get_rank()
-        if rank != int(os.environ.get("DSV4_LOSS_PATH_RANK", "0")):
-            return
-        md5 = hashlib.md5(grad.cast("float32").numpy().tobytes()).hexdigest()
-        print(
-            f"[HC_GRAD_MD5] rank={rank} {name}.grad shape={list(grad.shape)} md5={md5}",
-            flush=True,
-        )
-
-    tensor.register_hook(_hook)
-
-
-def _dsv4_log_hc_component_grad(name: str, tensor: Tensor) -> None:
-    if os.environ.get("DSV4_LOG_HC_COMPONENT_GRADS", "0") != "1":
-        return
-    import hashlib
-
-    rank = paddle.distributed.get_rank()
-    if rank != int(os.environ.get("DSV4_LOSS_PATH_RANK", "0")):
-        return
-    md5 = hashlib.md5(tensor.cast("float32").numpy().tobytes()).hexdigest()
-    print(
-        f"[HC_COMPONENT_GRAD_MD5] rank={rank} {name}.grad shape={list(tensor.shape)} md5={md5}",
-        flush=True,
-    )
-
-
-def _dsv4_store_hc_component_grad(name: str, kind: str, tensor: Tensor) -> None:
-    if os.environ.get("DSV4_LOG_HC_COMPONENT_GRADS", "0") != "1" or not name:
-        return
-    entry = _DSV4_HC_COMPONENT_STORE.setdefault(name, {})
-    entry[kind] = tensor
-    if "proj" not in entry or "r" not in entry:
-        return
-    proj_grad = entry.pop("proj")
-    r_grad = entry.pop("r")
-    if not entry:
-        _DSV4_HC_COMPONENT_STORE.pop(name, None)
-    _dsv4_log_hc_component_grad(
-        f"{name}_mapping_input_manual_proj_r",
-        proj_grad + r_grad,
-    )
-    _dsv4_log_hc_component_grad(
-        f"{name}_mapping_input_manual_r_proj",
-        r_grad + proj_grad,
-    )
-
-
-def _dsv4_log_torch_contract_probe(
-    hidden_states: Tensor,
-    head_fn_out_in: Tensor,
-    base: Tensor,
-    scale: Tensor,
-    n: int,
-    eps: float,
-    out_dtype,
-) -> None:
-    if os.environ.get("DSV4_FLEET_CONTRACT_TORCH_PROBE", "0") != "1":
-        return
-    if (
-        os.environ.get("LOG_LAYER_MD5", "0") != "1"
-        and os.environ.get("LOG_LOSS_MD5", "0") != "1"
-    ):
-        return
-
-    torch_site_packages = os.environ.get(
-        "DSV4_FLEET_CONTRACT_TORCH_SITE_PACKAGES",
-        os.environ.get("DSV4_FLEET_TE_SITE_PACKAGES", ""),
-    )
-    if torch_site_packages:
-        import sys
-
-        if torch_site_packages not in sys.path:
-            sys.path.insert(0, torch_site_packages)
-    import hashlib
-    import torch
-    import torch.nn.functional as torch_F
-    import torch.utils.dlpack
-    from paddle.utils import dlpack as paddle_dlpack
-
-    def to_torch(tensor: Tensor):
-        return torch.utils.dlpack.from_dlpack(
-            paddle_dlpack.to_dlpack(tensor.contiguous())
-        )
-
-    def log_torch(name: str, tensor):
-        data = tensor.detach().to(torch.float32).contiguous().cpu().numpy().tobytes()
-        md5 = hashlib.md5(data).hexdigest()
-        rank = paddle.distributed.get_rank()
-        print(
-            f"[LOSS_PATH_MD5] rank={rank} {name} shape={list(tensor.shape)} md5={md5}",
-            flush=True,
-        )
-
-    hidden_t = to_torch(hidden_states)
-    head_t = to_torch(head_fn_out_in)
-    base_t = to_torch(base)
-    scale_t = to_torch(scale)
-    torch_dtype = torch.bfloat16 if str(out_dtype) == "paddle.bfloat16" else hidden_t.dtype
-    with torch.no_grad():
-        rsqrt_t = torch.rsqrt(hidden_t.square().mean(-1, keepdim=True) + eps)
-        proj_t = torch_F.linear(hidden_t, head_t)
-        mixes_t = proj_t * rsqrt_t
-        pre_t = torch.sigmoid(mixes_t * scale_t + base_t) + eps
-        y_t = torch.sum(
-            pre_t.unsqueeze(-1) * hidden_t.reshape(*hidden_t.shape[:-1], n, -1),
-            dim=-2,
-        )
-        out_t = y_t.to(torch_dtype)
-    log_torch("final_contract_torch_probe_head_fn_out_in", head_t)
-    log_torch("final_contract_torch_probe_proj", proj_t)
-    log_torch("final_contract_torch_probe_mixes", mixes_t)
-    log_torch("final_contract_torch_probe_pre", pre_t)
-    log_torch("final_contract_torch_probe_y_float32", y_t)
-    log_torch("final_contract_torch_probe_main_output", out_t)
-
-
 def _dsv4_torch_contract_forward(
     hidden_states: Tensor,
     head_fn_out_in: Tensor,
@@ -335,33 +156,6 @@ def _dsv4_torch_contract_backward(
         out_t = y_t.to(hidden_input_t.dtype)
         out_t.backward(grad_t)
 
-    if os.environ.get("DSV4_FLEET_CONTRACT_TORCH_BWD_CAST_PROBE", "0") == "1":
-        import hashlib
-
-        rank = paddle.distributed.get_rank()
-
-        def log_torch(name: str, tensor):
-            data = tensor.detach().to(torch.float32).contiguous().cpu().numpy().tobytes()
-            md5 = hashlib.md5(data).hexdigest()
-            print(
-                f"[LOSS_PATH_MD5] rank={rank} {name} shape={list(tensor.shape)} md5={md5}",
-                flush=True,
-            )
-
-        manual_cast = hidden_t.grad.to(hidden_input_t.dtype)
-        log_torch("final_contract_hidden_fp32_manual_bf16_cast.grad", manual_cast)
-        if hidden_t.grad.ndim >= 3 and hidden_t.grad.shape[0] == 1:
-            megatron_shape_cast = (
-                hidden_t.grad.transpose(0, 1)
-                .contiguous()
-                .to(hidden_input_t.dtype)
-            )
-            log_torch(
-                "final_contract_hidden_fp32_megatron_shape_bf16_cast.grad",
-                megatron_shape_cast,
-            )
-        log_torch("final_contract_hidden_input_leaf.grad", hidden_input_t.grad)
-
     return (
         to_paddle(hidden_t.grad),
         to_paddle(hidden_input_t.grad),
@@ -413,14 +207,13 @@ def _dsv4_hc_sinkhorn_torch_backward(
 
 class _DSV4HCTorchOrderRmsScale(paddle.autograd.PyLayer):
     @staticmethod
-    def forward(ctx, x: Tensor, eps: float, debug_name: str = ""):
+    def forward(ctx, x: Tensor, eps: float):
         nC = x.shape[-1]
         norm = x.norm(axis=-1, keepdim=True)
         r = 1.0 / (norm / math.sqrt(nC) + eps)
         r = r.astype(x.dtype)
         ctx.nC = nC
         ctx.eps = eps
-        ctx.debug_name = debug_name
         ctx.save_for_backward(x, norm, r)
         return r
 
@@ -459,11 +252,6 @@ class _DSV4HCTorchOrderRmsScale(paddle.autograd.PyLayer):
                 r_t = 1.0 / (norm_t / math.sqrt(ctx.nC) + ctx.eps)
                 r_t.backward(grad_t)
             grad_x = to_paddle(x_t.grad).astype(x.dtype)
-            if ctx.debug_name:
-                _dsv4_log_hc_component_grad(
-                    f"{ctx.debug_name}_r_input_manual", grad_x
-                )
-                _dsv4_store_hc_component_grad(ctx.debug_name, "r", grad_x)
             return grad_x
         # Match Torch norm + reciprocal backward source-order in BF16.
         scaled = grad * (r * r)
@@ -477,11 +265,6 @@ class _DSV4HCTorchOrderRmsScale(paddle.autograd.PyLayer):
         torch_zero = paddle.where(x == 0, -paddle.ones_like(unit) * zero, (-unit) * zero)
         grad_x = paddle.where(scaled == 0, torch_zero, grad_x)
         grad_x = grad_x.astype(x.dtype)
-        if ctx.debug_name:
-            _dsv4_log_hc_component_grad(
-                f"{ctx.debug_name}_r_input_manual", grad_x
-            )
-            _dsv4_store_hc_component_grad(ctx.debug_name, "r", grad_x)
         return grad_x
 
 
@@ -803,7 +586,6 @@ class _DSV4LearnedOutputContract(paddle.autograd.PyLayer):
         hdim = hidden_fp32.shape[-1]
         hidden_streams = hidden_fp32.reshape([*hidden_fp32.shape[:-1], n, -1])
         grad_y = grad_output.astype("float32")
-        _dsv4_log_contract_grad("final_contract_main_output", grad_output)
         torch_grads = _dsv4_torch_contract_backward(
             hidden_input,
             head_fn_input,
@@ -815,12 +597,6 @@ class _DSV4LearnedOutputContract(paddle.autograd.PyLayer):
         )
         if torch_grads is not None:
             grad_hidden, grad_hidden_out, grad_head_fn_out, grad_base_out, grad_scale_out = torch_grads
-
-            _dsv4_log_contract_grad("final_contract_hidden_fp32", grad_hidden)
-            _dsv4_log_contract_grad("final_contract_input", grad_hidden_out)
-            _dsv4_log_contract_grad("final_contract_head_fn", grad_head_fn_out)
-            _dsv4_log_contract_grad("final_contract_base", grad_base_out)
-            _dsv4_log_contract_grad("final_contract_scale", grad_scale_out)
 
             return (
                 grad_hidden_out,
@@ -863,12 +639,6 @@ class _DSV4LearnedOutputContract(paddle.autograd.PyLayer):
         grad_head_fn_out = grad_head_fn.astype(ctx.head_fn_dtype)
         grad_base_out = grad_base.astype(ctx.base_dtype)
         grad_scale_out = grad_scale.astype(ctx.scale_dtype)
-
-        _dsv4_log_contract_grad("final_contract_hidden_fp32", grad_hidden)
-        _dsv4_log_contract_grad("final_contract_input", grad_hidden_out)
-        _dsv4_log_contract_grad("final_contract_head_fn", grad_head_fn_out)
-        _dsv4_log_contract_grad("final_contract_base", grad_base_out)
-        _dsv4_log_contract_grad("final_contract_scale", grad_scale_out)
 
         return (
             grad_hidden_out,
@@ -1081,34 +851,13 @@ class HyperConnectionModule(nn.Layer):
             x: [..., n*C] - n-stream hidden states
         """
         nC = x.shape[-1]
-        debug_name = getattr(self, "_dsv4_debug_name", "")
         weight = self.mapping_proj.weight
         x_2d = x.reshape([-1, nC])
-        r = _DSV4HCTorchOrderRmsScale.apply(
-            x_2d, self.norm_eps, debug_name
-        )
+        r = _DSV4HCTorchOrderRmsScale.apply(x_2d, self.norm_eps)
         # Match Megatron clean path: torch.matmul(x, weight.t()).  Paddle
         # nn.Linear uses a different BF16 cuBLAS path for this shape and drifts
         # before the first HC BDA.
         proj_2d = paddle.matmul(x_2d, weight.t(), transpose_y=True)
-        if (
-            os.environ.get("DSV4_LOG_HC_COMPONENT_GRADS", "0") == "1"
-            and debug_name
-            and not proj_2d.stop_gradient
-        ):
-
-            def _proj_hook(grad: Tensor) -> None:
-                grad_x = paddle.matmul(
-                    grad.astype(x_2d.dtype),
-                    weight.astype(x_2d.dtype),
-                    transpose_y=True,
-                )
-                _dsv4_log_hc_component_grad(
-                    f"{debug_name}_proj_input_manual", grad_x
-                )
-                _dsv4_store_hc_component_grad(debug_name, "proj", grad_x)
-
-            proj_2d.register_hook(_proj_hook)
         proj = proj_2d.reshape([*x.shape[:-1], weight.shape[-1]])
         return proj, r.reshape([*x.shape[:-1], 1])
 
@@ -1161,21 +910,14 @@ class HyperConnectionModule(nn.Layer):
             h_res: [..., n, n] - residual mixing matrix (doubly stochastic)
         """
         leading_shape = x.shape[:-1]
-        debug_name = getattr(self, "_dsv4_debug_name", "")
         proj, r = self._projection_and_get_norm(x)
-        _dsv4_register_hc_grad(f"{debug_name}_proj", proj)
-        _dsv4_register_hc_grad(f"{debug_name}_r", r)
         h_pre, h_post, h_res = self._compute_h(proj, r)
-        _dsv4_register_hc_grad(f"{debug_name}_h_pre", h_pre)
-        _dsv4_register_hc_grad(f"{debug_name}_h_post_pre_sinkhorn", h_post)
-        _dsv4_register_hc_grad(f"{debug_name}_h_res_logits", h_res)
         h_res_logits = h_res
         h_res_logits_view = h_res_logits.reshape([*leading_shape, self.n, self.n])
         h_res = SinkhornKnopp.apply(
             h_res_logits_view,
             self.sinkhorn_iterations,
         )  # [..., n, n]
-        _dsv4_register_hc_grad(f"{debug_name}_h_res", h_res)
 
         return h_pre, h_post, h_res
 
@@ -1200,23 +942,6 @@ class HyperConnectionModule(nn.Layer):
 
         # Weighted sum: [..., n, C] * [..., n, 1] -> sum over n -> [..., C]
         aggregated = (x_streams * h_pre.unsqueeze(-1)).sum(axis=-2)
-        debug_name = getattr(self, "_dsv4_debug_name", "")
-        if (
-            os.environ.get("DSV4_LOG_HC_COMPONENT_GRADS", "0") == "1"
-            and debug_name
-            and not aggregated.stop_gradient
-        ):
-
-            def _aggregate_hook(grad: Tensor) -> None:
-                grad_x = (
-                    grad.astype(x.dtype).unsqueeze(-2)
-                    * h_pre.astype(x.dtype).unsqueeze(-1)
-                ).reshape(x.shape)
-                _dsv4_log_hc_component_grad(
-                    f"{debug_name}_aggregate_input_manual", grad_x
-                )
-
-            aggregated.register_hook(_aggregate_hook)
         if aggregated.dtype != x.dtype:
             aggregated = aggregated.astype(x.dtype)
 
@@ -1322,23 +1047,10 @@ class HyperConnectionModule(nn.Layer):
             h_res: [..., n, n] - residual mixing matrix (for fused kernel)
             h_post: [..., n] - expansion weights
         """
-        debug_name = getattr(self, "_dsv4_debug_name", "")
         if os.environ.get("DSV4_FLEET_HC_INPUT_BRANCH_SPLIT", "0") == "1":
             mapping_input, aggregate_input = _DSV4HCInputBranchSplit.apply(
                 hidden_states
             )
-            if os.environ.get("DSV4_LOG_HC_BRANCH_GRADS", "0") == "1":
-                _dsv4_register_hc_grad(
-                    f"{debug_name}_mapping_input", mapping_input
-                )
-                _dsv4_register_hc_grad(
-                    f"{debug_name}_aggregate_input", aggregate_input
-                )
-        elif os.environ.get("DSV4_LOG_HC_BRANCH_GRADS", "0") == "1":
-            mapping_input = hidden_states.reshape(hidden_states.shape)
-            aggregate_input = hidden_states.reshape(hidden_states.shape)
-            _dsv4_register_hc_grad(f"{debug_name}_mapping_input", mapping_input)
-            _dsv4_register_hc_grad(f"{debug_name}_aggregate_input", aggregate_input)
         else:
             mapping_input = hidden_states
             aggregate_input = hidden_states
@@ -1348,7 +1060,6 @@ class HyperConnectionModule(nn.Layer):
 
         # Aggregate for layer input
         aggregated = self.aggregate(aggregate_input, h_pre)
-        _dsv4_register_hc_grad(f"{debug_name}_aggregated", aggregated)
 
         return aggregated, h_res, h_post
 
@@ -1422,10 +1133,6 @@ class HyperConnectionModule(nn.Layer):
         Returns:
             contracted: [..., h] single-stream output
         """
-        _dsv4_register_contract_grad("final_contract_input_total", hidden_states)
-        _dsv4_register_contract_grad("final_contract_head_fn_total", head_fn)
-        _dsv4_register_contract_grad("final_contract_base_total", base)
-        _dsv4_register_contract_grad("final_contract_scale_total", scale)
         if (
             os.environ.get("DSV4_FLEET_CONTRACT_CUSTOM_BWD", "0") == "1"
             or os.environ.get("DSV4_FLEET_CONTRACT_TORCH_FORWARD", "0") == "1"
@@ -1444,10 +1151,6 @@ class HyperConnectionModule(nn.Layer):
         head_fn = head_fn.astype("float32")
         base = base.astype("float32")
         scale = scale.astype("float32")
-        _dsv4_log_loss_path_tensor("final_contract_hidden_fp32", hidden_states)
-        _dsv4_log_loss_path_tensor("final_contract_head_fn", head_fn)
-        _dsv4_log_loss_path_tensor("final_contract_base", base)
-        _dsv4_log_loss_path_tensor("final_contract_scale", scale)
         hidden_for_rsqrt = hidden_states
         hidden_for_proj = hidden_states
         hidden_for_direct = hidden_states
@@ -1459,34 +1162,19 @@ class HyperConnectionModule(nn.Layer):
         rsqrt = paddle.rsqrt(
             hidden_for_rsqrt.square().mean(-1, keepdim=True) + eps
         )
-        _dsv4_log_loss_path_tensor("final_contract_rsqrt", rsqrt)
         # Match Torch F.linear(x, weight[out,in]) kernel selection. Paddle
         # F.linear(x, weight[in,out]) uses a different cuBLAS path and causes
         # BF16 ulp drift in DSv4 final output contraction.
         head_fn_out_in = head_fn.transpose([1, 0]).contiguous()
-        _dsv4_log_loss_path_tensor("final_contract_head_fn_out_in", head_fn_out_in)
-        _dsv4_log_torch_contract_probe(
-            hidden_for_proj,
-            head_fn_out_in,
-            base,
-            scale,
-            n,
-            eps,
-            dtype,
-        )
         with paddle.amp.auto_cast(False):
             proj = paddle.matmul(hidden_for_proj, head_fn_out_in, transpose_y=True)
         mixes = proj * rsqrt
-        _dsv4_log_loss_path_tensor("final_contract_mixes", mixes)
         pre_arg = mixes * scale + base
         pre = F.sigmoid(pre_arg) + eps
-        _dsv4_log_loss_path_tensor("final_contract_pre", pre)
         hidden_streams = hidden_for_direct.reshape([*hidden_for_direct.shape[:-1], n, -1])
         contract_prod = pre.unsqueeze(-1) * hidden_streams
         y = paddle.sum(contract_prod, axis=-2)
-        _dsv4_log_loss_path_tensor("final_contract_y_float32", y)
         out = y.astype(dtype)
-        _dsv4_log_loss_path_tensor("final_contract_main_output", out)
         return out
 
     # ==================== Fused kernel placeholder ====================
@@ -1539,36 +1227,6 @@ class HyperConnectionModule(nn.Layer):
                 self.n,
                 self.hidden_size,
             )
-
-        if (
-            os.environ.get("DSV4_LOG_HC_BDA_GRADS", "0") == "1"
-            and bias is None
-            and (dropout_prob == 0.0 or not training)
-        ):
-            debug_name = getattr(self, "_dsv4_debug_name", "")
-            leading_shape = original_residual.shape[:-1]
-            num_tokens = math.prod(leading_shape)
-            h_res_cast = h_res.astype(original_residual.dtype)
-            h_post_cast = h_post.astype(original_residual.dtype)
-            h_res_batched = (
-                h_res_cast.transpose([0, 1, 3, 2]).reshape(
-                    [num_tokens, self.n, self.n]
-                )
-            )
-            residual_batched = original_residual.reshape(
-                [num_tokens, self.n, self.hidden_size]
-            )
-            mixed = paddle.bmm(h_res_batched, residual_batched).reshape(
-                [*leading_shape, self.n, self.hidden_size]
-            )
-            x_expanded = h_post_cast.unsqueeze(-1) * x.unsqueeze(-2)
-            output_4d = x_expanded + mixed
-            output = output_4d.reshape([*leading_shape, self.n * self.hidden_size])
-            _dsv4_register_hc_grad(f"{debug_name}_bda_mixed", mixed)
-            _dsv4_register_hc_grad(f"{debug_name}_bda_x_expanded", x_expanded)
-            _dsv4_register_hc_grad(f"{debug_name}_bda_output_4d", output_4d)
-            _dsv4_register_hc_grad(f"{debug_name}_bda_output", output)
-            return output
 
         # Step 1: Apply H_res to original residual
         mixed = self.apply_h_res(h_res, original_residual)
@@ -1662,14 +1320,9 @@ class HyperConnectionContractLayer(FleetLayer):
         # When MTP is enabled, preserve multi-stream for MTP input
         if self.mtp_enabled and self.num_mtp > 0:
             dict_args["mhc_multistream"] = hidden_states
-            _dsv4_register_contract_split_grad(
-                "final_contract_mhc_multistream", hidden_states, self.num_mtp + 1
-            )
-            _dsv4_log_loss_path_tensor("final_contract_mhc_multistream", hidden_states)
 
             # Split into main backbone + MTP chunks
             chunks = paddle.split(hidden_states, self.num_mtp + 1)
-            _dsv4_log_loss_path_tensor("final_contract_input", chunks[0])
 
             # Main backbone: learned contraction [s, b, n*h] -> [s, b, h]
             main_contracted = HyperConnectionModule.learned_output_contract(
@@ -1680,27 +1333,17 @@ class HyperConnectionContractLayer(FleetLayer):
                 self.n,
                 self.config.rms_norm_eps,
             )
-            _dsv4_log_loss_path_tensor("final_contract_main_output", main_contracted)
-            _dsv4_log_loss_path_tensor("final_layernorm_input", main_contracted)
 
             # 为了后面MTP slice、取shape的时候兼容,原本也是expand过来的[[s,b,h]...]
             mtp_contracted = [
                 c[..., : c.shape[-1] // self.n] for c in chunks[1:]
             ]
-            for i, mtp_hidden in enumerate(mtp_contracted):
-                _dsv4_log_loss_path_tensor(
-                    f"final_contract_mtp{i}_passthrough", mtp_hidden
-                )
 
             dict_args["hidden_states"] = paddle.concat(
                 [main_contracted, *mtp_contracted]
             )
-            _dsv4_log_loss_path_tensor(
-                "final_contract_output_concat", dict_args["hidden_states"]
-            )
 
         else:
-            _dsv4_log_loss_path_tensor("final_contract_input", hidden_states)
             # Learned output contraction: [s, b, n*h] -> [s, b, h]
             dict_args["hidden_states"] = (
                 HyperConnectionModule.learned_output_contract(
@@ -1711,11 +1354,5 @@ class HyperConnectionContractLayer(FleetLayer):
                     self.n,
                     self.config.rms_norm_eps,
                 )
-            )
-            _dsv4_log_loss_path_tensor(
-                "final_contract_main_output", dict_args["hidden_states"]
-            )
-            _dsv4_log_loss_path_tensor(
-                "final_layernorm_input", dict_args["hidden_states"]
             )
         return dict_args

--- a/src/paddlefleet/transformer/hyper_connection.py
+++ b/src/paddlefleet/transformer/hyper_connection.py
@@ -37,6 +37,340 @@ if TYPE_CHECKING:
     from paddlefleet.transformer.transformer_config import TransformerConfig
 
 
+_DSV4_HC_COMPONENT_STORE: dict[str, dict[str, Tensor]] = {}
+
+
+def _dsv4_log_loss_path_tensor(name: str, tensor: Tensor) -> None:
+    if (
+        os.environ.get("LOG_LAYER_MD5", "0") != "1"
+        and os.environ.get("LOG_LOSS_MD5", "0") != "1"
+    ):
+        return
+    if tensor is None:
+        return
+    import hashlib
+
+    rank = paddle.distributed.get_rank()
+    md5 = hashlib.md5(tensor.cast("float32").numpy().tobytes()).hexdigest()
+    print(
+        f"[LOSS_PATH_MD5] rank={rank} {name} shape={list(tensor.shape)} md5={md5}",
+        flush=True,
+    )
+
+
+def _dsv4_log_contract_grad(name: str, tensor: Tensor) -> None:
+    if os.environ.get("DSV4_LOG_CONTRACT_GRADS", "0") != "1":
+        return
+    _dsv4_log_loss_path_tensor(f"{name}.grad", tensor)
+
+
+def _dsv4_register_contract_grad(name: str, tensor: Tensor) -> None:
+    if os.environ.get("DSV4_LOG_CONTRACT_GRADS", "0") != "1":
+        return
+    if tensor is None or tensor.stop_gradient:
+        return
+
+    def _hook(grad: Tensor):
+        _dsv4_log_contract_grad(name, grad)
+
+    tensor.register_hook(_hook)
+
+
+def _dsv4_register_contract_split_grad(name: str, tensor: Tensor, parts: int) -> None:
+    if os.environ.get("DSV4_LOG_CONTRACT_GRADS", "0") != "1":
+        return
+    if tensor is None or tensor.stop_gradient:
+        return
+
+    def _hook(grad: Tensor):
+        _dsv4_log_contract_grad(name, grad)
+        for idx, grad_chunk in enumerate(paddle.split(grad, parts)):
+            _dsv4_log_contract_grad(f"{name}_chunk{idx}", grad_chunk)
+
+    tensor.register_hook(_hook)
+
+
+def _dsv4_register_hc_grad(name: str, tensor: Tensor) -> None:
+    if os.environ.get("DSV4_LOG_HC_GRADS", "0") != "1":
+        return
+    if tensor is None or tensor.stop_gradient:
+        return
+
+    def _hook(grad: Tensor):
+        import hashlib
+
+        rank = paddle.distributed.get_rank()
+        if rank != int(os.environ.get("DSV4_LOSS_PATH_RANK", "0")):
+            return
+        md5 = hashlib.md5(grad.cast("float32").numpy().tobytes()).hexdigest()
+        print(
+            f"[HC_GRAD_MD5] rank={rank} {name}.grad shape={list(grad.shape)} md5={md5}",
+            flush=True,
+        )
+
+    tensor.register_hook(_hook)
+
+
+def _dsv4_log_hc_component_grad(name: str, tensor: Tensor) -> None:
+    if os.environ.get("DSV4_LOG_HC_COMPONENT_GRADS", "0") != "1":
+        return
+    import hashlib
+
+    rank = paddle.distributed.get_rank()
+    if rank != int(os.environ.get("DSV4_LOSS_PATH_RANK", "0")):
+        return
+    md5 = hashlib.md5(tensor.cast("float32").numpy().tobytes()).hexdigest()
+    print(
+        f"[HC_COMPONENT_GRAD_MD5] rank={rank} {name}.grad shape={list(tensor.shape)} md5={md5}",
+        flush=True,
+    )
+
+
+def _dsv4_store_hc_component_grad(name: str, kind: str, tensor: Tensor) -> None:
+    if os.environ.get("DSV4_LOG_HC_COMPONENT_GRADS", "0") != "1" or not name:
+        return
+    entry = _DSV4_HC_COMPONENT_STORE.setdefault(name, {})
+    entry[kind] = tensor
+    if "proj" not in entry or "r" not in entry:
+        return
+    proj_grad = entry.pop("proj")
+    r_grad = entry.pop("r")
+    if not entry:
+        _DSV4_HC_COMPONENT_STORE.pop(name, None)
+    _dsv4_log_hc_component_grad(
+        f"{name}_mapping_input_manual_proj_r",
+        proj_grad + r_grad,
+    )
+    _dsv4_log_hc_component_grad(
+        f"{name}_mapping_input_manual_r_proj",
+        r_grad + proj_grad,
+    )
+
+
+def _dsv4_log_torch_contract_probe(
+    hidden_states: Tensor,
+    head_fn_out_in: Tensor,
+    base: Tensor,
+    scale: Tensor,
+    n: int,
+    eps: float,
+    out_dtype,
+) -> None:
+    if os.environ.get("DSV4_FLEET_CONTRACT_TORCH_PROBE", "0") != "1":
+        return
+    if (
+        os.environ.get("LOG_LAYER_MD5", "0") != "1"
+        and os.environ.get("LOG_LOSS_MD5", "0") != "1"
+    ):
+        return
+
+    torch_site_packages = os.environ.get(
+        "DSV4_FLEET_CONTRACT_TORCH_SITE_PACKAGES",
+        os.environ.get("DSV4_FLEET_TE_SITE_PACKAGES", ""),
+    )
+    if torch_site_packages:
+        import sys
+
+        if torch_site_packages not in sys.path:
+            sys.path.insert(0, torch_site_packages)
+    import hashlib
+    import torch
+    import torch.nn.functional as torch_F
+    import torch.utils.dlpack
+    from paddle.utils import dlpack as paddle_dlpack
+
+    def to_torch(tensor: Tensor):
+        return torch.utils.dlpack.from_dlpack(
+            paddle_dlpack.to_dlpack(tensor.contiguous())
+        )
+
+    def log_torch(name: str, tensor):
+        data = tensor.detach().to(torch.float32).contiguous().cpu().numpy().tobytes()
+        md5 = hashlib.md5(data).hexdigest()
+        rank = paddle.distributed.get_rank()
+        print(
+            f"[LOSS_PATH_MD5] rank={rank} {name} shape={list(tensor.shape)} md5={md5}",
+            flush=True,
+        )
+
+    hidden_t = to_torch(hidden_states)
+    head_t = to_torch(head_fn_out_in)
+    base_t = to_torch(base)
+    scale_t = to_torch(scale)
+    torch_dtype = torch.bfloat16 if str(out_dtype) == "paddle.bfloat16" else hidden_t.dtype
+    with torch.no_grad():
+        rsqrt_t = torch.rsqrt(hidden_t.square().mean(-1, keepdim=True) + eps)
+        proj_t = torch_F.linear(hidden_t, head_t)
+        mixes_t = proj_t * rsqrt_t
+        pre_t = torch.sigmoid(mixes_t * scale_t + base_t) + eps
+        y_t = torch.sum(
+            pre_t.unsqueeze(-1) * hidden_t.reshape(*hidden_t.shape[:-1], n, -1),
+            dim=-2,
+        )
+        out_t = y_t.to(torch_dtype)
+    log_torch("final_contract_torch_probe_head_fn_out_in", head_t)
+    log_torch("final_contract_torch_probe_proj", proj_t)
+    log_torch("final_contract_torch_probe_mixes", mixes_t)
+    log_torch("final_contract_torch_probe_pre", pre_t)
+    log_torch("final_contract_torch_probe_y_float32", y_t)
+    log_torch("final_contract_torch_probe_main_output", out_t)
+
+
+def _dsv4_torch_contract_forward(
+    hidden_states: Tensor,
+    head_fn_out_in: Tensor,
+    base: Tensor,
+    scale: Tensor,
+    n: int,
+    eps: float,
+    out_dtype,
+):
+    torch_site_packages = os.environ.get(
+        "DSV4_FLEET_CONTRACT_TORCH_SITE_PACKAGES",
+        os.environ.get("DSV4_FLEET_TE_SITE_PACKAGES", ""),
+    )
+    if torch_site_packages:
+        import sys
+
+        if torch_site_packages not in sys.path:
+            sys.path.insert(0, torch_site_packages)
+    import torch
+    import torch.nn.functional as torch_F
+    import torch.utils.dlpack
+    from paddle.utils import dlpack as paddle_dlpack
+
+    def to_torch(tensor: Tensor):
+        return torch.utils.dlpack.from_dlpack(
+            paddle_dlpack.to_dlpack(tensor.contiguous())
+        )
+
+    def to_paddle(tensor):
+        return paddle_dlpack.from_dlpack(
+            torch.utils.dlpack.to_dlpack(tensor.contiguous())
+        )
+
+    hidden_t = to_torch(hidden_states)
+    head_t = to_torch(head_fn_out_in)
+    base_t = to_torch(base)
+    scale_t = to_torch(scale)
+    torch_dtype = torch.bfloat16 if str(out_dtype) == "paddle.bfloat16" else hidden_t.dtype
+    with torch.no_grad():
+        rsqrt_t = torch.rsqrt(hidden_t.square().mean(-1, keepdim=True) + eps)
+        proj_t = torch_F.linear(hidden_t, head_t)
+        mixes_t = proj_t * rsqrt_t
+        pre_arg_t = mixes_t * scale_t + base_t
+        sig_t = torch.sigmoid(pre_arg_t)
+        pre_t = sig_t + eps
+        y_t = torch.sum(
+            pre_t.unsqueeze(-1) * hidden_t.reshape(*hidden_t.shape[:-1], n, -1),
+            dim=-2,
+        )
+        out_t = y_t.to(torch_dtype)
+    return (
+        to_paddle(out_t),
+        to_paddle(rsqrt_t),
+        to_paddle(proj_t),
+        to_paddle(mixes_t),
+        to_paddle(sig_t),
+        to_paddle(pre_t),
+    )
+
+
+def _dsv4_torch_contract_backward(
+    hidden_input: Tensor,
+    head_fn_input: Tensor,
+    base_input: Tensor,
+    scale_input: Tensor,
+    grad_output: Tensor,
+    n: int,
+    eps: float,
+):
+    if os.environ.get("DSV4_FLEET_CONTRACT_TORCH_BWD", "0") != "1":
+        return None
+
+    torch_site_packages = os.environ.get(
+        "DSV4_FLEET_CONTRACT_TORCH_SITE_PACKAGES",
+        os.environ.get("DSV4_FLEET_TE_SITE_PACKAGES", ""),
+    )
+    if torch_site_packages:
+        import sys
+
+        if torch_site_packages not in sys.path:
+            sys.path.insert(0, torch_site_packages)
+    import torch
+    import torch.nn.functional as torch_F
+    import torch.utils.dlpack
+    from paddle.utils import dlpack as paddle_dlpack
+
+    def to_torch(tensor: Tensor):
+        return torch.utils.dlpack.from_dlpack(
+            paddle_dlpack.to_dlpack(tensor.contiguous())
+        )
+
+    def to_paddle(tensor):
+        return paddle_dlpack.from_dlpack(
+            torch.utils.dlpack.to_dlpack(tensor.detach().contiguous())
+        )
+
+    hidden_input_t = to_torch(hidden_input).detach().requires_grad_(True)
+    head_input_t = to_torch(head_fn_input).detach().requires_grad_(True)
+    base_input_t = to_torch(base_input).detach().requires_grad_(True)
+    scale_input_t = to_torch(scale_input).detach().requires_grad_(True)
+    grad_t = to_torch(grad_output).detach()
+
+    with torch.enable_grad():
+        hidden_t = hidden_input_t.to(torch.float32)
+        head_io_t = head_input_t.to(torch.float32)
+        base_t = base_input_t.to(torch.float32)
+        scale_t = scale_input_t.to(torch.float32)
+        hidden_t.retain_grad()
+        head_oi_t = head_io_t.transpose(0, 1).contiguous()
+        rsqrt_t = torch.rsqrt(hidden_t.square().mean(-1, keepdim=True) + eps)
+        mixes_t = torch_F.linear(hidden_t, head_oi_t) * rsqrt_t
+        pre_t = torch.sigmoid(mixes_t * scale_t + base_t) + eps
+        y_t = torch.sum(
+            pre_t.unsqueeze(-1) * hidden_t.reshape(*hidden_t.shape[:-1], n, -1),
+            dim=-2,
+        )
+        out_t = y_t.to(hidden_input_t.dtype)
+        out_t.backward(grad_t)
+
+    if os.environ.get("DSV4_FLEET_CONTRACT_TORCH_BWD_CAST_PROBE", "0") == "1":
+        import hashlib
+
+        rank = paddle.distributed.get_rank()
+
+        def log_torch(name: str, tensor):
+            data = tensor.detach().to(torch.float32).contiguous().cpu().numpy().tobytes()
+            md5 = hashlib.md5(data).hexdigest()
+            print(
+                f"[LOSS_PATH_MD5] rank={rank} {name} shape={list(tensor.shape)} md5={md5}",
+                flush=True,
+            )
+
+        manual_cast = hidden_t.grad.to(hidden_input_t.dtype)
+        log_torch("final_contract_hidden_fp32_manual_bf16_cast.grad", manual_cast)
+        if hidden_t.grad.ndim >= 3 and hidden_t.grad.shape[0] == 1:
+            megatron_shape_cast = (
+                hidden_t.grad.transpose(0, 1)
+                .contiguous()
+                .to(hidden_input_t.dtype)
+            )
+            log_torch(
+                "final_contract_hidden_fp32_megatron_shape_bf16_cast.grad",
+                megatron_shape_cast,
+            )
+        log_torch("final_contract_hidden_input_leaf.grad", hidden_input_t.grad)
+
+    return (
+        to_paddle(hidden_t.grad),
+        to_paddle(hidden_input_t.grad),
+        to_paddle(head_input_t.grad),
+        to_paddle(base_input_t.grad),
+        to_paddle(scale_input_t.grad),
+    )
+
+
 def _dsv4_hc_sinkhorn_torch_backward(
     logits: Tensor, grad_output: Tensor, num_iterations: int, eps: float
 ) -> Tensor:
@@ -79,12 +413,14 @@ def _dsv4_hc_sinkhorn_torch_backward(
 
 class _DSV4HCTorchOrderRmsScale(paddle.autograd.PyLayer):
     @staticmethod
-    def forward(ctx, x: Tensor, eps: float):
+    def forward(ctx, x: Tensor, eps: float, debug_name: str = ""):
         nC = x.shape[-1]
         norm = x.norm(axis=-1, keepdim=True)
         r = 1.0 / (norm / math.sqrt(nC) + eps)
         r = r.astype(x.dtype)
         ctx.nC = nC
+        ctx.eps = eps
+        ctx.debug_name = debug_name
         ctx.save_for_backward(x, norm, r)
         return r
 
@@ -92,6 +428,43 @@ class _DSV4HCTorchOrderRmsScale(paddle.autograd.PyLayer):
     def backward(ctx, grad: Tensor):
         x, norm, r = ctx.saved_tensor()
         grad = grad.astype(x.dtype)
+        if os.environ.get("DSV4_FLEET_HC_RMS_TORCH_BWD", "0") == "1":
+            torch_site_packages = os.environ.get(
+                "DSV4_FLEET_CONTRACT_TORCH_SITE_PACKAGES",
+                os.environ.get("DSV4_FLEET_TE_SITE_PACKAGES", ""),
+            )
+            if torch_site_packages:
+                import sys
+
+                if torch_site_packages not in sys.path:
+                    sys.path.insert(0, torch_site_packages)
+            import torch
+            import torch.utils.dlpack
+            from paddle.utils import dlpack as paddle_dlpack
+
+            def to_torch(tensor: Tensor):
+                return torch.utils.dlpack.from_dlpack(
+                    paddle_dlpack.to_dlpack(tensor.contiguous())
+                )
+
+            def to_paddle(tensor):
+                return paddle_dlpack.from_dlpack(
+                    torch.utils.dlpack.to_dlpack(tensor.detach().contiguous())
+                )
+
+            x_t = to_torch(x).detach().requires_grad_(True)
+            grad_t = to_torch(grad).detach()
+            with torch.enable_grad():
+                norm_t = x_t.norm(dim=-1, keepdim=True)
+                r_t = 1.0 / (norm_t / math.sqrt(ctx.nC) + ctx.eps)
+                r_t.backward(grad_t)
+            grad_x = to_paddle(x_t.grad).astype(x.dtype)
+            if ctx.debug_name:
+                _dsv4_log_hc_component_grad(
+                    f"{ctx.debug_name}_r_input_manual", grad_x
+                )
+                _dsv4_store_hc_component_grad(ctx.debug_name, "r", grad_x)
+            return grad_x
         # Match Torch norm + reciprocal backward source-order in BF16.
         scaled = grad * (r * r)
         scaled = scaled / math.sqrt(ctx.nC)
@@ -103,7 +476,252 @@ class _DSV4HCTorchOrderRmsScale(paddle.autograd.PyLayer):
         zero = paddle.zeros_like(unit)
         torch_zero = paddle.where(x == 0, -paddle.ones_like(unit) * zero, (-unit) * zero)
         grad_x = paddle.where(scaled == 0, torch_zero, grad_x)
-        return grad_x.astype(x.dtype)
+        grad_x = grad_x.astype(x.dtype)
+        if ctx.debug_name:
+            _dsv4_log_hc_component_grad(
+                f"{ctx.debug_name}_r_input_manual", grad_x
+            )
+            _dsv4_store_hc_component_grad(ctx.debug_name, "r", grad_x)
+        return grad_x
+
+
+class _DSV4HCApplyHRes(paddle.autograd.PyLayer):
+    @staticmethod
+    def forward(ctx, h_res: Tensor, residual: Tensor, n: int, hidden_size: int):
+        leading_shape = residual.shape[:-1]
+        num_tokens = math.prod(leading_shape)
+        h_res_batched = (
+            h_res.astype(residual.dtype)
+            .transpose([0, 1, 3, 2])
+            .reshape([num_tokens, n, n])
+        )
+        residual_batched = residual.reshape([num_tokens, n, hidden_size])
+        mixed = paddle.bmm(h_res_batched, residual_batched)
+        ctx.n = n
+        ctx.hidden_size = hidden_size
+        ctx.save_for_backward(h_res, residual)
+        return mixed.reshape([*leading_shape, n * hidden_size])
+
+    @staticmethod
+    def backward(ctx, grad_output: Tensor):
+        h_res, residual = ctx.saved_tensor()
+        if os.environ.get("DSV4_FLEET_HC_APPLY_H_RES_TORCH_BWD", "0") != "1":
+            return None, None
+
+        torch_site_packages = os.environ.get(
+            "DSV4_FLEET_HC_APPLY_H_RES_TORCH_SITE_PACKAGES",
+            os.environ.get("DSV4_FLEET_TE_SITE_PACKAGES", ""),
+        )
+        if torch_site_packages:
+            import sys
+
+            if torch_site_packages not in sys.path:
+                sys.path.insert(0, torch_site_packages)
+        import torch
+        import torch.utils.dlpack
+        from paddle.utils import dlpack as paddle_dlpack
+
+        def to_torch(tensor: Tensor):
+            return torch.utils.dlpack.from_dlpack(
+                paddle_dlpack.to_dlpack(tensor.contiguous())
+            )
+
+        def to_paddle(tensor):
+            return paddle_dlpack.from_dlpack(
+                torch.utils.dlpack.to_dlpack(tensor.detach().contiguous())
+            )
+
+        n = ctx.n
+        hidden_size = ctx.hidden_size
+        h_res_t = to_torch(h_res).detach().requires_grad_(True)
+        residual_t = to_torch(residual).detach().requires_grad_(True)
+        grad_t = to_torch(grad_output).detach()
+        leading_shape = tuple(residual_t.shape[:-1])
+        num_tokens = math.prod(leading_shape)
+
+        with torch.enable_grad():
+            h_res_batched = (
+                h_res_t.to(residual_t.dtype)
+                .transpose(-1, -2)
+                .contiguous()
+                .view(num_tokens, n, n)
+            )
+            residual_batched = residual_t.view(num_tokens, n, hidden_size)
+            mixed = torch.bmm(h_res_batched, residual_batched)
+            out = mixed.view(*leading_shape, n * hidden_size)
+            out.backward(grad_t)
+
+        return to_paddle(h_res_t.grad), to_paddle(residual_t.grad)
+
+
+class _DSV4HCInputBranchSplit(paddle.autograd.PyLayer):
+    @staticmethod
+    def forward(ctx, x: Tensor):
+        return paddle.assign(x), paddle.assign(x)
+
+    @staticmethod
+    def backward(ctx, grad_mapping: Tensor, grad_aggregate: Tensor):
+        if grad_mapping is None:
+            return grad_aggregate
+        if grad_aggregate is None:
+            return grad_mapping
+
+        order = os.environ.get(
+            "DSV4_FLEET_HC_INPUT_BRANCH_SPLIT_ORDER",
+            "aggregate_mapping",
+        )
+        first, second = (
+            (grad_aggregate, grad_mapping)
+            if order == "aggregate_mapping"
+            else (grad_mapping, grad_aggregate)
+        )
+        if os.environ.get("DSV4_FLEET_HC_INPUT_BRANCH_SPLIT_TORCH_BWD", "0") != "1":
+            return first + second
+
+        torch_site_packages = os.environ.get(
+            "DSV4_FLEET_CONTRACT_TORCH_SITE_PACKAGES",
+            os.environ.get("DSV4_FLEET_TE_SITE_PACKAGES", ""),
+        )
+        if torch_site_packages:
+            import sys
+
+            if torch_site_packages not in sys.path:
+                sys.path.insert(0, torch_site_packages)
+        import torch
+        import torch.utils.dlpack
+        from paddle.utils import dlpack as paddle_dlpack
+
+        def to_torch(tensor: Tensor):
+            return torch.utils.dlpack.from_dlpack(
+                paddle_dlpack.to_dlpack(tensor.contiguous())
+            )
+
+        def to_paddle(tensor):
+            return paddle_dlpack.from_dlpack(
+                torch.utils.dlpack.to_dlpack(tensor.contiguous())
+            )
+
+        with torch.no_grad():
+            out = to_torch(first) + to_torch(second)
+        return to_paddle(out)
+
+
+class _DSV4HCHPostBDATorch(paddle.autograd.PyLayer):
+    @staticmethod
+    def forward(
+        ctx,
+        h_res: Tensor,
+        original_residual: Tensor,
+        h_post: Tensor,
+        x: Tensor,
+        n: int,
+        hidden_size: int,
+    ):
+        torch_site_packages = os.environ.get(
+            "DSV4_FLEET_CONTRACT_TORCH_SITE_PACKAGES",
+            os.environ.get("DSV4_FLEET_TE_SITE_PACKAGES", ""),
+        )
+        if torch_site_packages:
+            import sys
+
+            if torch_site_packages not in sys.path:
+                sys.path.insert(0, torch_site_packages)
+        import torch
+        import torch.utils.dlpack
+        from paddle.utils import dlpack as paddle_dlpack
+
+        def to_torch(tensor: Tensor):
+            return torch.utils.dlpack.from_dlpack(
+                paddle_dlpack.to_dlpack(tensor.contiguous())
+            )
+
+        def to_paddle(tensor):
+            return paddle_dlpack.from_dlpack(
+                torch.utils.dlpack.to_dlpack(tensor.contiguous())
+            )
+
+        h_res_t = to_torch(h_res)
+        residual_t = to_torch(original_residual)
+        h_post_t = to_torch(h_post)
+        x_t = to_torch(x)
+        leading_shape = tuple(residual_t.shape[:-1])
+        num_tokens = math.prod(leading_shape)
+        with torch.no_grad():
+            h_res_batched = (
+                h_res_t.to(residual_t.dtype)
+                .transpose(-1, -2)
+                .contiguous()
+                .view(num_tokens, n, n)
+            )
+            residual_batched = residual_t.view(num_tokens, n, hidden_size)
+            mixed = torch.bmm(h_res_batched, residual_batched).view(
+                *leading_shape, n, hidden_size
+            )
+            x_expanded = h_post_t.to(residual_t.dtype).unsqueeze(-1) * x_t.unsqueeze(-2)
+            out = (x_expanded + mixed).reshape(*leading_shape, n * hidden_size)
+
+        ctx.save_for_backward(h_res, original_residual, h_post, x)
+        ctx.n = n
+        ctx.hidden_size = hidden_size
+        return to_paddle(out)
+
+    @staticmethod
+    def backward(ctx, grad_output: Tensor):
+        h_res, original_residual, h_post, x = ctx.saved_tensor()
+        torch_site_packages = os.environ.get(
+            "DSV4_FLEET_CONTRACT_TORCH_SITE_PACKAGES",
+            os.environ.get("DSV4_FLEET_TE_SITE_PACKAGES", ""),
+        )
+        if torch_site_packages:
+            import sys
+
+            if torch_site_packages not in sys.path:
+                sys.path.insert(0, torch_site_packages)
+        import torch
+        import torch.utils.dlpack
+        from paddle.utils import dlpack as paddle_dlpack
+
+        def to_torch(tensor: Tensor):
+            return torch.utils.dlpack.from_dlpack(
+                paddle_dlpack.to_dlpack(tensor.contiguous())
+            )
+
+        def to_paddle(tensor):
+            return paddle_dlpack.from_dlpack(
+                torch.utils.dlpack.to_dlpack(tensor.detach().contiguous())
+            )
+
+        n = ctx.n
+        hidden_size = ctx.hidden_size
+        h_res_t = to_torch(h_res).detach().requires_grad_(True)
+        residual_t = to_torch(original_residual).detach().requires_grad_(True)
+        h_post_t = to_torch(h_post).detach().requires_grad_(True)
+        x_t = to_torch(x).detach().requires_grad_(True)
+        grad_t = to_torch(grad_output).detach()
+        leading_shape = tuple(residual_t.shape[:-1])
+        num_tokens = math.prod(leading_shape)
+
+        with torch.enable_grad():
+            h_res_batched = (
+                h_res_t.to(residual_t.dtype)
+                .transpose(-1, -2)
+                .contiguous()
+                .view(num_tokens, n, n)
+            )
+            residual_batched = residual_t.view(num_tokens, n, hidden_size)
+            mixed = torch.bmm(h_res_batched, residual_batched).view(
+                *leading_shape, n, hidden_size
+            )
+            x_expanded = h_post_t.to(residual_t.dtype).unsqueeze(-1) * x_t.unsqueeze(-2)
+            out = (x_expanded + mixed).reshape(*leading_shape, n * hidden_size)
+            out.backward(grad_t)
+
+        return (
+            to_paddle(h_res_t.grad),
+            to_paddle(residual_t.grad),
+            to_paddle(h_post_t.grad),
+            to_paddle(x_t.grad),
+        )
 
 
 class _DSV4LearnedOutputContract(paddle.autograd.PyLayer):
@@ -117,34 +735,99 @@ class _DSV4LearnedOutputContract(paddle.autograd.PyLayer):
 
         rsqrt = paddle.rsqrt(hidden_fp32.square().mean(-1, keepdim=True) + eps)
         head_fn_out_in = head_fn_fp32.transpose([1, 0]).contiguous()
-        with paddle.amp.auto_cast(False):
-            proj = paddle.matmul(hidden_fp32, head_fn_out_in, transpose_y=True)
-        if os.environ.get("DSV4_FLEET_CONTRACT_MIXES_RSQRT_FIRST", "0") == "1":
-            mixes = rsqrt * proj
+        if os.environ.get("DSV4_FLEET_CONTRACT_TORCH_FORWARD", "0") == "1":
+            out, rsqrt, proj, mixes, sig, pre = _dsv4_torch_contract_forward(
+                hidden_fp32,
+                head_fn_out_in,
+                base_fp32,
+                scale_fp32,
+                n,
+                eps,
+                dtype,
+            )
         else:
-            mixes = proj * rsqrt
-        pre_arg = mixes * scale_fp32 + base_fp32
-        sig = F.sigmoid(pre_arg)
-        pre = sig + eps
-        hidden_streams = hidden_fp32.reshape([*hidden_fp32.shape[:-1], n, -1])
-        y = paddle.sum(pre.unsqueeze(-1) * hidden_streams, axis=-2)
+            with paddle.amp.auto_cast(False):
+                proj = paddle.matmul(hidden_fp32, head_fn_out_in, transpose_y=True)
+            if os.environ.get("DSV4_FLEET_CONTRACT_MIXES_RSQRT_FIRST", "0") == "1":
+                mixes = rsqrt * proj
+            else:
+                mixes = proj * rsqrt
+            pre_arg = mixes * scale_fp32 + base_fp32
+            sig = F.sigmoid(pre_arg)
+            pre = sig + eps
+            hidden_streams = hidden_fp32.reshape([*hidden_fp32.shape[:-1], n, -1])
+            y = paddle.sum(pre.unsqueeze(-1) * hidden_streams, axis=-2)
+            out = y.astype(dtype)
 
-        ctx.save_for_backward(hidden_fp32, head_fn_fp32, base_fp32, scale_fp32, rsqrt, proj, mixes, sig, pre)
+        ctx.save_for_backward(
+            hidden_states,
+            head_fn,
+            base,
+            scale,
+            hidden_fp32,
+            head_fn_fp32,
+            base_fp32,
+            scale_fp32,
+            rsqrt,
+            proj,
+            mixes,
+            sig,
+            pre,
+        )
         ctx.n = n
         ctx.eps = eps
         ctx.hidden_dtype = dtype
         ctx.head_fn_dtype = head_fn.dtype
         ctx.base_dtype = base.dtype
         ctx.scale_dtype = scale.dtype
-        return y.astype(dtype)
+        return out
 
     @staticmethod
     def backward(ctx, grad_output: Tensor):
-        hidden_fp32, head_fn_fp32, base_fp32, scale_fp32, rsqrt, proj, mixes, sig, pre = ctx.saved_tensor()
+        (
+            hidden_input,
+            head_fn_input,
+            base_input,
+            scale_input,
+            hidden_fp32,
+            head_fn_fp32,
+            base_fp32,
+            scale_fp32,
+            rsqrt,
+            proj,
+            mixes,
+            sig,
+            pre,
+        ) = ctx.saved_tensor()
         n = ctx.n
         hdim = hidden_fp32.shape[-1]
         hidden_streams = hidden_fp32.reshape([*hidden_fp32.shape[:-1], n, -1])
         grad_y = grad_output.astype("float32")
+        _dsv4_log_contract_grad("final_contract_main_output", grad_output)
+        torch_grads = _dsv4_torch_contract_backward(
+            hidden_input,
+            head_fn_input,
+            base_input,
+            scale_input,
+            grad_output,
+            n,
+            ctx.eps,
+        )
+        if torch_grads is not None:
+            grad_hidden, grad_hidden_out, grad_head_fn_out, grad_base_out, grad_scale_out = torch_grads
+
+            _dsv4_log_contract_grad("final_contract_hidden_fp32", grad_hidden)
+            _dsv4_log_contract_grad("final_contract_input", grad_hidden_out)
+            _dsv4_log_contract_grad("final_contract_head_fn", grad_head_fn_out)
+            _dsv4_log_contract_grad("final_contract_base", grad_base_out)
+            _dsv4_log_contract_grad("final_contract_scale", grad_scale_out)
+
+            return (
+                grad_hidden_out,
+                grad_head_fn_out,
+                grad_base_out,
+                grad_scale_out,
+            )
 
         grad_prod = paddle.expand(
             grad_y.unsqueeze(-2),
@@ -176,12 +859,22 @@ class _DSV4LearnedOutputContract(paddle.autograd.PyLayer):
         # Match PyTorch autograd's observed accumulation order for this graph:
         # direct view branch, projection branch, then rsqrt/mean branch.
         grad_hidden = (grad_hidden_direct + grad_hidden_proj) + grad_hidden_rsqrt
+        grad_hidden_out = grad_hidden.astype(ctx.hidden_dtype)
+        grad_head_fn_out = grad_head_fn.astype(ctx.head_fn_dtype)
+        grad_base_out = grad_base.astype(ctx.base_dtype)
+        grad_scale_out = grad_scale.astype(ctx.scale_dtype)
+
+        _dsv4_log_contract_grad("final_contract_hidden_fp32", grad_hidden)
+        _dsv4_log_contract_grad("final_contract_input", grad_hidden_out)
+        _dsv4_log_contract_grad("final_contract_head_fn", grad_head_fn_out)
+        _dsv4_log_contract_grad("final_contract_base", grad_base_out)
+        _dsv4_log_contract_grad("final_contract_scale", grad_scale_out)
 
         return (
-            grad_hidden.astype(ctx.hidden_dtype),
-            grad_head_fn.astype(ctx.head_fn_dtype),
-            grad_base.astype(ctx.base_dtype),
-            grad_scale.astype(ctx.scale_dtype),
+            grad_hidden_out,
+            grad_head_fn_out,
+            grad_base_out,
+            grad_scale_out,
         )
 
 
@@ -388,13 +1081,34 @@ class HyperConnectionModule(nn.Layer):
             x: [..., n*C] - n-stream hidden states
         """
         nC = x.shape[-1]
+        debug_name = getattr(self, "_dsv4_debug_name", "")
         weight = self.mapping_proj.weight
         x_2d = x.reshape([-1, nC])
-        r = _DSV4HCTorchOrderRmsScale.apply(x_2d, self.norm_eps)
+        r = _DSV4HCTorchOrderRmsScale.apply(
+            x_2d, self.norm_eps, debug_name
+        )
         # Match Megatron clean path: torch.matmul(x, weight.t()).  Paddle
         # nn.Linear uses a different BF16 cuBLAS path for this shape and drifts
         # before the first HC BDA.
         proj_2d = paddle.matmul(x_2d, weight.t(), transpose_y=True)
+        if (
+            os.environ.get("DSV4_LOG_HC_COMPONENT_GRADS", "0") == "1"
+            and debug_name
+            and not proj_2d.stop_gradient
+        ):
+
+            def _proj_hook(grad: Tensor) -> None:
+                grad_x = paddle.matmul(
+                    grad.astype(x_2d.dtype),
+                    weight.astype(x_2d.dtype),
+                    transpose_y=True,
+                )
+                _dsv4_log_hc_component_grad(
+                    f"{debug_name}_proj_input_manual", grad_x
+                )
+                _dsv4_store_hc_component_grad(debug_name, "proj", grad_x)
+
+            proj_2d.register_hook(_proj_hook)
         proj = proj_2d.reshape([*x.shape[:-1], weight.shape[-1]])
         return proj, r.reshape([*x.shape[:-1], 1])
 
@@ -447,14 +1161,21 @@ class HyperConnectionModule(nn.Layer):
             h_res: [..., n, n] - residual mixing matrix (doubly stochastic)
         """
         leading_shape = x.shape[:-1]
+        debug_name = getattr(self, "_dsv4_debug_name", "")
         proj, r = self._projection_and_get_norm(x)
+        _dsv4_register_hc_grad(f"{debug_name}_proj", proj)
+        _dsv4_register_hc_grad(f"{debug_name}_r", r)
         h_pre, h_post, h_res = self._compute_h(proj, r)
+        _dsv4_register_hc_grad(f"{debug_name}_h_pre", h_pre)
+        _dsv4_register_hc_grad(f"{debug_name}_h_post_pre_sinkhorn", h_post)
+        _dsv4_register_hc_grad(f"{debug_name}_h_res_logits", h_res)
         h_res_logits = h_res
         h_res_logits_view = h_res_logits.reshape([*leading_shape, self.n, self.n])
         h_res = SinkhornKnopp.apply(
             h_res_logits_view,
             self.sinkhorn_iterations,
         )  # [..., n, n]
+        _dsv4_register_hc_grad(f"{debug_name}_h_res", h_res)
 
         return h_pre, h_post, h_res
 
@@ -479,6 +1200,23 @@ class HyperConnectionModule(nn.Layer):
 
         # Weighted sum: [..., n, C] * [..., n, 1] -> sum over n -> [..., C]
         aggregated = (x_streams * h_pre.unsqueeze(-1)).sum(axis=-2)
+        debug_name = getattr(self, "_dsv4_debug_name", "")
+        if (
+            os.environ.get("DSV4_LOG_HC_COMPONENT_GRADS", "0") == "1"
+            and debug_name
+            and not aggregated.stop_gradient
+        ):
+
+            def _aggregate_hook(grad: Tensor) -> None:
+                grad_x = (
+                    grad.astype(x.dtype).unsqueeze(-2)
+                    * h_pre.astype(x.dtype).unsqueeze(-1)
+                ).reshape(x.shape)
+                _dsv4_log_hc_component_grad(
+                    f"{debug_name}_aggregate_input_manual", grad_x
+                )
+
+            aggregated.register_hook(_aggregate_hook)
         if aggregated.dtype != x.dtype:
             aggregated = aggregated.astype(x.dtype)
 
@@ -494,6 +1232,11 @@ class HyperConnectionModule(nn.Layer):
             h_res: [..., n, n] - residual mixing matrix
             residual: [..., n*C] - n-stream hidden states
         """
+        if os.environ.get("DSV4_FLEET_HC_APPLY_H_RES_TORCH_BWD", "0") == "1":
+            return _DSV4HCApplyHRes.apply(
+                h_res, residual, self.n, self.hidden_size
+            )
+
         leading_shape = residual.shape[:-1]
         n = self.n
         C = self.hidden_size
@@ -579,14 +1322,33 @@ class HyperConnectionModule(nn.Layer):
             h_res: [..., n, n] - residual mixing matrix (for fused kernel)
             h_post: [..., n] - expansion weights
         """
-        mapping_input = hidden_states
-        aggregate_input = hidden_states
+        debug_name = getattr(self, "_dsv4_debug_name", "")
+        if os.environ.get("DSV4_FLEET_HC_INPUT_BRANCH_SPLIT", "0") == "1":
+            mapping_input, aggregate_input = _DSV4HCInputBranchSplit.apply(
+                hidden_states
+            )
+            if os.environ.get("DSV4_LOG_HC_BRANCH_GRADS", "0") == "1":
+                _dsv4_register_hc_grad(
+                    f"{debug_name}_mapping_input", mapping_input
+                )
+                _dsv4_register_hc_grad(
+                    f"{debug_name}_aggregate_input", aggregate_input
+                )
+        elif os.environ.get("DSV4_LOG_HC_BRANCH_GRADS", "0") == "1":
+            mapping_input = hidden_states.reshape(hidden_states.shape)
+            aggregate_input = hidden_states.reshape(hidden_states.shape)
+            _dsv4_register_hc_grad(f"{debug_name}_mapping_input", mapping_input)
+            _dsv4_register_hc_grad(f"{debug_name}_aggregate_input", aggregate_input)
+        else:
+            mapping_input = hidden_states
+            aggregate_input = hidden_states
 
         # Compute mappings
         h_pre, h_post, h_res = self.compute_mappings(mapping_input)
 
         # Aggregate for layer input
         aggregated = self.aggregate(aggregate_input, h_pre)
+        _dsv4_register_hc_grad(f"{debug_name}_aggregated", aggregated)
 
         return aggregated, h_res, h_post
 
@@ -660,7 +1422,14 @@ class HyperConnectionModule(nn.Layer):
         Returns:
             contracted: [..., h] single-stream output
         """
-        if os.environ.get("DSV4_FLEET_CONTRACT_CUSTOM_BWD", "0") == "1":
+        _dsv4_register_contract_grad("final_contract_input_total", hidden_states)
+        _dsv4_register_contract_grad("final_contract_head_fn_total", head_fn)
+        _dsv4_register_contract_grad("final_contract_base_total", base)
+        _dsv4_register_contract_grad("final_contract_scale_total", scale)
+        if (
+            os.environ.get("DSV4_FLEET_CONTRACT_CUSTOM_BWD", "0") == "1"
+            or os.environ.get("DSV4_FLEET_CONTRACT_TORCH_FORWARD", "0") == "1"
+        ):
             return _DSV4LearnedOutputContract.apply(
                 hidden_states,
                 head_fn,
@@ -675,6 +1444,10 @@ class HyperConnectionModule(nn.Layer):
         head_fn = head_fn.astype("float32")
         base = base.astype("float32")
         scale = scale.astype("float32")
+        _dsv4_log_loss_path_tensor("final_contract_hidden_fp32", hidden_states)
+        _dsv4_log_loss_path_tensor("final_contract_head_fn", head_fn)
+        _dsv4_log_loss_path_tensor("final_contract_base", base)
+        _dsv4_log_loss_path_tensor("final_contract_scale", scale)
         hidden_for_rsqrt = hidden_states
         hidden_for_proj = hidden_states
         hidden_for_direct = hidden_states
@@ -686,19 +1459,34 @@ class HyperConnectionModule(nn.Layer):
         rsqrt = paddle.rsqrt(
             hidden_for_rsqrt.square().mean(-1, keepdim=True) + eps
         )
+        _dsv4_log_loss_path_tensor("final_contract_rsqrt", rsqrt)
         # Match Torch F.linear(x, weight[out,in]) kernel selection. Paddle
         # F.linear(x, weight[in,out]) uses a different cuBLAS path and causes
         # BF16 ulp drift in DSv4 final output contraction.
         head_fn_out_in = head_fn.transpose([1, 0]).contiguous()
+        _dsv4_log_loss_path_tensor("final_contract_head_fn_out_in", head_fn_out_in)
+        _dsv4_log_torch_contract_probe(
+            hidden_for_proj,
+            head_fn_out_in,
+            base,
+            scale,
+            n,
+            eps,
+            dtype,
+        )
         with paddle.amp.auto_cast(False):
             proj = paddle.matmul(hidden_for_proj, head_fn_out_in, transpose_y=True)
         mixes = proj * rsqrt
+        _dsv4_log_loss_path_tensor("final_contract_mixes", mixes)
         pre_arg = mixes * scale + base
         pre = F.sigmoid(pre_arg) + eps
+        _dsv4_log_loss_path_tensor("final_contract_pre", pre)
         hidden_streams = hidden_for_direct.reshape([*hidden_for_direct.shape[:-1], n, -1])
         contract_prod = pre.unsqueeze(-1) * hidden_streams
         y = paddle.sum(contract_prod, axis=-2)
+        _dsv4_log_loss_path_tensor("final_contract_y_float32", y)
         out = y.astype(dtype)
+        _dsv4_log_loss_path_tensor("final_contract_main_output", out)
         return out
 
     # ==================== Fused kernel placeholder ====================
@@ -737,11 +1525,55 @@ class HyperConnectionModule(nn.Layer):
         Returns:
             output: [..., n*C] - final output after all operations
         """
+        x, bias = layer_output_with_bias
+        if (
+            os.environ.get("DSV4_FLEET_HC_H_POST_BDA_TORCH", "0") == "1"
+            and bias is None
+            and (dropout_prob == 0.0 or not training)
+        ):
+            return _DSV4HCHPostBDATorch.apply(
+                h_res,
+                original_residual,
+                h_post,
+                x,
+                self.n,
+                self.hidden_size,
+            )
+
+        if (
+            os.environ.get("DSV4_LOG_HC_BDA_GRADS", "0") == "1"
+            and bias is None
+            and (dropout_prob == 0.0 or not training)
+        ):
+            debug_name = getattr(self, "_dsv4_debug_name", "")
+            leading_shape = original_residual.shape[:-1]
+            num_tokens = math.prod(leading_shape)
+            h_res_cast = h_res.astype(original_residual.dtype)
+            h_post_cast = h_post.astype(original_residual.dtype)
+            h_res_batched = (
+                h_res_cast.transpose([0, 1, 3, 2]).reshape(
+                    [num_tokens, self.n, self.n]
+                )
+            )
+            residual_batched = original_residual.reshape(
+                [num_tokens, self.n, self.hidden_size]
+            )
+            mixed = paddle.bmm(h_res_batched, residual_batched).reshape(
+                [*leading_shape, self.n, self.hidden_size]
+            )
+            x_expanded = h_post_cast.unsqueeze(-1) * x.unsqueeze(-2)
+            output_4d = x_expanded + mixed
+            output = output_4d.reshape([*leading_shape, self.n * self.hidden_size])
+            _dsv4_register_hc_grad(f"{debug_name}_bda_mixed", mixed)
+            _dsv4_register_hc_grad(f"{debug_name}_bda_x_expanded", x_expanded)
+            _dsv4_register_hc_grad(f"{debug_name}_bda_output_4d", output_4d)
+            _dsv4_register_hc_grad(f"{debug_name}_bda_output", output)
+            return output
+
         # Step 1: Apply H_res to original residual
         mixed = self.apply_h_res(h_res, original_residual)
 
         # Step 2: Apply H_post to layer output
-        x, bias = layer_output_with_bias
         x_expanded = self._apply_h_post(x, h_post)
         bias_expanded = (
             self._apply_h_post(bias, h_post) if bias is not None else None
@@ -830,9 +1662,14 @@ class HyperConnectionContractLayer(FleetLayer):
         # When MTP is enabled, preserve multi-stream for MTP input
         if self.mtp_enabled and self.num_mtp > 0:
             dict_args["mhc_multistream"] = hidden_states
+            _dsv4_register_contract_split_grad(
+                "final_contract_mhc_multistream", hidden_states, self.num_mtp + 1
+            )
+            _dsv4_log_loss_path_tensor("final_contract_mhc_multistream", hidden_states)
 
             # Split into main backbone + MTP chunks
             chunks = paddle.split(hidden_states, self.num_mtp + 1)
+            _dsv4_log_loss_path_tensor("final_contract_input", chunks[0])
 
             # Main backbone: learned contraction [s, b, n*h] -> [s, b, h]
             main_contracted = HyperConnectionModule.learned_output_contract(
@@ -843,17 +1680,27 @@ class HyperConnectionContractLayer(FleetLayer):
                 self.n,
                 self.config.rms_norm_eps,
             )
+            _dsv4_log_loss_path_tensor("final_contract_main_output", main_contracted)
+            _dsv4_log_loss_path_tensor("final_layernorm_input", main_contracted)
 
             # 为了后面MTP slice、取shape的时候兼容,原本也是expand过来的[[s,b,h]...]
             mtp_contracted = [
                 c[..., : c.shape[-1] // self.n] for c in chunks[1:]
             ]
+            for i, mtp_hidden in enumerate(mtp_contracted):
+                _dsv4_log_loss_path_tensor(
+                    f"final_contract_mtp{i}_passthrough", mtp_hidden
+                )
 
             dict_args["hidden_states"] = paddle.concat(
                 [main_contracted, *mtp_contracted]
             )
+            _dsv4_log_loss_path_tensor(
+                "final_contract_output_concat", dict_args["hidden_states"]
+            )
 
         else:
+            _dsv4_log_loss_path_tensor("final_contract_input", hidden_states)
             # Learned output contraction: [s, b, n*h] -> [s, b, h]
             dict_args["hidden_states"] = (
                 HyperConnectionModule.learned_output_contract(
@@ -864,5 +1711,11 @@ class HyperConnectionContractLayer(FleetLayer):
                     self.n,
                     self.config.rms_norm_eps,
                 )
+            )
+            _dsv4_log_loss_path_tensor(
+                "final_contract_main_output", dict_args["hidden_states"]
+            )
+            _dsv4_log_loss_path_tensor(
+                "final_layernorm_input", dict_args["hidden_states"]
             )
         return dict_args

--- a/src/paddlefleet/transformer/hyper_connection.py
+++ b/src/paddlefleet/transformer/hyper_connection.py
@@ -31,24 +31,168 @@ import paddle
 import paddle.nn.functional as F
 from paddle import Tensor, nn
 
-from paddlefleet.tensor_parallel.random import get_cuda_rng_tracker
 from paddlefleet.transformer.layer import FleetLayer
 
 if TYPE_CHECKING:
     from paddlefleet.transformer.transformer_config import TransformerConfig
 
 
-_ACCURACY_COMPATIBLE_KERNEL: bool = (
-    os.environ.get("FLAGS_use_accuracy_compatible_kernel", "0") == "1"
-)
+def _dsv4_hc_sinkhorn_torch_backward(
+    logits: Tensor, grad_output: Tensor, num_iterations: int, eps: float
+) -> Tensor:
+    if os.environ.get("DSV4_FLEET_HC_SINKHORN_TORCH_BWD", "0") != "1":
+        return None
+    torch_site_packages = os.environ.get(
+        "DSV4_FLEET_HC_SINKHORN_TORCH_SITE_PACKAGES",
+        os.environ.get("DSV4_FLEET_TE_SITE_PACKAGES", ""),
+    )
+    if torch_site_packages:
+        import sys
+
+        if torch_site_packages not in sys.path:
+            sys.path.insert(0, torch_site_packages)
+    import torch
+    import torch.utils.dlpack
+    from paddle.utils import dlpack as paddle_dlpack
+
+    logits_t = torch.utils.dlpack.from_dlpack(
+        paddle_dlpack.to_dlpack(logits.contiguous())
+    ).to(torch.bfloat16)
+    grad_t = torch.utils.dlpack.from_dlpack(
+        paddle_dlpack.to_dlpack(grad_output.contiguous())
+    ).to(torch.bfloat16)
+    # Match Megatron's training graph: Sinkhorn receives a transposed-view grad
+    # from H_res.T @ residual, so the last two dimensions have stride (1, n).
+    grad_t = grad_t.transpose(-1, -2).contiguous().transpose(-1, -2)
+
+    with torch.enable_grad():
+        logits_t = logits_t.detach().requires_grad_(True)
+        row_max = logits_t.max(dim=-1, keepdim=True).values
+        m = torch.exp(logits_t - row_max)
+        for _ in range(num_iterations):
+            m = m / m.sum(dim=-1, keepdim=True).clamp(min=eps)
+            m = m / m.sum(dim=-2, keepdim=True).clamp(min=eps)
+        m.backward(grad_t)
+    grad_input_t = logits_t.grad.contiguous()
+    return paddle_dlpack.from_dlpack(torch.utils.dlpack.to_dlpack(grad_input_t))
 
 
-def _use_accuracy_compatible_kernel() -> bool:
-    """Switch for Megatron-aligned (accuracy-compatible) numeric paths.
+class _DSV4HCTorchOrderRmsScale(paddle.autograd.PyLayer):
+    @staticmethod
+    def forward(ctx, x: Tensor, eps: float):
+        nC = x.shape[-1]
+        norm = x.norm(axis=-1, keepdim=True)
+        r = 1.0 / (norm / math.sqrt(nC) + eps)
+        r = r.astype(x.dtype)
+        ctx.nC = nC
+        ctx.save_for_backward(x, norm, r)
+        return r
 
-    Controlled by the ``FLAGS_use_accuracy_compatible_kernel`` env variable.
-    """
-    return _ACCURACY_COMPATIBLE_KERNEL
+    @staticmethod
+    def backward(ctx, grad: Tensor):
+        x, norm, r = ctx.saved_tensor()
+        grad = grad.astype(x.dtype)
+        # Match Torch norm + reciprocal backward source-order in BF16.
+        scaled = grad * (r * r)
+        scaled = scaled / math.sqrt(ctx.nC)
+        unit = x / norm
+        grad_x = (-scaled) * unit
+        # PyTorch preserves signed zeros in this path. Paddle's multiply tends
+        # to canonicalize the grad==0 row to +0, which is numerically equal but
+        # breaks bitwise grad checks.
+        zero = paddle.zeros_like(unit)
+        torch_zero = paddle.where(x == 0, -paddle.ones_like(unit) * zero, (-unit) * zero)
+        grad_x = paddle.where(scaled == 0, torch_zero, grad_x)
+        return grad_x.astype(x.dtype)
+
+
+class _DSV4LearnedOutputContract(paddle.autograd.PyLayer):
+    @staticmethod
+    def forward(ctx, hidden_states: Tensor, head_fn: Tensor, base: Tensor, scale: Tensor, n: int, eps: float):
+        dtype = hidden_states.dtype
+        hidden_fp32 = hidden_states.astype("float32")
+        head_fn_fp32 = head_fn.astype("float32")
+        base_fp32 = base.astype("float32")
+        scale_fp32 = scale.astype("float32")
+
+        rsqrt = paddle.rsqrt(hidden_fp32.square().mean(-1, keepdim=True) + eps)
+        head_fn_out_in = head_fn_fp32.transpose([1, 0]).contiguous()
+        with paddle.amp.auto_cast(False):
+            proj = paddle.matmul(hidden_fp32, head_fn_out_in, transpose_y=True)
+        if os.environ.get("DSV4_FLEET_CONTRACT_MIXES_RSQRT_FIRST", "0") == "1":
+            mixes = rsqrt * proj
+        else:
+            mixes = proj * rsqrt
+        pre_arg = mixes * scale_fp32 + base_fp32
+        sig = F.sigmoid(pre_arg)
+        pre = sig + eps
+        hidden_streams = hidden_fp32.reshape([*hidden_fp32.shape[:-1], n, -1])
+        y = paddle.sum(pre.unsqueeze(-1) * hidden_streams, axis=-2)
+
+        ctx.save_for_backward(hidden_fp32, head_fn_fp32, base_fp32, scale_fp32, rsqrt, proj, mixes, sig, pre)
+        ctx.n = n
+        ctx.eps = eps
+        ctx.hidden_dtype = dtype
+        ctx.head_fn_dtype = head_fn.dtype
+        ctx.base_dtype = base.dtype
+        ctx.scale_dtype = scale.dtype
+        return y.astype(dtype)
+
+    @staticmethod
+    def backward(ctx, grad_output: Tensor):
+        hidden_fp32, head_fn_fp32, base_fp32, scale_fp32, rsqrt, proj, mixes, sig, pre = ctx.saved_tensor()
+        n = ctx.n
+        hdim = hidden_fp32.shape[-1]
+        hidden_streams = hidden_fp32.reshape([*hidden_fp32.shape[:-1], n, -1])
+        grad_y = grad_output.astype("float32")
+
+        grad_prod = paddle.expand(
+            grad_y.unsqueeze(-2),
+            [*hidden_streams.shape],
+        )
+        grad_hidden_streams = grad_prod * pre.unsqueeze(-1)
+        grad_hidden_direct = grad_hidden_streams.reshape(hidden_fp32.shape)
+
+        grad_pre = paddle.sum(grad_prod * hidden_streams, axis=-1)
+        grad_pre_arg = grad_pre * sig * (1.0 - sig)
+        grad_mixes = grad_pre_arg * scale_fp32
+        grad_scale = paddle.sum(grad_pre_arg * mixes).reshape(scale_fp32.shape)
+        grad_base = paddle.sum(
+            grad_pre_arg.reshape([-1, grad_pre_arg.shape[-1]]),
+            axis=0,
+        ).reshape(base_fp32.shape)
+
+        grad_proj = grad_mixes * rsqrt
+        grad_rsqrt = paddle.sum(grad_mixes * proj, axis=-1, keepdim=True)
+
+        hidden_2d = hidden_fp32.reshape([-1, hdim])
+        grad_proj_2d = grad_proj.reshape([-1, grad_proj.shape[-1]])
+        grad_head_fn = paddle.matmul(hidden_2d, grad_proj_2d, transpose_x=True)
+        grad_hidden_proj = paddle.matmul(grad_proj, head_fn_fp32, transpose_y=True)
+
+        grad_mean = grad_rsqrt * (-0.5) * rsqrt * rsqrt * rsqrt
+        grad_hidden_rsqrt = hidden_fp32 * grad_mean * (2.0 / float(hdim))
+
+        # Match PyTorch autograd's observed accumulation order for this graph:
+        # direct view branch, projection branch, then rsqrt/mean branch.
+        grad_hidden = (grad_hidden_direct + grad_hidden_proj) + grad_hidden_rsqrt
+
+        return (
+            grad_hidden.astype(ctx.hidden_dtype),
+            grad_head_fn.astype(ctx.head_fn_dtype),
+            grad_base.astype(ctx.base_dtype),
+            grad_scale.astype(ctx.scale_dtype),
+        )
+
+
+class _DSV4ContractBranchSplit(paddle.autograd.PyLayer):
+    @staticmethod
+    def forward(ctx, hidden_states: Tensor):
+        return hidden_states.clone(), hidden_states.clone(), hidden_states.clone()
+
+    @staticmethod
+    def backward(ctx, grad_rsqrt: Tensor, grad_proj: Tensor, grad_direct: Tensor):
+        return (grad_direct + grad_proj) + grad_rsqrt
 
 
 class SinkhornKnopp(paddle.autograd.PyLayer):
@@ -61,65 +205,70 @@ class SinkhornKnopp(paddle.autograd.PyLayer):
     Reference: Eq. (9) in mHC paper - M^{(t)} = T_c(T_r(M^{(t-1)}))
     """
 
+    eps = 1e-6
+
+    class _ExpRowMax(paddle.autograd.PyLayer):
+        @staticmethod
+        def forward(ctx, logits: Tensor) -> Tensor:
+            row_max = logits.max(axis=-1, keepdim=True)
+            out = paddle.exp(logits - row_max)
+            row_argmax = logits.argmax(axis=-1, keepdim=True)
+            ctx.save_for_backward(out, row_argmax)
+            return out
+
+        @staticmethod
+        def backward(ctx, grad_output: Tensor) -> tuple[Tensor]:
+            out, row_argmax = ctx.saved_tensor()
+            grad_z = grad_output * out
+            grad_row_max = grad_z.sum(axis=-1, keepdim=True)
+            row_argmax_mask = F.one_hot(
+                row_argmax.squeeze(-1), num_classes=out.shape[-1]
+            ).astype(out.dtype)
+            return grad_z - row_argmax_mask * grad_row_max
+
     @staticmethod
-    def _sinkhorn_normalize(
-        M: Tensor, num_iterations: int, eps: float = 1e-6
-    ) -> Tensor:
+    def _sinkhorn_normalize(M: Tensor, num_iterations: int) -> Tensor:
         """
         Apply Sinkhorn-Knopp normalization iterations.
 
         Args:
             M: [..., n, n] - positive matrix to normalize
             num_iterations: Number of Sinkhorn iterations
-            eps: Small constant for numerical stability
 
         Returns:
             M: [..., n, n] - doubly stochastic matrix
         """
         for _ in range(num_iterations):
             # T_r: Row normalization
-            M = M / M.sum(axis=-1, keepdim=True).clip(min=eps)
+            M = M / M.sum(axis=-1, keepdim=True).clip(min=SinkhornKnopp.eps)
             # T_c: Column normalization
-            M = M / M.sum(axis=-2, keepdim=True).clip(min=eps)
+            M = M / M.sum(axis=-2, keepdim=True).clip(min=SinkhornKnopp.eps)
         return M
 
     @staticmethod
-    def forward(
-        ctx, H_res_logits: Tensor, num_iterations: int, eps: float = 1e-6
-    ) -> Tensor:
+    def forward(ctx, H_res_logits: Tensor, num_iterations: int) -> Tensor:
         """
         Project to doubly stochastic matrix via iterative row/col normalization.
 
         Args:
             H_res_logits: [..., n, n] - raw logits for residual mixing matrix
             num_iterations: Number of Sinkhorn iterations (paper uses 20)
-            eps: Small constant for numerical stability
 
         Returns:
             H_res: [..., n, n] - doubly stochastic matrix
         """
-        # Stabilized exp: subtract row-wise max to prevent overflow.
-        # Under FLAGS_use_accuracy_compatible_kernel, force this outside AMP
-        # so the Paddle native path preserves the BF16 contract used by
-        # Megatron's torch implementation.
-        if _use_accuracy_compatible_kernel():
-            with paddle.amp.auto_cast(enable=False):
-                M_init = paddle.exp(
-                    H_res_logits - H_res_logits.max(axis=-1, keepdim=True)
-                )
-                M = SinkhornKnopp._sinkhorn_normalize(
-                    M_init, num_iterations, eps
-                )
-        else:
-            M_init = paddle.exp(
-                H_res_logits - H_res_logits.max(axis=-1, keepdim=True)
-            )
-            M = SinkhornKnopp._sinkhorn_normalize(M_init, num_iterations, eps)
+        with paddle.amp.auto_cast(enable=False):
+            # Stabilized exp: subtract row-wise max to prevent overflow.
+            # Keep this outside AMP so the Paddle native path preserves the
+            # BF16 contract used by Megatron's torch implementation.
+            M_init = SinkhornKnopp._ExpRowMax.apply(H_res_logits)
 
-        # Save initial M for backward recomputation
-        ctx.save_for_backward(M_init)
+            M = SinkhornKnopp._sinkhorn_normalize(M_init, num_iterations)
+
+        # Save logits instead of M_init so backward recomputes the same graph
+        # as Megatron: exp(logits - row_max) followed by Sinkhorn iterations.
+        ctx.save_for_backward(H_res_logits)
         ctx.num_iterations = num_iterations
-        ctx.eps = eps
         return M
 
     @staticmethod
@@ -127,92 +276,29 @@ class SinkhornKnopp(paddle.autograd.PyLayer):
         """
         Backward through Sinkhorn-Knopp iterations using recomputation.
         """
-        (M_init,) = ctx.saved_tensor()
+        (H_res_logits,) = ctx.saved_tensor()
         num_iterations = ctx.num_iterations
-        eps = ctx.eps
+        torch_grad_input = _dsv4_hc_sinkhorn_torch_backward(
+            H_res_logits, grad_output, num_iterations, SinkhornKnopp.eps
+        )
+        if torch_grad_input is not None:
+            return torch_grad_input
 
         with paddle.enable_grad():
-            # Recompute forward with autograd enabled
-            M_input = M_init.detach()
-            M_input.stop_gradient = False
+            logits = H_res_logits.detach()
+            logits.stop_gradient = False
+            with paddle.amp.auto_cast(enable=False):
+                M_current = SinkhornKnopp._ExpRowMax.apply(logits)
+                M_current = SinkhornKnopp._sinkhorn_normalize(M_current, num_iterations)
 
-            M_current = SinkhornKnopp._sinkhorn_normalize(
-                M_input, num_iterations, eps
-            )
-
-            # Compute dL/dM_input via autograd
-            grad_M_init = paddle.grad(
+            grad_input = paddle.grad(
                 outputs=[M_current],
-                inputs=[M_input],
+                inputs=[logits],
                 grad_outputs=[grad_output],
                 create_graph=False,
             )[0]
 
-        # Apply chain rule: dL/dH = dL/dM_init * dM_init/dH = dL/dM_init * M_init
-        # Since M_init = exp(H_res_logits), d(exp(x))/dx = exp(x) = M_init
-        grad_input = grad_M_init * M_init
-
         return grad_input
-
-
-def native_sinkhorn(
-    input_logits: Tensor, num_iterations: int, eps: float = 1e-6
-) -> Tensor:
-    """Native Sinkhorn-Knopp (PyLayer wrapper)."""
-    return SinkhornKnopp.apply(input_logits, num_iterations, eps)
-
-
-def native_proj_rms(
-    x: Tensor, weight: Tensor, eps: float = 1e-6
-) -> tuple[Tensor, Tensor]:
-    """Native fused projection + RMS normalization."""
-    nC = x.shape[-1]
-    r = x.norm(axis=-1, keepdim=True) / math.sqrt(nC)
-    r = 1.0 / (r + eps)
-    proj = paddle.matmul(x, weight)
-    return proj, r
-
-
-def native_h_aggregate(x_streams: Tensor, h_pre: Tensor) -> Tensor:
-    """Native n-stream weighted aggregation: out = sum_j(h_pre_j * x_j)."""
-    return (x_streams * h_pre.unsqueeze(-1)).sum(axis=-2)
-
-
-def native_h_post_bda(
-    h_res: Tensor,
-    original_residual: Tensor,
-    h_post: Tensor,
-    x: Tensor,
-    bias: Tensor | None,
-) -> Tensor:
-    """Native H_res @ residual + H_post * (x [+ bias]).
-
-    Args:
-        h_res: [..., n, n] - residual mixing matrix
-        original_residual: [..., n, C] - n-stream hidden states
-        h_post: [..., n] - expansion weights
-        x: [..., C] - layer output
-        bias: [C] or None
-
-    Returns:
-        output: [..., n, C]
-    """
-    leading_shape = original_residual.shape[:-2]
-    n, C = original_residual.shape[-2], original_residual.shape[-1]
-    num_tokens = math.prod(leading_shape)
-
-    h_res_batched = h_res.reshape([num_tokens, n, n])
-    residual_batched = original_residual.reshape([num_tokens, n, C])
-    mixed = paddle.bmm(h_res_batched, residual_batched).reshape(
-        [*leading_shape, n, C]
-    )
-
-    x_expanded = h_post.unsqueeze(-1) * x.unsqueeze(-2)  # [..., n, C]
-    if bias is not None:
-        bias = bias.reshape([1] * len(leading_shape) + [1, C])
-        bias_expanded = h_post.unsqueeze(-1) * bias
-        return x_expanded + bias_expanded + mixed
-    return x_expanded + mixed
 
 
 class HyperConnectionModule(nn.Layer):
@@ -279,40 +365,12 @@ class HyperConnectionModule(nn.Layer):
 
         self.norm_eps = 1e-6
 
-        # Choose implementation: fused kernels vs native reference.
-        if config.use_fused_mhc:
-            from paddlefleet.fusions.fused_mhc_kernels import (
-                fused_h_aggregate,
-                fused_h_post_bda,
-                fused_proj_rms,
-                fused_sinkhorn,
-            )
-
-            self._sinkhorn_op = fused_sinkhorn
-            self._h_aggregate_op = fused_h_aggregate
-            self._h_post_bda_op = fused_h_post_bda
-            self._proj_rms_op = fused_proj_rms
-        else:
-            self._sinkhorn_op = native_sinkhorn
-            self._h_aggregate_op = native_h_aggregate
-            self._h_post_bda_op = native_h_post_bda
-            self._proj_rms_op = native_proj_rms
-
         self._init_weights()
 
     def _init_weights(self) -> None:
         """Initialize weights for stable training."""
-        # Xavier uniform for mapping projection.
-        # Use the model-parallel RNG tracker so that the initialization is
-        # controlled by PaddleFleet's RNG state (seeded once at model init)
-        # rather than the per-layer pipeline seed (base_seed + layer_index).
-        # This prevents layer_index shifts (e.g. from MTPEmbeddingLayer insertion
-        # in magic_send mode) from changing the weights.
-        if paddle.distributed.get_world_size() <= 1:
-            nn.initializer.XavierUniform()(self.mapping_proj.weight)
-        else:
-            with get_cuda_rng_tracker().fork():
-                nn.initializer.XavierUniform()(self.mapping_proj.weight)
+        # Xavier uniform for mapping projection
+        nn.initializer.XavierUniform()(self.mapping_proj.weight)
 
         # Set sequence_parallel attribute on parameters for gradient synchronization
         if self.config.sequence_parallel:
@@ -329,27 +387,16 @@ class HyperConnectionModule(nn.Layer):
         Args:
             x: [..., n*C] - n-stream hidden states
         """
-        if _use_accuracy_compatible_kernel():
-            nC = x.shape[-1]
-            weight = self.mapping_proj.weight
-            r = x.norm(axis=-1, keepdim=True) / math.sqrt(nC)  # [..., 1]
-            r = (1.0 / (r + self.norm_eps)).astype(x.dtype)  # [..., 1]
-            # Match Megatron clean path: torch.matmul(x, weight.t()). Paddle
-            # nn.Linear uses a different BF16 cuBLAS path for this shape and
-            # drifts before the first HC BDA.
-            x_2d = x.reshape([-1, nC])
-            weight_out_in = weight.t().contiguous()
-            proj_2d = paddle.matmul(x_2d, weight_out_in, transpose_y=True)
-            proj = proj_2d.reshape([*x.shape[:-1], weight.shape[-1]])
-        else:
-            ori_dtype = x.dtype
-            proj, r = self._proj_rms_op(
-                x, self.mapping_proj.weight.astype(ori_dtype), self.norm_eps
-            )
-            if not self.config.high_precision_mhc:
-                r = r.astype(ori_dtype)
-
-        return proj, r
+        nC = x.shape[-1]
+        weight = self.mapping_proj.weight
+        x_2d = x.reshape([-1, nC])
+        r = _DSV4HCTorchOrderRmsScale.apply(x_2d, self.norm_eps)
+        # Match Megatron clean path: torch.matmul(x, weight.t()).  Paddle
+        # nn.Linear uses a different BF16 cuBLAS path for this shape and drifts
+        # before the first HC BDA.
+        proj_2d = paddle.matmul(x_2d, weight.t(), transpose_y=True)
+        proj = proj_2d.reshape([*x.shape[:-1], weight.shape[-1]])
+        return proj, r.reshape([*x.shape[:-1], 1])
 
     def _compute_h(
         self, proj: Tensor, r: Tensor
@@ -377,12 +424,12 @@ class HyperConnectionModule(nn.Layer):
         h = r * proj * alpha_ + self.bias
         # H_pre = σ(α_pre * (θ_pre @ x̃) + b_pre)
         h_pre = h[..., : self.n].sigmoid()  # [..., n]
+        h_pre = h_pre.astype(proj.dtype)
+
         # H_post = 2σ(α_post * (θ_post @ x̃) + b_post)
         h_post = h[..., self.n : 2 * self.n].sigmoid() * 2  # [..., n]
         h_res = h[..., 2 * self.n :]
-        if _use_accuracy_compatible_kernel():
-            h_pre = h_pre.astype(proj.dtype)
-            h_post = h_post.astype(proj.dtype)
+        h_post = h_post.astype(proj.dtype)
         return h_pre, h_post, h_res
 
     def compute_mappings(self, x: Tensor) -> tuple[Tensor, Tensor, Tensor]:
@@ -402,10 +449,11 @@ class HyperConnectionModule(nn.Layer):
         leading_shape = x.shape[:-1]
         proj, r = self._projection_and_get_norm(x)
         h_pre, h_post, h_res = self._compute_h(proj, r)
-        h_res = self._sinkhorn_op(
-            h_res.reshape([*leading_shape, self.n, self.n]),
+        h_res_logits = h_res
+        h_res_logits_view = h_res_logits.reshape([*leading_shape, self.n, self.n])
+        h_res = SinkhornKnopp.apply(
+            h_res_logits_view,
             self.sinkhorn_iterations,
-            self.norm_eps,
         )  # [..., n, n]
 
         return h_pre, h_post, h_res
@@ -429,17 +477,12 @@ class HyperConnectionModule(nn.Layer):
         # Reshape to [..., n, C]
         x_streams = x.reshape([*leading_shape, self.n, C])
 
-        if _use_accuracy_compatible_kernel():
-            # Weighted sum: [..., n, C] * [..., n, 1] -> sum over n -> [..., C]
-            aggregated = (x_streams * h_pre.unsqueeze(-1)).sum(axis=-2)
-            if aggregated.dtype != x.dtype:
-                aggregated = aggregated.astype(x.dtype)
-            return aggregated
-        else:
-            aggregated = self._h_aggregate_op(x_streams, h_pre)
-            if aggregated.dtype != x.dtype:
-                aggregated = aggregated.astype(x.dtype)
-            return aggregated
+        # Weighted sum: [..., n, C] * [..., n, 1] -> sum over n -> [..., C]
+        aggregated = (x_streams * h_pre.unsqueeze(-1)).sum(axis=-2)
+        if aggregated.dtype != x.dtype:
+            aggregated = aggregated.astype(x.dtype)
+
+        return aggregated
 
     def apply_h_res(self, h_res: Tensor, residual: Tensor) -> Tensor:
         """
@@ -456,18 +499,8 @@ class HyperConnectionModule(nn.Layer):
         C = self.hidden_size
         num_tokens = math.prod(leading_shape)
 
-        if _use_accuracy_compatible_kernel():
-            # Megatron clean path applies H_res.T to residual.
-            ndim = h_res.ndim
-            perm = [*list(range(ndim - 2)), ndim - 1, ndim - 2]
-            h_res_batched = (
-                h_res.astype(residual.dtype)
-                .transpose(perm)
-                .reshape([num_tokens, n, n])
-            )
-        else:
-            # Reshape for bmm: [..., n, n] -> [batch, n, n]
-            h_res_batched = h_res.reshape([num_tokens, n, n])
+        # Megatron clean path applies H_res.T to residual.
+        h_res_batched = h_res.astype(residual.dtype).transpose([0, 1, 3, 2]).reshape([num_tokens, n, n])
         # [..., n*C] -> [..., n, C] -> [batch, n, C]
         residual_batched = residual.reshape([num_tokens, n, C])
 
@@ -546,17 +579,14 @@ class HyperConnectionModule(nn.Layer):
             h_res: [..., n, n] - residual mixing matrix (for fused kernel)
             h_post: [..., n] - expansion weights
         """
-        with paddle.amp.auto_cast(enable=False):
-            # Compute mappings
-            if (
-                not _use_accuracy_compatible_kernel()
-                and self.config.high_precision_mhc
-            ):
-                hidden_states = hidden_states.astype("float32")
-            h_pre, h_post, h_res = self.compute_mappings(hidden_states)
+        mapping_input = hidden_states
+        aggregate_input = hidden_states
 
-            # Aggregate for layer input
-            aggregated = self.aggregate(hidden_states, h_pre)
+        # Compute mappings
+        h_pre, h_post, h_res = self.compute_mappings(mapping_input)
+
+        # Aggregate for layer input
+        aggregated = self.aggregate(aggregate_input, h_pre)
 
         return aggregated, h_res, h_post
 
@@ -630,34 +660,46 @@ class HyperConnectionModule(nn.Layer):
         Returns:
             contracted: [..., h] single-stream output
         """
+        if os.environ.get("DSV4_FLEET_CONTRACT_CUSTOM_BWD", "0") == "1":
+            return _DSV4LearnedOutputContract.apply(
+                hidden_states,
+                head_fn,
+                base,
+                scale,
+                n,
+                eps,
+            )
+
         dtype = hidden_states.dtype
         hidden_states = hidden_states.astype("float32")
         head_fn = head_fn.astype("float32")
         base = base.astype("float32")
         scale = scale.astype("float32")
+        hidden_for_rsqrt = hidden_states
+        hidden_for_proj = hidden_states
+        hidden_for_direct = hidden_states
+        if os.environ.get("DSV4_FLEET_CONTRACT_BRANCH_SPLIT", "0") == "1":
+            hidden_for_rsqrt, hidden_for_proj, hidden_for_direct = _DSV4ContractBranchSplit.apply(
+                hidden_states
+            )
 
         rsqrt = paddle.rsqrt(
-            hidden_states.square().mean(-1, keepdim=True) + eps
+            hidden_for_rsqrt.square().mean(-1, keepdim=True) + eps
         )
-        if _use_accuracy_compatible_kernel():
-            # Match Torch F.linear(x, weight[out,in]) kernel selection. Paddle
-            # F.linear(x, weight[in,out]) uses a different cuBLAS path and
-            # causes BF16 ulp drift in DSv4 final output contraction.
-            head_fn_out_in = head_fn.transpose([1, 0]).contiguous()
-            with paddle.amp.auto_cast(False):
-                proj = paddle.matmul(
-                    hidden_states, head_fn_out_in, transpose_y=True
-                )
-            mixes = proj * rsqrt
-        else:
-            mixes = F.linear(hidden_states, head_fn) * rsqrt
-        pre = F.sigmoid(mixes * scale + base) + eps
-        y = paddle.sum(
-            pre.unsqueeze(-1)
-            * hidden_states.reshape([*hidden_states.shape[:-1], n, -1]),
-            axis=-2,
-        )
-        return y.astype(dtype)
+        # Match Torch F.linear(x, weight[out,in]) kernel selection. Paddle
+        # F.linear(x, weight[in,out]) uses a different cuBLAS path and causes
+        # BF16 ulp drift in DSv4 final output contraction.
+        head_fn_out_in = head_fn.transpose([1, 0]).contiguous()
+        with paddle.amp.auto_cast(False):
+            proj = paddle.matmul(hidden_for_proj, head_fn_out_in, transpose_y=True)
+        mixes = proj * rsqrt
+        pre_arg = mixes * scale + base
+        pre = F.sigmoid(pre_arg) + eps
+        hidden_streams = hidden_for_direct.reshape([*hidden_for_direct.shape[:-1], n, -1])
+        contract_prod = pre.unsqueeze(-1) * hidden_streams
+        y = paddle.sum(contract_prod, axis=-2)
+        out = y.astype(dtype)
+        return out
 
     # ==================== Fused kernel placeholder ====================
 
@@ -695,43 +737,23 @@ class HyperConnectionModule(nn.Layer):
         Returns:
             output: [..., n*C] - final output after all operations
         """
-        with paddle.amp.auto_cast(enable=False):
-            x, bias = layer_output_with_bias
+        # Step 1: Apply H_res to original residual
+        mixed = self.apply_h_res(h_res, original_residual)
 
-            # Fast path: no dropout — use fused/native h_post_bda kernel
-            if not _use_accuracy_compatible_kernel() and (
-                dropout_prob == 0.0 or not training
-            ):
-                leading_shape = original_residual.shape[:-1]
-                n = self.n
-                C = self.hidden_size
-                orig_reshaped = original_residual.reshape(
-                    [*leading_shape, n, C]
-                )
-                if self.config.high_precision_mhc:
-                    orig_reshaped = orig_reshaped.astype("float32")
-                    x = x.astype("float32")
-                    if bias is not None:
-                        bias = bias.astype("float32")
-                output = self._h_post_bda_op(
-                    h_res, orig_reshaped, h_post, x, bias
-                )
-                return output.reshape([*leading_shape, n * C])
+        # Step 2: Apply H_post to layer output
+        x, bias = layer_output_with_bias
+        x_expanded = self._apply_h_post(x, h_post)
+        bias_expanded = (
+            self._apply_h_post(bias, h_post) if bias is not None else None
+        )
 
-            # Sequential path: used when dropout required OR accuracy-compatible kernel is NOT enabled
-            mixed = self.apply_h_res(h_res, original_residual)
-
-            x_expanded = self._apply_h_post(x, h_post)
-            bias_expanded = (
-                self._apply_h_post(bias, h_post) if bias is not None else None
-            )
-
-            if bias_expanded is not None:
-                x_expanded = x_expanded + bias_expanded
-            out = paddle.nn.functional.dropout(
-                x_expanded, p=dropout_prob, training=training
-            )
-            output = out + mixed
+        # Step 3: Bias-dropout-add
+        if bias_expanded is not None:
+            x_expanded = x_expanded + bias_expanded
+        out = paddle.nn.functional.dropout(
+            x_expanded, p=dropout_prob, training=training
+        )
+        output = mixed + out
 
         return output
 
@@ -777,7 +799,6 @@ class HyperConnectionContractLayer(FleetLayer):
         )
 
         self.num_mtp = getattr(config, "num_nextn_predict_layers", 0) or 0
-        self.magic_send = getattr(config, "enable_mtp_magic_send", False)
 
         # Learned contraction parameters (DSv4 style, always used)
         n = self.n
@@ -807,50 +828,30 @@ class HyperConnectionContractLayer(FleetLayer):
         hidden_states = dict_args["hidden_states"]
 
         # When MTP is enabled, preserve multi-stream for MTP input
-        if (
-            self.mtp_enabled
-            and self.num_mtp > 0
-            and not getattr(self.config, "mtp_load_weight_only", False)
-        ):
+        if self.mtp_enabled and self.num_mtp > 0:
             dict_args["mhc_multistream"] = hidden_states
 
-            if self.magic_send:
-                # magic_send: hidden_states is pure backbone [B, S, n*H]
-                # Magic send: backbone processes only main sequence, no MTP chunks concatenated.
-                # Simply contract the entire tensor.
-                dict_args["hidden_states"] = (
-                    HyperConnectionModule.learned_output_contract(
-                        hidden_states,
-                        self.hc_head_fn,
-                        self.hc_head_base,
-                        self.hc_head_scale,
-                        self.n,
-                        self.config.rms_norm_eps,
-                    )
-                )
-            else:
-                # Non-magic_send: backbone output is [backbone_chunk | mtp_chunks...] concatenated.
-                # Split, contract main backbone, slice MTP chunks.
-                chunks = paddle.split(hidden_states, self.num_mtp + 1)
+            # Split into main backbone + MTP chunks
+            chunks = paddle.split(hidden_states, self.num_mtp + 1)
 
-                # Main backbone: learned contraction [s, b, n*h] -> [s, b, h]
-                main_contracted = HyperConnectionModule.learned_output_contract(
-                    chunks[0],
-                    self.hc_head_fn,
-                    self.hc_head_base,
-                    self.hc_head_scale,
-                    self.n,
-                    self.config.rms_norm_eps,
-                )
+            # Main backbone: learned contraction [s, b, n*h] -> [s, b, h]
+            main_contracted = HyperConnectionModule.learned_output_contract(
+                chunks[0],
+                self.hc_head_fn,
+                self.hc_head_base,
+                self.hc_head_scale,
+                self.n,
+                self.config.rms_norm_eps,
+            )
 
-                # 为了后面MTP slice、取shape的时候兼容,原本也是expand过来的[[s,b,h]...]
-                mtp_contracted = [
-                    c[..., : c.shape[-1] // self.n] for c in chunks[1:]
-                ]
+            # 为了后面MTP slice、取shape的时候兼容,原本也是expand过来的[[s,b,h]...]
+            mtp_contracted = [
+                c[..., : c.shape[-1] // self.n] for c in chunks[1:]
+            ]
 
-                dict_args["hidden_states"] = paddle.concat(
-                    [main_contracted, *mtp_contracted]
-                )
+            dict_args["hidden_states"] = paddle.concat(
+                [main_contracted, *mtp_contracted]
+            )
 
         else:
             # Learned output contraction: [s, b, n*h] -> [s, b, h]

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -42,14 +42,11 @@ from paddlefleet.transformer.utils import profile
 
 from .fp8_utils import fused_stack_quant_without_cache
 from .fused_a2a import configure_buffer
-from .fusion_layer_utils import (
-    FusionMoePyLayer,
-    HybridEPMoePyLayer,
-)
-from .moe_expert import GroupedMLPExpert, SonicMoEExpert, StandardMLPExpert
+from .fusion_layer_utils import FusionMoePyLayer, HybridEPMoePyLayer
+from .moe_expert import GroupedMLPExpert, StandardMLPExpert
 from .moe_router import TopKRouter
 from .moe_shared_expert import StandardMLPSharedExpert
-from .moe_utils import AddAuxiliaryLoss, use_accuracy_compatible_kernel
+from .moe_utils import AddAuxiliaryLoss
 from .token_dispatcher import (
     AllToAllTokenDispatcher,
     MoEFlexTokenDispatcher,
@@ -58,6 +55,8 @@ from .token_dispatcher import (
 
 logger = logging.getLogger(__name__)
 
+def _dsv4_expert_scale_before_down_enabled() -> bool:
+    return os.environ.get("DSV4_FLEET_EXPERT_SCALE_BEFORE_DOWN", "0") == "1"
 
 # MD5 logging for MoE precision debugging
 _LOG_LAYER_MD5 = os.environ.get("LOG_LAYER_MD5", "0") == "1"
@@ -84,7 +83,39 @@ def _log_moe_md5(tensor, name, layer_idx=None):
         )
 
 
+class _DSV4MTPMoEInputBranches(PyLayer):
+    @staticmethod
+    def forward(ctx, x, is_mtp_layer, layer_number):
+        return x.clone(), x.clone(), x.clone()
+
+    @staticmethod
+    def backward(ctx, routed_grad, router_grad, shared_grad):
+        return (routed_grad + router_grad) + shared_grad
+
+
+def _dsv4_mtp_moe_split_input_branches(tensor, is_mtp_layer, layer_number):
+    if is_mtp_layer:
+        enabled = os.environ.get("DSV4_FLEET_MTP_MOE_INPUT_ORDER", "0") == "1"
+    else:
+        enabled = os.environ.get("DSV4_FLEET_MOE_INPUT_ORDER", "0") == "1"
+    if not enabled:
+        return tensor, tensor, tensor
+    if tensor is None or not isinstance(tensor, paddle.Tensor) or tensor.stop_gradient:
+        return tensor, tensor, tensor
+    return _DSV4MTPMoEInputBranches.apply(tensor, is_mtp_layer, layer_number)
+
+
+if paddlefleet_ops.is_sonic_moe_available():
+    from paddlefleet_ops.sonicmoe.enums import ActivationType
+    from paddlefleet_ops.sonicmoe.functional import (
+        _DownProjection,
+        _UpProjection,
+    )
+
 from .moe_utils import (
+    count_cumsum,
+    filter_scores,
+    fused_expert_parallel_TC_topk_router_metadata,
     global_moe_balance_training_logs_enabled,
     log_moe_balance,
     log_moe_losses,
@@ -136,10 +167,11 @@ class MoELayer(nn.Layer):
         config: TransformerConfig,
         sublayers: MoESublayers | None = None,
         pg_collection: ProcessGroupCollection | None = None,
+        layer_number: int | None = None,
     ):
         super().__init__()
         self.config = config
-        self.moe_sublayers = sublayers
+        self.sublayers = sublayers
         routed_expert_config = deepcopy(config)
         shared_expert_config = deepcopy(config)
         global_use_bias = routed_expert_config.use_bias
@@ -153,6 +185,7 @@ class MoELayer(nn.Layer):
                 moe_routed_expert_use_bias,
             )
         self.pg_collection = pg_collection
+        self.is_mtp_layer = False
         self.hidden_size = config.hidden_size
         self.moe_intermediate_size = config.moe_intermediate_size
         self.num_experts = config.n_routed_experts
@@ -170,11 +203,11 @@ class MoELayer(nn.Layer):
         self.use_hybrid_ep_backend = False
         self.moe_shared_expert_overlap = config.moe_shared_expert_overlap
         self.fp8 = config.fp8
+        self.fp8_dispatch = bool(config.fp8)
+        self.fp8_wgrad = config.fp8_wgrad
         self.use_ue8m0 = config.use_ue8m0
         self.dw_p2p_overlap = getattr(config, "dw_p2p_overlap", False)
         self.using_sonic_moe = self.config.using_sonic_moe
-        self.fp8_dispatch = bool(config.fp8) and not self.using_sonic_moe
-        self.fp8_wgrad = config.fp8_wgrad
         self.moe_expert_fusion = config.moe_expert_fusion
         self.moe_subbatch_token_num_after_dispatch = (
             config.moe_subbatch_token_num_after_dispatch
@@ -273,9 +306,10 @@ class MoELayer(nn.Layer):
                 )
                 self.moe_deep_gemm = False
 
-        self.moe_use_fusion_node = config.moe_use_fusion_node
+        self.moe_use_fusion_node = False
         if self.expert_model_parallel_size > 1:
             if self.moe_token_dispatcher_type in ("deepep", "hybridep"):
+                self.moe_use_fusion_node = config.moe_use_fusion_node
                 self.use_hybrid_ep_backend = is_hybrid_ep_backend_selected(
                     self.moe_token_dispatcher_type
                 )
@@ -289,10 +323,6 @@ class MoELayer(nn.Layer):
                     )
                     self.moe_shared_expert_overlap = False
             else:
-                logger.info(
-                    "moe_use_fusion_node is only supported when moe_token_dispatcher_type is 'deepep' or 'hybridep'; disabling it."
-                )
-                self.moe_use_fusion_node = False
                 if self.moe_expert_fusion:
                     raise ValueError(
                         "moe_expert_fusion is only supported when moe_token_dispatcher_type is 'deepep' or 'hybridep' and on GPU architecture SM90 or higher. If these conditions are not met, please set it to false in the configuration yaml."
@@ -307,6 +337,9 @@ class MoELayer(nn.Layer):
             assert self.moe_use_fusion_node, (
                 "fp8 can only be used when moe_use_fusion_node = True."
             )
+            assert not self.using_sonic_moe, (
+                "fp8 and sonic_moe cannot be used at the same time."
+            )
 
         if self.use_ue8m0:
             assert paddle.device.cuda.get_device_capability()[0] == 10, (
@@ -317,41 +350,15 @@ class MoELayer(nn.Layer):
         expert_args["config"] = routed_expert_config
         expert_args["moe_intermediate_size"] = self.moe_intermediate_size
         expert_args["is_expert"] = True
-        expert_args["mlp_spec"] = self.moe_sublayers.mlp_spec
+        expert_args["mlp_spec"] = self.sublayers.mlp_spec
 
-        use_fused_weight = self.moe_expert_fusion
-        if (
-            self.fp8
-            and (self.moe_expert_fusion is False)
-            and self.moe_deep_gemm
-        ):
-            raise ValueError(
-                "For fp8 deep_gemm (i.e. use k-grouped gemm in backward), moe_expert_fusion must be True."
+        if self.moe_expert_fusion and (not self.fp8 or self.moe_deep_gemm):
+            self.grouped_gemm_experts = GroupedMLPExpert(
+                self.num_local_experts,
+                routed_expert_config,
+                self.moe_deep_gemm,
+                pg_collection,
             )
-        if self.fp8 and self.moe_expert_fusion and self.moe_deep_gemm is False:
-            use_fused_weight = False
-        if self.using_sonic_moe:
-            assert use_fused_weight is True, (
-                "for sonic moe, expert weight must be fused."
-            )
-
-        if use_fused_weight:
-            if self.using_sonic_moe:
-                # TODO: replace grouped_gemm_experts with fusion_experts
-                self.grouped_gemm_experts = SonicMoEExpert(
-                    self.num_local_experts,
-                    self.num_experts_per_tok,
-                    routed_expert_config,
-                    pg_collection,
-                )
-            else:
-                # TODO: replace grouped_gemm_experts with fusion_experts
-                self.grouped_gemm_experts = GroupedMLPExpert(
-                    self.num_local_experts,
-                    routed_expert_config,
-                    self.moe_deep_gemm,
-                    pg_collection,
-                )
         else:
             self.experts = nn.LayerList([])
             for i in range(self.num_experts):
@@ -404,6 +411,7 @@ class MoELayer(nn.Layer):
                     self.num_experts_per_device,
                     local_expert_indices,
                 )
+                self.token_dispatcher.layer_number = layer_number
             else:
                 raise NotImplementedError(
                     f"Unsupported moe_token_dispatcher_type {self.moe_token_dispatcher_type}"
@@ -433,11 +441,8 @@ class MoELayer(nn.Layer):
         if self.expert_model_parallel_size > 1:
             self.is_mp_moe = False
             self.is_ep_moe = True
-            fusion_experts = None
-            if hasattr(self, "grouped_gemm_experts"):
-                fusion_experts = self.grouped_gemm_experts
-            if fusion_experts is not None:
-                for p in fusion_experts.parameters():
+            if self.moe_expert_fusion and (not self.fp8 or self.moe_deep_gemm):
+                for p in self.grouped_gemm_experts.parameters():
                     p.is_moe_param = True
                     p.color = {
                         "color": "moe_expert",
@@ -448,9 +453,6 @@ class MoELayer(nn.Layer):
                     if self.is_mp_moe or self.is_ep_moe:
                         p.is_distributed = True
             else:
-                assert self.experts is not None, (
-                    "experts should be initialized."
-                )
                 for p in self.experts.parameters():
                     p.is_moe_param = True
                     p.color = {
@@ -563,15 +565,14 @@ class MoELayer(nn.Layer):
             dispatched_input, num_or_sections=tokens_per_expert, axis=0
         )
         scale_chunks = None
-        if use_accuracy_compatible_kernel():
+        if _dsv4_expert_scale_before_down_enabled():
             per_token_scale = getattr(
                 self.token_dispatcher, "global_input_probs", None
             )
-            if per_token_scale is None:
-                raise RuntimeError(
-                    "FLAGS_use_accuracy_compatible_kernel requires dispatched "
-                    "router probabilities from the token dispatcher."
-                )
+            assert per_token_scale is not None, (
+                "DSV4_FLEET_EXPERT_SCALE_BEFORE_DOWN requires dispatched "
+                "router probabilities from the token dispatcher."
+            )
             scale_chunks = paddle.split(
                 per_token_scale, num_or_sections=tokens_per_expert, axis=0
             )
@@ -584,9 +585,7 @@ class MoELayer(nn.Layer):
             if scale_chunks is None:
                 expert_output = expert(chunk)[0]
             else:
-                expert_output = expert(chunk, per_token_scale=scale_chunks[i])[
-                    0
-                ]
+                expert_output = expert(chunk, per_token_scale=scale_chunks[i])[0]
             outputs += [expert_output]
 
         if not outputs:
@@ -717,12 +716,69 @@ class MoELayer(nn.Layer):
                     fp8_dispatched_handle=fp8_dispatched_handle,
                 )
             elif self.using_sonic_moe:
-                use_fp8 = self.fp8 is not None
-                hidden_states = self.grouped_gemm_experts(
-                    dispatched_hidden_states,
-                    dispatched_indices,
+                T = dispatched_hidden_states.shape[0]
+                K = self.num_experts_per_tok
+                stream_id = paddle.device.cuda.current_stream().cuda_stream
+                topk_scores = filter_scores(
                     dispatched_probs,
-                    use_fp8,
+                    dispatched_indices,
+                )
+                expert_frequency, expert_frequency_offset = count_cumsum(
+                    dispatched_indices,
+                    self.num_experts_per_device,
+                    do_cumsum=True,
+                )
+                activation_type = ActivationType("swiglu")
+
+                (
+                    expert_frequency_offset,
+                    x_gather_idx,
+                    s_scatter_idx,
+                    s_reverse_scatter_idx,
+                    num_activated_expert_per_token_offset,
+                ) = fused_expert_parallel_TC_topk_router_metadata(
+                    dispatched_indices,
+                    expert_frequency_offset,
+                    K,
+                )
+
+                TK = s_scatter_idx.shape[0]
+                is_varlen_K = True
+                w1 = self.grouped_gemm_experts.weight1
+                y1, z = _UpProjection.apply(
+                    dispatched_hidden_states,
+                    w1.permute(1, 2, 0),
+                    None,
+                    expert_frequency_offset,
+                    TK,
+                    K,
+                    stream_id,
+                    x_gather_idx,
+                    s_scatter_idx,
+                    s_reverse_scatter_idx,
+                    num_activated_expert_per_token_offset,
+                    is_varlen_K,
+                    activation_type,
+                    is_inference_mode_enabled=False,
+                )
+
+                w2 = self.grouped_gemm_experts.weight2
+                hidden_states = _DownProjection.apply(
+                    y1,
+                    z,
+                    w2.permute(1, 2, 0),
+                    None,
+                    topk_scores,
+                    expert_frequency_offset,
+                    T,
+                    K,
+                    stream_id,
+                    x_gather_idx,
+                    s_scatter_idx,
+                    s_reverse_scatter_idx,
+                    num_activated_expert_per_token_offset,
+                    is_varlen_K,
+                    activation_type,
                 )
             else:
                 hidden_states = FusionMoePyLayer.apply(
@@ -744,7 +800,6 @@ class MoELayer(nn.Layer):
                     use_ue8m0=self.use_ue8m0,
                     dw_p2p_overlap=self.dw_p2p_overlap,
                     clamp_value=self.config.activation_func_clamp_value,
-                    is_first_fwd=not framework._dygraph_tracer()._has_grad,
                 )
 
         with profile("combine"):
@@ -951,6 +1006,9 @@ class MoELayer(nn.Layer):
 
         layer_idx = getattr(self, "layer_number", None)
         _log_moe_md5(hidden_states, "moe_input", layer_idx)
+        routed_input, gate_input, shared_residuals = _dsv4_mtp_moe_split_input_branches(
+            hidden_states, self.is_mtp_layer, self.layer_number
+        )
         (
             capacity,
             topk_weights,
@@ -961,7 +1019,7 @@ class MoELayer(nn.Layer):
             aux_loss,
             z_loss,
         ) = self.gate(
-            hidden_states,
+            gate_input,
             input_ids=input_ids,
         )
         # topk_weights, topk_indices: Shape is [seq_len, moe_router_topk]
@@ -982,14 +1040,14 @@ class MoELayer(nn.Layer):
         ):
             combine_overlap_handle = {
                 "fn": self.shared_experts,
-                "fn_args": (residuals,),
+                "fn_args": (shared_residuals,),
             }
         else:
             combine_overlap_handle = None
         if self.expert_model_parallel_size > 1:
             if self.moe_use_fusion_node:
                 output = self.fusion_moe_forward(
-                    hidden_states,
+                    routed_input,
                     probs,
                     mask,
                     combine_overlap_handle,
@@ -998,7 +1056,7 @@ class MoELayer(nn.Layer):
                 )
             else:
                 output = self.custom_forward(
-                    hidden_states,
+                    routed_input,
                     probs,
                     mask,
                     topk_weights=topk_weights,
@@ -1015,7 +1073,7 @@ class MoELayer(nn.Layer):
                 reshaped_input = self.fc1_latent_proj(reshaped_input)
             if self.moe_expert_fusion:
                 output = self._forward_single_card_grouped_gemm_moe(
-                    reshaped_input, mask, probs, topk_indices, topk_weights
+                    reshaped_input, mask, probs
                 )
             else:
                 output = self._forward_single_card_moe(
@@ -1026,7 +1084,6 @@ class MoELayer(nn.Layer):
                 output = self.fc2_latent_proj(output)
 
         _log_moe_md5(output, "moe_routed_output", layer_idx)
-
         if self.training and self.router_aux_loss_coef and aux_loss is not None:
             aux_loss = aux_loss * float(self.router_aux_loss_coef)
             output = AddAuxiliaryLoss.apply(output, aux_loss)
@@ -1039,7 +1096,7 @@ class MoELayer(nn.Layer):
             if combine_overlap_handle is not None:
                 shared_output = combine_overlap_handle["fn_out"][0]
             else:
-                shared_output = self.shared_experts(residuals)[0]
+                shared_output = self.shared_experts(shared_residuals)[0]
             output = output + shared_output
 
         _log_moe_md5(output, "moe_final_output", layer_idx)
@@ -1109,8 +1166,6 @@ class MoELayer(nn.Layer):
         hidden_states: paddle.Tensor,
         routing_map: paddle.Tensor,
         probs: paddle.Tensor,
-        topk_indices: paddle.Tensor | None = None,
-        topk_weights: paddle.Tensor | None = None,
     ) -> paddle.Tensor:
         """
         Forward without expert parallelism
@@ -1133,14 +1188,69 @@ class MoELayer(nn.Layer):
             return indices, weights
 
         if self.using_sonic_moe:
-            use_fp8 = self.fp8 is not None
-            final_hidden_states = self.grouped_gemm_experts(
-                hidden_states,
-                topk_indices,
-                topk_weights,
-                use_fp8,
+            T = hidden_states.shape[0]
+            K = self.num_experts_per_tok
+            stream_id = paddle.device.cuda.current_stream().cuda_stream
+            selected_indices, topk_scores = _convert_routing_map_and_probs(
+                routing_map, probs, self.num_experts_per_tok
             )
-            return final_hidden_states.cast(hidden_states.dtype)
+            activation_type = ActivationType("swiglu")
+            expert_frequency, expert_frequency_offset = count_cumsum(
+                selected_indices, self.num_experts_per_device, do_cumsum=True
+            )
+
+            (
+                expert_frequency_offset,
+                x_gather_idx,
+                s_scatter_idx,
+                s_reverse_scatter_idx,
+                num_activated_expert_per_token_offset,
+            ) = fused_expert_parallel_TC_topk_router_metadata(
+                selected_indices,
+                expert_frequency_offset,
+                K,
+            )
+
+            s_scatter_idx.stop_gradient = True
+
+            w1 = self.grouped_gemm_experts.weight1
+
+            y1, z = _UpProjection.apply(
+                hidden_states,
+                w1.permute([1, 2, 0]),
+                None,
+                expert_frequency_offset,
+                T * K,
+                K,
+                stream_id,
+                x_gather_idx,
+                s_scatter_idx,
+                s_reverse_scatter_idx,
+                num_activated_expert_per_token_offset,
+                False,
+                activation_type,
+                is_inference_mode_enabled=False,
+            )
+
+            w2 = self.grouped_gemm_experts.weight2
+            hidden_states = _DownProjection.apply(
+                y1,
+                z,
+                w2.permute([1, 2, 0]),
+                None,
+                topk_scores,
+                expert_frequency_offset,
+                T,
+                K,
+                stream_id,
+                x_gather_idx,
+                s_scatter_idx,
+                s_reverse_scatter_idx,
+                num_activated_expert_per_token_offset,
+                False,
+                activation_type,
+            )
+            return hidden_states
         else:
             tokens_per_expert = routing_map.sum(axis=0)
             permuted_local_hidden_states, sorted_indices = permute(
@@ -1270,11 +1380,12 @@ class MoELayer(nn.Layer):
             return True
         return False
 
-    def set_layer_number(self, layer_number, is_mtp_layer: bool = False):
+    def set_layer_number(self, layer_number, is_mtp_layer=False):
         self.layer_number = layer_number
+        self.is_mtp_layer = is_mtp_layer
         assert hasattr(self.gate, "set_layer_number"), (
             "expect gate has method 'set_layer_number'"
         )
         # Hash routing activation (moe_n_hash_layers) is decided by the router
         # itself based on layer_number. See TopKRouter._setup_hash_layer.
-        self.gate.set_layer_number(layer_number, is_mtp_layer=is_mtp_layer)
+        self.gate.set_layer_number(layer_number, is_mtp_layer)

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -66,7 +66,7 @@ def _log_moe_md5(tensor, name, layer_idx=None):
     """Log MD5 of a tensor for MoE precision alignment debugging."""
     from paddlefleet.transformer.transformer_layer import TransformerLayer
 
-    if _LOG_LAYER_MD5 and TransformerLayer._gpt_model_use_experimental_version:
+    if _LOG_LAYER_MD5:
         if TransformerLayer._skip_mtp_probes:
             return  # Skip MTP passes — EC has no MTP
         data = tensor.detach().cast("float32").numpy().tobytes()
@@ -605,6 +605,15 @@ class MoELayer(nn.Layer):
         hidden_states = self.token_dispatcher.dispatch_preprocess(
             hidden_states, probs, routing_map, topk_weights, topk_indices
         )
+        layer_idx = getattr(self, "layer_number", None)
+        _log_moe_md5(
+            hidden_states, "dispatch_preprocess_hidden", layer_idx
+        )
+        _log_moe_md5(
+            getattr(self.token_dispatcher, "global_input_probs", probs),
+            "dispatch_preprocess_probs",
+            layer_idx,
+        )
         hidden_states, fp8_dispatched_handle = (
             self.token_dispatcher.token_dispatch(
                 hidden_states,
@@ -613,22 +622,62 @@ class MoELayer(nn.Layer):
                 use_ue8m0=self.use_ue8m0,
             )
         )
+        _log_moe_md5(hidden_states, "token_dispatch_hidden", layer_idx)
         return hidden_states, fp8_dispatched_handle
 
     def permute(self, hidden_states: paddle.Tensor):
         global_input_tokens, tokens_per_expert = (
             self.token_dispatcher.dispatch_postprocess(hidden_states)
         )
+        layer_idx = getattr(self, "layer_number", None)
+        _log_moe_md5(
+            global_input_tokens, "dispatch_postprocess_hidden", layer_idx
+        )
+        _log_moe_md5(
+            paddle.to_tensor(tokens_per_expert, dtype="float32")
+            if not isinstance(tokens_per_expert, paddle.Tensor)
+            else tokens_per_expert.cast("float32"),
+            "tokens_per_expert",
+            layer_idx,
+        )
+        dispatch_probs = getattr(
+            self.token_dispatcher, "global_input_probs", None
+        )
+        if dispatch_probs is not None:
+            _log_moe_md5(
+                dispatch_probs, "dispatch_postprocess_probs", layer_idx
+            )
         return global_input_tokens, tokens_per_expert
 
     def unpermute(self, hidden_states: paddle.Tensor):
-        return self.token_dispatcher.combine_preprocess(hidden_states)
+        hidden_states = self.token_dispatcher.combine_preprocess(hidden_states)
+        _log_moe_md5(
+            hidden_states,
+            "combine_preprocess_output",
+            getattr(self, "layer_number", None),
+        )
+        return hidden_states
 
     def combine(self, hidden_states: paddle.Tensor, async_finish: bool = False):
         hidden_states = self.token_dispatcher.token_combine(
             hidden_states, async_finish=async_finish
         )
-        return self.token_dispatcher.combine_postprocess(hidden_states)
+        layer_idx = getattr(self, "layer_number", None)
+        reverse_mapping = getattr(
+            self.token_dispatcher,
+            "reversed_local_input_permutation_mapping",
+            None,
+        )
+        if reverse_mapping is not None:
+            _log_moe_md5(
+                reverse_mapping.cast("float32"),
+                "reverse_mapping_for_combine",
+                layer_idx,
+            )
+        _log_moe_md5(hidden_states, "token_combine_output", layer_idx)
+        hidden_states = self.token_dispatcher.combine_postprocess(hidden_states)
+        _log_moe_md5(hidden_states, "combine_postprocess_output", layer_idx)
+        return hidden_states
 
     def routed_experts_compute(
         self,
@@ -638,6 +687,9 @@ class MoELayer(nn.Layer):
         expert_outs = self.expert_forward(
             global_input_tokens,
             tokens_per_expert,
+        )
+        _log_moe_md5(
+            expert_outs, "expert_output", getattr(self, "layer_number", None)
         )
         return self.unpermute(expert_outs)
 
@@ -1097,6 +1149,7 @@ class MoELayer(nn.Layer):
                 shared_output = combine_overlap_handle["fn_out"][0]
             else:
                 shared_output = self.shared_experts(shared_residuals)[0]
+            _log_moe_md5(shared_output, "shared_expert_output", layer_idx)
             output = output + shared_output
 
         _log_moe_md5(output, "moe_final_output", layer_idx)

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-import hashlib
 import logging
 import os
 from copy import deepcopy
@@ -57,30 +56,6 @@ logger = logging.getLogger(__name__)
 
 def _dsv4_expert_scale_before_down_enabled() -> bool:
     return os.environ.get("DSV4_FLEET_EXPERT_SCALE_BEFORE_DOWN", "0") == "1"
-
-# MD5 logging for MoE precision debugging
-_LOG_LAYER_MD5 = os.environ.get("LOG_LAYER_MD5", "0") == "1"
-
-
-def _log_moe_md5(tensor, name, layer_idx=None):
-    """Log MD5 of a tensor for MoE precision alignment debugging."""
-    from paddlefleet.transformer.transformer_layer import TransformerLayer
-
-    if _LOG_LAYER_MD5:
-        if TransformerLayer._skip_mtp_probes:
-            return  # Skip MTP passes — EC has no MTP
-        data = tensor.detach().cast("float32").numpy().tobytes()
-        md5 = hashlib.md5(data).hexdigest()
-        rank = (
-            paddle.distributed.get_rank()
-            if paddle.distributed.is_initialized()
-            else 0
-        )
-        layer_str = f" Layer={layer_idx}" if layer_idx is not None else ""
-        print(
-            f"[MD5 MoE] Rank={rank}{layer_str} {name} MD5={md5} shape={list(tensor.shape)}",
-            flush=True,
-        )
 
 
 class _DSV4MTPMoEInputBranches(PyLayer):
@@ -605,15 +580,6 @@ class MoELayer(nn.Layer):
         hidden_states = self.token_dispatcher.dispatch_preprocess(
             hidden_states, probs, routing_map, topk_weights, topk_indices
         )
-        layer_idx = getattr(self, "layer_number", None)
-        _log_moe_md5(
-            hidden_states, "dispatch_preprocess_hidden", layer_idx
-        )
-        _log_moe_md5(
-            getattr(self.token_dispatcher, "global_input_probs", probs),
-            "dispatch_preprocess_probs",
-            layer_idx,
-        )
         hidden_states, fp8_dispatched_handle = (
             self.token_dispatcher.token_dispatch(
                 hidden_states,
@@ -622,61 +588,23 @@ class MoELayer(nn.Layer):
                 use_ue8m0=self.use_ue8m0,
             )
         )
-        _log_moe_md5(hidden_states, "token_dispatch_hidden", layer_idx)
         return hidden_states, fp8_dispatched_handle
 
     def permute(self, hidden_states: paddle.Tensor):
         global_input_tokens, tokens_per_expert = (
             self.token_dispatcher.dispatch_postprocess(hidden_states)
         )
-        layer_idx = getattr(self, "layer_number", None)
-        _log_moe_md5(
-            global_input_tokens, "dispatch_postprocess_hidden", layer_idx
-        )
-        _log_moe_md5(
-            paddle.to_tensor(tokens_per_expert, dtype="float32")
-            if not isinstance(tokens_per_expert, paddle.Tensor)
-            else tokens_per_expert.cast("float32"),
-            "tokens_per_expert",
-            layer_idx,
-        )
-        dispatch_probs = getattr(
-            self.token_dispatcher, "global_input_probs", None
-        )
-        if dispatch_probs is not None:
-            _log_moe_md5(
-                dispatch_probs, "dispatch_postprocess_probs", layer_idx
-            )
         return global_input_tokens, tokens_per_expert
 
     def unpermute(self, hidden_states: paddle.Tensor):
         hidden_states = self.token_dispatcher.combine_preprocess(hidden_states)
-        _log_moe_md5(
-            hidden_states,
-            "combine_preprocess_output",
-            getattr(self, "layer_number", None),
-        )
         return hidden_states
 
     def combine(self, hidden_states: paddle.Tensor, async_finish: bool = False):
         hidden_states = self.token_dispatcher.token_combine(
             hidden_states, async_finish=async_finish
         )
-        layer_idx = getattr(self, "layer_number", None)
-        reverse_mapping = getattr(
-            self.token_dispatcher,
-            "reversed_local_input_permutation_mapping",
-            None,
-        )
-        if reverse_mapping is not None:
-            _log_moe_md5(
-                reverse_mapping.cast("float32"),
-                "reverse_mapping_for_combine",
-                layer_idx,
-            )
-        _log_moe_md5(hidden_states, "token_combine_output", layer_idx)
         hidden_states = self.token_dispatcher.combine_postprocess(hidden_states)
-        _log_moe_md5(hidden_states, "combine_postprocess_output", layer_idx)
         return hidden_states
 
     def routed_experts_compute(
@@ -687,9 +615,6 @@ class MoELayer(nn.Layer):
         expert_outs = self.expert_forward(
             global_input_tokens,
             tokens_per_expert,
-        )
-        _log_moe_md5(
-            expert_outs, "expert_output", getattr(self, "layer_number", None)
         )
         return self.unpermute(expert_outs)
 
@@ -1056,8 +981,6 @@ class MoELayer(nn.Layer):
         orig_shape = hidden_states.shape
         residuals = hidden_states
 
-        layer_idx = getattr(self, "layer_number", None)
-        _log_moe_md5(hidden_states, "moe_input", layer_idx)
         routed_input, gate_input, shared_residuals = _dsv4_mtp_moe_split_input_branches(
             hidden_states, self.is_mtp_layer, self.layer_number
         )
@@ -1079,10 +1002,8 @@ class MoELayer(nn.Layer):
         # mask (routing_map): binary selection matrix [seq_len, num_experts]
         # capacity, priorities are used for dropping tokens, currently they are not used
 
-        _log_moe_md5(probs, "probs", layer_idx)
-        _log_moe_md5(mask, "routing_mask", layer_idx)
         if framework._dygraph_tracer()._has_grad:
-            log_moe_losses(layer_idx, aux_loss=aux_loss, z_loss=z_loss)
+            log_moe_losses(self.layer_number, aux_loss=aux_loss, z_loss=z_loss)
 
         if (
             self.shared_experts is not None
@@ -1135,7 +1056,6 @@ class MoELayer(nn.Layer):
             if self.use_latent_moe:
                 output = self.fc2_latent_proj(output)
 
-        _log_moe_md5(output, "moe_routed_output", layer_idx)
         if self.training and self.router_aux_loss_coef and aux_loss is not None:
             aux_loss = aux_loss * float(self.router_aux_loss_coef)
             output = AddAuxiliaryLoss.apply(output, aux_loss)
@@ -1149,10 +1069,7 @@ class MoELayer(nn.Layer):
                 shared_output = combine_overlap_handle["fn_out"][0]
             else:
                 shared_output = self.shared_experts(shared_residuals)[0]
-            _log_moe_md5(shared_output, "shared_expert_output", layer_idx)
             output = output + shared_output
-
-        _log_moe_md5(output, "moe_final_output", layer_idx)
 
         if self.expert_model_parallel_size <= 1 and self.sequence_parallel:
             output = ScatterOp.apply(output)

--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -62,6 +62,21 @@ def _get_moe_topk_fusion():
 _moe_router_logger = logging.getLogger(__name__)
 
 
+def _dsv4_router_fp32_wgrad_enabled() -> bool:
+    return os.environ.get("DSV4_FLEET_ROUTER_FP32_WGRAD", "0") == "1"
+
+
+def _dsv4_accumulate_router_fp32_wgrad(weight, w_grad):
+    if not _dsv4_router_fp32_wgrad_enabled() or w_grad is None:
+        return
+    w_grad = w_grad.detach().cast(paddle.float32)
+    prev = getattr(weight, "_dsv4_router_gate_fp32_wgrad", None)
+    if prev is None:
+        weight._dsv4_router_gate_fp32_wgrad = w_grad
+    else:
+        weight._dsv4_router_gate_fp32_wgrad = prev + w_grad
+
+
 def _log_moe_md5(tensor, name, layer_idx=None):
     """Log MD5 of a tensor for MoE precision alignment debugging."""
     from paddlefleet.transformer.transformer_layer import TransformerLayer
@@ -95,6 +110,7 @@ class FusedGateDetachMatmul(paddle.autograd.PyLayer):
         """
         ctx.dw_p2p_overlap = dw_p2p_overlap
         ctx.dtype = paddle.float32
+        ctx.weight_ref = w
         ctx.save_for_backward(x, w)
         w = w.T
         return F.linear(x.cast(ctx.dtype), w.cast(ctx.dtype))
@@ -105,6 +121,7 @@ class FusedGateDetachMatmul(paddle.autograd.PyLayer):
         backward
         """
         x, w = ctx.saved_tensor()
+        weight_ref = getattr(ctx, "weight_ref", w)
         assert ctx.dtype == y_grad.dtype, "dtype not match"
 
         w_stop_grad = w.stop_gradient
@@ -112,9 +129,11 @@ class FusedGateDetachMatmul(paddle.autograd.PyLayer):
 
         def _compute_weight_grad(x_cast, y_grad, weight):
             with paddle.amp.auto_cast(False):
-                w_grad = paddle.matmul(
+                w_grad_fp32 = paddle.matmul(
                     x_cast, y_grad, transpose_x=True
                 ).T  # 始终先算梯度
+                _dsv4_accumulate_router_fp32_wgrad(weight, w_grad_fp32)
+                w_grad = w_grad_fp32.cast("bfloat16").cast(paddle.float32)
 
             if hasattr(weight, "main_grad"):
                 if weight.main_grad is None:
@@ -147,13 +166,14 @@ class FusedGateDetachMatmul(paddle.autograd.PyLayer):
                         _compute_weight_grad,
                         x_cast.detach(),
                         y_grad.detach(),
-                        w,
+                        weight_ref,
                     )
                 )
                 WeightGradStore.enabled = False
                 return x_grad, None
         else:
-            w = w.T
+            weight = weight_ref
+            w = weight.T
             x_g, w_g = matmul_grad(
                 x.cast(ctx.dtype),
                 w.cast(ctx.dtype),
@@ -163,9 +183,11 @@ class FusedGateDetachMatmul(paddle.autograd.PyLayer):
             )
 
             x_grad = x_g.cast(x.dtype) if not x_stop_grad else None
-            w_grad = w_g.cast(w.dtype) if not w_stop_grad else None
-            if w_grad is not None:
-                w_grad = w_grad.T
+            w_grad = None
+            if not w_stop_grad:
+                w_grad_fp32 = w_g.T
+                _dsv4_accumulate_router_fp32_wgrad(weight, w_grad_fp32)
+                w_grad = w_grad_fp32.cast("bfloat16").cast(weight.dtype)
 
             return x_grad, w_grad
 
@@ -222,8 +244,6 @@ class StandardMoERouter(nn.Layer):
         self.topk_method = config.topk_method
         self.num_experts_per_tok = config.num_experts_per_tok
         self.norm_topk_prob = config.norm_topk_prob
-        # force keep in float32 when using amp
-        self._cast_to_low_precision = False
 
         self.n_group = config.n_group
 
@@ -250,7 +270,7 @@ class StandardMoERouter(nn.Layer):
         # Initialize gate weight with Normal distribution aligned with Megatron.
         self.weight = paddle.create_parameter(
             shape=[self.num_experts, self.hidden_size],
-            dtype="float32",
+            dtype=config.params_dtype or "float32",
             default_initializer=paddle.nn.initializer.Constant(0.0),
         )
         config.init_method(self.weight)
@@ -843,6 +863,7 @@ class StandardMoERouter(nn.Layer):
 
     def set_layer_number(self, layer_number, is_mtp_layer: bool = False):
         self.layer_number = layer_number
+        self.is_mtp_layer = is_mtp_layer
         self._setup_hash_layer(layer_number, is_mtp_layer)
 
     def _setup_hash_layer(self, layer_number, is_mtp_layer: bool = False):
@@ -922,6 +943,7 @@ class TopKRouter(StandardMoERouter):
     def set_layer_number(self, layer_number, is_mtp_layer: bool = False):
         self._layer_number = layer_number
         self.layer_number = layer_number
+        self.is_mtp_layer = is_mtp_layer
         self._setup_hash_layer(layer_number, is_mtp_layer=is_mtp_layer)
 
     def forward(self, input, input_ids=None):
@@ -952,6 +974,8 @@ class TopKRouter(StandardMoERouter):
                     f"input_ids=[{batch_size_}, {seq_len_}], "
                     f"expected [batch_size={batch_size}, seq_len={seq_len}]"
                 )
+                if self.is_mtp_layer:
+                    input_ids_none_zero_mask = None
             else:
                 input_ids_none_zero_mask = None
         elif len(input.shape) == 2:

--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -16,7 +16,6 @@
 # limitations under the License.
 from __future__ import annotations
 
-import hashlib
 import logging
 import os
 from functools import partial
@@ -43,9 +42,6 @@ from paddlefleet.context_parallel_utils import (
 from paddlefleet.parallel_state import get_context_parallel_world_size
 from paddlefleet.transformer.moe.moe_utils import apply_random_logits
 
-# MD5 logging for MoE router precision debugging
-_LOG_LAYER_MD5 = os.environ.get("LOG_LAYER_MD5", "0") == "1"
-
 # Lazy-loaded MoETopkFusion Triton kernel for bit-exact alignment
 _MoETopkFusion = None
 
@@ -62,15 +58,11 @@ def _get_moe_topk_fusion():
 _moe_router_logger = logging.getLogger(__name__)
 
 
-def _dsv4_router_torch_probe_enabled() -> bool:
-    return os.environ.get("DSV4_FLEET_ROUTER_TORCH_PROBE", "0") == "1"
-
-
 def _dsv4_router_torch_mm_enabled() -> bool:
     return os.environ.get("DSV4_FLEET_ROUTER_TORCH_MM", "0") == "1"
 
 
-def _dsv4_import_torch_for_router_probe():
+def _dsv4_import_torch_for_router():
     import sys
 
     torch_site_packages = os.environ.get("DSV4_FLEET_TE_SITE_PACKAGES")
@@ -83,7 +75,7 @@ def _dsv4_import_torch_for_router_probe():
 
 
 def _dsv4_torch_gate_mm(x, weight):
-    torch = _dsv4_import_torch_for_router_probe()
+    torch = _dsv4_import_torch_for_router()
     x_t = torch.utils.dlpack.from_dlpack(
         paddle.utils.dlpack.to_dlpack(x.detach().contiguous())
     )
@@ -110,45 +102,6 @@ def _dsv4_accumulate_router_fp32_wgrad(weight, w_grad):
         weight._dsv4_router_gate_fp32_wgrad = w_grad
     else:
         weight._dsv4_router_gate_fp32_wgrad = prev + w_grad
-
-
-def _log_moe_md5(tensor, name, layer_idx=None):
-    """Log MD5 of a tensor for MoE precision alignment debugging."""
-    from paddlefleet.transformer.transformer_layer import TransformerLayer
-
-    if _LOG_LAYER_MD5:
-        if TransformerLayer._skip_mtp_probes:
-            return  # Skip MTP passes — EC has no MTP
-        data = tensor.detach().cast("float32").numpy().tobytes()
-        md5 = hashlib.md5(data).hexdigest()
-        rank = (
-            paddle.distributed.get_rank()
-            if paddle.distributed.is_initialized()
-            else 0
-        )
-        layer_str = f" Layer={layer_idx}" if layer_idx is not None else ""
-        print(
-            f"[MD5 MoE] Rank={rank}{layer_str} {name} MD5={md5} shape={list(tensor.shape)}",
-            flush=True,
-        )
-
-
-def _log_torch_gate_mm_probe(x, weight, layer_idx=None):
-    if not (_LOG_LAYER_MD5 and _dsv4_router_torch_probe_enabled()):
-        return
-    logits = _dsv4_torch_gate_mm(x, weight)
-    data = logits.detach().cast("float32").numpy().tobytes()
-    md5 = hashlib.md5(data).hexdigest()
-    rank = (
-        paddle.distributed.get_rank()
-        if paddle.distributed.is_initialized()
-        else 0
-    )
-    layer_str = f" Layer={layer_idx}" if layer_idx is not None else ""
-    print(
-        f"[MD5 MoE] Rank={rank}{layer_str} gate_logits_torch_probe MD5={md5} shape={list(logits.shape)}",
-        flush=True,
-    )
 
 
 class FusedGateDetachMatmul(paddle.autograd.PyLayer):
@@ -1047,7 +1000,6 @@ class TopKRouter(StandardMoERouter):
             )
 
         with paddle.amp.auto_cast(False):
-            _log_moe_md5(self.weight, "gate_weight", self._layer_number)
             logits = gate_detach_matmul(
                 input,
                 self.weight,
@@ -1055,9 +1007,6 @@ class TopKRouter(StandardMoERouter):
                 self.config.moe_router_force_load_balancing,
                 getattr(self.config, "dw_p2p_overlap", False),
             )
-            _log_torch_gate_mm_probe(input, self.weight, self._layer_number)
-
-        _log_moe_md5(logits, "gate_logits", self._layer_number)
 
         # ---- Hash routing branch ----
         if self.is_hash_layer:
@@ -1086,11 +1035,6 @@ class TopKRouter(StandardMoERouter):
                 top_gate = top_gate * valid_mask
                 top_idx = top_idx.masked_fill(~valid_mask.cast(paddle.bool), -1)
 
-            _log_moe_md5(
-                top_idx.cast(paddle.float32),
-                "hash_topk_indices",
-                self._layer_number,
-            )
             # No aux/z loss, no expert-bias updates on hash layers.
             return (None, top_gate, top_idx, probs, mask, None, None, None)
         # ---- end hash routing ----
@@ -1105,8 +1049,6 @@ class TopKRouter(StandardMoERouter):
             )
             logits = logits * valid_mask
             gates = gates * valid_mask
-
-        _log_moe_md5(gates, "gate_probs_sigmoid", self._layer_number)
 
         # Use clone() to ensure that the execution order of the grad nodes is consistent with EC.
         gates_ori = gates.clone()
@@ -1136,15 +1078,6 @@ class TopKRouter(StandardMoERouter):
                 )
             else:
                 probs_for_choice = gates + self.e_score_correction_bias.detach()
-            if _LOG_LAYER_MD5 and self._layer_number == 0:
-                _log_moe_md5(
-                    self.e_score_correction_bias,
-                    "e_score_correction_bias",
-                    self._layer_number,
-                )
-                _log_moe_md5(
-                    probs_for_choice, "probs_for_choice", self._layer_number
-                )
             top_gate, top_idx = MoETopkFusion.apply(
                 gates,  # gate_probs (original sigmoid scores)
                 probs_for_choice,  # probs_for_choice (with correction bias)
@@ -1155,20 +1088,6 @@ class TopKRouter(StandardMoERouter):
                 self.norm_topk_prob,  # norm_gate_logits
             )
             # top_gate is already normalized by the Triton kernel when norm_topk_prob=True
-
-            _log_moe_md5(
-                top_idx.cast("float32"), "topk_indices", self._layer_number
-            )
-            # Log raw weights and sum for alignment verification (re-computed from gate_probs)
-            if _LOG_LAYER_MD5:
-                raw_topk_weights = paddle.take_along_axis(
-                    gates, top_idx, axis=-1
-                )
-                _log_moe_md5(
-                    raw_topk_weights, "topk_weights_raw", self._layer_number
-                )
-                raw_sum = raw_topk_weights.sum(axis=-1, keepdim=True)
-                _log_moe_md5(raw_sum, "topk_raw_sum", self._layer_number)
         else:
             # top_gate: [B*S, K], top_idx: [B*S, K]
             top_gate, top_idx = self._call_topk_method(
@@ -1178,11 +1097,6 @@ class TopKRouter(StandardMoERouter):
                 n_group=self.n_group,
                 topk_group=self.topk_group,
             )
-
-            _log_moe_md5(
-                top_idx.cast("float32"), "topk_indices", self._layer_number
-            )
-            _log_moe_md5(top_gate, "topk_weights_raw", self._layer_number)
 
         # z-loss
         if self.config.router_z_loss_coef:
@@ -1232,9 +1146,6 @@ class TopKRouter(StandardMoERouter):
         probs = paddle.zeros_like(gates, dtype=top_gate.dtype).put_along_axis_(
             top_idx, top_gate, axis=1
         )
-
-        _log_moe_md5(probs, "probs", self._layer_number)
-        _log_moe_md5(top_gate, "topk_weights_normed", self._layer_number)
 
         if self.topk_method == "noaux_tc":
             with paddle.no_grad():

--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -62,6 +62,41 @@ def _get_moe_topk_fusion():
 _moe_router_logger = logging.getLogger(__name__)
 
 
+def _dsv4_router_torch_probe_enabled() -> bool:
+    return os.environ.get("DSV4_FLEET_ROUTER_TORCH_PROBE", "0") == "1"
+
+
+def _dsv4_router_torch_mm_enabled() -> bool:
+    return os.environ.get("DSV4_FLEET_ROUTER_TORCH_MM", "0") == "1"
+
+
+def _dsv4_import_torch_for_router_probe():
+    import sys
+
+    torch_site_packages = os.environ.get("DSV4_FLEET_TE_SITE_PACKAGES")
+    if torch_site_packages and torch_site_packages not in sys.path:
+        sys.path.insert(0, torch_site_packages)
+    import torch
+    import torch.utils.dlpack
+
+    return torch
+
+
+def _dsv4_torch_gate_mm(x, weight):
+    torch = _dsv4_import_torch_for_router_probe()
+    x_t = torch.utils.dlpack.from_dlpack(
+        paddle.utils.dlpack.to_dlpack(x.detach().contiguous())
+    )
+    w_t = torch.utils.dlpack.from_dlpack(
+        paddle.utils.dlpack.to_dlpack(weight.detach().contiguous())
+    )
+    with torch.no_grad():
+        logits_t = torch.mm(x_t.float(), w_t.float().t())
+    return paddle.utils.dlpack.from_dlpack(
+        torch.utils.dlpack.to_dlpack(logits_t.contiguous())
+    )
+
+
 def _dsv4_router_fp32_wgrad_enabled() -> bool:
     return os.environ.get("DSV4_FLEET_ROUTER_FP32_WGRAD", "0") == "1"
 
@@ -81,7 +116,7 @@ def _log_moe_md5(tensor, name, layer_idx=None):
     """Log MD5 of a tensor for MoE precision alignment debugging."""
     from paddlefleet.transformer.transformer_layer import TransformerLayer
 
-    if _LOG_LAYER_MD5 and TransformerLayer._gpt_model_use_experimental_version:
+    if _LOG_LAYER_MD5:
         if TransformerLayer._skip_mtp_probes:
             return  # Skip MTP passes — EC has no MTP
         data = tensor.detach().cast("float32").numpy().tobytes()
@@ -98,6 +133,24 @@ def _log_moe_md5(tensor, name, layer_idx=None):
         )
 
 
+def _log_torch_gate_mm_probe(x, weight, layer_idx=None):
+    if not (_LOG_LAYER_MD5 and _dsv4_router_torch_probe_enabled()):
+        return
+    logits = _dsv4_torch_gate_mm(x, weight)
+    data = logits.detach().cast("float32").numpy().tobytes()
+    md5 = hashlib.md5(data).hexdigest()
+    rank = (
+        paddle.distributed.get_rank()
+        if paddle.distributed.is_initialized()
+        else 0
+    )
+    layer_str = f" Layer={layer_idx}" if layer_idx is not None else ""
+    print(
+        f"[MD5 MoE] Rank={rank}{layer_str} gate_logits_torch_probe MD5={md5} shape={list(logits.shape)}",
+        flush=True,
+    )
+
+
 class FusedGateDetachMatmul(paddle.autograd.PyLayer):
     """
     FusedGateDetachMatmul
@@ -112,6 +165,8 @@ class FusedGateDetachMatmul(paddle.autograd.PyLayer):
         ctx.dtype = paddle.float32
         ctx.weight_ref = w
         ctx.save_for_backward(x, w)
+        if _dsv4_router_torch_mm_enabled():
+            return _dsv4_torch_gate_mm(x, w)
         w = w.T
         return F.linear(x.cast(ctx.dtype), w.cast(ctx.dtype))
 
@@ -992,6 +1047,7 @@ class TopKRouter(StandardMoERouter):
             )
 
         with paddle.amp.auto_cast(False):
+            _log_moe_md5(self.weight, "gate_weight", self._layer_number)
             logits = gate_detach_matmul(
                 input,
                 self.weight,
@@ -999,6 +1055,7 @@ class TopKRouter(StandardMoERouter):
                 self.config.moe_router_force_load_balancing,
                 getattr(self.config, "dw_p2p_overlap", False),
             )
+            _log_torch_gate_mm_probe(input, self.weight, self._layer_number)
 
         _log_moe_md5(logits, "gate_logits", self._layer_number)
 

--- a/src/paddlefleet/transformer/moe/moe_utils.py
+++ b/src/paddlefleet/transformer/moe/moe_utils.py
@@ -45,22 +45,41 @@ if TYPE_CHECKING:
     from paddle.distributed.communication.group import Group
 
 
-_USE_ACCURACY_COMPATIBLE_KERNEL = (
-    os.environ.get("FLAGS_use_accuracy_compatible_kernel", "0") == "1"
-)
+def _dsv4_fleet_moe_fp32_accum_enabled() -> bool:
+    return os.environ.get("DSV4_FLEET_MOE_FP32_ACCUM", "0") == "1"
 
 
-def use_accuracy_compatible_kernel() -> bool:
-    """Unified switch for accuracy-compatible (Megatron-aligned) numeric paths.
-
-    Controlled via the ``FLAGS_use_accuracy_compatible_kernel`` environment
-    variable. When enabled, modules switch to fp32-accumulating / Torch-aligned
-    kernels at the cost of throughput.
-    """
-    return _USE_ACCURACY_COMPATIBLE_KERNEL
+def _dsv4_probs_mul_custom_bwd_enabled() -> bool:
+    return os.environ.get("DSV4_FLEET_PROBS_MUL_CUSTOM_BWD", "0") == "1"
 
 
-def _unpermute_scatter(
+def _dsv4_fleet_moe_torch_index_add_enabled() -> bool:
+    explicit = os.environ.get("DSV4_FLEET_MOE_TORCH_INDEX_ADD")
+    if explicit is not None:
+        return explicit.lower() in ("1", "true", "yes", "on")
+    return os.environ.get("FLAGS_use_deterministic_algorithm", "0").lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
+
+def _dsv4_import_torch_for_moe_index_add():
+    import sys
+
+    torch_site_packages = os.environ.get("DSV4_FLEET_TE_SITE_PACKAGES")
+    if torch_site_packages and torch_site_packages not in sys.path:
+        sys.path.insert(0, torch_site_packages)
+    import torch
+    import torch.utils.dlpack
+
+    if _dsv4_fleet_moe_torch_index_add_enabled():
+        torch.use_deterministic_algorithms(True)
+    return torch
+
+
+def _dsv4_unpermute_scatter(
     permuted_tokens: paddle.Tensor, sorted_indices: paddle.Tensor, restore_shape
 ) -> paddle.Tensor:
     output_tokens = paddle.zeros(restore_shape, dtype=permuted_tokens.dtype)
@@ -70,7 +89,7 @@ def _unpermute_scatter(
     return output_tokens
 
 
-def _unpermute_fp32_accum(
+def _dsv4_unpermute_fp32_accum(
     permuted_tokens: paddle.Tensor, sorted_indices: paddle.Tensor, restore_shape
 ) -> paddle.Tensor:
     output_tokens = paddle.zeros(restore_shape, dtype="float32")
@@ -82,9 +101,35 @@ def _unpermute_fp32_accum(
     return output_tokens.cast(permuted_tokens.dtype)
 
 
-class ApplyPermutedProbs(PyLayer):
-    """tokens * probs with fp32-accumulated probs gradient."""
+class _DSV4TorchIndexAddUnpermute(PyLayer):
+    @staticmethod
+    def forward(ctx, permuted_tokens, sorted_indices, restore_shape):
+        ctx.save_for_backward(sorted_indices)
+        torch = _dsv4_import_torch_for_moe_index_add()
+        permuted_t = torch.utils.dlpack.from_dlpack(
+            paddle.utils.dlpack.to_dlpack(permuted_tokens.detach().contiguous())
+        )
+        indices_t = torch.utils.dlpack.from_dlpack(
+            paddle.utils.dlpack.to_dlpack(sorted_indices.detach().contiguous())
+        ).long()
+        output_t = torch.zeros(
+            (int(restore_shape[0]), int(restore_shape[1])),
+            dtype=permuted_t.dtype,
+            device=permuted_t.device,
+        )
+        output_t.index_add_(0, indices_t, permuted_t)
+        return paddle.utils.dlpack.from_dlpack(
+            torch.utils.dlpack.to_dlpack(output_t.contiguous())
+        )
 
+    @staticmethod
+    def backward(ctx, grad_output):
+        (sorted_indices,) = ctx.saved_tensor()
+        grad_tokens = grad_output.index_select(axis=0, index=sorted_indices)
+        return grad_tokens, None
+
+
+class _DSV4ApplyPermutedProbs(PyLayer):
     @staticmethod
     def forward(ctx, permuted_tokens, permuted_probs):
         ctx.input_dtype = permuted_tokens.dtype
@@ -98,9 +143,7 @@ class ApplyPermutedProbs(PyLayer):
         grad_probs = (
             permuted_tokens.cast("float32") * grad_output.cast("float32")
         ).sum(axis=-1)
-        return grad_tokens.cast(ctx.input_dtype), grad_probs.cast(
-            permuted_probs.dtype
-        )
+        return grad_tokens.cast(ctx.input_dtype), grad_probs.cast(permuted_probs.dtype)
 
 
 def barrier_ep(ep_group):
@@ -185,19 +228,23 @@ def unpermute(
         permuted_probs = probs.T.contiguous().masked_select(
             routing_map.T.contiguous().cast(paddle.bool)
         )
-        if use_accuracy_compatible_kernel():
-            permuted_tokens = ApplyPermutedProbs.apply(
+        if _dsv4_probs_mul_custom_bwd_enabled():
+            permuted_tokens = _DSV4ApplyPermutedProbs.apply(
                 permuted_tokens, permuted_probs
             )
         else:
             permuted_tokens = permuted_tokens * permuted_probs.unsqueeze(-1)
 
-    if use_accuracy_compatible_kernel():
-        output_tokens = _unpermute_fp32_accum(
+    if _dsv4_fleet_moe_fp32_accum_enabled():
+        output_tokens = _dsv4_unpermute_fp32_accum(
+            permuted_tokens, sorted_indices, restore_shape
+        )
+    elif _dsv4_fleet_moe_torch_index_add_enabled():
+        output_tokens = _DSV4TorchIndexAddUnpermute.apply(
             permuted_tokens, sorted_indices, restore_shape
         )
     else:
-        output_tokens = _unpermute_scatter(
+        output_tokens = _dsv4_unpermute_scatter(
             permuted_tokens, sorted_indices, restore_shape
         )
 

--- a/src/paddlefleet/transformer/moe/moe_utils.py
+++ b/src/paddlefleet/transformer/moe/moe_utils.py
@@ -141,7 +141,12 @@ def permute(
     sorted_indices = token_indices.masked_select(routing_map)
 
     # use the mapping to permute the tokens
-    permuted_input = tokens.index_select(axis=0, index=sorted_indices)
+    if _dsv4_fleet_moe_fp32_accum_enabled():
+        permuted_input = tokens.cast("float32").index_select(
+            axis=0, index=sorted_indices
+        ).cast(tokens.dtype)
+    else:
+        permuted_input = tokens.index_select(axis=0, index=sorted_indices)
 
     return permuted_input, sorted_indices
 

--- a/src/paddlefleet/transformer/moe/moe_utils.py
+++ b/src/paddlefleet/transformer/moe/moe_utils.py
@@ -45,6 +45,16 @@ if TYPE_CHECKING:
     from paddle.distributed.communication.group import Group
 
 
+_USE_ACCURACY_COMPATIBLE_KERNEL = (
+    os.environ.get("FLAGS_use_accuracy_compatible_kernel", "0") == "1"
+)
+
+
+def use_accuracy_compatible_kernel() -> bool:
+    """Unified switch for accuracy-compatible numeric paths."""
+    return _USE_ACCURACY_COMPATIBLE_KERNEL
+
+
 def _dsv4_fleet_moe_fp32_accum_enabled() -> bool:
     return os.environ.get("DSV4_FLEET_MOE_FP32_ACCUM", "0") == "1"
 

--- a/src/paddlefleet/transformer/multi_token_prediction.py
+++ b/src/paddlefleet/transformer/multi_token_prediction.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+import os
 import warnings
 from contextlib import nullcontext
 from dataclasses import dataclass
@@ -57,6 +58,31 @@ SUPPORTED_ATTN_MASK = [
     AttnMaskType.no_mask,
     AttnMaskType.padding_causal,
 ]
+
+
+def _dsv4_mtp_tensor_md5(tensor: Tensor) -> str:
+    import hashlib
+
+    return hashlib.md5(tensor.cast("float32").numpy().tobytes()).hexdigest()
+
+
+def _dsv4_register_mtp_grad(name: str, tensor: Tensor) -> None:
+    if os.environ.get("DSV4_LOG_MTP_GRADS", "0") != "1":
+        return
+    if tensor is None or tensor.stop_gradient:
+        return
+
+    def _hook(grad: Tensor) -> None:
+        rank = paddle.distributed.get_rank()
+        if rank != int(os.environ.get("DSV4_LOSS_PATH_RANK", "0")):
+            return
+        print(
+            f"[MTP_GRAD_MD5] rank={rank} {name}.grad shape={list(grad.shape)} "
+            f"md5={_dsv4_mtp_tensor_md5(grad)}",
+            flush=True,
+        )
+
+    tensor.register_hook(_hook)
 
 
 class MTPLossLoggingHelper:
@@ -583,6 +609,7 @@ class MultiTokenPredictionLayer(FleetLayer):
             hidden_states = self._concat_embeddings(
                 hidden_states, decoder_input, mtp_hidden_inputs_mask
             )
+            _dsv4_register_mtp_grad("mtp_transformer_input", hidden_states)
 
             input_dict = {
                 "hidden_states": hidden_states,
@@ -602,6 +629,7 @@ class MultiTokenPredictionLayer(FleetLayer):
             rst_dict = self.transformer_layer(input_dict)
 
         hidden_states = rst_dict["hidden_states"]
+        _dsv4_register_mtp_grad("mtp_transformer_output", hidden_states)
 
         # In mHC mode, skip postprocess here - it's deferred to forward()
         # so we can keep multi-stream state for subsequent MTP layers.
@@ -620,6 +648,7 @@ class MultiTokenPredictionLayer(FleetLayer):
         contracted to single-stream [s, b, h] before being used for loss computation.
         """
         if self.mhc_enabled:
+            _dsv4_register_mtp_grad("mtp_postprocess_input", hidden_states)
             from paddlefleet.transformer.hyper_connection import (
                 HyperConnectionModule,
             )
@@ -632,10 +661,12 @@ class MultiTokenPredictionLayer(FleetLayer):
                 self.config.num_residual_streams,
                 self.config.rms_norm_eps,
             )
+            _dsv4_register_mtp_grad("mtp_postprocess_contract_output", hidden_states)
 
         # Final layer norm
         if not self.config.gpt_model_use_experimental_version:
             hidden_states = self.norm(hidden_states)
+        _dsv4_register_mtp_grad("mtp_postprocess_output", hidden_states)
 
         return hidden_states
 
@@ -1046,6 +1077,9 @@ class MultiTokenPredictionLayer(FleetLayer):
             if mhc_chunks is not None:
                 # mHC mode: use multi-stream as MTP input
                 dict_args["hidden_states"] = mhc_chunks[self.layer_number]
+                _dsv4_register_mtp_grad(
+                    "mtp_mhc_input", dict_args["hidden_states"]
+                )
             else:
                 dict_args["hidden_states"] = tensor_list[self.layer_number]
             dict_args["decoder_input"] = tensor_list[self.layer_number + 1]

--- a/src/paddlefleet/transformer/multi_token_prediction.py
+++ b/src/paddlefleet/transformer/multi_token_prediction.py
@@ -60,31 +60,6 @@ SUPPORTED_ATTN_MASK = [
 ]
 
 
-def _dsv4_mtp_tensor_md5(tensor: Tensor) -> str:
-    import hashlib
-
-    return hashlib.md5(tensor.cast("float32").numpy().tobytes()).hexdigest()
-
-
-def _dsv4_register_mtp_grad(name: str, tensor: Tensor) -> None:
-    if os.environ.get("DSV4_LOG_MTP_GRADS", "0") != "1":
-        return
-    if tensor is None or tensor.stop_gradient:
-        return
-
-    def _hook(grad: Tensor) -> None:
-        rank = paddle.distributed.get_rank()
-        if rank != int(os.environ.get("DSV4_LOSS_PATH_RANK", "0")):
-            return
-        print(
-            f"[MTP_GRAD_MD5] rank={rank} {name}.grad shape={list(grad.shape)} "
-            f"md5={_dsv4_mtp_tensor_md5(grad)}",
-            flush=True,
-        )
-
-    tensor.register_hook(_hook)
-
-
 class MTPLossLoggingHelper:
     """Helper class for logging MTP losses."""
 
@@ -609,7 +584,6 @@ class MultiTokenPredictionLayer(FleetLayer):
             hidden_states = self._concat_embeddings(
                 hidden_states, decoder_input, mtp_hidden_inputs_mask
             )
-            _dsv4_register_mtp_grad("mtp_transformer_input", hidden_states)
 
             input_dict = {
                 "hidden_states": hidden_states,
@@ -629,7 +603,6 @@ class MultiTokenPredictionLayer(FleetLayer):
             rst_dict = self.transformer_layer(input_dict)
 
         hidden_states = rst_dict["hidden_states"]
-        _dsv4_register_mtp_grad("mtp_transformer_output", hidden_states)
 
         # In mHC mode, skip postprocess here - it's deferred to forward()
         # so we can keep multi-stream state for subsequent MTP layers.
@@ -648,7 +621,6 @@ class MultiTokenPredictionLayer(FleetLayer):
         contracted to single-stream [s, b, h] before being used for loss computation.
         """
         if self.mhc_enabled:
-            _dsv4_register_mtp_grad("mtp_postprocess_input", hidden_states)
             from paddlefleet.transformer.hyper_connection import (
                 HyperConnectionModule,
             )
@@ -661,12 +633,10 @@ class MultiTokenPredictionLayer(FleetLayer):
                 self.config.num_residual_streams,
                 self.config.rms_norm_eps,
             )
-            _dsv4_register_mtp_grad("mtp_postprocess_contract_output", hidden_states)
 
         # Final layer norm
         if not self.config.gpt_model_use_experimental_version:
             hidden_states = self.norm(hidden_states)
-        _dsv4_register_mtp_grad("mtp_postprocess_output", hidden_states)
 
         return hidden_states
 
@@ -1077,9 +1047,6 @@ class MultiTokenPredictionLayer(FleetLayer):
             if mhc_chunks is not None:
                 # mHC mode: use multi-stream as MTP input
                 dict_args["hidden_states"] = mhc_chunks[self.layer_number]
-                _dsv4_register_mtp_grad(
-                    "mtp_mhc_input", dict_args["hidden_states"]
-                )
             else:
                 dict_args["hidden_states"] = tensor_list[self.layer_number]
             dict_args["decoder_input"] = tensor_list[self.layer_number + 1]

--- a/src/paddlefleet/transformer/paddle_norm.py
+++ b/src/paddlefleet/transformer/paddle_norm.py
@@ -43,6 +43,24 @@ if TYPE_CHECKING:
     from paddlefleet.transformer import TransformerConfig
 
 
+def _dsv4_log_loss_path_tensor(name: str, tensor: paddle.Tensor) -> None:
+    if (
+        os.environ.get("LOG_LAYER_MD5", "0") != "1"
+        and os.environ.get("LOG_LOSS_MD5", "0") != "1"
+    ):
+        return
+    if tensor is None:
+        return
+    import hashlib
+
+    rank = paddle.distributed.get_rank()
+    md5 = hashlib.md5(tensor.cast("float32").numpy().tobytes()).hexdigest()
+    print(
+        f"[LOSS_PATH_MD5] rank={rank} {name} shape={list(tensor.shape)} md5={md5}",
+        flush=True,
+    )
+
+
 class RMSNorm(paddle.nn.Layer):
     def __init__(
         self,
@@ -251,6 +269,7 @@ class WrappedPaddleNormPipe(paddle.nn.Layer):
         )
 
     def forward(self, dict_args: dict):
+        tensor_list = None
         if (
             self.config.num_nextn_predict_layers is not None
             and self.config.num_nextn_predict_layers > 0
@@ -262,9 +281,17 @@ class WrappedPaddleNormPipe(paddle.nn.Layer):
                 hidden_states_concat, self.config.num_nextn_predict_layers + 1
             )
             dict_args["hidden_states"] = tensor_list[0]
+
+        _dsv4_log_loss_path_tensor(
+            "final_layernorm_input", dict_args["hidden_states"]
+        )
+        normed_hidden_states = self.norm(dict_args["hidden_states"])
+        _dsv4_log_loss_path_tensor(
+            "final_layernorm_output", normed_hidden_states
+        )
         rst = {
             **dict_args,
-            "hidden_states": self.norm(dict_args["hidden_states"]),
+            "hidden_states": normed_hidden_states,
         }
         if (
             self.config.num_nextn_predict_layers is not None
@@ -276,26 +303,18 @@ class WrappedPaddleNormPipe(paddle.nn.Layer):
             if self.config.gpt_model_use_experimental_version:
                 for i in range(1, len(tensor_list)):
                     tensor_list[i] = self.norm(tensor_list[i])
+            for i, mtp_hidden in enumerate(tensor_list[1:]):
+                _dsv4_log_loss_path_tensor(
+                    f"final_layernorm_mtp{i}_output", mtp_hidden
+                )
             hidden_states_concat = paddle.concat(
                 [rst["hidden_states"], *tensor_list[1:]]
             )
             rst["hidden_states"] = hidden_states_concat
-        rst = {**dict_args, **rst}
-
-        # Loss-path MD5 probe: final_layernorm output
-        if (
-            os.environ.get("LOG_LAYER_MD5", "0") == "1"
-            or os.environ.get("LOG_LOSS_MD5", "0") == "1"
-        ):
-            import hashlib
-
-            rank = paddle.distributed.get_rank()
-            h = rst["hidden_states"]
-            md5 = hashlib.md5(h.cast("float32").numpy().tobytes()).hexdigest()
-            print(
-                f"[LOSS_PATH_MD5] rank={rank} final_layernorm_output shape={list(h.shape)} md5={md5}",
-                flush=True,
+            _dsv4_log_loss_path_tensor(
+                "final_layernorm_output_concat", hidden_states_concat
             )
+        rst = {**dict_args, **rst}
 
         return rst
 

--- a/src/paddlefleet/transformer/paddle_norm.py
+++ b/src/paddlefleet/transformer/paddle_norm.py
@@ -43,24 +43,6 @@ if TYPE_CHECKING:
     from paddlefleet.transformer import TransformerConfig
 
 
-def _dsv4_log_loss_path_tensor(name: str, tensor: paddle.Tensor) -> None:
-    if (
-        os.environ.get("LOG_LAYER_MD5", "0") != "1"
-        and os.environ.get("LOG_LOSS_MD5", "0") != "1"
-    ):
-        return
-    if tensor is None:
-        return
-    import hashlib
-
-    rank = paddle.distributed.get_rank()
-    md5 = hashlib.md5(tensor.cast("float32").numpy().tobytes()).hexdigest()
-    print(
-        f"[LOSS_PATH_MD5] rank={rank} {name} shape={list(tensor.shape)} md5={md5}",
-        flush=True,
-    )
-
-
 class RMSNorm(paddle.nn.Layer):
     def __init__(
         self,
@@ -282,13 +264,7 @@ class WrappedPaddleNormPipe(paddle.nn.Layer):
             )
             dict_args["hidden_states"] = tensor_list[0]
 
-        _dsv4_log_loss_path_tensor(
-            "final_layernorm_input", dict_args["hidden_states"]
-        )
         normed_hidden_states = self.norm(dict_args["hidden_states"])
-        _dsv4_log_loss_path_tensor(
-            "final_layernorm_output", normed_hidden_states
-        )
         rst = {
             **dict_args,
             "hidden_states": normed_hidden_states,
@@ -303,17 +279,10 @@ class WrappedPaddleNormPipe(paddle.nn.Layer):
             if self.config.gpt_model_use_experimental_version:
                 for i in range(1, len(tensor_list)):
                     tensor_list[i] = self.norm(tensor_list[i])
-            for i, mtp_hidden in enumerate(tensor_list[1:]):
-                _dsv4_log_loss_path_tensor(
-                    f"final_layernorm_mtp{i}_output", mtp_hidden
-                )
             hidden_states_concat = paddle.concat(
                 [rst["hidden_states"], *tensor_list[1:]]
             )
             rst["hidden_states"] = hidden_states_concat
-            _dsv4_log_loss_path_tensor(
-                "final_layernorm_output_concat", hidden_states_concat
-            )
         rst = {**dict_args, **rst}
 
         return rst

--- a/src/paddlefleet/transformer/transformer_layer.py
+++ b/src/paddlefleet/transformer/transformer_layer.py
@@ -93,6 +93,47 @@ def tensors_clone(outputs):
         )
 
 
+def _dsv4_register_mtp_layer_grad(
+    name: str, tensor: Tensor, is_mtp_layer: bool
+) -> None:
+    if not is_mtp_layer or os.environ.get("DSV4_LOG_MTP_GRADS", "0") != "1":
+        return
+    if tensor is None or tensor.stop_gradient:
+        return
+
+    def _hook(grad: Tensor) -> None:
+        rank = (
+            paddle.distributed.get_rank()
+            if paddle.distributed.is_initialized()
+            else 0
+        )
+        if rank != int(os.environ.get("DSV4_LOSS_PATH_RANK", "0")):
+            return
+        md5 = hashlib.md5(grad.cast("float32").numpy().tobytes()).hexdigest()
+        print(
+            f"[MTP_LAYER_GRAD_MD5] rank={rank} {name}.grad shape={list(grad.shape)} md5={md5}",
+            flush=True,
+        )
+
+    tensor.register_hook(_hook)
+
+
+class _DSV4MTPMlpInputBranchSplit(paddle.autograd.PyLayer):
+    @staticmethod
+    def forward(ctx, x: Tensor):
+        return paddle.assign(x), paddle.assign(x)
+
+    @staticmethod
+    def backward(ctx, residual_grad: Tensor, hc_grad: Tensor):
+        order = os.environ.get(
+            "DSV4_FLEET_MTP_MLP_INPUT_BRANCH_SPLIT_ORDER",
+            "residual_hc",
+        )
+        if order == "hc_residual":
+            return hc_grad + residual_grad
+        return residual_grad + hc_grad
+
+
 @dataclass
 class TransformerLayerSublayersSpec:
     """
@@ -157,10 +198,7 @@ class TransformerLayer(nn.Layer):
     @staticmethod
     def _log_md5(tensor, name, layer_idx):
         """Log MD5 of a tensor for precision alignment debugging."""
-        if (
-            TransformerLayer._LOG_LAYER_MD5
-            and TransformerLayer._gpt_model_use_experimental_version
-        ):
+        if TransformerLayer._LOG_LAYER_MD5:
             if TransformerLayer._skip_mtp_probes:
                 return  # Skip MTP passes — EC has no MTP
             data = tensor.cast("float32").numpy().tobytes()
@@ -1062,10 +1100,7 @@ class TransformerLayer(nn.Layer):
                 mlp_output_with_bias = self.mlp(post_attention_layernorm_output)
 
         # Log MLP raw output before BDA
-        if (
-            TransformerLayer._LOG_LAYER_MD5
-            and TransformerLayer._gpt_model_use_experimental_version
-        ):
+        if TransformerLayer._LOG_LAYER_MD5:
             _mlp_tensor = (
                 mlp_output_with_bias[0]
                 if isinstance(mlp_output_with_bias, tuple)
@@ -1184,10 +1219,26 @@ class HyperConnectionTransformerLayer(TransformerLayer):
         ori_dtype = hidden_states.dtype
 
         # mHC: aggregate n-stream → 1-stream
+        attn_hc_input = hidden_states
+        _dsv4_register_mtp_layer_grad(
+            "mtp_layer_attn_hc_input", attn_hc_input, self.is_mtp_layer
+        )
+        self.self_attention_hyper_connection._dsv4_debug_name = (
+            "mtp_attn_hc" if self.is_mtp_layer else ""
+        )
         aggregated, h_res, h_post = self.self_attention_hyper_connection(
-            hidden_states
+            attn_hc_input
         )
         aggregated = aggregated.to(ori_dtype)
+        _dsv4_register_mtp_layer_grad(
+            "mtp_layer_attn_agg", aggregated, self.is_mtp_layer
+        )
+        _dsv4_register_mtp_layer_grad(
+            "mtp_layer_attn_h_res", h_res, self.is_mtp_layer
+        )
+        _dsv4_register_mtp_layer_grad(
+            "mtp_layer_attn_h_post", h_post, self.is_mtp_layer
+        )
 
         # LayerNorm on aggregated single stream
         if self.recompute_input_layernorm:
@@ -1197,6 +1248,11 @@ class HyperConnectionTransformerLayer(TransformerLayer):
 
         self._log_md5(
             input_layernorm_output, "input_layernorm_out", self.layer_number
+        )
+        _dsv4_register_mtp_layer_grad(
+            "mtp_layer_attn_norm_out",
+            input_layernorm_output,
+            self.is_mtp_layer,
         )
 
         # Self-attention
@@ -1224,6 +1280,14 @@ class HyperConnectionTransformerLayer(TransformerLayer):
                 packed_seq_params=packed_seq_params,
                 in_recompute=in_recompute,
             )
+        _attention_tensor = (
+            attention_output_with_bias[0]
+            if isinstance(attention_output_with_bias, (tuple, list))
+            else attention_output_with_bias
+        )
+        _dsv4_register_mtp_layer_grad(
+            "mtp_layer_attn_out", _attention_tensor, self.is_mtp_layer
+        )
 
         # mHC: fused H_res + H_post + bias-dropout-add
         with paddle.enable_grad():
@@ -1239,6 +1303,9 @@ class HyperConnectionTransformerLayer(TransformerLayer):
                 )
             )
             hidden_states = hidden_states.to(ori_dtype)
+        _dsv4_register_mtp_layer_grad(
+            "mtp_layer_post_attn", hidden_states, self.is_mtp_layer
+        )
 
         # Cross attention (unchanged)
         residual = hidden_states
@@ -1276,12 +1343,37 @@ class HyperConnectionTransformerLayer(TransformerLayer):
     ):
         """mHC MLP forward: aggregate → layernorm → MLP → fused_h_res_h_post_bda."""
         # Save n-stream residual for H_res mixing
-        original_residual = hidden_states
+        if (
+            self.is_mtp_layer
+            and os.environ.get("DSV4_FLEET_MTP_MLP_INPUT_BRANCH_SPLIT", "0")
+            == "1"
+        ):
+            original_residual, mlp_hc_input = _DSV4MTPMlpInputBranchSplit.apply(
+                hidden_states
+            )
+        else:
+            original_residual = hidden_states
+            mlp_hc_input = hidden_states
         ori_dtype = hidden_states.dtype
 
         # mHC: aggregate n-stream → 1-stream
-        aggregated, h_res, h_post = self.mlp_hyper_connection(hidden_states)
+        _dsv4_register_mtp_layer_grad(
+            "mtp_layer_mlp_hc_input", mlp_hc_input, self.is_mtp_layer
+        )
+        self.mlp_hyper_connection._dsv4_debug_name = (
+            "mtp_mlp_hc" if self.is_mtp_layer else ""
+        )
+        aggregated, h_res, h_post = self.mlp_hyper_connection(mlp_hc_input)
         aggregated = aggregated.to(ori_dtype)
+        _dsv4_register_mtp_layer_grad(
+            "mtp_layer_mlp_agg", aggregated, self.is_mtp_layer
+        )
+        _dsv4_register_mtp_layer_grad(
+            "mtp_layer_mlp_h_res", h_res, self.is_mtp_layer
+        )
+        _dsv4_register_mtp_layer_grad(
+            "mtp_layer_mlp_h_post", h_post, self.is_mtp_layer
+        )
 
         # LayerNorm on aggregated single stream
         if self.recompute_post_attention_layernorm:
@@ -1297,6 +1389,11 @@ class HyperConnectionTransformerLayer(TransformerLayer):
             post_attention_layernorm_output,
             "post_attn_layernorm_out",
             self.layer_number,
+        )
+        _dsv4_register_mtp_layer_grad(
+            "mtp_layer_mlp_norm_out",
+            post_attention_layernorm_output,
+            self.is_mtp_layer,
         )
 
         # MLP
@@ -1333,6 +1430,14 @@ class HyperConnectionTransformerLayer(TransformerLayer):
                 )
             else:
                 mlp_output_with_bias = self.mlp(post_attention_layernorm_output)
+        _mlp_tensor = (
+            mlp_output_with_bias[0]
+            if isinstance(mlp_output_with_bias, (tuple, list))
+            else mlp_output_with_bias
+        )
+        _dsv4_register_mtp_layer_grad(
+            "mtp_layer_mlp_out", _mlp_tensor, self.is_mtp_layer
+        )
 
         # mHC: fused H_res + H_post + bias-dropout-add
         with paddle.enable_grad():
@@ -1346,6 +1451,9 @@ class HyperConnectionTransformerLayer(TransformerLayer):
                 fused=self.config.bias_dropout_fusion,
             )
             hidden_states = hidden_states.to(ori_dtype)
+        _dsv4_register_mtp_layer_grad(
+            "mtp_layer_output", hidden_states, self.is_mtp_layer
+        )
 
         if is_first_fwd:
             hidden_states.stop_gradient = False

--- a/src/paddlefleet/transformer/transformer_layer.py
+++ b/src/paddlefleet/transformer/transformer_layer.py
@@ -15,7 +15,6 @@
 
 from __future__ import annotations
 
-import hashlib
 import logging
 import os
 from collections import OrderedDict
@@ -93,31 +92,6 @@ def tensors_clone(outputs):
         )
 
 
-def _dsv4_register_mtp_layer_grad(
-    name: str, tensor: Tensor, is_mtp_layer: bool
-) -> None:
-    if not is_mtp_layer or os.environ.get("DSV4_LOG_MTP_GRADS", "0") != "1":
-        return
-    if tensor is None or tensor.stop_gradient:
-        return
-
-    def _hook(grad: Tensor) -> None:
-        rank = (
-            paddle.distributed.get_rank()
-            if paddle.distributed.is_initialized()
-            else 0
-        )
-        if rank != int(os.environ.get("DSV4_LOSS_PATH_RANK", "0")):
-            return
-        md5 = hashlib.md5(grad.cast("float32").numpy().tobytes()).hexdigest()
-        print(
-            f"[MTP_LAYER_GRAD_MD5] rank={rank} {name}.grad shape={list(grad.shape)} md5={md5}",
-            flush=True,
-        )
-
-    tensor.register_hook(_hook)
-
-
 class _DSV4MTPMlpInputBranchSplit(paddle.autograd.PyLayer):
     @staticmethod
     def forward(ctx, x: Tensor):
@@ -190,28 +164,6 @@ class TransformerLayer(nn.Layer):
     """
 
     _gpt_model_use_experimental_version = False
-    _LOG_LAYER_MD5 = os.environ.get("LOG_LAYER_MD5", "0") == "1"
-    _skip_mtp_probes = (
-        False  # Set True during MTP forward to suppress MD5 probes
-    )
-
-    @staticmethod
-    def _log_md5(tensor, name, layer_idx):
-        """Log MD5 of a tensor for precision alignment debugging."""
-        if TransformerLayer._LOG_LAYER_MD5:
-            if TransformerLayer._skip_mtp_probes:
-                return  # Skip MTP passes — EC has no MTP
-            data = tensor.cast("float32").numpy().tobytes()
-            md5 = hashlib.md5(data).hexdigest()
-            rank = (
-                paddle.distributed.get_rank()
-                if paddle.distributed.is_initialized()
-                else 0
-            )
-            print(
-                f"[MD5 Probe] Rank={rank} Layer={layer_idx} {name} MD5={md5} shape={list(tensor.shape)}",
-                flush=True,
-            )
 
     def __init__(
         self,
@@ -483,9 +435,6 @@ class TransformerLayer(nn.Layer):
         values = tuple(dict_args.values())
 
         is_mtp = dict_args.pop("is_mtp", False)
-        TransformerLayer._skip_mtp_probes = (
-            is_mtp  # Suppress MD5 probes for MTP passes
-        )
         mtp_input = None
         mtp_ids = None
         if (
@@ -845,7 +794,6 @@ class TransformerLayer(nn.Layer):
             # Accumulate mlp output into partial_block
             output = partial_block + mlp_out
         else:
-            self._log_md5(hidden_states, "input", self.layer_number)
             with profile("attn"):
                 if need_do_attention():
                     hidden_states, context = self._forward_attention(
@@ -866,12 +814,8 @@ class TransformerLayer(nn.Layer):
                         in_recompute=self.full_recompute,
                         **kwargs,
                     )
-            self._log_md5(
-                hidden_states, "post_attn_residual", self.layer_number
-            )
             with profile(timer_name):
                 output = self._forward_mlp(hidden_states, input_ids=input_ids)
-            self._log_md5(output, "layer_output", self.layer_number)
         if context is not None:
             return output, context
         return output
@@ -935,10 +879,6 @@ class TransformerLayer(nn.Layer):
             )
         else:
             input_layernorm_output = self.input_layernorm(hidden_states)
-
-        self._log_md5(
-            input_layernorm_output, "input_layernorm_out", self.layer_number
-        )
 
         if rope_freqs_cis is not None:
             attention_output_with_bias = self.self_attn(
@@ -1056,12 +996,6 @@ class TransformerLayer(nn.Layer):
                 hidden_states
             )
 
-        self._log_md5(
-            post_attention_layernorm_output,
-            "post_attn_layernorm_out",
-            self.layer_number,
-        )
-
         if self.recompute_mlp:
             _mlp_input_ids = (
                 input_ids if isinstance(self.mlp, MoELayer) else None
@@ -1098,15 +1032,6 @@ class TransformerLayer(nn.Layer):
                 )
             else:
                 mlp_output_with_bias = self.mlp(post_attention_layernorm_output)
-
-        # Log MLP raw output before BDA
-        if TransformerLayer._LOG_LAYER_MD5:
-            _mlp_tensor = (
-                mlp_output_with_bias[0]
-                if isinstance(mlp_output_with_bias, tuple)
-                else mlp_output_with_bias
-            )
-            self._log_md5(_mlp_tensor, "mlp_out", self.layer_number)
 
         with paddle.enable_grad():
             if block_attention_residuals:
@@ -1220,40 +1145,16 @@ class HyperConnectionTransformerLayer(TransformerLayer):
 
         # mHC: aggregate n-stream → 1-stream
         attn_hc_input = hidden_states
-        _dsv4_register_mtp_layer_grad(
-            "mtp_layer_attn_hc_input", attn_hc_input, self.is_mtp_layer
-        )
-        self.self_attention_hyper_connection._dsv4_debug_name = (
-            "mtp_attn_hc" if self.is_mtp_layer else ""
-        )
         aggregated, h_res, h_post = self.self_attention_hyper_connection(
             attn_hc_input
         )
         aggregated = aggregated.to(ori_dtype)
-        _dsv4_register_mtp_layer_grad(
-            "mtp_layer_attn_agg", aggregated, self.is_mtp_layer
-        )
-        _dsv4_register_mtp_layer_grad(
-            "mtp_layer_attn_h_res", h_res, self.is_mtp_layer
-        )
-        _dsv4_register_mtp_layer_grad(
-            "mtp_layer_attn_h_post", h_post, self.is_mtp_layer
-        )
 
         # LayerNorm on aggregated single stream
         if self.recompute_input_layernorm:
             input_layernorm_output = recompute(self.input_layernorm, aggregated)
         else:
             input_layernorm_output = self.input_layernorm(aggregated)
-
-        self._log_md5(
-            input_layernorm_output, "input_layernorm_out", self.layer_number
-        )
-        _dsv4_register_mtp_layer_grad(
-            "mtp_layer_attn_norm_out",
-            input_layernorm_output,
-            self.is_mtp_layer,
-        )
 
         # Self-attention
         if rope_freqs_cis is not None:
@@ -1280,15 +1181,6 @@ class HyperConnectionTransformerLayer(TransformerLayer):
                 packed_seq_params=packed_seq_params,
                 in_recompute=in_recompute,
             )
-        _attention_tensor = (
-            attention_output_with_bias[0]
-            if isinstance(attention_output_with_bias, (tuple, list))
-            else attention_output_with_bias
-        )
-        _dsv4_register_mtp_layer_grad(
-            "mtp_layer_attn_out", _attention_tensor, self.is_mtp_layer
-        )
-
         # mHC: fused H_res + H_post + bias-dropout-add
         with paddle.enable_grad():
             hidden_states = (
@@ -1303,9 +1195,6 @@ class HyperConnectionTransformerLayer(TransformerLayer):
                 )
             )
             hidden_states = hidden_states.to(ori_dtype)
-        _dsv4_register_mtp_layer_grad(
-            "mtp_layer_post_attn", hidden_states, self.is_mtp_layer
-        )
 
         # Cross attention (unchanged)
         residual = hidden_states
@@ -1357,23 +1246,8 @@ class HyperConnectionTransformerLayer(TransformerLayer):
         ori_dtype = hidden_states.dtype
 
         # mHC: aggregate n-stream → 1-stream
-        _dsv4_register_mtp_layer_grad(
-            "mtp_layer_mlp_hc_input", mlp_hc_input, self.is_mtp_layer
-        )
-        self.mlp_hyper_connection._dsv4_debug_name = (
-            "mtp_mlp_hc" if self.is_mtp_layer else ""
-        )
         aggregated, h_res, h_post = self.mlp_hyper_connection(mlp_hc_input)
         aggregated = aggregated.to(ori_dtype)
-        _dsv4_register_mtp_layer_grad(
-            "mtp_layer_mlp_agg", aggregated, self.is_mtp_layer
-        )
-        _dsv4_register_mtp_layer_grad(
-            "mtp_layer_mlp_h_res", h_res, self.is_mtp_layer
-        )
-        _dsv4_register_mtp_layer_grad(
-            "mtp_layer_mlp_h_post", h_post, self.is_mtp_layer
-        )
 
         # LayerNorm on aggregated single stream
         if self.recompute_post_attention_layernorm:
@@ -1384,17 +1258,6 @@ class HyperConnectionTransformerLayer(TransformerLayer):
             post_attention_layernorm_output = self.post_attention_layernorm(
                 aggregated
             )
-
-        self._log_md5(
-            post_attention_layernorm_output,
-            "post_attn_layernorm_out",
-            self.layer_number,
-        )
-        _dsv4_register_mtp_layer_grad(
-            "mtp_layer_mlp_norm_out",
-            post_attention_layernorm_output,
-            self.is_mtp_layer,
-        )
 
         # MLP
         if self.recompute_mlp:
@@ -1430,15 +1293,6 @@ class HyperConnectionTransformerLayer(TransformerLayer):
                 )
             else:
                 mlp_output_with_bias = self.mlp(post_attention_layernorm_output)
-        _mlp_tensor = (
-            mlp_output_with_bias[0]
-            if isinstance(mlp_output_with_bias, (tuple, list))
-            else mlp_output_with_bias
-        )
-        _dsv4_register_mtp_layer_grad(
-            "mtp_layer_mlp_out", _mlp_tensor, self.is_mtp_layer
-        )
-
         # mHC: fused H_res + H_post + bias-dropout-add
         with paddle.enable_grad():
             hidden_states = self.mlp_hyper_connection.fused_h_res_h_post_bda(
@@ -1451,9 +1305,6 @@ class HyperConnectionTransformerLayer(TransformerLayer):
                 fused=self.config.bias_dropout_fusion,
             )
             hidden_states = hidden_states.to(ori_dtype)
-        _dsv4_register_mtp_layer_grad(
-            "mtp_layer_output", hidden_states, self.is_mtp_layer
-        )
 
         if is_first_fwd:
             hidden_states.stop_gradient = False


### PR DESCRIPTION
## Summary

Port the DSv4 backward-alignment changes onto the latest PaddleFleet `develop` baseline.

This branch includes the two backward-alignment commits ported from the old alignment branch, plus a small latest-baseline compatibility commit:

- enable `DSV4_EMBEDDING_INDEX_BACKWARD` to force deterministic vocab embedding backward wiring
- accept latest attention pass-through kwargs in `CompressedSparseAttention`
- restore `use_accuracy_compatible_kernel()` for newer MoE dispatcher imports

This PR is intended to be used together with the matching PaddleFormers PR from branch `codex/dsv4-backward-align-latest`.

## Validation

- `git diff --check origin/develop..HEAD`
- 10-step DSv4 old/latest comparison completed with paired PaddleFormers changes:
  - main loss md5 diff: `0/10`
  - MTP loss md5 diff: `0/10`
  - latest log: `/root/paddlejob/share-storage/gpfs/system-public/huangjiyi/dsv4_backward_align/0605_latest_align_22steps/outputs/dpskv4_ep8_4layer_1k_align_20260606_1318/output_0/workerlog.0`
  - old log: `/root/paddlejob/share-storage/gpfs/system-public/huangjiyi/dsv4_backward_align/0605_align_22steps/outputs/dpskv4_ep8_4layer_1k_align_20260606_1325/output_0/workerlog.0`