### PR TITLE
[DSV4] Add accuracy compatible patch

### DIFF
--- a/src/paddlefleet/accuracy_compatible_patch.py
+++ b/src/paddlefleet/accuracy_compatible_patch.py
@@ -22,14 +22,20 @@ import paddle
 from paddle import Tensor
 from paddle.utils import dlpack as paddle_dlpack
 
+_MEGATRON_SITE_PACKAGES = os.environ.get("MEGATRON_SITE_PACKAGES", "")
+_TORCH = None
+
 
 def _import_torch():
-    site_packages = os.environ.get("MEGATRON_SITE_PACKAGES", "")
-    if site_packages and site_packages not in sys.path:
-        sys.path.insert(0, site_packages)
+    global _TORCH
+    if _TORCH is not None:
+        return _TORCH
+    if _MEGATRON_SITE_PACKAGES and _MEGATRON_SITE_PACKAGES not in sys.path:
+        sys.path.insert(0, _MEGATRON_SITE_PACKAGES)
     import torch
 
-    return torch
+    _TORCH = torch
+    return _TORCH
 
 
 def _to_torch(tensor):

--- a/src/paddlefleet/accuracy_compatible_patch.py
+++ b/src/paddlefleet/accuracy_compatible_patch.py
@@ -1,0 +1,635 @@
+from __future__ import annotations
+
+import math
+import os
+import sys
+
+import paddle
+from paddle import Tensor
+from paddle.utils import dlpack as paddle_dlpack
+
+def _import_torch():
+    site_packages = os.environ.get("MEGATRON_SITE_PACKAGES", "")
+    if site_packages and site_packages not in sys.path:
+        sys.path.insert(0, site_packages)
+    import torch
+
+    return torch
+
+
+def _to_torch(tensor):
+    torch = _import_torch()
+    return torch.utils.dlpack.from_dlpack(
+        paddle_dlpack.to_dlpack(tensor.contiguous())
+    )
+
+
+def _to_paddle(tensor):
+    torch = _import_torch()
+    return paddle_dlpack.from_dlpack(
+        torch.utils.dlpack.to_dlpack(tensor.contiguous())
+    )
+
+
+def sum_for_small_rows(value: Tensor) -> Tensor:
+    if len(value.shape) != 2 or value.shape[0] >= 16:
+        return paddle.sum(value, axis=-1, keepdim=True)
+    pad_rows = 16 - value.shape[0]
+    if pad_rows <= 0:
+        return paddle.sum(value, axis=-1, keepdim=True)
+    padding = paddle.zeros([pad_rows, value.shape[1]], dtype=value.dtype)
+    padded = paddle.concat([value, padding], axis=0)
+    return paddle.sum(padded, axis=-1, keepdim=True)[: value.shape[0]]
+
+
+class LossScaleBeforeBackward:
+    _raw_loss_sum: Tensor | None = None
+    _raw_loss_count = 0
+    _acc_steps = 1
+
+    @classmethod
+    def set_acc_steps(cls, acc_steps: int) -> None:
+        cls._acc_steps = max(1, acc_steps)
+
+    @classmethod
+    def record(cls, loss: Tensor) -> None:
+        with paddle.no_grad():
+            loss_tensor = loss.detach().cast("float32").reshape([1])
+            if cls._raw_loss_sum is None:
+                cls._raw_loss_sum = loss_tensor
+            else:
+                cls._raw_loss_sum = cls._raw_loss_sum + loss_tensor
+            cls._raw_loss_count += 1
+
+    @classmethod
+    def pop(cls) -> tuple[Tensor, Tensor] | None:
+        if cls._raw_loss_sum is None or cls._raw_loss_count == 0:
+            return None
+
+        loss_sum = cls._raw_loss_sum
+        loss_count = paddle.to_tensor([cls._raw_loss_count], dtype="float32")
+        cls._raw_loss_sum = None
+        cls._raw_loss_count = 0
+        return loss_sum, loss_count
+
+    @classmethod
+    def scale(cls, loss: Tensor) -> Tensor:
+        if cls._acc_steps <= 1:
+            return loss
+        return loss / cls._acc_steps
+
+
+class CompatibleCSASinkSoftmax(paddle.autograd.PyLayer):
+    @staticmethod
+    def forward(ctx, scores: Tensor, sink: Tensor):
+        ctx.save_for_backward(scores, sink)
+        scores_max = scores.max(axis=-1, keepdim=True)
+        scores_max = paddle.maximum(scores_max, sink)
+        exp_scores = paddle.exp(scores - scores_max)
+        exp_sink = paddle.exp(sink - scores_max)
+        sum_exp = exp_scores.sum(axis=-1, keepdim=True) + exp_sink
+        return exp_scores / sum_exp
+
+    @staticmethod
+    def backward(ctx, grad_attn_weights: Tensor):
+        torch = _import_torch()
+        scores, sink = ctx.saved_tensor()
+        scores_t = _to_torch(scores.detach())
+        sink_t = _to_torch(sink.detach())
+        grad_t = _to_torch(grad_attn_weights.detach())
+
+        with torch.enable_grad():
+            scores_t = scores_t.detach().requires_grad_(True)
+            sink_t = sink_t.detach().requires_grad_(True)
+            scores_max_t = torch.maximum(
+                scores_t.max(dim=-1, keepdim=True).values, sink_t
+            )
+            exp_scores_t = torch.exp(scores_t - scores_max_t)
+            exp_sink_t = torch.exp(sink_t - scores_max_t)
+            sum_exp_t = exp_scores_t.sum(dim=-1, keepdim=True) + exp_sink_t
+            attn_weights_t = exp_scores_t / sum_exp_t
+            attn_weights_t.backward(grad_t)
+
+        grad_scores = _to_paddle(scores_t.grad)
+        grad_sink = _to_paddle(sink_t.grad)
+        return grad_scores, grad_sink
+
+
+def compatible_einsum(grad_scores: Tensor, q: Tensor) -> Tensor:
+    torch = _import_torch()
+    grad_scores_t = _to_torch(grad_scores)
+    q_t = _to_torch(q)
+    grad_k_t = torch.einsum(
+        "sbht,sbhd->tbd", grad_scores_t, q_t.to(dtype=torch.float32)
+    ).to(dtype=q_t.dtype)
+    return _to_paddle(grad_k_t)
+
+
+class CompatibleHadamard(paddle.autograd.PyLayer):
+    @staticmethod
+    def forward(ctx, x: Tensor, scale: float):
+        from fast_hadamard_transform import hadamard_transform
+        scale = float(scale)
+        ctx.scale = scale
+        x_t = _to_torch(x)
+        y_t = hadamard_transform(x_t, scale=scale)
+        return _to_paddle(y_t)
+
+    @staticmethod
+    def backward(ctx, grad_output: Tensor):
+        from fast_hadamard_transform import hadamard_transform
+        grad_t = _to_torch(grad_output)
+        grad_x_t = hadamard_transform(grad_t, scale=ctx.scale)
+        return _to_paddle(grad_x_t)
+
+class CompatibleOGroupProjection(paddle.autograd.PyLayer):
+    @staticmethod
+    def forward(
+        ctx,
+        x: Tensor,
+        weight: Tensor,
+        o_local_groups: int,
+        o_lora_rank: int,
+        layer_number: int,
+        call_idx: int,
+    ):
+        torch = _import_torch()
+
+        ctx.o_local_groups = o_local_groups
+        ctx.o_lora_rank = o_lora_rank
+        ctx.layer_number = layer_number
+        ctx.call_idx = call_idx
+        ctx.save_for_backward(x, weight)
+
+        x_seqfirst = x.detach().transpose([1, 0, 2, 3]).contiguous()
+        weight_grouped = weight.detach().reshape(
+            [o_local_groups, o_lora_rank, -1]
+        ).contiguous()
+        x_t = _to_torch(x_seqfirst).detach()
+        weight_t = _to_torch(weight_grouped).detach()
+        out_t = torch.einsum("...gd,grd->...gr", x_t, weight_t)
+        out = _to_paddle(out_t)
+        return out.transpose([1, 0, 2, 3]).contiguous()
+
+    @staticmethod
+    def backward(ctx, grad_output: Tensor):
+        torch = _import_torch()
+
+        x, weight = ctx.saved_tensor()
+        x_seqfirst = x.detach().transpose([1, 0, 2, 3]).contiguous()
+        grad_seqfirst = grad_output.detach().transpose(
+            [1, 0, 2, 3]
+        ).contiguous()
+        weight_grouped = weight.detach().reshape(
+            [ctx.o_local_groups, ctx.o_lora_rank, -1]
+        ).contiguous()
+
+        x_t = _to_torch(x_seqfirst).detach()
+        grad_t = _to_torch(grad_seqfirst).detach()
+        weight_t = _to_torch(weight_grouped).detach()
+
+        with torch.enable_grad():
+            x_t = x_t.requires_grad_(True)
+            weight_t = weight_t.requires_grad_(True)
+            out_t = torch.einsum("...gd,grd->...gr", x_t, weight_t)
+            out_t.backward(grad_t)
+            x_grad_t = x_t.grad.contiguous()
+            w_grad_t = weight_t.grad.reshape(tuple(weight.shape)).contiguous()
+
+        x_grad = _to_paddle(x_grad_t)
+        x_grad = x_grad.transpose([1, 0, 2, 3]).contiguous()
+        w_grad = _to_paddle(w_grad_t)
+        w_grad_accum = w_grad.detach().cast(paddle.float32)
+        prev = getattr(weight, "_dsv4_attn_o_group_seqfirst_wgrad", None)
+        if prev is None:
+            weight._dsv4_attn_o_group_seqfirst_wgrad = w_grad_accum
+        else:
+            weight._dsv4_attn_o_group_seqfirst_wgrad = prev + w_grad_accum
+        return x_grad, w_grad
+
+class CompatibleQRMSNorm(paddle.autograd.PyLayer):
+    @staticmethod
+    def forward(ctx, q: Tensor, eps: float) -> Tensor:
+        r = paddle.rsqrt(q.square().mean(axis=-1, keepdim=True) + eps)
+        ctx.save_for_backward(q, r)
+        return q * r
+
+    @staticmethod
+    def backward(ctx, grad_output: Tensor):
+        q, r = ctx.saved_tensor()
+        hidden_size = q.shape[-1]
+        grad_r = (grad_output * q).sum(axis=-1, keepdim=True)
+        grad_q = grad_output * r
+        grad_add = grad_r * (-0.5) * (r * r * r)
+        grad_q = grad_q + (paddle.full_like(q, 2.0) * q) * (
+            grad_add / hidden_size
+        )
+        return grad_q
+
+class CompatibleEmbeddingIndexBackward(paddle.autograd.PyLayer):
+    @staticmethod
+    def forward(
+        ctx, masked_input: Tensor, weight: Tensor
+    ) -> Tensor:
+        ctx.save_for_backward(masked_input, weight)
+        return weight[masked_input]
+
+    @staticmethod
+    def backward(ctx, grad_output: Tensor):
+        torch = _import_torch()
+
+        masked_input, weight = ctx.saved_tensor()
+        ids_t = _to_torch(masked_input.detach().cast("int64")).detach()
+        grad_t = _to_torch(grad_output.detach()).detach()
+        weight_t = _to_torch(weight.detach()).detach()
+
+        with torch.enable_grad():
+            weight_t = weight_t.requires_grad_(True)
+            output_t = weight_t[ids_t]
+            output_t.backward(grad_t)
+            grad_weight_t = weight_t.grad
+
+        grad_weight = _to_paddle(grad_weight_t)
+        return None, grad_weight
+
+def te_matmul(grad_output: Tensor, weight: Tensor) -> Tensor:
+    torch = _import_torch()
+    from transformer_engine.pytorch.cpp_extensions.gemm import general_gemm
+
+    grad_output_torch = _to_torch(grad_output)
+    weight_oi_torch = _to_torch(weight.t())
+    grad_input_torch, *_ = general_gemm(
+        weight_oi_torch,
+        grad_output_torch,
+        out_dtype=torch.bfloat16,
+        layout="NN",
+        grad=True,
+    )
+
+    return _to_paddle(grad_input_torch)
+
+
+def linear_seqfirst_wgrad(
+    input: Tensor, grad_output: Tensor, weight: Tensor
+) -> Tensor | None:
+    if input.dim() not in (3, 4) or grad_output.dim() != input.dim():
+        return None
+    if input.shape[0] <= 1 or input.shape[0] >= input.shape[1]:
+        return None
+    if weight.dtype != paddle.bfloat16:
+        return None
+
+    torch = _import_torch()
+
+    out_features = grad_output.shape[-1]
+    if input.dim() == 3:
+        batch, seq, hidden = input.shape
+        flat_rows = batch * seq
+        input_seqfirst = (
+            input.detach()
+            .reshape([batch, seq, hidden])
+            .transpose([1, 0, 2])
+            .reshape([flat_rows, hidden])
+            .contiguous()
+        )
+        grad_seqfirst = (
+            grad_output.detach()
+            .reshape([batch, seq, out_features])
+            .transpose([1, 0, 2])
+            .reshape([flat_rows, out_features])
+            .contiguous()
+        )
+    else:
+        batch, seq, streams, hidden = input.shape
+        flat_rows = batch * seq * streams
+        input_seqfirst = (
+            input.detach()
+            .reshape([batch, seq, streams, hidden])
+            .transpose([1, 0, 2, 3])
+            .reshape([flat_rows, hidden])
+            .contiguous()
+        )
+        grad_seqfirst = (
+            grad_output.detach()
+            .reshape([batch, seq, streams, out_features])
+            .transpose([1, 0, 2, 3])
+            .reshape([flat_rows, out_features])
+            .contiguous()
+        )
+
+    input_t = _to_torch(input_seqfirst).detach()
+    grad_t = _to_torch(grad_seqfirst).detach()
+    weight_oi_t = _to_torch(weight.t()).detach()
+
+    with torch.enable_grad():
+        input_t = input_t.requires_grad_(True)
+        weight_oi_t = weight_oi_t.requires_grad_(True)
+        output_t = torch.matmul(input_t, weight_oi_t.t())
+        output_t.backward(grad_t)
+        grad_weight_t = weight_oi_t.grad.t().contiguous()
+
+    return _to_paddle(grad_weight_t)
+
+
+class MoEInputBranches(paddle.autograd.PyLayer):
+    @staticmethod
+    def forward(ctx, x: Tensor):
+        return x.clone(), x.clone(), x.clone()
+
+    @staticmethod
+    def backward(
+        ctx, routed_grad: Tensor, router_grad: Tensor, shared_grad: Tensor
+    ):
+        return (routed_grad + router_grad) + shared_grad
+
+
+def indices_to_multihot(
+    indices: Tensor, probs: Tensor, num_local_experts: int
+) -> tuple[Tensor, Tensor]:
+    mask = indices != -1
+    safe_indices = paddle.where(mask, indices, paddle.zeros_like(indices))
+    one_hot = paddle.nn.functional.one_hot(
+        safe_indices.astype("int64"),
+        num_classes=num_local_experts,
+    )
+    valid = mask.astype(one_hot.dtype).unsqueeze(-1)
+    one_hot = one_hot * valid
+    multihot_routing_map = paddle.sum(one_hot, axis=1)
+    multihot_probs = paddle.sum(
+        one_hot.astype(probs.dtype) * probs.unsqueeze(-1),
+        axis=1,
+    ).astype("float32")
+    return multihot_routing_map.cast(paddle.bool), multihot_probs
+
+
+def _accumulate_hc_mapping_seqfirst_wgrad(
+    weight: Tensor, w_grad: Tensor
+) -> None:
+    if w_grad is None:
+        return
+    w_grad = w_grad.detach().cast(paddle.float32)
+    prev = getattr(weight, "_dsv4_hc_mapping_seqfirst_wgrad", None)
+    if prev is None:
+        weight._dsv4_hc_mapping_seqfirst_wgrad = w_grad
+    else:
+        weight._dsv4_hc_mapping_seqfirst_wgrad = prev + w_grad
+
+
+def _hc_mapping_wgrad(
+    x_seqfirst: Tensor,
+    grad_seqfirst: Tensor,
+    weight: Tensor,
+) -> Tensor:
+    torch = _import_torch()
+
+    x_t = _to_torch(x_seqfirst).detach().requires_grad_(True)
+    grad_t = _to_torch(grad_seqfirst).detach()
+    weight_oi_t = _to_torch(weight.t()).detach().requires_grad_(True)
+    with torch.enable_grad():
+        proj_t = torch.matmul(x_t, weight_oi_t.t())
+        proj_t.backward(grad_t)
+    return _to_paddle(weight_oi_t.grad.t().detach())
+
+
+def _register_hc_mapping_seqfirst_wgrad_hook(
+    proj_2d: Tensor, x: Tensor, weight: Tensor
+) -> None:
+    if (
+        len(x.shape) != 3
+        or x.shape[0] <= 1
+        or proj_2d.stop_gradient
+    ):
+        return
+
+    batch_size, seq_len, hidden_width = x.shape
+
+    def _seqfirst_wgrad_hook(grad: Tensor) -> None:
+        with paddle.no_grad():
+            out_width = grad.shape[-1]
+            x_seqfirst = (
+                x.detach()
+                .reshape([batch_size, seq_len, hidden_width])
+                .transpose([1, 0, 2])
+                .reshape([-1, hidden_width])
+            )
+            grad_seqfirst = (
+                grad.detach()
+                .reshape([batch_size, seq_len, out_width])
+                .transpose([1, 0, 2])
+                .reshape([-1, out_width])
+            )
+            w_grad = _hc_mapping_wgrad(
+                x_seqfirst,
+                grad_seqfirst,
+                weight,
+            )
+            _accumulate_hc_mapping_seqfirst_wgrad(weight, w_grad)
+
+    proj_2d.register_hook(_seqfirst_wgrad_hook)
+
+class TorchOrderRmsScale(paddle.autograd.PyLayer):
+    @staticmethod
+    def forward(ctx, x: Tensor, eps: float):
+        nC = x.shape[-1]
+        norm = x.norm(axis=-1, keepdim=True)
+        r = 1.0 / (norm / math.sqrt(nC) + eps)
+        r = r.astype(x.dtype)
+        ctx.nC = nC
+        ctx.eps = eps
+        ctx.save_for_backward(x, norm, r)
+        return r
+
+    @staticmethod
+    def backward(ctx, grad: Tensor):
+        x, _, _ = ctx.saved_tensor()
+        grad = grad.astype(x.dtype)
+        torch = _import_torch()
+
+        x_t = _to_torch(x).detach().requires_grad_(True)
+        grad_t = _to_torch(grad).detach()
+        with torch.enable_grad():
+            norm_t = x_t.norm(dim=-1, keepdim=True)
+            r_t = 1.0 / (norm_t / math.sqrt(ctx.nC) + ctx.eps)
+            r_t.backward(grad_t)
+        return _to_paddle(x_t.grad.detach()).astype(x.dtype)
+
+
+def compatible_projection_and_norm(
+    x: Tensor, weight: Tensor, eps: float
+) -> tuple[Tensor, Tensor]:
+    nC = x.shape[-1]
+    x_2d = x.reshape([-1, nC])
+    r = TorchOrderRmsScale.apply(x_2d, eps)
+    # Match Megatron clean path: torch.matmul(x, weight.t()). Paddle
+    # nn.Linear uses a different BF16 cuBLAS path for this shape and drifts
+    # before the first HC BDA.
+    proj_2d = paddle.matmul(x_2d, weight.t(), transpose_y=True)
+    _register_hc_mapping_seqfirst_wgrad_hook(proj_2d, x, weight)
+    proj = proj_2d.reshape([*x.shape[:-1], weight.shape[-1]])
+    r = r.reshape([*x.shape[:-1], 1])
+    return proj, r
+
+
+def compatible_sinkhorn_backward(
+    logits: Tensor, grad_output: Tensor, num_iterations: int, eps: float
+) -> Tensor:
+    torch = _import_torch()
+
+    logits_t = _to_torch(logits).to(torch.bfloat16)
+    grad_t = _to_torch(grad_output).to(torch.bfloat16)
+    with torch.enable_grad():
+        logits_t = logits_t.detach().requires_grad_(True)
+        row_max = logits_t.max(dim=-1, keepdim=True).values
+        m = torch.exp(logits_t - row_max)
+        for _ in range(num_iterations):
+            m = m / m.sum(dim=-1, keepdim=True).clamp(min=eps)
+            m = m / m.sum(dim=-2, keepdim=True).clamp(min=eps)
+        m.backward(grad_t)
+    grad_input_t = logits_t.grad.contiguous()
+    return _to_paddle(grad_input_t)
+
+
+class CompatibleLearnedOutputContract(paddle.autograd.PyLayer):
+    @staticmethod
+    def forward(
+        ctx,
+        hidden_states: Tensor,
+        head_fn: Tensor,
+        base: Tensor,
+        scale: Tensor,
+        n: int,
+        eps: float,
+        out_dtype,
+    ):
+        torch = _import_torch()
+        import torch.nn.functional as torch_F
+
+        head_fn_out_in = head_fn.transpose([1, 0]).contiguous()
+        hidden_t = _to_torch(hidden_states)
+        head_t = _to_torch(head_fn_out_in)
+        base_t = _to_torch(base)
+        scale_t = _to_torch(scale)
+        torch_dtype = (
+            torch.bfloat16
+            if str(out_dtype) == "paddle.bfloat16"
+            else hidden_t.dtype
+        )
+        with torch.no_grad():
+            rsqrt_t = torch.rsqrt(
+                hidden_t.square().mean(-1, keepdim=True) + eps
+            )
+            proj_t = torch_F.linear(hidden_t, head_t)
+            mixes_t = proj_t * rsqrt_t
+            pre_arg_t = mixes_t * scale_t + base_t
+            sig_t = torch.sigmoid(pre_arg_t)
+            pre_t = sig_t + eps
+            y_t = torch.sum(
+                pre_t.unsqueeze(-1)
+                * hidden_t.reshape(*hidden_t.shape[:-1], n, -1),
+                dim=-2,
+            )
+            out_t = y_t.to(torch_dtype)
+        out = _to_paddle(out_t)
+
+        ctx.save_for_backward(
+            hidden_states,
+            head_fn,
+            base,
+            scale,
+        )
+        ctx.n = n
+        ctx.eps = eps
+        ctx.out_dtype = out_dtype
+        return out
+
+    @staticmethod
+    def backward(ctx, grad_output: Tensor):
+        (
+            hidden_input,
+            head_fn_input,
+            base_input,
+            scale_input,
+        ) = ctx.saved_tensor()
+        n = ctx.n
+        eps = ctx.eps
+        torch = _import_torch()
+        import torch.nn.functional as torch_F
+
+        hidden_input_t = _to_torch(hidden_input).detach().requires_grad_(True)
+        head_input_t = _to_torch(head_fn_input).detach().requires_grad_(True)
+        base_input_t = _to_torch(base_input).detach().requires_grad_(True)
+        scale_input_t = _to_torch(scale_input).detach().requires_grad_(True)
+        grad_t = _to_torch(grad_output).detach()
+        torch_dtype = (
+            torch.bfloat16
+            if str(ctx.out_dtype) == "paddle.bfloat16"
+            else hidden_input_t.dtype
+        )
+
+        with torch.enable_grad():
+            hidden_t = hidden_input_t.to(torch.float32)
+            head_io_t = head_input_t.to(torch.float32)
+            base_t = base_input_t.to(torch.float32)
+            scale_t = scale_input_t.to(torch.float32)
+            head_oi_t = head_io_t.transpose(0, 1).contiguous()
+            rsqrt_t = torch.rsqrt(
+                hidden_t.square().mean(-1, keepdim=True) + eps
+            )
+            mixes_t = torch_F.linear(hidden_t, head_oi_t) * rsqrt_t
+            pre_t = torch.sigmoid(mixes_t * scale_t + base_t) + eps
+            y_t = torch.sum(
+                pre_t.unsqueeze(-1)
+                * hidden_t.reshape(*hidden_t.shape[:-1], n, -1),
+                dim=-2,
+            )
+            out_t = y_t.to(torch_dtype)
+            out_t.backward(grad_t)
+
+        head_grad_t = head_input_t.grad
+        if hidden_input_t.ndim == 3 and hidden_input_t.shape[0] > 1:
+            hidden_seq_input_t = (
+                hidden_input_t.detach()
+                .transpose(0, 1)
+                .contiguous()
+                .requires_grad_(True)
+            )
+            grad_seq_t = grad_t.transpose(0, 1).contiguous()
+            head_seq_t = head_input_t.detach().requires_grad_(True)
+            base_seq_t = base_input_t.detach()
+            scale_seq_t = scale_input_t.detach()
+            with torch.enable_grad():
+                hidden_seq_t = hidden_seq_input_t.to(torch.float32)
+                head_seq_oi_t = (
+                    head_seq_t.to(torch.float32)
+                    .transpose(0, 1)
+                    .contiguous()
+                )
+                base_seq_f32_t = base_seq_t.to(torch.float32)
+                scale_seq_f32_t = scale_seq_t.to(torch.float32)
+                rsqrt_seq_t = torch.rsqrt(
+                    hidden_seq_t.square().mean(-1, keepdim=True) + eps
+                )
+                mixes_seq_t = (
+                    torch_F.linear(hidden_seq_t, head_seq_oi_t) * rsqrt_seq_t
+                )
+                pre_seq_t = (
+                    torch.sigmoid(
+                        mixes_seq_t * scale_seq_f32_t + base_seq_f32_t
+                    )
+                    + eps
+                )
+                y_seq_t = torch.sum(
+                    pre_seq_t.unsqueeze(-1)
+                    * hidden_seq_t.reshape(*hidden_seq_t.shape[:-1], n, -1),
+                    dim=-2,
+                )
+                out_seq_t = y_seq_t.to(torch_dtype)
+                out_seq_t.backward(grad_seq_t)
+            head_grad_t = head_seq_t.grad
+
+        return (
+            _to_paddle(hidden_input_t.grad.detach()),
+            _to_paddle(head_grad_t.detach()),
+            _to_paddle(base_input_t.grad.detach()),
+            _to_paddle(scale_input_t.grad.detach()),
+        )

--- a/src/paddlefleet/accuracy_compatible_patch.py
+++ b/src/paddlefleet/accuracy_compatible_patch.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import annotations
 
 import math
@@ -7,6 +21,7 @@ import sys
 import paddle
 from paddle import Tensor
 from paddle.utils import dlpack as paddle_dlpack
+
 
 def _import_torch():
     site_packages = os.environ.get("MEGATRON_SITE_PACKAGES", "")
@@ -129,6 +144,7 @@ class CompatibleHadamard(paddle.autograd.PyLayer):
     @staticmethod
     def forward(ctx, x: Tensor, scale: float):
         from fast_hadamard_transform import hadamard_transform
+
         scale = float(scale)
         ctx.scale = scale
         x_t = _to_torch(x)
@@ -138,9 +154,11 @@ class CompatibleHadamard(paddle.autograd.PyLayer):
     @staticmethod
     def backward(ctx, grad_output: Tensor):
         from fast_hadamard_transform import hadamard_transform
+
         grad_t = _to_torch(grad_output)
         grad_x_t = hadamard_transform(grad_t, scale=ctx.scale)
         return _to_paddle(grad_x_t)
+
 
 class CompatibleOGroupProjection(paddle.autograd.PyLayer):
     @staticmethod
@@ -162,9 +180,11 @@ class CompatibleOGroupProjection(paddle.autograd.PyLayer):
         ctx.save_for_backward(x, weight)
 
         x_seqfirst = x.detach().transpose([1, 0, 2, 3]).contiguous()
-        weight_grouped = weight.detach().reshape(
-            [o_local_groups, o_lora_rank, -1]
-        ).contiguous()
+        weight_grouped = (
+            weight.detach()
+            .reshape([o_local_groups, o_lora_rank, -1])
+            .contiguous()
+        )
         x_t = _to_torch(x_seqfirst).detach()
         weight_t = _to_torch(weight_grouped).detach()
         out_t = torch.einsum("...gd,grd->...gr", x_t, weight_t)
@@ -177,12 +197,14 @@ class CompatibleOGroupProjection(paddle.autograd.PyLayer):
 
         x, weight = ctx.saved_tensor()
         x_seqfirst = x.detach().transpose([1, 0, 2, 3]).contiguous()
-        grad_seqfirst = grad_output.detach().transpose(
-            [1, 0, 2, 3]
-        ).contiguous()
-        weight_grouped = weight.detach().reshape(
-            [ctx.o_local_groups, ctx.o_lora_rank, -1]
-        ).contiguous()
+        grad_seqfirst = (
+            grad_output.detach().transpose([1, 0, 2, 3]).contiguous()
+        )
+        weight_grouped = (
+            weight.detach()
+            .reshape([ctx.o_local_groups, ctx.o_lora_rank, -1])
+            .contiguous()
+        )
 
         x_t = _to_torch(x_seqfirst).detach()
         grad_t = _to_torch(grad_seqfirst).detach()
@@ -207,6 +229,7 @@ class CompatibleOGroupProjection(paddle.autograd.PyLayer):
             weight._dsv4_attn_o_group_seqfirst_wgrad = prev + w_grad_accum
         return x_grad, w_grad
 
+
 class CompatibleQRMSNorm(paddle.autograd.PyLayer):
     @staticmethod
     def forward(ctx, q: Tensor, eps: float) -> Tensor:
@@ -226,11 +249,10 @@ class CompatibleQRMSNorm(paddle.autograd.PyLayer):
         )
         return grad_q
 
+
 class CompatibleEmbeddingIndexBackward(paddle.autograd.PyLayer):
     @staticmethod
-    def forward(
-        ctx, masked_input: Tensor, weight: Tensor
-    ) -> Tensor:
+    def forward(ctx, masked_input: Tensor, weight: Tensor) -> Tensor:
         ctx.save_for_backward(masked_input, weight)
         return weight[masked_input]
 
@@ -251,6 +273,7 @@ class CompatibleEmbeddingIndexBackward(paddle.autograd.PyLayer):
 
         grad_weight = _to_paddle(grad_weight_t)
         return None, grad_weight
+
 
 def te_matmul(grad_output: Tensor, weight: Tensor) -> Tensor:
     torch = _import_torch()
@@ -394,11 +417,7 @@ def _hc_mapping_wgrad(
 def _register_hc_mapping_seqfirst_wgrad_hook(
     proj_2d: Tensor, x: Tensor, weight: Tensor
 ) -> None:
-    if (
-        len(x.shape) != 3
-        or x.shape[0] <= 1
-        or proj_2d.stop_gradient
-    ):
+    if len(x.shape) != 3 or x.shape[0] <= 1 or proj_2d.stop_gradient:
         return
 
     batch_size, seq_len, hidden_width = x.shape
@@ -426,6 +445,7 @@ def _register_hc_mapping_seqfirst_wgrad_hook(
             _accumulate_hc_mapping_seqfirst_wgrad(weight, w_grad)
 
     proj_2d.register_hook(_seqfirst_wgrad_hook)
+
 
 class TorchOrderRmsScale(paddle.autograd.PyLayer):
     @staticmethod
@@ -600,9 +620,7 @@ class CompatibleLearnedOutputContract(paddle.autograd.PyLayer):
             with torch.enable_grad():
                 hidden_seq_t = hidden_seq_input_t.to(torch.float32)
                 head_seq_oi_t = (
-                    head_seq_t.to(torch.float32)
-                    .transpose(0, 1)
-                    .contiguous()
+                    head_seq_t.to(torch.float32).transpose(0, 1).contiguous()
                 )
                 base_seq_f32_t = base_seq_t.to(torch.float32)
                 scale_seq_f32_t = scale_seq_t.to(torch.float32)

--- a/src/paddlefleet/fusions/fused_bias_swiglu.py
+++ b/src/paddlefleet/fusions/fused_bias_swiglu.py
@@ -21,7 +21,10 @@ import paddle
 import paddle.nn.functional as F
 
 from paddlefleet.jit import jit_fuser
-from paddlefleet.utils import nvtx_decorator
+from paddlefleet.utils import (
+    nvtx_decorator,
+    apply_dsv4_accuracy_compatible_patch,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -158,11 +161,21 @@ def clamped_swiglu_back(g, y, clamp_value):
     # Clamp masks in g.dtype
     y1_mask = (y_1 <= clamp_value).cast(g.dtype)
     y2_mask = ((y_2 >= -clamp_value) & (y_2 <= clamp_value)).cast(g.dtype)
-    sig = F.sigmoid(y_1_clamped)
-    grad_y1 = (
-        g * sig * (1.0 + y_1_clamped * (1.0 - sig)) * y_2_clamped * y1_mask
-    )
-    grad_y2 = g * (y_1_clamped * sig) * y2_mask  # silu = x * sigmoid(x)
+    if apply_dsv4_accuracy_compatible_patch():
+        grad_y1 = (
+            g
+            * F.sigmoid(y_1_clamped)
+            * (1.0 + y_1_clamped * (1.0 - F.sigmoid(y_1_clamped)))
+            * y_2_clamped
+            * y1_mask
+        )
+        grad_y2 = g * F.silu(y_1_clamped) * y2_mask
+    else:
+        sig = F.sigmoid(y_1_clamped)
+        grad_y1 = (
+            g * sig * (1.0 + y_1_clamped * (1.0 - sig)) * y_2_clamped * y1_mask
+        )
+        grad_y2 = g * (y_1_clamped * sig) * y2_mask  # silu = x * sigmoid(x)
     return paddle.concat([grad_y1, grad_y2], axis=-1).cast(dtype)
 
 
@@ -251,7 +264,11 @@ def clamped_weighted_swiglu_back(g, y, weights, clamp_value):
     w_dtype = weights.dtype
     input_grad = clamped_swiglu_back(g * weights, y, clamp_value)
     weights_grad = clamped_swiglu(y, clamp_value) * g.cast(w_dtype)
-    weights_grad = paddle.sum(weights_grad, axis=-1, keepdim=True)
+    if apply_dsv4_accuracy_compatible_patch():
+        from paddlefleet.accuracy_compatible_patch import sum_for_small_rows
+        weights_grad = sum_for_small_rows(weights_grad)
+    else:
+        weights_grad = paddle.sum(weights_grad, axis=-1, keepdim=True)
     return input_grad.cast(input_dtype), weights_grad.cast(w_dtype)
 
 

--- a/src/paddlefleet/fusions/fused_bias_swiglu.py
+++ b/src/paddlefleet/fusions/fused_bias_swiglu.py
@@ -22,8 +22,8 @@ import paddle.nn.functional as F
 
 from paddlefleet.jit import jit_fuser
 from paddlefleet.utils import (
-    nvtx_decorator,
     apply_dsv4_accuracy_compatible_patch,
+    nvtx_decorator,
 )
 
 logger = logging.getLogger(__name__)
@@ -266,6 +266,7 @@ def clamped_weighted_swiglu_back(g, y, weights, clamp_value):
     weights_grad = clamped_swiglu(y, clamp_value) * g.cast(w_dtype)
     if apply_dsv4_accuracy_compatible_patch():
         from paddlefleet.accuracy_compatible_patch import sum_for_small_rows
+
         weights_grad = sum_for_small_rows(weights_grad)
     else:
         weights_grad = paddle.sum(weights_grad, axis=-1, keepdim=True)

--- a/src/paddlefleet/models/common/language_loss/language_loss.py
+++ b/src/paddlefleet/models/common/language_loss/language_loss.py
@@ -28,12 +28,11 @@ from paddle.distributed.fleet.meta_parallel import ScheduleNode
 from paddle.distributed.fleet.utils import recompute
 from paddle.distributed.fleet.utils.sequence_parallel_utils import AllGatherOp
 
+from paddlefleet.accuracy_compatible_patch import LossScaleBeforeBackward
 from paddlefleet.context_parallel_utils import (
     ContextParallelGatherOp,
     ContextParallelScatterOp,
 )
-from paddlefleet.utils import apply_dsv4_accuracy_compatible_patch
-from paddlefleet.accuracy_compatible_patch import LossScaleBeforeBackward
 from paddlefleet.parallel_state import (
     get_context_parallel_world_size,
     get_tensor_model_parallel_world_size,
@@ -42,6 +41,7 @@ from paddlefleet.process_groups_config import ProcessGroupCollection
 from paddlefleet.training.global_vars import get_global_training_logs
 from paddlefleet.transformer.layer import FleetLayer
 from paddlefleet.transformer.transformer_config import TransformerConfig
+from paddlefleet.utils import apply_dsv4_accuracy_compatible_patch
 
 
 def _loss_md5_enabled() -> bool:

--- a/src/paddlefleet/models/common/language_loss/language_loss.py
+++ b/src/paddlefleet/models/common/language_loss/language_loss.py
@@ -32,6 +32,8 @@ from paddlefleet.context_parallel_utils import (
     ContextParallelGatherOp,
     ContextParallelScatterOp,
 )
+from paddlefleet.utils import apply_dsv4_accuracy_compatible_patch
+from paddlefleet.accuracy_compatible_patch import LossScaleBeforeBackward
 from paddlefleet.parallel_state import (
     get_context_parallel_world_size,
     get_tensor_model_parallel_world_size,
@@ -44,14 +46,6 @@ from paddlefleet.transformer.transformer_config import TransformerConfig
 
 def _loss_md5_enabled() -> bool:
     return os.environ.get("LOG_LOSS_MD5", "0") == "1"
-
-
-def _use_accuracy_compatible_kernel() -> bool:
-    """Switch for Megatron-aligned (accuracy-compatible) numeric paths.
-
-    Controlled by the ``FLAGS_use_accuracy_compatible_kernel`` env variable.
-    """
-    return os.environ.get("FLAGS_use_accuracy_compatible_kernel", "0") == "1"
 
 
 def _tensor_md5(tensor: Tensor, dtype: str = "float32") -> str:
@@ -633,6 +627,9 @@ class LanguageLoss(FleetLayer):
                         ploss = ploss / xishu
                         mtp_loss.append(ploss)
 
+            if apply_dsv4_accuracy_compatible_patch():
+                LossScaleBeforeBackward.record(lm_loss)
+
             # Store detached MTP loss tensors into class-level tracker and global_training_logs.
             # Use .detach() instead of .item() to avoid GPU synchronization on every
             # micro-batch. The trainer will call .item() only at logging steps.
@@ -652,12 +649,12 @@ class LanguageLoss(FleetLayer):
                     logs.update(**{f"mtp_{i + 1}_loss": loss_val.detach()})
 
             def add_loss(main_loss, loss):
-                if _use_accuracy_compatible_kernel():
+                if apply_dsv4_accuracy_compatible_patch():
                     # Megatron-aligned: MTP loss gradient flows but loss scalar unchanged.
                     # This matches Megatron's behavior where MTP contributes to training
                     # gradients without affecting the reported loss value.
                     if self.config.add_mtp_loss:
-                        return main_loss + loss - loss.detach()
+                        return loss - loss.detach() + main_loss
                     else:
                         return main_loss
                 else:
@@ -671,7 +668,7 @@ class LanguageLoss(FleetLayer):
                 # Align with EB: accumulate inside loop to match float32
                 # arithmetic order: loss += scaling * loss_i / N
                 loss = lm_loss
-                if _use_accuracy_compatible_kernel():
+                if apply_dsv4_accuracy_compatible_patch():
                     # Megatron-aligned: only add MTP loss when add_mtp_loss=True.
                     # Use add_loss() to keep single maintenance point for compat
                     # behavior (loss + val - val.detach() for gradient-only flow).
@@ -701,10 +698,16 @@ class LanguageLoss(FleetLayer):
                     * sum(mtp_loss)
                     / len(mtp_loss),
                 )
+            if apply_dsv4_accuracy_compatible_patch():
+                loss = LossScaleBeforeBackward.scale(loss)
 
             return loss
         else:
-            return self._forward(logits, labels)
+            loss = self._forward(logits, labels)
+            if apply_dsv4_accuracy_compatible_patch():
+                LossScaleBeforeBackward.record(loss)
+                loss = LossScaleBeforeBackward.scale(loss)
+            return loss
 
     def build_schedule_node(self):
         return ScheduleNode(self.forward, name="LanguageLoss")
@@ -763,7 +766,7 @@ class MainLanguageLoss(LanguageLoss):
                 logs.update(**{f"mtp_{i + 1}_loss": loss_val.detach()})
 
         def add_loss(main_loss, loss):
-            if _use_accuracy_compatible_kernel():
+            if apply_dsv4_accuracy_compatible_patch():
                 # Megatron-aligned: MTP loss gradient flows but loss scalar unchanged.
                 # This matches Megatron's behavior
                 if self.config.add_mtp_loss:

--- a/src/paddlefleet/models/gpt/gpt_embedding.py
+++ b/src/paddlefleet/models/gpt/gpt_embedding.py
@@ -382,8 +382,8 @@ class GPTEmbedding(FleetLayer):
                             shift = depth + 1
                             inputs_embeds_mtp = paddle.concat(
                                 [
-                                    inputs_embeds_ori[:, (depth + 1):, :],
-                                    inputs_embeds_extra[:, :(depth + 1), :],
+                                    inputs_embeds_ori[:, (depth + 1) :, :],
+                                    inputs_embeds_extra[:, : (depth + 1), :],
                                 ],
                                 axis=1,
                             )

--- a/src/paddlefleet/models/gpt/gpt_embedding.py
+++ b/src/paddlefleet/models/gpt/gpt_embedding.py
@@ -39,6 +39,7 @@ from paddlefleet.tensor_parallel.mappings import (
     scatter_to_sequence_parallel_region,
 )
 from paddlefleet.transformer.layer import FleetLayer
+from paddlefleet.utils import apply_dsv4_accuracy_compatible_patch
 
 if TYPE_CHECKING:
     from paddle import Tensor
@@ -137,6 +138,39 @@ class GPTEmbedding(FleetLayer):
     def build_schedule_node(self):
         return ScheduleNode(self.forward, name="GPTEmbedding")
 
+    def _embed_shifted_mtp(
+        self,
+        input_ids: Tensor,
+        position_ids: Tensor | None,
+        depth: int,
+        seq_length: int,
+    ):
+        shift = depth + 1
+        shifted_input_ids = input_ids[:, shift:seq_length]
+        pad_input_ids = paddle.zeros(
+            [input_ids.shape[0], shift],
+            dtype=input_ids.dtype,
+        )
+        mtp_input_ids = paddle.concat(
+            [shifted_input_ids, pad_input_ids],
+            axis=1,
+        )
+        mtp_position_ids = None
+        if not self.multimodal_embedding and position_ids is not None:
+            shifted_position_ids = position_ids[:, shift:seq_length]
+            pad_position_ids = paddle.zeros(
+                [position_ids.shape[0], shift],
+                dtype=position_ids.dtype,
+            )
+            mtp_position_ids = paddle.concat(
+                [shifted_position_ids, pad_position_ids],
+                axis=1,
+            )
+        return self.embedding(
+            input_ids=mtp_input_ids,
+            position_ids=mtp_position_ids,
+        )
+
     def forward(
         self,
         dict_args: dict,
@@ -234,9 +268,27 @@ class GPTEmbedding(FleetLayer):
                     )
                     mtp_ids_list = []
                     for depth in range(self.config.num_nextn_predict_layers):
-                        mtp_ids_list.append(
-                            input_ids[:, (depth + 1) : (depth + 1 + seq_length)]
-                        )
+                        if apply_dsv4_accuracy_compatible_patch():
+                            pad_ids = paddle.zeros(
+                                [input_ids.shape[0], depth + 1],
+                                dtype=input_ids.dtype,
+                            )
+                            mtp_ids_list.append(
+                                paddle.concat(
+                                    [
+                                        input_ids[:, depth + 1 : seq_length],
+                                        pad_ids,
+                                    ],
+                                    axis=1,
+                                )
+                            )
+                        else:
+                            mtp_ids_list.append(
+                                input_ids[
+                                    :,
+                                    (depth + 1) : (depth + 1 + seq_length),
+                                ]
+                            )
                     # [B, num_mtp, max_seq] - paddle.stack creates a new contiguous tensor
                     mtp_input_ids_for_moe_mask = paddle.stack(
                         mtp_ids_list, axis=1
@@ -319,13 +371,22 @@ class GPTEmbedding(FleetLayer):
                         )  # change to [S, B, H]
                     mtp_emb_res = [inputs_embeds]
                     for depth in range(self.config.num_nextn_predict_layers):
-                        inputs_embeds_mtp = paddle.concat(
-                            [
-                                inputs_embeds_ori[:, (depth + 1) :, :],
-                                inputs_embeds_extra[:, : (depth + 1), :],
-                            ],
-                            axis=1,
-                        )
+                        if apply_dsv4_accuracy_compatible_patch():
+                            inputs_embeds_mtp = self._embed_shifted_mtp(
+                                input_ids,
+                                position_ids,
+                                depth,
+                                seq_length,
+                            )
+                        else:
+                            shift = depth + 1
+                            inputs_embeds_mtp = paddle.concat(
+                                [
+                                    inputs_embeds_ori[:, (depth + 1):, :],
+                                    inputs_embeds_extra[:, :(depth + 1), :],
+                                ],
+                                axis=1,
+                            )
 
                         if (
                             get_context_parallel_world_size() > 1

--- a/src/paddlefleet/models/gpt/lm_head.py
+++ b/src/paddlefleet/models/gpt/lm_head.py
@@ -77,6 +77,7 @@ from paddlefleet.tensor_parallel.layers import (
     _initialize_affine_weight_cpu,
     _initialize_affine_weight_gpu,
 )
+from paddlefleet.utils import apply_dsv4_accuracy_compatible_patch
 from paddlefleet.transformer.identity_op import IdentityOp
 
 
@@ -232,6 +233,12 @@ class GPTLMHead(ColumnParallelLinear):
         return ScheduleNode(self.forward, name="GPTLMHead")
 
     def _forward(self, hidden_states: paddle.Tensor):
+        use_sequence_first_linear = (
+            apply_dsv4_accuracy_compatible_patch()
+            and not self.config.sequence_parallel
+        )
+        if use_sequence_first_linear:
+            hidden_states = hidden_states.transpose([1, 0, 2]).contiguous()
         # Fused linear + cross-entropy path: skip materializing [B, S, V] logits
         # and delegate the linear projection into LanguageLoss, which will call
         # LigerFusedLinearCrossEntropyFunction.
@@ -277,6 +284,8 @@ class GPTLMHead(ColumnParallelLinear):
             logits = recompute_handler(hidden_states, self.weight.T)
         else:
             logits, _ = super().forward(hidden_states, self.weight.T)
+        if use_sequence_first_linear:
+            logits = logits.transpose([1, 0, 2]).contiguous()
         if (
             not self.config.gpt_model_use_experimental_version
             and self.config.sequence_parallel

--- a/src/paddlefleet/models/gpt/lm_head.py
+++ b/src/paddlefleet/models/gpt/lm_head.py
@@ -77,8 +77,8 @@ from paddlefleet.tensor_parallel.layers import (
     _initialize_affine_weight_cpu,
     _initialize_affine_weight_gpu,
 )
-from paddlefleet.utils import apply_dsv4_accuracy_compatible_patch
 from paddlefleet.transformer.identity_op import IdentityOp
+from paddlefleet.utils import apply_dsv4_accuracy_compatible_patch
 
 
 def SegLU(x, ranges, ts):

--- a/src/paddlefleet/tensor_parallel/layers.py
+++ b/src/paddlefleet/tensor_parallel/layers.py
@@ -39,6 +39,7 @@ from ..parallel_state import (
 # from ..dist_checkpointing.mapping import ShardedStateDict
 # from ..transformer.utils import make_sharded_tensors_for_checkpoint
 from ..utils import (
+    apply_dsv4_accuracy_compatible_patch,
     divide,
     get_pg_rank,
     get_pg_size,
@@ -309,7 +310,10 @@ class VocabParallelEmbedding(paddle.nn.Layer):
         else:
             masked_input = input_
         # Get the embeddings.
-        if self.deterministic_mode:
+        if (
+            self.deterministic_mode
+            or apply_dsv4_accuracy_compatible_patch()
+        ):
             output_parallel = self.weight[masked_input]
         else:
             # F.embedding currently has a non-deterministic backward function
@@ -357,7 +361,12 @@ class LinearWithFrozenWeight(paddle.autograd.Function):
         ctx.save_for_backward(weight, bias)
         ctx.allreduce_dgrad = allreduce_dgrad
         ctx.tp_group = tp_group
-        output = paddle.matmul(input, weight)
+        if apply_dsv4_accuracy_compatible_patch():
+            output = paddle.matmul(
+                input, weight.t().contiguous(), transpose_y=True
+            )
+        else:
+            output = paddle.matmul(input, weight)
 
         if bias is not None:
             output = output + bias
@@ -367,7 +376,11 @@ class LinearWithFrozenWeight(paddle.autograd.Function):
     def backward(ctx, grad_output):
         """Backward with frozen weight."""
         (weight, bias) = ctx.saved_tensor()
-        grad_input = grad_output.matmul(weight.t())
+        if apply_dsv4_accuracy_compatible_patch():
+            from paddlefleet.accuracy_compatible_patch import te_matmul
+            grad_input = te_matmul(grad_output, weight)
+        else:
+            grad_input = grad_output.matmul(weight.t())
 
         if ctx.allreduce_dgrad:
             # All-reduce. Note: here async and sync are effectively the same.
@@ -515,6 +528,10 @@ class LinearWithGradAccumulationAndAsyncCommunication(paddle.autograd.Function):
 
         if bias is not None:
             output = paddle.nn.functional.linear(total_input, weight, bias)
+        elif apply_dsv4_accuracy_compatible_patch():
+            output = paddle.matmul(
+                total_input, weight.t().contiguous(), transpose_y=True
+            )
         else:
             output = paddle.matmul(total_input, weight)
         return output
@@ -569,14 +586,27 @@ class LinearWithGradAccumulationAndAsyncCommunication(paddle.autograd.Function):
                 total_input = all_gather_buffer
             else:
                 total_input = input
-        if input_needs_grad:
-            grad_input = grad_output.matmul(weight.t())
-        else:
+        if not input_needs_grad:
             grad_input = None
+        elif apply_dsv4_accuracy_compatible_patch():
+            from paddlefleet.accuracy_compatible_patch import te_matmul
+            grad_input = te_matmul(grad_output, weight)
+        else:
+            grad_input = grad_output.matmul(weight.t())
 
         if ctx.sequence_parallel and wgrad_compute:
             # pylint: disable=possibly-used-before-assignment
             handle.wait()
+
+        seqfirst_grad_weight = None
+        if wgrad_compute and apply_dsv4_accuracy_compatible_patch():
+            from paddlefleet.accuracy_compatible_patch import (
+                linear_seqfirst_wgrad,
+            )
+
+            seqfirst_grad_weight = linear_seqfirst_wgrad(
+                input, grad_output, weight
+            )
 
         if wgrad_compute:
             grad_output, total_input = prepare_input_tensors_for_wgrad_compute(
@@ -644,7 +674,10 @@ class LinearWithGradAccumulationAndAsyncCommunication(paddle.autograd.Function):
             else:
                 grad_weight = None
         else:
-            grad_weight = total_input.t().matmul(grad_output)
+            if seqfirst_grad_weight is not None:
+                grad_weight = seqfirst_grad_weight
+            else:
+                grad_weight = total_input.t().matmul(grad_output)
         grad_bias = grad_output.sum(dim=0) if use_bias else None
 
         if ctx.sequence_parallel:

--- a/src/paddlefleet/tensor_parallel/layers.py
+++ b/src/paddlefleet/tensor_parallel/layers.py
@@ -310,10 +310,7 @@ class VocabParallelEmbedding(paddle.nn.Layer):
         else:
             masked_input = input_
         # Get the embeddings.
-        if (
-            self.deterministic_mode
-            or apply_dsv4_accuracy_compatible_patch()
-        ):
+        if self.deterministic_mode or apply_dsv4_accuracy_compatible_patch():
             output_parallel = self.weight[masked_input]
         else:
             # F.embedding currently has a non-deterministic backward function
@@ -378,6 +375,7 @@ class LinearWithFrozenWeight(paddle.autograd.Function):
         (weight, bias) = ctx.saved_tensor()
         if apply_dsv4_accuracy_compatible_patch():
             from paddlefleet.accuracy_compatible_patch import te_matmul
+
             grad_input = te_matmul(grad_output, weight)
         else:
             grad_input = grad_output.matmul(weight.t())
@@ -590,6 +588,7 @@ class LinearWithGradAccumulationAndAsyncCommunication(paddle.autograd.Function):
             grad_input = None
         elif apply_dsv4_accuracy_compatible_patch():
             from paddlefleet.accuracy_compatible_patch import te_matmul
+
             grad_input = te_matmul(grad_output, weight)
         else:
             grad_input = grad_output.matmul(weight.t())

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -24,8 +24,6 @@ Components:
 """
 
 from __future__ import annotations
-
-import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -38,10 +36,7 @@ from paddlefleet.models.common.embeddings.rope_utils import (
     _apply_rotary_pos_emb_bshd,
 )
 from paddlefleet.transformer import FleetLayer
-
-_ACCURACY_COMPATIBLE_KERNEL: bool = (
-    os.environ.get("FLAGS_use_accuracy_compatible_kernel", "0") == "1"
-)
+from paddlefleet.utils import apply_dsv4_accuracy_compatible_patch
 from paddlefleet.transformer.dsa_attention import (
     DSAIndexerLossAutoScaler,
     DSAIndexerLossLoggingHelper,
@@ -569,17 +564,21 @@ def unfused_compressed_sparse_attn(
         # Softmax with attention sink
         # sink: [np] -> [1, np, 1, 1]
         sink = attn_sink.reshape([1, np_heads, 1, 1])
-        # Compute stable softmax: max over scores and sink
-        scores_max = scores.max(axis=-1, keepdim=True)  # [b, np, sq, 1]
-        scores_max = paddle.maximum(scores_max, sink)
+        if apply_dsv4_accuracy_compatible_patch():
+            from paddlefleet.accuracy_compatible_patch import (
+                CompatibleCSASinkSoftmax,
+            )
 
-        exp_scores = paddle.exp(scores - scores_max)  # [b, np, sq, topk]
-        exp_sink = paddle.exp(sink - scores_max)  # [b, np, sq, 1]
-
-        sum_exp = (
-            exp_scores.sum(axis=-1, keepdim=True) + exp_sink
-        )  # [b, np, sq, 1]
-        attn_weights = exp_scores / sum_exp  # [b, np, sq, topk]
+            attn_weights = CompatibleCSASinkSoftmax.apply(
+                scores, sink.cast("float32")
+            )
+        else:
+            scores_max = scores.max(axis=-1, keepdim=True)
+            scores_max = paddle.maximum(scores_max, sink)
+            exp_scores = paddle.exp(scores - scores_max)
+            exp_sink = paddle.exp(sink - scores_max)
+            sum_exp = exp_scores.sum(axis=-1, keepdim=True) + exp_sink
+            attn_weights = exp_scores / sum_exp
 
         # Weighted sum: [b, np, sq, topk] x [b, sq, topk, hn] -> [b, np, sq, hn]
         output = paddle.einsum("bnsk,bskh->bnsh", attn_weights, kv_g)
@@ -1124,8 +1123,8 @@ class Compressor(nn.Layer):
                 else 0.02
             ),
         )
-        self._cast_to_low_precision = False
-
+        if not apply_dsv4_accuracy_compatible_patch():
+            self._cast_to_low_precision = False
         self.norm = build_spec_layer(
             sublayers_spec.norm,
             config=config,
@@ -1266,7 +1265,8 @@ class Compressor(nn.Layer):
 
             # APE: [ratio, coff * head_dim] -> [1, 1, ratio, coff * head_dim]
             ape = self.ape.reshape([1, 1, ratio, -1])
-            ape = ape.cast(score.dtype) if _ACCURACY_COMPATIBLE_KERNEL else ape
+            if apply_dsv4_accuracy_compatible_patch():
+                ape = ape.cast(score.dtype)
             score = score + ape
 
             if self.overlap:
@@ -1343,7 +1343,8 @@ class Compressor(nn.Layer):
 
         # APE: [ratio, coff * head_dim] -> [1, 1, ratio, coff * head_dim]
         ape = self.ape.reshape([1, 1, ratio, -1])
-        ape = ape.cast(score.dtype) if _ACCURACY_COMPATIBLE_KERNEL else ape
+        if apply_dsv4_accuracy_compatible_patch():
+            ape = ape.cast(score.dtype)
         score = score + ape
 
         if self.overlap:
@@ -1629,7 +1630,8 @@ class CompressedSparseAttention(FleetLayer):
             dtype="float32",
             default_initializer=nn.initializer.Constant(0.0),
         )
-        self._cast_to_low_precision = False
+        if not apply_dsv4_accuracy_compatible_patch():
+            self._cast_to_low_precision = False
 
         # Conditionally build Compressor (ratio > 1)
         if self.compress_ratio > 1:
@@ -2364,7 +2366,7 @@ class CompressedSparseAttention(FleetLayer):
     ):
         attn_sink_fp32 = (
             attn_sink.cast("bfloat16").cast("float32")
-            if _ACCURACY_COMPATIBLE_KERNEL
+            if apply_dsv4_accuracy_compatible_patch()
             else attn_sink.cast("float32")
         )
         if _resolve_csa_tilelang_switch(

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -24,6 +24,7 @@ Components:
 """
 
 from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -36,7 +37,6 @@ from paddlefleet.models.common.embeddings.rope_utils import (
     _apply_rotary_pos_emb_bshd,
 )
 from paddlefleet.transformer import FleetLayer
-from paddlefleet.utils import apply_dsv4_accuracy_compatible_patch
 from paddlefleet.transformer.dsa_attention import (
     DSAIndexerLossAutoScaler,
     DSAIndexerLossLoggingHelper,
@@ -48,6 +48,7 @@ from paddlefleet.transformer.utils import (
     get_doc_lens,
     get_doc_starts,
 )
+from paddlefleet.utils import apply_dsv4_accuracy_compatible_patch
 
 if TYPE_CHECKING:
     from paddlefleet.process_groups_config import ProcessGroupCollection

--- a/src/paddlefleet/transformer/dsa_attention.py
+++ b/src/paddlefleet/transformer/dsa_attention.py
@@ -37,6 +37,7 @@ from paddlefleet import parallel_state
 from paddlefleet.models.common.embeddings.rope_utils import (
     _apply_rotary_pos_emb_bshd,
 )
+from paddlefleet.utils import apply_dsv4_accuracy_compatible_patch
 from paddlefleet.models.common.embeddings.rotary_pos_embedding import (
     RotaryEmbedding,
 )
@@ -85,6 +86,10 @@ def hadamard_transform(x: Tensor, scale: float = 1.0) -> Tensor:
     assert dim > 0 and (dim & (dim - 1)) == 0, (
         f"hadamard_transform requires dim to be a power of 2, got {dim}"
     )
+
+    if apply_dsv4_accuracy_compatible_patch():
+        from paddlefleet.accuracy_compatible_patch import CompatibleHadamard
+        return CompatibleHadamard.apply(x, scale)
 
     # Megatron uses fast_hadamard_transform, whose bf16 path accumulates in fp32
     # and casts back to bf16. Keep the same numeric contract here.
@@ -913,9 +918,14 @@ def _bwd_fused_indexer_loss(
         "sbht,tbd->sbhd", grad_scores, k.cast("float32")
     )  # [sq, b, h, d]
     # ∂L/∂k = einsum('sbht,sbhd->tbd', grad_scores, q)
-    grad_k = paddle.einsum(
-        "sbht,sbhd->tbd", grad_scores, q.cast("float32")
-    )  # [sk, b, d]
+    if apply_dsv4_accuracy_compatible_patch():
+        from paddlefleet.accuracy_compatible_patch import compatible_einsum
+
+        grad_k = compatible_einsum(grad_scores, q)
+    else:
+        grad_k = paddle.einsum(
+            "sbht,sbhd->tbd", grad_scores, q.cast("float32")
+        )  # [sk, b, d]
     del grad_scores
 
     return (

--- a/src/paddlefleet/transformer/dsa_attention.py
+++ b/src/paddlefleet/transformer/dsa_attention.py
@@ -37,7 +37,6 @@ from paddlefleet import parallel_state
 from paddlefleet.models.common.embeddings.rope_utils import (
     _apply_rotary_pos_emb_bshd,
 )
-from paddlefleet.utils import apply_dsv4_accuracy_compatible_patch
 from paddlefleet.models.common.embeddings.rotary_pos_embedding import (
     RotaryEmbedding,
 )
@@ -50,6 +49,7 @@ from paddlefleet.tensor_parallel.mappings import (
 )
 from paddlefleet.transformer.enums import AttnMaskType
 from paddlefleet.transformer.layer import FleetLayer
+from paddlefleet.utils import apply_dsv4_accuracy_compatible_patch
 
 if TYPE_CHECKING:
     from paddlefleet.packed_seq_params import PackedSeqParams
@@ -89,6 +89,7 @@ def hadamard_transform(x: Tensor, scale: float = 1.0) -> Tensor:
 
     if apply_dsv4_accuracy_compatible_patch():
         from paddlefleet.accuracy_compatible_patch import CompatibleHadamard
+
         return CompatibleHadamard.apply(x, scale)
 
     # Megatron uses fast_hadamard_transform, whose bf16 path accumulates in fp32

--- a/src/paddlefleet/transformer/dsv4_hybrid_attention.py
+++ b/src/paddlefleet/transformer/dsv4_hybrid_attention.py
@@ -43,6 +43,7 @@ from paddlefleet.models.common.embeddings.yarn_rotary_pos_embedding import (
     YarnRotaryEmbedding,
 )
 from paddlefleet.transformer.attention import Attention
+from paddlefleet.utils import apply_dsv4_accuracy_compatible_patch
 
 if TYPE_CHECKING:
     from paddlefleet.process_groups_config import ProcessGroupCollection
@@ -52,6 +53,10 @@ if TYPE_CHECKING:
 
 def _q_rms_norm(q: Tensor, eps: float) -> Tensor:
     """RMS normalization for query (no learnable weight)."""
+    if apply_dsv4_accuracy_compatible_patch():
+        from paddlefleet.accuracy_compatible_patch import CompatibleQRMSNorm
+
+        return CompatibleQRMSNorm.apply(q, eps)
     return q * paddle.rsqrt(q.square().mean(-1, keepdim=True) + eps)
 
 
@@ -257,6 +262,8 @@ class DSv4HybridAttention(Attention):
         startend_row_indices = kwargs.get(
             "attn_mask_startend_row_indices", None
         )
+        if apply_dsv4_accuracy_compatible_patch():
+            startend_row_indices = None
 
         # Get Q, K, V tensors
         # In CP mode, pass position_offset so RoPE uses correct global positions.
@@ -342,9 +349,25 @@ class DSv4HybridAttention(Attention):
         wo_a_weight = self.linear_o_group_proj.reshape(
             [self.o_local_groups, self.config.o_lora_rank, -1]
         )
-        core_attn_out = paddle.einsum(
-            "...gd,grd->...gr", core_attn_out, wo_a_weight
-        )
+        if apply_dsv4_accuracy_compatible_patch() and b > 1:
+            from paddlefleet.accuracy_compatible_patch import (
+                CompatibleOGroupProjection,
+            )
+
+            call_idx = getattr(self, "_ogroup_projection_call_idx", 0)
+            self._ogroup_projection_call_idx = call_idx + 1
+            core_attn_out = CompatibleOGroupProjection.apply(
+                core_attn_out,
+                self.linear_o_group_proj,
+                self.o_local_groups,
+                self.config.o_lora_rank,
+                self.layer_number,
+                call_idx,
+            )
+        else:
+            core_attn_out = paddle.einsum(
+                "...gd,grd->...gr", core_attn_out, wo_a_weight
+            )
         core_attn_out = core_attn_out.reshape([b, sq, -1])
 
         # Output projection

--- a/src/paddlefleet/transformer/hyper_connection.py
+++ b/src/paddlefleet/transformer/hyper_connection.py
@@ -447,8 +447,13 @@ class HyperConnectionModule(nn.Layer):
         C = self.hidden_size
         num_tokens = math.prod(leading_shape)
 
-        # Reshape for bmm: [..., n, n] -> [batch, n, n]
-        h_res_batched = h_res.reshape([num_tokens, n, n])
+        if apply_dsv4_accuracy_compatible_patch():
+            h_res_batched = h_res.reshape([num_tokens, n, n])
+        else:
+            # Reshape for bmm: [..., n, n] -> [batch, n, n]
+            ndim = h_res.ndim
+            perm = [*list(range(ndim - 2)), ndim - 1, ndim - 2]
+            h_res_batched = h_res.transpose(perm).reshape([num_tokens, n, n])
         # [..., n*C] -> [..., n, C] -> [batch, n, C]
         residual_batched = residual.reshape([num_tokens, n, C])
 

--- a/src/paddlefleet/transformer/hyper_connection.py
+++ b/src/paddlefleet/transformer/hyper_connection.py
@@ -24,7 +24,6 @@ Reference: mHC paper - Manifold-Constrained Hyper-Connections for transformers.
 from __future__ import annotations
 
 import math
-import os
 from typing import TYPE_CHECKING
 
 import paddle
@@ -33,22 +32,10 @@ from paddle import Tensor, nn
 
 from paddlefleet.tensor_parallel.random import get_cuda_rng_tracker
 from paddlefleet.transformer.layer import FleetLayer
+from paddlefleet.utils import apply_dsv4_accuracy_compatible_patch
 
 if TYPE_CHECKING:
     from paddlefleet.transformer.transformer_config import TransformerConfig
-
-
-_ACCURACY_COMPATIBLE_KERNEL: bool = (
-    os.environ.get("FLAGS_use_accuracy_compatible_kernel", "0") == "1"
-)
-
-
-def _use_accuracy_compatible_kernel() -> bool:
-    """Switch for Megatron-aligned (accuracy-compatible) numeric paths.
-
-    Controlled by the ``FLAGS_use_accuracy_compatible_kernel`` env variable.
-    """
-    return _ACCURACY_COMPATIBLE_KERNEL
 
 
 class SinkhornKnopp(paddle.autograd.PyLayer):
@@ -99,10 +86,7 @@ class SinkhornKnopp(paddle.autograd.PyLayer):
             H_res: [..., n, n] - doubly stochastic matrix
         """
         # Stabilized exp: subtract row-wise max to prevent overflow.
-        # Under FLAGS_use_accuracy_compatible_kernel, force this outside AMP
-        # so the Paddle native path preserves the BF16 contract used by
-        # Megatron's torch implementation.
-        if _use_accuracy_compatible_kernel():
+        if apply_dsv4_accuracy_compatible_patch():
             with paddle.amp.auto_cast(enable=False):
                 M_init = paddle.exp(
                     H_res_logits - H_res_logits.max(axis=-1, keepdim=True)
@@ -110,14 +94,16 @@ class SinkhornKnopp(paddle.autograd.PyLayer):
                 M = SinkhornKnopp._sinkhorn_normalize(
                     M_init, num_iterations, eps
                 )
+            # Save initial M for backward recomputation
+            ctx.save_for_backward(H_res_logits)
         else:
             M_init = paddle.exp(
                 H_res_logits - H_res_logits.max(axis=-1, keepdim=True)
             )
             M = SinkhornKnopp._sinkhorn_normalize(M_init, num_iterations, eps)
 
-        # Save initial M for backward recomputation
-        ctx.save_for_backward(M_init)
+            # Save initial M for backward recomputation
+            ctx.save_for_backward(M_init)
         ctx.num_iterations = num_iterations
         ctx.eps = eps
         return M
@@ -127,13 +113,22 @@ class SinkhornKnopp(paddle.autograd.PyLayer):
         """
         Backward through Sinkhorn-Knopp iterations using recomputation.
         """
-        (M_init,) = ctx.saved_tensor()
+        (saved_tensor,) = ctx.saved_tensor()
         num_iterations = ctx.num_iterations
         eps = ctx.eps
 
+        if apply_dsv4_accuracy_compatible_patch():
+            from paddlefleet.accuracy_compatible_patch import (
+                compatible_sinkhorn_backward,
+            )
+
+            return compatible_sinkhorn_backward(
+                saved_tensor, grad_output, num_iterations, ctx.eps
+            )
+
         with paddle.enable_grad():
             # Recompute forward with autograd enabled
-            M_input = M_init.detach()
+            M_input = saved_tensor.detach()
             M_input.stop_gradient = False
 
             M_current = SinkhornKnopp._sinkhorn_normalize(
@@ -150,7 +145,7 @@ class SinkhornKnopp(paddle.autograd.PyLayer):
 
         # Apply chain rule: dL/dH = dL/dM_init * dM_init/dH = dL/dM_init * M_init
         # Since M_init = exp(H_res_logits), d(exp(x))/dx = exp(x) = M_init
-        grad_input = grad_M_init * M_init
+        grad_input = grad_M_init * saved_tensor
 
         return grad_input
 
@@ -329,18 +324,14 @@ class HyperConnectionModule(nn.Layer):
         Args:
             x: [..., n*C] - n-stream hidden states
         """
-        if _use_accuracy_compatible_kernel():
-            nC = x.shape[-1]
-            weight = self.mapping_proj.weight
-            r = x.norm(axis=-1, keepdim=True) / math.sqrt(nC)  # [..., 1]
-            r = (1.0 / (r + self.norm_eps)).astype(x.dtype)  # [..., 1]
-            # Match Megatron clean path: torch.matmul(x, weight.t()). Paddle
-            # nn.Linear uses a different BF16 cuBLAS path for this shape and
-            # drifts before the first HC BDA.
-            x_2d = x.reshape([-1, nC])
-            weight_out_in = weight.t().contiguous()
-            proj_2d = paddle.matmul(x_2d, weight_out_in, transpose_y=True)
-            proj = proj_2d.reshape([*x.shape[:-1], weight.shape[-1]])
+        if apply_dsv4_accuracy_compatible_patch():
+            from paddlefleet.accuracy_compatible_patch import (
+                compatible_projection_and_norm,
+            )
+
+            proj, r = compatible_projection_and_norm(
+                x, self.mapping_proj.weight, self.norm_eps
+            )
         else:
             ori_dtype = x.dtype
             proj, r = self._proj_rms_op(
@@ -380,7 +371,7 @@ class HyperConnectionModule(nn.Layer):
         # H_post = 2σ(α_post * (θ_post @ x̃) + b_post)
         h_post = h[..., self.n : 2 * self.n].sigmoid() * 2  # [..., n]
         h_res = h[..., 2 * self.n :]
-        if _use_accuracy_compatible_kernel():
+        if apply_dsv4_accuracy_compatible_patch():
             h_pre = h_pre.astype(proj.dtype)
             h_post = h_post.astype(proj.dtype)
         return h_pre, h_post, h_res
@@ -429,7 +420,7 @@ class HyperConnectionModule(nn.Layer):
         # Reshape to [..., n, C]
         x_streams = x.reshape([*leading_shape, self.n, C])
 
-        if _use_accuracy_compatible_kernel():
+        if apply_dsv4_accuracy_compatible_patch():
             # Weighted sum: [..., n, C] * [..., n, 1] -> sum over n -> [..., C]
             aggregated = (x_streams * h_pre.unsqueeze(-1)).sum(axis=-2)
             if aggregated.dtype != x.dtype:
@@ -456,20 +447,8 @@ class HyperConnectionModule(nn.Layer):
         C = self.hidden_size
         num_tokens = math.prod(leading_shape)
 
-        if _use_accuracy_compatible_kernel():
-            # Megatron clean path applies H_res.T to residual.
-            ndim = h_res.ndim
-            perm = [*list(range(ndim - 2)), ndim - 1, ndim - 2]
-            h_res_batched = (
-                h_res.astype(residual.dtype)
-                .transpose(perm)
-                .reshape([num_tokens, n, n])
-            )
-        else:
-            # Reshape for bmm: [..., n, n] -> [batch, n, n]
-            ndim = h_res.ndim
-            perm = [*list(range(ndim - 2)), ndim - 1, ndim - 2]
-            h_res_batched = h_res.transpose(perm).reshape([num_tokens, n, n])
+        # Reshape for bmm: [..., n, n] -> [batch, n, n]
+        h_res_batched = h_res.reshape([num_tokens, n, n])
         # [..., n*C] -> [..., n, C] -> [batch, n, C]
         residual_batched = residual.reshape([num_tokens, n, C])
 
@@ -551,7 +530,7 @@ class HyperConnectionModule(nn.Layer):
         with paddle.amp.auto_cast(enable=False):
             # Compute mappings
             if (
-                not _use_accuracy_compatible_kernel()
+                not apply_dsv4_accuracy_compatible_patch()
                 and self.config.high_precision_mhc
             ):
                 hidden_states = hidden_states.astype("float32")
@@ -638,21 +617,26 @@ class HyperConnectionModule(nn.Layer):
         base = base.astype("float32")
         scale = scale.astype("float32")
 
+        if apply_dsv4_accuracy_compatible_patch():
+            from paddlefleet.accuracy_compatible_patch import (
+                CompatibleLearnedOutputContract,
+            )
+
+            return CompatibleLearnedOutputContract.apply(
+                hidden_states,
+                head_fn,
+                base,
+                scale,
+                n,
+                eps,
+                dtype,
+            )
+
+
         rsqrt = paddle.rsqrt(
             hidden_states.square().mean(-1, keepdim=True) + eps
         )
-        if _use_accuracy_compatible_kernel():
-            # Match Torch F.linear(x, weight[out,in]) kernel selection. Paddle
-            # F.linear(x, weight[in,out]) uses a different cuBLAS path and
-            # causes BF16 ulp drift in DSv4 final output contraction.
-            head_fn_out_in = head_fn.transpose([1, 0]).contiguous()
-            with paddle.amp.auto_cast(False):
-                proj = paddle.matmul(
-                    hidden_states, head_fn_out_in, transpose_y=True
-                )
-            mixes = proj * rsqrt
-        else:
-            mixes = F.linear(hidden_states, head_fn) * rsqrt
+        mixes = F.linear(hidden_states, head_fn) * rsqrt
         pre = F.sigmoid(mixes * scale + base) + eps
         y = paddle.sum(
             pre.unsqueeze(-1)
@@ -701,7 +685,7 @@ class HyperConnectionModule(nn.Layer):
             x, bias = layer_output_with_bias
 
             # Fast path: no dropout — use fused/native h_post_bda kernel
-            if not _use_accuracy_compatible_kernel() and (
+            if not apply_dsv4_accuracy_compatible_patch() and (
                 dropout_prob == 0.0 or not training
             ):
                 leading_shape = original_residual.shape[:-1]

--- a/src/paddlefleet/transformer/hyper_connection.py
+++ b/src/paddlefleet/transformer/hyper_connection.py
@@ -632,7 +632,6 @@ class HyperConnectionModule(nn.Layer):
                 dtype,
             )
 
-
         rsqrt = paddle.rsqrt(
             hidden_states.square().mean(-1, keepdim=True) + eps
         )

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -982,8 +982,7 @@ class MoELayer(nn.Layer):
         if self.expert_model_parallel_size <= 1 and self.sequence_parallel:
             hidden_states = GatherOp.apply(hidden_states)
         sequence_first_moe = (
-            apply_dsv4_accuracy_compatible_patch()
-            and hidden_states.ndim == 3
+            apply_dsv4_accuracy_compatible_patch() and hidden_states.ndim == 3
         )
         if sequence_first_moe:
             hidden_states = hidden_states.transpose([1, 0, 2]).contiguous()
@@ -997,8 +996,9 @@ class MoELayer(nn.Layer):
 
         if apply_dsv4_accuracy_compatible_patch():
             from paddlefleet.accuracy_compatible_patch import MoEInputBranches
-            routed_input, gate_input, shared_residuals = (
-                MoEInputBranches.apply(hidden_states)
+
+            routed_input, gate_input, shared_residuals = MoEInputBranches.apply(
+                hidden_states
             )
         else:
             routed_input, gate_input, shared_residuals = (

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
 from paddlefleet import utils
 from paddlefleet.recompute_utils import need_recompute_in_first_n
 from paddlefleet.transformer.utils import profile
+from paddlefleet.utils import apply_dsv4_accuracy_compatible_patch
 
 from .fp8_utils import fused_stack_quant_without_cache
 from .fused_a2a import configure_buffer
@@ -50,7 +51,7 @@ from .fusion_layer_utils import (
 from .moe_expert import GroupedMLPExpert, SonicMoEExpert, StandardMLPExpert
 from .moe_router import TopKRouter
 from .moe_shared_expert import StandardMLPSharedExpert
-from .moe_utils import AddAuxiliaryLoss, use_accuracy_compatible_kernel
+from .moe_utils import AddAuxiliaryLoss
 from .token_dispatcher import (
     AllToAllTokenDispatcher,
     MoEFlexTokenDispatcher,
@@ -597,13 +598,13 @@ class MoELayer(nn.Layer):
             dispatched_input, num_or_sections=tokens_per_expert, axis=0
         )
         scale_chunks = None
-        if use_accuracy_compatible_kernel():
+        if apply_dsv4_accuracy_compatible_patch():
             per_token_scale = getattr(
                 self.token_dispatcher, "global_input_probs", None
             )
             if per_token_scale is None:
                 raise RuntimeError(
-                    "FLAGS_use_accuracy_compatible_kernel requires dispatched "
+                    "APPLY_DSV4_ACCURACY_COMPATIBLE_PATCH requires dispatched "
                     "router probabilities from the token dispatcher."
                 )
             scale_chunks = paddle.split(
@@ -980,11 +981,32 @@ class MoELayer(nn.Layer):
         """
         if self.expert_model_parallel_size <= 1 and self.sequence_parallel:
             hidden_states = GatherOp.apply(hidden_states)
+        sequence_first_moe = (
+            apply_dsv4_accuracy_compatible_patch()
+            and hidden_states.ndim == 3
+        )
+        if sequence_first_moe:
+            hidden_states = hidden_states.transpose([1, 0, 2]).contiguous()
+            if input_ids is not None and input_ids.ndim == 2:
+                input_ids = input_ids.transpose([1, 0]).contiguous()
         orig_shape = hidden_states.shape
         residuals = hidden_states
 
         layer_idx = getattr(self, "layer_number", None)
         _log_moe_md5(hidden_states, "moe_input", layer_idx)
+
+        if apply_dsv4_accuracy_compatible_patch():
+            from paddlefleet.accuracy_compatible_patch import MoEInputBranches
+            routed_input, gate_input, shared_residuals = (
+                MoEInputBranches.apply(hidden_states)
+            )
+        else:
+            routed_input, gate_input, shared_residuals = (
+                hidden_states,
+                hidden_states,
+                hidden_states,
+            )
+
         (
             capacity,
             topk_weights,
@@ -995,7 +1017,7 @@ class MoELayer(nn.Layer):
             aux_loss,
             z_loss,
         ) = self.gate(
-            hidden_states,
+            gate_input,
             input_ids=input_ids,
         )
         # topk_weights, topk_indices: Shape is [seq_len, moe_router_topk]
@@ -1016,14 +1038,14 @@ class MoELayer(nn.Layer):
         ):
             combine_overlap_handle = {
                 "fn": self.shared_experts,
-                "fn_args": (residuals,),
+                "fn_args": (shared_residuals,),
             }
         else:
             combine_overlap_handle = None
         if self.expert_model_parallel_size > 1:
             if self.moe_use_fusion_node:
                 output = self.fusion_moe_forward(
-                    hidden_states,
+                    routed_input,
                     probs,
                     mask,
                     combine_overlap_handle,
@@ -1032,7 +1054,7 @@ class MoELayer(nn.Layer):
                 )
             else:
                 output = self.custom_forward(
-                    hidden_states,
+                    routed_input,
                     probs,
                     mask,
                     topk_weights=topk_weights,
@@ -1073,11 +1095,13 @@ class MoELayer(nn.Layer):
             if combine_overlap_handle is not None:
                 shared_output = combine_overlap_handle["fn_out"][0]
             else:
-                shared_output = self.shared_experts(residuals)[0]
+                shared_output = self.shared_experts(shared_residuals)[0]
             output = output + shared_output
 
         _log_moe_md5(output, "moe_final_output", layer_idx)
 
+        if sequence_first_moe:
+            output = output.transpose([1, 0, 2]).contiguous()
         if self.expert_model_parallel_size <= 1 and self.sequence_parallel:
             output = ScatterOp.apply(output)
         return output, None  # None is bias

--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -53,6 +53,7 @@ from paddlefleet.parallel_state import (
     get_tensor_model_parallel_group,
 )
 from paddlefleet.transformer.moe.moe_utils import apply_random_logits
+from paddlefleet.utils import apply_dsv4_accuracy_compatible_patch
 
 # MD5 logging for MoE router precision debugging
 _LOG_LAYER_MD5 = os.environ.get("LOG_LAYER_MD5", "0") == "1"
@@ -107,6 +108,10 @@ class FusedGateDetachMatmul(paddle.autograd.PyLayer):
         ctx.dw_p2p_overlap = dw_p2p_overlap
         ctx.dtype = paddle.float32
         ctx.save_for_backward(x, w)
+        if apply_dsv4_accuracy_compatible_patch():
+            return paddle.matmul(
+                x.cast(ctx.dtype), w.cast(ctx.dtype), transpose_y=True
+            )
         w = w.T
         return F.linear(x.cast(ctx.dtype), w.cast(ctx.dtype))
 
@@ -259,10 +264,14 @@ class StandardMoERouter(nn.Layer):
                 f"seq_aux is True but routing_type is {self.routing_type}. Please check."
             )
 
+        router_weight_dtype = "float32"
+        if apply_dsv4_accuracy_compatible_patch():
+            router_weight_dtype = "bfloat16"
+
         # Initialize gate weight with Normal distribution aligned with Megatron.
         self.weight = paddle.create_parameter(
             shape=[self.num_experts, self.hidden_size],
-            dtype="float32",
+            dtype=router_weight_dtype,
             default_initializer=paddle.nn.initializer.Constant(0.0),
         )
         config.init_method(self.weight)
@@ -915,6 +924,7 @@ class StandardMoERouter(nn.Layer):
 
     def set_layer_number(self, layer_number, is_mtp_layer: bool = False):
         self.layer_number = layer_number
+        self.is_mtp_layer = is_mtp_layer
         self._setup_hash_layer(layer_number, is_mtp_layer)
 
     def _setup_hash_layer(self, layer_number, is_mtp_layer: bool = False):
@@ -994,6 +1004,7 @@ class TopKRouter(StandardMoERouter):
     def set_layer_number(self, layer_number, is_mtp_layer: bool = False):
         self._layer_number = layer_number
         self.layer_number = layer_number
+        self.is_mtp_layer = is_mtp_layer
         self._setup_hash_layer(layer_number, is_mtp_layer=is_mtp_layer)
 
     def forward(self, input, input_ids=None):
@@ -1033,6 +1044,11 @@ class TopKRouter(StandardMoERouter):
                     f"input_ids=[{batch_size_}, {seq_len_}], "
                     f"expected [batch_size={batch_size}, seq_len={seq_len}]"
                 )
+                if (
+                    apply_dsv4_accuracy_compatible_patch()
+                    and self.is_mtp_layer
+                ):
+                    input_ids_none_zero_mask = None
             else:
                 input_ids_none_zero_mask = None
         elif len(input.shape) == 2:

--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -1044,10 +1044,7 @@ class TopKRouter(StandardMoERouter):
                     f"input_ids=[{batch_size_}, {seq_len_}], "
                     f"expected [batch_size={batch_size}, seq_len={seq_len}]"
                 )
-                if (
-                    apply_dsv4_accuracy_compatible_patch()
-                    and self.is_mtp_layer
-                ):
+                if apply_dsv4_accuracy_compatible_patch() and self.is_mtp_layer:
                     input_ids_none_zero_mask = None
             else:
                 input_ids_none_zero_mask = None

--- a/src/paddlefleet/transformer/moe/moe_utils.py
+++ b/src/paddlefleet/transformer/moe/moe_utils.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 from __future__ import annotations
 
-import os
 from typing import TYPE_CHECKING, Any
 
 import paddle
@@ -37,27 +36,12 @@ from paddlefleet.tensor_parallel.random import (
     get_expert_parallel_rng_tracker_name,
 )
 from paddlefleet.training.global_vars import get_global_training_logs
-from paddlefleet.utils import get_pg_size
+from paddlefleet.utils import apply_dsv4_accuracy_compatible_patch, get_pg_size
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
     from paddle.distributed.communication.group import Group
-
-
-_USE_ACCURACY_COMPATIBLE_KERNEL = (
-    os.environ.get("FLAGS_use_accuracy_compatible_kernel", "0") == "1"
-)
-
-
-def use_accuracy_compatible_kernel() -> bool:
-    """Unified switch for accuracy-compatible (Megatron-aligned) numeric paths.
-
-    Controlled via the ``FLAGS_use_accuracy_compatible_kernel`` environment
-    variable. When enabled, modules switch to fp32-accumulating / Torch-aligned
-    kernels at the cost of throughput.
-    """
-    return _USE_ACCURACY_COMPATIBLE_KERNEL
 
 
 def _unpermute_scatter(
@@ -141,7 +125,12 @@ def permute(
     sorted_indices = token_indices.masked_select(routing_map)
 
     # use the mapping to permute the tokens
-    permuted_input = tokens.index_select(axis=0, index=sorted_indices)
+    if apply_dsv4_accuracy_compatible_patch():
+        permuted_input = tokens.cast("float32").index_select(
+            axis=0, index=sorted_indices
+        ).cast(tokens.dtype)
+    else:
+        permuted_input = tokens.index_select(axis=0, index=sorted_indices)
 
     return permuted_input, sorted_indices
 
@@ -180,14 +169,14 @@ def unpermute(
         permuted_probs = probs.T.contiguous().masked_select(
             routing_map.T.contiguous().cast(paddle.bool)
         )
-        if use_accuracy_compatible_kernel():
+        if apply_dsv4_accuracy_compatible_patch():
             permuted_tokens = ApplyPermutedProbs.apply(
                 permuted_tokens, permuted_probs
             )
         else:
             permuted_tokens = permuted_tokens * permuted_probs.unsqueeze(-1)
 
-    if use_accuracy_compatible_kernel():
+    if apply_dsv4_accuracy_compatible_patch():
         output_tokens = _unpermute_fp32_accum(
             permuted_tokens, sorted_indices, restore_shape
         )

--- a/src/paddlefleet/transformer/moe/moe_utils.py
+++ b/src/paddlefleet/transformer/moe/moe_utils.py
@@ -126,9 +126,11 @@ def permute(
 
     # use the mapping to permute the tokens
     if apply_dsv4_accuracy_compatible_patch():
-        permuted_input = tokens.cast("float32").index_select(
-            axis=0, index=sorted_indices
-        ).cast(tokens.dtype)
+        permuted_input = (
+            tokens.cast("float32")
+            .index_select(axis=0, index=sorted_indices)
+            .cast(tokens.dtype)
+        )
     else:
         permuted_input = tokens.index_select(axis=0, index=sorted_indices)
 

--- a/src/paddlefleet/transformer/moe/token_dispatcher.py
+++ b/src/paddlefleet/transformer/moe/token_dispatcher.py
@@ -655,9 +655,7 @@ class _DeepEPManager(_DispatchManager):
         if apply_dsv4_accuracy_compatible_patch():
             self.global_input_probs = (
                 self.dispatched_probs.T.contiguous().masked_select(
-                    self.dispatched_routing_map.T.contiguous().cast(
-                        paddle.bool
-                    )
+                    self.dispatched_routing_map.T.contiguous().cast(paddle.bool)
                 )
             )
         self.hidden_shape_before_permute = hidden_states.shape
@@ -1114,9 +1112,7 @@ class AllToAllTokenDispatcher(nn.Layer):
             self.reversed_local_input_permutation_mapping,
             restore_shape=self.reshaped_input_shape,
             probs=(
-                None
-                if apply_dsv4_accuracy_compatible_patch()
-                else self.probs
+                None if apply_dsv4_accuracy_compatible_patch() else self.probs
             ),
             routing_map=self.routing_map,
         )

--- a/src/paddlefleet/transformer/moe/token_dispatcher.py
+++ b/src/paddlefleet/transformer/moe/token_dispatcher.py
@@ -21,6 +21,8 @@ from typing import TYPE_CHECKING
 import paddle
 from paddle import nn
 
+from paddlefleet.utils import apply_dsv4_accuracy_compatible_patch
+
 if TYPE_CHECKING:
     from paddle.distributed.communication.group import Group
 
@@ -40,7 +42,6 @@ from .moe_utils import (
     permute,
     sort_chunks_by_idxs,
     unpermute,
-    use_accuracy_compatible_kernel,
 )
 
 HAVE_HYBRID_EP = False
@@ -485,6 +486,7 @@ class _DeepEPManager(_DispatchManager):
         self.token_probs = None
         # Handle used for combine operation
         self.handle = None
+        self.global_input_probs = None
 
         if fused_dispatch is None:
             raise ImportError(
@@ -536,6 +538,7 @@ class _DeepEPManager(_DispatchManager):
         self.tokens_per_expert = states["tokens_per_expert"]
         self.dispatched_indices = states["dispatched_indices"]
         self.dispatched_probs = dispatched_probs
+        self.global_input_probs = None
 
         return hidden_states, scale
 
@@ -561,6 +564,7 @@ class _DeepEPManager(_DispatchManager):
         self.tokens_per_expert = states["tokens_per_expert"]
         self.dispatched_indices = states["dispatched_indices"]
         self.dispatched_probs = dispatched_probs
+        self.global_input_probs = None
 
         return hidden_states, scale
 
@@ -577,15 +581,20 @@ class _DeepEPManager(_DispatchManager):
                 - routing_map: Multihot vector.
                 - probs: Multihot probabilities.
         """
+        if apply_dsv4_accuracy_compatible_patch():
+            from paddlefleet.accuracy_compatible_patch import (
+                indices_to_multihot,
+            )
+
+            return indices_to_multihot(indices, probs, self.num_local_experts)
+
         batch_size = indices.shape[0]
         multihot_routing_map = paddle.zeros(
             (batch_size, self.num_local_experts), dtype=paddle.int64
         )
-
         multihot_probs = paddle.zeros(
             (batch_size, self.num_local_experts), dtype=paddle.float32
         )
-
         mask = indices != -1
         valid_indices = indices[mask]
         row_indices = paddle.arange(batch_size).repeat_interleave(
@@ -643,6 +652,14 @@ class _DeepEPManager(_DispatchManager):
                 self.dispatched_indices, self.dispatched_probs
             )
         )
+        if apply_dsv4_accuracy_compatible_patch():
+            self.global_input_probs = (
+                self.dispatched_probs.T.contiguous().masked_select(
+                    self.dispatched_routing_map.T.contiguous().cast(
+                        paddle.bool
+                    )
+                )
+            )
         self.hidden_shape_before_permute = hidden_states.shape
         hidden_states, self.reversed_mapping_for_combine = permute(
             hidden_states,
@@ -663,7 +680,11 @@ class _DeepEPManager(_DispatchManager):
             self.reversed_mapping_for_combine,
             restore_shape=self.hidden_shape_before_permute,
             routing_map=self.dispatched_routing_map,
-            probs=self.dispatched_probs,
+            probs=(
+                None
+                if apply_dsv4_accuracy_compatible_patch()
+                else self.dispatched_probs
+            ),
         )
         return hidden_states.to(input_dtype)
 
@@ -758,6 +779,7 @@ class MoEFlexTokenDispatcher(MoETokenDispatcher):
         if manager_cls is _HybridEPManager:
             manager_kwargs["hybridep_buffer_configs"] = hybridep_buffer_configs
         self._comm_manager = manager_cls(**manager_kwargs)
+        self.global_input_probs = None
 
     def dispatch_preprocess(
         self,
@@ -768,6 +790,7 @@ class MoEFlexTokenDispatcher(MoETokenDispatcher):
         topk_indices: paddle.Tensor | None = None,
     ):
         self.hidden_shape = hidden_states.shape
+        self.global_input_probs = None
         hidden_states = hidden_states.view([-1, self.hidden_shape[-1]])
         self._comm_manager.setup_metadata(
             routing_map, probs, topk_weights, topk_indices
@@ -781,6 +804,7 @@ class MoEFlexTokenDispatcher(MoETokenDispatcher):
         token_indices: paddle.Tensor,
     ):
         self.hidden_shape = hidden_states.shape
+        self.global_input_probs = None
         hidden_states = hidden_states.view([-1, self.hidden_shape[-1]])
         self._comm_manager.routing_map = None
         self._comm_manager.routing_probs = None
@@ -826,6 +850,9 @@ class MoEFlexTokenDispatcher(MoETokenDispatcher):
                 hidden_states
             )
         )
+        self.global_input_probs = getattr(
+            self._comm_manager, "global_input_probs", None
+        )
         tokens_per_expert = self._comm_manager.get_number_of_tokens_per_expert()
 
         return global_input_tokens, tokens_per_expert
@@ -862,6 +889,9 @@ class MoEFlexTokenDispatcher(MoETokenDispatcher):
             self._comm_manager.get_permuted_hidden_states_by_experts(
                 hidden_states
             )
+        )
+        self.global_input_probs = getattr(
+            self._comm_manager, "global_input_probs", None
         )
         tokens_per_expert = self._comm_manager.get_number_of_tokens_per_expert()
 
@@ -977,14 +1007,13 @@ class AllToAllTokenDispatcher(nn.Layer):
             permutated_local_input_tokens,
             self.reversed_local_input_permutation_mapping,
         ) = permute(reshaped_input, self.routing_map)
-        if use_accuracy_compatible_kernel():
-            num_routed_tokens = int(tokens_per_expert.sum().item())
+        if apply_dsv4_accuracy_compatible_patch():
             routing_map = self.routing_map.cast(paddle.bool).T.contiguous()
             flat_sorted = paddle.argsort(
                 routing_map.reshape([-1]).cast("int32"),
                 descending=True,
                 stable=True,
-            )[:num_routed_tokens]
+            )[: int(tokens_per_expert.sum().item())]
             self.permuted_local_probs = paddle.index_select(
                 self.probs.T.contiguous().reshape([-1]),
                 flat_sorted,
@@ -1011,7 +1040,7 @@ class AllToAllTokenDispatcher(nn.Layer):
             in_split_sizes=self.input_split_sizes,
             group=self.moe_group,
         )
-        if use_accuracy_compatible_kernel():
+        if apply_dsv4_accuracy_compatible_patch():
             # Match Megatron's all-to-all backward numerics by routing probs through a
             # 2D [tokens, 1] tensor, like hidden-state dispatch.
             global_input_probs_2d = _AllToAll.apply(
@@ -1040,20 +1069,16 @@ class AllToAllTokenDispatcher(nn.Layer):
         ).T.ravel()
 
         if self.num_local_experts > 1 and not self.is_empty_tokens:
-            split_sizes_list = (
-                self.num_global_tokens_per_local_expert.ravel().tolist()
-            )
-            sorted_idxs_list = self.sort_input_by_local_experts.tolist()
             global_input_tokens, _ = sort_chunks_by_idxs(
                 global_input_tokens,
                 self.num_global_tokens_per_local_expert.ravel(),
                 self.sort_input_by_local_experts,
             )
-            if use_accuracy_compatible_kernel():
-                self.global_input_probs = _sort_chunks_like_tokens(
+            if apply_dsv4_accuracy_compatible_patch():
+                self.global_input_probs, _ = sort_chunks_by_idxs(
                     self.global_input_probs,
-                    split_sizes_list,
-                    sorted_idxs_list,
+                    self.num_global_tokens_per_local_expert.ravel(),
+                    self.sort_input_by_local_experts,
                 )
         sorted_tokens = global_input_tokens
         self.tokens_per_expert_post_gather = self.tokens_per_expert
@@ -1088,7 +1113,11 @@ class AllToAllTokenDispatcher(nn.Layer):
             permutated_local_input_tokens,
             self.reversed_local_input_permutation_mapping,
             restore_shape=self.reshaped_input_shape,
-            probs=(None if use_accuracy_compatible_kernel() else self.probs),
+            probs=(
+                None
+                if apply_dsv4_accuracy_compatible_patch()
+                else self.probs
+            ),
             routing_map=self.routing_map,
         )
 

--- a/src/paddlefleet/transformer/multi_token_prediction.py
+++ b/src/paddlefleet/transformer/multi_token_prediction.py
@@ -492,10 +492,7 @@ class MultiTokenPredictionLayer(FleetLayer):
             # Megatron flattens [S, B, N, H] for the weight-gradient GEMM.
             # The transpose is forward-equivalent but aligns the wgrad
             # accumulation order.
-            if (
-                apply_dsv4_accuracy_compatible_patch()
-                and hs_streams.ndim == 4
-            ):
+            if apply_dsv4_accuracy_compatible_patch() and hs_streams.ndim == 4:
                 orig_shape = hs_streams.shape
                 hs_seqfirst = hs_streams.transpose([1, 0, 2, 3]).contiguous()
                 seqfirst_shape = hs_seqfirst.shape

--- a/src/paddlefleet/transformer/multi_token_prediction.py
+++ b/src/paddlefleet/transformer/multi_token_prediction.py
@@ -492,7 +492,11 @@ class MultiTokenPredictionLayer(FleetLayer):
             # Megatron flattens [S, B, N, H] for the weight-gradient GEMM.
             # The transpose is forward-equivalent but aligns the wgrad
             # accumulation order.
-            if apply_dsv4_accuracy_compatible_patch() and hs_streams.ndim == 4:
+            if (
+                apply_dsv4_accuracy_compatible_patch()
+                and hs_streams.ndim == 4
+                and not self.sequence_parallel
+            ):
                 orig_shape = hs_streams.shape
                 hs_seqfirst = hs_streams.transpose([1, 0, 2, 3]).contiguous()
                 seqfirst_shape = hs_seqfirst.shape
@@ -501,8 +505,9 @@ class MultiTokenPredictionLayer(FleetLayer):
                 h_out = h_out.reshape([*seqfirst_shape[:-1], -1])
                 h_out = h_out.transpose([1, 0, 2, 3]).contiguous()
             else:
-                # hs_streams is 4D, so flatten before ColumnParallelLinear.
-                orig_shape = hs_streams.shape
+                orig_shape = list(hs_streams.shape)
+                if self.tensor_parallel > 1 and self.sequence_parallel:
+                    orig_shape[0] = orig_shape[0] * self.tensor_parallel
                 hs_flat = hs_streams.reshape([-1, orig_shape[-1]])
                 h_out, _ = self.h_proj(hs_flat)
                 h_out = h_out.reshape([*orig_shape[:-1], -1])

--- a/src/paddlefleet/transformer/multi_token_prediction.py
+++ b/src/paddlefleet/transformer/multi_token_prediction.py
@@ -46,6 +46,7 @@ from paddlefleet.tensor_parallel.mappings import (
 from paddlefleet.tensor_parallel.random import get_cuda_rng_tracker
 from paddlefleet.transformer.enums import AttnMaskType
 from paddlefleet.transformer.layer import FleetLayer
+from paddlefleet.utils import apply_dsv4_accuracy_compatible_patch
 
 if TYPE_CHECKING:
     from paddlefleet.models.backends import BackendSpecProvider
@@ -486,15 +487,28 @@ class MultiTokenPredictionLayer(FleetLayer):
 
             # e_proj: [.., h] -> [.., h/tp]
             e_out, _ = self.e_proj(decoder_input)
-            # h_proj: applied per-stream [.., n, h] -> [.., n, h/tp]
-            # 这里hs_streams是4D tensor: [b,s,n,h]会导致算梯度的时候调用.t()报错，必须reshape到更低维度
-            orig_shape = list(hs_streams.shape)  # [s/sp, b, n, h]
-            if self.tensor_parallel > 1 and self.sequence_parallel:
-                # [s/sp, b, n, h] --> [s, b, n, h]
-                orig_shape[0] = orig_shape[0] * self.tensor_parallel
-            hs_flat = hs_streams.reshape([-1, orig_shape[-1]])  # [s/sp*b*n, h]
-            h_out, _ = self.h_proj(hs_flat)  # [s*b*n, h/tp]
-            h_out = h_out.reshape([*orig_shape[:-1], -1])  # [s, b, n, h/tp]
+            # h_proj: applied per-stream [.., n, h] -> [.., n, h/tp].
+            # For mbs>1 Paddle reaches this point as [B, S, N, H], while
+            # Megatron flattens [S, B, N, H] for the weight-gradient GEMM.
+            # The transpose is forward-equivalent but aligns the wgrad
+            # accumulation order.
+            if (
+                apply_dsv4_accuracy_compatible_patch()
+                and hs_streams.ndim == 4
+            ):
+                orig_shape = hs_streams.shape
+                hs_seqfirst = hs_streams.transpose([1, 0, 2, 3]).contiguous()
+                seqfirst_shape = hs_seqfirst.shape
+                hs_flat = hs_seqfirst.reshape([-1, seqfirst_shape[-1]])
+                h_out, _ = self.h_proj(hs_flat)
+                h_out = h_out.reshape([*seqfirst_shape[:-1], -1])
+                h_out = h_out.transpose([1, 0, 2, 3]).contiguous()
+            else:
+                # hs_streams is 4D, so flatten before ColumnParallelLinear.
+                orig_shape = hs_streams.shape
+                hs_flat = hs_streams.reshape([-1, orig_shape[-1]])
+                h_out, _ = self.h_proj(hs_flat)
+                h_out = h_out.reshape([*orig_shape[:-1], -1])
             # Broadcast add before gather (saves one all-gather vs gathering separately)
             hidden_states = e_out.unsqueeze(-2) + h_out
             if self.tensor_parallel > 1:

--- a/src/paddlefleet/transformer/paddle_norm.py
+++ b/src/paddlefleet/transformer/paddle_norm.py
@@ -36,6 +36,7 @@ except ImportError:
 from paddle.distributed.fleet.meta_parallel import ScheduleNode
 
 from paddlefleet.jit import jit_fuser
+from paddlefleet.utils import apply_dsv4_accuracy_compatible_patch
 
 if TYPE_CHECKING:
     from paddle import Tensor
@@ -73,8 +74,11 @@ class RMSNorm(paddle.nn.Layer):
             self.enable_sequence_parallel()
 
     def forward(self, hidden_states: Tensor):
-        # Ensure hidden_states dtype matches weight dtype for rms_norm
-        if hidden_states.dtype != self.weight.dtype:
+        if apply_dsv4_accuracy_compatible_patch():
+            axes = [1, 0, 2, 3] if hidden_states.ndim == 4 else [1, 0, 2]
+            hidden_states = hidden_states.transpose(axes).contiguous()
+        elif hidden_states.dtype != self.weight.dtype:
+            # Ensure hidden_states dtype matches weight dtype for rms_norm.
             hidden_states = hidden_states.astype(self.weight.dtype)
         rms_norm_out = rms_norm(
             hidden_states,
@@ -83,9 +87,13 @@ class RMSNorm(paddle.nn.Layer):
             self.variance_epsilon,
         )
         if isinstance(rms_norm_out, (tuple, list)):
-            return rms_norm_out[0].astype(self.weight.dtype)
+            output = rms_norm_out[0]
         else:
-            return rms_norm_out.astype(self.weight.dtype)
+            output = rms_norm_out
+        output = output.astype(self.weight.dtype)
+        if apply_dsv4_accuracy_compatible_patch():
+            output = output.transpose(axes).contiguous()
+        return output
 
     def enable_sequence_parallel(self):
         mark_as_sequence_parallel_parameter(self.weight)
@@ -143,6 +151,9 @@ class LayerNorm(paddle.nn.Layer):
 
 class FusedRMSNorm(RMSNorm):
     def forward(self, hidden_states: Tensor):
+        if apply_dsv4_accuracy_compatible_patch():
+            axes = [1, 0, 2, 3] if hidden_states.ndim == 4 else [1, 0, 2]
+            hidden_states = hidden_states.transpose(axes).contiguous()
         rms_norm_out = rms_norm(
             hidden_states,
             hidden_states.shape[-1:],
@@ -150,9 +161,13 @@ class FusedRMSNorm(RMSNorm):
             self.variance_epsilon,
         )
         if isinstance(rms_norm_out, (tuple, list)):
-            return rms_norm_out[0].astype(self.weight.dtype)
+            output = rms_norm_out[0]
         else:
-            return rms_norm_out.astype(self.weight.dtype)
+            output = rms_norm_out
+        output = output.astype(self.weight.dtype)
+        if apply_dsv4_accuracy_compatible_patch():
+            output = output.transpose(axes).contiguous()
+        return output
 
 
 class RMSNormTriton(RMSNorm):

--- a/src/paddlefleet/utils.py
+++ b/src/paddlefleet/utils.py
@@ -21,6 +21,7 @@ import functools
 import inspect
 import math
 import operator
+import os
 import warnings
 from collections.abc import Callable
 from contextlib import nullcontext
@@ -545,3 +546,7 @@ def deprecate_inference_params(inference_context, inference_params):
         )
         return inference_params
     return inference_context
+
+
+def apply_dsv4_accuracy_compatible_patch():
+    return os.environ.get("APPLY_DSV4_ACCURACY_COMPATIBLE_PATCH", "0") == "1"

--- a/src/paddlefleet/utils.py
+++ b/src/paddlefleet/utils.py
@@ -33,6 +33,10 @@ import paddle
 from paddlefleet import parallel_state
 from paddlefleet.context_parallel_utils import ContextParallelScatterOp
 
+_APPLY_DSV4_ACCURACY_COMPATIBLE_PATCH = (
+    os.environ.get("APPLY_DSV4_ACCURACY_COMPATIBLE_PATCH", "0") == "1"
+)
+
 try:
     from packaging.version import Version as PkgVersion
 
@@ -549,4 +553,4 @@ def deprecate_inference_params(inference_context, inference_params):
 
 
 def apply_dsv4_accuracy_compatible_patch():
-    return os.environ.get("APPLY_DSV4_ACCURACY_COMPATIBLE_PATCH", "0") == "1"
+    return _APPLY_DSV4_ACCURACY_COMPATIBLE_PATCH


### PR DESCRIPTION
### PR Category
Distributed Strategy

### PR Types
Improvements

### Description
- 新增由 `APPLY_DSV4_ACCURACY_COMPATIBLE_PATCH` 控制的 DSV4 精度对齐兼容路径。
- 将精度对齐相关 helper 统一收敛到 `paddlefleet.accuracy_compatible_patch`，并在开关开启时由相关 Fleet 模块调用。
- 默认不开启开关时保持原始 PaddleFleet 代码路径不变。

### 是否引起精度变化
否。默认不开 `APPLY_DSV4_ACCURACY_COMPATIBLE_PATCH` 时保持原始代码路径；开启后用于 DSV4 精度对齐兼容路径。
