### PR TITLE
[release/0.4][Execute Infrastructure] Add bot approval required check gated on risemeup1111 approval

### DIFF
--- a/.github/workflows/bot-approval-required.yml
+++ b/.github/workflows/bot-approval-required.yml
@@ -1,0 +1,97 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Bot Approval Required
+
+# 合入门禁：满足以下任一条件本检查即通过（仅统计【当前 head commit】上的评审）——
+#   1) AI review 机器人 risemeup1111 对当前 head commit 提交了 APPROVED 评审；或
+#   2) sneaxiy 或 From00 任意一个账号对当前 head commit 提交了 APPROVED 评审。
+# 评审提交/修改/撤销或推送新 commit 时自动复检；旧 commit 上的审批在 push 新提交后自动失效。
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+env:
+  # AI review 机器人的 GitHub login。
+  REQUIRED_BOT_LOGIN: risemeup1111
+  # 机器人未 approve 时，任意一个账号 approve 即可放行的审批账号。
+  HUMAN_APPROVER_1: sneaxiy
+  HUMAN_APPROVER_2: From00
+
+jobs:
+  check-bot-approval:
+    name: Require review-bot approval
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify approval status
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          echo "AI review 机器人账号: ${REQUIRED_BOT_LOGIN}"
+
+          # 分页读取全部 reviews，避免超过 100 条时漏掉后续页面上的评审。
+          reviews=$(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/reviews?per_page=100" | jq -s 'add')
+
+          # 取指定 login 在【当前 PR head commit】上的最新一条“决定性”评审状态。
+          # 仅统计 commit_id == 当前 head 的评审，避免旧 commit 上的审批放行未复审的新代码。
+          # COMMENT / PENDING 不影响审批结论。
+          latest_state() {
+            echo "${reviews}" | jq -r --arg u "$1" --arg head "${HEAD_SHA}" '
+              [ .[]
+                | select(.user.login == $u)
+                | select(.commit_id == $head)
+                | select(.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "DISMISSED")
+              ]
+              | sort_by(.submitted_at)
+              | last
+              | .state // "NONE"
+            '
+          }
+
+          bot_state=$(latest_state "${REQUIRED_BOT_LOGIN}")
+          approver1_state=$(latest_state "${HUMAN_APPROVER_1}")
+          approver2_state=$(latest_state "${HUMAN_APPROVER_2}")
+
+          if [ "${bot_state}" = "APPROVED" ]; then
+            echo "::notice::AI review 机器人 ${REQUIRED_BOT_LOGIN} 已 approve，本 PR 通过审批门禁。"
+            exit 0
+          fi
+
+          if [ "${approver1_state}" = "APPROVED" ] || [ "${approver2_state}" = "APPROVED" ]; then
+            echo "::notice::${HUMAN_APPROVER_1} / ${HUMAN_APPROVER_2} 中已有账号 approve，本 PR 通过审批门禁。"
+            exit 0
+          fi
+
+          echo "==================================================================="
+          echo "本PR 尚未通过AI review机器人approve。"
+          echo "请研发同学按AI review机器人的review 意见修改代码并提交新的commit；或联系 ${HUMAN_APPROVER_1} 和 ${HUMAN_APPROVER_2} 进行 approve。"
+          echo ""
+          echo "评审意见处理要求（按优先级）："
+          echo "  - P0（阻塞）：必须修复问题并提交新的 commit，仅回复不算解决。"
+          echo "  - P1（高）：必须修复问题并提交新的 commit，仅回复不算解决。"
+          echo "  - P2（中）：需针对评论进行回复（同意并已修改回复 Done，不同意请给出理由）。"
+          echo "  - P3（低）：需针对评论进行回复（同意并已修改回复 Done，不同意请给出理由）。"
+          echo "==================================================================="
+          echo "::error::本PR 尚未通过AI review机器人approve。请研发同学按AI review机器人的review 意见修改代码并提交新的commit（P0/P1 必须修复并提交新 commit；P2/P3 需针对评论回复）；或联系 ${HUMAN_APPROVER_1} 和 ${HUMAN_APPROVER_2} 进行 approve。"
+          exit 1


### PR DESCRIPTION
### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Devs

### Description
<!-- Describe what you've done -->
新增 `.github/workflows/bot-approval-required.yml`，在 `pull_request` 与 `pull_request_review` 事件上作为合入门禁的 required status check。

**门禁通过条件（满足任一即可，且仅统计当前 head commit 上的评审）：**
1. AI review 机器人 `risemeup1111` 对当前 head commit 提交了 `APPROVED` 评审；**或**
2. `sneaxiy` 或 `From00` 任意一个账号对当前 head commit 提交了 `APPROVED` 评审。

**未通过时的中文提醒：** 提示 RD 按 AI review 机器人的意见修改代码并提交新 commit，或联系 sneaxiy / From00 approve；并附 P0/P1（必须修复并提交新 commit）、P2/P3（需针对评论回复）处理要求。

**可靠性处理：**
- 按 review 的 `commit_id` 过滤到 `github.event.pull_request.head.sha`，避免旧 commit 上的审批在 push 新提交后仍放行未复审的新代码。
- 使用 `gh api --paginate ... | jq -s 'add'` 分页读取全部 reviews，避免超过 100 条时漏判。
- 仅需 `contents: read` 与 `pull-requests: read` 权限。


Cherry-pick of #1460 to `release/0.4`.

Merged in dev: #1460  <!-- For pass CI -->