### PR TITLE
[MTP] add mtp_depth_sampling

### DIFF
--- a/src/paddlefleet/models/common/language_loss/language_loss.py
+++ b/src/paddlefleet/models/common/language_loss/language_loss.py
@@ -475,6 +475,12 @@ class LanguageLoss(FleetLayer):
                     lm_loss = self._forward(logits[0], lm_labels)
 
                 for depth in range(self.config.num_nextn_predict_layers):
+                    # MTP depth sampling: the LM head emits None for depths not
+                    # computed this step; skip them so mtp_loss holds only the K
+                    # computed depths (loss averages over K). No effect when
+                    # sampling is off (logits are never None).
+                    if mtp_logits[depth] is None:
+                        continue
                     logits_cur_depth = mtp_logits[depth]
                     labels_cur_depth = labels_ori[
                         :, (depth + 1) : (depth + 1 + seq_length)
@@ -663,6 +669,16 @@ class LanguageLoss(FleetLayer):
                     f"mtp{i + 1}.final_loss",
                     loss_val,
                 )
+
+            # MTP depth sampling: mtp_loss holds only the computed prefix
+            # (depths 0..len-1). Drop stale tracker entries for the skipped deeper
+            # depths so the trainer does not re-log a stale value on steps where
+            # those depths were sampled out (per-depth curves stay
+            # sparse-but-correct instead of flat).
+            for _d in range(
+                len(mtp_loss), self.config.num_nextn_predict_layers
+            ):
+                LanguageLoss.mtp_loss_tracker.pop(f"mtp_{_d + 1}_loss", None)
 
             logs = get_global_training_logs()
             if logs is not None and hasattr(logs, "update"):

--- a/src/paddlefleet/models/gpt/lm_head.py
+++ b/src/paddlefleet/models/gpt/lm_head.py
@@ -327,8 +327,20 @@ class GPTLMHead(ColumnParallelLinear):
                 self.config.num_nextn_predict_layers + 1,
             )
             logits = [self._forward(tensor_list[0])]
+            # MTP depth sampling: skip the vocab projection for depths >= K (they
+            # were not computed this step); keep a None placeholder so the logits
+            # list length stays num_nextn_predict_layers + 1 and the loss can
+            # detect skipped depths. K flows in dict_args (recompute/pp/grad-accum
+            # safe).
+            K = dict_args.get(
+                "mtp_sampled_depth", self.config.num_nextn_predict_layers
+            )
+            sampling_on = bool(getattr(self.config, "mtp_depth_sampling", None))
             for i in range(self.config.num_nextn_predict_layers):
-                logits.append(self._forward(tensor_list[i + 1]))
+                if sampling_on and i >= K:
+                    logits.append(None)
+                else:
+                    logits.append(self._forward(tensor_list[i + 1]))
             return logits
         else:
             return self._forward(hidden_states)

--- a/src/paddlefleet/transformer/multi_token_prediction.py
+++ b/src/paddlefleet/transformer/multi_token_prediction.py
@@ -795,6 +795,41 @@ class MultiTokenPredictionLayer(FleetLayer):
 
         return outputs
 
+    def _sample_mtp_depth(self):
+        """Sample how many MTP depths K to actually run this step (prefix 1..K).
+
+        Driven by config.mtp_depth_sampling, a list P(K=k) of length
+        D=num_nextn_predict_layers. Returns D when sampling is disabled.
+
+        The draw is DETERMINISTIC and collective-free: a private RNG is seeded
+        by a per-call counter, so every rank that runs this MTP layer draws the
+        SAME K without any communication. This is required for the MTP layer's
+        MoE expert-parallel all-to-all to stay consistent (all participating
+        ranks must agree whether a depth is skipped). A world-group
+        broadcast(src=0) — the previous mechanism — deadlocks under pp>1, since
+        only the last pipeline stage runs the MTP layer while src=0 sits on the
+        first stage and never joins the collective. A private Generator is used
+        (not np.random.*) so the global RNG stream used elsewhere is untouched.
+        """
+        import numpy as np
+
+        D = self.config.num_nextn_predict_layers
+        ratio = getattr(self.config, "mtp_depth_sampling", None)
+        if not ratio:
+            return D
+        probs = np.asarray(ratio, dtype="float64")
+        probs = probs / probs.sum()
+        # Per-call counter -> identical sequence of seeds on every rank running
+        # this layer (all ranks execute the same pipeline schedule in lockstep).
+        if not hasattr(self, "_mtp_sampling_counter"):
+            self._mtp_sampling_counter = 0
+        base = int(getattr(self.config, "seed", 0) or 0)
+        seed = base * 1_000_003 + self._mtp_sampling_counter
+        self._mtp_sampling_counter += 1
+        rng = np.random.default_rng(seed)
+        k = int(rng.choice(len(probs), p=probs)) + 1
+        return max(1, min(k, D))
+
     def forward(self, dict_args: dict):
         if "context" in dict_args:
             assert dict_args["context"] is None, (
@@ -804,6 +839,32 @@ class MultiTokenPredictionLayer(FleetLayer):
             assert dict_args["packed_seq_params"] is None, (
                 "multi token prediction + sequence packing is not yet supported."
             )
+
+        # === MTP depth sampling (prefix-length sampling) ===
+        # Sample K once per micro-batch in the depth-0 layer and carry it in
+        # dict_args so it flows WITH the data (robust to grad-accum, pipeline,
+        # recompute — no shared/config state an interleaved micro-batch could
+        # overwrite). Depths >= K skip their transformer_layer forward.
+        if (
+            getattr(self.config, "mtp_depth_sampling", None)
+            and not self.config.enable_mtp_magic_send
+        ):
+            D = self.config.num_nextn_predict_layers
+            if self.layer_number == 0 and "mtp_sampled_depth" not in dict_args:
+                # Draw once per micro-batch. The `not in dict_args` guard makes
+                # this idempotent: if a recompute pass re-enters this layer with
+                # the same dict_args, K is reused (not re-drawn), so the skip
+                # decision matches the original forward.
+                k = self._sample_mtp_depth()
+                dict_args["mtp_sampled_depth"] = k
+                self._last_sampled_depth = (
+                    k  # observability only, not used in logic
+                )
+            K = dict_args.get("mtp_sampled_depth", D)
+            if self.layer_number >= K:
+                # Skip this depth entirely: leave hidden_states unchanged (K stays
+                # in dict_args for downstream MTP layers + the LM head).
+                return dict_args
 
         # === Magic Send branch ===
         if self.config.enable_mtp_magic_send:

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -80,6 +80,18 @@ class TransformerConfig(ModelParallelConfig):
     mtp_shared_last_layer: bool = False
     """When True, MTP layers share the last backbone TransformerLayer parameters."""
 
+    mtp_depth_sampling: list | None = None
+    """Per-step random sampling of how many MTP depths to actually run, to keep MTP
+    compute close to num_nextn_predict_layers=1 while still training deeper depths
+    occasionally.
+    - None: disabled — always run all num_nextn_predict_layers depths (default).
+    - list[float] of length D=num_nextn_predict_layers: a probability distribution
+      P(K=k), k=1..D (must sum to 1). Each step samples a prefix length K and runs
+      only MTP depths 1..K; depths >K are skipped (no forward, no loss). The loss
+      averages over the K computed depths, so the sampling frequency P(K>=i) acts as
+      depth i's effective weight. K is sampled once and synced across all ranks
+      (required so MoE expert-parallel all-to-all stays consistent)."""
+
     separate_mtp_headloss: bool = False
     """Separate MTP LMHead & Loss calculate for pipeline balance."""
 
@@ -1144,6 +1156,31 @@ class TransformerConfig(ModelParallelConfig):
             # use_dense_mtp so the MTP layer matches whatever the backbone is.
             assert not self.use_dense_mtp, (
                 "mtp_shared_last_layer cannot be True if use_dense_mtp= True"
+            )
+
+        if self.mtp_depth_sampling is not None:
+            assert not self.enable_mtp_magic_send, (
+                "mtp_depth_sampling is not supported with enable_mtp_magic_send=True"
+            )
+            assert not self.separate_mtp_headloss, (
+                "mtp_depth_sampling is not supported with separate_mtp_headloss=True"
+            )
+            assert not self.mtp_distillation_loss, (
+                "mtp_depth_sampling is not supported with "
+                "mtp_distillation_loss=True (the distillation path does not "
+                "handle skipped-depth placeholders)"
+            )
+            _d = self.num_nextn_predict_layers
+            assert (
+                isinstance(self.mtp_depth_sampling, (list, tuple))
+                and len(self.mtp_depth_sampling) == _d
+            ), (
+                "mtp_depth_sampling must be a list of length "
+                f"num_nextn_predict_layers={_d}, got {self.mtp_depth_sampling}"
+            )
+            _s = float(sum(self.mtp_depth_sampling))
+            assert abs(_s - 1.0) < 1e-3, (
+                f"mtp_depth_sampling must sum to 1.0 (P(K=k)), got sum={_s}"
             )
 
         if self.enable_mtp_magic_send:

--- a/tests/multi_card_tests/pipeline_parallel/test_gpt_pp_mtp_depth_sampling.py
+++ b/tests/multi_card_tests/pipeline_parallel/test_gpt_pp_mtp_depth_sampling.py
@@ -1,0 +1,172 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Multi-card (pipeline-parallel) regression test for mtp_depth_sampling.
+
+The single-card TestMTPDepthSampling cannot catch the pp>1 failure mode: the
+MTP layer only runs on the LAST pipeline stage, so any collective it issues
+(the earlier broadcast(src=0) K-sync) is joined by no other stage and
+deadlocks. The collective-free sampler must let a pp>1 forward_backward
+complete. This test builds a small MoE+MTP model under pp=2 and asserts the
+step finishes with a finite loss for:
+  * sampling disabled (None)            -> baseline
+  * fixed K=1                           -> exercises the skip path (depths>=1)
+  * mixed distribution (varying K)      -> K changes per micro-batch, must stay
+                                           rank-consistent (else MoE all-to-all
+                                           on the last stage would deadlock)
+It also works alongside the mtp_shared_last_layer weight-sharing mechanism.
+"""
+
+import functools
+import os
+import unittest
+
+import numpy as np
+import paddle
+from paddle.distributed import fleet
+from paddle.distributed.fleet import distributed_model
+
+from paddlefleet.gpt_builders import gpt_builder
+from paddlefleet.models.gpt import GPTConfig
+from paddlefleet.training.initialize import initialize_fleet
+
+PP_DEGREE = 2
+MTP_DEGREE = 3
+REPO_FLAG = os.getenv("repo_flag")
+SKIP_TESTS = REPO_FLAG != "paddlefleet"
+
+
+def _run_pp(mtp_depth_sampling, mtp_shared_last_layer=False, seed=46):
+    config = GPTConfig(
+        moe_expert_fusion=False,
+        vocab_size=128,
+        max_sequence_length=64,
+        num_hidden_layers=4,
+        hidden_size=256,
+        num_attention_heads=4,
+        intermediate_size=512,
+        normalization="RMSNorm",
+        hidden_dropout_prob=0.0,
+        attention_dropout=0.0,
+        use_cpu_initialization=True,
+        parallel_output=True,
+        tie_word_embeddings=True,
+        position_embedding_type="rope",
+        rotary_percent=1.0,
+        rotary_base=10000,
+        rope_scaling=1.0,
+        init_method=functools.partial(paddle.nn.init.xavier_uniform_, gain=1.0),
+        output_layer_init_method=functools.partial(
+            paddle.nn.init.xavier_uniform_, gain=1.0
+        ),
+        use_qk_norm=True,
+        pipeline_model_parallel_size=PP_DEGREE,
+        tensor_model_parallel_size=1,
+        expert_model_parallel_size=1,
+        n_shared_experts=1,
+        n_routed_experts=8,
+        moe_intermediate_size=512,
+        gated_linear_unit=True,
+        num_nextn_predict_layers=MTP_DEGREE,
+        mtp_shared_last_layer=mtp_shared_last_layer,
+        mtp_depth_sampling=mtp_depth_sampling,
+    )
+
+    micro = 1
+    num_acc = 2
+    np.random.seed(seed)
+    paddle.seed(seed)
+
+    model = gpt_builder(
+        config,
+        num_stages=PP_DEGREE,
+        seg_method="layer:TransformerLayer|EmptyLayer",
+    )
+    pipe = distributed_model(model)
+
+    data = paddle.randint(low=0, high=128, shape=(micro, 64 + MTP_DEGREE + 1))
+    input_ids = data[:, :-1]
+    labels = data[:, 1:]
+    position_ids = paddle.arange(input_ids.shape[1]).reshape([1, -1])
+    inputs = (
+        {
+            "input_ids": [input_ids] * num_acc,
+            "position_ids": [position_ids] * num_acc,
+        },
+        [labels] * num_acc,
+    )
+    return pipe.forward_backward_pipeline(inputs, None)
+
+
+@unittest.skipIf(SKIP_TESTS, "requires repo_flag=paddlefleet multi-card env")
+class TestMTPDepthSamplingPP(unittest.TestCase):
+    """pp=2 forward_backward must COMPLETE (no collective deadlock)."""
+
+    @classmethod
+    def setUpClass(cls):
+        # fleet / parallel state can only be initialized once per process, so
+        # do it here (pp=2, mp=1, ep=1 is identical for every test below); each
+        # test only rebuilds the model with different mtp_depth_sampling config.
+        strategy = fleet.DistributedStrategy()
+        strategy.hybrid_configs = {
+            "dp_degree": 1,
+            "mp_degree": 1,
+            "pp_degree": PP_DEGREE,
+            "sharding_degree": 1,
+            "sep_degree": 1,
+            "cp_degree": 1,
+            "ep_degree": 1,
+            "moe_sharding_degree": 1,
+            "order": [
+                "sharding",
+                "moe_sharding",
+                "pp",
+                "sep",
+                "cp",
+                "dp",
+                "ep",
+                "mp",
+            ],
+            "pp_configs": {
+                "overlap_p2p_comm": True,
+                "enable_dynamic_shape": True,
+            },
+        }
+        strategy.pipeline_configs = {
+            "accumulate_steps": 2,
+            "micro_batch_size": 1,
+        }
+        initialize_fleet(strategy)
+
+    def _assert_finite(self, loss):
+        assert loss is not None, "loss is None"
+        assert not paddle.isnan(loss).any(), "loss has NaN"
+        assert not paddle.isinf(loss).any(), "loss has Inf"
+
+    def test_pp_sampling_disabled(self):
+        self._assert_finite(_run_pp(None))
+
+    def test_pp_sampling_fixed_k1(self):
+        # Depths >= 1 skipped on the last stage every step; the collective-free
+        # sampler must not hang (the old broadcast(src=0) deadlocked here).
+        self._assert_finite(_run_pp([1.0, 0.0, 0.0]))
+
+    def test_pp_sampling_mixed(self):
+        # K varies per micro-batch; every rank running the MTP layer must draw
+        # the same K deterministically or the MoE all-to-all deadlocks.
+        self._assert_finite(_run_pp([0.34, 0.33, 0.33]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/model/test_gpt_model_dense_mtp.py
+++ b/tests/single_card_tests/model/test_gpt_model_dense_mtp.py
@@ -217,5 +217,168 @@ class TestDenseMTP(unittest.TestCase):
         )
 
 
+class TestMTPDepthSampling(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        seed = 46
+        random.seed(seed)
+        np.random.seed(seed)
+        paddle.seed(seed)
+        strategy = fleet.DistributedStrategy()
+        strategy.hybrid_configs = {
+            "dp_degree": 1,
+            "mp_degree": 1,
+            "pp_degree": 1,
+            "sharding_degree": 1,
+            "sep_degree": 1,
+            "cp_degree": 1,
+            "ep_degree": 1,
+            "moe_sharding_degree": 1,
+            "order": [
+                "sharding",
+                "moe_sharding",
+                "pp",
+                "sep",
+                "cp",
+                "dp",
+                "ep",
+                "mp",
+            ],
+        }
+        try:
+            fleet.init(is_collective=True, strategy=strategy)
+        except Exception:
+            pass
+        hcg = fleet.get_hybrid_communicate_group()
+        try:
+            ps.initialize_model_parallel(hcg)
+        except Exception:
+            pass
+        cls.strategy = strategy
+
+    def _cfg(self, mtp_depth_sampling, num_nextn=3):
+        return GPTConfig(
+            num_hidden_layers=2,
+            hidden_size=512,
+            vocab_size=100,
+            max_sequence_length=64,
+            num_attention_heads=4,
+            moe_expert_fusion=False,
+            intermediate_size=1024,
+            normalization="RMSNorm",
+            hidden_dropout_prob=0.0,
+            attention_dropout=0.0,
+            n_routed_experts=8,
+            moe_intermediate_size=1024,
+            moe_token_dispatcher_type="alltoall",
+            n_shared_experts=1,
+            use_bias=False,
+            rotary_percent=1.0,
+            rotary_base=10000,
+            rope_scaling=1.0,
+            init_method=functools.partial(
+                paddle.nn.init.xavier_uniform_, gain=1.0
+            ),
+            output_layer_init_method=functools.partial(
+                paddle.nn.init.xavier_uniform_, gain=1.0
+            ),
+            tie_word_embeddings=True,
+            use_qk_norm=True,
+            num_nextn_predict_layers=num_nextn,
+            use_dense_mtp=False,
+            mtp_depth_sampling=mtp_depth_sampling,
+        )
+
+    def _mtp0(self, model):
+        for layer in model.run_function:
+            if isinstance(layer, MultiTokenPredictionLayer):
+                return layer
+        return None
+
+    def _run_step(self, model, config):
+        seq = config.max_sequence_length
+        data = list(range(seq))
+        input_ids = paddle.to_tensor(data, dtype=paddle.int64).repeat((1, 1))
+        position_ids = paddle.to_tensor(data, dtype=paddle.int64).repeat((1, 1))
+        labels = paddle.to_tensor(
+            list(range(1, seq + 1)), dtype=paddle.int64
+        ).repeat((1, 1))
+        pipe = NoPipelineParallel(model, self.strategy)
+        loss = pipe.forward_backward_pipeline(
+            (
+                {"input_ids": [input_ids], "position_ids": [position_ids]},
+                [labels],
+            )
+        )
+        return loss
+
+    def test_sampler_disabled_returns_full_depth(self):
+        """mtp_depth_sampling=None -> _sample_mtp_depth short-circuits to D."""
+        cfg = self._cfg(None)
+        model = gpt_builder(cfg, num_stages=1)
+        mtp0 = self._mtp0(model)
+        assert mtp0._sample_mtp_depth() == cfg.num_nextn_predict_layers
+
+    def test_sampler_fixed_k1(self):
+        """P(K=1)=1 -> always sample K=1."""
+        cfg = self._cfg([1.0, 0.0, 0.0])
+        model = gpt_builder(cfg, num_stages=1)
+        mtp0 = self._mtp0(model)
+        ks = [mtp0._sample_mtp_depth() for _ in range(50)]
+        assert set(ks) == {1}, f"expected all K==1, got {sorted(set(ks))}"
+
+    def test_sampler_fixed_k3(self):
+        """P(K=3)=1 -> always sample K=3 (= run all depths)."""
+        cfg = self._cfg([0.0, 0.0, 1.0])
+        model = gpt_builder(cfg, num_stages=1)
+        mtp0 = self._mtp0(model)
+        ks = [mtp0._sample_mtp_depth() for _ in range(50)]
+        assert set(ks) == {3}, f"expected all K==3, got {sorted(set(ks))}"
+
+    def test_sampler_distribution(self):
+        """Mixed distribution -> K spans expected support, E[K] < D."""
+        cfg = self._cfg([0.5, 0.5, 0.0])
+        model = gpt_builder(cfg, num_stages=1)
+        mtp0 = self._mtp0(model)
+        ks = [mtp0._sample_mtp_depth() for _ in range(400)]
+        assert set(ks) <= {1, 2}, f"K out of support: {sorted(set(ks))}"
+        assert 1 in ks and 2 in ks, (
+            f"both 1 and 2 should appear: {sorted(set(ks))}"
+        )
+        assert sum(ks) / len(ks) < 3, "E[K] must be < D=3"
+
+    def test_forward_backward_sampling_k1(self):
+        """Fixed K=1: forward/backward runs, loss finite, only depth-0 active."""
+        cfg = self._cfg([1.0, 0.0, 0.0])
+        model = gpt_builder(cfg, num_stages=1)
+        mtp0 = self._mtp0(model)
+        loss = self._run_step(model, cfg)
+        assert loss is not None and not paddle.isnan(loss).any(), "loss NaN"
+        assert not paddle.isinf(loss).any(), "loss Inf"
+        assert getattr(mtp0, "_last_sampled_depth", None) == 1, (
+            f"expected sampled K==1, got {getattr(mtp0, '_last_sampled_depth', None)}"
+        )
+
+    def test_forward_backward_sampling_full(self):
+        """Fixed K=3 sampling equals running all depths; loss finite."""
+        cfg = self._cfg([0.0, 0.0, 1.0])
+        model = gpt_builder(cfg, num_stages=1)
+        mtp0 = self._mtp0(model)
+        loss = self._run_step(model, cfg)
+        assert loss is not None and not paddle.isnan(loss).any(), "loss NaN"
+        assert getattr(mtp0, "_last_sampled_depth", None) == 3
+
+    def test_null_baseline_runs(self):
+        """mtp_depth_sampling=None (default) trains normally (no skip path)."""
+        cfg = self._cfg(None)
+        model = gpt_builder(cfg, num_stages=1)
+        mtp0 = self._mtp0(model)
+        loss = self._run_step(model, cfg)
+        assert loss is not None and not paddle.isnan(loss).any(), "loss NaN"
+        assert not hasattr(mtp0, "_last_sampled_depth"), (
+            "sampling state must not be set when feature is disabled"
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Sample how many of num_nextn_predict_layers MTP depths to run each step (prefix 1..K); depths>=K skip forward, lm_head emits None, loss averages over K. Independent of reuse/share mechanism (works with mtp_reuse_last_layer aliasing and mtp_shared_last_layer).

K is drawn DETERMINISTICALLY from a private RNG seeded by a per-call counter, so every rank running the MTP layer gets the same K with NO collective. An earlier world-group broadcast(src=0) deadlocks under pp>1 (only the last stage runs the MTP layer; src=0 on first stage never joins). 'not in dict_args' guard keeps recompute idempotent.

Default off (None) => identical to before. Verified on GPU: pp=1 tests pass; pp=2 forward_backward completes for sampling on and mixed (previously hung).

<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->


### Description
<!-- Describe what you’ve done -->


### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
