### PR TITLE
Set color for echoMTP to avoid hook bug in sharding overlap

### DIFF
--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -526,16 +526,29 @@ class MoELayer(nn.Layer):
         if self.expert_model_parallel_size > 1:
             self.is_mp_moe = False
             self.is_ep_moe = True
+            # Color routed-expert params with the default "moe_expert" now,
+            # matching the historical construction-time behavior, UNLESS
+            # mtp_shared_last_layer is enabled. In the shared-MTP case the color
+            # (moe_expert vs the no-hook variant) depends on the layer number,
+            # which is unknown here, so coloring is deferred to
+            # set_layer_number()/_color_expert_params(). Paddle forbids
+            # reassigning a non-None color, so coloring must happen exactly once.
+            color_experts_now = not getattr(
+                self.config, "mtp_shared_last_layer", False
+            )
             fusion_experts = None
             if hasattr(self, "grouped_gemm_experts"):
                 fusion_experts = self.grouped_gemm_experts
             if fusion_experts is not None:
                 for p in fusion_experts.parameters():
                     p.is_moe_param = True
-                    p.color = {
-                        "color": "moe_expert",
-                        "group": self.moe_grad_group,
-                    }
+                    # Default color set here; deferred when mtp_shared_last_layer
+                    # is on (see set_layer_number/_color_expert_params).
+                    if color_experts_now:
+                        p.color = {
+                            "color": "moe_expert",
+                            "group": self.moe_grad_group,
+                        }
                     p.no_sync = not self.is_mp_moe
                     p.expert = not self.is_mp_moe
                     if self.is_mp_moe or self.is_ep_moe:
@@ -546,10 +559,13 @@ class MoELayer(nn.Layer):
                 )
                 for p in self.experts.parameters():
                     p.is_moe_param = True
-                    p.color = {
-                        "color": "moe_expert",
-                        "group": self.moe_grad_group,
-                    }
+                    # Default color set here; deferred when mtp_shared_last_layer
+                    # is on (see set_layer_number/_color_expert_params).
+                    if color_experts_now:
+                        p.color = {
+                            "color": "moe_expert",
+                            "group": self.moe_grad_group,
+                        }
                     p.no_sync = not self.is_mp_moe
                     p.expert = not self.is_mp_moe
                     if self.is_mp_moe or self.is_ep_moe:
@@ -1590,12 +1606,61 @@ class MoELayer(nn.Layer):
 
     def set_layer_number(self, layer_number, is_mtp_layer: bool = False):
         self.layer_number = layer_number
+        self.is_mtp_layer = is_mtp_layer
+        # Assign routed-expert 'color' now that the layer number is known. This
+        # is the single place color is set for experts (Paddle forbids
+        # reassigning it): the MTP-shared last layer uses the no-hook color.
+        self._color_expert_params()
         assert hasattr(self.gate, "set_layer_number"), (
             "expect gate has method 'set_layer_number'"
         )
         # Hash routing activation (moe_n_hash_layers) is decided by the router
         # itself based on layer_number. See TopKRouter._setup_hash_layer.
         self.gate.set_layer_number(layer_number, is_mtp_layer=is_mtp_layer)
+
+    def _color_expert_params(self):
+        """Set the sharding 'color' on routed-expert params (called once).
+
+        Only needed when ``mtp_shared_last_layer`` is enabled: in that case the
+        expert params were intentionally left uncolored at construction (the
+        moe_expert vs no-hook choice depends on the layer number). Picks
+        ``moe_weight_no_hook`` for the MTP-shared backbone last layer so the
+        sharding-stage1 optimizer reduces those shared params synchronously (no
+        overlap hook); otherwise the normal ``moe_expert`` color is used.
+
+        Params already colored at construction (the common, non-shared-MTP case)
+        are skipped: Paddle forbids reassigning a non-None color, and their
+        color would be ``moe_expert`` either way.
+        """
+        if self.expert_model_parallel_size <= 1:
+            return
+        # Lazy import to avoid a circular import: transformer_layer imports
+        # MoELayer from this module.
+        from paddlefleet.transformer.transformer_layer import (
+            is_mtp_shared_last_layer,
+        )
+
+        fusion_experts = getattr(self, "grouped_gemm_experts", None)
+        if fusion_experts is not None:
+            expert_params = fusion_experts.parameters()
+        else:
+            assert self.experts is not None, "experts should be initialized."
+            expert_params = self.experts.parameters()
+        color_key = (
+            "moe_weight_no_hook"
+            if is_mtp_shared_last_layer(
+                self.config, self.layer_number, self.is_mtp_layer
+            )
+            else "moe_expert"
+        )
+        for p in expert_params:
+            # Skip params already colored at construction (the non-shared-MTP
+            # case); Paddle forbids reassigning a non-None color. Uncolored
+            # params carry no color attribute (None) or the -1 sentinel.
+            color = getattr(p, "color", None)
+            if color not in (None, -1):
+                continue
+            p.color = {"color": color_key, "group": self.moe_grad_group}
 
 
 class Gemma4TopKRouter(TopKRouter):

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -940,6 +940,11 @@ class TransformerConfig(ModelParallelConfig):
         kernel.
     """
 
+    stage1_overlap: bool = False
+    """
+    overlap backward with sharding gradient reduce for non-pipeline parallelism
+    """
+
     use_fast_hadamard: bool = False
     """Use Tridao's fast Hadamard transform for DSv4 rotate activation function."""
 

--- a/src/paddlefleet/transformer/transformer_layer.py
+++ b/src/paddlefleet/transformer/transformer_layer.py
@@ -62,6 +62,45 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def is_mtp_shared_last_layer(config, layer_number, is_mtp_layer):
+    """Whether this transformer layer is the MTP-shared backbone last layer.
+
+    When ``mtp_shared_last_layer`` is enabled, the backbone's last transformer
+    layer shares (aliases) its weights with the MTP layer. Those shared params
+    must use dedicated "no_hook" colors so the sharding-stage1 optimizer places
+    them in their own comm buffers and reduces them synchronously instead of via
+    the per-param overlap hook (which would fire from multiple detached autograd
+    graphs and break the comm buffer bookkeeping). See MuonShardingOptimizer.
+
+    Returns False when sharing is off, when sharding stage1 comm-overlap is
+    disabled, when MTP is absent, for the MTP layer itself (its params are
+    aliases owned by the backbone), or for non-last layers.
+    """
+    if not getattr(config, "mtp_shared_last_layer", False):
+        return False
+    # The no-hook color only exists to keep the sharding-stage1 comm-overlap
+    # per-param backward hook from double-firing on the aliased shared params.
+    # With stage1 overlap off there is no such hook, so no re-coloring is needed.
+    if not getattr(config, "stage1_overlap", False):
+        return False
+    # Only re-color when MTP is actually present in the model.
+    mtp_num_layers = (
+        config.mtp_num_layers
+        if getattr(config, "mtp_num_layers", 0)
+        else (getattr(config, "num_nextn_predict_layers", 0) or 0)
+    )
+    if mtp_num_layers <= 0:
+        return False
+    if is_mtp_layer:
+        return False
+    last_layer_number = (
+        config.num_hidden_layers
+        - 1
+        + getattr(config, "num_empty_layers_add_in_head", 0)
+    )
+    return layer_number == last_layer_number
+
+
 def tensors_clone(outputs):
     """
     The tensors required for recompute_forward need to be cloned to prevent them from being released prematurely and becoming inaccessible.
@@ -423,6 +462,8 @@ class TransformerLayer(nn.Layer):
                 in_mlp_recompute=self.recompute_mlp,
             )
 
+        self._mark_shared_no_hook_params()
+
     def _compute_act_offload_kwargs(self):
         """Compute activation offload kwargs based on decoderlayer_act_offload_settings."""
         decoderlayer_act_offload_settings = self.config.get(
@@ -442,6 +483,38 @@ class TransformerLayer(nn.Layer):
                 [0] if self.layer_number in offload_value else []
             )
         return offload_kwargs
+
+    def _mark_shared_no_hook_params(self):
+        """Tag the MTP-shared transformer layer's dense params with a no-hook color.
+
+        When ``mtp_shared_last_layer`` is enabled, the backbone's last
+        transformer layer shares its weights with the MTP layer: the very same
+        parameter tensors are reused in a second, detached autograd graph. Under
+        sharding stage1 comm-overlap, the per-param backward hook that drives
+        gradient communication would then fire from multiple graphs (e.g. under
+        FP8 manual backward or recompute), breaking the comm buffer's check-in
+        bookkeeping (``add_grad`` assert / duplicate reduce).
+
+        To avoid this, the shared params live in dedicated "no_hook" color
+        groups. MoE expert params are colored at creation time in
+        ``MoELayer.set_layer_number`` (Paddle forbids reassigning ``color``), so
+        here we only color the remaining plain dense params, which carry no
+        color yet, with ``dense_weight_no_hook`` (default sharding group, same as
+        plain dense params with color=None).
+        """
+        if not is_mtp_shared_last_layer(
+            self.config, self.layer_number, self.is_mtp_layer
+        ):
+            return
+
+        for p in self.parameters():
+            color = getattr(p, "color", None)
+            # MoE experts are already colored (moe_weight_no_hook) at creation
+            # and Paddle forbids reassigning color, so skip anything already
+            # colored; only uncolored dense params need the dense no-hook color.
+            if isinstance(color, dict) or color not in (None, -1):
+                continue
+            p.color = {"color": "dense_weight_no_hook"}
 
     def build_schedule_node(self):
         return TransformerLayerNode(
@@ -1223,6 +1296,14 @@ class HyperConnectionTransformerLayer(TransformerLayer):
             config=self.config,
             layer_number=self.layer_number,
         )
+
+        # The hyper-connection submodules are created after super().__init__()
+        # (which already ran _mark_shared_no_hook_params on the base params), so
+        # their params (mapping_proj.weight, alpha_pre/post/res, bias, ...) are
+        # still uncolored. Under mtp_shared_last_layer these params are also
+        # aliased into the MTP layer, so re-run the no-hook coloring now. It is
+        # idempotent: already-colored base params are skipped.
+        self._mark_shared_no_hook_params()
 
     def _forward_attention(
         self,

--- a/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_router.py
+++ b/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_router.py
@@ -2106,6 +2106,8 @@ class TestMoELayerSetLayerNumberForwardsIsMtp(unittest.TestCase):
         moe = MoELayer.__new__(MoELayer)
         moe.gate = MagicMock()
         moe.layer_number = None
+        # set_layer_number now colors expert params; EP=1 makes that a no-op.
+        moe.expert_model_parallel_size = 1
         return moe
 
     def test_forwards_is_mtp_layer_true(self):

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_layer_2.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_layer_2.py
@@ -182,6 +182,9 @@ class TestMoELayerLightweightMethods(unittest.TestCase):
         self.assertTrue(MoELayer.use_fp8(model))
 
         model.gate = Gate()
+        # set_layer_number now colors expert params; MinimalMoE is not a
+        # MoELayer subclass, so stub the coloring hook out (not under test here).
+        model._color_expert_params = lambda: None
         MoELayer.set_layer_number(model, 11)
         self.assertEqual(model.layer_number, 11)
         self.assertEqual(model.gate.layer_number, 11)

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_layer_7.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_layer_7.py
@@ -241,6 +241,8 @@ class TestMoELayerSetLayerNumber(unittest.TestCase):
     def test_set_layer_number(self):
         layer = MoELayer.__new__(MoELayer)
         layer.gate = MagicMock()
+        # set_layer_number now colors expert params; EP=1 makes that a no-op.
+        layer.expert_model_parallel_size = 1
         layer.set_layer_number(5)
         self.assertEqual(layer.layer_number, 5)
         layer.gate.set_layer_number.assert_called_once_with(
@@ -250,6 +252,7 @@ class TestMoELayerSetLayerNumber(unittest.TestCase):
     def test_set_layer_number_no_set_method(self):
         layer = MoELayer.__new__(MoELayer)
         layer.gate = MagicMock()
+        layer.expert_model_parallel_size = 1
         del layer.gate.set_layer_number
         with self.assertRaises(AssertionError):
             layer.set_layer_number(5)

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_layer_shared_no_hook.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_layer_shared_no_hook.py
@@ -1,0 +1,339 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [AI-EDITED] Unit tests for the model-side "no-hook shared color" coloring that
+# supports sharding-stage1 comm-overlap when the MTP layer shares (aliases) the
+# backbone's last transformer layer weights. Because Paddle now forbids
+# reassigning a parameter's ``color``, the coloring is split into two single
+# assignment sites:
+#   - MoE expert params: colored in MoELayer.set_layer_number/_color_expert_params
+#   - dense params:       colored in TransformerLayer._mark_shared_no_hook_params
+# 覆盖: is_mtp_shared_last_layer 判定 + moe 专家染色 + dense 染色(跳过已染色).
+import types
+import unittest
+
+from paddlefleet.transformer.moe.moe_layer import (
+    MoELayer,
+)
+from paddlefleet.transformer.transformer_layer import (
+    TransformerLayer,
+    is_mtp_shared_last_layer,
+)
+
+
+class _FakeParam:
+    """Minimal parameter stand-in carrying a mutable ``color`` attribute."""
+
+    def __init__(self, color=-1, name="p"):
+        self.color = color
+        self.name = name
+
+
+def _make_config(**overrides):
+    """Build a config namespace with the attrs the logic reads."""
+    cfg = {
+        "mtp_shared_last_layer": True,
+        "stage1_overlap": True,
+        "mtp_num_layers": 0,
+        "num_nextn_predict_layers": 1,
+        "num_hidden_layers": 2,
+        "num_empty_layers_add_in_head": 0,
+    }
+    cfg.update(overrides)
+    return types.SimpleNamespace(**cfg)
+
+
+# PLACEHOLDER_APPEND
+
+
+class TestIsMtpSharedLastLayer(unittest.TestCase):
+    """is_mtp_shared_last_layer 判定逻辑
+    The shared-last-layer predicate used by both coloring sites."""
+
+    def test_sharing_disabled(self):
+        """mtp_shared_last_layer=False -> False"""
+        cfg = _make_config(mtp_shared_last_layer=False)
+        self.assertFalse(is_mtp_shared_last_layer(cfg, 1, False))
+
+    def test_stage1_overlap_disabled(self):
+        """stage1_overlap=False -> False (无 overlap hook, 无需染色)"""
+        cfg = _make_config(stage1_overlap=False)
+        self.assertFalse(is_mtp_shared_last_layer(cfg, 1, False))
+
+    def test_stage1_overlap_attr_missing(self):
+        """config 缺失 stage1_overlap 属性 (getattr -> False) -> False"""
+        cfg = _make_config()
+        del cfg.stage1_overlap
+        self.assertFalse(is_mtp_shared_last_layer(cfg, 1, False))
+
+    def test_no_mtp_layers(self):
+        """mtp_num_layers 与 num_nextn_predict_layers 均为 0 -> False"""
+        cfg = _make_config(mtp_num_layers=0, num_nextn_predict_layers=0)
+        self.assertFalse(is_mtp_shared_last_layer(cfg, 1, False))
+
+    def test_is_mtp_layer(self):
+        """MTP 层自身 (is_mtp_layer=True) -> False (其 param 是别名)"""
+        self.assertFalse(is_mtp_shared_last_layer(_make_config(), 1, True))
+
+    def test_not_last_layer(self):
+        """非最后一层 -> False (last_layer_number = 2-1+0 = 1)"""
+        self.assertFalse(is_mtp_shared_last_layer(_make_config(), 0, False))
+
+    def test_last_layer_via_num_nextn(self):
+        """通过 num_nextn_predict_layers 判定 MTP 存在 -> True"""
+        cfg = _make_config(mtp_num_layers=0, num_nextn_predict_layers=1)
+        self.assertTrue(is_mtp_shared_last_layer(cfg, 1, False))
+
+    def test_last_layer_via_mtp_num_layers(self):
+        """通过 mtp_num_layers 判定 MTP 存在 -> True"""
+        cfg = _make_config(mtp_num_layers=2, num_nextn_predict_layers=0)
+        self.assertTrue(is_mtp_shared_last_layer(cfg, 1, False))
+
+    def test_empty_layers_offset(self):
+        """num_empty_layers_add_in_head 影响最后一层编号
+        last_layer_number = 2 - 1 + 3 = 4"""
+        cfg = _make_config(num_hidden_layers=2, num_empty_layers_add_in_head=3)
+        self.assertFalse(is_mtp_shared_last_layer(cfg, 1, False))
+        self.assertTrue(is_mtp_shared_last_layer(cfg, 4, False))
+
+
+# PLACEHOLDER_APPEND2
+
+
+def _make_moe_stub(
+    config, layer_number, is_mtp_layer, params, ep_size=2, fusion=True
+):
+    """Build a stub 'self' for MoELayer._color_expert_params."""
+    experts = types.SimpleNamespace(parameters=lambda: params)
+    ns = types.SimpleNamespace(
+        config=config,
+        layer_number=layer_number,
+        is_mtp_layer=is_mtp_layer,
+        expert_model_parallel_size=ep_size,
+        moe_grad_group="GRAD_GROUP",
+    )
+    if fusion:
+        ns.grouped_gemm_experts = experts
+    else:
+        ns.experts = experts
+    return ns
+
+
+class TestColorExpertParams(unittest.TestCase):
+    """MoELayer._color_expert_params: 专家参数唯一染色点
+    Experts get colored exactly once, no-hook only on the shared last layer."""
+
+    def test_last_layer_uses_no_hook(self):
+        """最后一层 + mtp_share -> moe_weight_no_hook, 带 moe_grad_group"""
+        p = _FakeParam(-1)
+        stub = _make_moe_stub(_make_config(), 1, False, [p])
+        MoELayer._color_expert_params(stub)
+        self.assertEqual(
+            p.color, {"color": "moe_weight_no_hook", "group": "GRAD_GROUP"}
+        )
+
+    def test_non_last_layer_uses_moe_expert(self):
+        """非最后一层 -> 普通 moe_expert"""
+        p = _FakeParam(-1)
+        stub = _make_moe_stub(_make_config(), 0, False, [p])
+        MoELayer._color_expert_params(stub)
+        self.assertEqual(
+            p.color, {"color": "moe_expert", "group": "GRAD_GROUP"}
+        )
+
+    def test_sharing_off_uses_moe_expert(self):
+        """未开共享 -> moe_expert"""
+        p = _FakeParam(-1)
+        cfg = _make_config(mtp_shared_last_layer=False)
+        stub = _make_moe_stub(cfg, 1, False, [p])
+        MoELayer._color_expert_params(stub)
+        self.assertEqual(
+            p.color, {"color": "moe_expert", "group": "GRAD_GROUP"}
+        )
+
+    def test_stage1_overlap_off_uses_moe_expert(self):
+        """stage1_overlap 关闭 -> 最后一层专家也只用普通 moe_expert, 不染 no_hook"""
+        p = _FakeParam(-1)
+        cfg = _make_config(stage1_overlap=False)
+        stub = _make_moe_stub(cfg, 1, False, [p])
+        MoELayer._color_expert_params(stub)
+        self.assertEqual(
+            p.color, {"color": "moe_expert", "group": "GRAD_GROUP"}
+        )
+
+    def test_non_fusion_experts_branch(self):
+        """无 grouped_gemm_experts 时走 self.experts 分支"""
+        p = _FakeParam(-1)
+        stub = _make_moe_stub(_make_config(), 1, False, [p], fusion=False)
+        MoELayer._color_expert_params(stub)
+        self.assertEqual(p.color["color"], "moe_weight_no_hook")
+
+    def test_ep_le_one_noop(self):
+        """expert_model_parallel_size <= 1 -> 不染色 (无 EP)"""
+        p = _FakeParam(-1)
+        stub = _make_moe_stub(_make_config(), 1, False, [p], ep_size=1)
+        MoELayer._color_expert_params(stub)
+        self.assertEqual(p.color, -1)
+
+    def test_already_colored_param_skipped(self):
+        """构造期已染色 (dict color) 的参数被跳过, 不二次赋值
+        Params colored at construction (non-shared-MTP case) are skipped so
+        Paddle's no-reassign-color constraint is not violated."""
+        grp = object()
+        p = _FakeParam({"color": "moe_expert", "group": grp})
+        # Even on the shared last layer, an already-colored param is left as-is.
+        stub = _make_moe_stub(_make_config(), 1, False, [p])
+        MoELayer._color_expert_params(stub)
+        self.assertEqual(p.color, {"color": "moe_expert", "group": grp})
+
+
+# PLACEHOLDER_APPEND3
+
+
+def _make_layer(config, layer_number, is_mtp_layer, params):
+    """Build a stub 'self' for TransformerLayer._mark_shared_no_hook_params."""
+    return types.SimpleNamespace(
+        config=config,
+        layer_number=layer_number,
+        is_mtp_layer=is_mtp_layer,
+        parameters=lambda: params,
+    )
+
+
+def _mark(stub):
+    TransformerLayer._mark_shared_no_hook_params(stub)
+
+
+class TestMarkSharedNoHookDense(unittest.TestCase):
+    """TransformerLayer._mark_shared_no_hook_params: 只染色未染色的 dense 参数
+    Only uncolored dense params are colored; moe/colored params are skipped."""
+
+    def test_early_return_not_shared_last_layer(self):
+        """非共享最后一层 -> dense 不染色 (color 保持 -1)"""
+        p = _FakeParam(-1)
+        stub = _make_layer(
+            _make_config(), layer_number=0, is_mtp_layer=False, params=[p]
+        )
+        _mark(stub)
+        self.assertEqual(p.color, -1)
+
+    def test_stage1_overlap_off_dense_not_colored(self):
+        """stage1_overlap 关闭 -> 最后一层 dense 也不染色 (color 保持 -1)"""
+        p = _FakeParam(-1)
+        cfg = _make_config(stage1_overlap=False)
+        stub = _make_layer(cfg, layer_number=1, is_mtp_layer=False, params=[p])
+        _mark(stub)
+        self.assertEqual(p.color, -1)
+
+    def test_dense_param_gets_no_hook(self):
+        """最后一层: 未染色 dense (color=-1) -> dense_weight_no_hook, 无 group"""
+        p = _FakeParam(-1)
+        stub = _make_layer(
+            _make_config(), layer_number=1, is_mtp_layer=False, params=[p]
+        )
+        _mark(stub)
+        self.assertEqual(p.color, {"color": "dense_weight_no_hook"})
+
+    def test_uncolored_param_none_gets_no_hook(self):
+        """color 属性缺失 (getattr -> None) 的 dense 也应被染色"""
+        p = _FakeParam(-1)
+        del p.color  # simulate a param that never had a color attribute
+        stub = _make_layer(
+            _make_config(), layer_number=1, is_mtp_layer=False, params=[p]
+        )
+        _mark(stub)
+        self.assertEqual(p.color, {"color": "dense_weight_no_hook"})
+
+    def test_moe_colored_param_skipped(self):
+        """已染色的 moe 参数 (dict color) 应被跳过, 不重染 (Paddle 禁止二次染色)"""
+        moe = _FakeParam({"color": "moe_weight_no_hook", "group": object()})
+        stub = _make_layer(
+            _make_config(), layer_number=1, is_mtp_layer=False, params=[moe]
+        )
+        _mark(stub)
+        self.assertEqual(moe.color["color"], "moe_weight_no_hook")
+
+    def test_mixed_params(self):
+        """dense 与 moe 混合: 仅 dense 被染色, moe 原样保留"""
+        dense = _FakeParam(-1)
+        moe = _FakeParam({"color": "moe_expert", "group": object()})
+        stub = _make_layer(
+            _make_config(),
+            layer_number=1,
+            is_mtp_layer=False,
+            params=[dense, moe],
+        )
+        _mark(stub)
+        self.assertEqual(dense.color, {"color": "dense_weight_no_hook"})
+        self.assertEqual(moe.color["color"], "moe_expert")
+
+
+class TestHyperConnectionSharedNoHook(unittest.TestCase):
+    """HyperConnectionTransformerLayer: hyper-connection 子模块在 super().__init__()
+    之后才创建, 其参数在第一次 _mark_shared_no_hook_params 时还不存在。
+    再次调用应给这些后创建的参数染色, 且对已染色的基类参数幂等。
+    Regression for the bug where late-created hyper-connection params
+    (mapping_proj.weight, alpha_pre/post/res, bias) missed the no-hook color."""
+
+    def test_second_call_colors_late_params(self):
+        """第二次调用给后创建的 hyper-connection 参数补染 dense_weight_no_hook"""
+        # Phase 1: base params present at super().__init__() time.
+        dense = _FakeParam(-1, name="dense")
+        moe = _FakeParam(
+            {"color": "moe_weight_no_hook", "group": object()}, name="moe"
+        )
+        base_params = [dense, moe]
+        stub = _make_layer(
+            _make_config(),
+            layer_number=1,
+            is_mtp_layer=False,
+            params=base_params,
+        )
+        _mark(stub)
+        self.assertEqual(dense.color, {"color": "dense_weight_no_hook"})
+        self.assertEqual(moe.color["color"], "moe_weight_no_hook")
+
+        # Phase 2: hyper-connection submodules created -> new uncolored params.
+        mapping_proj = _FakeParam(-1, name="mapping_proj.weight")
+        alpha = _FakeParam(-1, name="alpha_res")
+        hc_bias = _FakeParam(-1, name="bias")
+        base_params.extend([mapping_proj, alpha, hc_bias])
+        _mark(stub)
+
+        # Late params now colored.
+        for p in (mapping_proj, alpha, hc_bias):
+            self.assertEqual(
+                p.color, {"color": "dense_weight_no_hook"}, msg=p.name
+            )
+        # Base params unchanged (idempotent / no reassignment).
+        self.assertEqual(dense.color, {"color": "dense_weight_no_hook"})
+        self.assertEqual(moe.color["color"], "moe_weight_no_hook")
+
+    def test_second_call_noop_when_not_shared(self):
+        """非共享最后一层: 两次调用后 hyper-connection 参数仍不染色"""
+        dense = _FakeParam(-1)
+        params = [dense]
+        stub = _make_layer(
+            _make_config(), layer_number=0, is_mtp_layer=False, params=params
+        )
+        _mark(stub)
+        mapping_proj = _FakeParam(-1, name="mapping_proj.weight")
+        params.append(mapping_proj)
+        _mark(stub)
+        self.assertEqual(dense.color, -1)
+        self.assertEqual(mapping_proj.color, -1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
对被echo共享的weight设置新color，避免sharding优化器overlap hook bug

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否