### PR TITLE
[hysparse] Add the full-causal MQA layer via csa_compress_ratios=-1

### DIFF
--- a/src/paddlefleet/cudnn_ops/attn/csa_sparse_attn_fwd_cudnn.py
+++ b/src/paddlefleet/cudnn_ops/attn/csa_sparse_attn_fwd_cudnn.py
@@ -47,7 +47,14 @@ def _get_topk_alignment() -> int:
 
 
 def flash_mla_sparse_attn(
-    q, kv, attn_sink, topk_idxs, sm_scale=None, indexer_topk: int = 0, d_v=None
+    q,
+    kv,
+    attn_sink,
+    topk_idxs,
+    sm_scale=None,
+    indexer_topk: int = 0,
+    d_v=None,
+    topk_length=None,
 ):
     if _flash_mla_sparse_fwd is None:
         raise RuntimeError("flash_mla is not available")
@@ -63,6 +70,12 @@ def flash_mla_sparse_attn(
     q_flat = q.reshape([b * sq, h, d])
     kv_flat = kv.reshape([b * skv, d])
     global_idxs = _local_to_global_flat(topk_idxs, skv)
+    # [b, sq] -> [b * sq]: one valid-prefix length per flattened query row.
+    topk_length_flat = (
+        None
+        if topk_length is None
+        else topk_length.reshape([b * sq]).cast("int32")
+    )
 
     topk_align = _get_topk_alignment()
     topk_padded = (topk + topk_align - 1) // topk_align * topk_align
@@ -76,7 +89,7 @@ def flash_mla_sparse_attn(
         sm_scale,
         d_v=d_v,
         attn_sink=attn_sink,
-        topk_length=None,
+        topk_length=topk_length_flat,
         indexer_topk=indexer_topk,
     )
     if indexer_topk > 0:

--- a/src/paddlefleet/fusions/csa_sparse_attn.py
+++ b/src/paddlefleet/fusions/csa_sparse_attn.py
@@ -31,6 +31,7 @@ def unfused_compressed_sparse_attn(
     attn_sink: Tensor,
     topk_indices: Tensor,
     softmax_scale: float,
+    topk_length: Tensor | None = None,
 ) -> Tensor:
     """Sparse attention with MQA and learnable attention sink.
 
@@ -40,6 +41,8 @@ def unfused_compressed_sparse_attn(
         attn_sink: [np] per-head learnable bias (attention sink)
         topk_indices: [b, sq, topk] indices into kv_full dim=1 (-1 = invalid)
         softmax_scale: attention scale factor
+        topk_length: optional [b, sq] int32 valid prefix length; slots at
+            ``>= topk_length[b, i]`` are ignored for query row ``i``.
 
     Returns:
         output: [b, sq, np * hn]
@@ -69,7 +72,13 @@ def unfused_compressed_sparse_attn(
             paddle.einsum("bnsh,bskh->bnsk", q, kv_g) * softmax_scale
         )  # [b, np, sq, topk]
         # Mask invalid positions (topk_indices < 0) with -inf
-        invalid_mask = (topk_indices < 0).unsqueeze(1)  # [b, 1, sq, topk]
+        invalid = topk_indices < 0  # [b, sq, topk]
+        if topk_length is not None:
+            slots = paddle.arange(topk, dtype="int32").reshape([1, 1, topk])
+            invalid = invalid | (
+                slots >= topk_length.reshape([b, sq, 1]).cast("int32")
+            )
+        invalid_mask = invalid.unsqueeze(1)  # [b, 1, sq, topk]
         scores = scores.masked_fill(invalid_mask, float("-inf"))
 
         # Softmax with attention sink
@@ -120,7 +129,14 @@ def _csa_compute_topk_length(topk_idxs_flat: Tensor) -> Tensor:
 class CSASparseAttention(paddle.autograd.PyLayer):
     @staticmethod
     def forward(
-        ctx, query, kv_full, attn_sink, topk_idxs, softmax_scale, backend
+        ctx,
+        query,
+        kv_full,
+        attn_sink,
+        topk_idxs,
+        softmax_scale,
+        backend,
+        topk_length=None,
     ):
         from paddlefleet.fusions.csa_sparse_attn_utils import prepare_inputs
 
@@ -129,6 +145,12 @@ class CSASparseAttention(paddle.autograd.PyLayer):
         ctx.softmax_scale = float(softmax_scale)
         ctx.attn_sink_dtype = attn_sink.dtype
         ctx.backend = backend
+        # ``topk_length`` is a forward-only early-stop hint: correctness comes
+        # from the ``-1`` padding in ``topk_idxs``, which backward already turns
+        # into its own bound via ``_csa_compute_topk_length``. Only remember
+        # whether it was passed, so backward can return the matching number of
+        # placeholder gradients.
+        ctx.has_topk_length = topk_length is not None
 
         query, kv_full, attn_sink, topk_idxs = prepare_inputs(
             query,
@@ -147,8 +169,14 @@ class CSASparseAttention(paddle.autograd.PyLayer):
                 attn_sink,
                 topk_idxs,
                 sm_scale=ctx.softmax_scale,
+                topk_length=topk_length,
             )
         else:
+            if topk_length is not None:
+                raise NotImplementedError(
+                    "topk_length is only supported by the 'cudnn' and "
+                    f"'unfused' backends, got backend={backend!r}."
+                )
             from paddlefleet.tilelang_ops.attn.sparse_mqa import sparse_attn
 
             output, lse = sparse_attn(
@@ -219,16 +247,31 @@ class CSASparseAttention(paddle.autograd.PyLayer):
                 ctx.attn_sink_dtype
             )
 
-        return (dq, dkv, d_attn_sink, None)
+        grads = (dq, dkv, d_attn_sink, None)
+        if ctx.has_topk_length:
+            # ``topk_length`` was passed as an extra (non-differentiable) tensor
+            # input, so an extra placeholder gradient is required.
+            grads = (*grads, None)
+        return grads
 
 
 def csa_sparse_attn(
-    query, kv_full, attn_sink, topk_idxs, softmax_scale, backend="tilelang"
+    query,
+    kv_full,
+    attn_sink,
+    topk_idxs,
+    softmax_scale,
+    backend="tilelang",
+    topk_length=None,
 ):
     """Unified CSA sparse attention entry point.
 
     Args:
         backend: one of {"unfused", "tilelang", "cudnn"}.
+        topk_length: optional ``[b, sq]`` int32 valid prefix length per query
+            row. Only the "cudnn" and "unfused" backends support it; it lets
+            the kernel stop early instead of walking all ``topk`` slots, which
+            is what makes the full-causal MQA layers affordable.
     """
     if backend == "unfused":
         return unfused_compressed_sparse_attn(
@@ -237,6 +280,7 @@ def csa_sparse_attn(
             attn_sink,
             topk_idxs,
             softmax_scale,
+            topk_length=topk_length,
         )
     if backend not in ("tilelang", "cudnn"):
         raise ValueError(
@@ -250,4 +294,5 @@ def csa_sparse_attn(
         topk_idxs,
         softmax_scale,
         backend,
+        topk_length,
     )

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -2021,7 +2021,8 @@ class CompressedSparseAttention(FleetLayer):
                     "with csa_sparse_attn_backend='unfused' materialises a "
                     "dense [b, sq, sq, head_dim] gather and only fits tiny "
                     "sequences (~68 TB at sq=8192). Use 'cudnn' for training; "
-                    "'unfused' is a reference path for tests."
+                    "'unfused' is a reference path for tests.",
+                    stacklevel=2,
                 )
         self.window_size = config.csa_window_size
         self.v_head_dim = config.v_head_dim

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -26,6 +26,7 @@ Components:
 from __future__ import annotations
 
 import os
+import warnings
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -67,6 +68,11 @@ from paddlefleet.transformer.cp_utils import (
     get_window_topk_idxs_cp,
     map_compressed_topk_to_kv_full_cp,
 )
+
+# Sentinel value in ``config.csa_compress_ratios`` selecting the full-causal
+# MQA layer: no compressor, no indexer and no sliding window, every query
+# attends to all preceding original KV positions of its own document.
+CSA_MQA_RATIO = -1
 
 
 def _normalize_csa_docmask_args(
@@ -158,6 +164,42 @@ def _build_window_topk_idxs_from_doc_bounds(
     )
     result = paddle.where(invalid, paddle.full_like(indices, -1), indices)
     return result.unsqueeze(0).expand([batch_size, -1, -1])
+
+
+def _build_mqa_causal_topk_idxs_from_doc_bounds(
+    batch_size: int,
+    seqlen: int,
+    doc_start_per_pos: Tensor,
+    is_valid: Tensor,
+) -> tuple[Tensor, Tensor]:
+    """Build full-causal (per-document) indices + valid lengths for MQA layers.
+
+    Row ``i`` holds ``[doc_start[i], ..., i]`` followed by ``-1`` padding, so a
+    packed multi-document batch is bit-identical to running each document on
+    its own. Padding rows (``is_valid == False``) get a single ``-1`` slot,
+    which degenerates to the attention-sink-only output used by the window
+    path.
+
+    Returns:
+        (topk_idxs, topk_length) with shapes ``[batch_size, seqlen, seqlen]``
+        int32 and ``[batch_size, seqlen]`` int32.
+    """
+    positions = paddle.arange(seqlen, dtype="int64")
+    offsets = paddle.arange(seqlen, dtype="int64").unsqueeze(0)
+    indices = doc_start_per_pos.unsqueeze(1) + offsets
+    invalid = (indices > positions.unsqueeze(1)) | (~is_valid).unsqueeze(
+        1
+    ).expand_as(indices)
+    indices = paddle.where(
+        invalid, paddle.full_like(indices, -1), indices
+    ).cast("int32")
+    lengths = (positions - doc_start_per_pos + 1).cast("int32")
+    # Padding rows keep a single masked slot instead of length 0.
+    lengths = paddle.where(is_valid, lengths, paddle.ones_like(lengths))
+    return (
+        indices.unsqueeze(0).expand([batch_size, -1, -1]),
+        lengths.unsqueeze(0).expand([batch_size, -1]),
+    )
 
 
 def _build_compress_topk_idxs_from_valid_range(
@@ -398,6 +440,7 @@ class CSADocMaskMetadata:
     _compress_offset: int | None = None
     _compressed_causal_mask: Tensor | None = None
     _is_first_compressed_group: Tensor | None = None
+    _mqa_causal_topk: tuple[Tensor, Tensor] | None = None
 
     @classmethod
     def build(
@@ -620,6 +663,40 @@ class CSADocMaskMetadata:
             )
         return self._compressed_causal_mask
 
+    def get_mqa_causal_topk_idxs(self) -> tuple[Tensor, Tensor]:
+        """Return ``([b, seqlen, seqlen], [b, seqlen])`` MQA causal indices.
+
+        Indices reset at each document boundary and ``topk_length`` gives the
+        per-row valid prefix so the kernel can stop early.
+
+        Cached on this metadata object. NOTE: the current DSv4 forward builds a
+        fresh ``CSADocMaskMetadata`` per layer (see
+        ``dsv4_hybrid_attention.py``), so today this cache is effectively
+        per-layer and never hits across layers. Reusing one metadata instance
+        across the MQA layers of a forward would make this build once, but that
+        optimisation requires keying the cache on ``(seqlen, doc layout)``
+        first: the table is a function of build-time document boundaries, and a
+        table built for one layout is silently wrong for another (grad
+        accumulation, ``variable_seq_lengths`` and ``document_mask_prob_text``
+        all produce differing layouts across microbatches).
+        """
+        if self._mqa_causal_topk is None:
+            # ``build`` only derives ``is_valid`` for the indexer path
+            # (``ratio > 1 and not dense_mode``); an MQA layer builds its
+            # metadata with ratio=1, so recover it from the always-present
+            # per-position document bounds using the same definition as
+            # ``_derive_csa_doc_boundaries``.
+            is_valid = self.is_valid
+            if is_valid is None:
+                is_valid = self.pos_in_doc < self.doc_len_per_pos
+            self._mqa_causal_topk = _build_mqa_causal_topk_idxs_from_doc_bounds(
+                self.batch_size,
+                self.seqlen,
+                self.doc_start_per_pos,
+                is_valid,
+            )
+        return self._mqa_causal_topk
+
     def get_is_first_compressed_group(self) -> Tensor:
         """Return ``[actual_n_compressed]`` bool flags marking each document's
         first compressed group (used by overlap transforms to avoid reusing
@@ -717,6 +794,41 @@ def get_window_topk_idxs(
         1, batch_size, seqlen, startend_row_indices, seqlen
     )
     return docmask_meta.get_window_topk_idxs(window_size)
+
+
+def get_mqa_causal_topk_idxs(
+    batch_size: int,
+    seqlen: int,
+    startend_row_indices: Tensor | None = None,
+    docmask_meta: CSADocMaskMetadata | None = None,
+) -> tuple[Tensor, Tensor]:
+    """Get full-causal MQA indices + valid lengths.
+
+    Returns ``([b, seqlen, seqlen] int32, [b, seqlen] int32)``. With document
+    boundaries the causal range restarts at each document start, which makes a
+    packed batch equivalent to attending within each document separately.
+    """
+    if docmask_meta is not None:
+        return docmask_meta.get_mqa_causal_topk_idxs()
+
+    if startend_row_indices is None:
+        positions = paddle.arange(seqlen, dtype="int64")
+        matrix = positions.unsqueeze(0).expand([seqlen, -1])
+        matrix = paddle.where(
+            matrix > positions.unsqueeze(1),
+            paddle.full_like(matrix, -1),
+            matrix,
+        ).cast("int32")
+        lengths = (positions + 1).cast("int32")
+        return (
+            matrix.unsqueeze(0).expand([batch_size, -1, -1]),
+            lengths.unsqueeze(0).expand([batch_size, -1]),
+        )
+
+    docmask_meta = CSADocMaskMetadata.build(
+        1, batch_size, seqlen, startend_row_indices, seqlen
+    )
+    return docmask_meta.get_mqa_causal_topk_idxs()
 
 
 def get_valid_range(
@@ -1850,6 +1962,7 @@ class CompressedSparseAttention(FleetLayer):
     """Core attention combining sliding window + compressed KV attention.
 
     Conditionally builds Compressor and CSAIndexer based on compress_ratio:
+      - ratio=-1 (``CSA_MQA_RATIO``): full-causal MQA, no window/compressor
       - ratio=0: window-only attention
       - ratio=4: window + 4x compressed + learned CSAIndexer
       - ratio=128: window + 128x compressed, attend to all compressed positions
@@ -1892,6 +2005,24 @@ class CompressedSparseAttention(FleetLayer):
             )
         self.tp_group = None
         self.compress_ratio = compress_ratio
+        self.is_mqa_layer = compress_ratio == CSA_MQA_RATIO
+        if self.is_mqa_layer:
+            backend = getattr(config, "csa_sparse_attn_backend", "tilelang")
+            if backend not in ("cudnn", "unfused"):
+                raise NotImplementedError(
+                    f"csa_compress_ratios={CSA_MQA_RATIO} (full-causal MQA) "
+                    "requires csa_sparse_attn_backend='cudnn' (the tilelang "
+                    "kernel has no topk_length support), got "
+                    f"{backend!r}."
+                )
+            if backend == "unfused":
+                warnings.warn(
+                    f"csa_compress_ratios={CSA_MQA_RATIO} (full-causal MQA) "
+                    "with csa_sparse_attn_backend='unfused' materialises a "
+                    "dense [b, sq, sq, head_dim] gather and only fits tiny "
+                    "sequences (~68 TB at sq=8192). Use 'cudnn' for training; "
+                    "'unfused' is a reference path for tests."
+                )
         self.window_size = config.csa_window_size
         self.v_head_dim = config.v_head_dim
         self.n_local_heads = config.num_attention_heads
@@ -2273,6 +2404,12 @@ class CompressedSparseAttention(FleetLayer):
             global_valid_count = None
 
         if self.cp_enabled:
+            if self.is_mqa_layer:
+                raise NotImplementedError(
+                    f"csa_compress_ratios={CSA_MQA_RATIO} (full-causal MQA) "
+                    "does not support context parallelism yet, got "
+                    f"cp={self.cp_size}."
+                )
             return self._forward_cp(
                 query,
                 key,
@@ -2282,6 +2419,9 @@ class CompressedSparseAttention(FleetLayer):
                 global_valid_count=global_valid_count,
                 docmask_meta=docmask_meta,
             )
+
+        if self.is_mqa_layer:
+            return self._forward_mqa(query, key, docmask_meta=docmask_meta)
 
         if docmask_meta is not None and self.compress_ratio > 1:
             actual_n_compressed = docmask_meta.actual_n_compressed
@@ -2387,6 +2527,36 @@ class CompressedSparseAttention(FleetLayer):
             output = DSAIndexerLossAutoScaler.apply(output, indexer_loss)
 
         return output
+
+    def _forward_mqa(
+        self,
+        query: Tensor,
+        key: Tensor,
+        docmask_meta: CSADocMaskMetadata | None = None,
+    ) -> Tensor:
+        """Full-causal MQA forward (``compress_ratio == CSA_MQA_RATIO``).
+
+        No sliding window, no compressor and no indexer: every query attends to
+        all preceding original KV positions inside its own document. The CSA
+        sparse kernel is reused with a dense causal index table plus
+        ``topk_length`` so it stops at the diagonal instead of scanning all
+        ``sq`` slots.
+        """
+        b, sq, _, _ = query.shape
+        kv_full = key.squeeze(2)  # [b, sq, v_head_dim]
+        topk_idxs, topk_length = get_mqa_causal_topk_idxs(
+            b,
+            sq,
+            docmask_meta=docmask_meta,
+        )
+        return self.compressed_sparse_attn(
+            query,
+            kv_full,
+            self.attn_sink,
+            topk_idxs,
+            self.softmax_scale,
+            topk_length=topk_length,
+        )
 
     def _forward_cp(
         self,
@@ -2786,6 +2956,7 @@ class CompressedSparseAttention(FleetLayer):
         attn_sink: Tensor,
         topk_idxs: Tensor,
         softmax_scale: float,
+        topk_length: Tensor | None = None,
     ):
         from paddlefleet.fusions.csa_sparse_attn import csa_sparse_attn
 
@@ -2804,4 +2975,5 @@ class CompressedSparseAttention(FleetLayer):
             topk_idxs,
             softmax_scale,
             backend=sparse_attn_backend,
+            topk_length=topk_length,
         )

--- a/src/paddlefleet/transformer/dsv4_hybrid_attention.py
+++ b/src/paddlefleet/transformer/dsv4_hybrid_attention.py
@@ -590,7 +590,12 @@ class DSv4HybridAttention(Attention):
         # Per-layer RoPE (potentially different base for compressed layers)
         rope_base = getattr(config, "rotary_base", 10000)
         if compress_ratio > 1:
-            rope_base = config.csa_compress_rotary_base
+            # Every shipped model_config.json writes csa_compress_rotary_base as
+            # a *string* ("160000.0"). pretrain.py coerces numeric strings
+            # before building the config, but any path that calls from_config
+            # directly (unit tests, offline inference, tooling) would reach
+            # YarnRotaryEmbedding's math.log() with a str and raise TypeError.
+            rope_base = float(config.csa_compress_rotary_base)
 
         use_compressed_yarn = compress_ratio > 1
         if not use_compressed_yarn:

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -1395,10 +1395,18 @@ class TransformerConfig(ModelParallelConfig):
                     f"must equal num_hidden_layers ({self.num_hidden_layers + mtp_num_layers})."
                 )
             for i, r in enumerate(self.csa_compress_ratios):
-                if not (isinstance(r, int) and (r == 0 or 2 <= r <= 128)):
+                # Accept python int and numpy integer scalars (a ratios list
+                # loaded from npy/np.load yields np.int64, which would otherwise
+                # be rejected); reject bool / np.bool_ so True does not sneak
+                # through as 1, and reject floats.
+                is_integral = hasattr(r, "__index__") and type(
+                    r
+                ).__name__ not in ("bool", "bool_")
+                if not (is_integral and (r == -1 or r == 0 or 2 <= r <= 128)):
                     raise ValueError(
                         f"csa_compress_ratios[{i}]={r} is invalid. "
-                        f"Each value must be 0 (window), an integer in [2, 127] "
+                        f"Each value must be -1 (full-causal MQA), 0 (window), "
+                        f"an integer in [2, 127] "
                         f"(CSA, overlap + Lightning Indexer), or 128 (HCA)."
                     )
 

--- a/tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_utils.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_utils.py
@@ -305,7 +305,13 @@ class TestCudnnBackendDispatch(unittest.TestCase):
         b, sq, h, hn, s_kv, topk = 1, 2, 3, 4, 6, 4
 
         def fake_fwd(
-            q, kv, attn_sink, topk_idxs, sm_scale=None, indexer_topk=0
+            q,
+            kv,
+            attn_sink,
+            topk_idxs,
+            sm_scale=None,
+            indexer_topk=0,
+            topk_length=None,
         ):
             bb, ss, hh, dd = q.shape
             out = paddle.ones([bb, ss, hh, dd], dtype=q.dtype)

--- a/tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_utils.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_utils.py
@@ -355,7 +355,52 @@ class TestCudnnBackendDispatch(unittest.TestCase):
             self.assertEqual(q.grad.shape, [b, sq, h, hn])
             self.assertEqual(kv.grad.shape, [b, s_kv, hn])
             self.assertEqual(sink.grad.shape, [h])
+
+            # With topk_length the PyLayer takes one extra (non-differentiable)
+            # input, so backward has to return one extra placeholder gradient.
+            q2 = paddle.randn([b, sq, h, hn], dtype="float32")
+            q2.stop_gradient = False
+            kv2 = paddle.randn([b, s_kv, hn], dtype="float32")
+            kv2.stop_gradient = False
+            sink2 = paddle.randn([h], dtype="float32")
+            sink2.stop_gradient = False
+            length = paddle.full([b, sq], topk, dtype="int32")
+
+            out = csa_sparse_attn(
+                q2,
+                kv2,
+                sink2,
+                idx,
+                0.5,
+                backend="cudnn",
+                topk_length=length,
+            )
+            out.sum().backward()
+            self.assertEqual(q2.grad.shape, [b, sq, h, hn])
+            self.assertEqual(kv2.grad.shape, [b, s_kv, hn])
+            self.assertEqual(sink2.grad.shape, [h])
         finally:
             fwd.flash_mla_sparse_attn = orig_fwd
             if orig_bwd is not None:
                 cudnn_pkg.csa_sparse_attn_bwd_cudnn = orig_bwd
+
+    def test_topk_length_rejected_by_tilelang_backend(self):
+        from paddlefleet.fusions.csa_sparse_attn import csa_sparse_attn
+
+        b, sq, h, hn, s_kv, topk = 1, 2, 3, 4, 6, 4
+        q = paddle.randn([b, sq, h, hn], dtype="float32")
+        kv = paddle.randn([b, s_kv, hn], dtype="float32")
+        sink = paddle.randn([h], dtype="float32")
+        idx = paddle.randint(0, s_kv, [b, sq, topk]).cast("int32")
+        length = paddle.full([b, sq], topk, dtype="int32")
+
+        with self.assertRaisesRegex(NotImplementedError, "backend='tilelang'"):
+            csa_sparse_attn(
+                q,
+                kv,
+                sink,
+                idx,
+                0.5,
+                backend="tilelang",
+                topk_length=length,
+            )

--- a/tests/single_card_tests/transformer/test_dsv4_hybrid_attention.py
+++ b/tests/single_card_tests/transformer/test_dsv4_hybrid_attention.py
@@ -42,6 +42,7 @@ from paddlefleet.transformer.csa_attention import (
     _resolve_csa_indexer_attn_topk_effective,
     _resolve_csa_indexer_loss_topk_effective,
     get_compress_topk_idxs,
+    get_mqa_causal_topk_idxs,
     get_valid_range,
     get_window_topk_idxs,
 )
@@ -201,10 +202,10 @@ class TestDSv4HybridConfigAndSpec(unittest.TestCase):
             _make_config(num_layers=1, csa_compress_ratios=[129])
 
     def test_csa_compress_ratios_accepts_general_set(self):
-        # window (0), CSA over the full [2, 127] range (including non-power-of-2
-        # 3 and the boundary 127), and HCA (128) must all be accepted and
-        # round-trip through the config.
-        ratios = [0, 2, 3, 4, 8, 16, 32, 64, 127, 128]
+        # full-causal MQA (-1), window (0), CSA over the full [2, 127] range
+        # (including non-power-of-2 3 and the boundary 127), and HCA (128) must
+        # all be accepted and round-trip through the config.
+        ratios = [-1, 0, 2, 3, 4, 8, 16, 32, 64, 127, 128]
         cfg = _make_config(num_layers=len(ratios), csa_compress_ratios=ratios)
         self.assertEqual(cfg.csa_compress_ratios, ratios)
 
@@ -1003,7 +1004,7 @@ class TestDSv4HybridDocumentRoPE(unittest.TestCase):
 
     def test_attention_module_document_mask_matches_separate_documents(self):
         paddle.seed(_SEED)
-        for ratio in [0, 4, 128]:
+        for ratio in [-1, 0, 4, 128]:
             config = _make_config(
                 hidden_size=64,
                 num_attention_heads=2,
@@ -1367,6 +1368,95 @@ class TestDSv4HybridAttentionConstructor(unittest.TestCase):
         # ratio 129 is above HCA (128) -> rejected.
         with self.assertRaisesRegex(ValueError, "is invalid"):
             _make_config(num_layers=1, csa_compress_ratios=[129])
+
+    def test_mqa_ratio_matches_window_covering_full_sequence(self):
+        # ratio=-1 is full-causal MQA: no compressor, no indexer, no window.
+        # A window-only layer (ratio=0) whose window covers the whole sequence
+        # attends to exactly the same key set, so both must agree bit-exactly.
+        seq_len = 32
+        kwargs = {
+            "hidden_size": 64,
+            "num_attention_heads": 2,
+            "v_head_dim": 32,
+            "q_lora_rank": 32,
+            "o_groups": 2,
+            "o_lora_rank": 16,
+            "dsa_indexer_loss_coeff": 0.0,
+            "num_layers": 1,
+        }
+        mqa_config = _make_config(
+            csa_compress_ratios=[-1], csa_window_size=8, **kwargs
+        )
+        window_config = _make_config(
+            csa_compress_ratios=[0], csa_window_size=seq_len, **kwargs
+        )
+
+        paddle.seed(_SEED)
+        model_parallel_cuda_manual_seed(_SEED)
+        mqa_attn = _build_attention(mqa_config, layer_number=0)
+        mqa_attn.eval()
+        paddle.seed(_SEED)
+        model_parallel_cuda_manual_seed(_SEED)
+        window_attn = _build_attention(window_config, layer_number=0)
+        window_attn.eval()
+
+        core = mqa_attn.core_attention
+        self.assertTrue(core.is_mqa_layer)
+        self.assertIsNone(core.compressor)
+        self.assertIsNone(core.indexer)
+        # MQA uses plain RoPE (base rotary_base), never the compressed YaRN.
+        self.assertNotIsInstance(mqa_attn.rotary_pos_emb, YarnRotaryEmbedding)
+
+        hidden = paddle.randn(
+            [1, seq_len, mqa_config.hidden_size], dtype="bfloat16"
+        )
+        with paddle.no_grad():
+            mqa_out, _ = mqa_attn(hidden_states=hidden, attention_mask=None)
+            window_out, _ = window_attn(
+                hidden_states=hidden, attention_mask=None
+            )
+        self.assertTrue(
+            paddle.equal_all(
+                mqa_out.cast("float32"), window_out.cast("float32")
+            ).item()
+        )
+
+    def test_mqa_topk_length_matches_mask_only_indices(self):
+        # The MQA index table carries both -1 padding and topk_length; dropping
+        # topk_length must not change the result (the kernel only stops early).
+        paddle.seed(_SEED)
+        seqlen, heads, dim = 24, 2, 16
+        query = paddle.randn([1, seqlen, heads, dim], dtype="bfloat16")
+        kv = paddle.randn([1, seqlen, dim], dtype="bfloat16")
+        sink = paddle.randn([heads], dtype="float32") * 0.1
+        startend_row_indices = _make_startend_row_indices([10, 9], seqlen)
+        meta = CSADocMaskMetadata.build(
+            1, 1, seqlen, startend_row_indices, seqlen
+        )
+        topk_idxs, topk_length = get_mqa_causal_topk_idxs(
+            1, seqlen, docmask_meta=meta
+        )
+        expected_length = [
+            min(i, 9) + 1 if i < 10 else (i - 10 + 1 if i < 19 else 1)
+            for i in range(seqlen)
+        ]
+        self.assertEqual(topk_length[0].numpy().tolist(), expected_length)
+
+        with_length = unfused_compressed_sparse_attn(
+            query, kv, sink, topk_idxs, dim**-0.5, topk_length=topk_length
+        )
+        mask_only = unfused_compressed_sparse_attn(
+            query, kv, sink, topk_idxs, dim**-0.5
+        )
+        self.assertTrue(
+            paddle.equal_all(
+                with_length.cast("float32"), mask_only.cast("float32")
+            ).item()
+        )
+        # Padding rows (19..23) fall back to the attention sink only.
+        self.assertEqual(
+            float(with_length[:, 19:].cast("float32").abs().max()), 0.0
+        )
 
     def test_q_head_dim_equals_v_head_dim(self):
         paddle.seed(_SEED)

--- a/tests/single_card_tests/transformer/test_dsv4_hybrid_attention.py
+++ b/tests/single_card_tests/transformer/test_dsv4_hybrid_attention.py
@@ -1458,6 +1458,72 @@ class TestDSv4HybridAttentionConstructor(unittest.TestCase):
             float(with_length[:, 19:].cast("float32").abs().max()), 0.0
         )
 
+    def test_mqa_causal_topk_idxs_from_startend_row_indices(self):
+        # Without a prebuilt metadata object the helper builds one itself from
+        # startend_row_indices; both entry points must agree.
+        seqlen = 16
+        startend_row_indices = _make_startend_row_indices([7, 9], seqlen)
+        idxs, lengths = get_mqa_causal_topk_idxs(
+            1, seqlen, startend_row_indices=startend_row_indices
+        )
+        meta = CSADocMaskMetadata.build(
+            1, 1, seqlen, startend_row_indices, seqlen
+        )
+        meta_idxs, meta_lengths = get_mqa_causal_topk_idxs(
+            1, seqlen, docmask_meta=meta
+        )
+        self.assertEqual(idxs.shape, [1, seqlen, seqlen])
+        self.assertEqual(lengths.shape, [1, seqlen])
+        self.assertTrue(paddle.equal_all(idxs, meta_idxs).item())
+        self.assertTrue(paddle.equal_all(lengths, meta_lengths).item())
+        # The causal range restarts at the second document's start (7).
+        self.assertEqual(
+            lengths[0].numpy().tolist(),
+            [i + 1 for i in range(7)] + [i - 7 + 1 for i in range(7, 16)],
+        )
+
+    def test_mqa_rejects_tilelang_backend(self):
+        # tilelang has no topk_length support, so the MQA layer cannot use it.
+        config = _make_config(
+            num_layers=1,
+            csa_compress_ratios=[-1],
+            csa_sparse_attn_backend="tilelang",
+        )
+        with self.assertRaisesRegex(NotImplementedError, "'tilelang'"):
+            CompressedSparseAttention(
+                config=config,
+                sublayers_spec=CompressedSparseAttentionSublayersSpec(),
+                layer_number=0,
+                attn_mask_type=AttnMaskType.causal,
+                attention_type="self",
+                pg_collection=_FakePGCollection(),
+                compress_ratio=-1,
+            )
+
+    def test_mqa_rejects_context_parallelism(self):
+        # CP must fail loudly instead of taking the CSA CP path, which assumes
+        # a compressed KV stream the MQA layer never builds.
+        paddle.seed(_SEED)
+        config = _make_config(num_layers=1, csa_compress_ratios=[-1])
+        core = CompressedSparseAttention(
+            config=config,
+            sublayers_spec=CompressedSparseAttentionSublayersSpec(),
+            layer_number=0,
+            attn_mask_type=AttnMaskType.causal,
+            attention_type="self",
+            pg_collection=_FakePGCollection(cp_nranks=2),
+            compress_ratio=-1,
+        )
+        self.assertTrue(core.cp_enabled)
+        b, sq = 1, 8
+        query = paddle.randn(
+            [b, sq, config.num_attention_heads, config.v_head_dim],
+            dtype="bfloat16",
+        )
+        key = paddle.randn([b, sq, 1, config.v_head_dim], dtype="bfloat16")
+        with self.assertRaisesRegex(NotImplementedError, "cp=2"):
+            core(query, key, key)
+
     def test_q_head_dim_equals_v_head_dim(self):
         paddle.seed(_SEED)
         config = _make_config()


### PR DESCRIPTION
### PR Category

Operator Mechanism

### PR Types

New features

### Description

#### 背景

`csa_compress_ratios` 目前的取值语义是 `0`=滑窗、`2..127`=CSA(compressor + Lightning
Indexer)、`128`=HCA(compressor only)。本 PR 增加 `-1` 作为**全因果 MQA 层**的哨兵值：
不建 compressor、不建 indexer、不开滑窗，每个 query 注意到**本 document 内**它之前的
全部原始 KV 位置，单头 KV 被所有 query head 共享，沿用已有的可学习 per-head
attention sink。

实现方式是复用现成的 CSA 稀疏 kernel：喂一张稠密因果 index 表，再给前向补一个
`topk_length`（每行有效前缀长度），让 kernel 在对角线处停下，而不是把 `topk` 个 slot
全走一遍 —— 这是让全因果层在稀疏路径上跑得起的关键。

反向侧不需要新增参数：#1540 已经给 `csa_sparse_attn_bwd_cudnn` 接上
`_csa_compute_topk_length(topk_idxs_flat)`，它从 `-1` padding 反推出同样的尾界，对
MQA 的稠密因果表天然成立。所以本 PR 只补前向那一路。

#### 改动（5 个 commit，按依赖顺序）

1. **`[DSv4] accept csa_compress_ratios=-1; harden ratio + compress-RoPE config`**
   - 配置校验放行 `-1`；逐值校验同时放行 numpy 整型标量（ratios 经 `np.load` 往返会变成
     `np.int64`，此前被误拒），但仍拒绝 `bool` / `np.bool_`，避免 `True` 当作 `1` 混进来。
   - `csa_compress_rotary_base` 用 `float()` 强转。线上所有 `model_config.json` 都把它写成
     **字符串** `"160000.0"`；`pretrain.py` 建配置前会转数字串，但直接调 `from_config` 的
     路径（单测、离线推理、周边工具）会把 str 送进 `YarnRotaryEmbedding` 的 `math.log()`
     直接 `TypeError`。

2. **`[hysparse] thread topk_length through the CSA sparse attention kernels`**
   - `csa_sparse_attn(..., topk_length=None)`：转发给 cuDNN FlashMLA 前向 kernel（按其要求
     flatten 成 `[b * sq]` int32），unfused 参考路径用一条 `slot >= length` 的额外 mask
     等价模拟。tilelang 没有 `topk_length` 支持，现在显式 `NotImplementedError`，而不是静默
     忽略参数。
   - `topk_length` 是**纯前向的提前停提示**：正确性由 `topk_idxs` 里的 `-1` padding 保证，
     反向已由 `_csa_compute_topk_length` 自行推出等价尾界。因此不进 `save_for_backward`、
     不改既有 saved-tensor 布局，`ctx` 上只记一个 `has_topk_length`，让 backward 在真的传了
     该参数时多返回一个 `None` 占位梯度。

3. **`[hysparse] add the full-causal MQA layer (csa_compress_ratios=-1)`**
   - `get_mqa_causal_topk_idxs()` / `CSADocMaskMetadata.get_mqa_causal_topk_idxs()`：索引在每个
     document 边界重置，因此 packed 多 document 与逐 document 单独跑**逐位一致**。padding 行
     保留单个 masked slot，退化为滑窗路径已有的 sink-only 输出。
     `build()` 只在 indexer 路径（`ratio > 1 and not dense_mode`）导出 `is_valid`，而 MQA 层
     以 `ratio=1` 建 metadata，所以这里按 `_derive_csa_doc_boundaries` 的同一定义
     （`pos_in_doc < doc_len_per_pos`）就地补出来，不改 `build()` 的既有分支。
   - metadata 上的 cache 已注明**当前是 per-layer 生效、跨层不命中**（DSv4 forward 每层新建
     metadata），并写清跨层复用的前提：必须先按 `(seqlen, doc layout)` 做 key —— 梯度累积、
     `variable_seq_lengths`、`document_mask_prob_text` 都会让不同 microbatch 的 layout 不同，
     拿一种 layout 的表用到另一种上是静默错误。
   - 构造期拒绝 tilelang 后端；`unfused` 给警告：它的稠密 `[b, sq, sq, head_dim]` gather 只装
     得下极小序列（`sq=8192` 约 68 TB），是测试用参考路径。
   - CP 显式 `NotImplementedError`，而不是走 CSA 的 CP 路径 —— 那条路径假设存在本层根本不会
     构造的压缩 KV 流。

4. **`[hysparse] test coverage for the full-causal MQA layer`**

5. **`[hysparse] cover the remaining MQA guard paths; polish the unfused warning`**
   - 补齐上一版增量覆盖率漏掉的 6 行（全是 error/warning 分支与 `get_mqa_causal_topk_idxs`
     的自建 metadata 分支）：`csa_sparse_attn.py` L176/L254、`csa_attention.py`
     L828/L831/L2012/L2408。
   - `warnings.warn(..., stacklevel=2)`，让 `unfused` 后端告警指向调用方而不是库内部。

#### 测试

`ruff check` / `ruff format --check`、copyright hook 均通过。单卡（SM100）：

```
tests/single_card_tests/transformer/test_dsv4_hybrid_attention.py
tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_utils.py
tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_backends.py
tests/single_card_tests/transformer/test_csa_high_precision_norm.py
tests/single_card_tests/transformer/test_csa_loss_mask.py
=> 106 passed, 1 skipped, 29 subtests passed
```

新增的关键断言：

- `ratio=-1` vs 「滑窗覆盖整条序列的 `ratio=0` 层」：二者注意到的 key 集合完全相同，输出
  **逐位相等**（`paddle.equal_all`）；同时断言该层不建 compressor/indexer、且用的是普通
  RoPE 而非 compressed YaRN。
- packed 多 document 等价性：`ratio=-1` 加入原有 `[0, 4, 128]` 的对照 sweep。
- `topk_length` 只是提前停的提示：传与不传（只靠 `-1` padding mask）结果必须一致；逐行期望
  前缀长度（含 padding 行的兜底值）显式校验。

另外在下游训练仓库里跑过一轮多智能体交叉验证，覆盖多 document 等价性、MTP 交互、RoPE（含
共享单头 KV 下的反 RoPE）、算子与散算子梯度对比（**幅度**与余弦分别判，`norm(mine)/norm(ref)`
及逐元素比值分位数均与同结构 SWA(0)/CSA(4)/HCA(128) 基线同量级）、full recompute、以及
sharding `split_param` + muon + EP 组合下的分片语义。这部分脚本不在本 PR 内。

#### 未覆盖 / 已知边界

- **CP 不支持**，构造期即报错，不是静默降级。
- **tilelang 后端不支持**（无 `topk_length`），构造期即报错；`unfused` 仅供小尺寸测试。
- 生产规模（64 卡 EP）真跑尚未进行；分片语义为静态判据 + 2 卡实测外推：attention 参数全程
  不打 `color`/`expert` marker，故沿 EP 轴复制，该逻辑与 EP degree 无关。


#### CI 备注

- review 中提到的 `mtp_shared_last_layer` 与 per-layer `csa_compress_ratio` 的一致性检查已从本 PR 移除（该检查与「支持全因果 MQA 层」正交，且仓库现存配置会命中它），历史已 rebase 压平，本 PR 现在只包含 `csa_compress_ratios=-1` 相关改动。MTP / shared-layer 的交互后续单独开 PR。
- `Integration test (H20, multi-card)` 的失败与本 PR 无关：三个失败步骤都是 GLM4.5 sft/lora/dpo，前者卡在 MoE DeepEP `barrier_ep` 的 NCCL `unhandled cuda error`，后两者因此读不到 `checkpoints/glm_full_pp_ckpts/config.json`。同一天 `agent/*`、`test`、`merge_paddlefleet_repo_and_formers_repo` 等与 CSA 无关的分支在同一步骤上有相同报错。本 PR 不改 MoE / DeepEP / 通信路径。
