### PR TITLE
[Test] Remove obsolete ai edited test path inserts

### DIFF
--- a/tests/multi_card_tests/ai_edited_test/models/test_ai_gpt_builders.py
+++ b/tests/multi_card_tests/ai_edited_test/models/test_ai_gpt_builders.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 import functools
-import os
-import sys
 import unittest
 
 import numpy as np
@@ -22,15 +20,6 @@ import paddle
 import paddle.distributed as dist
 from paddle.distributed import fleet
 from paddle.distributed.fleet import distributed_model
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import paddlefleet
 from paddlefleet.gpt_builders import gpt_builder

--- a/tests/multi_card_tests/ai_edited_test/models/test_ai_gpt_builders_2.py
+++ b/tests/multi_card_tests/ai_edited_test/models/test_ai_gpt_builders_2.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 import functools
-import os
-import sys
 import unittest
 
 import numpy as np
@@ -22,15 +20,6 @@ import paddle
 import paddle.distributed as dist
 from paddle.distributed import fleet
 from paddle.distributed.fleet import distributed_model
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import paddlefleet
 from paddlefleet.gpt_builders import gpt_builder

--- a/tests/multi_card_tests/ai_edited_test/models/test_ai_gpt_model.py
+++ b/tests/multi_card_tests/ai_edited_test/models/test_ai_gpt_model.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 import functools
-import os
-import sys
 import unittest
 
 import numpy as np
@@ -22,15 +20,6 @@ import paddle
 import paddle.distributed as dist
 from paddle.distributed import fleet
 from paddle.distributed.fleet import distributed_model
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import paddlefleet
 from paddlefleet.gpt_builders import gpt_builder

--- a/tests/multi_card_tests/ai_edited_test/models/test_ai_language_loss.py
+++ b/tests/multi_card_tests/ai_edited_test/models/test_ai_language_loss.py
@@ -13,23 +13,12 @@
 # limitations under the License.
 
 import functools
-import os
-import sys
 import unittest
 
 import numpy as np
 import paddle
 import paddle.distributed as dist
 from paddle.distributed import fleet
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 from paddlefleet.models.common.language_loss.language_loss import LanguageLoss
 from paddlefleet.process_groups_config import ProcessGroupCollection

--- a/tests/multi_card_tests/ai_edited_test/moe/test_ai_gpt_layer_specs.py
+++ b/tests/multi_card_tests/ai_edited_test/moe/test_ai_gpt_layer_specs.py
@@ -12,23 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import sys
 import unittest
 
 import numpy as np
 import paddle
 import paddle.distributed as dist
 from paddle.distributed import fleet
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import paddlefleet
 from paddlefleet.models.gpt.gpt_layer_specs import get_gpt_layer_local_spec

--- a/tests/multi_card_tests/ai_edited_test/moe/test_ai_gpt_layer_specs_2.py
+++ b/tests/multi_card_tests/ai_edited_test/moe/test_ai_gpt_layer_specs_2.py
@@ -15,22 +15,12 @@
 import functools
 import gc
 import os
-import sys
 import unittest
 
 import numpy as np
 import paddle
 import paddle.distributed as dist
 from paddle.distributed import fleet
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 from paddlefleet.models.gpt.gpt_layer_specs import get_gpt_layer_local_spec
 from paddlefleet.process_groups_config import ProcessGroupCollection

--- a/tests/multi_card_tests/ai_edited_test/moe/test_ai_moe_router.py
+++ b/tests/multi_card_tests/ai_edited_test/moe/test_ai_moe_router.py
@@ -13,22 +13,11 @@
 # limitations under the License.
 
 import functools
-import os
-import sys
 import unittest
 
 import numpy as np
 import paddle
 from paddle.distributed import fleet
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 from paddlefleet.process_groups_config import ProcessGroupCollection
 from paddlefleet.tensor_parallel.random import model_parallel_cuda_manual_seed

--- a/tests/multi_card_tests/ai_edited_test/moe/test_ai_moe_utils.py
+++ b/tests/multi_card_tests/ai_edited_test/moe/test_ai_moe_utils.py
@@ -12,23 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import sys
 import unittest
 
 import numpy as np
 import paddle
 import paddle.distributed as dist
 from paddle.distributed import fleet
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 from paddlefleet.process_groups_config import ProcessGroupCollection
 from paddlefleet.tensor_parallel.random import model_parallel_cuda_manual_seed

--- a/tests/multi_card_tests/ai_edited_test/moe/test_ai_token_dispatcher.py
+++ b/tests/multi_card_tests/ai_edited_test/moe/test_ai_token_dispatcher.py
@@ -13,23 +13,12 @@
 # limitations under the License.
 
 import functools
-import os
-import sys
 import unittest
 
 import numpy as np
 import paddle
 import paddle.distributed as dist
 from paddle.distributed import fleet
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 from paddlefleet.process_groups_config import ProcessGroupCollection
 from paddlefleet.tensor_parallel.random import model_parallel_cuda_manual_seed

--- a/tests/multi_card_tests/ai_edited_test/pipeline_parallel/test_ai_forward_backward_overlap_utils.py
+++ b/tests/multi_card_tests/ai_edited_test/pipeline_parallel/test_ai_forward_backward_overlap_utils.py
@@ -12,23 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import sys
 import unittest
 
 import numpy as np
 import paddle
 import paddle.distributed as dist
 from paddle.distributed import fleet
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 from paddlefleet.pipeline_parallel.pp_utils.forward_backward_overlap_utils import (
     ScheduleChunk,

--- a/tests/multi_card_tests/ai_edited_test/pipeline_parallel/test_ai_forward_backward_overlap_utils_2.py
+++ b/tests/multi_card_tests/ai_edited_test/pipeline_parallel/test_ai_forward_backward_overlap_utils_2.py
@@ -12,22 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import sys
 import unittest
 
 import numpy as np
 import paddle
 from paddle.distributed import fleet
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 from paddlefleet.pipeline_parallel.pp_utils.forward_backward_overlap_utils import (
     FakeClone,

--- a/tests/multi_card_tests/ai_edited_test/pipeline_parallel/test_ai_four_directions_p2p_communication.py
+++ b/tests/multi_card_tests/ai_edited_test/pipeline_parallel/test_ai_four_directions_p2p_communication.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import os
-import sys
 import unittest
 
 os.environ["PADDLE_USE_FOUR_DIRECTIONS_P2P"] = "True"
@@ -21,15 +20,6 @@ os.environ["PADDLE_USE_FOUR_DIRECTIONS_P2P"] = "True"
 import numpy as np
 import paddle
 from paddle.distributed import fleet
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 from paddlefleet.pipeline_parallel.pp_utils.four_directions_p2p_communication import (
     P2pHelper,

--- a/tests/multi_card_tests/ai_edited_test/pipeline_parallel/test_ai_four_directions_p2p_communication_2.py
+++ b/tests/multi_card_tests/ai_edited_test/pipeline_parallel/test_ai_four_directions_p2p_communication_2.py
@@ -11,18 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
 import unittest
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import paddle
 

--- a/tests/multi_card_tests/ai_edited_test/pipeline_parallel/test_ai_four_directions_p2p_communication_3.py
+++ b/tests/multi_card_tests/ai_edited_test/pipeline_parallel/test_ai_four_directions_p2p_communication_3.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import os
-import sys
 import unittest
 
 os.environ["PADDLE_USE_FOUR_DIRECTIONS_P2P"] = "True"
@@ -22,15 +21,6 @@ import numpy as np
 import paddle
 import paddle.distributed as dist
 from paddle.distributed import fleet
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 from paddlefleet.pipeline_parallel.pp_utils.four_directions_p2p_communication import (
     _is_valid_send_recv_partial,

--- a/tests/multi_card_tests/ai_edited_test/pipeline_parallel/test_ai_four_directions_p2p_communication_4.py
+++ b/tests/multi_card_tests/ai_edited_test/pipeline_parallel/test_ai_four_directions_p2p_communication_4.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import os
-import sys
 import unittest
 
 # Enable sync_send mode before importing the module
@@ -24,15 +23,6 @@ import numpy as np
 import paddle
 import paddle.distributed as dist
 from paddle.distributed import fleet
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 from paddlefleet.pipeline_parallel.pp_utils.four_directions_p2p_communication import (
     SendRecvMeta,

--- a/tests/multi_card_tests/ai_edited_test/pipeline_parallel/test_ai_p2p_communication.py
+++ b/tests/multi_card_tests/ai_edited_test/pipeline_parallel/test_ai_p2p_communication.py
@@ -12,23 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import sys
 import unittest
 
 import numpy as np
 import paddle
 import paddle.distributed as dist
 from paddle.distributed import fleet
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 from paddlefleet.pipeline_parallel.pp_utils.p2p_communication import (
     P2PonCalcStream,

--- a/tests/multi_card_tests/ai_edited_test/pipeline_parallel/test_ai_p2p_communication_2.py
+++ b/tests/multi_card_tests/ai_edited_test/pipeline_parallel/test_ai_p2p_communication_2.py
@@ -11,18 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
 import unittest
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import paddle
 

--- a/tests/multi_card_tests/ai_edited_test/pipeline_parallel/test_ai_p2p_communication_3.py
+++ b/tests/multi_card_tests/ai_edited_test/pipeline_parallel/test_ai_p2p_communication_3.py
@@ -11,18 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
 import unittest
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import paddle
 

--- a/tests/multi_card_tests/ai_edited_test/pipeline_parallel/test_ai_vpp_simulator.py
+++ b/tests/multi_card_tests/ai_edited_test/pipeline_parallel/test_ai_vpp_simulator.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import sys
 import unittest
 from unittest.mock import MagicMock
@@ -24,15 +23,6 @@ from paddle.distributed import fleet
 # vpp_simulator.py imports matplotlib which may not be installed in CI
 sys.modules["matplotlib"] = MagicMock()
 sys.modules["matplotlib.pyplot"] = MagicMock()
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 from paddlefleet.pipeline_parallel.vpp_simulator import (
     PPChunkRecorder,

--- a/tests/multi_card_tests/ai_edited_test/tensor_parallel/test_ai_layers.py
+++ b/tests/multi_card_tests/ai_edited_test/tensor_parallel/test_ai_layers.py
@@ -12,23 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import sys
 import unittest
 
 import numpy as np
 import paddle
 import paddle.distributed as dist
 from paddle.distributed import fleet
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 from paddlefleet.tensor_parallel.layers import (
     ColumnParallelLinear,

--- a/tests/multi_card_tests/ai_edited_test/tensor_parallel/test_ai_mappings.py
+++ b/tests/multi_card_tests/ai_edited_test/tensor_parallel/test_ai_mappings.py
@@ -12,23 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import sys
 import unittest
 
 import numpy as np
 import paddle
 import paddle.distributed as dist
 from paddle.distributed import fleet
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 from paddlefleet.tensor_parallel.layers import (
     ColumnParallelLinear,

--- a/tests/multi_card_tests/ai_edited_test/tensor_parallel/test_ai_mappings_2.py
+++ b/tests/multi_card_tests/ai_edited_test/tensor_parallel/test_ai_mappings_2.py
@@ -12,23 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import sys
 import unittest
 
 import numpy as np
 import paddle
 import paddle.distributed as dist
 from paddle.distributed import fleet
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 from paddlefleet.tensor_parallel.mappings import (
     _AllGatherFromTensorParallelRegion,

--- a/tests/multi_card_tests/ai_edited_test/tensor_parallel/test_ai_parallel_state.py
+++ b/tests/multi_card_tests/ai_edited_test/tensor_parallel/test_ai_parallel_state.py
@@ -12,23 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import sys
 import unittest
 
 import numpy as np
 import paddle
 import paddle.distributed as dist
 from paddle.distributed import fleet
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import paddlefleet
 from paddlefleet.process_groups_config import ProcessGroupCollection

--- a/tests/multi_card_tests/ai_edited_test/transformer/test_ai_transformer_encoder.py
+++ b/tests/multi_card_tests/ai_edited_test/transformer/test_ai_transformer_encoder.py
@@ -13,23 +13,12 @@
 # limitations under the License.
 
 import functools
-import os
-import sys
 import unittest
 
 import numpy as np
 import paddle
 import paddle.distributed as dist
 from paddle.distributed import fleet
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 from paddlefleet.models.gpt.gpt_layer_specs import get_gpt_layer_local_spec
 from paddlefleet.process_groups_config import ProcessGroupCollection

--- a/tests/multi_card_tests/ai_edited_test/transformer/test_ai_transformer_layer.py
+++ b/tests/multi_card_tests/ai_edited_test/transformer/test_ai_transformer_layer.py
@@ -13,23 +13,12 @@
 # limitations under the License.
 
 import functools
-import os
-import sys
 import unittest
 
 import numpy as np
 import paddle
 import paddle.distributed as dist
 from paddle.distributed import fleet
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 from paddlefleet.models.gpt.gpt_layer_specs import get_gpt_layer_local_spec
 from paddlefleet.process_groups_config import ProcessGroupCollection

--- a/tests/single_card_tests/ai_edited_test/common/test_ai_paddlefleet.py
+++ b/tests/single_card_tests/ai_edited_test/common/test_ai_paddlefleet.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 
 

--- a/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_arguments.py
+++ b/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_arguments.py
@@ -11,19 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_config_logger.py
+++ b/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_config_logger.py
@@ -11,20 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import json
+import os
 import tempfile
 import unittest
 from collections import OrderedDict

--- a/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_config_logger_2.py
+++ b/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_config_logger_2.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import json
 import unittest

--- a/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_context_parallel_utils.py
+++ b/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_context_parallel_utils.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_global_vars.py
+++ b/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_global_vars.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 
 

--- a/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_global_vars_2.py
+++ b/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_global_vars_2.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 # Tests for src/paddlefleet/training/global_vars.py
 # Additional tests for get_args, set_args, destroy_global_vars,
 # get_timers, _set_timers, set_global_variables, unset_global_variables,

--- a/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_gpt_builders.py
+++ b/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_gpt_builders.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from functools import partial
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_initialize.py
+++ b/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_initialize.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 # Tests for src/paddlefleet/training/initialize.py
 # Test initialize_fleet, set_logging
 

--- a/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_jit.py
+++ b/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_jit.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 
 

--- a/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_package_info.py
+++ b/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_package_info.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 
 

--- a/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_parallel_state.py
+++ b/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_parallel_state.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 # Tests for src/paddlefleet/parallel_state.py
 # Additional tests for expert parallel state functions, pipeline helpers,
 # context parallel, memory buffer, and embedding group

--- a/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_spec_utils.py
+++ b/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_spec_utils.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 
 import paddle

--- a/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_timers.py
+++ b/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_timers.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import time
 import unittest
 from io import StringIO

--- a/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_timers_2.py
+++ b/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_timers_2.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 # Tests for src/paddlefleet/timers.py
 # Additional tests for Timers class, _Timer, RuntimeTimer
 

--- a/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_transformer_config_hash.py
+++ b/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_transformer_config_hash.py
@@ -11,18 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
 import unittest
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 
 class TestTransformerConfigHashRoutingValidation(unittest.TestCase):

--- a/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_utils.py
+++ b/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_utils.py
@@ -11,22 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import functools
 import logging
 import operator
+import os
 import unittest
 import warnings
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_utils_2.py
+++ b/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_utils_2.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import logging
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_utils_3.py
+++ b/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_utils_3.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import functools
 import unittest

--- a/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_utils_4.py
+++ b/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_utils_4.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import logging
 import unittest

--- a/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_utils_5.py
+++ b/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_utils_5.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_yaml_arguments.py
+++ b/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_yaml_arguments.py
@@ -12,22 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-import sys
 import tempfile
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
 
 # Tests for src/paddlefleet/training/yaml_arguments.py
 # Test _flatten_configs, load_yaml
-
 import unittest
 
 try:

--- a/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_yaml_arguments_2.py
+++ b/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_yaml_arguments_2.py
@@ -12,21 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
 
 # Extra tests for paddlefleet/training/yaml_arguments.py
 # Focus on edge cases and additional scenarios
-
 import tempfile
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_yaml_arguments_3.py
+++ b/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_yaml_arguments_3.py
@@ -12,21 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
 
 # Extra tests for paddlefleet/training/yaml_arguments.py
 # Focus on: error handling and more complex YAML structures
-
 import tempfile
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_yaml_arguments_4.py
+++ b/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_yaml_arguments_4.py
@@ -12,17 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
 import tempfile
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_yaml_arguments_5.py
+++ b/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_yaml_arguments_5.py
@@ -12,17 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
 import tempfile
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/distributed/test_ai_context_parallel_utils.py
+++ b/tests/single_card_tests/ai_edited_test/distributed/test_ai_context_parallel_utils.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 # Tests for src/paddlefleet/context_parallel_utils.py
 
 import unittest

--- a/tests/single_card_tests/ai_edited_test/distributed/test_ai_context_parallel_utils_2.py
+++ b/tests/single_card_tests/ai_edited_test/distributed/test_ai_context_parallel_utils_2.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 # Tests for src/paddlefleet/context_parallel_utils.py
 # Additional tests for scatter_balance, all_gather_balance, reduce_scatter
 

--- a/tests/single_card_tests/ai_edited_test/distributed/test_ai_context_parallel_utils_3.py
+++ b/tests/single_card_tests/ai_edited_test/distributed/test_ai_context_parallel_utils_3.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 # Tests for src/paddlefleet/context_parallel_utils.py
 # Test FlashMaskContextParallel, flashmask_attention_cp, preprocess_index
 

--- a/tests/single_card_tests/ai_edited_test/distributed/test_ai_context_parallel_utils_4.py
+++ b/tests/single_card_tests/ai_edited_test/distributed/test_ai_context_parallel_utils_4.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 # Tests for src/paddlefleet/context_parallel_utils.py
 # Test scatter_with_padding, all_gather_without_padding,
 # ContextParallelNormalScatter, ContextParallelNormalGather

--- a/tests/single_card_tests/ai_edited_test/distributed/test_ai_context_parallel_utils_5.py
+++ b/tests/single_card_tests/ai_edited_test/distributed/test_ai_context_parallel_utils_5.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 # Tests for src/paddlefleet/context_parallel_utils.py
 # Test ContextParallelScatterOp, ContextParallelGatherOp,
 # ContextParallelAllGatherOp PyLayers

--- a/tests/single_card_tests/ai_edited_test/distributed/test_ai_distributed.py
+++ b/tests/single_card_tests/ai_edited_test/distributed/test_ai_distributed.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 
 

--- a/tests/single_card_tests/ai_edited_test/distributed/test_ai_distributed_2.py
+++ b/tests/single_card_tests/ai_edited_test/distributed/test_ai_distributed_2.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 # Tests for src/paddlefleet/distributed/__init__.py
 
 import unittest

--- a/tests/single_card_tests/ai_edited_test/distributed/test_ai_linear.py
+++ b/tests/single_card_tests/ai_edited_test/distributed/test_ai_linear.py
@@ -11,19 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
 import types
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
 
 # DeepGEMM assertion errors on CI GPUs - skip all FP8 tests
 import unittest

--- a/tests/single_card_tests/ai_edited_test/distributed/test_ai_model.py
+++ b/tests/single_card_tests/ai_edited_test/distributed/test_ai_model.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 # Tests for src/paddlefleet/distributed/model.py
 
 import unittest

--- a/tests/single_card_tests/ai_edited_test/distributed/test_ai_model_parallel_config.py
+++ b/tests/single_card_tests/ai_edited_test/distributed/test_ai_model_parallel_config.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 # Tests for src/paddlefleet/model_parallel_config.py
 
 import unittest

--- a/tests/single_card_tests/ai_edited_test/distributed/test_ai_packed_seq_params.py
+++ b/tests/single_card_tests/ai_edited_test/distributed/test_ai_packed_seq_params.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 # Tests for src/paddlefleet/packed_seq_params.py
 
 import unittest

--- a/tests/single_card_tests/ai_edited_test/distributed/test_ai_parallel_state.py
+++ b/tests/single_card_tests/ai_edited_test/distributed/test_ai_parallel_state.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 # Tests for src/paddlefleet/parallel_state.py
 
 import unittest

--- a/tests/single_card_tests/ai_edited_test/distributed/test_ai_parallel_state_2.py
+++ b/tests/single_card_tests/ai_edited_test/distributed/test_ai_parallel_state_2.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 import warnings

--- a/tests/single_card_tests/ai_edited_test/distributed/test_ai_parallel_state_3.py
+++ b/tests/single_card_tests/ai_edited_test/distributed/test_ai_parallel_state_3.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 import warnings

--- a/tests/single_card_tests/ai_edited_test/distributed/test_ai_process_groups_config.py
+++ b/tests/single_card_tests/ai_edited_test/distributed/test_ai_process_groups_config.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 # Tests for src/paddlefleet/process_groups_config.py
 
 import unittest

--- a/tests/single_card_tests/ai_edited_test/distributed/test_ai_recompute_utils.py
+++ b/tests/single_card_tests/ai_edited_test/distributed/test_ai_recompute_utils.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 # Tests for src/paddlefleet/recompute_utils.py
 
 import unittest

--- a/tests/single_card_tests/ai_edited_test/distributed/test_ai_utils.py
+++ b/tests/single_card_tests/ai_edited_test/distributed/test_ai_utils.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 # Tests for src/paddlefleet/utils.py
 # Additional tests for make_viewless_tensor, get_pg_rank, divide,
 # WrappedTensor, GlobalMemoryBuffer, init_method_normal,

--- a/tests/single_card_tests/ai_edited_test/distributed/test_cp_balance_mode_dispatch.py
+++ b/tests/single_card_tests/ai_edited_test/distributed/test_cp_balance_mode_dispatch.py
@@ -26,19 +26,6 @@ Covers:
 Single-card tests using mocked distributed groups.
 """
 
-import os
-import sys
-
-# Insert local src/ before site-packages so we test the dev version
-_project_root = os.path.dirname(
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    )
-)
-sys.path.insert(0, os.path.join(_project_root, "src"))
-
 import unittest
 from unittest import mock
 

--- a/tests/single_card_tests/ai_edited_test/embeddings/test_ai_language_model_embedding.py
+++ b/tests/single_card_tests/ai_edited_test/embeddings/test_ai_language_model_embedding.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/tests/single_card_tests/ai_edited_test/embeddings/test_ai_language_model_embedding_2.py
+++ b/tests/single_card_tests/ai_edited_test/embeddings/test_ai_language_model_embedding_2.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/tests/single_card_tests/ai_edited_test/embeddings/test_ai_rope_utils.py
+++ b/tests/single_card_tests/ai_edited_test/embeddings/test_ai_rope_utils.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/tests/single_card_tests/ai_edited_test/embeddings/test_ai_rotary_pos_embedding.py
+++ b/tests/single_card_tests/ai_edited_test/embeddings/test_ai_rotary_pos_embedding.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/tests/single_card_tests/ai_edited_test/embeddings/test_ai_rotary_pos_embedding_2.py
+++ b/tests/single_card_tests/ai_edited_test/embeddings/test_ai_rotary_pos_embedding_2.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from unittest.mock import MagicMock
 

--- a/tests/single_card_tests/ai_edited_test/embeddings/test_ai_yarn_rotary_pos_embedding.py
+++ b/tests/single_card_tests/ai_edited_test/embeddings/test_ai_yarn_rotary_pos_embedding.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import math
 import unittest
 from unittest.mock import MagicMock

--- a/tests/single_card_tests/ai_edited_test/embeddings/test_ai_yarn_rotary_pos_embedding_2.py
+++ b/tests/single_card_tests/ai_edited_test/embeddings/test_ai_yarn_rotary_pos_embedding_2.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import math
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/extensions/test_ai_block_mask_utils.py
+++ b/tests/single_card_tests/ai_edited_test/extensions/test_ai_block_mask_utils.py
@@ -11,22 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
 
 # Tests for src/paddlefleet/_extensions/flashmask/block_mask_utils.py
 # Triton kernels are mocked since they require GPU.
-
 import types
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/extensions/test_ai_block_mask_utils_2.py
+++ b/tests/single_card_tests/ai_edited_test/extensions/test_ai_block_mask_utils_2.py
@@ -17,15 +17,6 @@ import os
 import sys
 import types
 
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
 # Setup comprehensive triton mock before any paddlefleet_ops imports
 _mock_tl = types.ModuleType("triton.language")
 _mock_tl_core = types.ModuleType("triton.language.core")

--- a/tests/single_card_tests/ai_edited_test/extensions/test_ai_block_mask_utils_3.py
+++ b/tests/single_card_tests/ai_edited_test/extensions/test_ai_block_mask_utils_3.py
@@ -11,22 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
 
 # Extra tests for paddlefleet_ops/_extensions/flashmask/block_mask_utils.py
 # Focus on: find_blocks_topp, _extract_raw_ptrs, _prepare_stride_maxmin_ptrs
-
 import types
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/extensions/test_ai_block_mask_utils_4.py
+++ b/tests/single_card_tests/ai_edited_test/extensions/test_ai_block_mask_utils_4.py
@@ -11,22 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
 
 # Tests for paddlefleet_ops/_extensions/flashmask/block_mask_utils.py
 # Focus on: find_blocks_topp, top_p_kernel, _compare_and_swap definitions
-
 import types
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/extensions/test_ai_block_mask_utils_5.py
+++ b/tests/single_card_tests/ai_edited_test/extensions/test_ai_block_mask_utils_5.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/extensions/test_ai_block_mask_utils_6.py
+++ b/tests/single_card_tests/ai_edited_test/extensions/test_ai_block_mask_utils_6.py
@@ -11,23 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
 
 # Tests for src/paddlefleet/_extensions/flashmask/block_mask_utils.py
 # Dedicated tests for bitonic_argsort_device, top_p_kernel, _compare_and_swap,
 # _bitonic_merge
-
 import types
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/extensions/test_ai_flashmask_ext_structure.py
+++ b/tests/single_card_tests/ai_edited_test/extensions/test_ai_flashmask_ext_structure.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/extensions/test_ai_index_utils.py
+++ b/tests/single_card_tests/ai_edited_test/extensions/test_ai_index_utils.py
@@ -11,22 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
 
 # Tests for src/paddlefleet/_extensions/flashmask/index_utils.py
 # Triton kernels are mocked since they require GPU.
-
 import types
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/extensions/test_ai_index_utils_2.py
+++ b/tests/single_card_tests/ai_edited_test/extensions/test_ai_index_utils_2.py
@@ -11,22 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
 
 # Tests for src/paddlefleet/_extensions/flashmask/index_utils.py
 # Additional tests for prepare_maxmin and scan_maxmin_chunked
-
 import types
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/extensions/test_ai_index_utils_3.py
+++ b/tests/single_card_tests/ai_edited_test/extensions/test_ai_index_utils_3.py
@@ -11,22 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
 
 # Extra tests for paddlefleet_ops/_extensions/flashmask/index_utils.py
 # Focus on: prepare_maxmin function and its validation
-
 import types
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/extensions/test_ai_index_utils_4.py
+++ b/tests/single_card_tests/ai_edited_test/extensions/test_ai_index_utils_4.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/extensions/test_ai_ops.py
+++ b/tests/single_card_tests/ai_edited_test/extensions/test_ai_ops.py
@@ -11,17 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
 import unittest
 
 try:

--- a/tests/single_card_tests/ai_edited_test/extensions/test_ai_ops_2.py
+++ b/tests/single_card_tests/ai_edited_test/extensions/test_ai_ops_2.py
@@ -10,17 +10,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/extensions/test_ai_rr_attn_estimate_triton_op.py
+++ b/tests/single_card_tests/ai_edited_test/extensions/test_ai_rr_attn_estimate_triton_op.py
@@ -11,22 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
 
 # Tests for src/paddlefleet/_extensions/flashmask/rr_attn_estimate_triton_op.py
 # Triton kernels are mocked since they require GPU.
-
 import types
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/extensions/test_ai_rr_attn_estimate_triton_op_2.py
+++ b/tests/single_card_tests/ai_edited_test/extensions/test_ai_rr_attn_estimate_triton_op_2.py
@@ -11,23 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
 
 # Tests for src/paddlefleet/_extensions/flashmask/rr_attn_estimate_triton_op.py
 # Dedicated tests for triton kernel wrappers: check_dense_contains_partial_stride,
 # gemm_fuse_softmax_causal, gemm_fuse_softmax_non_causal
-
 import types
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/extensions/test_ai_rr_attn_estimate_triton_op_3.py
+++ b/tests/single_card_tests/ai_edited_test/extensions/test_ai_rr_attn_estimate_triton_op_3.py
@@ -17,15 +17,6 @@ import os
 import sys
 import types
 
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
 # Setup comprehensive triton mock before any paddlefleet_ops imports
 _mock_tl = types.ModuleType("triton.language")
 _mock_tl_core = types.ModuleType("triton.language.core")

--- a/tests/single_card_tests/ai_edited_test/extensions/test_ai_rr_attn_estimate_triton_op_4.py
+++ b/tests/single_card_tests/ai_edited_test/extensions/test_ai_rr_attn_estimate_triton_op_4.py
@@ -11,23 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
 
 # Extra tests for paddlefleet_ops/_extensions/flashmask/rr_attn_estimate_triton_op.py
 # Focus on: _require, _extract_raw_ptrs, _prepare_stride_maxmin_ptrs,
 # rr_attn_estimate_triton_func validation, dataclass structures
-
 import types
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/fp8/test_ai_fp8_module_structure.py
+++ b/tests/single_card_tests/ai_edited_test/fp8/test_ai_fp8_module_structure.py
@@ -11,19 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
 import importlib.util
+import os
 import unittest
 
 

--- a/tests/single_card_tests/ai_edited_test/fp8/test_ai_fp8_utils.py
+++ b/tests/single_card_tests/ai_edited_test/fp8/test_ai_fp8_utils.py
@@ -11,19 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
 import importlib.util
+import os
 import unittest
 
 import paddle

--- a/tests/single_card_tests/ai_edited_test/fp8/test_ai_linear.py
+++ b/tests/single_card_tests/ai_edited_test/fp8/test_ai_linear.py
@@ -11,19 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import types
 import unittest
 from unittest.mock import MagicMock

--- a/tests/single_card_tests/ai_edited_test/fp8/test_ai_quantization.py
+++ b/tests/single_card_tests/ai_edited_test/fp8/test_ai_quantization.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 # Tests for paddlefleet/fp8/quantization.py
 # Tests for get_quant_func
 

--- a/tests/single_card_tests/ai_edited_test/fp8/test_ai_quantization_2.py
+++ b/tests/single_card_tests/ai_edited_test/fp8/test_ai_quantization_2.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 # Extra tests for paddlefleet/fp8/quantization.py
 # Focus on: get_quant_func with various parameters and error handling
 

--- a/tests/single_card_tests/ai_edited_test/fp8/test_ai_quantization_3.py
+++ b/tests/single_card_tests/ai_edited_test/fp8/test_ai_quantization_3.py
@@ -11,20 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
 import functools
 import importlib.util
+import os
 import unittest
 from unittest.mock import patch
 

--- a/tests/single_card_tests/ai_edited_test/fusions/test_ai_clampswiglu_align.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_ai_clampswiglu_align.py
@@ -31,8 +31,6 @@ for _ in range(10):
     _repo_root = os.path.dirname(_repo_root)
     if os.path.isdir(os.path.join(_repo_root, "src", "paddlefleet")):
         break
-sys.path.insert(0, _repo_root)
-sys.path.insert(0, os.path.join(_repo_root, "src"))
 for _mod in list(sys.modules.keys()):
     if _mod == "paddlefleet" or _mod.startswith("paddlefleet."):
         del sys.modules[_mod]

--- a/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_bias_dropout.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_bias_dropout.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_bias_dropout_2.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_bias_dropout_2.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 
 import numpy as np

--- a/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_bias_geglu.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_bias_geglu.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_bias_geglu_2.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_bias_geglu_2.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_bias_geglu_3.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_bias_geglu_3.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 
 import numpy as np

--- a/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_bias_geglu_4.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_bias_geglu_4.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_bias_geglu_5.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_bias_geglu_5.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 # Tests for src/paddlefleet/fusions/fused_bias_geglu.py
 # Additional tests for geglu, bias_geglu, geglu_back, bias_geglu_back,
 # BiasGeGLUFunction, GeGLUFunction, bias_geglu_impl

--- a/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_bias_geglu_6.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_bias_geglu_6.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import patch

--- a/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_bias_gelu.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_bias_gelu.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_bias_gelu_2.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_bias_gelu_2.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 
 import numpy as np

--- a/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_bias_swiglu.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_bias_swiglu.py
@@ -21,8 +21,6 @@ for _ in range(10):
     _repo_root = os.path.dirname(_repo_root)
     if os.path.isdir(os.path.join(_repo_root, "src", "paddlefleet")):
         break
-sys.path.insert(0, _repo_root)
-sys.path.insert(0, os.path.join(_repo_root, "src"))
 for _mod in list(sys.modules.keys()):
     if _mod == "paddlefleet" or _mod.startswith("paddlefleet."):
         del sys.modules[_mod]

--- a/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_bias_swiglu_2.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_bias_swiglu_2.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_bias_swiglu_3.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_bias_swiglu_3.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import patch

--- a/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_bias_swiglu_4.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_bias_swiglu_4.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 # Tests for src/paddlefleet/fusions/fused_bias_swiglu.py
 # Focus: numeric equivalence of *_back wrappers against native

--- a/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_layer_norm.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_layer_norm.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from unittest.mock import patch
 

--- a/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_layer_norm_2.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_layer_norm_2.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_rms_norm.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_rms_norm.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 
 import numpy as np

--- a/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_rms_norm_2.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_rms_norm_2.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_softmax.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_softmax.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock

--- a/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_softmax_2.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_softmax_2.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 
 import numpy as np

--- a/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_softmax_3.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_softmax_3.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_swiglu_scale.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_swiglu_scale.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import patch

--- a/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_swiglu_scale_2.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_swiglu_scale_2.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 # Tests for src/paddlefleet/fusions/fused_swiglu_scale.py
 # Additional tests for fused_swiglu_scale_forward and fused_swiglu_scale_backward
 

--- a/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_swiglu_scale_3.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_swiglu_scale_3.py
@@ -22,9 +22,6 @@ for _ in range(10):
     if os.path.isdir(os.path.join(_repo_root, "src", "paddlefleet")):
         break
 
-sys.path.insert(0, _repo_root)
-sys.path.insert(0, os.path.join(_repo_root, "src"))
-
 # Flush any pre-cached paddlefleet modules so the src/ version wins.
 for _mod in list(sys.modules.keys()):
     if _mod == "paddlefleet" or _mod.startswith("paddlefleet."):

--- a/tests/single_card_tests/ai_edited_test/fusions/test_ai_fusions_module_structure.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_ai_fusions_module_structure.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_backends.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_backends.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 
 

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_clip_vit_model.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_clip_vit_model.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_clip_vit_model_2.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_clip_vit_model_2.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_context_parallel.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_context_parallel.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 # Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
 
 import unittest

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_context_parallel_2.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_context_parallel_2.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 
 

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_embedding.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_embedding.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_empty_layer.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_empty_layer.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from unittest.mock import MagicMock
 

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_gpt.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_gpt.py
@@ -11,18 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
 import unittest
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 from paddle import nn
 from paddle.distributed.fleet.meta_parallel import SharedLayerDesc

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_gpt_config.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_gpt_config.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from dataclasses import fields
 

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_gpt_embedding.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_gpt_embedding.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 import unittest.mock

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_gpt_model.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_gpt_model.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from unittest.mock import MagicMock
 

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_gpt_model_2.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_gpt_model_2.py
@@ -11,14 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
 import unittest
-
-REPO_ROOT = os.path.dirname(
-    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-)
-sys.path.insert(0, os.path.join(REPO_ROOT, "src"))
 
 import paddle
 from paddle import nn

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_gpt_model_3.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_gpt_model_3.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_gpt_model_4.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_gpt_model_4.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_gpt_model_5.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_gpt_model_5.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_gpt_model_6.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_gpt_model_6.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_gpt_model_7.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_gpt_model_7.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_kimi_k25_model.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_kimi_k25_model.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from unittest.mock import MagicMock
 

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_kimi_k25_model_2.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_kimi_k25_model_2.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_language_loss.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_language_loss.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 # Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
 
 import unittest

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_language_loss_2.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_language_loss_2.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_language_loss_3.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_language_loss_3.py
@@ -12,17 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_language_loss_4.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_language_loss_4.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_language_loss_5.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_language_loss_5.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_language_loss_6.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_language_loss_6.py
@@ -10,17 +10,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_llava_model.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_llava_model.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 # Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
 
 import unittest

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_llava_model_2.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_llava_model_2.py
@@ -11,19 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
 import unittest
 from collections import namedtuple
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import paddle
 

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_llava_model_3.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_llava_model_3.py
@@ -11,19 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
 import unittest
 from collections import namedtuple
-
-REPO_ROOT = os.path.dirname(
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    )
-)
-sys.path.insert(0, os.path.join(REPO_ROOT, "src"))
 
 import paddle
 

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_llava_model_4.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_llava_model_4.py
@@ -11,15 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import sys
 import types
 import unittest
-
-REPO_ROOT = os.path.dirname(
-    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-)
-sys.path.insert(0, os.path.join(REPO_ROOT, "src"))
 
 import paddle
 

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_llava_model_5.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_llava_model_5.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_llava_model_6.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_llava_model_6.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_llava_model_7.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_llava_model_7.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_llava_model_8.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_llava_model_8.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_llava_spec.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_llava_spec.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_llava_spec_2.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_llava_spec_2.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_lm_head.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_lm_head.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_moe_layer_specs.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_moe_layer_specs.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_multimodal_projector.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_multimodal_projector.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_multimodal_projector_2.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_multimodal_projector_2.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_patch_merger.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_patch_merger.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_qwen3_5_model.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_qwen3_5_model.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from unittest.mock import MagicMock
 

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_qwen3_5_model_2.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_qwen3_5_model_2.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_qwen3_vl_model.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_qwen3_vl_model.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_radio.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_radio.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_radio_2.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_radio_2.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_rope_utils.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_rope_utils.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import patch

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_rope_utils_2.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_rope_utils_2.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import patch

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_sd2_tpool_merge.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_sd2_tpool_merge.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_utils.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_utils.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from unittest.mock import patch
 

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_vision_layer.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_vision_layer.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from unittest.mock import MagicMock
 

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_vit_layer_specs.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_vit_layer_specs.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 
 # Check if the installed version has the required API

--- a/tests/single_card_tests/ai_edited_test/moe/test_ai_block_attn_res.py
+++ b/tests/single_card_tests/ai_edited_test/moe/test_ai_block_attn_res.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from unittest.mock import MagicMock
 

--- a/tests/single_card_tests/ai_edited_test/moe/test_ai_fp8_utils.py
+++ b/tests/single_card_tests/ai_edited_test/moe/test_ai_fp8_utils.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/tests/single_card_tests/ai_edited_test/moe/test_ai_fused_a2a.py
+++ b/tests/single_card_tests/ai_edited_test/moe/test_ai_fused_a2a.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/tests/single_card_tests/ai_edited_test/moe/test_ai_fusion_layer_utils.py
+++ b/tests/single_card_tests/ai_edited_test/moe/test_ai_fusion_layer_utils.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_expert.py
+++ b/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_expert.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_layer.py
+++ b/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_layer.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from unittest.mock import MagicMock
 

--- a/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_layer_2.py
+++ b/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_layer_2.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_router.py
+++ b/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_router.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from unittest.mock import patch
 

--- a/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_utils.py
+++ b/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_utils.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/tests/single_card_tests/ai_edited_test/moe/test_ai_multi_token_prediction.py
+++ b/tests/single_card_tests/ai_edited_test/moe/test_ai_multi_token_prediction.py
@@ -12,19 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from contextlib import nullcontext
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/moe/test_ai_token_dispatcher.py
+++ b/tests/single_card_tests/ai_edited_test/moe/test_ai_token_dispatcher.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/tests/single_card_tests/ai_edited_test/moe/test_latent_moe.py
+++ b/tests/single_card_tests/ai_edited_test/moe/test_latent_moe.py
@@ -23,18 +23,6 @@ Covers new code in:
 Target: >90% line coverage of all newly added lines.
 """
 
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/tests/single_card_tests/ai_edited_test/ops/test_ai_cross_entropy.py
+++ b/tests/single_card_tests/ai_edited_test/ops/test_ai_cross_entropy.py
@@ -11,18 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
 import types
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/ops/test_ai_cross_entropy_2.py
+++ b/tests/single_card_tests/ai_edited_test/ops/test_ai_cross_entropy_2.py
@@ -11,22 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
 
 # Tests for paddlefleet_ops/ops/triton_ops/fused_linear_cross_entropy/cross_entropy.py
 # Triton kernels are mocked since they require GPU.
-
 import types
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/ops/test_ai_fused_linear_cross_entropy.py
+++ b/tests/single_card_tests/ai_edited_test/ops/test_ai_fused_linear_cross_entropy.py
@@ -11,23 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
 
 # Tests for paddlefleet_ops/ops/triton_ops/fused_linear_cross_entropy/fused_linear_cross_entropy.py
 # Focus on: LigerFusedLinearCrossEntropyFunction backward with main_grad,
 # ec_align mode, bias handling
-
 import types
 import unittest
 from unittest.mock import MagicMock

--- a/tests/single_card_tests/ai_edited_test/ops/test_ai_fused_linear_cross_entropy_2.py
+++ b/tests/single_card_tests/ai_edited_test/ops/test_ai_fused_linear_cross_entropy_2.py
@@ -11,22 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
 
 # Tests for paddlefleet_ops/ops/triton_ops/fused_linear_cross_entropy/fused_linear_cross_entropy.py
 # Tests focus on forward and backward logic without GPU/Triton
-
 import types
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/ops/test_ai_moe_topk_fusion.py
+++ b/tests/single_card_tests/ai_edited_test/ops/test_ai_moe_topk_fusion.py
@@ -11,22 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
 
 # Tests for paddlefleet_ops/ops/triton_ops/moe_topk_fusion.py
 # Triton kernels are mocked since they require GPU.
-
 import types
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/ops/test_ai_moe_topk_fusion_2.py
+++ b/tests/single_card_tests/ai_edited_test/ops/test_ai_moe_topk_fusion_2.py
@@ -11,18 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
 import unittest
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import paddle
 

--- a/tests/single_card_tests/ai_edited_test/ops/test_ai_moe_topk_fusion_3.py
+++ b/tests/single_card_tests/ai_edited_test/ops/test_ai_moe_topk_fusion_3.py
@@ -11,18 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
 import unittest
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import paddle
 

--- a/tests/single_card_tests/ai_edited_test/ops/test_ai_moe_topk_fusion_4.py
+++ b/tests/single_card_tests/ai_edited_test/ops/test_ai_moe_topk_fusion_4.py
@@ -11,14 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
 import unittest
-
-REPO_ROOT = os.path.dirname(
-    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-)
-sys.path.insert(0, os.path.join(REPO_ROOT, "src"))
 
 from paddlefleet.triton_ops import moe_topk_fusion
 

--- a/tests/single_card_tests/ai_edited_test/ops/test_ai_moe_topk_fusion_5.py
+++ b/tests/single_card_tests/ai_edited_test/ops/test_ai_moe_topk_fusion_5.py
@@ -11,22 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
 
 # Tests for paddlefleet_ops/ops/triton_ops/moe_topk_fusion.py
 # Focus on: MoETopkFusion forward validation and routing_map_fusion_forward
-
 import types
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/ops/test_ai_moe_topk_fusion_6.py
+++ b/tests/single_card_tests/ai_edited_test/ops/test_ai_moe_topk_fusion_6.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/ops/test_ai_paddlefleet_ops_utils.py
+++ b/tests/single_card_tests/ai_edited_test/ops/test_ai_paddlefleet_ops_utils.py
@@ -11,19 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/ops/test_ai_rms_norm_fusion.py
+++ b/tests/single_card_tests/ai_edited_test/ops/test_ai_rms_norm_fusion.py
@@ -11,21 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import sys
 
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 # Tests for paddlefleet_ops/ops/triton_ops/rms_norm_fusion.py
-
 import types
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/ops/test_ai_rms_norm_fusion_2.py
+++ b/tests/single_card_tests/ai_edited_test/ops/test_ai_rms_norm_fusion_2.py
@@ -11,22 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
 
 # Extra tests for paddlefleet_ops/ops/triton_ops/rms_norm_fusion.py
 # Focus on: RMSNormFusionTriton forward/backward parameter handling
-
 import types
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/ops/test_ai_rms_norm_fusion_3.py
+++ b/tests/single_card_tests/ai_edited_test/ops/test_ai_rms_norm_fusion_3.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/ops/test_ai_sigmoid_gate_fusion.py
+++ b/tests/single_card_tests/ai_edited_test/ops/test_ai_sigmoid_gate_fusion.py
@@ -11,21 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import sys
 
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 # Tests for paddlefleet_ops/ops/triton_ops/sigmoid_gate_fusion.py
-
 import types
 import unittest
 from unittest.mock import MagicMock

--- a/tests/single_card_tests/ai_edited_test/ops/test_ai_sigmoid_gate_fusion_2.py
+++ b/tests/single_card_tests/ai_edited_test/ops/test_ai_sigmoid_gate_fusion_2.py
@@ -11,22 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
 
 # Extra tests for paddlefleet_ops/ops/triton_ops/sigmoid_gate_fusion.py
 # Focus on: SigmoidGateFusionTriton forward/backward, pure Paddle validation
-
 import types
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/ops/test_ai_sigmoid_gate_fusion_3.py
+++ b/tests/single_card_tests/ai_edited_test/ops/test_ai_sigmoid_gate_fusion_3.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/ops/test_ai_triton_compat.py
+++ b/tests/single_card_tests/ai_edited_test/ops/test_ai_triton_compat.py
@@ -11,21 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import sys
 
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 # Tests for paddlefleet_ops/ops/triton_ops/triton_compat.py
-
 import types
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/ops/test_ai_triton_compat_2.py
+++ b/tests/single_card_tests/ai_edited_test/ops/test_ai_triton_compat_2.py
@@ -11,22 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
 
 # Tests for paddlefleet_ops/ops/triton_ops/triton_compat.py (ops package version)
 # This is the triton_compat in the ops package, different from the src/paddlefleet one
-
 import types
 import unittest
 from unittest.mock import patch

--- a/tests/single_card_tests/ai_edited_test/ops/test_ai_utils.py
+++ b/tests/single_card_tests/ai_edited_test/ops/test_ai_utils.py
@@ -11,23 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
 
 # Tests for paddlefleet_ops/ops/triton_ops/fused_linear_cross_entropy/utils.py
 # element_mul_kernel is a Triton kernel, so we test module structure and
 # simulate the computation logic.
-
 import types
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/ops/test_ai_utils_2.py
+++ b/tests/single_card_tests/ai_edited_test/ops/test_ai_utils_2.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock

--- a/tests/single_card_tests/ai_edited_test/ops/test_ai_utils_3.py
+++ b/tests/single_card_tests/ai_edited_test/ops/test_ai_utils_3.py
@@ -16,15 +16,6 @@ import os
 import sys
 import types
 
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
 # Find the utils.py source file directly
 _project_root = os.path.dirname(
     os.path.dirname(

--- a/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_forward_backward_overlap_utils.py
+++ b/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_forward_backward_overlap_utils.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_forward_backward_overlap_utils_2.py
+++ b/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_forward_backward_overlap_utils_2.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from unittest.mock import MagicMock
 

--- a/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_forward_backward_overlap_utils_3.py
+++ b/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_forward_backward_overlap_utils_3.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_forward_backward_overlap_utils_4.py
+++ b/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_forward_backward_overlap_utils_4.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_four_directions_p2p_communication.py
+++ b/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_four_directions_p2p_communication.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_four_directions_p2p_communication_2.py
+++ b/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_four_directions_p2p_communication_2.py
@@ -11,18 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
 import unittest
-
-REPO_ROOT = os.path.dirname(
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    )
-)
-sys.path.insert(0, os.path.join(REPO_ROOT, "src"))
 
 import paddle
 

--- a/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_four_directions_p2p_communication_3.py
+++ b/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_four_directions_p2p_communication_3.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_four_directions_p2p_communication_4.py
+++ b/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_four_directions_p2p_communication_4.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_four_directions_p2p_communication_5.py
+++ b/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_four_directions_p2p_communication_5.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_four_directions_p2p_communication_6.py
+++ b/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_four_directions_p2p_communication_6.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_four_directions_p2p_communication_7.py
+++ b/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_four_directions_p2p_communication_7.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_overlap_edge_cases.py
+++ b/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_overlap_edge_cases.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_p2p_communication.py
+++ b/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_p2p_communication.py
@@ -12,17 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_p2p_communication_2.py
+++ b/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_p2p_communication_2.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_p2p_communication_3.py
+++ b/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_p2p_communication_3.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_p2p_communication_4.py
+++ b/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_p2p_communication_4.py
@@ -12,17 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_p2p_communication_5.py
+++ b/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_p2p_communication_5.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_p2p_communication_6.py
+++ b/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_p2p_communication_6.py
@@ -12,17 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-import sys
 import unittest
-
-REPO_ROOT = os.path.dirname(
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    )
-)
-sys.path.insert(0, os.path.join(REPO_ROOT, "src"))
 
 import paddle
 

--- a/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_p2p_communication_7.py
+++ b/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_p2p_communication_7.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_p2p_communication_8.py
+++ b/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_p2p_communication_8.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_p2p_communication_9.py
+++ b/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_p2p_communication_9.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_pipeline_hooks.py
+++ b/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_pipeline_hooks.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from unittest.mock import MagicMock
 

--- a/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_pipeline_parallel.py
+++ b/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_pipeline_parallel.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_pipeline_parallel_2.py
+++ b/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_pipeline_parallel_2.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_pipeline_parallel_withinterleave.py
+++ b/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_pipeline_parallel_withinterleave.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_pipeline_parallel_withinterleave_fthenb.py
+++ b/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_pipeline_parallel_withinterleave_fthenb.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_pp_layers.py
+++ b/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_pp_layers.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 
 from paddle.distributed.fleet.meta_parallel.parallel_layers.pp_layers import (

--- a/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_pp_utils.py
+++ b/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_pp_utils.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_utils.py
+++ b/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_utils.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_utils_2.py
+++ b/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_utils_2.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_utils_3.py
+++ b/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_utils_3.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_utils_4.py
+++ b/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_utils_4.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_utils_5.py
+++ b/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_utils_5.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_utils_6.py
+++ b/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_utils_6.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_vpp_balanced_memory.py
+++ b/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_vpp_balanced_memory.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_vpp_simulator.py
+++ b/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_vpp_simulator.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from unittest.mock import MagicMock
 

--- a/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_vpp_simulator_2.py
+++ b/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_vpp_simulator_2.py
@@ -18,15 +18,6 @@ import tempfile
 import types
 import unittest
 
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
 
 class Axis:
     def __init__(self):

--- a/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_vpp_simulator_3.py
+++ b/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_vpp_simulator_3.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_vpp_simulator_4.py
+++ b/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_vpp_simulator_4.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/recompute/test_ai_flash_attn.py
+++ b/tests/single_card_tests/ai_edited_test/recompute/test_ai_flash_attn.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import queue
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/recompute/test_ai_flash_attn_2.py
+++ b/tests/single_card_tests/ai_edited_test/recompute/test_ai_flash_attn_2.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/recompute/test_ai_flash_attn_3.py
+++ b/tests/single_card_tests/ai_edited_test/recompute/test_ai_flash_attn_3.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 # Extra tests for paddlefleet/refined_recompute/flash_attn.py
 # Focus on: _get_fa_version, flashattn_auto_cast,
 # RefinedRcomputeFlashAttention, FlashAttnFunctor

--- a/tests/single_card_tests/ai_edited_test/recompute/test_ai_flash_attn_4.py
+++ b/tests/single_card_tests/ai_edited_test/recompute/test_ai_flash_attn_4.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 # Extra tests for paddlefleet/refined_recompute/flash_attn.py
 # Focus on: FlashMaskAttnCpAttention _first_fwd validation,
 # FlashMaskAttnFunctor forward/backward structure

--- a/tests/single_card_tests/ai_edited_test/recompute/test_ai_flash_attn_5.py
+++ b/tests/single_card_tests/ai_edited_test/recompute/test_ai_flash_attn_5.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/recompute/test_ai_flash_attn_6.py
+++ b/tests/single_card_tests/ai_edited_test/recompute/test_ai_flash_attn_6.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/recompute/test_ai_flash_attn_7.py
+++ b/tests/single_card_tests/ai_edited_test/recompute/test_ai_flash_attn_7.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/recompute/test_ai_flash_attn_8.py
+++ b/tests/single_card_tests/ai_edited_test/recompute/test_ai_flash_attn_8.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/recompute/test_ai_flash_attn_9.py
+++ b/tests/single_card_tests/ai_edited_test/recompute/test_ai_flash_attn_9.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/recompute/test_ai_queue_check.py
+++ b/tests/single_card_tests/ai_edited_test/recompute/test_ai_queue_check.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import queue
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/recompute/test_ai_queue_check_2.py
+++ b/tests/single_card_tests/ai_edited_test/recompute/test_ai_queue_check_2.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import queue
 import unittest

--- a/tests/single_card_tests/ai_edited_test/recompute/test_ai_queue_check_3.py
+++ b/tests/single_card_tests/ai_edited_test/recompute/test_ai_queue_check_3.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import queue
 import unittest

--- a/tests/single_card_tests/ai_edited_test/tensor_parallel/test_ai_cross_entropy.py
+++ b/tests/single_card_tests/ai_edited_test/tensor_parallel/test_ai_cross_entropy.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from unittest.mock import patch
 

--- a/tests/single_card_tests/ai_edited_test/tensor_parallel/test_ai_cross_entropy_2.py
+++ b/tests/single_card_tests/ai_edited_test/tensor_parallel/test_ai_cross_entropy_2.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import patch

--- a/tests/single_card_tests/ai_edited_test/tensor_parallel/test_ai_cross_entropy_3.py
+++ b/tests/single_card_tests/ai_edited_test/tensor_parallel/test_ai_cross_entropy_3.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 # Extra tests for paddlefleet/tensor_parallel/cross_entropy.py
 # Focus on: VocabParallelCrossEntropy static methods, label_smoothing,
 # _VocabParallelCrossEntropy backward with label_smoothing

--- a/tests/single_card_tests/ai_edited_test/tensor_parallel/test_ai_data.py
+++ b/tests/single_card_tests/ai_edited_test/tensor_parallel/test_ai_data.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/tests/single_card_tests/ai_edited_test/tensor_parallel/test_ai_data_2.py
+++ b/tests/single_card_tests/ai_edited_test/tensor_parallel/test_ai_data_2.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/tests/single_card_tests/ai_edited_test/tensor_parallel/test_ai_data_3.py
+++ b/tests/single_card_tests/ai_edited_test/tensor_parallel/test_ai_data_3.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/tensor_parallel/test_ai_layers.py
+++ b/tests/single_card_tests/ai_edited_test/tensor_parallel/test_ai_layers.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/tests/single_card_tests/ai_edited_test/tensor_parallel/test_ai_layers_2.py
+++ b/tests/single_card_tests/ai_edited_test/tensor_parallel/test_ai_layers_2.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/tensor_parallel/test_ai_layers_3.py
+++ b/tests/single_card_tests/ai_edited_test/tensor_parallel/test_ai_layers_3.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/tensor_parallel/test_ai_mappings.py
+++ b/tests/single_card_tests/ai_edited_test/tensor_parallel/test_ai_mappings.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/tensor_parallel/test_ai_mappings_2.py
+++ b/tests/single_card_tests/ai_edited_test/tensor_parallel/test_ai_mappings_2.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 # Extra tests for paddlefleet/tensor_parallel/mappings.py
 # Focus on: AllToAll, all_gather_last_dim, reduce_scatter_last_dim,
 # all_to_all_sp2hp, all_to_all_hp2sp, symbolic functions

--- a/tests/single_card_tests/ai_edited_test/tensor_parallel/test_ai_mappings_3.py
+++ b/tests/single_card_tests/ai_edited_test/tensor_parallel/test_ai_mappings_3.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 # Extra tests for paddlefleet/tensor_parallel/mappings.py
 # Focus on: _reduce_scatter_along_first_dim with input_split_sizes,
 # _gather_along_first_dim with output_split_sizes,

--- a/tests/single_card_tests/ai_edited_test/tensor_parallel/test_ai_mappings_4.py
+++ b/tests/single_card_tests/ai_edited_test/tensor_parallel/test_ai_mappings_4.py
@@ -10,17 +10,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock

--- a/tests/single_card_tests/ai_edited_test/tensor_parallel/test_ai_mappings_5.py
+++ b/tests/single_card_tests/ai_edited_test/tensor_parallel/test_ai_mappings_5.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock

--- a/tests/single_card_tests/ai_edited_test/tensor_parallel/test_ai_mappings_6.py
+++ b/tests/single_card_tests/ai_edited_test/tensor_parallel/test_ai_mappings_6.py
@@ -10,17 +10,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/tensor_parallel/test_ai_mappings_7.py
+++ b/tests/single_card_tests/ai_edited_test/tensor_parallel/test_ai_mappings_7.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/tensor_parallel/test_ai_random.py
+++ b/tests/single_card_tests/ai_edited_test/tensor_parallel/test_ai_random.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/tensor_parallel/test_ai_random_2.py
+++ b/tests/single_card_tests/ai_edited_test/tensor_parallel/test_ai_random_2.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 # Extra tests for paddlefleet/tensor_parallel/random.py
 # Focus on: CudaRNGStatesTracker, _get/_set_cuda_rng_state,
 # get_all_rng_states, model_parallel_cuda_manual_seed, _fork_rng,

--- a/tests/single_card_tests/ai_edited_test/tensor_parallel/test_ai_random_3.py
+++ b/tests/single_card_tests/ai_edited_test/tensor_parallel/test_ai_random_3.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 # Extra tests for paddlefleet/tensor_parallel/random.py
 # Focus on: initialize_rng_tracker, get_cuda_rng_tracker, get_all_rng_states,
 # model_parallel_cuda_manual_seed, _get/_set_all_rng_states, _fork_rng

--- a/tests/single_card_tests/ai_edited_test/tensor_parallel/test_ai_random_4.py
+++ b/tests/single_card_tests/ai_edited_test/tensor_parallel/test_ai_random_4.py
@@ -10,17 +10,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock

--- a/tests/single_card_tests/ai_edited_test/tensor_parallel/test_ai_random_5.py
+++ b/tests/single_card_tests/ai_edited_test/tensor_parallel/test_ai_random_5.py
@@ -10,17 +10,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import patch

--- a/tests/single_card_tests/ai_edited_test/tensor_parallel/test_ai_random_6.py
+++ b/tests/single_card_tests/ai_edited_test/tensor_parallel/test_ai_random_6.py
@@ -10,17 +10,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/tensor_parallel/test_ai_utils.py
+++ b/tests/single_card_tests/ai_edited_test/tensor_parallel/test_ai_utils.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/tests/single_card_tests/ai_edited_test/tensor_parallel/test_ai_utils_2.py
+++ b/tests/single_card_tests/ai_edited_test/tensor_parallel/test_ai_utils_2.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_attention.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_attention.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 
 import paddle

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_attention_2.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_attention_2.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_attention_3.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_attention_3.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_attention_4.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_attention_4.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_attention_5.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_attention_5.py
@@ -10,17 +10,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_block_attn_res.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_block_attn_res.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_dot_product_attention.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_dot_product_attention.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_dot_product_attention_2.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_dot_product_attention_2.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_dot_product_attention_3.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_dot_product_attention_3.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_dot_product_attention_4.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_dot_product_attention_4.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_dot_product_attention_5.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_dot_product_attention_5.py
@@ -10,17 +10,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_dot_product_attention_6.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_dot_product_attention_6.py
@@ -10,17 +10,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_dsa_attention.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_dsa_attention.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import patch

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_fp8_utils.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_fp8_utils.py
@@ -11,18 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
 import unittest
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import paddle
 

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_fp8_utils_2.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_fp8_utils_2.py
@@ -11,18 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
 import unittest
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import paddle
 

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_fp8_utils_3.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_fp8_utils_3.py
@@ -11,14 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
 import unittest
-
-REPO_ROOT = os.path.dirname(
-    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-)
-sys.path.insert(0, os.path.join(REPO_ROOT, "src"))
 
 import paddle
 

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_fp8_utils_4.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_fp8_utils_4.py
@@ -12,15 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import importlib.util
-import os
 import sys
 import types
 import unittest
-
-REPO_ROOT = os.path.dirname(
-    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-)
-sys.path.insert(0, os.path.join(REPO_ROOT, "src"))
 
 import paddle
 

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_fp8_utils_5.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_fp8_utils_5.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_fp8_utils_6.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_fp8_utils_6.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_fused_a2a.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_fused_a2a.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_fusion_layer_utils.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_fusion_layer_utils.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_gated_delta_net.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_gated_delta_net.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_hyper_connection_transformer_layer.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_hyper_connection_transformer_layer.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_mlp.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_mlp.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 
 import paddle

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_mlp_2.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_mlp_2.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_mlp_3.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_mlp_3.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_mlp_4.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_mlp_4.py
@@ -22,18 +22,6 @@ The mock strategy:
     function bodies are executed and tracked by coverage.
 """
 
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
 import unittest
 from unittest.mock import patch
 

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_expert.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_expert.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_expert_2.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_expert_2.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_layer.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_layer.py
@@ -13,18 +13,7 @@
 # limitations under the License.
 import contextlib
 import io
-import os
-import sys
 import unittest
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import paddle
 

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_layer_2.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_layer_2.py
@@ -11,18 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
 import unittest
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import paddle
 

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_layer_4.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_layer_4.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_layer_5.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_layer_5.py
@@ -12,14 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import functools
-import os
-import sys
 import unittest
-
-REPO_ROOT = os.path.dirname(
-    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-)
-sys.path.insert(0, os.path.join(REPO_ROOT, "src"))
 
 import paddle
 

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_layer_6.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_layer_6.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import patch

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_layer_7.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_layer_7.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_utils.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_utils.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_utils_2.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_utils_2.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_utils_3.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_utils_3.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_utils_4.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_utils_4.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import patch

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_utils_5.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_utils_5.py
@@ -10,17 +10,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_utils_6.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_utils_6.py
@@ -10,17 +10,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_utils_7.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_utils_7.py
@@ -10,17 +10,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_utils_8.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_utils_8.py
@@ -10,17 +10,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_multi_latent_attention.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_multi_latent_attention.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_multi_latent_attention_2.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_multi_latent_attention_2.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_multi_latent_attention_3.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_multi_latent_attention_3.py
@@ -10,17 +10,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_multi_latent_attention_4.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_multi_latent_attention_4.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_paddle_norm.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_paddle_norm.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_paddle_norm_2.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_paddle_norm_2.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_paddle_norm_3.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_paddle_norm_3.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_token_dispatcher.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_token_dispatcher.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_token_dispatcher_2.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_token_dispatcher_2.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_token_dispatcher_3.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_token_dispatcher_3.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_block.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_block.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_block_2.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_block_2.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_config.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_config.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_config_2.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_config_2.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_encoder.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_encoder.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from unittest.mock import MagicMock
 

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_encoder_2.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_encoder_2.py
@@ -11,18 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
 import unittest
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 from paddle import nn
 from paddle.distributed.fleet.meta_parallel import SharedLayerDesc

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_encoder_3.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_encoder_3.py
@@ -11,17 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
 import unittest
 
 import paddle
-
-REPO_ROOT = os.path.dirname(
-    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-)
-sys.path.insert(0, os.path.join(REPO_ROOT, "src"))
-
 from paddle import nn
 from paddle.distributed.fleet.meta_parallel import (
     ScheduleChunk,

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_encoder_4.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_encoder_4.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_encoder_5.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_encoder_5.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_encoder_6.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_encoder_6.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_encoder_7.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_encoder_7.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_encoder_8.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_encoder_8.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_encoder_9.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_encoder_9.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_layer.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_layer.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 from unittest.mock import patch
 

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_layer_2.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_layer_2.py
@@ -11,18 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
 import unittest
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import paddle
 from paddle.distributed.fleet.meta_parallel import ScheduleNode

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_layer_3.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_layer_3.py
@@ -11,14 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
 import unittest
-
-REPO_ROOT = os.path.dirname(
-    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-)
-sys.path.insert(0, os.path.join(REPO_ROOT, "src"))
 
 import paddle
 

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_layer_5.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_layer_5.py
@@ -12,14 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import functools
-import os
-import sys
 import unittest
-
-REPO_ROOT = os.path.dirname(
-    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-)
-sys.path.insert(0, os.path.join(REPO_ROOT, "src"))
 
 import paddle
 from paddle.distributed.fleet.meta_parallel import LayerSpec

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_layer_6.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_layer_6.py
@@ -12,17 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
 import unittest
 from unittest.mock import MagicMock
 

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_layer_7.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_layer_7.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_layer_8.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_layer_8.py
@@ -12,18 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import functools
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
 import unittest
 from unittest.mock import MagicMock
 

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_layer_9.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_layer_9.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 from unittest.mock import MagicMock

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_utils.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_utils.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 
 import paddle

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_utils_2.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_utils_2.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 

--- a/tests/single_card_tests/ai_edited_test/transformer_enums/test_ai_enums.py
+++ b/tests/single_card_tests/ai_edited_test/transformer_enums/test_ai_enums.py
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
-
-
 import unittest
 
 

--- a/tests/single_card_tests/ai_edited_test/triton_ops/test_ai_fused_linear_cross_entropy.py
+++ b/tests/single_card_tests/ai_edited_test/triton_ops/test_ai_fused_linear_cross_entropy.py
@@ -11,17 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import sys
-
-sys.path.insert(
-    0,
-    os.path.dirname(
-        os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-    ),
-)
 
 import unittest
 


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Not User Facing

### Description
- Re-submit the change from #1282 in a new PR.
- Remove obsolete `sys.path.insert` path injection blocks from ai edited unit tests.
- Clean up now-unused `os` and `sys` imports after removing the path setup code.

### 是否引起精度变化
否

### Test plan
- [x] `python -m pre_commit run --all-files`
