### PR TITLE
Add use_accuracy_compatible mode for MoE/MLP numerical alignment

### DIFF
--- a/src/paddlefleet/fusions/fused_bias_swiglu.py
+++ b/src/paddlefleet/fusions/fused_bias_swiglu.py
@@ -40,6 +40,11 @@ def swiglu(y):
     return F.swiglu(y)
 
 
+def swiglu_eager(y):
+    y_1, y_2 = paddle.chunk(y, 2, axis=-1)
+    return F.silu(y_1) * y_2
+
+
 @jit_fuser
 def bias_swiglu(y, bias):
     """Performs SwiGLU activation with bias addition.
@@ -53,6 +58,11 @@ def bias_swiglu(y, bias):
     """
     y = y + bias
     return swiglu(y)
+
+
+def bias_swiglu_eager(y, bias):
+    y = y + bias
+    return swiglu_eager(y)
 
 
 @jit_fuser
@@ -81,6 +91,20 @@ def swiglu_back(g, y):
     return dx
 
 
+def swiglu_back_eager(g, y):
+    y_1, y_2 = paddle.chunk(y, 2, axis=-1)
+    return paddle.concat(
+        (
+            g
+            * paddle.nn.functional.sigmoid(y_1)
+            * (1 + y_1 * (1 - paddle.nn.functional.sigmoid(y_1)))
+            * y_2,
+            g * F.silu(y_1),
+        ),
+        axis=-1,
+    )
+
+
 @jit_fuser
 def bias_swiglu_back(g, y, bias):
     """Computes the gradient for the biased SwiGLU activation function.
@@ -107,6 +131,15 @@ def weighted_swiglu_back(g, y, weights):
     weights_grad = swiglu(y) * g.to(w_dtype)
     weights_grad = paddle.sum(weights_grad, dim=-1, keepdim=True)
     return input_grad.to(input_dtype), weights_grad.to(w_dtype)
+
+
+def weighted_swiglu_back_eager(g, y, weights):
+    input_dtype = y.dtype
+    w_dtype = weights.dtype
+    input_grad = swiglu_back_eager(g * weights, y)
+    weights_grad = swiglu_eager(y) * g.cast(w_dtype)
+    weights_grad = paddle.sum(weights_grad, axis=-1, keepdim=True)
+    return input_grad.cast(input_dtype), weights_grad.cast(w_dtype)
 
 
 @jit_fuser
@@ -261,7 +294,13 @@ class BiasSwiGLUFunction(paddle.autograd.PyLayer):
     @staticmethod
     @nvtx_decorator()
     def forward(
-        ctx, input, bias, fp8_input_store, cpu_offload_input, clamp_value=None
+        ctx,
+        input,
+        bias,
+        fp8_input_store,
+        cpu_offload_input,
+        clamp_value=None,
+        use_accuracy_compatible=False,
     ):
         """Forward pass of biased SwiGLU activation.
 
@@ -288,8 +327,11 @@ class BiasSwiGLUFunction(paddle.autograd.PyLayer):
         ctx.ori_input_dtype = input.dtype
         ctx.fp8_input_store = fp8_input_store
         ctx.clamp_value = clamp_value
+        ctx.use_accuracy_compatible = use_accuracy_compatible
         if clamp_value is not None and clamp_value > 0:
             return clamped_bias_swiglu(input, bias, clamp_value)
+        if use_accuracy_compatible:
+            return bias_swiglu_eager(input, bias)
         return bias_swiglu(input, bias)
 
     @staticmethod
@@ -312,6 +354,9 @@ class BiasSwiGLUFunction(paddle.autograd.PyLayer):
             tmp = clamped_bias_swiglu_back(
                 grad_output, input, bias, ctx.clamp_value
             )
+        elif ctx.use_accuracy_compatible:
+            y = input + bias
+            tmp = swiglu_back_eager(grad_output, y)
         else:
             tmp = bias_swiglu_back(grad_output, input, bias)
         return tmp, tmp
@@ -323,7 +368,12 @@ class SwiGLUFunction(paddle.autograd.PyLayer):
     @staticmethod
     @nvtx_decorator()
     def forward(
-        ctx, input, fp8_input_store, cpu_offload_input, clamp_value=None
+        ctx,
+        input,
+        fp8_input_store,
+        cpu_offload_input,
+        clamp_value=None,
+        use_accuracy_compatible=False,
     ):
         """Forward pass of SwiGLU activation.
 
@@ -348,8 +398,11 @@ class SwiGLUFunction(paddle.autograd.PyLayer):
         ctx.ori_input_dtype = input.dtype
         ctx.fp8_input_store = fp8_input_store
         ctx.clamp_value = clamp_value
+        ctx.use_accuracy_compatible = use_accuracy_compatible
         if clamp_value is not None and clamp_value > 0:
             return clamped_swiglu(input, clamp_value)
+        if use_accuracy_compatible:
+            return swiglu_eager(input)
         return swiglu(input)
 
     @staticmethod
@@ -368,6 +421,8 @@ class SwiGLUFunction(paddle.autograd.PyLayer):
         input = input.to(ctx.ori_input_dtype) if ctx.fp8_input_store else input
         if ctx.clamp_value is not None and ctx.clamp_value > 0:
             tmp = clamped_swiglu_back(grad_output, input, ctx.clamp_value)
+        elif ctx.use_accuracy_compatible:
+            tmp = swiglu_back_eager(grad_output, input)
         else:
             tmp = swiglu_back(grad_output, input)
         return tmp
@@ -376,7 +431,14 @@ class SwiGLUFunction(paddle.autograd.PyLayer):
 class WeightedSwiGLUFunction(paddle.autograd.PyLayer):
     @staticmethod
     # bias is an optional argument
-    def forward(ctx, input, weights, fp8_input_store, clamp_value=None):
+    def forward(
+        ctx,
+        input,
+        weights,
+        fp8_input_store,
+        clamp_value=None,
+        use_accuracy_compatible=False,
+    ):
         input_for_backward = (
             input.to(paddle.float8_e4m3fn) if fp8_input_store else input
         )
@@ -384,8 +446,12 @@ class WeightedSwiGLUFunction(paddle.autograd.PyLayer):
         ctx.ori_input_dtype = input.dtype
         ctx.fp8_input_store = fp8_input_store
         ctx.clamp_value = clamp_value
+        ctx.use_accuracy_compatible = use_accuracy_compatible
         if clamp_value is not None and clamp_value > 0:
             res = clamped_weighted_swiglu(input, weights, clamp_value)
+        elif use_accuracy_compatible:
+            res = swiglu_eager(input) * weights
+            return res.cast(input.dtype)
         else:
             res = weighted_swiglu(input, weights)
         return res
@@ -398,6 +464,8 @@ class WeightedSwiGLUFunction(paddle.autograd.PyLayer):
             tmp, wgrad = clamped_weighted_swiglu_back(
                 grad_output, input, weights, ctx.clamp_value
             )
+        elif ctx.use_accuracy_compatible:
+            tmp, wgrad = weighted_swiglu_back_eager(grad_output, input, weights)
         else:
             tmp, wgrad = weighted_swiglu_back(grad_output, input, weights)
         return tmp, wgrad
@@ -409,6 +477,7 @@ def bias_swiglu_impl(
     fp8_input_store=False,
     cpu_offload_input=False,
     clamp_value=None,
+    use_accuracy_compatible=False,
 ):
     """Implementation of biased SwiGLU that handles different input shapes.
 
@@ -438,11 +507,20 @@ def bias_swiglu_impl(
     input = input.view(-1, ori_shape[-1])
     if bias is not None:
         output = BiasSwiGLUFunction.apply(
-            input, bias, fp8_input_store, cpu_offload_input, clamp_value
+            input,
+            bias,
+            fp8_input_store,
+            cpu_offload_input,
+            clamp_value,
+            use_accuracy_compatible,
         )
     else:
         output = SwiGLUFunction.apply(
-            input, fp8_input_store, cpu_offload_input, clamp_value
+            input,
+            fp8_input_store,
+            cpu_offload_input,
+            clamp_value,
+            use_accuracy_compatible,
         )
 
     return (
@@ -453,7 +531,12 @@ def bias_swiglu_impl(
 
 
 def weighted_bias_swiglu_impl(
-    input, bias, weights, fp8_input_store=False, clamp_value=None
+    input,
+    bias,
+    weights,
+    fp8_input_store=False,
+    clamp_value=None,
+    use_accuracy_compatible=False,
 ):
     """
     Token-wise-weighted bias swiglu fusion.
@@ -478,7 +561,11 @@ def weighted_bias_swiglu_impl(
         )
     else:
         output = WeightedSwiGLUFunction.apply(
-            input, weights, fp8_input_store, clamp_value
+            input,
+            weights,
+            fp8_input_store,
+            clamp_value,
+            use_accuracy_compatible,
         )
 
     return (

--- a/src/paddlefleet/models/common/language_loss/language_loss.py
+++ b/src/paddlefleet/models/common/language_loss/language_loss.py
@@ -354,6 +354,15 @@ class LanguageLoss(FleetLayer):
                 labels, axis=1, mode=self.config.cp_balance_mode
             )
 
+        if _use_accuracy_compatible_kernel():
+            # 定位锚点 1：CP gather 后、mask/归一化前的 per-token CE，
+            # 两侧语义唯一，未掺入归一化差异。
+            print(
+                f"\nper_token_loss: rank={dist.get_rank()} "
+                f"shape={list(loss.shape)} md5={loss.cast('float32')._md5sum()}",
+                flush=True,
+            )
+
         lossmask = labels != self.ignored_index
         if (~lossmask).all():
             loss = paddle.mean(loss) * 0.0
@@ -434,6 +443,15 @@ class LanguageLoss(FleetLayer):
                     loss.cast(paddle.float32).reshape([-1]) * lossmask
                 )
                 loss = loss / lossmask.sum()
+
+        if _use_accuracy_compatible_kernel():
+            # 定位锚点 2：mask + 归一化后的标量 loss，与锚点 1 配合可切开
+            # 「CE 上游差异」和「lossmask / valid_token / 除法差异」。
+            print(
+                f"\nfinal_loss: rank={dist.get_rank()} "
+                f"val={float(loss):.20f} md5={loss.cast('float32')._md5sum()}",
+                flush=True,
+            )
 
         return loss
 

--- a/src/paddlefleet/tensor_parallel/layers.py
+++ b/src/paddlefleet/tensor_parallel/layers.py
@@ -764,6 +764,11 @@ class LinearWithGradAccumulationAndAsyncCommunication(paddle.autograd.Function):
         ctx.wgrad_deferral_limit = wgrad_deferral_limit
         ctx.grad_output_buffer = grad_output_buffer
         ctx.tp_group = tp_group
+        ctx.use_accuracy_compatible = use_accuracy_compatible
+        # Cache input.stop_gradient: ``_new_shared_tensor()`` does not
+        # necessarily preserve this flag, and Paddle's PyLayer contract
+        # requires backward to return None at position 0 iff the original
+        # forward input had stop_gradient=True.
         ctx.input_stop_gradient = bool(input.stop_gradient)
         ctx.fp8 = fp8
         ctx.fp8_wgrad = fp8_wgrad
@@ -1049,7 +1054,25 @@ class LinearWithGradAccumulationAndAsyncCommunication(paddle.autograd.Function):
             else:
                 grad_weight = None
         else:
-            if wgrad_compute:
+            if (
+                wgrad_compute
+                and ctx.use_accuracy_compatible
+                and getattr(weight, "is_expert_param", False)
+                and hasattr(weight, "main_grad")
+                and weight.main_grad is not None
+                and weight.main_grad.dtype == paddle.float32
+            ):
+                weight.main_grad.add_(
+                    paddle.matmul(
+                        grad_output.astype("float32"),
+                        total_input.astype("float32"),
+                        transpose_x=True,
+                    ).t()
+                )
+                if hasattr(weight, "grad_added_to_main_grad"):
+                    weight.grad_added_to_main_grad = True
+                grad_weight = paddle.zeros(weight.shape, dtype=input.dtype)
+            elif wgrad_compute:
                 if total_input is not None:
                     grad_weight, _ = general_gemm(total_input.t(), grad_output)
                 elif inp_t_fp8 is not None:
@@ -1363,6 +1386,7 @@ class Linear(paddle.nn.Layer):
             # Weight is duplicated across TP ranks; reduce gradient on DP group.
             self.weight.allreduce = True
             self.weight.is_distributed = False
+            self.weight.is_expert_param = self.is_expert
         else:
             self.weight = None
 
@@ -1826,6 +1850,7 @@ class ColumnParallelLinear(paddle.nn.Layer):
                 self.is_expert and self.expert_parallel
             )
             self.weight.is_distributed = True if self.world_size > 1 else False
+            self.weight.is_expert_param = self.is_expert
         else:
             self.weight = None
 
@@ -2217,6 +2242,7 @@ class RowParallelLinear(paddle.nn.Layer):
                 )
         self.weight.allreduce = not (self.is_expert and self.expert_parallel)
         self.weight.is_distributed = True if self.world_size > 1 else False
+        self.weight.is_expert_param = self.is_expert
 
         if bias:
             self.bias = self.create_parameter(

--- a/src/paddlefleet/transformer/mlp.py
+++ b/src/paddlefleet/transformer/mlp.py
@@ -99,6 +99,9 @@ class MLP(FleetLayer):
         super().__init__(config=config)
 
         self.config: TransformerConfig = config
+        self.use_accuracy_compatible = getattr(
+            config, "use_accuracy_compatible", False
+        )
 
         self.input_size = (
             input_size if input_size is not None else self.config.hidden_size
@@ -228,6 +231,7 @@ class MLP(FleetLayer):
                             False,
                         ),
                         self.config.activation_func_clamp_value,
+                        use_accuracy_compatible=self.use_accuracy_compatible,
                     )
                 elif (
                     self.hidden_act == quick_gelu
@@ -273,6 +277,7 @@ class MLP(FleetLayer):
                         ),
                         cpu_offload_input=False,
                         clamp_value=self.config.activation_func_clamp_value,
+                        use_accuracy_compatible=self.use_accuracy_compatible,
                     )
                 else:
                     raise ValueError("Only support fusion of gelu and swiglu")

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -127,6 +127,20 @@ class GradDtypeUnguard(PyLayer):
         return grad
 
 
+class ThreePathCloneAlignMG(PyLayer):
+    """Three-way differentiable identity clone with MG-aligned backward sum order."""
+
+    @staticmethod
+    def forward(ctx, x):
+        return x.clone(), x.clone(), x.clone()
+
+    @staticmethod
+    def backward(ctx, g_router, g_dispatcher, g_shared):
+        partial = g_dispatcher + g_shared
+        out = partial + g_router
+        return out
+
+
 @dataclass
 class MoESublayers:
     """MoE Layer Sublayers spec"""
@@ -143,6 +157,9 @@ class MoELayer(nn.Layer):
     ):
         super().__init__()
         self.config = config
+        self.use_accuracy_compatible = getattr(
+            config, "use_accuracy_compatible", False
+        )
         self.moe_sublayers = sublayers
         routed_expert_config = deepcopy(config)
         shared_expert_config = deepcopy(config)
@@ -474,6 +491,7 @@ class MoELayer(nn.Layer):
                         config, "hybridep_buffer_configs", None
                     ),
                     moe_deep_gemm=self.moe_deep_gemm,
+                    use_accuracy_compatible=self.use_accuracy_compatible,
                 )
                 if (
                     self.moe_token_dispatcher_type == "deepep"
@@ -493,6 +511,7 @@ class MoELayer(nn.Layer):
                     self.expert_model_parallel_size,
                     self.num_experts_per_device,
                     local_expert_indices,
+                    use_accuracy_compatible=self.use_accuracy_compatible,
                 )
             elif self.moe_token_dispatcher_type == "allgather":
                 self.token_dispatcher = AllGatherTokenDispatcher(
@@ -1248,10 +1267,22 @@ class MoELayer(nn.Layer):
         residuals = hidden_states
 
         layer_idx = getattr(self, "layer_number", None)
+
+        _three_paths_enabled = (
+            self.use_accuracy_compatible
+            and hidden_states.stop_gradient is False
+        )
+        if _three_paths_enabled:
+            _hs_router_path, _hs_dispatcher_path, _hs_shared_path = (
+                ThreePathCloneAlignMG.apply(hidden_states)
+            )
+            residuals = _hs_shared_path
         _log_moe_md5(hidden_states, "moe_input", layer_idx)
 
         self._maybe_pre_allgather_overlap(hidden_states)
         gate_input = self._prepare_gate_input(hidden_states, residual)
+        if _three_paths_enabled:
+            gate_input = _hs_router_path
 
         (
             capacity,
@@ -1291,6 +1322,8 @@ class MoELayer(nn.Layer):
             combine_overlap_handle = None
 
         expert_input = self._prepare_expert_input(hidden_states, residual)
+        if _three_paths_enabled:
+            expert_input = _hs_dispatcher_path
         if self.expert_model_parallel_size > 1:
             if self.moe_use_fusion_node:
                 output = self.fusion_moe_forward(

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -491,7 +491,9 @@ class MoELayer(nn.Layer):
                         config, "hybridep_buffer_configs", None
                     ),
                     moe_deep_gemm=self.moe_deep_gemm,
-                    use_accuracy_compatible=self.use_accuracy_compatible,
+                    use_accuracy_compatible=getattr(
+                        self, "use_accuracy_compatible", False
+                    ),
                 )
                 if (
                     self.moe_token_dispatcher_type == "deepep"
@@ -511,7 +513,9 @@ class MoELayer(nn.Layer):
                     self.expert_model_parallel_size,
                     self.num_experts_per_device,
                     local_expert_indices,
-                    use_accuracy_compatible=self.use_accuracy_compatible,
+                    use_accuracy_compatible=getattr(
+                        self, "use_accuracy_compatible", False
+                    ),
                 )
             elif self.moe_token_dispatcher_type == "allgather":
                 self.token_dispatcher = AllGatherTokenDispatcher(
@@ -1269,7 +1273,7 @@ class MoELayer(nn.Layer):
         layer_idx = getattr(self, "layer_number", None)
 
         _three_paths_enabled = (
-            self.use_accuracy_compatible
+            getattr(self, "use_accuracy_compatible", False)
             and hidden_states.stop_gradient is False
         )
         if _three_paths_enabled:

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -1243,6 +1243,21 @@ class MoELayer(nn.Layer):
         """Post-process shared expert output before combining. Default: identity."""
         return shared_output
 
+    def _supports_three_path_clone(self) -> bool:
+        """Whether the MG-aligned three-path clone applies to this topology.
+
+        The clone assumes router / dispatcher / shared branches all consume the
+        same ``hidden_states``. Subclasses overriding the gate/expert input
+        hooks (e.g. Gemma4MoELayer routes on ``residual`` and applies
+        ``pre_feedforward_layernorm_2``) have a different topology, so the
+        clone must not be used there.
+        """
+        cls = type(self)
+        return (
+            cls._prepare_gate_input is MoELayer._prepare_gate_input
+            and cls._prepare_expert_input is MoELayer._prepare_expert_input
+        )
+
     def forward(
         self,
         hidden_states: paddle.Tensor,
@@ -1275,18 +1290,19 @@ class MoELayer(nn.Layer):
         _three_paths_enabled = (
             getattr(self, "use_accuracy_compatible", False)
             and hidden_states.stop_gradient is False
+            and self._supports_three_path_clone()
         )
         if _three_paths_enabled:
             _hs_router_path, _hs_dispatcher_path, _hs_shared_path = (
                 ThreePathCloneAlignMG.apply(hidden_states)
             )
             residuals = _hs_shared_path
+        else:
+            _hs_router_path = _hs_dispatcher_path = hidden_states
         _log_moe_md5(hidden_states, "moe_input", layer_idx)
 
         self._maybe_pre_allgather_overlap(hidden_states)
-        gate_input = self._prepare_gate_input(hidden_states, residual)
-        if _three_paths_enabled:
-            gate_input = _hs_router_path
+        gate_input = self._prepare_gate_input(_hs_router_path, residual)
 
         (
             capacity,
@@ -1325,9 +1341,7 @@ class MoELayer(nn.Layer):
         else:
             combine_overlap_handle = None
 
-        expert_input = self._prepare_expert_input(hidden_states, residual)
-        if _three_paths_enabled:
-            expert_input = _hs_dispatcher_path
+        expert_input = self._prepare_expert_input(_hs_dispatcher_path, residual)
         if self.expert_model_parallel_size > 1:
             if self.moe_use_fusion_node:
                 output = self.fusion_moe_forward(

--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -649,18 +649,28 @@ class StandardMoERouter(nn.Layer):
                 )  # [B, E]
                 _aggregated = all_probs.sum(axis=seq_axis)  # [B, E]
                 _per_expert = _aggregated * tokens_per_expert  # [B, E]
-                # MG normalizes by the (fixed) sequence length, not by the
-                # per-line valid token count, so `denom` is intentionally
-                # unused here: using it would break the MG alignment.
+                _bsz = _per_expert.shape[0]
+                # MG get_tokens_per_expert_and_token_count():
+                #   total_num_tokens = tokens_per_expert.sum() / (topk * bsz)
+                # i.e. the number of *valid routing* tokens per line (padding
+                # rows contribute no routing entry). Without padding this is
+                # exactly max_seq_len, so the no-padding path stays bit-exact.
+                # Kept as a Python scalar (single division) to match MG's
+                # scalar arithmetic instead of a multi-kernel tensor path.
+                _total_num_tokens = float(
+                    tokens_per_expert.sum().item()
+                ) / float(top_k * _bsz)
+                if _total_num_tokens <= 0.0:
+                    # Every line is padding: no routed token, no loss.
+                    return _per_expert.sum() * 0.0
                 _scalar = float(self.num_experts) / (
-                    float(top_k) * float(max_seq_len) * float(max_seq_len)
+                    float(top_k) * _total_num_tokens * _total_num_tokens
                 )
                 seq_aux_loss = _per_expert.sum() * _scalar
-                # sequence-level loss is averaged over the batch; keep the
-                # single-line case bit-identical (no extra op).
-                _num_lines = _per_expert.shape[0]
-                if _num_lines > 1:
-                    seq_aux_loss = seq_aux_loss / float(_num_lines)
+                # MG divides the sequence-level loss by bsz; keep the
+                # single-line case free of the extra op (bit-exact).
+                if _bsz > 1:
+                    seq_aux_loss = seq_aux_loss / float(_bsz)
             else:
                 cost_coeff = routing_map.sum(axis=seq_axis, dtype="float32") / (
                     denom

--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -484,6 +484,29 @@ class StandardMoERouter(nn.Layer):
         input_ids=None,
         origin_input_ids=None,
     ):
+        if self.use_accuracy_compatible:
+            _probs_2d_pf = (
+                probs
+                if probs.dim() == 2
+                else probs.reshape([-1, probs.shape[-1]])
+            )
+            _aux_top_idx_pf = paddle.topk(
+                _probs_2d_pf, k=top_k, axis=-1
+            ).indices.cast("int64")
+            _aux_routing_map_pf = paddle.zeros_like(
+                _probs_2d_pf
+            ).put_along_axis_(
+                _aux_top_idx_pf,
+                paddle.to_tensor(1.0, dtype=_probs_2d_pf.dtype),
+                axis=-1,
+            )
+            _aux_routing_map_pf = _aux_routing_map_pf.reshape(routing_map.shape)
+            # Mask out padding/invalid tokens (rows where original routing_map is all-zero)
+            row_mask = (
+                routing_map.cast("int64").sum(axis=-1, keepdim=True) > 0
+            ).cast(_aux_routing_map_pf.dtype)
+            routing_map = _aux_routing_map_pf * row_mask
+
         # all_probs and routing_map should be computed using the runtime local sequence length on each worker.
         if (
             self.tensor_model_parallel_size > 1
@@ -620,16 +643,29 @@ class StandardMoERouter(nn.Layer):
             )
         else:
             # [B, E]
-            cost_coeff = routing_map.sum(axis=seq_axis, dtype="float32") / (
-                denom
-                * paddle.to_tensor(top_k / self.num_experts, dtype="float32")
-            )
-            # [B, E] -> [B] -> []
-            seq_aux_loss = (
-                (cost_coeff * all_probs.sum(axis=seq_axis) / denom)
-                .sum(axis=1)
-                .mean()
-            )
+            if self.use_accuracy_compatible:
+                tokens_per_expert = routing_map.sum(
+                    axis=seq_axis, dtype="float32"
+                )  # [B, E]
+                _aggregated = all_probs.sum(axis=seq_axis)  # [B, E]
+                _per_expert = _aggregated * tokens_per_expert  # [B, E]
+                _scalar = float(self.num_experts) / (
+                    float(top_k) * float(max_seq_len) * float(max_seq_len)
+                )
+                seq_aux_loss = _per_expert.sum() * _scalar
+            else:
+                cost_coeff = routing_map.sum(axis=seq_axis, dtype="float32") / (
+                    denom
+                    * paddle.to_tensor(
+                        top_k / self.num_experts, dtype="float32"
+                    )
+                )
+                # [B, E] -> [B] -> []
+                seq_aux_loss = (
+                    (cost_coeff * all_probs.sum(axis=seq_axis) / denom)
+                    .sum(axis=1)
+                    .mean()
+                )
         return seq_aux_loss
 
     def _cal_z_loss(
@@ -919,7 +955,15 @@ class StandardMoERouter(nn.Layer):
 
         # The bias term b is used only to adjust affinity scores for Top-K expert selection (routing); it does not affect gating.
         # The gate applied during dispatch and to weight the FFN output is computed from the original affinity score s_{i,t} (without the bias).
-        topk_weight = scores.take_along_axis(topk_idx, axis=1)
+        if self.use_accuracy_compatible:
+            row_idx = paddle.arange(
+                bsz_seq_len, dtype=topk_idx.dtype
+            ).unsqueeze(-1)
+            row_idx = row_idx.expand(topk_idx.shape)
+            gather_idx = paddle.stack([row_idx, topk_idx], axis=-1)
+            topk_weight = paddle.gather_nd(scores, gather_idx)
+        else:
+            topk_weight = scores.take_along_axis(topk_idx, axis=1)
 
         return topk_weight, topk_idx
 
@@ -1331,7 +1375,14 @@ class TopKRouter(StandardMoERouter):
         _log_moe_md5(gates, "gate_probs_sigmoid", self._layer_number)
 
         # Use clone() to ensure that the execution order of the grad nodes is consistent with EC.
-        gates_ori = gates.clone()
+        if self.use_accuracy_compatible:
+            gates_ori = paddle.nn.functional.sigmoid(
+                logits.cast(paddle.float32)
+            ).cast(logits.dtype)
+            if input_ids_none_zero_mask is not None:
+                gates_ori = gates_ori * valid_mask
+        else:
+            gates_ori = gates.clone()
         if self.config.router_aux_loss_coef and self.scoring_func != "softmax":
             if not getattr(
                 self.config, "gpt_model_use_experimental_version", False
@@ -1441,7 +1492,13 @@ class TopKRouter(StandardMoERouter):
         # norm
         if self.norm_topk_prob:
             if not getattr(self.config, "moe_topk_fusion", False):
-                denominator = top_gate.sum(axis=-1, keepdim=True) + 1e-20
+                if self.use_accuracy_compatible:
+                    _sum_f64 = top_gate.cast(paddle.float64).sum(
+                        axis=-1, keepdim=True
+                    )
+                    denominator = _sum_f64.cast(paddle.float32) + 1e-20
+                else:
+                    denominator = top_gate.sum(axis=-1, keepdim=True) + 1e-20
                 top_gate = top_gate / denominator
             # When gpt_model_use_experimental_version is True, top_gate is already normalized by MoETopkFusion
 

--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -649,10 +649,18 @@ class StandardMoERouter(nn.Layer):
                 )  # [B, E]
                 _aggregated = all_probs.sum(axis=seq_axis)  # [B, E]
                 _per_expert = _aggregated * tokens_per_expert  # [B, E]
+                # MG normalizes by the (fixed) sequence length, not by the
+                # per-line valid token count, so `denom` is intentionally
+                # unused here: using it would break the MG alignment.
                 _scalar = float(self.num_experts) / (
                     float(top_k) * float(max_seq_len) * float(max_seq_len)
                 )
                 seq_aux_loss = _per_expert.sum() * _scalar
+                # sequence-level loss is averaged over the batch; keep the
+                # single-line case bit-identical (no extra op).
+                _num_lines = _per_expert.shape[0]
+                if _num_lines > 1:
+                    seq_aux_loss = seq_aux_loss / float(_num_lines)
             else:
                 cost_coeff = routing_map.sum(axis=seq_axis, dtype="float32") / (
                     denom
@@ -1375,10 +1383,8 @@ class TopKRouter(StandardMoERouter):
         _log_moe_md5(gates, "gate_probs_sigmoid", self._layer_number)
 
         # Use clone() to ensure that the execution order of the grad nodes is consistent with EC.
-        if self.use_accuracy_compatible:
-            gates_ori = paddle.nn.functional.sigmoid(
-                logits.cast(paddle.float32)
-            ).cast(logits.dtype)
+        if self.use_accuracy_compatible and not use_split:
+            gates_ori = self.gate_score_func(logits).cast(logits.dtype)
             if input_ids_none_zero_mask is not None:
                 gates_ori = gates_ori * valid_mask
         else:

--- a/src/paddlefleet/transformer/moe/moe_utils.py
+++ b/src/paddlefleet/transformer/moe/moe_utils.py
@@ -159,28 +159,34 @@ class _UnpermuteGatherSumAlignedPyLayer(PyLayer):
     def forward(
         ctx,
         permuted_tokens,
-        reverse_indices_flat,
+        gather_index_flat,
+        valid_rows,
         num_total_tokens,
         num_tokens,
         topk,
         hidden,
+        has_padding,
     ):
         ctx.input_dtype = permuted_tokens.dtype
         ctx.num_total_tokens = num_total_tokens
         ctx.num_tokens = num_tokens
         ctx.topk = topk
         ctx.hidden = hidden
-        ctx.save_for_backward(reverse_indices_flat)
-        gathered = permuted_tokens.index_select(
-            axis=0, index=reverse_indices_flat
-        )
+        ctx.has_padding = has_padding
+        ctx.save_for_backward(gather_index_flat, valid_rows)
+        gathered = permuted_tokens.index_select(axis=0, index=gather_index_flat)
         gathered = gathered.reshape([num_tokens, topk, hidden])
+        if has_padding:
+            # Padding rows point at slot 0; force their output to zero.
+            gathered = gathered * valid_rows.cast(gathered.dtype).reshape(
+                [num_tokens, 1, 1]
+            )
         output_tokens = gathered.sum(axis=1)
         return output_tokens.cast(ctx.input_dtype)
 
     @staticmethod
     def backward(ctx, grad_out):
-        (reverse_indices_flat,) = ctx.saved_tensor()
+        gather_index_flat, valid_rows = ctx.saved_tensor()
         # Broadcast in fp32: [N, H] → [N, topk, H] → [N*topk, H]
         grad_expand = (
             grad_out.cast("float32")
@@ -190,15 +196,85 @@ class _UnpermuteGatherSumAlignedPyLayer(PyLayer):
         )
         N_total = ctx.num_total_tokens
         inverse_perm = paddle.zeros([N_total], dtype="int64")
-        src_idx = paddle.arange(ctx.num_tokens * ctx.topk, dtype="int64")
+        slot_idx = paddle.arange(ctx.num_tokens * ctx.topk, dtype="int64")
+        if ctx.has_padding:
+            # Only slots of valid rows map to real permuted rows.
+            slot_valid = (
+                valid_rows.cast(paddle.bool)
+                .unsqueeze(1)
+                .expand([ctx.num_tokens, ctx.topk])
+                .reshape([-1])
+            )
+            src_idx = slot_idx.masked_select(slot_valid)
+            dst_idx = gather_index_flat.masked_select(slot_valid)
+        else:
+            src_idx = slot_idx
+            dst_idx = gather_index_flat
         inverse_perm = paddle.scatter(
             inverse_perm,
-            reverse_indices_flat,
+            dst_idx,
             src_idx,
             overwrite=True,  # UNIQUE indices → deterministic
         )
         grad_permuted = grad_expand.index_select(axis=0, index=inverse_perm)
         return grad_permuted.cast(ctx.input_dtype)
+
+
+def _build_aligned_gather_index(routing_map: paddle.Tensor):
+    """Build the (token, k) → permuted-row index map for aligned permute.
+
+    Router zeroes the routing row of padding tokens, so a routing map may mix
+    valid rows (exactly ``topk`` experts) with all-zero rows. Returns:
+
+    - ``gather_index_flat``: [num_tokens * topk] int64. Slots of padding rows
+      are filled with 0 and must be masked out by ``valid_rows``.
+    - ``valid_rows``: [num_tokens] bool, False for all-zero (padding) rows.
+    - ``topk``: routed experts per valid row (0 when every row is padding).
+    """
+    routing_map_bool = routing_map.cast(paddle.bool)
+    num_tokens, num_experts = routing_map_bool.shape
+
+    rm_int_T = routing_map_bool.T.contiguous().cast("int64")  # [E, N]
+    tokens_per_expert = rm_int_T.sum(axis=-1)
+    expert_offsets = paddle.zeros([num_experts + 1], dtype="int64")
+    expert_offsets[1:] = paddle.cumsum(tokens_per_expert, axis=0)
+    global_position_per_token = (
+        rm_int_T.cumsum(axis=-1) - 1 + expert_offsets[:-1].unsqueeze(1)
+    ).T  # [N, E]
+
+    per_token_k = routing_map_bool.cast("int64").sum(axis=-1)
+    valid_rows = per_token_k > 0
+    valid_ks = per_token_k.masked_select(valid_rows)
+    num_valid = int(valid_rows.cast("int64").sum().item())
+    if num_valid == 0:
+        topk = 0
+    else:
+        topk = int(valid_ks.max().item())
+        if int(valid_ks.min().item()) != topk:
+            raise ValueError(
+                "use_accuracy_compatible requires a fixed top-k for all "
+                "valid (non-padding) tokens."
+            )
+
+    gather_index = paddle.zeros([num_tokens, topk], dtype="int64")
+    if topk > 0:
+        flat_valid = paddle.masked_select(
+            global_position_per_token * routing_map_bool.cast("int64"),
+            routing_map_bool,
+        ).reshape([num_valid, topk])
+        if num_valid == num_tokens:
+            gather_index = flat_valid
+        else:
+            gather_index = paddle.scatter(
+                gather_index,
+                paddle.nonzero(valid_rows).reshape([-1]),
+                flat_valid,
+                overwrite=True,
+            )
+    gather_index_flat = gather_index.reshape([num_tokens * topk])
+    gather_index_flat.stop_gradient = True
+    valid_rows.stop_gradient = True
+    return gather_index_flat, valid_rows, topk, num_valid < num_tokens
 
 
 def _unpermute_gather_sum_aligned(
@@ -208,40 +284,23 @@ def _unpermute_gather_sum_aligned(
     routing_map: paddle.Tensor,
 ) -> paddle.Tensor:
     num_tokens, hidden = restore_shape[0], restore_shape[-1]
-    num_experts = routing_map.shape[1]
     num_total_tokens = permuted_tokens.shape[0]
 
-    routing_map_bool = routing_map.cast(paddle.bool)
-    routing_map_T = routing_map_bool.T.contiguous()  # [num_experts, num_tokens]
-
-    tokens_per_expert = routing_map_T.cast("int64").sum(
-        axis=-1
-    )  # [num_experts]
-    expert_offsets = paddle.zeros([num_experts + 1], dtype="int64")
-    expert_offsets[1:] = paddle.cumsum(tokens_per_expert, axis=0)
-
-    position_in_expert_T = (
-        routing_map_T.cast("int64").cumsum(axis=-1) - 1
-    )  # [num_experts, num_tokens]
-    global_position = position_in_expert_T + expert_offsets[:-1].unsqueeze(
-        1
-    )  # [num_experts, num_tokens]
-    global_position_per_token = global_position.T  # [num_tokens, num_experts]
-
-    topk = int(routing_map_bool.cast("int64").sum(axis=-1)[0].item())
-    valid_positions = global_position_per_token * routing_map_bool.cast("int64")
-    reverse_indices_flat = paddle.masked_select(
-        valid_positions, routing_map_bool
-    ).reshape([num_tokens * topk])
-    reverse_indices_flat.stop_gradient = True
+    gather_index_flat, valid_rows, topk, has_padding = (
+        _build_aligned_gather_index(routing_map)
+    )
+    if topk == 0:
+        return paddle.zeros(restore_shape, dtype=permuted_tokens.dtype)
 
     return _UnpermuteGatherSumAlignedPyLayer.apply(
         permuted_tokens,
-        reverse_indices_flat,
+        gather_index_flat,
+        valid_rows,
         num_total_tokens,
         num_tokens,
         topk,
         hidden,
+        has_padding,
     )
 
 
@@ -277,27 +336,39 @@ class _PermuteAlignedPyLayer(PyLayer):
         ctx,
         tokens,
         sorted_indices,
-        reverse_indices_flat,
+        gather_index_flat,
+        valid_rows,
         num_tokens,
         topk,
         hidden,
+        has_padding,
     ):
         ctx.input_dtype = tokens.dtype
         ctx.num_tokens = num_tokens
         ctx.topk = topk
         ctx.hidden = hidden
-        ctx.save_for_backward(reverse_indices_flat)
+        ctx.has_padding = has_padding
+        ctx.save_for_backward(gather_index_flat, valid_rows)
         permuted_input = tokens.index_select(axis=0, index=sorted_indices)
         return permuted_input
 
     @staticmethod
     def backward(ctx, grad_permuted):
-        (reverse_indices_flat,) = ctx.saved_tensor()
+        gather_index_flat, valid_rows = ctx.saved_tensor()
+        if ctx.topk == 0:
+            return paddle.zeros(
+                [ctx.num_tokens, ctx.hidden], dtype=ctx.input_dtype
+            )
         # gather → [N*topk, H] in fp32 → reshape [N, topk, H] → sum(axis=1)
         gathered = grad_permuted.cast("float32").index_select(
-            axis=0, index=reverse_indices_flat
+            axis=0, index=gather_index_flat
         )
         gathered = gathered.reshape([ctx.num_tokens, ctx.topk, ctx.hidden])
+        if ctx.has_padding:
+            # Padding rows point at slot 0; their gradient must stay zero.
+            gathered = gathered * valid_rows.cast("float32").reshape(
+                [ctx.num_tokens, 1, 1]
+            )
         grad_tokens = gathered.sum(axis=1)
         return grad_tokens.cast(ctx.input_dtype)
 
@@ -337,42 +408,19 @@ def permute(
 
     if use_accuracy_compatible:
         sorted_indices.stop_gradient = True
-        rm_int = routing_map_bool_T.cast("int64")
-        tokens_per_expert = rm_int.sum(axis=-1)
-        expert_offsets = paddle.zeros([num_experts + 1], dtype="int64")
-        expert_offsets[1:] = paddle.cumsum(tokens_per_expert, axis=0)
-        position_in_expert_T = rm_int.cumsum(axis=-1) - 1
-        global_position = (
-            position_in_expert_T + expert_offsets[:-1].unsqueeze(1)
-        ).T
-
-        rm_bool_token = routing_map.cast(paddle.bool)
-        per_token_k = rm_bool_token.cast("int64").sum(axis=-1)
-        # Filter out padding tokens (k=0) before checking fixed top-k
-        valid_mask = per_token_k > 0
-        valid_ks = per_token_k.masked_select(valid_mask)
-        if valid_ks.numel() == 0:
-            topk_val = 0
-        else:
-            topk_val = int(valid_ks.max().item())
-            if int(valid_ks.min().item()) != topk_val:
-                raise ValueError(
-                    "use_accuracy_compatible requires a fixed top-k for all "
-                    "valid (non-padding) tokens."
-                )
-        valid_positions = global_position * rm_bool_token.cast("int64")
-        reverse_indices_flat = paddle.masked_select(
-            valid_positions, rm_bool_token
-        ).reshape([-1])
-        reverse_indices_flat.stop_gradient = True
+        gather_index_flat, valid_rows, topk_val, has_padding = (
+            _build_aligned_gather_index(routing_map)
+        )
 
         permuted_input = _PermuteAlignedPyLayer.apply(
             tokens,
             sorted_indices,
-            reverse_indices_flat,
+            gather_index_flat,
+            valid_rows,
             num_tokens,
             topk_val,
             hidden,
+            has_padding,
         )
     else:
         # use the mapping to permute the tokens

--- a/src/paddlefleet/transformer/moe/moe_utils.py
+++ b/src/paddlefleet/transformer/moe/moe_utils.py
@@ -154,6 +154,97 @@ def _unpermute_fp32_accum(
     return output_tokens.cast(permuted_tokens.dtype)
 
 
+class _UnpermuteGatherSumAlignedPyLayer(PyLayer):
+    @staticmethod
+    def forward(
+        ctx,
+        permuted_tokens,
+        reverse_indices_flat,
+        num_total_tokens,
+        num_tokens,
+        topk,
+        hidden,
+    ):
+        ctx.input_dtype = permuted_tokens.dtype
+        ctx.num_total_tokens = num_total_tokens
+        ctx.num_tokens = num_tokens
+        ctx.topk = topk
+        ctx.hidden = hidden
+        ctx.save_for_backward(reverse_indices_flat)
+        gathered = permuted_tokens.index_select(
+            axis=0, index=reverse_indices_flat
+        )
+        gathered = gathered.reshape([num_tokens, topk, hidden])
+        output_tokens = gathered.sum(axis=1)
+        return output_tokens.cast(ctx.input_dtype)
+
+    @staticmethod
+    def backward(ctx, grad_out):
+        (reverse_indices_flat,) = ctx.saved_tensor()
+        # Broadcast in fp32: [N, H] → [N, topk, H] → [N*topk, H]
+        grad_expand = (
+            grad_out.cast("float32")
+            .unsqueeze(1)
+            .expand([ctx.num_tokens, ctx.topk, ctx.hidden])
+            .reshape([ctx.num_tokens * ctx.topk, ctx.hidden])
+        )
+        N_total = ctx.num_total_tokens
+        inverse_perm = paddle.zeros([N_total], dtype="int64")
+        src_idx = paddle.arange(ctx.num_tokens * ctx.topk, dtype="int64")
+        inverse_perm = paddle.scatter(
+            inverse_perm,
+            reverse_indices_flat,
+            src_idx,
+            overwrite=True,  # UNIQUE indices → deterministic
+        )
+        grad_permuted = grad_expand.index_select(axis=0, index=inverse_perm)
+        return grad_permuted.cast(ctx.input_dtype)
+
+
+def _unpermute_gather_sum_aligned(
+    permuted_tokens: paddle.Tensor,
+    sorted_indices: paddle.Tensor,
+    restore_shape,
+    routing_map: paddle.Tensor,
+) -> paddle.Tensor:
+    num_tokens, hidden = restore_shape[0], restore_shape[-1]
+    num_experts = routing_map.shape[1]
+    num_total_tokens = permuted_tokens.shape[0]
+
+    routing_map_bool = routing_map.cast(paddle.bool)
+    routing_map_T = routing_map_bool.T.contiguous()  # [num_experts, num_tokens]
+
+    tokens_per_expert = routing_map_T.cast("int64").sum(
+        axis=-1
+    )  # [num_experts]
+    expert_offsets = paddle.zeros([num_experts + 1], dtype="int64")
+    expert_offsets[1:] = paddle.cumsum(tokens_per_expert, axis=0)
+
+    position_in_expert_T = (
+        routing_map_T.cast("int64").cumsum(axis=-1) - 1
+    )  # [num_experts, num_tokens]
+    global_position = position_in_expert_T + expert_offsets[:-1].unsqueeze(
+        1
+    )  # [num_experts, num_tokens]
+    global_position_per_token = global_position.T  # [num_tokens, num_experts]
+
+    topk = int(routing_map_bool.cast("int64").sum(axis=-1)[0].item())
+    valid_positions = global_position_per_token * routing_map_bool.cast("int64")
+    reverse_indices_flat = paddle.masked_select(
+        valid_positions, routing_map_bool
+    ).reshape([num_tokens * topk])
+    reverse_indices_flat.stop_gradient = True
+
+    return _UnpermuteGatherSumAlignedPyLayer.apply(
+        permuted_tokens,
+        reverse_indices_flat,
+        num_total_tokens,
+        num_tokens,
+        topk,
+        hidden,
+    )
+
+
 class ApplyPermutedProbs(PyLayer):
     """tokens * probs with fp32-accumulated probs gradient."""
 
@@ -180,11 +271,43 @@ def barrier_ep(ep_group):
     paddle.distributed.barrier(ep_group)
 
 
+class _PermuteAlignedPyLayer(PyLayer):
+    @staticmethod
+    def forward(
+        ctx,
+        tokens,
+        sorted_indices,
+        reverse_indices_flat,
+        num_tokens,
+        topk,
+        hidden,
+    ):
+        ctx.input_dtype = tokens.dtype
+        ctx.num_tokens = num_tokens
+        ctx.topk = topk
+        ctx.hidden = hidden
+        ctx.save_for_backward(reverse_indices_flat)
+        permuted_input = tokens.index_select(axis=0, index=sorted_indices)
+        return permuted_input
+
+    @staticmethod
+    def backward(ctx, grad_permuted):
+        (reverse_indices_flat,) = ctx.saved_tensor()
+        # gather → [N*topk, H] in fp32 → reshape [N, topk, H] → sum(axis=1)
+        gathered = grad_permuted.cast("float32").index_select(
+            axis=0, index=reverse_indices_flat
+        )
+        gathered = gathered.reshape([ctx.num_tokens, ctx.topk, ctx.hidden])
+        grad_tokens = gathered.sum(axis=1)
+        return grad_tokens.cast(ctx.input_dtype)
+
+
 def permute(
     tokens,
     routing_map,
     num_out_tokens: int | None = None,
     drop_and_pad: bool = False,
+    use_accuracy_compatible: bool = False,
 ):
     """Permute the tokens and probs based on the mask.
     Tokens with the same designated expert will be grouped together.
@@ -204,16 +327,56 @@ def permute(
     num_experts = routing_map.shape[1]
 
     # mask [num_tokens, num_experts] -> [num_experts, num_tokens]
-    routing_map = routing_map.cast(paddle.bool).T.contiguous()
+    routing_map_bool_T = routing_map.cast(paddle.bool).T.contiguous()
 
     # Create a dense expert-to-token mapping from the sparse token-to-expert mapping
     token_indices = (
         paddle.arange(num_tokens).unsqueeze(0).expand([num_experts, -1])
     )
-    sorted_indices = token_indices.masked_select(routing_map)
+    sorted_indices = token_indices.masked_select(routing_map_bool_T)
 
-    # use the mapping to permute the tokens
-    permuted_input = tokens.index_select(axis=0, index=sorted_indices)
+    if use_accuracy_compatible:
+        sorted_indices.stop_gradient = True
+        rm_int = routing_map_bool_T.cast("int64")
+        tokens_per_expert = rm_int.sum(axis=-1)
+        expert_offsets = paddle.zeros([num_experts + 1], dtype="int64")
+        expert_offsets[1:] = paddle.cumsum(tokens_per_expert, axis=0)
+        position_in_expert_T = rm_int.cumsum(axis=-1) - 1
+        global_position = (
+            position_in_expert_T + expert_offsets[:-1].unsqueeze(1)
+        ).T
+
+        rm_bool_token = routing_map.cast(paddle.bool)
+        per_token_k = rm_bool_token.cast("int64").sum(axis=-1)
+        # Filter out padding tokens (k=0) before checking fixed top-k
+        valid_mask = per_token_k > 0
+        valid_ks = per_token_k.masked_select(valid_mask)
+        if valid_ks.numel() == 0:
+            topk_val = 0
+        else:
+            topk_val = int(valid_ks.max().item())
+            if int(valid_ks.min().item()) != topk_val:
+                raise ValueError(
+                    "use_accuracy_compatible requires a fixed top-k for all "
+                    "valid (non-padding) tokens."
+                )
+        valid_positions = global_position * rm_bool_token.cast("int64")
+        reverse_indices_flat = paddle.masked_select(
+            valid_positions, rm_bool_token
+        ).reshape([-1])
+        reverse_indices_flat.stop_gradient = True
+
+        permuted_input = _PermuteAlignedPyLayer.apply(
+            tokens,
+            sorted_indices,
+            reverse_indices_flat,
+            num_tokens,
+            topk_val,
+            hidden,
+        )
+    else:
+        # use the mapping to permute the tokens
+        permuted_input = tokens.index_select(axis=0, index=sorted_indices)
 
     return permuted_input, sorted_indices
 
@@ -225,6 +388,7 @@ def unpermute(
     probs: paddle.Tensor = None,
     routing_map: paddle.Tensor = None,
     drop_and_pad: bool = False,
+    use_accuracy_compatible: bool = False,
 ):
     """
     Restore the original order of tokens after permutation. If probs are provided, it
@@ -258,6 +422,11 @@ def unpermute(
             )
         else:
             permuted_tokens = permuted_tokens * permuted_probs.unsqueeze(-1)
+
+    if use_accuracy_compatible and routing_map is not None:
+        return _unpermute_gather_sum_aligned(
+            permuted_tokens, sorted_indices, restore_shape, routing_map
+        )
 
     if use_accuracy_compatible_kernel():
         output_tokens = _unpermute_fp32_accum(

--- a/src/paddlefleet/transformer/moe/token_dispatcher.py
+++ b/src/paddlefleet/transformer/moe/token_dispatcher.py
@@ -563,12 +563,14 @@ class _DeepEPManager(_DispatchManager):
         num_experts: int | None = None,
         num_local_experts: int | None = None,
         moe_ep_barrier: bool = True,
+        use_accuracy_compatible: bool = False,
     ):
         self.group = group
         self.router_topk = router_topk
         self.num_experts = num_experts
         self.num_local_experts = num_local_experts
         self.moe_ep_barrier = moe_ep_barrier
+        self.use_accuracy_compatible = use_accuracy_compatible
 
         # Metadata
         self.token_indices = None
@@ -752,6 +754,7 @@ class _DeepEPManager(_DispatchManager):
             hidden_states,
             self.dispatched_routing_map,
             num_out_tokens=sum(self.tokens_per_expert),
+            use_accuracy_compatible=self.use_accuracy_compatible,
         )
         return hidden_states
 
@@ -768,6 +771,7 @@ class _DeepEPManager(_DispatchManager):
             restore_shape=self.hidden_shape_before_permute,
             routing_map=self.dispatched_routing_map,
             probs=self.dispatched_probs,
+            use_accuracy_compatible=self.use_accuracy_compatible,
         )
         return hidden_states.to(input_dtype)
 
@@ -843,9 +847,11 @@ class MoEFlexTokenDispatcher(MoETokenDispatcher):
         dispatcher_type: str | None = None,
         hybridep_buffer_configs: dict | None = None,
         moe_deep_gemm: bool = False,
+        use_accuracy_compatible: bool = False,
     ):
         super().__init__(ep_group)
 
+        self.use_accuracy_compatible = use_accuracy_compatible
         self.num_local_experts = num_local_experts
         assert self.ep_size > 1, "Flex token dispatcher requires EP > 1"
         manager_cls = (
@@ -863,6 +869,8 @@ class MoEFlexTokenDispatcher(MoETokenDispatcher):
         if manager_cls is _HybridEPManager:
             manager_kwargs["hybridep_buffer_configs"] = hybridep_buffer_configs
             manager_kwargs["moe_deep_gemm"] = moe_deep_gemm
+        else:
+            manager_kwargs["use_accuracy_compatible"] = use_accuracy_compatible
         self._comm_manager = manager_cls(**manager_kwargs)
 
     def dispatch_preprocess(
@@ -1012,6 +1020,7 @@ class AllToAllTokenDispatcher(nn.Layer):
         expert_model_parallel_size: int,
         num_experts_per_device: int,
         local_expert_indices: list,
+        use_accuracy_compatible: bool = False,
     ):
         nn.Layer.__init__(self)
         self.moe_group = moe_group
@@ -1019,6 +1028,7 @@ class AllToAllTokenDispatcher(nn.Layer):
         self.num_experts_per_device = num_experts_per_device
         self.local_expert_indices = local_expert_indices
         self.num_local_experts = len(local_expert_indices)
+        self.use_accuracy_compatible = use_accuracy_compatible
 
     def dispatch_preprocess(
         self,
@@ -1095,7 +1105,11 @@ class AllToAllTokenDispatcher(nn.Layer):
         (
             permutated_local_input_tokens,
             self.reversed_local_input_permutation_mapping,
-        ) = permute(reshaped_input, self.routing_map)
+        ) = permute(
+            reshaped_input,
+            self.routing_map,
+            use_accuracy_compatible=self.use_accuracy_compatible,
+        )
         if use_accuracy_compatible_kernel():
             num_routed_tokens = int(tokens_per_expert.sum().item())
             routing_map = self.routing_map.cast(paddle.bool).T.contiguous()
@@ -1221,6 +1235,7 @@ class AllToAllTokenDispatcher(nn.Layer):
             restore_shape=self.reshaped_input_shape,
             probs=(None if use_accuracy_compatible_kernel() else self.probs),
             routing_map=self.routing_map,
+            use_accuracy_compatible=self.use_accuracy_compatible,
         )
         return output
 

--- a/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_bias_swiglu_use_accuracy_compatible.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_ai_fused_bias_swiglu_use_accuracy_compatible.py
@@ -1,0 +1,201 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Coverage for the ``use_accuracy_compatible`` (eager) SwiGLU paths added in
+commit 80a72f9. These eager paths must be numerically equivalent to the fused
+paths while exercising the pure-python fallback branches."""
+
+import os
+import sys
+
+# Walk up to find the repo root.
+_test_file = os.path.abspath(__file__)
+_repo_root = _test_file
+for _ in range(10):
+    _repo_root = os.path.dirname(_repo_root)
+    if os.path.isdir(os.path.join(_repo_root, "src", "paddlefleet")):
+        break
+sys.path.insert(0, _repo_root)
+sys.path.insert(0, os.path.join(_repo_root, "src"))
+for _mod in list(sys.modules.keys()):
+    if _mod == "paddlefleet" or _mod.startswith("paddlefleet."):
+        del sys.modules[_mod]
+
+import unittest
+
+import numpy as np
+import paddle
+
+from paddlefleet.fusions.fused_bias_swiglu import (
+    BiasSwiGLUFunction,
+    SwiGLUFunction,
+    WeightedSwiGLUFunction,
+    bias_swiglu,
+    bias_swiglu_eager,
+    bias_swiglu_impl,
+    swiglu,
+    swiglu_back,
+    swiglu_back_eager,
+    swiglu_eager,
+    weighted_bias_swiglu_impl,
+    weighted_swiglu_back,
+    weighted_swiglu_back_eager,
+)
+
+
+class TestEagerForwardEquivalence(unittest.TestCase):
+    """Eager forward helpers must match their fused counterparts."""
+
+    def test_swiglu_eager_matches_swiglu(self):
+        y = paddle.randn([4, 16])
+        out = swiglu_eager(y)
+        self.assertEqual(out.shape, [4, 8])
+        np.testing.assert_allclose(
+            out.numpy(), swiglu(y).numpy(), rtol=1e-5, atol=1e-5
+        )
+
+    def test_bias_swiglu_eager_matches_bias_swiglu(self):
+        y = paddle.randn([4, 16])
+        b = paddle.randn([16])
+        np.testing.assert_allclose(
+            bias_swiglu_eager(y, b).numpy(),
+            bias_swiglu(y, b).numpy(),
+            rtol=1e-5,
+            atol=1e-5,
+        )
+
+
+class TestEagerBackwardEquivalence(unittest.TestCase):
+    """Eager backward helpers must match the native-grad-backed versions."""
+
+    def test_swiglu_back_eager_matches_native(self):
+        paddle.seed(0)
+        g = paddle.randn([2, 4])
+        y = paddle.randn([2, 8])
+        np.testing.assert_allclose(
+            swiglu_back_eager(g, y).numpy(),
+            swiglu_back(g, y).numpy(),
+            rtol=1e-4,
+            atol=1e-4,
+        )
+
+    def test_weighted_swiglu_back_eager_matches_native(self):
+        paddle.seed(0)
+        g = paddle.randn([2, 4])
+        y = paddle.randn([2, 8])
+        w = paddle.randn([2, 1])
+        ig_e, wg_e = weighted_swiglu_back_eager(g, y, w)
+        ig_s, wg_s = weighted_swiglu_back(g, y, w)
+        self.assertEqual(ig_e.shape, [2, 8])
+        self.assertEqual(wg_e.shape, [2, 1])
+        np.testing.assert_allclose(
+            ig_e.numpy(), ig_s.numpy(), rtol=1e-4, atol=1e-4
+        )
+        np.testing.assert_allclose(
+            wg_e.numpy(), wg_s.numpy(), rtol=1e-4, atol=1e-4
+        )
+
+
+class TestPyLayerAccuracyCompatible(unittest.TestCase):
+    """PyLayer forward+backward through the use_accuracy_compatible branch."""
+
+    def test_swiglu_function_eager_fwd_bwd(self):
+        x = paddle.randn([4, 16]).astype("float32")
+        x.stop_gradient = False
+        out = SwiGLUFunction.apply(x, False, False, None, True)
+        self.assertEqual(out.shape, [4, 8])
+        np.testing.assert_allclose(
+            out.numpy(), swiglu_eager(x).numpy(), rtol=1e-5, atol=1e-5
+        )
+        out.sum().backward()
+        self.assertEqual(x.grad.shape, [4, 16])
+
+    def test_bias_swiglu_function_eager_fwd_bwd(self):
+        x = paddle.randn([4, 16]).astype("float32")
+        x.stop_gradient = False
+        b = paddle.randn([16]).astype("float32")
+        b.stop_gradient = False
+        out = BiasSwiGLUFunction.apply(x, b, False, False, None, True)
+        self.assertEqual(out.shape, [4, 8])
+        np.testing.assert_allclose(
+            out.numpy(),
+            bias_swiglu_eager(x, b).numpy(),
+            rtol=1e-5,
+            atol=1e-5,
+        )
+        out.sum().backward()
+        self.assertEqual(x.grad.shape, [4, 16])
+        self.assertIsNotNone(b.grad)
+
+    def test_weighted_swiglu_function_eager_fwd_bwd(self):
+        x = paddle.randn([4, 16]).astype("float32")
+        x.stop_gradient = False
+        w = paddle.ones([4, 1]).astype("float32")
+        w.stop_gradient = False
+        out = WeightedSwiGLUFunction.apply(x, w, False, None, True)
+        self.assertEqual(out.shape, [4, 8])
+        # weights are all ones => equals plain eager swiglu
+        np.testing.assert_allclose(
+            out.numpy(), swiglu_eager(x).numpy(), rtol=1e-5, atol=1e-5
+        )
+        out.sum().backward()
+        self.assertEqual(x.grad.shape, [4, 16])
+        self.assertEqual(w.grad.shape, [4, 1])
+
+    def test_weighted_swiglu_function_eager_dtype_preserved(self):
+        x = paddle.randn([3, 8]).astype("float32")
+        w = paddle.randn([3, 1]).astype("float32")
+        out = WeightedSwiGLUFunction.apply(x, w, False, None, True)
+        self.assertEqual(out.dtype, paddle.float32)
+        self.assertEqual(out.shape, [3, 4])
+
+
+class TestImplAccuracyCompatible(unittest.TestCase):
+    """bias_swiglu_impl / weighted_bias_swiglu_impl accuracy-compatible path."""
+
+    def test_bias_swiglu_impl_eager_with_bias(self):
+        inp = paddle.randn([4, 16])
+        inp.stop_gradient = False
+        b = paddle.randn([16])
+        b.stop_gradient = False
+        out = bias_swiglu_impl(inp, b, use_accuracy_compatible=True)
+        self.assertEqual(out.shape, [4, 8])
+        grads = paddle.grad([out.sum()], [inp, b])
+        self.assertEqual(grads[0].shape, [4, 16])
+        # BiasSwiGLUFunction returns the same tensor for input and bias grads.
+        self.assertIsNotNone(grads[1])
+
+    def test_bias_swiglu_impl_eager_no_bias_3d(self):
+        inp = paddle.randn([2, 4, 16])
+        inp.stop_gradient = False
+        out = bias_swiglu_impl(inp, None, use_accuracy_compatible=True)
+        self.assertEqual(out.shape, [2, 4, 8])
+        grads = paddle.grad([out.sum()], [inp])
+        self.assertEqual(grads[0].shape, [2, 4, 16])
+
+    def test_weighted_bias_swiglu_impl_eager_no_bias(self):
+        inp = paddle.randn([4, 16])
+        inp.stop_gradient = False
+        w = paddle.randn([4, 1])
+        w.stop_gradient = False
+        out = weighted_bias_swiglu_impl(
+            inp, None, w, use_accuracy_compatible=True
+        )
+        self.assertEqual(out.shape, [4, 8])
+        grads = paddle.grad([out.sum()], [inp, w])
+        self.assertEqual(grads[0].shape, [4, 16])
+        self.assertEqual(grads[1].shape, [4, 1])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_router_use_accuracy_compatible.py
+++ b/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_router_use_accuracy_compatible.py
@@ -83,10 +83,9 @@ class TestRouterAccuracyCompatible(unittest.TestCase):
         self.assertTrue(router.use_accuracy_compatible)
 
     @patch(_CP_PATCH, return_value=1)
-    def test_seq_aux_loss_scalar_and_formula(self, _cp):
+    def test_seq_aux_loss_scalar_and_matches_default(self, _cp):
         from paddlefleet.transformer.moe.moe_router import StandardMoERouter
 
-        router = StandardMoERouter(_make_router_config())
         B, S, E, K = 2, 3, 4, 2
         paddle.seed(0)
         probs = paddle.nn.functional.softmax(paddle.randn([B * S, E]), axis=-1)
@@ -95,18 +94,74 @@ class TestRouterAccuracyCompatible(unittest.TestCase):
             idx, paddle.to_tensor(1.0), axis=-1
         )
 
-        loss = router._cal_seq_aux_loss(probs, K, routing_map, S, B)
-        self.assertEqual(loss.shape, [])
-
-        # Reference computation of the accuracy-compatible branch.
-        rm3 = routing_map.reshape([B, S, E])
-        probs3 = probs.reshape([B, S, E])
-        tokens_per_expert = rm3.sum(axis=1, dtype="float32")
-        aggregated = probs3.sum(axis=1)
-        scalar = float(E) / (float(K) * float(S) * float(S))
-        expected = (aggregated * tokens_per_expert).sum() * scalar
+        aligned = StandardMoERouter(_make_router_config())
+        default = StandardMoERouter(
+            _make_router_config(use_accuracy_compatible=False)
+        )
+        loss_a = aligned._cal_seq_aux_loss(probs, K, routing_map, S, B)
+        loss_d = default._cal_seq_aux_loss(probs, K, routing_map, S, B)
+        self.assertEqual(loss_a.shape, [])
+        # The aligned branch only reorders float ops; the value must match the
+        # reference (batch-mean) formula of the default branch.
         np.testing.assert_allclose(
-            loss.numpy(), expected.numpy(), rtol=1e-5, atol=1e-5
+            loss_a.numpy(), loss_d.numpy(), rtol=1e-5, atol=1e-6
+        )
+
+    @patch(_CP_PATCH, return_value=1)
+    def test_seq_aux_loss_is_batch_mean(self, _cp):
+        """Duplicating a sequence across the batch must not change the loss."""
+        from paddlefleet.transformer.moe.moe_router import StandardMoERouter
+
+        S, E, K = 3, 4, 2
+        paddle.seed(3)
+        probs1 = paddle.nn.functional.softmax(paddle.randn([S, E]), axis=-1)
+        idx1 = paddle.topk(probs1, k=K, axis=-1).indices
+        rm1 = paddle.zeros([S, E]).put_along_axis_(
+            idx1, paddle.to_tensor(1.0), axis=-1
+        )
+
+        router = StandardMoERouter(_make_router_config())
+        loss_b1 = router._cal_seq_aux_loss(probs1, K, rm1, S, 1)
+        loss_b2 = router._cal_seq_aux_loss(
+            paddle.concat([probs1, probs1], axis=0),
+            K,
+            paddle.concat([rm1, rm1], axis=0),
+            S,
+            2,
+        )
+        np.testing.assert_allclose(
+            loss_b2.numpy(), loss_b1.numpy(), rtol=1e-6, atol=1e-6
+        )
+
+    @patch(_CP_PATCH, return_value=1)
+    def test_seq_aux_loss_padding_uses_sequence_length(self, _cp):
+        """The aligned branch follows MG and normalizes by the (fixed) sequence
+        length, so per-line padding info must not change the loss. Covers B > 1
+        with a different padding length per line."""
+        from paddlefleet.transformer.moe.moe_router import StandardMoERouter
+
+        B, S, E, K = 3, 5, 4, 2
+        valid_lens = [5, 3, 1]
+        paddle.seed(5)
+        probs = paddle.nn.functional.softmax(paddle.randn([B, S, E]), axis=-1)
+        idx = paddle.topk(probs, k=K, axis=-1).indices
+        rm = paddle.zeros([B, S, E]).put_along_axis_(
+            idx, paddle.to_tensor(1.0), axis=-1
+        )
+        ids = paddle.zeros([B, S], dtype="int64")
+        for b, n in enumerate(valid_lens):
+            ids[b, :n] = 1
+            if n < S:
+                probs[b, n:] = 0.0
+                rm[b, n:] = 0.0
+
+        router = StandardMoERouter(_make_router_config())
+        args = (probs.reshape([B * S, E]), K, rm.reshape([B * S, E]), S, B)
+        loss_with_ids = router._cal_seq_aux_loss(*args, input_ids=ids)
+        loss_no_ids = router._cal_seq_aux_loss(*args)
+        self.assertTrue(bool(paddle.isfinite(loss_with_ids).all().numpy()))
+        np.testing.assert_allclose(
+            loss_with_ids.numpy(), loss_no_ids.numpy(), rtol=1e-6, atol=1e-6
         )
 
     @patch(_CP_PATCH, return_value=1)

--- a/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_router_use_accuracy_compatible.py
+++ b/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_router_use_accuracy_compatible.py
@@ -1,0 +1,170 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Coverage for the ``use_accuracy_compatible`` router branches added in
+commit 80a72f9: MG-aligned seq aux-loss and gather_nd top-k weight lookup."""
+
+import os
+import sys
+
+# Walk up to find the repo root and import the working-tree source so the
+# ``use_accuracy_compatible`` branches under test are the ones exercised
+# (the installed paddlefleet may predate this commit).
+_test_file = os.path.abspath(__file__)
+_repo_root = _test_file
+for _ in range(10):
+    _repo_root = os.path.dirname(_repo_root)
+    if os.path.isdir(os.path.join(_repo_root, "src", "paddlefleet")):
+        break
+sys.path.insert(0, _repo_root)
+sys.path.insert(0, os.path.join(_repo_root, "src"))
+for _mod in list(sys.modules.keys()):
+    if _mod == "paddlefleet" or _mod.startswith("paddlefleet."):
+        del sys.modules[_mod]
+
+import unittest
+from unittest.mock import patch
+
+import numpy as np
+import paddle
+
+
+def _make_router_config(**overrides):
+    from paddlefleet.transformer.transformer_config import TransformerConfig
+
+    defaults = {
+        "hidden_size": 64,
+        "num_attention_heads": 2,
+        "intermediate_size": 256,
+        "n_routed_experts": 4,
+        "num_experts_per_tok": 2,
+        "sequence_parallel": False,
+        "tensor_model_parallel_size": 1,
+        "topk_method": "greedy",
+        "norm_topk_prob": True,
+        "scoring_func": "softmax",
+        "n_group": 1,
+        "topk_group": 1,
+        "routed_scaling_factor": 1.0,
+        "routed_scaling_factor_learnable": False,
+        "moe_router_force_load_balancing": False,
+        "moe_router_load_balancing_type": "aux_loss",
+        "moe_deep_gemm": False,
+        "router_aux_loss_coef": 0.01,
+        "router_z_loss_coef": None,
+        "moe_n_hash_layers": 0,
+        "use_accuracy_compatible": True,
+    }
+    defaults.update(overrides)
+    return TransformerConfig(**defaults)
+
+
+_CP_PATCH = (
+    "paddlefleet.transformer.moe.moe_router.get_context_parallel_world_size"
+)
+
+
+class TestRouterAccuracyCompatible(unittest.TestCase):
+    @patch(_CP_PATCH, return_value=1)
+    def test_use_accuracy_compatible_flag_set(self, _cp):
+        from paddlefleet.transformer.moe.moe_router import StandardMoERouter
+
+        router = StandardMoERouter(_make_router_config())
+        self.assertTrue(router.use_accuracy_compatible)
+
+    @patch(_CP_PATCH, return_value=1)
+    def test_seq_aux_loss_scalar_and_formula(self, _cp):
+        from paddlefleet.transformer.moe.moe_router import StandardMoERouter
+
+        router = StandardMoERouter(_make_router_config())
+        B, S, E, K = 2, 3, 4, 2
+        paddle.seed(0)
+        probs = paddle.nn.functional.softmax(paddle.randn([B * S, E]), axis=-1)
+        idx = paddle.topk(probs, k=K, axis=-1).indices
+        routing_map = paddle.zeros([B * S, E]).put_along_axis_(
+            idx, paddle.to_tensor(1.0), axis=-1
+        )
+
+        loss = router._cal_seq_aux_loss(probs, K, routing_map, S, B)
+        self.assertEqual(loss.shape, [])
+
+        # Reference computation of the accuracy-compatible branch.
+        rm3 = routing_map.reshape([B, S, E])
+        probs3 = probs.reshape([B, S, E])
+        tokens_per_expert = rm3.sum(axis=1, dtype="float32")
+        aggregated = probs3.sum(axis=1)
+        scalar = float(E) / (float(K) * float(S) * float(S))
+        expected = (aggregated * tokens_per_expert).sum() * scalar
+        np.testing.assert_allclose(
+            loss.numpy(), expected.numpy(), rtol=1e-5, atol=1e-5
+        )
+
+    @patch(_CP_PATCH, return_value=1)
+    def test_seq_aux_loss_matches_default_router(self, _cp):
+        """The recomputed routing_map means the aligned loss is a well-defined
+        scalar; the default router path must also produce a finite scalar."""
+        from paddlefleet.transformer.moe.moe_router import StandardMoERouter
+
+        B, S, E, K = 2, 4, 4, 2
+        paddle.seed(1)
+        probs = paddle.nn.functional.softmax(paddle.randn([B * S, E]), axis=-1)
+        idx = paddle.topk(probs, k=K, axis=-1).indices
+        routing_map = paddle.zeros([B * S, E]).put_along_axis_(
+            idx, paddle.to_tensor(1.0), axis=-1
+        )
+
+        aligned = StandardMoERouter(_make_router_config())
+        default = StandardMoERouter(
+            _make_router_config(use_accuracy_compatible=False)
+        )
+        loss_a = aligned._cal_seq_aux_loss(probs, K, routing_map, S, B)
+        loss_d = default._cal_seq_aux_loss(probs, K, routing_map, S, B)
+        self.assertEqual(loss_a.shape, [])
+        self.assertEqual(loss_d.shape, [])
+        self.assertTrue(bool(paddle.isfinite(loss_a).all().numpy()))
+        self.assertTrue(bool(paddle.isfinite(loss_d).all().numpy()))
+
+    @patch(_CP_PATCH, return_value=1)
+    def test_topk_noaux_tc_gather_nd_matches_default(self, _cp):
+        from paddlefleet.transformer.moe.moe_router import StandardMoERouter
+
+        E, K = 4, 2
+        paddle.seed(2)
+        scores = paddle.nn.functional.softmax(paddle.randn([5, E]), axis=-1)
+
+        aligned = StandardMoERouter(_make_router_config(topk_method="noaux_tc"))
+        default = StandardMoERouter(
+            _make_router_config(
+                topk_method="noaux_tc", use_accuracy_compatible=False
+            )
+        )
+        # Force identical correction bias so routing decisions match.
+        default.e_score_correction_bias.set_value(
+            aligned.e_score_correction_bias
+        )
+
+        tw_a, ti_a = aligned._topk_noaux_tc(
+            scores, k=K, n_group=1, topk_group=1
+        )
+        tw_d, ti_d = default._topk_noaux_tc(
+            scores, k=K, n_group=1, topk_group=1
+        )
+        self.assertEqual(tw_a.shape, [5, K])
+        np.testing.assert_array_equal(ti_a.numpy(), ti_d.numpy())
+        np.testing.assert_allclose(
+            tw_a.numpy(), tw_d.numpy(), rtol=1e-6, atol=1e-6
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_router_use_accuracy_compatible.py
+++ b/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_router_use_accuracy_compatible.py
@@ -14,29 +14,36 @@
 """Coverage for the ``use_accuracy_compatible`` router branches added in
 commit 80a72f9: MG-aligned seq aux-loss and gather_nd top-k weight lookup."""
 
-import os
-import sys
-
-# Walk up to find the repo root and import the working-tree source so the
-# ``use_accuracy_compatible`` branches under test are the ones exercised
-# (the installed paddlefleet may predate this commit).
-_test_file = os.path.abspath(__file__)
-_repo_root = _test_file
-for _ in range(10):
-    _repo_root = os.path.dirname(_repo_root)
-    if os.path.isdir(os.path.join(_repo_root, "src", "paddlefleet")):
-        break
-sys.path.insert(0, _repo_root)
-sys.path.insert(0, os.path.join(_repo_root, "src"))
-for _mod in list(sys.modules.keys()):
-    if _mod == "paddlefleet" or _mod.startswith("paddlefleet."):
-        del sys.modules[_mod]
-
 import unittest
 from unittest.mock import patch
 
 import numpy as np
 import paddle
+
+
+def _mg_seq_aux_loss_ref(probs, routing_map, top_k, num_experts, batch_size):
+    """Independent reference mirroring Megatron-LM.
+
+    ``switch_load_balancing_loss_func`` (moe_utils.py) computes
+    ``sum(agg_probs_per_expert * tokens_per_expert) * E / (topk * T^2)`` and
+    ``_apply_seq_aux_loss`` (router.py) divides it by ``bsz``, where
+    ``get_tokens_per_expert_and_token_count`` sets
+    ``T = tokens_per_expert.sum() / (topk * bsz)`` (the valid routing token
+    count per line) once a padding mask is in play.
+    """
+    p = probs.numpy().reshape([batch_size, -1, num_experts]).astype("float64")
+    rm = (
+        routing_map.numpy()
+        .reshape([batch_size, -1, num_experts])
+        .astype("float64")
+    )
+    tokens_per_expert = rm.sum(axis=1)  # [B, E]
+    aggregated = p.sum(axis=1)  # [B, E]
+    total_num_tokens = tokens_per_expert.sum() / (top_k * batch_size)
+    loss = (aggregated * tokens_per_expert).sum() * (
+        num_experts / (top_k * total_num_tokens * total_num_tokens)
+    )
+    return loss / batch_size
 
 
 def _make_router_config(**overrides):
@@ -134,10 +141,9 @@ class TestRouterAccuracyCompatible(unittest.TestCase):
         )
 
     @patch(_CP_PATCH, return_value=1)
-    def test_seq_aux_loss_padding_uses_sequence_length(self, _cp):
-        """The aligned branch follows MG and normalizes by the (fixed) sequence
-        length, so per-line padding info must not change the loss. Covers B > 1
-        with a different padding length per line."""
+    def test_seq_aux_loss_padding_uses_valid_token_count(self, _cp):
+        """With padding rows the denominator must be the valid routing token
+        count per line (MG semantics), not the fixed sequence length."""
         from paddlefleet.transformer.moe.moe_router import StandardMoERouter
 
         B, S, E, K = 3, 5, 4, 2
@@ -156,12 +162,51 @@ class TestRouterAccuracyCompatible(unittest.TestCase):
                 rm[b, n:] = 0.0
 
         router = StandardMoERouter(_make_router_config())
-        args = (probs.reshape([B * S, E]), K, rm.reshape([B * S, E]), S, B)
-        loss_with_ids = router._cal_seq_aux_loss(*args, input_ids=ids)
-        loss_no_ids = router._cal_seq_aux_loss(*args)
-        self.assertTrue(bool(paddle.isfinite(loss_with_ids).all().numpy()))
+        loss = router._cal_seq_aux_loss(
+            probs.reshape([B * S, E]),
+            K,
+            rm.reshape([B * S, E]),
+            S,
+            B,
+            input_ids=ids,
+        )
+
+        expected = _mg_seq_aux_loss_ref(
+            probs.reshape([B * S, E]), rm.reshape([B * S, E]), K, E, B
+        )
         np.testing.assert_allclose(
-            loss_with_ids.numpy(), loss_no_ids.numpy(), rtol=1e-6, atol=1e-6
+            loss.numpy(), np.float32(expected), rtol=1e-5, atol=1e-7
+        )
+        # Guard against normalizing by the fixed sequence length: the mean
+        # valid length is 3, so an S=5 normalization is off by (3/5)^2.
+        mean_valid = sum(valid_lens) / B
+        seq_len_normalized = expected * (mean_valid / S) ** 2
+        self.assertFalse(
+            np.allclose(
+                loss.numpy(),
+                np.float32(seq_len_normalized),
+                rtol=1e-3,
+                atol=1e-8,
+            )
+        )
+
+    @patch(_CP_PATCH, return_value=1)
+    def test_seq_aux_loss_matches_mg_reference_without_padding(self, _cp):
+        from paddlefleet.transformer.moe.moe_router import StandardMoERouter
+
+        B, S, E, K = 2, 4, 4, 2
+        paddle.seed(6)
+        probs = paddle.nn.functional.softmax(paddle.randn([B * S, E]), axis=-1)
+        idx = paddle.topk(probs, k=K, axis=-1).indices
+        rm = paddle.zeros([B * S, E]).put_along_axis_(
+            idx, paddle.to_tensor(1.0), axis=-1
+        )
+
+        router = StandardMoERouter(_make_router_config())
+        loss = router._cal_seq_aux_loss(probs, K, rm, S, B)
+        expected = _mg_seq_aux_loss_ref(probs, rm, K, E, B)
+        np.testing.assert_allclose(
+            loss.numpy(), np.float32(expected), rtol=1e-5, atol=1e-7
         )
 
     @patch(_CP_PATCH, return_value=1)

--- a/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_utils_use_accuracy_compatible.py
+++ b/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_utils_use_accuracy_compatible.py
@@ -1,0 +1,161 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Coverage for the ``use_accuracy_compatible`` permute/unpermute paths added
+in commit 80a72f9 (MG-aligned gather/sum permute + unpermute). The aligned
+paths must be numerically equivalent to the default paths in both forward and
+backward while exercising the dedicated PyLayers."""
+
+import os
+import sys
+
+_test_file = os.path.abspath(__file__)
+_repo_root = _test_file
+for _ in range(10):
+    _repo_root = os.path.dirname(_repo_root)
+    if os.path.isdir(os.path.join(_repo_root, "src", "paddlefleet")):
+        break
+sys.path.insert(0, _repo_root)
+sys.path.insert(0, os.path.join(_repo_root, "src"))
+for _mod in list(sys.modules.keys()):
+    if _mod == "paddlefleet" or _mod.startswith("paddlefleet."):
+        del sys.modules[_mod]
+
+import unittest
+
+import numpy as np
+import paddle
+
+from paddlefleet.transformer.moe.moe_utils import permute, unpermute
+
+
+def _make_fixed_topk_routing_map(num_tokens, num_experts, topk, seed=0):
+    """Build a [num_tokens, num_experts] 0/1 routing map with a fixed top-k."""
+    paddle.seed(seed)
+    scores = paddle.randn([num_tokens, num_experts])
+    idx = paddle.topk(scores, k=topk, axis=-1).indices
+    routing_map = paddle.zeros([num_tokens, num_experts])
+    routing_map = routing_map.put_along_axis_(
+        idx, paddle.to_tensor(1.0), axis=-1
+    )
+    return routing_map
+
+
+class TestPermuteAligned(unittest.TestCase):
+    def test_permute_forward_matches_default(self):
+        rm = _make_fixed_topk_routing_map(6, 4, 2)
+        tokens = paddle.randn([6, 8])
+        p_a, si_a = permute(tokens, rm, use_accuracy_compatible=True)
+        p_s, si_s = permute(tokens, rm, use_accuracy_compatible=False)
+        np.testing.assert_allclose(p_a.numpy(), p_s.numpy(), atol=1e-6)
+        np.testing.assert_array_equal(si_a.numpy(), si_s.numpy())
+
+    def test_permute_backward_sums_topk_copies(self):
+        topk = 2
+        rm = _make_fixed_topk_routing_map(5, 3, topk)
+        tokens = paddle.randn([5, 4])
+        tokens.stop_gradient = False
+        permuted, _ = permute(tokens, rm, use_accuracy_compatible=True)
+        permuted.sum().backward()
+        # Each token is copied to `topk` experts; d(sum)/d(token) == topk.
+        self.assertEqual(tokens.grad.shape, [5, 4])
+        np.testing.assert_allclose(
+            tokens.grad.numpy(),
+            np.full([5, 4], float(topk), dtype="float32"),
+            atol=1e-6,
+        )
+
+    def test_permute_variable_topk_raises(self):
+        # token 0 -> 2 experts, token 1 -> 1 expert => not a fixed top-k.
+        rm = paddle.to_tensor(
+            [[1.0, 1.0, 0.0], [1.0, 0.0, 0.0]], dtype="float32"
+        )
+        tokens = paddle.randn([2, 4])
+        with self.assertRaises(ValueError):
+            permute(tokens, rm, use_accuracy_compatible=True)
+
+    def test_permute_all_padding_tokens(self):
+        # No token routed anywhere => topk_val == 0, must not raise.
+        rm = paddle.zeros([3, 4])
+        tokens = paddle.randn([3, 8])
+        permuted, sorted_indices = permute(
+            tokens, rm, use_accuracy_compatible=True
+        )
+        self.assertEqual(permuted.shape[0], 0)
+
+
+class TestUnpermuteAligned(unittest.TestCase):
+    def test_unpermute_forward_matches_default(self):
+        rm = _make_fixed_topk_routing_map(6, 4, 2)
+        tokens = paddle.randn([6, 8])
+        p, si = permute(tokens, rm, use_accuracy_compatible=True)
+        out_a = unpermute(
+            p, si, tokens.shape, routing_map=rm, use_accuracy_compatible=True
+        )
+        out_s = unpermute(
+            p, si, tokens.shape, routing_map=rm, use_accuracy_compatible=False
+        )
+        self.assertEqual(out_a.shape, [6, 8])
+        np.testing.assert_allclose(out_a.numpy(), out_s.numpy(), atol=1e-5)
+
+    def test_permute_unpermute_roundtrip(self):
+        topk = 2
+        rm = _make_fixed_topk_routing_map(6, 4, topk)
+        tokens = paddle.randn([6, 8])
+        p, si = permute(tokens, rm, use_accuracy_compatible=True)
+        out = unpermute(
+            p, si, tokens.shape, routing_map=rm, use_accuracy_compatible=True
+        )
+        # unpermute sums the topk copies back => topk * original token.
+        np.testing.assert_allclose(
+            out.numpy(), (topk * tokens).numpy(), atol=1e-5
+        )
+
+    def test_unpermute_backward_shape(self):
+        rm = _make_fixed_topk_routing_map(5, 3, 2)
+        tokens = paddle.randn([5, 4])
+        tokens.stop_gradient = False
+        p, si = permute(tokens, rm, use_accuracy_compatible=True)
+        out = unpermute(
+            p, si, tokens.shape, routing_map=rm, use_accuracy_compatible=True
+        )
+        out.sum().backward()
+        self.assertEqual(tokens.grad.shape, [5, 4])
+
+    def test_unpermute_with_probs_matches_default(self):
+        rm = _make_fixed_topk_routing_map(6, 4, 2)
+        tokens = paddle.randn([6, 8])
+        probs = paddle.rand([6, 4])
+        p, si = permute(tokens, rm, use_accuracy_compatible=True)
+        out_a = unpermute(
+            p,
+            si,
+            tokens.shape,
+            probs=probs,
+            routing_map=rm,
+            use_accuracy_compatible=True,
+        )
+        out_s = unpermute(
+            p,
+            si,
+            tokens.shape,
+            probs=probs,
+            routing_map=rm,
+            use_accuracy_compatible=False,
+        )
+        self.assertEqual(out_a.shape, [6, 8])
+        np.testing.assert_allclose(out_a.numpy(), out_s.numpy(), atol=1e-5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_utils_use_accuracy_compatible.py
+++ b/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_utils_use_accuracy_compatible.py
@@ -51,6 +51,23 @@ def _make_fixed_topk_routing_map(num_tokens, num_experts, topk, seed=0):
     return routing_map
 
 
+def _make_padded_routing_map():
+    """Routing map mixing all-zero (padding) rows with fixed top-k=2 rows.
+
+    Row 0 is padding on purpose: the top-k probe must not read it.
+    """
+    return paddle.to_tensor(
+        [
+            [0.0, 0.0, 0.0, 0.0],  # padding
+            [1.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0],  # padding
+            [0.0, 1.0, 1.0, 0.0],
+            [1.0, 0.0, 0.0, 1.0],
+        ],
+        dtype="float32",
+    )
+
+
 class TestPermuteAligned(unittest.TestCase):
     def test_permute_forward_matches_default(self):
         rm = _make_fixed_topk_routing_map(6, 4, 2)
@@ -92,6 +109,26 @@ class TestPermuteAligned(unittest.TestCase):
             tokens, rm, use_accuracy_compatible=True
         )
         self.assertEqual(permuted.shape[0], 0)
+
+    def test_permute_mixed_padding_forward_matches_default(self):
+        rm = _make_padded_routing_map()
+        tokens = paddle.randn([5, 8])
+        p_a, si_a = permute(tokens, rm, use_accuracy_compatible=True)
+        p_s, si_s = permute(tokens, rm, use_accuracy_compatible=False)
+        self.assertEqual(p_a.shape[0], 6)  # 3 valid rows * topk 2
+        np.testing.assert_allclose(p_a.numpy(), p_s.numpy(), atol=1e-6)
+        np.testing.assert_array_equal(si_a.numpy(), si_s.numpy())
+
+    def test_permute_mixed_padding_backward_zeroes_padding_rows(self):
+        rm = _make_padded_routing_map()
+        tokens = paddle.randn([5, 4])
+        tokens.stop_gradient = False
+        permuted, _ = permute(tokens, rm, use_accuracy_compatible=True)
+        permuted.sum().backward()
+        expected = np.full([5, 4], 2.0, dtype="float32")
+        expected[0] = 0.0
+        expected[2] = 0.0
+        np.testing.assert_allclose(tokens.grad.numpy(), expected, atol=1e-6)
 
 
 class TestUnpermuteAligned(unittest.TestCase):
@@ -155,6 +192,85 @@ class TestUnpermuteAligned(unittest.TestCase):
         )
         self.assertEqual(out_a.shape, [6, 8])
         np.testing.assert_allclose(out_a.numpy(), out_s.numpy(), atol=1e-5)
+
+
+class TestAlignedPaddedRoutingMap(unittest.TestCase):
+    """Mixed valid / all-zero routing rows must work in forward and backward."""
+
+    def test_unpermute_mixed_padding_forward_matches_default(self):
+        rm = _make_padded_routing_map()
+        tokens = paddle.randn([5, 8])
+        p, si = permute(tokens, rm, use_accuracy_compatible=True)
+        out_a = unpermute(
+            p, si, tokens.shape, routing_map=rm, use_accuracy_compatible=True
+        )
+        out_s = unpermute(
+            p, si, tokens.shape, routing_map=rm, use_accuracy_compatible=False
+        )
+        self.assertEqual(out_a.shape, [5, 8])
+        np.testing.assert_allclose(out_a.numpy(), out_s.numpy(), atol=1e-5)
+        # Padding rows produce zero output.
+        np.testing.assert_allclose(
+            out_a.numpy()[[0, 2]], np.zeros([2, 8], dtype="float32"), atol=0
+        )
+
+    def test_unpermute_mixed_padding_roundtrip(self):
+        rm = _make_padded_routing_map()
+        tokens = paddle.randn([5, 8])
+        p, si = permute(tokens, rm, use_accuracy_compatible=True)
+        out = unpermute(
+            p, si, tokens.shape, routing_map=rm, use_accuracy_compatible=True
+        )
+        expected = (2 * tokens).numpy()
+        expected[[0, 2]] = 0.0
+        np.testing.assert_allclose(out.numpy(), expected, atol=1e-5)
+
+    def test_unpermute_mixed_padding_backward(self):
+        rm = _make_padded_routing_map()
+        permuted = paddle.randn([6, 4])
+        permuted.stop_gradient = False
+        out = unpermute(
+            permuted,
+            None,
+            [5, 4],
+            routing_map=rm,
+            use_accuracy_compatible=True,
+        )
+        out.sum().backward()
+        # Every permuted row feeds exactly one valid output row.
+        np.testing.assert_allclose(
+            permuted.grad.numpy(),
+            np.ones([6, 4], dtype="float32"),
+            atol=1e-6,
+        )
+
+    def test_permute_unpermute_mixed_padding_backward(self):
+        rm = _make_padded_routing_map()
+        tokens = paddle.randn([5, 4])
+        tokens.stop_gradient = False
+        p, si = permute(tokens, rm, use_accuracy_compatible=True)
+        out = unpermute(
+            p, si, tokens.shape, routing_map=rm, use_accuracy_compatible=True
+        )
+        out.sum().backward()
+        expected = np.full([5, 4], 2.0, dtype="float32")
+        expected[0] = 0.0
+        expected[2] = 0.0
+        np.testing.assert_allclose(tokens.grad.numpy(), expected, atol=1e-6)
+
+    def test_unpermute_all_padding_returns_zeros(self):
+        rm = paddle.zeros([3, 4])
+        permuted = paddle.zeros([0, 8])
+        out = unpermute(
+            permuted,
+            None,
+            [3, 8],
+            routing_map=rm,
+            use_accuracy_compatible=True,
+        )
+        np.testing.assert_allclose(
+            out.numpy(), np.zeros([3, 8], dtype="float32"), atol=0
+        )
 
 
 if __name__ == "__main__":

--- a/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_utils_use_accuracy_compatible.py
+++ b/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_utils_use_accuracy_compatible.py
@@ -16,21 +16,6 @@ in commit 80a72f9 (MG-aligned gather/sum permute + unpermute). The aligned
 paths must be numerically equivalent to the default paths in both forward and
 backward while exercising the dedicated PyLayers."""
 
-import os
-import sys
-
-_test_file = os.path.abspath(__file__)
-_repo_root = _test_file
-for _ in range(10):
-    _repo_root = os.path.dirname(_repo_root)
-    if os.path.isdir(os.path.join(_repo_root, "src", "paddlefleet")):
-        break
-sys.path.insert(0, _repo_root)
-sys.path.insert(0, os.path.join(_repo_root, "src"))
-for _mod in list(sys.modules.keys()):
-    if _mod == "paddlefleet" or _mod.startswith("paddlefleet."):
-        del sys.modules[_mod]
-
 import unittest
 
 import numpy as np

--- a/tests/single_card_tests/ai_edited_test/moe/test_ai_three_path_clone_align_mg.py
+++ b/tests/single_card_tests/ai_edited_test/moe/test_ai_three_path_clone_align_mg.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Coverage for ThreePathCloneAlignMG added in commit 80a72f9. It is a
+three-way differentiable identity clone whose backward sums the incoming
+gradients in the MG-aligned order (dispatcher + shared) + router."""
+
+import os
+import sys
+
+_test_file = os.path.abspath(__file__)
+_repo_root = _test_file
+for _ in range(10):
+    _repo_root = os.path.dirname(_repo_root)
+    if os.path.isdir(os.path.join(_repo_root, "src", "paddlefleet")):
+        break
+sys.path.insert(0, _repo_root)
+sys.path.insert(0, os.path.join(_repo_root, "src"))
+for _mod in list(sys.modules.keys()):
+    if _mod == "paddlefleet" or _mod.startswith("paddlefleet."):
+        del sys.modules[_mod]
+
+import unittest
+
+import numpy as np
+import paddle
+
+from paddlefleet.transformer.moe.moe_layer import ThreePathCloneAlignMG
+
+
+class TestThreePathCloneAlignMG(unittest.TestCase):
+    def test_forward_returns_three_equal_clones(self):
+        x = paddle.randn([3, 5])
+        a, b, c = ThreePathCloneAlignMG.apply(x)
+        for out in (a, b, c):
+            self.assertEqual(out.shape, [3, 5])
+            np.testing.assert_array_equal(out.numpy(), x.numpy())
+
+    def test_backward_sums_all_three_paths(self):
+        x = paddle.randn([3, 5])
+        x.stop_gradient = False
+        a, b, c = ThreePathCloneAlignMG.apply(x)
+        # distinct weights so the summed gradient is 1 + 2 + 3 = 6.
+        (a * 1.0 + b * 2.0 + c * 3.0).sum().backward()
+        self.assertEqual(x.grad.shape, [3, 5])
+        np.testing.assert_allclose(
+            x.grad.numpy(), np.full([3, 5], 6.0, dtype="float32"), atol=1e-6
+        )
+
+    def test_backward_only_one_path_used(self):
+        # Only the router path contributes to the loss; the other two clones
+        # still feed zero grads into the backward sum.
+        x = paddle.randn([2, 4])
+        x.stop_gradient = False
+        a, _b, _c = ThreePathCloneAlignMG.apply(x)
+        a.sum().backward()
+        np.testing.assert_allclose(
+            x.grad.numpy(), np.ones([2, 4], dtype="float32"), atol=1e-6
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/transformer/test_gemma4.py
+++ b/tests/single_card_tests/transformer/test_gemma4.py
@@ -1052,6 +1052,44 @@ class TestGemma4MoELayerForward(unittest.TestCase):
         gate_input = layer.gate.call_args[0][0]
         self.assertEqual(gate_input.shape, [2, 4, 64])
 
+    def test_forward_accuracy_compatible_keeps_dual_input_hooks(self):
+        """use_accuracy_compatible must not bypass the dual-input hooks."""
+        layer = self._make_moe_layer()
+        layer.use_accuracy_compatible = True
+        hidden = paddle.randn([2, 4, 64])
+        hidden.stop_gradient = False
+        residual = paddle.randn([2, 4, 64])
+        layer._forward_single_card_moe = MagicMock(
+            return_value=paddle.ones([8, 64])
+        )
+
+        out, _ = layer.forward(hidden, residual=residual)
+        self.assertEqual(out.shape, [2, 4, 64])
+
+        # Three-path clone is disabled for dual-input topology.
+        self.assertFalse(layer._supports_three_path_clone())
+
+        # Router still consumes residual, not a clone of hidden_states.
+        gate_input = layer.gate.call_args[0][0]
+        np.testing.assert_allclose(
+            gate_input.numpy(), residual.numpy(), rtol=1e-6, atol=1e-6
+        )
+
+        # Expert input still goes through pre_feedforward_layernorm_2(residual).
+        expert_input = layer._forward_single_card_moe.call_args[0][0]
+        expected = layer.pre_feedforward_layernorm_2(residual).reshape([-1, 64])
+        np.testing.assert_allclose(
+            expert_input.numpy(), expected.numpy(), rtol=1e-5, atol=1e-5
+        )
+
+    def test_base_moe_layer_supports_three_path_clone(self):
+        """Base MoELayer (single-input topology) still enables the clone."""
+        from paddlefleet.transformer.moe.moe_layer import MoELayer
+
+        layer = MoELayer.__new__(MoELayer)
+        nn.Layer.__init__(layer)
+        self.assertTrue(layer._supports_three_path_clone())
+
 
 # ===========================================================
 # Test: Gemma4TopKRouter full forward (lines 1357-1405)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Operator Mechanism 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
**概述**
1. 引入 use_accuracy_compatible 开关，贯穿 MLP、MoE 层、router、token dispatcher 和 SwiGLU 融合，使数值行为与参考实现对齐。

**改动**
1. fused_bias_swiglu：新增 eager 版 SwiGLU 前向/反向路径（swiglu_eager、bias_swiglu_eager、swiglu_back_eager、weighted_swiglu_back_eager），由 use_accuracy_compatible 控制。
2. tensor_parallel/layers：linear 反向中对 expert 参数使用 fp32 main_grad 累加；为权重打上 is_expert_param 标记。
moe_layer：新增 ThreePathCloneAlignMG clone，其反向按 MG 对齐的求和顺序执行；router / dispatcher / shared 输入分别走独立路径。
3. moe_router：aux-loss 重算、gather_nd 方式的 top-k 权重 gather、以及 fp64 归一化分母对齐。
moe_utils / token_dispatcher：与 MG 对齐的 gather/sum 版 permute/unpermute PyLayer，并接入各个 dispatcher。


### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否