### PR TITLE
Restrict seq_aux_loss to non-negative MoE scoring

### DIFF
--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -259,10 +259,12 @@ class StandardMoERouter(nn.Layer):
                 f"seq_aux is True but routing_type is {self.routing_type}. Please check."
             )
 
-        if (
-            self.routing_type == "seq_aux_loss"
-            and self.scoring_func
-            not in ("softmax", "sigmoid", "relu", "sftplus", "sqrtsoftplus")
+        if self.routing_type == "seq_aux_loss" and self.scoring_func not in (
+            "softmax",
+            "sigmoid",
+            "relu",
+            "sftplus",
+            "sqrtsoftplus",
         ):
             raise ValueError(
                 "seq_aux_loss requires a non-negative MoE scoring_func, "

--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -1170,7 +1170,7 @@ class TopKRouter(StandardMoERouter):
 
         # Use clone() to ensure that the execution order of the grad nodes is consistent with EC.
         gates_ori = gates.clone()
-        if self.scoring_func != "softmax":
+        if self.config.router_aux_loss_coef and self.scoring_func != "softmax":
             if not getattr(
                 self.config, "gpt_model_use_experimental_version", False
             ):

--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -259,6 +259,16 @@ class StandardMoERouter(nn.Layer):
                 f"seq_aux is True but routing_type is {self.routing_type}. Please check."
             )
 
+        if (
+            self.routing_type == "seq_aux_loss"
+            and self.scoring_func
+            not in ("softmax", "sigmoid", "relu", "sftplus", "sqrtsoftplus")
+        ):
+            raise ValueError(
+                "seq_aux_loss requires a non-negative MoE scoring_func, "
+                f"but got {self.scoring_func!r}. "
+            )
+
         # Initialize gate weight with Normal distribution aligned with Megatron.
         self.weight = paddle.create_parameter(
             shape=[self.num_experts, self.hidden_size],
@@ -1158,7 +1168,7 @@ class TopKRouter(StandardMoERouter):
 
         # Use clone() to ensure that the execution order of the grad nodes is consistent with EC.
         gates_ori = gates.clone()
-        if self.scoring_func in {"sigmoid", "sqrtsoftplus"}:
+        if self.scoring_func != "softmax":
             if not getattr(
                 self.config, "gpt_model_use_experimental_version", False
             ):

--- a/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_router.py
+++ b/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_router.py
@@ -406,6 +406,21 @@ class TestMoERouter(unittest.TestCase):
         "paddlefleet.transformer.moe.moe_router.get_context_parallel_world_size",
         return_value=1,
     )
+    def test_seq_aux_loss_rejects_negative_scoring_func(self, mock_cp):
+        """Test seq_aux_loss rejects scoring functions that may go negative."""
+        from paddlefleet.transformer.moe.moe_router import StandardMoERouter
+
+        config = _make_router_config(
+            moe_router_load_balancing_type="seq_aux_loss",
+            scoring_func="tanh",
+        )
+        with self.assertRaisesRegex(ValueError, "non-negative"):
+            StandardMoERouter(config)
+
+    @patch(
+        "paddlefleet.transformer.moe.moe_router.get_context_parallel_world_size",
+        return_value=1,
+    )
     def test_gate_detach_matmul_no_fuse(self, mock_cp):
         """Test gate_detach_matmul without fusion."""
         from paddlefleet.transformer.moe.moe_router import gate_detach_matmul


### PR DESCRIPTION
### PR Category
Distributed Strategy

### PR Types
Bug fixes

### Description
- 对所有非 `softmax` 的 MoE scoring function 归一化 `gates_ori`。
- 同时限制 `seq_aux_loss` 只能搭配非负 scoring function，避免 `tanh`、`gelu`、`leaky_relu` 等可能产生负值的函数进入辅助 loss 计算路径，导致归一化结果不稳定。
- 在归一化判断中增加 `self.config.router_aux_loss_coef`，是为了只在 aux loss 实际启用时执行 `gates_ori` 的 sum/div，避免 aux loss 关闭或非消费路径中产生额外 forward 开销，

### 是否引起精度变化
否
