### PR TITLE
Revert "fix some gpu oom"

### DIFF
--- a/src/paddlefleet/transformer/moe/token_dispatcher.py
+++ b/src/paddlefleet/transformer/moe/token_dispatcher.py
@@ -20,7 +20,7 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
 import paddle
-from paddle import framework, nn
+from paddle import nn
 
 if TYPE_CHECKING:
     from paddle.distributed.communication.group import Group
@@ -716,13 +716,12 @@ class _DeepEPManager(_DispatchManager):
             fp8_dispatch=fp8_dispatch,
             combine_grad_handle=combine_grad_handle,
         )
-        # Release the handle after combine operation
+        # Release the handle and token_indices after combine operation
         self.handle = None
-        if framework._dygraph_tracer()._has_grad:
-            self.token_indices = None
-            self.token_probs = None
-            self.dispatched_probs = None
-            self.dispatched_indices = None
+        self.token_indices = None
+        self.token_probs = None
+        self.dispatched_probs = None
+        self.dispatched_indices = None
         return hidden_states
 
     def get_permuted_hidden_states_by_experts(


### PR DESCRIPTION
### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library  | Environment Adaptation ] -->
Distributed Strategy
### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes
### Description
<!-- Describe what you’ve done -->
Reverts PaddlePaddle/PaddleFleet#1399. The previous change kept `_DeepEPManager` routing metadata alive until the optimizer phase in some paths, reducing available optimizer memory. This PR restores releasing the DeepEP handle, token indices/probs, and dispatched indices/probs immediately after `combine()`, and removes the now-unused `framework` import from `token_dispatcher.py`.