### PR TITLE
Align Kimi BF16 column linear under accuracy gate

### DIFF
--- a/src/paddlefleet/tensor_parallel/layers.py
+++ b/src/paddlefleet/tensor_parallel/layers.py
@@ -1058,6 +1058,7 @@ def column_sequence_parallel_linear(
     weight,
     bias=None,
     mp_group=None,
+    use_accuracy_compatible: bool = False,
 ):
     """Functional version of ColumnSequenceParallelLinear using fused_linear.
 
@@ -1085,6 +1086,20 @@ def column_sequence_parallel_linear(
         input_parallel = AllGatherOpLegacy.apply(x, 0, mp_group)
     else:
         input_parallel = x
+
+    if (
+        use_accuracy_compatible
+        and not is_mp
+        and input_parallel.dtype == paddle.bfloat16
+        and weight.dtype == paddle.bfloat16
+    ):
+        # Accuracy-compatible Kimi alignment: in TP=1 there is no sequence
+        # parallel communication to preserve here, and Paddle fused_linear
+        # selects a BF16 GEMM path that diverges from Megatron-Core no-TE
+        # torch.nn.functional.linear for shared-expert fc1.  Use Paddle's
+        # F.linear path under the explicit accuracy gate; default experimental
+        # fused_linear behavior remains unchanged.
+        return F.linear(input_parallel, weight, bias)
 
     output = fused_linear(input_parallel, weight, bias)
     return output
@@ -1404,7 +1419,13 @@ class ColumnParallelLinear(paddle.nn.Layer):
 
         if getattr(self.config, "gpt_model_use_experimental_version", False):
             output = column_sequence_parallel_linear(
-                input_, weight, self.bias, mp_group=self.tp_group
+                input_,
+                weight,
+                self.bias,
+                mp_group=self.tp_group,
+                use_accuracy_compatible=getattr(
+                    self.config, "use_accuracy_compatible", False
+                ),
             )
             return output, None
 

--- a/tests/single_card_tests/tensor_parallel/test_column_sequence_parallel_accuracy.py
+++ b/tests/single_card_tests/tensor_parallel/test_column_sequence_parallel_accuracy.py
@@ -1,0 +1,140 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import types
+import unittest
+from unittest.mock import patch
+
+import paddle
+
+from paddlefleet.tensor_parallel.layers import (
+    ColumnParallelLinear,
+    column_sequence_parallel_linear,
+)
+
+
+class TestColumnSequenceParallelAccuracyGate(unittest.TestCase):
+    """Tests for the TP=1 BF16 accuracy gate in experimental column linear."""
+
+    def _fake_tensor(self, dtype):
+        return types.SimpleNamespace(dtype=dtype)
+
+    def test_accuracy_gate_uses_f_linear_for_bf16_tp1(self):
+        x = self._fake_tensor(paddle.bfloat16)
+        weight = self._fake_tensor(paddle.bfloat16)
+        bias = object()
+        sentinel = object()
+
+        with (
+            patch(
+                "paddlefleet.tensor_parallel.layers.F.linear",
+                return_value=sentinel,
+            ) as mock_linear,
+            patch("paddle.incubate.nn.functional.fused_linear") as mock_fused,
+        ):
+            output = column_sequence_parallel_linear(
+                x,
+                weight,
+                bias,
+                mp_group=None,
+                use_accuracy_compatible=True,
+            )
+
+        self.assertIs(output, sentinel)
+        mock_linear.assert_called_once_with(x, weight, bias)
+        mock_fused.assert_not_called()
+
+    def test_default_path_keeps_fused_linear(self):
+        x = self._fake_tensor(paddle.bfloat16)
+        weight = self._fake_tensor(paddle.bfloat16)
+        bias = object()
+        sentinel = object()
+
+        with (
+            patch("paddlefleet.tensor_parallel.layers.F.linear") as mock_linear,
+            patch(
+                "paddle.incubate.nn.functional.fused_linear",
+                return_value=sentinel,
+            ) as mock_fused,
+        ):
+            output = column_sequence_parallel_linear(
+                x,
+                weight,
+                bias,
+                mp_group=None,
+                use_accuracy_compatible=False,
+            )
+
+        self.assertIs(output, sentinel)
+        mock_fused.assert_called_once_with(x, weight, bias)
+        mock_linear.assert_not_called()
+
+    def test_accuracy_gate_requires_bf16_weight(self):
+        x = self._fake_tensor(paddle.bfloat16)
+        weight = self._fake_tensor(paddle.float32)
+        bias = object()
+        sentinel = object()
+
+        with (
+            patch("paddlefleet.tensor_parallel.layers.F.linear") as mock_linear,
+            patch(
+                "paddle.incubate.nn.functional.fused_linear",
+                return_value=sentinel,
+            ) as mock_fused,
+        ):
+            output = column_sequence_parallel_linear(
+                x,
+                weight,
+                bias,
+                mp_group=None,
+                use_accuracy_compatible=True,
+            )
+
+        self.assertIs(output, sentinel)
+        mock_fused.assert_called_once_with(x, weight, bias)
+        mock_linear.assert_not_called()
+
+    def test_column_parallel_forward_passes_config_gate(self):
+        layer = types.SimpleNamespace(
+            weight=object(),
+            bias=object(),
+            skip_bias_add=False,
+            tp_group=None,
+            config=types.SimpleNamespace(
+                gpt_model_use_experimental_version=True,
+                use_accuracy_compatible=True,
+            ),
+        )
+        input_ = object()
+        sentinel = object()
+
+        with patch(
+            "paddlefleet.tensor_parallel.layers.column_sequence_parallel_linear",
+            return_value=sentinel,
+        ) as mock_column_linear:
+            output, output_bias = ColumnParallelLinear.forward(layer, input_)
+
+        self.assertIs(output, sentinel)
+        self.assertIsNone(output_bias)
+        mock_column_linear.assert_called_once_with(
+            input_,
+            layer.weight,
+            layer.bias,
+            mp_group=layer.tp_group,
+            use_accuracy_compatible=True,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
This PR narrows the Kimi accuracy-compatible BF16 column-linear alignment change to the experimental ColumnParallelLinear path only.

- Add an explicit `use_accuracy_compatible` argument to `column_sequence_parallel_linear`.
- In TP=1 BF16 only, route through `paddle.nn.functional.linear` to match the Megatron-Core no-TE behavior observed for Kimi shared-expert fc1.
- Keep the default `fused_linear` path unchanged unless `use_accuracy_compatible=True`.
- Add a single-card regression test for the accuracy gate, default fused path, dtype guard, and `ColumnParallelLinear.forward` config propagation.

Validation:
- `python -m py_compile src/paddlefleet/tensor_parallel/layers.py tests/single_card_tests/tensor_parallel/test_column_sequence_parallel_accuracy.py`
- `pre-commit run --files tests/single_card_tests/tensor_parallel/test_column_sequence_parallel_accuracy.py src/paddlefleet/tensor_parallel/layers.py --show-diff-on-failure`
- Kimi 2-layer no-TE forward-loss comparisons reached 20-step and 100-step `BITWISE_PASS` in the repro workspace.
