### PR TITLE
[New feature] Add HySparse MQA/MLA block-sparse attention TileLang ops

### DIFF
--- a/src/paddlefleet/tilelang_ops/hysparse/__init__.py
+++ b/src/paddlefleet/tilelang_ops/hysparse/__init__.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""HySparse block-attention TileLang operators (paper arXiv 2602.03560).
+
+MQA/MLA variant: K/V are a single shared head, block selection is aggregated
+across the query group by a group-wise maximum, and the sparse branch gathers
+only the selected blocks.
+"""
+
+from .block_score_attn import (
+    block_score_mqa_attn_fwd,
+    block_scores_from_logit,
+)
+from .block_score_attn_bwd import block_score_mqa_bwd_interface
+from .block_sparse_attn_mqa import block_sparse_mqa_attn_fwd
+from .block_sparse_attn_mqa_bwd import block_sparse_mqa_bwd_interface
+from .pipeline import (
+    hysparse_forward_mqa,
+    select_topk_blocks,
+)
+
+__all__ = [
+    "block_score_mqa_attn_fwd",
+    "block_scores_from_logit",
+    "block_score_mqa_bwd_interface",
+    "block_sparse_mqa_attn_fwd",
+    "block_sparse_mqa_bwd_interface",
+    "hysparse_forward_mqa",
+    "select_topk_blocks",
+]

--- a/src/paddlefleet/tilelang_ops/hysparse/benchmark.py
+++ b/src/paddlefleet/tilelang_ops/hysparse/benchmark.py
@@ -1,0 +1,226 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Latency benchmark for the HySparse (MQA) block-attention operators.
+
+Times each operator (block-score fwd/bwd, block-sparse gather fwd/bwd, and the
+full block-score -> TopK -> block-sparse pipeline) and reports wall time plus
+peak allocated memory. Includes the target MLA scenario head_dim=576,
+num_heads=64, seq_len up to 32k.
+
+Run standalone::
+
+    python -m paddlefleet.tilelang_ops.hysparse.benchmark            # full sweep
+    python -m paddlefleet.tilelang_ops.hysparse.benchmark --mla-32k  # only 32k
+    python -m paddlefleet.tilelang_ops.hysparse.benchmark \
+        --seqlens 8192 --H 64 --D 576 --block-B 64 --topk 16
+"""
+
+import argparse
+import time
+
+import paddle
+
+paddle.enable_compat(scope={"tilelang"}, silent=True)
+
+from .block_score_attn import block_score_mqa_attn_fwd
+from .block_score_attn_bwd import block_score_mqa_bwd_interface
+from .block_sparse_attn_mqa import block_sparse_mqa_attn_fwd
+from .block_sparse_attn_mqa_bwd import block_sparse_mqa_bwd_interface
+from .pipeline import hysparse_forward_mqa
+from .reference import make_causal_valid_range
+
+
+def _sync():
+    paddle.device.synchronize()
+
+
+def _time_ms(fn, warmup=2, iters=5):
+    """Median-free mean latency in ms over ``iters`` runs after ``warmup``."""
+    for _ in range(warmup):
+        fn()
+    _sync()
+    t0 = time.time()
+    for _ in range(iters):
+        fn()
+    _sync()
+    return (time.time() - t0) / iters * 1000.0
+
+
+def _peak_gb():
+    return paddle.device.cuda.max_memory_allocated() / 1e9
+
+
+def _rand_inputs(B, S, H, D, seed=0):
+    paddle.seed(seed)
+    q = paddle.randn([B, S, H, D], dtype="bfloat16")
+    k = paddle.randn([B, S, D], dtype="bfloat16")
+    v = paddle.randn([B, S, D], dtype="bfloat16")
+    return q, k, v
+
+
+def bench_config(B, S, H, D, block_B, topk, do_bwd=True, iters=5):
+    """Benchmark every HySparse MQA op for one shape; returns a result dict."""
+    q, k, v = _rand_inputs(B, S, H, D)
+    vr = make_causal_valid_range(S, batch=B)
+    sm = D**-0.5
+    res = {"B": B, "S": S, "H": H, "D": D, "block_B": block_B, "topk": topk}
+
+    # block-score full-attention forward (emits per-block max logits)
+    paddle.device.cuda.reset_max_memory_allocated()
+    res["score_fwd"] = _time_ms(
+        lambda: block_score_mqa_attn_fwd(
+            q, k, v, vr, sm_scale=sm, block_B=block_B
+        ),
+        iters=iters,
+    )
+    o, lse, _ = block_score_mqa_attn_fwd(
+        q, k, v, vr, sm_scale=sm, block_B=block_B
+    )
+
+    # end-to-end pipeline (scoring -> TopK -> gather sparse attention)
+    paddle.device.cuda.reset_max_memory_allocated()
+    res["pipeline"] = _time_ms(
+        lambda: hysparse_forward_mqa(
+            q, k, v, vr, topk, sm_scale=sm, block_B=block_B
+        ),
+        iters=iters,
+    )
+    _, _, idx, _, _ = hysparse_forward_mqa(
+        q, k, v, vr, topk, sm_scale=sm, block_B=block_B
+    )
+    res["pipeline_peak_gb"] = _peak_gb()
+
+    # block-sparse gather forward, given the pipeline's selected indices
+    res["sparse_fwd"] = _time_ms(
+        lambda: block_sparse_mqa_attn_fwd(
+            q, k, v, idx, vr, sm_scale=sm, block_B=block_B
+        ),
+        iters=iters,
+    )
+    so, slse = block_sparse_mqa_attn_fwd(
+        q, k, v, idx, vr, sm_scale=sm, block_B=block_B
+    )
+
+    if do_bwd:
+        do = paddle.randn([B, S, H, D], dtype="bfloat16")
+        res["score_bwd"] = _time_ms(
+            lambda: block_score_mqa_bwd_interface(
+                q, k, v, o, do, lse, vr, sm_scale=sm, block_B=block_B
+            ),
+            iters=iters,
+        )
+        res["sparse_bwd"] = _time_ms(
+            lambda: block_sparse_mqa_bwd_interface(
+                q, k, v, so, do, slse, idx, vr, sm_scale=sm, block_B=block_B
+            ),
+            iters=iters,
+        )
+    return res
+
+
+_COLS = [
+    ("S", "S", 7),
+    ("H", "H", 4),
+    ("D", "D", 5),
+    ("topk", "topk", 5),
+    ("score_fwd", "scoreFwd", 10),
+    ("score_bwd", "scoreBwd", 10),
+    ("sparse_fwd", "sparseFwd", 10),
+    ("sparse_bwd", "sparseBwd", 10),
+    ("pipeline", "pipeline", 10),
+    ("pipeline_peak_gb", "peakGB", 8),
+]
+
+
+def _fmt(res):
+    cells = []
+    for key, _, w in _COLS:
+        v = res.get(key)
+        if v is None:
+            s = "-"
+        elif isinstance(v, float):
+            s = f"{v:.1f}"
+        else:
+            s = str(v)
+        cells.append(s.rjust(w))
+    return " ".join(cells)
+
+
+def _header():
+    return " ".join(h.rjust(w) for _, h, w in _COLS)
+
+
+def run_sweep(seqlens, H, D, block_B, topk, do_bwd, iters):
+    print(
+        f"HySparse MQA benchmark  (B=1, H={H}, D={D}, block_B={block_B}, "
+        f"units=ms, bf16)"
+    )
+    print(_header())
+    for S in seqlens:
+        res = bench_config(
+            1, S, H, D, block_B, topk, do_bwd=do_bwd, iters=iters
+        )
+        print(_fmt(res))
+
+
+def main():
+    p = argparse.ArgumentParser(description="HySparse MQA latency benchmark")
+    p.add_argument(
+        "--seqlens",
+        type=int,
+        nargs="+",
+        default=[2048, 4096, 8192, 16384, 32768],
+    )
+    p.add_argument("--H", type=int, default=64)
+    p.add_argument("--D", type=int, default=576)
+    p.add_argument("--block-B", type=int, default=64)
+    p.add_argument("--topk", type=int, default=16)
+    p.add_argument("--iters", type=int, default=5)
+    p.add_argument(
+        "--no-bwd",
+        action="store_true",
+        help="skip backward kernels (forward/pipeline only)",
+    )
+    p.add_argument(
+        "--mla-32k",
+        action="store_true",
+        help="only the MLA target: D=576,H=64,S=32768",
+    )
+    args = p.parse_args()
+
+    if args.mla_32k:
+        run_sweep(
+            [32768],
+            64,
+            576,
+            args.block_B,
+            args.topk,
+            not args.no_bwd,
+            args.iters,
+        )
+        return
+    run_sweep(
+        args.seqlens,
+        args.H,
+        args.D,
+        args.block_B,
+        args.topk,
+        not args.no_bwd,
+        args.iters,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/paddlefleet/tilelang_ops/hysparse/block_score_attn.py
+++ b/src/paddlefleet/tilelang_ops/hysparse/block_score_attn.py
@@ -253,6 +253,17 @@ def block_score_mqa_attn_fwd(q, k, v, valid_range, sm_scale=None, block_B=64):
     assert q.is_contiguous()
     b, s, h, d = q.shape
     s_kv = k.shape[1]
+    # lightweight host-side shape checks (no device sync) so mismatched inputs
+    # fail early and clearly instead of causing undefined kernel behaviour.
+    assert len(k.shape) == 3 and list(k.shape) == list(v.shape), (
+        f"k/v must be [B, S_kv, D] and match; got {k.shape} vs {v.shape}"
+    )
+    assert k.shape[0] == b and k.shape[2] == d, (
+        f"k/v batch/head_dim must match q; got k {k.shape}, q {q.shape}"
+    )
+    assert list(valid_range.shape) == [b, s, 2], (
+        f"valid_range must be [B, S, 2]; got {valid_range.shape}"
+    )
     if sm_scale is None:
         sm_scale = d**-0.5
     if valid_range.dtype != paddle.int32:

--- a/src/paddlefleet/tilelang_ops/hysparse/block_score_attn.py
+++ b/src/paddlefleet/tilelang_ops/hysparse/block_score_attn.py
@@ -1,0 +1,279 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Block-score attention (paper "Algorithm 1") with a single shared K/V head
+(MQA/MLA): full attention that additionally emits per-block max logits used to
+derive block-level selection scores.
+
+Q is ``[B, S, H, D]`` (H query heads); K, V are one shared head
+``[B, S_kv, D]``. Masking (causal + document) is expressed through
+``valid_range`` ``[B, S, 2]`` giving each query's half-open valid key column
+range ``[bos, eos)``.
+
+The forward returns:
+* ``Output``    ``[B, S, H, D]`` attention output.
+* ``Lse``       ``[B, S, H]`` natural log-sum-exp of the *scaled* logits.
+* ``BlockLogit`` ``[B, H, S, num_blocks]`` per-(query, key-block) max of the
+  *raw* (unscaled) ``q·k`` logit over valid columns; fully-masked blocks store
+  ``-inf``. The block-max softmax *probability* score of eq. (3) is recovered
+  on the host as ``exp(BlockLogit * sm_scale - Lse)`` (see
+  :func:`block_scores_from_logit`).
+
+The backward (:mod:`block_score_attn_bwd`) is a standard flash-attention
+backward (dQ, dK, dV); the block scores feed a non-differentiable TopK and
+therefore carry no gradient.
+"""
+
+import paddle
+import tilelang
+from tilelang import language as T
+
+
+@tilelang.jit(
+    out_idx=[-2, -1],
+    pass_configs={
+        tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
+        tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
+    },
+)
+def block_score_mqa_fwd(
+    H,
+    D,
+    sm_scale,
+    block_B=64,
+    num_stages=2,
+    threads=128,
+):
+    """Block-score kernel with a single shared K/V head (MQA/MLA scoring).
+
+    One program per query **token**, with the ``H`` query heads placed on the
+    GEMM ``M`` dimension (like the gather kernel). Blocks are
+    **document-relative**: block ``j`` of a query spans absolute key columns
+    ``[bos + j*block_B, bos + (j+1)*block_B)`` where ``bos`` is the query's
+    document start. The full-attention ``Output``/``Lse`` are unchanged (they
+    still sum over every valid key in ``[bos, eos)``); only the emitted
+    per-block max logit is binned relative to ``bos`` so downstream TopK
+    selects blocks exactly as if each document were processed standalone.
+    """
+    assert D % 16 == 0, (
+        f"D must be a multiple of 16 (tensor-core k-tile), got {D}"
+    )
+    assert H <= 128, "this kernel supports up to 128 query heads"
+    scale_log2 = sm_scale * 1.44269504  # log2(e), online softmax in base 2
+
+    batch = T.dynamic("batch")
+    seq_len = T.dynamic("seq_len")
+    seq_len_kv = T.dynamic("seq_len_kv")
+    num_blocks = T.dynamic("num_blocks")
+
+    q_shape = [batch, seq_len, H, D]
+    kv_shape = [batch, seq_len_kv, D]
+    o_shape = [batch, seq_len, H, D]
+    lse_shape = [batch, seq_len, H]
+    vr_shape = [batch, seq_len, 2]
+    blk_shape = [batch, H, seq_len, num_blocks]
+
+    dtype = T.bfloat16
+    accum_dtype = T.float32
+    idx_dtype = T.int32
+    PH = max(tilelang.math.next_power_of_2(H), 16)  # padded heads on M
+    BB = block_B
+
+    @T.prim_func
+    def main(
+        Q: T.Tensor(q_shape, dtype),
+        K: T.Tensor(kv_shape, dtype),
+        V: T.Tensor(kv_shape, dtype),
+        ValidRange: T.Tensor(vr_shape, idx_dtype),
+        BlockLogit: T.Tensor(blk_shape, accum_dtype),
+        Output: T.Tensor(o_shape, dtype),
+        Lse: T.Tensor(lse_shape, accum_dtype),
+    ):
+        with T.Kernel(seq_len, batch, threads=threads) as (bs, bb):
+            Q_shared = T.alloc_shared([PH, D], dtype)
+            K_shared = T.alloc_shared([BB, D], dtype)
+            V_shared = T.alloc_shared([BB, D], dtype)
+            P_shared = T.alloc_shared([PH, BB], dtype)
+
+            acc_o = T.alloc_fragment([PH, D], accum_dtype)
+            acc_s = T.alloc_fragment([PH, BB], accum_dtype)
+            blk_max = T.alloc_fragment([PH], accum_dtype)
+            m_i = T.alloc_fragment([PH], accum_dtype)
+            m_prev = T.alloc_fragment([PH], accum_dtype)
+            l_i = T.alloc_fragment([PH], accum_dtype)
+            l_new = T.alloc_fragment([PH], accum_dtype)
+            alpha = T.alloc_fragment([PH], accum_dtype)
+
+            T.fill(acc_o, 0)
+            T.fill(m_i, -(2**30))
+            T.fill(l_i, 0)
+
+            bos = ValidRange[bb, bs, 0]
+            eos = ValidRange[bb, bs, 1]
+
+            # load this token's H query heads onto M (pad rows >= H with 0)
+            for h, d in T.Parallel(PH, D):
+                Q_shared[h, d] = T.if_then_else(
+                    h < H, Q[bb, bs, h, d], T.cast(0, dtype)
+                )
+
+            # causal/document early-exit: only this token's own valid blocks
+            # (relative block j in [0, ceil((eos-bos)/block_B))) can hold a
+            # valid key; every later block is fully masked (all cols >= eos)
+            # and contributes nothing to out/lse. Its per-block max logit would
+            # be -inf, which the host ``BlockLogit`` buffer is pre-filled with,
+            # so skipping those blocks is exact. For pure causal this halves the
+            # work; for packed documents a token only scans its own document.
+            num_valid_blocks = T.ceildiv(eos - bos, BB)
+            for j in T.Pipelined(num_valid_blocks, num_stages=num_stages):
+                # gather relative block j: cols [bos + j*BB, bos + (j+1)*BB).
+                # Guard the read against the padded K/V length (cols >= eos are
+                # masked below, so a clamped dummy read is harmless).
+                for c, d in T.Parallel(BB, D):
+                    col = bos + j * BB + c
+                    in_bounds = col < seq_len_kv
+                    safe_col = T.if_then_else(in_bounds, col, 0)
+                    K_shared[c, d] = T.if_then_else(
+                        in_bounds, K[bb, safe_col, d], T.cast(0, dtype)
+                    )
+                    V_shared[c, d] = T.if_then_else(
+                        in_bounds, V[bb, safe_col, d], T.cast(0, dtype)
+                    )
+
+                # raw q·k^T
+                T.clear(acc_s)
+                T.gemm(
+                    Q_shared,
+                    K_shared,
+                    acc_s,
+                    transpose_B=True,
+                    policy=T.GemmWarpPolicy.FullRow,
+                )
+
+                # causal + document mask (col >= bos automatic for block j)
+                for h, c in T.Parallel(PH, BB):
+                    col = bos + j * BB + c
+                    acc_s[h, c] = T.if_then_else(
+                        col < eos, acc_s[h, c], -T.infinity(accum_dtype)
+                    )
+
+                # per-block max of raw logit over valid cols -> block score src
+                T.reduce_max(acc_s, blk_max, dim=1, clear=True)
+                for h in T.Parallel(PH):
+                    if h < H:
+                        BlockLogit[bb, h, bs, j] = blk_max[h]
+
+                # online softmax (base 2) over scaled logits
+                T.copy(m_i, m_prev)
+                for h in T.Parallel(PH):
+                    m_i[h] = T.max(m_i[h], blk_max[h] * sm_scale)
+                for h in T.Parallel(PH):
+                    alpha[h] = T.exp2((m_prev[h] - m_i[h]) * 1.44269504)
+                for h, c in T.Parallel(PH, BB):
+                    acc_s[h, c] = T.exp2(
+                        acc_s[h, c] * scale_log2 - m_i[h] * 1.44269504
+                    )
+                T.reduce_sum(acc_s, l_new, dim=1)
+                for h in T.Parallel(PH):
+                    l_i[h] = l_i[h] * alpha[h] + l_new[h]
+                for h, d in T.Parallel(PH, D):
+                    acc_o[h, d] = acc_o[h, d] * alpha[h]
+                T.copy(acc_s, P_shared)
+                T.gemm(
+                    P_shared, V_shared, acc_o, policy=T.GemmWarpPolicy.FullRow
+                )
+
+            # normalize; empty rows (no valid key) -> 0 out / -inf lse
+            for h, d in T.Parallel(PH, D):
+                acc_o[h, d] = T.if_then_else(
+                    l_i[h] > 0, acc_o[h, d] / l_i[h], 0.0
+                )
+            for h, d in T.Parallel(PH, D):
+                if h < H:
+                    Output[bb, bs, h, d] = acc_o[h, d]
+            for h in T.Parallel(PH):
+                if h < H:
+                    Lse[bb, bs, h] = T.if_then_else(
+                        l_i[h] > 0,
+                        m_i[h] + T.log(l_i[h]),
+                        -T.infinity(accum_dtype),
+                    )
+
+    return main
+
+
+def block_scores_from_logit(block_logit, lse, sm_scale):
+    """Recover eq.(3) block-max probability scores on the host.
+
+    Args:
+        block_logit: [B, H, S, num_blocks] raw per-block max logit (-inf if
+            fully masked), as returned by the forward kernel.
+        lse:         [B, S, H] natural-log LSE from the forward kernel.
+        sm_scale:    softmax scale.
+
+    Returns:
+        [B, H, S, num_blocks] block-max softmax probabilities in [0, 1];
+        fully-masked blocks are 0.
+    """
+    lse_bhs = lse.transpose([0, 2, 1]).unsqueeze(-1)  # [B,H,S,1]
+    scaled = block_logit.astype("float32") * sm_scale - lse_bhs
+    scores = paddle.exp(scaled)
+    # exp(-inf) already 0, but guard any nan from (-inf)-(-inf) style edge.
+    scores = paddle.where(
+        paddle.isfinite(scores), scores, paddle.zeros_like(scores)
+    )
+    return scores
+
+
+def block_score_mqa_attn_fwd(q, k, v, valid_range, sm_scale=None, block_B=64):
+    """Forward interface for the MQA (shared K/V head) block-score attention.
+
+    Args:
+        q:           [B, S, H, D] bf16 query (H heads).
+        k, v:        [B, S_kv, D] bf16 single shared key/value head.
+        valid_range: [B, S, 2] int32 per-query [bos, eos) valid key columns.
+        sm_scale:    softmax scale; defaults to D**-0.5.
+        block_B:     key block size.
+
+    Returns:
+        out [B,S,H,D], lse [B,S,H], block_logit [B,H,S,num_blocks] where
+        num_blocks = ceil(S_kv / block_B).
+    """
+    assert q.is_contiguous()
+    b, s, h, d = q.shape
+    s_kv = k.shape[1]
+    if sm_scale is None:
+        sm_scale = d**-0.5
+    if valid_range.dtype != paddle.int32:
+        valid_range = valid_range.cast("int32")
+
+    # kernel reads whole block_B blocks; pad K/V so the last block is in bounds
+    pad = (block_B - s_kv % block_B) % block_B
+    if pad > 0:
+        k = paddle.nn.functional.pad(k, [0, 0, 0, pad])
+        v = paddle.nn.functional.pad(v, [0, 0, 0, pad])
+    k = k.contiguous()
+    v = v.contiguous()
+    valid_range = valid_range.contiguous()
+    num_blocks = (s_kv + pad) // block_B
+
+    # Blocks past a token's own valid range are skipped by the kernel's
+    # causal/document early-exit, so their per-block max logit must already read
+    # as -inf (score 0). Pre-fill instead of leaving the buffer uninitialised.
+    block_logit = paddle.full(
+        [b, h, s, num_blocks], float("-inf"), dtype="float32"
+    )
+    kernel = block_score_mqa_fwd(h, d, float(sm_scale), block_B=block_B)
+    out, lse = kernel(q, k, v, valid_range, block_logit)
+    return out, lse, block_logit

--- a/src/paddlefleet/tilelang_ops/hysparse/block_score_attn_bwd.py
+++ b/src/paddlefleet/tilelang_ops/hysparse/block_score_attn_bwd.py
@@ -1,0 +1,335 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Backward for the MQA block-score attention: flash-attention backward
+(dQ, dK, dV) for full attention with a single shared K/V head and causal +
+document masking.
+
+K/V are one shared head ``[B, S_kv, D]``; dK/dV from every query head are
+scattered into that single head via ``atomic_add``. The block-score output of
+the forward is consumed by a non-differentiable TopK and therefore contributes
+no gradient here.
+"""
+
+import paddle
+import tilelang
+from tilelang import language as T
+
+from .block_sparse_attn_mqa_bwd import _cast_bf16_kv
+
+
+@tilelang.jit(
+    out_idx=[-1],
+    pass_configs={
+        tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
+        tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
+    },
+)
+def block_score_mqa_bwd(
+    H,
+    D,
+    sm_scale,
+    block_M=64,
+    block_N=64,
+    block_B=64,
+    num_stages=1,
+    threads=128,
+):
+    assert D % 16 == 0, (
+        f"D must be a multiple of 16 (tensor-core k-tile), got {D}"
+    )
+    assert block_B % block_N == 0, "block_B must be a multiple of block_N"
+
+    batch = T.dynamic("batch")
+    seq_len = T.dynamic("seq_len")
+    seq_len_kv = T.dynamic("seq_len_kv")
+    num_bm = T.dynamic("num_bm")
+
+    q_shape = [batch, seq_len, H, D]
+    kv_shape = [batch, seq_len_kv, D]
+    lse_shape = [batch, seq_len, H]
+    vr_shape = [batch, seq_len, 2]
+    br_shape = [batch, num_bm, 2]
+
+    dtype = T.bfloat16
+    accum_dtype = T.float32
+    idx_dtype = T.int32
+    BM = block_M
+    BN = block_N
+    ratio = (
+        block_B // block_N
+    )  # key sub-tiles per block_B-sized selection block
+
+    @T.prim_func
+    def main(
+        Q: T.Tensor(q_shape, dtype),
+        K: T.Tensor(kv_shape, dtype),
+        V: T.Tensor(kv_shape, dtype),
+        dO: T.Tensor(q_shape, dtype),
+        Lse: T.Tensor(lse_shape, accum_dtype),
+        Delta: T.Tensor(lse_shape, accum_dtype),
+        ValidRange: T.Tensor(vr_shape, idx_dtype),
+        BlockRange: T.Tensor(br_shape, idx_dtype),
+        dK: T.Tensor(kv_shape, accum_dtype),
+        dV: T.Tensor(kv_shape, accum_dtype),
+        dQ: T.Tensor(q_shape, dtype),
+    ):
+        with T.Kernel(T.ceildiv(seq_len, BM), H, batch, threads=threads) as (
+            bm,
+            bh,
+            bb,
+        ):
+            Q_shared = T.alloc_shared([BM, D], dtype)
+            dO_shared = T.alloc_shared([BM, D], dtype)
+            K_shared = T.alloc_shared([BN, D], dtype)
+            V_shared = T.alloc_shared([BN, D], dtype)
+            P_shared = T.alloc_shared([BM, BN], dtype)
+            dS_shared = T.alloc_shared([BM, BN], dtype)
+
+            acc_s = T.alloc_fragment([BM, BN], accum_dtype)
+            acc_p = T.alloc_fragment([BM, BN], accum_dtype)
+            acc_dp = T.alloc_fragment([BM, BN], accum_dtype)
+            acc_dq = T.alloc_fragment([BM, D], accum_dtype)
+            acc_dk = T.alloc_fragment([BN, D], accum_dtype)
+            acc_dv = T.alloc_fragment([BN, D], accum_dtype)
+            lse_f = T.alloc_fragment([BM], accum_dtype)
+            delta_f = T.alloc_fragment([BM], accum_dtype)
+            bos = T.alloc_fragment([BM], idx_dtype)
+            eos = T.alloc_fragment([BM], idx_dtype)
+
+            for i in T.Parallel(BM):
+                row = bm * BM + i
+                in_range = row < seq_len
+                bos[i] = T.if_then_else(in_range, ValidRange[bb, row, 0], 0)
+                eos[i] = T.if_then_else(in_range, ValidRange[bb, row, 1], 0)
+                lse_f[i] = T.if_then_else(in_range, Lse[bb, row, bh], 0)
+                delta_f[i] = T.if_then_else(in_range, Delta[bb, row, bh], 0)
+
+            T.copy(Q[bb, bm * BM : (bm + 1) * BM, bh, :], Q_shared)
+            T.copy(dO[bb, bm * BM : (bm + 1) * BM, bh, :], dO_shared)
+            T.clear(acc_dq)
+
+            # document-tight early-exit: the host precomputes, per query tile,
+            # the block-B key window [jl, jh) actually reachable by this tile's
+            # rows -- jl = min_i(bos_i) // block_B skips leading blocks before
+            # the tile's document start; jh = ceil(max_i(eos_i) / block_B) skips
+            # blocks past the (causal) end. Every skipped block is fully masked
+            # (col < bos_i or col >= eos_i) for all rows, so dQ/dK/dV are
+            # unchanged. The window is in block_B units; we iterate it in
+            # ``block_N`` sub-tiles (``ratio`` per block) so the K/V/P/dS shared
+            # buffers stay small enough to fit a full block_M=64 query tile at
+            # large head dims (D=576) -- bigger M matches the forward's
+            # tensor-core utilisation and K/V amortisation.
+            jl = BlockRange[bb, bm, 0]
+            jh = BlockRange[bb, bm, 1]
+            for nn in T.Pipelined((jh - jl) * ratio, num_stages=num_stages):
+                col0 = (jl * ratio + nn) * BN
+                # single shared K/V head -> no head index
+                T.copy(K[bb, col0 : col0 + BN, :], K_shared)
+                T.copy(V[bb, col0 : col0 + BN, :], V_shared)
+
+                # P = softmax prob = exp(raw*sm_scale - lse); masked -> 0
+                T.clear(acc_s)
+                T.gemm(
+                    Q_shared,
+                    K_shared,
+                    acc_s,
+                    transpose_B=True,
+                    policy=T.GemmWarpPolicy.FullRow,
+                )
+                for i, c in T.Parallel(BM, BN):
+                    col = col0 + c
+                    keep = (col >= bos[i]) and (col < eos[i])
+                    acc_p[i, c] = T.if_then_else(
+                        keep,
+                        T.exp2(
+                            (acc_s[i, c] * sm_scale - lse_f[i]) * 1.44269504
+                        ),
+                        0.0,
+                    )
+                T.copy(acc_p, P_shared)
+
+                # dP = dO @ V^T
+                T.clear(acc_dp)
+                T.gemm(
+                    dO_shared,
+                    V_shared,
+                    acc_dp,
+                    transpose_B=True,
+                    policy=T.GemmWarpPolicy.FullRow,
+                )
+                # dS = P * (dP - Delta) * sm_scale
+                for i, c in T.Parallel(BM, BN):
+                    acc_dp[i, c] = (
+                        acc_p[i, c] * (acc_dp[i, c] - delta_f[i]) * sm_scale
+                    )
+                T.copy(acc_dp, dS_shared)
+
+                # dQ += dS @ K
+                T.gemm(
+                    dS_shared,
+                    K_shared,
+                    acc_dq,
+                    policy=T.GemmWarpPolicy.FullRow,
+                )
+                # dV += P^T @ dO ; dK += dS^T @ Q  (scattered to shared KV)
+                T.clear(acc_dv)
+                T.gemm(
+                    P_shared,
+                    dO_shared,
+                    acc_dv,
+                    transpose_A=True,
+                    policy=T.GemmWarpPolicy.FullRow,
+                )
+                T.clear(acc_dk)
+                T.gemm(
+                    dS_shared,
+                    Q_shared,
+                    acc_dk,
+                    transpose_A=True,
+                    policy=T.GemmWarpPolicy.FullRow,
+                )
+                for c, d in T.Parallel(BN, D):
+                    T.atomic_add(dV[bb, col0 + c, d], acc_dv[c, d])
+                    T.atomic_add(dK[bb, col0 + c, d], acc_dk[c, d])
+
+            # write dQ straight from the accumulator fragment (no shared-memory
+            # staging) -- one fewer [BM, D] bf16 buffer lets the shared budget
+            # fit a larger query tile (bigger M -> better tensor-core use).
+            for i, d in T.Parallel(BM, D):
+                if bm * BM + i < seq_len:
+                    dQ[bb, bm * BM + i, bh, d] = acc_dq[i, d]
+
+    return main
+
+
+def _fit_block_mn(D, block_B, cap_bytes=230000):
+    """Pick (block_M, block_N) maximising the query tile then the key sub-tile.
+
+    The backward holds Q/dO ``[block_M, D]`` + K/V ``[block_N, D]`` + P/dS
+    ``[block_M, block_N]`` in bf16 shared memory (dQ writes straight from its
+    accumulator). Prefer the largest ``block_M`` (<=64) -- big M matches the
+    forward's tensor-core utilisation and K/V amortisation -- and, for that M,
+    the largest ``block_N`` (dividing ``block_B``) that fits. At MLA D=576 a
+    full block_M=64 needs block_N=32 to fit Blackwell's ~227 KB; small dims
+    (D=64) keep block_N=block_B (single-tile fast path).
+    """
+    cands_n = [n for n in (block_B, 32, 16) if block_B % n == 0]
+    cands_n = sorted(set(cands_n), reverse=True)
+    for bm in (64, 48, 32, 16):
+        for bn in cands_n:
+            shared = 4 * (bm * D + bn * D + bm * bn)
+            if shared <= cap_bytes:
+                return bm, bn
+    return 16, min(16, block_B)
+
+
+def block_score_mqa_bwd_interface(
+    q,
+    k,
+    v,
+    o,
+    do,
+    lse,
+    valid_range,
+    sm_scale=None,
+    block_B=64,
+    block_M=None,
+    block_N=None,
+):
+    """Backward interface for the MQA block-score attention.
+
+    Args:
+        q:           [B, S, H, D] bf16 forward query.
+        k, v:        [B, S_kv, D] bf16 single shared key/value head.
+        o:           [B, S, H, D] bf16 forward output.
+        do:          [B, S, H, D] bf16 grad of output.
+        lse:         [B, S, H] fp32 natural-log LSE from forward.
+        valid_range: [B, S, 2] int32.
+        sm_scale:    softmax scale; defaults to D**-0.5.
+        block_B:     key block size.
+        block_M:     query tile size on the GEMM M dim; ``None`` auto-fits the
+                     largest tile that fits shared memory (:func:`_fit_block_mn`).
+        block_N:     key sub-tile size (must divide ``block_B``); ``None``
+                     auto-fits. Overrides are for tuning/testing the tiling; the
+                     result is mathematically identical for any valid choice.
+
+    Returns:
+        dq [B,S,H,D] bf16, dk/dv [B,S_kv,D] bf16.
+    """
+    assert q.is_contiguous() and do.is_contiguous() and lse.is_contiguous()
+    b, s, h, d = q.shape
+    s_kv = k.shape[1]
+    if sm_scale is None:
+        sm_scale = d**-0.5
+    if valid_range.dtype != paddle.int32:
+        valid_range = valid_range.cast("int32")
+
+    # kernel reads whole block_B blocks; pad K/V (and dK/dV) so the last block
+    # is addressable.
+    pad = (block_B - s_kv % block_B) % block_B
+    s_kv_pad = s_kv + pad
+    if pad > 0:
+        k = paddle.nn.functional.pad(k, [0, 0, 0, pad])
+        v = paddle.nn.functional.pad(v, [0, 0, 0, pad])
+    k = k.contiguous()
+    v = v.contiguous()
+    valid_range = valid_range.contiguous()
+
+    delta = (o.astype("float32") * do.astype("float32")).sum(-1).contiguous()
+    dk = paddle.zeros([b, s_kv_pad, d], dtype="float32")
+    dv = paddle.zeros([b, s_kv_pad, d], dtype="float32")
+
+    fit_m, fit_n = _fit_block_mn(d, block_B)
+    if block_M is None:
+        block_M = fit_m
+    if block_N is None:
+        block_N = fit_n
+    num_kv_blocks = s_kv_pad // block_B
+
+    # Per query-tile key-block window [jl, jh): jl skips leading blocks before
+    # the tile's document start, jh caps at the tile's (causal) reach. Rows are
+    # grouped into tiles of ``block_M``; padded rows get bos=+big / eos=0 so
+    # they never widen a tile's window.
+    num_bm = (s + block_M - 1) // block_M
+    pad_rows = num_bm * block_M - s
+    bos = valid_range[:, :, 0]
+    eos = valid_range[:, :, 1]
+    if pad_rows > 0:
+        bos = paddle.nn.functional.pad(bos, [0, pad_rows], value=s_kv_pad)
+        eos = paddle.nn.functional.pad(eos, [0, pad_rows], value=0)
+    bos = bos.reshape([b, num_bm, block_M])
+    eos = eos.reshape([b, num_bm, block_M])
+    jl = (bos.min(-1) // block_B).clip(0, num_kv_blocks)
+    jh = ((eos.max(-1) + block_B - 1) // block_B).clip(0, num_kv_blocks)
+    jh = paddle.maximum(jh, jl)
+    block_range = paddle.stack([jl, jh], axis=-1).astype("int32").contiguous()
+
+    bwd = block_score_mqa_bwd(
+        h,
+        d,
+        float(sm_scale),
+        block_M=block_M,
+        block_N=block_N,
+        block_B=block_B,
+    )
+    dq = bwd(q, k, v, do, lse, delta, valid_range, block_range, dk, dv)
+
+    cast = _cast_bf16_kv(d)
+    dk_bf = cast(dk)
+    dv_bf = cast(dv)
+    if pad > 0:
+        dk_bf = dk_bf[:, :s_kv, :].contiguous()
+        dv_bf = dv_bf[:, :s_kv, :].contiguous()
+    return dq, dk_bf, dv_bf

--- a/src/paddlefleet/tilelang_ops/hysparse/block_sparse_attn_mqa.py
+++ b/src/paddlefleet/tilelang_ops/hysparse/block_sparse_attn_mqa.py
@@ -1,0 +1,241 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Block-sparse attention (MQA gather): per-query-token block-sparse attention
+with a single shared Key/Value head.
+
+Unlike the dense-mask variant (:mod:`block_sparse_attn`), this kernel actually
+**gathers only the selected key blocks** and skips the rest, so its cost scales
+with ``nsel`` (selected blocks) instead of the full sequence length.
+
+Efficiency comes from the MQA/MLA layout: K/V is a single head shared by all
+query heads, and the TopK block indices are shared across heads. The kernel
+therefore places the ``H`` query heads on the GEMM ``M`` dimension (one query
+token per program), so a single gathered key block feeds every head and the
+GEMM is wide enough to saturate tensor cores. This mirrors the repo's
+``sparse_mqa`` kernel but gathers whole ``block_B``-sized key blocks and applies
+the causal + document ``valid_range`` column mask inside the kernel.
+
+Layout:
+* ``Q``           ``[B, S, H, D]`` bf16.
+* ``K``, ``V``    ``[B, S_kv, D]`` bf16 (single shared head).
+* ``Indices``     ``[B, S, nsel]`` int32 block ids (``-1`` = padding), shared
+  across heads.
+* ``ValidRange``  ``[B, S, 2]`` int32 per-query ``[bos, eos)``.
+* ``Output``      ``[B, S, H, D]`` bf16, ``Lse`` ``[B, S, H]`` fp32 natural-log.
+"""
+
+import paddle
+import tilelang
+from tilelang import language as T
+
+
+@tilelang.jit(
+    out_idx=[-2, -1],
+    pass_configs={
+        tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
+        tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
+    },
+)
+def block_sparse_mqa_fwd(
+    H,
+    D,
+    nsel,
+    sm_scale,
+    block_B=64,
+    num_stages=2,
+    threads=128,
+):
+    assert D % 16 == 0, (
+        f"D must be a multiple of 16 (tensor-core k-tile), got {D}"
+    )
+    assert H <= 128, "this kernel supports up to 128 query heads"
+    scale_log2 = sm_scale * 1.44269504
+
+    batch = T.dynamic("batch")
+    seq_len = T.dynamic("seq_len")
+    seq_len_kv = T.dynamic("seq_len_kv")
+
+    q_shape = [batch, seq_len, H, D]
+    kv_shape = [batch, seq_len_kv, D]
+    o_shape = [batch, seq_len, H, D]
+    idx_shape = [batch, seq_len, nsel]
+    vr_shape = [batch, seq_len, 2]
+    lse_shape = [batch, seq_len, H]
+
+    dtype = T.bfloat16
+    accum_dtype = T.float32
+    idx_dtype = T.int32
+    PH = max(tilelang.math.next_power_of_2(H), 16)  # padded heads on M
+    BB = block_B
+
+    @T.prim_func
+    def main(
+        Q: T.Tensor(q_shape, dtype),
+        K: T.Tensor(kv_shape, dtype),
+        V: T.Tensor(kv_shape, dtype),
+        Indices: T.Tensor(idx_shape, idx_dtype),
+        ValidRange: T.Tensor(vr_shape, idx_dtype),
+        Output: T.Tensor(o_shape, dtype),
+        Lse: T.Tensor(lse_shape, accum_dtype),
+    ):
+        with T.Kernel(seq_len, batch, threads=threads) as (bs, bb):
+            Q_shared = T.alloc_shared([PH, D], dtype)
+            K_shared = T.alloc_shared([BB, D], dtype)
+            V_shared = T.alloc_shared([BB, D], dtype)
+            P_shared = T.alloc_shared([PH, BB], dtype)
+
+            acc_o = T.alloc_fragment([PH, D], accum_dtype)
+            acc_s = T.alloc_fragment([PH, BB], accum_dtype)
+            row_max = T.alloc_fragment([PH], accum_dtype)
+            m_i = T.alloc_fragment([PH], accum_dtype)
+            m_prev = T.alloc_fragment([PH], accum_dtype)
+            l_i = T.alloc_fragment([PH], accum_dtype)
+            l_new = T.alloc_fragment([PH], accum_dtype)
+            alpha = T.alloc_fragment([PH], accum_dtype)
+
+            T.fill(acc_o, 0)
+            T.fill(m_i, -(2**30))
+            T.fill(l_i, 0)
+
+            bos = ValidRange[bb, bs, 0]
+            eos = ValidRange[bb, bs, 1]
+
+            # load this token's H query heads onto M (pad rows >= H with 0)
+            for h, d in T.Parallel(PH, D):
+                Q_shared[h, d] = T.if_then_else(
+                    h < H, Q[bb, bs, h, d], T.cast(0, dtype)
+                )
+
+            for i in T.Pipelined(nsel, num_stages=num_stages):
+                blk = Indices[bb, bs, i]
+                valid_blk = blk >= 0
+                safe_blk = T.if_then_else(valid_blk, blk, 0)
+
+                # gather one selected block. Block ids are document-relative:
+                # relative block ``blk`` spans absolute columns
+                # [bos + blk*BB, bos + (blk+1)*BB). Guard the read against the
+                # padded K/V length (columns >= eos are masked out below, so a
+                # clamped dummy read is harmless).
+                for c, d in T.Parallel(BB, D):
+                    col = bos + safe_blk * BB + c
+                    in_bounds = col < seq_len_kv
+                    safe_col = T.if_then_else(in_bounds, col, 0)
+                    K_shared[c, d] = T.if_then_else(
+                        in_bounds, K[bb, safe_col, d], T.cast(0, dtype)
+                    )
+                    V_shared[c, d] = T.if_then_else(
+                        in_bounds, V[bb, safe_col, d], T.cast(0, dtype)
+                    )
+
+                T.clear(acc_s)
+                T.gemm(
+                    Q_shared,
+                    K_shared,
+                    acc_s,
+                    transpose_B=True,
+                    policy=T.GemmWarpPolicy.FullRow,
+                )
+
+                # mask: keep column iff block valid and in [bos, eos). The
+                # relative column bos + blk*BB + c is always >= bos, so only the
+                # upper bound needs checking.
+                for h, c in T.Parallel(PH, BB):
+                    col = bos + safe_blk * BB + c
+                    keep = valid_blk and (col < eos)
+                    acc_s[h, c] = T.if_then_else(
+                        keep, acc_s[h, c], -T.infinity(accum_dtype)
+                    )
+
+                # online softmax (base 2)
+                T.reduce_max(acc_s, row_max, dim=1, clear=True)
+                T.copy(m_i, m_prev)
+                for h in T.Parallel(PH):
+                    m_i[h] = T.max(m_i[h], row_max[h] * sm_scale)
+                for h in T.Parallel(PH):
+                    alpha[h] = T.exp2((m_prev[h] - m_i[h]) * 1.44269504)
+                for h, c in T.Parallel(PH, BB):
+                    acc_s[h, c] = T.exp2(
+                        acc_s[h, c] * scale_log2 - m_i[h] * 1.44269504
+                    )
+                T.reduce_sum(acc_s, l_new, dim=1)
+                for h in T.Parallel(PH):
+                    l_i[h] = l_i[h] * alpha[h] + l_new[h]
+                for h, d in T.Parallel(PH, D):
+                    acc_o[h, d] = acc_o[h, d] * alpha[h]
+                T.copy(acc_s, P_shared)
+                T.gemm(
+                    P_shared, V_shared, acc_o, policy=T.GemmWarpPolicy.FullRow
+                )
+
+            # normalize; empty rows (no selected valid key) -> 0 out / -inf lse
+            for h, d in T.Parallel(PH, D):
+                acc_o[h, d] = T.if_then_else(
+                    l_i[h] > 0, acc_o[h, d] / l_i[h], 0.0
+                )
+            for h, d in T.Parallel(PH, D):
+                if h < H:
+                    Output[bb, bs, h, d] = acc_o[h, d]
+            for h in T.Parallel(PH):
+                if h < H:
+                    Lse[bb, bs, h] = T.if_then_else(
+                        l_i[h] > 0,
+                        m_i[h] + T.log(l_i[h]),
+                        -T.infinity(accum_dtype),
+                    )
+
+    return main
+
+
+def block_sparse_mqa_attn_fwd(
+    q, k, v, indices, valid_range, sm_scale=None, block_B=64
+):
+    """Forward interface for the MQA gather block-sparse attention.
+
+    Args:
+        q:           [B, S, H, D] bf16.
+        k, v:        [B, S_kv, D] bf16 shared key/value.
+        indices:     [B, S, nsel] int32 block ids (-1 padding), shared heads.
+        valid_range: [B, S, 2] int32.
+        sm_scale:    softmax scale; defaults to D**-0.5.
+        block_B:     key block size.
+
+    Returns:
+        out [B,S,H,D] bf16, lse [B,S,H] fp32 (natural log; empty rows -inf).
+    """
+    assert q.is_contiguous()
+    b, s, h, d = q.shape
+    s_kv = k.shape[1]
+    nsel = indices.shape[-1]
+    if sm_scale is None:
+        sm_scale = d**-0.5
+    if valid_range.dtype != paddle.int32:
+        valid_range = valid_range.cast("int32")
+    if indices.dtype != paddle.int32:
+        indices = indices.cast("int32")
+
+    # kernel gathers whole block_B blocks without bounds clamping, so pad
+    # K/V so the last block is fully addressable.
+    pad = (block_B - s_kv % block_B) % block_B
+    if pad > 0:
+        k = paddle.nn.functional.pad(k, [0, 0, 0, pad])
+        v = paddle.nn.functional.pad(v, [0, 0, 0, pad])
+    k = k.contiguous()
+    v = v.contiguous()
+    valid_range = valid_range.contiguous()
+    indices = indices.contiguous()
+
+    kernel = block_sparse_mqa_fwd(h, d, nsel, float(sm_scale), block_B=block_B)
+    out, lse = kernel(q, k, v, indices, valid_range)
+    return out, lse

--- a/src/paddlefleet/tilelang_ops/hysparse/block_sparse_attn_mqa.py
+++ b/src/paddlefleet/tilelang_ops/hysparse/block_sparse_attn_mqa.py
@@ -218,6 +218,20 @@ def block_sparse_mqa_attn_fwd(
     b, s, h, d = q.shape
     s_kv = k.shape[1]
     nsel = indices.shape[-1]
+    # lightweight host-side shape checks (no device sync) so mismatched inputs
+    # fail early and clearly instead of causing undefined kernel behaviour.
+    assert len(k.shape) == 3 and list(k.shape) == list(v.shape), (
+        f"k/v must be [B, S_kv, D] and match; got {k.shape} vs {v.shape}"
+    )
+    assert k.shape[0] == b and k.shape[2] == d, (
+        f"k/v batch/head_dim must match q; got k {k.shape}, q {q.shape}"
+    )
+    assert list(indices.shape[:2]) == [b, s], (
+        f"indices must be [B, S, nsel] matching q; got {indices.shape}"
+    )
+    assert list(valid_range.shape) == [b, s, 2], (
+        f"valid_range must be [B, S, 2]; got {valid_range.shape}"
+    )
     if sm_scale is None:
         sm_scale = d**-0.5
     if valid_range.dtype != paddle.int32:

--- a/src/paddlefleet/tilelang_ops/hysparse/block_sparse_attn_mqa_bwd.py
+++ b/src/paddlefleet/tilelang_ops/hysparse/block_sparse_attn_mqa_bwd.py
@@ -1,0 +1,320 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Backward for the MQA gather block-sparse attention
+(:mod:`block_sparse_attn_mqa`).
+
+Mirrors the forward's layout: one program per query token, with the ``H``
+query heads placed on the GEMM ``M`` dimension and the single shared K/V head
+gathered ``block_B`` at a time over the ``nsel`` selected blocks. dQ for the
+token is accumulated locally; dK/dV are scattered into the shared K/V head via
+``atomic_add`` (many query tokens may select the same block).
+"""
+
+import paddle
+import tilelang
+from tilelang import language as T
+
+
+@tilelang.jit(
+    out_idx=[-1],
+    pass_configs={
+        tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
+        tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
+    },
+)
+def block_sparse_mqa_bwd(
+    H,
+    D,
+    nsel,
+    sm_scale,
+    block_B=64,
+    block_H=None,
+    num_stages=1,
+    threads=128,
+):
+    assert D % 16 == 0, (
+        f"D must be a multiple of 16 (tensor-core k-tile), got {D}"
+    )
+    assert H <= 128, "this kernel supports up to 128 query heads"
+
+    batch = T.dynamic("batch")
+    seq_len = T.dynamic("seq_len")
+    seq_len_kv = T.dynamic("seq_len_kv")
+
+    q_shape = [batch, seq_len, H, D]
+    kv_shape = [batch, seq_len_kv, D]
+    idx_shape = [batch, seq_len, nsel]
+    vr_shape = [batch, seq_len, 2]
+    lse_shape = [batch, seq_len, H]
+
+    dtype = T.bfloat16
+    accum_dtype = T.float32
+    idx_dtype = T.int32
+    # Heads are tiled on the GEMM M dimension in groups of ``BH`` so that the
+    # ``[·, D]`` shared buffers fit on-chip for large head dims (e.g. MLA
+    # D=576); ``BH == H`` keeps the single-program-per-token fast path.
+    BH = block_H if block_H is not None else H
+    PH = max(tilelang.math.next_power_of_2(BH), 16)
+    num_hg = (H + BH - 1) // BH
+    BB = block_B
+
+    @T.prim_func
+    def main(
+        Q: T.Tensor(q_shape, dtype),
+        K: T.Tensor(kv_shape, dtype),
+        V: T.Tensor(kv_shape, dtype),
+        dO: T.Tensor(q_shape, dtype),
+        Lse: T.Tensor(lse_shape, accum_dtype),
+        Delta: T.Tensor(lse_shape, accum_dtype),
+        Indices: T.Tensor(idx_shape, idx_dtype),
+        ValidRange: T.Tensor(vr_shape, idx_dtype),
+        dK: T.Tensor(kv_shape, accum_dtype),
+        dV: T.Tensor(kv_shape, accum_dtype),
+        dQ: T.Tensor(q_shape, dtype),
+    ):
+        with T.Kernel(num_hg, seq_len, batch, threads=threads) as (hg, bs, bb):
+            h0 = hg * BH
+            Q_shared = T.alloc_shared([PH, D], dtype)
+            dO_shared = T.alloc_shared([PH, D], dtype)
+            K_shared = T.alloc_shared([BB, D], dtype)
+            V_shared = T.alloc_shared([BB, D], dtype)
+            P_shared = T.alloc_shared([PH, BB], dtype)
+            dS_shared = T.alloc_shared([PH, BB], dtype)
+            dQ_shared = T.alloc_shared([PH, D], dtype)
+
+            acc_s = T.alloc_fragment([PH, BB], accum_dtype)
+            acc_p = T.alloc_fragment([PH, BB], accum_dtype)
+            acc_dp = T.alloc_fragment([PH, BB], accum_dtype)
+            acc_dq = T.alloc_fragment([PH, D], accum_dtype)
+            acc_dk = T.alloc_fragment([BB, D], accum_dtype)
+            acc_dv = T.alloc_fragment([BB, D], accum_dtype)
+            lse_f = T.alloc_fragment([PH], accum_dtype)
+            delta_f = T.alloc_fragment([PH], accum_dtype)
+
+            bos = ValidRange[bb, bs, 0]
+            eos = ValidRange[bb, bs, 1]
+
+            for h, d in T.Parallel(PH, D):
+                gh = h0 + h
+                use = (h < BH) and (gh < H)
+                sh = T.if_then_else(use, gh, 0)
+                Q_shared[h, d] = T.if_then_else(
+                    use, Q[bb, bs, sh, d], T.cast(0, dtype)
+                )
+                dO_shared[h, d] = T.if_then_else(
+                    use, dO[bb, bs, sh, d], T.cast(0, dtype)
+                )
+            for h in T.Parallel(PH):
+                gh = h0 + h
+                use = (h < BH) and (gh < H)
+                sh = T.if_then_else(use, gh, 0)
+                lse_f[h] = T.if_then_else(use, Lse[bb, bs, sh], 0.0)
+                delta_f[h] = T.if_then_else(use, Delta[bb, bs, sh], 0.0)
+
+            T.clear(acc_dq)
+
+            for i in T.Pipelined(nsel, num_stages=num_stages):
+                blk = Indices[bb, bs, i]
+                valid_blk = blk >= 0
+                safe_blk = T.if_then_else(valid_blk, blk, 0)
+
+                # document-relative gather: relative block ``blk`` spans
+                # absolute columns [bos + blk*BB, bos + (blk+1)*BB). Guard the
+                # read against the padded K/V length.
+                for c, d in T.Parallel(BB, D):
+                    col = bos + safe_blk * BB + c
+                    in_bounds = col < seq_len_kv
+                    safe_col = T.if_then_else(in_bounds, col, 0)
+                    K_shared[c, d] = T.if_then_else(
+                        in_bounds, K[bb, safe_col, d], T.cast(0, dtype)
+                    )
+                    V_shared[c, d] = T.if_then_else(
+                        in_bounds, V[bb, safe_col, d], T.cast(0, dtype)
+                    )
+
+                # P = softmax prob = exp(raw*sm_scale - lse); masked -> 0.
+                T.clear(acc_s)
+                T.gemm(
+                    Q_shared,
+                    K_shared,
+                    acc_s,
+                    transpose_B=True,
+                    policy=T.GemmWarpPolicy.FullRow,
+                )
+                for h, c in T.Parallel(PH, BB):
+                    col = bos + safe_blk * BB + c
+                    keep = valid_blk and (col < eos)
+                    acc_p[h, c] = T.if_then_else(
+                        keep,
+                        T.exp2(
+                            (acc_s[h, c] * sm_scale - lse_f[h]) * 1.44269504
+                        ),
+                        0.0,
+                    )
+                T.copy(acc_p, P_shared)
+
+                # dP = dO @ V^T
+                T.clear(acc_dp)
+                T.gemm(
+                    dO_shared,
+                    V_shared,
+                    acc_dp,
+                    transpose_B=True,
+                    policy=T.GemmWarpPolicy.FullRow,
+                )
+                # dS = P * (dP - Delta) * sm_scale
+                for h, c in T.Parallel(PH, BB):
+                    acc_dp[h, c] = (
+                        acc_p[h, c] * (acc_dp[h, c] - delta_f[h]) * sm_scale
+                    )
+                T.copy(acc_dp, dS_shared)
+
+                # dQ += dS @ K
+                T.gemm(
+                    dS_shared,
+                    K_shared,
+                    acc_dq,
+                    policy=T.GemmWarpPolicy.FullRow,
+                )
+                # dV = P^T @ dO ; dK = dS^T @ Q  (scattered to shared KV)
+                T.clear(acc_dv)
+                T.gemm(
+                    P_shared,
+                    dO_shared,
+                    acc_dv,
+                    transpose_A=True,
+                    policy=T.GemmWarpPolicy.FullRow,
+                )
+                T.clear(acc_dk)
+                T.gemm(
+                    dS_shared,
+                    Q_shared,
+                    acc_dk,
+                    transpose_A=True,
+                    policy=T.GemmWarpPolicy.FullRow,
+                )
+                for c, d in T.Parallel(BB, D):
+                    col = bos + safe_blk * BB + c
+                    if valid_blk and (col < seq_len_kv):
+                        T.atomic_add(dV[bb, col, d], acc_dv[c, d])
+                        T.atomic_add(dK[bb, col, d], acc_dk[c, d])
+
+            T.copy(acc_dq, dQ_shared)
+            for h, d in T.Parallel(PH, D):
+                gh = h0 + h
+                if (h < BH) and (gh < H):
+                    dQ[bb, bs, gh, d] = dQ_shared[h, d]
+
+    return main
+
+
+@tilelang.jit(out_idx=[-1])
+def _cast_bf16_kv(D, block_N=64, threads=128):
+    batch = T.dynamic("batch")
+    seq_len_kv = T.dynamic("seq_len_kv")
+    shape = [batch, seq_len_kv, D]
+
+    @T.prim_func
+    def main(
+        X: T.Tensor(shape, T.float32),
+        Out: T.Tensor(shape, T.bfloat16),
+    ):
+        with T.Kernel(
+            T.ceildiv(seq_len_kv, block_N), batch, threads=threads
+        ) as (bn, bb):
+            for i, d in T.Parallel(block_N, D):
+                if bn * block_N + i < seq_len_kv:
+                    Out[bb, bn * block_N + i, d] = X[bb, bn * block_N + i, d]
+
+    return main
+
+
+def _fit_block_h(H, D, block_B, cap_bytes=200000):
+    """Largest head-group (a divisor-ish of H) whose per-token backward shared
+    buffers fit. Q/dO/dQ ``[PH, D]`` + K/V ``[BB, D]`` + P/dS ``[PH, BB]`` in
+    bf16; for large D (MLA 576) all H=64 heads on M overflow, so tile them.
+    """
+    for bh in (H, 64, 32, 16):
+        if bh > H:
+            continue
+        ph = max(tilelang.math.next_power_of_2(bh), 16)
+        shared = 6 * ph * D + 4 * block_B * D + 4 * ph * block_B
+        if shared <= cap_bytes:
+            return bh
+    return min(H, 16)
+
+
+def block_sparse_mqa_bwd_interface(
+    q, k, v, o, do, lse, indices, valid_range, sm_scale=None, block_B=64
+):
+    """Backward interface for the MQA gather block-sparse attention.
+
+    Args:
+        q:           [B, S, H, D] bf16 forward query.
+        k, v:        [B, S_kv, D] bf16 shared key/value (forward inputs).
+        o:           [B, S, H, D] bf16 forward output.
+        do:          [B, S, H, D] bf16 grad of output.
+        lse:         [B, S, H] fp32 natural-log LSE from forward.
+        indices:     [B, S, nsel] int block ids selected per query token.
+        valid_range: [B, S, 2] int32.
+        sm_scale:    softmax scale; defaults to D**-0.5.
+        block_B:     key block size.
+
+    Returns:
+        dq [B,S,H,D] bf16, dk/dv [B,S_kv,D] bf16.
+    """
+    assert q.is_contiguous() and do.is_contiguous() and lse.is_contiguous()
+    b, s, h, d = q.shape
+    s_kv = k.shape[1]
+    if sm_scale is None:
+        sm_scale = d**-0.5
+    if valid_range.dtype != paddle.int32:
+        valid_range = valid_range.cast("int32")
+    if indices.dtype != paddle.int32:
+        indices = indices.cast("int32")
+
+    # gather reads whole blocks without clamping -> pad K/V (and dK/dV) so the
+    # last block is addressable.
+    pad = (block_B - s_kv % block_B) % block_B
+    s_kv_pad = s_kv + pad
+    if pad > 0:
+        k = paddle.nn.functional.pad(k, [0, 0, 0, pad])
+        v = paddle.nn.functional.pad(v, [0, 0, 0, pad])
+    k = k.contiguous()
+    v = v.contiguous()
+    valid_range = valid_range.contiguous()
+    indices = indices.contiguous()
+
+    delta = (o.astype("float32") * do.astype("float32")).sum(-1).contiguous()
+    dk = paddle.zeros([b, s_kv_pad, d], dtype="float32")
+    dv = paddle.zeros([b, s_kv_pad, d], dtype="float32")
+
+    bwd = block_sparse_mqa_bwd(
+        h,
+        d,
+        indices.shape[-1],
+        float(sm_scale),
+        block_B=block_B,
+        block_H=_fit_block_h(h, d, block_B),
+    )
+    dq = bwd(q, k, v, do, lse, delta, indices, valid_range, dk, dv)
+
+    cast = _cast_bf16_kv(d)
+    dk_bf = cast(dk)
+    dv_bf = cast(dv)
+    if pad > 0:
+        dk_bf = dk_bf[:, :s_kv, :].contiguous()
+        dv_bf = dv_bf[:, :s_kv, :].contiguous()
+    return dq, dk_bf, dv_bf

--- a/src/paddlefleet/tilelang_ops/hysparse/pipeline.py
+++ b/src/paddlefleet/tilelang_ops/hysparse/pipeline.py
@@ -1,0 +1,151 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""HySparse forward pipeline: chain block-score attention, block-TopK, and
+block-sparse attention.
+
+All stages share a single K/V head (MQA/MLA sparse branch):
+
+1. **Block-score attention** (:func:`block_score_mqa_attn_fwd`): full attention
+   with the shared K/V head that also emits per-(query, key-block) max raw
+   logits ``BlockLogit``.
+2. **Block TopK selection** (:func:`select_topk_blocks`): recover eq.(3) block
+   scores, aggregate them across heads by a group-wise **maximum** (shared
+   block selection), mask blocks that hold no causal/document-valid key, and
+   TopK to per-query block indices.
+3. **Block-sparse attention** (:func:`block_sparse_mqa_attn_fwd`): MQA
+   block-sparse attention that gathers only the selected blocks, so its cost
+   scales with ``topk`` rather than the sequence length.
+
+The block scores feed a non-differentiable TopK, so only the two attention
+operators carry gradient.
+"""
+
+import paddle
+
+from .block_score_attn import (
+    block_score_mqa_attn_fwd,
+    block_scores_from_logit,
+)
+from .block_sparse_attn_mqa import block_sparse_mqa_attn_fwd
+
+
+def _valid_block_mask(valid_range, num_blocks, block_B):
+    """Boolean [B, S, num_blocks]: relative block j holds >=1 valid key.
+
+    Block ids are **document-relative**: block j of a query spans key columns
+    ``[bos + j*block_B, bos + (j+1)*block_B)``. It holds at least one valid key
+    iff its start still lies inside the query's valid range, i.e.
+    ``bos + j*block_B < eos``.
+    """
+    bos = valid_range[..., 0:1].astype("int64")  # [B, S, 1]
+    eos = valid_range[..., 1:2].astype("int64")  # [B, S, 1]
+    j = paddle.arange(num_blocks, dtype="int64").reshape([1, 1, num_blocks])
+    start = bos + j * block_B  # absolute column where relative block j starts
+    return start < eos  # [B, S, num_blocks]
+
+
+def select_topk_blocks(
+    block_logit, lse, valid_range, sm_scale, topk, block_B, head_agg="max"
+):
+    """Select per-query TopK key blocks from block-score attention outputs.
+
+    Args:
+        block_logit: [B, H, S, num_blocks] raw per-block max logit.
+        lse:         [B, S, H] natural-log LSE from block-score attention.
+        valid_range: [B, S, 2] int, per-query [bos, eos) valid key columns.
+        sm_scale:    softmax scale.
+        topk:        number of blocks to select per query token.
+        block_B:     key block size.
+        head_agg:    how to aggregate block scores across heads so the whole
+                     query group shares one selection. ``"max"`` (paper eq. 3
+                     group-wise maximum) or ``"sum"``.
+
+    Returns:
+        indices: [B, S, topk] int32 selected block ids, shared across heads;
+                 slots beyond the number of valid blocks are -1.
+    """
+    b, h, s, num_blocks = block_logit.shape
+    scores = block_scores_from_logit(block_logit, lse, sm_scale)  # [B,H,S,nb]
+    # aggregate across heads (block selection shared across the query group)
+    if head_agg == "max":
+        agg = scores.max(axis=1)  # [B, S, num_blocks]
+    elif head_agg == "sum":
+        agg = scores.sum(axis=1)  # [B, S, num_blocks]
+    else:
+        raise ValueError(f"unknown head_agg={head_agg!r}")
+
+    valid = _valid_block_mask(valid_range, num_blocks, block_B)  # [B,S,nb]
+    neg = paddle.full_like(agg, -1.0)
+    agg = paddle.where(valid, agg, neg)  # invalid blocks pushed to the bottom
+
+    k = min(topk, num_blocks)
+    top_val, top_idx = paddle.topk(agg, k=k, axis=-1)  # [B, S, k]
+    # slots that landed on an invalid block (negative score) -> -1
+    top_idx = paddle.where(top_val >= 0, top_idx, paddle.full_like(top_idx, -1))
+    return top_idx.astype("int32").contiguous()
+
+
+def hysparse_forward_mqa(q, k, v, valid_range, topk, sm_scale=None, block_B=64):
+    """HySparse forward with a single shared K/V head (MQA/MLA sparse branch).
+
+    Three stages (block-score -> TopK -> block-sparse) with K/V as one shared
+    head
+    ``[B, S_kv, D]``: the block selection is aggregated across the whole query
+    group by a group-wise **maximum** (paper eq. 3) so all heads share indices,
+    and the sparse branch uses the MQA gather kernel
+    (:func:`block_sparse_mqa_attn_fwd`) whose cost scales with ``topk`` rather
+    than the sequence length.
+
+    Both stages keep K/V as a single shared head: block-score attention uses
+    the MQA scoring kernel (:func:`block_score_mqa_attn_fwd`, no head broadcast)
+    and the sparse branch uses the MQA gather kernel.
+
+    Args:
+        q:           [B, S, H, D] bf16 query (H heads).
+        k, v:        [B, S_kv, D] bf16 single shared key/value head.
+        valid_range: [B, S, 2] int32 causal + document valid key range.
+        topk:        number of blocks selected per query token.
+        sm_scale:    softmax scale; defaults to D**-0.5.
+        block_B:     key block size.
+
+    Returns:
+        sparse_out:  [B, S, H, D] MQA block-sparse attention output.
+        sparse_lse:  [B, S, H] natural-log LSE of the sparse branch.
+        indices:     [B, S, topk] selected block ids (int32, -1 padding).
+        full_out:    [B, S, H, D] full attention output (block-score).
+        full_lse:    [B, S, H] natural-log LSE of block-score attention.
+    """
+    b, s, h, d = q.shape
+    if sm_scale is None:
+        sm_scale = d**-0.5
+
+    # block-score attention with the single shared K/V head -- no broadcast.
+    full_out, full_lse, block_logit = block_score_mqa_attn_fwd(
+        q, k, v, valid_range, sm_scale=sm_scale, block_B=block_B
+    )
+    indices = select_topk_blocks(
+        block_logit,
+        full_lse,
+        valid_range,
+        sm_scale,
+        topk,
+        block_B,
+        head_agg="max",
+    )
+    # sparse branch uses the shared single-head K/V gather kernel
+    sparse_out, sparse_lse = block_sparse_mqa_attn_fwd(
+        q, k, v, indices, valid_range, sm_scale=sm_scale, block_B=block_B
+    )
+    return sparse_out, sparse_lse, indices, full_out, full_lse

--- a/src/paddlefleet/tilelang_ops/hysparse/pipeline.py
+++ b/src/paddlefleet/tilelang_ops/hysparse/pipeline.py
@@ -74,8 +74,12 @@ def select_topk_blocks(
 
     Returns:
         indices: [B, S, topk] int32 selected block ids, shared across heads;
-                 slots beyond the number of valid blocks are -1.
+                 slots beyond the number of valid blocks are -1. The width is
+                 always ``topk`` even when ``topk > num_blocks`` (the extra
+                 slots are -1 padding), keeping the shape contract stable.
     """
+    if topk <= 0:
+        raise ValueError(f"topk must be positive, got {topk}")
     b, h, s, num_blocks = block_logit.shape
     scores = block_scores_from_logit(block_logit, lse, sm_scale)  # [B,H,S,nb]
     # aggregate across heads (block selection shared across the query group)
@@ -94,7 +98,14 @@ def select_topk_blocks(
     top_val, top_idx = paddle.topk(agg, k=k, axis=-1)  # [B, S, k]
     # slots that landed on an invalid block (negative score) -> -1
     top_idx = paddle.where(top_val >= 0, top_idx, paddle.full_like(top_idx, -1))
-    return top_idx.astype("int32").contiguous()
+    top_idx = top_idx.astype("int32")
+    if k < topk:
+        # honour the promised [B, S, topk] width when topk exceeds the number
+        # of blocks; the surplus slots are -1 padding (already ignored by the
+        # gather kernel and the reference).
+        pad = paddle.full([b, s, topk - k], -1, dtype="int32")
+        top_idx = paddle.concat([top_idx, pad], axis=-1)
+    return top_idx.contiguous()
 
 
 def hysparse_forward_mqa(q, k, v, valid_range, topk, sm_scale=None, block_B=64):

--- a/src/paddlefleet/tilelang_ops/hysparse/reference.py
+++ b/src/paddlefleet/tilelang_ops/hysparse/reference.py
@@ -1,0 +1,231 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Naive Paddle reference (散算子) for HySparse block attention operators.
+
+Two operators, mirroring the paper (arXiv 2602.03560), with a single shared
+Key/Value head (MQA/MLA):
+
+* ``ref_block_score_attn_mqa``  — block-score attention, "Algorithm 1": standard
+  full attention (shared K/V head) that additionally emits block-level max
+  attention *probability* scores ``S`` (eq. 3), used for TopK block selection.
+* ``ref_block_sparse_attn_mqa`` — block-sparse attention: each query token
+  attends only to a per-token selected set of key blocks gathered from the
+  shared K/V head.
+
+Masking (causal + document) is expressed through ``valid_range`` of shape
+``[B, S, 2]`` giving, per query token, the half-open valid key column range
+``[bos, eos)``. Causal masking sets ``eos = t + 1``; document masking sets
+``bos`` to the document start.
+
+These functions are written for readability/correctness, not speed, and are
+the ground truth the TileLang kernels are validated against.
+"""
+
+import paddle
+import paddle.nn.functional as F
+
+NEG_INF = float("-inf")
+
+
+def _range_mask(valid_range, seq_len_kv):
+    """Build a boolean key mask [B, 1, S, S_kv] from valid_range [B, S, 2]."""
+    bos = valid_range[..., 0].unsqueeze(1).unsqueeze(-1)  # [B, 1, S, 1]
+    eos = valid_range[..., 1].unsqueeze(1).unsqueeze(-1)  # [B, 1, S, 1]
+    col = paddle.arange(seq_len_kv, dtype=valid_range.dtype)
+    col = col.reshape([1, 1, 1, seq_len_kv])  # [1, 1, 1, S_kv]
+    return (col >= bos) & (col < eos)  # [B, 1, S, S_kv]
+
+
+def _to_bhsd(x):
+    """[B, S, H, D] -> [B, H, S, D]."""
+    return x.transpose([0, 2, 1, 3])
+
+
+def ref_block_score_attn_mqa(q, k, v, valid_range, sm_scale=None, block_B=64):
+    """Block-score attention reference (MQA): full attention with a single
+    shared K/V head plus block-max probability scores (eq. 3).
+
+    Args:
+        q:           [B, S, H, D] query (H heads).
+        k, v:        [B, S_kv, D] shared key/value (single head).
+        valid_range: [B, S, 2] int, per-query [bos, eos) valid key columns.
+        sm_scale:    softmax scale; defaults to D**-0.5.
+        block_B:     key block size for the emitted block scores.
+
+    Returns:
+        out:     [B, S, H, D] attention output.
+        lse:     [B, S, H] natural-log-sum-exp of the masked logits.
+        s_block: [B, H, S, num_blocks] block-max softmax probability (eq. 3),
+                 num_blocks = ceil(S_kv / block_B). Fully-masked blocks -> 0.
+    """
+    b, s, h, d = q.shape
+    s_kv = k.shape[1]
+    if sm_scale is None:
+        sm_scale = d**-0.5
+
+    qb = _to_bhsd(q).astype("float32")  # [B, H, S, D]
+    # broadcast the single shared K/V head across all query heads
+    kb = k.astype("float32").unsqueeze(1)  # [B, 1, S_kv, D]
+    vb = v.astype("float32").unsqueeze(1)  # [B, 1, S_kv, D]
+
+    logits = paddle.matmul(qb, kb, transpose_y=True) * sm_scale  # [B,H,S,S_kv]
+    mask = _range_mask(valid_range, s_kv)  # [B,1,S,S_kv]
+    neg = paddle.full_like(logits, NEG_INF)
+    logits = paddle.where(mask, logits, neg)
+
+    # Rows with no valid key (bos >= eos) would make softmax/logsumexp nan;
+    # guard them to 0 output and leave lse as -inf (matches the kernel).
+    row_has_key = mask.any(axis=-1, keepdim=True)  # [B,1,S,1]
+    lse = paddle.logsumexp(logits, axis=-1)  # [B,H,S]
+    probs = F.softmax(logits, axis=-1)  # [B,H,S,S_kv]
+    probs = paddle.where(
+        row_has_key.expand_as(probs), probs, paddle.zeros_like(probs)
+    )
+    out = paddle.matmul(probs, vb.expand([b, h, s_kv, d]))  # [B,H,S,D]
+
+    # Block-max probability with **document-relative** block coordinates: block j
+    # of a query spans key columns [bos + j*block_B, bos + (j+1)*block_B), i.e.
+    # the grid is anchored at that query's document start ``bos`` (not absolute
+    # sequence columns). This matches processing each document standalone.
+    num_blocks = (s_kv + block_B - 1) // block_B
+    col = paddle.arange(s_kv, dtype="int64").reshape([1, 1, s_kv])  # [1,1,S_kv]
+    bos = valid_range[..., 0:1].astype("int64")  # [B, S, 1]
+    rel = col - bos  # [B, S, S_kv] column position relative to doc start
+    rel_id = paddle.where(  # relative block id; -1 for cols before doc start
+        rel >= 0, rel // block_B, paddle.full_like(rel, -1)
+    )  # [B, S, S_kv]
+    rel_id = rel_id.unsqueeze(1)  # [B, 1, S, S_kv]
+    s_block_list = []
+    for j in range(num_blocks):
+        hit = rel_id == j  # [B, 1, S, S_kv]
+        masked = paddle.where(hit, probs, paddle.zeros_like(probs))
+        s_block_list.append(masked.max(axis=-1))  # [B, H, S]
+    s_block = paddle.stack(s_block_list, axis=-1)  # [B,H,S,num_blocks]
+
+    out = out.transpose([0, 2, 1, 3])  # back to [B,S,H,D]
+    lse = lse.transpose([0, 2, 1])  # [B,S,H]
+    return out.astype(q.dtype), lse, s_block
+
+
+def _selected_key_mask(indices, valid_range, seq_len_kv, block_B):
+    """Boolean [B, S, S_kv]: key column selected by this query's block ids.
+
+    Block ids are **document-relative**: block ``j`` of a query spans key
+    columns ``[bos + j*block_B, bos + (j+1)*block_B)`` where ``bos`` is the
+    query's document start (``valid_range[..., 0]``). A column is selected iff
+    it lies at or after ``bos`` and its relative block id is among the query's
+    (valid) selected ids.
+
+    indices: [B, S, nsel] int block ids; -1 marks an invalid/padding slot.
+    """
+    col = paddle.arange(seq_len_kv, dtype="int64").reshape([1, 1, seq_len_kv])
+    bos = valid_range[..., 0:1].astype("int64")  # [B, S, 1]
+    rel = col - bos  # [B, S, S_kv]
+    col_block = paddle.where(  # relative block id of each key column
+        rel >= 0, rel // block_B, paddle.full_like(rel, -1)
+    )  # [B, S, S_kv]
+    idx = indices.astype("int64").unsqueeze(-2)  # [B,S,1,nsel]
+    col_block_e = col_block.unsqueeze(-1)  # [B,S,S_kv,1]
+    # a column is selected iff its relative block id equals any valid selected id
+    hit = (col_block_e == idx) & (idx >= 0)  # [B,S,S_kv,nsel]
+    return hit.any(axis=-1)  # [B,S,S_kv]
+
+
+def ref_block_sparse_attn_mqa(
+    q, k, v, indices, valid_range, sm_scale=None, block_B=64
+):
+    """Block-sparse attention reference (MQA): per-query-token block-sparse
+    attention with a single Key/Value head shared across all query heads.
+
+    This mirrors the efficient HySparse sparse branch: the block indices are
+    shared across heads (GQA group-wise max upstream), and K/V are a single
+    shared head so one gathered block feeds every query head.
+
+    Args:
+        q:           [B, S, H, D] query (H heads).
+        k, v:        [B, S_kv, D] shared key/value (single head).
+        indices:     [B, S, nsel] int block ids selected per query token
+                     (-1 = padding). Shared across heads.
+        valid_range: [B, S, 2] int, per-query [bos, eos) valid key columns.
+        sm_scale:    softmax scale; defaults to D**-0.5.
+        block_B:     key block size.
+
+    Returns:
+        out: [B, S, H, D]; lse: [B, S, H].
+    """
+    b, s, h, d = q.shape
+    s_kv = k.shape[1]
+    if sm_scale is None:
+        sm_scale = d**-0.5
+
+    qb = _to_bhsd(q).astype("float32")  # [B, H, S, D]
+    # broadcast the single shared KV head across all query heads
+    kb = k.astype("float32").unsqueeze(1)  # [B, 1, S_kv, D]
+    vb = v.astype("float32").unsqueeze(1)  # [B, 1, S_kv, D]
+
+    logits = paddle.matmul(qb, kb, transpose_y=True) * sm_scale  # [B,H,S,S_kv]
+
+    range_m = _range_mask(valid_range, s_kv)  # [B,1,S,S_kv]
+    sel_m = _selected_key_mask(indices, valid_range, s_kv, block_B).unsqueeze(
+        1
+    )  # [B,1,S,S_kv]
+    mask = range_m & sel_m
+    neg = paddle.full_like(logits, NEG_INF)
+    logits = paddle.where(mask, logits, neg)
+
+    # Rows with no valid key -> softmax would be nan; guard to 0 output.
+    row_has_key = mask.any(axis=-1, keepdim=True)  # [B,1,S,1]
+    safe_logits = paddle.where(mask, logits, paddle.zeros_like(logits))
+    logits = paddle.where(row_has_key.expand_as(logits), logits, safe_logits)
+
+    lse = paddle.logsumexp(logits, axis=-1)  # [B,H,S]
+    probs = F.softmax(logits, axis=-1)
+    probs = paddle.where(
+        row_has_key.expand_as(probs), probs, paddle.zeros_like(probs)
+    )
+    out = paddle.matmul(probs, vb.expand([b, h, s_kv, d]))  # [B,H,S,D]
+
+    out = out.transpose([0, 2, 1, 3])
+    lse = lse.transpose([0, 2, 1])
+    return out.astype(q.dtype), lse
+
+
+def make_causal_valid_range(seq_len, batch=1, doc_lengths=None):
+    """Helper: build valid_range [B, S, 2] for causal (+ optional document) mask.
+
+    Args:
+        seq_len:     total sequence length S (== S_kv).
+        batch:       batch size B.
+        doc_lengths: optional list of document lengths (packed along S). If
+                     given, sum must equal seq_len; each token's bos is set to
+                     its document start. If None, a single document is assumed.
+
+    Returns:
+        valid_range: [B, S, 2] int32.
+    """
+    pos = paddle.arange(seq_len, dtype="int32")
+    eos = pos + 1  # causal: attend up to and including self
+    if doc_lengths is None:
+        bos = paddle.zeros([seq_len], dtype="int32")
+    else:
+        assert sum(doc_lengths) == seq_len
+        starts = []
+        cur = 0
+        for dl in doc_lengths:
+            starts += [cur] * dl
+            cur += dl
+        bos = paddle.to_tensor(starts, dtype="int32")
+    vr = paddle.stack([bos, eos], axis=-1)  # [S, 2]
+    return vr.unsqueeze(0).expand([batch, seq_len, 2]).contiguous()

--- a/src/paddlefleet/tilelang_ops/hysparse/reference.py
+++ b/src/paddlefleet/tilelang_ops/hysparse/reference.py
@@ -185,11 +185,10 @@ def ref_block_sparse_attn_mqa(
     neg = paddle.full_like(logits, NEG_INF)
     logits = paddle.where(mask, logits, neg)
 
-    # Rows with no valid key -> softmax would be nan; guard to 0 output.
+    # LSE is taken from the fully -inf-masked logits so empty rows (no valid
+    # key) stay -inf, matching the kernel and the docstring. softmax then uses
+    # the same logits and its NaN empty rows are zeroed via ``row_has_key``.
     row_has_key = mask.any(axis=-1, keepdim=True)  # [B,1,S,1]
-    safe_logits = paddle.where(mask, logits, paddle.zeros_like(logits))
-    logits = paddle.where(row_has_key.expand_as(logits), logits, safe_logits)
-
     lse = paddle.logsumexp(logits, axis=-1)  # [B,H,S]
     probs = F.softmax(logits, axis=-1)
     probs = paddle.where(

--- a/tests/single_card_tests/custom_ops/test_hysparse_block_attn.py
+++ b/tests/single_card_tests/custom_ops/test_hysparse_block_attn.py
@@ -24,17 +24,10 @@ Validates, against the naive Paddle reference (散算子):
 Both causal and causal+document masking are covered via ``valid_range``.
 """
 
-import os
-import sys
 import unittest
 
 import numpy as np
 import paddle
-
-# Prefer the in-repo source tree (the hysparse ops may not be installed yet).
-_SRC = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../src"))
-if _SRC not in sys.path:
-    sys.path.insert(0, _SRC)
 
 paddle.enable_compat(scope={"tilelang"}, silent=True)
 
@@ -431,6 +424,25 @@ class TestPipelineMQA(unittest.TestCase):
                 ).all()
             )
         )
+
+    def test_topk_exceeds_num_blocks(self):
+        # topk larger than the number of key blocks must still return a stable
+        # [B, S, topk] index tensor, padding the surplus slots with -1.
+        _cuda_or_skip(self)
+        B, S, H, D = 1, 96, 4, 64
+        block_B = 64  # num_blocks = ceil(96/64) = 2
+        topk = 5
+        q, k, v = _rand_qkv_mqa(B, S, H, D, seed=11)
+        vr = make_causal_valid_range(S, batch=B)
+        _, _, indices, _, _ = hysparse_forward_mqa(
+            q, k, v, vr, topk, block_B=block_B
+        )
+        self.assertEqual(list(indices.shape), [B, S, topk])
+        # at most num_blocks real ids per row; the rest are -1 padding
+        idx_np = indices.numpy()
+        self.assertTrue(bool((idx_np < 2).all()))
+        self.assertTrue(bool((idx_np[:, -1, :] >= -1).all()))
+        self.assertTrue(bool((idx_np == -1).any()))
 
 
 class TestDocEquivalenceMQA(unittest.TestCase):

--- a/tests/single_card_tests/custom_ops/test_hysparse_block_attn.py
+++ b/tests/single_card_tests/custom_ops/test_hysparse_block_attn.py
@@ -1,0 +1,686 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Accuracy tests for the HySparse (MQA) block-attention TileLang operators.
+
+Validates, against the naive Paddle reference (散算子):
+* Block-score attention (Algorithm 1, MQA): full attention with a single shared
+  K/V head + block-max scores, fwd & bwd.
+* Block-sparse attention (MQA gather): per-query block-sparse attn over a single
+  shared K/V head, fwd & bwd.
+* The end-to-end pipeline (block-score -> TopK -> block-sparse).
+
+Both causal and causal+document masking are covered via ``valid_range``.
+"""
+
+import os
+import sys
+import unittest
+
+import numpy as np
+import paddle
+
+# Prefer the in-repo source tree (the hysparse ops may not be installed yet).
+_SRC = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../src"))
+if _SRC not in sys.path:
+    sys.path.insert(0, _SRC)
+
+paddle.enable_compat(scope={"tilelang"}, silent=True)
+
+from paddlefleet.tilelang_ops.hysparse.block_score_attn import (
+    block_score_mqa_attn_fwd,
+    block_scores_from_logit,
+)
+from paddlefleet.tilelang_ops.hysparse.block_score_attn_bwd import (
+    block_score_mqa_bwd_interface,
+)
+from paddlefleet.tilelang_ops.hysparse.block_sparse_attn_mqa import (
+    block_sparse_mqa_attn_fwd,
+)
+from paddlefleet.tilelang_ops.hysparse.block_sparse_attn_mqa_bwd import (
+    block_sparse_mqa_bwd_interface,
+)
+from paddlefleet.tilelang_ops.hysparse.pipeline import (
+    hysparse_forward_mqa,
+)
+from paddlefleet.tilelang_ops.hysparse.reference import (
+    make_causal_valid_range,
+    ref_block_score_attn_mqa,
+    ref_block_sparse_attn_mqa,
+)
+
+
+def _cuda_or_skip(testcase):
+    if not paddle.device.is_compiled_with_cuda():
+        testcase.skipTest("CUDA build of Paddle is required")
+    if paddle.device.cuda.device_count() == 0:
+        testcase.skipTest("No CUDA device available")
+
+
+def _maxerr(a, b):
+    a = a.astype("float32").numpy()
+    b = b.astype("float32").numpy()
+    return float(np.abs(a - b).max())
+
+
+def _cos(a, b):
+    a = a.astype("float32").numpy().ravel()
+    b = b.astype("float32").numpy().ravel()
+    denom = float(np.linalg.norm(a) * np.linalg.norm(b)) + 1e-12
+    return float((a * b).sum() / denom)
+
+
+def _rand_qkv_mqa(b, s, h, d, seed=0):
+    """Query with H heads; K/V a single shared head [B, S, D]."""
+    paddle.seed(seed)
+    q = paddle.randn([b, s, h, d], dtype="bfloat16")
+    k = paddle.randn([b, s, d], dtype="bfloat16")
+    v = paddle.randn([b, s, d], dtype="bfloat16")
+    return q, k, v
+
+
+def _grad_ref_qkv(q, k, v):
+    """float32 leaf copies of q/k/v for autograd reference gradients."""
+    qf = q.astype("float32")
+    qf.stop_gradient = False
+    kf = k.astype("float32")
+    kf.stop_gradient = False
+    vf = v.astype("float32")
+    vf.stop_gradient = False
+    return qf, kf, vf
+
+
+# tolerances: bf16 matmul + fp32 accumulation
+OUT_ATOL = 5e-2
+LSE_ATOL = 1e-3
+GRAD_ATOL = 8e-2
+
+
+class TestBlockScoreMQA(unittest.TestCase):
+    """Block-score attention (MQA): shared-K/V full attn + block-max scores."""
+
+    def _run(self, doc_lengths=None, block_B=64, H=8, D=64):
+        _cuda_or_skip(self)
+        B, S = 2, 256
+        q, k, v = _rand_qkv_mqa(B, S, H, D, seed=1)
+        vr = make_causal_valid_range(S, batch=B, doc_lengths=doc_lengths)
+        sm_scale = D**-0.5
+
+        qf, kf, vf = _grad_ref_qkv(q, k, v)
+        ref_out, ref_lse, ref_sblk = ref_block_score_attn_mqa(
+            qf, kf, vf, vr, sm_scale=sm_scale, block_B=block_B
+        )
+
+        out, lse, block_logit = block_score_mqa_attn_fwd(
+            q, k, v, vr, sm_scale=sm_scale, block_B=block_B
+        )
+        sblk = block_scores_from_logit(block_logit, lse, sm_scale)
+
+        self.assertLess(_maxerr(out, ref_out), OUT_ATOL)
+        self.assertLess(_maxerr(lse, ref_lse), LSE_ATOL)
+        self.assertLess(_maxerr(sblk, ref_sblk), 1e-3)
+
+        # backward
+        do = paddle.randn([B, S, H, D], dtype="bfloat16")
+        (ref_out * do.astype("float32")).sum().backward()
+        dq, dk, dv = block_score_mqa_bwd_interface(
+            q, k, v, out, do, lse, vr, sm_scale=sm_scale, block_B=block_B
+        )
+        self.assertLess(_maxerr(dq, qf.grad), GRAD_ATOL)
+        self.assertLess(_maxerr(dk, kf.grad), GRAD_ATOL)
+        self.assertLess(_maxerr(dv, vf.grad), GRAD_ATOL)
+
+    def test_causal(self):
+        self._run(doc_lengths=None)
+
+    def test_causal_document(self):
+        self._run(doc_lengths=[96, 160])
+
+    def test_block_b_32(self):
+        # smaller key block size (must still divide the auto-picked block_N).
+        self._run(doc_lengths=[96, 160], block_B=32)
+
+    def test_block_b_128(self):
+        # larger key block size exercises a different tiling / mask layout.
+        self._run(doc_lengths=None, block_B=128)
+
+    def test_single_query_head(self):
+        # H=1: heads-on-M padding edge (PH = max(pow2(1), 16) = 16).
+        self._run(doc_lengths=None, H=1)
+
+    def test_backward_block_n_invariance(self):
+        """The block-score backward sub-tiles the key dim by ``block_N``; any
+        valid ``block_N`` dividing ``block_B`` must give the SAME gradients
+        (only the fp-accumulation / per-sub-tile bf16 recast order changes).
+        Validates the sub-tiling introduced for the D=576 MB=64 backward.
+        """
+        _cuda_or_skip(self)
+        B, S, H, D, block_B = 2, 256, 8, 64, 64
+        q, k, v = _rand_qkv_mqa(B, S, H, D, seed=13)
+        vr = make_causal_valid_range(S, batch=B, doc_lengths=[96, 160])
+        sm = D**-0.5
+
+        qf, kf, vf = _grad_ref_qkv(q, k, v)
+        ref_out, _, _ = ref_block_score_attn_mqa(
+            qf, kf, vf, vr, sm_scale=sm, block_B=block_B
+        )
+        out, lse, _ = block_score_mqa_attn_fwd(
+            q, k, v, vr, sm_scale=sm, block_B=block_B
+        )
+        do = paddle.randn([B, S, H, D], dtype="bfloat16")
+        (ref_out * do.astype("float32")).sum().backward()
+
+        # ratio=1 (block_N == block_B) vs ratio=2 (block_N = block_B // 2)
+        dq1, dk1, dv1 = block_score_mqa_bwd_interface(
+            q,
+            k,
+            v,
+            out,
+            do,
+            lse,
+            vr,
+            sm_scale=sm,
+            block_B=block_B,
+            block_M=64,
+            block_N=64,
+        )
+        dq2, dk2, dv2 = block_score_mqa_bwd_interface(
+            q,
+            k,
+            v,
+            out,
+            do,
+            lse,
+            vr,
+            sm_scale=sm,
+            block_B=block_B,
+            block_M=64,
+            block_N=32,
+        )
+        # the two tilings must agree tightly (differences only from fp order)
+        self.assertLess(_maxerr(dq1, dq2), 1e-2)
+        self.assertLess(_maxerr(dk1, dk2), 1e-2)
+        self.assertLess(_maxerr(dv1, dv2), 1e-2)
+        # and both must match the fp32 reference
+        for dq, dk, dv in ((dq1, dk1, dv1), (dq2, dk2, dv2)):
+            self.assertLess(_maxerr(dq, qf.grad), GRAD_ATOL)
+            self.assertLess(_maxerr(dk, kf.grad), GRAD_ATOL)
+            self.assertLess(_maxerr(dv, vf.grad), GRAD_ATOL)
+
+    def test_backward_packed_deep_docs(self):
+        """Backward with several packed documents whose later tiles start deep
+        into the sequence (bos >> 0). Exercises the document-tight key-block
+        window (leading-block skip) in the block-score backward: skipped blocks
+        must contribute nothing so dq/dk/dv still match the fp32 reference.
+        """
+        _cuda_or_skip(self)
+        B, H, D, block_B = 1, 8, 64, 64
+        # deep docs: three documents, each many blocks long and not aligned to
+        # block_B, so per-tile min(bos) lands well past column 0.
+        doc_lengths = [130, 200, 180]
+        S = sum(doc_lengths)
+        q, k, v = _rand_qkv_mqa(B, S, H, D, seed=17)
+        vr = make_causal_valid_range(S, batch=B, doc_lengths=doc_lengths)
+        sm_scale = D**-0.5
+
+        qf, kf, vf = _grad_ref_qkv(q, k, v)
+        ref_out, _, _ = ref_block_score_attn_mqa(
+            qf, kf, vf, vr, sm_scale=sm_scale, block_B=block_B
+        )
+        out, lse, _ = block_score_mqa_attn_fwd(
+            q, k, v, vr, sm_scale=sm_scale, block_B=block_B
+        )
+        do = paddle.randn([B, S, H, D], dtype="bfloat16")
+        (ref_out * do.astype("float32")).sum().backward()
+        dq, dk, dv = block_score_mqa_bwd_interface(
+            q, k, v, out, do, lse, vr, sm_scale=sm_scale, block_B=block_B
+        )
+        self.assertLess(_maxerr(dq, qf.grad), GRAD_ATOL)
+        self.assertLess(_maxerr(dk, kf.grad), GRAD_ATOL)
+        self.assertLess(_maxerr(dv, vf.grad), GRAD_ATOL)
+
+    def test_empty_rows(self):
+        """A query row with no valid key (bos == eos) must give 0 output,
+        -inf lse, and 0 gradient -- matching the guarded reference.
+        """
+        _cuda_or_skip(self)
+        B, S, H, D, block_B = 1, 128, 8, 64, 64
+        q, k, v = _rand_qkv_mqa(B, S, H, D, seed=31)
+        vr = make_causal_valid_range(S, batch=B).clone()
+        empty = 40
+        vr[:, empty, 0] = empty  # bos == eos -> empty half-open range
+        vr[:, empty, 1] = empty
+        vr = vr.contiguous()
+        sm = D**-0.5
+
+        qf, kf, vf = _grad_ref_qkv(q, k, v)
+        ref_out, ref_lse, _ = ref_block_score_attn_mqa(
+            qf, kf, vf, vr, sm_scale=sm, block_B=block_B
+        )
+        out, lse, _ = block_score_mqa_attn_fwd(
+            q, k, v, vr, sm_scale=sm, block_B=block_B
+        )
+        # empty row: zero output and -inf lse
+        self.assertLess(float(out[:, empty].abs().max()), 1e-6)
+        self.assertTrue(bool((lse[:, empty] == float("-inf")).all().item()))
+        # non-empty rows still match the reference
+        self.assertLess(_maxerr(out, ref_out), OUT_ATOL)
+
+        do = paddle.randn([B, S, H, D], dtype="bfloat16")
+        (ref_out * do.astype("float32")).sum().backward()
+        dq, dk, dv = block_score_mqa_bwd_interface(
+            q, k, v, out, do, lse, vr, sm_scale=sm, block_B=block_B
+        )
+        self.assertLess(float(dq[:, empty].abs().max()), 1e-6)
+        self.assertLess(_maxerr(dq, qf.grad), GRAD_ATOL)
+        self.assertLess(_maxerr(dk, kf.grad), GRAD_ATOL)
+        self.assertLess(_maxerr(dv, vf.grad), GRAD_ATOL)
+
+
+class TestBlockSparseMQA(unittest.TestCase):
+    """Block-sparse attention (MQA gather): gathers only selected blocks."""
+
+    def _make_indices(self, vr, block_B, nsel, seed=0):
+        """Random **document-relative** block ids per query token.
+
+        Relative block ``j`` of a token spans key columns
+        ``[bos + j*block_B, bos + (j+1)*block_B)``; valid blocks are
+        ``0 .. ceil((eos-bos)/block_B) - 1``.
+        """
+        rng = np.random.default_rng(seed)
+        vr_np = vr.numpy()
+        B, S, _ = vr_np.shape
+        idx = np.full([B, S, nsel], -1, dtype=np.int32)
+        for b in range(B):
+            for t in range(S):
+                bos = int(vr_np[b, t, 0])
+                eos = int(vr_np[b, t, 1])
+                n = (eos - bos + block_B - 1) // block_B
+                cand = list(range(n))
+                chosen = (
+                    cand
+                    if len(cand) <= nsel
+                    else list(rng.choice(cand, size=nsel, replace=False))
+                )
+                for jj, blk in enumerate(chosen):
+                    idx[b, t, jj] = blk
+        return paddle.to_tensor(idx, dtype="int32")
+
+    def _run(self, S=256, doc_lengths=None, block_B=64):
+        _cuda_or_skip(self)
+        B, H, D = 2, 8, 64
+        nsel = 3
+        q, k, v = _rand_qkv_mqa(B, S, H, D, seed=5)
+        vr = make_causal_valid_range(S, batch=B, doc_lengths=doc_lengths)
+        idx = self._make_indices(vr, block_B, nsel)
+        sm_scale = D**-0.5
+
+        qf, kf, vf = _grad_ref_qkv(q, k, v)
+        ref_out, ref_lse = ref_block_sparse_attn_mqa(
+            qf, kf, vf, idx, vr, sm_scale=sm_scale, block_B=block_B
+        )
+        out, lse = block_sparse_mqa_attn_fwd(
+            q, k, v, idx, vr, sm_scale=sm_scale, block_B=block_B
+        )
+        self.assertLess(_maxerr(out, ref_out), OUT_ATOL)
+        finite = np.isfinite(ref_lse.numpy())
+        lse_err = np.abs(lse.numpy()[finite] - ref_lse.numpy()[finite]).max()
+        self.assertLess(float(lse_err), LSE_ATOL)
+
+        do = paddle.randn([B, S, H, D], dtype="bfloat16")
+        (ref_out * do.astype("float32")).sum().backward()
+        dq, dk, dv = block_sparse_mqa_bwd_interface(
+            q, k, v, out, do, lse, idx, vr, sm_scale=sm_scale, block_B=block_B
+        )
+        self.assertLess(_maxerr(dq, qf.grad), GRAD_ATOL)
+        self.assertLess(_maxerr(dk, kf.grad), GRAD_ATOL)
+        self.assertLess(_maxerr(dv, vf.grad), GRAD_ATOL)
+
+    def test_causal(self):
+        self._run(doc_lengths=None)
+
+    def test_causal_document(self):
+        self._run(doc_lengths=[96, 160])
+
+    def test_unaligned_seqlen(self):
+        # S_kv not a multiple of block_B exercises the K/V padding path.
+        self._run(S=200, doc_lengths=None)
+
+    def test_block_b_32(self):
+        self._run(doc_lengths=[96, 160], block_B=32)
+
+    def test_block_b_128(self):
+        self._run(S=384, doc_lengths=None, block_B=128)
+
+    def test_all_blocks_equals_full(self):
+        """Selecting every block must reproduce full-range attention (block-score)."""
+        _cuda_or_skip(self)
+        B, S, H, D = 2, 256, 8, 64
+        block_B = 64
+        num_blocks = (S + block_B - 1) // block_B
+        q, k, v = _rand_qkv_mqa(B, S, H, D, seed=3)
+        vr = make_causal_valid_range(S, batch=B)
+        sm_scale = D**-0.5
+
+        idx_all = (
+            paddle.arange(num_blocks, dtype="int32")
+            .reshape([1, 1, num_blocks])
+            .expand([B, S, num_blocks])
+            .contiguous()
+        )
+        out_a, _ = block_sparse_mqa_attn_fwd(
+            q, k, v, idx_all, vr, sm_scale=sm_scale, block_B=block_B
+        )
+        out_b, _, _ = block_score_mqa_attn_fwd(
+            q, k, v, vr, sm_scale=sm_scale, block_B=block_B
+        )
+        self.assertLess(_maxerr(out_a, out_b), 1e-3)
+
+
+class TestPipelineMQA(unittest.TestCase):
+    """End-to-end MQA block-score -> TopK -> block-sparse pipeline."""
+
+    def test_pipeline_matches_reference(self):
+        _cuda_or_skip(self)
+        B, S, H, D = 2, 256, 8, 64
+        block_B = 64
+        topk = 3
+        q, k, v = _rand_qkv_mqa(B, S, H, D, seed=6)
+        vr = make_causal_valid_range(S, batch=B)
+        sm_scale = D**-0.5
+
+        sparse_out, sparse_lse, indices, full_out, full_lse = (
+            hysparse_forward_mqa(
+                q, k, v, vr, topk, sm_scale=sm_scale, block_B=block_B
+            )
+        )
+
+        # full-attention branch must match the MQA block-score reference
+        qf, kf, vf = _grad_ref_qkv(q, k, v)
+        ref_full_out, _, _ = ref_block_score_attn_mqa(
+            qf, kf, vf, vr, sm_scale=sm_scale, block_B=block_B
+        )
+        self.assertLess(_maxerr(full_out, ref_full_out), OUT_ATOL)
+
+        # sparse branch must match the MQA reference given the SAME indices
+        ref_sparse_out, _ = ref_block_sparse_attn_mqa(
+            qf, kf, vf, indices, vr, sm_scale=sm_scale, block_B=block_B
+        )
+        self.assertLess(_maxerr(sparse_out, ref_sparse_out), OUT_ATOL)
+
+        # indices are shared across heads, in range, causal
+        idx_np = indices.numpy()
+        qblk = (np.arange(S) // block_B).reshape([1, S, 1])
+        picked = idx_np >= 0
+        self.assertTrue(
+            bool(
+                (
+                    idx_np[picked]
+                    <= np.broadcast_to(qblk, idx_np.shape)[picked]
+                ).all()
+            )
+        )
+
+
+class TestDocEquivalenceMQA(unittest.TestCase):
+    """Documents packed with a document mask must give the SAME sparse result
+    as running each document standalone -- even when document lengths are not
+    multiples of block_B. This is the whole point of the document-relative
+    block coordinates: block selection is anchored at each document's start, so
+    a packed batch and per-document batches select identical (relative) blocks.
+    """
+
+    def _run(self, doc_lengths, topk, block_B=64, H=8, D=64, seed=11):
+        _cuda_or_skip(self)
+        S = sum(doc_lengths)
+        q, k, v = _rand_qkv_mqa(1, S, H, D, seed=seed)
+        vr = make_causal_valid_range(S, batch=1, doc_lengths=doc_lengths)
+        sm_scale = D**-0.5
+
+        packed_out, _, _, _, _ = hysparse_forward_mqa(
+            q, k, v, vr, topk, sm_scale=sm_scale, block_B=block_B
+        )
+
+        start = 0
+        for L in doc_lengths:
+            end = start + L
+            q_d = q[:, start:end].contiguous()
+            k_d = k[:, start:end].contiguous()
+            v_d = v[:, start:end].contiguous()
+            vr_d = make_causal_valid_range(L, batch=1)
+            d_out, _, _, _, _ = hysparse_forward_mqa(
+                q_d, k_d, v_d, vr_d, topk, sm_scale=sm_scale, block_B=block_B
+            )
+            err = _maxerr(packed_out[:, start:end], d_out)
+            self.assertLess(err, 2e-3, f"doc [{start},{end}) err={err}")
+            start = end
+
+    def test_two_docs_select_all(self):
+        # topk >= #blocks/doc -> every valid block selected in both layouts
+        self._run(doc_lengths=[96, 160], topk=3)
+
+    def test_two_docs_true_sparsity(self):
+        # topk < #blocks in the long doc -> genuine subset selection must agree
+        self._run(doc_lengths=[100, 200], topk=2)
+
+    def test_three_docs(self):
+        self._run(doc_lengths=[64, 96, 130], topk=2)
+
+
+class TestHeadDim576MQA(unittest.TestCase):
+    """MLA-shaped head_dim=576 (non-power-of-2), num_heads=64.
+
+    Validates the ops run and stay accurate at the large MLA head dim. Output
+    is checked against the fp32 reference with the usual absolute tolerance;
+    gradients are checked by cosine similarity because absolute errors grow
+    with the (large) gradient magnitudes at D=576.
+    """
+
+    def test_score_fwd_bwd(self):
+        _cuda_or_skip(self)
+        B, S, H, D = 1, 192, 64, 576
+        block_B = 64
+        q, k, v = _rand_qkv_mqa(B, S, H, D, seed=7)
+        vr = make_causal_valid_range(S, batch=B)
+        sm_scale = D**-0.5
+
+        qf, kf, vf = _grad_ref_qkv(q, k, v)
+        ref_out, ref_lse, ref_sblk = ref_block_score_attn_mqa(
+            qf, kf, vf, vr, sm_scale=sm_scale, block_B=block_B
+        )
+        out, lse, block_logit = block_score_mqa_attn_fwd(
+            q, k, v, vr, sm_scale=sm_scale, block_B=block_B
+        )
+        sblk = block_scores_from_logit(block_logit, lse, sm_scale)
+        self.assertLess(_maxerr(out, ref_out), OUT_ATOL)
+        self.assertLess(_maxerr(lse, ref_lse), LSE_ATOL)
+        self.assertLess(_maxerr(sblk, ref_sblk), 1e-3)
+
+        do = paddle.randn([B, S, H, D], dtype="bfloat16")
+        (ref_out * do.astype("float32")).sum().backward()
+        dq, dk, dv = block_score_mqa_bwd_interface(
+            q, k, v, out, do, lse, vr, sm_scale=sm_scale, block_B=block_B
+        )
+        self.assertGreater(_cos(dq, qf.grad), 0.999)
+        self.assertGreater(_cos(dk, kf.grad), 0.999)
+        self.assertGreater(_cos(dv, vf.grad), 0.999)
+
+    def test_sparse_fwd_bwd_and_pipeline(self):
+        _cuda_or_skip(self)
+        B, S, H, D = 1, 192, 64, 576
+        block_B, topk = 64, 2
+        q, k, v = _rand_qkv_mqa(B, S, H, D, seed=8)
+        vr = make_causal_valid_range(S, batch=B)
+        sm_scale = D**-0.5
+
+        sparse_out, sparse_lse, idx, full_out, _ = hysparse_forward_mqa(
+            q, k, v, vr, topk, sm_scale=sm_scale, block_B=block_B
+        )
+        qf, kf, vf = _grad_ref_qkv(q, k, v)
+        ref_full, _, _ = ref_block_score_attn_mqa(
+            qf, kf, vf, vr, sm_scale=sm_scale, block_B=block_B
+        )
+        self.assertLess(_maxerr(full_out, ref_full), OUT_ATOL)
+        ref_sparse, _ = ref_block_sparse_attn_mqa(
+            qf, kf, vf, idx, vr, sm_scale=sm_scale, block_B=block_B
+        )
+        self.assertLess(_maxerr(sparse_out, ref_sparse), OUT_ATOL)
+
+        # gather backward with head-tiled M (block_H) for the large head dim
+        do = paddle.randn([B, S, H, D], dtype="bfloat16")
+        (ref_sparse * do.astype("float32")).sum().backward()
+        dq, dk, dv = block_sparse_mqa_bwd_interface(
+            q,
+            k,
+            v,
+            sparse_out,
+            do,
+            sparse_lse,
+            idx,
+            vr,
+            sm_scale=sm_scale,
+            block_B=block_B,
+        )
+        self.assertGreater(_cos(dq, qf.grad), 0.999)
+        self.assertGreater(_cos(dk, kf.grad), 0.999)
+        self.assertGreater(_cos(dv, vf.grad), 0.999)
+
+
+class TestBenchmarkSmoke(unittest.TestCase):
+    """The benchmark harness runs and yields finite latencies for every op."""
+
+    def test_bench_config_small(self):
+        _cuda_or_skip(self)
+        from paddlefleet.tilelang_ops.hysparse.benchmark import bench_config
+
+        res = bench_config(
+            B=1,
+            S=512,
+            H=16,
+            D=64,
+            block_B=64,
+            topk=4,
+            do_bwd=True,
+            iters=1,
+        )
+        for key in (
+            "score_fwd",
+            "score_bwd",
+            "sparse_fwd",
+            "sparse_bwd",
+            "pipeline",
+            "pipeline_peak_gb",
+        ):
+            self.assertIn(key, res)
+            self.assertTrue(np.isfinite(res[key]))
+            self.assertGreater(res[key], 0.0)
+
+
+class TestBatchEquivalenceMQA(unittest.TestCase):
+    """Batch size > 1: batch elements are fully independent, and each row may
+    carry its own document layout. A packed B=2 batch must reproduce (a) each
+    row run standalone as B=1, and (b) each document run standalone -- even
+    when the two rows pack completely different document lengths.
+    """
+
+    def _vr_multi(self, S, layouts):
+        """Stack per-row causal+document valid_ranges into [B, S, 2]."""
+        rows = [
+            make_causal_valid_range(S, batch=1, doc_lengths=dl)
+            for dl in layouts
+        ]
+        return paddle.concat(rows, axis=0).contiguous()
+
+    def test_row_isolation(self):
+        # B=2 packed == two independent B=1 runs (different per-row layouts).
+        _cuda_or_skip(self)
+        S, H, D, block_B, topk = 256, 8, 64, 64, 2
+        layouts = [[100, 156], [96, 64, 96]]
+        q, k, v = _rand_qkv_mqa(2, S, H, D, seed=21)
+        vr = self._vr_multi(S, layouts)
+        sm = D**-0.5
+
+        packed, _, _, _, _ = hysparse_forward_mqa(
+            q, k, v, vr, topk, sm_scale=sm, block_B=block_B
+        )
+        for b, dl in enumerate(layouts):
+            vr_b = make_causal_valid_range(S, batch=1, doc_lengths=dl)
+            solo, _, _, _, _ = hysparse_forward_mqa(
+                q[b : b + 1],
+                k[b : b + 1],
+                v[b : b + 1],
+                vr_b,
+                topk,
+                sm_scale=sm,
+                block_B=block_B,
+            )
+            self.assertLess(_maxerr(packed[b : b + 1], solo), 2e-3)
+
+    def test_per_row_doc_equivalence(self):
+        # Each (row, doc) slice equals that document run on its own, with the
+        # two rows using different, non-block-aligned document layouts.
+        _cuda_or_skip(self)
+        S, H, D, block_B, topk = 256, 8, 64, 64, 2
+        layouts = [[100, 156], [96, 64, 96]]
+        q, k, v = _rand_qkv_mqa(2, S, H, D, seed=22)
+        vr = self._vr_multi(S, layouts)
+        sm = D**-0.5
+
+        packed, _, _, _, _ = hysparse_forward_mqa(
+            q, k, v, vr, topk, sm_scale=sm, block_B=block_B
+        )
+        for b, docs in enumerate(layouts):
+            start = 0
+            for L in docs:
+                end = start + L
+                d_out, _, _, _, _ = hysparse_forward_mqa(
+                    q[b : b + 1, start:end].contiguous(),
+                    k[b : b + 1, start:end].contiguous(),
+                    v[b : b + 1, start:end].contiguous(),
+                    make_causal_valid_range(L, batch=1),
+                    topk,
+                    sm_scale=sm,
+                    block_B=block_B,
+                )
+                err = _maxerr(packed[b : b + 1, start:end], d_out)
+                self.assertLess(err, 2e-3, f"row{b} [{start},{end}) err={err}")
+                start = end
+
+    def test_backward_batched(self):
+        # dq/dk/dv for a B=2 batch match the fp32 reference (block-score).
+        _cuda_or_skip(self)
+        B, S, H, D, block_B = 2, 256, 8, 64, 64
+        q, k, v = _rand_qkv_mqa(B, S, H, D, seed=23)
+        vr = make_causal_valid_range(S, batch=B, doc_lengths=[96, 160])
+        sm = D**-0.5
+
+        qf, kf, vf = _grad_ref_qkv(q, k, v)
+        ref_out, _, _ = ref_block_score_attn_mqa(
+            qf, kf, vf, vr, sm_scale=sm, block_B=block_B
+        )
+        out, lse, _ = block_score_mqa_attn_fwd(
+            q, k, v, vr, sm_scale=sm, block_B=block_B
+        )
+        do = paddle.randn([B, S, H, D], dtype="bfloat16")
+        (ref_out * do.astype("float32")).sum().backward()
+        dq, dk, dv = block_score_mqa_bwd_interface(
+            q, k, v, out, do, lse, vr, sm_scale=sm, block_B=block_B
+        )
+        self.assertLess(_maxerr(dq, qf.grad), GRAD_ATOL)
+        self.assertLess(_maxerr(dk, kf.grad), GRAD_ATOL)
+        self.assertLess(_maxerr(dv, vf.grad), GRAD_ATOL)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
New features

### Description

Add TileLang implementations of the HySparse (arXiv 2602.03560) block attention pipeline for the MQA/MLA setting (single shared K/V head), under `src/paddlefleet/tilelang_ops/hysparse/`:

- **block-score attention** (fwd + bwd): full attention that additionally emits per-(query, key-block) max logits for downstream TopK block selection. Causal + document masking via **document-relative** block coordinates, with causal/document early-exit to skip fully-masked blocks.
- **block-sparse gather attention** (fwd + bwd): per-token block-sparse attention over TopK-selected blocks; block indices shared across heads and one shared K/V head so a single gathered block feeds every query head.
- **pipeline**: block-score scoring -> group-wise (cross-head) max aggregation -> TopK block selection -> block-sparse attention.
- **reference.py**: naive Paddle fp32 reference used as ground truth.
- **benchmark.py**: standalone performance harness.

Supports `head_dim=576` (MLA) and `batch>1`. The backward tiles the query `M` dim and sub-tiles the key `N` dim to fit shared memory at large head dims (Blackwell ~227KB/block).

**Tested**: 25 single-card precision tests in `tests/single_card_tests/custom_ops/test_hysparse_block_attn.py`, all validated against the naive fp32 reference (causal / document / `block_B in {32,64,128}` / `H=1` / deep-doc / empty rows / block_N sub-tiling invariance / batch=2 / packed multi-doc bit-exact / D=576 MLA fwd+bwd / topk>num_blocks shape). Tolerances: out < 5e-2, lse < 1e-3, block-score < 1e-3, grad < 8e-2 (bf16 matmul + fp32 accumulation).

**Review follow-ups addressed**:
- `select_topk_blocks` always returns `[B, S, topk]` (surplus slots padded with -1 when `topk > num_blocks`) and validates `topk > 0`.
- `ref_block_sparse_attn_mqa` empty-row LSE stays `-inf` (matches kernel/docstring).
- Lightweight host-side shape checks added to the forward interfaces.
- Removed the test's `sys.path.insert(src)` hack (relies on the installed package).

### 是否引起精度变化
否