### PR TITLE
[release/0.3] Set num_qps_per_rank for deepep internode

### DIFF
--- a/src/paddlefleet/transformer/moe/fused_a2a.py
+++ b/src/paddlefleet/transformer/moe/fused_a2a.py
@@ -130,7 +130,12 @@ def get_buffer(group: Group, hidden_bytes: int):
         or _buffer.num_nvl_bytes < num_nvl_bytes
         or _buffer.num_rdma_bytes < num_rdma_bytes
     ):
-        _buffer = deep_ep.Buffer(group, num_nvl_bytes, num_rdma_bytes)
+        _buffer = deep_ep.Buffer(
+            group,
+            num_nvl_bytes,
+            num_rdma_bytes,
+            num_qps_per_rank=max(24, deep_ep.Buffer.num_sms),
+        )
     return _buffer
 
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
Operator Mechanism


### PR Types
Bug fixes


### Description
正确设置 DeepEP Buffer 初始化的`num_qps_per_rank`值

该值仅在 internode 模式生效，源码中约束必须 >= num_sms，默认为 24，但是之前没人在 internode 下使用超过 24 的 num_sms，所以没发现要设置这个值

internode 推荐配置：
```yaml
deepep_buffer_configs:
  num_sms: 52
  dispatch_config: [60, 512, 40, 128]
  combine_config: [20, 512, 40, 128]
```

### 是否引起精度变化
否


Cherry-pick of #1346 to `release/0.3`.

Merged in dev: #1346  <!-- For pass CI -->