### PR TITLE
[DSv4] Add check for explicit qk_pos_emb_head_dim value

### DIFF
--- a/src/paddlefleet/transformer/dsv4_hybrid_attention.py
+++ b/src/paddlefleet/transformer/dsv4_hybrid_attention.py
@@ -218,7 +218,7 @@ class DSv4HybridAttention(Attention):
 
         self.num_attention_heads = config.num_attention_heads
         self.v_head_dim = config.v_head_dim
-        self.qk_pos_emb_head_dim = config.qk_pos_emb_head_dim or 0
+        self.qk_pos_emb_head_dim = config.qk_pos_emb_head_dim
         self.query_projection_size = self.num_attention_heads * self.v_head_dim
         self.q_head_dim = self.v_head_dim
         self.key_hidden_size = self.q_head_dim

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -1423,6 +1423,11 @@ class TransformerConfig(ModelParallelConfig):
                     f"csa_sparse_attn_backend={self.csa_sparse_attn_backend!r} is invalid. "
                     "Must be one of {'unfused', 'tilelang', 'cudnn'}."
                 )
+            if self.qk_pos_emb_head_dim is None:
+                raise ValueError(
+                    "qk_pos_emb_head_dim must be explicitly set when using "
+                    "dsv4_hybrid attention. Set to 0 to explicitly disable RoPE."
+                )
 
         # swa_high_precision_norm is only supported for DSv4 models.
         if (

--- a/tests/single_card_tests/custom_ops/test_cudnn_dsa_indexer_bwd.py
+++ b/tests/single_card_tests/custom_ops/test_cudnn_dsa_indexer_bwd.py
@@ -852,6 +852,7 @@ class TestTransformerConfigCsaIndexerBackend(unittest.TestCase):
             experimental_attention_variant="dsv4_hybrid",
             csa_compress_ratios=[4],
             csa_indexer_backend="cudnn",
+            qk_pos_emb_head_dim=64,
         )
         self.assertEqual(cfg.csa_indexer_backend, "cudnn")
 
@@ -862,6 +863,7 @@ class TestTransformerConfigCsaIndexerBackend(unittest.TestCase):
             experimental_attention_variant="dsv4_hybrid",
             csa_compress_ratios=[4],
             csa_indexer_backend="tilelang",
+            qk_pos_emb_head_dim=64,
         )
         self.assertEqual(cfg.csa_indexer_backend, "tilelang")
 

--- a/tests/single_card_tests/transformer/test_dsv4_hybrid_attention.py
+++ b/tests/single_card_tests/transformer/test_dsv4_hybrid_attention.py
@@ -300,6 +300,14 @@ class TestDSv4HybridConfigAndSpec(unittest.TestCase):
                 compress_ratio=4,
             )
 
+    def test_qk_pos_emb_head_dim_not_none(self):
+        with self.assertRaisesRegex(
+            ValueError, "qk_pos_emb_head_dim must be explicitly set"
+        ):
+            cfg = _make_config()
+            cfg.qk_pos_emb_head_dim = None
+            cfg.__post_init__()
+
     def test_phase2_loss_topk_does_not_expand_attention_topk(self):
         config = _make_config(
             dsa_index_topk=2,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
User Experience


### PR Types
Bug fixes


### Description
新增检查要求使用 CSA 时必须显式设置 qk_pos_emb_head_dim，避免在别的基模里使用 CSA 时忘记设置，导致整个模型都没有 RoPE 了


### 是否引起精度变化
否