### PR TITLE
[Kimi-K3] Add SiTU-GLU support

### DIFF
--- a/src/paddlefleet/transformer/activations.py
+++ b/src/paddlefleet/transformer/activations.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import paddle
+import paddle.nn.functional as F
+
+
+def situ(x: paddle.Tensor, beta: float = 1.0) -> paddle.Tensor:
+    """Apply the SiTU gate activation with float32 intermediates."""
+
+    beta = beta or 1.0
+    input_dtype = x.dtype
+    x = x.astype("float32")
+    output = beta * paddle.tanh(x / beta) * F.sigmoid(x)
+    return output.astype(input_dtype)
+
+
+def situ_glu(
+    x: paddle.Tensor,
+    beta: float = 1.0,
+    linear_beta: float | None = None,
+) -> paddle.Tensor:
+    """Apply Kimi-K3 SiTU-GLU to concatenated ``[gate, up]`` projections."""
+
+    if x.shape[-1] % 2 != 0:
+        raise ValueError(
+            "SiTU-GLU requires an even last dimension containing "
+            f"concatenated [gate, up] projections, but got {x.shape[-1]}."
+        )
+
+    beta = beta or 1.0
+    input_dtype = x.dtype
+    gate, up = paddle.chunk(x, chunks=2, axis=-1)
+    gate = gate.astype("float32")
+    up = up.astype("float32")
+
+    gate = beta * paddle.tanh(gate / beta) * F.sigmoid(gate)
+    if linear_beta is not None:
+        up = linear_beta * paddle.tanh(up / linear_beta)
+    return (gate * up).astype(input_dtype)
+
+
+class SituAndMul(paddle.nn.Layer):
+    """Layer wrapper matching the official Kimi-K3 ``SituAndMul`` contract."""
+
+    def __init__(
+        self,
+        beta: float = 1.0,
+        linear_beta: float | None = None,
+    ):
+        super().__init__()
+        self.beta = beta
+        self.linear_beta = linear_beta
+
+    def forward(self, x: paddle.Tensor) -> paddle.Tensor:
+        return situ_glu(
+            x,
+            beta=self.beta,
+            linear_beta=self.linear_beta,
+        )
+
+
+__all__ = ["SituAndMul", "situ", "situ_glu"]

--- a/src/paddlefleet/transformer/activations.py
+++ b/src/paddlefleet/transformer/activations.py
@@ -14,30 +14,15 @@
 
 from __future__ import annotations
 
-import math
-from numbers import Real
-
 import paddle
 import paddle.nn.functional as F
-
-
-def _validate_situ_scale(name: str, value: float) -> float:
-    if (
-        isinstance(value, bool)
-        or not isinstance(value, Real)
-        or not math.isfinite(value)
-        or value <= 0
-    ):
-        raise ValueError(
-            f"{name} must be a finite positive number, but got {value!r}."
-        )
-    return float(value)
 
 
 def situ(x: paddle.Tensor, beta: float = 1.0) -> paddle.Tensor:
     """Apply the SiTU gate activation with float32 intermediates."""
 
-    beta = _validate_situ_scale("beta", beta)
+    assert beta >= 0
+
     input_dtype = x.dtype
     x = x.astype("float32")
     output = beta * paddle.tanh(x / beta) * F.sigmoid(x)
@@ -57,9 +42,8 @@ def situ_glu(
             f"concatenated [gate, up] projections, but got {x.shape[-1]}."
         )
 
-    beta = _validate_situ_scale("beta", beta)
-    if linear_beta is not None:
-        linear_beta = _validate_situ_scale("linear_beta", linear_beta)
+    assert beta >= 0
+    assert linear_beta is None or linear_beta >= 0
 
     input_dtype = x.dtype
     gate, up = paddle.chunk(x, chunks=2, axis=-1)

--- a/src/paddlefleet/transformer/activations.py
+++ b/src/paddlefleet/transformer/activations.py
@@ -14,14 +14,30 @@
 
 from __future__ import annotations
 
+import math
+from numbers import Real
+
 import paddle
 import paddle.nn.functional as F
+
+
+def _validate_situ_scale(name: str, value: float) -> float:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, Real)
+        or not math.isfinite(value)
+        or value <= 0
+    ):
+        raise ValueError(
+            f"{name} must be a finite positive number, but got {value!r}."
+        )
+    return float(value)
 
 
 def situ(x: paddle.Tensor, beta: float = 1.0) -> paddle.Tensor:
     """Apply the SiTU gate activation with float32 intermediates."""
 
-    beta = beta or 1.0
+    beta = _validate_situ_scale("beta", beta)
     input_dtype = x.dtype
     x = x.astype("float32")
     output = beta * paddle.tanh(x / beta) * F.sigmoid(x)
@@ -41,7 +57,10 @@ def situ_glu(
             f"concatenated [gate, up] projections, but got {x.shape[-1]}."
         )
 
-    beta = beta or 1.0
+    beta = _validate_situ_scale("beta", beta)
+    if linear_beta is not None:
+        linear_beta = _validate_situ_scale("linear_beta", linear_beta)
+
     input_dtype = x.dtype
     gate, up = paddle.chunk(x, chunks=2, axis=-1)
     gate = gate.astype("float32")

--- a/src/paddlefleet/transformer/activations.py
+++ b/src/paddlefleet/transformer/activations.py
@@ -21,7 +21,7 @@ import paddle.nn.functional as F
 def situ(x: paddle.Tensor, beta: float = 1.0) -> paddle.Tensor:
     """Apply the SiTU gate activation with float32 intermediates."""
 
-    assert beta >= 0
+    assert beta > 0
 
     input_dtype = x.dtype
     x = x.astype("float32")
@@ -42,8 +42,8 @@ def situ_glu(
             f"concatenated [gate, up] projections, but got {x.shape[-1]}."
         )
 
-    assert beta >= 0
-    assert linear_beta is None or linear_beta >= 0
+    assert beta > 0
+    assert linear_beta is None or linear_beta > 0
 
     input_dtype = x.dtype
     gate, up = paddle.chunk(x, chunks=2, axis=-1)

--- a/src/paddlefleet/transformer/mlp.py
+++ b/src/paddlefleet/transformer/mlp.py
@@ -42,6 +42,7 @@ from paddlefleet.fusions.fused_bias_swiglu import (
     bias_swiglu_impl,
     weighted_bias_swiglu_impl,
 )
+from paddlefleet.transformer.activations import situ, situ_glu
 from paddlefleet.transformer.layer import FleetLayer
 
 if TYPE_CHECKING:
@@ -196,6 +197,7 @@ class MLP(FleetLayer):
             self.config.use_bias
             and self.config.gpt_model_use_experimental_version
             and self.config.tensor_model_parallel_size == 1
+            and self.hidden_act != situ
         ):
             hidden_states = paddle.incubate.nn.functional.fused_linear(
                 hidden_states, self.up_gate_proj.weight, self.up_gate_proj.bias
@@ -206,7 +208,21 @@ class MLP(FleetLayer):
             )
             return output, None
 
-        if (
+        if self.hidden_act == situ and self.config.gated_linear_unit:
+            if bias_parallel is not None:
+                intermediate_parallel = intermediate_parallel + bias_parallel
+            intermediate_parallel = situ_glu(
+                intermediate_parallel,
+                beta=self.config.activation_situ_beta,
+                linear_beta=self.config.activation_situ_linear_beta,
+            )
+            if per_token_scale is not None:
+                original_dtype = intermediate_parallel.dtype
+                intermediate_parallel = (
+                    intermediate_parallel * per_token_scale.unsqueeze(-1)
+                )
+                intermediate_parallel = intermediate_parallel.to(original_dtype)
+        elif (
             _use_paddle_swiglu
             and self.hidden_act == F.silu
             and self.config.gated_linear_unit

--- a/src/paddlefleet/transformer/moe/moe_expert.py
+++ b/src/paddlefleet/transformer/moe/moe_expert.py
@@ -31,6 +31,7 @@ from paddlefleet.tensor_parallel.random import (
     get_cuda_rng_tracker,
     get_expert_parallel_rng_tracker_name,
 )
+from paddlefleet.transformer.activations import situ, situ_glu
 from paddlefleet.transformer.layer import FleetLayer
 from paddlefleet.transformer.mlp import MLP, MLPSublayersSpec
 from paddlefleet.transformer.transformer_config import TransformerConfig
@@ -170,7 +171,6 @@ class GroupedMLPExpert(FleetLayer):
     ):
         super().__init__(config=config)
         self.config: TransformerConfig = config
-        self.config.hidden_act = F.silu
         self.num_local_experts = num_local_experts
         self.moe_deep_gemm = moe_deep_gemm
         # Intermediate size for the local shard of every expert. When using the
@@ -192,14 +192,26 @@ class GroupedMLPExpert(FleetLayer):
         )
 
         if self.config.gated_linear_unit:
-            if self.config.hidden_act not in [F.silu, F.gelu]:
-                raise ValueError(
-                    "Activation function must be silu or gelu when using GroupedMLP."
-                )
+            if self.config.hidden_act in [F.silu, F.gelu]:
 
-            def glu(x):
-                x = paddle.chunk(x, 2, dim=-1)
-                return self.config.hidden_act(x[0]) * x[1]
+                def glu(x):
+                    x = paddle.chunk(x, 2, dim=-1)
+                    return self.config.hidden_act(x[0]) * x[1]
+
+            elif self.config.hidden_act == situ:
+
+                def glu(x):
+                    return situ_glu(
+                        x,
+                        beta=self.config.activation_situ_beta,
+                        linear_beta=self.config.activation_situ_linear_beta,
+                    )
+
+            else:
+                raise ValueError(
+                    "Activation function must be silu, gelu, or situ when "
+                    "using GroupedMLP."
+                )
 
             self.activation_func = glu
         else:
@@ -545,9 +557,13 @@ class SonicMoEExpert(GroupedMLPExpert):
         pg_collection: ProcessGroupCollection | None = None,
         intermediate_size_per_partition: int | None = None,
     ):
-        assert config.gated_linear_unit is True, (
-            "Sonic MoE must use SwiGLU, i.e. set gated_linear_unit=True."
-        )
+        if config.hidden_act != F.silu or not config.gated_linear_unit:
+            raise ValueError(
+                "SonicMoE only supports SwiGLU (hidden_act=F.silu and "
+                "gated_linear_unit=True), but got "
+                f"hidden_act={config.hidden_act} and "
+                f"gated_linear_unit={config.gated_linear_unit}."
+            )
         super().__init__(
             num_local_experts=num_local_experts,
             config=config,

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -32,6 +32,7 @@ from ..utils import (
     scaled_init_method_normal,
     truncated_init_method_normal,
 )
+from .activations import situ
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -190,6 +191,12 @@ class TransformerConfig(ModelParallelConfig):
 
     hidden_act: Callable = F.gelu
     """Activation function to use for the non-linearity in the MLP."""
+
+    activation_situ_beta: float = 1.0
+    """Scale of the tanh term in the SiTU gate activation."""
+
+    activation_situ_linear_beta: float | None = None
+    """Optional tanh scale applied to the linear branch of SiTU-GLU."""
 
     use_bias: bool = False
     """Include a bias term in all linear layers (QKV projections and Output projections, after core attention, and two in
@@ -1174,6 +1181,8 @@ class TransformerConfig(ModelParallelConfig):
             if isinstance(value, str):
                 if value == "gelu_pytorch_tanh":
                     func = functools.partial(F.gelu, approximate=True)
+                elif value == "situ":
+                    func = situ
                 else:
                     func = getattr(F, value)
                 setattr(self, key, func)

--- a/tests/single_card_tests/model/test_gpt_model_moe_grouped_gemm.py
+++ b/tests/single_card_tests/model/test_gpt_model_moe_grouped_gemm.py
@@ -21,6 +21,7 @@ import unittest
 
 import numpy as np
 import paddle
+import paddle.nn.functional as F
 from paddle.distributed import fleet
 
 # from paddlefleet.tensor_parallel.random import model_parallel_cuda_manual_seed
@@ -125,6 +126,7 @@ class TestGPTModel(unittest.TestCase):
             output_layer_init_method=functools.partial(
                 paddle.nn.init.xavier_uniform_, gain=1.0
             ),
+            hidden_act=F.silu,
             use_qk_norm=True,
             moe_expert_fusion=True,
             moe_deep_gemm=False,

--- a/tests/single_card_tests/transformer/test_situ_glu.py
+++ b/tests/single_card_tests/transformer/test_situ_glu.py
@@ -61,9 +61,9 @@ class TestSituGLU(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "even last dimension"):
             situ_glu(paddle.ones([2, 7]))
 
-    def test_rejects_negative_scales(self):
+    def test_rejects_non_positive_scales(self):
         x = paddle.ones([2, 8])
-        invalid_scales = (-1.0,)
+        invalid_scales = (-1.0, 0.0)
 
         for beta in invalid_scales:
             with (

--- a/tests/single_card_tests/transformer/test_situ_glu.py
+++ b/tests/single_card_tests/transformer/test_situ_glu.py
@@ -1,0 +1,197 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from types import SimpleNamespace
+
+import paddle
+import paddle.nn.functional as F
+
+from paddlefleet.models.gpt.gpt_layer_specs import get_gpt_layer_local_spec
+from paddlefleet.tensor_parallel.random import model_parallel_cuda_manual_seed
+from paddlefleet.transformer.activations import SituAndMul, situ, situ_glu
+from paddlefleet.transformer.mlp import MLP
+from paddlefleet.transformer.moe.moe_expert import (
+    GroupedMLPExpert,
+    SonicMoEExpert,
+)
+from paddlefleet.transformer.transformer_config import TransformerConfig
+
+
+class TestSituGLU(unittest.TestCase):
+    def test_config_resolves_situ_name(self):
+        config = TransformerConfig.from_config(
+            SimpleNamespace(
+                hidden_size=8,
+                num_attention_heads=2,
+                hidden_act="situ",
+            )
+        )
+
+        self.assertIs(config.hidden_act, situ)
+
+    def test_matches_official_formula(self):
+        x = paddle.linspace(-8.0, 8.0, 32).reshape([2, 16])
+        gate, up = paddle.chunk(x, chunks=2, axis=-1)
+        expected = (
+            4.0
+            * paddle.tanh(gate / 4.0)
+            * F.sigmoid(gate)
+            * (25.0 * paddle.tanh(up / 25.0))
+        )
+
+        actual = situ_glu(x, beta=4.0, linear_beta=25.0)
+        layer_actual = SituAndMul(beta=4.0, linear_beta=25.0)(x)
+
+        self.assertTrue(paddle.allclose(actual, expected))
+        self.assertTrue(paddle.equal_all(actual, layer_actual))
+
+    def test_rejects_odd_projection_width(self):
+        with self.assertRaisesRegex(ValueError, "even last dimension"):
+            situ_glu(paddle.ones([2, 7]))
+
+    def test_grouped_bf16_expert_forward_backward(self):
+        model_parallel_cuda_manual_seed(2026)
+        config = TransformerConfig(
+            hidden_size=8,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+            intermediate_size=8,
+            moe_intermediate_size=4,
+            gated_linear_unit=True,
+            hidden_act=situ,
+            activation_situ_beta=4.0,
+            activation_situ_linear_beta=25.0,
+            params_dtype="bfloat16",
+        )
+        expert = GroupedMLPExpert(
+            num_local_experts=2,
+            config=config,
+            moe_deep_gemm=False,
+        )
+        self.assertIs(config.hidden_act, situ)
+        hidden_states = paddle.randn([5, 8], dtype="bfloat16")
+        hidden_states.stop_gradient = False
+
+        output, output_bias = expert(
+            hidden_states,
+            paddle.to_tensor([2, 3], dtype="int64"),
+        )
+        output.sum().backward()
+
+        self.assertIsNone(output_bias)
+        self.assertEqual(list(output.shape), [5, config.hidden_size])
+        self.assertTrue(
+            bool(paddle.isfinite(output.astype("float32")).all().item())
+        )
+        self.assertTrue(
+            bool(
+                paddle.isfinite(hidden_states.grad.astype("float32"))
+                .all()
+                .item()
+            )
+        )
+
+    def test_grouped_expert_preserves_standard_activation_config(self):
+        model_parallel_cuda_manual_seed(2026)
+        for hidden_act in (F.silu, F.gelu):
+            with self.subTest(hidden_act=hidden_act):
+                config = TransformerConfig(
+                    hidden_size=8,
+                    num_hidden_layers=1,
+                    num_attention_heads=2,
+                    intermediate_size=8,
+                    moe_intermediate_size=4,
+                    gated_linear_unit=True,
+                    hidden_act=hidden_act,
+                    params_dtype="bfloat16",
+                )
+                expert = GroupedMLPExpert(
+                    num_local_experts=2,
+                    config=config,
+                    moe_deep_gemm=False,
+                )
+                x = paddle.linspace(-4.0, 4.0, 16).reshape([2, 8])
+                gate, up = paddle.chunk(x, chunks=2, axis=-1)
+
+                self.assertIs(config.hidden_act, hidden_act)
+                self.assertTrue(
+                    paddle.allclose(
+                        expert.activation_func(x),
+                        hidden_act(gate) * up,
+                    )
+                )
+
+    def test_sonic_moe_rejects_non_swiglu_configurations(self):
+        for hidden_act, gated_linear_unit in (
+            (F.gelu, True),
+            (situ, True),
+            (F.silu, False),
+        ):
+            with self.subTest(
+                hidden_act=hidden_act,
+                gated_linear_unit=gated_linear_unit,
+            ):
+                config = TransformerConfig(
+                    hidden_size=8,
+                    num_hidden_layers=1,
+                    num_attention_heads=2,
+                    intermediate_size=8,
+                    moe_intermediate_size=4,
+                    gated_linear_unit=gated_linear_unit,
+                    hidden_act=hidden_act,
+                    params_dtype="bfloat16",
+                )
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "only supports SwiGLU",
+                ):
+                    SonicMoEExpert(
+                        num_local_experts=2,
+                        topk=2,
+                        config=config,
+                    )
+                self.assertIs(config.hidden_act, hidden_act)
+
+    def test_mlp_forward_backward_bypasses_swiglu_fusion(self):
+        model_parallel_cuda_manual_seed(2026)
+        config = TransformerConfig(
+            num_hidden_layers=2,
+            hidden_size=12,
+            intermediate_size=24,
+            num_attention_heads=4,
+            use_bias=True,
+            bias_activation_fusion=True,
+            gated_linear_unit=True,
+            hidden_act=situ,
+            activation_situ_beta=4.0,
+            activation_situ_linear_beta=25.0,
+        )
+        mlp = MLP(
+            config,
+            get_gpt_layer_local_spec(config).sublayers_spec.mlp.sublayers_spec,
+        )
+        hidden_states = paddle.randn([4, 2, config.hidden_size])
+        hidden_states.stop_gradient = False
+
+        output, output_bias = mlp(hidden_states)
+        (output.sum() + output_bias.sum()).backward()
+
+        self.assertEqual(list(output.shape), [4, 2, config.hidden_size])
+        self.assertTrue(bool(paddle.isfinite(output).all().item()))
+        self.assertTrue(bool(paddle.isfinite(hidden_states.grad).all().item()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/transformer/test_situ_glu.py
+++ b/tests/single_card_tests/transformer/test_situ_glu.py
@@ -61,6 +61,42 @@ class TestSituGLU(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "even last dimension"):
             situ_glu(paddle.ones([2, 7]))
 
+    def test_rejects_non_positive_or_non_finite_scales(self):
+        x = paddle.ones([2, 8])
+        invalid_scales = (
+            0.0,
+            -1.0,
+            float("inf"),
+            float("-inf"),
+            float("nan"),
+        )
+
+        for beta in invalid_scales:
+            with (
+                self.subTest(beta=beta, function="situ"),
+                self.assertRaisesRegex(
+                    ValueError, "beta must be a finite positive number"
+                ),
+            ):
+                situ(x, beta=beta)
+            with (
+                self.subTest(beta=beta, function="situ_glu"),
+                self.assertRaisesRegex(
+                    ValueError, "beta must be a finite positive number"
+                ),
+            ):
+                situ_glu(x, beta=beta)
+
+        for linear_beta in invalid_scales:
+            with (
+                self.subTest(linear_beta=linear_beta),
+                self.assertRaisesRegex(
+                    ValueError,
+                    "linear_beta must be a finite positive number",
+                ),
+            ):
+                situ_glu(x, linear_beta=linear_beta)
+
     def test_grouped_bf16_expert_forward_backward(self):
         model_parallel_cuda_manual_seed(2026)
         config = TransformerConfig(
@@ -191,7 +227,3 @@ class TestSituGLU(unittest.TestCase):
         self.assertEqual(list(output.shape), [4, 2, config.hidden_size])
         self.assertTrue(bool(paddle.isfinite(output).all().item()))
         self.assertTrue(bool(paddle.isfinite(hidden_states.grad).all().item()))
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/single_card_tests/transformer/test_situ_glu.py
+++ b/tests/single_card_tests/transformer/test_situ_glu.py
@@ -61,39 +61,26 @@ class TestSituGLU(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "even last dimension"):
             situ_glu(paddle.ones([2, 7]))
 
-    def test_rejects_non_positive_or_non_finite_scales(self):
+    def test_rejects_negative_scales(self):
         x = paddle.ones([2, 8])
-        invalid_scales = (
-            0.0,
-            -1.0,
-            float("inf"),
-            float("-inf"),
-            float("nan"),
-        )
+        invalid_scales = (-1.0,)
 
         for beta in invalid_scales:
             with (
                 self.subTest(beta=beta, function="situ"),
-                self.assertRaisesRegex(
-                    ValueError, "beta must be a finite positive number"
-                ),
+                self.assertRaises(AssertionError),
             ):
                 situ(x, beta=beta)
             with (
                 self.subTest(beta=beta, function="situ_glu"),
-                self.assertRaisesRegex(
-                    ValueError, "beta must be a finite positive number"
-                ),
+                self.assertRaises(AssertionError),
             ):
                 situ_glu(x, beta=beta)
 
         for linear_beta in invalid_scales:
             with (
                 self.subTest(linear_beta=linear_beta),
-                self.assertRaisesRegex(
-                    ValueError,
-                    "linear_beta must be a finite positive number",
-                ),
+                self.assertRaises(AssertionError),
             ):
                 situ_glu(x, linear_beta=linear_beta)
 

--- a/tests/single_card_tests/transformer/test_situ_glu.py
+++ b/tests/single_card_tests/transformer/test_situ_glu.py
@@ -44,16 +44,14 @@ class TestSituGLU(unittest.TestCase):
     def test_matches_official_formula(self):
         x = paddle.linspace(-8.0, 8.0, 32).reshape([2, 16])
         gate, up = paddle.chunk(x, chunks=2, axis=-1)
-        expected = (
-            4.0
-            * paddle.tanh(gate / 4.0)
-            * F.sigmoid(gate)
-            * (25.0 * paddle.tanh(up / 25.0))
-        )
+        expected_gate = 4.0 * paddle.tanh(gate / 4.0) * F.sigmoid(gate)
+        expected = expected_gate * (25.0 * paddle.tanh(up / 25.0))
 
+        gate_actual = situ(gate, beta=4.0)
         actual = situ_glu(x, beta=4.0, linear_beta=25.0)
         layer_actual = SituAndMul(beta=4.0, linear_beta=25.0)(x)
 
+        self.assertTrue(paddle.allclose(gate_actual, expected_gate))
         self.assertTrue(paddle.allclose(actual, expected))
         self.assertTrue(paddle.equal_all(actual, layer_actual))
 


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
New features

### Description
- Add pure Paddle `situ`, `situ_glu`, and `SituAndMul` with FP32 intermediate computation.
- Resolve `hidden_act="situ"` and wire SiTU-GLU into dense and grouped MoE MLP paths.
- Preserve standard grouped SiLU/GELU configuration and reject non-SwiGLU SonicMoE configurations early.
- Add focused tests for the formula, config resolution, BF16 grouped forward/backward, dense forward/backward, and SonicMoE validation.

### 是否引起精度变化
否