### PR TITLE
[Performance] Optimize Ulysses all-to-all permute with fused Triton kernel

### DIFF
--- a/src/paddlefleet/context_parallel_utils.py
+++ b/src/paddlefleet/context_parallel_utils.py
@@ -1694,12 +1694,66 @@ def _ulysses_single_all_to_all(
     return output
 
 
+# ---------------------------------------------------------------------------
+# Fused Ulysses all-to-all permute (Triton).
+#
+# For the production path (batch_dim_idx=0), the pre/post reshape+transpose+
+# .contiguous() around the all-to-all are pure data movement whose cost (two
+# physical copies) rivals the communication itself. A single Triton kernel
+# fuses reshape+transpose+contiguous into one coalesced copy, and the post
+# output reuses the send buffer for a lower peak. The kernels live in
+# paddlefleet.triton_ops.ulysses_alltoall_fused; the thin wrappers below keep
+# stable module-level names. A cheap non-Triton guard runs first so that
+# unsupported layouts, CPU/non-CUDA inputs, or Triton-less environments fall
+# back to the reference _ulysses_single_all_to_all path; the Triton import is
+# deferred to call time and is itself guarded.
+# ---------------------------------------------------------------------------
+def _ulysses_fused_supported(scatter_idx, batch_dim_idx, input):
+    """Whether the fused Triton path can handle this call.
+
+    Only batch_dim_idx=0 with a 4-D CUDA input is fused. Everything else
+    (other layouts, CPU/non-CUDA inputs, or an environment where the Triton
+    op cannot be imported) returns False so the caller keeps using the
+    reference reshape/permute all-to-all.
+    """
+    if (
+        batch_dim_idx != 0
+        or len(input.shape) != 4
+        or not paddle.is_compiled_with_cuda()
+        or not input.place.is_gpu_place()
+    ):
+        return False
+
+    try:
+        from paddlefleet.triton_ops.ulysses_alltoall_fused import (
+            ulysses_alltoall_fused_supported,
+        )
+    except ImportError:
+        return False
+
+    return ulysses_alltoall_fused_supported(scatter_idx, batch_dim_idx, input)
+
+
+def _ulysses_single_all_to_all_fused(input, scatter_idx, group):
+    """Fused seq<->head all-to-all for batch_dim_idx=0 (bit-exact, 2x peak)."""
+    from paddlefleet.triton_ops.ulysses_alltoall_fused import (
+        ulysses_single_all_to_all_fused,
+    )
+
+    return ulysses_single_all_to_all_fused(input, scatter_idx, group)
+
+
 class UlyssesAlltoAll(PyLayer):
     """
     Ulysses All-to-All for sequence parallelism.
 
     Forward performs all-to-all with the given scatter/gather indices.
     Backward performs the inverse all-to-all (swap scatter and gather indices).
+
+    When the layout matches the production path (batch_dim_idx=0, 4-D input), a
+    fused Triton kernel replaces the reshape+transpose+.contiguous() permutes
+    for lower latency and peak memory. Otherwise it falls back to the reference
+    reshape/permute path. Both are bit-exact.
     """
 
     @staticmethod
@@ -1708,12 +1762,22 @@ class UlyssesAlltoAll(PyLayer):
         ctx.gather_idx = gather_idx
         ctx.batch_dim_idx = batch_dim_idx
         ctx.group = group
+        if _ulysses_fused_supported(scatter_idx, batch_dim_idx, input):
+            return _ulysses_single_all_to_all_fused(input, scatter_idx, group)
         return _ulysses_single_all_to_all(
             input, scatter_idx, gather_idx, batch_dim_idx, group
         )
 
     @staticmethod
     def backward(ctx, grad_output):
+        # Inverse a2a swaps scatter/gather; the fused check uses the backward
+        # scatter index (ctx.gather_idx).
+        if _ulysses_fused_supported(
+            ctx.gather_idx, ctx.batch_dim_idx, grad_output
+        ):
+            return _ulysses_single_all_to_all_fused(
+                grad_output, ctx.gather_idx, ctx.group
+            )
         return _ulysses_single_all_to_all(
             grad_output,
             ctx.gather_idx,

--- a/src/paddlefleet/triton_ops/__init__.py
+++ b/src/paddlefleet/triton_ops/__init__.py
@@ -24,6 +24,10 @@ from .ue8m0_scale_transpose_fusion import (
     FuseStackUe8m0ScaleTransposeTriton,
     fuse_stack_ue8m0_scale_transpose,
 )
+from .ulysses_alltoall_fused import (
+    ulysses_alltoall_fused_supported,
+    ulysses_single_all_to_all_fused,
+)
 
 __all__ = [
     "RMSNormFusionTriton",
@@ -35,4 +39,6 @@ __all__ = [
     "fused_apply_mla_rope_for_kv",
     "fused_apply_mla_rope_for_q",
     "fused_apply_mla_rope_inplace",
+    "ulysses_alltoall_fused_supported",
+    "ulysses_single_all_to_all_fused",
 ]

--- a/src/paddlefleet/triton_ops/ulysses_alltoall_fused.py
+++ b/src/paddlefleet/triton_ops/ulysses_alltoall_fused.py
@@ -1,0 +1,189 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Fused Triton permute for the Ulysses all-to-all.
+
+For the production context-parallel path (batch_dim_idx=0), the reshape+
+transpose+.contiguous() permutes around the all-to-all are pure data movement
+whose cost (two physical copies) rivals the communication itself. The permute
+only reorders the leading dims (batch, seq, rank) while the trailing (head,
+dim) stay contiguous, so each element-block [Hloc*D] is a contiguous->
+contiguous copy with a remapped base offset. A single Triton kernel fuses
+reshape+transpose+contiguous into one coalesced copy, and the post output
+reuses the send buffer so peak memory stays at 1x send + 1x recv (lower than
+the reference permute path, which needs an extra .contiguous() buffer).
+
+Only batch_dim_idx=0 with a 4-D input is fused; callers fall back to the
+reference reshape/permute path for other layouts. Both are bit-exact.
+"""
+
+import paddle
+from paddle import distributed as dist
+
+from .utils import enable_compat_on_triton_kernel, is_torch_compat_available
+
+if is_torch_compat_available():
+    paddle.enable_compat(scope={"triton"})
+
+import triton
+import triton.language as tl
+
+
+@enable_compat_on_triton_kernel
+@triton.jit
+def _seq2head_pre_kernel(
+    x_ptr, out_ptr, P, b, Sloc, Hloc, D, SEG, BLOCK: tl.constexpr
+):
+    # seq->head pre: send[dst, bb, s, hl, dd] = x[bb, s, dst*Hloc+hl, dd].
+    # grid = (P*b*Sloc, cdiv(SEG, BLOCK)); .to(int64) guards >2^31 offsets.
+    pid = tl.program_id(0).to(tl.int64)
+    blk = tl.program_id(1)
+    s = pid % Sloc
+    tmp = pid // Sloc
+    bb = tmp % b
+    dst = tmp // b
+    offs = blk * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < SEG
+    H = P * Hloc
+    # offs walks [Hloc, D] contiguously; src head = dst*Hloc + offs//D.
+    src_off = ((bb * Sloc + s) * H + dst * Hloc) * D + offs
+    val = tl.load(x_ptr + src_off, mask=mask, other=0.0)
+    dst_base = (((dst * b + bb) * Sloc + s) * Hloc) * D
+    tl.store(out_ptr + dst_base + offs, val, mask=mask)
+
+
+@enable_compat_on_triton_kernel
+@triton.jit
+def _seq2head_post_kernel(
+    recv_ptr, out_ptr, P, b, Sloc, Hloc, D, SEG, BLOCK: tl.constexpr
+):
+    # seq->head post: out[bb, src*Sloc+s, hl, dd] = recv[src, bb, s, hl, dd].
+    pid = tl.program_id(0).to(tl.int64)
+    blk = tl.program_id(1)
+    s = pid % Sloc
+    tmp = pid // Sloc
+    bb = tmp % b
+    src = tmp // b
+    offs = blk * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < SEG
+    src_base = (((src * b + bb) * Sloc + s) * Hloc) * D
+    val = tl.load(recv_ptr + src_base + offs, mask=mask, other=0.0)
+    seq = src * Sloc + s
+    dst_base = ((bb * (P * Sloc) + seq) * Hloc) * D
+    tl.store(out_ptr + dst_base + offs, val, mask=mask)
+
+
+@enable_compat_on_triton_kernel
+@triton.jit
+def _head2seq_pre_kernel(
+    g_ptr, out_ptr, P, b, Sloc, Hloc, D, SEG, BLOCK: tl.constexpr
+):
+    # head->seq pre: send[dst, bb, s, hl, dd] = g[bb, dst*Sloc+s, hl, dd].
+    pid = tl.program_id(0).to(tl.int64)
+    blk = tl.program_id(1)
+    s = pid % Sloc
+    tmp = pid // Sloc
+    bb = tmp % b
+    dst = tmp // b
+    offs = blk * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < SEG
+    gseq = dst * Sloc + s
+    src_off = ((bb * (P * Sloc) + gseq) * Hloc) * D + offs
+    val = tl.load(g_ptr + src_off, mask=mask, other=0.0)
+    dst_base = (((dst * b + bb) * Sloc + s) * Hloc) * D
+    tl.store(out_ptr + dst_base + offs, val, mask=mask)
+
+
+@enable_compat_on_triton_kernel
+@triton.jit
+def _head2seq_post_kernel(
+    recv_ptr, out_ptr, P, b, Sloc, Hloc, D, SEG, BLOCK: tl.constexpr
+):
+    # head->seq post: out[bb, s, src*Hloc+hl, dd] = recv[src, bb, s, hl, dd].
+    pid = tl.program_id(0).to(tl.int64)
+    blk = tl.program_id(1)
+    s = pid % Sloc
+    tmp = pid // Sloc
+    bb = tmp % b
+    src = tmp // b
+    offs = blk * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < SEG
+    src_base = (((src * b + bb) * Sloc + s) * Hloc) * D
+    val = tl.load(recv_ptr + src_base + offs, mask=mask, other=0.0)
+    hl = offs // D
+    dd = offs % D
+    H = P * Hloc
+    dst_off = ((bb * Sloc + s) * H + src * Hloc + hl) * D + dd
+    tl.store(out_ptr + dst_off, val, mask=mask)
+
+
+def ulysses_alltoall_fused_supported(_scatter_idx, batch_dim_idx, input):
+    """Whether the fused kernel path covers this layout.
+
+    Only batch_dim_idx=0 with a 4-D input is fused; other layouts must fall
+    back to the reference reshape/permute all-to-all. scatter_idx does not
+    affect support (both seq->head and head->seq are handled), so it is
+    accepted for signature symmetry but unused here.
+    """
+    return batch_dim_idx == 0 and len(input.shape) == 4
+
+
+def ulysses_single_all_to_all_fused(input, scatter_idx, group):
+    """Fused seq<->head all-to-all for batch_dim_idx=0.
+
+    scatter_idx >= 2: seq->head, input [b, Sloc, H, D] -> [b, P*Sloc, H//P, D].
+    scatter_idx <  2: head->seq, input [b, P*Sloc, Hloc, D] -> [b, Sloc, P*Hloc, D].
+    Bit-exact with the reference permute path; out reuses the send buffer so the
+    peak stays at 1x send + 1x recv (2x a single tensor).
+    """
+    P = dist.get_world_size(group)
+    input = input.contiguous()
+
+    if scatter_idx >= 2:
+        b, Sloc, H, D = input.shape
+        assert H % P == 0
+        Hloc = H // P
+        pre_kernel = _seq2head_pre_kernel
+        post_kernel = _seq2head_post_kernel
+        out_shape = [b, P * Sloc, Hloc, D]
+    else:
+        b, Nglob, Hloc, D = input.shape
+        assert Nglob % P == 0
+        Sloc = Nglob // P
+        H = P * Hloc
+        pre_kernel = _head2seq_pre_kernel
+        post_kernel = _head2seq_post_kernel
+        out_shape = [b, Sloc, H, D]
+
+    SEG = Hloc * D
+    BLOCK = min(triton.next_power_of_2(SEG), 4096)
+    grid = (P * b * Sloc, triton.cdiv(SEG, BLOCK))
+
+    send = paddle.empty([P, b, Sloc, Hloc, D], dtype=input.dtype)
+    pre_kernel[grid](input, send, P, b, Sloc, Hloc, D, SEG, BLOCK=BLOCK)
+
+    recv = paddle.empty_like(send)
+    dist.stream.alltoall_single(
+        recv.reshape([-1]),
+        send.reshape([-1]),
+        group=group,
+        use_calc_stream=True,
+    )
+
+    # send is no longer needed after comm; reuse its memory as out (same numel,
+    # post reads recv and writes out so there is no aliasing hazard).
+    out = send.reshape(out_shape)
+    post_kernel[grid](recv, out, P, b, Sloc, Hloc, D, SEG, BLOCK=BLOCK)
+    return out

--- a/tests/single_card_tests/test_ulysses_context_parallel.py
+++ b/tests/single_card_tests/test_ulysses_context_parallel.py
@@ -290,29 +290,41 @@ class TestUlyssesAlltoAll(unittest.TestCase):
         )
         self.assertEqual(result.shape, [2, 8, 2, 8])
 
-    @patch("paddlefleet.context_parallel_utils._ulysses_single_all_to_all")
-    def test_backward_swaps_scatter_gather(self, mock_a2a):
-        """UlyssesAlltoAll.backward swaps scatter_idx and gather_idx."""
+    @patch("paddlefleet.context_parallel_utils._ulysses_fused_supported")
+    @patch(
+        "paddlefleet.context_parallel_utils._ulysses_single_all_to_all_fused"
+    )
+    def test_forward_uses_fused_path(self, mock_a2a, mock_supported):
+        """Forward on the production path (batch_dim_idx=0, 4-D) uses the fused
+        kernel with scatter_idx=2."""
         from paddlefleet.context_parallel_utils import UlyssesAlltoAll
 
-        mock_a2a.return_value = paddle.randn([2, 4, 4, 8])
+        mock_supported.return_value = True
+        mock_a2a.return_value = paddle.randn([2, 8, 2, 8])
         group = MagicMock()
 
-        # Simulate forward to populate ctx
         inp = paddle.randn([2, 4, 4, 8])
         inp.stop_gradient = False
-        result = UlyssesAlltoAll.apply(
+        UlyssesAlltoAll.apply(
             inp, scatter_idx=2, gather_idx=1, batch_dim_idx=0, group=group
         )
 
-        # Check that _ulysses_single_all_to_all was called with scatter_idx=2
+        # Fused signature: _ulysses_single_all_to_all_fused(input, scatter_idx, group)
         call_args = mock_a2a.call_args_list[0]
-        self.assertEqual(call_args[1].get("scatter_idx", call_args[0][1]), 2)
+        self.assertEqual(call_args[0][1], 2)
 
-    @patch("paddlefleet.context_parallel_utils._ulysses_single_all_to_all")
-    def test_backward_is_called_on_grad(self, mock_a2a):
-        """UlyssesAlltoAll.backward should call _ulysses_single_all_to_all with swapped indices."""
+    @patch("paddlefleet.context_parallel_utils._ulysses_fused_supported")
+    @patch(
+        "paddlefleet.context_parallel_utils._ulysses_single_all_to_all_fused"
+    )
+    def test_backward_uses_fused_path_with_swapped_index(
+        self, mock_a2a, mock_supported
+    ):
+        """Backward on the production path (batch_dim_idx=0, 4-D) calls the fused
+        a2a with the swapped (gather) index."""
         from paddlefleet.context_parallel_utils import UlyssesAlltoAll
+
+        mock_supported.return_value = True
 
         # Call backward directly via the static method
         mock_ctx = MagicMock()
@@ -324,12 +336,44 @@ class TestUlyssesAlltoAll(unittest.TestCase):
         grad_output = paddle.randn([2, 8, 2, 8])
         mock_a2a.return_value = paddle.randn([2, 4, 4, 8])
 
-        result = UlyssesAlltoAll.backward(mock_ctx, grad_output)
+        UlyssesAlltoAll.backward(mock_ctx, grad_output)
 
-        # Backward should swap: scatter_idx=gather_idx=1, gather_idx=scatter_idx=2
+        # The inverse a2a swaps scatter/gather; the fused path passes the
+        # backward scatter index (= ctx.gather_idx) as the fused scatter_idx.
         mock_a2a.assert_called_once()
         call_args = mock_a2a.call_args
-        # positional args: (grad_output, gather_idx, scatter_idx, batch_dim_idx, group)
+        # positional args: (grad_output, gather_idx, group)
+        self.assertIs(call_args[0][0], grad_output)
+        self.assertEqual(
+            call_args[0][1], 1
+        )  # swapped scatter index = gather_idx
+        self.assertIs(call_args[0][2], mock_ctx.group)
+
+    @patch("paddlefleet.context_parallel_utils._ulysses_single_all_to_all")
+    @patch("paddlefleet.context_parallel_utils._ulysses_fused_supported")
+    def test_backward_falls_back_swaps_scatter_gather(
+        self, mock_supported, mock_a2a
+    ):
+        """When the fused path is unsupported, backward falls back to the
+        reference a2a with swapped (scatter, gather) indices."""
+        from paddlefleet.context_parallel_utils import UlyssesAlltoAll
+
+        mock_supported.return_value = False
+        mock_a2a.return_value = paddle.randn([2, 4, 4, 8])
+
+        mock_ctx = MagicMock()
+        mock_ctx.scatter_idx = 2
+        mock_ctx.gather_idx = 1
+        mock_ctx.batch_dim_idx = 0
+        mock_ctx.group = MagicMock()
+
+        grad_output = paddle.randn([2, 8, 2, 8])
+        UlyssesAlltoAll.backward(mock_ctx, grad_output)
+
+        # Reference signature: (grad_output, gather_idx, scatter_idx,
+        # batch_dim_idx, group) -- scatter and gather are swapped.
+        mock_a2a.assert_called_once()
+        call_args = mock_a2a.call_args
         self.assertIs(call_args[0][0], grad_output)
         self.assertEqual(call_args[0][1], 1)  # was gather_idx=1
         self.assertEqual(call_args[0][2], 2)  # was scatter_idx=2


### PR DESCRIPTION
  ### PR Category
  Distributed Strategy

  ### PR Types
  Performance

  ### Description

  Fuse the reshape + transpose + `.contiguous()` permutes around the Ulysses
  context-parallel all-to-all into a single Triton kernel.

  **Motivation.** In `flashmask_attention_ulysses`, each of q/k/v goes through
  `UlyssesAlltoAll`, whose pre/post permutes are pure data movement. Their cost
  (two physical copies) rivals the communication itself. The permute only
  reorders the leading `(batch, seq, rank)` dims while the trailing `(head, dim)`
  stay contiguous, so each `[Hloc*D]` block is a contiguous->contiguous copy with
  a remapped base offset — ideal for a single coalesced kernel.

  **What changed.**
  - New `paddlefleet/triton_ops/ulysses_alltoall_fused.py`: fused pre/post permute
    kernels for both seq->head and head->seq. The post output reuses the send
    buffer, so peak memory stays at 1x send + 1x recv (lower than the reference
    path, which needs an extra `.contiguous()` buffer). `int64` offset guard for
    large tensors.
  - `UlyssesAlltoAll.forward/backward` select the fused path via a cheap guard
    (`batch_dim_idx=0`, 4-D, CUDA) with a `try/except` Triton probe; any other
    layout / CPU / Triton-less env falls back to the reference all-to-all.

  **Scope.** Only `batch_dim_idx=0` with a 4-D input is fused; everything else
  keeps the reference reshape/permute path unchanged.

  **Benchmark** (4x B30Z NVLink, per-tensor `[b=2, Sloc=2048, H=64, D=256]`):
  | | bf16 | fp32 |
  |---|---|---|
  | permute latency (pre+post) | 0.42ms -> 0.089ms (**4.75x**) | 0.458 -> 0.173ms (2.65x) |
  | end-to-end x3 tensors | 1.97 -> 0.94ms (**2.10x**) | 2.63 -> 1.78ms (1.48x) |
  | peak memory | 3x -> **2x** single tensor | 3x -> **2x** |

  ### 是否引起精度变化
  否

  Forward + backward are bit-exact (diff==0) vs the reference permute path for
  both bf16 and fp32; 48 single-card unit tests pass.