### PR TITLE
Implement HySparse Attention with MQA and KV-sharing

### DIFF
--- a/src/paddlefleet/models/gpt/gpt_layer_specs.py
+++ b/src/paddlefleet/models/gpt/gpt_layer_specs.py
@@ -87,12 +87,14 @@ from paddlefleet.transformer.mlp import MLP, MLPSublayersSpec
 from paddlefleet.transformer.multi_latent_attention import (
     MLASelfAttention,
     MLASelfAttentionSublayersSpec,
+    MQASelfAttention,
 )
 from paddlefleet.transformer.multi_token_prediction import (
     get_mtp_layer_spec_for_backend,
 )
 from paddlefleet.transformer.paddle_norm import L2Norm
 from paddlefleet.transformer.transformer_layer import (
+    HySparseTransformerLayer,
     TransformerLayer,
     TransformerLayerSublayersSpec,
     TransformerLayerWithOverlap,
@@ -232,6 +234,10 @@ def get_attention_spec(
         assert qk_l2_norm is False, "qk_l2_norm is not supported with MLA."
         # Decide attention class: always MLASelfAttention (DSA is a pluggable core_attention)
         attn_cls = MLASelfAttention
+
+        if config is not None and config.enable_hy_sparse_attention:
+            attn_cls = MQASelfAttention
+
         # Gated attention
         gated_attention = getattr(config, "gated_attention", False)
 
@@ -406,6 +412,9 @@ def get_gpt_layer_local_spec(
         )
 
         transformer_cls = HyperConnectionTransformerLayer
+
+    if config is not None and config.enable_hy_sparse_attention:
+        transformer_cls = HySparseTransformerLayer
 
     if paddle.distributed.is_initialized():
         try:

--- a/src/paddlefleet/transformer/multi_latent_attention.py
+++ b/src/paddlefleet/transformer/multi_latent_attention.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import dataclasses
 import math
 import os
 from dataclasses import dataclass
@@ -472,6 +471,7 @@ class MultiLatentAttention(Attention):
         packed_seq_params=None,
         in_recompute: bool = False,
         position_ids=None,
+        shared_kv: list[Tensor] | None = None,
         **kwargs,
     ):
         """Forward pass for multi-latent attention"""
@@ -591,6 +591,14 @@ class MultiLatentAttention(Attention):
             )
 
         _log(core_attn_out, "core_attn_out", layer_num)
+
+        if self.config.enable_hy_sparse_attention and shared_kv is not None:
+            shared_key = paddle.concat(
+                [kv_compressed.unsqueeze(2), k_pos_emb], axis=-1
+            )
+            shared_kv.append(shared_key)
+            block_indices = paddle.empty([0])  # TODO: from full attention
+            shared_kv.append(block_indices)
 
         # =================
         # Output. [b, sq, h]
@@ -1283,24 +1291,22 @@ class MQASelfAttention(MLASelfAttention):
             "MQA does not support rope fusion."
         )
 
-        # Adjust absorbed kv channels for core attention
-        k_channels = self.config.kv_lora_rank + self.qk_rope_head_dim
-        v_channels = self.config.kv_lora_rank
+        # Use MQA only when HySparse is enabled and this is an SWA layer.
+        # Otherwise, use its parent's forward method (MLA).
+        self.is_mqa = config.enable_hy_sparse_attention and self.is_swa
 
-        self.core_attention.hidden_size_per_partition = (
-            k_channels * self.num_attention_heads_per_partition
-        )
-        self.core_attention.k_channels = k_channels
-        self.core_attention.v_channels = v_channels
+        if self.is_mqa:
+            # Adjust absorbed kv channels for core attention
+            k_channels = self.config.kv_lora_rank + self.qk_rope_head_dim
+            v_channels = self.config.kv_lora_rank
 
-        if k_channels > 256:
-            self.core_attention.config = dataclasses.replace(
-                self.core_attention.config,
-                _attn_implementation="eager",
+            self.core_attention.hidden_size_per_partition = (
+                k_channels * self.num_attention_heads_per_partition
             )
+            self.core_attention.k_channels = k_channels
+            self.core_attention.v_channels = v_channels
 
-        # Create sparse core attention and sparse gate
-        if config.enable_hy_sparse_attention and self.is_swa:
+            # Block sparse attention
             self.sparse_core_attention = build_spec_layer(
                 sublayers_spec.core_attention,
                 config=self.core_attention.config,
@@ -1317,6 +1323,8 @@ class MQASelfAttention(MLASelfAttention):
                 cp_comm_type=cp_comm_type,
                 pg_collection=self.pg_collection,
             )
+
+            # Gate for block sparse attention
             if self.gated_attention:
                 self.sparse_gate_proj = build_spec_layer(
                     sublayers_spec.gate_proj,
@@ -1368,6 +1376,19 @@ class MQASelfAttention(MLASelfAttention):
         assert get_pg_size(self.pg_collection.tp) == 1, (
             "MQA does not support tensor parallel."
         )
+
+        if not self.is_mqa:
+            return super().forward(
+                hidden_states,
+                attention_mask,
+                attn_mask_startend_row_indices=attn_mask_startend_row_indices,
+                key_value_states=key_value_states,
+                packed_seq_params=packed_seq_params,
+                in_recompute=in_recompute,
+                position_ids=position_ids,
+                shared_kv=shared_kv,
+                **kwargs,
+            )
 
         # =====================
         # Query, Key, and Value
@@ -1422,11 +1443,6 @@ class MQASelfAttention(MLASelfAttention):
 
         _log(core_attn_out, "core_attn_out", layer_num)
 
-        if shared_kv is not None and not self.is_swa:
-            shared_kv.append(key)
-            block_indices = paddle.empty([0])  # TODO: from full attention
-            shared_kv.append(block_indices)
-
         # =================
         # Absorb value. [b, sq, num_heads * v_head_dim]
         # =================
@@ -1456,22 +1472,21 @@ class MQASelfAttention(MLASelfAttention):
         # Sparse attention computation
         # =================
 
-        if self.config.enable_hy_sparse_attention and self.is_swa:
-            shared_key, shared_block_indices = shared_kv
-            shared_value = shared_key[:, :, :, :kv_lora_rank].contiguous()
+        shared_key, shared_block_indices = shared_kv
+        shared_value = shared_key[:, :, :, :kv_lora_rank].contiguous()
 
-            sparse_core_attn_out = self.sparse_core_attention(
-                query,
-                shared_key,
-                shared_value,
-                attention_mask,
-                attn_mask_startend_row_indices,
-                attn_mask_type=attn_mask_type,
-                attention_bias=attention_bias,
-                layer_idx=layer_idx,
-            )
+        sparse_core_attn_out = self.sparse_core_attention(
+            query,
+            shared_key,
+            shared_value,
+            attention_mask,
+            attn_mask_startend_row_indices,
+            attn_mask_type=attn_mask_type,
+            attention_bias=attention_bias,
+            layer_idx=layer_idx,
+        )
 
-            sparse_core_attn_out = compute_absorbed_v(sparse_core_attn_out)
+        sparse_core_attn_out = compute_absorbed_v(sparse_core_attn_out)
 
         # =================
         # Output. [b, sq, h]
@@ -1486,13 +1501,12 @@ class MQASelfAttention(MLASelfAttention):
             core_attn_out = self._gate(gate_source, core_attn_out)
 
         # Add sparse attention output
-        if self.config.enable_hy_sparse_attention and self.is_swa:
-            if self.gated_attention:
-                gate, _ = self.sparse_gate_proj(gate_source)
-                sparse_core_attn_out = (
-                    sparse_core_attn_out * paddle.nn.functional.sigmoid(gate)
-                )
-            core_attn_out += sparse_core_attn_out
+        if self.gated_attention:
+            gate, _ = self.sparse_gate_proj(gate_source)
+            sparse_core_attn_out = (
+                sparse_core_attn_out * paddle.nn.functional.sigmoid(gate)
+            )
+        core_attn_out += sparse_core_attn_out
 
         output, bias = self.o_proj(core_attn_out)
 
@@ -1510,6 +1524,14 @@ class MQASelfAttention(MLASelfAttention):
         """
         Derives `query`, `key` and `value` tensors from `hidden_states`.
         """
+        if not self.is_mqa:
+            return super().get_query_key_value_tensors(
+                hidden_states,
+                key_value_states=key_value_states,
+                position_ids=position_ids,
+                packed_seq_params=packed_seq_params,
+            )
+
         # b = batch size, s = sequence length, h = hidden size, n = num attention heads
         # Attention heads [b, s, n*h]
         assert hidden_states.ndim == 3, (

--- a/src/paddlefleet/transformer/multi_latent_attention.py
+++ b/src/paddlefleet/transformer/multi_latent_attention.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import dataclasses
 import math
 import os
 from dataclasses import dataclass
@@ -1253,3 +1254,409 @@ class MLASelfAttention(MultiLatentAttention):
     def _backward_output_proj(self):
         """Computes weight gradients of output projection layer"""
         self.o_proj.backward_dw()
+
+
+class MQASelfAttention(MLASelfAttention):
+    """Multi-Query Attention."""
+
+    def __init__(
+        self,
+        config: TransformerConfig,
+        sublayers_spec: MLASelfAttentionSublayersSpec,
+        layer_number: int,
+        attn_mask_type=AttnMaskType.padding,
+        cp_comm_type: str | None = None,
+        pg_collection: ProcessGroupCollection | None = None,
+        is_mtp_layer: bool = False,
+    ):
+        super().__init__(
+            config=config,
+            sublayers_spec=sublayers_spec,
+            layer_number=layer_number,
+            attn_mask_type=attn_mask_type,
+            cp_comm_type=cp_comm_type,
+            pg_collection=pg_collection,
+            is_mtp_layer=is_mtp_layer,
+        )
+
+        assert not self.config.apply_rope_fusion, (
+            "MQA does not support rope fusion."
+        )
+
+        # Adjust absorbed kv channels for core attention
+        k_channels = self.config.kv_lora_rank + self.qk_rope_head_dim
+        v_channels = self.config.kv_lora_rank
+
+        self.core_attention.hidden_size_per_partition = (
+            k_channels * self.num_attention_heads_per_partition
+        )
+        self.core_attention.k_channels = k_channels
+        self.core_attention.v_channels = v_channels
+
+        if k_channels > 256:
+            self.core_attention.config = dataclasses.replace(
+                self.core_attention.config,
+                _attn_implementation="eager",
+            )
+
+        # Create sparse core attention and sparse gate
+        if config.enable_hy_sparse_attention and self.is_swa:
+            self.sparse_core_attention = build_spec_layer(
+                sublayers_spec.core_attention,
+                config=self.core_attention.config,
+                layer_number=self.layer_number,
+                attn_mask_type=self.attn_mask_type,
+                attention_type=self.attention_type,
+                is_mtp_layer=self.is_mtp_layer,
+                is_swa=False,
+                softmax_scale=self.config.softmax_scale,
+                k_channels=k_channels,
+                v_channels=v_channels,
+                num_attention_heads=self.num_attention_heads,
+                num_key_value_heads=1,
+                cp_comm_type=cp_comm_type,
+                pg_collection=self.pg_collection,
+            )
+            if self.gated_attention:
+                self.sparse_gate_proj = build_spec_layer(
+                    sublayers_spec.gate_proj,
+                    self.gate_proj.input_size,
+                    self.gate_proj.output_size,
+                    config=self.config,
+                    init_method=self.config.init_method,
+                    gather_output=False,
+                    bias=self.config.use_bias,
+                    skip_bias_add=False,
+                    is_expert=False,
+                    tp_comm_buffer_name="mla_gate",
+                    tp_group=self.pg_collection.tp,
+                )
+
+    def forward(
+        self,
+        hidden_states,
+        attention_mask,
+        attn_mask_startend_row_indices: Tensor | None = None,
+        key_value_states=None,
+        rotary_pos_emb=None,
+        rotary_pos_cos=None,
+        rotary_pos_sin=None,
+        attention_bias=None,
+        packed_seq_params=None,
+        in_recompute: bool = False,
+        position_ids=None,
+        shared_kv: list[Tensor] | None = None,
+        **kwargs,
+    ):
+        """Forward pass for multi-latent attention"""
+        from paddlefleet.transformer.transformer_layer import TransformerLayer
+
+        _log = TransformerLayer._log_md5
+
+        assert rotary_pos_emb is None, (
+            "Rotary position embeddings should not be passed into MQA."
+        )
+        assert attention_bias is None, (
+            "Attention bias should not be passed into MQA."
+        )
+        assert rotary_pos_cos is None and rotary_pos_sin is None, (
+            "MQA does not support Flash Decoding"
+        )
+        assert not get_context_parallel_world_size() > 1, (
+            "MQA does not support context parallel."
+        )
+        assert get_pg_size(self.pg_collection.tp) == 1, (
+            "MQA does not support tensor parallel."
+        )
+
+        # =====================
+        # Query, Key, and Value
+        # =====================
+        # Get the query, key and value tensors based on the type of attention
+        # Also get q_compressed for DSA indexer (if enabled)
+        query, key, value, q_compressed, kv_compressed, k_pos_emb = (
+            self.get_query_key_value_tensors(
+                hidden_states,
+                key_value_states,
+                position_ids,
+                packed_seq_params,
+            )
+        )
+
+        layer_num = getattr(self, "layer_number", -1)
+        _log(query, "attn_query", layer_num)
+        _log(key, "attn_key", layer_num)
+        if value is not None:
+            _log(value, "attn_value", layer_num)
+
+        attn_mask_type = self.attn_mask_type
+        query = query.contiguous()
+        key = key.contiguous()
+
+        if value is not None:
+            value = value.contiguous()
+
+        # ==================================
+        # core attention computation
+        # ==================================
+        # Extract inference kwargs to pass through to core_attention
+        past_key_values = kwargs.get("past_key_values")
+        layer_idx = kwargs.get("layer_idx")
+        use_cache = kwargs.get("use_cache", False)
+
+        # Static batching attention kernel.
+        core_attn_out = self.core_attention(
+            query,
+            key,
+            value,
+            attention_mask,
+            attn_mask_startend_row_indices,
+            attn_mask_type=attn_mask_type,
+            attention_bias=attention_bias,
+            packed_seq_params=packed_seq_params,
+            use_rr_flash_attention=self.use_rr_flash_attention and in_recompute,
+            past_key_values=past_key_values,
+            layer_idx=layer_idx,
+            use_cache=use_cache,
+        )
+
+        _log(core_attn_out, "core_attn_out", layer_num)
+
+        if shared_kv is not None and not self.is_swa:
+            shared_kv.append(key)
+            block_indices = paddle.empty([0])  # TODO: from full attention
+            shared_kv.append(block_indices)
+
+        # =================
+        # Absorb value. [b, sq, num_heads * v_head_dim]
+        # =================
+
+        kv_lora_rank = self.config.kv_lora_rank
+        num_heads = self.num_attention_heads_per_partition
+
+        v_absorb_weight = self.kv_b_proj.weight.reshape(
+            [kv_lora_rank, num_heads, -1]
+        )[:, :, self.qk_nope_head_dim :]
+
+        def compute_absorbed_v(core_attn_out):
+            core_attn_out = core_attn_out.view(
+                *core_attn_out.shape[:-1], num_heads, kv_lora_rank
+            )
+            core_attn_out = paddle.einsum(
+                "bshl,lhv->bshv", core_attn_out, v_absorb_weight
+            )
+            core_attn_out = core_attn_out.view(
+                *core_attn_out.shape[:-2], num_heads * self.v_head_dim
+            )
+            return core_attn_out
+
+        core_attn_out = compute_absorbed_v(core_attn_out)
+
+        # =================
+        # Sparse attention computation
+        # =================
+
+        if self.config.enable_hy_sparse_attention and self.is_swa:
+            shared_key, shared_block_indices = shared_kv
+            shared_value = shared_key[:, :, :, :kv_lora_rank].contiguous()
+
+            sparse_core_attn_out = self.sparse_core_attention(
+                query,
+                shared_key,
+                shared_value,
+                attention_mask,
+                attn_mask_startend_row_indices,
+                attn_mask_type=attn_mask_type,
+                attention_bias=attention_bias,
+                layer_idx=layer_idx,
+            )
+
+            sparse_core_attn_out = compute_absorbed_v(sparse_core_attn_out)
+
+        # =================
+        # Output. [b, sq, h]
+        # =================
+        # Apply gated attention
+        if self.gated_attention:
+            # Gate input source: q_compressed (post q_a_layernorm, dim=q_lora_rank) when
+            # gated_attn_use_q_lora is set, otherwise hidden_states.
+            gate_source = (
+                q_compressed if self.gated_attn_use_q_lora else hidden_states
+            )
+            core_attn_out = self._gate(gate_source, core_attn_out)
+
+        # Add sparse attention output
+        if self.config.enable_hy_sparse_attention and self.is_swa:
+            if self.gated_attention:
+                gate, _ = self.sparse_gate_proj(gate_source)
+                sparse_core_attn_out = (
+                    sparse_core_attn_out * paddle.nn.functional.sigmoid(gate)
+                )
+            core_attn_out += sparse_core_attn_out
+
+        output, bias = self.o_proj(core_attn_out)
+
+        _log(output, "attn_o_proj_out", layer_num)
+
+        return output, bias
+
+    def get_query_key_value_tensors(
+        self,
+        hidden_states,
+        key_value_states=None,
+        position_ids=None,
+        packed_seq_params=None,
+    ):
+        """
+        Derives `query`, `key` and `value` tensors from `hidden_states`.
+        """
+        # b = batch size, s = sequence length, h = hidden size, n = num attention heads
+        # Attention heads [b, s, n*h]
+        assert hidden_states.ndim == 3, (
+            f"hidden_states should be 3D, [b, s, n*h], got {hidden_states.ndim}D"
+        )
+
+        # =========================================
+        # Prepare RoPE and seqlen related params
+        # =========================================
+        rotary_seq_len = self.rotary_pos_emb.get_rotary_seq_len(
+            hidden_states, self.config, packed_seq_params
+        )
+
+        # rotary_pos_emb: [1, s, 1, pe_dim]
+        mscale = 1.0
+        rotary_pos_cos = None
+        rotary_pos_sin = None
+
+        assert self.config.rope_type == "rope", (
+            f"MQA only supports rope_type 'rope', got {self.config.rope_type}"
+        )
+        assert packed_seq_params is None, (
+            "MQA doesn't support packed_seq_params"
+        )
+
+        rotary_pos_emb = self.rotary_pos_emb(
+            rotary_seq_len,
+            position_ids=None if self.training else position_ids,
+        )
+
+        # =========================================
+        # QKV down projection and layernorm
+        # =========================================
+        if self.config.q_lora_rank is not None:
+            q_compressed, _ = self.q_a_proj(hidden_states)
+        else:
+            q_compressed = hidden_states
+
+        # kv_combined: [b, s, (kv_lora_rank + qk_rope_head_dim)]
+        kv_combined, _ = self.kv_a_proj_with_mqa(hidden_states)
+
+        # kv_compressed: [b, s, kv_lora_rank], k_pos_emb: [b, s, qk_rope_head_dim]
+        kv_compressed, k_pos_emb = paddle.split(
+            kv_combined,
+            [self.config.kv_lora_rank, self.qk_rope_head_dim],
+            axis=-1,
+        )
+
+        # =========================================
+        # Apply norm
+        # =========================================
+
+        if self.config.q_lora_rank is not None:
+            # q_compressed: [num_tokens, q_lora_rank]
+            q_compressed = self.q_a_layernorm(q_compressed)
+
+        kv_compressed = self.kv_a_layernorm(kv_compressed)
+
+        # === MD5 probes for MLA intermediate values ===
+        from paddlefleet.transformer.transformer_layer import TransformerLayer
+
+        _log = TransformerLayer._log_md5
+        _log(q_compressed, "mla_q_compressed_normed", self.layer_number)
+        _log(kv_compressed, "mla_kv_compressed_normed", self.layer_number)
+        _log(k_pos_emb, "mla_k_pos_emb_raw", self.layer_number)
+
+        # =========================================
+        # QKV up projection and RoPE apply
+        # =========================================
+
+        def qkv_up_proj_and_rope_apply(
+            q_compressed,
+            kv_compressed,
+            k_pos_emb,
+            rotary_pos_emb,
+            rotary_pos_cos,
+            rotary_pos_sin,
+            position_ids=None,
+        ):
+            """
+            Apply the up projection and RoPE to the query and key.
+            When sequence packing enabled, the input tensors adopt a packed shape of [t, ...];
+            otherwise, they maintain the unpacked shape [b, s, ...]. In subsequent code comments,
+            we uniformly use [num_tokens, ...] to denote [b, s, ...] or [t, ...] for two cases.
+            """
+            if self.config.q_lora_rank is not None:
+                # q_compressed: [num_tokens, q_lora_rank]
+                # q: [num_tokens, n * (qk_nope_head_dim + qk_rope_head_dim)]
+                q, _ = self.q_b_proj(q_compressed)
+            else:
+                # q_compressed: [num_tokens, hidden_size]
+                # q: [num_tokens, n * (qk_nope_head_dim + qk_rope_head_dim)]
+                q, _ = self.q_proj(q_compressed)
+
+            # q: [num_tokens, n, q_head_dim]
+            q = q.view(
+                *q.size()[:-1],
+                self.num_attention_heads_per_partition,
+                self.q_head_dim,
+            )
+
+            kv_lora_rank = self.config.kv_lora_rank
+            num_heads = self.num_attention_heads_per_partition
+
+            q_no_pe = q[..., : self.qk_nope_head_dim]
+            q_pos_emb = q[..., self.qk_nope_head_dim :]
+
+            q_absorb_weight = self.kv_b_proj.weight.reshape(
+                [kv_lora_rank, num_heads, -1]
+            )[:, :, : self.qk_nope_head_dim]
+            q_nope_absorbed = paddle.einsum(
+                "bshd,lhd->bshl", q_no_pe, q_absorb_weight
+            )
+
+            q_pos_emb = apply_rotary_pos_emb(
+                q_pos_emb,
+                rotary_pos_emb,
+                rotary_pos_cos,
+                rotary_pos_sin,
+                config=self.config,
+                mscale=mscale,
+            )
+            k_pos_emb = apply_rotary_pos_emb(
+                k_pos_emb.unsqueeze(-2),
+                rotary_pos_emb,
+                rotary_pos_cos,
+                rotary_pos_sin,
+                config=self.config,
+                mscale=mscale,
+            )
+
+            kv_compressed = kv_compressed.unsqueeze(-2)
+
+            query = paddle.concat([q_nope_absorbed, q_pos_emb], axis=-1)
+            key = paddle.concat([kv_compressed, k_pos_emb], axis=-1)
+            value = kv_compressed
+
+            return query, key, value, k_pos_emb
+
+        query, key, value, k_pos_emb = qkv_up_proj_and_rope_apply(
+            q_compressed,
+            kv_compressed,
+            k_pos_emb,
+            rotary_pos_emb,
+            rotary_pos_cos,
+            rotary_pos_sin,
+            position_ids,
+        )
+
+        return query, key, value, q_compressed, kv_compressed, k_pos_emb

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -788,6 +788,14 @@ class TransformerConfig(ModelParallelConfig):
     with num_chunks=N. Only compatible with tensor_model_parallel_size == 1
     (or parallel_output disabled)."""
 
+    enable_hy_sparse_attention: bool = False
+    """Enable the HySparse Attention variant.
+
+    HySparse has the following features: (1) adding a Block Sparse Attention in SWA
+    layers. (2) KV sharing between full attention and Block Sparse Attention. (3) using
+    MQA instead of MLA.
+    """
+
     # cache_mla_latents: bool = False
 
     ####################

--- a/src/paddlefleet/transformer/transformer_layer.py
+++ b/src/paddlefleet/transformer/transformer_layer.py
@@ -1403,9 +1403,6 @@ class HySparseTransformerLayer(TransformerLayer):
             is_mtp  # Suppress MD5 probes for MTP passes
         )
 
-        if self.config.block_attention_residuals and "blocks" not in dict_args:
-            dict_args["blocks"] = []
-
         if self.full_recompute:
 
             def dict_args_get_clone(key):

--- a/src/paddlefleet/transformer/transformer_layer.py
+++ b/src/paddlefleet/transformer/transformer_layer.py
@@ -916,6 +916,8 @@ class TransformerLayer(nn.Layer):
             self.self_attn, DSv4HybridAttention
         ):
             extra_kwargs["input_ids"] = input_ids
+        if "shared_kv" in kwargs:
+            extra_kwargs["shared_kv"] = kwargs["shared_kv"]
 
         if rope_freqs_cis is not None:
             attention_output_with_bias = self.self_attn(
@@ -1374,6 +1376,150 @@ class HyperConnectionTransformerLayer(TransformerLayer):
             hidden_states.stop_gradient = False
 
         return hidden_states
+
+
+class HySparseTransformerLayer(TransformerLayer):
+    """Transformer layer with cross-layer KV sharing."""
+
+    def forward(
+        self,
+        dict_args: dict,
+    ):
+        """
+        Perform a forward pass through the transformer layer.
+
+        This method calls the core computation of a transformer layer, including
+        self-attention, cross-attention (if applicable), and feed-forward operations.
+        """
+        # Remove 'dynamic_inference_decode_only' from kwargs if present
+        # this is only used to uniquely identify decode and non-decode cuda graph
+        # runners in the cuda graph manager
+        dict_args.pop("dynamic_inference_decode_only", None)
+        keys = tuple(dict_args.keys())
+        values = tuple(dict_args.values())
+
+        is_mtp = dict_args.pop("is_mtp", False)
+        TransformerLayer._skip_mtp_probes = (
+            is_mtp  # Suppress MD5 probes for MTP passes
+        )
+
+        if self.config.block_attention_residuals and "blocks" not in dict_args:
+            dict_args["blocks"] = []
+
+        if self.full_recompute:
+
+            def dict_args_get_clone(key):
+                """Clone is necessary for some args."""
+                value = dict_args.get(key, None)
+                return value.clone() if value is not None else None
+
+            outputs = recompute(
+                self._forward_impl,
+                hidden_states=dict_args["hidden_states"],
+                attention_mask=dict_args.get("attention_mask", None),
+                attn_mask_startend_row_indices=dict_args_get_clone(
+                    "attn_mask_startend_row_indices"
+                ),
+                context=dict_args.get("context", None),
+                context_mask=dict_args.get("context_mask", None),
+                rotary_pos_emb=dict_args_get_clone("rotary_pos_emb"),
+                rotary_pos_cos=dict_args_get_clone("rotary_pos_cos"),
+                rotary_pos_sin=dict_args_get_clone("rotary_pos_sin"),
+                swa_rotary_pos_emb=dict_args_get_clone("swa_rotary_pos_emb"),
+                swa_rotary_pos_cos=dict_args_get_clone("swa_rotary_pos_cos"),
+                swa_rotary_pos_sin=dict_args_get_clone("swa_rotary_pos_sin"),
+                position_ids=dict_args_get_clone("position_ids"),
+                attention_bias=dict_args.get("attention_bias", None),
+                packed_seq_params=dict_args.get("packed_seq_params", None),
+                input_ids=dict_args.get("input_ids", None),
+                shared_key=dict_args.get("shared_key", None),
+                shared_block_indices=dict_args.get(
+                    "shared_block_indices", None
+                ),
+            )
+        else:
+            outputs = self._forward_impl(**dict_args)
+
+        if isinstance(outputs, tuple):
+            output, shared_key, shared_block_indices = outputs
+        else:
+            output, shared_key, shared_block_indices = outputs, None, None
+
+        rst = OrderedDict()
+        rst = {"hidden_states": output}
+        if shared_key is not None:
+            rst["shared_key"] = shared_key
+            rst["shared_block_indices"] = shared_block_indices
+        rst = {**dict_args, **rst}
+        return rst
+
+    def _forward_impl(
+        self,
+        hidden_states: Tensor,
+        attention_mask: Tensor | None = None,
+        attn_mask_startend_row_indices: Tensor | None = None,
+        context: Tensor | None = None,
+        context_mask: Tensor | None = None,
+        rotary_pos_emb: Tensor | None = None,
+        rotary_pos_cos: Tensor | None = None,
+        rotary_pos_sin: Tensor | None = None,
+        swa_rotary_pos_emb: Tensor | None = None,
+        swa_rotary_pos_cos: Tensor | None = None,
+        swa_rotary_pos_sin: Tensor | None = None,
+        position_ids: Tensor | None = None,
+        attention_bias: Tensor | None = None,
+        packed_seq_params: PackedSeqParams | None = None,
+        input_ids: Tensor | None = None,
+        shared_key: Tensor | None = None,
+        shared_block_indices: Tensor | None = None,
+        **kwargs,
+    ):
+        timer_name = "moe-mlp" if isinstance(self.mlp, MoELayer) else "mlp"
+
+        # 使用统一的 shared_kv 参数处理输入输出:
+        # 1. 对于 swa 层是输入, 只消费 shared_kv，不生产;
+        # 2. 对于 full 层是输出, 只生产 shared_kv, 不消费.
+        if self.self_attn.is_swa:
+            shared_kv = [shared_key, shared_block_indices]
+        else:
+            shared_kv = []
+
+        self._log_md5(hidden_states, "input", self.layer_number)
+        with profile("attn"):
+            hidden_states, context = self._forward_attention(
+                hidden_states=hidden_states,
+                attention_mask=attention_mask,
+                attn_mask_startend_row_indices=attn_mask_startend_row_indices,
+                context=context,
+                context_mask=context_mask,
+                rotary_pos_emb=rotary_pos_emb,
+                rotary_pos_cos=rotary_pos_cos,
+                rotary_pos_sin=rotary_pos_sin,
+                swa_rotary_pos_emb=swa_rotary_pos_emb,
+                swa_rotary_pos_cos=swa_rotary_pos_cos,
+                swa_rotary_pos_sin=swa_rotary_pos_sin,
+                position_ids=position_ids,
+                attention_bias=attention_bias,
+                packed_seq_params=packed_seq_params,
+                in_recompute=self.full_recompute,
+                input_ids=input_ids,
+                shared_kv=shared_kv,
+                **kwargs,
+            )
+        assert context is None, (
+            "HySparseTransformerLayer doesn't support cross-attention."
+        )
+        self._log_md5(hidden_states, "post_attn_residual", self.layer_number)
+        with profile(timer_name):
+            output = self._forward_mlp(hidden_states, input_ids=input_ids)
+        self._log_md5(output, "layer_output", self.layer_number)
+
+        if (not self.self_attn.is_swa) and shared_kv:
+            shared_key, shared_block_indices = shared_kv
+            if self.training and not paddle.is_grad_enabled():
+                shared_key.stop_gradient = False
+            return output, shared_key, shared_block_indices
+        return output
 
 
 class TransformerLayerWithOverlap(TransformerLayer):

--- a/tests/single_card_tests/test_mqa_self_attention.py
+++ b/tests/single_card_tests/test_mqa_self_attention.py
@@ -161,13 +161,13 @@ class TestMQASelfAttention(unittest.TestCase):
         full_layer = paddle.amp.decorate(
             full_layer, level="O2", dtype="bfloat16"
         )
+        full_layer.full_recompute = True
 
         swa_layer = HySparseTransformerLayer(
             self.config, layer_spec, layer_number=1
         )
         swa_layer.self_attn.attn_mask_type = AttnMaskType.causal
         swa_layer = paddle.amp.decorate(swa_layer, level="O2", dtype="bfloat16")
-        swa_layer.full_recompute = True
 
         hidden_states = paddle.randn(
             [self.batch_size, self.seq_len, self.config.hidden_size],

--- a/tests/single_card_tests/test_mqa_self_attention.py
+++ b/tests/single_card_tests/test_mqa_self_attention.py
@@ -1,0 +1,197 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import dataclasses
+import os
+import unittest
+
+os.environ["FLAGS_cudnn_deterministic"] = "True"
+
+import numpy as np
+import paddle
+from paddle.distributed.fleet.meta_parallel import LayerSpec
+
+from paddlefleet.fusions.fused_bias_dropout import get_bias_dropout_add
+from paddlefleet.tensor_parallel.layers import (
+    ColumnParallelLinear,
+    RowParallelLinear,
+)
+from paddlefleet.tensor_parallel.random import model_parallel_cuda_manual_seed
+from paddlefleet.transformer.dot_product_attention import DotProductAttention
+from paddlefleet.transformer.enums import AttnMaskType
+from paddlefleet.transformer.multi_latent_attention import (
+    MLASelfAttention,
+    MLASelfAttentionSublayersSpec,
+    MQASelfAttention,
+)
+from paddlefleet.transformer.paddle_norm import WrappedPaddleNorm
+from paddlefleet.transformer.transformer_config import TransformerConfig
+from paddlefleet.transformer.transformer_layer import (
+    HySparseTransformerLayer,
+    TransformerLayerSublayersSpec,
+)
+
+
+class TestMQASelfAttention(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        paddle.seed(2026)
+        model_parallel_cuda_manual_seed(2026)
+
+        cls.batch_size = 2
+        cls.seq_len = 4096
+
+        cls.config = TransformerConfig(
+            hidden_size=1536,
+            head_dim=128,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            gated_attention=True,
+            qk_rope_head_dim=64,
+            qk_nope_head_dim=192,
+            v_head_dim=256,
+            kv_lora_rank=192,
+            rope_theta=5000000,
+            use_qk_norm=True,
+            multi_latent_attention=True,
+            rope_type="rope",
+            add_swa_attention_sink_bias=False,
+            sliding_window=[128, 128],
+            window_attn_skip_freq=2,
+            enable_hy_sparse_attention=True,
+        )
+
+        cls.sublayer_spec = MLASelfAttentionSublayersSpec(
+            core_attention=DotProductAttention,
+            o_proj=RowParallelLinear,
+            gate_proj=ColumnParallelLinear,
+            q_a_proj=ColumnParallelLinear,
+            q_b_proj=ColumnParallelLinear,
+            kv_a_proj_with_mqa=ColumnParallelLinear,
+            kv_b_proj=ColumnParallelLinear,
+            q_a_layernorm=WrappedPaddleNorm,
+            kv_a_layernorm=WrappedPaddleNorm,
+        )
+
+    def test_forward_backward(self):
+        # use larger kv_lora_rank to force eager path
+        config = dataclasses.replace(self.config, kv_lora_rank=512)
+
+        mla = MLASelfAttention(
+            config,
+            self.sublayer_spec,
+            layer_number=0,
+            attn_mask_type=AttnMaskType.causal,
+        )
+        mla = paddle.amp.decorate(mla, level="O2", dtype="bfloat16")
+
+        mqa = MQASelfAttention(
+            config,
+            self.sublayer_spec,
+            layer_number=0,
+            attn_mask_type=AttnMaskType.causal,
+        )
+        mqa = paddle.amp.decorate(mqa, level="O2", dtype="bfloat16")
+        mqa.set_state_dict(mla.state_dict())
+
+        hidden_states = paddle.randn(
+            [self.batch_size, self.seq_len, config.hidden_size],
+            dtype="bfloat16",
+        )
+        hidden_states.stop_gradient = False
+
+        # Run MLA
+        mla_out, _ = mla(
+            hidden_states=hidden_states,
+            attention_mask=None,
+        )
+        output_grad = paddle.randn_like(mla_out) * 1e-2
+        mla_out.backward(output_grad)
+        mla_input_grad = hidden_states.grad
+
+        hidden_states = hidden_states.detach()
+        hidden_states.stop_gradient = False
+
+        # Run MQA
+        mqa_out, _ = mqa(
+            hidden_states=hidden_states,
+            attention_mask=None,
+        )
+        mqa_out.backward(output_grad)
+        mqa_input_grad = hidden_states.grad
+
+        # Compare
+        np.testing.assert_allclose(
+            mla_out.float(), mqa_out.float(), atol=2e-3, rtol=2e-3
+        )
+        np.testing.assert_allclose(
+            mla_input_grad.float(), mqa_input_grad.float(), atol=2e-3, rtol=2e-3
+        )
+        for mla_param, mqa_param in zip(mla.parameters(), mqa.parameters()):
+            np.testing.assert_allclose(
+                mla_param.grad.float(),
+                mqa_param.grad.float(),
+                atol=2e-3,
+                rtol=2e-3,
+            )
+
+    def test_kv_sharing(self):
+        layer_spec = TransformerLayerSublayersSpec(
+            self_attn=LayerSpec(
+                layer=MQASelfAttention,
+                sublayers_spec=self.sublayer_spec,
+            ),
+            self_attn_bda=get_bias_dropout_add,
+        )
+        full_layer = HySparseTransformerLayer(
+            self.config, layer_spec, layer_number=0
+        )
+        full_layer.self_attn.attn_mask_type = AttnMaskType.causal
+        full_layer = paddle.amp.decorate(
+            full_layer, level="O2", dtype="bfloat16"
+        )
+
+        swa_layer = HySparseTransformerLayer(
+            self.config, layer_spec, layer_number=1
+        )
+        swa_layer.self_attn.attn_mask_type = AttnMaskType.causal
+        swa_layer = paddle.amp.decorate(swa_layer, level="O2", dtype="bfloat16")
+        swa_layer.full_recompute = True
+
+        hidden_states = paddle.randn(
+            [self.batch_size, self.seq_len, self.config.hidden_size],
+            dtype="bfloat16",
+        )
+        attn_mask_startend_row_indices = paddle.full(
+            [self.batch_size, 1, self.seq_len, 1], self.seq_len, dtype="int32"
+        )
+
+        out_dict = full_layer(
+            {
+                "hidden_states": hidden_states,
+                "attn_mask_startend_row_indices": attn_mask_startend_row_indices,
+            }
+        )
+
+        self.assertTrue("shared_key" in out_dict)
+        self.assertTrue("shared_block_indices" in out_dict)
+
+        out_dict = swa_layer(out_dict)
+
+        self.assertTrue("shared_key" in out_dict)
+        self.assertFalse(out_dict["shared_key"].stop_gradient)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
Operator Mechanism

### PR Types
New features

### Description
实现了一种新的 MQASelfAttention 类，与原有的 MLA 在数学上等价

所谓 MQA（Multi-Query-Attention），就是把 MLA 的 kv_b_proj 的 k 和 v 的计算分别吸收到 q 侧和 o 侧；在 core_attention 看来，就是本来 qkv 都是 num_heads 个头，变成 MQA 之后只有 q 是 num_heads 个头，kv 都只有 1 个头

<b>当前限制：</b>
* 不支持 CP、TP、SP
* 由于 MQA 的 head_dim 通常很大（如512），FA 和 FlashMask 都不支持，所以会 fallback 到 eager，性能和显存无法保证，而且 eager 不支持 startend_row_indices

### 是否引起精度变化
是

<b>注：</b>MQA 和 MLA 在数学上等价，只是改变了矩阵乘的结合顺序，只有浮点精度的误差