### PR TITLE
Support DSV4 IndexCache training, distillation, and recompute

### DIFF
--- a/src/paddlefleet/__init__.py
+++ b/src/paddlefleet/__init__.py
@@ -14,6 +14,10 @@
 
 # Re-export from Paddle for backward compatibility (PaddleFormers imports these from paddlefleet)
 
+from .indexcache_pp_runtime_patch import apply_indexcache_pp_runtime_patch
+
+apply_indexcache_pp_runtime_patch()
+
 from . import (
     parallel_state as parallel_state,
     training as training,

--- a/src/paddlefleet/fusions/csa_sparse_attn.py
+++ b/src/paddlefleet/fusions/csa_sparse_attn.py
@@ -107,6 +107,7 @@ class CSASparseAttention(paddle.autograd.PyLayer):
         ctx.query_shape = (b, sq, np_heads, hn)
         ctx.softmax_scale = float(softmax_scale)
         ctx.attn_sink_dtype = attn_sink.dtype
+        ctx.attn_sink_stop_gradient = bool(attn_sink.stop_gradient)
         ctx.backend = backend
 
         query, kv_full, attn_sink, topk_idxs = prepare_inputs(
@@ -195,6 +196,7 @@ class CSASparseAttention(paddle.autograd.PyLayer):
                 ctx.attn_sink_dtype
             )
 
+        d_attn_sink = None if ctx.attn_sink_stop_gradient else d_attn_sink
         return (dq, dkv, d_attn_sink, None)
 
 

--- a/src/paddlefleet/indexcache_pp_runtime_patch.py
+++ b/src/paddlefleet/indexcache_pp_runtime_patch.py
@@ -38,14 +38,15 @@ def _has_indexcache_key(tensors) -> bool:
 
 
 def _mark_indexcache_state_stop_gradient(value):
+    from paddlefleet.transformer.indexcache_state import (
+        apply_stop_gradient_mask,
+    )
+
     if value is None:
         return value
     if not isinstance(value, (tuple, list)):
         value = (value,)
-    for tensor in value:
-        if isinstance(tensor, paddle.Tensor):
-            tensor.stop_gradient = True
-    return tuple(value)
+    return apply_stop_gradient_mask(value)
 
 
 def _describe_tensor_keys(tensors):

--- a/src/paddlefleet/indexcache_pp_runtime_patch.py
+++ b/src/paddlefleet/indexcache_pp_runtime_patch.py
@@ -1,0 +1,283 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import os
+
+import paddle
+
+
+_PATCH_FLAG = "_indexcache_pp_runtime_patch_applied"
+_INDEXCACHE_STATE_KEY = "indexcache_state"
+
+
+def _debug_enabled() -> bool:
+    return os.environ.get("INDEXCACHE_TRAIN_DEBUG", "0") == "1"
+
+
+def _is_indexcache_key(key) -> bool:
+    return isinstance(key, str) and key.startswith(_INDEXCACHE_STATE_KEY)
+
+
+def _has_indexcache_key(tensors) -> bool:
+    if not isinstance(tensors, (tuple, list)):
+        tensors = (tensors,)
+    return any(_is_indexcache_key(getattr(tensor, "key", None)) for tensor in tensors)
+
+
+def _mark_indexcache_state_stop_gradient(value):
+    if value is None:
+        return value
+    if not isinstance(value, (tuple, list)):
+        value = (value,)
+    for tensor in value:
+        if isinstance(tensor, paddle.Tensor):
+            tensor.stop_gradient = True
+    return tuple(value)
+
+
+def _describe_tensor_keys(tensors):
+    if not isinstance(tensors, (tuple, list)):
+        tensors = (tensors,)
+    desc = []
+    for tensor in tensors:
+        if not isinstance(tensor, paddle.Tensor):
+            desc.append(type(tensor).__name__)
+            continue
+        desc.append(
+            {
+                "key": getattr(tensor, "key", None),
+                "shape": list(tensor.shape),
+                "dtype": str(tensor.dtype),
+                "stop_gradient": bool(tensor.stop_gradient),
+            }
+        )
+    return desc
+
+
+def _detach_and_requires_grad(value):
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        return {
+            key: _detach_and_requires_grad(item)
+            for key, item in value.items()
+            if item is not None
+        }
+    if isinstance(value, (tuple, list)):
+        detached = [_detach_and_requires_grad(item) for item in value]
+        return tuple(detached) if isinstance(value, tuple) else detached
+    if isinstance(value, paddle.Tensor):
+        detached = value.detach()
+        detached.stop_gradient = value.stop_gradient
+        return detached
+    return value
+
+
+def _clone_and_clear_dataptr(value, fake_clone, clear_dataptr=False):
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        cloned = {
+            key: _clone_and_clear_dataptr(item, fake_clone, clear_dataptr)
+            for key, item in value.items()
+            if item is not None
+        }
+        return cloned
+    if isinstance(value, (tuple, list)):
+        cloned = [
+            _clone_and_clear_dataptr(item, fake_clone, clear_dataptr)
+            for item in value
+            if item is not None
+        ]
+        return tuple(cloned) if isinstance(value, tuple) else cloned
+    if isinstance(value, paddle.Tensor):
+        cloned = fake_clone.apply(value)
+        cloned.stop_gradient = value.stop_gradient
+        if clear_dataptr:
+            cloned._clear_dataptr()
+        return cloned
+    return value
+
+
+def _convert_tensor_dict_to_tuple(output_tensor_dict):
+    output_tensor = []
+    for key, tensor in output_tensor_dict.items():
+        if tensor is None:
+            continue
+        if isinstance(tensor, (list, tuple)):
+            if key == _INDEXCACHE_STATE_KEY:
+                tensor = _mark_indexcache_state_stop_gradient(tensor)
+            for idx, item in enumerate(tensor):
+                if item is None:
+                    continue
+                if not isinstance(item, paddle.Tensor):
+                    raise TypeError(
+                        "Pipeline dict tuple values must be paddle.Tensor "
+                        f"or None, but {key}[{idx}] is {type(item).__name__}."
+                    )
+                item.key = f"{key} {idx}"
+                output_tensor.append(item)
+        else:
+            if not isinstance(tensor, paddle.Tensor):
+                raise TypeError(
+                    "Pipeline dict values must be paddle.Tensor or tensor "
+                    f"tuple/list, but {key} is {type(tensor).__name__}."
+                )
+            tensor.key = key
+            output_tensor.append(tensor)
+
+    output_tensor = tuple(output_tensor)
+    if _debug_enabled() and _has_indexcache_key(output_tensor):
+        print(
+            "[INDEXCACHE_PP_FLOW] dict_to_tuple "
+            f"tensors={_describe_tensor_keys(output_tensor)}",
+            flush=True,
+        )
+    return output_tensor
+
+
+def _convert_tensor_tuple_to_dict(input_tensor_tuple):
+    input_tensor_dict = {}
+    if not isinstance(input_tensor_tuple, tuple):
+        input_tensor_tuple = (input_tensor_tuple,)
+    for tensor in input_tensor_tuple:
+        key = tensor.key
+        if " " in key:
+            real_key, suffix = key.rsplit(" ", 1)
+            if suffix.isdigit():
+                input_tensor_dict.setdefault(real_key, []).append(tensor)
+            else:
+                input_tensor_dict[key] = tensor
+        else:
+            input_tensor_dict[key] = tensor
+        delattr(tensor, "key")
+    if isinstance(input_tensor_dict.get(_INDEXCACHE_STATE_KEY), list):
+        input_tensor_dict[_INDEXCACHE_STATE_KEY] = tuple(
+            input_tensor_dict[_INDEXCACHE_STATE_KEY]
+        )
+    if _INDEXCACHE_STATE_KEY in input_tensor_dict:
+        input_tensor_dict[_INDEXCACHE_STATE_KEY] = (
+            _mark_indexcache_state_stop_gradient(
+                input_tensor_dict[_INDEXCACHE_STATE_KEY]
+            )
+        )
+    if _debug_enabled() and _INDEXCACHE_STATE_KEY in input_tensor_dict:
+        state = input_tensor_dict[_INDEXCACHE_STATE_KEY]
+        print(
+            "[INDEXCACHE_PP_FLOW] tuple_to_dict "
+            f"keys={list(input_tensor_dict.keys())} "
+            f"state_type={type(state).__name__} "
+            f"state={_describe_tensor_keys(state)}",
+            flush=True,
+        )
+    return input_tensor_dict
+
+
+def _tuple_to_dict_helper(input_tensor):
+    use_dict = False
+    if isinstance(input_tensor, tuple):
+        use_dict = len(input_tensor) > 0 and hasattr(input_tensor[0], "key")
+    else:
+        use_dict = hasattr(input_tensor, "key")
+    if use_dict:
+        input_tensor = _convert_tensor_tuple_to_dict(input_tensor)
+    return input_tensor, use_dict
+
+
+def _dict_to_tuple_helper(output_tensor):
+    if isinstance(output_tensor, dict):
+        return _convert_tensor_dict_to_tuple(output_tensor)
+    return output_tensor
+
+
+def _schedule_node_backward(self, output_grad=None, scaler=None):
+    if output_grad is None:
+        if isinstance(self.outputs, (tuple, list)):
+            assert len(self.outputs) == 1
+            outputs = self.outputs[0]
+        else:
+            outputs = self.outputs
+        assert isinstance(outputs, paddle.Tensor)
+        if scaler is not None:
+            paddle.autograd.backward(scaler.scale(outputs))
+        else:
+            paddle.autograd.backward(outputs)
+    else:
+        is_output_grad_tuple = isinstance(output_grad, tuple)
+        if not isinstance(output_grad, (tuple, list)):
+            is_output_grad_tuple = True
+            output_grad = (output_grad,)
+
+        outputs = _dict_to_tuple_helper(self.outputs)
+        if not isinstance(outputs, (tuple, list)):
+            outputs = (outputs,)
+        outputs = [
+            tensor
+            for tensor in outputs
+            if isinstance(tensor, paddle.Tensor) and not tensor.stop_gradient
+        ]
+
+        output_grad = [grad for grad in output_grad if grad is not None]
+        output_grad = (
+            tuple(output_grad) if is_output_grad_tuple else list(output_grad)
+        )
+
+        assert len(outputs) == len(output_grad), (
+            f"{len(outputs)} of {type(outputs[0])} vs "
+            f"{len(output_grad)} of {type(output_grad[0])}"
+        )
+        paddle.autograd.backward(outputs, output_grad)
+
+    inputs = _dict_to_tuple_helper(self.inputs)
+    if not isinstance(inputs, (tuple, list)):
+        inputs = (inputs,)
+    grad = tuple(
+        tensor.grad
+        for tensor in inputs
+        if isinstance(tensor, paddle.Tensor) and not tensor.stop_gradient
+    )
+    self._reset_states()
+    return grad
+
+
+def apply_indexcache_pp_runtime_patch() -> None:
+    import paddle.distributed.fleet.meta_parallel as meta_parallel
+    import paddle.distributed.fleet.meta_parallel.pp_utils.forward_backward_overlap_utils as fbo
+    import paddle.distributed.fleet.meta_parallel.pp_utils.utils as pp_utils
+
+    if getattr(pp_utils, _PATCH_FLAG, False):
+        return
+
+    def clone_and_clear_dataptr(outputs, clear_dataptr=False):
+        return _clone_and_clear_dataptr(
+            outputs,
+            fbo.FakeClone,
+            clear_dataptr=clear_dataptr,
+        )
+
+    pp_utils.convert_tensor_dict_to_tuple = _convert_tensor_dict_to_tuple
+    pp_utils.convert_tensor_tuple_to_dict = _convert_tensor_tuple_to_dict
+    pp_utils.tuple_to_dict_helper = _tuple_to_dict_helper
+    pp_utils.dict_to_tuple_helper = _dict_to_tuple_helper
+    setattr(pp_utils, _PATCH_FLAG, True)
+
+    meta_parallel.dict_to_tuple_helper = _dict_to_tuple_helper
+    meta_parallel.tuple_to_dict_helper = _tuple_to_dict_helper
+
+    fbo.detach_and_requires_grad = _detach_and_requires_grad
+    fbo.clone_and_clear_dataptr = clone_and_clear_dataptr
+    fbo.ScheduleNode.backward = _schedule_node_backward
+    setattr(fbo, _PATCH_FLAG, True)

--- a/src/paddlefleet/indexcache_pp_runtime_patch.py
+++ b/src/paddlefleet/indexcache_pp_runtime_patch.py
@@ -23,6 +23,8 @@ import paddle
 _PATCH_FLAG = "_indexcache_pp_runtime_patch_applied"
 _INDEXCACHE_STATE_KEY = "indexcache_state"
 _PIPELINE_KEY_ATTR = "_paddlefleet_pipeline_key"
+_PIPELINE_SHAPE_ATTR = "_paddlefleet_pipeline_shape"
+_PIPELINE_DTYPE_ATTR = "_paddlefleet_pipeline_dtype"
 
 
 def _debug_enabled() -> bool:
@@ -38,6 +40,12 @@ def _get_pipeline_key(tensor):
     if key is None:
         key = getattr(tensor, _PIPELINE_KEY_ATTR, None)
     return key
+
+
+def _save_pipeline_metadata(tensor, key):
+    setattr(tensor, _PIPELINE_KEY_ATTR, key)
+    setattr(tensor, _PIPELINE_SHAPE_ATTR, tuple(tensor.shape))
+    setattr(tensor, _PIPELINE_DTYPE_ATTR, tensor.dtype)
 
 
 def _has_indexcache_key(tensors) -> bool:
@@ -139,7 +147,7 @@ def _convert_tensor_dict_to_tuple(output_tensor_dict):
                         f"or None, but {key}[{idx}] is {type(item).__name__}."
                     )
                 item.key = f"{key} {idx}"
-                setattr(item, _PIPELINE_KEY_ATTR, item.key)
+                _save_pipeline_metadata(item, item.key)
                 output_tensor.append(item)
         else:
             if not isinstance(tensor, paddle.Tensor):
@@ -148,7 +156,7 @@ def _convert_tensor_dict_to_tuple(output_tensor_dict):
                     f"tuple/list, but {key} is {type(tensor).__name__}."
                 )
             tensor.key = key
-            setattr(tensor, _PIPELINE_KEY_ATTR, key)
+            _save_pipeline_metadata(tensor, key)
             output_tensor.append(tensor)
 
     output_tensor = tuple(output_tensor)
@@ -167,7 +175,7 @@ def _convert_tensor_tuple_to_dict(input_tensor_tuple):
         input_tensor_tuple = (input_tensor_tuple,)
     for tensor in input_tensor_tuple:
         key = tensor.key
-        setattr(tensor, _PIPELINE_KEY_ATTR, key)
+        _save_pipeline_metadata(tensor, key)
         if " " in key:
             real_key, suffix = key.rsplit(" ", 1)
             if suffix.isdigit():
@@ -244,6 +252,22 @@ def _collect_input_gradients(inputs):
     return tuple(gradients)
 
 
+def _zeros_from_tensor_metadata(tensor):
+    shape = getattr(tensor, _PIPELINE_SHAPE_ATTR, None)
+    dtype = getattr(tensor, _PIPELINE_DTYPE_ATTR, None)
+    if shape is None or dtype is None:
+        raise RuntimeError(
+            "IndexCache pipeline tensor lacks preserved shape/dtype metadata: "
+            f"key={_get_pipeline_key(tensor)!r}."
+        )
+    grad = paddle.zeros(
+        shape=list(shape),
+        dtype=dtype,
+    )
+    grad.stop_gradient = False
+    return grad
+
+
 def _normalize_pipeline_input_gradients(input_tensor, input_tensor_grad):
     if input_tensor is None:
         return input_tensor_grad
@@ -284,8 +308,7 @@ def _normalize_pipeline_input_gradients(input_tensor, input_tensor_grad):
                     f"state: key={key!r}, shape={list(tensor.shape)}, "
                     f"dtype={tensor.dtype}."
                 )
-            grad = paddle.zeros_like(tensor)
-            grad.stop_gradient = False
+            grad = _zeros_from_tensor_metadata(tensor)
             gradients[idx] = grad
             zero_filled_keys.append(key)
         elif not isinstance(grad, paddle.Tensor):

--- a/src/paddlefleet/indexcache_pp_runtime_patch.py
+++ b/src/paddlefleet/indexcache_pp_runtime_patch.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import functools
 import os
 
 import paddle
@@ -21,6 +22,7 @@ import paddle
 
 _PATCH_FLAG = "_indexcache_pp_runtime_patch_applied"
 _INDEXCACHE_STATE_KEY = "indexcache_state"
+_PIPELINE_KEY_ATTR = "_paddlefleet_pipeline_key"
 
 
 def _debug_enabled() -> bool:
@@ -31,10 +33,17 @@ def _is_indexcache_key(key) -> bool:
     return isinstance(key, str) and key.startswith(_INDEXCACHE_STATE_KEY)
 
 
+def _get_pipeline_key(tensor):
+    key = getattr(tensor, "key", None)
+    if key is None:
+        key = getattr(tensor, _PIPELINE_KEY_ATTR, None)
+    return key
+
+
 def _has_indexcache_key(tensors) -> bool:
     if not isinstance(tensors, (tuple, list)):
         tensors = (tensors,)
-    return any(_is_indexcache_key(getattr(tensor, "key", None)) for tensor in tensors)
+    return any(_is_indexcache_key(_get_pipeline_key(tensor)) for tensor in tensors)
 
 
 def _mark_indexcache_state_stop_gradient(value):
@@ -59,7 +68,7 @@ def _describe_tensor_keys(tensors):
             continue
         desc.append(
             {
-                "key": getattr(tensor, "key", None),
+                "key": _get_pipeline_key(tensor),
                 "shape": list(tensor.shape),
                 "dtype": str(tensor.dtype),
                 "stop_gradient": bool(tensor.stop_gradient),
@@ -130,6 +139,7 @@ def _convert_tensor_dict_to_tuple(output_tensor_dict):
                         f"or None, but {key}[{idx}] is {type(item).__name__}."
                     )
                 item.key = f"{key} {idx}"
+                setattr(item, _PIPELINE_KEY_ATTR, item.key)
                 output_tensor.append(item)
         else:
             if not isinstance(tensor, paddle.Tensor):
@@ -138,6 +148,7 @@ def _convert_tensor_dict_to_tuple(output_tensor_dict):
                     f"tuple/list, but {key} is {type(tensor).__name__}."
                 )
             tensor.key = key
+            setattr(tensor, _PIPELINE_KEY_ATTR, key)
             output_tensor.append(tensor)
 
     output_tensor = tuple(output_tensor)
@@ -156,6 +167,7 @@ def _convert_tensor_tuple_to_dict(input_tensor_tuple):
         input_tensor_tuple = (input_tensor_tuple,)
     for tensor in input_tensor_tuple:
         key = tensor.key
+        setattr(tensor, _PIPELINE_KEY_ATTR, key)
         if " " in key:
             real_key, suffix = key.rsplit(" ", 1)
             if suffix.isdigit():
@@ -212,7 +224,7 @@ def _collect_input_gradients(inputs):
             continue
         grad = tensor.grad
         if grad is None:
-            key = getattr(tensor, "key", None)
+            key = _get_pipeline_key(tensor)
             if not _is_indexcache_key(key):
                 raise RuntimeError(
                     "Pipeline input is missing a gradient outside IndexCache "
@@ -230,6 +242,82 @@ def _collect_input_gradients(inputs):
             flush=True,
         )
     return tuple(gradients)
+
+
+def _normalize_pipeline_input_gradients(input_tensor, input_tensor_grad):
+    if input_tensor is None:
+        return input_tensor_grad
+
+    is_tuple_input = isinstance(input_tensor, tuple)
+    inputs = input_tensor if is_tuple_input else (input_tensor,)
+    if not _has_indexcache_key(inputs):
+        return input_tensor_grad
+
+    differentiable_inputs = [
+        tensor
+        for tensor in inputs
+        if isinstance(tensor, paddle.Tensor) and not tensor.stop_gradient
+    ]
+    if is_tuple_input:
+        if not isinstance(input_tensor_grad, (tuple, list)):
+            raise RuntimeError(
+                "IndexCache pipeline input gradients must preserve tuple "
+                f"structure, but got {type(input_tensor_grad).__name__}."
+            )
+        gradients = list(input_tensor_grad)
+    else:
+        gradients = [input_tensor_grad]
+
+    if len(gradients) != len(differentiable_inputs):
+        raise RuntimeError(
+            "IndexCache pipeline input gradient arity mismatch: "
+            f"inputs={len(differentiable_inputs)}, gradients={len(gradients)}."
+        )
+
+    zero_filled_keys = []
+    for idx, (tensor, grad) in enumerate(zip(differentiable_inputs, gradients)):
+        key = _get_pipeline_key(tensor)
+        if grad is None:
+            if not _is_indexcache_key(key):
+                raise RuntimeError(
+                    "Pipeline input is missing a gradient outside IndexCache "
+                    f"state: key={key!r}, shape={list(tensor.shape)}, "
+                    f"dtype={tensor.dtype}."
+                )
+            grad = paddle.zeros_like(tensor)
+            grad.stop_gradient = False
+            gradients[idx] = grad
+            zero_filled_keys.append(key)
+        elif not isinstance(grad, paddle.Tensor):
+            raise TypeError(
+                "Pipeline input gradients must be paddle.Tensor or None, "
+                f"but key={key!r} has {type(grad).__name__}."
+            )
+
+    if _debug_enabled() and zero_filled_keys:
+        print(
+            "[INDEXCACHE_PP_GRAD] boundary=pipeline zero_filled_keys="
+            f"{zero_filled_keys}",
+            flush=True,
+        )
+    return tuple(gradients) if is_tuple_input else gradients[0]
+
+
+def _wrap_pipeline_backward_step(original_backward_step):
+    @functools.wraps(original_backward_step)
+    def backward_step(self, input_tensor, *args, **kwargs):
+        input_tensor_grad = original_backward_step(
+            self,
+            input_tensor,
+            *args,
+            **kwargs,
+        )
+        return _normalize_pipeline_input_gradients(
+            input_tensor,
+            input_tensor_grad,
+        )
+
+    return backward_step
 
 
 def _schedule_node_backward(self, output_grad=None, scaler=None):
@@ -280,6 +368,7 @@ def _schedule_node_backward(self, output_grad=None, scaler=None):
 
 def apply_indexcache_pp_runtime_patch() -> None:
     import paddle.distributed.fleet.meta_parallel as meta_parallel
+    import paddle.distributed.fleet.meta_parallel.pipeline_parallel as pipeline_parallel
     import paddle.distributed.fleet.meta_parallel.pp_utils.forward_backward_overlap_utils as fbo
     import paddle.distributed.fleet.meta_parallel.pp_utils.utils as pp_utils
 
@@ -306,3 +395,10 @@ def apply_indexcache_pp_runtime_patch() -> None:
     fbo.clone_and_clear_dataptr = clone_and_clear_dataptr
     fbo.ScheduleNode.backward = _schedule_node_backward
     setattr(fbo, _PATCH_FLAG, True)
+
+    pipeline_parallel.PipelineParallel._backward_step = (
+        _wrap_pipeline_backward_step(
+            pipeline_parallel.PipelineParallel._backward_step
+        )
+    )
+    setattr(pipeline_parallel, _PATCH_FLAG, True)

--- a/src/paddlefleet/indexcache_pp_runtime_patch.py
+++ b/src/paddlefleet/indexcache_pp_runtime_patch.py
@@ -204,6 +204,34 @@ def _dict_to_tuple_helper(output_tensor):
     return output_tensor
 
 
+def _collect_input_gradients(inputs):
+    gradients = []
+    zero_filled_keys = []
+    for tensor in inputs:
+        if not isinstance(tensor, paddle.Tensor) or tensor.stop_gradient:
+            continue
+        grad = tensor.grad
+        if grad is None:
+            key = getattr(tensor, "key", None)
+            if not _is_indexcache_key(key):
+                raise RuntimeError(
+                    "Pipeline input is missing a gradient outside IndexCache "
+                    f"state: key={key!r}, shape={list(tensor.shape)}, "
+                    f"dtype={tensor.dtype}."
+                )
+            grad = paddle.zeros_like(tensor)
+            grad.stop_gradient = False
+            zero_filled_keys.append(key)
+        gradients.append(grad)
+    if _debug_enabled() and zero_filled_keys:
+        print(
+            "[INDEXCACHE_PP_GRAD] zero_filled_keys="
+            f"{zero_filled_keys}",
+            flush=True,
+        )
+    return tuple(gradients)
+
+
 def _schedule_node_backward(self, output_grad=None, scaler=None):
     if output_grad is None:
         if isinstance(self.outputs, (tuple, list)):
@@ -245,11 +273,7 @@ def _schedule_node_backward(self, output_grad=None, scaler=None):
     inputs = _dict_to_tuple_helper(self.inputs)
     if not isinstance(inputs, (tuple, list)):
         inputs = (inputs,)
-    grad = tuple(
-        tensor.grad
-        for tensor in inputs
-        if isinstance(tensor, paddle.Tensor) and not tensor.stop_gradient
-    )
+    grad = _collect_input_gradients(inputs)
     self._reset_states()
     return grad
 

--- a/src/paddlefleet/models/gpt/gpt_embedding.py
+++ b/src/paddlefleet/models/gpt/gpt_embedding.py
@@ -217,6 +217,11 @@ class GPTEmbedding(FleetLayer):
                 )
                 input_ids_for_moe_mask = input_ids
             if (
+                input_ids_for_moe_mask is None
+                and getattr(self.config, "moe_n_hash_layers", 0) > 0
+            ):
+                input_ids_for_moe_mask = input_ids
+            if (
                 self.config.num_nextn_predict_layers is not None
                 and self.config.num_nextn_predict_layers > 0
                 and not self.config.mtp_load_weight_only

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -841,6 +841,12 @@ class TileLangCSAIndexerLossAutoScaler(paddle.autograd.PyLayer):
         num_rows_override: float | None = None,
         loss_mask: Tensor | None = None,
     ) -> Tensor:
+        ctx.input_stop_gradients = (
+            bool(output.stop_gradient),
+            bool(index_q.stop_gradient),
+            bool(weights.stop_gradient),
+            bool(index_k_comp.stop_gradient),
+        )
         ctx.save_for_backward(
             index_q.detach(),
             weights.detach(),
@@ -952,7 +958,14 @@ class TileLangCSAIndexerLossAutoScaler(paddle.autograd.PyLayer):
         if grad_k.dtype != index_k_comp.dtype:
             grad_k = grad_k.cast(index_k_comp.dtype)
 
-        grads = (grad_output, grad_q, grad_weights, grad_k) + (None,) * (
+        grad_slots = [grad_output, grad_q, grad_weights, grad_k]
+        for idx, stop_gradient in enumerate(
+            getattr(ctx, "input_stop_gradients", ())
+        ):
+            if stop_gradient:
+                grad_slots[idx] = None
+
+        grads = tuple(grad_slots) + (None,) * (
             4 if getattr(ctx, "loss_mask", None) is not None else 3
         )
         return grads
@@ -1651,6 +1664,12 @@ class CompressedSparseAttention(FleetLayer):
         coeff = getattr(self.config, "dsa_indexer_loss_coeff", 0.0) or 0.0
         return float(coeff) / float(max(int(served_count), 1))
 
+    def _indexcache_clear_cached_state(self) -> None:
+        self.config._indexcache_last_topk_idxs = None
+        self.config._indexcache_last_layer_number = None
+        self.config._indexcache_last_distill_state = None
+        self.config._indexcache_last_served_count = None
+
     def _indexcache_c4_layers(self) -> list[int]:
         ratios = getattr(self.config, "csa_compress_ratios", None) or []
         empty_head = int(
@@ -1676,6 +1695,14 @@ class CompressedSparseAttention(FleetLayer):
             return None
         return c4_layers[producer_ordinal]
 
+    @staticmethod
+    def _indexcache_has_future_served_layer(
+        pattern: str, c4_ordinal: int
+    ) -> bool:
+        next_f = pattern.find("F", c4_ordinal + 1)
+        end = next_f if next_f != -1 else len(pattern)
+        return "S" in pattern[c4_ordinal + 1 : end]
+
     def _indexcache_next_c4_action(self) -> tuple[int, str, str] | None:
         pattern = self._indexcache_pattern()
         if pattern is None or self.compress_ratio != 4 or self.indexer is None:
@@ -1697,10 +1724,7 @@ class CompressedSparseAttention(FleetLayer):
             )
 
         if c4_ordinal == 0:
-            self.config._indexcache_last_topk_idxs = None
-            self.config._indexcache_last_layer_number = None
-            self.config._indexcache_last_distill_state = None
-            self.config._indexcache_last_served_count = None
+            self._indexcache_clear_cached_state()
 
         action = pattern[c4_ordinal]
         return c4_ordinal, action, pattern
@@ -1716,13 +1740,19 @@ class CompressedSparseAttention(FleetLayer):
         except Exception:
             return int(value.numpy().reshape([-1])[0])
 
+    @staticmethod
+    def _indexcache_forward_state_tensor(value: Tensor) -> Tensor:
+        value = value.detach()
+        value.stop_gradient = True
+        return value
+
     def _indexcache_pack_state(
         self,
         compress_topk_idxs: Tensor,
         tilelang_indexer_loss_state: tuple | None = None,
         served_count: int | None = None,
     ) -> tuple[Tensor, ...]:
-        state = [compress_topk_idxs.detach()]
+        state = [self._indexcache_forward_state_tensor(compress_topk_idxs)]
         if tilelang_indexer_loss_state is not None:
             (
                 q_indexer_bf,
@@ -1734,14 +1764,29 @@ class CompressedSparseAttention(FleetLayer):
             ) = tilelang_indexer_loss_state
             state.extend(
                 [
-                    q_indexer_bf,
-                    weights_indexer_bf,
-                    k_indexer_bf,
-                    topk_indices_compressed,
-                    topk_probs,
-                    paddle.full([1], self.layer_number, dtype="int64"),
-                    paddle.full(
-                        [1], int(served_count or 1), dtype="int64"
+                    self._indexcache_forward_state_tensor(q_indexer_bf),
+                    self._indexcache_forward_state_tensor(weights_indexer_bf),
+                    self._indexcache_forward_state_tensor(k_indexer_bf),
+                    self._indexcache_forward_state_tensor(
+                        topk_indices_compressed
+                    ),
+                    self._indexcache_forward_state_tensor(topk_probs),
+                    self._indexcache_forward_state_tensor(
+                        paddle.full([1], self.layer_number, dtype="int64")
+                    ),
+                    self._indexcache_forward_state_tensor(
+                        paddle.full([1], int(served_count or 1), dtype="int64")
+                    ),
+                ]
+            )
+        else:
+            state.extend(
+                [
+                    self._indexcache_forward_state_tensor(
+                        paddle.full([1], self.layer_number, dtype="int64")
+                    ),
+                    self._indexcache_forward_state_tensor(
+                        paddle.full([1], int(served_count or 1), dtype="int64")
                     ),
                 ]
             )
@@ -1753,9 +1798,13 @@ class CompressedSparseAttention(FleetLayer):
         if not indexcache_state:
             return None, None
         producer_layer = None
-        if len(indexcache_state) > 6:
+        if len(indexcache_state) >= 8:
             producer_layer = self._indexcache_tensor_to_int(
                 indexcache_state[6]
+            )
+        elif len(indexcache_state) >= 3:
+            producer_layer = self._indexcache_tensor_to_int(
+                indexcache_state[1]
             )
         if producer_layer is None:
             producer_layer = getattr(
@@ -2242,6 +2291,7 @@ class CompressedSparseAttention(FleetLayer):
         """
         b, sq, np_heads, hn = query.shape
         indexcache_state_next = indexcache_state
+        indexcache_state_updated = False
 
         if startend_row_indices is not None:
             assert b == 1, (
@@ -2297,12 +2347,15 @@ class CompressedSparseAttention(FleetLayer):
                 global_valid_count=global_valid_count,
                 indexcache_state=indexcache_state,
             )
+            cp_indexcache_state_updated = isinstance(cp_result, tuple)
             if isinstance(cp_result, tuple):
                 output, indexcache_state_next = cp_result
             else:
                 output = cp_result
             if indexcache_state_next is not None:
                 return output, indexcache_state_next
+            if cp_indexcache_state_updated:
+                return output, None
             return output
 
         if startend_row_indices is not None and self.compress_ratio > 1:
@@ -2379,6 +2432,14 @@ class CompressedSparseAttention(FleetLayer):
                             indexcache_state=indexcache_state,
                         )
                     )
+                    if self._indexcache_has_future_served_layer(
+                        pattern, c4_ordinal
+                    ):
+                        indexcache_state_next = indexcache_state
+                    else:
+                        indexcache_state_next = None
+                        self._indexcache_clear_cached_state()
+                    indexcache_state_updated = True
                 else:
                     served_count = None
                     loss_coeff_override = None
@@ -2411,7 +2472,7 @@ class CompressedSparseAttention(FleetLayer):
                     )
                     if indexcache_action is not None:
                         c4_ordinal, _action, pattern = indexcache_action
-                        indexcache_state_next = self._indexcache_cache_topk(
+                        produced_state = self._indexcache_cache_topk(
                             compress_topk_idxs,
                             c4_ordinal,
                             pattern,
@@ -2419,6 +2480,14 @@ class CompressedSparseAttention(FleetLayer):
                             served_count,
                             loss_coeff_override,
                         )
+                        if self._indexcache_has_future_served_layer(
+                            pattern, c4_ordinal
+                        ):
+                            indexcache_state_next = produced_state
+                        else:
+                            indexcache_state_next = None
+                            self._indexcache_clear_cached_state()
+                        indexcache_state_updated = True
             else:
                 # ratio=128: attend to all compressed positions
                 compress_topk_idxs = get_compress_topk_idxs(
@@ -2464,6 +2533,8 @@ class CompressedSparseAttention(FleetLayer):
 
         if indexcache_state_next is not None:
             return output, indexcache_state_next
+        if indexcache_state_updated:
+            return output, None
         return output
 
     def _forward_cp(
@@ -2493,6 +2564,7 @@ class CompressedSparseAttention(FleetLayer):
         """
         b, sq, np_heads, hn = query.shape
         indexcache_state_next = indexcache_state
+        indexcache_state_updated = False
         sq_global = sq * self.cp_size
         position_offset = self.cp_rank * sq
         q_positions = paddle.arange(
@@ -2593,6 +2665,14 @@ class CompressedSparseAttention(FleetLayer):
                             indexcache_state=indexcache_state,
                         )
                     )
+                    if self._indexcache_has_future_served_layer(
+                        pattern, c4_ordinal
+                    ):
+                        indexcache_state_next = indexcache_state
+                    else:
+                        indexcache_state_next = None
+                        self._indexcache_clear_cached_state()
+                    indexcache_state_updated = True
                 else:
                     x_det = x.detach()
                     qr_det = qr.detach()
@@ -2856,7 +2936,7 @@ class CompressedSparseAttention(FleetLayer):
                             if tilelang_indexer_loss_state is not None
                             else loss_coeff_override
                         )
-                        indexcache_state_next = self._indexcache_cache_topk(
+                        produced_state = self._indexcache_cache_topk(
                             compress_topk_idxs,
                             c4_ordinal,
                             pattern,
@@ -2864,6 +2944,14 @@ class CompressedSparseAttention(FleetLayer):
                             served_count,
                             effective_loss_scale,
                         )
+                        if self._indexcache_has_future_served_layer(
+                            pattern, c4_ordinal
+                        ):
+                            indexcache_state_next = produced_state
+                        else:
+                            indexcache_state_next = None
+                            self._indexcache_clear_cached_state()
+                        indexcache_state_updated = True
             else:
                 # HCA path: attend to all compressed positions
                 if startend_row_indices is None:
@@ -2915,6 +3003,8 @@ class CompressedSparseAttention(FleetLayer):
 
         if indexcache_state_next is not None:
             return output, indexcache_state_next
+        if indexcache_state_updated:
+            return output, None
         return output
 
     def compressed_sparse_attn(

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -800,6 +800,24 @@ def _compute_fused_csa_indexer_loss_forward(
     return loss, topk_indices, topk_probs, target
 
 
+def _compute_csa_selected_set_kl_loss(
+    target: Tensor,
+    topk_probs: Tensor,
+    loss_coeff: float,
+    loss_mask: Tensor | None = None,
+    global_valid_count: float | None = None,
+) -> Tensor:
+    eps = 1e-10
+    kl_per_elem = target * (
+        paddle.log(target + eps) - paddle.log(topk_probs + eps)
+    )
+    kl_per_pos = kl_per_elem.sum(axis=-1)
+    if loss_mask is not None:
+        lm = loss_mask.reshape(kl_per_pos.shape).astype(kl_per_pos.dtype)
+        return (kl_per_pos * lm).sum() / global_valid_count * float(loss_coeff)
+    return kl_per_pos.mean() * float(loss_coeff)
+
+
 class TileLangCSAIndexerLossAutoScaler(paddle.autograd.PyLayer):
     """Attach TileLang CSA indexer loss gradients to the main output.
 
@@ -1578,6 +1596,379 @@ class CompressedSparseAttention(FleetLayer):
         else:
             self.indexer = None
 
+    def _indexcache_pattern(self) -> str | None:
+        pattern = getattr(self.config, "index_topk_pattern", None)
+        if pattern is None:
+            return None
+        pattern = str(pattern).strip().upper()
+        if not pattern:
+            return None
+        invalid_chars = sorted(set(pattern) - {"F", "S"})
+        if invalid_chars:
+            raise ValueError(
+                "index_topk_pattern may only contain 'F' and 'S', "
+                f"got invalid chars: {invalid_chars}."
+            )
+        if pattern[0] != "F":
+            raise ValueError("index_topk_pattern must start with 'F'.")
+        return pattern
+
+    def _indexcache_debug(self, msg: str) -> None:
+        if os.environ.get("INDEXCACHE_TRAIN_DEBUG", "0") == "1":
+            cp_msg = (
+                f" cp_rank={self.cp_rank} cp_size={self.cp_size}"
+                if self.cp_enabled
+                else ""
+            )
+            print(
+                f"[INDEXCACHE_TRAIN] layer={self.layer_number}{cp_msg} {msg}",
+                flush=True,
+            )
+
+    def _indexcache_distill_debug(self, msg: str) -> None:
+        if os.environ.get("INDEXCACHE_TRAIN_DEBUG", "0") == "1":
+            cp_msg = (
+                f" cp_rank={self.cp_rank} cp_size={self.cp_size}"
+                if self.cp_enabled
+                else ""
+            )
+            print(
+                f"[INDEXCACHE_DISTILL] layer={self.layer_number}{cp_msg} {msg}",
+                flush=True,
+            )
+
+    def _indexcache_multi_layer_distill_enabled(self) -> bool:
+        return bool(getattr(self.config, "indexcache_multi_layer_distill", False))
+
+    @staticmethod
+    def _indexcache_served_count(pattern: str, c4_ordinal: int) -> int:
+        next_f = pattern.find("F", c4_ordinal + 1)
+        if next_f == -1:
+            next_f = len(pattern)
+        return max(1, next_f - c4_ordinal)
+
+    def _indexcache_scaled_loss_coeff(self, served_count: int) -> float:
+        coeff = getattr(self.config, "dsa_indexer_loss_coeff", 0.0) or 0.0
+        return float(coeff) / float(max(int(served_count), 1))
+
+    def _indexcache_c4_layers(self) -> list[int]:
+        ratios = getattr(self.config, "csa_compress_ratios", None) or []
+        empty_head = int(
+            getattr(self.config, "num_empty_layers_add_in_head", 0) or 0
+        )
+        return [
+            int(layer_idx) + empty_head
+            for layer_idx, ratio in enumerate(ratios)
+            if int(ratio) == 4
+        ]
+
+    def _indexcache_infer_producer_layer(
+        self, c4_ordinal: int, pattern: str
+    ) -> int | None:
+        producer_ordinal = min(c4_ordinal - 1, len(pattern) - 1)
+        while producer_ordinal >= 0 and pattern[producer_ordinal] != "F":
+            producer_ordinal -= 1
+        if producer_ordinal < 0:
+            return None
+
+        c4_layers = self._indexcache_c4_layers()
+        if producer_ordinal >= len(c4_layers):
+            return None
+        return c4_layers[producer_ordinal]
+
+    def _indexcache_next_c4_action(self) -> tuple[int, str, str] | None:
+        pattern = self._indexcache_pattern()
+        if pattern is None or self.compress_ratio != 4 or self.indexer is None:
+            return None
+
+        c4_layers = self._indexcache_c4_layers()
+        if self.layer_number not in c4_layers:
+            raise RuntimeError(
+                "IndexCache C4 static mapping could not find the current "
+                f"layer={self.layer_number} in csa_compress_ratios C4 layers "
+                f"{c4_layers}."
+            )
+        c4_ordinal = c4_layers.index(self.layer_number)
+        if c4_ordinal >= len(pattern):
+            raise ValueError(
+                "index_topk_pattern must cover every C4 layer in this "
+                f"configuration. pattern={pattern}, c4_layers={c4_layers}, "
+                f"current_c4_ordinal={c4_ordinal}."
+            )
+
+        if c4_ordinal == 0:
+            self.config._indexcache_last_topk_idxs = None
+            self.config._indexcache_last_layer_number = None
+            self.config._indexcache_last_distill_state = None
+            self.config._indexcache_last_served_count = None
+
+        action = pattern[c4_ordinal]
+        return c4_ordinal, action, pattern
+
+    @staticmethod
+    def _indexcache_tensor_to_int(value: Tensor | int | None) -> int | None:
+        if value is None:
+            return None
+        if isinstance(value, int):
+            return value
+        try:
+            return int(value.item())
+        except Exception:
+            return int(value.numpy().reshape([-1])[0])
+
+    def _indexcache_pack_state(
+        self,
+        compress_topk_idxs: Tensor,
+        tilelang_indexer_loss_state: tuple | None = None,
+        served_count: int | None = None,
+    ) -> tuple[Tensor, ...]:
+        state = [compress_topk_idxs.detach()]
+        if tilelang_indexer_loss_state is not None:
+            (
+                q_indexer_bf,
+                weights_indexer_bf,
+                k_indexer_bf,
+                topk_indices_compressed,
+                topk_probs,
+                *_,
+            ) = tilelang_indexer_loss_state
+            state.extend(
+                [
+                    q_indexer_bf,
+                    weights_indexer_bf,
+                    k_indexer_bf,
+                    topk_indices_compressed,
+                    topk_probs,
+                    paddle.full([1], self.layer_number, dtype="int64"),
+                    paddle.full(
+                        [1], int(served_count or 1), dtype="int64"
+                    ),
+                ]
+            )
+        return tuple(state)
+
+    def _indexcache_state_topk(
+        self, indexcache_state: tuple | list | None
+    ) -> tuple[Tensor | None, int | None]:
+        if not indexcache_state:
+            return None, None
+        producer_layer = None
+        if len(indexcache_state) > 6:
+            producer_layer = self._indexcache_tensor_to_int(
+                indexcache_state[6]
+            )
+        if producer_layer is None:
+            producer_layer = getattr(
+                self.config, "_indexcache_last_layer_number", None
+            )
+        return indexcache_state[0], producer_layer
+
+    def _indexcache_cache_topk(
+        self,
+        compress_topk_idxs: Tensor,
+        c4_ordinal: int,
+        pattern: str,
+        tilelang_indexer_loss_state: tuple | None = None,
+        served_count: int | None = None,
+        loss_scale: float | None = None,
+    ) -> tuple[Tensor, ...]:
+        self.config._indexcache_last_topk_idxs = compress_topk_idxs.detach()
+        self.config._indexcache_last_layer_number = self.layer_number
+        if (
+            self._indexcache_multi_layer_distill_enabled()
+            and tilelang_indexer_loss_state is not None
+        ):
+            self.config._indexcache_last_distill_state = tilelang_indexer_loss_state
+            self.config._indexcache_last_served_count = served_count
+            self._indexcache_distill_debug(
+                "action=producer "
+                f"c4_ordinal={c4_ordinal} served_count={served_count} "
+                f"loss_scale={loss_scale:.8g}"
+            )
+        self._indexcache_debug(
+            "action=produce "
+            f"c4_ordinal={c4_ordinal} pattern={pattern} "
+            f"topk_shape={list(compress_topk_idxs.shape)}"
+        )
+        return self._indexcache_pack_state(
+            compress_topk_idxs,
+            tilelang_indexer_loss_state,
+            served_count,
+        )
+
+    def _indexcache_reuse_topk(
+        self,
+        b: int,
+        sq: int,
+        c4_ordinal: int,
+        pattern: str,
+        indexcache_state: tuple | list | None = None,
+    ) -> Tensor:
+        cached, producer_layer = self._indexcache_state_topk(
+            indexcache_state
+        )
+        if cached is None:
+            cached = getattr(self.config, "_indexcache_last_topk_idxs", None)
+            producer_layer = getattr(
+                self.config, "_indexcache_last_layer_number", None
+            )
+        if cached is None:
+            raise RuntimeError(
+                "index_topk_pattern requested reuse before a cached producer "
+                f"top-k exists at c4_ordinal={c4_ordinal}, pattern={pattern}."
+            )
+        cached_shape = list(cached.shape)
+        if len(cached_shape) < 3 or cached_shape[0] != b or cached_shape[1] != sq:
+            raise ValueError(
+                "Cached IndexCache top-k shape does not match the current "
+                f"layer input. cached={cached_shape}, current_batch={b}, "
+                f"current_seq={sq}."
+            )
+        if producer_layer is None:
+            producer_layer = self._indexcache_infer_producer_layer(
+                c4_ordinal, pattern
+            )
+        self._indexcache_debug(
+            "action=reuse "
+            f"c4_ordinal={c4_ordinal} pattern={pattern} "
+            f"producer_layer={producer_layer} topk_shape={cached_shape}"
+        )
+        return cached
+
+    def _indexcache_served_distill_state(
+        self,
+        query: Tensor,
+        compressed_kv: Tensor,
+        c4_ordinal: int,
+        pattern: str,
+        loss_mask: Tensor | None = None,
+        global_valid_count: float | None = None,
+        indexcache_state: tuple | list | None = None,
+    ) -> tuple | None:
+        if not (
+            self._indexcache_multi_layer_distill_enabled()
+            and self.training
+            and paddle.is_grad_enabled()
+        ):
+            return None
+
+        producer_state = None
+        producer_layer = None
+        served_count = None
+        if indexcache_state is not None:
+            if len(indexcache_state) >= 8:
+                producer_state = (
+                    indexcache_state[1],
+                    indexcache_state[2],
+                    indexcache_state[3],
+                    indexcache_state[4],
+                    indexcache_state[5],
+                    None,
+                    None,
+                    getattr(self.config, "csa_indexer_backend", "tilelang"),
+                    None,
+                    None,
+                )
+                producer_layer = self._indexcache_tensor_to_int(
+                    indexcache_state[6]
+                )
+                served_count = self._indexcache_tensor_to_int(
+                    indexcache_state[7]
+                )
+            else:
+                raise RuntimeError(
+                    "indexcache_multi_layer_distill received a producer "
+                    "top-k state without producer loss tensors. "
+                    f"c4_ordinal={c4_ordinal}, pattern={pattern}."
+                )
+
+        if producer_state is None:
+            producer_state = getattr(
+                self.config, "_indexcache_last_distill_state", None
+            )
+            producer_layer = getattr(
+                self.config, "_indexcache_last_layer_number", None
+            )
+            served_count = getattr(
+                self.config, "_indexcache_last_served_count", None
+            )
+        if producer_state is None or served_count is None:
+            raise RuntimeError(
+                "indexcache_multi_layer_distill requested an S-layer target "
+                "before a producer distill state exists. "
+                f"c4_ordinal={c4_ordinal}, pattern={pattern}."
+            )
+
+        (
+            q_indexer_bf,
+            weights_indexer_bf,
+            k_indexer_bf,
+            topk_indices_compressed,
+            topk_probs,
+            _producer_target,
+            _producer_loss_coeff,
+            backend,
+            _producer_num_rows,
+            _producer_loss_mask,
+        ) = producer_state
+        key_comp_mla = compressed_kv.detach()
+
+        if self.tp_group is not None and getattr(self.tp_group, "nranks", 1) > 1:
+            target = _compute_attn_target_on_selected_set(
+                query.detach(),
+                key_comp_mla,
+                topk_indices_compressed.detach(),
+                self.softmax_scale,
+                self.tp_group,
+            )
+        else:
+            from paddlefleet.tilelang_ops import csa_attn_target_reducesum
+
+            target = csa_attn_target_reducesum(
+                query.detach(),
+                key_comp_mla,
+                topk_indices_compressed.detach(),
+                self.softmax_scale,
+            )
+
+        loss_scale = self._indexcache_scaled_loss_coeff(int(served_count))
+        if self.cp_enabled and loss_mask is None:
+            loss_scale /= float(self.cp_size)
+        if loss_scale > 0:
+            loss = _compute_csa_selected_set_kl_loss(
+                target.detach(),
+                topk_probs.detach(),
+                loss_scale,
+                loss_mask,
+                global_valid_count,
+            )
+            DSAIndexerLossLoggingHelper.save_loss_to_tracker(
+                loss=loss,
+                layer_number=self.layer_number,
+                num_layers=DSAIndexerLossLoggingHelper.get_total_num_layers(
+                    self.config
+                ),
+            )
+        self._indexcache_distill_debug(
+            "action=served "
+            f"c4_ordinal={c4_ordinal} pattern={pattern} "
+            f"producer_layer={producer_layer} served_count={served_count} "
+            f"topk_shape={list(topk_indices_compressed.shape)} "
+            f"loss_scale={loss_scale:.8g}"
+        )
+        return (
+            q_indexer_bf,
+            weights_indexer_bf,
+            k_indexer_bf,
+            topk_indices_compressed,
+            topk_probs,
+            target,
+            loss_scale,
+            backend,
+            global_valid_count if loss_mask is not None else None,
+            loss_mask,
+        )
+
     def _compute_indexer_compressed_topk_idxs(
         self,
         query: Tensor,
@@ -1589,6 +1980,7 @@ class CompressedSparseAttention(FleetLayer):
         startend_row_indices: Tensor | None = None,
         loss_mask: Tensor | None = None,
         global_valid_count: float | None = None,
+        indexer_loss_coeff_override: float | None = None,
     ) -> tuple[Tensor, Tensor | None, tuple | None]:
         """Build indexer-selected compressed KV indices and loss state."""
         b, sq, np_heads, _ = query.shape
@@ -1642,8 +2034,10 @@ class CompressedSparseAttention(FleetLayer):
             # Training grad-enabled forward with TileLang/cuDNN backend.
             # The same backend's top-k-only kernel is used during recompute's
             # first no-grad forward below.
-            indexer_loss_coeff = getattr(
-                self.config, "dsa_indexer_loss_coeff", 0.0
+            indexer_loss_coeff = (
+                indexer_loss_coeff_override
+                if indexer_loss_coeff_override is not None
+                else getattr(self.config, "dsa_indexer_loss_coeff", 0.0)
             )
             q_indexer_bf, k_indexer_bf, weights_indexer_bf = (
                 self.indexer.forward_before_topk(
@@ -1760,8 +2154,10 @@ class CompressedSparseAttention(FleetLayer):
                         x_det, qr_det, startend_row_indices
                     )
                 )
-                indexer_loss_coeff = getattr(
-                    self.config, "dsa_indexer_loss_coeff", 0.0
+                indexer_loss_coeff = (
+                    indexer_loss_coeff_override
+                    if indexer_loss_coeff_override is not None
+                    else getattr(self.config, "dsa_indexer_loss_coeff", 0.0)
                 )
                 key_for_loss = compressed_kv.unsqueeze(2).expand(
                     [-1, -1, np_heads, -1]
@@ -1829,6 +2225,7 @@ class CompressedSparseAttention(FleetLayer):
         x: Tensor = None,
         qr: Tensor = None,
         input_ids: Tensor | None = None,
+        indexcache_state: tuple | list | None = None,
     ) -> Tensor:
         """Forward pass for CompressedSparseAttention.
 
@@ -1844,6 +2241,7 @@ class CompressedSparseAttention(FleetLayer):
             output: [b, sq, np * v_head_dim]
         """
         b, sq, np_heads, hn = query.shape
+        indexcache_state_next = indexcache_state
 
         if startend_row_indices is not None:
             assert b == 1, (
@@ -1889,7 +2287,7 @@ class CompressedSparseAttention(FleetLayer):
             global_valid_count = None
 
         if self.cp_enabled:
-            return self._forward_cp(
+            cp_result = self._forward_cp(
                 query,
                 key,
                 x,
@@ -1897,7 +2295,15 @@ class CompressedSparseAttention(FleetLayer):
                 startend_row_indices,
                 loss_mask=loss_mask,
                 global_valid_count=global_valid_count,
+                indexcache_state=indexcache_state,
             )
+            if isinstance(cp_result, tuple):
+                output, indexcache_state_next = cp_result
+            else:
+                output = cp_result
+            if indexcache_state_next is not None:
+                return output, indexcache_state_next
+            return output
 
         if startend_row_indices is not None and self.compress_ratio > 1:
             doc_lens = get_doc_lens(startend_row_indices)
@@ -1941,6 +2347,7 @@ class CompressedSparseAttention(FleetLayer):
         # Step 4: Compressed indices
         indexer_loss = None
         tilelang_indexer_loss_state = None
+        indexcache_served_loss_state = None
 
         if (
             self.compress_ratio > 1
@@ -1948,21 +2355,70 @@ class CompressedSparseAttention(FleetLayer):
             and actual_n_compressed > 0
         ):
             if self.indexer is not None:
-                (
-                    compress_topk_idxs,
-                    indexer_loss,
-                    tilelang_indexer_loss_state,
-                ) = self._compute_indexer_compressed_topk_idxs(
-                    query,
-                    x,
-                    qr,
-                    compressed_kv,
-                    n_compressed,
-                    offset,
-                    startend_row_indices,
-                    loss_mask=loss_mask,
-                    global_valid_count=global_valid_count,
-                )
+                indexcache_action = self._indexcache_next_c4_action()
+                if (
+                    indexcache_action is not None
+                    and indexcache_action[1] == "S"
+                ):
+                    c4_ordinal, _action, pattern = indexcache_action
+                    compress_topk_idxs = self._indexcache_reuse_topk(
+                        b,
+                        sq,
+                        c4_ordinal,
+                        pattern,
+                        indexcache_state=indexcache_state,
+                    )
+                    indexcache_served_loss_state = (
+                        self._indexcache_served_distill_state(
+                            query,
+                            compressed_kv,
+                            c4_ordinal,
+                            pattern,
+                            loss_mask=loss_mask,
+                            global_valid_count=global_valid_count,
+                            indexcache_state=indexcache_state,
+                        )
+                    )
+                else:
+                    served_count = None
+                    loss_coeff_override = None
+                    if (
+                        indexcache_action is not None
+                        and self._indexcache_multi_layer_distill_enabled()
+                    ):
+                        c4_ordinal, _action, pattern = indexcache_action
+                        served_count = self._indexcache_served_count(
+                            pattern, c4_ordinal
+                        )
+                        loss_coeff_override = self._indexcache_scaled_loss_coeff(
+                            served_count
+                        )
+                    (
+                        compress_topk_idxs,
+                        indexer_loss,
+                        tilelang_indexer_loss_state,
+                    ) = self._compute_indexer_compressed_topk_idxs(
+                        query,
+                        x,
+                        qr,
+                        compressed_kv,
+                        n_compressed,
+                        offset,
+                        startend_row_indices,
+                        loss_mask=loss_mask,
+                        global_valid_count=global_valid_count,
+                        indexer_loss_coeff_override=loss_coeff_override,
+                    )
+                    if indexcache_action is not None:
+                        c4_ordinal, _action, pattern = indexcache_action
+                        indexcache_state_next = self._indexcache_cache_topk(
+                            compress_topk_idxs,
+                            c4_ordinal,
+                            pattern,
+                            tilelang_indexer_loss_state,
+                            served_count,
+                            loss_coeff_override,
+                        )
             else:
                 # ratio=128: attend to all compressed positions
                 compress_topk_idxs = get_compress_topk_idxs(
@@ -2000,7 +2456,14 @@ class CompressedSparseAttention(FleetLayer):
             )
         elif indexer_loss is not None and self.training:
             output = DSAIndexerLossAutoScaler.apply(output, indexer_loss)
+        if indexcache_served_loss_state is not None:
+            output = TileLangCSAIndexerLossAutoScaler.apply(
+                output,
+                *indexcache_served_loss_state,
+            )
 
+        if indexcache_state_next is not None:
+            return output, indexcache_state_next
         return output
 
     def _forward_cp(
@@ -2012,6 +2475,7 @@ class CompressedSparseAttention(FleetLayer):
         startend_row_indices: Tensor | None = None,
         loss_mask: Tensor | None = None,
         global_valid_count: float | None = None,
+        indexcache_state: tuple | list | None = None,
     ) -> Tensor:
         """CP-aware forward: local compress + all-gather, sparse attention.
 
@@ -2028,6 +2492,7 @@ class CompressedSparseAttention(FleetLayer):
             reduce_scatter(SUM) + optimizer x cp_size aggregates them correctly
         """
         b, sq, np_heads, hn = query.shape
+        indexcache_state_next = indexcache_state
         sq_global = sq * self.cp_size
         position_offset = self.cp_rank * sq
         q_positions = paddle.arange(
@@ -2096,6 +2561,7 @@ class CompressedSparseAttention(FleetLayer):
         # Step 3: Compressed topk + optional fused indexer loss
         indexer_loss = None
         tilelang_indexer_loss_state = None
+        indexcache_served_loss_state = None
 
         if (
             self.compress_ratio > 1
@@ -2103,233 +2569,301 @@ class CompressedSparseAttention(FleetLayer):
             and actual_n_compressed > 0
         ):
             if self.indexer is not None:
-                x_det = x.detach()
-                qr_det = qr.detach()
-                if self.training:
-                    x_det.stop_gradient = False
-                    qr_det.stop_gradient = False
-
-                indexer_backend = getattr(
-                    self.config, "csa_indexer_backend", "tilelang"
-                )
-                use_tilelang_indexer = indexer_backend == "tilelang"
-                use_tilelang_loss_path = (
-                    use_tilelang_indexer
-                    and self.training
-                    and paddle.is_grad_enabled()
-                )
-                loss_topk_effective = _resolve_csa_indexer_loss_topk_effective(
-                    self.config, self.indexer.index_topk, n_compressed_global
-                )
-                attn_topk_effective = _resolve_csa_indexer_attn_topk_effective(
-                    self.indexer.index_topk, n_compressed_global
-                )
-
-                # valid_range for varlen: [b, sq_local, 2] or None
-                if startend_row_indices is not None:
-                    valid_range_full = get_valid_range(
-                        int(self.compress_ratio),
-                        b,
-                        sq_global,
-                        startend_row_indices,
-                    )
-                    valid_range = valid_range_full[
-                        :, position_offset : position_offset + sq, :
-                    ]
-                else:
-                    valid_range = None
-
-                q_indexer_bf, k_indexer_global, weights_indexer_bf = (
-                    self.indexer.forward_before_topk(
-                        x_det,
-                        qr_det,
-                        startend_row_indices=startend_row_indices,
-                        position_offset=position_offset,
-                        cp_group=self.cp_group,
-                    )
-                )
-
-                indexer_loss_coeff = getattr(
-                    self.config, "dsa_indexer_loss_coeff", 0.0
-                )
-
-                if use_tilelang_loss_path:  # CP training grad-enabled forward with TileLang indexer backend.
-                    # Fused TileLang: single PyLayer produces topk + loss.
-                    # key_comp_mla is 3D [b, n_comp_global, hn] (shared across heads).
-                    key_comp_mla = compressed_kv_global.detach()
-                    (
-                        indexer_loss,
-                        topk_indices_compressed,
-                        topk_probs,
-                        target,
-                    ) = _compute_fused_csa_indexer_loss_forward(
-                        q_indexer_bf,
-                        weights_indexer_bf,
-                        k_indexer_global,
-                        query.detach(),
-                        key_comp_mla,
-                        valid_range,
-                        int(self.compress_ratio),
-                        int(loss_topk_effective),
-                        float(self.softmax_scale),
-                        float(indexer_loss_coeff),
-                        self.tp_group,
-                        seq_offset=position_offset,
-                        loss_mask=loss_mask,
-                        global_valid_count=global_valid_count,
-                    )
-                    tilelang_indexer_loss_state = (
-                        q_indexer_bf,
-                        weights_indexer_bf,
-                        k_indexer_global,
-                        topk_indices_compressed,
-                        topk_probs,
-                        target,
-                        float(indexer_loss_coeff)
-                        if loss_mask is not None
-                        else float(indexer_loss_coeff) / self.cp_size,
-                        getattr(self.config, "csa_indexer_backend", "tilelang"),
-                        global_valid_count if loss_mask is not None else None,
-                        loss_mask,
-                    )
-                    if (
-                        indexer_loss_coeff > 0
-                    ):  # CP TileLang training path logs only when indexer loss is enabled.
-                        DSAIndexerLossLoggingHelper.save_loss_to_tracker(
-                            loss=indexer_loss,
-                            layer_number=self.layer_number,
-                            num_layers=self.config.num_hidden_layers,
-                        )
-                    # Scale: each rank's loss is mean over sq_local;
-                    # global loss is mean over sq_global = sq_local * cp_size.
-                    if loss_mask is None:
-                        indexer_loss = indexer_loss / self.cp_size
-
-                elif (
-                    self.training and not use_tilelang_indexer
-                ):  # CP training forward with unfused indexer backend.
-                    # Paddle reference loss path
-                    key_for_loss = (
-                        compressed_kv_global.detach()
-                        .unsqueeze(2)
-                        .expand([-1, -1, np_heads, -1])
-                    )
-
-                    if startend_row_indices is None:
-                        causal_mask = build_causal_mask_cp(
-                            q_positions,
-                            n_compressed_global,
-                            self.compress_ratio,
-                            b,
-                        )
-                    else:
-                        causal_mask_full = _build_compressed_causal_mask(
-                            self.compress_ratio,
-                            b,
-                            sq_global,
-                            n_compressed_global,
-                            startend_row_indices,
-                        )
-                        causal_mask = causal_mask_full[
-                            :, position_offset : position_offset + sq, ...
-                        ]
-
-                    weights_for_loss = (
-                        weights_indexer_bf * self.indexer.softmax_scale
-                    )
-                    mask_for_loss = causal_mask.unsqueeze(1)
-
-                    indexer_loss = FusedDSAIndexerLoss.apply(
-                        q_indexer_bf,
-                        weights_for_loss,
-                        k_indexer_global,
-                        query.detach(),
-                        key_for_loss.detach(),
-                        self.softmax_scale,
-                        min(self.indexer.index_topk, n_compressed_global),
-                        indexer_loss_coeff,
-                        mask_for_loss,
-                        getattr(
-                            self.config, "dsa_indexer_use_sparse_loss", True
-                        ),
-                        self.tp_group,
-                        loss_mask,
-                        global_valid_count,
-                    )
-                    topk_indices_compressed = (
-                        FusedDSAIndexerLoss._last_topk_indices
-                    )
-                    if (
-                        indexer_loss_coeff > 0
-                    ):  # CP unfused training path logs only when indexer loss is enabled.
-                        DSAIndexerLossLoggingHelper.save_loss_to_tracker(
-                            loss=indexer_loss,
-                            layer_number=self.layer_number,
-                            num_layers=self.config.num_hidden_layers,
-                        )
-                    if loss_mask is None:
-                        indexer_loss = indexer_loss / self.cp_size
-
-                elif not use_tilelang_indexer:  # CP eval/no-grad forward with unfused backend; only materialize attention top-k.
-                    # Inference-only Paddle topk (use already-gathered global K)
-                    if startend_row_indices is None:
-                        causal_mask = build_causal_mask_cp(
-                            q_positions,
-                            n_compressed_global,
-                            self.compress_ratio,
-                            b,
-                        )
-                    else:
-                        causal_mask_full = _build_compressed_causal_mask(
-                            self.compress_ratio,
-                            b,
-                            sq_global,
-                            n_compressed_global,
-                            startend_row_indices,
-                        )
-                        causal_mask = causal_mask_full[
-                            :, position_offset : position_offset + sq, ...
-                        ]
-
-                    _, topk_indices_compressed = fused_qk_topk_naive(
-                        q_indexer_bf,
-                        k_indexer_global,
-                        weights_indexer_bf,
-                        attn_topk_effective,
-                        causal_mask,
-                    )
-
-                # TileLang fwd-only topk (no loss, or loss already produced above)
+                indexcache_action = self._indexcache_next_c4_action()
                 if (
-                    use_tilelang_indexer and not use_tilelang_loss_path
-                ):  # CP eval/no-grad or recompute first forward with TileLang backend.
-                    from paddlefleet.tilelang_ops import csa_indexer_topk_fwd
+                    indexcache_action is not None
+                    and indexcache_action[1] == "S"
+                ):
+                    c4_ordinal, _action, pattern = indexcache_action
+                    compress_topk_idxs = self._indexcache_reuse_topk(
+                        b,
+                        sq,
+                        c4_ordinal,
+                        pattern,
+                        indexcache_state=indexcache_state,
+                    )
+                    indexcache_served_loss_state = (
+                        self._indexcache_served_distill_state(
+                            query,
+                            compressed_kv_global,
+                            c4_ordinal,
+                            pattern,
+                            loss_mask=loss_mask,
+                            global_valid_count=global_valid_count,
+                            indexcache_state=indexcache_state,
+                        )
+                    )
+                else:
+                    x_det = x.detach()
+                    qr_det = qr.detach()
+                    if self.training:
+                        x_det.stop_gradient = False
+                        qr_det.stop_gradient = False
 
-                    with paddle.no_grad():
-                        tl_topk_indices, _ = csa_indexer_topk_fwd(
+                    indexer_backend = getattr(
+                        self.config, "csa_indexer_backend", "tilelang"
+                    )
+                    use_tilelang_indexer = indexer_backend == "tilelang"
+                    use_tilelang_loss_path = (
+                        use_tilelang_indexer
+                        and self.training
+                        and paddle.is_grad_enabled()
+                    )
+                    loss_topk_effective = (
+                        _resolve_csa_indexer_loss_topk_effective(
+                            self.config,
+                            self.indexer.index_topk,
+                            n_compressed_global,
+                        )
+                    )
+                    attn_topk_effective = (
+                        _resolve_csa_indexer_attn_topk_effective(
+                            self.indexer.index_topk, n_compressed_global
+                        )
+                    )
+
+                    # valid_range for varlen: [b, sq_local, 2] or None
+                    if startend_row_indices is not None:
+                        valid_range_full = get_valid_range(
+                            int(self.compress_ratio),
+                            b,
+                            sq_global,
+                            startend_row_indices,
+                        )
+                        valid_range = valid_range_full[
+                            :, position_offset : position_offset + sq, :
+                        ]
+                    else:
+                        valid_range = None
+
+                    q_indexer_bf, k_indexer_global, weights_indexer_bf = (
+                        self.indexer.forward_before_topk(
+                            x_det,
+                            qr_det,
+                            startend_row_indices=startend_row_indices,
+                            position_offset=position_offset,
+                            cp_group=self.cp_group,
+                        )
+                    )
+
+                    served_count = None
+                    loss_coeff_override = None
+                    if (
+                        indexcache_action is not None
+                        and self._indexcache_multi_layer_distill_enabled()
+                    ):
+                        c4_ordinal, _action, pattern = indexcache_action
+                        served_count = self._indexcache_served_count(
+                            pattern, c4_ordinal
+                        )
+                        loss_coeff_override = (
+                            self._indexcache_scaled_loss_coeff(served_count)
+                        )
+                    indexer_loss_coeff = (
+                        loss_coeff_override
+                        if loss_coeff_override is not None
+                        else getattr(self.config, "dsa_indexer_loss_coeff", 0.0)
+                    )
+
+                    if use_tilelang_loss_path:  # CP training grad-enabled forward with TileLang indexer backend.
+                        # Fused TileLang: single PyLayer produces topk + loss.
+                        # key_comp_mla is 3D [b, n_comp_global, hn] (shared across heads).
+                        key_comp_mla = compressed_kv_global.detach()
+                        (
+                            indexer_loss,
+                            topk_indices_compressed,
+                            topk_probs,
+                            target,
+                        ) = _compute_fused_csa_indexer_loss_forward(
+                            q_indexer_bf,
+                            weights_indexer_bf,
+                            k_indexer_global,
+                            query.detach(),
+                            key_comp_mla,
+                            valid_range,
+                            int(self.compress_ratio),
+                            int(loss_topk_effective),
+                            float(self.softmax_scale),
+                            float(indexer_loss_coeff),
+                            self.tp_group,
+                            seq_offset=position_offset,
+                            loss_mask=loss_mask,
+                            global_valid_count=global_valid_count,
+                        )
+                        tilelang_indexer_loss_state = (
+                            q_indexer_bf,
+                            weights_indexer_bf,
+                            k_indexer_global,
+                            topk_indices_compressed,
+                            topk_probs,
+                            target,
+                            float(indexer_loss_coeff)
+                            if loss_mask is not None
+                            else float(indexer_loss_coeff) / self.cp_size,
+                            getattr(
+                                self.config, "csa_indexer_backend", "tilelang"
+                            ),
+                            global_valid_count
+                            if loss_mask is not None
+                            else None,
+                            loss_mask,
+                        )
+                        if (
+                            indexer_loss_coeff > 0
+                        ):  # CP TileLang training path logs only when indexer loss is enabled.
+                            DSAIndexerLossLoggingHelper.save_loss_to_tracker(
+                                loss=indexer_loss,
+                                layer_number=self.layer_number,
+                                num_layers=self.config.num_hidden_layers,
+                            )
+                        # Scale: each rank's loss is mean over sq_local;
+                        # global loss is mean over sq_global = sq_local * cp_size.
+                        if loss_mask is None:
+                            indexer_loss = indexer_loss / self.cp_size
+
+                    elif (
+                        self.training and not use_tilelang_indexer
+                    ):  # CP training forward with unfused indexer backend.
+                        # Paddle reference loss path
+                        key_for_loss = (
+                            compressed_kv_global.detach()
+                            .unsqueeze(2)
+                            .expand([-1, -1, np_heads, -1])
+                        )
+
+                        if startend_row_indices is None:
+                            causal_mask = build_causal_mask_cp(
+                                q_positions,
+                                n_compressed_global,
+                                self.compress_ratio,
+                                b,
+                            )
+                        else:
+                            causal_mask_full = _build_compressed_causal_mask(
+                                self.compress_ratio,
+                                b,
+                                sq_global,
+                                n_compressed_global,
+                                startend_row_indices,
+                            )
+                            causal_mask = causal_mask_full[
+                                :, position_offset : position_offset + sq, ...
+                            ]
+
+                        weights_for_loss = (
+                            weights_indexer_bf * self.indexer.softmax_scale
+                        )
+                        mask_for_loss = causal_mask.unsqueeze(1)
+
+                        indexer_loss = FusedDSAIndexerLoss.apply(
+                            q_indexer_bf,
+                            weights_for_loss,
+                            k_indexer_global,
+                            query.detach(),
+                            key_for_loss.detach(),
+                            self.softmax_scale,
+                            min(self.indexer.index_topk, n_compressed_global),
+                            indexer_loss_coeff,
+                            mask_for_loss,
+                            getattr(
+                                self.config,
+                                "dsa_indexer_use_sparse_loss",
+                                True,
+                            ),
+                            self.tp_group,
+                            loss_mask,
+                            global_valid_count,
+                        )
+                        topk_indices_compressed = (
+                            FusedDSAIndexerLoss._last_topk_indices
+                        )
+                        if (
+                            indexer_loss_coeff > 0
+                        ):  # CP unfused training path logs only when indexer loss is enabled.
+                            DSAIndexerLossLoggingHelper.save_loss_to_tracker(
+                                loss=indexer_loss,
+                                layer_number=self.layer_number,
+                                num_layers=self.config.num_hidden_layers,
+                            )
+                        if loss_mask is None:
+                            indexer_loss = indexer_loss / self.cp_size
+
+                    elif not use_tilelang_indexer:  # CP eval/no-grad forward with unfused backend; only materialize attention top-k.
+                        # Inference-only Paddle topk (use already-gathered global K)
+                        if startend_row_indices is None:
+                            causal_mask = build_causal_mask_cp(
+                                q_positions,
+                                n_compressed_global,
+                                self.compress_ratio,
+                                b,
+                            )
+                        else:
+                            causal_mask_full = _build_compressed_causal_mask(
+                                self.compress_ratio,
+                                b,
+                                sq_global,
+                                n_compressed_global,
+                                startend_row_indices,
+                            )
+                            causal_mask = causal_mask_full[
+                                :, position_offset : position_offset + sq, ...
+                            ]
+
+                        _, topk_indices_compressed = fused_qk_topk_naive(
                             q_indexer_bf,
                             k_indexer_global,
                             weights_indexer_bf,
-                            ratio=self.compress_ratio,
-                            topk_effective=attn_topk_effective,
-                            seq_offset=position_offset,
-                            valid_range=valid_range,
+                            attn_topk_effective,
+                            causal_mask,
                         )
-                    topk_indices_compressed = tl_topk_indices
 
-                if (
-                    topk_indices_compressed.shape[-1] > attn_topk_effective
-                ):  # CP loss path may return wider top-k than attention consumes.
-                    topk_indices_compressed = topk_indices_compressed[
-                        ..., :attn_topk_effective
-                    ].contiguous()
+                    # TileLang fwd-only topk (no loss, or loss already produced above)
+                    if (
+                        use_tilelang_indexer and not use_tilelang_loss_path
+                    ):  # CP eval/no-grad or recompute first forward with TileLang backend.
+                        from paddlefleet.tilelang_ops import csa_indexer_topk_fwd
 
-                compress_topk_idxs = map_compressed_topk_to_kv_full_cp(
-                    topk_indices_compressed,
-                    q_positions,
-                    self.compress_ratio,
-                    offset,
-                )
+                        with paddle.no_grad():
+                            tl_topk_indices, _ = csa_indexer_topk_fwd(
+                                q_indexer_bf,
+                                k_indexer_global,
+                                weights_indexer_bf,
+                                ratio=self.compress_ratio,
+                                topk_effective=attn_topk_effective,
+                                seq_offset=position_offset,
+                                valid_range=valid_range,
+                            )
+                        topk_indices_compressed = tl_topk_indices
+
+                    if (
+                        topk_indices_compressed.shape[-1]
+                        > attn_topk_effective
+                    ):  # CP loss path may return wider top-k than attention consumes.
+                        topk_indices_compressed = topk_indices_compressed[
+                            ..., :attn_topk_effective
+                        ].contiguous()
+
+                    compress_topk_idxs = map_compressed_topk_to_kv_full_cp(
+                        topk_indices_compressed,
+                        q_positions,
+                        self.compress_ratio,
+                        offset,
+                    )
+                    if indexcache_action is not None:
+                        c4_ordinal, _action, pattern = indexcache_action
+                        effective_loss_scale = (
+                            tilelang_indexer_loss_state[6]
+                            if tilelang_indexer_loss_state is not None
+                            else loss_coeff_override
+                        )
+                        indexcache_state_next = self._indexcache_cache_topk(
+                            compress_topk_idxs,
+                            c4_ordinal,
+                            pattern,
+                            tilelang_indexer_loss_state,
+                            served_count,
+                            effective_loss_scale,
+                        )
             else:
                 # HCA path: attend to all compressed positions
                 if startend_row_indices is None:
@@ -2374,7 +2908,13 @@ class CompressedSparseAttention(FleetLayer):
             )
         elif indexer_loss is not None and self.training:
             output = DSAIndexerLossAutoScaler.apply(output, indexer_loss)
+        if indexcache_served_loss_state is not None:
+            output = TileLangCSAIndexerLossAutoScaler.apply(
+                output, *indexcache_served_loss_state
+            )
 
+        if indexcache_state_next is not None:
+            return output, indexcache_state_next
         return output
 
     def compressed_sparse_attn(

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -72,6 +72,17 @@ from paddlefleet.transformer.cp_utils import (
     map_compressed_topk_to_kv_full_cp,
 )
 
+_INDEXCACHE_STATE_KIND_NONE = "none"
+_INDEXCACHE_STATE_KIND_TOPK_ONLY = "topk_only"
+_INDEXCACHE_STATE_KIND_DISTILL = "distill"
+_INDEXCACHE_STATE_KIND_INVALID = "invalid"
+_INDEXCACHE_TOPK_ONLY_STATE_LEN = 3
+_INDEXCACHE_DISTILL_STATE_LEN = 8
+_INDEXCACHE_STATE_TOPK_IDXS = 0
+_INDEXCACHE_STATE_PRODUCER_LAYER = 1
+_INDEXCACHE_DISTILL_STATE_PRODUCER_LAYER = 6
+_INDEXCACHE_DISTILL_STATE_SERVED_COUNT = 7
+
 
 class LinearBF16FP32Func(paddle.autograd.PyLayer):
     """BF16 activation x BF16 weight -> FP32 output autograd function.
@@ -1626,6 +1637,77 @@ class CompressedSparseAttention(FleetLayer):
             raise ValueError("index_topk_pattern must start with 'F'.")
         return pattern
 
+    def _indexcache_recompute_enabled(self) -> bool:
+        return bool(getattr(self.config, "recompute_granularity", None))
+
+    def _indexcache_in_recompute(self) -> bool:
+        return (
+            self._indexcache_recompute_enabled()
+            and self.training
+            and not paddle.is_grad_enabled()
+        )
+
+    def _indexcache_context_msg(
+        self, c4_ordinal: int, pattern: str
+    ) -> str:
+        return (
+            f"layer_number={self.layer_number}, "
+            f"c4_ordinal={c4_ordinal}, "
+            f"pattern={pattern}, "
+            "recompute_granularity="
+            f"{getattr(self.config, 'recompute_granularity', None)}, "
+            "pipeline_model_parallel_size="
+            f"{getattr(self.config, 'pipeline_model_parallel_size', 1)}, "
+            "context_parallel_size="
+            f"{getattr(self.config, 'context_parallel_size', 1)}"
+        )
+
+    def _indexcache_requires_explicit_state(self) -> bool:
+        pp_size = int(
+            getattr(self.config, "pipeline_model_parallel_size", 1) or 1
+        )
+        cp_size = int(getattr(self.config, "context_parallel_size", 1) or 1)
+        return self._indexcache_recompute_enabled() or pp_size > 1 or cp_size > 1
+
+    @staticmethod
+    def _indexcache_state_kind(indexcache_state: tuple | list | None) -> str:
+        if not indexcache_state:
+            return _INDEXCACHE_STATE_KIND_NONE
+        state_len = len(indexcache_state)
+        if state_len == _INDEXCACHE_TOPK_ONLY_STATE_LEN:
+            return _INDEXCACHE_STATE_KIND_TOPK_ONLY
+        if state_len >= _INDEXCACHE_DISTILL_STATE_LEN:
+            return _INDEXCACHE_STATE_KIND_DISTILL
+        return _INDEXCACHE_STATE_KIND_INVALID
+
+    def _indexcache_validate_state_for_reuse(
+        self,
+        indexcache_state: tuple | list | None,
+        c4_ordinal: int,
+        pattern: str,
+    ) -> str:
+        state_kind = self._indexcache_state_kind(indexcache_state)
+        if state_kind == _INDEXCACHE_STATE_KIND_INVALID:
+            raise ValueError(
+                "IndexCache state must be either topk-only "
+                f"({_INDEXCACHE_TOPK_ONLY_STATE_LEN} tensors) or distill "
+                f"(>={_INDEXCACHE_DISTILL_STATE_LEN} tensors), got "
+                f"len={len(indexcache_state)}. "
+                + self._indexcache_context_msg(c4_ordinal, pattern)
+            )
+        if (
+            self._indexcache_recompute_enabled()
+            and state_kind == _INDEXCACHE_STATE_KIND_DISTILL
+        ):
+            raise RuntimeError(
+                "IndexCache recompute reuse-only expects a topk-only "
+                "indexcache_state; distill-state tensors are not supported "
+                "with recompute in phase 1. "
+                f"state_kind={state_kind}. "
+                + self._indexcache_context_msg(c4_ordinal, pattern)
+            )
+        return state_kind
+
     def _indexcache_debug(self, msg: str) -> None:
         if os.environ.get("INDEXCACHE_TRAIN_DEBUG", "0") == "1":
             cp_msg = (
@@ -1633,8 +1715,17 @@ class CompressedSparseAttention(FleetLayer):
                 if self.cp_enabled
                 else ""
             )
+            recompute_msg = (
+                " recompute_enabled="
+                f"{self._indexcache_recompute_enabled()}"
+                " in_recompute="
+                f"{self._indexcache_in_recompute()}"
+                " grad_enabled="
+                f"{paddle.is_grad_enabled()}"
+            )
             print(
-                f"[INDEXCACHE_TRAIN] layer={self.layer_number}{cp_msg} {msg}",
+                f"[INDEXCACHE_TRAIN] layer={self.layer_number}{cp_msg}"
+                f"{recompute_msg} {msg}",
                 flush=True,
             )
 
@@ -1753,7 +1844,11 @@ class CompressedSparseAttention(FleetLayer):
         served_count: int | None = None,
     ) -> tuple[Tensor, ...]:
         state = [self._indexcache_forward_state_tensor(compress_topk_idxs)]
-        if tilelang_indexer_loss_state is not None:
+        include_distill_state = (
+            self._indexcache_multi_layer_distill_enabled()
+            and tilelang_indexer_loss_state is not None
+        )
+        if include_distill_state:
             (
                 q_indexer_bf,
                 weights_indexer_bf,
@@ -1793,24 +1888,34 @@ class CompressedSparseAttention(FleetLayer):
         return tuple(state)
 
     def _indexcache_state_topk(
-        self, indexcache_state: tuple | list | None
-    ) -> tuple[Tensor | None, int | None]:
+        self,
+        indexcache_state: tuple | list | None,
+        c4_ordinal: int,
+        pattern: str,
+    ) -> tuple[Tensor | None, int | None, str]:
+        state_kind = self._indexcache_validate_state_for_reuse(
+            indexcache_state, c4_ordinal, pattern
+        )
         if not indexcache_state:
-            return None, None
+            return None, None, state_kind
         producer_layer = None
-        if len(indexcache_state) >= 8:
+        if state_kind == _INDEXCACHE_STATE_KIND_DISTILL:
             producer_layer = self._indexcache_tensor_to_int(
-                indexcache_state[6]
+                indexcache_state[_INDEXCACHE_DISTILL_STATE_PRODUCER_LAYER]
             )
-        elif len(indexcache_state) >= 3:
+        elif state_kind == _INDEXCACHE_STATE_KIND_TOPK_ONLY:
             producer_layer = self._indexcache_tensor_to_int(
-                indexcache_state[1]
+                indexcache_state[_INDEXCACHE_STATE_PRODUCER_LAYER]
             )
         if producer_layer is None:
             producer_layer = getattr(
                 self.config, "_indexcache_last_layer_number", None
             )
-        return indexcache_state[0], producer_layer
+        return (
+            indexcache_state[_INDEXCACHE_STATE_TOPK_IDXS],
+            producer_layer,
+            state_kind,
+        )
 
     def _indexcache_cache_topk(
         self,
@@ -1827,6 +1932,7 @@ class CompressedSparseAttention(FleetLayer):
             self._indexcache_multi_layer_distill_enabled()
             and tilelang_indexer_loss_state is not None
         ):
+            state_kind = _INDEXCACHE_STATE_KIND_DISTILL
             self.config._indexcache_last_distill_state = tilelang_indexer_loss_state
             self.config._indexcache_last_served_count = served_count
             self._indexcache_distill_debug(
@@ -1834,9 +1940,12 @@ class CompressedSparseAttention(FleetLayer):
                 f"c4_ordinal={c4_ordinal} served_count={served_count} "
                 f"loss_scale={loss_scale:.8g}"
             )
+        else:
+            state_kind = _INDEXCACHE_STATE_KIND_TOPK_ONLY
         self._indexcache_debug(
             "action=produce "
             f"c4_ordinal={c4_ordinal} pattern={pattern} "
+            f"state_kind={state_kind} "
             f"topk_shape={list(compress_topk_idxs.shape)}"
         )
         return self._indexcache_pack_state(
@@ -1853,18 +1962,22 @@ class CompressedSparseAttention(FleetLayer):
         pattern: str,
         indexcache_state: tuple | list | None = None,
     ) -> Tensor:
-        cached, producer_layer = self._indexcache_state_topk(
-            indexcache_state
+        cached, producer_layer, state_kind = self._indexcache_state_topk(
+            indexcache_state, c4_ordinal, pattern
         )
-        if cached is None:
+        if cached is None and not self._indexcache_requires_explicit_state():
             cached = getattr(self.config, "_indexcache_last_topk_idxs", None)
             producer_layer = getattr(
                 self.config, "_indexcache_last_layer_number", None
             )
+            if cached is not None:
+                state_kind = "config_fallback"
         if cached is None:
             raise RuntimeError(
-                "index_topk_pattern requested reuse before a cached producer "
-                f"top-k exists at c4_ordinal={c4_ordinal}, pattern={pattern}."
+                "index_topk_pattern requested reuse before an explicit "
+                "producer top-k state exists. "
+                f"state_kind={state_kind}. "
+                + self._indexcache_context_msg(c4_ordinal, pattern)
             )
         cached_shape = list(cached.shape)
         if len(cached_shape) < 3 or cached_shape[0] != b or cached_shape[1] != sq:
@@ -1880,7 +1993,8 @@ class CompressedSparseAttention(FleetLayer):
         self._indexcache_debug(
             "action=reuse "
             f"c4_ordinal={c4_ordinal} pattern={pattern} "
-            f"producer_layer={producer_layer} topk_shape={cached_shape}"
+            f"producer_layer={producer_layer} state_kind={state_kind} "
+            f"topk_shape={cached_shape}"
         )
         return cached
 
@@ -1905,7 +2019,8 @@ class CompressedSparseAttention(FleetLayer):
         producer_layer = None
         served_count = None
         if indexcache_state is not None:
-            if len(indexcache_state) >= 8:
+            state_kind = self._indexcache_state_kind(indexcache_state)
+            if state_kind == _INDEXCACHE_STATE_KIND_DISTILL:
                 producer_state = (
                     indexcache_state[1],
                     indexcache_state[2],
@@ -1919,10 +2034,10 @@ class CompressedSparseAttention(FleetLayer):
                     None,
                 )
                 producer_layer = self._indexcache_tensor_to_int(
-                    indexcache_state[6]
+                    indexcache_state[_INDEXCACHE_DISTILL_STATE_PRODUCER_LAYER]
                 )
                 served_count = self._indexcache_tensor_to_int(
-                    indexcache_state[7]
+                    indexcache_state[_INDEXCACHE_DISTILL_STATE_SERVED_COUNT]
                 )
             else:
                 raise RuntimeError(
@@ -1931,7 +2046,7 @@ class CompressedSparseAttention(FleetLayer):
                     f"c4_ordinal={c4_ordinal}, pattern={pattern}."
                 )
 
-        if producer_state is None:
+        if producer_state is None and not self._indexcache_requires_explicit_state():
             producer_state = getattr(
                 self.config, "_indexcache_last_distill_state", None
             )
@@ -1944,8 +2059,8 @@ class CompressedSparseAttention(FleetLayer):
         if producer_state is None or served_count is None:
             raise RuntimeError(
                 "indexcache_multi_layer_distill requested an S-layer target "
-                "before a producer distill state exists. "
-                f"c4_ordinal={c4_ordinal}, pattern={pattern}."
+                "before an explicit producer distill state exists. "
+                + self._indexcache_context_msg(c4_ordinal, pattern)
             )
 
         (

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -51,6 +51,24 @@ from paddlefleet.transformer.dsa_attention import (
     fused_qk_topk_naive,
     rotate_activation,
 )
+from paddlefleet.transformer.indexcache_state import (
+    INDEXCACHE_DISTILL_STATE_K,
+    INDEXCACHE_DISTILL_STATE_PRODUCER_LAYER,
+    INDEXCACHE_DISTILL_STATE_Q,
+    INDEXCACHE_DISTILL_STATE_SERVED_COUNT,
+    INDEXCACHE_DISTILL_STATE_TOPK_INDICES,
+    INDEXCACHE_DISTILL_STATE_TOPK_PROBS,
+    INDEXCACHE_DISTILL_STATE_WEIGHTS,
+    INDEXCACHE_STATE_KIND_DISTILL,
+    INDEXCACHE_STATE_KIND_INVALID,
+    INDEXCACHE_STATE_KIND_TOPK_ONLY,
+    INDEXCACHE_STATE_TOPK_IDXS,
+    INDEXCACHE_TOPK_ONLY_STATE_LEN,
+    INDEXCACHE_TOPK_ONLY_STATE_PRODUCER_LAYER,
+    apply_stop_gradient_mask,
+    detach_stop_gradient_tensor,
+    state_kind,
+)
 from paddlefleet.transformer.utils import (
     get_doc_lens,
     get_doc_starts,
@@ -71,18 +89,6 @@ from paddlefleet.transformer.cp_utils import (
     get_window_topk_idxs_cp,
     map_compressed_topk_to_kv_full_cp,
 )
-
-_INDEXCACHE_STATE_KIND_NONE = "none"
-_INDEXCACHE_STATE_KIND_TOPK_ONLY = "topk_only"
-_INDEXCACHE_STATE_KIND_DISTILL = "distill"
-_INDEXCACHE_STATE_KIND_INVALID = "invalid"
-_INDEXCACHE_TOPK_ONLY_STATE_LEN = 3
-_INDEXCACHE_DISTILL_STATE_LEN = 8
-_INDEXCACHE_STATE_TOPK_IDXS = 0
-_INDEXCACHE_STATE_PRODUCER_LAYER = 1
-_INDEXCACHE_DISTILL_STATE_PRODUCER_LAYER = 6
-_INDEXCACHE_DISTILL_STATE_SERVED_COUNT = 7
-
 
 class LinearBF16FP32Func(paddle.autograd.PyLayer):
     """BF16 activation x BF16 weight -> FP32 output autograd function.
@@ -969,6 +975,27 @@ class TileLangCSAIndexerLossAutoScaler(paddle.autograd.PyLayer):
         if grad_k.dtype != index_k_comp.dtype:
             grad_k = grad_k.cast(index_k_comp.dtype)
 
+        if os.environ.get("INDEXCACHE_TRAIN_DEBUG", "0") == "1":
+            q_norm = float(
+                paddle.linalg.norm(grad_q.cast(paddle.float32)).item()
+            )
+            weights_norm = float(
+                paddle.linalg.norm(grad_weights.cast(paddle.float32)).item()
+            )
+            k_norm = float(
+                paddle.linalg.norm(grad_k.cast(paddle.float32)).item()
+            )
+            print(
+                "[INDEXCACHE_DISTILL_GRAD] "
+                f"backend={ctx.indexer_backend} "
+                f"loss_coeff={ctx.loss_coeff:.8g} "
+                f"input_stop_gradients={ctx.input_stop_gradients} "
+                f"q_grad_norm={q_norm:.8g} "
+                f"weights_grad_norm={weights_norm:.8g} "
+                f"k_grad_norm={k_norm:.8g}",
+                flush=True,
+            )
+
         grad_slots = [grad_output, grad_q, grad_weights, grad_k]
         for idx, stop_gradient in enumerate(
             getattr(ctx, "input_stop_gradients", ())
@@ -1671,14 +1698,7 @@ class CompressedSparseAttention(FleetLayer):
 
     @staticmethod
     def _indexcache_state_kind(indexcache_state: tuple | list | None) -> str:
-        if not indexcache_state:
-            return _INDEXCACHE_STATE_KIND_NONE
-        state_len = len(indexcache_state)
-        if state_len == _INDEXCACHE_TOPK_ONLY_STATE_LEN:
-            return _INDEXCACHE_STATE_KIND_TOPK_ONLY
-        if state_len >= _INDEXCACHE_DISTILL_STATE_LEN:
-            return _INDEXCACHE_STATE_KIND_DISTILL
-        return _INDEXCACHE_STATE_KIND_INVALID
+        return state_kind(indexcache_state)
 
     def _indexcache_validate_state_for_reuse(
         self,
@@ -1687,22 +1707,22 @@ class CompressedSparseAttention(FleetLayer):
         pattern: str,
     ) -> str:
         state_kind = self._indexcache_state_kind(indexcache_state)
-        if state_kind == _INDEXCACHE_STATE_KIND_INVALID:
+        if state_kind == INDEXCACHE_STATE_KIND_INVALID:
             raise ValueError(
                 "IndexCache state must be either topk-only "
-                f"({_INDEXCACHE_TOPK_ONLY_STATE_LEN} tensors) or distill "
-                f"(>={_INDEXCACHE_DISTILL_STATE_LEN} tensors), got "
+                f"({INDEXCACHE_TOPK_ONLY_STATE_LEN} tensors) or distill "
+                "(8 tensors), got "
                 f"len={len(indexcache_state)}. "
                 + self._indexcache_context_msg(c4_ordinal, pattern)
             )
         if (
-            self._indexcache_recompute_enabled()
-            and state_kind == _INDEXCACHE_STATE_KIND_DISTILL
+            state_kind == INDEXCACHE_STATE_KIND_DISTILL
+            and not self._indexcache_multi_layer_distill_enabled()
         ):
             raise RuntimeError(
-                "IndexCache recompute reuse-only expects a topk-only "
-                "indexcache_state; distill-state tensors are not supported "
-                "with recompute in phase 1. "
+                "IndexCache reuse-only expects a topk-only indexcache_state; "
+                "distill-state tensors require "
+                "indexcache_multi_layer_distill=True. "
                 f"state_kind={state_kind}. "
                 + self._indexcache_context_msg(c4_ordinal, pattern)
             )
@@ -1833,9 +1853,7 @@ class CompressedSparseAttention(FleetLayer):
 
     @staticmethod
     def _indexcache_forward_state_tensor(value: Tensor) -> Tensor:
-        value = value.detach()
-        value.stop_gradient = True
-        return value
+        return detach_stop_gradient_tensor(value)
 
     def _indexcache_pack_state(
         self,
@@ -1859,9 +1877,9 @@ class CompressedSparseAttention(FleetLayer):
             ) = tilelang_indexer_loss_state
             state.extend(
                 [
-                    self._indexcache_forward_state_tensor(q_indexer_bf),
-                    self._indexcache_forward_state_tensor(weights_indexer_bf),
-                    self._indexcache_forward_state_tensor(k_indexer_bf),
+                    q_indexer_bf,
+                    weights_indexer_bf,
+                    k_indexer_bf,
                     self._indexcache_forward_state_tensor(
                         topk_indices_compressed
                     ),
@@ -1885,7 +1903,7 @@ class CompressedSparseAttention(FleetLayer):
                     ),
                 ]
             )
-        return tuple(state)
+        return apply_stop_gradient_mask(tuple(state))
 
     def _indexcache_state_topk(
         self,
@@ -1899,20 +1917,20 @@ class CompressedSparseAttention(FleetLayer):
         if not indexcache_state:
             return None, None, state_kind
         producer_layer = None
-        if state_kind == _INDEXCACHE_STATE_KIND_DISTILL:
+        if state_kind == INDEXCACHE_STATE_KIND_DISTILL:
             producer_layer = self._indexcache_tensor_to_int(
-                indexcache_state[_INDEXCACHE_DISTILL_STATE_PRODUCER_LAYER]
+                indexcache_state[INDEXCACHE_DISTILL_STATE_PRODUCER_LAYER]
             )
-        elif state_kind == _INDEXCACHE_STATE_KIND_TOPK_ONLY:
+        elif state_kind == INDEXCACHE_STATE_KIND_TOPK_ONLY:
             producer_layer = self._indexcache_tensor_to_int(
-                indexcache_state[_INDEXCACHE_STATE_PRODUCER_LAYER]
+                indexcache_state[INDEXCACHE_TOPK_ONLY_STATE_PRODUCER_LAYER]
             )
         if producer_layer is None:
             producer_layer = getattr(
                 self.config, "_indexcache_last_layer_number", None
             )
         return (
-            indexcache_state[_INDEXCACHE_STATE_TOPK_IDXS],
+            indexcache_state[INDEXCACHE_STATE_TOPK_IDXS],
             producer_layer,
             state_kind,
         )
@@ -1932,7 +1950,7 @@ class CompressedSparseAttention(FleetLayer):
             self._indexcache_multi_layer_distill_enabled()
             and tilelang_indexer_loss_state is not None
         ):
-            state_kind = _INDEXCACHE_STATE_KIND_DISTILL
+            state_kind = INDEXCACHE_STATE_KIND_DISTILL
             self.config._indexcache_last_distill_state = tilelang_indexer_loss_state
             self.config._indexcache_last_served_count = served_count
             self._indexcache_distill_debug(
@@ -1941,7 +1959,7 @@ class CompressedSparseAttention(FleetLayer):
                 f"loss_scale={loss_scale:.8g}"
             )
         else:
-            state_kind = _INDEXCACHE_STATE_KIND_TOPK_ONLY
+            state_kind = INDEXCACHE_STATE_KIND_TOPK_ONLY
         self._indexcache_debug(
             "action=produce "
             f"c4_ordinal={c4_ordinal} pattern={pattern} "
@@ -2020,13 +2038,13 @@ class CompressedSparseAttention(FleetLayer):
         served_count = None
         if indexcache_state is not None:
             state_kind = self._indexcache_state_kind(indexcache_state)
-            if state_kind == _INDEXCACHE_STATE_KIND_DISTILL:
+            if state_kind == INDEXCACHE_STATE_KIND_DISTILL:
                 producer_state = (
-                    indexcache_state[1],
-                    indexcache_state[2],
-                    indexcache_state[3],
-                    indexcache_state[4],
-                    indexcache_state[5],
+                    indexcache_state[INDEXCACHE_DISTILL_STATE_Q],
+                    indexcache_state[INDEXCACHE_DISTILL_STATE_WEIGHTS],
+                    indexcache_state[INDEXCACHE_DISTILL_STATE_K],
+                    indexcache_state[INDEXCACHE_DISTILL_STATE_TOPK_INDICES],
+                    indexcache_state[INDEXCACHE_DISTILL_STATE_TOPK_PROBS],
                     None,
                     None,
                     getattr(self.config, "csa_indexer_backend", "tilelang"),
@@ -2034,10 +2052,10 @@ class CompressedSparseAttention(FleetLayer):
                     None,
                 )
                 producer_layer = self._indexcache_tensor_to_int(
-                    indexcache_state[_INDEXCACHE_DISTILL_STATE_PRODUCER_LAYER]
+                    indexcache_state[INDEXCACHE_DISTILL_STATE_PRODUCER_LAYER]
                 )
                 served_count = self._indexcache_tensor_to_int(
-                    indexcache_state[_INDEXCACHE_DISTILL_STATE_SERVED_COUNT]
+                    indexcache_state[INDEXCACHE_DISTILL_STATE_SERVED_COUNT]
                 )
             else:
                 raise RuntimeError(
@@ -2145,6 +2163,7 @@ class CompressedSparseAttention(FleetLayer):
         loss_mask: Tensor | None = None,
         global_valid_count: float | None = None,
         indexer_loss_coeff_override: float | None = None,
+        materialize_distill_state: bool = False,
     ) -> tuple[Tensor, Tensor | None, tuple | None]:
         """Build indexer-selected compressed KV indices and loss state."""
         b, sq, np_heads, _ = query.shape
@@ -2164,10 +2183,16 @@ class CompressedSparseAttention(FleetLayer):
         indexer_backend = getattr(
             self.config, "csa_indexer_backend", "tilelang"
         )
+        if materialize_distill_state and indexer_backend != "tilelang":
+            raise NotImplementedError(
+                "IndexCache distill recompute materialization currently "
+                "supports only csa_indexer_backend='tilelang'."
+            )
         # The indexer loss path is only active during the grad-enabled forward.
         # Full recompute runs the first forward under no_grad; that pass should
-        # only materialize main-attention indices. The backend branch remains
-        # fixed across both forwards.
+        # materialize main-attention indices, plus producer distill state when
+        # a later S layer will consume it. The backend branch remains fixed
+        # across both forwards.
         need_indexer_loss = self.training and paddle.is_grad_enabled()
         loss_topk_effective = _resolve_csa_indexer_loss_topk_effective(
             self.config,
@@ -2290,7 +2315,7 @@ class CompressedSparseAttention(FleetLayer):
                     topk_indices_compressed,
                     tilelang_indexer_loss_state,
                 ) = compute_fused_indexer_loss("tilelang")
-            else:  # First recompute no-grad forward; only materialize TileLang top-k for attention.
+            else:  # First recompute no-grad forward; materialize attention top-k and optional producer distill state.
                 from paddlefleet.tilelang_ops import csa_indexer_topk_fwd
 
                 with paddle.no_grad():
@@ -2299,15 +2324,40 @@ class CompressedSparseAttention(FleetLayer):
                             x_det, qr_det, startend_row_indices
                         )
                     )
-                    tl_topk_indices, _tl_topk_scores = csa_indexer_topk_fwd(
+                    tl_topk_effective = (
+                        loss_topk_effective
+                        if materialize_distill_state
+                        else attn_topk_effective
+                    )
+                    tl_topk_indices, tl_topk_scores = csa_indexer_topk_fwd(
                         q_indexer_tl,
                         k_indexer_tl,
                         weights_indexer_tl,
                         ratio=self.compress_ratio,
-                        topk_effective=attn_topk_effective,
+                        topk_effective=tl_topk_effective,
                         valid_range=valid_range,
                     )
                 topk_indices_compressed = tl_topk_indices
+                if materialize_distill_state:
+                    indexer_loss_coeff = (
+                        indexer_loss_coeff_override
+                        if indexer_loss_coeff_override is not None
+                        else getattr(
+                            self.config, "dsa_indexer_loss_coeff", 0.0
+                        )
+                    )
+                    tilelang_indexer_loss_state = (
+                        q_indexer_tl,
+                        weights_indexer_tl,
+                        k_indexer_tl,
+                        topk_indices_compressed,
+                        tl_topk_scores,
+                        None,
+                        float(indexer_loss_coeff),
+                        "tilelang",
+                        global_valid_count if loss_mask is not None else None,
+                        loss_mask,
+                    )
 
         elif (
             indexer_backend == "unfused"
@@ -2558,6 +2608,7 @@ class CompressedSparseAttention(FleetLayer):
                 else:
                     served_count = None
                     loss_coeff_override = None
+                    materialize_distill_state = False
                     if (
                         indexcache_action is not None
                         and self._indexcache_multi_layer_distill_enabled()
@@ -2568,6 +2619,11 @@ class CompressedSparseAttention(FleetLayer):
                         )
                         loss_coeff_override = self._indexcache_scaled_loss_coeff(
                             served_count
+                        )
+                        materialize_distill_state = (
+                            self._indexcache_has_future_served_layer(
+                                pattern, c4_ordinal
+                            )
                         )
                     (
                         compress_topk_idxs,
@@ -2584,6 +2640,7 @@ class CompressedSparseAttention(FleetLayer):
                         loss_mask=loss_mask,
                         global_valid_count=global_valid_count,
                         indexer_loss_coeff_override=loss_coeff_override,
+                        materialize_distill_state=materialize_distill_state,
                     )
                     if indexcache_action is not None:
                         c4_ordinal, _action, pattern = indexcache_action
@@ -2633,12 +2690,20 @@ class CompressedSparseAttention(FleetLayer):
         )
 
         # Step 6: Attach indexer loss
-        if tilelang_indexer_loss_state is not None and self.training:
+        if (
+            tilelang_indexer_loss_state is not None
+            and self.training
+            and paddle.is_grad_enabled()
+        ):
             output = TileLangCSAIndexerLossAutoScaler.apply(
                 output,
                 *tilelang_indexer_loss_state,
             )
-        elif indexer_loss is not None and self.training:
+        elif (
+            indexer_loss is not None
+            and self.training
+            and paddle.is_grad_enabled()
+        ):
             output = DSAIndexerLossAutoScaler.apply(output, indexer_loss)
         if indexcache_served_loss_state is not None:
             output = TileLangCSAIndexerLossAutoScaler.apply(
@@ -2843,6 +2908,7 @@ class CompressedSparseAttention(FleetLayer):
 
                     served_count = None
                     loss_coeff_override = None
+                    materialize_distill_state = False
                     if (
                         indexcache_action is not None
                         and self._indexcache_multi_layer_distill_enabled()
@@ -2853,6 +2919,11 @@ class CompressedSparseAttention(FleetLayer):
                         )
                         loss_coeff_override = (
                             self._indexcache_scaled_loss_coeff(served_count)
+                        )
+                        materialize_distill_state = (
+                            self._indexcache_has_future_served_layer(
+                                pattern, c4_ordinal
+                            )
                         )
                     indexer_loss_coeff = (
                         loss_coeff_override
@@ -3019,16 +3090,42 @@ class CompressedSparseAttention(FleetLayer):
                         from paddlefleet.tilelang_ops import csa_indexer_topk_fwd
 
                         with paddle.no_grad():
-                            tl_topk_indices, _ = csa_indexer_topk_fwd(
+                            tl_topk_effective = (
+                                loss_topk_effective
+                                if materialize_distill_state
+                                else attn_topk_effective
+                            )
+                            tl_topk_indices, tl_topk_probs = csa_indexer_topk_fwd(
                                 q_indexer_bf,
                                 k_indexer_global,
                                 weights_indexer_bf,
                                 ratio=self.compress_ratio,
-                                topk_effective=attn_topk_effective,
+                                topk_effective=tl_topk_effective,
                                 seq_offset=position_offset,
                                 valid_range=valid_range,
                             )
                         topk_indices_compressed = tl_topk_indices
+                        if materialize_distill_state:
+                            tilelang_indexer_loss_state = (
+                                q_indexer_bf,
+                                weights_indexer_bf,
+                                k_indexer_global,
+                                topk_indices_compressed,
+                                tl_topk_probs,
+                                None,
+                                float(indexer_loss_coeff)
+                                if loss_mask is not None
+                                else float(indexer_loss_coeff) / self.cp_size,
+                                getattr(
+                                    self.config,
+                                    "csa_indexer_backend",
+                                    "tilelang",
+                                ),
+                                global_valid_count
+                                if loss_mask is not None
+                                else None,
+                                loss_mask,
+                            )
 
                     if (
                         topk_indices_compressed.shape[-1]
@@ -3105,11 +3202,19 @@ class CompressedSparseAttention(FleetLayer):
         )
 
         # Step 5: Attach indexer loss
-        if tilelang_indexer_loss_state is not None and self.training:
+        if (
+            tilelang_indexer_loss_state is not None
+            and self.training
+            and paddle.is_grad_enabled()
+        ):
             output = TileLangCSAIndexerLossAutoScaler.apply(
                 output, *tilelang_indexer_loss_state
             )
-        elif indexer_loss is not None and self.training:
+        elif (
+            indexer_loss is not None
+            and self.training
+            and paddle.is_grad_enabled()
+        ):
             output = DSAIndexerLossAutoScaler.apply(output, indexer_loss)
         if indexcache_served_loss_state is not None:
             output = TileLangCSAIndexerLossAutoScaler.apply(

--- a/src/paddlefleet/transformer/dsv4_hybrid_attention.py
+++ b/src/paddlefleet/transformer/dsv4_hybrid_attention.py
@@ -296,8 +296,8 @@ class DSv4HybridAttention(Attention):
         )
 
         # Core attention (CompressedSparseAttention)
-        input_ids = kwargs.get("input_ids", None)
-        core_attn_out = self.core_attention(
+        indexcache_state = kwargs.get("indexcache_state", None)
+        core_attn_result = self.core_attention(
             query,
             key,
             value,
@@ -306,7 +306,13 @@ class DSv4HybridAttention(Attention):
             x=hidden_states,
             qr=q_compressed,
             input_ids=kwargs.get("input_ids", None),
+            indexcache_state=indexcache_state,
         )
+        core_attn_returns_indexcache_state = isinstance(core_attn_result, tuple)
+        if isinstance(core_attn_result, tuple):
+            core_attn_out, indexcache_state = core_attn_result
+        else:
+            core_attn_out = core_attn_result
         # core_attn_out: [b, sq, np * v_head_dim]
 
         # Inverse RoPE on last qk_pos_emb_head_dim of each head
@@ -384,6 +390,8 @@ class DSv4HybridAttention(Attention):
         # Output projection
         output, bias = self.o_proj(core_attn_out)
 
+        if indexcache_state is not None or core_attn_returns_indexcache_state:
+            return output, bias, indexcache_state
         return output, bias
 
     def get_query_key_value_tensors(

--- a/src/paddlefleet/transformer/indexcache_state.py
+++ b/src/paddlefleet/transformer/indexcache_state.py
@@ -1,0 +1,132 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import paddle
+
+
+INDEXCACHE_STATE_KIND_NONE = "none"
+INDEXCACHE_STATE_KIND_TOPK_ONLY = "topk_only"
+INDEXCACHE_STATE_KIND_DISTILL = "distill"
+INDEXCACHE_STATE_KIND_INVALID = "invalid"
+
+INDEXCACHE_TOPK_ONLY_STATE_LEN = 3
+INDEXCACHE_DISTILL_STATE_LEN = 8
+INDEXCACHE_RECOMPUTE_STATE_MAX_LEN = INDEXCACHE_DISTILL_STATE_LEN
+
+INDEXCACHE_STATE_TOPK_IDXS = 0
+INDEXCACHE_TOPK_ONLY_STATE_PRODUCER_LAYER = 1
+INDEXCACHE_TOPK_ONLY_STATE_SERVED_COUNT = 2
+
+INDEXCACHE_DISTILL_STATE_Q = 1
+INDEXCACHE_DISTILL_STATE_WEIGHTS = 2
+INDEXCACHE_DISTILL_STATE_K = 3
+INDEXCACHE_DISTILL_STATE_TOPK_INDICES = 4
+INDEXCACHE_DISTILL_STATE_TOPK_PROBS = 5
+INDEXCACHE_DISTILL_STATE_PRODUCER_LAYER = 6
+INDEXCACHE_DISTILL_STATE_SERVED_COUNT = 7
+
+INDEXCACHE_DISTILL_GRAD_INDICES = (
+    INDEXCACHE_DISTILL_STATE_Q,
+    INDEXCACHE_DISTILL_STATE_WEIGHTS,
+    INDEXCACHE_DISTILL_STATE_K,
+)
+
+
+def state_kind(indexcache_state: tuple | list | None) -> str:
+    if not indexcache_state:
+        return INDEXCACHE_STATE_KIND_NONE
+    state_len = len(indexcache_state)
+    if state_len == INDEXCACHE_TOPK_ONLY_STATE_LEN:
+        return INDEXCACHE_STATE_KIND_TOPK_ONLY
+    if state_len == INDEXCACHE_DISTILL_STATE_LEN:
+        return INDEXCACHE_STATE_KIND_DISTILL
+    return INDEXCACHE_STATE_KIND_INVALID
+
+
+def is_valid_state(indexcache_state: tuple | list | None) -> bool:
+    return state_kind(indexcache_state) in (
+        INDEXCACHE_STATE_KIND_NONE,
+        INDEXCACHE_STATE_KIND_TOPK_ONLY,
+        INDEXCACHE_STATE_KIND_DISTILL,
+    )
+
+
+def _as_state_tuple(indexcache_state: tuple | list | None) -> tuple | None:
+    if indexcache_state is None:
+        return None
+    return tuple(indexcache_state)
+
+
+def apply_stop_gradient_mask(
+    indexcache_state: tuple | list | None,
+) -> tuple | None:
+    indexcache_state = _as_state_tuple(indexcache_state)
+    kind = state_kind(indexcache_state)
+    if kind == INDEXCACHE_STATE_KIND_NONE:
+        return None
+    if kind == INDEXCACHE_STATE_KIND_INVALID:
+        raise ValueError(
+            "IndexCache state must be either topk-only "
+            f"({INDEXCACHE_TOPK_ONLY_STATE_LEN} tensors) or distill "
+            f"({INDEXCACHE_DISTILL_STATE_LEN} tensors), got "
+            f"len={len(indexcache_state)}."
+        )
+
+    for idx, tensor in enumerate(indexcache_state):
+        if not isinstance(tensor, paddle.Tensor):
+            raise TypeError(
+                "IndexCache state entries must be Paddle tensors, got "
+                f"type={type(tensor).__name__} at index={idx}."
+            )
+        tensor.stop_gradient = not (
+            kind == INDEXCACHE_STATE_KIND_DISTILL
+            and idx in INDEXCACHE_DISTILL_GRAD_INDICES
+        )
+    return indexcache_state
+
+
+def detach_stop_gradient_tensor(value: paddle.Tensor) -> paddle.Tensor:
+    value = value.detach()
+    value.stop_gradient = True
+    return value
+
+
+def clone_state_outputs(indexcache_state: tuple | list | None) -> tuple | None:
+    masked = apply_stop_gradient_mask(indexcache_state)
+    if masked is None:
+        return None
+    cloned = tuple(tensor.clone() for tensor in masked)
+    return apply_stop_gradient_mask(cloned)
+
+
+def flatten_state(indexcache_state: tuple | list | None) -> tuple:
+    masked = apply_stop_gradient_mask(indexcache_state)
+    if masked is None:
+        return ()
+    return masked
+
+
+def state_to_slots(indexcache_state: tuple | list | None) -> tuple:
+    slots = list(flatten_state(indexcache_state))
+    if len(slots) > INDEXCACHE_RECOMPUTE_STATE_MAX_LEN:
+        raise ValueError(
+            "IndexCache recompute state has too many slots: "
+            f"{len(slots)} > {INDEXCACHE_RECOMPUTE_STATE_MAX_LEN}."
+        )
+    slots.extend([None] * (INDEXCACHE_RECOMPUTE_STATE_MAX_LEN - len(slots)))
+    return tuple(slots)
+
+
+def state_from_slots(slots: Iterable) -> tuple | None:
+    state = list(slots)
+    while state and state[-1] is None:
+        state.pop()
+    if not state:
+        return None
+    return apply_stop_gradient_mask(tuple(state))

--- a/src/paddlefleet/transformer/moe/fp8_utils.py
+++ b/src/paddlefleet/transformer/moe/fp8_utils.py
@@ -1902,6 +1902,22 @@ class ExpertsGroupGemmContiguousNode:
         """
         BF16 GEMM for weight grad
         """
+        def _get_stop_gradient(w):
+            if isinstance(w, (list, tuple)):
+                return all(getattr(item, "stop_gradient", True) for item in w)
+            parent = getattr(w, "_parent", None)
+            if parent is not None:
+                for attr in ("weight1", "weight2"):
+                    parent_weight = getattr(parent, attr, None)
+                    if parent_weight is not None and hasattr(
+                        parent_weight, "stop_gradient"
+                    ):
+                        return bool(parent_weight.stop_gradient)
+            return bool(getattr(w, "stop_gradient", True))
+
+        if _get_stop_gradient(weights):
+            return
+
         if x is None:
             if self.dequant_input:
                 x = paddle.incubate.nn.functional.fused_act_dequant(

--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -974,7 +974,7 @@ class StandardMoERouter(nn.Layer):
         # inference checkpoint; no public initialization recipe is documented.
         # Round-robin is used here only as a placeholder so the layer is
         # runnable from scratch.
-        ids = paddle.arange(vocab_size, dtype=paddle.int64)
+        ids = paddle.arange(vocab_size, dtype=paddle.int32)
         tid2eid = paddle.stack(
             [
                 (ids + k) % self.num_experts

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -874,6 +874,20 @@ class TransformerConfig(ModelParallelConfig):
         kernel.
     """
 
+    index_topk_pattern: str | None = None
+    """Optional IndexCache training pattern over ratio=4 CSA indexer layers.
+
+    Each character corresponds to one ratio=4 layer in execution order:
+      - "F": run the learned indexer and cache its top-k indices
+      - "S": skip the local indexer and reuse the previous cached top-k indices
+    """
+
+    indexcache_multi_layer_distill: bool = False
+    """Train retained IndexCache indexers with targets from all served layers.
+
+    CP training is supported only for no-MTP, no-recompute TileLang CSA.
+    """
+
     use_fast_hadamard: bool = False
     """Use Tridao's fast Hadamard transform for DSv4 rotate activation function."""
 
@@ -930,6 +944,8 @@ class TransformerConfig(ModelParallelConfig):
         "csa_dense_mode": "csa_dense_mode",
         "csa_indexer_backend": "csa_indexer_backend",
         "csa_sparse_attn_backend": "csa_sparse_attn_backend",
+        "index_topk_pattern": "index_topk_pattern",
+        "indexcache_multi_layer_distill": "indexcache_multi_layer_distill",
         "o_groups": "o_groups",
         "o_lora_rank": "o_lora_rank",
         "qk_pos_emb_head_dim": "qk_pos_emb_head_dim",
@@ -1187,6 +1203,67 @@ class TransformerConfig(ModelParallelConfig):
                     raise ValueError(
                         f"csa_compress_ratios[{i}]={r} is invalid. "
                         f"Must be one of {valid_ratios}."
+                    )
+
+            if self.index_topk_pattern is not None:
+                pattern = str(self.index_topk_pattern).strip().upper()
+                if not pattern:
+                    self.index_topk_pattern = None
+                else:
+                    invalid_chars = sorted(set(pattern) - {"F", "S"})
+                    if invalid_chars:
+                        raise ValueError(
+                            "index_topk_pattern may only contain 'F' and 'S', "
+                            f"got invalid chars: {invalid_chars}."
+                        )
+                    if pattern[0] != "F":
+                        raise ValueError(
+                            "index_topk_pattern must start with 'F' so there "
+                            "is a producer before any reused top-k indices."
+                        )
+                    if self.csa_dense_mode:
+                        raise ValueError(
+                            "index_topk_pattern requires csa_dense_mode=False."
+                        )
+                    c4_layer_count = sum(
+                        1 for ratio in self.csa_compress_ratios if ratio == 4
+                    )
+                    if len(pattern) != c4_layer_count:
+                        raise ValueError(
+                            "index_topk_pattern length must equal the number "
+                            f"of ratio=4 CSA layers ({c4_layer_count}), got "
+                            f"{len(pattern)}."
+                        )
+                    self.index_topk_pattern = pattern
+
+            if self.indexcache_multi_layer_distill:
+                if not self.index_topk_pattern:
+                    raise ValueError(
+                        "indexcache_multi_layer_distill=True requires a "
+                        "non-empty index_topk_pattern."
+                    )
+                if self.context_parallel_size > 1 and (
+                    self.num_nextn_predict_layers is not None
+                    and self.num_nextn_predict_layers > 0
+                ):
+                    raise NotImplementedError(
+                        "indexcache_multi_layer_distill currently supports "
+                        "CP training only when num_nextn_predict_layers=0."
+                    )
+                if self.context_parallel_size > 1 and self.recompute_granularity:
+                    raise NotImplementedError(
+                        "indexcache_multi_layer_distill currently supports "
+                        "CP training only with recompute disabled."
+                    )
+                if self.csa_indexer_backend != "tilelang":
+                    raise NotImplementedError(
+                        "indexcache_multi_layer_distill currently supports "
+                        "only csa_indexer_backend='tilelang'."
+                    )
+                if self.csa_sparse_attn_backend != "tilelang":
+                    raise NotImplementedError(
+                        "indexcache_multi_layer_distill currently supports "
+                        "only csa_sparse_attn_backend='tilelang'."
                     )
 
             if (

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -1242,6 +1242,13 @@ class TransformerConfig(ModelParallelConfig):
                         "indexcache_multi_layer_distill=True requires a "
                         "non-empty index_topk_pattern."
                     )
+                if self.recompute_granularity:
+                    raise NotImplementedError(
+                        "indexcache_multi_layer_distill + recompute is not "
+                        "supported in IndexCache phase 1. Use reuse-only "
+                        "IndexCache with full/uniform recompute, or disable "
+                        "recompute for multi-layer distill."
+                    )
                 if self.context_parallel_size > 1 and (
                     self.num_nextn_predict_layers is not None
                     and self.num_nextn_predict_layers > 0
@@ -1264,6 +1271,29 @@ class TransformerConfig(ModelParallelConfig):
                     raise NotImplementedError(
                         "indexcache_multi_layer_distill currently supports "
                         "only csa_sparse_attn_backend='tilelang'."
+                    )
+
+            if self.index_topk_pattern and self.recompute_granularity:
+                if not (
+                    self.recompute_granularity == "full"
+                    and self.recompute_method == "uniform"
+                    and self.recompute_num_layers == 1
+                ):
+                    raise NotImplementedError(
+                        "IndexCache reuse-only recompute phase 1 only supports "
+                        "recompute_granularity='full', "
+                        "recompute_method='uniform', and "
+                        "recompute_num_layers=1."
+                    )
+                if self.csa_indexer_backend != "tilelang":
+                    raise NotImplementedError(
+                        "IndexCache reuse-only recompute phase 1 only supports "
+                        "csa_indexer_backend='tilelang'."
+                    )
+                if self.csa_sparse_attn_backend != "tilelang":
+                    raise NotImplementedError(
+                        "IndexCache reuse-only recompute phase 1 only supports "
+                        "csa_sparse_attn_backend='tilelang'."
                     )
 
             if (

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -885,7 +885,7 @@ class TransformerConfig(ModelParallelConfig):
     indexcache_multi_layer_distill: bool = False
     """Train retained IndexCache indexers with targets from all served layers.
 
-    CP training is supported only for no-MTP, no-recompute TileLang CSA.
+    CP training is supported only for no-MTP TileLang CSA.
     """
 
     use_fast_hadamard: bool = False
@@ -1242,13 +1242,6 @@ class TransformerConfig(ModelParallelConfig):
                         "indexcache_multi_layer_distill=True requires a "
                         "non-empty index_topk_pattern."
                     )
-                if self.recompute_granularity:
-                    raise NotImplementedError(
-                        "indexcache_multi_layer_distill + recompute is not "
-                        "supported in IndexCache phase 1. Use reuse-only "
-                        "IndexCache with full/uniform recompute, or disable "
-                        "recompute for multi-layer distill."
-                    )
                 if self.context_parallel_size > 1 and (
                     self.num_nextn_predict_layers is not None
                     and self.num_nextn_predict_layers > 0
@@ -1256,11 +1249,6 @@ class TransformerConfig(ModelParallelConfig):
                     raise NotImplementedError(
                         "indexcache_multi_layer_distill currently supports "
                         "CP training only when num_nextn_predict_layers=0."
-                    )
-                if self.context_parallel_size > 1 and self.recompute_granularity:
-                    raise NotImplementedError(
-                        "indexcache_multi_layer_distill currently supports "
-                        "CP training only with recompute disabled."
                     )
                 if self.csa_indexer_backend != "tilelang":
                     raise NotImplementedError(
@@ -1280,19 +1268,19 @@ class TransformerConfig(ModelParallelConfig):
                     and self.recompute_num_layers == 1
                 ):
                     raise NotImplementedError(
-                        "IndexCache reuse-only recompute phase 1 only supports "
+                        "IndexCache recompute currently supports only "
                         "recompute_granularity='full', "
                         "recompute_method='uniform', and "
                         "recompute_num_layers=1."
                     )
                 if self.csa_indexer_backend != "tilelang":
                     raise NotImplementedError(
-                        "IndexCache reuse-only recompute phase 1 only supports "
+                        "IndexCache recompute currently supports only "
                         "csa_indexer_backend='tilelang'."
                     )
                 if self.csa_sparse_attn_backend != "tilelang":
                     raise NotImplementedError(
-                        "IndexCache reuse-only recompute phase 1 only supports "
+                        "IndexCache recompute currently supports only "
                         "csa_sparse_attn_backend='tilelang'."
                     )
 

--- a/src/paddlefleet/transformer/transformer_layer.py
+++ b/src/paddlefleet/transformer/transformer_layer.py
@@ -595,6 +595,7 @@ class TransformerLayer(nn.Layer):
             attention_bias = dict_args.get("attention_bias", None)
             packed_seq_params = dict_args.get("packed_seq_params", None)
             input_ids = dict_args.get("input_ids", None)
+            indexcache_state = dict_args.get("indexcache_state", None)
             outputs = recompute(
                 self._forward_impl,
                 hidden_states=hidden_states,
@@ -628,12 +629,16 @@ class TransformerLayer(nn.Layer):
                 attention_bias=attention_bias,
                 packed_seq_params=packed_seq_params,
                 input_ids=input_ids,
+                indexcache_state=indexcache_state,
             )
         else:
             outputs = self._forward_impl(**dict_args)
 
+        indexcache_state = None
         if isinstance(outputs, tuple):
             output, context = outputs[0], outputs[1]
+            if len(outputs) > 2:
+                indexcache_state = outputs[2]
         else:
             output, context = outputs, None
 
@@ -694,6 +699,10 @@ class TransformerLayer(nn.Layer):
             # dict_args unchanged and will be consumed by MTP layer directly
         if context is not None:
             rst["context"] = context
+        if indexcache_state is not None:
+            rst["indexcache_state"] = indexcache_state
+        else:
+            dict_args.pop("indexcache_state", None)
         rst = {**dict_args, **rst}
         return rst
 
@@ -716,6 +725,17 @@ class TransformerLayer(nn.Layer):
         input_ids: Tensor | None = None,
         **kwargs,
     ):
+        indexcache_state = kwargs.get("indexcache_state", None)
+
+        def unpack_attention_outputs(attention_outputs):
+            if isinstance(attention_outputs, tuple) and len(attention_outputs) == 3:
+                return (
+                    attention_outputs[0],
+                    attention_outputs[1],
+                    attention_outputs[2],
+                )
+            return attention_outputs[0], attention_outputs[1], indexcache_state
+
         def need_do_attention():
             # need_do_prefill = forward_meta.max_len_tensor_cpu[1] > 0
             # need_do_decode = forward_meta.max_len_tensor_cpu[2] > 0
@@ -760,25 +780,29 @@ class TransformerLayer(nn.Layer):
             # Self-attention (skip internal bda residual)
             with profile("attn"):
                 if need_do_attention():
-                    hidden_states, context = self._forward_attention(
-                        hidden_states=hidden_states,
-                        attention_mask=attention_mask,
-                        attn_mask_startend_row_indices=attn_mask_startend_row_indices,
-                        context=context,
-                        context_mask=context_mask,
-                        rotary_pos_emb=rotary_pos_emb,
-                        rotary_pos_cos=rotary_pos_cos,
-                        rotary_pos_sin=rotary_pos_sin,
-                        swa_rotary_pos_emb=swa_rotary_pos_emb,
-                        swa_rotary_pos_cos=swa_rotary_pos_cos,
-                        swa_rotary_pos_sin=swa_rotary_pos_sin,
-                        position_ids=position_ids,
-                        attention_bias=attention_bias,
-                        packed_seq_params=packed_seq_params,
-                        block_attention_residuals=True,
-                        in_recompute=self.full_recompute,
-                        input_ids=input_ids,
-                        **kwargs,
+                    hidden_states, context, indexcache_state = (
+                        unpack_attention_outputs(
+                            self._forward_attention(
+                                hidden_states=hidden_states,
+                                attention_mask=attention_mask,
+                                attn_mask_startend_row_indices=attn_mask_startend_row_indices,
+                                context=context,
+                                context_mask=context_mask,
+                                rotary_pos_emb=rotary_pos_emb,
+                                rotary_pos_cos=rotary_pos_cos,
+                                rotary_pos_sin=rotary_pos_sin,
+                                swa_rotary_pos_emb=swa_rotary_pos_emb,
+                                swa_rotary_pos_cos=swa_rotary_pos_cos,
+                                swa_rotary_pos_sin=swa_rotary_pos_sin,
+                                position_ids=position_ids,
+                                attention_bias=attention_bias,
+                                packed_seq_params=packed_seq_params,
+                                block_attention_residuals=True,
+                                in_recompute=self.full_recompute,
+                                input_ids=input_ids,
+                                **kwargs,
+                            )
+                        )
                     )
 
             # Accumulate attn output into partial_block
@@ -812,24 +836,28 @@ class TransformerLayer(nn.Layer):
             self._log_md5(hidden_states, "input", self.layer_number)
             with profile("attn"):
                 if need_do_attention():
-                    hidden_states, context = self._forward_attention(
-                        hidden_states=hidden_states,
-                        attention_mask=attention_mask,
-                        attn_mask_startend_row_indices=attn_mask_startend_row_indices,
-                        context=context,
-                        context_mask=context_mask,
-                        rotary_pos_emb=rotary_pos_emb,
-                        rotary_pos_cos=rotary_pos_cos,
-                        rotary_pos_sin=rotary_pos_sin,
-                        swa_rotary_pos_emb=swa_rotary_pos_emb,
-                        swa_rotary_pos_cos=swa_rotary_pos_cos,
-                        swa_rotary_pos_sin=swa_rotary_pos_sin,
-                        position_ids=position_ids,
-                        attention_bias=attention_bias,
-                        packed_seq_params=packed_seq_params,
-                        in_recompute=self.full_recompute,
-                        input_ids=input_ids,
-                        **kwargs,
+                    hidden_states, context, indexcache_state = (
+                        unpack_attention_outputs(
+                            self._forward_attention(
+                                hidden_states=hidden_states,
+                                attention_mask=attention_mask,
+                                attn_mask_startend_row_indices=attn_mask_startend_row_indices,
+                                context=context,
+                                context_mask=context_mask,
+                                rotary_pos_emb=rotary_pos_emb,
+                                rotary_pos_cos=rotary_pos_cos,
+                                rotary_pos_sin=rotary_pos_sin,
+                                swa_rotary_pos_emb=swa_rotary_pos_emb,
+                                swa_rotary_pos_cos=swa_rotary_pos_cos,
+                                swa_rotary_pos_sin=swa_rotary_pos_sin,
+                                position_ids=position_ids,
+                                attention_bias=attention_bias,
+                                packed_seq_params=packed_seq_params,
+                                in_recompute=self.full_recompute,
+                                input_ids=input_ids,
+                                **kwargs,
+                            )
+                        )
                     )
             self._log_md5(
                 hidden_states, "post_attn_residual", self.layer_number
@@ -837,6 +865,8 @@ class TransformerLayer(nn.Layer):
             with profile(timer_name):
                 output = self._forward_mlp(hidden_states, input_ids=input_ids)
             self._log_md5(output, "layer_output", self.layer_number)
+        if indexcache_state is not None:
+            return output, context, indexcache_state
         if context is not None:
             return output, context
         return output
@@ -911,6 +941,11 @@ class TransformerLayer(nn.Layer):
             self.self_attn, DSv4HybridAttention
         ):
             extra_kwargs["input_ids"] = input_ids
+        indexcache_state = kwargs.get("indexcache_state", None)
+        if indexcache_state is not None and isinstance(
+            self.self_attn, DSv4HybridAttention
+        ):
+            extra_kwargs["indexcache_state"] = indexcache_state
 
         if rope_freqs_cis is not None:
             attention_output_with_bias = self.self_attn(
@@ -947,6 +982,13 @@ class TransformerLayer(nn.Layer):
                 use_cache=kwargs.get("use_cache", False),
                 **extra_kwargs,
             )
+
+        if (
+            isinstance(attention_output_with_bias, tuple)
+            and len(attention_output_with_bias) == 3
+        ):
+            indexcache_state = attention_output_with_bias[2]
+            attention_output_with_bias = attention_output_with_bias[:2]
 
         with paddle.enable_grad():
             if block_attention_residuals:
@@ -997,6 +1039,8 @@ class TransformerLayer(nn.Layer):
         if is_first_fwd:
             hidden_states.stop_gradient = False
 
+        if indexcache_state is not None:
+            return hidden_states, context, indexcache_state
         return hidden_states, context
 
     def _forward_mlp(
@@ -1217,6 +1261,11 @@ class HyperConnectionTransformerLayer(TransformerLayer):
             self.self_attn, DSv4HybridAttention
         ):
             extra_kwargs["input_ids"] = kwargs["input_ids"]
+        indexcache_state = kwargs.get("indexcache_state", None)
+        if indexcache_state is not None and isinstance(
+            self.self_attn, DSv4HybridAttention
+        ):
+            extra_kwargs["indexcache_state"] = indexcache_state
 
         if rope_freqs_cis is not None:
             attention_output_with_bias = self.self_attn(
@@ -1244,6 +1293,13 @@ class HyperConnectionTransformerLayer(TransformerLayer):
                 in_recompute=in_recompute,
                 **extra_kwargs,
             )
+
+        if (
+            isinstance(attention_output_with_bias, tuple)
+            and len(attention_output_with_bias) == 3
+        ):
+            indexcache_state = attention_output_with_bias[2]
+            attention_output_with_bias = attention_output_with_bias[:2]
 
         # mHC: fused H_res + H_post + bias-dropout-add
         hidden_states = (
@@ -1284,6 +1340,8 @@ class HyperConnectionTransformerLayer(TransformerLayer):
         if is_first_fwd:
             hidden_states.stop_gradient = False
 
+        if indexcache_state is not None:
+            return hidden_states, context, indexcache_state
         return hidden_states, context
 
     def _forward_mlp(

--- a/src/paddlefleet/transformer/transformer_layer.py
+++ b/src/paddlefleet/transformer/transformer_layer.py
@@ -60,6 +60,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_INDEXCACHE_RECOMPUTE_TOPK_STATE_LEN = 3
+
 
 def tensors_clone(outputs):
     """
@@ -92,6 +94,112 @@ def tensors_clone(outputs):
         raise ValueError(
             f"Unsupported data type:{type(outputs)} in tensors_clone"
         )
+
+
+def _is_indexcache_recompute_topk_state(value):
+    return (
+        isinstance(value, (tuple, list))
+        and len(value) == _INDEXCACHE_RECOMPUTE_TOPK_STATE_LEN
+        and all(isinstance(item, paddle.Tensor) for item in value)
+    )
+
+
+def _mark_indexcache_recompute_topk_state_stop_gradient(value):
+    if not _is_indexcache_recompute_topk_state(value):
+        return value
+    for tensor in value:
+        tensor.stop_gradient = True
+    return tuple(value)
+
+
+def _ensure_recompute_non_leaf_tensor(value):
+    if (
+        isinstance(value, paddle.Tensor)
+        and not value.stop_gradient
+        and getattr(value, "is_leaf", False)
+    ):
+        return paddle.scale(value, scale=1.0, bias=0.0)
+    return value
+
+
+def _describe_indexcache_recompute_input(value):
+    if value is None:
+        return None
+    if isinstance(value, paddle.Tensor):
+        return {
+            "type": "Tensor",
+            "shape": list(value.shape),
+            "dtype": str(value.dtype),
+            "stop_gradient": bool(value.stop_gradient),
+            "is_leaf": bool(getattr(value, "is_leaf", False)),
+        }
+    if isinstance(value, (tuple, list)):
+        return [
+            _describe_indexcache_recompute_input(item)
+            for item in value
+            if item is not None
+        ]
+    return {"type": type(value).__name__}
+
+
+def _clone_indexcache_recompute_state_outputs(value):
+    value = _mark_indexcache_recompute_topk_state_stop_gradient(value)
+    cloned = tuple(tensor.clone() for tensor in value)
+    return _mark_indexcache_recompute_topk_state_stop_gradient(cloned)
+
+
+def _flatten_indexcache_recompute_outputs(outputs):
+    if not isinstance(outputs, tuple) or len(outputs) <= 2:
+        return outputs
+
+    output, context, indexcache_state = outputs[0], outputs[1], outputs[2]
+    if not _is_indexcache_recompute_topk_state(indexcache_state):
+        return outputs
+
+    indexcache_state = _clone_indexcache_recompute_state_outputs(indexcache_state)
+
+    if context is None:
+        return (output, *indexcache_state)
+    return (output, context, *indexcache_state)
+
+
+def _unpack_flattened_indexcache_recompute_outputs(outputs):
+    if not isinstance(outputs, tuple):
+        return None
+
+    if (
+        len(outputs) == 1 + _INDEXCACHE_RECOMPUTE_TOPK_STATE_LEN
+        and all(
+            isinstance(item, paddle.Tensor)
+            for item in outputs[1 : 1 + _INDEXCACHE_RECOMPUTE_TOPK_STATE_LEN]
+        )
+    ):
+        indexcache_state = _mark_indexcache_recompute_topk_state_stop_gradient(
+            outputs[1 : 1 + _INDEXCACHE_RECOMPUTE_TOPK_STATE_LEN]
+        )
+        return (
+            outputs[0],
+            None,
+            indexcache_state,
+        )
+
+    if (
+        len(outputs) == 2 + _INDEXCACHE_RECOMPUTE_TOPK_STATE_LEN
+        and all(
+            isinstance(item, paddle.Tensor)
+            for item in outputs[2 : 2 + _INDEXCACHE_RECOMPUTE_TOPK_STATE_LEN]
+        )
+    ):
+        indexcache_state = _mark_indexcache_recompute_topk_state_stop_gradient(
+            outputs[2 : 2 + _INDEXCACHE_RECOMPUTE_TOPK_STATE_LEN]
+        )
+        return (
+            outputs[0],
+            outputs[1],
+            indexcache_state,
+        )
+
+    return None
 
 
 @dataclass
@@ -596,8 +704,100 @@ class TransformerLayer(nn.Layer):
             packed_seq_params = dict_args.get("packed_seq_params", None)
             input_ids = dict_args.get("input_ids", None)
             indexcache_state = dict_args.get("indexcache_state", None)
+            indexcache_state = (
+                _mark_indexcache_recompute_topk_state_stop_gradient(
+                    indexcache_state
+                )
+                if indexcache_state is not None
+                else None
+            )
+            hidden_states = _ensure_recompute_non_leaf_tensor(hidden_states)
+            attention_mask = _ensure_recompute_non_leaf_tensor(attention_mask)
+            context = _ensure_recompute_non_leaf_tensor(context)
+            context_mask = _ensure_recompute_non_leaf_tensor(context_mask)
+            attn_mask_startend_row_indices = _ensure_recompute_non_leaf_tensor(
+                attn_mask_startend_row_indices
+            )
+            rotary_pos_emb = _ensure_recompute_non_leaf_tensor(rotary_pos_emb)
+            rotary_pos_cos = _ensure_recompute_non_leaf_tensor(rotary_pos_cos)
+            rotary_pos_sin = _ensure_recompute_non_leaf_tensor(rotary_pos_sin)
+            swa_rotary_pos_emb = _ensure_recompute_non_leaf_tensor(
+                swa_rotary_pos_emb
+            )
+            swa_rotary_pos_cos = _ensure_recompute_non_leaf_tensor(
+                swa_rotary_pos_cos
+            )
+            swa_rotary_pos_sin = _ensure_recompute_non_leaf_tensor(
+                swa_rotary_pos_sin
+            )
+            position_ids = _ensure_recompute_non_leaf_tensor(position_ids)
+            attention_bias = _ensure_recompute_non_leaf_tensor(attention_bias)
+            input_ids = _ensure_recompute_non_leaf_tensor(input_ids)
+
+            if os.environ.get("INDEXCACHE_TRAIN_DEBUG", "0") == "1":
+                print(
+                    "[INDEXCACHE_RECOMPUTE_INPUT] "
+                    f"layer_number={self.layer_number} "
+                    f"hidden_states={_describe_indexcache_recompute_input(hidden_states)} "
+                    f"attention_mask={_describe_indexcache_recompute_input(attention_mask)} "
+                    f"attn_mask_startend_row_indices={_describe_indexcache_recompute_input(attn_mask_startend_row_indices)} "
+                    f"context={_describe_indexcache_recompute_input(context)} "
+                    f"context_mask={_describe_indexcache_recompute_input(context_mask)} "
+                    f"rotary_pos_emb={_describe_indexcache_recompute_input(rotary_pos_emb)} "
+                    f"rotary_pos_cos={_describe_indexcache_recompute_input(rotary_pos_cos)} "
+                    f"rotary_pos_sin={_describe_indexcache_recompute_input(rotary_pos_sin)} "
+                    f"swa_rotary_pos_emb={_describe_indexcache_recompute_input(swa_rotary_pos_emb)} "
+                    f"swa_rotary_pos_cos={_describe_indexcache_recompute_input(swa_rotary_pos_cos)} "
+                    f"swa_rotary_pos_sin={_describe_indexcache_recompute_input(swa_rotary_pos_sin)} "
+                    f"position_ids={_describe_indexcache_recompute_input(position_ids)} "
+                    f"attention_bias={_describe_indexcache_recompute_input(attention_bias)} "
+                    f"packed_seq_params={_describe_indexcache_recompute_input(packed_seq_params)} "
+                    f"input_ids={_describe_indexcache_recompute_input(input_ids)} "
+                    f"indexcache_state={_describe_indexcache_recompute_input(indexcache_state)}",
+                    flush=True,
+                )
+
+            def _forward_impl_for_recompute(
+                hidden_states,
+                attention_mask=None,
+                attn_mask_startend_row_indices=None,
+                context=None,
+                context_mask=None,
+                rotary_pos_emb=None,
+                rotary_pos_cos=None,
+                rotary_pos_sin=None,
+                swa_rotary_pos_emb=None,
+                swa_rotary_pos_cos=None,
+                swa_rotary_pos_sin=None,
+                position_ids=None,
+                attention_bias=None,
+                packed_seq_params=None,
+                input_ids=None,
+                indexcache_state=None,
+            ):
+                return _flatten_indexcache_recompute_outputs(
+                    self._forward_impl(
+                        hidden_states=hidden_states,
+                        attention_mask=attention_mask,
+                        attn_mask_startend_row_indices=attn_mask_startend_row_indices,
+                        context=context,
+                        context_mask=context_mask,
+                        rotary_pos_emb=rotary_pos_emb,
+                        rotary_pos_cos=rotary_pos_cos,
+                        rotary_pos_sin=rotary_pos_sin,
+                        swa_rotary_pos_emb=swa_rotary_pos_emb,
+                        swa_rotary_pos_cos=swa_rotary_pos_cos,
+                        swa_rotary_pos_sin=swa_rotary_pos_sin,
+                        position_ids=position_ids,
+                        attention_bias=attention_bias,
+                        packed_seq_params=packed_seq_params,
+                        input_ids=input_ids,
+                        indexcache_state=indexcache_state,
+                    )
+                )
+
             outputs = recompute(
-                self._forward_impl,
+                _forward_impl_for_recompute,
                 hidden_states=hidden_states,
                 attention_mask=attention_mask,
                 attn_mask_startend_row_indices=attn_mask_startend_row_indices.clone()  # Clone is necessary!
@@ -635,7 +835,14 @@ class TransformerLayer(nn.Layer):
             outputs = self._forward_impl(**dict_args)
 
         indexcache_state = None
-        if isinstance(outputs, tuple):
+        flattened_indexcache_outputs = (
+            _unpack_flattened_indexcache_recompute_outputs(outputs)
+            if self.full_recompute
+            else None
+        )
+        if flattened_indexcache_outputs is not None:
+            output, context, indexcache_state = flattened_indexcache_outputs
+        elif isinstance(outputs, tuple):
             output, context = outputs[0], outputs[1]
             if len(outputs) > 2:
                 indexcache_state = outputs[2]
@@ -704,6 +911,39 @@ class TransformerLayer(nn.Layer):
         else:
             dict_args.pop("indexcache_state", None)
         rst = {**dict_args, **rst}
+        if (
+            os.environ.get("INDEXCACHE_TRAIN_DEBUG", "0") == "1"
+            and getattr(self.config, "index_topk_pattern", None)
+        ):
+            state = rst.get("indexcache_state", None)
+            if isinstance(state, (tuple, list)):
+                state_len = len(state)
+                state_shapes = [
+                    list(item.shape)
+                    if isinstance(item, paddle.Tensor)
+                    else type(item).__name__
+                    for item in state
+                ]
+                state_stop_gradients = [
+                    bool(item.stop_gradient)
+                    if isinstance(item, paddle.Tensor)
+                    else None
+                    for item in state
+                ]
+            else:
+                state_len = 0
+                state_shapes = None
+                state_stop_gradients = None
+            print(
+                "[INDEXCACHE_TRAIN_FLOW] "
+                f"layer={self.layer_number} "
+                f"full_recompute={self.full_recompute} "
+                f"flattened={flattened_indexcache_outputs is not None} "
+                f"state_len={state_len} state_shapes={state_shapes} "
+                f"state_stop_gradients={state_stop_gradients} "
+                f"keys={list(rst.keys())}",
+                flush=True,
+            )
         return rst
 
     def _forward_impl(
@@ -723,9 +963,18 @@ class TransformerLayer(nn.Layer):
         attention_bias: Tensor | None = None,
         packed_seq_params: PackedSeqParams | None = None,
         input_ids: Tensor | None = None,
+        indexcache_state: tuple | list | None = None,
         **kwargs,
     ):
-        indexcache_state = kwargs.get("indexcache_state", None)
+        if indexcache_state is None:
+            indexcache_state = kwargs.get("indexcache_state", None)
+        if _is_indexcache_recompute_topk_state(indexcache_state):
+            indexcache_state = _mark_indexcache_recompute_topk_state_stop_gradient(
+                indexcache_state
+            )
+            kwargs["indexcache_state"] = indexcache_state
+        elif indexcache_state is not None and "indexcache_state" not in kwargs:
+            kwargs["indexcache_state"] = indexcache_state
 
         def unpack_attention_outputs(attention_outputs):
             if isinstance(attention_outputs, tuple) and len(attention_outputs) == 3:

--- a/src/paddlefleet/transformer/transformer_layer.py
+++ b/src/paddlefleet/transformer/transformer_layer.py
@@ -43,6 +43,18 @@ from paddlefleet.recompute_utils import (
 )
 from paddlefleet.transformer.dsv4_hybrid_attention import DSv4HybridAttention
 from paddlefleet.transformer.identity_op import IdentityFuncOp, IdentityOp
+from paddlefleet.transformer.indexcache_state import (
+    INDEXCACHE_DISTILL_STATE_LEN,
+    INDEXCACHE_RECOMPUTE_STATE_MAX_LEN,
+    INDEXCACHE_STATE_KIND_DISTILL,
+    INDEXCACHE_STATE_KIND_TOPK_ONLY,
+    INDEXCACHE_TOPK_ONLY_STATE_LEN,
+    apply_stop_gradient_mask,
+    clone_state_outputs,
+    state_from_slots,
+    state_kind,
+    state_to_slots,
+)
 from paddlefleet.transformer.mlp import MLP
 from paddlefleet.transformer.moe.moe_layer import MoELayer
 from paddlefleet.transformer.utils import profile
@@ -59,8 +71,6 @@ if TYPE_CHECKING:
     from paddlefleet.transformer.transformer_config import TransformerConfig
 
 logger = logging.getLogger(__name__)
-
-_INDEXCACHE_RECOMPUTE_TOPK_STATE_LEN = 3
 
 
 def tensors_clone(outputs):
@@ -96,20 +106,24 @@ def tensors_clone(outputs):
         )
 
 
-def _is_indexcache_recompute_topk_state(value):
-    return (
+def _is_indexcache_recompute_state(value):
+    if not (
         isinstance(value, (tuple, list))
-        and len(value) == _INDEXCACHE_RECOMPUTE_TOPK_STATE_LEN
+        and len(value)
+        in (INDEXCACHE_TOPK_ONLY_STATE_LEN, INDEXCACHE_DISTILL_STATE_LEN)
         and all(isinstance(item, paddle.Tensor) for item in value)
+    ):
+        return False
+    return state_kind(value) in (
+        INDEXCACHE_STATE_KIND_TOPK_ONLY,
+        INDEXCACHE_STATE_KIND_DISTILL,
     )
 
 
-def _mark_indexcache_recompute_topk_state_stop_gradient(value):
-    if not _is_indexcache_recompute_topk_state(value):
+def _mark_indexcache_recompute_state_stop_gradient(value):
+    if not _is_indexcache_recompute_state(value):
         return value
-    for tensor in value:
-        tensor.stop_gradient = True
-    return tuple(value)
+    return apply_stop_gradient_mask(value)
 
 
 def _ensure_recompute_non_leaf_tensor(value):
@@ -143,9 +157,7 @@ def _describe_indexcache_recompute_input(value):
 
 
 def _clone_indexcache_recompute_state_outputs(value):
-    value = _mark_indexcache_recompute_topk_state_stop_gradient(value)
-    cloned = tuple(tensor.clone() for tensor in value)
-    return _mark_indexcache_recompute_topk_state_stop_gradient(cloned)
+    return clone_state_outputs(value)
 
 
 def _flatten_indexcache_recompute_outputs(outputs):
@@ -153,7 +165,7 @@ def _flatten_indexcache_recompute_outputs(outputs):
         return outputs
 
     output, context, indexcache_state = outputs[0], outputs[1], outputs[2]
-    if not _is_indexcache_recompute_topk_state(indexcache_state):
+    if not _is_indexcache_recompute_state(indexcache_state):
         return outputs
 
     indexcache_state = _clone_indexcache_recompute_state_outputs(indexcache_state)
@@ -168,36 +180,22 @@ def _unpack_flattened_indexcache_recompute_outputs(outputs):
         return None
 
     if (
-        len(outputs) == 1 + _INDEXCACHE_RECOMPUTE_TOPK_STATE_LEN
-        and all(
-            isinstance(item, paddle.Tensor)
-            for item in outputs[1 : 1 + _INDEXCACHE_RECOMPUTE_TOPK_STATE_LEN]
+        len(outputs) in (
+            1 + INDEXCACHE_TOPK_ONLY_STATE_LEN,
+            1 + INDEXCACHE_DISTILL_STATE_LEN,
         )
+        and all(isinstance(item, paddle.Tensor) for item in outputs[1:])
     ):
-        indexcache_state = _mark_indexcache_recompute_topk_state_stop_gradient(
-            outputs[1 : 1 + _INDEXCACHE_RECOMPUTE_TOPK_STATE_LEN]
-        )
-        return (
-            outputs[0],
-            None,
-            indexcache_state,
-        )
+        indexcache_state = apply_stop_gradient_mask(outputs[1:])
+        return outputs[0], None, indexcache_state
 
     if (
-        len(outputs) == 2 + _INDEXCACHE_RECOMPUTE_TOPK_STATE_LEN
-        and all(
-            isinstance(item, paddle.Tensor)
-            for item in outputs[2 : 2 + _INDEXCACHE_RECOMPUTE_TOPK_STATE_LEN]
-        )
+        len(outputs)
+        in (2 + INDEXCACHE_TOPK_ONLY_STATE_LEN, 2 + INDEXCACHE_DISTILL_STATE_LEN)
+        and all(isinstance(item, paddle.Tensor) for item in outputs[2:])
     ):
-        indexcache_state = _mark_indexcache_recompute_topk_state_stop_gradient(
-            outputs[2 : 2 + _INDEXCACHE_RECOMPUTE_TOPK_STATE_LEN]
-        )
-        return (
-            outputs[0],
-            outputs[1],
-            indexcache_state,
-        )
+        indexcache_state = apply_stop_gradient_mask(outputs[2:])
+        return outputs[0], outputs[1], indexcache_state
 
     return None
 
@@ -705,11 +703,13 @@ class TransformerLayer(nn.Layer):
             input_ids = dict_args.get("input_ids", None)
             indexcache_state = dict_args.get("indexcache_state", None)
             indexcache_state = (
-                _mark_indexcache_recompute_topk_state_stop_gradient(
-                    indexcache_state
-                )
+                apply_stop_gradient_mask(indexcache_state)
                 if indexcache_state is not None
                 else None
+            )
+            indexcache_state_slots = state_to_slots(indexcache_state)
+            assert (
+                len(indexcache_state_slots) == INDEXCACHE_RECOMPUTE_STATE_MAX_LEN
             )
             hidden_states = _ensure_recompute_non_leaf_tensor(hidden_states)
             attention_mask = _ensure_recompute_non_leaf_tensor(attention_mask)
@@ -773,8 +773,27 @@ class TransformerLayer(nn.Layer):
                 attention_bias=None,
                 packed_seq_params=None,
                 input_ids=None,
-                indexcache_state=None,
+                indexcache_state_0=None,
+                indexcache_state_1=None,
+                indexcache_state_2=None,
+                indexcache_state_3=None,
+                indexcache_state_4=None,
+                indexcache_state_5=None,
+                indexcache_state_6=None,
+                indexcache_state_7=None,
             ):
+                indexcache_state = state_from_slots(
+                    (
+                        indexcache_state_0,
+                        indexcache_state_1,
+                        indexcache_state_2,
+                        indexcache_state_3,
+                        indexcache_state_4,
+                        indexcache_state_5,
+                        indexcache_state_6,
+                        indexcache_state_7,
+                    )
+                )
                 return _flatten_indexcache_recompute_outputs(
                     self._forward_impl(
                         hidden_states=hidden_states,
@@ -829,7 +848,14 @@ class TransformerLayer(nn.Layer):
                 attention_bias=attention_bias,
                 packed_seq_params=packed_seq_params,
                 input_ids=input_ids,
-                indexcache_state=indexcache_state,
+                indexcache_state_0=indexcache_state_slots[0],
+                indexcache_state_1=indexcache_state_slots[1],
+                indexcache_state_2=indexcache_state_slots[2],
+                indexcache_state_3=indexcache_state_slots[3],
+                indexcache_state_4=indexcache_state_slots[4],
+                indexcache_state_5=indexcache_state_slots[5],
+                indexcache_state_6=indexcache_state_slots[6],
+                indexcache_state_7=indexcache_state_slots[7],
             )
         else:
             outputs = self._forward_impl(**dict_args)
@@ -968,8 +994,8 @@ class TransformerLayer(nn.Layer):
     ):
         if indexcache_state is None:
             indexcache_state = kwargs.get("indexcache_state", None)
-        if _is_indexcache_recompute_topk_state(indexcache_state):
-            indexcache_state = _mark_indexcache_recompute_topk_state_stop_gradient(
+        if _is_indexcache_recompute_state(indexcache_state):
+            indexcache_state = _mark_indexcache_recompute_state_stop_gradient(
                 indexcache_state
             )
             kwargs["indexcache_state"] = indexcache_state

--- a/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_router.py
+++ b/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_router.py
@@ -548,6 +548,7 @@ class TestHashRouter(unittest.TestCase):
         self.assertTrue(router.is_hash_layer)
         self.assertIsNotNone(router.tid2eid)
         self.assertEqual(list(router.tid2eid.shape), [16, 2])
+        self.assertEqual(router.tid2eid.dtype, paddle.int32)
         # Round-robin placeholder: tid2eid[i, k] = (i + k) % num_experts.
         ids = np.arange(16)
         expected = np.stack([(ids + k) % 4 for k in range(2)], axis=1)

--- a/tests/single_card_tests/test_indexcache_pp_runtime_patch.py
+++ b/tests/single_card_tests/test_indexcache_pp_runtime_patch.py
@@ -14,7 +14,11 @@ from paddle.distributed.fleet.meta_parallel.pp_utils.p2p_communication import (
 )
 
 import paddlefleet  # noqa: F401 - installs the IndexCache pipeline patch
-from paddlefleet.indexcache_pp_runtime_patch import _dict_to_tuple_helper
+from paddlefleet.indexcache_pp_runtime_patch import (
+    _dict_to_tuple_helper,
+    _normalize_pipeline_input_gradients,
+    _tuple_to_dict_helper,
+)
 
 
 def _make_distill_state(offset):
@@ -88,6 +92,71 @@ class TestIndexCachePipelineBackward(unittest.TestCase):
             "missing a gradient outside IndexCache state",
         ):
             node.backward(output_grads)
+
+    def test_outer_pipeline_boundary_uses_sendable_zero_gradients(self):
+        pipeline_inputs = _dict_to_tuple_helper(
+            {
+                "hidden_states": paddle.to_tensor(
+                    [4.0], stop_gradient=False
+                ),
+                "indexcache_state": _make_distill_state(0),
+            }
+        )
+        converted_inputs, use_dict = _tuple_to_dict_helper(pipeline_inputs)
+
+        self.assertTrue(use_dict)
+        self.assertIn("indexcache_state", converted_inputs)
+        self.assertTrue(all(not hasattr(tensor, "key") for tensor in pipeline_inputs))
+
+        hidden_grad = paddle.ones_like(pipeline_inputs[0])
+        hidden_grad.stop_gradient = False
+        input_grads = _normalize_pipeline_input_gradients(
+            pipeline_inputs,
+            (hidden_grad, None, None, None),
+        )
+
+        self.assertEqual(len(input_grads), 4)
+        self.assertTrue(all(isinstance(grad, paddle.Tensor) for grad in input_grads))
+        self.assertTrue(all(not grad.stop_gradient for grad in input_grads))
+        self.assertEqual(input_grads[0].item(), 1.0)
+        for grad in input_grads[1:]:
+            self.assertEqual(grad.item(), 0.0)
+
+        meta = SendRecvMeta()
+        meta.set_send_message(input_grads)
+        self.assertEqual(len(meta.send_shape_message), 4)
+
+    def test_outer_pipeline_boundary_preserves_baseline_none_gradient(self):
+        hidden = paddle.to_tensor([4.0], stop_gradient=False)
+        unused = paddle.to_tensor([5.0], stop_gradient=False)
+        input_grads = (paddle.ones_like(hidden), None)
+
+        normalized = _normalize_pipeline_input_gradients(
+            (hidden, unused),
+            input_grads,
+        )
+
+        self.assertIs(normalized, input_grads)
+
+    def test_outer_pipeline_boundary_rejects_missing_hidden_gradient(self):
+        pipeline_inputs = _dict_to_tuple_helper(
+            {
+                "hidden_states": paddle.to_tensor(
+                    [4.0], stop_gradient=False
+                ),
+                "indexcache_state": _make_distill_state(0),
+            }
+        )
+        _tuple_to_dict_helper(pipeline_inputs)
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "missing a gradient outside IndexCache state",
+        ):
+            _normalize_pipeline_input_gradients(
+                pipeline_inputs,
+                (None, None, None, None),
+            )
 
 
 if __name__ == "__main__":

--- a/tests/single_card_tests/test_indexcache_pp_runtime_patch.py
+++ b/tests/single_card_tests/test_indexcache_pp_runtime_patch.py
@@ -16,6 +16,7 @@ from paddle.distributed.fleet.meta_parallel.pp_utils.p2p_communication import (
 import paddlefleet  # noqa: F401 - installs the IndexCache pipeline patch
 from paddlefleet.indexcache_pp_runtime_patch import (
     _dict_to_tuple_helper,
+    _get_pipeline_key,
     _normalize_pipeline_input_gradients,
     _tuple_to_dict_helper,
 )
@@ -137,6 +138,51 @@ class TestIndexCachePipelineBackward(unittest.TestCase):
         )
 
         self.assertIs(normalized, input_grads)
+
+    def test_outer_pipeline_boundary_handles_released_state(self):
+        pipeline_inputs = _dict_to_tuple_helper(
+            {
+                "hidden_states": paddle.to_tensor(
+                    [4.0], stop_gradient=False
+                ),
+                "indexcache_state": _make_distill_state(0),
+            }
+        )
+        _tuple_to_dict_helper(pipeline_inputs)
+        released_inputs = [
+            tensor
+            for tensor in pipeline_inputs
+            if _get_pipeline_key(tensor)
+            in {
+                "indexcache_state 1",
+                "indexcache_state 2",
+                "indexcache_state 3",
+            }
+        ]
+        expected_metadata = [
+            (list(tensor.shape), tensor.dtype) for tensor in released_inputs
+        ]
+        for tensor in released_inputs:
+            tensor._clear_dataptr()
+
+        hidden_grad = paddle.ones_like(pipeline_inputs[0])
+        hidden_grad.stop_gradient = False
+        input_grads = _normalize_pipeline_input_gradients(
+            pipeline_inputs,
+            (hidden_grad, None, None, None),
+        )
+
+        self.assertEqual(len(released_inputs), 3)
+        self.assertEqual(len(input_grads), 4)
+        for grad, (shape, dtype) in zip(input_grads[1:], expected_metadata):
+            self.assertEqual(list(grad.shape), shape)
+            self.assertEqual(grad.dtype, dtype)
+            self.assertFalse(grad.stop_gradient)
+            self.assertEqual(float(grad.sum().item()), 0.0)
+
+        meta = SendRecvMeta()
+        meta.set_send_message(input_grads)
+        self.assertEqual(len(meta.send_shape_message), 4)
 
     def test_outer_pipeline_boundary_rejects_missing_hidden_gradient(self):
         pipeline_inputs = _dict_to_tuple_helper(

--- a/tests/single_card_tests/test_indexcache_pp_runtime_patch.py
+++ b/tests/single_card_tests/test_indexcache_pp_runtime_patch.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+import unittest
+
+import paddle
+from paddle.distributed.fleet.meta_parallel.pp_utils.forward_backward_overlap_utils import (
+    ScheduleNode,
+)
+from paddle.distributed.fleet.meta_parallel.pp_utils.p2p_communication import (
+    SendRecvMeta,
+)
+
+import paddlefleet  # noqa: F401 - installs the IndexCache pipeline patch
+from paddlefleet.indexcache_pp_runtime_patch import _dict_to_tuple_helper
+
+
+def _make_distill_state(offset):
+    return (
+        paddle.to_tensor([offset], dtype="int64"),
+        paddle.to_tensor([1.0 + offset], stop_gradient=False),
+        paddle.to_tensor([2.0 + offset], stop_gradient=False),
+        paddle.to_tensor([3.0 + offset], stop_gradient=False),
+        paddle.to_tensor([offset], dtype="int64"),
+        paddle.to_tensor([0.5 + offset]),
+        paddle.to_tensor([offset], dtype="int64"),
+        paddle.to_tensor([0], dtype="int64"),
+    )
+
+
+class TestIndexCachePipelineBackward(unittest.TestCase):
+    def test_replaced_distill_state_uses_sendable_zero_gradients(self):
+        old_state = _make_distill_state(0)
+        new_state = _make_distill_state(10)
+        node = ScheduleNode(
+            lambda inputs: {
+                "hidden": inputs["hidden"] * 2,
+                "indexcache_state": new_state,
+            },
+            name="replace_indexcache_producer",
+        )
+
+        outputs = node.forward(
+            {
+                "hidden": paddle.to_tensor([4.0], stop_gradient=False),
+                "indexcache_state": old_state,
+            }
+        )
+        output_grads = tuple(
+            paddle.ones_like(tensor)
+            for tensor in _dict_to_tuple_helper(outputs)
+            if not tensor.stop_gradient
+        )
+        input_grads = node.backward(output_grads)
+
+        self.assertEqual(len(input_grads), 4)
+        self.assertTrue(all(isinstance(grad, paddle.Tensor) for grad in input_grads))
+        self.assertTrue(all(not grad.stop_gradient for grad in input_grads))
+        self.assertEqual(input_grads[0].item(), 2.0)
+        for grad in input_grads[1:]:
+            self.assertEqual(grad.item(), 0.0)
+
+        meta = SendRecvMeta()
+        meta.set_send_message(input_grads)
+        self.assertEqual(len(meta.send_shape_message), 4)
+
+    def test_missing_non_indexcache_gradient_fails_fast(self):
+        node = ScheduleNode(
+            lambda inputs: {"hidden": inputs["hidden"] * 2},
+            name="drop_regular_pipeline_input",
+        )
+        outputs = node.forward(
+            {
+                "hidden": paddle.to_tensor([4.0], stop_gradient=False),
+                "unused": paddle.to_tensor([5.0], stop_gradient=False),
+            }
+        )
+        output_grads = tuple(
+            paddle.ones_like(tensor)
+            for tensor in _dict_to_tuple_helper(outputs)
+            if not tensor.stop_gradient
+        )
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "missing a gradient outside IndexCache state",
+        ):
+            node.backward(output_grads)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add DSV4 IndexCache F/S pattern configuration, validation, producer/reuse flow, and non-uniform pattern support
- carry explicit IndexCache state across PP/CP boundaries, including FSF handoff
- support reuse-only and multi-layer distillation with full/uniform recompute
- preserve producer gradients through schedule and outer pipeline backward boundaries, including missing or released metadata cases
- add training safeguards for frozen/indexer-only paths, custom backward behavior, debug visibility, and invalid state
- keep checkpoint routing-table dtype compatible with the current training and resume path

## Baseline

- base branch: `PaddlePaddle/PaddleFleet:release/0.3`
- validated base commit: `4dd81f92437e120208e7814267622617add3054b`
- current head commit: `10fd153843c6c14a7cae7a72084fc86c16feafa8`

The upstream `release/0.3` branch has advanced by three commits since this validated base. This draft intentionally preserves the tested history while the change is reviewed.

## Scope

- 10 commits
- 13 changed files
- 2,353 insertions and 271 deletions

The stack is intentionally left unsquashed in this draft so the evolution from basic F/S reuse through recompute and PP-gradient fixes remains reviewable.

## Validation

- `git diff --check 4dd81f9..10fd153`
- focused IndexCache PP runtime suite: `6 passed`
- downstream single-node 4/8-GPU training regressions, including a 36-step soak
- downstream 16-node/64-GPU two-step RL training and full-state checkpoint resume validation

## Upstream synchronization note

GitHub currently reports one content conflict with the three newer `release/0.3` commits:

- `src/paddlefleet/transformer/transformer_layer.py`

It is intentionally left unresolved in this Draft so the validated `10fd153` stack remains unchanged. The conflict should be resolved and the relevant validation repeated before this PR is made ready for final submission.

## Review status

This remains a Draft PR for inspecting the complete current integration. Commit cleanup, upstream-base synchronization, and any requested split into smaller PRs are intentionally deferred until the review direction is clear.