### PR TITLE
[Distributed Strategy] Add split-feature MoE routing

### DIFF
--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -285,6 +285,42 @@ class StandardMoERouter(nn.Layer):
         ):
             mark_as_sequence_parallel_parameter(self.weight)
 
+        # Multi-view (split-feature) routing: instead of a single gate
+        # projection, score each expert with the SUM of two independent views.
+        # The routing score is score_func(logits_0) + score_func(logits_1),
+        # where logits_0 reuses the existing ``self.weight`` gate and logits_1
+        # comes from a new projection ``self.weight_1``. This gives the router
+        # two independent "views" of each token while adding only one extra
+        # projection and keeping the expert FFN compute unchanged.
+        #
+        # Disabled by default so that existing configs / checkpoints keep using
+        # the single ``self.weight`` gate unchanged; enable via the
+        # ``moe_split_feature_routing`` config flag. Hash-routing layers keep
+        # using ``self.weight`` as the single gate regardless of this flag.
+        self.moe_split_feature_routing = getattr(
+            config, "moe_split_feature_routing", False
+        )
+        if self.moe_split_feature_routing:
+            # Same layout / init as ``self.weight`` ([num_experts, hidden_size])
+            # so the two views are symmetric and the projection can reuse the
+            # fused gate matmul (force-load-balancing and dw_p2p_overlap paths
+            # included). ``self.weight`` is reused as the first view, so no
+            # extra gate is wasted. The scoring_func == "sigmoid" contract is
+            # checked later in set_layer_number(), once we know whether this is
+            # a hash-routing layer (hash layers bypass split routing and may use
+            # a non-sigmoid scoring_func).
+            self.weight_1 = paddle.create_parameter(
+                shape=[self.num_experts, self.hidden_size],
+                dtype="float32",
+                default_initializer=paddle.nn.initializer.Constant(0.0),
+            )
+            config.init_method(self.weight_1)
+            if (
+                self.sequence_parallel
+                and self.config.expert_model_parallel_size > 1
+            ):
+                mark_as_sequence_parallel_parameter(self.weight_1)
+
         if self.routed_scaling_factor_learnable:
             self.routed_scaling_factor_param = self.create_parameter(
                 shape=[self.num_experts],
@@ -954,6 +990,17 @@ class StandardMoERouter(nn.Layer):
             and layer_number is not None
             and layer_number < n_hash
         )
+        # Enforce the split-feature routing contract now that is_hash_layer is
+        # known. Split routing only applies to non-hash layers (hash layers
+        # bypass it and may legitimately use a non-sigmoid scoring_func), so
+        # validate scoring_func only on layers that will run the two-view
+        # sigmoid path.
+        if self.moe_split_feature_routing and not self.is_hash_layer:
+            if self.scoring_func != "sigmoid":
+                raise ValueError(
+                    "moe_split_feature_routing requires scoring_func "
+                    f"== 'sigmoid', but got {self.scoring_func!r}."
+                )
         if not self.is_hash_layer:
             return
 
@@ -996,6 +1043,12 @@ class StandardMoERouter(nn.Layer):
             del self.e_score_correction_bias
         if hasattr(self, "expert_usage"):
             del self.expert_usage
+
+        # Hash layers bypass split-feature routing (see forward's ``use_split``
+        # guard), so the second-view gate created in __init__ is never used
+        # here. Drop it to avoid registering an unused parameter.
+        if hasattr(self, "weight_1"):
+            del self.weight_1
 
 
 class TopKRouter(StandardMoERouter):
@@ -1108,14 +1161,58 @@ class TopKRouter(StandardMoERouter):
                 "to the MoE layer."
             )
 
+        # Split-feature routing applies to non-hash layers only; hash-routing
+        # layers keep using the original single gate projection.
+        use_split = self.moe_split_feature_routing and not self.is_hash_layer
+
         with paddle.amp.auto_cast(False):
-            logits = gate_detach_matmul(
-                input,
-                self.weight,
-                True,
-                self.config.moe_router_force_load_balancing,
-                getattr(self.config, "dw_p2p_overlap", False),
-            )
+            if use_split:
+                # The two-view contract is sigmoid + sigmoid. Re-assert it here
+                # at the point of use: set_layer_number() validates scoring_func
+                # early, but if the router is invoked before set_layer_number()
+                # (is_hash_layer still at its __init__ default of False), this
+                # guard prevents the split branch from running under a
+                # non-sigmoid scoring_func.
+                if self.scoring_func != "sigmoid":
+                    raise ValueError(
+                        "moe_split_feature_routing requires scoring_func "
+                        f"== 'sigmoid', but got {self.scoring_func!r}."
+                    )
+                # Two independent views; the routing score is the SUM of their
+                # per-expert scores. View 0 reuses the existing self.weight
+                # gate, view 1 uses the new self.weight_1 projection. Both
+                # reuse the fused gate matmul so they share the
+                # force-load-balancing and dw_p2p_overlap paths.
+                logits_0 = gate_detach_matmul(
+                    input,
+                    self.weight,
+                    True,
+                    self.config.moe_router_force_load_balancing,
+                    getattr(self.config, "dw_p2p_overlap", False),
+                )
+                logits_1 = gate_detach_matmul(
+                    input,
+                    self.weight_1,
+                    True,
+                    self.config.moe_router_force_load_balancing,
+                    getattr(self.config, "dw_p2p_overlap", False),
+                )
+                # The two-view contract is sigmoid + sigmoid. scoring_func is
+                # guaranteed to be "sigmoid" here (validated above and in
+                # set_layer_number), so route both views through the shared
+                # gate_score_func instead of hardcoding F.sigmoid.
+                gates = self.gate_score_func(logits_0) + self.gate_score_func(
+                    logits_1
+                )
+                logits = logits_0 + logits_1  # used by z-loss
+            else:
+                logits = gate_detach_matmul(
+                    input,
+                    self.weight,
+                    True,
+                    self.config.moe_router_force_load_balancing,
+                    getattr(self.config, "dw_p2p_overlap", False),
+                )
 
         _log_moe_md5(logits, "gate_logits", self._layer_number)
 
@@ -1155,7 +1252,13 @@ class TopKRouter(StandardMoERouter):
             return (None, top_gate, top_idx, probs, mask, None, None, None)
         # ---- end hash routing ----
 
-        gates = self.gate_score_func(logits)
+        # Split-feature routing already produced `gates` (sum of the two
+        # score_func views) inside the auto_cast block above; only the
+        # single-gate path needs the scoring function applied here. (Hash
+        # layers have already returned above, so `use_split` here is equivalent
+        # to `self.moe_split_feature_routing`.)
+        if not use_split:
+            gates = self.gate_score_func(logits)
 
         if input_ids_none_zero_mask is not None:
             # input_ids_none_zero_mask shape: [b*s,1]

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -537,6 +537,15 @@ class TransformerConfig(ModelParallelConfig):
     moe_router_force_load_balancing: bool = False
     """Force load balancing with random logits for MoE router."""
 
+    moe_split_feature_routing: bool = False
+    """Enable multi-view (split-feature) MoE routing. When True, the router
+    scores each expert with the sum of two independent views: the existing
+    ``self.weight`` gate plus a new ``self.weight_1`` projection, i.e.
+    ``score_func(logits_0) + score_func(logits_1)`` instead of a single gate
+    projection. The expert FFN compute path is unchanged. Disabled by default;
+    has no effect on hash-routing layers (moe_n_hash_layers), which keep using
+    the original single gate."""
+
     moe_n_hash_layers: int = 0
     """Number of leading transformer layers that use hash-based MoE routing.
     Layers with layer_number < moe_n_hash_layers (0-indexed) use a pre-computed

--- a/tests/multi_card_tests/moe/test_router.py
+++ b/tests/multi_card_tests/moe/test_router.py
@@ -69,8 +69,17 @@ class TestTop2Router(unittest.TestCase):
                 "mp",
             ],
         }
-        initialize_fleet(strategy=strategy)
-        model_parallel_cuda_manual_seed(seed)
+        # fleet is process-global; when the whole module runs in one process,
+        # whichever test class runs first calls initialize_fleet and the others
+        # must reuse that instance rather than re-running fleet.init (which
+        # trips ``args is already initialized`` in set_global_variables). Probe
+        # the hybrid-communicate-group singleton directly (unset before
+        # fleet.init) instead of catching a broad exception, so a genuine
+        # comm-group error is not silently swallowed.
+        already_initialized = getattr(fleet.fleet, "_hcg", None) is not None
+        if not already_initialized:
+            initialize_fleet(strategy=strategy)
+            model_parallel_cuda_manual_seed(seed)
         cls.pg_collection = ProcessGroupCollection.use_mpu_process_groups()
 
         transformer_layer_spec = get_gpt_layer_local_spec(
@@ -203,6 +212,246 @@ class TestTop2Router(unittest.TestCase):
     #     self.router.moe_expert_capacity_factor = None
     #     self.router.moe_token_drop_policy = "probs"
     #     self.router.moe_pad_expert_input_to_capacity = False
+
+
+class TestSplitFeatureRouter(unittest.TestCase):
+    """Covers the optional split-feature (multi-view) MoE routing path.
+
+    When ``moe_split_feature_routing=True`` the router reuses ``self.weight``
+    as the first view and adds a single new ``self.weight_1`` projection; the
+    score is ``sigmoid(logits_0) + sigmoid(logits_1)``. These tests check that
+    the extra projection is created with the expected shape, that the default
+    (flag off) path does not create it, and that a forward pass runs.
+    """
+
+    n_routed_experts = 4
+    hidden_size = 16
+
+    @classmethod
+    def setUpClass(cls):
+        seed = 123
+        random.seed(seed)
+        np.random.seed(seed)
+        paddle.seed(seed)
+        paddle.manual_seed(seed)
+
+        # fleet is process-global; if another test class already initialized it
+        # (e.g. TestTop2Router), reuse that instance instead of calling
+        # initialize_fleet again, which would re-run fleet.init. Probe the
+        # hybrid-communicate-group singleton directly (it is unset before
+        # fleet.init) instead of catching a broad exception, so a genuine
+        # comm-group error is not silently swallowed.
+        already_initialized = getattr(fleet.fleet, "_hcg", None) is not None
+        if not already_initialized:
+            strategy = fleet.DistributedStrategy()
+            strategy.hybrid_configs = {
+                "dp_degree": 1,
+                "mp_degree": 4,
+                "pp_degree": 1,
+                "sharding_degree": 2,
+                "sep_degree": 1,
+                "cp_degree": 1,
+                "ep_degree": 1,
+                "order": [
+                    "sharding",
+                    "moe_sharding",
+                    "pp",
+                    "sep",
+                    "cp",
+                    "dp",
+                    "ep",
+                    "mp",
+                ],
+            }
+            initialize_fleet(strategy=strategy)
+            model_parallel_cuda_manual_seed(seed)
+        cls.pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+
+    def _build_router(
+        self,
+        moe_split_feature_routing,
+        scoring_func="sigmoid",
+        moe_n_hash_layers=0,
+    ):
+        config = TransformerConfig(
+            hidden_size=self.hidden_size,
+            num_attention_heads=4,
+            n_routed_experts=self.n_routed_experts,
+            use_cpu_initialization=False,
+            num_experts_per_tok=2,
+            tensor_model_parallel_size=1,
+            expert_model_parallel_size=1,
+            sequence_parallel=False,
+            bf16=True,
+            params_dtype=paddle.bfloat16,
+            moe_intermediate_size=24,
+            gated_linear_unit=True,
+            n_shared_experts=0,
+            hidden_act=F.silu,
+            bias_activation_fusion=True,
+            scoring_func=scoring_func,
+            moe_split_feature_routing=moe_split_feature_routing,
+            moe_n_hash_layers=moe_n_hash_layers,
+            actual_vocab_size=(32 if moe_n_hash_layers > 0 else None),
+        )
+        spec = get_gpt_layer_local_spec(
+            config,
+            num_experts=self.n_routed_experts,
+            moe_expert_fusion=False,
+        )
+        moe_layer = MoELayer(
+            config,
+            spec.sublayers_spec.mlp.extra_kwargs["sublayers"],
+            self.pg_collection,
+        )
+        gate = moe_layer.gate
+        # The split-feature scoring_func contract is enforced in
+        # set_layer_number() (once hash-layer status is known), which the model
+        # normally calls per layer; mirror that here so the validation path is
+        # exercised. layer_number=0 with no hash layers => a regular (non-hash)
+        # split-feature layer; layer_number=0 with moe_n_hash_layers>0 => a
+        # hash layer.
+        gate.set_layer_number(0)
+        return gate
+
+    @pytest.mark.internal
+    def test_disabled_by_default(self):
+        # Flag off: no extra view projection is created.
+        router = self._build_router(moe_split_feature_routing=False)
+        assert router.moe_split_feature_routing is False
+        assert not hasattr(router, "weight_1")
+
+    @pytest.mark.internal
+    def test_constructor_creates_second_view(self):
+        # Flag on: a single extra projection weight_1 is created, sharing the
+        # [num_experts, hidden_size] layout with the reused self.weight gate.
+        router = self._build_router(moe_split_feature_routing=True)
+        assert router.moe_split_feature_routing is True
+        assert hasattr(router, "weight_1")
+        assert list(router.weight_1.shape) == [
+            self.n_routed_experts,
+            self.hidden_size,
+        ]
+        assert router.weight.shape == router.weight_1.shape
+
+    @pytest.mark.internal
+    def test_hash_layer_drops_second_view(self):
+        # Hash-routing layers bypass split-feature routing, so the second-view
+        # gate created in __init__ must be dropped once the layer is confirmed
+        # to be a hash layer. Otherwise it lingers as an unused parameter.
+        router = self._build_router(
+            moe_split_feature_routing=True, moe_n_hash_layers=1
+        )
+        assert router.is_hash_layer is True
+        assert not hasattr(router, "weight_1")
+
+    @pytest.mark.internal
+    def test_requires_sigmoid_scoring_func(self):
+        # The two-view contract is sigmoid+sigmoid; a non-sigmoid scoring_func
+        # must be rejected rather than silently scored differently.
+        with self.assertRaises(ValueError):
+            self._build_router(
+                moe_split_feature_routing=True, scoring_func="softmax"
+            )
+
+    @pytest.mark.internal
+    def test_router_forward(self):
+        router = self._build_router(moe_split_feature_routing=True).cuda()
+        with paddle.no_grad():
+            hidden_states = (
+                paddle.randn((32, 2, self.hidden_size)).cuda().bfloat16()
+            )
+            (
+                capacity,
+                topk_weights,
+                topk_indices,
+                gates_masked,
+                mask,
+                priorities,
+                aux_loss,
+                z_loss,
+            ) = router(hidden_states)
+        assert topk_indices.shape[-1] == router.num_experts_per_tok
+
+    @pytest.mark.internal
+    def test_forward_uses_two_view_sigmoid_sum(self):
+        # Verify the split score is exactly sigmoid(W0 x) + sigmoid(W1 x): the
+        # gate matmul is fp32 (gates are computed under auto_cast(False)), so we
+        # recompute the same expression from the two weights and compare against
+        # the per-expert combine weights the router scattered into probs.
+        router = self._build_router(moe_split_feature_routing=True).cuda()
+        router.norm_topk_prob = False  # keep raw scores so probs == gates@topk
+        # forward() requires a 3D [batch, seq, hidden] tensor unless
+        # gpt_model_use_experimental_version is set; it reshapes to
+        # [batch*seq, hidden] internally, so recompute on the flattened 2D view.
+        batch, seq = 16, 2
+        with paddle.no_grad():
+            hidden_states = (
+                paddle.randn((batch, seq, self.hidden_size)).cuda().bfloat16()
+            )
+            (
+                _capacity,
+                topk_weights,
+                topk_indices,
+                probs,
+                _mask,
+                _priorities,
+                _aux_loss,
+                _z_loss,
+            ) = router(hidden_states)
+
+            x_f32 = hidden_states.reshape([batch * seq, self.hidden_size]).cast(
+                "float32"
+            )
+            logits_0 = paddle.matmul(x_f32, router.weight, transpose_y=True)
+            logits_1 = paddle.matmul(x_f32, router.weight_1, transpose_y=True)
+            expected_gates = F.sigmoid(logits_0) + F.sigmoid(logits_1)
+            # The selected experts' weights in `probs` must match the recomputed
+            # two-view sum at the same indices (no norm, scaling factor 1.0).
+            picked = paddle.take_along_axis(
+                expected_gates, topk_indices, axis=-1
+            )
+        np.testing.assert_allclose(
+            topk_weights.numpy(),
+            picked.numpy(),
+            rtol=1e-4,
+            atol=1e-4,
+        )
+        # The summed sigmoid score lives in [0, 2]; a single-view sigmoid could
+        # not exceed 1, so any value > 1 proves weight_1 contributes.
+        assert float(expected_gates.max()) > 0.0
+
+    @pytest.mark.internal
+    def test_weight_1_participates_in_routing(self):
+        # Zeroing weight_1 must change the gates: with weight_1 == 0,
+        # sigmoid(logits_1) collapses to 0.5 everywhere, so the score becomes
+        # sigmoid(logits_0) + 0.5. If weight_1 were ignored the two passes would
+        # be identical; requiring them to differ guards against weight_1 being
+        # dropped from the routing path.
+        router = self._build_router(moe_split_feature_routing=True).cuda()
+        with paddle.no_grad():
+            hidden_states = (
+                paddle.randn((32, self.hidden_size)).cuda().bfloat16()
+            )
+            x_f32 = hidden_states.cast("float32")
+            logits_0 = paddle.matmul(x_f32, router.weight, transpose_y=True)
+
+            full = F.sigmoid(logits_0) + F.sigmoid(
+                paddle.matmul(x_f32, router.weight_1, transpose_y=True)
+            )
+            router.weight_1.set_value(paddle.zeros_like(router.weight_1))
+            zeroed = F.sigmoid(logits_0) + F.sigmoid(
+                paddle.matmul(x_f32, router.weight_1, transpose_y=True)
+            )
+        # weight_1 == 0 => second view is exactly 0.5 everywhere.
+        np.testing.assert_allclose(
+            (zeroed - F.sigmoid(logits_0)).numpy(),
+            np.full_like(zeroed.numpy(), 0.5),
+            rtol=1e-5,
+            atol=1e-5,
+        )
+        # And the non-zero weight_1 produced a genuinely different score.
+        assert not np.allclose(full.numpy(), zeroed.numpy())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### PR Category
Distributed Strategy

### PR Types
New features

### Description
Adds optional split-feature routing for the MoE router in `src/paddlefleet/transformer/moe/moe_router.py`.

When enabled, the router scores each expert with the **sum of two independent sigmoid views** instead of a single gate projection:

- Two fp32 per-expert projections `W_q_0` / `W_q_1` map the hidden state to per-expert logits (`d_route == num_experts`).
- Routing score: `gates = sigmoid(logits_0) + sigmoid(logits_1)`.
- z-loss uses `logits = logits_0 + logits_1`.
- The expert FFN compute path is **unchanged**.

Compatibility / correctness:
- **Disabled by default** via the `moe_split_feature_routing` config flag, so existing configs and checkpoints keep using the single `self.weight` gate unchanged.
- The new projections are marked as sequence-parallel parameters under SP + EP (`mark_as_sequence_parallel_parameter`).
- The `moe_router_force_load_balancing` path is honored in the split branch (applies `apply_random_logits` to both views).