### PR TITLE
[Execute Infrastructure] Gate PaddleFleet GPT tests by repo flag

### DIFF
--- a/tests/multi_card_tests/test_gpt_model_dense_cp.py
+++ b/tests/multi_card_tests/test_gpt_model_dense_cp.py
@@ -16,6 +16,7 @@
 import functools
 import os
 import random
+import sys
 
 import numpy as np
 import paddle
@@ -26,6 +27,9 @@ import paddlefleet
 from paddlefleet.gpt_builders import gpt_builder
 from paddlefleet.models.gpt import GPTConfig
 from paddlefleet.training.initialize import initialize_fleet
+
+REPO_FLAG = os.getenv("repo_flag")
+SKIP_TESTS = REPO_FLAG != "paddlefleet"
 
 
 def _set_random_seed(
@@ -144,6 +148,9 @@ def run_cp(seed, batch_size, seq_len, vocab_size, config):
 
 
 if __name__ == "__main__":
+    if SKIP_TESTS:
+        print(f"Skipping tests: repo_flag={REPO_FLAG} (not 'paddlefleet')")
+        sys.exit(0)
     seed = 46
     batch_size = 1
     seq_len = 128

--- a/tests/multi_card_tests/test_gpt_model_moe_mtp_cp_experimental_dataflow.py
+++ b/tests/multi_card_tests/test_gpt_model_moe_mtp_cp_experimental_dataflow.py
@@ -52,6 +52,9 @@ from paddlefleet.gpt_builders import gpt_builder
 from paddlefleet.models.gpt import GPTConfig
 from paddlefleet.training.initialize import initialize_fleet
 
+REPO_FLAG = os.getenv("repo_flag")
+SKIP_TESTS = REPO_FLAG != "paddlefleet"
+
 
 def _set_random_seed(seed_):
     """Set random seed for reproducibility."""
@@ -260,5 +263,8 @@ def run_experimental_dataflow_cp_e2e():
 
 
 if __name__ == "__main__":
+    if SKIP_TESTS:
+        print(f"Skipping tests: repo_flag={REPO_FLAG} (not 'paddlefleet')")
+        sys.exit(0)
     paddle.set_default_dtype("bfloat16")
     run_experimental_dataflow_cp_e2e()

--- a/tests/single_card_tests/model/test_gpt_model_moe_grouped_gemm.py
+++ b/tests/single_card_tests/model/test_gpt_model_moe_grouped_gemm.py
@@ -32,6 +32,9 @@ import paddlefleet.parallel_state as ps
 from paddlefleet.gpt_builders import gpt_builder
 from paddlefleet.models.gpt import GPTConfig
 
+REPO_FLAG = os.getenv("repo_flag")
+SKIP_TESTS = REPO_FLAG != "paddlefleet"
+
 
 def get_gpu_models_via_nvidia_smi():
     try:
@@ -62,6 +65,10 @@ version, cuda_minor = get_cuda_version()
 print("CUDA version:", version)
 
 
+@unittest.skipIf(
+    SKIP_TESTS,
+    f"Skipping tests: repo_flag={REPO_FLAG} (not 'paddlefleet')",
+)
 class TestGPTModel(unittest.TestCase):
     def setUp(self):
         seed = 46


### PR DESCRIPTION
### PR Category
Execute Infrastructure
### PR Types
Devs
### Description
为以下 GPT/MoE/CP 相关测试添加 repo_flag 环境判断，使其在非 PaddleFleet 仓库环境下跳过：
- tests/multi_card_tests/test_gpt_model_dense_cp.py
- tests/multi_card_tests/test_gpt_model_moe_mtp_cp_experimental_dataflow.py
- tests/single_card_tests/model/test_gpt_model_moe_grouped_gemm.py
### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否
