### PR TITLE
Sink muon orthogonal-slice specs into transformer modules

### DIFF
--- a/src/paddlefleet/transformer/attention.py
+++ b/src/paddlefleet/transformer/attention.py
@@ -923,6 +923,75 @@ class SelfAttention(Attention):
         else:
             self.k_norm = None
 
+    def muon_slice_specs(self, muon_configs):
+        """Muon orthogonal-slice specs for this module's fused QKV weight.
+
+        Returns {relative_param_path: (slice_fn, kwargs)}. Uses per-partition
+        head counts (TP-local), so it naturally slices only this rank's shard.
+        """
+        from paddlefleet.transformer.muon_utils import (
+            ortho_per_head,
+            ortho_qkv_contiguous,
+            ortho_qkv_interleaved,
+        )
+
+        mode = muon_configs.get("muon_qkv_update_mode", "split_head")
+        if mode not in ("split_head", "split_qkv"):
+            return {}
+
+        num_query_groups = self.num_query_groups_per_partition
+        head_dim = self.hidden_size_per_attention_head
+        v_head_dim = self.value_hidden_size_per_attention_head
+
+        if self.config.gpt_model_use_experimental_version:
+            # EC layout: qkv_proj is non-interleaved [all_Q | all_K | all_V]
+            # and gate lives in a separate gate_proj, so use the dedicated EC
+            # slice_fn. split_qkv mode is not supported for this layout yet.
+            if mode != "split_head":
+                return {}
+            specs = {
+                "qkv_proj.weight": (
+                    ortho_qkv_contiguous,
+                    {
+                        "heads": self.num_attention_heads_per_partition,
+                        "groups": num_query_groups,
+                        "head_dim": head_dim,
+                        "v_head_dim": v_head_dim,
+                    },
+                ),
+            }
+            if self.gated_attention:
+                specs["gate_proj.weight"] = (
+                    ortho_per_head,
+                    {
+                        "heads": self.num_attention_heads_per_partition,
+                        "head_sizes": [v_head_dim],
+                    },
+                )
+            return specs
+
+        q_heads_per_group = (
+            self.num_attention_heads_per_partition // num_query_groups
+        )
+        q_dim = q_heads_per_group * head_dim
+        if self.gated_attention:
+            gate_dim = q_heads_per_group * v_head_dim
+            split_dims = [q_dim, gate_dim, head_dim, v_head_dim]
+        else:
+            split_dims = [q_dim, head_dim, v_head_dim]
+
+        return {
+            "qkv_proj.weight": (
+                ortho_qkv_interleaved,
+                {
+                    "groups": num_query_groups,
+                    "role_sizes": split_dims,
+                    "heads_per_group": q_heads_per_group,
+                    "per_head": mode == "split_head",
+                },
+            ),
+        }
+
     def get_query_key_value_tensors(
         self, hidden_states, key_value_states=None, split_qkv=True
     ):
@@ -1321,6 +1390,61 @@ class SelfAttentionVHA(Attention):
         )
 
         vha_postmix_rank_val = vha_postmix_rank
+
+    def muon_slice_specs(self, muon_configs):
+        """Muon orthogonal-slice specs for VHA independent projections.
+
+        Only the ``split_head`` mode is supported (VHA has no fused QKV).
+        Optional projections are guarded so only weights that actually exist on
+        this rank produce specs.
+        """
+        from paddlefleet.transformer.muon_utils import (
+            ortho_per_head,
+            ortho_stacked,
+        )
+
+        if (
+            muon_configs.get("muon_qkv_update_mode", "split_head")
+            != "split_head"
+        ):
+            return {}
+
+        num_kv_heads = self.num_query_groups_per_partition
+        specs = {
+            "q_proj.weight": (
+                ortho_per_head,
+                {
+                    "heads": self.num_attention_heads_per_partition,
+                    "head_sizes": [self.q_head_dim],
+                },
+            ),
+        }
+        if hasattr(self, "shared_kv_proj"):
+            specs["shared_kv_proj.weight"] = (
+                ortho_per_head,
+                {"heads": num_kv_heads, "head_sizes": [self.v_head_dim]},
+            )
+        if hasattr(self, "k_proj"):
+            specs["k_proj.weight"] = (
+                ortho_per_head,
+                {"heads": num_kv_heads, "head_sizes": [self.head_dim]},
+            )
+        if hasattr(self, "v_proj"):
+            specs["v_proj.weight"] = (
+                ortho_per_head,
+                {"heads": num_kv_heads, "head_sizes": [self.v_head_dim]},
+            )
+        if getattr(self, "gate_proj", None) is not None:
+            specs["gate_proj.weight"] = (
+                ortho_per_head,
+                {
+                    "heads": self.num_attention_heads,
+                    "head_sizes": [self.v_head_dim],
+                },
+            )
+        if hasattr(self, "vha_premix_weight"):
+            specs["vha_premix_weight"] = (ortho_stacked, {})
+        return specs
 
     def _apply_vha_premix(self, query: Tensor) -> Tensor:
         # query: [b, sq, g, q_head_dim], premix: [nkv, q_head_dim, head_dim]

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -1434,6 +1434,34 @@ class Compressor(nn.Layer):
         )
         self.high_precision_rope = getattr(config, "high_precision_rope", False)
 
+    def muon_slice_specs(self, muon_configs):
+        """Muon orthogonal-slice specs for the compressor (overlap/ratio-4 only).
+
+        Covers both the core-attention compressor (``self.head_dim`` == v_head_dim)
+        and the indexer compressor (``self.head_dim`` == dsa_index_head_dim); the
+        head_dim is read from ``self`` so the same method serves both.
+        """
+        from paddlefleet.transformer.muon_utils import ortho_per_head
+
+        if (
+            muon_configs.get("muon_qkv_update_mode", "split_head")
+            != "split_head"
+        ):
+            return {}
+        if not self.overlap:
+            return {}
+
+        return {
+            "linear_wkv.weight": (
+                ortho_per_head,
+                {"head_sizes": [self.head_dim, self.head_dim]},
+            ),
+            "linear_wgate.weight": (
+                ortho_per_head,
+                {"head_sizes": [self.head_dim, self.head_dim]},
+            ),
+        }
+
     def _overlap_transform(
         self,
         tensor: Tensor,
@@ -1752,6 +1780,23 @@ class CSAIndexer(nn.Layer):
 
         self.use_fp8_qat = getattr(config, "use_fp8_qat", False)
         self.use_fast_hadamard = getattr(config, "use_fast_hadamard", False)
+
+    def muon_slice_specs(self, muon_configs):
+        """Muon orthogonal-slice spec for the indexer q-up projection."""
+        from paddlefleet.transformer.muon_utils import ortho_per_head
+
+        if (
+            muon_configs.get("muon_qkv_update_mode", "split_head")
+            != "split_head"
+        ):
+            return {}
+
+        return {
+            "linear_wq_b.weight": (
+                ortho_per_head,
+                {"heads": self.index_n_heads},
+            ),
+        }
 
     def forward_before_topk(
         self,

--- a/src/paddlefleet/transformer/dsv4_hybrid_attention.py
+++ b/src/paddlefleet/transformer/dsv4_hybrid_attention.py
@@ -1004,6 +1004,23 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
             eps=getattr(config, "rms_norm_eps", 1e-5),
         )
 
+    def muon_slice_specs(self, muon_configs):
+        """Muon orthogonal-slice spec for the DSv4 hybrid q-up projection."""
+        from paddlefleet.transformer.muon_utils import ortho_per_head
+
+        if (
+            muon_configs.get("muon_qkv_update_mode", "split_head")
+            != "split_head"
+        ):
+            return {}
+
+        return {
+            "linear_q_up_proj.weight": (
+                ortho_per_head,
+                {"heads": self.num_attention_heads_per_partition},
+            ),
+        }
+
     def get_query_key_value_tensors(
         self,
         hidden_states: Tensor,

--- a/src/paddlefleet/transformer/mlp.py
+++ b/src/paddlefleet/transformer/mlp.py
@@ -179,6 +179,21 @@ class MLP(FleetLayer):
             disable_fp8=disable_fp8,
         )
 
+    def muon_slice_specs(self, muon_configs):
+        """Muon orthogonal-slice spec for the fused gate/up projection.
+
+        Inherited by StandardMLPExpert / StandardMLPSharedExpert, so each expert
+        (auto-prefixed by the module tree) gets its own spec. The gate/up split
+        point is derived from the weight shape inside ``ortho_gate_up``.
+        """
+        from paddlefleet.transformer.muon_utils import ortho_gate_up
+
+        if not self.config.gated_linear_unit or not muon_configs.get(
+            "muon_ffn_split", False
+        ):
+            return {}
+        return {"up_gate_proj.weight": (ortho_gate_up, {})}
+
     def forward(self, hidden_states, per_token_scale=None):
         """Perform the forward pass through the MLP block."""
         # [s, b, 4 * h/p]

--- a/src/paddlefleet/transformer/moe/moe_expert.py
+++ b/src/paddlefleet/transformer/moe/moe_expert.py
@@ -259,6 +259,26 @@ class GroupedMLPExpert(FleetLayer):
         self.weight1.is_distributed = self.expert_parallel
         self.weight2.is_distributed = self.expert_parallel
 
+    def muon_slice_specs(self, muon_configs):
+        """Muon orthogonal-slice specs for fused grouped-gemm expert weights.
+
+        weight1 (fused gate/up) is split by shape when ``muon_ffn_split`` is on;
+        weight2 (down) is always orthogonalised per-expert (grouped gemm is
+        inherently a fused 3D expert tensor).
+        """
+        from paddlefleet.transformer.muon_utils import (
+            ortho_gate_up,
+            ortho_stacked,
+        )
+
+        specs = {}
+        if self.config.gated_linear_unit and muon_configs.get(
+            "muon_ffn_split", False
+        ):
+            specs["weight1"] = (ortho_gate_up, {})
+        specs["weight2"] = (ortho_stacked, {})
+        return specs
+
     def forward(
         self,
         permuted_local_hidden_states: paddle.Tensor,

--- a/src/paddlefleet/transformer/multi_latent_attention.py
+++ b/src/paddlefleet/transformer/multi_latent_attention.py
@@ -1109,6 +1109,39 @@ class MLASelfAttention(MultiLatentAttention):
             eps=self.config.rms_norm_eps,
         )
 
+    def muon_slice_specs(self, muon_configs):
+        """Muon orthogonal-slice specs for MLA projections (split_head only)."""
+        from paddlefleet.transformer.muon_utils import ortho_per_head
+
+        if (
+            muon_configs.get("muon_qkv_update_mode", "split_head")
+            != "split_head"
+        ):
+            return {}
+
+        num_heads = self.num_attention_heads_per_partition
+        qk_nope = self.qk_nope_head_dim
+        qk_rope = self.qk_rope_head_dim
+        kv_lora = self.config.kv_lora_rank
+
+        specs = {}
+        if hasattr(self, "q_b_proj"):
+            specs["q_b_proj.weight"] = (
+                ortho_per_head,
+                {"heads": num_heads, "head_sizes": [qk_nope, qk_rope]},
+            )
+        specs["kv_a_proj_with_mqa.weight"] = (
+            ortho_per_head,
+            {"head_sizes": [kv_lora, qk_rope]},
+        )
+        specs["kv_b_proj.weight"] = (
+            ortho_per_head,
+            {"heads": num_heads, "head_sizes": [qk_nope, self.v_head_dim]},
+        )
+        if getattr(self, "gate_proj", None) is not None:
+            specs["gate_proj.weight"] = (ortho_per_head, {"heads": num_heads})
+        return specs
+
     def _is_cudagraph_active(self) -> bool:
         """Check if CUDA Graph capture or replay is currently active.
 

--- a/src/paddlefleet/transformer/muon_utils.py
+++ b/src/paddlefleet/transformer/muon_utils.py
@@ -1,0 +1,150 @@
+# Copyright (c) 2024 Baidu, Inc. All Rights Reserved.
+"""Muon orthogonal-slice helpers.
+
+A fused weight often packs several logically independent matrices into one
+tensor (Q/K/V, gate/up, stacked experts). Muon must orthogonalise each of them
+on its own, so every helper here follows the same shape: split the weight along
+one axis, hand each block to ``ortho_fn``, concatenate the results back into the
+original layout.
+
+The transformer submodules own the knowledge of *how* their weights are packed
+and reference these helpers from ``muon_slice_specs``; the helpers themselves
+know nothing about muon configs or module structure.
+"""
+
+import paddle
+
+
+def ortho_blocks(weight, ortho_fn, sizes, axis=-1):
+    """Split ``weight`` along ``axis``, orthogonalise each block, concat back.
+
+    ``sizes`` is either an int (that many equal-width blocks) or a list of
+    per-block widths, matching ``paddle.split``.
+    """
+    blocks = paddle.split(weight, sizes, axis=axis)
+    return paddle.concat([ortho_fn(b) for b in blocks], axis=axis)
+
+
+def ortho_per_head(weight, ortho_fn, heads=1, head_sizes=None, axis=-1):
+    """Orthogonalise a projection head by head.
+
+    ``head_sizes`` describes the widths a single head is made of (e.g.
+    ``[nope_dim, rope_dim]`` or ``[k_dim, v_dim]``); each of those pieces is
+    orthogonalised separately. When it is None a head is one contiguous block
+    and the weight is simply cut into ``heads`` equal parts.
+    """
+    sizes = heads if head_sizes is None else head_sizes * heads
+    return ortho_blocks(weight, ortho_fn, sizes, axis=axis)
+
+
+def ortho_gate_up(weight, ortho_fn):
+    """Orthogonalise the gate and up halves of a fused FFN weight separately.
+
+    Works for 2D (single expert) and 3D (stacked experts) tensors. The split
+    point comes from the tensor shape, so under tensor parallelism each rank
+    splits its own shard rather than a global size.
+    """
+    assert weight.ndim == 2 or weight.ndim == 3, (
+        "FFN gate_up split expects 2D or 3D tensor"
+    )
+
+    half = weight.shape[-1] // 2
+    return ortho_blocks(weight, ortho_fn, [half, half])
+
+
+def ortho_stacked(weight, ortho_fn):
+    """Orthogonalise a stacked 3D weight, one matrix per leading-dim entry.
+
+    Used for tensors whose first axis enumerates independent matrices (fused
+    MoE experts, VHA premix); ``ortho_fn`` handles the leading axis as a batch.
+    """
+    if weight.ndim != 3:
+        raise ValueError(
+            f"Stacked split expects 3D tensor, got shape {weight.shape}"
+        )
+
+    return ortho_fn(weight)
+
+
+def ortho_qkv_interleaved(
+    weight,
+    ortho_fn,
+    groups=None,
+    role_sizes=None,
+    heads_per_group=None,
+    per_head=True,
+):
+    """Orthogonalise a fused QKV weight laid out group by group.
+
+    The weight is ``[group_0(Q, [Gate,] K, V), group_1(...), ...]`` where
+    ``role_sizes`` gives the widths of one group's roles (3 entries without
+    output gating, 4 with).
+
+    ``per_head=True`` orthogonalises every head separately: Q (and Gate) are
+    cut into ``heads_per_group`` heads, K and V are one head each.
+    ``per_head=False`` instead gathers each role across all groups and
+    orthogonalises it as a single matrix, then scatters it back.
+    """
+    group_slices = [
+        paddle.split(group, role_sizes, axis=-1)
+        for group in paddle.split(weight, groups, axis=-1)
+    ]
+
+    if not per_head:
+        out_by_role = [
+            paddle.split(
+                ortho_fn(paddle.concat(list(role_parts), axis=-1)),
+                groups,
+                axis=-1,
+            )
+            for role_parts in zip(*group_slices)
+        ]
+        return paddle.concat(
+            [
+                paddle.concat([role[i] for role in out_by_role], axis=-1)
+                for i in range(groups)
+            ],
+            axis=-1,
+        )
+
+    # Q (and Gate) span heads_per_group heads; K and V are a single head.
+    heads_by_role = [heads_per_group] * (len(role_sizes) - 2) + [1, 1]
+    return paddle.concat(
+        [
+            paddle.concat(
+                [
+                    ortho_blocks(part, ortho_fn, heads)
+                    for part, heads in zip(parts, heads_by_role)
+                ],
+                axis=-1,
+            )
+            for parts in group_slices
+        ],
+        axis=-1,
+    )
+
+
+def ortho_qkv_contiguous(
+    weight,
+    ortho_fn,
+    heads=None,
+    groups=None,
+    head_dim=None,
+    v_head_dim=None,
+):
+    """Orthogonalise a fused QKV weight laid out as ``[all_Q | all_K | all_V]``.
+
+    Every Q head, K head and V head is orthogonalised on its own. Output gating
+    lives in a separate weight for this layout, so there is no Gate role here.
+    """
+    role_sizes = [heads * head_dim, groups * head_dim, groups * v_head_dim]
+    heads_by_role = [heads, groups, groups]
+    return paddle.concat(
+        [
+            ortho_blocks(part, ortho_fn, count)
+            for part, count in zip(
+                paddle.split(weight, role_sizes, axis=-1), heads_by_role
+            )
+        ],
+        axis=-1,
+    )

--- a/tests/single_card_tests/transformer/test_muon_slice_specs.py
+++ b/tests/single_card_tests/transformer/test_muon_slice_specs.py
@@ -1,0 +1,493 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for muon orthogonal-slice specs and the muon_utils slice functions.
+
+The slice functions are pure tensor transforms, so they are tested directly
+on synthetic weights. The per-module ``muon_slice_specs`` methods only read a
+handful of attributes from ``self``, so they are invoked unbound with a
+lightweight namespace object standing in for the layer instance; every
+returned (slice_fn, kwargs) pair is then executed against a weight tensor of
+the matching shape to validate that the split sizes are consistent.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+import paddle
+
+from paddlefleet.transformer.attention import SelfAttention, SelfAttentionVHA
+from paddlefleet.transformer.csa_attention import Compressor, CSAIndexer
+from paddlefleet.transformer.dsv4_hybrid_attention import (
+    DSv4HybridSelfAttention,
+)
+from paddlefleet.transformer.mlp import MLP
+from paddlefleet.transformer.moe.moe_expert import GroupedMLPExpert
+from paddlefleet.transformer.multi_latent_attention import MLASelfAttention
+from paddlefleet.transformer.muon_utils import (
+    ortho_blocks,
+    ortho_gate_up,
+    ortho_per_head,
+    ortho_qkv_contiguous,
+    ortho_qkv_interleaved,
+    ortho_stacked,
+)
+
+HIDDEN = 32
+
+
+class _OrthoRecorder:
+    """Identity ortho_fn that records the shape of every slice it receives."""
+
+    def __init__(self):
+        self.shapes = []
+
+    def __call__(self, x):
+        self.shapes.append(tuple(x.shape))
+        return x
+
+
+def _run_specs(specs, weight_shapes):
+    """Execute every (slice_fn, kwargs) spec against its weight tensor."""
+    outputs = {}
+    for name, (fn, kwargs) in specs.items():
+        ortho = _OrthoRecorder()
+        weight = paddle.randn(weight_shapes[name])
+        out = fn(weight, ortho, **kwargs)
+        assert tuple(out.shape) == tuple(weight.shape), (
+            f"{name}: output shape {out.shape} != input {weight.shape}"
+        )
+        outputs[name] = ortho
+    return outputs
+
+
+class TestMuonUtils(unittest.TestCase):
+    def test_qkv_interleaved_per_head_non_gated(self):
+        groups, heads_per_group, head_dim, v_head_dim = 2, 3, 4, 4
+        split_dims = [heads_per_group * head_dim, head_dim, v_head_dim]
+        width = groups * sum(split_dims)
+        ortho = _OrthoRecorder()
+        w = paddle.randn([HIDDEN, width])
+        out = ortho_qkv_interleaved(
+            w,
+            ortho,
+            groups=groups,
+            role_sizes=split_dims,
+            heads_per_group=heads_per_group,
+        )
+        self.assertEqual(tuple(out.shape), tuple(w.shape))
+        # per group: heads_per_group Q slices + 1 K + 1 V
+        self.assertEqual(len(ortho.shapes), groups * (heads_per_group + 2))
+
+    def test_qkv_interleaved_per_head_gated(self):
+        groups, heads_per_group, head_dim, v_head_dim = 2, 2, 4, 4
+        split_dims = [
+            heads_per_group * head_dim,
+            heads_per_group * v_head_dim,
+            head_dim,
+            v_head_dim,
+        ]
+        width = groups * sum(split_dims)
+        ortho = _OrthoRecorder()
+        w = paddle.randn([HIDDEN, width])
+        out = ortho_qkv_interleaved(
+            w,
+            ortho,
+            groups=groups,
+            role_sizes=split_dims,
+            heads_per_group=heads_per_group,
+        )
+        self.assertEqual(tuple(out.shape), tuple(w.shape))
+        # per group: Q heads + gate heads + K + V
+        self.assertEqual(len(ortho.shapes), groups * (2 * heads_per_group + 2))
+
+    def test_qkv_interleaved_per_role_non_gated(self):
+        groups, heads_per_group, head_dim = 2, 2, 4
+        split_dims = [heads_per_group * head_dim, head_dim, head_dim]
+        w = paddle.randn([HIDDEN, groups * sum(split_dims)])
+        ortho = _OrthoRecorder()
+        out = ortho_qkv_interleaved(
+            w, ortho, groups=groups, role_sizes=split_dims, per_head=False
+        )
+        self.assertEqual(tuple(out.shape), tuple(w.shape))
+        # whole Q / K / V blocks
+        self.assertEqual(len(ortho.shapes), 3)
+
+    def test_qkv_interleaved_per_role_gated(self):
+        groups, heads_per_group, head_dim = 2, 2, 4
+        split_dims = [
+            heads_per_group * head_dim,
+            heads_per_group * head_dim,
+            head_dim,
+            head_dim,
+        ]
+        w = paddle.randn([HIDDEN, groups * sum(split_dims)])
+        ortho = _OrthoRecorder()
+        out = ortho_qkv_interleaved(
+            w, ortho, groups=groups, role_sizes=split_dims, per_head=False
+        )
+        self.assertEqual(tuple(out.shape), tuple(w.shape))
+        # whole Q / Gate / K / V blocks
+        self.assertEqual(len(ortho.shapes), 4)
+
+    def test_qkv_contiguous_per_head(self):
+        num_heads, num_kv, head_dim, v_head_dim = 6, 2, 4, 4
+        width = num_heads * head_dim + num_kv * head_dim + num_kv * v_head_dim
+        w = paddle.randn([HIDDEN, width])
+        ortho = _OrthoRecorder()
+        out = ortho_qkv_contiguous(
+            w,
+            ortho,
+            heads=num_heads,
+            groups=num_kv,
+            head_dim=head_dim,
+            v_head_dim=v_head_dim,
+        )
+        self.assertEqual(tuple(out.shape), tuple(w.shape))
+        self.assertEqual(len(ortho.shapes), num_heads + 2 * num_kv)
+        self.assertTrue(all(s == (HIDDEN, head_dim) for s in ortho.shapes))
+
+    def test_ortho_blocks_int_and_list_sizes(self):
+        w = paddle.randn([HIDDEN, 12])
+        ortho = _OrthoRecorder()
+        out = ortho_blocks(w, ortho, 3)
+        self.assertEqual(tuple(out.shape), tuple(w.shape))
+        self.assertEqual(ortho.shapes, [(HIDDEN, 4)] * 3)
+
+        ortho = _OrthoRecorder()
+        out = ortho_blocks(w, ortho, [2, 4, 6])
+        self.assertEqual(tuple(out.shape), tuple(w.shape))
+        self.assertEqual(ortho.shapes, [(HIDDEN, 2), (HIDDEN, 4), (HIDDEN, 6)])
+
+    def test_gate_up_2d_and_3d(self):
+        for shape in ([HIDDEN, 16], [2, HIDDEN, 16]):
+            ortho = _OrthoRecorder()
+            w = paddle.randn(shape)
+            out = ortho_gate_up(w, ortho)
+            self.assertEqual(tuple(out.shape), tuple(w.shape))
+            self.assertEqual(len(ortho.shapes), 2)
+
+    def test_gate_up_rejects_bad_ndim(self):
+        with self.assertRaises(AssertionError):
+            ortho_gate_up(paddle.randn([8]), lambda x: x)
+
+    def test_per_head_even_and_sized(self):
+        w = paddle.randn([HIDDEN, 12])
+        ortho = _OrthoRecorder()
+        out = ortho_per_head(w, ortho, heads=3)
+        self.assertEqual(tuple(out.shape), tuple(w.shape))
+        self.assertEqual(len(ortho.shapes), 3)
+
+        ortho = _OrthoRecorder()
+        out = ortho_per_head(w, ortho, heads=2, head_sizes=[2, 4])
+        self.assertEqual(tuple(out.shape), tuple(w.shape))
+        self.assertEqual(ortho.shapes, [(HIDDEN, 2), (HIDDEN, 4)] * 2)
+
+    def test_stacked(self):
+        w = paddle.randn([2, HIDDEN, 8])
+        ortho = _OrthoRecorder()
+        out = ortho_stacked(w, ortho)
+        self.assertEqual(tuple(out.shape), tuple(w.shape))
+        self.assertEqual(len(ortho.shapes), 1)
+
+    def test_stacked_rejects_non_3d(self):
+        with self.assertRaises(ValueError):
+            ortho_stacked(paddle.randn([HIDDEN, 8]), lambda x: x)
+
+
+class TestSelfAttentionSpecs(unittest.TestCase):
+    def _fake(self, experimental=False, gated=False):
+        return SimpleNamespace(
+            config=SimpleNamespace(
+                gpt_model_use_experimental_version=experimental
+            ),
+            gated_attention=gated,
+            num_attention_heads_per_partition=4,
+            num_query_groups_per_partition=2,
+            hidden_size_per_attention_head=4,
+            value_hidden_size_per_attention_head=4,
+        )
+
+    def _qkv_width(self, fake):
+        heads = fake.num_attention_heads_per_partition
+        groups = fake.num_query_groups_per_partition
+        head_dim = fake.hidden_size_per_attention_head
+        v_head_dim = fake.value_hidden_size_per_attention_head
+        width = heads * head_dim + groups * (head_dim + v_head_dim)
+        if fake.gated_attention:
+            width += heads * v_head_dim
+        return width
+
+    def test_default_split_head(self):
+        fake = self._fake()
+        specs = SelfAttention.muon_slice_specs(fake, {})
+        self.assertEqual(set(specs), {"qkv_proj.weight"})
+        _run_specs(specs, {"qkv_proj.weight": [HIDDEN, self._qkv_width(fake)]})
+
+    def test_gated_split_qkv(self):
+        fake = self._fake(gated=True)
+        specs = SelfAttention.muon_slice_specs(
+            fake, {"muon_qkv_update_mode": "split_qkv"}
+        )
+        self.assertEqual(set(specs), {"qkv_proj.weight"})
+        _run_specs(specs, {"qkv_proj.weight": [HIDDEN, self._qkv_width(fake)]})
+
+    def test_experimental_non_gated(self):
+        fake = self._fake(experimental=True)
+        specs = SelfAttention.muon_slice_specs(fake, {})
+        self.assertEqual(set(specs), {"qkv_proj.weight"})
+        _run_specs(specs, {"qkv_proj.weight": [HIDDEN, self._qkv_width(fake)]})
+
+    def test_experimental_gated_has_separate_gate_spec(self):
+        fake = self._fake(experimental=True, gated=True)
+        specs = SelfAttention.muon_slice_specs(fake, {})
+        self.assertEqual(set(specs), {"qkv_proj.weight", "gate_proj.weight"})
+        heads = fake.num_attention_heads_per_partition
+        groups = fake.num_query_groups_per_partition
+        head_dim = fake.hidden_size_per_attention_head
+        v_head_dim = fake.value_hidden_size_per_attention_head
+        # EC qkv_proj carries no gate columns; gate is a separate projection.
+        qkv_width = heads * head_dim + groups * (head_dim + v_head_dim)
+        _run_specs(
+            specs,
+            {
+                "qkv_proj.weight": [HIDDEN, qkv_width],
+                "gate_proj.weight": [HIDDEN, heads * v_head_dim],
+            },
+        )
+
+    def test_experimental_split_qkv_unsupported(self):
+        fake = self._fake(experimental=True, gated=True)
+        specs = SelfAttention.muon_slice_specs(
+            fake, {"muon_qkv_update_mode": "split_qkv"}
+        )
+        self.assertEqual(specs, {})
+
+    def test_unknown_mode(self):
+        specs = SelfAttention.muon_slice_specs(
+            self._fake(), {"muon_qkv_update_mode": "none"}
+        )
+        self.assertEqual(specs, {})
+
+
+class TestSelfAttentionVHASpecs(unittest.TestCase):
+    def _fake(self):
+        # VHA overrides num_attention_heads_per_partition to mean the number of
+        # query heads *per group* (num_attention_heads // num_key_value_heads),
+        # so keep it distinct from num_attention_heads here: a spec that grabs
+        # the wrong one then fails on width instead of passing silently.
+        return SimpleNamespace(
+            num_attention_heads_per_partition=2,
+            num_query_groups_per_partition=2,
+            num_attention_heads=4,
+            q_head_dim=4,
+            head_dim=4,
+            v_head_dim=4,
+            shared_kv_proj=object(),
+            k_proj=object(),
+            v_proj=object(),
+            gate_proj=object(),
+            vha_premix_weight=object(),
+        )
+
+    def test_full_specs(self):
+        fake = self._fake()
+        specs = SelfAttentionVHA.muon_slice_specs(fake, {})
+        self.assertEqual(
+            set(specs),
+            {
+                "q_proj.weight",
+                "shared_kv_proj.weight",
+                "k_proj.weight",
+                "v_proj.weight",
+                "gate_proj.weight",
+                "vha_premix_weight",
+            },
+        )
+        _run_specs(
+            specs,
+            {
+                # q is low-rank: width == heads_per_group * q_head_dim
+                "q_proj.weight": [HIDDEN, 2 * 4],
+                "shared_kv_proj.weight": [HIDDEN, 2 * 4],
+                "k_proj.weight": [HIDDEN, 2 * 4],
+                "v_proj.weight": [HIDDEN, 2 * 4],
+                # gate spans all heads: num_attention_heads * v_head_dim
+                "gate_proj.weight": [HIDDEN, 4 * 4],
+                "vha_premix_weight": [2, 4, 4],
+            },
+        )
+
+    def test_minimal_specs(self):
+        fake = self._fake()
+        del fake.shared_kv_proj, fake.k_proj, fake.v_proj
+        del fake.vha_premix_weight
+        fake.gate_proj = None
+        specs = SelfAttentionVHA.muon_slice_specs(fake, {})
+        self.assertEqual(set(specs), {"q_proj.weight"})
+
+    def test_non_split_head_mode(self):
+        specs = SelfAttentionVHA.muon_slice_specs(
+            self._fake(), {"muon_qkv_update_mode": "split_qkv"}
+        )
+        self.assertEqual(specs, {})
+
+
+class TestMLASpecs(unittest.TestCase):
+    def _fake(self):
+        return SimpleNamespace(
+            config=SimpleNamespace(kv_lora_rank=8),
+            num_attention_heads_per_partition=2,
+            qk_nope_head_dim=4,
+            qk_rope_head_dim=2,
+            v_head_dim=4,
+            q_b_proj=object(),
+            gate_proj=object(),
+        )
+
+    def test_full_specs(self):
+        fake = self._fake()
+        specs = MLASelfAttention.muon_slice_specs(fake, {})
+        self.assertEqual(
+            set(specs),
+            {
+                "q_b_proj.weight",
+                "kv_a_proj_with_mqa.weight",
+                "kv_b_proj.weight",
+                "gate_proj.weight",
+            },
+        )
+        _run_specs(
+            specs,
+            {
+                "q_b_proj.weight": [HIDDEN, 2 * (4 + 2)],
+                "kv_a_proj_with_mqa.weight": [HIDDEN, 8 + 2],
+                "kv_b_proj.weight": [HIDDEN, 2 * (4 + 4)],
+                "gate_proj.weight": [HIDDEN, 2 * 4],
+            },
+        )
+
+    def test_without_optional_projections(self):
+        fake = self._fake()
+        del fake.q_b_proj
+        fake.gate_proj = None
+        specs = MLASelfAttention.muon_slice_specs(fake, {})
+        self.assertEqual(
+            set(specs),
+            {"kv_a_proj_with_mqa.weight", "kv_b_proj.weight"},
+        )
+
+    def test_non_split_head_mode(self):
+        specs = MLASelfAttention.muon_slice_specs(
+            self._fake(), {"muon_qkv_update_mode": "split_qkv"}
+        )
+        self.assertEqual(specs, {})
+
+
+class TestDSv4HybridSpecs(unittest.TestCase):
+    def test_specs(self):
+        fake = SimpleNamespace(num_attention_heads_per_partition=4)
+        specs = DSv4HybridSelfAttention.muon_slice_specs(fake, {})
+        self.assertEqual(set(specs), {"linear_q_up_proj.weight"})
+        _run_specs(specs, {"linear_q_up_proj.weight": [HIDDEN, 4 * 4]})
+
+    def test_non_split_head_mode(self):
+        fake = SimpleNamespace(num_attention_heads_per_partition=4)
+        specs = DSv4HybridSelfAttention.muon_slice_specs(
+            fake, {"muon_qkv_update_mode": "split_qkv"}
+        )
+        self.assertEqual(specs, {})
+
+
+class TestMLPSpecs(unittest.TestCase):
+    def test_gated_with_ffn_split(self):
+        fake = SimpleNamespace(config=SimpleNamespace(gated_linear_unit=True))
+        specs = MLP.muon_slice_specs(fake, {"muon_ffn_split": True})
+        self.assertEqual(set(specs), {"up_gate_proj.weight"})
+        _run_specs(specs, {"up_gate_proj.weight": [HIDDEN, 16]})
+
+    def test_non_gated_is_guarded(self):
+        fake = SimpleNamespace(config=SimpleNamespace(gated_linear_unit=False))
+        specs = MLP.muon_slice_specs(fake, {"muon_ffn_split": True})
+        self.assertEqual(specs, {})
+
+    def test_ffn_split_off(self):
+        fake = SimpleNamespace(config=SimpleNamespace(gated_linear_unit=True))
+        specs = MLP.muon_slice_specs(fake, {})
+        self.assertEqual(specs, {})
+
+
+class TestGroupedMLPExpertSpecs(unittest.TestCase):
+    def test_gated_with_ffn_split(self):
+        fake = SimpleNamespace(config=SimpleNamespace(gated_linear_unit=True))
+        specs = GroupedMLPExpert.muon_slice_specs(
+            fake, {"muon_ffn_split": True}
+        )
+        self.assertEqual(set(specs), {"weight1", "weight2"})
+        _run_specs(
+            specs,
+            {"weight1": [2, HIDDEN, 16], "weight2": [2, 8, HIDDEN]},
+        )
+
+    def test_non_gated_keeps_weight2_only(self):
+        fake = SimpleNamespace(config=SimpleNamespace(gated_linear_unit=False))
+        specs = GroupedMLPExpert.muon_slice_specs(
+            fake, {"muon_ffn_split": True}
+        )
+        self.assertEqual(set(specs), {"weight2"})
+
+
+class TestCSASpecs(unittest.TestCase):
+    def test_compressor_overlap(self):
+        fake = SimpleNamespace(overlap=True, head_dim=4)
+        specs = Compressor.muon_slice_specs(fake, {})
+        self.assertEqual(
+            set(specs), {"linear_wkv.weight", "linear_wgate.weight"}
+        )
+        _run_specs(
+            specs,
+            {
+                "linear_wkv.weight": [HIDDEN, 8],
+                "linear_wgate.weight": [HIDDEN, 8],
+            },
+        )
+
+    def test_compressor_no_overlap(self):
+        fake = SimpleNamespace(overlap=False, head_dim=4)
+        specs = Compressor.muon_slice_specs(fake, {})
+        self.assertEqual(specs, {})
+
+    def test_compressor_non_split_head_mode(self):
+        fake = SimpleNamespace(overlap=True, head_dim=4)
+        specs = Compressor.muon_slice_specs(
+            fake, {"muon_qkv_update_mode": "split_qkv"}
+        )
+        self.assertEqual(specs, {})
+
+    def test_indexer(self):
+        fake = SimpleNamespace(index_n_heads=2)
+        specs = CSAIndexer.muon_slice_specs(fake, {})
+        self.assertEqual(set(specs), {"linear_wq_b.weight"})
+        _run_specs(specs, {"linear_wq_b.weight": [HIDDEN, 8]})
+
+    def test_indexer_non_split_head_mode(self):
+        fake = SimpleNamespace(index_n_heads=2)
+        specs = CSAIndexer.muon_slice_specs(
+            fake, {"muon_qkv_update_mode": "split_qkv"}
+        )
+        self.assertEqual(specs, {})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
Add a `muon_slice_specs(self, muon_configs)` method to the relevant transformer
modules. It returns `{relative_param_path: (slice_fn, kwargs)}`, where
`slice_fn` comes from the new `paddlefleet/transformer/muon_utils.py`:

- `_muon_qkv_per_head` / `_muon_qkv_sep`: split a fused QKV weight per head
  group or into separate Q/K/V segments (controlled by `muon_qkv_update_mode`:
  `split_head` / `split_qkv`).
- `_muon_mla_per_head`: split a projection along the head axis, with optional
  per-head sub-splits (`head_split_sizes`).
- `_muon_ffn_gate_up`: split a fused gate/up FFN weight into the two halves
  (controlled by `muon_ffn_split`).
- `_muon_moe_experts`: treat a 3D grouped expert tensor as per-expert matrices.

#### How to build muon_slice_config?

```

def _build_muon_slice_config(model, config) -> dict:
    """Build declarative slice configuration for Muon optimizer.

    Each weight-holding submodule owns the knowledge of how to Muon-slice its
    own parameters via a ``muon_slice_specs(muon_configs)`` method returning
    ``{relative_param_path: (slice_fn, kwargs)}``. Here we simply walk the module
    tree and prepend each submodule's name, so only parameters that actually
    exist on this rank get a slice spec (layer/MTP/SWA enumeration is implicit).
    """
    muon_configs = config.muon_configs
    slice_config = {}
    for name, sub in model.named_sublayers():
        fn = getattr(sub, "muon_slice_specs", None)
        if fn is None:
            continue
        for rel, spec in fn(muon_configs).items():
            slice_config[f"{name}.{rel}"] = spec
    return slice_config
```

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否