### PR TITLE
[Config] Modify configuration default values

### DIFF
--- a/src/paddlefleet/model_parallel_config.py
+++ b/src/paddlefleet/model_parallel_config.py
@@ -277,12 +277,12 @@ class ModelParallelConfig:
         should only be set if the sequence length varies by microbatch within a global batch.
     """
 
-    overlap_p2p_comm: bool = False
+    overlap_p2p_comm: bool = True
     """When True some of the peer to peer communication for pipeline parallelism will overlap with
        computation. Must be False if batch_p2p_comm is true.
     """
 
-    batch_p2p_comm: bool = True
+    batch_p2p_comm: bool | None = None
     """Use batch_isend_irecv instead of individual isend/irecv calls. Must be False if
        overlap_p2p_comm is True.
     """

--- a/src/paddlefleet/transformer/moe/token_dispatcher.py
+++ b/src/paddlefleet/transformer/moe/token_dispatcher.py
@@ -1238,7 +1238,8 @@ class AllToAllTokenDispatcher(nn.Layer):
             routing_map=self.routing_map,
             use_accuracy_compatible=self.use_accuracy_compatible,
         )
-        return output.cast(self.hidden_states_dtype)
+        output_dtype = getattr(self, "hidden_states_dtype", output.dtype)
+        return output.cast(output_dtype)
 
 
 class _RouterAllGather(paddle.autograd.PyLayer):

--- a/src/paddlefleet/transformer/moe/token_dispatcher.py
+++ b/src/paddlefleet/transformer/moe/token_dispatcher.py
@@ -1040,6 +1040,7 @@ class AllToAllTokenDispatcher(nn.Layer):
     ) -> tuple[paddle.Tensor, paddle.Tensor]:
         self.routing_map = mask
         self.probs = probs
+        self.hidden_states_dtype = hidden_states.dtype
         self.num_experts = (
             self.num_experts_per_device * self.expert_model_parallel_size
         )
@@ -1237,7 +1238,7 @@ class AllToAllTokenDispatcher(nn.Layer):
             routing_map=self.routing_map,
             use_accuracy_compatible=self.use_accuracy_compatible,
         )
-        return output
+        return output.cast(self.hidden_states_dtype)
 
 
 class _RouterAllGather(paddle.autograd.PyLayer):

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -66,7 +66,7 @@ class TransformerConfig(ModelParallelConfig):
     mtp_num_layers: int = 0
     """MTP Layer number."""
 
-    mtp_loss_scaling_factor: float = 0.3
+    mtp_loss_scaling_factor: float = 0.1
     """Weighting factor of Multi-Token Prediction (MTP) loss."""
 
     add_mtp_loss: bool = True
@@ -577,8 +577,8 @@ class TransformerConfig(ModelParallelConfig):
     topk_method: str = "greedy"
     """Options are greedy, group_limited_greedy, noaux_tc, quantile_balancing"""
 
-    moe_token_dispatcher_type: str = "deepep"
-    """The type of token dispatcher to use. The default is 'deepep'.
+    moe_token_dispatcher_type: str = "alltoall"
+    """The type of token dispatcher to use. The default is 'alltoall'.
     Options are 'allgather', 'alltoall', 'deepep', and 'hybridep'."""
 
     moe_allgather_gate_overlap: bool = True
@@ -1209,8 +1209,8 @@ class TransformerConfig(ModelParallelConfig):
     by TransformerConfig.transform_rules.
     """
 
-    dsa_indexer_loss_coeff: float | None = None
-    """KL loss coefficient for DSA Indexer training. None disables the KL loss.
+    dsa_indexer_loss_coeff: float = 0.0
+    """KL loss coefficient for DSA Indexer training. 0 disables the KL loss.
 
     Note: This field corresponds to the HuggingFace config.json field "indexer_loss_coeff".
     The mapping from HuggingFace field name to PaddleFleet internal field name is handled
@@ -1255,9 +1255,6 @@ class TransformerConfig(ModelParallelConfig):
     This allows compatibility with MLA's YaRN RoPE which always generates
     interleaved frequencies.
     """
-
-    dsa_indexer_loss_coeff: float = 0.01
-    """KL loss coefficient for DSA Indexer training. None disables the KL loss."""
 
     ####################
     # CSA / DSv4 Hybrid Attention

--- a/tests/multi_card_tests/moe/test_force_balance.py
+++ b/tests/multi_card_tests/moe/test_force_balance.py
@@ -83,6 +83,7 @@ class TestFusionBF16ExpertParallel(unittest.TestCase):
             hidden_act=F.silu,
             moe_router_force_load_balancing=True,
             moe_expert_fusion=True,
+            moe_token_dispatcher_type="deepep",
             bias_activation_fusion=True,
         )
 

--- a/tests/multi_card_tests/moe/test_fusion_ep.py
+++ b/tests/multi_card_tests/moe/test_fusion_ep.py
@@ -82,6 +82,7 @@ class TestFusionBF16ExpertParallel(unittest.TestCase):
             n_shared_experts=0,
             hidden_act=F.silu,
             moe_expert_fusion=True,
+            moe_token_dispatcher_type="deepep",
             bias_activation_fusion=True,
             moe_deep_gemm=False,
         )

--- a/tests/multi_card_tests/moe/test_grouped_gemm.py
+++ b/tests/multi_card_tests/moe/test_grouped_gemm.py
@@ -98,6 +98,7 @@ class TestFusionBF16ExpertParallel(unittest.TestCase):
             n_shared_experts=0,
             hidden_act=F.silu,
             moe_expert_fusion=True,
+            moe_token_dispatcher_type="deepep",
             bias_activation_fusion=True,
         )
 

--- a/tests/multi_card_tests/moe/test_imbalance.py
+++ b/tests/multi_card_tests/moe/test_imbalance.py
@@ -82,6 +82,7 @@ class TestFusionBF16ExpertParallel(unittest.TestCase):
             n_shared_experts=0,
             hidden_act=F.silu,
             moe_expert_fusion=True,
+            moe_token_dispatcher_type="deepep",
             bias_activation_fusion=True,
         )
 

--- a/tests/multi_card_tests/pipeline_parallel/test_gpt_pp_with_moe_with_mtp.py
+++ b/tests/multi_card_tests/pipeline_parallel/test_gpt_pp_with_moe_with_mtp.py
@@ -232,7 +232,11 @@ class TestPP(unittest.TestCase):
             bf16=True,
             gated_linear_unit=True,
             bias_activation_fusion=True,
+            moe_token_dispatcher_type="deepep",
             num_nextn_predict_layers=MTP_DEGREE,
+            mtp_loss_scaling_factor=0.3,
+            overlap_p2p_comm=False,
+            batch_p2p_comm=True,
         )
 
         overlap_loss, overlap_gpt_model = run_pp(

--- a/tests/multi_card_tests/pipeline_parallel/test_gpt_pp_with_moe_with_mtp_alltoall.py
+++ b/tests/multi_card_tests/pipeline_parallel/test_gpt_pp_with_moe_with_mtp_alltoall.py
@@ -1,0 +1,255 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import functools
+import os
+import random
+import subprocess
+import unittest
+
+import numpy as np
+import paddle
+from paddle.distributed import fleet
+from paddle.distributed.fleet import distributed_model
+
+import paddlefleet
+from paddlefleet.gpt_builders import gpt_builder
+from paddlefleet.models.gpt import GPTConfig
+from paddlefleet.training.initialize import initialize_fleet
+
+PP_DEGREE = 4
+MTP_DEGREE = 3
+# skip test for paddle pr 79368 merge
+REPO_FLAG = os.getenv("repo_flag")
+SKIP_TESTS = REPO_FLAG != "paddlefleet"
+
+
+def get_gpu_models_via_nvidia_smi():
+    try:
+        output = subprocess.check_output(
+            "nvidia-smi --query-gpu=name --format=csv,noheader", shell=True
+        )
+        models = output.decode().strip().replace("NVIDIA", "")
+        return models
+    except Exception as e:
+        return ["Unknown"]
+
+
+def judge_machine_type():
+    if not paddle.is_compiled_with_cuda():
+        return "No CUDA GPU"
+    models = get_gpu_models_via_nvidia_smi()
+    for model in models:
+        name = model.upper()
+        if "V" in name:
+            return "V"
+        elif "H" in name:
+            return "H"
+        elif "B" in name:
+            return "B"
+
+
+def judge_h_subtype():
+    """Distinguish H800 vs H20 within the Hopper ("H") family."""
+    name = "".join(get_gpu_models_via_nvidia_smi()).upper()
+    if "H800" in name:
+        return "H800"
+    if "H20" in name:
+        return "H20"
+    return None
+
+
+def _set_random_seed(
+    seed_: int,
+    data_parallel_random_init: bool = False,
+    te_rng_tracker: bool = False,
+    inference_rng_tracker: bool = False,
+    use_cudagraphable_rng: bool = False,
+):
+    """Set random seed for reproducibility."""
+    if seed_ is not None and seed_ > 0:
+        # Ensure that different pipeline MP stages get different seeds.
+        seed = seed_ + (
+            100 * paddlefleet.parallel_state.get_pipeline_model_parallel_rank()
+        )
+        # Ensure different data parallel ranks get different seeds
+        if data_parallel_random_init:
+            seed = seed + (
+                10 * paddlefleet.parallel_state.get_data_parallel_rank()
+            )
+        random.seed(seed)
+        np.random.seed(seed)
+        paddle.manual_seed(seed)
+
+        if (
+            paddle.distributed.is_initialized()
+            and paddle.cuda.device_count() > 0
+        ):
+            paddlefleet.tensor_parallel.model_parallel_cuda_manual_seed(
+                seed,
+                te_rng_tracker,
+                inference_rng_tracker,
+                use_cudagraphable_rng,
+            )
+    else:
+        raise ValueError(f"Seed ({seed_}) should be a positive integer.")
+
+
+def run_pp(
+    seed,
+    batch_size,
+    seq_len,
+    vocab_size,
+    config,
+    forward_backward_overlap_scheduler=False,
+):
+    strategy = fleet.DistributedStrategy()
+    strategy.hybrid_configs = {
+        "dp_degree": 1,
+        "mp_degree": config.tensor_model_parallel_size,
+        "pp_degree": config.pipeline_model_parallel_size,
+        "sharding_degree": 1,
+        "sep_degree": 1,
+        "cp_degree": 1,
+        "ep_degree": config.expert_model_parallel_size,
+        "moe_sharding_degree": 1,
+        "order": [
+            "sharding",
+            "moe_sharding",
+            "pp",
+            "sep",
+            "cp",
+            "dp",
+            "ep",
+            "mp",
+        ],
+        "pp_configs": {
+            "forward_backward_overlap_scheduler": forward_backward_overlap_scheduler,
+            "overlap_p2p_comm": True,
+            "enable_dynamic_shape": True,
+        },
+    }
+    micro_batch_size = 1
+    num_acc = batch_size // micro_batch_size
+    strategy.pipeline_configs = {
+        "accumulate_steps": num_acc,
+        "micro_batch_size": micro_batch_size,
+    }
+    initialize_fleet(strategy)
+
+    _set_random_seed(seed)
+
+    gpt_model = gpt_builder(
+        config,
+        num_stages=config.pipeline_model_parallel_size,
+        seg_method="layer:TransformerLayer|EmptyLayer",
+    )
+    gpt_model = paddle.amp.decorate(
+        models=gpt_model, optimizers=None, level="O2", dtype="bfloat16"
+    )
+
+    gpt_pipe_model = distributed_model(gpt_model)
+
+    data = paddle.randint(
+        low=0,
+        high=vocab_size,
+        shape=(micro_batch_size, seq_len + MTP_DEGREE + 1),
+    )
+    input_ids = data[:, :-1]
+    labels = data[:, 1:]
+    position_ids = paddle.to_tensor(data, dtype=paddle.int64).repeat(
+        (micro_batch_size, 1)
+    )
+
+    inputs = (
+        {
+            "input_ids": [input_ids] * num_acc,
+            "position_ids": [position_ids] * num_acc,
+        },
+        [labels] * num_acc,
+    )
+    loss = gpt_pipe_model.forward_backward_pipeline(inputs, None)
+    return loss, gpt_pipe_model
+
+
+class TestPP(unittest.TestCase):
+    def setUp(self):
+        self.seed = 46
+        self.batch_size = 12
+        self.seq_len = 128
+        self.vocab_size = 1024
+
+    def test_pp(self):
+        config = GPTConfig(
+            moe_expert_fusion=False,
+            vocab_size=self.vocab_size,
+            max_sequence_length=self.seq_len,
+            num_hidden_layers=11,
+            hidden_size=512,
+            num_attention_heads=4,
+            intermediate_size=1024,
+            normalization="RMSNorm",
+            hidden_dropout_prob=0.0,
+            attention_dropout=0.0,
+            use_cpu_initialization=True,
+            parallel_output=True,
+            tie_word_embeddings=True,
+            position_embedding_type="rope",
+            rotary_percent=1.0,
+            rotary_base=10000,
+            rope_scaling=1.0,
+            init_method=functools.partial(
+                paddle.nn.init.xavier_uniform_, gain=1.0
+            ),
+            output_layer_init_method=functools.partial(
+                paddle.nn.init.xavier_uniform_, gain=1.0
+            ),
+            use_qk_norm=True,
+            num_empty_layers_add_in_head=2,
+            num_empty_layers_add_in_tail=3,
+            pipeline_model_parallel_size=PP_DEGREE,
+            virtual_pipeline_model_parallel_size=2,
+            tensor_model_parallel_size=2,
+            expert_model_parallel_size=2,
+            sequence_parallel=True,
+            n_shared_experts=1,
+            n_routed_experts=8,
+            moe_intermediate_size=1024,
+            bf16=True,
+            gated_linear_unit=True,
+            bias_activation_fusion=True,
+            num_nextn_predict_layers=MTP_DEGREE,
+        )
+
+        overlap_loss, overlap_gpt_model = run_pp(
+            self.seed,
+            self.batch_size,
+            self.seq_len,
+            self.vocab_size,
+            config,
+        )
+
+        print("PP loss MD5:", overlap_loss._md5sum())
+
+        actual_md5 = overlap_loss._md5sum()
+        expected_md5 = "d389df6ffaea31994404e9268f496967"
+        print(f"PP loss MD5 - Actual: {actual_md5}, Expected: {expected_md5}")
+        assert actual_md5 == expected_md5, (
+            f"PP loss MD5 mismatch! Actual: {actual_md5}, Expected: {expected_md5}"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/multi_card_tests/pipeline_parallel/test_gpt_pp_with_moe_with_mtp_alltoall.py
+++ b/tests/multi_card_tests/pipeline_parallel/test_gpt_pp_with_moe_with_mtp_alltoall.py
@@ -244,7 +244,7 @@ class TestPP(unittest.TestCase):
         print("PP loss MD5:", overlap_loss._md5sum())
 
         actual_md5 = overlap_loss._md5sum()
-        expected_md5 = "d389df6ffaea31994404e9268f496967"
+        expected_md5 = "c095ff73e0078fae9fb936c6efb69c22"
         print(f"PP loss MD5 - Actual: {actual_md5}, Expected: {expected_md5}")
         assert actual_md5 == expected_md5, (
             f"PP loss MD5 mismatch! Actual: {actual_md5}, Expected: {expected_md5}"

--- a/tests/single_card_tests/ai_edited_test/distributed/test_cp_balance_mode_dispatch.py
+++ b/tests/single_card_tests/ai_edited_test/distributed/test_cp_balance_mode_dispatch.py
@@ -1027,6 +1027,7 @@ class TestTransformerConfigMqaIndexerCpMode(unittest.TestCase):
                 self._config(
                     cp_balance_mode="contiguous_allgather",
                     mqa_indexer_cp_mode="dualchunk_p2p",
+                    dsa_indexer_loss_coeff=0.01,
                     **self.MQA_HYBRID,
                     **phase,
                 )

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_config.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_config.py
@@ -351,7 +351,7 @@ class TestTransformerConfigEdgeCases(unittest.TestCase):
         cfg = _make_config()
         self.assertEqual(cfg.num_nextn_predict_layers, 0)
         self.assertFalse(cfg.train_mtp_only)
-        self.assertEqual(cfg.mtp_loss_scaling_factor, 0.3)
+        self.assertEqual(cfg.mtp_loss_scaling_factor, 0.1)
 
     def test_dsa_config_defaults(self):
         cfg = _make_config()

--- a/tests/test_configs.yaml
+++ b/tests/test_configs.yaml
@@ -22,6 +22,9 @@ tests:
   - test_case: [tests/multi_card_tests/pipeline_parallel/test_gpt_pp_with_moe.py]
     products:
       - num_gpus: 8
+  - test_case: [tests/multi_card_tests/pipeline_parallel/test_gpt_pp_with_moe_with_mtp_alltoall.py]
+    products:
+      - num_gpus: 8
   - test_case: [tests/multi_card_tests/pipeline_parallel/test_gpt_pp_with_moe_with_mtp.py]
     products:
       - num_gpus: 8


### PR DESCRIPTION
### PR Category
User Experience


### PR Types
BC Breaking


### Description
修改配置默认值以对齐 Megatron-Swift （https://swift.readthedocs.io/en/latest/Megatron-SWIFT/Command-line-parameters.html）

- 将 `overlap_p2p_comm` 默认值改为 True
- 将 `batch_p2p_comm` 类型改为 `bool | None`，默认值改为 None
- 将 `mtp_loss_scaling_factor` 默认值从 0.3 减至 0.1
- 将 `moe_token_dispatcher_type` 默认值改为 "alltoall"
- 将 `dsa_indexer_loss_coeff` 默认值从 0.01 改为 0.0 并移除重复字段



### 是否引起精度变化
是，只影响使用 MTP loss 或 DSA indexer 训练的配置；不启用这些路径的推理/训练配置不受这两项 loss 权重影响。
