### PR TITLE
[release/0.3] Optimize MTP distillation loss with boundary-token P2P exchange

### DIFF
--- a/src/paddlefleet/context_parallel_utils.py
+++ b/src/paddlefleet/context_parallel_utils.py
@@ -1946,3 +1946,117 @@ def flashmask_attention_cp(
     else:
         raise ValueError(f"invalid cp_balance_mode: {mode}")
     return output
+
+
+# ===================== MTP Distillation Loss Shift Layer =====================
+
+
+def _mtp_distillation_loss_shift_forward(tensor, nextn, group):
+    ops = []
+
+    bs, _, hidden = tensor.shape
+    rank = group.rank
+    cp_size = group.world_size
+
+    if rank > 0:
+        send_rank = group.ranks[rank - 1]
+        send_window = tensor[:, :nextn].contiguous()
+        ops.append(dist.P2POp(dist.isend, send_window, send_rank, group))
+
+    if rank < cp_size - 1:
+        recv_rank = group.ranks[rank + 1]
+        recv_window = paddle.empty([bs, nextn, hidden], tensor.dtype)
+        ops.append(dist.P2POp(dist.irecv, recv_window, recv_rank, group))
+    else:
+        recv_window = paddle.zeros([bs, nextn, hidden], tensor.dtype)
+
+    _wait_all(dist.batch_isend_irecv(ops))
+
+    tensor = paddle.concat([tensor[:, 1:], recv_window], axis=1)
+    return tensor
+
+
+def _mtp_distillation_loss_shift_backward(tensor, nextn, group):
+    ops = []
+
+    bs, _, hidden = tensor.shape
+    rank = group.rank
+    cp_size = group.world_size
+
+    if rank < cp_size - 1:
+        send_rank = group.ranks[rank + 1]
+        send_window = tensor[:, -nextn:].contiguous()
+        ops.append(dist.P2POp(dist.isend, send_window, send_rank, group))
+
+    if rank > 0:
+        recv_rank = group.ranks[rank - 1]
+        recv_window = paddle.empty([bs, nextn, hidden], tensor.dtype)
+        ops.append(dist.P2POp(dist.irecv, recv_window, recv_rank, group))
+    else:
+        recv_window = paddle.zeros([bs, nextn, hidden], tensor.dtype)
+
+    _wait_all(dist.batch_isend_irecv(ops))
+
+    # output has shape [bs, seq_len, hidden]
+    output = paddle.nn.functional.pad(
+        tensor[:, :-nextn], [0, 0, 1], mode="constant", value=0
+    )
+    output[:, :nextn] += recv_window
+    return output
+
+
+class MTPDistillationLossShift(PyLayer):
+    """
+    Shift LMHead logits for MTP distillation loss computation.
+
+    Given a local input tensor of shape [B, S, H] on each rank of a CP group, this function is
+    conceptually equivalent to first all-gathering the global tensor of shape [B, S*cp_size, H]
+    and then returning the slice [:, S*cp_rank+1 : S*(cp_rank+1)+nextn, :] on each rank.
+    In practice, only the boundary tokens are exchanged between neighboring ranks instead of
+    performing a full gather.
+    """
+
+    @staticmethod
+    def forward(
+        ctx, tensor, num_nextn_predict_layers, mode="contiguous_allgather"
+    ):
+        hcg = fleet.get_hybrid_communicate_group()
+        group = hcg.get_context_parallel_group()
+
+        assert len(tensor.shape) == 3, (
+            f"Expect input of shape [B, S, H], got {tensor.shape}"
+        )
+        batch_size, seq_len, hidden_size = tensor.shape
+        assert seq_len > num_nextn_predict_layers, (
+            "The local seq_len per-rank should be greater than nextn, "
+            f"got {seq_len=} and {num_nextn_predict_layers=}"
+        )
+        assert num_nextn_predict_layers > 0, (
+            f"num_nextn_predict_layers must be greater than 0, got {num_nextn_predict_layers}"
+        )
+        assert mode == "contiguous_allgather", (
+            f"MTPDistillationLossShift only supports 'contiguous_allgather' mode, got {mode}"
+        )
+
+        ctx.group = group
+        ctx.batch_size = batch_size
+        ctx.seq_len = seq_len
+        ctx.hidden_size = hidden_size
+        ctx.num_nextn_predict_layers = num_nextn_predict_layers
+
+        return _mtp_distillation_loss_shift_forward(
+            tensor, num_nextn_predict_layers, group
+        )
+
+    @staticmethod
+    def backward(ctx, output_grad):
+        output_grad = output_grad.reshape(
+            [
+                ctx.batch_size,
+                ctx.seq_len + ctx.num_nextn_predict_layers - 1,
+                ctx.hidden_size,
+            ]
+        )
+        return _mtp_distillation_loss_shift_backward(
+            output_grad, ctx.num_nextn_predict_layers, ctx.group
+        )

--- a/src/paddlefleet/models/common/language_loss/language_loss.py
+++ b/src/paddlefleet/models/common/language_loss/language_loss.py
@@ -31,6 +31,7 @@ from paddle.distributed.fleet.utils.sequence_parallel_utils import AllGatherOp
 from paddlefleet.context_parallel_utils import (
     ContextParallelGatherOp,
     ContextParallelScatterOp,
+    MTPDistillationLossShift,
 )
 from paddlefleet.parallel_state import (
     get_context_parallel_world_size,
@@ -557,11 +558,19 @@ class LanguageLoss(FleetLayer):
                 else:
                     target_p_self_op_dist = nn.Softmax(axis=2)(logits[0])
                 if get_context_parallel_world_size() > 1:
-                    target_p_self_op_dist = ContextParallelGatherOp.apply(
-                        target_p_self_op_dist,
-                        axis=1,
-                        mode=self.config.cp_balance_mode,
-                    )
+                    cp_balance_mode = self.config.cp_balance_mode
+                    if cp_balance_mode == "contiguous_allgather":
+                        target_p_self_op_dist = MTPDistillationLossShift.apply(
+                            target_p_self_op_dist,
+                            self.config.num_nextn_predict_layers,
+                            mode=cp_balance_mode,
+                        )
+                    else:
+                        target_p_self_op_dist = ContextParallelGatherOp.apply(
+                            target_p_self_op_dist,
+                            axis=1,
+                            mode=cp_balance_mode,
+                        )
 
                 def padding(tensor, left=False, pad_len=1):
                     zeropadding = paddle.zeros_like(tensor[:, -pad_len:, :])
@@ -594,18 +603,27 @@ class LanguageLoss(FleetLayer):
                                 prediction_scores_cur_depth
                             )
 
-                        target_p = target_p_self_op_dist[
-                            :, (depth + 1) :, :
-                        ].clone()
-                        target_p = padding(
-                            target_p, left=False, pad_len=depth + 1
-                        )
-                        if get_context_parallel_world_size() > 1:
-                            target_p = ContextParallelScatterOp.apply(
-                                target_p,
-                                axis=1,
-                                mode=self.config.cp_balance_mode,
+                        if not (
+                            get_context_parallel_world_size() > 1
+                            and cp_balance_mode == "contiguous_allgather"
+                        ):
+                            target_p = target_p_self_op_dist[
+                                :, (depth + 1) :, :
+                            ].clone()
+                            target_p = padding(
+                                target_p, left=False, pad_len=depth + 1
                             )
+                        if get_context_parallel_world_size() > 1:
+                            if cp_balance_mode == "contiguous_allgather":
+                                target_p = target_p_self_op_dist[
+                                    :, depth : depth + out_logp.shape[1]
+                                ]
+                            else:
+                                target_p = ContextParallelScatterOp.apply(
+                                    target_p,
+                                    axis=1,
+                                    mode=cp_balance_mode,
+                                )
                         plogp = target_p * out_logp
 
                         lossmask = lossmask[..., None]

--- a/tests/multi_card_tests/tensor_parallel/test_mtp_distillation_loss_cp.py
+++ b/tests/multi_card_tests/tensor_parallel/test_mtp_distillation_loss_cp.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import unittest
+
+sys.path.insert(
+    0,
+    os.path.dirname(
+        os.path.dirname(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        )
+    ),
+)
+
+import numpy as np
+import paddle
+
+from paddlefleet.context_parallel_utils import (
+    ContextParallelGatherOp,
+    ContextParallelScatterOp,
+)
+from paddlefleet.models.common.language_loss.language_loss import LanguageLoss
+from paddlefleet.transformer.transformer_config import TransformerConfig
+from tests.multi_card_tests.tensor_parallel.test_utilities import Utils
+
+
+class TestMTPDistillationLossCP(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        world_size = 4
+        Utils.initialize_model_parallel(
+            context_parallel_size=world_size,
+            expert_parallel_size=world_size,
+            sharding_parallel_size=world_size,
+        )
+
+    def setUp(self):
+        paddle.seed(Utils.rank)
+
+    def test_forward_backward(self):
+        batch_size = 2
+        seq_len = 256
+        vocab_size = 128
+        nextn = 2
+
+        config = TransformerConfig(
+            context_parallel_size=Utils.world_size,
+            num_nextn_predict_layers=nextn,
+            params_dtype=paddle.bfloat16,
+            mtp_distillation_loss=True,
+            experimental_dataflow=True,
+            cp_balance_mode="dualchunk_allgather",
+        )
+
+        model = LanguageLoss(config)
+
+        logits_ref, logits_tgt = [], []
+        for i in range(1 + nextn):
+            t = paddle.randn(
+                [batch_size, seq_len, vocab_size], dtype="bfloat16"
+            )
+            t.stop_gradient = False
+            logits_ref.append(t)
+            t = t.detach()
+            t.stop_gradient = False
+            logits_tgt.append(t)
+
+        labels = paddle.randint(
+            vocab_size,
+            shape=[batch_size, seq_len * Utils.world_size + nextn],
+            dtype="int64",
+        )
+
+        # Run reference (Gather-Shift-Scatter)
+        # 注：下面实际走的是 dualchunk_allgather 的路径，但是通过 mock 让分布式通信使用
+        # contiguous_allgather 的布局，从而与 target 对齐
+        try:
+            gather_apply = ContextParallelGatherOp.apply
+            scatter_apply = ContextParallelScatterOp.apply
+
+            ContextParallelGatherOp.apply = (
+                lambda tensor, axis, mode: gather_apply(
+                    tensor, axis, mode="contiguous_allgather"
+                )
+            )
+            ContextParallelScatterOp.apply = (
+                lambda tensor, axis, mode: scatter_apply(
+                    tensor, axis, mode="contiguous_allgather"
+                )
+            )
+
+            loss_ref = model(logits_ref, labels)
+        finally:
+            del ContextParallelGatherOp.apply
+            del ContextParallelScatterOp.apply
+
+        loss_ref.backward()
+
+        # Run target (MTPDistillationLossShift)
+        model.config.cp_balance_mode = "contiguous_allgather"
+        loss_tgt = model(logits_tgt, labels)
+        loss_tgt.backward()
+
+        # Compare
+        np.testing.assert_allclose(loss_ref, loss_tgt, atol=0, rtol=0)
+        for ref, tgt in zip(logits_ref, logits_tgt):
+            np.testing.assert_allclose(
+                ref.grad.float(), tgt.grad.float(), atol=0, rtol=0
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
Communication Library

### PR Types
Performance

### Description
实现了 MTP Distillation Loss 的无冗余通信的 CP

原来的实现是先做 cp_group 内的 gather，然后 shift，再 scatter，这个 gather 会产生一个未 cp 切分的中间变量，失去了 cp 的意义，长文下很容易 OOM；本 PR 则只交换 shift 的边界 token，不会产生中间变量，也不会冗余发送

优化后的分支仅对 cp_balance_mode == "contiguous_allgather" 生效，原来的 dualchunk 布局依然支持，但是就没有优化，可能会 OOM

由于本 PR 只是对数据搬运的优化，不涉及 reduce 等，因此无任何精度 diff，单测保证 atol=0 rtol=0

### 是否引起精度变化
否

Cherry-pick of #1405 to `release/0.3`.

Merged in dev: #1405  <!-- For pass CI -->