### PR TITLE
[release/0.4] skip cudnn indexer test for python < 3.12

### DIFF
--- a/tests/single_card_tests/transformer/test_dsv4_hybrid_attention.py
+++ b/tests/single_card_tests/transformer/test_dsv4_hybrid_attention.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 import unittest
 from unittest.mock import patch
 
@@ -1158,6 +1159,9 @@ class TestDSv4HybridDocumentRoPE(unittest.TestCase):
         self.assertGreaterEqual(mocked.call_count, 1)
         self.assertEqual(mocked.call_args_list[0].args[0], 1)
 
+    @unittest.skipIf(
+        sys.version_info < (3, 12), "cuDNN indexer requires Python >= 3.12"
+    )
     def test_cudnn_indexer_document_mask_matches_separate_documents(self):
         """Main-path integration: csa_indexer_backend='cudnn' packed-vs-separate.
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
skip cudnn indexer test for python < 3.12

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否

Cherry-pick of #1498 to `release/0.4`.

Merged in dev: #1498  <!-- For pass CI -->