### PR TITLE
[release/0.3] update inspect_tensor func for RL

### DIFF
--- a/src/paddlefleet/transformer/utils.py
+++ b/src/paddlefleet/transformer/utils.py
@@ -186,31 +186,34 @@ def get_doc_starts(doc_lens: paddle.Tensor) -> paddle.Tensor:
     return starts
 
 
-def inspect_and_load_tensor(tag, layer_idx, tensor, load=True):
-    """Inspect tensor info and optionally override it with a saved numpy tensor.
+def inspect_tensor(tag, layer_idx, tensor, save=False, load=True):
+    """Inspect tensor info, optionally save to .npy and/or load override from .npy.
 
     Controlled by environment variables:
         ABLATION_INSPECT_TENSOR: "1" to enable printing tensor info.
+        ABLATION_SAVE_TENSOR_PATH: path to save .npy files (layer 0 only, first call).
         ABLATION_LOAD_TENSOR_PATH: path to directory with saved .npy files (layer 0 only).
         ABLATION_INFO_SKIP_TAGS: comma-separated tags to skip for info printing.
-        ABLATION_DUMP_SKIP_TAGS: comma-separated tags to skip for tensor loading.
+        ABLATION_DUMP_SKIP_TAGS: comma-separated tags to skip for tensor saving/loading.
 
     Args:
         tag: identifier for the tensor checkpoint.
         layer_idx: transformer layer index.
         tensor: the live paddle tensor.
+        save: if True, attempt to save the tensor to .npy file. Default is False.
         load: if True, attempt to load and override the tensor from disk (layer 0 only).
               Default is True.
 
     Returns:
-        The original tensor (if load=False or no file found), or the loaded tensor.
+        The original tensor (if no load or no file found), or the loaded tensor.
     """
     import hashlib
     import os
 
     import numpy as np
 
-    inspect_tensor = os.environ.get("ABLATION_INSPECT_TENSOR", "0") == "1"
+    inspect_flag = os.environ.get("ABLATION_INSPECT_TENSOR", "0") == "1"
+    ablation_save_path = os.environ.get("ABLATION_SAVE_TENSOR_PATH", "")
     ablation_load_path = os.environ.get("ABLATION_LOAD_TENSOR_PATH", "")
     skip_tags = set(
         filter(None, os.environ.get("ABLATION_INFO_SKIP_TAGS", "").split(","))
@@ -219,14 +222,18 @@ def inspect_and_load_tensor(tag, layer_idx, tensor, load=True):
         filter(None, os.environ.get("ABLATION_DUMP_SKIP_TAGS", "").split(","))
     )
 
+    if (not inspect_flag) or (tensor is None):
+        return tensor
+
+    rank = (
+        paddle.distributed.get_rank()
+        if paddle.distributed.is_initialized()
+        else 0
+    )
+
     # --- info (print) ---
-    if inspect_tensor and tensor is not None and tag not in skip_tags:
+    if tag not in skip_tags:
         try:
-            rank = (
-                paddle.distributed.get_rank()
-                if paddle.distributed.is_initialized()
-                else 0
-            )
             t_f = tensor.astype("float32")
             abssum = t_f.abs().sum().item()
             md5 = hashlib.md5(t_f.numpy().tobytes()).hexdigest()
@@ -241,27 +248,41 @@ def inspect_and_load_tensor(tag, layer_idx, tensor, load=True):
                 flush=True,
             )
 
-    # --- load (override) ---
-    if (
-        load
-        and tensor is not None
-        and ablation_load_path
-        and layer_idx == 0
-        and tag not in dump_skip_tags
-    ):
-        path = os.path.join(ablation_load_path, f"{tag}.npy")
+    # --- save (dump .npy, rank_xxx/layer_xxx directory) ---
+    if save and ablation_save_path and tag not in dump_skip_tags:
+        rank_dir = os.path.join(ablation_save_path, f"rank_{rank}")
+        layer_dir = os.path.join(rank_dir, f"layer_{layer_idx}")
+        os.makedirs(layer_dir, exist_ok=True)
+        fpath = os.path.join(layer_dir, f"{tag}.npy")
+        arr = tensor.astype("float32").numpy()
+        np.save(fpath, arr)
+        abssum = float(np.abs(arr).sum())
+        md5 = hashlib.md5(arr.tobytes()).hexdigest()
+        print(
+            f"[ABLATION_dump_tensor] saved {tag} rank={rank} layer={layer_idx} shape={list(tensor.shape)} "
+            f"dtype={tensor.dtype} abssum={abssum} md5={md5} -> {fpath}",
+            flush=True,
+        )
+
+    # --- load (override, rank_xxx/layer_xxx directory) ---
+    if load and ablation_load_path and tag not in dump_skip_tags:
+        rank_dir = os.path.join(ablation_load_path, f"rank_{rank}")
+        layer_dir = os.path.join(rank_dir, f"layer_{layer_idx}")
+        path = os.path.join(layer_dir, f"{tag}.npy")
         if os.path.exists(path):
             arr = np.load(path)
             if arr.shape != tuple(tensor.shape):
                 arr = arr.reshape(tensor.shape)
-            loaded = paddle.to_tensor(
-                arr, dtype=tensor.dtype, place=tensor.place
-            )
+            # Load as float32 first, then cast to target dtype
+            # (paddle.to_tensor doesn't support float8 dtypes directly)
+            loaded = paddle.to_tensor(arr, dtype="float32", place=tensor.place)
+            if tensor.dtype != paddle.float32:
+                loaded = loaded.astype(tensor.dtype)
             load_f32 = loaded.astype("float32")
             abssum = load_f32.abs().sum().item()
             md5 = hashlib.md5(load_f32.numpy().tobytes()).hexdigest()
             print(
-                f"[ABLATION_load_tensor] loaded {tag} shape={list(loaded.shape)} dtype={loaded.dtype} abssum={abssum} md5={md5}",
+                f"[ABLATION_load_tensor] loaded {tag} rank={rank} shape={list(loaded.shape)} dtype={loaded.dtype} abssum={abssum} md5={md5}",
                 flush=True,
             )
             orig_f32 = tensor.astype("float32")

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_utils_3.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_utils_3.py
@@ -22,114 +22,252 @@ import paddle
 from paddlefleet.transformer.utils import (
     get_doc_lens,
     get_doc_starts,
-    inspect_and_load_tensor,
+    inspect_tensor,
 )
 
 
-class TestInspectAndLoadTensor(unittest.TestCase):
-    """Tests for inspect_and_load_tensor."""
+class TestInspectTensor(unittest.TestCase):
+    """Tests for inspect_tensor."""
 
     def _make_tensor(self, shape=(2, 4), dtype="float32"):
         arr = np.random.randn(*shape).astype(np.float32)
         return paddle.to_tensor(arr)
 
-    def test_returns_original_tensor_no_env(self):
-        t = self._make_tensor()
-        result = inspect_and_load_tensor("q", 0, t, load=True)
-        self.assertIs(result, t)
-
-    def test_returns_original_when_load_false(self):
-        arr = np.random.randn(2, 4).astype(np.float32)
-        with tempfile.TemporaryDirectory() as tmpdir:
-            np.save(os.path.join(tmpdir, "q.npy"), arr)
-            with patch.dict(os.environ, {"ABLATION_LOAD_TENSOR_PATH": tmpdir}):
-                t = paddle.zeros([2, 4])
-                result = inspect_and_load_tensor("q", 0, t, load=False)
-        self.assertIs(result, t)
-
-    @patch.dict(os.environ, {"ABLATION_INSPECT_TENSOR": "1"})
-    def test_dump_prints_info(self):
+    def test_returns_original_tensor_when_inspect_disabled(self):
+        """inspect_flag=0, should return tensor unchanged without printing."""
         t = self._make_tensor()
         with patch("builtins.print") as mock_print:
-            result = inspect_and_load_tensor("attn_out", 2, t, load=False)
+            result = inspect_tensor("q", 0, t, save=False, load=True)
+        self.assertIs(result, t)
+        mock_print.assert_not_called()
+
+    def test_none_tensor_returns_none(self):
+        """tensor is None should return None immediately."""
+        result = inspect_tensor("q", 0, None, save=False, load=True)
+        self.assertIsNone(result)
+
+    @patch.dict(os.environ, {"ABLATION_INSPECT_TENSOR": "1"})
+    def test_none_tensor_with_inspect_enabled(self):
+        """inspect_flag=1 but tensor is None, should return None without crash."""
+        with patch("builtins.print") as mock_print:
+            result = inspect_tensor("q", 0, None, save=False, load=False)
+        self.assertIsNone(result)
+        mock_print.assert_not_called()
+
+    @patch.dict(os.environ, {"ABLATION_INSPECT_TENSOR": "1"})
+    def test_info_prints_with_rank_abssum_md5(self):
+        """When inspect enabled, should print info with rank, abssum, md5."""
+        t = self._make_tensor()
+        with patch("builtins.print") as mock_print:
+            result = inspect_tensor("attn_out", 2, t, save=False, load=False)
         self.assertIs(result, t)
         output = " ".join(str(c) for c in mock_print.call_args_list)
         self.assertIn("[ABLATION_train]", output)
         self.assertIn("tag=attn_out", output)
         self.assertIn("layer=2", output)
+        self.assertIn("rank=", output)
+        self.assertIn("abssum=", output)
+        self.assertIn("md5=", output)
+        self.assertIn("shape=", output)
+        self.assertIn("dtype=", output)
 
     @patch.dict(
         os.environ,
         {"ABLATION_INSPECT_TENSOR": "1", "ABLATION_INFO_SKIP_TAGS": "q,k"},
     )
     def test_info_skip_tags(self):
+        """Tags in ABLATION_INFO_SKIP_TAGS should not be printed."""
         t = self._make_tensor()
         with patch("builtins.print") as mock_print:
-            inspect_and_load_tensor("q", 0, t, load=False)
+            inspect_tensor("q", 0, t, save=False, load=False)
         output = " ".join(str(c) for c in mock_print.call_args_list)
         self.assertNotIn("[ABLATION_train]", output)
 
     @patch.dict(os.environ, {"ABLATION_INSPECT_TENSOR": "1"})
-    def test_none_tensor_no_crash(self):
-        with patch("builtins.print") as mock_print:
-            result = inspect_and_load_tensor("q", 0, None, load=False)
-        self.assertIsNone(result)
-        mock_print.assert_not_called()
+    def test_info_exception_handling(self):
+        """If tensor info computation fails, should print info_failed without crashing."""
+        t = self._make_tensor()
+        with (
+            patch.object(t, "astype", side_effect=RuntimeError("cast fail")),
+            patch("builtins.print") as mock_print,
+        ):
+            result = inspect_tensor("q", 0, t, save=False, load=False)
+        self.assertIs(result, t)
+        output = " ".join(str(c) for c in mock_print.call_args_list)
+        self.assertIn("info_failed", output)
 
-    def test_load_tensor_from_npy(self):
+    @patch.dict(os.environ, {"ABLATION_INSPECT_TENSOR": "1"})
+    def test_save_tensor_to_disk(self):
+        """save=True should dump tensor to rank_0/layer_X/{tag}.npy."""
+        t = self._make_tensor((3, 5))
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with (
+                patch.dict(os.environ, {"ABLATION_SAVE_TENSOR_PATH": tmpdir}),
+                patch("builtins.print"),
+            ):
+                inspect_tensor("q", 2, t, save=True, load=False)
+            saved_path = os.path.join(tmpdir, "rank_0", "layer_2", "q.npy")
+            self.assertTrue(os.path.exists(saved_path))
+            loaded_arr = np.load(saved_path)
+            np.testing.assert_allclose(
+                loaded_arr, t.numpy().astype(np.float32), rtol=1e-5
+            )
+
+    @patch.dict(os.environ, {"ABLATION_INSPECT_TENSOR": "1"})
+    def test_save_prints_dump_info(self):
+        """save=True should print [ABLATION_dump_tensor] info."""
+        t = self._make_tensor()
+        with (
+            tempfile.TemporaryDirectory() as tmpdir,
+            patch.dict(os.environ, {"ABLATION_SAVE_TENSOR_PATH": tmpdir}),
+            patch("builtins.print") as mock_print,
+        ):
+            inspect_tensor("q", 0, t, save=True, load=False)
+        output = " ".join(str(c) for c in mock_print.call_args_list)
+        self.assertIn("[ABLATION_dump_tensor]", output)
+        self.assertIn("saved q", output)
+
+    @patch.dict(
+        os.environ,
+        {"ABLATION_INSPECT_TENSOR": "1", "ABLATION_DUMP_SKIP_TAGS": "q"},
+    )
+    def test_save_skipped_by_dump_skip_tags(self):
+        """Tags in ABLATION_DUMP_SKIP_TAGS should not be saved."""
+        t = self._make_tensor()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with (
+                patch.dict(os.environ, {"ABLATION_SAVE_TENSOR_PATH": tmpdir}),
+                patch("builtins.print"),
+            ):
+                inspect_tensor("q", 0, t, save=True, load=False)
+            saved_path = os.path.join(tmpdir, "rank_0", "layer_0", "q.npy")
+            self.assertFalse(os.path.exists(saved_path))
+
+    @patch.dict(os.environ, {"ABLATION_INSPECT_TENSOR": "1"})
+    def test_save_not_triggered_when_no_path(self):
+        """save=True but no ABLATION_SAVE_TENSOR_PATH should not crash."""
+        t = self._make_tensor()
+        with patch("builtins.print"):
+            result = inspect_tensor("q", 0, t, save=True, load=False)
+        self.assertIs(result, t)
+
+    @patch.dict(os.environ, {"ABLATION_INSPECT_TENSOR": "1"})
+    def test_load_tensor_from_rank_layer_dir(self):
+        """load=True should load from rank_0/layer_X/{tag}.npy."""
         arr = np.random.randn(2, 4).astype(np.float32)
         with tempfile.TemporaryDirectory() as tmpdir:
-            np.save(os.path.join(tmpdir, "q.npy"), arr)
+            rank_layer_dir = os.path.join(tmpdir, "rank_0", "layer_0")
+            os.makedirs(rank_layer_dir)
+            np.save(os.path.join(rank_layer_dir, "q.npy"), arr)
             with patch.dict(os.environ, {"ABLATION_LOAD_TENSOR_PATH": tmpdir}):
                 t = paddle.zeros([2, 4])
-                result = inspect_and_load_tensor("q", 0, t, load=True)
+                with patch("builtins.print"):
+                    result = inspect_tensor("q", 0, t, save=False, load=True)
         np.testing.assert_allclose(result.numpy(), arr, rtol=1e-5)
 
-    def test_load_skipped_for_nonzero_layer(self):
+    @patch.dict(os.environ, {"ABLATION_INSPECT_TENSOR": "1"})
+    def test_load_nonzero_layer(self):
+        """load should work for any layer, not just layer 0."""
         arr = np.random.randn(2, 4).astype(np.float32)
         with tempfile.TemporaryDirectory() as tmpdir:
-            np.save(os.path.join(tmpdir, "q.npy"), arr)
+            rank_layer_dir = os.path.join(tmpdir, "rank_0", "layer_3")
+            os.makedirs(rank_layer_dir)
+            np.save(os.path.join(rank_layer_dir, "q.npy"), arr)
             with patch.dict(os.environ, {"ABLATION_LOAD_TENSOR_PATH": tmpdir}):
                 t = paddle.zeros([2, 4])
-                result = inspect_and_load_tensor("q", 1, t, load=True)
+                with patch("builtins.print"):
+                    result = inspect_tensor("q", 3, t, save=False, load=True)
+        np.testing.assert_allclose(result.numpy(), arr, rtol=1e-5)
+
+    @patch.dict(os.environ, {"ABLATION_INSPECT_TENSOR": "1"})
+    def test_load_returns_original_when_file_missing(self):
+        """If .npy file does not exist, should return original tensor."""
+        with (
+            tempfile.TemporaryDirectory() as tmpdir,
+            patch.dict(os.environ, {"ABLATION_LOAD_TENSOR_PATH": tmpdir}),
+        ):
+            t = paddle.zeros([2, 4])
+            with patch("builtins.print"):
+                result = inspect_tensor("q", 0, t, save=False, load=True)
         self.assertIs(result, t)
 
-    def test_dump_skip_tags_suppresses_load(self):
-        arr = np.random.randn(2, 4).astype(np.float32)
-        with tempfile.TemporaryDirectory() as tmpdir:
-            np.save(os.path.join(tmpdir, "q.npy"), arr)
-            with patch.dict(
-                os.environ,
-                {
-                    "ABLATION_LOAD_TENSOR_PATH": tmpdir,
-                    "ABLATION_DUMP_SKIP_TAGS": "q",
-                },
-            ):
-                t = paddle.zeros([2, 4])
-                result = inspect_and_load_tensor("q", 0, t, load=True)
-        self.assertIs(result, t)
-
+    @patch.dict(os.environ, {"ABLATION_INSPECT_TENSOR": "1"})
     def test_load_auto_reshape(self):
+        """Loaded array with different shape should be reshaped to match tensor."""
         arr = np.arange(8, dtype=np.float32)  # shape (8,)
         with tempfile.TemporaryDirectory() as tmpdir:
-            np.save(os.path.join(tmpdir, "q.npy"), arr)
+            rank_layer_dir = os.path.join(tmpdir, "rank_0", "layer_0")
+            os.makedirs(rank_layer_dir)
+            np.save(os.path.join(rank_layer_dir, "q.npy"), arr)
             with patch.dict(os.environ, {"ABLATION_LOAD_TENSOR_PATH": tmpdir}):
                 t = paddle.zeros([2, 4])
-                result = inspect_and_load_tensor("q", 0, t, load=True)
+                with patch("builtins.print"):
+                    result = inspect_tensor("q", 0, t, save=False, load=True)
         self.assertEqual(list(result.shape), [2, 4])
         np.testing.assert_allclose(result.numpy(), arr.reshape(2, 4), rtol=1e-5)
 
+    @patch.dict(os.environ, {"ABLATION_INSPECT_TENSOR": "1"})
+    def test_load_dtype_cast(self):
+        """Loaded tensor should be cast to target tensor's dtype."""
+        arr = np.random.randn(2, 4).astype(np.float32)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            rank_layer_dir = os.path.join(tmpdir, "rank_0", "layer_0")
+            os.makedirs(rank_layer_dir)
+            np.save(os.path.join(rank_layer_dir, "q.npy"), arr)
+            with patch.dict(os.environ, {"ABLATION_LOAD_TENSOR_PATH": tmpdir}):
+                t = paddle.zeros([2, 4], dtype="float16")
+                with patch("builtins.print"):
+                    result = inspect_tensor("q", 0, t, save=False, load=True)
+        self.assertEqual(result.dtype, paddle.float16)
+
+    @patch.dict(os.environ, {"ABLATION_INSPECT_TENSOR": "1"})
     def test_load_prints_diff_info(self):
+        """Load should print [ABLATION_load_tensor] with diff stats."""
         arr = np.ones((2, 4), dtype=np.float32) * 3.0
         with tempfile.TemporaryDirectory() as tmpdir:
-            np.save(os.path.join(tmpdir, "v.npy"), arr)
+            rank_layer_dir = os.path.join(tmpdir, "rank_0", "layer_0")
+            os.makedirs(rank_layer_dir)
+            np.save(os.path.join(rank_layer_dir, "v.npy"), arr)
             with patch.dict(os.environ, {"ABLATION_LOAD_TENSOR_PATH": tmpdir}):
                 t = paddle.zeros([2, 4])
                 with patch("builtins.print") as mock_print:
-                    inspect_and_load_tensor("v", 0, t, load=True)
+                    inspect_tensor("v", 0, t, save=False, load=True)
         output = " ".join(str(c) for c in mock_print.call_args_list)
         self.assertIn("[ABLATION_load_tensor]", output)
         self.assertIn("max_abs_diff", output)
+        self.assertIn("mean_abs_diff", output)
+        self.assertIn("relative_diff", output)
+
+    @patch.dict(
+        os.environ,
+        {"ABLATION_INSPECT_TENSOR": "1", "ABLATION_DUMP_SKIP_TAGS": "q"},
+    )
+    def test_load_skipped_by_dump_skip_tags(self):
+        """Tags in ABLATION_DUMP_SKIP_TAGS should not be loaded."""
+        arr = np.random.randn(2, 4).astype(np.float32)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            rank_layer_dir = os.path.join(tmpdir, "rank_0", "layer_0")
+            os.makedirs(rank_layer_dir)
+            np.save(os.path.join(rank_layer_dir, "q.npy"), arr)
+            with patch.dict(os.environ, {"ABLATION_LOAD_TENSOR_PATH": tmpdir}):
+                t = paddle.zeros([2, 4])
+                with patch("builtins.print"):
+                    result = inspect_tensor("q", 0, t, save=False, load=True)
+        self.assertIs(result, t)
+
+    @patch.dict(os.environ, {"ABLATION_INSPECT_TENSOR": "1"})
+    def test_returns_original_when_load_false(self):
+        """load=False should not load even if file exists."""
+        arr = np.random.randn(2, 4).astype(np.float32)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            rank_layer_dir = os.path.join(tmpdir, "rank_0", "layer_0")
+            os.makedirs(rank_layer_dir)
+            np.save(os.path.join(rank_layer_dir, "q.npy"), arr)
+            with patch.dict(os.environ, {"ABLATION_LOAD_TENSOR_PATH": tmpdir}):
+                t = paddle.zeros([2, 4])
+                with patch("builtins.print"):
+                    result = inspect_tensor("q", 0, t, save=False, load=False)
+        self.assertIs(result, t)
 
 
 class TestGetDocLens(unittest.TestCase):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
升级inspect_tensor方法，支持训练dump训练load，支持moe expert部分save_load（不同rank dump不同数据，可复现dispatch情况）
工具函数，流程中暂未使用

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否

Cherry-pick of #1489 to `release/0.3`.

Merged in dev: #1489  <!-- For pass CI -->