### PR TITLE
[Feat] SWA CP optimization with P2P boundary send-recv

### DIFF
--- a/src/paddlefleet/context_parallel_utils.py
+++ b/src/paddlefleet/context_parallel_utils.py
@@ -1229,8 +1229,6 @@ class FlashMaskContextParallel(PyLayer):
 
 # ======================== P2P SWA CP fast path Layer ========================
 
-SWA_WIN_SIZE = 128
-
 
 def _wait_all(tasks):
     """Wait for all asynchronous communication tasks."""
@@ -1238,7 +1236,7 @@ def _wait_all(tasks):
         task.wait()
 
 
-def _exchange_prev_window(key, value, group, window_size=SWA_WIN_SIZE):
+def _exchange_prev_window(key, value, group, window_size=128):
     """Exchange each rank's tail KV window with the next CP rank."""
     rank = group.rank
     cp_size = group.world_size
@@ -1305,7 +1303,7 @@ def _scatter_kv_to_global_tensor(key, value, recv_key, recv_value, group):
 
 
 def _send_window_grad_back(
-    key_grad_tensor, value_grad_tensor, key, value, group
+    key_grad_tensor, value_grad_tensor, key, value, group, window_size
 ):
     """Return remote-window KV gradients to owner ranks and accumulate them."""
     rank = group.rank
@@ -1322,7 +1320,7 @@ def _send_window_grad_back(
     value_grad = value_grad_tensor[:, local_start:local_end, :, :].contiguous()
 
     recv_grad_window = paddle.empty(
-        [2, key.shape[0], SWA_WIN_SIZE, key.shape[2], key.shape[3]],
+        [2, key.shape[0], window_size, key.shape[2], key.shape[3]],
         dtype=key.dtype,
     )
     ops = []
@@ -1333,7 +1331,7 @@ def _send_window_grad_back(
 
     if rank > 0:
         recv_rank = group.ranks[rank - 1]
-        window_start = local_start - SWA_WIN_SIZE
+        window_start = local_start - window_size
         send_grad_window = paddle.stack(
             [
                 key_grad_tensor[:, window_start:local_start, :, :],
@@ -1347,8 +1345,8 @@ def _send_window_grad_back(
         _wait_all(dist.batch_isend_irecv(ops))
 
     if rank < cp_size - 1:
-        key_grad[:, -SWA_WIN_SIZE:, :, :].add_(recv_grad_window[0])
-        value_grad[:, -SWA_WIN_SIZE:, :, :].add_(recv_grad_window[1])
+        key_grad[:, -window_size:, :, :].add_(recv_grad_window[0])
+        value_grad[:, -window_size:, :, :].add_(recv_grad_window[1])
 
     return key_grad, value_grad
 
@@ -1363,6 +1361,7 @@ def cp_flashmask_swa_p2p_forward(
     causal,
     is_training,
     softmax_scale,
+    window_size,
 ):
     """Run forward SWA FlashMask CP with one-hop P2P KV exchange."""
     paddle.base.core.nvprof_nvtx_push("cp_flashmask_swa_p2p_forward")
@@ -1374,7 +1373,7 @@ def cp_flashmask_swa_p2p_forward(
         max_seqlen_q=query.shape[1],
     )
 
-    recv_key, recv_value = _exchange_prev_window(key, value, group)
+    recv_key, recv_value = _exchange_prev_window(key, value, group, window_size)
 
     key_tensor, value_tensor = _scatter_kv_to_global_tensor(
         key, value, recv_key, recv_value, group
@@ -1411,6 +1410,7 @@ def cp_flashmask_swa_p2p_backward(
     group,
     causal,
     softmax_scale,
+    window_size,
 ):
     """Run backward SWA FlashMask CP and return P2P KV gradients."""
     paddle.base.core.nvprof_nvtx_push("cp_flashmask_swa_p2p_backward")
@@ -1436,7 +1436,7 @@ def cp_flashmask_swa_p2p_backward(
     )
 
     key_grad, value_grad = _send_window_grad_back(
-        key_grad_tensor, value_grad_tensor, key, value, group
+        key_grad_tensor, value_grad_tensor, key, value, group, window_size
     )
 
     paddle.base.core.nvprof_nvtx_pop()
@@ -1444,8 +1444,8 @@ def cp_flashmask_swa_p2p_backward(
     return query_grad, key_grad, value_grad, grad_sink
 
 
-class SwaP2PFlashMask(PyLayer):
-    """PyLayer for SWA FlashMask context parallelism using one-hop P2P KV exchange."""
+class FlashMaskSwaP2P(PyLayer):
+    """PyLayer for FlashMask SWA context parallelism using one-hop P2P KV exchange."""
 
     @staticmethod
     def forward(
@@ -1462,6 +1462,7 @@ class SwaP2PFlashMask(PyLayer):
         softmax_scale=None,
         group=None,
         mode="contiguous_allgather",
+        window_size=None,
     ):
         """Forward pass for SWA P2P FlashMask attention."""
         if dropout > 0.0:
@@ -1470,6 +1471,11 @@ class SwaP2PFlashMask(PyLayer):
             )
         if fixed_seed_offset is not None:
             raise NotImplementedError("Fixed seed offset is not supported yet.")
+        window_size = 128 if window_size is None else window_size
+        if window_size <= 0:
+            raise ValueError(
+                f"SWA P2P window_size must be positive, got {window_size}"
+            )
 
         output, log_sum_exp, recv_key, recv_value, startend_row_indices = (
             cp_flashmask_swa_p2p_forward(
@@ -1482,6 +1488,7 @@ class SwaP2PFlashMask(PyLayer):
                 causal,
                 training,
                 softmax_scale,
+                window_size,
             )
         )
 
@@ -1502,6 +1509,7 @@ class SwaP2PFlashMask(PyLayer):
         )
         ctx.group = group
         ctx.causal = causal
+        ctx.window_size = window_size
         return output
 
     @staticmethod
@@ -1532,6 +1540,7 @@ class SwaP2PFlashMask(PyLayer):
                 ctx.group,
                 ctx.causal,
                 ctx.softmax_scale,
+                ctx.window_size,
             )
         )
         if ctx.sink_requires_grad:
@@ -1551,6 +1560,7 @@ def flashmask_attention_cp(
     learnable_sink=None,
     softmax_scale=None,
     mode="dualchunk_allgather",
+    window_size=None,
 ):
     """
     FlashMask attention with context parallelism - public API.
@@ -1593,7 +1603,7 @@ def flashmask_attention_cp(
             "P2P SWA fast path requires flashmask installed. Please check."
         )
 
-        return SwaP2PFlashMask.apply(
+        return FlashMaskSwaP2P.apply(
             query,
             key,
             value,
@@ -1606,6 +1616,7 @@ def flashmask_attention_cp(
             softmax_scale,
             cp_group,
             mode,
+            window_size,
         )
     else:
         output = FlashMaskContextParallel.apply(

--- a/src/paddlefleet/context_parallel_utils.py
+++ b/src/paddlefleet/context_parallel_utils.py
@@ -662,6 +662,7 @@ def cp_flashmask_allgatherkv_balance_forward(
     causal,
     is_training,
     softmax_scale,
+    mode: str = "dualchunk_allgather",
 ):
     """
     Forward pass of context parallel flashmask attention with balanced all-gather strategy.
@@ -675,6 +676,8 @@ def cp_flashmask_allgatherkv_balance_forward(
         group (paddle.distributed.Group): Communication group
         causal (bool): Whether to use causal attention
         is_training (bool): Whether in training mode
+        softmax_scale (float): softmax scaling factor
+        mode (str): Attention mode, support 'dualchunk_allgather' and 'contiguous_allgather'
     Returns:
         tuple: (output, log_sum_exp, processed_indices, fa_version)
             ``fa_version`` is the effective FlashAttention version actually
@@ -688,23 +691,33 @@ def cp_flashmask_allgatherkv_balance_forward(
     rank = group.rank
     cp_size = group.world_size
 
-    # All-gather key tensors across context parallel ranks
-    key_gathered = all_gather_balance(key, axis=1, group=group)
+    if mode == "dualchunk_allgather":
+        key_gathered = all_gather_balance(key, axis=1, group=group)
+        value_gathered = all_gather_balance(value, axis=1, group=group)
 
-    # All-gather value tensors across context parallel ranks
-    value_gathered = all_gather_balance(value, axis=1, group=group)
+        # Calculate sequence block size for dual-chunk strategy
+        seq_blocksize = query.shape[1] // 2
 
-    # Calculate sequence block size for dual-chunk strategy
-    seq_blocksize = query.shape[1] // 2
+        # Preprocess indices for dual-chunk strategy
+        startend_row_indices = preprocess_index_dual_chunks(
+            startend_row_indices,
+            chunk_id_first=rank,
+            chunk_id_second=2 * cp_size - rank - 1,
+            seq_blocksize=seq_blocksize,
+            max_seqlen_q=seq_blocksize,
+        )
+    elif mode == "contiguous_allgather":
+        key_gathered = all_gather_contiguous(key, axis=1, group=group)
+        value_gathered = all_gather_contiguous(value, axis=1, group=group)
 
-    # Preprocess indices for dual-chunk strategy
-    startend_row_indices = preprocess_index_dual_chunks(
-        startend_row_indices,
-        chunk_id_first=rank,
-        chunk_id_second=2 * cp_size - rank - 1,
-        seq_blocksize=seq_blocksize,
-        max_seqlen_q=seq_blocksize,
-    )
+        startend_row_indices = preprocess_index(
+            startend_row_indices,
+            chunk_id=group.rank,
+            seq_blocksize=query.shape[1],
+            max_seqlen_q=query.shape[1],
+        )
+    else:
+        raise ValueError(f"Unsupported FlashMask context parallel mode: {mode}")
 
     # Perform flashmask attention with startend_row_indices
     fa_version = paddle.base.framework.get_flags(["FLAGS_flash_attn_version"])[
@@ -767,6 +780,7 @@ def cp_flashmask_allgatherkv_balance_backward(
     causal,
     fa_version: int,
     softmax_scale,
+    mode: str = "dualchunk_allgather",
 ):
     """
     Backward pass of context parallel flashmask attention with balanced all-gather strategy.
@@ -785,6 +799,8 @@ def cp_flashmask_allgatherkv_balance_backward(
         fa_version (int): FlashAttention version that was actually used by the
             forward kernel. Must be propagated from the forward call to keep
             fwd/bwd consistent.
+        softmax_scale (float): Softmax scaling factor
+        mode (str): Attention mode, support 'dualchunk_allgather' and 'contiguous_allgather'
     Returns:
         tuple: (query_grad, key_grad, value_grad, grad_sink)
     """
@@ -793,8 +809,14 @@ def cp_flashmask_allgatherkv_balance_backward(
     )
 
     # All-gather key and value tensors (same as forward pass)
-    key_gathered = all_gather_balance(key, axis=1, group=group)
-    value_gathered = all_gather_balance(value, axis=1, group=group)
+    if mode == "dualchunk_allgather":
+        key_gathered = all_gather_balance(key, axis=1, group=group)
+        value_gathered = all_gather_balance(value, axis=1, group=group)
+    elif mode == "contiguous_allgather":
+        key_gathered = all_gather_contiguous(key, axis=1, group=group)
+        value_gathered = all_gather_contiguous(value, axis=1, group=group)
+    else:
+        raise ValueError(f"Unsupported FlashMask context parallel mode: {mode}")
 
     grad_sink = None
     if fa_version == 2:
@@ -915,12 +937,22 @@ def cp_flashmask_allgatherkv_balance_backward(
         )
 
     # Reduce-scatter key and value gradients
-    key_grad = reduce_scatter_any_axis_balance(
-        key_grad_gathered, axis=1, group=group
-    )
-    value_grad = reduce_scatter_any_axis_balance(
-        value_grad_gathered, axis=1, group=group
-    )
+    if mode == "dualchunk_allgather":
+        key_grad = reduce_scatter_any_axis_balance(
+            key_grad_gathered, axis=1, group=group
+        )
+        value_grad = reduce_scatter_any_axis_balance(
+            value_grad_gathered, axis=1, group=group
+        )
+    elif mode == "contiguous_allgather":
+        key_grad = reduce_scatter_contiguous(
+            key_grad_gathered, axis=1, group=group
+        )
+        value_grad = reduce_scatter_contiguous(
+            value_grad_gathered, axis=1, group=group
+        )
+    else:
+        raise ValueError(f"Unsupported FlashMask context parallel mode: {mode}")
 
     paddle.base.core.nvprof_nvtx_pop()
     return query_grad, key_grad, value_grad, grad_sink
@@ -1063,7 +1095,7 @@ class FlashMaskContextParallel(PyLayer):
         training=True,
         learnable_sink=None,
         softmax_scale=None,
-        mode="allgather_kv",
+        mode="dualchunk_allgather",
     ):
         """
         Forward pass of FlashMask attention with context parallelism.
@@ -1077,7 +1109,7 @@ class FlashMaskContextParallel(PyLayer):
             dropout (float): Dropout probability
             causal (bool): Whether to use causal attention
             training (bool): Whether in training mode
-            mode (str): Attention mode, currently supports "allgather_kv"
+            mode (str): Attention mode, supports "dualchunk_allgather" and "contiguous_allgather"
         Returns:
             paddle.Tensor: Attention output
         Raises:
@@ -1121,6 +1153,7 @@ class FlashMaskContextParallel(PyLayer):
                 causal,
                 training,
                 softmax_scale,
+                mode,
             )
         )
 
@@ -1139,6 +1172,7 @@ class FlashMaskContextParallel(PyLayer):
         ctx.sink_requires_grad = (
             learnable_sink is not None and not learnable_sink.stop_gradient
         )
+        ctx.mode = mode
 
         return output
 
@@ -1161,6 +1195,7 @@ class FlashMaskContextParallel(PyLayer):
         fa_version = ctx.fa_version
         learnable_sink = ctx.learnable_sink
         softmax_scale = ctx.softmax_scale
+        mode = ctx.mode
 
         # Compute gradients
         query_grad, key_grad, value_grad, grad_sink = (
@@ -1177,6 +1212,7 @@ class FlashMaskContextParallel(PyLayer):
                 causal,
                 fa_version,
                 softmax_scale,
+                mode,
             )
         )
 
@@ -1202,7 +1238,7 @@ def flashmask_attention_cp(
     training=True,
     learnable_sink=None,
     softmax_scale=None,
-    mode="allgather_kv",
+    mode="dualchunk_allgather",
 ):
     """
     FlashMask attention with context parallelism - public API.
@@ -1217,7 +1253,7 @@ def flashmask_attention_cp(
         dropout (float, optional): Dropout probability. Defaults to 0.0
         causal (bool, optional): Whether to use causal attention. Defaults to False
         training (bool, optional): Whether in training mode. Defaults to True
-        mode (str, optional): Attention mode. Defaults to "allgather_kv"
+        mode (str, optional): Attention mode. Defaults to "dualchunk_allgather"
     Returns:
         paddle.Tensor: Attention output with shape [batch, seq_len/n, num_heads, head_dim]
     Example:
@@ -1252,3 +1288,354 @@ def flashmask_attention_cp(
         mode,
     )
     return output
+
+
+# ======================== P2P SWA CP fast path Layer ========================
+
+SWA_WIN_SIZE = 128
+
+
+def _wait_all(tasks):
+    """Wait for all asynchronous communication tasks."""
+    for task in tasks:
+        task.wait()
+
+
+def _exchange_prev_window(key, value, group, window_size=SWA_WIN_SIZE):
+    """Exchange each rank's tail KV window with the next CP rank."""
+    rank = group.rank
+    cp_size = group.world_size
+
+    assert len(key.shape) == 4, (
+        f"SWA P2P expects BSHD KV, got key.shape={key.shape}"
+    )
+    assert key.shape[1] >= window_size, (
+        f"SWA window requires local KV sequence length >= {window_size}, "
+        f"got {key.shape[1]}"
+    )
+    assert value.shape == key.shape, (
+        f"key/value shape mismatch: key={key.shape}, value={value.shape}"
+    )
+
+    recv_window = paddle.empty(
+        [2, key.shape[0], window_size, key.shape[2], key.shape[3]],
+        dtype=key.dtype,
+    )
+    ops = []
+
+    if rank > 0:
+        recv_rank = group.ranks[rank - 1]
+        ops.append(dist.P2POp(dist.irecv, recv_window, recv_rank, group))
+
+    if rank < cp_size - 1:
+        send_rank = group.ranks[rank + 1]
+        send_window = paddle.stack(
+            [key[:, -window_size:, :, :], value[:, -window_size:, :, :]], axis=0
+        ).contiguous()
+        ops.append(dist.P2POp(dist.isend, send_window, send_rank, group))
+
+    if ops:
+        _wait_all(dist.batch_isend_irecv(ops))
+
+    return recv_window[0], recv_window[1]
+
+
+def _scatter_kv_to_global_tensor(key, value, recv_key, recv_value, group):
+    """Place local KV and received previous-window KV into global sequence layout."""
+    rank = group.rank
+    cp_size = group.world_size
+    local_seqlen = key.shape[1]
+    total_seqlen = local_seqlen * cp_size
+    local_start = rank * local_seqlen
+    local_end = local_start + local_seqlen
+
+    if cp_size == 1:
+        return key, value
+
+    scratch_shape = [key.shape[0], total_seqlen, key.shape[2], key.shape[3]]
+    key_tensor = paddle.empty(scratch_shape, dtype=key.dtype)
+    value_tensor = paddle.empty(scratch_shape, dtype=value.dtype)
+    key_tensor[:, local_start:local_end, :, :] = key
+    value_tensor[:, local_start:local_end, :, :] = value
+
+    if rank > 0:
+        window_size = recv_key.shape[1]
+        window_start = local_start - window_size
+        key_tensor[:, window_start:local_start, :, :] = recv_key
+        value_tensor[:, window_start:local_start, :, :] = recv_value
+
+    return key_tensor, value_tensor
+
+
+def _send_window_grad_back(
+    key_grad_tensor, value_grad_tensor, key, value, group
+):
+    """Return remote-window KV gradients to owner ranks and accumulate them."""
+    rank = group.rank
+    cp_size = group.world_size
+    local_seqlen = key.shape[1]
+    local_start = rank * local_seqlen
+    local_end = local_start + local_seqlen
+
+    if cp_size == 1:
+        return key_grad_tensor, value_grad_tensor
+
+    # TODO(heqianyue): the following can be optimized via cudaMemcpyAsync2D (3ms -> 0.7ms)
+    key_grad = key_grad_tensor[:, local_start:local_end, :, :].contiguous()
+    value_grad = value_grad_tensor[:, local_start:local_end, :, :].contiguous()
+
+    recv_grad_window = paddle.empty(
+        [2, key.shape[0], SWA_WIN_SIZE, key.shape[2], key.shape[3]],
+        dtype=key.dtype,
+    )
+    ops = []
+
+    if rank < cp_size - 1:
+        send_rank = group.ranks[rank + 1]
+        ops.append(dist.P2POp(dist.irecv, recv_grad_window, send_rank, group))
+
+    if rank > 0:
+        recv_rank = group.ranks[rank - 1]
+        window_start = local_start - SWA_WIN_SIZE
+        send_grad_window = paddle.stack(
+            [
+                key_grad_tensor[:, window_start:local_start, :, :],
+                value_grad_tensor[:, window_start:local_start, :, :],
+            ],
+            axis=0,
+        ).contiguous()
+        ops.append(dist.P2POp(dist.isend, send_grad_window, recv_rank, group))
+
+    if ops:
+        _wait_all(dist.batch_isend_irecv(ops))
+
+    if rank < cp_size - 1:
+        key_grad[:, -SWA_WIN_SIZE:, :, :].add_(recv_grad_window[0])
+        value_grad[:, -SWA_WIN_SIZE:, :, :].add_(recv_grad_window[1])
+
+    return key_grad, value_grad
+
+
+def cp_flashmask_swa_p2p_forward(
+    query,
+    key,
+    value,
+    startend_row_indices,
+    learnable_sink,
+    group,
+    causal,
+    is_training,
+    softmax_scale,
+):
+    """Run forward SWA FlashMask CP with one-hop P2P KV exchange."""
+    paddle.base.core.nvprof_nvtx_push("cp_flashmask_swa_p2p_forward")
+
+    startend_row_indices = preprocess_index(
+        startend_row_indices,
+        chunk_id=group.rank,
+        seq_blocksize=query.shape[1],
+        max_seqlen_q=query.shape[1],
+    )
+
+    recv_key, recv_value = _exchange_prev_window(key, value, group)
+
+    key_tensor, value_tensor = _scatter_kv_to_global_tensor(
+        key, value, recv_key, recv_value, group
+    )
+
+    output, log_sum_exp = _flash_attn_fwd(
+        query,
+        key_tensor,
+        value_tensor,
+        startend_row_indices=startend_row_indices,
+        learnable_sink=learnable_sink,
+        causal=causal,
+        return_lse=True,
+        pack_gqa=False,
+        softmax_scale=softmax_scale,
+    )
+
+    paddle.base.core.nvprof_nvtx_pop()
+
+    return output, log_sum_exp, recv_key, recv_value, startend_row_indices
+
+
+def cp_flashmask_swa_p2p_backward(
+    query,
+    key,
+    value,
+    recv_key,
+    recv_value,
+    startend_row_indices,
+    output,
+    log_sum_exp,
+    output_grad,
+    learnable_sink,
+    group,
+    causal,
+    softmax_scale,
+):
+    """Run backward SWA FlashMask CP and return P2P KV gradients."""
+    paddle.base.core.nvprof_nvtx_push("cp_flashmask_swa_p2p_backward")
+
+    key_tensor, value_tensor = _scatter_kv_to_global_tensor(
+        key, value, recv_key, recv_value, group
+    )
+
+    query_grad, key_grad_tensor, value_grad_tensor, grad_sink = _flash_attn_bwd(
+        query,
+        key_tensor,
+        value_tensor,
+        output,
+        output_grad,
+        log_sum_exp,
+        flashmask_info=startend_row_indices,
+        learnable_sink=learnable_sink,
+        causal=causal,
+        softmax_scale=softmax_scale,
+        deterministic=paddle.get_flags(["FLAGS_cudnn_deterministic"])[
+            "FLAGS_cudnn_deterministic"
+        ],
+    )
+
+    key_grad, value_grad = _send_window_grad_back(
+        key_grad_tensor, value_grad_tensor, key, value, group
+    )
+
+    paddle.base.core.nvprof_nvtx_pop()
+
+    return query_grad, key_grad, value_grad, grad_sink
+
+
+class SwaP2PFlashMask(PyLayer):
+    """PyLayer for SWA FlashMask context parallelism using one-hop P2P KV exchange."""
+
+    @staticmethod
+    def forward(
+        ctx,
+        query,
+        key,
+        value,
+        startend_row_indices,
+        fixed_seed_offset=None,
+        dropout=0.0,
+        causal=False,
+        training=True,
+        learnable_sink=None,
+        softmax_scale=None,
+        group=None,
+        mode="contiguous_allgather",
+    ):
+        """Forward pass for SWA P2P FlashMask attention."""
+        if dropout > 0.0:
+            raise NotImplementedError(
+                "Dropout is not supported in FlashMask context parallel yet."
+            )
+        if fixed_seed_offset is not None:
+            raise NotImplementedError("Fixed seed offset is not supported yet.")
+        if group is None:
+            group = fleet.get_hybrid_communicate_group().get_context_parallel_group()
+
+        output, log_sum_exp, recv_key, recv_value, startend_row_indices = (
+            cp_flashmask_swa_p2p_forward(
+                query,
+                key,
+                value,
+                startend_row_indices,
+                learnable_sink,
+                group,
+                causal,
+                training,
+                softmax_scale,
+            )
+        )
+
+        ctx.save_for_backward(
+            query,
+            key,
+            value,
+            recv_key,
+            recv_value,
+            output,
+            log_sum_exp,
+            startend_row_indices,
+        )
+        ctx.learnable_sink = learnable_sink
+        ctx.softmax_scale = softmax_scale
+        ctx.sink_requires_grad = (
+            learnable_sink is not None and not learnable_sink.stop_gradient
+        )
+        ctx.group = group
+        ctx.causal = causal
+        return output
+
+    @staticmethod
+    def backward(ctx, output_grad):
+        """Backward pass for SWA P2P FlashMask attention."""
+        (
+            query,
+            key,
+            value,
+            recv_key,
+            recv_value,
+            output,
+            log_sum_exp,
+            startend_row_indices,
+        ) = ctx.saved_tensor()
+        query_grad, key_grad, value_grad, grad_sink = (
+            cp_flashmask_swa_p2p_backward(
+                query,
+                key,
+                value,
+                recv_key,
+                recv_value,
+                startend_row_indices,
+                output,
+                log_sum_exp,
+                output_grad,
+                ctx.learnable_sink,
+                ctx.group,
+                ctx.causal,
+                ctx.softmax_scale,
+            )
+        )
+        if ctx.sink_requires_grad:
+            return query_grad, key_grad, value_grad, None, grad_sink
+        return query_grad, key_grad, value_grad
+
+
+def p2p_flashmask_attention(
+    query,
+    key,
+    value,
+    startend_row_indices,
+    fixed_seed_offset=None,
+    dropout=0.0,
+    causal=False,
+    training=True,
+    learnable_sink=None,
+    softmax_scale=None,
+    mode="contiguous_allgather",
+):
+    """Apply the SWA P2P FlashMask context-parallel fast path."""
+    hcg = fleet.get_hybrid_communicate_group()
+    cp_group = hcg.get_context_parallel_group()
+
+    assert _flash_mask_available, (
+        "P2P SWA fast path requires flashmask installed. Please check."
+    )
+
+    return SwaP2PFlashMask.apply(
+        query,
+        key,
+        value,
+        startend_row_indices,
+        fixed_seed_offset,
+        dropout,
+        causal,
+        training,
+        learnable_sink,
+        softmax_scale,
+        cp_group,
+        mode,
+    )

--- a/src/paddlefleet/context_parallel_utils.py
+++ b/src/paddlefleet/context_parallel_utils.py
@@ -506,13 +506,13 @@ class ContextParallelScatterOp(PyLayer):
         group = hcg.get_context_parallel_group()
         ctx.group = group
 
-        if mode == "contiguous_allgather":
+        if mode.startswith("contiguous"):
             return scatter_contiguous(input_tensor, group=group, axis=axis)
         return scatter_balance(input_tensor, axis=axis, group=group)
 
     @staticmethod
     def backward(ctx, grad_output):
-        if ctx.mode == "contiguous_allgather":
+        if ctx.mode.startswith("contiguous"):
             return all_gather_contiguous(
                 grad_output, group=ctx.group, axis=ctx.axis
             )
@@ -540,13 +540,13 @@ class ContextParallelGatherOp(PyLayer):
         group = hcg.get_context_parallel_group()
         ctx.group = group
 
-        if mode == "contiguous_allgather":
+        if mode.startswith("contiguous"):
             return all_gather_contiguous(input_tensor, group=group, axis=axis)
         return all_gather_balance(input_tensor, axis=axis, group=group)
 
     @staticmethod
     def backward(ctx, grad_output):
-        if ctx.mode == "contiguous_allgather":
+        if ctx.mode.startswith("contiguous"):
             return scatter_contiguous(
                 grad_output, group=ctx.group, axis=ctx.axis
             )
@@ -574,13 +574,13 @@ class ContextParallelAllGatherOp(PyLayer):
         group = hcg.get_context_parallel_group()
         ctx.group = group
 
-        if mode == "contiguous_allgather":
+        if mode.startswith("contiguous"):
             return all_gather_contiguous(input_tensor, group=group, axis=axis)
         return all_gather_balance(input_tensor, axis=axis, group=group)
 
     @staticmethod
     def backward(ctx, grad_output):
-        if ctx.mode == "contiguous_allgather":
+        if ctx.mode.startswith("contiguous"):
             return reduce_scatter_contiguous(
                 grad_output, axis=ctx.axis, group=ctx.group
             )
@@ -1227,69 +1227,6 @@ class FlashMaskContextParallel(PyLayer):
         return query_grad, key_grad, value_grad
 
 
-def flashmask_attention_cp(
-    query,
-    key,
-    value,
-    startend_row_indices,
-    fixed_seed_offset=None,
-    dropout=0.0,
-    causal=False,
-    training=True,
-    learnable_sink=None,
-    softmax_scale=None,
-    mode="dualchunk_allgather",
-):
-    """
-    FlashMask attention with context parallelism - public API.
-    This is the main entry point for using FlashMask attention with context parallelism.
-    It provides a convenient interface that wraps the FlashMaskContextParallel PyLayer.
-    Args:
-        query (paddle.Tensor): Query tensor with shape [batch, seq_len/n, num_heads, head_dim]
-        key (paddle.Tensor): Key tensor with shape [batch, seq_len/n, num_heads, head_dim]
-        value (paddle.Tensor): Value tensor with shape [batch, seq_len/n, num_heads, head_dim]
-        startend_row_indices (paddle.Tensor): Row indices for attention mask
-        fixed_seed_offset (paddle.Tensor, optional): Fixed seed offset for dropout
-        dropout (float, optional): Dropout probability. Defaults to 0.0
-        causal (bool, optional): Whether to use causal attention. Defaults to False
-        training (bool, optional): Whether in training mode. Defaults to True
-        mode (str, optional): Attention mode. Defaults to "dualchunk_allgather"
-    Returns:
-        paddle.Tensor: Attention output with shape [batch, seq_len/n, num_heads, head_dim]
-    Example:
-        ```python
-        # Initialize tensors (assuming context parallelism is set up)
-        query = paddle.randn([2, 512, 8, 64])  # [batch, seq_len/n, heads, head_dim]
-        key = paddle.randn([2, 512, 8, 64])    # [batch, seq_len/n, heads, head_dim]
-        value = paddle.randn([2, 512, 8, 64])  # [batch, seq_len/n, heads, head_dim]
-        mask_indices = paddle.randint(0, 1024, [100, 2])
-        # Apply FlashMask attention with context parallelism
-        output = flashmask_attention_cp(
-            query=query,
-            key=key,
-            value=value,
-            startend_row_indices=mask_indices,
-            training=True
-        )
-        ```
-    """
-
-    output = FlashMaskContextParallel.apply(
-        query,
-        key,
-        value,
-        startend_row_indices,
-        fixed_seed_offset,
-        dropout,
-        causal,
-        training,
-        learnable_sink,
-        softmax_scale,
-        mode,
-    )
-    return output
-
-
 # ======================== P2P SWA CP fast path Layer ========================
 
 SWA_WIN_SIZE = 128
@@ -1533,8 +1470,6 @@ class SwaP2PFlashMask(PyLayer):
             )
         if fixed_seed_offset is not None:
             raise NotImplementedError("Fixed seed offset is not supported yet.")
-        if group is None:
-            group = fleet.get_hybrid_communicate_group().get_context_parallel_group()
 
         output, log_sum_exp, recv_key, recv_value, startend_row_indices = (
             cp_flashmask_swa_p2p_forward(
@@ -1604,7 +1539,7 @@ class SwaP2PFlashMask(PyLayer):
         return query_grad, key_grad, value_grad
 
 
-def p2p_flashmask_attention(
+def flashmask_attention_cp(
     query,
     key,
     value,
@@ -1615,27 +1550,75 @@ def p2p_flashmask_attention(
     training=True,
     learnable_sink=None,
     softmax_scale=None,
-    mode="contiguous_allgather",
+    mode="dualchunk_allgather",
 ):
-    """Apply the SWA P2P FlashMask context-parallel fast path."""
-    hcg = fleet.get_hybrid_communicate_group()
-    cp_group = hcg.get_context_parallel_group()
+    """
+    FlashMask attention with context parallelism - public API.
+    This is the main entry point for using FlashMask attention with context parallelism.
+    It provides a convenient interface that wraps the FlashMaskContextParallel PyLayer.
+    Args:
+        query (paddle.Tensor): Query tensor with shape [batch, seq_len/n, num_heads, head_dim]
+        key (paddle.Tensor): Key tensor with shape [batch, seq_len/n, num_heads, head_dim]
+        value (paddle.Tensor): Value tensor with shape [batch, seq_len/n, num_heads, head_dim]
+        startend_row_indices (paddle.Tensor): Row indices for attention mask
+        fixed_seed_offset (paddle.Tensor, optional): Fixed seed offset for dropout
+        dropout (float, optional): Dropout probability. Defaults to 0.0
+        causal (bool, optional): Whether to use causal attention. Defaults to False
+        training (bool, optional): Whether in training mode. Defaults to True
+        mode (str, optional): Attention mode. Defaults to "dualchunk_allgather"
+    Returns:
+        paddle.Tensor: Attention output with shape [batch, seq_len/n, num_heads, head_dim]
+    Example:
+        ```python
+        # Initialize tensors (assuming context parallelism is set up)
+        query = paddle.randn([2, 512, 8, 64])  # [batch, seq_len/n, heads, head_dim]
+        key = paddle.randn([2, 512, 8, 64])    # [batch, seq_len/n, heads, head_dim]
+        value = paddle.randn([2, 512, 8, 64])  # [batch, seq_len/n, heads, head_dim]
+        mask_indices = paddle.randint(0, 1024, [100, 2])
+        # Apply FlashMask attention with context parallelism
+        output = flashmask_attention_cp(
+            query=query,
+            key=key,
+            value=value,
+            startend_row_indices=mask_indices,
+            training=True
+        )
+        ```
+    """
+    if mode == "contiguous_swap2p":
+        hcg = fleet.get_hybrid_communicate_group()
+        cp_group = hcg.get_context_parallel_group()
 
-    assert _flash_mask_available, (
-        "P2P SWA fast path requires flashmask installed. Please check."
-    )
+        assert _flash_mask_available, (
+            "P2P SWA fast path requires flashmask installed. Please check."
+        )
 
-    return SwaP2PFlashMask.apply(
-        query,
-        key,
-        value,
-        startend_row_indices,
-        fixed_seed_offset,
-        dropout,
-        causal,
-        training,
-        learnable_sink,
-        softmax_scale,
-        cp_group,
-        mode,
-    )
+        return SwaP2PFlashMask.apply(
+            query,
+            key,
+            value,
+            startend_row_indices,
+            fixed_seed_offset,
+            dropout,
+            causal,
+            training,
+            learnable_sink,
+            softmax_scale,
+            cp_group,
+            mode,
+        )
+    else:
+        output = FlashMaskContextParallel.apply(
+            query,
+            key,
+            value,
+            startend_row_indices,
+            fixed_seed_offset,
+            dropout,
+            causal,
+            training,
+            learnable_sink,
+            softmax_scale,
+            mode,
+        )
+    return output

--- a/src/paddlefleet/transformer/dot_product_attention.py
+++ b/src/paddlefleet/transformer/dot_product_attention.py
@@ -34,10 +34,7 @@ from paddlefleet_ops.flash_mask_facade import (
     flashmask_attention,
 )
 
-from paddlefleet.context_parallel_utils import (
-    flashmask_attention_cp,
-    p2p_flashmask_attention,
-)
+from paddlefleet.context_parallel_utils import flashmask_attention_cp
 from paddlefleet.fusions.fused_softmax import FusedScaleMaskSoftmax
 from paddlefleet.parallel_state import get_context_parallel_world_size
 from paddlefleet.process_groups_config import ProcessGroupCollection
@@ -513,6 +510,8 @@ class DotProductAttention(FleetLayer):
                     is_causal = True
             else:
                 is_causal = attn_mask_type == AttnMaskType.causal
+
+            extra_kwargs = {}
             if self.context_parallel_size > 1:
                 flashmask_attention_func = (
                     self.rr_flashmask_attention_cp_func
@@ -522,8 +521,12 @@ class DotProductAttention(FleetLayer):
                 use_mla = bool(
                     getattr(self.config, "multi_latent_attention", False)
                 )
-                if self.is_swa and use_mla:
-                    flashmask_attention_func = p2p_flashmask_attention
+
+                extra_kwargs["mode"] = self.config.cp_balance_mode
+                if self.config.cp_balance_mode == "contiguous_a2a":
+                    if self.is_swa and use_mla:
+                        extra_kwargs["mode"] = "contiguous_swap2p"
+
                 is_causal = (
                     False  # only support non-causal for flashmask_attention_cp
                 )
@@ -576,6 +579,7 @@ class DotProductAttention(FleetLayer):
                 dropout=self.config.attention_dropout,
                 causal=is_causal,
                 learnable_sink=self.softmax_offset,
+                **extra_kwargs,
             )
 
             if need_value_padding:

--- a/src/paddlefleet/transformer/dot_product_attention.py
+++ b/src/paddlefleet/transformer/dot_product_attention.py
@@ -34,7 +34,10 @@ from paddlefleet_ops.flash_mask_facade import (
     flashmask_attention,
 )
 
-from paddlefleet.context_parallel_utils import flashmask_attention_cp
+from paddlefleet.context_parallel_utils import (
+    flashmask_attention_cp,
+    p2p_flashmask_attention,
+)
 from paddlefleet.fusions.fused_softmax import FusedScaleMaskSoftmax
 from paddlefleet.parallel_state import get_context_parallel_world_size
 from paddlefleet.process_groups_config import ProcessGroupCollection
@@ -516,6 +519,11 @@ class DotProductAttention(FleetLayer):
                     if use_rr_flash_attention
                     else flashmask_attention_cp
                 )
+                use_mla = bool(
+                    getattr(self.config, "multi_latent_attention", False)
+                )
+                if self.is_swa and use_mla:
+                    flashmask_attention_func = p2p_flashmask_attention
                 is_causal = (
                     False  # only support non-causal for flashmask_attention_cp
                 )

--- a/src/paddlefleet/transformer/dot_product_attention.py
+++ b/src/paddlefleet/transformer/dot_product_attention.py
@@ -526,6 +526,7 @@ class DotProductAttention(FleetLayer):
                 if self.config.cp_balance_mode == "contiguous_a2a":
                     if self.is_swa and use_mla:
                         extra_kwargs["mode"] = "contiguous_swap2p"
+                        extra_kwargs["window_size"] = self.sliding_window[0]
 
                 is_causal = (
                     False  # only support non-causal for flashmask_attention_cp

--- a/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_context_parallel_flashmask_modes.py
+++ b/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_context_parallel_flashmask_modes.py
@@ -1,0 +1,750 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+import paddle
+
+REPO_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..", "..")
+)
+sys.path.insert(0, os.path.join(REPO_ROOT, "src"))
+
+from paddlefleet import context_parallel_utils as cp_utils
+
+
+class FakeGroup:
+    def __init__(self, rank=0, world_size=2):
+        self.rank = rank
+        self.world_size = world_size
+        self.nranks = world_size
+        self.ranks = list(range(world_size))
+
+
+class FakeContext:
+    def save_for_backward(self, *tensors):
+        self.saved = tensors
+
+    def saved_tensor(self):
+        return self.saved
+
+
+class FakeHcg:
+    def __init__(self, group):
+        self.group = group
+
+    def get_context_parallel_group(self):
+        return self.group
+
+
+class FakeTask:
+    def wait(self):
+        pass
+
+
+def assert_tensor_equal(testcase, actual, expected):
+    testcase.assertTrue(bool((actual == expected).all().item()))
+
+
+class TestFlashMaskAllGatherModes(unittest.TestCase):
+    def setUp(self):
+        self.query = paddle.zeros([1, 4, 1, 1], dtype="float32")
+        self.key = paddle.full([1, 4, 1, 1], 2.0, dtype="float32")
+        self.value = paddle.full([1, 4, 1, 1], 3.0, dtype="float32")
+        self.output = paddle.full([1, 4, 1, 1], 7.0, dtype="float32")
+        self.lse = paddle.full([1, 1, 4], 0.5, dtype="float32")
+        self.group = FakeGroup(rank=1, world_size=2)
+
+    def _run_forward(self, mode, indices):
+        captured = {}
+
+        def fake_flashmask_attention(query, key, value, **kwargs):
+            captured["key"] = key
+            captured["value"] = value
+            captured["indices"] = kwargs["startend_row_indices"]
+            captured["softmax_scale"] = kwargs["softmax_scale"]
+            return self.output, self.lse
+
+        patches = [
+            patch.object(
+                cp_utils.paddle.base.core, "nvprof_nvtx_push", lambda _: None
+            ),
+            patch.object(
+                cp_utils.paddle.base.core, "nvprof_nvtx_pop", lambda: None
+            ),
+            patch.object(
+                cp_utils.paddle.base.framework,
+                "get_flags",
+                lambda _: {"FLAGS_flash_attn_version": 2},
+            ),
+            patch.object(
+                cp_utils.paddle,
+                "get_flags",
+                lambda _: {"FLAGS_cudnn_deterministic": False},
+            ),
+            patch.object(
+                cp_utils, "flashmask_attention", fake_flashmask_attention
+            ),
+            patch.object(
+                cp_utils, "all_gather_balance", lambda x, axis, group: x + 10
+            ),
+            patch.object(
+                cp_utils, "all_gather_contiguous", lambda x, axis, group: x + 20
+            ),
+        ]
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+        ):
+            output, lse, processed_indices, fa_version = (
+                cp_utils.cp_flashmask_allgatherkv_balance_forward(
+                    self.query,
+                    self.key,
+                    self.value,
+                    indices,
+                    None,
+                    self.group,
+                    False,
+                    True,
+                    0.25,
+                    mode,
+                )
+            )
+
+        assert_tensor_equal(self, output, self.output)
+        assert_tensor_equal(self, lse, self.lse)
+        self.assertEqual(fa_version, 2)
+        assert_tensor_equal(self, processed_indices, captured["indices"])
+        self.assertEqual(captured["softmax_scale"], 0.25)
+        return captured, processed_indices
+
+    def test_dualchunk_forward_preprocesses_indices_and_uses_balanced_layout(
+        self,
+    ):
+        indices = paddle.to_tensor([0, 1, 2, 3, 4, 5, 6], dtype="int32")
+        captured, processed_indices = self._run_forward(
+            "dualchunk_allgather", indices
+        )
+
+        expected_indices = cp_utils.preprocess_index_dual_chunks(
+            indices,
+            chunk_id_first=1,
+            chunk_id_second=2,
+            seq_blocksize=2,
+            max_seqlen_q=2,
+        )
+        assert_tensor_equal(self, processed_indices, expected_indices)
+        assert_tensor_equal(self, captured["key"], self.key + 10)
+        assert_tensor_equal(self, captured["value"], self.value + 10)
+
+    def test_contiguous_forward_preprocesses_indices_and_uses_rank_order_layout(
+        self,
+    ):
+        indices = paddle.to_tensor([0, 3, 4, 6, 8], dtype="int32")
+        captured, processed_indices = self._run_forward(
+            "contiguous_allgather", indices
+        )
+
+        expected_indices = cp_utils.preprocess_index(
+            indices, chunk_id=1, seq_blocksize=4, max_seqlen_q=4
+        )
+        assert_tensor_equal(self, processed_indices, expected_indices)
+        assert_tensor_equal(self, captured["key"], self.key + 20)
+        assert_tensor_equal(self, captured["value"], self.value + 20)
+
+    def test_forward_rejects_unknown_mode(self):
+        with (
+            patch.object(
+                cp_utils.paddle.base.core, "nvprof_nvtx_push", lambda _: None
+            ),
+            self.assertRaises(ValueError),
+        ):
+            cp_utils.cp_flashmask_allgatherkv_balance_forward(
+                self.query,
+                self.key,
+                self.value,
+                paddle.to_tensor([0], dtype="int32"),
+                None,
+                self.group,
+                False,
+                True,
+                None,
+                "swa_p2p",
+            )
+
+    def _run_backward(self, mode):
+        gathered_key_grad = paddle.full([1, 8, 1, 1], 5.0, dtype="float32")
+        gathered_value_grad = paddle.full([1, 8, 1, 1], 6.0, dtype="float32")
+        reduced_key_grad = paddle.full([1, 4, 1, 1], 7.0, dtype="float32")
+        reduced_value_grad = paddle.full([1, 4, 1, 1], 8.0, dtype="float32")
+        captured = {}
+
+        def fake_flashmask_grad(query, key, value, *args):
+            captured["key"] = key
+            captured["value"] = value
+            return self.query + 1, gathered_key_grad, gathered_value_grad
+
+        def fake_reduce_balance(x, axis, group):
+            captured.setdefault("reduced", []).append(x)
+            return (
+                reduced_key_grad
+                if len(captured["reduced"]) == 1
+                else reduced_value_grad
+            )
+
+        def fake_reduce_contiguous(x, axis, group):
+            captured.setdefault("reduced", []).append(x)
+            return (
+                reduced_key_grad + 10
+                if len(captured["reduced"]) == 1
+                else reduced_value_grad + 10
+            )
+
+        patches = [
+            patch.object(
+                cp_utils.paddle.base.core, "nvprof_nvtx_push", lambda _: None
+            ),
+            patch.object(
+                cp_utils.paddle.base.core, "nvprof_nvtx_pop", lambda: None
+            ),
+            patch.object(
+                cp_utils, "all_gather_balance", lambda x, axis, group: x + 10
+            ),
+            patch.object(
+                cp_utils, "all_gather_contiguous", lambda x, axis, group: x + 20
+            ),
+            patch.object(
+                cp_utils, "reduce_scatter_any_axis_balance", fake_reduce_balance
+            ),
+            patch.object(
+                cp_utils, "reduce_scatter_contiguous", fake_reduce_contiguous
+            ),
+            patch.object(
+                cp_utils.paddle._C_ops,
+                "flashmask_attention_grad",
+                fake_flashmask_grad,
+            ),
+        ]
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+        ):
+            query_grad, key_grad, value_grad, grad_sink = (
+                cp_utils.cp_flashmask_allgatherkv_balance_backward(
+                    self.query,
+                    self.key,
+                    self.value,
+                    paddle.to_tensor([0, 1], dtype="int32"),
+                    self.output,
+                    self.lse,
+                    self.output,
+                    None,
+                    self.group,
+                    False,
+                    2,
+                    None,
+                    mode,
+                )
+            )
+        return captured, query_grad, key_grad, value_grad, grad_sink
+
+    def test_dualchunk_backward_uses_balanced_gather_and_reduce_scatter(self):
+        captured, query_grad, key_grad, value_grad, grad_sink = (
+            self._run_backward("dualchunk_allgather")
+        )
+
+        assert_tensor_equal(self, captured["key"], self.key + 10)
+        assert_tensor_equal(self, captured["value"], self.value + 10)
+        assert_tensor_equal(self, query_grad, self.query + 1)
+        assert_tensor_equal(self, key_grad, 7.0)
+        assert_tensor_equal(self, value_grad, 8.0)
+        self.assertIsNone(grad_sink)
+
+    def test_contiguous_backward_uses_rank_order_gather_and_reduce_scatter(
+        self,
+    ):
+        captured, query_grad, key_grad, value_grad, grad_sink = (
+            self._run_backward("contiguous_allgather")
+        )
+
+        assert_tensor_equal(self, captured["key"], self.key + 20)
+        assert_tensor_equal(self, captured["value"], self.value + 20)
+        assert_tensor_equal(self, query_grad, self.query + 1)
+        assert_tensor_equal(self, key_grad, 17.0)
+        assert_tensor_equal(self, value_grad, 18.0)
+        self.assertIsNone(grad_sink)
+
+    def test_backward_rejects_unknown_mode(self):
+        with (
+            patch.object(
+                cp_utils.paddle.base.core, "nvprof_nvtx_push", lambda _: None
+            ),
+            self.assertRaises(ValueError),
+        ):
+            cp_utils.cp_flashmask_allgatherkv_balance_backward(
+                self.query,
+                self.key,
+                self.value,
+                paddle.to_tensor([0], dtype="int32"),
+                self.output,
+                self.lse,
+                self.output,
+                None,
+                self.group,
+                False,
+                2,
+                None,
+                "swa_p2p",
+            )
+
+
+class TestFlashMaskContextParallelMode(unittest.TestCase):
+    def test_forward_passes_mode_to_impl_and_saves_it_for_backward(self):
+        query = paddle.zeros([1, 4, 1, 1], dtype="float32")
+        key = paddle.zeros([1, 4, 1, 1], dtype="float32")
+        value = paddle.zeros([1, 4, 1, 1], dtype="float32")
+        indices = paddle.to_tensor([0, 1], dtype="int32")
+        output = paddle.full([1, 4, 1, 1], 9.0, dtype="float32")
+        lse = paddle.full([1, 1, 4], 1.0, dtype="float32")
+        ctx = FakeContext()
+        captured = {}
+
+        def fake_forward(*args):
+            captured["mode"] = args[-1]
+            return output, lse, indices + 1, 2
+
+        with (
+            patch.object(
+                cp_utils.fleet,
+                "get_hybrid_communicate_group",
+                lambda: FakeHcg(FakeGroup(rank=0, world_size=2)),
+            ),
+            patch.object(
+                cp_utils,
+                "cp_flashmask_allgatherkv_balance_forward",
+                fake_forward,
+            ),
+        ):
+            result = cp_utils.FlashMaskContextParallel.forward(
+                ctx,
+                query,
+                key,
+                value,
+                indices,
+                mode="contiguous_allgather",
+            )
+
+        assert_tensor_equal(self, result, output)
+        self.assertEqual(captured["mode"], "contiguous_allgather")
+        self.assertEqual(ctx.mode, "contiguous_allgather")
+        self.assertEqual(ctx.fa_version, 2)
+        assert_tensor_equal(self, ctx.saved[-1], indices + 1)
+
+
+class TestSwaP2PHelpers(unittest.TestCase):
+    def test_scatter_kv_places_local_and_received_windows(self):
+        group = FakeGroup(rank=1, world_size=2)
+        key = paddle.arange(4, dtype="float32").reshape([1, 4, 1, 1]) + 10
+        value = key + 100
+        recv_key = paddle.arange(2, dtype="float32").reshape([1, 2, 1, 1]) + 8
+        recv_value = recv_key + 100
+
+        key_tensor, value_tensor = cp_utils._scatter_kv_to_global_tensor(
+            key, value, recv_key, recv_value, group
+        )
+
+        assert_tensor_equal(self, key_tensor[:, 2:4, :, :], recv_key)
+        assert_tensor_equal(self, value_tensor[:, 2:4, :, :], recv_value)
+        assert_tensor_equal(self, key_tensor[:, 4:8, :, :], key)
+        assert_tensor_equal(self, value_tensor[:, 4:8, :, :], value)
+
+    def test_send_window_grad_back_returns_original_tensors_for_single_rank(
+        self,
+    ):
+        group = FakeGroup(rank=0, world_size=1)
+        key_grad_tensor = paddle.zeros([1, 4, 1, 1], dtype="float32")
+        value_grad_tensor = paddle.ones([1, 4, 1, 1], dtype="float32")
+        key = paddle.zeros([1, 4, 1, 1], dtype="float32")
+        value = paddle.zeros([1, 4, 1, 1], dtype="float32")
+
+        key_grad, value_grad = cp_utils._send_window_grad_back(
+            key_grad_tensor, value_grad_tensor, key, value, group
+        )
+
+        self.assertIs(key_grad, key_grad_tensor)
+        self.assertIs(value_grad, value_grad_tensor)
+
+    def test_send_window_grad_back_accumulates_received_tail_grad(self):
+        group = FakeGroup(rank=0, world_size=2)
+        key_grad_tensor = paddle.arange(256, dtype="float32").reshape(
+            [1, 256, 1, 1]
+        )
+        value_grad_tensor = key_grad_tensor + 100
+        key = paddle.zeros([1, 128, 1, 1], dtype="float32")
+        value = paddle.zeros([1, 128, 1, 1], dtype="float32")
+        recv_grad_window = paddle.stack(
+            [
+                paddle.full([1, 128, 1, 1], 10.0, dtype="float32"),
+                paddle.full([1, 128, 1, 1], 20.0, dtype="float32"),
+            ],
+            axis=0,
+        )
+
+        with (
+            patch.object(
+                cp_utils.paddle,
+                "empty",
+                lambda *args, **kwargs: recv_grad_window,
+            ),
+            patch.object(cp_utils.dist, "P2POp", lambda *args: object()),
+            patch.object(
+                cp_utils.dist, "batch_isend_irecv", lambda ops: [FakeTask()]
+            ),
+        ):
+            key_grad, value_grad = cp_utils._send_window_grad_back(
+                key_grad_tensor, value_grad_tensor, key, value, group
+            )
+
+        assert_tensor_equal(
+            self, key_grad, key_grad_tensor[:, :128, :, :] + 10.0
+        )
+        assert_tensor_equal(
+            self, value_grad, value_grad_tensor[:, :128, :, :] + 20.0
+        )
+
+    def test_send_window_grad_back_sends_previous_window_grad_to_owner(self):
+        group = FakeGroup(rank=1, world_size=2)
+        key_grad_tensor = paddle.arange(256, dtype="float32").reshape(
+            [1, 256, 1, 1]
+        )
+        value_grad_tensor = key_grad_tensor + 100
+        key = paddle.zeros([1, 128, 1, 1], dtype="float32")
+        value = paddle.zeros([1, 128, 1, 1], dtype="float32")
+        captured = {}
+
+        def fake_p2p_op(op, tensor, peer, group_arg):
+            captured["tensor"] = tensor
+            captured["peer"] = peer
+            return object()
+
+        with (
+            patch.object(cp_utils.dist, "P2POp", fake_p2p_op),
+            patch.object(
+                cp_utils.dist, "batch_isend_irecv", lambda ops: [FakeTask()]
+            ),
+        ):
+            key_grad, value_grad = cp_utils._send_window_grad_back(
+                key_grad_tensor, value_grad_tensor, key, value, group
+            )
+
+        expected_send = paddle.stack(
+            [key_grad_tensor[:, :128, :, :], value_grad_tensor[:, :128, :, :]],
+            axis=0,
+        )
+        assert_tensor_equal(self, captured["tensor"], expected_send)
+        self.assertEqual(captured["peer"], 0)
+        assert_tensor_equal(self, key_grad, key_grad_tensor[:, 128:, :, :])
+        assert_tensor_equal(self, value_grad, value_grad_tensor[:, 128:, :, :])
+
+    def test_exchange_prev_window_receives_from_previous_rank(self):
+        group = FakeGroup(rank=1, world_size=2)
+        key = paddle.arange(4, dtype="float32").reshape([1, 4, 1, 1])
+        value = key + 10
+        recv_window = paddle.stack(
+            [key[:, :2, :, :] + 20, value[:, :2, :, :] + 20], axis=0
+        )
+
+        with (
+            patch.object(
+                cp_utils.paddle, "empty", lambda *args, **kwargs: recv_window
+            ),
+            patch.object(cp_utils.dist, "P2POp", lambda *args: object()),
+            patch.object(
+                cp_utils.dist, "batch_isend_irecv", lambda ops: [FakeTask()]
+            ),
+        ):
+            recv_key, recv_value = cp_utils._exchange_prev_window(
+                key, value, group, window_size=2
+            )
+
+        assert_tensor_equal(self, recv_key, recv_window[0])
+        assert_tensor_equal(self, recv_value, recv_window[1])
+
+    def test_exchange_prev_window_sends_tail_kv_to_next_rank(self):
+        group = FakeGroup(rank=0, world_size=2)
+        key = paddle.arange(4, dtype="float32").reshape([1, 4, 1, 1])
+        value = key + 10
+        captured = {}
+
+        def fake_p2p_op(op, tensor, peer, group_arg):
+            captured["tensor"] = tensor
+            captured["peer"] = peer
+            return object()
+
+        with (
+            patch.object(cp_utils.dist, "P2POp", fake_p2p_op),
+            patch.object(
+                cp_utils.dist, "batch_isend_irecv", lambda ops: [FakeTask()]
+            ),
+        ):
+            cp_utils._exchange_prev_window(key, value, group, window_size=2)
+
+        expected = paddle.stack(
+            [key[:, -2:, :, :], value[:, -2:, :, :]], axis=0
+        )
+        assert_tensor_equal(self, captured["tensor"], expected)
+        self.assertEqual(captured["peer"], 1)
+
+
+class TestSwaP2PFlashMaskPath(unittest.TestCase):
+    def setUp(self):
+        self.query = paddle.zeros([1, 128, 1, 1], dtype="float32")
+        self.key = paddle.arange(128, dtype="float32").reshape([1, 128, 1, 1])
+        self.value = self.key + 10
+        self.indices = paddle.to_tensor([0, 1, 128], dtype="int32")
+        self.group = FakeGroup(rank=0, world_size=1)
+
+    def test_p2p_forward_preprocesses_indices_and_calls_flash_attention(self):
+        output = paddle.full([1, 128, 1, 1], 3.0, dtype="float32")
+        lse = paddle.full([1, 1, 128], 4.0, dtype="float32")
+        captured = {}
+
+        def fake_flash_fwd(query, key, value, **kwargs):
+            captured["query"] = query
+            captured["key"] = key
+            captured["value"] = value
+            captured["indices"] = kwargs["startend_row_indices"]
+            captured["learnable_sink"] = kwargs["learnable_sink"]
+            captured["causal"] = kwargs["causal"]
+            captured["softmax_scale"] = kwargs["softmax_scale"]
+            return output, lse
+
+        with (
+            patch.object(
+                cp_utils.paddle.base.core, "nvprof_nvtx_push", lambda _: None
+            ),
+            patch.object(
+                cp_utils.paddle.base.core, "nvprof_nvtx_pop", lambda: None
+            ),
+            patch.object(cp_utils, "_flash_attn_fwd", fake_flash_fwd),
+        ):
+            result, result_lse, recv_key, recv_value, processed = (
+                cp_utils.cp_flashmask_swa_p2p_forward(
+                    self.query,
+                    self.key,
+                    self.value,
+                    self.indices,
+                    None,
+                    self.group,
+                    causal=False,
+                    is_training=True,
+                    softmax_scale=0.5,
+                )
+            )
+
+        expected_indices = cp_utils.preprocess_index(
+            self.indices, chunk_id=0, seq_blocksize=128, max_seqlen_q=128
+        )
+        assert_tensor_equal(self, result, output)
+        assert_tensor_equal(self, result_lse, lse)
+        assert_tensor_equal(self, processed, expected_indices)
+        self.assertIs(captured["query"], self.query)
+        self.assertIs(captured["key"], self.key)
+        self.assertIs(captured["value"], self.value)
+        assert_tensor_equal(self, captured["indices"], expected_indices)
+        self.assertIsNone(captured["learnable_sink"])
+        self.assertFalse(captured["causal"])
+        self.assertEqual(captured["softmax_scale"], 0.5)
+        self.assertEqual(list(recv_key.shape), [1, 128, 1, 1])
+        self.assertEqual(list(recv_value.shape), [1, 128, 1, 1])
+
+    def test_p2p_backward_calls_flash_bwd_and_returns_local_grads(self):
+        output = paddle.full([1, 128, 1, 1], 3.0, dtype="float32")
+        lse = paddle.full([1, 1, 128], 4.0, dtype="float32")
+        output_grad = paddle.ones([1, 128, 1, 1], dtype="float32")
+        recv_key = paddle.zeros([1, 128, 1, 1], dtype="float32")
+        recv_value = paddle.zeros([1, 128, 1, 1], dtype="float32")
+        query_grad = self.query + 1
+        key_grad = self.key + 2
+        value_grad = self.value + 3
+        captured = {}
+
+        def fake_flash_bwd(query, key, value, out, dout, lse_arg, **kwargs):
+            captured["key"] = key
+            captured["value"] = value
+            captured["output"] = out
+            captured["output_grad"] = dout
+            captured["lse"] = lse_arg
+            captured["indices"] = kwargs["flashmask_info"]
+            captured["learnable_sink"] = kwargs["learnable_sink"]
+            captured["softmax_scale"] = kwargs["softmax_scale"]
+            captured["deterministic"] = kwargs["deterministic"]
+            return query_grad, key_grad, value_grad, None
+
+        with (
+            patch.object(
+                cp_utils.paddle.base.core, "nvprof_nvtx_push", lambda _: None
+            ),
+            patch.object(
+                cp_utils.paddle.base.core, "nvprof_nvtx_pop", lambda: None
+            ),
+            patch.object(
+                cp_utils.paddle,
+                "get_flags",
+                lambda _: {"FLAGS_cudnn_deterministic": False},
+            ),
+            patch.object(cp_utils, "_flash_attn_bwd", fake_flash_bwd),
+        ):
+            qg, kg, vg, grad_sink = cp_utils.cp_flashmask_swa_p2p_backward(
+                self.query,
+                self.key,
+                self.value,
+                recv_key,
+                recv_value,
+                self.indices,
+                output,
+                lse,
+                output_grad,
+                None,
+                self.group,
+                causal=False,
+                softmax_scale=0.5,
+            )
+
+        assert_tensor_equal(self, qg, query_grad)
+        assert_tensor_equal(self, kg, key_grad)
+        assert_tensor_equal(self, vg, value_grad)
+        self.assertIs(captured["key"], self.key)
+        self.assertIs(captured["value"], self.value)
+        self.assertIs(captured["output"], output)
+        self.assertIs(captured["output_grad"], output_grad)
+        self.assertIs(captured["lse"], lse)
+        self.assertIs(captured["indices"], self.indices)
+        self.assertIsNone(captured["learnable_sink"])
+        self.assertEqual(captured["softmax_scale"], 0.5)
+        self.assertFalse(captured["deterministic"])
+        self.assertIsNone(grad_sink)
+
+    def test_pylayer_forward_saves_tensors_and_backward_uses_saved_context(
+        self,
+    ):
+        ctx = FakeContext()
+        output = paddle.full([1, 4, 1, 1], 3.0, dtype="float32")
+        lse = paddle.full([1, 1, 4], 4.0, dtype="float32")
+        recv_key = paddle.zeros([1, 128, 1, 1], dtype="float32")
+        recv_value = paddle.zeros([1, 128, 1, 1], dtype="float32")
+        qg = self.query + 1
+        kg = self.key + 2
+        vg = self.value + 3
+
+        with patch.object(
+            cp_utils,
+            "cp_flashmask_swa_p2p_forward",
+            lambda *args: (output, lse, recv_key, recv_value, self.indices + 1),
+        ):
+            result = cp_utils.SwaP2PFlashMask.forward(
+                ctx,
+                self.query,
+                self.key,
+                self.value,
+                self.indices,
+                group=self.group,
+            )
+
+        assert_tensor_equal(self, result, output)
+        self.assertIs(ctx.group, self.group)
+        self.assertFalse(ctx.causal)
+        assert_tensor_equal(self, ctx.saved[-1], self.indices + 1)
+
+        with patch.object(
+            cp_utils,
+            "cp_flashmask_swa_p2p_backward",
+            lambda *args: (qg, kg, vg, None),
+        ):
+            backward_result = cp_utils.SwaP2PFlashMask.backward(ctx, output)
+
+        self.assertEqual(len(backward_result), 3)
+        assert_tensor_equal(self, backward_result[0], qg)
+        assert_tensor_equal(self, backward_result[1], kg)
+        assert_tensor_equal(self, backward_result[2], vg)
+
+    def test_p2p_flashmask_attention_requires_flashmask(self):
+        with (
+            patch.object(cp_utils, "_flash_mask_available", False),
+            patch.object(
+                cp_utils.fleet,
+                "get_hybrid_communicate_group",
+                lambda: FakeHcg(self.group),
+            ),
+            self.assertRaises(AssertionError),
+        ):
+            cp_utils.p2p_flashmask_attention(
+                self.query, self.key, self.value, self.indices
+            )
+
+    def test_p2p_flashmask_attention_applies_pylayer_with_cp_group(self):
+        captured = {}
+        result = paddle.full([1, 4, 1, 1], 5.0, dtype="float32")
+        learnable_sink = paddle.ones([1], dtype="float32")
+
+        def fake_apply(*args):
+            captured["args"] = args
+            return result
+
+        with (
+            patch.object(cp_utils, "_flash_mask_available", True),
+            patch.object(
+                cp_utils.fleet,
+                "get_hybrid_communicate_group",
+                lambda: FakeHcg(self.group),
+            ),
+            patch.object(cp_utils.SwaP2PFlashMask, "apply", fake_apply),
+        ):
+            out = cp_utils.p2p_flashmask_attention(
+                self.query,
+                self.key,
+                self.value,
+                self.indices,
+                causal=True,
+                training=False,
+                learnable_sink=learnable_sink,
+                softmax_scale=0.5,
+            )
+
+        assert_tensor_equal(self, out, result)
+        self.assertIs(captured["args"][0], self.query)
+        self.assertIs(captured["args"][1], self.key)
+        self.assertIs(captured["args"][2], self.value)
+        self.assertTrue(captured["args"][6])
+        self.assertFalse(captured["args"][7])
+        self.assertIs(captured["args"][8], learnable_sink)
+        self.assertEqual(captured["args"][9], 0.5)
+        self.assertIs(captured["args"][10], self.group)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_context_parallel_flashmask_modes.py
+++ b/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_context_parallel_flashmask_modes.py
@@ -663,7 +663,9 @@ class TestSwaP2PFlashMaskPath(unittest.TestCase):
             patch.object(
                 cp_utils.paddle.base.core, "nvprof_nvtx_pop", lambda: None
             ),
-            patch.object(cp_utils, "_flash_attn_fwd", fake_flash_fwd),
+            patch.object(
+                cp_utils, "_flash_attn_fwd", fake_flash_fwd, create=True
+            ),
         ):
             result, result_lse, recv_key, recv_value, processed = (
                 cp_utils.cp_flashmask_swa_p2p_forward(
@@ -730,7 +732,9 @@ class TestSwaP2PFlashMaskPath(unittest.TestCase):
                 "get_flags",
                 lambda _: {"FLAGS_cudnn_deterministic": False},
             ),
-            patch.object(cp_utils, "_flash_attn_bwd", fake_flash_bwd),
+            patch.object(
+                cp_utils, "_flash_attn_bwd", fake_flash_bwd, create=True
+            ),
         ):
             qg, kg, vg, grad_sink = cp_utils.cp_flashmask_swa_p2p_backward(
                 self.query,

--- a/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_context_parallel_flashmask_modes.py
+++ b/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_context_parallel_flashmask_modes.py
@@ -478,7 +478,7 @@ class TestContextParallelOpsModes(unittest.TestCase):
             balanced.assert_not_called()
 
 
-class TestSwaP2PHelpers(unittest.TestCase):
+class TestFlashMaskSwaP2PHelpers(unittest.TestCase):
     def test_scatter_kv_places_local_and_received_windows(self):
         group = FakeGroup(rank=1, world_size=2)
         key = paddle.arange(4, dtype="float32").reshape([1, 4, 1, 1]) + 10
@@ -505,7 +505,7 @@ class TestSwaP2PHelpers(unittest.TestCase):
         value = paddle.zeros([1, 4, 1, 1], dtype="float32")
 
         key_grad, value_grad = cp_utils._send_window_grad_back(
-            key_grad_tensor, value_grad_tensor, key, value, group
+            key_grad_tensor, value_grad_tensor, key, value, group, 128
         )
 
         self.assertIs(key_grad, key_grad_tensor)
@@ -539,7 +539,7 @@ class TestSwaP2PHelpers(unittest.TestCase):
             ),
         ):
             key_grad, value_grad = cp_utils._send_window_grad_back(
-                key_grad_tensor, value_grad_tensor, key, value, group
+                key_grad_tensor, value_grad_tensor, key, value, group, 128
             )
 
         assert_tensor_equal(
@@ -571,7 +571,7 @@ class TestSwaP2PHelpers(unittest.TestCase):
             ),
         ):
             key_grad, value_grad = cp_utils._send_window_grad_back(
-                key_grad_tensor, value_grad_tensor, key, value, group
+                key_grad_tensor, value_grad_tensor, key, value, group, 128
             )
 
         expected_send = paddle.stack(
@@ -633,7 +633,7 @@ class TestSwaP2PHelpers(unittest.TestCase):
         self.assertEqual(captured["peer"], 1)
 
 
-class TestSwaP2PFlashMaskPath(unittest.TestCase):
+class TestFlashMaskSwaP2PPath(unittest.TestCase):
     def setUp(self):
         self.query = paddle.zeros([1, 128, 1, 1], dtype="float32")
         self.key = paddle.arange(128, dtype="float32").reshape([1, 128, 1, 1])
@@ -678,6 +678,7 @@ class TestSwaP2PFlashMaskPath(unittest.TestCase):
                     causal=False,
                     is_training=True,
                     softmax_scale=0.5,
+                    window_size=64,
                 )
             )
 
@@ -694,8 +695,8 @@ class TestSwaP2PFlashMaskPath(unittest.TestCase):
         self.assertIsNone(captured["learnable_sink"])
         self.assertFalse(captured["causal"])
         self.assertEqual(captured["softmax_scale"], 0.5)
-        self.assertEqual(list(recv_key.shape), [1, 128, 1, 1])
-        self.assertEqual(list(recv_value.shape), [1, 128, 1, 1])
+        self.assertEqual(list(recv_key.shape), [1, 64, 1, 1])
+        self.assertEqual(list(recv_value.shape), [1, 64, 1, 1])
 
     def test_p2p_backward_calls_flash_bwd_and_returns_local_grads(self):
         output = paddle.full([1, 128, 1, 1], 3.0, dtype="float32")
@@ -750,6 +751,7 @@ class TestSwaP2PFlashMaskPath(unittest.TestCase):
                 self.group,
                 causal=False,
                 softmax_scale=0.5,
+                window_size=128,
             )
 
         assert_tensor_equal(self, qg, query_grad)
@@ -778,32 +780,46 @@ class TestSwaP2PFlashMaskPath(unittest.TestCase):
         kg = self.key + 2
         vg = self.value + 3
 
+        captured = {}
+
+        def fake_forward(*args):
+            captured["forward_window_size"] = args[-1]
+            return output, lse, recv_key, recv_value, self.indices + 1
+
         with patch.object(
             cp_utils,
             "cp_flashmask_swa_p2p_forward",
-            lambda *args: (output, lse, recv_key, recv_value, self.indices + 1),
+            fake_forward,
         ):
-            result = cp_utils.SwaP2PFlashMask.forward(
+            result = cp_utils.FlashMaskSwaP2P.forward(
                 ctx,
                 self.query,
                 self.key,
                 self.value,
                 self.indices,
                 group=self.group,
+                window_size=64,
             )
 
         assert_tensor_equal(self, result, output)
         self.assertIs(ctx.group, self.group)
         self.assertFalse(ctx.causal)
+        self.assertEqual(ctx.window_size, 64)
+        self.assertEqual(captured["forward_window_size"], 64)
         assert_tensor_equal(self, ctx.saved[-1], self.indices + 1)
+
+        def fake_backward(*args):
+            captured["backward_window_size"] = args[-1]
+            return qg, kg, vg, None
 
         with patch.object(
             cp_utils,
             "cp_flashmask_swa_p2p_backward",
-            lambda *args: (qg, kg, vg, None),
+            fake_backward,
         ):
-            backward_result = cp_utils.SwaP2PFlashMask.backward(ctx, output)
+            backward_result = cp_utils.FlashMaskSwaP2P.backward(ctx, output)
 
+        self.assertEqual(captured["backward_window_size"], 64)
         self.assertEqual(len(backward_result), 3)
         assert_tensor_equal(self, backward_result[0], qg)
         assert_tensor_equal(self, backward_result[1], kg)
@@ -843,7 +859,7 @@ class TestSwaP2PFlashMaskPath(unittest.TestCase):
                 "get_hybrid_communicate_group",
                 lambda: FakeHcg(self.group),
             ),
-            patch.object(cp_utils.SwaP2PFlashMask, "apply", fake_apply),
+            patch.object(cp_utils.FlashMaskSwaP2P, "apply", fake_apply),
         ):
             out = cp_utils.flashmask_attention_cp(
                 self.query,
@@ -855,6 +871,7 @@ class TestSwaP2PFlashMaskPath(unittest.TestCase):
                 learnable_sink=learnable_sink,
                 softmax_scale=0.5,
                 mode="contiguous_swap2p",
+                window_size=64,
             )
 
         assert_tensor_equal(self, out, result)
@@ -867,6 +884,7 @@ class TestSwaP2PFlashMaskPath(unittest.TestCase):
         self.assertEqual(captured["args"][9], 0.5)
         self.assertIs(captured["args"][10], self.group)
         self.assertEqual(captured["args"][11], "contiguous_swap2p")
+        self.assertEqual(captured["args"][12], 64)
 
 
 if __name__ == "__main__":

--- a/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_context_parallel_flashmask_modes.py
+++ b/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_context_parallel_flashmask_modes.py
@@ -50,6 +50,9 @@ class FakeHcg:
     def get_context_parallel_group(self):
         return self.group
 
+    def get_context_parallel_world_size(self):
+        return self.group.world_size
+
 
 class FakeTask:
     def wait(self):
@@ -363,6 +366,116 @@ class TestFlashMaskContextParallelMode(unittest.TestCase):
         self.assertEqual(ctx.mode, "contiguous_allgather")
         self.assertEqual(ctx.fa_version, 2)
         assert_tensor_equal(self, ctx.saved[-1], indices + 1)
+
+
+class TestContextParallelOpsModes(unittest.TestCase):
+    def setUp(self):
+        self.group = FakeGroup(rank=0, world_size=2)
+        self.tensor = paddle.zeros([2, 4], dtype="float32")
+
+    def _patch_hcg(self):
+        return patch.object(
+            cp_utils.fleet,
+            "get_hybrid_communicate_group",
+            lambda: FakeHcg(self.group),
+        )
+
+    def test_contiguous_prefixed_modes_use_rank_order_scatter(self):
+        for mode in ("contiguous_a2a", "contiguous_swap2p"):
+            with (
+                self.subTest(mode=mode),
+                self._patch_hcg(),
+                patch.object(cp_utils, "scatter_contiguous") as contiguous,
+                patch.object(cp_utils, "scatter_balance") as balanced,
+            ):
+                contiguous.return_value = self.tensor + 1
+                result = cp_utils.ContextParallelScatterOp.forward(
+                    FakeContext(), self.tensor, -1, mode
+                )
+
+            assert_tensor_equal(self, result, self.tensor + 1)
+            contiguous.assert_called_once()
+            balanced.assert_not_called()
+
+    def test_non_contiguous_mode_uses_balanced_scatter(self):
+        with (
+            self._patch_hcg(),
+            patch.object(cp_utils, "scatter_contiguous") as contiguous,
+            patch.object(cp_utils, "scatter_balance") as balanced,
+        ):
+            balanced.return_value = self.tensor + 2
+            result = cp_utils.ContextParallelScatterOp.forward(
+                FakeContext(), self.tensor, -1, "dualchunk_allgather"
+            )
+
+        assert_tensor_equal(self, result, self.tensor + 2)
+        contiguous.assert_not_called()
+        balanced.assert_called_once()
+
+    def test_contiguous_prefixed_modes_use_rank_order_gather_and_allgather(
+        self,
+    ):
+        for op_cls, contiguous_name, balanced_name in (
+            (
+                cp_utils.ContextParallelGatherOp,
+                "all_gather_contiguous",
+                "all_gather_balance",
+            ),
+            (
+                cp_utils.ContextParallelAllGatherOp,
+                "all_gather_contiguous",
+                "all_gather_balance",
+            ),
+        ):
+            with (
+                self.subTest(op=op_cls.__name__),
+                self._patch_hcg(),
+                patch.object(cp_utils, contiguous_name) as contiguous,
+                patch.object(cp_utils, balanced_name) as balanced,
+            ):
+                contiguous.return_value = self.tensor + 3
+                result = op_cls.forward(
+                    FakeContext(), self.tensor, -1, "contiguous_a2a"
+                )
+
+            assert_tensor_equal(self, result, self.tensor + 3)
+            contiguous.assert_called_once()
+            balanced.assert_not_called()
+
+    def test_contiguous_prefixed_modes_use_rank_order_backward_ops(self):
+        cases = (
+            (
+                cp_utils.ContextParallelScatterOp,
+                "all_gather_contiguous",
+                "all_gather_balance",
+            ),
+            (
+                cp_utils.ContextParallelGatherOp,
+                "scatter_contiguous",
+                "scatter_balance",
+            ),
+            (
+                cp_utils.ContextParallelAllGatherOp,
+                "reduce_scatter_contiguous",
+                "reduce_scatter_any_axis_balance",
+            ),
+        )
+        for op_cls, contiguous_name, balanced_name in cases:
+            ctx = FakeContext()
+            ctx.mode = "contiguous_a2a"
+            ctx.axis = -1
+            ctx.group = self.group
+            with (
+                self.subTest(op=op_cls.__name__),
+                patch.object(cp_utils, contiguous_name) as contiguous,
+                patch.object(cp_utils, balanced_name) as balanced,
+            ):
+                contiguous.return_value = self.tensor + 4
+                result = op_cls.backward(ctx, self.tensor)
+
+            assert_tensor_equal(self, result, self.tensor + 4)
+            contiguous.assert_called_once()
+            balanced.assert_not_called()
 
 
 class TestSwaP2PHelpers(unittest.TestCase):
@@ -692,7 +805,7 @@ class TestSwaP2PFlashMaskPath(unittest.TestCase):
         assert_tensor_equal(self, backward_result[1], kg)
         assert_tensor_equal(self, backward_result[2], vg)
 
-    def test_p2p_flashmask_attention_requires_flashmask(self):
+    def test_flashmask_attention_cp_requires_flashmask_for_p2p_mode(self):
         with (
             patch.object(cp_utils, "_flash_mask_available", False),
             patch.object(
@@ -702,11 +815,15 @@ class TestSwaP2PFlashMaskPath(unittest.TestCase):
             ),
             self.assertRaises(AssertionError),
         ):
-            cp_utils.p2p_flashmask_attention(
-                self.query, self.key, self.value, self.indices
+            cp_utils.flashmask_attention_cp(
+                self.query,
+                self.key,
+                self.value,
+                self.indices,
+                mode="contiguous_swap2p",
             )
 
-    def test_p2p_flashmask_attention_applies_pylayer_with_cp_group(self):
+    def test_flashmask_attention_cp_dispatches_p2p_mode_to_pylayer(self):
         captured = {}
         result = paddle.full([1, 4, 1, 1], 5.0, dtype="float32")
         learnable_sink = paddle.ones([1], dtype="float32")
@@ -724,7 +841,7 @@ class TestSwaP2PFlashMaskPath(unittest.TestCase):
             ),
             patch.object(cp_utils.SwaP2PFlashMask, "apply", fake_apply),
         ):
-            out = cp_utils.p2p_flashmask_attention(
+            out = cp_utils.flashmask_attention_cp(
                 self.query,
                 self.key,
                 self.value,
@@ -733,6 +850,7 @@ class TestSwaP2PFlashMaskPath(unittest.TestCase):
                 training=False,
                 learnable_sink=learnable_sink,
                 softmax_scale=0.5,
+                mode="contiguous_swap2p",
             )
 
         assert_tensor_equal(self, out, result)
@@ -744,6 +862,7 @@ class TestSwaP2PFlashMaskPath(unittest.TestCase):
         self.assertIs(captured["args"][8], learnable_sink)
         self.assertEqual(captured["args"][9], 0.5)
         self.assertIs(captured["args"][10], self.group)
+        self.assertEqual(captured["args"][11], "contiguous_swap2p")
 
 
 if __name__ == "__main__":

--- a/tests/single_card_tests/ai_edited_test/distributed/test_ai_context_parallel_utils_3.py
+++ b/tests/single_card_tests/ai_edited_test/distributed/test_ai_context_parallel_utils_3.py
@@ -205,6 +205,7 @@ class TestFlashMaskContextParallelBackward(unittest.TestCase):
         mock_ctx.causal = False
         mock_ctx.fa_version = 2
         mock_ctx.softmax_scale = None
+        mock_ctx.mode = "dualchunk_allgather"
 
         grad = paddle.randn([2, 8, 4, 16])
 
@@ -215,13 +216,14 @@ class TestFlashMaskContextParallelBackward(unittest.TestCase):
             result = FlashMaskContextParallel.backward(mock_ctx, grad)
             mock_bwd.assert_called_once()
             call_args = mock_bwd.call_args[0]
-            # First args are tensors (query/key/value); fa_version is second-to-last,
-            # softmax_scale is last.
+            # First args are tensors (query/key/value); tail args are
+            # fa_version, softmax_scale, mode.
             self.assertIs(call_args[0], query)
             self.assertIs(call_args[1], key)
             self.assertIs(call_args[2], value)
-            self.assertEqual(call_args[-2], mock_ctx.fa_version)
-            self.assertEqual(call_args[-1], mock_ctx.softmax_scale)
+            self.assertEqual(call_args[-3], mock_ctx.fa_version)
+            self.assertEqual(call_args[-2], mock_ctx.softmax_scale)
+            self.assertEqual(call_args[-1], mock_ctx.mode)
 
 
 class TestFlashmaskAttentionCP(unittest.TestCase):

--- a/tests/single_card_tests/ai_edited_test/distributed/test_ai_context_parallel_utils_5.py
+++ b/tests/single_card_tests/ai_edited_test/distributed/test_ai_context_parallel_utils_5.py
@@ -89,6 +89,7 @@ class TestContextParallelScatterOp(unittest.TestCase):
         mock_ctx = mock.MagicMock()
         mock_ctx.axis = 0
         mock_ctx.group = mock.MagicMock()
+        mock_ctx.mode = "dualchunk_allgather"
 
         grad = paddle.randn([4, 16])
 
@@ -156,6 +157,7 @@ class TestContextParallelGatherOp(unittest.TestCase):
         mock_ctx = mock.MagicMock()
         mock_ctx.axis = 1
         mock_ctx.group = mock.MagicMock()
+        mock_ctx.mode = "dualchunk_allgather"
 
         grad = paddle.randn([8, 16])
 
@@ -229,6 +231,7 @@ class TestContextParallelAllGatherOp(unittest.TestCase):
         mock_ctx = mock.MagicMock()
         mock_ctx.axis = 1
         mock_ctx.group = mock.MagicMock()
+        mock_ctx.mode = "dualchunk_allgather"
 
         grad = paddle.randn([8, 16])
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
Performance Optimization


### PR Types
Performance


### Description
- P2P FlashMask Layer 跳过 SWA 层的大部分通信，加速 SWA 层。
- 支持了 flashmask_attention_cp 的 contiguous_allgather 模式。
- 注意，本 PR 不可以单独用 cp_balance_mode: contiguous_a2a 的yaml。contiguous_a2a 的功能在 #1365 中实现。需要后续配合。
- 注意，直接开启 contiguous_allgather 会导致相对 dualchunk_allgather 降速。符合预期：dualchunk 做了负载均衡。


### 是否引起精度变化
否
