### PR TITLE
[W4A8] Add fused CUDA 1x32 quantization operators

### DIFF
--- a/packages/paddlefleet_ops/setup.py
+++ b/packages/paddlefleet_ops/setup.py
@@ -210,6 +210,7 @@ def setup_ops_extension():
             f"{_ext_rel}/fuse_stack_transpose_fp8_quant.cu",
             f"{_ext_rel}/fuse_apply_rotary_pos_emb_vision.cu",
             f"{_ext_rel}/fused_swiglu_probs_bwd.cu",
+            f"{_ext_rel}/w4a8_quant.cu",
         ],
         include_dirs=[str(Path(__file__).parent / _ext_rel)],
         extra_compile_args={

--- a/packages/paddlefleet_ops/src/paddlefleet_ops/_extensions/w4a8_quant.cu
+++ b/packages/paddlefleet_ops/src/paddlefleet_ops/_extensions/w4a8_quant.cu
@@ -1,0 +1,585 @@
+// Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Fused 1x32 quantization primitives for SM100 W4A8 training.  The numerical
+// contract intentionally matches paddlefleet.transformer.moe.fp8_utils:
+//   * amax is clamped to 1e-4 before division;
+//   * scale is rounded upward to an exact UE8M0 power of two;
+//   * E2M1 uses strict midpoint comparisons and packs even K in the low nibble.
+
+#include <cuda_bf16.h>
+#include <cuda_fp8.h>
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+#include <vector>
+
+#include "paddle/extension.h"
+#include "paddle/phi/common/bfloat16.h"
+#include "paddle/phi/common/float8_e4m3fn.h"
+
+namespace {
+
+constexpr int kQuantBlock = 32;
+constexpr float kAmaxFloor = 1.0e-4f;
+constexpr float kFp8Max = 448.0f;
+constexpr float kFp4Max = 6.0f;
+constexpr int kMaxGridX = 1024 * 1024;
+constexpr int kGroupWarpsPerBlock = 8;
+constexpr int kGroupThreadsPerBlock = kGroupWarpsPerBlock * 32;
+
+enum class QuantKind : int64_t { kFp8 = 0, kFp4 = 1 };
+
+template <typename T>
+__device__ __forceinline__ float LoadAsFloat(const T* ptr, int64_t index) {
+  return static_cast<float>(ptr[index]);
+}
+
+template <>
+__device__ __forceinline__ float LoadAsFloat<__nv_bfloat16>(
+    const __nv_bfloat16* ptr, int64_t index) {
+  return __bfloat162float(ptr[index]);
+}
+
+__device__ __forceinline__ float WarpMax(float value) {
+  constexpr unsigned kMask = 0xffffffffu;
+#pragma unroll
+  for (int offset = 16; offset > 0; offset >>= 1) {
+    value = fmaxf(value, __shfl_down_sync(kMask, value, offset));
+  }
+  return __shfl_sync(kMask, value, 0);
+}
+
+__device__ __forceinline__ float CeilUe8m0(float value) {
+  const uint32_t bits = __float_as_uint(fabsf(value));
+  uint32_t exponent = (bits >> 23) & 0xffu;
+  exponent += (bits & 0x7fffffu) != 0u;
+  exponent = max(1u, min(254u, exponent));
+  return __uint_as_float(exponent << 23);
+}
+
+__device__ __forceinline__ uint8_t EncodeE2m1Strict(float value) {
+  const float absolute = fabsf(value);
+  uint8_t code = static_cast<uint8_t>((absolute > 0.25f) + (absolute > 0.75f) +
+                                      (absolute > 1.25f) + (absolute > 1.75f) +
+                                      (absolute > 2.5f) + (absolute > 3.5f) +
+                                      (absolute > 5.0f));
+  if (value < 0.0f && code != 0u) {
+    code |= 0x8u;
+  }
+  return code;
+}
+
+inline int GridFor(int64_t work_items) {
+  return static_cast<int>(std::min<int64_t>(work_items, kMaxGridX));
+}
+
+inline void CheckCudaLaunch(const char* op_name) {
+  const cudaError_t error = cudaGetLastError();
+  PD_CHECK(error == cudaSuccess,
+           op_name,
+           " CUDA launch failed: ",
+           cudaGetErrorString(error));
+}
+
+template <typename T, QuantKind Kind>
+__global__ void Quantize1x32Kernel(const T* __restrict__ input,
+                                   void* __restrict__ output,
+                                   float* __restrict__ scale,
+                                   int64_t total_groups) {
+  const int lane = threadIdx.x & 31;
+  const int warp = threadIdx.x >> 5;
+  for (int64_t group =
+           static_cast<int64_t>(blockIdx.x) * kGroupWarpsPerBlock + warp;
+       group < total_groups;
+       group += static_cast<int64_t>(gridDim.x) * kGroupWarpsPerBlock) {
+    const int64_t input_base = group * kQuantBlock;
+    float local_amax;
+
+    if constexpr (Kind == QuantKind::kFp8) {
+      const float value = LoadAsFloat(input, input_base + lane);
+      local_amax = fabsf(value);
+      const float amax = WarpMax(local_amax);
+      const float group_scale = CeilUe8m0(fmaxf(amax, kAmaxFloor) / kFp8Max);
+      if (lane == 0) {
+        scale[group] = group_scale;
+      }
+      auto* fp8_output = reinterpret_cast<__nv_fp8_e4m3*>(output);
+      fp8_output[input_base + lane] =
+          static_cast<__nv_fp8_e4m3>(value / group_scale);
+    } else {
+      float first = 0.0f;
+      float second = 0.0f;
+      if (lane < 16) {
+        first = LoadAsFloat(input, input_base + lane * 2);
+        second = LoadAsFloat(input, input_base + lane * 2 + 1);
+      }
+      local_amax = lane < 16 ? fmaxf(fabsf(first), fabsf(second)) : 0.0f;
+      const float amax = WarpMax(local_amax);
+      const float group_scale = CeilUe8m0(fmaxf(amax, kAmaxFloor) / kFp4Max);
+      if (lane == 0) {
+        scale[group] = group_scale;
+      }
+      if (lane < 16) {
+        const uint8_t low = EncodeE2m1Strict(first / group_scale);
+        const uint8_t high = EncodeE2m1Strict(second / group_scale);
+        reinterpret_cast<int8_t*>(output)[group * 16 + lane] =
+            static_cast<int8_t>(low | (high << 4));
+      }
+    }
+  }
+}
+
+template <typename T>
+__global__ void StackTransposeFp4Quantize1x32Kernel(const T* __restrict__ input,
+                                                    int8_t* __restrict__ output,
+                                                    float* __restrict__ scale,
+                                                    int64_t rows,
+                                                    int64_t cols) {
+  // input [E, rows, cols], output [E, cols, rows/2].  Padding one shared
+  // column avoids bank conflicts while each column computes its own scale.
+  __shared__ float tile[kQuantBlock][kQuantBlock + 1];
+  __shared__ float tile_scale[kQuantBlock];
+
+  const int64_t expert = blockIdx.z;
+  const int64_t row_group = blockIdx.y;
+  const int64_t col_group = blockIdx.x;
+  const int thread = threadIdx.x;
+  const int64_t input_expert_base = expert * rows * cols;
+
+#pragma unroll
+  for (int linear = thread; linear < kQuantBlock * kQuantBlock;
+       linear += blockDim.x) {
+    const int local_row = linear / kQuantBlock;
+    const int local_col = linear % kQuantBlock;
+    const int64_t global_row = row_group * kQuantBlock + local_row;
+    const int64_t global_col = col_group * kQuantBlock + local_col;
+    tile[local_row][local_col] =
+        LoadAsFloat(input, input_expert_base + global_row * cols + global_col);
+  }
+  __syncthreads();
+
+  if (thread < kQuantBlock) {
+    float amax = 0.0f;
+#pragma unroll
+    for (int local_row = 0; local_row < kQuantBlock; ++local_row) {
+      amax = fmaxf(amax, fabsf(tile[local_row][thread]));
+    }
+    const float group_scale = CeilUe8m0(fmaxf(amax, kAmaxFloor) / kFp4Max);
+    tile_scale[thread] = group_scale;
+    const int64_t global_col = col_group * kQuantBlock + thread;
+    scale[(expert * cols + global_col) * (rows / kQuantBlock) + row_group] =
+        group_scale;
+  }
+  __syncthreads();
+
+  // A 32x32 input tile becomes a 32x16 packed output tile.  The flattened
+  // mapping gives each warp two adjacent 16-byte row segments.
+#pragma unroll
+  for (int linear = thread; linear < kQuantBlock * (kQuantBlock / 2);
+       linear += blockDim.x) {
+    const int local_col = linear / (kQuantBlock / 2);
+    const int local_pair = linear % (kQuantBlock / 2);
+    const float group_scale = tile_scale[local_col];
+    const uint8_t low =
+        EncodeE2m1Strict(tile[local_pair * 2][local_col] / group_scale);
+    const uint8_t high =
+        EncodeE2m1Strict(tile[local_pair * 2 + 1][local_col] / group_scale);
+    const int64_t global_col = col_group * kQuantBlock + local_col;
+    const int64_t global_pair = row_group * (kQuantBlock / 2) + local_pair;
+    output[(expert * cols + global_col) * (rows / 2) + global_pair] =
+        static_cast<int8_t>(low | (high << 4));
+  }
+}
+
+template <bool HasClamp>
+__global__ void WeightedSwigluFp8Quantize1x32Kernel(
+    const __nv_bfloat16* __restrict__ input,
+    const float* __restrict__ probs,
+    __nv_fp8_e4m3* __restrict__ output,
+    float* __restrict__ scale,
+    int64_t rows,
+    int64_t hidden,
+    float clamp_value,
+    int64_t total_groups) {
+  const int lane = threadIdx.x & 31;
+  const int warp = threadIdx.x >> 5;
+  for (int64_t group_index =
+           static_cast<int64_t>(blockIdx.x) * kGroupWarpsPerBlock + warp;
+       group_index < total_groups;
+       group_index += static_cast<int64_t>(gridDim.x) * kGroupWarpsPerBlock) {
+    const int64_t groups_per_row = hidden / kQuantBlock;
+    const int64_t row = group_index / groups_per_row;
+    const int64_t group = group_index - row * groups_per_row;
+    const int64_t col = group * kQuantBlock + lane;
+    const int64_t input_base = row * hidden * 2;
+    float gate = __bfloat162float(input[input_base + col]);
+    float up = __bfloat162float(input[input_base + hidden + col]);
+    if constexpr (HasClamp) {
+      gate = fminf(gate, clamp_value);
+      up = fmaxf(fminf(up, clamp_value), -clamp_value);
+    }
+    const float sigmoid = HasClamp ? 1.0f / (1.0f + __expf(-gate))
+                                   : __frcp_rn(1.0f + __expf(-gate));
+    const float value = gate * sigmoid * up * probs[row];
+    const float amax = WarpMax(fabsf(value));
+    const float group_scale = CeilUe8m0(fmaxf(amax, kAmaxFloor) / kFp8Max);
+    if (lane == 0) {
+      scale[group_index] = group_scale;
+    }
+    output[row * hidden + col] =
+        static_cast<__nv_fp8_e4m3>(value / group_scale);
+  }
+}
+
+__global__ void DequantizeFp8OneBy32Kernel(
+    const __nv_fp8_e4m3* __restrict__ input,
+    const float* __restrict__ scale,
+    __nv_bfloat16* __restrict__ output,
+    int64_t numel) {
+  for (int64_t index =
+           static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+       index < numel;
+       index += static_cast<int64_t>(gridDim.x) * blockDim.x) {
+    const float value =
+        static_cast<float>(input[index]) * scale[index / kQuantBlock];
+    output[index] = __float2bfloat16_rn(value);
+  }
+}
+
+void CheckGpuContiguous(const paddle::Tensor& input, const char* op_name) {
+  PD_CHECK(input.is_gpu(), op_name, " requires a GPU tensor");
+  PD_CHECK(input.is_contiguous(), op_name, " requires a contiguous tensor");
+}
+
+template <typename Fn>
+void DispatchFloatInput(const paddle::Tensor& input, Fn&& fn) {
+  auto& mutable_input = const_cast<paddle::Tensor&>(input);
+  switch (input.dtype()) {
+    case paddle::DataType::BFLOAT16:
+      fn(reinterpret_cast<const __nv_bfloat16*>(
+          mutable_input.data<phi::bfloat16>()));
+      break;
+    case paddle::DataType::FLOAT32:
+      fn(mutable_input.data<float>());
+      break;
+    default:
+      PD_THROW("W4A8 quantization supports only bfloat16 and float32 input");
+  }
+}
+
+}  // namespace
+
+std::vector<paddle::Tensor> W4A8Quantize1x32(const paddle::Tensor& input,
+                                             int64_t quant_kind) {
+  constexpr const char* kOpName = "w4a8_quantize_1x32";
+  CheckGpuContiguous(input, kOpName);
+  PD_CHECK(input.shape().size() == 2, kOpName, " expects rank-2 input");
+  PD_CHECK(input.shape()[1] % kQuantBlock == 0,
+           kOpName,
+           " last dimension must be divisible by 32");
+  PD_CHECK(quant_kind == static_cast<int64_t>(QuantKind::kFp8) ||
+               quant_kind == static_cast<int64_t>(QuantKind::kFp4),
+           kOpName,
+           " quant_kind must be 0 (FP8) or 1 (FP4)");
+
+  const int64_t rows = input.shape()[0];
+  const int64_t cols = input.shape()[1];
+  const bool is_fp8 = quant_kind == static_cast<int64_t>(QuantKind::kFp8);
+  auto output = paddle::empty(
+      {rows, is_fp8 ? cols : cols / 2},
+      is_fp8 ? paddle::DataType::FLOAT8_E4M3FN : paddle::DataType::INT8,
+      input.place());
+  auto scale = paddle::empty(
+      {rows, cols / kQuantBlock}, paddle::DataType::FLOAT32, input.place());
+  const int64_t groups = rows * (cols / kQuantBlock);
+  if (groups == 0) {
+    return {output, scale};
+  }
+
+  DispatchFloatInput(input, [&](auto* input_ptr) {
+    using InputT = std::remove_cv_t<std::remove_pointer_t<decltype(input_ptr)>>;
+    if (is_fp8) {
+      Quantize1x32Kernel<InputT, QuantKind::kFp8>
+          <<<GridFor((groups + kGroupWarpsPerBlock - 1) / kGroupWarpsPerBlock),
+             kGroupThreadsPerBlock,
+             0,
+             input.stream()>>>(
+              input_ptr, output.data(), scale.data<float>(), groups);
+    } else {
+      Quantize1x32Kernel<InputT, QuantKind::kFp4>
+          <<<GridFor((groups + kGroupWarpsPerBlock - 1) / kGroupWarpsPerBlock),
+             kGroupThreadsPerBlock,
+             0,
+             input.stream()>>>(
+              input_ptr, output.data(), scale.data<float>(), groups);
+    }
+  });
+  CheckCudaLaunch(kOpName);
+  return {output, scale};
+}
+
+std::vector<paddle::Tensor> W4A8StackQuantize1x32(const paddle::Tensor& input,
+                                                  bool transpose) {
+  constexpr const char* kOpName = "w4a8_stack_quantize_1x32";
+  CheckGpuContiguous(input, kOpName);
+  PD_CHECK(input.shape().size() == 3, kOpName, " expects [E, R, C]");
+  const int64_t experts = input.shape()[0];
+  const int64_t rows = input.shape()[1];
+  const int64_t cols = input.shape()[2];
+  const int64_t quant_dim = transpose ? rows : cols;
+  PD_CHECK(quant_dim % kQuantBlock == 0,
+           kOpName,
+           " quantized dimension must be divisible by 32");
+  if (transpose) {
+    PD_CHECK(cols % kQuantBlock == 0,
+             kOpName,
+             " transpose output rows must be divisible by 32");
+  }
+
+  const std::vector<int64_t> output_shape =
+      transpose ? std::vector<int64_t>{experts, cols, rows / 2}
+                : std::vector<int64_t>{experts, rows, cols / 2};
+  const std::vector<int64_t> scale_shape =
+      transpose ? std::vector<int64_t>{experts, cols, rows / kQuantBlock}
+                : std::vector<int64_t>{experts, rows, cols / kQuantBlock};
+  auto output =
+      paddle::empty(output_shape, paddle::DataType::INT8, input.place());
+  auto scale =
+      paddle::empty(scale_shape, paddle::DataType::FLOAT32, input.place());
+  if (input.numel() == 0) {
+    return {output, scale};
+  }
+
+  DispatchFloatInput(input, [&](auto* input_ptr) {
+    using InputT = std::remove_cv_t<std::remove_pointer_t<decltype(input_ptr)>>;
+    if (transpose) {
+      const dim3 grid(cols / kQuantBlock,
+                      rows / kQuantBlock,
+                      static_cast<unsigned int>(experts));
+      StackTransposeFp4Quantize1x32Kernel<InputT>
+          <<<grid, 256, 0, input.stream()>>>(input_ptr,
+                                             output.data<int8_t>(),
+                                             scale.data<float>(),
+                                             rows,
+                                             cols);
+    } else {
+      const int64_t groups = experts * rows * (cols / kQuantBlock);
+      Quantize1x32Kernel<InputT, QuantKind::kFp4>
+          <<<GridFor((groups + kGroupWarpsPerBlock - 1) / kGroupWarpsPerBlock),
+             kGroupThreadsPerBlock,
+             0,
+             input.stream()>>>(
+              input_ptr, output.data(), scale.data<float>(), groups);
+    }
+  });
+  CheckCudaLaunch(kOpName);
+  return {output, scale};
+}
+
+std::vector<paddle::Tensor> W4A8WeightedSwigluQuantize1x32(
+    const paddle::Tensor& input,
+    const paddle::Tensor& probs,
+    double clamp_value) {
+  constexpr const char* kOpName = "w4a8_weighted_swiglu_quantize_1x32";
+  CheckGpuContiguous(input, kOpName);
+  CheckGpuContiguous(probs, kOpName);
+  PD_CHECK(input.dtype() == paddle::DataType::BFLOAT16,
+           kOpName,
+           " input must be bfloat16");
+  PD_CHECK(probs.dtype() == paddle::DataType::FLOAT32,
+           kOpName,
+           " probs must be float32");
+  PD_CHECK(input.shape().size() == 2 && input.shape()[1] % 2 == 0,
+           kOpName,
+           " input must have shape [M, 2H]");
+  const int64_t rows = input.shape()[0];
+  const int64_t hidden = input.shape()[1] / 2;
+  PD_CHECK(hidden % kQuantBlock == 0, kOpName, " H must be divisible by 32");
+  PD_CHECK(
+      probs.numel() == rows, kOpName, " probs must contain one float per row");
+
+  auto output = paddle::empty(
+      {rows, hidden}, paddle::DataType::FLOAT8_E4M3FN, input.place());
+  auto scale = paddle::empty(
+      {rows, hidden / kQuantBlock}, paddle::DataType::FLOAT32, input.place());
+  const int64_t groups = rows * (hidden / kQuantBlock);
+  if (groups == 0) {
+    return {output, scale};
+  }
+
+  auto& mutable_input = const_cast<paddle::Tensor&>(input);
+  auto& mutable_probs = const_cast<paddle::Tensor&>(probs);
+  const auto* input_ptr = reinterpret_cast<const __nv_bfloat16*>(
+      mutable_input.data<phi::bfloat16>());
+  auto* output_ptr =
+      reinterpret_cast<__nv_fp8_e4m3*>(output.data<phi::float8_e4m3fn>());
+  if (clamp_value > 0.0) {
+    WeightedSwigluFp8Quantize1x32Kernel<true>
+        <<<GridFor((groups + kGroupWarpsPerBlock - 1) / kGroupWarpsPerBlock),
+           kGroupThreadsPerBlock,
+           0,
+           input.stream()>>>(input_ptr,
+                             mutable_probs.data<float>(),
+                             output_ptr,
+                             scale.data<float>(),
+                             rows,
+                             hidden,
+                             static_cast<float>(clamp_value),
+                             groups);
+  } else {
+    WeightedSwigluFp8Quantize1x32Kernel<false>
+        <<<GridFor((groups + kGroupWarpsPerBlock - 1) / kGroupWarpsPerBlock),
+           kGroupThreadsPerBlock,
+           0,
+           input.stream()>>>(input_ptr,
+                             mutable_probs.data<float>(),
+                             output_ptr,
+                             scale.data<float>(),
+                             rows,
+                             hidden,
+                             0.0f,
+                             groups);
+  }
+  CheckCudaLaunch(kOpName);
+  return {output, scale};
+}
+
+std::vector<paddle::Tensor> W4A8Dequantize1x32Impl(
+    const paddle::Tensor& input, const paddle::Tensor& scale) {
+  constexpr const char* kOpName = "w4a8_dequantize_1x32";
+  CheckGpuContiguous(input, kOpName);
+  CheckGpuContiguous(scale, kOpName);
+  PD_CHECK(input.dtype() == paddle::DataType::FLOAT8_E4M3FN,
+           kOpName,
+           " input must be float8_e4m3fn");
+  PD_CHECK(scale.dtype() == paddle::DataType::FLOAT32,
+           kOpName,
+           " scale must be float32");
+  PD_CHECK(input.shape().size() == 2 && input.shape()[1] % kQuantBlock == 0,
+           kOpName,
+           " input must be [M, K] with K divisible by 32");
+  const std::vector<int64_t> expected_scale_shape = {
+      input.shape()[0], input.shape()[1] / kQuantBlock};
+  PD_CHECK(scale.shape() == expected_scale_shape,
+           kOpName,
+           " scale shape must be [M, K/32]");
+
+  auto output =
+      paddle::empty(input.shape(), paddle::DataType::BFLOAT16, input.place());
+  if (input.numel() == 0) {
+    return {output};
+  }
+  auto& mutable_input = const_cast<paddle::Tensor&>(input);
+  auto& mutable_scale = const_cast<paddle::Tensor&>(scale);
+  const int threads = 256;
+  const int blocks = GridFor((input.numel() + threads - 1) / threads);
+  DequantizeFp8OneBy32Kernel<<<blocks, threads, 0, input.stream()>>>(
+      reinterpret_cast<const __nv_fp8_e4m3*>(
+          mutable_input.data<phi::float8_e4m3fn>()),
+      mutable_scale.data<float>(),
+      reinterpret_cast<__nv_bfloat16*>(output.data<phi::bfloat16>()),
+      input.numel());
+  CheckCudaLaunch(kOpName);
+  return {output};
+}
+
+std::vector<std::vector<int64_t>> QuantInferShape(
+    std::vector<int64_t> input_shape, int64_t quant_kind) {
+  const bool fp8 = quant_kind == static_cast<int64_t>(QuantKind::kFp8);
+  return {{input_shape[0], fp8 ? input_shape[1] : input_shape[1] / 2},
+          {input_shape[0], input_shape[1] / kQuantBlock}};
+}
+
+std::vector<paddle::DataType> QuantInferDtype(paddle::DataType input_dtype,
+                                              int64_t quant_kind) {
+  return {quant_kind == static_cast<int64_t>(QuantKind::kFp8)
+              ? paddle::DataType::FLOAT8_E4M3FN
+              : paddle::DataType::INT8,
+          paddle::DataType::FLOAT32};
+}
+
+std::vector<std::vector<int64_t>> StackInferShape(
+    std::vector<int64_t> input_shape, bool transpose) {
+  const int64_t e = input_shape[0];
+  const int64_t r = input_shape[1];
+  const int64_t c = input_shape[2];
+  return transpose ? std::vector<std::vector<int64_t>>{{e, c, r / 2},
+                                                       {e, c, r / kQuantBlock}}
+                   : std::vector<std::vector<int64_t>>{{e, r, c / 2},
+                                                       {e, r, c / kQuantBlock}};
+}
+
+std::vector<paddle::DataType> StackInferDtype(paddle::DataType input_dtype,
+                                              bool transpose) {
+  return {paddle::DataType::INT8, paddle::DataType::FLOAT32};
+}
+
+std::vector<std::vector<int64_t>> WeightedSwigluInferShape(
+    std::vector<int64_t> input_shape,
+    std::vector<int64_t> probs_shape,
+    double clamp_value) {
+  const int64_t hidden = input_shape[1] / 2;
+  return {{input_shape[0], hidden}, {input_shape[0], hidden / kQuantBlock}};
+}
+
+std::vector<paddle::DataType> WeightedSwigluInferDtype(
+    paddle::DataType input_dtype,
+    paddle::DataType probs_dtype,
+    double clamp_value) {
+  return {paddle::DataType::FLOAT8_E4M3FN, paddle::DataType::FLOAT32};
+}
+
+std::vector<std::vector<int64_t>> DequantInferShape(
+    std::vector<int64_t> input_shape, std::vector<int64_t> scale_shape) {
+  return {input_shape};
+}
+
+std::vector<paddle::DataType> DequantInferDtype(paddle::DataType input_dtype,
+                                                paddle::DataType scale_dtype) {
+  return {paddle::DataType::BFLOAT16};
+}
+
+PD_BUILD_OP(w4a8_quantize_1x32)
+    .Inputs({"input"})
+    .Outputs({"output", "scale"})
+    .Attrs({"quant_kind: int64_t"})
+    .SetKernelFn(PD_KERNEL(W4A8Quantize1x32))
+    .SetInferShapeFn(PD_INFER_SHAPE(QuantInferShape))
+    .SetInferDtypeFn(PD_INFER_DTYPE(QuantInferDtype));
+
+PD_BUILD_OP(w4a8_stack_quantize_1x32)
+    .Inputs({"input"})
+    .Outputs({"output", "scale"})
+    .Attrs({"transpose: bool"})
+    .SetKernelFn(PD_KERNEL(W4A8StackQuantize1x32))
+    .SetInferShapeFn(PD_INFER_SHAPE(StackInferShape))
+    .SetInferDtypeFn(PD_INFER_DTYPE(StackInferDtype));
+
+PD_BUILD_OP(w4a8_weighted_swiglu_quantize_1x32)
+    .Inputs({"input", "probs"})
+    .Outputs({"output", "scale"})
+    .Attrs({"clamp_value: double"})
+    .SetKernelFn(PD_KERNEL(W4A8WeightedSwigluQuantize1x32))
+    .SetInferShapeFn(PD_INFER_SHAPE(WeightedSwigluInferShape));
+
+PD_BUILD_OP(w4a8_dequantize_1x32)
+    .Inputs({"input", "scale"})
+    .Outputs({"output"})
+    .SetKernelFn(PD_KERNEL(W4A8Dequantize1x32Impl))
+    .SetInferShapeFn(PD_INFER_SHAPE(DequantInferShape))
+    .SetInferDtypeFn(PD_INFER_DTYPE(DequantInferDtype));

--- a/packages/paddlefleet_ops/src/paddlefleet_ops/_extensions/w4a8_quant.cu
+++ b/packages/paddlefleet_ops/src/paddlefleet_ops/_extensions/w4a8_quant.cu
@@ -538,9 +538,7 @@ std::vector<std::vector<int64_t>> WeightedSwigluInferShape(
 }
 
 std::vector<paddle::DataType> WeightedSwigluInferDtype(
-    paddle::DataType input_dtype,
-    paddle::DataType probs_dtype,
-    double clamp_value) {
+    paddle::DataType input_dtype, paddle::DataType probs_dtype) {
   return {paddle::DataType::FLOAT8_E4M3FN, paddle::DataType::FLOAT32};
 }
 
@@ -575,7 +573,8 @@ PD_BUILD_OP(w4a8_weighted_swiglu_quantize_1x32)
     .Outputs({"output", "scale"})
     .Attrs({"clamp_value: double"})
     .SetKernelFn(PD_KERNEL(W4A8WeightedSwigluQuantize1x32))
-    .SetInferShapeFn(PD_INFER_SHAPE(WeightedSwigluInferShape));
+    .SetInferShapeFn(PD_INFER_SHAPE(WeightedSwigluInferShape))
+    .SetInferDtypeFn(PD_INFER_DTYPE(WeightedSwigluInferDtype));
 
 PD_BUILD_OP(w4a8_dequantize_1x32)
     .Inputs({"input", "scale"})

--- a/src/paddlefleet/transformer/moe/fp8_utils.py
+++ b/src/paddlefleet/transformer/moe/fp8_utils.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 """FP8 Utils"""
 
+import os
+
 import numpy
 import paddle
 import paddle.nn.functional as F
@@ -35,6 +37,18 @@ try:
     )
 except (ImportError, RuntimeError):
     pass
+
+try:
+    from paddlefleet_ops import (
+        w4a8_dequantize_1x32,
+        w4a8_quantize_1x32,
+        w4a8_stack_quantize_1x32,
+        w4a8_weighted_swiglu_quantize_1x32,
+    )
+
+    HAS_W4A8_FUSED_QUANT = True
+except (ImportError, AttributeError, RuntimeError):
+    HAS_W4A8_FUSED_QUANT = False
 
 # 优先从 paddlefleet_ops 导入（算子已重命名为 paddlefleet_fused_swiglu_probs_bwd 避免冲突），
 # 仅在 paddlefleet_ops 中不存在时回退到旧的 FusedQuantOps。
@@ -248,6 +262,16 @@ def tilewise_quant(x):
 # ---------------------------------------------------------------------------
 
 W4A8_QUANT_BLOCK = 32
+
+
+def _use_w4a8_fused_quant():
+    enabled = os.getenv("PADDLEFLEET_W4A8_FUSED_QUANT", "0") == "1"
+    if enabled and not HAS_W4A8_FUSED_QUANT:
+        raise RuntimeError(
+            "PADDLEFLEET_W4A8_FUSED_QUANT=1 requires paddlefleet_ops "
+            "built with the W4A8 1x32 CUDA custom ops"
+        )
+    return enabled
 
 
 def ceil_to_ue8m0(x):
@@ -495,6 +519,44 @@ def fused_act_dequant_python(x_fp8, sf):
     group_idx = paddle.arange(n, dtype="int64") // gran_k
     sf_expanded = paddle.index_select(sf.astype("float32"), group_idx, axis=1)
     return (x_fp8.astype("float32") * sf_expanded).astype("bfloat16")
+
+
+def _w4a8_quant(x, quant_dtype):
+    if _use_w4a8_fused_quant():
+        return w4a8_quantize_1x32(x, 0 if quant_dtype == "fp8" else 1)
+    return quant_blockwize(x, quant_dtype=quant_dtype)
+
+
+def _w4a8_stack_quant(weights, transpose):
+    if _use_w4a8_fused_quant():
+        weights = _stack_expert_weights(weights)
+        return w4a8_stack_quantize_1x32(weights, transpose)
+    fn = (
+        fuse_stack_transpose_fp8_quant_python
+        if transpose
+        else fuse_stack_fp8_quant_python
+    )
+    return fn(weights, quant_dtype="fp4")
+
+
+def _w4a8_weighted_swiglu_quant(o1, probs, clamp_value=None):
+    if _use_w4a8_fused_quant():
+        return w4a8_weighted_swiglu_quantize_1x32(
+            o1,
+            probs,
+            0.0 if clamp_value is None else float(clamp_value),
+        )
+    if clamp_value is not None and clamp_value > 0:
+        return fuse_weighted_swiglu_fp8_quant_clamp_python(
+            o1, probs, clamp_value
+        )
+    return fuse_weighted_swiglu_fp8_quant_python(o1, probs)
+
+
+def _w4a8_dequant(x_fp8, sf):
+    if _use_w4a8_fused_quant():
+        return w4a8_dequantize_1x32(x_fp8, sf)
+    return fused_act_dequant_python(x_fp8, sf)
 
 
 def split_group_gemm(
@@ -1088,12 +1150,10 @@ class ExpertsGroupGemmContiguousNode:
             else:
                 assert self.input is not None
                 x = self.input
-        # 在线量化权重（无 quant_weight_cache）：[E, K, N] -> [E, N, K/2]
-        w1_fp4, w1_sf = fuse_stack_transpose_fp8_quant_python(
-            expert_w1, quant_dtype="fp4"
-        )
+        # [E, K, N] -> [E, N, K/2]
+        w1_fp4, w1_sf = _w4a8_stack_quant(expert_w1, transpose=True)
         if x_fp8 is None:
-            x_fp8, x_sf = quant_blockwize(x, quant_dtype="fp8")
+            x_fp8, x_sf = _w4a8_quant(x, quant_dtype="fp8")
         # 给反向存储：dequant_input 存 fp8 1x32 量化结果（省显存，
         # 反向 bf16 wgrad 用 fused_act_dequant_python 反量化），否则存 bf16
         if self.dequant_input:
@@ -1116,17 +1176,10 @@ class ExpertsGroupGemmContiguousNode:
         [m_sum, k] = [m_sum, n] * [num_groups, n, k]
         """
         # 在线量化权重：[E, H, K] -> [E, K, H/2]
-        w2_fp4, w2_sf = fuse_stack_transpose_fp8_quant_python(
-            expert_w2, quant_dtype="fp4"
+        w2_fp4, w2_sf = _w4a8_stack_quant(expert_w2, transpose=True)
+        o2_fp8, o2_sf = _w4a8_weighted_swiglu_quant(
+            o1, unzipped_probs, self.clamp_value
         )
-        if self.clamp_value is not None and self.clamp_value > 0:
-            o2_fp8, o2_sf = fuse_weighted_swiglu_fp8_quant_clamp_python(
-                o1, unzipped_probs, self.clamp_value
-            )
-        else:
-            o2_fp8, o2_sf = fuse_weighted_swiglu_fp8_quant_python(
-                o1, unzipped_probs
-            )
         if clear_o1:
             o1._clear_to_zero_allocation()
 
@@ -1148,10 +1201,8 @@ class ExpertsGroupGemmContiguousNode:
         [m_sum, n] = [m_sum, k] * [num_groups, k, n]
         w2 [E, N, K] 不转置，收缩维为 K（do3 的列维）。
         """
-        w2_fp4, w2_sf = fuse_stack_fp8_quant_python(
-            expert_w2, quant_dtype="fp4"
-        )
-        grad_fp8, grad_sf = quant_blockwize(unzipped_grad, quant_dtype="fp8")
+        w2_fp4, w2_sf = _w4a8_stack_quant(expert_w2, transpose=False)
+        grad_fp8, grad_sf = _w4a8_quant(unzipped_grad, quant_dtype="fp8")
 
         do2_s = paddle.empty(
             [grad_fp8.shape[0], w2_fp4.shape[1]], dtype=unzipped_grad.dtype
@@ -1187,10 +1238,8 @@ class ExpertsGroupGemmContiguousNode:
         [m_sum, k] = [m_sum, n] * [num_groups, n, k]
         w1 [E, K, N] 不转置，收缩维为 N（do1 的列维）。
         """
-        w1_fp4, w1_sf = fuse_stack_fp8_quant_python(
-            expert_w1, quant_dtype="fp4"
-        )
-        do1_fp8, do1_sf = quant_blockwize(do1, quant_dtype="fp8")
+        w1_fp4, w1_sf = _w4a8_stack_quant(expert_w1, transpose=False)
+        do1_fp8, do1_sf = _w4a8_quant(do1, quant_dtype="fp8")
 
         dx_shape = [do1_fp8.shape[0], w1_fp4.shape[1]]
         if dx is None:
@@ -2564,9 +2613,7 @@ class ExpertsGroupGemmContiguousNode:
             if self.dequant_input:
                 if self.use_w4a8:
                     # w4a8 输入是 fp8 1x32 量化（fused_act_dequant 仅支持 1x128）
-                    x = fused_act_dequant_python(
-                        self.input_fp8, self.input_scale
-                    )
+                    x = _w4a8_dequant(self.input_fp8, self.input_scale)
                 else:
                     x = paddle.incubate.nn.functional.fused_act_dequant(
                         self.input_fp8, self.input_scale

--- a/src/paddlefleet/transformer/moe/fp8_utils.py
+++ b/src/paddlefleet/transformer/moe/fp8_utils.py
@@ -15,8 +15,6 @@
 # limitations under the License.
 """FP8 Utils"""
 
-import os
-
 import numpy
 import paddle
 import paddle.nn.functional as F
@@ -264,11 +262,10 @@ def tilewise_quant(x):
 W4A8_QUANT_BLOCK = 32
 
 
-def _use_w4a8_fused_quant():
-    enabled = os.getenv("PADDLEFLEET_W4A8_FUSED_QUANT", "0") == "1"
+def _use_w4a8_fused_quant(enabled):
     if enabled and not HAS_W4A8_FUSED_QUANT:
         raise RuntimeError(
-            "PADDLEFLEET_W4A8_FUSED_QUANT=1 requires paddlefleet_ops "
+            "use_w4a8_fused_quant=True requires paddlefleet_ops "
             "built with the W4A8 1x32 CUDA custom ops"
         )
     return enabled
@@ -521,14 +518,14 @@ def fused_act_dequant_python(x_fp8, sf):
     return (x_fp8.astype("float32") * sf_expanded).astype("bfloat16")
 
 
-def _w4a8_quant(x, quant_dtype):
-    if _use_w4a8_fused_quant():
+def _w4a8_quant(x, quant_dtype, use_w4a8_fused_quant=False):
+    if _use_w4a8_fused_quant(use_w4a8_fused_quant):
         return w4a8_quantize_1x32(x, 0 if quant_dtype == "fp8" else 1)
     return quant_blockwize(x, quant_dtype=quant_dtype)
 
 
-def _w4a8_stack_quant(weights, transpose):
-    if _use_w4a8_fused_quant():
+def _w4a8_stack_quant(weights, transpose, use_w4a8_fused_quant=False):
+    if _use_w4a8_fused_quant(use_w4a8_fused_quant):
         weights = _stack_expert_weights(weights)
         return w4a8_stack_quantize_1x32(weights, transpose)
     fn = (
@@ -539,8 +536,10 @@ def _w4a8_stack_quant(weights, transpose):
     return fn(weights, quant_dtype="fp4")
 
 
-def _w4a8_weighted_swiglu_quant(o1, probs, clamp_value=None):
-    if _use_w4a8_fused_quant():
+def _w4a8_weighted_swiglu_quant(
+    o1, probs, clamp_value=None, use_w4a8_fused_quant=False
+):
+    if _use_w4a8_fused_quant(use_w4a8_fused_quant):
         return w4a8_weighted_swiglu_quantize_1x32(
             o1,
             probs,
@@ -553,8 +552,8 @@ def _w4a8_weighted_swiglu_quant(o1, probs, clamp_value=None):
     return fuse_weighted_swiglu_fp8_quant_python(o1, probs)
 
 
-def _w4a8_dequant(x_fp8, sf):
-    if _use_w4a8_fused_quant():
+def _w4a8_dequant(x_fp8, sf, use_w4a8_fused_quant=False):
+    if _use_w4a8_fused_quant(use_w4a8_fused_quant):
         return w4a8_dequantize_1x32(x_fp8, sf)
     return fused_act_dequant_python(x_fp8, sf)
 
@@ -791,6 +790,7 @@ class ExpertsGroupGemmContiguousNode:
         activation_type="swiglu",
         use_accuracy_compatible=False,
         use_w4a8=False,
+        use_w4a8_fused_quant=False,
     ):
         """
             Initializes the experts group gemm contiguous node.
@@ -867,6 +867,7 @@ class ExpertsGroupGemmContiguousNode:
             use_accuracy_compatible=use_accuracy_compatible,
         )
         self.use_w4a8 = use_w4a8
+        self.use_w4a8_fused_quant = use_w4a8_fused_quant
         if use_w4a8:
             assert moe_expert_fusion and moe_deep_gemm and use_fp8_mlp, (
                 "use_w4a8 需要 moe_expert_fusion + moe_deep_gemm + use_fp8_mlp"
@@ -1151,9 +1152,17 @@ class ExpertsGroupGemmContiguousNode:
                 assert self.input is not None
                 x = self.input
         # [E, K, N] -> [E, N, K/2]
-        w1_fp4, w1_sf = _w4a8_stack_quant(expert_w1, transpose=True)
+        w1_fp4, w1_sf = _w4a8_stack_quant(
+            expert_w1,
+            transpose=True,
+            use_w4a8_fused_quant=self.use_w4a8_fused_quant,
+        )
         if x_fp8 is None:
-            x_fp8, x_sf = _w4a8_quant(x, quant_dtype="fp8")
+            x_fp8, x_sf = _w4a8_quant(
+                x,
+                quant_dtype="fp8",
+                use_w4a8_fused_quant=self.use_w4a8_fused_quant,
+            )
         # 给反向存储：dequant_input 存 fp8 1x32 量化结果（省显存，
         # 反向 bf16 wgrad 用 fused_act_dequant_python 反量化），否则存 bf16
         if self.dequant_input:
@@ -1176,9 +1185,16 @@ class ExpertsGroupGemmContiguousNode:
         [m_sum, k] = [m_sum, n] * [num_groups, n, k]
         """
         # 在线量化权重：[E, H, K] -> [E, K, H/2]
-        w2_fp4, w2_sf = _w4a8_stack_quant(expert_w2, transpose=True)
+        w2_fp4, w2_sf = _w4a8_stack_quant(
+            expert_w2,
+            transpose=True,
+            use_w4a8_fused_quant=self.use_w4a8_fused_quant,
+        )
         o2_fp8, o2_sf = _w4a8_weighted_swiglu_quant(
-            o1, unzipped_probs, self.clamp_value
+            o1,
+            unzipped_probs,
+            self.clamp_value,
+            use_w4a8_fused_quant=self.use_w4a8_fused_quant,
         )
         if clear_o1:
             o1._clear_to_zero_allocation()
@@ -1201,8 +1217,16 @@ class ExpertsGroupGemmContiguousNode:
         [m_sum, n] = [m_sum, k] * [num_groups, k, n]
         w2 [E, N, K] 不转置，收缩维为 K（do3 的列维）。
         """
-        w2_fp4, w2_sf = _w4a8_stack_quant(expert_w2, transpose=False)
-        grad_fp8, grad_sf = _w4a8_quant(unzipped_grad, quant_dtype="fp8")
+        w2_fp4, w2_sf = _w4a8_stack_quant(
+            expert_w2,
+            transpose=False,
+            use_w4a8_fused_quant=self.use_w4a8_fused_quant,
+        )
+        grad_fp8, grad_sf = _w4a8_quant(
+            unzipped_grad,
+            quant_dtype="fp8",
+            use_w4a8_fused_quant=self.use_w4a8_fused_quant,
+        )
 
         do2_s = paddle.empty(
             [grad_fp8.shape[0], w2_fp4.shape[1]], dtype=unzipped_grad.dtype
@@ -1238,8 +1262,16 @@ class ExpertsGroupGemmContiguousNode:
         [m_sum, k] = [m_sum, n] * [num_groups, n, k]
         w1 [E, K, N] 不转置，收缩维为 N（do1 的列维）。
         """
-        w1_fp4, w1_sf = _w4a8_stack_quant(expert_w1, transpose=False)
-        do1_fp8, do1_sf = _w4a8_quant(do1, quant_dtype="fp8")
+        w1_fp4, w1_sf = _w4a8_stack_quant(
+            expert_w1,
+            transpose=False,
+            use_w4a8_fused_quant=self.use_w4a8_fused_quant,
+        )
+        do1_fp8, do1_sf = _w4a8_quant(
+            do1,
+            quant_dtype="fp8",
+            use_w4a8_fused_quant=self.use_w4a8_fused_quant,
+        )
 
         dx_shape = [do1_fp8.shape[0], w1_fp4.shape[1]]
         if dx is None:
@@ -2613,7 +2645,11 @@ class ExpertsGroupGemmContiguousNode:
             if self.dequant_input:
                 if self.use_w4a8:
                     # w4a8 输入是 fp8 1x32 量化（fused_act_dequant 仅支持 1x128）
-                    x = _w4a8_dequant(self.input_fp8, self.input_scale)
+                    x = _w4a8_dequant(
+                        self.input_fp8,
+                        self.input_scale,
+                        use_w4a8_fused_quant=self.use_w4a8_fused_quant,
+                    )
                 else:
                     x = paddle.incubate.nn.functional.fused_act_dequant(
                         self.input_fp8, self.input_scale

--- a/src/paddlefleet/transformer/moe/fusion_layer_utils.py
+++ b/src/paddlefleet/transformer/moe/fusion_layer_utils.py
@@ -388,6 +388,7 @@ class MlpNode:
         activation_type=None,
         use_accuracy_compatible=False,
         use_w4a8=False,
+        use_w4a8_fused_quant=False,
     ):
         """
         Constructor
@@ -491,6 +492,8 @@ class MlpNode:
                     clamp_value=clamp_value,
                     activation_type=activation_type,
                     use_accuracy_compatible=use_accuracy_compatible,
+                    use_w4a8=use_w4a8,
+                    use_w4a8_fused_quant=use_w4a8_fused_quant,
                 )
                 for local_expert_id in range(self.num_experts_per_device)
             ]
@@ -510,6 +513,7 @@ class MlpNode:
                 activation_type=activation_type,
                 use_accuracy_compatible=use_accuracy_compatible,
                 use_w4a8=use_w4a8,
+                use_w4a8_fused_quant=use_w4a8_fused_quant,
             )
         self.unzip_node = UnZipNode(self.token_dispatcher)
         self.zip_node = ZipNode(self.token_dispatcher)
@@ -3121,6 +3125,7 @@ class FusionMoePyLayer(paddle.autograd.PyLayer):
         activation_type=None,
         use_accuracy_compatible=False,
         use_w4a8=False,
+        use_w4a8_fused_quant=False,
     ):
         """
         根据给定的参数执行前向传播操作。
@@ -3158,6 +3163,7 @@ class FusionMoePyLayer(paddle.autograd.PyLayer):
             activation_type=activation_type,
             use_accuracy_compatible=use_accuracy_compatible,
             use_w4a8=use_w4a8,
+            use_w4a8_fused_quant=use_w4a8_fused_quant,
         )
 
         if fp8_dispatched_handle is not None:

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -179,7 +179,6 @@ class MoELayer(nn.Layer):
         self.use_w4a8 = config.use_w4a8
         self.dw_p2p_overlap = getattr(config, "dw_p2p_overlap", False)
         self.using_sonic_moe = self.config.using_sonic_moe
-        self.fp8_dispatch = bool(config.fp8)
         self.fp8_dispatch = bool(config.fp8) and not self.use_w4a8
         self.fp8_wgrad = config.fp8_wgrad
         self.fp8_dispatch_bwd = (

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -177,6 +177,7 @@ class MoELayer(nn.Layer):
         self.fp8 = config.fp8
         self.use_ue8m0 = config.use_ue8m0
         self.use_w4a8 = config.use_w4a8
+        self.use_w4a8_fused_quant = config.use_w4a8_fused_quant
         self.dw_p2p_overlap = getattr(config, "dw_p2p_overlap", False)
         self.using_sonic_moe = self.config.using_sonic_moe
         self.fp8_dispatch = bool(config.fp8) and not self.use_w4a8
@@ -994,6 +995,7 @@ class MoELayer(nn.Layer):
                         self.config, "use_accuracy_compatible", False
                     ),
                     use_w4a8=self.use_w4a8,
+                    use_w4a8_fused_quant=self.use_w4a8_fused_quant,
                 )
 
         with profile("combine"):
@@ -1153,6 +1155,7 @@ class MoELayer(nn.Layer):
                         self.config, "use_accuracy_compatible", False
                     ),
                     use_w4a8=self.use_w4a8,
+                    use_w4a8_fused_quant=self.use_w4a8_fused_quant,
                 )
 
             if is_first_fwd:

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -671,6 +671,9 @@ class TransformerConfig(ModelParallelConfig):
     use_w4a8: bool = False
     """Whether to use w4a8 for mlp gemm."""
 
+    use_w4a8_fused_quant: bool = False
+    """Whether to use fused CUDA operators for W4A8 online quantization."""
+
     full_fp8_computation: bool = False
     """Master switch for FP8 on Linear / ColumnParallelLinear / RowParallelLinear
     and DSv4HybridSelfAttention / CSAIndexer. When ``False`` these layers stay

--- a/tests/single_card_tests/fp8/test_w4a8_cuda_quant.py
+++ b/tests/single_card_tests/fp8/test_w4a8_cuda_quant.py
@@ -21,6 +21,21 @@ from unittest import mock
 import numpy as np
 import paddle
 
+from paddlefleet.transformer.moe import fp8_utils
+from paddlefleet.transformer.moe.fp8_utils import (
+    ExpertsGroupGemmContiguousNode,
+    _w4a8_dequant,
+    _w4a8_quant,
+    _w4a8_stack_quant,
+    _w4a8_weighted_swiglu_quant,
+    fuse_stack_fp8_quant_python,
+    fuse_stack_transpose_fp8_quant_python,
+    fuse_weighted_swiglu_fp8_quant_clamp_python,
+    fuse_weighted_swiglu_fp8_quant_python,
+    fused_act_dequant_python,
+    quant_blockwize,
+)
+
 
 def _prepare_blackwell():
     if (
@@ -45,20 +60,335 @@ if IS_BLACKWELL:
         w4a8_weighted_swiglu_quantize_1x32,
     )
 
-    from paddlefleet.transformer.moe.fp8_utils import (
-        _w4a8_quant,
-        _w4a8_weighted_swiglu_quant,
-        fuse_stack_fp8_quant_python,
-        fuse_stack_transpose_fp8_quant_python,
-        fuse_weighted_swiglu_fp8_quant_clamp_python,
-        fuse_weighted_swiglu_fp8_quant_python,
-        fused_act_dequant_python,
-        quant_blockwize,
-    )
-
 
 def _fp8_bits(value):
     return value.view("int8")
+
+
+class TestW4A8RuntimeDispatch(unittest.TestCase):
+    def test_fused_quant_flag_requires_custom_ops(self):
+        with (
+            mock.patch.dict(os.environ, {"PADDLEFLEET_W4A8_FUSED_QUANT": "0"}),
+            mock.patch.object(fp8_utils, "HAS_W4A8_FUSED_QUANT", False),
+        ):
+            self.assertFalse(fp8_utils._use_w4a8_fused_quant())
+
+        with (
+            mock.patch.dict(os.environ, {"PADDLEFLEET_W4A8_FUSED_QUANT": "1"}),
+            mock.patch.object(fp8_utils, "HAS_W4A8_FUSED_QUANT", True),
+        ):
+            self.assertTrue(fp8_utils._use_w4a8_fused_quant())
+
+        with (
+            mock.patch.dict(os.environ, {"PADDLEFLEET_W4A8_FUSED_QUANT": "1"}),
+            mock.patch.object(fp8_utils, "HAS_W4A8_FUSED_QUANT", False),
+            self.assertRaisesRegex(RuntimeError, "requires paddlefleet_ops"),
+        ):
+            fp8_utils._use_w4a8_fused_quant()
+
+    def test_quant_dispatches_to_fused_and_python_ops(self):
+        value = mock.sentinel.value
+        fused_result = (mock.sentinel.fused_q, mock.sentinel.fused_scale)
+        python_result = (mock.sentinel.python_q, mock.sentinel.python_scale)
+
+        with (
+            mock.patch.object(
+                fp8_utils, "_use_w4a8_fused_quant", return_value=True
+            ),
+            mock.patch.object(
+                fp8_utils,
+                "w4a8_quantize_1x32",
+                create=True,
+                return_value=fused_result,
+            ) as fused_quant,
+        ):
+            self.assertEqual(_w4a8_quant(value, "fp8"), fused_result)
+            self.assertEqual(_w4a8_quant(value, "fp4"), fused_result)
+            fused_quant.assert_has_calls(
+                [mock.call(value, 0), mock.call(value, 1)]
+            )
+
+        with (
+            mock.patch.object(
+                fp8_utils, "_use_w4a8_fused_quant", return_value=False
+            ),
+            mock.patch.object(
+                fp8_utils, "quant_blockwize", return_value=python_result
+            ) as python_quant,
+        ):
+            self.assertEqual(_w4a8_quant(value, "fp8"), python_result)
+            python_quant.assert_called_once_with(value, quant_dtype="fp8")
+
+    def test_stack_quant_dispatches_to_fused_and_python_ops(self):
+        weights = mock.sentinel.weights
+        stacked = mock.sentinel.stacked
+        fused_result = (mock.sentinel.fused_q, mock.sentinel.fused_scale)
+
+        with (
+            mock.patch.object(
+                fp8_utils, "_use_w4a8_fused_quant", return_value=True
+            ),
+            mock.patch.object(
+                fp8_utils, "_stack_expert_weights", return_value=stacked
+            ) as stack_weights,
+            mock.patch.object(
+                fp8_utils,
+                "w4a8_stack_quantize_1x32",
+                create=True,
+                return_value=fused_result,
+            ) as fused_quant,
+        ):
+            self.assertEqual(_w4a8_stack_quant(weights, True), fused_result)
+            stack_weights.assert_called_once_with(weights)
+            fused_quant.assert_called_once_with(stacked, True)
+
+        for transpose, function_name in (
+            (False, "fuse_stack_fp8_quant_python"),
+            (True, "fuse_stack_transpose_fp8_quant_python"),
+        ):
+            python_result = (mock.sentinel.python_q, mock.sentinel.python_scale)
+            with (
+                self.subTest(transpose=transpose),
+                mock.patch.object(
+                    fp8_utils, "_use_w4a8_fused_quant", return_value=False
+                ),
+                mock.patch.object(
+                    fp8_utils, function_name, return_value=python_result
+                ) as python_quant,
+            ):
+                self.assertEqual(
+                    _w4a8_stack_quant(weights, transpose), python_result
+                )
+                python_quant.assert_called_once_with(weights, quant_dtype="fp4")
+
+    def test_weighted_swiglu_dispatches_all_paths(self):
+        value = mock.sentinel.value
+        probs = mock.sentinel.probs
+        result = (mock.sentinel.quantized, mock.sentinel.scale)
+
+        with (
+            mock.patch.object(
+                fp8_utils, "_use_w4a8_fused_quant", return_value=True
+            ),
+            mock.patch.object(
+                fp8_utils,
+                "w4a8_weighted_swiglu_quantize_1x32",
+                create=True,
+                return_value=result,
+            ) as fused_quant,
+        ):
+            self.assertEqual(_w4a8_weighted_swiglu_quant(value, probs), result)
+            self.assertEqual(
+                _w4a8_weighted_swiglu_quant(value, probs, 10), result
+            )
+            fused_quant.assert_has_calls(
+                [mock.call(value, probs, 0.0), mock.call(value, probs, 10.0)]
+            )
+
+        for clamp_value, function_name in (
+            (None, "fuse_weighted_swiglu_fp8_quant_python"),
+            (0.0, "fuse_weighted_swiglu_fp8_quant_python"),
+            (10.0, "fuse_weighted_swiglu_fp8_quant_clamp_python"),
+        ):
+            with (
+                self.subTest(clamp_value=clamp_value),
+                mock.patch.object(
+                    fp8_utils, "_use_w4a8_fused_quant", return_value=False
+                ),
+                mock.patch.object(
+                    fp8_utils, function_name, return_value=result
+                ) as python_quant,
+            ):
+                self.assertEqual(
+                    _w4a8_weighted_swiglu_quant(
+                        value, probs, clamp_value=clamp_value
+                    ),
+                    result,
+                )
+                expected_args = (
+                    (value, probs, clamp_value)
+                    if clamp_value
+                    else (value, probs)
+                )
+                python_quant.assert_called_once_with(*expected_args)
+
+    def test_dequant_dispatches_to_fused_and_python_ops(self):
+        value = mock.sentinel.value
+        scale = mock.sentinel.scale
+
+        for enabled, function_name in (
+            (True, "w4a8_dequantize_1x32"),
+            (False, "fused_act_dequant_python"),
+        ):
+            result = mock.sentinel.dequantized
+            with (
+                self.subTest(enabled=enabled),
+                mock.patch.object(
+                    fp8_utils,
+                    "_use_w4a8_fused_quant",
+                    return_value=enabled,
+                ),
+                mock.patch.object(
+                    fp8_utils,
+                    function_name,
+                    create=True,
+                    return_value=result,
+                ) as dequant,
+            ):
+                self.assertIs(_w4a8_dequant(value, scale), result)
+                dequant.assert_called_once_with(value, scale)
+
+    @staticmethod
+    def _make_node():
+        node = object.__new__(ExpertsGroupGemmContiguousNode)
+        node._w4a8_grouped_gemm = mock.Mock(
+            side_effect=lambda _x, _xs, _w, _ws, output: output
+        )
+        return node
+
+    def test_w4a8_forward_methods_use_dispatch_helpers(self):
+        node = self._make_node()
+        node.dequant_input = False
+        node.clamp_value = 10.0
+        x = mock.sentinel.x
+        weights = mock.sentinel.weights
+        probs = mock.sentinel.probs
+        x_q = mock.Mock(shape=[3, 32])
+        x_scale = mock.sentinel.x_scale
+        weight_q = mock.Mock(shape=[2, 64, 16])
+        weight_scale = mock.sentinel.weight_scale
+        gate_output = mock.Mock(shape=[3, 64])
+
+        with (
+            mock.patch.object(
+                fp8_utils,
+                "_w4a8_stack_quant",
+                return_value=(weight_q, weight_scale),
+            ) as stack_quant,
+            mock.patch.object(
+                fp8_utils, "_w4a8_quant", return_value=(x_q, x_scale)
+            ) as quant,
+            mock.patch.object(
+                fp8_utils.paddle, "empty", return_value=gate_output
+            ),
+        ):
+            self.assertIs(node._fwd_gate_up_w4a8(x, weights), gate_output)
+            stack_quant.assert_called_once_with(weights, transpose=True)
+            quant.assert_called_once_with(x, quant_dtype="fp8")
+
+        swiglu_q = mock.Mock(shape=[3, 64])
+        swiglu_scale = mock.sentinel.swiglu_scale
+        down_output = mock.Mock(shape=[3, 64])
+        with (
+            mock.patch.object(
+                fp8_utils,
+                "_w4a8_stack_quant",
+                return_value=(weight_q, weight_scale),
+            ) as stack_quant,
+            mock.patch.object(
+                fp8_utils,
+                "_w4a8_weighted_swiglu_quant",
+                return_value=(swiglu_q, swiglu_scale),
+            ) as swiglu_quant,
+            mock.patch.object(
+                fp8_utils.paddle, "empty", return_value=down_output
+            ),
+        ):
+            self.assertIs(
+                node._fwd_down_w4a8(
+                    mock.sentinel.o1, probs, weights, clear_o1=False
+                ),
+                down_output,
+            )
+            stack_quant.assert_called_once_with(weights, transpose=True)
+            swiglu_quant.assert_called_once_with(
+                mock.sentinel.o1, probs, node.clamp_value
+            )
+
+    def test_w4a8_backward_methods_use_dispatch_helpers(self):
+        node = self._make_node()
+        node.clamp_value = None
+        weights = mock.sentinel.weights
+        grad = mock.Mock(dtype=paddle.bfloat16)
+        weight_q = mock.Mock(shape=[2, 64, 16])
+        weight_scale = mock.sentinel.weight_scale
+        grad_q = mock.Mock(shape=[3, 32])
+        grad_scale = mock.sentinel.grad_scale
+        gemm_output = mock.Mock(shape=[3, 64])
+        backward_result = (
+            mock.sentinel.do1,
+            mock.sentinel.probs_grad,
+            mock.sentinel.o2,
+        )
+
+        with (
+            mock.patch.object(
+                fp8_utils,
+                "_w4a8_stack_quant",
+                return_value=(weight_q, weight_scale),
+            ) as stack_quant,
+            mock.patch.object(
+                fp8_utils, "_w4a8_quant", return_value=(grad_q, grad_scale)
+            ) as quant,
+            mock.patch.object(
+                fp8_utils.paddle, "empty", return_value=gemm_output
+            ),
+            mock.patch.object(fp8_utils.paddle.amp, "auto_cast") as auto_cast,
+            mock.patch.object(fp8_utils, "USE_INPLACE_SWIGLU_BWD", True),
+            mock.patch.object(
+                fp8_utils,
+                "_fused_swiglu_probs_bwd",
+                return_value=backward_result,
+            ),
+        ):
+            auto_cast.return_value.__enter__.return_value = None
+            result = node._bwd_down_input_w4a8(
+                weights, grad, mock.sentinel.o1, mock.sentinel.probs
+            )
+            self.assertEqual(
+                result,
+                (
+                    mock.sentinel.do1,
+                    mock.sentinel.o2,
+                    mock.sentinel.probs_grad,
+                ),
+            )
+            stack_quant.assert_called_once_with(weights, transpose=False)
+            quant.assert_called_once_with(grad, quant_dtype="fp8")
+
+        dx = mock.Mock(shape=[3, 64])
+        with (
+            mock.patch.object(
+                fp8_utils,
+                "_w4a8_stack_quant",
+                return_value=(weight_q, weight_scale),
+            ) as stack_quant,
+            mock.patch.object(
+                fp8_utils, "_w4a8_quant", return_value=(grad_q, grad_scale)
+            ) as quant,
+            mock.patch.object(fp8_utils.paddle, "empty", return_value=dx),
+        ):
+            self.assertIs(node._bwd_gate_up_input_w4a8(grad, weights), dx)
+            stack_quant.assert_called_once_with(weights, transpose=False)
+            quant.assert_called_once_with(grad, quant_dtype="fp8")
+
+    def test_w4a8_weight_grad_uses_dispatch_dequant(self):
+        class DequantCalled(Exception):
+            pass
+
+        node = self._make_node()
+        node.dequant_input = True
+        node.use_w4a8 = True
+        node.input_fp8 = mock.sentinel.input_fp8
+        node.input_scale = mock.sentinel.input_scale
+        with mock.patch.object(
+            fp8_utils, "_w4a8_dequant", side_effect=DequantCalled
+        ) as dequant:
+            with self.assertRaises(DequantCalled):
+                node.bf16_weight_grad(
+                    mock.sentinel.dy, None, mock.sentinel.weights
+                )
+            dequant.assert_called_once_with(node.input_fp8, node.input_scale)
 
 
 @unittest.skipUnless(IS_BLACKWELL, "requires a Blackwell CUDA device")

--- a/tests/single_card_tests/fp8/test_w4a8_cuda_quant.py
+++ b/tests/single_card_tests/fp8/test_w4a8_cuda_quant.py
@@ -14,8 +14,8 @@
 
 """Bit-exact parity tests for the fused W4A8 1x32 CUDA custom ops."""
 
-import os
 import unittest
+from types import SimpleNamespace
 from unittest import mock
 
 import numpy as np
@@ -35,6 +35,8 @@ from paddlefleet.transformer.moe.fp8_utils import (
     fused_act_dequant_python,
     quant_blockwize,
 )
+from paddlefleet.transformer.moe.fusion_layer_utils import MlpNode
+from paddlefleet.transformer.transformer_config import TransformerConfig
 
 
 def _prepare_blackwell():
@@ -66,25 +68,47 @@ def _fp8_bits(value):
 
 
 class TestW4A8RuntimeDispatch(unittest.TestCase):
+    def test_fused_quant_model_config(self):
+        self.assertFalse(TransformerConfig().use_w4a8_fused_quant)
+        self.assertTrue(
+            TransformerConfig(use_w4a8_fused_quant=True).use_w4a8_fused_quant
+        )
+
+    def test_mlp_node_forwards_fused_quant_model_config(self):
+        custom_map = SimpleNamespace(
+            token_dispatcher=SimpleNamespace(
+                _comm_manager=SimpleNamespace(tokens_per_expert=[1])
+            ),
+            num_experts_per_device=1,
+        )
+        with mock.patch(
+            "paddlefleet.transformer.moe.fusion_layer_utils."
+            "ExpertsGroupGemmContiguousNode"
+        ) as gemm_node:
+            MlpNode(
+                custom_map,
+                num_experts_per_tok=1,
+                moe_expert_fusion=True,
+                moe_deep_gemm=True,
+                use_w4a8=True,
+                use_w4a8_fused_quant=True,
+            )
+
+        self.assertTrue(gemm_node.call_args.kwargs["use_w4a8"])
+        self.assertTrue(gemm_node.call_args.kwargs["use_w4a8_fused_quant"])
+
     def test_fused_quant_flag_requires_custom_ops(self):
-        with (
-            mock.patch.dict(os.environ, {"PADDLEFLEET_W4A8_FUSED_QUANT": "0"}),
-            mock.patch.object(fp8_utils, "HAS_W4A8_FUSED_QUANT", False),
-        ):
-            self.assertFalse(fp8_utils._use_w4a8_fused_quant())
+        with mock.patch.object(fp8_utils, "HAS_W4A8_FUSED_QUANT", False):
+            self.assertFalse(fp8_utils._use_w4a8_fused_quant(False))
+
+        with mock.patch.object(fp8_utils, "HAS_W4A8_FUSED_QUANT", True):
+            self.assertTrue(fp8_utils._use_w4a8_fused_quant(True))
 
         with (
-            mock.patch.dict(os.environ, {"PADDLEFLEET_W4A8_FUSED_QUANT": "1"}),
-            mock.patch.object(fp8_utils, "HAS_W4A8_FUSED_QUANT", True),
-        ):
-            self.assertTrue(fp8_utils._use_w4a8_fused_quant())
-
-        with (
-            mock.patch.dict(os.environ, {"PADDLEFLEET_W4A8_FUSED_QUANT": "1"}),
             mock.patch.object(fp8_utils, "HAS_W4A8_FUSED_QUANT", False),
             self.assertRaisesRegex(RuntimeError, "requires paddlefleet_ops"),
         ):
-            fp8_utils._use_w4a8_fused_quant()
+            fp8_utils._use_w4a8_fused_quant(True)
 
     def test_quant_dispatches_to_fused_and_python_ops(self):
         value = mock.sentinel.value
@@ -102,8 +126,8 @@ class TestW4A8RuntimeDispatch(unittest.TestCase):
                 return_value=fused_result,
             ) as fused_quant,
         ):
-            self.assertEqual(_w4a8_quant(value, "fp8"), fused_result)
-            self.assertEqual(_w4a8_quant(value, "fp4"), fused_result)
+            self.assertEqual(_w4a8_quant(value, "fp8", True), fused_result)
+            self.assertEqual(_w4a8_quant(value, "fp4", True), fused_result)
             fused_quant.assert_has_calls(
                 [mock.call(value, 0), mock.call(value, 1)]
             )
@@ -138,7 +162,10 @@ class TestW4A8RuntimeDispatch(unittest.TestCase):
                 return_value=fused_result,
             ) as fused_quant,
         ):
-            self.assertEqual(_w4a8_stack_quant(weights, True), fused_result)
+            self.assertEqual(
+                _w4a8_stack_quant(weights, True, use_w4a8_fused_quant=True),
+                fused_result,
+            )
             stack_weights.assert_called_once_with(weights)
             fused_quant.assert_called_once_with(stacked, True)
 
@@ -177,9 +204,17 @@ class TestW4A8RuntimeDispatch(unittest.TestCase):
                 return_value=result,
             ) as fused_quant,
         ):
-            self.assertEqual(_w4a8_weighted_swiglu_quant(value, probs), result)
             self.assertEqual(
-                _w4a8_weighted_swiglu_quant(value, probs, 10), result
+                _w4a8_weighted_swiglu_quant(
+                    value, probs, use_w4a8_fused_quant=True
+                ),
+                result,
+            )
+            self.assertEqual(
+                _w4a8_weighted_swiglu_quant(
+                    value, probs, 10, use_w4a8_fused_quant=True
+                ),
+                result,
             )
             fused_quant.assert_has_calls(
                 [mock.call(value, probs, 0.0), mock.call(value, probs, 10.0)]
@@ -235,12 +270,20 @@ class TestW4A8RuntimeDispatch(unittest.TestCase):
                     return_value=result,
                 ) as dequant,
             ):
-                self.assertIs(_w4a8_dequant(value, scale), result)
+                self.assertIs(
+                    _w4a8_dequant(
+                        value,
+                        scale,
+                        use_w4a8_fused_quant=enabled,
+                    ),
+                    result,
+                )
                 dequant.assert_called_once_with(value, scale)
 
     @staticmethod
     def _make_node():
         node = object.__new__(ExpertsGroupGemmContiguousNode)
+        node.use_w4a8_fused_quant = True
         node._w4a8_grouped_gemm = mock.Mock(
             side_effect=lambda _x, _xs, _w, _ws, output: output
         )
@@ -273,8 +316,16 @@ class TestW4A8RuntimeDispatch(unittest.TestCase):
             ),
         ):
             self.assertIs(node._fwd_gate_up_w4a8(x, weights), gate_output)
-            stack_quant.assert_called_once_with(weights, transpose=True)
-            quant.assert_called_once_with(x, quant_dtype="fp8")
+            stack_quant.assert_called_once_with(
+                weights,
+                transpose=True,
+                use_w4a8_fused_quant=True,
+            )
+            quant.assert_called_once_with(
+                x,
+                quant_dtype="fp8",
+                use_w4a8_fused_quant=True,
+            )
 
         swiglu_q = mock.Mock(shape=[3, 64])
         swiglu_scale = mock.sentinel.swiglu_scale
@@ -300,9 +351,16 @@ class TestW4A8RuntimeDispatch(unittest.TestCase):
                 ),
                 down_output,
             )
-            stack_quant.assert_called_once_with(weights, transpose=True)
+            stack_quant.assert_called_once_with(
+                weights,
+                transpose=True,
+                use_w4a8_fused_quant=True,
+            )
             swiglu_quant.assert_called_once_with(
-                mock.sentinel.o1, probs, node.clamp_value
+                mock.sentinel.o1,
+                probs,
+                node.clamp_value,
+                use_w4a8_fused_quant=True,
             )
 
     def test_w4a8_backward_methods_use_dispatch_helpers(self):
@@ -353,8 +411,16 @@ class TestW4A8RuntimeDispatch(unittest.TestCase):
                     mock.sentinel.probs_grad,
                 ),
             )
-            stack_quant.assert_called_once_with(weights, transpose=False)
-            quant.assert_called_once_with(grad, quant_dtype="fp8")
+            stack_quant.assert_called_once_with(
+                weights,
+                transpose=False,
+                use_w4a8_fused_quant=True,
+            )
+            quant.assert_called_once_with(
+                grad,
+                quant_dtype="fp8",
+                use_w4a8_fused_quant=True,
+            )
 
         dx = mock.Mock(shape=[3, 64])
         with (
@@ -369,8 +435,16 @@ class TestW4A8RuntimeDispatch(unittest.TestCase):
             mock.patch.object(fp8_utils.paddle, "empty", return_value=dx),
         ):
             self.assertIs(node._bwd_gate_up_input_w4a8(grad, weights), dx)
-            stack_quant.assert_called_once_with(weights, transpose=False)
-            quant.assert_called_once_with(grad, quant_dtype="fp8")
+            stack_quant.assert_called_once_with(
+                weights,
+                transpose=False,
+                use_w4a8_fused_quant=True,
+            )
+            quant.assert_called_once_with(
+                grad,
+                quant_dtype="fp8",
+                use_w4a8_fused_quant=True,
+            )
 
     def test_w4a8_weight_grad_uses_dispatch_dequant(self):
         class DequantCalled(Exception):
@@ -388,7 +462,11 @@ class TestW4A8RuntimeDispatch(unittest.TestCase):
                 node.bf16_weight_grad(
                     mock.sentinel.dy, None, mock.sentinel.weights
                 )
-            dequant.assert_called_once_with(node.input_fp8, node.input_scale)
+            dequant.assert_called_once_with(
+                node.input_fp8,
+                node.input_scale,
+                use_w4a8_fused_quant=True,
+            )
 
 
 @unittest.skipUnless(IS_BLACKWELL, "requires a Blackwell CUDA device")
@@ -419,14 +497,13 @@ class TestW4A8CudaQuantParity(unittest.TestCase):
     def test_quantize_runtime_dispatch(self):
         value = paddle.randn([37, 256], dtype="bfloat16") * 3.0
         expected_q, expected_scale = quant_blockwize(value, quant_dtype="fp8")
-        for enabled in ("0", "1"):
-            with (
-                self.subTest(enabled=enabled),
-                mock.patch.dict(
-                    os.environ, {"PADDLEFLEET_W4A8_FUSED_QUANT": enabled}
-                ),
-            ):
-                actual_q, actual_scale = _w4a8_quant(value, quant_dtype="fp8")
+        for enabled in (False, True):
+            with self.subTest(enabled=enabled):
+                actual_q, actual_scale = _w4a8_quant(
+                    value,
+                    quant_dtype="fp8",
+                    use_w4a8_fused_quant=enabled,
+                )
                 self.assert_fp8_equal(actual_q, expected_q)
                 self.assert_tensor_equal(
                     actual_scale, expected_scale, "UE8M0 scale differs"
@@ -516,12 +593,12 @@ class TestW4A8CudaQuantParity(unittest.TestCase):
                 self.assert_tensor_equal(
                     actual_scale, expected_scale, "UE8M0 scale differs"
                 )
-                with mock.patch.dict(
-                    os.environ, {"PADDLEFLEET_W4A8_FUSED_QUANT": "1"}
-                ):
-                    dispatched_q, dispatched_scale = (
-                        _w4a8_weighted_swiglu_quant(value, probs, clamp_value)
-                    )
+                dispatched_q, dispatched_scale = _w4a8_weighted_swiglu_quant(
+                    value,
+                    probs,
+                    clamp_value,
+                    use_w4a8_fused_quant=True,
+                )
                 self.assert_fp8_equal(dispatched_q, expected_q)
                 self.assert_tensor_equal(
                     dispatched_scale,

--- a/tests/single_card_tests/fp8/test_w4a8_cuda_quant.py
+++ b/tests/single_card_tests/fp8/test_w4a8_cuda_quant.py
@@ -47,6 +47,7 @@ if IS_BLACKWELL:
 
     from paddlefleet.transformer.moe.fp8_utils import (
         _w4a8_quant,
+        _w4a8_weighted_swiglu_quant,
         fuse_stack_fp8_quant_python,
         fuse_stack_transpose_fp8_quant_python,
         fuse_weighted_swiglu_fp8_quant_clamp_python,
@@ -184,6 +185,18 @@ class TestW4A8CudaQuantParity(unittest.TestCase):
                 self.assert_fp8_equal(actual_q, expected_q)
                 self.assert_tensor_equal(
                     actual_scale, expected_scale, "UE8M0 scale differs"
+                )
+                with mock.patch.dict(
+                    os.environ, {"PADDLEFLEET_W4A8_FUSED_QUANT": "1"}
+                ):
+                    dispatched_q, dispatched_scale = (
+                        _w4a8_weighted_swiglu_quant(value, probs, clamp_value)
+                    )
+                self.assert_fp8_equal(dispatched_q, expected_q)
+                self.assert_tensor_equal(
+                    dispatched_scale,
+                    expected_scale,
+                    "runtime-dispatched UE8M0 scale differs",
                 )
 
     def test_dequantize_fp8(self):

--- a/tests/single_card_tests/fp8/test_w4a8_cuda_quant.py
+++ b/tests/single_card_tests/fp8/test_w4a8_cuda_quant.py
@@ -1,0 +1,198 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Bit-exact parity tests for the fused W4A8 1x32 CUDA custom ops."""
+
+import os
+import unittest
+from unittest import mock
+
+import numpy as np
+import paddle
+
+
+def _prepare_blackwell():
+    if (
+        not paddle.is_compiled_with_cuda()
+        or paddle.device.cuda.device_count() == 0
+    ):
+        return False
+    try:
+        paddle.set_device("gpu:0")
+        return paddle.device.cuda.get_device_capability()[0] >= 10
+    except (RuntimeError, ValueError):
+        return False
+
+
+IS_BLACKWELL = _prepare_blackwell()
+
+if IS_BLACKWELL:
+    from paddlefleet_ops import (
+        w4a8_dequantize_1x32,
+        w4a8_quantize_1x32,
+        w4a8_stack_quantize_1x32,
+        w4a8_weighted_swiglu_quantize_1x32,
+    )
+
+    from paddlefleet.transformer.moe.fp8_utils import (
+        _w4a8_quant,
+        fuse_stack_fp8_quant_python,
+        fuse_stack_transpose_fp8_quant_python,
+        fuse_weighted_swiglu_fp8_quant_clamp_python,
+        fuse_weighted_swiglu_fp8_quant_python,
+        fused_act_dequant_python,
+        quant_blockwize,
+    )
+
+
+def _fp8_bits(value):
+    return value.view("int8")
+
+
+@unittest.skipUnless(IS_BLACKWELL, "requires a Blackwell CUDA device")
+class TestW4A8CudaQuantParity(unittest.TestCase):
+    def setUp(self):
+        paddle.seed(23)
+        np.random.seed(23)
+
+    def assert_tensor_equal(self, actual, expected, message):
+        self.assertEqual(actual.dtype, expected.dtype)
+        self.assertEqual(list(actual.shape), list(expected.shape))
+        self.assertTrue(bool((actual == expected).all()), message)
+
+    def assert_fp8_equal(self, actual, expected):
+        self.assert_tensor_equal(
+            _fp8_bits(actual), _fp8_bits(expected), "FP8 payload differs"
+        )
+
+    def test_quantize_fp8(self):
+        value = paddle.randn([37, 256], dtype="bfloat16") * 3.0
+        expected_q, expected_scale = quant_blockwize(value, quant_dtype="fp8")
+        actual_q, actual_scale = w4a8_quantize_1x32(value, 0)
+        self.assert_fp8_equal(actual_q, expected_q)
+        self.assert_tensor_equal(
+            actual_scale, expected_scale, "UE8M0 scale differs"
+        )
+
+    def test_quantize_runtime_dispatch(self):
+        value = paddle.randn([37, 256], dtype="bfloat16") * 3.0
+        expected_q, expected_scale = quant_blockwize(value, quant_dtype="fp8")
+        for enabled in ("0", "1"):
+            with (
+                self.subTest(enabled=enabled),
+                mock.patch.dict(
+                    os.environ, {"PADDLEFLEET_W4A8_FUSED_QUANT": enabled}
+                ),
+            ):
+                actual_q, actual_scale = _w4a8_quant(value, quant_dtype="fp8")
+                self.assert_fp8_equal(actual_q, expected_q)
+                self.assert_tensor_equal(
+                    actual_scale, expected_scale, "UE8M0 scale differs"
+                )
+
+    def test_quantize_fp4_random_and_midpoints(self):
+        random_value = paddle.randn([17, 256], dtype="bfloat16") * 3.0
+        midpoints = np.array(
+            [
+                0.0,
+                0.25,
+                -0.25,
+                0.75,
+                -0.75,
+                1.25,
+                -1.25,
+                1.75,
+                -1.75,
+                2.5,
+                -2.5,
+                3.5,
+                -3.5,
+                5.0,
+                -5.0,
+                6.0,
+            ]
+            + [0.0] * 16,
+            dtype=np.float32,
+        )
+        midpoint_value = paddle.to_tensor(
+            np.tile(midpoints[:32], (1, 8)), dtype="float32"
+        )
+        for value in (random_value, midpoint_value):
+            with self.subTest(shape=list(value.shape)):
+                expected_q, expected_scale = quant_blockwize(
+                    value, quant_dtype="fp4"
+                )
+                actual_q, actual_scale = w4a8_quantize_1x32(value, 1)
+                self.assert_tensor_equal(
+                    actual_q, expected_q, "packed FP4 differs"
+                )
+                self.assert_tensor_equal(
+                    actual_scale, expected_scale, "UE8M0 scale differs"
+                )
+
+    def test_stack_fp4(self):
+        weights = paddle.randn([3, 64, 256], dtype="bfloat16")
+        for transpose in (False, True):
+            with self.subTest(transpose=transpose):
+                reference = (
+                    fuse_stack_transpose_fp8_quant_python
+                    if transpose
+                    else fuse_stack_fp8_quant_python
+                )
+                expected_q, expected_scale = reference(
+                    weights, quant_dtype="fp4"
+                )
+                actual_q, actual_scale = w4a8_stack_quantize_1x32(
+                    weights, transpose
+                )
+                self.assert_tensor_equal(
+                    actual_q, expected_q, "packed FP4 differs"
+                )
+                self.assert_tensor_equal(
+                    actual_scale, expected_scale, "UE8M0 scale differs"
+                )
+
+    def test_weighted_swiglu_fp8(self):
+        value = paddle.randn([31, 512], dtype="bfloat16") * 2.0
+        probs = paddle.rand([31], dtype="float32")
+        for clamp_value in (0.0, 10.0):
+            with self.subTest(clamp_value=clamp_value):
+                if clamp_value:
+                    expected_q, expected_scale = (
+                        fuse_weighted_swiglu_fp8_quant_clamp_python(
+                            value, probs, clamp_value
+                        )
+                    )
+                else:
+                    expected_q, expected_scale = (
+                        fuse_weighted_swiglu_fp8_quant_python(value, probs)
+                    )
+                actual_q, actual_scale = w4a8_weighted_swiglu_quantize_1x32(
+                    value, probs, clamp_value
+                )
+                self.assert_fp8_equal(actual_q, expected_q)
+                self.assert_tensor_equal(
+                    actual_scale, expected_scale, "UE8M0 scale differs"
+                )
+
+    def test_dequantize_fp8(self):
+        value = paddle.randn([37, 256], dtype="bfloat16")
+        quantized, scale = quant_blockwize(value, quant_dtype="fp8")
+        expected = fused_act_dequant_python(quantized, scale)
+        actual = w4a8_dequantize_1x32(quantized, scale)
+        self.assert_tensor_equal(actual, expected, "BF16 dequant differs")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### PR Category

Performance Optimization

### PR Types

Performance, New features

### Description

The W4A8 training base support is already available on develop via #1536.

This follow-up adds fused CUDA custom operators for the W4A8Training 1x32 quantization path:

- BF16 to FP8/FP4 group32 quantization
- stacked expert-weight FP4 quantization, with transpose and non-transpose layouts
- weighted SwiGLU + FP8 quantization, including clamp support
- FP8 group32 dequantization for backward

Enable the optimized path through the model config:

```yaml
use_w4a8: true
use_w4a8_fused_quant: true
```

`use_w4a8_fused_quant` requires `use_w4a8` to be enabled at the same time. When `use_w4a8_fused_quant` is `false` (the default), the existing Python quantization implementation remains unchanged. This PR does not include Expert Cache or FP4 Indexer changes.

Validation on B30Z / SM 10.3:

- 6 CUDA parity tests passed
- bit-exact FP8 payload and scale parity
- bit-exact packed FP4 parity, including E2M1 midpoint cases
- transpose/non-transpose, weighted SwiGLU clamp, and dequantization covered

### Whether precision changes

No. The fused CUDA path is bit-exact with the existing Python reference implementation in the covered W4A8Training operations.
