### PR TITLE
[generate] support fp8 generate

### DIFF
--- a/src/paddlefleet/transformer/moe/fused_a2a.py
+++ b/src/paddlefleet/transformer/moe/fused_a2a.py
@@ -71,9 +71,13 @@ def get_hidden_bytes(x: paddle.Tensor) -> int:
     return x.shape[1] * max(x.element_size(), 2)
 
 
-def _normalize_fp8_scale_for_deepep(x_fp8: paddle.Tensor, scale: paddle.Tensor):
+def _normalize_fp8_scale_for_deepep(
+    x_fp8: paddle.Tensor, scale: paddle.Tensor, use_ue8m0: bool = False
+):
     num_tokens = x_fp8.shape[0]
     num_scales = x_fp8.shape[1] // 128
+    if use_ue8m0:
+        num_scales //= 4
     if scale.shape[0] == num_scales:
         scale = scale.T.contiguous()
     else:
@@ -409,7 +413,9 @@ class DeepEPDispatch(PyLayer):
                 return_transpose_only=False,
                 using_ue8m0_scale=use_ue8m0,
             )
-            scale = _normalize_fp8_scale_for_deepep(x_fp8, scale)
+            scale = _normalize_fp8_scale_for_deepep(
+                x_fp8, scale, use_ue8m0=use_ue8m0
+            )
             x = (x_fp8, scale)
         recv_x, recv_token_probs, states, event = fused_dispatch_forward_func(
             x,

--- a/src/paddlefleet/transformer/moe/fused_a2a.py
+++ b/src/paddlefleet/transformer/moe/fused_a2a.py
@@ -71,6 +71,24 @@ def get_hidden_bytes(x: paddle.Tensor) -> int:
     return x.shape[1] * max(x.element_size(), 2)
 
 
+def _normalize_fp8_scale_for_deepep(x_fp8: paddle.Tensor, scale: paddle.Tensor):
+    num_tokens = x_fp8.shape[0]
+    num_scales = x_fp8.shape[1] // 128
+    if scale.shape[0] == num_scales:
+        scale = scale.T.contiguous()
+    else:
+        scale = scale.contiguous()
+    if scale.shape[0] > num_tokens:
+        scale = scale[:num_tokens, :]
+    if scale.shape[0] != num_tokens or scale.shape[1] != num_scales:
+        raise RuntimeError(
+            "Invalid FP8 scale shape for DeepEP dispatch: "
+            f"scale={scale.shape}, x_fp8={x_fp8.shape}, "
+            f"expected [{num_tokens}, {num_scales}]"
+        )
+    return scale
+
+
 def configure_buffer(num_sms=None, dispatch_config=None, combine_config=None):
     """
     Configure the runtime parameters for deep_ep kernels.
@@ -391,20 +409,7 @@ class DeepEPDispatch(PyLayer):
                 return_transpose_only=False,
                 using_ue8m0_scale=use_ue8m0,
             )
-            num_tokens = x_fp8.shape[0]
-            num_scales = x_fp8.shape[1] // 128
-            if scale.shape[0] == num_scales:
-                scale = scale.T.contiguous()
-            else:
-                scale = scale.contiguous()
-            if scale.shape[0] > num_tokens:
-                scale = scale[:num_tokens, :]
-            if scale.shape[0] != num_tokens or scale.shape[1] != num_scales:
-                raise RuntimeError(
-                    "Invalid FP8 scale shape for DeepEP dispatch: "
-                    f"scale={scale.shape}, x_fp8={x_fp8.shape}, "
-                    f"expected [{num_tokens}, {num_scales}]"
-                )
+            scale = _normalize_fp8_scale_for_deepep(x_fp8, scale)
             x = (x_fp8, scale)
         recv_x, recv_token_probs, states, event = fused_dispatch_forward_func(
             x,

--- a/src/paddlefleet/transformer/moe/fused_a2a.py
+++ b/src/paddlefleet/transformer/moe/fused_a2a.py
@@ -391,7 +391,20 @@ class DeepEPDispatch(PyLayer):
                 return_transpose_only=False,
                 using_ue8m0_scale=use_ue8m0,
             )
-            scale = scale.T.contiguous()
+            num_tokens = x_fp8.shape[0]
+            num_scales = x_fp8.shape[1] // 128
+            if scale.shape[0] == num_scales:
+                scale = scale.T.contiguous()
+            else:
+                scale = scale.contiguous()
+            if scale.shape[0] > num_tokens:
+                scale = scale[:num_tokens, :]
+            if scale.shape[0] != num_tokens or scale.shape[1] != num_scales:
+                raise RuntimeError(
+                    "Invalid FP8 scale shape for DeepEP dispatch: "
+                    f"scale={scale.shape}, x_fp8={x_fp8.shape}, "
+                    f"expected [{num_tokens}, {num_scales}]"
+                )
             x = (x_fp8, scale)
         recv_x, recv_token_probs, states, event = fused_dispatch_forward_func(
             x,

--- a/tests/single_card_tests/ai_edited_test/moe/test_ai_fused_a2a.py
+++ b/tests/single_card_tests/ai_edited_test/moe/test_ai_fused_a2a.py
@@ -115,6 +115,17 @@ class TestFusedA2A(unittest.TestCase):
         result = _normalize_fp8_scale_for_deepep(x_fp8, scale)
         self.assertEqual(result.shape, [3, 2])
 
+    def test_normalize_fp8_scale_for_deepep_supports_ue8m0(self):
+        """Test UE8M0 packed scale width is accepted and transposed."""
+        from paddlefleet.transformer.moe.fused_a2a import (
+            _normalize_fp8_scale_for_deepep,
+        )
+
+        x_fp8 = paddle.zeros([4, 512], dtype=paddle.float8_e4m3fn)
+        scale = paddle.ones([1, 4], dtype=paddle.int32)
+        result = _normalize_fp8_scale_for_deepep(x_fp8, scale, use_ue8m0=True)
+        self.assertEqual(result.shape, [4, 1])
+
     def test_normalize_fp8_scale_for_deepep_rejects_invalid_shape(self):
         """Test invalid FP8 scale shape fails before DeepEP dispatch."""
         from paddlefleet.transformer.moe.fused_a2a import (

--- a/tests/single_card_tests/ai_edited_test/moe/test_ai_fused_a2a.py
+++ b/tests/single_card_tests/ai_edited_test/moe/test_ai_fused_a2a.py
@@ -93,6 +93,39 @@ class TestFusedA2A(unittest.TestCase):
         # max(element_size=1, 2) = 2, so 64 * 2 = 128
         self.assertEqual(result, 128)
 
+    def test_normalize_fp8_scale_for_deepep_transposes_scale(self):
+        """Test FP8 scale layout is transposed to token-major format."""
+        from paddlefleet.transformer.moe.fused_a2a import (
+            _normalize_fp8_scale_for_deepep,
+        )
+
+        x_fp8 = paddle.zeros([4, 256], dtype=paddle.float8_e4m3fn)
+        scale = paddle.ones([2, 4], dtype=paddle.float32)
+        result = _normalize_fp8_scale_for_deepep(x_fp8, scale)
+        self.assertEqual(result.shape, [4, 2])
+
+    def test_normalize_fp8_scale_for_deepep_trims_padded_tokens(self):
+        """Test FP8 scale token padding is trimmed for inference dispatch."""
+        from paddlefleet.transformer.moe.fused_a2a import (
+            _normalize_fp8_scale_for_deepep,
+        )
+
+        x_fp8 = paddle.zeros([3, 256], dtype=paddle.float8_e4m3fn)
+        scale = paddle.ones([4, 2], dtype=paddle.float32)
+        result = _normalize_fp8_scale_for_deepep(x_fp8, scale)
+        self.assertEqual(result.shape, [3, 2])
+
+    def test_normalize_fp8_scale_for_deepep_rejects_invalid_shape(self):
+        """Test invalid FP8 scale shape fails before DeepEP dispatch."""
+        from paddlefleet.transformer.moe.fused_a2a import (
+            _normalize_fp8_scale_for_deepep,
+        )
+
+        x_fp8 = paddle.zeros([4, 256], dtype=paddle.float8_e4m3fn)
+        scale = paddle.ones([4, 3], dtype=paddle.float32)
+        with self.assertRaisesRegex(RuntimeError, "Invalid FP8 scale shape"):
+            _normalize_fp8_scale_for_deepep(x_fp8, scale)
+
     def test_dispatch_node_reset_statue(self):
         """Test DispatchNode.reset_statue clears handle."""
         from paddlefleet.transformer.moe.fused_a2a import DispatchNode


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Execute Infrastructure 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
 Improvements

### Description
<!-- Describe what you’ve done -->
动推情况下，输入的tokens 不是128对齐的，而scale 默认128对齐，deepep kenrel 中计算要求x_scales->size(0) == num_tokens 报错，因此处理scales的num_tokens 维度

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否