### PR TITLE
Add AutoSBHistoryTracker

### DIFF
--- a/src/paddlefleet/transformer/moe/fusion_layer_utils.py
+++ b/src/paddlefleet/transformer/moe/fusion_layer_utils.py
@@ -22,7 +22,9 @@ import paddlefleet_ops
 from paddlefleet.transformer.moe.fp8_utils import ExpertsGroupGemmContiguousNode
 
 from .fp8_utils import FP8_ALIGN, USE_INPLACE_SWIGLU_BWD, tilewise_quant
+from .moe_utils import get_auto_sb_history
 from .vmm_utils import (
+    allocator_free_block_info,
     auto_subbatch_allocator_backend,
     find_max_concurrent_subbatch_size,
     find_max_sequence_subbatch_size,
@@ -1108,16 +1110,26 @@ class MlpNode:
 
         num_unzipped_tokens = self.token_offsets[-1]
         hidden_size = zipped_out.shape[1]
-        zip_unzip_fusion = (
-            find_max_concurrent_subbatch_size(
-                [
-                    num_unzipped_tokens * zipped_out.shape[1] * 2,
-                    num_unzipped_tokens * zipped_out.shape[1],
-                ],
-                upper=1,
+
+        # 基于 warmup 历史峰值预测剩余 forward 是否需要降级
+        _free_blocks_now = allocator_free_block_info()
+        _allocator_total_free = sum(s for s, _ in _free_blocks_now)
+        _history = get_auto_sb_history()
+        _history.record_forward(_allocator_total_free)
+        _should_degrade = _history.should_degrade(_allocator_total_free)
+        if _should_degrade:
+            zip_unzip_fusion = False
+        else:
+            zip_unzip_fusion = (
+                find_max_concurrent_subbatch_size(
+                    [
+                        num_unzipped_tokens * zipped_out.shape[1] * 2,
+                        num_unzipped_tokens * zipped_out.shape[1],
+                    ],
+                    upper=1,
+                )
+                > 0
             )
-            > 0
-        )
 
         if zip_unzip_fusion:
             expert_unzipped_out = paddle.empty(
@@ -1307,14 +1319,30 @@ class MlpNode:
         output.stop_gradient = False
 
         if self.moe_subbatch_diag:
+            _predicted_need = _history.predicted_need_for_remaining()
+            _in_warmup = _history.in_warmup()
             logger.info(
                 "[AutoSubbatch FWD] backend=%s, path=%s, total_tokens=%d, "
-                "subbatch_rows=%d, zip_unzip_fusion=%s",
+                "subbatch_rows=%d, zip_unzip_fusion=%s, "
+                "history_step=%d, history_forward_count=%d, history_backward_count=%d, "
+                "history_prev_steps=%d, history_prev_max_delta_mb=%.2f, history_max_delta_mb=%.2f, "
+                "history_in_warmup=%s, allocator_free_mb=%.2f, "
+                "predicted_need_mb=%.2f, should_degrade=%s",
                 auto_subbatch_allocator_backend(),
                 fwd_path,
                 num_unzipped_tokens,
                 subbatch_rows,
                 zip_unzip_fusion,
+                _history.step_idx,
+                _history.forward_count,
+                _history.backward_count,
+                _history.prev_total_steps,
+                _history.prev_max_delta / 1024 / 1024,
+                _history.max_delta / 1024 / 1024,
+                _in_warmup,
+                _allocator_total_free / 1024 / 1024,
+                _predicted_need / 1024 / 1024,
+                _should_degrade,
             )
         return output
 
@@ -1613,15 +1641,25 @@ class MlpNode:
 
         self.reset_state()
 
+        _history = get_auto_sb_history()
+        _iteration_finished = _history.record_backward()
+
         if self.moe_subbatch_diag:
             logger.info(
                 "[AutoSubbatch BWD] backend=%s, path=%s, total_tokens=%d, "
-                "subbatch_rows=%d, zip_unzip_fusion=%s",
+                "subbatch_rows=%d, zip_unzip_fusion=%s, "
+                "history_step=%d, history_forward_count=%d, history_backward_count=%d, "
+                "history_prev_steps=%d, history_iteration_finished=%s",
                 auto_subbatch_allocator_backend(),
                 bwd_path,
                 num_unzipped_tokens,
                 subbatch_rows,
                 zip_unzip_fusion,
+                _history.step_idx,
+                _history.forward_count,
+                _history.backward_count,
+                _history.prev_total_steps,
+                _iteration_finished,
             )
 
         return hs_fp8_dispatched_grad, dispatched_probs_grad

--- a/src/paddlefleet/transformer/moe/moe_utils.py
+++ b/src/paddlefleet/transformer/moe/moe_utils.py
@@ -60,6 +60,78 @@ def use_accuracy_compatible_kernel() -> bool:
     return _USE_ACCURACY_COMPATIBLE_KERNEL
 
 
+class AutoSBHistoryTracker:
+    """只统计 warmup 阶段连续 MoE auto-subbatch forward 起点的显存下降。"""
+
+    def __init__(self):
+        self.step_idx = 0
+        self.forward_count = 0
+        self.backward_count = 0
+        self._last_forward_free = None
+        self.max_delta = 0
+        self.prev_total_steps = 0
+        self.prev_max_delta = 0
+
+    def in_warmup(self) -> bool:
+        return self.backward_count == 0
+
+    def record_forward(self, available_free: int):
+        if self.in_warmup():
+            if self._last_forward_free is not None:
+                self.max_delta = max(
+                    self.max_delta,
+                    self._last_forward_free - available_free,
+                    0,
+                )
+            self._last_forward_free = available_free
+            self.step_idx += 1
+        self.forward_count += 1
+
+    def record_backward(self) -> bool:
+        self.backward_count += 1
+        if self.forward_count > 0 and self.backward_count == self.forward_count:
+            self._new_iteration()
+            return True
+        return False
+
+    def _new_iteration(self):
+        if self.step_idx > 0:
+            self.prev_total_steps = self.step_idx
+            self.prev_max_delta = max(self.prev_max_delta, self.max_delta)
+        self.step_idx = 0
+        self.forward_count = 0
+        self.backward_count = 0
+        self._last_forward_free = None
+        self.max_delta = 0
+
+    def should_degrade(self, available_free: int) -> bool:
+        predicted_need = self.predicted_need_for_remaining()
+        return (
+            self.in_warmup()
+            and predicted_need > 0
+            and available_free < predicted_need
+        )
+
+    def predicted_need_for_remaining(self) -> int:
+        """预测当前 warmup 从当前 forward 起还需要的显存。返回 0 表示无法预测（冷启动）。"""
+        if self.prev_total_steps == 0 or self.prev_max_delta == 0:
+            return 0
+        remaining = self.prev_total_steps - self.step_idx + 1
+        if remaining <= 0:
+            return 0
+        predicted = self.prev_max_delta * remaining
+        # 安全系数 1.2x + 128MB 余量
+        predicted = int(predicted * 1.2) + 128 * 1024 * 1024
+        return predicted
+
+
+_AutoSBHistory = AutoSBHistoryTracker()
+
+
+def get_auto_sb_history():
+    return _AutoSBHistory
+
+
 def _unpermute_scatter(
     permuted_tokens: paddle.Tensor, sorted_indices: paddle.Tensor, restore_shape
 ) -> paddle.Tensor:

--- a/tests/single_card_tests/test_auto_sb_history_tracker.py
+++ b/tests/single_card_tests/test_auto_sb_history_tracker.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from paddlefleet.transformer.moe.moe_utils import AutoSBHistoryTracker
+
+
+class TestAutoSBHistoryTracker(unittest.TestCase):
+    def test_records_warmup_delta_and_resets_iteration(self):
+        tracker = AutoSBHistoryTracker()
+
+        tracker.record_forward(1000)
+        tracker.record_forward(900)
+        tracker.record_forward(850)
+
+        self.assertTrue(tracker.in_warmup())
+        self.assertEqual(tracker.step_idx, 3)
+        self.assertEqual(tracker.forward_count, 3)
+        self.assertEqual(tracker.backward_count, 0)
+        self.assertEqual(tracker.max_delta, 100)
+
+        self.assertFalse(tracker.record_backward())
+        self.assertFalse(tracker.in_warmup())
+        self.assertEqual(tracker.backward_count, 1)
+
+        self.assertFalse(tracker.record_backward())
+        self.assertTrue(tracker.record_backward())
+        self.assertTrue(tracker.in_warmup())
+        self.assertEqual(tracker.step_idx, 0)
+        self.assertEqual(tracker.forward_count, 0)
+        self.assertEqual(tracker.backward_count, 0)
+        self.assertEqual(tracker.max_delta, 0)
+        self.assertEqual(tracker.prev_total_steps, 3)
+        self.assertEqual(tracker.prev_max_delta, 100)
+
+    def test_predicts_remaining_need_from_previous_iteration(self):
+        mb = 1024 * 1024
+        tracker = AutoSBHistoryTracker()
+
+        tracker.record_forward(1000 * mb)
+        tracker.record_forward(900 * mb)
+        tracker.record_forward(840 * mb)
+        tracker.record_backward()
+        tracker.record_backward()
+        tracker.record_backward()
+
+        tracker.record_forward(1000 * mb)
+        expected_need = int(100 * mb * 3 * 1.2) + 128 * mb
+        self.assertEqual(tracker.predicted_need_for_remaining(), expected_need)
+        self.assertTrue(tracker.should_degrade(expected_need - 1))
+        self.assertFalse(tracker.should_degrade(expected_need))
+
+        tracker.record_forward(950 * mb)
+        tracker.record_forward(900 * mb)
+        self.assertEqual(
+            tracker.predicted_need_for_remaining(),
+            int(100 * mb * 1 * 1.2) + 128 * mb,
+        )
+
+        tracker.record_forward(850 * mb)
+        self.assertEqual(tracker.predicted_need_for_remaining(), 0)
+
+    def test_ignores_memory_growth_and_cold_start(self):
+        tracker = AutoSBHistoryTracker()
+
+        tracker.record_forward(100)
+        tracker.record_forward(120)
+
+        self.assertEqual(tracker.max_delta, 0)
+        self.assertEqual(tracker.predicted_need_for_remaining(), 0)
+        self.assertFalse(tracker.should_degrade(0))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
新增 AutoSBHistoryTracker 用于记录 MoE auto-subbatch warmup 阶段的显存变化历史，并基于上一轮 warmup 的最大显存下降幅度预测当前 warmup 后续 forward
  所需显存。

  主要改动：
  - 在 moe_utils.py 中新增 AutoSBHistoryTracker，记录 warmup forward 次数、forward/backward 计数、最大显存下降值以及上一轮 warmup 统计信息。
  - 提供 predicted_need_for_remaining() 和 should_degrade()，用于在 warmup 阶段根据历史显存变化判断是否需要提前降级subbatch。
  - 调整 MoE auto-subbatch 相关逻辑，接入历史显存追踪与预测。
  - 新增 tests/single_card_tests/test_auto_sb_history_tracker.py，覆盖：
    - warmup 显存下降统计与 iteration reset
    - 基于上一轮 warmup history 的剩余显存需求预测
    - cold start / 显存增长场景下不触发预测和降级

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否