### PR TITLE
Add mutual exclusivity validation for first_k_dense_replace and moe_n_hash_layers

### DIFF
--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -1438,6 +1438,17 @@ class TransformerConfig(ModelParallelConfig):
 
         # Hash-based MoE routing consistency checks.
         if self.moe_n_hash_layers > 0:
+            if (
+                self.first_k_dense_replace is not None
+                and self.first_k_dense_replace > 0
+            ):
+                raise ValueError(
+                    f"first_k_dense_replace ({self.first_k_dense_replace}) and "
+                    f"moe_n_hash_layers ({self.moe_n_hash_layers}) are mutually "
+                    f"exclusive; the first_k_dense_replace dense layers would "
+                    f"suppress hash routing. Set first_k_dense_replace=0 if you "
+                    f"want hash routing."
+                )
             if self.actual_vocab_size is None:
                 raise ValueError(
                     "actual_vocab_size must be set when moe_n_hash_layers > 0; "

--- a/tests/single_card_tests/test_transformer_config.py
+++ b/tests/single_card_tests/test_transformer_config.py
@@ -151,6 +151,44 @@ class TestMoeLayerFreqAndFirstKDenseReplace(unittest.TestCase):
         expected = [0, 1, 1, 1, 1]
         self.assertEqual(config.moe_layer_freq, expected)
 
+    # --- first_k_dense_replace vs moe_n_hash_layers mutual exclusivity ---
+
+    def test_hash_layers_with_first_k_dense_raises(self):
+        """moe_n_hash_layers > 0 and first_k_dense_replace > 0 should raise ValueError."""
+        with self.assertRaisesRegex(
+            ValueError,
+            "first_k_dense_replace.*moe_n_hash_layers.*mutually exclusive",
+        ):
+            TransformerConfig(
+                num_hidden_layers=12,
+                first_k_dense_replace=4,
+                moe_n_hash_layers=2,
+                actual_vocab_size=32000,
+                num_experts_per_tok=2,
+                n_routed_experts=8,
+            )
+
+    def test_hash_layers_with_zero_first_k_dense_ok(self):
+        """moe_n_hash_layers > 0 with first_k_dense_replace=0 is valid."""
+        config = TransformerConfig(
+            num_hidden_layers=12,
+            first_k_dense_replace=0,
+            moe_n_hash_layers=4,
+            actual_vocab_size=32000,
+            num_experts_per_tok=2,
+            n_routed_experts=8,
+        )
+        self.assertEqual(config.moe_n_hash_layers, 4)
+
+    def test_first_k_dense_with_zero_hash_layers_ok(self):
+        """first_k_dense_replace > 0 with moe_n_hash_layers=0 (default) is valid."""
+        config = TransformerConfig(
+            num_hidden_layers=12,
+            first_k_dense_replace=2,
+        )
+        self.assertEqual(config.first_k_dense_replace, 2)
+        self.assertEqual(config.moe_n_hash_layers, 0)
+
 
 class TestRoutedScalingFactorConfig(unittest.TestCase):
     """Tests for the routed_scaling_factor and routed_scaling_factor_learnable fields


### PR DESCRIPTION
### PR Category
Distributed Strategy

### PR Types
Improvements

### Description
Add ValueError when both `first_k_dense_replace` and `moe_n_hash_layers` are set to non-zero values, since `first_k_dense_replace` suppresses hash routing.

Add unit tests:
- test_hash_layers_with_first_k_dense_raises
- test_hash_layers_with_zero_first_k_dense_ok
- test_first_k_dense_with_zero_hash_layers_ok

Will be cherry-picked to release/0.4 after merge.

### 是否引起精度变化
否
