### PR TITLE
Fix CP scatter placement in gpt_embedding to occur before RoPE generation

### DIFF
--- a/src/paddlefleet/models/gpt/gpt_embedding.py
+++ b/src/paddlefleet/models/gpt/gpt_embedding.py
@@ -445,6 +445,22 @@ class GPTEmbedding(FleetLayer):
                     )
                     if self.config.clone_scatter_output_in_embedding:
                         decoder_input = decoder_input.clone()
+            # CP scatter for the plain (no-MTP, no-multimodal) path must happen
+            # before rope generation so that get_rotary_seq_len sees local seq len.
+            if (
+                not self.multimodal_embedding
+                and not (
+                    self.config.num_nextn_predict_layers
+                    and self.config.num_nextn_predict_layers > 0
+                    and not self.config.mtp_load_weight_only
+                )
+                and get_context_parallel_world_size() > 1
+                and self.config.experimental_dataflow
+            ):
+                decoder_input = ContextParallelScatterOp.apply(
+                    decoder_input, axis=1, mode=self.config.cp_balance_mode
+                )
+
         # Rotary positional embeddings (embedding is None for PP intermediate devices)
         rotary_pos_emb = None
         rotary_pos_cos = None
@@ -551,20 +567,6 @@ class GPTEmbedding(FleetLayer):
             get_context_parallel_world_size() > 1
             and self.config.experimental_dataflow
         ):
-            # MTP and multimodal paths scatter decoder_input internally;
-            # only scatter here for the plain (no-MTP, no-multimodal) path.
-            if (
-                not (
-                    self.config.num_nextn_predict_layers
-                    and self.config.num_nextn_predict_layers > 0
-                    and not self.config.mtp_load_weight_only
-                )
-                and not self.multimodal_embedding
-                and self.config.experimental_dataflow
-            ):
-                decoder_input = ContextParallelScatterOp.apply(
-                    decoder_input, axis=1
-                )
             if rotary_pos_emb is not None:
                 rotary_pos_emb = ContextParallelScatterOp.apply(
                     rotary_pos_emb, axis=1, mode=self.config.cp_balance_mode


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Distributed Strategy

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Fix CP scatter placement in gpt_embedding to occur before RoPE generation

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
是