### PR TITLE
[release/0.3][Bug fix] Use pad_token_id for MTP magic-send re-embedding and MoE mask

### DIFF
--- a/src/paddlefleet/models/gpt/gpt_embedding.py
+++ b/src/paddlefleet/models/gpt/gpt_embedding.py
@@ -192,7 +192,10 @@ class GPTEmbedding(FleetLayer):
                 self.config.expert_model_parallel_size > 1
                 and self.config.tensor_model_parallel_size < 2
             ):
-                text_padding_indices = input_ids == 0
+                pad_token_id = getattr(self.config, "pad_token_id", 0)
+                if pad_token_id is None:
+                    pad_token_id = 0
+                text_padding_indices = input_ids == pad_token_id
                 decoder_input = fill_feature(
                     decoder_input, text_padding_indices, 0
                 )

--- a/src/paddlefleet/models/gpt/mtp_embedding_layer.py
+++ b/src/paddlefleet/models/gpt/mtp_embedding_layer.py
@@ -95,7 +95,10 @@ class MTPEmbeddingLayer(FleetLayer):
             self.config.expert_model_parallel_size > 1
             and self.config.tensor_model_parallel_size < 2
         ):
-            text_padding_indices = input_ids == 0
+            pad_token_id = getattr(self.config, "pad_token_id", 0)
+            if pad_token_id is None:
+                pad_token_id = 0
+            text_padding_indices = input_ids == pad_token_id
             input_embeds = fill_feature(input_embeds, text_padding_indices, 0)
 
         dict_args["mtp_input_embeds"] = input_embeds

--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -192,7 +192,7 @@ def gate_detach_matmul(
 
 
 def _apply_routing_map_fusion(
-    gates, top_idx, input_ids_none_zero_mask, input_ids=None
+    gates, top_idx, input_ids_none_zero_mask, input_ids=None, pad_token_id=0
 ):
     from paddlefleet.triton_ops import routing_map_fusion_forward
 
@@ -205,6 +205,7 @@ def _apply_routing_map_fusion(
         top_idx,
         input_ids=fused_input_ids,
         is_pure_text_line=None,
+        pad_token_id=pad_token_id,
     )
     mask = fused_mask.cast(gates.dtype)
     return mask, top_idx, exp_counts
@@ -448,7 +449,10 @@ class StandardMoERouter(nn.Layer):
             _ids = input_ids
             if _ids.ndim == 1:
                 _ids = _ids.unsqueeze(axis=0)
-            origin_valid_mask = (_ids != 0).astype(paddle.float32)
+            pad_token_id = getattr(self.config, "pad_token_id", 0)
+            if pad_token_id is None:
+                pad_token_id = 0
+            origin_valid_mask = (_ids != pad_token_id).astype(paddle.float32)
             if getattr(
                 self.config, "gpt_model_use_experimental_version", False
             ):
@@ -518,8 +522,13 @@ class StandardMoERouter(nn.Layer):
                 )
             else:
                 origin_input_ids = input_ids
-            origin_loss_mask = (origin_input_ids != 0).astype(paddle.float32)
-            loss_mask = (input_ids != 0).astype(paddle.float32)
+            pad_token_id = getattr(self.config, "pad_token_id", 0)
+            if pad_token_id is None:
+                pad_token_id = 0
+            origin_loss_mask = (origin_input_ids != pad_token_id).astype(
+                paddle.float32
+            )
+            loss_mask = (input_ids != pad_token_id).astype(paddle.float32)
             loss_mask = loss_mask.reshape([-1])
             if getattr(
                 self.config, "gpt_model_use_experimental_version", False
@@ -962,12 +971,19 @@ class TopKRouter(StandardMoERouter):
                     input_ids, axis=1, mode=self.config.cp_balance_mode
                 )
             if input_ids is not None:
+                pad_token_id = getattr(self.config, "pad_token_id", 0)
+                if pad_token_id is None:
+                    pad_token_id = 0
                 if self.sequence_parallel:
                     input_ids_none_zero_mask = (
-                        (input_ids != 0).transpose([1, 0]).reshape([-1, 1])
+                        (input_ids != pad_token_id)
+                        .transpose([1, 0])
+                        .reshape([-1, 1])
                     )
                 else:
-                    input_ids_none_zero_mask = (input_ids != 0).reshape([-1, 1])
+                    input_ids_none_zero_mask = (
+                        input_ids != pad_token_id
+                    ).reshape([-1, 1])
                 batch_size_, seq_len_ = input_ids.shape
                 assert (batch_size_ == batch_size) and (seq_len_ == seq_len), (
                     f"input_ids shape mismatch with input: "
@@ -1135,8 +1151,15 @@ class TopKRouter(StandardMoERouter):
             l_zloss = None
 
         if getattr(self.config, "routing_map_fusion", False):
+            pad_token_id = getattr(self.config, "pad_token_id", 0)
+            if pad_token_id is None:
+                pad_token_id = 0
             mask, top_idx, exp_counts = _apply_routing_map_fusion(
-                gates, top_idx, input_ids_none_zero_mask, input_ids
+                gates,
+                top_idx,
+                input_ids_none_zero_mask,
+                input_ids,
+                pad_token_id=pad_token_id,
             )
         else:
             with paddle.amp.auto_cast(enable=False):

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -46,6 +46,9 @@ class TransformerConfig(ModelParallelConfig):
     num_hidden_layers: int = 1
     """Number of transformer layers in a transformer block."""
 
+    pad_token_id: int = 0
+    """Token ID used for padding."""
+
     num_nextn_predict_layers: int = 0
     """Number of Multi-Token Prediction (MTP) Layers."""
 

--- a/src/paddlefleet/triton_ops/moe_topk_fusion.py
+++ b/src/paddlefleet/triton_ops/moe_topk_fusion.py
@@ -381,6 +381,7 @@ def _routing_map_fwd_kernel(
     n_experts,
     seq_len,  # explicit seq_len for boundary checks during block processing
     moe_k,  # runtime parameter: the actual moe_k value
+    pad_token_id,  # runtime parameter: token id used for padding
     has_input_ids: tl.constexpr,
     has_pure_text_mask: tl.constexpr,
     BLOCK_M: tl.constexpr,  # block size along the sequence dim (e.g., 32, 64)
@@ -428,8 +429,10 @@ def _routing_map_fwd_kernel(
     is_valid = tl.full((BLOCK_M,), 1, dtype=tl.int1)
 
     if has_input_ids:
-        in_ids = tl.load(input_ids_ptr + offs_m, mask=mask_m, other=0)
-        is_valid = is_valid & (in_ids != 0)
+        in_ids = tl.load(
+            input_ids_ptr + offs_m, mask=mask_m, other=pad_token_id
+        )
+        is_valid = is_valid & (in_ids != pad_token_id)
 
     if has_pure_text_mask:
         p_mask = tl.load(is_pure_text_line_ptr + offs_m, mask=mask_m, other=0)
@@ -516,7 +519,11 @@ def _routing_map_fwd_kernel(
 
 
 def routing_map_fusion_forward(
-    gate_probs, topk_indices, input_ids=None, is_pure_text_line=None
+    gate_probs,
+    topk_indices,
+    input_ids=None,
+    is_pure_text_line=None,
+    pad_token_id=0,
 ):
     """
     Get routing_map using Triton kernel.
@@ -526,6 +533,7 @@ def routing_map_fusion_forward(
         topk_indices: Topk expert indices [seq_len, moe_k]
         input_ids: Input token IDs [seq_len] (optional, for padding mask)
         is_pure_text_line: Pure text line mask [seq_len] (optional)
+        pad_token_id: Token ID treated as padding (default 0)
 
     Returns:
         routing_map: Routing map [seq_len, n_experts]
@@ -572,6 +580,7 @@ def routing_map_fusion_forward(
         n_experts=n_experts,
         seq_len=seq_len,
         moe_k=moe_k,
+        pad_token_id=pad_token_id,
         has_input_ids=input_ids is not None,
         has_pure_text_mask=is_pure_text_line is not None,
         BLOCK_M=BLOCK_M,

--- a/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_router.py
+++ b/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_router.py
@@ -1337,7 +1337,12 @@ class TestRoutingMapFusionWrapper(unittest.TestCase):
     """
 
     def _fake_routing_map_fusion(
-        self, gates, top_idx, input_ids=None, is_pure_text_line=None
+        self,
+        gates,
+        top_idx,
+        input_ids=None,
+        is_pure_text_line=None,
+        pad_token_id=0,
     ):
         # Return a binary mask with selected indices set, matching gates shape.
         fused_mask = paddle.zeros_like(gates).put_along_axis(
@@ -1512,7 +1517,12 @@ class TestForwardRoutingMapFusion(unittest.TestCase):
     (line ~1089)."""
 
     def _fake_routing_map_fusion_forward(
-        self, gates, top_idx, input_ids=None, is_pure_text_line=None
+        self,
+        gates,
+        top_idx,
+        input_ids=None,
+        is_pure_text_line=None,
+        pad_token_id=0,
     ):
         fused_mask = paddle.zeros_like(gates).put_along_axis(
             top_idx, paddle.to_tensor(1.0, dtype=gates.dtype), axis=1

--- a/tests/single_card_tests/ai_edited_test/ops/test_ai_moe_topk_fusion_4.py
+++ b/tests/single_card_tests/ai_edited_test/ops/test_ai_moe_topk_fusion_4.py
@@ -300,6 +300,7 @@ class TestMoETopkFusionKernelDefinitionsNoMock(unittest.TestCase):
             4,
             2,
             2,
+            0,  # pad_token_id
             True,
             True,
             2,

--- a/tests/single_card_tests/model/test_base_embedding.py
+++ b/tests/single_card_tests/model/test_base_embedding.py
@@ -69,12 +69,10 @@ class TestBaseEmbedding(unittest.TestCase):
 class TestGPTEmbeddingFillFeatureBranch(unittest.TestCase):
     """Test fill_feature branch (lines 153-162) in GPTEmbedding.forward."""
 
-    def test_forward_zeros_padding_and_sets_moe_mask(self):
-        """Cover: fill_feature zeroes padding embeddings, input_ids_for_moe_mask is set."""
+    def _make_emb(self, pad_token_id):
         from paddlefleet.models.gpt.gpt_embedding import GPTEmbedding
 
         B, S, H = 2, 4, 8
-        # Bypass __init__ to avoid heavy distributed dependencies
         emb = object.__new__(GPTEmbedding)
         emb.sequence_parallel = False
         emb.multimodal_embedding = False
@@ -90,7 +88,13 @@ class TestGPTEmbeddingFillFeatureBranch(unittest.TestCase):
         cfg.num_nextn_predict_layers = None
         cfg.mtp_load_weight_only = False
         cfg.sequence_parallel = False
+        cfg.pad_token_id = pad_token_id
         emb.config = cfg
+        return emb, B, S, H
+
+    def test_forward_zeros_padding_and_sets_moe_mask(self):
+        """Cover: fill_feature zeroes padding embeddings, input_ids_for_moe_mask is set."""
+        emb, B, S, H = self._make_emb(pad_token_id=0)
 
         input_ids = paddle.to_tensor([[1, 2, 0, 0], [3, 0, 5, 0]])
         result = emb.forward({"input_ids": input_ids})
@@ -108,6 +112,32 @@ class TestGPTEmbeddingFillFeatureBranch(unittest.TestCase):
         # input_ids_for_moe_mask is passed through as "input_ids"
         self.assertIn("input_ids", result)
         self.assertTrue(paddle.equal_all(result["input_ids"], input_ids).item())
+
+    def test_forward_uses_custom_pad_token_id(self):
+        """When pad_token_id != 0, only that id is treated as padding."""
+        emb, B, S, _ = self._make_emb(pad_token_id=42)
+        # id 0 must NOT be padding; id 42 must be padding.
+        input_ids = paddle.to_tensor([[1, 0, 42, 42], [3, 42, 5, 0]])
+        hidden = emb.forward({"input_ids": input_ids})["hidden_states"]
+        # id == 42 → zeroed
+        self.assertAlmostEqual(hidden[0, 2, 0].item(), 0.0)
+        self.assertAlmostEqual(hidden[0, 3, 0].item(), 0.0)
+        self.assertAlmostEqual(hidden[1, 1, 0].item(), 0.0)
+        # id == 0 → kept as 1.0
+        self.assertAlmostEqual(hidden[0, 1, 0].item(), 1.0)
+        self.assertAlmostEqual(hidden[1, 3, 0].item(), 1.0)
+
+    def test_forward_handles_none_pad_token_id(self):
+        """A runtime-None pad_token_id must fall back to 0 instead of crashing."""
+        emb, B, S, _ = self._make_emb(pad_token_id=None)
+        input_ids = paddle.to_tensor([[1, 2, 0, 0], [3, 0, 5, 0]])
+        # If the defensive fallback is missing, `input_ids == None` returns
+        # a Python bool and the fill_feature path would raise AttributeError.
+        hidden = emb.forward({"input_ids": input_ids})["hidden_states"]
+        # id == 0 still treated as padding via fallback.
+        self.assertAlmostEqual(hidden[0, 2, 0].item(), 0.0)
+        self.assertAlmostEqual(hidden[1, 1, 0].item(), 0.0)
+        self.assertAlmostEqual(hidden[0, 0, 0].item(), 1.0)
 
 
 if __name__ == "__main__":

--- a/tests/single_card_tests/test_transformer_config.py
+++ b/tests/single_card_tests/test_transformer_config.py
@@ -322,5 +322,17 @@ class TestMagicInit(unittest.TestCase):
             )
 
 
+class TestPadTokenId(unittest.TestCase):
+    """Tests for the pad_token_id field on TransformerConfig."""
+
+    def test_default_is_zero(self):
+        config = TransformerConfig(num_hidden_layers=2)
+        self.assertEqual(config.pad_token_id, 0)
+
+    def test_override_value(self):
+        config = TransformerConfig(num_hidden_layers=2, pad_token_id=151643)
+        self.assertEqual(config.pad_token_id, 151643)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/single_card_tests/transformer/test_mtp_magic_send.py
+++ b/tests/single_card_tests/transformer/test_mtp_magic_send.py
@@ -362,6 +362,64 @@ class TestMTPEmbeddingLayer(unittest.TestCase):
             ).item()
         )
 
+    def test_fill_feature_uses_custom_pad_token_id(self):
+        """When pad_token_id != 0, only that id triggers fill_feature zeroing."""
+        layer = MTPEmbeddingLayer(
+            config=_cfg(
+                vocab_size=1024,
+                hidden_size=64,
+                expert_model_parallel_size=4,
+                pad_token_id=42,
+            )
+        )
+        # Force non-zero weights so fill_feature's effect is observable
+        # (perform_initialization=False otherwise leaves weights at zero).
+        layer.embed_tokens.weight.set_value(
+            paddle.ones_like(layer.embed_tokens.weight)
+        )
+        # Position 1 holds id 0 (must remain non-zero), position 3 holds id 42 (must be zeroed).
+        ids = paddle.to_tensor([[5, 0, 7, 42, 9]])
+        input_ids_for_mtp.clear()
+        input_ids_for_mtp.append(ids)
+        result = layer.forward({"hidden_states": paddle.randn([1, 4, 64])})
+        embeds = result["mtp_input_embeds"]
+        self.assertTrue(
+            paddle.allclose(embeds[0, 3, :], paddle.zeros([64])).item()
+        )
+        # id == 0 must NOT be treated as padding when pad_token_id == 42.
+        self.assertFalse(
+            paddle.allclose(embeds[0, 1, :], paddle.zeros([64])).item()
+        )
+
+    def test_fill_feature_handles_none_pad_token_id(self):
+        """A runtime-None pad_token_id falls back to 0 instead of erroring."""
+        layer = MTPEmbeddingLayer(
+            config=_cfg(
+                vocab_size=1024, hidden_size=64, expert_model_parallel_size=4
+            )
+        )
+        # Override after construction to simulate external config injecting None.
+        layer.config.pad_token_id = None
+        layer.embed_tokens.weight.set_value(
+            paddle.ones_like(layer.embed_tokens.weight)
+        )
+        ids = paddle.to_tensor([[5, 0, 7, 8, 9]])
+        input_ids_for_mtp.clear()
+        input_ids_for_mtp.append(ids)
+        result = layer.forward({"hidden_states": paddle.randn([1, 4, 64])})
+        # Fallback treats id 0 as padding.
+        self.assertTrue(
+            paddle.allclose(
+                result["mtp_input_embeds"][0, 1, :], paddle.zeros([64])
+            ).item()
+        )
+        # id != 0 stays non-zero.
+        self.assertFalse(
+            paddle.allclose(
+                result["mtp_input_embeds"][0, 0, :], paddle.zeros([64])
+            ).item()
+        )
+
 
 class TestWrappedPaddleNormPipe(unittest.TestCase):
     def test_magic_send_vs_non_magic_send(self):

--- a/tests/single_card_tests/transformer/test_router.py
+++ b/tests/single_card_tests/transformer/test_router.py
@@ -767,5 +767,151 @@ class TestCalZLoss(unittest.TestCase):
         self.assertGreater(l_zloss.item(), 0.0)
 
 
+class TestPadTokenId(unittest.TestCase):
+    """Tests covering config.pad_token_id usage in TopKRouter / loss helpers."""
+
+    def setUp(self):
+        self.config = MockTransformerConfig()
+        self.config.topk_method = "noaux_tc"
+        patcher = patch(
+            "paddlefleet.transformer.moe.moe_router.get_context_parallel_world_size",
+            return_value=1,
+        )
+        self.mock_cp = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def _make_router(self):
+        return TopKRouter(self.config)
+
+    def test_default_pad_token_id_zero_masks_zero_ids(self):
+        """When pad_token_id defaults to 0, input_ids==0 are treated as padding."""
+        self.config.pad_token_id = 0
+        router = self._make_router()
+        paddle.seed(7)
+        hidden = paddle.randn([2, 4, self.config.hidden_size])
+        input_ids = paddle.to_tensor([[1, 2, 0, 0], [3, 4, 5, 0]])
+
+        _, _, top_idx, probs, mask, _, _, _ = router(
+            hidden, input_ids=input_ids
+        )
+        for p in [2, 3, 7]:
+            self.assertTrue((top_idx[p] == -1).all().item())
+            self.assertAlmostEqual(mask[p].sum().item(), 0.0)
+            self.assertAlmostEqual(probs[p].sum().item(), 0.0)
+        for p in [0, 1, 4, 5, 6]:
+            self.assertGreater(probs[p].sum().item(), 0.0)
+
+    def test_custom_pad_token_id_masks_only_that_id(self):
+        """Setting pad_token_id=99 masks tokens with id 99, not id 0."""
+        self.config.pad_token_id = 99
+        router = self._make_router()
+        paddle.seed(7)
+        hidden = paddle.randn([2, 4, self.config.hidden_size])
+        # Token id 0 must NOT be masked; id 99 must be masked.
+        input_ids = paddle.to_tensor([[1, 0, 99, 99], [2, 99, 3, 0]])
+
+        _, _, top_idx, probs, mask, _, _, _ = router(
+            hidden, input_ids=input_ids
+        )
+        # Padding flat positions where id == 99: 2, 3, 5
+        for p in [2, 3, 5]:
+            self.assertTrue((top_idx[p] == -1).all().item())
+            self.assertAlmostEqual(probs[p].sum().item(), 0.0)
+        # id == 0 positions (1, 7) are valid now.
+        for p in [0, 1, 4, 6, 7]:
+            self.assertGreater(probs[p].sum().item(), 0.0)
+
+    def test_missing_pad_token_id_attr_falls_back_to_zero(self):
+        """If config has no pad_token_id attribute, getattr fallback uses 0."""
+        # MockTransformerConfig defines no pad_token_id by default.
+        self.assertFalse(hasattr(self.config, "pad_token_id"))
+        router = self._make_router()
+        paddle.seed(7)
+        hidden = paddle.randn([2, 4, self.config.hidden_size])
+        input_ids = paddle.to_tensor([[1, 2, 0, 0], [3, 4, 5, 0]])
+
+        # Should not raise, and id==0 should still be masked.
+        _, _, top_idx, _, mask, _, _, _ = router(hidden, input_ids=input_ids)
+        for p in [2, 3, 7]:
+            self.assertTrue((top_idx[p] == -1).all().item())
+            self.assertAlmostEqual(mask[p].sum().item(), 0.0)
+
+    def test_none_pad_token_id_falls_back_to_zero(self):
+        """If config.pad_token_id is None at runtime, fallback uses 0 instead of erroring."""
+        self.config.pad_token_id = None
+        router = self._make_router()
+        paddle.seed(7)
+        hidden = paddle.randn([2, 4, self.config.hidden_size])
+        input_ids = paddle.to_tensor([[1, 2, 0, 0], [3, 4, 5, 0]])
+
+        # `input_ids == None` would otherwise return Python bool and crash;
+        # the defensive fallback must convert None to 0.
+        _, _, top_idx, _, mask, _, _, _ = router(hidden, input_ids=input_ids)
+        for p in [2, 3, 7]:
+            self.assertTrue((top_idx[p] == -1).all().item())
+            self.assertAlmostEqual(mask[p].sum().item(), 0.0)
+
+    def test_cal_seq_aux_loss_uses_pad_token_id(self):
+        """_cal_seq_aux_loss masks tokens equal to config.pad_token_id."""
+        self.config.pad_token_id = 7
+        self.config.topk_method = "greedy"
+        router = self._make_router()
+
+        seq_len = 4
+        n_e = self.config.n_routed_experts
+        k = self.config.num_experts_per_tok
+        probs = paddle.rand([seq_len, n_e])
+        routing_map = paddle.zeros([seq_len, n_e])
+        for i in range(seq_len):
+            for j in range(k):
+                routing_map[i, j] = 1.0
+
+        # All tokens valid (none equal to 7) → loss should be finite and > 0.
+        loss_no_pad = router._cal_seq_aux_loss(
+            probs,
+            k,
+            routing_map,
+            seq_len,
+            batch_size=1,
+            input_ids=paddle.to_tensor([1, 2, 3, 4]),
+        )
+        # With token id 7 marked as padding, denom shrinks.
+        loss_with_pad = router._cal_seq_aux_loss(
+            probs,
+            k,
+            routing_map,
+            seq_len,
+            batch_size=1,
+            input_ids=paddle.to_tensor([1, 2, 7, 7]),
+        )
+        self.assertEqual(loss_no_pad.shape, [])
+        self.assertEqual(loss_with_pad.shape, [])
+        # The two losses must differ (different effective denominator).
+        self.assertNotAlmostEqual(
+            loss_no_pad.item(), loss_with_pad.item(), places=4
+        )
+
+    def test_cal_z_loss_uses_pad_token_id(self):
+        """_cal_z_loss masks tokens equal to config.pad_token_id."""
+        self.config.pad_token_id = 9
+        self.config.topk_method = "greedy"
+        self.config.router_aux_loss_coef = 0.0
+        self.config.router_z_loss_coef = 0.01
+        router = self._make_router()
+
+        paddle.seed(11)
+        logits = paddle.randn([4, self.config.n_routed_experts])
+        # 2 tokens valid, 2 tokens are padding (id == 9).
+        input_ids = paddle.to_tensor([[1, 2, 9, 9]])
+        loss = router._cal_z_loss(logits, input_ids)
+
+        loss_mask = (input_ids != 9).astype(paddle.float32).reshape([-1])
+        denom = (input_ids != 9).astype(paddle.float32).sum()
+        expected = (
+            logits.logsumexp(1).square() * loss_mask
+        ).sum() / paddle.clip(denom, min=1e-6)
+        self.assertAlmostEqual(loss.item(), expected.item(), places=5)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION

<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Distributed Strategy

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
[CP]Add cudnn for spase attention

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否

支持手动设置pad token id


Cherry-pick of #1155 to `release/0.3`.

Merged in dev: #1155  <!-- For pass CI -->