### PR TITLE
[EP] Set `NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN` automatically

### DIFF
--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -433,6 +433,23 @@ class MoELayer(nn.Layer):
 
         if self.expert_model_parallel_size > 1:
             if self.moe_token_dispatcher_type in ("deepep", "hybridep"):
+                # Set NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN automatically if not set by user.
+                if (
+                    self.moe_token_dispatcher_type == "hybridep"
+                    and os.getenv("NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN")
+                    is None
+                ):
+                    # We limit the default domain size to 64 due to NVL72 topology. If user wants to use
+                    # a larger domain size, they can set the environment variable manually.
+                    num_of_hybrid_ep_ranks_per_nvlink_domain = min(
+                        self.expert_model_parallel_size, 64
+                    )
+                    os.environ["NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN"] = (
+                        str(num_of_hybrid_ep_ranks_per_nvlink_domain)
+                    )
+                    logger.info(
+                        "Automatically set NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN=%d for hybrid EP backend.",
+                    )
                 self.token_dispatcher = MoEFlexTokenDispatcher(
                     self.num_experts_per_device,
                     self.num_experts_per_tok,

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -449,6 +449,7 @@ class MoELayer(nn.Layer):
                     )
                     logger.info(
                         "Automatically set NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN=%d for hybrid EP backend.",
+                        num_of_hybrid_ep_ranks_per_nvlink_domain,
                     )
                 self.token_dispatcher = MoEFlexTokenDispatcher(
                     self.num_experts_per_device,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->

Distributed Strategy

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Improvements

### Description
<!-- Describe what you’ve done -->

自动根据 ep size 设置 `NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN`，避免每次都必须手动设置

- 当用户需要自行指定 `NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN` 时，仍然可以设置该环境变量
- 当用户未设定时，会自动设定：
  - 当 ep size <= 64 时，设定为 ep size
  - 否则设定为 64

这对于 EP 8、EP 16、EP 32、EP 64、EP 128 等常见情况默认就是最佳配置，无需手动配置

如需测试一些极端场景，仍然可以手动设置 `NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN` 来实现

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->

否