### PR TITLE
[Performance Optimization] Add recovery-stage recompute

### DIFF
--- a/src/paddlefleet/recompute_utils.py
+++ b/src/paddlefleet/recompute_utils.py
@@ -14,7 +14,36 @@
 
 from __future__ import annotations
 
+import logging
+import os
 from itertools import chain
+
+logger = logging.getLogger(__name__)
+
+g_has_print_recovery_log = False
+
+
+def has_recovered():
+    """has recovered"""
+    recover_step = os.getenv("RECOVER_STEP")
+    if recover_step is None:
+        return True
+    recover_step = int(recover_step)
+    current_step = os.getenv("TRAINER_GLOBAL_STEP")
+    if current_step is None:
+        current_step = os.getenv("PDC_INIT_STEP")
+        assert current_step is not None, (
+            "TRAINER_GLOBAL_STEP or PDC_INIT_STEP should be specified"
+        )
+    current_step = int(current_step)
+    if current_step > recover_step:
+        global g_has_print_recovery_log
+        if not g_has_print_recovery_log:
+            logger.info(f"Recovery would be enabled in the step {current_step}")
+            g_has_print_recovery_log = True
+        return True
+    else:
+        return False
 
 
 def need_recompute_in_block(layer_number, config, recompute_num_layers):

--- a/src/paddlefleet/transformer/transformer_layer.py
+++ b/src/paddlefleet/transformer/transformer_layer.py
@@ -37,6 +37,7 @@ from paddlefleet.parallel_state import (
 )
 from paddlefleet.process_groups_config import ProcessGroupCollection
 from paddlefleet.recompute_utils import (
+    has_recovered,
     need_full_recompute,
     need_recompute_in_block,
     need_recompute_in_first_n,
@@ -581,7 +582,7 @@ class TransformerLayer(nn.Layer):
         if self.config.block_attention_residuals and "blocks" not in dict_args:
             dict_args["blocks"] = []
 
-        if self.full_recompute:
+        if self.full_recompute or (not has_recovered()):
             hidden_states = dict_args["hidden_states"]
             attention_mask = dict_args.get("attention_mask", None)
             attn_mask_startend_row_indices = dict_args.get(


### PR DESCRIPTION
### PR Category
Performance Optimization
### PR Types
New features
### Description
新增基于环境变量的恢复阶段 recompute 控制：当设置 RECOVER_STEP 且当前 TRAINER_GLOBAL_STEP/PDC_INIT_STEP 未超过恢复步数时，TransformerLayer 使用 recompute 路径；恢复完成后回到原有 full_recompute 配置路径。
### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否
