### PR TITLE
[DSv4 CSA] Use rope fusion for CSA kv and Indexer q

### DIFF
--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -948,19 +948,24 @@ def _apply_rope(
     if squeeze_head:
         x = x.unsqueeze(2)  # [b, s, 1, dim]
 
-    x_nope = x[..., :nope_dim]
-    x_pe = x[..., nope_dim:]
-    x_pe = _apply_rotary_pos_emb_bshd(
-        x_pe,
-        freqs,
-        mscale=mscale,
-        rotary_interleaved=False,
-        multi_latent_attention=True,
-        mla_output_remove_interleaving=True,
-        high_precision_rope=high_precision_rope,
-    )
+    if getattr(config, "apply_rope_fusion", False) and not high_precision_rope:
+        from paddlefleet.triton_ops import fused_apply_mla_rope_inplace
 
-    out = paddle.concat([x_nope, x_pe], axis=-1)
+        out = fused_apply_mla_rope_inplace(x, freqs, nope_dim, mscale)
+    else:
+        x_nope = x[..., :nope_dim]
+        x_pe = x[..., nope_dim:]
+        x_pe = _apply_rotary_pos_emb_bshd(
+            x_pe,
+            freqs,
+            mscale=mscale,
+            rotary_interleaved=False,
+            multi_latent_attention=True,
+            mla_output_remove_interleaving=True,
+            high_precision_rope=high_precision_rope,
+        )
+        out = paddle.concat([x_nope, x_pe], axis=-1)
+
     if squeeze_head:
         out = out.squeeze(2)
     return out

--- a/src/paddlefleet/transformer/dsv4_hybrid_attention.py
+++ b/src/paddlefleet/transformer/dsv4_hybrid_attention.py
@@ -711,26 +711,35 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
                 query = paddle.concat([q_nope, q_pe], axis=-1)
 
             # KV RoPE: split nope/pe, apply RoPE to pe part
-            kv_nope = kv[..., :nope_dim]
-            kv_pe = kv[..., nope_dim:]
-            # Add head dim for RoPE: [b, sq, pos_dim] -> [b, sq, 1, pos_dim]
-            kv_pe = kv_pe.unsqueeze(2)
-            kv_pe = _apply_rotary_pos_emb_bshd(
-                kv_pe,
-                freqs,
-                mscale=mscale,
-                rotary_interleaved=False,
-                multi_latent_attention=True,
-                mla_output_remove_interleaving=True,
-                high_precision_rope=self.config.high_precision_rope,
-            )
-            kv_pe = kv_pe.squeeze(2)
+            if (
+                self.config.apply_rope_fusion
+                and not self.config.high_precision_rope
+                and not self.use_fp8_qat
+            ):
+                kv = kv.unsqueeze(2)
+                kv = fused_apply_mla_rope_inplace(kv, freqs, nope_dim, mscale)
+                kv = kv.squeeze(2)
+            else:
+                kv_nope = kv[..., :nope_dim]
+                kv_pe = kv[..., nope_dim:]
+                # Add head dim for RoPE: [b, sq, pos_dim] -> [b, sq, 1, pos_dim]
+                kv_pe = kv_pe.unsqueeze(2)
+                kv_pe = _apply_rotary_pos_emb_bshd(
+                    kv_pe,
+                    freqs,
+                    mscale=mscale,
+                    rotary_interleaved=False,
+                    multi_latent_attention=True,
+                    mla_output_remove_interleaving=True,
+                    high_precision_rope=self.config.high_precision_rope,
+                )
+                kv_pe = kv_pe.squeeze(2)
 
-            # KV QAT:
-            #   kv_nope: bf16 -> fp32 -> fp8e4m3 ->fp32 -> bf16
-            if self.use_fp8_qat:
-                kv_nope = fp8_simulate_qat(kv_nope, 64)
-            kv = paddle.concat([kv_nope, kv_pe], axis=-1)
+                # KV QAT:
+                #   kv_nope: bf16 -> fp32 -> fp8e4m3 ->fp32 -> bf16
+                if self.use_fp8_qat:
+                    kv_nope = fp8_simulate_qat(kv_nope, 64)
+                kv = paddle.concat([kv_nope, kv_pe], axis=-1)
         else:
             query = q
 

--- a/src/paddlefleet/triton_ops/mla_rope_inplace_fusion.py
+++ b/src/paddlefleet/triton_ops/mla_rope_inplace_fusion.py
@@ -73,6 +73,32 @@ def _mul_round_bf16(a, b):
 
 
 @triton.jit
+def _cos_sin_kernel(
+    FREQS,
+    COS_OUT,
+    SIN_OUT,
+    n_elements,
+    mscale,
+    INVERSE: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    """Fused port of the eager cos/sin prelude."""
+    pid = tl.program_id(0)
+    offs = pid * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < n_elements
+
+    f = tl.load(FREQS + offs, mask=mask)  # fp32
+
+    c = (tl.cos(f) * mscale).to(tl.bfloat16)
+    s = (tl.sin(f) * mscale).to(tl.bfloat16)
+    if INVERSE:
+        s = -s
+
+    tl.store(COS_OUT + offs, c, mask=mask)
+    tl.store(SIN_OUT + offs, s, mask=mask)
+
+
+@triton.jit
 def _rope_mla_inplace_fwd_kernel(
     T,
     COS,
@@ -263,6 +289,38 @@ class RoPEMLAInplaceFusion(paddle.autograd.PyLayer):
         return grad, None, None  # (t, cos, sin)
 
 
+def _fused_cos_sin(
+    freqs: paddle.Tensor,
+    mscale: float,
+    inverse: bool,
+    dtype: paddle.dtype,
+) -> tuple[paddle.Tensor, paddle.Tensor]:
+    """Triton replacement for the three-line eager cos/sin prelude:
+
+    cos = (paddle.cos(freqs) * mscale).to(dtype)
+    sin = (paddle.sin(freqs) * mscale).to(dtype)
+    if inverse:
+        sin = -sin
+    """
+    freqs = freqs.contiguous()
+    n = freqs.size
+    cos = paddle.empty(freqs.shape, dtype=dtype)
+    sin = paddle.empty(freqs.shape, dtype=dtype)
+
+    BLOCK = 1024
+    grid = (triton.cdiv(n, BLOCK),)
+    _cos_sin_kernel[grid](
+        freqs,
+        cos,
+        sin,
+        n,
+        mscale,
+        inverse,
+        BLOCK,
+    )
+    return cos, sin
+
+
 def fused_apply_mla_rope_inplace(
     t: paddle.Tensor,
     freqs: paddle.Tensor,
@@ -304,7 +362,7 @@ def fused_apply_mla_rope_inplace(
     )
     B, S, H, D = t.shape
     pe_dim = freqs.shape[-1]
-    assert D > pe_dim, f"t last dim {D} must exceed rope pe_dim {pe_dim}"
+    assert D >= pe_dim, f"t last dim {D} must be at least rope pe_dim {pe_dim}"
     nope_dim_check = D - pe_dim
     assert nope_dim == nope_dim_check, (
         f"nope_dim {nope_dim} mismatches D-pe_dim {nope_dim_check}"
@@ -326,14 +384,9 @@ def fused_apply_mla_rope_inplace(
     if B_f < B:
         freqs = freqs.broadcast_to([B, S, 1, pe_dim])
 
-    # Compute cos/sin on the (possibly non-contiguous / broadcast) freqs.
-    # For inverse=True, mirror the eager `sin_ = -sin_` step (rope_utils.py).
-    # Negating after the bf16 cast is equivalent to negating before (bf16
-    # negate is a sign-bit flip), so both orders produce identical bytes.
-    cos = (paddle.cos(freqs) * mscale).to(t.dtype)
-    sin = (paddle.sin(freqs) * mscale).to(t.dtype)
-    if inverse:
-        sin = -sin
+    # Compute cos/sin on freqs
+    cos, sin = _fused_cos_sin(freqs, mscale, inverse, t.dtype)
+
     return RoPEMLAInplaceFusion.apply(
         t, cos, sin, nope_dim, pe_dim, clone_input
     )

--- a/tests/single_card_tests/test_mla_rope_inplace_fusion.py
+++ b/tests/single_card_tests/test_mla_rope_inplace_fusion.py
@@ -31,6 +31,7 @@ from paddlefleet.models.common.embeddings.rope_utils import (
     _apply_rotary_pos_emb_bshd,
 )
 from paddlefleet.triton_ops import fused_apply_mla_rope_inplace
+from paddlefleet.triton_ops.mla_rope_inplace_fusion import _fused_cos_sin
 
 # Shapes from DeepSeek-V4-Flash
 B, S, H, D = 1, 4096, 64, 512
@@ -138,6 +139,21 @@ class TestFusedMLARopeQPeInplace(unittest.TestCase):
         freqs = paddle.randn([B, S, 1, ROPE_DIM])
         freqs.stop_gradient = True
         self._run_case(B, S, freqs, inverse=True)
+
+    def test_fused_cos_sin(self) -> None:
+        freqs = paddle.randn([B, S, 1, ROPE_DIM])
+        dtype = paddle.bfloat16
+        mscale = 0.5
+
+        cos_ref = (paddle.cos(freqs) * mscale).to(dtype)
+        sin_ref = (paddle.sin(freqs) * mscale).to(dtype)
+
+        cos_fused, sin_fused = _fused_cos_sin(
+            freqs, mscale, inverse=False, dtype=dtype
+        )
+
+        _check_equal(cos_ref, cos_fused)
+        _check_equal(sin_ref, sin_fused)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
Performance Optimization


### PR Types
Performance


### Description
将 DSV4 CSA 的主 kv & Compressor kv（在 norm 之后）和 Indexer q（在 linear_wq_b 之后）的 rope 操作都换成可配置的 fusion 算子

虽然 kv 和 indexer q 的计算量很小，但散算子导致的空泡在 seqlen=8k 时非常严重，替换这几处可以提升端到端 5% 性能

另外，优化了融合算子的 cos/sin 计算，无精度变化


### 是否引起精度变化
否

该算子与 eager 逐位对齐，单测 tests/single_card_tests/test_mla_rope_inplace_fusion.py 已保证，无需验证收敛