### PR TITLE
[release/0.3][CI] Pin tvm-ffi below 0.1.12 for paddlefleet_ops

### DIFF
--- a/packages/paddlefleet_ops/setup.py
+++ b/packages/paddlefleet_ops/setup.py
@@ -39,7 +39,7 @@ def get_special_setup_deps():
             "triton",  # for deep_gemm, flashmask
             "nvidia-cutlass-dsl[cu13]==4.4.1",  # for sonic_moe and flash_attention
             "filelock",  # for sonic_moe
-            "apache-tvm-ffi>=0.1.3",  # for supersonic_moe
+            "apache-tvm-ffi>=0.1.3,<0.1.12",  # for supersonic_moe
         ]
         return deps
     elif backends.IS_XPU:


### PR DESCRIPTION
### PR Category

Execute Infrastructure

### PR Types

Bug fixes

### Description

This PR constrains the NVIDIA `paddlefleet_ops` dependency on `apache-tvm-ffi` from `>=0.1.3` to `>=0.1.3,<0.1.12`.

`apache-tvm-ffi==0.1.12` registers `__ffi_repr__` for `ffi.reflection.AccessStep` / `AccessPath`; current TileLang / PaddleFleet ops native libraries can register the same TypeAttr again and abort with:

```text
TypeAttr `__ffi_repr__` is already registered for type index 130
```

This issue was observed while investigating PaddlePaddle/Paddle#79289 Fleet multi-card CI, and TileLang issue #2367 has been filed upstream. Until TileLang adapts to `apache-tvm-ffi==0.1.12`, avoid resolving the incompatible version for `paddlefleet_ops`.

Validation:

```bash
rg -n "apache-tvm-ffi" packages/paddlefleet_ops/setup.py
python3 -m py_compile packages/paddlefleet_ops/setup.py
```


Cherry-pick of #1184 to `release/0.3`.

Merged in dev: #1184  <!-- For pass CI -->