### PR TITLE
fix notify script download in pr update ops

### DIFF
--- a/.github/workflows/pr_update_ops.yml
+++ b/.github/workflows/pr_update_ops.yml
@@ -593,7 +593,8 @@ jobs:
         run: |
           set -e
           python -m pip install requests
-          wget https://paddle-qa.bj.bcebos.com/paddleformers/notify_paddle_link.py
+          rm -rf notify_paddle_link.py*
+          wget -O notify_paddle_link.py https://paddle-qa.bj.bcebos.com/paddleformers/notify_paddle_link.py
           WHEEL_FILE=$(cat "${{ matrix.flavor.name_key }}")
           echo "Notify paddletest for ${WHEEL_FILE} (${{ matrix.flavor.bos_CUDA }})"
           python notify_paddle_link.py ${{ matrix.flavor.bos_CUDA }} ${WHEEL_FILE} paddlefleet-ops

--- a/ci/check_ce_precision.sh
+++ b/ci/check_ce_precision.sh
@@ -16,7 +16,7 @@ case_name=$1
 base_name=$2
 update_baseline=${3:-"false"}
 
-if [[ $BRANCH == "develop" ]]; then
+if [[ "$formers_branch" == "develop" ]]; then
     base_name="${base_name}_develop"
 fi
 case_gt_file=${base_name}_${case_name}_gt.txt
@@ -26,7 +26,22 @@ if [[ ! -f "${case_name}.txt" && "$case_name" == *glm* ]]; then
 fi
 
 if [[ "$update_baseline" == "true" ]]; then
-    cp ${case_name}.txt ${case_gt_file}
+    python -c "
+import sys
+sys.path.insert(0, 'PaddleFormers/tests/integration_test')
+from check_loss import parse_log_file
+d = parse_log_file('${case_name}.txt')
+if not d:
+    sys.exit('No step/loss extracted from ${case_name}.txt')
+with open('${case_gt_file}', 'w') as f:
+    for s in sorted(d):
+        f.write(f'{s} {d[s]}\n')
+"
+    exit_code=$?
+    if [ $exit_code -ne 0 ]; then
+        echo "Failed to extract baseline from ${case_name}.txt"
+        exit $exit_code
+    fi
     echo "Update baseline: ${case_gt_file}"
     wget -q --no-proxy --no-check-certificate \
         https://paddle-qa.bj.bcebos.com/CodeSync/develop/PaddlePaddle/PaddleTest/tools/bos_tools.py \

--- a/ci/check_ce_precision.sh
+++ b/ci/check_ce_precision.sh
@@ -16,7 +16,7 @@ case_name=$1
 base_name=$2
 update_baseline=${3:-"false"}
 
-if [[ $BRANCH == "develop" ]]; then
+if [[ "$BRANCH" == "develop" ]]; then
     base_name="${base_name}_develop"
 fi
 case_gt_file=${base_name}_${case_name}_gt.txt
@@ -26,17 +26,10 @@ if [[ ! -f "${case_name}.txt" && "$case_name" == *glm* ]]; then
 fi
 
 if [[ "$update_baseline" == "true" ]]; then
-    python -c "
-import sys
-sys.path.insert(0, 'PaddleFormers/tests/integration_test')
-from check_loss import parse_log_file
-d = parse_log_file('${case_name}.txt')
-if not d:
-    sys.exit('No step/loss extracted from ${case_name}.txt')
-with open('${case_gt_file}', 'w') as f:
-    for s in sorted(d):
-        f.write(f'{s} {d[s]}\n')
-"
+    python PaddleFormers/tests/integration_test/check_loss.py \
+        --log_file ${case_name}.txt \
+        --log_loss_file ${case_gt_file} \
+        --extract_loss_only
     exit_code=$?
     if [ $exit_code -ne 0 ]; then
         echo "Failed to extract baseline from ${case_name}.txt"

--- a/ci/check_ce_precision.sh
+++ b/ci/check_ce_precision.sh
@@ -16,7 +16,7 @@ case_name=$1
 base_name=$2
 update_baseline=${3:-"false"}
 
-if [[ "$formers_branch" == "develop" ]]; then
+if [[ $BRANCH == "develop" ]]; then
     base_name="${base_name}_develop"
 fi
 case_gt_file=${base_name}_${case_name}_gt.txt


### PR DESCRIPTION
### PR Category
Execute Infrastructure
### PR Types
Bug fixes
### Description
- Update `.github/workflows/pr_update_ops.yml` to remove stale `notify_paddle_link.py*` files before downloading and force `wget` to write `notify_paddle_link.py`.
- Update `ci/check_ce_precision.sh` so CE baseline naming follows the PaddleFormers branch and update-baseline mode writes normalized step/loss ground truth via `parse_log_file`.