### PR TITLE
[Feat][Bug fixes] Contextual parallelism support for DSV4 sparse-attention and some bug fixes.

### DIFF
--- a/src/paddlefleet/context_parallel_utils.py
+++ b/src/paddlefleet/context_parallel_utils.py
@@ -340,25 +340,111 @@ def reduce_scatter_any_axis_balance(input_tensor, axis, group=None):
     return result
 
 
+# ===========================================================================
+# Contiguous CP primitives (rank r owns [r*chunk, (r+1)*chunk])
+# ===========================================================================
+
+
+def scatter_contiguous(input_tensor, group=None, axis=0):
+    """Contiguous scatter: rank r gets slice [r*chunk, (r+1)*chunk] along axis."""
+    if group is None:
+        hcg = fleet.get_hybrid_communicate_group()
+        group = hcg.get_context_parallel_group()
+    nranks = group.nranks
+    if nranks == 1:
+        return input_tensor.clone()
+    rank = group.rank
+    chunk_size = input_tensor.shape[axis] // nranks
+    result = paddle.slice(
+        input_tensor,
+        axes=[axis],
+        starts=[rank * chunk_size],
+        ends=[(rank + 1) * chunk_size],
+    )
+    return paddle.assign(result)
+
+
+def all_gather_contiguous(input_tensor, group=None, axis=0):
+    """Contiguous all-gather: concatenate all ranks' local tensors in rank order."""
+    if group is None:
+        hcg = fleet.get_hybrid_communicate_group()
+        group = hcg.get_context_parallel_group()
+    nranks = group.nranks
+    if nranks == 1:
+        return input_tensor.clone()
+    if axis == 0:
+        shape = list(input_tensor.shape)
+        shape[0] *= nranks
+        gathered = paddle.empty(shape=shape, dtype=input_tensor.dtype)
+        dist.stream.all_gather(
+            gathered,
+            input_tensor.contiguous(),
+            group=group,
+            use_calc_stream=True,
+        )
+        return gathered
+    else:
+        tensor_list = [
+            paddle.empty(input_tensor.shape, dtype=input_tensor.dtype)
+            for _ in range(nranks)
+        ]
+        dist.stream.all_gather(
+            tensor_list,
+            input_tensor.contiguous(),
+            group=group,
+            use_calc_stream=True,
+        )
+        return paddle.concat(tensor_list, axis=axis)
+
+
+def reduce_scatter_contiguous(input_tensor, axis, group=None):
+    """Contiguous reduce-scatter: reduce_scatter for axis=0, alltoall+sum otherwise."""
+    if group is None:
+        hcg = fleet.get_hybrid_communicate_group()
+        group = hcg.get_context_parallel_group()
+    nranks = group.nranks
+    if nranks == 1:
+        return input_tensor.clone()
+    if axis == 0:
+        output_shape = list(input_tensor.shape)
+        output_shape[0] //= nranks
+        output = paddle.empty(shape=output_shape, dtype=input_tensor.dtype)
+        dist.stream.reduce_scatter(
+            output,
+            input_tensor.contiguous(),
+            op=dist.ReduceOp.SUM,
+            group=group,
+            use_calc_stream=True,
+        )
+        return output
+    else:
+        chunks = paddle.split(input_tensor, nranks, axis=axis)
+        bufs = [
+            paddle.empty(chunks[0].shape, dtype=input_tensor.dtype)
+            for _ in range(nranks)
+        ]
+        dist.stream.alltoall(
+            bufs,
+            [c.contiguous() for c in chunks],
+            group=group,
+            use_calc_stream=True,
+        )
+        return (
+            paddle.stack(bufs).cast("float32").sum(0).cast(input_tensor.dtype)
+        )
+
+
 class ContextParallelScatterOp(PyLayer):
     """
     Context parallel scatter operation using PyLayer for automatic differentiation.
-    Forward: Scatter input tensor using balanced splitting
-    Backward: All-gather gradients using balanced reconstruction
+    Forward: Scatter input tensor (balanced or contiguous based on mode)
+    Backward: All-gather gradients (inverse of forward scatter)
     """
 
     @staticmethod
-    def forward(ctx, input_tensor, axis=0):
-        """
-        Forward pass: scatter input tensor across context parallel ranks.
-        Args:
-            ctx: Context object for saving information for backward pass
-            input_tensor (paddle.Tensor): Input tensor to scatter
-            axis (int): Axis along which to scatter
-        Returns:
-            paddle.Tensor: Scattered tensor chunk
-        """
+    def forward(ctx, input_tensor, axis=0, mode="dualchunk_allgather"):
         ctx.axis = axis
+        ctx.mode = mode
         hcg = fleet.get_hybrid_communicate_group()
 
         assert hcg.get_context_parallel_world_size() > 1, (
@@ -369,43 +455,30 @@ class ContextParallelScatterOp(PyLayer):
         group = hcg.get_context_parallel_group()
         ctx.group = group
 
+        if mode == "contiguous_allgather":
+            return scatter_contiguous(input_tensor, group=group, axis=axis)
         return scatter_balance(input_tensor, axis=axis, group=group)
 
     @staticmethod
     def backward(ctx, grad_output):
-        """
-        Backward pass: all-gather gradients.
-        Args:
-            ctx: Context object with saved information
-            grad_output (paddle.Tensor): Gradient of output
-        Returns:
-            tuple: Gradients for input arguments
-        """
-        grad_input = all_gather_balance(
-            grad_output, axis=ctx.axis, group=ctx.group
-        )
-        return grad_input
+        if ctx.mode == "contiguous_allgather":
+            return all_gather_contiguous(
+                grad_output, group=ctx.group, axis=ctx.axis
+            )
+        return all_gather_balance(grad_output, axis=ctx.axis, group=ctx.group)
 
 
 class ContextParallelGatherOp(PyLayer):
     """
     Context parallel gather operation using PyLayer for automatic differentiation.
-    Forward: All-gather input tensor using balanced reconstruction
-    Backward: Scatter gradients using balanced splitting
+    Forward: All-gather input tensor (balanced or contiguous based on mode)
+    Backward: Scatter gradients (inverse of forward gather)
     """
 
     @staticmethod
-    def forward(ctx, input_tensor, axis=0):
-        """
-        Forward pass: all-gather input tensor across context parallel ranks.
-        Args:
-            ctx: Context object for saving information for backward pass
-            input_tensor (paddle.Tensor): Input tensor to gather
-            axis (int): Axis along which to gather
-        Returns:
-            paddle.Tensor: Gathered full tensor
-        """
+    def forward(ctx, input_tensor, axis=0, mode="dualchunk_allgather"):
         ctx.axis = axis
+        ctx.mode = mode
         hcg = fleet.get_hybrid_communicate_group()
 
         assert hcg.get_context_parallel_world_size() > 1, (
@@ -416,45 +489,30 @@ class ContextParallelGatherOp(PyLayer):
         group = hcg.get_context_parallel_group()
         ctx.group = group
 
+        if mode == "contiguous_allgather":
+            return all_gather_contiguous(input_tensor, group=group, axis=axis)
         return all_gather_balance(input_tensor, axis=axis, group=group)
 
     @staticmethod
     def backward(ctx, grad_output):
-        """
-        Backward pass: scatter gradients.
-        Args:
-            ctx: Context object with saved information
-            grad_output (paddle.Tensor): Gradient of output
-        Returns:
-            tuple: Gradients for input arguments
-        """
-        grad_input = scatter_balance(
-            grad_output, axis=ctx.axis, group=ctx.group
-        )
-        return grad_input
+        if ctx.mode == "contiguous_allgather":
+            return scatter_contiguous(
+                grad_output, group=ctx.group, axis=ctx.axis
+            )
+        return scatter_balance(grad_output, axis=ctx.axis, group=ctx.group)
 
 
 class ContextParallelAllGatherOp(PyLayer):
     """
     Context parallel all-gather operation with gradient reduction.
-    Forward: All-gather input tensor (e.g., [batch, seq_len/n, hidden] -> [batch, seq_len, hidden])
-    Backward: Reduce-scatter gradients with balanced distribution
-    This operation is similar to AllGatherOp but maintains context parallel state
-    after gradient aggregation.
+    Forward: All-gather input tensor (balanced or contiguous based on mode)
+    Backward: Reduce-scatter gradients (sum + scatter)
     """
 
     @staticmethod
-    def forward(ctx, input_tensor, axis):
-        """
-        Forward pass: all-gather input tensor.
-        Args:
-            ctx: Context object for saving information
-            input_tensor (paddle.Tensor): Input tensor with shape [batch, seq_len/n, hidden]
-            axis (int): Axis along which to gather
-        Returns:
-            paddle.Tensor: Gathered tensor with shape [batch, seq_len, hidden]
-        """
+    def forward(ctx, input_tensor, axis, mode="dualchunk_allgather"):
         ctx.axis = axis
+        ctx.mode = mode
         hcg = fleet.get_hybrid_communicate_group()
 
         assert hcg.get_context_parallel_world_size() > 1, (
@@ -465,22 +523,19 @@ class ContextParallelAllGatherOp(PyLayer):
         group = hcg.get_context_parallel_group()
         ctx.group = group
 
+        if mode == "contiguous_allgather":
+            return all_gather_contiguous(input_tensor, group=group, axis=axis)
         return all_gather_balance(input_tensor, axis=axis, group=group)
 
     @staticmethod
     def backward(ctx, grad_output):
-        """
-        Backward pass: reduce-scatter gradients.
-        Args:
-            ctx: Context object with saved information
-            grad_output (paddle.Tensor): Gradient with shape [batch, seq_len, hidden]
-        Returns:
-            tuple: Gradients with shape [batch, seq_len/n, hidden]
-        """
-        grad_input = reduce_scatter_any_axis_balance(
+        if ctx.mode == "contiguous_allgather":
+            return reduce_scatter_contiguous(
+                grad_output, axis=ctx.axis, group=ctx.group
+            )
+        return reduce_scatter_any_axis_balance(
             grad_output, axis=ctx.axis, group=ctx.group
         )
-        return grad_input
 
 
 def preprocess_index(

--- a/src/paddlefleet/models/common/language_loss/language_loss.py
+++ b/src/paddlefleet/models/common/language_loss/language_loss.py
@@ -269,8 +269,12 @@ class LanguageLoss(FleetLayer):
             loss = loss_1d.reshape([B, S])
 
             if get_context_parallel_world_size() > 1:
-                loss = ContextParallelGatherOp.apply(loss, axis=1)
-                labels = ContextParallelGatherOp.apply(labels, axis=1)
+                loss = ContextParallelGatherOp.apply(
+                    loss, axis=1, mode=self.config.cp_balance_mode
+                )
+                labels = ContextParallelGatherOp.apply(
+                    labels, axis=1, mode=self.config.cp_balance_mode
+                )
 
             lossmask = labels != self.ignored_index
             if (~lossmask).all():
@@ -327,8 +331,12 @@ class LanguageLoss(FleetLayer):
             loss = self.loss_func(logits.cast("float32"), labels)
 
         if get_context_parallel_world_size() > 1:
-            loss = ContextParallelGatherOp.apply(loss, axis=1)
-            labels = ContextParallelGatherOp.apply(labels, axis=1)
+            loss = ContextParallelGatherOp.apply(
+                loss, axis=1, mode=self.config.cp_balance_mode
+            )
+            labels = ContextParallelGatherOp.apply(
+                labels, axis=1, mode=self.config.cp_balance_mode
+            )
 
         lossmask = labels != self.ignored_index
         if (~lossmask).all():
@@ -417,7 +425,9 @@ class LanguageLoss(FleetLayer):
             and self.config.experimental_dataflow
         ):
             # In EB data flow and CP size > 1, scatter labels to cp local
-            labels = ContextParallelScatterOp.apply(labels, axis=1)
+            labels = ContextParallelScatterOp.apply(
+                labels, axis=1, mode=self.config.cp_balance_mode
+            )
         if (
             self.config.recompute_modules is not None
             and "loss_fn" in self.config.recompute_modules
@@ -460,7 +470,9 @@ class LanguageLoss(FleetLayer):
                             # In EB data flow and CP size > 1, since we do not use _forward
                             # we need to scatter labels to cp local here.
                             labels_cur_depth = ContextParallelScatterOp.apply(
-                                labels_cur_depth, axis=1
+                                labels_cur_depth,
+                                axis=1,
+                                mode=self.config.cp_balance_mode,
                             )
 
                         if self.config.fused_linear_ce_loss_chunk > 0:
@@ -478,11 +490,15 @@ class LanguageLoss(FleetLayer):
                             # In EB data flow and CP size > 1, loss and labels need to be gathered back.
                             loss_matrix_cur_depth = (
                                 ContextParallelGatherOp.apply(
-                                    loss_matrix_cur_depth, axis=1
+                                    loss_matrix_cur_depth,
+                                    axis=1,
+                                    mode=self.config.cp_balance_mode,
                                 )
                             )
                             labels_cur_depth = ContextParallelGatherOp.apply(
-                                labels_cur_depth, axis=1
+                                labels_cur_depth,
+                                axis=1,
+                                mode=self.config.cp_balance_mode,
                             )
 
                         lossmask_cur_depth = (
@@ -514,7 +530,9 @@ class LanguageLoss(FleetLayer):
                     target_p_self_op_dist = nn.Softmax(axis=2)(logits[0])
                 if get_context_parallel_world_size() > 1:
                     target_p_self_op_dist = ContextParallelGatherOp.apply(
-                        target_p_self_op_dist, axis=1
+                        target_p_self_op_dist,
+                        axis=1,
+                        mode=self.config.cp_balance_mode,
                     )
 
                 def padding(tensor, left=False, pad_len=1):
@@ -556,7 +574,9 @@ class LanguageLoss(FleetLayer):
                         )
                         if get_context_parallel_world_size() > 1:
                             target_p = ContextParallelScatterOp.apply(
-                                target_p, axis=1
+                                target_p,
+                                axis=1,
+                                mode=self.config.cp_balance_mode,
                             )
                         plogp = target_p * out_logp
 
@@ -564,7 +584,9 @@ class LanguageLoss(FleetLayer):
                         xishu = lossmask.sum() + 1e-5
                         if get_context_parallel_world_size() > 1:
                             lossmask = ContextParallelScatterOp.apply(
-                                lossmask, axis=1
+                                lossmask,
+                                axis=1,
+                                mode=self.config.cp_balance_mode,
                             )
 
                         ploss = -paddle.sum(lossmask * plogp)

--- a/src/paddlefleet/models/gpt/gpt_embedding.py
+++ b/src/paddlefleet/models/gpt/gpt_embedding.py
@@ -242,7 +242,9 @@ class GPTEmbedding(FleetLayer):
                         and self.config.experimental_dataflow
                     ):
                         decoder_input = ContextParallelScatterOp.apply(
-                            decoder_input, axis=1
+                            decoder_input,
+                            axis=1,
+                            mode=self.config.cp_balance_mode,
                         )
 
                     if self.sequence_parallel:
@@ -274,7 +276,9 @@ class GPTEmbedding(FleetLayer):
                     ):
                         # In EB data flow, main input embed apply CP scatter here
                         inputs_embeds = ContextParallelScatterOp.apply(
-                            inputs_embeds, axis=1
+                            inputs_embeds,
+                            axis=1,
+                            mode=self.config.cp_balance_mode,
                         )
 
                     if self.sequence_parallel:
@@ -303,7 +307,9 @@ class GPTEmbedding(FleetLayer):
                         ):
                             # In EB data flow, mtp input embed apply CP scatter here
                             inputs_embeds_mtp = ContextParallelScatterOp.apply(
-                                inputs_embeds_mtp, axis=1
+                                inputs_embeds_mtp,
+                                axis=1,
+                                mode=self.config.cp_balance_mode,
                             )
 
                         if self.sequence_parallel:
@@ -547,27 +553,27 @@ class GPTEmbedding(FleetLayer):
         ):
             if rotary_pos_emb is not None:
                 rotary_pos_emb = ContextParallelScatterOp.apply(
-                    rotary_pos_emb, axis=1
+                    rotary_pos_emb, axis=1, mode=self.config.cp_balance_mode
                 )
             if swa_rotary_pos_emb is not None:
                 swa_rotary_pos_emb = ContextParallelScatterOp.apply(
-                    swa_rotary_pos_emb, axis=1
+                    swa_rotary_pos_emb, axis=1, mode=self.config.cp_balance_mode
                 )
             if rotary_pos_cos is not None:
                 rotary_pos_cos = ContextParallelScatterOp.apply(
-                    rotary_pos_cos, axis=1
+                    rotary_pos_cos, axis=1, mode=self.config.cp_balance_mode
                 )
             if rotary_pos_sin is not None:
                 rotary_pos_sin = ContextParallelScatterOp.apply(
-                    rotary_pos_sin, axis=1
+                    rotary_pos_sin, axis=1, mode=self.config.cp_balance_mode
                 )
             if swa_rotary_pos_cos is not None:
                 swa_rotary_pos_cos = ContextParallelScatterOp.apply(
-                    swa_rotary_pos_cos, axis=1
+                    swa_rotary_pos_cos, axis=1, mode=self.config.cp_balance_mode
                 )
             if swa_rotary_pos_sin is not None:
                 swa_rotary_pos_sin = ContextParallelScatterOp.apply(
-                    swa_rotary_pos_sin, axis=1
+                    swa_rotary_pos_sin, axis=1, mode=self.config.cp_balance_mode
                 )
 
         preproc_output = {

--- a/src/paddlefleet/tilelang_ops/indexer/csa_indexer.py
+++ b/src/paddlefleet/tilelang_ops/indexer/csa_indexer.py
@@ -152,6 +152,7 @@ def csa_indexer_topk_fwd(
     weights,
     ratio: int,
     topk_effective: int,
+    seq_offset: int = 0,
     block_K: int = DEFAULT_INDEXER_BLOCK,
     num_stages: int = 0,
     num_threads: int = 128,
@@ -162,12 +163,15 @@ def csa_indexer_topk_fwd(
         index_q: [B, S, H_i, D_i] indexer queries.
         index_k_comp: [B, S_comp, D_i] compressed indexer keys.
         weights: [B, S, H_i] per-head weights for score aggregation.
-        ratio: compression ratio (e.g. 4). Causal range: [0, (t+1)//ratio).
+        ratio: compression ratio (e.g. 4). Causal range:
+            [0, (t + seq_offset + 1) // ratio).
         topk_effective: number of top-k entries to select per query position.
             - Phase 2 (dsa_indexer_use_sparse_loss=False): set to n_compressed
               = floor(S / ratio) for full-candidate selection.
             - Phase 3 (dsa_indexer_use_sparse_loss=True): set to
               min(index_topk, n_compressed), typically 512.
+        seq_offset: global position offset for the first local query token.
+            In CP mode, this is cp_rank * sq_local. Default 0.
         block_K: tile size for streaming over compressed keys (default 32).
 
     Returns:
@@ -187,6 +191,7 @@ def csa_indexer_topk_fwd(
         weights,
         ratio=int(ratio),
         topk_effective=topk_effective,
+        seq_offset=int(seq_offset),
         block_K=int(block_K),
         num_stages=int(num_stages),
         num_threads=int(num_threads),

--- a/src/paddlefleet/tilelang_ops/indexer/csa_indexer_bwd.py
+++ b/src/paddlefleet/tilelang_ops/indexer/csa_indexer_bwd.py
@@ -299,6 +299,9 @@ def tl_csa_indexer_bwd_impl(
                             d_index_k_frag[i, j],
                         )
 
+                # Prevent the race condition: threads in the warp might overwrite topk in the next loop
+                T.sync_threads()
+
             for i, j in T.Parallel(heads, dim):
                 d_index_q_frag[i, j] = d_index_q_frag[i, j] * sm_scale
 

--- a/src/paddlefleet/tilelang_ops/indexer/csa_indexer_fwd.py
+++ b/src/paddlefleet/tilelang_ops/indexer/csa_indexer_fwd.py
@@ -53,6 +53,7 @@ def tl_csa_indexer_topk_fwd_impl(
     dim: int,
     topk: int,
     ratio: int,
+    seq_offset: int = 0,
     block_K: int = 32,
     dtype: str = "bfloat16",
     num_stages: int = 0,
@@ -120,7 +121,7 @@ def tl_csa_indexer_topk_fwd_impl(
         with T.Kernel(seq_len, batch, threads=num_threads) as (bx, by):
             i_t = bx
             i_b = by
-            valid_end = T.min((i_t + 1) // ratio, seq_len_comp)
+            valid_end = T.min((i_t + seq_offset + 1) // ratio, seq_len_comp)
 
             topk_index_shared = T.alloc_shared([N], dtype=INT32)
             topk_value_shared = T.alloc_shared([N], dtype=FP32)
@@ -325,6 +326,7 @@ def csa_indexer_topk_fwd_interface(
     weights,
     ratio: int,
     topk_effective: int,
+    seq_offset: int = 0,
     block_K: int = 32,
     num_stages: int = 0,
     num_threads: int = 128,
@@ -336,9 +338,11 @@ def csa_indexer_topk_fwd_interface(
         index_k_comp: [B, S_comp, D_i] bf16/fp16, BSD layout.
         weights: [B, S, H_i] fp32 or castable to fp32.
         ratio: compression ratio. Valid compressed range for query t is
-            [0, (t + 1) // ratio).
+            [0, (t + seq_offset + 1) // ratio).
         topk_effective: requested output top-k. Phase 2 may set this to
             S_comp; Phase 3 usually sets this to dsa_indexer_topk.
+        seq_offset: global position offset for the first local query token.
+            In CP mode, this is cp_rank * sq_local.
 
     Returns:
         topk_indices: [B, S, topk_effective] int32, invalid slots are -1.
@@ -364,6 +368,7 @@ def csa_indexer_topk_fwd_interface(
         dim=dim,
         topk=padded_topk,
         ratio=ratio,
+        seq_offset=int(seq_offset),
         block_K=block_K,
         dtype=_tilelang_dtype(index_q),
         num_stages=num_stages,

--- a/src/paddlefleet/transformer/attention.py
+++ b/src/paddlefleet/transformer/attention.py
@@ -74,6 +74,7 @@ def _apply_ec_complex_3d_mrope(
     rope_theta=1000000.0,
     mrope_section=None,
     layer_number=0,
+    cp_balance_mode="dualchunk_allgather",
 ):
     """Apply EC-style complex multiplication 3D MRoPE to query and key tensors."""
     import logging
@@ -130,7 +131,9 @@ def _apply_ec_complex_3d_mrope(
     freqs_cis = paddle.polar(paddle.ones_like(freqs), freqs)
     freqs_cis = freqs_cis.unsqueeze(2)
     if get_context_parallel_world_size() > 1:
-        freqs_cis = ContextParallelScatterOp.apply(freqs_cis, axis=1)
+        freqs_cis = ContextParallelScatterOp.apply(
+            freqs_cis, axis=1, mode=cp_balance_mode
+        )
     if _LOG_LAYER_MD5:
         logger = logging.getLogger(__name__)
         rank = paddle.distributed.get_rank()
@@ -601,6 +604,7 @@ class Attention(FleetLayer, ABC):
                 rope_theta=self.config.rope_theta,
                 mrope_section=getattr(self.config, "mrope_section", [16, 1, 1]),
                 layer_number=self.layer_number,
+                cp_balance_mode=self.config.cp_balance_mode,
             )
         elif rope_freqs_cis is not None:
             rope_freqs_cis = rope_freqs_cis.unsqueeze(-2)  # ..., 1, head_dim/2

--- a/src/paddlefleet/transformer/cp_utils.py
+++ b/src/paddlefleet/transformer/cp_utils.py
@@ -85,7 +85,7 @@ def _cp_reduce_scatter(grad_full: Tensor, dim: int, group) -> Tensor:
     ]
     dist.stream.alltoall(bufs, list(chunks), group=group, use_calc_stream=True)
 
-    result = paddle.stack(bufs).cast("float32").sum(0).cast(grad_full.dtype)
+    result = paddle.stack(bufs).sum(0).cast(grad_full.dtype)
 
     if dim != 0:
         result = result.transpose(perm)
@@ -199,15 +199,17 @@ def map_compressed_topk_to_kv_full_cp(
         [b, sq_local, topk_eff] int32 indices into kv_full, -1 for invalid.
     """
     n_valid = (
-        ((q_positions + 1) // ratio).unsqueeze(0).unsqueeze(2)
-    )  # [1, sq_local, 1]
-    indices_i64 = topk_indices_compressed.cast("int64")
-    valid = (indices_i64 >= 0) & (indices_i64 < n_valid)
+        ((q_positions + 1) // ratio)
+        .unsqueeze(0)
+        .unsqueeze(2)
+        .cast(topk_indices_compressed.dtype)
+    )  # [1, sq_local, 1], same dtype as input
+    valid = (topk_indices_compressed >= 0) & (topk_indices_compressed < n_valid)
     return paddle.where(
         valid,
         topk_indices_compressed + offset,
         paddle.full_like(topk_indices_compressed, -1),
-    ).cast("int32")
+    )
 
 
 def build_causal_mask_cp(

--- a/src/paddlefleet/transformer/cp_utils.py
+++ b/src/paddlefleet/transformer/cp_utils.py
@@ -25,98 +25,23 @@ so it can be safely imported by both csa_attention.py without circular imports.
 from __future__ import annotations
 
 import paddle
-import paddle.distributed as dist
 from paddle import Tensor
-from paddle.autograd import PyLayer
 
 # ===========================================================================
-# Communication primitives
+# Differentiable all-gather — delegates to ContextParallelAllGatherOp
 # ===========================================================================
-
-
-def _cp_all_gather(local_tensor: Tensor, dim: int, group) -> Tensor:
-    """All-gather for contiguous CP along `dim`. Natural rank order.
-
-    Paddle's dist.stream.all_gather concatenates along axis=0, so we
-    transpose dim<->0 when dim != 0.
-    """
-    nranks = group.nranks
-    if nranks == 1:
-        return local_tensor
-
-    if dim != 0:
-        perm = list(range(local_tensor.ndim))
-        perm[0], perm[dim] = perm[dim], perm[0]
-        local_tensor = local_tensor.transpose(perm).contiguous()
-
-    shape = list(local_tensor.shape)
-    shape[0] = shape[0] * nranks
-    gathered = paddle.empty(shape=shape, dtype=local_tensor.dtype)
-    dist.stream.all_gather(
-        gathered, local_tensor, group=group, use_calc_stream=True
-    )
-
-    if dim != 0:
-        gathered = gathered.transpose(perm).contiguous()
-
-    return gathered
-
-
-def _cp_reduce_scatter(grad_full: Tensor, dim: int, group) -> Tensor:
-    """Reduce-scatter for contiguous CP along `dim`.
-
-    Each rank receives the sum of all ranks' gradients for its local slice.
-    Uses alltoall + local fp32 sum for bf16 precision.
-    """
-    nranks = group.nranks
-    if nranks == 1:
-        return grad_full
-
-    if dim != 0:
-        perm = list(range(grad_full.ndim))
-        perm[0], perm[dim] = perm[dim], perm[0]
-        grad_full = grad_full.transpose(perm).contiguous()
-
-    chunks = paddle.split(grad_full, nranks, axis=0)
-
-    bufs = [
-        paddle.empty(chunks[0].shape, dtype=grad_full.dtype)
-        for _ in range(nranks)
-    ]
-    dist.stream.alltoall(bufs, list(chunks), group=group, use_calc_stream=True)
-
-    result = paddle.stack(bufs).sum(0).cast(grad_full.dtype)
-
-    if dim != 0:
-        result = result.transpose(perm)
-
-    return result
-
-
-# ===========================================================================
-# Differentiable all-gather PyLayer
-# ===========================================================================
-
-
-class _AllGatherCPFunction(PyLayer):
-    """Forward: all-gather. Backward: reduce-scatter. Stores nothing."""
-
-    @staticmethod
-    def forward(ctx, x: Tensor, dim: int, group) -> Tensor:
-        ctx.dim = dim
-        ctx.group = group
-        return _cp_all_gather(x, dim, group)
-
-    @staticmethod
-    def backward(ctx, grad_output: Tensor):
-        return _cp_reduce_scatter(grad_output, ctx.dim, ctx.group)
+from paddlefleet.context_parallel_utils import ContextParallelAllGatherOp
 
 
 def all_gather_cp(x: Tensor, dim: int, group) -> Tensor:
-    """Differentiable all-gather for contiguous CP."""
+    """Differentiable all-gather for contiguous CP.
+
+    Delegates to ContextParallelAllGatherOp (mode='contiguous_allgather'),
+    which uses NCCL reduce_scatter in backward for axis=0 (more efficient).
+    """
     if group is None or group.nranks <= 1:
         return x
-    return _AllGatherCPFunction.apply(x, dim, group)
+    return ContextParallelAllGatherOp.apply(x, dim, "contiguous_allgather")
 
 
 # ===========================================================================

--- a/src/paddlefleet/transformer/cp_utils.py
+++ b/src/paddlefleet/transformer/cp_utils.py
@@ -1,0 +1,239 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Context Parallelism (CP) communication primitives and index utilities.
+
+Contiguous CP layout: rank r holds global positions [r*sq_local, (r+1)*sq_local).
+All-gather along seq dim produces natural global order; reduce-scatter inverts it.
+
+This module has no internal dependencies on other paddlefleet.transformer modules,
+so it can be safely imported by both csa_attention.py without circular imports.
+"""
+
+from __future__ import annotations
+
+import paddle
+import paddle.distributed as dist
+from paddle import Tensor
+from paddle.autograd import PyLayer
+
+# ===========================================================================
+# Communication primitives
+# ===========================================================================
+
+
+def _cp_all_gather(local_tensor: Tensor, dim: int, group) -> Tensor:
+    """All-gather for contiguous CP along `dim`. Natural rank order.
+
+    Paddle's dist.stream.all_gather concatenates along axis=0, so we
+    transpose dim<->0 when dim != 0.
+    """
+    nranks = group.nranks
+    if nranks == 1:
+        return local_tensor
+
+    if dim != 0:
+        perm = list(range(local_tensor.ndim))
+        perm[0], perm[dim] = perm[dim], perm[0]
+        local_tensor = local_tensor.transpose(perm).contiguous()
+
+    shape = list(local_tensor.shape)
+    shape[0] = shape[0] * nranks
+    gathered = paddle.empty(shape=shape, dtype=local_tensor.dtype)
+    dist.stream.all_gather(
+        gathered, local_tensor, group=group, use_calc_stream=True
+    )
+
+    if dim != 0:
+        gathered = gathered.transpose(perm).contiguous()
+
+    return gathered
+
+
+def _cp_reduce_scatter(grad_full: Tensor, dim: int, group) -> Tensor:
+    """Reduce-scatter for contiguous CP along `dim`.
+
+    Each rank receives the sum of all ranks' gradients for its local slice.
+    Uses alltoall + local fp32 sum for bf16 precision.
+    """
+    nranks = group.nranks
+    if nranks == 1:
+        return grad_full
+
+    if dim != 0:
+        perm = list(range(grad_full.ndim))
+        perm[0], perm[dim] = perm[dim], perm[0]
+        grad_full = grad_full.transpose(perm).contiguous()
+
+    chunks = paddle.split(grad_full, nranks, axis=0)
+
+    bufs = [
+        paddle.empty(chunks[0].shape, dtype=grad_full.dtype)
+        for _ in range(nranks)
+    ]
+    dist.stream.alltoall(bufs, list(chunks), group=group, use_calc_stream=True)
+
+    result = paddle.stack(bufs).cast("float32").sum(0).cast(grad_full.dtype)
+
+    if dim != 0:
+        result = result.transpose(perm)
+
+    return result
+
+
+# ===========================================================================
+# Differentiable all-gather PyLayer
+# ===========================================================================
+
+
+class _AllGatherCPFunction(PyLayer):
+    """Forward: all-gather. Backward: reduce-scatter. Stores nothing."""
+
+    @staticmethod
+    def forward(ctx, x: Tensor, dim: int, group) -> Tensor:
+        ctx.dim = dim
+        ctx.group = group
+        return _cp_all_gather(x, dim, group)
+
+    @staticmethod
+    def backward(ctx, grad_output: Tensor):
+        return _cp_reduce_scatter(grad_output, ctx.dim, ctx.group)
+
+
+def all_gather_cp(x: Tensor, dim: int, group) -> Tensor:
+    """Differentiable all-gather for contiguous CP."""
+    if group is None or group.nranks <= 1:
+        return x
+    return _AllGatherCPFunction.apply(x, dim, group)
+
+
+# ===========================================================================
+# CP-aware topk index generators
+# ===========================================================================
+
+
+def get_window_topk_idxs_cp(
+    q_positions: Tensor,
+    window_size: int,
+    batch_size: int,
+    sq_global: int,
+) -> Tensor:
+    """Sliding window indices using global q_positions.
+
+    Args:
+        q_positions: [sq_local] int64, global positions for this rank.
+        window_size: sliding window size.
+        batch_size: batch dimension.
+        sq_global: global sequence length.
+
+    Returns:
+        [batch_size, sq_local, window_size] int32, -1 for invalid slots.
+    """
+    effective_window = min(window_size, sq_global)
+    base = q_positions.unsqueeze(1)  # [sq_local, 1]
+    offsets = paddle.arange(effective_window)  # [window_size]
+    k_pos = (
+        paddle.clip(base - effective_window + 1, min=0) + offsets
+    )  # [sq_local, window_size]
+    topk_idxs = paddle.where(k_pos > base, paddle.full_like(k_pos, -1), k_pos)
+    return topk_idxs.unsqueeze(0).expand([batch_size, -1, -1]).cast("int32")
+
+
+def get_compress_topk_idxs_cp(
+    q_positions: Tensor,
+    ratio: int,
+    batch_size: int,
+    offset: int,
+    n_compressed_global: int,
+) -> Tensor:
+    """Static compressed topk indices using global q_positions (HCA path).
+
+    Args:
+        q_positions: [sq_local] global positions.
+        ratio: compression ratio.
+        batch_size: batch dimension.
+        offset: kv_full offset for compressed positions (= sq_global).
+        n_compressed_global: total compressed positions globally.
+
+    Returns:
+        [batch_size, sq_local, n_compressed_global] int32, -1 for invalid.
+    """
+    k_group_idx = paddle.arange(n_compressed_global)  # [n_comp]
+    q_first_invalid = ((q_positions + 1) // ratio).unsqueeze(1)  # [sq_local, 1]
+    invalid_mask = k_group_idx.unsqueeze(0) >= q_first_invalid
+    matrix = paddle.where(
+        invalid_mask,
+        paddle.full([1], -1, dtype="int64"),
+        k_group_idx.unsqueeze(0) + offset,
+    )
+    return matrix.unsqueeze(0).expand([batch_size, -1, -1]).cast("int32")
+
+
+def map_compressed_topk_to_kv_full_cp(
+    topk_indices_compressed: Tensor,
+    q_positions: Tensor,
+    ratio: int,
+    offset: int,
+) -> Tensor:
+    """Map indexer topk indices to kv_full coordinates with CP-aware causal check.
+
+    Args:
+        topk_indices_compressed: [b, sq_local, topk_eff] compressed block ids.
+        q_positions: [sq_local] global positions.
+        ratio: compression ratio.
+        offset: kv_full offset (= sq_global).
+
+    Returns:
+        [b, sq_local, topk_eff] int32 indices into kv_full, -1 for invalid.
+    """
+    n_valid = (
+        ((q_positions + 1) // ratio).unsqueeze(0).unsqueeze(2)
+    )  # [1, sq_local, 1]
+    indices_i64 = topk_indices_compressed.cast("int64")
+    valid = (indices_i64 >= 0) & (indices_i64 < n_valid)
+    return paddle.where(
+        valid,
+        topk_indices_compressed + offset,
+        paddle.full_like(topk_indices_compressed, -1),
+    ).cast("int32")
+
+
+def build_causal_mask_cp(
+    q_positions: Tensor,
+    n_compressed_global: int,
+    ratio: int,
+    batch_size: int,
+) -> Tensor:
+    """Build causal mask for CSA indexer with global positions.
+
+    Args:
+        q_positions: [sq_local] global positions.
+        n_compressed_global: total compressed positions globally.
+        ratio: compression ratio.
+        batch_size: batch dimension.
+
+    Returns:
+        [batch_size, sq_local, n_compressed_global] float32, -inf for invalid.
+    """
+    compressed_ids = paddle.arange(n_compressed_global).unsqueeze(
+        0
+    )  # [1, n_comp]
+    q_first_invalid = ((q_positions + 1) // ratio).unsqueeze(1)  # [sq_local, 1]
+    mask = paddle.where(
+        compressed_ids >= q_first_invalid,
+        paddle.full([1], float("-inf"), dtype="float32"),
+        paddle.zeros([1], dtype="float32"),
+    )  # [sq_local, n_comp]
+    return mask.unsqueeze(0).expand([batch_size, -1, -1])

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -904,11 +904,6 @@ class Compressor(nn.Layer):
                 )
             if self.rotate:
                 kv = rotate_activation(kv)
-            # Slice back to local rank's compressed range
-            cp_size = cp_group.nranks
-            n_comp_local = n_compressed // cp_size
-            cp_rank = cp_group.rank
-            kv = kv[:, cp_rank * n_comp_local : (cp_rank + 1) * n_comp_local, :]
             return kv
 
         # Non-CP path (original logic)
@@ -1551,12 +1546,9 @@ class CompressedSparseAttention(FleetLayer):
             and self.compress_ratio > 1
             and n_compressed_local > 0
         ):
-            # Miles pattern: project locally, gather projected, pool globally, slice back
-            compressed_kv_local = self.compressor(
+            # inside the compressor, we will all-gather all the compressed KV
+            compressed_kv_global = self.compressor(
                 x, position_offset=position_offset, cp_group=self.cp_group
-            )
-            compressed_kv_global = all_gather_cp(
-                compressed_kv_local, dim=1, group=self.cp_group
             )
             kv_full = paddle.concat([kv_global, compressed_kv_global], axis=1)
         else:
@@ -1589,18 +1581,13 @@ class CompressedSparseAttention(FleetLayer):
                     self.indexer.index_topk, n_compressed_global
                 )
 
-                q_indexer_bf, k_indexer_local, weights_indexer_bf = (
+                q_indexer_bf, k_indexer_global, weights_indexer_bf = (
                     self.indexer.forward_before_topk(
                         x_det,
                         qr_det,
                         position_offset=position_offset,
                         cp_group=self.cp_group,
                     )
-                )
-                # Gather indexer K globally (local K is already the local slice
-                # from the compressor's CP path)
-                k_indexer_global = all_gather_cp(
-                    k_indexer_local, dim=1, group=self.cp_group
                 )
 
                 indexer_loss_coeff = getattr(

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -51,6 +51,15 @@ if TYPE_CHECKING:
     from paddlefleet.transformer.enums import AttnMaskType
     from paddlefleet.transformer.transformer_config import TransformerConfig
 
+# CP utilities are imported lazily inside _forward_cp to avoid circular imports
+# at module load time. The public symbols are re-exported here for convenience.
+from paddlefleet.transformer.cp_utils import (
+    all_gather_cp,
+    build_causal_mask_cp,
+    get_compress_topk_idxs_cp,
+    get_window_topk_idxs_cp,
+    map_compressed_topk_to_kv_full_cp,
+)
 
 # ---------------------------------------------------------------------------
 # Helper functions for index computation
@@ -138,6 +147,7 @@ def _apply_rope(
     config: TransformerConfig,
     rotary_seq_len: int,
     ratio: int = 1,
+    position_offset: int = 0,
 ) -> Tensor:
     """Apply RoPE to the last pos_dim dims, leaving first nope_dim unchanged.
 
@@ -152,8 +162,13 @@ def _apply_rope(
         config: transformer config
         rotary_seq_len: sequence length for this tensor
         ratio: compression ratio for position subsampling
+        position_offset: global position offset for CP (cp_rank * sq_local)
     """
-    total_seq_len = rotary_seq_len * ratio if ratio > 1 else rotary_seq_len
+    total_seq_len = (
+        (rotary_seq_len + position_offset) * ratio
+        if ratio > 1
+        else (rotary_seq_len + position_offset)
+    )
     result = rotary_pos_emb_module(total_seq_len, packed_seq=False)
     if isinstance(result, tuple):
         freqs, mscale = result
@@ -164,7 +179,11 @@ def _apply_rope(
     mscale = 1.0
     # freqs: [1, total_seq_len, pos_dim]
     if ratio > 1:
-        freqs = freqs[:, :total_seq_len:ratio, :][:, :rotary_seq_len, :]
+        freqs = freqs[:, position_offset * ratio :: ratio, :][
+            :, :rotary_seq_len, :
+        ]
+    else:
+        freqs = freqs[:, position_offset : position_offset + rotary_seq_len, :]
 
     squeeze_head = x.ndim == 3
     if squeeze_head:
@@ -413,6 +432,7 @@ def _compute_tilelang_csa_indexer_loss_forward(
     softmax_scale: float,
     loss_coeff: float,
     tp_group=None,
+    seq_offset: int = 0,
 ) -> tuple[Tensor, Tensor, Tensor, Tensor]:
     from paddlefleet.tilelang_ops import (
         csa_attn_target_reducesum,
@@ -425,6 +445,7 @@ def _compute_tilelang_csa_indexer_loss_forward(
         weights,
         ratio=int(ratio),
         topk_effective=int(topk_effective),
+        seq_offset=int(seq_offset),
     )
 
     if tp_group is not None and getattr(tp_group, "nranks", 1) > 1:
@@ -500,6 +521,7 @@ class TileLangCSAIndexerLoss(paddle.autograd.PyLayer):
         loss_coeff: float,
         tp_group=None,
         indexer_backend: str = "tilelang",
+        seq_offset: int = 0,
     ) -> Tensor:
         # The TileLang kernel applies its own ``dim**-0.5`` scale on index_q
         # and consumes raw weights, so we pass them through unmodified. The
@@ -518,6 +540,7 @@ class TileLangCSAIndexerLoss(paddle.autograd.PyLayer):
                 softmax_scale,
                 loss_coeff,
                 tp_group,
+                seq_offset=seq_offset,
             )
         )
 
@@ -822,14 +845,21 @@ class Compressor(nn.Layer):
     def forward(
         self,
         x: Tensor,
+        position_offset: int = 0,
+        cp_group=None,
     ) -> Tensor | None:
         """Compress hidden states into shorter KV sequence.
 
         Args:
             x: [b, sq, hidden_size]
+            position_offset: global position offset for CP (cp_rank * sq_local).
+                When non-zero, all-gathers projected KV before pooling so that
+                the compressor sees the full global context.
+            cp_group: CP process group. Required when position_offset > 0.
 
         Returns:
             compressed_kv: [b, sq // ratio, head_dim] or None if too short.
+            In CP mode, returns the local rank's slice of the global compressed KV.
         """
         b, sq, _ = x.shape
         ratio = self.compress_ratio
@@ -840,6 +870,48 @@ class Compressor(nn.Layer):
         kv, _ = self.linear_wkv(x)  # [b, sq, coff * head_dim]
         score, _ = self.linear_wgate(x)  # [b, sq, coff * head_dim]
 
+        # CP: gather projected KV globally before pooling (Miles pattern).
+        # This lets the compressor pool across the full sequence while keeping
+        # communication cheap (projected dim << hidden_size).
+        if cp_group is not None and getattr(cp_group, "nranks", 1) > 1:
+            kv = all_gather_cp(kv, dim=1, group=cp_group)
+            score = all_gather_cp(score, dim=1, group=cp_group)
+            b, sq_global, _ = kv.shape
+            # Pool globally, then slice back to local rank's range
+            cutoff = (sq_global // ratio) * ratio
+            if cutoff < sq_global:
+                kv = kv[:, :cutoff, :]
+                score = score[:, :cutoff, :]
+            n_compressed = cutoff // ratio
+            kv = kv.reshape([b, n_compressed, ratio, -1])
+            score = score.reshape([b, n_compressed, ratio, -1])
+            score = score + self.ape.reshape([1, 1, ratio, -1])
+            if self.overlap:
+                kv = self._overlap_transform(kv, fill_value=0)
+                score = self._overlap_transform(score, fill_value=float("-inf"))
+            kv = (kv * F.softmax(score, axis=2)).sum(axis=2)
+            kv = self.norm(kv.cast(x.dtype))
+            if self.rotary_pos_emb is not None and self.qk_pos_emb_head_dim > 0:
+                kv = _apply_rope(
+                    kv,
+                    self.head_dim - self.qk_pos_emb_head_dim,
+                    self.qk_pos_emb_head_dim,
+                    self.rotary_pos_emb,
+                    self.config,
+                    n_compressed,
+                    ratio=ratio,
+                    position_offset=0,  # global compressed KV starts at 0
+                )
+            if self.rotate:
+                kv = rotate_activation(kv)
+            # Slice back to local rank's compressed range
+            cp_size = cp_group.nranks
+            n_comp_local = n_compressed // cp_size
+            cp_rank = cp_group.rank
+            kv = kv[:, cp_rank * n_comp_local : (cp_rank + 1) * n_comp_local, :]
+            return kv
+
+        # Non-CP path (original logic)
         cutoff = (sq // ratio) * ratio
         if cutoff < sq:
             kv = kv[:, :cutoff, :]
@@ -874,6 +946,7 @@ class Compressor(nn.Layer):
                 self.config,
                 n_compressed,
                 ratio=ratio,
+                position_offset=position_offset,
             )
 
         if self.rotate:
@@ -968,8 +1041,14 @@ class CSAIndexer(nn.Layer):
         self,
         x: Tensor,  # [b, sq, hidden_size]
         qr: Tensor,  # [b, sq, q_lora_rank]
+        position_offset: int = 0,
+        cp_group=None,
     ) -> tuple[Tensor, Tensor, Tensor]:
-        """Compute Q, compressed K, and weights before top-k selection."""
+        """Compute Q, compressed K, and weights before top-k selection.
+
+        In CP mode, position_offset and cp_group are forwarded to the internal
+        compressor so that indexer K is computed over the full global sequence.
+        """
         b, sq, _ = x.shape
 
         # Q path
@@ -984,11 +1063,14 @@ class CSAIndexer(nn.Layer):
                 self.config,
                 sq,
                 ratio=1,
+                position_offset=position_offset,
             )
         q = rotate_activation(q)
 
-        # K path: own compressor (already applies RoPE and rotation internally)
-        k = self.compressor(x)  # [b, n_compressed, index_head_dim]
+        # K path: own compressor (applies RoPE and rotation internally)
+        k = self.compressor(
+            x, position_offset=position_offset, cp_group=cp_group
+        )
 
         # Weights
         weights, _ = self.linear_weights_proj(x)  # [b, sq, n_heads]
@@ -1079,6 +1161,19 @@ class CompressedSparseAttention(FleetLayer):
         self.v_head_dim = config.v_head_dim
         self.n_local_heads = config.num_attention_heads
         self.softmax_scale = config.v_head_dim**-0.5
+
+        # CP state: derived from pg_collection.cp; cp_size=1 means CP disabled
+        cp_pg = pg_collection.cp if pg_collection is not None else None
+        if cp_pg is not None and getattr(cp_pg, "nranks", 1) > 1:
+            self.cp_group = cp_pg
+            self.cp_size = cp_pg.nranks
+            self.cp_rank = cp_pg.rank
+            self.cp_enabled = True
+        else:
+            self.cp_group = None
+            self.cp_size = 1
+            self.cp_rank = 0
+            self.cp_enabled = False
 
         # Learnable attention sink per head
         self.attn_sink = self.create_parameter(
@@ -1317,6 +1412,9 @@ class CompressedSparseAttention(FleetLayer):
         Returns:
             output: [b, sq, np * v_head_dim]
         """
+        if self.cp_enabled:
+            return self._forward_cp(query, key, x, qr)
+
         b, sq, np_heads, hn = query.shape
 
         # Step 1: Prepare single-head KV
@@ -1391,6 +1489,282 @@ class CompressedSparseAttention(FleetLayer):
             output = TileLangCSAIndexerLossAutoScaler.apply(
                 output,
                 *tilelang_indexer_loss_state,
+            )
+        elif indexer_loss is not None and self.training:
+            output = DSAIndexerLossAutoScaler.apply(output, indexer_loss)
+
+        return output
+
+    def _forward_cp(
+        self,
+        query: Tensor,
+        key: Tensor,
+        x: Tensor,
+        qr: Tensor,
+    ) -> Tensor:
+        """CP-aware forward: local compress + all-gather, sparse attention.
+
+        Mirrors the non-CP forward() structure exactly, with CP adaptations:
+          1. All-gather KV + compress (Miles pattern: gather projected, pool globally)
+          2. Indexer topk + fused loss (same three-branch logic as non-CP)
+          3. Sparse attention (same compressed_sparse_attn dispatch)
+          4. Attach loss (TileLangCSAIndexerLossAutoScaler or DSAIndexerLossAutoScaler)
+
+        Gradient correctness:
+          - all_gather_cp backward (reduce-scatter) routes attention/loss grads
+          - indexer_loss / cp_size corrects local-mean to global-mean scaling
+          - param grads are partial (each rank sees local Q); production ZeRO
+            reduce_scatter(SUM) + optimizer x cp_size aggregates them correctly
+        """
+        b, sq, np_heads, hn = query.shape
+        sq_global = sq * self.cp_size
+        position_offset = self.cp_rank * sq
+        q_positions = paddle.arange(
+            position_offset, position_offset + sq, dtype="int64"
+        )
+
+        # Step 1: Window topk (CP-aware: uses global q_positions)
+        window_idxs = get_window_topk_idxs_cp(
+            q_positions, self.window_size, b, sq_global
+        )
+
+        # Step 2: All-gather KV + compress
+        kv_local = key.squeeze(2)  # [b, sq, hn]
+        kv_global = all_gather_cp(kv_local, dim=1, group=self.cp_group)
+
+        compressed_kv_global = None
+        n_compressed_local = 0
+        if (
+            self.compressor is not None
+            and self.compress_ratio > 1
+            and sq >= self.compress_ratio
+        ):
+            assert sq % self.compress_ratio == 0, (
+                f"CP requires sq_local ({sq}) divisible by compress_ratio ({self.compress_ratio})"
+            )
+            n_compressed_local = sq // self.compress_ratio
+        n_compressed_global = n_compressed_local * self.cp_size
+        offset = sq_global  # compressed indices follow vanilla KV in kv_full
+
+        if (
+            self.compressor is not None
+            and self.compress_ratio > 1
+            and n_compressed_local > 0
+        ):
+            # Miles pattern: project locally, gather projected, pool globally, slice back
+            compressed_kv_local = self.compressor(
+                x, position_offset=position_offset, cp_group=self.cp_group
+            )
+            compressed_kv_global = all_gather_cp(
+                compressed_kv_local, dim=1, group=self.cp_group
+            )
+            kv_full = paddle.concat([kv_global, compressed_kv_global], axis=1)
+        else:
+            kv_full = kv_global
+
+        # Step 3: Compressed topk + optional fused indexer loss
+        indexer_loss = None
+        tilelang_indexer_loss_state = None
+
+        if self.compress_ratio > 1 and n_compressed_global > 0:
+            if self.indexer is not None:
+                x_det = x.detach()
+                qr_det = qr.detach()
+                if self.training:
+                    x_det.stop_gradient = False
+                    qr_det.stop_gradient = False
+
+                use_tilelang_indexer = _resolve_csa_tilelang_switch(
+                    self.config, "csa_tilelang_enable_indexer"
+                )
+                use_tilelang_loss_path = (
+                    use_tilelang_indexer
+                    and self.training
+                    and paddle.is_grad_enabled()
+                )
+                loss_topk_effective = _resolve_csa_indexer_loss_topk_effective(
+                    self.config, self.indexer.index_topk, n_compressed_global
+                )
+                attn_topk_effective = _resolve_csa_indexer_attn_topk_effective(
+                    self.indexer.index_topk, n_compressed_global
+                )
+
+                q_indexer_bf, k_indexer_local, weights_indexer_bf = (
+                    self.indexer.forward_before_topk(
+                        x_det,
+                        qr_det,
+                        position_offset=position_offset,
+                        cp_group=self.cp_group,
+                    )
+                )
+                # Gather indexer K globally (local K is already the local slice
+                # from the compressor's CP path)
+                k_indexer_global = all_gather_cp(
+                    k_indexer_local, dim=1, group=self.cp_group
+                )
+
+                indexer_loss_coeff = getattr(
+                    self.config, "dsa_indexer_loss_coeff", 0.0
+                )
+
+                if use_tilelang_loss_path:
+                    # Fused TileLang: single PyLayer produces topk + loss.
+                    # key_comp_mla is 3D [b, n_comp_global, hn] (shared across heads).
+                    key_comp_mla = compressed_kv_global.detach()
+                    (
+                        indexer_loss,
+                        topk_indices_compressed,
+                        topk_probs,
+                        target,
+                    ) = _compute_tilelang_csa_indexer_loss_forward(
+                        q_indexer_bf,
+                        weights_indexer_bf,
+                        k_indexer_global,
+                        query.detach(),
+                        key_comp_mla,
+                        int(self.compress_ratio),
+                        int(loss_topk_effective),
+                        float(self.softmax_scale),
+                        float(indexer_loss_coeff),
+                        self.tp_group,
+                        seq_offset=position_offset,
+                    )
+                    tilelang_indexer_loss_state = (
+                        q_indexer_bf,
+                        weights_indexer_bf,
+                        k_indexer_global,
+                        topk_indices_compressed,
+                        topk_probs,
+                        target,
+                        float(indexer_loss_coeff),
+                    )
+                    if indexer_loss_coeff > 0:
+                        DSAIndexerLossLoggingHelper.save_loss_to_tracker(
+                            loss=indexer_loss,
+                            layer_number=self.layer_number,
+                            num_layers=self.config.num_hidden_layers,
+                        )
+                    # Scale: each rank's loss is mean over sq_local;
+                    # global loss is mean over sq_global = sq_local * cp_size.
+                    indexer_loss = indexer_loss / self.cp_size
+
+                elif self.training and not use_tilelang_indexer:
+                    # Paddle reference loss path
+                    key_for_loss = (
+                        compressed_kv_global.detach()
+                        .transpose([1, 0, 2])
+                        .unsqueeze(2)
+                        .expand([-1, -1, np_heads, -1])
+                    )
+                    causal_mask = build_causal_mask_cp(
+                        q_positions, n_compressed_global, self.compress_ratio, b
+                    )
+                    q_sf = q_indexer_bf.transpose([1, 0, 2, 3])
+                    k_sf = (
+                        k_indexer_global.transpose([1, 0, 2])
+                        if k_indexer_global.ndim == 3
+                        else k_indexer_global.transpose([1, 0, 2, 3])
+                    )
+                    weights_sf = (
+                        weights_indexer_bf * self.indexer.softmax_scale
+                    ).transpose([1, 0, 2])
+                    query_sf = query.transpose([1, 0, 2, 3]).detach()
+                    mask_for_loss = causal_mask.unsqueeze(1)
+
+                    indexer_loss = FusedDSAIndexerLoss.apply(
+                        q_sf,
+                        weights_sf,
+                        k_sf,
+                        query_sf,
+                        key_for_loss.detach(),
+                        self.softmax_scale,
+                        min(self.indexer.index_topk, n_compressed_global),
+                        indexer_loss_coeff,
+                        mask_for_loss,
+                        getattr(
+                            self.config, "dsa_indexer_use_sparse_loss", True
+                        ),
+                        self.tp_group,
+                    )
+                    topk_indices_compressed = (
+                        FusedDSAIndexerLoss._last_topk_indices
+                    )
+                    if indexer_loss_coeff > 0:
+                        DSAIndexerLossLoggingHelper.save_loss_to_tracker(
+                            loss=indexer_loss,
+                            layer_number=self.layer_number,
+                            num_layers=self.config.num_hidden_layers,
+                        )
+                    indexer_loss = indexer_loss / self.cp_size
+
+                elif not use_tilelang_indexer:
+                    # Inference-only Paddle topk (use already-gathered global K)
+                    causal_mask = build_causal_mask_cp(
+                        q_positions, n_compressed_global, self.compress_ratio, b
+                    )
+                    _, topk_indices_compressed = fused_qk_topk_naive(
+                        q_indexer_bf,
+                        k_indexer_global,
+                        weights_indexer_bf,
+                        attn_topk_effective,
+                        causal_mask,
+                    )
+
+                # TileLang fwd-only topk (no loss, or loss already produced above)
+                if use_tilelang_indexer and not use_tilelang_loss_path:
+                    from paddlefleet.tilelang_ops import csa_indexer_topk_fwd
+
+                    with paddle.no_grad():
+                        tl_topk_indices, _ = csa_indexer_topk_fwd(
+                            q_indexer_bf,
+                            k_indexer_global,
+                            weights_indexer_bf,
+                            ratio=self.compress_ratio,
+                            topk_effective=attn_topk_effective,
+                            seq_offset=position_offset,
+                        )
+                    topk_indices_compressed = tl_topk_indices
+
+                if topk_indices_compressed.shape[-1] > attn_topk_effective:
+                    topk_indices_compressed = topk_indices_compressed[
+                        ..., :attn_topk_effective
+                    ].contiguous()
+
+                compress_topk_idxs = map_compressed_topk_to_kv_full_cp(
+                    topk_indices_compressed,
+                    q_positions,
+                    self.compress_ratio,
+                    offset,
+                )
+            else:
+                # HCA path: attend to all compressed positions
+                compress_topk_idxs = get_compress_topk_idxs_cp(
+                    q_positions,
+                    self.compress_ratio,
+                    b,
+                    offset,
+                    n_compressed_global,
+                )
+
+            if compress_topk_idxs.dtype != window_idxs.dtype:
+                compress_topk_idxs = compress_topk_idxs.cast(window_idxs.dtype)
+            topk_idxs = paddle.concat(
+                [window_idxs, compress_topk_idxs], axis=-1
+            )
+        else:
+            topk_idxs = window_idxs
+
+        topk_idxs = topk_idxs.cast("int32")
+
+        # Step 4: Sparse attention (same dispatch as non-CP)
+        output = self.compressed_sparse_attn(
+            query, kv_full, self.attn_sink, topk_idxs, self.softmax_scale
+        )
+
+        # Step 5: Attach indexer loss
+        if tilelang_indexer_loss_state is not None and self.training:
+            output = TileLangCSAIndexerLossAutoScaler.apply(
+                output, *tilelang_indexer_loss_state
             )
         elif indexer_loss is not None and self.training:
             output = DSAIndexerLossAutoScaler.apply(output, indexer_loss)

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -1623,7 +1623,7 @@ class CompressedSparseAttention(FleetLayer):
                         topk_indices_compressed,
                         topk_probs,
                         target,
-                        float(indexer_loss_coeff),
+                        float(indexer_loss_coeff) / self.cp_size,
                     )
                     if indexer_loss_coeff > 0:
                         DSAIndexerLossLoggingHelper.save_loss_to_tracker(

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -845,16 +845,12 @@ class Compressor(nn.Layer):
     def forward(
         self,
         x: Tensor,
-        position_offset: int = 0,
         cp_group=None,
     ) -> Tensor | None:
         """Compress hidden states into shorter KV sequence.
 
         Args:
             x: [b, sq, hidden_size]
-            position_offset: global position offset for CP (cp_rank * sq_local).
-                When non-zero, all-gathers projected KV before pooling so that
-                the compressor sees the full global context.
             cp_group: CP process group. Required when position_offset > 0.
 
         Returns:
@@ -876,35 +872,7 @@ class Compressor(nn.Layer):
         if cp_group is not None and getattr(cp_group, "nranks", 1) > 1:
             kv = all_gather_cp(kv, dim=1, group=cp_group)
             score = all_gather_cp(score, dim=1, group=cp_group)
-            b, sq_global, _ = kv.shape
-            # Pool globally, then slice back to local rank's range
-            cutoff = (sq_global // ratio) * ratio
-            if cutoff < sq_global:
-                kv = kv[:, :cutoff, :]
-                score = score[:, :cutoff, :]
-            n_compressed = cutoff // ratio
-            kv = kv.reshape([b, n_compressed, ratio, -1])
-            score = score.reshape([b, n_compressed, ratio, -1])
-            score = score + self.ape.reshape([1, 1, ratio, -1])
-            if self.overlap:
-                kv = self._overlap_transform(kv, fill_value=0)
-                score = self._overlap_transform(score, fill_value=float("-inf"))
-            kv = (kv * F.softmax(score, axis=2)).sum(axis=2)
-            kv = self.norm(kv.cast(x.dtype))
-            if self.rotary_pos_emb is not None and self.qk_pos_emb_head_dim > 0:
-                kv = _apply_rope(
-                    kv,
-                    self.head_dim - self.qk_pos_emb_head_dim,
-                    self.qk_pos_emb_head_dim,
-                    self.rotary_pos_emb,
-                    self.config,
-                    n_compressed,
-                    ratio=ratio,
-                    position_offset=0,  # global compressed KV starts at 0
-                )
-            if self.rotate:
-                kv = rotate_activation(kv)
-            return kv
+            b, sq, _ = kv.shape
 
         # Non-CP path (original logic)
         cutoff = (sq // ratio) * ratio
@@ -926,8 +894,9 @@ class Compressor(nn.Layer):
             score = self._overlap_transform(score, fill_value=float("-inf"))
 
         # Gated pooling: softmax over the pool_dim, weighted sum.
-        weights = F.softmax(score, axis=2).cast(kv.dtype)
-        kv = (kv * weights).sum(axis=2)  # [b, n_compressed, head_dim]
+        kv = (kv * F.softmax(score, axis=2)).sum(
+            axis=2
+        )  # [b, n_compressed, head_dim]
 
         kv = self.norm(kv.cast(x.dtype))
 
@@ -941,7 +910,7 @@ class Compressor(nn.Layer):
                 self.config,
                 n_compressed,
                 ratio=ratio,
-                position_offset=position_offset,
+                position_offset=0,
             )
 
         if self.rotate:
@@ -1063,9 +1032,7 @@ class CSAIndexer(nn.Layer):
         q = rotate_activation(q)
 
         # K path: own compressor (applies RoPE and rotation internally)
-        k = self.compressor(
-            x, position_offset=position_offset, cp_group=cp_group
-        )
+        k = self.compressor(x, cp_group=cp_group)
 
         # Weights
         weights, _ = self.linear_weights_proj(x)  # [b, sq, n_heads]
@@ -1547,9 +1514,7 @@ class CompressedSparseAttention(FleetLayer):
             and n_compressed_local > 0
         ):
             # inside the compressor, we will all-gather all the compressed KV
-            compressed_kv_global = self.compressor(
-                x, position_offset=position_offset, cp_group=self.cp_group
-            )
+            compressed_kv_global = self.compressor(x, cp_group=self.cp_group)
             kv_full = paddle.concat([kv_global, compressed_kv_global], axis=1)
         else:
             kv_full = kv_global

--- a/src/paddlefleet/transformer/dsv4_hybrid_attention.py
+++ b/src/paddlefleet/transformer/dsv4_hybrid_attention.py
@@ -213,8 +213,22 @@ class DSv4HybridAttention(Attention):
             (output [b, sq, hidden_size], bias=None)
         """
         # Get Q, K, V tensors
+        # In CP mode, pass position_offset so RoPE uses correct global positions.
+        cp_pg = getattr(self, "pg_collection", None)
+        cp_pg = cp_pg.cp if cp_pg is not None else None
+        cp_size = getattr(cp_pg, "nranks", 1) if cp_pg is not None else 1
+        cp_rank = (
+            getattr(cp_pg, "rank", 0)
+            if cp_pg is not None and cp_size > 1
+            else 0
+        )
+        _, sq, _ = hidden_states.shape
+        position_offset = cp_rank * sq if cp_size > 1 else 0
+
         query, key, value, q_compressed, kv_compressed = (
-            self.get_query_key_value_tensors(hidden_states)
+            self.get_query_key_value_tensors(
+                hidden_states, position_offset=position_offset
+            )
         )
 
         # Core attention (CompressedSparseAttention)
@@ -237,14 +251,16 @@ class DSv4HybridAttention(Attention):
             core_attn_out = core_attn_out.reshape(
                 [b, sq, self.num_attention_heads, self.v_head_dim]
             )
-            # Get RoPE frequencies for inverse
-            _rope_result = self.rotary_pos_emb(sq, packed_seq=False)
+            # Get RoPE frequencies for inverse; use global positions in CP mode
+            rope_len = sq + position_offset
+            _rope_result = self.rotary_pos_emb(rope_len, packed_seq=False)
             if isinstance(_rope_result, tuple):
                 freqs, mscale = _rope_result
             else:
                 freqs, mscale = _rope_result, 1.0
             # DSv4 reference uses pure norm-preserving RoPE; YaRN's mscale is not applied.
             mscale = 1.0
+            freqs = freqs[:, position_offset : position_offset + sq, :]
 
             content_part = core_attn_out[..., :nope_dim]
             rot_part = core_attn_out[..., nope_dim:]
@@ -376,12 +392,15 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
         )
 
     def get_query_key_value_tensors(
-        self, hidden_states: Tensor
+        self, hidden_states: Tensor, position_offset: int = 0
     ) -> tuple[Tensor, Tensor, Tensor, Tensor, Tensor]:
         """Derive query, key, value from hidden_states.
 
         Args:
             hidden_states: [b, sq, hidden_size]
+            position_offset: global position offset for CP (cp_rank * sq_local).
+                When non-zero, RoPE frequencies are sliced from the correct
+                global starting position.
 
         Returns:
             query: [b, sq, num_heads, v_head_dim]
@@ -411,14 +430,17 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
         nope_dim = self.v_head_dim - pos_dim
 
         if pos_dim > 0:
-            # Get RoPE frequencies
-            _rope_result = self.rotary_pos_emb(sq, packed_seq=False)
+            # Get RoPE frequencies for global positions
+            rope_len = sq + position_offset
+            _rope_result = self.rotary_pos_emb(rope_len, packed_seq=False)
             if isinstance(_rope_result, tuple):
                 freqs, mscale = _rope_result
             else:
                 freqs, mscale = _rope_result, 1.0
             # DSv4 reference uses pure norm-preserving RoPE; YaRN's mscale is not applied.
             mscale = 1.0
+            # Slice to local positions [position_offset : position_offset + sq]
+            freqs = freqs[:, position_offset : position_offset + sq, :]
 
             # Q RoPE: split nope/pe, apply RoPE to pe part
             q_nope = q[..., :nope_dim]

--- a/src/paddlefleet/transformer/dsv4_hybrid_attention.py
+++ b/src/paddlefleet/transformer/dsv4_hybrid_attention.py
@@ -217,6 +217,11 @@ class DSv4HybridAttention(Attention):
         cp_pg = getattr(self, "pg_collection", None)
         cp_pg = cp_pg.cp if cp_pg is not None else None
         cp_size = getattr(cp_pg, "nranks", 1) if cp_pg is not None else 1
+        if cp_size > 1:
+            assert self.config.cp_balance_mode == "contiguous_allgather", (
+                f"DSv4HybridAttention requires cp_balance_mode='contiguous_allgather', "
+                f"got '{self.config.cp_balance_mode}'"
+            )
         cp_rank = (
             getattr(cp_pg, "rank", 0)
             if cp_pg is not None and cp_size > 1

--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -394,7 +394,9 @@ class StandardMoERouter(nn.Layer):
                     ]
                 )
                 # [B, S, E]
-                all_probs = ContextParallelAllGatherOp.apply(all_probs, axis=1)
+                all_probs = ContextParallelAllGatherOp.apply(
+                    all_probs, axis=1, mode=self.config.cp_balance_mode
+                )
                 local_seq_len = local_seq_len * self.context_parallel_size
             else:
                 # [B, S, E]
@@ -424,7 +426,9 @@ class StandardMoERouter(nn.Layer):
                 and self.config.experimental_dataflow
             ):
                 # In EB data flow, we need to gather input_ids here to get right denom.
-                input_ids = ContextParallelGatherOp.apply(input_ids, axis=1)
+                input_ids = ContextParallelGatherOp.apply(
+                    input_ids, axis=1, mode=self.config.cp_balance_mode
+                )
             _ids = input_ids
             if _ids.ndim == 1:
                 _ids = _ids.unsqueeze(axis=0)
@@ -494,7 +498,7 @@ class StandardMoERouter(nn.Layer):
             ):
                 # In EB data flow, we need to gather input_ids here to get right denom.
                 origin_input_ids = ContextParallelGatherOp.apply(
-                    input_ids, axis=1
+                    input_ids, axis=1, mode=self.config.cp_balance_mode
                 )
             else:
                 origin_input_ids = input_ids
@@ -938,7 +942,9 @@ class TopKRouter(StandardMoERouter):
                 # In EB dataflow, shape of input_ids [b, s],
                 # but shape of input is [b, s/cp, h] ([s/cp, b, h] in sp),
                 # so we need to scatter input_ids here to avid the assertion below
-                input_ids = ContextParallelScatterOp.apply(input_ids, axis=1)
+                input_ids = ContextParallelScatterOp.apply(
+                    input_ids, axis=1, mode=self.config.cp_balance_mode
+                )
             if input_ids is not None:
                 if self.sequence_parallel:
                     input_ids_none_zero_mask = (

--- a/src/paddlefleet/transformer/multi_latent_attention.py
+++ b/src/paddlefleet/transformer/multi_latent_attention.py
@@ -67,6 +67,7 @@ def _ec_compatible_rope_apply(
     rope_base=1000000.0,
     position_offset=0,
     position_ids=None,
+    cp_balance_mode="dualchunk_allgather",
 ):
     """Apply RoPE using EC's complex multiplication method (no YaRN, no mscale).
 
@@ -117,7 +118,9 @@ def _ec_compatible_rope_apply(
     if get_context_parallel_world_size() > 1:
         # In EB dataflow and CP size > 1, freqs_cis is [b, s/cp, 1, d] in local
         # so, we need to scatter freqs_cis here
-        freqs_cis = ContextParallelScatterOp.apply(freqs_cis, axis=1)
+        freqs_cis = ContextParallelScatterOp.apply(
+            freqs_cis, axis=1, mode=cp_balance_mode
+        )
 
     # MD5 debug
     import hashlib as _hl
@@ -1035,7 +1038,7 @@ class MLASelfAttention(MultiLatentAttention):
                     # In EB dataflow and CP size > 1, rotary_pos_emb is [1, s, 1, d];
                     # we need to scatter it to [1, s/cp, 1, d] here.
                     rotary_pos_emb = ContextParallelScatterOp.apply(
-                        rotary_pos_emb, axis=1
+                        rotary_pos_emb, axis=1, mode=self.config.cp_balance_mode
                     )
                 elif (
                     packed_seq_params is None
@@ -1107,6 +1110,7 @@ class MLASelfAttention(MultiLatentAttention):
                         rope_base=self.rope_theta,  # Must match EC's config.rope_theta
                         position_offset=start_pos,
                         position_ids=position_ids,
+                        cp_balance_mode=self.config.cp_balance_mode,
                     )
                     _log(q_pos_emb, "mla_q_pe_after_rope", self.layer_number)
                     _log(k_pos_emb, "mla_k_pe_after_rope", self.layer_number)

--- a/src/paddlefleet/transformer/multi_token_prediction.py
+++ b/src/paddlefleet/transformer/multi_token_prediction.py
@@ -457,7 +457,9 @@ class MultiTokenPredictionLayer(FleetLayer):
                     and self.config.experimental_dataflow
                 ):
                     mtp_hidden_inputs_mask = ContextParallelScatterOp.apply(
-                        mtp_hidden_inputs_mask, axis=1
+                        mtp_hidden_inputs_mask,
+                        axis=1,
+                        mode=self.config.cp_balance_mode,
                     )
                 # when sp enable
                 if self.sequence_parallel:
@@ -518,7 +520,9 @@ class MultiTokenPredictionLayer(FleetLayer):
                     # In EB dataflow and CP size > 1, mtp_hidden_inputs_mask is [b, s, 1];
                     # we need to scatter it to [b, s/cp, 1] here.
                     mtp_hidden_inputs_mask = ContextParallelScatterOp.apply(
-                        mtp_hidden_inputs_mask, axis=1
+                        mtp_hidden_inputs_mask,
+                        axis=1,
+                        mode=self.config.cp_balance_mode,
                     )
 
                 # when sp enable
@@ -776,7 +780,7 @@ class MultiTokenPredictionLayer(FleetLayer):
                 and self.config.experimental_dataflow
             ):
                 decoder_input = ContextParallelScatterOp.apply(
-                    decoder_input, axis=1
+                    decoder_input, axis=1, mode=self.config.cp_balance_mode
                 )
 
             if self.config.sequence_parallel:

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -539,6 +539,12 @@ class TransformerConfig(ModelParallelConfig):
     List[str]: each layer has its separate communication type.
     """
 
+    cp_balance_mode: str = "dualchunk_allgather"
+    """Context parallel scatter/gather layout mode.
+    "dualchunk_allgather": balanced front+rear chunk splitting (default).
+    "contiguous_allgather": simple rank-order contiguous slicing.
+    """
+
     ####################
     # fp8
     ####################

--- a/src/paddlefleet/utils.py
+++ b/src/paddlefleet/utils.py
@@ -278,15 +278,19 @@ def is_paddle_min_version(version, check_equality=True):
 ########################
 
 
-def get_batch_on_this_cp_rank(inputs):
+def get_batch_on_this_cp_rank(inputs, cp_balance_mode="dualchunk_allgather"):
     if isinstance(inputs, paddle.Tensor):
-        return ContextParallelScatterOp.apply(inputs, axis=-1)
+        return ContextParallelScatterOp.apply(
+            inputs, axis=-1, mode=cp_balance_mode
+        )
     elif isinstance(inputs, dict):
         res = {}
         keys = ["input_ids", "position_ids", "labels"]
         for k, tensor in inputs.items():
             if k in keys:
-                res[k] = ContextParallelScatterOp.apply(tensor, axis=-1)
+                res[k] = ContextParallelScatterOp.apply(
+                    tensor, axis=-1, mode=cp_balance_mode
+                )
             else:
                 res[k] = tensor
     elif isinstance(inputs, list):

--- a/tests/multi_card_tests/transformer/test_csa_attention_cp.py
+++ b/tests/multi_card_tests/transformer/test_csa_attention_cp.py
@@ -492,6 +492,8 @@ class TestDSv4HybridAttentionCP(unittest.TestCase):
         config.o_lora_rank = 64
         config.sequence_parallel = False
         config.tensor_model_parallel_size = 1
+        config.cp_balance_mode = "contiguous_allgather"
+        config.csa_indexer_backend = "tilelang"
 
         sublayers = DSv4HybridSelfAttentionSublayersSpec(
             linear_q_down_proj=_TestLinear,
@@ -807,6 +809,7 @@ class TestTileLangCSALayerCP(unittest.TestCase):
             csa_tilelang_enable_indexer=True,
             csa_tilelang_enable_sparse_attn=False,
             csa_tilelang_backend="attention_paddle_compat",
+            csa_indexer_backend="tilelang",
             init_method=None,
             init_method_std=0.02,
             layernorm_epsilon=1e-5,

--- a/tests/multi_card_tests/transformer/test_csa_attention_cp.py
+++ b/tests/multi_card_tests/transformer/test_csa_attention_cp.py
@@ -1,0 +1,1040 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Multi-card unit tests for CSA (CompressedSparseAttention) Context Parallelism.
+
+Tests verify that CSA with CP enabled (local Q slice, all-gather KV) produces
+identical forward output and backward gradients compared to the non-CP reference
+(full sequence on a single rank).
+
+Covers:
+  - CompressedSparseAttention._forward_cp: fwd output matches non-CP forward
+  - Backward: input grads (dQ, dK, dX) match the local slice of non-CP grads
+  - Backward: parameter grads (compressor, indexer) match after all-reduce across CP
+  - DSv4HybridSelfAttention: full-layer fwd+bwd including RoPE offset
+
+Run with:
+    python -m paddle.distributed.launch --gpus 0,1 \
+        tests/multi_card_tests/transformer/test_csa_attention_cp.py
+"""
+
+import os
+import sys
+import types
+import unittest
+
+import paddle
+import paddle.distributed as dist
+from paddle import nn
+from paddle.distributed import fleet
+from paddle.distributed.fleet.meta_parallel import LayerSpec
+
+sys.path.insert(
+    0,
+    os.path.dirname(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    ),
+)
+
+from paddlefleet.models.common.embeddings.rotary_pos_embedding import (
+    RotaryEmbedding,
+)
+from paddlefleet.transformer.csa_attention import (
+    CompressedSparseAttention,
+    CompressedSparseAttentionSublayersSpec,
+    Compressor,
+    CompressorSublayersSpec,
+    CSAIndexer,
+    CSAIndexerSublayersSpec,
+)
+from paddlefleet.transformer.dsv4_hybrid_attention import (
+    DSv4HybridSelfAttention,
+    DSv4HybridSelfAttentionSublayersSpec,
+)
+
+# ---------------------------------------------------------------------------
+# Module-level initialization
+# ---------------------------------------------------------------------------
+CP_SIZE = None
+CP_RANK = None
+CP_GROUP = None
+
+DTYPE = "bfloat16"
+FWD_ATOL = 5e-1
+BWD_ATOL = 5e-1
+COS_SIM_THRESHOLD = 0.95
+
+
+def setUpModule():
+    global CP_SIZE, CP_RANK, CP_GROUP
+    CP_SIZE = dist.get_world_size()
+    strategy = fleet.DistributedStrategy()
+    strategy.hybrid_configs = {
+        "dp_degree": 1,
+        "mp_degree": 1,
+        "pp_degree": 1,
+        "sharding_degree": CP_SIZE,
+        "sep_degree": 1,
+        "cp_degree": CP_SIZE,
+        "ep_degree": CP_SIZE,
+        "moe_sharding_degree": 1,
+        "order": [
+            "sharding",
+            "moe_sharding",
+            "pp",
+            "sep",
+            "cp",
+            "dp",
+            "ep",
+            "mp",
+        ],
+    }
+    fleet.init(is_collective=True, strategy=strategy)
+    CP_GROUP = fleet.get_hybrid_communicate_group().get_context_parallel_group()
+    CP_RANK = CP_GROUP.rank
+    CP_SIZE = CP_GROUP.nranks
+
+
+# ---------------------------------------------------------------------------
+# Stub layers (lightweight, no TP distribution)
+# ---------------------------------------------------------------------------
+class _TestLinear(nn.Layer):
+    def __init__(self, input_size, output_size, dtype=None, **kwargs):
+        super().__init__()
+        if dtype is None:
+            dtype = DTYPE
+        self.weight = self.create_parameter(
+            shape=[output_size, input_size],
+            dtype=dtype,
+            default_initializer=nn.initializer.Normal(std=0.02),
+        )
+
+    def forward(self, x):
+        return paddle.matmul(x, self.weight.T), None
+
+
+class _TestRMSNorm(nn.Layer):
+    def __init__(self, hidden_size=None, eps=1e-5, **kwargs):
+        super().__init__()
+        self.eps = eps
+        self.weight = self.create_parameter(
+            shape=[hidden_size],
+            dtype="float32",
+            default_initializer=nn.initializer.Constant(1.0),
+        )
+
+    def forward(self, x):
+        normed = x * paddle.rsqrt(x.square().mean(-1, keepdim=True) + self.eps)
+        return normed * self.weight.cast(x.dtype)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _build_csa_config(
+    compress_ratio=4,
+    hidden_size=256,
+    head_dim=64,
+    q_lora_rank=64,
+    csa_window_size=64,
+    dsa_index_topk=16,
+    dsa_indexer_loss_coeff=0.0,
+):
+    return types.SimpleNamespace(
+        num_attention_heads=8,
+        v_head_dim=head_dim,
+        hidden_size=hidden_size,
+        q_lora_rank=q_lora_rank,
+        qk_pos_emb_head_dim=32,
+        csa_window_size=csa_window_size,
+        csa_compress_ratios=[compress_ratio],
+        csa_dense_mode=False,
+        dsa_index_n_heads=16,
+        dsa_index_head_dim=32,
+        dsa_index_topk=dsa_index_topk,
+        dsa_indexer_loss_coeff=dsa_indexer_loss_coeff,
+        dsa_indexer_use_sparse_loss=False,
+        csa_tilelang_enable_indexer=False,
+        csa_tilelang_enable_sparse_attn=False,
+        init_method=None,
+        init_method_std=0.02,
+        layernorm_epsilon=1e-5,
+        num_hidden_layers=1,
+    )
+
+
+def _build_csa(config, compress_ratio=4, head_dim=64):
+    rope = RotaryEmbedding(32, rotary_percent=1.0, rotary_base=160000)
+    comp_spec = CompressorSublayersSpec(
+        linear_wkv=_TestLinear,
+        linear_wgate=_TestLinear,
+        norm=_TestRMSNorm,
+    )
+    indexer_comp_spec = CompressorSublayersSpec(
+        linear_wkv=_TestLinear,
+        linear_wgate=_TestLinear,
+        norm=_TestRMSNorm,
+    )
+    indexer_sublayers = CSAIndexerSublayersSpec(
+        linear_wq_b=_TestLinear,
+        linear_weights_proj=_TestLinear,
+        compressor=LayerSpec(
+            layer=Compressor, sublayers_spec=indexer_comp_spec
+        ),
+    )
+    attn_spec = CompressedSparseAttentionSublayersSpec(
+        compressor=LayerSpec(layer=Compressor, sublayers_spec=comp_spec),
+        indexer=LayerSpec(layer=CSAIndexer, sublayers_spec=indexer_sublayers),
+    )
+    return CompressedSparseAttention(
+        config=config,
+        sublayers_spec=attn_spec,
+        layer_number=1,
+        attn_mask_type=None,
+        attention_type="self",
+        k_channels=head_dim,
+        v_channels=head_dim,
+        compress_ratio=compress_ratio,
+        rotary_pos_emb=rope,
+    )
+
+
+def _max_diff(actual, expected):
+    a = actual.cast("float32").flatten()
+    b = expected.cast("float32").flatten()
+    diff = (a - b).abs()
+    return diff.max().item()
+
+
+def _cosine_sim(actual, expected):
+    a = actual.cast("float32").flatten()
+    b = expected.cast("float32").flatten()
+    dot = (a * b).sum()
+    return (dot / (a.norm() * b.norm() + 1e-30)).item()
+
+
+def _run_csa_cp_vs_ref(
+    b,
+    sq_global,
+    head_dim,
+    hidden_size,
+    q_lora_rank,
+    csa_window_size,
+    dsa_index_topk,
+    dsa_indexer_loss_coeff,
+):
+    """Run one config: build ref (non-CP) and CP instances, compare fwd+bwd."""
+    compress_ratio = 4
+    sq_local = sq_global // CP_SIZE
+
+    config = _build_csa_config(
+        compress_ratio=compress_ratio,
+        hidden_size=hidden_size,
+        head_dim=head_dim,
+        q_lora_rank=q_lora_rank,
+        csa_window_size=csa_window_size,
+        dsa_index_topk=dsa_index_topk,
+        dsa_indexer_loss_coeff=dsa_indexer_loss_coeff,
+    )
+
+    # Reference: full sequence, CP disabled
+    paddle.seed(2026)
+    csa_ref = _build_csa(config, compress_ratio, head_dim)
+    csa_ref.cp_group = None
+    csa_ref.cp_size = 1
+    csa_ref.cp_rank = 0
+    csa_ref.cp_enabled = False
+
+    # CP: local slice, CP enabled
+    paddle.seed(2026)
+    csa_cp = _build_csa(config, compress_ratio, head_dim)
+    csa_cp.cp_group = CP_GROUP
+    csa_cp.cp_size = CP_SIZE
+    csa_cp.cp_rank = CP_RANK
+    csa_cp.cp_enabled = True
+
+    if dsa_indexer_loss_coeff > 0:
+        csa_ref.train()
+        csa_cp.train()
+
+    np_heads = config.num_attention_heads
+
+    # Generate inputs (same seed across ranks)
+    paddle.seed(1000)
+    query_full = paddle.randn([b, sq_global, np_heads, head_dim], dtype=DTYPE)
+    key_full = paddle.randn([b, sq_global, 1, head_dim], dtype=DTYPE)
+    x_full = paddle.randn([b, sq_global, hidden_size], dtype=DTYPE)
+    qr_full = paddle.randn([b, sq_global, q_lora_rank], dtype=DTYPE)
+
+    # Side A: full-sequence reference
+    q_a = query_full.clone()
+    q_a.stop_gradient = False
+    k_a = key_full.clone()
+    k_a.stop_gradient = False
+    x_a = x_full.clone()
+    x_a.stop_gradient = False
+    qr_a = qr_full.clone()
+    qr_a.stop_gradient = False
+    out_a = csa_ref.forward(q_a, k_a, k_a, None, x=x_a, qr=qr_a)
+    out_a.sum().backward()
+
+    # Side B: CP local slice
+    s, e = CP_RANK * sq_local, (CP_RANK + 1) * sq_local
+    q_b = query_full[:, s:e].clone()
+    q_b.stop_gradient = False
+    k_b = key_full[:, s:e].clone()
+    k_b.stop_gradient = False
+    x_b = x_full[:, s:e].clone()
+    x_b.stop_gradient = False
+    qr_b = qr_full[:, s:e].clone()
+    qr_b.stop_gradient = False
+    out_b = csa_cp.forward(q_b, k_b, k_b, None, x=x_b, qr=qr_b)
+    out_b.sum().backward()
+
+    # All-reduce param grads (simulates ZeRO sharding MEAN × cp_size = SUM)
+    for p in csa_cp.parameters():
+        if p.grad is not None:
+            g = p.grad.contiguous()
+            dist.all_reduce(g, group=CP_GROUP)
+            paddle.assign(g, p.grad)
+
+    # Assertions
+    results = {}
+    results["fwd_cos"] = _cosine_sim(out_b, out_a[:, s:e])
+    results["fwd_diff"] = _max_diff(out_b, out_a[:, s:e])
+    results["dq_cos"] = _cosine_sim(q_b.grad, q_a.grad[:, s:e])
+    results["dx_cos"] = _cosine_sim(x_b.grad, x_a.grad[:, s:e])
+
+    # Compressor param grad
+    results["comp_wkv_cos"] = _cosine_sim(
+        csa_cp.compressor.linear_wkv.weight.grad,
+        csa_ref.compressor.linear_wkv.weight.grad,
+    )
+
+    if dsa_indexer_loss_coeff > 0:
+        results["idx_wq_cos"] = _cosine_sim(
+            csa_cp.indexer.linear_wq_b.weight.grad,
+            csa_ref.indexer.linear_wq_b.weight.grad,
+        )
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Test cases
+# ---------------------------------------------------------------------------
+class TestCSAContextParallel(unittest.TestCase):
+    """CompressedSparseAttention CP vs non-CP equivalence."""
+
+    def _assert_results(self, results, msg=""):
+        self.assertGreater(
+            results["fwd_cos"],
+            COS_SIM_THRESHOLD,
+            f"{msg} forward cosine sim too low: {results['fwd_cos']:.6f}",
+        )
+        self.assertGreater(
+            results["dq_cos"],
+            COS_SIM_THRESHOLD,
+            f"{msg} dQ cosine sim too low: {results['dq_cos']:.6f}",
+        )
+        self.assertGreater(
+            results["dx_cos"],
+            COS_SIM_THRESHOLD,
+            f"{msg} dX cosine sim too low: {results['dx_cos']:.6f}",
+        )
+        self.assertGreater(
+            results["comp_wkv_cos"],
+            COS_SIM_THRESHOLD,
+            f"{msg} compressor.wkv grad cosine sim too low: {results['comp_wkv_cos']:.6f}",
+        )
+        if "idx_wq_cos" in results:
+            self.assertGreater(
+                results["idx_wq_cos"],
+                COS_SIM_THRESHOLD,
+                f"{msg} indexer.wq grad cosine sim too low: {results['idx_wq_cos']:.6f}",
+            )
+
+    def test_basic_fwd_bwd(self):
+        """Basic CSA CP: sq=256, window=64, topk=16, no indexer loss."""
+        results = _run_csa_cp_vs_ref(
+            b=2,
+            sq_global=256,
+            head_dim=64,
+            hidden_size=256,
+            q_lora_rank=64,
+            csa_window_size=64,
+            dsa_index_topk=16,
+            dsa_indexer_loss_coeff=0.0,
+        )
+        self._assert_results(results, "basic")
+
+    def test_large_window(self):
+        """CSA CP with larger window covering more of the sequence."""
+        results = _run_csa_cp_vs_ref(
+            b=2,
+            sq_global=256,
+            head_dim=64,
+            hidden_size=256,
+            q_lora_rank=64,
+            csa_window_size=128,
+            dsa_index_topk=16,
+            dsa_indexer_loss_coeff=0.0,
+        )
+        self._assert_results(results, "large_window")
+
+    def test_with_indexer_loss(self):
+        """CSA CP with indexer loss enabled (Paddle reference loss path)."""
+        results = _run_csa_cp_vs_ref(
+            b=2,
+            sq_global=256,
+            head_dim=64,
+            hidden_size=256,
+            q_lora_rank=64,
+            csa_window_size=64,
+            dsa_index_topk=16,
+            dsa_indexer_loss_coeff=1.0,
+        )
+        self._assert_results(results, "indexer_loss")
+
+    def test_longer_sequence(self):
+        """CSA CP with sq=1024 to exercise more CP boundary cases."""
+        results = _run_csa_cp_vs_ref(
+            b=2,
+            sq_global=1024,
+            head_dim=64,
+            hidden_size=256,
+            q_lora_rank=128,
+            csa_window_size=64,
+            dsa_index_topk=64,
+            dsa_indexer_loss_coeff=0.0,
+        )
+        self._assert_results(results, "long_seq")
+
+    def test_larger_topk(self):
+        """CSA CP with large topk relative to compressed sequence."""
+        results = _run_csa_cp_vs_ref(
+            b=2,
+            sq_global=256,
+            head_dim=64,
+            hidden_size=256,
+            q_lora_rank=64,
+            csa_window_size=64,
+            dsa_index_topk=64,
+            dsa_indexer_loss_coeff=0.0,
+        )
+        self._assert_results(results, "large_topk")
+
+
+class TestDSv4HybridAttentionCP(unittest.TestCase):
+    """DSv4HybridSelfAttention full-layer CP vs non-CP (includes RoPE)."""
+
+    def test_full_layer_fwd_bwd(self):
+        """Full DSv4HybridSelfAttention layer: Q/KV proj, RoPE, CSA, inverse RoPE."""
+        from paddlefleet.transformer.enums import AttnMaskType
+        from paddlefleet.transformer.transformer_config import TransformerConfig
+
+        head_dim = 64
+        hidden_size = 256
+        num_heads = 4
+        q_lora_rank = 64
+        pos_dim = 32
+        sq_global = 256
+        sq_local = sq_global // CP_SIZE
+        b = 2
+
+        config = TransformerConfig(
+            num_hidden_layers=1,
+            hidden_size=hidden_size,
+            num_attention_heads=num_heads,
+        )
+        config.num_key_value_heads = 1
+        config.head_dim = head_dim
+        config.q_lora_rank = q_lora_rank
+        config.kv_lora_rank = q_lora_rank
+        config.qk_nope_head_dim = head_dim - pos_dim
+        config.qk_rope_head_dim = pos_dim
+        config.qk_pos_emb_head_dim = pos_dim
+        config.v_head_dim = head_dim
+        config.multi_latent_attention = True
+        config.rope_type = "rope"
+        config.rotary_base = 10000.0
+        config.rotary_interleaved = False
+        config.rotary_percent = 1.0
+        config.apply_rope_fusion = False
+        config.csa_compress_ratios = [4]
+        config.csa_compress_rotary_base = 160000.0
+        config.csa_window_size = 64
+        config.csa_dense_mode = False
+        config.dsa_index_n_heads = 8
+        config.dsa_index_head_dim = 32
+        config.dsa_index_topk = 16
+        config.dsa_indexer_loss_coeff = 0.0
+        config.dsa_indexer_use_sparse_loss = False
+        config.csa_tilelang_enable_indexer = False
+        config.csa_tilelang_enable_sparse_attn = False
+        config.init_method = None
+        config.init_method_std = 0.02
+        config.output_layer_init_method = None
+        config.layernorm_epsilon = 1e-5
+        config.rms_norm_eps = 1e-5
+        config.o_groups = 4
+        config.o_lora_rank = 64
+        config.sequence_parallel = False
+        config.tensor_model_parallel_size = 1
+
+        sublayers = DSv4HybridSelfAttentionSublayersSpec(
+            linear_q_down_proj=_TestLinear,
+            linear_q_up_proj=_TestLinear,
+            linear_kv_proj=_TestLinear,
+            core_attention=LayerSpec(
+                layer=CompressedSparseAttention,
+                sublayers_spec=CompressedSparseAttentionSublayersSpec(
+                    compressor=LayerSpec(
+                        layer=Compressor,
+                        sublayers_spec=CompressorSublayersSpec(
+                            linear_wkv=_TestLinear,
+                            linear_wgate=_TestLinear,
+                            norm=_TestRMSNorm,
+                        ),
+                    ),
+                    indexer=LayerSpec(
+                        layer=CSAIndexer,
+                        sublayers_spec=CSAIndexerSublayersSpec(
+                            linear_wq_b=_TestLinear,
+                            linear_weights_proj=_TestLinear,
+                            compressor=LayerSpec(
+                                layer=Compressor,
+                                sublayers_spec=CompressorSublayersSpec(
+                                    linear_wkv=_TestLinear,
+                                    linear_wgate=_TestLinear,
+                                    norm=_TestRMSNorm,
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+            o_proj=_TestLinear,
+            q_layernorm=_TestRMSNorm,
+            kv_layernorm=_TestRMSNorm,
+        )
+
+        # Build ref (no CP) and CP instances with same weights
+        pg_ref = types.SimpleNamespace(tp=None, cp=None)
+        pg_cp = types.SimpleNamespace(tp=None, cp=CP_GROUP)
+
+        paddle.seed(2026)
+        layer_ref = DSv4HybridSelfAttention(
+            config=config,
+            sublayers_spec=sublayers,
+            layer_number=0,
+            attn_mask_type=AttnMaskType.causal,
+            pg_collection=pg_ref,
+        )
+
+        paddle.seed(2026)
+        layer_cp = DSv4HybridSelfAttention(
+            config=config,
+            sublayers_spec=sublayers,
+            layer_number=0,
+            attn_mask_type=AttnMaskType.causal,
+            pg_collection=pg_cp,
+        )
+
+        # Generate inputs
+        paddle.seed(1000)
+        hidden_full = paddle.randn([b, sq_global, hidden_size], dtype=DTYPE)
+
+        # Side A: full sequence
+        h_a = hidden_full.clone()
+        h_a.stop_gradient = False
+        out_a, _ = layer_ref.forward(h_a)
+        out_a.sum().backward()
+
+        # Side B: CP local slice
+        s, e = CP_RANK * sq_local, (CP_RANK + 1) * sq_local
+        h_b = hidden_full[:, s:e].clone()
+        h_b.stop_gradient = False
+        out_b, _ = layer_cp.forward(h_b)
+        out_b.sum().backward()
+
+        # All-reduce param grads
+        for p in layer_cp.parameters():
+            if p.grad is not None:
+                g = p.grad.contiguous()
+                dist.all_reduce(g, group=CP_GROUP)
+                paddle.assign(g, p.grad)
+
+        # Verify forward
+        fwd_cos = _cosine_sim(out_b, out_a[:, s:e])
+        self.assertGreater(
+            fwd_cos,
+            COS_SIM_THRESHOLD,
+            f"Full-layer forward cosine sim too low: {fwd_cos:.6f}",
+        )
+
+        # Verify input grad
+        dh_cos = _cosine_sim(h_b.grad, h_a.grad[:, s:e])
+        self.assertGreater(
+            dh_cos,
+            COS_SIM_THRESHOLD,
+            f"Full-layer dH cosine sim too low: {dh_cos:.6f}",
+        )
+
+
+# ---------------------------------------------------------------------------
+# TileLang CP: kernel-level isolation tests
+# ---------------------------------------------------------------------------
+class TestTileLangIndexerKernelCP(unittest.TestCase):
+    """TileLang indexer kernel with real CP group: fwd bit-exact, bwd sum-exact."""
+
+    def setUp(self):
+        paddle.enable_compat(scope={"tilelang"}, silent=True)
+
+    def _run_fwd(self, sq_global, topk_effective, h_i=16, d_i=32, ratio=4):
+        """Each rank runs kernel with seq_offset, verify == full-seq slice."""
+        from paddlefleet.tilelang_ops import csa_indexer_topk_fwd
+
+        b = 2
+        sq_local = sq_global // CP_SIZE
+        sk = sq_global // ratio
+
+        paddle.seed(8888)
+        q = paddle.randn([b, sq_global, h_i, d_i], dtype=DTYPE)
+        k = paddle.randn([b, sk, d_i], dtype=DTYPE)
+        w = paddle.randn([b, sq_global, h_i], dtype="float32")
+
+        # Full reference
+        idx_full, scores_full = csa_indexer_topk_fwd(
+            q,
+            k,
+            w,
+            ratio=ratio,
+            topk_effective=topk_effective,
+            seq_offset=0,
+        )
+
+        # This rank's slice
+        s = CP_RANK * sq_local
+        idx_local, scores_local = csa_indexer_topk_fwd(
+            q[:, s : s + sq_local, :, :],
+            k,
+            w[:, s : s + sq_local, :],
+            ratio=ratio,
+            topk_effective=topk_effective,
+            seq_offset=s,
+        )
+
+        self.assertTrue(
+            paddle.equal_all(
+                idx_local, idx_full[:, s : s + sq_local, :]
+            ).item(),
+            f"Fwd indices mismatch: sq={sq_global} topk={topk_effective} "
+            f"cp_rank={CP_RANK}",
+        )
+        score_diff = (
+            (scores_local - scores_full[:, s : s + sq_local, :])
+            .abs()
+            .max()
+            .item()
+        )
+        self.assertLess(
+            score_diff,
+            1e-6,
+            f"Fwd scores diff={score_diff:.2e}: sq={sq_global} "
+            f"topk={topk_effective} cp_rank={CP_RANK}",
+        )
+
+    def _run_bwd(self, sq_global, topk_effective, h_i=16, d_i=32, ratio=4):
+        """Each rank runs bwd; all_reduce dK; verify matches full-seq."""
+        from paddlefleet.tilelang_ops import (
+            csa_indexer_bwd,
+            csa_indexer_topk_fwd,
+        )
+
+        b = 2
+        sq_local = sq_global // CP_SIZE
+        sk = sq_global // ratio
+
+        paddle.seed(9999)
+        q = paddle.randn([b, sq_global, h_i, d_i], dtype=DTYPE)
+        k = paddle.randn([b, sk, d_i], dtype=DTYPE)
+        w = paddle.randn([b, sq_global, h_i], dtype="float32")
+
+        # Full reference
+        idx_full, _ = csa_indexer_topk_fwd(
+            q,
+            k,
+            w,
+            ratio=ratio,
+            topk_effective=topk_effective,
+            seq_offset=0,
+        )
+        paddle.seed(7777)
+        grad_full = (
+            paddle.randn([b, sq_global, topk_effective], dtype="float32") * 0.01
+        )
+        dq_full, dw_full, dk_full = csa_indexer_bwd(
+            q,
+            w,
+            k,
+            idx_full,
+            grad_full,
+        )
+
+        # This rank
+        s = CP_RANK * sq_local
+        idx_local, _ = csa_indexer_topk_fwd(
+            q[:, s : s + sq_local, :, :],
+            k,
+            w[:, s : s + sq_local, :],
+            ratio=ratio,
+            topk_effective=topk_effective,
+            seq_offset=s,
+        )
+        dq_local, dw_local, dk_local = csa_indexer_bwd(
+            q[:, s : s + sq_local, :, :],
+            w[:, s : s + sq_local, :],
+            k,
+            idx_local,
+            grad_full[:, s : s + sq_local, :],
+        )
+
+        # dQ/dW slice-exact
+        dq_diff = (
+            (
+                dq_local.cast("float32")
+                - dq_full[:, s : s + sq_local, :, :].cast("float32")
+            )
+            .abs()
+            .max()
+            .item()
+        )
+        self.assertLess(
+            dq_diff, 1e-4, f"dQ diff={dq_diff:.2e} cp_rank={CP_RANK}"
+        )
+
+        dw_diff = (
+            (
+                dw_local.cast("float32")
+                - dw_full[:, s : s + sq_local, :].cast("float32")
+            )
+            .abs()
+            .max()
+            .item()
+        )
+        self.assertLess(
+            dw_diff, 1e-4, f"dW diff={dw_diff:.2e} cp_rank={CP_RANK}"
+        )
+
+        # All-reduce dK and compare to full
+        dk_sum = dk_local.cast("float32").contiguous()
+        dist.all_reduce(dk_sum, group=CP_GROUP)
+        dk_diff = (dk_sum - dk_full.cast("float32")).abs().max().item()
+        self.assertLess(dk_diff, 1e-3, f"dK diff={dk_diff:.2e}")
+
+    def test_fwd_sq64_topk8(self):
+        self._run_fwd(sq_global=64, topk_effective=8)
+
+    def test_fwd_sq128_topk16(self):
+        self._run_fwd(sq_global=128, topk_effective=16)
+
+    def test_fwd_sq256_topk16(self):
+        self._run_fwd(sq_global=256, topk_effective=16)
+
+    def test_fwd_sq256_topk64_phase2(self):
+        self._run_fwd(sq_global=256, topk_effective=64)
+
+    def test_bwd_sq64_topk8(self):
+        self._run_bwd(sq_global=64, topk_effective=8)
+
+    def test_bwd_sq128_topk16(self):
+        self._run_bwd(sq_global=128, topk_effective=16)
+
+    def test_bwd_sq256_topk16(self):
+        self._run_bwd(sq_global=256, topk_effective=16)
+
+
+# ---------------------------------------------------------------------------
+# TileLang CP: Full-layer precision (output + all grads + all param grads)
+# ---------------------------------------------------------------------------
+class TestTileLangCSALayerCP(unittest.TestCase):
+    """Full CSA layer: CP+TileLang vs non-CP+TileLang, compare everything.
+
+    Tests the complete _forward_cp pipeline with TileLang enabled:
+    - Branch B1a: TileLang loss path (training)
+    - Branch B1d: TileLang fwd-only path (eval)
+    - Branch D1: TileLangCSAIndexerLossAutoScaler backward
+    - Compressor CP path: local project -> all-gather -> global pool -> slice
+    """
+
+    COS_THRESHOLD = 0.999
+
+    def setUp(self):
+        paddle.enable_compat(scope={"tilelang"}, silent=True)
+
+    def _build_tilelang_config(
+        self,
+        dsa_index_topk=16,
+        loss_coeff=0.0,
+        use_sparse_loss=False,
+    ):
+        return types.SimpleNamespace(
+            num_attention_heads=8,
+            v_head_dim=64,
+            hidden_size=256,
+            q_lora_rank=64,
+            qk_pos_emb_head_dim=32,
+            csa_window_size=64,
+            csa_compress_ratios=[4],
+            csa_dense_mode=False,
+            dsa_index_n_heads=16,
+            dsa_index_head_dim=32,
+            dsa_index_topk=dsa_index_topk,
+            dsa_indexer_loss_coeff=loss_coeff,
+            dsa_indexer_use_sparse_loss=use_sparse_loss,
+            csa_tilelang_enable_indexer=True,
+            csa_tilelang_enable_sparse_attn=False,
+            csa_tilelang_backend="attention_paddle_compat",
+            init_method=None,
+            init_method_std=0.02,
+            layernorm_epsilon=1e-5,
+            num_hidden_layers=1,
+        )
+
+    def _run(self, sq_global, dsa_index_topk, loss_coeff, use_sparse_loss):
+        sq_local = sq_global // CP_SIZE
+        b, head_dim, hidden_size, q_lora_rank = 2, 64, 256, 64
+
+        config = self._build_tilelang_config(
+            dsa_index_topk=dsa_index_topk,
+            loss_coeff=loss_coeff,
+            use_sparse_loss=use_sparse_loss,
+        )
+
+        # Reference: full sequence, no CP, TileLang enabled
+        paddle.seed(2026)
+        csa_ref = _build_csa(config, compress_ratio=4, head_dim=head_dim)
+        csa_ref.cp_group = None
+        csa_ref.cp_size = 1
+        csa_ref.cp_rank = 0
+        csa_ref.cp_enabled = False
+
+        # Under test: local slice, CP enabled, TileLang enabled
+        paddle.seed(2026)
+        csa_cp = _build_csa(config, compress_ratio=4, head_dim=head_dim)
+        csa_cp.cp_group = CP_GROUP
+        csa_cp.cp_size = CP_SIZE
+        csa_cp.cp_rank = CP_RANK
+        csa_cp.cp_enabled = True
+
+        if loss_coeff > 0:
+            csa_ref.train()
+            csa_cp.train()
+
+        # Inputs
+        paddle.seed(1000)
+        query_full = paddle.randn([b, sq_global, 8, head_dim], dtype=DTYPE)
+        key_full = paddle.randn([b, sq_global, 1, head_dim], dtype=DTYPE)
+        x_full = paddle.randn([b, sq_global, hidden_size], dtype=DTYPE)
+        qr_full = paddle.randn([b, sq_global, q_lora_rank], dtype=DTYPE)
+
+        # Side A: full-sequence reference
+        q_a = query_full.clone()
+        q_a.stop_gradient = False
+        k_a = key_full.clone()
+        k_a.stop_gradient = False
+        x_a = x_full.clone()
+        x_a.stop_gradient = False
+        qr_a = qr_full.clone()
+        qr_a.stop_gradient = False
+        out_a = csa_ref.forward(q_a, k_a, k_a, None, x=x_a, qr=qr_a)
+        out_a.sum().backward()
+
+        # Side B: CP local slice
+        s, e = CP_RANK * sq_local, (CP_RANK + 1) * sq_local
+        q_b = query_full[:, s:e].clone()
+        q_b.stop_gradient = False
+        k_b = key_full[:, s:e].clone()
+        k_b.stop_gradient = False
+        x_b = x_full[:, s:e].clone()
+        x_b.stop_gradient = False
+        qr_b = qr_full[:, s:e].clone()
+        qr_b.stop_gradient = False
+        out_b = csa_cp.forward(q_b, k_b, k_b, None, x=x_b, qr=qr_b)
+        out_b.sum().backward()
+
+        # All-reduce param grads
+        for p in csa_cp.parameters():
+            if p.grad is not None:
+                g = p.grad.contiguous()
+                dist.all_reduce(g, group=CP_GROUP)
+                paddle.assign(g, p.grad)
+
+        # Compensate indexer params (auto-scaler normalizes by 1/sq_local)
+        if loss_coeff > 0 and csa_cp.indexer is not None:
+            for p in csa_cp.indexer.parameters():
+                if p.grad is not None:
+                    paddle.assign(p.grad / CP_SIZE, p.grad)
+
+        # --- Assertions ---
+        # Forward output
+        fwd_cos = _cosine_sim(out_b, out_a[:, s:e])
+        self.assertGreater(
+            fwd_cos,
+            self.COS_THRESHOLD,
+            f"[R{CP_RANK}] output cos={fwd_cos:.6f}",
+        )
+
+        # Input grads
+        for name, g_cp, g_ref in [
+            ("dQ", q_b.grad, q_a.grad[:, s:e]),
+            ("dK", k_b.grad, k_a.grad[:, s:e]),
+            ("dX", x_b.grad, x_a.grad[:, s:e]),
+        ]:
+            if g_cp is None or g_ref is None:
+                continue
+            cos = _cosine_sim(g_cp, g_ref)
+            self.assertGreater(
+                cos,
+                self.COS_THRESHOLD,
+                f"[R{CP_RANK}] {name} cos={cos:.6f}",
+            )
+
+        # All parameter grads
+        ref_params = dict(csa_ref.named_parameters())
+        cp_params = dict(csa_cp.named_parameters())
+        for pname in sorted(ref_params.keys()):
+            g_ref = ref_params[pname].grad
+            g_cp = cp_params[pname].grad
+            if g_ref is None or g_cp is None:
+                continue
+            # Skip all-zero grads (e.g. ape in eval mode): cosine is undefined
+            if g_ref.abs().max().item() == 0 and g_cp.abs().max().item() == 0:
+                continue
+            cos = _cosine_sim(g_cp, g_ref)
+            self.assertGreater(
+                cos,
+                self.COS_THRESHOLD,
+                f"[R{CP_RANK}] d({pname}) cos={cos:.6f}",
+            )
+
+    # --- Fwd-only (eval, no loss; covers TileLang B1d path) ---
+    def test_fwd_only_sq128(self):
+        self._run(
+            sq_global=128,
+            dsa_index_topk=16,
+            loss_coeff=0.0,
+            use_sparse_loss=False,
+        )
+
+    def test_fwd_only_sq256(self):
+        self._run(
+            sq_global=256,
+            dsa_index_topk=16,
+            loss_coeff=0.0,
+            use_sparse_loss=False,
+        )
+
+    def test_fwd_only_sq512(self):
+        self._run(
+            sq_global=512,
+            dsa_index_topk=32,
+            loss_coeff=0.0,
+            use_sparse_loss=True,
+        )
+
+    # --- Phase 2 loss (topk_eff = n_compressed; covers B1a + D1 backward) ---
+    def test_phase2_sq128(self):
+        self._run(
+            sq_global=128,
+            dsa_index_topk=16,
+            loss_coeff=1.0,
+            use_sparse_loss=False,
+        )
+
+    def test_phase2_sq256(self):
+        self._run(
+            sq_global=256,
+            dsa_index_topk=16,
+            loss_coeff=1.0,
+            use_sparse_loss=False,
+        )
+
+    def test_phase2_sq256_large_topk(self):
+        self._run(
+            sq_global=256,
+            dsa_index_topk=64,
+            loss_coeff=1.0,
+            use_sparse_loss=False,
+        )
+
+    # --- Phase 3 loss (topk_eff = min(topk, n_comp); sparse selection) ---
+    def test_phase3_sq128(self):
+        self._run(
+            sq_global=128,
+            dsa_index_topk=8,
+            loss_coeff=1.0,
+            use_sparse_loss=True,
+        )
+
+    def test_phase3_sq256(self):
+        self._run(
+            sq_global=256,
+            dsa_index_topk=16,
+            loss_coeff=1.0,
+            use_sparse_loss=True,
+        )
+
+    def test_phase3_sq512(self):
+        self._run(
+            sq_global=512,
+            dsa_index_topk=32,
+            loss_coeff=1.0,
+            use_sparse_loss=True,
+        )
+
+    # --- Edge: topk >= n_compressed in Phase 3 (collapses to Phase 2) ---
+    def test_phase3_topk_ge_ncomp(self):
+        self._run(
+            sq_global=128,
+            dsa_index_topk=128,
+            loss_coeff=1.0,
+            use_sparse_loss=True,
+        )
+
+    # --- Small loss coeff (gradient scaling) ---
+    def test_small_loss_coeff(self):
+        self._run(
+            sq_global=256,
+            dsa_index_topk=16,
+            loss_coeff=0.1,
+            use_sparse_loss=True,
+        )
+
+    # --- Large sequence ---
+    def test_long_seq_sq1024(self):
+        self._run(
+            sq_global=1024,
+            dsa_index_topk=32,
+            loss_coeff=1.0,
+            use_sparse_loss=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/ai_edited_test/distributed/test_cp_balance_mode_dispatch.py
+++ b/tests/single_card_tests/ai_edited_test/distributed/test_cp_balance_mode_dispatch.py
@@ -1,0 +1,787 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for cp_balance_mode dispatch in context_parallel_utils.py and utils.py.
+
+Covers:
+  - scatter_contiguous / all_gather_contiguous / reduce_scatter_contiguous
+    (all branches: nranks==1, axis==0, axis!=0)
+  - ContextParallelScatterOp / GatherOp / AllGatherOp mode dispatch
+    (both "dualchunk_allgather" and "contiguous_allgather" paths)
+  - get_batch_on_this_cp_rank with cp_balance_mode parameter
+  - TransformerConfig.cp_balance_mode field default
+
+Single-card tests using mocked distributed groups.
+"""
+
+import os
+import sys
+
+# Insert local src/ before site-packages so we test the dev version
+_project_root = os.path.dirname(
+    os.path.dirname(
+        os.path.dirname(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        )
+    )
+)
+sys.path.insert(0, os.path.join(_project_root, "src"))
+
+import unittest
+from unittest import mock
+
+import paddle
+import paddle.distributed as dist
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_group(nranks=4, rank=1):
+    """Create a mock process group."""
+    group = mock.MagicMock()
+    group.nranks = nranks
+    group.rank = rank
+    return group
+
+
+def _make_mock_hcg(nranks=4, rank=1):
+    """Create a mock hybrid communicate group."""
+    hcg = mock.MagicMock()
+    group = _make_mock_group(nranks, rank)
+    hcg.get_context_parallel_group.return_value = group
+    hcg.get_context_parallel_world_size.return_value = nranks
+    return hcg, group
+
+
+# ===========================================================================
+# Test scatter_contiguous
+# ===========================================================================
+
+
+class TestScatterContiguous(unittest.TestCase):
+    """Tests for scatter_contiguous bare function."""
+
+    def test_nranks_1_returns_clone(self):
+        """nranks==1 returns a clone (no-op)."""
+        from paddlefleet.context_parallel_utils import scatter_contiguous
+
+        group = _make_mock_group(nranks=1, rank=0)
+        x = paddle.arange(12).reshape([3, 4]).cast("float32")
+        out = scatter_contiguous(x, group=group, axis=0)
+        self.assertTrue(paddle.equal_all(out, x))
+        # Must be a copy, not same storage
+        out[0, 0] = -1.0
+        self.assertNotEqual(x[0, 0].item(), -1.0)
+
+    def test_axis_0_rank_slicing(self):
+        """axis=0: rank r gets rows [r*chunk, (r+1)*chunk]."""
+        from paddlefleet.context_parallel_utils import scatter_contiguous
+
+        nranks = 4
+        x = paddle.arange(16).reshape([8, 2]).cast("float32")
+        for rank in range(nranks):
+            group = _make_mock_group(nranks=nranks, rank=rank)
+            out = scatter_contiguous(x, group=group, axis=0)
+            expected = x[rank * 2 : (rank + 1) * 2, :]
+            self.assertTrue(paddle.equal_all(out, expected))
+
+    def test_axis_1_rank_slicing(self):
+        """axis=1: rank r gets cols [r*chunk, (r+1)*chunk]."""
+        from paddlefleet.context_parallel_utils import scatter_contiguous
+
+        nranks = 2
+        x = paddle.arange(12).reshape([3, 4]).cast("float32")
+        for rank in range(nranks):
+            group = _make_mock_group(nranks=nranks, rank=rank)
+            out = scatter_contiguous(x, group=group, axis=1)
+            expected = x[:, rank * 2 : (rank + 1) * 2]
+            self.assertTrue(paddle.equal_all(out, expected))
+
+    def test_negative_axis(self):
+        """axis=-1 works correctly."""
+        from paddlefleet.context_parallel_utils import scatter_contiguous
+
+        nranks = 2
+        x = paddle.arange(24).reshape([2, 3, 4]).cast("float32")
+        group = _make_mock_group(nranks=nranks, rank=0)
+        out = scatter_contiguous(x, group=group, axis=-1)
+        expected = x[:, :, :2]
+        self.assertTrue(paddle.equal_all(out, expected))
+
+    def test_group_none_uses_fleet(self):
+        """group=None fetches group from fleet."""
+        from paddlefleet.context_parallel_utils import scatter_contiguous
+
+        hcg, group = _make_mock_hcg(nranks=2, rank=0)
+        x = paddle.arange(8).reshape([4, 2]).cast("float32")
+        with mock.patch(
+            "paddle.distributed.fleet.get_hybrid_communicate_group",
+            return_value=hcg,
+        ):
+            out = scatter_contiguous(x, group=None, axis=0)
+        expected = x[:2, :]
+        self.assertTrue(paddle.equal_all(out, expected))
+
+
+# ===========================================================================
+# Test all_gather_contiguous
+# ===========================================================================
+
+
+class TestAllGatherContiguous(unittest.TestCase):
+    """Tests for all_gather_contiguous bare function."""
+
+    def test_nranks_1_returns_clone(self):
+        """nranks==1 returns a clone."""
+        from paddlefleet.context_parallel_utils import all_gather_contiguous
+
+        group = _make_mock_group(nranks=1, rank=0)
+        x = paddle.randn([2, 4])
+        out = all_gather_contiguous(x, group=group, axis=0)
+        self.assertTrue(paddle.equal_all(out, x))
+
+    def test_axis_0_calls_all_gather_flat(self):
+        """axis=0: uses flat buffer all_gather."""
+        from paddlefleet.context_parallel_utils import all_gather_contiguous
+
+        nranks = 2
+        group = _make_mock_group(nranks=nranks, rank=0)
+        x = paddle.ones([3, 4])
+
+        def fake_all_gather(output, input_tensor, group, use_calc_stream):
+            output[:] = paddle.concat([input_tensor, input_tensor * 2], axis=0)
+
+        with mock.patch.object(
+            dist.stream, "all_gather", side_effect=fake_all_gather
+        ):
+            out = all_gather_contiguous(x, group=group, axis=0)
+        self.assertEqual(list(out.shape), [6, 4])
+
+    def test_axis_1_calls_list_all_gather(self):
+        """axis=1: uses list-based all_gather + concat."""
+        from paddlefleet.context_parallel_utils import all_gather_contiguous
+
+        nranks = 2
+        group = _make_mock_group(nranks=nranks, rank=0)
+        x = paddle.ones([2, 3])
+
+        def fake_all_gather(tensor_list, input_tensor, group, use_calc_stream):
+            for i, t in enumerate(tensor_list):
+                tensor_list[i][:] = input_tensor * (i + 1)
+
+        with mock.patch.object(
+            dist.stream, "all_gather", side_effect=fake_all_gather
+        ):
+            out = all_gather_contiguous(x, group=group, axis=1)
+        self.assertEqual(list(out.shape), [2, 6])
+
+    def test_group_none_uses_fleet(self):
+        """group=None fetches from fleet."""
+        from paddlefleet.context_parallel_utils import all_gather_contiguous
+
+        hcg, group = _make_mock_hcg(nranks=1, rank=0)
+        x = paddle.randn([2, 4])
+        with mock.patch(
+            "paddle.distributed.fleet.get_hybrid_communicate_group",
+            return_value=hcg,
+        ):
+            out = all_gather_contiguous(x, group=None, axis=0)
+        self.assertTrue(paddle.equal_all(out, x))
+
+
+# ===========================================================================
+# Test reduce_scatter_contiguous
+# ===========================================================================
+
+
+class TestReduceScatterContiguous(unittest.TestCase):
+    """Tests for reduce_scatter_contiguous bare function."""
+
+    def test_nranks_1_returns_clone(self):
+        """nranks==1 returns a clone."""
+        from paddlefleet.context_parallel_utils import reduce_scatter_contiguous
+
+        group = _make_mock_group(nranks=1, rank=0)
+        x = paddle.randn([4, 6])
+        out = reduce_scatter_contiguous(x, axis=0, group=group)
+        self.assertTrue(paddle.equal_all(out, x))
+
+    def test_axis_0_calls_reduce_scatter(self):
+        """axis=0: uses dist.stream.reduce_scatter."""
+        from paddlefleet.context_parallel_utils import reduce_scatter_contiguous
+
+        nranks = 2
+        group = _make_mock_group(nranks=nranks, rank=0)
+        x = paddle.ones([4, 6])
+
+        def fake_reduce_scatter(
+            output, input_tensor, op, group, use_calc_stream
+        ):
+            output[:] = input_tensor[: output.shape[0]]
+
+        with mock.patch.object(
+            dist.stream, "reduce_scatter", side_effect=fake_reduce_scatter
+        ):
+            out = reduce_scatter_contiguous(x, axis=0, group=group)
+        self.assertEqual(list(out.shape), [2, 6])
+
+    def test_axis_1_calls_alltoall(self):
+        """axis=1: uses split + alltoall + fp32 sum."""
+        from paddlefleet.context_parallel_utils import reduce_scatter_contiguous
+
+        nranks = 2
+        group = _make_mock_group(nranks=nranks, rank=0)
+        x = paddle.ones([3, 4])
+
+        def fake_alltoall(output_list, input_list, group, use_calc_stream):
+            for i, buf in enumerate(output_list):
+                buf[:] = input_list[i] * (i + 1)
+
+        with mock.patch.object(
+            dist.stream, "alltoall", side_effect=fake_alltoall
+        ):
+            out = reduce_scatter_contiguous(x, axis=1, group=group)
+        # output shape: each chunk is [3, 2], sum of 2 chunks
+        self.assertEqual(list(out.shape), [3, 2])
+        # dtype should match input
+        self.assertEqual(out.dtype, x.dtype)
+
+    def test_group_none_uses_fleet(self):
+        """group=None fetches from fleet."""
+        from paddlefleet.context_parallel_utils import reduce_scatter_contiguous
+
+        hcg, group = _make_mock_hcg(nranks=1, rank=0)
+        x = paddle.randn([4, 6])
+        with mock.patch(
+            "paddle.distributed.fleet.get_hybrid_communicate_group",
+            return_value=hcg,
+        ):
+            out = reduce_scatter_contiguous(x, axis=0, group=None)
+        self.assertTrue(paddle.equal_all(out, x))
+
+
+# ===========================================================================
+# Test PyLayer dispatch (ContextParallelScatterOp / GatherOp / AllGatherOp)
+# ===========================================================================
+
+
+class TestContextParallelScatterOpDispatch(unittest.TestCase):
+    """Tests for ContextParallelScatterOp mode dispatch."""
+
+    def _call_forward(self, mode, nranks=4, rank=1):
+        from paddlefleet.context_parallel_utils import ContextParallelScatterOp
+
+        hcg, group = _make_mock_hcg(nranks=nranks, rank=rank)
+        x = paddle.arange(16).reshape([4, 4]).cast("float32")
+
+        with mock.patch(
+            "paddle.distributed.fleet.get_hybrid_communicate_group",
+            return_value=hcg,
+        ):
+            ctx = mock.MagicMock()
+            out = ContextParallelScatterOp.forward(ctx, x, axis=0, mode=mode)
+        return out, ctx, x
+
+    def test_contiguous_mode_calls_scatter_contiguous(self):
+        """mode='contiguous_allgather' dispatches to scatter_contiguous."""
+        out, ctx, x = self._call_forward("contiguous_allgather")
+        # rank=1, nranks=4, chunk=1 row -> row [1:2]
+        expected = x[1:2, :]
+        self.assertTrue(paddle.equal_all(out, expected))
+        self.assertEqual(ctx.mode, "contiguous_allgather")
+
+    def test_dualchunk_mode_calls_scatter_balance(self):
+        """mode='dualchunk_allgather' dispatches to scatter_balance."""
+        from paddlefleet.context_parallel_utils import ContextParallelScatterOp
+
+        hcg, group = _make_mock_hcg(nranks=2, rank=0)
+        x = paddle.arange(8).reshape([4, 2]).cast("float32")
+
+        with (
+            mock.patch(
+                "paddle.distributed.fleet.get_hybrid_communicate_group",
+                return_value=hcg,
+            ),
+            mock.patch(
+                "paddlefleet.context_parallel_utils.scatter_balance",
+                return_value=x[:2],
+            ) as mock_scatter,
+        ):
+            ctx = mock.MagicMock()
+            out = ContextParallelScatterOp.forward(
+                ctx, x, axis=0, mode="dualchunk_allgather"
+            )
+            mock_scatter.assert_called_once()
+        self.assertEqual(ctx.mode, "dualchunk_allgather")
+
+    def test_backward_contiguous_calls_all_gather(self):
+        """backward with contiguous mode calls all_gather_contiguous."""
+        from paddlefleet.context_parallel_utils import ContextParallelScatterOp
+
+        ctx = mock.MagicMock()
+        ctx.mode = "contiguous_allgather"
+        ctx.axis = 0
+        ctx.group = _make_mock_group(nranks=1, rank=0)
+        grad = paddle.randn([2, 4])
+
+        out = ContextParallelScatterOp.backward(ctx, grad)
+        # nranks=1, clone
+        self.assertTrue(paddle.equal_all(out, grad))
+
+    def test_backward_dualchunk_calls_all_gather_balance(self):
+        """backward with dualchunk mode calls all_gather_balance."""
+        from paddlefleet.context_parallel_utils import ContextParallelScatterOp
+
+        ctx = mock.MagicMock()
+        ctx.mode = "dualchunk_allgather"
+        ctx.axis = 0
+        ctx.group = _make_mock_group(nranks=2, rank=0)
+        grad = paddle.randn([2, 4])
+
+        with mock.patch(
+            "paddlefleet.context_parallel_utils.all_gather_balance",
+            return_value=paddle.randn([4, 4]),
+        ) as mock_fn:
+            out = ContextParallelScatterOp.backward(ctx, grad)
+            mock_fn.assert_called_once()
+
+
+class TestContextParallelGatherOpDispatch(unittest.TestCase):
+    """Tests for ContextParallelGatherOp mode dispatch."""
+
+    def test_contiguous_mode_forward(self):
+        """forward with contiguous mode calls all_gather_contiguous."""
+        from paddlefleet.context_parallel_utils import ContextParallelGatherOp
+
+        hcg, group = _make_mock_hcg(nranks=2, rank=0)
+        x = paddle.randn([2, 4])
+        fake_gathered = paddle.randn([4, 4])
+
+        with (
+            mock.patch(
+                "paddle.distributed.fleet.get_hybrid_communicate_group",
+                return_value=hcg,
+            ),
+            mock.patch(
+                "paddlefleet.context_parallel_utils.all_gather_contiguous",
+                return_value=fake_gathered,
+            ) as mock_fn,
+        ):
+            ctx = mock.MagicMock()
+            out = ContextParallelGatherOp.forward(
+                ctx, x, axis=0, mode="contiguous_allgather"
+            )
+            mock_fn.assert_called_once()
+        self.assertTrue(paddle.equal_all(out, fake_gathered))
+        self.assertEqual(ctx.mode, "contiguous_allgather")
+
+    def test_dualchunk_mode_forward(self):
+        """forward with dualchunk mode calls all_gather_balance."""
+        from paddlefleet.context_parallel_utils import ContextParallelGatherOp
+
+        hcg, group = _make_mock_hcg(nranks=2, rank=0)
+        x = paddle.randn([2, 4])
+
+        with (
+            mock.patch(
+                "paddle.distributed.fleet.get_hybrid_communicate_group",
+                return_value=hcg,
+            ),
+            mock.patch(
+                "paddlefleet.context_parallel_utils.all_gather_balance",
+                return_value=paddle.randn([4, 4]),
+            ) as mock_fn,
+        ):
+            ctx = mock.MagicMock()
+            out = ContextParallelGatherOp.forward(
+                ctx, x, axis=0, mode="dualchunk_allgather"
+            )
+            mock_fn.assert_called_once()
+
+    def test_backward_contiguous(self):
+        """backward with contiguous mode calls scatter_contiguous."""
+        from paddlefleet.context_parallel_utils import ContextParallelGatherOp
+
+        ctx = mock.MagicMock()
+        ctx.mode = "contiguous_allgather"
+        ctx.axis = 0
+        ctx.group = _make_mock_group(nranks=2, rank=0)
+        grad = paddle.arange(8).reshape([4, 2]).cast("float32")
+
+        out = ContextParallelGatherOp.backward(ctx, grad)
+        expected = grad[:2, :]
+        self.assertTrue(paddle.equal_all(out, expected))
+
+    def test_backward_dualchunk(self):
+        """backward with dualchunk mode calls scatter_balance."""
+        from paddlefleet.context_parallel_utils import ContextParallelGatherOp
+
+        ctx = mock.MagicMock()
+        ctx.mode = "dualchunk_allgather"
+        ctx.axis = 0
+        ctx.group = _make_mock_group(nranks=2, rank=0)
+        grad = paddle.randn([4, 4])
+
+        with mock.patch(
+            "paddlefleet.context_parallel_utils.scatter_balance",
+            return_value=paddle.randn([2, 4]),
+        ) as mock_fn:
+            out = ContextParallelGatherOp.backward(ctx, grad)
+            mock_fn.assert_called_once()
+
+
+class TestContextParallelAllGatherOpDispatch(unittest.TestCase):
+    """Tests for ContextParallelAllGatherOp mode dispatch."""
+
+    def test_contiguous_mode_forward(self):
+        """forward with contiguous mode calls all_gather_contiguous."""
+        from paddlefleet.context_parallel_utils import (
+            ContextParallelAllGatherOp,
+        )
+
+        hcg, group = _make_mock_hcg(nranks=2, rank=0)
+        x = paddle.randn([2, 4])
+        fake_gathered = paddle.randn([4, 4])
+
+        with (
+            mock.patch(
+                "paddle.distributed.fleet.get_hybrid_communicate_group",
+                return_value=hcg,
+            ),
+            mock.patch(
+                "paddlefleet.context_parallel_utils.all_gather_contiguous",
+                return_value=fake_gathered,
+            ) as mock_fn,
+        ):
+            ctx = mock.MagicMock()
+            out = ContextParallelAllGatherOp.forward(
+                ctx, x, axis=0, mode="contiguous_allgather"
+            )
+            mock_fn.assert_called_once()
+        self.assertTrue(paddle.equal_all(out, fake_gathered))
+        self.assertEqual(ctx.mode, "contiguous_allgather")
+
+    def test_dualchunk_mode_forward(self):
+        """forward with dualchunk mode calls all_gather_balance."""
+        from paddlefleet.context_parallel_utils import (
+            ContextParallelAllGatherOp,
+        )
+
+        hcg, group = _make_mock_hcg(nranks=2, rank=0)
+        x = paddle.randn([2, 4])
+
+        with (
+            mock.patch(
+                "paddle.distributed.fleet.get_hybrid_communicate_group",
+                return_value=hcg,
+            ),
+            mock.patch(
+                "paddlefleet.context_parallel_utils.all_gather_balance",
+                return_value=paddle.randn([4, 4]),
+            ) as mock_fn,
+        ):
+            ctx = mock.MagicMock()
+            out = ContextParallelAllGatherOp.forward(
+                ctx, x, axis=0, mode="dualchunk_allgather"
+            )
+            mock_fn.assert_called_once()
+
+    def test_backward_contiguous(self):
+        """backward with contiguous mode calls reduce_scatter_contiguous."""
+        from paddlefleet.context_parallel_utils import (
+            ContextParallelAllGatherOp,
+        )
+
+        ctx = mock.MagicMock()
+        ctx.mode = "contiguous_allgather"
+        ctx.axis = 0
+        ctx.group = _make_mock_group(nranks=1, rank=0)
+        grad = paddle.randn([4, 4])
+
+        out = ContextParallelAllGatherOp.backward(ctx, grad)
+        self.assertTrue(paddle.equal_all(out, grad))  # nranks=1, clone
+
+    def test_backward_dualchunk(self):
+        """backward with dualchunk calls reduce_scatter_any_axis_balance."""
+        from paddlefleet.context_parallel_utils import (
+            ContextParallelAllGatherOp,
+        )
+
+        ctx = mock.MagicMock()
+        ctx.mode = "dualchunk_allgather"
+        ctx.axis = 0
+        ctx.group = _make_mock_group(nranks=2, rank=0)
+        grad = paddle.randn([4, 4])
+
+        with mock.patch(
+            "paddlefleet.context_parallel_utils.reduce_scatter_any_axis_balance",
+            return_value=paddle.randn([2, 4]),
+        ) as mock_fn:
+            out = ContextParallelAllGatherOp.backward(ctx, grad)
+            mock_fn.assert_called_once()
+
+
+# ===========================================================================
+# Test get_batch_on_this_cp_rank with cp_balance_mode
+# ===========================================================================
+
+
+class TestGetBatchOnThisCpRank(unittest.TestCase):
+    """Tests for get_batch_on_this_cp_rank in utils.py."""
+
+    def _setup_fleet_mock(self, nranks=4, rank=1):
+        hcg, group = _make_mock_hcg(nranks=nranks, rank=rank)
+        return mock.patch(
+            "paddle.distributed.fleet.get_hybrid_communicate_group",
+            return_value=hcg,
+        )
+
+    def test_tensor_input_default_mode(self):
+        """Tensor input uses dualchunk by default."""
+        from paddlefleet.utils import get_batch_on_this_cp_rank
+
+        x = paddle.arange(16).reshape([4, 4]).cast("float32")
+        with (
+            self._setup_fleet_mock(nranks=2, rank=0),
+            mock.patch(
+                "paddlefleet.context_parallel_utils.scatter_balance",
+                return_value=x[:, :2],
+            ) as mock_fn,
+        ):
+            out = get_batch_on_this_cp_rank(x)
+            mock_fn.assert_called_once()
+
+    def test_tensor_input_contiguous_mode(self):
+        """Tensor input with contiguous mode scatters along axis=-1."""
+        from paddlefleet.utils import get_batch_on_this_cp_rank
+
+        x = paddle.arange(16).reshape([4, 4]).cast("float32")
+        with self._setup_fleet_mock(nranks=2, rank=0):
+            out = get_batch_on_this_cp_rank(
+                x, cp_balance_mode="contiguous_allgather"
+            )
+        # axis=-1, rank=0, nranks=2 -> first half of cols
+        self.assertEqual(list(out.shape), [4, 2])
+
+    def test_dict_input_splits_known_keys(self):
+        """Dict input splits input_ids, position_ids, labels; passes others."""
+        from paddlefleet.utils import get_batch_on_this_cp_rank
+
+        inputs = {
+            "input_ids": paddle.arange(8).reshape([2, 4]).cast("int64"),
+            "position_ids": paddle.arange(8).reshape([2, 4]).cast("int64"),
+            "labels": paddle.arange(8).reshape([2, 4]).cast("int64"),
+            "attention_mask": paddle.ones([2, 4]),
+        }
+        with self._setup_fleet_mock(nranks=2, rank=0):
+            out = get_batch_on_this_cp_rank(
+                inputs, cp_balance_mode="contiguous_allgather"
+            )
+        # Split keys should be halved on axis=-1
+        self.assertEqual(list(out["input_ids"].shape), [2, 2])
+        self.assertEqual(list(out["position_ids"].shape), [2, 2])
+        self.assertEqual(list(out["labels"].shape), [2, 2])
+        # Non-split key should be unchanged
+        self.assertEqual(list(out["attention_mask"].shape), [2, 4])
+
+    def test_dict_input_default_dualchunk_mode(self):
+        """Dict input uses dualchunk by default."""
+        from paddlefleet.utils import get_batch_on_this_cp_rank
+
+        inputs = {
+            "input_ids": paddle.arange(8).reshape([2, 4]).cast("int64"),
+            "labels": paddle.arange(8).reshape([2, 4]).cast("int64"),
+        }
+        with (
+            self._setup_fleet_mock(nranks=2, rank=0),
+            mock.patch(
+                "paddlefleet.context_parallel_utils.scatter_balance",
+                return_value=paddle.zeros([2, 2], dtype="int64"),
+            ) as mock_fn,
+        ):
+            out = get_batch_on_this_cp_rank(inputs)
+            # Called once per split key
+            self.assertEqual(mock_fn.call_count, 2)
+
+    def test_list_input_raises(self):
+        """List input raises AssertionError."""
+        from paddlefleet.utils import get_batch_on_this_cp_rank
+
+        with self.assertRaises(AssertionError):
+            get_batch_on_this_cp_rank([paddle.ones([2, 4])])
+
+    def test_invalid_type_raises(self):
+        """Non-tensor/dict/list input raises ValueError."""
+        from paddlefleet.utils import get_batch_on_this_cp_rank
+
+        with self.assertRaises(ValueError):
+            get_batch_on_this_cp_rank("invalid")
+
+
+# ===========================================================================
+# Test PyLayer assertion guards (nranks <= 1 should raise)
+# ===========================================================================
+
+
+class TestPyLayerAssertionGuards(unittest.TestCase):
+    """Test that PyLayer ops raise AssertionError when cp_world_size <= 1."""
+
+    def test_scatter_op_asserts_nranks_gt_1(self):
+        """ScatterOp raises when context_parallel_world_size <= 1."""
+        from paddlefleet.context_parallel_utils import ContextParallelScatterOp
+
+        hcg, _ = _make_mock_hcg(nranks=1, rank=0)
+        x = paddle.randn([4, 4])
+        with (
+            mock.patch(
+                "paddle.distributed.fleet.get_hybrid_communicate_group",
+                return_value=hcg,
+            ),
+            self.assertRaises(AssertionError),
+        ):
+            ContextParallelScatterOp.forward(mock.MagicMock(), x, axis=0)
+
+    def test_gather_op_asserts_nranks_gt_1(self):
+        """GatherOp raises when context_parallel_world_size <= 1."""
+        from paddlefleet.context_parallel_utils import ContextParallelGatherOp
+
+        hcg, _ = _make_mock_hcg(nranks=1, rank=0)
+        x = paddle.randn([4, 4])
+        with (
+            mock.patch(
+                "paddle.distributed.fleet.get_hybrid_communicate_group",
+                return_value=hcg,
+            ),
+            self.assertRaises(AssertionError),
+        ):
+            ContextParallelGatherOp.forward(mock.MagicMock(), x, axis=0)
+
+    def test_allgather_op_asserts_nranks_gt_1(self):
+        """AllGatherOp raises when context_parallel_world_size <= 1."""
+        from paddlefleet.context_parallel_utils import (
+            ContextParallelAllGatherOp,
+        )
+
+        hcg, _ = _make_mock_hcg(nranks=1, rank=0)
+        x = paddle.randn([4, 4])
+        with (
+            mock.patch(
+                "paddle.distributed.fleet.get_hybrid_communicate_group",
+                return_value=hcg,
+            ),
+            self.assertRaises(AssertionError),
+        ):
+            ContextParallelAllGatherOp.forward(mock.MagicMock(), x, axis=0)
+
+
+# ===========================================================================
+# Test reduce_scatter_contiguous dtype preservation (bf16 path)
+# ===========================================================================
+
+
+class TestReduceScatterContiguousDtype(unittest.TestCase):
+    """Test that reduce_scatter_contiguous preserves input dtype through fp32 sum."""
+
+    def test_bf16_input_preserved(self):
+        """bf16 input -> fp32 sum -> cast back to bf16."""
+        from paddlefleet.context_parallel_utils import reduce_scatter_contiguous
+
+        nranks = 2
+        group = _make_mock_group(nranks=nranks, rank=0)
+        x = paddle.ones([3, 4]).cast("bfloat16")
+
+        def fake_alltoall(output_list, input_list, group, use_calc_stream):
+            for i, buf in enumerate(output_list):
+                buf[:] = paddle.ones(buf.shape).cast("bfloat16")
+
+        with mock.patch.object(
+            dist.stream, "alltoall", side_effect=fake_alltoall
+        ):
+            out = reduce_scatter_contiguous(x, axis=1, group=group)
+        self.assertEqual(out.dtype, paddle.bfloat16)
+
+    def test_float16_input_preserved(self):
+        """float16 input -> fp32 sum -> cast back to float16."""
+        from paddlefleet.context_parallel_utils import reduce_scatter_contiguous
+
+        nranks = 2
+        group = _make_mock_group(nranks=nranks, rank=0)
+        x = paddle.ones([3, 4]).cast("float16")
+
+        def fake_alltoall(output_list, input_list, group, use_calc_stream):
+            for i, buf in enumerate(output_list):
+                buf[:] = paddle.ones(buf.shape).cast("float16")
+
+        with mock.patch.object(
+            dist.stream, "alltoall", side_effect=fake_alltoall
+        ):
+            out = reduce_scatter_contiguous(x, axis=1, group=group)
+        self.assertEqual(out.dtype, paddle.float16)
+
+
+# ===========================================================================
+# Test scatter_contiguous value correctness for various ranks
+# ===========================================================================
+
+
+class TestScatterContiguousValueCorrectness(unittest.TestCase):
+    """Test scatter_contiguous produces correct values for all ranks with 3D tensors."""
+
+    def test_3d_tensor_axis_1(self):
+        """3D tensor [B, S, D] scattered on axis=1."""
+        from paddlefleet.context_parallel_utils import scatter_contiguous
+
+        nranks = 4
+        B, S, D = 2, 8, 3
+        x = paddle.arange(B * S * D).reshape([B, S, D]).cast("float32")
+        for rank in range(nranks):
+            group = _make_mock_group(nranks=nranks, rank=rank)
+            out = scatter_contiguous(x, group=group, axis=1)
+            expected = x[:, rank * 2 : (rank + 1) * 2, :]
+            self.assertTrue(paddle.equal_all(out, expected))
+            self.assertEqual(list(out.shape), [B, 2, D])
+
+
+# ===========================================================================
+# Test TransformerConfig.cp_balance_mode field
+# ===========================================================================
+
+
+class TestTransformerConfigCpBalanceMode(unittest.TestCase):
+    """Tests for cp_balance_mode field in TransformerConfig."""
+
+    def test_default_value(self):
+        """Default is 'dualchunk_allgather'."""
+        from paddlefleet.transformer.transformer_config import (
+            TransformerConfig,
+        )
+
+        config = TransformerConfig()
+        self.assertEqual(config.cp_balance_mode, "dualchunk_allgather")
+
+    def test_set_contiguous(self):
+        """Can be set to 'contiguous_allgather'."""
+        from paddlefleet.transformer.transformer_config import (
+            TransformerConfig,
+        )
+
+        config = TransformerConfig(cp_balance_mode="contiguous_allgather")
+        self.assertEqual(config.cp_balance_mode, "contiguous_allgather")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/custom_ops/test_tilelang_csa_indexer_cp.py
+++ b/tests/single_card_tests/custom_ops/test_tilelang_csa_indexer_cp.py
@@ -257,7 +257,7 @@ class TestIndexerBwdCPGradients(unittest.TestCase):
             )
             self.assertLess(
                 dw_diff,
-                1e-4,
+                1e-2,
                 f"dW mismatch: sq={sq_global} rank={r} diff={dw_diff:.2e}",
             )
             dk_accum += dk_r.cast("float32")
@@ -266,7 +266,7 @@ class TestIndexerBwdCPGradients(unittest.TestCase):
         dk_diff = (dk_accum - dk_full.cast("float32")).abs().max().item()
         self.assertLess(
             dk_diff,
-            1e-3,
+            1e-2,
             f"dK sum mismatch: sq={sq_global} cp={cp_size} diff={dk_diff:.2e}",
         )
 

--- a/tests/single_card_tests/custom_ops/test_tilelang_csa_indexer_cp.py
+++ b/tests/single_card_tests/custom_ops/test_tilelang_csa_indexer_cp.py
@@ -1,0 +1,563 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Single-card tests for TileLang CSA indexer under simulated CP conditions.
+
+Verifies that the TileLang indexer kernel produces correct results when called
+with seq_offset (the CP position offset), by comparing:
+  1. Local slice + seq_offset == full-sequence result slice (bit-exact for fwd)
+  2. Backward dQ/dW slice-exact, sum-of-dK across ranks == full dK
+  3. Causal boundary valid_count matches closed-form formula per-position
+  4. TileLang kernel vs Paddle reference indexer cross-validation
+
+These tests exercise the kernel's `valid_end = (i_t + seq_offset + 1) // ratio`
+logic without requiring multiple GPUs.
+
+Run:
+    python -m pytest tests/single_card_tests/custom_ops/test_tilelang_csa_indexer_cp.py -v
+"""
+
+import unittest
+
+import paddle
+
+paddle.enable_compat(scope={"tilelang"}, silent=True)
+
+
+# =========================================================================
+# Helpers
+# =========================================================================
+
+
+def _cuda_or_skip(testcase):
+    if not paddle.device.is_compiled_with_cuda():
+        testcase.skipTest("CUDA build of Paddle is required")
+    if paddle.device.cuda.device_count() == 0:
+        testcase.skipTest("No CUDA device available")
+
+
+def _make_inputs(b, sq, h_i, d_i, ratio, seed=2026):
+    """Generate q [b, sq, h_i, d_i], k [b, sk, d_i], w [b, sq, h_i]."""
+    sk = sq // ratio
+    paddle.seed(seed)
+    q = paddle.randn([b, sq, h_i, d_i], dtype="bfloat16")
+    k = paddle.randn([b, sk, d_i], dtype="bfloat16")
+    w = paddle.randn([b, sq, h_i], dtype="float32")
+    return q, k, w
+
+
+def _cosine_sim(a, b):
+    """Cosine similarity between two tensors (flattened to 1D)."""
+    a_f = a.cast("float32").flatten()
+    b_f = b.cast("float32").flatten()
+    dot = (a_f * b_f).sum()
+    return (dot / (a_f.norm() * b_f.norm() + 1e-30)).item()
+
+
+# =========================================================================
+# Test: Forward topk bit-exact under simulated CP
+# =========================================================================
+
+
+class TestIndexerFwdCPBitExact(unittest.TestCase):
+    """Slicing Q + seq_offset must produce identical results to full-seq slice."""
+
+    def setUp(self):
+        _cuda_or_skip(self)
+        paddle.set_device("gpu")
+
+    def _run(self, sq_global, cp_size, h_i, d_i, ratio, topk_eff):
+        from paddlefleet.tilelang_ops import csa_indexer_topk_fwd
+
+        b = 2
+        sq_local = sq_global // cp_size
+        q, k, w = _make_inputs(b, sq_global, h_i, d_i, ratio)
+        sk = sq_global // ratio
+        if topk_eff > sk:
+            self.skipTest(f"topk_eff={topk_eff} > sk={sk}")
+
+        # Full-sequence reference
+        idx_full, scores_full = csa_indexer_topk_fwd(
+            q,
+            k,
+            w,
+            ratio=ratio,
+            topk_effective=topk_eff,
+            seq_offset=0,
+        )
+
+        # Verify each simulated rank
+        for r in range(cp_size):
+            s = r * sq_local
+            idx_r, scores_r = csa_indexer_topk_fwd(
+                q[:, s : s + sq_local, :, :],
+                k,
+                w[:, s : s + sq_local, :],
+                ratio=ratio,
+                topk_effective=topk_eff,
+                seq_offset=s,
+            )
+            self.assertTrue(
+                paddle.equal_all(
+                    idx_r, idx_full[:, s : s + sq_local, :]
+                ).item(),
+                f"Indices mismatch: sq={sq_global} cp={cp_size} rank={r}",
+            )
+            score_diff = (
+                (scores_r - scores_full[:, s : s + sq_local, :])
+                .abs()
+                .max()
+                .item()
+            )
+            self.assertLess(
+                score_diff,
+                1e-6,
+                f"Scores diff={score_diff:.2e}: sq={sq_global} cp={cp_size} rank={r}",
+            )
+
+    def test_phase3_cp2_small(self):
+        self._run(sq_global=32, cp_size=2, h_i=16, d_i=32, ratio=4, topk_eff=4)
+
+    def test_phase3_cp2_medium(self):
+        self._run(sq_global=64, cp_size=2, h_i=16, d_i=32, ratio=4, topk_eff=8)
+
+    def test_phase3_cp4(self):
+        self._run(sq_global=64, cp_size=4, h_i=16, d_i=32, ratio=4, topk_eff=4)
+
+    def test_phase3_cp2_larger(self):
+        self._run(
+            sq_global=128, cp_size=2, h_i=16, d_i=32, ratio=4, topk_eff=16
+        )
+
+    def test_phase3_cp4_larger(self):
+        self._run(sq_global=128, cp_size=4, h_i=16, d_i=32, ratio=4, topk_eff=8)
+
+    def test_phase3_long_seq(self):
+        self._run(
+            sq_global=256, cp_size=2, h_i=16, d_i=32, ratio=4, topk_eff=16
+        )
+
+    def test_phase3_cp4_long(self):
+        self._run(
+            sq_global=256, cp_size=4, h_i=16, d_i=32, ratio=4, topk_eff=32
+        )
+
+    def test_phase3_512(self):
+        self._run(
+            sq_global=512, cp_size=2, h_i=16, d_i=32, ratio=4, topk_eff=32
+        )
+
+    def test_phase2_topk_eq_ncomp(self):
+        """Phase 2: topk_eff == n_compressed (full candidate selection)."""
+        self._run(sq_global=64, cp_size=2, h_i=16, d_i=32, ratio=4, topk_eff=16)
+
+    def test_phase2_cp4(self):
+        """Phase 2 with cp_size=4."""
+        self._run(
+            sq_global=128, cp_size=4, h_i=16, d_i=32, ratio=4, topk_eff=32
+        )
+
+
+# =========================================================================
+# Test: Backward dQ/dW slice-exact, dK sum-exact
+# =========================================================================
+
+
+class TestIndexerBwdCPGradients(unittest.TestCase):
+    """Backward under simulated CP: dQ/dW match slices, dK sums to full."""
+
+    def setUp(self):
+        _cuda_or_skip(self)
+        paddle.set_device("gpu")
+
+    def _run(self, sq_global, cp_size, h_i, d_i, ratio, topk_eff):
+        from paddlefleet.tilelang_ops import (
+            csa_indexer_bwd,
+            csa_indexer_topk_fwd,
+        )
+
+        b = 2
+        sq_local = sq_global // cp_size
+        q, k, w = _make_inputs(b, sq_global, h_i, d_i, ratio, seed=3030)
+        sk = sq_global // ratio
+        if topk_eff > sk:
+            self.skipTest(f"topk_eff={topk_eff} > sk={sk}")
+
+        # Full-sequence fwd + bwd
+        idx_full, _ = csa_indexer_topk_fwd(
+            q,
+            k,
+            w,
+            ratio=ratio,
+            topk_effective=topk_eff,
+            seq_offset=0,
+        )
+        paddle.seed(4040)
+        grad_full = (
+            paddle.randn([b, sq_global, topk_eff], dtype="float32") * 0.01
+        )
+        dq_full, dw_full, dk_full = csa_indexer_bwd(
+            q, w, k, idx_full, grad_full
+        )
+
+        # Simulate each rank and accumulate dK
+        dk_accum = paddle.zeros_like(dk_full).cast("float32")
+        for r in range(cp_size):
+            s = r * sq_local
+            idx_r, _ = csa_indexer_topk_fwd(
+                q[:, s : s + sq_local, :, :],
+                k,
+                w[:, s : s + sq_local, :],
+                ratio=ratio,
+                topk_effective=topk_eff,
+                seq_offset=s,
+            )
+            dq_r, dw_r, dk_r = csa_indexer_bwd(
+                q[:, s : s + sq_local, :, :],
+                w[:, s : s + sq_local, :],
+                k,
+                idx_r,
+                grad_full[:, s : s + sq_local, :],
+            )
+            # dQ slice-exact
+            dq_diff = (
+                (
+                    dq_r.cast("float32")
+                    - dq_full[:, s : s + sq_local, :, :].cast("float32")
+                )
+                .abs()
+                .max()
+                .item()
+            )
+            self.assertLess(
+                dq_diff,
+                1e-4,
+                f"dQ mismatch: sq={sq_global} rank={r} diff={dq_diff:.2e}",
+            )
+            # dW slice-exact
+            dw_diff = (
+                (
+                    dw_r.cast("float32")
+                    - dw_full[:, s : s + sq_local, :].cast("float32")
+                )
+                .abs()
+                .max()
+                .item()
+            )
+            self.assertLess(
+                dw_diff,
+                1e-4,
+                f"dW mismatch: sq={sq_global} rank={r} diff={dw_diff:.2e}",
+            )
+            dk_accum += dk_r.cast("float32")
+
+        # Sum of dK across ranks == full dK
+        dk_diff = (dk_accum - dk_full.cast("float32")).abs().max().item()
+        self.assertLess(
+            dk_diff,
+            1e-3,
+            f"dK sum mismatch: sq={sq_global} cp={cp_size} diff={dk_diff:.2e}",
+        )
+
+    def test_cp2_small(self):
+        self._run(sq_global=32, cp_size=2, h_i=16, d_i=32, ratio=4, topk_eff=4)
+
+    def test_cp2_medium(self):
+        self._run(sq_global=64, cp_size=2, h_i=16, d_i=32, ratio=4, topk_eff=8)
+
+    def test_cp4(self):
+        self._run(sq_global=64, cp_size=4, h_i=16, d_i=32, ratio=4, topk_eff=4)
+
+    def test_cp2_larger(self):
+        self._run(
+            sq_global=128, cp_size=2, h_i=16, d_i=32, ratio=4, topk_eff=16
+        )
+
+    def test_cp2_long(self):
+        self._run(
+            sq_global=256, cp_size=2, h_i=16, d_i=32, ratio=4, topk_eff=16
+        )
+
+    def test_phase2(self):
+        """Phase 2: topk == n_compressed."""
+        self._run(sq_global=64, cp_size=2, h_i=16, d_i=32, ratio=4, topk_eff=16)
+
+
+# =========================================================================
+# Test: Causal boundary exact valid_count
+# =========================================================================
+
+
+class TestIndexerCPCausalBoundary(unittest.TestCase):
+    """Per-position valid_count must match: min((global_pos+1)//ratio, sk, topk)."""
+
+    def setUp(self):
+        _cuda_or_skip(self)
+        paddle.set_device("gpu")
+
+    def _run(self, sq_global, cp_size, ratio):
+        from paddlefleet.tilelang_ops import csa_indexer_topk_fwd
+
+        b, h_i, d_i = 1, 16, 32
+        sq_local = sq_global // cp_size
+        sk = sq_global // ratio
+        topk_eff = sk  # Use full range to expose all valid positions
+
+        q, k, w = _make_inputs(b, sq_global, h_i, d_i, ratio, seed=6060)
+
+        for r in range(cp_size):
+            s = r * sq_local
+            idx_r, _ = csa_indexer_topk_fwd(
+                q[:, s : s + sq_local, :, :],
+                k,
+                w[:, s : s + sq_local, :],
+                ratio=ratio,
+                topk_effective=topk_eff,
+                seq_offset=s,
+            )
+            idx_np = idx_r[0].numpy()
+            for t in range(sq_local):
+                expected = min((s + t + 1) // ratio, sk, topk_eff)
+                actual = int((idx_np[t] >= 0).sum())
+                self.assertEqual(
+                    actual,
+                    expected,
+                    f"Causal boundary wrong: sq={sq_global} cp={cp_size} "
+                    f"rank={r} pos={s + t}: expected={expected} actual={actual}",
+                )
+
+    def test_cp2_sq64(self):
+        self._run(sq_global=64, cp_size=2, ratio=4)
+
+    def test_cp4_sq128(self):
+        self._run(sq_global=128, cp_size=4, ratio=4)
+
+    def test_cp2_sq256(self):
+        self._run(sq_global=256, cp_size=2, ratio=4)
+
+    def test_cp2_sq512(self):
+        self._run(sq_global=512, cp_size=2, ratio=4)
+
+    def test_first_positions_all_invalid(self):
+        """Positions 0..ratio-2 should have valid_count=0."""
+        from paddlefleet.tilelang_ops import csa_indexer_topk_fwd
+
+        b, h_i, d_i, ratio = 1, 16, 32, 4
+        sq_global, cp_size = 64, 2
+        sq_local = sq_global // cp_size
+        sk = sq_global // ratio
+        q, k, w = _make_inputs(b, sq_global, h_i, d_i, ratio, seed=7070)
+
+        # Rank 0 holds the first positions
+        idx_r, _ = csa_indexer_topk_fwd(
+            q[:, :sq_local, :, :],
+            k,
+            w[:, :sq_local, :],
+            ratio=ratio,
+            topk_effective=sk,
+            seq_offset=0,
+        )
+        idx_np = idx_r[0].numpy()
+        for t in range(ratio - 1):
+            count = int((idx_np[t] >= 0).sum())
+            self.assertEqual(
+                count,
+                0,
+                f"Position {t} should have 0 valid, got {count}",
+            )
+
+
+# =========================================================================
+# Test: TileLang vs Paddle reference cross-validation
+# =========================================================================
+
+
+class TestIndexerCPTileLangVsPaddleRef(unittest.TestCase):
+    """TileLang kernel topk set vs Paddle fused_qk_topk_naive set agreement."""
+
+    def setUp(self):
+        _cuda_or_skip(self)
+        paddle.set_device("gpu")
+
+    def _run(self, sq_global, cp_size, topk_eff, max_mismatch_rate=0.05):
+        from paddlefleet.tilelang_ops import csa_indexer_topk_fwd
+        from paddlefleet.transformer.cp_utils import build_causal_mask_cp
+        from paddlefleet.transformer.csa_attention import fused_qk_topk_naive
+
+        b, h_i, d_i, ratio = 2, 16, 32, 4
+        sq_local = sq_global // cp_size
+        sk = sq_global // ratio
+        if topk_eff > sk:
+            self.skipTest(f"topk_eff={topk_eff} > sk={sk}")
+
+        q, k, w = _make_inputs(b, sq_global, h_i, d_i, ratio, seed=5050)
+
+        total_mismatch = 0
+        total_pos = 0
+        for r in range(cp_size):
+            s = r * sq_local
+            q_r = q[:, s : s + sq_local, :, :]
+            w_r = w[:, s : s + sq_local, :]
+
+            tl_idx, _ = csa_indexer_topk_fwd(
+                q_r,
+                k,
+                w_r,
+                ratio=ratio,
+                topk_effective=topk_eff,
+                seq_offset=s,
+            )
+            q_pos = paddle.arange(s, s + sq_local, dtype="int64")
+            mask = build_causal_mask_cp(q_pos, sk, ratio, b)
+            _, pd_idx = fused_qk_topk_naive(q_r, k, w_r, topk_eff, mask)
+
+            tl_np = tl_idx.numpy()
+            pd_np = pd_idx.numpy()
+            for bi in range(b):
+                for ti in range(sq_local):
+                    # Number of causally valid compressed positions for this query
+                    n_valid = min((s + ti + 1) // ratio, sk)
+                    # TileLang: invalid slots are -1
+                    tl_set = set(tl_np[bi, ti][tl_np[bi, ti] >= 0])
+                    # Paddle: topk always fills all slots; filter to valid range
+                    pd_set = {int(x) for x in pd_np[bi, ti] if 0 <= x < n_valid}
+                    if tl_set != pd_set:
+                        total_mismatch += 1
+                    total_pos += 1
+
+        rate = total_mismatch / max(total_pos, 1)
+        self.assertLess(
+            rate,
+            max_mismatch_rate,
+            f"TL vs Paddle mismatch rate {rate * 100:.1f}% exceeds "
+            f"{max_mismatch_rate * 100:.0f}%: sq={sq_global} cp={cp_size} topk={topk_eff}",
+        )
+
+    def test_cp2_small(self):
+        self._run(sq_global=64, cp_size=2, topk_eff=8)
+
+    def test_cp2_medium(self):
+        self._run(sq_global=128, cp_size=2, topk_eff=16)
+
+    def test_cp4(self):
+        self._run(sq_global=256, cp_size=4, topk_eff=16)
+
+    def test_cp2_large_topk(self):
+        """Large topk (close to n_compressed)."""
+        self._run(sq_global=128, cp_size=2, topk_eff=32)
+
+
+# =========================================================================
+# Test: seq_offset edge cases
+# =========================================================================
+
+
+class TestIndexerSeqOffsetEdgeCases(unittest.TestCase):
+    """Edge cases for seq_offset parameter handling."""
+
+    def setUp(self):
+        _cuda_or_skip(self)
+        paddle.set_device("gpu")
+
+    def test_offset_zero_is_no_op(self):
+        """seq_offset=0 should produce same results as not passing it."""
+        from paddlefleet.tilelang_ops import csa_indexer_topk_fwd
+
+        b, sq, h_i, d_i, ratio = 2, 64, 16, 32, 4
+        q, k, w = _make_inputs(b, sq, h_i, d_i, ratio)
+        sk = sq // ratio
+        topk = 8
+
+        idx_default, scores_default = csa_indexer_topk_fwd(
+            q,
+            k,
+            w,
+            ratio=ratio,
+            topk_effective=topk,
+            seq_offset=0,
+        )
+        idx_explicit, scores_explicit = csa_indexer_topk_fwd(
+            q,
+            k,
+            w,
+            ratio=ratio,
+            topk_effective=topk,
+            seq_offset=0,
+        )
+        self.assertTrue(paddle.equal_all(idx_default, idx_explicit).item())
+
+    def test_large_offset_all_valid(self):
+        """With large seq_offset, all positions should have full valid range."""
+        from paddlefleet.tilelang_ops import csa_indexer_topk_fwd
+
+        b, sq, h_i, d_i, ratio = 1, 32, 16, 32, 4
+        q, k, w = _make_inputs(b, sq, h_i, d_i, ratio)
+        sk = sq // ratio
+        topk = sk
+
+        # Large offset: even position 0 sees all compressed positions
+        large_offset = 1024
+        idx, _ = csa_indexer_topk_fwd(
+            q,
+            k,
+            w,
+            ratio=ratio,
+            topk_effective=topk,
+            seq_offset=large_offset,
+        )
+        idx_np = idx[0].numpy()
+        for t in range(sq):
+            count = int((idx_np[t] >= 0).sum())
+            expected = min((t + large_offset + 1) // ratio, sk, topk)
+            self.assertEqual(
+                count,
+                expected,
+                f"pos={t}: expected {expected} valid, got {count}",
+            )
+
+    def test_rank_ordering_monotonic(self):
+        """Higher CP ranks should have >= valid positions compared to lower ranks."""
+        from paddlefleet.tilelang_ops import csa_indexer_topk_fwd
+
+        b, h_i, d_i, ratio = 1, 16, 32, 4
+        sq_global, cp_size = 128, 4
+        sq_local = sq_global // cp_size
+        sk = sq_global // ratio
+        topk = sk
+        q, k, w = _make_inputs(b, sq_global, h_i, d_i, ratio)
+
+        prev_min_valid = -1
+        for r in range(cp_size):
+            s = r * sq_local
+            idx_r, _ = csa_indexer_topk_fwd(
+                q[:, s : s + sq_local, :, :],
+                k,
+                w[:, s : s + sq_local, :],
+                ratio=ratio,
+                topk_effective=topk,
+                seq_offset=s,
+            )
+            idx_np = idx_r[0].numpy()
+            min_valid = int((idx_np[0] >= 0).sum())  # first position in rank
+            self.assertGreaterEqual(
+                min_valid,
+                prev_min_valid,
+                f"Rank {r} first pos has fewer valid ({min_valid}) "
+                f"than rank {r - 1} ({prev_min_valid})",
+            )
+            prev_min_valid = int((idx_np[-1] >= 0).sum())  # last position
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/transformer/test_mtp_magic_send.py
+++ b/tests/single_card_tests/transformer/test_mtp_magic_send.py
@@ -526,7 +526,7 @@ class TestMTPLayerForward(unittest.TestCase):
 
         cp_count = [0]
 
-        def cp_fn(x, axis=0):
+        def cp_fn(x, axis=0, **kwargs):
             cp_count[0] += 1
             return (
                 x[:, : x.shape[1] // 2, :]
@@ -573,7 +573,7 @@ class TestMTPLayerForward(unittest.TestCase):
             captured["di"] = decoder_input
             return hidden_states
 
-        def cp_fn(x, axis=0):
+        def cp_fn(x, axis=0, **kwargs):
             return (
                 x[:, : x.shape[1] // 2, :]
                 if axis == 1
@@ -631,7 +631,7 @@ class TestGPTEmbeddingForward(unittest.TestCase):
                         "paddlefleet.models.gpt.gpt_embedding.ContextParallelScatterOp"
                     )
                 )
-                cp.apply = lambda x, axis=0: x
+                cp.apply = lambda x, axis=0, **kwargs: x
             return emb.forward({"input_ids": paddle.randint(0, 512, [B, S])})
 
     def test_magic_send_paths(self):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
Operator Mechanism


### PR Types
New features


### Description
DSV4 CP 支持：
- 在 paddlefleet 中增加了连续非 dual-chunk CP 的通信 primitives
- paddlefleet 中增加了对 CP 通信模式的传递。之后可能会配合 flashmask (后话) 将 overlap 模式也一并整合到 mode 中。目前mode的格式是：{负载均衡策略}_{通信方式}， 之后可能会改成 {负载均衡策略}_{通信方式}_{是否做细粒度计算通信 overlap}。目前状态的例子："contiguous_allgather" 与 "dualchunk_allgather" 默认。
- 增加了 CSA attention 中的 CP 功能。不带 varlen 支持。


### 是否引起精度变化
否
