### PR TITLE
[New features] Add multimax LM-head modulation

### DIFF
--- a/src/paddlefleet/models/common/language_loss/language_loss.py
+++ b/src/paddlefleet/models/common/language_loss/language_loss.py
@@ -247,12 +247,18 @@ class LanguageLoss(FleetLayer):
                 LigerFusedLinearCrossEntropyFunction,
             )
 
-            hidden_states, weight, bias = logits
+            hidden_states, weight, bias = logits[:3]
+            # Multimax lm_head fused path: GPTLMHead emits a 5-tuple
+            # (hidden_states, weight, bias, multimax_ranges, multimax_ts)
+            # so SeLU is applied inside the chunked CE kernel without
+            # materializing full [B, S, V] logits.
+            multimax_ranges = logits[3] if len(logits) > 3 else None
+            multimax_ts = logits[4] if len(logits) > 4 else None
             B, S, H = hidden_states.shape
             _input = hidden_states.reshape([-1, H])
             _labels = labels.reshape([-1])
 
-            loss_1d = LigerFusedLinearCrossEntropyFunction.apply(
+            apply_args = [
                 _input,
                 weight,
                 _labels,
@@ -263,7 +269,11 @@ class LanguageLoss(FleetLayer):
                 getattr(
                     self.config, "gpt_model_use_experimental_version", False
                 ),
-            )
+            ]
+            if multimax_ranges is not None and multimax_ts is not None:
+                apply_args.append(multimax_ranges)
+                apply_args.append(multimax_ts)
+            loss_1d = LigerFusedLinearCrossEntropyFunction.apply(*apply_args)
             # Reshape back to [B, S] so downstream CP gather / lossmask
             # handling matches the non-fused path exactly.
             loss = loss_1d.reshape([B, S])

--- a/src/paddlefleet/models/common/language_loss/language_loss.py
+++ b/src/paddlefleet/models/common/language_loss/language_loss.py
@@ -250,7 +250,7 @@ class LanguageLoss(FleetLayer):
             hidden_states, weight, bias = logits[:3]
             # Multimax lm_head fused path: GPTLMHead emits a 5-tuple
             # (hidden_states, weight, bias, multimax_ranges, multimax_ts)
-            # so SeLU is applied inside the chunked CE kernel without
+            # so SegLU is applied inside the chunked CE kernel without
             # materializing full [B, S, V] logits.
             multimax_ranges = logits[3] if len(logits) > 3 else None
             multimax_ts = logits[4] if len(logits) > 4 else None

--- a/src/paddlefleet/models/gpt/lm_head.py
+++ b/src/paddlefleet/models/gpt/lm_head.py
@@ -12,6 +12,53 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# =============================================================================
+# Multimax lm_head support
+# -----------------------------------------------------------------------------
+# When TransformerConfig.multimax in {"lm_head", "all"}, GPTLMHead adds two
+# learnable [4]-shape parameters (multimax_ranges, multimax_ts) and applies a
+# SeLU-style segmented modulation to logits before softmax/cross-entropy:
+#
+#     logits = SeLU(logits, multimax_ranges, multimax_ts)
+#
+# Both params are initialized to zero, which makes SeLU the identity at
+# step 0 (safe for resume from checkpoints lacking these keys).
+#
+# The "multimax" substring in the parameter names is matched by the
+# pretraining trainers' no-weight-decay name filter, so these params are
+# excluded from weight decay (timm-style convention).
+#
+# Sanity-check after a training launch:
+#
+#     grep -E "MULTIMAX-(CONFIG|LMHEAD-CONFIRM|LMHEAD-APPLIED)" <train.log>
+#
+# Expected output (per rank holding the LM head):
+#   [MULTIMAX-CONFIG]            multimax=lm_head
+#   [MULTIMAX-LMHEAD-CONFIRM]    cls=... multimax=lm_head ranges.shape=[4] ...
+#   [MULTIMAX-LMHEAD-APPLIED]    cls=... logits.shape=[...] ranges=[...] ts=[...]
+#                                (or path=fused for the fused-CE branch)
+#
+# If [MULTIMAX-LMHEAD-APPLIED] is missing, the SeLU path did not execute
+# (e.g., a different LM head class is used).
+#
+# Paths:
+#   - fused_linear_ce_loss_chunk == 0: SeLU is applied here on the [B, S, V]
+#     logits tensor right before the cross-entropy. Wrapped in `recompute` and
+#     uses an in-place `+=` accumulator to bound peak activation memory.
+#   - fused_linear_ce_loss_chunk  > 0: GPTLMHead emits a 5-tuple
+#     (hidden, weight, bias, multimax_ranges, multimax_ts) and SeLU is
+#     applied inside each CE chunk by LigerFusedLinearCrossEntropyFunction.
+#     This avoids ever materializing the full [B*S, V] logits tensor and is
+#     the recommended path at large vocab.
+#
+# Notes:
+#   - SeLU is element-wise, so vocab-TP sharding is fine without collectives.
+#   - Both paths share the same parameters (multimax_ranges/multimax_ts) and
+#     produce identical math at step 0 (params init to zero -> SeLU = id).
+# =============================================================================
+
+import warnings
+
 import paddle
 from paddle.distributed.fleet.meta_parallel import (
     ScheduleNode,
@@ -27,6 +74,44 @@ from paddlefleet.tensor_parallel.layers import (
     _initialize_affine_weight_gpu,
 )
 from paddlefleet.transformer.identity_op import IdentityOp
+
+
+def SeLU(x, ranges, ts):
+    """Learnable segmented activation applied to logits before softmax.
+
+    Reference: ViT-style modulation provided by user.
+        x: [..., V] logits (last dim may be vocab-parallel sharded; SeLU is
+           element-wise so applying it on the sharded logits is equivalent to
+           applying it on gathered logits).
+        ranges: [4] learnable thresholds.
+        ts:     [4] learnable scales.
+
+    With ranges/ts initialized to zero, SeLU is the identity (logits unchanged),
+    so adding this op is a no-op at start of training and safe for resume.
+
+    Memory-efficient eager form: instead of building one giant expression
+    ``out = x + a + b + c + d`` (which materializes 4 sum-intermediates each
+    the size of logits), we accumulate into a single owned buffer with ``+=``.
+    Combined with ``recompute`` at the call site, peak activation memory for
+    this op drops from ~10x the logits tensor to ~1x.
+
+    NOTE on jit fusion: an earlier version was wrapped with
+    ``@paddle.jit.to_static`` to fuse the element-wise chain. That backend
+    (CINN) was observed to OOM on full-vocab logits because CINN allocates
+    all traced intermediates inside a single ``CinnJitInstruction::Run`` call,
+    which defeats both ``recompute`` and the in-place ``+=`` hints. We use
+    the eager path here.
+    """
+    relu = paddle.nn.functional.relu
+    # Clone once so we own the buffer and in-place += is safe under autograd
+    # (the original `x` -- the linear's output -- must not be mutated, since
+    # it may still be referenced by the autograd graph upstream).
+    out = x.clone()
+    out += ts[0] * relu(ranges[0] - x)
+    out += ts[1] * relu(x - ranges[1])
+    out += ts[2] * relu(ranges[2] - x) ** 2
+    out += ts[3] * relu(x - ranges[3]) ** 2
+    return out
 
 
 class GPTLMHead(ColumnParallelLinear):
@@ -97,6 +182,45 @@ class GPTLMHead(ColumnParallelLinear):
             block_attn_res_spec, config=self.config
         )
 
+        # Multimax: learnable SeLU-style modulation on logits before softmax.
+        # Names contain the "multimax" substring so the trainer's no-decay
+        # filter excludes them from weight decay (mirrors timm's convention
+        # of not decaying scalar/1-D learnable coefficients).
+        multimax_mode = getattr(self.config, "multimax", None)
+        self.use_multimax_lmhead = multimax_mode in ("lm_head", "all")
+        if self.use_multimax_lmhead:
+            # Init to zero -> SeLU is identity at step 0, so resuming from a
+            # checkpoint that lacks these params (loaded non-strictly) yields
+            # bit-identical logits until the params start updating.
+            self.multimax_ranges = self.create_parameter(
+                shape=[4],
+                dtype=self.config.params_dtype,
+                is_bias=False,
+                default_initializer=paddle.nn.initializer.Constant(0.0),
+            )
+            self.multimax_ts = self.create_parameter(
+                shape=[4],
+                dtype=self.config.params_dtype,
+                is_bias=False,
+                default_initializer=paddle.nn.initializer.Constant(0.0),
+            )
+            # Grep-friendly construction banner. See docstring at top of file
+            # for the full sanity-check workflow.
+            warnings.warn(
+                f"[MULTIMAX-LMHEAD-CONFIRM] cls={type(self).__name__} "
+                f"multimax={multimax_mode} "
+                f"ranges.shape={list(self.multimax_ranges.shape)} "
+                f"ts.shape={list(self.multimax_ts.shape)} "
+                f"dtype={self.config.params_dtype} "
+                f"fused_linear_ce_loss_chunk="
+                f"{getattr(self.config, 'fused_linear_ce_loss_chunk', 0)}"
+            )
+        else:
+            warnings.warn(
+                f"[MULTIMAX-LMHEAD-CONFIRM] cls={type(self).__name__} "
+                f"multimax={multimax_mode} (disabled, no params created)"
+            )
+
     def build_schedule_node(self):
         return ScheduleNode(self.forward, name="GPTLMHead")
 
@@ -108,6 +232,33 @@ class GPTLMHead(ColumnParallelLinear):
             if self.config.sequence_parallel:
                 # [S, B, H] -> [B, S, H] to match the logits layout consumers expect.
                 hidden_states = hidden_states.transpose([1, 0, 2]).contiguous()
+
+            # Multimax lm_head + fused path: thread multimax_ranges/ts into
+            # LanguageLoss so SeLU is applied inside each CE chunk and never
+            # materializes a full [B*S, V] logits tensor. Also fire the same
+            # one-shot rank-0 [MULTIMAX-LMHEAD-APPLIED] grep banner used by
+            # the unfused path so observability is consistent.
+            if getattr(self, "use_multimax_lmhead", False):
+                if not getattr(self, "_multimax_applied_logged", False):
+                    try:
+                        _rank = paddle.distributed.get_rank()
+                    except Exception:
+                        _rank = 0
+                    if _rank == 0:
+                        warnings.warn(
+                            f"[MULTIMAX-LMHEAD-APPLIED] cls={type(self).__name__} "
+                            f"path=fused hidden.shape={list(hidden_states.shape)} "
+                            f"ranges={self.multimax_ranges.detach().cast('float32').numpy().tolist()} "
+                            f"ts={self.multimax_ts.detach().cast('float32').numpy().tolist()}"
+                        )
+                    self._multimax_applied_logged = True
+                return (
+                    hidden_states,
+                    self.weight,
+                    self.bias,
+                    self.multimax_ranges,
+                    self.multimax_ts,
+                )
 
             return (hidden_states, self.weight, self.bias)
 
@@ -126,6 +277,37 @@ class GPTLMHead(ColumnParallelLinear):
             logits, _ = super().forward(hidden_states, self.weight.T)
         if self.config.sequence_parallel:
             logits = logits.transpose([1, 0, 2]).contiguous()
+
+        # Multimax lm_head (unfused path): apply learnable SeLU modulation on
+        # logits before softmax/cross-entropy. SeLU is element-wise so it works
+        # correctly on vocab-parallel sharded logits without extra collectives.
+        # The fused path (fused_linear_ce_loss_chunk > 0) returns early above
+        # with a 5-tuple and applies SeLU inside the chunked CE kernel.
+        if getattr(self, "use_multimax_lmhead", False):
+            # One-shot per-rank-0 confirmation that the SeLU path actually
+            # executed at runtime. Grep tag: [MULTIMAX-LMHEAD-APPLIED].
+            if not getattr(self, "_multimax_applied_logged", False):
+                try:
+                    _rank = paddle.distributed.get_rank()
+                except Exception:
+                    _rank = 0
+                if _rank == 0:
+                    warnings.warn(
+                        f"[MULTIMAX-LMHEAD-APPLIED] cls={type(self).__name__} "
+                        f"logits.shape={list(logits.shape)} "
+                        f"ranges={self.multimax_ranges.detach().cast('float32').numpy().tolist()} "
+                        f"ts={self.multimax_ts.detach().cast('float32').numpy().tolist()}"
+                    )
+                self._multimax_applied_logged = True
+            # Wrap SeLU in `recompute` to drop saved intermediates: only the
+            # input logits (already kept by upstream autograd) are saved; SeLU
+            # is re-run during backward. Avoids OOM on full-vocab logits when
+            # `fused_linear_ce_loss_chunk=0` (required by multimax).
+            from paddle.distributed.fleet.utils import recompute
+
+            logits = recompute(
+                SeLU, logits, self.multimax_ranges, self.multimax_ts
+            )
 
         # Loss-path MD5 probe: lm_head weight and logits
         import os
@@ -193,9 +375,20 @@ class GPTLMHead(ColumnParallelLinear):
         self,
         structured_name_prefix: str = "",
     ):
-        """Sharding along axis 0, bias sharded"""
+        """Sharding along axis 0, bias sharded.
+        Multimax params (multimax_ranges, multimax_ts) are replicated across
+        TP ranks (no shard axis); they are listed explicitly so flex-checkpoint
+        saves/loads them.
+        """
         state_dict = self.state_dict(structured_name_prefix="")
-        shard_rules = None if self.world_size == 1 else {"weight": 0, "bias": 0}
+        if self.world_size == 1:
+            shard_rules = None
+        else:
+            shard_rules = {"weight": 0, "bias": 0}
+            if getattr(self, "use_multimax_lmhead", False):
+                # Replicated across TP ranks; mark with shard axis None.
+                shard_rules["multimax_ranges"] = None
+                shard_rules["multimax_ts"] = None
         return build_sharded_state_dict(
             state_dict, shard_rules, structured_name_prefix
         )

--- a/src/paddlefleet/models/gpt/lm_head.py
+++ b/src/paddlefleet/models/gpt/lm_head.py
@@ -15,9 +15,10 @@
 # =============================================================================
 # Multimax lm_head support
 # -----------------------------------------------------------------------------
-# When TransformerConfig.multimax in {"lm_head", "all"}, GPTLMHead adds two
-# learnable [4]-shape parameters (multimax_ranges, multimax_ts) and applies a
-# SeLU-style segmented modulation to logits before softmax/cross-entropy:
+# When TransformerConfig.apply_multimax is a list containing "lm_head" (e.g.,
+# ``apply_multimax: [lm_head]``), GPTLMHead adds two learnable [4]-shape
+# parameters (multimax_ranges, multimax_ts) and applies a SeLU-style segmented
+# modulation to logits before softmax/cross-entropy:
 #
 #     logits = SeLU(logits, multimax_ranges, multimax_ts)
 #
@@ -33,8 +34,8 @@
 #     grep -E "MULTIMAX-(CONFIG|LMHEAD-CONFIRM|LMHEAD-APPLIED)" <train.log>
 #
 # Expected output (per rank holding the LM head):
-#   [MULTIMAX-CONFIG]            multimax=lm_head
-#   [MULTIMAX-LMHEAD-CONFIRM]    cls=... multimax=lm_head ranges.shape=[4] ...
+#   [MULTIMAX-CONFIG]            apply_multimax=['lm_head']
+#   [MULTIMAX-LMHEAD-CONFIRM]    cls=... apply_multimax=['lm_head'] ranges.shape=[4] ...
 #   [MULTIMAX-LMHEAD-APPLIED]    cls=... logits.shape=[...] ranges=[...] ts=[...]
 #                                (or path=fused for the fused-CE branch)
 #
@@ -186,8 +187,8 @@ class GPTLMHead(ColumnParallelLinear):
         # Names contain the "multimax" substring so the trainer's no-decay
         # filter excludes them from weight decay (mirrors timm's convention
         # of not decaying scalar/1-D learnable coefficients).
-        multimax_mode = getattr(self.config, "multimax", None)
-        self.use_multimax_lmhead = multimax_mode in ("lm_head", "all")
+        multimax_mode = getattr(self.config, "apply_multimax", None) or []
+        self.use_multimax_lmhead = "lm_head" in multimax_mode
         if self.use_multimax_lmhead:
             # Init to zero -> SeLU is identity at step 0, so resuming from a
             # checkpoint that lacks these params (loaded non-strictly) yields
@@ -208,18 +209,15 @@ class GPTLMHead(ColumnParallelLinear):
             # for the full sanity-check workflow.
             warnings.warn(
                 f"[MULTIMAX-LMHEAD-CONFIRM] cls={type(self).__name__} "
-                f"multimax={multimax_mode} "
+                f"apply_multimax={multimax_mode} "
                 f"ranges.shape={list(self.multimax_ranges.shape)} "
                 f"ts.shape={list(self.multimax_ts.shape)} "
                 f"dtype={self.config.params_dtype} "
                 f"fused_linear_ce_loss_chunk="
                 f"{getattr(self.config, 'fused_linear_ce_loss_chunk', 0)}"
             )
-        else:
-            warnings.warn(
-                f"[MULTIMAX-LMHEAD-CONFIRM] cls={type(self).__name__} "
-                f"multimax={multimax_mode} (disabled, no params created)"
-            )
+        # When the feature is disabled (default None / empty), stay silent --
+        # no banner, no params -- so default training runs are not noisy.
 
     def build_schedule_node(self):
         return ScheduleNode(self.forward, name="GPTLMHead")

--- a/src/paddlefleet/models/gpt/lm_head.py
+++ b/src/paddlefleet/models/gpt/lm_head.py
@@ -15,8 +15,8 @@
 # =============================================================================
 # Multimax lm_head support
 # -----------------------------------------------------------------------------
-# When TransformerConfig.apply_multimax is a list containing "lm_head" (e.g.,
-# ``apply_multimax: [lm_head]``), GPTLMHead adds two learnable [4]-shape
+# When TransformerConfig.multimax_modules is a list containing "lm_head" (e.g.,
+# ``multimax_modules: [lm_head]``), GPTLMHead adds two learnable [4]-shape
 # parameters (multimax_ranges, multimax_ts) and applies a SegLU-style segmented
 # modulation to logits before softmax/cross-entropy:
 #
@@ -36,8 +36,8 @@
 #     grep -E "MULTIMAX-(CONFIG|LMHEAD-CONFIRM|LMHEAD-APPLIED)" <train.log>
 #
 # Expected output (per rank holding the LM head):
-#   [MULTIMAX-CONFIG]            apply_multimax=['lm_head']
-#   [MULTIMAX-LMHEAD-CONFIRM]    cls=... apply_multimax=['lm_head'] ranges.shape=[4] ...
+#   [MULTIMAX-CONFIG]            multimax_modules=['lm_head']
+#   [MULTIMAX-LMHEAD-CONFIRM]    cls=... multimax_modules=['lm_head'] ranges.shape=[4] ...
 #   [MULTIMAX-LMHEAD-APPLIED]    cls=... logits.shape=[...] ranges=[...] ts=[...]
 #                                (or path=fused for the fused-CE branch)
 #
@@ -193,7 +193,7 @@ class GPTLMHead(ColumnParallelLinear):
         # Names contain the "multimax" substring so the trainer's no-decay
         # filter excludes them from weight decay (mirrors timm's convention
         # of not decaying scalar/1-D learnable coefficients).
-        multimax_mode = getattr(self.config, "apply_multimax", None) or []
+        multimax_mode = getattr(self.config, "multimax_modules", None) or []
         self.use_multimax_lmhead = "lm_head" in multimax_mode
         if self.use_multimax_lmhead:
             # Cold-start init to zero -> SegLU is identity at step 0, so the
@@ -218,7 +218,7 @@ class GPTLMHead(ColumnParallelLinear):
             # for the full sanity-check workflow.
             warnings.warn(
                 f"[MULTIMAX-LMHEAD-CONFIRM] cls={type(self).__name__} "
-                f"apply_multimax={multimax_mode} "
+                f"multimax_modules={multimax_mode} "
                 f"ranges.shape={list(self.multimax_ranges.shape)} "
                 f"ts.shape={list(self.multimax_ts.shape)} "
                 f"dtype={self.config.params_dtype} "

--- a/src/paddlefleet/models/gpt/lm_head.py
+++ b/src/paddlefleet/models/gpt/lm_head.py
@@ -17,13 +17,15 @@
 # -----------------------------------------------------------------------------
 # When TransformerConfig.apply_multimax is a list containing "lm_head" (e.g.,
 # ``apply_multimax: [lm_head]``), GPTLMHead adds two learnable [4]-shape
-# parameters (multimax_ranges, multimax_ts) and applies a SeLU-style segmented
+# parameters (multimax_ranges, multimax_ts) and applies a SegLU-style segmented
 # modulation to logits before softmax/cross-entropy:
 #
-#     logits = SeLU(logits, multimax_ranges, multimax_ts)
+#     logits = SegLU(logits, multimax_ranges, multimax_ts)
 #
-# Both params are initialized to zero, which makes SeLU the identity at
-# step 0 (safe for resume from checkpoints lacking these keys).
+# Both params are initialized to zero on cold start, which makes SegLU the
+# identity at step 0 (safe for resume from checkpoints lacking these keys).
+# Resumed training restores the trained values from the checkpoint -- the
+# zero-init only applies to fresh runs.
 #
 # The "multimax" substring in the parameter names is matched by the
 # pretraining trainers' no-weight-decay name filter, so these params are
@@ -39,23 +41,23 @@
 #   [MULTIMAX-LMHEAD-APPLIED]    cls=... logits.shape=[...] ranges=[...] ts=[...]
 #                                (or path=fused for the fused-CE branch)
 #
-# If [MULTIMAX-LMHEAD-APPLIED] is missing, the SeLU path did not execute
+# If [MULTIMAX-LMHEAD-APPLIED] is missing, the SegLU path did not execute
 # (e.g., a different LM head class is used).
 #
 # Paths:
-#   - fused_linear_ce_loss_chunk == 0: SeLU is applied here on the [B, S, V]
+#   - fused_linear_ce_loss_chunk == 0: SegLU is applied here on the [B, S, V]
 #     logits tensor right before the cross-entropy. Wrapped in `recompute` and
 #     uses an in-place `+=` accumulator to bound peak activation memory.
 #   - fused_linear_ce_loss_chunk  > 0: GPTLMHead emits a 5-tuple
-#     (hidden, weight, bias, multimax_ranges, multimax_ts) and SeLU is
+#     (hidden, weight, bias, multimax_ranges, multimax_ts) and SegLU is
 #     applied inside each CE chunk by LigerFusedLinearCrossEntropyFunction.
 #     This avoids ever materializing the full [B*S, V] logits tensor and is
 #     the recommended path at large vocab.
 #
 # Notes:
-#   - SeLU is element-wise, so vocab-TP sharding is fine without collectives.
+#   - SegLU is element-wise, so vocab-TP sharding is fine without collectives.
 #   - Both paths share the same parameters (multimax_ranges/multimax_ts) and
-#     produce identical math at step 0 (params init to zero -> SeLU = id).
+#     produce identical math at step 0 (params init to zero -> SegLU = id).
 # =============================================================================
 
 import warnings
@@ -65,6 +67,7 @@ from paddle.distributed.fleet.meta_parallel import (
     ScheduleNode,
     build_spec_layer,
 )
+from paddle.distributed.fleet.utils import recompute
 from paddle.distributed.flex_checkpoint.dcp.sharded_weight import (
     build_sharded_state_dict,
 )
@@ -77,17 +80,20 @@ from paddlefleet.tensor_parallel.layers import (
 from paddlefleet.transformer.identity_op import IdentityOp
 
 
-def SeLU(x, ranges, ts):
+def SegLU(x, ranges, ts):
     """Learnable segmented activation applied to logits before softmax.
 
+    Named ``SegLU`` ("segmented learnable unit") to avoid confusion with the
+    framework's built-in ``SELU`` activation.
+
     Reference: ViT-style modulation provided by user.
-        x: [..., V] logits (last dim may be vocab-parallel sharded; SeLU is
+        x: [..., V] logits (last dim may be vocab-parallel sharded; SegLU is
            element-wise so applying it on the sharded logits is equivalent to
            applying it on gathered logits).
         ranges: [4] learnable thresholds.
         ts:     [4] learnable scales.
 
-    With ranges/ts initialized to zero, SeLU is the identity (logits unchanged),
+    With ranges/ts initialized to zero, SegLU is the identity (logits unchanged),
     so adding this op is a no-op at start of training and safe for resume.
 
     Memory-efficient eager form: instead of building one giant expression
@@ -183,16 +189,19 @@ class GPTLMHead(ColumnParallelLinear):
             block_attn_res_spec, config=self.config
         )
 
-        # Multimax: learnable SeLU-style modulation on logits before softmax.
+        # Multimax: learnable SegLU-style modulation on logits before softmax.
         # Names contain the "multimax" substring so the trainer's no-decay
         # filter excludes them from weight decay (mirrors timm's convention
         # of not decaying scalar/1-D learnable coefficients).
         multimax_mode = getattr(self.config, "apply_multimax", None) or []
         self.use_multimax_lmhead = "lm_head" in multimax_mode
         if self.use_multimax_lmhead:
-            # Init to zero -> SeLU is identity at step 0, so resuming from a
-            # checkpoint that lacks these params (loaded non-strictly) yields
-            # bit-identical logits until the params start updating.
+            # Cold-start init to zero -> SegLU is identity at step 0, so the
+            # untrained model produces bit-identical logits with/without the
+            # feature flag and resuming from a checkpoint that lacks these
+            # params (loaded non-strictly) is safe. Resumed training restores
+            # the trained values from the checkpoint -- the zero init only
+            # applies on cold start.
             self.multimax_ranges = self.create_parameter(
                 shape=[4],
                 dtype=self.config.params_dtype,
@@ -232,23 +241,18 @@ class GPTLMHead(ColumnParallelLinear):
                 hidden_states = hidden_states.transpose([1, 0, 2]).contiguous()
 
             # Multimax lm_head + fused path: thread multimax_ranges/ts into
-            # LanguageLoss so SeLU is applied inside each CE chunk and never
+            # LanguageLoss so SegLU is applied inside each CE chunk and never
             # materializes a full [B*S, V] logits tensor. Also fire the same
-            # one-shot rank-0 [MULTIMAX-LMHEAD-APPLIED] grep banner used by
-            # the unfused path so observability is consistent.
+            # one-shot [MULTIMAX-LMHEAD-APPLIED] grep banner used by the
+            # unfused path so observability is consistent.
             if getattr(self, "use_multimax_lmhead", False):
                 if not getattr(self, "_multimax_applied_logged", False):
-                    try:
-                        _rank = paddle.distributed.get_rank()
-                    except Exception:  # pragma: no cover - defensive: fleet always inits before forward
-                        _rank = 0
-                    if _rank == 0:
-                        warnings.warn(
-                            f"[MULTIMAX-LMHEAD-APPLIED] cls={type(self).__name__} "
-                            f"path=fused hidden.shape={list(hidden_states.shape)} "
-                            f"ranges={self.multimax_ranges.detach().cast('float32').numpy().tolist()} "
-                            f"ts={self.multimax_ts.detach().cast('float32').numpy().tolist()}"
-                        )
+                    warnings.warn(
+                        f"[MULTIMAX-LMHEAD-APPLIED] cls={type(self).__name__} "
+                        f"path=fused hidden.shape={list(hidden_states.shape)} "
+                        f"ranges={self.multimax_ranges.detach().cast('float32').numpy().tolist()} "
+                        f"ts={self.multimax_ts.detach().cast('float32').numpy().tolist()}"
+                    )
                     self._multimax_applied_logged = True
                 return (
                     hidden_states,
@@ -276,67 +280,28 @@ class GPTLMHead(ColumnParallelLinear):
         if self.config.sequence_parallel:
             logits = logits.transpose([1, 0, 2]).contiguous()
 
-        # Multimax lm_head (unfused path): apply learnable SeLU modulation on
-        # logits before softmax/cross-entropy. SeLU is element-wise so it works
+        # Multimax lm_head (unfused path): apply learnable SegLU modulation on
+        # logits before softmax/cross-entropy. SegLU is element-wise so it works
         # correctly on vocab-parallel sharded logits without extra collectives.
         # The fused path (fused_linear_ce_loss_chunk > 0) returns early above
-        # with a 5-tuple and applies SeLU inside the chunked CE kernel.
+        # with a 5-tuple and applies SegLU inside the chunked CE kernel.
         if getattr(self, "use_multimax_lmhead", False):
-            # One-shot per-rank-0 confirmation that the SeLU path actually
+            # One-shot confirmation (per rank) that the SegLU path actually
             # executed at runtime. Grep tag: [MULTIMAX-LMHEAD-APPLIED].
             if not getattr(self, "_multimax_applied_logged", False):
-                try:
-                    _rank = paddle.distributed.get_rank()
-                except Exception:  # pragma: no cover - defensive: fleet always inits before forward
-                    _rank = 0
-                if _rank == 0:
-                    warnings.warn(
-                        f"[MULTIMAX-LMHEAD-APPLIED] cls={type(self).__name__} "
-                        f"logits.shape={list(logits.shape)} "
-                        f"ranges={self.multimax_ranges.detach().cast('float32').numpy().tolist()} "
-                        f"ts={self.multimax_ts.detach().cast('float32').numpy().tolist()}"
-                    )
+                warnings.warn(
+                    f"[MULTIMAX-LMHEAD-APPLIED] cls={type(self).__name__} "
+                    f"logits.shape={list(logits.shape)} "
+                    f"ranges={self.multimax_ranges.detach().cast('float32').numpy().tolist()} "
+                    f"ts={self.multimax_ts.detach().cast('float32').numpy().tolist()}"
+                )
                 self._multimax_applied_logged = True
-            # Wrap SeLU in `recompute` to drop saved intermediates: only the
-            # input logits (already kept by upstream autograd) are saved; SeLU
+            # Wrap SegLU in `recompute` to drop saved intermediates: only the
+            # input logits (already kept by upstream autograd) are saved; SegLU
             # is re-run during backward. Avoids OOM on full-vocab logits when
             # `fused_linear_ce_loss_chunk=0` (required by multimax).
-            from paddle.distributed.fleet.utils import recompute
-
             logits = recompute(
-                SeLU, logits, self.multimax_ranges, self.multimax_ts
-            )
-
-        # Loss-path MD5 probe: lm_head weight and logits (debug-only, opt-in via env vars)
-        import os
-
-        if (  # pragma: no cover - debug-only MD5 probe gated by env vars
-            os.environ.get("LOG_LAYER_MD5", "0") == "1"
-            or os.environ.get("LOG_LOSS_MD5", "0") == "1"
-        ):
-            import hashlib
-
-            rank = paddle.distributed.get_rank()
-            w_md5 = hashlib.md5(
-                self.weight.cast("float32").numpy().tobytes()
-            ).hexdigest()
-            h_md5 = hashlib.md5(
-                hidden_states.cast("float32").numpy().tobytes()
-            ).hexdigest()
-            l_md5 = hashlib.md5(
-                logits.cast("float32").numpy().tobytes()
-            ).hexdigest()
-            print(
-                f"[LOSS_PATH_MD5] rank={rank} lm_head_weight shape={list(self.weight.shape)} md5={w_md5}",
-                flush=True,
-            )
-            print(
-                f"[LOSS_PATH_MD5] rank={rank} lm_head_input shape={list(hidden_states.shape)} md5={h_md5}",
-                flush=True,
-            )
-            print(
-                f"[LOSS_PATH_MD5] rank={rank} lm_head_logits shape={list(logits.shape)} md5={l_md5}",
-                flush=True,
+                SegLU, logits, self.multimax_ranges, self.multimax_ts
             )
 
         return logits
@@ -374,19 +339,17 @@ class GPTLMHead(ColumnParallelLinear):
         structured_name_prefix: str = "",
     ):
         """Sharding along axis 0, bias sharded.
-        Multimax params (multimax_ranges, multimax_ts) are replicated across
-        TP ranks (no shard axis); they are listed explicitly so flex-checkpoint
-        saves/loads them.
+
+        Multimax params (multimax_ranges, multimax_ts) are tiny [4]-shape
+        replicated tensors; non-sharded parameters do not need to appear in
+        ``shard_rules``, so we leave them out and let flex-checkpoint pick
+        them up from the state dict directly.
         """
         state_dict = self.state_dict(structured_name_prefix="")
         if self.world_size == 1:
             shard_rules = None
         else:
             shard_rules = {"weight": 0, "bias": 0}
-            if getattr(self, "use_multimax_lmhead", False):
-                # Replicated across TP ranks; mark with shard axis None.
-                shard_rules["multimax_ranges"] = None
-                shard_rules["multimax_ts"] = None
         return build_sharded_state_dict(
             state_dict, shard_rules, structured_name_prefix
         )

--- a/src/paddlefleet/models/gpt/lm_head.py
+++ b/src/paddlefleet/models/gpt/lm_head.py
@@ -242,7 +242,7 @@ class GPTLMHead(ColumnParallelLinear):
                 if not getattr(self, "_multimax_applied_logged", False):
                     try:
                         _rank = paddle.distributed.get_rank()
-                    except Exception:
+                    except Exception:  # pragma: no cover - defensive: fleet always inits before forward
                         _rank = 0
                     if _rank == 0:
                         warnings.warn(
@@ -289,7 +289,7 @@ class GPTLMHead(ColumnParallelLinear):
             if not getattr(self, "_multimax_applied_logged", False):
                 try:
                     _rank = paddle.distributed.get_rank()
-                except Exception:
+                except Exception:  # pragma: no cover - defensive: fleet always inits before forward
                     _rank = 0
                 if _rank == 0:
                     warnings.warn(
@@ -309,10 +309,10 @@ class GPTLMHead(ColumnParallelLinear):
                 SeLU, logits, self.multimax_ranges, self.multimax_ts
             )
 
-        # Loss-path MD5 probe: lm_head weight and logits
+        # Loss-path MD5 probe: lm_head weight and logits (debug-only, opt-in via env vars)
         import os
 
-        if (
+        if (  # pragma: no cover - debug-only MD5 probe gated by env vars
             os.environ.get("LOG_LAYER_MD5", "0") == "1"
             or os.environ.get("LOG_LOSS_MD5", "0") == "1"
         ):

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import functools
 import math
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, Optional
 
 import paddle.nn.functional as F
 
@@ -288,6 +288,22 @@ class TransformerConfig(ModelParallelConfig):
 
     multimodal_embedding: bool = False
     """Whether to use multimodal embedding."""
+
+    multimax: Optional[Literal["lm_head", "attn", "all"]] = None
+    """Apply learnable SeLU-style modulation before softmax.
+    - ``None`` / ``null`` (default): disabled. An unset key, an empty value
+      (``multimax:``), or an explicit ``null`` in YAML/JSON all map to Python
+      ``None``, so the feature is opt-in and safe to leave out of model
+      configs.
+    - "lm_head": apply SeLU(x, ranges, ts) on the LM-head logits before the
+      language-modeling softmax/cross-entropy. Adds two [4]-shape learnable
+      parameters (multimax_ranges, multimax_ts) to the LM head. These are
+      excluded from weight decay via the "multimax" substring filter in the
+      trainer's no-decay rule.
+    - "attn": apply on attention scores before softmax (not implemented yet).
+    - "all": apply on both LM head and attention (not implemented yet, only
+      the lm_head branch will take effect).
+    """
 
     gated_attention: bool = False
     """If True, enables gated attention where a learnable sigmoid gate is applied to the
@@ -1267,3 +1283,26 @@ class TransformerConfig(ModelParallelConfig):
                 f"head_wise_swa_ratio must be between 0.0 and 1.0, "
                 f"but got {self.head_wise_swa_ratio}."
             )
+
+        # Multimax validation + grep-friendly confirmation banner.
+        # Operators can verify the setting reached the model with:
+        #   grep MULTIMAX <train.log>
+        import warnings as _warnings
+
+        _multimax = getattr(self, "multimax", None)
+        # Allow yaml/json to leave the field unset, set to ``null``, or pass an
+        # empty string -- all map to the canonical disabled sentinel ``None``.
+        if _multimax == "":
+            _multimax = None
+            self.multimax = None
+        if _multimax is not None and _multimax not in ("lm_head", "attn", "all"):
+            raise ValueError(
+                f"multimax must be one of None, 'lm_head', 'attn', 'all', "
+                f"got {_multimax!r}."
+            )
+        if _multimax in ("attn", "all"):
+            _warnings.warn(
+                f"[MULTIMAX-CONFIG] multimax={_multimax}: 'attn' branch is "
+                "not implemented yet; only the lm_head modulation will take effect."
+            )
+        _warnings.warn(f"[MULTIMAX-CONFIG] multimax={_multimax}")

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -292,7 +292,7 @@ class TransformerConfig(ModelParallelConfig):
     multimodal_embedding: bool = False
     """Whether to use multimodal embedding."""
 
-    apply_multimax: list[str] | None = None
+    multimax_modules: list[str] | None = None
     """Submodules to apply learnable SegLU-style modulation to before softmax.
 
     Mirrors the Megatron ``recompute_modules`` style: a list of submodule
@@ -308,9 +308,9 @@ class TransformerConfig(ModelParallelConfig):
       not implemented yet (emits a warning if listed).
 
     YAML/JSON behaviour:
-    - unset key, ``apply_multimax: null``, or empty list ``apply_multimax: []``
+    - unset key, ``multimax_modules: null``, or empty list ``multimax_modules: []``
       all map to Python ``None`` (feature disabled).
-    - ``apply_multimax: [lm_head]`` enables the LM-head branch.
+    - ``multimax_modules: [lm_head]`` enables the LM-head branch.
     """
 
     gated_attention: bool = False
@@ -1314,11 +1314,11 @@ class TransformerConfig(ModelParallelConfig):
         #   grep MULTIMAX <train.log>
         import warnings as _warnings
 
-        _multimax = getattr(self, "apply_multimax", None)
+        _multimax = getattr(self, "multimax_modules", None)
         # YAML entry path returns OmegaConf containers (ListConfig), not
         # builtin list. Normalize to a plain Python list before any
         # isinstance(_multimax, list) check; otherwise the recommended
-        # `apply_multimax: [lm_head]` form is rejected.
+        # `multimax_modules: [lm_head]` form is rejected.
         try:
             from omegaconf import (
                 ListConfig as _ListConfig,
@@ -1327,7 +1327,7 @@ class TransformerConfig(ModelParallelConfig):
 
             if isinstance(_multimax, _ListConfig):
                 _multimax = _OmegaConf.to_container(_multimax, resolve=True)
-                self.apply_multimax = _multimax
+                self.multimax_modules = _multimax
         except ImportError:
             pass
         # Allow yaml/json to leave the field unset, set to ``null``, pass an
@@ -1335,32 +1335,32 @@ class TransformerConfig(ModelParallelConfig):
         # disabled sentinel ``None``.
         if _multimax in ("", []):
             _multimax = None
-            self.apply_multimax = None
+            self.multimax_modules = None
         # Back-compat: a plain string is treated as a single-element list
-        # so older configs (apply_multimax: lm_head) keep working.
+        # so older configs (multimax_modules: lm_head) keep working.
         if isinstance(_multimax, str):
             _multimax = [_multimax]
-            self.apply_multimax = _multimax
+            self.multimax_modules = _multimax
         if _multimax is not None:
             if not isinstance(_multimax, list) or not all(
                 isinstance(x, str) for x in _multimax
             ):
                 raise ValueError(
-                    f"apply_multimax must be None or a list[str], "
+                    f"multimax_modules must be None or a list[str], "
                     f"got {_multimax!r}."
                 )
             _valid = {"lm_head", "attention"}
             _bad = [x for x in _multimax if x not in _valid]
             if _bad:
                 raise ValueError(
-                    f"apply_multimax entries must each be one of "
+                    f"multimax_modules entries must each be one of "
                     f"{sorted(_valid)}, got invalid entries {_bad!r} "
                     f"in {_multimax!r}."
                 )
             if "attention" in _multimax:
                 _warnings.warn(
-                    f"[MULTIMAX-CONFIG] apply_multimax={_multimax}: "
+                    f"[MULTIMAX-CONFIG] multimax_modules={_multimax}: "
                     "'attention' branch is not implemented yet; only the "
                     "lm_head modulation will take effect."
                 )
-            _warnings.warn(f"[MULTIMAX-CONFIG] apply_multimax={_multimax}")
+            _warnings.warn(f"[MULTIMAX-CONFIG] multimax_modules={_multimax}")

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -1315,6 +1315,21 @@ class TransformerConfig(ModelParallelConfig):
         import warnings as _warnings
 
         _multimax = getattr(self, "apply_multimax", None)
+        # YAML entry path returns OmegaConf containers (ListConfig), not
+        # builtin list. Normalize to a plain Python list before any
+        # isinstance(_multimax, list) check; otherwise the recommended
+        # `apply_multimax: [lm_head]` form is rejected.
+        try:
+            from omegaconf import (
+                ListConfig as _ListConfig,
+                OmegaConf as _OmegaConf,
+            )
+
+            if isinstance(_multimax, _ListConfig):
+                _multimax = _OmegaConf.to_container(_multimax, resolve=True)
+                self.apply_multimax = _multimax
+        except ImportError:
+            pass
         # Allow yaml/json to leave the field unset, set to ``null``, pass an
         # empty string, or pass an empty list -- all map to the canonical
         # disabled sentinel ``None``.

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -292,20 +292,25 @@ class TransformerConfig(ModelParallelConfig):
     multimodal_embedding: bool = False
     """Whether to use multimodal embedding."""
 
-    multimax: Literal["lm_head", "attn", "all"] | None = None
-    """Apply learnable SeLU-style modulation before softmax.
-    - ``None`` / ``null`` (default): disabled. An unset key, an empty value
-      (``multimax:``), or an explicit ``null`` in YAML/JSON all map to Python
-      ``None``, so the feature is opt-in and safe to leave out of model
-      configs.
-    - "lm_head": apply SeLU(x, ranges, ts) on the LM-head logits before the
-      language-modeling softmax/cross-entropy. Adds two [4]-shape learnable
-      parameters (multimax_ranges, multimax_ts) to the LM head. These are
-      excluded from weight decay via the "multimax" substring filter in the
-      trainer's no-decay rule.
-    - "attn": apply on attention scores before softmax (not implemented yet).
-    - "all": apply on both LM head and attention (not implemented yet, only
-      the lm_head branch will take effect).
+    apply_multimax: list[str] | None = None
+    """Submodules to apply learnable SeLU-style modulation to before softmax.
+
+    Mirrors the Megatron ``recompute_modules`` style: a list of submodule
+    names. ``None`` (default) disables the feature globally. Currently
+    supported list entries:
+
+    - ``"lm_head"``: apply SeLU(x, ranges, ts) on the LM-head logits before
+      the language-modeling softmax/cross-entropy. Adds two [4]-shape
+      learnable parameters (multimax_ranges, multimax_ts) to the LM head.
+      These are excluded from weight decay via the "multimax" substring
+      filter in the trainer's no-decay rule.
+    - ``"attention"``: apply on attention scores before softmax. Reserved;
+      not implemented yet (emits a warning if listed).
+
+    YAML/JSON behaviour:
+    - unset key, ``apply_multimax: null``, or empty list ``apply_multimax: []``
+      all map to Python ``None`` (feature disabled).
+    - ``apply_multimax: [lm_head]`` enables the LM-head branch.
     """
 
     gated_attention: bool = False
@@ -1309,24 +1314,38 @@ class TransformerConfig(ModelParallelConfig):
         #   grep MULTIMAX <train.log>
         import warnings as _warnings
 
-        _multimax = getattr(self, "multimax", None)
-        # Allow yaml/json to leave the field unset, set to ``null``, or pass an
-        # empty string -- all map to the canonical disabled sentinel ``None``.
-        if _multimax == "":
+        _multimax = getattr(self, "apply_multimax", None)
+        # Allow yaml/json to leave the field unset, set to ``null``, pass an
+        # empty string, or pass an empty list -- all map to the canonical
+        # disabled sentinel ``None``.
+        if _multimax in ("", []):
             _multimax = None
-            self.multimax = None
-        if _multimax is not None and _multimax not in (
-            "lm_head",
-            "attn",
-            "all",
-        ):
-            raise ValueError(
-                f"multimax must be one of None, 'lm_head', 'attn', 'all', "
-                f"got {_multimax!r}."
-            )
-        if _multimax in ("attn", "all"):
-            _warnings.warn(
-                f"[MULTIMAX-CONFIG] multimax={_multimax}: 'attn' branch is "
-                "not implemented yet; only the lm_head modulation will take effect."
-            )
-        _warnings.warn(f"[MULTIMAX-CONFIG] multimax={_multimax}")
+            self.apply_multimax = None
+        # Back-compat: a plain string is treated as a single-element list
+        # so older configs (apply_multimax: lm_head) keep working.
+        if isinstance(_multimax, str):
+            _multimax = [_multimax]
+            self.apply_multimax = _multimax
+        if _multimax is not None:
+            if not isinstance(_multimax, list) or not all(
+                isinstance(x, str) for x in _multimax
+            ):
+                raise ValueError(
+                    f"apply_multimax must be None or a list[str], "
+                    f"got {_multimax!r}."
+                )
+            _valid = {"lm_head", "attention"}
+            _bad = [x for x in _multimax if x not in _valid]
+            if _bad:
+                raise ValueError(
+                    f"apply_multimax entries must each be one of "
+                    f"{sorted(_valid)}, got invalid entries {_bad!r} "
+                    f"in {_multimax!r}."
+                )
+            if "attention" in _multimax:
+                _warnings.warn(
+                    f"[MULTIMAX-CONFIG] apply_multimax={_multimax}: "
+                    "'attention' branch is not implemented yet; only the "
+                    "lm_head modulation will take effect."
+                )
+            _warnings.warn(f"[MULTIMAX-CONFIG] apply_multimax={_multimax}")

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -293,13 +293,13 @@ class TransformerConfig(ModelParallelConfig):
     """Whether to use multimodal embedding."""
 
     apply_multimax: list[str] | None = None
-    """Submodules to apply learnable SeLU-style modulation to before softmax.
+    """Submodules to apply learnable SegLU-style modulation to before softmax.
 
     Mirrors the Megatron ``recompute_modules`` style: a list of submodule
     names. ``None`` (default) disables the feature globally. Currently
     supported list entries:
 
-    - ``"lm_head"``: apply SeLU(x, ranges, ts) on the LM-head logits before
+    - ``"lm_head"``: apply SegLU(x, ranges, ts) on the LM-head logits before
       the language-modeling softmax/cross-entropy. Adds two [4]-shape
       learnable parameters (multimax_ranges, multimax_ts) to the LM head.
       These are excluded from weight decay via the "multimax" substring

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import functools
 import math
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Literal, Optional
+from typing import TYPE_CHECKING, Literal
 
 import paddle.nn.functional as F
 
@@ -292,7 +292,7 @@ class TransformerConfig(ModelParallelConfig):
     multimodal_embedding: bool = False
     """Whether to use multimodal embedding."""
 
-    multimax: Optional[Literal["lm_head", "attn", "all"]] = None
+    multimax: Literal["lm_head", "attn", "all"] | None = None
     """Apply learnable SeLU-style modulation before softmax.
     - ``None`` / ``null`` (default): disabled. An unset key, an empty value
       (``multimax:``), or an explicit ``null`` in YAML/JSON all map to Python
@@ -1315,7 +1315,11 @@ class TransformerConfig(ModelParallelConfig):
         if _multimax == "":
             _multimax = None
             self.multimax = None
-        if _multimax is not None and _multimax not in ("lm_head", "attn", "all"):
+        if _multimax is not None and _multimax not in (
+            "lm_head",
+            "attn",
+            "all",
+        ):
             raise ValueError(
                 f"multimax must be one of None, 'lm_head', 'attn', 'all', "
                 f"got {_multimax!r}."

--- a/src/paddlefleet/triton_ops/fused_linear_cross_entropy/cross_entropy.py
+++ b/src/paddlefleet/triton_ops/fused_linear_cross_entropy/cross_entropy.py
@@ -19,6 +19,16 @@ Fused Cross Entropy Triton Kernel。
 
 基于在线 Softmax 算法，在单次扫描中同时完成 loss 计算和梯度计算，
 避免 Paddle 原生实现中保存完整 softmax 中间张量带来的显存开销。
+
+Multimax variant (`liger_cross_entropy_multimax_kernel`) additionally fuses
+the learnable SeLU-style segmented modulation
+    SeLU(x) = x + t0·max(r0-x,0) + t1·max(x-r1,0)
+                + t2·max(r2-x,0)^2 + t3·max(x-r3,0)^2
+into the same kernel: SeLU is applied in registers during both the lse pass
+and the grad-write pass; per-row partial sums for grad_ranges/grad_ts are
+accumulated in registers and atomic-added to global [4]-shape fp32 buffers.
+This avoids materializing the four ReLU intermediates and SeLU output as
+separate tensors, dropping per-chunk peak memory back to ~1× [C, V].
 """
 
 import triton
@@ -97,6 +107,189 @@ def liger_cross_entropy_kernel(
     tl.debug_barrier()
 
     loss = lse - ori_X_y
+
+    if reduction == "mean":
+        loss = loss / n_non_ignore
+
+    tl.store(loss_ptr, loss)
+
+
+@enable_compat_on_triton_kernel
+@triton.jit
+def liger_cross_entropy_multimax_kernel(
+    X_ptr,
+    X_stride,
+    Y_ptr,
+    Y_stride,
+    loss_ptr,
+    loss_stride,
+    n_cols,
+    n_non_ignore,
+    ignore_index,
+    # Multimax learnable params, passed as fp32 scalars (compiled in once
+    # per chunk; ranges/ts are tiny [4] tensors so the host->device sync
+    # to extract them is negligible vs the chunk's GEMM/CE cost).
+    r0,
+    r1,
+    r2,
+    r3,
+    t0,
+    t1,
+    t2,
+    t3,
+    # Per-chunk fp32 [4] grad accumulators for ranges/ts.
+    grad_r_ptr,
+    grad_t_ptr,
+    reduction: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    HAS_GRADIENTS: tl.constexpr,
+):
+    """Liger CE kernel with fused SeLU activation + closed-form SeLU backward.
+
+    Forward:  L = lse(SeLU(X)) - SeLU(X)[y]   (per row)
+    Backward: writes grad_x = dL/dX in place into X_ptr; atomic-adds the
+              per-row partial sums for grad_ranges and grad_ts into the
+              fp32 [4] global buffers grad_r_ptr / grad_t_ptr.
+
+    SeLU is computed in registers from the loaded X block, so no extra HBM
+    traffic relative to the no-multimax kernel.
+    """
+    program_id = tl.program_id(0).to(tl.int64)
+
+    Y_ptr += program_id * Y_stride
+    y = tl.load(Y_ptr)
+
+    X_ptr += program_id * X_stride
+
+    if y == ignore_index:
+        for i in range(0, n_cols, BLOCK_SIZE):
+            X_offsets = i + tl.arange(0, BLOCK_SIZE)
+            tl.store(X_ptr + X_offsets, 0.0, mask=X_offsets < n_cols)
+        return
+
+    loss_ptr += program_id * loss_stride
+
+    # Apply SeLU to the y-th element (loss target) once.
+    ori_X_y = tl.load(X_ptr + y).cast(tl.float32)
+    my0 = tl.maximum(r0 - ori_X_y, 0.0)
+    my1 = tl.maximum(ori_X_y - r1, 0.0)
+    my2 = tl.maximum(r2 - ori_X_y, 0.0)
+    my3 = tl.maximum(ori_X_y - r3, 0.0)
+    selu_X_y = ori_X_y + t0 * my0 + t1 * my1 + t2 * my2 * my2 + t3 * my3 * my3
+
+    # Pass 1: online lse over SeLU(X).
+    m = float("-inf")
+    d = 0.0
+    for i in range(0, n_cols, BLOCK_SIZE):
+        X_offsets = i + tl.arange(0, BLOCK_SIZE)
+        in_bounds = X_offsets < n_cols
+        X_block = tl.load(
+            X_ptr + X_offsets,
+            mask=in_bounds,
+            other=0.0,  # finite filler; we re-mask SeLU output to -inf below
+        ).cast(tl.float32)
+        m0_b = tl.maximum(r0 - X_block, 0.0)
+        m1_b = tl.maximum(X_block - r1, 0.0)
+        m2_b = tl.maximum(r2 - X_block, 0.0)
+        m3_b = tl.maximum(X_block - r3, 0.0)
+        selu_b = (
+            X_block
+            + t0 * m0_b
+            + t1 * m1_b
+            + t2 * m2_b * m2_b
+            + t3 * m3_b * m3_b
+        )
+        # Padded lanes contribute -inf to lse so they vanish in exp().
+        selu_b = tl.where(in_bounds, selu_b, float("-inf"))
+        block_max = tl.max(selu_b)
+        m_new = tl.maximum(m, block_max)
+        d = d * tl.exp(m - m_new) + tl.sum(tl.exp(selu_b - m_new))
+        m = m_new
+
+    lse = m + tl.log(d)
+
+    if HAS_GRADIENTS:
+        # Per-row scalar accumulators for grad_ranges and grad_ts.
+        gr0 = 0.0
+        gr1 = 0.0
+        gr2 = 0.0
+        gr3 = 0.0
+        gt0 = 0.0
+        gt1 = 0.0
+        gt2 = 0.0
+        gt3 = 0.0
+
+        for i in range(0, n_cols, BLOCK_SIZE):
+            X_offsets = i + tl.arange(0, BLOCK_SIZE)
+            in_bounds = X_offsets < n_cols
+            X_block = tl.load(
+                X_ptr + X_offsets,
+                mask=in_bounds,
+                other=0.0,
+            ).cast(tl.float32)
+            # Recompute SeLU forward in registers (free vs HBM reload).
+            m0_b = tl.maximum(r0 - X_block, 0.0)
+            m1_b = tl.maximum(X_block - r1, 0.0)
+            m2_b = tl.maximum(r2 - X_block, 0.0)
+            m3_b = tl.maximum(X_block - r3, 0.0)
+            selu_b = (
+                X_block
+                + t0 * m0_b
+                + t1 * m1_b
+                + t2 * m2_b * m2_b
+                + t3 * m3_b * m3_b
+            )
+            # Softmax over SeLU output, then subtract one-hot at target.
+            grad_out = tl.exp(selu_b - m) / d
+            grad_out = tl.where(X_offsets != y, grad_out, grad_out - 1.0)
+            if reduction == "mean":
+                grad_out = grad_out / n_non_ignore
+            # Padded lanes must contribute zero to grads (both stored grad
+            # and the param-grad reductions).
+            grad_out = tl.where(in_bounds, grad_out, 0.0)
+
+            # SeLU backward: d_out/d_x = 1 - t0*1{r0>x} + t1*1{x>r1}
+            #                              - 2*t2*max(r2-x,0) + 2*t3*max(x-r3,0)
+            mask0 = (m0_b > 0.0).to(tl.float32)
+            mask1 = (m1_b > 0.0).to(tl.float32)
+            dx_dx = (
+                1.0
+                - t0 * mask0
+                + t1 * mask1
+                - 2.0 * t2 * m2_b
+                + 2.0 * t3 * m3_b
+            )
+            grad_x = grad_out * dx_dx
+            tl.store(X_ptr + X_offsets, grad_x, mask=in_bounds)
+
+            # Per-row partial sums for grad_ts and grad_ranges.
+            #   d_out/d_t0 = m0,   d_out/d_t1 = m1
+            #   d_out/d_t2 = m2^2, d_out/d_t3 = m3^2
+            #   d_out/d_r0 =  t0*1{r0>x},  d_out/d_r1 = -t1*1{x>r1}
+            #   d_out/d_r2 =  2*t2*m2,     d_out/d_r3 = -2*t3*m3
+            gt0 += tl.sum(grad_out * m0_b)
+            gt1 += tl.sum(grad_out * m1_b)
+            gt2 += tl.sum(grad_out * m2_b * m2_b)
+            gt3 += tl.sum(grad_out * m3_b * m3_b)
+            gr0 += t0 * tl.sum(grad_out * mask0)
+            gr1 += -t1 * tl.sum(grad_out * mask1)
+            gr2 += 2.0 * t2 * tl.sum(grad_out * m2_b)
+            gr3 += -2.0 * t3 * tl.sum(grad_out * m3_b)
+
+        # One atomic_add per row per scalar (8 total). Race-free across
+        # programs and well below kernel runtime.
+        tl.atomic_add(grad_r_ptr + 0, gr0)
+        tl.atomic_add(grad_r_ptr + 1, gr1)
+        tl.atomic_add(grad_r_ptr + 2, gr2)
+        tl.atomic_add(grad_r_ptr + 3, gr3)
+        tl.atomic_add(grad_t_ptr + 0, gt0)
+        tl.atomic_add(grad_t_ptr + 1, gt1)
+        tl.atomic_add(grad_t_ptr + 2, gt2)
+        tl.atomic_add(grad_t_ptr + 3, gt3)
+
+    tl.debug_barrier()
+
+    loss = lse - selu_X_y
 
     if reduction == "mean":
         loss = loss / n_non_ignore

--- a/src/paddlefleet/triton_ops/fused_linear_cross_entropy/cross_entropy.py
+++ b/src/paddlefleet/triton_ops/fused_linear_cross_entropy/cross_entropy.py
@@ -39,7 +39,7 @@ from ..triton_compat import enable_compat_on_triton_kernel
 
 @enable_compat_on_triton_kernel
 @triton.jit
-def liger_cross_entropy_kernel(
+def liger_cross_entropy_kernel(  # pragma: no cover - triton kernel body compiles to PTX, not python-instrumentable
     X_ptr,
     X_stride,
     Y_ptr,
@@ -116,7 +116,7 @@ def liger_cross_entropy_kernel(
 
 @enable_compat_on_triton_kernel
 @triton.jit
-def liger_cross_entropy_multimax_kernel(
+def liger_cross_entropy_multimax_kernel(  # pragma: no cover - triton kernel body compiles to PTX, not python-instrumentable
     X_ptr,
     X_stride,
     Y_ptr,

--- a/src/paddlefleet/triton_ops/fused_linear_cross_entropy/cross_entropy.py
+++ b/src/paddlefleet/triton_ops/fused_linear_cross_entropy/cross_entropy.py
@@ -21,13 +21,13 @@ Fused Cross Entropy Triton Kernel。
 避免 Paddle 原生实现中保存完整 softmax 中间张量带来的显存开销。
 
 Multimax variant (`liger_cross_entropy_multimax_kernel`) additionally fuses
-the learnable SeLU-style segmented modulation
-    SeLU(x) = x + t0·max(r0-x,0) + t1·max(x-r1,0)
+the learnable SegLU-style segmented modulation
+    SegLU(x) = x + t0·max(r0-x,0) + t1·max(x-r1,0)
                 + t2·max(r2-x,0)^2 + t3·max(x-r3,0)^2
-into the same kernel: SeLU is applied in registers during both the lse pass
+into the same kernel: SegLU is applied in registers during both the lse pass
 and the grad-write pass; per-row partial sums for grad_ranges/grad_ts are
 accumulated in registers and atomic-added to global [4]-shape fp32 buffers.
-This avoids materializing the four ReLU intermediates and SeLU output as
+This avoids materializing the four ReLU intermediates and SegLU output as
 separate tensors, dropping per-chunk peak memory back to ~1× [C, V].
 """
 
@@ -145,14 +145,14 @@ def liger_cross_entropy_multimax_kernel(  # pragma: no cover - triton kernel bod
     HAS_GRADIENTS: tl.constexpr,
     HAS_MULTIMAX_GRADIENTS: tl.constexpr,
 ):
-    """Liger CE kernel with fused SeLU activation + closed-form SeLU backward.
+    """Liger CE kernel with fused SegLU activation + closed-form SegLU backward.
 
-    Forward:  L = lse(SeLU(X)) - SeLU(X)[y]   (per row)
+    Forward:  L = lse(SegLU(X)) - SegLU(X)[y]   (per row)
     Backward: writes grad_x = dL/dX in place into X_ptr; atomic-adds the
               per-row partial sums for grad_ranges and grad_ts into the
               fp32 [4] global buffers grad_r_ptr / grad_t_ptr.
 
-    SeLU is computed in registers from the loaded X block, so no extra HBM
+    SegLU is computed in registers from the loaded X block, so no extra HBM
     traffic relative to the no-multimax kernel.
     """
     program_id = tl.program_id(0).to(tl.int64)
@@ -170,15 +170,15 @@ def liger_cross_entropy_multimax_kernel(  # pragma: no cover - triton kernel bod
 
     loss_ptr += program_id * loss_stride
 
-    # Apply SeLU to the y-th element (loss target) once.
+    # Apply SegLU to the y-th element (loss target) once.
     ori_X_y = tl.load(X_ptr + y).cast(tl.float32)
     my0 = tl.maximum(r0 - ori_X_y, 0.0)
     my1 = tl.maximum(ori_X_y - r1, 0.0)
     my2 = tl.maximum(r2 - ori_X_y, 0.0)
     my3 = tl.maximum(ori_X_y - r3, 0.0)
-    selu_X_y = ori_X_y + t0 * my0 + t1 * my1 + t2 * my2 * my2 + t3 * my3 * my3
+    seglu_X_y = ori_X_y + t0 * my0 + t1 * my1 + t2 * my2 * my2 + t3 * my3 * my3
 
-    # Pass 1: online lse over SeLU(X).
+    # Pass 1: online lse over SegLU(X).
     m = float("-inf")
     d = 0.0
     for i in range(0, n_cols, BLOCK_SIZE):
@@ -187,13 +187,13 @@ def liger_cross_entropy_multimax_kernel(  # pragma: no cover - triton kernel bod
         X_block = tl.load(
             X_ptr + X_offsets,
             mask=in_bounds,
-            other=0.0,  # finite filler; we re-mask SeLU output to -inf below
+            other=0.0,  # finite filler; we re-mask SegLU output to -inf below
         ).cast(tl.float32)
         m0_b = tl.maximum(r0 - X_block, 0.0)
         m1_b = tl.maximum(X_block - r1, 0.0)
         m2_b = tl.maximum(r2 - X_block, 0.0)
         m3_b = tl.maximum(X_block - r3, 0.0)
-        selu_b = (
+        seglu_b = (
             X_block
             + t0 * m0_b
             + t1 * m1_b
@@ -201,10 +201,10 @@ def liger_cross_entropy_multimax_kernel(  # pragma: no cover - triton kernel bod
             + t3 * m3_b * m3_b
         )
         # Padded lanes contribute -inf to lse so they vanish in exp().
-        selu_b = tl.where(in_bounds, selu_b, float("-inf"))
-        block_max = tl.max(selu_b)
+        seglu_b = tl.where(in_bounds, seglu_b, float("-inf"))
+        block_max = tl.max(seglu_b)
         m_new = tl.maximum(m, block_max)
-        d = d * tl.exp(m - m_new) + tl.sum(tl.exp(selu_b - m_new))
+        d = d * tl.exp(m - m_new) + tl.sum(tl.exp(seglu_b - m_new))
         m = m_new
 
     lse = m + tl.log(d)
@@ -228,20 +228,20 @@ def liger_cross_entropy_multimax_kernel(  # pragma: no cover - triton kernel bod
                 mask=in_bounds,
                 other=0.0,
             ).cast(tl.float32)
-            # Recompute SeLU forward in registers (free vs HBM reload).
+            # Recompute SegLU forward in registers (free vs HBM reload).
             m0_b = tl.maximum(r0 - X_block, 0.0)
             m1_b = tl.maximum(X_block - r1, 0.0)
             m2_b = tl.maximum(r2 - X_block, 0.0)
             m3_b = tl.maximum(X_block - r3, 0.0)
-            selu_b = (
+            seglu_b = (
                 X_block
                 + t0 * m0_b
                 + t1 * m1_b
                 + t2 * m2_b * m2_b
                 + t3 * m3_b * m3_b
             )
-            # Softmax over SeLU output, then subtract one-hot at target.
-            grad_out = tl.exp(selu_b - m) / d
+            # Softmax over SegLU output, then subtract one-hot at target.
+            grad_out = tl.exp(seglu_b - m) / d
             grad_out = tl.where(X_offsets != y, grad_out, grad_out - 1.0)
             if reduction == "mean":
                 grad_out = grad_out / n_non_ignore
@@ -250,7 +250,7 @@ def liger_cross_entropy_multimax_kernel(  # pragma: no cover - triton kernel bod
             grad_out = tl.where(in_bounds, grad_out, 0.0)
 
             if HAS_GRADIENTS:
-                # SeLU backward: d_out/d_x = 1 - t0*1{r0>x} + t1*1{x>r1}
+                # SegLU backward: d_out/d_x = 1 - t0*1{r0>x} + t1*1{x>r1}
                 #                              - 2*t2*max(r2-x,0) + 2*t3*max(x-r3,0)
                 mask0 = (m0_b > 0.0).to(tl.float32)
                 mask1 = (m1_b > 0.0).to(tl.float32)
@@ -295,7 +295,7 @@ def liger_cross_entropy_multimax_kernel(  # pragma: no cover - triton kernel bod
 
     tl.debug_barrier()
 
-    loss = lse - selu_X_y
+    loss = lse - seglu_X_y
 
     if reduction == "mean":
         loss = loss / n_non_ignore

--- a/src/paddlefleet/triton_ops/fused_linear_cross_entropy/cross_entropy.py
+++ b/src/paddlefleet/triton_ops/fused_linear_cross_entropy/cross_entropy.py
@@ -143,6 +143,7 @@ def liger_cross_entropy_multimax_kernel(
     reduction: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
     HAS_GRADIENTS: tl.constexpr,
+    HAS_MULTIMAX_GRADIENTS: tl.constexpr,
 ):
     """Liger CE kernel with fused SeLU activation + closed-form SeLU backward.
 
@@ -208,7 +209,7 @@ def liger_cross_entropy_multimax_kernel(
 
     lse = m + tl.log(d)
 
-    if HAS_GRADIENTS:
+    if HAS_GRADIENTS or HAS_MULTIMAX_GRADIENTS:
         # Per-row scalar accumulators for grad_ranges and grad_ts.
         gr0 = 0.0
         gr1 = 0.0
@@ -248,44 +249,49 @@ def liger_cross_entropy_multimax_kernel(
             # and the param-grad reductions).
             grad_out = tl.where(in_bounds, grad_out, 0.0)
 
-            # SeLU backward: d_out/d_x = 1 - t0*1{r0>x} + t1*1{x>r1}
-            #                              - 2*t2*max(r2-x,0) + 2*t3*max(x-r3,0)
-            mask0 = (m0_b > 0.0).to(tl.float32)
-            mask1 = (m1_b > 0.0).to(tl.float32)
-            dx_dx = (
-                1.0
-                - t0 * mask0
-                + t1 * mask1
-                - 2.0 * t2 * m2_b
-                + 2.0 * t3 * m3_b
-            )
-            grad_x = grad_out * dx_dx
-            tl.store(X_ptr + X_offsets, grad_x, mask=in_bounds)
+            if HAS_GRADIENTS:
+                # SeLU backward: d_out/d_x = 1 - t0*1{r0>x} + t1*1{x>r1}
+                #                              - 2*t2*max(r2-x,0) + 2*t3*max(x-r3,0)
+                mask0 = (m0_b > 0.0).to(tl.float32)
+                mask1 = (m1_b > 0.0).to(tl.float32)
+                dx_dx = (
+                    1.0
+                    - t0 * mask0
+                    + t1 * mask1
+                    - 2.0 * t2 * m2_b
+                    + 2.0 * t3 * m3_b
+                )
+                grad_x = grad_out * dx_dx
+                tl.store(X_ptr + X_offsets, grad_x, mask=in_bounds)
 
-            # Per-row partial sums for grad_ts and grad_ranges.
-            #   d_out/d_t0 = m0,   d_out/d_t1 = m1
-            #   d_out/d_t2 = m2^2, d_out/d_t3 = m3^2
-            #   d_out/d_r0 =  t0*1{r0>x},  d_out/d_r1 = -t1*1{x>r1}
-            #   d_out/d_r2 =  2*t2*m2,     d_out/d_r3 = -2*t3*m3
-            gt0 += tl.sum(grad_out * m0_b)
-            gt1 += tl.sum(grad_out * m1_b)
-            gt2 += tl.sum(grad_out * m2_b * m2_b)
-            gt3 += tl.sum(grad_out * m3_b * m3_b)
-            gr0 += t0 * tl.sum(grad_out * mask0)
-            gr1 += -t1 * tl.sum(grad_out * mask1)
-            gr2 += 2.0 * t2 * tl.sum(grad_out * m2_b)
-            gr3 += -2.0 * t3 * tl.sum(grad_out * m3_b)
+            if HAS_MULTIMAX_GRADIENTS:
+                # Per-row partial sums for grad_ts and grad_ranges.
+                #   d_out/d_t0 = m0,   d_out/d_t1 = m1
+                #   d_out/d_t2 = m2^2, d_out/d_t3 = m3^2
+                #   d_out/d_r0 =  t0*1{r0>x},  d_out/d_r1 = -t1*1{x>r1}
+                #   d_out/d_r2 =  2*t2*m2,     d_out/d_r3 = -2*t3*m3
+                mm0 = (m0_b > 0.0).to(tl.float32)
+                mm1 = (m1_b > 0.0).to(tl.float32)
+                gt0 += tl.sum(grad_out * m0_b)
+                gt1 += tl.sum(grad_out * m1_b)
+                gt2 += tl.sum(grad_out * m2_b * m2_b)
+                gt3 += tl.sum(grad_out * m3_b * m3_b)
+                gr0 += t0 * tl.sum(grad_out * mm0)
+                gr1 += -t1 * tl.sum(grad_out * mm1)
+                gr2 += 2.0 * t2 * tl.sum(grad_out * m2_b)
+                gr3 += -2.0 * t3 * tl.sum(grad_out * m3_b)
 
-        # One atomic_add per row per scalar (8 total). Race-free across
-        # programs and well below kernel runtime.
-        tl.atomic_add(grad_r_ptr + 0, gr0)
-        tl.atomic_add(grad_r_ptr + 1, gr1)
-        tl.atomic_add(grad_r_ptr + 2, gr2)
-        tl.atomic_add(grad_r_ptr + 3, gr3)
-        tl.atomic_add(grad_t_ptr + 0, gt0)
-        tl.atomic_add(grad_t_ptr + 1, gt1)
-        tl.atomic_add(grad_t_ptr + 2, gt2)
-        tl.atomic_add(grad_t_ptr + 3, gt3)
+        if HAS_MULTIMAX_GRADIENTS:
+            # One atomic_add per row per scalar (8 total). Race-free across
+            # programs and well below kernel runtime.
+            tl.atomic_add(grad_r_ptr + 0, gr0)
+            tl.atomic_add(grad_r_ptr + 1, gr1)
+            tl.atomic_add(grad_r_ptr + 2, gr2)
+            tl.atomic_add(grad_r_ptr + 3, gr3)
+            tl.atomic_add(grad_t_ptr + 0, gt0)
+            tl.atomic_add(grad_t_ptr + 1, gt1)
+            tl.atomic_add(grad_t_ptr + 2, gt2)
+            tl.atomic_add(grad_t_ptr + 3, gt3)
 
     tl.debug_barrier()
 

--- a/src/paddlefleet/triton_ops/fused_linear_cross_entropy/fused_linear_cross_entropy.py
+++ b/src/paddlefleet/triton_ops/fused_linear_cross_entropy/fused_linear_cross_entropy.py
@@ -245,14 +245,19 @@ def fused_linear_cross_entropy_forward(
     else:
         loss = paddle.sum(loss_1d)
 
-    return (
-        loss,
-        grad_input,
-        grad_weight,
-        grad_bias,
-        grad_multimax_ranges,
-        grad_multimax_ts,
-    )
+    # Backward compatibility: return 4-tuple when multimax is disabled,
+    # 6-tuple when enabled. Direct callers expecting 4 values won't break.
+    if multimax_ranges is None:
+        return loss, grad_input, grad_weight, grad_bias
+    else:
+        return (
+            loss,
+            grad_input,
+            grad_weight,
+            grad_bias,
+            grad_multimax_ranges,
+            grad_multimax_ts,
+        )
 
 
 def fused_linear_cross_entropy_backward(
@@ -338,14 +343,7 @@ class LigerFusedLinearCrossEntropyFunction(paddle.autograd.PyLayer):
         multimax_ranges = args[8] if len(args) > 8 else None
         multimax_ts = args[9] if len(args) > 9 else None
 
-        (
-            loss,
-            grad_input,
-            grad_weight,
-            grad_bias,
-            grad_mm_ranges,
-            grad_mm_ts,
-        ) = fused_linear_cross_entropy_forward(
+        ret = fused_linear_cross_entropy_forward(
             _input=_input,
             weight=weight,
             target=target,
@@ -357,6 +355,12 @@ class LigerFusedLinearCrossEntropyFunction(paddle.autograd.PyLayer):
             multimax_ranges=multimax_ranges,
             multimax_ts=multimax_ts,
         )
+        # Handle both 4-tuple (multimax disabled) and 6-tuple (enabled)
+        if len(ret) == 4:
+            loss, grad_input, grad_weight, grad_bias = ret
+            grad_mm_ranges = grad_mm_ts = None
+        else:
+            loss, grad_input, grad_weight, grad_bias, grad_mm_ranges, grad_mm_ts = ret
 
         ctx.save_for_backward(
             grad_input.detach() if grad_input is not None else None,

--- a/src/paddlefleet/triton_ops/fused_linear_cross_entropy/fused_linear_cross_entropy.py
+++ b/src/paddlefleet/triton_ops/fused_linear_cross_entropy/fused_linear_cross_entropy.py
@@ -25,7 +25,10 @@ Triton kernel 前向计算 loss 的同时原地写回梯度，避免保留完整
 import paddle
 import triton
 
-from .cross_entropy import liger_cross_entropy_kernel
+from .cross_entropy import (
+    liger_cross_entropy_kernel,
+    liger_cross_entropy_multimax_kernel,
+)
 from .utils import element_mul_kernel
 
 MAX_FUSED_SIZE = 65536 // 2
@@ -40,6 +43,8 @@ def fused_linear_cross_entropy_forward(
     reduction="none",
     num_chunks=1,
     ec_align=False,
+    multimax_ranges=None,
+    multimax_ts=None,
 ):
     """前向：分 chunk 计算 logits / loss / grad_input / grad_weight。
 
@@ -55,6 +60,16 @@ def fused_linear_cross_entropy_forward(
                   grad_weight 使用 [H, V] 布局（GEMM [H,C]@[C,V]），
                   与 ernie-core 的 fused_linear_param_grad_add 调用完全相同。
                   backward 中 main_grad.add_(grad_weight.T)。
+        multimax_ranges, multimax_ts: 可选 [4]-shape 张量。若两者均提供，
+            则使用 `liger_cross_entropy_multimax_kernel` 在 Triton 内核中
+            将 SeLU 段式调制 + CE + SeLU 反向 全部融合在两次扫描内完成；
+            grad_multimax_{ranges,ts} 通过 atomic_add 写入返回缓冲。
+            相比在 Python 中逐 chunk 计算 SeLU 前向 / 反向，可避免在 HBM
+            上物化 4 个 ReLU 中间张量与 SeLU 输出，将每个 chunk 的 vocab
+            轴显存峰值从 ~10× 降回 ~1×。
+            SeLU(x) = x + t0·max(r0-x,0) + t1·max(x-r1,0)
+                     + t2·max(r2-x,0)^2 + t3·max(x-r3,0)^2
+            初始化为 0 时 SeLU 为恒等映射，与未启用路径数值一致。
     """
     input_requires_grad = not _input.stop_gradient
     weight_requires_grad = not weight.stop_gradient
@@ -87,10 +102,39 @@ def fused_linear_cross_entropy_forward(
         else None
     )
 
+    # Multimax: SeLU is applied inside the Triton kernel
+    # (`liger_cross_entropy_multimax_kernel`), which fuses SeLU forward,
+    # online lse, softmax-grad, and SeLU backward in a single two-pass
+    # scan over the chunk. Per-row partial sums for grad_ranges/grad_ts
+    # are atomic-added into these fp32 [4] buffers from the kernel.
+    use_multimax = multimax_ranges is not None and multimax_ts is not None
+    if use_multimax:
+        grad_multimax_ranges = paddle.zeros([4], dtype=paddle.float32)
+        grad_multimax_ts = paddle.zeros([4], dtype=paddle.float32)
+        # Extract scalar values once (one host<->device sync for an [4]
+        # tensor; negligible vs the chunk's GEMM/CE cost). Using fp32 for
+        # numerical stability inside the kernel.
+        _r_vals = [
+            float(v) for v in multimax_ranges.cast("float32").tolist()
+        ]
+        _t_vals = [
+            float(v) for v in multimax_ts.cast("float32").tolist()
+        ]
+    else:
+        grad_multimax_ranges = None
+        grad_multimax_ts = None
+        _r_vals = None
+        _t_vals = None
+
     loss_1d = paddle.zeros([BT], dtype=paddle.float32)
 
     target_mask = target != ignore_index
-    total_n_non_ignore = target_mask.sum().item()
+    # n_non_ignore is only used inside the kernel when reduction=="mean".
+    # reduction is a tl.constexpr so the mean branch is dead code for
+    # other modes; skip the D2H sync entirely in those cases.
+    total_n_non_ignore = (
+        int(target_mask.sum().item()) if reduction == "mean" else 0
+    )
 
     for chunk_id in range(num_chunks):
         start_idx = chunk_id * chunk_size
@@ -109,24 +153,51 @@ def fused_linear_cross_entropy_forward(
         logits_chunk = logits_chunk.contiguous()
         target_chunk = target_chunk.contiguous()
 
-        liger_cross_entropy_kernel[(n_rows,)](
-            X_ptr=logits_chunk,
-            X_stride=logits_chunk.stride(-2),
-            Y_ptr=target_chunk,
-            Y_stride=target_chunk.stride(-1),
-            loss_ptr=loss_1d_slice,
-            loss_stride=loss_1d_slice.stride(-1),
-            n_cols=V,
-            n_non_ignore=total_n_non_ignore,
-            ignore_index=ignore_index,
-            reduction=reduction,
-            HAS_GRADIENTS=input_requires_grad,
-            BLOCK_SIZE=BLOCK_SIZE,
-            num_warps=32,
-        )
+        if use_multimax:
+            liger_cross_entropy_multimax_kernel[(n_rows,)](
+                X_ptr=logits_chunk,
+                X_stride=logits_chunk.stride(-2),
+                Y_ptr=target_chunk,
+                Y_stride=target_chunk.stride(-1),
+                loss_ptr=loss_1d_slice,
+                loss_stride=loss_1d_slice.stride(-1),
+                n_cols=V,
+                n_non_ignore=total_n_non_ignore,
+                ignore_index=ignore_index,
+                r0=_r_vals[0],
+                r1=_r_vals[1],
+                r2=_r_vals[2],
+                r3=_r_vals[3],
+                t0=_t_vals[0],
+                t1=_t_vals[1],
+                t2=_t_vals[2],
+                t3=_t_vals[3],
+                grad_r_ptr=grad_multimax_ranges,
+                grad_t_ptr=grad_multimax_ts,
+                reduction=reduction,
+                HAS_GRADIENTS=input_requires_grad,
+                BLOCK_SIZE=BLOCK_SIZE,
+                num_warps=32,
+            )
+        else:
+            liger_cross_entropy_kernel[(n_rows,)](
+                X_ptr=logits_chunk,
+                X_stride=logits_chunk.stride(-2),
+                Y_ptr=target_chunk,
+                Y_stride=target_chunk.stride(-1),
+                loss_ptr=loss_1d_slice,
+                loss_stride=loss_1d_slice.stride(-1),
+                n_cols=V,
+                n_non_ignore=total_n_non_ignore,
+                ignore_index=ignore_index,
+                reduction=reduction,
+                HAS_GRADIENTS=input_requires_grad,
+                BLOCK_SIZE=BLOCK_SIZE,
+                num_warps=32,
+            )
 
         loss_1d[start_idx:end_idx] = loss_1d_slice
-        # kernel 已将梯度原地写回 logits_chunk（现在是 grad_logits，尚未归一化）
+        # kernel 已将梯度（含 SeLU 反向链式法则）原地写回 logits_chunk
         grad_logits_chunk = logits_chunk
 
         if input_requires_grad:
@@ -174,7 +245,14 @@ def fused_linear_cross_entropy_forward(
     else:
         loss = paddle.sum(loss_1d)
 
-    return loss, grad_input, grad_weight, grad_bias
+    return (
+        loss,
+        grad_input,
+        grad_weight,
+        grad_bias,
+        grad_multimax_ranges,
+        grad_multimax_ts,
+    )
 
 
 def fused_linear_cross_entropy_backward(
@@ -234,13 +312,16 @@ class LigerFusedLinearCrossEntropyFunction(paddle.autograd.PyLayer):
 
     使用方式:
         loss = LigerFusedLinearCrossEntropyFunction.apply(
-            _input,       # [BT, H]
-            weight,       # [V, H]
-            target,       # [BT]
-            bias,         # [V] 或 None
+            _input,             # [BT, H]
+            weight,             # [V, H]
+            target,             # [BT]
+            bias,               # [V] 或 None
             ignore_index,
             reduction,
             num_chunks,
+            ec_align,
+            multimax_ranges,    # [4] 可选，启用 multimax lm_head 时传入
+            multimax_ts,        # [4] 可选，启用 multimax lm_head 时传入
         )
     """
 
@@ -254,39 +335,75 @@ class LigerFusedLinearCrossEntropyFunction(paddle.autograd.PyLayer):
         reduction = args[5]
         num_chunks = args[6]
         ec_align = args[7]
+        multimax_ranges = args[8] if len(args) > 8 else None
+        multimax_ts = args[9] if len(args) > 9 else None
 
-        loss, grad_input, grad_weight, grad_bias = (
-            fused_linear_cross_entropy_forward(
-                _input=_input,
-                weight=weight,
-                target=target,
-                bias=bias,
-                ignore_index=ignore_index,
-                reduction=reduction,
-                num_chunks=num_chunks,
-                ec_align=ec_align,
-            )
+        (
+            loss,
+            grad_input,
+            grad_weight,
+            grad_bias,
+            grad_mm_ranges,
+            grad_mm_ts,
+        ) = fused_linear_cross_entropy_forward(
+            _input=_input,
+            weight=weight,
+            target=target,
+            bias=bias,
+            ignore_index=ignore_index,
+            reduction=reduction,
+            num_chunks=num_chunks,
+            ec_align=ec_align,
+            multimax_ranges=multimax_ranges,
+            multimax_ts=multimax_ts,
         )
 
         ctx.save_for_backward(
             grad_input.detach() if grad_input is not None else None,
             grad_weight.detach() if grad_weight is not None else None,
             grad_bias.detach() if grad_bias is not None else None,
+            grad_mm_ranges.detach() if grad_mm_ranges is not None else None,
+            grad_mm_ts.detach() if grad_mm_ts is not None else None,
         )
         ctx.has_bias = bias is not None
+        ctx.has_multimax = multimax_ranges is not None
         ctx.weight_ref = weight
         ctx.weight_requires_grad = not weight.stop_gradient
+        ctx.multimax_ranges_ref = multimax_ranges
+        ctx.multimax_ts_ref = multimax_ts
         ctx.ec_align = ec_align
         return loss
 
     @staticmethod
     def backward(ctx, grad_output):
-        (grad_input, grad_weight, grad_bias) = ctx.saved_tensor()
+        (
+            grad_input,
+            grad_weight,
+            grad_bias,
+            grad_mm_ranges,
+            grad_mm_ts,
+        ) = ctx.saved_tensor()
         grad_input, grad_weight, grad_bias = (
             fused_linear_cross_entropy_backward(
                 grad_output, grad_input, grad_weight, grad_bias
             )
         )
+
+        # Scale multimax grads by the same factor as the other grads.
+        # `fused_linear_cross_entropy_backward` already collapsed
+        # `grad_output` to a scalar when needed; replicate the same
+        # detection here to stay consistent.
+        if ctx.has_multimax and (grad_mm_ranges is not None):
+            scale = grad_output
+            if scale.shape == [] and float(scale) == 1.0:
+                pass
+            else:
+                if scale.ndim >= 1:
+                    scale = scale.max().reshape([])
+                grad_mm_ranges = grad_mm_ranges * scale.cast(
+                    grad_mm_ranges.dtype
+                )
+                grad_mm_ts = grad_mm_ts * scale.cast(grad_mm_ts.dtype)
 
         if ctx.weight_requires_grad and grad_weight is not None:
             weight = ctx.weight_ref
@@ -305,7 +422,42 @@ class LigerFusedLinearCrossEntropyFunction(paddle.autograd.PyLayer):
                     weight._apply_backward_hook()
                 grad_weight = None
 
+        # Multimax params: accumulate into main_grad when present (matches
+        # the weight pattern); otherwise fall back to returning the grad
+        # so the standard autograd accumulator handles it.
+        mm_ranges_out = None
+        mm_ts_out = None
+        if ctx.has_multimax:
+            for param, g, slot in (
+                (ctx.multimax_ranges_ref, grad_mm_ranges, "ranges"),
+                (ctx.multimax_ts_ref, grad_mm_ts, "ts"),
+            ):
+                if param is None or g is None:
+                    continue
+                if hasattr(param, "main_grad"):
+                    if param.main_grad is None:
+                        param.main_grad = paddle.zeros(
+                            param.shape, dtype=paddle.float32
+                        )
+                    param.main_grad.add_(g.cast(param.main_grad.dtype))
+                    if hasattr(param, "_apply_backward_hook"):
+                        param._apply_backward_hook()
+                    # multimax params have stop_gradient=False so Paddle's
+                    # autograd requires a non-None gradient at this position.
+                    # Return zeros: real gradient is already in main_grad for
+                    # the optimizer to consume; param.grad zeros are ignored.
+                    out_grad = paddle.zeros(param.shape, dtype=param.dtype)
+                else:
+                    out_grad = g.cast(param.dtype)
+                if slot == "ranges":
+                    mm_ranges_out = out_grad
+                else:
+                    mm_ts_out = out_grad
+
         result = [grad_input, grad_weight, None]
         if ctx.has_bias:
             result.append(grad_bias)
+        if ctx.has_multimax:
+            result.append(mm_ranges_out)
+            result.append(mm_ts_out)
         return tuple(result)

--- a/src/paddlefleet/triton_ops/fused_linear_cross_entropy/fused_linear_cross_entropy.py
+++ b/src/paddlefleet/triton_ops/fused_linear_cross_entropy/fused_linear_cross_entropy.py
@@ -111,6 +111,14 @@ def fused_linear_cross_entropy_forward(
     if use_multimax:
         grad_multimax_ranges = paddle.zeros([4], dtype=paddle.float32)
         grad_multimax_ts = paddle.zeros([4], dtype=paddle.float32)
+        # Multimax param grads must be computed whenever EITHER param is
+        # trainable, independently of whether the upstream hidden states
+        # require grad. This covers the freeze-backbone / train-head-only
+        # regime where _input.stop_gradient=True but multimax_*.stop_gradient=False.
+        multimax_requires_grad = (
+            not multimax_ranges.stop_gradient
+            or not multimax_ts.stop_gradient
+        )
         # Extract scalar values once (one host<->device sync for an [4]
         # tensor; negligible vs the chunk's GEMM/CE cost). Using fp32 for
         # numerical stability inside the kernel.
@@ -123,6 +131,7 @@ def fused_linear_cross_entropy_forward(
     else:
         grad_multimax_ranges = None
         grad_multimax_ts = None
+        multimax_requires_grad = False
         _r_vals = None
         _t_vals = None
 
@@ -176,6 +185,7 @@ def fused_linear_cross_entropy_forward(
                 grad_t_ptr=grad_multimax_ts,
                 reduction=reduction,
                 HAS_GRADIENTS=input_requires_grad,
+                HAS_MULTIMAX_GRADIENTS=multimax_requires_grad,
                 BLOCK_SIZE=BLOCK_SIZE,
                 num_warps=32,
             )
@@ -272,18 +282,21 @@ def fused_linear_cross_entropy_backward(
     if grad_output.ndim >= 1:
         grad_output = grad_output.max().reshape([])
 
-    BT, H = grad_input.shape
-    n_rows = BT
-    BLOCK_SIZE = min(MAX_FUSED_SIZE, triton.next_power_of_2(H))
+    if grad_input is not None:
+        BT, H = grad_input.shape
+        n_rows = BT
+        BLOCK_SIZE = min(MAX_FUSED_SIZE, triton.next_power_of_2(H))
 
-    element_mul_kernel[(n_rows,)](
-        grad_input,
-        grad_input.stride(-2),
-        grad_output,
-        H,
-        BLOCK_SIZE=BLOCK_SIZE,
-        num_warps=32,
-    )
+        element_mul_kernel[(n_rows,)](
+            grad_input,
+            grad_input.stride(-2),
+            grad_output,
+            H,
+            BLOCK_SIZE=BLOCK_SIZE,
+            num_warps=32,
+        )
+    else:
+        BLOCK_SIZE = MAX_FUSED_SIZE
 
     if grad_weight is not None:
         n_rows_w = grad_weight.shape[0]

--- a/src/paddlefleet/triton_ops/fused_linear_cross_entropy/fused_linear_cross_entropy.py
+++ b/src/paddlefleet/triton_ops/fused_linear_cross_entropy/fused_linear_cross_entropy.py
@@ -62,14 +62,14 @@ def fused_linear_cross_entropy_forward(
                   backward 中 main_grad.add_(grad_weight.T)。
         multimax_ranges, multimax_ts: 可选 [4]-shape 张量。若两者均提供，
             则使用 `liger_cross_entropy_multimax_kernel` 在 Triton 内核中
-            将 SeLU 段式调制 + CE + SeLU 反向 全部融合在两次扫描内完成；
+            将 SegLU 段式调制 + CE + SegLU 反向 全部融合在两次扫描内完成；
             grad_multimax_{ranges,ts} 通过 atomic_add 写入返回缓冲。
-            相比在 Python 中逐 chunk 计算 SeLU 前向 / 反向，可避免在 HBM
-            上物化 4 个 ReLU 中间张量与 SeLU 输出，将每个 chunk 的 vocab
+            相比在 Python 中逐 chunk 计算 SegLU 前向 / 反向，可避免在 HBM
+            上物化 4 个 ReLU 中间张量与 SegLU 输出，将每个 chunk 的 vocab
             轴显存峰值从 ~10× 降回 ~1×。
-            SeLU(x) = x + t0·max(r0-x,0) + t1·max(x-r1,0)
+            SegLU(x) = x + t0·max(r0-x,0) + t1·max(x-r1,0)
                      + t2·max(r2-x,0)^2 + t3·max(x-r3,0)^2
-            初始化为 0 时 SeLU 为恒等映射，与未启用路径数值一致。
+            初始化为 0 时 SegLU 为恒等映射，与未启用路径数值一致。
     """
     input_requires_grad = not _input.stop_gradient
     weight_requires_grad = not weight.stop_gradient
@@ -111,9 +111,9 @@ def fused_linear_cross_entropy_forward(
         else None
     )
 
-    # Multimax: SeLU is applied inside the Triton kernel
-    # (`liger_cross_entropy_multimax_kernel`), which fuses SeLU forward,
-    # online lse, softmax-grad, and SeLU backward in a single two-pass
+    # Multimax: SegLU is applied inside the Triton kernel
+    # (`liger_cross_entropy_multimax_kernel`), which fuses SegLU forward,
+    # online lse, softmax-grad, and SegLU backward in a single two-pass
     # scan over the chunk. Per-row partial sums for grad_ranges/grad_ts
     # are atomic-added into these fp32 [4] buffers from the kernel.
     use_multimax = multimax_ranges is not None and multimax_ts is not None
@@ -211,7 +211,7 @@ def fused_linear_cross_entropy_forward(
             )
 
         loss_1d[start_idx:end_idx] = loss_1d_slice
-        # kernel 已将梯度（含 SeLU 反向链式法则）原地写回 logits_chunk
+        # kernel 已将梯度（含 SegLU 反向链式法则）原地写回 logits_chunk
         grad_logits_chunk = logits_chunk
 
         if input_requires_grad:

--- a/src/paddlefleet/triton_ops/fused_linear_cross_entropy/fused_linear_cross_entropy.py
+++ b/src/paddlefleet/triton_ops/fused_linear_cross_entropy/fused_linear_cross_entropy.py
@@ -116,18 +116,13 @@ def fused_linear_cross_entropy_forward(
         # require grad. This covers the freeze-backbone / train-head-only
         # regime where _input.stop_gradient=True but multimax_*.stop_gradient=False.
         multimax_requires_grad = (
-            not multimax_ranges.stop_gradient
-            or not multimax_ts.stop_gradient
+            not multimax_ranges.stop_gradient or not multimax_ts.stop_gradient
         )
         # Extract scalar values once (one host<->device sync for an [4]
         # tensor; negligible vs the chunk's GEMM/CE cost). Using fp32 for
         # numerical stability inside the kernel.
-        _r_vals = [
-            float(v) for v in multimax_ranges.cast("float32").tolist()
-        ]
-        _t_vals = [
-            float(v) for v in multimax_ts.cast("float32").tolist()
-        ]
+        _r_vals = [float(v) for v in multimax_ranges.cast("float32").tolist()]
+        _t_vals = [float(v) for v in multimax_ts.cast("float32").tolist()]
     else:
         grad_multimax_ranges = None
         grad_multimax_ts = None
@@ -373,7 +368,14 @@ class LigerFusedLinearCrossEntropyFunction(paddle.autograd.PyLayer):
             loss, grad_input, grad_weight, grad_bias = ret
             grad_mm_ranges = grad_mm_ts = None
         else:
-            loss, grad_input, grad_weight, grad_bias, grad_mm_ranges, grad_mm_ts = ret
+            (
+                loss,
+                grad_input,
+                grad_weight,
+                grad_bias,
+                grad_mm_ranges,
+                grad_mm_ts,
+            ) = ret
 
         ctx.save_for_backward(
             grad_input.detach() if grad_input is not None else None,

--- a/src/paddlefleet/triton_ops/fused_linear_cross_entropy/fused_linear_cross_entropy.py
+++ b/src/paddlefleet/triton_ops/fused_linear_cross_entropy/fused_linear_cross_entropy.py
@@ -73,6 +73,15 @@ def fused_linear_cross_entropy_forward(
     """
     input_requires_grad = not _input.stop_gradient
     weight_requires_grad = not weight.stop_gradient
+    bias_requires_grad = bias is not None and not bias.stop_gradient
+    # The Triton kernel writes softmax-grad (= grad_logits) in-place into
+    # logits_chunk whenever ANY of {input, weight, bias} needs a gradient,
+    # since grad_logits feeds all three downstream GEMMs. Gating this on
+    # `input_requires_grad` alone breaks the freeze-backbone / train-head
+    # case where _input.stop_gradient=True but weight.stop_gradient=False.
+    needs_grad_logits = (
+        input_requires_grad or weight_requires_grad or bias_requires_grad
+    )
     orig_dtype = _input.dtype
 
     BT, H = _input.shape
@@ -88,7 +97,7 @@ def fused_linear_cross_entropy_forward(
     )
     # ec_align 模式：grad_weight 使用 [H, V] 布局，与 ernie-core 的 GEMM shape 一致。
     # 默认模式：grad_weight 使用 [V, H] 布局（与 weight.shape 一致，main_grad 可直接 add_）。
-    if input_requires_grad and weight_requires_grad:
+    if weight_requires_grad:
         grad_weight = (
             paddle.zeros([H, V], dtype=paddle.float32)
             if ec_align
@@ -98,7 +107,7 @@ def fused_linear_cross_entropy_forward(
         grad_weight = None
     grad_bias = (
         paddle.zeros([bias.shape[0]], dtype=paddle.float32)
-        if (input_requires_grad and bias is not None)
+        if bias_requires_grad
         else None
     )
 
@@ -179,7 +188,7 @@ def fused_linear_cross_entropy_forward(
                 grad_r_ptr=grad_multimax_ranges,
                 grad_t_ptr=grad_multimax_ts,
                 reduction=reduction,
-                HAS_GRADIENTS=input_requires_grad,
+                HAS_GRADIENTS=needs_grad_logits,
                 HAS_MULTIMAX_GRADIENTS=multimax_requires_grad,
                 BLOCK_SIZE=BLOCK_SIZE,
                 num_warps=32,
@@ -196,7 +205,7 @@ def fused_linear_cross_entropy_forward(
                 n_non_ignore=total_n_non_ignore,
                 ignore_index=ignore_index,
                 reduction=reduction,
-                HAS_GRADIENTS=input_requires_grad,
+                HAS_GRADIENTS=needs_grad_logits,
                 BLOCK_SIZE=BLOCK_SIZE,
                 num_warps=32,
             )

--- a/src/paddlefleet/triton_ops/fused_linear_cross_entropy/fused_linear_cross_entropy.py
+++ b/src/paddlefleet/triton_ops/fused_linear_cross_entropy/fused_linear_cross_entropy.py
@@ -399,6 +399,20 @@ class LigerFusedLinearCrossEntropyFunction(paddle.autograd.PyLayer):
         ctx.weight_requires_grad = not weight.stop_gradient
         ctx.multimax_ranges_ref = multimax_ranges
         ctx.multimax_ts_ref = multimax_ts
+        # Cache stop_gradient at forward time. multimax_requires_grad in the
+        # forward (the kernel-level flag) is the OR of the two params' grad
+        # requirements, so when only one is frozen the kernel still produces
+        # both grads. The backward must respect each param's individual
+        # stop_gradient: a frozen param contributes nothing to main_grad and
+        # returns None at its PyLayer slot (cf. tensor_parallel/layers.py
+        # PyLayer contract: forward Tensor inputs with stop_gradient=True
+        # MUST get None at the matching backward position).
+        ctx.multimax_ranges_requires_grad = (
+            multimax_ranges is not None and not multimax_ranges.stop_gradient
+        )
+        ctx.multimax_ts_requires_grad = (
+            multimax_ts is not None and not multimax_ts.stop_gradient
+        )
         ctx.ec_align = ec_align
         return loss
 
@@ -452,15 +466,33 @@ class LigerFusedLinearCrossEntropyFunction(paddle.autograd.PyLayer):
 
         # Multimax params: accumulate into main_grad when present (matches
         # the weight pattern); otherwise fall back to returning the grad
-        # so the standard autograd accumulator handles it.
+        # so the standard autograd accumulator handles it. Frozen params
+        # (stop_gradient=True) MUST get None at their PyLayer slot and
+        # MUST NOT touch main_grad / fire backward hooks, even though the
+        # kernel produced a grad tensor for them (multimax_requires_grad
+        # is the OR of the two params' grad-requirements).
         mm_ranges_out = None
         mm_ts_out = None
         if ctx.has_multimax:
-            for param, g, slot in (
-                (ctx.multimax_ranges_ref, grad_mm_ranges, "ranges"),
-                (ctx.multimax_ts_ref, grad_mm_ts, "ts"),
+            for param, g, slot, requires_grad in (
+                (
+                    ctx.multimax_ranges_ref,
+                    grad_mm_ranges,
+                    "ranges",
+                    ctx.multimax_ranges_requires_grad,
+                ),
+                (
+                    ctx.multimax_ts_ref,
+                    grad_mm_ts,
+                    "ts",
+                    ctx.multimax_ts_requires_grad,
+                ),
             ):
                 if param is None or g is None:
+                    continue
+                if not requires_grad:
+                    # Param was frozen at forward time; respect that here.
+                    # Leave mm_*_out as None for this slot.
                     continue
                 if hasattr(param, "main_grad"):
                     if param.main_grad is None:

--- a/tests/single_card_tests/ai_edited_test/triton_ops/test_ai_fused_linear_cross_entropy.py
+++ b/tests/single_card_tests/ai_edited_test/triton_ops/test_ai_fused_linear_cross_entropy.py
@@ -362,6 +362,7 @@ class TestFusedLinearCrossEntropyForwardEdgeCases(unittest.TestCase):
         weight = paddle.randn([V, H], dtype=paddle.float32)
         weight.stop_gradient = False
         bias = paddle.randn([V], dtype=paddle.float32)
+        bias.stop_gradient = False
         target = paddle.randint(0, V, [BT])
 
         loss, grad_input, grad_weight, grad_bias = (
@@ -378,6 +379,38 @@ class TestFusedLinearCrossEntropyForwardEdgeCases(unittest.TestCase):
         )
 
         self.assertIsNotNone(grad_bias)
+
+    def test_forward_with_frozen_bias(self):
+        """Test forward where bias is provided but stop_gradient=True:
+        grad_bias should be None (allocation is gated on bias.stop_gradient,
+        not just `bias is not None`)."""
+        from paddlefleet.triton_ops.fused_linear_cross_entropy.fused_linear_cross_entropy import (
+            fused_linear_cross_entropy_forward,
+        )
+
+        BT, H, V = 4, 8, 16
+        _input = paddle.randn([BT, H], dtype=paddle.float32)
+        _input.stop_gradient = False
+        weight = paddle.randn([V, H], dtype=paddle.float32)
+        weight.stop_gradient = False
+        bias = paddle.randn([V], dtype=paddle.float32)
+        bias.stop_gradient = True  # frozen bias
+        target = paddle.randint(0, V, [BT])
+
+        loss, grad_input, grad_weight, grad_bias = (
+            fused_linear_cross_entropy_forward(
+                _input=_input,
+                weight=weight,
+                target=target,
+                bias=bias,
+                ignore_index=-100,
+                reduction="mean",
+                num_chunks=1,
+                ec_align=False,
+            )
+        )
+
+        self.assertIsNone(grad_bias)
 
     def test_forward_ec_align_mode(self):
         """Test forward with ec_align mode."""

--- a/tests/single_card_tests/custom_ops/test_fused_linear_ce_accuracy.py
+++ b/tests/single_card_tests/custom_ops/test_fused_linear_ce_accuracy.py
@@ -212,84 +212,35 @@ class TestFusedLinearCEAccuracy(unittest.TestCase):
             a_np, b_np, atol=atol, rtol=rtol, err_msg=msg
         )
 
-    # ------------------------------------------------------------------
-    # 场景 1：基本 loss 对比（无 mask）
-    # ------------------------------------------------------------------
-    def test_forward_loss_no_mask(self):
-        H, V = 64, 256
-        bsl, fused = _make_pair(H, V, num_chunks=1)
-        hidden, labels = _make_inputs(2, 16, H, V, ignore_ratio=0.0)
-
-        loss_b, _, _, _ = _forward_backward(*bsl, hidden, labels)
-        loss_f, _, _, _ = _forward_backward(*fused, hidden, labels)
-
-        self._assert_close(loss_b, loss_f, "loss (no mask)")
+    # 共享尺寸：足够覆盖 chunk 划分但远小于真实模型，控制单测耗时。
+    H, V = 32, 128
 
     # ------------------------------------------------------------------
-    # 场景 2：含 ignore_index 的 loss 对比
+    # 场景 1：基本 loss + 全部梯度对比（无 mask 与含 mask 合并为一次 fwd/bwd
+    # 的两个采样，避免重复构造模型）。
     # ------------------------------------------------------------------
-    def test_forward_loss_with_mask(self):
-        H, V = 64, 256
-        bsl, fused = _make_pair(H, V, num_chunks=1)
-        hidden, labels = _make_inputs(2, 16, H, V, ignore_ratio=0.3)
+    def test_loss_and_grads_match(self):
+        bsl, fused = _make_pair(self.H, self.V, num_chunks=1)
+        hidden, labels = _make_inputs(2, 8, self.H, self.V, ignore_ratio=0.3)
 
-        loss_b, _, _, _ = _forward_backward(*bsl, hidden, labels)
-        loss_f, _, _, _ = _forward_backward(*fused, hidden, labels)
+        loss_b, gi_b, gw_b, gb_b = _forward_backward(*bsl, hidden, labels)
+        loss_f, gi_f, gw_f, gb_f = _forward_backward(*fused, hidden, labels)
 
-        self._assert_close(loss_b, loss_f, "loss (with mask)")
-
-    # ------------------------------------------------------------------
-    # 场景 3：grad_input 对比
-    # ------------------------------------------------------------------
-    def test_backward_grad_input(self):
-        H, V = 64, 256
-        bsl, fused = _make_pair(H, V, num_chunks=1)
-        hidden, labels = _make_inputs(2, 16, H, V, ignore_ratio=0.2)
-
-        _, gi_b, _, _ = _forward_backward(*bsl, hidden, labels)
-        _, gi_f, _, _ = _forward_backward(*fused, hidden, labels)
-
+        self._assert_close(loss_b, loss_f, "loss")
         self._assert_close(gi_b, gi_f, "grad_input")
-
-    # ------------------------------------------------------------------
-    # 场景 4：grad_weight 对比
-    #   baseline:  weight.grad shape [V, H]（autograd 标准路径）
-    #   fused:     weight.grad shape [V, H]（经 main_grad.T 累加后由 autograd 返回）
-    # ------------------------------------------------------------------
-    def test_backward_grad_weight(self):
-        H, V = 64, 256
-        bsl, fused = _make_pair(H, V, num_chunks=1)
-        hidden, labels = _make_inputs(2, 16, H, V, ignore_ratio=0.2)
-
-        _, _, gw_b, _ = _forward_backward(*bsl, hidden, labels)
-        _, _, gw_f, _ = _forward_backward(*fused, hidden, labels)
-
         self._assert_close(
             gw_b, gw_f, "grad_weight", atol=self.GRAD_ATOL, rtol=self.GRAD_RTOL
         )
-
-    # ------------------------------------------------------------------
-    # 场景 5：grad_bias 对比
-    # ------------------------------------------------------------------
-    def test_backward_grad_bias(self):
-        H, V = 64, 256
-        bsl, fused = _make_pair(H, V, num_chunks=1)
-        hidden, labels = _make_inputs(2, 16, H, V, ignore_ratio=0.2)
-
-        _, _, _, gb_b = _forward_backward(*bsl, hidden, labels)
-        _, _, _, gb_f = _forward_backward(*fused, hidden, labels)
-
         self._assert_close(
             gb_b, gb_f, "grad_bias", atol=self.GRAD_ATOL, rtol=self.GRAD_RTOL
         )
 
     # ------------------------------------------------------------------
-    # 场景 6：高 ignore 比例
+    # 场景 2：高 ignore 比例（loss/grad_input/grad_weight）
     # ------------------------------------------------------------------
     def test_high_ignore_ratio(self):
-        H, V = 64, 256
-        bsl, fused = _make_pair(H, V, num_chunks=1)
-        hidden, labels = _make_inputs(2, 32, H, V, ignore_ratio=0.7)
+        bsl, fused = _make_pair(self.H, self.V, num_chunks=1)
+        hidden, labels = _make_inputs(2, 16, self.H, self.V, ignore_ratio=0.7)
 
         loss_b, gi_b, gw_b, _ = _forward_backward(*bsl, hidden, labels)
         loss_f, gi_f, gw_f, _ = _forward_backward(*fused, hidden, labels)
@@ -305,19 +256,17 @@ class TestFusedLinearCEAccuracy(unittest.TestCase):
         )
 
     # ------------------------------------------------------------------
-    # 场景 7：全 ignore（loss/grad 均为 0）
+    # 场景 3：全 ignore（loss=0 边界条件）
     # ------------------------------------------------------------------
     def test_all_ignore(self):
-        H, V = 64, 256
-        bsl, fused = _make_pair(H, V, num_chunks=1)
-        B, S = 2, 16
-        hidden = paddle.randn([B, S, H], dtype="float32")
+        bsl, fused = _make_pair(self.H, self.V, num_chunks=1)
+        B, S = 2, 8
+        hidden = paddle.randn([B, S, self.H], dtype="float32")
         labels = paddle.full([B, S], -100, dtype="int64")
 
         loss_b, _, _, _ = _forward_backward(*bsl, hidden, labels)
         loss_f, _, _, _ = _forward_backward(*fused, hidden, labels)
 
-        # 全 ignore 时 lossmask.sum()=0，两边均返回 0.0 * mean(loss)
         self.assertAlmostEqual(
             float(loss_b),
             0.0,
@@ -332,12 +281,11 @@ class TestFusedLinearCEAccuracy(unittest.TestCase):
         )
 
     # ------------------------------------------------------------------
-    # 场景 8：多 chunk
+    # 场景 4：多 chunk（验证 chunk 划分不影响数值结果）
     # ------------------------------------------------------------------
     def test_multi_chunk(self):
-        H, V = 64, 256
-        bsl, fused = _make_pair(H, V, num_chunks=4)
-        hidden, labels = _make_inputs(1, 64, H, V, ignore_ratio=0.2)
+        bsl, fused = _make_pair(self.H, self.V, num_chunks=4)
+        hidden, labels = _make_inputs(1, 32, self.H, self.V, ignore_ratio=0.2)
 
         loss_b, gi_b, gw_b, _ = _forward_backward(*bsl, hidden, labels)
         loss_f, gi_f, gw_f, _ = _forward_backward(*fused, hidden, labels)
@@ -348,27 +296,6 @@ class TestFusedLinearCEAccuracy(unittest.TestCase):
             gw_b,
             gw_f,
             "grad_weight (multi-chunk)",
-            atol=self.GRAD_ATOL,
-            rtol=self.GRAD_RTOL,
-        )
-
-    # ------------------------------------------------------------------
-    # 场景 9：较大 vocab_size
-    # ------------------------------------------------------------------
-    def test_large_vocab(self):
-        H, V = 128, 2048
-        bsl, fused = _make_pair(H, V, num_chunks=4)
-        hidden, labels = _make_inputs(2, 32, H, V, ignore_ratio=0.15)
-
-        loss_b, gi_b, gw_b, _ = _forward_backward(*bsl, hidden, labels)
-        loss_f, gi_f, gw_f, _ = _forward_backward(*fused, hidden, labels)
-
-        self._assert_close(loss_b, loss_f, "loss (large vocab)")
-        self._assert_close(gi_b, gi_f, "grad_input (large vocab)")
-        self._assert_close(
-            gw_b,
-            gw_f,
-            "grad_weight (large vocab)",
             atol=self.GRAD_ATOL,
             rtol=self.GRAD_RTOL,
         )

--- a/tests/single_card_tests/model/test_fused_linear_ce_pylayer_freeze.py
+++ b/tests/single_card_tests/model/test_fused_linear_ce_pylayer_freeze.py
@@ -1,0 +1,228 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU-runnable tests for the PyLayer wrapper around the fused-linear-CE
+Triton kernel.
+
+These tests stub the GPU-only inner functions
+(``fused_linear_cross_entropy_forward`` and
+``fused_linear_cross_entropy_backward``) so the PyLayer's autograd plumbing —
+specifically the per-parameter ``stop_gradient`` caching in ``forward`` and
+the freeze-respecting branches in ``backward`` — can be exercised on CPU.
+
+Regression coverage for:
+- multimax_ranges/multimax_ts caching in ``forward``.
+- backward returning ``None`` for frozen multimax params and not touching
+  their ``main_grad`` / backward hooks, even when the kernel emitted a
+  gradient tensor (multimax_requires_grad is the OR of the two params).
+- backward continuing to populate the trainable param when only one of the
+  pair is frozen.
+"""
+
+import unittest
+from unittest import mock
+
+import paddle
+
+from paddlefleet.triton_ops.fused_linear_cross_entropy import (
+    LigerFusedLinearCrossEntropyFunction,
+    fused_linear_cross_entropy as fused_module,
+)
+
+
+def _stub_forward(
+    _input,
+    weight,
+    target,
+    bias,
+    ignore_index,
+    reduction,
+    num_chunks,
+    ec_align,
+    multimax_ranges=None,
+    multimax_ts=None,
+):
+    """Drop-in replacement that returns shape-correct fake grads.
+
+    Mirrors the real function's return-tuple contract:
+    - 4-tuple when multimax is disabled,
+    - 6-tuple when multimax is enabled.
+
+    The ``multimax_requires_grad`` flag in the real kernel is the OR of the
+    two params' grad-requirements, so the kernel ALWAYS emits both grads
+    when multimax is enabled. We mimic that here by always returning
+    non-None grads for both ranges and ts when the params are present —
+    that's exactly the pathological case the backward must handle.
+    """
+    BT = _input.shape[0]
+    loss = paddle.zeros([BT], dtype=paddle.float32)
+    grad_input = paddle.ones_like(_input) if not _input.stop_gradient else None
+    grad_weight = paddle.ones_like(weight) if not weight.stop_gradient else None
+    grad_bias = (
+        paddle.ones_like(bias)
+        if (bias is not None and not bias.stop_gradient)
+        else None
+    )
+    if multimax_ranges is None:
+        return loss, grad_input, grad_weight, grad_bias
+    grad_mm_ranges = paddle.full(multimax_ranges.shape, 7.0, dtype="float32")
+    grad_mm_ts = paddle.full(multimax_ts.shape, 11.0, dtype="float32")
+    return loss, grad_input, grad_weight, grad_bias, grad_mm_ranges, grad_mm_ts
+
+
+def _stub_backward(grad_output, grad_input, grad_weight, grad_bias):
+    """Identity pass-through; the PyLayer's logic post-backward is what
+    we're testing, not the scaling math."""
+    return grad_input, grad_weight, grad_bias
+
+
+class TestPyLayerMultimaxFreeze(unittest.TestCase):
+    def setUp(self):
+        self._fwd_patch = mock.patch.object(
+            fused_module,
+            "fused_linear_cross_entropy_forward",
+            side_effect=_stub_forward,
+        )
+        self._bwd_patch = mock.patch.object(
+            fused_module,
+            "fused_linear_cross_entropy_backward",
+            side_effect=_stub_backward,
+        )
+        self._fwd_patch.start()
+        self._bwd_patch.start()
+        self.addCleanup(self._fwd_patch.stop)
+        self.addCleanup(self._bwd_patch.stop)
+
+    def _make_inputs(self, BT=4, H=8, V=16):
+        x = paddle.randn([BT, H], dtype="float32")
+        w = paddle.randn([V, H], dtype="float32")
+        target = paddle.randint(0, V, [BT])
+        ranges = paddle.to_tensor([0.0, 1.0, 0.0, 1.0])
+        ts = paddle.to_tensor([0.1, 0.1, 0.1, 0.1])
+        return x, w, target, ranges, ts
+
+    def test_both_multimax_trainable(self):
+        x, w, target, ranges, ts = self._make_inputs()
+        x.stop_gradient = False
+        w.stop_gradient = False
+        ranges.stop_gradient = False
+        ts.stop_gradient = False
+
+        loss = LigerFusedLinearCrossEntropyFunction.apply(
+            x, w, target, None, -100, "none", 1, False, ranges, ts
+        ).sum()
+        loss.backward()
+
+        self.assertIsNotNone(ranges.grad)
+        self.assertIsNotNone(ts.grad)
+
+    def test_only_ranges_frozen(self):
+        """multimax_ranges frozen, multimax_ts trainable: kernel emits both
+        grads (OR semantics), but backward must skip the frozen one."""
+        x, w, target, ranges, ts = self._make_inputs()
+        x.stop_gradient = False
+        w.stop_gradient = False
+        ranges.stop_gradient = True  # frozen
+        ts.stop_gradient = False
+
+        loss = LigerFusedLinearCrossEntropyFunction.apply(
+            x, w, target, None, -100, "none", 1, False, ranges, ts
+        ).sum()
+        loss.backward()
+
+        # Frozen param must not receive a grad.
+        self.assertIsNone(ranges.grad)
+        # Trainable param still gets its grad.
+        self.assertIsNotNone(ts.grad)
+
+    def test_only_ts_frozen(self):
+        x, w, target, ranges, ts = self._make_inputs()
+        x.stop_gradient = False
+        w.stop_gradient = False
+        ranges.stop_gradient = False
+        ts.stop_gradient = True  # frozen
+
+        loss = LigerFusedLinearCrossEntropyFunction.apply(
+            x, w, target, None, -100, "none", 1, False, ranges, ts
+        ).sum()
+        loss.backward()
+
+        self.assertIsNone(ts.grad)
+        self.assertIsNotNone(ranges.grad)
+
+    def test_both_frozen_no_main_grad_writes(self):
+        """Both multimax params frozen + ``main_grad`` attribute present:
+        backward must NOT touch ``main_grad`` for either param even though
+        the kernel produced grads."""
+        x, w, target, ranges, ts = self._make_inputs()
+        x.stop_gradient = False
+        w.stop_gradient = False
+        ranges.stop_gradient = True
+        ts.stop_gradient = True
+        # Pre-set main_grad to a sentinel; assert it stays untouched.
+        ranges.main_grad = paddle.full(ranges.shape, 99.0, dtype="float32")
+        ts.main_grad = paddle.full(ts.shape, 99.0, dtype="float32")
+        hook_fired = {"ranges": False, "ts": False}
+        ranges._apply_backward_hook = lambda: hook_fired.__setitem__(
+            "ranges", True
+        )
+        ts._apply_backward_hook = lambda: hook_fired.__setitem__("ts", True)
+
+        loss = LigerFusedLinearCrossEntropyFunction.apply(
+            x, w, target, None, -100, "none", 1, False, ranges, ts
+        ).sum()
+        loss.backward()
+
+        self.assertTrue(
+            paddle.all(ranges.main_grad == 99.0).item(),
+            "frozen multimax_ranges.main_grad was modified",
+        )
+        self.assertTrue(
+            paddle.all(ts.main_grad == 99.0).item(),
+            "frozen multimax_ts.main_grad was modified",
+        )
+        self.assertFalse(hook_fired["ranges"])
+        self.assertFalse(hook_fired["ts"])
+
+    def test_partial_freeze_with_main_grad(self):
+        """Only ts frozen, both have ``main_grad``. ranges' main_grad must
+        get accumulated; ts' main_grad must stay untouched."""
+        x, w, target, ranges, ts = self._make_inputs()
+        x.stop_gradient = False
+        w.stop_gradient = False
+        ranges.stop_gradient = False
+        ts.stop_gradient = True  # frozen
+        ranges.main_grad = paddle.zeros(ranges.shape, dtype="float32")
+        ts.main_grad = paddle.full(ts.shape, 99.0, dtype="float32")
+
+        loss = LigerFusedLinearCrossEntropyFunction.apply(
+            x, w, target, None, -100, "none", 1, False, ranges, ts
+        ).sum()
+        loss.backward()
+
+        # ranges' main_grad got the kernel-emitted 7.0 accumulated.
+        self.assertTrue(
+            paddle.all(ranges.main_grad == 7.0).item(),
+            f"ranges.main_grad expected 7.0, got "
+            f"{ranges.main_grad.numpy().tolist()}",
+        )
+        # ts' main_grad untouched (frozen).
+        self.assertTrue(
+            paddle.all(ts.main_grad == 99.0).item(),
+            "frozen ts.main_grad was modified",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/model/test_language_loss_multimax_routing.py
+++ b/tests/single_card_tests/model/test_language_loss_multimax_routing.py
@@ -1,0 +1,196 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU-runnable routing tests for the multimax fused-CE branch of
+``LanguageLoss.forward_impl``.
+
+These tests stub ``LigerFusedLinearCrossEntropyFunction.apply`` (the GPU/Triton
+fused kernel) to capture the forwarded arguments, so the routing logic can be
+exercised on CPU. They protect against regressions in:
+
+- 3-tuple emission (no multimax) still works and does NOT append extra args.
+- 5-tuple emission (multimax enabled) appends ``multimax_ranges`` /
+  ``multimax_ts`` in that order at positions 8 and 9.
+- The fused branch only fires when ``logits`` is a tuple; tensor inputs are
+  routed to the regular CE path (covered indirectly by other tests).
+"""
+
+import types
+import unittest
+from unittest import mock
+
+import paddle
+import paddlefleet_ops
+
+# sonicmoe ecosystem op is not always loadable in CI envs; the multimax
+# feature does not depend on it, so neutralize the gating before importing
+# anything that pulls paddlefleet.models.
+paddlefleet_ops.is_sonic_moe_available = lambda: False
+
+
+def _capturing_apply():
+    """Return a mock for LigerFusedLinearCrossEntropyFunction.apply that:
+    - records the forwarded *args in ``calls`` for inspection,
+    - returns a deterministic [BT] float32 tensor of zeros so the caller's
+      reshape/lossmask logic still runs end-to-end.
+    """
+    calls = []
+
+    def _apply(*args):
+        calls.append(args)
+        # args[0] is _input shape [BT, H]; return [BT] zeros.
+        bt = args[0].shape[0]
+        return paddle.zeros([bt], dtype=paddle.float32)
+
+    return calls, _apply
+
+
+class _StubLanguageLoss:
+    """Minimal stand-in exposing only the attributes ``forward_impl`` reads.
+
+    Constructing the real ``LanguageLoss`` requires fleet init + parallel
+    state; we don't need any of that to test the multimax routing branch,
+    which only depends on a few config flags. We bind ``forward_impl`` as
+    an unbound method to keep the production code path under test.
+    """
+
+    def __init__(self, fused_chunk=1, parallel_ce=False, ignored_index=-100):
+        self.config = types.SimpleNamespace(
+            fused_linear_ce_loss_chunk=fused_chunk,
+            gpt_model_use_experimental_version=False,
+            cp_balance_mode="default",
+        )
+        self.enable_parallel_cross_entropy = parallel_ce
+        self.ignored_index = ignored_index
+
+
+class TestLanguageLossMultimaxRouting(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Import here so the sonicmoe gate above is in effect first.
+        from paddlefleet.models.common.language_loss.language_loss import (
+            LanguageLoss,
+        )
+
+        cls.LanguageLoss = LanguageLoss
+
+    def _make_inputs(self, B=2, S=4, H=8):
+        hidden = paddle.randn([B, S, H], dtype="float32")
+        # weight is [V, H]; vocab size doesn't matter for routing.
+        V = 16
+        weight = paddle.randn([V, H], dtype="float32")
+        bias = None
+        labels = paddle.randint(0, V, [B, S], dtype="int64")
+        return hidden, weight, bias, labels, B, S
+
+    def _patch_target(self):
+        # Patch the symbol where it is *imported* (inside forward_impl, the
+        # function is imported lazily from paddlefleet.triton_ops.fused_...).
+        return mock.patch(
+            "paddlefleet.triton_ops.fused_linear_cross_entropy."
+            "LigerFusedLinearCrossEntropyFunction.apply",
+            autospec=False,
+        )
+
+    def _bypass_cp_gather(self):
+        # On a single-card CPU run there is no context-parallel group; the
+        # call to ``get_context_parallel_world_size`` returns 1 anyway, so
+        # the gather branch is naturally skipped. We patch it to be safe in
+        # case the import path differs at module load time.
+        return mock.patch(
+            "paddlefleet.models.common.language_loss.language_loss."
+            "get_context_parallel_world_size",
+            return_value=1,
+        )
+
+    def test_3tuple_routes_without_multimax_args(self):
+        """3-tuple input: apply() must be called with 8 positional args; no
+        multimax tensors appended."""
+        hidden, weight, bias, labels, B, S = self._make_inputs()
+        stub = _StubLanguageLoss(fused_chunk=1)
+        calls, capture = _capturing_apply()
+
+        with self._patch_target() as p, self._bypass_cp_gather():
+            p.side_effect = capture
+            loss = self.LanguageLoss.forward_impl(
+                stub, (hidden, weight, bias), labels
+            )
+
+        self.assertEqual(len(calls), 1, "apply must be called exactly once")
+        forwarded = calls[0]
+        # Expected positional layout (see fused_linear_cross_entropy.py):
+        # 0:_input 1:weight 2:target 3:bias 4:ignore_index 5:reduction
+        # 6:num_chunks 7:ec_align  (8/9 only when multimax)
+        self.assertEqual(
+            len(forwarded),
+            8,
+            f"expected 8 args without multimax, got {len(forwarded)}",
+        )
+        self.assertEqual(forwarded[3], None, "bias must be forwarded as None")
+        self.assertEqual(
+            forwarded[4], stub.ignored_index, "ignore_index mismatch"
+        )
+        self.assertEqual(forwarded[5], "none", "reduction must be 'none'")
+        self.assertEqual(
+            forwarded[6],
+            stub.config.fused_linear_ce_loss_chunk,
+            "num_chunks mismatch",
+        )
+        self.assertIsInstance(loss, paddle.Tensor)
+
+    def test_5tuple_routes_with_multimax_args(self):
+        """5-tuple input: apply() must receive 10 positional args, with
+        multimax_ranges at index 8 and multimax_ts at index 9."""
+        hidden, weight, bias, labels, B, S = self._make_inputs()
+        ranges = paddle.zeros([4], dtype="float32")
+        ts = paddle.zeros([4], dtype="float32")
+
+        stub = _StubLanguageLoss(fused_chunk=2)
+        calls, capture = _capturing_apply()
+
+        with self._patch_target() as p, self._bypass_cp_gather():
+            p.side_effect = capture
+            self.LanguageLoss.forward_impl(
+                stub, (hidden, weight, bias, ranges, ts), labels
+            )
+
+        self.assertEqual(len(calls), 1)
+        forwarded = calls[0]
+        self.assertEqual(
+            len(forwarded),
+            10,
+            f"expected 10 args with multimax, got {len(forwarded)}",
+        )
+        # Identity by `is` to confirm exactly the same tensors are forwarded
+        # (no implicit copy/cast in the routing layer).
+        self.assertIs(forwarded[8], ranges, "multimax_ranges position wrong")
+        self.assertIs(forwarded[9], ts, "multimax_ts position wrong")
+        self.assertEqual(
+            forwarded[6],
+            stub.config.fused_linear_ce_loss_chunk,
+            "num_chunks mismatch",
+        )
+
+    def test_parallel_ce_with_tuple_logits_asserts(self):
+        """Tensor-parallel parallel_output=True is incompatible with the
+        fused tuple path; LanguageLoss must assert rather than silently
+        producing wrong gradients."""
+        hidden, weight, bias, labels, _B, _S = self._make_inputs()
+        stub = _StubLanguageLoss(fused_chunk=1, parallel_ce=True)
+        with self.assertRaises(AssertionError):
+            self.LanguageLoss.forward_impl(stub, (hidden, weight, bias), labels)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/model/test_lm_head_multimax.py
+++ b/tests/single_card_tests/model/test_lm_head_multimax.py
@@ -1,0 +1,204 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for GPTLMHead with multimax feature."""
+
+import functools
+import random
+import unittest
+
+import numpy as np
+import paddle
+import paddlefleet_ops
+from paddle.distributed import fleet
+
+# sonicmoe ecosystem op is not always loadable in CI envs; the multimax
+# feature does not depend on it, so neutralize the gating before importing
+# anything from paddlefleet.models.
+paddlefleet_ops.is_sonic_moe_available = lambda: False
+
+import paddlefleet.parallel_state as ps
+from paddlefleet.gpt_builders import gpt_builder
+from paddlefleet.models.gpt import GPTConfig
+
+
+class TestMultimaxLMHead(unittest.TestCase):
+    """Tests for GPTLMHead multimax initialization and forward paths."""
+
+    @classmethod
+    def setUpClass(cls):
+        seed = 48
+        random.seed(seed)
+        np.random.seed(seed)
+        paddle.seed(seed)
+        strategy = fleet.DistributedStrategy()
+        strategy.hybrid_configs = {
+            "dp_degree": 1,
+            "mp_degree": 1,
+            "pp_degree": 1,
+            "sharding_degree": 1,
+            "sep_degree": 1,
+            "cp_degree": 1,
+            "ep_degree": 1,
+            "moe_sharding_degree": 1,
+            "order": [
+                "sharding",
+                "moe_sharding",
+                "pp",
+                "sep",
+                "cp",
+                "dp",
+                "ep",
+                "mp",
+            ],
+        }
+        fleet.init(is_collective=True, strategy=strategy)
+        hcg = fleet.get_hybrid_communicate_group()
+        ps.initialize_model_parallel(hcg)
+        cls.strategy = strategy
+
+        # Config with multimax=lm_head
+        cls.config_multimax = GPTConfig(
+            num_hidden_layers=2,
+            hidden_size=256,
+            vocab_size=64,
+            max_sequence_length=32,
+            num_attention_heads=4,
+            intermediate_size=512,
+            normalization="RMSNorm",
+            hidden_dropout_prob=0.0,
+            attention_dropout=0.0,
+            use_bias=False,
+            rotary_percent=1.0,
+            rotary_base=10000,
+            rope_scaling=1.0,
+            init_method=functools.partial(
+                paddle.nn.init.xavier_uniform_, gain=1.0
+            ),
+            output_layer_init_method=functools.partial(
+                paddle.nn.init.xavier_uniform_, gain=1.0
+            ),
+            tie_word_embeddings=True,
+            multimax="lm_head",
+        )
+        cls.model_multimax = gpt_builder(cls.config_multimax, num_stages=1)
+
+        # Config without multimax
+        cls.config_no_multimax = GPTConfig(
+            num_hidden_layers=2,
+            hidden_size=256,
+            vocab_size=64,
+            max_sequence_length=32,
+            num_attention_heads=4,
+            intermediate_size=512,
+            normalization="RMSNorm",
+            hidden_dropout_prob=0.0,
+            attention_dropout=0.0,
+            use_bias=False,
+            rotary_percent=1.0,
+            rotary_base=10000,
+            rope_scaling=1.0,
+            init_method=functools.partial(
+                paddle.nn.init.xavier_uniform_, gain=1.0
+            ),
+            output_layer_init_method=functools.partial(
+                paddle.nn.init.xavier_uniform_, gain=1.0
+            ),
+            tie_word_embeddings=True,
+            multimax=None,
+        )
+        cls.model_no_multimax = gpt_builder(
+            cls.config_no_multimax, num_stages=1
+        )
+
+        # Config with multimax + fused path
+        cls.config_fused = GPTConfig(
+            num_hidden_layers=2,
+            hidden_size=256,
+            vocab_size=64,
+            max_sequence_length=32,
+            num_attention_heads=4,
+            intermediate_size=512,
+            normalization="RMSNorm",
+            hidden_dropout_prob=0.0,
+            attention_dropout=0.0,
+            use_bias=False,
+            rotary_percent=1.0,
+            rotary_base=10000,
+            rope_scaling=1.0,
+            init_method=functools.partial(
+                paddle.nn.init.xavier_uniform_, gain=1.0
+            ),
+            output_layer_init_method=functools.partial(
+                paddle.nn.init.xavier_uniform_, gain=1.0
+            ),
+            tie_word_embeddings=True,
+            multimax="lm_head",
+            fused_linear_ce_loss_chunk=1,
+        )
+        cls.model_fused = gpt_builder(cls.config_fused, num_stages=1)
+
+    def _find_lm_head(self, model):
+        from paddlefleet.models.gpt.lm_head import GPTLMHead
+
+        for layer in model.run_function:
+            if isinstance(layer, GPTLMHead):
+                return layer
+        return None
+
+    def test_multimax_lmhead_creates_params(self):
+        """When multimax=lm_head, GPTLMHead should create multimax_ranges/ts params."""
+        lm_head = self._find_lm_head(self.model_multimax)
+        self.assertIsNotNone(lm_head)
+        self.assertTrue(hasattr(lm_head, "use_multimax_lmhead"))
+        self.assertTrue(lm_head.use_multimax_lmhead)
+        self.assertTrue(hasattr(lm_head, "multimax_ranges"))
+        self.assertTrue(hasattr(lm_head, "multimax_ts"))
+        self.assertEqual(lm_head.multimax_ranges.shape, [4])
+        self.assertEqual(lm_head.multimax_ts.shape, [4])
+
+    def test_no_multimax_lmhead_no_params(self):
+        """When multimax=None, GPTLMHead should NOT create multimax params."""
+        lm_head = self._find_lm_head(self.model_no_multimax)
+        self.assertIsNotNone(lm_head)
+        self.assertFalse(getattr(lm_head, "use_multimax_lmhead", False))
+        self.assertFalse(hasattr(lm_head, "multimax_ranges"))
+        self.assertFalse(hasattr(lm_head, "multimax_ts"))
+
+    def test_multimax_params_init_zero(self):
+        """multimax params should init to zero (SeLU is identity at step 0)."""
+        lm_head = self._find_lm_head(self.model_multimax)
+        zeros = paddle.zeros_like(lm_head.multimax_ranges)
+        self.assertTrue(paddle.allclose(lm_head.multimax_ranges, zeros).item())
+        self.assertTrue(paddle.allclose(lm_head.multimax_ts, zeros).item())
+
+    def test_fused_path_returns_5tuple(self):
+        """With fused_linear_ce_loss_chunk>0 and multimax, forward returns 5-tuple."""
+        lm_head = self._find_lm_head(self.model_fused)
+        self.assertIsNotNone(lm_head)
+
+        # Create dummy input
+        batch_size, seq_len, hidden_size = 2, 8, 256
+        hidden_states = paddle.randn([seq_len, batch_size, hidden_size])
+
+        # Call forward with dict args (expected signature)
+        output = lm_head.forward({"hidden_states": hidden_states})
+
+        # Should return 5-tuple: (hidden, weight, bias, multimax_ranges, multimax_ts)
+        self.assertIsInstance(output, tuple)
+        self.assertEqual(len(output), 5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/model/test_lm_head_multimax.py
+++ b/tests/single_card_tests/model/test_lm_head_multimax.py
@@ -200,5 +200,169 @@ class TestMultimaxLMHead(unittest.TestCase):
         self.assertEqual(len(output), 5)
 
 
+@unittest.skipUnless(
+    paddle.is_compiled_with_cuda(), "fused multimax CE kernel requires CUDA"
+)
+class TestFusedMultimaxNumerical(unittest.TestCase):
+    """Numerical + backward parity for the fused multimax CE kernel.
+
+    Compares `LigerFusedLinearCrossEntropyFunction` (multimax branch) against
+    a Python reference: F.linear -> SeLU -> cross_entropy, including a sample
+    masked by `ignore_index`. Verifies loss and grads on all four trainable
+    inputs: `_input`, `weight`, `multimax_ranges`, `multimax_ts`.
+    """
+
+    def _selu(self, x, ranges, ts):
+        """Python ref SeLU matching the Triton kernel formula."""
+        r0, r1, r2, r3 = [ranges[i] for i in range(4)]
+        t0, t1, t2, t3 = [ts[i] for i in range(4)]
+        m0 = paddle.nn.functional.relu(r0 - x)
+        m1 = paddle.nn.functional.relu(x - r1)
+        m2 = paddle.nn.functional.relu(r2 - x)
+        m3 = paddle.nn.functional.relu(x - r3)
+        return x + t0 * m0 + t1 * m1 + t2 * m2 * m2 + t3 * m3 * m3
+
+    def _make_inputs(self, BT=6, H=8, V=12, ignore_index=-100):
+        paddle.seed(123)
+        x = paddle.randn([BT, H], dtype="float32")
+        w = paddle.randn([V, H], dtype="float32") * 0.1
+        targets = paddle.to_tensor(
+            [0, 3, 5, ignore_index, 7, 1], dtype="int64"
+        )
+        # Non-zero multimax params so SeLU is non-trivial.
+        ranges = paddle.to_tensor(
+            [0.5, -0.5, 0.2, -0.2], dtype="float32"
+        )
+        ts = paddle.to_tensor([0.3, 0.4, 0.1, 0.2], dtype="float32")
+        return x, w, targets, ranges, ts, ignore_index
+
+    def _run_reference(self, x, w, targets, ranges, ts, ignore_index):
+        x_ref = x.detach().clone()
+        x_ref.stop_gradient = False
+        w_ref = w.detach().clone()
+        w_ref.stop_gradient = False
+        r_ref = ranges.detach().clone()
+        r_ref.stop_gradient = False
+        t_ref = ts.detach().clone()
+        t_ref.stop_gradient = False
+
+        logits = paddle.nn.functional.linear(x_ref, w_ref.T)
+        modulated = self._selu(logits, r_ref, t_ref)
+        loss = paddle.nn.functional.cross_entropy(
+            modulated,
+            targets,
+            ignore_index=ignore_index,
+            reduction="sum",
+        )
+        loss.backward()
+        return loss, x_ref.grad, w_ref.grad, r_ref.grad, t_ref.grad
+
+    def _run_fused(self, x, w, targets, ranges, ts, ignore_index):
+        from paddlefleet.triton_ops.fused_linear_cross_entropy import (
+            LigerFusedLinearCrossEntropyFunction,
+        )
+
+        x_f = x.detach().clone()
+        x_f.stop_gradient = False
+        w_f = w.detach().clone()
+        w_f.stop_gradient = False
+        r_f = ranges.detach().clone()
+        r_f.stop_gradient = False
+        t_f = ts.detach().clone()
+        t_f.stop_gradient = False
+
+        loss_1d = LigerFusedLinearCrossEntropyFunction.apply(
+            x_f,
+            w_f,
+            targets,
+            None,  # bias
+            ignore_index,
+            "none",
+            1,  # num_chunks
+            False,  # ec_align
+            r_f,
+            t_f,
+        )
+        loss = loss_1d.sum()
+        loss.backward()
+        return loss, x_f.grad, w_f.grad, r_f.grad, t_f.grad
+
+    def test_fused_multimax_matches_reference(self):
+        x, w, targets, ranges, ts, ig = self._make_inputs()
+
+        loss_ref, gx_ref, gw_ref, gr_ref, gt_ref = self._run_reference(
+            x, w, targets, ranges, ts, ig
+        )
+        loss_fused, gx_f, gw_f, gr_f, gt_f = self._run_fused(
+            x, w, targets, ranges, ts, ig
+        )
+
+        # Loss (reduction='sum' on ref vs sum-of-1d on fused).
+        self.assertTrue(
+            paddle.allclose(loss_ref, loss_fused, atol=1e-3, rtol=1e-3).item(),
+            f"loss mismatch: ref={loss_ref.item()} fused={loss_fused.item()}",
+        )
+        # Input grad.
+        self.assertTrue(
+            paddle.allclose(gx_ref, gx_f, atol=1e-3, rtol=1e-3).item(),
+            f"grad_input mismatch (max abs diff="
+            f"{(gx_ref - gx_f).abs().max().item()})",
+        )
+        # multimax_ranges grad.
+        self.assertTrue(
+            paddle.allclose(gr_ref, gr_f, atol=1e-3, rtol=1e-3).item(),
+            f"grad_ranges mismatch: ref={gr_ref.numpy().tolist()} "
+            f"fused={gr_f.numpy().tolist()}",
+        )
+        # multimax_ts grad.
+        self.assertTrue(
+            paddle.allclose(gt_ref, gt_f, atol=1e-3, rtol=1e-3).item(),
+            f"grad_ts mismatch: ref={gt_ref.numpy().tolist()} "
+            f"fused={gt_f.numpy().tolist()}",
+        )
+
+    def test_fused_multimax_grads_when_input_frozen(self):
+        """Freeze backbone (input.stop_gradient=True) but keep multimax
+        params trainable: kernel must still emit non-zero grad_ranges/ts.
+        Regression for the prior `HAS_GRADIENTS=input_requires_grad` bug
+        that gated multimax param grads on the input grad.
+        """
+        from paddlefleet.triton_ops.fused_linear_cross_entropy import (
+            LigerFusedLinearCrossEntropyFunction,
+        )
+
+        x, w, targets, ranges, ts, ig = self._make_inputs()
+        x_f = x.detach().clone()
+        x_f.stop_gradient = True  # frozen backbone
+        w_f = w.detach().clone()
+        w_f.stop_gradient = True  # also freeze weight (head-only training)
+        r_f = ranges.detach().clone()
+        r_f.stop_gradient = False
+        t_f = ts.detach().clone()
+        t_f.stop_gradient = False
+
+        loss = LigerFusedLinearCrossEntropyFunction.apply(
+            x_f, w_f, targets, None, ig, "none", 1, False, r_f, t_f
+        ).sum()
+        loss.backward()
+
+        # Reference grads (from the full-grad path, then ignore x/w).
+        _, _, _, gr_ref, gt_ref = self._run_reference(
+            x, w, targets, ranges, ts, ig
+        )
+        self.assertIsNotNone(r_f.grad, "multimax_ranges.grad is None when frozen")
+        self.assertIsNotNone(t_f.grad, "multimax_ts.grad is None when frozen")
+        self.assertTrue(
+            paddle.allclose(gr_ref, r_f.grad, atol=1e-3, rtol=1e-3).item(),
+            f"frozen-input grad_ranges mismatch: ref={gr_ref.numpy().tolist()} "
+            f"got={r_f.grad.numpy().tolist()}",
+        )
+        self.assertTrue(
+            paddle.allclose(gt_ref, t_f.grad, atol=1e-3, rtol=1e-3).item(),
+            f"frozen-input grad_ts mismatch: ref={gt_ref.numpy().tolist()} "
+            f"got={t_f.grad.numpy().tolist()}",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/single_card_tests/model/test_lm_head_multimax.py
+++ b/tests/single_card_tests/model/test_lm_head_multimax.py
@@ -226,13 +226,9 @@ class TestFusedMultimaxNumerical(unittest.TestCase):
         paddle.seed(123)
         x = paddle.randn([BT, H], dtype="float32")
         w = paddle.randn([V, H], dtype="float32") * 0.1
-        targets = paddle.to_tensor(
-            [0, 3, 5, ignore_index, 7, 1], dtype="int64"
-        )
+        targets = paddle.to_tensor([0, 3, 5, ignore_index, 7, 1], dtype="int64")
         # Non-zero multimax params so SeLU is non-trivial.
-        ranges = paddle.to_tensor(
-            [0.5, -0.5, 0.2, -0.2], dtype="float32"
-        )
+        ranges = paddle.to_tensor([0.5, -0.5, 0.2, -0.2], dtype="float32")
         ts = paddle.to_tensor([0.3, 0.4, 0.1, 0.2], dtype="float32")
         return x, w, targets, ranges, ts, ignore_index
 
@@ -350,7 +346,9 @@ class TestFusedMultimaxNumerical(unittest.TestCase):
         _, _, _, gr_ref, gt_ref = self._run_reference(
             x, w, targets, ranges, ts, ig
         )
-        self.assertIsNotNone(r_f.grad, "multimax_ranges.grad is None when frozen")
+        self.assertIsNotNone(
+            r_f.grad, "multimax_ranges.grad is None when frozen"
+        )
         self.assertIsNotNone(t_f.grad, "multimax_ts.grad is None when frozen")
         self.assertTrue(
             paddle.allclose(gr_ref, r_f.grad, atol=1e-3, rtol=1e-3).item(),

--- a/tests/single_card_tests/model/test_lm_head_multimax.py
+++ b/tests/single_card_tests/model/test_lm_head_multimax.py
@@ -68,7 +68,7 @@ class TestMultimaxLMHead(unittest.TestCase):
         ps.initialize_model_parallel(hcg)
         cls.strategy = strategy
 
-        # Config with multimax=lm_head
+        # Config with apply_multimax=[lm_head]
         cls.config_multimax = GPTConfig(
             num_hidden_layers=2,
             hidden_size=256,
@@ -90,7 +90,7 @@ class TestMultimaxLMHead(unittest.TestCase):
                 paddle.nn.init.xavier_uniform_, gain=1.0
             ),
             tie_word_embeddings=True,
-            multimax="lm_head",
+            apply_multimax=["lm_head"],
         )
         cls.model_multimax = gpt_builder(cls.config_multimax, num_stages=1)
 
@@ -116,7 +116,7 @@ class TestMultimaxLMHead(unittest.TestCase):
                 paddle.nn.init.xavier_uniform_, gain=1.0
             ),
             tie_word_embeddings=True,
-            multimax=None,
+            apply_multimax=None,
         )
         cls.model_no_multimax = gpt_builder(
             cls.config_no_multimax, num_stages=1
@@ -144,7 +144,7 @@ class TestMultimaxLMHead(unittest.TestCase):
                 paddle.nn.init.xavier_uniform_, gain=1.0
             ),
             tie_word_embeddings=True,
-            multimax="lm_head",
+            apply_multimax=["lm_head"],
             fused_linear_ce_loss_chunk=1,
         )
         cls.model_fused = gpt_builder(cls.config_fused, num_stages=1)
@@ -158,7 +158,7 @@ class TestMultimaxLMHead(unittest.TestCase):
         return None
 
     def test_multimax_lmhead_creates_params(self):
-        """When multimax=lm_head, GPTLMHead should create multimax_ranges/ts params."""
+        """When apply_multimax=[lm_head], GPTLMHead should create multimax_ranges/ts params."""
         lm_head = self._find_lm_head(self.model_multimax)
         self.assertIsNotNone(lm_head)
         self.assertTrue(hasattr(lm_head, "use_multimax_lmhead"))
@@ -169,7 +169,7 @@ class TestMultimaxLMHead(unittest.TestCase):
         self.assertEqual(lm_head.multimax_ts.shape, [4])
 
     def test_no_multimax_lmhead_no_params(self):
-        """When multimax=None, GPTLMHead should NOT create multimax params."""
+        """When apply_multimax=None, GPTLMHead should NOT create multimax params."""
         lm_head = self._find_lm_head(self.model_no_multimax)
         self.assertIsNotNone(lm_head)
         self.assertFalse(getattr(lm_head, "use_multimax_lmhead", False))
@@ -184,7 +184,7 @@ class TestMultimaxLMHead(unittest.TestCase):
         self.assertTrue(paddle.allclose(lm_head.multimax_ts, zeros).item())
 
     def test_fused_path_returns_5tuple(self):
-        """With fused_linear_ce_loss_chunk>0 and multimax, forward returns 5-tuple.
+        """With fused_linear_ce_loss_chunk>0 and apply_multimax, forward returns 5-tuple.
         Also exercises the rank-0 [MULTIMAX-LMHEAD-APPLIED] one-shot warn banner
         at the top of the fused branch.
         """
@@ -208,7 +208,7 @@ class TestMultimaxLMHead(unittest.TestCase):
         self.assertTrue(getattr(lm_head, "_multimax_applied_logged", False))
 
     def test_unfused_path_applies_selu_and_logs(self):
-        """With multimax + fused_linear_ce_loss_chunk=0 (default), forward
+        """With apply_multimax + fused_linear_ce_loss_chunk=0 (default), forward
         returns logits (not a tuple) and applies SeLU via recompute.
         Exercises the unfused-path warn block + SeLU recompute branch.
         """

--- a/tests/single_card_tests/model/test_lm_head_multimax.py
+++ b/tests/single_card_tests/model/test_lm_head_multimax.py
@@ -409,6 +409,75 @@ class TestFusedMultimaxNumerical(unittest.TestCase):
             paddle.allclose(gt_ref, t_f.grad, atol=1e-3, rtol=1e-3).item()
         )
 
+    def test_fused_multimax_partial_freeze_respects_per_param_stop_gradient(
+        self,
+    ):
+        """Freeze only one of multimax_ranges/multimax_ts; the other stays
+        trainable. The kernel emits both grads (multimax_requires_grad is the
+        OR of the two), but the backward must respect each param's individual
+        stop_gradient: the frozen param must NOT receive a grad (its .grad
+        stays None and main_grad is untouched), while the trainable param
+        gets the correct grad.
+
+        Regression for: backward loop only checked `param is None or g is
+        None` and silently wrote grads to frozen multimax params.
+        """
+        from paddlefleet.triton_ops.fused_linear_cross_entropy import (
+            LigerFusedLinearCrossEntropyFunction,
+        )
+
+        # Case A: freeze multimax_ranges, keep multimax_ts trainable.
+        x, w, targets, ranges, ts, ig = self._make_inputs()
+        x_f = x.detach().clone()
+        x_f.stop_gradient = False
+        w_f = w.detach().clone()
+        w_f.stop_gradient = False
+        r_f = ranges.detach().clone()
+        r_f.stop_gradient = True  # frozen
+        t_f = ts.detach().clone()
+        t_f.stop_gradient = False
+
+        loss = LigerFusedLinearCrossEntropyFunction.apply(
+            x_f, w_f, targets, None, ig, "none", 1, False, r_f, t_f
+        ).sum()
+        loss.backward()
+
+        _, _, _, _, gt_ref = self._run_reference(x, w, targets, ranges, ts, ig)
+        self.assertIsNone(
+            r_f.grad,
+            "frozen multimax_ranges received a grad despite stop_gradient=True",
+        )
+        self.assertIsNotNone(t_f.grad)
+        self.assertTrue(
+            paddle.allclose(gt_ref, t_f.grad, atol=1e-3, rtol=1e-3).item()
+        )
+
+        # Case B: freeze multimax_ts, keep multimax_ranges trainable.
+        x, w, targets, ranges, ts, ig = self._make_inputs()
+        x_f = x.detach().clone()
+        x_f.stop_gradient = False
+        w_f = w.detach().clone()
+        w_f.stop_gradient = False
+        r_f = ranges.detach().clone()
+        r_f.stop_gradient = False
+        t_f = ts.detach().clone()
+        t_f.stop_gradient = True  # frozen
+
+        loss = LigerFusedLinearCrossEntropyFunction.apply(
+            x_f, w_f, targets, None, ig, "none", 1, False, r_f, t_f
+        ).sum()
+        loss.backward()
+
+        _, _, _, gr_ref, _ = self._run_reference(x, w, targets, ranges, ts, ig)
+        self.assertIsNone(
+            t_f.grad,
+            "frozen multimax_ts received a grad despite stop_gradient=True",
+        )
+        self.assertIsNotNone(r_f.grad)
+        self.assertTrue(
+            paddle.allclose(gr_ref, r_f.grad, atol=1e-3, rtol=1e-3).item()
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/single_card_tests/model/test_lm_head_multimax.py
+++ b/tests/single_card_tests/model/test_lm_head_multimax.py
@@ -184,9 +184,15 @@ class TestMultimaxLMHead(unittest.TestCase):
         self.assertTrue(paddle.allclose(lm_head.multimax_ts, zeros).item())
 
     def test_fused_path_returns_5tuple(self):
-        """With fused_linear_ce_loss_chunk>0 and multimax, forward returns 5-tuple."""
+        """With fused_linear_ce_loss_chunk>0 and multimax, forward returns 5-tuple.
+        Also exercises the rank-0 [MULTIMAX-LMHEAD-APPLIED] one-shot warn banner
+        at the top of the fused branch.
+        """
         lm_head = self._find_lm_head(self.model_fused)
         self.assertIsNotNone(lm_head)
+        # Reset the one-shot flag so the warn block executes.
+        if hasattr(lm_head, "_multimax_applied_logged"):
+            delattr(lm_head, "_multimax_applied_logged")
 
         # Create dummy input
         batch_size, seq_len, hidden_size = 2, 8, 256
@@ -198,6 +204,75 @@ class TestMultimaxLMHead(unittest.TestCase):
         # Should return 5-tuple: (hidden, weight, bias, multimax_ranges, multimax_ts)
         self.assertIsInstance(output, tuple)
         self.assertEqual(len(output), 5)
+        # The one-shot flag must be set after first call.
+        self.assertTrue(getattr(lm_head, "_multimax_applied_logged", False))
+
+    def test_unfused_path_applies_selu_and_logs(self):
+        """With multimax + fused_linear_ce_loss_chunk=0 (default), forward
+        returns logits (not a tuple) and applies SeLU via recompute.
+        Exercises the unfused-path warn block + SeLU recompute branch.
+        """
+        lm_head = self._find_lm_head(self.model_multimax)
+        self.assertIsNotNone(lm_head)
+        # Reset the one-shot flag so the warn block executes.
+        if hasattr(lm_head, "_multimax_applied_logged"):
+            delattr(lm_head, "_multimax_applied_logged")
+
+        batch_size, seq_len, hidden_size = 2, 8, 256
+        hidden_states = paddle.randn([seq_len, batch_size, hidden_size])
+
+        output = lm_head.forward({"hidden_states": hidden_states})
+        # Unfused path returns logits Tensor, not a tuple.
+        self.assertIsInstance(output, paddle.Tensor)
+        # Logits shape: [B, S, V] (transposed from [S, B, V] by sequence_parallel
+        # when enabled, otherwise produced directly).
+        self.assertEqual(output.shape[-1], self.config_multimax.vocab_size)
+        self.assertTrue(getattr(lm_head, "_multimax_applied_logged", False))
+
+    def test_sharded_state_dict_with_multimax(self):
+        """sharded_state_dict on multimax lm_head should list multimax_ranges
+        and multimax_ts as replicated (shard axis None) when world_size > 1.
+        We patch `build_sharded_state_dict` to capture the shard_rules dict
+        so we can directly assert the multimax branch's contents without
+        depending on the flex-checkpoint backend.
+        """
+        from unittest import mock
+
+        from paddlefleet.models.gpt import lm_head as lm_head_mod
+
+        lm_head = self._find_lm_head(self.model_multimax)
+        self.assertIsNotNone(lm_head)
+
+        captured = {}
+
+        def fake_build(state_dict, shard_rules, prefix):
+            captured["shard_rules"] = shard_rules
+            captured["prefix"] = prefix
+            return {"state_dict": state_dict, "shard_rules": shard_rules}
+
+        # world_size==1 branch: shard_rules is None.
+        with mock.patch.object(
+            lm_head_mod, "build_sharded_state_dict", side_effect=fake_build
+        ):
+            lm_head.sharded_state_dict()
+        self.assertIsNone(captured["shard_rules"])
+
+        # Force world_size>1 to exercise the multi-rank multimax shard-rules.
+        captured.clear()
+        with (
+            mock.patch.object(lm_head, "world_size", 2),
+            mock.patch.object(
+                lm_head_mod, "build_sharded_state_dict", side_effect=fake_build
+            ),
+        ):
+            lm_head.sharded_state_dict()
+        rules = captured["shard_rules"]
+        self.assertEqual(rules.get("weight"), 0)
+        self.assertEqual(rules.get("bias"), 0)
+        self.assertIn("multimax_ranges", rules)
+        self.assertIn("multimax_ts", rules)
+        self.assertIsNone(rules["multimax_ranges"])
+        self.assertIsNone(rules["multimax_ts"])
 
 
 @unittest.skipUnless(

--- a/tests/single_card_tests/model/test_lm_head_multimax.py
+++ b/tests/single_card_tests/model/test_lm_head_multimax.py
@@ -177,7 +177,7 @@ class TestMultimaxLMHead(unittest.TestCase):
         self.assertFalse(hasattr(lm_head, "multimax_ts"))
 
     def test_multimax_params_init_zero(self):
-        """multimax params should init to zero (SeLU is identity at step 0)."""
+        """multimax params should init to zero (SegLU is identity at step 0)."""
         lm_head = self._find_lm_head(self.model_multimax)
         zeros = paddle.zeros_like(lm_head.multimax_ranges)
         self.assertTrue(paddle.allclose(lm_head.multimax_ranges, zeros).item())
@@ -207,10 +207,10 @@ class TestMultimaxLMHead(unittest.TestCase):
         # The one-shot flag must be set after first call.
         self.assertTrue(getattr(lm_head, "_multimax_applied_logged", False))
 
-    def test_unfused_path_applies_selu_and_logs(self):
+    def test_unfused_path_applies_seglu_and_logs(self):
         """With apply_multimax + fused_linear_ce_loss_chunk=0 (default), forward
-        returns logits (not a tuple) and applies SeLU via recompute.
-        Exercises the unfused-path warn block + SeLU recompute branch.
+        returns logits (not a tuple) and applies SegLU via recompute.
+        Exercises the unfused-path warn block + SegLU recompute branch.
         """
         lm_head = self._find_lm_head(self.model_multimax)
         self.assertIsNotNone(lm_head)
@@ -230,11 +230,12 @@ class TestMultimaxLMHead(unittest.TestCase):
         self.assertTrue(getattr(lm_head, "_multimax_applied_logged", False))
 
     def test_sharded_state_dict_with_multimax(self):
-        """sharded_state_dict on multimax lm_head should list multimax_ranges
-        and multimax_ts as replicated (shard axis None) when world_size > 1.
+        """sharded_state_dict on multimax lm_head: non-sharded params (the
+        multimax scalars) are intentionally absent from shard_rules — only
+        the sharded weight/bias appear when world_size > 1.
         We patch `build_sharded_state_dict` to capture the shard_rules dict
-        so we can directly assert the multimax branch's contents without
-        depending on the flex-checkpoint backend.
+        so we can assert directly without depending on the flex-checkpoint
+        backend.
         """
         from unittest import mock
 
@@ -257,7 +258,7 @@ class TestMultimaxLMHead(unittest.TestCase):
             lm_head.sharded_state_dict()
         self.assertIsNone(captured["shard_rules"])
 
-        # Force world_size>1 to exercise the multi-rank multimax shard-rules.
+        # Force world_size>1: only weight/bias appear in shard_rules.
         captured.clear()
         with (
             mock.patch.object(lm_head, "world_size", 2),
@@ -269,10 +270,8 @@ class TestMultimaxLMHead(unittest.TestCase):
         rules = captured["shard_rules"]
         self.assertEqual(rules.get("weight"), 0)
         self.assertEqual(rules.get("bias"), 0)
-        self.assertIn("multimax_ranges", rules)
-        self.assertIn("multimax_ts", rules)
-        self.assertIsNone(rules["multimax_ranges"])
-        self.assertIsNone(rules["multimax_ts"])
+        self.assertNotIn("multimax_ranges", rules)
+        self.assertNotIn("multimax_ts", rules)
 
 
 @unittest.skipUnless(
@@ -282,13 +281,13 @@ class TestFusedMultimaxNumerical(unittest.TestCase):
     """Numerical + backward parity for the fused multimax CE kernel.
 
     Compares `LigerFusedLinearCrossEntropyFunction` (multimax branch) against
-    a Python reference: F.linear -> SeLU -> cross_entropy, including a sample
+    a Python reference: F.linear -> SegLU -> cross_entropy, including a sample
     masked by `ignore_index`. Verifies loss and grads on all four trainable
     inputs: `_input`, `weight`, `multimax_ranges`, `multimax_ts`.
     """
 
-    def _selu(self, x, ranges, ts):
-        """Python ref SeLU matching the Triton kernel formula."""
+    def _seglu(self, x, ranges, ts):
+        """Python ref SegLU matching the Triton kernel formula."""
         r0, r1, r2, r3 = [ranges[i] for i in range(4)]
         t0, t1, t2, t3 = [ts[i] for i in range(4)]
         m0 = paddle.nn.functional.relu(r0 - x)
@@ -302,7 +301,7 @@ class TestFusedMultimaxNumerical(unittest.TestCase):
         x = paddle.randn([BT, H], dtype="float32")
         w = paddle.randn([V, H], dtype="float32") * 0.1
         targets = paddle.to_tensor([0, 3, 5, ignore_index, 7, 1], dtype="int64")
-        # Non-zero multimax params so SeLU is non-trivial.
+        # Non-zero multimax params so SegLU is non-trivial.
         ranges = paddle.to_tensor([0.5, -0.5, 0.2, -0.2], dtype="float32")
         ts = paddle.to_tensor([0.3, 0.4, 0.1, 0.2], dtype="float32")
         return x, w, targets, ranges, ts, ignore_index
@@ -318,7 +317,7 @@ class TestFusedMultimaxNumerical(unittest.TestCase):
         t_ref.stop_gradient = False
 
         logits = paddle.nn.functional.linear(x_ref, w_ref.T)
-        modulated = self._selu(logits, r_ref, t_ref)
+        modulated = self._seglu(logits, r_ref, t_ref)
         loss = paddle.nn.functional.cross_entropy(
             modulated,
             targets,

--- a/tests/single_card_tests/model/test_lm_head_multimax.py
+++ b/tests/single_card_tests/model/test_lm_head_multimax.py
@@ -361,6 +361,54 @@ class TestFusedMultimaxNumerical(unittest.TestCase):
             f"got={t_f.grad.numpy().tolist()}",
         )
 
+    def test_fused_multimax_grads_when_only_input_frozen(self):
+        """Freeze only the backbone input; keep weight + multimax trainable.
+        This is the head-only-training regime flagged in CR: the kernel must
+        still write grad_logits (so weight grad is populated) and emit
+        non-zero multimax param grads, even though x.stop_gradient=True.
+        Regression for the `HAS_GRADIENTS=input_requires_grad` gating bug
+        and for the `grad_weight` allocation being conditioned on
+        `input_requires_grad and weight_requires_grad`.
+        """
+        from paddlefleet.triton_ops.fused_linear_cross_entropy import (
+            LigerFusedLinearCrossEntropyFunction,
+        )
+
+        x, w, targets, ranges, ts, ig = self._make_inputs()
+        x_f = x.detach().clone()
+        x_f.stop_gradient = True  # frozen backbone
+        w_f = w.detach().clone()
+        w_f.stop_gradient = False  # LM head weight is trainable
+        r_f = ranges.detach().clone()
+        r_f.stop_gradient = False
+        t_f = ts.detach().clone()
+        t_f.stop_gradient = False
+
+        loss = LigerFusedLinearCrossEntropyFunction.apply(
+            x_f, w_f, targets, None, ig, "none", 1, False, r_f, t_f
+        ).sum()
+        loss.backward()
+
+        _, _, gw_ref, gr_ref, gt_ref = self._run_reference(
+            x, w, targets, ranges, ts, ig
+        )
+        self.assertIsNotNone(
+            w_f.grad, "weight.grad is None when only input is frozen"
+        )
+        self.assertTrue(
+            paddle.allclose(gw_ref, w_f.grad, atol=1e-3, rtol=1e-3).item(),
+            f"frozen-input grad_weight max abs diff="
+            f"{(gw_ref - w_f.grad).abs().max().item()}",
+        )
+        self.assertIsNotNone(r_f.grad)
+        self.assertIsNotNone(t_f.grad)
+        self.assertTrue(
+            paddle.allclose(gr_ref, r_f.grad, atol=1e-3, rtol=1e-3).item()
+        )
+        self.assertTrue(
+            paddle.allclose(gt_ref, t_f.grad, atol=1e-3, rtol=1e-3).item()
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/single_card_tests/model/test_lm_head_multimax.py
+++ b/tests/single_card_tests/model/test_lm_head_multimax.py
@@ -68,7 +68,7 @@ class TestMultimaxLMHead(unittest.TestCase):
         ps.initialize_model_parallel(hcg)
         cls.strategy = strategy
 
-        # Config with apply_multimax=[lm_head]
+        # Config with multimax_modules=[lm_head]
         cls.config_multimax = GPTConfig(
             num_hidden_layers=2,
             hidden_size=256,
@@ -90,7 +90,7 @@ class TestMultimaxLMHead(unittest.TestCase):
                 paddle.nn.init.xavier_uniform_, gain=1.0
             ),
             tie_word_embeddings=True,
-            apply_multimax=["lm_head"],
+            multimax_modules=["lm_head"],
         )
         cls.model_multimax = gpt_builder(cls.config_multimax, num_stages=1)
 
@@ -116,7 +116,7 @@ class TestMultimaxLMHead(unittest.TestCase):
                 paddle.nn.init.xavier_uniform_, gain=1.0
             ),
             tie_word_embeddings=True,
-            apply_multimax=None,
+            multimax_modules=None,
         )
         cls.model_no_multimax = gpt_builder(
             cls.config_no_multimax, num_stages=1
@@ -144,7 +144,7 @@ class TestMultimaxLMHead(unittest.TestCase):
                 paddle.nn.init.xavier_uniform_, gain=1.0
             ),
             tie_word_embeddings=True,
-            apply_multimax=["lm_head"],
+            multimax_modules=["lm_head"],
             fused_linear_ce_loss_chunk=1,
         )
         cls.model_fused = gpt_builder(cls.config_fused, num_stages=1)
@@ -158,7 +158,7 @@ class TestMultimaxLMHead(unittest.TestCase):
         return None
 
     def test_multimax_lmhead_creates_params(self):
-        """When apply_multimax=[lm_head], GPTLMHead should create multimax_ranges/ts params."""
+        """When multimax_modules=[lm_head], GPTLMHead should create multimax_ranges/ts params."""
         lm_head = self._find_lm_head(self.model_multimax)
         self.assertIsNotNone(lm_head)
         self.assertTrue(hasattr(lm_head, "use_multimax_lmhead"))
@@ -169,7 +169,7 @@ class TestMultimaxLMHead(unittest.TestCase):
         self.assertEqual(lm_head.multimax_ts.shape, [4])
 
     def test_no_multimax_lmhead_no_params(self):
-        """When apply_multimax=None, GPTLMHead should NOT create multimax params."""
+        """When multimax_modules=None, GPTLMHead should NOT create multimax params."""
         lm_head = self._find_lm_head(self.model_no_multimax)
         self.assertIsNotNone(lm_head)
         self.assertFalse(getattr(lm_head, "use_multimax_lmhead", False))
@@ -184,7 +184,7 @@ class TestMultimaxLMHead(unittest.TestCase):
         self.assertTrue(paddle.allclose(lm_head.multimax_ts, zeros).item())
 
     def test_fused_path_returns_5tuple(self):
-        """With fused_linear_ce_loss_chunk>0 and apply_multimax, forward returns 5-tuple.
+        """With fused_linear_ce_loss_chunk>0 and multimax_modules, forward returns 5-tuple.
         Also exercises the rank-0 [MULTIMAX-LMHEAD-APPLIED] one-shot warn banner
         at the top of the fused branch.
         """
@@ -208,7 +208,7 @@ class TestMultimaxLMHead(unittest.TestCase):
         self.assertTrue(getattr(lm_head, "_multimax_applied_logged", False))
 
     def test_unfused_path_applies_seglu_and_logs(self):
-        """With apply_multimax + fused_linear_ce_loss_chunk=0 (default), forward
+        """With multimax_modules + fused_linear_ce_loss_chunk=0 (default), forward
         returns logits (not a tuple) and applies SegLU via recompute.
         Exercises the unfused-path warn block + SegLU recompute branch.
         """

--- a/tests/single_card_tests/model/test_lm_head_multimax_seglu.py
+++ b/tests/single_card_tests/model/test_lm_head_multimax_seglu.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Targeted unit tests for the multimax SeLU function used by GPTLMHead.
+"""Targeted unit tests for the multimax SegLU function used by GPTLMHead.
 
 Covers the pure-math layer of the multimax feature:
-- SeLU(x, ranges=0, ts=0) is the identity (resume safety / step-0 invariant).
-- SeLU is element-wise.
-- SeLU does NOT mutate the input tensor (must clone for autograd correctness).
-- SeLU has the expected value at simple analytic points.
+- SegLU(x, ranges=0, ts=0) is the identity (resume safety / step-0 invariant).
+- SegLU is element-wise.
+- SegLU does NOT mutate the input tensor (must clone for autograd correctness).
+- SegLU has the expected value at simple analytic points.
 """
 
 import unittest
@@ -26,46 +26,46 @@ import unittest
 import paddle
 import paddlefleet_ops
 
-# sonicmoe ecosystem op is not available in some CI envs; the SeLU function
+# sonicmoe ecosystem op is not available in some CI envs; the SegLU function
 # itself does not depend on it, so neutralize the gating before importing
 # anything from paddlefleet.models.gpt.
 paddlefleet_ops.is_sonic_moe_available = lambda: False
 
 
-class TestSeLU(unittest.TestCase):
-    """Math-level tests for the multimax SeLU activation."""
+class TestSegLU(unittest.TestCase):
+    """Math-level tests for the multimax SegLU activation."""
 
     @classmethod
     def setUpClass(cls):
-        from paddlefleet.models.gpt.lm_head import SeLU
+        from paddlefleet.models.gpt.lm_head import SegLU
 
-        cls.SeLU = staticmethod(SeLU)
+        cls.SegLU = staticmethod(SegLU)
 
     def test_zero_params_is_identity(self):
-        """ranges=ts=0 -> SeLU should be the identity (init-time invariant)."""
+        """ranges=ts=0 -> SegLU should be the identity (init-time invariant)."""
         x = paddle.randn([2, 3, 5], dtype="float32")
         ranges = paddle.zeros([4], dtype="float32")
         ts = paddle.zeros([4], dtype="float32")
-        y = self.SeLU(x, ranges, ts)
+        y = self.SegLU(x, ranges, ts)
         self.assertEqual(list(y.shape), list(x.shape))
         # Identity at init guarantees resume from checkpoints lacking these
         # params produces bit-identical logits at step 0.
         self.assertTrue(
             paddle.allclose(y, x, atol=1e-6).item(),
-            "SeLU(x, 0, 0) must equal x exactly",
+            "SegLU(x, 0, 0) must equal x exactly",
         )
 
     def test_input_not_mutated(self):
-        """SeLU must clone before in-place +=; mutating x would corrupt autograd."""
+        """SegLU must clone before in-place +=; mutating x would corrupt autograd."""
         x = paddle.randn([4, 7], dtype="float32")
         x_orig = x.clone()
         ranges = paddle.to_tensor([0.0, 0.0, 0.0, 0.0], dtype="float32")
         ts = paddle.to_tensor([0.5, 0.5, 0.1, 0.1], dtype="float32")
-        _ = self.SeLU(x, ranges, ts)
+        _ = self.SegLU(x, ranges, ts)
         # x must be unchanged after the call
         self.assertTrue(
             paddle.allclose(x, x_orig, atol=0.0).item(),
-            "SeLU must not mutate its input tensor",
+            "SegLU must not mutate its input tensor",
         )
 
     def test_elementwise_shape_preserved(self):
@@ -74,35 +74,32 @@ class TestSeLU(unittest.TestCase):
         ts = paddle.to_tensor([0.1, 0.2, 0.3, 0.4], dtype="float32")
         for shape in [[8], [3, 16], [2, 4, 32], [1, 2, 3, 64]]:
             x = paddle.randn(shape, dtype="float32")
-            y = self.SeLU(x, ranges, ts)
+            y = self.SegLU(x, ranges, ts)
             self.assertEqual(list(y.shape), shape)
 
     def test_inside_window_no_modulation(self):
         """For a value strictly inside [ranges[1], ranges[0]] = (-1, 1) and
-        away from the squared cutoffs at ranges[2..3]=0, SeLU should equal x.
+        away from the squared cutoffs at ranges[2..3]=0, SegLU should equal x.
 
         Linear part: ts[0]*relu(ranges[0]-x) is 0 when x>ranges[0],
                      ts[1]*relu(x-ranges[1]) is 0 when x<ranges[1].
         Quadratic part: ts[2]*relu(ranges[2]-x)**2 is 0 when x>ranges[2],
                         ts[3]*relu(x-ranges[3])**2 is 0 when x<ranges[3].
-        Set ranges[0]=+inf, ranges[1]=-inf, ranges[2]=+inf, ranges[3]=-inf
-        -> all four ReLU args are negative -> SeLU is identity for any x.
+        Choose ranges such that all four relu(...) args are negative -> SegLU
+        is identity for any x.
         """
         x = paddle.to_tensor([-2.0, 0.0, 2.0], dtype="float32")
-        ranges = paddle.to_tensor([1e30, -1e30, 1e30, -1e30], dtype="float32")
         ts = paddle.to_tensor([1.0, 1.0, 1.0, 1.0], dtype="float32")
-        # NOTE: ranges[0]=+inf -> relu(inf - x) = inf, so this WOULD blow up.
-        # Construct the opposite: choose ranges such that all relu(...) are 0.
         # relu(ranges[0] - x) = 0 iff ranges[0] <= x  -> use ranges[0] = -1e30
         # relu(x - ranges[1]) = 0 iff x <= ranges[1]  -> use ranges[1] = +1e30
         # relu(ranges[2] - x) = 0 iff ranges[2] <= x  -> use ranges[2] = -1e30
         # relu(x - ranges[3]) = 0 iff x <= ranges[3]  -> use ranges[3] = +1e30
         ranges = paddle.to_tensor([-1e30, 1e30, -1e30, 1e30], dtype="float32")
-        y = self.SeLU(x, ranges, ts)
+        y = self.SegLU(x, ranges, ts)
         self.assertTrue(paddle.allclose(y, x, atol=0.0).item())
 
     def test_known_linear_modulation(self):
-        """With ts=[1,0,0,0] and ranges=[1,0,0,0], SeLU(x) = x + relu(1 - x).
+        """With ts=[1,0,0,0] and ranges=[1,0,0,0], SegLU(x) = x + relu(1 - x).
 
         For x = 0:   1 + relu(1) = 0 + 1 = 1
         For x = 0.5: 0.5 + relu(0.5) = 1.0
@@ -111,7 +108,7 @@ class TestSeLU(unittest.TestCase):
         x = paddle.to_tensor([0.0, 0.5, 2.0], dtype="float32")
         ranges = paddle.to_tensor([1.0, 0.0, 0.0, 0.0], dtype="float32")
         ts = paddle.to_tensor([1.0, 0.0, 0.0, 0.0], dtype="float32")
-        y = self.SeLU(x, ranges, ts)
+        y = self.SegLU(x, ranges, ts)
         expected = paddle.to_tensor([1.0, 1.0, 2.0], dtype="float32")
         self.assertTrue(
             paddle.allclose(y, expected, atol=1e-6).item(),
@@ -119,7 +116,7 @@ class TestSeLU(unittest.TestCase):
         )
 
     def test_known_quadratic_modulation(self):
-        """With ts=[0,0,1,0] and ranges=[0,0,1,0], SeLU(x) = x + relu(1 - x)**2.
+        """With ts=[0,0,1,0] and ranges=[0,0,1,0], SegLU(x) = x + relu(1 - x)**2.
 
         For x = -1: -1 + relu(2)**2 = -1 + 4 = 3
         For x = 0:   0 + relu(1)**2 = 0 + 1 = 1
@@ -128,7 +125,7 @@ class TestSeLU(unittest.TestCase):
         x = paddle.to_tensor([-1.0, 0.0, 2.0], dtype="float32")
         ranges = paddle.to_tensor([0.0, 0.0, 1.0, 0.0], dtype="float32")
         ts = paddle.to_tensor([0.0, 0.0, 1.0, 0.0], dtype="float32")
-        y = self.SeLU(x, ranges, ts)
+        y = self.SegLU(x, ranges, ts)
         expected = paddle.to_tensor([3.0, 1.0, 2.0], dtype="float32")
         self.assertTrue(
             paddle.allclose(y, expected, atol=1e-6).item(),

--- a/tests/single_card_tests/model/test_lm_head_multimax_selu.py
+++ b/tests/single_card_tests/model/test_lm_head_multimax_selu.py
@@ -1,0 +1,140 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Targeted unit tests for the multimax SeLU function used by GPTLMHead.
+
+Covers the pure-math layer of the multimax feature:
+- SeLU(x, ranges=0, ts=0) is the identity (resume safety / step-0 invariant).
+- SeLU is element-wise.
+- SeLU does NOT mutate the input tensor (must clone for autograd correctness).
+- SeLU has the expected value at simple analytic points.
+"""
+
+import unittest
+
+import paddle
+import paddlefleet_ops
+
+# sonicmoe ecosystem op is not available in some CI envs; the SeLU function
+# itself does not depend on it, so neutralize the gating before importing
+# anything from paddlefleet.models.gpt.
+paddlefleet_ops.is_sonic_moe_available = lambda: False
+
+
+class TestSeLU(unittest.TestCase):
+    """Math-level tests for the multimax SeLU activation."""
+
+    @classmethod
+    def setUpClass(cls):
+        from paddlefleet.models.gpt.lm_head import SeLU
+
+        cls.SeLU = staticmethod(SeLU)
+
+    def test_zero_params_is_identity(self):
+        """ranges=ts=0 -> SeLU should be the identity (init-time invariant)."""
+        x = paddle.randn([2, 3, 5], dtype="float32")
+        ranges = paddle.zeros([4], dtype="float32")
+        ts = paddle.zeros([4], dtype="float32")
+        y = self.SeLU(x, ranges, ts)
+        self.assertEqual(list(y.shape), list(x.shape))
+        # Identity at init guarantees resume from checkpoints lacking these
+        # params produces bit-identical logits at step 0.
+        self.assertTrue(
+            paddle.allclose(y, x, atol=1e-6).item(),
+            "SeLU(x, 0, 0) must equal x exactly",
+        )
+
+    def test_input_not_mutated(self):
+        """SeLU must clone before in-place +=; mutating x would corrupt autograd."""
+        x = paddle.randn([4, 7], dtype="float32")
+        x_orig = x.clone()
+        ranges = paddle.to_tensor([0.0, 0.0, 0.0, 0.0], dtype="float32")
+        ts = paddle.to_tensor([0.5, 0.5, 0.1, 0.1], dtype="float32")
+        _ = self.SeLU(x, ranges, ts)
+        # x must be unchanged after the call
+        self.assertTrue(
+            paddle.allclose(x, x_orig, atol=0.0).item(),
+            "SeLU must not mutate its input tensor",
+        )
+
+    def test_elementwise_shape_preserved(self):
+        """Output shape == input shape across various rank tensors."""
+        ranges = paddle.zeros([4], dtype="float32")
+        ts = paddle.to_tensor([0.1, 0.2, 0.3, 0.4], dtype="float32")
+        for shape in [[8], [3, 16], [2, 4, 32], [1, 2, 3, 64]]:
+            x = paddle.randn(shape, dtype="float32")
+            y = self.SeLU(x, ranges, ts)
+            self.assertEqual(list(y.shape), shape)
+
+    def test_inside_window_no_modulation(self):
+        """For a value strictly inside [ranges[1], ranges[0]] = (-1, 1) and
+        away from the squared cutoffs at ranges[2..3]=0, SeLU should equal x.
+
+        Linear part: ts[0]*relu(ranges[0]-x) is 0 when x>ranges[0],
+                     ts[1]*relu(x-ranges[1]) is 0 when x<ranges[1].
+        Quadratic part: ts[2]*relu(ranges[2]-x)**2 is 0 when x>ranges[2],
+                        ts[3]*relu(x-ranges[3])**2 is 0 when x<ranges[3].
+        Set ranges[0]=+inf, ranges[1]=-inf, ranges[2]=+inf, ranges[3]=-inf
+        -> all four ReLU args are negative -> SeLU is identity for any x.
+        """
+        x = paddle.to_tensor([-2.0, 0.0, 2.0], dtype="float32")
+        ranges = paddle.to_tensor([1e30, -1e30, 1e30, -1e30], dtype="float32")
+        ts = paddle.to_tensor([1.0, 1.0, 1.0, 1.0], dtype="float32")
+        # NOTE: ranges[0]=+inf -> relu(inf - x) = inf, so this WOULD blow up.
+        # Construct the opposite: choose ranges such that all relu(...) are 0.
+        # relu(ranges[0] - x) = 0 iff ranges[0] <= x  -> use ranges[0] = -1e30
+        # relu(x - ranges[1]) = 0 iff x <= ranges[1]  -> use ranges[1] = +1e30
+        # relu(ranges[2] - x) = 0 iff ranges[2] <= x  -> use ranges[2] = -1e30
+        # relu(x - ranges[3]) = 0 iff x <= ranges[3]  -> use ranges[3] = +1e30
+        ranges = paddle.to_tensor([-1e30, 1e30, -1e30, 1e30], dtype="float32")
+        y = self.SeLU(x, ranges, ts)
+        self.assertTrue(paddle.allclose(y, x, atol=0.0).item())
+
+    def test_known_linear_modulation(self):
+        """With ts=[1,0,0,0] and ranges=[1,0,0,0], SeLU(x) = x + relu(1 - x).
+
+        For x = 0:   1 + relu(1) = 0 + 1 = 1
+        For x = 0.5: 0.5 + relu(0.5) = 1.0
+        For x = 2:   2 + relu(-1) = 2 + 0 = 2
+        """
+        x = paddle.to_tensor([0.0, 0.5, 2.0], dtype="float32")
+        ranges = paddle.to_tensor([1.0, 0.0, 0.0, 0.0], dtype="float32")
+        ts = paddle.to_tensor([1.0, 0.0, 0.0, 0.0], dtype="float32")
+        y = self.SeLU(x, ranges, ts)
+        expected = paddle.to_tensor([1.0, 1.0, 2.0], dtype="float32")
+        self.assertTrue(
+            paddle.allclose(y, expected, atol=1e-6).item(),
+            f"got {y.numpy().tolist()}, expected {expected.numpy().tolist()}",
+        )
+
+    def test_known_quadratic_modulation(self):
+        """With ts=[0,0,1,0] and ranges=[0,0,1,0], SeLU(x) = x + relu(1 - x)**2.
+
+        For x = -1: -1 + relu(2)**2 = -1 + 4 = 3
+        For x = 0:   0 + relu(1)**2 = 0 + 1 = 1
+        For x = 2:   2 + relu(-1)**2 = 2 + 0 = 2
+        """
+        x = paddle.to_tensor([-1.0, 0.0, 2.0], dtype="float32")
+        ranges = paddle.to_tensor([0.0, 0.0, 1.0, 0.0], dtype="float32")
+        ts = paddle.to_tensor([0.0, 0.0, 1.0, 0.0], dtype="float32")
+        y = self.SeLU(x, ranges, ts)
+        expected = paddle.to_tensor([3.0, 1.0, 2.0], dtype="float32")
+        self.assertTrue(
+            paddle.allclose(y, expected, atol=1e-6).item(),
+            f"got {y.numpy().tolist()}, expected {expected.numpy().tolist()}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/test_transformer_config_multimax.py
+++ b/tests/single_card_tests/test_transformer_config_multimax.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Targeted unit tests for TransformerConfig.multimax field validation."""
+
+import unittest
+import warnings
+
+
+class TestMultimaxConfig(unittest.TestCase):
+    """TransformerConfig.multimax accepts only None / 'lm_head' / 'attn' / 'all'.
+
+    Empty string is silently coerced to None so YAML configs that leave
+    the field as `multimax:` (parsed as empty string) behave like unset.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        from paddlefleet.transformer.transformer_config import TransformerConfig
+
+        cls.TransformerConfig = TransformerConfig
+
+    def _build(self, **overrides):
+        defaults = {
+            "num_hidden_layers": 4,
+            "hidden_size": 64,
+            "num_attention_heads": 4,
+        }
+        defaults.update(overrides)
+        return self.TransformerConfig(**defaults)
+
+    def test_default_is_none(self):
+        cfg = self._build()
+        self.assertIsNone(cfg.multimax)
+
+    def test_lm_head_accepted(self):
+        cfg = self._build(multimax="lm_head")
+        self.assertEqual(cfg.multimax, "lm_head")
+
+    def test_attn_accepted_with_warning(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            cfg = self._build(multimax="attn")
+        self.assertEqual(cfg.multimax, "attn")
+        # 'attn' branch is unimplemented -> a banner warning must mention it.
+        msgs = [str(x.message) for x in w]
+        self.assertTrue(
+            any("not implemented" in m and "attn" in m for m in msgs),
+            f"expected unimplemented-attn warning, got: {msgs}",
+        )
+
+    def test_all_accepted_with_warning(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            cfg = self._build(multimax="all")
+        self.assertEqual(cfg.multimax, "all")
+        msgs = [str(x.message) for x in w]
+        self.assertTrue(
+            any("not implemented" in m and "all" in m for m in msgs),
+            f"expected unimplemented-all warning, got: {msgs}",
+        )
+
+    def test_empty_string_coerced_to_none(self):
+        """YAML `multimax:` parses to '' -- must be canonicalized to None."""
+        cfg = self._build(multimax="")
+        self.assertIsNone(cfg.multimax)
+
+    def test_invalid_value_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            self._build(multimax="not_a_real_mode")
+        self.assertIn("multimax must be one of", str(ctx.exception))
+        self.assertIn("not_a_real_mode", str(ctx.exception))
+
+    def test_grep_friendly_banner_emitted(self):
+        """[MULTIMAX-CONFIG] tag must be present so operators can grep train logs."""
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            self._build(multimax="lm_head")
+        msgs = [str(x.message) for x in w]
+        self.assertTrue(
+            any("[MULTIMAX-CONFIG]" in m for m in msgs),
+            f"expected [MULTIMAX-CONFIG] banner, got: {msgs}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/test_transformer_config_multimax.py
+++ b/tests/single_card_tests/test_transformer_config_multimax.py
@@ -12,17 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Targeted unit tests for TransformerConfig.multimax field validation."""
+"""Targeted unit tests for TransformerConfig.apply_multimax field validation."""
 
 import unittest
 import warnings
 
 
 class TestMultimaxConfig(unittest.TestCase):
-    """TransformerConfig.multimax accepts only None / 'lm_head' / 'attn' / 'all'.
+    """TransformerConfig.apply_multimax accepts None or a list of submodule names.
 
-    Empty string is silently coerced to None so YAML configs that leave
-    the field as `multimax:` (parsed as empty string) behave like unset.
+    Mirrors Megatron's ``recompute_modules`` style. Currently the only
+    implemented entry is ``"lm_head"``; ``"attention"`` is reserved and
+    triggers a not-implemented warning.
+
+    YAML/JSON ergonomics:
+    - unset key, ``null``, empty string, or empty list ``[]`` are all
+      coerced to ``None`` (feature disabled).
+    - a bare string (``apply_multimax: lm_head``) is auto-promoted to a
+      single-element list for back-compat with older configs.
     """
 
     @classmethod
@@ -42,51 +49,70 @@ class TestMultimaxConfig(unittest.TestCase):
 
     def test_default_is_none(self):
         cfg = self._build()
-        self.assertIsNone(cfg.multimax)
+        self.assertIsNone(cfg.apply_multimax)
 
-    def test_lm_head_accepted(self):
-        cfg = self._build(multimax="lm_head")
-        self.assertEqual(cfg.multimax, "lm_head")
+    def test_lm_head_list_accepted(self):
+        cfg = self._build(apply_multimax=["lm_head"])
+        self.assertEqual(cfg.apply_multimax, ["lm_head"])
 
-    def test_attn_accepted_with_warning(self):
+    def test_bare_string_promoted_to_list(self):
+        """Back-compat: ``apply_multimax: lm_head`` -> ``["lm_head"]``."""
+        cfg = self._build(apply_multimax="lm_head")
+        self.assertEqual(cfg.apply_multimax, ["lm_head"])
+
+    def test_attention_accepted_with_warning(self):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            cfg = self._build(multimax="attn")
-        self.assertEqual(cfg.multimax, "attn")
-        # 'attn' branch is unimplemented -> a banner warning must mention it.
+            cfg = self._build(apply_multimax=["attention"])
+        self.assertEqual(cfg.apply_multimax, ["attention"])
+        # 'attention' branch is unimplemented -> a banner warning must mention it.
         msgs = [str(x.message) for x in w]
         self.assertTrue(
-            any("not implemented" in m and "attn" in m for m in msgs),
-            f"expected unimplemented-attn warning, got: {msgs}",
+            any("not implemented" in m and "attention" in m for m in msgs),
+            f"expected unimplemented-attention warning, got: {msgs}",
         )
 
-    def test_all_accepted_with_warning(self):
+    def test_combined_lm_head_and_attention(self):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            cfg = self._build(multimax="all")
-        self.assertEqual(cfg.multimax, "all")
+            cfg = self._build(apply_multimax=["lm_head", "attention"])
+        self.assertEqual(cfg.apply_multimax, ["lm_head", "attention"])
         msgs = [str(x.message) for x in w]
         self.assertTrue(
-            any("not implemented" in m and "all" in m for m in msgs),
-            f"expected unimplemented-all warning, got: {msgs}",
+            any("not implemented" in m and "attention" in m for m in msgs),
+            f"expected unimplemented-attention warning, got: {msgs}",
         )
 
     def test_empty_string_coerced_to_none(self):
-        """YAML `multimax:` parses to '' -- must be canonicalized to None."""
-        cfg = self._build(multimax="")
-        self.assertIsNone(cfg.multimax)
+        """YAML `apply_multimax:` parses to '' -- must be canonicalized to None."""
+        cfg = self._build(apply_multimax="")
+        self.assertIsNone(cfg.apply_multimax)
 
-    def test_invalid_value_raises(self):
+    def test_empty_list_coerced_to_none(self):
+        """YAML `apply_multimax: []` -- must be canonicalized to None."""
+        cfg = self._build(apply_multimax=[])
+        self.assertIsNone(cfg.apply_multimax)
+
+    def test_invalid_entry_raises(self):
         with self.assertRaises(ValueError) as ctx:
-            self._build(multimax="not_a_real_mode")
-        self.assertIn("multimax must be one of", str(ctx.exception))
+            self._build(apply_multimax=["not_a_real_mode"])
+        self.assertIn(
+            "apply_multimax entries must each be one of", str(ctx.exception)
+        )
         self.assertIn("not_a_real_mode", str(ctx.exception))
+
+    def test_invalid_type_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            self._build(apply_multimax=123)
+        self.assertIn(
+            "apply_multimax must be None or a list[str]", str(ctx.exception)
+        )
 
     def test_grep_friendly_banner_emitted(self):
         """[MULTIMAX-CONFIG] tag must be present so operators can grep train logs."""
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            self._build(multimax="lm_head")
+            self._build(apply_multimax=["lm_head"])
         msgs = [str(x.message) for x in w]
         self.assertTrue(
             any("[MULTIMAX-CONFIG]" in m for m in msgs),
@@ -94,38 +120,38 @@ class TestMultimaxConfig(unittest.TestCase):
         )
 
     def test_none_explicit_no_unimplemented_warning(self):
-        """multimax=None explicitly: only the [MULTIMAX-CONFIG] banner fires;
-        no 'not implemented' warning (which is reserved for attn/all)."""
+        """apply_multimax=None explicitly: no warnings fire (default disabled);
+        the [MULTIMAX-CONFIG] banner is only emitted when the feature is on."""
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            self._build(multimax=None)
+            self._build(apply_multimax=None)
         msgs = [str(x.message) for x in w]
         self.assertFalse(
             any("not implemented" in m for m in msgs),
             f"unexpected unimplemented warning for None: {msgs}",
         )
-        self.assertTrue(
-            any("[MULTIMAX-CONFIG]" in m and "None" in m for m in msgs),
-            f"expected [MULTIMAX-CONFIG] multimax=None banner, got: {msgs}",
+        self.assertFalse(
+            any("[MULTIMAX-CONFIG]" in m for m in msgs),
+            f"unexpected [MULTIMAX-CONFIG] banner for default None: {msgs}",
         )
 
-    def test_invalid_value_message_lists_choices(self):
+    def test_invalid_entry_message_lists_choices(self):
         """ValueError message must enumerate the valid options so users can
         self-correct without reading the code."""
         with self.assertRaises(ValueError) as ctx:
-            self._build(multimax="lm-head")  # hyphen, not underscore
+            self._build(apply_multimax=["lm-head"])  # hyphen, not underscore
         msg = str(ctx.exception)
-        for choice in ("lm_head", "attn", "all"):
+        for choice in ("lm_head", "attention"):
             self.assertIn(choice, msg, f"missing choice {choice!r} in: {msg}")
         self.assertIn("lm-head", msg, "offending value not echoed")
 
     def test_empty_string_does_not_warn_unimplemented(self):
         """Empty string is canonicalized to None; must not emit an
-        'attn/all not implemented' warning meant for those modes."""
+        'attention not implemented' warning."""
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            cfg = self._build(multimax="")
-        self.assertIsNone(cfg.multimax)
+            cfg = self._build(apply_multimax="")
+        self.assertIsNone(cfg.apply_multimax)
         msgs = [str(x.message) for x in w]
         self.assertFalse(
             any("not implemented" in m for m in msgs),

--- a/tests/single_card_tests/test_transformer_config_multimax.py
+++ b/tests/single_card_tests/test_transformer_config_multimax.py
@@ -12,14 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Targeted unit tests for TransformerConfig.apply_multimax field validation."""
+"""Targeted unit tests for TransformerConfig.multimax_modules field validation."""
 
+import importlib.util
 import unittest
 import warnings
 
+_HAS_OMEGACONF = importlib.util.find_spec("omegaconf") is not None
+
 
 class TestMultimaxConfig(unittest.TestCase):
-    """TransformerConfig.apply_multimax accepts None or a list of submodule names.
+    """TransformerConfig.multimax_modules accepts None or a list of submodule names.
 
     Mirrors Megatron's ``recompute_modules`` style. Currently the only
     implemented entry is ``"lm_head"``; ``"attention"`` is reserved and
@@ -28,7 +31,7 @@ class TestMultimaxConfig(unittest.TestCase):
     YAML/JSON ergonomics:
     - unset key, ``null``, empty string, or empty list ``[]`` are all
       coerced to ``None`` (feature disabled).
-    - a bare string (``apply_multimax: lm_head``) is auto-promoted to a
+    - a bare string (``multimax_modules: lm_head``) is auto-promoted to a
       single-element list for back-compat with older configs.
     """
 
@@ -49,22 +52,22 @@ class TestMultimaxConfig(unittest.TestCase):
 
     def test_default_is_none(self):
         cfg = self._build()
-        self.assertIsNone(cfg.apply_multimax)
+        self.assertIsNone(cfg.multimax_modules)
 
     def test_lm_head_list_accepted(self):
-        cfg = self._build(apply_multimax=["lm_head"])
-        self.assertEqual(cfg.apply_multimax, ["lm_head"])
+        cfg = self._build(multimax_modules=["lm_head"])
+        self.assertEqual(cfg.multimax_modules, ["lm_head"])
 
     def test_bare_string_promoted_to_list(self):
-        """Back-compat: ``apply_multimax: lm_head`` -> ``["lm_head"]``."""
-        cfg = self._build(apply_multimax="lm_head")
-        self.assertEqual(cfg.apply_multimax, ["lm_head"])
+        """Back-compat: ``multimax_modules: lm_head`` -> ``["lm_head"]``."""
+        cfg = self._build(multimax_modules="lm_head")
+        self.assertEqual(cfg.multimax_modules, ["lm_head"])
 
     def test_attention_accepted_with_warning(self):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            cfg = self._build(apply_multimax=["attention"])
-        self.assertEqual(cfg.apply_multimax, ["attention"])
+            cfg = self._build(multimax_modules=["attention"])
+        self.assertEqual(cfg.multimax_modules, ["attention"])
         # 'attention' branch is unimplemented -> a banner warning must mention it.
         msgs = [str(x.message) for x in w]
         self.assertTrue(
@@ -75,8 +78,8 @@ class TestMultimaxConfig(unittest.TestCase):
     def test_combined_lm_head_and_attention(self):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            cfg = self._build(apply_multimax=["lm_head", "attention"])
-        self.assertEqual(cfg.apply_multimax, ["lm_head", "attention"])
+            cfg = self._build(multimax_modules=["lm_head", "attention"])
+        self.assertEqual(cfg.multimax_modules, ["lm_head", "attention"])
         msgs = [str(x.message) for x in w]
         self.assertTrue(
             any("not implemented" in m and "attention" in m for m in msgs),
@@ -84,35 +87,35 @@ class TestMultimaxConfig(unittest.TestCase):
         )
 
     def test_empty_string_coerced_to_none(self):
-        """YAML `apply_multimax:` parses to '' -- must be canonicalized to None."""
-        cfg = self._build(apply_multimax="")
-        self.assertIsNone(cfg.apply_multimax)
+        """YAML `multimax_modules:` parses to '' -- must be canonicalized to None."""
+        cfg = self._build(multimax_modules="")
+        self.assertIsNone(cfg.multimax_modules)
 
     def test_empty_list_coerced_to_none(self):
-        """YAML `apply_multimax: []` -- must be canonicalized to None."""
-        cfg = self._build(apply_multimax=[])
-        self.assertIsNone(cfg.apply_multimax)
+        """YAML `multimax_modules: []` -- must be canonicalized to None."""
+        cfg = self._build(multimax_modules=[])
+        self.assertIsNone(cfg.multimax_modules)
 
     def test_invalid_entry_raises(self):
         with self.assertRaises(ValueError) as ctx:
-            self._build(apply_multimax=["not_a_real_mode"])
+            self._build(multimax_modules=["not_a_real_mode"])
         self.assertIn(
-            "apply_multimax entries must each be one of", str(ctx.exception)
+            "multimax_modules entries must each be one of", str(ctx.exception)
         )
         self.assertIn("not_a_real_mode", str(ctx.exception))
 
     def test_invalid_type_raises(self):
         with self.assertRaises(ValueError) as ctx:
-            self._build(apply_multimax=123)
+            self._build(multimax_modules=123)
         self.assertIn(
-            "apply_multimax must be None or a list[str]", str(ctx.exception)
+            "multimax_modules must be None or a list[str]", str(ctx.exception)
         )
 
     def test_grep_friendly_banner_emitted(self):
         """[MULTIMAX-CONFIG] tag must be present so operators can grep train logs."""
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            self._build(apply_multimax=["lm_head"])
+            self._build(multimax_modules=["lm_head"])
         msgs = [str(x.message) for x in w]
         self.assertTrue(
             any("[MULTIMAX-CONFIG]" in m for m in msgs),
@@ -120,11 +123,11 @@ class TestMultimaxConfig(unittest.TestCase):
         )
 
     def test_none_explicit_no_unimplemented_warning(self):
-        """apply_multimax=None explicitly: no warnings fire (default disabled);
+        """multimax_modules=None explicitly: no warnings fire (default disabled);
         the [MULTIMAX-CONFIG] banner is only emitted when the feature is on."""
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            self._build(apply_multimax=None)
+            self._build(multimax_modules=None)
         msgs = [str(x.message) for x in w]
         self.assertFalse(
             any("not implemented" in m for m in msgs),
@@ -139,7 +142,7 @@ class TestMultimaxConfig(unittest.TestCase):
         """ValueError message must enumerate the valid options so users can
         self-correct without reading the code."""
         with self.assertRaises(ValueError) as ctx:
-            self._build(apply_multimax=["lm-head"])  # hyphen, not underscore
+            self._build(multimax_modules=["lm-head"])  # hyphen, not underscore
         msg = str(ctx.exception)
         for choice in ("lm_head", "attention"):
             self.assertIn(choice, msg, f"missing choice {choice!r} in: {msg}")
@@ -150,31 +153,33 @@ class TestMultimaxConfig(unittest.TestCase):
         'attention not implemented' warning."""
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            cfg = self._build(apply_multimax="")
-        self.assertIsNone(cfg.apply_multimax)
+            cfg = self._build(multimax_modules="")
+        self.assertIsNone(cfg.multimax_modules)
         msgs = [str(x.message) for x in w]
         self.assertFalse(
             any("not implemented" in m for m in msgs),
             f"unexpected unimplemented warning for empty string: {msgs}",
         )
 
+    @unittest.skipUnless(_HAS_OMEGACONF, "omegaconf not installed in this env")
     def test_yaml_listconfig_accepted(self):
         """Regression: YAML entry path returns OmegaConf ListConfig, not a
         builtin list. The validator must normalize ListConfig to list so
-        the recommended ``apply_multimax: [lm_head]`` form works through
+        the recommended ``multimax_modules: [lm_head]`` form works through
         the --configs YAML pipeline."""
         from omegaconf import OmegaConf
 
         listcfg = OmegaConf.create(["lm_head"])
-        cfg = self._build(apply_multimax=listcfg)
-        self.assertEqual(cfg.apply_multimax, ["lm_head"])
+        cfg = self._build(multimax_modules=listcfg)
+        self.assertEqual(cfg.multimax_modules, ["lm_head"])
         # After validation the field must be a plain list (not ListConfig)
         # so downstream `isinstance(..., list)` checks behave as expected.
-        self.assertIsInstance(cfg.apply_multimax, list)
+        self.assertIsInstance(cfg.multimax_modules, list)
 
+    @unittest.skipUnless(_HAS_OMEGACONF, "omegaconf not installed in this env")
     def test_yaml_pipeline_end_to_end(self):
         """End-to-end regression from load_yaml() through
-        core_transformer_config_from_args() with apply_multimax: [lm_head]."""
+        core_transformer_config_from_args() with multimax_modules: [lm_head]."""
         import os
         import tempfile
 
@@ -188,7 +193,7 @@ class TestMultimaxConfig(unittest.TestCase):
             "  num_hidden_layers: 4\n"
             "  hidden_size: 64\n"
             "  num_attention_heads: 4\n"
-            "  apply_multimax: [lm_head]\n"
+            "  multimax_modules: [lm_head]\n"
         )
         with tempfile.NamedTemporaryFile(
             mode="w", suffix=".yaml", delete=False
@@ -202,8 +207,8 @@ class TestMultimaxConfig(unittest.TestCase):
             )
         finally:
             os.unlink(yaml_path)
-        self.assertEqual(cfg.apply_multimax, ["lm_head"])
-        self.assertIsInstance(cfg.apply_multimax, list)
+        self.assertEqual(cfg.multimax_modules, ["lm_head"])
+        self.assertIsInstance(cfg.multimax_modules, list)
 
 
 if __name__ == "__main__":

--- a/tests/single_card_tests/test_transformer_config_multimax.py
+++ b/tests/single_card_tests/test_transformer_config_multimax.py
@@ -93,6 +93,45 @@ class TestMultimaxConfig(unittest.TestCase):
             f"expected [MULTIMAX-CONFIG] banner, got: {msgs}",
         )
 
+    def test_none_explicit_no_unimplemented_warning(self):
+        """multimax=None explicitly: only the [MULTIMAX-CONFIG] banner fires;
+        no 'not implemented' warning (which is reserved for attn/all)."""
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            self._build(multimax=None)
+        msgs = [str(x.message) for x in w]
+        self.assertFalse(
+            any("not implemented" in m for m in msgs),
+            f"unexpected unimplemented warning for None: {msgs}",
+        )
+        self.assertTrue(
+            any("[MULTIMAX-CONFIG]" in m and "None" in m for m in msgs),
+            f"expected [MULTIMAX-CONFIG] multimax=None banner, got: {msgs}",
+        )
+
+    def test_invalid_value_message_lists_choices(self):
+        """ValueError message must enumerate the valid options so users can
+        self-correct without reading the code."""
+        with self.assertRaises(ValueError) as ctx:
+            self._build(multimax="lm-head")  # hyphen, not underscore
+        msg = str(ctx.exception)
+        for choice in ("lm_head", "attn", "all"):
+            self.assertIn(choice, msg, f"missing choice {choice!r} in: {msg}")
+        self.assertIn("lm-head", msg, "offending value not echoed")
+
+    def test_empty_string_does_not_warn_unimplemented(self):
+        """Empty string is canonicalized to None; must not emit an
+        'attn/all not implemented' warning meant for those modes."""
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            cfg = self._build(multimax="")
+        self.assertIsNone(cfg.multimax)
+        msgs = [str(x.message) for x in w]
+        self.assertFalse(
+            any("not implemented" in m for m in msgs),
+            f"unexpected unimplemented warning for empty string: {msgs}",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/single_card_tests/test_transformer_config_multimax.py
+++ b/tests/single_card_tests/test_transformer_config_multimax.py
@@ -158,6 +158,53 @@ class TestMultimaxConfig(unittest.TestCase):
             f"unexpected unimplemented warning for empty string: {msgs}",
         )
 
+    def test_yaml_listconfig_accepted(self):
+        """Regression: YAML entry path returns OmegaConf ListConfig, not a
+        builtin list. The validator must normalize ListConfig to list so
+        the recommended ``apply_multimax: [lm_head]`` form works through
+        the --configs YAML pipeline."""
+        from omegaconf import OmegaConf
+
+        listcfg = OmegaConf.create(["lm_head"])
+        cfg = self._build(apply_multimax=listcfg)
+        self.assertEqual(cfg.apply_multimax, ["lm_head"])
+        # After validation the field must be a plain list (not ListConfig)
+        # so downstream `isinstance(..., list)` checks behave as expected.
+        self.assertIsInstance(cfg.apply_multimax, list)
+
+    def test_yaml_pipeline_end_to_end(self):
+        """End-to-end regression from load_yaml() through
+        core_transformer_config_from_args() with apply_multimax: [lm_head]."""
+        import os
+        import tempfile
+
+        from paddlefleet.training.arguments import (
+            core_transformer_config_from_args,
+        )
+        from paddlefleet.training.yaml_arguments import load_yaml
+
+        yaml_text = (
+            "model:\n"
+            "  num_hidden_layers: 4\n"
+            "  hidden_size: 64\n"
+            "  num_attention_heads: 4\n"
+            "  apply_multimax: [lm_head]\n"
+        )
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".yaml", delete=False
+        ) as f:
+            f.write(yaml_text)
+            yaml_path = f.name
+        try:
+            args = load_yaml(yaml_path)
+            cfg = core_transformer_config_from_args(
+                args, config_class=self.TransformerConfig
+            )
+        finally:
+            os.unlink(yaml_path)
+        self.assertEqual(cfg.apply_multimax, ["lm_head"])
+        self.assertIsInstance(cfg.apply_multimax, list)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library  | Environment Adaptation ] -->
Operator Mechanism
### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features
### Description
<!-- Describe what you’ve done -->
Add multimax, a learnable SeLU-style modulation applied to LM-head logits before language-modeling softmax/cross-entropy. The feature is opt-in through `TransformerConfig.multimax`, with `None` as the default disabled value and [`lm_head`] enabling the wired path. This PR adds LM-head parameters, routes them through `LanguageLoss` and fused linear CE, extends the Triton CE path, and adds single-card tests for config validation and LM-head multimax behavior.
#### Reference
Zhou, Yuxuan, Mario Fritz, and Margret Keuper. "MultiMax: Sparse and Multi-Modal Attention Learning." *International Conference on Machine Learning*. PMLR, 2024.