### PR TITLE
[Fix] Avoid bare `import cudnn` in HySparse DSA availability probe

### DIFF
--- a/src/paddlefleet/cudnn_ops/block_sparse_mqa_dsa.py
+++ b/src/paddlefleet/cudnn_ops/block_sparse_mqa_dsa.py
@@ -49,6 +49,7 @@ and contribute no KV gradient).
 """
 
 import os
+from functools import lru_cache
 
 import paddle
 
@@ -56,16 +57,15 @@ _DSA_HEADS = 64  # FlashMLA sparse fwd only supports h_q == 64 on SM100.
 _NEG_SINK = -1e30  # sink so large-negative that exp(sink - m) underflows to 0.
 
 
+@lru_cache(maxsize=1)
 def is_dsa_available() -> bool:
     """Whether the FlashMLA sparse fwd + cuDNN DSA bwd path can run here.
 
     The DSA fwd/bwd kernels are only implemented for SM100+ (Blackwell); there
-    is no eager fallback below it. The cuDNN DSA *backward* additionally does a
-    bare ``import cudnn`` (the NVIDIA cuDNN python frontend) at call time, which
-    ``paddlefleet_ops.is_cudnn_frontend_available()`` (an ops-level probe) does
-    NOT cover. Probe both here so environments missing either -- e.g. an SM90
-    H20 CI box without the ``cudnn`` wheel -- report unavailable and skip the
-    path instead of failing deep inside the backward.
+    is no eager fallback below it. Probe the actual PaddleFleet ops dependencies
+    once per process. Avoid importing the standalone ``cudnn`` package here:
+    under Paddle's torch proxy its module discovery can recursively enter
+    ``find_spec`` and hang the first attention forward.
     """
     try:
         import paddlefleet_ops
@@ -81,9 +81,6 @@ def is_dsa_available() -> bool:
             return False
         if not paddlefleet_ops.is_cudnn_frontend_available():
             return False
-        # The backward's ``import cudnn`` python frontend is a separate wheel
-        # from the ops-level frontend checked above.
-        import cudnn  # noqa: F401
     except (ImportError, RuntimeError, AttributeError):
         return False
     return True


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
Under Paddle's torch-compat proxy (`paddle/compat/proxy.py`), the bare `import cudnn` inside `is_dsa_available()` triggers the proxy's local-enabled-scope branch in `find_spec`. That branch is evaluated before the re-entry guard, so `importlib.util.find_spec("cudnn")` re-enters `find_spec` unboundedly, producing a CPU-bound livelock on the first HySparse attention forward (GPU util 0%, python pegged ~100% CPU, zero log/cache byte growth, first loss never appears).

Fix in `src/paddlefleet/cudnn_ops/block_sparse_mqa_dsa.py`:
- Drop the bare `import cudnn` in `is_dsa_available()`. Availability is already fully determined by the compiled ops probes: `paddlefleet_ops.is_flash_mla_available()`, `csa_sparse_attn_fwd_cudnn._flash_mla_sparse_fwd`, and `paddlefleet_ops.is_cudnn_frontend_available()`.
- Add `@lru_cache(maxsize=1)` so the probe runs once per process.
- Update the docstring to document why the standalone `cudnn` package must not be imported here.

The cuDNN DSA backward still uses the compiled `paddlefleet.cudnn_ops.csa_sparse_attn_bwd_cudnn` op (not the python `cudnn` module), so functionality is unchanged. Verified no residual bare `import cudnn` under `src/`, and a restarted training run clears the first-forward livelock and progresses past the DSA path normally.
