### PR TITLE
align paddlefleet and sglang in share_expert_fp8

### DIFF
--- a/src/paddlefleet/fusions/fused_bias_swiglu.py
+++ b/src/paddlefleet/fusions/fused_bias_swiglu.py
@@ -110,7 +110,7 @@ def weighted_swiglu_back(g, y, weights):
 
 
 @jit_fuser
-def clamped_swiglu(y, clamp_value):
+def clamped_swiglu(y, clamp_value, high_precision=False):
     """SwiGLU with clamped inputs for numerical stability.
 
     Clamps y1 (gate) to (-inf, clamp_value] and y2 (value) to
@@ -129,11 +129,14 @@ def clamped_swiglu(y, clamp_value):
     y_1 = y_1.clip(max=clamp_value)
     y_2 = y_2.clip(min=-clamp_value, max=clamp_value)
     res = F.silu(y_1) * y_2
-    return res.cast(dtype)
+    if high_precision:
+        return res
+    else:
+        return res.cast(dtype)
 
 
 @jit_fuser
-def clamped_swiglu_back(g, y, clamp_value):
+def clamped_swiglu_back(g, y, clamp_value, high_precision=False):
     """Backward pass for clamped_swiglu.
 
     Gradient is zeroed out where inputs were clamped.
@@ -152,6 +155,8 @@ def clamped_swiglu_back(g, y, clamp_value):
     """
     dtype = y.dtype
     y_fp32 = y.cast(paddle.float32)
+    if high_precision:
+        g = g.cast(paddle.float32)
     y_1, y_2 = paddle.chunk(y_fp32, 2, axis=-1)
     y_1_clamped = y_1.clip(max=clamp_value)
     y_2_clamped = y_2.clip(min=-clamp_value, max=clamp_value)
@@ -167,7 +172,7 @@ def clamped_swiglu_back(g, y, clamp_value):
 
 
 @jit_fuser
-def clamped_bias_swiglu(y, bias, clamp_value):
+def clamped_bias_swiglu(y, bias, clamp_value, high_precision=False):
     """Clamped SwiGLU with bias addition.
 
     Adds bias to the input tensor, then applies clamped SwiGLU activation.
@@ -183,11 +188,11 @@ def clamped_bias_swiglu(y, bias, clamp_value):
         paddle.Tensor: clamped_swiglu(y + bias), same dtype as y.
     """
     y = y + bias
-    return clamped_swiglu(y, clamp_value)
+    return clamped_swiglu(y, clamp_value, high_precision)
 
 
 @jit_fuser
-def clamped_bias_swiglu_back(g, y, bias, clamp_value):
+def clamped_bias_swiglu_back(g, y, bias, clamp_value, high_precision=False):
     """Backward pass for clamped_bias_swiglu.
 
     Adds bias to the input tensor and delegates to clamped_swiglu_back
@@ -203,7 +208,7 @@ def clamped_bias_swiglu_back(g, y, bias, clamp_value):
         paddle.Tensor: Gradient w.r.t. (y + bias), same dtype as y.
     """
     y = y + bias
-    return clamped_swiglu_back(g, y, clamp_value)
+    return clamped_swiglu_back(g, y, clamp_value, high_precision)
 
 
 @jit_fuser
@@ -261,7 +266,13 @@ class BiasSwiGLUFunction(paddle.autograd.PyLayer):
     @staticmethod
     @nvtx_decorator()
     def forward(
-        ctx, input, bias, fp8_input_store, cpu_offload_input, clamp_value=None
+        ctx,
+        input,
+        bias,
+        fp8_input_store,
+        cpu_offload_input,
+        clamp_value=None,
+        high_precision=False,
     ):
         """Forward pass of biased SwiGLU activation.
 
@@ -288,8 +299,9 @@ class BiasSwiGLUFunction(paddle.autograd.PyLayer):
         ctx.ori_input_dtype = input.dtype
         ctx.fp8_input_store = fp8_input_store
         ctx.clamp_value = clamp_value
+        ctx.high_precision = high_precision
         if clamp_value is not None and clamp_value > 0:
-            return clamped_bias_swiglu(input, bias, clamp_value)
+            return clamped_bias_swiglu(input, bias, clamp_value, high_precision)
         return bias_swiglu(input, bias)
 
     @staticmethod
@@ -323,7 +335,12 @@ class SwiGLUFunction(paddle.autograd.PyLayer):
     @staticmethod
     @nvtx_decorator()
     def forward(
-        ctx, input, fp8_input_store, cpu_offload_input, clamp_value=None
+        ctx,
+        input,
+        fp8_input_store,
+        cpu_offload_input,
+        clamp_value=None,
+        high_precision=False,
     ):
         """Forward pass of SwiGLU activation.
 
@@ -348,8 +365,9 @@ class SwiGLUFunction(paddle.autograd.PyLayer):
         ctx.ori_input_dtype = input.dtype
         ctx.fp8_input_store = fp8_input_store
         ctx.clamp_value = clamp_value
+        ctx.high_precision = high_precision
         if clamp_value is not None and clamp_value > 0:
-            return clamped_swiglu(input, clamp_value)
+            return clamped_swiglu(input, clamp_value, high_precision)
         return swiglu(input)
 
     @staticmethod
@@ -365,9 +383,12 @@ class SwiGLUFunction(paddle.autograd.PyLayer):
             paddle.Tensor: Gradient with respect to the input tensor.
         """
         input = ctx.saved_tensor()[0]
+        high_precision = ctx.high_precision
         input = input.to(ctx.ori_input_dtype) if ctx.fp8_input_store else input
         if ctx.clamp_value is not None and ctx.clamp_value > 0:
-            tmp = clamped_swiglu_back(grad_output, input, ctx.clamp_value)
+            tmp = clamped_swiglu_back(
+                grad_output, input, ctx.clamp_value, high_precision
+            )
         else:
             tmp = swiglu_back(grad_output, input)
         return tmp
@@ -409,6 +430,7 @@ def bias_swiglu_impl(
     fp8_input_store=False,
     cpu_offload_input=False,
     clamp_value=None,
+    high_precision=False,
 ):
     """Implementation of biased SwiGLU that handles different input shapes.
 
@@ -438,11 +460,20 @@ def bias_swiglu_impl(
     input = input.view(-1, ori_shape[-1])
     if bias is not None:
         output = BiasSwiGLUFunction.apply(
-            input, bias, fp8_input_store, cpu_offload_input, clamp_value
+            input,
+            bias,
+            fp8_input_store,
+            cpu_offload_input,
+            clamp_value,
+            high_precision,
         )
     else:
         output = SwiGLUFunction.apply(
-            input, fp8_input_store, cpu_offload_input, clamp_value
+            input,
+            fp8_input_store,
+            cpu_offload_input,
+            clamp_value,
+            high_precision,
         )
 
     return (

--- a/src/paddlefleet/tensor_parallel/layers.py
+++ b/src/paddlefleet/tensor_parallel/layers.py
@@ -741,6 +741,7 @@ class LinearWithGradAccumulationAndAsyncCommunication(paddle.autograd.Function):
         use_pow2_scale=False,
         use_ue8m0=False,
         save_original_input=False,
+        input_in_high_precision=False,
     ):
         """Forward."""
         if gradient_accumulation_fusion and hasattr(weight, "main_grad"):
@@ -797,7 +798,14 @@ class LinearWithGradAccumulationAndAsyncCommunication(paddle.autograd.Function):
 
         save_list = []
         if not skip_bf16_input_save:
-            save_list.append(input._new_shared_tensor())
+            input_for_bw = input
+            if input_in_high_precision:
+                # Cast fp32 input back to weight dtype (bf16) for backward pass,
+                # so that grad_input stays in bf16.
+                # Only applies to shared_expert's down_proj when both
+                # shared_expert_fp8=True and silu_quant_high_precision=True.
+                input_for_bw = input.cast(weight.dtype)
+            save_list.append(input_for_bw._new_shared_tensor())
         save_list.append(weight)
         if fp8 and fp8_meta is not None:
             (
@@ -1113,6 +1121,7 @@ def linear_with_grad_accumulation_and_async_allreduce(
     use_pow2_scale: bool = False,
     use_ue8m0: bool = False,
     save_original_input: bool = False,
+    input_in_high_precision: bool = False,
 ) -> paddle.Tensor:
     """Linear layer execution with asynchronous communication and
     gradient accumulation fusion in backprop.
@@ -1206,6 +1215,7 @@ def linear_with_grad_accumulation_and_async_allreduce(
         use_pow2_scale,
         use_ue8m0,
         save_original_input,
+        input_in_high_precision,
     ]
 
     if not linear_with_grad_accumulation_and_async_allreduce.warned:
@@ -2354,6 +2364,9 @@ class RowParallelLinear(paddle.nn.Layer):
             use_pow2_scale=self.use_pow2_scale,
             use_ue8m0=self.use_ue8m0,
             save_original_input=self.save_original_input,
+            input_in_high_precision=getattr(
+                self, "input_in_high_precision", False
+            ),
         )
 
         # All-reduce across all the partitions.

--- a/src/paddlefleet/transformer/mlp.py
+++ b/src/paddlefleet/transformer/mlp.py
@@ -273,6 +273,9 @@ class MLP(FleetLayer):
                         ),
                         cpu_offload_input=False,
                         clamp_value=self.config.activation_func_clamp_value,
+                        high_precision=getattr(
+                            self, "silu_return_high_precision", False
+                        ),
                     )
                 else:
                     raise ValueError("Only support fusion of gelu and swiglu")

--- a/src/paddlefleet/transformer/moe/moe_shared_expert.py
+++ b/src/paddlefleet/transformer/moe/moe_shared_expert.py
@@ -19,6 +19,7 @@ import paddle
 import paddle.nn.functional as F
 
 from paddlefleet.transformer.mlp import MLP, MLPSublayersSpec
+from paddlefleet.transformer.moe.fp8_utils import quant_blockwize
 from paddlefleet.transformer.transformer_config import TransformerConfig
 
 
@@ -64,6 +65,18 @@ class StandardMLPSharedExpert(MLP):
             config.init_method(self.gate_weight)
         else:
             self.gate_weight = None
+
+        if self.config.silu_quant_high_precision_in_shared_expert:
+            # SiLU outputs fp32 for higher precision; configure down_proj to
+            # accept fp32 input and quantize it to fp8 before matmul.
+            self.silu_return_high_precision = True
+            self.down_proj.inp_quant_func = lambda x: quant_blockwize(
+                x,
+                quant_method="1x128",
+                quant_dtype="fp8",
+                using_ue8m0_scale=True,
+            )
+            self.down_proj.input_in_high_precision = True
 
     def forward(self, hidden_states: paddle.Tensor) -> paddle.Tensor:
         output, output_bias = super().forward(hidden_states)

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -307,6 +307,9 @@ class TransformerConfig(ModelParallelConfig):
     """Offset term in the GLU activation function: activation_func(x[0]) * (x[1] + offset). Only
     used when gated_linear_unit is True"""
 
+    silu_quant_high_precision_in_shared_expert: bool = False
+    """If True, use high precision computation for SiLU quantization in share expert"""
+
     multimodal_embedding: bool = False
     """Whether to use multimodal embedding."""
 
@@ -1192,6 +1195,11 @@ class TransformerConfig(ModelParallelConfig):
                 assert self.variable_seq_lengths, (
                     "enable_mtp_magic_send with vpp requires variable_seq_lengths=True"
                 )
+
+        if self.silu_quant_high_precision_in_shared_expert:
+            assert self.fp8, (
+                "silu_quant_high_precision_in_shared_expert requires fp8 to be True."
+            )
 
         if self.intermediate_size is None:
             self.intermediate_size = 4 * self.hidden_size

--- a/tests/single_card_tests/ai_edited_test/moe/test_silu_quant_high_precision_shared_expert.py
+++ b/tests/single_card_tests/ai_edited_test/moe/test_silu_quant_high_precision_shared_expert.py
@@ -1,0 +1,167 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+
+sys.path.insert(
+    0,
+    os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        "..",
+        "..",
+        "..",
+        "..",
+        "src",
+    ),
+)
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import paddle
+
+from paddlefleet.transformer.moe.fp8_utils import quant_blockwize
+from paddlefleet.transformer.transformer_config import TransformerConfig
+
+
+def _make_config(silu_quant_high_precision=False, **overrides):
+    """Create a TransformerConfig suitable for SharedExpert testing."""
+    defaults = {
+        "hidden_size": 128,
+        "num_attention_heads": 2,
+        "intermediate_size": 256,
+        "gated_linear_unit": True,
+        "sequence_parallel": False,
+        "tensor_model_parallel_size": 1,
+        "fp8": "e4m3",
+        "fp8_wgrad": True,
+        "use_bias": False,
+        "use_cpu_initialization": True,
+        "moe_shared_expert_gate": False,
+        "silu_quant_high_precision_in_shared_expert": silu_quant_high_precision,
+    }
+    defaults.update(overrides)
+    return TransformerConfig(**defaults)
+
+
+class TestSiluQuantHighPrecisionInSharedExpert(unittest.TestCase):
+    """Test silu_quant_high_precision_in_shared_expert=True path in StandardMLPSharedExpert."""
+
+    def _build_expert(self, config):
+        """Build StandardMLPSharedExpert with mocked parallel state."""
+        from paddlefleet.tensor_parallel import (
+            ColumnParallelLinear,
+            RowParallelLinear,
+        )
+        from paddlefleet.transformer.mlp import MLPSublayersSpec
+        from paddlefleet.transformer.moe.moe_shared_expert import (
+            StandardMLPSharedExpert,
+        )
+
+        mlp_spec = MLPSublayersSpec(
+            up_gate_proj=ColumnParallelLinear,
+            hidden_act=None,
+            down_proj=RowParallelLinear,
+        )
+        return StandardMLPSharedExpert(
+            config=config,
+            moe_intermediate_size=config.intermediate_size,
+            is_expert=False,
+            mlp_spec=mlp_spec,
+        )
+
+    @patch("paddlefleet.tensor_parallel.random.get_cuda_rng_tracker")
+    def test_enabled_sets_silu_return_high_precision(self, mock_rng_tracker):
+        """When enabled, silu_return_high_precision should be True."""
+        mock_rng_tracker.return_value.fork = MagicMock(
+            return_value=_noop_context()
+        )
+        config = _make_config(silu_quant_high_precision=True)
+        expert = self._build_expert(config)
+        self.assertTrue(expert.silu_return_high_precision)
+
+    @patch("paddlefleet.tensor_parallel.random.get_cuda_rng_tracker")
+    def test_enabled_sets_inp_quant_func_on_down_proj(self, mock_rng_tracker):
+        """When enabled, down_proj.inp_quant_func should be a callable."""
+        mock_rng_tracker.return_value.fork = MagicMock(
+            return_value=_noop_context()
+        )
+        config = _make_config(silu_quant_high_precision=True)
+        expert = self._build_expert(config)
+        self.assertTrue(callable(expert.down_proj.inp_quant_func))
+
+    @patch("paddlefleet.tensor_parallel.random.get_cuda_rng_tracker")
+    def test_enabled_sets_input_in_high_precision_on_down_proj(
+        self, mock_rng_tracker
+    ):
+        """When enabled, down_proj.input_in_high_precision should be True."""
+        mock_rng_tracker.return_value.fork = MagicMock(
+            return_value=_noop_context()
+        )
+        config = _make_config(silu_quant_high_precision=True)
+        expert = self._build_expert(config)
+        self.assertTrue(expert.down_proj.input_in_high_precision)
+
+    @patch("paddlefleet.tensor_parallel.random.get_cuda_rng_tracker")
+    def test_disabled_does_not_set_silu_return_high_precision(
+        self, mock_rng_tracker
+    ):
+        """When disabled, silu_return_high_precision should not be set."""
+        mock_rng_tracker.return_value.fork = MagicMock(
+            return_value=_noop_context()
+        )
+        config = _make_config(silu_quant_high_precision=False)
+        expert = self._build_expert(config)
+        self.assertFalse(getattr(expert, "silu_return_high_precision", False))
+
+    @patch("paddlefleet.tensor_parallel.random.get_cuda_rng_tracker")
+    def test_disabled_does_not_set_inp_quant_func(self, mock_rng_tracker):
+        """When disabled, down_proj should not have inp_quant_func."""
+        mock_rng_tracker.return_value.fork = MagicMock(
+            return_value=_noop_context()
+        )
+        config = _make_config(silu_quant_high_precision=False)
+        expert = self._build_expert(config)
+        self.assertIsNone(getattr(expert.down_proj, "inp_quant_func", None))
+
+    def test_quant_blockwize_fp8_output(self):
+        """quant_blockwize should produce fp8 quantized output with correct shape."""
+        x = paddle.randn([2, 128], dtype="float32")
+        q, sf = quant_blockwize(
+            x, quant_method="1x128", quant_dtype="fp8", using_ue8m0_scale=True
+        )
+
+        self.assertEqual(q.dtype, paddle.float8_e4m3fn)
+        self.assertEqual(q.shape, [2, 128])
+        self.assertEqual(sf.dtype, paddle.float32)
+        # With block size 128, scale factor should be [2, 1]
+        self.assertEqual(sf.shape, [2, 1])
+
+    def test_config_validation_requires_fp8(self):
+        """silu_quant_high_precision_in_shared_expert requires fp8 to be set."""
+        with self.assertRaises(AssertionError):
+            _make_config(silu_quant_high_precision=True, fp8=None)
+
+
+import contextlib
+
+
+@contextlib.contextmanager
+def _noop_context(*args, **kwargs):
+    yield
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
config新增silu_quant_high_precision_in_shared_expert字段，用于支持在share_expert中的silu激活函数输出为fp32，从而令PaddleFleet输出与推理前向逐位对齐。

```
# share_expert
gate_up_proj
⬇️
silu (return bf16 -> fp8)
⬇️
down_proj 
```

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
是