### PR TITLE
[Execute Infrastructure] Add bot approval required check gated on risemeup1111 approval

### DIFF
--- a/.github/workflows/bot-approval-required.yml
+++ b/.github/workflows/bot-approval-required.yml
@@ -15,8 +15,8 @@
 name: Bot Approval Required
 
 # 合入门禁：满足以下任一条件本检查即通过——
-#   1) Review 机器人 risemeup1111 对本 PR 提交了 APPROVED 评审；或
-#   2) jinle 与 ruibiao 两人均对本 PR 提交了 APPROVED 评审。
+#   1) AI review 机器人 risemeup1111 对本 PR 提交了 APPROVED 评审；或
+#   2) jinle 或 ruibiao 任意一人对本 PR 提交了 APPROVED 评审。
 # 评审提交/修改/撤销或推送新 commit 时自动复检。
 on:
   pull_request:
@@ -29,9 +29,9 @@ permissions:
   pull-requests: read
 
 env:
-  # Review 机器人的 GitHub login。
+  # AI review 机器人的 GitHub login。
   REQUIRED_BOT_LOGIN: risemeup1111
-  # 机器人未 approve 时，需同时 approve 的人工审批人。
+  # 机器人未 approve 时，任意一人 approve 即可放行的人工审批人。
   HUMAN_APPROVER_1: jinle
   HUMAN_APPROVER_2: ruibiao
 
@@ -47,8 +47,8 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
-          echo "机器人审批账号: ${REQUIRED_BOT_LOGIN}"
-          echo "备选人工审批人: ${HUMAN_APPROVER_1} + ${HUMAN_APPROVER_2}"
+          echo "AI review 机器人账号: ${REQUIRED_BOT_LOGIN}"
+          echo "备选人工审批人（任一即可）: ${HUMAN_APPROVER_1} / ${HUMAN_APPROVER_2}"
           echo "Pull request: ${REPO}#${PR_NUMBER}"
 
           reviews=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews?per_page=100")
@@ -71,19 +71,29 @@ jobs:
           approver1_state=$(latest_state "${HUMAN_APPROVER_1}")
           approver2_state=$(latest_state "${HUMAN_APPROVER_2}")
 
-          echo "机器人 ${REQUIRED_BOT_LOGIN} 最新评审状态: ${bot_state}"
+          echo "AI review 机器人 ${REQUIRED_BOT_LOGIN} 最新评审状态: ${bot_state}"
           echo "${HUMAN_APPROVER_1} 最新评审状态: ${approver1_state}"
           echo "${HUMAN_APPROVER_2} 最新评审状态: ${approver2_state}"
 
           if [ "${bot_state}" = "APPROVED" ]; then
-            echo "::notice::机器人 ${REQUIRED_BOT_LOGIN} 已 approve，本 PR 通过审批门禁。"
+            echo "::notice::AI review 机器人 ${REQUIRED_BOT_LOGIN} 已 approve，本 PR 通过审批门禁。"
             exit 0
           fi
 
-          if [ "${approver1_state}" = "APPROVED" ] && [ "${approver2_state}" = "APPROVED" ]; then
-            echo "::notice::${HUMAN_APPROVER_1} 与 ${HUMAN_APPROVER_2} 均已 approve，本 PR 通过审批门禁。"
+          if [ "${approver1_state}" = "APPROVED" ] || [ "${approver2_state}" = "APPROVED" ]; then
+            echo "::notice::${HUMAN_APPROVER_1} / ${HUMAN_APPROVER_2} 中已有人 approve，本 PR 通过审批门禁。"
             exit 0
           fi
 
-          echo "::error::本 PR 尚未通过审批门禁。请研发同学按机器人 ${REQUIRED_BOT_LOGIN} 的 review 意见修改代码并提交新的 commit；或联系 ${HUMAN_APPROVER_1} 和 ${HUMAN_APPROVER_2} 进行 approve（两人都 approve 后本流水线即可通过）。"
+          echo "==================================================================="
+          echo "本PR 尚未通过AI review机器人approve。"
+          echo "请研发同学按AI review机器人的review 意见修改代码并提交新的commit；或联系 ${HUMAN_APPROVER_1} 和 ${HUMAN_APPROVER_2} 进行 approve。"
+          echo ""
+          echo "评审意见处理要求（按优先级）："
+          echo "  - P0（阻塞）：必须修复问题并提交新的 commit，仅回复不算解决。"
+          echo "  - P1（高）：必须修复问题并提交新的 commit，仅回复不算解决。"
+          echo "  - P2（中）：需针对评论进行回复（同意并已修改回复 Done，不同意请给出理由）。"
+          echo "  - P3（低）：需针对评论进行回复（同意并已修改回复 Done，不同意请给出理由）。"
+          echo "==================================================================="
+          echo "::error::本PR 尚未通过AI review机器人approve。请研发同学按AI review机器人的review 意见修改代码并提交新的commit（P0/P1 必须修复并提交新 commit；P2/P3 需针对评论回复）；或联系 ${HUMAN_APPROVER_1} 和 ${HUMAN_APPROVER_2} 进行 approve。"
           exit 1

--- a/.github/workflows/bot-approval-required.yml
+++ b/.github/workflows/bot-approval-required.yml
@@ -16,7 +16,7 @@ name: Bot Approval Required
 
 # 合入门禁：满足以下任一条件本检查即通过——
 #   1) AI review 机器人 risemeup1111 对本 PR 提交了 APPROVED 评审；或
-#   2) GitHub 账号 jinle 或 ruibiao 任意一个对本 PR 提交了 APPROVED 评审。
+#   2) sneaxiy 或 From00 任意一个账号对本 PR 提交了 APPROVED 评审。
 # 评审提交/修改/撤销或推送新 commit 时自动复检。
 on:
   pull_request:
@@ -31,9 +31,9 @@ permissions:
 env:
   # AI review 机器人的 GitHub login。
   REQUIRED_BOT_LOGIN: risemeup1111
-  # 机器人未 approve 时，任意一个 GitHub 账号 approve 即可放行的审批账号。
-  HUMAN_APPROVER_1: jinle
-  HUMAN_APPROVER_2: ruibiao
+  # 机器人未 approve 时，任意一个账号 approve 即可放行的审批账号。
+  HUMAN_APPROVER_1: sneaxiy
+  HUMAN_APPROVER_2: From00
 
 jobs:
   check-bot-approval:
@@ -48,7 +48,6 @@ jobs:
         run: |
           set -euo pipefail
           echo "AI review 机器人账号: ${REQUIRED_BOT_LOGIN}"
-          echo "Pull request: ${REPO}#${PR_NUMBER}"
 
           reviews=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews?per_page=100")
 
@@ -70,17 +69,13 @@ jobs:
           approver1_state=$(latest_state "${HUMAN_APPROVER_1}")
           approver2_state=$(latest_state "${HUMAN_APPROVER_2}")
 
-          echo "AI review 机器人账号 ${REQUIRED_BOT_LOGIN} 最新评审状态: ${bot_state}"
-          echo "GitHub 账号 ${HUMAN_APPROVER_1} 最新评审状态: ${approver1_state}"
-          echo "GitHub 账号 ${HUMAN_APPROVER_2} 最新评审状态: ${approver2_state}"
-
           if [ "${bot_state}" = "APPROVED" ]; then
             echo "::notice::AI review 机器人 ${REQUIRED_BOT_LOGIN} 已 approve，本 PR 通过审批门禁。"
             exit 0
           fi
 
           if [ "${approver1_state}" = "APPROVED" ] || [ "${approver2_state}" = "APPROVED" ]; then
-            echo "::notice::GitHub 账号 ${HUMAN_APPROVER_1} / ${HUMAN_APPROVER_2} 中已有账号 approve，本 PR 通过审批门禁。"
+            echo "::notice::${HUMAN_APPROVER_1} / ${HUMAN_APPROVER_2} 中已有账号 approve，本 PR 通过审批门禁。"
             exit 0
           fi
 

--- a/.github/workflows/bot-approval-required.yml
+++ b/.github/workflows/bot-approval-required.yml
@@ -14,10 +14,10 @@
 
 name: Bot Approval Required
 
-# 合入门禁：满足以下任一条件本检查即通过——
-#   1) AI review 机器人 risemeup1111 对本 PR 提交了 APPROVED 评审；或
-#   2) sneaxiy 或 From00 任意一个账号对本 PR 提交了 APPROVED 评审。
-# 评审提交/修改/撤销或推送新 commit 时自动复检。
+# 合入门禁：满足以下任一条件本检查即通过（仅统计【当前 head commit】上的评审）——
+#   1) AI review 机器人 risemeup1111 对当前 head commit 提交了 APPROVED 评审；或
+#   2) sneaxiy 或 From00 任意一个账号对当前 head commit 提交了 APPROVED 评审。
+# 评审提交/修改/撤销或推送新 commit 时自动复检；旧 commit 上的审批在 push 新提交后自动失效。
 on:
   pull_request:
     types: [opened, synchronize, reopened]
@@ -45,18 +45,22 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
           echo "AI review 机器人账号: ${REQUIRED_BOT_LOGIN}"
 
-          reviews=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews?per_page=100")
+          # 分页读取全部 reviews，避免超过 100 条时漏掉后续页面上的评审。
+          reviews=$(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/reviews?per_page=100" | jq -s 'add')
 
-          # 取指定 login 的最新一条“决定性”评审状态。
+          # 取指定 login 在【当前 PR head commit】上的最新一条“决定性”评审状态。
+          # 仅统计 commit_id == 当前 head 的评审，避免旧 commit 上的审批放行未复审的新代码。
           # COMMENT / PENDING 不影响审批结论。
           latest_state() {
-            echo "${reviews}" | jq -r --arg u "$1" '
+            echo "${reviews}" | jq -r --arg u "$1" --arg head "${HEAD_SHA}" '
               [ .[]
                 | select(.user.login == $u)
+                | select(.commit_id == $head)
                 | select(.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "DISMISSED")
               ]
               | sort_by(.submitted_at)

--- a/.github/workflows/bot-approval-required.yml
+++ b/.github/workflows/bot-approval-required.yml
@@ -14,10 +14,10 @@
 
 name: Bot Approval Required
 
-# This check only passes once the review bot has APPROVED the pull request.
-# Re-runs automatically whenever a review is submitted, edited or dismissed,
-# and whenever new commits are pushed, so the merge gate always reflects the
-# bot's latest decision.
+# 合入门禁：满足以下任一条件本检查即通过——
+#   1) Review 机器人 risemeup1111 对本 PR 提交了 APPROVED 评审；或
+#   2) jinle 与 ruibiao 两人均对本 PR 提交了 APPROVED 评审。
+# 评审提交/修改/撤销或推送新 commit 时自动复检。
 on:
   pull_request:
     types: [opened, synchronize, reopened]
@@ -29,43 +29,61 @@ permissions:
   pull-requests: read
 
 env:
-  # GitHub login of the review bot that must approve before merge.
-  REQUIRED_BOT_LOGIN: raisemeup1111
+  # Review 机器人的 GitHub login。
+  REQUIRED_BOT_LOGIN: risemeup1111
+  # 机器人未 approve 时，需同时 approve 的人工审批人。
+  HUMAN_APPROVER_1: jinle
+  HUMAN_APPROVER_2: ruibiao
 
 jobs:
   check-bot-approval:
     name: Require review-bot approval
     runs-on: ubuntu-latest
     steps:
-      - name: Verify ${{ env.REQUIRED_BOT_LOGIN }} approval
+      - name: Verify approval status
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
-          echo "Required approver bot: ${REQUIRED_BOT_LOGIN}"
+          echo "机器人审批账号: ${REQUIRED_BOT_LOGIN}"
+          echo "备选人工审批人: ${HUMAN_APPROVER_1} + ${HUMAN_APPROVER_2}"
           echo "Pull request: ${REPO}#${PR_NUMBER}"
 
           reviews=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews?per_page=100")
 
-          # Keep only decisive reviews authored by the bot, then take the latest
-          # one. COMMENT / PENDING reviews do not change the approval decision.
-          latest_state=$(echo "${reviews}" | jq -r --arg bot "${REQUIRED_BOT_LOGIN}" '
-            [ .[]
-              | select(.user.login == $bot)
-              | select(.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "DISMISSED")
-            ]
-            | sort_by(.submitted_at)
-            | last
-            | .state // "NONE"
-          ')
+          # 取指定 login 的最新一条“决定性”评审状态。
+          # COMMENT / PENDING 不影响审批结论。
+          latest_state() {
+            echo "${reviews}" | jq -r --arg u "$1" '
+              [ .[]
+                | select(.user.login == $u)
+                | select(.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "DISMISSED")
+              ]
+              | sort_by(.submitted_at)
+              | last
+              | .state // "NONE"
+            '
+          }
 
-          echo "Latest decisive review state from ${REQUIRED_BOT_LOGIN}: ${latest_state}"
+          bot_state=$(latest_state "${REQUIRED_BOT_LOGIN}")
+          approver1_state=$(latest_state "${HUMAN_APPROVER_1}")
+          approver2_state=$(latest_state "${HUMAN_APPROVER_2}")
 
-          if [ "${latest_state}" = "APPROVED" ]; then
-            echo "::notice::${REQUIRED_BOT_LOGIN} has approved this PR."
-          else
-            echo "::error::This PR must be approved by ${REQUIRED_BOT_LOGIN} before it can be merged (current state: ${latest_state})."
-            exit 1
+          echo "机器人 ${REQUIRED_BOT_LOGIN} 最新评审状态: ${bot_state}"
+          echo "${HUMAN_APPROVER_1} 最新评审状态: ${approver1_state}"
+          echo "${HUMAN_APPROVER_2} 最新评审状态: ${approver2_state}"
+
+          if [ "${bot_state}" = "APPROVED" ]; then
+            echo "::notice::机器人 ${REQUIRED_BOT_LOGIN} 已 approve，本 PR 通过审批门禁。"
+            exit 0
           fi
+
+          if [ "${approver1_state}" = "APPROVED" ] && [ "${approver2_state}" = "APPROVED" ]; then
+            echo "::notice::${HUMAN_APPROVER_1} 与 ${HUMAN_APPROVER_2} 均已 approve，本 PR 通过审批门禁。"
+            exit 0
+          fi
+
+          echo "::error::本 PR 尚未通过审批门禁。请研发同学按机器人 ${REQUIRED_BOT_LOGIN} 的 review 意见修改代码并提交新的 commit；或联系 ${HUMAN_APPROVER_1} 和 ${HUMAN_APPROVER_2} 进行 approve（两人都 approve 后本流水线即可通过）。"
+          exit 1

--- a/.github/workflows/bot-approval-required.yml
+++ b/.github/workflows/bot-approval-required.yml
@@ -16,7 +16,7 @@ name: Bot Approval Required
 
 # 合入门禁：满足以下任一条件本检查即通过——
 #   1) AI review 机器人 risemeup1111 对本 PR 提交了 APPROVED 评审；或
-#   2) jinle 或 ruibiao 任意一人对本 PR 提交了 APPROVED 评审。
+#   2) GitHub 账号 jinle 或 ruibiao 任意一个对本 PR 提交了 APPROVED 评审。
 # 评审提交/修改/撤销或推送新 commit 时自动复检。
 on:
   pull_request:
@@ -31,7 +31,7 @@ permissions:
 env:
   # AI review 机器人的 GitHub login。
   REQUIRED_BOT_LOGIN: risemeup1111
-  # 机器人未 approve 时，任意一人 approve 即可放行的人工审批人。
+  # 机器人未 approve 时，任意一个 GitHub 账号 approve 即可放行的审批账号。
   HUMAN_APPROVER_1: jinle
   HUMAN_APPROVER_2: ruibiao
 
@@ -48,7 +48,6 @@ jobs:
         run: |
           set -euo pipefail
           echo "AI review 机器人账号: ${REQUIRED_BOT_LOGIN}"
-          echo "备选人工审批人（任一即可）: ${HUMAN_APPROVER_1} / ${HUMAN_APPROVER_2}"
           echo "Pull request: ${REPO}#${PR_NUMBER}"
 
           reviews=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews?per_page=100")
@@ -71,9 +70,9 @@ jobs:
           approver1_state=$(latest_state "${HUMAN_APPROVER_1}")
           approver2_state=$(latest_state "${HUMAN_APPROVER_2}")
 
-          echo "AI review 机器人 ${REQUIRED_BOT_LOGIN} 最新评审状态: ${bot_state}"
-          echo "${HUMAN_APPROVER_1} 最新评审状态: ${approver1_state}"
-          echo "${HUMAN_APPROVER_2} 最新评审状态: ${approver2_state}"
+          echo "AI review 机器人账号 ${REQUIRED_BOT_LOGIN} 最新评审状态: ${bot_state}"
+          echo "GitHub 账号 ${HUMAN_APPROVER_1} 最新评审状态: ${approver1_state}"
+          echo "GitHub 账号 ${HUMAN_APPROVER_2} 最新评审状态: ${approver2_state}"
 
           if [ "${bot_state}" = "APPROVED" ]; then
             echo "::notice::AI review 机器人 ${REQUIRED_BOT_LOGIN} 已 approve，本 PR 通过审批门禁。"
@@ -81,7 +80,7 @@ jobs:
           fi
 
           if [ "${approver1_state}" = "APPROVED" ] || [ "${approver2_state}" = "APPROVED" ]; then
-            echo "::notice::${HUMAN_APPROVER_1} / ${HUMAN_APPROVER_2} 中已有人 approve，本 PR 通过审批门禁。"
+            echo "::notice::GitHub 账号 ${HUMAN_APPROVER_1} / ${HUMAN_APPROVER_2} 中已有账号 approve，本 PR 通过审批门禁。"
             exit 0
           fi
 

--- a/.github/workflows/bot-approval-required.yml
+++ b/.github/workflows/bot-approval-required.yml
@@ -1,0 +1,71 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Bot Approval Required
+
+# This check only passes once the review bot has APPROVED the pull request.
+# Re-runs automatically whenever a review is submitted, edited or dismissed,
+# and whenever new commits are pushed, so the merge gate always reflects the
+# bot's latest decision.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+env:
+  # GitHub login of the review bot that must approve before merge.
+  REQUIRED_BOT_LOGIN: raisemeup1111
+
+jobs:
+  check-bot-approval:
+    name: Require review-bot approval
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify ${{ env.REQUIRED_BOT_LOGIN }} approval
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          echo "Required approver bot: ${REQUIRED_BOT_LOGIN}"
+          echo "Pull request: ${REPO}#${PR_NUMBER}"
+
+          reviews=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews?per_page=100")
+
+          # Keep only decisive reviews authored by the bot, then take the latest
+          # one. COMMENT / PENDING reviews do not change the approval decision.
+          latest_state=$(echo "${reviews}" | jq -r --arg bot "${REQUIRED_BOT_LOGIN}" '
+            [ .[]
+              | select(.user.login == $bot)
+              | select(.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "DISMISSED")
+            ]
+            | sort_by(.submitted_at)
+            | last
+            | .state // "NONE"
+          ')
+
+          echo "Latest decisive review state from ${REQUIRED_BOT_LOGIN}: ${latest_state}"
+
+          if [ "${latest_state}" = "APPROVED" ]; then
+            echo "::notice::${REQUIRED_BOT_LOGIN} has approved this PR."
+          else
+            echo "::error::This PR must be approved by ${REQUIRED_BOT_LOGIN} before it can be merged (current state: ${latest_state})."
+            exit 1
+          fi


### PR DESCRIPTION
### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Devs

### Description
<!-- Describe what you've done -->
新增 `.github/workflows/bot-approval-required.yml`，在 `pull_request` 与 `pull_request_review` 事件上作为合入门禁的 required status check。

**门禁通过条件（满足任一即可，且仅统计当前 head commit 上的评审）：**
1. AI review 机器人 `risemeup1111` 对当前 head commit 提交了 `APPROVED` 评审；**或**
2. `sneaxiy` 或 `From00` 任意一个账号对当前 head commit 提交了 `APPROVED` 评审。

**未通过时的中文提醒：** 提示 RD 按 AI review 机器人的意见修改代码并提交新 commit，或联系 sneaxiy / From00 approve；并附 P0/P1（必须修复并提交新 commit）、P2/P3（需针对评论回复）处理要求。

**可靠性处理：**
- 按 review 的 `commit_id` 过滤到 `github.event.pull_request.head.sha`，避免旧 commit 上的审批在 push 新提交后仍放行未复审的新代码。
- 使用 `gh api --paginate ... | jq -s 'add'` 分页读取全部 reviews，避免超过 100 条时漏判。
- 仅需 `contents: read` 与 `pull-requests: read` 权限。
