### PR TITLE
[DSv4] Add refined-recompute for indexer_topk

### DIFF
--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -26,6 +26,7 @@ Components:
 from __future__ import annotations
 
 import os
+import queue
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -672,6 +673,7 @@ def _compute_tilelang_csa_indexer_loss_forward(
     indexer_backend: str = "tilelang",
     loss_mask: Tensor | None = None,
     global_valid_count: float | None = None,
+    indexer_topk_states: tuple[Tensor, Tensor] | None = None,
 ) -> tuple[Tensor, Tensor, Tensor, Tensor]:
     from paddlefleet.tilelang_ops import (
         csa_attn_target_reducesum,
@@ -711,6 +713,8 @@ def _compute_tilelang_csa_indexer_loss_forward(
         )
         topk_probs = paddle.nn.functional.softmax(topk_scores, axis=-1)
         topk_probs = topk_probs * row_valid.cast(topk_probs.dtype)
+    elif indexer_topk_states is not None:
+        topk_indices, topk_probs = indexer_topk_states
     else:
         topk_indices, topk_probs = csa_indexer_topk_fwd(
             index_q,
@@ -1502,6 +1506,16 @@ class CompressedSparseAttention(FleetLayer):
         else:
             self.indexer = None
 
+        # Configure indexer refined-recompute
+        self._use_rr_indexer_topk = (
+            self.indexer is not None
+            and config.recompute_granularity == "full"
+            and config.recompute_modules is not None
+            and "indexer_topk" in config.recompute_modules
+        )
+        if self._use_rr_indexer_topk:
+            self._rr_indexer_topk_queue = queue.Queue()
+
     def _compute_indexer_compressed_topk_idxs(
         self,
         query: Tensor,
@@ -1609,6 +1623,11 @@ class CompressedSparseAttention(FleetLayer):
                 else "tilelang",
                 loss_mask=loss_mask,
                 global_valid_count=global_valid_count,
+                indexer_topk_states=(
+                    self._rr_indexer_topk_queue.get_nowait()
+                    if self._use_rr_indexer_topk
+                    else None
+                ),
             )
             tilelang_indexer_loss_state = (
                 q_indexer_bf,
@@ -1724,7 +1743,7 @@ class CompressedSparseAttention(FleetLayer):
                         x_det, qr_det, startend_row_indices
                     )
                 )
-                tl_topk_indices, _tl_topk_scores = csa_indexer_topk_fwd(
+                tl_topk_indices, tl_topk_scores = csa_indexer_topk_fwd(
                     q_indexer_tl,
                     k_indexer_tl,
                     weights_indexer_tl,
@@ -1732,6 +1751,10 @@ class CompressedSparseAttention(FleetLayer):
                     topk_effective=attn_topk_effective,
                     valid_range=valid_range,
                 )
+                if self._use_rr_indexer_topk:
+                    self._rr_indexer_topk_queue.put(
+                        (tl_topk_indices, tl_topk_scores)
+                    )
 
             topk_indices_compressed = tl_topk_indices
 
@@ -2095,6 +2118,11 @@ class CompressedSparseAttention(FleetLayer):
                         seq_offset=position_offset,
                         loss_mask=loss_mask,
                         global_valid_count=global_valid_count,
+                        indexer_topk_states=(
+                            self._rr_indexer_topk_queue.get_nowait()
+                            if self._use_rr_indexer_topk
+                            else None
+                        ),
                     )
                     tilelang_indexer_loss_state = (
                         q_indexer_bf,
@@ -2224,7 +2252,7 @@ class CompressedSparseAttention(FleetLayer):
                     from paddlefleet.tilelang_ops import csa_indexer_topk_fwd
 
                     with paddle.no_grad():
-                        tl_topk_indices, _ = csa_indexer_topk_fwd(
+                        tl_topk_indices, tl_topk_probs = csa_indexer_topk_fwd(
                             q_indexer_bf,
                             k_indexer_global,
                             weights_indexer_bf,
@@ -2232,6 +2260,10 @@ class CompressedSparseAttention(FleetLayer):
                             topk_effective=attn_topk_effective,
                             seq_offset=position_offset,
                             valid_range=valid_range,
+                        )
+                    if self._use_rr_indexer_topk:
+                        self._rr_indexer_topk_queue.put(
+                            (tl_topk_indices, tl_topk_probs)
                         )
                     topk_indices_compressed = tl_topk_indices
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
Execute Infrastructure

### PR Types
Performance

### Description
实现 DSv4 CSA indexer_topk（即 csa_indexer_topk_fwd 算子）的 RR

<b>开启方法：</b>在 yaml 中设置：
```yaml
recompute_granularity: full
recompute_method: uniform
recompute_num_layers: 1
recompute_modules: ["indexer_topk"]  # 加上这个
```

<b>性能提升：</b>该优化是针对 indexer tilelang 算子在 128K 下前向太慢的问题，128K 下性能提升 20%；但 32K 下由于 indexer 占比不高，仅提升 5%

<b>显存：</b>32K 或 128K-CP4 下，每层 decoder 理论增加 0.125G，实测总共增加约 6G，在 sharding 路数大的情况下不构成瓶颈

### 是否引起精度变化
否