### PR TITLE
support fp32 hadamard and add bf16bf16fp32 pylayer (#1354)

### DIFF
--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -72,6 +72,65 @@ from paddlefleet.transformer.cp_utils import (
     map_compressed_topk_to_kv_full_cp,
 )
 
+
+class LinearBF16FP32Func(paddle.autograd.PyLayer):
+    """BF16 activation x BF16 weight -> FP32 output autograd function.
+
+    Forward matches SGLang's default DeepSeek-V4 compressor path
+    (`sglang.jit_kernel.deepseek_v4.linear_bf16_fp32`, cublas backend).
+    BF16 activation x BF16 weight -> FP32 output. This keeps Megatron's
+    compressor log-prob computation aligned with SGLang rollout. Backward is
+    only needed for training, so keep its gradient matmuls in FP32.
+    """
+
+    @staticmethod
+    def forward(ctx, x: Tensor, weight: Tensor) -> Tensor:
+        """Forward pass: BF16 matmul with FP32 output."""
+        x_bf16 = x.cast(paddle.bfloat16)
+        weight_bf16 = weight.cast(paddle.bfloat16)
+        ctx.save_for_backward(x_bf16, weight_bf16)
+        ctx.input_shape = x.shape
+        ctx.input_dtype = x.dtype
+        ctx.weight_dtype = weight.dtype
+        # Paddle PyLayer requires None for stop_gradient inputs; record here.
+        ctx.x_needs_grad = not x.stop_gradient
+        ctx.weight_needs_grad = not weight.stop_gradient
+
+        x_2d = x_bf16.reshape([-1, x_bf16.shape[-1]])
+        out = paddle.mm(x_2d, weight_bf16, out_dtype=paddle.float32)
+        return out.view(*x.shape[:-1], weight_bf16.shape[1])
+
+    @staticmethod
+    def backward(ctx, grad_output: Tensor):
+        """Backward pass: compute gradients for x and weight."""
+        x_bf16, weight_bf16 = ctx.saved_tensor()
+        grad_output_2d = grad_output.reshape([-1, grad_output.shape[-1]]).cast(
+            paddle.float32
+        )
+
+        grad_x = None
+        if ctx.x_needs_grad:
+            grad_x = grad_output_2d.matmul(weight_bf16.cast(paddle.float32).t())
+            grad_x = grad_x.view(ctx.input_shape).cast(ctx.input_dtype)
+
+        grad_weight = None
+        if ctx.weight_needs_grad:
+            x_2d = x_bf16.reshape([-1, x_bf16.shape[-1]])
+            grad_weight = (
+                x_2d.cast(paddle.float32)
+                .t()
+                .matmul(grad_output_2d)
+                .cast(ctx.weight_dtype)
+            )
+
+        return grad_x, grad_weight
+
+
+def linear_bf16_fp32(x: Tensor, weight: Tensor) -> Tensor:
+    """BF16 matmul with FP32 output wrapper function."""
+    return LinearBF16FP32Func.apply(x, weight)
+
+
 # ---------------------------------------------------------------------------
 # Helper functions for index computation
 # ---------------------------------------------------------------------------
@@ -396,6 +455,7 @@ def _apply_rope(
     doc_lens_cutoff: Tensor | None = None,  # for token compressed, such as kv
     doc_lens: Tensor | None = None,  # for token not compressed, such as q
     position_offset: int = 0,
+    high_precision_rope: bool = False,
 ) -> Tensor:
     """Apply RoPE to the last pos_dim dims, leaving first nope_dim unchanged.
 
@@ -507,6 +567,7 @@ def _apply_rope(
         rotary_interleaved=False,
         multi_latent_attention=True,
         mla_output_remove_interleaving=True,
+        high_precision_rope=high_precision_rope,
     )
 
     out = paddle.concat([x_nope, x_pe], axis=-1)
@@ -969,6 +1030,10 @@ class Compressor(nn.Layer):
 
         self.use_fp8_qat = getattr(config, "use_fp8_qat", False)
         self.use_fast_hadamard = getattr(config, "use_fast_hadamard", False)
+        self.swa_high_precision_norm = getattr(
+            config, "swa_high_precision_norm", False
+        )
+        self.high_precision_rope = getattr(config, "high_precision_rope", False)
 
     def _overlap_transform(
         self,
@@ -1039,9 +1104,16 @@ class Compressor(nn.Layer):
 
         if sq < ratio:
             return None
-
-        kv, _ = self.linear_wkv(x)  # [b, sq, coff * head_dim]
-        score, _ = self.linear_wgate(x)  # [b, sq, coff * head_dim]
+        if self.swa_high_precision_norm:
+            kv = linear_bf16_fp32(
+                x, self.linear_wkv.weight
+            )  # [b, sq, coff * head_dim]
+            score = linear_bf16_fp32(
+                x, self.linear_wgate.weight
+            )  # [b, sq, coff * head_dim]
+        else:
+            kv, _ = self.linear_wkv(x)  # [b, sq, coff * head_dim]
+            score, _ = self.linear_wgate(x)  # [b, sq, coff * head_dim]
 
         # CP: gather projected KV globally before pooling (Miles pattern).
         # This lets the compressor pool across the full sequence while keeping
@@ -1121,7 +1193,14 @@ class Compressor(nn.Layer):
             kv = (kv * F.softmax(score, axis=2)).sum(axis=2)
             # kv: [b, actual_n_compressed, head_dim]
 
-            kv = self.norm(kv.cast(x.dtype))
+            if self.swa_high_precision_norm:
+                kv = self.norm(
+                    kv,
+                    high_precision_norm=True,
+                    return_high_precision_norm=True,
+                )
+            else:
+                kv = self.norm(kv.cast(x.dtype))
 
             # Pad to n_compressed before RoPE
             if actual_n_compressed < n_compressed:
@@ -1147,11 +1226,14 @@ class Compressor(nn.Layer):
                     n_compressed,
                     ratio=ratio,
                     doc_lens_cutoff=doc_lens_cutoff,
+                    high_precision_rope=self.high_precision_rope,
                 )
 
             if self.rotate:
                 kv = rotate_activation(
-                    kv, use_fast_hadamard=self.use_fast_hadamard
+                    kv,
+                    use_fast_hadamard=self.use_fast_hadamard,
+                    high_precision_hadamard=self.swa_high_precision_norm,
                 )
                 if self.use_fp8_qat:
                     kv = fp8_simulate_qat(kv, 128)
@@ -1162,6 +1244,8 @@ class Compressor(nn.Layer):
                         kv[..., :nope_dim], 64
                     )
 
+            if self.swa_high_precision_norm:
+                kv = kv.cast(x.dtype)
             return kv  # [b, n_compressed, head_dim]
         else:
             # Original simple cutoff logic

--- a/src/paddlefleet/transformer/dsa_attention.py
+++ b/src/paddlefleet/transformer/dsa_attention.py
@@ -112,7 +112,11 @@ def hadamard_transform(x: Tensor, scale: float = 1.0) -> Tensor:
     return (x.reshape(original_shape) * scale).cast(output_dtype)
 
 
-def rotate_activation(x: Tensor, use_fast_hadamard: bool = False) -> Tensor:
+def rotate_activation(
+    x: Tensor,
+    use_fast_hadamard: bool = False,
+    high_precision_hadamard: bool = False,
+) -> Tensor:
     """Apply Hadamard rotation activation.
 
     Reference:
@@ -120,13 +124,15 @@ def rotate_activation(x: Tensor, use_fast_hadamard: bool = False) -> Tensor:
 
     Args:
         x: Input tensor (must be bfloat16).
+        high_precision_hadamard: if True, means type of input x is float32.
 
     Returns:
         Rotated tensor.
     """
-    assert x.dtype == paddle.bfloat16, (
-        f"rotate_activation only support bf16 input, but got {x.dtype}"
-    )
+    if not high_precision_hadamard:
+        assert x.dtype == paddle.bfloat16, (
+            f"rotate_activation only support bf16 input, but got {x.dtype}"
+        )
     hidden_size = x.shape[-1]
     scale = hidden_size**-0.5
 

--- a/tests/single_card_tests/transformer/test_csa_high_precision_norm.py
+++ b/tests/single_card_tests/transformer/test_csa_high_precision_norm.py
@@ -1,0 +1,284 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for CSA Compressor + CSAIndexer with swa_high_precision_norm=True."""
+
+import types
+import unittest
+
+import paddle
+from paddle import nn
+from paddle.distributed.fleet.meta_parallel import LayerSpec
+
+from paddlefleet.transformer.csa_attention import (
+    Compressor,
+    CompressorSublayersSpec,
+    CSAIndexer,
+    CSAIndexerSublayersSpec,
+)
+
+# =========================================================================
+# Helpers
+# =========================================================================
+
+
+class _Linear(nn.Layer):
+    """Linear layer with weight shape [in_size, out_size] to match
+    linear_bf16_fp32 which does x @ weight directly (no transpose)."""
+
+    def __init__(self, in_size, out_size, **kwargs):
+        super().__init__()
+        self.weight = self.create_parameter(
+            shape=[in_size, out_size],
+            dtype="float32",
+            default_initializer=nn.initializer.Normal(std=0.02),
+        )
+
+    def forward(self, x):
+        return (
+            paddle.matmul(x.cast("float32"), self.weight).cast(x.dtype),
+            None,
+        )
+
+
+class _Norm(nn.Layer):
+    def __init__(self, hidden_size=None, **kwargs):
+        super().__init__()
+        size = hidden_size or 1
+        self.weight = self.create_parameter(
+            shape=[size],
+            default_initializer=nn.initializer.Constant(1.0),
+        )
+        self.eps = 1e-5
+
+    def forward(self, x, **kwargs):
+        x_f32 = x.cast("float32")
+        normed = (
+            x_f32
+            * paddle.rsqrt(x_f32.square().mean(-1, keepdim=True) + self.eps)
+            * self.weight
+        )
+        return normed.cast(x.dtype)
+
+
+def _make_config(
+    hidden_size=256,
+    head_dim=128,
+    pos_dim=64,
+    compress_ratio=2,
+    index_n_heads=2,
+    index_head_dim=64,
+    index_topk=4,
+    q_lora_rank=128,
+    swa_high_precision_norm=True,
+    use_fp8_qat=False,
+    use_fast_hadamard=False,
+    high_precision_rope=False,
+):
+    return types.SimpleNamespace(
+        hidden_size=hidden_size,
+        qk_pos_emb_head_dim=pos_dim,
+        init_method=None,
+        init_method_std=0.02,
+        rms_norm_eps=1e-5,
+        num_hidden_layers=1,
+        use_fp8_qat=use_fp8_qat,
+        swa_high_precision_norm=swa_high_precision_norm,
+        use_fast_hadamard=use_fast_hadamard,
+        high_precision_rope=high_precision_rope,
+        q_lora_rank=q_lora_rank,
+        dsa_index_n_heads=index_n_heads,
+        dsa_index_head_dim=index_head_dim,
+        dsa_index_topk=index_topk,
+    )
+
+
+# =========================================================================
+# Tests
+# =========================================================================
+
+
+class TestCSAHighPrecisionNorm(unittest.TestCase):
+    """Test Compressor and CSAIndexer with swa_high_precision_norm=True."""
+
+    def setUp(self):
+        paddle.seed(42)
+        self.config = _make_config()
+        self.hidden_size = 256
+        self.head_dim = 128
+        self.compress_ratio = 2
+        self.b = 2
+        self.sq = 64
+
+    def test_compressor_forward_no_rotate(self):
+        """Compressor with swa_high_precision_norm=True, rotate=False produces correct output."""
+        comp_spec = CompressorSublayersSpec(
+            linear_wkv=_Linear,
+            linear_wgate=_Linear,
+            norm=_Norm,
+        )
+        compressor = Compressor(
+            config=self.config,
+            sublayers_spec=comp_spec,
+            compress_ratio=self.compress_ratio,
+            head_dim=self.head_dim,
+            rotate=False,
+            rotary_pos_emb=None,
+        )
+
+        x = paddle.randn([self.b, self.sq, self.hidden_size]).astype("bfloat16")
+        kv = compressor(x)
+
+        n_compressed = self.sq // self.compress_ratio
+        self.assertEqual(kv.shape, [self.b, n_compressed, self.head_dim])
+        self.assertEqual(kv.dtype, paddle.bfloat16)
+        self.assertFalse(paddle.isnan(kv).any().item())
+
+    def test_compressor_forward_with_rotate(self):
+        """Compressor with swa_high_precision_norm=True, rotate=True runs correctly."""
+        comp_spec = CompressorSublayersSpec(
+            linear_wkv=_Linear,
+            linear_wgate=_Linear,
+            norm=_Norm,
+        )
+        compressor = Compressor(
+            config=self.config,
+            sublayers_spec=comp_spec,
+            compress_ratio=self.compress_ratio,
+            head_dim=self.head_dim,
+            rotate=True,
+            rotary_pos_emb=None,
+        )
+
+        x = paddle.randn([self.b, self.sq, self.hidden_size]).astype("bfloat16")
+        kv = compressor(x)
+
+        n_compressed = self.sq // self.compress_ratio
+        self.assertEqual(kv.shape, [self.b, n_compressed, self.head_dim])
+        self.assertEqual(kv.dtype, paddle.bfloat16)
+        self.assertFalse(paddle.isnan(kv).any().item())
+
+    def test_compressor_short_sequence_returns_none(self):
+        """Compressor returns None when seq_len < compress_ratio."""
+        comp_spec = CompressorSublayersSpec(
+            linear_wkv=_Linear,
+            linear_wgate=_Linear,
+            norm=_Norm,
+        )
+        compressor = Compressor(
+            config=self.config,
+            sublayers_spec=comp_spec,
+            compress_ratio=self.compress_ratio,
+            head_dim=self.head_dim,
+            rotate=False,
+            rotary_pos_emb=None,
+        )
+
+        x = paddle.randn([self.b, 1, self.hidden_size]).astype("bfloat16")
+        kv = compressor(x)
+        self.assertIsNone(kv)
+
+    def test_indexer_forward(self):
+        """CSAIndexer with swa_high_precision_norm=True runs forward correctly."""
+        indexer_comp_spec = CompressorSublayersSpec(
+            linear_wkv=_Linear,
+            linear_wgate=_Linear,
+            norm=_Norm,
+        )
+        indexer_spec = CSAIndexerSublayersSpec(
+            linear_wq_b=_Linear,
+            linear_weights_proj=_Linear,
+            compressor=LayerSpec(Compressor, sublayers_spec=indexer_comp_spec),
+        )
+        indexer = CSAIndexer(
+            config=self.config,
+            sublayers_spec=indexer_spec,
+            compress_ratio=self.compress_ratio,
+            rotary_pos_emb=None,
+        )
+
+        x = paddle.randn([self.b, self.sq, self.hidden_size]).astype("bfloat16")
+        qr = paddle.randn([self.b, self.sq, self.config.q_lora_rank]).astype(
+            "bfloat16"
+        )
+        index_scores, topk_indices = indexer(x, qr, mask=None)
+
+        n_compressed = self.sq // self.compress_ratio
+        self.assertEqual(index_scores.shape, [self.b, self.sq, n_compressed])
+        self.assertEqual(
+            topk_indices.shape, [self.b, self.sq, self.config.dsa_index_topk]
+        )
+        self.assertFalse(paddle.isnan(index_scores).any().item())
+
+    def test_compressor_backward(self):
+        """Compressor with swa_high_precision_norm=True supports backward pass."""
+        comp_spec = CompressorSublayersSpec(
+            linear_wkv=_Linear,
+            linear_wgate=_Linear,
+            norm=_Norm,
+        )
+        compressor = Compressor(
+            config=self.config,
+            sublayers_spec=comp_spec,
+            compress_ratio=self.compress_ratio,
+            head_dim=self.head_dim,
+            rotate=False,
+            rotary_pos_emb=None,
+        )
+
+        x = paddle.randn([self.b, self.sq, self.hidden_size]).astype("bfloat16")
+        x.stop_gradient = False
+        kv = compressor(x)
+        loss = kv.cast("float32").sum()
+        loss.backward()
+
+        self.assertIsNotNone(x.grad)
+        self.assertFalse(paddle.isnan(x.grad).any().item())
+
+    def test_indexer_backward(self):
+        """CSAIndexer with swa_high_precision_norm=True supports backward pass."""
+        indexer_comp_spec = CompressorSublayersSpec(
+            linear_wkv=_Linear,
+            linear_wgate=_Linear,
+            norm=_Norm,
+        )
+        indexer_spec = CSAIndexerSublayersSpec(
+            linear_wq_b=_Linear,
+            linear_weights_proj=_Linear,
+            compressor=LayerSpec(Compressor, sublayers_spec=indexer_comp_spec),
+        )
+        indexer = CSAIndexer(
+            config=self.config,
+            sublayers_spec=indexer_spec,
+            compress_ratio=self.compress_ratio,
+            rotary_pos_emb=None,
+        )
+
+        x = paddle.randn([self.b, self.sq, self.hidden_size]).astype("bfloat16")
+        x.stop_gradient = False
+        qr = paddle.randn([self.b, self.sq, self.config.q_lora_rank]).astype(
+            "bfloat16"
+        )
+        qr.stop_gradient = False
+
+        index_scores, topk_indices = indexer(x, qr, mask=None)
+        loss = index_scores.cast("float32").sum()
+        loss.backward()
+
+        self.assertIsNotNone(x.grad)
+        self.assertFalse(paddle.isnan(x.grad).any().item())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
新增bf16bf16fp32 pylayer，compressor中支持fp32 norm_rope_hadamard计算。用开关swa_high_precision_norm控制

Merged in dev: #1354 

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否
