### PR TITLE
Support mem_info with legacy allocator

### DIFF
--- a/src/paddlefleet/transformer/moe/fusion_layer_utils.py
+++ b/src/paddlefleet/transformer/moe/fusion_layer_utils.py
@@ -23,6 +23,7 @@ from paddlefleet.transformer.moe.fp8_utils import ExpertsGroupGemmContiguousNode
 
 from .fp8_utils import FP8_ALIGN, USE_INPLACE_SWIGLU_BWD, tilewise_quant
 from .vmm_utils import (
+    auto_subbatch_allocator_backend,
     find_max_concurrent_subbatch_size,
     find_max_sequence_subbatch_size,
     merge_subbatch_cast,
@@ -402,14 +403,6 @@ class MlpNode:
         self.use_fp8_mlp = use_fp8_mlp
         self.use_auto_subbatch = use_auto_subbatch
         self.moe_subbatch_diag = moe_subbatch_diag
-        if self.use_auto_subbatch:
-            (vmm_flag,) = paddle.framework.get_flags(
-                "FLAGS_use_virtual_memory_auto_growth"
-            ).values()
-            assert vmm_flag, (
-                "use_auto_subbatch requires FLAGS_use_virtual_memory_auto_growth=True"
-            )
-
         if self.moe_subbatch_token_num_after_dispatch is not None:
             self.min_auto_subbatch_rows = (
                 self.moe_subbatch_token_num_after_dispatch
@@ -1314,8 +1307,9 @@ class MlpNode:
 
         if self.moe_subbatch_diag:
             logger.info(
-                "[AutoSubbatch FWD] path=%s, total_tokens=%d, "
+                "[AutoSubbatch FWD] backend=%s, path=%s, total_tokens=%d, "
                 "subbatch_rows=%d, zip_unzip_fusion=%s",
+                auto_subbatch_allocator_backend(),
                 fwd_path,
                 num_unzipped_tokens,
                 subbatch_rows,
@@ -1620,8 +1614,9 @@ class MlpNode:
 
         if self.moe_subbatch_diag:
             logger.info(
-                "[AutoSubbatch BWD] path=%s, total_tokens=%d, "
+                "[AutoSubbatch BWD] backend=%s, path=%s, total_tokens=%d, "
                 "subbatch_rows=%d, zip_unzip_fusion=%s",
+                auto_subbatch_allocator_backend(),
                 bwd_path,
                 num_unzipped_tokens,
                 subbatch_rows,

--- a/src/paddlefleet/transformer/moe/vmm_utils.py
+++ b/src/paddlefleet/transformer/moe/vmm_utils.py
@@ -12,11 +12,97 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""VMM (Virtual Memory Management) utility functions for auto subbatch."""
+"""Memory block utility functions for auto subbatch."""
 
 import paddle
 import paddlefleet_ops
 from paddle.device.cuda.memory_analyzer import GB, MemoryAnalysisTool
+
+
+def _use_virtual_memory_auto_growth() -> bool:
+    """
+    Return whether Paddle VMM auto growth is enabled.
+    """
+    try:
+        (vmm_flag,) = paddle.framework.get_flags(
+            "FLAGS_use_virtual_memory_auto_growth"
+        ).values()
+    except Exception:
+        return False
+    return bool(vmm_flag)
+
+
+def _normalize_block_info(
+    block_info: list[list[tuple[int, int, bool]]] | list[tuple[int, int, bool]],
+) -> list[tuple[int, int, bool]]:
+    """
+    Normalize MemoryAnalysisTool block info to a flat list of (size, addr, free).
+    """
+    if not block_info:
+        return []
+
+    first = block_info[0]
+    if isinstance(first, tuple) and len(first) >= 3:
+        return list(block_info)
+
+    blocks = []
+    for heap in block_info:
+        if not heap:
+            continue
+        for block in heap:
+            if isinstance(block, tuple) and len(block) >= 3:
+                blocks.append(block)
+    return blocks
+
+
+def legacy_free_block_info() -> list[tuple[int, int]]:
+    """
+    获取老 allocator 当前已报告的 free block 信息。
+
+    与 VMM backend 不同，legacy backend 第一版只使用 all_block_info() 返回的
+    free blocks，不额外虚构未 reserved 显存对应的 growable block。
+    返回列表按照 block size 从小到大排序。
+    """
+    try:
+        all_blocks = _normalize_block_info(MemoryAnalysisTool.all_block_info())
+    except Exception:
+        return []
+    free_blocks = []
+    for block in all_blocks:
+        size, addr, free = block[:3]
+        if free and size > 0:
+            free_blocks.append((int(size), int(addr)))
+    free_blocks.sort()
+
+    return free_blocks
+
+
+def auto_subbatch_allocator_backend() -> str:
+    """
+    Return allocator backend name used by auto subbatch memory planning.
+    """
+    return "vmm" if _use_virtual_memory_auto_growth() else "legacy"
+
+
+def is_auto_subbatch_memory_analysis_available() -> bool:
+    """
+    Return whether auto subbatch has a memory block query backend available.
+    """
+    return _use_virtual_memory_auto_growth() or hasattr(
+        MemoryAnalysisTool, "all_block_info"
+    )
+
+
+def allocator_free_block_info() -> list[tuple[int, int]]:
+    """
+    获取当前 allocator 可用 free block 信息。
+
+    VMM 开启时保持原有 growable 语义；不开 VMM 时使用老 allocator 已报告的
+    free blocks，保持 conservative auto subbatch 行为。
+    """
+    if _use_virtual_memory_auto_growth():
+        return vmm_free_and_growable_block_info()
+    return legacy_free_block_info()
 
 
 def vmm_free_and_growable_block_info() -> list[tuple[int, int]]:
@@ -87,7 +173,7 @@ def find_max_concurrent_subbatch_size(
     if not feature_sizes or feature_sizes[0] == 0:
         return 1
 
-    free_blocks = vmm_free_and_growable_block_info()  # smallest first
+    free_blocks = allocator_free_block_info()  # smallest first
     if not free_blocks:
         return 0
 
@@ -151,7 +237,7 @@ def find_max_sequence_subbatch_size(feature_size: int, length: int = 1) -> int:
 
     如果不指定 length，相当于分析大小为 feature_size 的 Tensor 能否分配。
     """
-    free_blocks = vmm_free_and_growable_block_info()  # smallest first
+    free_blocks = allocator_free_block_info()  # smallest first
 
     def can_pack(subbatch_size):
         num_subbatches = (length + subbatch_size - 1) // subbatch_size

--- a/tests/single_card_tests/test_moe_auto_subbatch_deep_gemm_non_vmm.py
+++ b/tests/single_card_tests/test_moe_auto_subbatch_deep_gemm_non_vmm.py
@@ -1,0 +1,489 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Single-card unit tests for auto_subbatch with moe_deep_gemm=True and VMM disabled.
+
+Tests auto_subbatch fallback correctness with the legacy allocator when using
+GroupedMLPExpert (stacked weights) instead of per-expert weight lists.
+
+Run with:
+  python tests/single_card_tests/test_moe_auto_subbatch_deep_gemm_non_vmm.py
+"""
+
+import contextlib
+import logging
+import os
+import unittest
+
+import numpy as np
+
+os.environ["FLAGS_use_virtual_memory_auto_growth"] = "False"
+os.environ["FLAGS_cudnn_deterministic"] = "True"
+
+from types import SimpleNamespace
+
+import paddle
+from paddle import nn
+from paddle.device.cuda.memory_analyzer import MemoryAnalysisTool
+
+from paddlefleet.tensor_parallel.random import model_parallel_cuda_manual_seed
+from paddlefleet.transformer.moe.fp8_utils import (
+    fused_stack_quant_without_cache,
+    tilewise_quant,
+)
+from paddlefleet.transformer.moe.fusion_layer_utils import (
+    FusionMoePyLayer,
+    MlpNode,
+)
+from paddlefleet.transformer.moe.moe_expert import GroupedMLPExpert
+from paddlefleet.transformer.transformer_config import TransformerConfig
+
+# hack: lower min_auto_subbatch_rows so small seq_len can trigger multi-chunk subbatch
+_orig_mlpnode_init = MlpNode.__init__
+
+
+def _patched_mlpnode_init(self, *args, **kwargs):
+    _orig_mlpnode_init(self, *args, **kwargs)
+    self.min_auto_subbatch_rows = 256
+
+
+MlpNode.__init__ = _patched_mlpnode_init
+
+
+class FakeDeepGemmMOELayer(nn.Layer):
+    """
+    A mock MoE layer for deep_gemm mode using GroupedMLPExpert (stacked weights).
+
+    In deep_gemm mode, MoELayer creates grouped_gemm_experts instead of per-expert list.
+    This fake layer mimics that structure.
+    """
+
+    def __init__(
+        self,
+        hidden_size,
+        intermediate_size,
+        n_routed_experts,
+        tokens_per_expert,
+    ):
+        super().__init__()
+        config = TransformerConfig(
+            hidden_size=hidden_size,
+            moe_intermediate_size=intermediate_size,
+            gated_linear_unit=True,
+        )
+        self.grouped_gemm_experts = GroupedMLPExpert(
+            num_local_experts=n_routed_experts,
+            config=config,
+            moe_deep_gemm=True,
+        )
+        # Initialize weights with small random values for numerical stability
+        with paddle.no_grad():
+            self.grouped_gemm_experts.weight1.set_value(
+                paddle.randn(
+                    self.grouped_gemm_experts.weight1.shape, dtype="bfloat16"
+                )
+                * 0.01
+            )
+            self.grouped_gemm_experts.weight2.set_value(
+                paddle.randn(
+                    self.grouped_gemm_experts.weight2.shape, dtype="bfloat16"
+                )
+                * 0.01
+            )
+        self.token_dispatcher = SimpleNamespace(
+            _comm_manager=SimpleNamespace(
+                tokens_per_expert=tokens_per_expert,
+            ),
+        )
+        # deep_gemm mode has no per-expert list
+        self.experts = None
+
+    def clear_main_grad(self):
+        self.grouped_gemm_experts.weight1.main_grad = None
+        self.grouped_gemm_experts.weight2.main_grad = None
+
+    def fp8_quant_weight(self, quant_transpose=True):
+        """Simulate FP8QuantWeightCallback: quant bf16 weights to fp8 stacked tensors."""
+        w1 = self.grouped_gemm_experts.weight1
+        w2 = self.grouped_gemm_experts.weight2
+        local_expert_num = w1.shape[0]
+        w1_list = [w1[i, :, :] for i in range(local_expert_num)]
+        w2_list = [w2[i, :, :] for i in range(local_expert_num)]
+
+        # Non-transpose version
+        fp8_w1, fp8_s1 = fused_stack_quant_without_cache(
+            w1_list, transpose=False
+        )
+        w1.fp8_weight_stacked = fp8_w1
+        w1.fp8_scale_stacked = fp8_s1
+
+        fp8_w2, fp8_s2 = fused_stack_quant_without_cache(
+            w2_list, transpose=False
+        )
+        w2.fp8_weight_stacked = fp8_w2
+        w2.fp8_scale_stacked = fp8_s2
+
+        # Transpose version
+        if quant_transpose:
+            fp8_w1_t, fp8_s1_t = fused_stack_quant_without_cache(
+                w1_list, transpose=True
+            )
+            w1.fp8_weight_stacked_transpose = fp8_w1_t
+            w1.fp8_scale_stacked_transpose = fp8_s1_t
+
+            fp8_w2_t, fp8_s2_t = fused_stack_quant_without_cache(
+                w2_list, transpose=True
+            )
+            w2.fp8_weight_stacked_transpose = fp8_w2_t
+            w2.fp8_scale_stacked_transpose = fp8_s2_t
+        else:
+            w1.fp8_weight_stacked_transpose = None
+            w1.fp8_scale_stacked_transpose = None
+            w2.fp8_weight_stacked_transpose = None
+            w2.fp8_scale_stacked_transpose = None
+
+    def clear_weight_storage(self):
+        """Simulate optimizer.clear_param_storage: clear bf16 weight memory."""
+        self.grouped_gemm_experts.weight1._clear_to_zero_allocation()
+        self.grouped_gemm_experts.weight2._clear_to_zero_allocation()
+
+
+@contextlib.contextmanager
+def legacy_no_free_space():
+    """Mock legacy allocator free blocks as empty to simulate tight memory."""
+    old_all_block_info = MemoryAnalysisTool.all_block_info
+    MemoryAnalysisTool.all_block_info = lambda: [[]]
+    try:
+        yield
+    finally:
+        MemoryAnalysisTool.all_block_info = old_all_block_info
+
+
+class TestAutoSubbatchDeepGemm(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        (vmm_enabled,) = paddle.framework.get_flags(
+            "FLAGS_use_virtual_memory_auto_growth"
+        ).values()
+        print(
+            "[test_moe_auto_subbatch_deep_gemm_non_vmm] "
+            f"FLAGS_use_virtual_memory_auto_growth={vmm_enabled}"
+        )
+        model_parallel_cuda_manual_seed(1234)
+        cls.seq_len = 1024
+        cls.topk = 4
+        cls.hidden_size = 4096
+        cls.intermediate_size = 1536
+        cls.n_routed_experts = 8
+
+    def setUp(self):
+        paddle.seed(2026)
+        np.random.seed(2026)
+
+        hidden_states = paddle.randn(
+            [self.seq_len, self.hidden_size], "bfloat16"
+        )
+        hidden_states_out_grad = paddle.randn_like(hidden_states)
+        hidden_states, scale = tilewise_quant(hidden_states)
+        probs = paddle.randn([self.seq_len, self.topk])
+        hidden_states.stop_gradient = False
+        probs.stop_gradient = False
+
+        self.hidden_states = hidden_states
+        self.hidden_states_out_grad = hidden_states_out_grad
+        self.scale = scale
+        self.probs = probs
+
+        # Each token is assigned 1 to topk experts, always including expert 0
+        indices_np = np.full([self.seq_len, self.topk], -1, dtype=np.int64)
+        tokens_per_expert = [0] * self.n_routed_experts
+        for i in range(self.seq_len):
+            chosen = np.array([0])
+            n_active = np.random.randint(self.topk)
+            if n_active > 0:
+                chosen = np.append(
+                    chosen,
+                    np.random.choice(
+                        self.n_routed_experts - 1,
+                        size=n_active,
+                        replace=False,
+                    )
+                    + 1,
+                )
+            indices_np[i, : n_active + 1] = np.sort(chosen)
+            for expert_id in chosen:
+                tokens_per_expert[expert_id] += 1
+        self.indices = paddle.to_tensor(indices_np)
+
+        moe_layer = FakeDeepGemmMOELayer(
+            self.hidden_size,
+            self.intermediate_size,
+            self.n_routed_experts,
+            tokens_per_expert,
+        )
+        moe_layer = paddle.amp.decorate(moe_layer, level="O2", dtype="bfloat16")
+        moe_layer.clear_main_grad()
+        self.moe_layer = moe_layer
+
+    def run_moe_layer(
+        self, is_ref=False, tight_forward=False, tight_backward=False, **kwargs
+    ):
+        params = {
+            "use_fp8_mlp": True,
+            "moe_deep_gemm": True,
+            "recompute_moe_gate_up": False,
+            "dequant_input": True,
+            "moe_expert_fusion": True,
+            "recompute_moe_premute": False,
+            "use_bf16_gemm_weight_grad": True,
+            "fp8_dispatched_handle": {"scale": self.scale},
+            "use_auto_subbatch": not is_ref,
+            "moe_subbatch_diag": True,
+        }
+        params.update(kwargs)
+
+        with (
+            legacy_no_free_space()
+            if tight_forward
+            else contextlib.nullcontext()
+        ):
+            hidden_states = FusionMoePyLayer.apply(
+                self.hidden_states,
+                self.probs,
+                self.indices.clone(),
+                self.moe_layer,
+                self.topk,
+                **params,
+            )
+
+        with (
+            legacy_no_free_space()
+            if tight_backward
+            else contextlib.nullcontext()
+        ):
+            paddle.autograd.backward(hidden_states, self.hidden_states_out_grad)
+
+        hidden_states_grad = self.hidden_states.grad
+        probs_grad = self.probs.grad
+        self.hidden_states.clear_grad()
+        self.probs.clear_grad()
+
+        weight_grad = self.moe_layer.grouped_gemm_experts.weight2.main_grad
+        self.moe_layer.clear_main_grad()
+
+        return hidden_states, hidden_states_grad, probs_grad, weight_grad
+
+    def compare_results(self, ref_out, tgt_out):
+        names = [
+            "hidden_states",
+            "hidden_states_grad",
+            "probs_grad",
+            "weight_grad",
+        ]
+        # First three must be bitwise equal; weight_grad allows FP8 accumulation order diff
+        tolerances = {
+            "weight_grad": {"atol": 1e-4, "rtol": 1e-5},
+        }
+        for i, name in enumerate(names):
+            ref_np = ref_out[i].float().numpy()
+            tgt_np = tgt_out[i].float().numpy()
+            tol = tolerances.get(name)
+            if tol is None:
+                np.testing.assert_equal(ref_np, tgt_np, err_msg=name)
+            else:
+                diff = np.abs(ref_np - tgt_np)
+                max_diff = diff.max()
+                if max_diff > tol["atol"]:
+                    # Print top diffs on failure for debugging
+                    flat = diff.flatten()
+                    top_idx = np.argsort(flat)[-10:][::-1]
+                    lines = [
+                        f"\n=== {name} FAILED: max_abs_diff={max_diff:.6g} ==="
+                    ]
+                    for rank, idx in enumerate(top_idx):
+                        coords = np.unravel_index(idx, ref_np.shape)
+                        lines.append(
+                            f"  #{rank} {coords} ref={ref_np.flat[idx]:.6g}, "
+                            f"tgt={tgt_np.flat[idx]:.6g}, diff={flat[idx]:.6g}"
+                        )
+                    self.fail("\n".join(lines))
+                np.testing.assert_allclose(ref_np, tgt_np, **tol, err_msg=name)
+
+    def test_auto_subbatch_deep_gemm_no_recompute(self):
+        """deep_gemm + no_recompute: auto_subbatch vs group_gemm reference"""
+        ref_out = self.run_moe_layer(is_ref=True)
+
+        cases = {}
+        kwargs = {"recompute_moe_gate_up": False}
+
+        logging.info("case1 (deep_gemm, plenty)")
+        cases["case1 (plenty)"] = self.run_moe_layer(**kwargs)
+        logging.info("case2 (deep_gemm, tight_fwd)")
+        cases["case2 (tight_fwd)"] = self.run_moe_layer(
+            tight_forward=True, **kwargs
+        )
+
+        logging.info("case3 (deep_gemm, tight_bwd)")
+        cases["case3 (tight_bwd)"] = self.run_moe_layer(
+            tight_backward=True, **kwargs
+        )
+        logging.info("case4 (deep_gemm, tight_both)")
+        cases["case4 (tight_both)"] = self.run_moe_layer(
+            tight_forward=True, tight_backward=True, **kwargs
+        )
+
+        for name, result in cases.items():
+            with self.subTest(case=name):
+                self.compare_results(ref_out, result)
+
+    def test_auto_subbatch_deep_gemm_recompute(self):
+        """deep_gemm + recompute_moe_gate_up: auto_subbatch vs group_gemm reference"""
+        ref_out = self.run_moe_layer(is_ref=True, recompute_moe_gate_up=True)
+
+        cases = {}
+        kwargs = {"recompute_moe_gate_up": True}
+
+        logging.info("case5 (deep_gemm recompute, plenty)")
+        cases["case5 (plenty)"] = self.run_moe_layer(**kwargs)
+        logging.info("case6 (deep_gemm recompute, tight_fwd)")
+        cases["case6 (tight_fwd)"] = self.run_moe_layer(
+            tight_forward=True, **kwargs
+        )
+
+        logging.info("case7 (deep_gemm recompute, tight_bwd)")
+        cases["case7 (tight_bwd)"] = self.run_moe_layer(
+            tight_backward=True, **kwargs
+        )
+        logging.info("case8 (deep_gemm recompute, tight_both)")
+        cases["case8 (tight_both)"] = self.run_moe_layer(
+            tight_forward=True, tight_backward=True, **kwargs
+        )
+
+        for name, result in cases.items():
+            with self.subTest(case=name):
+                self.compare_results(ref_out, result)
+
+    def test_auto_subbatch_deep_gemm_offline_quant(self):
+        """deep_gemm + offline fp8 quant + clear bf16 weight: simulates FP8QuantWeightCallback.
+
+        After offline quant, bf16 weight memory is cleared (memory_size=0).
+        Forward/backward must work using only fp8_weight_stacked attributes.
+        """
+        # First get reference output BEFORE clearing weight
+        ref_out = self.run_moe_layer(is_ref=True)
+
+        # Now simulate FP8QuantWeightCallback: quant + clear bf16
+        self.moe_layer.fp8_quant_weight(quant_transpose=False)
+        self.moe_layer.clear_weight_storage()
+
+        cases = {}
+        # no recompute
+        kwargs = {"recompute_moe_gate_up": False}
+
+        logging.info("case9 (offline_quant, plenty)")
+        cases["case9 (plenty)"] = self.run_moe_layer(**kwargs)
+        logging.info("case10 (offline_quant, tight_fwd)")
+        cases["case10 (tight_fwd)"] = self.run_moe_layer(
+            tight_forward=True, **kwargs
+        )
+        logging.info("case11 (offline_quant, tight_bwd)")
+        cases["case11 (tight_bwd)"] = self.run_moe_layer(
+            tight_backward=True, **kwargs
+        )
+        logging.info("case12 (offline_quant, tight_both)")
+        cases["case12 (tight_both)"] = self.run_moe_layer(
+            tight_forward=True, tight_backward=True, **kwargs
+        )
+
+        # with recompute
+        kwargs_rc = {"recompute_moe_gate_up": True}
+
+        logging.info("case9r (offline_quant+recompute, plenty)")
+        cases["case9r (plenty)"] = self.run_moe_layer(**kwargs_rc)
+        logging.info("case10r (offline_quant+recompute, tight_fwd)")
+        cases["case10r (tight_fwd)"] = self.run_moe_layer(
+            tight_forward=True, **kwargs_rc
+        )
+        logging.info("case11r (offline_quant+recompute, tight_bwd)")
+        cases["case11r (tight_bwd)"] = self.run_moe_layer(
+            tight_backward=True, **kwargs_rc
+        )
+        logging.info("case12r (offline_quant+recompute, tight_both)")
+        cases["case12r (tight_both)"] = self.run_moe_layer(
+            tight_forward=True, tight_backward=True, **kwargs_rc
+        )
+
+        for name, result in cases.items():
+            with self.subTest(case=name):
+                self.compare_results(ref_out, result)
+
+    def test_auto_subbatch_deep_gemm_offline_quant_transpose(self):
+        """deep_gemm + offline fp8 quant with quant_transpose=True + clear bf16 weight.
+
+        When quant_transpose=True, fp8_weight_stacked_transpose is pre-computed.
+        The per-expert fallback should use the pre-computed transpose directly.
+        """
+        # First get reference output BEFORE clearing weight
+        ref_out = self.run_moe_layer(is_ref=True)
+
+        # Simulate FP8QuantWeightCallback with quant_transpose=True
+        self.moe_layer.fp8_quant_weight(quant_transpose=True)
+        self.moe_layer.clear_weight_storage()
+
+        cases = {}
+        # no recompute
+        kwargs = {"recompute_moe_gate_up": False}
+
+        logging.info("case13 (offline_quant_transpose, plenty)")
+        cases["case13 (plenty)"] = self.run_moe_layer(**kwargs)
+        logging.info("case14 (offline_quant_transpose, tight_fwd)")
+        cases["case14 (tight_fwd)"] = self.run_moe_layer(
+            tight_forward=True, **kwargs
+        )
+        logging.info("case15 (offline_quant_transpose, tight_bwd)")
+        cases["case15 (tight_bwd)"] = self.run_moe_layer(
+            tight_backward=True, **kwargs
+        )
+        logging.info("case16 (offline_quant_transpose, tight_both)")
+        cases["case16 (tight_both)"] = self.run_moe_layer(
+            tight_forward=True, tight_backward=True, **kwargs
+        )
+
+        # with recompute
+        kwargs_rc = {"recompute_moe_gate_up": True}
+
+        logging.info("case13r (offline_quant_transpose+recompute, plenty)")
+        cases["case13r (plenty)"] = self.run_moe_layer(**kwargs_rc)
+        logging.info("case14r (offline_quant_transpose+recompute, tight_fwd)")
+        cases["case14r (tight_fwd)"] = self.run_moe_layer(
+            tight_forward=True, **kwargs_rc
+        )
+        logging.info("case15r (offline_quant_transpose+recompute, tight_bwd)")
+        cases["case15r (tight_bwd)"] = self.run_moe_layer(
+            tight_backward=True, **kwargs_rc
+        )
+        logging.info("case16r (offline_quant_transpose+recompute, tight_both)")
+        cases["case16r (tight_both)"] = self.run_moe_layer(
+            tight_forward=True, tight_backward=True, **kwargs_rc
+        )
+
+        for name, result in cases.items():
+            with self.subTest(case=name):
+                self.compare_results(ref_out, result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/test_moe_auto_subbatch_non_vmm.py
+++ b/tests/single_card_tests/test_moe_auto_subbatch_non_vmm.py
@@ -1,0 +1,554 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Single-card unit tests for auto_subbatch functionality with VMM disabled.
+
+Tests:
+  1. test_auto_subbatch_vs_ref: Compare auto_subbatch results against group_gemm reference.
+     - case1-4: split_gemm + selective_recompute (moe_expert_fusion=False),
+                varying tight_forward/tight_backward combinations.
+     - case5-7: group_gemm + selective_recompute (Level 0, moe_expert_fusion=True),
+                varying tight_forward/tight_backward combinations.
+     - case8-10: group_gemm + full_recompute (Level 0, fp8_quant_weight 预量化),
+                 varying tight_forward/tight_backward combinations.
+  2. test_legacy_utils: Unit tests for legacy allocator utility functions.
+
+Note: Ordinary (non-auto) subbatch tests are in test_moe_subbatch.py.
+
+Run with:
+  python tests/single_card_tests/test_moe_auto_subbatch_non_vmm.py
+"""
+
+import contextlib
+import logging
+import os
+import unittest
+
+import numpy as np
+
+os.environ["FLAGS_use_virtual_memory_auto_growth"] = "False"
+os.environ["FLAGS_cudnn_deterministic"] = "True"
+
+from types import SimpleNamespace
+
+import paddle
+from paddle import nn
+from paddle.device.cuda.memory_analyzer import MemoryAnalysisTool
+
+from paddlefleet.tensor_parallel.layers import (
+    ColumnParallelLinear,
+    RowParallelLinear,
+)
+from paddlefleet.tensor_parallel.random import model_parallel_cuda_manual_seed
+from paddlefleet.transformer.mlp import MLPSublayersSpec
+from paddlefleet.transformer.moe.fp8_utils import tilewise_quant
+from paddlefleet.transformer.moe.fusion_layer_utils import FusionMoePyLayer
+from paddlefleet.transformer.moe.moe_expert import StandardMLPExpert
+from paddlefleet.transformer.moe.moe_layer import MoELayer
+from paddlefleet.transformer.moe.vmm_utils import (
+    allocator_free_block_info,
+    auto_subbatch_allocator_backend,
+    find_max_concurrent_subbatch_size,
+    find_max_sequence_subbatch_size,
+    is_auto_subbatch_memory_analysis_available,
+    legacy_free_block_info,
+)
+from paddlefleet.transformer.transformer_config import TransformerConfig
+
+
+class FakeMOELayer(nn.Layer):
+    """
+    A mock MoE layer that provides the interface expected by FusionMoePyLayer.
+
+    Uses StandardMLPExpert (native PaddleFleet expert) for realistic testing.
+
+    Required attributes:
+      - self.experts: nn.LayerList of expert modules
+      - self.token_dispatcher._comm_manager.tokens_per_expert: list[int]
+    """
+
+    def __init__(
+        self,
+        hidden_size,
+        intermediate_size,
+        n_routed_experts,
+        tokens_per_expert,
+    ):
+        super().__init__()
+        config = TransformerConfig(
+            hidden_size=hidden_size,
+            gated_linear_unit=True,
+        )
+        mlp_spec = MLPSublayersSpec(
+            up_gate_proj=ColumnParallelLinear,
+            down_proj=RowParallelLinear,
+        )
+        self.experts = nn.LayerList(
+            [
+                StandardMLPExpert(
+                    config,
+                    moe_intermediate_size=intermediate_size,
+                    is_expert=True,
+                    mlp_spec=mlp_spec,
+                )
+                for _ in range(n_routed_experts)
+            ]
+        )
+        self.token_dispatcher = SimpleNamespace(
+            _comm_manager=SimpleNamespace(
+                tokens_per_expert=tokens_per_expert,
+            ),
+        )
+
+    def clear_main_grad(self):
+        for expert in self.experts:
+            expert.up_gate_proj.weight.main_grad = None
+            expert.down_proj.weight.main_grad = None
+
+    def fp8_quant_weight(self, batch_mode=False, quant_transpose=True):
+        """借用 MoELayer 的实现，对 expert 权重做 FP8 预量化。"""
+        # MoELayer.fp8_quant_weight 检查 self.moe_use_fusion_node and self.fp8
+        self.moe_use_fusion_node = True
+        self.fp8 = True
+        self.use_ue8m0 = False
+        MoELayer.fp8_quant_weight(
+            self, batch_mode=batch_mode, quant_transpose=quant_transpose
+        )
+
+
+@contextlib.contextmanager
+def legacy_no_free_space():
+    """Mock legacy allocator free blocks as empty to simulate tight memory."""
+    old_all_block_info = MemoryAnalysisTool.all_block_info
+    MemoryAnalysisTool.all_block_info = lambda: [[]]
+    try:
+        yield
+    finally:
+        MemoryAnalysisTool.all_block_info = old_all_block_info
+
+
+class TestAutoSubbatch(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """设置默认配置"""
+        (vmm_enabled,) = paddle.framework.get_flags(
+            "FLAGS_use_virtual_memory_auto_growth"
+        ).values()
+        print(
+            "[test_moe_auto_subbatch] "
+            f"FLAGS_use_virtual_memory_auto_growth={vmm_enabled}"
+        )
+        model_parallel_cuda_manual_seed(1234)
+        cls.seq_len = 1000
+        cls.topk = 4
+        cls.hidden_size = 4096
+        cls.intermediate_size = 1536
+        cls.n_routed_experts = 8
+
+    def setUp(self):
+        """创建测试层和输入数据"""
+        paddle.seed(2026)
+        np.random.seed(2026)
+
+        hidden_states = paddle.randn(
+            [self.seq_len, self.hidden_size], "bfloat16"
+        )
+        hidden_states_out_grad = paddle.randn_like(hidden_states)
+        hidden_states, scale = tilewise_quant(hidden_states)
+        probs = paddle.randn([self.seq_len, self.topk])
+        hidden_states.stop_gradient = False
+        probs.stop_gradient = False
+
+        self.hidden_states = hidden_states
+        self.hidden_states_out_grad = hidden_states_out_grad
+        self.scale = scale
+        self.probs = probs
+
+        # 每个 token 随机分配 1 到 topk 个专家，但总是包括专家0，给专家0增加压力
+        indices_np = np.full([self.seq_len, self.topk], -1, dtype=np.int64)
+        tokens_per_expert = [0] * self.n_routed_experts
+        for i in range(self.seq_len):
+            chosen = np.array([0])
+            n_active = np.random.randint(self.topk)
+            if n_active > 0:
+                chosen = np.append(
+                    chosen,
+                    np.random.choice(
+                        self.n_routed_experts - 1,
+                        size=n_active,
+                        replace=False,
+                    )
+                    + 1,
+                )
+            indices_np[i, : n_active + 1] = np.sort(chosen)
+            for expert_id in chosen:
+                tokens_per_expert[expert_id] += 1
+        self.indices = paddle.to_tensor(indices_np)
+
+        moe_layer = FakeMOELayer(
+            self.hidden_size,
+            self.intermediate_size,
+            self.n_routed_experts,
+            tokens_per_expert,
+        )
+        moe_layer = paddle.amp.decorate(moe_layer, level="O2", dtype="bfloat16")
+        moe_layer.clear_main_grad()
+        self.moe_layer = moe_layer
+
+    def run_moe_layer(
+        self, is_ref=False, tight_forward=False, tight_backward=False, **kwargs
+    ):
+        params = {
+            "use_fp8_mlp": True,
+            "moe_deep_gemm": False,
+            "recompute_moe_gate_up": True,
+            "dequant_input": True,
+            "moe_expert_fusion": is_ref,
+            "recompute_moe_premute": False,
+            "use_bf16_gemm_weight_grad": True,
+            "fp8_dispatched_handle": {"scale": self.scale},
+            "use_auto_subbatch": not is_ref,
+            "moe_subbatch_diag": True,
+        }
+        params.update(kwargs)
+
+        with (
+            legacy_no_free_space()
+            if tight_forward
+            else contextlib.nullcontext()
+        ):
+            hidden_states = FusionMoePyLayer.apply(
+                self.hidden_states,
+                self.probs,
+                self.indices.clone(),
+                self.moe_layer,
+                self.topk,
+                **params,
+            )
+
+        with (
+            legacy_no_free_space()
+            if tight_backward
+            else contextlib.nullcontext()
+        ):
+            paddle.autograd.backward(hidden_states, self.hidden_states_out_grad)
+
+        hidden_states_grad = self.hidden_states.grad
+        probs_grad = self.probs.grad
+        self.hidden_states.clear_grad()
+        self.probs.clear_grad()
+
+        # 专家0最大，只要检查专家0的 weight_grad 即可
+        weight_grad = self.moe_layer.experts[0].down_proj.weight.main_grad
+        self.moe_layer.clear_main_grad()
+
+        return hidden_states, hidden_states_grad, probs_grad, weight_grad
+
+    def compare_results(self, ref_out, tgt_out, loose_weight=False):
+        for i, name in enumerate(
+            ["hidden_states", "hidden_states_grad", "probs_grad"]
+        ):
+            np.testing.assert_equal(
+                ref_out[i].float().numpy(),
+                tgt_out[i].float().numpy(),
+                name,
+            )
+        i = 3  # weight_grad
+        if loose_weight:
+            np.testing.assert_allclose(
+                ref_out[i].numpy(),
+                tgt_out[i].numpy(),
+                atol=3e-4,
+                rtol=1e-4,
+            )
+        else:
+            np.testing.assert_equal(ref_out[i].numpy(), tgt_out[i].numpy())
+
+    def test_auto_subbatch_vs_ref(self):
+        """测试 auto_subbatch 的多种情况与 group_gemm 是否对齐"""
+        logging.info("baseline group_gemm")
+        # group_gemm (reference, no auto_subbatch)
+        ref_out = self.run_moe_layer(is_ref=True)
+
+        cases = {}
+
+        # --- group_gemm + no_recompute (moe_expert_fusion=False) ---
+        kwargs = {
+            "moe_expert_fusion": True,
+            "recompute_moe_premute": False,
+            "recompute_moe_gate_up": False,
+        }
+
+        logging.info("case1 (group, plenty)")
+        # case1: 显存充裕
+        cases["case1 (group, plenty)"] = self.run_moe_layer(**kwargs)
+        # case2: 前向紧张
+        logging.info("case2 (group, tight_fwd)")
+        cases["case2 (group, tight_fwd)"] = self.run_moe_layer(
+            tight_forward=True, **kwargs
+        )
+        # case3: 反向紧张
+        logging.info("case3 (group, tight_bwd)")
+        cases["case3 (group, tight_bwd)"] = self.run_moe_layer(
+            tight_backward=True, **kwargs
+        )
+        # case4: 前向+反向都紧张
+        logging.info("case4 (group, tight_both)")
+        cases["case4 (group, tight_both)"] = self.run_moe_layer(
+            tight_forward=True, tight_backward=True, **kwargs
+        )
+
+        kwargs = {
+            "moe_expert_fusion": True,
+            "recompute_moe_premute": False,
+            "recompute_moe_gate_up": True,
+            # "recompute_unzipped": True,
+        }
+        # --- group_gemm + selective_recompute (recompute_moe_gate_up)---
+        # case5: 显存充裕 → 走 3a group_gemm
+        logging.info("case5 (recompute_moe_gate_up, group, plenty)")
+        cases["case5 (group, plenty)"] = self.run_moe_layer(**kwargs)
+        # case6: 前向紧张 → fallback 到逐专家
+        logging.info("case6 (recompute_moe_gate_up, group, tight_fwd)")
+        cases["case6 (group, tight_fwd)"] = self.run_moe_layer(
+            tight_forward=True, **kwargs
+        )
+        # case7: 反向紧张 → 前向 3a, 反向 fallback
+        logging.info("case7 (recompute_moe_gate_up, group, tight_bwd)")
+        cases["case7 (group, tight_bwd)"] = self.run_moe_layer(
+            tight_backward=True, **kwargs
+        )
+        # case8: 向+反向都紧张, fallback
+        logging.info("case8 (recompute_moe_gate_up, group, tight_both)")
+        cases["case8 (group, tight_both)"] = self.run_moe_layer(
+            tight_forward=True, tight_backward=True, **kwargs
+        )
+
+        # --- group_gemm + selective_recompute (recompute_moe_gate_up + recompute_moe_premute) ---
+        # when recompute_moe_premute is True. recompute_moe_gate_up must be true
+        kwargs = {
+            "moe_expert_fusion": True,
+            "recompute_moe_premute": False,
+            "recompute_moe_gate_up": False,
+        }
+        # case9: 显存充裕 → 走 3a group_gemm
+        logging.info(
+            "case9 (recompute_moe_gate_up,recompute_moe_premute, group, plenty)"
+        )
+        cases["case9 (group, plenty)"] = self.run_moe_layer(**kwargs)
+        # case10: 前向紧张 → fallback 到逐专家
+        cases["case10 (group, tight_fwd)"] = self.run_moe_layer(
+            tight_forward=True, **kwargs
+        )
+        # case11: 反向紧张 → 前向 3a, 反向 fallback
+        logging.info(
+            "case11 (recompute_moe_gate_up,recompute_moe_premute, group, tight_bwd)"
+        )
+        cases["case11 (group, tight_bwd)"] = self.run_moe_layer(
+            tight_backward=True, **kwargs
+        )
+        # case12: 向+反向都紧张, fallback
+        logging.info(
+            "case12 (recompute_moe_gate_up,recompute_moe_premute, group, tight_both)"
+        )
+        cases["case12 (group, tight_both)"] = self.run_moe_layer(
+            tight_forward=True, tight_backward=True, **kwargs
+        )
+
+        # split gemm + no moe_subbatch_token_num_after_dispatch ---
+        kwargs = {
+            "moe_expert_fusion": False,
+            "recompute_moe_premute": False,
+            "recompute_moe_gate_up": False,
+        }
+        # case13: 显存充裕 → 走 3a group_gemm
+        logging.info("case13 (split, plenty)")
+        cases["case13 (split, plenty)"] = self.run_moe_layer(**kwargs)
+        # case14: 前向紧张 → fallback 到逐专家
+        logging.info("case14 (split, tight_fwd)")
+        cases["case14 (split, tight_fwd)"] = self.run_moe_layer(
+            tight_forward=True, **kwargs
+        )
+        # case15: 反向紧张 → 前向 3a, 反向 fallback
+        logging.info("case15 (split, tight_bwd)")
+        cases["case15 (split, tight_bwd)"] = self.run_moe_layer(
+            tight_backward=True, **kwargs
+        )
+        # case16: 向+反向都紧张, fallback
+        logging.info("case16 (split, tight_both)")
+        cases["case16 (split, tight_both)"] = self.run_moe_layer(
+            tight_forward=True, tight_backward=True, **kwargs
+        )
+
+        # split gemm + moe_subbatch_token_num_after_dispatch 512 ---
+        kwargs = {
+            "moe_expert_fusion": False,
+            "recompute_moe_premute": False,
+            "recompute_moe_gate_up": True,
+            "moe_subbatch_token_num_after_dispatch": 512,
+        }
+        # case13: 显存充裕 → 走 3a group_gemm
+        logging.info("case13 (split, plenty)")
+        cases["case13 (split, plenty)"] = self.run_moe_layer(**kwargs)
+        # case14: 前向紧张 → fallback 到逐专家
+        logging.info("case14 (split, tight_fwd)")
+        cases["case14 (split, tight_fwd)"] = self.run_moe_layer(
+            tight_forward=True, **kwargs
+        )
+        # case15: 反向紧张 → 前向 3a, 反向 fallback
+        logging.info("case15 (split, tight_bwd)")
+        cases["case15 (split, tight_bwd)"] = self.run_moe_layer(
+            tight_backward=True, **kwargs
+        )
+        # case16: 向+反向都紧张, fallback
+        logging.info("case16 (split, tight_both)")
+        cases["case16 (split, tight_both)"] = self.run_moe_layer(
+            tight_forward=True, tight_backward=True, **kwargs
+        )
+
+        # group gemm + 预量化
+        kwargs = {
+            "moe_expert_fusion": True,
+            "recompute_moe_premute": False,
+            "recompute_moe_gate_up": False,
+        }
+        self.moe_layer.fp8_quant_weight(batch_mode=True, quant_transpose=False)
+        logging.info("case17 (group, plenty) pre_quant")
+        cases["case17 (group, plenty) pre_quant"] = self.run_moe_layer(**kwargs)
+        logging.info("case18 (group, tight_fwd) pre_quant")
+        cases["case18 (group, tight_fwd) pre_quant"] = self.run_moe_layer(
+            tight_forward=True, **kwargs
+        )
+        logging.info("case19 (group, tight_bwd) pre_quant")
+        cases["case19 (group, tight_bwd) pre_quant"] = self.run_moe_layer(
+            tight_backward=True, **kwargs
+        )
+        logging.info("case20 (group, tight_both) pre_quant")
+        cases["case20 (group, tight_both) pre_quant"] = self.run_moe_layer(
+            tight_forward=True, tight_backward=True, **kwargs
+        )
+
+        # split gemm + recompute + moe_subbatch_token_num_after_dispatch 512 ---
+        kwargs = {
+            "moe_expert_fusion": False,
+            "recompute_moe_premute": True,
+            "recompute_moe_gate_up": True,
+            "moe_subbatch_token_num_after_dispatch": 512,
+        }
+        # case21: 显存充裕 → 走 3a group_gemm
+        logging.info("case21 (split, plenty)")
+        cases["case21 (split, plenty)"] = self.run_moe_layer(**kwargs)
+        # case22: 前向紧张 → fallback 到逐专家
+        logging.info("case22 (split, tight_fwd)")
+        cases["case22 (split, tight_fwd)"] = self.run_moe_layer(
+            tight_forward=True, **kwargs
+        )
+        # case23: 反向紧张 → 前向 3a, 反向 fallback
+        logging.info("case23 (split, tight_bwd)")
+        cases["case23 (split, tight_bwd)"] = self.run_moe_layer(
+            tight_backward=True, **kwargs
+        )
+        # case24: 向+反向都紧张, fallback
+        logging.info("case24 (split, tight_both)")
+        cases["case24 (split, tight_both)"] = self.run_moe_layer(
+            tight_forward=True, tight_backward=True, **kwargs
+        )
+
+        loose_cases = {}
+        # --- 数值对比 ---
+        loose_cases = {
+            "case15 (split, tight_bwd)",
+            "case16 (split, tight_both)",
+            "case21 (split, plenty)",
+            "case22 (split, tight_fwd)",
+            "case23 (split, tight_bwd)",
+            "case24 (split, tight_both)",
+        }
+        for name, result in cases.items():
+            with self.subTest(case=name):
+                self.compare_results(
+                    ref_out, result, loose_weight=(name in loose_cases)
+                )
+
+
+class TestMemoryBlockUtils(unittest.TestCase):
+    def test_legacy_utils(self):
+        """测试不开 VMM 时 legacy backend 使用 all_block_info reported free blocks。"""
+        old_all_func = MemoryAnalysisTool.all_block_info
+        old_get_flags = paddle.framework.get_flags
+
+        def fake_get_flags(name):
+            if name == "FLAGS_use_virtual_memory_auto_growth":
+                return {name: False}
+            return old_get_flags(name)
+
+        try:
+            paddle.framework.get_flags = fake_get_flags
+            MemoryAnalysisTool.all_block_info = lambda: [
+                [
+                    (1024, 0, True),
+                    (2048, 1024, False),
+                    (4096, 3072, True),
+                ]
+            ]
+
+            self.assertEqual(auto_subbatch_allocator_backend(), "legacy")
+            self.assertEqual(
+                legacy_free_block_info(), [(1024, 0), (4096, 3072)]
+            )
+            self.assertEqual(
+                allocator_free_block_info(), [(1024, 0), (4096, 3072)]
+            )
+            self.assertEqual(find_max_concurrent_subbatch_size([1024]), 4)
+            self.assertEqual(find_max_sequence_subbatch_size(1024, 2), 2)
+
+            MemoryAnalysisTool.all_block_info = lambda: [[(1024, 0, False)]]
+            self.assertEqual(legacy_free_block_info(), [])
+            self.assertEqual(find_max_concurrent_subbatch_size([1024]), 0)
+
+            MemoryAnalysisTool.all_block_info = lambda: []
+            self.assertEqual(legacy_free_block_info(), [])
+
+            MemoryAnalysisTool.all_block_info = lambda: [
+                (2048, 0, True),
+                (1024, 2048, True),
+                (512, 3072, False),
+            ]
+            self.assertEqual(
+                legacy_free_block_info(), [(1024, 2048), (2048, 0)]
+            )
+
+            def raise_all_block_info():
+                raise RuntimeError("mock all_block_info failure")
+
+            MemoryAnalysisTool.all_block_info = raise_all_block_info
+            self.assertEqual(legacy_free_block_info(), [])
+
+            self.assertTrue(is_auto_subbatch_memory_analysis_available())
+
+            def raise_get_flags(name):
+                raise RuntimeError("mock get_flags failure")
+
+            paddle.framework.get_flags = raise_get_flags
+            self.assertEqual(auto_subbatch_allocator_backend(), "legacy")
+            self.assertTrue(is_auto_subbatch_memory_analysis_available())
+        finally:
+            MemoryAnalysisTool.all_block_info = old_all_func
+            paddle.framework.get_flags = old_get_flags
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
 New features

### Description
<!-- Describe what you’ve done -->

当前 MoE auto_subbatch 的显存规划依赖 VMM allocator，这导致 use_auto_subbatch=True 原本强依赖：FLAGS_use_virtual_memory_auto_growth=True
现在 Paddle 侧已提供：MemoryAnalysisTool.all_block_info()该接口在不开 VMM 时也能返回 allocator block 信息
**因此本 PR 增加 legacy allocator 下的 conservative auto subbatch 支持。**

---
修改内容
  
  1. 抽象 auto subbatch free block 查询入口

  在 vmm_utils.py 中新增 allocator-agnostic 查询入口：

  allocator_free_block_info()

  其行为为：

  VMM 开启:
    使用原有 vmm_free_and_growable_block_info()
    保留 VMM growable block 语义

  VMM 关闭:
    使用 legacy_free_block_info()
    基于 MemoryAnalysisTool.all_block_info() 获取 reported free blocks
    不额外虚构 growable block

  ---
  2. 新增 legacy allocator free block 查询

  新增：

  legacy_free_block_info()

  实现逻辑：

  1. 调用 MemoryAnalysisTool.all_block_info()；
  2. 将 list[heap][block] 展平成一层 block list；
  3. 提取 free=True 的 blocks；
  4. 返回：

  [(size_bytes, addr), ...]

  5. 按 block size 从小到大排序。

  legacy backend 第一版采用保守策略：

  只使用 all_block_info() reported free blocks
  不使用 FLAGS_max_reserved_threshold_in_gb - memory_reserved() 构造 growable block

  这样可以避免 old allocator 场景下因 cold-start 显存看起来过于宽松而做出过度乐观的 auto subbatch 决策。

  ---
  3. 保持 VMM 路径兼容
  
  VMM 开启时仍走原有逻辑：

  vmm_free_and_growable_block_info()

  保留：

  - MemoryAnalysisTool.vmm_all_block_info()
  - FLAGS_max_reserved_threshold_in_gb
  - paddle.cuda.memory_reserved()
  - heap top growable 合并
  - free block 按 size 升序返回

  已有 VMM auto subbatch 行为不变。

  ---
  4. 移除 use_auto_subbatch 对 VMM flag 的硬依赖
  
  移除了 MlpNode.__init__ 中对：

  FLAGS_use_virtual_memory_auto_growth=True

  的硬 assert。

  现在 use_auto_subbatch=True 时：

  - VMM 开启：走 VMM backend；
  - VMM 关闭：走 legacy backend；
  - legacy backend 查询失败或无 free block 时，packing 函数会保守返回 0，后续由现有 min_auto_subbatch_rows 兜底。

  ---
  5. auto subbatch 诊断日志增加 backend 信息
  
  moe_subbatch_diag=True 时，forward/backward auto subbatch 日志增加 allocator backend：

  backend=vmm
  backend=legacy

  示例：

  [AutoSubbatch FWD] backend=legacy, path=per_expert, total_tokens=..., subbatch_rows=..., zip_unzip_fusion=False
  [AutoSubbatch BWD] backend=legacy, path=per_expert, total_tokens=..., subbatch_rows=..., zip_unzip_fusion=False

  方便确认当前测试或训练实际走的是 VMM backend 还是 legacy backend。

  ---
  6. 单测覆盖 VMM 开/关两种模式
  
  更新以下单测：

  tests/single_card_tests/test_moe_auto_subbatch.py
  tests/single_card_tests/test_moe_auto_subbatch_deep_gemm.py
  tests/single_card_tests/test_moe_subbatch.py
  tests/single_card_tests/test_moe_subbatch_deep_gemm.py

  每个测试文件内部会分别启动两个子进程执行：

  FLAGS_use_virtual_memory_auto_growth=True
  FLAGS_use_virtual_memory_auto_growth=False

  这样不依赖外层脚本控制 VMM 开关，单测文件自身即可覆盖两种 allocator backend。

  测试输出中会打印当前 VMM 状态，例如：

  [test_moe_auto_subbatch] FLAGS_use_virtual_memory_auto_growth=True
  [test_moe_auto_subbatch] FLAGS_use_virtual_memory_auto_growth=False

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否