### PR TITLE
Cherry-pick obsolete multi-card path insert cleanup

### DIFF
--- a/tests/multi_card_tests/ai_edited_test/models/test_ai_gpt_builders.py
+++ b/tests/multi_card_tests/ai_edited_test/models/test_ai_gpt_builders.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 import functools
-import os
-import sys
 import unittest
 
 import numpy as np
@@ -22,15 +20,6 @@ import paddle
 import paddle.distributed as dist
 from paddle.distributed import fleet
 from paddle.distributed.fleet import distributed_model
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import paddlefleet
 from paddlefleet.gpt_builders import gpt_builder

--- a/tests/multi_card_tests/ai_edited_test/models/test_ai_gpt_builders_2.py
+++ b/tests/multi_card_tests/ai_edited_test/models/test_ai_gpt_builders_2.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 import functools
-import os
-import sys
 import unittest
 
 import numpy as np
@@ -22,15 +20,6 @@ import paddle
 import paddle.distributed as dist
 from paddle.distributed import fleet
 from paddle.distributed.fleet import distributed_model
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import paddlefleet
 from paddlefleet.gpt_builders import gpt_builder

--- a/tests/multi_card_tests/ai_edited_test/models/test_ai_gpt_model.py
+++ b/tests/multi_card_tests/ai_edited_test/models/test_ai_gpt_model.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 import functools
-import os
-import sys
 import unittest
 
 import numpy as np
@@ -22,15 +20,6 @@ import paddle
 import paddle.distributed as dist
 from paddle.distributed import fleet
 from paddle.distributed.fleet import distributed_model
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import paddlefleet
 from paddlefleet.gpt_builders import gpt_builder

--- a/tests/multi_card_tests/ai_edited_test/models/test_ai_language_loss.py
+++ b/tests/multi_card_tests/ai_edited_test/models/test_ai_language_loss.py
@@ -13,23 +13,12 @@
 # limitations under the License.
 
 import functools
-import os
-import sys
 import unittest
 
 import numpy as np
 import paddle
 import paddle.distributed as dist
 from paddle.distributed import fleet
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 from paddlefleet.models.common.language_loss.language_loss import LanguageLoss
 from paddlefleet.process_groups_config import ProcessGroupCollection

--- a/tests/multi_card_tests/ai_edited_test/moe/test_ai_gpt_layer_specs.py
+++ b/tests/multi_card_tests/ai_edited_test/moe/test_ai_gpt_layer_specs.py
@@ -12,23 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import sys
 import unittest
 
 import numpy as np
 import paddle
 import paddle.distributed as dist
 from paddle.distributed import fleet
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import paddlefleet
 from paddlefleet.models.gpt.gpt_layer_specs import get_gpt_layer_local_spec

--- a/tests/multi_card_tests/ai_edited_test/moe/test_ai_gpt_layer_specs_2.py
+++ b/tests/multi_card_tests/ai_edited_test/moe/test_ai_gpt_layer_specs_2.py
@@ -15,22 +15,12 @@
 import functools
 import gc
 import os
-import sys
 import unittest
 
 import numpy as np
 import paddle
 import paddle.distributed as dist
 from paddle.distributed import fleet
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 from paddlefleet.models.gpt.gpt_layer_specs import get_gpt_layer_local_spec
 from paddlefleet.process_groups_config import ProcessGroupCollection

--- a/tests/multi_card_tests/ai_edited_test/moe/test_ai_moe_router.py
+++ b/tests/multi_card_tests/ai_edited_test/moe/test_ai_moe_router.py
@@ -13,22 +13,11 @@
 # limitations under the License.
 
 import functools
-import os
-import sys
 import unittest
 
 import numpy as np
 import paddle
 from paddle.distributed import fleet
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 from paddlefleet.process_groups_config import ProcessGroupCollection
 from paddlefleet.tensor_parallel.random import model_parallel_cuda_manual_seed

--- a/tests/multi_card_tests/ai_edited_test/moe/test_ai_moe_utils.py
+++ b/tests/multi_card_tests/ai_edited_test/moe/test_ai_moe_utils.py
@@ -12,23 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import sys
 import unittest
 
 import numpy as np
 import paddle
 import paddle.distributed as dist
 from paddle.distributed import fleet
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 from paddlefleet.process_groups_config import ProcessGroupCollection
 from paddlefleet.tensor_parallel.random import model_parallel_cuda_manual_seed

--- a/tests/multi_card_tests/ai_edited_test/moe/test_ai_token_dispatcher.py
+++ b/tests/multi_card_tests/ai_edited_test/moe/test_ai_token_dispatcher.py
@@ -13,23 +13,12 @@
 # limitations under the License.
 
 import functools
-import os
-import sys
 import unittest
 
 import numpy as np
 import paddle
 import paddle.distributed as dist
 from paddle.distributed import fleet
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 from paddlefleet.process_groups_config import ProcessGroupCollection
 from paddlefleet.tensor_parallel.random import model_parallel_cuda_manual_seed

--- a/tests/multi_card_tests/ai_edited_test/pipeline_parallel/test_ai_forward_backward_overlap_utils.py
+++ b/tests/multi_card_tests/ai_edited_test/pipeline_parallel/test_ai_forward_backward_overlap_utils.py
@@ -12,23 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import sys
 import unittest
 
 import numpy as np
 import paddle
 import paddle.distributed as dist
 from paddle.distributed import fleet
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 from paddlefleet.pipeline_parallel.pp_utils.forward_backward_overlap_utils import (
     ScheduleChunk,

--- a/tests/multi_card_tests/ai_edited_test/pipeline_parallel/test_ai_forward_backward_overlap_utils_2.py
+++ b/tests/multi_card_tests/ai_edited_test/pipeline_parallel/test_ai_forward_backward_overlap_utils_2.py
@@ -12,22 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import sys
 import unittest
 
 import numpy as np
 import paddle
 from paddle.distributed import fleet
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 from paddlefleet.pipeline_parallel.pp_utils.forward_backward_overlap_utils import (
     FakeClone,

--- a/tests/multi_card_tests/ai_edited_test/pipeline_parallel/test_ai_four_directions_p2p_communication.py
+++ b/tests/multi_card_tests/ai_edited_test/pipeline_parallel/test_ai_four_directions_p2p_communication.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import os
-import sys
 import unittest
 
 os.environ["PADDLE_USE_FOUR_DIRECTIONS_P2P"] = "True"
@@ -21,15 +20,6 @@ os.environ["PADDLE_USE_FOUR_DIRECTIONS_P2P"] = "True"
 import numpy as np
 import paddle
 from paddle.distributed import fleet
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 from paddlefleet.pipeline_parallel.pp_utils.four_directions_p2p_communication import (
     P2pHelper,

--- a/tests/multi_card_tests/ai_edited_test/pipeline_parallel/test_ai_four_directions_p2p_communication_2.py
+++ b/tests/multi_card_tests/ai_edited_test/pipeline_parallel/test_ai_four_directions_p2p_communication_2.py
@@ -11,18 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
 import unittest
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import paddle
 

--- a/tests/multi_card_tests/ai_edited_test/pipeline_parallel/test_ai_four_directions_p2p_communication_3.py
+++ b/tests/multi_card_tests/ai_edited_test/pipeline_parallel/test_ai_four_directions_p2p_communication_3.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import os
-import sys
 import unittest
 
 os.environ["PADDLE_USE_FOUR_DIRECTIONS_P2P"] = "True"
@@ -22,15 +21,6 @@ import numpy as np
 import paddle
 import paddle.distributed as dist
 from paddle.distributed import fleet
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 from paddlefleet.pipeline_parallel.pp_utils.four_directions_p2p_communication import (
     _is_valid_send_recv_partial,

--- a/tests/multi_card_tests/ai_edited_test/pipeline_parallel/test_ai_four_directions_p2p_communication_4.py
+++ b/tests/multi_card_tests/ai_edited_test/pipeline_parallel/test_ai_four_directions_p2p_communication_4.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import os
-import sys
 import unittest
 
 # Enable sync_send mode before importing the module
@@ -24,15 +23,6 @@ import numpy as np
 import paddle
 import paddle.distributed as dist
 from paddle.distributed import fleet
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 from paddlefleet.pipeline_parallel.pp_utils.four_directions_p2p_communication import (
     SendRecvMeta,

--- a/tests/multi_card_tests/ai_edited_test/pipeline_parallel/test_ai_p2p_communication.py
+++ b/tests/multi_card_tests/ai_edited_test/pipeline_parallel/test_ai_p2p_communication.py
@@ -12,23 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import sys
 import unittest
 
 import numpy as np
 import paddle
 import paddle.distributed as dist
 from paddle.distributed import fleet
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 from paddlefleet.pipeline_parallel.pp_utils.p2p_communication import (
     P2PonCalcStream,

--- a/tests/multi_card_tests/ai_edited_test/pipeline_parallel/test_ai_p2p_communication_2.py
+++ b/tests/multi_card_tests/ai_edited_test/pipeline_parallel/test_ai_p2p_communication_2.py
@@ -11,18 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
 import unittest
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import paddle
 

--- a/tests/multi_card_tests/ai_edited_test/pipeline_parallel/test_ai_p2p_communication_3.py
+++ b/tests/multi_card_tests/ai_edited_test/pipeline_parallel/test_ai_p2p_communication_3.py
@@ -11,18 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
 import unittest
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import paddle
 

--- a/tests/multi_card_tests/ai_edited_test/pipeline_parallel/test_ai_vpp_simulator.py
+++ b/tests/multi_card_tests/ai_edited_test/pipeline_parallel/test_ai_vpp_simulator.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import sys
 import unittest
 from unittest.mock import MagicMock
@@ -24,15 +23,6 @@ from paddle.distributed import fleet
 # vpp_simulator.py imports matplotlib which may not be installed in CI
 sys.modules["matplotlib"] = MagicMock()
 sys.modules["matplotlib.pyplot"] = MagicMock()
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 from paddlefleet.pipeline_parallel.vpp_simulator import (
     PPChunkRecorder,

--- a/tests/multi_card_tests/ai_edited_test/tensor_parallel/test_ai_layers.py
+++ b/tests/multi_card_tests/ai_edited_test/tensor_parallel/test_ai_layers.py
@@ -12,23 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import sys
 import unittest
 
 import numpy as np
 import paddle
 import paddle.distributed as dist
 from paddle.distributed import fleet
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 from paddlefleet.tensor_parallel.layers import (
     ColumnParallelLinear,

--- a/tests/multi_card_tests/ai_edited_test/tensor_parallel/test_ai_mappings.py
+++ b/tests/multi_card_tests/ai_edited_test/tensor_parallel/test_ai_mappings.py
@@ -12,23 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import sys
 import unittest
 
 import numpy as np
 import paddle
 import paddle.distributed as dist
 from paddle.distributed import fleet
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 from paddlefleet.tensor_parallel.layers import (
     ColumnParallelLinear,

--- a/tests/multi_card_tests/ai_edited_test/tensor_parallel/test_ai_mappings_2.py
+++ b/tests/multi_card_tests/ai_edited_test/tensor_parallel/test_ai_mappings_2.py
@@ -12,23 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import sys
 import unittest
 
 import numpy as np
 import paddle
 import paddle.distributed as dist
 from paddle.distributed import fleet
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 from paddlefleet.tensor_parallel.mappings import (
     _AllGatherFromTensorParallelRegion,

--- a/tests/multi_card_tests/ai_edited_test/tensor_parallel/test_ai_parallel_state.py
+++ b/tests/multi_card_tests/ai_edited_test/tensor_parallel/test_ai_parallel_state.py
@@ -12,23 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import sys
 import unittest
 
 import numpy as np
 import paddle
 import paddle.distributed as dist
 from paddle.distributed import fleet
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import paddlefleet
 from paddlefleet.process_groups_config import ProcessGroupCollection

--- a/tests/multi_card_tests/ai_edited_test/transformer/test_ai_transformer_encoder.py
+++ b/tests/multi_card_tests/ai_edited_test/transformer/test_ai_transformer_encoder.py
@@ -13,23 +13,12 @@
 # limitations under the License.
 
 import functools
-import os
-import sys
 import unittest
 
 import numpy as np
 import paddle
 import paddle.distributed as dist
 from paddle.distributed import fleet
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 from paddlefleet.models.gpt.gpt_layer_specs import get_gpt_layer_local_spec
 from paddlefleet.process_groups_config import ProcessGroupCollection

--- a/tests/multi_card_tests/ai_edited_test/transformer/test_ai_transformer_layer.py
+++ b/tests/multi_card_tests/ai_edited_test/transformer/test_ai_transformer_layer.py
@@ -13,23 +13,12 @@
 # limitations under the License.
 
 import functools
-import os
-import sys
 import unittest
 
 import numpy as np
 import paddle
 import paddle.distributed as dist
 from paddle.distributed import fleet
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 from paddlefleet.models.gpt.gpt_layer_specs import get_gpt_layer_local_spec
 from paddlefleet.process_groups_config import ProcessGroupCollection


### PR DESCRIPTION
## Summary
- Cherry-pick 97e80640827791174556735340e2d59774e8c5ab to remove obsolete multi-card test path inserts.
- The diff is non-empty and updates existing multi-card AI edited tests only.

## Test plan
- python -m pre_commit run --all-files