### PR TITLE
[MLA] Add gated_attn_use_q_lora switch for low-rank gate input

### DIFF
--- a/src/paddlefleet/transformer/multi_latent_attention.py
+++ b/src/paddlefleet/transformer/multi_latent_attention.py
@@ -335,10 +335,22 @@ class MultiLatentAttention(Attention):
 
         # Gated attention
         self.gated_attention = getattr(self.config, "gated_attention", False)
+        self.gated_attn_use_q_lora = getattr(
+            self.config, "gated_attn_use_q_lora", False
+        )
         if self.gated_attention and sublayers_spec.gate_proj is not None:
+            # Gate input source: q_compressed (post q_a_layernorm, dim=q_lora_rank) when
+            # gated_attn_use_q_lora is set, otherwise the full hidden_states.
+            if self.gated_attn_use_q_lora:
+                assert self.config.q_lora_rank is not None, (
+                    "gated_attn_use_q_lora=True requires q_lora_rank is not None"
+                )
+                gate_in_dim = self.config.q_lora_rank
+            else:
+                gate_in_dim = self.config.hidden_size
             self.gate_proj = build_spec_layer(
                 sublayers_spec.gate_proj,
-                self.config.hidden_size,
+                gate_in_dim,
                 self.out_projection_size,
                 config=self.config,
                 init_method=self.config.init_method,
@@ -348,6 +360,16 @@ class MultiLatentAttention(Attention):
                 is_expert=False,
                 tp_comm_buffer_name="mla_gate",
                 tp_group=self.pg_collection.tp,
+            )
+            print(
+                f"[GatedAttnCheck][init] layer={getattr(self, 'layer_number', -1)} "
+                f"gated_attention={self.gated_attention} "
+                f"gated_attn_use_q_lora={self.gated_attn_use_q_lora} "
+                f"q_lora_rank={self.config.q_lora_rank} "
+                f"hidden_size={self.config.hidden_size} "
+                f"gate_in_dim={gate_in_dim} "
+                f"gate_out_dim={self.out_projection_size}",
+                flush=True,
             )
         else:
             self.gated_attention = False
@@ -561,17 +583,36 @@ class MultiLatentAttention(Attention):
 
         # Apply gated attention
         if self.gated_attention:
+            # Gate input source: q_compressed (post q_a_layernorm, dim=q_lora_rank) when
+            # gated_attn_use_q_lora is set, otherwise hidden_states.
+            gate_source = (
+                q_compressed if self.gated_attn_use_q_lora else hidden_states
+            )
+            # [GatedAttnCheck][forward] debug print (kept commented for on-demand use):
+            # if not getattr(self, "_gated_attn_fwd_logged", False):
+            #     self._gated_attn_fwd_logged = True
+            #     _src_is_qc = gate_source is q_compressed
+            #     print(
+            #         f"[GatedAttnCheck][forward] layer={getattr(self, 'layer_number', -1)} "
+            #         f"gated_attn_use_q_lora={self.gated_attn_use_q_lora} "
+            #         f"gate_source_is_q_compressed={_src_is_qc} "
+            #         f"gate_source.shape={list(gate_source.shape)} "
+            #         f"q_compressed.shape={list(q_compressed.shape)} "
+            #         f"hidden_states.shape={list(hidden_states.shape)} "
+            #         f"recompute_gated_attn={self.recompute_gated_attn}",
+            #         flush=True,
+            #     )
             if self.recompute_gated_attn:
                 gate_recompute = RecomputeWithoutOutput()
                 core_attn_out = gate_recompute.recompute(
                     self._gate,
-                    hidden_states,
+                    gate_source,
                     core_attn_out,
                     preserve_rng_state=False,
                     share_grad_holder=True,
                 )
             else:
-                core_attn_out = self._gate(hidden_states, core_attn_out)
+                core_attn_out = self._gate(gate_source, core_attn_out)
 
         if getattr(self.config, "dw_p2p_overlap", False) and not getattr(
             self.config, "use_bias", False
@@ -588,8 +629,8 @@ class MultiLatentAttention(Attention):
 
         return output, bias
 
-    def _gate(self, hidden_states, core_attn_out):
-        gate, _ = self.gate_proj(hidden_states)
+    def _gate(self, gate_source, core_attn_out):
+        gate, _ = self.gate_proj(gate_source)
         if self.config.sigmoid_gate_fusion:
             from paddlefleet.triton_ops import SigmoidGateFusionTriton
 

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -325,6 +325,12 @@ class TransformerConfig(ModelParallelConfig):
     from the fused QKV projection (doubling the query projection size). This allows the model
     to dynamically control the information flow from attention. See Qwen3.5 for reference."""
 
+    gated_attn_use_q_lora: bool = False
+    """If True, the gated attention gate uses the q_a_proj output (q_compressed, post
+    q_a_layernorm, dim = q_lora_rank) as the gate input instead of hidden_states. This is a
+    low-rank gate input for MLA networks that also reduces the gate projection parameter count.
+    Requires q_lora_rank is not None. Only applies when gated_attention is True."""
+
     ####################
     # block attention residuals
     ####################

--- a/tests/single_card_tests/transformer/test_mla_gate_attn.py
+++ b/tests/single_card_tests/transformer/test_mla_gate_attn.py
@@ -181,6 +181,18 @@ class TestMLAGateConstruction(unittest.TestCase):
         self.assertEqual(in_features, expected_in)
         self.assertEqual(out_features, expected_out)
 
+    def test_gate_proj_input_dim_uses_q_lora_rank(self):
+        """When gated_attn_use_q_lora=True, gate_proj input dim is q_lora_rank."""
+        attn = _build_mla(gated_attention=True, gated_attn_use_q_lora=True)
+        self.assertTrue(attn.gated_attn_use_q_lora)
+        gate = attn.gate_proj
+        in_features = gate.linear.weight.shape[0]
+        out_features = gate.linear.weight.shape[1]
+        expected_in = 64  # q_lora_rank (not hidden_size=128)
+        expected_out = 4 * 32  # num_attention_heads * v_head_dim = 128
+        self.assertEqual(in_features, expected_in)
+        self.assertEqual(out_features, expected_out)
+
 
 class TestMLAGatedForward(unittest.TestCase):
     def test_forward_shape_with_gate(self):
@@ -192,6 +204,14 @@ class TestMLAGatedForward(unittest.TestCase):
 
     def test_forward_shape_without_gate(self):
         attn = _build_mla(gated_attention=False)
+        attn.eval()
+        x = paddle.randn([2, 4, 128])
+        out, bias = attn(x, attention_mask=None)
+        self.assertEqual(out.shape, [2, 4, 128])
+
+    def test_forward_shape_with_gate_q_lora(self):
+        """Forward with gated_attn_use_q_lora: gate consumes q_compressed."""
+        attn = _build_mla(gated_attention=True, gated_attn_use_q_lora=True)
         attn.eval()
         x = paddle.randn([2, 4, 128])
         out, bias = attn(x, attention_mask=None)


### PR DESCRIPTION
### PR Category
Distributed Strategy

### PR Types
New features

### Description
Add a `gated_attn_use_q_lora` config switch to Multi-Latent Attention (MLA).

When enabled, the gated-attention gate is computed from `q_compressed` (the post-`q_a_layernorm` output of `q_a_proj`, dim = `q_lora_rank`) instead of the full `hidden_states`. This lowers the gate projection input dimension from `hidden_size` to `q_lora_rank`, reducing the gate parameter count while keeping the per-head gate output dimension unchanged.

Changes:
- `transformer_config`: add `gated_attn_use_q_lora` bool field (default `False`)
- `multi_latent_attention`: select the gate input (`q_compressed` vs `hidden_states`) in both `__init__` (gate_proj input dim) and `forward`; asserts `q_lora_rank is not None` when enabled
- tests: cover gate_proj input dim and forward shape for the q_lora path

Defaults to `False`, so existing behavior is unaffected.

### 是否引起精度变化
否