### PR TITLE
update config approval

### DIFF
--- a/ci/check_approval.sh
+++ b/ci/check_approval.sh
@@ -83,7 +83,7 @@ MODELCONFIG_FILES=(
 for FILE in "${MODELCONFIG_FILES[@]}"; do
     HAS_MODIFIED=$(git diff --name-only "${DIFF_BASE}" HEAD -- | grep "^${FILE}" || true)
     if [ "${HAS_MODIFIED}" != "" ] && [ "${PR_ID}" != "" ]; then
-        echo_line="You must be approved by two of ${MODELCONFIG_APPROVERS} for changes in ${FILE}.\n"
+        echo_line="You must be approved by one of ${MODELCONFIG_APPROVERS} for changes in ${FILE}.\n"
         APPROVER_LIST=(${MODELCONFIG_APPROVERS})
         check_approval 1 "${APPROVER_LIST[@]}"
     fi

--- a/ci/check_approval.sh
+++ b/ci/check_approval.sh
@@ -75,7 +75,7 @@ done
 
 
 
-MODELCONFIG_APPROVERS="sneaxiy From00 ForFishes Hz188 Waynezee"
+MODELCONFIG_APPROVERS="sneaxiy From00 ForFishes"
 MODELCONFIG_FILES=(
     "src/paddlefleet/model_parallel_config.py"
     "src/paddlefleet/transformer/transformer_config.py"
@@ -85,7 +85,7 @@ for FILE in "${MODELCONFIG_FILES[@]}"; do
     if [ "${HAS_MODIFIED}" != "" ] && [ "${PR_ID}" != "" ]; then
         echo_line="You must be approved by two of ${MODELCONFIG_APPROVERS} for changes in ${FILE}.\n"
         APPROVER_LIST=(${MODELCONFIG_APPROVERS})
-        check_approval 2 "${APPROVER_LIST[@]}"
+        check_approval 1 "${APPROVER_LIST[@]}"
     fi
 done
 


### PR DESCRIPTION
### PR Category
Execute Infrastructure
### PR Types
Improvements
### Description
Update `ci/check_approval.sh` for model config approval checks:
- reduce `MODELCONFIG_APPROVERS` to `sneaxiy From00 ForFishes`
- change approval count for `src/paddlefleet/model_parallel_config.py` and `src/paddlefleet/transformer/transformer_config.py` from 2 to 1
- no model/runtime precision change

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否