### PR TITLE
Support FA4 sink.

### DIFF
--- a/packages/paddlefleet_ops/src/paddlefleet_ops/flash_mask_facade.py
+++ b/packages/paddlefleet_ops/src/paddlefleet_ops/flash_mask_facade.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import inspect
-from functools import partial
 
 import paddle
 
@@ -55,11 +54,24 @@ def flashmask_attention(
     softmax_scale: float | None = None,
     block_mask: paddle.Tensor | None = None,
     use_varlen: bool = False,
+    learnable_sink: paddle.Tensor | None = None,
 ):
     if use_varlen:
         assert (
             "use_varlen" in inspect.signature(_flashmask_attention).parameters
         ), "The flash_mask installed does not support use_varlen"
+
+    if learnable_sink is not None:
+        if (
+            "learnable_sink"
+            not in inspect.signature(_flashmask_attention).parameters
+        ):
+            raise NotImplementedError(
+                "learnable_sink (softmax sink) requires FA4 (cute backend); the "
+                "installed flash_mask / current device (e.g. H-card fa2/fa3) does "
+                "not support it. Disable the attention sink or run on a "
+                "FA4-capable device."
+            )
 
     if "xpu" in paddle.get_device():
         fa_version = 2
@@ -90,12 +102,14 @@ def flashmask_attention(
         )
         value = paddle.concat([value, value_padding], axis=-1)
 
+    extra_kwargs = {}
     if use_varlen:
-        flashmask_attention_func = partial(
-            _flashmask_attention, use_varlen=True
-        )
-    else:
-        flashmask_attention_func = _flashmask_attention
+        # use_varlen is no longer used and will be removed soon.
+        extra_kwargs["use_varlen"] = True
+    if learnable_sink is not None:
+        extra_kwargs["learnable_sink"] = learnable_sink
+
+    flashmask_attention_func = _flashmask_attention
 
     outs = flashmask_attention_func(
         query=query,
@@ -113,6 +127,7 @@ def flashmask_attention(
         name=name,
         softmax_scale=softmax_scale,
         block_mask=block_mask,
+        **extra_kwargs,
     )
 
     if return_softmax_lse:

--- a/src/paddlefleet/context_parallel_utils.py
+++ b/src/paddlefleet/context_parallel_utils.py
@@ -602,7 +602,14 @@ def preprocess_index_dual_chunks(
 
 
 def cp_flashmask_allgatherkv_balance_forward(
-    query, key, value, startend_row_indices, group, causal, is_training
+    query,
+    key,
+    value,
+    startend_row_indices,
+    learnable_sink,
+    group,
+    causal,
+    is_training,
 ):
     """
     Forward pass of context parallel flashmask attention with balanced all-gather strategy.
@@ -671,9 +678,14 @@ def cp_flashmask_allgatherkv_balance_forward(
             causal=causal,
             return_lse=True,
             startend_row_indices=startend_row_indices,
+            learnable_sink=learnable_sink,
             pack_gqa=False,
         )
     else:
+        if learnable_sink is not None:
+            raise NotImplementedError(
+                "learnable_sink only supported on fa_version==4 cute backend"
+            )
         output, log_sum_exp = flashmask_attention(
             query,
             key_gathered,
@@ -696,6 +708,7 @@ def cp_flashmask_allgatherkv_balance_backward(
     output,
     log_sum_exp,
     output_grad,
+    learnable_sink,
     group,
     causal,
     fa_version: int,
@@ -718,7 +731,7 @@ def cp_flashmask_allgatherkv_balance_backward(
             forward kernel. Must be propagated from the forward call to keep
             fwd/bwd consistent.
     Returns:
-        tuple: (query_grad, key_grad, value_grad)
+        tuple: (query_grad, key_grad, value_grad, grad_sink)
     """
     paddle.base.core.nvprof_nvtx_push(
         "cp_flashmask_allgatherkv_balance_backward"
@@ -728,7 +741,12 @@ def cp_flashmask_allgatherkv_balance_backward(
     key_gathered = all_gather_balance(key, axis=1, group=group)
     value_gathered = all_gather_balance(value, axis=1, group=group)
 
+    grad_sink = None
     if fa_version == 2:
+        if learnable_sink is not None:
+            raise NotImplementedError(
+                "learnable_sink only supported on fa_version==4 cute backend"
+            )
         # Create seed offset tensor (required for gradient computation)
         seed_offset = paddle.zeros(
             shape=[query.shape[1], query.shape[2]], dtype=paddle.int64
@@ -750,6 +768,10 @@ def cp_flashmask_allgatherkv_balance_backward(
             )
         )
     elif fa_version == 3:
+        if learnable_sink is not None:
+            raise NotImplementedError(
+                "learnable_sink only supported on fa_version==4 cute backend"
+            )
         sig_params = inspect.signature(flashmask_attention).parameters
         if "group" in sig_params:
             query_grad, key_grad_gathered, value_grad_gathered = (
@@ -805,18 +827,21 @@ def cp_flashmask_allgatherkv_balance_backward(
             )
         else:
             flashmask_info = None
-        query_grad, key_grad_gathered, value_grad_gathered = _flash_attn_bwd(
-            query,
-            key_gathered,
-            value_gathered,
-            output,
-            output_grad,
-            log_sum_exp,
-            flashmask_info,
-            causal=causal,
-            deterministic=paddle.get_flags(["FLAGS_cudnn_deterministic"])[
-                "FLAGS_cudnn_deterministic"
-            ],
+        query_grad, key_grad_gathered, value_grad_gathered, grad_sink = (
+            _flash_attn_bwd(
+                query,
+                key_gathered,
+                value_gathered,
+                output,
+                output_grad,
+                log_sum_exp,
+                flashmask_info,
+                learnable_sink=learnable_sink,
+                causal=causal,
+                deterministic=paddle.get_flags(["FLAGS_cudnn_deterministic"])[
+                    "FLAGS_cudnn_deterministic"
+                ],
+            )
         )
     else:
         raise ValueError(
@@ -832,7 +857,7 @@ def cp_flashmask_allgatherkv_balance_backward(
     )
 
     paddle.base.core.nvprof_nvtx_pop()
-    return query_grad, key_grad, value_grad
+    return query_grad, key_grad, value_grad, grad_sink
 
 
 def scatter_with_padding(input_tensor, num_pad, axis, group):
@@ -970,6 +995,7 @@ class FlashMaskContextParallel(PyLayer):
         dropout=0.0,
         causal=False,
         training=True,
+        learnable_sink=None,
         mode="allgather_kv",
     ):
         """
@@ -1019,7 +1045,14 @@ class FlashMaskContextParallel(PyLayer):
         # Perform forward pass
         output, log_sum_exp, startend_row_indices, fa_version = (
             cp_flashmask_allgatherkv_balance_forward(
-                query, key, value, startend_row_indices, group, causal, training
+                query,
+                key,
+                value,
+                startend_row_indices,
+                learnable_sink,
+                group,
+                causal,
+                training,
             )
         )
 
@@ -1030,6 +1063,13 @@ class FlashMaskContextParallel(PyLayer):
         ctx.group = group
         ctx.causal = causal
         ctx.fa_version = fa_version
+        ctx.learnable_sink = learnable_sink
+        # Only a trainable sink (a Parameter) needs a gradient returned from
+        # backward. A fixed off-by-one sink is created as a stop_gradient=True
+        # Tensor, and Paddle's PyLayer requires None in that return slot.
+        ctx.sink_requires_grad = (
+            learnable_sink is not None and not learnable_sink.stop_gradient
+        )
 
         return output
 
@@ -1050,9 +1090,10 @@ class FlashMaskContextParallel(PyLayer):
         group = ctx.group
         causal = ctx.causal
         fa_version = ctx.fa_version
+        learnable_sink = ctx.learnable_sink
 
         # Compute gradients
-        query_grad, key_grad, value_grad = (
+        query_grad, key_grad, value_grad, grad_sink = (
             cp_flashmask_allgatherkv_balance_backward(
                 query,
                 key,
@@ -1061,12 +1102,21 @@ class FlashMaskContextParallel(PyLayer):
                 output,
                 log_sum_exp,
                 output_grad,
+                learnable_sink,
                 group,
                 causal,
                 fa_version,
             )
         )
 
+        # PyLayer maps backward returns positionally onto the forward TENSOR
+        # inputs: query(0)/key(1)/value(2)/startend_row_indices(3)/
+        # learnable_sink(4). startend_row_indices is stop_gradient=True, so its
+        # slot (position 3) must be None -- grad_sink belongs in position 4.
+        # A fixed off-by-one sink is also stop_gradient=True, so for it the
+        # 3-tuple (sink slot omitted) is correct.
+        if ctx.sink_requires_grad:
+            return query_grad, key_grad, value_grad, None, grad_sink
         return query_grad, key_grad, value_grad
 
 
@@ -1079,6 +1129,7 @@ def flashmask_attention_cp(
     dropout=0.0,
     causal=False,
     training=True,
+    learnable_sink=None,
     mode="allgather_kv",
 ):
     """
@@ -1114,6 +1165,11 @@ def flashmask_attention_cp(
         )
         ```
     """
+    if learnable_sink is not None:
+        raise NotImplementedError(
+            "learnable_sink is not supported on flashmask_attention_cp"
+        )
+
     output = FlashMaskContextParallel.apply(
         query,
         key,
@@ -1123,6 +1179,7 @@ def flashmask_attention_cp(
         dropout,
         causal,
         training,
+        learnable_sink,
         mode,
     )
     return output

--- a/src/paddlefleet/refined_recompute/flash_attn.py
+++ b/src/paddlefleet/refined_recompute/flash_attn.py
@@ -645,11 +645,18 @@ class RefinedRcomputeFlashMaskAttention:
         causal=True,
         return_softmax=False,
         training=True,
+        learnable_sink=None,
     ):
         """
         The main entry point for the forward pass.
         Dispatches to either the first or second forward pass based on autograd state.
         """
+        if learnable_sink is not None:
+            raise NotImplementedError(
+                "refined recompute attention does not support learnable_sink "
+                "(softmax sink); use flashmask_attention / "
+                "flashmask_attention_cp instead."
+            )
         if not framework._dygraph_tracer()._has_grad:
             # This is the initial, normal forward pass.
             attn_output = self._first_fwd(
@@ -858,7 +865,7 @@ class FlashMaskAttnCpFunctor(PyLayer):
         fa_version = ctx.fa_version
 
         # Compute gradients
-        query_grad, key_grad, value_grad = (
+        query_grad, key_grad, value_grad, _ = (
             cp_flashmask_allgatherkv_balance_backward(
                 q,
                 k,
@@ -867,6 +874,7 @@ class FlashMaskAttnCpFunctor(PyLayer):
                 result_attention,
                 softmax_lse,
                 grad,
+                None,
                 group,
                 causal,
                 fa_version,
@@ -904,11 +912,18 @@ class RefinedRcomputeFlashMaskCpAttention:
         causal=False,
         training=True,
         mode="allgather_kv",
+        learnable_sink=None,
     ):
         """
         The main entry point for the forward pass.
         Dispatches to either the first or second forward pass based on autograd state.
         """
+        if learnable_sink is not None:
+            raise NotImplementedError(
+                "refined recompute attention does not support learnable_sink "
+                "(softmax sink); use flashmask_attention / "
+                "flashmask_attention_cp instead."
+            )
         if not framework._dygraph_tracer()._has_grad:
             # This is the initial, normal forward pass.
             attn_output = self._first_fwd(
@@ -982,6 +997,7 @@ class RefinedRcomputeFlashMaskCpAttention:
                 key_states,
                 value_states,
                 startend_row_indices,
+                None,
                 group,
                 causal,
                 training,

--- a/src/paddlefleet/transformer/dot_product_attention.py
+++ b/src/paddlefleet/transformer/dot_product_attention.py
@@ -526,6 +526,7 @@ class DotProductAttention(FleetLayer):
                 startend_row_indices=attn_mask_startend_row_indices,
                 dropout=self.config.attention_dropout,
                 causal=is_causal,
+                learnable_sink=self.softmax_offset,
             )
 
             if need_value_padding:

--- a/tests/multi_card_tests/transformer/test_flash_mask_sink_cp.py
+++ b/tests/multi_card_tests/transformer/test_flash_mask_sink_cp.py
@@ -1,0 +1,398 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Multi-card tests for FA4 attention-sink under context parallelism.
+
+Verifies that flashmask_attention_cp with a learnable_sink produces forward
+output and input/sink gradients matching a single-rank full-sequence reference.
+
+Key detail: CP uses the DualChunkSwap load-balancing layout (scatter_balance),
+so the per-rank input slice AND the reference-output slice must both be taken
+with scatter_balance -- NOT contiguous slicing.
+
+Constraints exercised (per FlashMaskContextParallel):
+  - causal=False only
+  - startend_row_indices.shape[-1] == 2
+  - seq divisible by (cp_size * 2)
+"""
+
+import math
+import unittest
+
+import numpy as np
+import paddle
+import paddle.distributed as dist
+from paddle.distributed import fleet
+
+paddle.set_flags({"FLAGS_flash_attn_version": 4})
+
+from paddlefleet.context_parallel_utils import (
+    flashmask_attention_cp,
+    scatter_balance,
+)
+
+DTYPE = paddle.bfloat16
+SEED = 2026
+COS_SIM_THRESHOLD = 0.95
+# A non-trivial sink bias so the sink measurably perturbs the reference output,
+# giving the discriminative "closer to with-sink than no-sink" check signal.
+SINK_BIAS = 4.0
+
+CP_SIZE = None
+CP_RANK = None
+CP_GROUP = None
+
+
+def setUpModule():
+    # FA4 attention-sink lives only in the cute backend, built solely for
+    # compute capability >= 10 (sm100/Blackwell). Skip before fleet.init so
+    # non-sm100 ranks exit cleanly without initializing distributed.
+    from paddlefleet_ops import is_flash_mask_available
+
+    if not is_flash_mask_available():
+        raise unittest.SkipTest(
+            "FA4 attention-sink CP requires the cute backend "
+            "(sm100, capability >= 10)"
+        )
+    global CP_SIZE, CP_RANK, CP_GROUP
+    strategy = fleet.DistributedStrategy()
+    world = dist.get_world_size()
+    strategy.hybrid_configs = {
+        "dp_degree": 1,
+        "mp_degree": 1,
+        "pp_degree": 1,
+        "sharding_degree": world,
+        "sep_degree": 1,
+        "cp_degree": world,
+        "ep_degree": world,
+        "moe_sharding_degree": 1,
+        "order": [
+            "sharding",
+            "moe_sharding",
+            "pp",
+            "sep",
+            "cp",
+            "dp",
+            "ep",
+            "mp",
+        ],
+    }
+    fleet.init(is_collective=True, strategy=strategy)
+    CP_GROUP = fleet.get_hybrid_communicate_group().get_context_parallel_group()
+    CP_RANK = CP_GROUP.rank
+    CP_SIZE = CP_GROUP.nranks
+
+
+def _cosine_sim(actual, expected):
+    a = actual.cast("float32").flatten()
+    b = expected.cast("float32").flatten()
+    dot = (a * b).sum()
+    return (dot / (a.norm() * b.norm() + 1e-30)).item()
+
+
+def _noncausal_startend_row_indices(batch_size, seq_len):
+    """Full non-causal [b, 1, seq_len, 2] startend_row_indices.
+
+    For a 2-col non-causal mask the columns are (down_start, up_end):
+      col0 (down_start): rows >= down_start are masked (-inf) for that key
+      col1 (up_end):     rows <  up_end    are masked (-inf) for that key
+    So "mask nothing" (full attention) is down_start=seq_len, up_end=0 --
+    matching the repo's own generate_non_causal_mask (down_left=seqlen_k,
+    up_right=0). The previous (0, seq_len) masked EVERY row -> all-zero output.
+    """
+    down_start = np.full((batch_size, 1, seq_len, 1), seq_len, dtype=np.int32)
+    up_end = np.zeros((batch_size, 1, seq_len, 1), dtype=np.int32)
+    indices = np.concatenate([down_start, up_end], axis=-1)
+    return paddle.to_tensor(indices, dtype=paddle.int32)
+
+
+def _full_attention_ref(q, k, v, learnable_sink):
+    """fp32 full non-causal attention with optional sink, no masking.
+
+    q,k,v: [b, s, h, d]. learnable_sink: [h] or None. Returns [b, s, h, d].
+    """
+    qf = q.astype("float32").transpose([0, 2, 1, 3])
+    kf = k.astype("float32").transpose([0, 2, 1, 3])
+    vf = v.astype("float32").transpose([0, 2, 1, 3])
+
+    h = qf.shape[1]
+    d = qf.shape[-1]
+    softmax_scale = 1.0 / math.sqrt(d)
+    scores = paddle.matmul(qf * softmax_scale, kf, transpose_y=True)
+
+    row_max = scores.max(axis=-1, keepdim=True)
+    if learnable_sink is not None:
+        sink = learnable_sink.astype("float32").reshape([1, h, 1, 1])
+        row_max = paddle.maximum(row_max, sink)
+        exp_sink = paddle.exp(sink - row_max)
+    else:
+        exp_sink = 0.0
+
+    exp_scores = paddle.exp(scores - row_max)
+    denom = exp_scores.sum(axis=-1, keepdim=True) + exp_sink
+    attention = exp_scores / denom
+    out = paddle.matmul(attention.astype(vf.dtype), vf)
+    return out.transpose([0, 2, 1, 3])
+
+
+def _scatter_leaf(full_tensor):
+    """Per-rank DualChunkSwap slice of a full tensor as a fresh CP leaf.
+
+    scatter_balance performs the same balanced (both-ends) split that
+    flashmask_attention_cp expects its already-sharded inputs to follow.
+    We detach first so autograd treats the per-rank slice as a leaf.
+    """
+    local = scatter_balance(full_tensor.detach(), group=CP_GROUP, axis=1)
+    local = local.detach()
+    local.stop_gradient = False
+    return local
+
+
+class TestFlashMaskSinkCP(unittest.TestCase):
+    """flashmask_attention_cp + learnable_sink vs a full-sequence reference.
+
+    Each rank holds the scatter_balance slice of identical full q/k/v; the
+    reference output/grads are sliced the same way for comparison.
+    """
+
+    def _full_inputs(self, batch_size, seq_len, nheads, d):
+        paddle.seed(SEED)
+        np.random.seed(SEED)
+        q = paddle.randn([batch_size, seq_len, nheads, d], dtype=DTYPE)
+        k = paddle.randn([batch_size, seq_len, nheads, d], dtype=DTYPE)
+        v = paddle.randn([batch_size, seq_len, nheads, d], dtype=DTYPE)
+        return q, k, v
+
+    def _run(
+        self, batch_size, seq_len, nheads, d, use_sink, sink_trainable=True
+    ):
+        assert seq_len % (CP_SIZE * 2) == 0, (
+            f"seq_len {seq_len} must be divisible by cp_size*2 {CP_SIZE * 2}"
+        )
+
+        q_full, k_full, v_full = self._full_inputs(
+            batch_size, seq_len, nheads, d
+        )
+        # Full-sequence reference leaves (single-rank golden).
+        q_ref, k_ref, v_ref = [
+            x.detach().clone() for x in (q_full, k_full, v_full)
+        ]
+        for t in (q_ref, k_ref, v_ref):
+            t.stop_gradient = False
+
+        if use_sink:
+            paddle.seed(SEED + 1)
+            # Use a large-magnitude sink so its effect on the softmax denom is
+            # unmistakable: a path that silently drops the sink will diverge
+            # well below COS_SIM_THRESHOLD instead of staying borderline.
+            sink_full = paddle.randn([nheads], dtype=DTYPE) + SINK_BIAS
+            sink_ref = sink_full.detach().clone()
+            sink_ref.stop_gradient = not sink_trainable
+            sink_local = sink_full.detach().clone()
+            sink_local.stop_gradient = not sink_trainable
+        else:
+            sink_full = sink_ref = sink_local = None
+
+        # Per-rank scatter_balance slices (the layout CP expects).
+        q_local = _scatter_leaf(q_full)
+        k_local = _scatter_leaf(k_full)
+        v_local = _scatter_leaf(v_full)
+
+        startend_row_indices = _noncausal_startend_row_indices(
+            batch_size, seq_len
+        )
+
+        out_local = flashmask_attention_cp(
+            q_local,
+            k_local,
+            v_local,
+            startend_row_indices,
+            causal=False,
+            learnable_sink=sink_local,
+        )
+
+        # Reference forward over the full sequence, then slice the same way.
+        out_ref_full = _full_attention_ref(q_ref, k_ref, v_ref, sink_ref)
+        out_ref_local = scatter_balance(
+            out_ref_full.detach(), group=CP_GROUP, axis=1
+        )
+
+        cos = _cosine_sim(out_local, out_ref_local)
+        self.assertGreaterEqual(
+            cos,
+            COS_SIM_THRESHOLD,
+            f"[rank {CP_RANK}] fwd cosine {cos} < {COS_SIM_THRESHOLD}",
+        )
+
+        if use_sink:
+            # Discriminative check: the sink must materially change the output,
+            # and out_local must track the WITH-sink reference rather than the
+            # no-sink one. A path that silently drops the sink would instead sit
+            # closer to the no-sink reference.
+            #
+            # Note: a global cosine vs the no-sink output is a poor probe here.
+            # With full non-causal attention over `seq_len` keys, the single
+            # exp(sink - row_max) term is diluted by the seq_len-way denominator,
+            # so the sink only perturbs the output slightly (cosine stays ~0.99)
+            # even though it is correctly applied. We therefore compare absolute
+            # distances to the two references instead.
+            out_nosink_full = _full_attention_ref(q_ref, k_ref, v_ref, None)
+            out_nosink_local = scatter_balance(
+                out_nosink_full.detach(), group=CP_GROUP, axis=1
+            )
+
+            def _max_abs_diff(a, b):
+                return (
+                    (a.cast("float32") - b.cast("float32")).abs().max().item()
+                )
+
+            # Sanity: the sink must actually change the reference output,
+            # otherwise this test cannot distinguish "applied" from "ignored".
+            ref_sink_effect = _max_abs_diff(out_ref_local, out_nosink_local)
+            self.assertGreater(
+                ref_sink_effect,
+                1e-3,
+                f"[rank {CP_RANK}] reference sink effect {ref_sink_effect} is "
+                f"too small to be a meaningful probe; increase SINK_BIAS",
+            )
+
+            # out_local must be closer to the WITH-sink reference than to the
+            # no-sink one; if the sink were silently ignored these would flip.
+            dist_to_sink = _max_abs_diff(out_local, out_ref_local)
+            dist_to_nosink = _max_abs_diff(out_local, out_nosink_local)
+            self.assertLess(
+                dist_to_sink,
+                dist_to_nosink,
+                f"[rank {CP_RANK}] output is closer to the no-sink reference "
+                f"(d={dist_to_nosink}) than to the with-sink reference "
+                f"(d={dist_to_sink}); learnable_sink is likely being ignored",
+            )
+
+        # Backward: identical upstream grad on both sides (sliced for local).
+        paddle.seed(SEED + 2)
+        g_full = paddle.randn(out_ref_full.shape, dtype=out_ref_full.dtype)
+        g_local = scatter_balance(g_full.detach(), group=CP_GROUP, axis=1)
+
+        out_local.backward(g_local.clone())
+        out_ref_full.backward(g_full.clone())
+
+        for name, a_full in (
+            ("dq", q_ref.grad),
+            ("dk", k_ref.grad),
+            ("dv", v_ref.grad),
+        ):
+            ref_local = scatter_balance(a_full.detach(), group=CP_GROUP, axis=1)
+            got = {"dq": q_local.grad, "dk": k_local.grad, "dv": v_local.grad}[
+                name
+            ]
+            c = _cosine_sim(got, ref_local)
+            self.assertGreaterEqual(
+                c,
+                COS_SIM_THRESHOLD,
+                f"[rank {CP_RANK}] {name} cosine {c} < {COS_SIM_THRESHOLD}",
+            )
+
+        if use_sink and sink_trainable:
+            # The in-kernel all_reduce is removed: each CP rank's dsink is only
+            # the partial sum over the query rows it owns. The global dsink is
+            # produced trainer-side (grad scale + allreduce). Here we SUM across
+            # the CP group explicitly before it should match the full-sequence
+            # reference.
+            self.assertIsNotNone(sink_local.grad)
+            self.assertEqual(list(sink_local.grad.shape), [nheads])
+            self.assertIsNotNone(sink_ref.grad)
+
+            summed = sink_local.grad.detach().clone()
+            if CP_SIZE > 1:
+                # A single rank's partial sum should NOT already equal the
+                # global reference (proves nothing reduces across CP ranks
+                # inside the kernel).
+                local_gap = (
+                    (
+                        sink_local.grad.cast("float32")
+                        - sink_ref.grad.cast("float32")
+                    )
+                    .abs()
+                    .max()
+                    .item()
+                )
+                self.assertGreater(
+                    local_gap,
+                    1e-3,
+                    f"[rank {CP_RANK}] per-rank dsink already matches the "
+                    f"global reference (gap={local_gap}); an in-kernel reduce "
+                    f"may still be summing across CP ranks",
+                )
+                dist.all_reduce(summed, group=CP_GROUP)
+
+            sc = _cosine_sim(summed, sink_ref.grad)
+            self.assertGreaterEqual(
+                sc,
+                COS_SIM_THRESHOLD,
+                f"[rank {CP_RANK}] summed dsink cosine {sc} < {COS_SIM_THRESHOLD}",
+            )
+        elif use_sink and not sink_trainable:
+            # Fixed off-by-one sink: stop_gradient -> CP returns the 3-tuple,
+            # so the sink leaf must receive no gradient.
+            self.assertIsNone(sink_local.grad)
+
+    def test_cp_trainable_sink(self):
+        self._run(2, 256, 4, 128, use_sink=True)
+
+    def test_cp_sink_none(self):
+        self._run(2, 256, 4, 128, use_sink=False)
+
+    def test_cp_offbyone_fixed_sink(self):
+        # Fixed (stop_gradient) sink -> backward returns 3-tuple, grad is None.
+        self._run(2, 256, 4, 128, use_sink=True, sink_trainable=False)
+
+    def test_cp_small_head_dim_sink(self):
+        self._run(2, 128, 4, 64, use_sink=True)
+
+
+class TestSinkUnsupportedPaths(unittest.TestCase):
+    """learnable_sink must be confined to flashmask_attention / *_cp.
+
+    The refined-recompute (RR / RR-CP) path does NOT support attention sink.
+    Passing a sink to it must raise NotImplementedError rather than being
+    silently dropped (the bug this PR guards against).
+    """
+
+    def test_rr_cp_rejects_sink(self):
+        from paddlefleet.refined_recompute.flash_attn import (
+            RefinedRcomputeFlashMaskCpAttention,
+        )
+
+        q = paddle.randn([2, 256, 4, 128], dtype=DTYPE)
+        startend = _noncausal_startend_row_indices(2, 256)
+        sink = paddle.randn([4], dtype=DTYPE)
+        attn = RefinedRcomputeFlashMaskCpAttention()
+        with self.assertRaises(NotImplementedError):
+            attn.forward(q, q, q, startend, learnable_sink=sink)
+
+    def test_rr_rejects_sink(self):
+        from paddlefleet.refined_recompute.flash_attn import (
+            RefinedRcomputeFlashMaskAttention,
+        )
+
+        q = paddle.randn([2, 256, 4, 128], dtype=DTYPE)
+        startend = _noncausal_startend_row_indices(2, 256)
+        sink = paddle.randn([4], dtype=DTYPE)
+        attn = RefinedRcomputeFlashMaskAttention()
+        with self.assertRaises(NotImplementedError):
+            attn.forward(q, q, q, startend, learnable_sink=sink)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/ai_edited_test/distributed/test_ai_context_parallel_utils_3.py
+++ b/tests/single_card_tests/ai_edited_test/distributed/test_ai_context_parallel_utils_3.py
@@ -209,7 +209,7 @@ class TestFlashMaskContextParallelBackward(unittest.TestCase):
 
         with mock.patch(
             "paddlefleet.context_parallel_utils.cp_flashmask_allgatherkv_balance_backward",
-            return_value=(grad, grad, grad),
+            return_value=(grad, grad, grad, None),
         ) as mock_bwd:
             result = FlashMaskContextParallel.backward(mock_ctx, grad)
             mock_bwd.assert_called_once()
@@ -411,7 +411,7 @@ class TestCpFlashmaskForwardDeterministicOverride(unittest.TestCase):
             mock.patch.object(paddle, "get_flags", return_value=flags_det),
         ):
             out = cpu.cp_flashmask_allgatherkv_balance_forward(
-                query, key, value, indices, group, False, True
+                query, key, value, indices, None, group, False, True
             )
         return out[-1]  # fa_version
 

--- a/tests/single_card_tests/ai_edited_test/distributed/test_ai_flash_attn.py
+++ b/tests/single_card_tests/ai_edited_test/distributed/test_ai_flash_attn.py
@@ -81,6 +81,7 @@ class TestCpFlashmaskBackwardDispatch(unittest.TestCase):
                 out,
                 lse,
                 out_grad,
+                None,
                 group,
                 False,
                 config.fa_version,

--- a/tests/single_card_tests/transformer/test_flash_mask_sink.py
+++ b/tests/single_card_tests/transformer/test_flash_mask_sink.py
@@ -1,0 +1,608 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Single-card tests for FA4 attention-sink (learnable_sink) support.
+
+Covers PR "Support FA4 sink." (ab8c450) on the non-CP paths:
+  1. Low-level cute ``flashmask_attention(..., learnable_sink=)`` fwd+bwd vs an
+     inline fp32 golden (trainable sink / sink=None / GQA / dsink dtype).
+  2. Facade ``paddlefleet_ops.flash_mask_facade.flashmask_attention`` (+2 lines:
+     forwards learnable_sink), exercising its two quirks (clone() on
+     startend_row_indices; lse reshape only valid for nheads==1).
+  3. ``DotProductAttention`` softmax_offset construction (vanilla/off-by-one/
+     learnable + sink-bias promotion) and the fwd/bwd sink branch.
+"""
+
+import math
+import unittest
+
+import numpy as np
+import paddle
+from paddlefleet_ops import is_flash_mask_available
+
+# Force FA4 (cute) backend for the whole module: sink only exists there.
+paddle.set_flags({"FLAGS_flash_attn_version": 4})
+
+DTYPE = paddle.bfloat16
+SEED = 2026
+
+# FA4 attention-sink lives only in the cute backend, which is built solely for
+# compute capability >= 10 (sm100/Blackwell). Elsewhere the cute kernels are
+# absent and the facade falls back to a sink-less backend, so skip these tests.
+_SINK_AVAILABLE = is_flash_mask_available()
+_SKIP_REASON = (
+    "FA4 attention-sink requires the cute backend (sm100, capability >= 10)"
+)
+
+
+def _startend_row_indices(batch_size, seq_len, causal):
+    """Build a [b, 1, seq_len, 2] int32 startend_row_indices tensor.
+
+    causal=True  -> start=0,       end=arange(1, seq+1)  (lower-triangular)
+    causal=False -> start=seq_len, end=0                 (full attention)
+
+    For the non-causal 2-col case the columns are (down_start, up_end):
+    rows >= down_start and rows < up_end are masked. "Mask nothing" (full
+    attention) is therefore down_start=seq_len, up_end=0 -- matching the repo's
+    generate_non_causal_mask. (start=0, end=seq_len would mask EVERY row.)
+    """
+    if causal:
+        start = np.zeros((batch_size, 1, seq_len, 1), dtype=np.int32)
+        end = np.arange(1, seq_len + 1, dtype=np.int32).reshape(
+            1, 1, seq_len, 1
+        )
+        end = np.broadcast_to(end, (batch_size, 1, seq_len, 1))
+    else:
+        start = np.full((batch_size, 1, seq_len, 1), seq_len, dtype=np.int32)
+        end = np.zeros((batch_size, 1, seq_len, 1), dtype=np.int32)
+    indices = np.concatenate([start, end], axis=-1)
+    return paddle.to_tensor(indices, dtype=paddle.int32)
+
+
+def _attn_bias_from_indices(startend_row_indices, seqlen_q, nheads, causal):
+    """Dense additive bias (-inf masked) from a 2-col startend_row_indices.
+
+    Mirrors generate_startend_row_indices.startend_row_indices_to_attn_bias for
+    the causal-2col / non-causal-2col cases used in these tests. Returns a fp32
+    tensor broadcastable to [b, nheads, seqlen_q, seqlen_k].
+    """
+    bz, num_head, seqlen_k, bound_num = startend_row_indices.shape
+    assert nheads % num_head == 0
+    idx = startend_row_indices.numpy()
+    m = np.zeros((bz, num_head, seqlen_q, seqlen_k), dtype=np.float32)
+    for bi in range(bz):
+        for hi in range(num_head):
+            for j in range(seqlen_k):
+                downstart = int(idx[bi, hi, j, 0])
+                if causal:
+                    downend = int(idx[bi, hi, j, 1])
+                    m[bi, hi, downstart:downend, j] = -np.inf
+                    # bottom-right aligned causal mask
+                    top = max(0, j - (seqlen_k - seqlen_q))
+                    m[bi, hi, :top, j] = -np.inf
+                else:
+                    upend = int(idx[bi, hi, j, 1])
+                    m[bi, hi, downstart:, j] = -np.inf
+                    m[bi, hi, :upend, j] = -np.inf
+    m = np.repeat(m, nheads // num_head, axis=1)
+    return paddle.to_tensor(m, dtype=paddle.float32)
+
+
+def attention_ref_with_sink(q, k, v, attn_bias, learnable_sink):
+    """fp32 reference for flashmask + attention-sink.
+
+    q,k,v: [b, s, h, d] (GQA: h_kv may be < h_q). attn_bias: additive [-inf] mask
+    broadcastable to [b, h_q, sq, sk]. learnable_sink: [h_q] per-q-head logit
+    (un-scaled) competing only in the softmax denominator, or None.
+
+    sink formula:
+        sink   = sink[h].reshape(1, h, 1, 1)            # fp32, un-scaled logit
+        row_max= max(scores.max(-1, keepdim), sink)
+        denom  = exp(scores-row_max).sum(-1, keepdim) + exp(sink-row_max)
+        attn   = exp(scores-row_max) / denom
+        out    = attn @ v
+    """
+    qf = q.astype("float32").transpose([0, 2, 1, 3])  # b h s d
+    kf = k.astype("float32").transpose([0, 2, 1, 3])
+    vf = v.astype("float32").transpose([0, 2, 1, 3])
+
+    h_q = qf.shape[1]
+    g = h_q // kf.shape[1]
+    if g > 1:
+        kf = paddle.repeat_interleave(kf, g, axis=1)
+        vf = paddle.repeat_interleave(vf, g, axis=1)
+
+    d = qf.shape[-1]
+    softmax_scale = 1.0 / math.sqrt(d)
+    scores = paddle.matmul(qf * softmax_scale, kf, transpose_y=True)
+
+    if attn_bias is not None:
+        bias = attn_bias
+        if bias.shape[1] != h_q:
+            bias = paddle.repeat_interleave(bias, h_q // bias.shape[1], axis=1)
+        scores = scores + bias
+        all_inf = (bias == -np.inf).all(axis=-1, keepdim=True)
+        scores = paddle.where(all_inf, paddle.full_like(scores, -1e30), scores)
+    else:
+        all_inf = None
+
+    row_max = scores.max(axis=-1, keepdim=True)
+    if learnable_sink is not None:
+        sink = learnable_sink.astype("float32").reshape([1, h_q, 1, 1])
+        row_max = paddle.maximum(row_max, sink)
+        exp_sink = paddle.exp(sink - row_max)
+    else:
+        exp_sink = 0.0
+
+    exp_scores = paddle.exp(scores - row_max)
+    denom = exp_scores.sum(axis=-1, keepdim=True) + exp_sink
+    attention = exp_scores / denom
+    if all_inf is not None:
+        attention = paddle.where(
+            all_inf, paddle.zeros_like(attention), attention
+        )
+
+    out = paddle.matmul(attention.astype(vf.dtype), vf)
+    out = out.transpose([0, 2, 1, 3])  # b s h d
+    return out
+
+
+@unittest.skipUnless(_SINK_AVAILABLE, _SKIP_REASON)
+class TestCuteFlashmaskSink(unittest.TestCase):
+    """Low-level cute flashmask_attention numerical correctness with sink."""
+
+    def _run(
+        self,
+        batch_size,
+        seq_len,
+        nheads,
+        nheads_kv,
+        d,
+        causal,
+        use_sink,
+    ):
+        from paddlefleet_ops.flash_mask.cute.interface import (
+            flashmask_attention,
+        )
+
+        paddle.seed(SEED)
+        np.random.seed(SEED)
+
+        q_ref = paddle.randn([batch_size, seq_len, nheads, d], dtype=DTYPE)
+        k_ref = paddle.randn([batch_size, seq_len, nheads_kv, d], dtype=DTYPE)
+        v_ref = paddle.randn([batch_size, seq_len, nheads_kv, d], dtype=DTYPE)
+        for t in (q_ref, k_ref, v_ref):
+            t.stop_gradient = False
+
+        q, k, v = [x.detach().clone() for x in (q_ref, k_ref, v_ref)]
+        for t in (q, k, v):
+            t.stop_gradient = False
+
+        if use_sink:
+            sink_ref = paddle.randn([nheads], dtype=DTYPE)
+            sink_ref.stop_gradient = False
+            sink = sink_ref.detach().clone()
+            sink.stop_gradient = False
+        else:
+            sink_ref = None
+            sink = None
+
+        startend_row_indices = _startend_row_indices(
+            batch_size, seq_len, causal
+        )
+        attn_bias = _attn_bias_from_indices(
+            startend_row_indices, seq_len, nheads, causal
+        )
+
+        out_ref = attention_ref_with_sink(
+            q_ref, k_ref, v_ref, attn_bias, sink_ref
+        )
+
+        out = flashmask_attention(
+            q,
+            k,
+            v,
+            startend_row_indices=startend_row_indices,
+            causal=causal,
+            learnable_sink=sink,
+        )
+
+        # Forward tolerance: 2x the bf16->fp32 round-trip noise of the reference.
+        fwd_atol = 2 * (out_ref + 0.3 - 0.3 - out_ref).abs().max().item()
+        max_diff = (out - out_ref).abs().max().item()
+        self.assertLessEqual(
+            max_diff,
+            2e-2 + fwd_atol,
+            f"fwd max diff {max_diff} too large (atol={fwd_atol})",
+        )
+
+        # Backward
+        g = paddle.randn(out.shape, dtype=out.dtype)
+        out.backward(g.clone())
+        out_ref.backward(g.clone())
+
+        for name, a, b in (
+            ("dq", q.grad, q_ref.grad),
+            ("dk", k.grad, k_ref.grad),
+            ("dv", v.grad, v_ref.grad),
+        ):
+            atol = 2 * (b + 0.3 - 0.3 - b).abs().max().item()
+            diff = (a - b).abs().max().item()
+            self.assertLessEqual(
+                diff, 5e-2 + atol, f"{name} max diff {diff} too large"
+            )
+
+        if use_sink:
+            self.assertIsNotNone(sink.grad)
+            # Kernel computes dsink in fp32 then casts back to sink dtype (bf16).
+            self.assertEqual(sink.grad.dtype, DTYPE)
+            self.assertEqual(list(sink.grad.shape), [nheads])
+
+    def test_causal_with_trainable_sink(self):
+        self._run(2, 256, 4, 4, 128, causal=True, use_sink=True)
+
+    def test_noncausal_with_trainable_sink(self):
+        self._run(2, 256, 4, 4, 128, causal=False, use_sink=True)
+
+    def test_sink_none_matches_plain_softmax(self):
+        self._run(2, 256, 4, 4, 128, causal=True, use_sink=False)
+
+    def test_gqa_with_sink(self):
+        # nheads_kv < nheads exercises the GQA repeat path with sink.
+        self._run(2, 256, 8, 2, 128, causal=True, use_sink=True)
+
+    def test_small_head_dim_sink(self):
+        self._run(2, 128, 4, 4, 64, causal=False, use_sink=True)
+
+    def test_fixed_sink_backward_returns_dsink_slot(self):
+        # A FIXED (stop_gradient=True) bf16 sink is a valid forward input, but
+        # FlashMaskFunc.backward chooses its return arity from
+        # ``learnable_sink is None`` alone (interface.py:1770-1772) -- it does
+        # NOT consult stop_gradient. So a non-None fixed sink makes backward
+        # return the 4-tuple (dq, dk, dv, dsink); Paddle's PyLayer then rejects
+        # it because the sink forward input has stop_gradient=True and its slot
+        # must be None. We assert the forward is still numerically correct and
+        # that backward raises this ValueError, documenting the limitation.
+        from paddlefleet_ops.flash_mask.cute.interface import (
+            flashmask_attention,
+        )
+
+        paddle.seed(SEED)
+        np.random.seed(SEED)
+        b, s, h, d = 2, 256, 4, 128
+        q = paddle.randn([b, s, h, d], dtype=DTYPE)
+        k = paddle.randn([b, s, h, d], dtype=DTYPE)
+        v = paddle.randn([b, s, h, d], dtype=DTYPE)
+        for t in (q, k, v):
+            t.stop_gradient = False
+
+        # off-by-one == a fixed all-zeros sink logit (stop_gradient=True).
+        sink = paddle.zeros([h], dtype=DTYPE)
+        sink.stop_gradient = True
+
+        idx = _startend_row_indices(b, s, causal=True)
+        attn_bias = _attn_bias_from_indices(idx, s, h, causal=True)
+        out_ref = attention_ref_with_sink(q, k, v, attn_bias, sink)
+
+        out = flashmask_attention(
+            q,
+            k,
+            v,
+            startend_row_indices=idx,
+            causal=True,
+            learnable_sink=sink,
+        )
+        fwd_atol = 2 * (out_ref + 0.3 - 0.3 - out_ref).abs().max().item()
+        self.assertLessEqual(
+            (out - out_ref).abs().max().item(), 2e-2 + fwd_atol
+        )
+
+        with self.assertRaises(ValueError):
+            out.backward(paddle.randn(out.shape, dtype=out.dtype))
+
+    def test_sink_dtype_assert(self):
+        # The cute kernel asserts learnable_sink is bf16; fp32 must raise.
+        from paddlefleet_ops.flash_mask.cute.interface import (
+            flashmask_attention,
+        )
+
+        paddle.seed(SEED)
+        b, s, h, d = 1, 64, 2, 64
+        q = paddle.randn([b, s, h, d], dtype=DTYPE)
+        k = paddle.randn([b, s, h, d], dtype=DTYPE)
+        v = paddle.randn([b, s, h, d], dtype=DTYPE)
+        sink_fp32 = paddle.zeros([h], dtype=paddle.float32)
+        idx = _startend_row_indices(b, s, causal=True)
+        with self.assertRaises(AssertionError):
+            flashmask_attention(
+                q,
+                k,
+                v,
+                startend_row_indices=idx,
+                causal=True,
+                learnable_sink=sink_fp32,
+            )
+
+
+@unittest.skipUnless(_SINK_AVAILABLE, _SKIP_REASON)
+class TestFacadeFlashmaskSink(unittest.TestCase):
+    """paddlefleet_ops.flash_mask_facade.flashmask_attention sink forwarding.
+
+    The PR adds learnable_sink to the facade signature and forwards it to the
+    cute kernel. Note two facade quirks exercised here:
+      - startend_row_indices.clone() is called unconditionally -> must pass a
+        non-None tensor.
+      - return_softmax_lse reshapes lse to [bsz, q_len] -> only valid nheads==1.
+    """
+
+    def _run(self, nheads, nheads_kv, use_sink, return_lse=False, causal=False):
+        from paddlefleet_ops.flash_mask_facade import flashmask_attention
+
+        paddle.seed(SEED)
+        b, s, d = 2, 128, 128
+        q = paddle.randn([b, s, nheads, d], dtype=DTYPE)
+        k = paddle.randn([b, s, nheads_kv, d], dtype=DTYPE)
+        v = paddle.randn([b, s, nheads_kv, d], dtype=DTYPE)
+        for t in (q, k, v):
+            t.stop_gradient = False
+
+        sink = None
+        if use_sink:
+            sink = paddle.randn([nheads], dtype=DTYPE)
+            sink.stop_gradient = False
+
+        idx = _startend_row_indices(b, s, causal)
+        out = flashmask_attention(
+            q,
+            k,
+            v,
+            startend_row_indices=idx,
+            causal=causal,
+            return_softmax_lse=return_lse,
+            learnable_sink=sink,
+        )
+        if return_lse:
+            out, lse = out
+            self.assertEqual(list(lse.shape), [b, s])
+        self.assertEqual(list(out.shape), [b, s, nheads, d])
+
+        # Reference + numerical check (facade should be a thin wrapper).
+        attn_bias = _attn_bias_from_indices(idx, s, nheads, causal)
+        out_ref = attention_ref_with_sink(q, k, v, attn_bias, sink)
+        fwd_atol = 2 * (out_ref + 0.3 - 0.3 - out_ref).abs().max().item()
+        diff = (out - out_ref).abs().max().item()
+        self.assertLessEqual(diff, 2e-2 + fwd_atol)
+
+        out.sum().backward()
+        self.assertIsNotNone(q.grad)
+        if use_sink:
+            self.assertIsNotNone(sink.grad)
+
+    def test_facade_with_sink(self):
+        self._run(nheads=4, nheads_kv=4, use_sink=True)
+
+    def test_facade_sink_none(self):
+        self._run(nheads=4, nheads_kv=4, use_sink=False)
+
+    def test_facade_lse_single_head(self):
+        # lse reshape [bsz, q_len] only works for nheads == 1 (facade quirk 2).
+        self._run(nheads=1, nheads_kv=1, use_sink=True, return_lse=True)
+
+    def test_facade_gqa_with_sink(self):
+        self._run(nheads=8, nheads_kv=2, use_sink=True)
+
+
+def _make_config(
+    softmax_type="vanilla",
+    add_full_attention_sink_bias=False,
+    add_swa_attention_sink_bias=False,
+    num_attention_heads=4,
+    head_dim=128,
+    hidden_size=512,
+):
+    """TransformerConfig for DotProductAttention sink tests (bf16, no CP)."""
+    from paddlefleet.transformer.transformer_config import TransformerConfig
+
+    config = TransformerConfig(
+        num_hidden_layers=1,
+        hidden_size=hidden_size,
+        num_attention_heads=num_attention_heads,
+    )
+    config.head_dim = head_dim
+    config.num_key_value_heads = num_attention_heads
+    config.softmax_scale = None
+    config.use_bias = False
+    config.context_parallel_size = 1
+    config.apply_query_key_layer_scaling = False
+    config.sliding_window = None
+    config.window_attn_skip_freq = None
+    config.fp16 = False
+    config.bf16 = True
+    config.masked_softmax_fusion = False
+    config.attention_softmax_in_fp32 = True
+    config.attention_dropout = 0.0
+    config.softmax_type = softmax_type
+    config.add_full_attention_sink_bias = add_full_attention_sink_bias
+    config.add_swa_attention_sink_bias = add_swa_attention_sink_bias
+    # learnable softmax_offset is created with config.params_dtype; the cute
+    # kernel requires bf16 sink, so params_dtype must be bf16.
+    config.params_dtype = paddle.bfloat16
+    config.perform_initialization = False
+    config.flashmask_use_varlen = False
+    config.experimental_dataflow = False
+    return config
+
+
+@unittest.skipUnless(_SINK_AVAILABLE, _SKIP_REASON)
+class TestDotProductAttentionSinkInit(unittest.TestCase):
+    """softmax_offset construction across softmax_type / sink-bias promotion."""
+
+    def _build(self, **cfg_kwargs):
+        from paddlefleet.transformer.dot_product_attention import (
+            DotProductAttention,
+        )
+        from paddlefleet.transformer.enums import AttnMaskType
+
+        config = _make_config(**cfg_kwargs)
+        return DotProductAttention(
+            config=config,
+            layer_number=1,
+            attn_mask_type=AttnMaskType.causal,
+            attention_type="self",
+        )
+
+    def test_vanilla_offset_none(self):
+        attn = self._build(softmax_type="vanilla")
+        self.assertIsNone(attn.softmax_offset)
+
+    def test_offbyone_zeros(self):
+        attn = self._build(softmax_type="off-by-one")
+        self.assertIsNotNone(attn.softmax_offset)
+        self.assertEqual(
+            list(attn.softmax_offset.shape),
+            [attn.num_attention_heads_per_partition],
+        )
+        self.assertTrue(bool((attn.softmax_offset == 0).all().item()))
+
+    def test_learnable_is_parameter(self):
+        attn = self._build(softmax_type="learnable")
+        self.assertIsNotNone(attn.softmax_offset)
+        # A create_parameter() result is trainable (stop_gradient False).
+        self.assertFalse(attn.softmax_offset.stop_gradient)
+        self.assertEqual(attn.softmax_offset.dtype, paddle.bfloat16)
+
+    def test_full_attention_sink_bias_promotes_to_learnable(self):
+        # add_full_attention_sink_bias + non-SWA -> promoted to learnable.
+        attn = self._build(
+            softmax_type="vanilla",
+            add_full_attention_sink_bias=True,
+        )
+        self.assertIsNotNone(attn.softmax_offset)
+        self.assertFalse(attn.softmax_offset.stop_gradient)
+
+
+@unittest.skipUnless(_SINK_AVAILABLE, _SKIP_REASON)
+class TestDotProductAttentionSinkForward(unittest.TestCase):
+    """Full fwd/bwd through the flashmask sink branch of DotProductAttention."""
+
+    def _run(self, softmax_type, **cfg_kwargs):
+        from paddlefleet.transformer.dot_product_attention import (
+            DotProductAttention,
+        )
+        from paddlefleet.transformer.enums import AttnMaskType
+
+        paddle.seed(SEED)
+        config = _make_config(softmax_type=softmax_type, **cfg_kwargs)
+        attn = DotProductAttention(
+            config=config,
+            layer_number=1,
+            attn_mask_type=AttnMaskType.causal,
+            attention_type="self",
+        )
+
+        b, s = 2, 64
+        h = config.num_attention_heads
+        d = config.head_dim
+        q = paddle.randn([b, s, h, d], dtype=DTYPE)
+        k = paddle.randn([b, s, h, d], dtype=DTYPE)
+        v = paddle.randn([b, s, h, d], dtype=DTYPE)
+        for t in (q, k, v):
+            t.stop_gradient = False
+
+        idx = _startend_row_indices(b, s, causal=True)
+        out = attn(
+            query=q,
+            key=k,
+            value=v,
+            attention_mask=None,
+            attn_mask_startend_row_indices=idx,
+            attn_mask_type=AttnMaskType.causal,
+        )
+        self.assertEqual(list(out.shape), [b, s, h * d])
+
+        out.sum().backward()
+        self.assertIsNotNone(q.grad)
+        self.assertIsNotNone(k.grad)
+        self.assertIsNotNone(v.grad)
+
+        if softmax_type == "learnable":
+            self.assertIsNotNone(attn.softmax_offset.grad)
+            self.assertEqual(attn.softmax_offset.grad.dtype, paddle.bfloat16)
+
+    def test_forward_vanilla(self):
+        self._run("vanilla")
+
+    def test_forward_learnable_sink(self):
+        self._run("learnable")
+
+    def test_forward_offbyone(self):
+        # off-by-one builds an fp32 zeros offset; the cute kernel asserts bf16,
+        # so this path is expected to raise on the fa4 sink branch.
+        with self.assertRaises(AssertionError):
+            self._run("off-by-one")
+
+
+@unittest.skipUnless(_SINK_AVAILABLE, _SKIP_REASON)
+class TestDotProductAttentionRefinedRecompute(unittest.TestCase):
+    """Refined-recompute (rr) non-CP path does NOT support learnable_sink.
+
+    dot_product_attention.forward unconditionally passes
+    learnable_sink=self.softmax_offset to flashmask_attention_func. When the
+    sink is active (softmax_type != "vanilla") and the rr functor is selected,
+    the rr entry point must reject it with NotImplementedError rather than
+    silently dropping the sink. This asserts that contract end-to-end against
+    the real rr functor (no stub).
+    """
+
+    def test_rr_path_with_active_sink_raises(self):
+        from paddlefleet.transformer.dot_product_attention import (
+            DotProductAttention,
+        )
+        from paddlefleet.transformer.enums import AttnMaskType
+
+        paddle.seed(SEED)
+        config = _make_config(softmax_type="learnable")
+        attn = DotProductAttention(
+            config=config,
+            layer_number=1,
+            attn_mask_type=AttnMaskType.causal,
+            attention_type="self",
+        )
+        # softmax_type="learnable" -> a non-None sink is forwarded.
+        self.assertIsNotNone(attn.softmax_offset)
+
+        b, s = 2, 64
+        h = config.num_attention_heads
+        d = config.head_dim
+        q = paddle.randn([b, s, h, d], dtype=DTYPE)
+        k = paddle.randn([b, s, h, d], dtype=DTYPE)
+        v = paddle.randn([b, s, h, d], dtype=DTYPE)
+        for t in (q, k, v):
+            t.stop_gradient = False
+
+        idx = _startend_row_indices(b, s, causal=True)
+        with self.assertRaises(NotImplementedError):
+            attn(
+                query=q,
+                key=k,
+                value=v,
+                attention_mask=None,
+                attn_mask_startend_row_indices=idx,
+                attn_mask_type=AttnMaskType.causal,
+                use_rr_flash_attention=True,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_configs.yaml
+++ b/tests/test_configs.yaml
@@ -136,6 +136,10 @@ tests:
   - test_case: [tests/multi_card_tests/transformer/test_mtp_input_mask_tp.py]
     products:
       - num_gpus: 2
+  # transformer: FlashMask FA4 sink context-parallel (CP=2)
+  - test_case: [tests/multi_card_tests/transformer/test_flash_mask_sink_cp.py]
+    products:
+      - num_gpus: 2
   # default fallback for remaining multi_card_tests
   - test_case: [tests/multi_card_tests/pipeline_parallel/*.py]
     products:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
flashmask v4 支持 sink

当前策略：
  learnable_sink is not None 的时候，默认 flashmask 接口都是支持 learnable_sink 的，遇到不支持的情况直接 assert：
  + learnable_sink is not None，但是调用 fa2、fa3，直接 assert。
  + learnable_sink is not None，走 rr，直接 assert。
  + 不管 varlen，现在没在用，这个 pr 合入后我会尽快删掉 varlen 分支。


### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
是