### PR TITLE
[Performance Optimization] Add docmask metadata reuse helper

### DIFF
--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -72,21 +72,6 @@ from paddlefleet.transformer.cp_utils import (
 )
 
 
-def is_csa_docmask_meta_reuse_disabled() -> bool:
-    return os.getenv("CSA_DISABLE_DOCMASK_META_REUSE", "0") == "1"
-
-
-def _csa_docmask_as_int(value, name: str) -> int:
-    if isinstance(value, Tensor):
-        numel = value.numel()
-        if isinstance(numel, Tensor):
-            numel = numel.item()
-        if numel != 1:
-            raise ValueError(f"{name} must be scalar, got shape: {value.shape}")
-        return int(value.item())
-    return int(value)
-
-
 def _normalize_csa_docmask_args(
     ratio: int,
     batch_size: int,
@@ -95,11 +80,11 @@ def _normalize_csa_docmask_args(
     *,
     require_batch_one: bool = True,
 ) -> tuple[int, int, int, int]:
-    ratio = _csa_docmask_as_int(ratio, "ratio")
-    batch_size = _csa_docmask_as_int(batch_size, "batch_size")
-    seqlen = _csa_docmask_as_int(seqlen, "seqlen")
+    ratio = int(ratio)
+    batch_size = int(batch_size)
+    seqlen = int(seqlen)
     if n_compressed is not None:
-        n_compressed = _csa_docmask_as_int(n_compressed, "n_compressed")
+        n_compressed = int(n_compressed)
     if ratio <= 0:
         raise ValueError(f"ratio must be positive, got ratio: {ratio}")
     if seqlen <= 0:
@@ -285,15 +270,6 @@ def get_cutoff_doc_starts(cutoff_doc_lens: Tensor) -> Tensor:
     return starts
 
 
-def _get_actual_n_compressed_from_docmask(
-    ratio: int,
-    startend_row_indices: Tensor,
-) -> int:
-    doc_lens = get_doc_lens(startend_row_indices)
-    doc_lens_cutoff = get_cutoff_doc_lens(doc_lens, ratio)
-    return int(doc_lens_cutoff.sum().item()) // ratio
-
-
 @dataclass
 class CSADocMaskMetadata:
     """Reusable CSA metadata derived from ``startend_row_indices``."""
@@ -384,8 +360,9 @@ class CSADocMaskMetadata:
     ) -> bool:
         """Return True if this instance can be reused for the given inputs.
 
-        Reuse is limited to the same tensor object and matching shape/ratio.
-        Callers should build metadata once per forward and pass it explicitly.
+        Reuse is safe only for the same docmask tensor and identical metadata
+        layout parameters. Different ratios or compressed widths derive
+        different packed compressed columns from the same document boundaries.
         """
         ratio, batch_size, seqlen, n_compressed = _normalize_csa_docmask_args(
             ratio, batch_size, seqlen, n_compressed, require_batch_one=False
@@ -532,12 +509,8 @@ def get_or_build_csa_docmask_meta(
     ratio, batch_size, seqlen, n_compressed = _normalize_csa_docmask_args(
         ratio, batch_size, seqlen, n_compressed
     )
-    if (
-        docmask_meta is not None
-        and not is_csa_docmask_meta_reuse_disabled()
-        and docmask_meta.matches(
-            ratio, batch_size, seqlen, startend_row_indices, n_compressed
-        )
+    if docmask_meta is not None and docmask_meta.matches(
+        ratio, batch_size, seqlen, startend_row_indices, n_compressed
     ):
         return docmask_meta
     return CSADocMaskMetadata.build(
@@ -623,7 +596,6 @@ def get_window_topk_idxs(
 
     if not (
         docmask_meta is not None
-        and not is_csa_docmask_meta_reuse_disabled()
         and docmask_meta.batch_size == batch_size
         and docmask_meta.seqlen == seqlen
         and docmask_meta.startend_row_indices is startend_row_indices
@@ -1677,8 +1649,6 @@ class CSAIndexer(nn.Layer):
         compressor so that indexer K is computed over the full global sequence.
         """
         b, sq, _ = x.shape
-        if is_csa_docmask_meta_reuse_disabled():
-            docmask_meta = None
         doc_lens = docmask_meta.doc_lens if docmask_meta is not None else None
         if doc_lens is None and startend_row_indices is not None:
             doc_lens = get_doc_lens(startend_row_indices)
@@ -2197,12 +2167,7 @@ class CompressedSparseAttention(FleetLayer):
                 docmask_meta=docmask_meta,
             )
 
-        reuse_docmask_meta = not is_csa_docmask_meta_reuse_disabled()
-        if (
-            startend_row_indices is not None
-            and self.compress_ratio > 1
-            and reuse_docmask_meta
-        ):
+        if startend_row_indices is not None and self.compress_ratio > 1:
             docmask_meta = get_or_build_csa_docmask_meta(
                 ratio=self.compress_ratio,
                 batch_size=b,
@@ -2211,11 +2176,6 @@ class CompressedSparseAttention(FleetLayer):
                 docmask_meta=docmask_meta,
             )
             actual_n_compressed = docmask_meta.actual_n_compressed
-        elif startend_row_indices is not None and self.compress_ratio > 1:
-            docmask_meta = None
-            actual_n_compressed = _get_actual_n_compressed_from_docmask(
-                self.compress_ratio, startend_row_indices
-            )
         elif self.compress_ratio > 1:
             actual_n_compressed = sq // self.compress_ratio
         else:
@@ -2354,12 +2314,7 @@ class CompressedSparseAttention(FleetLayer):
         q_positions = paddle.arange(
             position_offset, position_offset + sq, dtype="int64"
         )
-        reuse_docmask_meta = not is_csa_docmask_meta_reuse_disabled()
-        if (
-            startend_row_indices is not None
-            and self.compress_ratio > 1
-            and reuse_docmask_meta
-        ):
+        if startend_row_indices is not None and self.compress_ratio > 1:
             docmask_meta = get_or_build_csa_docmask_meta(
                 ratio=self.compress_ratio,
                 batch_size=b,
@@ -2367,8 +2322,6 @@ class CompressedSparseAttention(FleetLayer):
                 startend_row_indices=startend_row_indices,
                 docmask_meta=docmask_meta,
             )
-        elif startend_row_indices is not None and self.compress_ratio > 1:
-            docmask_meta = None
 
         # Step 1: Window topk (CP-aware: uses global q_positions)
         if startend_row_indices is None:
@@ -2406,12 +2359,7 @@ class CompressedSparseAttention(FleetLayer):
 
         # Compute actual_n_compressed accounting for document boundaries
         if startend_row_indices is not None and self.compress_ratio > 1:
-            if docmask_meta is not None:
-                actual_n_compressed = docmask_meta.actual_n_compressed
-            else:
-                actual_n_compressed = _get_actual_n_compressed_from_docmask(
-                    self.compress_ratio, startend_row_indices
-                )
+            actual_n_compressed = docmask_meta.actual_n_compressed
         elif self.compress_ratio > 1:
             actual_n_compressed = n_compressed_global
         else:

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -350,31 +350,6 @@ class CSADocMaskMetadata:
             is_valid=is_valid,
         )
 
-    def matches(
-        self,
-        ratio: int,
-        batch_size: int,
-        seqlen: int,
-        startend_row_indices: Tensor,
-        n_compressed: int | None = None,
-    ) -> bool:
-        """Return True if this instance can be reused for the given inputs.
-
-        Reuse is safe only for the same docmask tensor and identical metadata
-        layout parameters. Different ratios or compressed widths derive
-        different packed compressed columns from the same document boundaries.
-        """
-        ratio, batch_size, seqlen, n_compressed = _normalize_csa_docmask_args(
-            ratio, batch_size, seqlen, n_compressed, require_batch_one=False
-        )
-        return (
-            self.ratio == ratio
-            and self.batch_size == batch_size
-            and self.seqlen == seqlen
-            and self.n_compressed == n_compressed
-            and self.startend_row_indices is startend_row_indices
-        )
-
     @property
     def doc_lens_cutoff(self) -> Tensor:
         if self._doc_lens_cutoff is None:
@@ -498,26 +473,6 @@ class CSADocMaskMetadata:
         return self._is_first_compressed_group
 
 
-def get_or_build_csa_docmask_meta(
-    ratio: int,
-    batch_size: int,
-    seqlen: int,
-    startend_row_indices: Tensor,
-    n_compressed: int | None = None,
-    docmask_meta: CSADocMaskMetadata | None = None,
-) -> CSADocMaskMetadata:
-    ratio, batch_size, seqlen, n_compressed = _normalize_csa_docmask_args(
-        ratio, batch_size, seqlen, n_compressed
-    )
-    if docmask_meta is not None and docmask_meta.matches(
-        ratio, batch_size, seqlen, startend_row_indices, n_compressed
-    ):
-        return docmask_meta
-    return CSADocMaskMetadata.build(
-        ratio, batch_size, seqlen, startend_row_indices, n_compressed
-    )
-
-
 def get_compress_topk_idxs(
     ratio: int,
     batch_size: int,
@@ -560,14 +515,11 @@ def get_compress_topk_idxs(
         )
         return matrix.unsqueeze(0).expand([batch_size, -1, -1])
 
-    return get_or_build_csa_docmask_meta(
-        ratio=ratio,
-        batch_size=batch_size,
-        seqlen=seqlen,
-        startend_row_indices=startend_row_indices,
-        docmask_meta=docmask_meta,
-        n_compressed=n_compressed,
-    ).get_compress_topk_idxs(offset)
+    if docmask_meta is None:
+        docmask_meta = CSADocMaskMetadata.build(
+            ratio, batch_size, seqlen, startend_row_indices, n_compressed
+        )
+    return docmask_meta.get_compress_topk_idxs(offset)
 
 
 def get_window_topk_idxs(
@@ -594,12 +546,7 @@ def get_window_topk_idxs(
         )
         return matrix.unsqueeze(0).expand([batch_size, -1, -1])
 
-    if not (
-        docmask_meta is not None
-        and docmask_meta.batch_size == batch_size
-        and docmask_meta.seqlen == seqlen
-        and docmask_meta.startend_row_indices is startend_row_indices
-    ):
+    if docmask_meta is None:
         _, batch_size, seqlen, _ = _normalize_csa_docmask_args(
             1, batch_size, seqlen, seqlen
         )
@@ -636,13 +583,11 @@ def get_valid_range(
     """
     if startend_row_indices is None:
         return None
-    return get_or_build_csa_docmask_meta(
-        ratio=ratio,
-        batch_size=batch_size,
-        seqlen=seqlen,
-        startend_row_indices=startend_row_indices,
-        docmask_meta=docmask_meta,
-    ).valid_range
+    if docmask_meta is None:
+        docmask_meta = CSADocMaskMetadata.build(
+            ratio, batch_size, seqlen, startend_row_indices
+        )
+    return docmask_meta.valid_range
 
 
 def _build_compressed_causal_mask(
@@ -676,14 +621,11 @@ def _build_compressed_causal_mask(
             paddle.zeros([1], dtype="float32"),
         )
 
-    return get_or_build_csa_docmask_meta(
-        ratio=ratio,
-        batch_size=batch_size,
-        seqlen=seqlen,
-        startend_row_indices=startend_row_indices,
-        docmask_meta=docmask_meta,
-        n_compressed=n_compressed,
-    ).get_compressed_causal_mask()
+    if docmask_meta is None:
+        docmask_meta = CSADocMaskMetadata.build(
+            ratio, batch_size, seqlen, startend_row_indices, n_compressed
+        )
+    return docmask_meta.get_compressed_causal_mask()
 
 
 def compact_kv_score_cutoff(
@@ -1398,13 +1340,7 @@ class Compressor(nn.Layer):
         # Shared compression logic for both CP and non-CP paths.
         if startend_row_indices is not None:
             # per-document cutoff, pack contiguously without padding
-            docmask_meta = get_or_build_csa_docmask_meta(
-                ratio=ratio,
-                batch_size=b,
-                seqlen=sq,
-                startend_row_indices=startend_row_indices,
-                docmask_meta=docmask_meta,
-            )
+            assert docmask_meta is not None
             doc_lens = docmask_meta.doc_lens
             doc_starts = docmask_meta.doc_starts
             doc_lens_cutoff = docmask_meta.doc_lens_cutoff
@@ -2117,6 +2053,10 @@ class CompressedSparseAttention(FleetLayer):
                 "when startend_row_indices is not None, ",
                 f"only support batch_size == 1, current batch_size: {b}",
             )
+            assert docmask_meta is not None, (
+                "docmask_meta must be built by DSv4HybridAttention.forward "
+                "when startend_row_indices is not None"
+            )
 
         # Compute loss_mask from input_ids (mask out padding tokens)
         if input_ids is not None:
@@ -2168,13 +2108,7 @@ class CompressedSparseAttention(FleetLayer):
             )
 
         if startend_row_indices is not None and self.compress_ratio > 1:
-            docmask_meta = get_or_build_csa_docmask_meta(
-                ratio=self.compress_ratio,
-                batch_size=b,
-                seqlen=sq,
-                startend_row_indices=startend_row_indices,
-                docmask_meta=docmask_meta,
-            )
+            assert docmask_meta is not None
             actual_n_compressed = docmask_meta.actual_n_compressed
         elif self.compress_ratio > 1:
             actual_n_compressed = sq // self.compress_ratio
@@ -2315,13 +2249,7 @@ class CompressedSparseAttention(FleetLayer):
             position_offset, position_offset + sq, dtype="int64"
         )
         if startend_row_indices is not None and self.compress_ratio > 1:
-            docmask_meta = get_or_build_csa_docmask_meta(
-                ratio=self.compress_ratio,
-                batch_size=b,
-                seqlen=sq_global,
-                startend_row_indices=startend_row_indices,
-                docmask_meta=docmask_meta,
-            )
+            assert docmask_meta is not None
 
         # Step 1: Window topk (CP-aware: uses global q_positions)
         if startend_row_indices is None:

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -53,7 +53,6 @@ from paddlefleet.transformer.dsa_attention import (
 )
 from paddlefleet.transformer.utils import (
     get_doc_lens,
-    get_doc_starts,
 )
 
 if TYPE_CHECKING:
@@ -71,6 +70,185 @@ from paddlefleet.transformer.cp_utils import (
     get_window_topk_idxs_cp,
     map_compressed_topk_to_kv_full_cp,
 )
+
+
+def is_csa_docmask_meta_reuse_disabled() -> bool:
+    return os.getenv("CSA_DISABLE_DOCMASK_META_REUSE", "0") == "1"
+
+
+def _csa_docmask_as_int(value, name: str) -> int:
+    if isinstance(value, Tensor):
+        numel = value.numel()
+        if isinstance(numel, Tensor):
+            numel = numel.item()
+        if numel != 1:
+            raise ValueError(f"{name} must be scalar, got shape: {value.shape}")
+        return int(value.item())
+    return int(value)
+
+
+def _normalize_csa_docmask_args(
+    ratio: int,
+    batch_size: int,
+    seqlen: int,
+    n_compressed: int | None = None,
+    *,
+    require_batch_one: bool = True,
+) -> tuple[int, int, int, int]:
+    ratio = _csa_docmask_as_int(ratio, "ratio")
+    batch_size = _csa_docmask_as_int(batch_size, "batch_size")
+    seqlen = _csa_docmask_as_int(seqlen, "seqlen")
+    if n_compressed is not None:
+        n_compressed = _csa_docmask_as_int(n_compressed, "n_compressed")
+    if ratio <= 0:
+        raise ValueError(f"ratio must be positive, got ratio: {ratio}")
+    if seqlen <= 0:
+        raise ValueError(f"seqlen must be positive, got seqlen: {seqlen}")
+    if require_batch_one and batch_size != 1:
+        raise ValueError(
+            f"only support batch_size = 1, got batch_size: {batch_size}"
+        )
+    if n_compressed is None:
+        n_compressed = seqlen // ratio
+    if n_compressed < 0:
+        raise ValueError(
+            f"n_compressed must be non-negative, got n_compressed: {n_compressed}"
+        )
+    return ratio, batch_size, seqlen, n_compressed
+
+
+def _validate_csa_docmask_shape(
+    startend_row_indices: Tensor,
+    batch_size: int,
+    seqlen: int,
+) -> None:
+    shape = list(startend_row_indices.shape)
+    expected = [batch_size, 1, seqlen, 1]
+    if shape != expected:
+        raise ValueError(
+            "startend_row_indices must have shape "
+            f"{expected}, got shape: {shape}"
+        )
+
+
+def _derive_csa_doc_boundaries(
+    startend_row_indices: Tensor,
+    seqlen: int,
+) -> tuple[Tensor, Tensor, Tensor, Tensor, Tensor]:
+    mask = startend_row_indices.flatten().cast("int64")
+    positions = paddle.arange(seqlen, dtype="int64")
+
+    is_boundary = paddle.zeros([seqlen], dtype="bool")
+    is_boundary[0] = True
+    is_boundary[1:] = (positions[1:] == mask[:-1]) & (mask[1:] != mask[:-1])
+
+    doc_start_per_pos = paddle.cummax(
+        is_boundary.cast("int64") * positions, axis=0
+    ).values
+    pos_in_doc = positions - doc_start_per_pos
+    doc_len_per_pos = mask - doc_start_per_pos
+    is_valid = pos_in_doc < doc_len_per_pos
+
+    doc_starts_i64 = paddle.nonzero(is_boundary).flatten()
+    doc_lens = (mask[doc_starts_i64] - doc_starts_i64).cast("int32")
+    doc_starts = doc_starts_i64
+
+    return doc_start_per_pos, doc_len_per_pos, is_valid, doc_lens, doc_starts
+
+
+def _build_window_topk_idxs_from_doc_bounds(
+    batch_size: int,
+    seqlen: int,
+    window_size: int,
+    doc_start_per_pos: Tensor,
+    is_valid: Tensor,
+) -> Tensor:
+    if window_size <= 0:
+        raise ValueError(f"window_size must be positive, got {window_size}")
+    positions = paddle.arange(seqlen, dtype="int64")
+    win_start = paddle.maximum(doc_start_per_pos, positions - window_size + 1)
+    offsets = paddle.arange(window_size, dtype="int64").unsqueeze(0)
+    indices = win_start.unsqueeze(1) + offsets
+    invalid = (
+        (indices > positions.unsqueeze(1))
+        | (indices < doc_start_per_pos.unsqueeze(1))
+        | (~is_valid).unsqueeze(1).expand_as(indices)
+    )
+    result = paddle.where(invalid, paddle.full_like(indices, -1), indices)
+    return result.unsqueeze(0).expand([batch_size, -1, -1])
+
+
+def _build_compress_topk_idxs_from_valid_range(
+    batch_size: int,
+    seqlen: int,
+    n_compressed: int,
+    offset: int,
+    valid_range: Tensor,
+) -> Tensor:
+    c_grid = paddle.arange(n_compressed, dtype="int64").unsqueeze(0)
+    valid_range = valid_range[0].cast("int64")
+    range_start = valid_range[:, 0]
+    range_end = valid_range[:, 1]
+    active = (c_grid >= range_start.unsqueeze(1)) & (
+        c_grid < range_end.unsqueeze(1)
+    )
+    result = paddle.where(
+        active,
+        (c_grid + offset).cast("int32"),
+        paddle.full([seqlen, n_compressed], -1, dtype="int32"),
+    )
+    return result.unsqueeze(0).expand([batch_size, -1, -1])
+
+
+def _build_compressed_causal_mask_from_valid_range(
+    batch_size: int,
+    seqlen: int,
+    n_compressed: int,
+    valid_range: Tensor,
+) -> Tensor:
+    c_grid = paddle.arange(n_compressed, dtype="int64").unsqueeze(0)
+    valid_range = valid_range[0].cast("int64")
+    range_start = valid_range[:, 0]
+    range_end = valid_range[:, 1]
+    valid_mask = (c_grid >= range_start.unsqueeze(1)) & (
+        c_grid < range_end.unsqueeze(1)
+    )
+    invalid = (
+        (~valid_mask).unsqueeze(0).expand([batch_size, seqlen, n_compressed])
+    )
+    return paddle.where(
+        invalid,
+        paddle.full([1], float("-inf"), dtype="float32"),
+        paddle.zeros([1], dtype="float32"),
+    )
+
+
+def _build_valid_range_from_doc_bounds(
+    ratio: int,
+    seqlen: int,
+    doc_start_per_pos: Tensor,
+    doc_len_per_pos: Tensor,
+    is_valid: Tensor,
+) -> Tensor:
+    positions = paddle.arange(seqlen, dtype="int64")
+    pos_in_doc = positions - doc_start_per_pos
+    num_compressed_per_pos = doc_len_per_pos // ratio
+    boundary_marker = (positions == doc_start_per_pos).cast("int64")
+    boundary_compressed = boundary_marker * num_compressed_per_pos
+    cum_compressed = paddle.cumsum(boundary_compressed, axis=0)
+    doc_col_start = cum_compressed - num_compressed_per_pos
+
+    causal_avail = (pos_in_doc + 1) // ratio
+    num_available = paddle.minimum(causal_avail, num_compressed_per_pos)
+    range_start = doc_col_start
+    range_end = doc_col_start + num_available
+    zero_mask = (num_available == 0) | (~is_valid)
+    range_start = paddle.where(
+        zero_mask, paddle.zeros_like(range_start), range_start
+    )
+    range_end = paddle.where(zero_mask, paddle.zeros_like(range_end), range_end)
+    return paddle.stack([range_start, range_end], axis=-1).cast("int32")
+
 
 # ---------------------------------------------------------------------------
 # Helper functions for index computation
@@ -107,12 +285,273 @@ def get_cutoff_doc_starts(cutoff_doc_lens: Tensor) -> Tensor:
     return starts
 
 
+def _get_actual_n_compressed_from_docmask(
+    ratio: int,
+    startend_row_indices: Tensor,
+) -> int:
+    doc_lens = get_doc_lens(startend_row_indices)
+    doc_lens_cutoff = get_cutoff_doc_lens(doc_lens, ratio)
+    return int(doc_lens_cutoff.sum().item()) // ratio
+
+
+@dataclass
+class CSADocMaskMetadata:
+    """Reusable CSA metadata derived from ``startend_row_indices``."""
+
+    startend_row_indices: Tensor
+    ratio: int
+    batch_size: int
+    seqlen: int
+    n_compressed: int
+    doc_lens: Tensor
+    doc_starts: Tensor
+    doc_start_per_pos: Tensor
+    doc_len_per_pos: Tensor
+    is_valid: Tensor
+    _doc_lens_cutoff: Tensor | None = None
+    _doc_starts_cutoff: Tensor | None = None
+    _actual_n_compressed: int | None = None
+    _valid_range: Tensor | None = None
+    _window_topk_idxs: Tensor | None = None
+    _window_size: int | None = None
+    _compress_topk_idxs: Tensor | None = None
+    _compress_offset: int | None = None
+    _compressed_causal_mask: Tensor | None = None
+    _is_first_compressed_group: Tensor | None = None
+
+    @classmethod
+    def build(
+        cls,
+        ratio: int,
+        batch_size: int,
+        seqlen: int,
+        startend_row_indices: Tensor | None,
+        n_compressed: int | None = None,
+    ) -> CSADocMaskMetadata | None:
+        """Build metadata from ``startend_row_indices``.
+
+        Args:
+            ratio: compression ratio (e.g. 4 or 128).
+            batch_size: batch size; must be 1 (varlen packs docs along seq).
+            seqlen: sequence length; must equal
+                ``startend_row_indices.shape[2]``.
+            startend_row_indices: ``[batch_size, 1, seqlen, 1]`` document
+                boundary tensor where entry ``t`` holds the (exclusive) end
+                row index of ``t``'s document, or ``None`` for causal-only
+                mode (returns ``None``).
+            n_compressed: optional override for ``seqlen // ratio``; used when
+                the caller already knows the compressed slot count.
+
+        Returns:
+            A populated :class:`CSADocMaskMetadata`, or ``None`` when
+            ``startend_row_indices is None``.
+        """
+        if startend_row_indices is None:
+            return None
+        ratio, batch_size, seqlen, n_compressed = _normalize_csa_docmask_args(
+            ratio, batch_size, seqlen, n_compressed
+        )
+        _validate_csa_docmask_shape(startend_row_indices, batch_size, seqlen)
+
+        (
+            doc_start_per_pos,
+            doc_len_per_pos,
+            is_valid,
+            doc_lens,
+            doc_starts,
+        ) = _derive_csa_doc_boundaries(startend_row_indices, seqlen)
+
+        return cls(
+            startend_row_indices=startend_row_indices,
+            ratio=ratio,
+            batch_size=batch_size,
+            seqlen=seqlen,
+            n_compressed=n_compressed,
+            doc_lens=doc_lens,
+            doc_starts=doc_starts,
+            doc_start_per_pos=doc_start_per_pos,
+            doc_len_per_pos=doc_len_per_pos,
+            is_valid=is_valid,
+        )
+
+    def matches(
+        self,
+        ratio: int,
+        batch_size: int,
+        seqlen: int,
+        startend_row_indices: Tensor,
+        n_compressed: int | None = None,
+    ) -> bool:
+        """Return True if this instance can be reused for the given inputs.
+
+        Reuse is limited to the same tensor object and matching shape/ratio.
+        Callers should build metadata once per forward and pass it explicitly.
+        """
+        ratio, batch_size, seqlen, n_compressed = _normalize_csa_docmask_args(
+            ratio, batch_size, seqlen, n_compressed, require_batch_one=False
+        )
+        return (
+            self.ratio == ratio
+            and self.batch_size == batch_size
+            and self.seqlen == seqlen
+            and self.n_compressed == n_compressed
+            and self.startend_row_indices is startend_row_indices
+        )
+
+    @property
+    def doc_lens_cutoff(self) -> Tensor:
+        if self._doc_lens_cutoff is None:
+            self._doc_lens_cutoff = get_cutoff_doc_lens(
+                self.doc_lens, self.ratio
+            )
+        return self._doc_lens_cutoff
+
+    @property
+    def doc_starts_cutoff(self) -> Tensor:
+        if self._doc_starts_cutoff is None:
+            self._doc_starts_cutoff = get_cutoff_doc_starts(
+                self.doc_lens_cutoff
+            )
+        return self._doc_starts_cutoff
+
+    @property
+    def actual_n_compressed(self) -> int:
+        if self._actual_n_compressed is None:
+            total_cutoff = int(self.doc_lens_cutoff.sum().item())
+            actual_n_compressed = total_cutoff // self.ratio
+            if actual_n_compressed > self.n_compressed:
+                raise ValueError(
+                    "n_compressed must cover all packed document compressed "
+                    "groups, got n_compressed="
+                    f"{self.n_compressed}, required={actual_n_compressed}"
+                )
+            self._actual_n_compressed = actual_n_compressed
+        return self._actual_n_compressed
+
+    @property
+    def valid_range(self) -> Tensor:
+        if self._valid_range is None:
+            self._valid_range = _build_valid_range_from_doc_bounds(
+                self.ratio,
+                self.seqlen,
+                self.doc_start_per_pos,
+                self.doc_len_per_pos,
+                self.is_valid,
+            ).unsqueeze(0)
+        return self._valid_range
+
+    def get_window_topk_idxs(self, window_size: int) -> Tensor:
+        """Return ``[batch_size, seqlen, window_size]`` sliding-window indices.
+
+        Indices reset at each document boundary; invalid slots (beyond the
+        query position, before the document start, or on padding) are set to
+        ``-1``. Cached and keyed by ``window_size``.
+        """
+        window_size = int(window_size)
+        cache_hit = (
+            self._window_topk_idxs is not None
+            and self._window_size == window_size
+        )
+        if not cache_hit:
+            self._window_topk_idxs = _build_window_topk_idxs_from_doc_bounds(
+                self.batch_size,
+                self.seqlen,
+                window_size,
+                self.doc_start_per_pos,
+                self.is_valid,
+            )
+            self._window_size = window_size
+        return self._window_topk_idxs
+
+    def get_compress_topk_idxs(self, offset: int) -> Tensor:
+        """Return ``[batch_size, seqlen, n_compressed]`` compressed indices.
+
+        For each query position, valid compressed positions (within the
+        document's causal valid range) carry ``compressed_id + offset``;
+        invalid slots are ``-1``. Cached and keyed by ``offset``.
+        """
+        offset = int(offset)
+        cache_hit = (
+            self._compress_topk_idxs is not None
+            and self._compress_offset == offset
+        )
+        if not cache_hit:
+            self._compress_topk_idxs = (
+                _build_compress_topk_idxs_from_valid_range(
+                    self.batch_size,
+                    self.seqlen,
+                    self.n_compressed,
+                    offset,
+                    self.valid_range,
+                )
+            )
+            self._compress_offset = offset
+        return self._compress_topk_idxs
+
+    def get_compressed_causal_mask(self) -> Tensor:
+        """Return ``[batch_size, seqlen, n_compressed]`` float32 causal mask.
+
+        ``0`` for valid (within the document's compressed range), ``-inf``
+        otherwise. Cached on first access.
+        """
+        cache_hit = self._compressed_causal_mask is not None
+        if not cache_hit:
+            self._compressed_causal_mask = (
+                _build_compressed_causal_mask_from_valid_range(
+                    self.batch_size,
+                    self.seqlen,
+                    self.n_compressed,
+                    self.valid_range,
+                )
+            )
+        return self._compressed_causal_mask
+
+    def get_is_first_compressed_group(self) -> Tensor:
+        """Return ``[actual_n_compressed]`` bool flags marking each document's
+        first compressed group (used by overlap transforms to avoid reusing
+        the previous document's data). Cached on first access.
+        """
+        cache_hit = self._is_first_compressed_group is not None
+        if not cache_hit:
+            is_first = paddle.zeros([self.actual_n_compressed], dtype="bool")
+            first_indices = self.doc_starts_cutoff // self.ratio
+            valid_indices = first_indices < self.actual_n_compressed
+            is_first[first_indices[valid_indices]] = True
+            self._is_first_compressed_group = is_first
+        return self._is_first_compressed_group
+
+
+def get_or_build_csa_docmask_meta(
+    ratio: int,
+    batch_size: int,
+    seqlen: int,
+    startend_row_indices: Tensor,
+    n_compressed: int | None = None,
+    docmask_meta: CSADocMaskMetadata | None = None,
+) -> CSADocMaskMetadata:
+    ratio, batch_size, seqlen, n_compressed = _normalize_csa_docmask_args(
+        ratio, batch_size, seqlen, n_compressed
+    )
+    if (
+        docmask_meta is not None
+        and not is_csa_docmask_meta_reuse_disabled()
+        and docmask_meta.matches(
+            ratio, batch_size, seqlen, startend_row_indices, n_compressed
+        )
+    ):
+        return docmask_meta
+    return CSADocMaskMetadata.build(
+        ratio, batch_size, seqlen, startend_row_indices, n_compressed
+    )
+
+
 def get_compress_topk_idxs(
     ratio: int,
     batch_size: int,
     seqlen: int,
     offset: int,
     startend_row_indices: Tensor | None = None,
+    docmask_meta: CSADocMaskMetadata | None = None,
 ) -> Tensor:
     """Get compressed indices: [b, seqlen, seqlen // ratio].
 
@@ -130,6 +569,7 @@ def get_compress_topk_idxs(
         seqlen: sequence length.
         offset: offset added to column indices to produce KV indices.
         startend_row_indices: [batch_size, h, seqlen, 1] tensor, or None.
+        docmask_meta: optional reusable metadata for ``startend_row_indices``.
 
     Returns:
         result: [b, seqlen, seqlen // ratio] int32 tensor.
@@ -147,43 +587,14 @@ def get_compress_topk_idxs(
         )
         return matrix.unsqueeze(0).expand([batch_size, -1, -1])
 
-    mask = startend_row_indices.flatten().cast("int64")
-    positions = paddle.arange(seqlen, dtype="int64")
-
-    is_boundary = paddle.zeros([seqlen], dtype="int64")
-    is_boundary[0] = 1
-    is_boundary[1:] = (
-        (positions[1:] == mask[:-1]) & (mask[1:] != mask[:-1])
-    ).cast("int64")
-
-    start_marker = is_boundary * positions
-    doc_start = paddle.cummax(start_marker, axis=0).values
-
-    pos_in_doc = positions - doc_start
-    doc_len = mask - doc_start
-    num_compressed_per_pos = doc_len // ratio
-
-    boundary_compressed = is_boundary * num_compressed_per_pos
-    cum_compressed = paddle.cumsum(boundary_compressed, axis=0)
-    doc_col_start = cum_compressed - num_compressed_per_pos
-
-    is_valid = pos_in_doc < doc_len
-    causal_avail = ((pos_in_doc + 1) // ratio) * is_valid.cast("int64")
-    num_available = paddle.minimum(causal_avail, num_compressed_per_pos)
-    upper_bound = doc_col_start + num_available
-
-    c_grid = paddle.arange(n_compressed, dtype="int64").unsqueeze(0)
-    lower = doc_col_start.unsqueeze(1)
-    upper = upper_bound.unsqueeze(1)
-
-    active = (c_grid >= lower) & (c_grid < upper)
-
-    result = paddle.where(
-        active,
-        (c_grid + offset).cast("int32"),
-        paddle.full([seqlen, n_compressed], -1, dtype="int32"),
-    )
-    return result.unsqueeze(0).expand([batch_size, -1, -1])
+    return get_or_build_csa_docmask_meta(
+        ratio=ratio,
+        batch_size=batch_size,
+        seqlen=seqlen,
+        startend_row_indices=startend_row_indices,
+        docmask_meta=docmask_meta,
+        n_compressed=n_compressed,
+    ).get_compress_topk_idxs(offset)
 
 
 def get_window_topk_idxs(
@@ -191,6 +602,7 @@ def get_window_topk_idxs(
     batch_size: int,
     seqlen: int,
     startend_row_indices: Tensor | None = None,
+    docmask_meta: CSADocMaskMetadata | None = None,
 ) -> Tensor:
     """Get sliding window indices: [b, seqlen, window_size].
 
@@ -209,34 +621,32 @@ def get_window_topk_idxs(
         )
         return matrix.unsqueeze(0).expand([batch_size, -1, -1])
 
-    mask = startend_row_indices.flatten().cast("int64")
-    positions = paddle.arange(seqlen, dtype="int64")
-
-    is_boundary = paddle.zeros([seqlen], dtype="int64")
-    is_boundary[0] = 1
-    is_boundary[1:] = (
-        (positions[1:] == mask[:-1]) & (mask[1:] != mask[:-1])
-    ).cast("int64")
-
-    start_marker = is_boundary * positions
-    doc_start = paddle.cummax(start_marker, axis=0).values
-
-    pos_in_doc = positions - doc_start
-    doc_len = mask - doc_start
-    is_padding = pos_in_doc >= doc_len
-
-    win_start = paddle.maximum(doc_start, positions - window_size + 1)
-
-    offsets = paddle.arange(window_size, dtype="int64").unsqueeze(0)
-    indices = win_start.unsqueeze(1) + offsets
-
-    beyond_pos = indices > positions.unsqueeze(1)
-    below_doc_start = indices < doc_start.unsqueeze(1)
-    padding_mask = is_padding.unsqueeze(1).expand_as(indices)
-
-    invalid = beyond_pos | below_doc_start | padding_mask
-    result = paddle.where(invalid, paddle.full_like(indices, -1), indices)
-    return result.unsqueeze(0).expand([batch_size, -1, -1])
+    if not (
+        docmask_meta is not None
+        and not is_csa_docmask_meta_reuse_disabled()
+        and docmask_meta.batch_size == batch_size
+        and docmask_meta.seqlen == seqlen
+        and docmask_meta.startend_row_indices is startend_row_indices
+    ):
+        _, batch_size, seqlen, _ = _normalize_csa_docmask_args(
+            1, batch_size, seqlen, seqlen
+        )
+        _validate_csa_docmask_shape(startend_row_indices, batch_size, seqlen)
+        (
+            doc_start_per_pos,
+            _doc_len_per_pos,
+            is_valid,
+            _doc_lens,
+            _doc_starts,
+        ) = _derive_csa_doc_boundaries(startend_row_indices, seqlen)
+        return _build_window_topk_idxs_from_doc_bounds(
+            batch_size=batch_size,
+            seqlen=seqlen,
+            window_size=window_size,
+            doc_start_per_pos=doc_start_per_pos,
+            is_valid=is_valid,
+        )
+    return docmask_meta.get_window_topk_idxs(window_size)
 
 
 def get_valid_range(
@@ -244,6 +654,7 @@ def get_valid_range(
     batch_size: int,
     seqlen: int,
     startend_row_indices: Tensor | None = None,
+    docmask_meta: CSADocMaskMetadata | None = None,
 ) -> Tensor | None:
     """Get valid compressed KV range [start, end) for each position.
 
@@ -253,47 +664,13 @@ def get_valid_range(
     """
     if startend_row_indices is None:
         return None
-
-    assert batch_size == 1, (
-        f"only support batch_size == 1, got batch_size: {batch_size}"
-    )
-    mask = startend_row_indices.flatten().cast("int64")
-    positions = paddle.arange(seqlen, dtype="int64")
-
-    is_boundary = paddle.zeros([seqlen], dtype="int64")
-    is_boundary[0] = 1
-    is_boundary[1:] = (
-        (positions[1:] == mask[:-1]) & (mask[1:] != mask[:-1])
-    ).cast("int64")
-
-    start_marker = is_boundary * positions
-    doc_start = paddle.cummax(start_marker, axis=0).values
-
-    pos_in_doc = positions - doc_start
-    doc_len = mask - doc_start
-    is_valid = pos_in_doc < doc_len
-
-    cutoff_doc_len = (doc_len // ratio) * ratio
-    num_compressed_per_doc = cutoff_doc_len // ratio
-
-    boundary_compressed = is_boundary * num_compressed_per_doc
-    cum_compressed = paddle.cumsum(boundary_compressed, axis=0)
-    doc_col_start = cum_compressed - num_compressed_per_doc
-
-    causal_avail = (pos_in_doc + 1) // ratio
-    num_available = paddle.minimum(causal_avail, num_compressed_per_doc)
-
-    range_start = doc_col_start
-    range_end = doc_col_start + num_available
-
-    zero_mask = (num_available == 0) | (~is_valid)
-    range_start = paddle.where(
-        zero_mask, paddle.zeros_like(range_start), range_start
-    )
-    range_end = paddle.where(zero_mask, paddle.zeros_like(range_end), range_end)
-
-    result = paddle.stack([range_start, range_end], axis=-1).cast("int32")
-    return result.unsqueeze(0)
+    return get_or_build_csa_docmask_meta(
+        ratio=ratio,
+        batch_size=batch_size,
+        seqlen=seqlen,
+        startend_row_indices=startend_row_indices,
+        docmask_meta=docmask_meta,
+    ).valid_range
 
 
 def _build_compressed_causal_mask(
@@ -302,6 +679,7 @@ def _build_compressed_causal_mask(
     seqlen: int,
     n_compressed: int,
     startend_row_indices: Tensor | None = None,
+    docmask_meta: CSADocMaskMetadata | None = None,
 ) -> Tensor:
     """Build causal mask for compressed attention: [b, seqlen, n_compressed].
 
@@ -326,58 +704,14 @@ def _build_compressed_causal_mask(
             paddle.zeros([1], dtype="float32"),
         )
 
-    # Document-aware mask: use valid_range logic
-    mask = startend_row_indices.flatten().cast("int64")
-    positions = paddle.arange(seqlen, dtype="int64")
-
-    is_boundary = paddle.zeros([seqlen], dtype="int64")
-    is_boundary[0] = 1
-    is_boundary[1:] = (
-        (positions[1:] == mask[:-1]) & (mask[1:] != mask[:-1])
-    ).cast("int64")
-
-    start_marker = is_boundary * positions
-    doc_start = paddle.cummax(start_marker, axis=0).values
-
-    pos_in_doc = positions - doc_start
-    doc_len = mask - doc_start
-    is_valid = pos_in_doc < doc_len
-
-    cutoff_doc_len = (doc_len // ratio) * ratio
-    num_compressed_per_doc = cutoff_doc_len // ratio
-
-    boundary_compressed = is_boundary * num_compressed_per_doc
-    cum_compressed = paddle.cumsum(boundary_compressed, axis=0)
-    doc_col_start = cum_compressed - num_compressed_per_doc
-
-    causal_avail = (pos_in_doc + 1) // ratio
-    num_available = paddle.minimum(causal_avail, num_compressed_per_doc)
-
-    range_start = doc_col_start  # [seqlen]
-    range_end = doc_col_start + num_available  # [seqlen]
-
-    # Zero out for padding/invalid positions
-    zero_mask = (num_available == 0) | (~is_valid)
-    range_start = paddle.where(
-        zero_mask, paddle.zeros_like(range_start), range_start
-    )
-    range_end = paddle.where(zero_mask, paddle.zeros_like(range_end), range_end)
-
-    # Build 2D mask: [seqlen, n_compressed]
-    c_grid = paddle.arange(n_compressed, dtype="int64").unsqueeze(
-        0
-    )  # [1, n_compressed]
-    lower = range_start.unsqueeze(1)  # [seqlen, 1]
-    upper = range_end.unsqueeze(1)  # [seqlen, 1]
-
-    valid_mask = (c_grid >= lower) & (c_grid < upper)  # [seqlen, n_compressed]
-    invalid = ~valid_mask
-    invalid = invalid.unsqueeze(0).expand([batch_size, seqlen, n_compressed])
-    return paddle.where(
-        invalid,
-        paddle.full([1], float("-inf"), dtype="float32"),
-        paddle.zeros([1], dtype="float32"),
-    )
+    return get_or_build_csa_docmask_meta(
+        ratio=ratio,
+        batch_size=batch_size,
+        seqlen=seqlen,
+        startend_row_indices=startend_row_indices,
+        docmask_meta=docmask_meta,
+        n_compressed=n_compressed,
+    ).get_compressed_causal_mask()
 
 
 def compact_kv_score_cutoff(
@@ -1041,9 +1375,8 @@ class Compressor(nn.Layer):
             # should not use previous group data
             # is_first[0] is always True (handled by skipping group 0 above),
             # so we only need to handle is_first[1:] for groups 1..n_groups-1
-            boundary_mask = is_first[1:]  # [n_groups - 1]
-            if boundary_mask.any():
-                # Expand to [b, n_groups-1, ratio, d] broadcast shape
+            if n_groups > 1:
+                boundary_mask = is_first[1:]  # [n_groups - 1]
                 bm = boundary_mask.reshape([1, -1, 1, 1])
                 new_tensor[:, 1:, :ratio, :] = paddle.where(
                     bm,
@@ -1057,6 +1390,7 @@ class Compressor(nn.Layer):
         x: Tensor,
         startend_row_indices: Tensor | None = None,
         cp_group=None,
+        docmask_meta: CSADocMaskMetadata | None = None,
     ) -> Tensor | None:
         """Compress hidden states into shorter KV sequence.
 
@@ -1092,20 +1426,25 @@ class Compressor(nn.Layer):
         # Shared compression logic for both CP and non-CP paths.
         if startend_row_indices is not None:
             # per-document cutoff, pack contiguously without padding
-            doc_lens = get_doc_lens(startend_row_indices)
-            doc_starts = get_doc_starts(doc_lens)
-
-            doc_lens_cutoff = get_cutoff_doc_lens(doc_lens, ratio)
-            doc_starts_cutoff = get_cutoff_doc_starts(doc_lens_cutoff)
+            docmask_meta = get_or_build_csa_docmask_meta(
+                ratio=ratio,
+                batch_size=b,
+                seqlen=sq,
+                startend_row_indices=startend_row_indices,
+                docmask_meta=docmask_meta,
+            )
+            doc_lens = docmask_meta.doc_lens
+            doc_starts = docmask_meta.doc_starts
+            doc_lens_cutoff = docmask_meta.doc_lens_cutoff
+            doc_starts_cutoff = docmask_meta.doc_starts_cutoff
 
             assert len(doc_lens) == len(doc_starts)
             assert len(doc_lens) == len(doc_lens_cutoff)
             assert len(doc_lens) == len(doc_starts_cutoff)
 
             n_compressed = sq // ratio
-            total_cutoff = int(doc_lens_cutoff.sum().item())
-            actual_n_compressed = total_cutoff // ratio
-            coff_head_dim = kv.shape[-1]
+            actual_n_compressed = docmask_meta.actual_n_compressed
+            total_cutoff = actual_n_compressed * ratio
 
             # Pack only valid cutoff data contiguously (no padding)
             kv, score = compact_kv_score_cutoff(
@@ -1127,11 +1466,7 @@ class Compressor(nn.Layer):
             score = score + ape
 
             if self.overlap:
-                # Build is_first mask for document boundaries
-                is_first = paddle.zeros([actual_n_compressed], dtype="bool")
-                is_first_indices = doc_starts_cutoff // ratio
-                is_first_indices_valid = is_first_indices < actual_n_compressed
-                is_first[is_first_indices[is_first_indices_valid]] = True
+                is_first = docmask_meta.get_is_first_compressed_group()
                 kv = self._overlap_transform(
                     kv, fill_value=0, is_first=is_first
                 )
@@ -1334,6 +1669,7 @@ class CSAIndexer(nn.Layer):
         startend_row_indices: Tensor | None = None,
         position_offset: int = 0,
         cp_group=None,
+        docmask_meta: CSADocMaskMetadata | None = None,
     ) -> tuple[Tensor, Tensor, Tensor]:
         """Compute Q, compressed K, and weights before top-k selection.
 
@@ -1341,11 +1677,11 @@ class CSAIndexer(nn.Layer):
         compressor so that indexer K is computed over the full global sequence.
         """
         b, sq, _ = x.shape
-        doc_lens = (
-            get_doc_lens(startend_row_indices)
-            if startend_row_indices is not None
-            else None
-        )
+        if is_csa_docmask_meta_reuse_disabled():
+            docmask_meta = None
+        doc_lens = docmask_meta.doc_lens if docmask_meta is not None else None
+        if doc_lens is None and startend_row_indices is not None:
+            doc_lens = get_doc_lens(startend_row_indices)
         # Q path
         q, _ = self.linear_wq_b(qr)  # [b, sq, n_heads * head_dim]
         q = q.reshape([b, sq, self.index_n_heads, self.index_head_dim])
@@ -1372,6 +1708,7 @@ class CSAIndexer(nn.Layer):
             x,
             startend_row_indices=startend_row_indices,
             cp_group=cp_group,
+            docmask_meta=docmask_meta,
         )  # [b, n_compressed, index_head_dim]
 
         # Weights
@@ -1386,6 +1723,7 @@ class CSAIndexer(nn.Layer):
         qr: Tensor,
         startend_row_indices: Tensor | None = None,
         mask: Tensor | None = None,
+        docmask_meta: CSADocMaskMetadata | None = None,
     ) -> tuple[Tensor, Tensor]:
         """Return (index_scores, topk_indices).
 
@@ -1399,7 +1737,9 @@ class CSAIndexer(nn.Layer):
             index_scores: [b, sq, n_compressed]
             topk_indices: [b, sq, topk]
         """
-        q, k, weights = self.forward_before_topk(x, qr, startend_row_indices)
+        q, k, weights = self.forward_before_topk(
+            x, qr, startend_row_indices, docmask_meta=docmask_meta
+        )
         effective_topk = min(self.index_topk, k.shape[1])
         weights = (
             weights * self.softmax_scale
@@ -1459,13 +1799,15 @@ class CompressedSparseAttention(FleetLayer):
         if is_mtp_layer:
             self.layer_number += self.config.num_hidden_layers + 1
         self.pg_collection = pg_collection
-        self.tp_group = (
-            pg_collection.tp
-            if pg_collection is not None
-            and pg_collection.tp is not None
-            and getattr(pg_collection.tp, "nranks", 1) > 1
-            else None
-        )
+        tp_size = int(getattr(config, "tensor_model_parallel_size", 1))
+        if pg_collection is not None and pg_collection.tp is not None:
+            tp_size = max(tp_size, int(getattr(pg_collection.tp, "nranks", 1)))
+        if tp_size > 1:
+            raise NotImplementedError(
+                "CompressedSparseAttention does not support tensor parallelism "
+                f"> 1, got tp={tp_size}."
+            )
+        self.tp_group = None
         self.compress_ratio = compress_ratio
         self.window_size = config.csa_window_size
         self.v_head_dim = config.v_head_dim
@@ -1528,6 +1870,7 @@ class CompressedSparseAttention(FleetLayer):
         startend_row_indices: Tensor | None = None,
         loss_mask: Tensor | None = None,
         global_valid_count: float | None = None,
+        docmask_meta: CSADocMaskMetadata | None = None,
     ) -> tuple[Tensor, Tensor | None, tuple | None]:
         """Build indexer-selected compressed KV indices and loss state."""
         b, sq, np_heads, _ = query.shape
@@ -1568,13 +1911,14 @@ class CompressedSparseAttention(FleetLayer):
             sq,
             n_compressed,
             startend_row_indices,
+            docmask_meta=docmask_meta,
         )
-
         valid_range = get_valid_range(
             int(self.compress_ratio),
             b,
             sq,
             startend_row_indices,
+            docmask_meta=docmask_meta,
         )
 
         def compute_fused_indexer_loss(backend: str):
@@ -1586,7 +1930,10 @@ class CompressedSparseAttention(FleetLayer):
             )
             q_indexer_bf, k_indexer_bf, weights_indexer_bf = (
                 self.indexer.forward_before_topk(
-                    x_det, qr_det, startend_row_indices
+                    x_det,
+                    qr_det,
+                    startend_row_indices,
+                    docmask_meta=docmask_meta,
                 )
             )
             key_comp_mla = compressed_kv.detach()
@@ -1650,7 +1997,10 @@ class CompressedSparseAttention(FleetLayer):
                 with paddle.no_grad():
                     q_indexer_cu, k_indexer_cu, weights_indexer_cu = (
                         self.indexer.forward_before_topk(
-                            x_det, qr_det, startend_row_indices
+                            x_det,
+                            qr_det,
+                            startend_row_indices,
+                            docmask_meta=docmask_meta,
                         )
                     )
                     cu_topk_indices, _cu_topk_length = cudnn_indexer_topk_fwd(
@@ -1677,7 +2027,10 @@ class CompressedSparseAttention(FleetLayer):
                 with paddle.no_grad():
                     q_indexer_tl, k_indexer_tl, weights_indexer_tl = (
                         self.indexer.forward_before_topk(
-                            x_det, qr_det, startend_row_indices
+                            x_det,
+                            qr_det,
+                            startend_row_indices,
+                            docmask_meta=docmask_meta,
                         )
                     )
                     tl_topk_indices, _tl_topk_scores = csa_indexer_topk_fwd(
@@ -1696,7 +2049,10 @@ class CompressedSparseAttention(FleetLayer):
             if need_indexer_loss:  # Grad-enabled recompute forward; compute Paddle indexer loss and top-k.
                 q_indexer, k_indexer, weights_indexer = (
                     self.indexer.forward_before_topk(
-                        x_det, qr_det, startend_row_indices
+                        x_det,
+                        qr_det,
+                        startend_row_indices,
+                        docmask_meta=docmask_meta,
                     )
                 )
                 indexer_loss_coeff = getattr(
@@ -1740,6 +2096,7 @@ class CompressedSparseAttention(FleetLayer):
                     qr_det,
                     startend_row_indices,
                     mask=causal_mask,
+                    docmask_meta=docmask_meta,
                 )
 
         if (
@@ -1768,6 +2125,7 @@ class CompressedSparseAttention(FleetLayer):
         x: Tensor = None,
         qr: Tensor = None,
         input_ids: Tensor | None = None,
+        docmask_meta: CSADocMaskMetadata | None = None,
     ) -> Tensor:
         """Forward pass for CompressedSparseAttention.
 
@@ -1836,13 +2194,28 @@ class CompressedSparseAttention(FleetLayer):
                 startend_row_indices,
                 loss_mask=loss_mask,
                 global_valid_count=global_valid_count,
+                docmask_meta=docmask_meta,
             )
 
-        if startend_row_indices is not None and self.compress_ratio > 1:
-            doc_lens = get_doc_lens(startend_row_indices)
-            doc_lens_cutoff = get_cutoff_doc_lens(doc_lens, self.compress_ratio)
-            total_cutoff = int(doc_lens_cutoff.sum().item())
-            actual_n_compressed = total_cutoff // self.compress_ratio
+        reuse_docmask_meta = not is_csa_docmask_meta_reuse_disabled()
+        if (
+            startend_row_indices is not None
+            and self.compress_ratio > 1
+            and reuse_docmask_meta
+        ):
+            docmask_meta = get_or_build_csa_docmask_meta(
+                ratio=self.compress_ratio,
+                batch_size=b,
+                seqlen=sq,
+                startend_row_indices=startend_row_indices,
+                docmask_meta=docmask_meta,
+            )
+            actual_n_compressed = docmask_meta.actual_n_compressed
+        elif startend_row_indices is not None and self.compress_ratio > 1:
+            docmask_meta = None
+            actual_n_compressed = _get_actual_n_compressed_from_docmask(
+                self.compress_ratio, startend_row_indices
+            )
         elif self.compress_ratio > 1:
             actual_n_compressed = sq // self.compress_ratio
         else:
@@ -1858,7 +2231,9 @@ class CompressedSparseAttention(FleetLayer):
             and actual_n_compressed > 0
         ):
             compressed_kv = self.compressor(
-                x, startend_row_indices
+                x,
+                startend_row_indices,
+                docmask_meta=docmask_meta,
             )  # [b, n_compressed, v_head_dim]
             if compressed_kv is not None:
                 kv_full = paddle.concat([kv, compressed_kv], axis=1)
@@ -1874,7 +2249,11 @@ class CompressedSparseAttention(FleetLayer):
 
         # Step 3: Window indices
         window_idxs = get_window_topk_idxs(
-            self.window_size, b, sq, startend_row_indices
+            self.window_size,
+            b,
+            sq,
+            startend_row_indices,
+            docmask_meta=docmask_meta,
         )
 
         # Step 4: Compressed indices
@@ -1901,6 +2280,7 @@ class CompressedSparseAttention(FleetLayer):
                     startend_row_indices,
                     loss_mask=loss_mask,
                     global_valid_count=global_valid_count,
+                    docmask_meta=docmask_meta,
                 )
             else:
                 # ratio=128: attend to all compressed positions
@@ -1910,6 +2290,7 @@ class CompressedSparseAttention(FleetLayer):
                     sq,
                     offset,
                     startend_row_indices,
+                    docmask_meta=docmask_meta,
                 )
 
             if compress_topk_idxs.dtype != window_idxs.dtype:
@@ -1951,6 +2332,7 @@ class CompressedSparseAttention(FleetLayer):
         startend_row_indices: Tensor | None = None,
         loss_mask: Tensor | None = None,
         global_valid_count: float | None = None,
+        docmask_meta: CSADocMaskMetadata | None = None,
     ) -> Tensor:
         """CP-aware forward: local compress + all-gather, sparse attention.
 
@@ -1972,6 +2354,21 @@ class CompressedSparseAttention(FleetLayer):
         q_positions = paddle.arange(
             position_offset, position_offset + sq, dtype="int64"
         )
+        reuse_docmask_meta = not is_csa_docmask_meta_reuse_disabled()
+        if (
+            startend_row_indices is not None
+            and self.compress_ratio > 1
+            and reuse_docmask_meta
+        ):
+            docmask_meta = get_or_build_csa_docmask_meta(
+                ratio=self.compress_ratio,
+                batch_size=b,
+                seqlen=sq_global,
+                startend_row_indices=startend_row_indices,
+                docmask_meta=docmask_meta,
+            )
+        elif startend_row_indices is not None and self.compress_ratio > 1:
+            docmask_meta = None
 
         # Step 1: Window topk (CP-aware: uses global q_positions)
         if startend_row_indices is None:
@@ -1980,7 +2377,11 @@ class CompressedSparseAttention(FleetLayer):
             )
         else:
             full_window_idxs = get_window_topk_idxs(
-                self.window_size, b, sq_global, startend_row_indices
+                self.window_size,
+                b,
+                sq_global,
+                startend_row_indices,
+                docmask_meta=docmask_meta,
             )
             window_idxs = full_window_idxs[
                 :, position_offset : position_offset + sq, ...
@@ -2005,10 +2406,12 @@ class CompressedSparseAttention(FleetLayer):
 
         # Compute actual_n_compressed accounting for document boundaries
         if startend_row_indices is not None and self.compress_ratio > 1:
-            doc_lens = get_doc_lens(startend_row_indices)
-            doc_lens_cutoff = get_cutoff_doc_lens(doc_lens, self.compress_ratio)
-            total_cutoff = int(doc_lens_cutoff.sum().item())
-            actual_n_compressed = total_cutoff // self.compress_ratio
+            if docmask_meta is not None:
+                actual_n_compressed = docmask_meta.actual_n_compressed
+            else:
+                actual_n_compressed = _get_actual_n_compressed_from_docmask(
+                    self.compress_ratio, startend_row_indices
+                )
         elif self.compress_ratio > 1:
             actual_n_compressed = n_compressed_global
         else:
@@ -2027,6 +2430,7 @@ class CompressedSparseAttention(FleetLayer):
                 x,
                 startend_row_indices=startend_row_indices,
                 cp_group=self.cp_group,
+                docmask_meta=docmask_meta,
             )
             kv_full = paddle.concat([kv_global, compressed_kv_global], axis=1)
         else:
@@ -2066,11 +2470,15 @@ class CompressedSparseAttention(FleetLayer):
 
                 # valid_range for varlen: [b, sq_local, 2] or None
                 if startend_row_indices is not None:
-                    valid_range_full = get_valid_range(
-                        int(self.compress_ratio),
-                        b,
-                        sq_global,
-                        startend_row_indices,
+                    valid_range_full = (
+                        docmask_meta.valid_range
+                        if docmask_meta is not None
+                        else get_valid_range(
+                            int(self.compress_ratio),
+                            b,
+                            sq_global,
+                            startend_row_indices,
+                        )
                     )
                     valid_range = valid_range_full[
                         :, position_offset : position_offset + sq, :
@@ -2085,6 +2493,7 @@ class CompressedSparseAttention(FleetLayer):
                         startend_row_indices=startend_row_indices,
                         position_offset=position_offset,
                         cp_group=self.cp_group,
+                        docmask_meta=docmask_meta,
                     )
                 )
 
@@ -2162,12 +2571,16 @@ class CompressedSparseAttention(FleetLayer):
                             b,
                         )
                     else:
-                        causal_mask_full = _build_compressed_causal_mask(
-                            self.compress_ratio,
-                            b,
-                            sq_global,
-                            n_compressed_global,
-                            startend_row_indices,
+                        causal_mask_full = (
+                            docmask_meta.get_compressed_causal_mask()
+                            if docmask_meta is not None
+                            else _build_compressed_causal_mask(
+                                self.compress_ratio,
+                                b,
+                                sq_global,
+                                n_compressed_global,
+                                startend_row_indices,
+                            )
                         )
                         causal_mask = causal_mask_full[
                             :, position_offset : position_offset + sq, ...
@@ -2219,12 +2632,16 @@ class CompressedSparseAttention(FleetLayer):
                             b,
                         )
                     else:
-                        causal_mask_full = _build_compressed_causal_mask(
-                            self.compress_ratio,
-                            b,
-                            sq_global,
-                            n_compressed_global,
-                            startend_row_indices,
+                        causal_mask_full = (
+                            docmask_meta.get_compressed_causal_mask()
+                            if docmask_meta is not None
+                            else _build_compressed_causal_mask(
+                                self.compress_ratio,
+                                b,
+                                sq_global,
+                                n_compressed_global,
+                                startend_row_indices,
+                            )
                         )
                         causal_mask = causal_mask_full[
                             :, position_offset : position_offset + sq, ...
@@ -2280,12 +2697,16 @@ class CompressedSparseAttention(FleetLayer):
                         n_compressed_global,
                     )
                 else:
-                    compress_topk_idxs = get_compress_topk_idxs(
-                        self.compress_ratio,
-                        b,
-                        sq_global,
-                        offset,
-                        startend_row_indices,
+                    compress_topk_idxs = (
+                        docmask_meta.get_compress_topk_idxs(offset)
+                        if docmask_meta is not None
+                        else get_compress_topk_idxs(
+                            self.compress_ratio,
+                            b,
+                            sq_global,
+                            offset,
+                            startend_row_indices,
+                        )
                     )
                     compress_topk_idxs = compress_topk_idxs[
                         :, position_offset : position_offset + sq, ...

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -51,9 +51,6 @@ from paddlefleet.transformer.dsa_attention import (
     fused_qk_topk_naive,
     rotate_activation,
 )
-from paddlefleet.transformer.utils import (
-    get_doc_lens,
-)
 
 if TYPE_CHECKING:
     from paddlefleet.process_groups_config import ProcessGroupCollection
@@ -504,6 +501,9 @@ def get_compress_topk_idxs(
     """
     n_compressed = seqlen // ratio
 
+    if docmask_meta is not None:
+        return docmask_meta.get_compress_topk_idxs(offset)
+
     if startend_row_indices is None:
         # Original simple causal logic
         k_indices = paddle.arange(n_compressed)
@@ -515,10 +515,9 @@ def get_compress_topk_idxs(
         )
         return matrix.unsqueeze(0).expand([batch_size, -1, -1])
 
-    if docmask_meta is None:
-        docmask_meta = CSADocMaskMetadata.build(
-            ratio, batch_size, seqlen, startend_row_indices, n_compressed
-        )
+    docmask_meta = CSADocMaskMetadata.build(
+        ratio, batch_size, seqlen, startend_row_indices, n_compressed
+    )
     return docmask_meta.get_compress_topk_idxs(offset)
 
 
@@ -536,6 +535,9 @@ def get_window_topk_idxs(
 
     When startend_row_indices is None, uses simple causal sliding window.
     """
+    if docmask_meta is not None:
+        return docmask_meta.get_window_topk_idxs(window_size)
+
     if startend_row_indices is None:
         # Original simple sliding-window logic
         base = paddle.arange(seqlen).unsqueeze(1)  # [seqlen, 1]
@@ -546,25 +548,9 @@ def get_window_topk_idxs(
         )
         return matrix.unsqueeze(0).expand([batch_size, -1, -1])
 
-    if docmask_meta is None:
-        _, batch_size, seqlen, _ = _normalize_csa_docmask_args(
-            1, batch_size, seqlen, seqlen
-        )
-        _validate_csa_docmask_shape(startend_row_indices, batch_size, seqlen)
-        (
-            doc_start_per_pos,
-            _doc_len_per_pos,
-            is_valid,
-            _doc_lens,
-            _doc_starts,
-        ) = _derive_csa_doc_boundaries(startend_row_indices, seqlen)
-        return _build_window_topk_idxs_from_doc_bounds(
-            batch_size=batch_size,
-            seqlen=seqlen,
-            window_size=window_size,
-            doc_start_per_pos=doc_start_per_pos,
-            is_valid=is_valid,
-        )
+    docmask_meta = CSADocMaskMetadata.build(
+        1, batch_size, seqlen, startend_row_indices, seqlen
+    )
     return docmask_meta.get_window_topk_idxs(window_size)
 
 
@@ -581,12 +567,13 @@ def get_valid_range(
     startend_row_indices is not provided (causal-only mode, let the
     downstream kernel build its own valid range).
     """
+    if docmask_meta is not None:
+        return docmask_meta.valid_range
     if startend_row_indices is None:
         return None
-    if docmask_meta is None:
-        docmask_meta = CSADocMaskMetadata.build(
-            ratio, batch_size, seqlen, startend_row_indices
-        )
+    docmask_meta = CSADocMaskMetadata.build(
+        ratio, batch_size, seqlen, startend_row_indices
+    )
     return docmask_meta.valid_range
 
 
@@ -607,6 +594,9 @@ def _build_compressed_causal_mask(
     Returns:
         mask: [b, seqlen, n_compressed] float32, 0 for valid, -inf for invalid.
     """
+    if docmask_meta is not None:
+        return docmask_meta.get_compressed_causal_mask()
+
     if startend_row_indices is None:
         # Simple causal-only mask
         compressed_ids = paddle.arange(n_compressed).unsqueeze(0)
@@ -621,10 +611,9 @@ def _build_compressed_causal_mask(
             paddle.zeros([1], dtype="float32"),
         )
 
-    if docmask_meta is None:
-        docmask_meta = CSADocMaskMetadata.build(
-            ratio, batch_size, seqlen, startend_row_indices, n_compressed
-        )
+    docmask_meta = CSADocMaskMetadata.build(
+        ratio, batch_size, seqlen, startend_row_indices, n_compressed
+    )
     return docmask_meta.get_compressed_causal_mask()
 
 
@@ -1302,7 +1291,6 @@ class Compressor(nn.Layer):
     def forward(
         self,
         x: Tensor,
-        startend_row_indices: Tensor | None = None,
         cp_group=None,
         docmask_meta: CSADocMaskMetadata | None = None,
     ) -> Tensor | None:
@@ -1310,9 +1298,8 @@ class Compressor(nn.Layer):
 
         Args:
             x: [b, sq, hidden_size]
-            startend_row_indices: [batch_size, h, seqlen, 1] tensor for
-                varlen document boundaries, or None for simple causal mode.
             cp_group: CP process group.
+            docmask_meta: document-mask metadata, or None for simple causal mode.
 
         Returns:
             compressed_kv: [b, sq // ratio, head_dim] or None if too short.
@@ -1338,9 +1325,8 @@ class Compressor(nn.Layer):
             b, sq, _ = kv.shape
 
         # Shared compression logic for both CP and non-CP paths.
-        if startend_row_indices is not None:
+        if docmask_meta is not None:
             # per-document cutoff, pack contiguously without padding
-            assert docmask_meta is not None
             doc_lens = docmask_meta.doc_lens
             doc_starts = docmask_meta.doc_starts
             doc_lens_cutoff = docmask_meta.doc_lens_cutoff
@@ -1574,7 +1560,6 @@ class CSAIndexer(nn.Layer):
         self,
         x: Tensor,  # [b, sq, hidden_size]
         qr: Tensor,  # [b, sq, q_lora_rank]
-        startend_row_indices: Tensor | None = None,
         position_offset: int = 0,
         cp_group=None,
         docmask_meta: CSADocMaskMetadata | None = None,
@@ -1586,8 +1571,6 @@ class CSAIndexer(nn.Layer):
         """
         b, sq, _ = x.shape
         doc_lens = docmask_meta.doc_lens if docmask_meta is not None else None
-        if doc_lens is None and startend_row_indices is not None:
-            doc_lens = get_doc_lens(startend_row_indices)
         # Q path
         q, _ = self.linear_wq_b(qr)  # [b, sq, n_heads * head_dim]
         q = q.reshape([b, sq, self.index_n_heads, self.index_head_dim])
@@ -1612,7 +1595,6 @@ class CSAIndexer(nn.Layer):
         # K path: own compressor (already applies RoPE and rotation internally)
         k = self.compressor(
             x,
-            startend_row_indices=startend_row_indices,
             cp_group=cp_group,
             docmask_meta=docmask_meta,
         )  # [b, n_compressed, index_head_dim]
@@ -1627,7 +1609,6 @@ class CSAIndexer(nn.Layer):
         self,
         x: Tensor,
         qr: Tensor,
-        startend_row_indices: Tensor | None = None,
         mask: Tensor | None = None,
         docmask_meta: CSADocMaskMetadata | None = None,
     ) -> tuple[Tensor, Tensor]:
@@ -1636,7 +1617,6 @@ class CSAIndexer(nn.Layer):
         Args:
             x: [b, sq, hidden_size]
             qr: [b, sq, q_lora_rank]
-            startend_row_indices: document boundary tensor, or None
             mask: [b, sq, n_compressed] optional causal mask
 
         Returns:
@@ -1644,7 +1624,7 @@ class CSAIndexer(nn.Layer):
             topk_indices: [b, sq, topk]
         """
         q, k, weights = self.forward_before_topk(
-            x, qr, startend_row_indices, docmask_meta=docmask_meta
+            x, qr, docmask_meta=docmask_meta
         )
         effective_topk = min(self.index_topk, k.shape[1])
         weights = (
@@ -1773,7 +1753,6 @@ class CompressedSparseAttention(FleetLayer):
         compressed_kv: Tensor,
         n_compressed: int,
         offset: int,
-        startend_row_indices: Tensor | None = None,
         loss_mask: Tensor | None = None,
         global_valid_count: float | None = None,
         docmask_meta: CSADocMaskMetadata | None = None,
@@ -1816,14 +1795,12 @@ class CompressedSparseAttention(FleetLayer):
             b,
             sq,
             n_compressed,
-            startend_row_indices,
             docmask_meta=docmask_meta,
         )
         valid_range = get_valid_range(
             int(self.compress_ratio),
             b,
             sq,
-            startend_row_indices,
             docmask_meta=docmask_meta,
         )
 
@@ -1838,7 +1815,6 @@ class CompressedSparseAttention(FleetLayer):
                 self.indexer.forward_before_topk(
                     x_det,
                     qr_det,
-                    startend_row_indices,
                     docmask_meta=docmask_meta,
                 )
             )
@@ -1905,7 +1881,6 @@ class CompressedSparseAttention(FleetLayer):
                         self.indexer.forward_before_topk(
                             x_det,
                             qr_det,
-                            startend_row_indices,
                             docmask_meta=docmask_meta,
                         )
                     )
@@ -1935,7 +1910,6 @@ class CompressedSparseAttention(FleetLayer):
                         self.indexer.forward_before_topk(
                             x_det,
                             qr_det,
-                            startend_row_indices,
                             docmask_meta=docmask_meta,
                         )
                     )
@@ -1957,7 +1931,6 @@ class CompressedSparseAttention(FleetLayer):
                     self.indexer.forward_before_topk(
                         x_det,
                         qr_det,
-                        startend_row_indices,
                         docmask_meta=docmask_meta,
                     )
                 )
@@ -2000,7 +1973,6 @@ class CompressedSparseAttention(FleetLayer):
                 _, topk_indices_compressed = self.indexer(
                     x_det,
                     qr_det,
-                    startend_row_indices,
                     mask=causal_mask,
                     docmask_meta=docmask_meta,
                 )
@@ -2026,7 +1998,6 @@ class CompressedSparseAttention(FleetLayer):
         query: Tensor,
         key: Tensor,
         value: Tensor,
-        startend_row_indices: Tensor | None = None,
         attention_mask: Tensor | None = None,
         x: Tensor = None,
         qr: Tensor = None,
@@ -2048,14 +2019,10 @@ class CompressedSparseAttention(FleetLayer):
         """
         b, sq, np_heads, hn = query.shape
 
-        if startend_row_indices is not None:
+        if docmask_meta is not None:
             assert b == 1, (
-                "when startend_row_indices is not None, ",
+                "when docmask_meta is not None, ",
                 f"only support batch_size == 1, current batch_size: {b}",
-            )
-            assert docmask_meta is not None, (
-                "docmask_meta must be built by DSv4HybridAttention.forward "
-                "when startend_row_indices is not None"
             )
 
         # Compute loss_mask from input_ids (mask out padding tokens)
@@ -2101,14 +2068,12 @@ class CompressedSparseAttention(FleetLayer):
                 key,
                 x,
                 qr,
-                startend_row_indices,
                 loss_mask=loss_mask,
                 global_valid_count=global_valid_count,
                 docmask_meta=docmask_meta,
             )
 
-        if startend_row_indices is not None and self.compress_ratio > 1:
-            assert docmask_meta is not None
+        if docmask_meta is not None and self.compress_ratio > 1:
             actual_n_compressed = docmask_meta.actual_n_compressed
         elif self.compress_ratio > 1:
             actual_n_compressed = sq // self.compress_ratio
@@ -2126,7 +2091,6 @@ class CompressedSparseAttention(FleetLayer):
         ):
             compressed_kv = self.compressor(
                 x,
-                startend_row_indices,
                 docmask_meta=docmask_meta,
             )  # [b, n_compressed, v_head_dim]
             if compressed_kv is not None:
@@ -2146,7 +2110,6 @@ class CompressedSparseAttention(FleetLayer):
             self.window_size,
             b,
             sq,
-            startend_row_indices,
             docmask_meta=docmask_meta,
         )
 
@@ -2171,7 +2134,6 @@ class CompressedSparseAttention(FleetLayer):
                     compressed_kv,
                     n_compressed,
                     offset,
-                    startend_row_indices,
                     loss_mask=loss_mask,
                     global_valid_count=global_valid_count,
                     docmask_meta=docmask_meta,
@@ -2183,7 +2145,6 @@ class CompressedSparseAttention(FleetLayer):
                     b,
                     sq,
                     offset,
-                    startend_row_indices,
                     docmask_meta=docmask_meta,
                 )
 
@@ -2223,7 +2184,6 @@ class CompressedSparseAttention(FleetLayer):
         key: Tensor,
         x: Tensor,
         qr: Tensor,
-        startend_row_indices: Tensor | None = None,
         loss_mask: Tensor | None = None,
         global_valid_count: float | None = None,
         docmask_meta: CSADocMaskMetadata | None = None,
@@ -2248,11 +2208,8 @@ class CompressedSparseAttention(FleetLayer):
         q_positions = paddle.arange(
             position_offset, position_offset + sq, dtype="int64"
         )
-        if startend_row_indices is not None and self.compress_ratio > 1:
-            assert docmask_meta is not None
-
         # Step 1: Window topk (CP-aware: uses global q_positions)
-        if startend_row_indices is None:
+        if docmask_meta is None:
             window_idxs = get_window_topk_idxs_cp(
                 q_positions, self.window_size, b, sq_global
             )
@@ -2261,7 +2218,6 @@ class CompressedSparseAttention(FleetLayer):
                 self.window_size,
                 b,
                 sq_global,
-                startend_row_indices,
                 docmask_meta=docmask_meta,
             )
             window_idxs = full_window_idxs[
@@ -2286,7 +2242,7 @@ class CompressedSparseAttention(FleetLayer):
         n_compressed_global = n_compressed_local * self.cp_size
 
         # Compute actual_n_compressed accounting for document boundaries
-        if startend_row_indices is not None and self.compress_ratio > 1:
+        if docmask_meta is not None and self.compress_ratio > 1:
             actual_n_compressed = docmask_meta.actual_n_compressed
         elif self.compress_ratio > 1:
             actual_n_compressed = n_compressed_global
@@ -2304,7 +2260,6 @@ class CompressedSparseAttention(FleetLayer):
             # inside the compressor, we will all-gather all the compressed KV
             compressed_kv_global = self.compressor(
                 x,
-                startend_row_indices=startend_row_indices,
                 cp_group=self.cp_group,
                 docmask_meta=docmask_meta,
             )
@@ -2345,18 +2300,8 @@ class CompressedSparseAttention(FleetLayer):
                 )
 
                 # valid_range for varlen: [b, sq_local, 2] or None
-                if startend_row_indices is not None:
-                    valid_range_full = (
-                        docmask_meta.valid_range
-                        if docmask_meta is not None
-                        else get_valid_range(
-                            int(self.compress_ratio),
-                            b,
-                            sq_global,
-                            startend_row_indices,
-                        )
-                    )
-                    valid_range = valid_range_full[
+                if docmask_meta is not None:
+                    valid_range = docmask_meta.valid_range[
                         :, position_offset : position_offset + sq, :
                     ]
                 else:
@@ -2366,7 +2311,6 @@ class CompressedSparseAttention(FleetLayer):
                     self.indexer.forward_before_topk(
                         x_det,
                         qr_det,
-                        startend_row_indices=startend_row_indices,
                         position_offset=position_offset,
                         cp_group=self.cp_group,
                         docmask_meta=docmask_meta,
@@ -2439,7 +2383,7 @@ class CompressedSparseAttention(FleetLayer):
                         .expand([-1, -1, np_heads, -1])
                     )
 
-                    if startend_row_indices is None:
+                    if docmask_meta is None:
                         causal_mask = build_causal_mask_cp(
                             q_positions,
                             n_compressed_global,
@@ -2449,14 +2393,6 @@ class CompressedSparseAttention(FleetLayer):
                     else:
                         causal_mask_full = (
                             docmask_meta.get_compressed_causal_mask()
-                            if docmask_meta is not None
-                            else _build_compressed_causal_mask(
-                                self.compress_ratio,
-                                b,
-                                sq_global,
-                                n_compressed_global,
-                                startend_row_indices,
-                            )
                         )
                         causal_mask = causal_mask_full[
                             :, position_offset : position_offset + sq, ...
@@ -2500,7 +2436,7 @@ class CompressedSparseAttention(FleetLayer):
 
                 elif not use_tilelang_indexer:  # CP eval/no-grad forward with unfused backend; only materialize attention top-k.
                     # Inference-only Paddle topk (use already-gathered global K)
-                    if startend_row_indices is None:
+                    if docmask_meta is None:
                         causal_mask = build_causal_mask_cp(
                             q_positions,
                             n_compressed_global,
@@ -2510,14 +2446,6 @@ class CompressedSparseAttention(FleetLayer):
                     else:
                         causal_mask_full = (
                             docmask_meta.get_compressed_causal_mask()
-                            if docmask_meta is not None
-                            else _build_compressed_causal_mask(
-                                self.compress_ratio,
-                                b,
-                                sq_global,
-                                n_compressed_global,
-                                startend_row_indices,
-                            )
                         )
                         causal_mask = causal_mask_full[
                             :, position_offset : position_offset + sq, ...
@@ -2564,7 +2492,7 @@ class CompressedSparseAttention(FleetLayer):
                 )
             else:
                 # HCA path: attend to all compressed positions
-                if startend_row_indices is None:
+                if docmask_meta is None:
                     compress_topk_idxs = get_compress_topk_idxs_cp(
                         q_positions,
                         self.compress_ratio,
@@ -2573,16 +2501,8 @@ class CompressedSparseAttention(FleetLayer):
                         n_compressed_global,
                     )
                 else:
-                    compress_topk_idxs = (
-                        docmask_meta.get_compress_topk_idxs(offset)
-                        if docmask_meta is not None
-                        else get_compress_topk_idxs(
-                            self.compress_ratio,
-                            b,
-                            sq_global,
-                            offset,
-                            startend_row_indices,
-                        )
+                    compress_topk_idxs = docmask_meta.get_compress_topk_idxs(
+                        offset
                     )
                     compress_topk_idxs = compress_topk_idxs[
                         :, position_offset : position_offset + sq, ...

--- a/src/paddlefleet/transformer/dsv4_hybrid_attention.py
+++ b/src/paddlefleet/transformer/dsv4_hybrid_attention.py
@@ -43,6 +43,11 @@ from paddlefleet.models.common.embeddings.yarn_rotary_pos_embedding import (
     YarnRotaryEmbedding,
 )
 from paddlefleet.transformer.attention import Attention
+from paddlefleet.transformer.csa_attention import (
+    CSADocMaskMetadata,
+    get_or_build_csa_docmask_meta,
+    is_csa_docmask_meta_reuse_disabled,
+)
 
 if TYPE_CHECKING:
     from paddlefleet.process_groups_config import ProcessGroupCollection
@@ -63,16 +68,38 @@ from paddlefleet.transformer.utils import (
 def build_document_rope_freqs(
     rotary_pos_emb: nn.Layer,
     sq: int,
-    startend_row_indices: Tensor,
+    startend_row_indices: Tensor | None = None,
     position_offset: int = 0,
+    doc_lens: Tensor | None = None,
 ):
-    """Build RoPE frequencies that restart from zero for each document."""
-    assert (
-        startend_row_indices.shape[0] == 1
-        and startend_row_indices.shape[1] == 1
-    ), "Document RoPE currently expects batch_size == 1 and head == 1."
+    """Build RoPE frequencies that restart from zero for each document.
 
-    doc_lens = get_doc_lens(startend_row_indices)
+    Args:
+        rotary_pos_emb: the layer's RotaryEmbedding / YarnRotaryEmbedding.
+        sq: local query sequence length.
+        startend_row_indices: optional ``[1, 1, seqlen, 1]`` document
+            boundary tensor. Required only when ``doc_lens`` is not provided.
+        position_offset: global position offset for CP (``cp_rank * sq``);
+            the returned freqs cover ``[0, position_offset + sq)`` and are
+            sliced by the caller.
+        doc_lens: optional precomputed document lengths (e.g. from
+            ``CSADocMaskMetadata.doc_lens``) to avoid recomputing them from
+            ``startend_row_indices``.
+
+    Returns:
+        (freqs, mscale): ``freqs`` is ``[1, position_offset + sq, 1, head_dim]``
+        and ``mscale`` is the YaRN mscale (DSv4 forces it to 1.0 downstream).
+    """
+    if doc_lens is None:
+        assert startend_row_indices is not None, (
+            "Document RoPE requires startend_row_indices when doc_lens is not provided."
+        )
+        assert (
+            startend_row_indices.shape[0] == 1
+            and startend_row_indices.shape[1] == 1
+        ), "Document RoPE currently expects batch_size == 1 and head == 1."
+        doc_lens = get_doc_lens(startend_row_indices)
+
     max_doc_len = int(doc_lens.max().item())
     _rope_result = rotary_pos_emb(max_doc_len, packed_seq=False)
     if isinstance(_rope_result, tuple):
@@ -278,14 +305,32 @@ class DSv4HybridAttention(Attention):
             if cp_pg is not None and cp_size > 1
             else 0
         )
-        _, sq, _ = hidden_states.shape
+        b, sq, _ = hidden_states.shape
         position_offset = cp_rank * sq if cp_size > 1 else 0
+
+        docmask_meta = None
+        ratio = int(getattr(self.core_attention, "compress_ratio", 0))
+        if (
+            startend_row_indices is not None
+            and not is_csa_docmask_meta_reuse_disabled()
+        ):
+            docmask_seqlen = sq * cp_size if cp_size > 1 else sq
+            docmask_meta = get_or_build_csa_docmask_meta(
+                ratio=max(1, ratio),
+                batch_size=b,
+                seqlen=docmask_seqlen,
+                startend_row_indices=startend_row_indices,
+                docmask_meta=docmask_meta,
+            )
+        else:
+            docmask_meta = None
 
         query, key, value, q_compressed, kv_compressed = (
             self.get_query_key_value_tensors(
                 hidden_states=hidden_states,
                 startend_row_indices=startend_row_indices,
                 position_offset=position_offset,
+                docmask_meta=docmask_meta,
             )
         )
 
@@ -299,7 +344,8 @@ class DSv4HybridAttention(Attention):
             attention_mask,
             x=hidden_states,
             qr=q_compressed,
-            input_ids=kwargs.get("input_ids", None),
+            input_ids=input_ids,
+            docmask_meta=docmask_meta,
         )
         # core_attn_out: [b, sq, np * v_head_dim]
 
@@ -313,11 +359,18 @@ class DSv4HybridAttention(Attention):
                 [b, sq, self.num_attention_heads, self.v_head_dim]
             )
             # Get RoPE frequencies for inverse
-            if startend_row_indices is not None:
+            if docmask_meta is not None:
                 freqs, mscale = build_document_rope_freqs(
                     self.rotary_pos_emb,
                     sq,
-                    startend_row_indices,
+                    position_offset=position_offset,
+                    doc_lens=docmask_meta.doc_lens,
+                )
+            elif startend_row_indices is not None:
+                freqs, mscale = build_document_rope_freqs(
+                    self.rotary_pos_emb,
+                    sq,
+                    startend_row_indices=startend_row_indices,
                     position_offset=position_offset,
                 )
             else:
@@ -377,7 +430,11 @@ class DSv4HybridAttention(Attention):
         return output, bias
 
     def get_query_key_value_tensors(
-        self, hidden_states: Tensor, startend_row_indices: Tensor | None = None
+        self,
+        hidden_states: Tensor,
+        startend_row_indices: Tensor | None = None,
+        position_offset: int = 0,
+        docmask_meta: CSADocMaskMetadata | None = None,
     ):
         """Override in subclass."""
         raise NotImplementedError
@@ -482,14 +539,19 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
         hidden_states: Tensor,
         startend_row_indices: Tensor | None = None,
         position_offset: int = 0,
+        docmask_meta: CSADocMaskMetadata | None = None,
     ) -> tuple[Tensor, Tensor, Tensor, Tensor, Tensor]:
         """Derive query, key, value from hidden_states.
 
         Args:
             hidden_states: [b, sq, hidden_size]
+            startend_row_indices: document boundary tensor, or None.
             position_offset: global position offset for CP (cp_rank * sq_local).
                 When non-zero, RoPE frequencies are sliced from the correct
                 global starting position.
+            docmask_meta: optional :class:`CSADocMaskMetadata` carrying
+                precomputed ``doc_lens`` so document RoPE frequencies can be
+                built without rescanning ``startend_row_indices``.
 
         Returns:
             query: [b, sq, num_heads, v_head_dim]
@@ -520,11 +582,18 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
 
         if pos_dim > 0:
             # Get RoPE frequencies
-            if startend_row_indices is not None:
+            if docmask_meta is not None:
                 freqs, mscale = build_document_rope_freqs(
                     self.rotary_pos_emb,
                     sq,
-                    startend_row_indices,
+                    position_offset=position_offset,
+                    doc_lens=docmask_meta.doc_lens,
+                )
+            elif startend_row_indices is not None:
+                freqs, mscale = build_document_rope_freqs(
+                    self.rotary_pos_emb,
+                    sq,
+                    startend_row_indices=startend_row_indices,
                     position_offset=position_offset,
                 )
             else:

--- a/src/paddlefleet/transformer/dsv4_hybrid_attention.py
+++ b/src/paddlefleet/transformer/dsv4_hybrid_attention.py
@@ -45,7 +45,6 @@ from paddlefleet.models.common.embeddings.yarn_rotary_pos_embedding import (
 from paddlefleet.transformer.attention import Attention
 from paddlefleet.transformer.csa_attention import (
     CSADocMaskMetadata,
-    get_or_build_csa_docmask_meta,
 )
 
 if TYPE_CHECKING:
@@ -311,12 +310,11 @@ class DSv4HybridAttention(Attention):
         ratio = int(getattr(self.core_attention, "compress_ratio", 0))
         if startend_row_indices is not None:
             docmask_seqlen = sq * cp_size if cp_size > 1 else sq
-            docmask_meta = get_or_build_csa_docmask_meta(
-                ratio=max(1, ratio),
-                batch_size=b,
-                seqlen=docmask_seqlen,
-                startend_row_indices=startend_row_indices,
-                docmask_meta=docmask_meta,
+            docmask_meta = CSADocMaskMetadata.build(
+                max(1, ratio),
+                b,
+                docmask_seqlen,
+                startend_row_indices,
             )
 
         query, key, value, q_compressed, kv_compressed = (

--- a/src/paddlefleet/transformer/dsv4_hybrid_attention.py
+++ b/src/paddlefleet/transformer/dsv4_hybrid_attention.py
@@ -46,7 +46,6 @@ from paddlefleet.transformer.attention import Attention
 from paddlefleet.transformer.csa_attention import (
     CSADocMaskMetadata,
     get_or_build_csa_docmask_meta,
-    is_csa_docmask_meta_reuse_disabled,
 )
 
 if TYPE_CHECKING:
@@ -310,10 +309,7 @@ class DSv4HybridAttention(Attention):
 
         docmask_meta = None
         ratio = int(getattr(self.core_attention, "compress_ratio", 0))
-        if (
-            startend_row_indices is not None
-            and not is_csa_docmask_meta_reuse_disabled()
-        ):
+        if startend_row_indices is not None:
             docmask_seqlen = sq * cp_size if cp_size > 1 else sq
             docmask_meta = get_or_build_csa_docmask_meta(
                 ratio=max(1, ratio),
@@ -322,8 +318,6 @@ class DSv4HybridAttention(Attention):
                 startend_row_indices=startend_row_indices,
                 docmask_meta=docmask_meta,
             )
-        else:
-            docmask_meta = None
 
         query, key, value, q_compressed, kv_compressed = (
             self.get_query_key_value_tensors(

--- a/src/paddlefleet/transformer/dsv4_hybrid_attention.py
+++ b/src/paddlefleet/transformer/dsv4_hybrid_attention.py
@@ -123,6 +123,36 @@ def build_document_rope_freqs(
     return freqs.reshape([1, -1, 1, freqs.shape[-1]]), mscale
 
 
+def _build_rope_freqs(
+    rotary_pos_emb: nn.Layer,
+    sq: int,
+    position_offset: int = 0,
+    docmask_meta: CSADocMaskMetadata | None = None,
+    startend_row_indices: Tensor | None = None,
+):
+    if docmask_meta is not None:
+        freqs, mscale = build_document_rope_freqs(
+            rotary_pos_emb,
+            sq,
+            position_offset=position_offset,
+            doc_lens=docmask_meta.doc_lens,
+        )
+    elif startend_row_indices is not None:
+        freqs, mscale = build_document_rope_freqs(
+            rotary_pos_emb,
+            sq,
+            startend_row_indices=startend_row_indices,
+            position_offset=position_offset,
+        )
+    else:
+        _rope_result = rotary_pos_emb(sq + position_offset, packed_seq=False)
+        if isinstance(_rope_result, tuple):
+            freqs, mscale = _rope_result
+        else:
+            freqs, mscale = _rope_result, 1.0
+    return freqs[:, position_offset : position_offset + sq, :], mscale
+
+
 # ---------------------------------------------------------------------------
 # Sublayers spec dataclass
 # ---------------------------------------------------------------------------
@@ -320,7 +350,6 @@ class DSv4HybridAttention(Attention):
         query, key, value, q_compressed, kv_compressed = (
             self.get_query_key_value_tensors(
                 hidden_states=hidden_states,
-                startend_row_indices=startend_row_indices,
                 position_offset=position_offset,
                 docmask_meta=docmask_meta,
             )
@@ -332,7 +361,6 @@ class DSv4HybridAttention(Attention):
             query,
             key,
             value,
-            startend_row_indices,
             attention_mask,
             x=hidden_states,
             qr=q_compressed,
@@ -350,32 +378,14 @@ class DSv4HybridAttention(Attention):
             core_attn_out = core_attn_out.reshape(
                 [b, sq, self.num_attention_heads, self.v_head_dim]
             )
-            # Get RoPE frequencies for inverse
-            if docmask_meta is not None:
-                freqs, mscale = build_document_rope_freqs(
-                    self.rotary_pos_emb,
-                    sq,
-                    position_offset=position_offset,
-                    doc_lens=docmask_meta.doc_lens,
-                )
-            elif startend_row_indices is not None:
-                freqs, mscale = build_document_rope_freqs(
-                    self.rotary_pos_emb,
-                    sq,
-                    startend_row_indices=startend_row_indices,
-                    position_offset=position_offset,
-                )
-            else:
-                # Get RoPE frequencies for inverse; use global positions in CP mode
-                rope_len = sq + position_offset
-                _rope_result = self.rotary_pos_emb(rope_len, packed_seq=False)
-                if isinstance(_rope_result, tuple):
-                    freqs, mscale = _rope_result
-                else:
-                    freqs, mscale = _rope_result, 1.0
+            freqs, mscale = _build_rope_freqs(
+                self.rotary_pos_emb,
+                sq,
+                position_offset=position_offset,
+                docmask_meta=docmask_meta,
+            )
             # DSv4 reference uses pure norm-preserving RoPE; YaRN's mscale is not applied.
             mscale = 1.0
-            freqs = freqs[:, position_offset : position_offset + sq, :]
 
             if self.config.apply_rope_fusion:
                 from paddlefleet.triton_ops import fused_apply_mla_rope_inplace
@@ -573,33 +583,15 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
         nope_dim = self.v_head_dim - pos_dim
 
         if pos_dim > 0:
-            # Get RoPE frequencies
-            if docmask_meta is not None:
-                freqs, mscale = build_document_rope_freqs(
-                    self.rotary_pos_emb,
-                    sq,
-                    position_offset=position_offset,
-                    doc_lens=docmask_meta.doc_lens,
-                )
-            elif startend_row_indices is not None:
-                freqs, mscale = build_document_rope_freqs(
-                    self.rotary_pos_emb,
-                    sq,
-                    startend_row_indices=startend_row_indices,
-                    position_offset=position_offset,
-                )
-            else:
-                # Get RoPE frequencies for global positions
-                rope_len = sq + position_offset
-                _rope_result = self.rotary_pos_emb(rope_len, packed_seq=False)
-                if isinstance(_rope_result, tuple):
-                    freqs, mscale = _rope_result
-                else:
-                    freqs, mscale = _rope_result, 1.0
+            freqs, mscale = _build_rope_freqs(
+                self.rotary_pos_emb,
+                sq,
+                position_offset=position_offset,
+                docmask_meta=docmask_meta,
+                startend_row_indices=startend_row_indices,
+            )
             # DSv4 reference uses pure norm-preserving RoPE; YaRN's mscale is not applied.
             mscale = 1.0
-            # Slice to local positions [position_offset : position_offset + sq]
-            freqs = freqs[:, position_offset : position_offset + sq, :]
 
             # Q RoPE: split nope/pe, apply RoPE to pe part
             if self.config.apply_rope_fusion:

--- a/tests/single_card_tests/transformer/test_dsv4_hybrid_attention.py
+++ b/tests/single_card_tests/transformer/test_dsv4_hybrid_attention.py
@@ -1,5 +1,4 @@
 # Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
-# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,6 +13,7 @@
 # limitations under the License.
 
 import unittest
+from unittest.mock import patch
 
 import paddle
 from paddle.distributed.fleet.meta_parallel import build_spec_layer
@@ -34,10 +34,15 @@ from paddlefleet.models.gpt.gpt_layer_specs import (
 from paddlefleet.tensor_parallel.random import model_parallel_cuda_manual_seed
 from paddlefleet.transformer.csa_attention import (
     CompressedSparseAttention,
+    CompressedSparseAttentionSublayersSpec,
+    CSADocMaskMetadata,
     _apply_rope,
+    _build_compressed_causal_mask,
     _resolve_csa_indexer_attn_topk_effective,
     _resolve_csa_indexer_loss_topk_effective,
     get_compress_topk_idxs,
+    get_or_build_csa_docmask_meta,
+    get_valid_range,
     get_window_topk_idxs,
 )
 from paddlefleet.transformer.dsa_attention import (
@@ -51,6 +56,30 @@ from paddlefleet.transformer.enums import AttnMaskType
 from paddlefleet.transformer.transformer_config import TransformerConfig
 
 _SEED = 42
+
+
+class _FakeGroup:
+    def __init__(self, nranks=1):
+        self.nranks = nranks
+        self.ranks = list(range(nranks))
+        self.rank = 0
+
+
+class _FakePGCollection:
+    def __init__(self, tp_nranks=1, cp_nranks=1):
+        self.tp = _FakeGroup(tp_nranks)
+        self.cp = _FakeGroup(cp_nranks)
+
+
+def _make_startend_row_indices(doc_lens, seqlen):
+    values = []
+    doc_end = 0
+    for doc_len in doc_lens:
+        doc_end += doc_len
+        values.extend([doc_end] * doc_len)
+    if len(values) < seqlen:
+        values.extend([doc_end] * (seqlen - len(values)))
+    return paddle.to_tensor(values, dtype="int32").reshape([1, 1, seqlen, 1])
 
 
 def _make_config(
@@ -204,6 +233,37 @@ class TestDSv4HybridConfigAndSpec(unittest.TestCase):
                 setattr(cfg, attr, True)
                 cfg.__post_init__()
 
+    def test_csa_rejects_tensor_parallelism(self):
+        config = _make_config(num_layers=1, csa_compress_ratios=[4])
+        with self.assertRaisesRegex(
+            NotImplementedError,
+            "got tp=2",
+        ):
+            CompressedSparseAttention(
+                config=config,
+                sublayers_spec=CompressedSparseAttentionSublayersSpec(),
+                layer_number=0,
+                attn_mask_type=AttnMaskType.causal,
+                attention_type="self",
+                pg_collection=_FakePGCollection(tp_nranks=2),
+                compress_ratio=4,
+            )
+
+        config = _make_config(num_layers=1, csa_compress_ratios=[4])
+        config.tensor_model_parallel_size = 2
+        with self.assertRaisesRegex(
+            NotImplementedError,
+            "got tp=2",
+        ):
+            CompressedSparseAttention(
+                config=config,
+                sublayers_spec=CompressedSparseAttentionSublayersSpec(),
+                layer_number=0,
+                attn_mask_type=AttnMaskType.causal,
+                attention_type="self",
+                compress_ratio=4,
+            )
+
     def test_phase2_loss_topk_does_not_expand_attention_topk(self):
         config = _make_config(
             dsa_index_topk=2,
@@ -281,7 +341,271 @@ class TestCSAIndexHelpers(unittest.TestCase):
         self.assertEqual(topk_indices.numpy().tolist()[0][0][0], 0)
 
 
+class TestCSADocMaskMetadata(unittest.TestCase):
+    def _make_docmask(self):
+        return paddle.to_tensor(
+            [5, 5, 5, 5, 5, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12],
+            dtype="int32",
+        ).reshape([1, 1, 16, 1])
+
+    def test_metadata_matches_expected_docmask_outputs(self):
+        ratio = 4
+        batch_size = 1
+        seqlen = 16
+        startend_row_indices = self._make_docmask()
+        meta = CSADocMaskMetadata.build(
+            ratio, batch_size, seqlen, startend_row_indices
+        )
+
+        self.assertIsNotNone(meta)
+        self.assertEqual(meta.actual_n_compressed, 2)
+        self.assertEqual(meta.doc_lens.numpy().tolist(), [5, 7])
+        self.assertEqual(meta.doc_starts.numpy().tolist(), [0, 5])
+        self.assertEqual(meta.doc_lens_cutoff.numpy().tolist(), [4, 4])
+        self.assertEqual(meta.doc_starts_cutoff.numpy().tolist(), [0, 4])
+        self.assertEqual(
+            meta.valid_range.numpy().tolist(),
+            [
+                [
+                    [0, 0],
+                    [0, 0],
+                    [0, 0],
+                    [0, 1],
+                    [0, 1],
+                    [0, 0],
+                    [0, 0],
+                    [0, 0],
+                    [1, 2],
+                    [1, 2],
+                    [1, 2],
+                    [1, 2],
+                    [0, 0],
+                    [0, 0],
+                    [0, 0],
+                    [0, 0],
+                ]
+            ],
+        )
+        self.assertEqual(
+            meta.get_window_topk_idxs(3).numpy().tolist(),
+            [
+                [
+                    [0, -1, -1],
+                    [0, 1, -1],
+                    [0, 1, 2],
+                    [1, 2, 3],
+                    [2, 3, 4],
+                    [5, -1, -1],
+                    [5, 6, -1],
+                    [5, 6, 7],
+                    [6, 7, 8],
+                    [7, 8, 9],
+                    [8, 9, 10],
+                    [9, 10, 11],
+                    [-1, -1, -1],
+                    [-1, -1, -1],
+                    [-1, -1, -1],
+                    [-1, -1, -1],
+                ]
+            ],
+        )
+        self.assertEqual(
+            meta.get_compress_topk_idxs(offset=16).numpy().tolist(),
+            [
+                [
+                    [-1, -1, -1, -1],
+                    [-1, -1, -1, -1],
+                    [-1, -1, -1, -1],
+                    [16, -1, -1, -1],
+                    [16, -1, -1, -1],
+                    [-1, -1, -1, -1],
+                    [-1, -1, -1, -1],
+                    [-1, -1, -1, -1],
+                    [-1, 17, -1, -1],
+                    [-1, 17, -1, -1],
+                    [-1, 17, -1, -1],
+                    [-1, 17, -1, -1],
+                    [-1, -1, -1, -1],
+                    [-1, -1, -1, -1],
+                    [-1, -1, -1, -1],
+                    [-1, -1, -1, -1],
+                ]
+            ],
+        )
+        causal_mask = meta.get_compressed_causal_mask()
+        self.assertTrue(paddle.isinf(causal_mask[:, :3, :]).all().item())
+        self.assertEqual(
+            causal_mask[0, 3, :].numpy().tolist(),
+            [0.0, -float("inf"), -float("inf"), -float("inf")],
+        )
+        self.assertEqual(
+            causal_mask[0, 8, :].numpy().tolist(),
+            [-float("inf"), 0.0, -float("inf"), -float("inf")],
+        )
+        self.assertTrue(paddle.isinf(causal_mask[:, 12:, :]).all().item())
+        self.assertEqual(
+            meta.get_is_first_compressed_group().numpy().tolist(),
+            [True, True],
+        )
+
+    def test_metadata_handles_three_docs_ratio_128(self):
+        ratio = 128
+        seqlen = 384
+        startend_row_indices = _make_startend_row_indices([129, 128, 1], seqlen)
+        meta = CSADocMaskMetadata.build(ratio, 1, seqlen, startend_row_indices)
+
+        self.assertEqual(meta.doc_lens.numpy().tolist(), [129, 128, 1])
+        self.assertEqual(meta.doc_starts.numpy().tolist(), [0, 129, 257])
+        self.assertEqual(meta.doc_lens_cutoff.numpy().tolist(), [128, 128, 0])
+        self.assertEqual(meta.doc_starts_cutoff.numpy().tolist(), [0, 128, 256])
+        self.assertEqual(meta.actual_n_compressed, 2)
+        self.assertEqual(
+            meta.get_is_first_compressed_group().numpy().tolist(),
+            [True, True],
+        )
+
+        valid_range = meta.valid_range.numpy().tolist()[0]
+        self.assertEqual(valid_range[126], [0, 0])
+        self.assertEqual(valid_range[127], [0, 1])
+        self.assertEqual(valid_range[128], [0, 1])
+        self.assertEqual(valid_range[129], [0, 0])
+        self.assertEqual(valid_range[256], [1, 2])
+        self.assertEqual(valid_range[257], [0, 0])
+        self.assertEqual(valid_range[-1], [0, 0])
+
+        compressed = meta.get_compress_topk_idxs(offset=seqlen)
+        self.assertEqual(compressed[0, 127, :].numpy().tolist(), [384, -1, -1])
+        self.assertEqual(compressed[0, 256, :].numpy().tolist(), [-1, 385, -1])
+        self.assertEqual(compressed[0, 257, :].numpy().tolist(), [-1, -1, -1])
+
+    def test_metadata_lazy_cache_keys_recompute_when_inputs_change(self):
+        meta = CSADocMaskMetadata.build(4, 1, 16, self._make_docmask())
+
+        window_3 = meta.get_window_topk_idxs(3)
+        self.assertIs(window_3, meta.get_window_topk_idxs(3))
+        window_5 = meta.get_window_topk_idxs(5)
+        self.assertIs(window_5, meta.get_window_topk_idxs(5))
+        self.assertIsNot(window_3, window_5)
+        self.assertTrue(
+            paddle.equal_all(
+                window_5,
+                get_window_topk_idxs(5, 1, 16, self._make_docmask()),
+            ).item()
+        )
+
+        compressed_16 = meta.get_compress_topk_idxs(offset=16)
+        self.assertIs(compressed_16, meta.get_compress_topk_idxs(offset=16))
+        compressed_32 = meta.get_compress_topk_idxs(offset=32)
+        self.assertIs(compressed_32, meta.get_compress_topk_idxs(offset=32))
+        self.assertIsNot(compressed_16, compressed_32)
+        self.assertTrue(
+            paddle.equal_all(
+                compressed_32,
+                get_compress_topk_idxs(4, 1, 16, 32, self._make_docmask()),
+            ).item()
+        )
+
+    def test_metadata_none_when_no_docmask(self):
+        self.assertIsNone(CSADocMaskMetadata.build(4, 1, 16, None))
+
+    def test_helpers_reuse_supplied_metadata(self):
+        startend_row_indices = self._make_docmask()
+        meta = CSADocMaskMetadata.build(4, 1, 16, startend_row_indices)
+
+        window = get_window_topk_idxs(
+            3, 1, 16, startend_row_indices, docmask_meta=meta
+        )
+        compressed = get_compress_topk_idxs(
+            4, 1, 16, 16, startend_row_indices, docmask_meta=meta
+        )
+        valid_range = get_valid_range(
+            4, 1, 16, startend_row_indices, docmask_meta=meta
+        )
+        causal_mask = _build_compressed_causal_mask(
+            4, 1, 16, 4, startend_row_indices, docmask_meta=meta
+        )
+
+        self.assertIs(window, meta.get_window_topk_idxs(3))
+        self.assertIs(compressed, meta.get_compress_topk_idxs(16))
+        self.assertIs(valid_range, meta.valid_range)
+        self.assertIs(causal_mask, meta.get_compressed_causal_mask())
+
+    def test_metadata_rejects_inconsistent_shape(self):
+        with self.assertRaisesRegex(ValueError, "startend_row_indices"):
+            CSADocMaskMetadata.build(4, 1, 8, self._make_docmask())
+
+    def test_metadata_match_rejects_unregistered_same_shape_mask(self):
+        meta = CSADocMaskMetadata.build(4, 1, 16, self._make_docmask())
+        different_startend_row_indices = paddle.to_tensor(
+            [8] * 8 + [16] * 8, dtype="int32"
+        ).reshape([1, 1, 16, 1])
+
+        self.assertFalse(
+            meta.matches(
+                4,
+                1,
+                16,
+                different_startend_row_indices,
+            )
+        )
+
+    def test_get_or_build_reuses_only_matching_metadata(self):
+        startend_row_indices = self._make_docmask()
+        meta_ratio_4 = get_or_build_csa_docmask_meta(
+            4, 1, 16, startend_row_indices
+        )
+        reused = get_or_build_csa_docmask_meta(
+            4, 1, 16, startend_row_indices, docmask_meta=meta_ratio_4
+        )
+        meta_ratio_8 = get_or_build_csa_docmask_meta(
+            8, 1, 16, startend_row_indices, docmask_meta=meta_ratio_4
+        )
+
+        self.assertIs(reused, meta_ratio_4)
+        self.assertIsNot(meta_ratio_8, meta_ratio_4)
+        self.assertEqual(meta_ratio_8.ratio, 8)
+
+
 class TestDSv4HybridDocumentRoPE(unittest.TestCase):
+    def test_document_rope_freqs_reuses_supplied_doc_lens(self):
+        config = _make_config(rope_type="yarn")
+        rotary_pos_emb = YarnRotaryEmbedding(
+            config.qk_pos_emb_head_dim,
+            rotary_base=config.csa_compress_rotary_base,
+            scaling_factor=getattr(config, "rotary_scaling_factor", 40),
+            original_max_position_embeddings=getattr(
+                config, "original_max_position_embeddings", 4096
+            ),
+            beta_fast=getattr(config, "beta_fast", 32),
+            beta_slow=getattr(config, "beta_slow", 1),
+            mscale=getattr(config, "mscale", 1.0),
+            mscale_all_dim=getattr(config, "mscale_all_dim", 0.0),
+        )
+        startend_row_indices = paddle.to_tensor(
+            [4, 4, 4, 4, 8, 8, 8, 8], dtype="int32"
+        ).reshape([1, 1, 8, 1])
+        doc_lens = paddle.to_tensor([4, 4], dtype="int32")
+
+        freqs_from_meta, mscale_from_meta = build_document_rope_freqs(
+            rotary_pos_emb,
+            8,
+            startend_row_indices,
+            doc_lens=doc_lens,
+        )
+        freqs_from_mask, mscale_from_mask = build_document_rope_freqs(
+            rotary_pos_emb,
+            8,
+            startend_row_indices,
+        )
+
+        self.assertEqual(mscale_from_meta, mscale_from_mask)
+        self.assertTrue(
+            paddle.equal_all(
+                freqs_from_meta.cast("float32"),
+                freqs_from_mask.cast("float32"),
+            ).item()
+        )
+
     def test_document_rope_freqs_with_position_offset_pads_to_local_slice(self):
         config = _make_config(rope_type="yarn")
         rotary_pos_emb = YarnRotaryEmbedding(
@@ -743,6 +1067,198 @@ class TestDSv4HybridDocumentRoPE(unittest.TestCase):
                         doc2_out.cast("float32"),
                     ).item()
                 )
+
+    def test_attention_top_level_metadata_reuse_matches_recompute_bitwise(self):
+        test_cases = [
+            (0, 64, [17, 23, 11]),
+            (4, 64, [17, 23, 11]),
+            (128, 256, [129, 80, 40]),
+        ]
+        for ratio, seq_len, doc_lens in test_cases:
+            with self.subTest(ratio=ratio, doc_lens=doc_lens):
+                paddle.seed(_SEED)
+                config = _make_config(
+                    hidden_size=64,
+                    num_attention_heads=2,
+                    v_head_dim=32,
+                    q_lora_rank=32,
+                    o_groups=2,
+                    o_lora_rank=16,
+                    csa_window_size=32,
+                    dsa_indexer_loss_coeff=0.0,
+                    csa_compress_ratios=[ratio],
+                    num_layers=1,
+                    csa_indexer_backend="unfused",
+                    csa_sparse_attn_backend="unfused",
+                )
+                model_parallel_cuda_manual_seed(_SEED)
+                reuse_attn = _build_attention(config, layer_number=0)
+                model_parallel_cuda_manual_seed(_SEED)
+                recompute_attn = _build_attention(config, layer_number=0)
+                recompute_attn.set_state_dict(reuse_attn.state_dict())
+                reuse_attn.eval()
+                recompute_attn.eval()
+
+                hidden = paddle.randn(
+                    [1, seq_len, config.hidden_size], dtype="bfloat16"
+                )
+                startend_row_indices = _make_startend_row_indices(
+                    doc_lens, seq_len
+                )
+
+                with paddle.no_grad():
+                    with patch.dict(
+                        "os.environ",
+                        {"CSA_DISABLE_DOCMASK_META_REUSE": "0"},
+                    ):
+                        reuse_out, _ = reuse_attn(
+                            hidden_states=hidden,
+                            attention_mask=None,
+                            attn_mask_startend_row_indices=startend_row_indices,
+                        )
+                    with patch.dict(
+                        "os.environ",
+                        {"CSA_DISABLE_DOCMASK_META_REUSE": "1"},
+                    ):
+                        recompute_out, _ = recompute_attn(
+                            hidden_states=hidden.clone(),
+                            attention_mask=None,
+                            attn_mask_startend_row_indices=startend_row_indices,
+                        )
+
+                self.assertTrue(
+                    paddle.equal_all(
+                        reuse_out.cast("float32"),
+                        recompute_out.cast("float32"),
+                    ).item()
+                )
+
+    def test_attention_metadata_reuse_matches_recompute_backward_bitwise(self):
+        test_cases = [
+            (0, 64, [17, 23, 11]),
+            (4, 64, [17, 23, 11]),
+            (128, 256, [129, 80, 40]),
+        ]
+        for ratio, seq_len, doc_lens in test_cases:
+            with self.subTest(ratio=ratio, doc_lens=doc_lens):
+                paddle.seed(_SEED)
+                config = _make_config(
+                    hidden_size=64,
+                    num_attention_heads=2,
+                    v_head_dim=32,
+                    q_lora_rank=32,
+                    o_groups=2,
+                    o_lora_rank=16,
+                    csa_window_size=32,
+                    dsa_indexer_loss_coeff=0.0,
+                    csa_compress_ratios=[ratio],
+                    num_layers=1,
+                    csa_indexer_backend="unfused",
+                    csa_sparse_attn_backend="unfused",
+                )
+                model_parallel_cuda_manual_seed(_SEED)
+                reuse_attn = _build_attention(config, layer_number=0)
+                model_parallel_cuda_manual_seed(_SEED)
+                recompute_attn = _build_attention(config, layer_number=0)
+                recompute_attn.set_state_dict(reuse_attn.state_dict())
+                reuse_attn.train()
+                recompute_attn.train()
+
+                hidden = paddle.randn(
+                    [1, seq_len, config.hidden_size], dtype="bfloat16"
+                )
+                grad = paddle.randn(
+                    [1, seq_len, config.hidden_size], dtype="bfloat16"
+                )
+                startend_row_indices = _make_startend_row_indices(
+                    doc_lens, seq_len
+                )
+
+                reuse_hidden = hidden.clone()
+                recompute_hidden = hidden.clone()
+                reuse_hidden.stop_gradient = False
+                recompute_hidden.stop_gradient = False
+
+                with patch.dict(
+                    "os.environ", {"CSA_DISABLE_DOCMASK_META_REUSE": "0"}
+                ):
+                    reuse_out, _ = reuse_attn(
+                        hidden_states=reuse_hidden,
+                        attention_mask=None,
+                        attn_mask_startend_row_indices=startend_row_indices,
+                    )
+                    reuse_out.backward(grad)
+                with patch.dict(
+                    "os.environ", {"CSA_DISABLE_DOCMASK_META_REUSE": "1"}
+                ):
+                    recompute_out, _ = recompute_attn(
+                        hidden_states=recompute_hidden,
+                        attention_mask=None,
+                        attn_mask_startend_row_indices=startend_row_indices,
+                    )
+                    recompute_out.backward(grad)
+
+                self.assertTrue(
+                    paddle.equal_all(
+                        reuse_out.cast("float32"),
+                        recompute_out.cast("float32"),
+                    ).item()
+                )
+                self.assertTrue(
+                    paddle.equal_all(
+                        reuse_hidden.grad.cast("float32"),
+                        recompute_hidden.grad.cast("float32"),
+                    ).item()
+                )
+
+                reuse_params = dict(reuse_attn.named_parameters())
+                for name, recompute_param in recompute_attn.named_parameters():
+                    if recompute_param.grad is None:
+                        self.assertIsNone(reuse_params[name].grad, name)
+                        continue
+                    self.assertIsNotNone(reuse_params[name].grad, name)
+                    self.assertTrue(
+                        paddle.equal_all(
+                            reuse_params[name].grad.cast("float32"),
+                            recompute_param.grad.cast("float32"),
+                        ).item(),
+                        name,
+                    )
+
+    def test_top_level_builds_ratio_one_metadata_for_window_only_docmask(self):
+        paddle.seed(_SEED)
+        config = _make_config(
+            hidden_size=64,
+            num_attention_heads=2,
+            v_head_dim=32,
+            q_lora_rank=32,
+            o_groups=2,
+            o_lora_rank=16,
+            csa_compress_ratios=[0],
+            num_layers=1,
+            csa_indexer_backend="unfused",
+            csa_sparse_attn_backend="unfused",
+        )
+        attn = _build_attention(config, layer_number=0)
+        attn.eval()
+        hidden = paddle.randn([1, 32, config.hidden_size], dtype="bfloat16")
+        startend_row_indices = _make_startend_row_indices([17, 11], 32)
+
+        with (
+            patch(
+                "paddlefleet.transformer.dsv4_hybrid_attention.get_or_build_csa_docmask_meta",
+                wraps=get_or_build_csa_docmask_meta,
+            ) as mocked,
+            paddle.no_grad(),
+        ):
+            attn(
+                hidden_states=hidden,
+                attention_mask=None,
+                attn_mask_startend_row_indices=startend_row_indices,
+            )
+
+        self.assertGreaterEqual(mocked.call_count, 1)
+        self.assertEqual(mocked.call_args_list[0].kwargs["ratio"], 1)
 
 
 class TestDSv4HybridAttentionConstructor(unittest.TestCase):

--- a/tests/single_card_tests/transformer/test_dsv4_hybrid_attention.py
+++ b/tests/single_card_tests/transformer/test_dsv4_hybrid_attention.py
@@ -41,7 +41,6 @@ from paddlefleet.transformer.csa_attention import (
     _resolve_csa_indexer_attn_topk_effective,
     _resolve_csa_indexer_loss_topk_effective,
     get_compress_topk_idxs,
-    get_or_build_csa_docmask_meta,
     get_valid_range,
     get_window_topk_idxs,
 )
@@ -533,37 +532,6 @@ class TestCSADocMaskMetadata(unittest.TestCase):
     def test_metadata_rejects_inconsistent_shape(self):
         with self.assertRaisesRegex(ValueError, "startend_row_indices"):
             CSADocMaskMetadata.build(4, 1, 8, self._make_docmask())
-
-    def test_metadata_match_rejects_unregistered_same_shape_mask(self):
-        meta = CSADocMaskMetadata.build(4, 1, 16, self._make_docmask())
-        different_startend_row_indices = paddle.to_tensor(
-            [8] * 8 + [16] * 8, dtype="int32"
-        ).reshape([1, 1, 16, 1])
-
-        self.assertFalse(
-            meta.matches(
-                4,
-                1,
-                16,
-                different_startend_row_indices,
-            )
-        )
-
-    def test_get_or_build_reuses_only_matching_metadata(self):
-        startend_row_indices = self._make_docmask()
-        meta_ratio_4 = get_or_build_csa_docmask_meta(
-            4, 1, 16, startend_row_indices
-        )
-        reused = get_or_build_csa_docmask_meta(
-            4, 1, 16, startend_row_indices, docmask_meta=meta_ratio_4
-        )
-        meta_ratio_8 = get_or_build_csa_docmask_meta(
-            8, 1, 16, startend_row_indices, docmask_meta=meta_ratio_4
-        )
-
-        self.assertIs(reused, meta_ratio_4)
-        self.assertIsNot(meta_ratio_8, meta_ratio_4)
-        self.assertEqual(meta_ratio_8.ratio, 8)
 
 
 class TestDSv4HybridDocumentRoPE(unittest.TestCase):
@@ -1092,11 +1060,7 @@ class TestDSv4HybridDocumentRoPE(unittest.TestCase):
 
         with (
             patch(
-                "paddlefleet.transformer.dsv4_hybrid_attention.get_or_build_csa_docmask_meta",
-                wraps=get_or_build_csa_docmask_meta,
-            ) as top_level_get_or_build,
-            patch(
-                "paddlefleet.transformer.csa_attention.CSADocMaskMetadata.build",
+                "paddlefleet.transformer.dsv4_hybrid_attention.CSADocMaskMetadata.build",
                 wraps=CSADocMaskMetadata.build,
             ) as build_meta,
             paddle.no_grad(),
@@ -1112,7 +1076,6 @@ class TestDSv4HybridDocumentRoPE(unittest.TestCase):
                 attn_mask_startend_row_indices=startend_row_indices,
             )
 
-        self.assertGreaterEqual(top_level_get_or_build.call_count, 2)
         self.assertEqual(build_meta.call_count, 2)
         self.assertTrue(
             paddle.equal_all(
@@ -1143,8 +1106,8 @@ class TestDSv4HybridDocumentRoPE(unittest.TestCase):
 
         with (
             patch(
-                "paddlefleet.transformer.dsv4_hybrid_attention.get_or_build_csa_docmask_meta",
-                wraps=get_or_build_csa_docmask_meta,
+                "paddlefleet.transformer.dsv4_hybrid_attention.CSADocMaskMetadata.build",
+                wraps=CSADocMaskMetadata.build,
             ) as mocked,
             paddle.no_grad(),
         ):
@@ -1155,7 +1118,7 @@ class TestDSv4HybridDocumentRoPE(unittest.TestCase):
             )
 
         self.assertGreaterEqual(mocked.call_count, 1)
-        self.assertEqual(mocked.call_args_list[0].kwargs["ratio"], 1)
+        self.assertEqual(mocked.call_args_list[0].args[0], 1)
 
 
 class TestDSv4HybridAttentionConstructor(unittest.TestCase):

--- a/tests/single_card_tests/transformer/test_dsv4_hybrid_attention.py
+++ b/tests/single_card_tests/transformer/test_dsv4_hybrid_attention.py
@@ -1068,162 +1068,58 @@ class TestDSv4HybridDocumentRoPE(unittest.TestCase):
                     ).item()
                 )
 
-    def test_attention_top_level_metadata_reuse_matches_recompute_bitwise(self):
-        test_cases = [
-            (0, 64, [17, 23, 11]),
-            (4, 64, [17, 23, 11]),
-            (128, 256, [129, 80, 40]),
-        ]
-        for ratio, seq_len, doc_lens in test_cases:
-            with self.subTest(ratio=ratio, doc_lens=doc_lens):
-                paddle.seed(_SEED)
-                config = _make_config(
-                    hidden_size=64,
-                    num_attention_heads=2,
-                    v_head_dim=32,
-                    q_lora_rank=32,
-                    o_groups=2,
-                    o_lora_rank=16,
-                    csa_window_size=32,
-                    dsa_indexer_loss_coeff=0.0,
-                    csa_compress_ratios=[ratio],
-                    num_layers=1,
-                    csa_indexer_backend="unfused",
-                    csa_sparse_attn_backend="unfused",
-                )
-                model_parallel_cuda_manual_seed(_SEED)
-                reuse_attn = _build_attention(config, layer_number=0)
-                model_parallel_cuda_manual_seed(_SEED)
-                recompute_attn = _build_attention(config, layer_number=0)
-                recompute_attn.set_state_dict(reuse_attn.state_dict())
-                reuse_attn.eval()
-                recompute_attn.eval()
+    def test_attention_top_level_reuses_docmask_metadata_once(self):
+        paddle.seed(_SEED)
+        config = _make_config(
+            hidden_size=64,
+            num_attention_heads=2,
+            v_head_dim=32,
+            q_lora_rank=32,
+            o_groups=2,
+            o_lora_rank=16,
+            csa_window_size=32,
+            dsa_indexer_loss_coeff=0.0,
+            csa_compress_ratios=[4],
+            num_layers=1,
+            csa_indexer_backend="unfused",
+            csa_sparse_attn_backend="unfused",
+        )
+        model_parallel_cuda_manual_seed(_SEED)
+        attn = _build_attention(config, layer_number=0)
+        attn.eval()
+        hidden = paddle.randn([1, 64, config.hidden_size], dtype="bfloat16")
+        startend_row_indices = _make_startend_row_indices([17, 23, 11], 64)
 
-                hidden = paddle.randn(
-                    [1, seq_len, config.hidden_size], dtype="bfloat16"
-                )
-                startend_row_indices = _make_startend_row_indices(
-                    doc_lens, seq_len
-                )
+        with (
+            patch(
+                "paddlefleet.transformer.dsv4_hybrid_attention.get_or_build_csa_docmask_meta",
+                wraps=get_or_build_csa_docmask_meta,
+            ) as top_level_get_or_build,
+            patch(
+                "paddlefleet.transformer.csa_attention.CSADocMaskMetadata.build",
+                wraps=CSADocMaskMetadata.build,
+            ) as build_meta,
+            paddle.no_grad(),
+        ):
+            out_first, _ = attn(
+                hidden_states=hidden,
+                attention_mask=None,
+                attn_mask_startend_row_indices=startend_row_indices,
+            )
+            out_second, _ = attn(
+                hidden_states=hidden.clone(),
+                attention_mask=None,
+                attn_mask_startend_row_indices=startend_row_indices,
+            )
 
-                with paddle.no_grad():
-                    with patch.dict(
-                        "os.environ",
-                        {"CSA_DISABLE_DOCMASK_META_REUSE": "0"},
-                    ):
-                        reuse_out, _ = reuse_attn(
-                            hidden_states=hidden,
-                            attention_mask=None,
-                            attn_mask_startend_row_indices=startend_row_indices,
-                        )
-                    with patch.dict(
-                        "os.environ",
-                        {"CSA_DISABLE_DOCMASK_META_REUSE": "1"},
-                    ):
-                        recompute_out, _ = recompute_attn(
-                            hidden_states=hidden.clone(),
-                            attention_mask=None,
-                            attn_mask_startend_row_indices=startend_row_indices,
-                        )
-
-                self.assertTrue(
-                    paddle.equal_all(
-                        reuse_out.cast("float32"),
-                        recompute_out.cast("float32"),
-                    ).item()
-                )
-
-    def test_attention_metadata_reuse_matches_recompute_backward_bitwise(self):
-        test_cases = [
-            (0, 64, [17, 23, 11]),
-            (4, 64, [17, 23, 11]),
-            (128, 256, [129, 80, 40]),
-        ]
-        for ratio, seq_len, doc_lens in test_cases:
-            with self.subTest(ratio=ratio, doc_lens=doc_lens):
-                paddle.seed(_SEED)
-                config = _make_config(
-                    hidden_size=64,
-                    num_attention_heads=2,
-                    v_head_dim=32,
-                    q_lora_rank=32,
-                    o_groups=2,
-                    o_lora_rank=16,
-                    csa_window_size=32,
-                    dsa_indexer_loss_coeff=0.0,
-                    csa_compress_ratios=[ratio],
-                    num_layers=1,
-                    csa_indexer_backend="unfused",
-                    csa_sparse_attn_backend="unfused",
-                )
-                model_parallel_cuda_manual_seed(_SEED)
-                reuse_attn = _build_attention(config, layer_number=0)
-                model_parallel_cuda_manual_seed(_SEED)
-                recompute_attn = _build_attention(config, layer_number=0)
-                recompute_attn.set_state_dict(reuse_attn.state_dict())
-                reuse_attn.train()
-                recompute_attn.train()
-
-                hidden = paddle.randn(
-                    [1, seq_len, config.hidden_size], dtype="bfloat16"
-                )
-                grad = paddle.randn(
-                    [1, seq_len, config.hidden_size], dtype="bfloat16"
-                )
-                startend_row_indices = _make_startend_row_indices(
-                    doc_lens, seq_len
-                )
-
-                reuse_hidden = hidden.clone()
-                recompute_hidden = hidden.clone()
-                reuse_hidden.stop_gradient = False
-                recompute_hidden.stop_gradient = False
-
-                with patch.dict(
-                    "os.environ", {"CSA_DISABLE_DOCMASK_META_REUSE": "0"}
-                ):
-                    reuse_out, _ = reuse_attn(
-                        hidden_states=reuse_hidden,
-                        attention_mask=None,
-                        attn_mask_startend_row_indices=startend_row_indices,
-                    )
-                    reuse_out.backward(grad)
-                with patch.dict(
-                    "os.environ", {"CSA_DISABLE_DOCMASK_META_REUSE": "1"}
-                ):
-                    recompute_out, _ = recompute_attn(
-                        hidden_states=recompute_hidden,
-                        attention_mask=None,
-                        attn_mask_startend_row_indices=startend_row_indices,
-                    )
-                    recompute_out.backward(grad)
-
-                self.assertTrue(
-                    paddle.equal_all(
-                        reuse_out.cast("float32"),
-                        recompute_out.cast("float32"),
-                    ).item()
-                )
-                self.assertTrue(
-                    paddle.equal_all(
-                        reuse_hidden.grad.cast("float32"),
-                        recompute_hidden.grad.cast("float32"),
-                    ).item()
-                )
-
-                reuse_params = dict(reuse_attn.named_parameters())
-                for name, recompute_param in recompute_attn.named_parameters():
-                    if recompute_param.grad is None:
-                        self.assertIsNone(reuse_params[name].grad, name)
-                        continue
-                    self.assertIsNotNone(reuse_params[name].grad, name)
-                    self.assertTrue(
-                        paddle.equal_all(
-                            reuse_params[name].grad.cast("float32"),
-                            recompute_param.grad.cast("float32"),
-                        ).item(),
-                        name,
-                    )
+        self.assertGreaterEqual(top_level_get_or_build.call_count, 2)
+        self.assertEqual(build_meta.call_count, 2)
+        self.assertTrue(
+            paddle.equal_all(
+                out_first.cast("float32"),
+                out_second.cast("float32"),
+            ).item()
+        )
 
     def test_top_level_builds_ratio_one_metadata_for_window_only_docmask(self):
         paddle.seed(_SEED)
@@ -1239,6 +1135,7 @@ class TestDSv4HybridDocumentRoPE(unittest.TestCase):
             csa_indexer_backend="unfused",
             csa_sparse_attn_backend="unfused",
         )
+        model_parallel_cuda_manual_seed(_SEED)
         attn = _build_attention(config, layer_number=0)
         attn.eval()
         hidden = paddle.randn([1, 32, config.hidden_size], dtype="bfloat16")


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->
避免重复计算和 docmask 相关的 metadata. 当前版本实现的是 单个 DSv4 CSA attention layer 的一次 forward 内复用：同一层内只从 attn_mask_startend_row_indices 构建一次 docmask 派生 metadata，然后显式传给本层的 document RoPE、compressor、indexer、window/compressed index helper 和 compressed causal mask helper。

当前版本刻意不做跨 Transformer layer 复用，也不修改通用 TransformerLayer / TransformerConfig 来承载 CSA 专用状态。原因是跨层复用需要同时处理 PP 流水并行、不同层不同 compress_ratio、recompute/MTP 生命周期以及 CP 全局序列语义；这些问题如果没有完整设计，容易把模型特定逻辑扩散到通用组件，代码复杂度和误用风险都会上升。

CSA 当前不支持 TP>1。代码在 CompressedSparseAttention.__init__ 中根据 config.tensor_model_parallel_size 和 pg_collection.tp.nranks 做显式检查，只要发现 TP size 大于 1 就直接抛 NotImplementedError。因此 docmask metadata 不需要实现 TP>1 下的 shard/remap 逻辑。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否