### PR TITLE
[paddlefleet_ops] Add FlashKDA support for kimi-k3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@ packages/paddlefleet_ops/src/paddlefleet_ops/hybrid_ep
 packages/paddlefleet_ops/src/paddlefleet_ops/hybrid_ep_cpp.so
 packages/paddlefleet_ops/src/paddlefleet_ops/flash_mask
 packages/paddlefleet_ops/src/paddlefleet_ops/flash_mla
+packages/paddlefleet_ops/src/paddlefleet_ops/flash_kda
+packages/paddlefleet_ops/src/paddlefleet_ops/flash_kda_C.py
+packages/paddlefleet_ops/src/paddlefleet_ops/flash_kda_C_pd_.so
 packages/paddlefleet_ops/src/paddlefleet_ops/sonicmoe
 packages/paddlefleet_ops/src/paddlefleet_ops/quack
 packages/paddlefleet_ops/src/paddlefleet_ops/cudnn

--- a/.gitmodules
+++ b/.gitmodules
@@ -28,4 +28,3 @@
 [submodule "packages/paddlefleet_ops/third_party/FlashKDA"]
 	path = packages/paddlefleet_ops/third_party/FlashKDA
 	url = https://github.com/PFCCLab/FlashKDA.git
-	branch = paddle

--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,7 @@
 [submodule "packages/paddlefleet_ops/third_party/fast-hadamard-transform"]
 	path = packages/paddlefleet_ops/third_party/fast-hadamard-transform
 	url = https://github.com/PFCCLab/fast-hadamard-transform.git
+[submodule "packages/paddlefleet_ops/third_party/FlashKDA"]
+	path = packages/paddlefleet_ops/third_party/FlashKDA
+	url = https://github.com/PFCCLab/FlashKDA.git
+	branch = paddle

--- a/packages/paddlefleet_ops/build_utils.py
+++ b/packages/paddlefleet_ops/build_utils.py
@@ -202,6 +202,7 @@ def check_submodule_updated():
             "sonic-moe",
             "flash-attention",
             "FlashMLA",
+            "FlashKDA",
             "fast-hadamard-transform",
         ]
         if not all(
@@ -428,6 +429,15 @@ def get_libs():
                     (cuda_major, cuda_minor) <= (12, 8)
                 ),
             },
+        ),
+        EcosystemLibrary(
+            name="FlashKDA",
+            source_rel_path="third_party/FlashKDA",
+            artifacts=[
+                Artifact("flash_kda", "flash_kda"),
+                Artifact("flash_kda_C.py", "flash_kda_C.py"),
+                Artifact("flash_kda_C.so", "flash_kda_C_pd_.so"),
+            ],
         ),
         EcosystemLibrary(
             name="fast-hadamard-transform",

--- a/packages/paddlefleet_ops/build_utils.py
+++ b/packages/paddlefleet_ops/build_utils.py
@@ -438,6 +438,16 @@ def get_libs():
                 Artifact("flash_kda_C.py", "flash_kda_C.py"),
                 Artifact("flash_kda_C.so", "flash_kda_C_pd_.so"),
             ],
+            extra_env={
+                "FLASH_KDA_CUDA_ARCHS": ",".join(
+                    {
+                        "9.0": "90a",
+                        "10.0": "100a",
+                        "10.3": "103a",
+                    }[arch]
+                    for arch in _deep_ep_arch.split(";")
+                ),
+            },
         ),
         EcosystemLibrary(
             name="fast-hadamard-transform",

--- a/packages/paddlefleet_ops/src/paddlefleet_ops/__init__.py
+++ b/packages/paddlefleet_ops/src/paddlefleet_ops/__init__.py
@@ -153,6 +153,11 @@ if paddle.is_compiled_with_cuda():
         "For users: use a GPU with compute capability >= 9.0 (Hopper or Blackwell) to enable."
     )
 
+    FLASH_KDA_HINT = (
+        "For developers: guard imports with `is_flash_kda_available()` and only call `paddlefleet_ops.flash_kda` when the flag branch is enabled.\n"
+        "For users: use a GPU with compute capability >= 9.0 (Hopper or Blackwell) to enable."
+    )
+
     FAST_HADAMARD_TRANSFORM_HINT = "For developers: guard imports with `is_fast_hadamard_transform_available()` and only call `paddlefleet_ops.fast_hadamard_transform` when CUDA is enabled."
 else:
     DEEP_GEMM_HINT = "deep_gemm is not supported on XPU backend."
@@ -161,6 +166,7 @@ else:
     SONIC_MOE_HINT = "sonicmoe is not supported on XPU backend."
     CUDNN_FRONTEND_HINT = "cudnn frontend is not supported on XPU backend."
     FLASH_MLA_HINT = "flash_mla is not supported on XPU backend."
+    FLASH_KDA_HINT = "flash_kda is not supported on XPU backend."
     FAST_HADAMARD_TRANSFORM_HINT = (
         "fast_hadamard_transform is not supported on XPU backend."
     )
@@ -231,6 +237,7 @@ _DEEP_EP_AVAILABLE = False
 _HYBRID_EP_AVAILABLE = False
 _SONIC_MOE_AVAILABLE = False
 _FLASH_MLA_AVAILABLE = False
+_FLASH_KDA_AVAILABLE = False
 _FLASH_MASK_AVAILABLE = False
 _CUDNN_FRONTEND_AVAILABLE = False
 _FAST_HADAMARD_TRANSFORM_AVAILABLE = False
@@ -240,6 +247,7 @@ if paddle.is_compiled_with_cuda():
         _DEEP_GEMM_AVAILABLE = True
         _DEEP_EP_AVAILABLE = True
         _FLASH_MLA_AVAILABLE = True
+        _FLASH_KDA_AVAILABLE = True
         if _cuda_version >= (12, 9):
             _HYBRID_EP_AVAILABLE = True
     if paddle.cuda.get_device_capability()[0] >= 10:
@@ -276,6 +284,10 @@ def is_sonic_moe_available():
 
 def is_flash_mla_available():
     return _FLASH_MLA_AVAILABLE
+
+
+def is_flash_kda_available():
+    return _FLASH_KDA_AVAILABLE
 
 
 def is_flash_mask_available():
@@ -403,6 +415,18 @@ if paddle.is_compiled_with_cuda():
         )
         logger.warning(warning)
         blocked_import_messages["paddlefleet_ops.flash_mla"] = error
+
+    if is_flash_kda_available():
+        paddle.enable_compat(scope={"flash_kda"}, silent=True)
+        _safe_load_ecosystem_lib(
+            "flash_kda", ops_dir, globals(), ["flash_kda_C"]
+        )
+    else:
+        warning, error = _hopper_requirement(
+            "paddlefleet_ops.flash_kda", hint=FLASH_KDA_HINT
+        )
+        logger.warning(warning)
+        blocked_import_messages["paddlefleet_ops.flash_kda"] = error
 
     if is_flash_mask_available():
         _safe_load_ecosystem_lib("flash_mask", ops_dir, globals())

--- a/tests/single_card_tests/custom_ops/test_ops_import.py
+++ b/tests/single_card_tests/custom_ops/test_ops_import.py
@@ -122,5 +122,19 @@ class TestFastHadamardTransformImport(unittest.TestCase):
             )
 
 
+class TestFlashKDAImport(unittest.TestCase):
+    def test_flash_kda_import(self):
+        import paddlefleet_ops
+        from paddlefleet_ops import flash_kda
+
+        self.assertIs(flash_kda, paddlefleet_ops.flash_kda)
+        self.assertTrue(callable(flash_kda.fwd))
+        self.assertTrue(callable(flash_kda.get_workspace_size))
+
+    def test_error_import(self):
+        with self.assertRaises(ImportError):
+            from paddlefleet_ops.flash_kda import xxxx  # noqa: F401
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### PR Category

Operator Mechanism

### PR Types

New features

### Description

- Add the `paddle` branch of [PFCCLab/FlashKDA](https://github.com/PFCCLab/FlashKDA/tree/paddle) as a PaddleFleet Ops submodule.
- Register FlashKDA ecosystem build artifacts and expose `paddlefleet_ops.flash_kda`.
- Gate FlashKDA availability on supported CUDA GPUs and add import contract tests.

#### Validation

- `uv pip install -e packages/paddlefleet_ops -vv --no-build-isolation`
- `python -m pytest -q tests/single_card_tests/custom_ops/test_ops_import.py::TestFlashKDAImport`
- Representative fixed/varlen Paddle outputs matched Torch golden tensors bitwise exactly.
- Full installed-package alignment covered 580/580 cases and 872/872 output tensors bitwise exactly.

### 是否引起精度变化

否
