### PR TITLE
Fix memory leak caused by c_pointers

### DIFF
--- a/packages/paddlefleet_ops/src/paddlefleet_ops/__init__.py
+++ b/packages/paddlefleet_ops/src/paddlefleet_ops/__init__.py
@@ -22,6 +22,65 @@ from typing import Any
 
 import paddle
 
+
+# ---------------------------------------------------------------------------
+# Patch CUTLASS DSL scalar types to cache __c_pointers__ results.
+# Prevents pymalloc arena fragmentation from short-lived ctypes objects
+# created on every kernel launch. Must run before any CUTLASS kernel is called.
+# ---------------------------------------------------------------------------
+def _patch_cutlass_cptr_cache(maxsize=4096):
+    try:
+        from cutlass.base_dsl import typing as _typing
+    except Exception:
+        return 0
+    _logger = logging.getLogger(__name__)
+    _warned = set()
+    count = 0
+
+    def _make_cached(orig_fn, cache, cls_name):
+        def _cached(self):
+            v = self.value
+            r = cache.get(v)
+            if r is None:
+                r = orig_fn(self)
+                if len(cache) < maxsize:
+                    cache[v] = r
+                elif cls_name not in _warned:
+                    _warned.add(cls_name)
+                    _logger.warning(
+                        f"[cptr_cache] {cls_name}.__c_pointers__ cache exceeded "
+                        f"{maxsize} entries. Dynamic scalar values may cause "
+                        f"pymalloc arena fragmentation."
+                    )
+            return r
+
+        return _cached
+
+    _Numeric = getattr(_typing, "Numeric", None)
+    for name in dir(_typing):
+        cls = getattr(_typing, name)
+        if (
+            isinstance(cls, type)
+            and "__c_pointers__" in cls.__dict__
+            and _Numeric
+            and issubclass(cls, _Numeric)
+            and cls is not _Numeric
+            and not name.startswith("_")
+        ):
+            cache = {}
+            cls.__c_pointers__ = _make_cached(cls.__c_pointers__, cache, name)
+            count += 1
+    return count
+
+
+_patched_count = _patch_cutlass_cptr_cache()
+if _patched_count:
+    logging.getLogger(__name__).warning(
+        f"[cptr_cache] Patched {_patched_count} CUTLASS DSL types"
+    )
+del _patch_cutlass_cptr_cache, _patched_count
+# ---------------------------------------------------------------------------
+
 from .utils import (
     HardwareIncompatibleBlocker,
     ModuleContext,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Fix memory fragmentation caused by uncached __c_pointers__() in CUTLASS DSL scalar types.

  **Problem**:
  CUTLASS DSL scalar types (Int32, Float32, Float64, Float16, BFloat16, TFloat32 等) 的 __c_pointers__() 方法在每次 kernel 调用时都会创建新的 ctypes
  对象。在训练循环中高频 kernel launch 场景下，这些短生命周期对象与框架长生命周期对象交替分配，导致 pymalloc arena 碎片化，进程 RSS 单调增长

  **Fix**:
  在 paddlefleet_ops/__init__.py 中添加 monkey-patch，对所有 CUTLASS DSL Numeric 子类的 __c_pointers__() 方法注入 per-type cache（dict keyed by
  scalar value）。首次调用时缓存结果，后续相同值直接返回缓存，避免重复创建 ctypes 对象。

**验证生效**
在日志搜索是否存在：[cptr_cache] Result: patched 18 types

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否