### PR TITLE
[Execute Infrastructure] ci: fix approval reminder wording & drop pull_request_review trigger

### DIFF
--- a/.github/workflows/bot-approval-required.yml
+++ b/.github/workflows/bot-approval-required.yml
@@ -17,12 +17,10 @@ name: Bot Approval Required
 # 合入门禁：满足以下任一条件本检查即通过（仅统计【当前 head commit】上的评审）——
 #   1) AI review 机器人 risemeup1111 对当前 head commit 提交了 APPROVED 评审；或
 #   2) sneaxiy 或 From00 任意一个账号对当前 head commit 提交了 APPROVED 评审。
-# 评审提交/修改/撤销或推送新 commit 时自动复检；旧 commit 上的审批在 push 新提交后自动失效。
+# 评审后推送新 commit（synchronize）或重开 PR 时自动复检；旧 commit 上的审批在 push 新提交后自动失效。
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-  pull_request_review:
-    types: [submitted, edited, dismissed]
 
 permissions:
   contents: read

--- a/.github/workflows/bot-approval-required.yml
+++ b/.github/workflows/bot-approval-required.yml
@@ -1,23 +1,10 @@
-# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 name: Bot Approval Required
 
 # 合入门禁：满足以下任一条件本检查即通过（仅统计【当前 head commit】上的评审）——
 #   1) AI review 机器人 risemeup1111 对当前 head commit 提交了 APPROVED 评审；或
-#   2) sneaxiy 或 From00 任意一个账号对当前 head commit 提交了 APPROVED 评审。
-# 评审后推送新 commit（synchronize）或重开 PR 时自动复检；旧 commit 上的审批在 push 新提交后自动失效。
+#   2) APPROVERS 名单中任意一个账号对当前 head commit 提交了 APPROVED 评审。
+# 推送新 commit（synchronize）或重开 PR 时自动复检；旧 commit 上的审批在 push 新提交后自动失效。
+# CI 团队成员可通过 check-bypass（skip-ci label / 评论）豁免本检查。
 on:
   pull_request:
     types: [opened, synchronize, reopened]
@@ -29,13 +16,23 @@ permissions:
 env:
   # AI review 机器人的 GitHub login。
   REQUIRED_BOT_LOGIN: risemeup1111
-  # 机器人未 approve 时，任意一个账号 approve 即可放行的审批账号。
-  HUMAN_APPROVER_1: sneaxiy
-  HUMAN_APPROVER_2: From00
+  # 机器人未 approve 时，名单中任意一个账号 approve 即可放行（空格分隔）。
+  APPROVERS: "sneaxiy From00"
 
 jobs:
+  check-bypass:
+    name: Check bypass
+    if: ${{ github.repository_owner == 'PaddlePaddle' }}
+    uses: ./.github/workflows/check-bypass.yml
+    with:
+      workflow-name: 'bot-approval-required'
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+
   check-bot-approval:
     name: Require review-bot approval
+    needs: [check-bypass]
+    if: ${{ needs.check-bypass.outputs.can-skip != 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Verify approval status
@@ -67,23 +64,21 @@ jobs:
             '
           }
 
-          bot_state=$(latest_state "${REQUIRED_BOT_LOGIN}")
-          approver1_state=$(latest_state "${HUMAN_APPROVER_1}")
-          approver2_state=$(latest_state "${HUMAN_APPROVER_2}")
-
-          if [ "${bot_state}" = "APPROVED" ]; then
+          if [ "$(latest_state "${REQUIRED_BOT_LOGIN}")" = "APPROVED" ]; then
             echo "::notice::AI review 机器人 ${REQUIRED_BOT_LOGIN} 已 approve，本 PR 通过审批门禁。"
             exit 0
           fi
 
-          if [ "${approver1_state}" = "APPROVED" ] || [ "${approver2_state}" = "APPROVED" ]; then
-            echo "::notice::${HUMAN_APPROVER_1} / ${HUMAN_APPROVER_2} 中已有账号 approve，本 PR 通过审批门禁。"
-            exit 0
-          fi
+          for u in ${APPROVERS}; do
+            if [ "$(latest_state "$u")" = "APPROVED" ]; then
+              echo "::notice::审批账号 ${u} 已 approve，本 PR 通过审批门禁。"
+              exit 0
+            fi
+          done
 
           echo "==================================================================="
           echo "本PR 尚未通过AI review机器人approve。"
-          echo "请研发同学按AI review机器人的review 意见修改代码并提交新的commit；或联系 ${HUMAN_APPROVER_1} 或 ${HUMAN_APPROVER_2} 进行 approve。"
+          echo "请研发同学按AI review机器人的review 意见修改代码并提交新的commit；或联系审批账号（${APPROVERS}）中任一人进行 approve。"
           echo ""
           echo "评审意见处理要求（按优先级）："
           echo "  - P0（阻塞）：必须修复问题并提交新的 commit，仅回复不算解决。"
@@ -91,5 +86,5 @@ jobs:
           echo "  - P2（中）：需针对评论进行回复（同意并已修改回复 Done，不同意请给出理由）。"
           echo "  - P3（低）：需针对评论进行回复（同意并已修改回复 Done，不同意请给出理由）。"
           echo "==================================================================="
-          echo "::error::本PR 尚未通过AI review机器人approve。请研发同学按AI review机器人的review 意见修改代码并提交新的commit（P0/P1 必须修复并提交新 commit；P2/P3 需针对评论回复）；或联系 ${HUMAN_APPROVER_1} 或 ${HUMAN_APPROVER_2} 进行 approve。"
+          echo "::error::本PR 尚未通过AI review机器人approve。请研发同学按AI review机器人的review 意见修改代码并提交新的commit（P0/P1 必须修复并提交新 commit；P2/P3 需针对评论回复）；或联系审批账号（${APPROVERS}）中任一人进行 approve。"
           exit 1

--- a/.github/workflows/bot-approval-required.yml
+++ b/.github/workflows/bot-approval-required.yml
@@ -85,7 +85,7 @@ jobs:
 
           echo "==================================================================="
           echo "本PR 尚未通过AI review机器人approve。"
-          echo "请研发同学按AI review机器人的review 意见修改代码并提交新的commit；或联系 ${HUMAN_APPROVER_1} 和 ${HUMAN_APPROVER_2} 进行 approve。"
+          echo "请研发同学按AI review机器人的review 意见修改代码并提交新的commit；或联系 ${HUMAN_APPROVER_1} 或 ${HUMAN_APPROVER_2} 进行 approve。"
           echo ""
           echo "评审意见处理要求（按优先级）："
           echo "  - P0（阻塞）：必须修复问题并提交新的 commit，仅回复不算解决。"
@@ -93,5 +93,5 @@ jobs:
           echo "  - P2（中）：需针对评论进行回复（同意并已修改回复 Done，不同意请给出理由）。"
           echo "  - P3（低）：需针对评论进行回复（同意并已修改回复 Done，不同意请给出理由）。"
           echo "==================================================================="
-          echo "::error::本PR 尚未通过AI review机器人approve。请研发同学按AI review机器人的review 意见修改代码并提交新的commit（P0/P1 必须修复并提交新 commit；P2/P3 需针对评论回复）；或联系 ${HUMAN_APPROVER_1} 和 ${HUMAN_APPROVER_2} 进行 approve。"
+          echo "::error::本PR 尚未通过AI review机器人approve。请研发同学按AI review机器人的review 意见修改代码并提交新的commit（P0/P1 必须修复并提交新 commit；P2/P3 需针对评论回复）；或联系 ${HUMAN_APPROVER_1} 或 ${HUMAN_APPROVER_2} 进行 approve。"
           exit 1


### PR DESCRIPTION
### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Devs

### Description
<!-- Describe what you've done -->
承接 #1460，对已合入的 `bot-approval-required.yml` 按 Paddle 的同样形式继续调整，并与 Paddle / PaddleFormers 的门禁保持一致：

1. **检查流程**：新增 `check-bypass` job 复用 `./.github/workflows/check-bypass.yml`，支持 `skip-ci` label / 评论豁免；`check-bot-approval` 依赖 `check-bypass`，当 `can-skip != 'true'` 时才执行审批检查。
2. **审批逻辑**：仅统计当前 head commit 上的评审。AI review 机器人 `risemeup1111` approve，或 `sneaxiy` / `From00` 名单中任一账号 approve 即可通过。
3. **触发器**：仅保留 `pull_request: [opened, synchronize, reopened]`，不再使用 `pull_request_review`。

### 是否引起精度变化
<!-- Describe the impact on precision if any -->
否。本 PR 仅修改 GitHub Actions CI workflow，不涉及框架代码，不引起任何精度变化。
