### PR TITLE
[Cherry-Pick][Devs] Update model config approval requirement (#1352)

### DIFF
--- a/ci/check_approval.sh
+++ b/ci/check_approval.sh
@@ -75,7 +75,7 @@ done
 
 
 
-MODELCONFIG_APPROVERS="sneaxiy From00 ForFishes Hz188 Waynezee"
+MODELCONFIG_APPROVERS="sneaxiy From00 ForFishes"
 MODELCONFIG_FILES=(
     "src/paddlefleet/model_parallel_config.py"
     "src/paddlefleet/transformer/transformer_config.py"
@@ -83,9 +83,9 @@ MODELCONFIG_FILES=(
 for FILE in "${MODELCONFIG_FILES[@]}"; do
     HAS_MODIFIED=$(git diff --name-only "${DIFF_BASE}" HEAD -- | grep "^${FILE}" || true)
     if [ "${HAS_MODIFIED}" != "" ] && [ "${PR_ID}" != "" ]; then
-        echo_line="You must be approved by two of ${MODELCONFIG_APPROVERS} for changes in ${FILE}.\n"
+        echo_line="You must be approved by one of ${MODELCONFIG_APPROVERS} for changes in ${FILE}.\n"
         APPROVER_LIST=(${MODELCONFIG_APPROVERS})
-        check_approval 2 "${APPROVER_LIST[@]}"
+        check_approval 1 "${APPROVER_LIST[@]}"
     fi
 done
 


### PR DESCRIPTION
### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library  | Environment Adaptation ] -->
Execute Infrastructure
### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Devs
### Description
<!-- Describe what you’ve done -->
Update `ci/check_approval.sh` so changes to `src/paddlefleet/model_parallel_config.py` and `src/paddlefleet/transformer/transformer_config.py` require approval from one of `sneaxiy`, `From00`, or `ForFishes` instead of two reviewers from the previous model config approver list.

Merged in dev: #1352 