### PR TITLE
[release/0.3] fix pp send in gpt embedding

### DIFF
--- a/src/paddlefleet/models/gpt/gpt_embedding.py
+++ b/src/paddlefleet/models/gpt/gpt_embedding.py
@@ -171,6 +171,11 @@ class GPTEmbedding(FleetLayer):
             attn_mask_startend_row_indices = dict_args.get(
                 "startend_row_indices", None
             )
+        attn_mask_startend_row_indices = (
+            attn_mask_startend_row_indices.to(device)
+            if attn_mask_startend_row_indices is not None
+            else None
+        )
         deepstack_image_embeds = dict_args.get("deepstack_image_embeds", None)
         deepstack_video_embeds = dict_args.get("deepstack_video_embeds", None)
         visual_pos_masks = None
@@ -633,7 +638,7 @@ class GPTEmbedding(FleetLayer):
                 )
 
         preproc_output = {
-            "hidden_states": decoder_input,
+            "hidden_states": decoder_input.contiguous(),  # prepare for pp send
             "attention_mask": attention_mask,
             "attn_mask_startend_row_indices": attn_mask_startend_row_indices,
             "rotary_pos_emb": rotary_pos_emb,


### PR DESCRIPTION
### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library  | Environment Adaptation ] -->
Distributed Strategy
### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes
### Description
<!-- Describe what you’ve done -->
修复 GPTEmbedding.forward 中 Pipeline Parallel send 前的张量准备：将 attn_mask_startend_row_indices 移动到当前设备，并在 preproc_output 中将 hidden_states 转为 contiguous，以适配 PP P2P send 对设备和连续内存的要求。

无精度变化

Cherry-pick of #1335 to `release/0.3`.

Merged in dev: #1335  <!-- For pass CI -->