### PR TITLE
[DSV4] Fix hash router empty layer offset

### DIFF
--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -1764,11 +1764,12 @@ class CompressedSparseAttention(FleetLayer):
         super().__init__(config)
         DSAIndexerLossLoggingHelper.register_total_num_layers(config)
         self.config = config
-        self.layer_number = layer_number - (
-            0 if is_mtp_layer else self.config.num_empty_layers_add_in_head
-        )
         if is_mtp_layer:
-            self.layer_number += self.config.num_hidden_layers + 1
+            self.layer_number = layer_number + self.config.num_hidden_layers + 1
+        else:
+            self.layer_number = (
+                layer_number - self.config.num_empty_layers_add_in_head + 1
+            )
         self.pg_collection = pg_collection
         tp_size = int(getattr(config, "tensor_model_parallel_size", 1))
         if pg_collection is not None and pg_collection.tp is not None:

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -1764,11 +1764,13 @@ class CompressedSparseAttention(FleetLayer):
         super().__init__(config)
         DSAIndexerLossLoggingHelper.register_total_num_layers(config)
         self.config = config
-        self.layer_number = layer_number + 1
+        self.layer_number = layer_number
         if is_mtp_layer:
-            self.layer_number += self.config.num_hidden_layers
+            self.layer_number += self.config.num_hidden_layers + 1
         else:
-            self.layer_number -= self.config.num_empty_layers_add_in_head
+            self.layer_number = (
+                layer_number - self.config.num_empty_layers_add_in_head + 1
+            )
         self.pg_collection = pg_collection
         tp_size = int(getattr(config, "tensor_model_parallel_size", 1))
         if pg_collection is not None and pg_collection.tp is not None:

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -1769,7 +1769,9 @@ class CompressedSparseAttention(FleetLayer):
             self.layer_number += self.config.num_hidden_layers + 1
         else:
             self.layer_number = (
-                layer_number - getattr(self.config, "num_empty_layers_add_in_head", 0) + 1
+                layer_number
+                - getattr(self.config, "num_empty_layers_add_in_head", 0)
+                + 1
             )
         self.pg_collection = pg_collection
         tp_size = int(getattr(config, "tensor_model_parallel_size", 1))

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -1764,12 +1764,11 @@ class CompressedSparseAttention(FleetLayer):
         super().__init__(config)
         DSAIndexerLossLoggingHelper.register_total_num_layers(config)
         self.config = config
+        self.layer_number = layer_number + 1
         if is_mtp_layer:
-            self.layer_number = layer_number + self.config.num_hidden_layers + 1
+            self.layer_number += self.config.num_hidden_layers
         else:
-            self.layer_number = (
-                layer_number - self.config.num_empty_layers_add_in_head + 1
-            )
+            self.layer_number -= self.config.num_empty_layers_add_in_head
         self.pg_collection = pg_collection
         tp_size = int(getattr(config, "tensor_model_parallel_size", 1))
         if pg_collection is not None and pg_collection.tp is not None:

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -1764,7 +1764,9 @@ class CompressedSparseAttention(FleetLayer):
         super().__init__(config)
         DSAIndexerLossLoggingHelper.register_total_num_layers(config)
         self.config = config
-        self.layer_number = layer_number
+        self.layer_number = layer_number - (
+            0 if is_mtp_layer else self.config.num_empty_layers_add_in_head
+        )
         if is_mtp_layer:
             self.layer_number += self.config.num_hidden_layers + 1
         self.pg_collection = pg_collection

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -1767,12 +1767,6 @@ class CompressedSparseAttention(FleetLayer):
         self.layer_number = layer_number
         if is_mtp_layer:
             self.layer_number += self.config.num_hidden_layers + 1
-        else:
-            self.layer_number = (
-                layer_number
-                - getattr(self.config, "num_empty_layers_add_in_head", 0)
-                + 1
-            )
         self.pg_collection = pg_collection
         tp_size = int(getattr(config, "tensor_model_parallel_size", 1))
         if pg_collection is not None and pg_collection.tp is not None:

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -1769,7 +1769,7 @@ class CompressedSparseAttention(FleetLayer):
             self.layer_number += self.config.num_hidden_layers + 1
         else:
             self.layer_number = (
-                layer_number - self.config.num_empty_layers_add_in_head + 1
+                layer_number - getattr(self.config, "num_empty_layers_add_in_head", 0) + 1
             )
         self.pg_collection = pg_collection
         tp_size = int(getattr(config, "tensor_model_parallel_size", 1))

--- a/src/paddlefleet/transformer/dsa_attention.py
+++ b/src/paddlefleet/transformer/dsa_attention.py
@@ -1095,9 +1095,10 @@ class DSAIndexerLossLoggingHelper:
 
     @staticmethod
     def register_total_num_layers(config):
-        DSAIndexerLossLoggingHelper.num_layers = (
-            DSAIndexerLossLoggingHelper.get_total_num_layers(config)
-        )
+        num_layers = DSAIndexerLossLoggingHelper.get_total_num_layers(config)
+        if DSAIndexerLossLoggingHelper.num_layers != num_layers:
+            DSAIndexerLossLoggingHelper.tracker.clear()
+        DSAIndexerLossLoggingHelper.num_layers = num_layers
 
     @staticmethod
     def save_loss_to_tracker(

--- a/src/paddlefleet/transformer/dsv4_hybrid_attention.py
+++ b/src/paddlefleet/transformer/dsv4_hybrid_attention.py
@@ -258,7 +258,7 @@ class DSv4HybridAttention(Attention):
         self.core_attention = build_spec_layer(
             sublayers_spec.core_attention,
             config=config,
-            layer_number=layer_number,
+            layer_number=layer_number if is_mtp_layer else layer_idx + 1,
             attn_mask_type=attn_mask_type,
             attention_type=attention_type,
             attention_dropout=None,

--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -984,11 +984,20 @@ class StandardMoERouter(nn.Layer):
           on hash layers.
         """
         n_hash = getattr(self.config, "moe_n_hash_layers", 0)
+        head_empty_layers = getattr(
+            self.config, "num_empty_layers_add_in_head", 0
+        )
+        logical_layer_number = (
+            None
+            if layer_number is None or is_mtp_layer
+            else layer_number - head_empty_layers
+        )
         self.is_hash_layer = (
             not is_mtp_layer
             and n_hash > 0
-            and layer_number is not None
-            and layer_number < n_hash
+            and logical_layer_number is not None
+            and logical_layer_number >= 0
+            and logical_layer_number < n_hash
         )
         # Enforce the split-feature routing contract now that is_hash_layer is
         # known. Split routing only applies to non-hash layers (hash layers

--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -983,11 +983,12 @@ class StandardMoERouter(nn.Layer):
         - Disables expert-bias state (e_score_correction_bias / expert_usage)
           on hash layers.
         """
-        n_hash = self.config.moe_n_hash_layers
+        n_hash = getattr(self.config, "moe_n_hash_layers", 0)
+        head_empty_layers = getattr(
+            self.config, "num_empty_layers_add_in_head", 0
+        )
         logical_layer_number = (
-            None
-            if layer_number is None
-            else layer_number - self.config.num_empty_layers_add_in_head
+            None if layer_number is None else layer_number - head_empty_layers
         )
         self.is_hash_layer = (
             not is_mtp_layer

--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -983,21 +983,17 @@ class StandardMoERouter(nn.Layer):
         - Disables expert-bias state (e_score_correction_bias / expert_usage)
           on hash layers.
         """
-        n_hash = getattr(self.config, "moe_n_hash_layers", 0)
-        head_empty_layers = getattr(
-            self.config, "num_empty_layers_add_in_head", 0
-        )
+        n_hash = self.config.moe_n_hash_layers
         logical_layer_number = (
             None
-            if layer_number is None or is_mtp_layer
-            else layer_number - head_empty_layers
+            if layer_number is None
+            else layer_number - self.config.num_empty_layers_add_in_head
         )
         self.is_hash_layer = (
             not is_mtp_layer
             and n_hash > 0
             and logical_layer_number is not None
-            and logical_layer_number >= 0
-            and logical_layer_number < n_hash
+            and 0 <= logical_layer_number < n_hash
         )
         # Enforce the split-feature routing contract now that is_hash_layer is
         # known. Split routing only applies to non-hash layers (hash layers

--- a/tests/single_card_tests/transformer/test_dsa_attention.py
+++ b/tests/single_card_tests/transformer/test_dsa_attention.py
@@ -981,6 +981,16 @@ class TestDSAIndexerLossLoggingHelperReduce(unittest.TestCase):
             DSAIndexerLossLoggingHelper.get_total_num_layers(config), 4
         )
 
+    def test_register_total_num_layers_clears_stale_tracker(self):
+        DSAIndexerLossLoggingHelper.num_layers = 1
+        DSAIndexerLossLoggingHelper.tracker["values"] = paddle.zeros([1])
+        config = SimpleNamespace(num_hidden_layers=4, mtp_num_layers=0)
+
+        DSAIndexerLossLoggingHelper.register_total_num_layers(config)
+
+        self.assertEqual(DSAIndexerLossLoggingHelper.num_layers, 4)
+        self.assertEqual(DSAIndexerLossLoggingHelper.tracker, {})
+
     @patch("paddlefleet.transformer.dsa_attention.parallel_state")
     def test_reduce_empty_tracker_with_num_layers_joins_pp_reduce(
         self, mock_ps

--- a/tests/single_card_tests/transformer/test_router.py
+++ b/tests/single_card_tests/transformer/test_router.py
@@ -166,6 +166,23 @@ class TestTopKRouter(unittest.TestCase):
         self.assertFalse(hasattr(router_greedy, "e_score_correction_bias"))
         self.assertFalse(hasattr(router_greedy, "expert_usage"))
 
+    def test_hash_layer_respects_head_empty_layer_offset(self):
+        self.config.topk_method = "noaux_tc"
+        self.config.moe_n_hash_layers = 1
+        self.config.num_empty_layers_add_in_head = 2
+        self.config.actual_vocab_size = 16
+
+        router = TopKRouter(self.config)
+        router.set_layer_number(2)
+        self.assertTrue(router.is_hash_layer)
+        self.assertIsNotNone(router.tid2eid)
+        self.assertFalse(hasattr(router, "e_score_correction_bias"))
+
+        router = TopKRouter(self.config)
+        router.set_layer_number(1)
+        self.assertFalse(router.is_hash_layer)
+        self.assertIsNone(router.tid2eid)
+
     def test_call_topk_method_directly(self):
         """
         Directly test `_call_topk_method` to ensure it returns a tuple (gate, idx).

--- a/tests/single_card_tests/transformer/test_router.py
+++ b/tests/single_card_tests/transformer/test_router.py
@@ -60,8 +60,6 @@ class MockTransformerConfig:
         self.tensor_model_parallel_size = 1
         self.context_parallel_size = 1
         self.sequence_parallel = False
-        self.moe_n_hash_layers = 0
-        self.num_empty_layers_add_in_head = 0
 
         # Experimental version flag
         self.gpt_model_use_experimental_version = False

--- a/tests/single_card_tests/transformer/test_router.py
+++ b/tests/single_card_tests/transformer/test_router.py
@@ -60,6 +60,8 @@ class MockTransformerConfig:
         self.tensor_model_parallel_size = 1
         self.context_parallel_size = 1
         self.sequence_parallel = False
+        self.moe_n_hash_layers = 0
+        self.num_empty_layers_add_in_head = 0
 
         # Experimental version flag
         self.gpt_model_use_experimental_version = False


### PR DESCRIPTION
### PR Category
Distributed Strategy

### PR Types
Bug fixes

### Description
- 修复 DSV4 hash router 的层号判断：确定物理 MoE 层是否属于逻辑 hash-routing 前缀时，计入 `num_empty_layers_add_in_head`。
- 启用头部空层时，将 CSA DSA loss tracker 的索引转换为逻辑主干层号。
- 保持 MTP tracker 的原有映射，同时避免头部空层被误判为 hash-routing 层。

启用头部空层后，物理层号与 DSV4 逻辑层号不再一致。如果不进行转换，hash router 可能错误识别层类型，CSA 也可能访问超出已注册范围的 DSA loss tracker。

### 是否引起精度变化
否