### PR TITLE
[HySparse] Add MHA + SWA TileLang attention ops (MQA Dv generalization)

### DIFF
--- a/src/paddlefleet/tilelang_ops/hysparse/__init__.py
+++ b/src/paddlefleet/tilelang_ops/hysparse/__init__.py
@@ -24,19 +24,27 @@ from .block_score_attn import (
     block_scores_from_logit,
 )
 from .block_score_attn_bwd import block_score_mqa_bwd_interface
+from .block_score_attn_mha import block_score_mha_attn_fwd
+from .block_score_attn_mha_bwd import block_score_mha_bwd_interface
 from .block_sparse_attn_mqa import block_sparse_mqa_attn_fwd
 from .block_sparse_attn_mqa_bwd import block_sparse_mqa_bwd_interface
 from .pipeline import (
     hysparse_forward_mqa,
     select_topk_blocks,
 )
+from .swa_attn import (
+    sliding_window_mqa_attention,
+)
 
 __all__ = [
     "block_score_mqa_attn_fwd",
     "block_scores_from_logit",
     "block_score_mqa_bwd_interface",
+    "block_score_mha_attn_fwd",
+    "block_score_mha_bwd_interface",
     "block_sparse_mqa_attn_fwd",
     "block_sparse_mqa_bwd_interface",
     "hysparse_forward_mqa",
     "select_topk_blocks",
+    "sliding_window_mqa_attention",
 ]

--- a/src/paddlefleet/tilelang_ops/hysparse/__init__.py
+++ b/src/paddlefleet/tilelang_ops/hysparse/__init__.py
@@ -28,6 +28,15 @@ from .block_score_attn_mha import block_score_mha_attn_fwd
 from .block_score_attn_mha_bwd import block_score_mha_bwd_interface
 from .block_sparse_attn_mqa import block_sparse_mqa_attn_fwd
 from .block_sparse_attn_mqa_bwd import block_sparse_mqa_bwd_interface
+from .differentiable_ops import (
+    BlockScoreMHAAttn,
+    BlockScoreMQAAttn,
+    BlockSparseMQAAttn,
+    block_score_mha_attention,
+    block_score_mqa_attention,
+    block_sparse_mqa_attention,
+    hysparse_mqa_attention,
+)
 from .pipeline import (
     hysparse_forward_mqa,
     select_topk_blocks,
@@ -44,6 +53,13 @@ __all__ = [
     "block_score_mha_bwd_interface",
     "block_sparse_mqa_attn_fwd",
     "block_sparse_mqa_bwd_interface",
+    "BlockScoreMQAAttn",
+    "BlockScoreMHAAttn",
+    "BlockSparseMQAAttn",
+    "block_score_mqa_attention",
+    "block_score_mha_attention",
+    "block_sparse_mqa_attention",
+    "hysparse_mqa_attention",
     "hysparse_forward_mqa",
     "select_topk_blocks",
     "sliding_window_mqa_attention",

--- a/src/paddlefleet/tilelang_ops/hysparse/autograd.py
+++ b/src/paddlefleet/tilelang_ops/hysparse/autograd.py
@@ -56,6 +56,13 @@ class BlockScoreMQAAttn(paddle.autograd.PyLayer):
         ctx.save_for_backward(q, k, v, out, lse, valid_range)
         ctx.sm_scale = sm_scale
         ctx.block_B = block_B
+        # PyLayer contract: backward must return None for any input whose
+        # stop_gradient=True (frozen / detached), a Tensor otherwise.
+        ctx.needs_grad = (
+            not q.stop_gradient,
+            not k.stop_gradient,
+            not v.stop_gradient,
+        )
         # lse / block_logit feed a non-differentiable TopK -> no gradient.
         ctx.mark_non_differentiable(lse, block_logit)
         return out, lse, block_logit
@@ -74,7 +81,14 @@ class BlockScoreMQAAttn(paddle.autograd.PyLayer):
             sm_scale=ctx.sm_scale,
             block_B=ctx.block_B,
         )
-        return dq, dk, dv
+        gq, gk, gv = ctx.needs_grad
+        # one entry per Tensor input: q, k, v, valid_range (last has no grad).
+        return (
+            dq if gq else None,
+            dk if gk else None,
+            dv if gv else None,
+            None,
+        )
 
 
 class BlockSparseMQAAttn(paddle.autograd.PyLayer):
@@ -94,6 +108,11 @@ class BlockSparseMQAAttn(paddle.autograd.PyLayer):
         ctx.save_for_backward(q, k, v, out, lse, indices, valid_range)
         ctx.sm_scale = sm_scale
         ctx.block_B = block_B
+        ctx.needs_grad = (
+            not q.stop_gradient,
+            not k.stop_gradient,
+            not v.stop_gradient,
+        )
         ctx.mark_non_differentiable(lse)
         return out, lse
 
@@ -112,7 +131,16 @@ class BlockSparseMQAAttn(paddle.autograd.PyLayer):
             sm_scale=ctx.sm_scale,
             block_B=ctx.block_B,
         )
-        return dq, dk, dv
+        gq, gk, gv = ctx.needs_grad
+        # one entry per Tensor input: q, k, v, indices, valid_range
+        # (indices and valid_range never carry gradient).
+        return (
+            dq if gq else None,
+            dk if gk else None,
+            dv if gv else None,
+            None,
+            None,
+        )
 
 
 def block_score_mqa_attention(q, k, v, valid_range, sm_scale=None, block_B=64):

--- a/src/paddlefleet/tilelang_ops/hysparse/autograd.py
+++ b/src/paddlefleet/tilelang_ops/hysparse/autograd.py
@@ -1,0 +1,189 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Autograd (``paddle.autograd.PyLayer``) wrappers for the HySparse MQA block
+attention operators, combining the separate TileLang forward and backward
+kernels into differentiable ops usable inside a training network.
+
+Two ops, both with a single shared K/V head:
+
+* :class:`BlockScoreMQAAttn` -- full block-score attention. Returns the
+  attention output (differentiable) plus ``lse`` and per-block ``block_logit``
+  (both non-differentiable: they feed a non-differentiable TopK selection).
+* :class:`BlockSparseMQAAttn` -- block-sparse gather attention over a
+  per-query-token selection of key blocks. Returns output (differentiable) and
+  ``lse`` (non-differentiable).
+
+The convenience :func:`hysparse_mqa_attention` chains score -> TopK -> sparse:
+the TopK sits between the two PyLayers and carries no gradient, exactly as in
+the non-differentiable :func:`.pipeline.hysparse_forward_mqa`.
+"""
+
+import paddle
+
+from .block_score_attn import block_score_mqa_attn_fwd
+from .block_score_attn_bwd import block_score_mqa_bwd_interface
+from .block_sparse_attn_mqa import block_sparse_mqa_attn_fwd
+from .block_sparse_attn_mqa_bwd import block_sparse_mqa_bwd_interface
+from .pipeline import select_topk_blocks
+
+
+class BlockScoreMQAAttn(paddle.autograd.PyLayer):
+    """Differentiable MQA block-score attention.
+
+    forward inputs: q [B,S,H,Dk], k [B,S_kv,Dk], v [B,S_kv,Dv],
+    valid_range [B,S,2] int32, plus scalar ``sm_scale`` and ``block_B``.
+    outputs: out [B,S,H,Dv] (differentiable), lse [B,S,H] and
+    block_logit [B,H,S,num_blocks] (both non-differentiable).
+    """
+
+    @staticmethod
+    def forward(ctx, q, k, v, valid_range, sm_scale, block_B):
+        out, lse, block_logit = block_score_mqa_attn_fwd(
+            q, k, v, valid_range, sm_scale=sm_scale, block_B=block_B
+        )
+        ctx.save_for_backward(q, k, v, out, lse, valid_range)
+        ctx.sm_scale = sm_scale
+        ctx.block_B = block_B
+        # lse / block_logit feed a non-differentiable TopK -> no gradient.
+        ctx.mark_non_differentiable(lse, block_logit)
+        return out, lse, block_logit
+
+    @staticmethod
+    def backward(ctx, grad_out, *_):
+        q, k, v, out, lse, valid_range = ctx.saved_tensor()
+        dq, dk, dv = block_score_mqa_bwd_interface(
+            q,
+            k,
+            v,
+            out,
+            grad_out.contiguous(),
+            lse,
+            valid_range,
+            sm_scale=ctx.sm_scale,
+            block_B=ctx.block_B,
+        )
+        return dq, dk, dv
+
+
+class BlockSparseMQAAttn(paddle.autograd.PyLayer):
+    """Differentiable MQA block-sparse gather attention.
+
+    forward inputs: q [B,S,H,Dk], k [B,S_kv,Dk], v [B,S_kv,Dv],
+    indices [B,S,nsel] int32 (document-relative block ids, -1 padding),
+    valid_range [B,S,2] int32, plus scalar ``sm_scale`` and ``block_B``.
+    outputs: out [B,S,H,Dv] (differentiable), lse [B,S,H] (non-differentiable).
+    """
+
+    @staticmethod
+    def forward(ctx, q, k, v, indices, valid_range, sm_scale, block_B):
+        out, lse = block_sparse_mqa_attn_fwd(
+            q, k, v, indices, valid_range, sm_scale=sm_scale, block_B=block_B
+        )
+        ctx.save_for_backward(q, k, v, out, lse, indices, valid_range)
+        ctx.sm_scale = sm_scale
+        ctx.block_B = block_B
+        ctx.mark_non_differentiable(lse)
+        return out, lse
+
+    @staticmethod
+    def backward(ctx, grad_out, *_):
+        q, k, v, out, lse, indices, valid_range = ctx.saved_tensor()
+        dq, dk, dv = block_sparse_mqa_bwd_interface(
+            q,
+            k,
+            v,
+            out,
+            grad_out.contiguous(),
+            lse,
+            indices,
+            valid_range,
+            sm_scale=ctx.sm_scale,
+            block_B=ctx.block_B,
+        )
+        return dq, dk, dv
+
+
+def block_score_mqa_attention(q, k, v, valid_range, sm_scale=None, block_B=64):
+    """Differentiable block-score attention (see :class:`BlockScoreMQAAttn`).
+
+    Returns ``(out, lse, block_logit)``; only ``out`` carries gradient.
+    """
+    if sm_scale is None:
+        sm_scale = q.shape[-1] ** -0.5
+    return BlockScoreMQAAttn.apply(
+        q, k, v, valid_range, float(sm_scale), block_B
+    )
+
+
+def block_sparse_mqa_attention(
+    q, k, v, indices, valid_range, sm_scale=None, block_B=64
+):
+    """Differentiable block-sparse gather attention.
+
+    Returns ``(out, lse)``; only ``out`` carries gradient.
+    """
+    if sm_scale is None:
+        sm_scale = q.shape[-1] ** -0.5
+    return BlockSparseMQAAttn.apply(
+        q, k, v, indices, valid_range, float(sm_scale), block_B
+    )
+
+
+def hysparse_mqa_attention(
+    q, k, v, valid_range, topk, sm_scale=None, block_B=64, head_agg="max"
+):
+    """Differentiable HySparse forward: block-score -> TopK -> block-sparse.
+
+    The TopK selection between the two attention ops is non-differentiable
+    (block scores feed a hard selection), so gradient flows only through the
+    two attention PyLayers.
+
+    Args:
+        q:           [B, S, H, Dk] bf16 query.
+        k:           [B, S_kv, Dk] bf16 shared key head.
+        v:           [B, S_kv, Dv] bf16 shared value head.
+        valid_range: [B, S, 2] int32 causal + document valid key range.
+        topk:        number of key blocks selected per query token.
+        sm_scale:    softmax scale; defaults to Dk**-0.5.
+        block_B:     key block size.
+        head_agg:    cross-head block-score aggregation ("max" or "sum").
+
+    Returns:
+        sparse_out [B,S,H,Dv], sparse_lse [B,S,H], indices [B,S,topk],
+        full_out [B,S,H,Dv], full_lse [B,S,H]. ``sparse_out`` and ``full_out``
+        carry gradient; the rest are detached side outputs.
+    """
+    if sm_scale is None:
+        sm_scale = q.shape[-1] ** -0.5
+    sm_scale = float(sm_scale)
+
+    full_out, full_lse, block_logit = block_score_mqa_attention(
+        q, k, v, valid_range, sm_scale=sm_scale, block_B=block_B
+    )
+    # non-differentiable block selection (detached inputs)
+    with paddle.no_grad():
+        indices = select_topk_blocks(
+            block_logit.detach(),
+            full_lse.detach(),
+            valid_range,
+            sm_scale,
+            topk,
+            block_B,
+            head_agg=head_agg,
+        )
+    sparse_out, sparse_lse = block_sparse_mqa_attention(
+        q, k, v, indices, valid_range, sm_scale=sm_scale, block_B=block_B
+    )
+    return sparse_out, sparse_lse, indices, full_out, full_lse

--- a/src/paddlefleet/tilelang_ops/hysparse/block_score_attn.py
+++ b/src/paddlefleet/tilelang_ops/hysparse/block_score_attn.py
@@ -51,6 +51,7 @@ def block_score_mqa_fwd(
     H,
     D,
     sm_scale,
+    D_v=None,
     block_B=64,
     num_stages=2,
     threads=128,
@@ -65,9 +66,19 @@ def block_score_mqa_fwd(
     still sum over every valid key in ``[bos, eos)``); only the emitted
     per-block max logit is binned relative to ``bos`` so downstream TopK
     selects blocks exactly as if each document were processed standalone.
+
+    ``D`` is the query/key head dim (used for the ``q·k`` logit); ``D_v`` is the
+    value/output head dim. For plain attention they are equal; for absorbed MLA
+    the key carries an extra RoPE slice so ``D`` (e.g. 576) exceeds ``D_v`` (the
+    compressed value rank, e.g. 512). ``D_v`` defaults to ``D``.
     """
+    if D_v is None:
+        D_v = D
     assert D % 16 == 0, (
         f"D must be a multiple of 16 (tensor-core k-tile), got {D}"
+    )
+    assert D_v % 16 == 0, (
+        f"D_v must be a multiple of 16 (tensor-core k-tile), got {D_v}"
     )
     assert H <= 128, "this kernel supports up to 128 query heads"
     scale_log2 = sm_scale * 1.44269504  # log2(e), online softmax in base 2
@@ -79,7 +90,8 @@ def block_score_mqa_fwd(
 
     q_shape = [batch, seq_len, H, D]
     kv_shape = [batch, seq_len_kv, D]
-    o_shape = [batch, seq_len, H, D]
+    v_shape = [batch, seq_len_kv, D_v]
+    o_shape = [batch, seq_len, H, D_v]
     lse_shape = [batch, seq_len, H]
     vr_shape = [batch, seq_len, 2]
     blk_shape = [batch, H, seq_len, num_blocks]
@@ -94,7 +106,7 @@ def block_score_mqa_fwd(
     def main(
         Q: T.Tensor(q_shape, dtype),
         K: T.Tensor(kv_shape, dtype),
-        V: T.Tensor(kv_shape, dtype),
+        V: T.Tensor(v_shape, dtype),
         ValidRange: T.Tensor(vr_shape, idx_dtype),
         BlockLogit: T.Tensor(blk_shape, accum_dtype),
         Output: T.Tensor(o_shape, dtype),
@@ -103,10 +115,10 @@ def block_score_mqa_fwd(
         with T.Kernel(seq_len, batch, threads=threads) as (bs, bb):
             Q_shared = T.alloc_shared([PH, D], dtype)
             K_shared = T.alloc_shared([BB, D], dtype)
-            V_shared = T.alloc_shared([BB, D], dtype)
+            V_shared = T.alloc_shared([BB, D_v], dtype)
             P_shared = T.alloc_shared([PH, BB], dtype)
 
-            acc_o = T.alloc_fragment([PH, D], accum_dtype)
+            acc_o = T.alloc_fragment([PH, D_v], accum_dtype)
             acc_s = T.alloc_fragment([PH, BB], accum_dtype)
             blk_max = T.alloc_fragment([PH], accum_dtype)
             m_i = T.alloc_fragment([PH], accum_dtype)
@@ -147,6 +159,10 @@ def block_score_mqa_fwd(
                     K_shared[c, d] = T.if_then_else(
                         in_bounds, K[bb, safe_col, d], T.cast(0, dtype)
                     )
+                for c, d in T.Parallel(BB, D_v):
+                    col = bos + j * BB + c
+                    in_bounds = col < seq_len_kv
+                    safe_col = T.if_then_else(in_bounds, col, 0)
                     V_shared[c, d] = T.if_then_else(
                         in_bounds, V[bb, safe_col, d], T.cast(0, dtype)
                     )
@@ -187,7 +203,7 @@ def block_score_mqa_fwd(
                 T.reduce_sum(acc_s, l_new, dim=1)
                 for h in T.Parallel(PH):
                     l_i[h] = l_i[h] * alpha[h] + l_new[h]
-                for h, d in T.Parallel(PH, D):
+                for h, d in T.Parallel(PH, D_v):
                     acc_o[h, d] = acc_o[h, d] * alpha[h]
                 T.copy(acc_s, P_shared)
                 T.gemm(
@@ -195,11 +211,11 @@ def block_score_mqa_fwd(
                 )
 
             # normalize; empty rows (no valid key) -> 0 out / -inf lse
-            for h, d in T.Parallel(PH, D):
+            for h, d in T.Parallel(PH, D_v):
                 acc_o[h, d] = T.if_then_else(
                     l_i[h] > 0, acc_o[h, d] / l_i[h], 0.0
                 )
-            for h, d in T.Parallel(PH, D):
+            for h, d in T.Parallel(PH, D_v):
                 if h < H:
                     Output[bb, bs, h, d] = acc_o[h, d]
             for h in T.Parallel(PH):
@@ -253,13 +269,14 @@ def block_score_mqa_attn_fwd(q, k, v, valid_range, sm_scale=None, block_B=64):
     assert q.is_contiguous()
     b, s, h, d = q.shape
     s_kv = k.shape[1]
+    d_v = v.shape[-1]
     # lightweight host-side shape checks (no device sync) so mismatched inputs
     # fail early and clearly instead of causing undefined kernel behaviour.
-    assert len(k.shape) == 3 and list(k.shape) == list(v.shape), (
-        f"k/v must be [B, S_kv, D] and match; got {k.shape} vs {v.shape}"
+    assert len(k.shape) == 3 and k.shape[0] == b and k.shape[2] == d, (
+        f"k must be [B, S_kv, D] matching q; got k {k.shape}, q {q.shape}"
     )
-    assert k.shape[0] == b and k.shape[2] == d, (
-        f"k/v batch/head_dim must match q; got k {k.shape}, q {q.shape}"
+    assert len(v.shape) == 3 and list(v.shape[:2]) == [b, s_kv], (
+        f"v must be [B, S_kv, D_v] matching k seqlen; got {v.shape}, k {k.shape}"
     )
     assert list(valid_range.shape) == [b, s, 2], (
         f"valid_range must be [B, S, 2]; got {valid_range.shape}"
@@ -285,6 +302,8 @@ def block_score_mqa_attn_fwd(q, k, v, valid_range, sm_scale=None, block_B=64):
     block_logit = paddle.full(
         [b, h, s, num_blocks], float("-inf"), dtype="float32"
     )
-    kernel = block_score_mqa_fwd(h, d, float(sm_scale), block_B=block_B)
+    kernel = block_score_mqa_fwd(
+        h, d, float(sm_scale), D_v=d_v, block_B=block_B
+    )
     out, lse = kernel(q, k, v, valid_range, block_logit)
     return out, lse, block_logit

--- a/src/paddlefleet/tilelang_ops/hysparse/block_score_attn_mha.py
+++ b/src/paddlefleet/tilelang_ops/hysparse/block_score_attn_mha.py
@@ -1,0 +1,323 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Block-score attention (paper "Algorithm 1") with **per-head** K/V (MHA):
+the decompressed MLA layout where each of the ``H`` query heads has its own
+Key/Value head. Emitted per-block max logits feed the same block-level TopK
+selection as the MQA variant.
+
+This is the sibling of :mod:`block_score_attn` (MQA/absorbed MLA, single shared
+K/V head). The two exist to measure the wall-clock cost of the ``H``x KV-access
+factor: MHA saves attention FLOPs (smaller head dim, no RoPE slice) but reads
+``H`` independent K/V heads instead of one, so in the memory-bound regime it can
+be *slower* despite the FLOP saving.
+
+Q is ``[B, S, H, D]``; K is ``[B, S_kv, H, D]``; V is ``[B, S_kv, H, D_v]`` --
+one K/V head per query head. Masking (causal + document) is expressed through
+``valid_range`` ``[B, S, 2]`` giving each query's half-open valid key column
+range ``[bos, eos)``.
+
+Efficient structure (vs the MQA per-token / heads-on-M kernel): one program per
+``(query-tile, head, batch)`` with ``block_M`` query tokens on the GEMM ``M``
+dim sharing that head's K -- the standard dense-attention tiling that fills the
+tensor cores. The two layouts are each mode's natural best structure.
+
+Block coordinates are **absolute** (``col // block_B``), not document-relative:
+tiling ``block_M`` query rows together makes per-row document-relative binning
+(different ``bos`` per row within a tile) awkward to scatter. For the causal
+single-document case used in the accuracy tests (``bos == 0``)
+absolute == relative, so the emitted block scores are directly comparable to the
+MQA kernel's. Document-relative binning is out of scope here (it does not affect
+the FLOP/memory comparison, since binning is only a cheap ``reduce_max``).
+
+The forward returns:
+* ``Output``    ``[B, S, H, D_v]`` attention output.
+* ``Lse``       ``[B, S, H]`` natural log-sum-exp of the *scaled* logits.
+* ``BlockLogit`` ``[B, H, S, num_blocks]`` per-(query, key-block) max of the
+  *raw* (unscaled) ``q·k`` logit over valid columns; fully-masked blocks store
+  ``-inf``. Recover the eq.(3) probability score on the host with
+  :func:`~block_score_attn.block_scores_from_logit`.
+"""
+
+import paddle
+import tilelang
+from tilelang import language as T
+
+
+@tilelang.jit(
+    out_idx=[-2, -1],
+    pass_configs={
+        tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
+        tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
+    },
+)
+def block_score_mha_fwd(
+    H,
+    D,
+    sm_scale,
+    D_v=None,
+    block_B=64,
+    block_M=64,
+    num_stages=2,
+    threads=128,
+):
+    """Per-head (MHA) block-score kernel.
+
+    One program per ``(query-tile, head, batch)``: ``block_M`` query tokens on
+    the GEMM ``M`` dimension, sharing this head's K/V. ``D`` is the query/key
+    head dim (``q·k`` logit); ``D_v`` is the value/output head dim (defaults to
+    ``D``). For decompressed MLA ``D == D_v`` (e.g. 256).
+    """
+    if D_v is None:
+        D_v = D
+    assert D % 16 == 0, (
+        f"D must be a multiple of 16 (tensor-core k-tile), got {D}"
+    )
+    assert D_v % 16 == 0, (
+        f"D_v must be a multiple of 16 (tensor-core k-tile), got {D_v}"
+    )
+    scale_log2 = sm_scale * 1.44269504  # log2(e), online softmax in base 2
+
+    batch = T.dynamic("batch")
+    seq_len = T.dynamic("seq_len")
+    seq_len_kv = T.dynamic("seq_len_kv")
+    num_blocks = T.dynamic("num_blocks")
+    num_bm = T.dynamic("num_bm")
+
+    q_shape = [batch, seq_len, H, D]
+    k_shape = [batch, seq_len_kv, H, D]
+    v_shape = [batch, seq_len_kv, H, D_v]
+    o_shape = [batch, seq_len, H, D_v]
+    lse_shape = [batch, seq_len, H]
+    vr_shape = [batch, seq_len, 2]
+    br_shape = [batch, num_bm, 2]
+    blk_shape = [batch, H, seq_len, num_blocks]
+
+    dtype = T.bfloat16
+    accum_dtype = T.float32
+    idx_dtype = T.int32
+    BM = block_M
+    BB = block_B
+
+    @T.prim_func
+    def main(
+        Q: T.Tensor(q_shape, dtype),
+        K: T.Tensor(k_shape, dtype),
+        V: T.Tensor(v_shape, dtype),
+        ValidRange: T.Tensor(vr_shape, idx_dtype),
+        BlockRange: T.Tensor(br_shape, idx_dtype),
+        BlockLogit: T.Tensor(blk_shape, accum_dtype),
+        Output: T.Tensor(o_shape, dtype),
+        Lse: T.Tensor(lse_shape, accum_dtype),
+    ):
+        with T.Kernel(T.ceildiv(seq_len, BM), H, batch, threads=threads) as (
+            bm,
+            bh,
+            bb,
+        ):
+            Q_shared = T.alloc_shared([BM, D], dtype)
+            K_shared = T.alloc_shared([BB, D], dtype)
+            V_shared = T.alloc_shared([BB, D_v], dtype)
+            P_shared = T.alloc_shared([BM, BB], dtype)
+
+            acc_o = T.alloc_fragment([BM, D_v], accum_dtype)
+            acc_s = T.alloc_fragment([BM, BB], accum_dtype)
+            blk_max = T.alloc_fragment([BM], accum_dtype)
+            m_i = T.alloc_fragment([BM], accum_dtype)
+            m_prev = T.alloc_fragment([BM], accum_dtype)
+            l_i = T.alloc_fragment([BM], accum_dtype)
+            l_new = T.alloc_fragment([BM], accum_dtype)
+            alpha = T.alloc_fragment([BM], accum_dtype)
+            bos = T.alloc_fragment([BM], idx_dtype)
+            eos = T.alloc_fragment([BM], idx_dtype)
+
+            T.fill(acc_o, 0)
+            T.fill(m_i, -(2**30))
+            T.fill(l_i, 0)
+
+            for i in T.Parallel(BM):
+                row = bm * BM + i
+                in_range = row < seq_len
+                bos[i] = T.if_then_else(in_range, ValidRange[bb, row, 0], 0)
+                eos[i] = T.if_then_else(in_range, ValidRange[bb, row, 1], 0)
+
+            T.copy(Q[bb, bm * BM : (bm + 1) * BM, bh, :], Q_shared)
+
+            # causal/document early-exit: the host precomputes, per query tile,
+            # the block-B key window [jl, jh) reachable by this tile's rows --
+            # jl = min_i(bos_i)//block_B (skip leading blocks before the tile's
+            # document start); jh = ceil(max_i(eos_i)/block_B) (skip blocks past
+            # the causal end). Blocks outside are fully masked for every row and
+            # contribute nothing to out/lse; their per-block max logit stays the
+            # host-prefilled -inf.
+            jl = BlockRange[bb, bm, 0]
+            jh = BlockRange[bb, bm, 1]
+            for j in T.Pipelined(jh - jl, num_stages=num_stages):
+                jb = jl + j  # absolute block index
+                col0 = jb * BB
+                for c, d in T.Parallel(BB, D):
+                    col = col0 + c
+                    in_bounds = col < seq_len_kv
+                    safe_col = T.if_then_else(in_bounds, col, 0)
+                    K_shared[c, d] = T.if_then_else(
+                        in_bounds, K[bb, safe_col, bh, d], T.cast(0, dtype)
+                    )
+                for c, d in T.Parallel(BB, D_v):
+                    col = col0 + c
+                    in_bounds = col < seq_len_kv
+                    safe_col = T.if_then_else(in_bounds, col, 0)
+                    V_shared[c, d] = T.if_then_else(
+                        in_bounds, V[bb, safe_col, bh, d], T.cast(0, dtype)
+                    )
+
+                # raw q·k^T
+                T.clear(acc_s)
+                T.gemm(
+                    Q_shared,
+                    K_shared,
+                    acc_s,
+                    transpose_B=True,
+                    policy=T.GemmWarpPolicy.FullRow,
+                )
+
+                # per-row causal + document mask: col in [bos_i, eos_i)
+                for i, c in T.Parallel(BM, BB):
+                    col = col0 + c
+                    keep = (col >= bos[i]) and (col < eos[i])
+                    acc_s[i, c] = T.if_then_else(
+                        keep, acc_s[i, c], -T.infinity(accum_dtype)
+                    )
+
+                # per-block max of raw logit over valid cols -> block score src
+                # (absolute block coordinate jb)
+                T.reduce_max(acc_s, blk_max, dim=1, clear=True)
+                for i in T.Parallel(BM):
+                    row = bm * BM + i
+                    if row < seq_len:
+                        BlockLogit[bb, bh, row, jb] = blk_max[i]
+
+                # online softmax (base 2) over scaled logits
+                T.copy(m_i, m_prev)
+                for i in T.Parallel(BM):
+                    m_i[i] = T.max(m_i[i], blk_max[i] * sm_scale)
+                for i in T.Parallel(BM):
+                    alpha[i] = T.exp2((m_prev[i] - m_i[i]) * 1.44269504)
+                for i, c in T.Parallel(BM, BB):
+                    acc_s[i, c] = T.exp2(
+                        acc_s[i, c] * scale_log2 - m_i[i] * 1.44269504
+                    )
+                T.reduce_sum(acc_s, l_new, dim=1)
+                for i in T.Parallel(BM):
+                    l_i[i] = l_i[i] * alpha[i] + l_new[i]
+                for i, d in T.Parallel(BM, D_v):
+                    acc_o[i, d] = acc_o[i, d] * alpha[i]
+                T.copy(acc_s, P_shared)
+                T.gemm(
+                    P_shared, V_shared, acc_o, policy=T.GemmWarpPolicy.FullRow
+                )
+
+            # normalize; empty rows (no valid key) -> 0 out / -inf lse
+            for i, d in T.Parallel(BM, D_v):
+                acc_o[i, d] = T.if_then_else(
+                    l_i[i] > 0, acc_o[i, d] / l_i[i], 0.0
+                )
+            for i, d in T.Parallel(BM, D_v):
+                row = bm * BM + i
+                if row < seq_len:
+                    Output[bb, row, bh, d] = acc_o[i, d]
+            for i in T.Parallel(BM):
+                row = bm * BM + i
+                if row < seq_len:
+                    Lse[bb, row, bh] = T.if_then_else(
+                        l_i[i] > 0,
+                        m_i[i] + T.log(l_i[i]),
+                        -T.infinity(accum_dtype),
+                    )
+
+    return main
+
+
+def block_score_mha_attn_fwd(q, k, v, valid_range, sm_scale=None, block_B=64):
+    """Forward interface for the MHA (per-head K/V) block-score attention.
+
+    Args:
+        q:           [B, S, H, D] bf16 query (H heads).
+        k:           [B, S_kv, H, D] bf16 key (H heads).
+        v:           [B, S_kv, H, D_v] bf16 value (H heads).
+        valid_range: [B, S, 2] int32 per-query [bos, eos) valid key columns.
+        sm_scale:    softmax scale; defaults to D**-0.5.
+        block_B:     key block size.
+
+    Returns:
+        out [B,S,H,D_v], lse [B,S,H], block_logit [B,H,S,num_blocks] where
+        num_blocks = ceil(S_kv / block_B). Block coordinates are absolute.
+    """
+    assert q.is_contiguous()
+    b, s, h, d = q.shape
+    s_kv = k.shape[1]
+    d_v = v.shape[-1]
+    assert list(k.shape) == [b, s_kv, h, d], (
+        f"k must be [B, S_kv, H, D] matching q; got k {k.shape}, q {q.shape}"
+    )
+    assert list(v.shape[:3]) == [b, s_kv, h], (
+        f"v must be [B, S_kv, H, D_v] matching k; got {v.shape}, k {k.shape}"
+    )
+    assert list(valid_range.shape) == [b, s, 2], (
+        f"valid_range must be [B, S, 2]; got {valid_range.shape}"
+    )
+    if sm_scale is None:
+        sm_scale = d**-0.5
+    if valid_range.dtype != paddle.int32:
+        valid_range = valid_range.cast("int32")
+
+    # kernel reads whole block_B blocks; pad K/V so the last block is in bounds
+    pad = (block_B - s_kv % block_B) % block_B
+    s_kv_pad = s_kv + pad
+    if pad > 0:
+        # pad along the sequence axis (axis 1) of [B, S_kv, H, D(_v)]
+        k = paddle.nn.functional.pad(k, [0, 0, 0, 0, 0, pad])
+        v = paddle.nn.functional.pad(v, [0, 0, 0, 0, 0, pad])
+    k = k.contiguous()
+    v = v.contiguous()
+    valid_range = valid_range.contiguous()
+    num_blocks = s_kv_pad // block_B
+
+    # Per query-tile key-block window [jl, jh): jl skips leading blocks before
+    # the tile's document start, jh caps at the tile's (causal) reach. Padded
+    # rows get bos=+big / eos=0 so they never widen a tile's window.
+    block_M = 64
+    num_bm_v = (s + block_M - 1) // block_M
+    pad_rows = num_bm_v * block_M - s
+    bos = valid_range[:, :, 0]
+    eos = valid_range[:, :, 1]
+    if pad_rows > 0:
+        bos = paddle.nn.functional.pad(bos, [0, pad_rows], value=s_kv_pad)
+        eos = paddle.nn.functional.pad(eos, [0, pad_rows], value=0)
+    bos = bos.reshape([b, num_bm_v, block_M])
+    eos = eos.reshape([b, num_bm_v, block_M])
+    jl = (bos.min(-1) // block_B).clip(0, num_blocks)
+    jh = ((eos.max(-1) + block_B - 1) // block_B).clip(0, num_blocks)
+    jh = paddle.maximum(jh, jl)
+    block_range = paddle.stack([jl, jh], axis=-1).astype("int32").contiguous()
+
+    # Skipped blocks (outside a tile's window) keep -inf so their host-side
+    # block-score is 0; pre-fill instead of leaving the buffer uninitialised.
+    block_logit = paddle.full(
+        [b, h, s, num_blocks], float("-inf"), dtype="float32"
+    )
+    kernel = block_score_mha_fwd(
+        h, d, float(sm_scale), D_v=d_v, block_B=block_B, block_M=block_M
+    )
+    out, lse = kernel(q, k, v, valid_range, block_range, block_logit)
+    return out, lse, block_logit

--- a/src/paddlefleet/tilelang_ops/hysparse/block_score_attn_mha_bwd.py
+++ b/src/paddlefleet/tilelang_ops/hysparse/block_score_attn_mha_bwd.py
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Backward for the MQA block-score attention: flash-attention backward
-(dQ, dK, dV) for full attention with a single shared K/V head and causal +
+"""Backward for the MHA (per-head K/V) block-score attention: flash-attention
+backward (dQ, dK, dV) for full attention with per-head K/V and causal +
 document masking.
 
-K/V are one shared head ``[B, S_kv, D]``; dK/dV from every query head are
-scattered into that single head via ``atomic_add``. The block-score output of
-the forward is consumed by a non-differentiable TopK and therefore contributes
-no gradient here.
+Mirrors :mod:`block_score_attn_bwd` (MQA) but K/V carry a head index and dK/dV
+are scattered per head. Within a head, different query tiles still overlap the
+same key columns, so ``atomic_add`` is retained for dK/dV; across heads there is
+no conflict (each head owns its own K/V slice).
 """
 
 import paddle
@@ -36,7 +36,7 @@ from .block_sparse_attn_mqa_bwd import _cast_bf16_kv
         tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
     },
 )
-def block_score_mqa_bwd(
+def block_score_mha_bwd(
     H,
     D,
     sm_scale,
@@ -63,8 +63,8 @@ def block_score_mqa_bwd(
     num_bm = T.dynamic("num_bm")
 
     q_shape = [batch, seq_len, H, D]
-    kv_shape = [batch, seq_len_kv, D]
-    v_shape = [batch, seq_len_kv, D_v]
+    k_shape = [batch, seq_len_kv, H, D]
+    v_shape = [batch, seq_len_kv, H, D_v]
     do_shape = [batch, seq_len, H, D_v]
     lse_shape = [batch, seq_len, H]
     vr_shape = [batch, seq_len, 2]
@@ -82,14 +82,14 @@ def block_score_mqa_bwd(
     @T.prim_func
     def main(
         Q: T.Tensor(q_shape, dtype),
-        K: T.Tensor(kv_shape, dtype),
+        K: T.Tensor(k_shape, dtype),
         V: T.Tensor(v_shape, dtype),
         dO: T.Tensor(do_shape, dtype),
         Lse: T.Tensor(lse_shape, accum_dtype),
         Delta: T.Tensor(lse_shape, accum_dtype),
         ValidRange: T.Tensor(vr_shape, idx_dtype),
         BlockRange: T.Tensor(br_shape, idx_dtype),
-        dK: T.Tensor(kv_shape, accum_dtype),
+        dK: T.Tensor(k_shape, accum_dtype),
         dV: T.Tensor(v_shape, accum_dtype),
         dQ: T.Tensor(q_shape, dtype),
     ):
@@ -128,24 +128,16 @@ def block_score_mqa_bwd(
             T.copy(dO[bb, bm * BM : (bm + 1) * BM, bh, :], dO_shared)
             T.clear(acc_dq)
 
-            # document-tight early-exit: the host precomputes, per query tile,
-            # the block-B key window [jl, jh) actually reachable by this tile's
-            # rows -- jl = min_i(bos_i) // block_B skips leading blocks before
-            # the tile's document start; jh = ceil(max_i(eos_i) / block_B) skips
-            # blocks past the (causal) end. Every skipped block is fully masked
-            # (col < bos_i or col >= eos_i) for all rows, so dQ/dK/dV are
-            # unchanged. The window is in block_B units; we iterate it in
-            # ``block_N`` sub-tiles (``ratio`` per block) so the K/V/P/dS shared
-            # buffers stay small enough to fit a full block_M=64 query tile at
-            # large head dims (D=576) -- bigger M matches the forward's
-            # tensor-core utilisation and K/V amortisation.
+            # document-tight key-block window [jl, jh) (block_B units), iterated
+            # in block_N sub-tiles (ratio per block). Same early-exit as MQA;
+            # every skipped sub-tile is fully masked for all rows.
             jl = BlockRange[bb, bm, 0]
             jh = BlockRange[bb, bm, 1]
             for nn in T.Pipelined((jh - jl) * ratio, num_stages=num_stages):
                 col0 = (jl * ratio + nn) * BN
-                # single shared K/V head -> no head index
-                T.copy(K[bb, col0 : col0 + BN, :], K_shared)
-                T.copy(V[bb, col0 : col0 + BN, :], V_shared)
+                # per-head K/V slice
+                T.copy(K[bb, col0 : col0 + BN, bh, :], K_shared)
+                T.copy(V[bb, col0 : col0 + BN, bh, :], V_shared)
 
                 # P = softmax prob = exp(raw*sm_scale - lse); masked -> 0
                 T.clear(acc_s)
@@ -191,7 +183,7 @@ def block_score_mqa_bwd(
                     acc_dq,
                     policy=T.GemmWarpPolicy.FullRow,
                 )
-                # dV += P^T @ dO ; dK += dS^T @ Q  (scattered to shared KV)
+                # dV += P^T @ dO ; dK += dS^T @ Q  (scattered per head)
                 T.clear(acc_dv)
                 T.gemm(
                     P_shared,
@@ -209,13 +201,11 @@ def block_score_mqa_bwd(
                     policy=T.GemmWarpPolicy.FullRow,
                 )
                 for c, d in T.Parallel(BN, D):
-                    T.atomic_add(dK[bb, col0 + c, d], acc_dk[c, d])
+                    T.atomic_add(dK[bb, col0 + c, bh, d], acc_dk[c, d])
                 for c, d in T.Parallel(BN, D_v):
-                    T.atomic_add(dV[bb, col0 + c, d], acc_dv[c, d])
+                    T.atomic_add(dV[bb, col0 + c, bh, d], acc_dv[c, d])
 
-            # write dQ straight from the accumulator fragment (no shared-memory
-            # staging) -- one fewer [BM, D] bf16 buffer lets the shared budget
-            # fit a larger query tile (bigger M -> better tensor-core use).
+            # write dQ straight from the accumulator fragment
             for i, d in T.Parallel(BM, D):
                 if bm * BM + i < seq_len:
                     dQ[bb, bm * BM + i, bh, d] = acc_dq[i, d]
@@ -226,14 +216,10 @@ def block_score_mqa_bwd(
 def _fit_block_mn(D, block_B, D_v=None, cap_bytes=230000):
     """Pick (block_M, block_N) maximising the query tile then the key sub-tile.
 
-    The backward holds Q ``[block_M, D]`` + dO ``[block_M, D_v]`` + K
-    ``[block_N, D]`` + V ``[block_N, D_v]`` + P/dS ``[block_M, block_N]`` in
-    bf16 shared memory (dQ writes straight from its accumulator). Prefer the
-    largest ``block_M`` (<=64) -- big M matches the forward's tensor-core
-    utilisation and K/V amortisation -- and, for that M, the largest
-    ``block_N`` (dividing ``block_B``) that fits. At MLA D=576 a full
-    block_M=64 needs block_N=32 to fit Blackwell's ~227 KB; small dims (D=64)
-    keep block_N=block_B (single-tile fast path).
+    Same budget model as the MQA backward: Q ``[block_M, D]`` + dO
+    ``[block_M, D_v]`` + K ``[block_N, D]`` + V ``[block_N, D_v]`` + P/dS
+    ``[block_M, block_N]`` in bf16 shared memory. At the decompressed-MLA dim
+    D=D_v=256 a full block_M=block_N=64 fits comfortably.
     """
     if D_v is None:
         D_v = D
@@ -247,7 +233,7 @@ def _fit_block_mn(D, block_B, D_v=None, cap_bytes=230000):
     return 16, min(16, block_B)
 
 
-def block_score_mqa_bwd_interface(
+def block_score_mha_bwd_interface(
     q,
     k,
     v,
@@ -260,25 +246,23 @@ def block_score_mqa_bwd_interface(
     block_M=None,
     block_N=None,
 ):
-    """Backward interface for the MQA block-score attention.
+    """Backward interface for the MHA block-score attention.
 
     Args:
         q:           [B, S, H, D] bf16 forward query.
-        k, v:        [B, S_kv, D] bf16 single shared key/value head.
-        o:           [B, S, H, D] bf16 forward output.
-        do:          [B, S, H, D] bf16 grad of output.
+        k:           [B, S_kv, H, D] bf16 per-head key.
+        v:           [B, S_kv, H, D_v] bf16 per-head value.
+        o:           [B, S, H, D_v] bf16 forward output.
+        do:          [B, S, H, D_v] bf16 grad of output.
         lse:         [B, S, H] fp32 natural-log LSE from forward.
         valid_range: [B, S, 2] int32.
         sm_scale:    softmax scale; defaults to D**-0.5.
         block_B:     key block size.
-        block_M:     query tile size on the GEMM M dim; ``None`` auto-fits the
-                     largest tile that fits shared memory (:func:`_fit_block_mn`).
-        block_N:     key sub-tile size (must divide ``block_B``); ``None``
-                     auto-fits. Overrides are for tuning/testing the tiling; the
-                     result is mathematically identical for any valid choice.
+        block_M:     query tile size (auto-fit if None).
+        block_N:     key sub-tile size, must divide block_B (auto-fit if None).
 
     Returns:
-        dq [B,S,H,D] bf16, dk/dv [B,S_kv,D] bf16.
+        dq [B,S,H,D] bf16, dk [B,S_kv,H,D] bf16, dv [B,S_kv,H,D_v] bf16.
     """
     assert q.is_contiguous() and do.is_contiguous() and lse.is_contiguous()
     b, s, h, d = q.shape
@@ -290,19 +274,19 @@ def block_score_mqa_bwd_interface(
         valid_range = valid_range.cast("int32")
 
     # kernel reads whole block_B blocks; pad K/V (and dK/dV) so the last block
-    # is addressable.
+    # is addressable. Pad along the sequence axis (axis 1).
     pad = (block_B - s_kv % block_B) % block_B
     s_kv_pad = s_kv + pad
     if pad > 0:
-        k = paddle.nn.functional.pad(k, [0, 0, 0, pad])
-        v = paddle.nn.functional.pad(v, [0, 0, 0, pad])
+        k = paddle.nn.functional.pad(k, [0, 0, 0, 0, 0, pad])
+        v = paddle.nn.functional.pad(v, [0, 0, 0, 0, 0, pad])
     k = k.contiguous()
     v = v.contiguous()
     valid_range = valid_range.contiguous()
 
     delta = (o.astype("float32") * do.astype("float32")).sum(-1).contiguous()
-    dk = paddle.zeros([b, s_kv_pad, d], dtype="float32")
-    dv = paddle.zeros([b, s_kv_pad, d_v], dtype="float32")
+    dk = paddle.zeros([b, s_kv_pad, h, d], dtype="float32")
+    dv = paddle.zeros([b, s_kv_pad, h, d_v], dtype="float32")
 
     fit_m, fit_n = _fit_block_mn(d, block_B, d_v)
     if block_M is None:
@@ -311,10 +295,7 @@ def block_score_mqa_bwd_interface(
         block_N = fit_n
     num_kv_blocks = s_kv_pad // block_B
 
-    # Per query-tile key-block window [jl, jh): jl skips leading blocks before
-    # the tile's document start, jh caps at the tile's (causal) reach. Rows are
-    # grouped into tiles of ``block_M``; padded rows get bos=+big / eos=0 so
-    # they never widen a tile's window.
+    # Per query-tile key-block window [jl, jh) in block_B units.
     num_bm = (s + block_M - 1) // block_M
     pad_rows = num_bm * block_M - s
     bos = valid_range[:, :, 0]
@@ -329,7 +310,7 @@ def block_score_mqa_bwd_interface(
     jh = paddle.maximum(jh, jl)
     block_range = paddle.stack([jl, jh], axis=-1).astype("int32").contiguous()
 
-    bwd = block_score_mqa_bwd(
+    bwd = block_score_mha_bwd(
         h,
         d,
         float(sm_scale),
@@ -340,9 +321,15 @@ def block_score_mqa_bwd_interface(
     )
     dq = bwd(q, k, v, do, lse, delta, valid_range, block_range, dk, dv)
 
-    dk_bf = _cast_bf16_kv(d)(dk)
-    dv_bf = _cast_bf16_kv(d_v)(dv)
+    # _cast_bf16_kv is a [B, S_kv, D] kernel; merge the (head, dim) axes so it
+    # covers the per-head [B, S_kv, H, D(_v)] accumulator, then restore shape.
+    dk_bf = _cast_bf16_kv(h * d)(dk.reshape([b, s_kv_pad, h * d])).reshape(
+        [b, s_kv_pad, h, d]
+    )
+    dv_bf = _cast_bf16_kv(h * d_v)(dv.reshape([b, s_kv_pad, h * d_v])).reshape(
+        [b, s_kv_pad, h, d_v]
+    )
     if pad > 0:
-        dk_bf = dk_bf[:, :s_kv, :].contiguous()
-        dv_bf = dv_bf[:, :s_kv, :].contiguous()
+        dk_bf = dk_bf[:, :s_kv, :, :].contiguous()
+        dv_bf = dv_bf[:, :s_kv, :, :].contiguous()
     return dq, dk_bf, dv_bf

--- a/src/paddlefleet/tilelang_ops/hysparse/block_sparse_attn_mqa.py
+++ b/src/paddlefleet/tilelang_ops/hysparse/block_sparse_attn_mqa.py
@@ -53,12 +53,18 @@ def block_sparse_mqa_fwd(
     D,
     nsel,
     sm_scale,
+    D_v=None,
     block_B=64,
     num_stages=2,
     threads=128,
 ):
+    if D_v is None:
+        D_v = D
     assert D % 16 == 0, (
         f"D must be a multiple of 16 (tensor-core k-tile), got {D}"
+    )
+    assert D_v % 16 == 0, (
+        f"D_v must be a multiple of 16 (tensor-core k-tile), got {D_v}"
     )
     assert H <= 128, "this kernel supports up to 128 query heads"
     scale_log2 = sm_scale * 1.44269504
@@ -69,7 +75,8 @@ def block_sparse_mqa_fwd(
 
     q_shape = [batch, seq_len, H, D]
     kv_shape = [batch, seq_len_kv, D]
-    o_shape = [batch, seq_len, H, D]
+    v_shape = [batch, seq_len_kv, D_v]
+    o_shape = [batch, seq_len, H, D_v]
     idx_shape = [batch, seq_len, nsel]
     vr_shape = [batch, seq_len, 2]
     lse_shape = [batch, seq_len, H]
@@ -84,7 +91,7 @@ def block_sparse_mqa_fwd(
     def main(
         Q: T.Tensor(q_shape, dtype),
         K: T.Tensor(kv_shape, dtype),
-        V: T.Tensor(kv_shape, dtype),
+        V: T.Tensor(v_shape, dtype),
         Indices: T.Tensor(idx_shape, idx_dtype),
         ValidRange: T.Tensor(vr_shape, idx_dtype),
         Output: T.Tensor(o_shape, dtype),
@@ -93,10 +100,10 @@ def block_sparse_mqa_fwd(
         with T.Kernel(seq_len, batch, threads=threads) as (bs, bb):
             Q_shared = T.alloc_shared([PH, D], dtype)
             K_shared = T.alloc_shared([BB, D], dtype)
-            V_shared = T.alloc_shared([BB, D], dtype)
+            V_shared = T.alloc_shared([BB, D_v], dtype)
             P_shared = T.alloc_shared([PH, BB], dtype)
 
-            acc_o = T.alloc_fragment([PH, D], accum_dtype)
+            acc_o = T.alloc_fragment([PH, D_v], accum_dtype)
             acc_s = T.alloc_fragment([PH, BB], accum_dtype)
             row_max = T.alloc_fragment([PH], accum_dtype)
             m_i = T.alloc_fragment([PH], accum_dtype)
@@ -135,6 +142,10 @@ def block_sparse_mqa_fwd(
                     K_shared[c, d] = T.if_then_else(
                         in_bounds, K[bb, safe_col, d], T.cast(0, dtype)
                     )
+                for c, d in T.Parallel(BB, D_v):
+                    col = bos + safe_blk * BB + c
+                    in_bounds = col < seq_len_kv
+                    safe_col = T.if_then_else(in_bounds, col, 0)
                     V_shared[c, d] = T.if_then_else(
                         in_bounds, V[bb, safe_col, d], T.cast(0, dtype)
                     )
@@ -172,7 +183,7 @@ def block_sparse_mqa_fwd(
                 T.reduce_sum(acc_s, l_new, dim=1)
                 for h in T.Parallel(PH):
                     l_i[h] = l_i[h] * alpha[h] + l_new[h]
-                for h, d in T.Parallel(PH, D):
+                for h, d in T.Parallel(PH, D_v):
                     acc_o[h, d] = acc_o[h, d] * alpha[h]
                 T.copy(acc_s, P_shared)
                 T.gemm(
@@ -180,11 +191,11 @@ def block_sparse_mqa_fwd(
                 )
 
             # normalize; empty rows (no selected valid key) -> 0 out / -inf lse
-            for h, d in T.Parallel(PH, D):
+            for h, d in T.Parallel(PH, D_v):
                 acc_o[h, d] = T.if_then_else(
                     l_i[h] > 0, acc_o[h, d] / l_i[h], 0.0
                 )
-            for h, d in T.Parallel(PH, D):
+            for h, d in T.Parallel(PH, D_v):
                 if h < H:
                     Output[bb, bs, h, d] = acc_o[h, d]
             for h in T.Parallel(PH):
@@ -217,14 +228,15 @@ def block_sparse_mqa_attn_fwd(
     assert q.is_contiguous()
     b, s, h, d = q.shape
     s_kv = k.shape[1]
+    d_v = v.shape[-1]
     nsel = indices.shape[-1]
     # lightweight host-side shape checks (no device sync) so mismatched inputs
     # fail early and clearly instead of causing undefined kernel behaviour.
-    assert len(k.shape) == 3 and list(k.shape) == list(v.shape), (
-        f"k/v must be [B, S_kv, D] and match; got {k.shape} vs {v.shape}"
+    assert len(k.shape) == 3 and k.shape[0] == b and k.shape[2] == d, (
+        f"k must be [B, S_kv, D] matching q; got k {k.shape}, q {q.shape}"
     )
-    assert k.shape[0] == b and k.shape[2] == d, (
-        f"k/v batch/head_dim must match q; got k {k.shape}, q {q.shape}"
+    assert len(v.shape) == 3 and list(v.shape[:2]) == [b, s_kv], (
+        f"v must be [B, S_kv, D_v] matching k seqlen; got {v.shape}, k {k.shape}"
     )
     assert list(indices.shape[:2]) == [b, s], (
         f"indices must be [B, S, nsel] matching q; got {indices.shape}"
@@ -250,6 +262,8 @@ def block_sparse_mqa_attn_fwd(
     valid_range = valid_range.contiguous()
     indices = indices.contiguous()
 
-    kernel = block_sparse_mqa_fwd(h, d, nsel, float(sm_scale), block_B=block_B)
+    kernel = block_sparse_mqa_fwd(
+        h, d, nsel, float(sm_scale), D_v=d_v, block_B=block_B
+    )
     out, lse = kernel(q, k, v, indices, valid_range)
     return out, lse

--- a/src/paddlefleet/tilelang_ops/hysparse/block_sparse_attn_mqa_bwd.py
+++ b/src/paddlefleet/tilelang_ops/hysparse/block_sparse_attn_mqa_bwd.py
@@ -39,13 +39,19 @@ def block_sparse_mqa_bwd(
     D,
     nsel,
     sm_scale,
+    D_v=None,
     block_B=64,
     block_H=None,
     num_stages=1,
     threads=128,
 ):
+    if D_v is None:
+        D_v = D
     assert D % 16 == 0, (
         f"D must be a multiple of 16 (tensor-core k-tile), got {D}"
+    )
+    assert D_v % 16 == 0, (
+        f"D_v must be a multiple of 16 (tensor-core k-tile), got {D_v}"
     )
     assert H <= 128, "this kernel supports up to 128 query heads"
 
@@ -55,6 +61,8 @@ def block_sparse_mqa_bwd(
 
     q_shape = [batch, seq_len, H, D]
     kv_shape = [batch, seq_len_kv, D]
+    v_shape = [batch, seq_len_kv, D_v]
+    do_shape = [batch, seq_len, H, D_v]
     idx_shape = [batch, seq_len, nsel]
     vr_shape = [batch, seq_len, 2]
     lse_shape = [batch, seq_len, H]
@@ -74,22 +82,22 @@ def block_sparse_mqa_bwd(
     def main(
         Q: T.Tensor(q_shape, dtype),
         K: T.Tensor(kv_shape, dtype),
-        V: T.Tensor(kv_shape, dtype),
-        dO: T.Tensor(q_shape, dtype),
+        V: T.Tensor(v_shape, dtype),
+        dO: T.Tensor(do_shape, dtype),
         Lse: T.Tensor(lse_shape, accum_dtype),
         Delta: T.Tensor(lse_shape, accum_dtype),
         Indices: T.Tensor(idx_shape, idx_dtype),
         ValidRange: T.Tensor(vr_shape, idx_dtype),
         dK: T.Tensor(kv_shape, accum_dtype),
-        dV: T.Tensor(kv_shape, accum_dtype),
+        dV: T.Tensor(v_shape, accum_dtype),
         dQ: T.Tensor(q_shape, dtype),
     ):
         with T.Kernel(num_hg, seq_len, batch, threads=threads) as (hg, bs, bb):
             h0 = hg * BH
             Q_shared = T.alloc_shared([PH, D], dtype)
-            dO_shared = T.alloc_shared([PH, D], dtype)
+            dO_shared = T.alloc_shared([PH, D_v], dtype)
             K_shared = T.alloc_shared([BB, D], dtype)
-            V_shared = T.alloc_shared([BB, D], dtype)
+            V_shared = T.alloc_shared([BB, D_v], dtype)
             P_shared = T.alloc_shared([PH, BB], dtype)
             dS_shared = T.alloc_shared([PH, BB], dtype)
             dQ_shared = T.alloc_shared([PH, D], dtype)
@@ -99,7 +107,7 @@ def block_sparse_mqa_bwd(
             acc_dp = T.alloc_fragment([PH, BB], accum_dtype)
             acc_dq = T.alloc_fragment([PH, D], accum_dtype)
             acc_dk = T.alloc_fragment([BB, D], accum_dtype)
-            acc_dv = T.alloc_fragment([BB, D], accum_dtype)
+            acc_dv = T.alloc_fragment([BB, D_v], accum_dtype)
             lse_f = T.alloc_fragment([PH], accum_dtype)
             delta_f = T.alloc_fragment([PH], accum_dtype)
 
@@ -113,6 +121,10 @@ def block_sparse_mqa_bwd(
                 Q_shared[h, d] = T.if_then_else(
                     use, Q[bb, bs, sh, d], T.cast(0, dtype)
                 )
+            for h, d in T.Parallel(PH, D_v):
+                gh = h0 + h
+                use = (h < BH) and (gh < H)
+                sh = T.if_then_else(use, gh, 0)
                 dO_shared[h, d] = T.if_then_else(
                     use, dO[bb, bs, sh, d], T.cast(0, dtype)
                 )
@@ -140,6 +152,10 @@ def block_sparse_mqa_bwd(
                     K_shared[c, d] = T.if_then_else(
                         in_bounds, K[bb, safe_col, d], T.cast(0, dtype)
                     )
+                for c, d in T.Parallel(BB, D_v):
+                    col = bos + safe_blk * BB + c
+                    in_bounds = col < seq_len_kv
+                    safe_col = T.if_then_else(in_bounds, col, 0)
                     V_shared[c, d] = T.if_then_else(
                         in_bounds, V[bb, safe_col, d], T.cast(0, dtype)
                     )
@@ -208,8 +224,11 @@ def block_sparse_mqa_bwd(
                 for c, d in T.Parallel(BB, D):
                     col = bos + safe_blk * BB + c
                     if valid_blk and (col < seq_len_kv):
-                        T.atomic_add(dV[bb, col, d], acc_dv[c, d])
                         T.atomic_add(dK[bb, col, d], acc_dk[c, d])
+                for c, d in T.Parallel(BB, D_v):
+                    col = bos + safe_blk * BB + c
+                    if valid_blk and (col < seq_len_kv):
+                        T.atomic_add(dV[bb, col, d], acc_dv[c, d])
 
             T.copy(acc_dq, dQ_shared)
             for h, d in T.Parallel(PH, D):
@@ -241,16 +260,21 @@ def _cast_bf16_kv(D, block_N=64, threads=128):
     return main
 
 
-def _fit_block_h(H, D, block_B, cap_bytes=200000):
+def _fit_block_h(H, D, block_B, D_v=None, cap_bytes=200000):
     """Largest head-group (a divisor-ish of H) whose per-token backward shared
-    buffers fit. Q/dO/dQ ``[PH, D]`` + K/V ``[BB, D]`` + P/dS ``[PH, BB]`` in
-    bf16; for large D (MLA 576) all H=64 heads on M overflow, so tile them.
+    buffers fit. Q/dQ ``[PH, D]`` + dO ``[PH, D_v]`` + K ``[BB, D]`` + V
+    ``[BB, D_v]`` + P/dS ``[PH, BB]`` in bf16; for large D (MLA 576) all H=64
+    heads on M overflow, so tile them.
     """
+    if D_v is None:
+        D_v = D
     for bh in (H, 64, 32, 16):
         if bh > H:
             continue
         ph = max(tilelang.math.next_power_of_2(bh), 16)
-        shared = 6 * ph * D + 4 * block_B * D + 4 * ph * block_B
+        shared = 2 * (
+            ph * (2 * D + D_v) + block_B * (D + D_v) + 2 * ph * block_B
+        )
         if shared <= cap_bytes:
             return bh
     return min(H, 16)
@@ -278,6 +302,7 @@ def block_sparse_mqa_bwd_interface(
     assert q.is_contiguous() and do.is_contiguous() and lse.is_contiguous()
     b, s, h, d = q.shape
     s_kv = k.shape[1]
+    d_v = v.shape[-1]
     if sm_scale is None:
         sm_scale = d**-0.5
     if valid_range.dtype != paddle.int32:
@@ -299,21 +324,21 @@ def block_sparse_mqa_bwd_interface(
 
     delta = (o.astype("float32") * do.astype("float32")).sum(-1).contiguous()
     dk = paddle.zeros([b, s_kv_pad, d], dtype="float32")
-    dv = paddle.zeros([b, s_kv_pad, d], dtype="float32")
+    dv = paddle.zeros([b, s_kv_pad, d_v], dtype="float32")
 
     bwd = block_sparse_mqa_bwd(
         h,
         d,
         indices.shape[-1],
         float(sm_scale),
+        D_v=d_v,
         block_B=block_B,
-        block_H=_fit_block_h(h, d, block_B),
+        block_H=_fit_block_h(h, d, block_B, d_v),
     )
     dq = bwd(q, k, v, do, lse, delta, indices, valid_range, dk, dv)
 
-    cast = _cast_bf16_kv(d)
-    dk_bf = cast(dk)
-    dv_bf = cast(dv)
+    dk_bf = _cast_bf16_kv(d)(dk)
+    dv_bf = _cast_bf16_kv(d_v)(dv)
     if pad > 0:
         dk_bf = dk_bf[:, :s_kv, :].contiguous()
         dv_bf = dv_bf[:, :s_kv, :].contiguous()

--- a/src/paddlefleet/tilelang_ops/hysparse/differentiable_ops.py
+++ b/src/paddlefleet/tilelang_ops/hysparse/differentiable_ops.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Autograd (``paddle.autograd.PyLayer``) wrappers for the HySparse MQA block
+"""Autograd (``paddle.autograd.PyLayer``) wrappers for the HySparse block
 attention operators, combining the separate TileLang forward and backward
 kernels into differentiable ops usable inside a training network.
 
-Two ops, both with a single shared K/V head:
+MQA (single shared K/V head):
 
 * :class:`BlockScoreMQAAttn` -- full block-score attention. Returns the
   attention output (differentiable) plus ``lse`` and per-block ``block_logit``
@@ -24,6 +24,12 @@ Two ops, both with a single shared K/V head:
 * :class:`BlockSparseMQAAttn` -- block-sparse gather attention over a
   per-query-token selection of key blocks. Returns output (differentiable) and
   ``lse`` (non-differentiable).
+
+MHA (per-head K/V, decompressed-MLA layout):
+
+* :class:`BlockScoreMHAAttn` -- full block-score attention with a K/V head per
+  query head. Same differentiable / non-differentiable split as the MQA
+  variant.
 
 The convenience :func:`hysparse_mqa_attention` chains score -> TopK -> sparse:
 the TopK sits between the two PyLayers and carries no gradient, exactly as in
@@ -34,6 +40,8 @@ import paddle
 
 from .block_score_attn import block_score_mqa_attn_fwd
 from .block_score_attn_bwd import block_score_mqa_bwd_interface
+from .block_score_attn_mha import block_score_mha_attn_fwd
+from .block_score_attn_mha_bwd import block_score_mha_bwd_interface
 from .block_sparse_attn_mqa import block_sparse_mqa_attn_fwd
 from .block_sparse_attn_mqa_bwd import block_sparse_mqa_bwd_interface
 from .pipeline import select_topk_blocks
@@ -143,6 +151,55 @@ class BlockSparseMQAAttn(paddle.autograd.PyLayer):
         )
 
 
+class BlockScoreMHAAttn(paddle.autograd.PyLayer):
+    """Differentiable MHA block-score attention (per-head K/V).
+
+    forward inputs: q [B,S,H,D], k [B,S_kv,H,D], v [B,S_kv,H,Dv],
+    valid_range [B,S,2] int32, plus scalar ``sm_scale`` and ``block_B``.
+    outputs: out [B,S,H,Dv] (differentiable), lse [B,S,H] and
+    block_logit [B,H,S,num_blocks] (both non-differentiable).
+    """
+
+    @staticmethod
+    def forward(ctx, q, k, v, valid_range, sm_scale, block_B):
+        out, lse, block_logit = block_score_mha_attn_fwd(
+            q, k, v, valid_range, sm_scale=sm_scale, block_B=block_B
+        )
+        ctx.save_for_backward(q, k, v, out, lse, valid_range)
+        ctx.sm_scale = sm_scale
+        ctx.block_B = block_B
+        ctx.needs_grad = (
+            not q.stop_gradient,
+            not k.stop_gradient,
+            not v.stop_gradient,
+        )
+        ctx.mark_non_differentiable(lse, block_logit)
+        return out, lse, block_logit
+
+    @staticmethod
+    def backward(ctx, grad_out, *_):
+        q, k, v, out, lse, valid_range = ctx.saved_tensor()
+        dq, dk, dv = block_score_mha_bwd_interface(
+            q,
+            k,
+            v,
+            out,
+            grad_out.contiguous(),
+            lse,
+            valid_range,
+            sm_scale=ctx.sm_scale,
+            block_B=ctx.block_B,
+        )
+        gq, gk, gv = ctx.needs_grad
+        # one entry per Tensor input: q, k, v, valid_range (no grad on range).
+        return (
+            dq if gq else None,
+            dk if gk else None,
+            dv if gv else None,
+            None,
+        )
+
+
 def block_score_mqa_attention(q, k, v, valid_range, sm_scale=None, block_B=64):
     """Differentiable block-score attention (see :class:`BlockScoreMQAAttn`).
 
@@ -166,6 +223,19 @@ def block_sparse_mqa_attention(
         sm_scale = q.shape[-1] ** -0.5
     return BlockSparseMQAAttn.apply(
         q, k, v, indices, valid_range, float(sm_scale), block_B
+    )
+
+
+def block_score_mha_attention(q, k, v, valid_range, sm_scale=None, block_B=64):
+    """Differentiable MHA block-score attention (see :class:`BlockScoreMHAAttn`).
+
+    Per-head K/V; returns ``(out, lse, block_logit)``; only ``out`` carries
+    gradient.
+    """
+    if sm_scale is None:
+        sm_scale = q.shape[-1] ** -0.5
+    return BlockScoreMHAAttn.apply(
+        q, k, v, valid_range, float(sm_scale), block_B
     )
 
 

--- a/src/paddlefleet/tilelang_ops/hysparse/reference.py
+++ b/src/paddlefleet/tilelang_ops/hysparse/reference.py
@@ -72,13 +72,14 @@ def ref_block_score_attn_mqa(q, k, v, valid_range, sm_scale=None, block_B=64):
     """
     b, s, h, d = q.shape
     s_kv = k.shape[1]
+    d_v = v.shape[-1]
     if sm_scale is None:
         sm_scale = d**-0.5
 
     qb = _to_bhsd(q).astype("float32")  # [B, H, S, D]
     # broadcast the single shared K/V head across all query heads
     kb = k.astype("float32").unsqueeze(1)  # [B, 1, S_kv, D]
-    vb = v.astype("float32").unsqueeze(1)  # [B, 1, S_kv, D]
+    vb = v.astype("float32").unsqueeze(1)  # [B, 1, S_kv, D_v]
 
     logits = paddle.matmul(qb, kb, transpose_y=True) * sm_scale  # [B,H,S,S_kv]
     mask = _range_mask(valid_range, s_kv)  # [B,1,S,S_kv]
@@ -93,7 +94,7 @@ def ref_block_score_attn_mqa(q, k, v, valid_range, sm_scale=None, block_B=64):
     probs = paddle.where(
         row_has_key.expand_as(probs), probs, paddle.zeros_like(probs)
     )
-    out = paddle.matmul(probs, vb.expand([b, h, s_kv, d]))  # [B,H,S,D]
+    out = paddle.matmul(probs, vb.expand([b, h, s_kv, d_v]))  # [B,H,S,D_v]
 
     # Block-max probability with **document-relative** block coordinates: block j
     # of a query spans key columns [bos + j*block_B, bos + (j+1)*block_B), i.e.
@@ -115,6 +116,71 @@ def ref_block_score_attn_mqa(q, k, v, valid_range, sm_scale=None, block_B=64):
     s_block = paddle.stack(s_block_list, axis=-1)  # [B,H,S,num_blocks]
 
     out = out.transpose([0, 2, 1, 3])  # back to [B,S,H,D]
+    lse = lse.transpose([0, 2, 1])  # [B,S,H]
+    return out.astype(q.dtype), lse, s_block
+
+
+def ref_block_score_attn_mha(q, k, v, valid_range, sm_scale=None, block_B=64):
+    """Block-score attention reference (MHA): full attention with **per-head**
+    K/V plus block-max probability scores (eq. 3).
+
+    Sibling of :func:`ref_block_score_attn_mqa` but K/V carry a head axis and
+    are *not* broadcast: ``logits = einsum(q[B,H,S,D], k[B,H,S_kv,D])``. Block
+    coordinates are **absolute** (``col // block_B``), matching
+    :mod:`block_score_attn_mha`; the causal single-document tests use
+    ``bos == 0`` so absolute == document-relative.
+
+    Args:
+        q:           [B, S, H, D] query (H heads).
+        k:           [B, S_kv, H, D] per-head key.
+        v:           [B, S_kv, H, D_v] per-head value.
+        valid_range: [B, S, 2] int, per-query [bos, eos) valid key columns.
+        sm_scale:    softmax scale; defaults to D**-0.5.
+        block_B:     key block size for the emitted block scores.
+
+    Returns:
+        out:     [B, S, H, D_v] attention output.
+        lse:     [B, S, H] natural-log-sum-exp of the masked logits.
+        s_block: [B, H, S, num_blocks] block-max softmax probability (eq. 3),
+                 num_blocks = ceil(S_kv / block_B). Fully-masked blocks -> 0.
+    """
+    b, s, h, d = q.shape
+    s_kv = k.shape[1]
+    if sm_scale is None:
+        sm_scale = d**-0.5
+
+    qb = _to_bhsd(q).astype("float32")  # [B, H, S, D]
+    kb = _to_bhsd(k).astype("float32")  # [B, H, S_kv, D]
+    vb = _to_bhsd(v).astype("float32")  # [B, H, S_kv, D_v]
+
+    logits = paddle.matmul(qb, kb, transpose_y=True) * sm_scale  # [B,H,S,S_kv]
+    mask = _range_mask(valid_range, s_kv)  # [B,1,S,S_kv]
+    neg = paddle.full_like(logits, NEG_INF)
+    logits = paddle.where(mask, logits, neg)
+
+    row_has_key = mask.any(axis=-1, keepdim=True)  # [B,1,S,1]
+    lse = paddle.logsumexp(logits, axis=-1)  # [B,H,S]
+    probs = F.softmax(logits, axis=-1)  # [B,H,S,S_kv]
+    probs = paddle.where(
+        row_has_key.expand_as(probs), probs, paddle.zeros_like(probs)
+    )
+    out = paddle.matmul(probs, vb)  # [B,H,S,D_v]
+
+    # Block-max probability with **absolute** block coordinates: block j spans
+    # key columns [j*block_B, (j+1)*block_B).
+    num_blocks = (s_kv + block_B - 1) // block_B
+    col = paddle.arange(s_kv, dtype="int64").reshape([1, 1, 1, s_kv])
+    abs_id = col // block_B  # [1,1,1,S_kv] absolute block id per key column
+    s_block_list = []
+    for j in range(num_blocks):
+        hit = abs_id == j  # [1,1,1,S_kv]
+        masked = paddle.where(
+            hit.expand_as(probs), probs, paddle.zeros_like(probs)
+        )
+        s_block_list.append(masked.max(axis=-1))  # [B, H, S]
+    s_block = paddle.stack(s_block_list, axis=-1)  # [B,H,S,num_blocks]
+
+    out = out.transpose([0, 2, 1, 3])  # back to [B,S,H,D_v]
     lse = lse.transpose([0, 2, 1])  # [B,S,H]
     return out.astype(q.dtype), lse, s_block
 
@@ -167,13 +233,14 @@ def ref_block_sparse_attn_mqa(
     """
     b, s, h, d = q.shape
     s_kv = k.shape[1]
+    d_v = v.shape[-1]
     if sm_scale is None:
         sm_scale = d**-0.5
 
     qb = _to_bhsd(q).astype("float32")  # [B, H, S, D]
     # broadcast the single shared KV head across all query heads
     kb = k.astype("float32").unsqueeze(1)  # [B, 1, S_kv, D]
-    vb = v.astype("float32").unsqueeze(1)  # [B, 1, S_kv, D]
+    vb = v.astype("float32").unsqueeze(1)  # [B, 1, S_kv, D_v]
 
     logits = paddle.matmul(qb, kb, transpose_y=True) * sm_scale  # [B,H,S,S_kv]
 
@@ -194,7 +261,7 @@ def ref_block_sparse_attn_mqa(
     probs = paddle.where(
         row_has_key.expand_as(probs), probs, paddle.zeros_like(probs)
     )
-    out = paddle.matmul(probs, vb.expand([b, h, s_kv, d]))  # [B,H,S,D]
+    out = paddle.matmul(probs, vb.expand([b, h, s_kv, d_v]))  # [B,H,S,D_v]
 
     out = out.transpose([0, 2, 1, 3])
     lse = lse.transpose([0, 2, 1])
@@ -226,5 +293,47 @@ def make_causal_valid_range(seq_len, batch=1, doc_lengths=None):
             starts += [cur] * dl
             cur += dl
         bos = paddle.to_tensor(starts, dtype="int32")
+    vr = paddle.stack([bos, eos], axis=-1)  # [S, 2]
+    return vr.unsqueeze(0).expand([batch, seq_len, 2]).contiguous()
+
+
+def make_sliding_window_valid_range(
+    seq_len, window_size, batch=1, doc_lengths=None
+):
+    """Helper: build valid_range [B, S, 2] for a causal **sliding window**.
+
+    Each query token ``t`` attends to key columns
+    ``[max(doc_start, t - window_size + 1), t + 1)`` -- i.e. the last
+    ``window_size`` keys (inclusive of self), clamped to the token's document
+    start. This is the standard causal sliding-window (SWA) mask, expressed
+    through the same half-open ``valid_range`` used by the block-attention
+    kernels, so a full-attention kernel fed this range computes SWA (and its
+    ``eos - bos`` early-exit naturally bounds the work to the window).
+
+    Args:
+        seq_len:     total sequence length S (== S_kv).
+        window_size: sliding window width W (number of keys each query sees).
+        batch:       batch size B.
+        doc_lengths: optional packed document lengths; each token's window is
+                     clamped to its own document start.
+
+    Returns:
+        valid_range: [B, S, 2] int32.
+    """
+    assert window_size >= 1
+    pos = paddle.arange(seq_len, dtype="int32")
+    eos = pos + 1  # causal upper bound (inclusive of self)
+    if doc_lengths is None:
+        doc_start = paddle.zeros([seq_len], dtype="int32")
+    else:
+        assert sum(doc_lengths) == seq_len
+        starts = []
+        cur = 0
+        for dl in doc_lengths:
+            starts += [cur] * dl
+            cur += dl
+        doc_start = paddle.to_tensor(starts, dtype="int32")
+    win_start = pos - window_size + 1  # earliest key in the window
+    bos = paddle.maximum(win_start, doc_start).cast("int32")
     vr = paddle.stack([bos, eos], axis=-1)  # [S, 2]
     return vr.unsqueeze(0).expand([batch, seq_len, 2]).contiguous()

--- a/src/paddlefleet/tilelang_ops/hysparse/swa_attn.py
+++ b/src/paddlefleet/tilelang_ops/hysparse/swa_attn.py
@@ -49,6 +49,12 @@ class _SlidingWindowMQAAttn(paddle.autograd.PyLayer):
         ctx.save_for_backward(q, k, v, out, lse, valid_range)
         ctx.sm_scale = sm_scale
         ctx.block_B = block_B
+        # PyLayer contract: backward returns None for stop_gradient inputs.
+        ctx.needs_grad = (
+            not q.stop_gradient,
+            not k.stop_gradient,
+            not v.stop_gradient,
+        )
         ctx.mark_non_differentiable(lse)
         return out, lse
 
@@ -60,13 +66,20 @@ class _SlidingWindowMQAAttn(paddle.autograd.PyLayer):
             k,
             v,
             out,
-            dout,
+            dout.contiguous(),
             lse,
             valid_range,
             sm_scale=ctx.sm_scale,
             block_B=ctx.block_B,
         )
-        return dq, dk, dv, None
+        gq, gk, gv = ctx.needs_grad
+        # one entry per Tensor input: q, k, v, valid_range (no grad on range).
+        return (
+            dq if gq else None,
+            dk if gk else None,
+            dv if gv else None,
+            None,
+        )
 
 
 def sliding_window_mqa_attention(

--- a/src/paddlefleet/tilelang_ops/hysparse/swa_attn.py
+++ b/src/paddlefleet/tilelang_ops/hysparse/swa_attn.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Causal sliding-window attention (SWA), MQA, on top of the tested block-score
+TileLang kernels.
+
+A causal sliding window is just a masking pattern: query token ``t`` attends to
+keys ``[max(doc_start, t - W + 1), t + 1)``. That half-open range is exactly the
+``valid_range [B, S, 2]`` the block-score kernels already consume, and their
+``eos - bos`` (document-tight) early-exit naturally bounds the per-token work to
+the window ``W`` instead of the full sequence. So SWA needs **no new kernel** --
+we feed a windowed ``valid_range`` (see
+:func:`..reference.make_sliding_window_valid_range`) to the block-score
+forward/backward and drop the (unused) per-block max-logit output.
+
+Why this matters for the HySparse / MLA stack: FlashAttention (FA2/3/4) exposes
+``window_size`` and covers SWA directly for ``head_dim <= 256``. But the
+**absorbed-MLA MQA** shape has Dk=576 / Dv=512 (> 256), which FA4 does not
+support (the model falls back to an eager dense attention). This TileLang SWA
+MQA path fills that gap: a fused windowed flash attention at Dk=576/Dv=512 that
+is far cheaper than the eager O(S^2) fallback.
+"""
+
+import paddle
+
+from .block_score_attn import block_score_mqa_attn_fwd
+from .block_score_attn_bwd import block_score_mqa_bwd_interface
+
+
+class _SlidingWindowMQAAttn(paddle.autograd.PyLayer):
+    """Autograd wrapper: causal SWA with a single shared K/V head (MQA)."""
+
+    @staticmethod
+    def forward(ctx, q, k, v, valid_range, sm_scale, block_B):
+        out, lse, _ = block_score_mqa_attn_fwd(
+            q, k, v, valid_range, sm_scale=sm_scale, block_B=block_B
+        )
+        ctx.save_for_backward(q, k, v, out, lse, valid_range)
+        ctx.sm_scale = sm_scale
+        ctx.block_B = block_B
+        ctx.mark_non_differentiable(lse)
+        return out, lse
+
+    @staticmethod
+    def backward(ctx, dout, dlse):
+        q, k, v, out, lse, valid_range = ctx.saved_tensor()
+        dq, dk, dv = block_score_mqa_bwd_interface(
+            q,
+            k,
+            v,
+            out,
+            dout,
+            lse,
+            valid_range,
+            sm_scale=ctx.sm_scale,
+            block_B=ctx.block_B,
+        )
+        return dq, dk, dv, None
+
+
+def sliding_window_mqa_attention(
+    q, k, v, valid_range, sm_scale=None, block_B=64
+):
+    """Causal sliding-window attention, MQA (single shared K/V head).
+
+    Args:
+        q:           [B, S, H, D] bf16.
+        k, v:        [B, S_kv, D] bf16 shared key/value.
+        valid_range: [B, S, 2] int32 windowed range (see
+                     :func:`..reference.make_sliding_window_valid_range`).
+        sm_scale:    softmax scale; defaults to D**-0.5.
+        block_B:     key block size.
+
+    Returns:
+        out [B, S, H, D_v] bf16, lse [B, S, H] fp32 (non-differentiable).
+    """
+    if sm_scale is None:
+        sm_scale = q.shape[-1] ** -0.5
+    return _SlidingWindowMQAAttn.apply(
+        q, k, v, valid_range, float(sm_scale), block_B
+    )

--- a/tests/single_card_tests/custom_ops/test_hysparse_autograd.py
+++ b/tests/single_card_tests/custom_ops/test_hysparse_autograd.py
@@ -1,0 +1,160 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Autograd-contract tests for the HySparse MQA ``PyLayer`` wrappers.
+
+These validate two properties the low-level fwd/bwd interface tests do not:
+
+* the ``PyLayer`` backward honours the Paddle contract -- it returns a gradient
+  for exactly the Tensor inputs whose ``stop_gradient`` is False and ``None``
+  for every frozen input (and for the non-differentiable ``indices`` /
+  ``valid_range`` slots), so partial-freeze training graphs do not error and
+  do not leak gradient into detached tensors;
+* the backward accepts a **non-contiguous** upstream gradient (the kernel
+  interfaces assert ``do.is_contiguous()`` -- the wrapper must materialise it).
+"""
+
+import unittest
+
+import paddle
+
+paddle.enable_compat(scope={"tilelang"}, silent=True)
+
+from paddlefleet.tilelang_ops.hysparse.autograd import (
+    block_score_mqa_attention,
+    block_sparse_mqa_attention,
+)
+from paddlefleet.tilelang_ops.hysparse.reference import (
+    make_causal_valid_range,
+)
+
+
+def _cuda_or_skip(testcase):
+    if not paddle.device.is_compiled_with_cuda():
+        testcase.skipTest("CUDA build of Paddle is required")
+    if paddle.device.cuda.device_count() == 0:
+        testcase.skipTest("No CUDA device available")
+
+
+def _leaves(b, s, h, d, seed=0, freeze=()):
+    """q [B,S,H,D] and shared K/V [B,S,D]; ``freeze`` names get
+    stop_gradient=True."""
+    paddle.seed(seed)
+    q = paddle.randn([b, s, h, d], dtype="bfloat16")
+    k = paddle.randn([b, s, d], dtype="bfloat16")
+    v = paddle.randn([b, s, d], dtype="bfloat16")
+    tensors = {"q": q, "k": k, "v": v}
+    for name, t in tensors.items():
+        t.stop_gradient = name in freeze
+    return q, k, v
+
+
+class TestAutogradStopGradient(unittest.TestCase):
+    """PyLayer backward must return None for frozen inputs, Tensor otherwise."""
+
+    B, S, H, D = 2, 128, 4, 64
+
+    def _score(self, freeze):
+        q, k, v = _leaves(self.B, self.S, self.H, self.D, seed=3, freeze=freeze)
+        vr = make_causal_valid_range(self.S, batch=self.B)
+        out, _, _ = block_score_mqa_attention(q, k, v, vr, block_B=64)
+        out.sum().backward()
+        return q, k, v
+
+    def _sparse(self, freeze):
+        q, k, v = _leaves(self.B, self.S, self.H, self.D, seed=4, freeze=freeze)
+        vr = make_causal_valid_range(self.S, batch=self.B)
+        num_blocks = (self.S + 63) // 64
+        idx = paddle.arange(num_blocks, dtype="int32")
+        idx = idx.reshape([1, 1, num_blocks]).expand(
+            [self.B, self.S, num_blocks]
+        )
+        out, _ = block_sparse_mqa_attention(q, k, v, idx, vr, block_B=64)
+        out.sum().backward()
+        return q, k, v
+
+    def _check(self, q, k, v, freeze):
+        for name, t in (("q", q), ("k", k), ("v", v)):
+            if name in freeze:
+                self.assertIsNone(t.grad, f"{name} frozen -> grad must be None")
+            else:
+                self.assertIsNotNone(
+                    t.grad, f"{name} trainable -> grad must exist"
+                )
+
+    def test_score_all_trainable(self):
+        _cuda_or_skip(self)
+        self._check(*self._score(freeze=()), freeze=())
+
+    def test_score_freeze_q(self):
+        _cuda_or_skip(self)
+        self._check(*self._score(freeze=("q",)), freeze=("q",))
+
+    def test_score_freeze_kv(self):
+        _cuda_or_skip(self)
+        self._check(*self._score(freeze=("k", "v")), freeze=("k", "v"))
+
+    def test_sparse_all_trainable(self):
+        _cuda_or_skip(self)
+        self._check(*self._sparse(freeze=()), freeze=())
+
+    def test_sparse_freeze_q(self):
+        _cuda_or_skip(self)
+        self._check(*self._sparse(freeze=("q",)), freeze=("q",))
+
+    def test_sparse_freeze_kv(self):
+        _cuda_or_skip(self)
+        self._check(*self._sparse(freeze=("k", "v")), freeze=("k", "v"))
+
+
+class TestAutogradNonContiguousGrad(unittest.TestCase):
+    """Backward must accept a non-contiguous upstream gradient."""
+
+    B, S, H, D = 2, 128, 4, 64
+
+    def _non_contig_grad_loss(self, out):
+        # Transposing the PyLayer output makes the gradient that flows back
+        # into ``out`` non-contiguous, exercising the wrapper's .contiguous().
+        t = out.transpose([0, 2, 1, 3])
+        self.assertFalse(t.is_contiguous())
+        return t.sum()
+
+    def test_score_non_contiguous(self):
+        _cuda_or_skip(self)
+        q, k, v = _leaves(self.B, self.S, self.H, self.D, seed=5)
+        vr = make_causal_valid_range(self.S, batch=self.B)
+        out, _, _ = block_score_mqa_attention(q, k, v, vr, block_B=64)
+        self._non_contig_grad_loss(out).backward()
+        self.assertIsNotNone(q.grad)
+        self.assertIsNotNone(k.grad)
+        self.assertIsNotNone(v.grad)
+
+    def test_sparse_non_contiguous(self):
+        _cuda_or_skip(self)
+        q, k, v = _leaves(self.B, self.S, self.H, self.D, seed=6)
+        vr = make_causal_valid_range(self.S, batch=self.B)
+        num_blocks = (self.S + 63) // 64
+        idx = paddle.arange(num_blocks, dtype="int32")
+        idx = idx.reshape([1, 1, num_blocks]).expand(
+            [self.B, self.S, num_blocks]
+        )
+        out, _ = block_sparse_mqa_attention(q, k, v, idx, vr, block_B=64)
+        self._non_contig_grad_loss(out).backward()
+        self.assertIsNotNone(q.grad)
+        self.assertIsNotNone(k.grad)
+        self.assertIsNotNone(v.grad)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/custom_ops/test_hysparse_block_attn.py
+++ b/tests/single_card_tests/custom_ops/test_hysparse_block_attn.py
@@ -83,6 +83,18 @@ def _rand_qkv_mqa(b, s, h, d, seed=0):
     return q, k, v
 
 
+def _rand_qkv_mqa_dv(b, s, h, dk, dv, seed=0):
+    """Asymmetric absorbed-MLA layout: query/key head dim ``dk`` (e.g. 576),
+    value/output head dim ``dv`` (e.g. 512). Q [B,S,H,Dk]; K [B,S,Dk] and
+    V [B,S,Dv] a single shared head each.
+    """
+    paddle.seed(seed)
+    q = paddle.randn([b, s, h, dk], dtype="bfloat16")
+    k = paddle.randn([b, s, dk], dtype="bfloat16")
+    v = paddle.randn([b, s, dv], dtype="bfloat16")
+    return q, k, v
+
+
 def _grad_ref_qkv(q, k, v):
     """float32 leaf copies of q/k/v for autograd reference gradients."""
     qf = q.astype("float32")
@@ -564,6 +576,86 @@ class TestHeadDim576MQA(unittest.TestCase):
             sm_scale=sm_scale,
             block_B=block_B,
         )
+        self.assertGreater(_cos(dq, qf.grad), 0.999)
+        self.assertGreater(_cos(dk, kf.grad), 0.999)
+        self.assertGreater(_cos(dv, vf.grad), 0.999)
+
+
+class TestAsymmetricDkDvMQA(unittest.TestCase):
+    """Absorbed-MLA asymmetric head dims: query/key Dk=576, value/output
+    Dv=512. Exercises the Dk!=Dv generalization of both ops (fwd + bwd).
+    Gradients checked by cosine (absolute errors grow with magnitude at D=576).
+    """
+
+    def test_score_fwd_bwd(self):
+        _cuda_or_skip(self)
+        B, S, H, Dk, Dv = 1, 192, 8, 576, 512
+        block_B = 64
+        q, k, v = _rand_qkv_mqa_dv(B, S, H, Dk, Dv, seed=41)
+        vr = make_causal_valid_range(S, batch=B)
+        sm_scale = Dk**-0.5
+
+        qf, kf, vf = _grad_ref_qkv(q, k, v)
+        ref_out, ref_lse, ref_sblk = ref_block_score_attn_mqa(
+            qf, kf, vf, vr, sm_scale=sm_scale, block_B=block_B
+        )
+        out, lse, block_logit = block_score_mqa_attn_fwd(
+            q, k, v, vr, sm_scale=sm_scale, block_B=block_B
+        )
+        self.assertEqual(list(out.shape), [B, S, H, Dv])
+        sblk = block_scores_from_logit(block_logit, lse, sm_scale)
+        self.assertLess(_maxerr(out, ref_out), OUT_ATOL)
+        self.assertLess(_maxerr(lse, ref_lse), LSE_ATOL)
+        self.assertLess(_maxerr(sblk, ref_sblk), 1e-3)
+
+        do = paddle.randn([B, S, H, Dv], dtype="bfloat16")
+        (ref_out * do.astype("float32")).sum().backward()
+        dq, dk, dv = block_score_mqa_bwd_interface(
+            q, k, v, out, do, lse, vr, sm_scale=sm_scale, block_B=block_B
+        )
+        self.assertEqual(list(dq.shape), [B, S, H, Dk])
+        self.assertEqual(list(dk.shape), [B, S, Dk])
+        self.assertEqual(list(dv.shape), [B, S, Dv])
+        self.assertGreater(_cos(dq, qf.grad), 0.999)
+        self.assertGreater(_cos(dk, kf.grad), 0.999)
+        self.assertGreater(_cos(dv, vf.grad), 0.999)
+
+    def test_sparse_fwd_bwd(self):
+        _cuda_or_skip(self)
+        B, S, H, Dk, Dv = 1, 192, 8, 576, 512
+        block_B, topk = 64, 2
+        q, k, v = _rand_qkv_mqa_dv(B, S, H, Dk, Dv, seed=42)
+        vr = make_causal_valid_range(S, batch=B)
+        sm_scale = Dk**-0.5
+
+        # derive selection from the block-score branch (shares the Dv path)
+        _, lse, block_logit = block_score_mqa_attn_fwd(
+            q, k, v, vr, sm_scale=sm_scale, block_B=block_B
+        )
+        from paddlefleet.tilelang_ops.hysparse.pipeline import (
+            select_topk_blocks,
+        )
+
+        idx = select_topk_blocks(
+            block_logit, lse, vr, sm_scale, topk, block_B, head_agg="max"
+        )
+
+        qf, kf, vf = _grad_ref_qkv(q, k, v)
+        ref_out, _ = ref_block_sparse_attn_mqa(
+            qf, kf, vf, idx, vr, sm_scale=sm_scale, block_B=block_B
+        )
+        out, slse = block_sparse_mqa_attn_fwd(
+            q, k, v, idx, vr, sm_scale=sm_scale, block_B=block_B
+        )
+        self.assertEqual(list(out.shape), [B, S, H, Dv])
+        self.assertLess(_maxerr(out, ref_out), OUT_ATOL)
+
+        do = paddle.randn([B, S, H, Dv], dtype="bfloat16")
+        (ref_out * do.astype("float32")).sum().backward()
+        dq, dk, dv = block_sparse_mqa_bwd_interface(
+            q, k, v, out, do, slse, idx, vr, sm_scale=sm_scale, block_B=block_B
+        )
+        self.assertEqual(list(dv.shape), [B, S, Dv])
         self.assertGreater(_cos(dq, qf.grad), 0.999)
         self.assertGreater(_cos(dk, kf.grad), 0.999)
         self.assertGreater(_cos(dv, vf.grad), 0.999)

--- a/tests/single_card_tests/custom_ops/test_hysparse_differentiable_ops.py
+++ b/tests/single_card_tests/custom_ops/test_hysparse_differentiable_ops.py
@@ -27,16 +27,21 @@ These validate two properties the low-level fwd/bwd interface tests do not:
 
 import unittest
 
+import numpy as np
 import paddle
 
 paddle.enable_compat(scope={"tilelang"}, silent=True)
 
-from paddlefleet.tilelang_ops.hysparse.autograd import (
+from paddlefleet.tilelang_ops.hysparse.differentiable_ops import (
+    block_score_mha_attention,
     block_score_mqa_attention,
     block_sparse_mqa_attention,
+    hysparse_mqa_attention,
 )
 from paddlefleet.tilelang_ops.hysparse.reference import (
     make_causal_valid_range,
+    ref_block_score_attn_mha,
+    ref_block_score_attn_mqa,
 )
 
 
@@ -45,6 +50,24 @@ def _cuda_or_skip(testcase):
         testcase.skipTest("CUDA build of Paddle is required")
     if paddle.device.cuda.device_count() == 0:
         testcase.skipTest("No CUDA device available")
+
+
+def _maxerr(a, b):
+    a = a.astype("float32").numpy()
+    b = b.astype("float32").numpy()
+    return float(np.abs(a - b).max())
+
+
+def _grad_leaves(*tensors):
+    """Independent float32 leaf copies (stop_gradient=False) for reference
+    gradients. ``detach`` first so each is a graph leaf whose ``.grad`` is
+    retained even when the source tensor already tracks gradient."""
+    out = []
+    for t in tensors:
+        tf = t.detach().astype("float32")
+        tf.stop_gradient = False
+        out.append(tf)
+    return out
 
 
 def _leaves(b, s, h, d, seed=0, freeze=()):
@@ -58,6 +81,22 @@ def _leaves(b, s, h, d, seed=0, freeze=()):
     for name, t in tensors.items():
         t.stop_gradient = name in freeze
     return q, k, v
+
+
+def _leaves_mha(b, s, h, d, dv=None, seed=0, freeze=()):
+    """q [B,S,H,D], per-head k [B,S,H,D], v [B,S,H,Dv]; ``freeze`` -> frozen."""
+    paddle.seed(seed)
+    dv = d if dv is None else dv
+    q = paddle.randn([b, s, h, d], dtype="bfloat16")
+    k = paddle.randn([b, s, h, d], dtype="bfloat16")
+    v = paddle.randn([b, s, h, dv], dtype="bfloat16")
+    for name, t in (("q", q), ("k", k), ("v", v)):
+        t.stop_gradient = name in freeze
+    return q, k, v
+
+
+OUT_ATOL = 5e-2
+GRAD_ATOL = 8e-2
 
 
 class TestAutogradStopGradient(unittest.TestCase):
@@ -151,6 +190,118 @@ class TestAutogradNonContiguousGrad(unittest.TestCase):
         )
         out, _ = block_sparse_mqa_attention(q, k, v, idx, vr, block_B=64)
         self._non_contig_grad_loss(out).backward()
+        self.assertIsNotNone(q.grad)
+        self.assertIsNotNone(k.grad)
+        self.assertIsNotNone(v.grad)
+
+    def test_mha_score_non_contiguous(self):
+        _cuda_or_skip(self)
+        q, k, v = _leaves_mha(self.B, self.S, self.H, self.D, seed=7)
+        vr = make_causal_valid_range(self.S, batch=self.B)
+        out, _, _ = block_score_mha_attention(q, k, v, vr, block_B=64)
+        self._non_contig_grad_loss(out).backward()
+        self.assertIsNotNone(q.grad)
+        self.assertIsNotNone(k.grad)
+        self.assertIsNotNone(v.grad)
+
+
+class TestMHAScoreStopGradient(unittest.TestCase):
+    """stop_gradient contract for the per-head MHA block-score wrapper."""
+
+    B, S, H, D = 2, 128, 4, 64
+
+    def _run(self, freeze):
+        q, k, v = _leaves_mha(
+            self.B, self.S, self.H, self.D, seed=8, freeze=freeze
+        )
+        vr = make_causal_valid_range(self.S, batch=self.B)
+        out, _, _ = block_score_mha_attention(q, k, v, vr, block_B=64)
+        out.sum().backward()
+        for name, t in (("q", q), ("k", k), ("v", v)):
+            if name in freeze:
+                self.assertIsNone(t.grad, f"{name} frozen -> grad None")
+            else:
+                self.assertIsNotNone(t.grad, f"{name} trainable -> grad exists")
+
+    def test_all_trainable(self):
+        _cuda_or_skip(self)
+        self._run(())
+
+    def test_freeze_q(self):
+        _cuda_or_skip(self)
+        self._run(("q",))
+
+    def test_freeze_kv(self):
+        _cuda_or_skip(self)
+        self._run(("k", "v"))
+
+
+class TestDifferentiableCorrectness(unittest.TestCase):
+    """Wrappers must match the naive reference forward and backward."""
+
+    B, S, H, D = 2, 128, 4, 64
+
+    def test_mqa_score_matches_reference(self):
+        _cuda_or_skip(self)
+        q, k, v = _leaves(self.B, self.S, self.H, self.D, seed=20)
+        for t in (q, k, v):
+            t.stop_gradient = False
+        vr = make_causal_valid_range(self.S, batch=self.B)
+        qf, kf, vf = _grad_leaves(q, k, v)
+        sm = self.D**-0.5
+        ref_out, _, _ = ref_block_score_attn_mqa(qf, kf, vf, vr, sm_scale=sm)
+        out, _, _ = block_score_mqa_attention(q, k, v, vr, sm_scale=sm)
+        self.assertLess(_maxerr(out, ref_out), OUT_ATOL)
+        do = paddle.randn([self.B, self.S, self.H, self.D], dtype="bfloat16")
+        (ref_out * do.astype("float32")).sum().backward()
+        (out.astype("float32") * do.astype("float32")).sum().backward()
+        self.assertLess(_maxerr(q.grad, qf.grad), GRAD_ATOL)
+        self.assertLess(_maxerr(k.grad, kf.grad), GRAD_ATOL)
+        self.assertLess(_maxerr(v.grad, vf.grad), GRAD_ATOL)
+
+    def test_mha_score_matches_reference(self):
+        _cuda_or_skip(self)
+        q, k, v = _leaves_mha(self.B, self.S, self.H, self.D, seed=21)
+        for t in (q, k, v):
+            t.stop_gradient = False
+        vr = make_causal_valid_range(self.S, batch=self.B)
+        qf, kf, vf = _grad_leaves(q, k, v)
+        sm = self.D**-0.5
+        ref_out, _, _ = ref_block_score_attn_mha(qf, kf, vf, vr, sm_scale=sm)
+        out, _, _ = block_score_mha_attention(q, k, v, vr, sm_scale=sm)
+        self.assertLess(_maxerr(out, ref_out), OUT_ATOL)
+        do = paddle.randn([self.B, self.S, self.H, self.D], dtype="bfloat16")
+        (ref_out * do.astype("float32")).sum().backward()
+        (out.astype("float32") * do.astype("float32")).sum().backward()
+        self.assertLess(_maxerr(q.grad, qf.grad), GRAD_ATOL)
+        self.assertLess(_maxerr(k.grad, kf.grad), GRAD_ATOL)
+        self.assertLess(_maxerr(v.grad, vf.grad), GRAD_ATOL)
+
+
+class TestHySparsePipeline(unittest.TestCase):
+    """The score -> TopK -> sparse chain runs forward and backward."""
+
+    B, S, H, D = 2, 128, 4, 64
+
+    def test_forward_backward(self):
+        _cuda_or_skip(self)
+        q, k, v = _leaves(self.B, self.S, self.H, self.D, seed=30)
+        for t in (q, k, v):
+            t.stop_gradient = False
+        vr = make_causal_valid_range(self.S, batch=self.B)
+        sparse_out, sparse_lse, indices, full_out, full_lse = (
+            hysparse_mqa_attention(q, k, v, vr, topk=2, block_B=64)
+        )
+        self.assertEqual(
+            list(sparse_out.shape), [self.B, self.S, self.H, self.D]
+        )
+        self.assertEqual(list(indices.shape), [self.B, self.S, 2])
+        self.assertTrue(indices.stop_gradient)
+        # both differentiable outputs flow gradient back to q/k/v
+        (
+            sparse_out.astype("float32").sum()
+            + full_out.astype("float32").sum()
+        ).backward()
         self.assertIsNotNone(q.grad)
         self.assertIsNotNone(k.grad)
         self.assertIsNotNone(v.grad)

--- a/tests/single_card_tests/custom_ops/test_hysparse_mha_block_score.py
+++ b/tests/single_card_tests/custom_ops/test_hysparse_mha_block_score.py
@@ -1,0 +1,316 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Accuracy tests for the MHA (per-head K/V) block-score TileLang operator.
+
+Validates the decompressed-MLA block-score attention (each query head has its
+own K/V head) against the naive Paddle reference (散算子), forward and backward.
+Kept separate from the MQA suite (test_hysparse_block_attn.py) so the existing
+MQA cases are untouched. The coverage mirrors ``TestBlockScoreMQA`` (block_B
+variants, single head, block_N sub-tiling invariance, packed deep documents,
+empty rows, batched backward, asymmetric Dk!=Dv, MLA-shaped D=256/H=64).
+
+Unlike the MQA op, MHA uses **absolute** block coordinates, so packed-document
+== per-document standalone equivalence does NOT hold for the emitted block
+scores; masking correctness is still validated through ``valid_range``.
+"""
+
+import unittest
+
+import numpy as np
+import paddle
+
+paddle.enable_compat(scope={"tilelang"}, silent=True)
+
+from paddlefleet.tilelang_ops.hysparse.block_score_attn import (
+    block_scores_from_logit,
+)
+from paddlefleet.tilelang_ops.hysparse.block_score_attn_mha import (
+    block_score_mha_attn_fwd,
+)
+from paddlefleet.tilelang_ops.hysparse.block_score_attn_mha_bwd import (
+    block_score_mha_bwd_interface,
+)
+from paddlefleet.tilelang_ops.hysparse.reference import (
+    make_causal_valid_range,
+    ref_block_score_attn_mha,
+)
+
+
+def _cuda_or_skip(testcase):
+    if not paddle.device.is_compiled_with_cuda():
+        testcase.skipTest("CUDA build of Paddle is required")
+    if paddle.device.cuda.device_count() == 0:
+        testcase.skipTest("No CUDA device available")
+
+
+def _maxerr(a, b):
+    a = a.astype("float32").numpy()
+    b = b.astype("float32").numpy()
+    return float(np.abs(a - b).max())
+
+
+def _cos(a, b):
+    a = a.astype("float32").numpy().ravel()
+    b = b.astype("float32").numpy().ravel()
+    denom = float(np.linalg.norm(a) * np.linalg.norm(b)) + 1e-12
+    return float((a * b).sum() / denom)
+
+
+def _rand_qkv_mha(b, s, h, dk, dv, seed=0):
+    """Per-head K/V: Q [B,S,H,Dk]; K [B,S_kv,H,Dk]; V [B,S_kv,H,Dv]."""
+    paddle.seed(seed)
+    q = paddle.randn([b, s, h, dk], dtype="bfloat16")
+    k = paddle.randn([b, s, h, dk], dtype="bfloat16")
+    v = paddle.randn([b, s, h, dv], dtype="bfloat16")
+    return q, k, v
+
+
+def _grad_ref_qkv(q, k, v):
+    """float32 leaf copies of q/k/v for autograd reference gradients."""
+    qf = q.astype("float32")
+    qf.stop_gradient = False
+    kf = k.astype("float32")
+    kf.stop_gradient = False
+    vf = v.astype("float32")
+    vf.stop_gradient = False
+    return qf, kf, vf
+
+
+# tolerances: bf16 matmul + fp32 accumulation
+OUT_ATOL = 5e-2
+LSE_ATOL = 1e-3
+GRAD_ATOL = 8e-2
+
+
+class TestBlockScoreMHA(unittest.TestCase):
+    """Per-head K/V full attention + block-max scores, fwd & bwd.
+
+    Mirrors ``TestBlockScoreMQA`` (test_hysparse_block_attn.py) case-for-case.
+    """
+
+    def _run(self, doc_lengths=None, block_B=64, H=8, D=64, Dv=None):
+        _cuda_or_skip(self)
+        B, S = 2, 256
+        Dv = D if Dv is None else Dv
+        q, k, v = _rand_qkv_mha(B, S, H, D, Dv, seed=1)
+        vr = make_causal_valid_range(S, batch=B, doc_lengths=doc_lengths)
+        sm_scale = D**-0.5
+
+        qf, kf, vf = _grad_ref_qkv(q, k, v)
+        ref_out, ref_lse, ref_sblk = ref_block_score_attn_mha(
+            qf, kf, vf, vr, sm_scale=sm_scale, block_B=block_B
+        )
+
+        out, lse, block_logit = block_score_mha_attn_fwd(
+            q, k, v, vr, sm_scale=sm_scale, block_B=block_B
+        )
+        sblk = block_scores_from_logit(block_logit, lse, sm_scale)
+
+        self.assertEqual(list(out.shape), [B, S, H, Dv])
+        self.assertLess(_maxerr(out, ref_out), OUT_ATOL)
+        self.assertLess(_maxerr(lse, ref_lse), LSE_ATOL)
+        self.assertLess(_maxerr(sblk, ref_sblk), 1e-3)
+
+        do = paddle.randn([B, S, H, Dv], dtype="bfloat16")
+        (ref_out * do.astype("float32")).sum().backward()
+        dq, dk, dv = block_score_mha_bwd_interface(
+            q, k, v, out, do, lse, vr, sm_scale=sm_scale, block_B=block_B
+        )
+        self.assertEqual(list(dk.shape), [B, S, H, D])
+        self.assertEqual(list(dv.shape), [B, S, H, Dv])
+        self.assertLess(_maxerr(dq, qf.grad), GRAD_ATOL)
+        self.assertLess(_maxerr(dk, kf.grad), GRAD_ATOL)
+        self.assertLess(_maxerr(dv, vf.grad), GRAD_ATOL)
+
+    def test_causal(self):
+        self._run(doc_lengths=None)
+
+    def test_causal_document(self):
+        self._run(doc_lengths=[96, 160])
+
+    def test_block_b_32(self):
+        # smaller key block size (must still divide the auto-picked block_N).
+        self._run(doc_lengths=[96, 160], block_B=32)
+
+    def test_block_b_128(self):
+        # larger key block size exercises a different tiling / mask layout.
+        self._run(doc_lengths=None, block_B=128)
+
+    def test_single_query_head(self):
+        # H=1: one program per (query-tile, head, batch) with a single head.
+        self._run(doc_lengths=None, H=1)
+
+    def test_backward_block_n_invariance(self):
+        """The MHA block-score backward sub-tiles the key dim by ``block_N``;
+        any valid ``block_N`` dividing ``block_B`` must give the SAME gradients
+        (only the fp-accumulation / per-sub-tile recast order changes).
+        """
+        _cuda_or_skip(self)
+        B, S, H, D, block_B = 2, 256, 8, 64, 64
+        q, k, v = _rand_qkv_mha(B, S, H, D, D, seed=13)
+        vr = make_causal_valid_range(S, batch=B, doc_lengths=[96, 160])
+        sm = D**-0.5
+
+        qf, kf, vf = _grad_ref_qkv(q, k, v)
+        ref_out, _, _ = ref_block_score_attn_mha(
+            qf, kf, vf, vr, sm_scale=sm, block_B=block_B
+        )
+        out, lse, _ = block_score_mha_attn_fwd(
+            q, k, v, vr, sm_scale=sm, block_B=block_B
+        )
+        do = paddle.randn([B, S, H, D], dtype="bfloat16")
+        (ref_out * do.astype("float32")).sum().backward()
+
+        dq1, dk1, dv1 = block_score_mha_bwd_interface(
+            q,
+            k,
+            v,
+            out,
+            do,
+            lse,
+            vr,
+            sm_scale=sm,
+            block_B=block_B,
+            block_M=64,
+            block_N=64,
+        )
+        dq2, dk2, dv2 = block_score_mha_bwd_interface(
+            q,
+            k,
+            v,
+            out,
+            do,
+            lse,
+            vr,
+            sm_scale=sm,
+            block_B=block_B,
+            block_M=64,
+            block_N=32,
+        )
+        self.assertLess(_maxerr(dq1, dq2), 1e-2)
+        self.assertLess(_maxerr(dk1, dk2), 1e-2)
+        self.assertLess(_maxerr(dv1, dv2), 1e-2)
+        for dq, dk, dv in ((dq1, dk1, dv1), (dq2, dk2, dv2)):
+            self.assertLess(_maxerr(dq, qf.grad), GRAD_ATOL)
+            self.assertLess(_maxerr(dk, kf.grad), GRAD_ATOL)
+            self.assertLess(_maxerr(dv, vf.grad), GRAD_ATOL)
+
+    def test_backward_packed_deep_docs(self):
+        """Backward with several packed documents whose later tiles start deep
+        into the sequence (bos >> 0). Exercises the document-tight key-block
+        window (leading-block skip) in the MHA block-score backward.
+        """
+        _cuda_or_skip(self)
+        B, H, D, block_B = 1, 8, 64, 64
+        doc_lengths = [130, 200, 180]
+        S = sum(doc_lengths)
+        q, k, v = _rand_qkv_mha(B, S, H, D, D, seed=17)
+        vr = make_causal_valid_range(S, batch=B, doc_lengths=doc_lengths)
+        sm_scale = D**-0.5
+
+        qf, kf, vf = _grad_ref_qkv(q, k, v)
+        ref_out, _, _ = ref_block_score_attn_mha(
+            qf, kf, vf, vr, sm_scale=sm_scale, block_B=block_B
+        )
+        out, lse, _ = block_score_mha_attn_fwd(
+            q, k, v, vr, sm_scale=sm_scale, block_B=block_B
+        )
+        do = paddle.randn([B, S, H, D], dtype="bfloat16")
+        (ref_out * do.astype("float32")).sum().backward()
+        dq, dk, dv = block_score_mha_bwd_interface(
+            q, k, v, out, do, lse, vr, sm_scale=sm_scale, block_B=block_B
+        )
+        self.assertLess(_maxerr(dq, qf.grad), GRAD_ATOL)
+        self.assertLess(_maxerr(dk, kf.grad), GRAD_ATOL)
+        self.assertLess(_maxerr(dv, vf.grad), GRAD_ATOL)
+
+    def test_empty_rows(self):
+        """A query row with no valid key (bos == eos) must give 0 output,
+        -inf lse, and 0 gradient -- matching the guarded reference.
+        """
+        _cuda_or_skip(self)
+        B, S, H, D, block_B = 1, 128, 8, 64, 64
+        q, k, v = _rand_qkv_mha(B, S, H, D, D, seed=31)
+        vr = make_causal_valid_range(S, batch=B).clone()
+        empty = 40
+        vr[:, empty, 0] = empty  # bos == eos -> empty half-open range
+        vr[:, empty, 1] = empty
+        vr = vr.contiguous()
+        sm = D**-0.5
+
+        qf, kf, vf = _grad_ref_qkv(q, k, v)
+        ref_out, ref_lse, _ = ref_block_score_attn_mha(
+            qf, kf, vf, vr, sm_scale=sm, block_B=block_B
+        )
+        out, lse, _ = block_score_mha_attn_fwd(
+            q, k, v, vr, sm_scale=sm, block_B=block_B
+        )
+        self.assertLess(float(out[:, empty].abs().max()), 1e-6)
+        self.assertTrue(bool((lse[:, empty] == float("-inf")).all().item()))
+        self.assertLess(_maxerr(out, ref_out), OUT_ATOL)
+
+        do = paddle.randn([B, S, H, D], dtype="bfloat16")
+        (ref_out * do.astype("float32")).sum().backward()
+        dq, dk, dv = block_score_mha_bwd_interface(
+            q, k, v, out, do, lse, vr, sm_scale=sm, block_B=block_B
+        )
+        self.assertLess(float(dq[:, empty].abs().max()), 1e-6)
+        self.assertLess(_maxerr(dq, qf.grad), GRAD_ATOL)
+        self.assertLess(_maxerr(dk, kf.grad), GRAD_ATOL)
+        self.assertLess(_maxerr(dv, vf.grad), GRAD_ATOL)
+
+    def test_batched_backward(self):
+        # dq/dk/dv for a B=2 batch (mixed doc layout) match the fp32 reference.
+        self._run(doc_lengths=[96, 160])
+
+    def test_asymmetric_dk_dv(self):
+        # Dk != Dv (query/key dim 128, value/output dim 64): exercises the
+        # kernel's separate D_v path in fwd + bwd.
+        self._run(doc_lengths=None, D=128, Dv=64)
+
+    def test_fwd_bwd_dv256_h64(self):
+        # target decompressed-MLA shape: D=256, H=64. Gradients checked by
+        # cosine (magnitudes grow at large H).
+        _cuda_or_skip(self)
+        B, S, H, D = 1, 192, 64, 256
+        block_B = 64
+        q, k, v = _rand_qkv_mha(B, S, H, D, D, seed=7)
+        vr = make_causal_valid_range(S, batch=B)
+        sm_scale = D**-0.5
+
+        qf, kf, vf = _grad_ref_qkv(q, k, v)
+        ref_out, ref_lse, ref_sblk = ref_block_score_attn_mha(
+            qf, kf, vf, vr, sm_scale=sm_scale, block_B=block_B
+        )
+        out, lse, block_logit = block_score_mha_attn_fwd(
+            q, k, v, vr, sm_scale=sm_scale, block_B=block_B
+        )
+        sblk = block_scores_from_logit(block_logit, lse, sm_scale)
+        self.assertLess(_maxerr(out, ref_out), OUT_ATOL)
+        self.assertLess(_maxerr(lse, ref_lse), LSE_ATOL)
+        self.assertLess(_maxerr(sblk, ref_sblk), 1e-3)
+
+        do = paddle.randn([B, S, H, D], dtype="bfloat16")
+        (ref_out * do.astype("float32")).sum().backward()
+        dq, dk, dv = block_score_mha_bwd_interface(
+            q, k, v, out, do, lse, vr, sm_scale=sm_scale, block_B=block_B
+        )
+        self.assertGreater(_cos(dq, qf.grad), 0.999)
+        self.assertGreater(_cos(dk, kf.grad), 0.999)
+        self.assertGreater(_cos(dv, vf.grad), 0.999)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/custom_ops/test_hysparse_swa.py
+++ b/tests/single_card_tests/custom_ops/test_hysparse_swa.py
@@ -182,5 +182,62 @@ class TestSlidingWindowMQA(unittest.TestCase):
         self.assertGreater(_cos(v.grad, vf.grad), 0.999)
 
 
+class TestSlidingWindowMQAAutograd(unittest.TestCase):
+    """PyLayer contract for the SWA MQA wrapper: stop_gradient handling and
+    non-contiguous upstream gradients."""
+
+    B, S, H, D, W = 2, 128, 4, 64, 32
+
+    def _leaves(self, freeze=(), seed=11):
+        paddle.seed(seed)
+        q = paddle.randn([self.B, self.S, self.H, self.D], dtype="bfloat16")
+        k = paddle.randn([self.B, self.S, self.D], dtype="bfloat16")
+        v = paddle.randn([self.B, self.S, self.D], dtype="bfloat16")
+        for name, t in (("q", q), ("k", k), ("v", v)):
+            t.stop_gradient = name in freeze
+        vr = make_sliding_window_valid_range(self.S, self.W, batch=self.B)
+        return q, k, v, vr
+
+    def _check_grads(self, q, k, v, freeze):
+        for name, t in (("q", q), ("k", k), ("v", v)):
+            if name in freeze:
+                self.assertIsNone(t.grad, f"{name} frozen -> grad None")
+            else:
+                self.assertIsNotNone(t.grad, f"{name} trainable -> grad exists")
+
+    def test_all_trainable(self):
+        _cuda_or_skip(self)
+        q, k, v, vr = self._leaves()
+        out, _ = sliding_window_mqa_attention(q, k, v, vr)
+        out.sum().backward()
+        self._check_grads(q, k, v, ())
+
+    def test_freeze_q(self):
+        _cuda_or_skip(self)
+        q, k, v, vr = self._leaves(freeze=("q",))
+        out, _ = sliding_window_mqa_attention(q, k, v, vr)
+        out.sum().backward()
+        self._check_grads(q, k, v, ("q",))
+
+    def test_freeze_kv(self):
+        _cuda_or_skip(self)
+        q, k, v, vr = self._leaves(freeze=("k", "v"))
+        out, _ = sliding_window_mqa_attention(q, k, v, vr)
+        out.sum().backward()
+        self._check_grads(q, k, v, ("k", "v"))
+
+    def test_non_contiguous_grad(self):
+        # Transposed output -> non-contiguous grad into the PyLayer output.
+        _cuda_or_skip(self)
+        q, k, v, vr = self._leaves(seed=12)
+        out, _ = sliding_window_mqa_attention(q, k, v, vr)
+        t = out.transpose([0, 2, 1, 3])
+        self.assertFalse(t.is_contiguous())
+        t.sum().backward()
+        self.assertIsNotNone(q.grad)
+        self.assertIsNotNone(k.grad)
+        self.assertIsNotNone(v.grad)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/single_card_tests/custom_ops/test_hysparse_swa.py
+++ b/tests/single_card_tests/custom_ops/test_hysparse_swa.py
@@ -1,0 +1,186 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Accuracy tests for the TileLang causal sliding-window attention (SWA).
+
+Validates both the MQA (single shared K/V head, absorbed-MLA shape Dk=576/
+Dv=512 that FA4 cannot run) and MHA (per-head K/V, Dk=Dv<=256 that FA4 can run)
+SWA wrappers against the naive Paddle windowed reference, forward and backward.
+The windowed mask is expressed through ``make_sliding_window_valid_range`` and
+computed by the block-score kernels' ``eos - bos`` early-exit.
+"""
+
+import unittest
+
+import numpy as np
+import paddle
+
+paddle.enable_compat(scope={"tilelang"}, silent=True)
+
+from paddlefleet.tilelang_ops.hysparse.reference import (
+    make_sliding_window_valid_range,
+    ref_block_score_attn_mqa,
+)
+from paddlefleet.tilelang_ops.hysparse.swa_attn import (
+    sliding_window_mqa_attention,
+)
+
+
+def _cuda_or_skip(testcase):
+    if not paddle.device.is_compiled_with_cuda():
+        testcase.skipTest("CUDA build of Paddle is required")
+    if paddle.device.cuda.device_count() == 0:
+        testcase.skipTest("No CUDA device available")
+
+
+def _maxerr(a, b):
+    a = a.astype("float32").numpy()
+    b = b.astype("float32").numpy()
+    return float(np.abs(a - b).max())
+
+
+def _cos(a, b):
+    a = a.astype("float32").numpy().ravel()
+    b = b.astype("float32").numpy().ravel()
+    denom = float(np.linalg.norm(a) * np.linalg.norm(b)) + 1e-12
+    return float((a * b).sum() / denom)
+
+
+OUT_ATOL = 5e-2
+LSE_ATOL = 1e-3
+GRAD_ATOL = 8e-2
+
+
+class TestSlidingWindowMQA(unittest.TestCase):
+    """SWA with a single shared K/V head (absorbed-MLA MQA shape)."""
+
+    def _run(
+        self,
+        S=256,
+        window_size=64,
+        H=8,
+        D=64,
+        Dv=None,
+        doc_lengths=None,
+        block_B=64,
+    ):
+        _cuda_or_skip(self)
+        B = 2
+        Dv = D if Dv is None else Dv
+        paddle.seed(5)
+        q = paddle.randn([B, S, H, D], dtype="bfloat16")
+        k = paddle.randn([B, S, D], dtype="bfloat16")
+        v = paddle.randn([B, S, Dv], dtype="bfloat16")
+        vr = make_sliding_window_valid_range(
+            S, window_size, batch=B, doc_lengths=doc_lengths
+        )
+        sm = D**-0.5
+
+        qf = q.astype("float32")
+        qf.stop_gradient = False
+        kf = k.astype("float32")
+        kf.stop_gradient = False
+        vf = v.astype("float32")
+        vf.stop_gradient = False
+        ref_out, ref_lse, _ = ref_block_score_attn_mqa(
+            qf, kf, vf, vr, sm_scale=sm, block_B=block_B
+        )
+
+        q.stop_gradient = False
+        k.stop_gradient = False
+        v.stop_gradient = False
+        out, lse = sliding_window_mqa_attention(
+            q, k, v, vr, sm_scale=sm, block_B=block_B
+        )
+        self.assertEqual(list(out.shape), [B, S, H, Dv])
+        self.assertLess(_maxerr(out, ref_out), OUT_ATOL)
+        finite = np.isfinite(ref_lse.numpy())
+        lse_err = np.abs(lse.numpy()[finite] - ref_lse.numpy()[finite]).max()
+        self.assertLess(float(lse_err), LSE_ATOL)
+
+        do = paddle.randn([B, S, H, Dv], dtype="bfloat16")
+        (ref_out * do.astype("float32")).sum().backward()
+        (out.astype("float32") * do.astype("float32")).sum().backward()
+        self.assertLess(_maxerr(q.grad, qf.grad), GRAD_ATOL)
+        self.assertLess(_maxerr(k.grad, kf.grad), GRAD_ATOL)
+        self.assertLess(_maxerr(v.grad, vf.grad), GRAD_ATOL)
+
+    def test_causal_window(self):
+        self._run()
+
+    def test_window_document(self):
+        self._run(doc_lengths=[96, 160])
+
+    def test_small_window(self):
+        self._run(window_size=32)
+
+    def test_window_ge_seqlen(self):
+        # window >= S degenerates to full causal attention.
+        self._run(S=128, window_size=256)
+
+    def test_window_size_one(self):
+        # W=1: every query attends to exactly itself (bos == eos-1).
+        self._run(window_size=1)
+
+    def test_unaligned_seqlen(self):
+        # S not a multiple of block_B exercises the K/V padding path.
+        self._run(S=200, window_size=48)
+
+    def test_block_b_32(self):
+        self._run(window_size=48, block_B=32)
+
+    def test_block_b_128(self):
+        self._run(S=384, window_size=100, block_B=128)
+
+    def test_absorbed_mla_shape(self):
+        # the FA4 gap: Dk=576 > 256, Dv=512. Grad checked by cosine.
+        _cuda_or_skip(self)
+        B, S, H, D, Dv = 1, 192, 4, 576, 512
+        window_size = 64
+        paddle.seed(7)
+        q = paddle.randn([B, S, H, D], dtype="bfloat16")
+        k = paddle.randn([B, S, D], dtype="bfloat16")
+        v = paddle.randn([B, S, Dv], dtype="bfloat16")
+        vr = make_sliding_window_valid_range(S, window_size, batch=B)
+        sm = D**-0.5
+
+        qf = q.astype("float32")
+        qf.stop_gradient = False
+        kf = k.astype("float32")
+        kf.stop_gradient = False
+        vf = v.astype("float32")
+        vf.stop_gradient = False
+        ref_out, ref_lse, _ = ref_block_score_attn_mqa(
+            qf, kf, vf, vr, sm_scale=sm, block_B=64
+        )
+
+        q.stop_gradient = False
+        k.stop_gradient = False
+        v.stop_gradient = False
+        out, lse = sliding_window_mqa_attention(q, k, v, vr, sm_scale=sm)
+        self.assertLess(_maxerr(out, ref_out), OUT_ATOL)
+        finite = np.isfinite(ref_lse.numpy())
+        lse_err = np.abs(lse.numpy()[finite] - ref_lse.numpy()[finite]).max()
+        self.assertLess(float(lse_err), LSE_ATOL)
+
+        do = paddle.randn([B, S, H, Dv], dtype="bfloat16")
+        (ref_out * do.astype("float32")).sum().backward()
+        (out.astype("float32") * do.astype("float32")).sum().backward()
+        self.assertGreater(_cos(q.grad, qf.grad), 0.999)
+        self.assertGreater(_cos(k.grad, kf.grad), 0.999)
+        self.assertGreater(_cos(v.grad, vf.grad), 0.999)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
New features

### Description

算子层改动（不含模型组网）。在现有 HySparse MQA block-attention TileLang 算子基础上，新增 per-head K/V (MHA) 的 block-score attention 与因果滑动窗口 (SWA) 算子，并将原 MQA 算子从 Dk==Dv 泛化到 Dk!=Dv。

**新增算子**
- **block-score MHA** 前向/反向（per-head K/V，绝对 block 坐标）。对应解压 MLA 布局，每个 query head 拥有独立 K/V head，用于对比 MQA（单一共享 K/V head）在访存受限场景下的 wall-clock 代价。
- **因果滑动窗口 (SWA) MQA** 封装：复用 block-score kernel，通过窗口化的 `valid_range`（`[max(doc_start, t-W+1), t+1)`）与 `eos-bos` early-exit 将每 token 计算量限制在窗口 W 内，**无需新 kernel**。覆盖 absorbed-MLA 的 Dk=576/Dv=512（head dim > 256，FA4 无法运行）场景。

**已有 MQA 算子增强**
- `Dv` 泛化：block-score / block-sparse 前反向支持 `Dk != Dv`（如 MLA Dk=576, Dv=512）。
- causal / document 维度的 early-exit（block loop trip count 由 `valid_range` 动态推导），packed 多文档等价于逐文档独立计算。

**配套**
- `paddle.autograd.PyLayer` 前反向封装；MHA / SWA 的 naive Paddle 参考实现。

不包含：benchmark 脚本、模型组网（MQASelfAttention 等）。

**测试**（`tests/single_card_tests/custom_ops/`）
- MQA 全套 `test_hysparse_block_attn.py`
- MHA block-score `test_hysparse_mha_block_score.py`
- SWA `test_hysparse_swa.py`

覆盖边界：`window=1`、非对齐 seqlen、`block_B` 32/128、空行（`bos==eos`）、全 padding indices、非对称 `Dk!=Dv`。
