### PR TITLE
[BugFix] fix align mode when cp = 1

### DIFF
--- a/src/paddlefleet/models/common/language_loss/language_loss.py
+++ b/src/paddlefleet/models/common/language_loss/language_loss.py
@@ -411,7 +411,7 @@ class LanguageLoss(FleetLayer):
             # EC's ErniemmPretrainingCriterion recomputes loss as line-wise when task_id
             # is present, which changes the value due to division by (count + 1e-6).
             if self.config.gpt_model_use_experimental_version:
-                if get_tensor_model_parallel_world_size() > 1:
+                if max(get_tensor_model_parallel_world_size(), 1) > 1:
                     loss = loss.squeeze(-1)
                 loss_2d = loss.cast(paddle.float32) * lossmask.reshape(
                     labels.shape

--- a/src/paddlefleet/transformer/attention.py
+++ b/src/paddlefleet/transformer/attention.py
@@ -946,7 +946,7 @@ class SelfAttention(Attention):
                     [
                         -1,
                         self.config.max_sequence_length
-                        // get_context_parallel_world_size(),
+                        // max(get_context_parallel_world_size(), 1),
                         gate.shape[-1],
                     ]
                 )
@@ -974,9 +974,8 @@ class SelfAttention(Attention):
             if not split_qkv:
                 split_arg_list = [num_heads, num_kv_heads, num_kv_heads]
                 return mixed_qkv, split_arg_list
-            seq_len_local = (
-                self.config.max_sequence_length
-                // get_context_parallel_world_size()
+            seq_len_local = self.config.max_sequence_length // max(
+                get_context_parallel_world_size(), 1
             )
             query, key, value = paddle.split(
                 mixed_qkv.reshape(

--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -1042,7 +1042,7 @@ class TopKRouter(StandardMoERouter):
                     "gpt_model_use_experimental_version=True."
                 )
             cp_size = (
-                get_context_parallel_world_size()
+                max(get_context_parallel_world_size(), 1)
                 if getattr(self.config, "experimental_dataflow", False)
                 else 1
             )
@@ -1052,7 +1052,7 @@ class TopKRouter(StandardMoERouter):
             seq_len = self.config.max_sequence_length // (cp_size * tp_size)
             batch_size = input.shape[0] // seq_len
             if (
-                get_context_parallel_world_size() > 1
+                max(get_context_parallel_world_size(), 1) > 1
                 and self.config.experimental_dataflow
                 and input_ids is not None
             ):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Distributed Strategy

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
当不开cp时，get_context_parallel_world_size() 返回-1，导致shape处理错误

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否