### PR TITLE
[MoE][FP8] Fix DeepGEMM scale-factor layout assertion by threading use_ue8m0

### DIFF
--- a/src/paddlefleet/transformer/moe/fp8_utils.py
+++ b/src/paddlefleet/transformer/moe/fp8_utils.py
@@ -252,11 +252,11 @@ def split_group_gemm(
         if use_ue8m0:
             w_scale_tma_align = w_scale[i].T.contiguous().T
         else:
-            w_scale_tma_align = w_scale[i]
+            w_scale_tma_align = w_scale[i].contiguous()
 
         deep_gemm.fp8_gemm_nt(
             (x_i, x_scale_tma_align),
-            (w_fp8[i].contiguous(), w_scale_tma_align.contiguous()),
+            (w_fp8[i].contiguous(), w_scale_tma_align),
             gemm_out[start_idx:end_idx],
         )
 

--- a/src/paddlefleet/transformer/moe/fusion_layer_utils.py
+++ b/src/paddlefleet/transformer/moe/fusion_layer_utils.py
@@ -3166,6 +3166,7 @@ class HybridEPMoePyLayer(paddle.autograd.PyLayer):
         is_first_fwd=False,
         dw_p2p_overlap=False,
         clamp_value=None,
+        use_ue8m0=False,
         use_accuracy_compatible=False,
     ):
         node = ExpertsGroupGemmContiguousNode(
@@ -3176,6 +3177,7 @@ class HybridEPMoePyLayer(paddle.autograd.PyLayer):
             use_fp8_mlp=use_fp8_mlp,
             moe_deep_gemm=moe_deep_gemm,
             moe_expert_fusion=moe_expert_fusion,
+            use_ue8m0=use_ue8m0,
             dw_p2p_overlap=dw_p2p_overlap,
             clamp_value=clamp_value,
             activation_type=getattr(custom_map, "_activation_type", "swiglu"),

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -1008,6 +1008,7 @@ class MoELayer(nn.Layer):
             use_fp8_mlp=self.fp8,
             moe_deep_gemm=self.moe_deep_gemm,
             moe_expert_fusion=self.moe_expert_fusion,
+            use_ue8m0=self.use_ue8m0,
             recompute_moe_gate_up=self.recompute_moe_gate_up,
             use_bf16_gemm_weight_grad=not self.fp8_wgrad,
             fp8_dispatched_handle=fp8_dispatched_handle,


### PR DESCRIPTION
### PR Category

Operator Mechanism

### PR Types

Bug fixes

### Description

修复 MoE FP8 group GEMM 路径的 DeepGEMM scale-factor 布局断言（`layout.hpp:84` / `layout.hpp:86`）。

**根因**：`use_ue8m0` 没有从 `moe_layer.py` 透传经 `HybridEPMoePyLayer` 到专家 GEMM 节点，节点默认 `use_ue8m0=False`，从而跳过了把 scale factor 做成 MN-major 的布局处理。但在 `offline_quant_expert_weight=true` 时专家权重 scale 是 UE8M0 打包的 int32（打包后 K 维 = ceil_div(K, 512)，真实模型尺寸下 > 1）。DeepGEMM 会按 int32 dtype 自动识别为 UE8M0 并要求 MN-major 布局，收到 row-major 即触发断言。K 很小、打包后 K 维 == 1 时天然是 MN-major，因此该 bug 在小算例下被掩盖。

**修复（3 个文件）**：
1. `moe_layer.py`：在 `HybridEPMoePyLayer.apply(...)` 调用中传入 `use_ue8m0=self.use_ue8m0`。
2. `fusion_layer_utils.py`：`HybridEPMoePyLayer.forward` 签名增加 `use_ue8m0` 参数，并透传给 `ExpertsGroupGemmContiguousNode(...)`。
3. `fp8_utils.py`：在 `split_group_gemm` 中去掉 `fp8_gemm_nt` 调用里对 weight scale 多余的外层 `.contiguous()`，使 UE8M0 分支保住 `.T.contiguous().T` 得到的 MN-major 布局（非 UE8M0 分支把 `.contiguous()` 移到 else 赋值处，行为不变）。
