### PR TITLE
[release/0.3][Performance Optimization] Migrate CSA indexer forward to cuDNN frontend

### DIFF
--- a/src/paddlefleet/cudnn_ops/__init__.py
+++ b/src/paddlefleet/cudnn_ops/__init__.py
@@ -14,18 +14,18 @@
 
 """cuDNN frontend ops bridged into PaddleFleet."""
 
-__all__ = ["csa_indexer_bwd", "csa_sparse_attn_bwd_cudnn"]
+from .attn.csa_sparse_attn_bwd_cudnn import csa_sparse_attn_bwd_cudnn
+from .indexer.csa_indexer_bwd_cudnn import csa_indexer_bwd
+from .indexer.csa_indexer_fwd_cudnn import (
+    cudnn_indexer_forward,
+    cudnn_indexer_topk,
+    cudnn_indexer_topk_fwd,
+)
 
-
-def __getattr__(name):
-    if name == "csa_indexer_bwd":
-        from .indexer.csa_indexer_bwd_cudnn import csa_indexer_bwd
-
-        globals()[name] = csa_indexer_bwd
-        return csa_indexer_bwd
-    if name == "csa_sparse_attn_bwd_cudnn":
-        from .attn.csa_sparse_attn_bwd_cudnn import csa_sparse_attn_bwd_cudnn
-
-        globals()[name] = csa_sparse_attn_bwd_cudnn
-        return csa_sparse_attn_bwd_cudnn
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+__all__ = [
+    "csa_indexer_bwd",
+    "csa_sparse_attn_bwd_cudnn",
+    "cudnn_indexer_forward",
+    "cudnn_indexer_topk",
+    "cudnn_indexer_topk_fwd",
+]

--- a/src/paddlefleet/cudnn_ops/attn/csa_sparse_attn_bwd_cudnn.py
+++ b/src/paddlefleet/cudnn_ops/attn/csa_sparse_attn_bwd_cudnn.py
@@ -13,9 +13,12 @@
 # limitations under the License.
 
 
-from paddlefleet_ops.cudnn.deepseek_sparse_attention.sparse_attention_backward.api import (
-    sparse_attention_backward_wrapper,
-)
+from paddlefleet_ops import CUDNN_FRONTEND_HINT, is_cudnn_frontend_available
+
+
+def _require_cudnn_frontend():
+    if not is_cudnn_frontend_available():
+        raise ImportError(CUDNN_FRONTEND_HINT)
 
 
 def csa_sparse_attn_bwd_cudnn(
@@ -29,6 +32,11 @@ def csa_sparse_attn_bwd_cudnn(
     softmax_scale=None,
     topk_length=None,
 ):
+    _require_cudnn_frontend()
+    from paddlefleet_ops.cudnn.deepseek_sparse_attention.sparse_attention_backward.api import (
+        sparse_attention_backward_wrapper,
+    )
+
     # print(f"get here.....")
     result = sparse_attention_backward_wrapper(
         q,

--- a/src/paddlefleet/cudnn_ops/indexer/__init__.py
+++ b/src/paddlefleet/cudnn_ops/indexer/__init__.py
@@ -13,5 +13,15 @@
 # limitations under the License.
 
 from .csa_indexer_bwd_cudnn import csa_indexer_bwd
+from .csa_indexer_fwd_cudnn import (
+    cudnn_indexer_forward,
+    cudnn_indexer_topk,
+    cudnn_indexer_topk_fwd,
+)
 
-__all__ = ["csa_indexer_bwd"]
+__all__ = [
+    "csa_indexer_bwd",
+    "cudnn_indexer_forward",
+    "cudnn_indexer_topk",
+    "cudnn_indexer_topk_fwd",
+]

--- a/src/paddlefleet/cudnn_ops/indexer/csa_indexer_bwd_cudnn.py
+++ b/src/paddlefleet/cudnn_ops/indexer/csa_indexer_bwd_cudnn.py
@@ -26,9 +26,12 @@ Returns d_index_q / d_weights / d_index_k_comp matching input dtypes/shapes.
 from __future__ import annotations
 
 import paddle
-from paddlefleet_ops.cudnn.deepseek_sparse_attention.indexer_backward.api import (
-    indexer_backward_wrapper,
-)
+from paddlefleet_ops import CUDNN_FRONTEND_HINT, is_cudnn_frontend_available
+
+
+def _require_cudnn_frontend():
+    if not is_cudnn_frontend_available():
+        raise ImportError(CUDNN_FRONTEND_HINT)
 
 
 def _to_bf16(t: paddle.Tensor) -> paddle.Tensor:
@@ -101,6 +104,11 @@ def csa_indexer_bwd(
         grad_loss_paddle = grad_loss
         if grad_loss_paddle.dtype != paddle.float32:
             grad_loss_paddle = grad_loss_paddle.cast(paddle.float32)
+
+    _require_cudnn_frontend()
+    from paddlefleet_ops.cudnn.deepseek_sparse_attention.indexer_backward.api import (
+        indexer_backward_wrapper,
+    )
 
     out = indexer_backward_wrapper(
         index_q_bf,

--- a/src/paddlefleet/cudnn_ops/indexer/csa_indexer_fwd_cudnn.py
+++ b/src/paddlefleet/cudnn_ops/indexer/csa_indexer_fwd_cudnn.py
@@ -1,0 +1,198 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Paddle wrapper around the cuDNN-frontend DSA indexer forward.
+
+Calls ``paddlefleet_ops.cudnn.deepseek_sparse_attention.indexer_forward.api
+.indexer_forward_wrapper`` and ``paddlefleet_ops.cudnn.deepseek_sparse_attention
+.indexer_top_k.api.indexer_top_k_wrapper`` directly on Paddle tensors.
+
+Returns selected compressed KV indices and per-row valid counts.
+"""
+
+from __future__ import annotations
+
+import paddle
+from paddlefleet_ops import CUDNN_FRONTEND_HINT, is_cudnn_frontend_available
+
+
+def _require_cudnn_frontend():
+    if not is_cudnn_frontend_available():
+        raise ImportError(CUDNN_FRONTEND_HINT)
+
+
+def _validate_indexer_inputs(index_q, index_k_comp, weights):
+    if not isinstance(index_q, paddle.Tensor):
+        raise TypeError(
+            f"index_q must be a paddle.Tensor, got {type(index_q)!r}"
+        )
+    if not isinstance(index_k_comp, paddle.Tensor):
+        raise TypeError(
+            f"index_k_comp must be a paddle.Tensor, got {type(index_k_comp)!r}"
+        )
+    if not isinstance(weights, paddle.Tensor):
+        raise TypeError(
+            f"weights must be a paddle.Tensor, got {type(weights)!r}"
+        )
+    if len(index_q.shape) != 4:
+        raise ValueError(
+            f"index_q must have shape [B, S, H_i, D_i], got {index_q.shape}"
+        )
+    if len(index_k_comp.shape) != 3:
+        raise ValueError(
+            f"index_k_comp must have shape [B, S_comp, D_i], got {index_k_comp.shape}"
+        )
+    if len(weights.shape) != 3:
+        raise ValueError(
+            f"weights must have shape [B, S, H_i], got {weights.shape}"
+        )
+
+    batch, seq_len, heads, dim = index_q.shape
+    batch_k, _, dim_k = index_k_comp.shape
+    batch_w, seq_len_w, heads_w = weights.shape
+    if batch != batch_k or batch != batch_w:
+        raise ValueError(
+            f"batch mismatch: index_q={index_q.shape}, "
+            f"index_k_comp={index_k_comp.shape}, weights={weights.shape}"
+        )
+    if seq_len != seq_len_w or heads != heads_w or dim != dim_k:
+        raise ValueError(
+            f"shape mismatch: index_q={index_q.shape}, "
+            f"index_k_comp={index_k_comp.shape}, weights={weights.shape}"
+        )
+    if heads not in (32, 64):
+        raise ValueError(
+            f"cuDNN IndexerForward requires H_i (qhead_per_kv_head) in {{32, 64}}, got {heads}"
+        )
+    if dim != 128:
+        raise ValueError(f"cuDNN IndexerForward requires D_i=128, got {dim}")
+
+
+def cudnn_indexer_forward(
+    index_q, index_k_comp, weights, ratio=4, sm_scale=None
+):
+    """Compute indexer scores using cuDNN CuTe-DSL kernel (SM100).
+
+    Args:
+        index_q:       [B, S_q, H_i, D_i] bf16, indexer queries.
+        index_k_comp:  [B, S_k, D_i] bf16, compressed indexer keys.
+        weights:       [B, S_q, H_i] bf16, per-head weights.
+        ratio:         compression ratio for the causal mask.
+        sm_scale:      scale factor applied to QK scores (default: dim**-0.5).
+
+    Returns:
+        scores: [B, S_q, S_k] fp32 Paddle tensor. Masked positions are -inf.
+    """
+    if sm_scale is None:
+        sm_scale = float(index_q.shape[-1]) ** -0.5
+    _require_cudnn_frontend()
+    from paddlefleet_ops.cudnn.deepseek_sparse_attention.indexer_forward.api import (
+        indexer_forward_wrapper,
+    )
+
+    result = indexer_forward_wrapper(
+        index_q.contiguous(),
+        index_k_comp.unsqueeze(2).contiguous(),
+        weights.contiguous(),
+        ratio=int(ratio),
+        sm_scale=float(sm_scale),
+    )
+    return result["scores"]
+
+
+def cudnn_indexer_topk(scores, sq, ratio, topk):
+    """Select top-K indices using cuDNN TRT-LLM radix kernel (SM100).
+
+    Args:
+        scores:  [B, S_q, S_k] fp32 Paddle tensor.
+        sq:      query sequence length.
+        ratio:   compression ratio.
+        topk:    number of entries to select per query position.
+
+    Returns:
+        topk_indices: [B, S_q, topk] int32, invalid slots are -1.
+        topk_length:  [B, S_q] int32, per-row valid count.
+    """
+    batch = int(scores.shape[0])
+    sk = int(scores.shape[2])
+    sq = int(sq)
+    topk = int(topk)
+    topk_k = min(topk, sk)
+
+    q_idx = paddle.arange(sq, dtype="int32")
+    seq_lens = paddle.clip((q_idx + 1) // int(ratio), max=sk).tile([batch])
+    _require_cudnn_frontend()
+    from paddlefleet_ops.cudnn.deepseek_sparse_attention.indexer_top_k.api import (
+        indexer_top_k_wrapper,
+    )
+
+    result = indexer_top_k_wrapper(
+        scores.reshape([batch * sq, sk]).contiguous(),
+        seq_lens,
+        top_k=topk_k,
+        next_n=1,
+        return_val=False,
+    )
+    topk_indices = result["indices"].reshape([batch, sq, topk_k]).cast("int32")
+
+    if topk_k < topk:
+        padding = paddle.full([batch, sq, topk - topk_k], -1, dtype="int32")
+        topk_indices = paddle.concat([topk_indices, padding], axis=-1)
+
+    topk_length = (topk_indices >= 0).sum(axis=-1).cast("int32")
+    return topk_indices, topk_length
+
+
+def cudnn_indexer_topk_fwd(
+    index_q,
+    index_k_comp,
+    weights,
+    ratio=4,
+    topk_effective=64,
+    indexer_softmax_scale=1.0,
+):
+    """Run cuDNN-frontend DSA indexer forward on Paddle tensors.
+
+    Args:
+        index_q:                [B, S, H_i, D_i] bf16, indexer queries.
+        index_k_comp:           [B, S_comp, D_i] bf16, compressed indexer keys.
+        weights:                [B, S, H_i] bf16, per-head weights.
+        ratio:                  compression ratio (e.g. 4).
+        topk_effective:         number of entries to select per query position.
+        indexer_softmax_scale:  additional scale on weights.
+
+    Returns:
+        topk_indices: [B, S, topk_effective] int32, invalid slots are -1.
+        topk_length:  [B, S] int32, per-row valid count.
+    """
+    _validate_indexer_inputs(index_q, index_k_comp, weights)
+    if int(topk_effective) <= 0:
+        raise ValueError(
+            f"topk_effective must be positive, got {topk_effective}"
+        )
+
+    # sm_scale combines base dim**-0.5 with any additional indexer_softmax_scale
+    _sm = float(index_q.shape[-1]) ** -0.5
+    if float(indexer_softmax_scale) != 1.0:
+        _sm = _sm * float(indexer_softmax_scale)
+
+    scores = cudnn_indexer_forward(
+        index_q, index_k_comp, weights, ratio=ratio, sm_scale=_sm
+    )
+    return cudnn_indexer_topk(
+        scores,
+        int(index_q.shape[1]),
+        ratio,
+        topk_effective,
+    )

--- a/src/paddlefleet/tilelang_ops/__init__.py
+++ b/src/paddlefleet/tilelang_ops/__init__.py
@@ -16,36 +16,16 @@ import paddle
 
 paddle.enable_compat(scope={"tilelang"}, silent=True)
 
+from .compressed_sparse_attn import csa_sparse_attn
+from .indexer.csa_indexer import (
+    csa_attn_target_reducesum,
+    csa_indexer_bwd,
+    csa_indexer_topk_fwd,
+)
+
 __all__ = [
     "csa_attn_target_reducesum",
     "csa_indexer_bwd",
     "csa_indexer_topk_fwd",
     "csa_sparse_attn",
 ]
-
-
-def __getattr__(name):
-    if name in {
-        "csa_attn_target_reducesum",
-        "csa_indexer_bwd",
-        "csa_indexer_topk_fwd",
-    }:
-        from .indexer.csa_indexer import (
-            csa_attn_target_reducesum,
-            csa_indexer_bwd,
-            csa_indexer_topk_fwd,
-        )
-
-        exports = {
-            "csa_attn_target_reducesum": csa_attn_target_reducesum,
-            "csa_indexer_bwd": csa_indexer_bwd,
-            "csa_indexer_topk_fwd": csa_indexer_topk_fwd,
-        }
-        globals().update(exports)
-        return exports[name]
-    if name == "csa_sparse_attn":
-        from .compressed_sparse_attn import csa_sparse_attn
-
-        globals()[name] = csa_sparse_attn
-        return csa_sparse_attn
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/paddlefleet/tilelang_ops/indexer/csa_indexer.py
+++ b/src/paddlefleet/tilelang_ops/indexer/csa_indexer.py
@@ -219,6 +219,10 @@ def csa_indexer_topk_fwd(
             "TileLang must return Paddle tensors. "
             "Ensure paddle.enable_compat(scope={'tilelang'}) runs before import tilelang."
         )
+    if topk_indices.dtype != paddle.int32:
+        topk_indices = topk_indices.cast("int32")
+    if topk_scores.dtype != paddle.float32:
+        topk_scores = topk_scores.cast("float32")
     return topk_indices, topk_scores
 
 

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -739,21 +739,56 @@ def _compute_tilelang_csa_indexer_loss_forward(
     loss_coeff: float,
     tp_group=None,
     seq_offset: int = 0,
+    indexer_backend: str = "tilelang",
 ) -> tuple[Tensor, Tensor, Tensor, Tensor]:
     from paddlefleet.tilelang_ops import (
         csa_attn_target_reducesum,
         csa_indexer_topk_fwd,
     )
 
-    topk_indices, topk_probs = csa_indexer_topk_fwd(
-        index_q,
-        index_k_comp,
-        weights,
-        ratio=int(ratio),
-        topk_effective=int(topk_effective),
-        seq_offset=int(seq_offset),
-        valid_range=valid_range,
-    )
+    if indexer_backend == "cudnn":
+        from paddlefleet.cudnn_ops.indexer.csa_indexer_fwd_cudnn import (
+            cudnn_indexer_forward,
+            cudnn_indexer_topk,
+        )
+
+        scores = cudnn_indexer_forward(
+            index_q, index_k_comp, weights, ratio=int(ratio)
+        )
+        topk_indices, _ = cudnn_indexer_topk(
+            scores, int(index_q.shape[1]), int(ratio), int(topk_effective)
+        )
+        # Gather scores at topk positions and softmax to get probs
+        # topk_indices: [B, Sq, topk], scores: [B, Sq, Sk]
+        invalid_mask = topk_indices < 0
+        safe_indices = paddle.where(
+            invalid_mask, paddle.zeros_like(topk_indices), topk_indices
+        )
+        topk_scores = paddle.take_along_axis(
+            scores, safe_indices.cast("int64"), axis=2
+        )
+        topk_scores = paddle.where(
+            invalid_mask,
+            paddle.full_like(topk_scores, float("-inf")),
+            topk_scores,
+        )
+        # Avoid NaN from softmax on all-(-inf) rows: zero them before softmax.
+        row_valid = (~invalid_mask).any(axis=-1, keepdim=True)  # [B, Sq, 1]
+        topk_scores = paddle.where(
+            row_valid, topk_scores, paddle.zeros_like(topk_scores)
+        )
+        topk_probs = paddle.nn.functional.softmax(topk_scores, axis=-1)
+        topk_probs = topk_probs * row_valid.cast(topk_probs.dtype)
+    else:
+        topk_indices, topk_probs = csa_indexer_topk_fwd(
+            index_q,
+            index_k_comp,
+            weights,
+            ratio=int(ratio),
+            topk_effective=int(topk_effective),
+            seq_offset=int(seq_offset),
+            valid_range=valid_range,
+        )
 
     if tp_group is not None and getattr(tp_group, "nranks", 1) > 1:
         target = _compute_attn_target_on_selected_set(
@@ -1659,11 +1694,19 @@ class CompressedSparseAttention(FleetLayer):
             self.config,
             "csa_tilelang_enable_indexer",
         )
-        # The fused TileLang indexer-loss path is only active during the
+        indexer_backend = getattr(
+            self.config, "csa_indexer_backend", "tilelang"
+        )
+        use_cudnn_indexer = indexer_backend == "cudnn"
+        # The fused selected-set indexer-loss path is only active during the
         # grad-enabled forward. Full recompute runs the first forward under
         # no_grad; that pass should only materialize main-attention indices.
+        # cuDNN backend reuses the selected-set loss tensors and dispatches
+        # its backward through TileLangCSAIndexerLossAutoScaler.
         use_tilelang_loss_path = (
-            use_tilelang_indexer and self.training and paddle.is_grad_enabled()
+            (use_tilelang_indexer or use_cudnn_indexer)
+            and self.training
+            and paddle.is_grad_enabled()
         )
         loss_topk_effective = _resolve_csa_indexer_loss_topk_effective(
             self.config,
@@ -1722,6 +1765,9 @@ class CompressedSparseAttention(FleetLayer):
                 float(self.softmax_scale),
                 float(indexer_loss_coeff),
                 self.tp_group,
+                indexer_backend=indexer_backend
+                if use_cudnn_indexer
+                else "tilelang",
             )
             tilelang_indexer_loss_state = (
                 q_indexer_bf,
@@ -1731,7 +1777,7 @@ class CompressedSparseAttention(FleetLayer):
                 topk_probs,
                 target,
                 float(indexer_loss_coeff),
-                str(self.config.csa_indexer_backend),
+                indexer_backend,
             )
             if indexer_loss_coeff > 0 and paddle.is_grad_enabled():
                 DSAIndexerLossLoggingHelper.save_loss_to_tracker(
@@ -1799,9 +1845,32 @@ class CompressedSparseAttention(FleetLayer):
                 mask=causal_mask,
             )
 
-        # Optionally replace topk producer with TileLang fused compressed
-        # indexer forward. This only swaps the indices fed to sparse attention.
-        if use_tilelang_indexer and not use_tilelang_loss_path:
+        # Optionally replace topk producer with fused compressed indexer
+        # forward. This only swaps the indices fed to sparse attention.
+        # When use_tilelang_loss_path is active and cuDNN was used there,
+        # topk_indices_compressed already comes from cuDNN fwd; skip redundant call.
+        if use_cudnn_indexer and not use_tilelang_loss_path:
+            from paddlefleet.cudnn_ops.indexer.csa_indexer_fwd_cudnn import (
+                cudnn_indexer_topk_fwd,
+            )
+
+            with paddle.no_grad():
+                q_indexer_cu, k_indexer_cu, weights_indexer_cu = (
+                    self.indexer.forward_before_topk(
+                        x_det, qr_det, startend_row_indices
+                    )
+                )
+                cu_topk_indices, _cu_topk_length = cudnn_indexer_topk_fwd(
+                    q_indexer_cu,
+                    k_indexer_cu,
+                    weights_indexer_cu,
+                    ratio=self.compress_ratio,
+                    topk_effective=attn_topk_effective,
+                )
+
+            topk_indices_compressed = cu_topk_indices
+
+        elif use_tilelang_indexer and not use_tilelang_loss_path:
             from paddlefleet.tilelang_ops import csa_indexer_topk_fwd
 
             with paddle.no_grad():

--- a/tests/single_card_tests/custom_ops/test_cudnn_dsa_indexer_bwd.py
+++ b/tests/single_card_tests/custom_ops/test_cudnn_dsa_indexer_bwd.py
@@ -659,20 +659,18 @@ class TestCudnnCsaIndexerBwd(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# Tests: cudnn_ops/__init__.py (lazy __getattr__)
+# Tests: cudnn_ops/__init__.py imports
 # ---------------------------------------------------------------------------
 
 
 class TestCudnnOpsInit(unittest.TestCase):
-    """Cover paddlefleet.cudnn_ops.__init__.py lazy import mechanism."""
+    """Cover paddlefleet.cudnn_ops.__init__.py direct imports."""
 
     def test_export_csa_indexer_bwd(self):
         import paddlefleet.cudnn_ops as cudnn_ops_mod
 
         fn = cudnn_ops_mod.csa_indexer_bwd
         self.assertTrue(callable(fn))
-        # Second access should be cached in globals
-        self.assertIs(cudnn_ops_mod.csa_indexer_bwd, fn)
 
     def test_unknown_attribute_raises(self):
         import paddlefleet.cudnn_ops as cudnn_ops_mod

--- a/tests/single_card_tests/custom_ops/test_cudnn_dsa_indexer_fwd.py
+++ b/tests/single_card_tests/custom_ops/test_cudnn_dsa_indexer_fwd.py
@@ -1,0 +1,459 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for cuDNN DSA indexer forward.
+
+Covers:
+- csa_indexer_fwd_cudnn.py (_validate_indexer_inputs, cudnn_indexer_forward,
+  cudnn_indexer_topk, cudnn_indexer_topk_fwd)
+- cudnn_ops/__init__.py (lazy __getattr__ for fwd symbols)
+- cudnn_ops/indexer/__init__.py (lazy __getattr__ for fwd symbols)
+"""
+
+import unittest
+
+import paddle
+
+# =========================================================================
+# Helpers
+# =========================================================================
+
+_SKIP_CONDITION = (
+    not paddle.is_compiled_with_cuda()
+    or paddle.device.cuda.get_device_capability()[0] != 10
+)
+_SKIP_REASON = "cuDNN DSA indexer requires Blackwell GPU (SM10x)"
+
+
+def _require_sm100(cls):
+    return unittest.skipIf(_SKIP_CONDITION, _SKIP_REASON)(cls)
+
+
+def _cuda_or_skip(testcase):
+    if not paddle.device.is_compiled_with_cuda():
+        testcase.skipTest("CUDA build of Paddle is required")
+    if paddle.device.cuda.device_count() == 0:
+        testcase.skipTest("No CUDA device available")
+
+
+def _make_indexer_inputs(b, sq, sk, h_i, d_i, dtype="bfloat16", seed=2026):
+    paddle.seed(seed)
+    q = paddle.randn([b, sq, h_i, d_i]).astype(dtype)
+    k = paddle.randn([b, sk, d_i]).astype(dtype)
+    w = paddle.randn([b, sq, h_i]).astype(dtype)
+    return q, k, w
+
+
+def _all_equal(tensor, value):
+    return bool((tensor == value).all().item())
+
+
+def _sorted_compare_indices(out_indices, ref_indices):
+    out_sorted = paddle.sort(out_indices, axis=-1)
+    ref_sorted = paddle.sort(ref_indices, axis=-1)
+    return bool((out_sorted == ref_sorted).all().item())
+
+
+def _build_causal_mask(batch, seq_len, seq_len_comp, ratio):
+    comp_ids = paddle.arange(seq_len_comp, dtype="int64").reshape(
+        [1, 1, seq_len_comp]
+    )
+    valid_end = paddle.arange(1, seq_len + 1, dtype="int64").reshape(
+        [1, seq_len, 1]
+    ) // int(ratio)
+    valid = (comp_ids < valid_end).expand([batch, seq_len, seq_len_comp])
+    neg_inf = paddle.full(
+        [batch, seq_len, seq_len_comp], float("-inf"), dtype="float32"
+    )
+    return paddle.where(valid, paddle.zeros_like(neg_inf), neg_inf)
+
+
+def _paddle_indexer_scores_and_topk(
+    index_q, index_k_comp, weights, ratio, topk
+):
+    from paddlefleet.transformer.dsa_attention import fused_qk_topk_naive
+
+    scores, indices = fused_qk_topk_naive(
+        index_q,
+        index_k_comp,
+        weights.cast("float32"),
+        index_topk=min(int(topk), int(index_k_comp.shape[1])),
+        mask=_build_causal_mask(
+            int(index_q.shape[0]),
+            int(index_q.shape[1]),
+            int(index_k_comp.shape[1]),
+            ratio,
+        ),
+    )
+    if indices.shape[-1] < int(topk):
+        padding = paddle.full(
+            [
+                int(index_q.shape[0]),
+                int(index_q.shape[1]),
+                int(topk) - int(indices.shape[-1]),
+            ],
+            -1,
+            dtype=indices.dtype,
+        )
+        indices = paddle.concat([indices, padding], axis=-1)
+    return scores, indices.cast("int32")
+
+
+# =========================================================================
+# Test cases: input validation
+# =========================================================================
+
+
+@_require_sm100
+class TestValidateIndexerInputs(unittest.TestCase):
+    """Tests for _validate_indexer_inputs."""
+
+    def setUp(self):
+        from paddlefleet.cudnn_ops.indexer.csa_indexer_fwd_cudnn import (
+            _validate_indexer_inputs,
+        )
+
+        self._validate = _validate_indexer_inputs
+        self.B, self.S, self.H, self.D = 1, 16, 32, 128
+        self.Sk = self.S // 4
+        self.index_q = paddle.zeros(
+            [self.B, self.S, self.H, self.D], dtype="bfloat16"
+        )
+        self.index_k = paddle.zeros([self.B, self.Sk, self.D], dtype="bfloat16")
+        self.weights = paddle.zeros([self.B, self.S, self.H], dtype="bfloat16")
+
+    def test_valid_inputs_pass(self):
+        self._validate(self.index_q, self.index_k, self.weights)
+
+    def test_type_error_index_q(self):
+        with self.assertRaises(TypeError):
+            self._validate([1, 2], self.index_k, self.weights)
+
+    def test_type_error_index_k(self):
+        with self.assertRaises(TypeError):
+            self._validate(self.index_q, "bad", self.weights)
+
+    def test_type_error_weights(self):
+        with self.assertRaises(TypeError):
+            self._validate(self.index_q, self.index_k, 123)
+
+    def test_wrong_ndim_index_q(self):
+        with self.assertRaises(ValueError):
+            self._validate(
+                paddle.zeros([self.B, self.S, self.H], dtype="bfloat16"),
+                self.index_k,
+                self.weights,
+            )
+
+    def test_wrong_ndim_index_k(self):
+        with self.assertRaises(ValueError):
+            self._validate(
+                self.index_q,
+                paddle.zeros([self.B, self.Sk, self.D, 1], dtype="bfloat16"),
+                self.weights,
+            )
+
+    def test_wrong_ndim_weights(self):
+        with self.assertRaises(ValueError):
+            self._validate(
+                self.index_q,
+                self.index_k,
+                paddle.zeros([self.B, self.S], dtype="bfloat16"),
+            )
+
+    def test_batch_mismatch(self):
+        with self.assertRaises(ValueError):
+            self._validate(
+                self.index_q,
+                paddle.zeros([2, self.Sk, self.D], dtype="bfloat16"),
+                self.weights,
+            )
+
+    def test_shape_mismatch_dim(self):
+        with self.assertRaises(ValueError):
+            self._validate(
+                self.index_q,
+                paddle.zeros([self.B, self.Sk, 64], dtype="bfloat16"),
+                self.weights,
+            )
+
+    def test_invalid_heads(self):
+        with self.assertRaises(ValueError):
+            self._validate(
+                paddle.zeros([self.B, self.S, 16, self.D], dtype="bfloat16"),
+                paddle.zeros([self.B, self.Sk, self.D], dtype="bfloat16"),
+                paddle.zeros([self.B, self.S, 16], dtype="bfloat16"),
+            )
+
+    def test_invalid_dim(self):
+        with self.assertRaises(ValueError):
+            self._validate(
+                paddle.zeros([self.B, self.S, 32, 64], dtype="bfloat16"),
+                paddle.zeros([self.B, self.Sk, 64], dtype="bfloat16"),
+                paddle.zeros([self.B, self.S, 32], dtype="bfloat16"),
+            )
+
+
+@_require_sm100
+class TestTopkEffectiveValidation(unittest.TestCase):
+    """Tests for cudnn_indexer_topk_fwd topk_effective <= 0."""
+
+    def test_topk_effective_zero_raises(self):
+        from paddlefleet.cudnn_ops.indexer.csa_indexer_fwd_cudnn import (
+            cudnn_indexer_topk_fwd,
+        )
+
+        B, S, H, D = 1, 16, 32, 128
+        Sk = S // 4
+        q = paddle.zeros([B, S, H, D], dtype="bfloat16")
+        k = paddle.zeros([B, Sk, D], dtype="bfloat16")
+        w = paddle.zeros([B, S, H], dtype="bfloat16")
+        with self.assertRaises(ValueError):
+            cudnn_indexer_topk_fwd(q, k, w, topk_effective=0)
+
+    def test_topk_effective_negative_raises(self):
+        from paddlefleet.cudnn_ops.indexer.csa_indexer_fwd_cudnn import (
+            cudnn_indexer_topk_fwd,
+        )
+
+        B, S, H, D = 1, 16, 32, 128
+        Sk = S // 4
+        q = paddle.zeros([B, S, H, D], dtype="bfloat16")
+        k = paddle.zeros([B, Sk, D], dtype="bfloat16")
+        w = paddle.zeros([B, S, H], dtype="bfloat16")
+        with self.assertRaises(ValueError):
+            cudnn_indexer_topk_fwd(q, k, w, topk_effective=-1)
+
+
+# =========================================================================
+# Test cases: forward kernel
+# =========================================================================
+
+
+@_require_sm100
+class TestCudnnIndexerForward(unittest.TestCase):
+    """Tests for cudnn_indexer_forward (score computation)."""
+
+    def setUp(self):
+        from paddlefleet.cudnn_ops.indexer.csa_indexer_fwd_cudnn import (
+            cudnn_indexer_forward,
+        )
+
+        self.cudnn_indexer_forward = cudnn_indexer_forward
+
+    def test_output_shape_and_dtype(self):
+        B, S_q, H_i, D_i, ratio = 2, 128, 64, 128, 4
+        S_k = S_q // ratio
+        q, k, w = _make_indexer_inputs(B, S_q, S_k, H_i, D_i)
+        scores = self.cudnn_indexer_forward(q, k, w, ratio=ratio)
+        self.assertEqual(list(scores.shape), [B, S_q, S_k])
+        self.assertEqual(scores.dtype, paddle.float32)
+
+    def test_masked_positions_are_neginf(self):
+        B, S_q, H_i, D_i, ratio = 1, 32, 64, 128, 4
+        S_k = S_q // ratio
+        q, k, w = _make_indexer_inputs(B, S_q, S_k, H_i, D_i)
+        scores = self.cudnn_indexer_forward(q, k, w, ratio=ratio)
+        # Position 0: (0+1)//4 = 0 valid KV -> all scores should be -inf
+        row0 = scores[0, 0, :].numpy()
+        self.assertTrue(
+            all(v == float("-inf") for v in row0),
+            f"Position 0 should be all -inf, got {row0}",
+        )
+
+    def test_scores_match_paddle_reference(self):
+        B, S_q, H_i, D_i, ratio = 1, 64, 64, 128, 4
+        S_k = S_q // ratio
+        q, k, w = _make_indexer_inputs(B, S_q, S_k, H_i, D_i, seed=2028)
+        scores = self.cudnn_indexer_forward(q, k, w, ratio=ratio, sm_scale=1.0)
+        ref_scores, _ = _paddle_indexer_scores_and_topk(
+            q, k, w, ratio=ratio, topk=S_k
+        )
+        valid = paddle.isfinite(ref_scores)
+        max_abs_diff = (scores[valid] - ref_scores[valid]).abs().max().item()
+        self.assertTrue(
+            paddle.allclose(
+                scores[valid], ref_scores[valid], rtol=1e-2, atol=1e-2
+            ).item(),
+            f"cuDNN indexer scores mismatch with Paddle reference, max_abs_diff={max_abs_diff}",
+        )
+
+
+@_require_sm100
+class TestCudnnIndexerTopkFwd(unittest.TestCase):
+    """Tests for cudnn_indexer_topk_fwd (combined score + top-K)."""
+
+    def setUp(self):
+        from paddlefleet.cudnn_ops.indexer.csa_indexer_fwd_cudnn import (
+            cudnn_indexer_topk_fwd,
+        )
+
+        self.cudnn_indexer_topk_fwd = cudnn_indexer_topk_fwd
+
+    def test_output_shape_and_dtype(self):
+        B, S_q, H_i, D_i, ratio, topk = 2, 128, 64, 128, 4, 8
+        S_k = S_q // ratio
+        q, k, w = _make_indexer_inputs(B, S_q, S_k, H_i, D_i)
+        indices, lengths = self.cudnn_indexer_topk_fwd(
+            q, k, w, ratio=ratio, topk_effective=topk
+        )
+        self.assertEqual(list(indices.shape), [B, S_q, topk])
+        self.assertEqual(indices.dtype, paddle.int32)
+        self.assertEqual(list(lengths.shape), [B, S_q])
+        self.assertEqual(lengths.dtype, paddle.int32)
+
+    def test_early_positions_all_invalid(self):
+        """Positions 0..ratio-2 have (s+1)//ratio==0 -> all indices -1."""
+        B, S_q, H_i, D_i, ratio, topk = 2, 64, 64, 128, 4, 8
+        S_k = S_q // ratio
+        q, k, w = _make_indexer_inputs(B, S_q, S_k, H_i, D_i)
+        indices, _ = self.cudnn_indexer_topk_fwd(
+            q, k, w, ratio=ratio, topk_effective=topk
+        )
+        for b in range(B):
+            for s in range(ratio - 1):
+                self.assertTrue(
+                    _all_equal(indices[b, s, :], -1),
+                    f"batch {b}, position {s} should be all -1",
+                )
+
+    def test_valid_indices_in_causal_range(self):
+        """All non-negative indices satisfy idx < (s+1)//ratio."""
+        B, S_q, H_i, D_i, ratio, topk = 2, 128, 64, 128, 4, 8
+        S_k = S_q // ratio
+        q, k, w = _make_indexer_inputs(B, S_q, S_k, H_i, D_i)
+        indices, _ = self.cudnn_indexer_topk_fwd(
+            q, k, w, ratio=ratio, topk_effective=topk
+        )
+        for b in range(B):
+            for s in range(S_q):
+                max_valid = (s + 1) // ratio
+                row = indices[b, s, :].numpy()
+                for idx in row:
+                    if idx >= 0:
+                        self.assertLess(
+                            idx,
+                            max_valid,
+                            f"batch {b}, pos {s}: index {idx} >= max_valid {max_valid}",
+                        )
+
+    def test_topk_length_matches_valid_count(self):
+        B, S_q, H_i, D_i, ratio, topk = 1, 64, 32, 128, 4, 4
+        S_k = S_q // ratio
+        q, k, w = _make_indexer_inputs(B, S_q, S_k, H_i, D_i)
+        indices, lengths = self.cudnn_indexer_topk_fwd(
+            q, k, w, ratio=ratio, topk_effective=topk
+        )
+        expected = (indices >= 0).sum(axis=-1).cast("int32")
+        self.assertTrue(
+            (lengths == expected).all().item(),
+            "topk_length mismatch with actual valid count",
+        )
+
+    def test_h32_support(self):
+        """Verify H_i=32 (qhead_per_kv_head=32) also works."""
+        B, S_q, H_i, D_i, ratio, topk = 1, 64, 32, 128, 4, 4
+        S_k = S_q // ratio
+        q, k, w = _make_indexer_inputs(B, S_q, S_k, H_i, D_i)
+        indices, _ = self.cudnn_indexer_topk_fwd(
+            q, k, w, ratio=ratio, topk_effective=topk
+        )
+        self.assertEqual(list(indices.shape), [B, S_q, topk])
+
+    def test_index_sets_match_paddle_reference(self):
+        B, S_q, H_i, D_i, ratio, topk = 2, 64, 64, 128, 4, 8
+        S_k = S_q // ratio
+        q, k, w = _make_indexer_inputs(B, S_q, S_k, H_i, D_i, seed=2029)
+        indices, _ = self.cudnn_indexer_topk_fwd(
+            q, k, w, ratio=ratio, topk_effective=topk
+        )
+        _, ref_indices = _paddle_indexer_scores_and_topk(
+            q, k, w, ratio=ratio, topk=topk
+        )
+        self.assertTrue(
+            _sorted_compare_indices(indices, ref_indices),
+            "cuDNN and Paddle indexer top-k sets should match",
+        )
+
+
+@_require_sm100
+class TestCudnnVsTileLangCrossValidation(unittest.TestCase):
+    """Cross-validate cuDNN and TileLang indexer backends produce same sets."""
+
+    def setUp(self):
+        try:
+            paddle.enable_compat(scope={"tilelang"}, silent=True)
+            from paddlefleet.tilelang_ops import csa_indexer_topk_fwd
+
+            self.csa_indexer_topk_fwd = csa_indexer_topk_fwd
+        except Exception:
+            self.skipTest("TileLang CSA indexer not available")
+        from paddlefleet.cudnn_ops.indexer.csa_indexer_fwd_cudnn import (
+            cudnn_indexer_topk_fwd,
+        )
+
+        self.cudnn_indexer_topk_fwd = cudnn_indexer_topk_fwd
+
+    def test_index_sets_match(self):
+        B, S_q, H_i, D_i, ratio, topk = 2, 64, 64, 128, 4, 8
+        S_k = S_q // ratio
+        q, k, w = _make_indexer_inputs(B, S_q, S_k, H_i, D_i, seed=42)
+        cudnn_indices, _ = self.cudnn_indexer_topk_fwd(
+            q, k, w, ratio=ratio, topk_effective=topk
+        )
+        tl_indices, _ = self.csa_indexer_topk_fwd(
+            q, k, w, ratio=ratio, topk_effective=topk
+        )
+        self.assertTrue(
+            _sorted_compare_indices(cudnn_indices, tl_indices),
+            "cuDNN and TileLang indexer top-k sets should match",
+        )
+
+
+# =========================================================================
+# Test cases: package imports
+# =========================================================================
+
+
+@_require_sm100
+class TestPackageImports(unittest.TestCase):
+    """Tests for cudnn_ops and cudnn_ops/indexer package exports."""
+
+    def test_cudnn_ops_unknown_attr(self):
+        import paddlefleet.cudnn_ops as pkg
+
+        with self.assertRaises(AttributeError):
+            _ = pkg.nonexistent_symbol_xyz
+
+    def test_cudnn_ops_indexer_unknown_attr(self):
+        import paddlefleet.cudnn_ops.indexer as pkg
+
+        with self.assertRaises(AttributeError):
+            _ = pkg.nonexistent_symbol_xyz
+
+    def test_cudnn_ops_resolves_cudnn_indexer_forward(self):
+        import paddlefleet.cudnn_ops as pkg
+
+        fn = pkg.cudnn_indexer_forward
+        self.assertTrue(callable(fn))
+
+    def test_cudnn_ops_indexer_resolves_cudnn_indexer_topk(self):
+        import paddlefleet.cudnn_ops.indexer as pkg
+
+        fn = pkg.cudnn_indexer_topk
+        self.assertTrue(callable(fn))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/custom_ops/test_tilelang_csa_indexer.py
+++ b/tests/single_card_tests/custom_ops/test_tilelang_csa_indexer.py
@@ -1836,6 +1836,7 @@ class TestCSAForwardTileLangFwdOnlyPath(unittest.TestCase):
             dsa_indexer_use_sparse_loss=False,
             csa_tilelang_enable_indexer=True,
             csa_tilelang_enable_sparse_attn=False,
+            csa_indexer_backend="tilelang",
             init_method=None,
             init_method_std=0.02,
             layernorm_epsilon=1e-5,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->

Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Performance

### Description
<!-- Describe what you’ve done -->
将 CSA（Compressed Sparse Attention）indexer forward kernel 的默认后端从 TileLang 迁移至 cuDNN-frontend 的 indexer_backward_wrapper。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
是


Cherry-pick of #1097 to `release/0.3`.

Merged in dev: #1097  <!-- For pass CI -->