### PR TITLE
[EP] Fix HybridEP BF16 DeepGEMM token alignment

### DIFF
--- a/src/paddlefleet/transformer/moe/fused_a2a.py
+++ b/src/paddlefleet/transformer/moe/fused_a2a.py
@@ -902,6 +902,12 @@ else:
     fused_combine = None
 
 
+def _get_hybrid_ep_pad_multiple(manager, use_fp8_dispatch):
+    if use_fp8_dispatch:
+        return FP8_ALIGN
+    return getattr(manager, "expert_padding_alignment", None)
+
+
 class HybridEPDispatch(PyLayer):
     """Fused HybridEP dispatch bridge for Paddle autograd."""
 
@@ -918,6 +924,7 @@ class HybridEPDispatch(PyLayer):
         ctx.num_unpadded_tokens = x.shape[0]
         ctx.hidden_dtype = x.dtype
         ctx.use_fp8_dispatch = fp8_dispatch
+        ctx.pad_multiple = _get_hybrid_ep_pad_multiple(manager, fp8_dispatch)
         ctx.set_grad_in_dtype_consistent(False)
         return recv_x, recv_token_probs, scale
 
@@ -932,7 +939,7 @@ class HybridEPDispatch(PyLayer):
             if grad_token_probs is None
             else grad_token_probs.astype("float32"),
             handle=ctx.handle,
-            pad_multiple=FP8_ALIGN if ctx.use_fp8_dispatch else None,
+            pad_multiple=ctx.pad_multiple,
         )
         if grad_x.shape[0] != ctx.num_unpadded_tokens:
             grad_x = grad_x[: ctx.num_unpadded_tokens]
@@ -954,6 +961,7 @@ def _replay_hybrid_ep_dispatch_backward(
     grad_output,
     num_permuted_tokens,
     use_fp8_dispatch,
+    pad_multiple=None,
 ):
     replay_handle = handle
     if use_fp8_dispatch:
@@ -968,11 +976,12 @@ def _replay_hybrid_ep_dispatch_backward(
             replay_config,
             handle[8],
         )
+        pad_multiple = FP8_ALIGN
     grad_x, _, _, _, _ = buffer.dispatch_with_permute(
         hidden=grad_output.contiguous(),
         handle=replay_handle,
         num_permuted_tokens=num_permuted_tokens,
-        pad_multiple=FP8_ALIGN if use_fp8_dispatch else None,
+        pad_multiple=pad_multiple,
         non_blocking=False,
     )
     return grad_x[:num_permuted_tokens]
@@ -992,15 +1001,17 @@ class HybridEPCombine(PyLayer):
             f"{num_permuted_tokens}."
         )
         use_fp8_dispatch = "UINT8" in str(handle[7].token_data_type)
+        pad_multiple = _get_hybrid_ep_pad_multiple(manager, use_fp8_dispatch)
         combined_x, _ = manager._active_buffer.combine_with_unpermute(
             hidden=x,
             handle=handle,
-            pad_multiple=FP8_ALIGN if use_fp8_dispatch else None,
+            pad_multiple=pad_multiple,
         )
         combined_x.stop_gradient = False
         ctx.buffer = manager._active_buffer
         ctx.handle = handle
         ctx.use_fp8_dispatch = use_fp8_dispatch
+        ctx.pad_multiple = pad_multiple
         ctx.num_permuted_tokens = num_permuted_tokens
         return combined_x
 
@@ -1012,6 +1023,7 @@ class HybridEPCombine(PyLayer):
             grad_output,
             ctx.num_permuted_tokens,
             ctx.use_fp8_dispatch,
+            pad_multiple=ctx.pad_multiple,
         )
         return grad_x
 

--- a/src/paddlefleet/transformer/moe/fused_a2a.py
+++ b/src/paddlefleet/transformer/moe/fused_a2a.py
@@ -916,7 +916,7 @@ class HybridEPDispatch(PyLayer):
         ctx.token_indices = token_indices
         ctx.num_unpadded_tokens = x.shape[0]
         ctx.hidden_dtype = x.dtype
-        ctx.pad_multiple = manager.get_pad_multiple(fp8_dispatch)
+        ctx.pad_multiple = manager._dispatch_pad_multiple
         ctx.set_grad_in_dtype_consistent(False)
         return recv_x, recv_token_probs, scale
 
@@ -952,10 +952,11 @@ def _replay_hybrid_ep_dispatch_backward(
     handle,
     grad_output,
     num_permuted_tokens,
+    use_fp8_dispatch,
     pad_multiple,
 ):
     replay_handle = handle
-    if "UINT8" in str(handle[7].token_data_type):
+    if use_fp8_dispatch:
         replay_config = buffer.update_template_config(
             hidden_dim=grad_output.shape[-1],
             num_of_tokens_per_rank=handle[6],
@@ -990,8 +991,8 @@ class HybridEPCombine(PyLayer):
             f"{x.shape[0]} rows but num_permuted_tokens is "
             f"{num_permuted_tokens}."
         )
-        use_fp8_dispatch = "UINT8" in str(handle[7].token_data_type)
-        pad_multiple = manager.get_pad_multiple(use_fp8_dispatch)
+        use_fp8_dispatch = manager._dispatch_uses_fp8
+        pad_multiple = manager._dispatch_pad_multiple
         combined_x, _ = manager._active_buffer.combine_with_unpermute(
             hidden=x,
             handle=handle,
@@ -1000,6 +1001,7 @@ class HybridEPCombine(PyLayer):
         combined_x.stop_gradient = False
         ctx.buffer = manager._active_buffer
         ctx.handle = handle
+        ctx.use_fp8_dispatch = use_fp8_dispatch
         ctx.pad_multiple = pad_multiple
         ctx.num_permuted_tokens = num_permuted_tokens
         return combined_x
@@ -1011,6 +1013,7 @@ class HybridEPCombine(PyLayer):
             ctx.handle,
             grad_output,
             ctx.num_permuted_tokens,
+            use_fp8_dispatch=ctx.use_fp8_dispatch,
             pad_multiple=ctx.pad_multiple,
         )
         return grad_x

--- a/src/paddlefleet/transformer/moe/fused_a2a.py
+++ b/src/paddlefleet/transformer/moe/fused_a2a.py
@@ -28,7 +28,6 @@ from paddlefleet_ops import (
 
 from paddlefleet.refined_recompute.queue_check import global_rr_queue_log
 
-from .fp8_utils import FP8_ALIGN
 from .moe_utils import manual_backward
 
 if is_deep_ep_available():
@@ -902,12 +901,6 @@ else:
     fused_combine = None
 
 
-def _get_hybrid_ep_pad_multiple(manager, use_fp8_dispatch):
-    if use_fp8_dispatch:
-        return FP8_ALIGN
-    return getattr(manager, "expert_padding_alignment", None)
-
-
 class HybridEPDispatch(PyLayer):
     """Fused HybridEP dispatch bridge for Paddle autograd."""
 
@@ -923,8 +916,7 @@ class HybridEPDispatch(PyLayer):
         ctx.token_indices = token_indices
         ctx.num_unpadded_tokens = x.shape[0]
         ctx.hidden_dtype = x.dtype
-        ctx.use_fp8_dispatch = fp8_dispatch
-        ctx.pad_multiple = _get_hybrid_ep_pad_multiple(manager, fp8_dispatch)
+        ctx.pad_multiple = manager.get_pad_multiple(fp8_dispatch)
         ctx.set_grad_in_dtype_consistent(False)
         return recv_x, recv_token_probs, scale
 
@@ -960,11 +952,10 @@ def _replay_hybrid_ep_dispatch_backward(
     handle,
     grad_output,
     num_permuted_tokens,
-    use_fp8_dispatch,
-    pad_multiple=None,
+    pad_multiple,
 ):
     replay_handle = handle
-    if use_fp8_dispatch:
+    if "UINT8" in str(handle[7].token_data_type):
         replay_config = buffer.update_template_config(
             hidden_dim=grad_output.shape[-1],
             num_of_tokens_per_rank=handle[6],
@@ -976,7 +967,6 @@ def _replay_hybrid_ep_dispatch_backward(
             replay_config,
             handle[8],
         )
-        pad_multiple = FP8_ALIGN
     grad_x, _, _, _, _ = buffer.dispatch_with_permute(
         hidden=grad_output.contiguous(),
         handle=replay_handle,
@@ -1001,7 +991,7 @@ class HybridEPCombine(PyLayer):
             f"{num_permuted_tokens}."
         )
         use_fp8_dispatch = "UINT8" in str(handle[7].token_data_type)
-        pad_multiple = _get_hybrid_ep_pad_multiple(manager, use_fp8_dispatch)
+        pad_multiple = manager.get_pad_multiple(use_fp8_dispatch)
         combined_x, _ = manager._active_buffer.combine_with_unpermute(
             hidden=x,
             handle=handle,
@@ -1010,7 +1000,6 @@ class HybridEPCombine(PyLayer):
         combined_x.stop_gradient = False
         ctx.buffer = manager._active_buffer
         ctx.handle = handle
-        ctx.use_fp8_dispatch = use_fp8_dispatch
         ctx.pad_multiple = pad_multiple
         ctx.num_permuted_tokens = num_permuted_tokens
         return combined_x
@@ -1022,7 +1011,6 @@ class HybridEPCombine(PyLayer):
             ctx.handle,
             grad_output,
             ctx.num_permuted_tokens,
-            ctx.use_fp8_dispatch,
             pad_multiple=ctx.pad_multiple,
         )
         return grad_x

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -466,6 +466,7 @@ class MoELayer(nn.Layer):
                     hybridep_buffer_configs=getattr(
                         config, "hybridep_buffer_configs", None
                     ),
+                    moe_deep_gemm=self.moe_deep_gemm,
                 )
                 if (
                     self.moe_token_dispatcher_type == "deepep"

--- a/src/paddlefleet/transformer/moe/token_dispatcher.py
+++ b/src/paddlefleet/transformer/moe/token_dispatcher.py
@@ -193,6 +193,7 @@ class _HybridEPManager(_DispatchManager):
         num_local_experts: int | None = None,
         moe_ep_barrier: bool = True,
         hybridep_buffer_configs: dict | None = None,
+        moe_deep_gemm: bool = False,
     ):
         if not HAVE_HYBRID_EP:
             raise ImportError("HybridEP runtime is not available.")
@@ -213,6 +214,7 @@ class _HybridEPManager(_DispatchManager):
         self.handle = None
         self._active_buffer = None
         self.hybridep_buffer_configs = hybridep_buffer_configs or {}
+        self.expert_padding_alignment = FP8_ALIGN if moe_deep_gemm else None
         self._num_unpadded_tokens = None
 
     def _get_max_num_tokens_per_rank(self, num_local_tokens: int, place) -> int:
@@ -424,7 +426,9 @@ class _HybridEPManager(_DispatchManager):
             num_of_experts_per_rank=self.num_local_experts,
             use_fp8=use_fp8,
             scaling_factor=scaling_factor,
-            pad_multiple=FP8_ALIGN if use_fp8 else None,
+            pad_multiple=(
+                FP8_ALIGN if use_fp8 else self.expert_padding_alignment
+            ),
             num_permuted_tokens=num_permuted_tokens,
             non_blocking=True,
         )
@@ -827,6 +831,7 @@ class MoEFlexTokenDispatcher(MoETokenDispatcher):
         moe_ep_barrier: bool = True,
         dispatcher_type: str | None = None,
         hybridep_buffer_configs: dict | None = None,
+        moe_deep_gemm: bool = False,
     ):
         super().__init__(ep_group)
 
@@ -846,6 +851,7 @@ class MoEFlexTokenDispatcher(MoETokenDispatcher):
         }
         if manager_cls is _HybridEPManager:
             manager_kwargs["hybridep_buffer_configs"] = hybridep_buffer_configs
+            manager_kwargs["moe_deep_gemm"] = moe_deep_gemm
         self._comm_manager = manager_cls(**manager_kwargs)
 
     def dispatch_preprocess(

--- a/src/paddlefleet/transformer/moe/token_dispatcher.py
+++ b/src/paddlefleet/transformer/moe/token_dispatcher.py
@@ -215,10 +215,15 @@ class _HybridEPManager(_DispatchManager):
         self._active_buffer = None
         self.hybridep_buffer_configs = hybridep_buffer_configs or {}
         self._moe_deep_gemm = moe_deep_gemm
+        self._dispatch_uses_fp8 = None
+        self._dispatch_pad_multiple = None
         self._num_unpadded_tokens = None
 
-    def get_pad_multiple(self, use_fp8: bool) -> int | None:
-        return FP8_ALIGN if use_fp8 or self._moe_deep_gemm else None
+    def _set_dispatch_state(self, use_fp8: bool):
+        self._dispatch_uses_fp8 = use_fp8
+        self._dispatch_pad_multiple = (
+            FP8_ALIGN if use_fp8 or self._moe_deep_gemm else None
+        )
 
     def _get_max_num_tokens_per_rank(self, num_local_tokens: int, place) -> int:
         max_num_tokens = num_local_tokens
@@ -416,6 +421,7 @@ class _HybridEPManager(_DispatchManager):
                 )
             )
             scaling_factor = scaling_factor.T.contiguous()
+        self._set_dispatch_state(use_fp8)
         (
             hidden_states,
             dispatched_probs,
@@ -429,7 +435,7 @@ class _HybridEPManager(_DispatchManager):
             num_of_experts_per_rank=self.num_local_experts,
             use_fp8=use_fp8,
             scaling_factor=scaling_factor,
-            pad_multiple=self.get_pad_multiple(use_fp8),
+            pad_multiple=self._dispatch_pad_multiple,
             num_permuted_tokens=num_permuted_tokens,
             non_blocking=True,
         )
@@ -491,6 +497,8 @@ class _HybridEPManager(_DispatchManager):
         self.dispatched_probs = None
         self.handle = None
         self.num_permuted_tokens = None
+        self._dispatch_uses_fp8 = None
+        self._dispatch_pad_multiple = None
         if (
             self._num_unpadded_tokens is not None
             and hidden_states.shape[0] != self._num_unpadded_tokens

--- a/src/paddlefleet/transformer/moe/token_dispatcher.py
+++ b/src/paddlefleet/transformer/moe/token_dispatcher.py
@@ -215,9 +215,12 @@ class _HybridEPManager(_DispatchManager):
         self._active_buffer = None
         self.hybridep_buffer_configs = hybridep_buffer_configs or {}
         self._moe_deep_gemm = moe_deep_gemm
+        self._reset_dispatch_state()
+        self._num_unpadded_tokens = None
+
+    def _reset_dispatch_state(self):
         self._dispatch_uses_fp8 = None
         self._dispatch_pad_multiple = None
-        self._num_unpadded_tokens = None
 
     def _set_dispatch_state(self, use_fp8: bool):
         self._dispatch_uses_fp8 = use_fp8
@@ -497,8 +500,7 @@ class _HybridEPManager(_DispatchManager):
         self.dispatched_probs = None
         self.handle = None
         self.num_permuted_tokens = None
-        self._dispatch_uses_fp8 = None
-        self._dispatch_pad_multiple = None
+        self._reset_dispatch_state()
         if (
             self._num_unpadded_tokens is not None
             and hidden_states.shape[0] != self._num_unpadded_tokens

--- a/src/paddlefleet/transformer/moe/token_dispatcher.py
+++ b/src/paddlefleet/transformer/moe/token_dispatcher.py
@@ -214,8 +214,11 @@ class _HybridEPManager(_DispatchManager):
         self.handle = None
         self._active_buffer = None
         self.hybridep_buffer_configs = hybridep_buffer_configs or {}
-        self.expert_padding_alignment = FP8_ALIGN if moe_deep_gemm else None
+        self._moe_deep_gemm = moe_deep_gemm
         self._num_unpadded_tokens = None
+
+    def get_pad_multiple(self, use_fp8: bool) -> int | None:
+        return FP8_ALIGN if use_fp8 or self._moe_deep_gemm else None
 
     def _get_max_num_tokens_per_rank(self, num_local_tokens: int, place) -> int:
         max_num_tokens = num_local_tokens
@@ -426,9 +429,7 @@ class _HybridEPManager(_DispatchManager):
             num_of_experts_per_rank=self.num_local_experts,
             use_fp8=use_fp8,
             scaling_factor=scaling_factor,
-            pad_multiple=(
-                FP8_ALIGN if use_fp8 else self.expert_padding_alignment
-            ),
+            pad_multiple=self.get_pad_multiple(use_fp8),
             num_permuted_tokens=num_permuted_tokens,
             non_blocking=True,
         )

--- a/tests/single_card_tests/transformer/test_hybrid_ep_backend.py
+++ b/tests/single_card_tests/transformer/test_hybrid_ep_backend.py
@@ -263,7 +263,8 @@ class TestHybridEPBackendSelection(unittest.TestCase):
         )
 
         self.assertEqual(
-            dispatcher._comm_manager.expert_padding_alignment, FP8_ALIGN
+            dispatcher._comm_manager.get_pad_multiple(use_fp8=False),
+            FP8_ALIGN,
         )
 
 
@@ -1005,6 +1006,10 @@ class TestHybridEPAutogradBridge(unittest.TestCase):
         handle = _make_hybrid_ep_handle(token_data_type="UINT8")
 
         class DispatchingManager:
+            @staticmethod
+            def get_pad_multiple(use_fp8):
+                return FP8_ALIGN if use_fp8 else None
+
             def _dispatch_with_permute_impl(
                 self, x, token_indices, token_probs, use_fp8
             ):
@@ -1046,7 +1051,9 @@ class TestHybridEPAutogradBridge(unittest.TestCase):
             buffer.combine_calls[-1]["probs"].dtype, paddle.float32
         )
 
-    def test_dispatch_pylayer_uses_deepgemm_alignment_in_backward(self):
+    def test_dispatch_pylayer_trims_padded_grad_and_keeps_alignment_without_dense_probs(
+        self,
+    ):
         grad_x = paddle.concat(
             [
                 paddle.full([2, 4], 5.0, dtype="float32"),
@@ -1058,7 +1065,9 @@ class TestHybridEPAutogradBridge(unittest.TestCase):
         handle = _make_hybrid_ep_handle(token_data_type="BF16")
 
         class DispatchingManager:
-            expert_padding_alignment = FP8_ALIGN
+            @staticmethod
+            def get_pad_multiple(use_fp8):
+                return FP8_ALIGN
 
             def _dispatch_with_permute_impl(
                 self, x, token_indices, token_probs, use_fp8
@@ -1202,7 +1211,7 @@ class TestHybridEPAutogradBridge(unittest.TestCase):
             handle,
             grad_output,
             num_permuted_tokens=2,
-            use_fp8_dispatch=False,
+            pad_multiple=None,
         )
 
         self.assertEqual(

--- a/tests/single_card_tests/transformer/test_hybrid_ep_backend.py
+++ b/tests/single_card_tests/transformer/test_hybrid_ep_backend.py
@@ -93,6 +93,7 @@ def _new_hybrid_manager(**overrides):
         "hybridep_buffer_configs": overrides.pop(
             "hybridep_buffer_configs", None
         ),
+        "moe_deep_gemm": overrides.pop("moe_deep_gemm", False),
     }
     manager = _HybridEPManager(**init_kwargs)
     for key, value in overrides.items():
@@ -250,6 +251,20 @@ class TestHybridEPBackendSelection(unittest.TestCase):
         self.assertIsInstance(dispatcher._comm_manager, _HybridEPManager)
         self.assertIs(dispatcher._comm_manager.group, group)
         self.assertEqual(dispatcher._comm_manager.num_local_experts, 2)
+
+    def test_flex_dispatcher_enables_deepgemm_expert_padding(self):
+        dispatcher = MoEFlexTokenDispatcher(
+            num_local_experts=2,
+            num_experts_per_tok=2,
+            n_routed_experts=4,
+            ep_group=_HybridEPGroup(nranks=2),
+            dispatcher_type="hybridep",
+            moe_deep_gemm=True,
+        )
+
+        self.assertEqual(
+            dispatcher._comm_manager.expert_padding_alignment, FP8_ALIGN
+        )
 
 
 class TestHybridEPMetadata(unittest.TestCase):
@@ -747,6 +762,49 @@ class TestHybridEPDispatchBoundary(unittest.TestCase):
             [HYBRIDEP_TOKEN_ALIGNMENT, 1],
         )
 
+    def test_bf16_deepgemm_dispatch_aligns_expert_inputs(self):
+        manager = _new_hybrid_manager(
+            group=_HybridEPGroup(nranks=1),
+            router_topk=1,
+            num_experts=2,
+            num_local_experts=2,
+            moe_deep_gemm=True,
+            routing_map=paddle.to_tensor(
+                [[True, False], [False, True]], dtype="bool"
+            ),
+            routing_probs=paddle.to_tensor(
+                [[1.0, 0.0], [0.0, 1.0]], dtype="float32"
+            ),
+        )
+        buffer = _RecordingHybridEPBuffer(
+            dispatch_results=[
+                (
+                    paddle.zeros([256, 4], dtype="bfloat16"),
+                    paddle.ones([256], dtype="float32"),
+                    None,
+                    paddle.to_tensor([128, 128], dtype="int64"),
+                    _make_hybrid_ep_handle(
+                        num_dispatched_tokens=2,
+                        local_expert_routing_map=manager.routing_map,
+                    ),
+                )
+            ]
+        )
+        _bind_buffer(manager, buffer)
+
+        manager._dispatch_with_permute_impl(
+            paddle.ones([2, 4], dtype="bfloat16"),
+            paddle.to_tensor([[0], [1]], dtype="int64"),
+            paddle.ones([2, 1], dtype="float32"),
+            use_fp8=False,
+        )
+
+        dispatch_kwargs = buffer.dispatch_calls[-1]
+        self.assertEqual(dispatch_kwargs["hidden"].dtype, paddle.bfloat16)
+        self.assertFalse(dispatch_kwargs["use_fp8"])
+        self.assertEqual(dispatch_kwargs["pad_multiple"], FP8_ALIGN)
+        self.assertEqual(manager.num_permuted_tokens, 256)
+
     def test_public_dispatch_uses_router_metadata_and_records_runtime_state(
         self,
     ):
@@ -988,7 +1046,7 @@ class TestHybridEPAutogradBridge(unittest.TestCase):
             buffer.combine_calls[-1]["probs"].dtype, paddle.float32
         )
 
-    def test_dispatch_pylayer_trims_padded_grad_without_dense_probs(self):
+    def test_dispatch_pylayer_uses_deepgemm_alignment_in_backward(self):
         grad_x = paddle.concat(
             [
                 paddle.full([2, 4], 5.0, dtype="float32"),
@@ -1000,6 +1058,8 @@ class TestHybridEPAutogradBridge(unittest.TestCase):
         handle = _make_hybrid_ep_handle(token_data_type="BF16")
 
         class DispatchingManager:
+            expert_padding_alignment = FP8_ALIGN
+
             def _dispatch_with_permute_impl(
                 self, x, token_indices, token_probs, use_fp8
             ):
@@ -1026,6 +1086,7 @@ class TestHybridEPAutogradBridge(unittest.TestCase):
         self.assertEqual(
             buffer.combine_calls[-1]["probs"].dtype, paddle.float32
         )
+        self.assertEqual(buffer.combine_calls[-1]["pad_multiple"], FP8_ALIGN)
 
     def test_combine_pylayer_requires_active_permuted_rows(self):
         manager = _new_hybrid_manager(group=_HybridEPGroup(nranks=1))
@@ -1041,20 +1102,38 @@ class TestHybridEPAutogradBridge(unittest.TestCase):
                 2,
             )
 
-    def test_combine_pylayer_accepts_explicit_active_permuted_rows(self):
-        manager = _new_hybrid_manager(group=_HybridEPGroup(nranks=1))
-        manager.handle = _make_hybrid_ep_handle(token_data_type="BF16")
-        manager._active_buffer = _RecordingHybridEPBuffer(
-            combine_results=[(paddle.full([2, 4], 4.0, dtype="float32"), None)]
+    def test_combine_pylayer_uses_deepgemm_alignment_in_both_directions(self):
+        manager = _new_hybrid_manager(
+            group=_HybridEPGroup(nranks=1), moe_deep_gemm=True
         )
+        manager.handle = _make_hybrid_ep_handle(token_data_type="BF16")
+        buffer = _RecordingHybridEPBuffer(
+            combine_results=[(paddle.full([2, 4], 4.0, dtype="float32"), None)],
+            dispatch_results=[
+                (
+                    paddle.full([2, 4], 2.0, dtype="float32"),
+                    None,
+                    None,
+                    None,
+                    None,
+                )
+            ],
+        )
+        manager._active_buffer = buffer
+        x = paddle.zeros([2, 4], dtype="float32")
+        x.stop_gradient = False
 
         result = HybridEPCombine.apply(
-            paddle.zeros([2, 4], dtype="float32"),
+            x,
             manager,
             2,
         )
+        result.sum().backward()
 
         self.assertEqual(result.numpy().tolist(), [[4.0] * 4, [4.0] * 4])
+        self.assertEqual(x.grad.numpy().tolist(), [[2.0] * 4, [2.0] * 4])
+        self.assertEqual(buffer.combine_calls[-1]["pad_multiple"], FP8_ALIGN)
+        self.assertEqual(buffer.dispatch_calls[-1]["pad_multiple"], FP8_ALIGN)
 
     def test_combine_pylayer_replays_dispatch_in_backward(self):
         combined = paddle.ones([2, 4], dtype="float32")

--- a/tests/single_card_tests/transformer/test_hybrid_ep_backend.py
+++ b/tests/single_card_tests/transformer/test_hybrid_ep_backend.py
@@ -262,9 +262,9 @@ class TestHybridEPBackendSelection(unittest.TestCase):
             moe_deep_gemm=True,
         )
 
+        dispatcher._comm_manager._set_dispatch_state(use_fp8=False)
         self.assertEqual(
-            dispatcher._comm_manager.get_pad_multiple(use_fp8=False),
-            FP8_ALIGN,
+            dispatcher._comm_manager._dispatch_pad_multiple, FP8_ALIGN
         )
 
 
@@ -1006,16 +1006,13 @@ class TestHybridEPAutogradBridge(unittest.TestCase):
         handle = _make_hybrid_ep_handle(token_data_type="UINT8")
 
         class DispatchingManager:
-            @staticmethod
-            def get_pad_multiple(use_fp8):
-                return FP8_ALIGN if use_fp8 else None
-
             def _dispatch_with_permute_impl(
                 self, x, token_indices, token_probs, use_fp8
             ):
                 self._active_buffer = buffer
                 self.handle = handle
                 self.use_fp8 = use_fp8
+                self._dispatch_pad_multiple = FP8_ALIGN if use_fp8 else None
                 return (
                     x * 2,
                     token_probs.reshape([-1]),
@@ -1065,15 +1062,12 @@ class TestHybridEPAutogradBridge(unittest.TestCase):
         handle = _make_hybrid_ep_handle(token_data_type="BF16")
 
         class DispatchingManager:
-            @staticmethod
-            def get_pad_multiple(use_fp8):
-                return FP8_ALIGN
-
             def _dispatch_with_permute_impl(
                 self, x, token_indices, token_probs, use_fp8
             ):
                 self._active_buffer = buffer
                 self.handle = handle
+                self._dispatch_pad_multiple = FP8_ALIGN
                 return x * 2, token_probs.reshape([-1]), None
 
         manager = DispatchingManager()
@@ -1129,6 +1123,7 @@ class TestHybridEPAutogradBridge(unittest.TestCase):
             ],
         )
         manager._active_buffer = buffer
+        manager._set_dispatch_state(use_fp8=False)
         x = paddle.zeros([2, 4], dtype="float32")
         x.stop_gradient = False
 
@@ -1177,6 +1172,7 @@ class TestHybridEPAutogradBridge(unittest.TestCase):
         manager.padded_tokens_per_expert = paddle.to_tensor(
             [1, 1], dtype="int64"
         )
+        manager._set_dispatch_state(use_fp8=True)
         x = paddle.zeros([2, 4], dtype="float32")
         x.stop_gradient = False
 
@@ -1211,6 +1207,7 @@ class TestHybridEPAutogradBridge(unittest.TestCase):
             handle,
             grad_output,
             num_permuted_tokens=2,
+            use_fp8_dispatch=False,
             pad_multiple=None,
         )
 


### PR DESCRIPTION
### PR Category
Communication Library

### PR Types
Bug fixes

### Description

#### 问题原因

HybridEP 原先只在 FP8 dispatch 时对每个 expert 的 token 数按 128 补齐。在 BF16 dispatch 且 `moe_deep_gemm=True` 时，expert token 数可能不是 128 的倍数，从而违反 DeepGEMM grouped BF16 wgrad 对 K 维的对齐要求并触发 `k % 128 == 0` 断言。

DeepEP 不经过这条缺失对齐的路径：其 fused MoE unzip/permute 流程会在 expert 计算前按 `FP8_ALIGN` 补齐输入。

#### 修改内容

- 将 `moe_deep_gemm` 的有效配置传入 HybridEP communication manager。
- 由 manager 在每次 dispatch 时统一记录 FP8 状态并计算 per-expert padding：FP8 或 BF16 DeepGEMM 使用 128 对齐，普通 BF16 不补齐。
- dispatch/combine 的 autograd 边界只快照并复用 manager 已确定的状态，backward replay 不再重复推导 alignment，也不再解析 HybridEP handle 的 dtype 字符串表示。
- combine 完成后统一清理本次 dispatch 状态，避免状态跨轮次残留；不再通过防御式 `getattr` 静默回退。
- 补充 dispatcher 构造与前后向通信边界测试；同时采纳 Copilot 建议，使测试名明确覆盖“无 dense probs 时裁剪 padded gradient”与“保留 alignment”两个行为。

#### 影响范围

行为变化仅限 `moe_token_dispatcher_type=hybridep` 且 `moe_deep_gemm=True` 的场景。现有 FP8 对齐行为保持不变，普通 HybridEP BF16 dispatch 仍不会增加 per-expert padding。

#### 验证

- python -m pytest -q tests/single_card_tests/transformer/test_hybrid_ep_backend.py`
- focused tests：`36 passed`；相对 `develop` 的修改行覆盖率为 `100%`（17/17）。
- `uvx --from 'ruff~=0.14.0' ruff format --check`（修改文件）
- `uvx --from 'ruff~=0.14.0' ruff check`（修改文件）
- `git diff --check`

### 是否引起精度变化
否

<div align="right">
   <sup>This PR is co-authored with @codex (gpt-5.6 sol max)</sup>
</div>
