### PR TITLE
[DSv4 CSA] Fix unexpected CPU hang in tensor slicing

### DIFF
--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -435,9 +435,9 @@ def _apply_rope(
     if doc_lens_cutoff is not None:
         freqs = freqs[:, :max_cutoff_doc_len:ratio, :, :]
         doc_freqs = [
-            freqs[:, : int(doc_len.item()), :, :]
-            for doc_len in compressed_doc_lens
-            if int(doc_len.item()) > 0
+            freqs[:, :doc_len, :, :]
+            for doc_len in compressed_doc_lens.tolist()
+            if doc_len > 0
         ]
         if doc_freqs:
             freqs = paddle.concat(doc_freqs, axis=1)

--- a/src/paddlefleet/transformer/dsv4_hybrid_attention.py
+++ b/src/paddlefleet/transformer/dsv4_hybrid_attention.py
@@ -76,7 +76,7 @@ def build_document_rope_freqs(
     else:
         freqs, mscale = _rope_result, 1.0
     freqs = freqs.squeeze(0).squeeze(1)
-    doc_freqs = [freqs[: int(doc_len.item())] for doc_len in doc_lens]
+    doc_freqs = [freqs[:doc_len] for doc_len in doc_lens.tolist()]
     freqs = paddle.concat(doc_freqs, axis=0)
     if freqs.shape[0] < sq:
         freqs = paddle.concat(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
Performance Optimization


### PR Types
Bug fixes


### Description
### 修复 2 处诡异的 CPU hang 问题

倒不是说用 tolist 比用 item 更快，但是原来用 item 的写法每次调用会产生 15ms 的 hang，即使这个列表只有几个元素，原因不明，换成 toliist 后就正常了

前向一共调用了 3 次这样的 bug 代码，那就是 45ms，加上我们是 full recompute，每次 1F1B 就产生了 90ms 的 hang！

AI 说可能是`for elem in tensor`这种写法会在 GPU tensor 上构造一个迭代器，而这个迭代器的析构速度很慢，导致了 CPU hang，但是实际上我抽单测出来是复现不了的，所以无法证明原因

### 是否引起精度变化
否
