### PR TITLE
[release/0.3] fix layer_idx if training with empty layer in head

### DIFF
--- a/src/paddlefleet/transformer/dsv4_hybrid_attention.py
+++ b/src/paddlefleet/transformer/dsv4_hybrid_attention.py
@@ -160,7 +160,8 @@ class DSv4HybridAttention(Attention):
             layer_idx = self.config.num_hidden_layers + layer_number
             compress_ratio = self.config.csa_compress_ratios[layer_idx]
         else:
-            compress_ratio = self.config.csa_compress_ratios[layer_number]
+            layer_idx = layer_number - self.config.num_empty_layers_add_in_head
+            compress_ratio = self.config.csa_compress_ratios[layer_idx]
         # Per-layer RoPE (potentially different base for compressed layers)
         rope_base = getattr(config, "rotary_base", 10000)
         if compress_ratio > 1:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->

Distributed Strategy

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复bug，索引未考虑空层的情况

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否

Cherry-pick of #1181 to `release/0.3`.

Merged in dev: #1181  <!-- For pass CI -->