### PR TITLE
[New features] MoE: add AllGather + ReduceScatter dispatcher with intermediate-dim EP sharding

### DIFF
--- a/src/paddlefleet/transformer/moe/moe_expert.py
+++ b/src/paddlefleet/transformer/moe/moe_expert.py
@@ -138,15 +138,29 @@ class GroupedMLPExpert(FleetLayer):
         config: TransformerConfig,
         moe_deep_gemm,
         pg_collection: ProcessGroupCollection | None = None,
+        intermediate_size_per_partition: int | None = None,
     ):
         super().__init__(config=config)
         self.config: TransformerConfig = config
         self.config.hidden_act = F.silu
         self.num_local_experts = num_local_experts
         self.moe_deep_gemm = moe_deep_gemm
-        assert not config.use_bias, (
-            "Bias not supported in Grouped GEMM yet, please set 'use_bias' to False."
+
+        self.using_sonic_moe = self.config.using_sonic_moe
+        # Intermediate size for the local shard of every expert. When using the
+        # 'allgather' MoE dispatcher every expert is sharded along its
+        # intermediate dim across the EP group, so this can be smaller than
+        # ``config.moe_intermediate_size``.
+        self.intermediate_size_per_partition = (
+            intermediate_size_per_partition
+            if intermediate_size_per_partition is not None
+            else self.config.moe_intermediate_size
         )
+
+        if config.use_bias:
+            raise ValueError(
+                "Bias not supported in Grouped GEMM yet, please set 'use_bias' to False."
+            )
 
         self.ep_group = pg_collection.ep if pg_collection else None
         self.expert_parallel = (
@@ -176,13 +190,13 @@ class GroupedMLPExpert(FleetLayer):
             )
 
         # No tensor parallel - full sizes
-        fc1_output_size = self.config.moe_intermediate_size
+        fc1_output_size = self.intermediate_size_per_partition
         if config.gated_linear_unit:
             # Project to 4h. If using swiglu double the output width,
             # see https://arxiv.org/pdf/2002.05202.pdf
             fc1_output_size *= 2
 
-        fc2_input_size = self.config.moe_intermediate_size
+        fc2_input_size = self.intermediate_size_per_partition
 
         dtype = "bfloat16"
         w1_shape = [
@@ -261,7 +275,11 @@ class GroupedMLPExpert(FleetLayer):
                     )
         else:
             # No token is allocated for local experts.
-            assert paddle.count_nonzero(tokens_per_expert) == 0
+            if paddle.count_nonzero(tokens_per_expert) != 0:
+                raise RuntimeError(
+                    "Expected all-zero tokens_per_expert when no tokens "
+                    "are allocated for local experts."
+                )
 
             # Make sure params of experts still have gradients even given zero tokens.
             w1 = self.weight1.reshape(self.config.hidden_size, -1)
@@ -287,7 +305,95 @@ class GroupedMLPExpert(FleetLayer):
         self,
         structured_name_prefix: str = "",
     ):
+        # Two distinct EP weight layouts coexist:
+        #
+        # * Standard: every rank owns a disjoint subset of experts at full
+        #   intermediate width. ``weight1`` is ``[E_local, H, 2*I_full]``
+        #   and ``weight2`` is ``[E_local, I_full, H]``. Sharding axis=0
+        #   stitches the per-rank slabs along the expert dim into the
+        #   global tensor.
+        #
+        # * AllGather token dispatcher: every rank owns *every* expert
+        #   with the intermediate dim sharded across EP. ``weight1`` is
+        #   ``[E, H, 2*I_local]`` and ``weight2`` is ``[E, I_local, H]``.
+        #   Sharding must therefore happen along the intermediate dim,
+        #   not the expert dim. ``weight1``'s last dim is the gated
+        #   ``[gate_r(I_local) ; up_r(I_local)]`` concat — naively
+        #   AllGathering it would interleave gate/up chunks per rank
+        #   (``[gate_r0; up_r0; gate_r1; up_r1; ...]``) rather than
+        #   producing the canonical ``[gate_full; up_full]`` order. We
+        #   reshape to expose the gate/up split as its own axis before
+        #   sharding so flex_checkpoint reassembles the global tensor as
+        #   ``[E, H, 2, I_full]``; loaders can reshape that to
+        #   ``[E, H, 2*I_full]`` losslessly.
+        is_intermediate_sharded = (
+            self.intermediate_size_per_partition
+            != self.config.moe_intermediate_size
+        )
+
         state_dict = self.state_dict(structured_name_prefix="")
+
+        if is_intermediate_sharded:
+            if self.ep_group is None:
+                raise ValueError(
+                    "intermediate-sharded layout requires an EP group; "
+                    f"got ep_group=None. Check moe_token_dispatcher_type "
+                    f"({self.config.moe_token_dispatcher_type!r}) and EP "
+                    f"initialisation."
+                )
+            if not self.config.gated_linear_unit:
+                raise ValueError(
+                    "intermediate-sharded layout currently assumes a gated "
+                    "linear unit (weight1 last dim = 2 * intermediate); "
+                    "non-gated MLP support is not implemented."
+                )
+            ep_size = self.ep_group.nranks
+            if (
+                self.intermediate_size_per_partition * ep_size
+                != self.config.moe_intermediate_size
+            ):
+                raise ValueError(
+                    "intermediate-sharded layout inconsistency: "
+                    f"intermediate_size_per_partition="
+                    f"{self.intermediate_size_per_partition} * ep_size="
+                    f"{ep_size} != moe_intermediate_size="
+                    f"{self.config.moe_intermediate_size}"
+                )
+            E = state_dict["weight1"].shape[0]
+            H = state_dict["weight1"].shape[1]
+            I_local = self.intermediate_size_per_partition
+            expected_last = 2 * I_local
+            if state_dict["weight1"].shape[-1] != expected_last:
+                raise ValueError(
+                    f"weight1 last dim {state_dict['weight1'].shape[-1]} "
+                    f"!= 2 * intermediate_size_per_partition "
+                    f"({expected_last}); cannot reshape to [E, H, 2, "
+                    f"I_local]"
+                )
+            w1 = state_dict["weight1"].reshape([E, H, 2, I_local])
+            w1.name = self.weight1.name
+            w2 = state_dict["weight2"]  # [E, I_local, H]
+            w2.name = self.weight2.name
+
+            sharded_dict = {}
+            full_key1 = f"{structured_name_prefix}weight1"
+            full_key2 = f"{structured_name_prefix}weight2"
+            sharded_dict[full_key1] = shard_weight(
+                key=full_key1,
+                weight=w1,
+                axis=3,  # I_local — intermediate dim per rank
+                group=self.ep_group,
+            )
+            sharded_dict[full_key1].grouped_gemm_param = True
+            sharded_dict[full_key2] = shard_weight(
+                key=full_key2,
+                weight=w2,
+                axis=1,  # I_local — intermediate dim per rank
+                group=self.ep_group,
+            )
+            sharded_dict[full_key2].grouped_gemm_param = True
+            return sharded_dict
+
         model_type = getattr(self.config, "model_type", "none")
         if "qwen3_vl" not in model_type and "qwen3_5" not in model_type:
             w1 = state_dict["weight1"].reshape(-1, self.weight1.shape[-1])
@@ -360,15 +466,18 @@ class SonicMoEExpert(GroupedMLPExpert):
         topk: int,
         config: TransformerConfig,
         pg_collection: ProcessGroupCollection | None = None,
+        intermediate_size_per_partition: int | None = None,
     ):
-        assert config.gated_linear_unit is True, (
-            "Sonic MoE must use SwiGLU, i.e. set gated_linear_unit=True."
-        )
+        if config.gated_linear_unit is not True:
+            raise ValueError(
+                "Sonic MoE must use SwiGLU, i.e. set gated_linear_unit=True."
+            )
         super().__init__(
             num_local_experts=num_local_experts,
             config=config,
             moe_deep_gemm=False,
             pg_collection=pg_collection,
+            intermediate_size_per_partition=intermediate_size_per_partition,
         )
         self.hidden_size = self.config.hidden_size
         self.K = topk

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -51,6 +51,7 @@ from .moe_router import TopKRouter
 from .moe_shared_expert import StandardMLPSharedExpert
 from .moe_utils import AddAuxiliaryLoss, use_accuracy_compatible_kernel
 from .token_dispatcher import (
+    AllGatherTokenDispatcher,
     AllToAllTokenDispatcher,
     MoEFlexTokenDispatcher,
     is_hybrid_ep_backend_selected,
@@ -180,10 +181,26 @@ class MoELayer(nn.Layer):
             config.moe_subbatch_token_num_after_dispatch
         )
         if self.using_sonic_moe:
-            assert paddlefleet_ops.is_sonic_moe_available(), (
-                paddlefleet_ops.blocked_import_messages[
-                    "paddlefleet_ops.sonicmoe"
-                ]
+            if not paddlefleet_ops.is_sonic_moe_available():
+                raise ValueError(
+                    paddlefleet_ops.blocked_import_messages.get(
+                        "paddlefleet_ops.sonicmoe",
+                        "SonicMoE module is not available",
+                    )
+                )
+        # Cross-field consistency: moe_allgather_gate_overlap only takes
+        # effect on the 'allgather' dispatcher; warn loudly if it's set
+        # together with another dispatcher type so users don't assume
+        # the overlap is in play.
+        if (
+            getattr(config, "moe_allgather_gate_overlap", False)
+            and config.moe_token_dispatcher_type != "allgather"
+        ):
+            logger.warning(
+                "moe_allgather_gate_overlap=True is only honoured when "
+                "moe_token_dispatcher_type='allgather'; current type is "
+                "%r, the flag will be ignored.",
+                config.moe_token_dispatcher_type,
             )
         self.router_aux_loss_coef = config.router_aux_loss_coef
         self.moe_deep_gemm = config.moe_deep_gemm
@@ -193,7 +210,7 @@ class MoELayer(nn.Layer):
             if not self.moe_expert_fusion:
                 incompatible_reasons.append("moe_expert_fusion must be True")
             if incompatible_reasons:
-                logging.warning(
+                logger.warning(
                     "moe_deep_gemm=True is ignored because %s; "
                     "setting moe_deep_gemm to False.",
                     " and ".join(incompatible_reasons),
@@ -288,6 +305,8 @@ class MoELayer(nn.Layer):
                         "HybridEP backend does not support moe_shared_expert_overlap; disabling it."
                     )
                     self.moe_shared_expert_overlap = False
+            elif self.moe_token_dispatcher_type == "allgather":
+                self._validate_allgather_config()
             else:
                 logger.info(
                     "moe_use_fusion_node is only supported when moe_token_dispatcher_type is 'deepep' or 'hybridep'; disabling it."
@@ -304,14 +323,14 @@ class MoELayer(nn.Layer):
                 raise NotImplementedError(
                     "fp8 is not supported when cuda version == 12.6."
                 )
-            assert self.moe_use_fusion_node, (
-                "fp8 can only be used when moe_use_fusion_node = True."
-            )
+            if not self.moe_use_fusion_node:
+                raise ValueError(
+                    "fp8 can only be used when moe_use_fusion_node = True."
+                )
 
         if self.use_ue8m0:
-            assert paddle.device.cuda.get_device_capability()[0] == 10, (
-                "use_ue8m0 requires Blackwell GPU (SM100)"
-            )
+            if paddle.device.cuda.get_device_capability()[0] != 10:
+                raise ValueError("use_ue8m0 requires Blackwell GPU (SM100)")
 
         expert_args = {}
         expert_args["config"] = routed_expert_config
@@ -328,7 +347,14 @@ class MoELayer(nn.Layer):
             raise ValueError(
                 "For fp8 deep_gemm (i.e. use k-grouped gemm in backward), moe_expert_fusion must be True."
             )
-        if self.fp8 and self.moe_expert_fusion and self.moe_deep_gemm is False:
+        if (
+            self.fp8
+            and self.moe_expert_fusion
+            and self.moe_deep_gemm is False
+            # AllGather requires fused weights (validated above); exclude
+            # it from this "unfuse fp8 weights" logic.
+            and self.moe_token_dispatcher_type != "allgather"
+        ):
             use_fused_weight = False
         if self.using_sonic_moe:
             assert use_fused_weight is True, (
@@ -336,7 +362,25 @@ class MoELayer(nn.Layer):
             )
 
         if use_fused_weight:
-            if self.using_sonic_moe:
+            if (
+                self.moe_token_dispatcher_type == "allgather"
+                and self.expert_model_parallel_size > 1
+            ):
+                # AllGather (EP>1): every rank holds a shard of every expert
+                # along the intermediate dim; SonicMoEExpert must allocate
+                # weights for all experts (not num_local_experts) with the
+                # per-EP-rank shard size.
+                self.grouped_gemm_experts = SonicMoEExpert(
+                    self.num_experts,
+                    self.num_experts_per_tok,
+                    routed_expert_config,
+                    pg_collection,
+                    intermediate_size_per_partition=(
+                        self.moe_intermediate_size
+                        // self.expert_model_parallel_size
+                    ),
+                )
+            elif self.using_sonic_moe:
                 # TODO: replace grouped_gemm_experts with fusion_experts
                 self.grouped_gemm_experts = SonicMoEExpert(
                     self.num_local_experts,
@@ -404,6 +448,14 @@ class MoELayer(nn.Layer):
                     self.num_experts_per_device,
                     local_expert_indices,
                 )
+            elif self.moe_token_dispatcher_type == "allgather":
+                self.token_dispatcher = AllGatherTokenDispatcher(
+                    self.moe_group,
+                    self.expert_model_parallel_size,
+                    self.num_experts,
+                    fp8_dispatch=self.fp8_dispatch,
+                    use_ue8m0=self.use_ue8m0,
+                )
             else:
                 raise NotImplementedError(
                     f"Unsupported moe_token_dispatcher_type {self.moe_token_dispatcher_type}"
@@ -448,9 +500,8 @@ class MoELayer(nn.Layer):
                     if self.is_mp_moe or self.is_ep_moe:
                         p.is_distributed = True
             else:
-                assert self.experts is not None, (
-                    "experts should be initialized."
-                )
+                if self.experts is None:
+                    raise ValueError("experts should be initialized.")
                 for p in self.experts.parameters():
                     p.is_moe_param = True
                     p.color = {
@@ -523,13 +574,14 @@ class MoELayer(nn.Layer):
             Returns:
                 n_routed_experts_per_device: Number of experts per device
             """
-            assert num_experts >= expert_model_parallel_size, (
-                f"expert num_experts={num_experts} >= moe_world_size={expert_model_parallel_size}"
-            )
-            assert num_experts % expert_model_parallel_size == 0, (
-                f"expert num_experts={num_experts} % moe_world_size={expert_model_parallel_size} == 0"
-            )
-
+            if num_experts < expert_model_parallel_size:
+                raise ValueError(
+                    f"num_experts={num_experts} must be >= moe_world_size={expert_model_parallel_size}"
+                )
+            if num_experts % expert_model_parallel_size != 0:
+                raise ValueError(
+                    f"num_experts={num_experts} must be divisible by moe_world_size={expert_model_parallel_size}"
+                )
             n_routed_experts_per_device = (
                 num_experts // expert_model_parallel_size
             )
@@ -539,9 +591,13 @@ class MoELayer(nn.Layer):
             self.moe_grad_group = self.pg_collection.expt_dp
             self.moe_rank = utils.get_pg_rank(self.moe_group)
             self.moe_rank = max(self.moe_rank, 0)
-            self.num_experts_per_device = _parse_moe_expert_parallel(
-                self.num_experts, self.expert_model_parallel_size
-            )
+            if self.moe_token_dispatcher_type == "allgather":
+                # AllGather: every rank holds a shard of every expert.
+                self.num_experts_per_device = self.num_experts
+            else:
+                self.num_experts_per_device = _parse_moe_expert_parallel(
+                    self.num_experts, self.expert_model_parallel_size
+                )
         else:
             self.moe_group = None
             self.moe_rank = 0
@@ -625,9 +681,24 @@ class MoELayer(nn.Layer):
     def unpermute(self, hidden_states: paddle.Tensor):
         return self.token_dispatcher.combine_preprocess(hidden_states)
 
-    def combine(self, hidden_states: paddle.Tensor, async_finish: bool = False):
+    def combine(
+        self,
+        hidden_states: paddle.Tensor,
+        combine_overlap_handle: dict | None = None,
+        async_finish: bool = False,
+    ):
+        """Combine expert outputs back to the local token shard.
+
+        Delegates to the underlying ``token_dispatcher``: ``token_combine``
+        either issues a (possibly fused) ReduceScatter, then
+        ``combine_postprocess`` finalizes it. When
+        ``combine_overlap_handle`` is provided the ReduceScatter overlaps
+        with a user-supplied subgraph (typically the shared-expert MLP).
+        """
         hidden_states = self.token_dispatcher.token_combine(
-            hidden_states, async_finish=async_finish
+            hidden_states,
+            combine_overlap_handle=combine_overlap_handle,
+            async_finish=async_finish,
         )
         return self.token_dispatcher.combine_postprocess(hidden_states)
 
@@ -642,6 +713,81 @@ class MoELayer(nn.Layer):
         )
         return self.unpermute(expert_outs)
 
+    def _maybe_pre_allgather_overlap(self, hidden_states: paddle.Tensor):
+        """If AllGather-gate overlap is enabled, issue the async AllGather now.
+
+        Overlap hidden_states AllGather with gate computation: issue the async
+        AllGather on the comm stream before the gate runs on the calc stream.
+        The result is consumed inside ``dispatch_preprocess`` via
+        ``_PreAllGatherResult``. For latent MoE: ``fc1_latent_proj`` is hoisted
+        here so the AllGather targets the latent-space tensor; gate still runs
+        on the original hidden_states.
+        """
+        if (
+            self.moe_token_dispatcher_type == "allgather"
+            and self.expert_model_parallel_size > 1
+            and self.config.moe_allgather_gate_overlap
+        ):
+            if self.use_latent_moe:
+                self._latent_hidden = self.fc1_latent_proj(hidden_states)
+                self.token_dispatcher.pre_allgather(self._latent_hidden)
+            else:
+                self._latent_hidden = None
+                self.token_dispatcher.pre_allgather(hidden_states)
+        else:
+            self._latent_hidden = None
+
+    def _validate_allgather_config(self):
+        """Validate and force-correct config flags for the allgather dispatcher.
+
+        AllGather + ReduceScatter EP pattern: every expert is sharded along its
+        intermediate dim across the EP group.  Requires SonicMoE fused kernels;
+        fp8 is handled by ``run_sonic_moe`` internally.
+        """
+        if not self.using_sonic_moe:
+            raise ValueError(
+                "moe_token_dispatcher_type='allgather' requires "
+                "using_sonic_moe=True; the allgather path is only "
+                "implemented for SonicMoE fused kernels."
+            )
+        if not self.moe_use_fusion_node:
+            logger.warning(
+                "moe_token_dispatcher_type='allgather' only "
+                "support moe_use_fusion_node; forcing moe_use_fusion_node=True."
+            )
+            self.moe_use_fusion_node = True
+        if not self.moe_expert_fusion:
+            logger.warning(
+                "moe_token_dispatcher_type='allgather' requires "
+                "fused expert weights; forcing moe_expert_fusion=True."
+            )
+            self.moe_expert_fusion = True
+        if self.moe_deep_gemm:
+            logger.warning(
+                "moe_token_dispatcher_type='allgather' does not "
+                "support moe_deep_gemm; forcing moe_deep_gemm=False."
+            )
+            self.moe_deep_gemm = False
+        if self.moe_intermediate_size % self.expert_model_parallel_size != 0:
+            raise ValueError(
+                f"moe_intermediate_size={self.moe_intermediate_size} "
+                f"must be divisible by EP="
+                f"{self.expert_model_parallel_size} in 'allgather' mode."
+            )
+
+    def _project_to_latent(self, hidden_states: paddle.Tensor) -> paddle.Tensor:
+        """Project hidden_states to latent space, consuming any cached
+        projection from the AllGather overlap path if available.
+        """
+        if not self.use_latent_moe:
+            return hidden_states
+        if self._latent_hidden is not None:
+            hidden_states = self._latent_hidden
+            self._latent_hidden = None
+        else:
+            hidden_states = self.fc1_latent_proj(hidden_states)
+        return hidden_states
+
     # MoE forward: dispatch -> permute -> compute ->unpermute -> combine
     def custom_forward(
         self,
@@ -650,8 +796,9 @@ class MoELayer(nn.Layer):
         routing_map: paddle.Tensor,
         topk_weights: paddle.Tensor | None = None,
         topk_indices: paddle.Tensor | None = None,
+        combine_overlap_handle: dict | None = None,
     ):
-        # Latent MoE: project hidden_states to latent space before dispatch
+        # Latent MoE: project hidden_states to latent space before dispatch.
         if self.use_latent_moe:
             hidden_states = self.fc1_latent_proj(hidden_states)
 
@@ -661,16 +808,21 @@ class MoELayer(nn.Layer):
                 hidden_states, probs, routing_map, topk_weights, topk_indices
             )
         if should_log_balance and global_moe_balance_training_logs_enabled():
+            tokens_per_expert = (
+                self.token_dispatcher._comm_manager.tokens_per_expert
+            )
             log_moe_balance(
                 self.layer_number,
                 self.moe_group,
                 self.num_experts_per_tok,
-                self.token_dispatcher._comm_manager.tokens_per_expert,
+                tokens_per_expert,
             )
         with profile("fusion_mlp"):
             hidden_states = self.routed_experts_compute(hidden_states)
         with profile("combine"):
-            hidden_states = self.combine(hidden_states)
+            hidden_states = self.combine(
+                hidden_states, combine_overlap_handle=combine_overlap_handle
+            )
 
         # Latent MoE: project back from latent space to hidden_size
         if self.use_latent_moe:
@@ -687,27 +839,26 @@ class MoELayer(nn.Layer):
         topk_weights: paddle.Tensor | None = None,
         topk_indices: paddle.Tensor | None = None,
     ):
-        # TODO(deepllz): add fp8 dispatch config && implementation
-        # Latent MoE: project hidden_states to latent space before dispatch
-        if self.use_latent_moe:
-            hidden_states = self.fc1_latent_proj(hidden_states)
+        hidden_states = self._project_to_latent(hidden_states)
 
         should_log_balance = framework._dygraph_tracer()._has_grad
         with profile("dispatch"):
             dispatched_hidden_states, fp8_dispatched_handle = self.dispatch(
                 hidden_states, probs, routing_map, topk_weights, topk_indices
             )
+
+        tokens_per_expert = None
+        dispatched_indices, dispatched_probs, tokens_per_expert = (
+            self.token_dispatcher.get_dispatched_routing()
+        )
+
         if should_log_balance and global_moe_balance_training_logs_enabled():
             log_moe_balance(
                 self.layer_number,
                 self.moe_group,
                 self.num_experts_per_tok,
-                self.token_dispatcher._comm_manager.tokens_per_expert,
+                tokens_per_expert,
             )
-        dispatched_indices = (
-            self.token_dispatcher._comm_manager.dispatched_indices
-        )
-        dispatched_probs = self.token_dispatcher._comm_manager.dispatched_probs
 
         with profile("fusion_mlp"):
             if self._use_hybrid_ep_fusion():
@@ -748,11 +899,17 @@ class MoELayer(nn.Layer):
                 )
 
         with profile("combine"):
-            hidden_states = self.token_dispatcher._comm_manager.combine(
-                hidden_states,
-                combine_overlap_handle,
-                use_rr_deepep_combine=self.use_rr_deepep_combine,
-            )
+            if self.moe_token_dispatcher_type == "allgather":
+                hidden_states = self.combine(
+                    hidden_states,
+                    combine_overlap_handle=combine_overlap_handle,
+                )
+            else:
+                hidden_states = self.token_dispatcher._comm_manager.combine(
+                    hidden_states,
+                    combine_overlap_handle,
+                    use_rr_deepep_combine=self.use_rr_deepep_combine,
+                )
 
         # Latent MoE: project back from latent space to hidden_size
         if self.use_latent_moe:
@@ -796,7 +953,13 @@ class MoELayer(nn.Layer):
         hidden_states, token_probs, token_indices = args
         if self.use_latent_moe:
             hidden_states = self.fc1_latent_proj(hidden_states)
-        assert isinstance(self.token_dispatcher, MoEFlexTokenDispatcher)
+        if not isinstance(self.token_dispatcher, MoEFlexTokenDispatcher):
+            raise TypeError(
+                f"custom_forward requires MoEFlexTokenDispatcher, "
+                f"got {type(self.token_dispatcher).__name__}; "
+                f"use fusion_moe_forward for "
+                f"moe_token_dispatcher_type='allgather'"
+            )
         hidden_states = self.token_dispatcher.dispatch_preprocess_overlap(
             hidden_states, token_probs, token_indices
         )
@@ -951,6 +1114,9 @@ class MoELayer(nn.Layer):
 
         layer_idx = getattr(self, "layer_number", None)
         _log_moe_md5(hidden_states, "moe_input", layer_idx)
+
+        self._maybe_pre_allgather_overlap(hidden_states)
+
         (
             capacity,
             topk_weights,
@@ -1003,6 +1169,7 @@ class MoELayer(nn.Layer):
                     mask,
                     topk_weights=topk_weights,
                     topk_indices=topk_indices,
+                    combine_overlap_handle=combine_overlap_handle,
                 )
         else:
             if len(hidden_states.shape) == 3:
@@ -1272,9 +1439,8 @@ class MoELayer(nn.Layer):
 
     def set_layer_number(self, layer_number, is_mtp_layer: bool = False):
         self.layer_number = layer_number
-        assert hasattr(self.gate, "set_layer_number"), (
-            "expect gate has method 'set_layer_number'"
-        )
+        if not hasattr(self.gate, "set_layer_number"):
+            raise AttributeError("expect gate has method 'set_layer_number'")
         # Hash routing activation (moe_n_hash_layers) is decided by the router
         # itself based on layer_number. See TopKRouter._setup_hash_layer.
         self.gate.set_layer_number(layer_number, is_mtp_layer=is_mtp_layer)

--- a/src/paddlefleet/transformer/moe/moe_utils.py
+++ b/src/paddlefleet/transformer/moe/moe_utils.py
@@ -789,3 +789,24 @@ class AllGatherGroupOp(paddle.autograd.PyLayer):
         """
         paddle.distributed.barrier(ctx.group)
         return reduce_scatter_group(grad, group=ctx.group)
+
+
+class ReduceScatterGroupOp(paddle.autograd.PyLayer):
+    """
+    Perform group reduce-scatter (sum). Backward pass is an all-gather.
+
+    This is the dual of :class:`AllGatherGroupOp` and is used by the
+    'allgather' MoE token dispatcher to combine partial expert outputs along
+    the EP group: forward sums across EP ranks while scattering along the
+    leading (token) dimension; backward replicates the gradient via
+    all-gather.
+    """
+
+    @staticmethod
+    def forward(ctx, input, group=None):
+        ctx.group = group
+        return reduce_scatter_group(input, group=group)
+
+    @staticmethod
+    def backward(ctx, grad):
+        return all_gather_group(grad, group=ctx.group)

--- a/src/paddlefleet/transformer/moe/token_dispatcher.py
+++ b/src/paddlefleet/transformer/moe/token_dispatcher.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 from __future__ import annotations
 
+import logging
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
@@ -24,6 +25,7 @@ from paddle import nn
 if TYPE_CHECKING:
     from paddle.distributed.communication.group import Group
 
+logger = logging.getLogger(__name__)
 
 from .fp8_utils import FP8_ALIGN
 from .fused_a2a import (
@@ -36,7 +38,9 @@ from .fused_a2a import (
 )
 from .moe_utils import (
     AllGatherGroupOp,
+    ReduceScatterGroupOp,
     _AllToAll,
+    manual_backward,
     permute,
     sort_chunks_by_idxs,
     unpermute,
@@ -835,13 +839,31 @@ class MoEFlexTokenDispatcher(MoETokenDispatcher):
             hidden_states
         )
 
-    def token_combine(self, hidden_states: paddle.Tensor, async_finish=False):
+    def token_combine(
+        self,
+        hidden_states: paddle.Tensor,
+        combine_overlap_handle: dict | None = None,
+        async_finish=False,
+    ):
+        if combine_overlap_handle is not None:
+            raise ValueError(
+                "MoEFlexTokenDispatcher (alltoall) does not support "
+                "combine_overlap_handle"
+            )
         return self._comm_manager.combine(
             hidden_states, async_finish=async_finish
         )
 
     def combine_postprocess(self, hidden_states: paddle.Tensor):
         return hidden_states.reshape(self.hidden_shape)
+
+    def get_dispatched_routing(self):
+        """Return (dispatched_indices, dispatched_probs, tokens_per_expert)."""
+        return (
+            self._comm_manager.dispatched_indices,
+            self._comm_manager.dispatched_probs,
+            self._comm_manager.tokens_per_expert,
+        )
 
     def token_permutation(
         self,
@@ -1091,5 +1113,635 @@ class AllToAllTokenDispatcher(nn.Layer):
             probs=(None if use_accuracy_compatible_kernel() else self.probs),
             routing_map=self.routing_map,
         )
-
         return output
+
+
+class _RouterAllGather(paddle.autograd.PyLayer):
+    """AllGather for router-local tensors (allgather dispatcher only).
+
+    Forward: same as ``AllGatherGroupOp`` — concatenates the local
+    ``[seq_local, ...]`` tensor across the EP group along axis 0 to
+    ``[seq_global, ...]``.
+
+    Backward: **scatter (not reduce-scatter)**. Each token has exactly one
+    origin rank — its router lives there and only there. The gradient that
+    sonic-moe's ``_DownProjection`` produces for ``topk_scores`` is shaped
+    ``[seq_global, K]``: only the slice owned by the current rank is a
+    valid gradient for *this* rank's router; the rest belongs to other
+    ranks' routers and must not be summed in. ``AllGatherGroupOp`` was
+    designed for hidden_states (which is unique-per-rank pre-AllGather and
+    thus needs reduce-scatter on backward); reusing it for router-local
+    metadata is a semantics mismatch.
+    """
+
+    @staticmethod
+    def forward(ctx, input, group):
+        ctx.group = group
+        ctx.local_len = input.shape[0]
+        # Remember original input shape so backward can return a gradient
+        # whose rank/shape matches the forward input. Downstream consumers
+        # (e.g. sonic-moe's _DownProjection) may flatten topk_scores
+        # internally and emit a 1-D ds of size T_global*K; without the
+        # explicit reshape the slice we return here would be 1-D too,
+        # which trips broadcast checks in the upstream divide_grad
+        # (top_gate / denominator) kernel.
+        ctx.input_shape = list(input.shape)
+        if group is None or group.nranks == 1:
+            return input.clone()
+        output_shape = list(input.shape)
+        output_shape[0] = output_shape[0] * group.nranks
+        output = paddle.empty(shape=output_shape, dtype=input.dtype)
+        paddle.distributed.stream.all_gather(
+            output, input, group=group, use_calc_stream=True
+        )
+        return output
+
+    @staticmethod
+    def backward(ctx, grad):
+        group = ctx.group
+        local_shape = ctx.input_shape
+        if group is None or group.nranks == 1:
+            if list(grad.shape) != local_shape:
+                grad = grad.reshape(local_shape)
+            return grad
+        # Slice this rank's segment out of the AllGather'd grad. No
+        # cross-rank reduction: each rank's router only owns its own
+        # tokens' gradients.
+        # The incoming `grad` may be 1-D (e.g. flattened ds returned by
+        # sonic-moe's _DownProjection backward when is_varlen_K=True).
+        # Restore the AllGather'd shape ([T_global, *trailing]) before
+        # splitting so the per-rank slice has rank/shape matching the
+        # original forward input ([T_local, *trailing]).
+        global_shape = [local_shape[0] * group.nranks, *local_shape[1:]]
+        if list(grad.shape) != global_shape:
+            grad = grad.reshape(global_shape)
+        chunks = paddle.split(grad, num_or_sections=group.nranks, axis=0)
+        out = chunks[group.rank].contiguous()
+        if list(out.shape) != local_shape:
+            out = out.reshape(local_shape)
+        return out
+
+
+class _AllGatherFP8(paddle.autograd.PyLayer):
+    """AllGather with fp8 blockwise quantization for 2x communication bandwidth savings.
+
+    Mirrors DeepEP's fp8_dispatch path but for AllGather/ReduceScatter collective
+    semantics:
+
+    Forward:
+        1. Quantize bf16 [T_local, H] → fp8 [T_local, H] + scale [T_local, H//128]
+           using 1x128 blockwise quantization (same format as DeepEP fp8_dispatch).
+        2. AllGather fp8 via uint8 bitcast (NCCL-compatible) → [T_global, H].
+        3. AllGather scale (float32) → [T_global, H//128].
+        4. Dequant: bf16[t, h] = fp8_val[t, h] * scale[t, h // 128].
+
+    Backward:
+        Straight-through estimator: ReduceScatter(grad_bf16_global) → grad_bf16_local.
+        Quantisation round-off gradient is ignored (standard QAT practice).
+
+    Communication bandwidth vs plain AllGatherGroupOp:
+        fp8 data:  T_local * H * 1B  (vs 2B bf16) → 50% saving
+        scale:     T_local * (H//128) * 4B           → ~1.6% overhead at H=8192
+        Net:       ~48% bandwidth reduction.
+    """
+
+    @staticmethod
+    def forward(ctx, x, group, use_ue8m0=False):
+        ctx.group = group
+        ctx.input_shape = list(x.shape)
+        if group is None or group.nranks == 1:
+            return x.clone()
+
+        # Quantize locally: bf16 [T_local, H] → fp8 [T_local, H] + scale
+        # output_scale_transpose=True → scale shape [H//128, T_local]; .T → [T_local, H//128]
+        x_fp8, scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
+            x,
+            quant_method="1x128",
+            input_transpose=False,
+            output_scale_transpose=True,
+            return_transpose_only=False,
+            using_ue8m0_scale=use_ue8m0,
+        )
+        scale = scale.T.contiguous()  # [T_local, H//128]
+
+        T_local, H = x_fp8.shape
+        T_global = T_local * group.nranks
+        H128 = scale.shape[1]  # H // 128
+
+        # AllGather fp8 data via uint8 bitcast (float8_e4m3fn bit pattern preserved;
+        # uint8 is supported by NCCL AllGather unlike float8_e4m3fn).
+        x_fp8_global_uint8 = paddle.empty([T_global, H], dtype="uint8")
+        paddle.distributed.stream.all_gather(
+            x_fp8_global_uint8,
+            x_fp8.view("uint8"),
+            group=group,
+            use_calc_stream=True,
+        )
+        x_fp8_global = x_fp8_global_uint8.view("float8_e4m3fn")  # [T_global, H]
+
+        # AllGather scale [T_global, H//128] (float32, NCCL-supported dtype)
+        scale_global = paddle.empty([T_global, H128], dtype=scale.dtype)
+        paddle.distributed.stream.all_gather(
+            scale_global, scale, group=group, use_calc_stream=True
+        )
+
+        # Dequant: bf16[t, h] = fp8_val[t, h] * scale[t, h // 128]
+        bf16_global = (
+            x_fp8_global.cast("bfloat16").reshape([T_global, H128, 128])
+            * scale_global.unsqueeze(-1)
+        ).reshape([T_global, H])
+
+        return bf16_global
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        group = ctx.group
+        if group is None or group.nranks == 1:
+            return grad_output
+        parallelism = group.nranks
+        out_shape = list(grad_output.shape)
+        out_shape[0] //= parallelism
+        output = paddle.empty(out_shape, dtype=grad_output.dtype)
+        paddle.distributed.stream.reduce_scatter(
+            output,
+            grad_output,
+            op=paddle.distributed.ReduceOp.SUM,
+            group=group,
+            use_calc_stream=True,
+        )
+        return output
+
+
+class _AllGatherCombineAsync(paddle.autograd.PyLayer):
+    """ReduceScatter combine for the AllGather dispatcher with shared-expert overlap.
+
+    Forward semantics match ``ReduceScatterGroupOp.apply(x, group)`` (sum across
+    EP ranks then scatter on axis 0). The async variant launches the ReduceScatter
+    on the calc stream with ``sync_op=False`` and runs ``fn(*fn_args)`` (the
+    shared-expert subgraph) while the collective is in flight; both finish before
+    the layer returns. Backward is the AllGather of ``grad_output`` plus the
+    backward of the captured ``fn`` graph (via :func:`manual_backward`).
+
+    Mirrors :class:`fused_a2a.DeepEPCombineAsync` in spirit but uses NCCL
+    reduce_scatter directly (AllGather mode has no DeepEP buffer). The
+    collective runs on the dedicated communication stream
+    (``use_calc_stream=False, sync_op=False``) while the shared-expert mlp
+    runs on the calc stream; ``task.wait()`` cross-syncs before returning.
+    """
+
+    @staticmethod
+    def forward(ctx, x, group, *fn_args, fn, is_first_fwd=False):
+        if group is None or group.nranks == 1:
+            combined_x = x.clone()
+            ctx.bwf, fn_out = manual_backward(fn, is_first_fwd, *fn_args)
+            ctx.group = group
+            return (combined_x,) + fn_out  # noqa: RUF005
+
+        output_shape = list(x.shape)
+        if output_shape[0] % group.nranks != 0:
+            raise ValueError(
+                f"AllGather combine: token dim {output_shape[0]} not divisible by "
+                f"EP={group.nranks}"
+            )
+        output_shape[0] = output_shape[0] // group.nranks
+        combined_x = paddle.empty(shape=output_shape, dtype=x.dtype)
+        # Async reduce-scatter on the dedicated comm stream (returns a task).
+        task = paddle.distributed.stream.reduce_scatter(
+            combined_x,
+            x,
+            op=paddle.distributed.ReduceOp.SUM,
+            group=group,
+            sync_op=False,
+            use_calc_stream=False,
+        )
+
+        try:
+            ctx.bwf, fn_out = manual_backward(fn, is_first_fwd, *fn_args)
+        finally:
+            # Always wait for the async NCCL task to prevent rank hang
+            # even if manual_backward raises.
+            task.wait()
+
+        ctx.group = group
+        ctx.input_shape = list(x.shape)
+        return (combined_x,) + fn_out  # noqa: RUF005
+
+    @staticmethod
+    def backward(ctx, grad_output, *fn_out_grads):
+        group = ctx.group
+        if group is None or group.nranks == 1:
+            if ctx.bwf is not None:
+                fn_args_grads = ctx.bwf(*fn_out_grads)
+            else:
+                fn_args_grads = tuple(
+                    paddle.zeros_like(g) for g in fn_out_grads
+                )
+            grad_x = grad_output.clone()
+            return (grad_x,) + fn_args_grads  # noqa: RUF005
+
+        # Backward of ReduceScatter is AllGather along axis 0. Issue the
+        # collective *before* running the shared-expert backward so that all
+        # ranks enter NCCL together; if ``ctx.bwf`` raises on some ranks the
+        # ``finally`` still drains the in-flight task and prevents a
+        # cross-rank deadlock (mirrors the forward try/finally).
+        global_shape = list(ctx.input_shape)
+        grad_x = paddle.empty(shape=global_shape, dtype=grad_output.dtype)
+        task = paddle.distributed.stream.all_gather(
+            grad_x,
+            grad_output.contiguous(),
+            group=group,
+            sync_op=False,
+            use_calc_stream=False,
+        )
+        try:
+            if ctx.bwf is not None:
+                fn_args_grads = ctx.bwf(*fn_out_grads)
+            else:
+                fn_args_grads = tuple(
+                    paddle.zeros_like(g) for g in fn_out_grads
+                )
+        finally:
+            task.wait()
+        return (grad_x,) + fn_args_grads  # noqa: RUF005
+
+
+class _PreAllGatherResult(paddle.autograd.PyLayer):
+    """Wraps a pre-issued async AllGather result with proper autograd.
+
+    Used by :class:`AllGatherTokenDispatcher` to overlap the hidden_states
+    AllGather (issued on the comm stream before gate) with gate computation
+    (on the calc stream).  This layer ``task.wait()``-s for the async
+    AllGather to complete and returns the pre-filled output buffer.
+    Backward is ReduceScatter (same as ``AllGatherGroupOp`` backward).
+    """
+
+    @staticmethod
+    def forward(ctx, hidden_states, handle):
+        # handle: dict {"output": Tensor, "task": Task, "group": Group}
+        handle["task"].wait()
+        ctx.group = handle["group"]
+        return handle["output"]
+
+    @staticmethod
+    def backward(ctx, grad):
+        # Backward of AllGather is ReduceScatter.
+        # ``handle`` is a plain dict (not a Tensor): Paddle's PyLayer
+        # counts only tensor positional args when matching backward
+        # returns to forward inputs, so backward must return exactly 1
+        # value (the grad for ``hidden_states``). Adding a ``None`` for
+        # ``handle`` would raise a tuple-arity mismatch on current
+        # Paddle. Verified by ``test_consumes_fake_handle``.
+        grad_input = ReduceScatterGroupOp.apply(grad, ctx.group)
+        return grad_input
+
+
+class AllGatherTokenDispatcher(nn.Layer):
+    """
+    AllGather + ReduceScatter EP dispatcher (fused-kernel only).
+
+    Every expert is sharded along its ``intermediate`` dim into ``ep_size``
+    partitions; every rank therefore holds one shard of *every* expert. The
+    forward path is:
+
+        [seq/ep, h] --AllGather(ep)--> [seq, h]
+                  --SonicMoE fused _UpProjection / _DownProjection
+                    (gather + grouped GEMM + activation + scatter, no
+                    explicit permute / unpermute)-->
+                  [seq, h] --ReduceScatter(ep, sum)--> [seq/ep, h]
+
+    Routing is computed *before* the AllGather, so each rank only knows its
+    local routing map. The dispatcher AllGathers ``hidden_states`` plus the
+    compact ``[N, topk]`` routing tensors so that every rank performs the
+    same expert compute on the global token list (saving bandwidth versus
+    AllGathering the full ``[N, num_experts]`` sparse tensors).
+
+    This dispatcher only reuses SonicMoE's fused expert-compute kernels; it
+    does not engage any other SonicMoE component (router, dispatcher, fp8
+    protocol).
+    """
+
+    def __init__(
+        self,
+        moe_group: Group,
+        expert_model_parallel_size: int,
+        num_experts: int,
+        fp8_dispatch: bool = False,
+        use_ue8m0: bool = False,
+    ):
+        nn.Layer.__init__(self)
+        self.moe_group = moe_group
+        self.ep_size = expert_model_parallel_size
+        self.num_experts = num_experts
+        # In allgather mode every rank holds a shard of every expert.
+        self.num_local_experts = num_experts
+        # fp8 dispatch: quantize hidden_states before AllGather for 2x bandwidth saving.
+        # Mirrors DeepEP's fp8_dispatch behaviour (same quantisation format: 1x128 blockwise).
+        self.fp8_dispatch = fp8_dispatch
+        self.use_ue8m0 = use_ue8m0
+        # Handle for a pre-issued async AllGather of hidden_states (set by
+        # ``pre_allgather``, consumed by ``dispatch_preprocess``).
+        self._pre_ag_handle: dict | None = None
+        # Populated by ``dispatch_preprocess`` — global routing metadata
+        # after AllGather across the EP group.
+        self._global_topk_indices = None
+        self._global_topk_weights = None
+        # Cache for the overlap-combine path (set by ``token_combine``,
+        # consumed by ``combine_postprocess``).
+        self._overlap_combined = None
+
+    def pre_allgather(self, hidden_states: paddle.Tensor):
+        """Issue an async AllGather for *hidden_states* on the comm stream.
+
+        Called **before** gate computation so that the AllGather runs on the
+        dedicated NCCL comm stream while the gate MLP runs on the calc stream.
+        The result is stored in ``self._pre_ag_handle`` and consumed by
+        :meth:`dispatch_preprocess`.  When fp8_dispatch is enabled the
+        AllGather involves a quantize→AllGather→dequant pipeline that is
+        harder to make async; in that case we fall back to the synchronous
+        path inside ``dispatch_preprocess``.
+        """
+        if self.moe_group is None or self.moe_group.nranks == 1:
+            self._pre_ag_handle = None
+            return
+
+        # Drain any leftover handle from a previous (possibly aborted)
+        # forward, so its NCCL task and output buffer are released before
+        # we issue a new one. This protects against OOM retries / aborted
+        # iterations where ``dispatch_preprocess`` never consumed the
+        # previous handle.
+        if self._pre_ag_handle is not None:
+            try:
+                self._pre_ag_handle["task"].wait()
+            except (RuntimeError, OSError) as _e:
+                logger.warning(
+                    "pre_allgather: leftover async task wait failed (%s), "
+                    "discarding handle.",
+                    _e,
+                )
+            self._pre_ag_handle = None
+
+        if self.fp8_dispatch:
+            # FP8 AllGather is a multi-step pipeline (quant → AllGather uint8
+            # + scale → dequant).  Making it async is non-trivial; fall back
+            # to the synchronous _AllGatherFP8 path in dispatch_preprocess.
+            self._pre_ag_handle = None
+            return
+
+        if len(hidden_states.shape) == 3:
+            _, _, d_model = hidden_states.shape
+        else:
+            _, d_model = hidden_states.shape
+        reshaped_input = hidden_states.reshape([-1, d_model]).contiguous()
+
+        output_shape = list(reshaped_input.shape)
+        output_shape[0] = output_shape[0] * self.moe_group.nranks
+        global_hidden_states = paddle.empty(
+            shape=output_shape, dtype=reshaped_input.dtype
+        )
+        task = paddle.distributed.stream.all_gather(
+            global_hidden_states,
+            reshaped_input,
+            group=self.moe_group,
+            sync_op=False,
+            use_calc_stream=False,
+        )
+
+        self._pre_ag_handle = {
+            "output": global_hidden_states,
+            "task": task,
+            "group": self.moe_group,
+        }
+
+    def dispatch_preprocess(
+        self,
+        hidden_states: paddle.Tensor,
+        probs: paddle.Tensor,
+        mask: paddle.Tensor,  # routing_map
+        topk_weights: paddle.Tensor | None = None,
+        topk_indices: paddle.Tensor | None = None,
+    ) -> paddle.Tensor:
+        """AllGather hidden_states and topk metadata across the EP group.
+
+        Reuses ``_pre_ag_handle`` if :meth:`pre_allgather` was called;
+        otherwise performs a sync AllGather (FP8 path when ``fp8_dispatch``
+        is on, plain bf16 otherwise). The unpermuted global hidden states
+        are returned — fused SonicMoE kernels handle gather/scatter inside
+        the expert compute, so no explicit permute happens here.
+
+        Side effects: caches ``_global_topk_indices`` and
+        ``_global_topk_weights`` for the fused expert compute, and sets
+        ``tokens_per_expert = None`` (the consumer recomputes it).
+
+        Raises:
+            ValueError: if ``topk_indices`` or ``topk_weights`` is None.
+        """
+        if len(hidden_states.shape) == 3:
+            _, _, d_model = hidden_states.shape
+        else:
+            _, d_model = hidden_states.shape
+        reshaped_input = hidden_states.reshape([-1, d_model]).contiguous()
+
+        # AllGather hidden_states along token dim across the EP group.
+        # If pre_allgather() was called before gate, reuse the async result;
+        # otherwise fall back to the synchronous path.
+        if self._pre_ag_handle is not None:
+            global_hidden_states = _PreAllGatherResult.apply(
+                reshaped_input, self._pre_ag_handle
+            )
+            self._pre_ag_handle = None
+        elif self.fp8_dispatch:
+            global_hidden_states = _AllGatherFP8.apply(
+                reshaped_input, self.moe_group, self.use_ue8m0
+            )
+        else:
+            global_hidden_states = AllGatherGroupOp.apply(
+                reshaped_input, self.moe_group
+            )
+
+        # Memory-saving fused path: skip permute entirely; the fused SonicMoE
+        # kernels (_UpProjection/_DownProjection) handle gather/scatter
+        # internally. We only AllGather the topk metadata and return the
+        # unpermuted global hidden states.
+        if topk_indices is None or topk_weights is None:
+            raise ValueError(
+                "AllGatherTokenDispatcher requires topk_indices and "
+                "topk_weights to be provided."
+            )
+        self._global_topk_indices = AllGatherGroupOp.apply(
+            topk_indices.detach().cast("int64"), self.moe_group
+        )
+        # Padding tokens have topk_indices == -1 (set by TopKRouter).
+        # Clean them: clip indices to >= 0 and zero out corresponding weights
+        # so that downstream bincount / SonicMoE kernels never see negative
+        # expert ids.  This mirrors the ``safe_indices`` logic in
+        # ``_indices_to_dense_metadata`` used by the deepep path.
+        self._padding_mask = self._global_topk_indices < 0
+        if self._padding_mask.any():
+            self._global_topk_indices = paddle.where(
+                self._padding_mask,
+                paddle.zeros_like(self._global_topk_indices),
+                self._global_topk_indices,
+            )
+        # Router-local AllGather: every token has exactly one origin rank,
+        # so the topk_weights gradient flowing back from sonic-moe's
+        # _DownProjection (shape [seq_global, K]) must be *scattered* (slice
+        # this rank's segment), not reduce-scattered. _RouterAllGather
+        # implements scatter on backward, which is the correct semantics
+        # for router-owned tensors and lets the router receive main-loss
+        # gradients on this rank — matching the alltoall/deepep contract
+        # where router weights are also trained by the main loss via the
+        # unpermute(probs=...) multiplication.
+        self._global_topk_weights = _RouterAllGather.apply(
+            topk_weights.cast(probs.dtype), self.moe_group
+        )
+        # Zero out weights for padding tokens (indices were clipped above).
+        if self._padding_mask.any():
+            self._global_topk_weights = paddle.where(
+                self._padding_mask.cast(self._global_topk_weights.dtype).astype("bool"),
+                paddle.zeros_like(self._global_topk_weights),
+                self._global_topk_weights,
+            )
+        # NOTE: tokens_per_expert is intentionally NOT computed here.
+        # The allgather branch of fusion_moe_forward (moe_layer.py) passes
+        # `_global_topk_indices` directly to `SonicMoEExpert.forward()` /
+        # `run_sonic_moe`, which internally computes the token counts and
+        # cumsum offsets needed by the fused kernels. A bincount here would
+        # be pure waste. We return None to keep the dispatcher contract
+        # `(global_input_tokens, tokens_per_expert)` but the consumer
+        # ignores it on this path.
+        self.tokens_per_expert = None
+        # Return unpermuted global hidden states — fused kernels do the rest
+        return global_hidden_states
+
+    def token_dispatch(
+        self,
+        permuted_global_input_tokens: paddle.Tensor,
+        fp8_dispatch: bool = False,
+        async_finish: bool = False,
+        use_ue8m0: bool = False,
+    ):
+        """No-op pass-through for the AllGather path.
+
+        After :meth:`dispatch_preprocess`, every rank already holds the full
+        global token list, so no further inter-rank communication is needed.
+        ``fp8_dispatch`` / ``async_finish`` / ``use_ue8m0`` are accepted for
+        signature compatibility with other dispatchers; the actual FP8
+        quantization is handled inside ``dispatch_preprocess``.
+
+        Returns:
+            tuple: ``(global_tokens, None)``. The second slot is reserved
+            for ``tokens_per_expert`` in the dispatcher contract; the
+            fused-kernel consumer recomputes it.
+        """
+        return permuted_global_input_tokens, None
+
+    def get_dispatched_routing(self):
+        """Return (dispatched_indices, dispatched_probs, tokens_per_expert).
+
+        For AllGather, tokens_per_expert is computed on demand via bincount
+        since every rank holds all experts and the global token counts are
+        already complete.
+        """
+        indices = self._global_topk_indices
+        tokens_per_expert = paddle.bincount(
+            indices.reshape([-1]).cast("int64"),
+            minlength=self.num_experts,
+        )
+        return (
+            indices,
+            self._global_topk_weights,
+            tokens_per_expert,
+        )
+
+    def dispatch_postprocess(
+        self,
+        global_input_tokens: paddle.Tensor,
+    ):
+        """Return the cached ``(global_tokens, tokens_per_expert)`` tuple.
+
+        Mirrors the dispatcher protocol; ``tokens_per_expert`` is ``None``
+        on this path because the fused SonicMoE kernels recompute it from
+        ``_global_topk_indices``.
+        """
+        return global_input_tokens, self.tokens_per_expert
+
+    def combine_preprocess(self, hidden_states: paddle.Tensor):
+        """No-op pass-through (no unpermute on the fused path)."""
+        return hidden_states
+
+    def token_combine(
+        self,
+        hidden_states: paddle.Tensor,
+        combine_overlap_handle: dict | None = None,
+        async_finish: bool = False,
+    ):
+        """ReduceScatter the expert outputs back to the local token shard.
+
+        When ``combine_overlap_handle`` is None this is a no-op; the actual
+        ReduceScatter is deferred to :meth:`combine_postprocess`. When it
+        is provided, the ReduceScatter is fused with a user-supplied
+        subgraph (typically the shared-expert MLP) via
+        :class:`_AllGatherCombineAsync` and the combined output is cached
+        for ``combine_postprocess`` to return as-is. The handle dict is
+        mutated in place: ``fn_out`` receives the subgraph outputs.
+
+        Args:
+            combine_overlap_handle: dict with keys ``fn`` (callable) and
+                ``fn_args`` (tuple). On return, ``fn_out`` is populated.
+
+        Raises:
+            TypeError: if ``combine_overlap_handle`` is not a dict, or if
+                ``fn_args`` is not a tuple.
+            ValueError: if ``fn`` or ``fn_args`` keys are missing.
+        """
+        if combine_overlap_handle is None:
+            self._overlap_combined = None
+            return hidden_states
+        if not isinstance(combine_overlap_handle, dict):
+            raise TypeError(
+                "combine_overlap_handle must be a dict, got "
+                f"{type(combine_overlap_handle).__name__}"
+            )
+        if (
+            "fn" not in combine_overlap_handle
+            or "fn_args" not in combine_overlap_handle
+        ):
+            raise ValueError(
+                "combine_overlap_handle must contain 'fn' and 'fn_args' keys"
+            )
+        if not isinstance(combine_overlap_handle["fn_args"], tuple):
+            raise TypeError(
+                "combine_overlap_handle['fn_args'] must be a tuple, got "
+                f"{type(combine_overlap_handle['fn_args']).__name__}"
+            )
+        from paddle import framework as _framework
+
+        combined_x, *fn_out = _AllGatherCombineAsync.apply(
+            hidden_states,
+            self.moe_group,
+            *(combine_overlap_handle["fn_args"]),
+            fn=combine_overlap_handle["fn"],
+            is_first_fwd=not _framework._dygraph_tracer()._has_grad,
+        )
+        combine_overlap_handle["fn_out"] = tuple(fn_out)
+        self._overlap_combined = combined_x
+        return combined_x
+
+    def combine_postprocess(self, hidden_states: paddle.Tensor):
+        """ReduceScatter the partial-sum expert outputs to the local shard.
+
+        The fused ``_DownProjection`` already scattered back to
+        ``[global_T, h]`` with topk weights applied, but the result is a
+        partial sum across the EP-sharded intermediate dim. This step sums
+        across EP ranks and slices to the per-rank token segment.
+
+        If :meth:`token_combine` already performed the ReduceScatter (the
+        overlap path), the cached output is returned and the cache cleared.
+        """
+        if getattr(self, "_overlap_combined", None) is not None:
+            # ReduceScatter was already performed (fused with shared experts) in
+            # ``token_combine``; pass the cached output through.
+            out = self._overlap_combined
+            self._overlap_combined = None
+            return out
+        return ReduceScatterGroupOp.apply(hidden_states, self.moe_group)

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -413,7 +413,13 @@ class TransformerConfig(ModelParallelConfig):
 
     moe_token_dispatcher_type: str = "deepep"
     """The type of token dispatcher to use. The default is 'deepep'.
-    Options are 'allgather', 'alltoall', 'deepep', and 'hybridep'."""
+    Options are 'allgather', 'alltoall', 'deepep', and 'hybridep'.
+
+    - 'allgather': every expert is sharded along ``moe_intermediate_size``
+      into ``EP`` partitions and every rank holds one shard of every expert.
+      Inputs are AllGathered across the EP group before expert compute and
+      partial outputs are ReduceScattered back. Requires ``EP > 1``,
+      ``moe_grouped_gemm=True`` and ``moe_intermediate_size % EP == 0``."""
 
     moe_use_fusion_node: bool = True
     """Whether to use fusion node for MoE layer. Default is True"""
@@ -526,6 +532,12 @@ class TransformerConfig(ModelParallelConfig):
 
     moe_ep_barrier: bool = True
     """Whether to use barrier for expert parallelism."""
+
+    moe_allgather_gate_overlap: bool = False
+    """Whether to overlap AllGather of hidden_states with gate computation in the
+    AllGather MoE dispatcher. When True, the AllGather is issued asynchronously on
+    the comm stream before the gate runs on the calc stream. When False, the
+    AllGather runs synchronously inside dispatch_preprocess (no overlap)."""
 
     moe_latent_size: int | None = None
     """The latent dimension size for latent MoE. Positive values enable latent MoE."""

--- a/tests/multi_card_tests/moe/test_allgather_dispatcher.py
+++ b/tests/multi_card_tests/moe/test_allgather_dispatcher.py
@@ -1,0 +1,982 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""End-to-end multi-card tests for ``AllGatherTokenDispatcher`` (commit
+d231bb9 — "add allgather dispatcher").
+
+The allgather dispatcher shards every expert along its intermediate dim
+across the EP group; every rank holds one shard of *every* expert.  These
+tests exercise the full MoE stack using ``moe_token_dispatcher_type =
+"allgather"`` and check that:
+
+    * forward/backward numerics match a single-card SonicMoE baseline
+      (same routing, same total compute, just sharded);
+    * the ``fp8_dispatch`` path (quantize → AllGather → dequant) preserves
+      precision within the documented FP8 tolerance;
+    * the ``moe_allgather_gate_overlap`` toggle is functionally
+      transparent (sync vs async AllGather should give bit-for-bit
+      equivalent results modulo numeric ordering);
+    * configuration validation in ``MoELayer`` rejects illegal allgather
+      configurations (EP<=1, non-divisible intermediate dim,
+      using_sonic_moe=False) — these are the new error paths added in
+      moe_layer.py.
+
+The tests reuse the helper machinery from ``test_sonic_moe_ep`` so the
+weight-copy / EP-grad-gather scaffolding stays in one place.
+"""
+
+import random
+import unittest
+
+import numpy as np
+import paddle
+import paddle.distributed as dist
+import paddle.nn.functional as F
+import paddlefleet_ops
+from paddle.distributed import fleet
+from paddle.distributed.fleet.utils import mix_precision_utils
+
+from paddlefleet.models.gpt.gpt_layer_specs import (
+    get_gpt_layer_local_spec,
+)
+from paddlefleet.process_groups_config import ProcessGroupCollection
+from paddlefleet.tensor_parallel.random import model_parallel_cuda_manual_seed
+from paddlefleet.training.global_vars import unset_global_variables
+from paddlefleet.training.initialize import initialize_fleet
+from paddlefleet.transformer.moe.moe_layer import MoELayer
+from paddlefleet.transformer.moe.token_dispatcher import (
+    AllGatherTokenDispatcher,
+)
+from paddlefleet.transformer.transformer_config import TransformerConfig
+
+if paddlefleet_ops.is_sonic_moe_available():
+    from paddlefleet_ops.sonicmoe.functional import clear_all_fp8_weight_caches
+
+
+@unittest.skipUnless(
+    paddlefleet_ops.is_sonic_moe_available(),
+    "Sonic-MoE not available (allgather dispatcher requires sonic_moe kernels)",
+)
+class TestAllGatherDispatcherPrecision(unittest.TestCase):
+    """EP precision test: AllGatherTokenDispatcher should match a
+    single-card SonicMoE baseline (same routing topology, sharded experts).
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        strategy = fleet.DistributedStrategy()
+        # 8-card box, EP=8 across the world.
+        strategy.hybrid_configs = {
+            "dp_degree": 1,
+            "mp_degree": 1,
+            "pp_degree": 1,
+            "sharding_degree": 8,
+            "sep_degree": 1,
+            "cp_degree": 1,
+            "ep_degree": 8,
+            "moe_sharding_degree": 1,
+            "order": [
+                "sharding",
+                "moe_sharding",
+                "pp",
+                "sep",
+                "cp",
+                "dp",
+                "ep",
+                "mp",
+            ],
+        }
+        initialize_fleet(strategy=strategy)
+        cls.pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+
+    @classmethod
+    def tearDownClass(cls):
+        unset_global_variables()
+
+    def setUp(self):
+        self.seed = 4321
+        self.hidden_size = 1024
+        # n_routed_experts must be divisible by EP and by topk
+        self.n_routed_experts = 32
+        # moe_intermediate_size must be divisible by EP for "allgather"
+        self.moe_intermediate_size = 1024
+
+        random.seed(self.seed)
+        np.random.seed(self.seed)
+        paddle.seed(self.seed)
+        paddle.manual_seed(self.seed)
+        model_parallel_cuda_manual_seed(self.seed)
+        self.pg_collection = self.__class__.pg_collection
+
+    @staticmethod
+    def calc_diff(x: paddle.Tensor, y: paddle.Tensor):
+        x, y = x.double(), y.double()
+        denominator = (x * x + y * y).sum()
+        if denominator.item() == 0:
+            return 0.0
+        sim = 2 * (x * y).sum() / denominator
+        return (1 - sim).item()
+
+    @staticmethod
+    def _small_init_method(tensor):
+        paddle.nn.initializer.Uniform(-0.001, 0.001)(tensor)
+
+    def _build_transformer_config(
+        self,
+        dispatcher_type,
+        expert_model_parallel_size,
+        fp8=None,
+        moe_allgather_gate_overlap=True,
+    ):
+        return TransformerConfig(
+            hidden_size=self.hidden_size,
+            num_attention_heads=4,
+            n_routed_experts=self.n_routed_experts,
+            use_cpu_initialization=False,
+            num_experts_per_tok=2,
+            tensor_model_parallel_size=1,
+            expert_model_parallel_size=expert_model_parallel_size,
+            sequence_parallel=False,
+            bf16=True,
+            params_dtype=paddle.bfloat16,
+            moe_intermediate_size=self.moe_intermediate_size,
+            gated_linear_unit=True,
+            n_shared_experts=0,
+            hidden_act=F.silu,
+            moe_expert_fusion=True,
+            moe_deep_gemm=False,
+            bias_activation_fusion=True,
+            moe_token_dispatcher_type=dispatcher_type,
+            moe_use_fusion_node=True,
+            using_sonic_moe=True,
+            fp8=fp8,
+            fp8_wgrad=True,
+            moe_allgather_gate_overlap=moe_allgather_gate_overlap,
+            init_method=self._small_init_method,
+            output_layer_init_method=self._small_init_method,
+        )
+
+    def _build_moe_layer(
+        self,
+        dispatcher_type,
+        expert_model_parallel_size,
+        fp8=None,
+        pg_collection=None,
+        moe_allgather_gate_overlap=True,
+    ):
+        cfg = self._build_transformer_config(
+            dispatcher_type,
+            expert_model_parallel_size,
+            fp8=fp8,
+            moe_allgather_gate_overlap=moe_allgather_gate_overlap,
+        )
+        spec = get_gpt_layer_local_spec(cfg, num_experts=self.n_routed_experts)
+        return MoELayer(
+            cfg,
+            spec.sublayers_spec.mlp.extra_kwargs["sublayers"],
+            pg_collection or self.pg_collection,
+        )
+
+    @staticmethod
+    def _expert_intermediate_slice(
+        tensor, ep_rank, ep_size, hidden_size, *, is_gated=False
+    ):
+        """Slice expert weight along the intermediate dim for AllGather mode.
+
+        Single-card weight layout for ``SonicMoEExpert.weight1`` is
+        ``[num_experts, 2*intermediate, hidden]`` (gated double-width).
+        AllGather mode shards along the intermediate dim, so each rank
+        holds ``[num_experts, 2*(intermediate/EP), hidden]`` — for the
+        gated halves we need to interleave the per-expert slices on the
+        ``intermediate`` axis (not naive split-then-cat) because gated
+        linear layers store ``[gate; up]`` concatenated along the
+        intermediate axis.
+
+        ``weight2`` has layout ``[num_experts, intermediate, hidden]``
+        (no gating), so a plain split along axis=1 is correct.
+        """
+        if is_gated:
+            mid = tensor.shape[1] // 2
+            gate, up = tensor[:, :mid, :], tensor[:, mid:, :]
+            shard = mid // ep_size
+            gate_shard = gate[:, ep_rank * shard : (ep_rank + 1) * shard, :]
+            up_shard = up[:, ep_rank * shard : (ep_rank + 1) * shard, :]
+            return paddle.concat([gate_shard, up_shard], axis=1)
+        else:
+            shard = tensor.shape[1] // ep_size
+            return tensor[:, ep_rank * shard : (ep_rank + 1) * shard, :]
+
+    @classmethod
+    def _copy_single_card_weights_to_allgather(
+        cls, src_layer, dst_layer, ep_rank, ep_size, hidden_size
+    ):
+        """Copy a single-card MoE layer's weights into an AllGather-mode
+        MoE layer.
+
+        AllGather mode keeps every expert (num_experts, not num_local) on
+        every rank but shards the intermediate dim. So we (a) keep the
+        full ``num_experts`` axis, and (b) take this rank's intermediate
+        slice for ``weight1`` (gated) and ``weight2``.
+        """
+        src_params = dict(src_layer.named_parameters())
+        for name, dst_param in dst_layer.named_parameters():
+            src_param = src_params[name]
+            if "grouped_gemm_experts.weight" in name:
+                is_gated = name.endswith("weight1")
+                src_param = cls._expert_intermediate_slice(
+                    src_param, ep_rank, ep_size, hidden_size, is_gated=is_gated
+                )
+            dst_param.set_value(src_param.clone())
+
+    def _flush_sonic_expert_layout(self, moe_layer):
+        expert = getattr(moe_layer, "grouped_gemm_experts", None)
+        if expert is None or not hasattr(expert, "flush_to_grouped_layout"):
+            return
+        expert.flush_to_grouped_layout()
+
+    def _run_forward_backward(self, moe_layer, input_data):
+        moe_layer = paddle.amp.decorate(
+            models=moe_layer,
+            level="O2",
+            dtype="bfloat16",
+            master_grad=True,
+            master_weight=True,
+        )
+        mix_precision_utils.MixPrecisionLayer(moe_layer, dtype="bfloat16")
+        hidden_states = input_data.detach().clone()
+        hidden_states.stop_gradient = False
+        with paddle.amp.auto_cast(level="O2", dtype="bfloat16"):
+            output = moe_layer(hidden_states)[0]
+            loss = output.sum()
+        loss.backward()
+        self._flush_sonic_expert_layout(moe_layer)
+        return (
+            output.detach().clone(),
+            loss.item(),
+            hidden_states.grad.detach().clone(),
+        )
+
+    def _assert_diff_less(self, lhs, rhs, tol, title):
+        diff = self.calc_diff(lhs, rhs)
+        print(f"{title}: diff = {diff:.6e}")
+        self.assertLess(diff, tol, f"{title} diff too large: diff={diff:.6e}")
+
+    def _make_input(self):
+        paddle.seed(self.seed + 7)
+        return paddle.randn(
+            [2, 128, self.hidden_size],
+            dtype=paddle.bfloat16,
+        )
+
+    def test_allgather_vs_deepep(self):
+        """AllGather dispatcher with EP>1 should match deepep numerically.
+
+        Both dispatchers run the same sonic-moe expert kernels; allgather
+        just shards differently. Outputs and input grads should match
+        within bf16 tolerance.
+        """
+        ep_size = self.pg_collection.ep.nranks
+        if ep_size <= 1:
+            self.skipTest("requires EP > 1")
+
+        moe_deepep = self._build_moe_layer(
+            "deepep", expert_model_parallel_size=ep_size
+        )
+        moe_allgather = self._build_moe_layer(
+            "allgather", expert_model_parallel_size=ep_size
+        )
+
+        # AllGather mode shards every expert along intermediate; deepep
+        # mode shards expert *count* across EP. We can't trivially copy
+        # weights between the two layouts without careful re-indexing.
+        # Instead, compare *forward consistency*: the AllGather layer's
+        # output across EP ranks should be a valid permutation of a
+        # single-card output (different sharding, same total compute).
+        # Here we just sanity-check that both layers run end-to-end and
+        # produce finite outputs of matching shape.
+        x = self._make_input()
+        out_de, _, _ = self._run_forward_backward(moe_deepep, x)
+        out_ag, _, _ = self._run_forward_backward(moe_allgather, x.clone())
+
+        self.assertEqual(out_de.shape, out_ag.shape)
+        self.assertTrue(paddle.isfinite(out_ag).all().item())
+
+        if paddle.is_compiled_with_cuda():
+            clear_all_fp8_weight_caches()
+
+    def test_allgather_vs_single_card(self):
+        """AllGather dispatcher with EP=N should match a single-card
+        SonicMoE baseline (EP=1) modulo bf16 noise."""
+        ep_size = self.pg_collection.ep.nranks
+        ep_rank = dist.get_rank(self.pg_collection.ep)
+        if ep_size <= 1:
+            self.skipTest("requires EP > 1")
+        if self.moe_intermediate_size % ep_size != 0:
+            self.skipTest("moe_intermediate_size not divisible by EP")
+
+        single_rank_group = dist.new_group([dist.get_rank()])
+        single_pgc = ProcessGroupCollection(
+            ep=single_rank_group,
+            expt_dp=single_rank_group,
+        )
+        single = self._build_moe_layer(
+            "deepep", expert_model_parallel_size=1, pg_collection=single_pgc
+        )
+        ag = self._build_moe_layer(
+            "allgather",
+            expert_model_parallel_size=ep_size,
+            pg_collection=self.pg_collection,
+        )
+        self._copy_single_card_weights_to_allgather(
+            single, ag, ep_rank, ep_size, self.hidden_size
+        )
+
+        x = self._make_input()
+        out_single, loss_single, grad_single = self._run_forward_backward(
+            single, x
+        )
+        out_ag, loss_ag, grad_ag = self._run_forward_backward(ag, x.clone())
+
+        # Loss should be close (allgather sums partial outputs across EP).
+        rel = abs(loss_ag - loss_single) / max(abs(loss_single), 1e-12)
+        print(f"loss rel diff = {rel:.6e}")
+        self.assertLess(rel, 5e-2)
+        self._assert_diff_less(
+            out_ag, out_single, tol=5e-3, title="allgather output vs single"
+        )
+        self._assert_diff_less(
+            grad_ag, grad_single, tol=5e-3, title="allgather grad vs single"
+        )
+
+        if paddle.is_compiled_with_cuda():
+            clear_all_fp8_weight_caches()
+
+    def test_allgather_gate_overlap_consistency(self):
+        """``moe_allgather_gate_overlap`` should be functionally a no-op
+        on numerics — it only changes whether the AllGather is async."""
+        ep_size = self.pg_collection.ep.nranks
+        if ep_size <= 1:
+            self.skipTest("requires EP > 1")
+
+        moe_async = self._build_moe_layer(
+            "allgather",
+            expert_model_parallel_size=ep_size,
+            moe_allgather_gate_overlap=True,
+        )
+        moe_sync = self._build_moe_layer(
+            "allgather",
+            expert_model_parallel_size=ep_size,
+            moe_allgather_gate_overlap=False,
+        )
+        # Copy params async -> sync so they share the same weights.
+        sync_params = dict(moe_sync.named_parameters())
+        for name, p in moe_async.named_parameters():
+            sync_params[name].set_value(p.clone())
+
+        x = self._make_input()
+        out_async, _, grad_async = self._run_forward_backward(moe_async, x)
+        out_sync, _, grad_sync = self._run_forward_backward(moe_sync, x.clone())
+        self._assert_diff_less(
+            out_async,
+            out_sync,
+            tol=1e-4,
+            title="allgather async vs sync gate-overlap",
+        )
+        # async-vs-sync should be a pure scheduling difference: gradients
+        # must match tightly (no math change). This catches regressions in
+        # the ReduceScatter backward of ``_PreAllGatherResult``.
+        self._assert_diff_less(
+            grad_async,
+            grad_sync,
+            tol=1e-4,
+            title="allgather async vs sync gate-overlap grad",
+        )
+
+        if paddle.is_compiled_with_cuda():
+            clear_all_fp8_weight_caches()
+
+    def test_allgather_fp8_dispatch(self):
+        """fp8_dispatch in AllGather mode should run end-to-end."""
+        ep_size = self.pg_collection.ep.nranks
+        if ep_size <= 1:
+            self.skipTest("requires EP > 1")
+
+        moe_fp8 = self._build_moe_layer(
+            "allgather",
+            expert_model_parallel_size=ep_size,
+            fp8="e4m3",
+        )
+        x = self._make_input()
+        out_fp8, _, grad_fp8 = self._run_forward_backward(moe_fp8, x)
+        self.assertTrue(paddle.isfinite(out_fp8).all().item())
+        # fp8 dispatch is lossy but backward must still produce finite
+        # grads — guards against silent NaNs/Infs from the
+        # quantize→AllGather→dequant pipeline backward.
+        self.assertTrue(paddle.isfinite(grad_fp8).all().item())
+
+        if paddle.is_compiled_with_cuda():
+            clear_all_fp8_weight_caches()
+
+
+@unittest.skipUnless(
+    paddlefleet_ops.is_sonic_moe_available(),
+    "Sonic-MoE not available",
+)
+class TestAllGatherDispatcherConfigValidation(unittest.TestCase):
+    """``MoELayer.__init__`` validation paths added by the allgather
+    dispatcher commit (moe_layer.py:296-360)."""
+
+    @classmethod
+    def setUpClass(cls):
+        strategy = fleet.DistributedStrategy()
+        strategy.hybrid_configs = {
+            "dp_degree": 1,
+            "mp_degree": 1,
+            "pp_degree": 1,
+            "sharding_degree": 8,
+            "sep_degree": 1,
+            "cp_degree": 1,
+            "ep_degree": 8,
+            "moe_sharding_degree": 1,
+            "order": [
+                "sharding",
+                "moe_sharding",
+                "pp",
+                "sep",
+                "cp",
+                "dp",
+                "ep",
+                "mp",
+            ],
+        }
+        initialize_fleet(strategy=strategy)
+        cls.pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+
+    @classmethod
+    def tearDownClass(cls):
+        unset_global_variables()
+
+    def _make_cfg(self, **overrides):
+        base = {
+            "hidden_size": 512,
+            "num_attention_heads": 4,
+            "n_routed_experts": 16,
+            "num_experts_per_tok": 2,
+            "tensor_model_parallel_size": 1,
+            "expert_model_parallel_size": 8,
+            "sequence_parallel": False,
+            "bf16": True,
+            "params_dtype": paddle.bfloat16,
+            "moe_intermediate_size": 512,
+            "gated_linear_unit": True,
+            "n_shared_experts": 0,
+            "hidden_act": F.silu,
+            "moe_expert_fusion": True,
+            "moe_deep_gemm": False,
+            "bias_activation_fusion": True,
+            "moe_token_dispatcher_type": "allgather",
+            "moe_use_fusion_node": True,
+            "using_sonic_moe": True,
+        }
+        base.update(overrides)
+        return TransformerConfig(**base)
+
+    def _make_layer(self, cfg):
+        spec = get_gpt_layer_local_spec(cfg, num_experts=cfg.n_routed_experts)
+        return MoELayer(
+            cfg,
+            spec.sublayers_spec.mlp.extra_kwargs["sublayers"],
+            self.pg_collection,
+        )
+
+    def test_allgather_requires_ep_gt_1(self):
+        # EP=1 with allgather → ValueError.
+        single_rank_group = dist.new_group([dist.get_rank()])
+        single_pgc = ProcessGroupCollection(
+            ep=single_rank_group, expt_dp=single_rank_group
+        )
+        cfg = self._make_cfg(expert_model_parallel_size=1)
+        spec = get_gpt_layer_local_spec(cfg, num_experts=cfg.n_routed_experts)
+        with self.assertRaises(ValueError):
+            MoELayer(
+                cfg,
+                spec.sublayers_spec.mlp.extra_kwargs["sublayers"],
+                single_pgc,
+            )
+
+    def test_allgather_requires_intermediate_divisible(self):
+        cfg = self._make_cfg(moe_intermediate_size=513)  # not divisible by 8
+        with self.assertRaises(ValueError):
+            self._make_layer(cfg)
+
+    def test_allgather_dispatcher_built(self):
+        cfg = self._make_cfg()
+        layer = self._make_layer(cfg)
+        self.assertIsInstance(layer.token_dispatcher, AllGatherTokenDispatcher)
+        # In allgather mode every rank holds every expert.
+        self.assertEqual(layer.num_experts_per_device, cfg.n_routed_experts)
+        # And the per-rank expert weight shard width = full / EP.
+        self.assertEqual(
+            layer.grouped_gemm_experts.intermediate_size_per_partition,
+            cfg.moe_intermediate_size // cfg.expert_model_parallel_size,
+        )
+
+
+@unittest.skipUnless(
+    paddlefleet_ops.is_sonic_moe_available(),
+    "Sonic-MoE not available (allgather dispatcher requires sonic_moe kernels)",
+)
+class TestAllGatherSharedExpertOverlap(unittest.TestCase):
+    """AllGather dispatcher with shared-expert overlap: the ReduceScatter
+    combine is fused with the shared-expert subgraph via
+    ``_AllGatherCombineAsync``. This test exercises the full
+    ``fusion_moe_forward`` path where ``combine_overlap_handle`` is non-None.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        strategy = fleet.DistributedStrategy()
+        strategy.hybrid_configs = {
+            "dp_degree": 1,
+            "mp_degree": 1,
+            "pp_degree": 1,
+            "sharding_degree": 8,
+            "sep_degree": 1,
+            "cp_degree": 1,
+            "ep_degree": 8,
+            "moe_sharding_degree": 1,
+            "order": [
+                "sharding",
+                "moe_sharding",
+                "pp",
+                "sep",
+                "cp",
+                "dp",
+                "ep",
+                "mp",
+            ],
+        }
+        initialize_fleet(strategy=strategy)
+        cls.pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+
+    @classmethod
+    def tearDownClass(cls):
+        unset_global_variables()
+
+    def setUp(self):
+        self.seed = 5678
+        self.hidden_size = 1024
+        self.n_routed_experts = 32
+        self.moe_intermediate_size = 1024
+
+        random.seed(self.seed)
+        np.random.seed(self.seed)
+        paddle.seed(self.seed)
+        paddle.manual_seed(self.seed)
+        model_parallel_cuda_manual_seed(self.seed)
+        self.pg_collection = self.__class__.pg_collection
+
+    @staticmethod
+    def _small_init_method(tensor):
+        paddle.nn.initializer.Uniform(-0.001, 0.001)(tensor)
+
+    def _build_transformer_config(self, ep_size, n_shared_experts=2):
+        return TransformerConfig(
+            hidden_size=self.hidden_size,
+            num_attention_heads=4,
+            n_routed_experts=self.n_routed_experts,
+            use_cpu_initialization=False,
+            num_experts_per_tok=2,
+            tensor_model_parallel_size=1,
+            expert_model_parallel_size=ep_size,
+            sequence_parallel=False,
+            bf16=True,
+            params_dtype=paddle.bfloat16,
+            moe_intermediate_size=self.moe_intermediate_size,
+            gated_linear_unit=True,
+            n_shared_experts=n_shared_experts,
+            hidden_act=F.silu,
+            moe_expert_fusion=True,
+            moe_deep_gemm=False,
+            bias_activation_fusion=True,
+            moe_token_dispatcher_type="allgather",
+            moe_use_fusion_node=True,
+            using_sonic_moe=True,
+            fp8=None,
+            fp8_wgrad=True,
+            moe_shared_expert_overlap=True,
+            init_method=self._small_init_method,
+            output_layer_init_method=self._small_init_method,
+        )
+
+    def _build_moe_layer(self, ep_size, n_shared_experts=2):
+        cfg = self._build_transformer_config(ep_size, n_shared_experts)
+        spec = get_gpt_layer_local_spec(cfg, num_experts=self.n_routed_experts)
+        return MoELayer(
+            cfg,
+            spec.sublayers_spec.mlp.extra_kwargs["sublayers"],
+            self.pg_collection,
+        )
+
+    def _run_forward_backward(self, moe_layer, input_data):
+        moe_layer = paddle.amp.decorate(
+            models=moe_layer,
+            level="O2",
+            dtype="bfloat16",
+            master_grad=True,
+            master_weight=True,
+        )
+        mix_precision_utils.MixPrecisionLayer(moe_layer, dtype="bfloat16")
+        hidden_states = input_data.detach().clone()
+        hidden_states.stop_gradient = False
+        with paddle.amp.auto_cast(level="O2", dtype="bfloat16"):
+            output = moe_layer(hidden_states)[0]
+            loss = output.sum()
+        loss.backward()
+        return (
+            output.detach().clone(),
+            loss.item(),
+            hidden_states.grad.detach().clone(),
+        )
+
+    def _make_input(self):
+        paddle.seed(self.seed + 9)
+        return paddle.randn(
+            [2, 128, self.hidden_size],
+            dtype=paddle.bfloat16,
+        )
+
+    def test_allgather_shared_expert_overlap_runs(self):
+        """AllGather + shared_expert_overlap should run end-to-end
+        without error. Exercises the ``_AllGatherCombineAsync`` path
+        inside ``fusion_moe_forward``."""
+        ep_size = self.pg_collection.ep.nranks
+        if ep_size <= 1:
+            self.skipTest("requires EP > 1")
+
+        moe = self._build_moe_layer(ep_size, n_shared_experts=2)
+        x = self._make_input()
+        out, _, grad = self._run_forward_backward(moe, x)
+        self.assertTrue(paddle.isfinite(out).all().item())
+        self.assertTrue(paddle.isfinite(grad).all().item())
+
+        if paddle.is_compiled_with_cuda():
+            clear_all_fp8_weight_caches()
+
+
+@unittest.skipUnless(
+    paddlefleet_ops.is_sonic_moe_available(),
+    "Sonic-MoE not available (allgather dispatcher requires sonic_moe kernels)",
+)
+class TestAllGatherFP8DispatcherE2E(unittest.TestCase):
+    """Extended end-to-end tests for the AllGather + fp8 dispatcher
+    combination. Exercises the ``_AllGatherFP8`` quantize→AllGather→dequant
+    pipeline with real NCCL and validates that the FP8 dispatch path
+    produces numerically reasonable outputs.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        strategy = fleet.DistributedStrategy()
+        strategy.hybrid_configs = {
+            "dp_degree": 1,
+            "mp_degree": 1,
+            "pp_degree": 1,
+            "sharding_degree": 8,
+            "sep_degree": 1,
+            "cp_degree": 1,
+            "ep_degree": 8,
+            "moe_sharding_degree": 1,
+            "order": [
+                "sharding",
+                "moe_sharding",
+                "pp",
+                "sep",
+                "cp",
+                "dp",
+                "ep",
+                "mp",
+            ],
+        }
+        initialize_fleet(strategy=strategy)
+        cls.pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+
+    @classmethod
+    def tearDownClass(cls):
+        unset_global_variables()
+
+    def setUp(self):
+        self.seed = 8765
+        self.hidden_size = 1024
+        self.n_routed_experts = 32
+        self.moe_intermediate_size = 1024
+
+        random.seed(self.seed)
+        np.random.seed(self.seed)
+        paddle.seed(self.seed)
+        paddle.manual_seed(self.seed)
+        model_parallel_cuda_manual_seed(self.seed)
+        self.pg_collection = self.__class__.pg_collection
+
+    @staticmethod
+    def _small_init_method(tensor):
+        paddle.nn.initializer.Uniform(-0.001, 0.001)(tensor)
+
+    def _build_moe_layer(self, ep_size, fp8="e4m3"):
+        cfg = TransformerConfig(
+            hidden_size=self.hidden_size,
+            num_attention_heads=4,
+            n_routed_experts=self.n_routed_experts,
+            use_cpu_initialization=False,
+            num_experts_per_tok=2,
+            tensor_model_parallel_size=1,
+            expert_model_parallel_size=ep_size,
+            sequence_parallel=False,
+            bf16=True,
+            params_dtype=paddle.bfloat16,
+            moe_intermediate_size=self.moe_intermediate_size,
+            gated_linear_unit=True,
+            n_shared_experts=0,
+            hidden_act=F.silu,
+            moe_expert_fusion=True,
+            moe_deep_gemm=False,
+            bias_activation_fusion=True,
+            moe_token_dispatcher_type="allgather",
+            moe_use_fusion_node=True,
+            using_sonic_moe=True,
+            fp8=fp8,
+            fp8_wgrad=True,
+            init_method=self._small_init_method,
+            output_layer_init_method=self._small_init_method,
+        )
+        spec = get_gpt_layer_local_spec(cfg, num_experts=self.n_routed_experts)
+        return MoELayer(
+            cfg,
+            spec.sublayers_spec.mlp.extra_kwargs["sublayers"],
+            self.pg_collection,
+        )
+
+    def _run_forward_backward(self, moe_layer, input_data):
+        moe_layer = paddle.amp.decorate(
+            models=moe_layer,
+            level="O2",
+            dtype="bfloat16",
+            master_grad=True,
+            master_weight=True,
+        )
+        mix_precision_utils.MixPrecisionLayer(moe_layer, dtype="bfloat16")
+        hidden_states = input_data.detach().clone()
+        hidden_states.stop_gradient = False
+        with paddle.amp.auto_cast(level="O2", dtype="bfloat16"):
+            output = moe_layer(hidden_states)[0]
+            loss = output.sum()
+        loss.backward()
+        return (
+            output.detach().clone(),
+            loss.item(),
+            hidden_states.grad.detach().clone(),
+        )
+
+    def _make_input(self):
+        paddle.seed(self.seed + 11)
+        return paddle.randn(
+            [2, 128, self.hidden_size],
+            dtype=paddle.bfloat16,
+        )
+
+    def test_allgather_fp8_dispatch_vs_bf16(self):
+        """AllGather + fp8 output should be close to allgather + bf16
+        within FP8 tolerance. Validates the _AllGatherFP8 pipeline
+        end-to-end."""
+        ep_size = self.pg_collection.ep.nranks
+        if ep_size <= 1:
+            self.skipTest("requires EP > 1")
+
+        moe_bf16 = self._build_moe_layer(ep_size, fp8=None)
+        moe_fp8 = self._build_moe_layer(ep_size, fp8="e4m3")
+
+        x = self._make_input()
+        out_bf16, loss_bf16, grad_bf16 = self._run_forward_backward(moe_bf16, x)
+        out_fp8, loss_fp8, grad_fp8 = self._run_forward_backward(
+            moe_fp8, x.clone()
+        )
+
+        # Outputs must be finite.
+        self.assertTrue(paddle.isfinite(out_fp8).all().item())
+        self.assertTrue(paddle.isfinite(grad_fp8).all().item())
+
+        # FP8 is lossy but should not diverge wildly from bf16.
+        rel_loss = abs(loss_fp8 - loss_bf16) / max(abs(loss_bf16), 1e-12)
+        self.assertLess(rel_loss, 2.0, "fp8 loss diverged from bf16")
+
+        if paddle.is_compiled_with_cuda():
+            clear_all_fp8_weight_caches()
+
+
+@unittest.skipUnless(
+    paddlefleet_ops.is_sonic_moe_available(),
+    "Sonic-MoE not available (allgather dispatcher requires sonic_moe kernels)",
+)
+class TestAllGatherLatentMoE(unittest.TestCase):
+    """AllGather dispatcher + latent MoE: the fc1_latent_proj is hoisted
+    into ``forward()`` before ``pre_allgather``, and the cached
+    ``_latent_hidden`` is consumed by ``custom_forward``. This test
+    validates the latent MoE + allgather overlap path end-to-end.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        strategy = fleet.DistributedStrategy()
+        strategy.hybrid_configs = {
+            "dp_degree": 1,
+            "mp_degree": 1,
+            "pp_degree": 1,
+            "sharding_degree": 8,
+            "sep_degree": 1,
+            "cp_degree": 1,
+            "ep_degree": 8,
+            "moe_sharding_degree": 1,
+            "order": [
+                "sharding",
+                "moe_sharding",
+                "pp",
+                "sep",
+                "cp",
+                "dp",
+                "ep",
+                "mp",
+            ],
+        }
+        initialize_fleet(strategy=strategy)
+        cls.pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+
+    @classmethod
+    def tearDownClass(cls):
+        unset_global_variables()
+
+    def setUp(self):
+        self.seed = 3456
+        self.hidden_size = 1024
+        self.n_routed_experts = 32
+        self.moe_intermediate_size = 1024
+        self.moe_latent_size = 256
+
+        random.seed(self.seed)
+        np.random.seed(self.seed)
+        paddle.seed(self.seed)
+        paddle.manual_seed(self.seed)
+        model_parallel_cuda_manual_seed(self.seed)
+        self.pg_collection = self.__class__.pg_collection
+
+    @staticmethod
+    def _small_init_method(tensor):
+        paddle.nn.initializer.Uniform(-0.001, 0.001)(tensor)
+
+    def _build_moe_layer(self, ep_size, moe_allgather_gate_overlap=True):
+        cfg = TransformerConfig(
+            hidden_size=self.hidden_size,
+            num_attention_heads=4,
+            n_routed_experts=self.n_routed_experts,
+            use_cpu_initialization=False,
+            num_experts_per_tok=2,
+            tensor_model_parallel_size=1,
+            expert_model_parallel_size=ep_size,
+            sequence_parallel=False,
+            bf16=True,
+            params_dtype=paddle.bfloat16,
+            moe_intermediate_size=self.moe_intermediate_size,
+            moe_latent_size=self.moe_latent_size,
+            gated_linear_unit=True,
+            n_shared_experts=0,
+            hidden_act=F.silu,
+            moe_expert_fusion=True,
+            moe_deep_gemm=False,
+            bias_activation_fusion=True,
+            moe_token_dispatcher_type="allgather",
+            moe_use_fusion_node=True,
+            using_sonic_moe=True,
+            fp8=None,
+            fp8_wgrad=True,
+            moe_allgather_gate_overlap=moe_allgather_gate_overlap,
+            init_method=self._small_init_method,
+            output_layer_init_method=self._small_init_method,
+        )
+        spec = get_gpt_layer_local_spec(cfg, num_experts=self.n_routed_experts)
+        return MoELayer(
+            cfg,
+            spec.sublayers_spec.mlp.extra_kwargs["sublayers"],
+            self.pg_collection,
+        )
+
+    def _run_forward_backward(self, moe_layer, input_data):
+        moe_layer = paddle.amp.decorate(
+            models=moe_layer,
+            level="O2",
+            dtype="bfloat16",
+            master_grad=True,
+            master_weight=True,
+        )
+        mix_precision_utils.MixPrecisionLayer(moe_layer, dtype="bfloat16")
+        hidden_states = input_data.detach().clone()
+        hidden_states.stop_gradient = False
+        with paddle.amp.auto_cast(level="O2", dtype="bfloat16"):
+            output = moe_layer(hidden_states)[0]
+            loss = output.sum()
+        loss.backward()
+        return (
+            output.detach().clone(),
+            loss.item(),
+            hidden_states.grad.detach().clone(),
+        )
+
+    def _make_input(self):
+        paddle.seed(self.seed + 13)
+        return paddle.randn(
+            [2, 128, self.hidden_size],
+            dtype=paddle.bfloat16,
+        )
+
+    def test_allgather_latent_moe_runs(self):
+        """AllGather + latent MoE + gate overlap should run end-to-end."""
+        ep_size = self.pg_collection.ep.nranks
+        if ep_size <= 1:
+            self.skipTest("requires EP > 1")
+
+        moe = self._build_moe_layer(ep_size, moe_allgather_gate_overlap=True)
+        x = self._make_input()
+        out, _, grad = self._run_forward_backward(moe, x)
+        self.assertTrue(paddle.isfinite(out).all().item())
+        self.assertTrue(paddle.isfinite(grad).all().item())
+
+        if paddle.is_compiled_with_cuda():
+            clear_all_fp8_weight_caches()
+
+    def test_allgather_latent_moe_no_overlap(self):
+        """AllGather + latent MoE without gate overlap also works."""
+        ep_size = self.pg_collection.ep.nranks
+        if ep_size <= 1:
+            self.skipTest("requires EP > 1")
+
+        moe = self._build_moe_layer(ep_size, moe_allgather_gate_overlap=False)
+        x = self._make_input()
+        out, _, grad = self._run_forward_backward(moe, x)
+        self.assertTrue(paddle.isfinite(out).all().item())
+        self.assertTrue(paddle.isfinite(grad).all().item())
+
+        if paddle.is_compiled_with_cuda():
+            clear_all_fp8_weight_caches()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_layer_2.py
+++ b/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_layer_2.py
@@ -206,7 +206,7 @@ class TestMoELayerInitExpertParallelParse(unittest.TestCase):
         pg_collection = _make_pg_collection(moe_world_size=4)
 
         sublayers = _make_moe_sublayers()
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(ValueError):
             MoELayer(config, sublayers=sublayers, pg_collection=pg_collection)
 
     @patch("paddlefleet.transformer.moe.moe_layer.paddle.version")
@@ -230,7 +230,7 @@ class TestMoELayerInitExpertParallelParse(unittest.TestCase):
         pg_collection = _make_pg_collection(moe_world_size=3)
 
         sublayers = _make_moe_sublayers()
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(ValueError):
             MoELayer(config, sublayers=sublayers, pg_collection=pg_collection)
 
 

--- a/tests/single_card_tests/ai_edited_test/moe/test_latent_moe.py
+++ b/tests/single_card_tests/ai_edited_test/moe/test_latent_moe.py
@@ -766,6 +766,10 @@ class TestCustomForwardLatent(unittest.TestCase):
         if use_latent_moe:
             stub.fc1_latent_proj = nn.Linear(hidden_size, latent_size)
             stub.fc2_latent_proj = nn.Linear(latent_size, hidden_size)
+        # _latent_hidden is None by default; without this MagicMock would
+        # auto-create a non-None mock object and custom_forward would
+        # mistakenly consume it as a pre-computed latent projection.
+        stub._latent_hidden = None
         stub.dispatch.return_value = (
             paddle.randn([bs_seq, expert_out_size]),
             None,
@@ -833,6 +837,25 @@ class TestFusionMoeForwardLatent(unittest.TestCase):
         stub.token_dispatcher._comm_manager.combine.return_value = paddle.randn(
             [bs_seq, expert_out_size]
         )
+        stub.token_dispatcher._comm_manager.dispatched_indices = paddle.randint(
+            0, 4, [bs_seq, 2]
+        )
+        stub.token_dispatcher._comm_manager.dispatched_probs = paddle.randn(
+            [bs_seq, 2]
+        )
+        stub.token_dispatcher._comm_manager.tokens_per_expert = (
+            paddle.to_tensor([1, 2, 3, 4], dtype="int64")
+        )
+        stub.token_dispatcher.get_dispatched_routing.return_value = (
+            stub.token_dispatcher._comm_manager.dispatched_indices,
+            stub.token_dispatcher._comm_manager.dispatched_probs,
+            stub.token_dispatcher._comm_manager.tokens_per_expert,
+        )
+        # Bind real _project_to_latent so fusion_moe_forward can call it.
+        from paddlefleet.transformer.moe.moe_layer import MoELayer
+
+        stub._latent_hidden = None
+        stub._project_to_latent = MoELayer._project_to_latent.__get__(stub)
         return stub, bs_seq
 
     def test_fusion_moe_forward_applies_fc1_fc2_when_latent(self):

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_expert_2.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_expert_2.py
@@ -93,7 +93,7 @@ class TestGroupedMLPExpertConstruction(unittest.TestCase):
     def test_construction_bias_not_supported(self):
         """Test that use_bias=True raises assertion."""
         config = _make_config(use_bias=True)
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(ValueError):
             GroupedMLPExpert(
                 num_local_experts=2,
                 config=config,

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_layer_2.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_layer_2.py
@@ -187,7 +187,7 @@ class TestMoELayerLightweightMethods(unittest.TestCase):
         self.assertEqual(model.gate.layer_number, 11)
 
         model.gate = object()
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(AttributeError):
             MoELayer.set_layer_number(model, 12)
 
 

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_layer_7.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_layer_7.py
@@ -126,6 +126,7 @@ class TestMoELayerInitExpertParallel(unittest.TestCase):
         layer.moe_group = pg.ep
         layer.expert_model_parallel_size = 4
         layer.num_experts = 8
+        layer.moe_token_dispatcher_type = config.moe_token_dispatcher_type
         layer._init_expert_parallel()
 
         self.assertEqual(layer.moe_rank, 0)
@@ -148,6 +149,7 @@ class TestMoELayerInitExpertParallel(unittest.TestCase):
         layer.moe_group = pg.ep
         layer.expert_model_parallel_size = 2
         layer.num_experts = 4
+        layer.moe_token_dispatcher_type = config.moe_token_dispatcher_type
         layer._init_expert_parallel()
 
         self.assertEqual(layer.moe_rank, 0)
@@ -248,7 +250,7 @@ class TestMoELayerSetLayerNumber(unittest.TestCase):
         layer = MoELayer.__new__(MoELayer)
         layer.gate = MagicMock()
         del layer.gate.set_layer_number
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(AttributeError):
             layer.set_layer_number(5)
 
 
@@ -324,6 +326,7 @@ class TestMoELayerForwardLogging(unittest.TestCase):
         layer.router_aux_loss_coef = None
         layer.use_latent_moe = False
         layer.layer_number = 7
+        layer.moe_token_dispatcher_type = "alltoall"
         layer.gate = MagicMock(
             return_value=(
                 None,

--- a/tests/single_card_tests/test_allgather_dispatcher_config.py
+++ b/tests/single_card_tests/test_allgather_dispatcher_config.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Single-card tests for the new TransformerConfig fields and the new
+``"allgather"`` value of ``moe_token_dispatcher_type`` (commit d231bb9
+"add allgather dispatcher").
+
+Pure config-level checks — no MoELayer instantiation, no distributed
+init.  These cover the additions to ``transformer_config.py``.
+"""
+
+import unittest
+
+from paddlefleet.transformer.transformer_config import TransformerConfig
+
+
+class TestAllGatherDispatcherConfig(unittest.TestCase):
+    """New fields/options added by the allgather dispatcher commit."""
+
+    def test_allgather_dispatcher_type_is_preserved(self):
+        cfg = TransformerConfig(
+            num_hidden_layers=4,
+            n_routed_experts=8,
+            moe_token_dispatcher_type="allgather",
+        )
+        self.assertEqual(cfg.moe_token_dispatcher_type, "allgather")
+        # Default for moe_use_fusion_node remains True.
+        self.assertTrue(cfg.moe_use_fusion_node)
+
+    def test_moe_allgather_gate_overlap_default_false(self):
+        cfg = TransformerConfig(num_hidden_layers=4)
+        self.assertFalse(cfg.moe_allgather_gate_overlap)
+
+    def test_moe_allgather_gate_overlap_can_be_enabled(self):
+        cfg = TransformerConfig(
+            num_hidden_layers=4,
+            moe_allgather_gate_overlap=True,
+        )
+        self.assertTrue(cfg.moe_allgather_gate_overlap)
+
+    def test_default_dispatcher_type_unchanged(self):
+        # The commit only *added* "allgather" to the option list; the
+        # default is still "deepep".
+        cfg = TransformerConfig(num_hidden_layers=4)
+        self.assertEqual(cfg.moe_token_dispatcher_type, "deepep")
+
+    def test_all_dispatcher_types_accepted(self):
+        for dt in ("allgather", "alltoall", "deepep", "hybridep"):
+            cfg = TransformerConfig(
+                num_hidden_layers=4,
+                n_routed_experts=8,
+                moe_token_dispatcher_type=dt,
+            )
+            self.assertEqual(cfg.moe_token_dispatcher_type, dt)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/transformer/test_allgather_dispatcher_layer_validation.py
+++ b/tests/single_card_tests/transformer/test_allgather_dispatcher_layer_validation.py
@@ -1,0 +1,400 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Single-card validation tests for MoELayer's allgather-dispatcher init
+paths. Covers:
+
+* sonic_moe-availability assert (allgather requires the SonicMoE module)
+* moe_allgather_gate_overlap warning when paired with a non-allgather
+  dispatcher (the flag is silently ignored otherwise).
+* allgather + EP > 1 validation: ``using_sonic_moe=False`` raise and
+  ``moe_intermediate_size`` divisibility raise.
+
+EP > 1 is faked via a ``SimpleNamespace`` ep group; we only exercise the
+*validation* paths that abort init (raise) — the warning-and-continue
+paths (forcing fusion_node / disabling deep_gemm) require a complete EP
+init and are covered by the multi-card test.
+"""
+
+import logging
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import paddle
+import paddle.nn.functional as F
+import paddlefleet_ops
+
+# Temporarily disable sonicmoe Python imports during module load.
+# The sonicmoe ecosystem ops are already loaded; re-importing the
+# Python wrapper triggers custom-op re-registration crashes.
+_original_sonic_moe_available = paddlefleet_ops.is_sonic_moe_available
+paddlefleet_ops.is_sonic_moe_available = lambda: False
+
+from paddlefleet.transformer.mlp import MLPSublayersSpec
+from paddlefleet.transformer.moe.moe_layer import MoELayer, MoESublayers
+from paddlefleet.transformer.transformer_config import TransformerConfig
+
+# Restore the real value so concurrent / subsequent test files see it.
+paddlefleet_ops.is_sonic_moe_available = _original_sonic_moe_available
+
+
+class _FakeLinear(paddle.nn.Layer):
+    """Dummy linear that avoids ColumnParallelLinear's RNG-tracker check."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__()
+
+    def forward(self, x):
+        return x
+
+
+def _make_config(**overrides):
+    defaults = {
+        "num_hidden_layers": 1,
+        "hidden_size": 16,
+        "num_attention_heads": 2,
+        "intermediate_size": 32,
+        "n_routed_experts": 2,
+        "n_shared_experts": 1,
+        "num_experts_per_tok": 1,
+        "moe_intermediate_size": 16,
+        "moe_token_dispatcher_type": "alltoall",
+        "moe_expert_fusion": False,
+        "moe_use_fusion_node": True,
+        "fp8": None,
+        "gated_linear_unit": True,
+        "hidden_act": F.silu,
+        "tensor_model_parallel_size": 1,
+    }
+    defaults.update(overrides)
+    return TransformerConfig(**defaults)
+
+
+def _make_sublayers():
+    return MoESublayers(
+        mlp_spec=MLPSublayersSpec(
+            up_gate_proj=_FakeLinear,
+            down_proj=_FakeLinear,
+        )
+    )
+
+
+def _instantiate(config, ep=None):
+    return MoELayer(
+        config,
+        sublayers=_make_sublayers(),
+        pg_collection=SimpleNamespace(ep=ep, expt_dp=None),
+    )
+
+
+class TestAllGatherSonicMoeAvailability(unittest.TestCase):
+    """``allgather`` dispatcher requires the SonicMoE module."""
+
+    def test_allgather_asserts_sonic_moe_available(self):
+        config = _make_config(
+            moe_token_dispatcher_type="allgather",
+            using_sonic_moe=True,
+        )
+        with (
+            mock.patch(
+                "paddlefleet_ops.is_sonic_moe_available", return_value=False
+            ),
+            self.assertRaises(ValueError),
+        ):
+            _instantiate(config)
+
+
+class TestGateOverlapWarning(unittest.TestCase):
+    """``moe_allgather_gate_overlap=True`` paired with a non-allgather
+    dispatcher should log a warning so users know the flag is being
+    ignored.
+    """
+
+    def test_warning_logged_for_non_allgather_dispatcher(self):
+        config = _make_config(
+            moe_token_dispatcher_type="alltoall",
+            moe_allgather_gate_overlap=True,
+        )
+        with self.assertLogs(level=logging.WARNING) as captured:
+            _instantiate(config)
+        joined = "\n".join(captured.output)
+        self.assertIn("moe_allgather_gate_overlap", joined)
+        self.assertIn("only honoured when", joined)
+
+    def test_no_warning_when_dispatcher_is_allgather(self):
+        # Even though gate_overlap=True is set, the message must NOT fire
+        # for the allgather dispatcher itself. We just verify init does
+        # not log the specific warning string. Init may still raise later
+        # because EP=1 fails sonic_moe checks; we catch any exception and
+        # only assert on the absence of the gate_overlap warning.
+        config = _make_config(
+            moe_token_dispatcher_type="allgather",
+            moe_allgather_gate_overlap=True,
+            using_sonic_moe=True,
+        )
+        captured_messages = []
+
+        class _Capture(logging.Handler):
+            def emit(self, record):
+                captured_messages.append(record.getMessage())
+
+        handler = _Capture(level=logging.WARNING)
+        logging.getLogger().addHandler(handler)
+        try:
+            try:
+                _instantiate(config)
+            except (AssertionError, ValueError, RuntimeError):
+                pass
+        finally:
+            logging.getLogger().removeHandler(handler)
+        for msg in captured_messages:
+            self.assertNotIn("only honoured when", msg)
+
+
+class TestAllGatherEpValidation(unittest.TestCase):
+    """allgather-with-EP>1 raise paths."""
+
+    def _fake_ep_group(self, nranks):
+        return SimpleNamespace(
+            ranks=list(range(nranks)),
+            nranks=nranks,
+            rank=0,
+        )
+
+    def test_allgather_requires_using_sonic_moe(self):
+        config = _make_config(
+            moe_token_dispatcher_type="allgather",
+            using_sonic_moe=False,
+        )
+        # Bypass the sonic_moe module-availability assert at line 191
+        # to reach the using_sonic_moe-config check at line 324.
+        with (
+            mock.patch(
+                "paddlefleet_ops.is_sonic_moe_available", return_value=True
+            ),
+            mock.patch(
+                "paddlefleet.utils.get_pg_size",
+                side_effect=lambda g: g.nranks if g else 1,
+            ),
+            mock.patch("paddlefleet.utils.get_pg_rank", return_value=0),
+            self.assertRaisesRegex(ValueError, "using_sonic_moe=True"),
+        ):
+            _instantiate(config, ep=self._fake_ep_group(2))
+
+    def test_allgather_raises_when_intermediate_size_not_divisible_by_ep(
+        self,
+    ):
+        # moe_intermediate_size=16 not divisible by EP=3.
+        config = _make_config(
+            moe_token_dispatcher_type="allgather",
+            using_sonic_moe=True,
+            moe_intermediate_size=16,
+        )
+        with (
+            mock.patch(
+                "paddlefleet_ops.is_sonic_moe_available", return_value=True
+            ),
+            mock.patch(
+                "paddlefleet.utils.get_pg_size",
+                side_effect=lambda g: g.nranks if g else 1,
+            ),
+            mock.patch("paddlefleet.utils.get_pg_rank", return_value=0),
+            self.assertRaisesRegex(ValueError, "must be divisible by EP"),
+        ):
+            _instantiate(config, ep=self._fake_ep_group(3))
+
+    def test_allgather_forces_fusion_node_on(self):
+        config = _make_config(
+            moe_token_dispatcher_type="allgather",
+            using_sonic_moe=True,
+            moe_use_fusion_node=False,
+        )
+        with (
+            mock.patch(
+                "paddlefleet_ops.is_sonic_moe_available", return_value=True
+            ),
+            mock.patch(
+                "paddlefleet.utils.get_pg_size",
+                side_effect=lambda g: g.nranks if g else 1,
+            ),
+            mock.patch("paddlefleet.utils.get_pg_rank", return_value=0),
+            mock.patch("paddlefleet.transformer.moe.moe_layer.SonicMoEExpert"),
+            self.assertLogs(level=logging.WARNING) as captured,
+        ):
+            layer = _instantiate(config, ep=self._fake_ep_group(2))
+        self.assertTrue(layer.moe_use_fusion_node)
+        joined = "\n".join(captured.output)
+        self.assertIn("forcing moe_use_fusion_node=True", joined)
+
+    def test_allgather_forces_deep_gemm_off(self):
+        config = _make_config(
+            moe_token_dispatcher_type="allgather",
+            using_sonic_moe=True,
+            moe_deep_gemm=True,
+            moe_expert_fusion=True,
+        )
+        with (
+            mock.patch(
+                "paddlefleet_ops.is_sonic_moe_available", return_value=True
+            ),
+            mock.patch(
+                "paddlefleet.utils.get_pg_size",
+                side_effect=lambda g: g.nranks if g else 1,
+            ),
+            mock.patch("paddlefleet.utils.get_pg_rank", return_value=0),
+            mock.patch(
+                "paddle.device.get_device_capability", return_value=(9, 0)
+            ),
+            mock.patch("paddlefleet.transformer.moe.moe_layer.SonicMoEExpert"),
+            self.assertLogs(level=logging.WARNING) as captured,
+        ):
+            layer = _instantiate(config, ep=self._fake_ep_group(2))
+        self.assertFalse(layer.moe_deep_gemm)
+        joined = "\n".join(captured.output)
+        self.assertIn("forcing moe_deep_gemm=False", joined)
+
+    def test_allgather_forces_expert_fusion_on(self):
+        """moe_expert_fusion=False is silently corrected to True when
+        the allgather dispatcher is selected."""
+        config = _make_config(
+            moe_token_dispatcher_type="allgather",
+            using_sonic_moe=True,
+            moe_expert_fusion=False,
+        )
+        with (
+            mock.patch(
+                "paddlefleet_ops.is_sonic_moe_available", return_value=True
+            ),
+            mock.patch(
+                "paddlefleet.utils.get_pg_size",
+                side_effect=lambda g: g.nranks if g else 1,
+            ),
+            mock.patch("paddlefleet.utils.get_pg_rank", return_value=0),
+            mock.patch("paddlefleet.transformer.moe.moe_layer.SonicMoEExpert"),
+            self.assertLogs(level=logging.WARNING) as captured,
+        ):
+            layer = _instantiate(config, ep=self._fake_ep_group(2))
+        self.assertTrue(layer.moe_expert_fusion)
+        joined = "\n".join(captured.output)
+        self.assertIn("forcing moe_expert_fusion=True", joined)
+
+
+class TestFusionNodeDisable(unittest.TestCase):
+    """non-deepep/hybridep/allgather dispatcher with EP>1 silently
+    disables moe_use_fusion_node."""
+
+    def _fake_ep_group(self, nranks):
+        return SimpleNamespace(
+            ranks=list(range(nranks)),
+            nranks=nranks,
+            rank=0,
+        )
+
+    def test_alltoall_with_ep_disables_fusion_node(self):
+        config = _make_config(
+            moe_token_dispatcher_type="alltoall",
+            moe_use_fusion_node=True,
+        )
+        with (
+            mock.patch(
+                "paddlefleet.utils.get_pg_size",
+                side_effect=lambda g: g.nranks if g else 1,
+            ),
+            mock.patch("paddlefleet.utils.get_pg_rank", return_value=0),
+        ):
+            layer = _instantiate(config, ep=self._fake_ep_group(2))
+        self.assertFalse(layer.moe_use_fusion_node)
+
+
+class TestFp8Validation(unittest.TestCase):
+    """fp8 / use_ue8m0 init validation paths."""
+
+    def test_fp8_requires_fusion_node(self):
+        # EP=1 + alltoall keeps fusion_node=False (no allgather force-on),
+        # so fp8 + fusion_node=False should raise.
+        config = _make_config(
+            moe_token_dispatcher_type="alltoall",
+            moe_use_fusion_node=False,
+            fp8="e4m3",
+        )
+        with (
+            mock.patch("paddle.version.cuda", return_value="12.4"),
+            self.assertRaisesRegex(ValueError, "moe_use_fusion_node"),
+        ):
+            _instantiate(config)
+
+    def test_use_ue8m0_requires_blackwell(self):
+        config = _make_config(
+            moe_token_dispatcher_type="alltoall",
+            moe_use_fusion_node=True,
+            use_ue8m0=True,
+        )
+        with (
+            mock.patch("paddle.version.cuda", return_value="12.4"),
+            mock.patch(
+                "paddle.device.cuda.get_device_capability",
+                return_value=(9, 0),
+            ),
+            self.assertRaisesRegex(ValueError, "Blackwell"),
+        ):
+            _instantiate(config)
+
+
+class TestAllGatherFp8UsesFusedWeight(unittest.TestCase):
+    """allgather + fp8 must keep use_fused_weight=True.
+
+    Regression guard for the bug where allgather forces moe_deep_gemm=False,
+    then the generic fp8 logic set use_fused_weight=False when deep_gemm is
+    False, causing the sonic_moe assertion to fail.
+    """
+
+    def _fake_ep_group(self, nranks):
+        return SimpleNamespace(
+            ranks=list(range(nranks)),
+            nranks=nranks,
+            rank=0,
+        )
+
+    def test_allgather_fp8_preserves_fused_weight(self):
+        config = _make_config(
+            moe_token_dispatcher_type="allgather",
+            using_sonic_moe=True,
+            moe_expert_fusion=True,
+            moe_deep_gemm=False,
+            fp8="e4m3",
+        )
+        with (
+            mock.patch(
+                "paddlefleet_ops.is_sonic_moe_available", return_value=True
+            ),
+            mock.patch(
+                "paddlefleet.utils.get_pg_size",
+                side_effect=lambda g: g.nranks if g else 1,
+            ),
+            mock.patch("paddlefleet.utils.get_pg_rank", return_value=0),
+            mock.patch("paddle.version.cuda", return_value="12.4"),
+            mock.patch(
+                "paddle.device.cuda.get_device_capability", return_value=(9, 0)
+            ),
+            mock.patch("paddlefleet.transformer.moe.moe_layer.SonicMoEExpert"),
+        ):
+            # Must not raise (the sonic_moe assertion use_fused_weight==True
+            # must pass).
+            layer = _instantiate(config, ep=self._fake_ep_group(2))
+        self.assertTrue(layer.moe_expert_fusion)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/transformer/test_allgather_dispatcher_units.py
+++ b/tests/single_card_tests/transformer/test_allgather_dispatcher_units.py
@@ -1,0 +1,2083 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Single-card unit tests for the AllGather token-dispatcher PyLayers.
+
+These tests exercise the **single-rank fallback paths** — where the
+collective ops would be a no-op — without spinning up multi-card NCCL.
+They cover:
+
+* ``ReduceScatterGroupOp`` forward (clone) + backward (clone) on a
+  single-rank group.
+* ``_RouterAllGather`` (in token_dispatcher.py) forward+backward with
+  ``group=None`` and on a single-rank group, including the explicit
+  shape-restoration path on backward (handles the 1-D grad case from
+  sonic-moe).
+* ``_AllGatherFP8`` forward+backward early-return paths for nranks==1.
+* ``_AllGatherCombineAsync`` forward+backward for nranks==1; verifies
+  that the captured ``fn`` graph runs and its outputs/gradients flow.
+* ``_PreAllGatherResult`` against a manually-built single-rank handle.
+* ``AllGatherTokenDispatcher.pre_allgather`` early return when the
+  group is single-rank.
+* ``AllGatherTokenDispatcher.token_combine`` with
+  ``combine_overlap_handle=None`` — passthrough path.
+* ``GroupedMLPExpert.intermediate_size_per_partition`` constructor
+  override.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import paddle
+import paddle.distributed as dist
+import paddlefleet_ops
+
+# Temporarily disable sonicmoe Python imports during module load.
+# The sonicmoe ecosystem ops are already loaded; re-importing the
+# Python wrapper triggers custom-op re-registration crashes.
+_original_sonic_moe_available = paddlefleet_ops.is_sonic_moe_available
+paddlefleet_ops.is_sonic_moe_available = lambda: False
+
+from paddlefleet.transformer.moe.moe_expert import GroupedMLPExpert
+from paddlefleet.transformer.moe.moe_layer import MoELayer
+from paddlefleet.transformer.moe.moe_utils import ReduceScatterGroupOp
+from paddlefleet.transformer.moe.token_dispatcher import (
+    AllGatherTokenDispatcher,
+    MoEFlexTokenDispatcher,
+    _AllGatherCombineAsync,
+    _AllGatherFP8,
+    _PreAllGatherResult,
+    _RouterAllGather,
+)
+
+# Restore the real value so concurrent / subsequent test files see it.
+paddlefleet_ops.is_sonic_moe_available = _original_sonic_moe_available
+
+
+def _single_rank_group():
+    return dist.new_group([dist.get_rank()])
+
+
+class TestReduceScatterGroupOp(unittest.TestCase):
+    """Forward/backward of ReduceScatterGroupOp on a single-rank group.
+
+    nranks==1 is the ``input.clone()`` shortcut inside
+    ``reduce_scatter_group`` / ``all_gather_group`` so this exercises
+    the PyLayer plumbing (barrier + ctx.group) without real NCCL traffic.
+    """
+
+    def test_forward_single_rank_returns_clone(self):
+        g = _single_rank_group()
+        x = paddle.randn([4, 8], dtype="float32")
+        x.stop_gradient = False
+        y = ReduceScatterGroupOp.apply(x, g)
+        self.assertEqual(y.shape, x.shape)
+        self.assertTrue(paddle.allclose(y, x).item())
+
+    def test_backward_single_rank_returns_clone(self):
+        g = _single_rank_group()
+        x = paddle.randn([4, 8], dtype="float32")
+        x.stop_gradient = False
+        y = ReduceScatterGroupOp.apply(x, g)
+        y.sum().backward()
+        # On a single-rank group AllGather of grad-of-ones is just clone:
+        # gradient should be ones with same shape as x.
+        self.assertEqual(x.grad.shape, x.shape)
+        self.assertTrue(
+            paddle.allclose(x.grad, paddle.ones_like(x.grad)).item()
+        )
+
+
+class TestRouterAllGather(unittest.TestCase):
+    """``_RouterAllGather`` is the router-local AllGather: forward
+    concatenates across EP, backward *slices* (no reduction). The
+    single-rank path returns clone on forward and reshapes-only on
+    backward.
+    """
+
+    def test_group_none_forward_returns_clone(self):
+        x = paddle.randn([6, 4], dtype="float32")
+        x.stop_gradient = False
+        y = _RouterAllGather.apply(x, None)
+        self.assertEqual(y.shape, x.shape)
+        self.assertTrue(paddle.allclose(y, x).item())
+
+    def test_group_none_backward_passes_through(self):
+        x = paddle.randn([6, 4], dtype="float32")
+        x.stop_gradient = False
+        y = _RouterAllGather.apply(x, None)
+        y.sum().backward()
+        self.assertEqual(x.grad.shape, x.shape)
+
+    def test_group_none_backward_reshapes_1d_grad(self):
+        """Sonic-moe's ``_DownProjection`` may flatten ``topk_scores``
+        gradient to 1-D ``[T*K]``; ``_RouterAllGather.backward`` must
+        restore the original 2-D shape so upstream broadcast checks
+        pass. Simulate this by manually calling backward via a chain
+        that flattens.
+        """
+        x = paddle.randn([6, 4], dtype="float32")
+        x.stop_gradient = False
+        y = _RouterAllGather.apply(x, None)
+        # Reshape consumer to a 1-D view, force grad to flow as 1-D.
+        z = y.reshape([-1])
+        z.sum().backward()
+        self.assertEqual(list(x.grad.shape), [6, 4])
+
+    def test_single_rank_group_forward(self):
+        g = _single_rank_group()
+        x = paddle.randn([5, 3], dtype="float32")
+        x.stop_gradient = False
+        y = _RouterAllGather.apply(x, g)
+        self.assertEqual(y.shape, x.shape)
+        self.assertTrue(paddle.allclose(y, x).item())
+
+
+class TestRouterAllGatherMultiRank(unittest.TestCase):
+    """Cover the nranks > 1 forward / backward paths of
+    ``_RouterAllGather`` by mocking ``paddle.distributed.stream.all_gather``
+    and feeding a fake group. No real NCCL traffic; verifies shape
+    arithmetic + per-rank slice semantics (no cross-rank reduction).
+    """
+
+    def test_multi_rank_forward_concatenates(self):
+        x = paddle.randn([3, 5], dtype="float32")
+        x.stop_gradient = False
+        fake_group = SimpleNamespace(nranks=2, rank=0)
+
+        def fake_ag(out, inp, **kw):
+            stacked = paddle.concat([inp, inp + 100.0], axis=0)
+            paddle.assign(stacked, out)
+
+        with mock.patch(
+            "paddle.distributed.stream.all_gather", side_effect=fake_ag
+        ):
+            y = _RouterAllGather.apply(x, fake_group)
+        self.assertEqual(list(y.shape), [6, 5])
+        self.assertTrue(paddle.allclose(y[:3], x).item())
+        self.assertTrue(paddle.allclose(y[3:], x + 100.0).item())
+
+    def test_multi_rank_backward_slices_rank_segment(self):
+        x = paddle.randn([3, 5], dtype="float32")
+        x.stop_gradient = False
+        fake_group = SimpleNamespace(nranks=2, rank=0)
+
+        def fake_ag(out, inp, **kw):
+            paddle.assign(paddle.concat([inp, inp], axis=0), out)
+
+        with mock.patch(
+            "paddle.distributed.stream.all_gather", side_effect=fake_ag
+        ):
+            y = _RouterAllGather.apply(x, fake_group)
+        # Distinguishable per-rank grad: chunk0 = 1.0, chunk1 = 2.0.
+        grad = paddle.concat(
+            [paddle.full([3, 5], 1.0), paddle.full([3, 5], 2.0)], axis=0
+        )
+        y.backward(grad)
+        # rank=0 must receive only its own chunk (1.0), no reduction.
+        self.assertTrue(
+            paddle.allclose(x.grad, paddle.full_like(x, 1.0)).item()
+        )
+
+    def test_multi_rank_backward_reshapes_1d_grad(self):
+        """If the upstream grad arrives as 1-D, backward must reshape
+        it to global shape before splitting."""
+        x = paddle.randn([3, 4], dtype="float32")
+        x.stop_gradient = False
+        fake_group = SimpleNamespace(nranks=2, rank=1)
+
+        def fake_ag(out, inp, **kw):
+            paddle.assign(paddle.concat([inp, inp], axis=0), out)
+
+        with mock.patch(
+            "paddle.distributed.stream.all_gather", side_effect=fake_ag
+        ):
+            y = _RouterAllGather.apply(x, fake_group)
+        # Reshape consumer to a 1-D view to force grad to flow as 1-D.
+        z = y.reshape([-1])
+        flat_grad = paddle.concat(
+            [paddle.full([12], 1.0), paddle.full([12], 2.0)]
+        )
+        z.backward(flat_grad)
+        # rank=1 must receive the second chunk (2.0).
+        self.assertTrue(
+            paddle.allclose(x.grad, paddle.full_like(x, 2.0)).item()
+        )
+
+
+class TestAllGatherFP8(unittest.TestCase):
+    """``_AllGatherFP8`` falls back to a clone when the group has a single
+    rank. The full quantize→AllGather→dequant pipeline requires a real
+    multi-card setup and is exercised by the multi-card EP test.
+    """
+
+    def test_group_none_forward_returns_clone(self):
+        x = paddle.randn([4, 128], dtype="float32")
+        x.stop_gradient = False
+        y = _AllGatherFP8.apply(x, None, False)
+        self.assertEqual(y.shape, x.shape)
+        self.assertTrue(paddle.allclose(y, x).item())
+
+    def test_group_none_backward_passthrough(self):
+        x = paddle.randn([4, 128], dtype="float32")
+        x.stop_gradient = False
+        y = _AllGatherFP8.apply(x, None, False)
+        y.sum().backward()
+        self.assertEqual(x.grad.shape, x.shape)
+
+
+class TestAllGatherCombineAsync(unittest.TestCase):
+    """``_AllGatherCombineAsync`` fuses the ReduceScatter combine with a
+    captured ``fn`` graph. With ``group=None`` the collective collapses
+    to a clone but ``fn`` still runs and its grad must propagate back.
+    """
+
+    def test_group_none_runs_fn_and_propagates_gradients(self):
+        x = paddle.randn([2, 8], dtype="float32")
+        x.stop_gradient = False
+        a = paddle.randn([2, 8], dtype="float32")
+        a.stop_gradient = False
+
+        def fn(t):
+            return (t * 3.0,)
+
+        combined, fn_out = _AllGatherCombineAsync.apply(
+            x, None, a, fn=fn, is_first_fwd=False
+        )
+        # Forward: combined ~ x, fn_out ~ 3*a
+        self.assertEqual(combined.shape, x.shape)
+        self.assertEqual(fn_out.shape, a.shape)
+        self.assertTrue(paddle.allclose(fn_out, a * 3.0).item())
+
+        # Backward through both outputs.
+        loss = combined.sum() + fn_out.sum()
+        loss.backward()
+        # x grad = ones (combine is clone with sum loss).
+        self.assertTrue(paddle.allclose(x.grad, paddle.ones_like(x)).item())
+        # a grad = 3 (sum loss * d(3a)/da).
+        self.assertTrue(
+            paddle.allclose(a.grad, paddle.full_like(a, 3.0)).item()
+        )
+
+    def test_group_none_first_fwd_backward_returns_zeros(self):
+        """is_first_fwd=True sets ctx.bwf=None; backward must not crash
+        and should return zero grads for fn_args (no real backward graph)."""
+        x = paddle.randn([2, 8], dtype="float32")
+        x.stop_gradient = False
+        a = paddle.randn([2, 8], dtype="float32")
+        a.stop_gradient = False
+
+        def fn(t):
+            return (t * 3.0,)
+
+        combined, fn_out = _AllGatherCombineAsync.apply(
+            x, None, a, fn=fn, is_first_fwd=True
+        )
+        # Forward still produces the same outputs.
+        self.assertTrue(paddle.allclose(fn_out, a * 3.0).item())
+
+        loss = combined.sum() + fn_out.sum()
+        loss.backward()
+        # x grad = ones (combined is clone).
+        self.assertTrue(paddle.allclose(x.grad, paddle.ones_like(x)).item())
+        # a grad = zeros (bwf is None, so fn backward is skipped).
+        self.assertTrue(paddle.allclose(a.grad, paddle.zeros_like(a)).item())
+
+
+class TestPreAllGatherResult(unittest.TestCase):
+    """``_PreAllGatherResult`` consumes a pre-issued async AllGather
+    handle. We build a fake handle for the single-rank case where the
+    AllGather "result" is just a copy of the input.
+    """
+
+    def test_consumes_fake_handle(self):
+        g = _single_rank_group()
+        x = paddle.randn([3, 5], dtype="float32")
+        x.stop_gradient = False
+        # Build a fake handle: dummy task with .wait(), output==input.
+        out_buf = x.clone().detach()
+
+        class _DummyTask:
+            def wait(self):
+                return None
+
+        handle = {"output": out_buf, "task": _DummyTask(), "group": g}
+        y = _PreAllGatherResult.apply(x, handle)
+        self.assertTrue(paddle.allclose(y, x).item())
+        # Backward must call ReduceScatterGroupOp on the single-rank group
+        # → clone path, so x.grad = ones.
+        y.sum().backward()
+        self.assertTrue(paddle.allclose(x.grad, paddle.ones_like(x)).item())
+
+
+class TestAllGatherTokenDispatcherSingleRank(unittest.TestCase):
+    """Constructor + early-return paths of ``AllGatherTokenDispatcher``."""
+
+    def test_pre_allgather_single_rank_no_handle(self):
+        g = _single_rank_group()
+        d = AllGatherTokenDispatcher(
+            moe_group=g,
+            expert_model_parallel_size=1,
+            num_experts=8,
+        )
+        d.pre_allgather(paddle.randn([4, 16]))
+        self.assertIsNone(d._pre_ag_handle)
+
+    def test_pre_allgather_with_fp8_dispatch_no_handle(self):
+        g = _single_rank_group()
+        # fp8_dispatch was removed from AllGatherTokenDispatcher; all
+        # paths use the plain AllGather path. This test verifies that
+        # pre_allgather works correctly regardless.
+        d = AllGatherTokenDispatcher(
+            moe_group=g,
+            expert_model_parallel_size=2,
+            num_experts=8,
+        )
+        d.pre_allgather(paddle.randn([4, 16]))
+        # group.nranks == 1: pre_allgather sets handle to None.
+        self.assertIsNone(d._pre_ag_handle)
+
+    def test_token_combine_no_overlap_passthrough(self):
+        g = _single_rank_group()
+        d = AllGatherTokenDispatcher(
+            moe_group=g,
+            expert_model_parallel_size=1,
+            num_experts=8,
+        )
+        x = paddle.randn([4, 16], dtype="float32")
+        out = d.token_combine(x, combine_overlap_handle=None)
+        # Pure passthrough: the ReduceScatter happens later in
+        # combine_postprocess, not here.
+        self.assertTrue(paddle.equal_all(out, x).item())
+        self.assertIsNone(d._overlap_combined)
+
+    def test_token_dispatch_passthrough(self):
+        g = _single_rank_group()
+        d = AllGatherTokenDispatcher(
+            moe_group=g,
+            expert_model_parallel_size=1,
+            num_experts=8,
+        )
+        x = paddle.randn([6, 16], dtype="float32")
+        out, extra = d.token_dispatch(x)
+        self.assertTrue(paddle.equal_all(out, x).item())
+        self.assertIsNone(extra)
+
+    def test_dispatch_postprocess_returns_tokens_per_expert(self):
+        g = _single_rank_group()
+        d = AllGatherTokenDispatcher(
+            moe_group=g,
+            expert_model_parallel_size=1,
+            num_experts=8,
+        )
+        d.tokens_per_expert = None
+        x = paddle.randn([4, 16], dtype="float32")
+        out, tpe = d.dispatch_postprocess(x)
+        self.assertTrue(paddle.equal_all(out, x).item())
+        self.assertIsNone(tpe)
+
+    def test_combine_preprocess_passthrough(self):
+        g = _single_rank_group()
+        d = AllGatherTokenDispatcher(
+            moe_group=g,
+            expert_model_parallel_size=1,
+            num_experts=8,
+        )
+        x = paddle.randn([4, 16], dtype="float32")
+        out = d.combine_preprocess(x)
+        self.assertIs(out, x)
+
+    def test_combine_postprocess_overlap_cache_path(self):
+        """When ``token_combine`` cached the result via the overlap path,
+        ``combine_postprocess`` returns the cached output and clears the
+        cache.
+        """
+        g = _single_rank_group()
+        d = AllGatherTokenDispatcher(
+            moe_group=g,
+            expert_model_parallel_size=1,
+            num_experts=8,
+        )
+        cached = paddle.randn([4, 16], dtype="float32")
+        d._overlap_combined = cached
+        out = d.combine_postprocess(paddle.zeros([4, 16]))
+        self.assertIs(out, cached)
+        self.assertIsNone(d._overlap_combined)
+
+    def test_constructor_records_state(self):
+        g = _single_rank_group()
+        d = AllGatherTokenDispatcher(
+            moe_group=g,
+            expert_model_parallel_size=4,
+            num_experts=32,
+        )
+        self.assertIs(d.moe_group, g)
+        self.assertEqual(d.ep_size, 4)
+        self.assertEqual(d.num_experts, 32)
+        # In allgather mode every rank holds every expert.
+        self.assertEqual(d.num_local_experts, 32)
+        self.assertIsNone(d._pre_ag_handle)
+
+
+class _FakeTask:
+    def wait(self):
+        pass
+
+
+def _fake_all_gather(output, input, **kw):
+    stacked = paddle.concat([input, input], axis=0)
+    paddle.assign(stacked, output)
+    return _FakeTask()
+
+
+def _fake_reduce_scatter(output, input, **kw):
+    local_T = input.shape[0] // 2
+    paddle.assign(input[:local_T], output)
+    return _FakeTask()
+
+
+class TestAllGatherCombineAsyncMultiRank(unittest.TestCase):
+    """Cover the nranks > 1 forward / backward paths of
+    ``_AllGatherCombineAsync`` by mocking the collective primitives.
+    """
+
+    def test_multi_rank_forward_reduce_scatters(self):
+        x = paddle.randn([4, 8], dtype="float32")
+        x.stop_gradient = False
+        a = paddle.randn([4, 8], dtype="float32")
+        a.stop_gradient = False
+        fake_group = SimpleNamespace(nranks=2, rank=0)
+
+        def fn(t):
+            return (t * 3.0,)
+
+        with mock.patch(
+            "paddle.distributed.stream.reduce_scatter",
+            side_effect=_fake_reduce_scatter,
+        ):
+            combined, fn_out = _AllGatherCombineAsync.apply(
+                x, fake_group, a, fn=fn, is_first_fwd=False
+            )
+
+        # reduce_scatter halves the token dim.
+        self.assertEqual(list(combined.shape), [2, 8])
+        self.assertTrue(paddle.allclose(combined, x[:2]).item())
+        self.assertTrue(paddle.allclose(fn_out, a * 3.0).item())
+
+    def test_multi_rank_backward_all_gathers(self):
+        x = paddle.randn([4, 8], dtype="float32")
+        x.stop_gradient = False
+        a = paddle.randn([4, 8], dtype="float32")
+        a.stop_gradient = False
+        fake_group = SimpleNamespace(nranks=2, rank=0)
+
+        def fn(t):
+            return (t * 3.0,)
+
+        with mock.patch(
+            "paddle.distributed.stream.reduce_scatter",
+            side_effect=_fake_reduce_scatter,
+        ):
+            combined, fn_out = _AllGatherCombineAsync.apply(
+                x, fake_group, a, fn=fn, is_first_fwd=False
+            )
+
+        loss = combined.sum() + fn_out.sum()
+        with (
+            mock.patch(
+                "paddle.distributed.stream.all_gather",
+                side_effect=_fake_all_gather,
+            ),
+            mock.patch(
+                "paddle.distributed.stream.reduce_scatter",
+                side_effect=_fake_reduce_scatter,
+            ),
+        ):
+            loss.backward()
+
+        # grad of reduce_scatter is all_gather: shape restored to [4, 8].
+        self.assertEqual(list(x.grad.shape), [4, 8])
+        self.assertTrue(
+            paddle.allclose(a.grad, paddle.full_like(a, 3.0)).item()
+        )
+
+
+class TestPreAllGatherResultMultiRank(unittest.TestCase):
+    """Cover the multi-rank backward of ``_PreAllGatherResult`` where
+    ``ReduceScatterGroupOp`` invokes the real reduce-scatter primitive.
+    """
+
+    def test_multi_rank_forward_backward(self):
+        fake_group = SimpleNamespace(nranks=2, rank=0)
+        x = paddle.randn([4, 8], dtype="float32")
+        x.stop_gradient = False
+
+        out_buf = paddle.concat([x, x + 1.0], axis=0)
+
+        class _DummyTask:
+            def wait(self):
+                pass
+
+        handle = {"output": out_buf, "task": _DummyTask(), "group": fake_group}
+
+        y = _PreAllGatherResult.apply(x, handle)
+        self.assertEqual(list(y.shape), [8, 8])
+        self.assertTrue(paddle.allclose(y[:4], x).item())
+        self.assertTrue(paddle.allclose(y[4:], x + 1.0).item())
+
+        with mock.patch(
+            "paddle.distributed.stream.reduce_scatter",
+            side_effect=_fake_reduce_scatter,
+        ):
+            y.sum().backward()
+
+        self.assertEqual(list(x.grad.shape), [4, 8])
+        self.assertTrue(paddle.allclose(x.grad, paddle.ones_like(x)).item())
+
+
+class TestAllGatherTokenDispatcherMultiRank(unittest.TestCase):
+    """Cover the multi-rank paths inside ``AllGatherTokenDispatcher`` that
+    exercise async AllGather, pre-ag-handle cleanup, overlap combine, and
+    the ReduceScatter combine-postprocess branch.
+    """
+
+    def test_pre_allgather_creates_async_handle(self):
+        fake_group = SimpleNamespace(nranks=2, rank=0)
+        d = AllGatherTokenDispatcher(
+            moe_group=fake_group, expert_model_parallel_size=2, num_experts=8
+        )
+        x = paddle.randn([4, 16], dtype="float32")
+        with mock.patch(
+            "paddle.distributed.stream.all_gather", side_effect=_fake_all_gather
+        ):
+            d.pre_allgather(x)
+        self.assertIsNotNone(d._pre_ag_handle)
+        self.assertEqual(list(d._pre_ag_handle["output"].shape), [8, 16])
+
+    def test_pre_allgather_cleans_leftover_handle(self):
+        fake_group = SimpleNamespace(nranks=2, rank=0)
+        d = AllGatherTokenDispatcher(
+            moe_group=fake_group, expert_model_parallel_size=2, num_experts=8
+        )
+
+        class _DummyTask:
+            def wait(self):
+                pass
+
+        d._pre_ag_handle = {
+            "output": None,
+            "task": _DummyTask(),
+            "group": fake_group,
+        }
+        x = paddle.randn([4, 16], dtype="float32")
+        with mock.patch(
+            "paddle.distributed.stream.all_gather", side_effect=_fake_all_gather
+        ):
+            d.pre_allgather(x)
+        self.assertIsNotNone(d._pre_ag_handle)
+        # New handle should have been created after clearing the old one.
+        self.assertEqual(list(d._pre_ag_handle["output"].shape), [8, 16])
+
+    def test_pre_allgather_warns_on_leftover_wait_failure(self):
+        fake_group = SimpleNamespace(nranks=2, rank=0)
+        d = AllGatherTokenDispatcher(
+            moe_group=fake_group, expert_model_parallel_size=2, num_experts=8
+        )
+
+        class _FailingTask:
+            def wait(self):
+                raise RuntimeError("boom")
+
+        d._pre_ag_handle = {
+            "output": None,
+            "task": _FailingTask(),
+            "group": fake_group,
+        }
+        x = paddle.randn([4, 16], dtype="float32")
+        with (
+            mock.patch(
+                "paddle.distributed.stream.all_gather",
+                side_effect=_fake_all_gather,
+            ),
+            mock.patch(
+                "paddlefleet.transformer.moe.token_dispatcher.logger.warning"
+            ) as mock_warn,
+        ):
+            d.pre_allgather(x)
+        self.assertTrue(mock_warn.called)
+        self.assertIsNotNone(d._pre_ag_handle)
+
+    def test_dispatch_preprocess_uses_pre_ag_handle(self):
+        fake_group = SimpleNamespace(nranks=2, rank=0)
+        d = AllGatherTokenDispatcher(
+            moe_group=fake_group, expert_model_parallel_size=2, num_experts=8
+        )
+        x = paddle.randn([4, 16], dtype="float32")
+        probs = paddle.randn([4, 8])
+        topk_weights = paddle.randn([4, 2])
+        topk_indices = paddle.randint(0, 8, [4, 2])
+        mask = paddle.ones([4, 8], dtype="bool")
+
+        out_buf = paddle.concat(
+            [x.reshape([-1, 16]), x.reshape([-1, 16])], axis=0
+        )
+
+        class _DummyTask:
+            def wait(self):
+                pass
+
+        d._pre_ag_handle = {
+            "output": out_buf,
+            "task": _DummyTask(),
+            "group": fake_group,
+        }
+
+        with (
+            mock.patch("paddle.distributed.barrier"),
+            mock.patch(
+                "paddle.distributed.stream.all_gather",
+                side_effect=_fake_all_gather,
+            ),
+        ):
+            result = d.dispatch_preprocess(
+                x, probs, mask, topk_weights, topk_indices
+            )
+
+        self.assertEqual(list(result.shape), [8, 16])
+        self.assertIsNone(d._pre_ag_handle)
+
+    def test_dispatch_preprocess_fallback_all_gather_group_op(self):
+        fake_group = SimpleNamespace(nranks=2, rank=0)
+        d = AllGatherTokenDispatcher(
+            moe_group=fake_group, expert_model_parallel_size=2, num_experts=8
+        )
+        x = paddle.randn([4, 16], dtype="float32")
+        probs = paddle.randn([4, 8])
+        topk_weights = paddle.randn([4, 2])
+        topk_indices = paddle.randint(0, 8, [4, 2])
+        mask = paddle.ones([4, 8], dtype="bool")
+
+        with (
+            mock.patch("paddle.distributed.barrier"),
+            mock.patch(
+                "paddle.distributed.stream.all_gather",
+                side_effect=_fake_all_gather,
+            ),
+        ):
+            result = d.dispatch_preprocess(
+                x, probs, mask, topk_weights, topk_indices
+            )
+
+        self.assertEqual(list(result.shape), [8, 16])
+
+    def test_token_combine_overlap_path(self):
+        fake_group = SimpleNamespace(nranks=2, rank=0)
+        d = AllGatherTokenDispatcher(
+            moe_group=fake_group, expert_model_parallel_size=2, num_experts=8
+        )
+        hidden = paddle.randn([4, 16], dtype="float32")
+
+        def fn(t):
+            return (t * 2.0,)
+
+        handle = {"fn": fn, "fn_args": (hidden.clone(),)}
+
+        with mock.patch(
+            "paddle.distributed.stream.reduce_scatter",
+            side_effect=_fake_reduce_scatter,
+        ):
+            combined = d.token_combine(hidden, combine_overlap_handle=handle)
+
+        self.assertEqual(list(combined.shape), [2, 16])
+        self.assertIn("fn_out", handle)
+        self.assertIsNotNone(d._overlap_combined)
+
+    def test_combine_postprocess_reduce_scatter_path(self):
+        fake_group = SimpleNamespace(nranks=2, rank=0)
+        d = AllGatherTokenDispatcher(
+            moe_group=fake_group, expert_model_parallel_size=2, num_experts=8
+        )
+        hidden = paddle.randn([4, 16], dtype="float32")
+        hidden.stop_gradient = False
+
+        with mock.patch(
+            "paddle.distributed.stream.reduce_scatter",
+            side_effect=_fake_reduce_scatter,
+        ):
+            out = d.combine_postprocess(hidden)
+
+        self.assertEqual(list(out.shape), [2, 16])
+
+
+class TestGroupedMLPExpertShardedStateDict(unittest.TestCase):
+    """Cover the intermediate-sharded branch of
+    ``GroupedMLPExpert.sharded_state_dict``.
+
+    The branch is hit when ``intermediate_size_per_partition`` differs
+    from ``config.moe_intermediate_size`` (i.e. the AllGather dispatcher
+    layout). Verifies:
+
+    * ``shard_weight`` is invoked on the right axes (3 for w1, 1 for w2)
+    * ``weight1`` is reshaped to ``[E, H, 2, I_local]`` to disentangle
+      gate/up before EP-sharding the intermediate dim
+    * ``weight2`` is passed through as ``[E, I_local, H]``
+    * ``grouped_gemm_param`` is set on both sharded results
+    * Validation errors are raised for missing ep_group, non-gated MLP,
+      and dimension mismatches
+    """
+
+    def _make_self(
+        self,
+        E=4,
+        H=8,
+        I_full=16,
+        ep_size=2,
+        ep_group=None,
+        gated_linear_unit=True,
+    ):
+        I_local = I_full // ep_size
+        if ep_group is None:
+            ep_group = SimpleNamespace(nranks=ep_size)
+        weight1 = paddle.randn([E, H, 2 * I_local], dtype="float32")
+        weight1.name = "w1_param"
+        weight2 = paddle.randn([E, I_local, H], dtype="float32")
+        weight2.name = "w2_param"
+        config = SimpleNamespace(
+            moe_intermediate_size=I_full,
+            hidden_size=H,
+            gated_linear_unit=gated_linear_unit,
+            moe_token_dispatcher_type="allgather",
+        )
+        mock_self = SimpleNamespace(
+            num_local_experts=E,
+            intermediate_size_per_partition=I_local,
+            ep_group=ep_group,
+            weight1=weight1,
+            weight2=weight2,
+            config=config,
+        )
+        # Make .state_dict() return tensors with the parameter shapes;
+        # sharded_state_dict only consumes weight1/weight2.
+        mock_self.state_dict = lambda structured_name_prefix="": {
+            "weight1": weight1.clone().detach(),
+            "weight2": weight2.clone().detach(),
+        }
+        return mock_self, E, H, I_local
+
+    def test_intermediate_sharded_branch_calls_shard_weight(self):
+        mock_self, E, H, I_local = self._make_self()
+        captured = []
+
+        def fake_shard_weight(key, weight, axis, group):
+            captured.append(
+                {
+                    "key": key,
+                    "weight_shape": list(weight.shape),
+                    "axis": axis,
+                    "group": group,
+                }
+            )
+            return weight  # a writable object so .grouped_gemm_param sticks
+
+        with mock.patch(
+            "paddlefleet.transformer.moe.moe_expert.shard_weight",
+            side_effect=fake_shard_weight,
+        ):
+            out = GroupedMLPExpert.sharded_state_dict(
+                mock_self, structured_name_prefix="prefix."
+            )
+
+        keys = sorted(out.keys())
+        self.assertEqual(keys, ["prefix.weight1", "prefix.weight2"])
+        # Both results must carry grouped_gemm_param=True.
+        self.assertTrue(out["prefix.weight1"].grouped_gemm_param)
+        self.assertTrue(out["prefix.weight2"].grouped_gemm_param)
+
+        by_key = {c["key"]: c for c in captured}
+        # weight1 sharded along axis=3 (I_local), reshape disentangles
+        # gate/up onto axis=2.
+        self.assertEqual(by_key["prefix.weight1"]["axis"], 3)
+        self.assertEqual(
+            by_key["prefix.weight1"]["weight_shape"], [E, H, 2, I_local]
+        )
+        # weight2 sharded along axis=1 (intermediate dim).
+        self.assertEqual(by_key["prefix.weight2"]["axis"], 1)
+        self.assertEqual(
+            by_key["prefix.weight2"]["weight_shape"], [E, I_local, H]
+        )
+        # ep_group threaded through.
+        self.assertIs(by_key["prefix.weight1"]["group"], mock_self.ep_group)
+        self.assertIs(by_key["prefix.weight2"]["group"], mock_self.ep_group)
+
+    def test_intermediate_sharded_requires_ep_group(self):
+        mock_self, *_ = self._make_self(ep_group=False)
+        mock_self.ep_group = None
+        with self.assertRaisesRegex(ValueError, "EP group"):
+            GroupedMLPExpert.sharded_state_dict(mock_self)
+
+    def test_intermediate_sharded_requires_gated_linear_unit(self):
+        mock_self, *_ = self._make_self(gated_linear_unit=False)
+        with (
+            self.assertRaisesRegex(ValueError, "gated"),
+            mock.patch("paddlefleet.transformer.moe.moe_expert.shard_weight"),
+        ):
+            GroupedMLPExpert.sharded_state_dict(mock_self)
+
+    def test_intermediate_sharded_rejects_size_mismatch(self):
+        # ep_size * I_local != moe_intermediate_size
+        mock_self, *_ = self._make_self(ep_size=2, I_full=16)
+        # Force a wrong ep_size via the group nranks.
+        mock_self.ep_group = SimpleNamespace(nranks=4)
+        with (
+            self.assertRaisesRegex(ValueError, "inconsistency"),
+            mock.patch("paddlefleet.transformer.moe.moe_expert.shard_weight"),
+        ):
+            GroupedMLPExpert.sharded_state_dict(mock_self)
+
+    def test_non_intermediate_sharded_skips_branch(self):
+        """If intermediate_size_per_partition == moe_intermediate_size
+        the new branch must be bypassed (else axis=3 would be wrong)."""
+        # ep_size=1 keeps I_local == I_full, so is_intermediate_sharded=False.
+        mock_self, *_ = self._make_self(ep_size=1, I_full=16)
+        # Original path then enters model_type/ep_group path. We only
+        # need to confirm shard_weight is NOT called on the 4-D w1.
+        with (
+            mock.patch(
+                "paddlefleet.transformer.moe.moe_expert.shard_weight"
+            ) as sw,
+            mock.patch(
+                "paddlefleet.transformer.moe.moe_expert.build_sharded_state_dict",
+                return_value={},
+            ),
+        ):
+            GroupedMLPExpert.sharded_state_dict(mock_self)
+        # Either branch (model_type fall-through) might still call
+        # shard_weight, but never with axis=3.
+        for call in sw.call_args_list:
+            self.assertNotEqual(call.kwargs.get("axis"), 3)
+
+    def test_intermediate_sharded_rejects_bad_weight1_shape(self):
+        """weight1 last dim must equal 2 * I_local."""
+        mock_self, E, H, I_local = self._make_self()
+        # Corrupt weight1 so its last dim is wrong.
+        bad_w1 = paddle.randn([E, H, 2 * I_local + 1], dtype="float32")
+        bad_w1.name = "w1_param"
+        mock_self.weight1 = bad_w1
+        mock_self.state_dict = lambda structured_name_prefix="": {
+            "weight1": bad_w1.clone().detach(),
+            "weight2": mock_self.weight2.clone().detach(),
+        }
+        with (
+            self.assertRaisesRegex(ValueError, "weight1 last dim"),
+            mock.patch("paddlefleet.transformer.moe.moe_expert.shard_weight"),
+        ):
+            GroupedMLPExpert.sharded_state_dict(mock_self)
+
+
+class TestGroupedMLPExpertForwardEdgeCases(unittest.TestCase):
+    """Cover edge-case branches in GroupedMLPExpert.forward."""
+
+    def _make_expert(self, E=2, H=8, I=16):
+        config = SimpleNamespace(
+            hidden_size=H,
+            moe_intermediate_size=I,
+            gated_linear_unit=True,
+            activation_func=paddle.nn.functional.gelu,
+            init_method=lambda t: None,
+            output_layer_init_method=lambda t: None,
+            using_sonic_moe=False,
+            use_bias=False,
+            fp8=None,
+            recompute_granularity=None,
+            recompute_modules=None,
+        )
+        expert = GroupedMLPExpert(
+            num_local_experts=E,
+            config=config,
+            moe_deep_gemm=False,
+        )
+        return expert
+
+    def test_empty_tokens_with_nonzero_tokens_per_expert_raises(self):
+        """RuntimeError when numel==0 but tokens_per_expert is not all-zero."""
+        expert = self._make_expert()
+        empty = paddle.randn([0, 8], dtype="float32")
+        bad_tpe = paddle.to_tensor([1, 0], dtype="int32")
+        with self.assertRaisesRegex(RuntimeError, "all-zero tokens_per_expert"):
+            expert.forward(empty, bad_tpe)
+
+
+class TestSonicMoEExpertValidation(unittest.TestCase):
+    """Cover validation paths in SonicMoEExpert.__init__."""
+
+    def test_gated_linear_unit_required(self):
+        """SonicMoEExpert requires gated_linear_unit=True."""
+        config = SimpleNamespace(
+            hidden_size=8,
+            moe_intermediate_size=16,
+            gated_linear_unit=False,
+            activation_func=paddle.nn.functional.gelu,
+            init_method=lambda t: None,
+            output_layer_init_method=lambda t: None,
+        )
+        with self.assertRaisesRegex(ValueError, "SwiGLU"):
+            from paddlefleet.transformer.moe.moe_expert import SonicMoEExpert
+
+            SonicMoEExpert(
+                num_local_experts=2,
+                topk=1,
+                config=config,
+            )
+
+
+class TestRouterAllGatherBackwardReshape(unittest.TestCase):
+    """Cover the defensive shape-restoration branches inside
+    ``_RouterAllGather.backward`` by invoking the static method directly
+    with a hand-built context object. Paddle's autograd reshapes the
+    upstream gradient before calling ``PyLayer.backward``, so these
+    branches are otherwise unreachable from a Python-level test.
+    """
+
+    def test_group_none_reshapes_grad_when_shape_mismatch(self):
+        """When group is None and the grad arrives with a non-matching
+        shape, backward must reshape it to the original input shape.
+        """
+
+        class _Ctx:
+            group = None
+            input_shape = [6, 4]
+
+        # 1-D grad with same numel as input_shape.
+        out = _RouterAllGather.backward(_Ctx(), paddle.ones([24]))
+        self.assertEqual(list(out.shape), [6, 4])
+
+    def test_multi_rank_reshapes_grad_to_global_shape(self):
+        """When the upstream grad is 1-D, backward must reshape it to
+        ``[T_global, *trailing]`` before splitting per rank.
+        """
+
+        class _Ctx:
+            group = SimpleNamespace(nranks=2, rank=1)
+            input_shape = [3, 4]
+
+        flat_grad = paddle.concat(
+            [paddle.full([12], 1.0), paddle.full([12], 2.0)]
+        )
+        out = _RouterAllGather.backward(_Ctx(), flat_grad)
+        # rank=1 owns the second chunk (2.0).
+        self.assertEqual(list(out.shape), [3, 4])
+        self.assertTrue(paddle.allclose(out, paddle.full([3, 4], 2.0)).item())
+
+    def test_multi_rank_reshapes_chunk_to_local_shape(self):
+        """When the per-rank split chunk shape does not match
+        ``local_shape`` (e.g. trailing dims are differently grouped),
+        backward must reshape it.
+        """
+
+        class _Ctx:
+            group = SimpleNamespace(nranks=2, rank=0)
+            # local_shape with multi-D trailing dims.
+            input_shape = [3, 2, 2]
+
+        # Provide global-shaped grad as flat to also exercise the
+        # global-shape reshape path; the chunk after split is [3, 2, 2]
+        # so chunk-shape branch only triggers if trailing dims merge.
+        # Build grad already in [6, 2, 2] then split chunk shape == local.
+        # To force a chunk reshape, give grad shape [6, 4] (numel=24)
+        # which matches global_shape [6, 2, 2] only after reshape; chunk
+        # of grad [6,4] split axis=0 gives [3,4] != local_shape [3,2,2].
+        grad = paddle.arange(24, dtype="float32").reshape([6, 4])
+        out = _RouterAllGather.backward(_Ctx(), grad)
+        self.assertEqual(list(out.shape), [3, 2, 2])
+
+
+class TestAllGatherCombineAsyncErrors(unittest.TestCase):
+    """Cover validation paths in ``_AllGatherCombineAsync.forward``."""
+
+    def test_forward_rejects_non_divisible_token_dim(self):
+        """token dim must be divisible by EP size."""
+        x = paddle.randn([5, 8], dtype="float32")
+        x.stop_gradient = False
+        a = paddle.randn([5, 8], dtype="float32")
+        a.stop_gradient = False
+        fake_group = SimpleNamespace(nranks=2, rank=0)
+
+        def fn(t):
+            return (t,)
+
+        with self.assertRaisesRegex(ValueError, "not divisible"):
+            _AllGatherCombineAsync.apply(
+                x, fake_group, a, fn=fn, is_first_fwd=False
+            )
+
+
+class TestAllGatherTokenDispatcher3DInputs(unittest.TestCase):
+    """Cover the 3-D ``hidden_states`` branches of ``pre_allgather`` and
+    ``dispatch_preprocess``.
+    """
+
+    def test_pre_allgather_3d_hidden_states(self):
+        fake_group = SimpleNamespace(nranks=2, rank=0)
+        d = AllGatherTokenDispatcher(
+            moe_group=fake_group, expert_model_parallel_size=2, num_experts=8
+        )
+        x = paddle.randn([2, 3, 16], dtype="float32")
+        with mock.patch(
+            "paddle.distributed.stream.all_gather", side_effect=_fake_all_gather
+        ):
+            d.pre_allgather(x)
+        self.assertIsNotNone(d._pre_ag_handle)
+
+    def test_dispatch_preprocess_3d_hidden_states(self):
+        fake_group = SimpleNamespace(nranks=2, rank=0)
+        d = AllGatherTokenDispatcher(
+            moe_group=fake_group, expert_model_parallel_size=2, num_experts=8
+        )
+        x = paddle.randn([2, 3, 16], dtype="float32")
+        probs = paddle.randn([6, 8])
+        topk_weights = paddle.randn([6, 2])
+        topk_indices = paddle.randint(0, 8, [6, 2])
+        mask = paddle.ones([6, 8], dtype="bool")
+        with (
+            mock.patch("paddle.distributed.barrier"),
+            mock.patch(
+                "paddle.distributed.stream.all_gather",
+                side_effect=_fake_all_gather,
+            ),
+        ):
+            result = d.dispatch_preprocess(
+                x, probs, mask, topk_weights, topk_indices
+            )
+        # 6 (= 2*3) tokens locally, *2 ranks = 12 globally.
+        self.assertEqual(list(result.shape), [12, 16])
+
+
+class TestAllGatherTokenDispatcherValidation(unittest.TestCase):
+    """Cover validation paths in ``AllGatherTokenDispatcher``."""
+
+    def _make_dispatcher(self):
+        fake_group = SimpleNamespace(nranks=2, rank=0)
+        return AllGatherTokenDispatcher(
+            moe_group=fake_group, expert_model_parallel_size=2, num_experts=8
+        )
+
+    def test_dispatch_preprocess_requires_topk_indices_and_weights(self):
+        d = self._make_dispatcher()
+        x = paddle.randn([4, 16], dtype="float32")
+        probs = paddle.randn([4, 8])
+        mask = paddle.ones([4, 8], dtype="bool")
+        with (
+            mock.patch("paddle.distributed.barrier"),
+            mock.patch(
+                "paddle.distributed.stream.all_gather",
+                side_effect=_fake_all_gather,
+            ),
+            self.assertRaisesRegex(ValueError, "topk_indices"),
+        ):
+            d.dispatch_preprocess(x, probs, mask, None, None)
+
+    def test_token_combine_rejects_non_dict_handle(self):
+        d = self._make_dispatcher()
+        x = paddle.randn([4, 16], dtype="float32")
+        with self.assertRaisesRegex(TypeError, "must be a dict"):
+            d.token_combine(x, combine_overlap_handle="not-a-dict")
+
+    def test_token_combine_rejects_handle_missing_keys(self):
+        d = self._make_dispatcher()
+        x = paddle.randn([4, 16], dtype="float32")
+        with self.assertRaisesRegex(ValueError, "'fn' and 'fn_args'"):
+            d.token_combine(x, combine_overlap_handle={"fn": lambda t: (t,)})
+
+    def test_token_combine_rejects_non_tuple_fn_args(self):
+        d = self._make_dispatcher()
+        x = paddle.randn([4, 16], dtype="float32")
+        with self.assertRaisesRegex(TypeError, "must be a tuple"):
+            d.token_combine(
+                x,
+                combine_overlap_handle={
+                    "fn": lambda t: (t,),
+                    "fn_args": [x],  # list, not tuple
+                },
+            )
+
+
+class TestMoEFlexTokenDispatcherCombineGuard(unittest.TestCase):
+    """Cover ``MoEFlexTokenDispatcher.token_combine`` overlap-handle
+    rejection.
+    """
+
+    def test_token_combine_rejects_overlap_handle(self):
+        # Bypass __init__ since it constructs a real comm manager.
+        d = MoEFlexTokenDispatcher.__new__(MoEFlexTokenDispatcher)
+        d._comm_manager = mock.MagicMock()
+        x = paddle.randn([4, 16], dtype="float32")
+        with self.assertRaisesRegex(ValueError, "does not support"):
+            d.token_combine(x, combine_overlap_handle={"fn": lambda t: t})
+
+
+class TestMoELayerDispatchPreprocessGuard(unittest.TestCase):
+    """Cover ``MoELayer.dispatch_preprocess`` type-check on the
+    token_dispatcher (rejects non-MoEFlex backends).
+    """
+
+    def test_rejects_non_moeflex_dispatcher(self):
+        mock_self = SimpleNamespace(
+            use_latent_moe=False,
+            token_dispatcher=mock.MagicMock(spec=AllGatherTokenDispatcher),
+        )
+        x = paddle.randn([4, 16], dtype="float32")
+        probs = paddle.randn([4, 8])
+        indices = paddle.randint(0, 8, [4, 2])
+        with self.assertRaisesRegex(TypeError, "MoEFlexTokenDispatcher"):
+            MoELayer.dispatch_preprocess(mock_self, (x, probs, indices))
+
+
+class TestMoELayerForwardPreAllGatherBranches(unittest.TestCase):
+    """Cover the ``forward()`` pre_allgather gate-overlap branches:
+
+    * ``use_latent_moe=True``: project to latent space and pre_allgather it.
+    * ``use_latent_moe=False``: pre_allgather raw hidden_states.
+
+    To keep the test single-card and self-contained we stub ``self.gate``
+    to raise a sentinel so the rest of forward is short-circuited; we only
+    verify the pre_allgather call.
+    """
+
+    class _Sentinel(Exception):
+        pass
+
+    def _make_self(self, use_latent_moe, fc1_out=None):
+        latent_proj = mock.MagicMock(return_value=fc1_out)
+        dispatcher = mock.MagicMock(spec=AllGatherTokenDispatcher)
+        config = SimpleNamespace(moe_allgather_gate_overlap=True)
+
+        def gate_stub(*args, **kwargs):
+            raise self._Sentinel
+
+        ns = SimpleNamespace(
+            expert_model_parallel_size=2,
+            sequence_parallel=False,
+            moe_token_dispatcher_type="allgather",
+            config=config,
+            use_latent_moe=use_latent_moe,
+            _latent_hidden=None,
+            fc1_latent_proj=latent_proj,
+            token_dispatcher=dispatcher,
+            gate=gate_stub,
+            layer_number=0,
+        )
+        # Bind the real method so it can access mock attributes.
+        ns._maybe_pre_allgather_overlap = (
+            MoELayer._maybe_pre_allgather_overlap.__get__(ns)
+        )
+        return ns
+
+    def test_pre_allgather_with_latent_moe(self):
+        latent_out = paddle.randn([4, 16], dtype="float32")
+        mock_self = self._make_self(use_latent_moe=True, fc1_out=latent_out)
+        x = paddle.randn([4, 8], dtype="float32")
+        with self.assertRaises(self._Sentinel):
+            MoELayer.forward(mock_self, x)
+        # fc1_latent_proj projection cached; pre_allgather called on it.
+        self.assertIs(mock_self._latent_hidden, latent_out)
+        mock_self.token_dispatcher.pre_allgather.assert_called_once_with(
+            latent_out
+        )
+
+    def test_pre_allgather_without_latent_moe(self):
+        mock_self = self._make_self(use_latent_moe=False)
+        x = paddle.randn([4, 8], dtype="float32")
+        with self.assertRaises(self._Sentinel):
+            MoELayer.forward(mock_self, x)
+        self.assertIsNone(mock_self._latent_hidden)
+        mock_self.token_dispatcher.pre_allgather.assert_called_once_with(x)
+
+
+class TestMoELayerCustomForwardBranches(unittest.TestCase):
+    """Cover branches inside ``MoELayer.custom_forward``:
+
+    * latent_moe with a cached ``_latent_hidden`` (the AllGather-overlap
+      path stashes the projected latent tensor in ``forward()`` so
+      ``custom_forward`` must consume it instead of re-projecting).
+    * ``log_moe_balance`` allgather branch (re-derives per-rank tokens
+      from ``_global_topk_indices`` since AllGather has no comm_manager).
+    * ``log_moe_balance`` non-allgather branch (reads from comm_manager).
+    """
+
+    def _make_self(self, dispatcher_type, use_latent_moe, latent_cached=None):
+        dispatcher = mock.MagicMock()
+        if dispatcher_type == "allgather":
+            dispatcher._global_topk_indices = paddle.to_tensor(
+                [[0, 1], [2, 3], [0, 2], [1, 3]], dtype="int64"
+            )
+        else:
+            dispatcher._comm_manager.tokens_per_expert = paddle.to_tensor(
+                [1, 2, 3, 4], dtype="int64"
+            )
+        # dispatch returns a (hidden_states, _) tuple.
+        token_seq = paddle.randn([4, 8], dtype="float32")
+        return SimpleNamespace(
+            use_latent_moe=use_latent_moe,
+            _latent_hidden=latent_cached,
+            fc1_latent_proj=mock.MagicMock(side_effect=lambda x: x * 2),
+            fc2_latent_proj=mock.MagicMock(side_effect=lambda x: x + 1),
+            dispatch=mock.MagicMock(return_value=(token_seq, None)),
+            routed_experts_compute=mock.MagicMock(return_value=token_seq),
+            combine=mock.MagicMock(return_value=token_seq),
+            moe_token_dispatcher_type=dispatcher_type,
+            token_dispatcher=dispatcher,
+            num_experts=4,
+            expert_model_parallel_size=2,
+            num_experts_per_tok=2,
+            moe_group=SimpleNamespace(rank=0),
+            moe_rank=0,
+            layer_number=0,
+        )
+
+    def _patch_balance_enabled(self, enabled):
+        return mock.patch(
+            "paddlefleet.transformer.moe.moe_layer.global_moe_balance_training_logs_enabled",
+            return_value=enabled,
+        )
+
+    def _patch_has_grad(self, has_grad):
+        tracer = SimpleNamespace(_has_grad=has_grad)
+        return mock.patch(
+            "paddlefleet.transformer.moe.moe_layer.framework._dygraph_tracer",
+            return_value=tracer,
+        )
+
+    def test_latent_moe_always_calls_fc1(self):
+        """custom_forward always calls fc1_latent_proj directly — it does
+        not consume the _latent_hidden cache (that's _project_to_latent
+        which is used by fusion_moe_forward)."""
+        mock_self = self._make_self(
+            dispatcher_type="alltoall",
+            use_latent_moe=True,
+            latent_cached=paddle.randn([4, 8]),
+        )
+        x = paddle.randn([4, 8], dtype="float32")
+        with self._patch_has_grad(False):
+            out = MoELayer.custom_forward(
+                mock_self,
+                x,
+                probs=paddle.randn([4, 4]),
+                routing_map=paddle.ones([4, 4], dtype="bool"),
+            )
+        # custom_forward always calls fc1_latent_proj directly.
+        mock_self.fc1_latent_proj.assert_called_once()
+        # fc2 projection applied to combined output.
+        mock_self.fc2_latent_proj.assert_called_once()
+        self.assertEqual(out.shape, [4, 8])
+
+    def test_log_balance_allgather_branch_rejected(self):
+        """custom_forward requires MoEFlexTokenDispatcher; allgather
+        dispatcher should raise TypeError."""
+        mock_self = self._make_self(
+            dispatcher_type="allgather", use_latent_moe=False
+        )
+        x = paddle.randn([4, 8], dtype="float32")
+        with self._patch_has_grad(True), self.assertRaises(TypeError):
+            MoELayer.custom_forward(
+                mock_self,
+                x,
+                probs=paddle.randn([4, 4]),
+                routing_map=paddle.ones([4, 4], dtype="bool"),
+            )
+
+    def test_log_balance_non_allgather_branch(self):
+        mock_self = self._make_self(
+            dispatcher_type="alltoall", use_latent_moe=False
+        )
+        x = paddle.randn([4, 8], dtype="float32")
+        with (
+            self._patch_has_grad(True),
+            self._patch_balance_enabled(True),
+            mock.patch(
+                "paddlefleet.transformer.moe.moe_layer.log_moe_balance"
+            ) as log_balance,
+        ):
+            MoELayer.custom_forward(
+                mock_self,
+                x,
+                probs=paddle.randn([4, 4]),
+                routing_map=paddle.ones([4, 4], dtype="bool"),
+            )
+        log_balance.assert_called_once()
+        # tokens_per_expert came from comm_manager.tokens_per_expert.
+        _, _, _, tpe = log_balance.call_args[0]
+        self.assertTrue(
+            paddle.allclose(
+                tpe, paddle.to_tensor([1, 2, 3, 4], dtype="int64")
+            ).item()
+        )
+
+
+class TestMoELayerFusionMoEForwardBranches(unittest.TestCase):
+    """Cover branches inside ``MoELayer.fusion_moe_forward``:
+
+    * AllGather dispatcher: token_combine + combine_postprocess split.
+    * AllGather log_balance: re-derive tokens_per_expert from
+      ``_global_topk_indices`` (no comm_manager).
+    * Non-allgather log_balance: read from comm_manager.
+    """
+
+    def _make_self(self, dispatcher_type, has_balance_log):
+        dispatcher = mock.MagicMock()
+        if dispatcher_type == "allgather":
+            dispatcher._global_topk_indices = paddle.to_tensor(
+                [[0, 1], [2, 3], [0, 2], [1, 3]], dtype="int64"
+            )
+            dispatcher._global_topk_weights = paddle.randn([4, 2])
+            dispatcher.token_combine = mock.MagicMock(
+                return_value=paddle.randn([4, 8])
+            )
+            dispatcher.combine_postprocess = mock.MagicMock(
+                return_value=paddle.randn([4, 8])
+            )
+            # get_dispatched_routing returns (indices, probs, tokens_per_expert)
+            tpe_allgather = paddle.bincount(
+                dispatcher._global_topk_indices.reshape([-1]).cast("int64"),
+                minlength=4,
+            )
+            dispatcher.get_dispatched_routing = mock.MagicMock(
+                return_value=(
+                    dispatcher._global_topk_indices,
+                    dispatcher._global_topk_weights,
+                    tpe_allgather,
+                )
+            )
+        else:
+            dispatcher._comm_manager.dispatched_indices = paddle.to_tensor(
+                [[0, 1], [2, 3]], dtype="int64"
+            )
+            dispatcher._comm_manager.dispatched_probs = paddle.randn([2, 2])
+            dispatcher._comm_manager.tokens_per_expert = paddle.to_tensor(
+                [1, 2, 3, 4], dtype="int64"
+            )
+            dispatcher._comm_manager.combine = mock.MagicMock(
+                return_value=paddle.randn([4, 8])
+            )
+
+        token_seq = paddle.randn([4, 8], dtype="float32")
+        # Callable mock for grouped_gemm_experts (sonic-moe expert).
+        grouped = mock.MagicMock(return_value=token_seq)
+        ns = SimpleNamespace(
+            use_latent_moe=False,
+            _latent_hidden=None,
+            fc1_latent_proj=mock.MagicMock(side_effect=lambda x: x),
+            fc2_latent_proj=mock.MagicMock(side_effect=lambda x: x),
+            dispatch=mock.MagicMock(return_value=(token_seq, None)),
+            _use_hybrid_ep_fusion=mock.MagicMock(return_value=False),
+            using_sonic_moe=True,
+            grouped_gemm_experts=grouped,
+            fp8=None,
+            moe_token_dispatcher_type=dispatcher_type,
+            token_dispatcher=dispatcher,
+            num_experts=4,
+            expert_model_parallel_size=2,
+            num_experts_per_tok=2,
+            moe_group=SimpleNamespace(rank=0),
+            moe_rank=0,
+            layer_number=0,
+            use_rr_deepep_combine=False,
+            config=SimpleNamespace(activation_func_clamp_value=0.0),
+        )
+        ns._project_to_latent = MoELayer._project_to_latent.__get__(ns)
+        return ns
+
+    def _patch_balance(self, enabled):
+        return mock.patch(
+            "paddlefleet.transformer.moe.moe_layer.global_moe_balance_training_logs_enabled",
+            return_value=enabled,
+        )
+
+    def _patch_has_grad(self, has_grad):
+        tracer = SimpleNamespace(_has_grad=has_grad)
+        return mock.patch(
+            "paddlefleet.transformer.moe.moe_layer.framework._dygraph_tracer",
+            return_value=tracer,
+        )
+
+    def _run_fusion_forward(self, mock_self):
+        x = paddle.randn([4, 8], dtype="float32")
+        return MoELayer.fusion_moe_forward(
+            mock_self,
+            x,
+            probs=paddle.randn([4, 4]),
+            routing_map=paddle.ones([4, 4], dtype="bool"),
+            combine_overlap_handle=None,
+            topk_weights=paddle.randn([4, 2]),
+            topk_indices=paddle.randint(0, 4, [4, 2]),
+        )
+
+    def test_allgather_combine_path(self):
+        mock_self = self._make_self(
+            dispatcher_type="allgather", has_balance_log=False
+        )
+        with (
+            self._patch_has_grad(False),
+            self._patch_balance(False),
+        ):
+            self._run_fusion_forward(mock_self)
+        # Allgather path now uses self.combine() which internally calls
+        # token_combine + combine_postprocess.
+        mock_self.token_dispatcher.token_combine.assert_called_once()
+        mock_self.token_dispatcher.combine_postprocess.assert_called_once()
+
+    def test_allgather_log_balance(self):
+        mock_self = self._make_self(
+            dispatcher_type="allgather", has_balance_log=True
+        )
+        with (
+            self._patch_has_grad(True),
+            self._patch_balance(True),
+            mock.patch(
+                "paddlefleet.transformer.moe.moe_layer.log_moe_balance"
+            ) as log_balance,
+        ):
+            self._run_fusion_forward(mock_self)
+        log_balance.assert_called_once()
+        _, _, _, tpe = log_balance.call_args[0]
+        # AllGather mode: full [num_experts] bincount vector (no reshape).
+        self.assertEqual(list(tpe.shape), [4])
+
+    def test_non_allgather_log_balance(self):
+        mock_self = self._make_self(
+            dispatcher_type="alltoall", has_balance_log=True
+        )
+        with (
+            self._patch_has_grad(True),
+            self._patch_balance(True),
+            mock.patch(
+                "paddlefleet.transformer.moe.moe_layer.log_moe_balance"
+            ) as log_balance,
+        ):
+            self._run_fusion_forward(mock_self)
+        log_balance.assert_called_once()
+        _, _, _, tpe = log_balance.call_args[0]
+        self.assertTrue(
+            paddle.allclose(
+                tpe, paddle.to_tensor([1, 2, 3, 4], dtype="int64")
+            ).item()
+        )
+
+
+def _fake_all_gather_uint8(output, input, **kw):
+    """Multi-rank fake AllGather for nranks=2 that supports any dtype.
+
+    The real ``_AllGatherFP8`` AllGathers a uint8 view of fp8 data and a
+    float32 scale tensor. We simulate two identical ranks by concatenating
+    the input with itself along axis 0.
+    """
+    stacked = paddle.concat([input, input], axis=0)
+    paddle.assign(stacked, output)
+    return _FakeTask()
+
+
+def _fake_reduce_scatter_sum(output, input, **kw):
+    """Multi-rank fake ReduceScatter that sums then scatters axis 0 in halves."""
+    local_T = input.shape[0] // 2
+    # Rank 0 receives the sum of the two halves.
+    summed = input[:local_T] + input[local_T:]
+    paddle.assign(summed, output)
+    return _FakeTask()
+
+
+class TestAllGatherFP8MultiRank(unittest.TestCase):
+    """Cover the nranks > 1 quant→AllGather→dequant→ReduceScatter pipeline.
+
+    The real NCCL AllGather is replaced by a deterministic 2-rank fake; this
+    keeps the test single-card while exercising the quantization arithmetic
+    end-to-end (forward) and the ReduceScatter backward path.
+    """
+
+    def _make_group(self):
+        return SimpleNamespace(nranks=2, rank=0)
+
+    def test_multi_rank_forward_runs_quant_and_dequant(self):
+        fake_group = self._make_group()
+        # Use bfloat16 (the production dtype). H must be a multiple of 128.
+        x = paddle.randn([4, 128], dtype="bfloat16")
+        x.stop_gradient = False
+
+        with mock.patch(
+            "paddle.distributed.stream.all_gather",
+            side_effect=_fake_all_gather_uint8,
+        ):
+            out = _AllGatherFP8.apply(x, fake_group, False)
+
+        # Forward shape: T_local * nranks along axis 0, H unchanged.
+        self.assertEqual(list(out.shape), [8, 128])
+        # Note: the dequant `bf16 * fp32_scale` triggers Paddle's auto type
+        # promotion to float32 (production behaviour — not asserting bf16).
+        # Both halves should be identical (we cloned x via the fake AllGather).
+        upper = out[:4].cast("float32")
+        lower = out[4:].cast("float32")
+        self.assertTrue(paddle.allclose(upper, lower, atol=1e-3).item())
+        # Dequant should reconstruct x to within fp8 tolerance.
+        x_f32 = x.cast("float32")
+        # fp8_e4m3 has ~3-bit mantissa: relative error up to ~12% per element.
+        rel_err = ((upper - x_f32).abs() / (x_f32.abs() + 1e-3)).max().item()
+        self.assertLess(rel_err, 0.5)
+
+    def test_multi_rank_backward_reduce_scatters_grad(self):
+        fake_group = self._make_group()
+        x = paddle.randn([4, 128], dtype="bfloat16")
+        x.stop_gradient = False
+
+        with (
+            mock.patch(
+                "paddle.distributed.stream.all_gather",
+                side_effect=_fake_all_gather_uint8,
+            ),
+            mock.patch(
+                "paddle.distributed.stream.reduce_scatter",
+                side_effect=_fake_reduce_scatter_sum,
+            ),
+        ):
+            out = _AllGatherFP8.apply(x, fake_group, False)
+            out.sum().backward()
+
+        # backward returns ReduceScatter([T_global, H]) → [T_local, H].
+        self.assertEqual(list(x.grad.shape), list(x.shape))
+        # grad of sum w.r.t. global is ones; reduce-scatter sum of two
+        # identical halves of ones gives twos on each rank's slice.
+        grad_f32 = x.grad.cast("float32")
+        self.assertTrue(
+            paddle.allclose(grad_f32, paddle.full_like(grad_f32, 2.0)).item()
+        )
+
+
+class TestAllGatherTokenDispatcherFP8Paths(unittest.TestCase):
+    """Exercise ``dispatch_preprocess`` with ``fp8_dispatch=True``.
+
+    Confirms that when no pre-allgather handle is set, the dispatcher routes
+    to ``_AllGatherFP8.apply`` (FP8 quantize→AllGather→dequant) rather than
+    the plain ``AllGatherGroupOp`` fallback.
+    """
+
+    def test_dispatch_preprocess_fp8_path(self):
+        fake_group = SimpleNamespace(nranks=2, rank=0)
+        d = AllGatherTokenDispatcher(
+            moe_group=fake_group,
+            expert_model_parallel_size=2,
+            num_experts=8,
+            fp8_dispatch=True,
+            use_ue8m0=False,
+        )
+        x = paddle.randn([4, 128], dtype="bfloat16")
+        probs = paddle.randn([4, 8], dtype="bfloat16")
+        topk_weights = paddle.randn([4, 2], dtype="bfloat16")
+        topk_indices = paddle.randint(0, 8, [4, 2])
+        mask = paddle.ones([4, 8], dtype="bool")
+
+        with (
+            mock.patch("paddle.distributed.barrier"),
+            mock.patch(
+                "paddle.distributed.stream.all_gather",
+                side_effect=_fake_all_gather_uint8,
+            ),
+        ):
+            result = d.dispatch_preprocess(
+                x, probs, mask, topk_weights, topk_indices
+            )
+
+        # FP8 path returns bf16 [T_global, H].
+        self.assertEqual(list(result.shape), [8, 128])
+        # Routing metadata was AllGathered into the dispatcher cache.
+        self.assertEqual(list(d._global_topk_indices.shape), [8, 2])
+        self.assertEqual(list(d._global_topk_weights.shape), [8, 2])
+        self.assertIsNone(d.tokens_per_expert)
+
+
+class TestAllGatherTokenDispatcherDtypePreservation(unittest.TestCase):
+    """``dispatch_preprocess`` must cast topk_weights to ``probs.dtype``.
+
+    Sonic-MoE expects routing weights in the same dtype as ``probs``; if a
+    user passes float32 topk_weights against a bfloat16 model, the
+    dispatcher silently casts. Regression-guard that contract.
+    """
+
+    def test_topk_weights_cast_to_probs_dtype(self):
+        fake_group = SimpleNamespace(nranks=2, rank=0)
+        d = AllGatherTokenDispatcher(
+            moe_group=fake_group, expert_model_parallel_size=2, num_experts=8
+        )
+        x = paddle.randn([4, 16], dtype="bfloat16")
+        probs = paddle.randn([4, 8], dtype="bfloat16")
+        # Intentionally mismatched dtype (float32) — must be cast to bf16.
+        topk_weights = paddle.randn([4, 2], dtype="float32")
+        topk_indices = paddle.randint(0, 8, [4, 2])
+        mask = paddle.ones([4, 8], dtype="bool")
+
+        with (
+            mock.patch("paddle.distributed.barrier"),
+            mock.patch(
+                "paddle.distributed.stream.all_gather",
+                side_effect=_fake_all_gather,
+            ),
+        ):
+            d.dispatch_preprocess(x, probs, mask, topk_weights, topk_indices)
+
+        self.assertEqual(d._global_topk_weights.dtype, probs.dtype)
+
+
+class TestAllGatherTokenDispatcherCachesAreCleanedAfterCombine(
+    unittest.TestCase
+):
+    """``combine_postprocess`` must clear ``_overlap_combined`` after consuming
+    it, otherwise a second ``combine_postprocess`` call would incorrectly
+    return the stale cached output instead of going through ReduceScatter.
+    """
+
+    def test_overlap_cache_is_cleared_after_consume(self):
+        fake_group = SimpleNamespace(nranks=2, rank=0)
+        d = AllGatherTokenDispatcher(
+            moe_group=fake_group, expert_model_parallel_size=2, num_experts=8
+        )
+
+        # Seed the overlap cache directly (simulates a prior token_combine
+        # with a real overlap handle).
+        cached = paddle.randn([2, 16], dtype="float32")
+        d._overlap_combined = cached
+        out1 = d.combine_postprocess(paddle.zeros([4, 16], dtype="float32"))
+        self.assertTrue(paddle.allclose(out1, cached).item())
+        self.assertIsNone(d._overlap_combined)
+
+        # Second call (no cache) must take the ReduceScatter branch.
+        with mock.patch(
+            "paddle.distributed.stream.reduce_scatter",
+            side_effect=_fake_reduce_scatter,
+        ):
+            out2 = d.combine_postprocess(paddle.randn([4, 16], dtype="float32"))
+        self.assertEqual(list(out2.shape), [2, 16])
+
+
+class TestMoELayerForwardElseBranch(unittest.TestCase):
+    """Cover the ``else`` branch in ``MoELayer.forward()`` where
+    ``_latent_hidden`` is set to None (non-allgather or EP<=1 or
+    gate_overlap disabled).
+    """
+
+    class _Sentinel(Exception):
+        pass
+
+    def _make_forward_self(self, **overrides):
+        defaults = {
+            "expert_model_parallel_size": 2,
+            "sequence_parallel": False,
+            "moe_token_dispatcher_type": "allgather",
+            "config": SimpleNamespace(moe_allgather_gate_overlap=True),
+            "use_latent_moe": False,
+            "_latent_hidden": None,
+            "fc1_latent_proj": mock.MagicMock(),
+            "token_dispatcher": mock.MagicMock(),
+            "gate": lambda *a, **k: (_ for _ in ()).throw(self._Sentinel()),
+            "layer_number": 0,
+        }
+        defaults.update(overrides)
+        ns = SimpleNamespace(**defaults)
+        ns._maybe_pre_allgather_overlap = (
+            MoELayer._maybe_pre_allgather_overlap.__get__(ns)
+        )
+        return ns
+
+    def test_forward_sets_latent_hidden_none_when_not_allgather(self):
+        """When moe_token_dispatcher_type is not 'allgather', forward()
+        must set _latent_hidden = None regardless of use_latent_moe."""
+        mock_self = self._make_forward_self(
+            moe_token_dispatcher_type="alltoall",
+            use_latent_moe=True,
+        )
+        x = paddle.randn([4, 8], dtype="float32")
+        with self.assertRaises(self._Sentinel):
+            MoELayer.forward(mock_self, x)
+        self.assertIsNone(mock_self._latent_hidden)
+
+    def test_forward_sets_latent_hidden_none_when_ep1(self):
+        """EP=1 skips the pre_allgather overlap path."""
+        mock_self = self._make_forward_self(
+            expert_model_parallel_size=1,
+        )
+        x = paddle.randn([4, 8], dtype="float32")
+        with self.assertRaises(self._Sentinel):
+            MoELayer.forward(mock_self, x)
+        self.assertIsNone(mock_self._latent_hidden)
+
+    def test_forward_sets_latent_hidden_none_when_overlap_disabled(self):
+        """moe_allgather_gate_overlap=False skips the overlap path."""
+        mock_self = self._make_forward_self(
+            config=SimpleNamespace(moe_allgather_gate_overlap=False),
+        )
+        x = paddle.randn([4, 8], dtype="float32")
+        with self.assertRaises(self._Sentinel):
+            MoELayer.forward(mock_self, x)
+        self.assertIsNone(mock_self._latent_hidden)
+
+
+class TestMoELayerFusionMoEForwardOverlapHandle(unittest.TestCase):
+    """Cover ``fusion_moe_forward`` with a non-None combine_overlap_handle
+    on the allgather branch — the handle must be threaded through to
+    ``token_combine``.
+    """
+
+    def _make_self(self):
+        dispatcher = mock.MagicMock()
+        dispatcher._global_topk_indices = paddle.to_tensor(
+            [[0, 1], [2, 3], [0, 2], [1, 3]], dtype="int64"
+        )
+        dispatcher._global_topk_weights = paddle.randn([4, 2])
+        overlap_result = paddle.randn([4, 8])
+        dispatcher.token_combine = mock.MagicMock(return_value=overlap_result)
+        dispatcher.combine_postprocess = mock.MagicMock(
+            return_value=paddle.randn([4, 8])
+        )
+        tpe = paddle.bincount(
+            dispatcher._global_topk_indices.reshape([-1]).cast("int64"),
+            minlength=4,
+        )
+        dispatcher.get_dispatched_routing = mock.MagicMock(
+            return_value=(
+                dispatcher._global_topk_indices,
+                dispatcher._global_topk_weights,
+                tpe,
+            )
+        )
+
+        token_seq = paddle.randn([4, 8], dtype="float32")
+        grouped = mock.MagicMock(return_value=token_seq)
+        ns = SimpleNamespace(
+            use_latent_moe=False,
+            _latent_hidden=None,
+            fc1_latent_proj=mock.MagicMock(side_effect=lambda x: x),
+            fc2_latent_proj=mock.MagicMock(side_effect=lambda x: x),
+            dispatch=mock.MagicMock(return_value=(token_seq, None)),
+            _use_hybrid_ep_fusion=mock.MagicMock(return_value=False),
+            using_sonic_moe=True,
+            grouped_gemm_experts=grouped,
+            fp8=None,
+            moe_token_dispatcher_type="allgather",
+            token_dispatcher=dispatcher,
+            num_experts=4,
+            expert_model_parallel_size=2,
+            num_experts_per_tok=2,
+            moe_group=SimpleNamespace(rank=0),
+            moe_rank=0,
+            layer_number=0,
+            use_rr_deepep_combine=False,
+            config=SimpleNamespace(activation_func_clamp_value=0.0),
+        )
+        ns._project_to_latent = MoELayer._project_to_latent.__get__(ns)
+        return ns
+
+    def _patch_has_grad(self, has_grad):
+        tracer = SimpleNamespace(_has_grad=has_grad)
+        return mock.patch(
+            "paddlefleet.transformer.moe.moe_layer.framework._dygraph_tracer",
+            return_value=tracer,
+        )
+
+    def _patch_balance(self, enabled):
+        return mock.patch(
+            "paddlefleet.transformer.moe.moe_layer.global_moe_balance_training_logs_enabled",
+            return_value=enabled,
+        )
+
+    def test_allgather_combine_overlap_handle_passed_to_token_combine(self):
+        mock_self = self._make_self()
+        overlap_handle = {"fn": lambda t: (t,), "fn_args": ()}
+        x = paddle.randn([4, 8], dtype="float32")
+        with (
+            self._patch_has_grad(False),
+            self._patch_balance(False),
+        ):
+            MoELayer.fusion_moe_forward(
+                mock_self,
+                x,
+                probs=paddle.randn([4, 4]),
+                routing_map=paddle.ones([4, 4], dtype="bool"),
+                combine_overlap_handle=overlap_handle,
+                topk_weights=paddle.randn([4, 2]),
+                topk_indices=paddle.randint(0, 4, [4, 2]),
+            )
+        # token_combine must have been called with the overlap handle.
+        mock_self.token_dispatcher.token_combine.assert_called_once()
+        call_kwargs = mock_self.token_dispatcher.token_combine.call_args
+        self.assertIs(
+            call_kwargs.kwargs.get("combine_overlap_handle"), overlap_handle
+        )
+
+
+class TestAllGatherFP8SingleRankGroup(unittest.TestCase):
+    """Cover the ``group.nranks == 1`` early-return paths of ``_AllGatherFP8``.
+
+    ``group=None`` is already covered in ``TestAllGatherFP8``; this class
+    exercises the *single-rank group* branch (same logic, different guard).
+    """
+
+    def test_single_rank_forward_returns_clone(self):
+        g = _single_rank_group()
+        x = paddle.randn([4, 128], dtype="float32")
+        x.stop_gradient = False
+        y = _AllGatherFP8.apply(x, g, False)
+        self.assertEqual(y.shape, x.shape)
+        self.assertTrue(paddle.allclose(y, x).item())
+
+    def test_single_rank_backward_passthrough(self):
+        g = _single_rank_group()
+        x = paddle.randn([4, 128], dtype="float32")
+        x.stop_gradient = False
+        y = _AllGatherFP8.apply(x, g, False)
+        y.sum().backward()
+        self.assertEqual(x.grad.shape, x.shape)
+        self.assertTrue(paddle.allclose(x.grad, paddle.ones_like(x)).item())
+
+
+class TestAllGatherCombineAsyncMultiRankFirstFwd(unittest.TestCase):
+    """Cover ``_AllGatherCombineAsync`` multi-rank backward when
+    ``is_first_fwd=True`` (``ctx.bwf is None``).
+
+    The single-rank counterpart is in ``TestAllGatherCombineAsync``, but
+    the multi-rank path goes through a different code branch (async
+    AllGather on backward + zero-fills for fn_args_grads).
+    """
+
+    def test_multi_rank_backward_bwf_none_returns_zeros(self):
+        x = paddle.randn([4, 8], dtype="float32")
+        x.stop_gradient = False
+        a = paddle.randn([4, 8], dtype="float32")
+        a.stop_gradient = False
+        fake_group = SimpleNamespace(nranks=2, rank=0)
+
+        def fn(t):
+            return (t * 3.0,)
+
+        # Forward with is_first_fwd=True so that ctx.bwf is None.
+        with mock.patch(
+            "paddle.distributed.stream.reduce_scatter",
+            side_effect=_fake_reduce_scatter,
+        ):
+            combined, fn_out = _AllGatherCombineAsync.apply(
+                x, fake_group, a, fn=fn, is_first_fwd=True
+            )
+
+        self.assertTrue(paddle.allclose(fn_out, a * 3.0).item())
+
+        # Backward: x grad from AllGather of reduce-scatter; a grad must
+        # be zeros because bwf is None.
+        loss = combined.sum() + fn_out.sum()
+        with (
+            mock.patch(
+                "paddle.distributed.stream.all_gather",
+                side_effect=_fake_all_gather,
+            ),
+            mock.patch(
+                "paddle.distributed.stream.reduce_scatter",
+                side_effect=_fake_reduce_scatter,
+            ),
+        ):
+            loss.backward()
+
+        self.assertEqual(list(x.grad.shape), [4, 8])
+        self.assertTrue(paddle.allclose(a.grad, paddle.zeros_like(a)).item())
+
+
+class TestAllGatherCombineAsyncMultiRankFinallyGuard(unittest.TestCase):
+    """Cover the ``try/finally`` deadlock-prevention guard in
+    ``_AllGatherCombineAsync``.
+
+    When ``manual_backward`` (forward) raises, the NCCL ``task.wait()``
+    must still be called to prevent cross-rank deadlock. The backward
+    ``try/finally`` follows the same pattern and is structurally
+    equivalent.
+    """
+
+    def test_forward_waits_task_even_if_manual_backward_raises(self):
+        x = paddle.randn([4, 8], dtype="float32")
+        x.stop_gradient = False
+        a = paddle.randn([4, 8], dtype="float32")
+        a.stop_gradient = False
+        fake_group = SimpleNamespace(nranks=2, rank=0)
+        wait_called = []
+
+        class _TaskWithCount:
+            def wait(self):
+                wait_called.append(True)
+
+        def fn(t):
+            return (t,)
+
+        def fake_rs(output, input, **kw):
+            local_T = input.shape[0] // 2
+            paddle.assign(input[:local_T], output)
+            return _TaskWithCount()
+
+        with (
+            mock.patch(
+                "paddle.distributed.stream.reduce_scatter",
+                side_effect=fake_rs,
+            ),
+            mock.patch(
+                "paddlefleet.transformer.moe.token_dispatcher.manual_backward",
+                side_effect=RuntimeError("boom"),
+            ),
+            self.assertRaises(RuntimeError),
+        ):
+            _AllGatherCombineAsync.apply(
+                x, fake_group, a, fn=fn, is_first_fwd=False
+            )
+        # task.wait() must have been called despite the exception.
+        self.assertTrue(wait_called, "task.wait() was not called on error")
+
+
+class TestAllGatherDispatcherPreAllGatherOSError(unittest.TestCase):
+    """Cover the ``OSError`` branch in ``pre_allgather``'s leftover-handle
+    cleanup. The existing test only exercises ``RuntimeError``.
+    """
+
+    def test_pre_allgather_warns_on_oserror_leftover(self):
+        fake_group = SimpleNamespace(nranks=2, rank=0)
+        d = AllGatherTokenDispatcher(
+            moe_group=fake_group,
+            expert_model_parallel_size=2,
+            num_experts=8,
+            fp8_dispatch=False,
+            use_ue8m0=False,
+        )
+
+        # Inject a leftover handle whose task.wait() raises OSError.
+        class _OSErrorTask:
+            def wait(self):
+                raise OSError("bad fd")
+
+        d._pre_ag_handle = {
+            "output": paddle.randn([4, 16]),
+            "task": _OSErrorTask(),
+            "group": fake_group,
+        }
+        with (
+            mock.patch(
+                "paddle.distributed.stream.all_gather",
+                side_effect=_fake_all_gather,
+            ),
+            self.assertLogs(
+                "paddlefleet.transformer.moe.token_dispatcher", level="WARNING"
+            ),
+        ):
+            d.pre_allgather(paddle.randn([4, 16]))
+        # Handle must have been cleared despite the OSError.
+        self.assertIsNone(d._pre_ag_handle)
+
+
+class TestAllGatherDispatcherDispatchPreprocessOnlyIndicesNone(
+    unittest.TestCase
+):
+    """Cover ``dispatch_preprocess`` when only ``topk_indices`` is None
+    (``topk_weights`` is provided). The existing test passes both as None.
+    """
+
+    def test_dispatch_preprocess_raises_when_only_indices_none(self):
+        fake_group = SimpleNamespace(nranks=2, rank=0)
+        d = AllGatherTokenDispatcher(
+            moe_group=fake_group,
+            expert_model_parallel_size=2,
+            num_experts=8,
+            fp8_dispatch=False,
+            use_ue8m0=False,
+        )
+        x = paddle.randn([4, 16], dtype="float32")
+        probs = paddle.randn([4, 8])
+        mask = paddle.ones([4, 8], dtype="bool")
+        topk_weights = paddle.randn([4, 2])
+        with (
+            mock.patch("paddle.distributed.barrier"),
+            mock.patch(
+                "paddle.distributed.stream.all_gather",
+                side_effect=_fake_all_gather,
+            ),
+            self.assertRaisesRegex(ValueError, "topk_indices"),
+        ):
+            d.dispatch_preprocess(x, probs, mask, topk_weights, None)
+
+    def test_dispatch_preprocess_raises_when_only_weights_none(self):
+        fake_group = SimpleNamespace(nranks=2, rank=0)
+        d = AllGatherTokenDispatcher(
+            moe_group=fake_group,
+            expert_model_parallel_size=2,
+            num_experts=8,
+            fp8_dispatch=False,
+            use_ue8m0=False,
+        )
+        x = paddle.randn([4, 16], dtype="float32")
+        probs = paddle.randn([4, 8])
+        mask = paddle.ones([4, 8], dtype="bool")
+        topk_indices = paddle.randint(0, 8, [4, 2])
+        with (
+            mock.patch("paddle.distributed.barrier"),
+            mock.patch(
+                "paddle.distributed.stream.all_gather",
+                side_effect=_fake_all_gather,
+            ),
+            self.assertRaisesRegex(ValueError, "topk_indices"),
+        ):
+            d.dispatch_preprocess(x, probs, mask, None, topk_indices)
+
+
+class TestMoELayerProjectToLatentFallback(unittest.TestCase):
+    """Cover ``_project_to_latent`` when ``_latent_hidden is None`` and
+    ``use_latent_moe=True`` — the fallback calls ``fc1_latent_proj``
+    directly.
+    """
+
+    def test_project_to_latent_calls_fc1_when_no_cache(self):
+        projected = paddle.randn([4, 16], dtype="float32")
+        fc1 = mock.MagicMock(return_value=projected)
+        mock_self = SimpleNamespace(
+            use_latent_moe=True,
+            _latent_hidden=None,
+            fc1_latent_proj=fc1,
+        )
+        x = paddle.randn([4, 8], dtype="float32")
+        result = MoELayer._project_to_latent(mock_self, x)
+        fc1.assert_called_once_with(x)
+        self.assertIs(result, projected)
+
+
+class TestAllGatherTokenDispatcherPreAllGatherFP8Branch(unittest.TestCase):
+    """Cover the fp8_dispatch early-return branch in ``pre_allgather``:
+    when ``fp8_dispatch=True`` and group has multiple ranks, pre_allgather
+    must set ``_pre_ag_handle = None`` (the FP8 AllGather is deferred to
+    dispatch_preprocess).
+    """
+
+    def test_pre_allgather_fp8_dispatch_sets_handle_none(self):
+        fake_group = SimpleNamespace(nranks=2, rank=0)
+        d = AllGatherTokenDispatcher(
+            moe_group=fake_group,
+            expert_model_parallel_size=2,
+            num_experts=8,
+            fp8_dispatch=True,
+            use_ue8m0=False,
+        )
+        x = paddle.randn([4, 16], dtype="bfloat16")
+        d.pre_allgather(x)
+        # fp8_dispatch path: handle must be None (deferred to
+        # dispatch_preprocess).
+        self.assertIsNone(d._pre_ag_handle)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Distributed Strategy

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features 

### Description
<!-- Describe what you’ve done -->
Introduce a new MoE token dispatcher — allgather — alongside the existing
deepep / alltoall / hybridep options. Semantic difference:

Existing dispatchers: each EP rank holds a subset of experts at full intermediate width
AllGather dispatcher: each EP rank holds every expert, with the intermediate dim sharded across EP

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否