### PR TITLE
feat: context-aware gated N-gram embedding with causal dilated conv

### DIFF
--- a/src/paddlefleet/models/common/embeddings/language_model_embedding.py
+++ b/src/paddlefleet/models/common/embeddings/language_model_embedding.py
@@ -73,11 +73,22 @@ class LanguageModelEmbedding(FleetLayer):
                 "must be set to True."
             )
         self.tp_group = get_tensor_model_parallel_group_if_none(tp_group)
+
+        # N-gram Embedding flag (read early for reduce_scatter decision)
+        self.ngram_embedding_enabled = getattr(
+            config, "ngram_embedding_enabled", False
+        )
+
+        # When N-gram embedding is enabled, we must disable the early
+        # reduce_scatter inside VocabParallelEmbedding, because ngram signal
+        # is computed in [B, S, H] layout and must be fused before any
+        # transpose/scatter. The scatter will happen later in forward().
         self.reduce_scatter_embeddings = (
             (not self.add_position_embedding)
             and self.num_tokentypes <= 0
             and self.sequence_parallel
             and self.scatter_to_sequence_parallel
+            and not self.ngram_embedding_enabled
         )
 
         # Word embeddings (parallel).
@@ -113,6 +124,22 @@ class LanguageModelEmbedding(FleetLayer):
                 )
         else:
             self.tokentype_embeddings = None
+
+        # N-gram Embedding (LongCat-style)
+        if self.ngram_embedding_enabled:
+            from paddlefleet.models.common.embeddings.ngram_embedding import NgramEmbedding
+            self.ngram_embedding = NgramEmbedding(
+                config=config, vocab_size=self.vocab_size
+            )
+
+        # Context-aware gated N-gram embedding
+        self.ngram_gate_enabled = (
+            self.ngram_embedding_enabled
+            and getattr(config, "ngram_gate_enabled", False)
+        )
+        if self.ngram_gate_enabled:
+            from paddlefleet.models.common.embeddings.ngram_gated_embedding import NgramGatedEmbedding
+            self.ngram_gate = NgramGatedEmbedding(config=config)
 
         # Embeddings dropout
         self.embedding_dropout = paddle.nn.Dropout(
@@ -151,6 +178,17 @@ class LanguageModelEmbedding(FleetLayer):
             Tensor: The output embeddings
         """
         embed_tokens = self.embed_tokens(input_ids)
+
+        # N-gram Embedding injection
+        if self.ngram_embedding_enabled:
+            if self.ngram_gate_enabled:
+                ngram_projections = self.ngram_embedding.forward_per_table(input_ids)
+                embed_tokens = self.ngram_gate(embed_tokens, ngram_projections)
+            else:
+                ngram_signal = self.ngram_embedding(input_ids)
+                normalizer = 1 + self.ngram_embedding.num_embedders
+                embed_tokens = (embed_tokens + ngram_signal) / normalizer
+
         if self.add_position_embedding:
             position_embeddings = self.position_embeddings(position_ids)
             embeddings = embed_tokens + position_embeddings

--- a/src/paddlefleet/models/common/embeddings/ngram_embedding.py
+++ b/src/paddlefleet/models/common/embeddings/ngram_embedding.py
@@ -1,0 +1,184 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+N-gram Embedding module for LLM pre-training.
+
+Implements LongCat-style N-gram Embedding Scaling:
+- Polynomial rolling hash for N-gram ID computation
+- Multiple sub-tables (K splits) per N-gram level to reduce hash collisions
+- Linear projection from sub-embedding dim to hidden_size
+- Averaged injection: output = (word_emb + sum(proj(ngram_emb))) / normalizer
+
+Reference: Meituan LongCat-Flash-Lite (https://huggingface.co/meituan-longcat/LongCat-Flash-Lite)
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import paddle
+import paddle.nn as nn
+from paddle import Tensor
+
+if TYPE_CHECKING:
+    from paddlefleet.transformer.transformer_config import TransformerConfig
+
+
+class NgramEmbedding(nn.Layer):
+    """N-gram Embedding with polynomial rolling hash and multi-table lookup.
+
+    Given input_ids [B, S], computes N-gram hash IDs for each (n, k) pair,
+    looks up sub-embeddings, projects to hidden_size, and returns the aggregated
+    N-gram signal to be added to the standard word embeddings.
+    """
+
+    def __init__(self, config: TransformerConfig, vocab_size: int):
+        super().__init__()
+
+        self.hidden_size = config.hidden_size
+        self.vocab_size = vocab_size
+
+        self.m = int(config.ngram_vocab_size_ratio * vocab_size)
+        self.k = config.ngram_emb_split_num
+        self.n = config.ngram_emb_neighbor_num
+        self.pad_token_id = getattr(config, "ngram_pad_token_id", 0)
+
+        num_embedders = self.k * (self.n - 1)
+        self.num_embedders = num_embedders
+
+        configured_emb_dim = getattr(config, "ngram_emb_dim", 0)
+        if configured_emb_dim > 0:
+            self.emb_dim = configured_emb_dim
+        else:
+            self.emb_dim = self.hidden_size // num_embedders
+
+        self.normalizer = 1 + num_embedders
+
+        embedders = []
+        post_projs = []
+        for i in range(num_embedders):
+            emb_vocab_size = int(self.m + i * 2 + 1)
+            emb = nn.Embedding(emb_vocab_size, self.emb_dim)
+            proj = nn.Linear(self.emb_dim, self.hidden_size, bias_attr=False)
+            embedders.append(emb)
+            post_projs.append(proj)
+
+        self.embedders = nn.LayerList(embedders)
+        self.post_projs = nn.LayerList(post_projs)
+
+        self._vocab_mods_cache = None
+
+    def _precompute_vocab_mods(self):
+        """Precompute (vocab_size^k) mod emb_vocab_dim for each (n, k) pair."""
+        if self._vocab_mods_cache is not None:
+            return self._vocab_mods_cache
+
+        vocab_mods = {}
+        for i in range(2, self.n + 1):
+            for j in range(self.k):
+                index = (i - 2) * self.k + j
+                emb_vocab_dim = int(self.m + index * 2 + 1)
+
+                mods = []
+                power_mod = 1
+                for _ in range(i - 1):
+                    power_mod = (power_mod * self.vocab_size) % emb_vocab_dim
+                    mods.append(power_mod)
+
+                vocab_mods[(i, j)] = mods
+
+        self._vocab_mods_cache = vocab_mods
+        return vocab_mods
+
+    def _compute_shifted_ids(self, input_ids: Tensor) -> dict:
+        """Compute right-shifted input_ids for each offset k."""
+        shifted_ids = {}
+        B, S = input_ids.shape
+
+        for k in range(1, self.n):
+            shifted = paddle.full([B, k], self.pad_token_id, dtype=input_ids.dtype)
+            shifted = paddle.concat([shifted, input_ids[:, :S - k]], axis=1)
+            shifted_ids[k + 1] = shifted
+
+        return shifted_ids
+
+    def _compute_ngram_hash_ids(
+        self, input_ids: Tensor, shifted_ids: dict, vocab_mods: dict, ngram: int, split_idx: int
+    ) -> Tensor:
+        """Compute N-gram hash IDs using polynomial rolling hash."""
+        index = (ngram - 2) * self.k + split_idx
+        emb_vocab_dim = int(self.m + index * 2 + 1)
+        mods = vocab_mods[(ngram, split_idx)]
+
+        ngram_ids = input_ids.cast("int64")
+        for k_offset in range(2, ngram + 1):
+            ngram_ids = ngram_ids + shifted_ids[k_offset].cast("int64") * mods[k_offset - 2]
+
+        ngram_ids = ngram_ids % emb_vocab_dim
+        return ngram_ids
+
+    def forward(self, input_ids: Tensor) -> Tensor:
+        """Compute N-gram embedding signal.
+
+        Args:
+            input_ids: [B, S] input token IDs
+
+        Returns:
+            [B, S, H] N-gram embedding signal
+        """
+        vocab_mods = self._precompute_vocab_mods()
+        shifted_ids = self._compute_shifted_ids(input_ids)
+
+        ngram_output = paddle.zeros(
+            [input_ids.shape[0], input_ids.shape[1], self.hidden_size],
+            dtype=self.embedders[0].weight.dtype,
+        )
+
+        for i in range(2, self.n + 1):
+            for j in range(self.k):
+                index = (i - 2) * self.k + j
+
+                hash_ids = self._compute_ngram_hash_ids(
+                    input_ids, shifted_ids, vocab_mods, ngram=i, split_idx=j
+                )
+
+                x_ngram = self.embedders[index](hash_ids)
+                x_proj = self.post_projs[index](x_ngram)
+                ngram_output = ngram_output + x_proj
+
+        return ngram_output
+
+    def forward_per_table(self, input_ids: Tensor) -> list:
+        """Return individual projected ngram embeddings per sub-table.
+
+        Returns:
+            list of K*(N-1) tensors, each [B, S, H], ordered as
+            [(n=2,k=0), (n=2,k=1), ..., (n=3,k=0), ..., (n=3,k=K-1)]
+        """
+        vocab_mods = self._precompute_vocab_mods()
+        shifted_ids = self._compute_shifted_ids(input_ids)
+
+        projections = []
+        for i in range(2, self.n + 1):
+            for j in range(self.k):
+                index = (i - 2) * self.k + j
+                hash_ids = self._compute_ngram_hash_ids(
+                    input_ids, shifted_ids, vocab_mods, ngram=i, split_idx=j
+                )
+                x_ngram = self.embedders[index](hash_ids)
+                x_proj = self.post_projs[index](x_ngram)
+                projections.append(x_proj)
+
+        return projections

--- a/src/paddlefleet/models/common/embeddings/ngram_gated_embedding.py
+++ b/src/paddlefleet/models/common/embeddings/ngram_gated_embedding.py
@@ -1,0 +1,127 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Context-aware gated N-gram embedding with causal depthwise dilated convolution.
+
+Uses DeepSeek V4-style sqrt(softplus) scoring with competitive normalization
+to dynamically weight unigram and ngram sub-table contributions based on
+local context captured via dilated causal convolutions.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import paddle
+import paddle.nn as nn
+import paddle.nn.functional as F
+from paddle import Tensor
+
+if TYPE_CHECKING:
+    from paddlefleet.transformer.transformer_config import TransformerConfig
+
+
+class NgramGatedEmbedding(nn.Layer):
+    """Context-aware gated mixing of unigram + ngram sub-table projections.
+
+    Each ngram level uses a causal depthwise conv with dilation = ngram_order,
+    capturing context at the appropriate scale. Gate scores are computed via
+    sqrt(softplus) and normalized to create competition.
+    """
+
+    def __init__(self, config: TransformerConfig):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.n = config.ngram_emb_neighbor_num
+        self.k = config.ngram_emb_split_num
+        self.kernel_size = config.ngram_gate_conv_kernel_size
+        self.route_scale = config.ngram_gate_route_scale
+
+        self.num_experts = 1 + self.k * (self.n - 1)
+
+        # Causal depthwise dilated convolutions: dilation = 1, 2, ..., n
+        self.convs = nn.LayerList()
+        for i in range(self.n):
+            dilation = i + 1
+            padding = (self.kernel_size - 1) * dilation
+            self.convs.append(
+                nn.Conv1D(
+                    in_channels=self.hidden_size,
+                    out_channels=self.hidden_size,
+                    kernel_size=self.kernel_size,
+                    groups=self.hidden_size,
+                    padding=padding,
+                    dilation=dilation,
+                    bias_attr=False,
+                    data_format="NCL",
+                )
+            )
+
+        # Gate projection: dilation=1 → 1 score (unigram), others → K scores
+        self.gate_projs = nn.LayerList()
+        self.gate_projs.append(nn.Linear(self.hidden_size, 1, bias_attr=False))
+        for _ in range(self.n - 1):
+            self.gate_projs.append(
+                nn.Linear(self.hidden_size, self.k, bias_attr=False)
+            )
+
+        self._init_gate_weights()
+
+    def _init_gate_weights(self):
+        for proj in self.gate_projs:
+            nn.initializer.Normal(mean=0.0, std=0.01)(proj.weight)
+
+    def forward(
+        self, word_emb: Tensor, ngram_projections: list
+    ) -> Tensor:
+        """Compute gated mixture of unigram and ngram projections.
+
+        Args:
+            word_emb: [B, S, H] word embedding (unigram expert)
+            ngram_projections: list of K*(N-1) tensors each [B, S, H]
+
+        Returns:
+            [B, S, H] gated output
+        """
+        B, S, H = word_emb.shape
+        input_dtype = word_emb.dtype
+
+        # [B, S, H] -> [B, H, S] for NCL conv
+        x_ncl = word_emb.transpose([0, 2, 1])
+
+        # Compute gate logits via dilated convs
+        all_scores = []
+        for conv, gate_proj in zip(self.convs, self.gate_projs):
+            conv_out = conv(x_ncl)[..., :S]  # [B, H, S] causal trim
+            conv_out = conv_out.transpose([0, 2, 1])  # [B, S, H]
+            all_scores.append(gate_proj(conv_out))  # [B, S, 1] or [B, S, K]
+
+        logits = paddle.concat(all_scores, axis=-1)  # [B, S, num_experts]
+
+        # sqrt(softplus) scoring with fp32 for stability
+        logits_fp32 = logits.cast("float32")
+        scores = paddle.sqrt(F.softplus(logits_fp32))
+        gate_weights = scores / scores.sum(axis=-1, keepdim=True)
+        gate_weights = (gate_weights * self.route_scale).cast(input_dtype)
+
+        # Weighted sum of experts
+        experts = paddle.stack(
+            [word_emb] + ngram_projections, axis=2
+        )  # [B, S, num_experts, H]
+
+        output = (
+            gate_weights.unsqueeze(-1) * experts
+        ).sum(axis=2)  # [B, S, H]
+
+        return output

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -630,6 +630,36 @@ class TransformerConfig(ModelParallelConfig):
     """When using_sonic_moe is enabled, the computation part of the moelayer will use the implementation provided by SonicMoE."""
 
     ####################
+    # N-gram Embedding (LongCat-style)
+    ####################
+    ngram_embedding_enabled: bool = False
+    """Master switch for N-gram Embedding. When False, model degrades to baseline."""
+
+    ngram_vocab_size_ratio: float = 12.2
+    """Ratio multiplier: ngram_vocab_size = vocab_size * ngram_vocab_size_ratio."""
+
+    ngram_emb_neighbor_num: int = 3
+    """Max N-gram order. 3 means bigram + trigram."""
+
+    ngram_emb_split_num: int = 4
+    """Number of sub-tables (hash functions) per N-gram level."""
+
+    ngram_emb_dim: int = 0
+    """Sub-embedding dimension per table. 0 means auto (hidden_size // num_embedders)."""
+
+    ngram_pad_token_id: int = 0
+    """Token ID used for padding when shifting sequences for N-gram computation."""
+
+    ngram_gate_enabled: bool = False
+    """Enable context-aware gated N-gram embedding. Replaces simple averaging."""
+
+    ngram_gate_conv_kernel_size: int = 7
+    """Kernel size for causal depthwise dilated convolutions in gate."""
+
+    ngram_gate_route_scale: float = 1.0
+    """Scale factor for normalized gate weights."""
+
+    ####################
     # MLA
     ####################
     """Configuration object for paddlefleet Multi-Latent Attention (MLA) transformers.


### PR DESCRIPTION
## Summary

Replace simple averaging and sigmoid/softmax gates with **DeepSeek V4-style sqrt(softplus) scoring + competitive normalization** for N-gram Embedding fusion. Uses causal depthwise dilated convolutions to compute context-aware gate weights, enabling dynamic token-adaptive specialization across unigram and ngram sub-table experts.

## Architecture

```
word_emb [B, S, H]
    │
    ├── expert_0: word_emb (unigram)
    ├── expert_1..4: bigram sub-table projections
    └── expert_5..8: trigram sub-table projections
    │
    └── Causal Depthwise Dilated Conv × N levels
         │  dilation=1 (unigram context)  → Linear → 1 score
         │  dilation=2 (bigram context)   → Linear → K scores
         │  dilation=3 (trigram context)  → Linear → K scores
         ▼
    sqrt(softplus(logits)) → normalize → gate_weights [B, S, 9]
         │
         ▼ output = Σ(gate_i × expert_i)
```

## Key Design

- **sqrt(softplus)** scoring: `sqrt(log(1 + exp(x)))` — non-negative, non-saturating, validated by DeepSeek V4
- **Competitive normalization**: L1-normalize creates zero-sum competition among experts
- **Multi-scale context**: Different dilation per ngram level (d=1,2,3) captures context at appropriate scales
- **Causal**: Left-padding + trim ensures future tokens cannot influence current position
- **Near-uniform init**: Gate projection ~ Normal(0, 0.01) → initial gate ≈ 1/9 per expert, compatible with pretrained checkpoints

## Changes

| File | Change |
|------|--------|
| `ngram_gated_embedding.py` | **New** — Core `NgramGatedEmbedding` module |
| `ngram_embedding.py` | **New** — LongCat-style N-gram embedding + `forward_per_table()` |
| `language_model_embedding.py` | Integrate ngram + gated path |
| `transformer_config.py` | Add 9 config fields (ngram + gate) |

## Config

```yaml
ngram_embedding_enabled: true
ngram_vocab_size_ratio: 12.2
ngram_emb_neighbor_num: 3
ngram_emb_split_num: 4
ngram_gate_enabled: true
ngram_gate_conv_kernel_size: 7
ngram_gate_route_scale: 1.0
```

## Overhead

- Params: ~123K (negligible vs model)
- FLOPs: ~1B/batch (negligible vs transformer ~1T/layer)
- Memory: bounded by [B, S, 9, H] expert stack (temporary)

## Related

- Based on N-gram Embedding infrastructure from PR #956
- Replaces sigmoid gate (v1) which collapsed to near-constant behavior
- Inspired by DeepSeek V4 MoE gating (arxiv 2606.19348)
