### PR TITLE
[release/0.3][CI] Fix ARM ops package build dependencies

### DIFF
--- a/.github/workflows/pr_update_ops.yml
+++ b/.github/workflows/pr_update_ops.yml
@@ -480,7 +480,7 @@ jobs:
             export PADDLEFLEET_VERSION=$VERSION
           fi
           export IS_NVIDIA=True
-          /usr/bin/python -m pip install --break-system-packages packaging "setuptools>=66.1.0" wheel
+          /usr/bin/python -m pip install --break-system-packages packaging "setuptools>=66.1.0" wheel "ninja==1.11.1.1" "pybind11[global]>=2.13,<3"
           /usr/bin/python -m pip install --break-system-packages "nvidia-nvshmem-cu13>=3.3.9,<3.5"
           # HybridEP links against NVML by soname; install dev stubs for libnvidia-ml.so.1.
           apt-get update && apt-get install -y --no-install-recommends libnvidia-ml-dev


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Bug fixes

### Description
Add the missing `ninja==1.11.1.1` and `pybind11[global]>=2.13,<3` build dependencies to the ARM `publish-ops-wheel-arm` path in `.github/workflows/pr_update_ops.yml`, matching the existing x86 ops wheel build setup.

This fixes the ARM ops package build failure where `nvidia-cudnn-frontend` could not find `pybind11Config.cmake`:
https://github.com/PaddlePaddle/PaddleFleet/actions/runs/27255893494/job/80590412767

Validation:
- `git diff --check -- .github/workflows/pr_update_ops.yml`
- `ruby -e 'require "yaml"; YAML.load_file(ARGV[0]); puts "YAML parse ok"' .github/workflows/pr_update_ops.yml`

### 是否引起精度变化
否


Cherry-pick of #1209 to `release/0.3`.

Merged in dev: #1209  <!-- For pass CI -->