### PR TITLE
[codex] Add -s to pytest test scripts

### DIFF
--- a/ci/single_card_sonic.sh
+++ b/ci/single_card_sonic.sh
@@ -32,7 +32,7 @@ for test_file in "${test_cases_list[@]}"; do
 
     echo "Running single card test: $test_file"
     run_count=$((run_count + 1))
-    coverage run -m pytest "$test_file"
+    coverage run -m pytest -s "$test_file"
     exit_code=$?
     if [ $exit_code -ne 0 ]; then
         echo "Test FAILED: $test_file, see log for details..."

--- a/ci/single_card_test.sh
+++ b/ci/single_card_test.sh
@@ -50,11 +50,11 @@ for test_file in $(find $test_dir -type f -name "test_*.py"); do
     echo "Running single card test: $test_file"
     run_count=$((run_count + 1))
     if [[ "${WITH_COVERAGE:-OFF}" == "ON" ]];then
-        # uv run -m coverage run -m pytest "$test_file"
-        coverage run -m pytest "$test_file"
+        # uv run -m coverage run -m pytest -s "$test_file"
+        coverage run -m pytest -s "$test_file"
     else
-        # uv run pytest "$test_file"
-        pytest "$test_file"
+        # uv run pytest -s "$test_file"
+        pytest -s "$test_file"
     fi
     exit_code=$?
     if [ $exit_code -ne 0 ]; then


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->

Distributed Strategy

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
## 变更说明

- 在 `ci/single_card_test.sh` 的 `coverage run -m pytest` 和直接 `pytest` 调用里添加 `-s`。
- 在 `ci/single_card_sonic.sh` 的 `coverage run -m pytest` 调用里添加 `-s`。
- 同步更新 `single_card_test.sh` 中注释掉的 `uv run` 示例命令。

## 变更原因

`pytest -s` 会关闭 stdout/stderr 捕获，单测失败时可以直接输出更完整的报错信息，方便 CI 日志定位问题。

## 验证

- `git diff --check upstream/develop...HEAD`
- `bash -n ci/single_card_test.sh`
- `bash -n ci/single_card_sonic.sh`

未运行完整单测；这些脚本依赖 Paddle CI/GPU 运行环境。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否
