### PR TITLE
SonicMoE Performance optimization

### DIFF
--- a/src/paddlefleet/transformer/moe/fp8_utils.py
+++ b/src/paddlefleet/transformer/moe/fp8_utils.py
@@ -168,18 +168,6 @@ def _get_fp8_weight_and_scale(
     return fp8_weight, fp8_scale
 
 
-def _log_stage_memory(stage: str) -> None:
-    paddle.cuda.synchronize()
-    mib = 1024**2
-    print(
-        f"[stage-memory] {stage}: "
-        f"alloc_mib={paddle.cuda.memory_allocated() / mib:.2f}, "
-        f"reserved_mib={paddle.cuda.memory_reserved() / mib:.2f}, "
-        f"peak_alloc_mib={paddle.cuda.max_memory_allocated() / mib:.2f}, "
-        f"peak_reserved_mib={paddle.cuda.max_memory_reserved() / mib:.2f}"
-    )
-
-
 def fused_stack_quant_without_cache(
     expert_weight_list, transpose=False, use_ue8m0=False
 ):
@@ -972,9 +960,6 @@ class ExpertsGroupGemmContiguousNode:
         if clear_o1:
             o1._clear_to_zero_allocation()
         # fused_weighted_swiglu_act_quant 已消费完 o1 产出 o2_fp8，此时 o1 可以安全释放。
-        _log_stage_memory(
-            f"In forward, after swiglu, swiglu_output:{o2_fp8.shape}, dtype: {o2_fp8.dtype}"
-        )
         o3_shape = [o2_fp8.shape[0], w2_quant.shape[1]]
         if o3 is not None:
             assert o3.shape == o3_shape, f"{o3.shape} vs {o3_shape}"
@@ -1286,9 +1271,6 @@ class ExpertsGroupGemmContiguousNode:
                     do2_s,
                     m_indices=self.m_indices,
                 )
-        _log_stage_memory(
-            f"In backward, after down gemm bwd, d_swiglu_output shape:{do2_s.shape}, dtype:{do2_s.dtype}"
-        )
 
         with paddle.amp.auto_cast(False):
             if self.clamp_value is not None and self.clamp_value > 0:
@@ -1317,9 +1299,6 @@ class ExpertsGroupGemmContiguousNode:
                         o1, do2_s, unzipped_probs
                     )
                 )
-        _log_stage_memory(
-            f"In backward, after swiglu bwd, d_swiglu_input shape:{do1.shape}, dtype:{do1.dtype}"
-        )
 
         return do1, o2_s, probs_grad
 
@@ -1675,9 +1654,6 @@ class ExpertsGroupGemmContiguousNode:
         o1 = self.fwd_gate_up(
             hs_out, expert_w1, num_expert, tokens_per_expert, scale=scale
         )
-        _log_stage_memory(
-            f"In forward, after up-gate gemm, up_gate_output shape:{o1.shape}, dtype: {o1.dtype}"
-        )
         if not self.recompute_moe_gate_up:
             self.o1 = o1
             clear_o1 = False
@@ -1700,9 +1676,6 @@ class ExpertsGroupGemmContiguousNode:
             num_expert,
             o3=fwd_down_output,
             clear_o1=clear_o1,
-        )
-        _log_stage_memory(
-            f"In forward, after down gemm, down_output shape: {o3.shape}, dtype: {o3.dtype}"
         )
         return o3
 
@@ -2075,7 +2048,6 @@ class ExpertsGroupGemmContiguousNode:
                 self.bf16_weight_grad(do1, None, expert_w1, self.dw_p2p_overlap)
             else:
                 self.bwd_gate_up_weight(do1, None, expert_w1, clear_input=True)
-            _log_stage_memory("In backward, after w1 grad")
             # 不调用 _record_stream，直接 None。
             # _record_stream 会触发 VMM 积极回收物理页，在 nparts loop 中
             # slice 被释放后原始 input_fp8 的物理页可能被提前回收，
@@ -2089,14 +2061,10 @@ class ExpertsGroupGemmContiguousNode:
                 self.bf16_weight_grad(out_grad, o2_s, expert_w2)
             else:
                 self.bwd_down_weight(out_grad, o2_s, expert_w2)
-            _log_stage_memory("In backward, after w2 grad")
 
             # dx
             dx = self.bwd_gate_up_input_fp8(do1, expert_w1, dx=out_grad)
 
-            _log_stage_memory(
-                f"In backward, after up_gate gemm bwd, d_up_gate_input shape: {dx.shape}, dtype:{dx.dtype}"
-            )
             # out-of-place 路径下 fused_swiglu_weighted_bwd 异步读 o1，但此时
             # 中间已经执行了 dw1、dw2 等多个 GEMM kernel（同一 stream 顺序入队），
             # 到达此处时 o1 的读取早已完成，del 安全。

--- a/src/paddlefleet/transformer/moe/fp8_utils.py
+++ b/src/paddlefleet/transformer/moe/fp8_utils.py
@@ -168,6 +168,18 @@ def _get_fp8_weight_and_scale(
     return fp8_weight, fp8_scale
 
 
+def _log_stage_memory(stage: str) -> None:
+    paddle.cuda.synchronize()
+    mib = 1024**2
+    print(
+        f"[stage-memory] {stage}: "
+        f"alloc_mib={paddle.cuda.memory_allocated() / mib:.2f}, "
+        f"reserved_mib={paddle.cuda.memory_reserved() / mib:.2f}, "
+        f"peak_alloc_mib={paddle.cuda.max_memory_allocated() / mib:.2f}, "
+        f"peak_reserved_mib={paddle.cuda.max_memory_reserved() / mib:.2f}"
+    )
+
+
 def fused_stack_quant_without_cache(
     expert_weight_list, transpose=False, use_ue8m0=False
 ):
@@ -960,6 +972,9 @@ class ExpertsGroupGemmContiguousNode:
         if clear_o1:
             o1._clear_to_zero_allocation()
         # fused_weighted_swiglu_act_quant 已消费完 o1 产出 o2_fp8，此时 o1 可以安全释放。
+        _log_stage_memory(
+            f"In forward, after swiglu, swiglu_output:{o2_fp8.shape}, dtype: {o2_fp8.dtype}"
+        )
         o3_shape = [o2_fp8.shape[0], w2_quant.shape[1]]
         if o3 is not None:
             assert o3.shape == o3_shape, f"{o3.shape} vs {o3_shape}"
@@ -1271,6 +1286,9 @@ class ExpertsGroupGemmContiguousNode:
                     do2_s,
                     m_indices=self.m_indices,
                 )
+        _log_stage_memory(
+            f"In backward, after down gemm bwd, d_swiglu_output shape:{do2_s.shape}, dtype:{do2_s.dtype}"
+        )
 
         with paddle.amp.auto_cast(False):
             if self.clamp_value is not None and self.clamp_value > 0:
@@ -1299,6 +1317,9 @@ class ExpertsGroupGemmContiguousNode:
                         o1, do2_s, unzipped_probs
                     )
                 )
+        _log_stage_memory(
+            f"In backward, after swiglu bwd, d_swiglu_input shape:{do1.shape}, dtype:{do1.dtype}"
+        )
 
         return do1, o2_s, probs_grad
 
@@ -1654,6 +1675,9 @@ class ExpertsGroupGemmContiguousNode:
         o1 = self.fwd_gate_up(
             hs_out, expert_w1, num_expert, tokens_per_expert, scale=scale
         )
+        _log_stage_memory(
+            f"In forward, after up-gate gemm, up_gate_output shape:{o1.shape}, dtype: {o1.dtype}"
+        )
         if not self.recompute_moe_gate_up:
             self.o1 = o1
             clear_o1 = False
@@ -1676,6 +1700,9 @@ class ExpertsGroupGemmContiguousNode:
             num_expert,
             o3=fwd_down_output,
             clear_o1=clear_o1,
+        )
+        _log_stage_memory(
+            f"In forward, after down gemm, down_output shape: {o3.shape}, dtype: {o3.dtype}"
         )
         return o3
 
@@ -2042,13 +2069,13 @@ class ExpertsGroupGemmContiguousNode:
         if used_inplace_swiglu:
             del o1
         self.o1 = None
-
         if a2a_async_fn is None:
             # dw1
             if self.use_bf16_gemm_weight_grad:
                 self.bf16_weight_grad(do1, None, expert_w1, self.dw_p2p_overlap)
             else:
                 self.bwd_gate_up_weight(do1, None, expert_w1, clear_input=True)
+            _log_stage_memory("In backward, after w1 grad")
             # 不调用 _record_stream，直接 None。
             # _record_stream 会触发 VMM 积极回收物理页，在 nparts loop 中
             # slice 被释放后原始 input_fp8 的物理页可能被提前回收，
@@ -2062,9 +2089,14 @@ class ExpertsGroupGemmContiguousNode:
                 self.bf16_weight_grad(out_grad, o2_s, expert_w2)
             else:
                 self.bwd_down_weight(out_grad, o2_s, expert_w2)
+            _log_stage_memory("In backward, after w2 grad")
 
             # dx
             dx = self.bwd_gate_up_input_fp8(do1, expert_w1, dx=out_grad)
+
+            _log_stage_memory(
+                f"In backward, after up_gate gemm bwd, d_up_gate_input shape: {dx.shape}, dtype:{dx.dtype}"
+            )
             # out-of-place 路径下 fused_swiglu_weighted_bwd 异步读 o1，但此时
             # 中间已经执行了 dw1、dw2 等多个 GEMM kernel（同一 stream 顺序入队），
             # 到达此处时 o1 的读取早已完成，del 安全。

--- a/src/paddlefleet/transformer/moe/fused_a2a.py
+++ b/src/paddlefleet/transformer/moe/fused_a2a.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
 import queue
 
 import paddle
@@ -67,6 +68,20 @@ _hybrid_ep_buffer = None
 HYBRIDEP_TOKEN_ALIGNMENT = 128
 
 
+def _supports_sonic_scale_word_packing(quantizer):
+    if quantizer is None:
+        return False
+    try:
+        return "pack_scale_words" in inspect.signature(quantizer).parameters
+    except (TypeError, ValueError):
+        return False
+
+
+_SONIC_PACK_SCALE_WORDS_AVAILABLE = _supports_sonic_scale_word_packing(
+    quantize_activation_blockscaled_fast
+)
+
+
 def barrier_ep(ep_group):
     """barrier_ep"""
     paddle.distributed.barrier(ep_group)
@@ -110,6 +125,90 @@ def _normalize_fp8_scale_for_deepep(
             f"expected [{num_tokens}, {num_scales}]"
         )
     return scale
+
+
+def _pack_sonic_fp8_scale_for_deepep(
+    x_fp8: paddle.Tensor, scale: paddle.Tensor
+):
+    """Expose four 1x32 E8M0 bytes as one DeepEP int32 scale word."""
+    num_tokens, hidden = x_fp8.shape
+    num_groups = (hidden + 31) // 32
+    if not scale.is_contiguous():
+        scale = scale.contiguous()
+    packed_groups = (num_groups + 3) // 4
+    if (
+        num_groups % 4 == 0
+        and scale.dtype == paddle.int32
+        and tuple(scale.shape) == (num_tokens, packed_groups)
+    ):
+        return scale
+    if tuple(scale.shape) != (num_tokens, num_groups):
+        raise RuntimeError(
+            "Invalid Sonic FP8 scale shape before DeepEP dispatch: "
+            f"scale={scale.shape}, x_fp8={x_fp8.shape}, "
+            f"expected [{num_tokens}, {num_groups}]"
+        )
+    if scale.dtype != paddle.uint8:
+        raise TypeError(
+            "Sonic FP8 scale carrier expects raw uint8 E8M0 bytes, "
+            f"got {scale.dtype}"
+        )
+    if num_groups % 4 != 0:
+        # DeepEP's tuple ABI requires a 32-bit scale type. Preserve the
+        # previous value-conversion fallback for non-aligned hidden sizes.
+        return scale.cast(paddle.int32)
+    return scale.view(paddle.int32)
+
+
+def _unpack_sonic_fp8_scale_from_deepep(
+    x_fp8: paddle.Tensor, scale: paddle.Tensor
+):
+    """Recover raw 1x32 E8M0 bytes from DeepEP's int32 carrier."""
+    num_tokens, hidden = x_fp8.shape
+    num_groups = (hidden + 31) // 32
+    if not scale.is_contiguous():
+        scale = scale.contiguous()
+    packed_groups = (num_groups + 3) // 4
+    if (
+        num_groups % 4 == 0
+        and scale.dtype == paddle.int32
+        and tuple(scale.shape) == (num_tokens, packed_groups)
+    ):
+        return scale.view(paddle.uint8)
+    if scale.dtype == paddle.int32 and tuple(scale.shape) == (
+        num_tokens,
+        num_groups,
+    ):
+        return scale.cast(paddle.uint8)
+    raise RuntimeError(
+        "Invalid packed Sonic FP8 scale received from DeepEP: "
+        f"scale={scale.shape}/{scale.dtype}, x_fp8={x_fp8.shape}"
+    )
+
+
+def _sonicmoe_quantize(x):
+    if _SONIC_PACK_SCALE_WORDS_AVAILABLE:
+        fp8, scale = quantize_activation_blockscaled_fast(
+            x,
+            pack_scale_words=(x.shape[1] % 128 == 0),
+        )
+        return fp8, _pack_sonic_fp8_scale_for_deepep(fp8, scale)
+    else:
+        return quantize_activation_blockscaled_fast(x, scale_dtype=paddle.int32)
+
+
+def _record_fp8_combine_grad(grad_x, combine_grad_handle):
+    if combine_grad_handle is None:
+        raise RuntimeError(
+            "For fp8_dispatch, combine_grad_handle must be provided in "
+            "combine backward."
+        )
+    grad_data, grad_scale = grad_x
+    if _SONIC_PACK_SCALE_WORDS_AVAILABLE:
+        grad_scale = _unpack_sonic_fp8_scale_from_deepep(grad_data, grad_scale)
+    combine_grad_handle["data"] = grad_data
+    combine_grad_handle["scale"] = grad_scale
+    return grad_data
 
 
 def configure_buffer(num_sms=None, dispatch_config=None, combine_config=None):
@@ -436,9 +535,7 @@ class DeepEPDispatch(PyLayer):
                 )
                 if not x.is_contiguous():
                     x = x.contiguous()
-                x_fp8, scale = quantize_activation_blockscaled_fast(
-                    x, scale_dtype=paddle.int32
-                )
+                x_fp8, scale = _sonicmoe_quantize(x)
             else:
                 x_fp8, scale = (
                     paddle.incubate.nn.functional.fp8_quant_blockwise(
@@ -534,9 +631,7 @@ class DeepEPCombine(PyLayer):
                 "Cannot find quantize_activation_blockscaled_fast, please update sonicmoe."
             )
             grad_output = grad_output.contiguous()
-            grad_for_comm = quantize_activation_blockscaled_fast(
-                grad_output, scale_dtype=paddle.int32
-            )
+            grad_for_comm = _sonicmoe_quantize(grad_output)
 
         grad_x = fused_combine_backward_func(
             grad_for_comm,
@@ -549,12 +644,7 @@ class DeepEPCombine(PyLayer):
         )
 
         if ctx.fp8_dispatch:
-            assert ctx.combine_grad_handle is not None, (
-                "For fp8_dispatch, combine_grad_handle must be provided in combine backward."
-            )
-            grad_x, grad_scale = grad_x
-            ctx.combine_grad_handle["data"] = grad_x
-            ctx.combine_grad_handle["scale"] = grad_scale
+            grad_x = _record_fp8_combine_grad(grad_x, ctx.combine_grad_handle)
 
         return grad_x
 
@@ -603,9 +693,7 @@ class DeepEPCombineAsync(PyLayer):
                 "Cannot find quantize_activation_blockscaled_fast, please update sonicmoe."
             )
             grad_output = grad_output.contiguous()
-            grad_for_comm = quantize_activation_blockscaled_fast(
-                grad_output, scale_dtype=paddle.int32
-            )
+            grad_for_comm = _sonicmoe_quantize(grad_output)
 
         grad_x = fused_combine_backward_func(
             grad_for_comm,
@@ -619,12 +707,7 @@ class DeepEPCombineAsync(PyLayer):
         wait_for_deepep(ctx.group.id)
 
         if ctx.fp8_dispatch:
-            assert ctx.combine_grad_handle is not None, (
-                "For fp8_dispatch, combine_grad_handle must be provided in combine backward."
-            )
-            grad_x, grad_scale = grad_x
-            ctx.combine_grad_handle["data"] = grad_x
-            ctx.combine_grad_handle["scale"] = grad_scale
+            grad_x = _record_fp8_combine_grad(grad_x, ctx.combine_grad_handle)
 
         return (grad_x,) + fn_args_grads  # noqa: RUF005
 
@@ -666,9 +749,7 @@ class DeepEPCombineAsyncFunctor(PyLayer):
                 "Cannot find quantize_activation_blockscaled_fast, please update sonicmoe."
             )
             grad_output = grad_output.contiguous()
-            grad_for_comm = quantize_activation_blockscaled_fast(
-                grad_output, scale_dtype=paddle.int32
-            )
+            grad_for_comm = _sonicmoe_quantize(grad_output)
 
         grad_x = fused_combine_backward_func(
             grad_for_comm,
@@ -682,12 +763,7 @@ class DeepEPCombineAsyncFunctor(PyLayer):
         wait_for_deepep(ctx.group.id)
 
         if ctx.fp8_dispatch:
-            assert ctx.combine_grad_handle is not None, (
-                "For fp8_dispatch, combine_grad_handle must be provided in combine backward."
-            )
-            grad_x, grad_scale = grad_x
-            ctx.combine_grad_handle["data"] = grad_x
-            ctx.combine_grad_handle["scale"] = grad_scale
+            grad_x = _record_fp8_combine_grad(grad_x, ctx.combine_grad_handle)
 
         return (grad_x,) + fn_args_grads  # noqa: RUF005
 

--- a/src/paddlefleet/transformer/moe/fusion_layer_utils.py
+++ b/src/paddlefleet/transformer/moe/fusion_layer_utils.py
@@ -37,7 +37,6 @@ from .vmm_utils import (
     tokens_zip_unique_add_with_subbatch,
 )
 
-_scatter_router_scores_i32 = None
 if paddlefleet_ops.is_sonic_moe_available():
     from paddlefleet_ops.sonicmoe.enums import ActivationType
     from paddlefleet_ops.sonicmoe.ernie_compat.deepep_metadata import (
@@ -68,7 +67,14 @@ if paddlefleet_ops.is_sonic_moe_available():
             _scatter_router_scores_i32,
         )
     except (ImportError, RuntimeError):
-        pass
+        _scatter_router_scores_i32 = None
+
+    try:
+        from paddlefleet_ops.sonicmoe.ernie_compat.deepep_metadata import (
+            deepep_topk_to_sonic_metadata_with_scales,
+        )
+    except (ImportError, RuntimeError):
+        deepep_topk_to_sonic_metadata_with_scales = None
 
 logger = logging.getLogger(__name__)
 
@@ -3414,7 +3420,11 @@ def run_sonic_moe(
         )
 
     fp8_scale_packed = None
-    if fp8 and fp8_scale is not None:
+    if (
+        fp8
+        and fp8_scale is not None
+        and deepep_topk_to_sonic_metadata_with_scales is not None
+    ):
         (
             expert_frequency_offset,
             x_gather_idx,
@@ -3511,7 +3521,7 @@ def run_sonic_moe(
             prequant_activation_payload=fp8_hidden_states,
             fp8_config=fp8_config,
         )
-        if release_fp8_weights:
+        if release_fp8_weights and not fp8_config.recompute_z:
             w1.fp8[0]._clear_to_zero_allocation()
             w1.fp8[1]._clear_to_zero_allocation()
 

--- a/src/paddlefleet/transformer/moe/fusion_layer_utils.py
+++ b/src/paddlefleet/transformer/moe/fusion_layer_utils.py
@@ -76,51 +76,24 @@ if paddlefleet_ops.is_sonic_moe_available():
     except (ImportError, RuntimeError):
         deepep_topk_to_sonic_metadata_with_scales = None
 
+    try:
+        from paddlefleet_ops.sonicmoe.functional import (
+            attach_preallocated_gated_outputs,
+        )
+    except ImportError:
+        attach_preallocated_gated_outputs = None
+
 logger = logging.getLogger(__name__)
 
 
-def _log_stage_memory(stage: str) -> None:
-    paddle.cuda.synchronize()
-    mib = 1024**2
-    print(
-        f"[stage-memory] {stage}: "
-        f"alloc_mib={paddle.cuda.memory_allocated() / mib:.2f}, "
-        f"reserved_mib={paddle.cuda.memory_reserved() / mib:.2f}, "
-        f"peak_alloc_mib={paddle.cuda.max_memory_allocated() / mib:.2f}, "
-        f"peak_reserved_mib={paddle.cuda.max_memory_reserved() / mib:.2f}"
-    )
-
-
-def _copy_sonic_fp8_weight_attrs(src, dst):
-    for attr_name in ("fp8", "transposed_fp8"):
-        attr = getattr(src, attr_name, None)
-        if attr is None:
-            raise RuntimeError(
-                f"Sonic FP8 forward requires weight.{attr_name} attribute; "
-                "call quant_weight() before FP8 forward."
-            )
-        setattr(dst, attr_name, attr)
-
-
-class _SonicFP8WeightCarrier(paddle.autograd.PyLayer):
-    @staticmethod
-    def forward(ctx, weight):
-        carrier = paddle.empty([1], dtype=weight.dtype).as_strided(
-            [weight.shape[1], weight.shape[2], weight.shape[0]], [0, 0, 0]
-        )
-        carrier.stop_gradient = weight.stop_gradient
-        _copy_sonic_fp8_weight_attrs(weight, carrier)
-        return carrier
-
-    @staticmethod
-    def backward(ctx, grad):
-        if grad is None:
-            return None
-        return grad.transpose([2, 0, 1])
-
-
-def _make_sonic_fp8_weight_carrier(weight):
-    return _SonicFP8WeightCarrier.apply(weight)
+def _resolve_sonic_config_bool(config, name):
+    if config is None:
+        return False
+    value = getattr(config, name, None)
+    if value is not None:
+        return bool(value)
+    resolver = getattr(config, f"resolve_{name}", None)
+    return bool(resolver()) if resolver is not None else False
 
 
 class _SonicRouterScoresFromMetadata(paddle.autograd.PyLayer):
@@ -2847,9 +2820,7 @@ class MlpNode:
             fill_output=fill_output,
             padding_alignment=self.moe_permute_padding_alignment,
         )
-        _log_stage_memory(
-            f"In forward, after local dispatch, unzipped_output shape:{unzipped_tokens.shape}, dtype: {unzipped_tokens.dtype}"
-        )
+
         fwd_path = "unknown"
         if (
             not self.moe_expert_fusion
@@ -2950,9 +2921,6 @@ class MlpNode:
                 num_experts=num_experts,
             )
 
-        _log_stage_memory(
-            f"In forward, after local combine, expert_out shape:{expert_out.shape}, dtype: {expert_out.dtype}"
-        )
         self.dispatched_probs = dispatched_probs
         expert_out.stop_gradient = False
 
@@ -3007,9 +2975,7 @@ class MlpNode:
             fill_output=fill_output,
             padding_alignment=self.moe_permute_padding_alignment,
         )
-        _log_stage_memory(
-            f"In backward, after local combine backward, unzipped_grad shape: {unzipped_grad.shape}, dtype: {unzipped_grad.dtype}"
-        )
+
         hidden_states_out_grad._record_stream()
         bwd_path = "unknown"
         if (
@@ -3108,9 +3074,7 @@ class MlpNode:
                     num_experts=len(self.tokens_per_expert),
                 )
             )
-            _log_stage_memory(
-                f"In backward, after local dispatch backward, hs_fp8_dispatched_grad shape: {hs_fp8_dispatched_grad.shape}, dtype: {hs_fp8_dispatched_grad.dtype}"
-            )
+
         self.reset_state()
 
         if self.moe_subbatch_diag:
@@ -3169,7 +3133,6 @@ class FusionMoePyLayer(paddle.autograd.PyLayer):
         Returns:
             tensor: 前向传播的结果张量。
         """
-        _log_stage_memory("MoE expert compute forward start")
         if activation_type is None:
             activation_type = getattr(custom_map, "_activation_type", "swiglu")
         ctx.node = MlpNode(
@@ -3216,7 +3179,6 @@ class FusionMoePyLayer(paddle.autograd.PyLayer):
             cached_tensors = ctx.node.cached_tensors()
             ctx.save_for_backward(cached_tensors)
             ctx.node.clear_cached_tensors()
-        _log_stage_memory("MoE expert compute forward end")
         return out
 
     @staticmethod
@@ -3232,7 +3194,6 @@ class FusionMoePyLayer(paddle.autograd.PyLayer):
                                             第三个为None，表示没有需要传递给更前向节点的梯度。
 
         """
-        _log_stage_memory("MoE expert compute backward start")
         (cached_tensors,) = ctx.saved_tensor()
         ctx.node.set_cached_tensors(cached_tensors)
 
@@ -3241,7 +3202,6 @@ class FusionMoePyLayer(paddle.autograd.PyLayer):
         hidden_states_grad, dispatched_probs_grad = ctx.node.backward(
             output_grad
         )
-        _log_stage_memory("MoE expert compute backward end")
         return hidden_states_grad, dispatched_probs_grad, None
 
 
@@ -3408,9 +3368,13 @@ def run_sonic_moe(
     fp8_config=None,
     release_fp8_weights=False,
 ):
-    _log_stage_memory("MoE expert compute forward start")
     T = hidden_states.shape[0]
     stream_id = paddle.device.current_stream()
+    topk_indices_i32 = (
+        topk_indices
+        if topk_indices.dtype == paddle.int32
+        else topk_indices.cast(paddle.int32)
+    )
 
     if tokens_per_expert is None:
         valid = topk_indices >= 0
@@ -3420,11 +3384,47 @@ def run_sonic_moe(
         )
 
     fp8_scale_packed = None
+    gated_outputs = ()
     if (
         fp8
         and fp8_scale is not None
         and deepep_topk_to_sonic_metadata_with_scales is not None
     ):
+        gated_n = int(w1.shape[1])
+        gated_z_quant = _resolve_sonic_config_bool(
+            fp8_config, "epilogue_quant"
+        ) and _resolve_sonic_config_bool(fp8_config, "save_z_fp8")
+        preallocate_gated_outputs = (
+            attach_preallocated_gated_outputs is not None
+            and hidden_states.dtype == paddle.float8_e4m3fn
+            and gated_n % 256 == 0
+            and _resolve_sonic_config_bool(fp8_config, "fused_gated")
+            and _resolve_sonic_config_bool(fp8_config, "fuse_y1_quant")
+        )
+        if preallocate_gated_outputs:
+            metadata_result = deepep_topk_to_sonic_metadata_with_scales(
+                topk_indices_i32,
+                topk_scores,
+                tokens_per_expert,
+                E,
+                fp8_scale,
+                int(hidden_states.shape[1]),
+                block=128,
+                gated_output_prototype=hidden_states,
+                gated_n=gated_n,
+                gated_preact_bf16=not gated_z_quant,
+                gated_allocate_z_scale=gated_z_quant,
+            )
+        else:
+            metadata_result = deepep_topk_to_sonic_metadata_with_scales(
+                topk_indices_i32,
+                topk_scores,
+                tokens_per_expert,
+                E,
+                fp8_scale,
+                int(hidden_states.shape[1]),
+                block=128,
+            )
         (
             expert_frequency_offset,
             x_gather_idx,
@@ -3437,15 +3437,8 @@ def run_sonic_moe(
             _N_recv,
             _score_src_idx,
             fp8_scale_packed,
-        ) = deepep_topk_to_sonic_metadata_with_scales(
-            topk_indices.cast(paddle.int32),
-            topk_scores,
-            tokens_per_expert,
-            E,
-            fp8_scale,
-            int(hidden_states.shape[1]),
-            block=128,
-        )
+        ) = metadata_result[:11]
+        gated_outputs = tuple(metadata_result[11:])
     else:
         (
             expert_frequency_offset,
@@ -3459,7 +3452,7 @@ def run_sonic_moe(
             _N_recv,
             _score_src_idx,
         ) = deepep_topk_to_sonic_metadata(
-            topk_indices.cast(paddle.int32),
+            topk_indices_i32,
             topk_scores,
             tokens_per_expert,
             E,
@@ -3470,7 +3463,27 @@ def run_sonic_moe(
     activation_type = ActivationType("swiglu")
 
     total_expert_freq = TK_padded
-    if _score_src_idx is not None and _scatter_router_scores_i32 is not None:
+    router_score_source = None
+    router_score_src_idx = None
+    router_scores_need_grad = (
+        hasattr(topk_scores, "stop_gradient") and not topk_scores.stop_gradient
+    )
+    if not router_scores_need_grad:
+        # Read stop_gradient before entering a PyLayer. Paddle detaches tensor
+        # inputs inside .apply(), so the original caller intent is unavailable
+        # to _DownProjection.forward. Metadata scores are forward-only here.
+        _router_scores.stop_gradient = True
+        scores_for_down = _router_scores
+    elif (
+        _score_src_idx is not None
+        and attach_preallocated_gated_outputs is not None
+    ):
+        # DownProjection already computes metadata-order ds. Attach the source
+        # edge there instead of scheduling a separate per-microbatch carrier.
+        scores_for_down = _router_scores
+        router_score_source = topk_scores
+        router_score_src_idx = _score_src_idx
+    elif _score_src_idx is not None and _scatter_router_scores_i32 is not None:
         scores_for_down = _SonicRouterScoresFromMetadata.apply(
             topk_scores, _router_scores, _score_src_idx
         )
@@ -3487,18 +3500,14 @@ def run_sonic_moe(
 
     fp8_hidden_states = None
     if fp8_scale is not None:
-        fp8_hidden_states = (
-            (hidden_states, fp8_scale, fp8_scale_packed)
-            if fp8_scale_packed is not None
-            else (hidden_states, fp8_scale)
-        )
-
-    # if fp8:
-    #     w1_sonic = _make_sonic_fp8_weight_carrier(w1)
-    #     w2_sonic = _make_sonic_fp8_weight_carrier(w2)
-    # else:
-    #     w1_sonic = w1.permute([1, 2, 0])
-    #     w2_sonic = w2.permute([1, 2, 0])
+        if fp8_scale_packed is not None:
+            if gated_outputs:
+                attach_preallocated_gated_outputs(
+                    fp8_scale_packed, gated_outputs
+                )
+            fp8_hidden_states = (hidden_states, fp8_scale, fp8_scale_packed)
+        else:
+            fp8_hidden_states = (hidden_states, fp8_scale)
 
     with enable_fp8(fp8):
         # _refresh_fp8_config()
@@ -3525,7 +3534,7 @@ def run_sonic_moe(
             w1.fp8[0]._clear_to_zero_allocation()
             w1.fp8[1]._clear_to_zero_allocation()
 
-        hidden_states = _DownProjection.apply(
+        down_args = (
             y1,
             z,
             w2,
@@ -3544,12 +3553,20 @@ def run_sonic_moe(
             activation_type,
             None,
             fp8_combine_grad_handle,
-            fp8_config=fp8_config,
         )
+        if router_score_source is not None:
+            hidden_states = _DownProjection.apply(
+                *down_args,
+                fp8_config,
+                router_score_source,
+                router_score_src_idx,
+            )
+        else:
+            hidden_states = _DownProjection.apply(
+                *down_args, fp8_config=fp8_config
+            )
         if release_fp8_weights:
             w2.fp8[0]._clear_to_zero_allocation()
             w2.fp8[1]._clear_to_zero_allocation()
-
-    _log_stage_memory("MoE expert compute forward end")
 
     return hidden_states

--- a/src/paddlefleet/transformer/moe/fusion_layer_utils.py
+++ b/src/paddlefleet/transformer/moe/fusion_layer_utils.py
@@ -73,6 +73,18 @@ if paddlefleet_ops.is_sonic_moe_available():
 logger = logging.getLogger(__name__)
 
 
+def _log_stage_memory(stage: str) -> None:
+    paddle.cuda.synchronize()
+    mib = 1024**2
+    print(
+        f"[stage-memory] {stage}: "
+        f"alloc_mib={paddle.cuda.memory_allocated() / mib:.2f}, "
+        f"reserved_mib={paddle.cuda.memory_reserved() / mib:.2f}, "
+        f"peak_alloc_mib={paddle.cuda.max_memory_allocated() / mib:.2f}, "
+        f"peak_reserved_mib={paddle.cuda.max_memory_reserved() / mib:.2f}"
+    )
+
+
 def _copy_sonic_fp8_weight_attrs(src, dst):
     for attr_name in ("fp8", "transposed_fp8"):
         attr = getattr(src, attr_name, None)
@@ -2829,6 +2841,9 @@ class MlpNode:
             fill_output=fill_output,
             padding_alignment=self.moe_permute_padding_alignment,
         )
+        _log_stage_memory(
+            f"In forward, after local dispatch, unzipped_output shape:{unzipped_tokens.shape}, dtype: {unzipped_tokens.dtype}"
+        )
         fwd_path = "unknown"
         if (
             not self.moe_expert_fusion
@@ -2929,6 +2944,9 @@ class MlpNode:
                 num_experts=num_experts,
             )
 
+        _log_stage_memory(
+            f"In forward, after local combine, expert_out shape:{expert_out.shape}, dtype: {expert_out.dtype}"
+        )
         self.dispatched_probs = dispatched_probs
         expert_out.stop_gradient = False
 
@@ -2982,6 +3000,9 @@ class MlpNode:
             tokens_per_expert=self.tokens_per_expert,
             fill_output=fill_output,
             padding_alignment=self.moe_permute_padding_alignment,
+        )
+        _log_stage_memory(
+            f"In backward, after local combine backward, unzipped_grad shape: {unzipped_grad.shape}, dtype: {unzipped_grad.dtype}"
         )
         hidden_states_out_grad._record_stream()
         bwd_path = "unknown"
@@ -3081,6 +3102,9 @@ class MlpNode:
                     num_experts=len(self.tokens_per_expert),
                 )
             )
+            _log_stage_memory(
+                f"In backward, after local dispatch backward, hs_fp8_dispatched_grad shape: {hs_fp8_dispatched_grad.shape}, dtype: {hs_fp8_dispatched_grad.dtype}"
+            )
         self.reset_state()
 
         if self.moe_subbatch_diag:
@@ -3139,6 +3163,7 @@ class FusionMoePyLayer(paddle.autograd.PyLayer):
         Returns:
             tensor: 前向传播的结果张量。
         """
+        _log_stage_memory("MoE expert compute forward start")
         if activation_type is None:
             activation_type = getattr(custom_map, "_activation_type", "swiglu")
         ctx.node = MlpNode(
@@ -3185,6 +3210,7 @@ class FusionMoePyLayer(paddle.autograd.PyLayer):
             cached_tensors = ctx.node.cached_tensors()
             ctx.save_for_backward(cached_tensors)
             ctx.node.clear_cached_tensors()
+        _log_stage_memory("MoE expert compute forward end")
         return out
 
     @staticmethod
@@ -3200,6 +3226,7 @@ class FusionMoePyLayer(paddle.autograd.PyLayer):
                                             第三个为None，表示没有需要传递给更前向节点的梯度。
 
         """
+        _log_stage_memory("MoE expert compute backward start")
         (cached_tensors,) = ctx.saved_tensor()
         ctx.node.set_cached_tensors(cached_tensors)
 
@@ -3208,6 +3235,7 @@ class FusionMoePyLayer(paddle.autograd.PyLayer):
         hidden_states_grad, dispatched_probs_grad = ctx.node.backward(
             output_grad
         )
+        _log_stage_memory("MoE expert compute backward end")
         return hidden_states_grad, dispatched_probs_grad, None
 
 
@@ -3372,7 +3400,9 @@ def run_sonic_moe(
     fp8_scale=None,
     fp8_combine_grad_handle=None,
     fp8_config=None,
+    release_fp8_weights=False,
 ):
+    _log_stage_memory("MoE expert compute forward start")
     T = hidden_states.shape[0]
     stream_id = paddle.device.current_stream()
 
@@ -3481,6 +3511,10 @@ def run_sonic_moe(
             prequant_activation_payload=fp8_hidden_states,
             fp8_config=fp8_config,
         )
+        if release_fp8_weights:
+            w1.fp8[0]._clear_to_zero_allocation()
+            w1.fp8[1]._clear_to_zero_allocation()
+
         hidden_states = _DownProjection.apply(
             y1,
             z,
@@ -3502,5 +3536,10 @@ def run_sonic_moe(
             fp8_combine_grad_handle,
             fp8_config=fp8_config,
         )
+        if release_fp8_weights:
+            w2.fp8[0]._clear_to_zero_allocation()
+            w2.fp8[1]._clear_to_zero_allocation()
+
+    _log_stage_memory("MoE expert compute forward end")
 
     return hidden_states

--- a/src/paddlefleet/transformer/moe/moe_expert.py
+++ b/src/paddlefleet/transformer/moe/moe_expert.py
@@ -17,9 +17,9 @@ import os
 from contextlib import nullcontext
 from copy import deepcopy
 
-import numpy as np
 import paddle
 import paddle.nn.functional as F
+import paddlefleet_ops
 from paddle.distributed.flex_checkpoint.dcp.sharded_weight import (
     build_sharded_state_dict,
     shard_weight,
@@ -35,7 +35,14 @@ from paddlefleet.transformer.layer import FleetLayer
 from paddlefleet.transformer.mlp import MLP, MLPSublayersSpec
 from paddlefleet.transformer.transformer_config import TransformerConfig
 
-from .fusion_layer_utils import run_sonic_moe
+if paddlefleet_ops.is_sonic_moe_available():
+    try:
+        from paddlefleet_ops.sonicmoe import run_sonic_moe
+    except ModuleNotFoundError as exc:
+        if exc.name != "paddlefleet_ops.sonicmoe.interface":
+            raise
+        from .fusion_layer_utils import run_sonic_moe
+
 from .moe_utils import (
     k_grouped_bf16_gemm_tn_contiguous_aligned,
 )
@@ -558,6 +565,7 @@ class SonicMoEExpert(GroupedMLPExpert):
         self.sonic_moe_config.fp8_wgrad = self.config.fp8_wgrad
         self.sonic_moe_config.fuse_y1_quant = True
         self.sonic_moe_config.fuse_y1_bf16_trunc = True
+        self.sonic_moe_config.recompute_z = False
 
         # Micro batch tracking for fp8 weight memory optimization.
         # _num_micro_batches: total forward passes per step for this layer.
@@ -591,6 +599,17 @@ class SonicMoEExpert(GroupedMLPExpert):
     def _is_last_micro_batch(self):
         return self._forward_counter >= self._num_micro_batches - 1
 
+    def _release_fp8_weight_after_fwd(self, recompute_moe_gate_up):
+        release_fp8_weight_after_fwd = (
+            self._is_last_micro_batch
+            and not g_shard_bypass_dygraph_optimizer
+            and not recompute_moe_gate_up
+            and self.config.recompute_granularity != "full"
+            and hasattr(self.weight1, "fp8")
+            and hasattr(self.weight2, "fp8")
+        )
+        return release_fp8_weight_after_fwd
+
     def _release_fp8_weights(self):
         """Release fp8 weight (non-transposed) to save memory.
 
@@ -598,9 +617,6 @@ class SonicMoEExpert(GroupedMLPExpert):
         """
         _log_stage_memory("before release fp8")
         for weight in (self.weight1, self.weight2):
-            print(
-                f"===== releasing weight shape:{weight.shape}, dtype:{weight.dtype}, mem:{np.prod(weight.shape) / 1024 / 1024} MB"
-            )
             if hasattr(weight, "fp8") and weight.fp8 is not None:
                 weight.fp8 = None
         _log_stage_memory("after release fp8")
@@ -703,17 +719,16 @@ class SonicMoEExpert(GroupedMLPExpert):
         use_fp8=False,
         tokens_per_expert=None,
         fp8_scale=None,
+        recompute_moe_gate_up=False,
         fp8_combine_grad_handle=None,
     ):
         self.convert_weights_to_sonic_layout()
         if self.sonic_moe_config.enabled is True and self.need_quant_weight():
             self.quant_weight()
 
-        release_fp8_weight_after_fwd = (
-            self._is_last_micro_batch and not g_shard_bypass_dygraph_optimizer
-        )
-        print(
-            f"==== forward_counter: {self._forward_counter}, num_micro_batches: {self._num_micro_batches}, release_fp8_weight_after_fwd: {release_fp8_weight_after_fwd} ===="
+        self.sonic_moe_config.recompute_z = recompute_moe_gate_up
+        release_fp8_weight_after_fwd = self._release_fp8_weight_after_fwd(
+            recompute_moe_gate_up
         )
         hidden_states = run_sonic_moe(
             hidden_states,

--- a/src/paddlefleet/transformer/moe/moe_expert.py
+++ b/src/paddlefleet/transformer/moe/moe_expert.py
@@ -607,7 +607,8 @@ class SonicMoEExpert(GroupedMLPExpert):
 
     def _release_fp8_weight_after_fwd(self, recompute_moe_gate_up):
         release_fp8_weight_after_fwd = (
-            self._is_last_micro_batch
+            self.config.sonicmoe_quant_format == "1x32"
+            and self._is_last_micro_batch
             and not g_shard_bypass_dygraph_optimizer
             and not recompute_moe_gate_up
             and self.config.recompute_granularity != "full"

--- a/src/paddlefleet/transformer/moe/moe_expert.py
+++ b/src/paddlefleet/transformer/moe/moe_expert.py
@@ -38,9 +38,7 @@ from paddlefleet.transformer.transformer_config import TransformerConfig
 if paddlefleet_ops.is_sonic_moe_available():
     try:
         from paddlefleet_ops.sonicmoe import run_sonic_moe
-    except ModuleNotFoundError as exc:
-        if exc.name != "paddlefleet_ops.sonicmoe.interface":
-            raise
+    except ImportError:
         from .fusion_layer_utils import run_sonic_moe
 
 from .moe_utils import (

--- a/src/paddlefleet/transformer/moe/moe_expert.py
+++ b/src/paddlefleet/transformer/moe/moe_expert.py
@@ -13,9 +13,11 @@
 # limitations under the License.
 
 
+import os
 from contextlib import nullcontext
 from copy import deepcopy
 
+import numpy as np
 import paddle
 import paddle.nn.functional as F
 from paddle.distributed.flex_checkpoint.dcp.sharded_weight import (
@@ -59,6 +61,10 @@ except (ImportError, RuntimeError):
     fused_grouped_w1_to_sonic = None
     fused_sonic_w1_to_grouped = None
     fused_transpose_w2_layout = None
+
+g_shard_bypass_dygraph_optimizer = int(
+    os.environ.get("FLAGS_shard_bypass_dygraph_optimizer", 0)
+)
 
 
 class BMMFunction(paddle.autograd.PyLayer):
@@ -462,6 +468,18 @@ class GroupedMLPExpert(FleetLayer):
         return sharded_dict
 
 
+def _log_stage_memory(stage: str) -> None:
+    paddle.cuda.synchronize()
+    mib = 1024**2
+    print(
+        f"[stage-memory] {stage}: "
+        f"alloc_mib={paddle.cuda.memory_allocated() / mib:.2f}, "
+        f"reserved_mib={paddle.cuda.memory_reserved() / mib:.2f}, "
+        f"peak_alloc_mib={paddle.cuda.max_memory_allocated() / mib:.2f}, "
+        f"peak_reserved_mib={paddle.cuda.max_memory_reserved() / mib:.2f}"
+    )
+
+
 class SonicMoEExpert(GroupedMLPExpert):
     _GROUPED_LAYOUT = "grouped"
     _SONIC_LAYOUT = "sonic"
@@ -541,6 +559,52 @@ class SonicMoEExpert(GroupedMLPExpert):
         self.sonic_moe_config.fuse_y1_quant = True
         self.sonic_moe_config.fuse_y1_bf16_trunc = True
 
+        # Micro batch tracking for fp8 weight memory optimization.
+        # _num_micro_batches: total forward passes per step for this layer.
+        # _forward_counter: auto-increments in forward(); reset in quant_weight().
+        self._forward_counter = 0
+        self._num_micro_batches = 1
+
+    def set_num_micro_batches(self, num_micro_batches):
+        """Set total number of forward passes (micro batches) per training step.
+
+        This should be called once (e.g. in a callback's on_step_begin) to
+        inform the layer how many forward passes will occur before the next
+        quant_weight(). On the last forward pass, fp8 weights are released to
+        save memory, keeping only transposed_fp8 for backward.
+
+        For pipeline parallel with VPP, num_micro_batches = accumulate_steps.
+        Each virtual chunk shares the same SonicMoEExpert instance, so the
+        layer sees accumulate_steps forward calls per step.
+        """
+        self._num_micro_batches = num_micro_batches
+
+    def set_micro_batch_info(self, micro_batch_id, num_micro_batches):
+        """Legacy API: set current micro batch id and total number.
+
+        Prefer set_num_micro_batches() which works with auto-incrementing counter.
+        """
+        self._forward_counter = micro_batch_id
+        self._num_micro_batches = num_micro_batches
+
+    @property
+    def _is_last_micro_batch(self):
+        return self._forward_counter >= self._num_micro_batches - 1
+
+    def _release_fp8_weights(self):
+        """Release fp8 weight (non-transposed) to save memory.
+
+        Only transposed_fp8 is needed for backward (activation gradient GEMM).
+        """
+        _log_stage_memory("before release fp8")
+        for weight in (self.weight1, self.weight2):
+            print(
+                f"===== releasing weight shape:{weight.shape}, dtype:{weight.dtype}, mem:{np.prod(weight.shape) / 1024 / 1024} MB"
+            )
+            if hasattr(weight, "fp8") and weight.fp8 is not None:
+                weight.fp8 = None
+        _log_stage_memory("after release fp8")
+
     def _convert_grad_layout(self, param, converter, convert_main_grad=True):
         main_grad = getattr(param, "main_grad", None)
         if convert_main_grad and main_grad is not None:
@@ -599,6 +663,7 @@ class SonicMoEExpert(GroupedMLPExpert):
     @paddle.no_grad()
     def quant_weight(self):
         self.convert_weights_to_sonic_layout()
+        self.clear_fp8_weights()
 
         payload = quantize_native_fp8_weights(
             self.weight1,
@@ -613,6 +678,8 @@ class SonicMoEExpert(GroupedMLPExpert):
         self.weight1.transposed_fp8 = (w1t_fp8, w1t_scale)
         self.weight2.fp8 = (w2_fp8, w2_scale)
         self.weight2.transposed_fp8 = (w2t_fp8, w2t_scale)
+        # Reset forward counter for the new step.
+        self._forward_counter = 0
 
     def clear_fp8_weights(self):
         clear_all_fp8_weight_caches()
@@ -641,6 +708,13 @@ class SonicMoEExpert(GroupedMLPExpert):
         self.convert_weights_to_sonic_layout()
         if self.sonic_moe_config.enabled is True and self.need_quant_weight():
             self.quant_weight()
+
+        release_fp8_weight_after_fwd = (
+            self._is_last_micro_batch and not g_shard_bypass_dygraph_optimizer
+        )
+        print(
+            f"==== forward_counter: {self._forward_counter}, num_micro_batches: {self._num_micro_batches}, release_fp8_weight_after_fwd: {release_fp8_weight_after_fwd} ===="
+        )
         hidden_states = run_sonic_moe(
             hidden_states,
             topk_indices,
@@ -654,7 +728,13 @@ class SonicMoEExpert(GroupedMLPExpert):
             fp8_scale=fp8_scale,
             fp8_combine_grad_handle=fp8_combine_grad_handle,
             fp8_config=self.sonic_moe_config,
+            release_fp8_weights=release_fp8_weight_after_fwd,
         )
+        # Release fp8 weights on last micro batch to save memory.
+        # Only transposed_fp8 is kept for backward computation.
+        if release_fp8_weight_after_fwd:
+            self._release_fp8_weights()
+        self._forward_counter += 1
         return hidden_states
 
     def sharded_state_dict(

--- a/src/paddlefleet/transformer/moe/moe_expert.py
+++ b/src/paddlefleet/transformer/moe/moe_expert.py
@@ -560,18 +560,26 @@ class SonicMoEExpert(GroupedMLPExpert):
         self.hidden_size = self.config.hidden_size
         self.K = topk
         self._weights_layout = self._GROUPED_LAYOUT
+
         self.sonic_moe_config = _refresh_fp8_config()
         self.sonic_moe_config.enabled = self.config.fp8 is not None
         self.sonic_moe_config.fp8_wgrad = self.config.fp8_wgrad
         self.sonic_moe_config.fuse_y1_quant = True
         self.sonic_moe_config.fuse_y1_bf16_trunc = True
         self.sonic_moe_config.recompute_z = False
+        self.sonic_moe_config.save_z_fp8 = (
+            self.config.sonicmoe_save_upgate_out_in_fp8
+        )
+        clamp_value = self.config.activation_func_clamp_value
+        self.sonic_moe_config.swiglu_clamp_value = (
+            0.0 if clamp_value is None else float(clamp_value)
+        )
 
         # Micro batch tracking for fp8 weight memory optimization.
         # _num_micro_batches: total forward passes per step for this layer.
         # _forward_counter: auto-increments in forward(); reset in quant_weight().
         self._forward_counter = 0
-        self._num_micro_batches = 1
+        self._num_micro_batches = 9999
 
     def set_num_micro_batches(self, num_micro_batches):
         """Set total number of forward passes (micro batches) per training step.
@@ -615,11 +623,9 @@ class SonicMoEExpert(GroupedMLPExpert):
 
         Only transposed_fp8 is needed for backward (activation gradient GEMM).
         """
-        _log_stage_memory("before release fp8")
         for weight in (self.weight1, self.weight2):
             if hasattr(weight, "fp8") and weight.fp8 is not None:
                 weight.fp8 = None
-        _log_stage_memory("after release fp8")
 
     def _convert_grad_layout(self, param, converter, convert_main_grad=True):
         main_grad = getattr(param, "main_grad", None)
@@ -681,15 +687,27 @@ class SonicMoEExpert(GroupedMLPExpert):
         self.convert_weights_to_sonic_layout()
         self.clear_fp8_weights()
 
+        iso32 = self.config.sonicmoe_quant_format == "32x32"
+        assert self.config.sonicmoe_quant_format in ["32x32", "1x32"], (
+            f"sonic_moe_quant_format {self.config.sonicmoe_quant_format} is not supported."
+        )
         payload = quantize_native_fp8_weights(
             self.weight1,
             self.weight2,
+            iso32=iso32,
         )
-        assert payload["format"] == "1x32", (
-            f"quant strategy {payload.get('format')} is not supported."
+        quant_format = payload["format"]
+        assert quant_format in ("1x32", "iso32"), (
+            f"quant strategy {quant_format} is not supported."
         )
-        w1_fp8, w1_scale, w1t_fp8, w1t_scale = payload["w1"]
-        w2_fp8, w2_scale, w2t_fp8, w2t_scale = payload["w2"]
+        if quant_format == "iso32":
+            w1_fp8, w1_scale, w1t_scale = payload["w1"]
+            w2_fp8, w2_scale, w2t_scale = payload["w2"]
+            w1t_fp8 = w1_fp8.transpose([0, 2, 1])
+            w2t_fp8 = w2_fp8.transpose([0, 2, 1])
+        else:
+            w1_fp8, w1_scale, w1t_fp8, w1t_scale = payload["w1"]
+            w2_fp8, w2_scale, w2t_fp8, w2t_scale = payload["w2"]
         self.weight1.fp8 = (w1_fp8, w1_scale)
         self.weight1.transposed_fp8 = (w1t_fp8, w1t_scale)
         self.weight2.fp8 = (w2_fp8, w2_scale)

--- a/src/paddlefleet/transformer/moe/moe_expert.py
+++ b/src/paddlefleet/transformer/moe/moe_expert.py
@@ -638,6 +638,18 @@ class SonicMoEExpert(GroupedMLPExpert):
     def _convert_layout(
         self, target_layout, weight1_converter, weight2_converter
     ):
+        # Shared MTP layers can have separate expert instances over the same
+        # parameters, so the instance-local layout flag may be stale. Infer the
+        # layout from the paired weight dimensions instead of the local config.
+        # In SONIC_LAYOUT: w1 [E, 2I, H], w2 [E, H, I]
+        # In GROUPED_LAYOUT: w1 [E, H, 2I], w2 [E, I, H]
+        w1_shape = self.weight1.shape
+        w2_shape = self.weight2.shape
+        if w1_shape[1] == 2 * w2_shape[2] and w1_shape[2] == w2_shape[1]:
+            self._weights_layout = self._SONIC_LAYOUT
+        elif w1_shape[1] == w2_shape[2] and w1_shape[2] == 2 * w2_shape[1]:
+            self._weights_layout = self._GROUPED_LAYOUT
+
         if self._weights_layout == target_layout:
             return
         with paddle.no_grad():

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -959,6 +959,7 @@ class MoELayer(nn.Layer):
                     use_fp8,
                     tokens_per_expert=tokens_per_expert,
                     fp8_scale=fp8_scale,
+                    recompute_moe_gate_up=self.recompute_moe_gate_up,
                     fp8_combine_grad_handle=fp8_combine_grad_handle,
                 )
             else:
@@ -1437,6 +1438,7 @@ class MoELayer(nn.Layer):
                 topk_indices,
                 topk_weights,
                 use_fp8,
+                recompute_moe_gate_up=self.recompute_moe_gate_up,
             )
             return final_hidden_states.cast(hidden_states.dtype)
         else:

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -1595,8 +1595,11 @@ class MoELayer(nn.Layer):
                     delattr(weight_obj, attr)
 
         if hasattr(self, "grouped_gemm_experts"):
-            _clear_attrs(self.grouped_gemm_experts.weight1)
-            _clear_attrs(self.grouped_gemm_experts.weight2)
+            if isinstance(self.grouped_gemm_experts, SonicMoEExpert):
+                self.grouped_gemm_experts.clear_fp8_weights()
+            else:
+                _clear_attrs(self.grouped_gemm_experts.weight1)
+                _clear_attrs(self.grouped_gemm_experts.weight2)
         else:
             for expert in self.experts:
                 if expert is not None:

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -750,8 +750,17 @@ class TransformerConfig(ModelParallelConfig):
     """When set to True, clone the output of scatter_to_sequence_parallel_region in embedding layer
     to facilitate garbage collection of input."""
 
+    ####################
+    # SonicMoE
+    ####################``
     using_sonic_moe: bool = False
     """When using_sonic_moe is enabled, the computation part of the moelayer will use the implementation provided by SonicMoE."""
+
+    sonicmoe_quant_format: str = "32x32"
+    """Quantization format used in SonicMoE for quantizing weights, options are 32x32 and 1x32."""
+
+    sonicmoe_save_upgate_out_in_fp8: bool = False
+    """Save the up-gate output in FP8 or BF16, if True, save in FP8."""
 
     ####################
     # MLA

--- a/tests/multi_card_tests/moe/test_sonic_moe_ep.py
+++ b/tests/multi_card_tests/moe/test_sonic_moe_ep.py
@@ -252,8 +252,9 @@ class TestSonicMoEExpertParallelPrecision(unittest.TestCase):
         fp8_wgrad=True,
         expert_model_parallel_size=4,
         pg_collection=None,
+        config=None,
     ):
-        transformer_config = self._build_transformer_config(
+        transformer_config = config or self._build_transformer_config(
             using_sonic_moe=using_sonic_moe,
             fp8=fp8,
             moe_deep_gemm=moe_deep_gemm,
@@ -655,10 +656,58 @@ class TestSonicMoEExpertParallelPrecision(unittest.TestCase):
             title="Sonic-MoE FP8 vs BF16 accumulated grad",
         )
 
+    def run_test_z_bf16_recompute_z(self):
+        paddle.seed(self.seed)
+        model_parallel_cuda_manual_seed(self.seed)
+        sonic_fp8 = self._build_moe_layer(using_sonic_moe=True, fp8="e4m3")
+
+        recompute_config = self._build_transformer_config(
+            using_sonic_moe=True, fp8="e4m3"
+        )
+        recompute_config.recompute_granularity = "selective"
+        recompute_config.recompute_modules = ["moe_gate_up"]
+
+        paddle.seed(self.seed)
+        model_parallel_cuda_manual_seed(self.seed)
+        sonic_fp8_recompute_z = self._build_moe_layer(
+            using_sonic_moe=True,
+            fp8="e4m3",
+            config=recompute_config,
+        )
+        self.assertFalse(sonic_fp8.recompute_moe_gate_up)
+        self.assertTrue(sonic_fp8_recompute_z.recompute_moe_gate_up)
+
+        input_data_list = [
+            paddle.randn([2, 64, self.hidden_size], dtype=paddle.bfloat16)
+        ]
+        output, grads = self._run_accumulated_forward_backward(
+            sonic_fp8, input_data_list
+        )
+        output_recompute, grads_recompute = (
+            self._run_accumulated_forward_backward(
+                sonic_fp8_recompute_z, input_data_list
+            )
+        )
+        clear_all_fp8_weight_caches()
+
+        self._assert_tensor_diff_less(
+            output,
+            output_recompute,
+            tol=1e-2,
+            title="Sonic-MoE FP8 recompute_z output",
+        )
+        self._assert_grad_diff_less(
+            grads,
+            grads_recompute,
+            tol=1e-2,
+            title="Sonic-MoE FP8 recompute_z accumulated grad",
+        )
+
     def test_sonic_moe_all(self):
         self.run_test_sonic_moe_ep_grad_accumulation()
         self.run_test_ep_precision()
         self.run_test_bf16_wgrad()
+        self.run_test_z_bf16_recompute_z()
 
 
 if __name__ == "__main__":

--- a/tests/single_card_tests/model/test_gpt_model_sonic_moe.py
+++ b/tests/single_card_tests/model/test_gpt_model_sonic_moe.py
@@ -158,22 +158,27 @@ class TestSonicMoELayerPrecision(unittest.TestCase):
         return TransformerConfig(**kwargs)
 
     def _build_moe_layer(
-        self, using_sonic_moe=False, fp8=None, moe_deep_gemm=None
+        self,
+        using_sonic_moe=False,
+        fp8=None,
+        moe_deep_gemm=None,
+        config=None,
     ):
         paddle.seed(self.seed)
         model_parallel_cuda_manual_seed(self.seed)
-        transformer_config = self._build_transformer_config(
-            using_sonic_moe=using_sonic_moe,
-            fp8=fp8,
-            moe_deep_gemm=moe_deep_gemm,
-        )
+        if config is None:
+            config = self._build_transformer_config(
+                using_sonic_moe=using_sonic_moe,
+                fp8=fp8,
+                moe_deep_gemm=moe_deep_gemm,
+            )
         transformer_layer_spec = get_gpt_layer_local_spec(
-            transformer_config,
+            config,
             num_experts=self.n_routed_experts,
         )
 
         moe_layer = MoELayer(
-            transformer_config,
+            config,
             transformer_layer_spec.sublayers_spec.mlp.extra_kwargs["sublayers"],
             self.pg_collection,
         )
@@ -385,13 +390,18 @@ class TestSonicMoELayerPrecision(unittest.TestCase):
 
     def run_test_z_bf16_recompute_z(self):
         sonic_fp8 = self._build_moe_layer(using_sonic_moe=True, fp8="e4m3")
-        sonic_fp8_recompute_z = self._build_moe_layer(
+
+        recompute_config = self._build_transformer_config(
             using_sonic_moe=True, fp8="e4m3"
         )
-
-        sonic_fp8.grouped_gemm_experts.sonic_moe_config.save_z_fp8 = False
-        sonic_fp8_recompute_z.grouped_gemm_experts.sonic_moe_config.save_z_fp8 = False
-        sonic_fp8_recompute_z.grouped_gemm_experts.sonic_moe_config.recompute_z = True
+        recompute_config.recompute_granularity = "selective"
+        recompute_config.recompute_modules = ["moe_gate_up"]
+        sonic_fp8_recompute_z = self._build_moe_layer(
+            using_sonic_moe=True, fp8="e4m3", config=recompute_config
+        )
+        # sonic_fp8.grouped_gemm_experts.sonic_moe_config.save_z_fp8 = False
+        # sonic_fp8_recompute_z.grouped_gemm_experts.sonic_moe_config.save_z_fp8 = False
+        # sonic_fp8_recompute_z.grouped_gemm_experts.sonic_moe_config.recompute_z = True
         # sonic_fp8.grouped_gemm_experts.sonic_moe_config.enabled = True
         input_data_list = []
         for step_idx in range(self.acc_steps):

--- a/tests/single_card_tests/model/test_gpt_model_sonic_moe.py
+++ b/tests/single_card_tests/model/test_gpt_model_sonic_moe.py
@@ -120,6 +120,17 @@ class TestSonicMoELayerPrecision(unittest.TestCase):
         self.n_routed_experts = 8
         self.acc_steps = 1
 
+    def test_sonic_moe_import(self):
+        from paddlefleet_ops import sonicmoe
+
+        from paddlefleet.transformer.moe import fusion_layer_utils, moe_expert
+
+        expected_run_sonic_moe = getattr(
+            sonicmoe, "run_sonic_moe", fusion_layer_utils.run_sonic_moe
+        )
+        self.assertIs(moe_expert.run_sonic_moe, expected_run_sonic_moe)
+        self.assertTrue(hasattr(moe_expert, "SonicMoEExpert"))
+
     @staticmethod
     def _small_init_method(tensor):
         """Small uniform init for precision tests (matches pre-update behavior)."""

--- a/tests/single_card_tests/transformer/test_clear_fp8_quant_weight.py
+++ b/tests/single_card_tests/transformer/test_clear_fp8_quant_weight.py
@@ -24,6 +24,9 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+from paddlefleet.transformer.moe.moe_expert import SonicMoEExpert
+from paddlefleet.transformer.moe.moe_layer import MoELayer
+
 
 class TestMoELayerClearFp8QuantWeight(unittest.TestCase):
     """Test MoELayer.clear_fp8_quant_weight logic."""
@@ -100,6 +103,34 @@ class TestMoELayerClearFp8QuantWeight(unittest.TestCase):
             self.assertFalse(
                 hasattr(weight2, attr), f"weight2.{attr} not cleared"
             )
+
+    def test_sonic_expert_path_clears_fp8_weight_caches(self):
+        """SonicMoEExpert cleanup must clear both FP8 weight cache layouts."""
+        moe = SimpleNamespace(moe_use_fusion_node=True, fp8=True)
+        sonic_experts = object.__new__(SonicMoEExpert)
+        sonic_experts.weight1 = SimpleNamespace(
+            fp8=("w1", "s1"), transposed_fp8=("wt1", "st1")
+        )
+        sonic_experts.weight2 = SimpleNamespace(
+            fp8=("w2", "s2"), transposed_fp8=("wt2", "st2")
+        )
+        sonic_experts.clear_fp8_weights = MagicMock(
+            side_effect=lambda: (
+                setattr(sonic_experts.weight1, "fp8", None),
+                setattr(sonic_experts.weight1, "transposed_fp8", None),
+                setattr(sonic_experts.weight2, "fp8", None),
+                setattr(sonic_experts.weight2, "transposed_fp8", None),
+            )
+        )
+        moe.grouped_gemm_experts = sonic_experts
+
+        MoELayer.clear_fp8_quant_weight(moe)
+
+        sonic_experts.clear_fp8_weights.assert_called_once_with()
+        self.assertIsNone(sonic_experts.weight1.fp8)
+        self.assertIsNone(sonic_experts.weight1.transposed_fp8)
+        self.assertIsNone(sonic_experts.weight2.fp8)
+        self.assertIsNone(sonic_experts.weight2.transposed_fp8)
 
     def test_experts_fallback_path_clears_attrs(self):
         """When no grouped_gemm_experts, clear per-expert weight attrs."""


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->
1. When using 1x32 quant strategy for weight, reduce memory footprint in SonicMoE by releasing fp8 weight after forward.
2. Adapt 32x32 weight quant strategy.
3. Use TransformerConfig to set SonicMoE `recompute_z`, `save_z_fp8`, `weight quant format`.''
4. Adapt new performance optimization in sonicmoe.


### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否
