### PR TITLE
[release/0.3] support high_precision_norm in swa

### DIFF
--- a/src/paddlefleet/transformer/dsv4_hybrid_attention.py
+++ b/src/paddlefleet/transformer/dsv4_hybrid_attention.py
@@ -50,9 +50,15 @@ if TYPE_CHECKING:
     from paddlefleet.transformer.transformer_config import TransformerConfig
 
 
-def _q_rms_norm(q: Tensor, eps: float) -> Tensor:
+def _q_rms_norm(q: Tensor, eps: float, high_precision_norm: bool) -> Tensor:
     """RMS normalization for query (no learnable weight)."""
-    return q * paddle.rsqrt(q.square().mean(-1, keepdim=True) + eps)
+    if high_precision_norm:
+        ori_dtype = q.dtype
+        q = q.float()
+        q = q * paddle.rsqrt(q.square().mean(-1, keepdim=True) + eps)
+        return q.astype(ori_dtype)
+    else:
+        return q * paddle.rsqrt(q.square().mean(-1, keepdim=True) + eps)
 
 
 from paddlefleet.transformer.utils import (
@@ -332,7 +338,10 @@ class DSv4HybridAttention(Attention):
             mscale = 1.0
             freqs = freqs[:, position_offset : position_offset + sq, :]
 
-            if self.config.apply_rope_fusion:
+            if (
+                self.config.apply_rope_fusion
+                and not self.config.high_precision_rope
+            ):
                 from paddlefleet.triton_ops import fused_apply_mla_rope_inplace
 
                 # The clone is necessary because sparse attention depends on core_attn_out
@@ -357,6 +366,7 @@ class DSv4HybridAttention(Attention):
                     multi_latent_attention=True,
                     inverse=True,
                     mla_output_remove_interleaving=True,
+                    high_precision_rope=self.config.high_precision_rope,
                 )
                 core_attn_out = paddle.concat([content_part, rot_part], axis=-1)
                 core_attn_out = core_attn_out.reshape([b, sq, -1])
@@ -508,11 +518,23 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
 
         q, _ = self.linear_q_up_proj(q_compressed)  # [b, sq, n * v_head_dim]
         q = q.reshape([b, sq, self.num_attention_heads, self.v_head_dim])
-        q = _q_rms_norm(q, getattr(self.config, "rms_norm_eps", 1e-5))
+        q = _q_rms_norm(
+            q,
+            getattr(self.config, "rms_norm_eps", 1e-5),
+            high_precision_norm=self.config.swa_high_precision_norm,
+        )
 
         # KV path
         kv, _ = self.linear_kv_proj(hidden_states)  # [b, sq, v_head_dim]
-        kv = self.kv_layernorm(kv)
+
+        if self.config.swa_high_precision_norm:
+            kv = self.kv_layernorm(
+                kv,
+                high_precision_norm=True,
+                return_high_precision_norm=True,
+            )
+        else:
+            kv = self.kv_layernorm(kv)
 
         # Apply RoPE to both Q and KV
         pos_dim = self.qk_pos_emb_head_dim
@@ -541,7 +563,10 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
             freqs = freqs[:, position_offset : position_offset + sq, :]
 
             # Q RoPE: split nope/pe, apply RoPE to pe part
-            if self.config.apply_rope_fusion:
+            if (
+                self.config.apply_rope_fusion
+                and not self.config.high_precision_rope
+            ):
                 from paddlefleet.triton_ops import fused_apply_mla_rope_inplace
 
                 query = fused_apply_mla_rope_inplace(q, freqs, nope_dim, mscale)
@@ -555,6 +580,7 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
                     rotary_interleaved=False,
                     multi_latent_attention=True,
                     mla_output_remove_interleaving=True,
+                    high_precision_rope=self.config.high_precision_rope,
                 )
                 query = paddle.concat([q_nope, q_pe], axis=-1)
 
@@ -570,6 +596,7 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
                 rotary_interleaved=False,
                 multi_latent_attention=True,
                 mla_output_remove_interleaving=True,
+                high_precision_rope=self.config.high_precision_rope,
             )
             kv_pe = kv_pe.squeeze(2)
 
@@ -577,10 +604,12 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
             #   kv_nope: bf16 -> fp32 -> fp8e4m3 ->fp32 -> bf16
             if self.use_fp8_qat:
                 kv_nope = fp8_simulate_qat(kv_nope, 64)
-
             kv = paddle.concat([kv_nope, kv_pe], axis=-1)
         else:
             query = q
+
+        if self.config.swa_high_precision_norm:
+            kv = kv.astype(hidden_states.dtype)
 
         # Single head: key = value = [b, sq, 1, v_head_dim]
         key = kv.unsqueeze(2)

--- a/src/paddlefleet/transformer/paddle_norm.py
+++ b/src/paddlefleet/transformer/paddle_norm.py
@@ -72,20 +72,32 @@ class RMSNorm(paddle.nn.Layer):
         if input_is_parallel:
             self.enable_sequence_parallel()
 
-    def forward(self, hidden_states: Tensor):
-        # Ensure hidden_states dtype matches weight dtype for rms_norm
-        if hidden_states.dtype != self.weight.dtype:
-            hidden_states = hidden_states.astype(self.weight.dtype)
+    def forward(
+        self,
+        hidden_states: Tensor,
+        high_precision_norm: bool = False,
+        return_high_precision_norm: bool = False,
+    ):
+        if high_precision_norm:
+            hidden_states = hidden_states.astype(paddle.float32)
+            weight = self.weight.astype(paddle.float32)
+        else:
+            if hidden_states.dtype != self.weight.dtype:
+                hidden_states = hidden_states.astype(self.weight.dtype)
+            weight = self.weight
         rms_norm_out = rms_norm(
             hidden_states,
             hidden_states.shape[-1:],
-            self.weight,
+            weight,
             self.variance_epsilon,
         )
+        return_dtype = self.weight.dtype
+        if return_high_precision_norm:
+            return_dtype = paddle.float32
         if isinstance(rms_norm_out, (tuple, list)):
-            return rms_norm_out[0].astype(self.weight.dtype)
+            return rms_norm_out[0].astype(return_dtype)
         else:
-            return rms_norm_out.astype(self.weight.dtype)
+            return rms_norm_out.astype(return_dtype)
 
     def enable_sequence_parallel(self):
         mark_as_sequence_parallel_parameter(self.weight)

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -348,6 +348,7 @@ class TransformerConfig(ModelParallelConfig):
     apply_query_key_layer_scaling is True."""
 
     high_precision_rope: bool = False
+    swa_high_precision_norm: bool = False
     ####################
     # fusion
     ####################
@@ -1229,6 +1230,18 @@ class TransformerConfig(ModelParallelConfig):
                     f"csa_sparse_attn_backend={self.csa_sparse_attn_backend!r} is invalid. "
                     "Must be one of {'unfused', 'tilelang', 'cudnn'}."
                 )
+
+        # swa_high_precision_norm is only supported for DSv4 models.
+        if (
+            self.swa_high_precision_norm
+            and self.experimental_attention_variant != "dsv4_hybrid"
+        ):
+            raise ValueError(
+                "swa_high_precision_norm=True is only supported when "
+                "experimental_attention_variant='dsv4_hybrid'. "
+                "High-precision norm mode is only adapted for DSv4 to align "
+                "training and inference numerical behavior."
+            )
 
         # Hash-based MoE routing consistency checks.
         if self.moe_n_hash_layers > 0:

--- a/tests/multi_card_tests/transformer/test_csa_attention_cp.py
+++ b/tests/multi_card_tests/transformer/test_csa_attention_cp.py
@@ -134,7 +134,7 @@ class _TestRMSNorm(nn.Layer):
             default_initializer=nn.initializer.Constant(1.0),
         )
 
-    def forward(self, x):
+    def forward(self, x, **kwargs):
         normed = x * paddle.rsqrt(x.square().mean(-1, keepdim=True) + self.eps)
         return normed * self.weight.cast(x.dtype)
 

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_swa_high_precision_norm.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_swa_high_precision_norm.py
@@ -1,0 +1,171 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for swa_high_precision_norm feature coverage.
+
+Covers:
+- dsv4_hybrid_attention.py:56-59 (_q_rms_norm high_precision_norm=True branch)
+- dsv4_hybrid_attention.py:531 (q_head_norm with high_precision_norm in forward)
+- dsv4_hybrid_attention.py:612 (kv RoPE mscale path in high_precision forward)
+- paddle_norm.py:82-83 (RMSNorm forward with high_precision_norm=True)
+- paddle_norm.py:96,98 (RMSNorm forward with return_high_precision_norm=True)
+- transformer_config.py:1239 (swa_high_precision_norm validation error)
+"""
+
+import os
+import sys
+
+sys.path.insert(
+    0,
+    os.path.dirname(
+        os.path.dirname(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        )
+    ),
+)
+
+import unittest
+
+import paddle
+
+from paddlefleet.transformer.dsv4_hybrid_attention import _q_rms_norm
+from paddlefleet.transformer.paddle_norm import RMSNorm
+from paddlefleet.transformer.transformer_config import TransformerConfig
+
+
+def _make_config(**overrides):
+    defaults = {
+        "hidden_size": 128,
+        "num_attention_heads": 4,
+        "normalization": "RMSNorm",
+        "rms_norm_eps": 1e-5,
+    }
+    defaults.update(overrides)
+    return TransformerConfig(**defaults)
+
+
+class TestQRmsNormHighPrecision(unittest.TestCase):
+    """Cover dsv4_hybrid_attention.py lines 56-59: _q_rms_norm with high_precision_norm=True."""
+
+    def test_high_precision_norm_true_casts_to_float32(self):
+        """When high_precision_norm=True, computation should happen in float32
+        and output should be cast back to original dtype."""
+        q = paddle.randn([2, 4, 8, 32]).astype(paddle.bfloat16)
+        result = _q_rms_norm(q, eps=1e-5, high_precision_norm=True)
+        # Output dtype should match input dtype (bfloat16)
+        self.assertEqual(result.dtype, paddle.bfloat16)
+        # Output shape should be preserved
+        self.assertEqual(result.shape, [2, 4, 8, 32])
+
+    def test_high_precision_norm_false_keeps_dtype(self):
+        """When high_precision_norm=False, no dtype casting happens."""
+        q = paddle.randn([2, 4, 8, 32]).astype(paddle.bfloat16)
+        result = _q_rms_norm(q, eps=1e-5, high_precision_norm=False)
+        self.assertEqual(result.dtype, paddle.bfloat16)
+        self.assertEqual(result.shape, [2, 4, 8, 32])
+
+    def test_high_precision_norm_float32_input(self):
+        """When input is already float32, high_precision_norm=True should still work."""
+        q = paddle.randn([1, 2, 4, 16]).astype(paddle.float32)
+        result = _q_rms_norm(q, eps=1e-5, high_precision_norm=True)
+        self.assertEqual(result.dtype, paddle.float32)
+
+
+class TestRMSNormHighPrecision(unittest.TestCase):
+    """Cover paddle_norm.py lines 82-83, 96, 98: RMSNorm forward with high_precision_norm
+    and return_high_precision_norm flags."""
+
+    def test_high_precision_norm_casts_input_and_weight_to_float32(self):
+        """Lines 82-83: When high_precision_norm=True, input and weight are cast to float32."""
+        config = _make_config(params_dtype=paddle.bfloat16)
+        norm = RMSNorm(config)
+        x = paddle.randn([2, 4, 128]).astype(paddle.bfloat16)
+        result = norm(x, high_precision_norm=True)
+        # Output should be cast back to weight dtype (bfloat16)
+        self.assertEqual(result.dtype, paddle.bfloat16)
+        self.assertEqual(result.shape, [2, 4, 128])
+
+    def test_return_high_precision_norm_returns_float32(self):
+        """Lines 96, 98: When return_high_precision_norm=True, output stays in float32."""
+        config = _make_config(params_dtype=paddle.bfloat16)
+        norm = RMSNorm(config)
+        x = paddle.randn([2, 4, 128]).astype(paddle.bfloat16)
+        result = norm(
+            x, high_precision_norm=True, return_high_precision_norm=True
+        )
+        # Output should remain float32 due to return_high_precision_norm
+        self.assertEqual(result.dtype, paddle.float32)
+        self.assertEqual(result.shape, [2, 4, 128])
+
+    def test_high_precision_norm_false_default_behavior(self):
+        """Without high_precision_norm, normal path is taken."""
+        config = _make_config(params_dtype=paddle.float32)
+        norm = RMSNorm(config)
+        x = paddle.randn([2, 4, 128]).astype(paddle.float32)
+        result = norm(x, high_precision_norm=False)
+        self.assertEqual(result.dtype, paddle.float32)
+        self.assertEqual(result.shape, [2, 4, 128])
+
+
+class TestSwaHighPrecisionNormConfigValidation(unittest.TestCase):
+    """Cover transformer_config.py line 1239: swa_high_precision_norm validation."""
+
+    def test_swa_high_precision_norm_with_non_dsv4_raises_error(self):
+        """Line 1239: Setting swa_high_precision_norm=True without dsv4_hybrid should raise."""
+        with self.assertRaisesRegex(
+            ValueError,
+            "swa_high_precision_norm=True is only supported when",
+        ):
+            TransformerConfig(
+                hidden_size=128,
+                num_attention_heads=4,
+                swa_high_precision_norm=True,
+                experimental_attention_variant=None,
+            )
+
+    def test_swa_high_precision_norm_with_dsv4_hybrid_passes(self):
+        """swa_high_precision_norm=True with dsv4_hybrid should not raise."""
+        config = TransformerConfig(
+            hidden_size=256,
+            num_attention_heads=8,
+            num_hidden_layers=4,
+            params_dtype=paddle.bfloat16,
+            bf16=True,
+            multi_latent_attention=True,
+            experimental_attention_variant="dsv4_hybrid",
+            swa_high_precision_norm=True,
+            q_lora_rank=64,
+            kv_lora_rank=16,
+            qk_nope_head_dim=16,
+            qk_rope_head_dim=16,
+            qk_pos_emb_head_dim=16,
+            v_head_dim=32,
+            csa_compress_ratios=[0, 4, 128, 4],
+            csa_window_size=16,
+        )
+        self.assertTrue(config.swa_high_precision_norm)
+
+    def test_swa_high_precision_norm_false_no_validation(self):
+        """swa_high_precision_norm=False should pass regardless of variant."""
+        config = TransformerConfig(
+            hidden_size=128,
+            num_attention_heads=4,
+            swa_high_precision_norm=False,
+            experimental_attention_variant=None,
+        )
+        self.assertFalse(config.swa_high_precision_norm)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
> 新增swa 中norm高精模式，支持qkv进行norm与rope的计算过程中以fp32进行，以支持训推一致。

**新增开关：**
+ swa_high_precision_norm：在QKV的Norm过程中，计算应用fp32，返回时重新cast回原有精度，如bf16。

**RMS_Norm forward函数新增入参**
+ high_precision_norm：RMS_Norm计算过程在fp32下进行
+ return_high_precision_norm：RMS_Norm返回的结果是否为fp32。

**备注**
当swa_high_precision_norm开启，kv的rms_norm将在fp32下进行，并返回kv为fp32
### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
是

Cherry-pick of #1334 to `release/0.3`.

Merged in dev: #1334  <!-- For pass CI -->