### PR TITLE
[Cherry-pick] Optimize CSA sparse attention backward with per-query topk_length

### DIFF
--- a/src/paddlefleet/fusions/csa_sparse_attn.py
+++ b/src/paddlefleet/fusions/csa_sparse_attn.py
@@ -96,6 +96,27 @@ def unfused_compressed_sparse_attn(
     return output
 
 
+def _csa_compute_topk_length(topk_idxs_flat: Tensor) -> Tensor:
+    """Per-query safe loop bound for the cuDNN backward kernel (``mTopkLength``).
+
+    Returns ``[N]`` int32 = (index of last valid entry + 1) per row, i.e. a SAFE
+    upper bound: all valid entries lie in ``[0, topk_length)``. Uses the trailing
+    bound (NOT ``sum(valid)``) so it stays correct when ``-1`` entries are
+    interleaved (multi-doc leading/interior holes). Clamped to >=1 so the kernel
+    writes every dq row (dq is allocated uninitialized in the backend).
+
+    Args:
+        topk_idxs_flat: ``[N, W]`` int32 global indices, -1 == invalid.
+    """
+    with paddle.no_grad():
+        _, w = topk_idxs_flat.shape
+        valid = (topk_idxs_flat >= 0).astype("int32")  # [N, W]
+        cols = paddle.arange(1, w + 1, dtype="int32").unsqueeze(0)  # [1, W]
+        trailing_len = (valid * cols).max(-1)  # [N] last valid index + 1
+        trailing_len = paddle.clip(trailing_len, min=1).astype("int32")
+    return trailing_len
+
+
 class CSASparseAttention(paddle.autograd.PyLayer):
     @staticmethod
     def forward(
@@ -160,6 +181,8 @@ class CSASparseAttention(paddle.autograd.PyLayer):
             lse_flat = lse.reshape([b * sq, np_heads])
             topk_idxs_flat = _local_to_global_flat(topk_idxs, s_kv)
 
+            topk_length = _csa_compute_topk_length(topk_idxs_flat)
+
             dq_flat, dkv_flat, d_sink = csa_sparse_attn_bwd_cudnn(
                 q_flat,
                 kv_flat,
@@ -169,6 +192,7 @@ class CSASparseAttention(paddle.autograd.PyLayer):
                 attn_sink,
                 topk_idxs_flat,
                 softmax_scale=ctx.softmax_scale,
+                topk_length=topk_length,
             )
             dq = dq_flat.reshape(query.shape)
             dkv = dkv_flat.reshape(kv_full.shape)

--- a/tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_utils.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_utils.py
@@ -321,6 +321,7 @@ class TestCudnnBackendDispatch(unittest.TestCase):
             attn_sink,
             topk_idxs_flat,
             softmax_scale=None,
+            topk_length=None,
         ):
             return (
                 paddle.ones_like(q_flat),


### PR DESCRIPTION

<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
#### 背景 / 动机
CSA (DeepSeek Sparse Attention) 的 backward 走 cuDNN backend 时,kernel 对每个 query 固定遍历 topk 个 KV tile。实际上多数 query 的有效 topk 条目远少于 topk,尾部整段是空洞却仍被遍历。本 PR 在融合层为每个 query 计算安全的循环上界并传给 kernel,让其提前终止,跳过尾部全空 tile;并同步 bump cudnn-frontend 子模块以引入对应的 kernel 支持(连续 KV tile 的 TMA 快路径 + topk_length 循环上界)。

#### 改动内容
1. src/paddlefleet/fusions/csa_sparse_attn.py 
新增 _csa_compute_topk_length(topk_idxs_flat):返回每个 query 的 [N] int32 上界。
采用尾界语义((valid * arange(1,W+1)).max(-1),即"最后一个有效索引 + 1"), 而非 sum(valid),以在 -1 空洞交错(multi-doc 开头/中间空洞)时仍保证所有有效条目落在 [0, topk_length)。
clamp 到 >=1:backend 中 dq 未初始化分配,保证每个 query 至少跑一个 tile、每行 dq 都被写出。
CSASparseAttention.backward 的 cudnn 分支中计算 topk_length 并作为参数传入 csa_sparse_attn_bwd_cudnn。

2. packages/paddlefleet_ops/third_party/cudnn-frontend(子模块指针)
Bump 到含 DSA backward SM100 优化的 commit(per-query topk_length 循环上界 + 连续 KV tile 的 TMA 批量加载快路径)。

cherry-pick: https://github.com/PaddlePaddle/PaddleFleet/pull/1540

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
是
Merged in dev: #1540