### PR TITLE
[release/0.3][DSV4 Attn][Fix] Fix document mask padding logic

### DIFF
--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -471,8 +471,9 @@ def _apply_rope(
             freqs = paddle.concat(doc_freqs, axis=1)
         else:
             freqs = freqs[:, :0, :, :]
-        if freqs.shape[1] < rotary_seq_len:
-            pad_len = rotary_seq_len - freqs.shape[1]
+        needed_len = position_offset + rotary_seq_len
+        if freqs.shape[1] < needed_len:
+            pad_len = needed_len - freqs.shape[1]
             freqs = paddle.concat(
                 [
                     freqs,
@@ -482,9 +483,7 @@ def _apply_rope(
                 ],
                 axis=1,
             )
-        freqs = freqs[
-            :, position_offset : position_offset + rotary_seq_len, :, :
-        ]
+        freqs = freqs[:, position_offset:needed_len, :, :]
     elif ratio > 1:  # CP without document mask -> KV
         freqs = freqs[:, position_offset * ratio : total_seq_len : ratio, :][
             :, :rotary_seq_len, :

--- a/src/paddlefleet/transformer/dsv4_hybrid_attention.py
+++ b/src/paddlefleet/transformer/dsv4_hybrid_attention.py
@@ -60,7 +60,10 @@ from paddlefleet.transformer.utils import (
 
 
 def build_document_rope_freqs(
-    rotary_pos_emb: nn.Layer, sq: int, startend_row_indices: Tensor
+    rotary_pos_emb: nn.Layer,
+    sq: int,
+    startend_row_indices: Tensor,
+    position_offset: int = 0,
 ):
     """Build RoPE frequencies that restart from zero for each document."""
     assert (
@@ -78,12 +81,14 @@ def build_document_rope_freqs(
     freqs = freqs.squeeze(0).squeeze(1)
     doc_freqs = [freqs[: int(doc_len.item())] for doc_len in doc_lens]
     freqs = paddle.concat(doc_freqs, axis=0)
-    if freqs.shape[0] < sq:
+    needed_len = position_offset + sq
+    if freqs.shape[0] < needed_len:
         freqs = paddle.concat(
             [
                 freqs,
                 paddle.zeros(
-                    [sq - freqs.shape[0], freqs.shape[-1]], dtype=freqs.dtype
+                    [needed_len - freqs.shape[0], freqs.shape[-1]],
+                    dtype=freqs.dtype,
                 ),
             ],
             axis=0,
@@ -306,7 +311,10 @@ class DSv4HybridAttention(Attention):
             # Get RoPE frequencies for inverse
             if startend_row_indices is not None:
                 freqs, mscale = build_document_rope_freqs(
-                    self.rotary_pos_emb, sq, startend_row_indices
+                    self.rotary_pos_emb,
+                    sq,
+                    startend_row_indices,
+                    position_offset=position_offset,
                 )
             else:
                 # Get RoPE frequencies for inverse; use global positions in CP mode
@@ -496,7 +504,10 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
             # Get RoPE frequencies
             if startend_row_indices is not None:
                 freqs, mscale = build_document_rope_freqs(
-                    self.rotary_pos_emb, sq, startend_row_indices
+                    self.rotary_pos_emb,
+                    sq,
+                    startend_row_indices,
+                    position_offset=position_offset,
                 )
             else:
                 # Get RoPE frequencies for global positions

--- a/tests/single_card_tests/transformer/test_dsv4_hybrid_attention.py
+++ b/tests/single_card_tests/transformer/test_dsv4_hybrid_attention.py
@@ -44,6 +44,7 @@ from paddlefleet.transformer.dsa_attention import (
 )
 from paddlefleet.transformer.dsv4_hybrid_attention import (
     DSv4HybridSelfAttention,
+    build_document_rope_freqs,
 )
 from paddlefleet.transformer.enums import AttnMaskType
 from paddlefleet.transformer.transformer_config import TransformerConfig
@@ -291,6 +292,48 @@ class TestCSAIndexHelpers(unittest.TestCase):
 
 
 class TestDSv4HybridDocumentRoPE(unittest.TestCase):
+    def test_document_rope_freqs_with_position_offset_pads_to_local_slice(self):
+        config = _make_config(rope_type="yarn")
+        rotary_pos_emb = YarnRotaryEmbedding(
+            config.qk_pos_emb_head_dim,
+            rotary_base=config.csa_compress_rotary_base,
+            scaling_factor=getattr(config, "rotary_scaling_factor", 40),
+            original_max_position_embeddings=getattr(
+                config, "original_max_position_embeddings", 4096
+            ),
+            beta_fast=getattr(config, "beta_fast", 32),
+            beta_slow=getattr(config, "beta_slow", 1),
+            mscale=getattr(config, "mscale", 1.0),
+            mscale_all_dim=getattr(config, "mscale_all_dim", 0.0),
+        )
+        sq_local = 4
+        position_offset = 4
+        needed_len = position_offset + sq_local
+        startend_row_indices = paddle.to_tensor(
+            [2, 2, 2, 2, 2, 2, 2, 2], dtype="int32"
+        ).reshape([1, 1, 8, 1])
+
+        freqs, _ = build_document_rope_freqs(
+            rotary_pos_emb,
+            sq_local,
+            startend_row_indices,
+            position_offset=position_offset,
+        )
+        local_freqs = freqs[
+            :, position_offset : position_offset + sq_local, :, :
+        ]
+
+        self.assertEqual(
+            list(local_freqs.shape),
+            [1, sq_local, 1, config.qk_pos_emb_head_dim],
+        )
+        self.assertTrue(
+            paddle.equal_all(
+                local_freqs[:, -2:, :, :],
+                paddle.zeros_like(local_freqs[:, -2:, :, :]),
+            ).item()
+        )
+
     def test_compressed_document_rope_matches_separate_documents(self):
         paddle.seed(_SEED)
         config = _make_config(rope_type="yarn")


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
Operator Mechanism


### PR Types
Bug fixes


### Description
修复了 DSV4 attention 中，文档总长过短情况下，padding 逻辑在 CP 下无法正确触发的 bug：
- 当 sum(doc_seqlen) < sq_global 情况下，就应该进行 padding 了。但实际判断的是 < sq_local，则可能永远不 padding。
- 一旦触发就会出 shape mismatch 问题。

修改后会按照 cp 的 rank offset 进行判断。可以不 padding 到 sq_global 长度，毕竟 CP 下 最后都会 slice 到本地段，保证本地段能被完整正确 slice 即可。

### 是否引起精度变化
否


Cherry-pick of #1248 to `release/0.3`.

Merged in dev: #1248  <!-- For pass CI -->