### PR TITLE
[Bug fixes] Revert disabling single-card tests

### DIFF
--- a/tests/single_card_tests/disable_single_card_uts.txt
+++ b/tests/single_card_tests/disable_single_card_uts.txt
@@ -8,7 +8,3 @@ test_layers.py
 test_sigmoid_gate_fusion_triton.py
 test_ai_sigmoid_gate_fusion.py
 test_ai_moe_layer_5.py
-test_sparse_mqa_flash_mla.py
-test_tilelang_csa_indexer_cp.py
-test_tilelang_csa_indexer.py
-test_dsv4_hybrid_attention.py


### PR DESCRIPTION
### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library  | Environment Adaptation ] -->
Execute Infrastructure
### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes
### Description
<!-- Describe what you’ve done -->
Reverts PaddlePaddle/PaddleFleet#1186. This removes `test_sparse_mqa_flash_mla.py`, `test_tilelang_csa_indexer_cp.py`, `test_tilelang_csa_indexer.py`, and `test_dsv4_hybrid_attention.py` from `tests/single_card_tests/disable_single_card_uts.txt`, so the single-card CI script will execute them again.