### PR TITLE
[release/0.4][DSv4 CSA] Optimize docmask with efficient metadata and triton fusion 

### DIFF
--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -327,7 +327,50 @@ def get_cutoff_doc_starts(cutoff_doc_lens: Tensor) -> Tensor:
 
 @dataclass
 class CSADocMaskMetadata:
-    """Reusable CSA metadata derived from ``startend_row_indices``."""
+    """
+    Reusable CSA metadata derived from `startend_row_indices`.
+
+    假设输入 seqlen=32，其中每个文本的 doc_lens=[5, 14, 3, 8]，最后还有 padding=2
+
+    则非压缩相关的信息如下，注意所有列表的长度都是32：
+    start_end_row_indices: [5 ... 5, 19  ... 19, 22 ... 22, 30 ... 30, 30, 30 ]
+    doc_start_per_pos:     [0 ... 0,  5  ...  5, 19 ... 19, 22 ... 22, 22, 22 ]
+    doc_len_per_pos:       [5 ... 5, 14  ... 14,  3 ...  3,  8 ...  8,  8,  8 ]
+    pos_in_doc:            [0 ... 4,  0  ... 13,  0 ...  2,  0 ...  7,  8,  9 ]
+    is_valid:              [T ... T,  T  ...  T,  T ...  T,  T ...  T,  F,  F ]
+                            {- 5 -}  {-- 14 --}  {-- 3 --}  {-- 8 --}  {- 2 -}
+    说明：
+    * padding 在 start_end_row_indices 中用前一个 doc 的末尾数字或对角线的值表示
+    * 其他变量中 padding 部分相当于自然接续前一个 doc，但实际上对梯度无贡献
+
+    假设压缩 ratio=4，则压缩前的相关信息如下，注意最后填充-1使得列表长度依然为32：
+    n_compressed:          seqlen // ratio = 8
+    actual_n_compressed:   sum(n // ratio for n in doc_lens) = 6
+    cutoff_gather_indices: [0 ... 3,  5  ... 16,   ...  , 22 ... 29, -1 ... -1]
+    cutoff_pos_in_doc:     [0 ... 3,  0  ... 11,   ...  ,  0 ...  7, -1 ... -1]
+                            {- 4 -}  {-- 12 --}  {- 0 -}  {-- 8 --}  {-- 8 --}
+
+    针对压缩变量的信息，长度为 n_compressed=8，最后无效部分填充 False 或-1：
+    compressed_is_first:   [ T,  T,  F,  F,  T,  F,  F,  F]
+    compressed_pos_in_doc: [ 0,  0,  4,  8,  0,  4, -1, -1]
+
+    其他变量：
+    每个位置所属 doc 的首个压缩 kv 槽的全局下标，最后 padding 自然接续，总长度32：
+    compressed_doc_start_per_pos: [0 ... 0,  1 ... 1, 4 ... 4, 4 ... 4,  4,  4 ]
+                                   {- 5 -}  {- 14 -}  {- 3 -}  {- 8 -}  {- 2 -}
+
+    window_topk_idxs: shape=[1, seqlen, window_size]
+    * idxs[0, i] 表示每个 q[i] 可以看见的 kv 的下标，升序排列，但-1在最后
+    * “看见”当且仅当两者属于同一个 doc、且满足因果律、且在 window_size 范围内、且 q[i] 有效
+
+    compress_topk_idxs: shape=[1, seqlen, n_compressed]
+    * idxs[0, i, j] = j 当且仅当 q[i] 可以看见 compressed_kv[j]，否则为-1
+    * “看见”当且仅当同 doc、且 compressed_kv[j] 包含的 token 均不晚于 q[i]、且 q[i] 有效
+      (也就是说，q[i] 要么完全在 compressed_kv[j] 之后，要么恰好是其最后一个 token)
+    * 另外，支持 offset 参数，即给 idxs 中所有非-1的数统一加上 offset
+
+    TODO(liangshuhao): 当前为了和原有流程兼容，压缩相关变量均截去了padding，后续会统一保留
+    """
 
     startend_row_indices: Tensor
     ratio: int
@@ -339,6 +382,11 @@ class CSADocMaskMetadata:
     doc_start_per_pos: Tensor
     doc_len_per_pos: Tensor
     is_valid: Tensor
+    pos_in_doc: Tensor
+    cutoff_gather_indices: Tensor
+    cutoff_pos_in_doc: Tensor
+    compressed_is_first: Tensor
+    compressed_pos_in_doc: Tensor
     _doc_lens_cutoff: Tensor | None = None
     _doc_lens_list: list[int] | None = None
     _doc_starts_cutoff: Tensor | None = None
@@ -359,6 +407,7 @@ class CSADocMaskMetadata:
         seqlen: int,
         startend_row_indices: Tensor | None,
         n_compressed: int | None = None,
+        dense_mode: bool = False,
     ) -> CSADocMaskMetadata | None:
         """Build metadata from ``startend_row_indices``.
 
@@ -373,6 +422,7 @@ class CSADocMaskMetadata:
                 mode (returns ``None``).
             n_compressed: optional override for ``seqlen // ratio``; used when
                 the caller already knows the compressed slot count.
+            dense_mode: whether it is in dense mode (no indexer).
 
         Returns:
             A populated :class:`CSADocMaskMetadata`, or ``None`` when
@@ -380,18 +430,51 @@ class CSADocMaskMetadata:
         """
         if startend_row_indices is None:
             return None
+
+        from paddlefleet.triton_ops.document_mask_fusion import (
+            cutoff_compact_triton,
+            document_mask_triton,
+        )
+
         ratio, batch_size, seqlen, n_compressed = _normalize_csa_docmask_args(
             ratio, batch_size, seqlen, n_compressed
         )
         _validate_csa_docmask_shape(startend_row_indices, batch_size, seqlen)
 
+        # Generate general metadata
+        doc_start_per_pos, doc_len_per_pos, pos_in_doc = document_mask_triton(
+            startend_row_indices.flatten()
+        )
         (
-            doc_start_per_pos,
-            doc_len_per_pos,
-            is_valid,
-            doc_lens,
-            doc_starts,
-        ) = _derive_csa_doc_boundaries(startend_row_indices, seqlen)
+            cutoff_gather_indices,
+            cutoff_pos_in_doc,
+            n_cutoff,
+            compressed_is_first,
+            compressed_pos_in_doc,
+        ) = cutoff_compact_triton(pos_in_doc, doc_len_per_pos, ratio)
+
+        n_cutoff = n_cutoff.item()
+        assert n_cutoff % ratio == 0, (
+            "seqlen after cutoff should be divisible by ratio, "
+            f"got {n_cutoff} and {ratio}."
+        )
+        actual_n_compressed = n_cutoff // ratio
+        cutoff_gather_indices = cutoff_gather_indices[:n_cutoff]
+        cutoff_pos_in_doc = cutoff_pos_in_doc[:n_cutoff]
+        compressed_is_first = compressed_is_first[:actual_n_compressed]
+        compressed_pos_in_doc = compressed_pos_in_doc[:actual_n_compressed]
+
+        # Generate metadata for indexer only
+        if ratio > 1 and not dense_mode:
+            (
+                doc_start_per_pos,
+                doc_len_per_pos,
+                is_valid,
+                doc_lens,
+                doc_starts,
+            ) = _derive_csa_doc_boundaries(startend_row_indices, seqlen)
+        else:
+            is_valid = doc_lens = doc_starts = None
 
         return cls(
             startend_row_indices=startend_row_indices,
@@ -404,6 +487,12 @@ class CSADocMaskMetadata:
             doc_start_per_pos=doc_start_per_pos,
             doc_len_per_pos=doc_len_per_pos,
             is_valid=is_valid,
+            pos_in_doc=pos_in_doc,
+            cutoff_gather_indices=cutoff_gather_indices,
+            cutoff_pos_in_doc=cutoff_pos_in_doc,
+            compressed_is_first=compressed_is_first,
+            compressed_pos_in_doc=compressed_pos_in_doc,
+            _actual_n_compressed=actual_n_compressed,
         )
 
     @property
@@ -470,12 +559,12 @@ class CSADocMaskMetadata:
             and self._window_size == window_size
         )
         if not cache_hit:
-            self._window_topk_idxs = _build_window_topk_idxs_from_doc_bounds(
-                self.batch_size,
-                self.seqlen,
-                window_size,
-                self.doc_start_per_pos,
-                self.is_valid,
+            from paddlefleet.triton_ops.document_mask_fusion import (
+                window_topk_idxs_triton,
+            )
+
+            self._window_topk_idxs = window_topk_idxs_triton(
+                self.doc_start_per_pos, self.doc_len_per_pos, window_size
             )
             self._window_size = window_size
         return self._window_topk_idxs
@@ -493,14 +582,22 @@ class CSADocMaskMetadata:
             and self._compress_offset == offset
         )
         if not cache_hit:
-            self._compress_topk_idxs = (
-                _build_compress_topk_idxs_from_valid_range(
-                    self.batch_size,
-                    self.seqlen,
-                    self.n_compressed,
-                    offset,
-                    self.valid_range,
-                )
+            from paddlefleet.triton_ops.document_mask_fusion import (
+                compressed_doc_start_triton,
+                compressed_topk_idxs_triton,
+            )
+
+            compressed_doc_start_per_pos = compressed_doc_start_triton(
+                self.startend_row_indices.flatten(),
+                self.doc_start_per_pos,
+                self.ratio,
+            )
+            self._compress_topk_idxs = compressed_topk_idxs_triton(
+                compressed_doc_start_per_pos,
+                self.pos_in_doc,
+                self.doc_len_per_pos,
+                self.ratio,
+                offset,
             )
             self._compress_offset = offset
         return self._compress_topk_idxs
@@ -736,6 +833,7 @@ def _apply_rope(
     ratio: int = 1,
     doc_lens_cutoff: Tensor | None = None,  # for token compressed, such as kv
     doc_lens: Tensor | None = None,  # for token not compressed, such as q
+    compressed_pos_in_doc: Tensor | None = None,  # for token compressed
     position_offset: int = 0,
     high_precision_rope: bool = False,
 ) -> Tensor:
@@ -829,6 +927,16 @@ def _apply_rope(
                 axis=1,
             )
         freqs = freqs[:, position_offset:needed_len, :, :]
+    elif compressed_pos_in_doc is not None:
+        freqs = paddle.gather(freqs, compressed_pos_in_doc, axis=1)
+        if freqs.shape[1] < rotary_seq_len:
+            freqs = paddle.nn.functional.pad(
+                freqs,
+                pad=[0, 0, 0, 0, 0, rotary_seq_len - freqs.shape[1]],
+                mode="constant",
+                value=0.0,
+            )
+        freqs = freqs[:, :rotary_seq_len]
     elif ratio > 1:  # CP without document mask -> KV
         freqs = freqs[:, position_offset * ratio : total_seq_len : ratio, :][
             :, :rotary_seq_len, :
@@ -1410,28 +1518,13 @@ class Compressor(nn.Layer):
         # Shared compression logic for both CP and non-CP paths.
         if docmask_meta is not None:
             # per-document cutoff, pack contiguously without padding
-            doc_lens = docmask_meta.doc_lens
-            doc_starts = docmask_meta.doc_starts
-            doc_lens_cutoff = docmask_meta.doc_lens_cutoff
-            doc_starts_cutoff = docmask_meta.doc_starts_cutoff
-
-            assert len(doc_lens) == len(doc_starts)
-            assert len(doc_lens) == len(doc_lens_cutoff)
-            assert len(doc_lens) == len(doc_starts_cutoff)
-
             n_compressed = sq // ratio
             actual_n_compressed = docmask_meta.actual_n_compressed
-            total_cutoff = actual_n_compressed * ratio
+            cutoff_gather_indices = docmask_meta.cutoff_gather_indices
 
             # Pack only valid cutoff data contiguously (no padding)
-            kv, score = compact_kv_score_cutoff(
-                doc_starts,
-                doc_lens_cutoff,
-                doc_starts_cutoff,
-                total_cutoff,
-                kv,
-                score,
-            )
+            kv = paddle.gather(kv, cutoff_gather_indices, axis=1)
+            score = paddle.gather(score, cutoff_gather_indices, axis=1)
 
             # Reshape: [b, actual_n_compressed, ratio, coff * head_dim]
             kv = kv.reshape([b, actual_n_compressed, ratio, -1])
@@ -1443,7 +1536,7 @@ class Compressor(nn.Layer):
             score = score + ape
 
             if self.overlap:
-                is_first = docmask_meta.get_is_first_compressed_group()
+                is_first = docmask_meta.compressed_is_first
                 kv = self._overlap_transform(
                     kv, fill_value=0, is_first=is_first
                 )
@@ -1488,7 +1581,7 @@ class Compressor(nn.Layer):
                     self.config,
                     n_compressed,
                     ratio=ratio,
-                    doc_lens_cutoff=doc_lens_cutoff,
+                    compressed_pos_in_doc=docmask_meta.compressed_pos_in_doc,
                     high_precision_rope=self.high_precision_rope,
                 )
 
@@ -2134,7 +2227,7 @@ class CompressedSparseAttention(FleetLayer):
             )
 
         # Compute loss_mask from input_ids (mask out padding tokens)
-        if input_ids is not None:
+        if input_ids is not None and self.indexer is not None:
             if (
                 get_context_parallel_world_size() > 1
                 and not self.config.experimental_dataflow

--- a/src/paddlefleet/transformer/dsv4_hybrid_attention.py
+++ b/src/paddlefleet/transformer/dsv4_hybrid_attention.py
@@ -137,12 +137,12 @@ def _build_rope_freqs(
     startend_row_indices: Tensor | None = None,
 ):
     if docmask_meta is not None:
-        freqs, mscale = build_document_rope_freqs(
-            rotary_pos_emb,
-            sq,
-            position_offset=position_offset,
-            doc_lens=docmask_meta.doc_lens,
-        )
+        _rope_result = rotary_pos_emb(docmask_meta.seqlen, packed_seq=False)
+        if isinstance(_rope_result, tuple):
+            freqs, mscale = _rope_result
+        else:
+            freqs, mscale = _rope_result, 1.0
+        freqs = paddle.gather(freqs, docmask_meta.pos_in_doc, axis=1)
     elif startend_row_indices is not None:
         freqs, mscale = build_document_rope_freqs(
             rotary_pos_emb,
@@ -351,6 +351,7 @@ class DSv4HybridAttention(Attention):
                 b,
                 docmask_seqlen,
                 startend_row_indices,
+                dense_mode=self.config.csa_dense_mode,
             )
 
         query, key, value, q_compressed, kv_compressed = (

--- a/src/paddlefleet/triton_ops/document_mask_fusion.py
+++ b/src/paddlefleet/triton_ops/document_mask_fusion.py
@@ -1,0 +1,646 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Triton document-mask forward kernel.
+"""
+
+import paddle
+from paddle import Tensor
+
+from .utils import is_torch_compat_available
+
+if is_torch_compat_available():
+    paddle.enable_compat(scope={"triton"})
+
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _max_combine(a, b):
+    """Associative combine op for cumulative max."""
+    return tl.maximum(a, b)
+
+
+@triton.jit
+def document_mask_fwd_kernel(
+    End_ptr,  # start_end_row_indices [seq_len], exclusive end per position
+    DocStart_ptr,  # output doc_start_per_pos [seq_len]
+    DocLen_ptr,  # output doc_len_per_pos [seq_len]
+    PosInDoc_ptr,  # output pos_in_doc [seq_len]
+    seq_len,
+    BLOCK_N: tl.constexpr,  # power of 2 block along seq_len
+):
+    """Single program, streams the 1-D row in BLOCK_N chunks."""
+    # running doc-start carried across blocks; real starts are >= 0, so -1 is a
+    # safe "-inf" for the cumulative max.
+    running_start = tl.full((), -1, tl.int32)
+
+    for start in range(0, seq_len, BLOCK_N):
+        cols = start + tl.arange(0, BLOCK_N)
+        mask = cols < seq_len
+
+        end = tl.load(End_ptr + cols, mask=mask, other=0).to(tl.int32)
+
+        # previous position's end value; read straight from global memory so the
+        # first lane of each block correctly picks up the previous block's tail.
+        prev_cols = cols - 1
+        prev_mask = (prev_cols >= 0) & mask
+        end_prev = tl.load(End_ptr + prev_cols, mask=prev_mask, other=-1).to(
+            tl.int32
+        )
+
+        # a document boundary starts wherever the end value changes; position 0
+        # (end_prev == -1) is always a boundary.
+        is_boundary = end != end_prev
+
+        # candidate start = this column index at a boundary, else -1; masked
+        # lanes are also -1 so they never win the cumulative max.
+        cand = tl.where(is_boundary & mask, cols.to(tl.int32), -1)
+
+        # inclusive cumulative max within the block, then fold in prior blocks.
+        cm = tl.associative_scan(cand, 0, _max_combine)
+        doc_start = tl.maximum(cm, running_start)
+
+        pos_in_doc = cols.to(tl.int32) - doc_start
+        doc_len = end - doc_start
+
+        tl.store(
+            DocStart_ptr + cols,
+            doc_start.to(DocStart_ptr.dtype.element_ty),
+            mask=mask,
+        )
+        tl.store(
+            DocLen_ptr + cols,
+            doc_len.to(DocLen_ptr.dtype.element_ty),
+            mask=mask,
+        )
+        tl.store(
+            PosInDoc_ptr + cols,
+            pos_in_doc.to(PosInDoc_ptr.dtype.element_ty),
+            mask=mask,
+        )
+
+        # carry the largest doc-start seen so far into the next block.
+        running_start = tl.max(doc_start, axis=0)
+
+
+def document_mask_triton(start_end_row_indices: Tensor):
+    """Compute (doc_start_per_pos, doc_len_per_pos, pos_in_doc) for a 1-D input.
+
+    Args:
+        start_end_row_indices: 1-D tensor [seq_len]; each entry is the exclusive
+            end index of the document that position belongs to (non-decreasing).
+
+    Returns:
+        tuple of three int64 tensors, each of shape [seq_len].
+    """
+    assert start_end_row_indices.ndim == 1, "expect 1-D input [seq_len]"
+
+    x = start_end_row_indices.astype("int32")
+    if not x.is_contiguous():
+        x = x.contiguous()
+
+    (seq_len,) = x.shape
+    doc_start = paddle.empty([seq_len], dtype="int64")
+    doc_len = paddle.empty([seq_len], dtype="int64")
+    pos_in_doc = paddle.empty([seq_len], dtype="int64")
+
+    BLOCK_N = 4096
+    grid = (1,)
+    document_mask_fwd_kernel[grid](
+        x,
+        doc_start,
+        doc_len,
+        pos_in_doc,
+        seq_len,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+    )
+    return doc_start, doc_len, pos_in_doc
+
+
+@triton.jit
+def cutoff_compact_kernel(
+    PosInDoc_ptr,  # pos_in_doc [seq_len]
+    DocLen_ptr,  # doc_len_per_pos [seq_len]
+    GatherIdx_ptr,  # output cutoff_gather_indices [seq_len]
+    CutoffPos_ptr,  # output cutoff_pos_in_doc [seq_len]
+    NCompressed_ptr,  # output n_compressed [1], number of kept tokens
+    IsFirst_ptr,  # output compressed_is_first [seq_len // ratio]
+    CompressedPos_ptr,  # output compressed_pos_in_doc [seq_len // ratio]
+    seq_len,
+    ratio,  # compression ratio (runtime scalar, need NOT be a power of 2)
+    pad_value: tl.constexpr,  # value written to trailing padding slots
+    BLOCK_N: tl.constexpr,  # power of 2 block along seq_len
+):
+    """
+    KV-compression compaction.
+
+    Each document keeps only its first ``doc_len // ratio * ratio`` tokens
+    (the trailing ``doc_len % ratio`` tokens are dropped); the survivors from
+    all documents are packed contiguously toward the front. For every kept
+    token in order, its source column index is written to
+    ``cutoff_gather_indices`` and its ``pos_in_doc`` to ``cutoff_pos_in_doc``.
+    Trailing slots (>= number of kept tokens) are filled with ``pad_value``.
+    The total kept count is written to ``n_compressed`` [1].
+
+    Also emits ``compressed_is_first`` of length ``seq_len // ratio``:
+    entry ``g`` is True iff compressed group ``g`` (compacted tokens
+    ``[g*ratio, (g+1)*ratio)``) starts a document, i.e. its first compacted
+    token has ``cutoff_pos_in_doc == 0``. Groups beyond the actual kept count
+    (``g >= n_compressed // ratio``) are padding and set to False.
+
+    And ``compressed_pos_in_doc`` of length ``seq_len // ratio``: entry ``g``
+    holds the ``cutoff_pos_in_doc`` of compressed group ``g``'s first compacted
+    token (i.e. ``cutoff_pos_in_doc[g*ratio]``). Padding groups are set to -1.
+
+    One program per row, streaming in BLOCK_N chunks with a running kept-count
+    carried across blocks.
+    """
+    # number of kept tokens before the current block (exclusive prefix base)
+    running_count = tl.zeros((), tl.int32)
+
+    for start in range(0, seq_len, BLOCK_N):
+        cols = start + tl.arange(0, BLOCK_N)
+        mask = cols < seq_len
+
+        pos = tl.load(PosInDoc_ptr + cols, mask=mask, other=0).to(tl.int32)
+        dlen = tl.load(DocLen_ptr + cols, mask=mask, other=0).to(tl.int32)
+
+        # cutoff length = largest multiple of ratio not exceeding doc_len.
+        cutoff = dlen - (dlen % ratio)
+        keep = (pos < cutoff) & mask
+        m = keep.to(tl.int32)
+
+        # exclusive prefix count within the row = destination slot in compact out
+        incl = tl.cumsum(m, axis=0)
+        dest = running_count + incl - m
+
+        tl.store(
+            GatherIdx_ptr + dest,
+            cols.to(GatherIdx_ptr.dtype.element_ty),
+            mask=keep,
+        )
+        tl.store(
+            CutoffPos_ptr + dest,
+            pos.to(CutoffPos_ptr.dtype.element_ty),
+            mask=keep,
+        )
+
+        running_count += tl.sum(m, axis=0)
+
+    # total number of kept tokens across the whole row.
+    tl.store(
+        NCompressed_ptr + tl.arange(0, 1),
+        running_count.to(NCompressed_ptr.dtype.element_ty),
+    )
+
+    # fill the trailing padding [running_count, seq_len) in the same launch.
+    # scattered slots [0, running_count) and pad slots are disjoint, so every
+    # output position is written exactly once (safe on an uninitialized buffer).
+    pad_g = tl.full([BLOCK_N], pad_value, GatherIdx_ptr.dtype.element_ty)
+    pad_c = tl.full([BLOCK_N], pad_value, CutoffPos_ptr.dtype.element_ty)
+    for start in range(running_count, seq_len, BLOCK_N):
+        cols = start + tl.arange(0, BLOCK_N)
+        pad_mask = cols < seq_len
+        tl.store(GatherIdx_ptr + cols, pad_g, mask=pad_mask)
+        tl.store(CutoffPos_ptr + cols, pad_c, mask=pad_mask)
+
+    # ---- compressed_is_first (reads back CutoffPos written above) ----
+    # single-CTA launch (grid=(1,)): the barrier makes the CutoffPos scatter
+    # visible to the group loads below.
+    tl.debug_barrier()
+
+    # n_compressed is divisible by ratio (each doc's cutoff len is), so valid
+    # groups exactly tile [0, running_count).
+    n_valid = running_count // ratio
+    n_groups = seq_len // ratio
+    for gstart in range(0, n_groups, BLOCK_N):
+        gids = gstart + tl.arange(0, BLOCK_N)
+        gmask = gids < n_groups
+        valid = gids < n_valid
+
+        tok = gids * ratio  # compacted index at each group start
+        gpos = tl.load(CutoffPos_ptr + tok, mask=valid, other=0).to(tl.int32)
+        # valid groups: first iff group-start token has pos_in_doc==0;
+        # padding groups (>= n_valid): forced False.
+        is_first = tl.where(valid, gpos == 0, False)
+        # compressed_pos_in_doc: group-start token's pos_in_doc; padding -> -1.
+        compressed_pos = tl.where(valid, gpos, -1)
+
+        tl.store(
+            IsFirst_ptr + gids,
+            is_first.to(IsFirst_ptr.dtype.element_ty),
+            mask=gmask,
+        )
+        tl.store(
+            CompressedPos_ptr + gids,
+            compressed_pos.to(CompressedPos_ptr.dtype.element_ty),
+            mask=gmask,
+        )
+
+
+def cutoff_compact_triton(
+    pos_in_doc: Tensor, doc_len_per_pos: Tensor, ratio: int, pad_value: int = -1
+):
+    """Compact KV tokens after dropping each document's non-ratio-divisible tail.
+
+    Args:
+        pos_in_doc: 1-D int tensor [seq_len], offset of each position in its doc.
+        doc_len_per_pos: 1-D int tensor [seq_len], length of the doc per position.
+        ratio: compression ratio (int, need NOT be a power of 2).
+        pad_value: fill value for the trailing (dropped) slots, default -1.
+
+    Both inputs are typically produced by ``document_mask_triton``.
+
+    Returns:
+        (cutoff_gather_indices, cutoff_pos_in_doc, n_compressed, compressed_is_first, compressed_pos_in_doc):
+        - cutoff_gather_indices, cutoff_pos_in_doc: int64 tensors [seq_len];
+          the first ``num_kept`` entries hold the compacted source column
+          indices / pos_in_doc, the rest are ``pad_value``.
+        - n_compressed: int64 tensor [1] holding ``num_kept`` (on device).
+        - compressed_is_first: bool tensor [seq_len // ratio]; entry
+          ``g`` marks whether compressed group ``g`` starts a document. Groups
+          beyond ``num_kept // ratio`` are padding and set to False.
+        - compressed_pos_in_doc: int64 tensor [seq_len // ratio]; entry ``g``
+          holds the ``cutoff_pos_in_doc`` of group ``g``'s first compacted
+          token. Padding groups are set to -1.
+    """
+    assert pos_in_doc.ndim == 1 and doc_len_per_pos.ndim == 1, (
+        "expect 1-D inputs"
+    )
+    assert pos_in_doc.shape == doc_len_per_pos.shape, "inputs must share shape"
+    assert ratio >= 1, "ratio must be >= 1"
+
+    pos = pos_in_doc.astype("int32")
+    dlen = doc_len_per_pos.astype("int32")
+    if not pos.is_contiguous():
+        pos = pos.contiguous()
+    if not dlen.is_contiguous():
+        dlen = dlen.contiguous()
+
+    (seq_len,) = pos.shape
+    ratio = int(ratio)
+    n_groups = seq_len // ratio
+
+    gather_idx = paddle.empty([seq_len], dtype="int64")
+    cutoff_pos = paddle.empty([seq_len], dtype="int64")
+    n_cutoff = paddle.empty([1], dtype="int64")
+    is_first = paddle.empty([n_groups], dtype="bool")
+    compressed_pos_in_doc = paddle.empty([n_groups], dtype="int64")
+
+    BLOCK_N = 4096
+    grid = (1,)
+    cutoff_compact_kernel[grid](
+        pos,
+        dlen,
+        gather_idx,
+        cutoff_pos,
+        n_cutoff,
+        is_first,
+        compressed_pos_in_doc,
+        seq_len,
+        ratio,
+        pad_value=pad_value,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+    )
+    return gather_idx, cutoff_pos, n_cutoff, is_first, compressed_pos_in_doc
+
+
+@triton.jit
+def window_topk_idxs_kernel(
+    DocStart_ptr,  # doc_start_per_pos [seqlen]
+    DocLen_ptr,  # doc_len_per_pos [seqlen]
+    Out_ptr,  # output [seqlen, window_size]
+    seqlen,
+    window_size,
+    BLOCK_W: tl.constexpr,  # power of 2 block along the window axis
+):
+    """
+    Per-position sliding-window index table (batch_size == 1).
+
+    For position ``i`` the window starts at ``max(doc_start[i], i - window + 1)``
+    and lists ``window`` consecutive source indices. Entries beyond ``i`` (future
+    tokens) or before ``doc_start[i]`` are set to -1. One program per position,
+    streaming the window in BLOCK_W chunks.
+
+    Trailing padding is supported: a position ``i`` is a valid query iff
+    ``pos_in_doc[i] = i - doc_start[i] < doc_len[i]`` (equivalently ``i`` is
+    inside a real document). Invalid (padding) query rows are filled with -1.
+
+    All arithmetic stays in int32: seqlen fits comfortably, so this avoids
+    mixed-width issues while the output buffer is int64.
+    """
+    pid = tl.program_id(0)  # position index i
+    pos = pid
+    doc_start = tl.load(DocStart_ptr + pid).to(tl.int32)
+    doc_len = tl.load(DocLen_ptr + pid).to(tl.int32)
+    # padding query: its offset within the (continued) doc reaches doc_len.
+    q_pad = (pos - doc_start) >= doc_len
+    win_start = tl.maximum(doc_start, pos - window_size + 1)
+    row_out = pid.to(tl.int64) * window_size  # big number (e.g. 1M * 4096)
+
+    for start in range(0, window_size, BLOCK_W):
+        offs = start + tl.arange(0, BLOCK_W)
+        mask = offs < window_size
+
+        indices = win_start + offs
+        invalid = (indices > pos) | (indices < doc_start) | q_pad
+        result = tl.where(invalid, -1, indices)
+
+        tl.store(
+            Out_ptr + row_out + offs,
+            result.to(Out_ptr.dtype.element_ty),
+            mask=mask,
+        )
+
+
+def window_topk_idxs_triton(
+    doc_start_per_pos: Tensor, doc_len_per_pos: Tensor, window_size: int
+) -> Tensor:
+    """Fused version of ``_build_window_topk_idxs_from_doc_bounds``.
+
+    Assumptions baked in per request: ``batch_size == 1`` and
+    ``seqlen == doc_start_per_pos.shape[0]``. Trailing padding positions
+    (``pos_in_doc >= doc_len``) are treated as invalid queries and emit an
+    all -1 row.
+
+    Args:
+        doc_start_per_pos: 1-D int tensor [seqlen] (e.g. from document_mask_triton).
+        doc_len_per_pos: 1-D int tensor [seqlen] (e.g. from document_mask_triton),
+            used to detect trailing-padding query positions.
+        window_size: positive window length.
+
+    Returns:
+        int64 tensor [1, seqlen, window_size]; each valid row holds the
+        sliding-window source indices for a position, with out-of-window slots
+        set to -1; padding-query rows are all -1.
+    """
+    if window_size <= 0:
+        raise ValueError(f"window_size must be positive, got {window_size}")
+    assert doc_start_per_pos.ndim == 1, "expect 1-D doc_start_per_pos [seqlen]"
+    assert doc_start_per_pos.shape == doc_len_per_pos.shape, (
+        "inputs must share shape"
+    )
+
+    ds = doc_start_per_pos.contiguous()
+    dl = doc_len_per_pos.contiguous()
+
+    (seqlen,) = ds.shape
+    out = paddle.empty([seqlen, window_size], dtype="int64")
+
+    BLOCK_W = min(triton.next_power_of_2(window_size), 2048)
+    grid = (seqlen,)
+    window_topk_idxs_kernel[grid](
+        ds,
+        dl,
+        out,
+        seqlen,
+        window_size,
+        BLOCK_W=BLOCK_W,
+        num_warps=4,
+    )
+    return out.unsqueeze(0)
+
+
+@triton.jit
+def compressed_doc_start_kernel(
+    End_ptr,  # start_end_row_indices [seq_len]
+    DocStart_ptr,  # doc_start_per_pos [seq_len]
+    Out_ptr,  # output compressed_doc_start_per_pos [seq_len]
+    seq_len,
+    ratio,  # compression ratio (runtime scalar, need NOT be a power of 2)
+    BLOCK_N: tl.constexpr,  # power of 2 block along seq_len
+):
+    """
+    Per-position global compressed-kv doc offset.
+
+    For every position, emit the number of compressed kv slots contributed by
+    all documents strictly before its own document, i.e. the global index of
+    the first compressed slot of its document. Document ``d`` contributes
+    ``doc_len_d // ratio`` slots.
+
+    Implementation: at each document boundary ``b_k`` (start of doc ``k``) place
+    a contribution ``len_{k-1} // ratio`` (the just-finished doc's slot count);
+    the inclusive prefix sum of these contributions over positions yields, for
+    any position in doc ``k``, ``sum_{m<k} len_m // ratio``. Streamed in BLOCK_N
+    chunks with a running sum carried across blocks.
+    """
+    running_sum = tl.zeros((), tl.int32)
+
+    for start in range(0, seq_len, BLOCK_N):
+        cols = start + tl.arange(0, BLOCK_N)
+        mask = cols < seq_len
+
+        end = tl.load(End_ptr + cols, mask=mask, other=0).to(tl.int32)
+
+        # previous position's end / doc_start, read from global memory so lane 0
+        # of each block correctly picks up the previous block's tail.
+        prev_cols = cols - 1
+        prev_mask = (prev_cols >= 0) & mask
+        end_prev = tl.load(End_ptr + prev_cols, mask=prev_mask, other=-1).to(
+            tl.int32
+        )
+        ds_prev = tl.load(DocStart_ptr + prev_cols, mask=prev_mask, other=0).to(
+            tl.int32
+        )
+
+        # a document boundary starts wherever the end value changes; position 0
+        # (prev_cols < 0) is the first doc and contributes nothing.
+        is_boundary = (end != end_prev) & (prev_cols >= 0) & mask
+        # length of the just-finished doc = its exclusive end minus its start.
+        prev_doc_len = end_prev - ds_prev
+        contrib = tl.where(is_boundary, prev_doc_len // ratio, 0)
+
+        incl = tl.cumsum(contrib, axis=0)
+        out = running_sum + incl
+        tl.store(Out_ptr + cols, out.to(Out_ptr.dtype.element_ty), mask=mask)
+
+        running_sum += tl.sum(contrib, axis=0)
+
+
+def compressed_doc_start_triton(
+    start_end_row_indices: Tensor, doc_start_per_pos: Tensor, ratio: int
+):
+    """Per-position global compressed-kv doc offset.
+
+    Args:
+        start_end_row_indices: 1-D int tensor [seq_len]; exclusive end index of
+            each position's document (non-decreasing).
+        doc_start_per_pos: 1-D int tensor [seq_len] from ``document_mask_triton``.
+        ratio: compression ratio (int, need NOT be a power of 2).
+
+    Returns:
+        int64 tensor [seq_len]; each entry is the global index of the first
+        compressed kv slot belonging to that position's document.
+    """
+    assert start_end_row_indices.ndim == 1 and doc_start_per_pos.ndim == 1, (
+        "expect 1-D inputs"
+    )
+    assert start_end_row_indices.shape == doc_start_per_pos.shape, (
+        "inputs must share shape"
+    )
+    assert ratio >= 1, "ratio must be >= 1"
+
+    end = start_end_row_indices.contiguous()
+    ds = doc_start_per_pos.contiguous()
+
+    (seq_len,) = end.shape
+    ratio = int(ratio)
+    out = paddle.empty([seq_len], dtype="int64")
+
+    BLOCK_N = 4096
+    grid = (1,)
+    compressed_doc_start_kernel[grid](
+        end,
+        ds,
+        out,
+        seq_len,
+        ratio,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+    )
+    return out
+
+
+@triton.jit
+def compressed_topk_idxs_kernel(
+    CompDocStart_ptr,  # compressed_doc_start_per_pos [seqlen]
+    PosInDoc_ptr,  # pos_in_doc [seqlen]
+    DocLen_ptr,  # doc_len_per_pos [seqlen]
+    Out_ptr,  # output [seqlen, n_groups]
+    seqlen,
+    n_groups,
+    ratio,  # compression ratio (runtime scalar, need NOT be power of 2)
+    offset,  # constant added to every accessible slot index (-1 kept as -1)
+    BLOCK_G: tl.constexpr,  # power of 2 block along the compressed-kv axis
+):
+    """
+    Per-query compressed-kv access table (batch_size == 1).
+
+    The last axis is aligned with ``compressed_is_first`` / ``compressed_pos_in_doc``:
+    entry ``g`` names global compressed slot ``g``. For query position ``i`` the
+    output holds ``g + offset`` where slot ``g`` is accessible and ``-1`` otherwise.
+    ``offset`` shifts every accessible id by a constant (e.g. compressed kv are
+    appended after the uncompressed kv during training); ``-1`` padding is kept.
+
+    A slot ``g`` is accessible by ``q[i]`` iff:
+      * ``q[i]`` is a valid (non-padding) query: ``pos_in_doc[i] < doc_len[i]``,
+      * it belongs to ``q``'s own document, and
+      * it is causally complete for ``q``: with local slot index
+        ``j = g - compressed_doc_start[i]``, ``0 <= j < (pos_in_doc[i] + 1) // ratio``.
+    That is, slot ``j`` covers local doc tokens ``[j*ratio, (j+1)*ratio)`` and only
+    becomes visible once ``q`` has reached the last of those tokens. Trailing
+    padding query rows are all -1.
+
+    For a valid query these conditions collapse to the contiguous range
+    ``[compressed_doc_start[i], compressed_doc_start[i] + (pos_in_doc[i]+1)//ratio)``.
+    One program per position, streaming the compressed axis in BLOCK_G chunks.
+    """
+    pid = tl.program_id(0)  # query position i
+    cds = tl.load(CompDocStart_ptr + pid).to(tl.int32)
+    pos = tl.load(PosInDoc_ptr + pid).to(tl.int32)
+    dlen = tl.load(DocLen_ptr + pid).to(tl.int32)
+
+    # padding query (pos_in_doc >= doc_len) sees nothing.
+    valid_q = pos < dlen
+    n_access = (pos + 1) // ratio  # causally-complete slots in the doc
+    lo = cds
+    hi = cds + tl.where(valid_q, n_access, 0)
+    row_out = pid.to(tl.int64) * n_groups  # big number (e.g. 128K * 32K)
+
+    for start in range(0, n_groups, BLOCK_G):
+        offs = start + tl.arange(0, BLOCK_G)
+        mask = offs < n_groups
+
+        accessible = (offs >= lo) & (offs < hi)
+        result = tl.where(accessible, offs + offset, -1)
+
+        tl.store(
+            Out_ptr + row_out + offs,
+            result.to(Out_ptr.dtype.element_ty),
+            mask=mask,
+        )
+
+
+def compressed_topk_idxs_triton(
+    compressed_doc_start_per_pos: Tensor,
+    pos_in_doc: Tensor,
+    doc_len_per_pos: Tensor,
+    ratio: int,
+    offset: int = 0,
+) -> Tensor:
+    """Build ``compressed_topk_ids`` for KV-compressed sparse attention.
+
+    Assumptions baked in per request: ``batch_size == 1``. Trailing padding
+    query positions (``pos_in_doc >= doc_len``) emit an all -1 row.
+
+    Args:
+        compressed_doc_start_per_pos: 1-D int tensor [seqlen] from
+            ``compressed_doc_start_triton``.
+        pos_in_doc: 1-D int tensor [seqlen] from ``document_mask_triton``.
+        doc_len_per_pos: 1-D int tensor [seqlen] from ``document_mask_triton``,
+            used to detect trailing-padding query positions.
+        ratio: compression ratio (int, need NOT be a power of 2).
+        offset: int constant added to every accessible compressed-kv id; ``-1``
+            padding is preserved. Use this when the compressed kv are appended
+            after the uncompressed kv (offset == number of uncompressed kv).
+
+    Returns:
+        int32 tensor [1, seqlen, seqlen // ratio]; entry ``[0, i, g]`` is
+        ``g + offset`` if query ``i`` may attend to compressed slot ``g`` (valid
+        query, same doc, causally complete), else ``-1``. The last axis aligns
+        with ``compressed_is_first``.
+    """
+    assert (
+        compressed_doc_start_per_pos.ndim == 1
+        and pos_in_doc.ndim == 1
+        and doc_len_per_pos.ndim == 1
+    ), "expect 1-D inputs"
+    assert (
+        compressed_doc_start_per_pos.shape
+        == pos_in_doc.shape
+        == doc_len_per_pos.shape
+    ), "inputs must share shape"
+    assert ratio >= 1, "ratio must be >= 1"
+
+    cds = compressed_doc_start_per_pos.contiguous()
+    pos = pos_in_doc.contiguous()
+    dlen = doc_len_per_pos.contiguous()
+
+    (seqlen,) = cds.shape
+    ratio = int(ratio)
+    offset = int(offset)
+    n_groups = seqlen // ratio
+
+    out = paddle.empty([seqlen, n_groups], dtype="int32")
+
+    BLOCK_G = min(triton.next_power_of_2(max(n_groups, 1)), 2048)
+    grid = (seqlen,)
+    compressed_topk_idxs_kernel[grid](
+        cds,
+        pos,
+        dlen,
+        out,
+        seqlen,
+        n_groups,
+        ratio,
+        offset,
+        BLOCK_G=BLOCK_G,
+        num_warps=4,
+    )
+    return out.unsqueeze(0)

--- a/tests/single_card_tests/test_document_mask_fusion.py
+++ b/tests/single_card_tests/test_document_mask_fusion.py
@@ -1,0 +1,178 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for ``paddlefleet.triton_ops.document_mask_fusion``.
+
+Every triton kernel is validated against the *original* (pre-fusion)
+implementation imported from ``csa_attention`` — the fusion replaced those
+functions, so they are the ground-truth reference.
+"""
+
+import unittest
+
+import numpy as np
+import paddle
+
+from paddlefleet.transformer.csa_attention import (
+    CSADocMaskMetadata,
+    _build_compress_topk_idxs_from_valid_range,
+    _build_window_topk_idxs_from_doc_bounds,
+    compact_kv_score_cutoff,
+)
+from paddlefleet.triton_ops.document_mask_fusion import (
+    compressed_doc_start_triton,
+    compressed_topk_idxs_triton,
+    cutoff_compact_triton,
+    document_mask_triton,
+    window_topk_idxs_triton,
+)
+
+
+class TestDocumentMaskFusion(unittest.TestCase):
+    def setUp(self):
+        self.ratio = 4
+        self.window_size = 4
+        self.batch_size = 1
+        doc_lens = [5, 14, 3, 8]
+        pad = 2
+
+        startend_row_indices = []
+        cum = 0
+        for length in doc_lens:
+            cum += length
+            startend_row_indices += [cum] * length
+        # padding continues the last doc's end value
+        startend_row_indices += [cum] * pad
+
+        self.seqlen = sum(doc_lens) + pad  # 32
+        self.startend_row_indices = paddle.to_tensor(
+            startend_row_indices, dtype="int32"
+        ).reshape([1, 1, self.seqlen, 1])
+
+        # --- reference doc boundaries (original implementation) ---
+        self.meta_ref = CSADocMaskMetadata.build(
+            self.ratio,
+            self.batch_size,
+            self.seqlen,
+            self.startend_row_indices,
+            dense_mode=False,
+        )
+        positions = paddle.arange(self.seqlen, dtype="int64")
+        self.pos_in_doc_ref = positions - self.meta_ref.doc_start_per_pos
+
+    def test_document_mask_kernel(self):
+        """document_mask_fwd_kernel -> (doc_start, doc_len, pos_in_doc)."""
+        doc_start, doc_len, pos_in_doc = document_mask_triton(
+            self.startend_row_indices.flatten()
+        )
+        np.testing.assert_array_equal(
+            doc_start, self.meta_ref.doc_start_per_pos
+        )
+        np.testing.assert_array_equal(doc_len, self.meta_ref.doc_len_per_pos)
+        np.testing.assert_array_equal(pos_in_doc, self.pos_in_doc_ref)
+
+    def test_cutoff_compact_kernel(self):
+        """cutoff_compact_kernel -> gather idx / pos / n / is_first / comp_pos."""
+        ratio = self.ratio
+        seqlen = self.seqlen
+        total_cutoff = self.meta_ref.doc_lens_cutoff.sum().item()
+        actual_n_compressed = total_cutoff // ratio
+
+        # ---- reference from original functions ----
+        identity = paddle.arange(seqlen, dtype="int64").reshape([1, seqlen, 1])
+        src_idx, _ = compact_kv_score_cutoff(
+            self.meta_ref.doc_starts,
+            self.meta_ref.doc_lens_cutoff,
+            self.meta_ref.doc_starts_cutoff,
+            total_cutoff,
+            identity,
+            identity,
+        )
+        gather_idx_ref = src_idx.flatten()  # [total_cutoff]
+        cutoff_pos_ref = paddle.gather(self.pos_in_doc_ref, gather_idx_ref)
+
+        # ---- kernel output ----
+        (
+            gather_idx,
+            cutoff_pos,
+            n_cutoff,
+            is_first,
+            compressed_pos,
+        ) = cutoff_compact_triton(
+            self.pos_in_doc_ref, self.meta_ref.doc_len_per_pos, ratio
+        )
+
+        self.assertEqual(n_cutoff.item(), total_cutoff)
+        np.testing.assert_array_equal(gather_idx[:n_cutoff], gather_idx_ref)
+        np.testing.assert_array_equal(cutoff_pos[:n_cutoff], cutoff_pos_ref)
+        np.testing.assert_array_equal(
+            is_first[:actual_n_compressed],
+            self.meta_ref.get_is_first_compressed_group(),
+        )
+
+        # compressed_pos_in_doc has no original reference
+        compressed_pos_ref = paddle.concat(
+            [
+                paddle.arange(0, doc_len, ratio)
+                for doc_len in self.meta_ref.doc_lens_cutoff
+            ],
+        )
+        np.testing.assert_array_equal(
+            compressed_pos[:actual_n_compressed], compressed_pos_ref
+        )
+
+    def test_window_topk_idxs_kernel(self):
+        """window_topk_idxs_kernel -> [1, seqlen, window_size]."""
+        window_ref = _build_window_topk_idxs_from_doc_bounds(
+            self.batch_size,
+            self.seqlen,
+            self.window_size,
+            self.meta_ref.doc_start_per_pos,
+            self.meta_ref.is_valid,
+        )
+        window_out = window_topk_idxs_triton(
+            self.meta_ref.doc_start_per_pos,
+            self.meta_ref.doc_len_per_pos,
+            self.window_size,
+        )
+        np.testing.assert_array_equal(window_out, window_ref)
+
+    def test_compressed_topk_idxs_kernel(self):
+        """compressed_topk_idxs_kernel -> [1, seqlen, seqlen // ratio]."""
+        n_compressed = self.seqlen // self.ratio
+        valid_range = self.meta_ref.valid_range
+
+        compressed_doc_start = compressed_doc_start_triton(
+            self.startend_row_indices.flatten(),
+            self.meta_ref.doc_start_per_pos,
+            self.ratio,
+        )
+
+        for offset in [0, 1000]:
+            ref = _build_compress_topk_idxs_from_valid_range(
+                self.batch_size, self.seqlen, n_compressed, offset, valid_range
+            )
+            out = compressed_topk_idxs_triton(
+                compressed_doc_start,
+                self.pos_in_doc_ref,
+                self.meta_ref.doc_len_per_pos,
+                self.ratio,
+                offset,
+            )
+            np.testing.assert_array_equal(out, ref)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/transformer/test_csa_loss_mask.py
+++ b/tests/single_card_tests/transformer/test_csa_loss_mask.py
@@ -434,6 +434,7 @@ class TestCSAForwardLossMaskComputation(unittest.TestCase):
         csa.cp_enabled = True
         csa.cp_size = 2
         csa.cp_rank = 0
+        csa.indexer = nn.Identity()  # mock indexer existence (never called)
 
         query = paddle.randn([b, sq, np_heads, hn], dtype="float32")
         key = paddle.randn([b, sq, 1, hn], dtype="float32")
@@ -505,6 +506,7 @@ class TestCSAForwardLossMaskComputation(unittest.TestCase):
         csa.cp_enabled = True
         csa.cp_size = 2
         csa.cp_rank = 0
+        csa.indexer = nn.Identity()  # mock indexer existence (never called)
 
         query = paddle.randn([b, sq, np_heads, hn], dtype="float32")
         key = paddle.randn([b, sq, 1, hn], dtype="float32")


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
Performance Optimization

### PR Types
Performance

### Description
重新设计了 CSADocMaskMetadata 的内容，并使用 Triton 融合算子优化了 DocMask 的处理过程，大幅减少了短文本下因为碎算子和 CPU 同步导致的空泡

本 PR 在 8k mbs=2 dense_mode=true 下 <b>性能提升 10%</b>；在非 dense_mode 也提升了 5%，因为本 PR 只优化了 docmask 的共同路径，没有优化 indexer 特有的部分

本 PR 为 <b>兼容性升级</b>，没有删掉 CSADocMaskMetadata 里面的旧方法，只是将 dense_mode=true 下的处理切换到新方法，旧方法在 dense_mode=false 时依然在使用，以及方便 fallback 调试

### 是否引起精度变化
否

本 PR 对<b>【单算子】</b>、<b>【端到端】</b>、<b>【大Tensor】</b>均进行了完善的测试：

CSADocMaskMetadata 一共有 6 处使用位置（不含 indexer），我在以下 6 处位置加上了严格的 assert all equal 与原有方法进行对比，在 dense_mode=true cp=1 时 <b>全部做到逐位对齐</b>：

模块 | 函数 | 涉及变量 | 逐位对齐
-- | -- | -- | :-:
DSA | _build_rope_freqs | pos_in_doc | ✅
Compressor | compact_kv_score_cutoff | cutoff_gather_indices | ✅
Compressor | _overlap_transform | is_first | ✅
Compressor | _apply_rope(kv) | compressed_pos_in_doc | ✅
CSA | get_window_topk_idxs | doc_start_per_pos | ✅
CSA | get_compress_topk_idxs | doc_start_per_pos, pos_in_doc | ✅

端到端测试 dense_mode=false 以及 cp>1 时的对齐情况，也 <b>全部通过</b>：
dense_mode | CP | loss&norm逐位对齐 | 性能提升
:-: | :-: | :-: | --:
True | 1 | ✅ | 10%
True | 4 | ✅ | 21%
False | 1 | ✅ | 5%
False | 4 | ✅ | 12%

（性能配置：CP=1 时为 8k mbs2，CP=4 时为 32k mbs1；由于所用数据集不同，CP=4 时性能可能偏高）

<b>大 Tensor</b>：128k 时输出的 compress_topk_idxs 已经是大 Tensor（16G），未出现问题

Cherry-pick of #1493 to `release/0.4`.

Merged in dev: #1493  <!-- For pass CI -->