### PR TITLE
[Distributed Strategy][Bug fixes]fix PP hang caused by indexer loss log

### DIFF
--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -1007,6 +1007,7 @@ class CompressedSparseAttention(FleetLayer):
         compress_ratio: int = 0,
     ):
         super().__init__(config)
+        DSAIndexerLossLoggingHelper.register_total_num_layers(config)
         self.config = config
         self.layer_number = layer_number
         if is_mtp_layer:

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -1009,6 +1009,8 @@ class CompressedSparseAttention(FleetLayer):
         super().__init__(config)
         self.config = config
         self.layer_number = layer_number
+        if is_mtp_layer:
+            self.layer_number += self.config.num_hidden_layers
         self.pg_collection = pg_collection
         self.tp_group = (
             pg_collection.tp
@@ -1149,7 +1151,11 @@ class CompressedSparseAttention(FleetLayer):
                 DSAIndexerLossLoggingHelper.save_loss_to_tracker(
                     loss=indexer_loss,
                     layer_number=self.layer_number,
-                    num_layers=self.config.num_hidden_layers,
+                    num_layers=self.config.num_hidden_layers
+                    + (
+                        getattr(self.config, "mtp_num_layers", 0)
+                        or getattr(self.config, "num_nextn_predict_layers", 0)
+                    ),
                 )
         elif self.training and not use_tilelang_indexer:
             q_indexer, k_indexer, weights_indexer = (
@@ -1195,7 +1201,11 @@ class CompressedSparseAttention(FleetLayer):
                 DSAIndexerLossLoggingHelper.save_loss_to_tracker(
                     loss=indexer_loss,
                     layer_number=self.layer_number,
-                    num_layers=self.config.num_hidden_layers,
+                    num_layers=self.config.num_hidden_layers
+                    + (
+                        getattr(self.config, "mtp_num_layers", 0)
+                        or getattr(self.config, "num_nextn_predict_layers", 0)
+                    ),
                 )
         elif not use_tilelang_indexer:
             _, topk_indices_compressed = self.indexer(

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -1010,7 +1010,7 @@ class CompressedSparseAttention(FleetLayer):
         self.config = config
         self.layer_number = layer_number
         if is_mtp_layer:
-            self.layer_number += self.config.num_hidden_layers
+            self.layer_number += self.config.num_hidden_layers + 1
         self.pg_collection = pg_collection
         self.tp_group = (
             pg_collection.tp
@@ -1151,10 +1151,8 @@ class CompressedSparseAttention(FleetLayer):
                 DSAIndexerLossLoggingHelper.save_loss_to_tracker(
                     loss=indexer_loss,
                     layer_number=self.layer_number,
-                    num_layers=self.config.num_hidden_layers
-                    + (
-                        getattr(self.config, "mtp_num_layers", 0)
-                        or getattr(self.config, "num_nextn_predict_layers", 0)
+                    num_layers=DSAIndexerLossLoggingHelper.get_total_num_layers(
+                        self.config
                     ),
                 )
         elif self.training and not use_tilelang_indexer:
@@ -1201,10 +1199,8 @@ class CompressedSparseAttention(FleetLayer):
                 DSAIndexerLossLoggingHelper.save_loss_to_tracker(
                     loss=indexer_loss,
                     layer_number=self.layer_number,
-                    num_layers=self.config.num_hidden_layers
-                    + (
-                        getattr(self.config, "mtp_num_layers", 0)
-                        or getattr(self.config, "num_nextn_predict_layers", 0)
+                    num_layers=DSAIndexerLossLoggingHelper.get_total_num_layers(
+                        self.config
                     ),
                 )
         elif not use_tilelang_indexer:

--- a/src/paddlefleet/transformer/dsa_attention.py
+++ b/src/paddlefleet/transformer/dsa_attention.py
@@ -1055,12 +1055,18 @@ class DSAIndexerLossLoggingHelper:
     """Helper class for logging sparse attention indexer losses across layers and ranks."""
 
     tracker = {}
+    num_layers = None
 
     @staticmethod
     def get_total_num_layers(config):
-        return config.num_hidden_layers + (
-            getattr(config, "mtp_num_layers", 0)
-            or getattr(config, "num_nextn_predict_layers", 0)
+        mtp_num_layers = getattr(config, "mtp_num_layers", 0) or 0
+        nextn_num_layers = getattr(config, "num_nextn_predict_layers", 0) or 0
+        return config.num_hidden_layers + (mtp_num_layers or nextn_num_layers)
+
+    @staticmethod
+    def register_total_num_layers(config):
+        DSAIndexerLossLoggingHelper.num_layers = (
+            DSAIndexerLossLoggingHelper.get_total_num_layers(config)
         )
 
     @staticmethod
@@ -1100,6 +1106,15 @@ class DSAIndexerLossLoggingHelper:
         tracker["avg_group"] = None
 
     @staticmethod
+    def _infer_num_layers(num_layers: int | None = None):
+        if num_layers is not None:
+            return num_layers
+        tracker = DSAIndexerLossLoggingHelper.tracker
+        if "values" in tracker:
+            return tracker["values"].shape[0]
+        return DSAIndexerLossLoggingHelper.num_layers
+
+    @staticmethod
     def reduce_loss_in_tracker(num_layers: int | None = None):
         """Collect and reduce the indexer losses across ranks.
 
@@ -1108,6 +1123,7 @@ class DSAIndexerLossLoggingHelper:
         still participate in the collective and do not hang other ranks.
         """
         tracker = DSAIndexerLossLoggingHelper.tracker
+        num_layers = DSAIndexerLossLoggingHelper._infer_num_layers(num_layers)
         if "values" not in tracker:
             if num_layers is None:
                 return
@@ -1159,6 +1175,7 @@ class DSAIndexerLossLoggingHelper:
             num_layers: Total number of layers with indexer metrics.
             csa_compress_ratios: Per-layer CSA compress ratios.
         """
+        num_layers = DSAIndexerLossLoggingHelper._infer_num_layers(num_layers)
         DSAIndexerLossLoggingHelper.reduce_loss_in_tracker(
             num_layers=num_layers
         )
@@ -1235,6 +1252,7 @@ class DSAttention(FleetLayer):
     ):
         super().__init__(config=config)
 
+        DSAIndexerLossLoggingHelper.register_total_num_layers(config)
         self.layer_number = layer_number
         self.attn_mask_type = attn_mask_type
 

--- a/src/paddlefleet/transformer/dsa_attention.py
+++ b/src/paddlefleet/transformer/dsa_attention.py
@@ -1093,11 +1093,20 @@ class DSAIndexerLossLoggingHelper:
         tracker["avg_group"] = None
 
     @staticmethod
-    def reduce_loss_in_tracker():
-        """Collect and reduce the indexer losses across ranks."""
+    def reduce_loss_in_tracker(num_layers: int | None = None):
+        """Collect and reduce the indexer losses across ranks.
+
+        PP all-reduce must be called on every rank in the pipeline group.
+        Ranks without local indexer layers lazily create a zero tracker so they
+        still participate in the collective and do not hang other ranks.
+        """
         tracker = DSAIndexerLossLoggingHelper.tracker
         if "values" not in tracker:
-            return
+            if num_layers is None:
+                return
+            tracker["values"] = paddle.zeros([num_layers])
+            tracker["reduce_group"] = None
+            tracker["avg_group"] = None
         values = tracker["values"]
 
         # PP all-reduce
@@ -1130,6 +1139,7 @@ class DSAIndexerLossLoggingHelper:
         iteration: int,
         writer=None,
         total_loss_dict: dict | None = None,
+        num_layers: int | None = None,
     ):
         """Track the sparse attention indexer metrics for logging.
 
@@ -1138,8 +1148,9 @@ class DSAIndexerLossLoggingHelper:
             iteration: Current training iteration.
             writer: TensorBoard writer (optional).
             total_loss_dict: Dictionary to accumulate total losses (optional).
+            num_layers: Total number of layers with indexer metrics.
         """
-        DSAIndexerLossLoggingHelper.reduce_loss_in_tracker()
+        DSAIndexerLossLoggingHelper.reduce_loss_in_tracker(num_layers=num_layers)
         tracker = DSAIndexerLossLoggingHelper.tracker
         if "values" not in tracker:
             return
@@ -1406,7 +1417,11 @@ class DSAttention(FleetLayer):
                 DSAIndexerLossLoggingHelper.save_loss_to_tracker(
                     loss=indexer_loss,
                     layer_number=self.layer_number,
-                    num_layers=self.config.num_hidden_layers,
+                    num_layers=self.config.num_hidden_layers
+                    + (
+                        getattr(self.config, "mtp_num_layers", 0)
+                        or getattr(self.config, "num_nextn_predict_layers", 0)
+                    ),
                 )
             core_attn_out = DSAIndexerLossAutoScaler.apply(
                 core_attn_out, indexer_loss

--- a/src/paddlefleet/transformer/dsa_attention.py
+++ b/src/paddlefleet/transformer/dsa_attention.py
@@ -1054,7 +1054,14 @@ class DSAIndexerLossAutoScaler(paddle.autograd.PyLayer):
 class DSAIndexerLossLoggingHelper:
     """Helper class for logging sparse attention indexer losses across layers and ranks."""
 
-    tracker: dict = {}
+    tracker = {}
+
+    @staticmethod
+    def get_total_num_layers(config):
+        return config.num_hidden_layers + (
+            getattr(config, "mtp_num_layers", 0)
+            or getattr(config, "num_nextn_predict_layers", 0)
+        )
 
     @staticmethod
     def save_loss_to_tracker(
@@ -1140,6 +1147,7 @@ class DSAIndexerLossLoggingHelper:
         writer=None,
         total_loss_dict: dict | None = None,
         num_layers: int | None = None,
+        csa_compress_ratios: list[int] | None = None,
     ):
         """Track the sparse attention indexer metrics for logging.
 
@@ -1149,15 +1157,26 @@ class DSAIndexerLossLoggingHelper:
             writer: TensorBoard writer (optional).
             total_loss_dict: Dictionary to accumulate total losses (optional).
             num_layers: Total number of layers with indexer metrics.
+            csa_compress_ratios: Per-layer CSA compress ratios.
         """
-        DSAIndexerLossLoggingHelper.reduce_loss_in_tracker(num_layers=num_layers)
+        DSAIndexerLossLoggingHelper.reduce_loss_in_tracker(
+            num_layers=num_layers
+        )
         tracker = DSAIndexerLossLoggingHelper.tracker
         if "values" not in tracker:
             return
 
         indexer_loss_values = tracker["values"] * loss_scale
-        num_layers = indexer_loss_values.shape[0]
-        avg_indexer_loss = indexer_loss_values.sum() / num_layers
+        if csa_compress_ratios is not None:
+            num_indexer_layers = sum(
+                1 for ratio in csa_compress_ratios if ratio == 4
+            )
+        else:
+            num_indexer_layers = indexer_loss_values.shape[0]
+        if num_indexer_layers == 0:
+            DSAIndexerLossLoggingHelper.clean_loss_in_tracker()
+            return
+        avg_indexer_loss = indexer_loss_values.sum() / num_indexer_layers
 
         if total_loss_dict is not None:
             if "indexer loss" in total_loss_dict:
@@ -1417,10 +1436,8 @@ class DSAttention(FleetLayer):
                 DSAIndexerLossLoggingHelper.save_loss_to_tracker(
                     loss=indexer_loss,
                     layer_number=self.layer_number,
-                    num_layers=self.config.num_hidden_layers
-                    + (
-                        getattr(self.config, "mtp_num_layers", 0)
-                        or getattr(self.config, "num_nextn_predict_layers", 0)
+                    num_layers=DSAIndexerLossLoggingHelper.get_total_num_layers(
+                        self.config
                     ),
                 )
             core_attn_out = DSAIndexerLossAutoScaler.apply(

--- a/src/paddlefleet/transformer/dsv4_hybrid_attention.py
+++ b/src/paddlefleet/transformer/dsv4_hybrid_attention.py
@@ -163,6 +163,7 @@ class DSv4HybridAttention(Attention):
             num_key_value_heads=1,
             cp_comm_type=cp_comm_type,
             pg_collection=self.pg_collection,
+            is_mtp_layer=is_mtp_layer,
             compress_ratio=compress_ratio,
             rotary_pos_emb=self.rotary_pos_emb,
         )

--- a/tests/single_card_tests/transformer/test_dsa_attention.py
+++ b/tests/single_card_tests/transformer/test_dsa_attention.py
@@ -971,6 +971,23 @@ class TestDSAIndexerLossLoggingHelperReduce(unittest.TestCase):
         # Should not raise
 
     @patch("paddlefleet.transformer.dsa_attention.parallel_state")
+    def test_reduce_empty_tracker_with_num_layers_joins_pp_reduce(
+        self, mock_ps
+    ):
+        """Empty tracker should initialize zeros and join PP all_reduce."""
+        pp_group = MagicMock()
+        pp_group.nranks = 2
+        mock_ps.get_pipeline_model_parallel_group.return_value = pp_group
+        mock_ps.get_data_parallel_group.return_value = None
+
+        with patch("paddle.distributed.all_reduce") as mock_all_reduce:
+            DSAIndexerLossLoggingHelper.reduce_loss_in_tracker(num_layers=3)
+            mock_all_reduce.assert_called_once()
+
+        values = DSAIndexerLossLoggingHelper.tracker["values"]
+        self.assertTrue(paddle.allclose(values, paddle.zeros([3])))
+
+    @patch("paddlefleet.transformer.dsa_attention.parallel_state")
     def test_reduce_no_distributed_groups(self, mock_ps):
         """Reduce with no distributed groups should keep values unchanged."""
         mock_ps.get_pipeline_model_parallel_group.return_value = None
@@ -1107,9 +1124,9 @@ class TestDSAIndexerLossLoggingHelperTrackMetrics(unittest.TestCase):
     def test_track_metrics_empty_tracker_noop(self, mock_reduce):
         """With no values, track_indexer_metrics should be a no-op after reduce."""
         DSAIndexerLossLoggingHelper.track_indexer_metrics(
-            loss_scale=1.0, iteration=10
+            loss_scale=1.0, iteration=10, num_layers=2
         )
-        mock_reduce.assert_called_once()
+        mock_reduce.assert_called_once_with(num_layers=2)
 
     @patch.object(DSAIndexerLossLoggingHelper, "reduce_loss_in_tracker")
     def test_track_metrics_logs_loss(self, mock_reduce):

--- a/tests/single_card_tests/transformer/test_dsa_attention.py
+++ b/tests/single_card_tests/transformer/test_dsa_attention.py
@@ -1237,6 +1237,42 @@ class TestDSAIndexerLossLoggingHelperTrackMetrics(unittest.TestCase):
             total_loss_dict["indexer loss"].item(), 1.5, places=4
         )
 
+    @patch.object(DSAIndexerLossLoggingHelper, "reduce_loss_in_tracker")
+    def test_track_metrics_averages_over_csa_indexer_layers(self, mock_reduce):
+        """CSA logging should average over layers with ratio == 4."""
+        DSAIndexerLossLoggingHelper.tracker["values"] = paddle.to_tensor(
+            [0.0, 2.0, 0.0, 4.0], dtype="float32"
+        )
+        total_loss_dict = {}
+        DSAIndexerLossLoggingHelper.track_indexer_metrics(
+            loss_scale=1.0,
+            iteration=1,
+            total_loss_dict=total_loss_dict,
+            csa_compress_ratios=[0, 4, 128, 4],
+        )
+        self.assertAlmostEqual(
+            total_loss_dict["indexer loss"].item(), 3.0, places=4
+        )
+
+    @patch.object(DSAIndexerLossLoggingHelper, "reduce_loss_in_tracker")
+    def test_track_metrics_no_csa_indexer_layers_noop(self, mock_reduce):
+        """CSA logging should skip metrics when no layer owns an indexer."""
+        DSAIndexerLossLoggingHelper.tracker["values"] = paddle.zeros([2])
+        total_loss_dict = {}
+        DSAIndexerLossLoggingHelper.track_indexer_metrics(
+            loss_scale=1.0,
+            iteration=1,
+            total_loss_dict=total_loss_dict,
+            csa_compress_ratios=[0, 128],
+        )
+        self.assertNotIn("indexer loss", total_loss_dict)
+        self.assertTrue(
+            paddle.allclose(
+                DSAIndexerLossLoggingHelper.tracker["values"],
+                paddle.zeros([2]),
+            )
+        )
+
 
 # ===========================================================================
 # Layer 6: Additional coverage for DSAIndexer and helper functions

--- a/tests/single_card_tests/transformer/test_dsa_attention.py
+++ b/tests/single_card_tests/transformer/test_dsa_attention.py
@@ -23,6 +23,7 @@ Tests are organized in 4 layers:
 """
 
 import unittest
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import paddle
@@ -961,14 +962,24 @@ class TestDSAIndexerLossLoggingHelperReduce(unittest.TestCase):
 
     def setUp(self):
         DSAIndexerLossLoggingHelper.tracker = {}
+        DSAIndexerLossLoggingHelper.num_layers = None
 
     def tearDown(self):
         DSAIndexerLossLoggingHelper.tracker = {}
+        DSAIndexerLossLoggingHelper.num_layers = None
 
     def test_reduce_empty_tracker_noop(self):
         """Reduce with no 'values' should be a no-op."""
         DSAIndexerLossLoggingHelper.reduce_loss_in_tracker()
         # Should not raise
+
+    def test_get_total_num_layers_treats_none_as_zero(self):
+        """None nextn layer count should be treated as zero."""
+        config = SimpleNamespace(num_hidden_layers=4, mtp_num_layers=0)
+        config.num_nextn_predict_layers = None
+        self.assertEqual(
+            DSAIndexerLossLoggingHelper.get_total_num_layers(config), 4
+        )
 
     @patch("paddlefleet.transformer.dsa_attention.parallel_state")
     def test_reduce_empty_tracker_with_num_layers_joins_pp_reduce(
@@ -982,6 +993,22 @@ class TestDSAIndexerLossLoggingHelperReduce(unittest.TestCase):
 
         with patch("paddle.distributed.all_reduce") as mock_all_reduce:
             DSAIndexerLossLoggingHelper.reduce_loss_in_tracker(num_layers=3)
+            mock_all_reduce.assert_called_once()
+
+        values = DSAIndexerLossLoggingHelper.tracker["values"]
+        self.assertTrue(paddle.allclose(values, paddle.zeros([3])))
+
+    @patch("paddlefleet.transformer.dsa_attention.parallel_state")
+    def test_reduce_empty_tracker_uses_registered_num_layers(self, mock_ps):
+        """Empty tracker should infer registered layer count for PP reduce."""
+        pp_group = MagicMock()
+        pp_group.nranks = 2
+        mock_ps.get_pipeline_model_parallel_group.return_value = pp_group
+        mock_ps.get_data_parallel_group.return_value = None
+        DSAIndexerLossLoggingHelper.num_layers = 3
+
+        with patch("paddle.distributed.all_reduce") as mock_all_reduce:
+            DSAIndexerLossLoggingHelper.reduce_loss_in_tracker()
             mock_all_reduce.assert_called_once()
 
         values = DSAIndexerLossLoggingHelper.tracker["values"]
@@ -1116,9 +1143,11 @@ class TestDSAIndexerLossLoggingHelperTrackMetrics(unittest.TestCase):
 
     def setUp(self):
         DSAIndexerLossLoggingHelper.tracker = {}
+        DSAIndexerLossLoggingHelper.num_layers = None
 
     def tearDown(self):
         DSAIndexerLossLoggingHelper.tracker = {}
+        DSAIndexerLossLoggingHelper.num_layers = None
 
     @patch.object(DSAIndexerLossLoggingHelper, "reduce_loss_in_tracker")
     def test_track_metrics_empty_tracker_noop(self, mock_reduce):

--- a/tests/single_card_tests/transformer/test_dsv4_hybrid_attention.py
+++ b/tests/single_card_tests/transformer/test_dsv4_hybrid_attention.py
@@ -356,6 +356,9 @@ class TestDSv4HybridAttentionConstructor(unittest.TestCase):
         self.assertEqual(
             attn.core_attention.compress_ratio, ratios[config.num_hidden_layers]
         )
+        self.assertEqual(
+            attn.core_attention.layer_number, config.num_hidden_layers + 1
+        )
 
     def test_non_dense_mtp_spec_uses_mtp_attention_ratio(self):
         ratios = [0, 4, 128, 4, 128]


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Distributed Strategy

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
在类似 DeepSeek v4 的混合注意力架构（CSA+HCA）中，可能存在开启流水并行时某些 rank 上的所有层都不包含 indexer 的情况，这会导致统计 indexer loss 时 hang 住。

问题描述可以参考 https://github.com/NVIDIA/Megatron-LM/issues/4745

之前 Megatron 中也有类似的问题。

参考 https://github.com/NVIDIA/Megatron-LM/pull/4518/changes/8e4f78cb92a9c67c4ba9950a4470a3fc4955f1cf 进行修复

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否