### PR TITLE
[Performance] Optimize Ulysses all-to-all with a fused Triton permute

### DIFF
--- a/src/paddlefleet/context_parallel_utils.py
+++ b/src/paddlefleet/context_parallel_utils.py
@@ -1695,12 +1695,66 @@ def _ulysses_single_all_to_all(
     return output
 
 
+# ---------------------------------------------------------------------------
+# Fused Ulysses all-to-all permute (Triton).
+#
+# For the production path (batch_dim_idx=0), the pre/post reshape+transpose+
+# .contiguous() around the all-to-all are pure data movement whose cost (two
+# physical copies) rivals the communication itself. A single Triton kernel
+# fuses reshape+transpose+contiguous into one coalesced copy, and the post
+# output reuses the send buffer for a lower peak. The kernels live in
+# paddlefleet.triton_ops.ulysses_alltoall_fused; the thin wrappers below keep
+# stable module-level names. A cheap non-Triton guard runs first so that
+# unsupported layouts, CPU/non-CUDA inputs, or Triton-less environments fall
+# back to the reference _ulysses_single_all_to_all path; the Triton import is
+# deferred to call time and is itself guarded.
+# ---------------------------------------------------------------------------
+def _ulysses_fused_supported(scatter_idx, batch_dim_idx, input):
+    """Whether the fused Triton path can handle this call.
+
+    Only batch_dim_idx=0 with a 4-D CUDA input is fused. Everything else
+    (other layouts, CPU/non-CUDA inputs, or an environment where the Triton
+    op cannot be imported) returns False so the caller keeps using the
+    reference reshape/permute all-to-all.
+    """
+    if (
+        batch_dim_idx != 0
+        or len(input.shape) != 4
+        or not paddle.is_compiled_with_cuda()
+        or not input.place.is_gpu_place()
+    ):
+        return False
+
+    try:
+        from paddlefleet.triton_ops.ulysses_alltoall_fused import (
+            ulysses_alltoall_fused_supported,
+        )
+    except ImportError:
+        return False
+
+    return ulysses_alltoall_fused_supported(scatter_idx, batch_dim_idx, input)
+
+
+def _ulysses_single_all_to_all_fused(input, scatter_idx, group):
+    """Fused seq<->head all-to-all for batch_dim_idx=0 (bit-exact, 2x peak)."""
+    from paddlefleet.triton_ops.ulysses_alltoall_fused import (
+        ulysses_single_all_to_all_fused,
+    )
+
+    return ulysses_single_all_to_all_fused(input, scatter_idx, group)
+
+
 class UlyssesAlltoAll(PyLayer):
     """
     Ulysses All-to-All for sequence parallelism.
 
     Forward performs all-to-all with the given scatter/gather indices.
     Backward performs the inverse all-to-all (swap scatter and gather indices).
+
+    When the layout matches the production path (batch_dim_idx=0, 4-D input), a
+    fused Triton kernel replaces the reshape+transpose+.contiguous() permutes
+    for lower latency and peak memory. Otherwise it falls back to the reference
+    reshape/permute path. Both are bit-exact.
     """
 
     @staticmethod
@@ -1709,12 +1763,22 @@ class UlyssesAlltoAll(PyLayer):
         ctx.gather_idx = gather_idx
         ctx.batch_dim_idx = batch_dim_idx
         ctx.group = group
+        if _ulysses_fused_supported(scatter_idx, batch_dim_idx, input):
+            return _ulysses_single_all_to_all_fused(input, scatter_idx, group)
         return _ulysses_single_all_to_all(
             input, scatter_idx, gather_idx, batch_dim_idx, group
         )
 
     @staticmethod
     def backward(ctx, grad_output):
+        # Inverse a2a swaps scatter/gather; the fused check uses the backward
+        # scatter index (ctx.gather_idx).
+        if _ulysses_fused_supported(
+            ctx.gather_idx, ctx.batch_dim_idx, grad_output
+        ):
+            return _ulysses_single_all_to_all_fused(
+                grad_output, ctx.gather_idx, ctx.group
+            )
         return _ulysses_single_all_to_all(
             grad_output,
             ctx.gather_idx,

--- a/src/paddlefleet/context_parallel_utils.py
+++ b/src/paddlefleet/context_parallel_utils.py
@@ -1729,7 +1729,10 @@ def _ulysses_fused_supported(scatter_idx, batch_dim_idx, input):
         from paddlefleet.triton_ops.ulysses_alltoall_fused import (
             ulysses_alltoall_fused_supported,
         )
-    except ImportError:
+    except (ImportError, OSError):
+        # ImportError: Triton not installed. OSError: Triton present but its
+        # binary deps fail to load (e.g. shared library errors). Either way,
+        # fall back to the reference reshape/permute path.
         return False
 
     return ulysses_alltoall_fused_supported(scatter_idx, batch_dim_idx, input)

--- a/src/paddlefleet/triton_ops/__init__.py
+++ b/src/paddlefleet/triton_ops/__init__.py
@@ -24,6 +24,10 @@ from .ue8m0_scale_transpose_fusion import (
     FuseStackUe8m0ScaleTransposeTriton,
     fuse_stack_ue8m0_scale_transpose,
 )
+from .ulysses_alltoall_fused import (
+    ulysses_alltoall_fused_supported,
+    ulysses_single_all_to_all_fused,
+)
 
 __all__ = [
     "RMSNormFusionTriton",
@@ -35,4 +39,6 @@ __all__ = [
     "fused_apply_mla_rope_for_kv",
     "fused_apply_mla_rope_for_q",
     "fused_apply_mla_rope_inplace",
+    "ulysses_alltoall_fused_supported",
+    "ulysses_single_all_to_all_fused",
 ]

--- a/src/paddlefleet/triton_ops/ulysses_alltoall_fused.py
+++ b/src/paddlefleet/triton_ops/ulysses_alltoall_fused.py
@@ -43,7 +43,7 @@ import triton.language as tl
 
 @enable_compat_on_triton_kernel
 @triton.jit
-def _seq2head_pre_kernel(
+def _seq2head_pre_kernel(  # pragma: no cover
     x_ptr, out_ptr, P, b, Sloc, Hloc, D, SEG, BLOCK: tl.constexpr
 ):
     # seq->head pre: send[dst, bb, s, hl, dd] = x[bb, s, dst*Hloc+hl, dd].
@@ -66,7 +66,7 @@ def _seq2head_pre_kernel(
 
 @enable_compat_on_triton_kernel
 @triton.jit
-def _seq2head_post_kernel(
+def _seq2head_post_kernel(  # pragma: no cover
     recv_ptr, out_ptr, P, b, Sloc, Hloc, D, SEG, BLOCK: tl.constexpr
 ):
     # seq->head post: out[bb, src*Sloc+s, hl, dd] = recv[src, bb, s, hl, dd].
@@ -87,7 +87,7 @@ def _seq2head_post_kernel(
 
 @enable_compat_on_triton_kernel
 @triton.jit
-def _head2seq_pre_kernel(
+def _head2seq_pre_kernel(  # pragma: no cover
     g_ptr, out_ptr, P, b, Sloc, Hloc, D, SEG, BLOCK: tl.constexpr
 ):
     # head->seq pre: send[dst, bb, s, hl, dd] = g[bb, dst*Sloc+s, hl, dd].
@@ -108,7 +108,7 @@ def _head2seq_pre_kernel(
 
 @enable_compat_on_triton_kernel
 @triton.jit
-def _head2seq_post_kernel(
+def _head2seq_post_kernel(  # pragma: no cover
     recv_ptr, out_ptr, P, b, Sloc, Hloc, D, SEG, BLOCK: tl.constexpr
 ):
     # head->seq post: out[bb, s, src*Hloc+hl, dd] = recv[src, bb, s, hl, dd].

--- a/src/paddlefleet/triton_ops/ulysses_alltoall_fused.py
+++ b/src/paddlefleet/triton_ops/ulysses_alltoall_fused.py
@@ -153,14 +153,21 @@ def ulysses_single_all_to_all_fused(input, scatter_idx, group):
 
     if scatter_idx >= 2:
         b, Sloc, H, D = input.shape
-        assert H % P == 0
+        if H % P != 0:
+            raise ValueError(
+                f"Number of heads ({H}) must be divisible by world size ({P})"
+            )
         Hloc = H // P
         pre_kernel = _seq2head_pre_kernel
         post_kernel = _seq2head_post_kernel
         out_shape = [b, P * Sloc, Hloc, D]
     else:
         b, Nglob, Hloc, D = input.shape
-        assert Nglob % P == 0
+        if Nglob % P != 0:
+            raise ValueError(
+                f"Global sequence length ({Nglob}) must be divisible by "
+                f"world size ({P})"
+            )
         Sloc = Nglob // P
         H = P * Hloc
         pre_kernel = _head2seq_pre_kernel

--- a/src/paddlefleet/triton_ops/ulysses_alltoall_fused.py
+++ b/src/paddlefleet/triton_ops/ulysses_alltoall_fused.py
@@ -1,0 +1,189 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Fused Triton permute for the Ulysses all-to-all.
+
+For the production context-parallel path (batch_dim_idx=0), the reshape+
+transpose+.contiguous() permutes around the all-to-all are pure data movement
+whose cost (two physical copies) rivals the communication itself. The permute
+only reorders the leading dims (batch, seq, rank) while the trailing (head,
+dim) stay contiguous, so each element-block [Hloc*D] is a contiguous->
+contiguous copy with a remapped base offset. A single Triton kernel fuses
+reshape+transpose+contiguous into one coalesced copy, and the post output
+reuses the send buffer so peak memory stays at 1x send + 1x recv (lower than
+the reference permute path, which needs an extra .contiguous() buffer).
+
+Only batch_dim_idx=0 with a 4-D input is fused; callers fall back to the
+reference reshape/permute path for other layouts. Both are bit-exact.
+"""
+
+import paddle
+from paddle import distributed as dist
+
+from .utils import enable_compat_on_triton_kernel, is_torch_compat_available
+
+if is_torch_compat_available():
+    paddle.enable_compat(scope={"triton"})
+
+import triton
+import triton.language as tl
+
+
+@enable_compat_on_triton_kernel
+@triton.jit
+def _seq2head_pre_kernel(
+    x_ptr, out_ptr, P, b, Sloc, Hloc, D, SEG, BLOCK: tl.constexpr
+):
+    # seq->head pre: send[dst, bb, s, hl, dd] = x[bb, s, dst*Hloc+hl, dd].
+    # grid = (P*b*Sloc, cdiv(SEG, BLOCK)); .to(int64) guards >2^31 offsets.
+    pid = tl.program_id(0).to(tl.int64)
+    blk = tl.program_id(1)
+    s = pid % Sloc
+    tmp = pid // Sloc
+    bb = tmp % b
+    dst = tmp // b
+    offs = blk * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < SEG
+    H = P * Hloc
+    # offs walks [Hloc, D] contiguously; src head = dst*Hloc + offs//D.
+    src_off = ((bb * Sloc + s) * H + dst * Hloc) * D + offs
+    val = tl.load(x_ptr + src_off, mask=mask, other=0.0)
+    dst_base = (((dst * b + bb) * Sloc + s) * Hloc) * D
+    tl.store(out_ptr + dst_base + offs, val, mask=mask)
+
+
+@enable_compat_on_triton_kernel
+@triton.jit
+def _seq2head_post_kernel(
+    recv_ptr, out_ptr, P, b, Sloc, Hloc, D, SEG, BLOCK: tl.constexpr
+):
+    # seq->head post: out[bb, src*Sloc+s, hl, dd] = recv[src, bb, s, hl, dd].
+    pid = tl.program_id(0).to(tl.int64)
+    blk = tl.program_id(1)
+    s = pid % Sloc
+    tmp = pid // Sloc
+    bb = tmp % b
+    src = tmp // b
+    offs = blk * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < SEG
+    src_base = (((src * b + bb) * Sloc + s) * Hloc) * D
+    val = tl.load(recv_ptr + src_base + offs, mask=mask, other=0.0)
+    seq = src * Sloc + s
+    dst_base = ((bb * (P * Sloc) + seq) * Hloc) * D
+    tl.store(out_ptr + dst_base + offs, val, mask=mask)
+
+
+@enable_compat_on_triton_kernel
+@triton.jit
+def _head2seq_pre_kernel(
+    g_ptr, out_ptr, P, b, Sloc, Hloc, D, SEG, BLOCK: tl.constexpr
+):
+    # head->seq pre: send[dst, bb, s, hl, dd] = g[bb, dst*Sloc+s, hl, dd].
+    pid = tl.program_id(0).to(tl.int64)
+    blk = tl.program_id(1)
+    s = pid % Sloc
+    tmp = pid // Sloc
+    bb = tmp % b
+    dst = tmp // b
+    offs = blk * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < SEG
+    gseq = dst * Sloc + s
+    src_off = ((bb * (P * Sloc) + gseq) * Hloc) * D + offs
+    val = tl.load(g_ptr + src_off, mask=mask, other=0.0)
+    dst_base = (((dst * b + bb) * Sloc + s) * Hloc) * D
+    tl.store(out_ptr + dst_base + offs, val, mask=mask)
+
+
+@enable_compat_on_triton_kernel
+@triton.jit
+def _head2seq_post_kernel(
+    recv_ptr, out_ptr, P, b, Sloc, Hloc, D, SEG, BLOCK: tl.constexpr
+):
+    # head->seq post: out[bb, s, src*Hloc+hl, dd] = recv[src, bb, s, hl, dd].
+    pid = tl.program_id(0).to(tl.int64)
+    blk = tl.program_id(1)
+    s = pid % Sloc
+    tmp = pid // Sloc
+    bb = tmp % b
+    src = tmp // b
+    offs = blk * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < SEG
+    src_base = (((src * b + bb) * Sloc + s) * Hloc) * D
+    val = tl.load(recv_ptr + src_base + offs, mask=mask, other=0.0)
+    hl = offs // D
+    dd = offs % D
+    H = P * Hloc
+    dst_off = ((bb * Sloc + s) * H + src * Hloc + hl) * D + dd
+    tl.store(out_ptr + dst_off, val, mask=mask)
+
+
+def ulysses_alltoall_fused_supported(_scatter_idx, batch_dim_idx, input):
+    """Whether the fused kernel path covers this layout.
+
+    Only batch_dim_idx=0 with a 4-D input is fused; other layouts must fall
+    back to the reference reshape/permute all-to-all. scatter_idx does not
+    affect support (both seq->head and head->seq are handled), so it is
+    accepted for signature symmetry but unused here.
+    """
+    return batch_dim_idx == 0 and len(input.shape) == 4
+
+
+def ulysses_single_all_to_all_fused(input, scatter_idx, group):
+    """Fused seq<->head all-to-all for batch_dim_idx=0.
+
+    scatter_idx >= 2: seq->head, input [b, Sloc, H, D] -> [b, P*Sloc, H//P, D].
+    scatter_idx <  2: head->seq, input [b, P*Sloc, Hloc, D] -> [b, Sloc, P*Hloc, D].
+    Bit-exact with the reference permute path; out reuses the send buffer so the
+    peak stays at 1x send + 1x recv (2x a single tensor).
+    """
+    P = dist.get_world_size(group)
+    input = input.contiguous()
+
+    if scatter_idx >= 2:
+        b, Sloc, H, D = input.shape
+        assert H % P == 0
+        Hloc = H // P
+        pre_kernel = _seq2head_pre_kernel
+        post_kernel = _seq2head_post_kernel
+        out_shape = [b, P * Sloc, Hloc, D]
+    else:
+        b, Nglob, Hloc, D = input.shape
+        assert Nglob % P == 0
+        Sloc = Nglob // P
+        H = P * Hloc
+        pre_kernel = _head2seq_pre_kernel
+        post_kernel = _head2seq_post_kernel
+        out_shape = [b, Sloc, H, D]
+
+    SEG = Hloc * D
+    BLOCK = min(triton.next_power_of_2(SEG), 4096)
+    grid = (P * b * Sloc, triton.cdiv(SEG, BLOCK))
+
+    send = paddle.empty([P, b, Sloc, Hloc, D], dtype=input.dtype)
+    pre_kernel[grid](input, send, P, b, Sloc, Hloc, D, SEG, BLOCK=BLOCK)
+
+    recv = paddle.empty_like(send)
+    dist.stream.alltoall_single(
+        recv.reshape([-1]),
+        send.reshape([-1]),
+        group=group,
+        use_calc_stream=True,
+    )
+
+    # send is no longer needed after comm; reuse its memory as out (same numel,
+    # post reads recv and writes out so there is no aliasing hazard).
+    out = send.reshape(out_shape)
+    post_kernel[grid](recv, out, P, b, Sloc, Hloc, D, SEG, BLOCK=BLOCK)
+    return out

--- a/tests/single_card_tests/test_ulysses_context_parallel.py
+++ b/tests/single_card_tests/test_ulysses_context_parallel.py
@@ -1337,6 +1337,20 @@ def _fused_kernels_available():
     return True
 
 
+def _triton_available():
+    """Triton importable (the fused op module can be loaded). Does not
+    require a GPU: the shape-validation paths raise before any kernel runs."""
+    try:
+        import triton  # noqa: F401
+
+        from paddlefleet.triton_ops.ulysses_alltoall_fused import (  # noqa: F401
+            ulysses_single_all_to_all_fused,
+        )
+    except (ImportError, OSError):
+        return False
+    return True
+
+
 @unittest.skipUnless(
     _fused_kernels_available(), "requires CUDA + Triton fused kernels"
 )
@@ -1456,6 +1470,79 @@ class TestUlyssesFusedKernels(unittest.TestCase):
                 )
             self.assertEqual(fused.shape, ref.shape)
             self.assertTrue(paddle.equal_all(fused, ref).item())
+
+
+class TestUlyssesFusedSupportGuard(unittest.TestCase):
+    """Exercise the non-Triton `_ulysses_fused_supported` guard directly
+    (the dispatch tests above mock it out). CPU-safe: the reject branches and
+    the import-failure fallback do not touch a GPU."""
+
+    def test_false_for_non_batch_dim0(self):
+        from paddlefleet.context_parallel_utils import (
+            _ulysses_fused_supported,
+        )
+
+        # batch_dim_idx != 0 short-circuits to the reference path regardless
+        # of build/device, so this covers the early `return False` guard.
+        x = paddle.randn([2, 4, 8, 16])
+        self.assertFalse(_ulysses_fused_supported(2, 1, x))
+
+    def test_false_when_triton_import_fails(self):
+        from paddlefleet.context_parallel_utils import (
+            _ulysses_fused_supported,
+        )
+
+        # Force the first guard to pass (compiled-with-cuda + gpu place + 4-D)
+        # then make the deferred Triton import raise, hitting the except path.
+        fake_input = MagicMock()
+        fake_input.shape = [2, 4, 8, 16]
+        fake_input.place.is_gpu_place.return_value = True
+        with (
+            patch.object(paddle, "is_compiled_with_cuda", return_value=True),
+            patch.dict(
+                sys.modules,
+                {"paddlefleet.triton_ops.ulysses_alltoall_fused": None},
+            ),
+        ):
+            self.assertFalse(_ulysses_fused_supported(2, 0, fake_input))
+
+
+@unittest.skipUnless(_triton_available(), "requires Triton fused op module")
+class TestUlyssesFusedOpValidation(unittest.TestCase):
+    """Shape-divisibility validation in the fused op. The ValueError is raised
+    before any kernel launch, so these run without a GPU."""
+
+    def test_raises_on_indivisible_heads(self):
+        from paddlefleet.triton_ops.ulysses_alltoall_fused import (
+            ulysses_single_all_to_all_fused,
+        )
+
+        x = paddle.randn([2, 4, 5, 8])  # H=5 not divisible by world size 2
+        with (
+            patch(
+                "paddlefleet.triton_ops.ulysses_alltoall_fused.dist"
+                ".get_world_size",
+                return_value=2,
+            ),
+            self.assertRaises(ValueError),
+        ):
+            ulysses_single_all_to_all_fused(x, 2, None)
+
+    def test_raises_on_indivisible_seq(self):
+        from paddlefleet.triton_ops.ulysses_alltoall_fused import (
+            ulysses_single_all_to_all_fused,
+        )
+
+        x = paddle.randn([2, 5, 4, 8])  # Nglob=5 not divisible by world size 2
+        with (
+            patch(
+                "paddlefleet.triton_ops.ulysses_alltoall_fused.dist"
+                ".get_world_size",
+                return_value=2,
+            ),
+            self.assertRaises(ValueError),
+        ):
+            ulysses_single_all_to_all_fused(x, 1, None)
 
 
 if __name__ == "__main__":

--- a/tests/single_card_tests/test_ulysses_context_parallel.py
+++ b/tests/single_card_tests/test_ulysses_context_parallel.py
@@ -274,7 +274,11 @@ class TestUlyssesAlltoAll(unittest.TestCase):
     @patch(
         "paddlefleet.context_parallel_utils.dist.get_world_size", return_value=2
     )
-    def test_forward(self, mock_ws, mock_a2a):
+    @patch(
+        "paddlefleet.context_parallel_utils._ulysses_fused_supported",
+        return_value=False,
+    )
+    def test_forward(self, mock_supported, mock_ws, mock_a2a):
         """UlyssesAlltoAll.forward should call _ulysses_single_all_to_all."""
         from paddlefleet.context_parallel_utils import UlyssesAlltoAll
 
@@ -1321,18 +1325,26 @@ class TestContextParallelOpsBackward(unittest.TestCase):
 
 
 def _fused_kernels_available():
-    """CUDA build + GPU place + importable Triton fused kernels."""
+    """Whether the CUDA + Triton fused kernels can actually run here.
+
+    Kept import-time cheap and side-effect free: it must NOT switch the global
+    default device (doing so at ``@skipUnless`` evaluation time would leak GPU
+    placement into the mock-based dispatch tests above and make them bypass
+    their mocks into the real fused path). It also swallows *any* optional-
+    backend failure (driver init, Triton runtime, missing GPU, etc.) so an
+    unavailable backend skips these tests instead of erroring at collection.
+    The GPU device switch itself happens in ``setUpClass`` below.
+    """
     if not paddle.is_compiled_with_cuda():
         return False
     try:
-        paddle.set_device("gpu")
         import triton  # noqa: F401
 
         from paddlefleet.triton_ops.ulysses_alltoall_fused import (  # noqa: F401
             _head2seq_post_kernel,
             _seq2head_pre_kernel,
         )
-    except (ImportError, OSError):
+    except Exception:
         return False
     return True
 
@@ -1364,6 +1376,18 @@ class TestUlyssesFusedKernels(unittest.TestCase):
     """
 
     P, B, SLOC, HLOC, D = 4, 2, 3, 2, 8
+
+    @classmethod
+    def setUpClass(cls):
+        # Switch to GPU only for these kernel tests and restore the previous
+        # default device afterwards, so the mock-based dispatch tests keep
+        # their CPU default (where _ulysses_fused_supported returns False).
+        cls._prev_device = paddle.get_device()
+        paddle.set_device("gpu")
+
+    @classmethod
+    def tearDownClass(cls):
+        paddle.set_device(cls._prev_device)
 
     def _launch(self, kernel, src, dst):
         import triton
@@ -1470,6 +1494,45 @@ class TestUlyssesFusedKernels(unittest.TestCase):
                 )
             self.assertEqual(fused.shape, ref.shape)
             self.assertTrue(paddle.equal_all(fused, ref).item())
+
+    def test_fused_supported_true_for_gpu_4d(self):
+        """The real guard accepts the production layout on GPU: exercises the
+        deferred Triton import and the underlying support check (returns True),
+        which the mock-based dispatch tests never run."""
+        from paddlefleet.context_parallel_utils import (
+            _ulysses_fused_supported,
+        )
+
+        x = paddle.randn([2, 4, 8, 16])  # batch_dim0, 4-D, on GPU
+        self.assertTrue(_ulysses_fused_supported(2, 0, x))
+
+    def test_wrapper_dispatches_to_fused_op(self):
+        """The `_ulysses_single_all_to_all_fused` thin wrapper imports and
+        calls the Triton op (P=1 mock keeps it single-rank)."""
+        from unittest.mock import patch
+
+        from paddlefleet.context_parallel_utils import (
+            _ulysses_single_all_to_all_fused,
+        )
+
+        def fake_a2a_single(recv, send, group=None, use_calc_stream=True):
+            recv.copy_(send, False)
+
+        inp = paddle.randn([2, 4, 4, 8])
+        with (
+            patch(
+                "paddlefleet.triton_ops.ulysses_alltoall_fused.dist"
+                ".get_world_size",
+                return_value=1,
+            ),
+            patch(
+                "paddlefleet.triton_ops.ulysses_alltoall_fused.dist"
+                ".stream.alltoall_single",
+                side_effect=fake_a2a_single,
+            ),
+        ):
+            out = _ulysses_single_all_to_all_fused(inp, 2, None)
+        self.assertEqual(out.shape, [2, 4, 4, 8])
 
 
 class TestUlyssesFusedSupportGuard(unittest.TestCase):

--- a/tests/single_card_tests/test_ulysses_context_parallel.py
+++ b/tests/single_card_tests/test_ulysses_context_parallel.py
@@ -290,29 +290,41 @@ class TestUlyssesAlltoAll(unittest.TestCase):
         )
         self.assertEqual(result.shape, [2, 8, 2, 8])
 
-    @patch("paddlefleet.context_parallel_utils._ulysses_single_all_to_all")
-    def test_backward_swaps_scatter_gather(self, mock_a2a):
-        """UlyssesAlltoAll.backward swaps scatter_idx and gather_idx."""
+    @patch("paddlefleet.context_parallel_utils._ulysses_fused_supported")
+    @patch(
+        "paddlefleet.context_parallel_utils._ulysses_single_all_to_all_fused"
+    )
+    def test_forward_uses_fused_path(self, mock_a2a, mock_supported):
+        """Forward on the production path (batch_dim_idx=0, 4-D) uses the fused
+        kernel with scatter_idx=2."""
         from paddlefleet.context_parallel_utils import UlyssesAlltoAll
 
-        mock_a2a.return_value = paddle.randn([2, 4, 4, 8])
+        mock_supported.return_value = True
+        mock_a2a.return_value = paddle.randn([2, 8, 2, 8])
         group = MagicMock()
 
-        # Simulate forward to populate ctx
         inp = paddle.randn([2, 4, 4, 8])
         inp.stop_gradient = False
-        result = UlyssesAlltoAll.apply(
+        UlyssesAlltoAll.apply(
             inp, scatter_idx=2, gather_idx=1, batch_dim_idx=0, group=group
         )
 
-        # Check that _ulysses_single_all_to_all was called with scatter_idx=2
+        # Fused signature: _ulysses_single_all_to_all_fused(input, scatter_idx, group)
         call_args = mock_a2a.call_args_list[0]
-        self.assertEqual(call_args[1].get("scatter_idx", call_args[0][1]), 2)
+        self.assertEqual(call_args[0][1], 2)
 
-    @patch("paddlefleet.context_parallel_utils._ulysses_single_all_to_all")
-    def test_backward_is_called_on_grad(self, mock_a2a):
-        """UlyssesAlltoAll.backward should call _ulysses_single_all_to_all with swapped indices."""
+    @patch("paddlefleet.context_parallel_utils._ulysses_fused_supported")
+    @patch(
+        "paddlefleet.context_parallel_utils._ulysses_single_all_to_all_fused"
+    )
+    def test_backward_uses_fused_path_with_swapped_index(
+        self, mock_a2a, mock_supported
+    ):
+        """Backward on the production path (batch_dim_idx=0, 4-D) calls the fused
+        a2a with the swapped (gather) index."""
         from paddlefleet.context_parallel_utils import UlyssesAlltoAll
+
+        mock_supported.return_value = True
 
         # Call backward directly via the static method
         mock_ctx = MagicMock()
@@ -324,12 +336,44 @@ class TestUlyssesAlltoAll(unittest.TestCase):
         grad_output = paddle.randn([2, 8, 2, 8])
         mock_a2a.return_value = paddle.randn([2, 4, 4, 8])
 
-        result = UlyssesAlltoAll.backward(mock_ctx, grad_output)
+        UlyssesAlltoAll.backward(mock_ctx, grad_output)
 
-        # Backward should swap: scatter_idx=gather_idx=1, gather_idx=scatter_idx=2
+        # The inverse a2a swaps scatter/gather; the fused path passes the
+        # backward scatter index (= ctx.gather_idx) as the fused scatter_idx.
         mock_a2a.assert_called_once()
         call_args = mock_a2a.call_args
-        # positional args: (grad_output, gather_idx, scatter_idx, batch_dim_idx, group)
+        # positional args: (grad_output, gather_idx, group)
+        self.assertIs(call_args[0][0], grad_output)
+        self.assertEqual(
+            call_args[0][1], 1
+        )  # swapped scatter index = gather_idx
+        self.assertIs(call_args[0][2], mock_ctx.group)
+
+    @patch("paddlefleet.context_parallel_utils._ulysses_single_all_to_all")
+    @patch("paddlefleet.context_parallel_utils._ulysses_fused_supported")
+    def test_backward_falls_back_swaps_scatter_gather(
+        self, mock_supported, mock_a2a
+    ):
+        """When the fused path is unsupported, backward falls back to the
+        reference a2a with swapped (scatter, gather) indices."""
+        from paddlefleet.context_parallel_utils import UlyssesAlltoAll
+
+        mock_supported.return_value = False
+        mock_a2a.return_value = paddle.randn([2, 4, 4, 8])
+
+        mock_ctx = MagicMock()
+        mock_ctx.scatter_idx = 2
+        mock_ctx.gather_idx = 1
+        mock_ctx.batch_dim_idx = 0
+        mock_ctx.group = MagicMock()
+
+        grad_output = paddle.randn([2, 8, 2, 8])
+        UlyssesAlltoAll.backward(mock_ctx, grad_output)
+
+        # Reference signature: (grad_output, gather_idx, scatter_idx,
+        # batch_dim_idx, group) -- scatter and gather are swapped.
+        mock_a2a.assert_called_once()
+        call_args = mock_a2a.call_args
         self.assertIs(call_args[0][0], grad_output)
         self.assertEqual(call_args[0][1], 1)  # was gather_idx=1
         self.assertEqual(call_args[0][2], 2)  # was scatter_idx=2

--- a/tests/single_card_tests/test_ulysses_context_parallel.py
+++ b/tests/single_card_tests/test_ulysses_context_parallel.py
@@ -1315,5 +1315,148 @@ class TestContextParallelOpsBackward(unittest.TestCase):
         mock_contiguous.assert_not_called()
 
 
+# =============================================================================
+# Tests that actually execute the fused Triton permute kernels
+# =============================================================================
+
+
+def _fused_kernels_available():
+    """CUDA build + GPU place + importable Triton fused kernels."""
+    if not paddle.is_compiled_with_cuda():
+        return False
+    try:
+        paddle.set_device("gpu")
+        import triton  # noqa: F401
+
+        from paddlefleet.triton_ops.ulysses_alltoall_fused import (  # noqa: F401
+            _head2seq_post_kernel,
+            _seq2head_pre_kernel,
+        )
+    except (ImportError, OSError):
+        return False
+    return True
+
+
+@unittest.skipUnless(
+    _fused_kernels_available(), "requires CUDA + Triton fused kernels"
+)
+class TestUlyssesFusedKernels(unittest.TestCase):
+    """Run the fused permute kernels and compare their index mapping against
+    an explicit paddle reshape/transpose reference (bit-exact).
+
+    These exercise the actual `_seq2head_*` / `_head2seq_*` kernels for P>1,
+    which the mock-based dispatch tests above do not, guarding the index math
+    and buffer layout against silent regressions.
+    """
+
+    P, B, SLOC, HLOC, D = 4, 2, 3, 2, 8
+
+    def _launch(self, kernel, src, dst):
+        import triton
+
+        P, b, Sloc, Hloc, D = self.P, self.B, self.SLOC, self.HLOC, self.D
+        seg = Hloc * D
+        block = min(triton.next_power_of_2(seg), 4096)
+        grid = (P * b * Sloc, triton.cdiv(seg, block))
+        kernel[grid](src, dst, P, b, Sloc, Hloc, D, seg, BLOCK=block)
+
+    def test_seq2head_pre_matches_reference(self):
+        from paddlefleet.triton_ops.ulysses_alltoall_fused import (
+            _seq2head_pre_kernel,
+        )
+
+        P, b, Sloc, Hloc, D = self.P, self.B, self.SLOC, self.HLOC, self.D
+        x = paddle.randn([b, Sloc, P * Hloc, D])
+        out = paddle.empty([P, b, Sloc, Hloc, D], dtype=x.dtype)
+        self._launch(_seq2head_pre_kernel, x, out)
+        ref = x.reshape([b, Sloc, P, Hloc, D]).transpose([2, 0, 1, 3, 4])
+        self.assertTrue(paddle.equal_all(out, ref).item())
+
+    def test_seq2head_post_matches_reference(self):
+        from paddlefleet.triton_ops.ulysses_alltoall_fused import (
+            _seq2head_post_kernel,
+        )
+
+        P, b, Sloc, Hloc, D = self.P, self.B, self.SLOC, self.HLOC, self.D
+        recv = paddle.randn([P, b, Sloc, Hloc, D])
+        out = paddle.empty([b, P * Sloc, Hloc, D], dtype=recv.dtype)
+        self._launch(_seq2head_post_kernel, recv, out)
+        ref = recv.transpose([1, 0, 2, 3, 4]).reshape([b, P * Sloc, Hloc, D])
+        self.assertTrue(paddle.equal_all(out, ref).item())
+
+    def test_head2seq_pre_matches_reference(self):
+        from paddlefleet.triton_ops.ulysses_alltoall_fused import (
+            _head2seq_pre_kernel,
+        )
+
+        P, b, Sloc, Hloc, D = self.P, self.B, self.SLOC, self.HLOC, self.D
+        g = paddle.randn([b, P * Sloc, Hloc, D])
+        out = paddle.empty([P, b, Sloc, Hloc, D], dtype=g.dtype)
+        self._launch(_head2seq_pre_kernel, g, out)
+        ref = g.reshape([b, P, Sloc, Hloc, D]).transpose([1, 0, 2, 3, 4])
+        self.assertTrue(paddle.equal_all(out, ref).item())
+
+    def test_head2seq_post_matches_reference(self):
+        from paddlefleet.triton_ops.ulysses_alltoall_fused import (
+            _head2seq_post_kernel,
+        )
+
+        P, b, Sloc, Hloc, D = self.P, self.B, self.SLOC, self.HLOC, self.D
+        recv = paddle.randn([P, b, Sloc, Hloc, D])
+        out = paddle.empty([b, Sloc, P * Hloc, D], dtype=recv.dtype)
+        self._launch(_head2seq_post_kernel, recv, out)
+        ref = recv.transpose([1, 2, 0, 3, 4]).reshape([b, Sloc, P * Hloc, D])
+        self.assertTrue(paddle.equal_all(out, ref).item())
+
+    def test_fused_full_a2a_matches_reference_single_rank(self):
+        """End-to-end fused vs reference all-to-all on a 1-rank group (P=1):
+        exercises the public wrapper, pre+post kernels, send-buffer reuse and
+        the alltoall_single call together."""
+        from unittest.mock import patch
+
+        from paddlefleet.context_parallel_utils import (
+            _ulysses_single_all_to_all,
+        )
+        from paddlefleet.triton_ops.ulysses_alltoall_fused import (
+            ulysses_single_all_to_all_fused,
+        )
+
+        b, Sloc, H, D = 2, 4, 4, 8
+
+        def fake_a2a_single(recv, send, group=None, use_calc_stream=True):
+            recv.copy_(send, False)  # 1-rank all-to-all is a copy
+
+        for scatter_idx, gather_idx in ((2, 1), (1, 2)):
+            inp = paddle.randn([b, Sloc, H, D])
+            with (
+                patch(
+                    "paddlefleet.triton_ops.ulysses_alltoall_fused.dist"
+                    ".get_world_size",
+                    return_value=1,
+                ),
+                patch(
+                    "paddlefleet.triton_ops.ulysses_alltoall_fused.dist"
+                    ".stream.alltoall_single",
+                    side_effect=fake_a2a_single,
+                ),
+            ):
+                fused = ulysses_single_all_to_all_fused(inp, scatter_idx, None)
+            with (
+                patch(
+                    "paddlefleet.context_parallel_utils.dist.get_world_size",
+                    return_value=1,
+                ),
+                patch(
+                    "paddlefleet.context_parallel_utils.dist.alltoall",
+                    side_effect=lambda out, i, group=None: out.copy_(i, False),
+                ),
+            ):
+                ref = _ulysses_single_all_to_all(
+                    inp, scatter_idx, gather_idx, 0, None
+                )
+            self.assertEqual(fused.shape, ref.shape)
+            self.assertTrue(paddle.equal_all(fused, ref).item())
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### PR Category
Performance Optimization

### PR Types
Performance

### Description
Fuse the Ulysses context-parallel all-to-all `reshape + transpose + .contiguous()` permutes into Triton kernels for the production path (`batch_dim_idx=0`, 4-D CUDA input).

**Motivation.** On that path the pre/post permutes are pure data movement whose cost (two physical copies) rivals the communication itself. A single Triton kernel fuses reshape+transpose+contiguous into one coalesced copy, and the post output reuses the send buffer so peak memory stays at `1x send + 1x recv`.

**Changes**
- New `src/paddlefleet/triton_ops/ulysses_alltoall_fused.py`: seq<->head pre/post kernels + `alltoall_single`, with send-buffer reuse.
- `UlyssesAlltoAll` forward/backward dispatch to the fused path when supported.
- Guarded fallback to the reference reshape/permute path for other layouts, CPU/non-CUDA inputs, or environments where Triton fails to import/load (`ImportError`/`OSError`). Triton import is deferred.
- Runtime shape checks use explicit `ValueError` (survive `python -O`).

**Testing**
- `TestUlyssesAlltoAll` (dispatch/fallback) and `TestUlyssesFusedKernels` (real Triton kernels: per-direction index mapping vs paddle reshape/transpose reference + 1-rank end-to-end fused-vs-reference equivalence) all pass; GPU/Triton tests skip when unavailable.
- pre-commit hooks pass on all changed files.
- Bit-exact: per-step training loss of a real run aligns with the baseline to 8 decimals across 40 steps (max abs diff = 0).
