### PR TITLE
[release/0.3][Configs] Add configuration for Ernie trainer

### DIFF
--- a/src/paddlefleet/training/yaml_arguments.py
+++ b/src/paddlefleet/training/yaml_arguments.py
@@ -15,6 +15,8 @@
 
 from omegaconf import DictConfig, OmegaConf
 
+_PRESERVED_DICT_CONFIG_KEYS = {"deepep_buffer_configs"}
+
 
 def _flatten_configs(cfg):
     result = {}
@@ -23,7 +25,10 @@ def _flatten_configs(cfg):
         if isinstance(node, DictConfig):
             for k, v in node.items():
                 if isinstance(v, DictConfig):
-                    recurse(v)
+                    if k in _PRESERVED_DICT_CONFIG_KEYS:
+                        result[k] = OmegaConf.to_container(v, resolve=True)
+                    else:
+                        recurse(v)
                 else:
                     result[k] = v
 

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -911,6 +911,16 @@ class TransformerConfig(ModelParallelConfig):
     magic_init: bool = False
     """Use the magic initialization method."""
 
+    ####################
+    # Ernie Trainer Configs
+    ####################
+
+    moe_logging: bool = False
+    """Whether to enable MoE logging."""
+
+    deepep_buffer_configs: dict | None = None
+    """DeepEP buffer configuration."""
+
     # Field name mapping rules: HuggingFace config.json name -> TransformerConfig name
     transform_rules = {
         # DSA field mapping

--- a/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_arguments.py
+++ b/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_arguments.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import os
 import sys
+from types import SimpleNamespace
 
 sys.path.insert(
     0,
@@ -158,3 +159,26 @@ class TestCoreTransformerConfigFromArgs(unittest.TestCase):
         # No matching attributes - uses all defaults
         config = core_transformer_config_from_args(args)
         self.assertIsNotNone(config)
+
+    def test_from_args_with_deepep_buffer_configs(self):
+        from paddlefleet.training.arguments import (
+            core_transformer_config_from_args,
+        )
+
+        args = SimpleNamespace(
+            deepep_buffer_configs={
+                "num_sms": 24,
+                "dispatch_config": [60, 256],
+                "combine_config": [20, 256],
+            }
+        )
+
+        config = core_transformer_config_from_args(args)
+        self.assertEqual(
+            config.deepep_buffer_configs,
+            {
+                "num_sms": 24,
+                "dispatch_config": [60, 256],
+                "combine_config": [20, 256],
+            },
+        )

--- a/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_yaml_arguments.py
+++ b/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_yaml_arguments.py
@@ -154,6 +154,34 @@ class TestFlattenConfigs(unittest.TestCase):
         self.assertTrue(result.bool_val)
         self.assertIsNone(result.none_val)
 
+    def test_deepep_buffer_configs_keeps_dict_value(self):
+        """Test _flatten_configs keeps deepep_buffer_configs as a dict field."""
+        from paddlefleet.training.yaml_arguments import _flatten_configs
+
+        cfg = OmegaConf.create(
+            {
+                "model": {
+                    "num_hidden_layers": 2,
+                    "deepep_buffer_configs": {
+                        "num_sms": 24,
+                        "dispatch_config": [60, 256],
+                        "combine_config": [20, 256],
+                    },
+                }
+            }
+        )
+        result = _flatten_configs(cfg)
+        self.assertEqual(result.num_hidden_layers, 2)
+        self.assertEqual(
+            result.deepep_buffer_configs,
+            {
+                "num_sms": 24,
+                "dispatch_config": [60, 256],
+                "combine_config": [20, 256],
+            },
+        )
+        self.assertFalse(hasattr(result, "num_sms"))
+
 
 @unittest.skipUnless(HAVE_OMEGACONF, "omegaconf not available in CI")
 class TestLoadYaml(unittest.TestCase):

--- a/tests/single_card_tests/test_transformer_config.py
+++ b/tests/single_card_tests/test_transformer_config.py
@@ -12,10 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib
+import sys
+import types
 import unittest
+from pathlib import Path
+from unittest.mock import patch
 
 import paddle
 
+from paddlefleet.training.arguments import core_transformer_config_from_args
 from paddlefleet.training.initialize import initialize_fleet
 from paddlefleet.transformer.transformer_config import TransformerConfig
 
@@ -332,6 +338,114 @@ class TestPadTokenId(unittest.TestCase):
     def test_override_value(self):
         config = TransformerConfig(num_hidden_layers=2, pad_token_id=151643)
         self.assertEqual(config.pad_token_id, 151643)
+
+
+class FakeDictConfig(dict):
+    def __getattr__(self, name):
+        try:
+            return self[name]
+        except KeyError as exc:
+            raise AttributeError(name) from exc
+
+
+class TestYamlArguments(unittest.TestCase):
+    def _load_yaml_arguments_with_fake_omegaconf(self):
+        class FakeOmegaConf:
+            @staticmethod
+            def create(value):
+                return FakeDictConfig(value)
+
+            @staticmethod
+            def to_container(value, resolve=True):
+                return dict(value)
+
+        fake_omegaconf = types.SimpleNamespace(
+            DictConfig=FakeDictConfig,
+            OmegaConf=FakeOmegaConf,
+        )
+
+        module_name = "paddlefleet.training.yaml_arguments"
+        module_path = (
+            Path(__file__).resolve().parents[2]
+            / "src"
+            / "paddlefleet"
+            / "training"
+            / "yaml_arguments.py"
+        )
+        spec = importlib.util.spec_from_file_location(module_name, module_path)
+        yaml_arguments = importlib.util.module_from_spec(spec)
+        with patch.dict(sys.modules, {"omegaconf": fake_omegaconf}):
+            spec.loader.exec_module(yaml_arguments)
+        return yaml_arguments
+
+    def test_deepep_buffer_configs_keeps_dict_value(self):
+        yaml_arguments = self._load_yaml_arguments_with_fake_omegaconf()
+        cfg = FakeDictConfig(
+            {
+                "model": FakeDictConfig(
+                    {
+                        "num_hidden_layers": 2,
+                        "deepep_buffer_configs": FakeDictConfig(
+                            {
+                                "num_sms": 24,
+                                "dispatch_config": [60, 256],
+                                "combine_config": [20, 256],
+                            }
+                        ),
+                    }
+                )
+            }
+        )
+
+        result = yaml_arguments._flatten_configs(cfg)
+
+        self.assertEqual(result.num_hidden_layers, 2)
+        self.assertEqual(
+            result.deepep_buffer_configs,
+            {
+                "num_sms": 24,
+                "dispatch_config": [60, 256],
+                "combine_config": [20, 256],
+            },
+        )
+        self.assertFalse(hasattr(result, "num_sms"))
+
+    def test_regular_nested_config_still_flattens(self):
+        yaml_arguments = self._load_yaml_arguments_with_fake_omegaconf()
+        cfg = FakeDictConfig(
+            {
+                "model": FakeDictConfig({"num_hidden_layers": 2}),
+                "training": FakeDictConfig({"micro_batch_size": 4}),
+            }
+        )
+
+        result = yaml_arguments._flatten_configs(cfg)
+
+        self.assertEqual(result.num_hidden_layers, 2)
+        self.assertEqual(result.micro_batch_size, 4)
+        self.assertFalse(hasattr(result, "model"))
+        self.assertFalse(hasattr(result, "training"))
+
+    def test_core_config_receives_deepep_buffer_configs(self):
+        yaml_arguments = self._load_yaml_arguments_with_fake_omegaconf()
+        args = yaml_arguments._flatten_configs(
+            FakeDictConfig(
+                {
+                    "model": FakeDictConfig(
+                        {
+                            "num_hidden_layers": 2,
+                            "deepep_buffer_configs": FakeDictConfig(
+                                {"num_sms": 24}
+                            ),
+                        }
+                    )
+                }
+            )
+        )
+
+        config = core_transformer_config_from_args(args)
+
+        self.assertEqual(config.deepep_buffer_configs, {"num_sms": 24})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### PR Category
Execute Infrastructure


### PR Types
New features


### Description
为 Ernie Trainer 添加 TransformerConfig，这些配置目前在 Ernie Trainer 里直接强制附在 model.config 上，现在正式添加配置


### 是否引起精度变化
否


Cherry-pick of #1287 to `release/0.3`.

Merged in dev: #1287  <!-- For pass CI -->