### PR TITLE
fix: correct Rope time-major flag for sequence parallel

### DIFF
--- a/src/paddlefleet/models/common/embeddings/rope_utils.py
+++ b/src/paddlefleet/models/common/embeddings/rope_utils.py
@@ -548,7 +548,7 @@ def apply_rotary_pos_emb(
         "multi_latent_attention": config.multi_latent_attention,
         "high_precision_rope": config.high_precision_rope,
         "rope_theta": config.rope_theta,
-        "time_major": config.sequence_parallel,
+        "time_major": config.sequence_parallel > 0,
         "sp_group": sp_group,
         "inverse": inverse,
         "mla_output_remove_interleaving": mla_output_remove_interleaving,

--- a/tests/single_card_tests/transformer/test_rope.py
+++ b/tests/single_card_tests/transformer/test_rope.py
@@ -127,26 +127,34 @@ def apply_fused_rope_reference(x, freqs):
 
 
 class TestApplyRotaryPosEmbRouter(unittest.TestCase):
-    def test_negative_sequence_parallel_is_not_time_major(self):
+    def test_sequence_parallel_controls_time_major(self):
         """Only positive sequence-parallel values enable time-major inputs."""
-        config = make_config(apply_rope_fusion=False, high_precision_rope=False)
-        config.sequence_parallel = -1
         t = paddle.zeros([1, 2, 1, 4], dtype="float32")
         freqs = paddle.zeros([1, 2, 4], dtype="float32")
 
-        with patch(
-            "paddlefleet.models.common.embeddings.rope_utils._apply_rotary_pos_emb_bshd",
-            return_value=t,
-        ) as apply_bshd:
-            apply_rotary_pos_emb(
-                t=t,
-                freqs=freqs,
-                cos=None,
-                sin=None,
-                config=config,
-            )
+        for sequence_parallel, expected_time_major in [(-1, False), (1, True)]:
+            with self.subTest(sequence_parallel=sequence_parallel):
+                config = make_config(
+                    apply_rope_fusion=False, high_precision_rope=False
+                )
+                config.sequence_parallel = sequence_parallel
 
-        self.assertIs(apply_bshd.call_args.kwargs["time_major"], False)
+                with patch(
+                    "paddlefleet.models.common.embeddings.rope_utils._apply_rotary_pos_emb_bshd",
+                    return_value=t,
+                ) as apply_bshd:
+                    apply_rotary_pos_emb(
+                        t=t,
+                        freqs=freqs,
+                        cos=None,
+                        sin=None,
+                        config=config,
+                    )
+
+                self.assertIs(
+                    apply_bshd.call_args.kwargs["time_major"],
+                    expected_time_major,
+                )
 
 
 class TestApplyRotaryPosEmbFusedHighPrecision(unittest.TestCase):

--- a/tests/single_card_tests/transformer/test_rope.py
+++ b/tests/single_card_tests/transformer/test_rope.py
@@ -14,6 +14,7 @@
 
 import unittest
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import numpy as np
 import paddle
@@ -123,6 +124,29 @@ def apply_fused_rope_reference(x, freqs):
     )
     rotated = rotated.astype(x.dtype)
     return paddle.cat((rotated, x[..., rot_dim:]), axis=-1)
+
+
+class TestApplyRotaryPosEmbRouter(unittest.TestCase):
+    def test_negative_sequence_parallel_is_not_time_major(self):
+        """Only positive sequence-parallel values enable time-major inputs."""
+        config = make_config(apply_rope_fusion=False, high_precision_rope=False)
+        config.sequence_parallel = -1
+        t = paddle.zeros([1, 2, 1, 4], dtype="float32")
+        freqs = paddle.zeros([1, 2, 4], dtype="float32")
+
+        with patch(
+            "paddlefleet.models.common.embeddings.rope_utils._apply_rotary_pos_emb_bshd",
+            return_value=t,
+        ) as apply_bshd:
+            apply_rotary_pos_emb(
+                t=t,
+                freqs=freqs,
+                cos=None,
+                sin=None,
+                config=config,
+            )
+
+        self.assertIs(apply_bshd.call_args.kwargs["time_major"], False)
 
 
 class TestApplyRotaryPosEmbFusedHighPrecision(unittest.TestCase):


### PR DESCRIPTION
### PR Category
Distributed Strategy

### PR Types
Bug fixes

### Description
修复 Rope 路径中 `time_major` 参数的判断逻辑。此前直接传递 `config.sequence_parallel`，当该配置为非正值（例如 `-1`）时会被错误地视为启用 time-major；现在仅当 `sequence_parallel > 0` 时才启用。新增单测同时覆盖负值关闭和正值开启两个场景。

### 是否引起精度变化
否

