### PR TITLE
[Performance] Integrate SonicMoE hotpath optimizations

### DIFF
--- a/src/paddlefleet/transformer/moe/fusion_layer_utils.py
+++ b/src/paddlefleet/transformer/moe/fusion_layer_utils.py
@@ -32,6 +32,9 @@ from .vmm_utils import (
     tokens_zip_unique_add_with_subbatch,
 )
 
+SonicMoEConfig = None
+_scatter_router_scores_i32 = None
+
 if paddlefleet_ops.is_sonic_moe_available():
     from paddlefleet_ops.sonicmoe.enums import ActivationType
     from paddlefleet_ops.sonicmoe.ernie_compat.deepep_metadata import (
@@ -46,13 +49,18 @@ if paddlefleet_ops.is_sonic_moe_available():
         _UpProjection,
     )
     from paddlefleet_ops.sonicmoe.functional.utils import enable_fp8
+
     try:
         from paddlefleet_ops.sonicmoe.config import SonicMoEConfig
     except (ImportError, RuntimeError):
-        SonicMoEConfig = None
-    from paddlefleet_ops.sonicmoe.quack_utils.blockscaled_fp8_gemm import (
-        _scatter_router_scores_i32,
-    )
+        pass
+
+    try:
+        from paddlefleet_ops.sonicmoe.quack_utils.blockscaled_fp8_gemm import (
+            _scatter_router_scores_i32,
+        )
+    except (ImportError, RuntimeError):
+        pass
 
 logger = logging.getLogger(__name__)
 
@@ -123,6 +131,13 @@ class _SonicRouterScoresFromMetadata(paddle.autograd.PyLayer):
     @staticmethod
     def backward(ctx, grad_out):
         (score_src_idx,) = ctx.saved_tensor()
+        if _scatter_router_scores_i32 is None:
+            raise RuntimeError(
+                "SonicMoE metadata router score backward requires "
+                "paddlefleet_ops.sonicmoe.quack_utils.blockscaled_fp8_gemm."
+                "_scatter_router_scores_i32; update paddlefleet_ops or use "
+                "the differentiable router-score fallback."
+            )
         grad_flat = _scatter_router_scores_i32(
             grad_out.contiguous(), score_src_idx, ctx.n_total
         )
@@ -2359,7 +2374,7 @@ def run_sonic_moe(
     activation_type = ActivationType("swiglu")
 
     total_expert_freq = TK_padded
-    if _score_src_idx is not None:
+    if _score_src_idx is not None and _scatter_router_scores_i32 is not None:
         scores_for_down = _SonicRouterScoresFromMetadata.apply(
             topk_scores, _router_scores, _score_src_idx
         )

--- a/src/paddlefleet/transformer/moe/fusion_layer_utils.py
+++ b/src/paddlefleet/transformer/moe/fusion_layer_utils.py
@@ -15,7 +15,6 @@
 import contextlib
 import copy
 import logging
-import os
 
 import paddle
 import paddlefleet_ops
@@ -91,27 +90,10 @@ def _make_sonic_fp8_weight_carrier(weight):
     return _SonicFP8WeightCarrier.apply(weight)
 
 
-def _env_flag(name, default=None):
-    value = os.getenv(name, "").strip().lower()
-    if value in {"1", "true", "yes", "on"}:
-        return True
-    if value in {"0", "false", "no", "off"}:
-        return False
-    return default
-
-
 def _sonic_moe_runtime_config_context():
-    fuse_y1_quant = _env_flag("SONIC_MOE_FUSE_Y1_QUANT", False)
-    if not fuse_y1_quant:
-        return contextlib.nullcontext()
     if SonicMoEConfig is None:
-        raise RuntimeError(
-            "SONIC_MOE_FUSE_Y1_QUANT=1 requires paddlefleet_ops.sonicmoe.config"
-        )
-    return SonicMoEConfig(
-        fuse_y1_quant=True,
-        fuse_y1_bf16_trunc=_env_flag("SONIC_MOE_FUSE_Y1_BF16_TRUNC", True),
-    ).activate()
+        return contextlib.nullcontext()
+    return SonicMoEConfig().activate()
 
 
 class _SonicRouterScoresFromMetadata(paddle.autograd.PyLayer):

--- a/src/paddlefleet/transformer/moe/fusion_layer_utils.py
+++ b/src/paddlefleet/transformer/moe/fusion_layer_utils.py
@@ -15,6 +15,7 @@
 import contextlib
 import copy
 import logging
+import os
 
 import paddle
 import paddlefleet_ops
@@ -46,6 +47,13 @@ if paddlefleet_ops.is_sonic_moe_available():
         _UpProjection,
     )
     from paddlefleet_ops.sonicmoe.functional.utils import enable_fp8
+    try:
+        from paddlefleet_ops.sonicmoe.config import SonicMoEConfig
+    except (ImportError, RuntimeError):
+        SonicMoEConfig = None
+    from paddlefleet_ops.sonicmoe.quack_utils.blockscaled_fp8_gemm import (
+        _scatter_router_scores_i32,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -64,7 +72,8 @@ def _copy_sonic_fp8_weight_attrs(src, dst):
 class _SonicFP8WeightCarrier(paddle.autograd.PyLayer):
     @staticmethod
     def forward(ctx, weight):
-        carrier = paddle.empty([1], dtype=weight.dtype).as_strided(
+        # The carrier data is never read; it only carries shape, dtype, and FP8 attrs.
+        carrier = weight.as_strided(
             [weight.shape[1], weight.shape[2], weight.shape[0]], [0, 0, 0]
         )
         carrier.stop_gradient = weight.stop_gradient
@@ -80,6 +89,62 @@ class _SonicFP8WeightCarrier(paddle.autograd.PyLayer):
 
 def _make_sonic_fp8_weight_carrier(weight):
     return _SonicFP8WeightCarrier.apply(weight)
+
+
+def _env_flag(name, default=None):
+    value = os.getenv(name, "").strip().lower()
+    if value in {"1", "true", "yes", "on"}:
+        return True
+    if value in {"0", "false", "no", "off"}:
+        return False
+    return default
+
+
+def _sonic_moe_runtime_config_context():
+    fuse_y1_quant = _env_flag("SONIC_MOE_FUSE_Y1_QUANT", False)
+    if not fuse_y1_quant:
+        return contextlib.nullcontext()
+    if SonicMoEConfig is None:
+        raise RuntimeError(
+            "SONIC_MOE_FUSE_Y1_QUANT=1 requires paddlefleet_ops.sonicmoe.config"
+        )
+    return SonicMoEConfig(
+        fuse_y1_quant=True,
+        fuse_y1_bf16_trunc=_env_flag("SONIC_MOE_FUSE_Y1_BF16_TRUNC", True),
+    ).activate()
+
+
+class _SonicRouterScoresFromMetadata(paddle.autograd.PyLayer):
+    @staticmethod
+    def forward(ctx, topk_scores, metadata_scores, score_src_idx):
+        if len(topk_scores.shape) != 2:
+            raise ValueError(
+                f"topk_scores: expected rank 2, got shape {topk_scores.shape}"
+            )
+        if metadata_scores.shape[0] < score_src_idx.shape[0]:
+            raise ValueError(
+                "metadata_scores must include every real score referenced by "
+                f"score_src_idx; got {metadata_scores.shape[0]} scores and "
+                f"{score_src_idx.shape[0]} indices"
+            )
+        if "int32" not in str(score_src_idx.dtype):
+            raise ValueError(
+                f"score_src_idx: expected int32, got {score_src_idx.dtype}"
+            )
+        metadata_scores.stop_gradient = True
+        score_src_idx.stop_gradient = True
+        ctx.save_for_backward(score_src_idx)
+        ctx.input_shape = list(topk_scores.shape)
+        ctx.n_total = int(topk_scores.shape[0]) * int(topk_scores.shape[1])
+        return metadata_scores.clone()
+
+    @staticmethod
+    def backward(ctx, grad_out):
+        (score_src_idx,) = ctx.saved_tensor()
+        grad_flat = _scatter_router_scores_i32(
+            grad_out.contiguous(), score_src_idx, ctx.n_total
+        )
+        return grad_flat.reshape(ctx.input_shape), None, None
 
 
 class UnZipNode:
@@ -2312,15 +2377,20 @@ def run_sonic_moe(
     activation_type = ActivationType("swiglu")
 
     total_expert_freq = TK_padded
-    scores_for_down = _differentiable_router_scores(
-        topk_scores,
-        topk_indices_i32,
-        num_activated_expert_per_token_offset,
-        TK_padded - total_pad_rows,
-        TK_padded,
-        E,
-        score_src_idx=_score_src_idx,
-    )
+    if _score_src_idx is not None:
+        scores_for_down = _SonicRouterScoresFromMetadata.apply(
+            topk_scores, _router_scores, _score_src_idx
+        )
+    else:
+        scores_for_down = _differentiable_router_scores(
+            topk_scores,
+            topk_indices_i32,
+            num_activated_expert_per_token_offset,
+            TK_padded - total_pad_rows,
+            TK_padded,
+            E,
+            score_src_idx=_score_src_idx,
+        )
 
     fp8_hidden_states = None
     if fp8_scale is not None:
@@ -2333,7 +2403,7 @@ def run_sonic_moe(
         w1_sonic = w1.permute([1, 2, 0])
         w2_sonic = w2.permute([1, 2, 0])
 
-    with enable_fp8(fp8):
+    with enable_fp8(fp8), _sonic_moe_runtime_config_context():
         _refresh_fp8_config()
         y1, z = _UpProjection.apply(
             hidden_states,

--- a/src/paddlefleet/transformer/moe/fusion_layer_utils.py
+++ b/src/paddlefleet/transformer/moe/fusion_layer_utils.py
@@ -111,11 +111,26 @@ class _SonicRouterScoresFromMetadata(paddle.autograd.PyLayer):
             raise ValueError(
                 f"topk_scores: expected rank 2, got shape {topk_scores.shape}"
             )
+        if len(metadata_scores.shape) != 1:
+            raise ValueError(
+                "metadata_scores: expected rank 1, got shape "
+                f"{metadata_scores.shape}"
+            )
+        if len(score_src_idx.shape) != 1:
+            raise ValueError(
+                f"score_src_idx: expected rank 1, got shape {score_src_idx.shape}"
+            )
         if metadata_scores.shape[0] < score_src_idx.shape[0]:
             raise ValueError(
                 "metadata_scores must include every real score referenced by "
                 f"score_src_idx; got {metadata_scores.shape[0]} scores and "
                 f"{score_src_idx.shape[0]} indices"
+            )
+        pad_scores = metadata_scores.shape[0] - score_src_idx.shape[0]
+        if pad_scores >= FP8_ALIGN:
+            raise ValueError(
+                "metadata_scores has too many padding scores; expected fewer "
+                f"than {FP8_ALIGN}, got {pad_scores}"
             )
         if "int32" not in str(score_src_idx.dtype):
             raise ValueError(
@@ -126,7 +141,9 @@ class _SonicRouterScoresFromMetadata(paddle.autograd.PyLayer):
         ctx.save_for_backward(score_src_idx)
         ctx.input_shape = list(topk_scores.shape)
         ctx.n_total = int(topk_scores.shape[0]) * int(topk_scores.shape[1])
-        return metadata_scores.clone()
+        scores = metadata_scores.clone()
+        scores.stop_gradient = topk_scores.stop_gradient
+        return scores
 
     @staticmethod
     def backward(ctx, grad_out):

--- a/src/paddlefleet/transformer/moe/fusion_layer_utils.py
+++ b/src/paddlefleet/transformer/moe/fusion_layer_utils.py
@@ -126,12 +126,6 @@ class _SonicRouterScoresFromMetadata(paddle.autograd.PyLayer):
                 f"score_src_idx; got {metadata_scores.shape[0]} scores and "
                 f"{score_src_idx.shape[0]} indices"
             )
-        pad_scores = metadata_scores.shape[0] - score_src_idx.shape[0]
-        if pad_scores >= FP8_ALIGN:
-            raise ValueError(
-                "metadata_scores has too many padding scores; expected fewer "
-                f"than {FP8_ALIGN}, got {pad_scores}"
-            )
         if "int32" not in str(score_src_idx.dtype):
             raise ValueError(
                 f"score_src_idx: expected int32, got {score_src_idx.dtype}"

--- a/src/paddlefleet/transformer/moe/moe_expert.py
+++ b/src/paddlefleet/transformer/moe/moe_expert.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 
+import logging
 from contextlib import nullcontext
 from copy import deepcopy
-import logging
 
 import paddle
 import paddle.nn.functional as F
@@ -474,7 +474,9 @@ class SonicMoEExpert(GroupedMLPExpert):
                 if fused_grouped_w1_to_sonic is not None:
                     return fused_grouped_w1_to_sonic(weight)
             except Exception:
-                logger.exception("fused grouped->sonic W1 layout failed; fallback")
+                logger.exception(
+                    "fused grouped->sonic W1 layout failed; fallback"
+                )
         target_shape = [weight.shape[0], weight.shape[2], weight.shape[1]]
         gate, up = paddle.chunk(weight, 2, axis=-1)
         gate = gate.transpose([0, 2, 1])
@@ -488,7 +490,9 @@ class SonicMoEExpert(GroupedMLPExpert):
                 if fused_sonic_w1_to_grouped is not None:
                     return fused_sonic_w1_to_grouped(weight)
             except Exception:
-                logger.exception("fused sonic->grouped W1 layout failed; fallback")
+                logger.exception(
+                    "fused sonic->grouped W1 layout failed; fallback"
+                )
         target_shape = [weight.shape[0], weight.shape[2], weight.shape[1]]
         weight = weight.reshape([weight.shape[0], -1, 2, weight.shape[2]])
         gate = weight[:, :, 0, :].transpose([0, 2, 1])

--- a/src/paddlefleet/transformer/moe/moe_expert.py
+++ b/src/paddlefleet/transformer/moe/moe_expert.py
@@ -15,6 +15,8 @@
 
 from contextlib import nullcontext
 from copy import deepcopy
+import logging
+import os
 
 import paddle
 import paddle.nn.functional as F
@@ -44,6 +46,20 @@ try:
     from paddlefleet_ops.sonicmoe.quack_utils import quantize_native_fp8_weights
 except (ImportError, RuntimeError):
     pass
+
+fused_grouped_w1_to_sonic = None
+fused_sonic_w1_to_grouped = None
+fused_transpose_w2_layout = None
+try:
+    from paddlefleet_ops.sonicmoe.ernie_compat.weight_layout_fusion import (
+        fused_grouped_w1_to_sonic,
+        fused_sonic_w1_to_grouped,
+        fused_transpose_w2_layout,
+    )
+except (ImportError, RuntimeError):
+    pass
+
+logger = logging.getLogger(__name__)
 
 
 class BMMFunction(paddle.autograd.PyLayer):
@@ -437,7 +453,22 @@ class SonicMoEExpert(GroupedMLPExpert):
         )
 
     @staticmethod
+    def _use_fused_weight_layout():
+        return os.getenv("SONIC_MOE_FUSED_WEIGHT_LAYOUT", "0").lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }
+
+    @staticmethod
     def _grouped_w1_to_sonic(weight):
+        if SonicMoEExpert._use_fused_weight_layout():
+            try:
+                if fused_grouped_w1_to_sonic is not None:
+                    return fused_grouped_w1_to_sonic(weight)
+            except Exception:
+                logger.exception("fused grouped->sonic W1 layout failed; fallback")
         target_shape = [weight.shape[0], weight.shape[2], weight.shape[1]]
         gate, up = paddle.chunk(weight, 2, axis=-1)
         gate = gate.transpose([0, 2, 1])
@@ -446,6 +477,12 @@ class SonicMoEExpert(GroupedMLPExpert):
 
     @staticmethod
     def _sonic_w1_to_grouped(weight):
+        if SonicMoEExpert._use_fused_weight_layout():
+            try:
+                if fused_sonic_w1_to_grouped is not None:
+                    return fused_sonic_w1_to_grouped(weight)
+            except Exception:
+                logger.exception("fused sonic->grouped W1 layout failed; fallback")
         target_shape = [weight.shape[0], weight.shape[2], weight.shape[1]]
         weight = weight.reshape([weight.shape[0], -1, 2, weight.shape[2]])
         gate = weight[:, :, 0, :].transpose([0, 2, 1])
@@ -456,6 +493,12 @@ class SonicMoEExpert(GroupedMLPExpert):
     def _transpose_w2_layout(weight):
         # if not SonicMoEExpert._is_tensor_initialized(weight):
         #     return weight
+        if SonicMoEExpert._use_fused_weight_layout():
+            try:
+                if fused_transpose_w2_layout is not None:
+                    return fused_transpose_w2_layout(weight)
+            except Exception:
+                logger.exception("fused W2 layout transpose failed; fallback")
         return weight.transpose([0, 2, 1])
 
     @staticmethod

--- a/src/paddlefleet/transformer/moe/moe_expert.py
+++ b/src/paddlefleet/transformer/moe/moe_expert.py
@@ -16,7 +16,6 @@
 from contextlib import nullcontext
 from copy import deepcopy
 import logging
-import os
 
 import paddle
 import paddle.nn.functional as F
@@ -50,6 +49,12 @@ except (ImportError, RuntimeError):
 fused_grouped_w1_to_sonic = None
 fused_sonic_w1_to_grouped = None
 fused_transpose_w2_layout = None
+SonicMoEConfig = None
+try:
+    from paddlefleet_ops.sonicmoe.config import SonicMoEConfig
+except (ImportError, RuntimeError):
+    pass
+
 try:
     from paddlefleet_ops.sonicmoe.ernie_compat.weight_layout_fusion import (
         fused_grouped_w1_to_sonic,
@@ -58,6 +63,10 @@ try:
     )
 except (ImportError, RuntimeError):
     pass
+
+_SONIC_MOE_DEFAULT_CONFIG = (
+    SonicMoEConfig() if SonicMoEConfig is not None else None
+)
 
 logger = logging.getLogger(__name__)
 
@@ -454,12 +463,9 @@ class SonicMoEExpert(GroupedMLPExpert):
 
     @staticmethod
     def _use_fused_weight_layout():
-        return os.getenv("SONIC_MOE_FUSED_WEIGHT_LAYOUT", "0").lower() in {
-            "1",
-            "true",
-            "yes",
-            "on",
-        }
+        if _SONIC_MOE_DEFAULT_CONFIG is None:
+            return True
+        return _SONIC_MOE_DEFAULT_CONFIG.resolve_fused_weight_layout()
 
     @staticmethod
     def _grouped_w1_to_sonic(weight):

--- a/src/paddlefleet/transformer/moe/moe_expert.py
+++ b/src/paddlefleet/transformer/moe/moe_expert.py
@@ -519,8 +519,12 @@ class SonicMoEExpert(GroupedMLPExpert):
             value = value.contiguous()
         if list(tensor.shape) != list(value.shape):
             tensor.reshape_(list(value.shape))
-        # tensor[...] = value
-        paddle.assign(value, output=tensor)
+        try:
+            value._share_buffer_to(tensor)
+        except Exception:
+            # Keep the conservative copy path if Paddle cannot share this
+            # tensor's storage, e.g. for an unsupported place or tensor type.
+            paddle.assign(value, output=tensor)
 
     def __init__(
         self,

--- a/src/paddlefleet/transformer/moe/moe_expert.py
+++ b/src/paddlefleet/transformer/moe/moe_expert.py
@@ -519,12 +519,7 @@ class SonicMoEExpert(GroupedMLPExpert):
             value = value.contiguous()
         if list(tensor.shape) != list(value.shape):
             tensor.reshape_(list(value.shape))
-        try:
-            value._share_buffer_to(tensor)
-        except Exception:
-            # Keep the conservative copy path if Paddle cannot share this
-            # tensor's storage, e.g. for an unsupported place or tensor type.
-            paddle.assign(value, output=tensor)
+        paddle.assign(value, output=tensor)
 
     def __init__(
         self,


### PR DESCRIPTION
### PR Category
Performance Optimization

### PR Types
Performance

### Description
Summary:
- Replace the SonicMoE hotpath env toggles in Fleet with `SonicMoEConfig()` defaults.
- Keep imports under the strict `paddlefleet_ops.sonicmoe.*` namespace.
- Add capability detection for the SonicMoE metadata router-score scatter backward symbol, with fallback to the existing differentiable router-score path when older `paddlefleet_ops` builds are used.
- Update the `packages/paddlefleet_ops/third_party/sonic-moe` submodule pointer to PFCCLab/supersonic-moe commit `08062c431f59571b582645e19b400943c745e556` (`Add SonicMoE weight layout bit-exact tests`, PFCCLab/supersonic-moe#62), based on merged SonicMoE layout kernel optimization #61 and metadata/layout hotpath update #60.
- Preserve persistent SonicMoE weight/grad buffer identity during layout conversion by writing converted values back with `paddle.assign(..., output=tensor)`; this intentionally avoids `_share_buffer_to` for parameters, `main_grad`, and `param.grad` because optimizers and gradient buffers may hold those storages.

Dependency:
- PFCCLab/supersonic-moe#60 has been merged; it provides the metadata and layout hotpath base currently used by Fleet.
- PFCCLab/supersonic-moe#61 has been merged; it carries the tiled W1/W2 layout kernel optimization now referenced by this Fleet submodule pointer.
- PFCCLab/supersonic-moe#62 adds strict bit-exact layout-kernel tests, including opt-in >4GB tensor coverage and compute-sanitizer validation.

Validation:
- `pre-commit run --all-files`
- `python -m py_compile src/paddlefleet/transformer/moe/fusion_layer_utils.py src/paddlefleet/transformer/moe/moe_expert.py`
- `_SonicRouterScoresFromMetadata` smoke: `[TK_padded]` metadata scores with `[TK]` score indices keep `out.stop_gradient=False` when `topk_scores.stop_gradient=False`.
- `MAX_JOBS=192 uv pip install -e packages/paddlefleet_ops -vv --no-build-isolation` completed successfully after the Sonic config changes.
- No-env resolver smoke with `SONIC_MOE_FUSE_Y1_QUANT`, `SONIC_MOE_FUSE_Y1_BF16_TRUNC`, and `SONIC_MOE_FUSED_WEIGHT_LAYOUT` unset: defaults and `_FP8Config` snapshot are `True True True`.
- GPU fused-layout parity smoke: W1 grouped->sonic, sonic->grouped roundtrip, fallback roundtrip, and W2 transpose all reported max diff 0.0.
- SonicMoE #61 file-level validation: `python -m py_compile sonicmoe/ernie_compat/weight_layout_fusion.py`, `git diff --check`, and GPU bit-exact smoke for small W1/W2 plus A1B-shape W1 `[32,1024,2048]` roundtrip and W2 `[32,1024,1024]` transpose.
- SonicMoE #62 test validation:
  - `python -m py_compile sonicmoe/ernie_compat/weight_layout_fusion.py tests/ops/test_weight_layout_fusion.py`
  - `CUDA_VISIBLE_DEVICES=0 python -m pytest -q tests/ops/test_weight_layout_fusion.py`: `54 passed, 3 skipped`
  - `CUDA_VISIBLE_DEVICES=5 SONIC_MOE_RUN_LARGE_LAYOUT_TESTS=1 python -m pytest -q tests/ops/test_weight_layout_fusion.py -k large_tensor_crosses_int32_boundary`: `3 passed`
  - `compute-sanitizer --tool memcheck` on W2 transpose >4GB case: `1 passed`, `ERROR SUMMARY: 0 errors`
  - `compute-sanitizer --tool memcheck` on both W1 >4GB cases: `2 passed`, `ERROR SUMMARY: 0 errors`
- SonicMoE layout write-back pointer smoke after review fix: `_assign_tensor()` keeps target `data_ptr()` stable for same-shape and reshape write-back while copying values correctly.
- NCU/event timing from the same optimized SonicMoE implementation used in the runtime install path:
  - W1 grouped -> Sonic: `3995.6 us -> 590.5 us`, `6.77x`
  - W1 Sonic -> grouped: `3867.0 us -> 604.8 us`, `6.39x`
  - W2 transpose: `1948.2 us -> 299.0 us`, `6.52x`
- Nsight Systems smoke: `output/nsys_profiles/sonic_cfg_default_10_13_20260705_224656_rank0_3639289.nsys-rep` captured steps 10-13 with no legacy env flags. Timeline contains `GemmGatedSm100ZeroMatQuantPostActQuant` plus fused layout kernels.
- Cache/warmup sanity: after clearing SonicMoE DeepEP topk metadata cache, `script/warmup_sonicmoe_deepep_topk_metadata.py` rebuilt the artifact successfully, and a 4-step A1B training smoke completed all ranks with normal loss.
- A1B barrier-on 950-step run completed with `ret=0` and `last_step=950` using `moe_dispatch_bwd_ep_barrier: true`; final `loss=1.0540837`, `global_grad_norm=0.205339`, `tokens_per_sec_per_card_total_average=15879.4`.
- A1B 950-step loss/norm comparison against `/root/paddlejob/share-storage/gpfs/system-public/zhangyichen/erniebot/eb5v2_logs/fp8_sonic_950steps/workerlog.0`: common steps `1..950`; loss max abs diff `2.8595e-02`, mean abs diff `1.8329e-03`, final loss diff `1.0437e-03`; global grad norm max abs diff `1.49989`, mean abs diff `0.10330`, final norm diff `0.010845`.

Note:
- This update intentionally does not change EP barrier behavior. The earlier local `moe_dispatch_bwd_ep_barrier` experiment was removed from this PR scope because barrier-off has correctness risk.
- The worktree-local `uv.lock` resolver churn is not included in this PR.
- Direct pytest invocation of the referenced single-card SonicMoE precision test now reaches the FP8 forward path but fails because `weight.fp8` is missing before `quant_weight()`, which is unrelated to the buffer identity fix. The local pointer-stability smoke for `_assign_tensor()` passes.

### 是否引起精度变化
否
