### PR TITLE
add w4a8 for rl

### DIFF
--- a/src/paddlefleet/transformer/moe/fp8_utils.py
+++ b/src/paddlefleet/transformer/moe/fp8_utils.py
@@ -222,6 +222,267 @@ def tilewise_quant(x):
         return x_fp8, x_scale
 
 
+# ---------------------------------------------------------------------------
+# w4a8 (fp4 权重 1x32 + fp8 激活 1x32) 在线量化散算子
+#
+# 实现参考 DeepGEMM 官方 python 参考实现（deep_gemm/utils/math.py）：
+#   ceil_to_ue8m0 / per_token_cast_to_fp8 / per_token_cast_to_fp4 /
+#   _quantize_to_fp4_e2m1 / cast_back_from_fp8
+# 命名约定：
+#   - 普通 blockwise 量化算子：quant_blockwize()，通过 attr 区分 fp4/fp8、ue8m0 等
+#   - 与 CUDA 融合算子对应的 python 散算子：原名 + "_python"
+# ---------------------------------------------------------------------------
+
+W4A8_QUANT_BLOCK = 32
+
+
+def ceil_to_ue8m0(x):
+    """将 scale 向上取整到 2 的幂（ue8m0）。
+
+    等价 DeepGEMM math.py 的 ceil_to_ue8m0：
+        bits = x.abs().float().view(torch.int32)
+        exp = ((bits >> 23) & 0xFF) + (bits & 0x7FFFFF).bool().int()
+        return (exp.clamp(1, 254) << 23).view(torch.float)
+    """
+    bits = x.abs().astype("float32").view("int32")
+    mask_ff = paddle.full_like(bits, 0xFF)
+    mask_7fffff = paddle.full_like(bits, 0x7FFFFF)
+    shift_23 = paddle.full_like(bits, 23)
+    exp = ((bits >> shift_23) & mask_ff) + ((bits & mask_7fffff) != 0).astype(
+        "int32"
+    )
+    return (exp.clip(1, 254) << shift_23).view("float32")
+
+
+def _quantize_to_fp4_e2m1(x):
+    """fp32 -> e2m1 4bit code（int32, 0~15），同 DeepGEMM _quantize_to_fp4_e2m1。
+
+    e2m1 可表示值 {0, 0.5, 1, 1.5, 2, 3, 4, 6}，
+    rounding 边界（相邻值中点）：0.25, 0.75, 1.25, 1.75, 2.5, 3.5, 5.0，
+    bit3 为符号位。
+    """
+    ax = x.abs()
+    code = paddle.zeros(ax.shape, dtype="int32")
+    for boundary in (0.25, 0.75, 1.25, 1.75, 2.5, 3.5, 5.0):
+        code = code + (ax > boundary).astype("int32")
+    sign = ((x < 0) & (code != 0)).astype("int32")
+    shift_3 = paddle.full_like(code, 3)
+    return code | (sign << shift_3)
+
+
+def quant_blockwize(
+    x, quant_method="1x32", quant_dtype="fp8", using_ue8m0_scale=True
+):
+    """普通 blockwise 量化散算子（对齐 fp8_quant_blockwise 的 attr 风格）。
+
+    参考 DeepGEMM math.py 的 per_token_cast_to_fp8 / per_token_cast_to_fp4。
+
+    Args:
+        x: [M, K] bf16/fp32，K 必须能被块大小整除（fp4 时还需被 2 整除）
+        quant_method: "1xN"，块大小（如 "1x32" / "1x128"）
+        quant_dtype: "fp8"（e4m3fn）或 "fp4"（e2m1，两值打包成一个 int8）
+        using_ue8m0_scale: scale 是否向上取整到 2 的幂（SM100 1D1D kernel
+            内部会把 fp32 scale cast 成 packed ue8m0，故 w4a8 必须为 True）
+
+    Returns:
+        (q, sf):
+          fp8: q [M, K] float8_e4m3fn, sf [M, K/gran_k] fp32
+          fp4: q [M, K/2] int8（低 nibble 存前一个元素）, sf [M, K/gran_k] fp32
+    """
+    gran_m, gran_k = (int(v) for v in quant_method.split("x"))
+    assert x.ndim == 2, x.shape
+    m, n = x.shape
+    assert n % gran_k == 0, f"K={n} 必须是 {gran_k} 的倍数"
+
+    if gran_m > 1:
+        # 2D tile 量化（如 128x128，权重量化，同 CUDA fuse_stack_*_fp8_quant）
+        assert quant_dtype == "fp8", "2D tile 量化仅支持 fp8"
+        assert m % gran_m == 0, f"M={m} 必须是 {gran_m} 的倍数"
+        tiles = (
+            x.reshape([m // gran_m, gran_m, n // gran_k, gran_k])
+            .transpose([0, 2, 1, 3])
+            .astype("float32")
+        )
+        amax = tiles.abs().max(axis=[2, 3]).clip(min=1e-4)
+        sf = amax / 448.0
+        sf = ceil_to_ue8m0(sf) if using_ue8m0_scale else sf
+        q = (
+            (tiles * (1.0 / sf.unsqueeze(-1).unsqueeze(-1)))
+            .transpose([0, 2, 1, 3])
+            .reshape([m, n])
+            .astype(paddle.float8_e4m3fn)
+        )
+        return q, sf
+
+    if m == 0:
+        if quant_dtype == "fp8":
+            q = paddle.empty([0, n], dtype=paddle.float8_e4m3fn)
+        else:
+            q = paddle.empty([0, n // 2], dtype=paddle.int8)
+        return q, paddle.empty([0, n // gran_k], dtype=paddle.float32)
+
+    x_view = x.reshape([m, n // gran_k, gran_k]).astype("float32")
+    x_amax = x_view.abs().max(axis=2).clip(min=1e-4)
+
+    if quant_dtype == "fp8":
+        sf = x_amax / 448.0
+        sf = ceil_to_ue8m0(sf) if using_ue8m0_scale else sf
+        q = (
+            (x_view * (1.0 / sf.unsqueeze(2)))
+            .reshape([m, n])
+            .astype(paddle.float8_e4m3fn)
+        )
+        return q, sf
+
+    if quant_dtype == "fp4":
+        assert n % 2 == 0, n
+        sf = x_amax / 6.0
+        sf = ceil_to_ue8m0(sf) if using_ue8m0_scale else sf
+        x_scaled = x_view * (1.0 / sf.unsqueeze(2))
+        codes = _quantize_to_fp4_e2m1(x_scaled).reshape([m, n])
+        # 打包：两个 4bit code -> 一个字节，低 nibble 存前一个元素
+        # （同 DeepGEMM per_token_cast_to_fp4）
+        codes2 = codes.reshape([m, n // 2, 2])
+        mask_0f = paddle.full_like(codes2[:, :, 0], 0x0F)
+        shift_4 = paddle.full_like(codes2[:, :, 0], 4)
+        packed = (codes2[:, :, 0] & mask_0f) | (
+            (codes2[:, :, 1] & mask_0f) << shift_4
+        )
+        # 按 bit pattern 转 int8（>127 的按补码回绕）
+        packed = paddle.where(packed > 127, packed - 256, packed).astype("int8")
+        return packed, sf
+
+    raise ValueError(f"unsupported quant_dtype: {quant_dtype}")
+
+
+def _stack_expert_weights(w):
+    """把专家权重 list/stacked tensor 统一成 [E, H0, H1]。"""
+    if isinstance(w, (list, tuple)):
+        w = w[0] if len(w) == 1 else paddle.stack(w, axis=0)
+    assert w.ndim == 3, w.shape
+    return w
+
+
+def fuse_stack_fp8_quant_python(
+    w, quant_method="1x32", quant_dtype="fp4", using_ue8m0_scale=True
+):
+    """fuse_stack_fp8_quant 的 python 散算子版本（不转置）。
+
+    输入 w: [E, R, C] bf16 stacked 权重（或 tensor list，自动 stack），
+    沿最后一维（GEMM 收缩维）做 blockwise 量化。
+    返回: fp4 时 (w_q [E, R, C/2] int8, sf [E, R, C/gran_k] fp32)
+    """
+    w = _stack_expert_weights(w)
+    e, r, c = w.shape
+    q, sf = quant_blockwize(
+        w.reshape([e * r, c]),
+        quant_method=quant_method,
+        quant_dtype=quant_dtype,
+        using_ue8m0_scale=using_ue8m0_scale,
+    )
+    if not quant_method.startswith("1x"):
+        # 2D tile（如 128x128）时保持 CUDA 融合算子的 2D 布局：
+        # q [E*R, C], sf [E*R/gm, C/gk]
+        return q, sf
+    return (
+        q.reshape([e, r, q.shape[-1]]),
+        sf.reshape([e, r, sf.shape[-1]]),
+    )
+
+
+def fuse_stack_transpose_fp8_quant_python(
+    w, quant_method="1x32", quant_dtype="fp4", using_ue8m0_scale=True
+):
+    """fuse_stack_transpose_fp8_quant 的 python 散算子版本。
+
+    输入 w: [E, H0, H1]，先转置成 [E, H1, H0] 再沿最后一维量化。
+    """
+    w = _stack_expert_weights(w)
+    return fuse_stack_fp8_quant_python(
+        w.transpose([0, 2, 1]).contiguous(),
+        quant_method=quant_method,
+        quant_dtype=quant_dtype,
+        using_ue8m0_scale=using_ue8m0_scale,
+    )
+
+
+def _weighted_swiglu_fp32(o1, probs, clamp_value=None):
+    """fp32 全程计算 swiglu(o1) * probs（与 CUDA 融合算子内部精度一致）。
+
+    CUDA 版 fuse_weighted_swiglu_fp8_quant(_clamp) 在 kernel 内用 fp32
+    计算 silu(gate)*up*probs 后直接量化，不落 bf16 中间结果；python 版
+    同样保持 fp32，才能与融合算子位级对齐。
+    """
+    x32 = o1.astype("float32")
+    h = x32.shape[-1] // 2
+    gate, up = x32[:, :h], x32[:, h:]
+    if clamp_value is not None:
+        gate = gate.clip(max=clamp_value)
+        up = up.clip(min=-clamp_value, max=clamp_value)
+    p = probs.astype("float32")
+    if p.ndim == 1:
+        # 端到端 forward 传入的 unzipped_probs 是 1-D [M]（CUDA 融合算子内部兼容），
+        # python 版需显式广播为 [M, 1]
+        p = p.reshape([-1, 1])
+    return F.silu(gate) * up * p
+
+
+def fuse_weighted_swiglu_fp8_quant_python(
+    o1, probs, quant_method="1x32", using_ue8m0_scale=True
+):
+    """fuse_weighted_swiglu_fp8_quant 的 python 散算子版本。
+
+    o2 = swiglu(o1) * probs（fp32 中间计算），再做 blockwise fp8 量化。
+    quant_method="1x128" 且 using_ue8m0_scale=True 时与 CUDA 融合算子
+    （using_pow2_scaling=True）逐位一致。
+    返回: (o2_fp8 [M, H] float8_e4m3fn, sf [M, H/gran_k] fp32)
+    """
+    o2 = _weighted_swiglu_fp32(o1, probs)
+    return quant_blockwize(
+        o2,
+        quant_method=quant_method,
+        quant_dtype="fp8",
+        using_ue8m0_scale=using_ue8m0_scale,
+    )
+
+
+def fuse_weighted_swiglu_fp8_quant_clamp_python(
+    o1, probs, clamp_value, quant_method="1x32", using_ue8m0_scale=True
+):
+    """fuse_weighted_swiglu_fp8_quant_clamp 的 python 散算子版本。
+
+    clamp 语义与 CUDA 版一致：gate 上界夹 min(x, c)，up 对称夹 clip(y, -c, c)。
+    quant_method="1x128" 且 using_ue8m0_scale=True 时与 CUDA 融合算子逐位一致。
+    """
+    o2 = _weighted_swiglu_fp32(o1, probs, clamp_value)
+    return quant_blockwize(
+        o2,
+        quant_method=quant_method,
+        quant_dtype="fp8",
+        using_ue8m0_scale=using_ue8m0_scale,
+    )
+
+
+def fused_act_dequant_python(x_fp8, sf):
+    """fused_act_dequant 的 python 散算子版本（blockwise 反量化）。
+
+    参考 DeepGEMM math.py 的 cast_back_from_fp8：
+        group_idx = arange(n) // gran_k
+        return x_fp8.float() * sf[:, group_idx]
+
+    输入: x_fp8 [M, K] float8_e4m3fn, sf [M, K/gran_k] fp32
+    返回: bf16 [M, K]
+    """
+    m, n = x_fp8.shape
+    assert sf.shape[0] == m and n % sf.shape[1] == 0, (
+        f"{x_fp8.shape} vs {sf.shape}"
+    )
+    gran_k = n // sf.shape[1]
+    group_idx = paddle.arange(n, dtype="int64") // gran_k
+    sf_expanded = paddle.index_select(sf.astype("float32"), group_idx, axis=1)
+    return (x_fp8.astype("float32") * sf_expanded).astype("bfloat16")
+
+
 def split_group_gemm(
     x_fp8, x_scale, w_fp8, w_scale, tokens_per_expert, gemm_out, use_ue8m0=False
 ):
@@ -451,6 +712,7 @@ class ExpertsGroupGemmContiguousNode:
         dw_p2p_overlap=False,
         moe_expert_fusion=False,
         clamp_value=None,
+        use_w4a8=False,
     ):
         """
             Initializes the experts group gemm contiguous node.
@@ -518,6 +780,22 @@ class ExpertsGroupGemmContiguousNode:
         self.dw_p2p_overlap = dw_p2p_overlap
         self.moe_expert_fusion = moe_expert_fusion
         self.clamp_value = clamp_value
+        self.use_w4a8 = use_w4a8
+        if use_w4a8:
+            assert moe_expert_fusion and moe_deep_gemm and use_fp8_mlp, (
+                "use_w4a8 需要 moe_expert_fusion + moe_deep_gemm + use_fp8_mlp"
+            )
+            # assert not dequant_input, (
+            #     "use_w4a8 要求关闭 fp8_dispatch（专家输入 bf16），"
+            #     "不支持 dequant_input"
+            # )
+            assert hasattr(
+                paddlefleet_deep_gemm, "m_grouped_fp8_fp4_gemm_nt_contiguous"
+            ), (
+                "use_w4a8 需要 paddlefleet_ops.deep_gemm 提供 fp8*fp4 grouped GEMM"
+            )
+            # 用户指定：w4a8 下 dw 全部走 bf16 grouped gemm
+            self.use_bf16_gemm_weight_grad = True
 
     def cached_tensors(self):
         """
@@ -658,6 +936,10 @@ class ExpertsGroupGemmContiguousNode:
         o1 = x * w1
         [m_sum, n] = [m_sum, k] * [num_groups, k, n] (m_sum = sum(tokens_per_expert))
         """
+        if self.use_w4a8:
+            # 反向存储（dequant_input: fp8 1x32 / 否则 bf16）在 _fwd_gate_up_w4a8
+            # 内完成，直接复用前向的量化结果
+            return self._fwd_gate_up_w4a8(x, expert_w1, scale=scale)
         # concat w1, shape is [num_groups, n, k]
 
         if hasattr(self, "grouped_gemm_experts"):
@@ -735,7 +1017,7 @@ class ExpertsGroupGemmContiguousNode:
                     (x_fp8, x_scale),
                     (w1_t_quant, w1_t_scale),
                     o1,
-                    m_indices=self.m_indices,
+                    self.m_indices,
                 )
 
         if self.dequant_input:
@@ -744,6 +1026,157 @@ class ExpertsGroupGemmContiguousNode:
         else:
             self.input = x
         return o1
+
+    # ------------------------------------------------------------------
+    # w4a8 路径：权重 fp4 1x32 在线量化 + 激活 fp8 1x32 量化 + DeepGEMM fp8*fp4
+    # ------------------------------------------------------------------
+
+    def _w4a8_grouped_gemm(self, x_fp8, x_sf, w_fp4, w_sf, out):
+        """调用 DeepGEMM 的 m_grouped fp8*fp4 contiguous GEMM (SM100 1D1D)。
+
+        x_fp8/x_sf: 激活 fp8 1x32 量化结果 [M, K] / [M, K/32]
+        w_fp4/w_sf: 权重 fp4 1x32 量化结果 [E, N, K/2] / [E, N, K/32]
+        out: [M, N] bf16；grouped_layout 即 self.m_indices（每行 group id）。
+        """
+        paddlefleet_deep_gemm.m_grouped_fp8_fp4_gemm_nt_contiguous(
+            (x_fp8, x_sf),
+            (w_fp4, w_sf),
+            out,
+            self.m_indices,
+            recipe_a=(1, W4A8_QUANT_BLOCK),
+            recipe_b=(1, W4A8_QUANT_BLOCK),
+        )
+        return out
+
+    def _fwd_gate_up_w4a8(self, x, expert_w1, scale=None):
+        """w4a8 前向 up_gate: o1 = x(fp8 1x32) @ w1(fp4 1x32)^T
+
+        [m_sum, n] = [m_sum, k] * [num_groups, k, n]
+        """
+        assert scale is None, "TODO w4a8支持fp8_dispatch"
+        x_fp8 = x_sf = None
+        if x is None:
+            # backward recompute：dequant_input 下直接复用存储的 1x32 fp8，
+            # 免去一次反量化+再量化
+            if self.dequant_input:
+                assert self.input_fp8 is not None
+                x_fp8, x_sf = self.input_fp8, self.input_scale
+            else:
+                assert self.input is not None
+                x = self.input
+        # 在线量化权重（无 quant_weight_cache）：[E, K, N] -> [E, N, K/2]
+        w1_fp4, w1_sf = fuse_stack_transpose_fp8_quant_python(
+            expert_w1, quant_dtype="fp4"
+        )
+        if x_fp8 is None:
+            x_fp8, x_sf = quant_blockwize(x, quant_dtype="fp8")
+        # 给反向存储：dequant_input 存 fp8 1x32 量化结果（省显存，
+        # 反向 bf16 wgrad 用 fused_act_dequant_python 反量化），否则存 bf16
+        if self.dequant_input:
+            self.input_fp8, self.input_scale = x_fp8, x_sf
+        else:
+            self.input = x
+
+        o1 = paddle.empty(
+            [x_fp8.shape[0], w1_fp4.shape[1]], dtype=paddle.bfloat16
+        )
+        if numpy.prod(x_fp8.shape) != 0:
+            self._w4a8_grouped_gemm(x_fp8, x_sf, w1_fp4, w1_sf, o1)
+        return o1
+
+    def _fwd_down_w4a8(
+        self, o1, unzipped_probs, expert_w2, o3=None, clear_o1=False
+    ):
+        """w4a8 前向 down: o3 = swiglu(o1)*probs (fp8 1x32) @ w2(fp4 1x32)^T
+
+        [m_sum, k] = [m_sum, n] * [num_groups, n, k]
+        """
+        # 在线量化权重：[E, H, K] -> [E, K, H/2]
+        w2_fp4, w2_sf = fuse_stack_transpose_fp8_quant_python(
+            expert_w2, quant_dtype="fp4"
+        )
+        if self.clamp_value is not None and self.clamp_value > 0:
+            o2_fp8, o2_sf = fuse_weighted_swiglu_fp8_quant_clamp_python(
+                o1, unzipped_probs, self.clamp_value
+            )
+        else:
+            o2_fp8, o2_sf = fuse_weighted_swiglu_fp8_quant_python(
+                o1, unzipped_probs
+            )
+        if clear_o1:
+            o1._clear_to_zero_allocation()
+
+        o3_shape = [o2_fp8.shape[0], w2_fp4.shape[1]]
+        if o3 is not None:
+            assert o3.shape == o3_shape, f"{o3.shape} vs {o3_shape}"
+            o3.zero_()
+        else:
+            o3 = paddle.empty(o3_shape, dtype=paddle.bfloat16)
+        if numpy.prod(o2_fp8.shape) != 0:
+            self._w4a8_grouped_gemm(o2_fp8, o2_sf, w2_fp4, w2_sf, o3)
+        return o3
+
+    def _bwd_down_input_w4a8(
+        self, expert_w2, unzipped_grad, o1, unzipped_probs
+    ):
+        """w4a8 反向 down dgrad: do2 = do3(fp8 1x32) @ w2(fp4 1x32)
+
+        [m_sum, n] = [m_sum, k] * [num_groups, k, n]
+        w2 [E, N, K] 不转置，收缩维为 K（do3 的列维）。
+        """
+        w2_fp4, w2_sf = fuse_stack_fp8_quant_python(
+            expert_w2, quant_dtype="fp4"
+        )
+        grad_fp8, grad_sf = quant_blockwize(unzipped_grad, quant_dtype="fp8")
+
+        do2_s = paddle.empty(
+            [grad_fp8.shape[0], w2_fp4.shape[1]], dtype=unzipped_grad.dtype
+        )
+        if numpy.prod(grad_fp8.shape) != 0:
+            self._w4a8_grouped_gemm(grad_fp8, grad_sf, w2_fp4, w2_sf, do2_s)
+
+        # swiglu 反向沿用现有逻辑（clamp / inplace / out-of-place 分支）
+        with paddle.amp.auto_cast(False):
+            if self.clamp_value is not None and self.clamp_value > 0:
+                do1, probs_grad, o2_s = fused_swiglu_weighted_clamp_bwd(
+                    o1,
+                    unzipped_probs,
+                    do2_s,
+                    float(self.clamp_value),
+                )
+            elif USE_INPLACE_SWIGLU_BWD:
+                do1, probs_grad, o2_s = _fused_swiglu_probs_bwd(
+                    o1, do2_s, unzipped_probs, True
+                )
+            else:
+                do1, probs_grad, o2_s = (
+                    paddle.incubate.nn.functional.fused_swiglu_weighted_bwd(
+                        o1, do2_s, unzipped_probs
+                    )
+                )
+
+        return do1, o2_s, probs_grad
+
+    def _bwd_gate_up_input_w4a8(self, do1, expert_w1, dx=None):
+        """w4a8 反向 up_gate dgrad: dx = do1(fp8 1x32) @ w1(fp4 1x32)
+
+        [m_sum, k] = [m_sum, n] * [num_groups, n, k]
+        w1 [E, K, N] 不转置，收缩维为 N（do1 的列维）。
+        """
+        w1_fp4, w1_sf = fuse_stack_fp8_quant_python(
+            expert_w1, quant_dtype="fp4"
+        )
+        do1_fp8, do1_sf = quant_blockwize(do1, quant_dtype="fp8")
+
+        dx_shape = [do1_fp8.shape[0], w1_fp4.shape[1]]
+        if dx is None:
+            dx = paddle.empty(shape=dx_shape, dtype=do1.dtype)
+        else:
+            assert dx.shape == dx_shape, f"{dx.shape} vs {dx_shape}"
+            dx.zero_()
+        if numpy.prod(do1_fp8.shape) != 0:
+            self._w4a8_grouped_gemm(do1_fp8, do1_sf, w1_fp4, w1_sf, dx)
+        return dx
 
     def fwd_swiglu(self, o1):
         o2 = swiglu(o1)
@@ -822,6 +1255,10 @@ class ExpertsGroupGemmContiguousNode:
         o3 = o2 * w2
         [m_sum, k] = [m_sum, n] * [num_groups, n, k]
         """
+        if self.use_w4a8:
+            return self._fwd_down_w4a8(
+                o1, unzipped_probs, expert_w2, o3=o3, clear_o1=clear_o1
+            )
         # concat and transpose w2
 
         if (
@@ -901,7 +1338,7 @@ class ExpertsGroupGemmContiguousNode:
                     (o2_fp8, o2_scale),
                     (w2_quant, w2_scale),
                     o3,
-                    m_indices=self.m_indices,
+                    self.m_indices,
                 )
         return o3
 
@@ -976,6 +1413,10 @@ class ExpertsGroupGemmContiguousNode:
         do2 = do3 * w2_t
         [m_sum, n] = [m_sum, k] * [num_groups, k, n]
         """
+        if self.use_w4a8:
+            return self._bwd_down_input_w4a8(
+                expert_w2, unzipped_grad, o1, unzipped_probs
+            )
         # recompute concated_w2_2d
 
         if hasattr(self, "grouped_gemm_experts"):
@@ -1067,7 +1508,7 @@ class ExpertsGroupGemmContiguousNode:
                     (unzipped_grad_fp8, unzipped_grad_scale),
                     (bw_w2_quant, bw_w2_scale),
                     do2_s,
-                    m_indices=self.m_indices,
+                    self.m_indices,
                 )
 
         with paddle.amp.auto_cast(False):
@@ -1153,6 +1594,8 @@ class ExpertsGroupGemmContiguousNode:
         dx = do1 * w1_t
         [m_sum, k] = [m_sum, n] * [num_groups, n, k]
         """
+        if self.use_w4a8:
+            return self._bwd_gate_up_input_w4a8(do1, expert_w1, dx=dx)
         # recompute concated_w1_t
 
         if hasattr(self, "grouped_gemm_experts"):
@@ -1237,7 +1680,7 @@ class ExpertsGroupGemmContiguousNode:
                     (do1_fp8, do1_scale),
                     (bw_w1_quant, bw_w1_scale),
                     dx,
-                    m_indices=self.m_indices,
+                    self.m_indices,
                 )
 
         return dx
@@ -1904,9 +2347,15 @@ class ExpertsGroupGemmContiguousNode:
         """
         if x is None:
             if self.dequant_input:
-                x = paddle.incubate.nn.functional.fused_act_dequant(
-                    self.input_fp8, self.input_scale
-                )
+                if self.use_w4a8:
+                    # w4a8 输入是 fp8 1x32 量化（fused_act_dequant 仅支持 1x128）
+                    x = fused_act_dequant_python(
+                        self.input_fp8, self.input_scale
+                    )
+                else:
+                    x = paddle.incubate.nn.functional.fused_act_dequant(
+                        self.input_fp8, self.input_scale
+                    )
             else:
                 x = self.input
 

--- a/src/paddlefleet/transformer/moe/fusion_layer_utils.py
+++ b/src/paddlefleet/transformer/moe/fusion_layer_utils.py
@@ -283,6 +283,7 @@ class MlpNode:
         use_ue8m0=False,
         dw_p2p_overlap=False,
         clamp_value=None,
+        use_w4a8=False,
     ):
         """
         Constructor
@@ -384,6 +385,7 @@ class MlpNode:
                 dw_p2p_overlap=dw_p2p_overlap,
                 moe_expert_fusion=moe_expert_fusion,
                 clamp_value=clamp_value,
+                use_w4a8=use_w4a8,
             )
         self.unzip_node = UnZipNode(self.token_dispatcher)
         self.zip_node = ZipNode(self.token_dispatcher)
@@ -1954,6 +1956,7 @@ class FusionMoePyLayer(paddle.autograd.PyLayer):
         use_ue8m0=False,
         dw_p2p_overlap=False,
         clamp_value=None,
+        use_w4a8=False,
     ):
         """
         根据给定的参数执行前向传播操作。
@@ -1983,6 +1986,7 @@ class FusionMoePyLayer(paddle.autograd.PyLayer):
             use_ue8m0=use_ue8m0,
             dw_p2p_overlap=dw_p2p_overlap,
             clamp_value=clamp_value,
+            use_w4a8=use_w4a8,
         )
 
         if fp8_dispatched_handle is not None:

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -172,9 +172,12 @@ class MoELayer(nn.Layer):
         self.moe_shared_expert_overlap = config.moe_shared_expert_overlap
         self.fp8 = config.fp8
         self.use_ue8m0 = config.use_ue8m0
+        self.use_w4a8 = config.use_w4a8
         self.dw_p2p_overlap = getattr(config, "dw_p2p_overlap", False)
         self.using_sonic_moe = self.config.using_sonic_moe
-        self.fp8_dispatch = bool(config.fp8) and not self.using_sonic_moe
+        self.fp8_dispatch = (
+            bool(config.fp8) and not self.using_sonic_moe and not self.use_w4a8
+        )
         self.fp8_wgrad = config.fp8_wgrad
         self.moe_expert_fusion = config.moe_expert_fusion
         self.moe_subbatch_token_num_after_dispatch = (
@@ -779,6 +782,7 @@ class MoELayer(nn.Layer):
                     dw_p2p_overlap=self.dw_p2p_overlap,
                     clamp_value=self.config.activation_func_clamp_value,
                     is_first_fwd=not framework._dygraph_tracer()._has_grad,
+                    use_w4a8=self.use_w4a8,
                 )
 
         with profile("combine"):
@@ -922,6 +926,7 @@ class MoELayer(nn.Layer):
                     use_ue8m0=self.use_ue8m0,
                     dw_p2p_overlap=self.dw_p2p_overlap,
                     clamp_value=self.config.activation_func_clamp_value,
+                    use_w4a8=self.use_w4a8,
                 )
 
             if is_first_fwd:

--- a/src/paddlefleet/transformer/moe/moe_utils.py
+++ b/src/paddlefleet/transformer/moe/moe_utils.py
@@ -671,12 +671,12 @@ def k_grouped_bf16_gemm_tn_contiguous_aligned(a, b, d, ks, ks_tensor, c):
     b_padded = pad_grouped_tensor(b, ks_tensor, padded_ks_tensor)
 
     paddlefleet_deep_gemm.k_grouped_bf16_gemm_tn_contiguous(
-        a=a_padded,
-        b=b_padded,
-        d=d,
-        ks=padded_sizes_list,
-        ks_tensor=padded_ks_tensor,
-        c=c,
+        a_padded,
+        b_padded,
+        d,
+        padded_sizes_list,
+        padded_ks_tensor,
+        c,
     )
 
     del a_padded, b_padded

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -624,6 +624,9 @@ class TransformerConfig(ModelParallelConfig):
     use_fp8_qat: bool = False
     """Whether to enable FP8 Quantization-Aware Training (QAT)."""
 
+    use_w4a8: bool = False
+    """Whether to use w4a8 for mlp gemm."""
+
     ####################
     # initialization
     ####################

--- a/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_moe_router.py
+++ b/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_moe_router.py
@@ -875,9 +875,6 @@ class TestFusionMoePyLayerDwP2POverlap(unittest.TestCase):
     def _make_dispatch_data(self):
         from paddlefleet.transformer.moe.fp8_utils import tilewise_quant
 
-        tokens_per_expert = [
-            self.seq_len * self.topk // self.n_routed_experts
-        ] * self.n_routed_experts
         hidden_states = paddle.randn(
             [self.seq_len, self.hidden_size], "bfloat16"
         )
@@ -893,6 +890,15 @@ class TestFusionMoePyLayerDwP2POverlap(unittest.TestCase):
             )
             indices_np[i] = np.sort(chosen)
         indices = paddle.to_tensor(indices_np)
+        # tokens_per_expert must match the actual routing in indices,
+        # otherwise the permuted buffers contain uninitialized regions.
+        tokens_per_expert = (
+            np.bincount(
+                indices_np.reshape([-1]), minlength=self.n_routed_experts
+            )
+            .astype(np.int64)
+            .tolist()
+        )
         return hidden_states, scale, probs, indices, tokens_per_expert
 
     def _run_fusion_layer(self, dw_p2p_overlap=False):

--- a/tests/single_card_tests/fp8/test_w4a8_fused_op_parity.py
+++ b/tests/single_card_tests/fp8/test_w4a8_fused_op_parity.py
@@ -1,0 +1,423 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Parity tests: python scattered quant ops vs paddlefleet_ops CUDA fused ops.
+
+Two parts:
+1. TestFusedOpParity: at the same granularity (128, pow2 scale), every python
+   scattered op must be bit-exact against its CUDA fused counterpart.
+2. TestEndToEndGranularityDiff: end-to-end ExpertsGroupGemmContiguousNode,
+   comparing the w4a8 path (scattered ops, 1x32 quantization) and the
+   original fp8 path (fused ops, 128 granularity) against a bf16 reference,
+   and reporting the difference between the two paths.
+
+Run (SM100, requires DeepGEMM with fp8*fp4 support so that
+``paddlefleet_ops.deep_gemm.m_grouped_fp8_fp4_gemm_nt_contiguous`` exists):
+    source <DeepGEMM-with-fp8xfp4 env>/bin/activate
+    PYTHONPATH=packages/paddlefleet_ops/src:src python -m pytest \
+        tests/single_card_tests/fp8/test_w4a8_fused_op_parity.py -v
+"""
+
+import unittest
+
+import numpy as np
+import paddle
+import paddle.nn.functional as F
+
+from paddlefleet.transformer.moe.fp8_utils import (
+    fuse_stack_fp8_quant_python,
+    fuse_stack_transpose_fp8_quant_python,
+    fuse_weighted_swiglu_fp8_quant_clamp_python,
+    fuse_weighted_swiglu_fp8_quant_python,
+    fused_act_dequant_python,
+    quant_blockwize,
+)
+
+try:
+    from paddlefleet_ops import (
+        fuse_stack_fp8_quant,
+        fuse_stack_transpose_fp8_quant,
+        fuse_weighted_swiglu_fp8_quant,
+        fuse_weighted_swiglu_fp8_quant_clamp,
+    )
+
+    HAS_FUSED_OPS = True
+except (ImportError, RuntimeError):
+    HAS_FUSED_OPS = False
+
+try:
+    from paddlefleet_ops import deep_gemm as _pf_deep_gemm
+
+    HAS_FP8_FP4_GEMM = hasattr(
+        _pf_deep_gemm, "m_grouped_fp8_fp4_gemm_nt_contiguous"
+    )
+except (ImportError, RuntimeError):
+    HAS_FP8_FP4_GEMM = False
+
+IS_SM100 = (
+    paddle.is_compiled_with_cuda()
+    and paddle.device.cuda.get_device_capability()[0] == 10
+)
+
+
+def _bits_equal(a, b):
+    """Bitwise comparison for fp8 tensors."""
+    return bool((a.view("int8") == b.view("int8")).all())
+
+
+def _cos(a, b):
+    a = np.asarray(a, dtype=np.float64).reshape(-1)
+    b = np.asarray(b, dtype=np.float64).reshape(-1)
+    return float(np.sum(a * b) / (np.linalg.norm(a) * np.linalg.norm(b)))
+
+
+@unittest.skipUnless(
+    HAS_FUSED_OPS and IS_SM100,
+    "requires paddlefleet_ops CUDA fused quant ops on SM100 "
+    "(pow2 scaling path)",
+)
+class TestFusedOpParity(unittest.TestCase):
+    """Bit-exact parity at 128 granularity.
+
+    On SM100 the CUDA fused ops use using_pow2_scaling=True (matching
+    using_ue8m0_scale=True in the scattered ops); weight stack quantization
+    uses 128x128 tiles and activations use 1x128.
+    """
+
+    def setUp(self):
+        paddle.seed(2026)
+        np.random.seed(2026)
+
+    def test_fuse_stack_transpose_fp8_quant(self):
+        """Python op is bit-exact vs CUDA fuse_stack_transpose_fp8_quant."""
+        e, k, n = 2, 256, 512
+        w_list = [paddle.randn([k, n], dtype="bfloat16") for _ in range(e)]
+        # CUDA: (x, using_pow2_scaling, using_ue8m0_scale,
+        #        output_scale_transpose)
+        cq, cs = fuse_stack_transpose_fp8_quant(w_list, True, False, False)
+        pq, ps = fuse_stack_transpose_fp8_quant_python(
+            w_list, quant_method="128x128", quant_dtype="fp8"
+        )
+        self.assertEqual(list(pq.shape), list(cq.shape))
+        self.assertEqual(list(ps.shape), list(cs.shape))
+        self.assertTrue(bool((cs == ps).all()), "scale mismatch")
+        self.assertTrue(_bits_equal(cq, pq), "fp8 payload mismatch")
+
+    def test_fuse_stack_fp8_quant(self):
+        """Python op is bit-exact vs CUDA fuse_stack_fp8_quant."""
+        e, k, n = 2, 256, 512
+        w_list = [paddle.randn([k, n], dtype="bfloat16") for _ in range(e)]
+        cq, cs = fuse_stack_fp8_quant(w_list, True, False, False)
+        pq, ps = fuse_stack_fp8_quant_python(
+            w_list, quant_method="128x128", quant_dtype="fp8"
+        )
+        self.assertEqual(list(pq.shape), list(cq.shape))
+        self.assertEqual(list(ps.shape), list(cs.shape))
+        self.assertTrue(bool((cs == ps).all()), "scale mismatch")
+        self.assertTrue(_bits_equal(cq, pq), "fp8 payload mismatch")
+
+    def test_fuse_weighted_swiglu_fp8_quant(self):
+        """Python op is bit-exact vs CUDA fuse_weighted_swiglu_fp8_quant."""
+        m, h2 = 128, 512
+        o1 = paddle.randn([m, h2], dtype="bfloat16")
+        probs = paddle.rand([m, 1], dtype="float32")
+        cq, cs = fuse_weighted_swiglu_fp8_quant(
+            o1, probs, using_pow2_scaling=True, use_ue8m0=False
+        )
+        pq, ps = fuse_weighted_swiglu_fp8_quant_python(
+            o1, probs, quant_method="1x128"
+        )
+        self.assertEqual(list(pq.shape), list(cq.shape))
+        self.assertTrue(bool((cs == ps).all()), "scale mismatch")
+        self.assertTrue(_bits_equal(cq, pq), "fp8 payload mismatch")
+
+    def test_fuse_weighted_swiglu_fp8_quant_clamp(self):
+        """Python op is bit-exact vs the CUDA fused clamp op."""
+        m, h2 = 128, 512
+        clamp_value = 1.0
+        o1 = 3.0 * paddle.randn([m, h2], dtype="bfloat16")
+        probs = paddle.rand([m, 1], dtype="float32")
+        cq, cs = fuse_weighted_swiglu_fp8_quant_clamp(
+            o1,
+            probs,
+            using_pow2_scaling=True,
+            use_ue8m0=False,
+            clamp_value=clamp_value,
+        )
+        pq, ps = fuse_weighted_swiglu_fp8_quant_clamp_python(
+            o1, probs, clamp_value, quant_method="1x128"
+        )
+        self.assertEqual(list(pq.shape), list(cq.shape))
+        self.assertTrue(bool((cs == ps).all()), "scale mismatch")
+        self.assertTrue(_bits_equal(cq, pq), "fp8 payload mismatch")
+
+    def test_fuse_weighted_swiglu_fp8_quant_clamp_probs_1d(self):
+        """The e2e forward passes 1-D unzipped_probs [M]; the python op must
+        match the CUDA op in that layout as well."""
+        m, h2 = 128, 512
+        clamp_value = 1.0
+        o1 = 3.0 * paddle.randn([m, h2], dtype="bfloat16")
+        probs = paddle.rand([m], dtype="float32")
+        cq, cs = fuse_weighted_swiglu_fp8_quant_clamp(
+            o1,
+            probs,
+            using_pow2_scaling=True,
+            use_ue8m0=False,
+            clamp_value=clamp_value,
+        )
+        pq, ps = fuse_weighted_swiglu_fp8_quant_clamp_python(
+            o1, probs, clamp_value, quant_method="1x128"
+        )
+        self.assertTrue(bool((cs == ps).all()), "scale mismatch")
+        self.assertTrue(_bits_equal(cq, pq), "fp8 payload mismatch")
+
+    def test_quant_blockwize_vs_fp8_quant_blockwise(self):
+        """quant_blockwize is bit-exact vs paddle fp8_quant_blockwise."""
+        x = paddle.randn([64, 256], dtype="bfloat16")
+        cq, cs = paddle.incubate.nn.functional.fp8_quant_blockwise(
+            x,
+            output_scale_transpose=False,
+            quant_method="1x128",
+            input_transpose=False,
+        )
+        pq, ps = quant_blockwize(x, quant_method="1x128", quant_dtype="fp8")
+        self.assertTrue(bool((cs == ps).all()), "scale mismatch")
+        self.assertTrue(_bits_equal(cq, pq), "fp8 payload mismatch")
+
+    def test_fused_act_dequant(self):
+        """Python dequant is bit-exact vs paddle fused_act_dequant."""
+        x = paddle.randn([128, 256], dtype="bfloat16")
+        xq, xs = paddle.incubate.nn.functional.fp8_quant_blockwise(
+            x,
+            output_scale_transpose=False,
+            quant_method="1x128",
+            input_transpose=False,
+        )
+        cd = paddle.incubate.nn.functional.fused_act_dequant(xq, xs)
+        pd = fused_act_dequant_python(xq, xs)
+        self.assertEqual(cd.dtype, pd.dtype)
+        self.assertTrue(bool((cd == pd).all()), "dequant mismatch")
+
+
+@unittest.skipUnless(
+    HAS_FUSED_OPS and HAS_FP8_FP4_GEMM and IS_SM100,
+    "requires CUDA fused ops + DeepGEMM with fp8*fp4 + SM100",
+)
+class TestEndToEndGranularityDiff(unittest.TestCase):
+    """End-to-end: w4a8 (scattered ops, 1x32) vs original fp8 (fused ops,
+    128 granularity) vs bf16 reference.
+
+    The w4a8 path stores weights in fp4, so its quantization noise is
+    markedly larger than the fp8 path; this test verifies both paths work
+    and reports their deviation from the bf16 reference.
+    """
+
+    def setUp(self):
+        paddle.seed(2026)
+        np.random.seed(2026)
+
+    @staticmethod
+    def _make_node(num_experts, k, n, use_w4a8, dequant_input=False):
+        """Build an ExpertsGroupGemmContiguousNode with the given quant path."""
+        from paddlefleet.transformer.moe.fp8_utils import (
+            ExpertsGroupGemmContiguousNode,
+        )
+
+        class _Experts:
+            pass
+
+        class _Map:
+            pass
+
+        experts = _Experts()
+        experts.weight1 = (
+            paddle.randn([num_experts, k, 2 * n], dtype="bfloat16") * 0.05
+        )
+        experts.weight2 = (
+            paddle.randn([num_experts, n, k], dtype="bfloat16") * 0.05
+        )
+        experts.weight1.main_grad = None
+        experts.weight2.main_grad = None
+        custom_map = _Map()
+        custom_map.grouped_gemm_experts = experts
+        # Both paths run dw through the bf16 grouped gemm: w4a8 forces bf16
+        # wgrad by design, and the fp8 path's fp8-wgrad kitchen_gemm is not
+        # supported by cuBLAS on this SM100 setup.
+        node = ExpertsGroupGemmContiguousNode(
+            custom_map,
+            use_fp8_mlp=True,
+            moe_deep_gemm=True,
+            moe_expert_fusion=True,
+            use_bf16_gemm_weight_grad=True,
+            use_w4a8=use_w4a8,
+            dequant_input=dequant_input,
+        )
+        return node, experts
+
+    @staticmethod
+    def _clone_weights(dst_experts, src_experts):
+        """Copy weights so both nodes start from identical parameters."""
+        dst_experts.weight1 = src_experts.weight1.clone()
+        dst_experts.weight2 = src_experts.weight2.clone()
+        dst_experts.weight1.main_grad = None
+        dst_experts.weight2.main_grad = None
+
+    @staticmethod
+    def _bf16_ref_forward(x, probs, tokens, experts, n):
+        """fp32 per-expert reference forward for the MoE MLP."""
+        ref_parts = []
+        start = 0
+        for i, t in enumerate(tokens):
+            xi = x[start : start + t].astype("float32")
+            o1 = xi @ experts.weight1[i].astype("float32")
+            gate, up = o1[:, :n], o1[:, n:]
+            o2 = F.silu(gate) * up * probs[start : start + t]
+            ref_parts.append(o2 @ experts.weight2[i].astype("float32"))
+            start += t
+        return paddle.concat(ref_parts, axis=0).numpy()
+
+    def test_forward_w4a8_vs_fp8_vs_bf16(self):
+        """Both paths track the bf16 reference; w4a8 is noisier than fp8."""
+        num_experts, k, n, tokens = 2, 256, 256, [128, 384]
+        m = sum(tokens)
+
+        node_w4a8, experts = self._make_node(num_experts, k, n, use_w4a8=True)
+        node_fp8, experts_fp8 = self._make_node(
+            num_experts, k, n, use_w4a8=False
+        )
+        self._clone_weights(experts_fp8, experts)
+
+        x = paddle.randn([m, k], dtype="bfloat16")
+        probs = paddle.rand([m, 1], dtype="float32")
+
+        out_w4a8 = (
+            node_w4a8.forward(x.clone(), probs, tokens)
+            .astype("float32")
+            .numpy()
+        )
+        out_fp8 = (
+            node_fp8.forward(x.clone(), probs, tokens).astype("float32").numpy()
+        )
+        ref = self._bf16_ref_forward(x, probs, tokens, experts, n)
+
+        cos_w4a8 = _cos(out_w4a8, ref)
+        cos_fp8 = _cos(out_fp8, ref)
+        cos_cross = _cos(out_w4a8, out_fp8)
+        rel_w4a8 = float(np.linalg.norm(out_w4a8 - ref) / np.linalg.norm(ref))
+        rel_fp8 = float(np.linalg.norm(out_fp8 - ref) / np.linalg.norm(ref))
+        rel_cross = float(
+            np.linalg.norm(out_w4a8 - out_fp8) / np.linalg.norm(out_fp8)
+        )
+        print(
+            f"\n[e2e forward] cos(w4a8,bf16)={cos_w4a8:.6f} "
+            f"rel_err={rel_w4a8:.4f} | cos(fp8,bf16)={cos_fp8:.6f} "
+            f"rel_err={rel_fp8:.4f} | cos(w4a8,fp8)={cos_cross:.6f} "
+            f"rel_diff={rel_cross:.4f}"
+        )
+
+        # fp8 1x128 path carries small quantization noise
+        self.assertGreater(cos_fp8, 0.995)
+        # w4a8 stacks fp4 weights in two chained layers: noticeably noisier
+        # but still highly correlated
+        self.assertGreater(cos_w4a8, 0.97)
+        self.assertGreater(cos_cross, 0.97)
+        # w4a8 must deviate more than fp8 (inherent fp4 weight noise);
+        # otherwise the comparison itself is broken
+        self.assertGreater(rel_w4a8, rel_fp8)
+
+    def test_backward_w4a8_vs_fp8(self):
+        """w4a8 backward grads stay correlated with the fp8 path."""
+        num_experts, k, n, tokens = 2, 256, 256, [128, 384]
+        m = sum(tokens)
+
+        node_w4a8, experts = self._make_node(num_experts, k, n, use_w4a8=True)
+        node_fp8, experts_fp8 = self._make_node(
+            num_experts, k, n, use_w4a8=False
+        )
+        self._clone_weights(experts_fp8, experts)
+
+        x = paddle.randn([m, k], dtype="bfloat16")
+        probs = paddle.rand([m], dtype="float32")
+        out_grad = paddle.randn([m, k], dtype="bfloat16")
+
+        node_w4a8.forward(x.clone(), probs.unsqueeze(-1), tokens)
+        dx_w4a8, pg_w4a8 = node_w4a8.backward(out_grad.clone(), probs)
+
+        node_fp8.forward(x.clone(), probs.unsqueeze(-1), tokens)
+        dx_fp8, pg_fp8 = node_fp8.backward(out_grad.clone(), probs)
+
+        got_dx = dx_w4a8.astype("float32").numpy()
+        ref_dx = dx_fp8.astype("float32").numpy()
+        cos_dx = _cos(got_dx, ref_dx)
+        rel_dx = float(np.linalg.norm(got_dx - ref_dx) / np.linalg.norm(ref_dx))
+        cos_pg = _cos(
+            pg_w4a8.astype("float32").numpy(),
+            pg_fp8.astype("float32").numpy(),
+        )
+        print(
+            f"\n[e2e backward] cos(dx: w4a8,fp8)={cos_dx:.6f} "
+            f"rel_diff={rel_dx:.4f} | cos(probs_grad)={cos_pg:.6f}"
+        )
+        self.assertGreater(cos_dx, 0.97)
+        self.assertGreater(cos_pg, 0.97)
+
+        # dw comparison (both paths compute dw with the bf16 grouped gemm;
+        # any difference comes from forward quantization noise)
+        for name, w_a, w_b in (
+            ("dw1", experts.weight1, experts_fp8.weight1),
+            ("dw2", experts.weight2, experts_fp8.weight2),
+        ):
+            cos_dw = _cos(
+                w_a.main_grad.astype("float32").numpy(),
+                w_b.main_grad.astype("float32").numpy(),
+            )
+            print(f"[e2e backward] cos({name}: w4a8,fp8)={cos_dw:.6f}")
+            self.assertGreater(cos_dw, 0.97)
+
+    def test_backward_fp8_dequant_input(self):
+        """fp8 path with dequant_input=True: the bf16 wgrad dequantizes the
+        stored 1x128 fp8 input via fused_act_dequant. Forward, dx and dw2
+        must be bit-identical to the flag-off run; dw1 only differs by the
+        1x128 quant-dequant noise on x."""
+        num_experts, k, n, tokens = 2, 256, 256, [128, 384]
+        m = sum(tokens)
+        results = {}
+        for flag in (False, True):
+            paddle.seed(2026)
+            np.random.seed(2026)
+            node, experts = self._make_node(
+                num_experts, k, n, use_w4a8=False, dequant_input=flag
+            )
+            paddle.seed(7)
+            x = paddle.randn([m, k], dtype="bfloat16")
+            probs = paddle.rand([m], dtype="float32")
+            out = node.forward(x.clone(), probs.unsqueeze(-1), tokens)
+            out_grad = paddle.randn([m, k], dtype="bfloat16")
+            dx, _ = node.backward(out_grad.clone(), probs)
+            results[flag] = (
+                out.astype("float32"),
+                dx.astype("float32"),
+                experts.weight1.main_grad.astype("float32"),
+                experts.weight2.main_grad.astype("float32"),
+            )
+        out_a, dx_a, dw1_a, dw2_a = results[False]
+        out_b, dx_b, dw1_b, dw2_b = results[True]
+        self.assertTrue(bool((out_a == out_b).all()), "forward mismatch")
+        self.assertTrue(bool((dx_a == dx_b).all()), "dx mismatch")
+        self.assertTrue(bool((dw2_a == dw2_b).all()), "dw2 mismatch")
+        c1 = _cos(dw1_a.numpy(), dw1_b.numpy())
+        self.assertGreater(c1, 0.99, f"dw1 cos={c1}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/fp8/test_w4a8_group_gemm.py
+++ b/tests/single_card_tests/fp8/test_w4a8_group_gemm.py
@@ -1,0 +1,941 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for the w4a8 MoE MLP path (fp4 weights x fp8 activations,
+1x32 blockwise online quantization).
+
+Two parts:
+1. Python scattered quant/dequant helpers in
+   ``paddlefleet.transformer.moe.fp8_utils`` (any CUDA device).
+2. End-to-end ``ExpertsGroupGemmContiguousNode(use_w4a8=True)``
+   forward/backward against bf16/fp32 references (requires DeepGEMM with
+   ``m_grouped_fp8_fp4_gemm_nt_contiguous`` and SM100).
+
+Run:
+    source <DeepGEMM-with-fp8xfp4 env>/bin/activate
+    PYTHONPATH=packages/paddlefleet_ops/src:src python -m pytest \
+        tests/single_card_tests/fp8/test_w4a8_group_gemm.py -v
+"""
+
+import unittest
+
+import numpy as np
+import paddle
+import paddle.nn.functional as F
+
+from paddlefleet.transformer.moe import fp8_utils
+from paddlefleet.transformer.moe.fp8_utils import (
+    W4A8_QUANT_BLOCK,
+    ceil_to_ue8m0,
+    fuse_stack_fp8_quant_python,
+    fuse_stack_transpose_fp8_quant_python,
+    fuse_weighted_swiglu_fp8_quant_clamp_python,
+    fuse_weighted_swiglu_fp8_quant_python,
+    fused_act_dequant_python,
+    quant_blockwize,
+)
+
+try:
+    from paddlefleet_ops import deep_gemm as _pf_deep_gemm
+
+    HAS_FP8_FP4_GEMM = hasattr(
+        _pf_deep_gemm, "m_grouped_fp8_fp4_gemm_nt_contiguous"
+    )
+except (ImportError, RuntimeError):
+    HAS_FP8_FP4_GEMM = False
+
+IS_SM100 = (
+    paddle.is_compiled_with_cuda()
+    and paddle.device.cuda.get_device_capability()[0] == 10
+)
+
+FP4_E2M1_MAX = 6.0
+# e2m1 code (0~7) magnitudes
+_FP4_VALUES = np.array([0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0])
+
+
+def _unpack_fp4_to_float(packed, sf):
+    """Unpack fp4 int8 [.., C/2] + scale [.., C/32] back to fp32 [.., C]."""
+    raw = packed.numpy().astype(np.uint8)
+    lo = raw & 0x0F
+    hi = raw >> 4
+    codes = np.stack([lo, hi], axis=-1).reshape(*raw.shape[:-1], -1)
+    mag = _FP4_VALUES[codes & 0x7]
+    val = np.where(codes >= 8, -mag, mag)
+    sf_np = sf.numpy().astype(np.float64)
+    val = val.reshape(*sf_np.shape, W4A8_QUANT_BLOCK) * sf_np[..., None]
+    return val.reshape(*raw.shape[:-1], raw.shape[-1] * 2)
+
+
+def _cos(a, b):
+    a = np.asarray(a, dtype=np.float64).reshape(-1)
+    b = np.asarray(b, dtype=np.float64).reshape(-1)
+    return float(np.sum(a * b) / (np.linalg.norm(a) * np.linalg.norm(b)))
+
+
+def _bits_equal(a, b):
+    """Bitwise comparison for fp8/bf16 tensors."""
+    if a.dtype == paddle.bfloat16:
+        return bool((a.view("int16") == b.view("int16")).all())
+    return bool((a.view("int8") == b.view("int8")).all())
+
+
+class TestCeilToUe8m0(unittest.TestCase):
+    def test_values(self):
+        """ceil_to_ue8m0 rounds scales up to powers of two."""
+        x = paddle.to_tensor(
+            [0.5, 1.0, 1.5, 3.0, 0.3, 1e-4, 448.0], dtype="float32"
+        )
+        y = ceil_to_ue8m0(x).numpy()
+        np.testing.assert_allclose(y, [0.5, 1.0, 2.0, 4.0, 0.5, 2**-13, 512.0])
+        exp = np.log2(y)
+        np.testing.assert_allclose(exp, np.round(exp))
+
+
+class TestQuantBlockwize(unittest.TestCase):
+    def setUp(self):
+        paddle.seed(2026)
+        np.random.seed(2026)
+
+    def test_fp8_1x32_dequant_roundtrip(self):
+        """fp8 1x32 quant-dequant roundtrip keeps relative error small."""
+        x = paddle.randn([64, 256], dtype="bfloat16")
+        x_fp8, sf = quant_blockwize(x, quant_method="1x32", quant_dtype="fp8")
+        self.assertEqual(x_fp8.dtype, paddle.float8_e4m3fn)
+        self.assertEqual(list(sf.shape), [64, 256 // W4A8_QUANT_BLOCK])
+        # ue8m0: scales are powers of 2
+        exp = np.log2(sf.numpy())
+        np.testing.assert_allclose(exp, np.round(exp))
+        x_dq = fused_act_dequant_python(x_fp8, sf)
+        err = (x_dq.astype("float32") - x.astype("float32")).abs()
+        ref = x.astype("float32").abs().clip(min=1e-2)
+        self.assertLess(float((err / ref).mean()), 0.06)
+
+    def test_fp8_no_ue8m0_exact_scale(self):
+        """using_ue8m0_scale=False keeps the exact amax/448 scale."""
+        x = paddle.randn([16, 64], dtype="bfloat16")
+        x_fp8, sf = quant_blockwize(
+            x, quant_dtype="fp8", using_ue8m0_scale=False
+        )
+        x_view = x.astype("float32").reshape([16, -1, W4A8_QUANT_BLOCK]).numpy()
+        amax = np.clip(np.abs(x_view).max(axis=-1), 1e-4, None)
+        np.testing.assert_allclose(sf.numpy(), amax / 448.0, rtol=1e-6)
+        self.assertEqual(x_fp8.dtype, paddle.float8_e4m3fn)
+
+    def test_empty_input(self):
+        """Zero-row input returns empty tensors with correct shapes."""
+        x = paddle.empty([0, 64], dtype="bfloat16")
+        x_fp8, sf = quant_blockwize(x, quant_dtype="fp8")
+        self.assertEqual(list(x_fp8.shape), [0, 64])
+        self.assertEqual(list(sf.shape), [0, 2])
+        x_fp4, sf4 = quant_blockwize(x, quant_dtype="fp4")
+        self.assertEqual(list(x_fp4.shape), [0, 32])
+        self.assertEqual(list(sf4.shape), [0, 2])
+
+    def test_fp4_dequant_roundtrip(self):
+        """fp4 1x32 quant-dequant roundtrip stays correlated with the input."""
+        x = paddle.randn([32, 128], dtype="bfloat16")
+        x_fp4, sf = quant_blockwize(x, quant_method="1x32", quant_dtype="fp4")
+        self.assertEqual(x_fp4.dtype, paddle.int8)
+        self.assertEqual(list(x_fp4.shape), [32, 64])
+        self.assertEqual(list(sf.shape), [32, 128 // W4A8_QUANT_BLOCK])
+        x_dq = _unpack_fp4_to_float(x_fp4, sf)
+        x_ref = x.astype("float32").numpy()
+        self.assertGreater(_cos(x_dq, x_ref), 0.98)
+        block = x_ref.reshape(32, -1, W4A8_QUANT_BLOCK)
+        amax = np.abs(block).max(axis=-1).clip(min=1e-4)
+        self.assertTrue(
+            (sf.numpy() * FP4_E2M1_MAX >= amax * 0.999).all(),
+            "scale must cover per-block amax",
+        )
+
+    def test_fp4_no_ue8m0_exact_scale(self):
+        """fp4 with using_ue8m0_scale=False keeps the exact amax/6 scale."""
+        x = paddle.randn([8, 64], dtype="bfloat16")
+        x_fp4, sf = quant_blockwize(
+            x, quant_dtype="fp4", using_ue8m0_scale=False
+        )
+        x_view = x.astype("float32").reshape([8, -1, W4A8_QUANT_BLOCK]).numpy()
+        amax = np.clip(np.abs(x_view).max(axis=-1), 1e-4, None)
+        np.testing.assert_allclose(sf.numpy(), amax / FP4_E2M1_MAX, rtol=1e-6)
+        # dequantized values must still track the input
+        x_dq = _unpack_fp4_to_float(x_fp4, sf)
+        self.assertGreater(_cos(x_dq, x_view.reshape(8, -1)), 0.98)
+
+    def test_2d_tile_128x128_matches_manual_reference(self):
+        """gran_m > 1 branch: 128x128 tile quantization for weights."""
+        m, n = 256, 384
+        x = paddle.randn([m, n], dtype="bfloat16")
+        for use_ue8m0 in (True, False):
+            q, sf = quant_blockwize(
+                x,
+                quant_method="128x128",
+                quant_dtype="fp8",
+                using_ue8m0_scale=use_ue8m0,
+            )
+            self.assertEqual(q.dtype, paddle.float8_e4m3fn)
+            self.assertEqual(list(q.shape), [m, n])
+            self.assertEqual(list(sf.shape), [m // 128, n // 128])
+            # manual per-tile reference in numpy
+            x32 = x.astype("float32").numpy()
+            tiles = x32.reshape(m // 128, 128, n // 128, 128).transpose(
+                0, 2, 1, 3
+            )
+            amax = np.clip(np.abs(tiles).max(axis=(2, 3)), 1e-4, None)
+            ref_sf = amax / 448.0
+            if use_ue8m0:
+                ref_sf = np.exp2(np.ceil(np.log2(ref_sf)))
+            np.testing.assert_allclose(sf.numpy(), ref_sf, rtol=1e-6)
+            # dequantize back and check the error is bounded by fp8 noise
+            q32 = q.astype("float32").numpy()
+            q_tiles = q32.reshape(m // 128, 128, n // 128, 128).transpose(
+                0, 2, 1, 3
+            )
+            dq = q_tiles * ref_sf[:, :, None, None]
+            self.assertGreater(_cos(dq, tiles), 0.999)
+
+    def test_2d_tile_rejects_fp4(self):
+        """2D tile quantization only supports fp8; fp4 must be rejected."""
+        x = paddle.randn([128, 128], dtype="bfloat16")
+        with self.assertRaises(AssertionError):
+            quant_blockwize(x, quant_method="128x128", quant_dtype="fp4")
+
+    def test_2d_tile_rejects_non_divisible_m(self):
+        """2D tile quantization requires M to be a multiple of gran_m."""
+        x = paddle.randn([100, 128], dtype="bfloat16")
+        with self.assertRaises(AssertionError):
+            quant_blockwize(x, quant_method="128x128", quant_dtype="fp8")
+
+    def test_rejects_non_divisible_k(self):
+        """K must be a multiple of the quantization block size."""
+        x = paddle.randn([4, 48], dtype="bfloat16")
+        with self.assertRaises(AssertionError):
+            quant_blockwize(x, quant_method="1x32", quant_dtype="fp8")
+
+    def test_rejects_unsupported_dtype(self):
+        """An unsupported quant_dtype raises ValueError."""
+        x = paddle.randn([4, 64], dtype="bfloat16")
+        with self.assertRaises(ValueError):
+            quant_blockwize(x, quant_method="1x32", quant_dtype="int8")
+
+
+class TestStackQuantHelpers(unittest.TestCase):
+    def setUp(self):
+        paddle.seed(2026)
+        np.random.seed(2026)
+
+    def test_fuse_stack_transpose_fp4(self):
+        """Stacked weights are transposed then fp4-quantized along K."""
+        e, k, n = 2, 64, 128
+        w = paddle.randn([e, k, n], dtype="bfloat16")
+        # transpose: [E, K, N] -> [E, N, K/2]
+        w_fp4, sf = fuse_stack_transpose_fp8_quant_python(w, quant_dtype="fp4")
+        self.assertEqual(w_fp4.dtype, paddle.int8)
+        self.assertEqual(list(w_fp4.shape), [e, n, k // 2])
+        self.assertEqual(list(sf.shape), [e, n, k // W4A8_QUANT_BLOCK])
+        w_dq = _unpack_fp4_to_float(w_fp4, sf)
+        w_ref = w.astype("float32").transpose([0, 2, 1]).numpy()
+        self.assertGreater(_cos(w_dq, w_ref), 0.98)
+
+    def test_fuse_stack_fp4(self):
+        """Stacked weights are fp4-quantized along the last dim."""
+        e, k, n = 2, 128, 64
+        w = paddle.randn([e, k, n], dtype="bfloat16")
+        w_fp4, sf = fuse_stack_fp8_quant_python(w, quant_dtype="fp4")
+        self.assertEqual(list(w_fp4.shape), [e, k, n // 2])
+        self.assertEqual(list(sf.shape), [e, k, n // W4A8_QUANT_BLOCK])
+        w_dq = _unpack_fp4_to_float(w_fp4, sf)
+        self.assertGreater(_cos(w_dq, w.astype("float32").numpy()), 0.98)
+
+    def test_list_input(self):
+        """A list of expert weights behaves exactly like the stacked tensor."""
+        w_list = [paddle.randn([64, 32], dtype="bfloat16") for _ in range(3)]
+        w_fp4, sf = fuse_stack_transpose_fp8_quant_python(
+            w_list, quant_dtype="fp4"
+        )
+        self.assertEqual(list(w_fp4.shape), [3, 32, 32])
+        self.assertEqual(list(sf.shape), [3, 32, 2])
+        # a list must behave exactly like the stacked tensor
+        w_fp4_ref, sf_ref = fuse_stack_transpose_fp8_quant_python(
+            paddle.stack(w_list, axis=0), quant_dtype="fp4"
+        )
+        self.assertTrue(bool((w_fp4 == w_fp4_ref).all()))
+        self.assertTrue(bool((sf == sf_ref).all()))
+
+    def test_single_element_list_input(self):
+        """A 1-element list holds an already-stacked [E, R, C] tensor and
+        takes the w[0] branch in _stack_expert_weights."""
+        w = paddle.randn([2, 64, 64], dtype="bfloat16")
+        w_fp4_a, sf_a = fuse_stack_fp8_quant_python([w], quant_dtype="fp4")
+        w_fp4_b, sf_b = fuse_stack_fp8_quant_python(w, quant_dtype="fp4")
+        self.assertTrue(bool((w_fp4_a == w_fp4_b).all()))
+        self.assertTrue(bool((sf_a == sf_b).all()))
+
+    def test_2d_tile_layout_kept(self):
+        """quant_method='128x128' keeps the 2D CUDA fused-op layout."""
+        e, k, n = 2, 128, 256
+        w = paddle.randn([e, k, n], dtype="bfloat16")
+        q, sf = fuse_stack_fp8_quant_python(
+            w, quant_method="128x128", quant_dtype="fp8"
+        )
+        self.assertEqual(list(q.shape), [e * k, n])
+        self.assertEqual(list(sf.shape), [e * k // 128, n // 128])
+        q_t, sf_t = fuse_stack_transpose_fp8_quant_python(
+            w, quant_method="128x128", quant_dtype="fp8"
+        )
+        self.assertEqual(list(q_t.shape), [e * n, k])
+        self.assertEqual(list(sf_t.shape), [e * n // 128, k // 128])
+
+
+class TestWeightedSwigluQuant(unittest.TestCase):
+    def setUp(self):
+        paddle.seed(2026)
+        np.random.seed(2026)
+
+    def test_matches_fp32_reference(self):
+        """swiglu(o1)*probs quantized output matches the fp32 reference."""
+        m, h2 = 32, 128
+        o1 = paddle.randn([m, h2], dtype="bfloat16")
+        probs = paddle.rand([m, 1], dtype="float32")
+        o2_fp8, sf = fuse_weighted_swiglu_fp8_quant_python(o1, probs)
+        self.assertEqual(list(o2_fp8.shape), [m, h2 // 2])
+        self.assertEqual(list(sf.shape), [m, h2 // 2 // W4A8_QUANT_BLOCK])
+        x32 = o1.astype("float32")
+        gate, up = x32[:, : h2 // 2], x32[:, h2 // 2 :]
+        ref = (F.silu(gate) * up * probs).numpy()
+        got = fused_act_dequant_python(o2_fp8, sf).astype("float32").numpy()
+        err = np.abs(got - ref)
+        denom = np.clip(np.abs(ref), 1e-2, None)
+        self.assertLess(float((err / denom).mean()), 0.06)
+
+    def test_clamp_matches_fp32_reference(self):
+        """Clamped swiglu output matches the clamped fp32 reference."""
+        m, h2 = 16, 128
+        clamp_value = 1.0
+        o1 = 5.0 * paddle.randn([m, h2], dtype="bfloat16")
+        probs = paddle.rand([m, 1], dtype="float32")
+        o2_fp8, sf = fuse_weighted_swiglu_fp8_quant_clamp_python(
+            o1, probs, clamp_value
+        )
+        x32 = o1.astype("float32")
+        gate = x32[:, : h2 // 2].clip(max=clamp_value)
+        up = x32[:, h2 // 2 :].clip(min=-clamp_value, max=clamp_value)
+        ref = (F.silu(gate) * up * probs).numpy()
+        got = fused_act_dequant_python(o2_fp8, sf).astype("float32").numpy()
+        err = np.abs(got - ref)
+        denom = np.clip(np.abs(ref), 1e-2, None)
+        self.assertLess(float((err / denom).mean()), 0.06)
+
+    def test_probs_1d_matches_2d(self):
+        """1-D probs [M] (as passed by the e2e forward) must broadcast the
+        same way as [M, 1]."""
+        m, h2 = 16, 128
+        o1 = paddle.randn([m, h2], dtype="bfloat16")
+        probs = paddle.rand([m], dtype="float32")
+        q_1d, sf_1d = fuse_weighted_swiglu_fp8_quant_python(o1, probs)
+        q_2d, sf_2d = fuse_weighted_swiglu_fp8_quant_python(
+            o1, probs.unsqueeze(-1)
+        )
+        self.assertTrue(_bits_equal(q_1d, q_2d))
+        self.assertTrue(bool((sf_1d == sf_2d).all()))
+        clamp = 1.0
+        qc_1d, sfc_1d = fuse_weighted_swiglu_fp8_quant_clamp_python(
+            o1, probs, clamp
+        )
+        qc_2d, sfc_2d = fuse_weighted_swiglu_fp8_quant_clamp_python(
+            o1, probs.unsqueeze(-1), clamp
+        )
+        self.assertTrue(_bits_equal(qc_1d, qc_2d))
+        self.assertTrue(bool((sfc_1d == sfc_2d).all()))
+
+
+class TestFusedActDequantPython(unittest.TestCase):
+    def setUp(self):
+        paddle.seed(2026)
+
+    def test_1x128_granularity_inferred(self):
+        """Granularity is inferred from the scale shape, so 1x128 fp8
+        activations (the original fp8 path) also dequantize correctly."""
+        x = paddle.randn([16, 256], dtype="bfloat16")
+        x_fp8, sf = quant_blockwize(x, quant_method="1x128", quant_dtype="fp8")
+        self.assertEqual(list(sf.shape), [16, 2])
+        x_dq = fused_act_dequant_python(x_fp8, sf)
+        err = (x_dq.astype("float32") - x.astype("float32")).abs()
+        ref = x.astype("float32").abs().clip(min=1e-2)
+        self.assertLess(float((err / ref).mean()), 0.06)
+
+
+HAS_K_GROUPED_BF16_GEMM = HAS_FP8_FP4_GEMM and hasattr(
+    _pf_deep_gemm, "k_grouped_bf16_gemm_tn_contiguous"
+)
+
+
+@unittest.skipUnless(
+    HAS_K_GROUPED_BF16_GEMM and IS_SM100,
+    "requires DeepGEMM with k_grouped_bf16_gemm_tn_contiguous on SM100",
+)
+class TestKGroupedBf16GemmAligned(unittest.TestCase):
+    """k_grouped_bf16_gemm_tn_contiguous_aligned (used by the bf16 dw path)
+    now calls the new DeepGEMM binding positionally; verify per-group
+    d[i] = a_i^T @ b_i against a numpy reference."""
+
+    def setUp(self):
+        paddle.seed(2026)
+
+    def _check(self, tokens, k=128, n=256):
+        """Run the aligned grouped gemm and compare with a numpy reference."""
+        from paddlefleet.transformer.moe.moe_utils import (
+            k_grouped_bf16_gemm_tn_contiguous_aligned,
+        )
+
+        e = len(tokens)
+        m = sum(tokens)
+        a = paddle.randn([m, k], dtype="bfloat16")
+        b = paddle.randn([m, n], dtype="bfloat16")
+        d = paddle.zeros([e, k, n], dtype="float32")
+        k_grouped_bf16_gemm_tn_contiguous_aligned(
+            a,
+            b,
+            d,
+            tokens,
+            paddle.to_tensor(tokens, dtype="int32"),
+            paddle.zeros([e, k, n], dtype="float32"),
+        )
+        ref = []
+        start = 0
+        for t in tokens:
+            ref.append(
+                (
+                    a[start : start + t].astype("float32").T
+                    @ b[start : start + t].astype("float32")
+                ).numpy()
+            )
+            start += t
+        ref = np.stack(ref)
+        rel = np.abs(d.numpy() - ref).max() / (np.abs(ref).max() + 1e-9)
+        self.assertLess(rel, 1e-5)
+
+    def test_aligned_groups(self):
+        """128-aligned groups compute per-group a^T @ b correctly."""
+        self._check([128, 384])
+
+    def test_unaligned_groups_are_padded(self):
+        """Groups not 128-aligned are padded internally and stay correct."""
+        # internal padding handles groups that are not 128-aligned
+        self._check([100, 156])
+
+
+def _make_experts_and_map(num_experts, k, n):
+    """Build fake stacked expert weights and the custom map object."""
+
+    class _Experts:
+        pass
+
+    class _Map:
+        pass
+
+    experts = _Experts()
+    experts.weight1 = (
+        paddle.randn([num_experts, k, 2 * n], dtype="bfloat16") * 0.05
+    )
+    experts.weight2 = paddle.randn([num_experts, n, k], dtype="bfloat16") * 0.05
+    experts.weight1.main_grad = None
+    experts.weight2.main_grad = None
+    custom_map = _Map()
+    custom_map.grouped_gemm_experts = experts
+    return experts, custom_map
+
+
+@unittest.skipUnless(
+    HAS_FP8_FP4_GEMM and IS_SM100,
+    "requires DeepGEMM with m_grouped_fp8_fp4_gemm_nt_contiguous on SM100",
+)
+class TestW4A8GroupGemm(unittest.TestCase):
+    """End-to-end: ExpertsGroupGemmContiguousNode(use_w4a8) vs references.
+
+    Note: the DeepGEMM SM100 contiguous layout requires the token count of
+    each group to be 128-aligned (guaranteed by the dispatcher padding in
+    real MoE runs); 0-token groups are allowed.
+    """
+
+    def setUp(self):
+        paddle.seed(2026)
+        np.random.seed(2026)
+
+    def _make_node(
+        self,
+        num_experts,
+        k,
+        n,
+        clamp_value=None,
+        dequant_input=False,
+        recompute_moe_gate_up=False,
+    ):
+        """Build an ExpertsGroupGemmContiguousNode with use_w4a8=True."""
+        from paddlefleet.transformer.moe.fp8_utils import (
+            ExpertsGroupGemmContiguousNode,
+        )
+
+        experts, custom_map = _make_experts_and_map(num_experts, k, n)
+        node = ExpertsGroupGemmContiguousNode(
+            custom_map,
+            use_fp8_mlp=True,
+            moe_deep_gemm=True,
+            moe_expert_fusion=True,
+            use_w4a8=True,
+            clamp_value=clamp_value,
+            dequant_input=dequant_input,
+            recompute_moe_gate_up=recompute_moe_gate_up,
+        )
+        return node, experts
+
+    def _bf16_ref_forward(self, x, probs, tokens, experts, n):
+        """fp32 per-expert reference forward for the MoE MLP."""
+        ref_parts = []
+        start = 0
+        for i, t in enumerate(tokens):
+            xi = x[start : start + t].astype("float32")
+            o1 = xi @ experts.weight1[i].astype("float32")
+            gate, up = o1[:, :n], o1[:, n:]
+            o2 = F.silu(gate) * up * probs[start : start + t]
+            ref_parts.append(o2 @ experts.weight2[i].astype("float32"))
+            start += t
+        return paddle.concat(ref_parts, axis=0).numpy()
+
+    # ---------------- construction-time branches ----------------
+
+    def test_init_requires_prerequisites(self):
+        """use_w4a8 without use_fp8_mlp must be rejected."""
+        experts, custom_map = _make_experts_and_map(2, 128, 128)
+        from paddlefleet.transformer.moe.fp8_utils import (
+            ExpertsGroupGemmContiguousNode,
+        )
+
+        # use_fp8_mlp=False (with moe_deep_gemm kept on so that the
+        # constructor reaches the w4a8 prerequisite assert) must be rejected
+        with self.assertRaises(AssertionError):
+            ExpertsGroupGemmContiguousNode(
+                custom_map,
+                use_fp8_mlp=False,
+                moe_deep_gemm=True,
+                moe_expert_fusion=True,
+                use_w4a8=True,
+            )
+
+    def test_init_forces_bf16_weight_grad(self):
+        """use_w4a8 forces the bf16 grouped-gemm weight-grad path."""
+        from paddlefleet.transformer.moe.fp8_utils import (
+            ExpertsGroupGemmContiguousNode,
+        )
+
+        experts, custom_map = _make_experts_and_map(2, 128, 128)
+        node = ExpertsGroupGemmContiguousNode(
+            custom_map,
+            use_fp8_mlp=True,
+            moe_deep_gemm=True,
+            moe_expert_fusion=True,
+            use_bf16_gemm_weight_grad=False,
+            use_w4a8=True,
+        )
+        self.assertTrue(node.use_bf16_gemm_weight_grad)
+
+    def test_default_use_w4a8_is_off(self):
+        """use_w4a8 defaults to False."""
+        from paddlefleet.transformer.moe.fp8_utils import (
+            ExpertsGroupGemmContiguousNode,
+        )
+
+        experts, custom_map = _make_experts_and_map(2, 128, 128)
+        node = ExpertsGroupGemmContiguousNode(
+            custom_map,
+            use_fp8_mlp=True,
+            moe_deep_gemm=True,
+            moe_expert_fusion=True,
+        )
+        self.assertFalse(node.use_w4a8)
+
+    # ---------------- forward ----------------
+
+    def test_forward_vs_bf16(self):
+        """w4a8 forward output stays close to the bf16 reference."""
+        num_experts, k, n, tokens = 2, 256, 256, [128, 128]
+        node, experts = self._make_node(num_experts, k, n)
+        m = sum(tokens)
+        x = paddle.randn([m, k], dtype="bfloat16")
+        probs = paddle.rand([m, 1], dtype="float32")
+
+        o3 = node.forward(x, probs, tokens)
+
+        ref = self._bf16_ref_forward(x, probs, tokens, experts, n)
+        got = o3.astype("float32").numpy()
+        # single-layer fp4 e2m1 tolerance ~0.01 (DeepGEMM reference);
+        # relaxed to 0.97 for two chained layers
+        self.assertGreater(_cos(got, ref), 0.97)
+
+    def test_forward_uneven_tokens(self):
+        """Uneven and zero-token groups still match the bf16 reference."""
+        num_experts, k, n, tokens = 4, 128, 256, [128, 256, 0, 128]
+        node, experts = self._make_node(num_experts, k, n)
+        m = sum(tokens)
+        x = paddle.randn([m, k], dtype="bfloat16")
+        probs = paddle.rand([m, 1], dtype="float32")
+
+        o3 = node.forward(x, probs, tokens)
+        ref = self._bf16_ref_forward(x, probs, tokens, experts, n)
+        self.assertGreater(_cos(o3.astype("float32").numpy(), ref), 0.97)
+
+    def test_forward_clamp(self):
+        """Forward with clamp_value matches the clamped bf16 reference."""
+        num_experts, k, n, tokens = 2, 128, 128, [128, 128]
+        clamp_value = 1.0
+        node, experts = self._make_node(
+            num_experts, k, n, clamp_value=clamp_value
+        )
+        m = sum(tokens)
+        # Moderate saturation: some elements hit the clamp boundary, but not
+        # so many that fp4 weight noise flips the clamp decision at the
+        # boundary (an inherent quantization sensitivity).
+        x = 2.0 * paddle.randn([m, k], dtype="bfloat16")
+        probs = paddle.rand([m, 1], dtype="float32")
+
+        o3 = node.forward(x, probs, tokens)
+
+        ref_parts = []
+        start = 0
+        for i, t in enumerate(tokens):
+            xi = x[start : start + t].astype("float32")
+            o1 = xi @ experts.weight1[i].astype("float32")
+            gate = o1[:, :n].clip(max=clamp_value)
+            up = o1[:, n:].clip(min=-clamp_value, max=clamp_value)
+            o2 = F.silu(gate) * up * probs[start : start + t]
+            ref_parts.append(o2 @ experts.weight2[i].astype("float32"))
+            start += t
+        ref = paddle.concat(ref_parts, axis=0).numpy()
+        # make sure the clamp actually kicks in
+        o1_full = paddle.concat(
+            [
+                x[sum(tokens[:i]) : sum(tokens[: i + 1])].astype("float32")
+                @ experts.weight1[i].astype("float32")
+                for i in range(num_experts)
+            ],
+            axis=0,
+        )
+        self.assertGreater(
+            float((o1_full.abs() > clamp_value).astype("float32").mean()),
+            0.05,
+        )
+        self.assertGreater(_cos(o3.astype("float32").numpy(), ref), 0.97)
+
+    # ---------------- backward ----------------
+
+    def _autograd_reference(
+        self, x, probs, tokens, experts, n, out_grad, clamp_value=None
+    ):
+        """fp32 paddle autograd reference; returns (dx, dprobs, dw1, dw2)."""
+        x_ref = x.astype("float32").detach()
+        x_ref.stop_gradient = False
+        probs_ref = probs.astype("float32").detach()
+        probs_ref.stop_gradient = False
+        w1_ref = experts.weight1.astype("float32").detach()
+        w1_ref.stop_gradient = False
+        w2_ref = experts.weight2.astype("float32").detach()
+        w2_ref.stop_gradient = False
+        ref_parts = []
+        start = 0
+        for i, t in enumerate(tokens):
+            xi = x_ref[start : start + t]
+            o1 = xi @ w1_ref[i]
+            gate, up = o1[:, :n], o1[:, n:]
+            if clamp_value is not None:
+                gate = gate.clip(max=clamp_value)
+                up = up.clip(min=-clamp_value, max=clamp_value)
+            o2 = F.silu(gate) * up * probs_ref[start : start + t].unsqueeze(-1)
+            ref_parts.append(o2 @ w2_ref[i])
+            start += t
+        o3_ref = paddle.concat(ref_parts, axis=0)
+        o3_ref.backward(out_grad.astype("float32"))
+        return x_ref.grad, probs_ref.grad, w1_ref.grad, w2_ref.grad
+
+    def test_backward(self):
+        """w4a8 backward grads match the fp32 autograd reference."""
+        num_experts, k, n, tokens = 2, 256, 256, [128, 384]
+        node, experts = self._make_node(num_experts, k, n)
+        m = sum(tokens)
+        x = paddle.randn([m, k], dtype="bfloat16")
+        probs = paddle.rand([m], dtype="float32")
+
+        node.forward(x, probs.unsqueeze(-1), tokens)
+        out_grad = paddle.randn([m, k], dtype="bfloat16")
+        dx, probs_grad = node.backward(out_grad.clone(), probs)
+        self.assertEqual(list(dx.shape), [m, k])
+        self.assertEqual(probs_grad.shape[0], m)
+        self.assertFalse(bool(paddle.isnan(dx.astype("float32")).any()))
+        # dw goes through the bf16 path; main_grad must be populated
+        self.assertIsNotNone(experts.weight1.main_grad)
+        self.assertIsNotNone(experts.weight2.main_grad)
+
+        ref_dx, ref_pg, ref_dw1, ref_dw2 = self._autograd_reference(
+            x, probs, tokens, experts, n, out_grad
+        )
+        self.assertGreater(
+            _cos(dx.astype("float32").numpy(), ref_dx.numpy()), 0.97
+        )
+        self.assertGreater(
+            _cos(probs_grad.astype("float32").numpy(), ref_pg.numpy()), 0.97
+        )
+        for got_dw, ref_dw in (
+            (experts.weight1.main_grad, ref_dw1),
+            (experts.weight2.main_grad, ref_dw2),
+        ):
+            got_np = got_dw.astype("float32").numpy()
+            self.assertFalse(np.isnan(got_np).any())
+            self.assertGreater(_cos(got_np, ref_dw.numpy()), 0.97)
+
+    def test_backward_clamp(self):
+        """Covers the clamp branch of the w4a8 swiglu backward.
+
+        Uses mild saturation (~8% of o1 elements clamped): fp4 weight noise
+        flips the clamp decision for elements sitting on the boundary, which
+        also flips the clip gradient mask, so heavier saturation inherently
+        degrades the gradient match.
+        """
+        num_experts, k, n, tokens = 2, 128, 128, [128, 128]
+        clamp_value = 1.0
+        node, experts = self._make_node(
+            num_experts, k, n, clamp_value=clamp_value
+        )
+        m = sum(tokens)
+        x = paddle.randn([m, k], dtype="bfloat16")
+        probs = paddle.rand([m], dtype="float32")
+
+        # make sure the clamp actually kicks in
+        o1_full = paddle.concat(
+            [
+                x[sum(tokens[:i]) : sum(tokens[: i + 1])].astype("float32")
+                @ experts.weight1[i].astype("float32")
+                for i in range(num_experts)
+            ],
+            axis=0,
+        )
+        self.assertGreater(
+            float((o1_full.abs() > clamp_value).astype("float32").mean()),
+            0.05,
+        )
+
+        node.forward(x, probs.unsqueeze(-1), tokens)
+        out_grad = paddle.randn([m, k], dtype="bfloat16")
+        dx, probs_grad = node.backward(out_grad.clone(), probs)
+        self.assertFalse(bool(paddle.isnan(dx.astype("float32")).any()))
+
+        ref_dx, ref_pg, ref_dw1, ref_dw2 = self._autograd_reference(
+            x, probs, tokens, experts, n, out_grad, clamp_value=clamp_value
+        )
+        self.assertGreater(
+            _cos(dx.astype("float32").numpy(), ref_dx.numpy()), 0.95
+        )
+        self.assertGreater(
+            _cos(probs_grad.astype("float32").numpy(), ref_pg.numpy()), 0.95
+        )
+        for got_dw, ref_dw in (
+            (experts.weight1.main_grad, ref_dw1),
+            (experts.weight2.main_grad, ref_dw2),
+        ):
+            self.assertGreater(
+                _cos(got_dw.astype("float32").numpy(), ref_dw.numpy()), 0.95
+            )
+
+    def test_backward_dequant_input(self):
+        """dequant_input only changes the backward storage format (fp8 1x32
+        instead of bf16): forward output and dx must be bit-identical to the
+        flag-off run; dw1 sees quant-dequant noise on x, checked via cosine.
+        """
+        num_experts, k, n, tokens = 2, 256, 256, [128, 384]
+        m = sum(tokens)
+        results = {}
+        for flag in (False, True):
+            paddle.seed(2026)
+            np.random.seed(2026)
+            node, experts = self._make_node(
+                num_experts, k, n, dequant_input=flag
+            )
+            paddle.seed(7)
+            x = paddle.randn([m, k], dtype="bfloat16")
+            probs = paddle.rand([m], dtype="float32")
+            out = node.forward(x, probs.unsqueeze(-1), tokens)
+            if flag:
+                self.assertIsNotNone(node.input_fp8, "fp8 input must be stored")
+                self.assertIsNone(node.input, "bf16 input must not be stored")
+            out_grad = paddle.randn([m, k], dtype="bfloat16")
+            dx, probs_grad = node.backward(out_grad.clone(), probs)
+            results[flag] = (
+                out.astype("float32"),
+                dx.astype("float32"),
+                experts.weight1.main_grad.astype("float32"),
+                experts.weight2.main_grad.astype("float32"),
+            )
+        out_a, dx_a, dw1_a, dw2_a = results[False]
+        out_b, dx_b, dw1_b, dw2_b = results[True]
+        # the forward path does not depend on dequant_input: bit-identical
+        self.assertTrue(bool((out_a == out_b).all()), "forward mismatch")
+        # dx does not depend on the stored input: bit-identical
+        self.assertTrue(bool((dx_a == dx_b).all()), "dx mismatch")
+        # dw2 does not depend on x at all; dw1 uses the dequantized x and
+        # carries 1x32 quantization noise
+        self.assertTrue(bool((dw2_a == dw2_b).all()), "dw2 mismatch")
+        c1 = _cos(dw1_a.numpy(), dw1_b.numpy())
+        self.assertGreater(c1, 0.99, f"dw1 cos={c1}")
+
+    def test_backward_recompute_gate_up(self):
+        """recompute_moe_gate_up re-runs the w4a8 gate_up in backward with
+        x=None; both storage formats must reproduce the no-recompute grads
+        bit-exactly (the recomputed o1 reuses the same quantized inputs)."""
+        num_experts, k, n, tokens = 2, 256, 256, [128, 384]
+        m = sum(tokens)
+        results = {}
+        for recompute, dequant in (
+            (False, False),
+            (True, False),
+            (True, True),
+        ):
+            paddle.seed(2026)
+            np.random.seed(2026)
+            node, experts = self._make_node(
+                num_experts,
+                k,
+                n,
+                dequant_input=dequant,
+                recompute_moe_gate_up=recompute,
+            )
+            paddle.seed(7)
+            x = paddle.randn([m, k], dtype="bfloat16")
+            probs = paddle.rand([m], dtype="float32")
+            out = node.forward(x, probs.unsqueeze(-1), tokens)
+            out_grad = paddle.randn([m, k], dtype="bfloat16")
+            dx, probs_grad = node.backward(out_grad.clone(), probs)
+            results[(recompute, dequant)] = (
+                out.astype("float32"),
+                dx.astype("float32"),
+                probs_grad.astype("float32"),
+                experts.weight2.main_grad.astype("float32"),
+            )
+        base = results[(False, False)]
+        for key in ((True, False), (True, True)):
+            out, dx, pg, dw2 = results[key]
+            self.assertTrue(
+                bool((base[0] == out).all()), f"forward mismatch {key}"
+            )
+            self.assertTrue(bool((base[1] == dx).all()), f"dx mismatch {key}")
+            self.assertTrue(
+                bool((base[2] == pg).all()), f"probs_grad mismatch {key}"
+            )
+            self.assertTrue(bool((base[3] == dw2).all()), f"dw2 mismatch {key}")
+
+    @unittest.skipUnless(
+        fp8_utils.USE_INPLACE_SWIGLU_BWD,
+        "requires the inplace fused_swiglu_probs_bwd op to compare branches",
+    )
+    def test_backward_out_of_place_swiglu_branch(self):
+        """USE_INPLACE_SWIGLU_BWD=False falls back to
+        fused_swiglu_weighted_bwd; grads must match the inplace branch."""
+        num_experts, k, n, tokens = 2, 256, 256, [128, 128]
+        m = sum(tokens)
+        results = {}
+        for inplace in (True, False):
+            paddle.seed(2026)
+            np.random.seed(2026)
+            node, experts = self._make_node(num_experts, k, n)
+            paddle.seed(7)
+            x = paddle.randn([m, k], dtype="bfloat16")
+            probs = paddle.rand([m], dtype="float32")
+            node.forward(x, probs.unsqueeze(-1), tokens)
+            out_grad = paddle.randn([m, k], dtype="bfloat16")
+            orig = fp8_utils.USE_INPLACE_SWIGLU_BWD
+            try:
+                fp8_utils.USE_INPLACE_SWIGLU_BWD = inplace
+                dx, probs_grad = node.backward(out_grad.clone(), probs)
+            finally:
+                fp8_utils.USE_INPLACE_SWIGLU_BWD = orig
+            results[inplace] = (
+                dx.astype("float32").numpy(),
+                probs_grad.astype("float32").numpy(),
+            )
+        cos_dx = _cos(results[True][0], results[False][0])
+        cos_pg = _cos(results[True][1], results[False][1])
+        self.assertGreater(cos_dx, 0.999, f"dx cos={cos_dx}")
+        self.assertGreater(cos_pg, 0.999, f"probs_grad cos={cos_pg}")
+
+    # ---------------- private-method branches ----------------
+
+    def test_fwd_gate_up_rejects_fp8_dispatch_scale(self):
+        """w4a8 does not support fp8-dispatched (pre-quantized) input yet."""
+        node, experts = self._make_node(2, 128, 128)
+        x = paddle.randn([128, 128], dtype="bfloat16")
+        scale = paddle.ones([128, 1], dtype="float32")
+        with self.assertRaises(AssertionError):
+            node._fwd_gate_up_w4a8(x, experts.weight1, scale=scale)
+
+    def test_empty_input_shapes(self):
+        """Zero-token inputs skip the grouped GEMM but keep output shapes."""
+        k, n = 128, 128
+        node, experts = self._make_node(2, k, n)
+        x = paddle.empty([0, k], dtype="bfloat16")
+        o1 = node._fwd_gate_up_w4a8(x, experts.weight1)
+        self.assertEqual(list(o1.shape), [0, 2 * n])
+        probs = paddle.empty([0, 1], dtype="float32")
+        o3 = node._fwd_down_w4a8(o1, probs, experts.weight2)
+        self.assertEqual(list(o3.shape), [0, k])
+        do1 = paddle.empty([0, 2 * n], dtype="bfloat16")
+        dx = node._bwd_gate_up_input_w4a8(do1, experts.weight1)
+        self.assertEqual(list(dx.shape), [0, k])
+        grad = paddle.empty([0, k], dtype="bfloat16")
+        probs_1d = paddle.empty([0], dtype="float32")
+        bdo1, o2_s, probs_grad = node._bwd_down_input_w4a8(
+            experts.weight2, grad, o1, probs_1d
+        )
+        self.assertEqual(list(bdo1.shape), [0, 2 * n])
+        self.assertEqual(list(o2_s.shape), [0, n])
+        self.assertEqual(list(probs_grad.shape), [0])
+
+    def test_fwd_down_preallocated_o3(self):
+        """A caller-provided o3 buffer (auto-subbatch path) must produce the
+        same bits as a freshly allocated one."""
+        num_experts, k, n, tokens = 2, 128, 128, [128, 128]
+        node, experts = self._make_node(num_experts, k, n)
+        m = sum(tokens)
+        node.m_indices = node.gen_m_indices(tokens)
+        o1 = paddle.randn([m, 2 * n], dtype="bfloat16")
+        probs = paddle.rand([m, 1], dtype="float32")
+        out_fresh = node._fwd_down_w4a8(o1.clone(), probs, experts.weight2)
+        buf = paddle.ones([m, k], dtype="bfloat16")
+        out_buf = node._fwd_down_w4a8(
+            o1.clone(), probs, experts.weight2, o3=buf
+        )
+        self.assertTrue(out_buf is buf)
+        self.assertTrue(_bits_equal(out_fresh, out_buf))
+
+    def test_bwd_gate_up_dx_none_matches_preallocated(self):
+        """A caller-provided dx buffer produces the same bits as a fresh one."""
+        num_experts, k, n, tokens = 2, 128, 128, [128, 128]
+        node, experts = self._make_node(num_experts, k, n)
+        m = sum(tokens)
+        node.m_indices = node.gen_m_indices(tokens)
+        do1 = paddle.randn([m, 2 * n], dtype="bfloat16")
+        dx_fresh = node._bwd_gate_up_input_w4a8(do1, experts.weight1)
+        buf = paddle.ones([m, k], dtype="bfloat16")
+        dx_buf = node._bwd_gate_up_input_w4a8(do1, experts.weight1, dx=buf)
+        self.assertTrue(dx_buf is buf)
+        self.assertTrue(_bits_equal(dx_fresh, dx_buf))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
Merged in dev: #1536 
1. 拉新deepgemm，以支持mxfp4/mxfp8 1*32量化，旧的api名字可以，但是kwargs有修改，需要改为位置传参，以兼容旧版逻辑 https://github.com/PFCCLab/DeepGEMM/pull/12
<img width="1014" height="238" alt="image" src="https://github.com/user-attachments/assets/9f29d610-7ed3-4c77-807a-2e3ab0514443" />

2. 升级paddlefleet组网，暂时使用python散算子替代一系列quant融合算子，以添加单测验证逐位对齐

3. 添加use_w4a8 flag，控制是否执行w4a8路径，B卡上添加mlp模块单测精度验证通过，在RL场景下端到端验证前反向均可跑通，k3正常

注：新版deepgemm需要搭配paddle https://github.com/PaddlePaddle/Paddle/pull/79540 否则存在越界风险（单测中m=1发生越界）

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
是