### PR TITLE
[WIP] add fp8 in general linear

### DIFF
--- a/src/paddlefleet/models/gpt/lm_head.py
+++ b/src/paddlefleet/models/gpt/lm_head.py
@@ -124,6 +124,7 @@ def SegLU(x, ranges, ts):
 class GPTLMHead(ColumnParallelLinear):
     def __init__(self, **kwargs):
         self.config = kwargs["config"]
+        self.config.fp8 = None
         self.skip_weight_param_allocation = kwargs[
             "skip_weight_param_allocation"
         ]

--- a/src/paddlefleet/tensor_parallel/layers.py
+++ b/src/paddlefleet/tensor_parallel/layers.py
@@ -62,6 +62,12 @@ try:
 except ImportError:
     _grad_accum_fusion_available = False
 
+_deep_gemm_available = True
+try:
+    from paddlefleet_ops import deep_gemm
+except (ImportError, RuntimeError):
+    _deep_gemm_available = False
+    deep_gemm = None
 
 HAVE_TE = False
 
@@ -389,6 +395,11 @@ def linear_with_frozen_weight(
     grad_output_buffer: list[paddle.Tensor] | None = None,
     wgrad_deferral_limit: None = None,
     async_grad_allreduce: bool | None = None,
+    fp8: bool = False,
+    fp8_wgrad: bool = False,
+    inp_quant_func=None,
+    weight_quant_func=None,
+    use_pow2_scale: bool = False,
 ) -> paddle.Tensor:
     """Linear layer execution with weight.requires_grad == False.
 
@@ -462,6 +473,95 @@ def linear_with_frozen_weight(
     return LinearWithFrozenWeight.apply(*args)
 
 
+def general_gemm(
+    a,
+    b,
+    bias=None,
+    fp8=False,
+    inp_quant_func=None,
+    weight_quant_func=None,
+    out=None,
+    recipe=None,
+):
+    """Unified GEMM interface supporting both bf16 and fp8 paths.
+
+    Args:
+        a: Left operand. Raw tensor or pre-quantized (fp8_tensor, scale) tuple.
+        b: Right operand. Same convention as *a*.
+        bias: Optional bias (only used in bf16 path).
+        fp8: If True, use fp8 gemm via deep_gemm.fp8_gemm_nt.
+        inp_quant_func: Quantization callable for input (when fp8=True).
+        weight_quant_func: Quantization callable for weight (when fp8=True).
+        out: Pre-allocated output buffer. If not None, accumulates into it;
+             if None, creates a new buffer.
+
+    Returns:
+        output tensor, and optionally quant cache tuple when fp8=True.
+    """
+    if fp8:
+        assert _deep_gemm_available, "FP8 GEMM requires paddlefleet_ops.deep_gemm"
+
+        from paddlefleet.fp8.utils import is_fp8_tensor
+
+        # fp8_quant_blockwise requires 2D input, reshape if needed
+        a_orig_shape = None
+        if not is_fp8_tensor(a) and a.ndim > 2:
+            a_orig_shape = a.shape
+            a = a.reshape([-1, a.shape[-1]])
+
+        if is_fp8_tensor(a):
+            inp_fp8, inp_scale = a
+            inp_t_fp8, inp_t_scale = None, None
+        else:
+            quant_result = inp_quant_func(a)
+            if len(quant_result) == 2:
+                inp_fp8, inp_scale = quant_result
+                inp_t_fp8, inp_t_scale = None, None
+            else:
+                inp_fp8, inp_scale, inp_t_fp8, inp_t_scale = quant_result
+
+        if is_fp8_tensor(b):
+            weight_fp8, weight_scale = b
+        else:
+            # weight is [K, N] but fp8_gemm_nt expects B as [N, K]
+            weight_fp8, weight_scale = weight_quant_func(b.T.contiguous())
+
+        # print(f"[general_gemm] fp8 path: "
+        #       f"A shape={inp_fp8.shape} stride={inp_fp8.strides} dtype={inp_fp8.dtype} "
+        #       f"B shape={weight_fp8.shape} stride={weight_fp8.strides} dtype={weight_fp8.dtype} "
+        #       f"A_scale shape={inp_scale.shape} B_scale shape={weight_scale.shape} "
+        #       f"out={'accumulate '+str(out.shape) if out is not None else 'new'}")
+
+        if out is not None:
+            # Accumulate into existing buffer
+            deep_gemm.fp8_gemm_nt(
+                (inp_fp8, inp_scale), (weight_fp8, weight_scale), out,
+                c=out, recipe=recipe,
+            )
+        else:
+            out = paddle.empty(
+                [inp_fp8.shape[0], weight_fp8.shape[0]], dtype=paddle.bfloat16
+            )
+            deep_gemm.fp8_gemm_nt(
+                (inp_fp8, inp_scale), (weight_fp8, weight_scale), out,
+                recipe=recipe,
+            )
+
+        # print(f"[general_gemm] fp8 done: out shape={out.shape}")
+        if a_orig_shape is not None:
+            out = out.reshape(list(a_orig_shape[:-1]) + [out.shape[-1]])
+        return out, (inp_fp8, inp_scale, inp_t_fp8, inp_t_scale, weight_fp8, weight_scale)
+
+    else:
+        # Standard bf16/fp16 path
+        if bias is not None:
+            output = paddle.nn.functional.linear(a, b, bias)
+        else:
+            output = paddle.matmul(a, b)
+        # print(f"[general_gemm] bf16 path: A shape={a.shape} B shape={b.shape} out shape={output.shape}")
+        return output, None
+
+
 class LinearWithGradAccumulationAndAsyncCommunication(paddle.autograd.Function):
     """See linear_with_grad_accumulation_and_async_allreduce"""
 
@@ -477,6 +577,11 @@ class LinearWithGradAccumulationAndAsyncCommunication(paddle.autograd.Function):
         grad_output_buffer,
         wgrad_deferral_limit,
         tp_group,
+        fp8=False,
+        fp8_wgrad=False,
+        inp_quant_func=None,
+        weight_quant_func=None,
+        use_pow2_scale=False,
     ):
         """Forward."""
         if gradient_accumulation_fusion and hasattr(weight, "main_grad"):
@@ -484,9 +589,6 @@ class LinearWithGradAccumulationAndAsyncCommunication(paddle.autograd.Function):
         else:
             main_grad = None
         ctx.save_for_backward(input._new_shared_tensor(), weight)
-        # We can't save main_grad in save_for_backward as this module would be
-        # reused across layers like MTP logits. So, to prevent in-place modification
-        # checks we save the tensor in ctx.
         ctx.main_grad = main_grad
         ctx.use_bias = bias is not None
         ctx.gradient_accumulation_fusion = gradient_accumulation_fusion
@@ -495,11 +597,13 @@ class LinearWithGradAccumulationAndAsyncCommunication(paddle.autograd.Function):
         ctx.wgrad_deferral_limit = wgrad_deferral_limit
         ctx.grad_output_buffer = grad_output_buffer
         ctx.tp_group = tp_group
-        # Cache input.stop_gradient: ``_new_shared_tensor()`` does not
-        # necessarily preserve this flag, and Paddle's PyLayer contract
-        # requires backward to return None at position 0 iff the original
-        # forward input had stop_gradient=True.
         ctx.input_stop_gradient = bool(input.stop_gradient)
+        # FP8 attributes
+        ctx.fp8 = fp8
+        ctx.fp8_wgrad = fp8_wgrad
+        ctx.inp_quant_func = inp_quant_func
+        ctx.weight_quant_func = weight_quant_func
+        ctx.use_pow2_scale = use_pow2_scale
 
         if sequence_parallel:
             dim_size = list(input.shape)
@@ -513,10 +617,26 @@ class LinearWithGradAccumulationAndAsyncCommunication(paddle.autograd.Function):
         else:
             total_input = input
 
-        if bias is not None:
-            output = paddle.nn.functional.linear(total_input, weight, bias)
+        output, fp8_meta = general_gemm(
+            total_input, weight, bias=bias,
+            fp8=fp8,
+            inp_quant_func=inp_quant_func,
+            weight_quant_func=weight_quant_func,
+        )
+
+        # Save fp8 quantized tensors for backward reuse
+        if fp8 and fp8_meta is not None:
+            _, _, inp_t_fp8, inp_t_scale, weight_fp8, weight_scale = fp8_meta
+            ctx.inp_t_fp8 = inp_t_fp8
+            ctx.inp_t_scale = inp_t_scale
+            ctx.weight_fp8 = weight_fp8
+            ctx.weight_scale = weight_scale
         else:
-            output = paddle.matmul(total_input, weight)
+            ctx.inp_t_fp8 = None
+            ctx.inp_t_scale = None
+            ctx.weight_fp8 = None
+            ctx.weight_scale = None
+
         return output
 
     @staticmethod
@@ -529,15 +649,9 @@ class LinearWithGradAccumulationAndAsyncCommunication(paddle.autograd.Function):
         wgrad_deferral_limit = ctx.wgrad_deferral_limit
         handle = None
         tp_group = ctx.tp_group
+        fp8 = ctx.fp8
+        fp8_wgrad = ctx.fp8_wgrad
 
-        # Paddle PyLayer contract: when a forward Tensor input has
-        # stop_gradient=True, the corresponding backward return slot MUST be
-        # None. The "input" position (0) is the only one that can carry
-        # stop_gradient=True in normal usage (weight/bias are trainable);
-        # callers that intentionally feed a detached tensor (e.g. for
-        # gradient isolation) rely on this. We must skip grad_input compute
-        # and any input-side collective (all_reduce / reduce_scatter) in
-        # that case, while still computing grad_weight / grad_bias.
         input_needs_grad = not ctx.input_stop_gradient
 
         if ctx.gradient_accumulation_fusion:
@@ -569,8 +683,28 @@ class LinearWithGradAccumulationAndAsyncCommunication(paddle.autograd.Function):
                 total_input = all_gather_buffer
             else:
                 total_input = input
+
+        # Compute grad_input
         if input_needs_grad:
-            grad_input = grad_output.matmul(weight.t())
+            if fp8 and ctx.weight_fp8 is not None:
+                # FP8 dgrad: grad_input = grad_output @ weight
+                # fp8_gemm_nt(A, B) = A @ B.T, so B = weight.T = [K, N] K-major
+                # print(f"[backward] dgrad fp8: grad_output={grad_output.shape} weight_fp8={ctx.weight_fp8.shape} weight_scale={ctx.weight_scale.shape}")
+                grad_input, _ = general_gemm(
+                    grad_output,
+                    (ctx.weight_fp8.T.contiguous(), ctx.weight_scale.T),
+                    fp8=True,
+                    inp_quant_func=lambda x: paddle.incubate.nn.functional.fp8_quant_blockwise(
+                        x,
+                        output_scale_transpose=False,
+                        quant_method="1x128",
+                        input_transpose=False,
+                        using_pow2_scale=ctx.use_pow2_scale,
+                    )[:2],
+                )
+            else:
+                # print(f"[backward] dgrad bf16: grad_output={grad_output.shape} weight={weight.shape}")
+                grad_input, _ = general_gemm(grad_output, weight.t())
         else:
             grad_input = None
 
@@ -605,7 +739,37 @@ class LinearWithGradAccumulationAndAsyncCommunication(paddle.autograd.Function):
             else:
                 sub_grad_input = None
 
-        if ctx.gradient_accumulation_fusion:
+        # Compute grad_weight
+        if fp8_wgrad and wgrad_compute:
+            # FP8 wgrad: grad_output^T @ total_input
+            # grad_output and total_input are already 2D from prepare_input_tensors_for_wgrad_compute
+            # Quantize grad_output transposed and total_input transposed
+            # print(f"[backward] wgrad fp8: grad_output={grad_output.shape} total_input={total_input.shape}")
+            grad_out_t_fp8, grad_out_t_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
+                grad_output.T.contiguous(),
+                output_scale_transpose=False,
+                quant_method="1x128",
+                input_transpose=False,
+                using_pow2_scale=ctx.use_pow2_scale,
+            )[:2]
+            inp_t_fp8, inp_t_scale = ctx.inp_t_fp8, ctx.inp_t_scale
+            if inp_t_fp8 is None:
+                inp_t_fp8, inp_t_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
+                    total_input.T.contiguous(),
+                    output_scale_transpose=False,
+                    quant_method="1x128",
+                    input_transpose=False,
+                    using_pow2_scale=ctx.use_pow2_scale,
+                )[:2]
+
+            grad_weight, _ = general_gemm(
+                (inp_t_fp8, inp_t_scale),
+                (grad_out_t_fp8, grad_out_t_scale),
+                fp8=True,
+                recipe=(1, 1, 128),
+            )
+
+        elif ctx.gradient_accumulation_fusion:
             if wgrad_compute:
                 if weight.main_grad.dtype == paddle.float32:
                     fused_weight_gradient_mlp_cuda.wgrad_gemm_accum_fp32(
@@ -644,7 +808,9 @@ class LinearWithGradAccumulationAndAsyncCommunication(paddle.autograd.Function):
             else:
                 grad_weight = None
         else:
-            grad_weight = total_input.t().matmul(grad_output)
+            if wgrad_compute:
+                pass  # print(f"[backward] wgrad bf16: total_input={total_input.shape} grad_output={grad_output.shape}")
+            grad_weight, _ = general_gemm(total_input.t(), grad_output)
         grad_bias = grad_output.sum(dim=0) if use_bias else None
 
         if ctx.sequence_parallel:
@@ -680,6 +846,11 @@ def linear_with_grad_accumulation_and_async_allreduce(
     wgrad_deferral_limit: int | None = 0,
     async_grad_allreduce: bool | None = None,
     tp_group: paddle.core.ProcessGroup | None = None,
+    fp8: bool = False,
+    fp8_wgrad: bool = False,
+    inp_quant_func=None,
+    weight_quant_func=None,
+    use_pow2_scale: bool = False,
 ) -> paddle.Tensor:
     """Linear layer execution with asynchronous communication and
     gradient accumulation fusion in backprop.
@@ -765,6 +936,11 @@ def linear_with_grad_accumulation_and_async_allreduce(
         grad_output_buffer,
         wgrad_deferral_limit,
         tp_group,
+        fp8,
+        fp8_wgrad,
+        inp_quant_func,
+        weight_quant_func,
+        use_pow2_scale,
     ]
 
     if not linear_with_grad_accumulation_and_async_allreduce.warned:
@@ -789,6 +965,22 @@ def linear_with_grad_accumulation_and_async_allreduce(
 
 
 linear_with_grad_accumulation_and_async_allreduce.warned = False
+
+
+def _log_fp8_linear_once(layer, input_, weight):
+    if not getattr(layer, "fp8", False) or getattr(layer, "_fp8_linear_logged", False):
+        return
+    layer._fp8_linear_logged = True
+    print(
+        "[fp8_linear] "
+        f"class={layer.__class__.__name__} "
+        f"name={getattr(layer, 'tp_comm_buffer_name', None)} "
+        f"input_shape={list(input_.shape)} "
+        f"weight_shape={list(weight.shape)} "
+        f"fp8_wgrad={getattr(layer, 'fp8_wgrad', False)} "
+        f"recipe={getattr(layer.config, 'fp8_recipe', 'blockwise')}",
+        flush=True,
+    )
 
 
 class Linear(paddle.nn.Layer):
@@ -875,6 +1067,8 @@ class Linear(paddle.nn.Layer):
         self.grad_output_buffer = grad_output_buffer
         self.config = config
         self._dtype = config.params_dtype
+        self.tp_comm_buffer_name = tp_comm_buffer_name
+        self._fp8_linear_logged = False
 
         # No TP: output_size_per_partition equals the full output_size.
         self.output_size_per_partition = output_size
@@ -939,6 +1133,25 @@ class Linear(paddle.nn.Layer):
 
         self._forward_impl = linear_with_grad_accumulation_and_async_allreduce
 
+        # FP8 config
+        self.fp8 = getattr(config, "fp8", None) is not None
+        self.fp8_wgrad = getattr(config, "fp8_wgrad", False) and self.fp8
+        self.use_pow2_scale = False
+        self.inp_quant_func = None
+        self.weight_quant_func = None
+        if self.fp8:
+            from paddlefleet.fp8.quantization import get_quant_func
+
+            self.use_pow2_scale = (
+                paddle.device.cuda.get_device_capability()[0] == 10
+            )
+            self.inp_quant_func, self.weight_quant_func = get_quant_func(
+                getattr(config, "fp8_recipe", "blockwise"),
+                input_trans=True,
+                out_scale_trans=False,
+                pow2_scale=self.use_pow2_scale,
+            )
+
     def forward(
         self,
         input_: paddle.Tensor,
@@ -990,6 +1203,8 @@ class Linear(paddle.nn.Layer):
                 linear_with_grad_accumulation_and_async_allreduce
             )
 
+        _log_fp8_linear_once(self, input_, weight)
+
         output = self._forward_impl(
             input=input_,
             weight=weight,
@@ -1008,6 +1223,11 @@ class Linear(paddle.nn.Layer):
                 else None
             ),
             tp_group=None,
+            fp8=self.fp8,
+            fp8_wgrad=self.fp8_wgrad,
+            inp_quant_func=self.inp_quant_func,
+            weight_quant_func=self.weight_quant_func,
+            use_pow2_scale=self.use_pow2_scale,
         )
 
         output_bias = (
@@ -1250,6 +1470,8 @@ class ColumnParallelLinear(paddle.nn.Layer):
         self.disable_grad_reduce = disable_grad_reduce
         self.tp_group = tp_group
         self._dtype = config.params_dtype
+        self.tp_comm_buffer_name = tp_comm_buffer_name
+        self._fp8_linear_logged = False
 
         self.tp_group = get_tensor_model_parallel_group_if_none(
             self.tp_group, is_expert=self.is_expert, check_initialized=False
@@ -1353,6 +1575,25 @@ class ColumnParallelLinear(paddle.nn.Layer):
 
         self._forward_impl = linear_with_grad_accumulation_and_async_allreduce
 
+        # FP8 config
+        self.fp8 = getattr(config, "fp8", None) is not None
+        self.fp8_wgrad = getattr(config, "fp8_wgrad", False) and self.fp8
+        self.use_pow2_scale = False
+        self.inp_quant_func = None
+        self.weight_quant_func = None
+        if self.fp8:
+            from paddlefleet.fp8.quantization import get_quant_func
+
+            self.use_pow2_scale = (
+                paddle.device.cuda.get_device_capability()[0] == 10
+            )
+            self.inp_quant_func, self.weight_quant_func = get_quant_func(
+                getattr(config, "fp8_recipe", "blockwise"),
+                input_trans=True,
+                out_scale_trans=False,
+                pow2_scale=self.use_pow2_scale,
+            )
+
     def forward(
         self,
         input_: paddle.Tensor,
@@ -1445,6 +1686,8 @@ class ColumnParallelLinear(paddle.nn.Layer):
                         self.config.cpu_offloading_activations
                     )
 
+        _log_fp8_linear_once(self, input_parallel, weight)
+
         output_parallel = self._forward_impl(
             input=input_parallel,
             weight=weight,
@@ -1465,6 +1708,11 @@ class ColumnParallelLinear(paddle.nn.Layer):
                 else None
             ),
             tp_group=self.tp_group,
+            fp8=self.fp8,
+            fp8_wgrad=self.fp8_wgrad,
+            inp_quant_func=self.inp_quant_func,
+            weight_quant_func=self.weight_quant_func,
+            use_pow2_scale=self.use_pow2_scale,
         )
 
         gather_output = self.gather_output
@@ -1581,6 +1829,8 @@ class RowParallelLinear(paddle.nn.Layer):
         self.sequence_parallel = config.sequence_parallel
         self.tp_group = tp_group
         self._dtype = config.params_dtype
+        self.tp_comm_buffer_name = tp_comm_buffer_name
+        self._fp8_linear_logged = False
 
         if self.sequence_parallel and not self.input_is_parallel:
             raise RuntimeError(
@@ -1663,6 +1913,25 @@ class RowParallelLinear(paddle.nn.Layer):
 
         self._forward_impl = linear_with_grad_accumulation_and_async_allreduce
 
+        # FP8 config
+        self.fp8 = getattr(config, "fp8", None) is not None
+        self.fp8_wgrad = getattr(config, "fp8_wgrad", False) and self.fp8
+        self.use_pow2_scale = False
+        self.inp_quant_func = None
+        self.weight_quant_func = None
+        if self.fp8:
+            from paddlefleet.fp8.quantization import get_quant_func
+
+            self.use_pow2_scale = (
+                paddle.device.cuda.get_device_capability()[0] == 10
+            )
+            self.inp_quant_func, self.weight_quant_func = get_quant_func(
+                getattr(config, "fp8_recipe", "blockwise"),
+                input_trans=True,
+                out_scale_trans=False,
+                pow2_scale=self.use_pow2_scale,
+            )
+
     def forward(self, input_):
         """Forward of RowParallelLinear
 
@@ -1716,6 +1985,8 @@ class RowParallelLinear(paddle.nn.Layer):
                         self.config.cpu_offloading_activations
                     )
 
+        _log_fp8_linear_once(self, input_parallel, self.weight)
+
         output_parallel = self._forward_impl(
             input=input_parallel,
             weight=self.weight,
@@ -1725,6 +1996,11 @@ class RowParallelLinear(paddle.nn.Layer):
             sequence_parallel=False,
             tp_group=None,
             grad_output_buffer=None,
+            fp8=self.fp8,
+            fp8_wgrad=self.fp8_wgrad,
+            inp_quant_func=self.inp_quant_func,
+            weight_quant_func=self.weight_quant_func,
+            use_pow2_scale=self.use_pow2_scale,
         )
 
         # All-reduce across all the partitions.

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -25,6 +25,7 @@ Components:
 
 from __future__ import annotations
 
+import copy
 import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -920,13 +921,17 @@ class Compressor(nn.Layer):
         self.qk_pos_emb_head_dim = config.qk_pos_emb_head_dim or 0
         self.rotary_pos_emb = rotary_pos_emb
 
+        non_fp8_config = copy.copy(config)
+        non_fp8_config.fp8 = None
+        non_fp8_config.fp8_wgrad = False
+
         proj_out_dim = self.coff * head_dim
 
         self.linear_wkv = build_spec_layer(
             sublayers_spec.linear_wkv,
             config.hidden_size,
             proj_out_dim,
-            config=config,
+            config=non_fp8_config,
             init_method=config.init_method,
             bias=False,
             skip_bias_add=False,
@@ -938,7 +943,7 @@ class Compressor(nn.Layer):
             sublayers_spec.linear_wgate,
             config.hidden_size,
             proj_out_dim,
-            config=config,
+            config=non_fp8_config,
             init_method=config.init_method,
             bias=False,
             skip_bias_add=False,
@@ -1263,6 +1268,10 @@ class CSAIndexer(nn.Layer):
 
         self.rotary_pos_emb = rotary_pos_emb
 
+        non_fp8_config = copy.copy(config)
+        non_fp8_config.fp8 = None
+        non_fp8_config.fp8_wgrad = False
+
         # Q projection: q_lora_rank -> n_heads * head_dim
         self.linear_wq_b = build_spec_layer(
             sublayers_spec.linear_wq_b,
@@ -1282,7 +1291,7 @@ class CSAIndexer(nn.Layer):
             sublayers_spec.linear_weights_proj,
             self.hidden_size,
             self.index_n_heads,
-            config=config,
+            config=non_fp8_config,
             init_method=config.init_method,
             bias=False,
             skip_bias_add=False,

--- a/src/paddlefleet/transformer/dsa_attention.py
+++ b/src/paddlefleet/transformer/dsa_attention.py
@@ -24,6 +24,7 @@ This module provides:
 
 from __future__ import annotations
 
+import copy
 import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -286,6 +287,10 @@ class DSAIndexer(paddle.nn.Layer):
         self.index_topk = config.dsa_index_topk
         self.softmax_scale = self.head_dim**-0.5
 
+        non_fp8_config = copy.copy(self.config)
+        non_fp8_config.fp8 = None
+        non_fp8_config.fp8_wgrad = False
+
         # wq_b: q_lora_rank -> n_heads * head_dim (duplicated)
         self.wq_b = build_spec_layer(
             sublayers_spec.linear_wq_b,
@@ -326,7 +331,7 @@ class DSAIndexer(paddle.nn.Layer):
             sublayers_spec.linear_weights_proj,
             config.hidden_size,
             self.n_heads,
-            config=self.config,
+            config=non_fp8_config,
             init_method=self.config.init_method,
             bias=False,
             skip_bias_add=False,

--- a/src/paddlefleet/transformer/dsv4_hybrid_attention.py
+++ b/src/paddlefleet/transformer/dsv4_hybrid_attention.py
@@ -36,6 +36,14 @@ from paddlefleet.fp8.qat import fp8_simulate_qat
 from paddlefleet.models.common.embeddings.rope_utils import (
     _apply_rotary_pos_emb_bshd,
 )
+
+try:
+    from paddlefleet_ops import deep_gemm
+
+    _DEEP_GEMM_AVAILABLE = hasattr(deep_gemm, "fp8_einsum")
+except (ImportError, RuntimeError):
+    deep_gemm = None
+    _DEEP_GEMM_AVAILABLE = False
 from paddlefleet.models.common.embeddings.rotary_pos_embedding import (
     RotaryEmbedding,
 )
@@ -53,6 +61,161 @@ if TYPE_CHECKING:
 def _q_rms_norm(q: Tensor, eps: float) -> Tensor:
     """RMS normalization for query (no learnable weight)."""
     return q * paddle.rsqrt(q.square().mean(-1, keepdim=True) + eps)
+
+
+class GroupedOutputFP8(paddle.autograd.PyLayer):
+    _logged = False
+    _logged_bwd = False
+
+    @staticmethod
+    def forward(ctx, x: Tensor, weight: Tensor, num_groups: int, o_lora_rank: int, fp8_wgrad: bool = True):
+        assert _DEEP_GEMM_AVAILABLE, "GroupedOutputFP8 requires deep_gemm.fp8_einsum"
+        b, sq, _, d = x.shape
+        assert d % 128 == 0, "FP8 grouped output requires per-group hidden dim to be divisible by 128"
+        assert o_lora_rank % 128 == 0, "FP8 grouped output requires o_lora_rank to be divisible by 128"
+        if not GroupedOutputFP8._logged:
+            print(f"[fp8_grouped_output] forward: x={list(x.shape)} weight={list(weight.shape)} num_groups={num_groups} o_lora_rank={o_lora_rank} d={d} fp8_wgrad={fp8_wgrad}", flush=True)
+            GroupedOutputFP8._logged = True
+        weight_bf16 = weight.reshape([num_groups, o_lora_rank, d])
+        weight_for_gemm = weight_bf16.transpose([0, 2, 1]).contiguous()
+
+        x_2d = x.reshape([-1, d]).contiguous()
+        x_fp8, x_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
+            x_2d,
+            output_scale_transpose=False,
+            quant_method="1x128",
+            input_transpose=False,
+            using_pow2_scale=True,
+        )[:2]
+        x_fp8 = x_fp8.reshape([b * sq, num_groups, d])
+        x_scale = x_scale.reshape([b * sq, num_groups, -1])
+
+        weight_fp8, weight_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
+            weight_for_gemm.reshape([-1, weight_for_gemm.shape[-1]]),
+            output_scale_transpose=False,
+            quant_method="128x128",
+            input_transpose=False,
+            using_pow2_scale=True,
+        )[:2]
+        weight_fp8 = weight_fp8.reshape([num_groups, d, o_lora_rank])
+        weight_scale = weight_scale.reshape([num_groups, d // 128, o_lora_rank // 128])
+
+        out = paddle.empty([b * sq, num_groups, o_lora_rank], dtype=paddle.bfloat16)
+        deep_gemm.fp8_einsum(
+            "bhd,hdr->bhr",
+            (x_fp8, x_scale),
+            (weight_fp8, weight_scale),
+            out,
+            recipe=(1, 128, 128),
+        )
+
+        ctx.save_for_backward(x, weight_bf16)
+        ctx.num_groups = num_groups
+        ctx.o_lora_rank = o_lora_rank
+        ctx.fp8_wgrad = fp8_wgrad
+        return out.reshape([b, sq, num_groups * o_lora_rank])
+
+    @staticmethod
+    def backward(ctx, grad_output: Tensor):
+        x, weight = ctx.saved_tensor()
+        num_groups = ctx.num_groups
+        o_lora_rank = ctx.o_lora_rank
+        fp8_wgrad = ctx.fp8_wgrad
+        b, sq, _, d = x.shape
+        grad_output = grad_output.reshape([b, sq, num_groups, o_lora_rank])
+        print(f"[fp8_grouped_output] backward: grad_output={list(grad_output.shape)} x={list(x.shape)} fp8_wgrad={fp8_wgrad}", flush=True) if not GroupedOutputFP8._logged_bwd else None
+        GroupedOutputFP8._logged_bwd = True
+
+        # dgrad: always FP8
+        # grad_x = grad_output @ weight, "bhr,hdr->bhd"
+        # weight is [g, r, d], need [g, d, r] for "hdr" layout
+        grad_out_2d = grad_output.reshape([-1, o_lora_rank]).contiguous()
+        go_fp8, go_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
+            grad_out_2d,
+            output_scale_transpose=False,
+            quant_method="1x128",
+            input_transpose=False,
+            using_pow2_scale=True,
+        )[:2]
+        go_fp8 = go_fp8.reshape([b * sq, num_groups, o_lora_rank])
+        go_scale = go_scale.reshape([b * sq, num_groups, -1])
+
+        w_for_dgrad = weight.transpose([0, 2, 1]).contiguous()  # [g, r, d] -> [g, d, r]
+        w_2d = w_for_dgrad.reshape([-1, o_lora_rank]).contiguous()  # [g*d, r]
+        w_fp8, w_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
+            w_2d,
+            output_scale_transpose=False,
+            quant_method="128x128",
+            input_transpose=False,
+            using_pow2_scale=True,
+        )[:2]
+        w_fp8 = w_fp8.reshape([num_groups, d, o_lora_rank])
+        w_scale = w_scale.reshape([num_groups, d // 128, o_lora_rank // 128])
+
+        grad_x = paddle.empty([b * sq, num_groups, d], dtype=paddle.bfloat16)
+        deep_gemm.fp8_einsum(
+            "bhr,hdr->bhd",
+            (go_fp8, go_scale),
+            (w_fp8, w_scale),
+            grad_x,
+            recipe=(1, 128, 128),
+        )
+        grad_x = grad_x.reshape([b, sq, num_groups, d])
+
+        # wgrad
+        if fp8_wgrad:
+            # grad_weight = x^T @ grad_output, "bhd,bhr->hdr"
+            # DeepGEMM internally permutes A,B by {1,2,0} -> [h,d,b] @ [h,r,b]^T
+            # fp8_bmm with recipe=(1,1,128) expects A_scale: [h, d, ceil_div(b,128)]
+            # So we need to quant along the b dimension (last dim after permute)
+            # Approach: permute to [h,d,b], quant 2D [h*d, b] with 1x128, get scale [h*d, b//128]
+            x_wgrad = x.reshape([b * sq, num_groups, d]).transpose([1, 2, 0]).contiguous()  # [h, d, b*sq]
+            x_w_2d = x_wgrad.reshape([-1, b * sq]).contiguous()  # [h*d, b*sq]
+            x_fp8_w, x_scale_w = paddle.incubate.nn.functional.fp8_quant_blockwise(
+                x_w_2d,
+                output_scale_transpose=False,
+                quant_method="1x128",
+                input_transpose=False,
+                using_pow2_scale=True,
+            )[:2]
+            # scale: [h*d, ceil(b*sq/128)] -> reshape to [h, d, ceil(b*sq/128)]
+            x_fp8_w = x_fp8_w.reshape([num_groups, d, b * sq])
+            x_scale_w = x_scale_w.reshape([num_groups, d, -1])
+
+            go_wgrad = grad_output.reshape([b * sq, num_groups, o_lora_rank]).transpose([1, 2, 0]).contiguous()  # [h, r, b*sq]
+            go_w_2d = go_wgrad.reshape([-1, b * sq]).contiguous()  # [h*r, b*sq]
+            go_fp8_w, go_scale_w = paddle.incubate.nn.functional.fp8_quant_blockwise(
+                go_w_2d,
+                output_scale_transpose=False,
+                quant_method="1x128",
+                input_transpose=False,
+                using_pow2_scale=True,
+            )[:2]
+            go_fp8_w = go_fp8_w.reshape([num_groups, o_lora_rank, b * sq])
+            go_scale_w = go_scale_w.reshape([num_groups, o_lora_rank, -1])
+
+            # Now pass pre-permuted tensors. But fp8_einsum will permute {1,2,0} again!
+            # We need to pass in the ORIGINAL [b,h,d] layout so kernel can permute internally.
+            # Re-permute back: [h,d,b] -> [b,h,d]
+            x_fp8_w = x_fp8_w.transpose([2, 0, 1]).contiguous()  # [b*sq, h, d]
+            x_scale_w = x_scale_w.transpose([2, 0, 1]).contiguous()  # [ceil(b/128), h, d]
+            go_fp8_w = go_fp8_w.transpose([2, 0, 1]).contiguous()  # [b*sq, h, r]
+            go_scale_w = go_scale_w.transpose([2, 0, 1]).contiguous()  # [ceil(b/128), h, r]
+
+            grad_weight = paddle.empty([num_groups, d, o_lora_rank], dtype=paddle.bfloat16)
+            deep_gemm.fp8_einsum(
+                "bhd,bhr->hdr",
+                (x_fp8_w, x_scale_w),
+                (go_fp8_w, go_scale_w),
+                grad_weight,
+                recipe=(1, 1, 128),
+            )
+            grad_weight = grad_weight.transpose([0, 2, 1]).contiguous()  # [g, d, r] -> [g, r, d]
+        else:
+            # bf16 path
+            grad_weight = paddle.einsum("bsgd,bsgr->grd", x, grad_output)
+
+        return grad_x, grad_weight.reshape([num_groups * o_lora_rank, d])
 
 
 from paddlefleet.transformer.utils import (
@@ -243,6 +406,8 @@ class DSv4HybridAttention(Attention):
             tp_group=self.pg_collection.tp,
         )
         self.use_fp8_qat = getattr(config, "use_fp8_qat", False)
+        self.use_fp8_grouped_output = getattr(config, "fp8", False) and _DEEP_GEMM_AVAILABLE
+        self.fp8_wgrad = getattr(config, "fp8_wgrad", False)
 
     def forward(
         self,
@@ -363,13 +528,22 @@ class DSv4HybridAttention(Attention):
 
         # Grouped output projection
         core_attn_out = core_attn_out.reshape([b, sq, self.o_local_groups, -1])
-        wo_a_weight = self.linear_o_group_proj.reshape(
-            [self.o_local_groups, self.config.o_lora_rank, -1]
-        )
-        core_attn_out = paddle.einsum(
-            "...gd,grd->...gr", core_attn_out, wo_a_weight
-        )
-        core_attn_out = core_attn_out.reshape([b, sq, -1])
+        if self.use_fp8_grouped_output:
+            core_attn_out = GroupedOutputFP8.apply(
+                core_attn_out,
+                self.linear_o_group_proj,
+                self.o_local_groups,
+                self.config.o_lora_rank,
+                self.fp8_wgrad,
+            )
+        else:
+            wo_a_weight = self.linear_o_group_proj.reshape(
+                [self.o_local_groups, self.config.o_lora_rank, -1]
+            )
+            core_attn_out = paddle.einsum(
+                "...gd,grd->...gr", core_attn_out, wo_a_weight
+            )
+            core_attn_out = core_attn_out.reshape([b, sq, -1])
 
         # Output projection
         output, bias = self.o_proj(core_attn_out)

--- a/src/paddlefleet/transformer/moe/fp8_utils.py
+++ b/src/paddlefleet/transformer/moe/fp8_utils.py
@@ -85,6 +85,9 @@ try:
 except:
     pass
 
+# Use deep_gemm on Blackwell (SM100) and above
+_USE_DEEP_GEMM = paddle.device.cuda.get_device_capability()[0] >= 10
+
 try:
     from paddle.incubate.nn.functional import fused_transpose_wlch_split_quant
 except ImportError:
@@ -291,12 +294,18 @@ def kitchen_gemm(
     out=None,
     rtn_dtype=paddle.bfloat16,
 ):
-    # if USE_DS_GEMM:
-    #     if out is None:
-    #         out = paddle.zeros([x_fp8.shape[0], w_fp8.shape[0]], rtn_dtype)
-    #     if numpy.prod(x_fp8.shape) != 0 and numpy.prod(w_fp8.shape) != 0:
-    #         deep_gemm.wgrad_gemm_fp8_fp8_fp32_nt((x_fp8, x_scale), (w_fp8, w_scale), out, num_sms=get_sm_num())
-    #     return out
+    if _USE_DEEP_GEMM:
+        if out is not None:
+            c = out
+        else:
+            c = paddle.empty([x_fp8.shape[0], w_fp8.shape[0]], rtn_dtype)
+        if numpy.prod(x_fp8.shape) != 0 and numpy.prod(w_fp8.shape) != 0:
+            recipe = (1, 1, 128) if (is_a_1d_scaled and is_b_1d_scaled) else None
+            deep_gemm.fp8_gemm_nt(
+                (x_fp8, x_scale), (w_fp8, w_scale), c,
+                c=out, recipe=recipe,
+            )
+        return c
 
     if out is not None:
         accumulate = True
@@ -1250,6 +1259,51 @@ class ExpertsGroupGemmContiguousNode:
         )
         return out, scale
 
+    def k_grouped_fp8_weight_grad(
+        self,
+        x_t_fp8,
+        x_t_scale,
+        dy_t_fp8,
+        dy_t_scale,
+        weights,
+    ):
+        if not (
+            self.moe_expert_fusion
+            and (not self.use_fp8_mlp or self.moe_deep_gemm)
+            and _USE_DEEP_GEMM
+            and hasattr(deep_gemm, "k_grouped_fp8_gemm_tn_contiguous")
+        ):
+            return False
+
+        x_fp8 = paddle.concat([x.T.contiguous() for x in x_t_fp8], axis=0)
+        dy_fp8 = paddle.concat([x.T.contiguous() for x in dy_t_fp8], axis=0)
+        x_scale = paddle.concat(x_t_scale, axis=0)
+        dy_scale = paddle.concat(dy_t_scale, axis=0)
+
+        if hasattr(weights, "main_grad"):
+            if weights.main_grad is None:
+                weights.main_grad = paddle.zeros(weights.shape, dtype=paddle.float32)
+            weight_grad = weights.main_grad
+        else:
+            if weights.grad is None:
+                weights.grad = paddle.zeros(weights.shape, dtype=paddle.float32)
+            weight_grad = weights.grad
+
+        deep_gemm.k_grouped_fp8_gemm_tn_contiguous(
+            (x_fp8, x_scale),
+            (dy_fp8, dy_scale),
+            weight_grad,
+            self.tokens_per_expert,
+            self.tokens_per_expert_tensor,
+            weight_grad,
+            recipe=(1, 1, 128),
+            compiled_dims="mn",
+        )
+
+        if hasattr(weights, "_apply_backward_hook") and not weights.stop_gradient:
+            weights._apply_backward_hook()
+        return True
+
     def bwd_down_weight(self, do3, o2, expert_w2):
         """
         dw2 = do2_t * do3
@@ -1262,18 +1316,25 @@ class ExpertsGroupGemmContiguousNode:
             do3, None, self.tokens_per_expert, True
         )
 
+        if self.k_grouped_fp8_weight_grad(
+            o2_t_fp8, o2_t_scale, do3_t_fp8, do3_t_scale, expert_w2
+        ):
+            return
+
         for i in range(len(expert_w2)):
             if hasattr(expert_w2[i], "main_grad"):
                 if expert_w2[i].main_grad is None:
                     expert_w2[i].main_grad = paddle.zeros(
                         shape=expert_w2[i].shape, dtype=paddle.float32
                     )
-                if self.use_ue8m0:
+                if _USE_DEEP_GEMM:
                     deep_gemm.fp8_gemm_nt(
                         (o2_t_fp8[i], o2_t_scale[i].T),
                         (do3_t_fp8[i], do3_t_scale[i].T),
                         expert_w2[i].main_grad,
                         expert_w2[i].main_grad,
+                        recipe=(1,1,128),
+                        compiled_dims="mn",
                     )
                 else:
                     kitchen_gemm(
@@ -1291,12 +1352,14 @@ class ExpertsGroupGemmContiguousNode:
                     expert_w2[i].grad = paddle.zeros(
                         shape=expert_w2[i].shape, dtype=paddle.float32
                     )
-                if self.use_ue8m0:
+                if _USE_DEEP_GEMM:
                     deep_gemm.fp8_gemm_nt(
                         (o2_t_fp8[i], o2_t_scale[i].T),
                         (do3_t_fp8[i], do3_t_scale[i].T),
                         expert_w2[i].grad,
                         expert_w2[i].grad,
+                        recipe=(1,1,128),
+                        compiled_dims="mn",
                     )
                 else:
                     kitchen_gemm(
@@ -1351,18 +1414,25 @@ class ExpertsGroupGemmContiguousNode:
             do1, None, self.tokens_per_expert, True
         )
 
+        if self.k_grouped_fp8_weight_grad(
+            input_x_t_fp8, input_x_t_scale, do1_t_fp8, do1_t_scale, expert_w1
+        ):
+            return
+
         for i in range(len(expert_w1)):
             if hasattr(expert_w1[i], "main_grad"):
                 if expert_w1[i].main_grad is None:
                     expert_w1[i].main_grad = paddle.zeros(
                         shape=expert_w1[i].shape, dtype=paddle.float32
                     )
-                if self.use_ue8m0:
+                if _USE_DEEP_GEMM:
                     deep_gemm.fp8_gemm_nt(
                         (input_x_t_fp8[i], input_x_t_scale[i].T),
                         (do1_t_fp8[i], do1_t_scale[i].T),
                         expert_w1[i].main_grad,
                         expert_w1[i].main_grad,
+                        recipe=(1,1,128),
+                        compiled_dims="mn",
                     )
                 else:
                     kitchen_gemm(
@@ -1380,12 +1450,14 @@ class ExpertsGroupGemmContiguousNode:
                     expert_w1[i].grad = paddle.zeros(
                         shape=expert_w1[i].shape, dtype=paddle.float32
                     )
-                if self.use_ue8m0:
+                if _USE_DEEP_GEMM:
                     deep_gemm.fp8_gemm_nt(
                         (input_x_t_fp8[i], input_x_t_scale[i].T),
                         (do1_t_fp8[i], do1_t_scale[i].T),
                         expert_w1[i].grad,
                         expert_w1[i].grad,
+                        recipe=(1,1,128),
+                        compiled_dims="mn",
                     )
                 else:
                     kitchen_gemm(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
# Core Code Flow

## 1. Dense Linear FP8 Path

```
                                  forward
                                  ───────
 input (bf16, [b*s, h])           weight (bf16, [h, h'])
       │                              │
       │ reshape to 2D if needed      │ .T.contiguous() → [h', h]
       │                              │
       ▼                              ▼
 inp_quant_func(1x128)         weight_quant_func(128x128)
       │                              │
       ▼                              ▼
 inp_fp8 + inp_scale           weight_fp8 + weight_scale  ◄── cached
       │                              │
       └─────────┬────────────────────┘
                 ▼
     deep_gemm.fp8_gemm_nt(A, B) = A @ B.T
          = [b*s, h] @ [h, h'] = [b*s, h']
                 │
                 ▼
            output (bf16, [b*s, h'])
```
```
                                  backward dgrad
                                  ──────────────
 grad_output (bf16, [b*s, h'])      weight_fp8 ([h', h], cached)
       │                              │
       ▼                              │
 fp8_quant_blockwise(1x128)           │
       │                              │
       ▼                              ▼
 grad_out_fp8 + scale          weight_fp8.T.contiguous() → [h, h']
       │                              │
       └─────────┬────────────────────┘
                 ▼
     deep_gemm.fp8_gemm_nt = [b*s, h'] @ [h', h] = [b*s, h]
                 │
                 ▼
           grad_input (bf16, [b*s, h])
```
```
                                  backward wgrad
                                  ──────────────
 grad_output (bf16, [b*s, h'])      total_input (bf16, [b*s, h]) ← all_gathered
       │                              │
       │ .T.contiguous()              │ .T.contiguous()
       ▼                              ▼
 grad_out_T ([h', b*s])            inp_T ([h, b*s])  ──── or reuse from ctx.inp_t_fp8
       │                              │
       ▼                              ▼
 fp8_quant_blockwise(1x128)     fp8_quant_blockwise(1x128)
       │                              │
       ▼                              ▼
 go_t_fp8 + go_t_scale          inp_t_fp8 + inp_t_scale
       │                              │
       └─────────┬────────────────────┘
                 ▼
     deep_gemm.fp8_gemm_nt = [h, b*s] @ [b*s, h'] = [h, h']  ✓
                 │
                 ▼
           grad_weight (bf16, [h, h'])
```

## 2 Attention Grouped Output FP8 Path

```text
Input: x = [b, sq, g, d],  weight = [g*r, d]  (r = o_lora_rank)
```
```
                                  forward
                                  ───────
 x ([b, sq, g, d])              weight ([g*r, d])
       │                              │
       │ reshape [b*sq, d]            │ reshape [g, r, d] → permute [g, d, r]
       ▼                              ▼
 fp8_quant(1x128, pow2)         fp8_quant(128x128, pow2)
       │                              │
       ▼                              ▼
 x_fp8 [b*sq, g, d]            w_fp8 [g, d, r]
       │                              │
       └─────────┬────────────────────┘
                 ▼
         fp8_einsum("bhd,hdr->bhr")
          = [b*sq, g, d] @ [g, d, r] = [b*sq, g, r]
                 │
                 ▼
         out = [b, sq, g*r] (bf16)
```
```
                                  backward dgrad
                                  ──────────────
 grad_output [b, sq, g, r]      weight [g, r, d]
       │                              │
       │ reshape 2D + quant            │ permute [g, d, r] + quant(128x128)
       ▼                              ▼
 go_fp8 [b*sq, g, r]            w_fp8 [g, d, r]
       │                              │
       └─────────┬────────────────────┘
                 ▼
         fp8_einsum("bhr,hdr->bhd")
          = [b*sq, g, r] @ [g, r, d] = [b*sq, g, d]
                 │
                 ▼
           grad_x = [b, sq, g, d]
```
```
                                  backward wgrad
                                  ──────────────
 x [b, sq, g, d]                grad_output [b, sq, g, r]
       │                              │
       │ permute [g, d, b*sq]         │ permute [g, r, b*sq]
       │ reshape [g*d, b*sq]          │ reshape [g*r, b*sq]
       │ quant(1x128, pow2)           │ quant(1x128, pow2)
       │ re-permute back [b*sq, g, d] │ re-permute back [b*sq, g, r]
       ▼                              ▼
 x_fp8_w [b*sq, g, d]          go_fp8_w [b*sq, g, r]
       │                              │
       └─────────┬────────────────────┘
                 ▼
         fp8_einsum("bhd,bhr->hdr", recipe=(1,1,128))
          = [b*sq, g, d] @ [b*sq, g, r]^T = [g, d, r]  (batch dim contracted)
                 │
                 ▼
         grad_weight = [g, d, r] → permute [g, r, d] → reshape [g*r, d]
```

## 3. MoE FP8 Enhancement

```
bwd_down_weight / bwd_up_weight:

  Try k_grouped_fp8_weight_grad()         ← new grouped FP8 wgrad
  ────────────────────────────────
  x_t_fp8, dy_t_fp8 → concat per expert
      → deep_gemm.k_grouped_fp8_gemm_tn_contiguous(recipe=(1,1,128))
      → write to weight.main_grad or weight.grad
      → return on success (skip per-expert loop)
                 │
            fallback on failure
                 ▼
  Per-expert loop:
    if _USE_DEEP_GEMM:                     ← originally checked use_ue8m0
      deep_gemm.fp8_gemm_nt(recipe=(1,1,128), compiled_dims="mn")
    else:
      kitchen_gemm(...)                    ← old path fallback
```

---

## 4. non FP8 layer

**CSA/HSA Compressor**: `wkv`, `wgate`
**CSA /DSA Indexer**: `weights_proj` 
**GPTLMHead** 

---

# Limited
1. only support TP == 1
2. always save origin_input (bfloat16) for backward
3. always quant weight on the fly


