### PR TITLE
[EP] Update `HYBRIDEP_TOKEN_ALIGNMENT` to 128

### DIFF
--- a/src/paddlefleet/transformer/moe/fused_a2a.py
+++ b/src/paddlefleet/transformer/moe/fused_a2a.py
@@ -63,8 +63,9 @@ else:
 _buffer = None
 _hybrid_ep_buffer = None
 
-# HybridEP dispatch/combine kernels use 64-token chunks for public APIs.
-HYBRIDEP_TOKEN_ALIGNMENT = 64
+# HybridEP dispatch/combine kernels use 128-token chunks to align with default
+# NUM_OF_TOKENS_PER_CHUNK_DISPATCH_API and NUM_OF_TOKENS_PER_CHUNK_COMBINE_API
+HYBRIDEP_TOKEN_ALIGNMENT = 128
 
 
 def barrier_ep(ep_group):

--- a/tests/single_card_tests/transformer/test_hybrid_ep_backend.py
+++ b/tests/single_card_tests/transformer/test_hybrid_ep_backend.py
@@ -499,7 +499,7 @@ class TestHybridEPDispatchBoundary(unittest.TestCase):
             self.assertEqual(int(tensor.item()), 3)
             self.assertEqual(op, paddle.distributed.ReduceOp.MAX)
             self.assertIs(group, manager.group)
-            tensor.set_value(paddle.to_tensor([65], dtype="int64"))
+            tensor.set_value(paddle.to_tensor([129], dtype="int64"))
 
         with patch(
             "paddle.distributed.all_reduce", side_effect=fake_all_reduce


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->

Distributed Strategy

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

将 `HYBRIDEP_TOKEN_ALIGNMENT` 设置为 128，以匹配 `NUM_OF_TOKENS_PER_CHUNK_DISPATCH_API` 和 `NUM_OF_TOKENS_PER_CHUNK_COMBINE_API` 的默认值（128），否则可能会在如下位置报错：

```
static_assert(MAX_NUM_OF_TOKENS_PER_RANK % NUM_OF_TOKENS_PER_CHUNK == 0, "MAX_NUM_OF_TOKENS_PER_RANK must be multiple of NUM_OF_TOKENS_PER_CHUNK.");
```

因为前者 `MAX_NUM_OF_TOKENS_PER_RANK` 之前是按照 `HYBRIDEP_TOKEN_ALIGNMENT` padding 的，在之前使用 64 时，可能不满足上述条件

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->

否