### PR TITLE
[Performance] Reduce SonicMoE metadata launch overhead

### DIFF
--- a/src/paddlefleet/transformer/moe/fused_a2a.py
+++ b/src/paddlefleet/transformer/moe/fused_a2a.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
 import queue
 
 import paddle
@@ -68,6 +69,20 @@ _hybrid_ep_buffer = None
 HYBRIDEP_TOKEN_ALIGNMENT = 128
 
 
+def _supports_sonic_scale_word_packing(quantizer):
+    if quantizer is None:
+        return False
+    try:
+        return "pack_scale_words" in inspect.signature(quantizer).parameters
+    except (TypeError, ValueError):
+        return False
+
+
+_SONIC_PACK_SCALE_WORDS_AVAILABLE = _supports_sonic_scale_word_packing(
+    quantize_activation_blockscaled_fast
+)
+
+
 def barrier_ep(ep_group):
     """barrier_ep"""
     paddle.distributed.barrier(ep_group)
@@ -111,6 +126,99 @@ def _normalize_fp8_scale_for_deepep(
             f"expected [{num_tokens}, {num_scales}]"
         )
     return scale
+
+
+def _pack_sonic_fp8_scale_for_deepep(
+    x_fp8: paddle.Tensor, scale: paddle.Tensor
+):
+    """Expose four 1x32 E8M0 bytes as one DeepEP int32 scale word."""
+    num_tokens, hidden = x_fp8.shape
+    num_groups = (hidden + 31) // 32
+    if not scale.is_contiguous():
+        scale = scale.contiguous()
+    packed_groups = (num_groups + 3) // 4
+    if (
+        num_groups % 4 == 0
+        and scale.dtype == paddle.int32
+        and tuple(scale.shape) == (num_tokens, packed_groups)
+    ):
+        return scale
+    if tuple(scale.shape) != (num_tokens, num_groups):
+        raise RuntimeError(
+            "Invalid Sonic FP8 scale shape before DeepEP dispatch: "
+            f"scale={scale.shape}, x_fp8={x_fp8.shape}, "
+            f"expected [{num_tokens}, {num_groups}]"
+        )
+    if scale.dtype != paddle.uint8:
+        raise TypeError(
+            "Sonic FP8 scale carrier expects raw uint8 E8M0 bytes, "
+            f"got {scale.dtype}"
+        )
+    if num_groups % 4 != 0:
+        # DeepEP's tuple ABI requires a 32-bit scale type. Preserve the
+        # previous value-conversion fallback for non-aligned hidden sizes.
+        return scale.cast(paddle.int32)
+    return scale.view(paddle.int32)
+
+
+def _unpack_sonic_fp8_scale_from_deepep(
+    x_fp8: paddle.Tensor, scale: paddle.Tensor
+):
+    """Recover raw 1x32 E8M0 bytes from DeepEP's int32 carrier."""
+    num_tokens, hidden = x_fp8.shape
+    num_groups = (hidden + 31) // 32
+    if not scale.is_contiguous():
+        scale = scale.contiguous()
+    packed_groups = (num_groups + 3) // 4
+    if (
+        num_groups % 4 == 0
+        and scale.dtype == paddle.int32
+        and tuple(scale.shape) == (num_tokens, packed_groups)
+    ):
+        return scale.view(paddle.uint8)
+    if scale.dtype == paddle.int32 and tuple(scale.shape) == (
+        num_tokens,
+        num_groups,
+    ):
+        return scale.cast(paddle.uint8)
+    raise RuntimeError(
+        "Invalid packed Sonic FP8 scale received from DeepEP: "
+        f"scale={scale.shape}/{scale.dtype}, x_fp8={x_fp8.shape}"
+    )
+
+
+def _quantize_combine_grad_for_deepep(grad_output, combine_grad_handle):
+    grad_output = grad_output.contiguous()
+    using_sonic = bool(
+        combine_grad_handle
+        and combine_grad_handle.get("using_sonic_moe", False)
+    )
+    if using_sonic and _SONIC_PACK_SCALE_WORDS_AVAILABLE:
+        fp8, scale = quantize_activation_blockscaled_fast(
+            grad_output,
+            pack_scale_words=(grad_output.shape[1] % 128 == 0),
+        )
+        return fp8, _pack_sonic_fp8_scale_for_deepep(fp8, scale)
+    return quantize_activation_blockscaled_fast(
+        grad_output, scale_dtype=paddle.int32
+    )
+
+
+def _record_fp8_combine_grad(grad_x, combine_grad_handle):
+    if combine_grad_handle is None:
+        raise RuntimeError(
+            "For fp8_dispatch, combine_grad_handle must be provided in "
+            "combine backward."
+        )
+    grad_data, grad_scale = grad_x
+    if (
+        combine_grad_handle.get("using_sonic_moe", False)
+        and _SONIC_PACK_SCALE_WORDS_AVAILABLE
+    ):
+        grad_scale = _unpack_sonic_fp8_scale_from_deepep(grad_data, grad_scale)
+    combine_grad_handle["data"] = grad_data
+    combine_grad_handle["scale"] = grad_scale
+    return grad_data
 
 
 def configure_buffer(num_sms=None, dispatch_config=None, combine_config=None):
@@ -437,9 +545,15 @@ class DeepEPDispatch(PyLayer):
                 )
                 if not x.is_contiguous():
                     x = x.contiguous()
-                x_fp8, scale = quantize_activation_blockscaled_fast(
-                    x, scale_dtype=paddle.int32
-                )
+                if _SONIC_PACK_SCALE_WORDS_AVAILABLE:
+                    x_fp8, scale = quantize_activation_blockscaled_fast(
+                        x, pack_scale_words=(x.shape[1] % 128 == 0)
+                    )
+                    scale = _pack_sonic_fp8_scale_for_deepep(x_fp8, scale)
+                else:
+                    x_fp8, scale = quantize_activation_blockscaled_fast(
+                        x, scale_dtype=paddle.int32
+                    )
             else:
                 x_fp8, scale = (
                     paddle.incubate.nn.functional.fp8_quant_blockwise(
@@ -534,9 +648,8 @@ class DeepEPCombine(PyLayer):
             assert quantize_activation_blockscaled_fast is not None, (
                 "Cannot find quantize_activation_blockscaled_fast, please update sonicmoe."
             )
-            grad_output = grad_output.contiguous()
-            grad_for_comm = quantize_activation_blockscaled_fast(
-                grad_output, scale_dtype=paddle.int32
+            grad_for_comm = _quantize_combine_grad_for_deepep(
+                grad_output, ctx.combine_grad_handle
             )
 
         grad_x = fused_combine_backward_func(
@@ -550,12 +663,7 @@ class DeepEPCombine(PyLayer):
         )
 
         if ctx.fp8_dispatch:
-            assert ctx.combine_grad_handle is not None, (
-                "For fp8_dispatch, combine_grad_handle must be provided in combine backward."
-            )
-            grad_x, grad_scale = grad_x
-            ctx.combine_grad_handle["data"] = grad_x
-            ctx.combine_grad_handle["scale"] = grad_scale
+            grad_x = _record_fp8_combine_grad(grad_x, ctx.combine_grad_handle)
 
         return grad_x
 
@@ -603,9 +711,8 @@ class DeepEPCombineAsync(PyLayer):
             assert quantize_activation_blockscaled_fast is not None, (
                 "Cannot find quantize_activation_blockscaled_fast, please update sonicmoe."
             )
-            grad_output = grad_output.contiguous()
-            grad_for_comm = quantize_activation_blockscaled_fast(
-                grad_output, scale_dtype=paddle.int32
+            grad_for_comm = _quantize_combine_grad_for_deepep(
+                grad_output, ctx.combine_grad_handle
             )
 
         grad_x = fused_combine_backward_func(
@@ -620,12 +727,7 @@ class DeepEPCombineAsync(PyLayer):
         wait_for_deepep(ctx.group.id)
 
         if ctx.fp8_dispatch:
-            assert ctx.combine_grad_handle is not None, (
-                "For fp8_dispatch, combine_grad_handle must be provided in combine backward."
-            )
-            grad_x, grad_scale = grad_x
-            ctx.combine_grad_handle["data"] = grad_x
-            ctx.combine_grad_handle["scale"] = grad_scale
+            grad_x = _record_fp8_combine_grad(grad_x, ctx.combine_grad_handle)
 
         return (grad_x,) + fn_args_grads  # noqa: RUF005
 
@@ -666,9 +768,8 @@ class DeepEPCombineAsyncFunctor(PyLayer):
             assert quantize_activation_blockscaled_fast is not None, (
                 "Cannot find quantize_activation_blockscaled_fast, please update sonicmoe."
             )
-            grad_output = grad_output.contiguous()
-            grad_for_comm = quantize_activation_blockscaled_fast(
-                grad_output, scale_dtype=paddle.int32
+            grad_for_comm = _quantize_combine_grad_for_deepep(
+                grad_output, ctx.combine_grad_handle
             )
 
         grad_x = fused_combine_backward_func(
@@ -683,12 +784,7 @@ class DeepEPCombineAsyncFunctor(PyLayer):
         wait_for_deepep(ctx.group.id)
 
         if ctx.fp8_dispatch:
-            assert ctx.combine_grad_handle is not None, (
-                "For fp8_dispatch, combine_grad_handle must be provided in combine backward."
-            )
-            grad_x, grad_scale = grad_x
-            ctx.combine_grad_handle["data"] = grad_x
-            ctx.combine_grad_handle["scale"] = grad_scale
+            grad_x = _record_fp8_combine_grad(grad_x, ctx.combine_grad_handle)
 
         return (grad_x,) + fn_args_grads  # noqa: RUF005
 

--- a/src/paddlefleet/transformer/moe/fusion_layer_utils.py
+++ b/src/paddlefleet/transformer/moe/fusion_layer_utils.py
@@ -3364,7 +3364,16 @@ def run_sonic_moe(
     total_expert_freq = TK_padded
     router_score_source = None
     router_score_src_idx = None
-    if _score_src_idx is not None and _HAS_SONIC_METADATA_LAUNCH_BRIDGE:
+    router_scores_need_grad = (
+        hasattr(topk_scores, "stop_gradient") and not topk_scores.stop_gradient
+    )
+    if not router_scores_need_grad:
+        # Read stop_gradient before entering a PyLayer. Paddle detaches tensor
+        # inputs inside .apply(), so the original caller intent is unavailable
+        # to _DownProjection.forward. Metadata scores are forward-only here.
+        _router_scores.stop_gradient = True
+        scores_for_down = _router_scores
+    elif _score_src_idx is not None and _HAS_SONIC_METADATA_LAUNCH_BRIDGE:
         # DownProjection already computes metadata-order ds. Attach the source
         # edge there instead of scheduling a separate per-microbatch carrier.
         scores_for_down = _router_scores

--- a/src/paddlefleet/transformer/moe/fusion_layer_utils.py
+++ b/src/paddlefleet/transformer/moe/fusion_layer_utils.py
@@ -33,6 +33,7 @@ from .vmm_utils import (
 )
 
 _scatter_router_scores_i32 = None
+attach_preallocated_gated_outputs = None
 if paddlefleet_ops.is_sonic_moe_available():
     from paddlefleet_ops.sonicmoe.enums import ActivationType
     from paddlefleet_ops.sonicmoe.ernie_compat.deepep_metadata import (
@@ -49,11 +50,23 @@ if paddlefleet_ops.is_sonic_moe_available():
     from paddlefleet_ops.sonicmoe.functional.utils import enable_fp8
 
     try:
+        from paddlefleet_ops.sonicmoe.functional import (
+            attach_preallocated_gated_outputs,
+        )
+    except ImportError:
+        attach_preallocated_gated_outputs = None
+
+    try:
         from paddlefleet_ops.sonicmoe.quack_utils.blockscaled_fp8_gemm import (
             _scatter_router_scores_i32,
         )
     except (ImportError, RuntimeError):
         pass
+
+_HAS_SONIC_METADATA_LAUNCH_BRIDGE = (
+    paddlefleet_ops.is_sonic_moe_available()
+    and attach_preallocated_gated_outputs is not None
+)
 
 logger = logging.getLogger(__name__)
 
@@ -3234,6 +3247,16 @@ class HybridEPMoePyLayer(paddle.autograd.PyLayer):
         return hidden_states_grad, dispatched_probs_grad
 
 
+def _resolve_sonic_config_bool(config, name):
+    if config is None:
+        return False
+    value = getattr(config, name, None)
+    if value is not None:
+        return bool(value)
+    resolver = getattr(config, f"resolve_{name}", None)
+    return bool(resolver()) if resolver is not None else False
+
+
 def run_sonic_moe(
     hidden_states,
     topk_indices,
@@ -3250,6 +3273,11 @@ def run_sonic_moe(
 ):
     T = hidden_states.shape[0]
     stream_id = paddle.device.current_stream()
+    topk_indices_i32 = (
+        topk_indices
+        if topk_indices.dtype == paddle.int32
+        else topk_indices.cast(paddle.int32)
+    )
 
     if tokens_per_expert is None:
         valid = topk_indices >= 0
@@ -3259,7 +3287,43 @@ def run_sonic_moe(
         )
 
     fp8_scale_packed = None
+    gated_outputs = ()
     if fp8 and fp8_scale is not None:
+        gated_n = int(w1.shape[1])
+        gated_z_quant = _resolve_sonic_config_bool(
+            fp8_config, "epilogue_quant"
+        ) and _resolve_sonic_config_bool(fp8_config, "save_z_fp8")
+        preallocate_gated_outputs = (
+            _HAS_SONIC_METADATA_LAUNCH_BRIDGE
+            and hidden_states.dtype == paddle.float8_e4m3fn
+            and gated_n % 256 == 0
+            and _resolve_sonic_config_bool(fp8_config, "fused_gated")
+            and _resolve_sonic_config_bool(fp8_config, "fuse_y1_quant")
+        )
+        if preallocate_gated_outputs:
+            metadata_result = deepep_topk_to_sonic_metadata_with_scales(
+                topk_indices_i32,
+                topk_scores,
+                tokens_per_expert,
+                E,
+                fp8_scale,
+                int(hidden_states.shape[1]),
+                block=128,
+                gated_output_prototype=hidden_states,
+                gated_n=gated_n,
+                gated_preact_bf16=not gated_z_quant,
+                gated_allocate_z_scale=gated_z_quant,
+            )
+        else:
+            metadata_result = deepep_topk_to_sonic_metadata_with_scales(
+                topk_indices_i32,
+                topk_scores,
+                tokens_per_expert,
+                E,
+                fp8_scale,
+                int(hidden_states.shape[1]),
+                block=128,
+            )
         (
             expert_frequency_offset,
             x_gather_idx,
@@ -3272,15 +3336,8 @@ def run_sonic_moe(
             _N_recv,
             _score_src_idx,
             fp8_scale_packed,
-        ) = deepep_topk_to_sonic_metadata_with_scales(
-            topk_indices.cast(paddle.int32),
-            topk_scores,
-            tokens_per_expert,
-            E,
-            fp8_scale,
-            int(hidden_states.shape[1]),
-            block=128,
-        )
+        ) = metadata_result[:11]
+        gated_outputs = tuple(metadata_result[11:])
     else:
         (
             expert_frequency_offset,
@@ -3294,7 +3351,7 @@ def run_sonic_moe(
             _N_recv,
             _score_src_idx,
         ) = deepep_topk_to_sonic_metadata(
-            topk_indices.cast(paddle.int32),
+            topk_indices_i32,
             topk_scores,
             tokens_per_expert,
             E,
@@ -3305,14 +3362,22 @@ def run_sonic_moe(
     activation_type = ActivationType("swiglu")
 
     total_expert_freq = TK_padded
-    if _score_src_idx is not None and _scatter_router_scores_i32 is not None:
+    router_score_source = None
+    router_score_src_idx = None
+    if _score_src_idx is not None and _HAS_SONIC_METADATA_LAUNCH_BRIDGE:
+        # DownProjection already computes metadata-order ds. Attach the source
+        # edge there instead of scheduling a separate per-microbatch carrier.
+        scores_for_down = _router_scores
+        router_score_source = topk_scores
+        router_score_src_idx = _score_src_idx
+    elif _score_src_idx is not None and _scatter_router_scores_i32 is not None:
         scores_for_down = _SonicRouterScoresFromMetadata.apply(
             topk_scores, _router_scores, _score_src_idx
         )
     else:
         scores_for_down = _differentiable_router_scores(
             topk_scores,
-            topk_indices.cast(paddle.int32),
+            topk_indices_i32,
             num_activated_expert_per_token_offset,
             TK_padded - total_pad_rows,
             TK_padded,
@@ -3322,11 +3387,14 @@ def run_sonic_moe(
 
     fp8_hidden_states = None
     if fp8_scale is not None:
-        fp8_hidden_states = (
-            (hidden_states, fp8_scale, fp8_scale_packed)
-            if fp8_scale_packed is not None
-            else (hidden_states, fp8_scale)
-        )
+        if fp8_scale_packed is not None:
+            if gated_outputs:
+                attach_preallocated_gated_outputs(
+                    fp8_scale_packed, gated_outputs
+                )
+            fp8_hidden_states = (hidden_states, fp8_scale, fp8_scale_packed)
+        else:
+            fp8_hidden_states = (hidden_states, fp8_scale)
 
     # if fp8:
     #     w1_sonic = _make_sonic_fp8_weight_carrier(w1)
@@ -3356,7 +3424,7 @@ def run_sonic_moe(
             prequant_activation_payload=fp8_hidden_states,
             fp8_config=fp8_config,
         )
-        hidden_states = _DownProjection.apply(
+        down_args = (
             y1,
             z,
             w2,
@@ -3375,7 +3443,17 @@ def run_sonic_moe(
             activation_type,
             None,
             fp8_combine_grad_handle,
-            fp8_config=fp8_config,
         )
+        if router_score_source is not None:
+            hidden_states = _DownProjection.apply(
+                *down_args,
+                fp8_config,
+                router_score_source,
+                router_score_src_idx,
+            )
+        else:
+            hidden_states = _DownProjection.apply(
+                *down_args, fp8_config=fp8_config
+            )
 
     return hidden_states

--- a/tests/single_card_tests/transformer/test_sonic_metadata_launch_bridge.py
+++ b/tests/single_card_tests/transformer/test_sonic_metadata_launch_bridge.py
@@ -263,10 +263,13 @@ def _mock_sonic_metadata(with_gated_outputs, packed_scale=True):
     return tuple(values)
 
 
-def _run_sonic_with_mocks(has_bridge, packed_scale=True):
+def _run_sonic_with_mocks(
+    has_bridge, packed_scale=True, scores_stop_gradient=False
+):
     hidden_states = MagicMock(shape=(4, 256), dtype=paddle.float8_e4m3fn)
     topk_indices = MagicMock(dtype=paddle.int32)
     topk_scores = MagicMock()
+    topk_scores.stop_gradient = scores_stop_gradient
     w1 = MagicMock(shape=(2, 512, 256))
     w2 = MagicMock()
     fp8_scale = MagicMock()
@@ -359,6 +362,17 @@ def test_run_sonic_moe_uses_preallocated_outputs_and_fused_router_edge():
     down_args = down_projection.apply.call_args.args
     assert down_args[-2] is not None
     assert down_args[-1] is metadata[9]
+    assert carrier is None
+
+
+def test_run_sonic_moe_does_not_attach_stopped_router_score_edge():
+    metadata, down_projection, attach_outputs, carrier = _run_sonic_with_mocks(
+        True, scores_stop_gradient=True
+    )
+
+    attach_outputs.assert_called_once_with(metadata[10], metadata[11:])
+    assert down_projection.apply.call_args.kwargs.keys() == {"fp8_config"}
+    assert metadata[5].stop_gradient is True
     assert carrier is None
 
 

--- a/tests/single_card_tests/transformer/test_sonic_metadata_launch_bridge.py
+++ b/tests/single_card_tests/transformer/test_sonic_metadata_launch_bridge.py
@@ -1,0 +1,389 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import contextlib
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import paddle
+import pytest
+
+from paddlefleet.transformer.moe import fused_a2a, fusion_layer_utils
+
+
+def _bytes_equal(lhs, rhs):
+    return bool(paddle.all(lhs.view(paddle.uint8) == rhs.view(paddle.uint8)))
+
+
+def test_scale_word_capability_detection_is_import_safe():
+    class OpaqueQuantizer:
+        @property
+        def __signature__(self):
+            raise ValueError("opaque")
+
+        def __call__(self, value):
+            return value
+
+    assert not fused_a2a._supports_sonic_scale_word_packing(None)
+    assert not fused_a2a._supports_sonic_scale_word_packing(OpaqueQuantizer())
+    assert fused_a2a._supports_sonic_scale_word_packing(
+        lambda value, pack_scale_words=False: value
+    )
+
+
+def test_scale_carrier_aligned_is_zero_copy_and_bit_exact():
+    x_fp8 = paddle.empty([5, 256], dtype=paddle.uint8)
+    raw = paddle.randint(0, 256, [5, 8], dtype=paddle.int32).cast(paddle.uint8)
+
+    carrier = fused_a2a._pack_sonic_fp8_scale_for_deepep(x_fp8, raw)
+    restored = fused_a2a._unpack_sonic_fp8_scale_from_deepep(x_fp8, carrier)
+
+    assert carrier.dtype == paddle.int32
+    assert tuple(carrier.shape) == (5, 2)
+    assert carrier.data_ptr() == raw.data_ptr()
+    assert restored.data_ptr() == raw.data_ptr()
+    assert _bytes_equal(restored, raw)
+
+
+def test_scale_carrier_non_aligned_uses_value_fallback():
+    x_fp8 = paddle.empty([3, 160], dtype=paddle.uint8)
+    raw = paddle.randint(0, 256, [3, 5], dtype=paddle.int32).cast(paddle.uint8)
+
+    carrier = fused_a2a._pack_sonic_fp8_scale_for_deepep(x_fp8, raw)
+    restored = fused_a2a._unpack_sonic_fp8_scale_from_deepep(x_fp8, carrier)
+
+    assert carrier.dtype == paddle.int32
+    assert tuple(carrier.shape) == (3, 5)
+    assert bool(paddle.all(restored == raw))
+
+
+def test_scale_carrier_rejects_invalid_shape_and_dtype():
+    x_fp8 = paddle.empty([2, 256], dtype=paddle.uint8)
+    with pytest.raises(RuntimeError, match="Invalid Sonic FP8 scale shape"):
+        fused_a2a._pack_sonic_fp8_scale_for_deepep(
+            x_fp8, paddle.empty([2, 7], dtype=paddle.uint8)
+        )
+    with pytest.raises(TypeError, match="expects raw uint8"):
+        fused_a2a._pack_sonic_fp8_scale_for_deepep(
+            x_fp8, paddle.empty([2, 8], dtype=paddle.float32)
+        )
+    with pytest.raises(RuntimeError, match="Invalid packed Sonic FP8 scale"):
+        fused_a2a._unpack_sonic_fp8_scale_from_deepep(
+            x_fp8, paddle.empty([2, 3], dtype=paddle.int32)
+        )
+
+
+def test_scale_carrier_normalizes_noncontiguous_inputs():
+    x_fp8 = paddle.empty([5, 256], dtype=paddle.uint8)
+    raw = (
+        paddle.randint(0, 256, [8, 5], dtype=paddle.int32)
+        .cast(paddle.uint8)
+        .transpose([1, 0])
+    )
+    assert not raw.is_contiguous()
+
+    carrier = fused_a2a._pack_sonic_fp8_scale_for_deepep(x_fp8, raw)
+    noncontiguous_carrier = (
+        carrier.transpose([1, 0]).contiguous().transpose([1, 0])
+    )
+    assert not noncontiguous_carrier.is_contiguous()
+
+    repacked = fused_a2a._pack_sonic_fp8_scale_for_deepep(
+        x_fp8, noncontiguous_carrier
+    )
+    restored = fused_a2a._unpack_sonic_fp8_scale_from_deepep(
+        x_fp8, noncontiguous_carrier
+    )
+    assert tuple(repacked.shape) == (5, 2)
+    assert _bytes_equal(restored, raw.contiguous())
+
+
+def test_combine_helpers_preserve_sonic_scale_bytes():
+    grad = paddle.randn([3, 256], dtype=paddle.float32)
+    fp8 = paddle.empty([3, 256], dtype=paddle.uint8)
+    raw = paddle.randint(0, 256, [3, 8], dtype=paddle.int32).cast(paddle.uint8)
+    handle = {"using_sonic_moe": True}
+
+    with (
+        patch.object(fused_a2a, "_SONIC_PACK_SCALE_WORDS_AVAILABLE", True),
+        patch.object(
+            fused_a2a,
+            "quantize_activation_blockscaled_fast",
+            return_value=(fp8, raw),
+        ) as quantize,
+    ):
+        packed = fused_a2a._quantize_combine_grad_for_deepep(grad, handle)
+        restored = fused_a2a._record_fp8_combine_grad(packed, handle)
+
+    assert quantize.call_args.kwargs == {"pack_scale_words": True}
+    assert restored is fp8
+    assert handle["data"] is fp8
+    assert _bytes_equal(handle["scale"], raw)
+
+
+def test_combine_helpers_keep_legacy_quantizer_contract():
+    grad = paddle.randn([2, 160], dtype=paddle.float32)
+    expected = (MagicMock(), MagicMock())
+    with (
+        patch.object(fused_a2a, "_SONIC_PACK_SCALE_WORDS_AVAILABLE", False),
+        patch.object(
+            fused_a2a,
+            "quantize_activation_blockscaled_fast",
+            return_value=expected,
+        ) as quantize,
+    ):
+        actual = fused_a2a._quantize_combine_grad_for_deepep(
+            grad, {"using_sonic_moe": True}
+        )
+
+    assert actual is expected
+    assert quantize.call_args.kwargs == {"scale_dtype": paddle.int32}
+    with pytest.raises(RuntimeError, match="combine_grad_handle"):
+        fused_a2a._record_fp8_combine_grad(expected, None)
+
+
+@pytest.mark.parametrize("packed_words", [True, False])
+def test_dispatch_supports_new_and_legacy_sonic_quantizers(packed_words):
+    ctx = MagicMock()
+    x = paddle.randn([2, 256], dtype=paddle.float32)
+    fp8 = paddle.empty([2, 256], dtype=paddle.uint8)
+    raw = paddle.randint(0, 256, [2, 8], dtype=paddle.int32).cast(paddle.uint8)
+    scale = raw if packed_words else raw.cast(paddle.int32)
+    token_indices = MagicMock()
+    token_probs = MagicMock()
+    states = {"handle": MagicMock()}
+
+    def dispatch(value, *_args, **_kwargs):
+        return value, token_probs, states, None
+
+    with (
+        patch.object(
+            fused_a2a, "_SONIC_PACK_SCALE_WORDS_AVAILABLE", packed_words
+        ),
+        patch.object(
+            fused_a2a,
+            "quantize_activation_blockscaled_fast",
+            return_value=(fp8, scale),
+        ) as quantize,
+        patch.object(
+            fused_a2a,
+            "fused_dispatch_forward_func",
+            side_effect=dispatch,
+        ),
+    ):
+        recv_x, _, _, handle = fused_a2a.DeepEPDispatch.forward(
+            ctx,
+            x,
+            token_indices,
+            token_probs,
+            2,
+            MagicMock(),
+            fp8_dispatch=True,
+            using_sonic_moe=True,
+        )
+
+    assert recv_x is fp8
+    assert handle["scale"].dtype == paddle.int32
+    expected_kwargs = (
+        {"pack_scale_words": True}
+        if packed_words
+        else {"scale_dtype": paddle.int32}
+    )
+    assert quantize.call_args.kwargs == expected_kwargs
+
+
+@pytest.mark.parametrize(
+    "combine_cls",
+    [
+        fused_a2a.DeepEPCombine,
+        fused_a2a.DeepEPCombineAsync,
+        fused_a2a.DeepEPCombineAsyncFunctor,
+    ],
+)
+def test_all_combine_variants_use_shared_scale_bridge(combine_cls):
+    grad_output = MagicMock()
+    grad_data = MagicMock()
+    ctx = SimpleNamespace(
+        fp8_dispatch=True,
+        combine_grad_handle={"using_sonic_moe": True},
+        group=SimpleNamespace(id=1),
+        handle=MagicMock(),
+        previous_event=None,
+        async_finish=False,
+        allocate_on_comm_stream=False,
+        moe_ep_barrier=True,
+        bwf=lambda *args: (),
+    )
+    with (
+        patch.object(
+            fused_a2a,
+            "_quantize_combine_grad_for_deepep",
+            return_value=MagicMock(),
+        ) as quantize,
+        patch.object(
+            fused_a2a,
+            "fused_combine_backward_func",
+            return_value=MagicMock(),
+        ),
+        patch.object(
+            fused_a2a,
+            "_record_fp8_combine_grad",
+            return_value=grad_data,
+        ) as record,
+        patch.object(fused_a2a, "wait_for_deepep"),
+    ):
+        result = combine_cls.backward(ctx, grad_output)
+
+    quantize.assert_called_once_with(grad_output, ctx.combine_grad_handle)
+    record.assert_called_once()
+    if combine_cls is fused_a2a.DeepEPCombine:
+        assert result is grad_data
+    else:
+        assert result == (grad_data,)
+
+
+def _mock_sonic_metadata(with_gated_outputs, packed_scale=True):
+    values = [MagicMock() for _ in range(6)]
+    values.extend([256, 8, 4, MagicMock(), MagicMock()])
+    if not packed_scale:
+        values[10] = None
+    if with_gated_outputs:
+        values.extend(MagicMock() for _ in range(4))
+    return tuple(values)
+
+
+def _run_sonic_with_mocks(has_bridge, packed_scale=True):
+    hidden_states = MagicMock(shape=(4, 256), dtype=paddle.float8_e4m3fn)
+    topk_indices = MagicMock(dtype=paddle.int32)
+    topk_scores = MagicMock()
+    w1 = MagicMock(shape=(2, 512, 256))
+    w2 = MagicMock()
+    fp8_scale = MagicMock()
+    fp8_config = SimpleNamespace(
+        epilogue_quant=True,
+        save_z_fp8=True,
+        fused_gated=True,
+        fuse_y1_quant=True,
+    )
+    metadata_result = _mock_sonic_metadata(has_bridge, packed_scale)
+    up_projection = MagicMock()
+    up_projection.apply.return_value = (MagicMock(), MagicMock())
+    down_projection = MagicMock()
+    down_projection.apply.return_value = MagicMock()
+
+    patches = (
+        patch.object(
+            fusion_layer_utils,
+            "_HAS_SONIC_METADATA_LAUNCH_BRIDGE",
+            has_bridge,
+        ),
+        patch.object(
+            fusion_layer_utils,
+            "deepep_topk_to_sonic_metadata_with_scales",
+            return_value=metadata_result,
+        ),
+        patch.object(fusion_layer_utils, "_UpProjection", up_projection),
+        patch.object(fusion_layer_utils, "_DownProjection", down_projection),
+        patch.object(
+            fusion_layer_utils,
+            "ActivationType",
+            side_effect=lambda name: name,
+        ),
+        patch.object(
+            fusion_layer_utils,
+            "enable_fp8",
+            side_effect=lambda enabled: contextlib.nullcontext(),
+        ),
+        patch.object(
+            fusion_layer_utils.paddle.device,
+            "current_stream",
+            return_value=7,
+        ),
+        patch.object(
+            fusion_layer_utils,
+            "attach_preallocated_gated_outputs",
+        ),
+    )
+    with contextlib.ExitStack() as stack:
+        entered = [stack.enter_context(item) for item in patches]
+        if not has_bridge:
+            carrier = stack.enter_context(
+                patch.object(
+                    fusion_layer_utils._SonicRouterScoresFromMetadata,
+                    "apply",
+                    return_value=MagicMock(),
+                )
+            )
+            stack.enter_context(
+                patch.object(
+                    fusion_layer_utils,
+                    "_scatter_router_scores_i32",
+                    MagicMock(),
+                )
+            )
+        else:
+            carrier = None
+        fusion_layer_utils.run_sonic_moe(
+            hidden_states,
+            topk_indices,
+            topk_scores,
+            2,
+            2,
+            w1,
+            w2,
+            fp8=True,
+            tokens_per_expert=[2, 2],
+            fp8_scale=fp8_scale,
+            fp8_config=fp8_config,
+        )
+    return metadata_result, down_projection, entered[-1], carrier
+
+
+def test_run_sonic_moe_uses_preallocated_outputs_and_fused_router_edge():
+    metadata, down_projection, attach_outputs, carrier = _run_sonic_with_mocks(
+        True
+    )
+
+    attach_outputs.assert_called_once_with(metadata[10], metadata[11:])
+    down_args = down_projection.apply.call_args.args
+    assert down_args[-2] is not None
+    assert down_args[-1] is metadata[9]
+    assert carrier is None
+
+
+def test_run_sonic_moe_preserves_legacy_router_carrier_fallback():
+    _, down_projection, attach_outputs, carrier = _run_sonic_with_mocks(False)
+
+    attach_outputs.assert_not_called()
+    carrier.assert_called_once()
+    assert down_projection.apply.call_args.kwargs.keys() == {"fp8_config"}
+
+
+def test_run_sonic_moe_preserves_unpacked_scale_fallback():
+    metadata, _, attach_outputs, _ = _run_sonic_with_mocks(
+        False, packed_scale=False
+    )
+
+    assert metadata[10] is None
+    attach_outputs.assert_not_called()
+
+
+def test_resolve_sonic_config_bool_supports_values_and_resolvers():
+    assert not fusion_layer_utils._resolve_sonic_config_bool(None, "enabled")
+    assert fusion_layer_utils._resolve_sonic_config_bool(
+        SimpleNamespace(enabled=True), "enabled"
+    )
+    assert fusion_layer_utils._resolve_sonic_config_bool(
+        SimpleNamespace(resolve_enabled=lambda: True), "enabled"
+    )


### PR DESCRIPTION
### PR Category

Performance Optimization

### PR Types

Performance

### Description

This PR removes avoidable host and GPU launch overhead between DeepEP dispatch and SonicMoE gated GEMM.

Root causes addressed:
- Four opaque E8M0 scale bytes are packed into each DeepEP int32 carrier word without numeric conversion.
- Metadata conversion and gated-output allocation are combined when the companion Sonic capability is available.
- Router-score gradients connect directly to the current source tensor instead of using a per-microbatch carrier.
- The caller reads `stop_gradient` before entering the Sonic PyLayer. Stopped scores remain forward-only and do not receive an invalid backward edge; differentiable scores retain the fused scatter path.

Compatibility is capability-gated. Legacy quantization, metadata, and router-gradient paths remain available with older Sonic versions. No barrier logic, optimizer bypass, layout conversion, or persistent parameter/gradient buffer ownership is changed.

Companion PR: https://github.com/PFCCLab/supersonic-moe/pull/68

The Sonic submodule pointer remains at the current upstream revision. It can advance after the companion PR lands.

### Validation

- Focused tests passed for the fused differentiable edge, stopped-score semantics, and legacy carrier fallback.
- Repository pre-commit hooks passed, including ruff, formatting, private-key, conflict, and AST checks.
- Companion tests cover bit-exact router forward/backward, metadata ownership, FFI pointer rebinding, large shapes, and BF16 persistent `main_grad` accumulation.
- A single-node 8-GPU 100-step integration run matched all reference samples and learning rates. Maximum loss difference was `6.49e-4`, versus `1.91e-2` before the companion wgrad fix, under the same nondeterministic settings.