### PR TITLE
[DSv4] Align training numerics with Megatron reference

### DIFF
--- a/packages/paddlefleet_ops/src/paddlefleet_ops/utils.py
+++ b/packages/paddlefleet_ops/src/paddlefleet_ops/utils.py
@@ -92,12 +92,13 @@ class ModuleContext:
 
 def patch_module_namespace(source_name: str, target_prefix: str):
     """
-    Moves loaded modules from source_name to target_prefix + source_name.
-    Effectively 'installs' the module into the new namespace.
+    Copies loaded modules from source_name to target_prefix + source_name.
+    Effectively 'installs' the module into the new namespace while keeping
+    the original name so that internal absolute imports still resolve.
     """
     for name in list(sys.modules.keys()):
         if name == source_name or name.startswith(source_name + "."):
-            module = sys.modules.pop(name)
+            module = sys.modules[name]
             new_name = target_prefix + name
             sys.modules[new_name] = module
 

--- a/src/paddlefleet/fusions/fused_bias_swiglu.py
+++ b/src/paddlefleet/fusions/fused_bias_swiglu.py
@@ -16,6 +16,7 @@
 # pylint: disable=missing-function-docstring, missing-class-docstring
 
 import logging
+import os
 
 import paddle
 import paddle.nn.functional as F
@@ -24,6 +25,29 @@ from paddlefleet.jit import jit_fuser
 from paddlefleet.utils import nvtx_decorator
 
 logger = logging.getLogger(__name__)
+
+
+def _dsv4_megatron_swiglu_enabled() -> bool:
+    return os.environ.get("DSV4_FLEET_MEGATRON_SWIGLU", "0") == "1"
+
+
+def _dsv4_megatron_swiglu_wgrad_enabled() -> bool:
+    return os.environ.get("DSV4_FLEET_MEGATRON_SWIGLU_WGRAD", "0") == "1"
+
+
+def _dsv4_sum_like_megatron_for_small_chunks(value: paddle.Tensor) -> paddle.Tensor:
+    if (
+        not _dsv4_megatron_swiglu_wgrad_enabled()
+        or len(value.shape) != 2
+        or value.shape[0] >= 16
+    ):
+        return paddle.sum(value, axis=-1, keepdim=True)
+    pad_rows = 16 - value.shape[0]
+    if pad_rows <= 0:
+        return paddle.sum(value, axis=-1, keepdim=True)
+    padding = paddle.zeros([pad_rows, value.shape[1]], dtype=value.dtype)
+    padded = paddle.concat([value, padding], axis=0)
+    return paddle.sum(padded, axis=-1, keepdim=True)[: value.shape[0]]
 
 ###### BIAS SWIGLU FUSION/ NO AUTOGRAD ################
 
@@ -37,6 +61,9 @@ def swiglu(y):
     Returns:
         paddle.Tensor: Result of SwiGLU activation: SiLU(y1) * y2, where y1, y2 are the split halves.
     """
+    if _dsv4_megatron_swiglu_enabled():
+        y_1, y_2 = paddle.chunk(y, 2, axis=-1)
+        return F.silu(y_1) * y_2
     return F.swiglu(y)
 
 
@@ -75,10 +102,19 @@ def swiglu_back(g, y):
 
     Returns:
         paddle.Tensor: Gradient with respect to the input tensor, computed using the
-            Paddle native SwiGLU gradient operator.
+            chain rule and the derivative of the SiLU activation function.
     """
-    dx, _ = paddle._C_ops.swiglu_grad(y, None, g)
-    return dx
+    if paddle.is_compiled_with_cuda():
+        from paddlefleet_ops import fused_swiglu_bwd
+
+        return fused_swiglu_bwd(g, y)
+    elif paddle.is_compiled_with_xpu():
+        dx, _ = paddle._C_ops.swiglu_grad(y, None, g)
+        return dx
+    else:
+        raise NotImplementedError(
+            "fused_swiglu_bwd is not implemented for non-CUDA backends."
+        )
 
 
 @jit_fuser
@@ -105,7 +141,7 @@ def weighted_swiglu_back(g, y, weights):
     input_grad = swiglu_back(g * weights, y)
     # precision of w may be higher than y and g, so we need to cast g to w_dtype
     weights_grad = swiglu(y) * g.to(w_dtype)
-    weights_grad = paddle.sum(weights_grad, dim=-1, keepdim=True)
+    weights_grad = _dsv4_sum_like_megatron_for_small_chunks(weights_grad)
     return input_grad.to(input_dtype), weights_grad.to(w_dtype)
 
 
@@ -137,10 +173,6 @@ def clamped_swiglu_back(g, y, clamp_value):
     """Backward pass for clamped_swiglu.
 
     Gradient is zeroed out where inputs were clamped.
-    Computation is performed in float32; g is used in its
-    original dtype so auto-promotion to float32 occurs naturally through
-    the float32 terms; masks are cast to g.dtype matching
-    ``.to(g.dtype)`` in the reference implementation.
 
     Args:
         g (paddle.Tensor): Upstream gradient.
@@ -155,55 +187,21 @@ def clamped_swiglu_back(g, y, clamp_value):
     y_1, y_2 = paddle.chunk(y_fp32, 2, axis=-1)
     y_1_clamped = y_1.clip(max=clamp_value)
     y_2_clamped = y_2.clip(min=-clamp_value, max=clamp_value)
-    # Clamp masks in g.dtype
-    y1_mask = (y_1 <= clamp_value).cast(g.dtype)
-    y2_mask = ((y_2 >= -clamp_value) & (y_2 <= clamp_value)).cast(g.dtype)
-    sig = F.sigmoid(y_1_clamped)
-    grad_y1 = (
-        g * sig * (1.0 + y_1_clamped * (1.0 - sig)) * y_2_clamped * y1_mask
+    g_fp32 = g.cast(paddle.float32)
+    # Clamp masks: gradient is 0 where the input was clamped
+    y1_mask = (y_1 <= clamp_value).cast(paddle.float32)
+    y2_mask = ((y_2 >= -clamp_value) & (y_2 <= clamp_value)).cast(
+        paddle.float32
     )
-    grad_y2 = g * (y_1_clamped * sig) * y2_mask  # silu = x * sigmoid(x)
+    grad_y1 = (
+        g_fp32
+        * F.sigmoid(y_1_clamped)
+        * (1.0 + y_1_clamped * (1.0 - F.sigmoid(y_1_clamped)))
+        * y_2_clamped
+        * y1_mask
+    )
+    grad_y2 = g_fp32 * F.silu(y_1_clamped) * y2_mask
     return paddle.concat([grad_y1, grad_y2], axis=-1).cast(dtype)
-
-
-@jit_fuser
-def clamped_bias_swiglu(y, bias, clamp_value):
-    """Clamped SwiGLU with bias addition.
-
-    Adds bias to the input tensor, then applies clamped SwiGLU activation.
-    Gate (y1) is clamped to (-inf, clamp_value] and value (y2) to
-    [-clamp_value, clamp_value] before computing SiLU(y1) * y2.
-
-    Args:
-        y (paddle.Tensor): Input tensor, split into gate/value halves along last dim.
-        bias (paddle.Tensor): Bias tensor added to input before activation.
-        clamp_value (float): Clamp bound for numerical stability.
-
-    Returns:
-        paddle.Tensor: clamped_swiglu(y + bias), same dtype as y.
-    """
-    y = y + bias
-    return clamped_swiglu(y, clamp_value)
-
-
-@jit_fuser
-def clamped_bias_swiglu_back(g, y, bias, clamp_value):
-    """Backward pass for clamped_bias_swiglu.
-
-    Adds bias to the input tensor and delegates to clamped_swiglu_back
-    which zeros out gradients where inputs were clamped in the forward pass.
-
-    Args:
-        g (paddle.Tensor): Upstream gradient.
-        y (paddle.Tensor): Original (un-clamped) input tensor from forward pass.
-        bias (paddle.Tensor): Bias tensor that was added in the forward pass.
-        clamp_value (float): Clamp bound used in forward pass.
-
-    Returns:
-        paddle.Tensor: Gradient w.r.t. (y + bias), same dtype as y.
-    """
-    y = y + bias
-    return clamped_swiglu_back(g, y, clamp_value)
 
 
 @jit_fuser
@@ -227,21 +225,10 @@ def clamped_weighted_swiglu(y, weights, clamp_value):
 def clamped_weighted_swiglu_back(g, y, weights, clamp_value):
     """Backward pass for clamped_weighted_swiglu.
 
-    Delegates to clamped_swiglu_back for input grad and recomputes
-    clamped_swiglu(y) for weights grad. This re-executes one SwiGLU forward
-    (clip + sigmoid + silu) in the backward — a conscious trade-off:
-    correctness and code clarity take priority over the marginal FLOPs,
-    matching the reference implementation structure. The overhead is ~1
-    SwiGLU forward which is negligible compared to the main matmul.
-
-    Precision note: ``paddle.sum`` internally accumulates bf16 inputs in
-    float32, matching the CUDA kernel's ``float`` accumulation for
-    ``local_d_probs_sum`` in the same-type branch.
-
     Args:
         g (paddle.Tensor): Upstream gradient.
         y (paddle.Tensor): Original input tensor from forward pass.
-        weights (paddle.Tensor): Per-token weights, broadcastable to g's shape.
+        weights (paddle.Tensor): Per-token weights from forward pass.
         clamp_value (float): Clamp bound used in forward pass.
 
     Returns:
@@ -251,7 +238,7 @@ def clamped_weighted_swiglu_back(g, y, weights, clamp_value):
     w_dtype = weights.dtype
     input_grad = clamped_swiglu_back(g * weights, y, clamp_value)
     weights_grad = clamped_swiglu(y, clamp_value) * g.cast(w_dtype)
-    weights_grad = paddle.sum(weights_grad, axis=-1, keepdim=True)
+    weights_grad = _dsv4_sum_like_megatron_for_small_chunks(weights_grad)
     return input_grad.cast(input_dtype), weights_grad.cast(w_dtype)
 
 
@@ -260,9 +247,7 @@ class BiasSwiGLUFunction(paddle.autograd.PyLayer):
 
     @staticmethod
     @nvtx_decorator()
-    def forward(
-        ctx, input, bias, fp8_input_store, cpu_offload_input, clamp_value=None
-    ):
+    def forward(ctx, input, bias, fp8_input_store, cpu_offload_input, clamp_value=None):
         """Forward pass of biased SwiGLU activation.
 
         Args:
@@ -270,10 +255,6 @@ class BiasSwiGLUFunction(paddle.autograd.PyLayer):
             input (paddle.Tensor): Input tensor to apply SwiGLU to.
             bias (paddle.Tensor): Bias tensor to be added to input before SwiGLU.
             fp8_input_store (bool): If True, stores intermediate values in FP8 format.
-            cpu_offload_input (bool): If True, enables CPU activation offloading.
-            clamp_value (float, optional): If provided and > 0, clamps gate to
-                (-inf, clamp_value] and value to [-clamp_value, clamp_value] for
-                numerical stability.
 
         Returns:
             paddle.Tensor: Result of applying bias addition followed by SwiGLU activation.
@@ -289,7 +270,7 @@ class BiasSwiGLUFunction(paddle.autograd.PyLayer):
         ctx.fp8_input_store = fp8_input_store
         ctx.clamp_value = clamp_value
         if clamp_value is not None and clamp_value > 0:
-            return clamped_bias_swiglu(input, bias, clamp_value)
+            return clamped_swiglu(input + bias, clamp_value)
         return bias_swiglu(input, bias)
 
     @staticmethod
@@ -305,16 +286,15 @@ class BiasSwiGLUFunction(paddle.autograd.PyLayer):
             tuple: Tuple containing:
                 - Gradient with respect to the input tensor
                 - Gradient with respect to the bias tensor
+                - None for fp8_input_store parameter
         """
         input, bias = ctx.saved_tensor()
         input = input.to(ctx.ori_input_dtype) if ctx.fp8_input_store else input
         if ctx.clamp_value is not None and ctx.clamp_value > 0:
-            tmp = clamped_bias_swiglu_back(
-                grad_output, input, bias, ctx.clamp_value
-            )
+            tmp = clamped_swiglu_back(grad_output, input + bias, ctx.clamp_value)
         else:
             tmp = bias_swiglu_back(grad_output, input, bias)
-        return tmp, tmp
+        return tmp, tmp, None, None, None
 
 
 class SwiGLUFunction(paddle.autograd.PyLayer):
@@ -322,19 +302,13 @@ class SwiGLUFunction(paddle.autograd.PyLayer):
 
     @staticmethod
     @nvtx_decorator()
-    def forward(
-        ctx, input, fp8_input_store, cpu_offload_input, clamp_value=None
-    ):
+    def forward(ctx, input, fp8_input_store, cpu_offload_input, clamp_value=None):
         """Forward pass of SwiGLU activation.
 
         Args:
             ctx: Autograd context object for saving tensors for backward pass.
             input (paddle.Tensor): Input tensor to apply SwiGLU to.
             fp8_input_store (bool): If True, stores intermediate values in FP8 format.
-            cpu_offload_input (bool): If True, enables CPU activation offloading.
-            clamp_value (float, optional): If provided and > 0, clamps gate to
-                (-inf, clamp_value] and value to [-clamp_value, clamp_value] for
-                numerical stability.
 
         Returns:
             paddle.Tensor: Result of applying SwiGLU activation.
@@ -362,7 +336,9 @@ class SwiGLUFunction(paddle.autograd.PyLayer):
             grad_output (paddle.Tensor): Gradient of the loss with respect to the output.
 
         Returns:
-            paddle.Tensor: Gradient with respect to the input tensor.
+            tuple: Tuple containing:
+                - Gradient with respect to the input tensor
+                - None for fp8_input_store parameter
         """
         input = ctx.saved_tensor()[0]
         input = input.to(ctx.ori_input_dtype) if ctx.fp8_input_store else input
@@ -370,6 +346,7 @@ class SwiGLUFunction(paddle.autograd.PyLayer):
             tmp = clamped_swiglu_back(grad_output, input, ctx.clamp_value)
         else:
             tmp = swiglu_back(grad_output, input)
+        # return tmp, None, None
         return tmp
 
 
@@ -384,19 +361,18 @@ class WeightedSwiGLUFunction(paddle.autograd.PyLayer):
         ctx.ori_input_dtype = input.dtype
         ctx.fp8_input_store = fp8_input_store
         ctx.clamp_value = clamp_value
-        if clamp_value is not None and clamp_value > 0:
-            res = clamped_weighted_swiglu(input, weights, clamp_value)
-        else:
-            res = weighted_swiglu(input, weights)
-        return res
+        if clamp_value is not None:
+            return clamped_weighted_swiglu(input, weights, clamp_value)
+        return weighted_swiglu(input, weights)
 
     @staticmethod
     def backward(ctx, grad_output):
         input, weights = ctx.saved_tensor()
         input = input.to(ctx.ori_input_dtype) if ctx.fp8_input_store else input
-        if ctx.clamp_value is not None and ctx.clamp_value > 0:
+        clamp_value = ctx.clamp_value
+        if clamp_value is not None:
             tmp, wgrad = clamped_weighted_swiglu_back(
-                grad_output, input, weights, ctx.clamp_value
+                grad_output, input, weights, clamp_value
             )
         else:
             tmp, wgrad = weighted_swiglu_back(grad_output, input, weights)
@@ -404,11 +380,7 @@ class WeightedSwiGLUFunction(paddle.autograd.PyLayer):
 
 
 def bias_swiglu_impl(
-    input,
-    bias,
-    fp8_input_store=False,
-    cpu_offload_input=False,
-    clamp_value=None,
+    input, bias, fp8_input_store=False, cpu_offload_input=False, clamp_value=None
 ):
     """Implementation of biased SwiGLU that handles different input shapes.
 
@@ -421,11 +393,6 @@ def bias_swiglu_impl(
             uses the bias-free SwiGLU variant.
         fp8_input_store (bool, optional): Whether to store intermediate values in FP8 format.
             Defaults to False.
-        cpu_offload_input (bool, optional): If True, enables CPU activation offloading.
-            Defaults to False.
-        clamp_value (float, optional): If provided and > 0, clamps gate to
-            (-inf, clamp_value] and value to [-clamp_value, clamp_value] for
-            numerical stability.
 
     Returns:
         paddle.Tensor: Result of biased SwiGLU activation.
@@ -441,9 +408,7 @@ def bias_swiglu_impl(
             input, bias, fp8_input_store, cpu_offload_input, clamp_value
         )
     else:
-        output = SwiGLUFunction.apply(
-            input, fp8_input_store, cpu_offload_input, clamp_value
-        )
+        output = SwiGLUFunction.apply(input, fp8_input_store, cpu_offload_input, clamp_value)
 
     return (
         output
@@ -463,15 +428,11 @@ def weighted_bias_swiglu_impl(
         bias: Optional bias (not supported for weighted variant).
         weights: Per-token weights, shape [..., 1].
         fp8_input_store (bool): Whether to store intermediate values in FP8 format.
-        clamp_value (float, optional): If provided and > 0, clamps gate to
-            (-inf, clamp_value] and value to [-clamp_value, clamp_value] for
-            numerical stability.
+        clamp_value (float, optional): If provided, use ClampedSwiGLU instead of standard SwiGLU.
     """
     ori_shape = input.shape
     assert len(ori_shape) in [2, 3]
     input = input.view(-1, ori_shape[-1])
-    if len(ori_shape) == 3:
-        weights = weights.view(-1, weights.shape[-1])
     if bias is not None:
         raise NotImplementedError(
             "Bias is not supported for weighted swiglu fusion"

--- a/src/paddlefleet/fusions/fused_swiglu_scale.py
+++ b/src/paddlefleet/fusions/fused_swiglu_scale.py
@@ -17,146 +17,90 @@ import paddle.nn.functional as F
 from paddle.nn.functional import swiglu
 
 
-def _broadcast_scale(scale, target_dtype, target_ndim):
-    """Cast scale to target dtype and unsqueeze to match target rank."""
-    scale_exp = scale.cast(target_dtype)
-    while scale_exp.ndim < target_ndim:
-        scale_exp = scale_exp.unsqueeze(-1)
-    return scale_exp
-
-
 def fused_swiglu_scale_forward(x, scale, clamp_value=None):
     if paddle.is_compiled_with_cuda():
-        if clamp_value is not None and clamp_value > 0:
+        if clamp_value is not None:
             from paddlefleet_ops import fused_swiglu_scale_clamp
 
-            return fused_swiglu_scale_clamp(x, scale, clamp_value)
+            return fused_swiglu_scale_clamp(x, scale, float(clamp_value))
         else:
             from paddlefleet_ops import fused_swiglu_scale
 
             return fused_swiglu_scale(x, scale)
+
+    # ----------------------------
+    # XPU / CPU fallback
+    # ----------------------------
+    if clamp_value is not None:
+        hidden = x.shape[-1] // 2
+        gate = paddle.clip(x[..., :hidden], max=clamp_value)
+        val = paddle.clip(x[..., hidden:], min=-clamp_value, max=clamp_value)
+        out = F.silu(gate) * val
     else:
-        if clamp_value is not None and clamp_value > 0:
-            # cast to float32, clamp, silu, cast back
-            hidden = x.shape[-1] // 2
-            x_fp32 = x.cast(paddle.float32)
-            gate = paddle.clip(x_fp32[..., :hidden], max=clamp_value)
-            val = paddle.clip(
-                x_fp32[..., hidden:], min=-clamp_value, max=clamp_value
-            )
-            out = (F.silu(gate) * val).cast(x.dtype)
-        else:
-            out = swiglu(x)
-        scale_exp = _broadcast_scale(scale, x.dtype, out.ndim)
-        return out * scale_exp
+        out = swiglu(x)
+
+    scale_exp = scale.cast(x.dtype)
+    while scale_exp.ndim < out.ndim:
+        scale_exp = scale_exp.unsqueeze(-1)
+
+    return out * scale_exp
 
 
 def fused_swiglu_scale_backward(x, scale, out_grad, clamp_value=None):
-    """Backward for fused SwiGLU * scale.
-
-    When clamp_value is not None, clamps gate to (-inf, clamp_value] and
-    value to [-clamp_value, clamp_value], then zeros gradients where inputs
-    were saturated.  The gradient output order is [d_gate, d_val] which
-    matches ``paddle.chunk(x, 2, axis=-1)`` -> [gate, value].
-    """
     if paddle.is_compiled_with_cuda():
-        if clamp_value is not None and clamp_value > 0:
+        if clamp_value is not None:
             from paddlefleet_ops import fused_swiglu_scale_clamp_bwd
 
             return fused_swiglu_scale_clamp_bwd(
                 x, scale, out_grad, float(clamp_value)
             )
-        from paddlefleet_ops import fused_swiglu_scale_bwd
+        else:
+            from paddlefleet_ops import fused_swiglu_scale_bwd
 
-        return fused_swiglu_scale_bwd(x, scale, out_grad)
+            return fused_swiglu_scale_bwd(x, scale, out_grad)
+
+    # ----------------------------
+    # XPU / CPU fallback
+    # ----------------------------
+    hidden = x.shape[-1] // 2
+
+    gate_raw = x[..., :hidden]
+    val_raw = x[..., hidden:]
+
+    if clamp_value is not None:
+        gate = paddle.clip(gate_raw, max=clamp_value)
+        val = paddle.clip(val_raw, min=-clamp_value, max=clamp_value)
+        g_mask = (gate_raw <= clamp_value).cast(x.dtype)
+        v_mask = ((val_raw <= clamp_value) & (val_raw >= -clamp_value)).cast(
+            x.dtype
+        )
     else:
-        # ----------------------------
-        # XPU / CPU fallback
-        # ----------------------------
-        hidden = x.shape[-1] // 2
+        gate = gate_raw
+        val = val_raw
+        g_mask = None
+        v_mask = None
 
-        if clamp_value is not None and clamp_value > 0:
-            # Cast to float32 for the backward pass
-            x_fp32 = x.cast(paddle.float32)
-            gate_fp32 = x_fp32[..., :hidden]
-            val_fp32 = x_fp32[..., hidden:]
+    sig = F.sigmoid(gate).cast(x.dtype)
+    silu = gate * sig
+    swiglu_val = silu * val
 
-            # Clamp the raw inputs and build saturation masks matching g.dtype
-            gate_raw = gate_fp32
-            val_raw = val_fp32
-            gate_fp32 = paddle.clip(gate_raw, max=clamp_value)
-            val_fp32 = paddle.clip(val_raw, min=-clamp_value, max=clamp_value)
-            g_mask = (gate_raw <= clamp_value).cast(out_grad.dtype)
-            v_mask = (
-                (val_raw <= clamp_value) & (val_raw >= -clamp_value)
-            ).cast(out_grad.dtype)
+    scale_exp = scale.cast(x.dtype)
+    while scale_exp.ndim < out_grad.ndim:
+        scale_exp = scale_exp.unsqueeze(-1)
 
-            sig = F.sigmoid(gate_fp32)  # float32
-            silu = gate_fp32 * sig  # float32
-            swiglu_val = silu * val_fp32  # float32
+    d_u = out_grad * scale_exp
 
-            scale_fp32 = scale.cast(paddle.float32)
-            scale_exp = _broadcast_scale(
-                scale_fp32, paddle.float32, out_grad.ndim
-            )
-            d_u = out_grad * scale_exp
+    d_val = d_u * silu
+    d_gate = d_u * val * sig * (1.0 + gate * (1.0 - sig))
 
-            # d_val (gradient w.r.t. value / second half)
-            d_val = d_u * silu * v_mask
+    if clamp_value is not None:
+        d_val = d_val * v_mask
+        d_gate = d_gate * g_mask
 
-            # d_gate (gradient w.r.t. gate / first half)
-            d_gate = (
-                d_u * sig * (1.0 + gate_fp32 * (1.0 - sig)) * val_fp32 * g_mask
-            )
+    d_x = paddle.concat([d_gate, d_val], axis=-1).cast(x.dtype)
 
-            # Output order must be [d_gate, d_val] matching
-            # chunk(x,2)=[gate,value]
-            d_x = paddle.concat([d_gate, d_val], axis=-1).cast(x.dtype)
+    d_scale = paddle.sum(
+        out_grad.cast(paddle.float32) * swiglu_val.cast(paddle.float32), axis=-1
+    ).cast(scale.dtype)
 
-            # d_scale:
-            #   sum(swiglu_val.cast(x.dtype) * out_grad.cast(scale_dtype))
-            scale_dtype = scale.dtype
-            d_scale = paddle.sum(
-                swiglu_val.cast(x.dtype) * out_grad.cast(scale_dtype),
-                axis=-1,
-                keepdim=True,
-            ).cast(scale_dtype)
-
-            return d_x, d_scale
-
-        # Original non-clamp logic
-        gate = x[..., :hidden]
-        val = x[..., hidden:]
-
-        sig = F.sigmoid(gate).cast(x.dtype)
-        silu = gate * sig
-        swiglu_val = silu * val
-
-        scale_exp = _broadcast_scale(scale, x.dtype, out_grad.ndim)
-        d_u = out_grad * scale_exp
-
-        # ----------------------------
-        # dv
-        # ----------------------------
-        d_val = d_u * silu
-
-        # ----------------------------
-        # dg
-        # ----------------------------
-        d_gate = d_u * val * sig * (1.0 + gate * (1.0 - sig))
-
-        # ----------------------------
-        # d_x concat back
-        # ----------------------------
-        d_x = paddle.concat([d_gate, d_val], axis=-1).cast(x.dtype)
-
-        # ----------------------------
-        # d_scale
-        # sum(dout * swiglu) over hidden dim
-        # ----------------------------
-        d_scale = paddle.sum(
-            out_grad.cast(paddle.float32) * swiglu_val.cast(paddle.float32),
-            axis=-1,
-        ).cast(scale.dtype)
-
-        return d_x, d_scale
+    return d_x, d_scale

--- a/src/paddlefleet/models/common/language_loss/language_loss.py
+++ b/src/paddlefleet/models/common/language_loss/language_loss.py
@@ -14,7 +14,6 @@
 
 
 import functools
-import hashlib
 import os
 
 import numpy as np
@@ -37,41 +36,29 @@ from paddlefleet.parallel_state import (
     get_tensor_model_parallel_world_size,
 )
 from paddlefleet.process_groups_config import ProcessGroupCollection
-from paddlefleet.training.global_vars import get_global_training_logs
 from paddlefleet.transformer.layer import FleetLayer
 from paddlefleet.transformer.transformer_config import TransformerConfig
 
 
-def _loss_md5_enabled() -> bool:
+def _dsv4_loss_md5_enabled() -> bool:
     return os.environ.get("LOG_LOSS_MD5", "0") == "1"
 
 
-def _use_accuracy_compatible_kernel() -> bool:
-    """Switch for Megatron-aligned (accuracy-compatible) numeric paths.
+def _dsv4_tensor_md5(tensor: Tensor, dtype: str = "float32") -> str:
+    import hashlib
 
-    Controlled by the ``FLAGS_use_accuracy_compatible_kernel`` env variable.
-    """
-    return os.environ.get("FLAGS_use_accuracy_compatible_kernel", "0") == "1"
-
-
-def _tensor_md5(tensor: Tensor, dtype: str = "float32") -> str:
-    """Calculate MD5 hash of a tensor, **for debugging only**.
-
-    Note: internally calls .numpy() which triggers GPU→CPU synchronization
-    and blocks the async training pipeline. Do NOT use in the forward pass.
-    """
     tensor_for_md5 = tensor.detach().cast(dtype)
     return hashlib.md5(tensor_for_md5.numpy().tobytes()).hexdigest()
 
 
-def _print_scalar_loss_md5(prefix: str, name: str, loss: Tensor) -> None:
-    if not _loss_md5_enabled():
+def _dsv4_print_scalar_loss_md5(prefix: str, name: str, loss: Tensor) -> None:
+    if not _dsv4_loss_md5_enabled():
         return
     rank = paddle.distributed.get_rank()
     loss_tensor = loss.detach().cast("float32").reshape([1])
     print(
         f"[{prefix}] rank={rank} {name}={loss_tensor.item():.20f} "
-        f"{name}_md5={_tensor_md5(loss_tensor)}",
+        f"{name}_md5={_dsv4_tensor_md5(loss_tensor)}",
         flush=True,
     )
 
@@ -288,32 +275,6 @@ class LanguageLoss(FleetLayer):
             return loss
 
         seq_len = logits.shape[1]
-
-        # Loss-path MD5 probe: logits and labels before cross-entropy
-        import os
-
-        if (
-            os.environ.get("LOG_LAYER_MD5", "0") == "1"
-            or os.environ.get("LOG_LOSS_MD5", "0") == "1"
-        ):
-            import hashlib
-
-            rank = paddle.distributed.get_rank()
-            lg_md5 = hashlib.md5(
-                logits.cast("float32").numpy().tobytes()
-            ).hexdigest()
-            lb_md5 = hashlib.md5(
-                labels.cast("int64").numpy().tobytes()
-            ).hexdigest()
-            print(
-                f"[LOSS_PATH_MD5] rank={rank} loss_input_logits shape={list(logits.shape)} md5={lg_md5}",
-                flush=True,
-            )
-            print(
-                f"[LOSS_PATH_MD5] rank={rank} loss_input_labels shape={list(labels.shape)} md5={lb_md5}",
-                flush=True,
-            )
-
         if self.use_subbatch and seq_len > self.loss_subbatch_sequence_length:
 
             def _cast_loss_func(logits, labels):
@@ -344,53 +305,28 @@ class LanguageLoss(FleetLayer):
         else:
             lossmask = lossmask.reshape([-1]).cast(paddle.float32)
 
-            # Loss-path MD5 probe: per-token loss and lossmask
-            if (
-                os.environ.get("LOG_LAYER_MD5", "0") == "1"
-                or os.environ.get("LOG_LOSS_MD5", "0") == "1"
-            ):
-                import hashlib
-
+            if _dsv4_loss_md5_enabled():
                 rank = paddle.distributed.get_rank()
-                pt_md5 = hashlib.md5(
-                    loss.cast("float32").reshape([-1]).numpy().tobytes()
-                ).hexdigest()
-                lm_md5 = hashlib.md5(lossmask.numpy().tobytes()).hexdigest()
+                loss_float = loss.cast("float32").reshape([-1])
                 valid_count = lossmask.sum().item()
-                loss_sum_val = paddle.sum(
-                    loss.cast("float32").reshape([-1]) * lossmask
-                ).item()
+                loss_sum_tensor = paddle.sum(
+                    loss_float * lossmask
+                ).detach().cast("float32").reshape([1])
+                valid_count_tensor = lossmask.sum().detach().cast("float32").reshape([1])
+                final_loss_tensor = (
+                    loss_sum_tensor / valid_count_tensor
+                    if valid_count
+                    else paddle.full([1], float("nan"), dtype="float32")
+                )
+                loss_sum_val = loss_sum_tensor.item()
+                final_loss_val = final_loss_tensor.item()
                 print(
-                    f"[LOSS_PATH_MD5] rank={rank} per_token_loss md5={pt_md5}",
+                    f"[LOSS_PATH_MD5] rank={rank} loss_sum={loss_sum_val:.20f} "
+                    f"loss_sum_md5={_dsv4_tensor_md5(loss_sum_tensor)} "
+                    f"final_loss={final_loss_val:.20f} "
+                    f"final_loss_md5={_dsv4_tensor_md5(final_loss_tensor)}",
                     flush=True,
                 )
-                print(
-                    f"[LOSS_PATH_MD5] rank={rank} lossmask md5={lm_md5} valid_tokens={valid_count}",
-                    flush=True,
-                )
-                print(
-                    f"[LOSS_PATH_MD5] rank={rank} loss_sum={loss_sum_val} final_loss={loss_sum_val / valid_count}",
-                    flush=True,
-                )
-                # Also compute line-wise loss (matches EC's _line_wise_loss) for exact comparison
-                if self.config.gpt_model_use_experimental_version:
-                    _probe_loss_2d = loss.cast(
-                        paddle.float32
-                    ) * lossmask.reshape(labels.shape)
-                    _probe_lm_2d = lossmask.reshape(labels.shape)
-                    _probe_tc = _probe_lm_2d.sum(-1)
-                    _probe_inv = (_probe_tc == 0).astype(paddle.float32)
-                    _probe_lpl = _probe_loss_2d.sum(-1) / (
-                        _probe_tc + 1e-6 * _probe_inv
-                    )
-                    _probe_lpl = _probe_lpl * (1 - _probe_inv)
-                    _probe_lw = _probe_lpl.sum() / (
-                        (1 - _probe_inv).sum() + 1e-6
-                    )
-                    print(
-                        f"[LOSS_PATH_MD5] rank={rank} line_wise_loss={_probe_lw.item():.20f}",
-                        flush=True,
-                    )
 
             # EC-compat: line-wise loss (per-sample mean then average across samples)
             # EC's ErniemmPretrainingCriterion recomputes loss as line-wise when task_id
@@ -475,16 +411,10 @@ class LanguageLoss(FleetLayer):
                                 mode=self.config.cp_balance_mode,
                             )
 
-                        if self.config.fused_linear_ce_loss_chunk > 0:
-                            loss_matrix_cur_depth = self._forward(
-                                logits_cur_depth,
-                                labels_cur_depth,
-                            )
-                        else:
-                            loss_matrix_cur_depth = self.loss_func(
-                                logits_cur_depth.cast("float32"),
-                                labels_cur_depth,
-                            )
+                        loss_matrix_cur_depth = self.loss_func(
+                            logits_cur_depth.cast("float32"),
+                            labels_cur_depth,
+                        )
 
                         if get_context_parallel_world_size() > 1:
                             # In EB data flow and CP size > 1, loss and labels need to be gathered back.
@@ -605,66 +535,37 @@ class LanguageLoss(FleetLayer):
                         ploss = ploss / xishu
                         mtp_loss.append(ploss)
 
-            # Store detached MTP loss tensors into class-level tracker and global_training_logs.
+            # Store detached MTP loss tensors into class-level tracker.
             # Use .detach() instead of .item() to avoid GPU synchronization on every
             # micro-batch. The trainer will call .item() only at logging steps.
             for i, loss_val in enumerate(mtp_loss):
                 LanguageLoss.mtp_loss_tracker[f"mtp_{i + 1}_loss"] = (
                     loss_val.detach()
                 )
-                _print_scalar_loss_md5(
+                _dsv4_print_scalar_loss_md5(
                     "MTP_LOSS_PATH_MD5",
                     f"mtp{i + 1}.final_loss",
                     loss_val,
                 )
 
-            logs = get_global_training_logs()
-            if logs is not None and hasattr(logs, "update"):
-                for i, loss_val in enumerate(mtp_loss):
-                    logs.update(**{f"mtp_{i + 1}_loss": loss_val.detach()})
-
             def add_loss(main_loss, loss):
-                if _use_accuracy_compatible_kernel():
-                    # Megatron-aligned: MTP loss gradient flows but loss scalar unchanged.
-                    # This matches Megatron's behavior where MTP contributes to training
-                    # gradients without affecting the reported loss value.
-                    if self.config.add_mtp_loss:
-                        return main_loss + loss - loss.detach()
-                    else:
-                        return main_loss
+                if self.config.add_mtp_loss:
+                    return main_loss + loss - loss.detach()
                 else:
-                    # Original behavior
-                    if self.config.add_mtp_loss:
-                        return main_loss + loss
-                    else:
-                        return main_loss + loss - loss.detach()
+                    return main_loss
 
             if self.config.gpt_model_use_experimental_version:
                 # Align with EB: accumulate inside loop to match float32
                 # arithmetic order: loss += scaling * loss_i / N
                 loss = lm_loss
-                if _use_accuracy_compatible_kernel():
-                    # Megatron-aligned: only add MTP loss when add_mtp_loss=True.
-                    # Use add_loss() to keep single maintenance point for compat
-                    # behavior (loss + val - val.detach() for gradient-only flow).
-                    if self.config.add_mtp_loss:
-                        num_mtp = len(mtp_loss)
-                        for mtp_l in mtp_loss:
-                            mtp_val = (
-                                self.config.mtp_loss_scaling_factor
-                                * mtp_l
-                                / num_mtp
-                            )
-                            loss = add_loss(loss, mtp_val)
-                else:
-                    # Original behavior: always use add_loss
+                if self.config.add_mtp_loss:
                     num_mtp = len(mtp_loss)
                     for mtp_l in mtp_loss:
-                        loss = add_loss(
-                            loss,
-                            self.config.mtp_loss_scaling_factor
+                        loss = (
+                            loss
+                            + self.config.mtp_loss_scaling_factor
                             * mtp_l
-                            / num_mtp,
+                            / num_mtp
                         )
             else:
                 loss = add_loss(
@@ -715,39 +616,24 @@ class MainLanguageLoss(LanguageLoss):
         else:
             lm_loss = self._forward(logits, lm_labels)
 
-        # Store detached MTP loss tensors into class-level tracker and global_training_logs.
+        # Store detached MTP loss tensors into class-level tracker.
         # Use .detach() instead of .item() to avoid GPU synchronization on every
         # micro-batch. The trainer will call .item() only at logging steps.
         for i, loss_val in enumerate(mtp_loss):
             MainLanguageLoss.mtp_loss_tracker[f"mtp_{i + 1}_loss"] = (
                 loss_val.detach()
             )
-            _print_scalar_loss_md5(
+            _dsv4_print_scalar_loss_md5(
                 "MTP_LOSS_PATH_MD5",
                 f"mtp{i + 1}.final_loss",
                 loss_val,
             )
 
-        # Also write to global_training_logs to read
-        logs = get_global_training_logs()
-        if logs is not None and hasattr(logs, "update"):
-            for i, loss_val in enumerate(mtp_loss):
-                logs.update(**{f"mtp_{i + 1}_loss": loss_val.detach()})
-
         def add_loss(main_loss, loss):
-            if _use_accuracy_compatible_kernel():
-                # Megatron-aligned: MTP loss gradient flows but loss scalar unchanged.
-                # This matches Megatron's behavior
-                if self.config.add_mtp_loss:
-                    return main_loss + loss - loss.detach()
-                else:
-                    return main_loss
+            if self.config.add_mtp_loss:
+                return main_loss + loss - loss.detach()
             else:
-                # Original behavior
-                if self.config.add_mtp_loss:
-                    return main_loss + loss
-                else:
-                    return main_loss + loss - loss.detach()
+                return main_loss
 
         loss = add_loss(
             lm_loss,

--- a/src/paddlefleet/models/gpt/gpt_embedding.py
+++ b/src/paddlefleet/models/gpt/gpt_embedding.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from __future__ import annotations
 
+import os
 import warnings
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
@@ -220,8 +221,15 @@ class GPTEmbedding(FleetLayer):
                     )
                     mtp_ids_list = []
                     for depth in range(self.config.num_nextn_predict_layers):
+                        pad_ids = paddle.zeros(
+                            [input_ids.shape[0], depth + 1],
+                            dtype=input_ids.dtype,
+                        )
                         mtp_ids_list.append(
-                            input_ids[:, (depth + 1) : (depth + 1 + seq_length)]
+                            paddle.concat(
+                                [input_ids[:, depth + 1 : seq_length], pad_ids],
+                                axis=1,
+                            )
                         )
                     # [B, num_mtp, max_seq] - paddle.stack creates a new contiguous tensor
                     mtp_input_ids_for_moe_mask = paddle.stack(
@@ -293,13 +301,56 @@ class GPTEmbedding(FleetLayer):
                         )  # change to [S, B, H]
                     mtp_emb_res = [inputs_embeds]
                     for depth in range(self.config.num_nextn_predict_layers):
-                        inputs_embeds_mtp = paddle.concat(
-                            [
-                                inputs_embeds_ori[:, (depth + 1) :, :],
-                                inputs_embeds_extra[:, : (depth + 1), :],
-                            ],
-                            axis=1,
+                        pad_input_ids = paddle.zeros(
+                            [batch_size, depth + 1], dtype=input_ids.dtype
                         )
+                        pad_position_ids = None
+                        if (
+                            not self.multimodal_embedding
+                            and position_ids is not None
+                        ):
+                            pad_position_ids = paddle.zeros(
+                                [batch_size, depth + 1],
+                                dtype=position_ids.dtype,
+                            )
+                        pad_embeds = self.embedding(
+                            input_ids=pad_input_ids,
+                            position_ids=pad_position_ids,
+                        )
+
+                        if (
+                            paddle.core._has_grad()
+                            and os.getenv(
+                                "DSV4_FLEET_MTP_SEPARATE_EMBEDDING", "0"
+                            )
+                            == "1"
+                        ):
+                            shifted_input_ids = input_ids[
+                                :, (depth + 1) : seq_length
+                            ]
+                            shifted_position_ids = None
+                            if (
+                                not self.multimodal_embedding
+                                and position_ids is not None
+                            ):
+                                shifted_position_ids = position_ids[
+                                    :, (depth + 1) : seq_length
+                                ]
+                            shifted_embeds = self.embedding(
+                                input_ids=shifted_input_ids,
+                                position_ids=shifted_position_ids,
+                            )
+                            inputs_embeds_mtp = paddle.concat(
+                                [shifted_embeds, pad_embeds], axis=1
+                            )
+                        else:
+                            inputs_embeds_mtp = paddle.concat(
+                                [
+                                    inputs_embeds_ori[:, (depth + 1) :, :],
+                                    inputs_embeds_extra[:, : (depth + 1), :],
+                                ],
+                                axis=1,
+                            )
 
                         if (
                             get_context_parallel_world_size() > 1
@@ -479,7 +530,7 @@ class GPTEmbedding(FleetLayer):
                 rotary_seq_len,
                 packed_seq=packed_seq_params is not None
                 and packed_seq_params.qkv_format == "thd",
-                position_ids=None if self.training else mtp_position_ids,
+                position_ids=position_ids,
             )
         elif (
             self.position_embedding_type == "mrope"

--- a/src/paddlefleet/models/gpt/lm_head.py
+++ b/src/paddlefleet/models/gpt/lm_head.py
@@ -27,6 +27,12 @@ from paddlefleet.tensor_parallel.layers import (
     _initialize_affine_weight_gpu,
 )
 from paddlefleet.transformer.identity_op import IdentityOp
+from paddlefleet.utils import dsv4_sequence_first_feature_enabled
+
+def _dsv4_lm_head_sequence_first_linear_enabled() -> bool:
+    return dsv4_sequence_first_feature_enabled(
+        "DSV4_FLEET_LM_HEAD_SEQUENCE_FIRST_LINEAR"
+    )
 
 
 class GPTLMHead(ColumnParallelLinear):
@@ -41,8 +47,6 @@ class GPTLMHead(ColumnParallelLinear):
         block_attn_res_spec = kwargs.pop("block_attn_res", IdentityOp)
 
         kwargs["skip_weight_param_allocation"] = True
-        if self.config.gpt_model_use_experimental_version:
-            kwargs["bias"] = self.config.use_bias
         super().__init__(**kwargs)
 
         stride = kwargs["stride"] if "stride" in kwargs.keys() else 1
@@ -100,7 +104,16 @@ class GPTLMHead(ColumnParallelLinear):
     def build_schedule_node(self):
         return ScheduleNode(self.forward, name="GPTLMHead")
 
-    def _forward(self, hidden_states: paddle.Tensor):
+    def _forward(self, hidden_states: paddle.Tensor, *, is_main: bool = False):
+        use_sequence_first_linear = (
+            _dsv4_lm_head_sequence_first_linear_enabled()
+            and not self.config.sequence_parallel
+            and hidden_states.ndim == 3
+            and hidden_states.shape[0] > 1
+        )
+        linear_input = hidden_states
+        if use_sequence_first_linear:
+            linear_input = hidden_states.transpose([1, 0, 2]).contiguous()
         # Fused linear + cross-entropy path: skip materializing [B, S, V] logits
         # and delegate the linear projection into LanguageLoss, which will call
         # LigerFusedLinearCrossEntropyFunction.
@@ -121,44 +134,13 @@ class GPTLMHead(ColumnParallelLinear):
                 logits, _ = recompute_func(hidden_states, weight)
                 return logits
 
-            logits = recompute_handler(hidden_states, self.weight.T)
+            logits = recompute_handler(linear_input, self.weight.T)
         else:
-            logits, _ = super().forward(hidden_states, self.weight.T)
+            logits, _ = super().forward(linear_input, self.weight.T)
+        if use_sequence_first_linear:
+            logits = logits.transpose([1, 0, 2]).contiguous()
         if self.config.sequence_parallel:
             logits = logits.transpose([1, 0, 2]).contiguous()
-
-        # Loss-path MD5 probe: lm_head weight and logits
-        import os
-
-        if (
-            os.environ.get("LOG_LAYER_MD5", "0") == "1"
-            or os.environ.get("LOG_LOSS_MD5", "0") == "1"
-        ):
-            import hashlib
-
-            rank = paddle.distributed.get_rank()
-            w_md5 = hashlib.md5(
-                self.weight.cast("float32").numpy().tobytes()
-            ).hexdigest()
-            h_md5 = hashlib.md5(
-                hidden_states.cast("float32").numpy().tobytes()
-            ).hexdigest()
-            l_md5 = hashlib.md5(
-                logits.cast("float32").numpy().tobytes()
-            ).hexdigest()
-            print(
-                f"[LOSS_PATH_MD5] rank={rank} lm_head_weight shape={list(self.weight.shape)} md5={w_md5}",
-                flush=True,
-            )
-            print(
-                f"[LOSS_PATH_MD5] rank={rank} lm_head_input shape={list(hidden_states.shape)} md5={h_md5}",
-                flush=True,
-            )
-            print(
-                f"[LOSS_PATH_MD5] rank={rank} lm_head_logits shape={list(logits.shape)} md5={l_md5}",
-                flush=True,
-            )
-
         return logits
 
     def forward(self, dict_args: dict):
@@ -178,12 +160,12 @@ class GPTLMHead(ColumnParallelLinear):
                 hidden_states,
                 self.config.num_nextn_predict_layers + 1,
             )
-            logits = [self._forward(tensor_list[0])]
+            logits = [self._forward(tensor_list[0], is_main=True)]
             for i in range(self.config.num_nextn_predict_layers):
                 logits.append(self._forward(tensor_list[i + 1]))
             return logits
         else:
-            return self._forward(hidden_states)
+            return self._forward(hidden_states, is_main=True)
 
     @property
     def embedding_weight(self):
@@ -225,7 +207,7 @@ class GPTMainLMHead(GPTLMHead):
             hidden_states,
             self.config.num_nextn_predict_layers + 1,
         )
-        logits = self._forward(tensor_list[0])
+        logits = self._forward(tensor_list[0], is_main=True)
         ret = {
             "logits": logits,
             "mtp_loss": mtp_loss,

--- a/src/paddlefleet/tensor_parallel/layers.py
+++ b/src/paddlefleet/tensor_parallel/layers.py
@@ -40,6 +40,7 @@ from ..parallel_state import (
 # from ..transformer.utils import make_sharded_tensors_for_checkpoint
 from ..utils import (
     divide,
+    dsv4_sequence_first_feature_enabled,
     get_pg_rank,
     get_pg_size,
     get_tensor_model_parallel_group_if_none,
@@ -75,6 +76,148 @@ _MODEL_PARALLEL_ATTRIBUTE_DEFAULTS = {
     "partition_dim": -1,
     "partition_stride": 1,
 }
+def _dsv4_te_dgrad_enabled(
+    grad_output: paddle.Tensor, weight: paddle.Tensor
+) -> bool:
+    if os.getenv("DSV4_FLEET_TE_DGRAD", "0") != "1":
+        return False
+    shape_filter = os.getenv("DSV4_FLEET_TE_DGRAD_WEIGHT_SHAPES", "")
+    if shape_filter:
+        allowed = {
+            item.strip() for item in shape_filter.split(",") if item.strip()
+        }
+        if "x".join(str(dim) for dim in weight.shape) not in allowed:
+            return False
+    return weight.dtype == paddle.bfloat16 and grad_output.dtype == paddle.bfloat16
+
+
+def _dsv4_te_dgrad(
+    grad_output: paddle.Tensor, weight: paddle.Tensor
+) -> paddle.Tensor:
+    import sys
+
+    te_site_packages = os.getenv("DSV4_FLEET_TE_SITE_PACKAGES", "")
+    if te_site_packages and te_site_packages not in sys.path:
+        sys.path.insert(0, te_site_packages)
+
+    import torch
+    import torch.utils.dlpack
+    from paddle.utils import dlpack as paddle_dlpack
+    from transformer_engine.pytorch.cpp_extensions.gemm import general_gemm
+
+    grad_output_torch = torch.utils.dlpack.from_dlpack(
+        paddle_dlpack.to_dlpack(grad_output.contiguous())
+    )
+    weight_oi_torch = torch.utils.dlpack.from_dlpack(
+        paddle_dlpack.to_dlpack(weight.t().contiguous())
+    )
+    grad_input_torch, *_ = general_gemm(
+        weight_oi_torch,
+        grad_output_torch,
+        out_dtype=torch.bfloat16,
+        layout="NN",
+        grad=True,
+    )
+
+    return paddle_dlpack.from_dlpack(
+        torch.utils.dlpack.to_dlpack(grad_input_torch.contiguous())
+    )
+
+
+def _dsv4_linear_seqfirst_wgrad_enabled(
+    input: paddle.Tensor, grad_output: paddle.Tensor, weight: paddle.Tensor
+) -> bool:
+    if not dsv4_sequence_first_feature_enabled(
+        "DSV4_FLEET_LINEAR_SEQFIRST_WGRAD"
+    ):
+        return False
+    if input.dim() not in (3, 4) or grad_output.dim() != input.dim():
+        return False
+    # This branch is for DSv4 Paddle modules that run linears as [B, S, H]
+    # / [B, S, N, H] while the Megatron reference computes wgrad over
+    # [S, B, H] / [S, B, N, H].
+    if input.shape[0] <= 1:
+        return False
+    if os.getenv("DSV4_FLEET_LINEAR_SEQFIRST_WGRAD_REQUIRE_BATCH_FIRST", "1") == "1":
+        if input.shape[0] >= input.shape[1]:
+            return False
+    shape_filter = os.getenv("DSV4_FLEET_LINEAR_SEQFIRST_WGRAD_WEIGHT_SHAPES", "")
+    if shape_filter:
+        allowed = {
+            item.strip() for item in shape_filter.split(",") if item.strip()
+        }
+        if "x".join(str(dim) for dim in weight.shape) not in allowed:
+            return False
+    return weight.dtype == paddle.bfloat16
+
+
+def _dsv4_torch_linear_seqfirst_wgrad(
+    input: paddle.Tensor, grad_output: paddle.Tensor, weight: paddle.Tensor
+) -> paddle.Tensor:
+    import sys
+
+    site_packages = os.getenv("DSV4_FLEET_TE_SITE_PACKAGES", "")
+    if site_packages and site_packages not in sys.path:
+        sys.path.insert(0, site_packages)
+
+    import torch
+    import torch.utils.dlpack
+    from paddle.utils import dlpack as paddle_dlpack
+
+    out_features = grad_output.shape[-1]
+    if input.dim() == 3:
+        batch, seq, hidden = input.shape
+        flat_rows = batch * seq
+        input_seqfirst = (
+            input.detach()
+            .reshape([batch, seq, hidden])
+            .transpose([1, 0, 2])
+            .reshape([flat_rows, hidden])
+            .contiguous()
+        )
+        grad_seqfirst = (
+            grad_output.detach()
+            .reshape([batch, seq, out_features])
+            .transpose([1, 0, 2])
+            .reshape([flat_rows, out_features])
+            .contiguous()
+        )
+    else:
+        batch, seq, streams, hidden = input.shape
+        flat_rows = batch * seq * streams
+        input_seqfirst = (
+            input.detach()
+            .reshape([batch, seq, streams, hidden])
+            .transpose([1, 0, 2, 3])
+            .reshape([flat_rows, hidden])
+            .contiguous()
+        )
+        grad_seqfirst = (
+            grad_output.detach()
+            .reshape([batch, seq, streams, out_features])
+            .transpose([1, 0, 2, 3])
+            .reshape([flat_rows, out_features])
+            .contiguous()
+        )
+
+    input_t = torch.utils.dlpack.from_dlpack(
+        paddle_dlpack.to_dlpack(input_seqfirst)
+    ).detach()
+    grad_t = torch.utils.dlpack.from_dlpack(
+        paddle_dlpack.to_dlpack(grad_seqfirst)
+    ).detach()
+    weight_oi_t = torch.utils.dlpack.from_dlpack(
+        paddle_dlpack.to_dlpack(weight.t().contiguous())
+    ).detach()
+
+    with torch.enable_grad():
+        input_t = input_t.requires_grad_(True)
+        weight_oi_t = weight_oi_t.requires_grad_(True)
+        output_t = torch.matmul(input_t, weight_oi_t.t())
+        output_t.backward(grad_t)
+        grad_weight_t = weight_oi_t.grad.t().contiguous()
+
+    return paddle_dlpack.from_dlpack(torch.utils.dlpack.to_dlpack(grad_weight_t))
 
 
 def param_is_not_tensor_parallel_duplicate(param):
@@ -299,7 +442,7 @@ class VocabParallelEmbedding(paddle.nn.Layer):
         else:
             masked_input = input_
         # Get the embeddings.
-        if self.deterministic_mode:
+        if self.deterministic_mode or os.getenv("DSV4_EMBEDDING_INDEX_BACKWARD", "0") == "1":
             output_parallel = self.weight[masked_input]
         else:
             # F.embedding currently has a non-deterministic backward function
@@ -342,12 +485,19 @@ class LinearWithFrozenWeight(paddle.autograd.Function):
     but in experiments they are not identical mathematically."""
 
     @staticmethod
-    def forward(ctx, input, weight, bias, allreduce_dgrad, tp_group):
+    def forward(
+        ctx,
+        input,
+        weight,
+        bias,
+        allreduce_dgrad,
+        tp_group,
+    ):
         """Forward with frozen weight."""
         ctx.save_for_backward(weight, bias)
         ctx.allreduce_dgrad = allreduce_dgrad
         ctx.tp_group = tp_group
-        output = paddle.matmul(input, weight)
+        output = paddle.matmul(input, weight.t().contiguous(), transpose_y=True)
 
         if bias is not None:
             output = output + bias
@@ -357,7 +507,10 @@ class LinearWithFrozenWeight(paddle.autograd.Function):
     def backward(ctx, grad_output):
         """Backward with frozen weight."""
         (weight, bias) = ctx.saved_tensor()
-        grad_input = grad_output.matmul(weight.t())
+        if _dsv4_te_dgrad_enabled(grad_output, weight):
+            grad_input = _dsv4_te_dgrad(grad_output, weight)
+        else:
+            grad_input = grad_output.matmul(weight.t())
 
         if ctx.allreduce_dgrad:
             # All-reduce. Note: here async and sync are effectively the same.
@@ -447,7 +600,13 @@ def linear_with_frozen_weight(
     else:
         input = input
 
-    args = [input, weight, bias, allreduce_dgrad, tp_group]
+    args = [
+        input,
+        weight,
+        bias,
+        allreduce_dgrad,
+        tp_group,
+    ]
 
     return LinearWithFrozenWeight.apply(*args)
 
@@ -485,11 +644,6 @@ class LinearWithGradAccumulationAndAsyncCommunication(paddle.autograd.Function):
         ctx.wgrad_deferral_limit = wgrad_deferral_limit
         ctx.grad_output_buffer = grad_output_buffer
         ctx.tp_group = tp_group
-        # Cache input.stop_gradient: ``_new_shared_tensor()`` does not
-        # necessarily preserve this flag, and Paddle's PyLayer contract
-        # requires backward to return None at position 0 iff the original
-        # forward input had stop_gradient=True.
-        ctx.input_stop_gradient = bool(input.stop_gradient)
 
         if sequence_parallel:
             dim_size = list(input.shape)
@@ -506,7 +660,9 @@ class LinearWithGradAccumulationAndAsyncCommunication(paddle.autograd.Function):
         if bias is not None:
             output = paddle.nn.functional.linear(total_input, weight, bias)
         else:
-            output = paddle.matmul(total_input, weight)
+            output = paddle.matmul(
+                total_input, weight.t().contiguous(), transpose_y=True
+            )
         return output
 
     @staticmethod
@@ -519,16 +675,6 @@ class LinearWithGradAccumulationAndAsyncCommunication(paddle.autograd.Function):
         wgrad_deferral_limit = ctx.wgrad_deferral_limit
         handle = None
         tp_group = ctx.tp_group
-
-        # Paddle PyLayer contract: when a forward Tensor input has
-        # stop_gradient=True, the corresponding backward return slot MUST be
-        # None. The "input" position (0) is the only one that can carry
-        # stop_gradient=True in normal usage (weight/bias are trainable);
-        # callers that intentionally feed a detached tensor (e.g. for
-        # gradient isolation) rely on this. We must skip grad_input compute
-        # and any input-side collective (all_reduce / reduce_scatter) in
-        # that case, while still computing grad_weight / grad_bias.
-        input_needs_grad = not ctx.input_stop_gradient
 
         if ctx.gradient_accumulation_fusion:
             weight.main_grad = main_grad
@@ -559,21 +705,29 @@ class LinearWithGradAccumulationAndAsyncCommunication(paddle.autograd.Function):
                 total_input = all_gather_buffer
             else:
                 total_input = input
-        if input_needs_grad:
-            grad_input = grad_output.matmul(weight.t())
+        if _dsv4_te_dgrad_enabled(grad_output, weight):
+            grad_input = _dsv4_te_dgrad(grad_output, weight)
         else:
-            grad_input = None
+            grad_input = grad_output.matmul(weight.t())
 
         if ctx.sequence_parallel and wgrad_compute:
             # pylint: disable=possibly-used-before-assignment
             handle.wait()
+
+        dsv4_seqfirst_grad_weight = None
+        if wgrad_compute and _dsv4_linear_seqfirst_wgrad_enabled(
+            input, grad_output, weight
+        ):
+            dsv4_seqfirst_grad_weight = _dsv4_torch_linear_seqfirst_wgrad(
+                input, grad_output, weight
+            )
 
         if wgrad_compute:
             grad_output, total_input = prepare_input_tensors_for_wgrad_compute(
                 grad_output, total_input
             )
 
-        if ctx.allreduce_dgrad and input_needs_grad:
+        if ctx.allreduce_dgrad:
             # Asynchronous all-reduce
             handle = dist.all_reduce(grad_input, group=tp_group, sync_op=False)
             # Here we rely on CUDA_DEVICE_MAX_CONNECTIONS=1 to ensure that the
@@ -581,19 +735,16 @@ class LinearWithGradAccumulationAndAsyncCommunication(paddle.autograd.Function):
 
         if ctx.sequence_parallel:
             assert not ctx.allreduce_dgrad
-            if input_needs_grad:
-                dim_size = list(input.shape)
-                sub_grad_input = paddle.empty(
-                    dim_size, dtype=input.dtype, requires_grad=False
-                )
-                # reduce_scatter
-                handle = _reduce_scatter_base(
-                    sub_grad_input, grad_input, group=tp_group, sync_op=False
-                )
-                # Here we rely on CUDA_DEVICE_MAX_CONNECTIONS=1 to ensure that the
-                # reduce scatter is scheduled before the weight gradient computation
-            else:
-                sub_grad_input = None
+            dim_size = list(input.shape)
+            sub_grad_input = paddle.empty(
+                dim_size, dtype=input.dtype, requires_grad=False
+            )
+            # reduce_scatter
+            handle = _reduce_scatter_base(
+                sub_grad_input, grad_input, group=tp_group, sync_op=False
+            )
+            # Here we rely on CUDA_DEVICE_MAX_CONNECTIONS=1 to ensure that the
+            # reduce scatter is scheduled before the weight gradient computation
 
         if ctx.gradient_accumulation_fusion:
             if wgrad_compute:
@@ -634,12 +785,14 @@ class LinearWithGradAccumulationAndAsyncCommunication(paddle.autograd.Function):
             else:
                 grad_weight = None
         else:
-            grad_weight = total_input.t().matmul(grad_output)
+            if dsv4_seqfirst_grad_weight is not None:
+                grad_weight = dsv4_seqfirst_grad_weight
+            else:
+                grad_weight = total_input.t().matmul(grad_output)
         grad_bias = grad_output.sum(dim=0) if use_bias else None
 
         if ctx.sequence_parallel:
-            if input_needs_grad:
-                handle.wait()
+            handle.wait()
             # Need to return None's as gradient has to flow for all the input arguments
             # provided during forward
             if use_bias:
@@ -647,7 +800,7 @@ class LinearWithGradAccumulationAndAsyncCommunication(paddle.autograd.Function):
             else:
                 return sub_grad_input, grad_weight
 
-        if ctx.allreduce_dgrad and input_needs_grad:
+        if ctx.allreduce_dgrad:
             handle.wait()
 
         # PyLayer requires the number of output in backward
@@ -1259,21 +1412,6 @@ class ColumnParallelLinear(paddle.nn.Layer):
                 )
 
         bias = self.bias if not self.skip_bias_add else None
-
-        if (
-            getattr(self.config, "gpt_model_use_experimental_version", False)
-            and self.world_size == 1
-            and self.bias is not None
-        ):
-            output = paddle.incubate.nn.functional.fused_linear(
-                input_, weight, self.bias
-            )
-            output_bias = (
-                self.bias.clone()
-                if (self.skip_bias_add and self.bias is not None)
-                else None
-            )
-            return output, output_bias
 
         if (
             self.allreduce_dgrad

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -1025,7 +1025,7 @@ class Compressor(nn.Layer):
             score = self._overlap_transform(score, fill_value=float("-inf"))
 
         # Gated pooling: softmax over the pool_dim, weighted sum.
-        weights = F.softmax(score, axis=2, dtype="float32").cast(kv.dtype)
+        weights = F.softmax(score, axis=2).cast(kv.dtype)
         kv = (kv * weights).sum(axis=2)  # [b, n_compressed, head_dim]
 
         kv = self.norm(kv.cast(x.dtype))

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -26,6 +26,7 @@ Components:
 from __future__ import annotations
 
 import functools
+import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -66,11 +67,34 @@ from paddlefleet.transformer.cp_utils import (
 # ---------------------------------------------------------------------------
 
 
+def _get_doc_start(
+    attn_mask_startend_row_indices: Tensor, seqlen: int
+) -> Tensor:
+    """Derive per-position document start from packed document boundaries."""
+    mask = attn_mask_startend_row_indices
+    squeeze_batch: bool = mask.ndim == 1
+    if squeeze_batch:
+        mask = mask.unsqueeze(0)
+
+    changed = paddle.zeros_like(mask, dtype="int64")
+    changed[:, 0] = 1
+    changed[:, 1:] = (mask[:, 1:] != mask[:, :-1]).cast("int64")
+
+    positions = (
+        paddle.arange(seqlen, dtype="int64").unsqueeze(0).expand_as(mask)
+    )
+    doc_start = paddle.cummax(changed * positions, axis=1).values
+
+    if squeeze_batch:
+        doc_start = doc_start.squeeze(0)
+    return doc_start
+
+
 @functools.lru_cache(maxsize=8)
-def _get_window_topk_idxs_cached(
+def _get_window_topk_idxs_no_doc(
     window_size: int, seqlen: int, device_str: str
 ) -> Tensor:
-    """Compute sliding window indices for a single sequence (cached)."""
+    """Compute sliding window indices without document mask (cached)."""
     base = paddle.arange(seqlen).unsqueeze(1)  # [seqlen, 1]
     offsets = paddle.arange(window_size)  # [window_size]
     matrix = paddle.clip(base - window_size + 1, min=0) + offsets
@@ -79,10 +103,10 @@ def _get_window_topk_idxs_cached(
 
 
 @functools.lru_cache(maxsize=8)
-def _get_compress_topk_idxs_cached(
+def _get_compress_topk_idxs_no_doc(
     ratio: int, seqlen: int, offset: int, device_str: str
 ) -> Tensor:
-    """Compute compressed indices for a single sequence (cached)."""
+    """Compute compressed indices without document mask (cached)."""
     n_compressed = seqlen // ratio
     k_indices = paddle.arange(n_compressed)
     matrix = k_indices.unsqueeze(0).expand([seqlen, -1])
@@ -98,11 +122,34 @@ def get_window_topk_idxs(
     window_size: int,
     batch_size: int,
     seqlen: int,
+    attn_mask_startend_row_indices: Tensor | None = None,
     device=None,
 ) -> Tensor:
     """Get sliding window indices: [b, seqlen, window_size]."""
-    indices = _get_window_topk_idxs_cached(window_size, seqlen, "gpu")
-    return indices.unsqueeze(0).expand([batch_size, -1, -1])
+    if attn_mask_startend_row_indices is None:
+        indices = _get_window_topk_idxs_no_doc(window_size, seqlen, "gpu")
+        return indices.unsqueeze(0).expand([batch_size, -1, -1])
+
+    assert (
+        attn_mask_startend_row_indices.shape[1] == 1
+        and attn_mask_startend_row_indices.shape[3] == 1
+    ), (
+        f"attn_mask_startend_row_indices shape must be [b, 1, seqlen, 1] now, but got {attn_mask_startend_row_indices.shape}"
+    )
+    mask = attn_mask_startend_row_indices.reshape([batch_size, seqlen])
+    doc_start = _get_doc_start(mask, seqlen)
+
+    base = paddle.arange(seqlen).unsqueeze(1)
+    offsets = paddle.arange(window_size)
+    base_3d = base.unsqueeze(0)
+    win_start = paddle.maximum(
+        base_3d - window_size + 1, doc_start.unsqueeze(2)
+    )
+    matrix = win_start + offsets.unsqueeze(0).unsqueeze(0)
+    matrix = paddle.where(
+        matrix > base_3d, paddle.full_like(matrix, -1), matrix
+    )
+    return matrix
 
 
 def _build_compressed_causal_mask(
@@ -127,11 +174,38 @@ def get_compress_topk_idxs(
     batch_size: int,
     seqlen: int,
     offset: int,
+    attn_mask_startend_row_indices: Tensor | None = None,
     device=None,
 ) -> Tensor:
     """Get compressed indices: [b, seqlen, seqlen // ratio]."""
-    matrix = _get_compress_topk_idxs_cached(ratio, seqlen, offset, "gpu")
-    return matrix.unsqueeze(0).expand([batch_size, -1, -1])
+    if attn_mask_startend_row_indices is None:
+        matrix = _get_compress_topk_idxs_no_doc(ratio, seqlen, offset, "gpu")
+        return matrix.unsqueeze(0).expand([batch_size, -1, -1])
+
+    mask = attn_mask_startend_row_indices.reshape([batch_size, seqlen])
+    doc_start = _get_doc_start(mask, seqlen)
+
+    n_compressed = seqlen // ratio
+    matrix = (
+        paddle.arange(n_compressed)
+        .unsqueeze(0)
+        .unsqueeze(0)
+        .expand([batch_size, seqlen, -1])
+    )
+
+    causal_bound = (
+        paddle.arange(1, seqlen + 1).unsqueeze(1) // ratio
+    ).unsqueeze(0)
+    causal_invalid = matrix >= causal_bound
+
+    doc_start_compressed = ((doc_start + ratio - 1) // ratio).unsqueeze(2)
+    doc_invalid = matrix < doc_start_compressed
+
+    invalid = causal_invalid | doc_invalid
+    matrix = paddle.where(
+        invalid, paddle.full_like(matrix, -1), matrix + offset
+    )
+    return matrix
 
 
 # ---------------------------------------------------------------------------
@@ -212,6 +286,72 @@ def _apply_rope(
 # ---------------------------------------------------------------------------
 
 
+def _dsv4_import_torch_for_csa_sink_softmax():
+    site_packages = os.environ.get("DSV4_FLEET_TE_SITE_PACKAGES", "")
+    if site_packages and site_packages not in os.sys.path:
+        os.sys.path.insert(0, site_packages)
+    import torch
+    import torch.utils.dlpack
+
+    return torch
+
+
+def _dsv4_csa_sink_softmax_torch_bwd_enabled() -> bool:
+    return os.environ.get("DSV4_FLEET_CSA_SINK_SOFTMAX_TORCH_BWD", "0") == "1"
+
+
+def _dsv4_csa_sink_softmax_paddle(scores: Tensor, sink: Tensor) -> Tensor:
+    scores_max = scores.max(axis=-1, keepdim=True)  # [b, np, sq, 1]
+    scores_max = paddle.maximum(scores_max, sink)
+    exp_scores = paddle.exp(scores - scores_max)  # [b, np, sq, topk]
+    exp_sink = paddle.exp(sink - scores_max)  # [b, np, sq, 1]
+    sum_exp = exp_scores.sum(axis=-1, keepdim=True) + exp_sink  # [b, np, sq, 1]
+    return exp_scores / sum_exp  # [b, np, sq, topk]
+
+
+class _DSV4CSASinkSoftmaxTorchBackward(paddle.autograd.PyLayer):
+    @staticmethod
+    def forward(ctx, scores: Tensor, sink: Tensor):
+        ctx.save_for_backward(scores, sink)
+        return _dsv4_csa_sink_softmax_paddle(scores, sink)
+
+    @staticmethod
+    def backward(ctx, grad_attn_weights: Tensor):
+        torch = _dsv4_import_torch_for_csa_sink_softmax()
+        scores, sink = ctx.saved_tensor()
+        scores_t = torch.utils.dlpack.from_dlpack(
+            paddle.utils.dlpack.to_dlpack(scores.detach().contiguous())
+        )
+        sink_t = torch.utils.dlpack.from_dlpack(
+            paddle.utils.dlpack.to_dlpack(sink.detach().contiguous())
+        )
+        grad_t = torch.utils.dlpack.from_dlpack(
+            paddle.utils.dlpack.to_dlpack(
+                grad_attn_weights.detach().contiguous()
+            )
+        )
+
+        with torch.enable_grad():
+            scores_t = scores_t.detach().requires_grad_(True)
+            sink_t = sink_t.detach().requires_grad_(True)
+            scores_max_t = torch.maximum(
+                scores_t.max(dim=-1, keepdim=True).values, sink_t
+            )
+            exp_scores_t = torch.exp(scores_t - scores_max_t)
+            exp_sink_t = torch.exp(sink_t - scores_max_t)
+            sum_exp_t = exp_scores_t.sum(dim=-1, keepdim=True) + exp_sink_t
+            attn_weights_t = exp_scores_t / sum_exp_t
+            attn_weights_t.backward(grad_t)
+
+        grad_scores = paddle.utils.dlpack.from_dlpack(
+            torch.utils.dlpack.to_dlpack(scores_t.grad.contiguous())
+        )
+        grad_sink = paddle.utils.dlpack.from_dlpack(
+            torch.utils.dlpack.to_dlpack(sink_t.grad.contiguous())
+        )
+        return grad_scores, grad_sink
+
+
 def unfused_compressed_sparse_attn(
     query: Tensor,
     kv_full: Tensor,
@@ -261,18 +401,11 @@ def unfused_compressed_sparse_attn(
 
         # Softmax with attention sink
         # sink: [np] -> [1, np, 1, 1]
-        sink = attn_sink.reshape([1, np_heads, 1, 1])
-        # Compute stable softmax: max over scores and sink
-        scores_max = scores.max(axis=-1, keepdim=True)  # [b, np, sq, 1]
-        scores_max = paddle.maximum(scores_max, sink)
-
-        exp_scores = paddle.exp(scores - scores_max)  # [b, np, sq, topk]
-        exp_sink = paddle.exp(sink - scores_max)  # [b, np, sq, 1]
-
-        sum_exp = (
-            exp_scores.sum(axis=-1, keepdim=True) + exp_sink
-        )  # [b, np, sq, 1]
-        attn_weights = exp_scores / sum_exp  # [b, np, sq, topk]
+        sink = attn_sink.reshape([1, np_heads, 1, 1]).cast("float32")
+        if _dsv4_csa_sink_softmax_torch_bwd_enabled():
+            attn_weights = _DSV4CSASinkSoftmaxTorchBackward.apply(scores, sink)
+        else:
+            attn_weights = _dsv4_csa_sink_softmax_paddle(scores, sink)
 
         # Weighted sum: [b, np, sq, topk] x [b, sq, topk, hn] -> [b, np, sq, hn]
         output = paddle.einsum("bnsk,bskh->bnsh", attn_weights, kv_g)
@@ -814,8 +947,6 @@ class Compressor(nn.Layer):
                 else 0.02
             ),
         )
-        self._cast_to_low_precision = False
-
         self.norm = build_spec_layer(
             sublayers_spec.norm,
             config=config,
@@ -894,9 +1025,8 @@ class Compressor(nn.Layer):
             score = self._overlap_transform(score, fill_value=float("-inf"))
 
         # Gated pooling: softmax over the pool_dim, weighted sum.
-        kv = (kv * F.softmax(score, axis=2)).sum(
-            axis=2
-        )  # [b, n_compressed, head_dim]
+        weights = F.softmax(score, axis=2, dtype="float32").cast(kv.dtype)
+        kv = (kv * weights).sum(axis=2)  # [b, n_compressed, head_dim]
 
         kv = self.norm(kv.cast(x.dtype))
 
@@ -1094,12 +1224,12 @@ class CompressedSparseAttention(FleetLayer):
         layer_number: int,
         attn_mask_type: AttnMaskType,
         attention_type: str,
+        is_mtp_layer: bool = False,
+        is_swa: bool = False,
         attention_dropout: float | None = None,
         softmax_scale: float | None = None,
         k_channels: int | None = None,
         v_channels: int | None = None,
-        is_mtp_layer: bool = False,
-        is_swa: bool = False,
         num_attention_heads: int | None = None,
         num_key_value_heads: int | None = None,
         cp_comm_type: str = "p2p",
@@ -1143,7 +1273,6 @@ class CompressedSparseAttention(FleetLayer):
             dtype="float32",
             default_initializer=nn.initializer.Constant(0.0),
         )
-        self._cast_to_low_precision = False
 
         # Conditionally build Compressor (ratio > 1)
         if self.compress_ratio > 1:
@@ -1360,6 +1489,7 @@ class CompressedSparseAttention(FleetLayer):
         attention_mask: Tensor | None,
         x: Tensor = None,
         qr: Tensor = None,
+        attn_mask_startend_row_indices: Tensor | None = None,
     ) -> Tensor:
         """Forward pass for CompressedSparseAttention.
 
@@ -1398,7 +1528,9 @@ class CompressedSparseAttention(FleetLayer):
         offset = sq  # compressed indices start after original positions
 
         # Step 3: Window indices
-        window_idxs = get_window_topk_idxs(self.window_size, b, sq)
+        window_idxs = get_window_topk_idxs(
+            self.window_size, b, sq, attn_mask_startend_row_indices
+        )
 
         # Step 4: Compressed indices
         indexer_loss = None
@@ -1425,6 +1557,7 @@ class CompressedSparseAttention(FleetLayer):
                     b,
                     sq,
                     offset,
+                    attn_mask_startend_row_indices,
                 )
 
             if compress_topk_idxs.dtype != window_idxs.dtype:

--- a/src/paddlefleet/transformer/dsa_attention.py
+++ b/src/paddlefleet/transformer/dsa_attention.py
@@ -25,6 +25,7 @@ This module provides:
 from __future__ import annotations
 
 import logging
+import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -57,6 +58,57 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+def _dsv4_torch_dsa_grad_k(grad_scores: Tensor, q: Tensor) -> Tensor | None:
+    if os.environ.get("DSV4_FLEET_DSA_INDEXER_GRAD_K_TORCH_BWD", "0") != "1":
+        return None
+    site_packages = os.environ.get("DSV4_FLEET_TE_SITE_PACKAGES", "")
+    if site_packages and site_packages not in os.sys.path:
+        os.sys.path.insert(0, site_packages)
+    import torch
+    import torch.utils.dlpack
+
+    grad_scores_t = torch.utils.dlpack.from_dlpack(
+        paddle.utils.dlpack.to_dlpack(grad_scores)
+    )
+    q_t = torch.utils.dlpack.from_dlpack(paddle.utils.dlpack.to_dlpack(q))
+    grad_k_t = torch.einsum(
+        "sbht,sbhd->tbd", grad_scores_t, q_t.to(dtype=torch.float32)
+    ).to(dtype=q_t.dtype)
+    return paddle.utils.dlpack.from_dlpack(torch.utils.dlpack.to_dlpack(grad_k_t))
+
+
+def _dsv4_import_torch_for_hadamard():
+    site_packages = os.environ.get("DSV4_FLEET_TE_SITE_PACKAGES", "")
+    if site_packages and site_packages not in os.sys.path:
+        os.sys.path.insert(0, site_packages)
+    import torch
+    import torch.utils.dlpack
+    from fast_hadamard_transform import hadamard_transform as torch_hadamard_transform
+
+    return torch, torch_hadamard_transform
+
+
+class _DSV4TorchHadamard(paddle.autograd.PyLayer):
+    @staticmethod
+    def forward(ctx, x: Tensor, scale_tensor: Tensor):
+        scale = float(scale_tensor.item())
+        ctx.scale = scale
+        torch, torch_hadamard_transform = _dsv4_import_torch_for_hadamard()
+        x_t = torch.utils.dlpack.from_dlpack(
+            paddle.utils.dlpack.to_dlpack(x.contiguous())
+        )
+        y_t = torch_hadamard_transform(x_t, scale=scale)
+        return paddle.utils.dlpack.from_dlpack(torch.utils.dlpack.to_dlpack(y_t.contiguous()))
+
+    @staticmethod
+    def backward(ctx, grad_output: Tensor):
+        torch, torch_hadamard_transform = _dsv4_import_torch_for_hadamard()
+        grad_t = torch.utils.dlpack.from_dlpack(
+            paddle.utils.dlpack.to_dlpack(grad_output.contiguous())
+        )
+        grad_x_t = torch_hadamard_transform(grad_t, scale=ctx.scale)
+        return paddle.utils.dlpack.from_dlpack(torch.utils.dlpack.to_dlpack(grad_x_t.contiguous())), None
+
 
 def hadamard_transform(x: Tensor, scale: float = 1.0) -> Tensor:
     """Fast Walsh-Hadamard Transform using the butterfly algorithm.
@@ -85,6 +137,10 @@ def hadamard_transform(x: Tensor, scale: float = 1.0) -> Tensor:
     assert dim > 0 and (dim & (dim - 1)) == 0, (
         f"hadamard_transform requires dim to be a power of 2, got {dim}"
     )
+
+    if os.environ.get("DSV4_FLEET_HADAMARD_TORCH", "0") == "1":
+        scale_tensor = paddle.to_tensor([scale], dtype="float32")
+        return _DSV4TorchHadamard.apply(x, scale_tensor)
 
     # Megatron uses fast_hadamard_transform, whose bf16 path accumulates in fp32
     # and casts back to bf16. Keep the same numeric contract here.
@@ -903,9 +959,11 @@ def _bwd_fused_indexer_loss(
         "sbht,tbd->sbhd", grad_scores, k.cast("float32")
     )  # [sq, b, h, d]
     # ∂L/∂k = einsum('sbht,sbhd->tbd', grad_scores, q)
-    grad_k = paddle.einsum(
-        "sbht,sbhd->tbd", grad_scores, q.cast("float32")
-    )  # [sk, b, d]
+    grad_k = _dsv4_torch_dsa_grad_k(grad_scores, q)
+    if grad_k is None:
+        grad_k = paddle.einsum(
+            "sbht,sbhd->tbd", grad_scores, q.cast("float32")
+        )  # [sk, b, d]
     del grad_scores
 
     return (
@@ -1196,10 +1254,6 @@ class DSAttention(FleetLayer):
         softmax_scale: float,
         k_channels: int | None = None,
         v_channels: int | None = None,
-        is_mtp_layer: bool = False,
-        is_swa: bool = False,
-        num_attention_heads: int | None = None,
-        num_key_value_heads: int | None = None,
         cp_comm_type: str | None = None,
         pg_collection: ProcessGroupCollection | None = None,
     ):
@@ -1242,18 +1296,9 @@ class DSAttention(FleetLayer):
         attention_bias: Tensor | None = None,
         packed_seq_params: PackedSeqParams | None = None,
         use_rr_flash_attention: bool = False,
-        # KV cache parameters (ignored by DSAttention, for interface compatibility)
-        past_key_values=None,
-        layer_idx=None,
-        use_cache: bool = False,
         # DSA-specific parameters
         x: Tensor | None = None,
         qr: Tensor | None = None,
-        # ignore fastdeploy specific parameters
-        kv_compressed: paddle.Tensor = None,
-        k_pos_emb: paddle.Tensor = None,
-        q_absorbed: paddle.Tensor = None,
-        v_b_proj_weight: paddle.Tensor = None,
     ) -> Tensor:
         """Forward pass for Sparse Attention.
 

--- a/src/paddlefleet/transformer/dsv4_hybrid_attention.py
+++ b/src/paddlefleet/transformer/dsv4_hybrid_attention.py
@@ -25,6 +25,7 @@ Components:
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -42,6 +43,7 @@ from paddlefleet.models.common.embeddings.yarn_rotary_pos_embedding import (
     YarnRotaryEmbedding,
 )
 from paddlefleet.transformer.attention import Attention
+from paddlefleet.utils import dsv4_sequence_first_feature_enabled
 
 if TYPE_CHECKING:
     from paddlefleet.process_groups_config import ProcessGroupCollection
@@ -49,9 +51,104 @@ if TYPE_CHECKING:
     from paddlefleet.transformer.transformer_config import TransformerConfig
 
 
+class _DSV4TorchOGroupProjection(paddle.autograd.PyLayer):
+    @staticmethod
+    def forward(ctx, x: Tensor, weight: Tensor, o_local_groups: int, o_lora_rank: int):
+        import sys
+
+        site_packages = os.environ.get("DSV4_FLEET_TE_SITE_PACKAGES", "")
+        if site_packages and site_packages not in sys.path:
+            sys.path.insert(0, site_packages)
+
+        import torch
+        import torch.utils.dlpack
+        from paddle.utils import dlpack as paddle_dlpack
+
+        ctx.o_local_groups = o_local_groups
+        ctx.o_lora_rank = o_lora_rank
+        ctx.save_for_backward(x, weight)
+
+        x_seqfirst = x.detach().transpose([1, 0, 2, 3]).contiguous()
+        weight_grouped = weight.detach().reshape([o_local_groups, o_lora_rank, -1]).contiguous()
+        x_t = torch.utils.dlpack.from_dlpack(paddle_dlpack.to_dlpack(x_seqfirst)).detach()
+        weight_t = torch.utils.dlpack.from_dlpack(
+            paddle_dlpack.to_dlpack(weight_grouped)
+        ).detach()
+        out_t = torch.einsum("...gd,grd->...gr", x_t, weight_t)
+        out = paddle_dlpack.from_dlpack(torch.utils.dlpack.to_dlpack(out_t.contiguous()))
+        return out.transpose([1, 0, 2, 3]).contiguous()
+
+    @staticmethod
+    def backward(ctx, grad_output: Tensor):
+        import sys
+
+        site_packages = os.environ.get("DSV4_FLEET_TE_SITE_PACKAGES", "")
+        if site_packages and site_packages not in sys.path:
+            sys.path.insert(0, site_packages)
+
+        import torch
+        import torch.utils.dlpack
+        from paddle.utils import dlpack as paddle_dlpack
+
+        x, weight = ctx.saved_tensor()
+        x_seqfirst = x.detach().transpose([1, 0, 2, 3]).contiguous()
+        grad_seqfirst = grad_output.detach().transpose([1, 0, 2, 3]).contiguous()
+        weight_grouped = weight.detach().reshape(
+            [ctx.o_local_groups, ctx.o_lora_rank, -1]
+        ).contiguous()
+
+        x_t = torch.utils.dlpack.from_dlpack(paddle_dlpack.to_dlpack(x_seqfirst)).detach()
+        grad_t = torch.utils.dlpack.from_dlpack(
+            paddle_dlpack.to_dlpack(grad_seqfirst)
+        ).detach()
+        weight_t = torch.utils.dlpack.from_dlpack(
+            paddle_dlpack.to_dlpack(weight_grouped)
+        ).detach()
+
+        with torch.enable_grad():
+            x_t = x_t.requires_grad_(True)
+            weight_t = weight_t.requires_grad_(True)
+            out_t = torch.einsum("...gd,grd->...gr", x_t, weight_t)
+            out_t.backward(grad_t)
+            x_grad_t = x_t.grad.contiguous()
+            w_grad_t = weight_t.grad.reshape(tuple(weight.shape)).contiguous()
+
+        x_grad = paddle_dlpack.from_dlpack(torch.utils.dlpack.to_dlpack(x_grad_t))
+        x_grad = x_grad.transpose([1, 0, 2, 3]).contiguous()
+        w_grad = paddle_dlpack.from_dlpack(torch.utils.dlpack.to_dlpack(w_grad_t))
+        return x_grad, w_grad
+
+
+def _dsv4_torch_attn_o_group_projection(
+    x: Tensor,
+    weight: Tensor,
+    o_local_groups: int,
+    o_lora_rank: int,
+) -> Tensor:
+    return _DSV4TorchOGroupProjection.apply(x, weight, o_local_groups, o_lora_rank)
+
+
+class _DSV4QRMSNorm(paddle.autograd.PyLayer):
+    @staticmethod
+    def forward(ctx, q: Tensor, eps: float) -> Tensor:
+        r = paddle.rsqrt(q.square().mean(axis=-1, keepdim=True) + eps)
+        ctx.save_for_backward(q, r)
+        return q * r
+
+    @staticmethod
+    def backward(ctx, grad_output: Tensor):
+        q, r = ctx.saved_tensor()
+        hidden_size = q.shape[-1]
+        grad_r = (grad_output * q).sum(axis=-1, keepdim=True)
+        grad_q = grad_output * r
+        grad_add = grad_r * (-0.5) * (r * r * r)
+        grad_q = grad_q + (paddle.full_like(q, 2.0) * q) * (grad_add / hidden_size)
+        return grad_q
+
+
 def _q_rms_norm(q: Tensor, eps: float) -> Tensor:
     """RMS normalization for query (no learnable weight)."""
-    return q * paddle.rsqrt(q.square().mean(-1, keepdim=True) + eps)
+    return _DSV4QRMSNorm.apply(q, eps)
 
 
 # ---------------------------------------------------------------------------
@@ -159,8 +256,6 @@ class DSv4HybridAttention(Attention):
             softmax_scale=getattr(config, "softmax_scale", None),
             k_channels=self.q_head_dim,
             v_channels=self.v_head_dim,
-            num_attention_heads=self.num_attention_heads,
-            num_key_value_heads=1,
             cp_comm_type=cp_comm_type,
             pg_collection=self.pg_collection,
             compress_ratio=compress_ratio,
@@ -244,6 +339,9 @@ class DSv4HybridAttention(Attention):
             attention_mask,
             x=hidden_states,
             qr=q_compressed,
+            attn_mask_startend_row_indices=kwargs.get(
+                "attn_mask_startend_row_indices", None
+            ),
         )
         # core_attn_out: [b, sq, np * v_head_dim]
 
@@ -287,9 +385,23 @@ class DSv4HybridAttention(Attention):
         wo_a_weight = self.linear_o_group_proj.reshape(
             [self.o_local_groups, self.config.o_lora_rank, -1]
         )
-        core_attn_out = paddle.einsum(
-            "...gd,grd->...gr", core_attn_out, wo_a_weight
+        use_torch_o_group_projection = (
+            dsv4_sequence_first_feature_enabled(
+                "DSV4_FLEET_ATTN_O_GROUP_TORCH_BWD"
+            )
+            and b > 1
         )
+        if use_torch_o_group_projection:
+            core_attn_out = _dsv4_torch_attn_o_group_projection(
+                core_attn_out,
+                self.linear_o_group_proj,
+                self.o_local_groups,
+                self.config.o_lora_rank,
+            )
+        else:
+            core_attn_out = paddle.einsum(
+                "...gd,grd->...gr", core_attn_out, wo_a_weight
+            )
         core_attn_out = core_attn_out.reshape([b, sq, -1])
 
         # Output projection

--- a/src/paddlefleet/transformer/dsv4_hybrid_attention.py
+++ b/src/paddlefleet/transformer/dsv4_hybrid_attention.py
@@ -178,7 +178,7 @@ class DSv4HybridAttention(Attention):
     """DSv4 Hybrid Attention with CSA core attention, inverse RoPE, and grouped output.
 
     This class:
-    1. Builds per-layer RotaryEmbedding (with configurable base for compressed layers)
+    1. Builds RotaryEmbedding or YarnRotaryEmbedding from config.rope_type
     2. Builds CompressedSparseAttention as core attention
     3. Applies inverse RoPE on attention output
     4. Performs grouped low-rank output projection
@@ -220,19 +220,17 @@ class DSv4HybridAttention(Attention):
             compress_ratio = self.config.csa_compress_ratios[layer_idx]
         else:
             compress_ratio = self.config.csa_compress_ratios[layer_number]
-        # Per-layer RoPE (potentially different base for compressed layers)
         rope_base = getattr(config, "rotary_base", 10000)
         if compress_ratio > 1:
             rope_base = config.csa_compress_rotary_base
 
-        use_compressed_yarn = compress_ratio > 1
-        if not use_compressed_yarn:
+        if config.rope_type == "rope":
             self.rotary_pos_emb = RotaryEmbedding(
                 self.qk_pos_emb_head_dim,
                 rotary_percent=getattr(config, "rotary_percent", 1.0),
                 rotary_base=rope_base,
             )
-        else:
+        elif config.rope_type == "yarn":
             self.rotary_pos_emb = YarnRotaryEmbedding(
                 self.qk_pos_emb_head_dim,
                 rotary_base=rope_base,
@@ -244,6 +242,11 @@ class DSv4HybridAttention(Attention):
                 beta_slow=getattr(config, "beta_slow", 1),
                 mscale=getattr(config, "mscale", 1.0),
                 mscale_all_dim=getattr(config, "mscale_all_dim", 0.0),
+            )
+        else:
+            raise ValueError(
+                f"Unsupported RoPE type: {config.rope_type}, supported types are "
+                "'rope' and 'yarn'"
             )
 
         self.core_attention = build_spec_layer(

--- a/src/paddlefleet/transformer/hyper_connection.py
+++ b/src/paddlefleet/transformer/hyper_connection.py
@@ -31,24 +31,534 @@ import paddle
 import paddle.nn.functional as F
 from paddle import Tensor, nn
 
-from paddlefleet.tensor_parallel.random import get_cuda_rng_tracker
 from paddlefleet.transformer.layer import FleetLayer
+from paddlefleet.utils import dsv4_sequence_first_feature_enabled
 
 if TYPE_CHECKING:
     from paddlefleet.transformer.transformer_config import TransformerConfig
 
 
-_ACCURACY_COMPATIBLE_KERNEL: bool = (
-    os.environ.get("FLAGS_use_accuracy_compatible_kernel", "0") == "1"
-)
+def _dsv4_hc_mapping_seqfirst_wgrad_enabled() -> bool:
+    return dsv4_sequence_first_feature_enabled(
+        "DSV4_FLEET_HC_MAPPING_SEQFIRST_WGRAD"
+    )
 
 
-def _use_accuracy_compatible_kernel() -> bool:
-    """Switch for Megatron-aligned (accuracy-compatible) numeric paths.
+def _dsv4_accumulate_hc_mapping_seqfirst_wgrad(weight: Tensor, w_grad: Tensor) -> None:
+    if not _dsv4_hc_mapping_seqfirst_wgrad_enabled() or w_grad is None:
+        return
+    w_grad = w_grad.detach().cast(paddle.float32)
+    prev = getattr(weight, "_dsv4_hc_mapping_seqfirst_wgrad", None)
+    if prev is None:
+        weight._dsv4_hc_mapping_seqfirst_wgrad = w_grad
+    else:
+        weight._dsv4_hc_mapping_seqfirst_wgrad = prev + w_grad
 
-    Controlled by the ``FLAGS_use_accuracy_compatible_kernel`` env variable.
-    """
-    return _ACCURACY_COMPATIBLE_KERNEL
+
+def _dsv4_hc_mapping_torch_wgrad(
+    x_seqfirst: Tensor,
+    grad_seqfirst: Tensor,
+    weight: Tensor,
+) -> Tensor:
+    torch_site_packages = os.environ.get("DSV4_FLEET_TE_SITE_PACKAGES", "")
+    if torch_site_packages:
+        import sys
+
+        if torch_site_packages not in sys.path:
+            sys.path.insert(0, torch_site_packages)
+    import torch
+    import torch.utils.dlpack
+    from paddle.utils import dlpack as paddle_dlpack
+
+    def to_torch(tensor: Tensor):
+        return torch.utils.dlpack.from_dlpack(
+            paddle_dlpack.to_dlpack(tensor.contiguous())
+        )
+
+    def to_paddle(tensor):
+        return paddle_dlpack.from_dlpack(
+            torch.utils.dlpack.to_dlpack(tensor.detach().contiguous())
+        )
+
+    x_t = to_torch(x_seqfirst).detach().requires_grad_(True)
+    grad_t = to_torch(grad_seqfirst).detach()
+    weight_oi_t = to_torch(weight.t()).detach().requires_grad_(True)
+    with torch.enable_grad():
+        proj_t = torch.matmul(x_t, weight_oi_t.t())
+        proj_t.backward(grad_t)
+    return to_paddle(weight_oi_t.grad.t())
+
+
+def _dsv4_torch_contract_forward(
+    hidden_states: Tensor,
+    head_fn_out_in: Tensor,
+    base: Tensor,
+    scale: Tensor,
+    n: int,
+    eps: float,
+    out_dtype,
+):
+    torch_site_packages = os.environ.get("DSV4_FLEET_TE_SITE_PACKAGES", "")
+    if torch_site_packages:
+        import sys
+
+        if torch_site_packages not in sys.path:
+            sys.path.insert(0, torch_site_packages)
+    import torch
+    import torch.nn.functional as torch_F
+    import torch.utils.dlpack
+    from paddle.utils import dlpack as paddle_dlpack
+
+    def to_torch(tensor: Tensor):
+        return torch.utils.dlpack.from_dlpack(
+            paddle_dlpack.to_dlpack(tensor.contiguous())
+        )
+
+    def to_paddle(tensor):
+        return paddle_dlpack.from_dlpack(
+            torch.utils.dlpack.to_dlpack(tensor.contiguous())
+        )
+
+    hidden_t = to_torch(hidden_states)
+    head_t = to_torch(head_fn_out_in)
+    base_t = to_torch(base)
+    scale_t = to_torch(scale)
+    torch_dtype = torch.bfloat16 if str(out_dtype) == "paddle.bfloat16" else hidden_t.dtype
+    with torch.no_grad():
+        rsqrt_t = torch.rsqrt(hidden_t.square().mean(-1, keepdim=True) + eps)
+        proj_t = torch_F.linear(hidden_t, head_t)
+        mixes_t = proj_t * rsqrt_t
+        pre_arg_t = mixes_t * scale_t + base_t
+        sig_t = torch.sigmoid(pre_arg_t)
+        pre_t = sig_t + eps
+        y_t = torch.sum(
+            pre_t.unsqueeze(-1) * hidden_t.reshape(*hidden_t.shape[:-1], n, -1),
+            dim=-2,
+        )
+        out_t = y_t.to(torch_dtype)
+    return (
+        to_paddle(out_t),
+        to_paddle(rsqrt_t),
+        to_paddle(proj_t),
+        to_paddle(mixes_t),
+        to_paddle(sig_t),
+        to_paddle(pre_t),
+    )
+
+
+def _dsv4_torch_contract_backward(
+    hidden_input: Tensor,
+    head_fn_input: Tensor,
+    base_input: Tensor,
+    scale_input: Tensor,
+    grad_output: Tensor,
+    n: int,
+    eps: float,
+):
+    if os.environ.get("DSV4_FLEET_CONTRACT_TORCH_BWD", "0") != "1":
+        return None
+
+    torch_site_packages = os.environ.get("DSV4_FLEET_TE_SITE_PACKAGES", "")
+    if torch_site_packages:
+        import sys
+
+        if torch_site_packages not in sys.path:
+            sys.path.insert(0, torch_site_packages)
+    import torch
+    import torch.nn.functional as torch_F
+    import torch.utils.dlpack
+    from paddle.utils import dlpack as paddle_dlpack
+
+    def to_torch(tensor: Tensor):
+        return torch.utils.dlpack.from_dlpack(
+            paddle_dlpack.to_dlpack(tensor.contiguous())
+        )
+
+    def to_paddle(tensor):
+        return paddle_dlpack.from_dlpack(
+            torch.utils.dlpack.to_dlpack(tensor.detach().contiguous())
+        )
+
+    hidden_input_t = to_torch(hidden_input).detach().requires_grad_(True)
+    head_input_t = to_torch(head_fn_input).detach().requires_grad_(True)
+    base_input_t = to_torch(base_input).detach().requires_grad_(True)
+    scale_input_t = to_torch(scale_input).detach().requires_grad_(True)
+    grad_t = to_torch(grad_output).detach()
+
+    with torch.enable_grad():
+        hidden_t = hidden_input_t.to(torch.float32)
+        head_io_t = head_input_t.to(torch.float32)
+        base_t = base_input_t.to(torch.float32)
+        scale_t = scale_input_t.to(torch.float32)
+        hidden_t.retain_grad()
+        head_oi_t = head_io_t.transpose(0, 1).contiguous()
+        rsqrt_t = torch.rsqrt(hidden_t.square().mean(-1, keepdim=True) + eps)
+        mixes_t = torch_F.linear(hidden_t, head_oi_t) * rsqrt_t
+        pre_t = torch.sigmoid(mixes_t * scale_t + base_t) + eps
+        y_t = torch.sum(
+            pre_t.unsqueeze(-1) * hidden_t.reshape(*hidden_t.shape[:-1], n, -1),
+            dim=-2,
+        )
+        out_t = y_t.to(hidden_input_t.dtype)
+        out_t.backward(grad_t)
+
+    head_grad_t = head_input_t.grad
+    if (
+        dsv4_sequence_first_feature_enabled(
+            "DSV4_FLEET_CONTRACT_HEAD_SEQFIRST_WGRAD"
+        )
+        and hidden_input_t.ndim == 3
+        and hidden_input_t.shape[0] > 1
+    ):
+        hidden_seq_input_t = (
+            hidden_input_t.detach()
+            .transpose(0, 1)
+            .contiguous()
+            .requires_grad_(True)
+        )
+        grad_seq_t = grad_t.transpose(0, 1).contiguous()
+        head_seq_t = head_input_t.detach().requires_grad_(True)
+        base_seq_t = base_input_t.detach()
+        scale_seq_t = scale_input_t.detach()
+        with torch.enable_grad():
+            hidden_seq_t = hidden_seq_input_t.to(torch.float32)
+            head_seq_oi_t = (
+                head_seq_t.to(torch.float32).transpose(0, 1).contiguous()
+            )
+            base_seq_f32_t = base_seq_t.to(torch.float32)
+            scale_seq_f32_t = scale_seq_t.to(torch.float32)
+            rsqrt_seq_t = torch.rsqrt(
+                hidden_seq_t.square().mean(-1, keepdim=True) + eps
+            )
+            mixes_seq_t = torch_F.linear(hidden_seq_t, head_seq_oi_t) * rsqrt_seq_t
+            pre_seq_t = torch.sigmoid(mixes_seq_t * scale_seq_f32_t + base_seq_f32_t) + eps
+            y_seq_t = torch.sum(
+                pre_seq_t.unsqueeze(-1)
+                * hidden_seq_t.reshape(*hidden_seq_t.shape[:-1], n, -1),
+                dim=-2,
+            )
+            out_seq_t = y_seq_t.to(hidden_seq_input_t.dtype)
+            out_seq_t.backward(grad_seq_t)
+        head_grad_t = head_seq_t.grad
+
+    return (
+        to_paddle(hidden_t.grad),
+        to_paddle(hidden_input_t.grad),
+        to_paddle(head_grad_t),
+        to_paddle(base_input_t.grad),
+        to_paddle(scale_input_t.grad),
+    )
+
+
+def _dsv4_torch_contract_head_seqfirst_wgrad(
+    hidden_fp32: Tensor, grad_proj: Tensor, head_fn_input: Tensor
+):
+    if not dsv4_sequence_first_feature_enabled(
+        "DSV4_FLEET_CONTRACT_HEAD_SEQFIRST_WGRAD"
+    ):
+        return None
+    if hidden_fp32.ndim != 3 or grad_proj.ndim != 3 or hidden_fp32.shape[0] <= 1:
+        return None
+
+    torch_site_packages = os.environ.get("DSV4_FLEET_TE_SITE_PACKAGES", "")
+    if torch_site_packages:
+        import sys
+
+        if torch_site_packages not in sys.path:
+            sys.path.insert(0, torch_site_packages)
+    import torch
+    import torch.nn.functional as torch_F
+    import torch.utils.dlpack
+    from paddle.utils import dlpack as paddle_dlpack
+
+    def to_torch(tensor: Tensor):
+        return torch.utils.dlpack.from_dlpack(
+            paddle_dlpack.to_dlpack(tensor.contiguous())
+        )
+
+    def to_paddle(tensor):
+        return paddle_dlpack.from_dlpack(
+            torch.utils.dlpack.to_dlpack(tensor.detach().contiguous())
+        )
+
+    batch, seq, hidden = hidden_fp32.shape
+    out_features = grad_proj.shape[-1]
+    hidden_seqfirst = (
+        hidden_fp32.detach()
+        .reshape([batch, seq, hidden])
+        .transpose([1, 0, 2])
+        .reshape([batch * seq, hidden])
+        .contiguous()
+    )
+    grad_seqfirst = (
+        grad_proj.detach()
+        .reshape([batch, seq, out_features])
+        .transpose([1, 0, 2])
+        .reshape([batch * seq, out_features])
+        .contiguous()
+    )
+
+    hidden_t = to_torch(hidden_seqfirst).detach()
+    grad_t = to_torch(grad_seqfirst).detach()
+    head_t = to_torch(head_fn_input).detach().requires_grad_(True)
+    with torch.enable_grad():
+        head_oi_t = head_t.to(torch.float32).transpose(0, 1).contiguous()
+        out_t = torch_F.linear(hidden_t, head_oi_t)
+        out_t.backward(grad_t)
+
+    return to_paddle(head_t.grad)
+
+
+def _dsv4_hc_sinkhorn_torch_backward(
+    logits: Tensor, grad_output: Tensor, num_iterations: int, eps: float
+) -> Tensor:
+    if os.environ.get("DSV4_FLEET_HC_SINKHORN_TORCH_BWD", "0") != "1":
+        return None
+    torch_site_packages = os.environ.get("DSV4_FLEET_TE_SITE_PACKAGES", "")
+    if torch_site_packages:
+        import sys
+
+        if torch_site_packages not in sys.path:
+            sys.path.insert(0, torch_site_packages)
+    import torch
+    import torch.utils.dlpack
+    from paddle.utils import dlpack as paddle_dlpack
+
+    logits_t = torch.utils.dlpack.from_dlpack(
+        paddle_dlpack.to_dlpack(logits.contiguous())
+    ).to(torch.bfloat16)
+    grad_t = torch.utils.dlpack.from_dlpack(
+        paddle_dlpack.to_dlpack(grad_output.contiguous())
+    ).to(torch.bfloat16)
+    # Match Megatron's training graph: Sinkhorn receives a transposed-view grad
+    # from H_res.T @ residual, so the last two dimensions have stride (1, n).
+    grad_t = grad_t.transpose(-1, -2).contiguous().transpose(-1, -2)
+
+    with torch.enable_grad():
+        logits_t = logits_t.detach().requires_grad_(True)
+        row_max = logits_t.max(dim=-1, keepdim=True).values
+        m = torch.exp(logits_t - row_max)
+        for _ in range(num_iterations):
+            m = m / m.sum(dim=-1, keepdim=True).clamp(min=eps)
+            m = m / m.sum(dim=-2, keepdim=True).clamp(min=eps)
+        m.backward(grad_t)
+    grad_input_t = logits_t.grad.contiguous()
+    return paddle_dlpack.from_dlpack(torch.utils.dlpack.to_dlpack(grad_input_t))
+
+
+class _DSV4HCTorchOrderRmsScale(paddle.autograd.PyLayer):
+    @staticmethod
+    def forward(ctx, x: Tensor, eps: float):
+        nC = x.shape[-1]
+        norm = x.norm(axis=-1, keepdim=True)
+        r = 1.0 / (norm / math.sqrt(nC) + eps)
+        r = r.astype(x.dtype)
+        ctx.nC = nC
+        ctx.eps = eps
+        ctx.save_for_backward(x, norm, r)
+        return r
+
+    @staticmethod
+    def backward(ctx, grad: Tensor):
+        x, norm, r = ctx.saved_tensor()
+        grad = grad.astype(x.dtype)
+        if os.environ.get("DSV4_FLEET_HC_RMS_TORCH_BWD", "0") == "1":
+            torch_site_packages = os.environ.get("DSV4_FLEET_TE_SITE_PACKAGES", "")
+            if torch_site_packages:
+                import sys
+
+                if torch_site_packages not in sys.path:
+                    sys.path.insert(0, torch_site_packages)
+            import torch
+            import torch.utils.dlpack
+            from paddle.utils import dlpack as paddle_dlpack
+
+            def to_torch(tensor: Tensor):
+                return torch.utils.dlpack.from_dlpack(
+                    paddle_dlpack.to_dlpack(tensor.contiguous())
+                )
+
+            def to_paddle(tensor):
+                return paddle_dlpack.from_dlpack(
+                    torch.utils.dlpack.to_dlpack(tensor.detach().contiguous())
+                )
+
+            x_t = to_torch(x).detach().requires_grad_(True)
+            grad_t = to_torch(grad).detach()
+            with torch.enable_grad():
+                norm_t = x_t.norm(dim=-1, keepdim=True)
+                r_t = 1.0 / (norm_t / math.sqrt(ctx.nC) + ctx.eps)
+                r_t.backward(grad_t)
+            grad_x = to_paddle(x_t.grad).astype(x.dtype)
+            return grad_x
+        # Match Torch norm + reciprocal backward source-order in BF16.
+        scaled = grad * (r * r)
+        scaled = scaled / math.sqrt(ctx.nC)
+        unit = x / norm
+        grad_x = (-scaled) * unit
+        # PyTorch preserves signed zeros in this path. Paddle's multiply tends
+        # to canonicalize the grad==0 row to +0, which is numerically equal but
+        # breaks bitwise grad checks.
+        zero = paddle.zeros_like(unit)
+        torch_zero = paddle.where(x == 0, -paddle.ones_like(unit) * zero, (-unit) * zero)
+        grad_x = paddle.where(scaled == 0, torch_zero, grad_x)
+        grad_x = grad_x.astype(x.dtype)
+        return grad_x
+
+
+class _DSV4LearnedOutputContract(paddle.autograd.PyLayer):
+    @staticmethod
+    def forward(ctx, hidden_states: Tensor, head_fn: Tensor, base: Tensor, scale: Tensor, n: int, eps: float):
+        dtype = hidden_states.dtype
+        hidden_fp32 = hidden_states.astype("float32")
+        head_fn_fp32 = head_fn.astype("float32")
+        base_fp32 = base.astype("float32")
+        scale_fp32 = scale.astype("float32")
+
+        rsqrt = paddle.rsqrt(hidden_fp32.square().mean(-1, keepdim=True) + eps)
+        head_fn_out_in = head_fn_fp32.transpose([1, 0]).contiguous()
+        if os.environ.get("DSV4_FLEET_CONTRACT_TORCH_FORWARD", "0") == "1":
+            out, rsqrt, proj, mixes, sig, pre = _dsv4_torch_contract_forward(
+                hidden_fp32,
+                head_fn_out_in,
+                base_fp32,
+                scale_fp32,
+                n,
+                eps,
+                dtype,
+            )
+        else:
+            with paddle.amp.auto_cast(False):
+                proj = paddle.matmul(hidden_fp32, head_fn_out_in, transpose_y=True)
+            mixes = proj * rsqrt
+            pre_arg = mixes * scale_fp32 + base_fp32
+            sig = F.sigmoid(pre_arg)
+            pre = sig + eps
+            hidden_streams = hidden_fp32.reshape([*hidden_fp32.shape[:-1], n, -1])
+            y = paddle.sum(pre.unsqueeze(-1) * hidden_streams, axis=-2)
+            out = y.astype(dtype)
+
+        ctx.save_for_backward(
+            hidden_states,
+            head_fn,
+            base,
+            scale,
+            hidden_fp32,
+            head_fn_fp32,
+            base_fp32,
+            scale_fp32,
+            rsqrt,
+            proj,
+            mixes,
+            sig,
+            pre,
+        )
+        ctx.n = n
+        ctx.eps = eps
+        ctx.hidden_dtype = dtype
+        ctx.head_fn_dtype = head_fn.dtype
+        ctx.base_dtype = base.dtype
+        ctx.scale_dtype = scale.dtype
+        return out
+
+    @staticmethod
+    def backward(ctx, grad_output: Tensor):
+        (
+            hidden_input,
+            head_fn_input,
+            base_input,
+            scale_input,
+            hidden_fp32,
+            head_fn_fp32,
+            base_fp32,
+            scale_fp32,
+            rsqrt,
+            proj,
+            mixes,
+            sig,
+            pre,
+        ) = ctx.saved_tensor()
+        n = ctx.n
+        hdim = hidden_fp32.shape[-1]
+        hidden_streams = hidden_fp32.reshape([*hidden_fp32.shape[:-1], n, -1])
+        grad_y = grad_output.astype("float32")
+        torch_grads = _dsv4_torch_contract_backward(
+            hidden_input,
+            head_fn_input,
+            base_input,
+            scale_input,
+            grad_output,
+            n,
+            ctx.eps,
+        )
+        if torch_grads is not None:
+            grad_hidden, grad_hidden_out, grad_head_fn_out, grad_base_out, grad_scale_out = torch_grads
+
+            return (
+                grad_hidden_out,
+                grad_head_fn_out,
+                grad_base_out,
+                grad_scale_out,
+            )
+
+        grad_prod = paddle.expand(
+            grad_y.unsqueeze(-2),
+            [*hidden_streams.shape],
+        )
+        grad_hidden_streams = grad_prod * pre.unsqueeze(-1)
+        grad_hidden_direct = grad_hidden_streams.reshape(hidden_fp32.shape)
+
+        grad_pre = paddle.sum(grad_prod * hidden_streams, axis=-1)
+        grad_pre_arg = grad_pre * sig * (1.0 - sig)
+        grad_mixes = grad_pre_arg * scale_fp32
+        grad_scale = paddle.sum(grad_pre_arg * mixes).reshape(scale_fp32.shape)
+        grad_base = paddle.sum(
+            grad_pre_arg.reshape([-1, grad_pre_arg.shape[-1]]),
+            axis=0,
+        ).reshape(base_fp32.shape)
+
+        grad_proj = grad_mixes * rsqrt
+        grad_rsqrt = paddle.sum(grad_mixes * proj, axis=-1, keepdim=True)
+
+        hidden_2d = hidden_fp32.reshape([-1, hdim])
+        grad_proj_2d = grad_proj.reshape([-1, grad_proj.shape[-1]])
+        grad_head_fn = paddle.matmul(hidden_2d, grad_proj_2d, transpose_x=True)
+        seqfirst_grad_head_fn = _dsv4_torch_contract_head_seqfirst_wgrad(
+            hidden_fp32,
+            grad_proj,
+            head_fn_input,
+        )
+        if seqfirst_grad_head_fn is not None:
+            grad_head_fn = seqfirst_grad_head_fn
+        grad_hidden_proj = paddle.matmul(grad_proj, head_fn_fp32, transpose_y=True)
+
+        grad_mean = grad_rsqrt * (-0.5) * rsqrt * rsqrt * rsqrt
+        grad_hidden_rsqrt = hidden_fp32 * grad_mean * (2.0 / float(hdim))
+
+        # Match PyTorch autograd's observed accumulation order for this graph:
+        # direct view branch, projection branch, then rsqrt/mean branch.
+        grad_hidden = (grad_hidden_direct + grad_hidden_proj) + grad_hidden_rsqrt
+        grad_hidden_out = grad_hidden.astype(ctx.hidden_dtype)
+        grad_head_fn_out = grad_head_fn.astype(ctx.head_fn_dtype)
+        grad_base_out = grad_base.astype(ctx.base_dtype)
+        grad_scale_out = grad_scale.astype(ctx.scale_dtype)
+
+        return (
+            grad_hidden_out,
+            grad_head_fn_out,
+            grad_base_out,
+            grad_scale_out,
+        )
+
+
+class _DSV4ContractBranchSplit(paddle.autograd.PyLayer):
+    @staticmethod
+    def forward(ctx, hidden_states: Tensor):
+        return hidden_states.clone(), hidden_states.clone(), hidden_states.clone()
+
+    @staticmethod
+    def backward(ctx, grad_rsqrt: Tensor, grad_proj: Tensor, grad_direct: Tensor):
+        return (grad_direct + grad_proj) + grad_rsqrt
 
 
 class SinkhornKnopp(paddle.autograd.PyLayer):
@@ -61,65 +571,70 @@ class SinkhornKnopp(paddle.autograd.PyLayer):
     Reference: Eq. (9) in mHC paper - M^{(t)} = T_c(T_r(M^{(t-1)}))
     """
 
+    eps = 1e-6
+
+    class _ExpRowMax(paddle.autograd.PyLayer):
+        @staticmethod
+        def forward(ctx, logits: Tensor) -> Tensor:
+            row_max = logits.max(axis=-1, keepdim=True)
+            out = paddle.exp(logits - row_max)
+            row_argmax = logits.argmax(axis=-1, keepdim=True)
+            ctx.save_for_backward(out, row_argmax)
+            return out
+
+        @staticmethod
+        def backward(ctx, grad_output: Tensor) -> tuple[Tensor]:
+            out, row_argmax = ctx.saved_tensor()
+            grad_z = grad_output * out
+            grad_row_max = grad_z.sum(axis=-1, keepdim=True)
+            row_argmax_mask = F.one_hot(
+                row_argmax.squeeze(-1), num_classes=out.shape[-1]
+            ).astype(out.dtype)
+            return grad_z - row_argmax_mask * grad_row_max
+
     @staticmethod
-    def _sinkhorn_normalize(
-        M: Tensor, num_iterations: int, eps: float = 1e-6
-    ) -> Tensor:
+    def _sinkhorn_normalize(M: Tensor, num_iterations: int) -> Tensor:
         """
         Apply Sinkhorn-Knopp normalization iterations.
 
         Args:
             M: [..., n, n] - positive matrix to normalize
             num_iterations: Number of Sinkhorn iterations
-            eps: Small constant for numerical stability
 
         Returns:
             M: [..., n, n] - doubly stochastic matrix
         """
         for _ in range(num_iterations):
             # T_r: Row normalization
-            M = M / M.sum(axis=-1, keepdim=True).clip(min=eps)
+            M = M / M.sum(axis=-1, keepdim=True).clip(min=SinkhornKnopp.eps)
             # T_c: Column normalization
-            M = M / M.sum(axis=-2, keepdim=True).clip(min=eps)
+            M = M / M.sum(axis=-2, keepdim=True).clip(min=SinkhornKnopp.eps)
         return M
 
     @staticmethod
-    def forward(
-        ctx, H_res_logits: Tensor, num_iterations: int, eps: float = 1e-6
-    ) -> Tensor:
+    def forward(ctx, H_res_logits: Tensor, num_iterations: int) -> Tensor:
         """
         Project to doubly stochastic matrix via iterative row/col normalization.
 
         Args:
             H_res_logits: [..., n, n] - raw logits for residual mixing matrix
             num_iterations: Number of Sinkhorn iterations (paper uses 20)
-            eps: Small constant for numerical stability
 
         Returns:
             H_res: [..., n, n] - doubly stochastic matrix
         """
-        # Stabilized exp: subtract row-wise max to prevent overflow.
-        # Under FLAGS_use_accuracy_compatible_kernel, force this outside AMP
-        # so the Paddle native path preserves the BF16 contract used by
-        # Megatron's torch implementation.
-        if _use_accuracy_compatible_kernel():
-            with paddle.amp.auto_cast(enable=False):
-                M_init = paddle.exp(
-                    H_res_logits - H_res_logits.max(axis=-1, keepdim=True)
-                )
-                M = SinkhornKnopp._sinkhorn_normalize(
-                    M_init, num_iterations, eps
-                )
-        else:
-            M_init = paddle.exp(
-                H_res_logits - H_res_logits.max(axis=-1, keepdim=True)
-            )
-            M = SinkhornKnopp._sinkhorn_normalize(M_init, num_iterations, eps)
+        with paddle.amp.auto_cast(enable=False):
+            # Stabilized exp: subtract row-wise max to prevent overflow.
+            # Keep this outside AMP so the Paddle native path preserves the
+            # BF16 contract used by Megatron's torch implementation.
+            M_init = SinkhornKnopp._ExpRowMax.apply(H_res_logits)
 
-        # Save initial M for backward recomputation
-        ctx.save_for_backward(M_init)
+            M = SinkhornKnopp._sinkhorn_normalize(M_init, num_iterations)
+
+        # Save logits instead of M_init so backward recomputes the same graph
+        # as Megatron: exp(logits - row_max) followed by Sinkhorn iterations.
+        ctx.save_for_backward(H_res_logits)
         ctx.num_iterations = num_iterations
-        ctx.eps = eps
         return M
 
     @staticmethod
@@ -127,92 +642,29 @@ class SinkhornKnopp(paddle.autograd.PyLayer):
         """
         Backward through Sinkhorn-Knopp iterations using recomputation.
         """
-        (M_init,) = ctx.saved_tensor()
+        (H_res_logits,) = ctx.saved_tensor()
         num_iterations = ctx.num_iterations
-        eps = ctx.eps
+        torch_grad_input = _dsv4_hc_sinkhorn_torch_backward(
+            H_res_logits, grad_output, num_iterations, SinkhornKnopp.eps
+        )
+        if torch_grad_input is not None:
+            return torch_grad_input
 
         with paddle.enable_grad():
-            # Recompute forward with autograd enabled
-            M_input = M_init.detach()
-            M_input.stop_gradient = False
+            logits = H_res_logits.detach()
+            logits.stop_gradient = False
+            with paddle.amp.auto_cast(enable=False):
+                M_current = SinkhornKnopp._ExpRowMax.apply(logits)
+                M_current = SinkhornKnopp._sinkhorn_normalize(M_current, num_iterations)
 
-            M_current = SinkhornKnopp._sinkhorn_normalize(
-                M_input, num_iterations, eps
-            )
-
-            # Compute dL/dM_input via autograd
-            grad_M_init = paddle.grad(
+            grad_input = paddle.grad(
                 outputs=[M_current],
-                inputs=[M_input],
+                inputs=[logits],
                 grad_outputs=[grad_output],
                 create_graph=False,
             )[0]
 
-        # Apply chain rule: dL/dH = dL/dM_init * dM_init/dH = dL/dM_init * M_init
-        # Since M_init = exp(H_res_logits), d(exp(x))/dx = exp(x) = M_init
-        grad_input = grad_M_init * M_init
-
         return grad_input
-
-
-def native_sinkhorn(
-    input_logits: Tensor, num_iterations: int, eps: float = 1e-6
-) -> Tensor:
-    """Native Sinkhorn-Knopp (PyLayer wrapper)."""
-    return SinkhornKnopp.apply(input_logits, num_iterations, eps)
-
-
-def native_proj_rms(
-    x: Tensor, weight: Tensor, eps: float = 1e-6
-) -> tuple[Tensor, Tensor]:
-    """Native fused projection + RMS normalization."""
-    nC = x.shape[-1]
-    r = x.norm(axis=-1, keepdim=True) / math.sqrt(nC)
-    r = 1.0 / (r + eps)
-    proj = paddle.matmul(x, weight)
-    return proj, r
-
-
-def native_h_aggregate(x_streams: Tensor, h_pre: Tensor) -> Tensor:
-    """Native n-stream weighted aggregation: out = sum_j(h_pre_j * x_j)."""
-    return (x_streams * h_pre.unsqueeze(-1)).sum(axis=-2)
-
-
-def native_h_post_bda(
-    h_res: Tensor,
-    original_residual: Tensor,
-    h_post: Tensor,
-    x: Tensor,
-    bias: Tensor | None,
-) -> Tensor:
-    """Native H_res @ residual + H_post * (x [+ bias]).
-
-    Args:
-        h_res: [..., n, n] - residual mixing matrix
-        original_residual: [..., n, C] - n-stream hidden states
-        h_post: [..., n] - expansion weights
-        x: [..., C] - layer output
-        bias: [C] or None
-
-    Returns:
-        output: [..., n, C]
-    """
-    leading_shape = original_residual.shape[:-2]
-    n, C = original_residual.shape[-2], original_residual.shape[-1]
-    num_tokens = math.prod(leading_shape)
-
-    h_res_batched = h_res.reshape([num_tokens, n, n])
-    residual_batched = original_residual.reshape([num_tokens, n, C])
-    mixed = paddle.bmm(h_res_batched, residual_batched).reshape(
-        [*leading_shape, n, C]
-    )
-
-    x_expanded = h_post.unsqueeze(-1) * x.unsqueeze(-2)  # [..., n, C]
-    if bias is not None:
-        bias = bias.reshape([1] * len(leading_shape) + [1, C])
-        bias_expanded = h_post.unsqueeze(-1) * bias
-        return x_expanded + bias_expanded + mixed
-    return x_expanded + mixed
 
 
 class HyperConnectionModule(nn.Layer):
@@ -279,40 +731,12 @@ class HyperConnectionModule(nn.Layer):
 
         self.norm_eps = 1e-6
 
-        # Choose implementation: fused kernels vs native reference.
-        if config.use_fused_mhc:
-            from paddlefleet.fusions.fused_mhc_kernels import (
-                fused_h_aggregate,
-                fused_h_post_bda,
-                fused_proj_rms,
-                fused_sinkhorn,
-            )
-
-            self._sinkhorn_op = fused_sinkhorn
-            self._h_aggregate_op = fused_h_aggregate
-            self._h_post_bda_op = fused_h_post_bda
-            self._proj_rms_op = fused_proj_rms
-        else:
-            self._sinkhorn_op = native_sinkhorn
-            self._h_aggregate_op = native_h_aggregate
-            self._h_post_bda_op = native_h_post_bda
-            self._proj_rms_op = native_proj_rms
-
         self._init_weights()
 
     def _init_weights(self) -> None:
         """Initialize weights for stable training."""
-        # Xavier uniform for mapping projection.
-        # Use the model-parallel RNG tracker so that the initialization is
-        # controlled by PaddleFleet's RNG state (seeded once at model init)
-        # rather than the per-layer pipeline seed (base_seed + layer_index).
-        # This prevents layer_index shifts (e.g. from MTPEmbeddingLayer insertion
-        # in magic_send mode) from changing the weights.
-        if paddle.distributed.get_world_size() <= 1:
-            nn.initializer.XavierUniform()(self.mapping_proj.weight)
-        else:
-            with get_cuda_rng_tracker().fork():
-                nn.initializer.XavierUniform()(self.mapping_proj.weight)
+        # Xavier uniform for mapping projection
+        nn.initializer.XavierUniform()(self.mapping_proj.weight)
 
         # Set sequence_parallel attribute on parameters for gradient synchronization
         if self.config.sequence_parallel:
@@ -329,27 +753,47 @@ class HyperConnectionModule(nn.Layer):
         Args:
             x: [..., n*C] - n-stream hidden states
         """
-        if _use_accuracy_compatible_kernel():
-            nC = x.shape[-1]
-            weight = self.mapping_proj.weight
-            r = x.norm(axis=-1, keepdim=True) / math.sqrt(nC)  # [..., 1]
-            r = (1.0 / (r + self.norm_eps)).astype(x.dtype)  # [..., 1]
-            # Match Megatron clean path: torch.matmul(x, weight.t()). Paddle
-            # nn.Linear uses a different BF16 cuBLAS path for this shape and
-            # drifts before the first HC BDA.
-            x_2d = x.reshape([-1, nC])
-            weight_out_in = weight.t().contiguous()
-            proj_2d = paddle.matmul(x_2d, weight_out_in, transpose_y=True)
-            proj = proj_2d.reshape([*x.shape[:-1], weight.shape[-1]])
-        else:
-            ori_dtype = x.dtype
-            proj, r = self._proj_rms_op(
-                x, self.mapping_proj.weight.astype(ori_dtype), self.norm_eps
-            )
-            if not self.config.high_precision_mhc:
-                r = r.astype(ori_dtype)
+        nC = x.shape[-1]
+        weight = self.mapping_proj.weight
+        x_2d = x.reshape([-1, nC])
+        r = _DSV4HCTorchOrderRmsScale.apply(x_2d, self.norm_eps)
+        # Match Megatron clean path: torch.matmul(x, weight.t()).  Paddle
+        # nn.Linear uses a different BF16 cuBLAS path for this shape and drifts
+        # before the first HC BDA.
+        proj_2d = paddle.matmul(x_2d, weight.t(), transpose_y=True)
+        if (
+            _dsv4_hc_mapping_seqfirst_wgrad_enabled()
+            and len(x.shape) == 3
+            and x.shape[0] > 1
+            and not proj_2d.stop_gradient
+        ):
+            batch_size, seq_len, hidden_width = x.shape
 
-        return proj, r
+            def _seqfirst_wgrad_hook(grad: Tensor) -> None:
+                with paddle.no_grad():
+                    out_width = grad.shape[-1]
+                    x_seqfirst = (
+                        x.detach()
+                        .reshape([batch_size, seq_len, hidden_width])
+                        .transpose([1, 0, 2])
+                        .reshape([-1, hidden_width])
+                    )
+                    grad_seqfirst = (
+                        grad.detach()
+                        .reshape([batch_size, seq_len, out_width])
+                        .transpose([1, 0, 2])
+                        .reshape([-1, out_width])
+                    )
+                    w_grad = _dsv4_hc_mapping_torch_wgrad(
+                        x_seqfirst,
+                        grad_seqfirst,
+                        weight,
+                    )
+                    _dsv4_accumulate_hc_mapping_seqfirst_wgrad(weight, w_grad)
+
+            proj_2d.register_hook(_seqfirst_wgrad_hook)
+        proj = proj_2d.reshape([*x.shape[:-1], weight.shape[-1]])
+        return proj, r.reshape([*x.shape[:-1], 1])
 
     def _compute_h(
         self, proj: Tensor, r: Tensor
@@ -377,12 +821,12 @@ class HyperConnectionModule(nn.Layer):
         h = r * proj * alpha_ + self.bias
         # H_pre = σ(α_pre * (θ_pre @ x̃) + b_pre)
         h_pre = h[..., : self.n].sigmoid()  # [..., n]
+        h_pre = h_pre.astype(proj.dtype)
+
         # H_post = 2σ(α_post * (θ_post @ x̃) + b_post)
         h_post = h[..., self.n : 2 * self.n].sigmoid() * 2  # [..., n]
         h_res = h[..., 2 * self.n :]
-        if _use_accuracy_compatible_kernel():
-            h_pre = h_pre.astype(proj.dtype)
-            h_post = h_post.astype(proj.dtype)
+        h_post = h_post.astype(proj.dtype)
         return h_pre, h_post, h_res
 
     def compute_mappings(self, x: Tensor) -> tuple[Tensor, Tensor, Tensor]:
@@ -402,12 +846,12 @@ class HyperConnectionModule(nn.Layer):
         leading_shape = x.shape[:-1]
         proj, r = self._projection_and_get_norm(x)
         h_pre, h_post, h_res = self._compute_h(proj, r)
-        h_res = self._sinkhorn_op(
-            h_res.reshape([*leading_shape, self.n, self.n]),
+        h_res_logits = h_res
+        h_res_logits_view = h_res_logits.reshape([*leading_shape, self.n, self.n])
+        h_res = SinkhornKnopp.apply(
+            h_res_logits_view,
             self.sinkhorn_iterations,
-            self.norm_eps,
         )  # [..., n, n]
-
         return h_pre, h_post, h_res
 
     def aggregate(self, x: Tensor, h_pre: Tensor) -> Tensor:
@@ -429,17 +873,12 @@ class HyperConnectionModule(nn.Layer):
         # Reshape to [..., n, C]
         x_streams = x.reshape([*leading_shape, self.n, C])
 
-        if _use_accuracy_compatible_kernel():
-            # Weighted sum: [..., n, C] * [..., n, 1] -> sum over n -> [..., C]
-            aggregated = (x_streams * h_pre.unsqueeze(-1)).sum(axis=-2)
-            if aggregated.dtype != x.dtype:
-                aggregated = aggregated.astype(x.dtype)
-            return aggregated
-        else:
-            aggregated = self._h_aggregate_op(x_streams, h_pre)
-            if aggregated.dtype != x.dtype:
-                aggregated = aggregated.astype(x.dtype)
-            return aggregated
+        # Weighted sum: [..., n, C] * [..., n, 1] -> sum over n -> [..., C]
+        aggregated = (x_streams * h_pre.unsqueeze(-1)).sum(axis=-2)
+        if aggregated.dtype != x.dtype:
+            aggregated = aggregated.astype(x.dtype)
+
+        return aggregated
 
     def apply_h_res(self, h_res: Tensor, residual: Tensor) -> Tensor:
         """
@@ -456,18 +895,8 @@ class HyperConnectionModule(nn.Layer):
         C = self.hidden_size
         num_tokens = math.prod(leading_shape)
 
-        if _use_accuracy_compatible_kernel():
-            # Megatron clean path applies H_res.T to residual.
-            ndim = h_res.ndim
-            perm = [*list(range(ndim - 2)), ndim - 1, ndim - 2]
-            h_res_batched = (
-                h_res.astype(residual.dtype)
-                .transpose(perm)
-                .reshape([num_tokens, n, n])
-            )
-        else:
-            # Reshape for bmm: [..., n, n] -> [batch, n, n]
-            h_res_batched = h_res.reshape([num_tokens, n, n])
+        # Megatron clean path applies H_res.T to residual.
+        h_res_batched = h_res.astype(residual.dtype).transpose([0, 1, 3, 2]).reshape([num_tokens, n, n])
         # [..., n*C] -> [..., n, C] -> [batch, n, C]
         residual_batched = residual.reshape([num_tokens, n, C])
 
@@ -546,17 +975,11 @@ class HyperConnectionModule(nn.Layer):
             h_res: [..., n, n] - residual mixing matrix (for fused kernel)
             h_post: [..., n] - expansion weights
         """
-        with paddle.amp.auto_cast(enable=False):
-            # Compute mappings
-            if (
-                not _use_accuracy_compatible_kernel()
-                and self.config.high_precision_mhc
-            ):
-                hidden_states = hidden_states.astype("float32")
-            h_pre, h_post, h_res = self.compute_mappings(hidden_states)
+        # Compute mappings
+        h_pre, h_post, h_res = self.compute_mappings(hidden_states)
 
-            # Aggregate for layer input
-            aggregated = self.aggregate(hidden_states, h_pre)
+        # Aggregate for layer input
+        aggregated = self.aggregate(hidden_states, h_pre)
 
         return aggregated, h_res, h_post
 
@@ -630,34 +1053,46 @@ class HyperConnectionModule(nn.Layer):
         Returns:
             contracted: [..., h] single-stream output
         """
+        if os.environ.get("DSV4_FLEET_CONTRACT_TORCH_FORWARD", "0") == "1":
+            return _DSV4LearnedOutputContract.apply(
+                hidden_states,
+                head_fn,
+                base,
+                scale,
+                n,
+                eps,
+            )
+
         dtype = hidden_states.dtype
         hidden_states = hidden_states.astype("float32")
         head_fn = head_fn.astype("float32")
         base = base.astype("float32")
         scale = scale.astype("float32")
+        hidden_for_rsqrt = hidden_states
+        hidden_for_proj = hidden_states
+        hidden_for_direct = hidden_states
+        if os.environ.get("DSV4_FLEET_CONTRACT_BRANCH_SPLIT", "0") == "1":
+            hidden_for_rsqrt, hidden_for_proj, hidden_for_direct = _DSV4ContractBranchSplit.apply(
+                hidden_states
+            )
 
         rsqrt = paddle.rsqrt(
-            hidden_states.square().mean(-1, keepdim=True) + eps
+            hidden_for_rsqrt.square().mean(-1, keepdim=True) + eps
         )
-        if _use_accuracy_compatible_kernel():
-            # Match Torch F.linear(x, weight[out,in]) kernel selection. Paddle
-            # F.linear(x, weight[in,out]) uses a different cuBLAS path and
-            # causes BF16 ulp drift in DSv4 final output contraction.
-            head_fn_out_in = head_fn.transpose([1, 0]).contiguous()
-            with paddle.amp.auto_cast(False):
-                proj = paddle.matmul(
-                    hidden_states, head_fn_out_in, transpose_y=True
-                )
-            mixes = proj * rsqrt
-        else:
-            mixes = F.linear(hidden_states, head_fn) * rsqrt
-        pre = F.sigmoid(mixes * scale + base) + eps
-        y = paddle.sum(
-            pre.unsqueeze(-1)
-            * hidden_states.reshape([*hidden_states.shape[:-1], n, -1]),
-            axis=-2,
-        )
-        return y.astype(dtype)
+        # Match Torch F.linear(x, weight[out,in]) kernel selection. Paddle
+        # F.linear(x, weight[in,out]) uses a different cuBLAS path and causes
+        # BF16 ulp drift in DSv4 final output contraction.
+        head_fn_out_in = head_fn.transpose([1, 0]).contiguous()
+        with paddle.amp.auto_cast(False):
+            proj = paddle.matmul(hidden_for_proj, head_fn_out_in, transpose_y=True)
+        mixes = proj * rsqrt
+        pre_arg = mixes * scale + base
+        pre = F.sigmoid(pre_arg) + eps
+        hidden_streams = hidden_for_direct.reshape([*hidden_for_direct.shape[:-1], n, -1])
+        contract_prod = pre.unsqueeze(-1) * hidden_streams
+        y = paddle.sum(contract_prod, axis=-2)
+        out = y.astype(dtype)
+        return out
 
     # ==================== Fused kernel placeholder ====================
 
@@ -695,43 +1130,23 @@ class HyperConnectionModule(nn.Layer):
         Returns:
             output: [..., n*C] - final output after all operations
         """
-        with paddle.amp.auto_cast(enable=False):
-            x, bias = layer_output_with_bias
+        x, bias = layer_output_with_bias
+        # Step 1: Apply H_res to original residual
+        mixed = self.apply_h_res(h_res, original_residual)
 
-            # Fast path: no dropout — use fused/native h_post_bda kernel
-            if not _use_accuracy_compatible_kernel() and (
-                dropout_prob == 0.0 or not training
-            ):
-                leading_shape = original_residual.shape[:-1]
-                n = self.n
-                C = self.hidden_size
-                orig_reshaped = original_residual.reshape(
-                    [*leading_shape, n, C]
-                )
-                if self.config.high_precision_mhc:
-                    orig_reshaped = orig_reshaped.astype("float32")
-                    x = x.astype("float32")
-                    if bias is not None:
-                        bias = bias.astype("float32")
-                output = self._h_post_bda_op(
-                    h_res, orig_reshaped, h_post, x, bias
-                )
-                return output.reshape([*leading_shape, n * C])
+        # Step 2: Apply H_post to layer output
+        x_expanded = self._apply_h_post(x, h_post)
+        bias_expanded = (
+            self._apply_h_post(bias, h_post) if bias is not None else None
+        )
 
-            # Sequential path: used when dropout required OR accuracy-compatible kernel is NOT enabled
-            mixed = self.apply_h_res(h_res, original_residual)
-
-            x_expanded = self._apply_h_post(x, h_post)
-            bias_expanded = (
-                self._apply_h_post(bias, h_post) if bias is not None else None
-            )
-
-            if bias_expanded is not None:
-                x_expanded = x_expanded + bias_expanded
-            out = paddle.nn.functional.dropout(
-                x_expanded, p=dropout_prob, training=training
-            )
-            output = out + mixed
+        # Step 3: Bias-dropout-add
+        if bias_expanded is not None:
+            x_expanded = x_expanded + bias_expanded
+        out = paddle.nn.functional.dropout(
+            x_expanded, p=dropout_prob, training=training
+        )
+        output = mixed + out
 
         return output
 
@@ -777,7 +1192,6 @@ class HyperConnectionContractLayer(FleetLayer):
         )
 
         self.num_mtp = getattr(config, "num_nextn_predict_layers", 0) or 0
-        self.magic_send = getattr(config, "enable_mtp_magic_send", False)
 
         # Learned contraction parameters (DSv4 style, always used)
         n = self.n
@@ -807,50 +1221,30 @@ class HyperConnectionContractLayer(FleetLayer):
         hidden_states = dict_args["hidden_states"]
 
         # When MTP is enabled, preserve multi-stream for MTP input
-        if (
-            self.mtp_enabled
-            and self.num_mtp > 0
-            and not getattr(self.config, "mtp_load_weight_only", False)
-        ):
+        if self.mtp_enabled and self.num_mtp > 0:
             dict_args["mhc_multistream"] = hidden_states
 
-            if self.magic_send:
-                # magic_send: hidden_states is pure backbone [B, S, n*H]
-                # Magic send: backbone processes only main sequence, no MTP chunks concatenated.
-                # Simply contract the entire tensor.
-                dict_args["hidden_states"] = (
-                    HyperConnectionModule.learned_output_contract(
-                        hidden_states,
-                        self.hc_head_fn,
-                        self.hc_head_base,
-                        self.hc_head_scale,
-                        self.n,
-                        self.config.rms_norm_eps,
-                    )
-                )
-            else:
-                # Non-magic_send: backbone output is [backbone_chunk | mtp_chunks...] concatenated.
-                # Split, contract main backbone, slice MTP chunks.
-                chunks = paddle.split(hidden_states, self.num_mtp + 1)
+            # Split into main backbone + MTP chunks
+            chunks = paddle.split(hidden_states, self.num_mtp + 1)
 
-                # Main backbone: learned contraction [s, b, n*h] -> [s, b, h]
-                main_contracted = HyperConnectionModule.learned_output_contract(
-                    chunks[0],
-                    self.hc_head_fn,
-                    self.hc_head_base,
-                    self.hc_head_scale,
-                    self.n,
-                    self.config.rms_norm_eps,
-                )
+            # Main backbone: learned contraction [s, b, n*h] -> [s, b, h]
+            main_contracted = HyperConnectionModule.learned_output_contract(
+                chunks[0],
+                self.hc_head_fn,
+                self.hc_head_base,
+                self.hc_head_scale,
+                self.n,
+                self.config.rms_norm_eps,
+            )
 
-                # 为了后面MTP slice、取shape的时候兼容,原本也是expand过来的[[s,b,h]...]
-                mtp_contracted = [
-                    c[..., : c.shape[-1] // self.n] for c in chunks[1:]
-                ]
+            # 为了后面MTP slice、取shape的时候兼容,原本也是expand过来的[[s,b,h]...]
+            mtp_contracted = [
+                c[..., : c.shape[-1] // self.n] for c in chunks[1:]
+            ]
 
-                dict_args["hidden_states"] = paddle.concat(
-                    [main_contracted, *mtp_contracted]
-                )
+            dict_args["hidden_states"] = paddle.concat(
+                [main_contracted, *mtp_contracted]
+            )
 
         else:
             # Learned output contraction: [s, b, n*h] -> [s, b, h]

--- a/src/paddlefleet/transformer/hyper_connection.py
+++ b/src/paddlefleet/transformer/hyper_connection.py
@@ -330,10 +330,6 @@ def _dsv4_hc_sinkhorn_torch_backward(
     grad_t = torch.utils.dlpack.from_dlpack(
         paddle_dlpack.to_dlpack(grad_output.contiguous())
     ).to(torch.bfloat16)
-    # Match Megatron's training graph: Sinkhorn receives a transposed-view grad
-    # from H_res.T @ residual, so the last two dimensions have stride (1, n).
-    grad_t = grad_t.transpose(-1, -2).contiguous().transpose(-1, -2)
-
     with torch.enable_grad():
         logits_t = logits_t.detach().requires_grad_(True)
         row_max = logits_t.max(dim=-1, keepdim=True).values
@@ -895,8 +891,7 @@ class HyperConnectionModule(nn.Layer):
         C = self.hidden_size
         num_tokens = math.prod(leading_shape)
 
-        # Megatron clean path applies H_res.T to residual.
-        h_res_batched = h_res.astype(residual.dtype).transpose([0, 1, 3, 2]).reshape([num_tokens, n, n])
+        h_res_batched = h_res.reshape([num_tokens, n, n])
         # [..., n*C] -> [..., n, C] -> [batch, n, C]
         residual_batched = residual.reshape([num_tokens, n, C])
 

--- a/src/paddlefleet/transformer/moe/fp8_utils.py
+++ b/src/paddlefleet/transformer/moe/fp8_utils.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 """FP8 Utils"""
 
+import os
+
 import numpy
 import paddle
 import paddle.nn.functional as F
@@ -31,28 +33,21 @@ try:
         fuse_stack_transpose_fp8_quant,
         fuse_weighted_swiglu_fp8_quant,
         fuse_weighted_swiglu_fp8_quant_clamp,
-        fused_swiglu_weighted_clamp_bwd,
     )
 except (ImportError, RuntimeError):
     pass
 
-# 优先从 paddlefleet_ops 导入（算子已重命名为 paddlefleet_fused_swiglu_probs_bwd 避免冲突），
-# 仅在 paddlefleet_ops 中不存在时回退到旧的 FusedQuantOps。
+# 优先使用 FusedQuantOps.fused_swiglu_probs_bwd（inplace，行为对齐）。
+# 若环境中没有 FusedQuantOps，则回退到 paddle.incubate 的 out-of-place 实现。
+# TODO: 迁移fused_swiglu_probs_bwd至paddlefleet_ops
 try:
-    from paddlefleet_ops import (
-        fused_swiglu_probs_bwd as _fused_swiglu_probs_bwd,
-    )
+    import FusedQuantOps as _FQO
 
+    _fused_swiglu_probs_bwd = _FQO.fused_swiglu_probs_bwd
     USE_INPLACE_SWIGLU_BWD = True
-except (ImportError, AttributeError, RuntimeError):
-    try:
-        import FusedQuantOps as _FQO
-
-        _fused_swiglu_probs_bwd = _FQO.fused_swiglu_probs_bwd
-        USE_INPLACE_SWIGLU_BWD = True
-    except (ImportError, AttributeError):
-        _fused_swiglu_probs_bwd = None
-        USE_INPLACE_SWIGLU_BWD = False
+except (ImportError, AttributeError):
+    _fused_swiglu_probs_bwd = None
+    USE_INPLACE_SWIGLU_BWD = False
 
 try:
     from paddle.nn.functional import swiglu
@@ -326,112 +321,6 @@ def kitchen_gemm(
     return y
 
 
-class _PerExpertWeightView:
-    """A lightweight view into a single expert's slice of the stacked fp8 weight.
-
-    After offline fp8 quant, the original bf16 weight storage is cleared.
-    This view provides the same interface that ``_get_fp8_weight_and_scale``
-    expects (``fp8_weight_stacked``, ``fp8_scale_stacked``, etc.) by slicing
-    the parent's stacked fp8 tensors for a single expert.
-
-    The ``shape`` property reports ``[1, K, N]`` so that downstream code
-    (e.g., ``_get_fp8_weight_and_scale``) correctly infers ``num_expert = 1``.
-    """
-
-    def __init__(self, parent_weight, local_id, num_experts):
-        self._parent = parent_weight
-        self._local_id = local_id
-        self._num_experts = num_experts
-        self._shape = [1, *list(parent_weight.shape[1:])]
-
-    def _slice_stacked(self, attr_name):
-        """Slice a 2D stacked tensor [E*rows, cols] to this expert's rows."""
-        t = getattr(self._parent, attr_name, None)
-        if t is None:
-            return None
-        rows_per_expert = t.shape[0] // self._num_experts
-        start = self._local_id * rows_per_expert
-        return t._slice(start, start + rows_per_expert)
-
-    @property
-    def shape(self):
-        return self._shape
-
-    def __len__(self):
-        return self._shape[0]
-
-    @property
-    def dtype(self):
-        return self._parent.dtype
-
-    @property
-    def fp8_weight_stacked(self):
-        return self._slice_stacked("fp8_weight_stacked")
-
-    @property
-    def fp8_scale_stacked(self):
-        return self._slice_stacked("fp8_scale_stacked")
-
-    @property
-    def fp8_weight_stacked_transpose(self):
-        return self._slice_stacked("fp8_weight_stacked_transpose")
-
-    @property
-    def fp8_scale_stacked_transpose(self):
-        return self._slice_stacked("fp8_scale_stacked_transpose")
-
-    @property
-    def main_grad(self):
-        mg = getattr(self._parent, "main_grad", None)
-        if mg is None:
-            return None
-        return mg._slice(self._local_id, self._local_id + 1)
-
-    @main_grad.setter
-    def main_grad(self, value):
-        # When backward tries to allocate main_grad, ensure parent has it
-        if getattr(self._parent, "main_grad", None) is None:
-            self._parent.main_grad = paddle.zeros(
-                self._parent.shape, dtype=paddle.float32
-            )
-
-    @property
-    def grad(self):
-        g = self._parent.grad
-        if g is None:
-            return None
-        return g._slice(self._local_id, self._local_id + 1)
-
-    @grad.setter
-    def grad(self, value):
-        pass
-
-    def _apply_backward_hook(self):
-        if hasattr(self._parent, "_apply_backward_hook"):
-            self._parent._apply_backward_hook()
-
-    @property
-    def stop_gradient(self):
-        return self._parent.stop_gradient
-
-
-class _PerExpertWeightProxy:
-    """Proxy for grouped_gemm_experts that provides per-expert weight views.
-
-    Holds ``weight1`` and ``weight2`` as ``_PerExpertWeightView`` instances
-    that lazily slice from the parent's fp8 stacked weights.
-    """
-
-    def __init__(self, parent, local_id):
-        num_experts = parent.weight1.shape[0]
-        self.weight1 = _PerExpertWeightView(
-            parent.weight1, local_id, num_experts
-        )
-        self.weight2 = _PerExpertWeightView(
-            parent.weight2, local_id, num_experts
-        )
-
-
 class ExpertsGroupGemmContiguousNode:
     """ExpertsGroupGemmContiguousNode"""
 
@@ -461,30 +350,12 @@ class ExpertsGroupGemmContiguousNode:
             dequant_input (bool, optional): Whether to dequantize input. Defaults to False.
             name (str, optional): Name of the node. Defaults to "experts_group_gemm_contiguous_node".
         """
-        if moe_deep_gemm and expert_id is not None:
-            # Per-expert node for deep_gemm: slice stacked weight to [1, K, N]
-            parent = custom_map.grouped_gemm_experts
-            moe_rank = getattr(custom_map, "moe_rank", 0)
-            num_experts_per_device = getattr(
-                custom_map, "num_experts_per_device", parent.weight1.shape[0]
-            )
-            local_id = expert_id - moe_rank * num_experts_per_device
-            if hasattr(parent.weight1, "fp8_weight_stacked"):
-                # Offline quant: bf16 weight may have been cleared, use proxy
-                self.grouped_gemm_experts = _PerExpertWeightProxy(
-                    parent, local_id
-                )
-            else:
-                # Normal: bf16 weight is valid, slice directly
-                sliced = type("_SlicedGroupedExpert", (), {})()
-                sliced.weight1 = parent.weight1._slice(local_id, local_id + 1)
-                sliced.weight2 = parent.weight2._slice(local_id, local_id + 1)
-                sliced._parent = parent
-                sliced._local_id = local_id
-                self.grouped_gemm_experts = sliced
-            self.experts = None
-            moe_expert_fusion = True
-        elif not moe_expert_fusion or (use_fp8_mlp and not moe_deep_gemm):
+        # 两条路径：
+        #   split path (self.experts): 权重为 list，支持 auto_subbatch 逐专家 fallback
+        #     条件: moe_expert_fusion=False, 或 use_fp8_mlp=True & moe_deep_gemm=False
+        #   grouped path (self.grouped_gemm_experts): 权重为 stacked tensor，走批量 gemm
+        #     条件: moe_expert_fusion=True & (use_fp8_mlp=False 或 moe_deep_gemm=True)
+        if not moe_expert_fusion or (use_fp8_mlp and not moe_deep_gemm):
             if expert_id is None:
                 self.experts = custom_map.experts
             else:
@@ -601,7 +472,7 @@ class ExpertsGroupGemmContiguousNode:
                         x,
                         expert_w1,
                         o1,
-                        self.m_indices,
+                        self.tokens_per_expert_indices,
                     )
                 else:
                     o1 = paddle.incubate.nn.functional.batched_gemm(
@@ -640,10 +511,10 @@ class ExpertsGroupGemmContiguousNode:
         self, x, expert_w1, num_expert, tokens_per_expert, scale=None
     ):
         self.tokens_per_expert = tokens_per_expert
-        if self.moe_deep_gemm or self.moe_expert_fusion:
-            self.m_indices = self.gen_m_indices(self.tokens_per_expert)
-        else:
-            self.m_indices = None
+        if self.moe_deep_gemm:
+            self.tokens_per_expert_indices = self.gen_m_indices(
+                self.tokens_per_expert
+            )
         if not self.use_fp8_mlp:
             return self.fwd_gate_up_bf16(x, expert_w1)
         else:
@@ -658,6 +529,9 @@ class ExpertsGroupGemmContiguousNode:
         o1 = x * w1
         [m_sum, n] = [m_sum, k] * [num_groups, k, n] (m_sum = sum(tokens_per_expert))
         """
+
+        if self.moe_expert_fusion:
+            self.m_indices = self.gen_m_indices(tokens_per_expert)
         # concat w1, shape is [num_groups, n, k]
 
         if hasattr(self, "grouped_gemm_experts"):
@@ -754,9 +628,9 @@ class ExpertsGroupGemmContiguousNode:
         fwd_down_bf16
         """
 
-        if self.clamp_value is not None and self.clamp_value > 0:
+        if self.clamp_value is not None:
             o2 = fused_swiglu_scale_forward(
-                o1, unzipped_probs, self.clamp_value
+                o1, unzipped_probs, clamp_value=self.clamp_value
             )
         else:
             o2 = fused_swiglu_scale_forward(o1, unzipped_probs)
@@ -775,7 +649,7 @@ class ExpertsGroupGemmContiguousNode:
                         o2,
                         expert_w2,
                         o3,
-                        self.m_indices,
+                        self.tokens_per_expert_indices,
                     )
                 else:
                     o3 = paddle.incubate.nn.functional.batched_gemm(
@@ -824,10 +698,7 @@ class ExpertsGroupGemmContiguousNode:
         """
         # concat and transpose w2
 
-        if (
-            hasattr(self, "grouped_gemm_experts")
-            and self.grouped_gemm_experts is not None
-        ):
+        if hasattr(self, "grouped_gemm_experts"):
             offline_quant = hasattr(
                 self.grouped_gemm_experts.weight2,
                 "fp8_weight_stacked_transpose",
@@ -851,7 +722,7 @@ class ExpertsGroupGemmContiguousNode:
         w2_quant = w2_quant.reshape([num_expert, -1, w2_quant.shape[-1]])
         w2_scale = w2_scale.reshape([num_expert, -1, w2_scale.shape[-1]])
 
-        if self.clamp_value is not None and self.clamp_value > 0:
+        if self.clamp_value is not None:
             o2_fp8, o2_scale = fuse_weighted_swiglu_fp8_quant_clamp(
                 o1,
                 unzipped_probs,
@@ -920,7 +791,7 @@ class ExpertsGroupGemmContiguousNode:
                         unzipped_grad,
                         expert_w2,
                         do2_s,
-                        self.m_indices,
+                        self.tokens_per_expert_indices,
                     )
                 else:
                     do2_s = paddle.incubate.nn.functional.batched_gemm(
@@ -952,9 +823,12 @@ class ExpertsGroupGemmContiguousNode:
                 do2_s_shape = [unzipped_grad.shape[0], expert_w2[0].shape[1]]
             do2_s = paddle.empty(do2_s_shape, dtype=unzipped_grad.dtype)
 
-        if self.clamp_value is not None and self.clamp_value > 0:
-            do1, probs_grad, o2_s = fused_swiglu_weighted_clamp_bwd(
-                o1, unzipped_probs, do2_s, float(self.clamp_value)
+        if self.clamp_value is not None:
+            o2_s = fused_swiglu_scale_forward(
+                o1, unzipped_probs, clamp_value=self.clamp_value
+            )
+            do1, probs_grad = fused_swiglu_scale_backward(
+                o1, unzipped_probs, do2_s, clamp_value=self.clamp_value
             )
         else:
             o2_s = fused_swiglu_scale_forward(o1, unzipped_probs)
@@ -1071,12 +945,16 @@ class ExpertsGroupGemmContiguousNode:
                 )
 
         with paddle.amp.auto_cast(False):
-            if self.clamp_value is not None and self.clamp_value > 0:
-                do1, probs_grad, o2_s = fused_swiglu_weighted_clamp_bwd(
-                    o1,
-                    unzipped_probs,
-                    do2_s,
-                    float(self.clamp_value),
+            if self.clamp_value is not None:
+                # Neither the inplace fused kernel nor Paddle core's
+                # fused_swiglu_weighted_bwd support clamp. Fall back to the
+                # python implementation in paddlefleet.fusions.fused_swiglu_scale
+                # which handles clamp via gradient masking.
+                o2_s = fused_swiglu_scale_forward(
+                    o1, unzipped_probs, clamp_value=self.clamp_value
+                )
+                do1, probs_grad = fused_swiglu_scale_backward(
+                    o1, unzipped_probs, do2_s, clamp_value=self.clamp_value
                 )
             elif USE_INPLACE_SWIGLU_BWD:
                 # inplace，do1 复用 o1 的 GPU buffer（data_ptr 相同）。
@@ -1119,7 +997,7 @@ class ExpertsGroupGemmContiguousNode:
                         do1,
                         expert_w1,
                         dx,
-                        self.m_indices,
+                        self.tokens_per_expert_indices,
                     )
                 else:
                     dx = paddle.incubate.nn.functional.batched_gemm(
@@ -1567,7 +1445,7 @@ class ExpertsGroupGemmContiguousNode:
         subbatch_rows = self.moe_subbatch_token_num_after_dispatch
         if subbatch_rows is None:
             self.tokens_per_expert_tensor = paddle.to_tensor(
-                self.tokens_per_expert, dtype="int32"
+                self.tokens_per_expert, dtype="int64"
             )
             return self.backward_impl(
                 out_grad, unzipped_probs, a2a_async_fn=a2a_async_fn
@@ -1582,7 +1460,7 @@ class ExpertsGroupGemmContiguousNode:
         nparts = (rows + subbatch_rows - 1) // subbatch_rows
         if nparts <= 1:
             self.tokens_per_expert_tensor = paddle.to_tensor(
-                self.tokens_per_expert, dtype="int32"
+                self.tokens_per_expert, dtype="int64"
             )
             return self.backward_impl(
                 out_grad, unzipped_probs, a2a_async_fn=a2a_async_fn
@@ -1609,10 +1487,13 @@ class ExpertsGroupGemmContiguousNode:
                 self.o1 = o1._slice(s_idx, e_idx)
             self.tokens_per_expert = [e_idx - s_idx]
             self.tokens_per_expert_tensor = paddle.to_tensor(
-                self.tokens_per_expert, dtype="int32"
+                self.tokens_per_expert, dtype="int64"
             )
             if self.moe_deep_gemm:
-                self.m_indices = self.gen_m_indices(self.tokens_per_expert)
+                self.tokens_per_expert_indices = paddle.repeat_interleave(
+                    paddle.arange(len(self.tokens_per_expert)),
+                    paddle.to_tensor(self.tokens_per_expert),
+                ).cast("int32")
 
             tmp_out_grad = out_grad._slice(s_idx, e_idx)
             tmp_unzipped_probs = unzipped_probs._slice(s_idx, e_idx)
@@ -1635,7 +1516,10 @@ class ExpertsGroupGemmContiguousNode:
 
         self.tokens_per_expert = tokens_per_expert
         if self.moe_deep_gemm:
-            self.m_indices = self.gen_m_indices(self.tokens_per_expert)
+            self.tokens_per_expert_indices = paddle.repeat_interleave(
+                paddle.arange(len(self.tokens_per_expert)),
+                paddle.to_tensor(self.tokens_per_expert),
+            ).cast("int32")
         probs_grad = paddle.concat(probs_grad, axis=0)
         return out_grad, probs_grad
 

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-import hashlib
 import logging
 import os
 from copy import deepcopy
@@ -39,17 +38,15 @@ if TYPE_CHECKING:
 from paddlefleet import utils
 from paddlefleet.recompute_utils import need_recompute_in_first_n
 from paddlefleet.transformer.utils import profile
+from paddlefleet.utils import dsv4_sequence_first_feature_enabled
 
 from .fp8_utils import fused_stack_quant_without_cache
 from .fused_a2a import configure_buffer
-from .fusion_layer_utils import (
-    FusionMoePyLayer,
-    HybridEPMoePyLayer,
-)
-from .moe_expert import GroupedMLPExpert, SonicMoEExpert, StandardMLPExpert
+from .fusion_layer_utils import FusionMoePyLayer, HybridEPMoePyLayer
+from .moe_expert import GroupedMLPExpert, StandardMLPExpert
 from .moe_router import TopKRouter
 from .moe_shared_expert import StandardMLPSharedExpert
-from .moe_utils import AddAuxiliaryLoss, use_accuracy_compatible_kernel
+from .moe_utils import AddAuxiliaryLoss
 from .token_dispatcher import (
     AllToAllTokenDispatcher,
     MoEFlexTokenDispatcher,
@@ -59,32 +56,49 @@ from .token_dispatcher import (
 logger = logging.getLogger(__name__)
 
 
-# MD5 logging for MoE precision debugging
-_LOG_LAYER_MD5 = os.environ.get("LOG_LAYER_MD5", "0") == "1"
+def _dsv4_expert_scale_before_down_enabled() -> bool:
+    return os.environ.get("DSV4_FLEET_EXPERT_SCALE_BEFORE_DOWN", "0") == "1"
 
 
-def _log_moe_md5(tensor, name, layer_idx=None):
-    """Log MD5 of a tensor for MoE precision alignment debugging."""
-    from paddlefleet.transformer.transformer_layer import TransformerLayer
+def _dsv4_sequence_first_moe_enabled() -> bool:
+    return dsv4_sequence_first_feature_enabled(
+        "DSV4_FLEET_SEQUENCE_FIRST_MOE"
+    )
 
-    if _LOG_LAYER_MD5 and TransformerLayer._gpt_model_use_experimental_version:
-        if TransformerLayer._skip_mtp_probes:
-            return  # Skip MTP passes — EC has no MTP
-        data = tensor.detach().cast("float32").numpy().tobytes()
-        md5 = hashlib.md5(data).hexdigest()
-        rank = (
-            paddle.distributed.get_rank()
-            if paddle.distributed.is_initialized()
-            else 0
-        )
-        layer_str = f" Layer={layer_idx}" if layer_idx is not None else ""
-        print(
-            f"[MD5 MoE] Rank={rank}{layer_str} {name} MD5={md5} shape={list(tensor.shape)}",
-            flush=True,
-        )
 
+class _DSV4MTPMoEInputBranches(PyLayer):
+    @staticmethod
+    def forward(ctx, x, is_mtp_layer, layer_number):
+        return x.clone(), x.clone(), x.clone()
+
+    @staticmethod
+    def backward(ctx, routed_grad, router_grad, shared_grad):
+        return (routed_grad + router_grad) + shared_grad
+
+
+def _dsv4_mtp_moe_split_input_branches(tensor, is_mtp_layer, layer_number):
+    if is_mtp_layer:
+        enabled = os.environ.get("DSV4_FLEET_MTP_MOE_INPUT_ORDER", "0") == "1"
+    else:
+        enabled = os.environ.get("DSV4_FLEET_MOE_INPUT_ORDER", "0") == "1"
+    if not enabled:
+        return tensor, tensor, tensor
+    if tensor is None or not isinstance(tensor, paddle.Tensor) or tensor.stop_gradient:
+        return tensor, tensor, tensor
+    return _DSV4MTPMoEInputBranches.apply(tensor, is_mtp_layer, layer_number)
+
+
+if paddlefleet_ops.is_sonic_moe_available():
+    from paddlefleet_ops.sonicmoe.enums import ActivationType
+    from paddlefleet_ops.sonicmoe.functional import (
+        _DownProjection,
+        _UpProjection,
+    )
 
 from .moe_utils import (
+    count_cumsum,
+    filter_scores,
+    fused_expert_parallel_TC_topk_router_metadata,
     global_moe_balance_training_logs_enabled,
     log_moe_balance,
     log_moe_losses,
@@ -136,10 +150,11 @@ class MoELayer(nn.Layer):
         config: TransformerConfig,
         sublayers: MoESublayers | None = None,
         pg_collection: ProcessGroupCollection | None = None,
+        layer_number: int | None = None,
     ):
         super().__init__()
         self.config = config
-        self.moe_sublayers = sublayers
+        self.sublayers = sublayers
         routed_expert_config = deepcopy(config)
         shared_expert_config = deepcopy(config)
         global_use_bias = routed_expert_config.use_bias
@@ -153,6 +168,7 @@ class MoELayer(nn.Layer):
                 moe_routed_expert_use_bias,
             )
         self.pg_collection = pg_collection
+        self.is_mtp_layer = False
         self.hidden_size = config.hidden_size
         self.moe_intermediate_size = config.moe_intermediate_size
         self.num_experts = config.n_routed_experts
@@ -170,11 +186,11 @@ class MoELayer(nn.Layer):
         self.use_hybrid_ep_backend = False
         self.moe_shared_expert_overlap = config.moe_shared_expert_overlap
         self.fp8 = config.fp8
+        self.fp8_dispatch = bool(config.fp8)
+        self.fp8_wgrad = config.fp8_wgrad
         self.use_ue8m0 = config.use_ue8m0
         self.dw_p2p_overlap = getattr(config, "dw_p2p_overlap", False)
         self.using_sonic_moe = self.config.using_sonic_moe
-        self.fp8_dispatch = bool(config.fp8) and not self.using_sonic_moe
-        self.fp8_wgrad = config.fp8_wgrad
         self.moe_expert_fusion = config.moe_expert_fusion
         self.moe_subbatch_token_num_after_dispatch = (
             config.moe_subbatch_token_num_after_dispatch
@@ -273,9 +289,10 @@ class MoELayer(nn.Layer):
                 )
                 self.moe_deep_gemm = False
 
-        self.moe_use_fusion_node = config.moe_use_fusion_node
+        self.moe_use_fusion_node = False
         if self.expert_model_parallel_size > 1:
             if self.moe_token_dispatcher_type in ("deepep", "hybridep"):
+                self.moe_use_fusion_node = config.moe_use_fusion_node
                 self.use_hybrid_ep_backend = is_hybrid_ep_backend_selected(
                     self.moe_token_dispatcher_type
                 )
@@ -289,10 +306,6 @@ class MoELayer(nn.Layer):
                     )
                     self.moe_shared_expert_overlap = False
             else:
-                logger.info(
-                    "moe_use_fusion_node is only supported when moe_token_dispatcher_type is 'deepep' or 'hybridep'; disabling it."
-                )
-                self.moe_use_fusion_node = False
                 if self.moe_expert_fusion:
                     raise ValueError(
                         "moe_expert_fusion is only supported when moe_token_dispatcher_type is 'deepep' or 'hybridep' and on GPU architecture SM90 or higher. If these conditions are not met, please set it to false in the configuration yaml."
@@ -307,6 +320,9 @@ class MoELayer(nn.Layer):
             assert self.moe_use_fusion_node, (
                 "fp8 can only be used when moe_use_fusion_node = True."
             )
+            assert not self.using_sonic_moe, (
+                "fp8 and sonic_moe cannot be used at the same time."
+            )
 
         if self.use_ue8m0:
             assert paddle.device.cuda.get_device_capability()[0] == 10, (
@@ -317,41 +333,15 @@ class MoELayer(nn.Layer):
         expert_args["config"] = routed_expert_config
         expert_args["moe_intermediate_size"] = self.moe_intermediate_size
         expert_args["is_expert"] = True
-        expert_args["mlp_spec"] = self.moe_sublayers.mlp_spec
+        expert_args["mlp_spec"] = self.sublayers.mlp_spec
 
-        use_fused_weight = self.moe_expert_fusion
-        if (
-            self.fp8
-            and (self.moe_expert_fusion is False)
-            and self.moe_deep_gemm
-        ):
-            raise ValueError(
-                "For fp8 deep_gemm (i.e. use k-grouped gemm in backward), moe_expert_fusion must be True."
+        if self.moe_expert_fusion and (not self.fp8 or self.moe_deep_gemm):
+            self.grouped_gemm_experts = GroupedMLPExpert(
+                self.num_local_experts,
+                routed_expert_config,
+                self.moe_deep_gemm,
+                pg_collection,
             )
-        if self.fp8 and self.moe_expert_fusion and self.moe_deep_gemm is False:
-            use_fused_weight = False
-        if self.using_sonic_moe:
-            assert use_fused_weight is True, (
-                "for sonic moe, expert weight must be fused."
-            )
-
-        if use_fused_weight:
-            if self.using_sonic_moe:
-                # TODO: replace grouped_gemm_experts with fusion_experts
-                self.grouped_gemm_experts = SonicMoEExpert(
-                    self.num_local_experts,
-                    self.num_experts_per_tok,
-                    routed_expert_config,
-                    pg_collection,
-                )
-            else:
-                # TODO: replace grouped_gemm_experts with fusion_experts
-                self.grouped_gemm_experts = GroupedMLPExpert(
-                    self.num_local_experts,
-                    routed_expert_config,
-                    self.moe_deep_gemm,
-                    pg_collection,
-                )
         else:
             self.experts = nn.LayerList([])
             for i in range(self.num_experts):
@@ -404,6 +394,7 @@ class MoELayer(nn.Layer):
                     self.num_experts_per_device,
                     local_expert_indices,
                 )
+                self.token_dispatcher.layer_number = layer_number
             else:
                 raise NotImplementedError(
                     f"Unsupported moe_token_dispatcher_type {self.moe_token_dispatcher_type}"
@@ -433,11 +424,8 @@ class MoELayer(nn.Layer):
         if self.expert_model_parallel_size > 1:
             self.is_mp_moe = False
             self.is_ep_moe = True
-            fusion_experts = None
-            if hasattr(self, "grouped_gemm_experts"):
-                fusion_experts = self.grouped_gemm_experts
-            if fusion_experts is not None:
-                for p in fusion_experts.parameters():
+            if self.moe_expert_fusion and (not self.fp8 or self.moe_deep_gemm):
+                for p in self.grouped_gemm_experts.parameters():
                     p.is_moe_param = True
                     p.color = {
                         "color": "moe_expert",
@@ -448,9 +436,6 @@ class MoELayer(nn.Layer):
                     if self.is_mp_moe or self.is_ep_moe:
                         p.is_distributed = True
             else:
-                assert self.experts is not None, (
-                    "experts should be initialized."
-                )
                 for p in self.experts.parameters():
                     p.is_moe_param = True
                     p.color = {
@@ -563,15 +548,14 @@ class MoELayer(nn.Layer):
             dispatched_input, num_or_sections=tokens_per_expert, axis=0
         )
         scale_chunks = None
-        if use_accuracy_compatible_kernel():
+        if _dsv4_expert_scale_before_down_enabled():
             per_token_scale = getattr(
                 self.token_dispatcher, "global_input_probs", None
             )
-            if per_token_scale is None:
-                raise RuntimeError(
-                    "FLAGS_use_accuracy_compatible_kernel requires dispatched "
-                    "router probabilities from the token dispatcher."
-                )
+            assert per_token_scale is not None, (
+                "DSV4_FLEET_EXPERT_SCALE_BEFORE_DOWN requires dispatched "
+                "router probabilities from the token dispatcher."
+            )
             scale_chunks = paddle.split(
                 per_token_scale, num_or_sections=tokens_per_expert, axis=0
             )
@@ -584,9 +568,9 @@ class MoELayer(nn.Layer):
             if scale_chunks is None:
                 expert_output = expert(chunk)[0]
             else:
-                expert_output = expert(chunk, per_token_scale=scale_chunks[i])[
-                    0
-                ]
+                expert_output = expert(
+                    chunk, per_token_scale=scale_chunks[i]
+                )[0]
             outputs += [expert_output]
 
         if not outputs:
@@ -623,13 +607,15 @@ class MoELayer(nn.Layer):
         return global_input_tokens, tokens_per_expert
 
     def unpermute(self, hidden_states: paddle.Tensor):
-        return self.token_dispatcher.combine_preprocess(hidden_states)
+        hidden_states = self.token_dispatcher.combine_preprocess(hidden_states)
+        return hidden_states
 
     def combine(self, hidden_states: paddle.Tensor, async_finish: bool = False):
         hidden_states = self.token_dispatcher.token_combine(
             hidden_states, async_finish=async_finish
         )
-        return self.token_dispatcher.combine_postprocess(hidden_states)
+        hidden_states = self.token_dispatcher.combine_postprocess(hidden_states)
+        return hidden_states
 
     def routed_experts_compute(
         self,
@@ -717,12 +703,69 @@ class MoELayer(nn.Layer):
                     fp8_dispatched_handle=fp8_dispatched_handle,
                 )
             elif self.using_sonic_moe:
-                use_fp8 = self.fp8 is not None
-                hidden_states = self.grouped_gemm_experts(
-                    dispatched_hidden_states,
-                    dispatched_indices,
+                T = dispatched_hidden_states.shape[0]
+                K = self.num_experts_per_tok
+                stream_id = paddle.device.cuda.current_stream().cuda_stream
+                topk_scores = filter_scores(
                     dispatched_probs,
-                    use_fp8,
+                    dispatched_indices,
+                )
+                expert_frequency, expert_frequency_offset = count_cumsum(
+                    dispatched_indices,
+                    self.num_experts_per_device,
+                    do_cumsum=True,
+                )
+                activation_type = ActivationType("swiglu")
+
+                (
+                    expert_frequency_offset,
+                    x_gather_idx,
+                    s_scatter_idx,
+                    s_reverse_scatter_idx,
+                    num_activated_expert_per_token_offset,
+                ) = fused_expert_parallel_TC_topk_router_metadata(
+                    dispatched_indices,
+                    expert_frequency_offset,
+                    K,
+                )
+
+                TK = s_scatter_idx.shape[0]
+                is_varlen_K = True
+                w1 = self.grouped_gemm_experts.weight1
+                y1, z = _UpProjection.apply(
+                    dispatched_hidden_states,
+                    w1.permute(1, 2, 0),
+                    None,
+                    expert_frequency_offset,
+                    TK,
+                    K,
+                    stream_id,
+                    x_gather_idx,
+                    s_scatter_idx,
+                    s_reverse_scatter_idx,
+                    num_activated_expert_per_token_offset,
+                    is_varlen_K,
+                    activation_type,
+                    is_inference_mode_enabled=False,
+                )
+
+                w2 = self.grouped_gemm_experts.weight2
+                hidden_states = _DownProjection.apply(
+                    y1,
+                    z,
+                    w2.permute(1, 2, 0),
+                    None,
+                    topk_scores,
+                    expert_frequency_offset,
+                    T,
+                    K,
+                    stream_id,
+                    x_gather_idx,
+                    s_scatter_idx,
+                    s_reverse_scatter_idx,
+                    num_activated_expert_per_token_offset,
+                    is_varlen_K,
+                    activation_type,
                 )
             else:
                 hidden_states = FusionMoePyLayer.apply(
@@ -744,7 +787,6 @@ class MoELayer(nn.Layer):
                     use_ue8m0=self.use_ue8m0,
                     dw_p2p_overlap=self.dw_p2p_overlap,
                     clamp_value=self.config.activation_func_clamp_value,
-                    is_first_fwd=not framework._dygraph_tracer()._has_grad,
                 )
 
         with profile("combine"):
@@ -946,11 +988,21 @@ class MoELayer(nn.Layer):
         """
         if self.expert_model_parallel_size <= 1 and self.sequence_parallel:
             hidden_states = GatherOp.apply(hidden_states)
+        dsv4_sequence_first_moe = (
+            _dsv4_sequence_first_moe_enabled()
+            and hidden_states.ndim == 3
+            and hidden_states.shape[0] > 1
+        )
+        if dsv4_sequence_first_moe:
+            hidden_states = hidden_states.transpose([1, 0, 2]).contiguous()
+            if input_ids is not None and input_ids.ndim == 2:
+                input_ids = input_ids.transpose([1, 0]).contiguous()
         orig_shape = hidden_states.shape
         residuals = hidden_states
 
-        layer_idx = getattr(self, "layer_number", None)
-        _log_moe_md5(hidden_states, "moe_input", layer_idx)
+        routed_input, gate_input, shared_residuals = _dsv4_mtp_moe_split_input_branches(
+            hidden_states, self.is_mtp_layer, self.layer_number
+        )
         (
             capacity,
             topk_weights,
@@ -961,7 +1013,7 @@ class MoELayer(nn.Layer):
             aux_loss,
             z_loss,
         ) = self.gate(
-            hidden_states,
+            gate_input,
             input_ids=input_ids,
         )
         # topk_weights, topk_indices: Shape is [seq_len, moe_router_topk]
@@ -969,8 +1021,7 @@ class MoELayer(nn.Layer):
         # mask (routing_map): binary selection matrix [seq_len, num_experts]
         # capacity, priorities are used for dropping tokens, currently they are not used
 
-        _log_moe_md5(probs, "probs", layer_idx)
-        _log_moe_md5(mask, "routing_mask", layer_idx)
+        layer_idx = getattr(self, "layer_number", None)
         if framework._dygraph_tracer()._has_grad:
             log_moe_losses(layer_idx, aux_loss=aux_loss, z_loss=z_loss)
 
@@ -982,14 +1033,14 @@ class MoELayer(nn.Layer):
         ):
             combine_overlap_handle = {
                 "fn": self.shared_experts,
-                "fn_args": (residuals,),
+                "fn_args": (shared_residuals,),
             }
         else:
             combine_overlap_handle = None
         if self.expert_model_parallel_size > 1:
             if self.moe_use_fusion_node:
                 output = self.fusion_moe_forward(
-                    hidden_states,
+                    routed_input,
                     probs,
                     mask,
                     combine_overlap_handle,
@@ -998,7 +1049,7 @@ class MoELayer(nn.Layer):
                 )
             else:
                 output = self.custom_forward(
-                    hidden_states,
+                    routed_input,
                     probs,
                     mask,
                     topk_weights=topk_weights,
@@ -1015,7 +1066,7 @@ class MoELayer(nn.Layer):
                 reshaped_input = self.fc1_latent_proj(reshaped_input)
             if self.moe_expert_fusion:
                 output = self._forward_single_card_grouped_gemm_moe(
-                    reshaped_input, mask, probs, topk_indices, topk_weights
+                    reshaped_input, mask, probs
                 )
             else:
                 output = self._forward_single_card_moe(
@@ -1024,8 +1075,6 @@ class MoELayer(nn.Layer):
             # Latent MoE: project back from latent space
             if self.use_latent_moe:
                 output = self.fc2_latent_proj(output)
-
-        _log_moe_md5(output, "moe_routed_output", layer_idx)
 
         if self.training and self.router_aux_loss_coef and aux_loss is not None:
             aux_loss = aux_loss * float(self.router_aux_loss_coef)
@@ -1039,11 +1088,11 @@ class MoELayer(nn.Layer):
             if combine_overlap_handle is not None:
                 shared_output = combine_overlap_handle["fn_out"][0]
             else:
-                shared_output = self.shared_experts(residuals)[0]
+                shared_output = self.shared_experts(shared_residuals)[0]
             output = output + shared_output
 
-        _log_moe_md5(output, "moe_final_output", layer_idx)
-
+        if dsv4_sequence_first_moe:
+            output = output.transpose([1, 0, 2]).contiguous()
         if self.expert_model_parallel_size <= 1 and self.sequence_parallel:
             output = ScatterOp.apply(output)
         return output, None  # None is bias
@@ -1109,8 +1158,6 @@ class MoELayer(nn.Layer):
         hidden_states: paddle.Tensor,
         routing_map: paddle.Tensor,
         probs: paddle.Tensor,
-        topk_indices: paddle.Tensor | None = None,
-        topk_weights: paddle.Tensor | None = None,
     ) -> paddle.Tensor:
         """
         Forward without expert parallelism
@@ -1133,14 +1180,69 @@ class MoELayer(nn.Layer):
             return indices, weights
 
         if self.using_sonic_moe:
-            use_fp8 = self.fp8 is not None
-            final_hidden_states = self.grouped_gemm_experts(
-                hidden_states,
-                topk_indices,
-                topk_weights,
-                use_fp8,
+            T = hidden_states.shape[0]
+            K = self.num_experts_per_tok
+            stream_id = paddle.device.cuda.current_stream().cuda_stream
+            selected_indices, topk_scores = _convert_routing_map_and_probs(
+                routing_map, probs, self.num_experts_per_tok
             )
-            return final_hidden_states.cast(hidden_states.dtype)
+            activation_type = ActivationType("swiglu")
+            expert_frequency, expert_frequency_offset = count_cumsum(
+                selected_indices, self.num_experts_per_device, do_cumsum=True
+            )
+
+            (
+                expert_frequency_offset,
+                x_gather_idx,
+                s_scatter_idx,
+                s_reverse_scatter_idx,
+                num_activated_expert_per_token_offset,
+            ) = fused_expert_parallel_TC_topk_router_metadata(
+                selected_indices,
+                expert_frequency_offset,
+                K,
+            )
+
+            s_scatter_idx.stop_gradient = True
+
+            w1 = self.grouped_gemm_experts.weight1
+
+            y1, z = _UpProjection.apply(
+                hidden_states,
+                w1.permute([1, 2, 0]),
+                None,
+                expert_frequency_offset,
+                T * K,
+                K,
+                stream_id,
+                x_gather_idx,
+                s_scatter_idx,
+                s_reverse_scatter_idx,
+                num_activated_expert_per_token_offset,
+                False,
+                activation_type,
+                is_inference_mode_enabled=False,
+            )
+
+            w2 = self.grouped_gemm_experts.weight2
+            hidden_states = _DownProjection.apply(
+                y1,
+                z,
+                w2.permute([1, 2, 0]),
+                None,
+                topk_scores,
+                expert_frequency_offset,
+                T,
+                K,
+                stream_id,
+                x_gather_idx,
+                s_scatter_idx,
+                s_reverse_scatter_idx,
+                num_activated_expert_per_token_offset,
+                False,
+                activation_type,
+            )
+            return hidden_states
         else:
             tokens_per_expert = routing_map.sum(axis=0)
             permuted_local_hidden_states, sorted_indices = permute(
@@ -1270,11 +1372,12 @@ class MoELayer(nn.Layer):
             return True
         return False
 
-    def set_layer_number(self, layer_number, is_mtp_layer: bool = False):
+    def set_layer_number(self, layer_number, is_mtp_layer=False):
         self.layer_number = layer_number
+        self.is_mtp_layer = is_mtp_layer
         assert hasattr(self.gate, "set_layer_number"), (
             "expect gate has method 'set_layer_number'"
         )
         # Hash routing activation (moe_n_hash_layers) is decided by the router
         # itself based on layer_number. See TopKRouter._setup_hash_layer.
-        self.gate.set_layer_number(layer_number, is_mtp_layer=is_mtp_layer)
+        self.gate.set_layer_number(layer_number, is_mtp_layer)

--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -16,7 +16,6 @@
 # limitations under the License.
 from __future__ import annotations
 
-import hashlib
 import logging
 import os
 from functools import partial
@@ -43,9 +42,6 @@ from paddlefleet.context_parallel_utils import (
 from paddlefleet.parallel_state import get_context_parallel_world_size
 from paddlefleet.transformer.moe.moe_utils import apply_random_logits
 
-# MD5 logging for MoE router precision debugging
-_LOG_LAYER_MD5 = os.environ.get("LOG_LAYER_MD5", "0") == "1"
-
 # Lazy-loaded MoETopkFusion Triton kernel for bit-exact alignment
 _MoETopkFusion = None
 
@@ -62,25 +58,50 @@ def _get_moe_topk_fusion():
 _moe_router_logger = logging.getLogger(__name__)
 
 
-def _log_moe_md5(tensor, name, layer_idx=None):
-    """Log MD5 of a tensor for MoE precision alignment debugging."""
-    from paddlefleet.transformer.transformer_layer import TransformerLayer
+def _dsv4_router_torch_mm_enabled() -> bool:
+    return os.environ.get("DSV4_FLEET_ROUTER_TORCH_MM", "0") == "1"
 
-    if _LOG_LAYER_MD5 and TransformerLayer._gpt_model_use_experimental_version:
-        if TransformerLayer._skip_mtp_probes:
-            return  # Skip MTP passes — EC has no MTP
-        data = tensor.detach().cast("float32").numpy().tobytes()
-        md5 = hashlib.md5(data).hexdigest()
-        rank = (
-            paddle.distributed.get_rank()
-            if paddle.distributed.is_initialized()
-            else 0
-        )
-        layer_str = f" Layer={layer_idx}" if layer_idx is not None else ""
-        print(
-            f"[MD5 MoE] Rank={rank}{layer_str} {name} MD5={md5} shape={list(tensor.shape)}",
-            flush=True,
-        )
+
+def _dsv4_import_torch_for_router_mm():
+    import sys
+
+    torch_site_packages = os.environ.get("DSV4_FLEET_TE_SITE_PACKAGES")
+    if torch_site_packages and torch_site_packages not in sys.path:
+        sys.path.insert(0, torch_site_packages)
+    import torch
+    import torch.utils.dlpack
+
+    return torch
+
+
+def _dsv4_torch_gate_mm(x, weight):
+    torch = _dsv4_import_torch_for_router_mm()
+    x_t = torch.utils.dlpack.from_dlpack(
+        paddle.utils.dlpack.to_dlpack(x.detach().contiguous())
+    )
+    w_t = torch.utils.dlpack.from_dlpack(
+        paddle.utils.dlpack.to_dlpack(weight.detach().contiguous())
+    )
+    with torch.no_grad():
+        logits_t = torch.mm(x_t.float(), w_t.float().t())
+    return paddle.utils.dlpack.from_dlpack(
+        torch.utils.dlpack.to_dlpack(logits_t.contiguous())
+    )
+
+
+def _dsv4_router_fp32_wgrad_enabled() -> bool:
+    return os.environ.get("DSV4_FLEET_ROUTER_FP32_WGRAD", "0") == "1"
+
+
+def _dsv4_accumulate_router_fp32_wgrad(weight, w_grad):
+    if not _dsv4_router_fp32_wgrad_enabled() or w_grad is None:
+        return
+    w_grad = w_grad.detach().cast(paddle.float32)
+    prev = getattr(weight, "_dsv4_router_gate_fp32_wgrad", None)
+    if prev is None:
+        weight._dsv4_router_gate_fp32_wgrad = w_grad
+    else:
+        weight._dsv4_router_gate_fp32_wgrad = prev + w_grad
 
 
 class FusedGateDetachMatmul(paddle.autograd.PyLayer):
@@ -95,7 +116,10 @@ class FusedGateDetachMatmul(paddle.autograd.PyLayer):
         """
         ctx.dw_p2p_overlap = dw_p2p_overlap
         ctx.dtype = paddle.float32
+        ctx.weight_ref = w
         ctx.save_for_backward(x, w)
+        if _dsv4_router_torch_mm_enabled():
+            return _dsv4_torch_gate_mm(x, w)
         w = w.T
         return F.linear(x.cast(ctx.dtype), w.cast(ctx.dtype))
 
@@ -105,6 +129,7 @@ class FusedGateDetachMatmul(paddle.autograd.PyLayer):
         backward
         """
         x, w = ctx.saved_tensor()
+        weight_ref = getattr(ctx, "weight_ref", w)
         assert ctx.dtype == y_grad.dtype, "dtype not match"
 
         w_stop_grad = w.stop_gradient
@@ -112,9 +137,11 @@ class FusedGateDetachMatmul(paddle.autograd.PyLayer):
 
         def _compute_weight_grad(x_cast, y_grad, weight):
             with paddle.amp.auto_cast(False):
-                w_grad = paddle.matmul(
+                w_grad_fp32 = paddle.matmul(
                     x_cast, y_grad, transpose_x=True
                 ).T  # 始终先算梯度
+                _dsv4_accumulate_router_fp32_wgrad(weight, w_grad_fp32)
+                w_grad = w_grad_fp32.cast("bfloat16").cast(paddle.float32)
 
             if hasattr(weight, "main_grad"):
                 if weight.main_grad is None:
@@ -147,13 +174,14 @@ class FusedGateDetachMatmul(paddle.autograd.PyLayer):
                         _compute_weight_grad,
                         x_cast.detach(),
                         y_grad.detach(),
-                        w,
+                        weight_ref,
                     )
                 )
                 WeightGradStore.enabled = False
                 return x_grad, None
         else:
-            w = w.T
+            weight = weight_ref
+            w = weight.T
             x_g, w_g = matmul_grad(
                 x.cast(ctx.dtype),
                 w.cast(ctx.dtype),
@@ -163,9 +191,11 @@ class FusedGateDetachMatmul(paddle.autograd.PyLayer):
             )
 
             x_grad = x_g.cast(x.dtype) if not x_stop_grad else None
-            w_grad = w_g.cast(w.dtype) if not w_stop_grad else None
-            if w_grad is not None:
-                w_grad = w_grad.T
+            w_grad = None
+            if not w_stop_grad:
+                w_grad_fp32 = w_g.T
+                _dsv4_accumulate_router_fp32_wgrad(weight, w_grad_fp32)
+                w_grad = w_grad_fp32.cast("bfloat16").cast(weight.dtype)
 
             return x_grad, w_grad
 
@@ -222,9 +252,6 @@ class StandardMoERouter(nn.Layer):
         self.topk_method = config.topk_method
         self.num_experts_per_tok = config.num_experts_per_tok
         self.norm_topk_prob = config.norm_topk_prob
-        # force keep in float32 when using amp
-        self._cast_to_low_precision = False
-
         self.n_group = config.n_group
 
         self.topk_group = config.topk_group
@@ -250,7 +277,7 @@ class StandardMoERouter(nn.Layer):
         # Initialize gate weight with Normal distribution aligned with Megatron.
         self.weight = paddle.create_parameter(
             shape=[self.num_experts, self.hidden_size],
-            dtype="float32",
+            dtype=config.params_dtype or "float32",
             default_initializer=paddle.nn.initializer.Constant(0.0),
         )
         config.init_method(self.weight)
@@ -265,16 +292,10 @@ class StandardMoERouter(nn.Layer):
             )
 
         if self.topk_method == "noaux_tc":
-            if not self.config.gpt_model_use_experimental_version:
-                self.register_buffer(
-                    "e_score_correction_bias",
-                    paddle.zeros((self.num_experts,), dtype=paddle.float32),
-                )
-            else:
-                self.register_buffer(
-                    "e_score_correction_bias",
-                    paddle.zeros((1, self.num_experts), dtype=paddle.float32),
-                )
+            self.register_buffer(
+                "e_score_correction_bias",
+                paddle.zeros((self.num_experts,), dtype=paddle.float32),
+            )
             self._cast_to_low_precision = False
             self.expert_usage = paddle.zeros(
                 shape=[self.num_experts],
@@ -718,15 +739,9 @@ class StandardMoERouter(nn.Layer):
         assert self.e_score_correction_bias is not None, (
             "e_score_correction_bias is None"
         )
-        if not self.config.gpt_model_use_experimental_version:
-            scores_for_choice = scores.reshape(
-                [bsz_seq_len, -1]
-            ) + self.e_score_correction_bias.detach().unsqueeze(0)
-        else:
-            scores_for_choice = (
-                scores.reshape([bsz_seq_len, -1])
-                + self.e_score_correction_bias.detach()
-            )
+        scores_for_choice = scores.reshape(
+            [bsz_seq_len, -1]
+        ) + self.e_score_correction_bias.detach().unsqueeze(0)
         if n_group == 1:
             topk_weight, topk_idx = paddle.topk(
                 scores_for_choice, k=k, axis=-1, sorted=True
@@ -793,13 +808,11 @@ class StandardMoERouter(nn.Layer):
             scores = F.softmax(logits_fp32, axis=-1).cast(orig_dtype)
         elif score_function == "sigmoid":
             scores = F.sigmoid(logits_fp32).cast(orig_dtype)
-        elif score_function == "sqrtsoftplus":
+        else:
+            # _setup_hash_layer guarantees scoring_func is one of
+            # {softmax, sigmoid, sqrtsoftplus}, so this is sqrtsoftplus.
             scores = paddle.sqrt(F.softplus(logits_fp32) + 1e-20).cast(
                 orig_dtype
-            )
-        else:
-            raise ValueError(
-                f"Unsupported scoring_func in hash routing: {score_function!r}"
             )
 
         top_idx = self.tid2eid[flat_ids].cast(paddle.int64)  # [N, topk]
@@ -847,6 +860,7 @@ class StandardMoERouter(nn.Layer):
 
     def set_layer_number(self, layer_number, is_mtp_layer: bool = False):
         self.layer_number = layer_number
+        self.is_mtp_layer = is_mtp_layer
         self._setup_hash_layer(layer_number, is_mtp_layer)
 
     def _setup_hash_layer(self, layer_number, is_mtp_layer: bool = False):
@@ -926,6 +940,7 @@ class TopKRouter(StandardMoERouter):
     def set_layer_number(self, layer_number, is_mtp_layer: bool = False):
         self._layer_number = layer_number
         self.layer_number = layer_number
+        self.is_mtp_layer = is_mtp_layer
         self._setup_hash_layer(layer_number, is_mtp_layer=is_mtp_layer)
 
     def forward(self, input, input_ids=None):
@@ -946,18 +961,15 @@ class TopKRouter(StandardMoERouter):
                     input_ids, axis=1, mode=self.config.cp_balance_mode
                 )
             if input_ids is not None:
-                if self.sequence_parallel:
-                    input_ids_none_zero_mask = (
-                        (input_ids != 0).transpose([1, 0]).reshape([-1, 1])
-                    )
-                else:
-                    input_ids_none_zero_mask = (input_ids != 0).reshape([-1, 1])
+                input_ids_none_zero_mask = (input_ids != 0).reshape([-1, 1])
                 batch_size_, seq_len_ = input_ids.shape
                 assert (batch_size_ == batch_size) and (seq_len_ == seq_len), (
                     f"input_ids shape mismatch with input: "
                     f"input_ids=[{batch_size_}, {seq_len_}], "
                     f"expected [batch_size={batch_size}, seq_len={seq_len}]"
                 )
+                if self.is_mtp_layer:
+                    input_ids_none_zero_mask = None
             else:
                 input_ids_none_zero_mask = None
         elif len(input.shape) == 2:
@@ -982,8 +994,6 @@ class TopKRouter(StandardMoERouter):
                 getattr(self.config, "dw_p2p_overlap", False),
             )
 
-        _log_moe_md5(logits, "gate_logits", self._layer_number)
-
         # ---- Hash routing branch ----
         if self.is_hash_layer:
             if self.sequence_parallel:
@@ -1003,7 +1013,6 @@ class TopKRouter(StandardMoERouter):
 
             # Apply padding (input_ids == 0):
             # routing_map = routing_map & ~padding_mask.
-            # input_ids_none_zero_mask shape: [N, 1], broadcast over expert/topk dim.
             if input_ids_none_zero_mask is not None:
                 valid_mask = input_ids_none_zero_mask.cast(mask.dtype)
                 mask = mask * valid_mask
@@ -1011,11 +1020,6 @@ class TopKRouter(StandardMoERouter):
                 top_gate = top_gate * valid_mask
                 top_idx = top_idx.masked_fill(~valid_mask.cast(paddle.bool), -1)
 
-            _log_moe_md5(
-                top_idx.cast(paddle.float32),
-                "hash_topk_indices",
-                self._layer_number,
-            )
             # No aux/z loss, no expert-bias updates on hash layers.
             return (None, top_gate, top_idx, probs, mask, None, None, None)
         # ---- end hash routing ----
@@ -1030,8 +1034,6 @@ class TopKRouter(StandardMoERouter):
             )
             logits = logits * valid_mask
             gates = gates * valid_mask
-
-        _log_moe_md5(gates, "gate_probs_sigmoid", self._layer_number)
 
         # Use clone() to ensure that the execution order of the grad nodes is consistent with EC.
         gates_ori = gates.clone()
@@ -1055,21 +1057,9 @@ class TopKRouter(StandardMoERouter):
             # Triton's scalar loop and Paddle's tensor ops.
             MoETopkFusion = _get_moe_topk_fusion()
             use_node_limit = self.n_group > 1
-            if not self.config.gpt_model_use_experimental_version:
-                probs_for_choice = (
-                    gates + self.e_score_correction_bias.detach().unsqueeze(0)
-                )
-            else:
-                probs_for_choice = gates + self.e_score_correction_bias.detach()
-            if _LOG_LAYER_MD5 and self._layer_number == 0:
-                _log_moe_md5(
-                    self.e_score_correction_bias,
-                    "e_score_correction_bias",
-                    self._layer_number,
-                )
-                _log_moe_md5(
-                    probs_for_choice, "probs_for_choice", self._layer_number
-                )
+            probs_for_choice = (
+                gates + self.e_score_correction_bias.detach().unsqueeze(0)
+            )
             top_gate, top_idx = MoETopkFusion.apply(
                 gates,  # gate_probs (original sigmoid scores)
                 probs_for_choice,  # probs_for_choice (with correction bias)
@@ -1081,19 +1071,6 @@ class TopKRouter(StandardMoERouter):
             )
             # top_gate is already normalized by the Triton kernel when norm_topk_prob=True
 
-            _log_moe_md5(
-                top_idx.cast("float32"), "topk_indices", self._layer_number
-            )
-            # Log raw weights and sum for alignment verification (re-computed from gate_probs)
-            if _LOG_LAYER_MD5:
-                raw_topk_weights = paddle.take_along_axis(
-                    gates, top_idx, axis=-1
-                )
-                _log_moe_md5(
-                    raw_topk_weights, "topk_weights_raw", self._layer_number
-                )
-                raw_sum = raw_topk_weights.sum(axis=-1, keepdim=True)
-                _log_moe_md5(raw_sum, "topk_raw_sum", self._layer_number)
         else:
             # top_gate: [B*S, K], top_idx: [B*S, K]
             top_gate, top_idx = self._call_topk_method(
@@ -1103,11 +1080,6 @@ class TopKRouter(StandardMoERouter):
                 n_group=self.n_group,
                 topk_group=self.topk_group,
             )
-
-            _log_moe_md5(
-                top_idx.cast("float32"), "topk_indices", self._layer_number
-            )
-            _log_moe_md5(top_gate, "topk_weights_raw", self._layer_number)
 
         # z-loss
         if self.config.router_z_loss_coef:
@@ -1157,9 +1129,6 @@ class TopKRouter(StandardMoERouter):
         probs = paddle.zeros_like(gates, dtype=top_gate.dtype).put_along_axis_(
             top_idx, top_gate, axis=1
         )
-
-        _log_moe_md5(probs, "probs", self._layer_number)
-        _log_moe_md5(top_gate, "topk_weights_normed", self._layer_number)
 
         if self.topk_method == "noaux_tc":
             with paddle.no_grad():

--- a/src/paddlefleet/transformer/moe/moe_utils.py
+++ b/src/paddlefleet/transformer/moe/moe_utils.py
@@ -45,22 +45,15 @@ if TYPE_CHECKING:
     from paddle.distributed.communication.group import Group
 
 
-_USE_ACCURACY_COMPATIBLE_KERNEL = (
-    os.environ.get("FLAGS_use_accuracy_compatible_kernel", "0") == "1"
-)
+def _dsv4_fleet_moe_fp32_accum_enabled() -> bool:
+    return os.environ.get("DSV4_FLEET_MOE_FP32_ACCUM", "0") == "1"
 
 
-def use_accuracy_compatible_kernel() -> bool:
-    """Unified switch for accuracy-compatible (Megatron-aligned) numeric paths.
-
-    Controlled via the ``FLAGS_use_accuracy_compatible_kernel`` environment
-    variable. When enabled, modules switch to fp32-accumulating / Torch-aligned
-    kernels at the cost of throughput.
-    """
-    return _USE_ACCURACY_COMPATIBLE_KERNEL
+def _dsv4_probs_mul_custom_bwd_enabled() -> bool:
+    return os.environ.get("DSV4_FLEET_PROBS_MUL_CUSTOM_BWD", "0") == "1"
 
 
-def _unpermute_scatter(
+def _dsv4_unpermute_scatter(
     permuted_tokens: paddle.Tensor, sorted_indices: paddle.Tensor, restore_shape
 ) -> paddle.Tensor:
     output_tokens = paddle.zeros(restore_shape, dtype=permuted_tokens.dtype)
@@ -70,7 +63,7 @@ def _unpermute_scatter(
     return output_tokens
 
 
-def _unpermute_fp32_accum(
+def _dsv4_unpermute_fp32_accum(
     permuted_tokens: paddle.Tensor, sorted_indices: paddle.Tensor, restore_shape
 ) -> paddle.Tensor:
     output_tokens = paddle.zeros(restore_shape, dtype="float32")
@@ -82,9 +75,7 @@ def _unpermute_fp32_accum(
     return output_tokens.cast(permuted_tokens.dtype)
 
 
-class ApplyPermutedProbs(PyLayer):
-    """tokens * probs with fp32-accumulated probs gradient."""
-
+class _DSV4ApplyPermutedProbs(PyLayer):
     @staticmethod
     def forward(ctx, permuted_tokens, permuted_probs):
         ctx.input_dtype = permuted_tokens.dtype
@@ -98,9 +89,7 @@ class ApplyPermutedProbs(PyLayer):
         grad_probs = (
             permuted_tokens.cast("float32") * grad_output.cast("float32")
         ).sum(axis=-1)
-        return grad_tokens.cast(ctx.input_dtype), grad_probs.cast(
-            permuted_probs.dtype
-        )
+        return grad_tokens.cast(ctx.input_dtype), grad_probs.cast(permuted_probs.dtype)
 
 
 def barrier_ep(ep_group):
@@ -141,7 +130,12 @@ def permute(
     sorted_indices = token_indices.masked_select(routing_map)
 
     # use the mapping to permute the tokens
-    permuted_input = tokens.index_select(axis=0, index=sorted_indices)
+    if _dsv4_fleet_moe_fp32_accum_enabled():
+        permuted_input = tokens.cast("float32").index_select(
+            axis=0, index=sorted_indices
+        ).cast(tokens.dtype)
+    else:
+        permuted_input = tokens.index_select(axis=0, index=sorted_indices)
 
     return permuted_input, sorted_indices
 
@@ -180,19 +174,19 @@ def unpermute(
         permuted_probs = probs.T.contiguous().masked_select(
             routing_map.T.contiguous().cast(paddle.bool)
         )
-        if use_accuracy_compatible_kernel():
-            permuted_tokens = ApplyPermutedProbs.apply(
+        if _dsv4_probs_mul_custom_bwd_enabled():
+            permuted_tokens = _DSV4ApplyPermutedProbs.apply(
                 permuted_tokens, permuted_probs
             )
         else:
             permuted_tokens = permuted_tokens * permuted_probs.unsqueeze(-1)
 
-    if use_accuracy_compatible_kernel():
-        output_tokens = _unpermute_fp32_accum(
+    if _dsv4_fleet_moe_fp32_accum_enabled():
+        output_tokens = _dsv4_unpermute_fp32_accum(
             permuted_tokens, sorted_indices, restore_shape
         )
     else:
-        output_tokens = _unpermute_scatter(
+        output_tokens = _dsv4_unpermute_scatter(
             permuted_tokens, sorted_indices, restore_shape
         )
 

--- a/src/paddlefleet/transformer/moe/token_dispatcher.py
+++ b/src/paddlefleet/transformer/moe/token_dispatcher.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 from __future__ import annotations
 
+import os
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
@@ -40,21 +41,23 @@ from .moe_utils import (
     permute,
     sort_chunks_by_idxs,
     unpermute,
-    use_accuracy_compatible_kernel,
 )
 
 HAVE_HYBRID_EP = False
 HYBRID_EP_LOAD_CACHED_KERNELS = True
 
 
+def _dsv4_expert_scale_before_down_enabled() -> bool:
+    return os.environ.get("DSV4_FLEET_EXPERT_SCALE_BEFORE_DOWN", "0") == "1"
+
+
 def _sort_chunks_like_tokens(
     input: paddle.Tensor,
-    split_sizes: list[int],
-    sorted_idxs: list[int],
+    split_sizes: paddle.Tensor,
+    sorted_idxs: paddle.Tensor,
 ) -> paddle.Tensor:
-    chunks = paddle.split(input, split_sizes, axis=0)
-    return paddle.concat([chunks[i] for i in sorted_idxs], axis=0)
-
+    chunks = paddle.split(input, split_sizes.tolist(), axis=0)
+    return paddle.cat([chunks[i] for i in sorted_idxs.tolist()], axis=0)
 
 try:
     from paddlefleet_ops import is_hybrid_ep_available
@@ -485,6 +488,7 @@ class _DeepEPManager(_DispatchManager):
         self.token_probs = None
         # Handle used for combine operation
         self.handle = None
+        self.global_input_probs = None
 
         if fused_dispatch is None:
             raise ImportError(
@@ -536,6 +540,7 @@ class _DeepEPManager(_DispatchManager):
         self.tokens_per_expert = states["tokens_per_expert"]
         self.dispatched_indices = states["dispatched_indices"]
         self.dispatched_probs = dispatched_probs
+        self.global_input_probs = None
 
         return hidden_states, scale
 
@@ -561,6 +566,7 @@ class _DeepEPManager(_DispatchManager):
         self.tokens_per_expert = states["tokens_per_expert"]
         self.dispatched_indices = states["dispatched_indices"]
         self.dispatched_probs = dispatched_probs
+        self.global_input_probs = None
 
         return hidden_states, scale
 
@@ -578,21 +584,17 @@ class _DeepEPManager(_DispatchManager):
                 - probs: Multihot probabilities.
         """
         batch_size = indices.shape[0]
-        multihot_routing_map = paddle.zeros(
-            (batch_size, self.num_local_experts), dtype=paddle.int64
-        )
-
-        multihot_probs = paddle.zeros(
-            (batch_size, self.num_local_experts), dtype=paddle.float32
-        )
-
         mask = indices != -1
-        valid_indices = indices[mask]
-        row_indices = paddle.arange(batch_size).repeat_interleave(
-            mask.sum(axis=1)
+        safe_indices = paddle.where(mask, indices, paddle.zeros_like(indices))
+        one_hot = paddle.nn.functional.one_hot(
+            safe_indices.astype("int64"), num_classes=self.num_local_experts
         )
-        multihot_routing_map[row_indices, valid_indices] = 1
-        multihot_probs[row_indices, valid_indices] = probs[mask]
+        valid = mask.astype(one_hot.dtype).unsqueeze(-1)
+        one_hot = one_hot * valid
+        multihot_routing_map = paddle.sum(one_hot, axis=1)
+        multihot_probs = paddle.sum(
+            one_hot.astype(probs.dtype) * probs.unsqueeze(-1), axis=1
+        ).astype("float32")
         return multihot_routing_map.cast(paddle.bool), multihot_probs
 
     def get_dispatched_metadata(self) -> paddle.Tensor:
@@ -643,6 +645,14 @@ class _DeepEPManager(_DispatchManager):
                 self.dispatched_indices, self.dispatched_probs
             )
         )
+        if _dsv4_expert_scale_before_down_enabled():
+            self.global_input_probs = (
+                self.dispatched_probs.T.contiguous().masked_select(
+                    self.dispatched_routing_map.T.contiguous().cast(
+                        paddle.bool
+                    )
+                )
+            )
         self.hidden_shape_before_permute = hidden_states.shape
         hidden_states, self.reversed_mapping_for_combine = permute(
             hidden_states,
@@ -663,7 +673,11 @@ class _DeepEPManager(_DispatchManager):
             self.reversed_mapping_for_combine,
             restore_shape=self.hidden_shape_before_permute,
             routing_map=self.dispatched_routing_map,
-            probs=self.dispatched_probs,
+            probs=(
+                None
+                if _dsv4_expert_scale_before_down_enabled()
+                else self.dispatched_probs
+            ),
         )
         return hidden_states.to(input_dtype)
 
@@ -758,6 +772,7 @@ class MoEFlexTokenDispatcher(MoETokenDispatcher):
         if manager_cls is _HybridEPManager:
             manager_kwargs["hybridep_buffer_configs"] = hybridep_buffer_configs
         self._comm_manager = manager_cls(**manager_kwargs)
+        self.global_input_probs = None
 
     def dispatch_preprocess(
         self,
@@ -768,6 +783,7 @@ class MoEFlexTokenDispatcher(MoETokenDispatcher):
         topk_indices: paddle.Tensor | None = None,
     ):
         self.hidden_shape = hidden_states.shape
+        self.global_input_probs = None
         hidden_states = hidden_states.view([-1, self.hidden_shape[-1]])
         self._comm_manager.setup_metadata(
             routing_map, probs, topk_weights, topk_indices
@@ -781,6 +797,7 @@ class MoEFlexTokenDispatcher(MoETokenDispatcher):
         token_indices: paddle.Tensor,
     ):
         self.hidden_shape = hidden_states.shape
+        self.global_input_probs = None
         hidden_states = hidden_states.view([-1, self.hidden_shape[-1]])
         self._comm_manager.routing_map = None
         self._comm_manager.routing_probs = None
@@ -826,6 +843,9 @@ class MoEFlexTokenDispatcher(MoETokenDispatcher):
                 hidden_states
             )
         )
+        self.global_input_probs = getattr(
+            self._comm_manager, "global_input_probs", None
+        )
         tokens_per_expert = self._comm_manager.get_number_of_tokens_per_expert()
 
         return global_input_tokens, tokens_per_expert
@@ -862,6 +882,9 @@ class MoEFlexTokenDispatcher(MoETokenDispatcher):
             self._comm_manager.get_permuted_hidden_states_by_experts(
                 hidden_states
             )
+        )
+        self.global_input_probs = getattr(
+            self._comm_manager, "global_input_probs", None
         )
         tokens_per_expert = self._comm_manager.get_number_of_tokens_per_expert()
 
@@ -977,14 +1000,13 @@ class AllToAllTokenDispatcher(nn.Layer):
             permutated_local_input_tokens,
             self.reversed_local_input_permutation_mapping,
         ) = permute(reshaped_input, self.routing_map)
-        if use_accuracy_compatible_kernel():
-            num_routed_tokens = int(tokens_per_expert.sum().item())
+        if _dsv4_expert_scale_before_down_enabled():
             routing_map = self.routing_map.cast(paddle.bool).T.contiguous()
             flat_sorted = paddle.argsort(
                 routing_map.reshape([-1]).cast("int32"),
                 descending=True,
                 stable=True,
-            )[:num_routed_tokens]
+            )[: int(tokens_per_expert.sum().item())]
             self.permuted_local_probs = paddle.index_select(
                 self.probs.T.contiguous().reshape([-1]),
                 flat_sorted,
@@ -1011,7 +1033,7 @@ class AllToAllTokenDispatcher(nn.Layer):
             in_split_sizes=self.input_split_sizes,
             group=self.moe_group,
         )
-        if use_accuracy_compatible_kernel():
+        if _dsv4_expert_scale_before_down_enabled():
             # Match Megatron's all-to-all backward numerics by routing probs through a
             # 2D [tokens, 1] tensor, like hidden-state dispatch.
             global_input_probs_2d = _AllToAll.apply(
@@ -1040,20 +1062,16 @@ class AllToAllTokenDispatcher(nn.Layer):
         ).T.ravel()
 
         if self.num_local_experts > 1 and not self.is_empty_tokens:
-            split_sizes_list = (
-                self.num_global_tokens_per_local_expert.ravel().tolist()
-            )
-            sorted_idxs_list = self.sort_input_by_local_experts.tolist()
             global_input_tokens, _ = sort_chunks_by_idxs(
                 global_input_tokens,
                 self.num_global_tokens_per_local_expert.ravel(),
                 self.sort_input_by_local_experts,
             )
-            if use_accuracy_compatible_kernel():
+            if _dsv4_expert_scale_before_down_enabled():
                 self.global_input_probs = _sort_chunks_like_tokens(
                     self.global_input_probs,
-                    split_sizes_list,
-                    sorted_idxs_list,
+                    self.num_global_tokens_per_local_expert.ravel(),
+                    self.sort_input_by_local_experts,
                 )
         sorted_tokens = global_input_tokens
         self.tokens_per_expert_post_gather = self.tokens_per_expert
@@ -1088,7 +1106,11 @@ class AllToAllTokenDispatcher(nn.Layer):
             permutated_local_input_tokens,
             self.reversed_local_input_permutation_mapping,
             restore_shape=self.reshaped_input_shape,
-            probs=(None if use_accuracy_compatible_kernel() else self.probs),
+            probs=(
+                None
+                if _dsv4_expert_scale_before_down_enabled()
+                else self.probs
+            ),
             routing_map=self.routing_map,
         )
 

--- a/src/paddlefleet/transformer/multi_token_prediction.py
+++ b/src/paddlefleet/transformer/multi_token_prediction.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+import os
 import warnings
 from contextlib import nullcontext
 from dataclasses import dataclass
@@ -28,9 +29,6 @@ from paddle.distributed.fleet.meta_parallel import (
     build_spec_layer,
 )
 from paddle.distributed.fleet.utils import recompute
-from paddle.distributed.fleet.utils.sequence_parallel_utils import (
-    ScatterOp,
-)
 
 from paddlefleet import tensor_parallel
 from paddlefleet.context_parallel_utils import ContextParallelScatterOp
@@ -42,9 +40,9 @@ from paddlefleet.tensor_parallel.mappings import (
     gather_from_tensor_model_parallel_region,
     scatter_to_sequence_parallel_region,
 )
-from paddlefleet.tensor_parallel.random import get_cuda_rng_tracker
 from paddlefleet.transformer.enums import AttnMaskType
 from paddlefleet.transformer.layer import FleetLayer
+from paddlefleet.utils import dsv4_sequence_first_feature_enabled
 
 if TYPE_CHECKING:
     from paddlefleet.models.backends import BackendSpecProvider
@@ -57,6 +55,12 @@ SUPPORTED_ATTN_MASK = [
     AttnMaskType.no_mask,
     AttnMaskType.padding_causal,
 ]
+
+
+def _dsv4_mtp_tensor_md5(tensor: Tensor) -> str:
+    import hashlib
+
+    return hashlib.md5(tensor.cast("float32").numpy().tobytes()).hexdigest()
 
 
 class MTPLossLoggingHelper:
@@ -360,15 +364,8 @@ class MultiTokenPredictionLayer(FleetLayer):
             self.hc_head_fn = self.create_parameter(
                 shape=[hc_dim, n],
                 dtype=self.config.params_dtype,
-                default_initializer=nn.initializer.Constant(0.0),
+                default_initializer=nn.initializer.XavierUniform(),
             )
-            # Use model-parallel RNG tracker for Xavier init so that the
-            # initialization is independent of pipeline layer_index.
-            if paddle.distributed.get_world_size() <= 1:
-                nn.initializer.XavierUniform()(self.hc_head_fn)
-            else:
-                with get_cuda_rng_tracker().fork():
-                    nn.initializer.XavierUniform()(self.hc_head_fn)
             self.hc_head_base = self.create_parameter(
                 shape=[n],
                 dtype=self.config.params_dtype,
@@ -390,9 +387,6 @@ class MultiTokenPredictionLayer(FleetLayer):
             # so the input's shape is [s, b, 2*h].
             # The output will be sent to the following transformer layer,
             # so the output's shape should be [s, b, h].
-            use_bias = False
-            if self.config.gpt_model_use_experimental_version:
-                use_bias = self.config.use_bias
             self.eh_proj = build_spec_layer(
                 self.sublayers_spec.eh_proj,
                 self.config.hidden_size * 2,
@@ -400,7 +394,7 @@ class MultiTokenPredictionLayer(FleetLayer):
                 config=self.config,
                 init_method=self.config.init_method,
                 gather_output=False,
-                bias=use_bias,
+                bias=False,
                 skip_bias_add=False,
                 is_expert=False,
             )
@@ -410,7 +404,6 @@ class MultiTokenPredictionLayer(FleetLayer):
         self.transformer_layer = build_spec_layer(
             self.sublayers_spec.transformer_layer,
             config=self.config,
-            is_mtp_layer=True,
         )
         if not self.config.gpt_model_use_experimental_version:
             self.norm = build_spec_layer(
@@ -448,7 +441,6 @@ class MultiTokenPredictionLayer(FleetLayer):
 
             # Apply mask if needed
             if mtp_hidden_inputs_mask is not None:
-                # [B, 1, S] -> [B, S, 1]
                 mtp_hidden_inputs_mask = mtp_hidden_inputs_mask.transpose(
                     [0, 2, 1]
                 ).astype(hs_streams.dtype)
@@ -461,31 +453,36 @@ class MultiTokenPredictionLayer(FleetLayer):
                         axis=1,
                         mode=self.config.cp_balance_mode,
                     )
-                # when sp enable
-                if self.sequence_parallel:
-                    # [B, S/CP, 1] -> [S/CP, B, 1]
-                    mtp_hidden_inputs_mask = mtp_hidden_inputs_mask.transpose(
-                        [1, 0, 2]
-                    )
-                    # [S/CP, B, 1] -> [S/CP/TP, B, 1]
-                    mtp_hidden_inputs_mask = (
-                        scatter_to_sequence_parallel_region(
-                            mtp_hidden_inputs_mask
-                        )
-                    )
                 hs_streams = hs_streams * mtp_hidden_inputs_mask.unsqueeze(-1)
 
             # e_proj: [.., h] -> [.., h/tp]
             e_out, _ = self.e_proj(decoder_input)
-            # h_proj: applied per-stream [.., n, h] -> [.., n, h/tp]
-            # 这里hs_streams是4D tensor: [b,s,n,h]会导致算梯度的时候调用.t()报错，必须reshape到更低维度
-            orig_shape = list(hs_streams.shape)  # [s/sp, b, n, h]
-            if self.tensor_parallel > 1 and self.sequence_parallel:
-                # [s/sp, b, n, h] --> [s, b, n, h]
-                orig_shape[0] = orig_shape[0] * self.tensor_parallel
-            hs_flat = hs_streams.reshape([-1, orig_shape[-1]])  # [s/sp*b*n, h]
-            h_out, _ = self.h_proj(hs_flat)  # [s*b*n, h/tp]
-            h_out = h_out.reshape([*orig_shape[:-1], -1])  # [s, b, n, h/tp]
+            # h_proj: applied per-stream [.., n, h] -> [.., n, h/tp].
+            # For mbs>1 Paddle reaches this point as [B, S, N, H], while
+            # Megatron flattens [S, B, N, H] for the weight-gradient GEMM.
+            # The transpose is forward-equivalent but aligns the wgrad
+            # accumulation order.
+            if (
+                dsv4_sequence_first_feature_enabled(
+                    "DSV4_FLEET_MTP_H_PROJ_SEQUENCE_FIRST_LINEAR"
+                )
+                and hs_streams.ndim == 4
+                and hs_streams.shape[0] > 1
+                and hs_streams.shape[0] < hs_streams.shape[1]
+            ):
+                orig_shape = hs_streams.shape
+                hs_seqfirst = hs_streams.transpose([1, 0, 2, 3]).contiguous()
+                seqfirst_shape = hs_seqfirst.shape
+                hs_flat = hs_seqfirst.reshape([-1, seqfirst_shape[-1]])
+                h_out, _ = self.h_proj(hs_flat)
+                h_out = h_out.reshape([*seqfirst_shape[:-1], -1])
+                h_out = h_out.transpose([1, 0, 2, 3]).contiguous()
+            else:
+                # hs_streams is 4D, so flatten before ColumnParallelLinear.
+                orig_shape = hs_streams.shape
+                hs_flat = hs_streams.reshape([-1, orig_shape[-1]])
+                h_out, _ = self.h_proj(hs_flat)
+                h_out = h_out.reshape([*orig_shape[:-1], -1])
             # Broadcast add before gather (saves one all-gather vs gathering separately)
             hidden_states = e_out.unsqueeze(-2) + h_out
             if self.tensor_parallel > 1:
@@ -525,17 +522,6 @@ class MultiTokenPredictionLayer(FleetLayer):
                         mode=self.config.cp_balance_mode,
                     )
 
-                # when sp enable
-                if self.sequence_parallel:
-                    # [B, S/CP, 1] -> [S/CP, B, 1]
-                    mtp_hidden_inputs_mask = mtp_hidden_inputs_mask.transpose(
-                        [1, 0, 2]
-                    )
-                    mtp_hidden_inputs_mask = (
-                        scatter_to_sequence_parallel_region(
-                            mtp_hidden_inputs_mask
-                        )
-                    )
                 hidden_states = hidden_states * mtp_hidden_inputs_mask
             # At the (k - 1)-th MTP layer, concatenates the i-th token's hidden_states
             # and the (i + K)-th token's embedding, and combine them with linear projection.
@@ -572,7 +558,6 @@ class MultiTokenPredictionLayer(FleetLayer):
         attn_mask_startend_row_indices: paddle.Tensor | None = None,
         mtp_hidden_inputs_mask: paddle.Tensor | None = None,
         input_ids: paddle.Tensor | None = None,
-        position_ids: paddle.Tensor | None = None,
         **kwargs,
     ) -> paddle.Tensor:
         """
@@ -601,7 +586,6 @@ class MultiTokenPredictionLayer(FleetLayer):
                 "attn_mask_startend_row_indices": attn_mask_startend_row_indices,
                 "is_mtp": True,
                 "input_ids": input_ids,
-                "position_ids": position_ids,
             }
             rst_dict = self.transformer_layer(input_dict)
 
@@ -699,7 +683,6 @@ class MultiTokenPredictionLayer(FleetLayer):
                 if mtp_hidden_inputs_mask is not None
                 else None,
                 input_ids=input_ids if input_ids is not None else None,
-                position_ids=position_ids if position_ids is not None else None,
             )
 
         if self.config.recompute_method == "uniform":

--- a/src/paddlefleet/transformer/paddle_norm.py
+++ b/src/paddlefleet/transformer/paddle_norm.py
@@ -36,11 +36,46 @@ except ImportError:
 from paddle.distributed.fleet.meta_parallel import ScheduleNode
 
 from paddlefleet.jit import jit_fuser
+from paddlefleet.utils import dsv4_sequence_first_feature_enabled
 
 if TYPE_CHECKING:
     from paddle import Tensor
 
     from paddlefleet.transformer import TransformerConfig
+
+
+def _dsv4_sequence_first_rmsnorm_enabled() -> bool:
+    return dsv4_sequence_first_feature_enabled(
+        "DSV4_FLEET_SEQUENCE_FIRST_RMSNORM"
+    )
+
+
+def _dsv4_should_use_sequence_first_rmsnorm(hidden_states: paddle.Tensor) -> bool:
+    return (
+        _dsv4_sequence_first_rmsnorm_enabled()
+        and hidden_states.ndim in (3, 4)
+        and hidden_states.shape[0] > 1
+        and (hidden_states.ndim == 3 or hidden_states.shape[0] < hidden_states.shape[1])
+    )
+
+
+def _dsv4_sequence_first_rmsnorm_axes(hidden_states: paddle.Tensor) -> list[int]:
+    if hidden_states.ndim == 4:
+        return [1, 0, 2, 3]
+    return [1, 0, 2]
+
+
+def _dsv4_restore_batch_first_rmsnorm_output(
+    rms_norm_out: paddle.Tensor | tuple | list, use_sequence_first: bool, weight_dtype
+) -> paddle.Tensor:
+    if isinstance(rms_norm_out, (tuple, list)):
+        output = rms_norm_out[0]
+    else:
+        output = rms_norm_out
+    output = output.astype(weight_dtype)
+    if use_sequence_first:
+        output = output.transpose(_dsv4_sequence_first_rmsnorm_axes(output)).contiguous()
+    return output
 
 
 class RMSNorm(paddle.nn.Layer):
@@ -73,19 +108,23 @@ class RMSNorm(paddle.nn.Layer):
             self.enable_sequence_parallel()
 
     def forward(self, hidden_states: Tensor):
-        # Ensure hidden_states dtype matches weight dtype for rms_norm
-        if hidden_states.dtype != self.weight.dtype:
-            hidden_states = hidden_states.astype(self.weight.dtype)
+        use_sequence_first = _dsv4_should_use_sequence_first_rmsnorm(
+            hidden_states
+        )
+        norm_input = (
+            hidden_states.transpose(_dsv4_sequence_first_rmsnorm_axes(hidden_states)).contiguous()
+            if use_sequence_first
+            else hidden_states
+        )
         rms_norm_out = rms_norm(
-            hidden_states,
-            hidden_states.shape[-1:],
+            norm_input,
+            norm_input.shape[-1:],
             self.weight,
             self.variance_epsilon,
         )
-        if isinstance(rms_norm_out, (tuple, list)):
-            return rms_norm_out[0].astype(self.weight.dtype)
-        else:
-            return rms_norm_out.astype(self.weight.dtype)
+        return _dsv4_restore_batch_first_rmsnorm_output(
+            rms_norm_out, use_sequence_first, self.weight.dtype
+        )
 
     def enable_sequence_parallel(self):
         mark_as_sequence_parallel_parameter(self.weight)
@@ -143,16 +182,23 @@ class LayerNorm(paddle.nn.Layer):
 
 class FusedRMSNorm(RMSNorm):
     def forward(self, hidden_states: Tensor):
+        use_sequence_first = _dsv4_should_use_sequence_first_rmsnorm(
+            hidden_states
+        )
+        norm_input = (
+            hidden_states.transpose(_dsv4_sequence_first_rmsnorm_axes(hidden_states)).contiguous()
+            if use_sequence_first
+            else hidden_states
+        )
         rms_norm_out = rms_norm(
-            hidden_states,
-            hidden_states.shape[-1:],
+            norm_input,
+            norm_input.shape[-1:],
             self.weight,
             self.variance_epsilon,
         )
-        if isinstance(rms_norm_out, (tuple, list)):
-            return rms_norm_out[0].astype(self.weight.dtype)
-        else:
-            return rms_norm_out.astype(self.weight.dtype)
+        return _dsv4_restore_batch_first_rmsnorm_output(
+            rms_norm_out, use_sequence_first, self.weight.dtype
+        )
 
 
 class RMSNormTriton(RMSNorm):
@@ -251,26 +297,27 @@ class WrappedPaddleNormPipe(paddle.nn.Layer):
         )
 
     def forward(self, dict_args: dict):
+        tensor_list = None
         if (
             self.config.num_nextn_predict_layers is not None
             and self.config.num_nextn_predict_layers > 0
             and not self.config.mtp_load_weight_only
-            and not self.config.enable_mtp_magic_send
         ):
             hidden_states_concat = dict_args["hidden_states"]
             tensor_list = paddle.split(
                 hidden_states_concat, self.config.num_nextn_predict_layers + 1
             )
             dict_args["hidden_states"] = tensor_list[0]
+
+        normed_hidden_states = self.norm(dict_args["hidden_states"])
         rst = {
             **dict_args,
-            "hidden_states": self.norm(dict_args["hidden_states"]),
+            "hidden_states": normed_hidden_states,
         }
         if (
             self.config.num_nextn_predict_layers is not None
             and self.config.num_nextn_predict_layers > 0
             and not self.config.mtp_load_weight_only
-            and not self.config.enable_mtp_magic_send
         ):
             # normalize MTP hidden_states
             if self.config.gpt_model_use_experimental_version:
@@ -281,21 +328,6 @@ class WrappedPaddleNormPipe(paddle.nn.Layer):
             )
             rst["hidden_states"] = hidden_states_concat
         rst = {**dict_args, **rst}
-
-        # Loss-path MD5 probe: final_layernorm output
-        if (
-            os.environ.get("LOG_LAYER_MD5", "0") == "1"
-            or os.environ.get("LOG_LOSS_MD5", "0") == "1"
-        ):
-            import hashlib
-
-            rank = paddle.distributed.get_rank()
-            h = rst["hidden_states"]
-            md5 = hashlib.md5(h.cast("float32").numpy().tobytes()).hexdigest()
-            print(
-                f"[LOSS_PATH_MD5] rank={rank} final_layernorm_output shape={list(h.shape)} md5={md5}",
-                flush=True,
-            )
 
         return rst
 

--- a/src/paddlefleet/transformer/transformer_layer.py
+++ b/src/paddlefleet/transformer/transformer_layer.py
@@ -15,7 +15,6 @@
 
 from __future__ import annotations
 
-import hashlib
 import logging
 import os
 from collections import OrderedDict
@@ -149,40 +148,15 @@ class TransformerLayer(nn.Layer):
     """
 
     _gpt_model_use_experimental_version = False
-    _LOG_LAYER_MD5 = os.environ.get("LOG_LAYER_MD5", "0") == "1"
-    _skip_mtp_probes = (
-        False  # Set True during MTP forward to suppress MD5 probes
-    )
-
-    @staticmethod
-    def _log_md5(tensor, name, layer_idx):
-        """Log MD5 of a tensor for precision alignment debugging."""
-        if (
-            TransformerLayer._LOG_LAYER_MD5
-            and TransformerLayer._gpt_model_use_experimental_version
-        ):
-            if TransformerLayer._skip_mtp_probes:
-                return  # Skip MTP passes — EC has no MTP
-            data = tensor.cast("float32").numpy().tobytes()
-            md5 = hashlib.md5(data).hexdigest()
-            rank = (
-                paddle.distributed.get_rank()
-                if paddle.distributed.is_initialized()
-                else 0
-            )
-            print(
-                f"[MD5 Probe] Rank={rank} Layer={layer_idx} {name} MD5={md5} shape={list(tensor.shape)}",
-                flush=True,
-            )
 
     def __init__(
         self,
         config: TransformerConfig,
         sublayers_spec: TransformerLayerSublayersSpec,
         layer_number: int = 1,
+        is_mtp_layer: bool = False,
         hidden_dropout_prob: float | None = None,
         pg_collection: ProcessGroupCollection | None = None,
-        is_mtp_layer: bool = False,
     ):
         super().__init__()
 
@@ -293,9 +267,7 @@ class TransformerLayer(nn.Layer):
             sublayers_spec.mlp, config=self.config, **additional_mlp_kwargs
         )
         if hasattr(self.mlp, "set_layer_number"):
-            self.mlp.set_layer_number(
-                self.layer_number, is_mtp_layer=self.is_mtp_layer
-            )
+            self.mlp.set_layer_number(self.layer_number, self.is_mtp_layer)
 
         # [Layer 9: BiasDropoutFusion]
         self.mlp_bda = build_spec_layer(sublayers_spec.mlp_bda)
@@ -445,9 +417,6 @@ class TransformerLayer(nn.Layer):
         values = tuple(dict_args.values())
 
         is_mtp = dict_args.pop("is_mtp", False)
-        TransformerLayer._skip_mtp_probes = (
-            is_mtp  # Suppress MD5 probes for MTP passes
-        )
         mtp_input = None
         mtp_ids = None
         if (
@@ -455,7 +424,6 @@ class TransformerLayer(nn.Layer):
             and self.config.num_nextn_predict_layers > 0
             and not is_mtp
             and not self.config.mtp_load_weight_only
-            and not self.config.enable_mtp_magic_send
         ):
             # process hidden_states
             hidden_states_concat = dict_args["hidden_states"]
@@ -467,16 +435,15 @@ class TransformerLayer(nn.Layer):
             dict_args["hidden_states"] = hidden_states
 
             # process position_ids
-            if not self.config.gpt_model_use_experimental_version:
-                if "position_ids" in dict_args.keys():
-                    position_ids = dict_args["position_ids"]
-                    decoder_ids = position_ids[
-                        :, : -self.config.num_nextn_predict_layers
-                    ]
-                    mtp_ids = position_ids[
-                        :, -self.config.num_nextn_predict_layers :
-                    ]
-                    dict_args["position_ids"] = decoder_ids
+            if "position_ids" in dict_args.keys():
+                position_ids = dict_args["position_ids"]
+                decoder_ids = position_ids[
+                    :, : -self.config.num_nextn_predict_layers
+                ]
+                mtp_ids = position_ids[
+                    :, -self.config.num_nextn_predict_layers :
+                ]
+                dict_args["position_ids"] = decoder_ids
 
             # process rotary_pos_emb: trim to main decoder sequence length
             # With SP: rotary_pos_emb is [S, B, head_dim], seq is dim 0
@@ -587,9 +554,6 @@ class TransformerLayer(nn.Layer):
             rotary_pos_emb = dict_args.get("rotary_pos_emb", None)
             rotary_pos_cos = dict_args.get("rotary_pos_cos", None)
             rotary_pos_sin = dict_args.get("rotary_pos_sin", None)
-            swa_rotary_pos_emb = dict_args.get("swa_rotary_pos_emb", None)
-            swa_rotary_pos_cos = dict_args.get("swa_rotary_pos_cos", None)
-            swa_rotary_pos_sin = dict_args.get("swa_rotary_pos_sin", None)
             position_ids = dict_args.get("position_ids", None)
             attention_bias = dict_args.get("attention_bias", None)
             packed_seq_params = dict_args.get("packed_seq_params", None)
@@ -611,15 +575,6 @@ class TransformerLayer(nn.Layer):
                 else None,
                 rotary_pos_sin=rotary_pos_sin.clone()  # Clone is necessary!
                 if rotary_pos_sin is not None
-                else None,
-                swa_rotary_pos_emb=swa_rotary_pos_emb.clone()  # Clone is necessary!
-                if swa_rotary_pos_emb is not None
-                else None,
-                swa_rotary_pos_cos=swa_rotary_pos_cos.clone()  # Clone is necessary!
-                if swa_rotary_pos_cos is not None
-                else None,
-                swa_rotary_pos_sin=swa_rotary_pos_sin.clone()  # Clone is necessary!
-                if swa_rotary_pos_sin is not None
                 else None,
                 position_ids=position_ids.clone()  # Clone is necessary!
                 if position_ids is not None
@@ -643,16 +598,15 @@ class TransformerLayer(nn.Layer):
             and self.config.num_nextn_predict_layers > 0
             and not is_mtp
             and not self.config.mtp_load_weight_only
-            and not self.config.enable_mtp_magic_send
         ):
             hidden_states_concat = paddle.concat([output, *mtp_input])
             rst["hidden_states"] = hidden_states_concat
-            if not self.config.gpt_model_use_experimental_version:
-                if "position_ids" in dict_args.keys():
-                    position_ids = paddle.concat(
-                        [dict_args["position_ids"], mtp_ids], axis=1
-                    )
-                    dict_args["position_ids"] = position_ids
+
+            if "position_ids" in dict_args.keys():
+                position_ids = paddle.concat(
+                    [dict_args["position_ids"], mtp_ids], axis=1
+                )
+                dict_args["position_ids"] = position_ids
 
             # Restore rotary_pos_emb/cos/sin to full length for next layer
             if rotary_pos_emb_full is not None:
@@ -706,41 +660,12 @@ class TransformerLayer(nn.Layer):
         rotary_pos_emb: Tensor | None = None,
         rotary_pos_cos: Tensor | None = None,
         rotary_pos_sin: Tensor | None = None,
-        swa_rotary_pos_emb: Tensor | None = None,
-        swa_rotary_pos_cos: Tensor | None = None,
-        swa_rotary_pos_sin: Tensor | None = None,
         position_ids: Tensor | None = None,
         attention_bias: Tensor | None = None,
         packed_seq_params: PackedSeqParams | None = None,
         input_ids: Tensor | None = None,
         **kwargs,
     ):
-        def need_do_attention():
-            # need_do_prefill = forward_meta.max_len_tensor_cpu[1] > 0
-            # need_do_decode = forward_meta.max_len_tensor_cpu[2] > 0
-            # in fastdeploy mode , not need_do_prefill and not need_do_decode,
-            # core_attention will return none, so pass self attention
-            if (
-                getattr(self, "training", True)
-                or not self.config.multi_latent_attention
-            ):
-                return True
-            if hasattr(self, "self_attn") and hasattr(
-                self.self_attn, "core_attention"
-            ):
-                core_attn = self.self_attn.core_attention
-                if hasattr(core_attn, "config") and hasattr(
-                    core_attn.config, "forward_meta"
-                ):
-                    fm = core_attn.config.forward_meta
-                    return not (
-                        fm.max_len_tensor_cpu[1] <= 0
-                        and fm.max_len_tensor_cpu[2] <= 0
-                    )
-                return True
-            else:
-                return True
-
         timer_name = "moe-mlp" if isinstance(self.mlp, MoELayer) else "mlp"
         if self.config.block_attention_residuals:
             blocks = kwargs.get("blocks", [])
@@ -758,26 +683,20 @@ class TransformerLayer(nn.Layer):
 
             # Self-attention (skip internal bda residual)
             with profile("attn"):
-                if need_do_attention():
-                    hidden_states, context = self._forward_attention(
-                        hidden_states=hidden_states,
-                        attention_mask=attention_mask,
-                        attn_mask_startend_row_indices=attn_mask_startend_row_indices,
-                        context=context,
-                        context_mask=context_mask,
-                        rotary_pos_emb=rotary_pos_emb,
-                        rotary_pos_cos=rotary_pos_cos,
-                        rotary_pos_sin=rotary_pos_sin,
-                        swa_rotary_pos_emb=swa_rotary_pos_emb,
-                        swa_rotary_pos_cos=swa_rotary_pos_cos,
-                        swa_rotary_pos_sin=swa_rotary_pos_sin,
-                        position_ids=position_ids,
-                        attention_bias=attention_bias,
-                        packed_seq_params=packed_seq_params,
-                        block_attention_residuals=True,
-                        in_recompute=self.full_recompute,
-                        **kwargs,
-                    )
+                hidden_states, context = self._forward_attention(
+                    hidden_states=hidden_states,
+                    attention_mask=attention_mask,
+                    attn_mask_startend_row_indices=attn_mask_startend_row_indices,
+                    context=context,
+                    context_mask=context_mask,
+                    rotary_pos_emb=rotary_pos_emb,
+                    rotary_pos_cos=rotary_pos_cos,
+                    rotary_pos_sin=rotary_pos_sin,
+                    position_ids=position_ids,
+                    attention_bias=attention_bias,
+                    packed_seq_params=packed_seq_params,
+                    block_attention_residuals=True,
+                )
 
             # Accumulate attn output into partial_block
             if (
@@ -807,33 +726,23 @@ class TransformerLayer(nn.Layer):
             # Accumulate mlp output into partial_block
             output = partial_block + mlp_out
         else:
-            self._log_md5(hidden_states, "input", self.layer_number)
             with profile("attn"):
-                if need_do_attention():
-                    hidden_states, context = self._forward_attention(
-                        hidden_states=hidden_states,
-                        attention_mask=attention_mask,
-                        attn_mask_startend_row_indices=attn_mask_startend_row_indices,
-                        context=context,
-                        context_mask=context_mask,
-                        rotary_pos_emb=rotary_pos_emb,
-                        rotary_pos_cos=rotary_pos_cos,
-                        rotary_pos_sin=rotary_pos_sin,
-                        swa_rotary_pos_emb=swa_rotary_pos_emb,
-                        swa_rotary_pos_cos=swa_rotary_pos_cos,
-                        swa_rotary_pos_sin=swa_rotary_pos_sin,
-                        position_ids=position_ids,
-                        attention_bias=attention_bias,
-                        packed_seq_params=packed_seq_params,
-                        in_recompute=self.full_recompute,
-                        **kwargs,
-                    )
-            self._log_md5(
-                hidden_states, "post_attn_residual", self.layer_number
-            )
+                hidden_states, context = self._forward_attention(
+                    hidden_states=hidden_states,
+                    attention_mask=attention_mask,
+                    attn_mask_startend_row_indices=attn_mask_startend_row_indices,
+                    context=context,
+                    context_mask=context_mask,
+                    rotary_pos_emb=rotary_pos_emb,
+                    rotary_pos_cos=rotary_pos_cos,
+                    rotary_pos_sin=rotary_pos_sin,
+                    position_ids=position_ids,
+                    attention_bias=attention_bias,
+                    packed_seq_params=packed_seq_params,
+                    in_recompute=self.full_recompute,
+                )
             with profile(timer_name):
                 output = self._forward_mlp(hidden_states, input_ids=input_ids)
-            self._log_md5(output, "layer_output", self.layer_number)
         if context is not None:
             return output, context
         return output
@@ -849,9 +758,6 @@ class TransformerLayer(nn.Layer):
         rotary_pos_cos: Tensor | None = None,
         rotary_pos_sin: Tensor | None = None,
         rope_freqs_cis: Tensor | None = None,
-        swa_rotary_pos_emb: Tensor | None = None,
-        swa_rotary_pos_cos: Tensor | None = None,
-        swa_rotary_pos_sin: Tensor | None = None,
         position_ids: Tensor | None = None,
         attention_bias: Tensor | None = None,
         packed_seq_params: PackedSeqParams | None = None,
@@ -874,9 +780,6 @@ class TransformerLayer(nn.Layer):
             rotary_pos_cos (Tensor | None): Rotary embedding cosine.
             rotary_pos_sin (Tensor | None): Rotary embedding sine.
             rope_freqs_cis (Tensor | None): Rotary embedding frequency.
-            swa_rotary_pos_emb (Tensor | None): Sliding Window Rotary positional embeddings.
-            swa_rotary_pos_cos (Tensor | None): Sliding Window Rotary embedding cosine.
-            swa_rotary_pos_sin (Tensor | None): Sliding Window Rotary embedding sine.
             attention_bias (Tensor | None): Bias tensor for Q * K.T.
             packed_seq_params (object, optional): Parameters for packed sequence processing.
 
@@ -898,10 +801,6 @@ class TransformerLayer(nn.Layer):
         else:
             input_layernorm_output = self.input_layernorm(hidden_states)
 
-        self._log_md5(
-            input_layernorm_output, "input_layernorm_out", self.layer_number
-        )
-
         if rope_freqs_cis is not None:
             attention_output_with_bias = self.self_attn(
                 input_layernorm_output,
@@ -912,9 +811,6 @@ class TransformerLayer(nn.Layer):
                 attention_bias=attention_bias,
                 packed_seq_params=packed_seq_params,
                 in_recompute=in_recompute,
-                past_key_values=kwargs.get("past_key_values"),
-                layer_idx=self.layer_number,
-                use_cache=kwargs.get("use_cache", False),
             )
         else:
             attention_output_with_bias = self.self_attn(
@@ -924,16 +820,10 @@ class TransformerLayer(nn.Layer):
                 rotary_pos_emb=rotary_pos_emb,
                 rotary_pos_cos=rotary_pos_cos,
                 rotary_pos_sin=rotary_pos_sin,
-                swa_rotary_pos_emb=swa_rotary_pos_emb,
-                swa_rotary_pos_cos=swa_rotary_pos_cos,
-                swa_rotary_pos_sin=swa_rotary_pos_sin,
                 position_ids=position_ids,
                 attention_bias=attention_bias,
                 packed_seq_params=packed_seq_params,
                 in_recompute=in_recompute,
-                past_key_values=kwargs.get("past_key_values"),
-                layer_idx=self.layer_number,
-                use_cache=kwargs.get("use_cache", False),
             )
 
         with paddle.enable_grad():
@@ -1018,12 +908,6 @@ class TransformerLayer(nn.Layer):
                 hidden_states
             )
 
-        self._log_md5(
-            post_attention_layernorm_output,
-            "post_attn_layernorm_out",
-            self.layer_number,
-        )
-
         if self.recompute_mlp:
             _mlp_input_ids = (
                 input_ids if isinstance(self.mlp, MoELayer) else None
@@ -1060,18 +944,6 @@ class TransformerLayer(nn.Layer):
                 )
             else:
                 mlp_output_with_bias = self.mlp(post_attention_layernorm_output)
-
-        # Log MLP raw output before BDA
-        if (
-            TransformerLayer._LOG_LAYER_MD5
-            and TransformerLayer._gpt_model_use_experimental_version
-        ):
-            _mlp_tensor = (
-                mlp_output_with_bias[0]
-                if isinstance(mlp_output_with_bias, tuple)
-                else mlp_output_with_bias
-            )
-            self._log_md5(_mlp_tensor, "mlp_out", self.layer_number)
 
         with paddle.enable_grad():
             if block_attention_residuals:
@@ -1122,17 +994,17 @@ class HyperConnectionTransformerLayer(TransformerLayer):
         config: TransformerConfig,
         sublayers_spec: TransformerLayerSublayersSpec,
         layer_number: int = 1,
+        is_mtp_layer: bool = False,
         hidden_dropout_prob: float | None = None,
         pg_collection: ProcessGroupCollection | None = None,
-        is_mtp_layer: bool = False,
     ):
         super().__init__(
             config=config,
             sublayers_spec=sublayers_spec,
             layer_number=layer_number,
+            is_mtp_layer=is_mtp_layer,
             hidden_dropout_prob=hidden_dropout_prob,
             pg_collection=pg_collection,
-            is_mtp_layer=is_mtp_layer,
         )
 
         assert (
@@ -1184,8 +1056,9 @@ class HyperConnectionTransformerLayer(TransformerLayer):
         ori_dtype = hidden_states.dtype
 
         # mHC: aggregate n-stream → 1-stream
+        attn_hc_input = hidden_states
         aggregated, h_res, h_post = self.self_attention_hyper_connection(
-            hidden_states
+            attn_hc_input
         )
         aggregated = aggregated.to(ori_dtype)
 
@@ -1194,10 +1067,6 @@ class HyperConnectionTransformerLayer(TransformerLayer):
             input_layernorm_output = recompute(self.input_layernorm, aggregated)
         else:
             input_layernorm_output = self.input_layernorm(aggregated)
-
-        self._log_md5(
-            input_layernorm_output, "input_layernorm_out", self.layer_number
-        )
 
         # Self-attention
         if rope_freqs_cis is not None:
@@ -1224,7 +1093,6 @@ class HyperConnectionTransformerLayer(TransformerLayer):
                 packed_seq_params=packed_seq_params,
                 in_recompute=in_recompute,
             )
-
         # mHC: fused H_res + H_post + bias-dropout-add
         with paddle.enable_grad():
             hidden_states = (
@@ -1277,10 +1145,11 @@ class HyperConnectionTransformerLayer(TransformerLayer):
         """mHC MLP forward: aggregate → layernorm → MLP → fused_h_res_h_post_bda."""
         # Save n-stream residual for H_res mixing
         original_residual = hidden_states
+        mlp_hc_input = hidden_states
         ori_dtype = hidden_states.dtype
 
         # mHC: aggregate n-stream → 1-stream
-        aggregated, h_res, h_post = self.mlp_hyper_connection(hidden_states)
+        aggregated, h_res, h_post = self.mlp_hyper_connection(mlp_hc_input)
         aggregated = aggregated.to(ori_dtype)
 
         # LayerNorm on aggregated single stream
@@ -1292,12 +1161,6 @@ class HyperConnectionTransformerLayer(TransformerLayer):
             post_attention_layernorm_output = self.post_attention_layernorm(
                 aggregated
             )
-
-        self._log_md5(
-            post_attention_layernorm_output,
-            "post_attn_layernorm_out",
-            self.layer_number,
-        )
 
         # MLP
         if self.recompute_mlp:
@@ -1333,7 +1196,6 @@ class HyperConnectionTransformerLayer(TransformerLayer):
                 )
             else:
                 mlp_output_with_bias = self.mlp(post_attention_layernorm_output)
-
         # mHC: fused H_res + H_post + bias-dropout-add
         with paddle.enable_grad():
             hidden_states = self.mlp_hyper_connection.fused_h_res_h_post_bda(

--- a/src/paddlefleet/utils.py
+++ b/src/paddlefleet/utils.py
@@ -21,6 +21,7 @@ import functools
 import inspect
 import math
 import operator
+import os
 import warnings
 from collections.abc import Callable
 from contextlib import nullcontext
@@ -55,6 +56,24 @@ except Exception:
 if TYPE_CHECKING:
     import logging
     from collections.abc import Callable
+
+
+def dsv4_env_flag(name: str, default: bool = False) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def dsv4_mbs2_sequence_first_enabled() -> bool:
+    return dsv4_env_flag("DSV4_FLEET_MBS2_SEQUENCE_FIRST", False)
+
+
+def dsv4_sequence_first_feature_enabled(name: str) -> bool:
+    value = os.environ.get(name)
+    if value is not None:
+        return dsv4_env_flag(name)
+    return dsv4_mbs2_sequence_first_enabled()
 
 
 class WrappedTensor:

--- a/tests/single_card_tests/transformer/test_csa_sink_subtract_backward_repro.py
+++ b/tests/single_card_tests/transformer/test_csa_sink_subtract_backward_repro.py
@@ -1,0 +1,228 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import hashlib
+import sys
+import unittest
+from pathlib import Path
+
+import numpy as np
+import paddle
+
+try:
+    import torch
+    import torch.utils.dlpack
+except ImportError:
+    torch = None
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SRC_DIR = _REPO_ROOT / "src"
+if str(_SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(_SRC_DIR))
+
+from paddlefleet.transformer.csa_attention import (
+    _DSV4CSASinkSoftmaxTorchBackward,
+)
+
+
+class _SinkSubtract(paddle.autograd.PyLayer):
+    @staticmethod
+    def forward(ctx, scores, sink, scores_max):
+        return scores - scores_max, sink - scores_max
+
+    @staticmethod
+    def backward(ctx, grad_scores_shifted, grad_sink_shifted):
+        grad_scores = grad_scores_shifted
+        grad_sink = grad_sink_shifted.sum(axis=(0, 2, 3), keepdim=True)
+        grad_scores_max = (
+            -grad_scores_shifted.sum(axis=-1, keepdim=True) - grad_sink_shifted
+        )
+        return grad_scores, grad_sink, grad_scores_max
+
+
+def _md5_float32(array: np.ndarray) -> str:
+    return hashlib.md5(array.astype("float32", copy=False).tobytes()).hexdigest()
+
+
+def _make_inputs(seed=1234, shape=(2, 4, 128, 32)):
+    rng = np.random.default_rng(seed)
+    scores = (rng.standard_normal(shape).astype("float32") * 2.0).astype(
+        "float32"
+    )
+    sink = (
+        rng.standard_normal((1, shape[1], 1, 1)).astype("float32") * 0.2
+    ).astype("float32")
+    upstream = rng.standard_normal(shape).astype("float32")
+    return scores, sink, upstream
+
+
+def _diff_stats(lhs: np.ndarray, rhs: np.ndarray):
+    abs_diff = np.abs(lhs - rhs)
+    return int(np.count_nonzero(abs_diff)), float(abs_diff.max())
+
+
+def _run_paddle_sink_softmax(scores_np, sink_np, upstream_np, mode="default"):
+    scores = paddle.to_tensor(scores_np).cast("bfloat16").cast("float32")
+    sink = paddle.to_tensor(sink_np).cast("bfloat16").cast("float32")
+    scores.stop_gradient = False
+    sink.stop_gradient = False
+
+    if mode == "torch_backward":
+        attn_weights = _DSV4CSASinkSoftmaxTorchBackward.apply(scores, sink)
+    else:
+        scores_max = paddle.maximum(scores.max(axis=-1, keepdim=True), sink)
+        if mode == "subtract_custom":
+            scores_shifted, sink_shifted = _SinkSubtract.apply(
+                scores, sink, scores_max
+            )
+        elif mode == "default":
+            scores_shifted = scores - scores_max
+            sink_shifted = sink - scores_max
+        else:
+            raise ValueError(f"unknown mode: {mode}")
+
+        exp_scores = paddle.exp(scores_shifted)
+        exp_sink = paddle.exp(sink_shifted)
+        denom = exp_scores.sum(axis=-1, keepdim=True) + exp_sink
+        attn_weights = exp_scores / denom
+
+    upstream = paddle.to_tensor(upstream_np).cast("bfloat16").cast("float32")
+    loss = (attn_weights * upstream).sum()
+    loss.backward()
+    return (
+        scores.grad.detach().cast("float32").cpu().numpy(),
+        sink.grad.detach().cast("float32").cpu().numpy(),
+    )
+
+
+def _run_torch_sink_softmax(scores_np, sink_np, upstream_np):
+    scores = (
+        torch.tensor(scores_np, device="cuda", dtype=torch.bfloat16)
+        .float()
+        .requires_grad_(True)
+    )
+    sink = (
+        torch.tensor(sink_np, device="cuda", dtype=torch.bfloat16)
+        .float()
+        .requires_grad_(True)
+    )
+
+    scores_max = torch.maximum(scores.max(dim=-1, keepdim=True).values, sink)
+    exp_scores = torch.exp(scores - scores_max)
+    exp_sink = torch.exp(sink - scores_max)
+    denom = exp_scores.sum(dim=-1, keepdim=True) + exp_sink
+    attn_weights = exp_scores / denom
+
+    upstream = torch.tensor(upstream_np, device="cuda", dtype=torch.bfloat16).float()
+    loss = (attn_weights * upstream).sum()
+    loss.backward()
+    return (
+        scores.grad.detach().float().cpu().numpy(),
+        sink.grad.detach().float().cpu().numpy(),
+    )
+
+
+@unittest.skipUnless(
+    torch is not None and paddle.is_compiled_with_cuda() and torch.cuda.is_available(),
+    "CSA sink subtract repro requires CUDA Paddle and CUDA Torch.",
+)
+class TestCSASinkSoftmaxBackwardRepro(unittest.TestCase):
+    def setUp(self):
+        paddle.set_device("gpu:0")
+        torch.cuda.set_device(0)
+
+    def test_torch_backward_matches_torch_reference_across_seeds(self):
+        shapes = [
+            (2, 4, 128, 32),
+            (1, 8, 64, 64),
+            (3, 2, 257, 17),
+        ]
+        seeds = [0, 1, 2]
+        num_cases = 0
+        paddle_default_torch_diff_cases = 0
+        subtract_custom_torch_diff_cases = 0
+        torch_backward_torch_diff_cases = 0
+        sink_torch_backward_diff_cases = 0
+        sink_torch_diff_cases = 0
+
+        for shape in shapes:
+            for seed in seeds:
+                scores_np, sink_np, upstream_np = _make_inputs(seed, shape)
+                default_scores_grad, default_sink_grad = _run_paddle_sink_softmax(
+                    scores_np, sink_np, upstream_np, mode="default"
+                )
+                subtract_scores_grad, _ = _run_paddle_sink_softmax(
+                    scores_np, sink_np, upstream_np, mode="subtract_custom"
+                )
+                torch_bwd_scores_grad, torch_bwd_sink_grad = (
+                    _run_paddle_sink_softmax(
+                        scores_np, sink_np, upstream_np, mode="torch_backward"
+                    )
+                )
+                torch_scores_grad, torch_sink_grad = _run_torch_sink_softmax(
+                    scores_np, sink_np, upstream_np
+                )
+
+                default_torch_numdiff, default_torch_maxdiff = _diff_stats(
+                    default_scores_grad, torch_scores_grad
+                )
+                subtract_torch_numdiff, subtract_torch_maxdiff = _diff_stats(
+                    subtract_scores_grad, torch_scores_grad
+                )
+                torch_bwd_torch_numdiff, torch_bwd_torch_maxdiff = _diff_stats(
+                    torch_bwd_scores_grad, torch_scores_grad
+                )
+                sink_torch_numdiff, _ = _diff_stats(
+                    default_sink_grad, torch_sink_grad
+                )
+                sink_torch_bwd_numdiff, _ = _diff_stats(
+                    torch_bwd_sink_grad, torch_sink_grad
+                )
+
+                print(
+                    f"shape={shape} seed={seed} "
+                    f"default_torch_numdiff={default_torch_numdiff} "
+                    f"default_torch_maxdiff={default_torch_maxdiff:.12e} "
+                    f"subtract_torch_numdiff={subtract_torch_numdiff} "
+                    f"subtract_torch_maxdiff={subtract_torch_maxdiff:.12e} "
+                    f"torch_bwd_torch_numdiff={torch_bwd_torch_numdiff} "
+                    f"torch_bwd_torch_maxdiff={torch_bwd_torch_maxdiff:.12e} "
+                    f"torch_bwd_md5={_md5_float32(torch_bwd_scores_grad)} "
+                    f"torch_ref_md5={_md5_float32(torch_scores_grad)}"
+                )
+
+                num_cases += 1
+                paddle_default_torch_diff_cases += int(default_torch_numdiff > 0)
+                subtract_custom_torch_diff_cases += int(
+                    subtract_torch_numdiff > 0
+                )
+                torch_backward_torch_diff_cases += int(
+                    torch_bwd_torch_numdiff > 0
+                )
+                sink_torch_backward_diff_cases += int(
+                    sink_torch_bwd_numdiff > 0
+                )
+                sink_torch_diff_cases += int(sink_torch_numdiff > 0)
+
+        self.assertEqual(paddle_default_torch_diff_cases, num_cases)
+        self.assertEqual(subtract_custom_torch_diff_cases, num_cases)
+        self.assertEqual(torch_backward_torch_diff_cases, 0)
+        self.assertEqual(sink_torch_backward_diff_cases, 0)
+        self.assertEqual(sink_torch_diff_cases, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR adds the PaddleFleet-side DSv4 numerical alignment paths used to reproduce the Megatron reference training trajectory on current `develop`.

Main areas covered:
- Megatron-compatible DSv4 SwiGLU forward / wgrad behavior.
- Embedding, LM head, language loss, tensor-parallel linear, CSA/DSA attention, mHC, MoE router / dispatcher / MLP, MTP, norm, and utility alignment paths.
- Revert3 DSv4 attention / CSA compressor / mHC numerical semantics matching the Megatron CleanAlign reference.
- DeepEP / EP8 / mbs2 / acc2 training path support for bitwise loss reproduction.
- A single-card repro test for CSA sink-softmax backward behavior.

Pairs with PaddlePaddle/PaddleFormers#4623.

## Validation

Validated in `/root/paddlejob/share-storage/gpfs/system-public/huangjiyi/dsv4-flash-workspace` against Megatron CleanAlign revert3:

```text
RUN_STAMP=retest_source_revert3_100step_20260608 \
OUTPUT_PREFIX=dpskv4_ep8_4layer_1k_retest_source_revert3_100step \
MASTER_PORT=40531 \
bash paddlefleet_dsv4/run_align_100step_lr1e3_mbs2_acc2.sh
```

Result versus Megatron CleanAlign revert3 100-step log:

```text
main_matches=200/200
mtp_matches=200/200
first_main_diff=None
first_mtp_diff=None
step100 main final_loss=1.04997014999389648438 md5=e24faebe91ac491b4be0b8c71060a06a
step100 mtp final_loss=2.01599717140197753906 md5=80c6ec222c562733922f22dabb4fc8fe
```

Also validated the same commit in `/root/paddlejob/share-storage/gpfs/system-public/huangjiyi/dsv4_backward_align/0605_latest_align_22steps` after syncing these changes:

```text
main_matches=200/200
mtp_matches=200/200
first_main_diff=None
first_mtp_diff=None
```

Static checks:

```text
python -m py_compile src/paddlefleet/transformer/csa_attention.py src/paddlefleet/transformer/dsv4_hybrid_attention.py src/paddlefleet/transformer/hyper_connection.py tests/single_card_tests/transformer/test_csa_sink_subtract_backward_repro.py
git diff --check
```