### PR TITLE
[codex] Use fp32 softmax in CSA compressor

### DIFF
--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -802,7 +802,7 @@ class Compressor(nn.Layer):
             score = self._overlap_transform(score, fill_value=float("-inf"))
 
         # Gated pooling: softmax over the pool_dim, weighted sum.
-        weights = F.softmax(score, axis=2).cast(kv.dtype)
+        weights = F.softmax(score, axis=2, dtype="float32").cast(kv.dtype)
         kv = (kv * weights).sum(axis=2)  # [b, n_compressed, head_dim]
 
         kv = self.norm(kv.cast(x.dtype))


### PR DESCRIPTION
## Summary

- compute CSA compressor gated-pooling softmax in FP32
- cast the softmax weights back to `kv.dtype` before the weighted sum

## Why

This keeps the gated pooling reduction numerically aligned with the intended FP32 softmax path while preserving the downstream tensor dtype.

## Validation

- `git diff --check`
- verified the PR diff contains only `src/paddlefleet/transformer/csa_attention.py`
