### PR TITLE
[Execute Infrastructure] Rerun approval checks by head sha

### DIFF
--- a/.github/actions/rerun-workflow/action.yml
+++ b/.github/actions/rerun-workflow/action.yml
@@ -12,7 +12,10 @@ inputs:
     required: true
   PR_ID:
     description: 'Pull Request ID'
-    required: true
+    required: false
+  HEAD_SHA:
+    description: 'Commit SHA to rerun workflow jobs for'
+    required: false
   JOB_NAME:
     description: 'Job name to rerun'
     required: true
@@ -27,4 +30,5 @@ runs:
         OWNER: ${{ inputs.OWNER }}
         REPO: ${{ inputs.REPO }}
         PR_ID: ${{ inputs.PR_ID }}
+        HEAD_SHA: ${{ inputs.HEAD_SHA }}
         JOB_NAME: ${{ inputs.JOB_NAME }}

--- a/.github/actions/rerun-workflow/rerun.sh
+++ b/.github/actions/rerun-workflow/rerun.sh
@@ -14,8 +14,15 @@
 
 set -e
 
-COMMIT_SHA=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-    "https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_ID" | jq -r '.head.sha')
+if [ -n "${HEAD_SHA:-}" ]; then
+    COMMIT_SHA="$HEAD_SHA"
+elif [ -n "${PR_ID:-}" ]; then
+    COMMIT_SHA=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+        "https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_ID" | jq -r '.head.sha')
+else
+    echo "Either HEAD_SHA or PR_ID is required."
+    exit 1
+fi
 
 echo "Commit SHA: $COMMIT_SHA"
 

--- a/.github/workflows/approval-review-signal.yml
+++ b/.github/workflows/approval-review-signal.yml
@@ -1,0 +1,19 @@
+name: Approval Review Signal
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+permissions: {}
+
+jobs:
+  signal:
+    if: ${{ github.event.review.state == 'approved' }}
+    runs-on:
+      group: APPROVAL
+    steps:
+      - name: Record review update
+        run: |
+          echo "Review state: ${{ github.event.review.state }}"
+          echo "Pull request: ${{ github.event.pull_request.number }}"
+          echo "Head SHA: ${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -3,10 +3,18 @@ name: Re-run
 on:
   issue_comment:
     types: [created]
+  workflow_run:
+    workflows: ["Approval Review Signal"]
+    types: [completed]
+
+permissions:
+  actions: write
+  contents: read
+  pull-requests: read
 
 jobs:
   re-run:
-    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/re-run')  && github.event.comment.user.login == github.event.issue.user.login }}
+    if: ${{ github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '/re-run') && github.event.comment.user.login == github.event.issue.user.login }}
     runs-on:
       group: APPROVAL
     steps:
@@ -25,3 +33,54 @@ jobs:
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
           JOB_NAME: 'all-failed'
+
+      - name: Rerun Approval
+        if: ${{ contains(github.event.comment.body, '/re-run approval') }}
+        uses: ./.github/actions/rerun-workflow
+        with:
+          PR_ID: ${{ github.event.issue.number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          JOB_NAME: 'Check approval'
+
+      - name: Rerun Bot Approval Required
+        if: ${{ contains(github.event.comment.body, '/re-run bot-approval-required') }}
+        uses: ./.github/actions/rerun-workflow
+        with:
+          PR_ID: ${{ github.event.issue.number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          JOB_NAME: 'Require review-bot approval'
+
+  rerun-on-approval:
+    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.pull_requests[0].number != null }}
+    runs-on:
+      group: APPROVAL
+    steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Rerun Approval
+        uses: ./.github/actions/rerun-workflow
+        with:
+          PR_ID: ${{ github.event.workflow_run.pull_requests[0].number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          JOB_NAME: 'Check approval'
+
+      - name: Rerun Bot Approval Required
+        uses: ./.github/actions/rerun-workflow
+        with:
+          PR_ID: ${{ github.event.workflow_run.pull_requests[0].number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          JOB_NAME: 'Require review-bot approval'

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   re-run:
-    if: ${{ github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '/re-run') && github.event.comment.user.login == github.event.issue.user.login }}
+    if: ${{ github.event_name == 'issue_comment' && github.event.issue.pull_request && github.event.comment.user.login == github.event.issue.user.login && contains(fromJSON('["/re-run all-failed","/re-run approval","/re-run bot-approval-required"]'), github.event.comment.body) }}
     runs-on:
       group: APPROVAL
     steps:
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Rerun all failed jobs
-        if: ${{ contains(github.event.comment.body, 'all-failed') }}
+        if: ${{ github.event.comment.body == '/re-run all-failed' }}
         uses: ./.github/actions/rerun-workflow
         with:
           PR_ID: ${{ github.event.issue.number }}
@@ -35,7 +35,7 @@ jobs:
           JOB_NAME: 'all-failed'
 
       - name: Rerun Approval
-        if: ${{ contains(github.event.comment.body, '/re-run approval') }}
+        if: ${{ github.event.comment.body == '/re-run approval' }}
         uses: ./.github/actions/rerun-workflow
         with:
           PR_ID: ${{ github.event.issue.number }}
@@ -45,7 +45,7 @@ jobs:
           JOB_NAME: 'Check approval'
 
       - name: Rerun Bot Approval Required
-        if: ${{ contains(github.event.comment.body, '/re-run bot-approval-required') }}
+        if: ${{ github.event.comment.body == '/re-run bot-approval-required' }}
         uses: ./.github/actions/rerun-workflow
         with:
           PR_ID: ${{ github.event.issue.number }}
@@ -55,7 +55,7 @@ jobs:
           JOB_NAME: 'Require review-bot approval'
 
   rerun-on-approval:
-    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.pull_requests[0].number != null }}
+    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_sha != '' }}
     runs-on:
       group: APPROVAL
     steps:
@@ -70,7 +70,7 @@ jobs:
       - name: Rerun Approval
         uses: ./.github/actions/rerun-workflow
         with:
-          PR_ID: ${{ github.event.workflow_run.pull_requests[0].number }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
@@ -79,7 +79,7 @@ jobs:
       - name: Rerun Bot Approval Required
         uses: ./.github/actions/rerun-workflow
         with:
-          PR_ID: ${{ github.event.workflow_run.pull_requests[0].number }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Bug fixes

### Description
Use `head_sha` for approval-triggered reruns and keep manual rerun commands exact-match.

- Add `HEAD_SHA` support to `rerun-workflow`.
- Use `github.event.workflow_run.head_sha` in `rerun.yml` to rerun `Check approval` and `Require review-bot approval`.
- Restrict `/re-run all-failed`, `/re-run approval`, and `/re-run bot-approval-required` to exact comment bodies.
- The privileged rerun path checks out only the default branch.

Validation: `git diff --check`, `bash -n .github/actions/rerun-workflow/rerun.sh`, YAML parse.

### 是否引起精度变化
否
