### PR TITLE
Add fp8 dispatch for sonicmoe

### DIFF
--- a/src/paddlefleet/transformer/moe/fused_a2a.py
+++ b/src/paddlefleet/transformer/moe/fused_a2a.py
@@ -20,7 +20,11 @@ import paddle
 from paddle import framework
 from paddle.autograd import PyLayer
 from paddle.distributed.communication.group import Group
-from paddlefleet_ops import is_deep_ep_available, is_hybrid_ep_available
+from paddlefleet_ops import (
+    is_deep_ep_available,
+    is_hybrid_ep_available,
+    is_sonic_moe_available,
+)
 
 from paddlefleet.refined_recompute.queue_check import global_rr_queue_log
 
@@ -43,6 +47,18 @@ if is_hybrid_ep_available():
     HAVE_HYBRID_EP = True
 else:
     HAVE_HYBRID_EP = False
+
+if is_sonic_moe_available():
+    HAVE_SONIC_MOE = True
+    try:
+        from paddlefleet_ops.sonicmoe.quack_utils import (
+            quantize_activation_blockscaled_fast,
+        )
+    except ImportError:
+        quantize_activation_blockscaled_fast = None
+else:
+    quantize_activation_blockscaled_fast = None
+    HAVE_SONIC_MOE = False
 
 _buffer = None
 _hybrid_ep_buffer = None
@@ -380,18 +396,31 @@ class DeepEPDispatch(PyLayer):
         allocate_on_comm_stream: bool = False,
         moe_ep_barrier: bool = True,
         use_ue8m0: bool = False,
+        using_sonic_moe: bool = False,
     ):
         """Forward pass of fused dispatch."""
         if fp8_dispatch:
-            x_fp8, scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
-                x,
-                quant_method="1x128",
-                input_transpose=False,
-                output_scale_transpose=True,
-                return_transpose_only=False,
-                using_ue8m0_scale=use_ue8m0,
-            )
-            scale = scale.T.contiguous()
+            if using_sonic_moe:
+                assert quantize_activation_blockscaled_fast is not None, (
+                    "Cannot find quantize_activation_blockscaled_fast, please update sonicmoe."
+                )
+                if not x.is_contiguous():
+                    x = x.contiguous()
+                x_fp8, scale = quantize_activation_blockscaled_fast(
+                    x, scale_dtype=paddle.int32
+                )
+            else:
+                x_fp8, scale = (
+                    paddle.incubate.nn.functional.fp8_quant_blockwise(
+                        x,
+                        quant_method="1x128",
+                        input_transpose=False,
+                        output_scale_transpose=True,
+                        return_transpose_only=False,
+                        using_ue8m0_scale=use_ue8m0,
+                    )
+                )
+                scale = scale.T.contiguous()
             x = (x_fp8, scale)
         recv_x, recv_token_probs, states, event = fused_dispatch_forward_func(
             x,
@@ -445,6 +474,8 @@ class DeepEPCombine(PyLayer):
         async_finish=False,
         allocate_on_comm_stream=False,
         moe_ep_barrier: bool = True,
+        fp8_dispatch: bool = False,
+        combine_grad_handle: dict | None = None,
     ):
         """Forward pass of fused combine."""
         combined_x = fused_combine_forward_func(
@@ -457,14 +488,25 @@ class DeepEPCombine(PyLayer):
         ctx.async_finish = async_finish
         ctx.allocate_on_comm_stream = allocate_on_comm_stream
         ctx.moe_ep_barrier = moe_ep_barrier
+        ctx.fp8_dispatch = fp8_dispatch
+        ctx.combine_grad_handle = combine_grad_handle
 
         return combined_x
 
     @staticmethod
     def backward(ctx, grad_output):
         """Backward pass of fused combine."""
-        return fused_combine_backward_func(
-            grad_output,
+        grad_for_comm = grad_output
+        if ctx.fp8_dispatch:
+            assert quantize_activation_blockscaled_fast is not None, (
+                "Cannot find quantize_activation_blockscaled_fast, please update sonicmoe."
+            )
+            grad_output = grad_output.contiguous()
+            grad_for_comm = quantize_activation_blockscaled_fast(
+                grad_output, scale_dtype=paddle.int32
+            )
+        grad_x = fused_combine_backward_func(
+            grad_for_comm,
             ctx.group,
             ctx.handle,
             ctx.previous_event,
@@ -472,6 +514,14 @@ class DeepEPCombine(PyLayer):
             ctx.allocate_on_comm_stream,
             moe_ep_barrier=ctx.moe_ep_barrier,
         )
+        if ctx.fp8_dispatch:
+            assert ctx.combine_grad_handle is not None, (
+                "For fp8_dispatch, combine_grad_handle must be provided in combine backward."
+            )
+            grad_x, grad_scale = grad_x
+            ctx.combine_grad_handle["data"] = grad_x
+            ctx.combine_grad_handle["scale"] = grad_scale
+        return grad_x
 
 
 class DeepEPCombineAsync(PyLayer):
@@ -641,6 +691,7 @@ if HAVE_DEEP_EP:
         allocate_on_comm_stream=False,
         moe_ep_barrier: bool = True,
         use_ue8m0: bool = False,
+        using_sonic_moe: bool = False,
     ):
         """Perform fused dispatch operation if deep_ep is available.
 
@@ -668,6 +719,7 @@ if HAVE_DEEP_EP:
             allocate_on_comm_stream,
             moe_ep_barrier,
             use_ue8m0,
+            using_sonic_moe,
         )
 
     def fused_combine(
@@ -681,6 +733,8 @@ if HAVE_DEEP_EP:
         async_finish=False,
         moe_ep_barrier: bool = True,
         use_rr_deepep_combine: bool = False,
+        fp8_dispatch: bool = False,
+        combine_grad_handle: dict | None = None,
     ):
         """Perform fused combine operation if deep_ep is available.
 
@@ -711,6 +765,8 @@ if HAVE_DEEP_EP:
                 previous_event,
                 async_finish,
                 moe_ep_barrier=moe_ep_barrier,
+                fp8_dispatch=fp8_dispatch,
+                combine_grad_handle=combine_grad_handle,
             )
         else:
             if previous_event is not None:

--- a/src/paddlefleet/transformer/moe/fusion_layer_utils.py
+++ b/src/paddlefleet/transformer/moe/fusion_layer_utils.py
@@ -2176,16 +2176,27 @@ class HybridEPMoePyLayer(paddle.autograd.PyLayer):
 
 
 def run_sonic_moe(
-    hidden_states, topk_indices, topk_scores, K, E, w1, w2, fp8=False
+    hidden_states,
+    topk_indices,
+    topk_scores,
+    K,
+    E,
+    w1,
+    w2,
+    fp8=False,
+    tokens_per_expert=None,
+    fp8_scale=None,
+    fp8_combine_grad_handle=None,
 ):
     T = hidden_states.shape[0]
     stream_id = paddle.device.current_stream()
 
-    valid = topk_indices >= 0
-    valid_experts = topk_indices[valid].cast(paddle.int32)
-    tokens_per_expert = paddle.bincount(valid_experts, minlength=E).cast(
-        paddle.int32
-    )
+    if tokens_per_expert is None:
+        valid = topk_indices >= 0
+        valid_experts = topk_indices[valid].cast(paddle.int32)
+        tokens_per_expert = paddle.bincount(valid_experts, minlength=E).cast(
+            paddle.int32
+        )
 
     (
         expert_frequency_offset,
@@ -2198,6 +2209,7 @@ def run_sonic_moe(
         total_pad_rows,
         _N_recv,
         _score_src_idx,
+        expert_order_scores,
     ) = deepep_topk_to_sonic_metadata(
         topk_indices.cast(paddle.int32),
         topk_scores,
@@ -2210,7 +2222,7 @@ def run_sonic_moe(
     activation_type = ActivationType("swiglu")
 
     total_expert_freq = TK_padded
-    scores_for_down = _differentiable_router_scores(
+    router_scores_token_order = _differentiable_router_scores(
         topk_scores,
         topk_indices.cast(paddle.int32),
         num_activated_expert_per_token_offset,
@@ -2220,11 +2232,24 @@ def run_sonic_moe(
         score_src_idx=_score_src_idx,
     )
 
+    fp8_hidden_states = None
+    if fp8_scale is not None:
+        fp8_hidden_states = (hidden_states, fp8_scale)
+
+    w1_sonic = w1.permute([1, 2, 0])
+    w2_sonic = w2.permute([1, 2, 0])
+    if fp8:
+        for attr_name in ("fp8", "transposed_fp8"):
+            if hasattr(w1, attr_name):
+                setattr(w1_sonic, attr_name, getattr(w1, attr_name))
+            if hasattr(w2, attr_name):
+                setattr(w2_sonic, attr_name, getattr(w2, attr_name))
+
     with enable_fp8(fp8):
         _refresh_fp8_config()
         y1, z = _UpProjection.apply(
             hidden_states,
-            w1.permute([1, 2, 0]),
+            w1_sonic,
             None,
             expert_frequency_offset,
             total_expert_freq,
@@ -2238,13 +2263,14 @@ def run_sonic_moe(
             activation_type,
             is_inference_mode_enabled=False,
             use_low_precision_postact_buffer=False,
+            prequant_activation_payload=fp8_hidden_states,
         )
         hidden_states = _DownProjection.apply(
             y1,
             z,
-            w2.permute([1, 2, 0]),
+            w2_sonic,
             None,
-            scores_for_down,
+            topk_scores,
             s_scatter_idx,
             expert_frequency_offset,
             T,
@@ -2257,6 +2283,10 @@ def run_sonic_moe(
             True,  # is_varlen_k
             activation_type,
             None,
+            fp8_combine_grad_handle,
+            expert_order_scores,
+            router_scores_token_order,
+            _score_src_idx,
         )
 
     return hidden_states

--- a/src/paddlefleet/transformer/moe/moe_expert.py
+++ b/src/paddlefleet/transformer/moe/moe_expert.py
@@ -40,6 +40,7 @@ from .moe_utils import (
 
 try:
     from paddlefleet_ops import deep_gemm as paddlefleet_deep_gemm
+    from paddlefleet_ops.sonicmoe.quack_utils import quantize_native_fp8_weights
 except (ImportError, RuntimeError):
     pass
 
@@ -352,7 +353,8 @@ class SonicMoEExpert(GroupedMLPExpert):
             value = value.contiguous()
         if list(tensor.shape) != list(value.shape):
             tensor.reshape_(list(value.shape))
-        tensor[...] = value
+        # tensor[...] = value
+        paddle.assign(value, output=tensor)
 
     def __init__(
         self,
@@ -417,7 +419,34 @@ class SonicMoEExpert(GroupedMLPExpert):
     def step(self):
         self.flush_to_grouped_layout()
 
-    def forward(self, hidden_states, topk_indices, topk_scores, use_fp8=False):
+    @paddle.no_grad()
+    def quant_weight(self):
+        self.convert_weights_to_sonic_layout()
+
+        payload = quantize_native_fp8_weights(
+            self.weight1.permute([1, 2, 0]),
+            self.weight2.permute([1, 2, 0]),
+        )
+        assert payload["format"] == "1x32", (
+            f"quant strategy {payload.get('format')} is not supported."
+        )
+        w1_fp8, w1_scale, w1t_fp8, w1t_scale = payload["w1"]
+        w2_fp8, w2_scale, w2t_fp8, w2t_scale = payload["w2"]
+        self.weight1.fp8 = (w1_fp8.mT, w1_scale)
+        self.weight1.transposed_fp8 = (w1t_fp8, w1t_scale)
+        self.weight2.fp8 = (w2_fp8, w2_scale)
+        self.weight2.transposed_fp8 = (w2t_fp8, w2t_scale)
+
+    def forward(
+        self,
+        hidden_states,
+        topk_indices,
+        topk_scores,
+        use_fp8=False,
+        tokens_per_expert=None,
+        fp8_scale=None,
+        fp8_combine_grad_handle=None,
+    ):
         self.convert_weights_to_sonic_layout()
         hidden_states = run_sonic_moe(
             hidden_states,
@@ -428,6 +457,9 @@ class SonicMoEExpert(GroupedMLPExpert):
             self.weight1,
             self.weight2,
             use_fp8,
+            tokens_per_expert=tokens_per_expert,
+            fp8_scale=fp8_scale,
+            fp8_combine_grad_handle=fp8_combine_grad_handle,
         )
         return hidden_states
 

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -174,7 +174,7 @@ class MoELayer(nn.Layer):
         self.use_ue8m0 = config.use_ue8m0
         self.dw_p2p_overlap = getattr(config, "dw_p2p_overlap", False)
         self.using_sonic_moe = self.config.using_sonic_moe
-        self.fp8_dispatch = bool(config.fp8) and not self.using_sonic_moe
+        self.fp8_dispatch = bool(config.fp8)
         self.fp8_wgrad = config.fp8_wgrad
         self.moe_expert_fusion = config.moe_expert_fusion
         self.moe_subbatch_token_num_after_dispatch = (
@@ -338,7 +338,7 @@ class MoELayer(nn.Layer):
             use_fused_weight = False
         if self.using_sonic_moe:
             assert use_fused_weight is True, (
-                "for sonic moe, expert weight must be fused."
+                "For sonic moe, expert weight must be fused."
             )
 
         if use_fused_weight:
@@ -492,6 +492,7 @@ class MoELayer(nn.Layer):
                         p.is_distributed = True
 
         self.use_rr_deepep_combine = False
+        print(f"====== fp8_dispatch:{self.fp8_dispatch}")
 
     def rr_recompute_update(self, in_full_recompute, in_mlp_recompute):
         if (
@@ -641,6 +642,7 @@ class MoELayer(nn.Layer):
                 self.fp8_dispatch,
                 async_finish=async_finish,
                 use_ue8m0=self.use_ue8m0,
+                using_sonic_moe=self.using_sonic_moe,
             )
         )
         return hidden_states, fp8_dispatched_handle
@@ -737,6 +739,9 @@ class MoELayer(nn.Layer):
             self.token_dispatcher._comm_manager.dispatched_indices
         )
         dispatched_probs = self.token_dispatcher._comm_manager.dispatched_probs
+        fp8_combine_grad_handle = (
+            {} if self.fp8_dispatch and self.using_sonic_moe else None
+        )
 
         with profile("fusion_mlp"):
             if self._use_hybrid_ep_fusion():
@@ -747,11 +752,17 @@ class MoELayer(nn.Layer):
                 )
             elif self.using_sonic_moe:
                 use_fp8 = self.fp8 is not None
+                fp8_scale = None
+                if fp8_dispatched_handle is not None:
+                    fp8_scale = fp8_dispatched_handle["scale"]
                 hidden_states = self.grouped_gemm_experts(
                     dispatched_hidden_states,
                     dispatched_indices,
                     dispatched_probs,
                     use_fp8,
+                    tokens_per_expert=self.token_dispatcher._comm_manager.tokens_per_expert,
+                    fp8_scale=fp8_scale,
+                    fp8_combine_grad_handle=fp8_combine_grad_handle,
                 )
             else:
                 hidden_states = FusionMoePyLayer.apply(
@@ -781,6 +792,8 @@ class MoELayer(nn.Layer):
                 hidden_states,
                 combine_overlap_handle,
                 use_rr_deepep_combine=self.use_rr_deepep_combine,
+                fp8_dispatch=self.fp8_dispatch and self.using_sonic_moe,
+                combine_grad_handle=fp8_combine_grad_handle,
             )
 
         # Latent MoE: project back from latent space to hidden_size
@@ -1189,6 +1202,10 @@ class MoELayer(nn.Layer):
 
     def fp8_quant_weight(self, batch_mode=False, quant_transpose=True):
         if not (self.moe_use_fusion_node and self.fp8):
+            return
+
+        if self.using_sonic_moe and hasattr(self, "grouped_gemm_experts"):
+            self.grouped_gemm_experts.quant_weight()
             return
 
         def quantize_weights(

--- a/src/paddlefleet/transformer/moe/token_dispatcher.py
+++ b/src/paddlefleet/transformer/moe/token_dispatcher.py
@@ -545,6 +545,7 @@ class _DeepEPManager(_DispatchManager):
         fp8_dispatch: bool = False,
         async_finish: bool = False,
         use_ue8m0: bool = False,
+        using_sonic_moe: bool = False,
     ) -> paddle.Tensor:
         hidden_states, dispatched_probs, states, scale = fused_dispatch(
             hidden_states,
@@ -556,6 +557,7 @@ class _DeepEPManager(_DispatchManager):
             async_finish=async_finish,
             moe_ep_barrier=self.moe_ep_barrier,
             use_ue8m0=use_ue8m0,
+            using_sonic_moe=using_sonic_moe,
         )
         self.handle = states["handle"]
         self.tokens_per_expert = states["tokens_per_expert"]
@@ -610,6 +612,8 @@ class _DeepEPManager(_DispatchManager):
         combine_overlap_handle: dict | None = None,
         async_finish: bool = False,
         use_rr_deepep_combine: bool = False,
+        fp8_dispatch: bool = False,
+        combine_grad_handle: dict | None = None,
     ) -> paddle.Tensor:
         if combine_overlap_handle is not None and use_rr_deepep_combine:
             if self._rr_fusedcombined is None:
@@ -621,6 +625,10 @@ class _DeepEPManager(_DispatchManager):
                     f"_rr_fusedcombined type mismatch: expected DeepEPCombineAsyncRefinedRecompute, "
                     f"got {type(self._rr_fusedcombined).__name__}."
                 )
+        if fp8_dispatch is True:
+            assert combine_grad_handle is not None, (
+                "fp8_dispatch=True, but combine_grad_handle is None."
+            )
         hidden_states = fused_combine(
             hidden_states,
             self.group,
@@ -630,6 +638,8 @@ class _DeepEPManager(_DispatchManager):
             async_finish=async_finish,
             moe_ep_barrier=self.moe_ep_barrier,
             use_rr_deepep_combine=use_rr_deepep_combine,
+            fp8_dispatch=fp8_dispatch,
+            combine_grad_handle=combine_grad_handle,
         )
         # Release the handle after combine operation
         self.handle = None
@@ -812,9 +822,14 @@ class MoEFlexTokenDispatcher(MoETokenDispatcher):
         fp8_dispatch: bool,
         async_finish: bool = False,
         use_ue8m0: bool = False,
+        using_sonic_moe: bool = False,
     ):
         return self._comm_manager.dispatch(
-            hidden_states, fp8_dispatch, async_finish, use_ue8m0=use_ue8m0
+            hidden_states,
+            fp8_dispatch,
+            async_finish,
+            use_ue8m0=use_ue8m0,
+            using_sonic_moe=using_sonic_moe,
         )
 
     def dispatch_postprocess(

--- a/tests/multi_card_tests/moe/test_sonic_moe_ep.py
+++ b/tests/multi_card_tests/moe/test_sonic_moe_ep.py
@@ -439,6 +439,13 @@ class TestSonicMoEExpertParallelPrecision(unittest.TestCase):
             using_sonic_moe=True,
             fp8="e4m3",
         )
+        paddle.seed(self.seed)
+        model_parallel_cuda_manual_seed(self.seed)
+        moe_layer_sonic_fp8_dispatch = self._build_moe_layer(
+            using_sonic_moe=True,
+            fp8="e4m3",
+        )
+        moe_layer_sonic_fp8_dispatch.fp8_dispatch = True
 
         input_data_list = []
         for step_idx in range(acc_steps):
@@ -456,8 +463,15 @@ class TestSonicMoEExpertParallelPrecision(unittest.TestCase):
         output_bf16, grads_bf16 = self._run_accumulated_forward_backward(
             moe_layer_sonic_bf16, input_data_list
         )
+        moe_layer_sonic_fp8.grouped_gemm_experts.quant_weight()
         output_fp8, grads_fp8 = self._run_accumulated_forward_backward(
             moe_layer_sonic_fp8, input_data_list
+        )
+        moe_layer_sonic_fp8_dispatch.grouped_gemm_experts.quant_weight()
+        output_fp8_dispatch, grads_fp8_dispatch = (
+            self._run_accumulated_forward_backward(
+                moe_layer_sonic_fp8_dispatch, input_data_list
+            )
         )
         clear_all_fp8_weight_caches()
 
@@ -486,6 +500,31 @@ class TestSonicMoEExpertParallelPrecision(unittest.TestCase):
             grads_bf16,
             tol=fp8_tol,
             title="Sonic-MoE FP8 vs BF16 accumulated grad",
+        )
+
+        self._assert_tensor_diff_less(
+            output_fp8_dispatch,
+            output_bf16,
+            tol=fp8_tol,
+            title="Sonic-MoE FP8-dispatch vs BF16 final output",
+        )
+        self._assert_grad_diff_less(
+            grads_fp8_dispatch,
+            grads_bf16,
+            tol=fp8_tol,
+            title="Sonic-MoE FP8-dispatch vs BF16 accumulated grad",
+        )
+        self._assert_tensor_diff_less(
+            output_fp8_dispatch,
+            output_fp8,
+            tol=1e-8,
+            title="Sonic-MoE FP8-dispatch vs FP8 final output",
+        )
+        self._assert_grad_diff_less(
+            grads_fp8_dispatch,
+            grads_fp8,
+            tol=1e-8,
+            title="Sonic-MoE FP8-dispatch vs FP8 accumulated grad",
         )
 
         print("Final output and parameter gradient precision checks passed!")
@@ -524,9 +563,11 @@ class TestSonicMoEExpertParallelPrecision(unittest.TestCase):
             dtype=paddle.bfloat16,
         )
 
+        moe_layer_single.grouped_gemm_experts.quant_weight()
         output_single, loss_single, input_grad_single, grads_single = (
             self._run_forward_backward(moe_layer_single, input_data)
         )
+        moe_layer_ep.grouped_gemm_experts.quant_weight()
         output_ep, loss_ep, input_grad_ep, grads_ep = (
             self._run_forward_backward(moe_layer_ep, input_data)
         )


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->
Add fp8 dispatch for sonicmoe. Quant the bf16 input to fp8 in dispatch forward phase and combine backward phase.

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否