### PR TITLE
[DSv4] Add Tridao's fast hadamard transform for rotate_activation function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,8 @@ packages/paddlefleet_ops/src/paddlefleet_ops/flash_mla
 packages/paddlefleet_ops/src/paddlefleet_ops/sonicmoe
 packages/paddlefleet_ops/src/paddlefleet_ops/quack
 packages/paddlefleet_ops/src/paddlefleet_ops/cudnn
+packages/paddlefleet_ops/src/paddlefleet_ops/fast_hadamard_transform
+packages/paddlefleet_ops/src/paddlefleet_ops/fast_hadamard_transform_cuda
 
 # Generated version files
 # Both version.py files are auto-generated at build time by build_backend.py.

--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "packages/paddlefleet_ops/third_party/FlashMLA"]
 	path = packages/paddlefleet_ops/third_party/FlashMLA
 	url = https://github.com/PFCCLab/FlashMLA.git
+[submodule "packages/paddlefleet_ops/third_party/fast-hadamard-transform"]
+	path = packages/paddlefleet_ops/third_party/fast-hadamard-transform
+	url = https://github.com/PFCCLab/fast-hadamard-transform.git

--- a/packages/paddlefleet_ops/build_utils.py
+++ b/packages/paddlefleet_ops/build_utils.py
@@ -202,6 +202,7 @@ def check_submodule_updated():
             "sonic-moe",
             "flash-attention",
             "FlashMLA",
+            "fast-hadamard-transform",
         ]
         if not all(
             (PKG_ROOT / "third_party" / third_party / ".git").exists()
@@ -427,6 +428,16 @@ def get_libs():
                     (cuda_major, cuda_minor) <= (12, 8)
                 ),
             },
+            name="fast-hadamard-transform",
+            source_rel_path="third_party/fast-hadamard-transform",
+            artifacts=[
+                Artifact("fast_hadamard_transform", "fast_hadamard_transform"),
+                Artifact(
+                    "fast_hadamard_transform_cuda",
+                    "fast_hadamard_transform_cuda",
+                ),
+            ],
+            include_dirs=["csrc"],
         ),
     ]
     if (cuda_major, cuda_minor) >= (12, 9):

--- a/packages/paddlefleet_ops/build_utils.py
+++ b/packages/paddlefleet_ops/build_utils.py
@@ -428,6 +428,8 @@ def get_libs():
                     (cuda_major, cuda_minor) <= (12, 8)
                 ),
             },
+        ),
+        EcosystemLibrary(
             name="fast-hadamard-transform",
             source_rel_path="third_party/fast-hadamard-transform",
             artifacts=[

--- a/packages/paddlefleet_ops/src/paddlefleet_ops/__init__.py
+++ b/packages/paddlefleet_ops/src/paddlefleet_ops/__init__.py
@@ -93,6 +93,8 @@ if paddle.is_compiled_with_cuda():
         "For developers: guard imports with `is_flash_mla_available()` and only call `paddlefleet_ops.flash_mla` when flag branch enabled.\n"
         "For users: use a GPU with compute capability >= 9.0 (Hopper or Blackwell) to enable."
     )
+
+    FAST_HADAMARD_TRANSFORM_HINT = "For developers: guard imports with `is_fast_hadamard_transform_available()` and only call `paddlefleet_ops.fast_hadamard_transform` when CUDA is enabled."
 else:
     DEEP_GEMM_HINT = "deep_gemm is not supported on XPU backend."
     DEEP_EP_HINT = "deep_ep is not supported on XPU backend."
@@ -100,11 +102,13 @@ else:
     SONIC_MOE_HINT = "sonicmoe is not supported on XPU backend."
     CUDNN_FRONTEND_HINT = "cudnn frontend is not supported on XPU backend."
     FLASH_MLA_HINT = "flash_mla is not supported on XPU backend."
-
-FLASH_MASK_HINT = (
-    "For developers: guard imports with `is_flash_mask_available()` and only call `paddlefleet_ops.flash_mask` when flag branch enabled.\n"
-    "For users: use a GPU with compute capability >= 10.0 (Blackwell) to enable."
-)
+    FAST_HADAMARD_TRANSFORM_HINT = (
+        "fast_hadamard_transform is not supported on XPU backend."
+    )
+    FLASH_MASK_HINT = (
+        "For developers: guard imports with `is_flash_mask_available()` and only call `paddlefleet_ops.flash_mask` when flag branch enabled.\n"
+        "For users: use a GPU with compute capability >= 10.0 (Blackwell) to enable."
+    )
 
 
 def _build_notice(
@@ -169,8 +173,10 @@ _SONIC_MOE_AVAILABLE = False
 _FLASH_MLA_AVAILABLE = False
 _FLASH_MASK_AVAILABLE = False
 _CUDNN_FRONTEND_AVAILABLE = False
+_FAST_HADAMARD_TRANSFORM_AVAILABLE = False
 
 if paddle.is_compiled_with_cuda():
+    _FAST_HADAMARD_TRANSFORM_AVAILABLE = True
     if paddle.cuda.get_device_capability()[0] >= 9:
         _DEEP_GEMM_AVAILABLE = True
         _DEEP_EP_AVAILABLE = True
@@ -218,6 +224,10 @@ def is_flash_mask_available():
 
 def is_cudnn_frontend_available():
     return _CUDNN_FRONTEND_AVAILABLE
+
+
+def is_fast_hadamard_transform_available():
+    return _FAST_HADAMARD_TRANSFORM_AVAILABLE
 
 
 def _try_load_nvshmem(ops_dir: Path):
@@ -342,6 +352,24 @@ if paddle.is_compiled_with_cuda():
         )
         logger.warning(warning)
         blocked_import_messages["paddlefleet_ops.flash_mask"] = error
+
+    if is_fast_hadamard_transform_available():
+        _safe_load_ecosystem_lib(
+            "fast_hadamard_transform",
+            ops_dir,
+            globals(),
+            ["fast_hadamard_transform_cuda"],
+        )
+    else:
+        warning, error = _build_notice(
+            "paddlefleet_ops.fast_hadamard_transform",
+            "CUDA backend is unavailable.",
+            hint_for_error=FAST_HADAMARD_TRANSFORM_HINT,
+        )
+        logger.warning(warning)
+        blocked_import_messages["paddlefleet_ops.fast_hadamard_transform"] = (
+            error
+        )
 
     if is_cudnn_frontend_available():
         paddle.enable_compat(scope={"cudnn"}, silent=True)

--- a/packages/paddlefleet_ops/src/paddlefleet_ops/__init__.py
+++ b/packages/paddlefleet_ops/src/paddlefleet_ops/__init__.py
@@ -105,10 +105,11 @@ else:
     FAST_HADAMARD_TRANSFORM_HINT = (
         "fast_hadamard_transform is not supported on XPU backend."
     )
-    FLASH_MASK_HINT = (
-        "For developers: guard imports with `is_flash_mask_available()` and only call `paddlefleet_ops.flash_mask` when flag branch enabled.\n"
-        "For users: use a GPU with compute capability >= 10.0 (Blackwell) to enable."
-    )
+
+FLASH_MASK_HINT = (
+    "For developers: guard imports with `is_flash_mask_available()` and only call `paddlefleet_ops.flash_mask` when flag branch enabled.\n"
+    "For users: use a GPU with compute capability >= 10.0 (Blackwell) to enable."
+)
 
 
 def _build_notice(
@@ -176,7 +177,6 @@ _CUDNN_FRONTEND_AVAILABLE = False
 _FAST_HADAMARD_TRANSFORM_AVAILABLE = False
 
 if paddle.is_compiled_with_cuda():
-    _FAST_HADAMARD_TRANSFORM_AVAILABLE = True
     if paddle.cuda.get_device_capability()[0] >= 9:
         _DEEP_GEMM_AVAILABLE = True
         _DEEP_EP_AVAILABLE = True
@@ -193,6 +193,7 @@ if paddle.is_compiled_with_cuda():
         _SONIC_MOE_AVAILABLE = True
     if sys.version_info >= (3, 12):
         _CUDNN_FRONTEND_AVAILABLE = True
+    _FAST_HADAMARD_TRANSFORM_AVAILABLE = True
 
 if paddle.is_compiled_with_xpu():
     _DEEP_EP_AVAILABLE = True

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -940,6 +940,7 @@ class Compressor(nn.Layer):
         )
 
         self.use_fp8_qat = getattr(config, "use_fp8_qat", False)
+        self.use_fast_hadamard = getattr(config, "use_fast_hadamard", False)
 
     def _overlap_transform(
         self,
@@ -1123,7 +1124,9 @@ class Compressor(nn.Layer):
                 )
 
             if self.rotate:
-                kv = rotate_activation(kv)
+                kv = rotate_activation(
+                    kv, use_fast_hadamard=self.use_fast_hadamard
+                )
                 if self.use_fp8_qat:
                     kv = fp8_simulate_qat(kv, 128)
             else:
@@ -1180,7 +1183,7 @@ class Compressor(nn.Layer):
             )
 
         if self.rotate:
-            kv = rotate_activation(kv)
+            kv = rotate_activation(kv, use_fast_hadamard=self.use_fast_hadamard)
             if self.use_fp8_qat:
                 kv = fp8_simulate_qat(kv, 128)
         else:
@@ -1273,6 +1276,7 @@ class CSAIndexer(nn.Layer):
         )
 
         self.use_fp8_qat = getattr(config, "use_fp8_qat", False)
+        self.use_fast_hadamard = getattr(config, "use_fast_hadamard", False)
 
     def forward_before_topk(
         self,
@@ -1308,7 +1312,7 @@ class CSAIndexer(nn.Layer):
                 doc_lens=doc_lens,
                 position_offset=position_offset,
             )
-        q = rotate_activation(q)
+        q = rotate_activation(q, use_fast_hadamard=self.use_fast_hadamard)
 
         # k QAT:
         if self.use_fp8_qat:

--- a/src/paddlefleet/transformer/dsa_attention.py
+++ b/src/paddlefleet/transformer/dsa_attention.py
@@ -33,9 +33,16 @@ import paddle.nn.functional as F
 from paddle import Tensor
 
 try:
-    from fast_hadamard_transform import hadamard_transform as _fast_hadamard_transform
+    from paddlefleet_ops.fast_hadamard_transform import (
+        hadamard_transform as _fast_hadamard_transform,
+    )
 except Exception:
-    _fast_hadamard_transform = None
+    try:
+        from fast_hadamard_transform import (
+            hadamard_transform as _fast_hadamard_transform,
+        )
+    except Exception:
+        _fast_hadamard_transform = None
 from paddle.distributed.fleet.meta_parallel import LayerSpec, build_spec_layer
 
 from paddlefleet import parallel_state

--- a/src/paddlefleet/transformer/dsa_attention.py
+++ b/src/paddlefleet/transformer/dsa_attention.py
@@ -31,6 +31,11 @@ from typing import TYPE_CHECKING
 import paddle
 import paddle.nn.functional as F
 from paddle import Tensor
+
+try:
+    from fast_hadamard_transform import hadamard_transform as _fast_hadamard_transform
+except Exception:
+    _fast_hadamard_transform = None
 from paddle.distributed.fleet.meta_parallel import LayerSpec, build_spec_layer
 
 from paddlefleet import parallel_state
@@ -58,27 +63,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def hadamard_transform(x: Tensor, scale: float = 1.0) -> Tensor:
-    """Fast Walsh-Hadamard Transform using the butterfly algorithm.
-
-    Pure Paddle implementation, equivalent to:
-        F.linear(x, hadamard_matrix(dim)) * scale
-
-    Uses O(N log N) butterfly operations instead of O(N^2) matrix multiply.
-    The Hadamard matrix is symmetric and orthogonal, so backward is the same
-    transform applied to grad_output (handled automatically by Paddle autograd).
-
-    Reference:
-        - fast-hadamard-transform (Tri Dao): csrc/fast_hadamard_transform_cuda.cu
-        - PaddleFormers/paddleformers/quantization/hadamard_utils.py (matmul_hadU)
-
-    Args:
-        x: Input tensor of shape (..., dim). dim must be a power of 2.
-        scale: Scaling factor applied to the output.
-
-    Returns:
-        Hadamard-transformed tensor of the same shape.
-    """
+def _paddle_hadamard_transform(x: Tensor, scale: float = 1.0) -> Tensor:
     original_shape = x.shape
     output_dtype = x.dtype
     dim = original_shape[-1]
@@ -103,6 +88,34 @@ def hadamard_transform(x: Tensor, scale: float = 1.0) -> Tensor:
         h *= 2
 
     return (x.reshape(original_shape) * scale).cast(output_dtype)
+
+
+_fast_hadamard_available = _fast_hadamard_transform is not None
+
+
+def _can_use_fast_hadamard(x: Tensor) -> bool:
+    return _fast_hadamard_available and x.place.is_gpu_place()
+
+
+def hadamard_transform(x: Tensor, scale: float = 1.0) -> Tensor:
+    """Walsh-Hadamard Transform with an optional Paddle CUDA fast path.
+
+    Prefer the migrated Paddle ``fast_hadamard_transform`` operator when it is
+    available. Falls back to the pure Paddle butterfly implementation otherwise.
+    """
+    dim = x.shape[-1]
+    assert dim > 0 and (dim & (dim - 1)) == 0, (
+        f"hadamard_transform requires dim to be a power of 2, got {dim}"
+    )
+
+    global _fast_hadamard_available
+    if _can_use_fast_hadamard(x):
+        try:
+            return _fast_hadamard_transform(x, scale=scale)
+        except (ImportError, RuntimeError, ValueError, TypeError):
+            _fast_hadamard_available = False
+
+    return _paddle_hadamard_transform(x, scale)
 
 
 def rotate_activation(x: Tensor) -> Tensor:

--- a/src/paddlefleet/transformer/dsa_attention.py
+++ b/src/paddlefleet/transformer/dsa_attention.py
@@ -31,18 +31,6 @@ from typing import TYPE_CHECKING
 import paddle
 import paddle.nn.functional as F
 from paddle import Tensor
-
-try:
-    from paddlefleet_ops.fast_hadamard_transform import (
-        hadamard_transform as _fast_hadamard_transform,
-    )
-except Exception:
-    try:
-        from fast_hadamard_transform import (
-            hadamard_transform as _fast_hadamard_transform,
-        )
-    except Exception:
-        _fast_hadamard_transform = None
 from paddle.distributed.fleet.meta_parallel import LayerSpec, build_spec_layer
 
 from paddlefleet import parallel_state
@@ -62,6 +50,13 @@ from paddlefleet.tensor_parallel.mappings import (
 from paddlefleet.transformer.enums import AttnMaskType
 from paddlefleet.transformer.layer import FleetLayer
 
+try:
+    from paddlefleet_ops.fast_hadamard_transform import (
+        hadamard_transform as _fast_hadamard_transform,
+    )
+except (ImportError, RuntimeError):
+    _fast_hadamard_transform = None
+
 if TYPE_CHECKING:
     from paddlefleet.packed_seq_params import PackedSeqParams
     from paddlefleet.transformer.transformer_config import TransformerConfig
@@ -70,7 +65,27 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _paddle_hadamard_transform(x: Tensor, scale: float = 1.0) -> Tensor:
+def hadamard_transform(x: Tensor, scale: float = 1.0) -> Tensor:
+    """Fast Walsh-Hadamard Transform using the butterfly algorithm.
+
+    Pure Paddle implementation, equivalent to:
+        F.linear(x, hadamard_matrix(dim)) * scale
+
+    Uses O(N log N) butterfly operations instead of O(N^2) matrix multiply.
+    The Hadamard matrix is symmetric and orthogonal, so backward is the same
+    transform applied to grad_output (handled automatically by Paddle autograd).
+
+    Reference:
+        - fast-hadamard-transform (Tri Dao): csrc/fast_hadamard_transform_cuda.cu
+        - PaddleFormers/paddleformers/quantization/hadamard_utils.py (matmul_hadU)
+
+    Args:
+        x: Input tensor of shape (..., dim). dim must be a power of 2.
+        scale: Scaling factor applied to the output.
+
+    Returns:
+        Hadamard-transformed tensor of the same shape.
+    """
     original_shape = x.shape
     output_dtype = x.dtype
     dim = original_shape[-1]
@@ -97,35 +112,7 @@ def _paddle_hadamard_transform(x: Tensor, scale: float = 1.0) -> Tensor:
     return (x.reshape(original_shape) * scale).cast(output_dtype)
 
 
-_fast_hadamard_available = _fast_hadamard_transform is not None
-
-
-def _can_use_fast_hadamard(x: Tensor) -> bool:
-    return _fast_hadamard_available and x.place.is_gpu_place()
-
-
-def hadamard_transform(x: Tensor, scale: float = 1.0) -> Tensor:
-    """Walsh-Hadamard Transform with an optional Paddle CUDA fast path.
-
-    Prefer the migrated Paddle ``fast_hadamard_transform`` operator when it is
-    available. Falls back to the pure Paddle butterfly implementation otherwise.
-    """
-    dim = x.shape[-1]
-    assert dim > 0 and (dim & (dim - 1)) == 0, (
-        f"hadamard_transform requires dim to be a power of 2, got {dim}"
-    )
-
-    global _fast_hadamard_available
-    if _can_use_fast_hadamard(x):
-        try:
-            return _fast_hadamard_transform(x, scale=scale)
-        except (ImportError, RuntimeError, ValueError, TypeError):
-            _fast_hadamard_available = False
-
-    return _paddle_hadamard_transform(x, scale)
-
-
-def rotate_activation(x: Tensor) -> Tensor:
+def rotate_activation(x: Tensor, use_fast_hadamard: bool = False) -> Tensor:
     """Apply Hadamard rotation activation.
 
     Reference:
@@ -141,7 +128,14 @@ def rotate_activation(x: Tensor) -> Tensor:
         f"rotate_activation only support bf16 input, but got {x.dtype}"
     )
     hidden_size = x.shape[-1]
-    return hadamard_transform(x, scale=hidden_size**-0.5)
+    scale = hidden_size**-0.5
+
+    if use_fast_hadamard:
+        if _fast_hadamard_transform is None:
+            raise RuntimeError("fast_hadamard_transform is not available")
+        return _fast_hadamard_transform(x, scale)
+
+    return hadamard_transform(x, scale)
 
 
 # ---------------------------------------------------------------------------

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -885,6 +885,9 @@ class TransformerConfig(ModelParallelConfig):
         kernel.
     """
 
+    use_fast_hadamard: bool = False
+    """Use Tridao's fast Hadamard transform for DSv4 rotate activation function."""
+
     o_groups: int = 8
     """Number of groups for grouped low-rank output projection (wo_a) in DSv4 Hybrid.
     Set to 0 to use a single linear output projection instead.

--- a/tests/single_card_tests/custom_ops/test_fast_hadamard_transform.py
+++ b/tests/single_card_tests/custom_ops/test_fast_hadamard_transform.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+import paddle
+
+try:
+    import paddlefleet_ops
+
+    from paddlefleet.transformer import dsa_attention
+
+    _HAS_FAST_HADAMARD = (
+        paddlefleet_ops.is_fast_hadamard_transform_available()
+        and dsa_attention._fast_hadamard_transform is not None
+    )
+except (ImportError, RuntimeError, AttributeError):
+    _HAS_FAST_HADAMARD = False
+
+
+@unittest.skipUnless(
+    paddle.is_compiled_with_cuda() and _HAS_FAST_HADAMARD,
+    "Fast Hadamard transform requires CUDA and fast_hadamard_transform",
+)
+class TestFastHadamardTransform(unittest.TestCase):
+    def setUp(self):
+        paddle.seed(2026)
+
+    def test_forward_backward(self):
+        x = paddle.randn([1, 512, 128], "bfloat16")
+
+        x_ref = x.detach().requires_grad_()
+        y_ref = dsa_attention.rotate_activation(x_ref)
+
+        x_tgt = x.detach().requires_grad_()
+        y_tgt = dsa_attention.rotate_activation(x_tgt, use_fast_hadamard=True)
+
+        grad = paddle.randn_like(y_ref)
+        y_ref.backward(grad)
+        y_tgt.backward(grad)
+
+        # forward is binary-equal
+        np.testing.assert_allclose(y_ref.float(), y_tgt.float(), atol=0, rtol=0)
+
+        # Note: the backward of the Hadamard transform is identical to its forward.
+        # Tridao reuses the same kernel for both forward and backward passes, whereas
+        # Paddle relies on autograd, so Tridao is expected to be more numerically stable.
+        np.testing.assert_allclose(
+            x_ref.grad.float(), x_tgt.grad.float(), atol=1e-3, rtol=1e-3
+        )
+
+    def test_unavailable_assert(self):
+        x = paddle.randn([1, 1, 32], "bfloat16")
+        func = dsa_attention._fast_hadamard_transform
+        dsa_attention._fast_hadamard_transform = None
+
+        try:
+            with self.assertRaisesRegex(
+                RuntimeError, "fast_hadamard_transform is not available"
+            ):
+                dsa_attention.rotate_activation(x, use_fast_hadamard=True)
+        finally:
+            dsa_attention._fast_hadamard_transform = func
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/custom_ops/test_ops_import.py
+++ b/tests/single_card_tests/custom_ops/test_ops_import.py
@@ -105,5 +105,22 @@ class TestDeepEPImport(unittest.TestCase):
             from paddlefleet_ops.deep_ep import xxxx  # noqa: F401
 
 
+class TestFastHadamardTransformImport(unittest.TestCase):
+    def test_fast_hadamard_transform_import(self):
+        import paddlefleet_ops
+        from paddlefleet_ops.fast_hadamard_transform import (
+            hadamard_transform,
+        )
+
+        self.assertTrue(callable(hadamard_transform))
+        print(paddlefleet_ops.fast_hadamard_transform)
+
+    def test_error_import(self):
+        with self.assertRaises(ImportError):
+            from paddlefleet_ops.fast_hadamard_transform import (
+                xxxx,  # noqa: F401
+            )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
Operator Mechanism


### PR Types
Performance


### Description
接入 PFCC 的 fast-hadamard-transform 库，用于加速 DSv4 CSA 的 Indexer & Compressor 的 rotate_activation 操作

<b>开启方式：</b>在 yaml 中设置：
```yaml
use_fast_hadamard: true
```

<b>性能：</b>32K 时开启上述 flag 直接提升 9%，性能提升比较明显

### 是否引起精度变化
是

<b>说明：</b>Hadamard 的反向计算和前向是一模一样的，Tridao 的做法就是前反向用同一个 kernel。Paddle 前向可以和 Tridao 逐位对齐，但是 Paddle 反向用了 autograd，导致一些结合顺序不太一样，出现了 diff。从数学上说，Tridao 的写法应该是更数值稳定的，当然其实差距很小。

进行了 50 步收敛测试，Tridao 和 Paddle 的误差小于 DSv4 本身的 aadiff：
<img width="500" height="310" alt="tridao vs paddle" src="https://github.com/user-attachments/assets/6f9b8d7d-a54b-430d-ae46-b01fabe853b0" />