### PR TITLE
Pass activation clamp config to SonicMoE

### DIFF
--- a/src/paddlefleet/transformer/moe/moe_expert.py
+++ b/src/paddlefleet/transformer/moe/moe_expert.py
@@ -536,8 +536,9 @@ class SonicMoEExpert(GroupedMLPExpert):
         self.K = topk
         self._weights_layout = self._GROUPED_LAYOUT
         self.sonic_moe_config = _refresh_fp8_config()
+        clamp_value = self.config.activation_func_clamp_value
         self.sonic_moe_config.swiglu_clamp_value = (
-            self.config.activation_func_clamp_value or 0.0
+            0.0 if clamp_value is None else float(clamp_value)
         )
         self.sonic_moe_config.enabled = self.config.fp8 is not None
         self.sonic_moe_config.fp8_wgrad = self.config.fp8_wgrad

--- a/src/paddlefleet/transformer/moe/moe_expert.py
+++ b/src/paddlefleet/transformer/moe/moe_expert.py
@@ -536,6 +536,9 @@ class SonicMoEExpert(GroupedMLPExpert):
         self.K = topk
         self._weights_layout = self._GROUPED_LAYOUT
         self.sonic_moe_config = _refresh_fp8_config()
+        self.sonic_moe_config.swiglu_clamp_value = (
+            self.config.activation_func_clamp_value or 0.0
+        )
         self.sonic_moe_config.enabled = self.config.fp8 is not None
         self.sonic_moe_config.fp8_wgrad = self.config.fp8_wgrad
         self.sonic_moe_config.fuse_y1_quant = True

--- a/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_expert.py
+++ b/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_expert.py
@@ -25,6 +25,7 @@ sys.path.insert(
 
 
 import unittest
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 
@@ -74,3 +75,40 @@ class TestMoeExpert(unittest.TestCase):
         self.assertIsNotNone(expert.weight1)
         self.assertIsNotNone(expert.weight2)
         self.assertEqual(expert.weight1.shape[0], 2)
+
+    def test_sonic_moe_expert_inherits_activation_clamp(self):
+        """Test SonicMoE uses the shared activation clamp configuration."""
+        from paddlefleet.transformer.moe import moe_expert
+
+        for clamp_value, expected in ((7.5, 7.5), (None, 0.0)):
+            with self.subTest(clamp_value=clamp_value):
+                config = _make_expert_config(
+                    activation_func_clamp_value=clamp_value
+                )
+                runtime_config = SimpleNamespace()
+                with (
+                    patch.object(
+                        moe_expert.GroupedMLPExpert,
+                        "__init__",
+                        return_value=None,
+                    ),
+                    patch.object(
+                        moe_expert.SonicMoEExpert,
+                        "config",
+                        config,
+                        create=True,
+                    ),
+                    patch.object(
+                        moe_expert,
+                        "_refresh_fp8_config",
+                        return_value=runtime_config,
+                        create=True,
+                    ),
+                ):
+                    moe_expert.SonicMoEExpert(
+                        num_local_experts=2,
+                        topk=2,
+                        config=config,
+                    )
+
+                self.assertEqual(runtime_config.swiglu_clamp_value, expected)


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
The non-Sonic MoE path already passes `TransformerConfig.activation_func_clamp_value` to its fused expert implementation. SonicMoE creates a separate runtime config snapshot, so that shared setting was dropped before reaching the Sonic kernels.

This change initializes `swiglu_clamp_value` from the existing TransformerConfig field when constructing `SonicMoEExpert`. `None` maps to SonicMoE's disabled value, `0.0`. A focused unit test covers configured and disabled values.

Validation:
- Targeted unit tests: 2 passed.
- All pre-commit hooks passed for the changed files.

### 是否引起精度变化
是。仅当 `activation_func_clamp_value` 被显式配置时，SonicMoE 现在会与现有非 Sonic MoE 路径一致地执行 SwiGLU clamp；未配置时行为不变。