### PR TITLE
[Fix] TileLang windowed MQA dsink 128x over-count + harden HySparse precision tests

### DIFF
--- a/src/paddlefleet/tilelang_ops/hysparse/windowed_mqa_attn_bwd.py
+++ b/src/paddlefleet/tilelang_ops/hysparse/windowed_mqa_attn_bwd.py
@@ -283,7 +283,14 @@ def windowed_mqa_bwd(
                     0.0,
                 )
             T.reduce_sum(sink_contrib, sink_acc, dim=0, clear=True)
-            T.atomic_add(dAttnSink[bh], sink_acc[0])
+            # reduce_sum broadcasts the scalar to every thread; a bare atomic
+            # would then commit it on all `threads` lanes (dAttnSink counted
+            # threads-x). Guard the once-per-(bm,bh,bb)-block global commit to a
+            # single lane using the same idiom as block_score_mha.py (T.Parallel
+            # loop + `if i == 0`).
+            for i in T.Parallel(BM):
+                if i == 0:
+                    T.atomic_add(dAttnSink[bh], sink_acc[0])
 
     return main
 

--- a/tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_backends.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_backends.py
@@ -66,6 +66,19 @@ COS_THRESHOLDS = {
     "d_sink": 0.95,
 }
 
+# Magnitude-sensitive relative-L2 ceilings (||tl-cu|| / ||cu||). Cosine is
+# scale-invariant, so it passes even if the two backends diverge by a constant
+# factor (exactly the class of bug -- e.g. a 128x gradient scale -- that shipped
+# undetected). Since this compares TileLang vs cuDNN (two kernels, no fp32 ref)
+# the bound guards against a scale divergence between the backends. Ceilings are
+# ~2x the worst observed bf16-level error across all TEST_CASES.
+REL_L2_THRESHOLDS = {
+    "out": 5e-3,
+    "dq": 3e-3,
+    "dkv": 7e-4,
+    "d_sink": 6e-3,
+}
+
 
 def cosine_sim(a, b):
     a_f = a.flatten().cast("float32")
@@ -79,6 +92,14 @@ def cosine_sim(a, b):
 
 def max_abs_diff(a, b):
     return float((a.cast("float32") - b.cast("float32")).abs().max())
+
+
+def rel_l2(a, b):
+    a_f = a.flatten().cast("float32")
+    b_f = b.flatten().cast("float32")
+    return float(
+        paddle.linalg.norm(a_f - b_f) / (paddle.linalg.norm(b_f) + 1e-12)
+    )
 
 
 def make_inputs(batch_size, seq_len, kv_seq_len, num_heads, head_dim, topk):
@@ -136,16 +157,33 @@ def run_single_shape(
         return False, {"d_sink": None}
 
     metrics = {
-        "out": (cosine_sim(out_tl, out_cu), max_abs_diff(out_tl, out_cu)),
-        "dq": (cosine_sim(dq_tl, dq_cu), max_abs_diff(dq_tl, dq_cu)),
-        "dkv": (cosine_sim(dkv_tl, dkv_cu), max_abs_diff(dkv_tl, dkv_cu)),
+        "out": (
+            cosine_sim(out_tl, out_cu),
+            max_abs_diff(out_tl, out_cu),
+            rel_l2(out_tl, out_cu),
+        ),
+        "dq": (
+            cosine_sim(dq_tl, dq_cu),
+            max_abs_diff(dq_tl, dq_cu),
+            rel_l2(dq_tl, dq_cu),
+        ),
+        "dkv": (
+            cosine_sim(dkv_tl, dkv_cu),
+            max_abs_diff(dkv_tl, dkv_cu),
+            rel_l2(dkv_tl, dkv_cu),
+        ),
         "d_sink": (
             cosine_sim(dsink_tl, dsink_cu),
             max_abs_diff(dsink_tl, dsink_cu),
+            rel_l2(dsink_tl, dsink_cu),
         ),
     }
+    # Gate on BOTH a cosine floor (direction) and a rel-L2 ceiling (magnitude);
+    # cosine alone is scale-blind and would pass a constant-factor divergence.
     passed = all(
         metrics[name][0] > COS_THRESHOLDS[name] for name in COS_THRESHOLDS
+    ) and all(
+        metrics[name][2] < REL_L2_THRESHOLDS[name] for name in REL_L2_THRESHOLDS
     )
     return passed, metrics
 

--- a/tests/single_card_tests/custom_ops/test_hysparse_block_score_mha_dense_ref.py
+++ b/tests/single_card_tests/custom_ops/test_hysparse_block_score_mha_dense_ref.py
@@ -163,6 +163,7 @@ class TestBlockScoreMHADenseRef(unittest.TestCase):
             lse_k,
             lse_r,
             min_cos=0.999,
+            max_rel_l2=1e-7,
         )
         self._check_block_logit(f"{tag}:block_logit", blk_k, blk_r)
 

--- a/tests/single_card_tests/custom_ops/test_hysparse_dsa_pad_to_512.py
+++ b/tests/single_card_tests/custom_ops/test_hysparse_dsa_pad_to_512.py
@@ -135,6 +135,17 @@ def _cos(a, b):
     return float(np.dot(af, bf) / denom)
 
 
+def _rel_l2(a, b):
+    # Relative Frobenius error ||a-ref|| / ||ref||: unlike cosine this is
+    # scale-SENSITIVE, so it catches a constant-factor / offset gradient error
+    # (e.g. a wrong gradient scale) that cosine is blind to.
+    import numpy as np
+
+    af = a.astype("float32").numpy().reshape(-1)
+    bf = b.astype("float32").numpy().reshape(-1)
+    return float(np.linalg.norm(af - bf) / (np.linalg.norm(bf) + 1e-12))
+
+
 def _select_blocks(b, s, block_B, topk):
     """Per-token relative block ids: block 0 plus the running block (pos//BB),
     padded with -1 to width ``topk``."""
@@ -212,9 +223,17 @@ class TestBlockSparseDSAPadTo512(unittest.TestCase):
             _cos(dkv_dsa[..., : self.KV_LORA], dkv_ref[..., : self.KV_LORA]),
             0.99,
         )
+        self.assertLess(
+            _rel_l2(dkv_dsa[..., : self.KV_LORA], dkv_ref[..., : self.KV_LORA]),
+            4e-3,
+        )
         self.assertGreater(
             _cos(dkv_dsa[..., self.KV_LORA :], dkv_ref[..., self.KV_LORA :]),
             0.99,
+        )
+        self.assertLess(
+            _rel_l2(dkv_dsa[..., self.KV_LORA :], dkv_ref[..., self.KV_LORA :]),
+            5e-3,
         )
 
     def test_pad_path_equivalent_to_native_512(self):
@@ -262,7 +281,10 @@ class TestBlockSparseDSAPadTo512(unittest.TestCase):
         out512 = out512.reshape([b, s, h * self.KV_LORA])
 
         self.assertEqual(list(out_pad.shape), list(out512.shape))
+        # Near-exact equivalence: enforce a tight magnitude ceiling alongside
+        # the near-exact cosine floor (cosine alone would miss a scale drift).
         self.assertGreater(_cos(out_pad, out512), 0.999999)
+        self.assertLess(_rel_l2(out_pad, out512), 1e-3)
 
 
 if __name__ == "__main__":

--- a/tests/single_card_tests/custom_ops/test_hysparse_fa4_grad.py
+++ b/tests/single_card_tests/custom_ops/test_hysparse_fa4_grad.py
@@ -175,9 +175,32 @@ class TestBlockScoreFA4Backward(unittest.TestCase):
         ref = _ref_causal_attn(qr, kr, vr, sm_scale)
         ref.backward(g.astype("float32"))
 
-        self.assertGreater(_cos(qf.grad, qr.grad), 0.99)
-        self.assertGreater(_cos(kf.grad, kr.grad), 0.99)
-        self.assertGreater(_cos(vf.grad, vr.grad), 0.99)
+        # Cosine floor + magnitude-sensitive rel-L2 ceiling: cosine alone is
+        # scale-invariant and would miss a constant-factor gradient scale bug.
+        assert_close(
+            self,
+            "fa4_dense_dq",
+            qf.grad,
+            qr.grad,
+            min_cos=0.99,
+            max_rel_l2=6e-3,
+        )
+        assert_close(
+            self,
+            "fa4_dense_dk",
+            kf.grad,
+            kr.grad,
+            min_cos=0.99,
+            max_rel_l2=6e-3,
+        )
+        assert_close(
+            self,
+            "fa4_dense_dv",
+            vf.grad,
+            vr.grad,
+            min_cos=0.99,
+            max_rel_l2=6e-3,
+        )
 
     def test_default_sm_scale(self):
         _sm100_or_skip(self)
@@ -196,7 +219,17 @@ class TestBlockScoreFA4Backward(unittest.TestCase):
             q, k, v, sm_scale=d**-0.5, block_B=64, causal=True
         )
         self.assertEqual(list(out_default.shape), [b, s, h, d])
-        self.assertGreater(_cos(out_default, out_explicit), 0.999)
+        # Kernel-vs-kernel: default sm_scale must reproduce the explicit one.
+        # Guard magnitude too so a scale drift between the two paths can't hide
+        # behind a scale-invariant cosine.
+        assert_close(
+            self,
+            "default_sm_scale_out",
+            out_default,
+            out_explicit,
+            min_cos=0.999,
+            max_rel_l2=1e-3,
+        )
 
     def test_packed_multidoc_backward(self):
         # Packed [40, 88, 133, 27] documents (all unaligned to block_B) with a
@@ -246,9 +279,30 @@ class TestBlockScoreFA4Backward(unittest.TestCase):
         ref = _ref_packed_attn(qr, kr, vr, mask, sm_scale)
         ref.backward(g.astype("float32"))
 
-        assert_close(self, "fa4_packed_dq", qf.grad, qr.grad, min_cos=0.99)
-        assert_close(self, "fa4_packed_dk", kf.grad, kr.grad, min_cos=0.99)
-        assert_close(self, "fa4_packed_dv", vf.grad, vr.grad, min_cos=0.99)
+        assert_close(
+            self,
+            "fa4_packed_dq",
+            qf.grad,
+            qr.grad,
+            min_cos=0.99,
+            max_rel_l2=6e-3,
+        )
+        assert_close(
+            self,
+            "fa4_packed_dk",
+            kf.grad,
+            kr.grad,
+            min_cos=0.99,
+            max_rel_l2=6e-3,
+        )
+        assert_close(
+            self,
+            "fa4_packed_dv",
+            vf.grad,
+            vr.grad,
+            min_cos=0.99,
+            max_rel_l2=6e-3,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/single_card_tests/custom_ops/test_hysparse_mqa_gather_dsa.py
+++ b/tests/single_card_tests/custom_ops/test_hysparse_mqa_gather_dsa.py
@@ -139,15 +139,6 @@ def _causal_valid_range(b, s):
     return paddle.concat([bos, eos], axis=-1).contiguous()
 
 
-def _cos(a, b):
-    import numpy as np
-
-    af = a.astype("float32").numpy().reshape(-1)
-    bf = b.astype("float32").numpy().reshape(-1)
-    denom = (np.linalg.norm(af) * np.linalg.norm(bf)) + 1e-12
-    return float(np.dot(af, bf) / denom)
-
-
 def _select_blocks(b, s, block_B, topk):
     """Per-token relative block ids: block 0 plus the running block (pos//BB),
     padded with -1 to width ``topk``."""
@@ -215,9 +206,16 @@ class TestBlockSparseDSA(unittest.TestCase):
         out_dsa, dq_dsa, dkv_dsa = self._run_dsa(q, kf, idx, vr, sm)
         out_ref, dq_ref, dkv_ref = self._run_ref(q, kf, idx, vr, sm)
         self.assertEqual(list(out_dsa.shape), [b, s, h * self.Dv])
-        self.assertGreater(_cos(out_dsa, out_ref), 0.99)
-        self.assertGreater(_cos(dq_dsa, dq_ref), 0.99)
-        self.assertGreater(_cos(dkv_dsa, dkv_ref), 0.99)
+        # Cosine AND magnitude-sensitive rel-L2 (cosine alone is scale-blind).
+        assert_close(
+            self, "dsa_h4:out", out_dsa, out_ref, min_cos=0.99, max_rel_l2=4e-3
+        )
+        assert_close(
+            self, "dsa_h4:dq", dq_dsa, dq_ref, min_cos=0.99, max_rel_l2=5e-3
+        )
+        assert_close(
+            self, "dsa_h4:dkv", dkv_dsa, dkv_ref, min_cos=0.99, max_rel_l2=4e-3
+        )
 
     def test_dsa_vs_dense_reference_h64(self):
         _skip_if_no_dsa(self)
@@ -225,9 +223,20 @@ class TestBlockSparseDSA(unittest.TestCase):
         q, kf, vr, idx, sm = self._make(b, s, h, topk, seed=13)
         out_dsa, dq_dsa, dkv_dsa = self._run_dsa(q, kf, idx, vr, sm)
         out_ref, dq_ref, dkv_ref = self._run_ref(q, kf, idx, vr, sm)
-        self.assertGreater(_cos(out_dsa, out_ref), 0.99)
-        self.assertGreater(_cos(dq_dsa, dq_ref), 0.99)
-        self.assertGreater(_cos(dkv_dsa, dkv_ref), 0.99)
+        assert_close(
+            self, "dsa_h64:out", out_dsa, out_ref, min_cos=0.99, max_rel_l2=4e-3
+        )
+        assert_close(
+            self, "dsa_h64:dq", dq_dsa, dq_ref, min_cos=0.99, max_rel_l2=5e-3
+        )
+        assert_close(
+            self,
+            "dsa_h64:dkv",
+            dkv_dsa,
+            dkv_ref,
+            min_cos=0.99,
+            max_rel_l2=4e-3,
+        )
 
     def test_learnable_sink_matches_reference(self):
         # A finite learnable per-head sink: DSA forward + dq/dkv/d_sink grads
@@ -272,10 +281,31 @@ class TestBlockSparseDSA(unittest.TestCase):
         out_ref = out_ref.reshape([b, s, h * self.Dv])
         out_ref.sum().backward()
 
-        self.assertGreater(_cos(out_dsa, out_ref), 0.99)
+        assert_close(
+            self,
+            "dsa_sink:out",
+            out_dsa,
+            out_ref,
+            min_cos=0.99,
+            max_rel_l2=1.2e-1,
+        )
         self.assertIsNotNone(sink_d.grad)
-        self.assertGreater(_cos(qd.grad, qr.grad), 0.99)
-        self.assertGreater(_cos(sink_d.grad, sink_r.grad), 0.99)
+        assert_close(
+            self,
+            "dsa_sink:dq",
+            qd.grad,
+            qr.grad,
+            min_cos=0.99,
+            max_rel_l2=1e-1,
+        )
+        assert_close(
+            self,
+            "dsa_sink:dsink",
+            sink_d.grad,
+            sink_r.grad,
+            min_cos=0.99,
+            max_rel_l2=3e-1,
+        )
 
     def test_neg_sink_matches_sinkless(self):
         # Sinkless (attn_sink=None) must match a very-negative explicit sink:
@@ -305,7 +335,16 @@ class TestBlockSparseDSA(unittest.TestCase):
             kv_lora_rank=self.Dv,
             attn_sink=neg_sink,
         )
-        self.assertGreater(_cos(out_none, out_neg), 0.999999)
+        # Sinkless vs disabled sink must be bit-for-bit equivalent: enforce a
+        # tight magnitude ceiling alongside the near-exact cosine floor.
+        assert_close(
+            self,
+            "dsa_neg_sink_vs_sinkless:out",
+            out_none,
+            out_neg,
+            min_cos=0.999999,
+            max_rel_l2=1e-3,
+        )
 
 
 class TestBlockSparseDSAPackedMultiDoc(unittest.TestCase):
@@ -397,9 +436,15 @@ class TestBlockSparseDSAPackedMultiDoc(unittest.TestCase):
         self.assertGreater(int(vr[0, :, 0].max()), 0)  # nonzero bos present
         out_d, dq_d, dkv_d, _ = self._run_dsa(q, kf, idx, vr, sm)
         out_r, dq_r, dkv_r, _ = self._run_ref(q, kf, idx, vr, sm)
-        assert_close(self, "dsa_packed_out", out_d, out_r, min_cos=0.99)
-        assert_close(self, "dsa_packed_dq", dq_d, dq_r, min_cos=0.99)
-        assert_close(self, "dsa_packed_dkv", dkv_d, dkv_r, min_cos=0.99)
+        assert_close(
+            self, "dsa_packed_out", out_d, out_r, min_cos=0.99, max_rel_l2=4e-3
+        )
+        assert_close(
+            self, "dsa_packed_dq", dq_d, dq_r, min_cos=0.99, max_rel_l2=5e-3
+        )
+        assert_close(
+            self, "dsa_packed_dkv", dkv_d, dkv_r, min_cos=0.99, max_rel_l2=4e-3
+        )
 
     def test_packed_backward_finite_sink(self):
         # REGRESSION for the DSA finite-sink dQ fix. Before the fix, a finite
@@ -423,11 +468,39 @@ class TestBlockSparseDSAPackedMultiDoc(unittest.TestCase):
         sink = paddle.randn([h], dtype="float32") * 0.5
         out_d, dq_d, dkv_d, ds_d = self._run_dsa(q, kf, idx, vr, sm, sink=sink)
         out_r, dq_r, dkv_r, ds_r = self._run_ref(q, kf, idx, vr, sm, sink=sink)
-        assert_close(self, "dsa_packed_sink_out", out_d, out_r, min_cos=0.99)
-        assert_close(self, "dsa_packed_sink_dq", dq_d, dq_r, min_cos=0.99)
-        assert_close(self, "dsa_packed_sink_dkv", dkv_d, dkv_r, min_cos=0.99)
+        assert_close(
+            self,
+            "dsa_packed_sink_out",
+            out_d,
+            out_r,
+            min_cos=0.99,
+            max_rel_l2=4e-3,
+        )
+        assert_close(
+            self,
+            "dsa_packed_sink_dq",
+            dq_d,
+            dq_r,
+            min_cos=0.99,
+            max_rel_l2=5e-3,
+        )
+        assert_close(
+            self,
+            "dsa_packed_sink_dkv",
+            dkv_d,
+            dkv_r,
+            min_cos=0.99,
+            max_rel_l2=4e-3,
+        )
         self.assertIsNotNone(ds_d)
-        assert_close(self, "dsa_packed_sink_dsink", ds_d, ds_r, min_cos=0.99)
+        assert_close(
+            self,
+            "dsa_packed_sink_dsink",
+            ds_d,
+            ds_r,
+            min_cos=0.99,
+            max_rel_l2=5e-4,
+        )
 
     def test_packed_vs_solo_dq_equivalence(self):
         # A document run alone (bos=0) and the SAME document packed behind an
@@ -473,7 +546,12 @@ class TestBlockSparseDSAPackedMultiDoc(unittest.TestCase):
 
         dq_pack_doc = dq_pack[:, prefix_len:, :, :]
         assert_close(
-            self, "dsa_pack_vs_solo_dq", dq_pack_doc, dq_solo, min_cos=0.99
+            self,
+            "dsa_pack_vs_solo_dq",
+            dq_pack_doc,
+            dq_solo,
+            min_cos=0.99,
+            max_rel_l2=1e-3,
         )
 
 

--- a/tests/single_card_tests/custom_ops/test_hysparse_windowed_swa.py
+++ b/tests/single_card_tests/custom_ops/test_hysparse_windowed_swa.py
@@ -155,7 +155,7 @@ class TestWindowedMQAForward(unittest.TestCase):
         ref = _ref_masked_attn(q, k, v, allow, sm_scale)
         self.assertEqual(list(out.shape), [b, s, h, dv])
         self.assertEqual(list(lse.shape), [b, s, h])
-        self.assertGreater(_cos(out, ref), 0.995)
+        assert_close(self, "out", out, ref, min_cos=0.995, max_rel_l2=6e-2)
 
     def test_sliding_window_matches_dense(self):
         _skip_if_no_cuda(self)
@@ -177,7 +177,7 @@ class TestWindowedMQAForward(unittest.TestCase):
         )
         allow = _window_allow_mask(vr, s_kv)
         ref = _ref_masked_attn(q, k, v, allow, sm_scale)
-        self.assertGreater(_cos(out, ref), 0.995)
+        assert_close(self, "out", out, ref, min_cos=0.995, max_rel_l2=6e-2)
 
     def test_asymmetric_dk_dv(self):
         # absorbed-MLA-like head: D (key/query) != D_v (value). D=128, D_v=64.
@@ -201,7 +201,7 @@ class TestWindowedMQAForward(unittest.TestCase):
         allow = _window_allow_mask(vr, s_kv)
         ref = _ref_masked_attn(q, k, v, allow, sm_scale)
         self.assertEqual(list(out.shape), [b, s, h, dv])
-        self.assertGreater(_cos(out, ref), 0.995)
+        assert_close(self, "out", out, ref, min_cos=0.995, max_rel_l2=6e-2)
 
 
 class TestSlidingWindowWrapper(unittest.TestCase):
@@ -240,9 +240,15 @@ class TestSlidingWindowWrapper(unittest.TestCase):
         ref = _ref_masked_attn(qr, kr, vr_, allow, sm_scale)
         ref.backward(g.astype("float32"))
 
-        self.assertGreater(_cos(qk.grad, qr.grad), 0.99)
-        self.assertGreater(_cos(kk.grad, kr.grad), 0.99)
-        self.assertGreater(_cos(vk.grad, vr_.grad), 0.99)
+        assert_close(
+            self, "dQ", qk.grad, qr.grad, min_cos=0.99, max_rel_l2=7e-2
+        )
+        assert_close(
+            self, "dK", kk.grad, kr.grad, min_cos=0.99, max_rel_l2=1.3e-1
+        )
+        assert_close(
+            self, "dV", vk.grad, vr_.grad, min_cos=0.99, max_rel_l2=1.3e-1
+        )
 
     def test_grads_ragged_seqlen(self):
         # Regression for the windowed-bwd out-of-bounds guard: when
@@ -290,9 +296,15 @@ class TestSlidingWindowWrapper(unittest.TestCase):
                 np.isfinite(got.astype("float32").numpy()).all(),
                 f"{name} has non-finite entries (OOB read?)",
             )
-        self.assertGreater(_cos(qk.grad, qr.grad), 0.99)
-        self.assertGreater(_cos(kk.grad, kr.grad), 0.99)
-        self.assertGreater(_cos(vk.grad, vr_.grad), 0.99)
+        assert_close(
+            self, "dQ", qk.grad, qr.grad, min_cos=0.99, max_rel_l2=7e-2
+        )
+        assert_close(
+            self, "dK", kk.grad, kr.grad, min_cos=0.99, max_rel_l2=1.3e-1
+        )
+        assert_close(
+            self, "dV", vk.grad, vr_.grad, min_cos=0.99, max_rel_l2=1.3e-1
+        )
 
     def test_wrapper_default_sm_scale(self):
         _skip_if_no_cuda(self)
@@ -390,7 +402,7 @@ class TestWindowedMQAAttnSink(unittest.TestCase):
         )
         allow = _window_allow_mask(vr, s_kv)
         ref = _ref_masked_attn(q, k, v, allow, sm_scale, attn_sink=attn_sink)
-        self.assertGreater(_cos(out, ref), 0.99)
+        assert_close(self, "out", out, ref, min_cos=0.99, max_rel_l2=6e-2)
 
     def test_sink_grad_matches_reference(self):
         # d(attn_sink) from the fused backward must match autograd on the dense
@@ -435,8 +447,17 @@ class TestWindowedMQAAttnSink(unittest.TestCase):
         ref.backward(g.astype("float32"))
 
         self.assertIsNotNone(sink_k.grad)
-        self.assertGreater(_cos(qk.grad, qr.grad), 0.99)
-        self.assertGreater(_cos(sink_k.grad, sink_r.grad), 0.99)
+        assert_close(
+            self, "dQ", qk.grad, qr.grad, min_cos=0.99, max_rel_l2=7e-2
+        )
+        assert_close(
+            self,
+            "dSink",
+            sink_k.grad,
+            sink_r.grad,
+            min_cos=0.99,
+            max_rel_l2=8e-2,
+        )
 
 
 class TestPackedMultiDocBackward(unittest.TestCase):
@@ -502,13 +523,26 @@ class TestPackedMultiDocBackward(unittest.TestCase):
         ref = _ref_masked_attn(qr, kr, vr_, allow, sm_scale, attn_sink=sink_r)
         ref.backward(g.astype("float32"))
 
-        assert_close(self, "out", out, ref, min_cos=0.99)
-        assert_close(self, "dQ", qk.grad, qr.grad, min_cos=0.99)
-        assert_close(self, "dK", kk.grad, kr.grad, min_cos=0.99)
-        assert_close(self, "dV", vk.grad, vr_.grad, min_cos=0.99)
+        assert_close(self, "out", out, ref, min_cos=0.99, max_rel_l2=6e-2)
+        assert_close(
+            self, "dQ", qk.grad, qr.grad, min_cos=0.99, max_rel_l2=7e-2
+        )
+        assert_close(
+            self, "dK", kk.grad, kr.grad, min_cos=0.99, max_rel_l2=1.3e-1
+        )
+        assert_close(
+            self, "dV", vk.grad, vr_.grad, min_cos=0.99, max_rel_l2=1.3e-1
+        )
         if sink_k is not None:
             self.assertIsNotNone(sink_k.grad)
-            assert_close(self, "dSink", sink_k.grad, sink_r.grad, min_cos=0.99)
+            assert_close(
+                self,
+                "dSink",
+                sink_k.grad,
+                sink_r.grad,
+                min_cos=0.99,
+                max_rel_l2=8e-2,
+            )
 
     def test_packed_multidoc_backward_sinkless(self):
         _skip_if_no_cuda(self)


### PR DESCRIPTION
### PR Category

Operator Mechanism

### PR Types

Bug fixes

### Description

**Bug.** `windowed_mqa_bwd` (TileLang windowed-MQA backward) finalized the
per-head attention-sink gradient with a **bare**
`T.atomic_add(dAttnSink[bh], sink_acc[0])`. `T.reduce_sum` broadcasts the
reduced scalar to **every thread** in the block, so the un-guarded atomic
committed that same value on all `threads` lanes. `dAttnSink` was therefore
inflated by exactly the block thread count (**128x**, invariant to window
size / seq len / heads / block_B). Cosine similarity is scale-invariant, so
the existing cos-only test assertions (`min_cos=0.99`) were blind to this
constant-factor error and it went undetected.

**Fix.** Guard the once-per-`(bm,bh,bb)` global commit to a single lane,
using the same `T.Parallel + if i == 0` idiom already used in
`block_score_mha.py`:

```python
T.reduce_sum(sink_contrib, sink_acc, dim=0, clear=True)
for i in T.Parallel(BM):
    if i == 0:
        T.atomic_add(dAttnSink[bh], sink_acc[0])
```

**Verification.**
- `dAttnSink` vs an fp32 finite-difference reference: ~128x to ~1.0 (0.997 / 1.001 for H=4 / H=8).
- fwd / dQ / dK / dV unchanged.
- `tests/single_card_tests/custom_ops/test_hysparse_windowed_swa.py`: 11 passed.

**Test hardening (same PR).** Because cosine hid the bug, every cos-only
HySparse precision assertion is additionally guarded with a
magnitude-sensitive relative-Frobenius ceiling (`max_rel_l2`), following the
`test_hysparse_ft_bridge_corner` style. All `dsink` assertions are now
magnitude-guarded. Files: windowed_swa, fa4_grad, block_score_mha_dense_ref,
mqa_gather_dsa, dsa_pad_to_512, csa_sparse_attn_backends.
