### PR TITLE
Support attn sink in fa3

### DIFF
--- a/src/paddlefleet/transformer/dot_product_attention.py
+++ b/src/paddlefleet/transformer/dot_product_attention.py
@@ -47,6 +47,10 @@ from paddlefleet.refined_recompute import (
 )
 from paddlefleet.transformer.enums import AttnMaskType
 from paddlefleet.transformer.layer import FleetLayer
+from paddlefleet.transformer.sink_impl import (
+    prepare_fa3_sink_attention,
+    sink_attention_forward,
+)
 from paddlefleet.transformer.utils import (
     attention_mask_func,
     startend_row_indices_add_sliding_window,
@@ -648,15 +652,44 @@ class DotProductAttention(FleetLayer):
                 sdpa_kwargs = {}
                 if self._has_custom_softmax_scale:
                     sdpa_kwargs["scale"] = self.softmax_scale
-                attn_output = paddle.nn.functional.scaled_dot_product_attention(
-                    query,
-                    key,
-                    value_for_sdpa,
-                    attn_mask_kv,
-                    self.config.attention_dropout,
-                    is_causal=is_causal,
-                    **sdpa_kwargs,
+                use_fa3_sink, sink_startend_row_indices = (
+                    prepare_fa3_sink_attention(
+                        query,
+                        key,
+                        value_for_sdpa,
+                        self.softmax_offset,
+                        attention_mask=attn_mask_kv,
+                        causal=is_causal,
+                        context_parallel_size=self.context_parallel_size,
+                        use_rr_flash_attention=use_rr_flash_attention,
+                        flashmask_use_varlen=self.config.flashmask_use_varlen,
+                    )
                 )
+                if use_fa3_sink:
+                    attn_output = sink_attention_forward(
+                        query.astype(value_for_sdpa.dtype),
+                        key.astype(value_for_sdpa.dtype),
+                        value_for_sdpa.astype(value_for_sdpa.dtype),
+                        sink=self.softmax_offset,
+                        startend_row_indices=sink_startend_row_indices,
+                        attention_mask=None,
+                        dropout_p=self.config.attention_dropout,
+                        softmax_scale=self.softmax_scale,
+                        causal=is_causal,
+                        training=self.training,
+                    )
+                else:
+                    attn_output = (
+                        paddle.nn.functional.scaled_dot_product_attention(
+                            query,
+                            key,
+                            value_for_sdpa,
+                            attn_mask_kv,
+                            self.config.attention_dropout,
+                            is_causal=is_causal,
+                            **sdpa_kwargs,
+                        )
+                    )
 
             if sdpa_need_value_padding:
                 attn_output = attn_output[..., :v_head_dim]
@@ -727,6 +760,20 @@ class DotProductAttention(FleetLayer):
             else:
                 flashmask_attention_func = flashmask_attention
 
+            use_fa3_sink, attn_mask_startend_row_indices = (
+                prepare_fa3_sink_attention(
+                    query,
+                    key,
+                    value,
+                    self.softmax_offset,
+                    startend_row_indices=attn_mask_startend_row_indices,
+                    causal=is_causal,
+                    context_parallel_size=self.context_parallel_size,
+                    use_rr_flash_attention=use_rr_flash_attention,
+                    flashmask_use_varlen=self.config.flashmask_use_varlen,
+                )
+            )
+
             if self.sliding_window is not None:
                 attn_mask_startend_row_indices = (
                     startend_row_indices_add_sliding_window(
@@ -742,7 +789,8 @@ class DotProductAttention(FleetLayer):
             )
 
             need_value_padding = (
-                not (
+                use_fa3_sink
+                or not (
                     fa_version == 4 and q_head_dim == 192 and v_head_dim == 128
                 )
             ) and q_head_dim != v_head_dim
@@ -761,17 +809,30 @@ class DotProductAttention(FleetLayer):
 
             if not use_rr_flash_attention and self._has_custom_softmax_scale:
                 extra_kwargs["softmax_scale"] = self.softmax_scale
-
-            attn_output = flashmask_attention_func(
-                query.astype(value.dtype),
-                key.astype(value.dtype),
-                value_padded.astype(value.dtype),
-                startend_row_indices=attn_mask_startend_row_indices,
-                dropout=self.config.attention_dropout,
-                causal=is_causal,
-                learnable_sink=self.softmax_offset,
-                **extra_kwargs,
-            )
+            if use_fa3_sink:
+                attn_output = sink_attention_forward(
+                    query.astype(value.dtype),
+                    key.astype(value.dtype),
+                    value_padded.astype(value.dtype),
+                    sink=self.softmax_offset,
+                    startend_row_indices=attn_mask_startend_row_indices,
+                    dropout_p=self.config.attention_dropout,
+                    softmax_scale=self.softmax_scale,
+                    causal=is_causal,
+                    training=self.training,
+                )
+            else:
+                if self.softmax_offset is not None:
+                    extra_kwargs["learnable_sink"] = self.softmax_offset
+                attn_output = flashmask_attention_func(
+                    query.astype(value.dtype),
+                    key.astype(value.dtype),
+                    value_padded.astype(value.dtype),
+                    startend_row_indices=attn_mask_startend_row_indices,
+                    dropout=self.config.attention_dropout,
+                    causal=is_causal,
+                    **extra_kwargs,
+                )
 
             if need_value_padding:
                 # Truncate output back to original v_head_dim

--- a/src/paddlefleet/transformer/dot_product_attention.py
+++ b/src/paddlefleet/transformer/dot_product_attention.py
@@ -652,44 +652,6 @@ class DotProductAttention(FleetLayer):
                 sdpa_kwargs = {}
                 if self._has_custom_softmax_scale:
                     sdpa_kwargs["scale"] = self.softmax_scale
-                use_fa3_sink, sink_startend_row_indices = (
-                    prepare_fa3_sink_attention(
-                        query,
-                        key,
-                        value_for_sdpa,
-                        self.softmax_offset,
-                        attention_mask=attn_mask_kv,
-                        causal=is_causal,
-                        context_parallel_size=self.context_parallel_size,
-                        use_rr_flash_attention=use_rr_flash_attention,
-                        flashmask_use_varlen=self.config.flashmask_use_varlen,
-                    )
-                )
-                if use_fa3_sink:
-                    attn_output = sink_attention_forward(
-                        query.astype(value_for_sdpa.dtype),
-                        key.astype(value_for_sdpa.dtype),
-                        value_for_sdpa.astype(value_for_sdpa.dtype),
-                        sink=self.softmax_offset,
-                        startend_row_indices=sink_startend_row_indices,
-                        attention_mask=None,
-                        dropout_p=self.config.attention_dropout,
-                        softmax_scale=self.softmax_scale,
-                        causal=is_causal,
-                        training=self.training,
-                    )
-                else:
-                    attn_output = (
-                        paddle.nn.functional.scaled_dot_product_attention(
-                            query,
-                            key,
-                            value_for_sdpa,
-                            attn_mask_kv,
-                            self.config.attention_dropout,
-                            is_causal=is_causal,
-                            **sdpa_kwargs,
-                        )
-                    )
 
             if sdpa_need_value_padding:
                 attn_output = attn_output[..., :v_head_dim]

--- a/src/paddlefleet/transformer/dot_product_attention.py
+++ b/src/paddlefleet/transformer/dot_product_attention.py
@@ -652,6 +652,15 @@ class DotProductAttention(FleetLayer):
                 sdpa_kwargs = {}
                 if self._has_custom_softmax_scale:
                     sdpa_kwargs["scale"] = self.softmax_scale
+                attn_output = paddle.nn.functional.scaled_dot_product_attention(
+                    query,
+                    key,
+                    value_for_sdpa,
+                    attn_mask_kv,
+                    self.config.attention_dropout,
+                    is_causal=is_causal,
+                    **sdpa_kwargs,
+                )
 
             if sdpa_need_value_padding:
                 attn_output = attn_output[..., :v_head_dim]

--- a/src/paddlefleet/transformer/sink_impl.py
+++ b/src/paddlefleet/transformer/sink_impl.py
@@ -1,0 +1,961 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import inspect
+
+import paddle
+from paddle.autograd.py_layer import PyLayer
+
+_C_ops = paddle._C_ops
+_FlashMaskInfoPaddle = None
+_flash_attn_bwd = None
+_flash_attn_fwd = None
+
+try:
+    if (
+        paddle.cuda.is_available()
+        and paddle.cuda.get_device_capability()[0] == 10
+    ):
+        from paddlefleet_ops.flash_mask.cute.flashmask_utils import (
+            FlashMaskInfoPaddle as _FlashMaskInfoPaddle,
+        )
+        from paddlefleet_ops.flash_mask.cute.interface import (
+            _flash_attn_bwd,
+            _flash_attn_fwd,
+        )
+except (ImportError, AttributeError):
+    pass
+
+
+def gen_dense_mask_from_startend_row_indices(
+    attn_mask_startend_row_indices: paddle.Tensor,
+    dtype: paddle.dtype = paddle.bfloat16,
+    is_causal: bool | None = None,
+):
+    """Recover a 4-D dense attention mask from FlashMask's
+    ``startend_row_indices`` representation.
+    """
+    if (
+        attn_mask_startend_row_indices is not None
+        and attn_mask_startend_row_indices.ndim == 3
+    ):
+        attn_mask_startend_row_indices = (
+            attn_mask_startend_row_indices.unsqueeze(-1)
+        )
+    if (
+        attn_mask_startend_row_indices is not None
+        and attn_mask_startend_row_indices.shape[-1] == 1
+    ):
+        is_causal = True
+    if (
+        attn_mask_startend_row_indices is not None
+        and attn_mask_startend_row_indices.shape[-1] == 4
+    ):
+        is_causal = False
+
+    if is_causal is None:
+        raise ValueError(
+            "The `is_causal` argument must be specified when recovering the "
+            "dense attention mask from the column-wise sparse attention mask "
+            "row indices."
+        )
+
+    batch_size, num_head, seq_len, bound_num = (
+        attn_mask_startend_row_indices.shape
+    )
+    has_end = (is_causal and bound_num == 2) or (
+        (not is_causal) and bound_num == 4
+    )
+
+    attention_mask = paddle.ones([seq_len, seq_len], dtype="bool").expand(
+        [batch_size, num_head, seq_len, seq_len]
+    )
+    if is_causal:
+        attention_mask = paddle.tril(attention_mask)
+
+    base = (
+        paddle.arange(seq_len, dtype="int32")
+        .unsqueeze(1)
+        .expand([batch_size, num_head, -1, seq_len])
+    )
+
+    mask_indices = attn_mask_startend_row_indices.transpose([0, 1, 3, 2])
+
+    downstart_mask_indices = mask_indices[:, :, 0:1, :]
+    downstart_mask_indices = downstart_mask_indices.expand(
+        [batch_size, num_head, seq_len, -1]
+    )
+    lower_tri = base < downstart_mask_indices
+    if has_end:
+        downend_mask_indices = mask_indices[:, :, 1:2, :]
+        downend_mask_indices = downend_mask_indices.expand(
+            [batch_size, num_head, seq_len, -1]
+        )
+        lower_tri = paddle.logical_or(lower_tri, base >= downend_mask_indices)
+
+    attention_mask = paddle.logical_and(attention_mask, lower_tri)
+
+    if not is_causal:
+        if has_end:
+            upstart_mask_indices = mask_indices[:, :, 2:3, :]
+            upstart_mask_indices = upstart_mask_indices.expand(
+                [batch_size, num_head, seq_len, -1]
+            )
+            upend_mask_indices = mask_indices[:, :, 3:4, :]
+            upend_mask_indices = upend_mask_indices.expand(
+                [batch_size, num_head, seq_len, -1]
+            )
+            upper_tri = base >= upend_mask_indices
+            upper_tri = paddle.logical_or(
+                upper_tri, base < upstart_mask_indices
+            )
+        else:
+            upend_mask_indices = mask_indices[:, :, 1:2, :]
+            upend_mask_indices = upend_mask_indices.expand(
+                [batch_size, num_head, seq_len, -1]
+            )
+            upper_tri = base >= upend_mask_indices
+
+        attention_mask = paddle.logical_and(attention_mask, upper_tri)
+
+    attention_mask = paddle.scale(
+        x=attention_mask.astype(dtype),
+        scale=1000000.0,
+        bias=-1.0,
+        bias_after_scale=False,
+    )
+    return attention_mask
+
+
+def _repeat_kv(hidden_states: paddle.Tensor, n_rep: int) -> paddle.Tensor:
+    """Equivalent of ``paddle.repeat_interleave(hidden_states, n_rep, axis=2)``
+    for tensors with layout ``[batch, seq_len, num_kv_heads, head_dim]``.
+    """
+    batch, slen, num_key_value_heads, head_dim = hidden_states.shape
+    if n_rep == 1:
+        return hidden_states
+
+    hidden_states = hidden_states.unsqueeze(-2).tile([1, 1, 1, n_rep, 1])
+    return hidden_states.reshape(
+        [batch, slen, num_key_value_heads * n_rep, head_dim]
+    )
+
+
+def _get_fa_version(head_dim: int = 0):
+    """Get the FlashAttention version based on environment flags."""
+    if "xpu" in paddle.get_device():
+        return 2
+    fa_version = paddle.base.framework.get_flags(["FLAGS_flash_attn_version"])[
+        "FLAGS_flash_attn_version"
+    ]
+    if (
+        fa_version == 3
+        and paddle.base.framework.get_flags(["FLAGS_cudnn_deterministic"])[
+            "FLAGS_cudnn_deterministic"
+        ]
+        and head_dim > 128
+    ):
+        return 2
+    return fa_version
+
+
+def _full_startend_row_indices(batch_size: int, seq_len: int):
+    start = paddle.full(
+        [batch_size, 1, seq_len, 1], seq_len, dtype=paddle.int32
+    )
+    end = paddle.zeros([batch_size, 1, seq_len, 1], dtype=paddle.int32)
+    return paddle.concat([start, end], axis=-1)
+
+
+def _dense_mask_to_startend_row_indices(attention_mask, query, key, is_causal):
+    if attention_mask is None:
+        return None
+
+    bsz, q_len, _, _ = query.shape
+    kv_len = key.shape[1]
+    if q_len != kv_len:
+        raise NotImplementedError(
+            "FA3 sink attention dense mask conversion requires q_len == kv_len, "
+            f"got q_len={q_len}, kv_len={kv_len}."
+        )
+    if len(attention_mask.shape) != 4:
+        raise NotImplementedError(
+            "FA3 sink attention only supports 4-D dense masks that are "
+            "equivalent to causal or full attention."
+        )
+
+    if attention_mask.dtype == paddle.bool:
+        masked = attention_mask
+    elif bool(paddle.any(attention_mask < 0).item()):
+        masked = attention_mask < 0
+    else:
+        masked = attention_mask < 0.5
+
+    if masked.shape[0] not in (1, bsz) or masked.shape[1] != 1:
+        raise NotImplementedError(
+            "FA3 sink attention dense mask conversion only supports masks "
+            "with shape [1|batch, 1, seq, seq]."
+        )
+
+    mask_sample = masked[0, 0]
+    if is_causal:
+        expected = paddle.triu(
+            paddle.ones([q_len, kv_len], dtype="bool"), diagonal=1
+        )
+        startend = paddle.full([bsz, 1, kv_len, 1], kv_len, dtype=paddle.int32)
+    else:
+        expected = paddle.zeros([q_len, kv_len], dtype="bool")
+        startend = _full_startend_row_indices(bsz, kv_len)
+
+    if not bool(paddle.all(mask_sample == expected).item()):
+        raise NotImplementedError(
+            "FA3 sink attention only supports dense masks equivalent to "
+            "causal or full attention in phase one."
+        )
+    if masked.shape[0] == bsz:
+        for batch_idx in range(1, bsz):
+            if not bool(paddle.all(masked[batch_idx, 0] == mask_sample).item()):
+                raise NotImplementedError(
+                    "FA3 sink attention does not support per-sample dense "
+                    "mask differences in phase one."
+                )
+
+    return startend
+
+
+def prepare_fa3_sink_attention(
+    query,
+    key,
+    value,
+    sink: paddle.Tensor | None,
+    attention_mask=None,
+    startend_row_indices=None,
+    causal=False,
+    context_parallel_size: int = 1,
+    use_rr_flash_attention: bool = False,
+    flashmask_use_varlen: bool = False,
+):
+    q_head_dim = query.shape[-1]
+    v_head_dim = value.shape[-1]
+    if sink is None or _get_fa_version(q_head_dim) != 3:
+        return False, startend_row_indices
+    if context_parallel_size > 1:
+        raise NotImplementedError(
+            "FA3 sink attention is only supported for non-context-parallel paths."
+        )
+    if use_rr_flash_attention:
+        raise NotImplementedError(
+            "FA3 sink attention does not support refined recompute yet."
+        )
+    if flashmask_use_varlen:
+        raise NotImplementedError(
+            "FA3 sink attention does not support flashmask_use_varlen yet."
+        )
+    # FA3 dense sink only supports equal q/k/v sequence lengths. Raise here
+    # instead of falling through to avoid silently changing KV-cache decode behavior.
+    if startend_row_indices is None and (
+        query.shape[1] != key.shape[1] or key.shape[1] != value.shape[1]
+    ):
+        raise NotImplementedError(
+            "FA3 sink attention does not support KV-cache decode with unequal q/k/v sequence lengths yet, "
+            f"got q_len={query.shape[1]}, k_len={key.shape[1]}, v_len={value.shape[1]}."
+        )
+    if startend_row_indices is None:
+        startend_row_indices = _dense_mask_to_startend_row_indices(
+            attention_mask, query, key, causal
+        )
+    return True, startend_row_indices
+
+
+def _stable_logaddexp(lhs, rhs):
+    max_value = paddle.maximum(lhs, rhs)
+    return max_value + paddle.log(
+        paddle.exp(lhs - max_value) + paddle.exp(rhs - max_value)
+    )
+
+
+def _merge_kv_grad(grad_repeated, original, num_key_value_groups):
+    if (
+        num_key_value_groups > 1
+        and grad_repeated.shape[2] == original.shape[2] * num_key_value_groups
+    ):
+        batch, seq_len, num_kv_heads, head_dim = original.shape
+        return grad_repeated.reshape(
+            [batch, seq_len, num_kv_heads, num_key_value_groups, head_dim]
+        ).sum(axis=3)
+    return grad_repeated
+
+
+def _flash_attention_forward_dispatch(
+    query,
+    key,
+    value,
+    dropout=0.0,
+    causal=False,
+    return_softmax=False,
+    attention_mask: paddle.Tensor | None = None,
+    *,
+    fixed_seed_offset=None,
+    rng_name="",
+    training=True,
+    name=None,
+    softmax_scale=None,
+):
+    """Dispatch FlashAttention forward based on version. seq_k must equal seq_v."""
+    assert not return_softmax, "return_softmax must be false"
+
+    seq_k, seq_v = key.shape[1], value.shape[1]
+    q_head_dim = query.shape[-1]
+    v_head_dim = value.shape[-1]
+    assert seq_k == seq_v, (
+        f"FlashAttention requires equal sequence lengths: seq_k={seq_k}, seq_v={seq_v}"
+    )
+
+    if q_head_dim != v_head_dim:
+        raise NotImplementedError(
+            "FA3 sink attention requires query/key and value head_dim to match, "
+            f"got q/k={q_head_dim}, v={v_head_dim}."
+        )
+
+    fa_version = _get_fa_version(query.shape[-1])
+
+    if fa_version == 2:
+        softmax_scale = softmax_scale or 1.0 / (query.shape[-1] ** 0.5)
+        if hasattr(paddle.base.libpaddle.pir.ops, "flash_attn"):
+            out, _, lse, _ = _C_ops.flash_attn(
+                query,
+                key,
+                value,
+                fixed_seed_offset,
+                attention_mask,
+                dropout,
+                causal,
+                False,
+                not training,
+                rng_name,
+            )
+        else:
+            raise AssertionError(
+                "flash_attn_v2 is not supported, may be due to paddle version"
+            )
+        lse = lse[:, :, : query.shape[1]]
+    elif fa_version == 3:
+        softmax_scale = softmax_scale or 1.0 / (query.shape[-1] ** 0.5)
+        if dropout > 0.0 and training:
+            raise NotImplementedError(
+                "FA3 sink attention does not support attention_dropout > 0 yet."
+            )
+        if hasattr(paddle.base.libpaddle.pir.ops, "flash_attn_v3"):
+            out, lse = _C_ops.flash_attn_v3(
+                query,
+                key,
+                value,
+                None,
+                None,
+                None,
+                None,
+                softmax_scale,
+                causal,
+                -1,
+                -1,
+                0.0,
+                1,
+                False,
+                False,
+                0,
+            )
+        else:
+            raise AssertionError(
+                "flash_attn_v3 is not supported, may be due to paddle version"
+            )
+
+        assert attention_mask is None, (
+            "FA3 do not support dense mask(attention_mask)"
+        )
+    elif fa_version == 4:
+        if _flash_attn_fwd is None:
+            raise AssertionError(
+                "FA4 flash attention is not available, may be due to paddlefleet_ops version"
+            )
+        out, lse = _flash_attn_fwd(
+            query,
+            key,
+            value,
+            softmax_scale=softmax_scale,
+            causal=causal,
+            return_lse=True,
+            startend_row_indices=None,
+            pack_gqa=False,
+        )
+        assert attention_mask is None, (
+            "FA4 do not support dense mask(attention_mask)"
+        )
+    else:
+        raise ValueError(f"Unsupported FlashAttention version: {fa_version}")
+
+    return out, lse
+
+
+def _flash_attention_backward_dispatch(
+    grad_output,
+    query,
+    key,
+    value,
+    output,
+    lse,
+    dropout=0.0,
+    attention_mask: paddle.Tensor | None = None,
+    causal=False,
+    softmax_scale=None,
+):
+    """Dispatch FlashAttention backward based on version."""
+    fa_version = _get_fa_version(query.shape[-1])
+
+    if fa_version == 2:
+        seed_offset = paddle.zeros(shape=[2], dtype="int64")
+        if hasattr(paddle.base.libpaddle.pir.ops, "flash_attn_grad"):
+            grad_q, grad_k, grad_v = _C_ops.flash_attn_grad(
+                query,
+                key,
+                value,
+                output,
+                lse,
+                seed_offset,
+                attention_mask,
+                grad_output,
+                dropout,
+                causal,
+            )
+        else:
+            raise AssertionError(
+                "flash_attn_v2_grad is not supported, may be due to paddle version"
+            )
+    elif fa_version == 3:
+        softmax_scale = softmax_scale or 1.0 / (query.shape[-1] ** 0.5)
+        if hasattr(paddle.base.libpaddle.pir.ops, "flash_attn_v3_grad"):
+            grad_q, grad_k, grad_v = _C_ops.flash_attn_v3_grad(
+                query,
+                key,
+                value,
+                output,
+                lse,
+                grad_output,
+                softmax_scale,
+                causal,
+                -1,
+                -1,
+                0.0,
+                0,
+            )
+        else:
+            raise AssertionError(
+                "flash_attn_v3_grad is not supported, may be due to paddle version"
+            )
+        assert attention_mask is None, (
+            "FA3 do not support dense mask(attention_mask)"
+        )
+    elif fa_version == 4:
+        if _flash_attn_bwd is None:
+            raise AssertionError(
+                "FA4 flash attention backward is not available, may be due to paddlefleet_ops version"
+            )
+        grad_q, grad_k, grad_v = _flash_attn_bwd(
+            query,
+            key,
+            value,
+            output,
+            grad_output,
+            lse,
+            None,  # flashmask_info, startend_row_indices is not None
+            softmax_scale=softmax_scale,
+            causal=causal,
+            deterministic=bool(
+                paddle.get_flags(["FLAGS_cudnn_deterministic"])[
+                    "FLAGS_cudnn_deterministic"
+                ]
+            ),
+        )
+        assert attention_mask is None, (
+            "FA4 do not support dense mask(attention_mask)"
+        )
+    else:
+        raise ValueError(f"Unsupported FlashAttention version: {fa_version}")
+
+    return grad_q, grad_k, grad_v
+
+
+def _flashmask_attention_forward_dispatch(
+    query,
+    key,
+    value,
+    startend_row_indices,
+    dropout=0.0,
+    causal=False,
+    training=True,
+    softmax_scale=None,
+):
+    """Dispatch FlashMask attention forward. Only FlashMask v1 doesn't support
+    custom softmax_scale.
+    """
+    fa_version = _get_fa_version(query.shape[-1])
+
+    if fa_version == 2:
+        if softmax_scale is not None and softmax_scale != 1.0 / (
+            query.shape[-1] ** 0.5
+        ):
+            print(
+                f"Warning: FlashMask v1 doesn't support custom softmax_scale, "
+                f"ignoring provided value: {softmax_scale}"
+            )
+
+        output, log_sum_exp = paddle.nn.functional.flashmask_attention(
+            query,
+            key,
+            value,
+            startend_row_indices=startend_row_indices,
+            causal=causal,
+            dropout=dropout,
+            return_softmax_lse=True,
+            training=training,
+        )
+    elif fa_version == 3:
+        if dropout > 0.0 and training:
+            raise NotImplementedError(
+                "FA3 sink attention with startend_row_indices does not support attention_dropout > 0 yet."
+            )
+        output, log_sum_exp = paddle.nn.functional.flashmask_attention(
+            query,
+            key,
+            value,
+            startend_row_indices=startend_row_indices,
+            causal=causal,
+            dropout=dropout,
+            softmax_scale=softmax_scale,
+            return_softmax_lse=True,
+            training=training,
+        )
+    elif fa_version == 4:
+        if _flash_attn_fwd is None:
+            raise AssertionError(
+                "FA4 flashmask attention is not available, may be due to paddlefleet_ops version"
+            )
+        output, log_sum_exp = _flash_attn_fwd(
+            query,
+            key,
+            value,
+            softmax_scale=softmax_scale,
+            causal=causal,
+            return_lse=True,
+            startend_row_indices=startend_row_indices,
+            pack_gqa=False,
+        )
+    else:
+        raise ValueError(f"Unsupported FlashAttention version: {fa_version}")
+
+    return output, log_sum_exp
+
+
+def _flashmask_attention_backward_dispatch(
+    grad_output,
+    query,
+    key,
+    value,
+    output,
+    lse,
+    startend_row_indices,
+    dropout=0.0,
+    causal=False,
+    softmax_scale=None,
+):
+    """Dispatch FlashMask attention backward based on version."""
+    fa_version = _get_fa_version(query.shape[-1])
+    if fa_version == 2:
+        seed_offset = paddle.zeros(shape=[2], dtype="int64")
+        if hasattr(paddle.base.libpaddle.pir.ops, "flashmask_attention_grad"):
+            grad_q, grad_k, grad_v = _C_ops.flashmask_attention_grad(
+                query,
+                key,
+                value,
+                startend_row_indices,
+                output,
+                lse,
+                seed_offset,
+                grad_output,
+                dropout,
+                causal,
+            )
+        else:
+            raise AssertionError(
+                "flashmask_attention_grad is not supported, may be due to paddle version"
+            )
+    elif fa_version == 3:
+        softmax_scale = softmax_scale or 1.0 / (query.shape[-1] ** 0.5)
+        if hasattr(
+            paddle.base.libpaddle.pir.ops, "flashmask_attention_v2_grad"
+        ):
+            sig_params = inspect.signature(
+                paddle.nn.functional.flashmask_attention
+            ).parameters
+            if "group" in sig_params:
+                grad_q, grad_k, grad_v = _C_ops.flashmask_attention_v2_grad(
+                    query,
+                    key,
+                    value,
+                    output,
+                    lse,
+                    startend_row_indices,
+                    None,  # block_mask
+                    grad_output,
+                    softmax_scale,
+                    causal,
+                    0,  # rank
+                    1,  # nranks
+                )
+            elif "block_mask" in sig_params:
+                grad_q, grad_k, grad_v = _C_ops.flashmask_attention_v2_grad(
+                    query,
+                    key,
+                    value,
+                    output,
+                    lse,
+                    startend_row_indices,
+                    None,  # block_mask
+                    grad_output,
+                    softmax_scale,
+                    causal,
+                )
+            else:
+                grad_q, grad_k, grad_v = _C_ops.flashmask_attention_v2_grad(
+                    query,
+                    key,
+                    value,
+                    output,
+                    lse,
+                    startend_row_indices,
+                    grad_output,
+                    softmax_scale,
+                    causal,
+                )
+        else:
+            raise AssertionError(
+                "flashmask_attention_v2_grad is not supported, may be due to paddle version"
+            )
+    elif fa_version == 4:
+        if _flash_attn_bwd is None:
+            raise AssertionError(
+                "FA4 flash attention backward is not available, may be due to paddlefleet_ops version"
+            )
+        if startend_row_indices is not None:
+            flashmask_info = _FlashMaskInfoPaddle(
+                startend_row_indices=startend_row_indices,
+                is_causal=causal,
+            )
+        else:
+            flashmask_info = None
+        grad_q, grad_k, grad_v = _flash_attn_bwd(
+            query,
+            key,
+            value,
+            output,
+            grad_output,
+            lse,
+            flashmask_info,
+            softmax_scale=softmax_scale,
+            causal=causal,
+            deterministic=bool(
+                paddle.get_flags(["FLAGS_cudnn_deterministic"])[
+                    "FLAGS_cudnn_deterministic"
+                ]
+            ),
+        )
+    else:
+        raise ValueError(f"Unsupported FlashAttention version: {fa_version}")
+
+    return grad_q, grad_k, grad_v
+
+
+class FlashMaskSinkPyLayer(PyLayer):
+    """FlashAttention/FlashMask with 1F1B sink correction.
+
+    The underlying FA/FlashMask kernel remains unchanged. Forward first runs the
+    no-sink kernel, then folds the sink logit into the returned output and LSE.
+    Backward reuses the original kernel backward by passing the corrected output
+    and corrected LSE, so q/k/v need only one attention backward.
+    """
+
+    @staticmethod
+    def forward(
+        ctx,
+        query,
+        key,
+        value,
+        sink,
+        startend_row_indices,
+        attention_mask: paddle.Tensor | None = None,
+        dropout=0.0,
+        causal=False,
+        return_softmax=False,
+        *,
+        fixed_seed_offset=None,
+        rng_name="",
+        training=True,
+        name=None,
+        softmax_scale=None,
+    ):
+        assert not return_softmax, "return_softmax must be false"
+        assert query.ndim == 4, f"Query must be 4D tensor, got {query.ndim}D"
+        assert key.ndim == 4, f"Key must be 4D tensor, got {key.ndim}D"
+        assert value.ndim == 4, f"Value must be 4D tensor, got {value.ndim}D"
+        assert sink.ndim == 1, f"Sink must be 1D tensor, got {sink.ndim}D"
+
+        batch_q, seq_q, num_q_heads, head_dim_q = query.shape
+        batch_k, seq_k, num_kv_heads, head_dim_k = key.shape
+        batch_v, seq_v, num_kv_heads_v, head_dim_v = value.shape
+
+        assert batch_q == batch_k == batch_v, (
+            f"Batch sizes must match: query={batch_q}, key={batch_k}, value={batch_v}"
+        )
+        assert head_dim_q == head_dim_k, (
+            f"Head dimensions must match: query={head_dim_q}, key={head_dim_k}"
+        )
+        if head_dim_q != head_dim_v:
+            raise ValueError(
+                "attention sink requires value head_dim to match query/key "
+                f"head_dim, got q/k={head_dim_q}, v={head_dim_v}"
+            )
+        assert num_kv_heads == num_kv_heads_v, (
+            f"Key and value must have same number of heads: key={num_kv_heads}, value={num_kv_heads_v}"
+        )
+        assert num_q_heads % num_kv_heads == 0, (
+            f"Query heads ({num_q_heads}) must be divisible by key/value heads ({num_kv_heads})"
+        )
+        assert sink.shape[0] == num_q_heads, (
+            f"Sink parameter size ({sink.shape[0]}) must match number of query heads ({num_q_heads})"
+        )
+
+        if startend_row_indices is None:
+            assert seq_q == seq_k == seq_v, (
+                f"FlashAttention requires equal sequence lengths: seq_q={seq_q}, seq_k={seq_k}, seq_v={seq_v}"
+            )
+        else:
+            assert seq_k == seq_v, (
+                f"Key and value sequence lengths must match: seq_k={seq_k}, seq_v={seq_v}"
+            )
+            assert attention_mask is None, (
+                "Flashmask do not support dense mask(attention_mask)"
+            )
+
+        num_attention_heads = query.shape[2]
+        num_key_value_heads = key.shape[2]
+        num_key_value_groups = num_attention_heads // num_key_value_heads
+        if startend_row_indices is None:
+            key_states = _repeat_kv(key, num_key_value_groups)
+            value_states = _repeat_kv(value, num_key_value_groups)
+        else:
+            key_states = key
+            value_states = value
+
+        if startend_row_indices is None:
+            raw_output, lse_raw = _flash_attention_forward_dispatch(
+                query,
+                key_states,
+                value_states,
+                dropout,
+                causal,
+                attention_mask=attention_mask,
+                fixed_seed_offset=fixed_seed_offset,
+                rng_name=rng_name,
+                training=training,
+                name=name,
+                softmax_scale=softmax_scale,
+            )
+        else:
+            raw_output, lse_raw = _flashmask_attention_forward_dispatch(
+                query,
+                key_states,
+                value_states,
+                startend_row_indices,
+                dropout,
+                causal,
+                training=training,
+                softmax_scale=softmax_scale,
+            )
+
+        origin_dtype = raw_output.dtype
+        scale = softmax_scale or 1.0 / (query.shape[-1] ** 0.5)
+        batch_size, seq_len, num_heads, _ = query.shape
+
+        # Compat with old LSE shape (seqlen_q_rounded).
+        if lse_raw.shape[-1] != seq_len:
+            lse_raw = lse_raw[:, :, :seq_len]
+
+        lse_raw_fp32 = lse_raw.astype("float32")
+        sink_bhs = sink.astype("float32").reshape([1, num_heads, 1])
+        sink_lse = _stable_logaddexp(lse_raw_fp32, sink_bhs)
+        multiplier = paddle.exp(lse_raw_fp32 - sink_lse)
+        final_output = raw_output * multiplier.transpose([0, 2, 1]).unsqueeze(
+            -1
+        )
+        final_output = final_output.to(origin_dtype)
+
+        ctx.save_for_backward(
+            query,
+            key,
+            value,
+            sink,
+            attention_mask,
+            final_output,
+            sink_lse,
+            startend_row_indices,
+        )
+        ctx.dropout = dropout
+        ctx.causal = causal
+        ctx.softmax_scale = scale
+        ctx.fixed_seed_offset = fixed_seed_offset
+        ctx.rng_name = rng_name
+        ctx.training = training
+        ctx.name = name
+        ctx.num_key_value_groups = num_key_value_groups
+
+        return final_output
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        (
+            query,
+            key,
+            value,
+            sink,
+            attention_mask,
+            final_output,
+            sink_lse,
+            startend_row_indices,
+        ) = ctx.saved_tensor()
+
+        num_key_value_groups = ctx.num_key_value_groups
+        if startend_row_indices is None:
+            key_states = _repeat_kv(key, num_key_value_groups)
+            value_states = _repeat_kv(value, num_key_value_groups)
+        else:
+            key_states = key
+            value_states = value
+
+        dropout, causal, scale = ctx.dropout, ctx.causal, ctx.softmax_scale
+        grad_output_for_kernel = grad_output.to(query.dtype)
+
+        if startend_row_indices is None:
+            grad_q, grad_k_repeated, grad_v_repeated = (
+                _flash_attention_backward_dispatch(
+                    grad_output_for_kernel,
+                    query,
+                    key_states,
+                    value_states,
+                    final_output,
+                    sink_lse,
+                    dropout=dropout,
+                    attention_mask=attention_mask,
+                    causal=causal,
+                    softmax_scale=scale,
+                )
+            )
+        else:
+            grad_q, grad_k_repeated, grad_v_repeated = (
+                _flashmask_attention_backward_dispatch(
+                    grad_output_for_kernel,
+                    query,
+                    key_states,
+                    value_states,
+                    final_output,
+                    sink_lse,
+                    startend_row_indices,
+                    dropout,
+                    causal,
+                    scale,
+                )
+            )
+
+        grad_k = _merge_kv_grad(grad_k_repeated, key, num_key_value_groups)
+        grad_v = _merge_kv_grad(grad_v_repeated, value, num_key_value_groups)
+
+        if sink.stop_gradient:
+            grad_sink = None
+        else:
+            delta = paddle.sum(
+                final_output.astype("float32") * grad_output.astype("float32"),
+                axis=-1,
+            )
+            delta = delta.transpose([0, 2, 1])
+            sink_prob = paddle.exp(
+                sink.astype("float32").reshape([1, -1, 1])
+                - sink_lse.astype("float32")
+            )
+            grad_sink = -(sink_prob * delta).sum(axis=0).sum(axis=1)
+
+        if query.dtype != grad_q.dtype:
+            grad_q = grad_q.cast(query.dtype)
+        if key.dtype != grad_k.dtype:
+            grad_k = grad_k.cast(key.dtype)
+        if value.dtype != grad_v.dtype:
+            grad_v = grad_v.cast(value.dtype)
+        if grad_sink is not None and grad_sink.dtype != sink.dtype:
+            grad_sink = grad_sink.cast(sink.dtype)
+
+        if startend_row_indices is None:
+            return grad_q, grad_k, grad_v, grad_sink
+        return grad_q, grad_k, grad_v, grad_sink, None
+
+
+def sink_attention_forward(
+    q,
+    k,
+    v,
+    sink: paddle.Tensor,
+    attention_mask: paddle.Tensor | None = None,
+    startend_row_indices: paddle.Tensor | None = None,
+    dropout_p=0.0,
+    softmax_scale=None,
+    causal=False,
+    training=True,
+):
+    """Unified attention forward with Sink mechanism.
+
+    Automatically chooses between FlashAttention and FlashMask based on
+    ``startend_row_indices``. Shapes follow the ``[B, S, H, D]`` layout
+    (same as paddlefleet's ``DotProductAttention``).
+
+    Args:
+        q: Query tensor ``[B, S, H_q, D]``
+        k: Key tensor ``[B, S, H_kv, D]``
+        v: Value tensor ``[B, S, H_kv, D_v]``
+        sink: Sink parameter tensor ``[H_q]``
+        attention_mask: Dense mask, only supported for FA2 path.
+        startend_row_indices: If given, route to FlashMask.
+        dropout_p: Dropout probability.
+        softmax_scale: Custom softmax scaling factor.
+        causal: Whether to apply causal masking.
+        training: Whether to apply training-only dropout behavior.
+    """
+    return FlashMaskSinkPyLayer.apply(
+        q,
+        k,
+        v,
+        sink,
+        startend_row_indices,
+        attention_mask=attention_mask,
+        dropout=dropout_p,
+        causal=causal,
+        return_softmax=False,
+        training=training,
+        softmax_scale=softmax_scale,
+    )

--- a/tests/single_card_tests/transformer/test_flash_mask_sink.py
+++ b/tests/single_card_tests/transformer/test_flash_mask_sink.py
@@ -26,6 +26,7 @@ Covers PR "Support FA4 sink." (ab8c450) on the non-CP paths:
      through ``recompute`` to force both forward passes, vs the non-rr path.
 """
 
+import contextlib
 import math
 import unittest
 
@@ -33,11 +34,23 @@ import numpy as np
 import paddle
 from paddlefleet_ops import is_flash_mask_available
 
-# Force FA4 (cute) backend for the whole module: sink only exists there.
+# Force FA4 (cute) backend by default for the existing FA4 cases. FA3 cases
+# switch the flag locally and restore it after each run.
 paddle.set_flags({"FLAGS_flash_attn_version": 4})
 
 DTYPE = paddle.bfloat16
 SEED = 2026
+
+
+def _is_sm100_or_newer():
+    try:
+        return (
+            paddle.cuda.is_available()
+            and paddle.cuda.get_device_capability()[0] >= 10
+        )
+    except (AttributeError, RuntimeError, ValueError):
+        return False
+
 
 # FA4 attention-sink lives only in the cute backend, which is built solely for
 # compute capability >= 10 (sm100/Blackwell). Elsewhere the cute kernels are
@@ -46,6 +59,26 @@ _SINK_AVAILABLE = is_flash_mask_available()
 _SKIP_REASON = (
     "FA4 attention-sink requires the cute backend (sm100, capability >= 10)"
 )
+_IS_SM100_OR_NEWER = _is_sm100_or_newer()
+_FA3_SINK_AVAILABLE = (
+    not _IS_SM100_OR_NEWER
+    and hasattr(paddle.base.libpaddle.pir.ops, "flash_attn_v3")
+    and hasattr(paddle.base.libpaddle.pir.ops, "flash_attn_v3_grad")
+    and hasattr(paddle.base.libpaddle.pir.ops, "flashmask_attention_v2_grad")
+)
+_FA3_SKIP_REASON = "FA3 sink attention requires FA3 flash attention ops and is disabled on sm100+"
+
+
+@contextlib.contextmanager
+def _flash_attn_version(version):
+    old = paddle.get_flags(["FLAGS_flash_attn_version"])[
+        "FLAGS_flash_attn_version"
+    ]
+    paddle.set_flags({"FLAGS_flash_attn_version": version})
+    try:
+        yield
+    finally:
+        paddle.set_flags({"FLAGS_flash_attn_version": old})
 
 
 def _startend_row_indices(batch_size, seq_len, causal):
@@ -337,6 +370,140 @@ class TestCuteFlashmaskSink(unittest.TestCase):
             )
 
 
+@unittest.skipUnless(_FA3_SINK_AVAILABLE, _FA3_SKIP_REASON)
+class TestFA3SinkAttention(unittest.TestCase):
+    """FA3 sink_attention_forward numerical correctness with sink."""
+
+    def _run(
+        self,
+        batch_size,
+        seq_len,
+        nheads,
+        nheads_kv,
+        d,
+        causal,
+        use_startend=True,
+    ):
+        from paddlefleet.transformer.sink_impl import sink_attention_forward
+
+        with _flash_attn_version(3):
+            paddle.seed(SEED)
+            np.random.seed(SEED)
+
+            q_ref = paddle.randn([batch_size, seq_len, nheads, d], dtype=DTYPE)
+            k_ref = paddle.randn(
+                [batch_size, seq_len, nheads_kv, d], dtype=DTYPE
+            )
+            v_ref = paddle.randn(
+                [batch_size, seq_len, nheads_kv, d], dtype=DTYPE
+            )
+            for t in (q_ref, k_ref, v_ref):
+                t.stop_gradient = False
+
+            q, k, v = [x.detach().clone() for x in (q_ref, k_ref, v_ref)]
+            for t in (q, k, v):
+                t.stop_gradient = False
+
+            sink_ref = paddle.randn([nheads], dtype=DTYPE)
+            sink_ref.stop_gradient = False
+            sink = sink_ref.detach().clone()
+            sink.stop_gradient = False
+
+            startend_row_indices = None
+            if use_startend:
+                startend_row_indices = _startend_row_indices(
+                    batch_size, seq_len, causal
+                )
+                attn_bias = _attn_bias_from_indices(
+                    startend_row_indices, seq_len, nheads, causal
+                )
+            elif causal:
+                causal_mask = np.triu(
+                    np.ones((seq_len, seq_len), dtype=bool), k=1
+                )
+                attn_bias = paddle.to_tensor(
+                    np.where(causal_mask, -np.inf, 0.0).astype("float32")
+                ).reshape([1, 1, seq_len, seq_len])
+            else:
+                attn_bias = paddle.zeros(
+                    [1, 1, seq_len, seq_len], dtype=paddle.float32
+                )
+
+            out_ref = attention_ref_with_sink(
+                q_ref, k_ref, v_ref, attn_bias, sink_ref
+            )
+            out = sink_attention_forward(
+                q,
+                k,
+                v,
+                sink=sink,
+                startend_row_indices=startend_row_indices,
+                causal=causal,
+            )
+
+            fwd_atol = 2 * (out_ref + 0.3 - 0.3 - out_ref).abs().max().item()
+            max_diff = (out - out_ref).abs().max().item()
+            self.assertLessEqual(
+                max_diff,
+                2e-2 + fwd_atol,
+                f"fwd max diff {max_diff} too large (atol={fwd_atol})",
+            )
+
+            g = paddle.randn(out.shape, dtype=out.dtype)
+            out.backward(g.clone())
+            out_ref.backward(g.clone())
+
+            for name, a, b in (
+                ("dq", q.grad, q_ref.grad),
+                ("dk", k.grad, k_ref.grad),
+                ("dv", v.grad, v_ref.grad),
+            ):
+                atol = 2 * (b + 0.3 - 0.3 - b).abs().max().item()
+                diff = (a - b).abs().max().item()
+                self.assertLessEqual(
+                    diff, 5e-2 + atol, f"{name} max diff {diff} too large"
+                )
+
+            self.assertIsNotNone(sink.grad)
+            self.assertEqual(list(sink.grad.shape), [nheads])
+
+    def test_causal_with_trainable_sink(self):
+        self._run(2, 256, 4, 4, 128, causal=True)
+
+    def test_noncausal_with_trainable_sink(self):
+        self._run(2, 256, 4, 4, 128, causal=False)
+
+    def test_dense_causal_with_trainable_sink(self):
+        self._run(2, 256, 4, 4, 128, causal=True, use_startend=False)
+
+    def test_gqa_with_sink(self):
+        self._run(2, 256, 8, 2, 128, causal=True)
+
+    def test_small_head_dim_sink(self):
+        self._run(2, 128, 4, 4, 64, causal=False)
+
+    def test_fixed_sink_backward_no_dsink(self):
+        from paddlefleet.transformer.sink_impl import sink_attention_forward
+
+        with _flash_attn_version(3):
+            paddle.seed(SEED)
+            b, s, h, d = 2, 256, 4, 128
+            q = paddle.randn([b, s, h, d], dtype=DTYPE)
+            k = paddle.randn([b, s, h, d], dtype=DTYPE)
+            v = paddle.randn([b, s, h, d], dtype=DTYPE)
+            for t in (q, k, v):
+                t.stop_gradient = False
+            sink = paddle.zeros([h], dtype=DTYPE)
+            sink.stop_gradient = True
+            idx = _startend_row_indices(b, s, causal=True)
+            out = sink_attention_forward(
+                q, k, v, sink=sink, startend_row_indices=idx, causal=True
+            )
+            out.backward(paddle.randn(out.shape, dtype=out.dtype))
+            self.assertIsNone(sink.grad)
+            self.assertIsNotNone(q.grad)
+
+
 @unittest.skipUnless(_SINK_AVAILABLE, _SKIP_REASON)
 class TestFacadeFlashmaskSink(unittest.TestCase):
     """paddlefleet_ops.flash_mask_facade.flashmask_attention sink forwarding.
@@ -553,6 +720,228 @@ class TestDotProductAttentionSinkForward(unittest.TestCase):
         # so this path is expected to raise on the fa4 sink branch.
         with self.assertRaises(AssertionError):
             self._run("off-by-one")
+
+
+@unittest.skipUnless(_FA3_SINK_AVAILABLE, _FA3_SKIP_REASON)
+class TestDotProductAttentionFA3SinkForward(unittest.TestCase):
+    """Full fwd/bwd through the FA3 sink branch of DotProductAttention."""
+
+    def _run(self, softmax_type, use_startend=True, **cfg_kwargs):
+        from paddlefleet.transformer.dot_product_attention import (
+            DotProductAttention,
+        )
+        from paddlefleet.transformer.enums import AttnMaskType
+
+        with _flash_attn_version(3):
+            paddle.seed(SEED)
+            config = _make_config(softmax_type=softmax_type, **cfg_kwargs)
+            attn = DotProductAttention(
+                config=config,
+                layer_number=1,
+                attn_mask_type=AttnMaskType.causal,
+                attention_type="self",
+            )
+
+            b, s = 2, 64
+            h = config.num_attention_heads
+            d = config.head_dim
+            q = paddle.randn([b, s, h, d], dtype=DTYPE)
+            k = paddle.randn([b, s, h, d], dtype=DTYPE)
+            v = paddle.randn([b, s, h, d], dtype=DTYPE)
+            for t in (q, k, v):
+                t.stop_gradient = False
+
+            idx = (
+                _startend_row_indices(b, s, causal=True)
+                if use_startend
+                else None
+            )
+            out = attn(
+                query=q,
+                key=k,
+                value=v,
+                attention_mask=None,
+                attn_mask_startend_row_indices=idx,
+                attn_mask_type=AttnMaskType.causal,
+            )
+            self.assertEqual(list(out.shape), [b, s, h * d])
+
+            out.sum().backward()
+            self.assertIsNotNone(q.grad)
+            self.assertIsNotNone(k.grad)
+            self.assertIsNotNone(v.grad)
+
+            if softmax_type == "learnable":
+                self.assertIsNotNone(attn.softmax_offset.grad)
+                self.assertEqual(
+                    attn.softmax_offset.grad.dtype, paddle.bfloat16
+                )
+            elif softmax_type == "off-by-one":
+                self.assertIsNone(attn.softmax_offset.grad)
+
+    def test_forward_vanilla(self):
+        self._run("vanilla")
+
+    def test_forward_learnable_sink(self):
+        self._run("learnable")
+
+    def test_forward_learnable_sink_dense_causal(self):
+        self._run("learnable", use_startend=False)
+
+    def test_forward_learnable_sink_additive_dense_mask(self):
+        from paddlefleet.transformer.dot_product_attention import (
+            DotProductAttention,
+        )
+        from paddlefleet.transformer.enums import AttnMaskType
+
+        with _flash_attn_version(3):
+            paddle.seed(SEED)
+            config = _make_config(softmax_type="learnable")
+            attn = DotProductAttention(
+                config=config,
+                layer_number=1,
+                attn_mask_type=AttnMaskType.causal,
+                attention_type="self",
+            )
+
+            b, s = 2, 64
+            h = config.num_attention_heads
+            d = config.head_dim
+            q = paddle.randn([b, s, h, d], dtype=DTYPE)
+            k = paddle.randn([b, s, h, d], dtype=DTYPE)
+            v = paddle.randn([b, s, h, d], dtype=DTYPE)
+            for t in (q, k, v):
+                t.stop_gradient = False
+
+            causal_mask = np.triu(np.ones((s, s), dtype=bool), k=1)
+            attention_mask = paddle.to_tensor(
+                np.where(causal_mask, -1e6, 0.0).astype("float32")
+            ).reshape([1, 1, s, s])
+            out = attn(
+                query=q,
+                key=k,
+                value=v,
+                attention_mask=attention_mask,
+                attn_mask_startend_row_indices=None,
+                attn_mask_type=AttnMaskType.causal,
+            )
+            self.assertEqual(list(out.shape), [b, s, h * d])
+
+            out.sum().backward()
+            self.assertIsNotNone(q.grad)
+            self.assertIsNotNone(k.grad)
+            self.assertIsNotNone(v.grad)
+            self.assertIsNotNone(attn.softmax_offset.grad)
+            self.assertEqual(attn.softmax_offset.grad.dtype, paddle.bfloat16)
+
+    def test_forward_learnable_sink_value_head_dim_padding(self):
+        from paddlefleet.transformer.dot_product_attention import (
+            DotProductAttention,
+        )
+        from paddlefleet.transformer.enums import AttnMaskType
+
+        with _flash_attn_version(3):
+            paddle.seed(SEED)
+            b, s, h = 2, 64, 4
+            qk_dim, v_dim = 192, 128
+            config = _make_config(
+                softmax_type="learnable",
+                num_attention_heads=h,
+                head_dim=qk_dim,
+                hidden_size=h * qk_dim,
+            )
+            attn = DotProductAttention(
+                config=config,
+                layer_number=1,
+                attn_mask_type=AttnMaskType.causal,
+                attention_type="self",
+                k_channels=qk_dim,
+                v_channels=v_dim,
+            )
+
+            q = paddle.randn([b, s, h, qk_dim], dtype=DTYPE)
+            k = paddle.randn([b, s, h, qk_dim], dtype=DTYPE)
+            v = paddle.randn([b, s, h, v_dim], dtype=DTYPE)
+            for t in (q, k, v):
+                t.stop_gradient = False
+
+            out = attn(
+                query=q,
+                key=k,
+                value=v,
+                attention_mask=None,
+                attn_mask_startend_row_indices=None,
+                attn_mask_type=AttnMaskType.causal,
+            )
+            self.assertEqual(list(out.shape), [b, s, h * v_dim])
+
+            out.sum().backward()
+            self.assertIsNotNone(q.grad)
+            self.assertIsNotNone(k.grad)
+            self.assertIsNotNone(v.grad)
+            self.assertIsNotNone(attn.softmax_offset.grad)
+            self.assertEqual(attn.softmax_offset.grad.dtype, paddle.bfloat16)
+
+    def test_forward_learnable_sink_value_head_dim_larger_raises(self):
+        from paddlefleet.transformer.dot_product_attention import (
+            DotProductAttention,
+        )
+        from paddlefleet.transformer.enums import AttnMaskType
+
+        with _flash_attn_version(3):
+            paddle.seed(SEED)
+            b, s, h = 2, 64, 4
+            qk_dim, v_dim = 128, 192
+            config = _make_config(
+                softmax_type="learnable",
+                num_attention_heads=h,
+                head_dim=qk_dim,
+                hidden_size=h * qk_dim,
+            )
+            attn = DotProductAttention(
+                config=config,
+                layer_number=1,
+                attn_mask_type=AttnMaskType.causal,
+                attention_type="self",
+                k_channels=qk_dim,
+                v_channels=v_dim,
+            )
+
+            q = paddle.randn([b, s, h, qk_dim], dtype=DTYPE)
+            k = paddle.randn([b, s, h, qk_dim], dtype=DTYPE)
+            v = paddle.randn([b, s, h, v_dim], dtype=DTYPE)
+            with self.assertRaisesRegex(
+                ValueError,
+                "requires value head_dim to match query/key head_dim",
+            ):
+                attn(
+                    query=q,
+                    key=k,
+                    value=v,
+                    attention_mask=None,
+                    attn_mask_startend_row_indices=None,
+                    attn_mask_type=AttnMaskType.causal,
+                )
+
+    def test_decode_shape_raises_for_fa3_sink(self):
+        from paddlefleet.transformer.sink_impl import prepare_fa3_sink_attention
+
+        with _flash_attn_version(3):
+            b, h, d = 2, 4, 128
+            q = paddle.randn([b, 1, h, d], dtype=DTYPE)
+            k = paddle.randn([b, 8, h, d], dtype=DTYPE)
+            v = paddle.randn([b, 8, h, d], dtype=DTYPE)
+            sink = paddle.randn([h], dtype=DTYPE)
+            with self.assertRaisesRegex(
+                NotImplementedError,
+                "does not support KV-cache decode with unequal q/k/v sequence lengths",
+            ):
+                prepare_fa3_sink_attention(
+                    q, k, v, sink, attention_mask=None, causal=False
+                )
+
+    def test_forward_offbyone(self):
+        self._run("off-by-one")
 
 
 @unittest.skipUnless(_SINK_AVAILABLE, _SKIP_REASON)

--- a/tests/single_card_tests/transformer/test_flash_mask_sink.py
+++ b/tests/single_card_tests/transformer/test_flash_mask_sink.py
@@ -29,6 +29,8 @@ Covers PR "Support FA4 sink." (ab8c450) on the non-CP paths:
 import contextlib
 import math
 import unittest
+from types import SimpleNamespace
+from unittest import mock
 
 import numpy as np
 import paddle
@@ -191,6 +193,930 @@ def attention_ref_with_sink(q, k, v, attn_bias, learnable_sink):
     out = paddle.matmul(attention.astype(vf.dtype), vf)
     out = out.transpose([0, 2, 1, 3])  # b s h d
     return out
+
+
+class TestSinkImplMaskAndHelpers(unittest.TestCase):
+    """CPU-friendly coverage for sink_impl mask and tensor helpers."""
+
+    @staticmethod
+    def _assert_array_equal(actual, expected):
+        np.testing.assert_array_equal(actual.numpy(), np.asarray(expected))
+
+    def test_gen_dense_mask_supported_bound_layouts(self):
+        from paddlefleet.transformer.sink_impl import (
+            gen_dense_mask_from_startend_row_indices,
+        )
+
+        cases = (
+            (np.array([[[3, 2, 1]]], dtype=np.int32), None),
+            (
+                np.array([[[[1, 2], [1, 3], [2, 3]]]], dtype=np.int32),
+                True,
+            ),
+            (
+                np.array([[[[3, 0], [2, 1], [3, 2]]]], dtype=np.int32),
+                False,
+            ),
+            (
+                np.array(
+                    [[[[1, 2, 0, 1], [2, 3, 0, 2], [1, 3, 1, 2]]]],
+                    dtype=np.int32,
+                ),
+                None,
+            ),
+        )
+        for indices, is_causal in cases:
+            with self.subTest(bound_num=indices.shape[-1], causal=is_causal):
+                tensor = paddle.to_tensor(indices)
+                result = gen_dense_mask_from_startend_row_indices(
+                    tensor, dtype=paddle.float32, is_causal=is_causal
+                )
+
+                normalized = (
+                    indices[..., None] if indices.ndim == 3 else indices
+                )
+                causal = normalized.shape[-1] == 1 or is_causal is True
+                expected_allowed = np.ones((1, 1, 3, 3), dtype=bool)
+                for row in range(3):
+                    for col in range(3):
+                        bounds = normalized[0, 0, col]
+                        allowed = not causal or row >= col
+                        if causal:
+                            allowed &= row < bounds[0] or (
+                                len(bounds) == 2 and row >= bounds[1]
+                            )
+                        else:
+                            lower = row < bounds[0]
+                            if len(bounds) == 2:
+                                upper = row >= bounds[1]
+                            else:
+                                lower |= row >= bounds[1]
+                                upper = row >= bounds[3] or row < bounds[2]
+                            allowed &= lower and upper
+                        expected_allowed[0, 0, row, col] = allowed
+                expected = np.where(expected_allowed, 0.0, -1_000_000.0)
+                np.testing.assert_array_equal(result.numpy(), expected)
+
+    def test_gen_dense_mask_requires_causal_for_ambiguous_layout(self):
+        from paddlefleet.transformer.sink_impl import (
+            gen_dense_mask_from_startend_row_indices,
+        )
+
+        indices = paddle.zeros([1, 1, 2, 2], dtype=paddle.int32)
+        with self.assertRaisesRegex(ValueError, "is_causal.*must be specified"):
+            gen_dense_mask_from_startend_row_indices(indices)
+
+    def test_dense_mask_conversion_valid_masks(self):
+        from paddlefleet.transformer.sink_impl import (
+            _dense_mask_to_startend_row_indices,
+        )
+
+        query = paddle.zeros([2, 3, 2, 4])
+        key = paddle.zeros_like(query)
+        causal = np.triu(np.ones((3, 3), dtype=bool), k=1)
+
+        bool_result = _dense_mask_to_startend_row_indices(
+            paddle.to_tensor(causal).reshape([1, 1, 3, 3]),
+            query,
+            key,
+            True,
+        )
+        self.assertEqual(list(bool_result.shape), [2, 1, 3, 1])
+        self._assert_array_equal(bool_result, np.full((2, 1, 3, 1), 3))
+
+        additive = np.where(causal, -1e4, 0.0).astype("float32")
+        additive = np.broadcast_to(additive, (2, 1, 3, 3)).copy()
+        additive_result = _dense_mask_to_startend_row_indices(
+            paddle.to_tensor(additive), query, key, True
+        )
+        self._assert_array_equal(additive_result, bool_result.numpy())
+
+        keep_mask = paddle.ones([1, 1, 3, 3], dtype=paddle.float32)
+        full_result = _dense_mask_to_startend_row_indices(
+            keep_mask, query, key, False
+        )
+        expected_full = np.stack(
+            [np.full((2, 1, 3, 1), 3), np.zeros((2, 1, 3, 1))],
+            axis=-1,
+        ).reshape(2, 1, 3, 2)
+        self._assert_array_equal(full_result, expected_full)
+        self.assertIsNone(
+            _dense_mask_to_startend_row_indices(None, query, key, False)
+        )
+
+    def test_dense_mask_conversion_rejects_unsupported_masks(self):
+        from paddlefleet.transformer.sink_impl import (
+            _dense_mask_to_startend_row_indices,
+        )
+
+        query = paddle.zeros([2, 3, 2, 4])
+        key = paddle.zeros_like(query)
+        valid = paddle.zeros([1, 1, 3, 3], dtype=paddle.bool)
+        cases = (
+            (valid, query, paddle.zeros([2, 4, 2, 4]), "q_len == kv_len"),
+            (paddle.zeros([3, 3]), query, key, "4-D dense masks"),
+            (paddle.zeros([1, 2, 3, 3]), query, key, "shape.*seq, seq"),
+            (
+                paddle.to_tensor(
+                    np.stack(
+                        [np.zeros((3, 3), dtype=bool), np.eye(3, dtype=bool)]
+                    )[:, None]
+                ),
+                query,
+                key,
+                "per-sample dense mask differences",
+            ),
+            (
+                paddle.to_tensor(np.eye(3, dtype=bool)).reshape([1, 1, 3, 3]),
+                query,
+                key,
+                "equivalent to causal or full attention",
+            ),
+        )
+        for mask, q_value, k_value, message in cases:
+            with (
+                self.subTest(message=message),
+                self.assertRaisesRegex(NotImplementedError, message),
+            ):
+                _dense_mask_to_startend_row_indices(
+                    mask, q_value, k_value, False
+                )
+
+    def test_repeat_kv_identity_and_repetition(self):
+        from paddlefleet.transformer.sink_impl import _repeat_kv
+
+        hidden = paddle.arange(12, dtype=paddle.float32).reshape([1, 2, 2, 3])
+        self.assertIs(_repeat_kv(hidden, 1), hidden)
+        repeated = _repeat_kv(hidden, 3)
+        expected = np.repeat(hidden.numpy(), 3, axis=2)
+        self._assert_array_equal(repeated, expected)
+
+    def test_get_fa_version_environment_branches(self):
+        from paddlefleet.transformer import sink_impl
+
+        with (
+            mock.patch.object(
+                sink_impl.paddle, "get_device", return_value="xpu:0"
+            ),
+            mock.patch.object(
+                sink_impl.paddle.base.framework, "get_flags"
+            ) as get_flags,
+        ):
+            self.assertEqual(sink_impl._get_fa_version(256), 2)
+            get_flags.assert_not_called()
+
+        def flags(names):
+            name = names[0]
+            return {name: 3 if name == "FLAGS_flash_attn_version" else True}
+
+        with (
+            mock.patch.object(
+                sink_impl.paddle, "get_device", return_value="gpu:0"
+            ),
+            mock.patch.object(
+                sink_impl.paddle.base.framework,
+                "get_flags",
+                side_effect=flags,
+            ),
+        ):
+            self.assertEqual(sink_impl._get_fa_version(256), 2)
+            self.assertEqual(sink_impl._get_fa_version(128), 3)
+
+        with (
+            mock.patch.object(
+                sink_impl.paddle, "get_device", return_value="gpu:0"
+            ),
+            mock.patch.object(
+                sink_impl.paddle.base.framework,
+                "get_flags",
+                return_value={"FLAGS_flash_attn_version": 4},
+            ),
+        ):
+            self.assertEqual(sink_impl._get_fa_version(256), 4)
+
+    def test_full_indices_logaddexp_and_merge_grad(self):
+        from paddlefleet.transformer import sink_impl
+
+        _full_startend_row_indices = sink_impl._full_startend_row_indices
+        _merge_kv_grad = sink_impl._merge_kv_grad
+        _stable_logaddexp = sink_impl._stable_logaddexp
+
+        full = _full_startend_row_indices(2, 3)
+        expected_full = np.concatenate(
+            [np.full((2, 1, 3, 1), 3), np.zeros((2, 1, 3, 1))], axis=-1
+        )
+        self.assertEqual(full.dtype, paddle.int32)
+        self._assert_array_equal(full, expected_full)
+
+        lhs = paddle.to_tensor([[1000.0], [-1000.0], [0.0]])
+        rhs = paddle.to_tensor([[999.0, -1000.0]])
+        actual = _stable_logaddexp(lhs, rhs)
+        np.testing.assert_allclose(
+            actual.numpy(), np.logaddexp(lhs.numpy(), rhs.numpy()), rtol=1e-6
+        )
+
+        original = paddle.zeros([1, 2, 2, 1])
+        repeated = paddle.arange(8, dtype=paddle.float32).reshape([1, 2, 4, 1])
+        merged = _merge_kv_grad(repeated, original, 2)
+        expected = repeated.numpy().reshape(1, 2, 2, 2, 1).sum(axis=3)
+        self._assert_array_equal(merged, expected)
+        self.assertIs(_merge_kv_grad(repeated, original, 1), repeated)
+        mismatched = paddle.zeros([1, 2, 3, 1])
+        self.assertIs(_merge_kv_grad(mismatched, original, 2), mismatched)
+
+
+class TestPrepareFA3SinkAttention(unittest.TestCase):
+    """CPU-only routing tests for FA3 sink preparation."""
+
+    def setUp(self):
+        self.q = paddle.zeros([2, 3, 2, 4], dtype=paddle.float32)
+        self.k = paddle.zeros_like(self.q)
+        self.v = paddle.zeros_like(self.q)
+        self.sink = paddle.zeros([2], dtype=paddle.float32)
+
+    def test_routes_only_non_none_fa3_sink(self):
+        from paddlefleet.transformer import sink_impl
+
+        indices = paddle.zeros([2, 1, 3, 1], dtype=paddle.int32)
+        for version, sink, expected in (
+            (2, self.sink, False),
+            (3, None, False),
+        ):
+            with (
+                self.subTest(version=version, sink=sink),
+                mock.patch.object(
+                    sink_impl, "_get_fa_version", return_value=version
+                ),
+            ):
+                enabled, returned = sink_impl.prepare_fa3_sink_attention(
+                    self.q,
+                    self.k,
+                    self.v,
+                    sink,
+                    startend_row_indices=indices,
+                )
+                self.assertEqual(enabled, expected)
+                self.assertIs(returned, indices)
+
+        with mock.patch.object(sink_impl, "_get_fa_version", return_value=3):
+            enabled, returned = sink_impl.prepare_fa3_sink_attention(
+                self.q,
+                self.k,
+                self.v,
+                self.sink,
+                startend_row_indices=indices,
+            )
+        self.assertTrue(enabled)
+        self.assertIs(returned, indices)
+
+    def test_converts_dense_mask_and_forwards_causal(self):
+        from paddlefleet.transformer import sink_impl
+
+        converted = paddle.ones([2, 1, 3, 1], dtype=paddle.int32)
+        with (
+            mock.patch.object(sink_impl, "_get_fa_version", return_value=3),
+            mock.patch.object(
+                sink_impl,
+                "_dense_mask_to_startend_row_indices",
+                return_value=converted,
+            ) as convert,
+        ):
+            enabled, returned = sink_impl.prepare_fa3_sink_attention(
+                self.q,
+                self.k,
+                self.v,
+                self.sink,
+                attention_mask="mask",
+                causal=True,
+            )
+        self.assertTrue(enabled)
+        self.assertIs(returned, converted)
+        convert.assert_called_once_with("mask", self.q, self.k, True)
+
+    def test_rejects_unsupported_modes_and_decode(self):
+        from paddlefleet.transformer import sink_impl
+
+        cases = (
+            ({"context_parallel_size": 2}, "non-context-parallel"),
+            ({"use_rr_flash_attention": True}, "refined recompute"),
+            ({"flashmask_use_varlen": True}, "flashmask_use_varlen"),
+        )
+        with mock.patch.object(sink_impl, "_get_fa_version", return_value=3):
+            for kwargs, message in cases:
+                with (
+                    self.subTest(kwargs=kwargs),
+                    self.assertRaisesRegex(NotImplementedError, message),
+                ):
+                    sink_impl.prepare_fa3_sink_attention(
+                        self.q, self.k, self.v, self.sink, **kwargs
+                    )
+
+            short_key = paddle.zeros([2, 2, 2, 4], dtype=paddle.float32)
+            with self.assertRaisesRegex(NotImplementedError, "KV-cache decode"):
+                sink_impl.prepare_fa3_sink_attention(
+                    self.q, short_key, self.v, self.sink
+                )
+
+
+class TestFlashAttentionDispatch(unittest.TestCase):
+    """Mock every FA dispatch backend without invoking a device kernel."""
+
+    def setUp(self):
+        self.q = paddle.zeros([1, 2, 2, 4], dtype=paddle.float32)
+        self.k = paddle.ones_like(self.q)
+        self.v = paddle.full_like(self.q, 2.0)
+        self.out = paddle.full_like(self.q, 3.0)
+        self.lse = paddle.zeros([1, 2, 4], dtype=paddle.float32)
+        self.grad = paddle.ones_like(self.q)
+
+    @staticmethod
+    def _ops_patch(sink_impl, *names):
+        fake_ops = SimpleNamespace(**{name: object() for name in names})
+        return mock.patch.object(
+            sink_impl.paddle.base,
+            "libpaddle",
+            SimpleNamespace(pir=SimpleNamespace(ops=fake_ops)),
+        )
+
+    def test_forward_fa2_mock_and_lse_slice(self):
+        from paddlefleet.transformer import sink_impl
+
+        c_ops = SimpleNamespace(
+            flash_attn=mock.Mock(return_value=(self.out, None, self.lse, None))
+        )
+        with (
+            mock.patch.object(sink_impl, "_get_fa_version", return_value=2),
+            mock.patch.object(sink_impl, "_C_ops", c_ops),
+            self._ops_patch(sink_impl, "flash_attn"),
+        ):
+            result, lse = sink_impl._flash_attention_forward_dispatch(
+                self.q,
+                self.k,
+                self.v,
+                dropout=0.25,
+                causal=True,
+                fixed_seed_offset="seed",
+                rng_name="rng",
+                training=False,
+            )
+        self.assertIs(result, self.out)
+        self.assertEqual(list(lse.shape), [1, 2, 2])
+        args = c_ops.flash_attn.call_args.args
+        self.assertEqual(args[3:7], ("seed", None, 0.25, True))
+        self.assertEqual(args[8:10], (True, "rng"))
+
+    def test_forward_fa3_mock_and_parameter_errors(self):
+        from paddlefleet.transformer import sink_impl
+
+        c_ops = SimpleNamespace(
+            flash_attn_v3=mock.Mock(return_value=(self.out, self.lse))
+        )
+        with (
+            mock.patch.object(sink_impl, "_get_fa_version", return_value=3),
+            mock.patch.object(sink_impl, "_C_ops", c_ops),
+            self._ops_patch(sink_impl, "flash_attn_v3"),
+        ):
+            result = sink_impl._flash_attention_forward_dispatch(
+                self.q, self.k, self.v, causal=True, softmax_scale=0.7
+            )
+            self.assertIs(result[0], self.out)
+            self.assertIs(result[1], self.lse)
+            self.assertEqual(
+                c_ops.flash_attn_v3.call_args.args[7:9], (0.7, True)
+            )
+            with self.assertRaisesRegex(NotImplementedError, "dropout"):
+                sink_impl._flash_attention_forward_dispatch(
+                    self.q, self.k, self.v, dropout=0.1, training=True
+                )
+            with self.assertRaisesRegex(AssertionError, "dense mask"):
+                sink_impl._flash_attention_forward_dispatch(
+                    self.q, self.k, self.v, attention_mask=self.lse
+                )
+
+    def test_forward_fa4_mock_and_errors(self):
+        from paddlefleet.transformer import sink_impl
+
+        kernel = mock.Mock(return_value=(self.out, self.lse))
+        with (
+            mock.patch.object(sink_impl, "_get_fa_version", return_value=4),
+            mock.patch.object(sink_impl, "_flash_attn_fwd", kernel),
+        ):
+            self.assertEqual(
+                sink_impl._flash_attention_forward_dispatch(
+                    self.q, self.k, self.v, softmax_scale=0.25
+                ),
+                (self.out, self.lse),
+            )
+        kernel.assert_called_once_with(
+            self.q,
+            self.k,
+            self.v,
+            softmax_scale=0.25,
+            causal=False,
+            return_lse=True,
+            startend_row_indices=None,
+            pack_gqa=False,
+        )
+
+        with (
+            mock.patch.object(sink_impl, "_get_fa_version", return_value=4),
+            self.assertRaisesRegex(AssertionError, "not available"),
+        ):
+            sink_impl._flash_attention_forward_dispatch(self.q, self.k, self.v)
+
+    def test_forward_common_validation_and_unsupported_version(self):
+        from paddlefleet.transformer import sink_impl
+
+        with self.assertRaisesRegex(AssertionError, "return_softmax"):
+            sink_impl._flash_attention_forward_dispatch(
+                self.q, self.k, self.v, return_softmax=True
+            )
+        with self.assertRaisesRegex(AssertionError, "equal sequence lengths"):
+            sink_impl._flash_attention_forward_dispatch(
+                self.q, self.k[:, :1], self.v
+            )
+        with self.assertRaisesRegex(NotImplementedError, "head_dim to match"):
+            sink_impl._flash_attention_forward_dispatch(
+                self.q, self.k, self.v[..., :2]
+            )
+        with (
+            mock.patch.object(sink_impl, "_get_fa_version", return_value=9),
+            self.assertRaisesRegex(ValueError, "Unsupported"),
+        ):
+            sink_impl._flash_attention_forward_dispatch(self.q, self.k, self.v)
+
+    def test_backward_fa2_and_fa3_mocks(self):
+        from paddlefleet.transformer import sink_impl
+
+        grads = (self.q + 1, self.k + 2, self.v + 3)
+        cases = (
+            (2, "flash_attn_grad", 10),
+            (3, "flash_attn_v3_grad", 12),
+        )
+        for version, op_name, arg_count in cases:
+            op = mock.Mock(return_value=grads)
+            with (
+                self.subTest(version=version),
+                mock.patch.object(
+                    sink_impl, "_get_fa_version", return_value=version
+                ),
+                mock.patch.object(
+                    sink_impl, "_C_ops", SimpleNamespace(**{op_name: op})
+                ),
+                self._ops_patch(sink_impl, op_name),
+            ):
+                actual = sink_impl._flash_attention_backward_dispatch(
+                    self.grad,
+                    self.q,
+                    self.k,
+                    self.v,
+                    self.out,
+                    self.lse,
+                    causal=True,
+                    softmax_scale=0.5,
+                )
+            for returned, expected in zip(actual, grads):
+                self.assertIs(returned, expected)
+            self.assertEqual(len(op.call_args.args), arg_count)
+
+    def test_backward_fa4_and_error_branches(self):
+        from paddlefleet.transformer import sink_impl
+
+        grads = (self.q + 1, self.k + 2, self.v + 3)
+        kernel = mock.Mock(return_value=grads)
+        with (
+            mock.patch.object(sink_impl, "_get_fa_version", return_value=4),
+            mock.patch.object(sink_impl, "_flash_attn_bwd", kernel),
+            mock.patch.object(
+                sink_impl.paddle,
+                "get_flags",
+                return_value={"FLAGS_cudnn_deterministic": True},
+            ),
+        ):
+            actual = sink_impl._flash_attention_backward_dispatch(
+                self.grad, self.q, self.k, self.v, self.out, self.lse
+            )
+        for returned, expected in zip(actual, grads):
+            self.assertIs(returned, expected)
+        self.assertIsNone(kernel.call_args.args[6])
+        self.assertTrue(kernel.call_args.kwargs["deterministic"])
+
+        for version, message in ((4, "not available"), (8, "Unsupported")):
+            with (
+                self.subTest(version=version),
+                mock.patch.object(
+                    sink_impl, "_get_fa_version", return_value=version
+                ),
+                mock.patch.object(sink_impl, "_flash_attn_bwd", None),
+            ):
+                error = AssertionError if version == 4 else ValueError
+                with self.assertRaisesRegex(error, message):
+                    sink_impl._flash_attention_backward_dispatch(
+                        self.grad,
+                        self.q,
+                        self.k,
+                        self.v,
+                        self.out,
+                        self.lse,
+                    )
+
+
+class TestFlashMaskDispatch(unittest.TestCase):
+    """CPU-only FlashMask dispatch and compatibility-signature coverage."""
+
+    def setUp(self):
+        self.q = paddle.zeros([1, 2, 2, 4], dtype=paddle.float32)
+        self.k = paddle.ones_like(self.q)
+        self.v = paddle.full_like(self.q, 2.0)
+        self.out = paddle.full_like(self.q, 3.0)
+        self.lse = paddle.zeros([1, 2, 2], dtype=paddle.float32)
+        self.grad = paddle.ones_like(self.q)
+        self.indices = paddle.zeros([1, 1, 2, 1], dtype=paddle.int32)
+
+    def test_forward_fa2_fa3_functional_mocks(self):
+        from paddlefleet.transformer import sink_impl
+
+        for version in (2, 3):
+            function = mock.Mock(return_value=(self.out, self.lse))
+            with (
+                self.subTest(version=version),
+                mock.patch.object(
+                    sink_impl, "_get_fa_version", return_value=version
+                ),
+                mock.patch.object(
+                    sink_impl.paddle.nn.functional,
+                    "flashmask_attention",
+                    function,
+                ),
+            ):
+                actual = sink_impl._flashmask_attention_forward_dispatch(
+                    self.q,
+                    self.k,
+                    self.v,
+                    self.indices,
+                    dropout=0.0,
+                    causal=True,
+                    training=False,
+                    softmax_scale=0.25,
+                )
+            self.assertIs(actual[0], self.out)
+            self.assertIs(actual[1], self.lse)
+            kwargs = function.call_args.kwargs
+            self.assertIs(kwargs["startend_row_indices"], self.indices)
+            self.assertEqual("softmax_scale" in kwargs, version == 3)
+
+        with (
+            mock.patch.object(sink_impl, "_get_fa_version", return_value=3),
+            self.assertRaisesRegex(NotImplementedError, "dropout"),
+        ):
+            sink_impl._flashmask_attention_forward_dispatch(
+                self.q, self.k, self.v, self.indices, dropout=0.1
+            )
+
+    def test_forward_fa4_and_unsupported(self):
+        from paddlefleet.transformer import sink_impl
+
+        kernel = mock.Mock(return_value=(self.out, self.lse))
+        with (
+            mock.patch.object(sink_impl, "_get_fa_version", return_value=4),
+            mock.patch.object(sink_impl, "_flash_attn_fwd", kernel),
+        ):
+            actual = sink_impl._flashmask_attention_forward_dispatch(
+                self.q, self.k, self.v, self.indices, softmax_scale=0.3
+            )
+        self.assertIs(actual[0], self.out)
+        self.assertIs(actual[1], self.lse)
+        self.assertIs(
+            kernel.call_args.kwargs["startend_row_indices"], self.indices
+        )
+
+        with (
+            mock.patch.object(sink_impl, "_get_fa_version", return_value=7),
+            self.assertRaisesRegex(ValueError, "Unsupported"),
+        ):
+            sink_impl._flashmask_attention_forward_dispatch(
+                self.q, self.k, self.v, self.indices
+            )
+
+    def test_backward_fa2_mock(self):
+        from paddlefleet.transformer import sink_impl
+
+        grads = (self.q + 1, self.k + 2, self.v + 3)
+        op = mock.Mock(return_value=grads)
+        with (
+            mock.patch.object(sink_impl, "_get_fa_version", return_value=2),
+            mock.patch.object(
+                sink_impl,
+                "_C_ops",
+                SimpleNamespace(flashmask_attention_grad=op),
+            ),
+            mock.patch.object(
+                sink_impl.paddle.base,
+                "libpaddle",
+                SimpleNamespace(
+                    pir=SimpleNamespace(
+                        ops=SimpleNamespace(flashmask_attention_grad=object())
+                    )
+                ),
+            ),
+        ):
+            actual = sink_impl._flashmask_attention_backward_dispatch(
+                self.grad,
+                self.q,
+                self.k,
+                self.v,
+                self.out,
+                self.lse,
+                self.indices,
+            )
+        for returned, expected in zip(actual, grads):
+            self.assertIs(returned, expected)
+        self.assertIs(op.call_args.args[3], self.indices)
+
+    def test_backward_fa3_signature_variants(self):
+        from paddlefleet.transformer import sink_impl
+
+        grads = (self.q + 1, self.k + 2, self.v + 3)
+        for parameter, expected_count in (
+            ("group", 12),
+            ("block_mask", 10),
+            ("legacy", 9),
+        ):
+            op = mock.Mock(return_value=grads)
+            parameters = {} if parameter == "legacy" else {parameter: object()}
+            with (
+                self.subTest(parameter=parameter),
+                mock.patch.object(sink_impl, "_get_fa_version", return_value=3),
+                mock.patch.object(
+                    sink_impl,
+                    "_C_ops",
+                    SimpleNamespace(flashmask_attention_v2_grad=op),
+                ),
+                mock.patch.object(
+                    sink_impl.paddle.base,
+                    "libpaddle",
+                    SimpleNamespace(
+                        pir=SimpleNamespace(
+                            ops=SimpleNamespace(
+                                flashmask_attention_v2_grad=object()
+                            )
+                        )
+                    ),
+                ),
+                mock.patch.object(
+                    sink_impl.inspect,
+                    "signature",
+                    return_value=SimpleNamespace(parameters=parameters),
+                ),
+            ):
+                actual = sink_impl._flashmask_attention_backward_dispatch(
+                    self.grad,
+                    self.q,
+                    self.k,
+                    self.v,
+                    self.out,
+                    self.lse,
+                    self.indices,
+                    softmax_scale=0.4,
+                )
+            for returned, expected in zip(actual, grads):
+                self.assertIs(returned, expected)
+            self.assertEqual(len(op.call_args.args), expected_count)
+            scale_index = -4 if parameter == "group" else -2
+            self.assertEqual(op.call_args.args[scale_index], 0.4)
+
+    def test_backward_fa4_builds_flashmask_info(self):
+        from paddlefleet.transformer import sink_impl
+
+        info = object()
+        info_factory = mock.Mock(return_value=info)
+        kernel = mock.Mock(return_value=(self.q, self.k, self.v))
+        with (
+            mock.patch.object(sink_impl, "_get_fa_version", return_value=4),
+            mock.patch.object(sink_impl, "_FlashMaskInfoPaddle", info_factory),
+            mock.patch.object(sink_impl, "_flash_attn_bwd", kernel),
+            mock.patch.object(
+                sink_impl.paddle,
+                "get_flags",
+                return_value={"FLAGS_cudnn_deterministic": False},
+            ),
+        ):
+            sink_impl._flashmask_attention_backward_dispatch(
+                self.grad,
+                self.q,
+                self.k,
+                self.v,
+                self.out,
+                self.lse,
+                self.indices,
+                causal=True,
+            )
+        info_factory.assert_called_once_with(
+            startend_row_indices=self.indices, is_causal=True
+        )
+        self.assertIs(kernel.call_args.args[6], info)
+
+
+class TestFlashMaskSinkPyLayerMocked(unittest.TestCase):
+    """Exercise sink correction and gradients with fake contexts and kernels."""
+
+    class FakeContext:
+        def save_for_backward(self, *values):
+            self.values = values
+
+        def saved_tensor(self):
+            return self.values
+
+    def setUp(self):
+        self.q = paddle.zeros([1, 2, 4, 2], dtype=paddle.float32)
+        self.k = paddle.ones([1, 2, 2, 2], dtype=paddle.float32)
+        self.v = paddle.full([1, 2, 2, 2], 2.0, dtype=paddle.float32)
+        self.sink = paddle.zeros([4], dtype=paddle.float32)
+        self.sink.stop_gradient = False
+
+    def test_forward_sink_correction_gqa_and_saved_state(self):
+        from paddlefleet.transformer import sink_impl
+
+        raw = paddle.ones_like(self.q)
+        lse = paddle.full([1, 4, 3], math.log(2.0), dtype=paddle.float32)
+        ctx = self.FakeContext()
+        dispatch = mock.Mock(return_value=(raw, lse))
+        with mock.patch.object(
+            sink_impl, "_flash_attention_forward_dispatch", dispatch
+        ):
+            result = sink_impl.FlashMaskSinkPyLayer.forward(
+                ctx,
+                self.q,
+                self.k,
+                self.v,
+                self.sink,
+                None,
+                dropout=0.2,
+                causal=True,
+                training=False,
+                softmax_scale=0.3,
+            )
+        np.testing.assert_allclose(result.numpy(), np.full(result.shape, 2 / 3))
+        self.assertEqual(list(dispatch.call_args.args[1].shape), [1, 2, 4, 2])
+        self.assertEqual(list(dispatch.call_args.args[2].shape), [1, 2, 4, 2])
+        self.assertEqual(ctx.num_key_value_groups, 2)
+        self.assertEqual(ctx.softmax_scale, 0.3)
+        self.assertEqual(list(ctx.values[6].shape), [1, 4, 2])
+
+    def test_backward_merges_gqa_and_computes_sink_gradient(self):
+        from paddlefleet.transformer import sink_impl
+
+        ctx = self.FakeContext()
+        with mock.patch.object(
+            sink_impl,
+            "_flash_attention_forward_dispatch",
+            return_value=(
+                paddle.ones_like(self.q),
+                paddle.full([1, 4, 2], math.log(2.0)),
+            ),
+        ):
+            output = sink_impl.FlashMaskSinkPyLayer.forward(
+                ctx, self.q, self.k, self.v, self.sink, None
+            )
+
+        repeated_k = paddle.arange(16, dtype=paddle.float32).reshape(
+            [1, 2, 4, 2]
+        )
+        repeated_v = repeated_k + 20
+        kernel = mock.Mock(
+            return_value=(paddle.ones_like(self.q), repeated_k, repeated_v)
+        )
+        with mock.patch.object(
+            sink_impl, "_flash_attention_backward_dispatch", kernel
+        ):
+            grads = sink_impl.FlashMaskSinkPyLayer.backward(
+                ctx, paddle.ones_like(output)
+            )
+        self.assertEqual(len(grads), 4)
+        np.testing.assert_array_equal(
+            grads[1].numpy(), repeated_k.numpy().reshape(1, 2, 2, 2, 2).sum(3)
+        )
+        np.testing.assert_array_equal(
+            grads[2].numpy(), repeated_v.numpy().reshape(1, 2, 2, 2, 2).sum(3)
+        )
+        np.testing.assert_allclose(
+            grads[3].numpy(), np.full([4], -8 / 9), atol=1e-6
+        )
+        self.assertEqual(list(kernel.call_args.args[2].shape), [1, 2, 4, 2])
+
+    def test_flashmask_forward_backward_and_fixed_sink(self):
+        from paddlefleet.transformer import sink_impl
+
+        indices = paddle.zeros([1, 1, 2, 1], dtype=paddle.int32)
+        ctx = self.FakeContext()
+        self.sink.stop_gradient = True
+        forward = mock.Mock(
+            return_value=(
+                paddle.ones_like(self.q),
+                paddle.zeros([1, 4, 2], dtype=paddle.float32),
+            )
+        )
+        with mock.patch.object(
+            sink_impl, "_flashmask_attention_forward_dispatch", forward
+        ):
+            output = sink_impl.FlashMaskSinkPyLayer.forward(
+                ctx, self.q, self.k, self.v, self.sink, indices
+            )
+        backward = mock.Mock(
+            return_value=(
+                paddle.ones_like(self.q),
+                paddle.ones_like(self.k),
+                paddle.ones_like(self.v),
+            )
+        )
+        with mock.patch.object(
+            sink_impl, "_flashmask_attention_backward_dispatch", backward
+        ):
+            grads = sink_impl.FlashMaskSinkPyLayer.backward(
+                ctx, paddle.ones_like(output)
+            )
+        self.assertEqual(len(grads), 5)
+        self.assertIsNone(grads[3])
+        self.assertIs(grads[4], None)
+        self.assertIs(forward.call_args.args[3], indices)
+        self.assertIs(backward.call_args.args[6], indices)
+
+    def test_forward_validation(self):
+        from paddlefleet.transformer import sink_impl
+
+        cases = (
+            (
+                (self.q.reshape([2, 4, 2]), self.k, self.v, self.sink),
+                "Query must be 4D",
+            ),
+            (
+                (self.q, self.k, self.v, self.sink.reshape([2, 2])),
+                "Sink must be 1D",
+            ),
+            ((self.q, self.k, self.v[..., :1], self.sink), "value head_dim"),
+            (
+                (self.q, self.k[:, :, :1], self.v, self.sink),
+                "same number of heads",
+            ),
+            (
+                (self.q, self.k, self.v, paddle.zeros([3])),
+                "Sink parameter size",
+            ),
+        )
+        for args, message in cases:
+            with (
+                self.subTest(message=message),
+                self.assertRaisesRegex((AssertionError, ValueError), message),
+            ):
+                sink_impl.FlashMaskSinkPyLayer.forward(
+                    self.FakeContext(), *args, None
+                )
+
+        indices = paddle.zeros([1, 1, 2, 1], dtype=paddle.int32)
+        with self.assertRaisesRegex(AssertionError, "dense mask"):
+            sink_impl.FlashMaskSinkPyLayer.forward(
+                self.FakeContext(),
+                self.q,
+                self.k,
+                self.v,
+                self.sink,
+                indices,
+                attention_mask=paddle.zeros([1]),
+            )
+
+    def test_sink_attention_forward_forwards_arguments(self):
+        from paddlefleet.transformer import sink_impl
+
+        indices = paddle.zeros([1, 1, 2, 1], dtype=paddle.int32)
+        apply = mock.Mock(return_value="result")
+        with mock.patch.object(sink_impl.FlashMaskSinkPyLayer, "apply", apply):
+            result = sink_impl.sink_attention_forward(
+                self.q,
+                self.k,
+                self.v,
+                self.sink,
+                attention_mask="mask",
+                startend_row_indices=indices,
+                dropout_p=0.2,
+                softmax_scale=0.7,
+                causal=True,
+                training=False,
+            )
+        self.assertEqual(result, "result")
+        self.assertEqual(
+            apply.call_args.args, (self.q, self.k, self.v, self.sink, indices)
+        )
+        self.assertEqual(
+            apply.call_args.kwargs,
+            {
+                "attention_mask": "mask",
+                "dropout": 0.2,
+                "causal": True,
+                "return_softmax": False,
+                "training": False,
+                "softmax_scale": 0.7,
+            },
+        )
 
 
 @unittest.skipUnless(_SINK_AVAILABLE, _SKIP_REASON)
@@ -881,47 +1807,6 @@ class TestDotProductAttentionFA3SinkForward(unittest.TestCase):
             self.assertIsNotNone(v.grad)
             self.assertIsNotNone(attn.softmax_offset.grad)
             self.assertEqual(attn.softmax_offset.grad.dtype, paddle.bfloat16)
-
-    def test_forward_learnable_sink_value_head_dim_larger_raises(self):
-        from paddlefleet.transformer.dot_product_attention import (
-            DotProductAttention,
-        )
-        from paddlefleet.transformer.enums import AttnMaskType
-
-        with _flash_attn_version(3):
-            paddle.seed(SEED)
-            b, s, h = 2, 64, 4
-            qk_dim, v_dim = 128, 192
-            config = _make_config(
-                softmax_type="learnable",
-                num_attention_heads=h,
-                head_dim=qk_dim,
-                hidden_size=h * qk_dim,
-            )
-            attn = DotProductAttention(
-                config=config,
-                layer_number=1,
-                attn_mask_type=AttnMaskType.causal,
-                attention_type="self",
-                k_channels=qk_dim,
-                v_channels=v_dim,
-            )
-
-            q = paddle.randn([b, s, h, qk_dim], dtype=DTYPE)
-            k = paddle.randn([b, s, h, qk_dim], dtype=DTYPE)
-            v = paddle.randn([b, s, h, v_dim], dtype=DTYPE)
-            with self.assertRaisesRegex(
-                ValueError,
-                "requires value head_dim to match query/key head_dim",
-            ):
-                attn(
-                    query=q,
-                    key=k,
-                    value=v,
-                    attention_mask=None,
-                    attn_mask_startend_row_indices=None,
-                    attn_mask_type=AttnMaskType.causal,
-                )
 
     def test_decode_shape_raises_for_fa3_sink(self):
         from paddlefleet.transformer.sink_impl import prepare_fa3_sink_attention


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
新增 FA3 attention sink 实现，并在 DotProductAttention 的 SDPA/FlashMask 路径中按条件分发到 FA3 sink 分支

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否