### PR TITLE
[DSv4 CSA] Adopt cudnn score recompute kernel and reorder forward computation

### DIFF
--- a/src/paddlefleet/fusions/csa_sparse_attn.py
+++ b/src/paddlefleet/fusions/csa_sparse_attn.py
@@ -139,7 +139,7 @@ class CSASparseAttention(paddle.autograd.PyLayer):
         softmax_scale,
         backend,
         topk_length=None,
-        indexer_topk=None,
+        indexer_topk=0,
     ):
         from paddlefleet.fusions.csa_sparse_attn_utils import prepare_inputs
 
@@ -279,7 +279,7 @@ def csa_sparse_attn(
     softmax_scale,
     backend="tilelang",
     topk_length=None,
-    indexer_topk=None,
+    indexer_topk=0,
 ):
     """Unified CSA sparse attention entry point.
 

--- a/src/paddlefleet/fusions/csa_sparse_attn.py
+++ b/src/paddlefleet/fusions/csa_sparse_attn.py
@@ -127,6 +127,8 @@ def _csa_compute_topk_length(topk_idxs_flat: Tensor) -> Tensor:
 
 
 class CSASparseAttention(paddle.autograd.PyLayer):
+    _lse_indexer = None
+
     @staticmethod
     def forward(
         ctx,
@@ -137,6 +139,7 @@ class CSASparseAttention(paddle.autograd.PyLayer):
         softmax_scale,
         backend,
         topk_length=None,
+        indexer_topk=None,
     ):
         from paddlefleet.fusions.csa_sparse_attn_utils import prepare_inputs
 
@@ -169,14 +172,16 @@ class CSASparseAttention(paddle.autograd.PyLayer):
                 flash_mla_sparse_attn,
             )
 
-            output, lse, _ = flash_mla_sparse_attn(
+            output, lse, lse_indexer = flash_mla_sparse_attn(
                 query,
                 kv_full,
                 attn_sink,
                 topk_idxs,
                 sm_scale=ctx.softmax_scale,
                 topk_length=topk_length,
+                indexer_topk=indexer_topk,
             )
+            CSASparseAttention._lse_indexer = lse_indexer
         else:
             if topk_length is not None:
                 raise NotImplementedError(
@@ -274,6 +279,7 @@ def csa_sparse_attn(
     softmax_scale,
     backend="tilelang",
     topk_length=None,
+    indexer_topk=None,
 ):
     """Unified CSA sparse attention entry point.
 
@@ -298,7 +304,7 @@ def csa_sparse_attn(
             f"csa_sparse_attn_backend={backend!r} is invalid. "
             "Must be one of {'unfused', 'tilelang', 'cudnn'}."
         )
-    return CSASparseAttention.apply(
+    output = CSASparseAttention.apply(
         query,
         kv_full,
         attn_sink,
@@ -306,4 +312,10 @@ def csa_sparse_attn(
         softmax_scale,
         backend,
         topk_length,
+        indexer_topk,
     )
+    if CSASparseAttention._lse_indexer is not None:
+        lse_indexer = CSASparseAttention._lse_indexer
+        CSASparseAttention._lse_indexer = None
+        return output, lse_indexer
+    return output

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -25,10 +25,11 @@ Components:
 
 from __future__ import annotations
 
+import contextlib
 import os
 import warnings
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
 import paddle
 import paddle.nn.functional as F
@@ -1379,12 +1380,12 @@ class TileLangCSAIndexerLossAutoScaler(paddle.autograd.PyLayer):
     def forward(
         ctx,
         output: Tensor,
+        target: Tensor,
         index_q: Tensor,
         weights: Tensor,
         index_k_comp: Tensor,
         topk_indices: Tensor,
         topk_probs: Tensor,
-        target: Tensor,
         loss_coeff: float,
         indexer_backend: str = "tilelang",
         num_rows_override: float | None = None,
@@ -1507,10 +1508,35 @@ class TileLangCSAIndexerLossAutoScaler(paddle.autograd.PyLayer):
             grad_k = grad_k.cast(index_k_comp.dtype)
 
         grad_main = grad_output if ctx.output_needs_grad else None
-        grads = (grad_main, grad_q, grad_weights, grad_k, None, None, None)
+        grads = (grad_main, None, grad_q, grad_weights, grad_k, None, None, None)
         if getattr(ctx, "loss_mask", None) is not None:
             grads += (None,)
         return grads
+
+
+class HashableTensor(paddle.Tensor):
+    """Helper class with hashable shape/stride() method."""
+
+    @property
+    def shape(self):
+        return tuple(super().shape)
+
+    def stride(self, dim=None):
+        if dim is None:
+            return tuple(super().stride())
+        return super().stride(dim)
+
+
+class TilelangIndexerLossState(NamedTuple):
+    index_q: Tensor
+    weights: Tensor
+    index_k_comp: Tensor
+    topk_indices: Tensor
+    topk_probs: Tensor
+    indexer_loss_coeff: float
+    indexer_backend: str
+    global_valid_count: Tensor | None
+    loss_mask: Tensor | None
 
 
 # ---------------------------------------------------------------------------
@@ -2272,6 +2298,14 @@ class CompressedSparseAttention(FleetLayer):
         else:
             self.indexer = None
 
+        self.sparse_attn_backend = getattr(
+            config, "csa_sparse_attn_backend", "tilelang"
+        )
+        self.indexer_backend = getattr(
+            config, "csa_indexer_backend", "tilelang"
+        )
+        self.indexer_loss_coeff = getattr(config, "dsa_indexer_loss_coeff", 0.0)
+
     def _compute_indexer_compressed_topk_idxs(
         self,
         query: Tensor,
@@ -2330,136 +2364,81 @@ class CompressedSparseAttention(FleetLayer):
             sq,
             docmask_meta=docmask_meta,
         )
+        startend_row_indices = (
+            docmask_meta.startend_row_indices
+            if docmask_meta is not None
+            else None
+        )
+        doc_lens_list = (
+            docmask_meta.doc_lens_list if docmask_meta is not None else None
+        )
+        grad_ctx = (
+            contextlib.nullcontext if need_indexer_loss else paddle.no_grad
+        )
 
-        def compute_fused_indexer_loss(backend: str):
-            # Training grad-enabled forward with TileLang/cuDNN backend.
-            # The same backend's top-k-only kernel is used during recompute's
-            # first no-grad forward below.
-            indexer_loss_coeff = getattr(
-                self.config, "dsa_indexer_loss_coeff", 0.0
+        if indexer_backend == "cudnn":
+            from paddlefleet.cudnn_ops.indexer.csa_indexer_fwd_cudnn import (
+                cudnn_indexer_topk_fwd,
             )
-            q_indexer_bf, k_indexer_bf, weights_indexer_bf = (
-                self.indexer.forward_before_topk(
-                    x_det,
-                    qr_det,
-                    docmask_meta=docmask_meta,
-                )
-            )
-            key_comp_mla = compressed_kv.detach()
-            (
-                loss,
-                topk_indices,
-                topk_probs,
-                target,
-            ) = _compute_fused_csa_indexer_loss_forward(
-                q_indexer_bf,
-                weights_indexer_bf,
-                k_indexer_bf,
-                query.detach(),
-                key_comp_mla,
-                valid_range,
-                int(self.compress_ratio),
-                int(loss_topk_effective),
-                float(self.softmax_scale),
-                float(indexer_loss_coeff),
-                self.tp_group,
-                indexer_backend=backend,
-                loss_mask=loss_mask,
-                global_valid_count=global_valid_count,
-                startend_row_indices=docmask_meta.startend_row_indices
-                if docmask_meta is not None
-                else None,
-                docmask_meta=docmask_meta,
-            )
-            loss_state = (
-                q_indexer_bf,
-                weights_indexer_bf,
-                k_indexer_bf,
-                topk_indices,
-                topk_probs,
-                target,
-                float(indexer_loss_coeff),
-                backend,
-                global_valid_count if loss_mask is not None else None,
-                loss_mask,
-            )
-            if indexer_loss_coeff > 0:
-                DSAIndexerLossLoggingHelper.save_loss_to_tracker(
-                    loss=loss,
-                    layer_number=self.layer_number,
-                    num_layers=DSAIndexerLossLoggingHelper.get_total_num_layers(
-                        self.config
-                    ),
-                )
-            return loss, topk_indices, loss_state
 
-        if (
-            indexer_backend == "cudnn"
-        ):  # cuDNN branch for both recompute forwards; inner condition decides whether to compute loss.
-            if need_indexer_loss:  # Grad-enabled recompute forward; compute cuDNN fused selected-set loss and top-k.
-                (
-                    indexer_loss,
-                    topk_indices_compressed,
-                    tilelang_indexer_loss_state,
-                ) = compute_fused_indexer_loss("cudnn")
-            else:  # First recompute no-grad forward; only materialize cuDNN top-k for attention.
-                from paddlefleet.cudnn_ops.indexer.csa_indexer_fwd_cudnn import (
-                    cudnn_indexer_topk_fwd,
+            with grad_ctx():
+                index_q, index_k_comp, weights = (
+                    self.indexer.forward_before_topk(
+                        x_det,
+                        qr_det,
+                        docmask_meta=docmask_meta,
+                    )
+                )
+                topk_indices, _, *topk_scores = cudnn_indexer_topk_fwd(
+                    index_q,
+                    index_k_comp,
+                    weights,
+                    ratio=self.compress_ratio,
+                    topk_effective=attn_topk_effective,
+                    valid_range=valid_range,
+                    startend_row_indices=startend_row_indices,
+                    doc_lens=doc_lens_list,
+                    return_topk_scores=need_indexer_loss,
                 )
 
-                with paddle.no_grad():
-                    q_indexer_cu, k_indexer_cu, weights_indexer_cu = (
-                        self.indexer.forward_before_topk(
-                            x_det,
-                            qr_det,
-                            docmask_meta=docmask_meta,
-                        )
-                    )
-                    cu_topk_indices, _cu_topk_length = cudnn_indexer_topk_fwd(
-                        q_indexer_cu,
-                        k_indexer_cu,
-                        weights_indexer_cu,
-                        ratio=self.compress_ratio,
-                        topk_effective=attn_topk_effective,
-                        valid_range=valid_range,
-                        startend_row_indices=docmask_meta.startend_row_indices
-                        if docmask_meta is not None
-                        else None,
-                        doc_lens=docmask_meta.doc_lens_list
-                        if docmask_meta is not None
-                        else None,
-                    )
-                topk_indices_compressed = cu_topk_indices
+            topk_indices_compressed = topk_indices
 
-        elif (
-            indexer_backend == "tilelang"
-        ):  # TileLang branch for both recompute forwards; inner condition decides whether to compute loss.
-            if need_indexer_loss:  # Grad-enabled recompute forward; compute TileLang fused selected-set loss and top-k.
-                (
-                    indexer_loss,
-                    topk_indices_compressed,
-                    tilelang_indexer_loss_state,
-                ) = compute_fused_indexer_loss("tilelang")
-            else:  # First recompute no-grad forward; only materialize TileLang top-k for attention.
-                from paddlefleet.tilelang_ops import csa_indexer_topk_fwd
+            if need_indexer_loss:
+                (topk_scores,) = topk_scores
 
-                with paddle.no_grad():
-                    q_indexer_tl, k_indexer_tl, weights_indexer_tl = (
-                        self.indexer.forward_before_topk(
-                            x_det,
-                            qr_det,
-                            docmask_meta=docmask_meta,
-                        )
+                # Do softmax ourself because cudnn outputs raw scores.
+                # Avoid NaN from softmax on all-(-inf) rows: zero them before softmax.
+                valid_mask = topk_indices >= 0
+                row_valid = valid_mask.any(axis=-1, keepdim=True)  # [B, Sq, 1]
+                topk_scores = paddle.where(
+                    row_valid, topk_scores, paddle.zeros_like(topk_scores)
+                )
+                topk_probs = paddle.nn.functional.softmax(topk_scores, axis=-1)
+                topk_probs = topk_probs * row_valid.cast(topk_probs.dtype)
+
+        elif indexer_backend == "tilelang":
+            from paddlefleet.tilelang_ops import csa_indexer_topk_fwd
+
+            with grad_ctx():
+                index_q, index_k_comp, weights = (
+                    self.indexer.forward_before_topk(
+                        x_det,
+                        qr_det,
+                        docmask_meta=docmask_meta,
                     )
-                    tl_topk_indices, _tl_topk_scores = csa_indexer_topk_fwd(
-                        q_indexer_tl,
-                        k_indexer_tl,
-                        weights_indexer_tl,
-                        ratio=self.compress_ratio,
-                        topk_effective=attn_topk_effective,
-                        valid_range=valid_range,
-                    )
-                topk_indices_compressed = tl_topk_indices
+                )
+                topk_indices, topk_scores = csa_indexer_topk_fwd(
+                    index_q,
+                    index_k_comp,
+                    weights,
+                    ratio=self.compress_ratio,
+                    topk_effective=attn_topk_effective,
+                    valid_range=valid_range,
+                )
+
+            topk_indices_compressed = topk_indices
+            if need_indexer_loss:
+                topk_probs = topk_scores
 
         elif (
             indexer_backend == "unfused"
@@ -2514,6 +2493,19 @@ class CompressedSparseAttention(FleetLayer):
                     mask=causal_mask,
                     docmask_meta=docmask_meta,
                 )
+
+        if indexer_backend in ("cudnn", "tilelang") and need_indexer_loss:
+            tilelang_indexer_loss_state = TilelangIndexerLossState(
+                index_q,
+                weights,
+                index_k_comp,
+                topk_indices,
+                topk_probs,
+                self.indexer_loss_coeff,
+                indexer_backend,
+                global_valid_count if loss_mask is not None else None,
+                loss_mask,
+            )
 
         if (
             topk_indices_compressed.shape[-1] > attn_topk_effective
@@ -2597,6 +2589,65 @@ class CompressedSparseAttention(FleetLayer):
             topk_indices_compressed + offset,
             paddle.full_like(topk_indices_compressed, -1),
         )
+
+    def _compute_fused_indexer_target(
+        self,
+        query_mla: Tensor,
+        key_comp_mla: Tensor,
+        topk_indices: Tensor,
+        topk_probs: Tensor,
+        lse_indexer: Tensor | None = None,
+        loss_mask: Tensor | None = None,
+        global_valid_count: float | None = None,
+    ) -> Tensor:
+        """Compute indexer target and track indexer loss."""
+
+        if self.indexer_backend == "cudnn" and lse_indexer is not None:
+            from paddlefleet_ops.cudnn.deepseek_sparse_attention import (
+                sparse_attn_score_recompute_wrapper,
+            )
+
+            target = sparse_attn_score_recompute_wrapper(
+                HashableTensor(query_mla),
+                HashableTensor(key_comp_mla),
+                HashableTensor(lse_indexer),
+                HashableTensor(topk_indices),
+                self.softmax_scale,
+            )["target"]
+        else:
+            from paddlefleet.tilelang_ops import csa_attn_target_reducesum
+
+            target = csa_attn_target_reducesum(
+                query_mla,
+                key_comp_mla,
+                topk_indices,
+                self.softmax_scale,
+            )
+
+        # Compute KL-loss between topk_probs and target
+        eps = 1e-10
+        kl_per_elem = target * (
+            paddle.log(target + eps) - paddle.log(topk_probs + eps)
+        )
+        # kl_per_elem: [B, Sq, topk] -> sum over topk -> [B, Sq]
+        kl_per_pos = kl_per_elem.sum(axis=-1)
+        loss_coeff = self.indexer_loss_coeff
+        if loss_mask is not None:
+            lm = loss_mask.reshape(kl_per_pos.shape).astype(kl_per_pos.dtype)
+            loss = (kl_per_pos * lm).sum() / global_valid_count * loss_coeff
+        else:
+            loss = kl_per_pos.mean() * loss_coeff
+
+        # Track indexer loss globally (not returned)
+        if loss_coeff > 0:
+            DSAIndexerLossLoggingHelper.save_loss_to_tracker(
+                loss=loss,
+                layer_number=self.layer_number,
+                num_layers=DSAIndexerLossLoggingHelper.get_total_num_layers(
+                    self.config
+                ),
+            )
+        return target
 
     def forward(
         self,
@@ -2766,6 +2817,8 @@ class CompressedSparseAttention(FleetLayer):
         # Step 4: Compressed indices
         indexer_loss = None
         tilelang_indexer_loss_state = None
+        indexer_topk = 0
+        lse_indexer = None
 
         if (
             self.compress_ratio > 1
@@ -2798,15 +2851,23 @@ class CompressedSparseAttention(FleetLayer):
                     docmask_meta=docmask_meta,
                 )
 
-            if compress_topk_idxs.dtype != window_idxs.dtype:
-                compress_topk_idxs = compress_topk_idxs.cast(window_idxs.dtype)
-            topk_idxs = paddle.concat(
-                [window_idxs, compress_topk_idxs], axis=-1
-            )
+            # For cudnn's second forward (both indexer and SA should be cudnn),
+            # use [compress, window] order to generate lse_indexer. Otherwise,
+            # use [window, compress] order.
+            if (
+                self.indexer is not None
+                and self.sparse_attn_backend == "cudnn"
+                and self.indexer_backend == "cudnn"
+                and tilelang_indexer_loss_state is not None
+                and self.training
+            ):
+                topk_idxs = [compress_topk_idxs, window_idxs]
+                indexer_topk = compress_topk_idxs.shape[-1]
+            else:
+                topk_idxs = [window_idxs, compress_topk_idxs]
+            topk_idxs = paddle.concat(topk_idxs, axis=-1)
         else:
             topk_idxs = window_idxs
-
-        topk_idxs = topk_idxs.cast("int32")
 
         # Step 5: Sparse attention
         output = self.compressed_sparse_attn(
@@ -2815,12 +2876,25 @@ class CompressedSparseAttention(FleetLayer):
             self.attn_sink,
             topk_idxs,
             self.softmax_scale,
+            indexer_topk,
         )
+        if indexer_topk > 0:
+            output, lse_indexer = output
 
         # Step 6: Attach indexer loss
         if tilelang_indexer_loss_state is not None and self.training:
+            target = self._compute_fused_indexer_target(
+                query,
+                kv_full,
+                compress_topk_idxs,
+                tilelang_indexer_loss_state.topk_probs,
+                lse_indexer,
+                loss_mask,
+                global_valid_count,
+            )
             output = TileLangCSAIndexerLossAutoScaler.apply(
                 output,
+                target,
                 *tilelang_indexer_loss_state,
             )
         elif indexer_loss is not None and self.training:
@@ -3387,6 +3461,7 @@ class CompressedSparseAttention(FleetLayer):
         topk_idxs: Tensor,
         softmax_scale: float,
         topk_length: Tensor | None = None,
+        indexer_topk: int = 0,
     ):
         from paddlefleet.fusions.csa_sparse_attn import csa_sparse_attn
 
@@ -3406,4 +3481,5 @@ class CompressedSparseAttention(FleetLayer):
             softmax_scale,
             backend=sparse_attn_backend,
             topk_length=topk_length,
+            indexer_topk=indexer_topk,
         )

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -1276,96 +1276,9 @@ def _compute_attn_target_on_selected_set(
     return target
 
 
-def _compute_fused_csa_indexer_loss_forward(
-    index_q: Tensor,
-    weights: Tensor,
-    index_k_comp: Tensor,
-    query_mla: Tensor,
-    key_comp_mla: Tensor,
-    valid_range: Tensor,
-    ratio: int,
-    topk_effective: int,
-    softmax_scale: float,
-    loss_coeff: float,
-    tp_group=None,
-    seq_offset: int = 0,
-    indexer_backend: str = "tilelang",
-    loss_mask: Tensor | None = None,
-    global_valid_count: float | None = None,
-    startend_row_indices: Tensor | None = None,
-    docmask_meta: CSADocMaskMetadata | None = None,
-) -> tuple[Tensor, Tensor, Tensor, Tensor]:
-    from paddlefleet.tilelang_ops import (
-        csa_attn_target_reducesum,
-        csa_indexer_topk_fwd,
-    )
-
-    if indexer_backend == "cudnn":
-        from paddlefleet.cudnn_ops.indexer.csa_indexer_fwd_cudnn import (
-            cudnn_indexer_topk_fwd,
-        )
-
-        topk_indices, _, topk_scores = cudnn_indexer_topk_fwd(
-            index_q,
-            index_k_comp,
-            weights,
-            ratio=int(ratio),
-            topk_effective=int(topk_effective),
-            valid_range=valid_range,
-            startend_row_indices=(
-                docmask_meta.startend_row_indices
-                if docmask_meta is not None
-                else startend_row_indices
-            ),
-            doc_lens=docmask_meta.doc_lens_list
-            if docmask_meta is not None
-            else None,
-            seq_offset=int(seq_offset),
-            return_topk_scores=True,
-        )
-        invalid_mask = topk_indices < 0
-        # Avoid NaN from softmax on all-(-inf) rows: zero them before softmax.
-        row_valid = (~invalid_mask).any(axis=-1, keepdim=True)  # [B, Sq, 1]
-        topk_scores = paddle.where(
-            row_valid, topk_scores, paddle.zeros_like(topk_scores)
-        )
-        topk_probs = paddle.nn.functional.softmax(topk_scores, axis=-1)
-        topk_probs = topk_probs * row_valid.cast(topk_probs.dtype)
-    else:
-        topk_indices, topk_probs = csa_indexer_topk_fwd(
-            index_q,
-            index_k_comp,
-            weights,
-            ratio=int(ratio),
-            topk_effective=int(topk_effective),
-            seq_offset=int(seq_offset),
-            valid_range=valid_range,
-        )
-
-    if tp_group is not None and getattr(tp_group, "nranks", 1) > 1:
-        target = _compute_attn_target_on_selected_set(
-            query_mla, key_comp_mla, topk_indices, softmax_scale, tp_group
-        )
-    else:
-        target = csa_attn_target_reducesum(
-            query_mla,
-            key_comp_mla,
-            topk_indices,
-            softmax_scale,
-        )
-
-    eps = 1e-10
-    kl_per_elem = target * (
-        paddle.log(target + eps) - paddle.log(topk_probs + eps)
-    )
-    # kl_per_elem: [B, Sq, topk] -> sum over topk -> [B, Sq]
-    kl_per_pos = kl_per_elem.sum(axis=-1)
-    if loss_mask is not None:
-        lm = loss_mask.reshape(kl_per_pos.shape).astype(kl_per_pos.dtype)
-        loss = (kl_per_pos * lm).sum() / global_valid_count * float(loss_coeff)
-    else:
-        loss = kl_per_pos.mean() * float(loss_coeff)
-    return loss, topk_indices, topk_probs, target
+# ---------------------------------------------------------------------------
+# Utilities for index computation
+# ---------------------------------------------------------------------------
 
 
 class TileLangCSAIndexerLossAutoScaler(paddle.autograd.PyLayer):
@@ -1508,10 +1421,24 @@ class TileLangCSAIndexerLossAutoScaler(paddle.autograd.PyLayer):
             grad_k = grad_k.cast(index_k_comp.dtype)
 
         grad_main = grad_output if ctx.output_needs_grad else None
-        grads = (grad_main, None, grad_q, grad_weights, grad_k, None, None, None)
+        grads = (grad_main, None, grad_q, grad_weights, grad_k, None, None)
         if getattr(ctx, "loss_mask", None) is not None:
             grads += (None,)
         return grads
+
+
+def _row_masked_softmax(scores: Tensor, indices: Tensor) -> Tensor:
+    """
+    Comppute row-wise softmax on scores.
+    Only the rows with at least one valid index are processed. Invalid rows
+    (i.e. all -inf scores) get zeros values after softmax.
+    """
+    valid_mask = indices >= 0
+    row_valid = valid_mask.any(axis=-1, keepdim=True)  # [B, Sq, 1]
+    scores = paddle.where(row_valid, scores, paddle.zeros_like(scores))
+    scores = paddle.nn.functional.softmax(scores, axis=-1)
+    scores = scores * row_valid.cast(scores.dtype)
+    return scores
 
 
 class HashableTensor(paddle.Tensor):
@@ -2402,19 +2329,10 @@ class CompressedSparseAttention(FleetLayer):
                 )
 
             topk_indices_compressed = topk_indices
-
             if need_indexer_loss:
                 (topk_scores,) = topk_scores
-
-                # Do softmax ourself because cudnn outputs raw scores.
-                # Avoid NaN from softmax on all-(-inf) rows: zero them before softmax.
-                valid_mask = topk_indices >= 0
-                row_valid = valid_mask.any(axis=-1, keepdim=True)  # [B, Sq, 1]
-                topk_scores = paddle.where(
-                    row_valid, topk_scores, paddle.zeros_like(topk_scores)
-                )
-                topk_probs = paddle.nn.functional.softmax(topk_scores, axis=-1)
-                topk_probs = topk_probs * row_valid.cast(topk_probs.dtype)
+                # Cudnn outputs pre-softmax scores, We need to do softmax ourself.
+                topk_probs = _row_masked_softmax(topk_scores, topk_indices)
 
         elif indexer_backend == "tilelang":
             from paddlefleet.tilelang_ops import csa_indexer_topk_fwd
@@ -2600,7 +2518,11 @@ class CompressedSparseAttention(FleetLayer):
         loss_mask: Tensor | None = None,
         global_valid_count: float | None = None,
     ) -> Tensor:
-        """Compute indexer target and track indexer loss."""
+        """
+        Compute indexer target and track indexer loss for cudnn/tilelang
+        backend. The cudnn target kernel is used only when both indexer
+        and sparse_attn use cudnn backend.
+        """
 
         if self.indexer_backend == "cudnn" and lse_indexer is not None:
             from paddlefleet_ops.cudnn.deepseek_sparse_attention import (
@@ -2856,8 +2778,8 @@ class CompressedSparseAttention(FleetLayer):
             # use [window, compress] order.
             if (
                 self.indexer is not None
-                and self.sparse_attn_backend == "cudnn"
                 and self.indexer_backend == "cudnn"
+                and self.sparse_attn_backend == "cudnn"
                 and tilelang_indexer_loss_state is not None
                 and self.training
             ):
@@ -2876,7 +2798,7 @@ class CompressedSparseAttention(FleetLayer):
             self.attn_sink,
             topk_idxs,
             self.softmax_scale,
-            indexer_topk,
+            indexer_topk=indexer_topk,
         )
         if indexer_topk > 0:
             output, lse_indexer = output
@@ -2893,9 +2815,7 @@ class CompressedSparseAttention(FleetLayer):
                 global_valid_count,
             )
             output = TileLangCSAIndexerLossAutoScaler.apply(
-                output,
-                target,
-                *tilelang_indexer_loss_state,
+                output, target, *tilelang_indexer_loss_state
             )
         elif indexer_loss is not None and self.training:
             output = DSAIndexerLossAutoScaler.apply(output, indexer_loss)
@@ -3154,6 +3074,8 @@ class CompressedSparseAttention(FleetLayer):
         # Step 3: Compressed topk + optional fused indexer loss
         indexer_loss = None
         tilelang_indexer_loss_state = None
+        indexer_topk = 0
+        lse_indexer = None
 
         if (
             self.compress_ratio > 1
@@ -3206,64 +3128,79 @@ class CompressedSparseAttention(FleetLayer):
                     self.config, "dsa_indexer_loss_coeff", 0.0
                 )
 
-                if use_fused_indexer_loss_path:
-                    # CP training grad-enabled forward with TileLang/cuDNN
-                    # indexer backend.
-                    # Fused TileLang/cuDNN: single path produces topk + loss.
-                    # key_comp_mla is 3D [b, n_comp_global, hn] (shared across heads).
-                    key_comp_mla = compressed_kv_global.detach()
-                    (
-                        indexer_loss,
-                        topk_indices_compressed,
-                        topk_probs,
-                        target,
-                    ) = _compute_fused_csa_indexer_loss_forward(
-                        q_indexer_bf,
-                        weights_indexer_bf,
-                        k_indexer_global,
-                        query.detach(),
-                        key_comp_mla,
-                        valid_range,
-                        int(self.compress_ratio),
-                        int(loss_topk_effective),
-                        float(self.softmax_scale),
-                        float(indexer_loss_coeff),
-                        self.tp_group,
-                        seq_offset=position_offset,
-                        loss_mask=loss_mask,
-                        global_valid_count=global_valid_count,
-                        startend_row_indices=docmask_meta.startend_row_indices
-                        if docmask_meta is not None
-                        else None,
-                        docmask_meta=docmask_meta,
-                        indexer_backend=indexer_backend,
+                if use_tilelang_indexer or use_cudnn_indexer:
+                    # CP indexer forward with TileLang/cuDNN indexer backend.
+                    # This branch is for both grad-enabled and no-grad.
+                    grad_ctx = (
+                        contextlib.nullcontext
+                        if use_fused_indexer_loss_path
+                        else paddle.no_grad
                     )
-                    tilelang_indexer_loss_state = (
-                        q_indexer_bf,
-                        weights_indexer_bf,
-                        k_indexer_global,
-                        topk_indices_compressed,
-                        topk_probs,
-                        target,
-                        float(indexer_loss_coeff)
-                        if loss_mask is not None
-                        else float(indexer_loss_coeff) / self.cp_size,
-                        getattr(self.config, "csa_indexer_backend", "tilelang"),
-                        global_valid_count if loss_mask is not None else None,
-                        loss_mask,
-                    )
-                    if indexer_loss_coeff > 0:
-                        # CP fused training path logs only when indexer loss is
-                        # enabled.
-                        DSAIndexerLossLoggingHelper.save_loss_to_tracker(
-                            loss=indexer_loss,
-                            layer_number=self.layer_number,
-                            num_layers=self.config.num_hidden_layers,
+
+                    with grad_ctx():
+                        if use_cudnn_indexer:
+                            from paddlefleet.cudnn_ops.indexer.csa_indexer_fwd_cudnn import (
+                                cudnn_indexer_topk_fwd,
+                            )
+
+                            topk_indices_compressed, _, *topk_probs = (
+                                cudnn_indexer_topk_fwd(
+                                    q_indexer_bf,
+                                    k_indexer_global,
+                                    weights_indexer_bf,
+                                    ratio=self.compress_ratio,
+                                    topk_effective=attn_topk_effective,
+                                    valid_range=valid_range,
+                                    startend_row_indices=docmask_meta.startend_row_indices
+                                    if docmask_meta is not None
+                                    else None,
+                                    doc_lens=docmask_meta.doc_lens_list
+                                    if docmask_meta is not None
+                                    else None,
+                                    seq_offset=position_offset,
+                                    return_topk_scores=use_fused_indexer_loss_path,
+                                )
+                            )
+
+                            if use_fused_indexer_loss_path:
+                                (topk_probs,) = topk_probs
+                                topk_probs = _row_masked_softmax(
+                                    topk_probs, topk_indices_compressed
+                                )
+
+                        else:
+                            from paddlefleet.tilelang_ops import (
+                                csa_indexer_topk_fwd,
+                            )
+
+                            topk_indices_compressed, topk_probs = (
+                                csa_indexer_topk_fwd(
+                                    q_indexer_bf,
+                                    k_indexer_global,
+                                    weights_indexer_bf,
+                                    ratio=self.compress_ratio,
+                                    topk_effective=attn_topk_effective,
+                                    seq_offset=position_offset,
+                                    valid_range=valid_range,
+                                )
+                            )
+
+                    if use_fused_indexer_loss_path:
+                        tilelang_indexer_loss_state = TilelangIndexerLossState(
+                            q_indexer_bf,
+                            weights_indexer_bf,
+                            k_indexer_global,
+                            topk_indices_compressed,
+                            topk_probs,
+                            float(indexer_loss_coeff)
+                            if loss_mask is not None
+                            else float(indexer_loss_coeff) / self.cp_size,
+                            indexer_backend,
+                            global_valid_count
+                            if loss_mask is not None
+                            else None,
+                            loss_mask,
                         )
-                    # Scale: each rank's loss is mean over sq_local;
-                    # global loss is mean over sq_global = sq_local * cp_size.
-                    if loss_mask is None:
-                        indexer_loss = indexer_loss / self.cp_size
 
                 elif (
                     self.training
@@ -3356,47 +3293,6 @@ class CompressedSparseAttention(FleetLayer):
                         causal_mask,
                     )
 
-                # TileLang/cuDNN fwd-only topk (no loss, or loss already produced above)
-                if (
-                    (use_tilelang_indexer or use_cudnn_indexer)
-                    and not use_fused_indexer_loss_path
-                ):  # CP eval/no-grad or recompute first forward with TileLang/cuDNN backend.
-                    with paddle.no_grad():
-                        if use_cudnn_indexer:
-                            from paddlefleet.cudnn_ops.indexer.csa_indexer_fwd_cudnn import (
-                                cudnn_indexer_topk_fwd,
-                            )
-
-                            topk_indices_compressed, _ = cudnn_indexer_topk_fwd(
-                                q_indexer_bf,
-                                k_indexer_global,
-                                weights_indexer_bf,
-                                ratio=self.compress_ratio,
-                                topk_effective=attn_topk_effective,
-                                valid_range=valid_range,
-                                startend_row_indices=docmask_meta.startend_row_indices
-                                if docmask_meta is not None
-                                else None,
-                                doc_lens=docmask_meta.doc_lens_list
-                                if docmask_meta is not None
-                                else None,
-                                seq_offset=position_offset,
-                            )
-                        else:
-                            from paddlefleet.tilelang_ops import (
-                                csa_indexer_topk_fwd,
-                            )
-
-                            topk_indices_compressed, _ = csa_indexer_topk_fwd(
-                                q_indexer_bf,
-                                k_indexer_global,
-                                weights_indexer_bf,
-                                ratio=self.compress_ratio,
-                                topk_effective=attn_topk_effective,
-                                seq_offset=position_offset,
-                                valid_range=valid_range,
-                            )
-
                 if (
                     topk_indices_compressed.shape[-1] > attn_topk_effective
                 ):  # CP loss path may return wider top-k than attention consumes.
@@ -3428,25 +3324,46 @@ class CompressedSparseAttention(FleetLayer):
                         :, position_offset : position_offset + sq, ...
                     ]
 
-            if compress_topk_idxs.dtype != window_idxs.dtype:
-                compress_topk_idxs = compress_topk_idxs.cast(window_idxs.dtype)
-            topk_idxs = paddle.concat(
-                [window_idxs, compress_topk_idxs], axis=-1
-            )
+            if (
+                self.indexer is not None
+                and self.indexer_backend == "cudnn"
+                and self.sparse_attn_backend == "cudnn"
+                and tilelang_indexer_loss_state is not None
+                and self.training
+            ):
+                topk_idxs = [compress_topk_idxs, window_idxs]
+                indexer_topk = compress_topk_idxs.shape[-1]
+            else:
+                topk_idxs = [window_idxs, compress_topk_idxs]
+            topk_idxs = paddle.concat(topk_idxs, axis=-1)
         else:
             topk_idxs = window_idxs
 
-        topk_idxs = topk_idxs.cast("int32")
-
         # Step 4: Sparse attention (same dispatch as non-CP)
         output = self.compressed_sparse_attn(
-            query, kv_full, self.attn_sink, topk_idxs, self.softmax_scale
+            query,
+            kv_full,
+            self.attn_sink,
+            topk_idxs,
+            self.softmax_scale,
+            indexer_topk=indexer_topk,
         )
+        if indexer_topk > 0:
+            output, lse_indexer = output
 
         # Step 5: Attach indexer loss
         if tilelang_indexer_loss_state is not None and self.training:
+            target = self._compute_fused_indexer_target(
+                query,
+                kv_full,
+                compress_topk_idxs,
+                tilelang_indexer_loss_state.topk_probs,
+                lse_indexer,
+                loss_mask,
+                global_valid_count,
+            )
             output = TileLangCSAIndexerLossAutoScaler.apply(
-                output, *tilelang_indexer_loss_state
+                output, target, *tilelang_indexer_loss_state
             )
         elif indexer_loss is not None and self.training:
             output = DSAIndexerLossAutoScaler.apply(output, indexer_loss)

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -1149,34 +1149,6 @@ def _apply_rope(
 # ---------------------------------------------------------------------------
 
 
-def _resolve_csa_indexer_loss_topk_effective(
-    config, index_topk: int, n_compressed: int
-) -> int:
-    """Return the TileLang CSA indexer top-k width used by indexer loss.
-
-    Phase semantics (driven by ``dsa_indexer_use_sparse_loss``, **not** by the
-    new TileLang switches):
-
-    * Phase 3 (``dsa_indexer_use_sparse_loss=True``): ``min(index_topk,
-      n_compressed)`` — selected-topk semantics, same as the existing
-      ``FusedDSAIndexerLoss`` / ``CSAIndexer.forward`` choice.
-    * Phase 2 (``dsa_indexer_use_sparse_loss=False``): ``n_compressed`` — the
-      selected set covers the full compressed candidate range and is later
-      consumed as full-range KL by the indexer loss path.
-    """
-    use_sparse_loss = bool(getattr(config, "dsa_indexer_use_sparse_loss", True))
-    if use_sparse_loss:
-        return min(int(index_topk), int(n_compressed))
-    return int(n_compressed)
-
-
-def _resolve_csa_indexer_attn_topk_effective(
-    index_topk: int, n_compressed: int
-) -> int:
-    """Return the compressed top-k width consumed by main CSA attention."""
-    return min(int(index_topk), int(n_compressed))
-
-
 def _map_compressed_topk_to_kv_full(
     topk_indices_compressed: Tensor,
     sq: int,
@@ -2233,6 +2205,23 @@ class CompressedSparseAttention(FleetLayer):
         )
         self.indexer_loss_coeff = getattr(config, "dsa_indexer_loss_coeff", 0.0)
 
+    def _resolve_topk_effective(self, n_compressed: int):
+        """Return the CSA indexer top-k width for current phase.
+
+        Phase semantics (driven by `dsa_indexer_use_sparse_loss`):
+        * Phase 3 (`dsa_indexer_use_sparse_loss=True`): select topk, same as the
+          existing `FusedDSAIndexerLoss` / `CSAIndexer.forward` choice.
+        * Phase 2 (`dsa_indexer_use_sparse_loss=False`): `n_compressed` - select
+          full compressed candidate range and is later consumed as full-range KL
+          by the indexer loss path.
+        """
+        use_sparse_loss = getattr(
+            self.config, "dsa_indexer_use_sparse_loss", True
+        )
+        if use_sparse_loss:
+            return min(self.indexer.index_topk, n_compressed)
+        return n_compressed
+
     def _compute_indexer_compressed_topk_idxs(
         self,
         query: Tensor,
@@ -2268,15 +2257,7 @@ class CompressedSparseAttention(FleetLayer):
         # only materialize main-attention indices. The backend branch remains
         # fixed across both forwards.
         need_indexer_loss = self.training and paddle.is_grad_enabled()
-        loss_topk_effective = _resolve_csa_indexer_loss_topk_effective(
-            self.config,
-            self.indexer.index_topk,
-            n_compressed,
-        )
-        attn_topk_effective = _resolve_csa_indexer_attn_topk_effective(
-            self.indexer.index_topk,
-            n_compressed,
-        )
+        topk_effective = self._resolve_topk_effective(n_compressed)
 
         causal_mask = _build_compressed_causal_mask(
             self.compress_ratio,
@@ -2321,7 +2302,7 @@ class CompressedSparseAttention(FleetLayer):
                     index_k_comp,
                     weights,
                     ratio=self.compress_ratio,
-                    topk_effective=attn_topk_effective,
+                    topk_effective=topk_effective,
                     valid_range=valid_range,
                     startend_row_indices=startend_row_indices,
                     doc_lens=doc_lens_list,
@@ -2350,7 +2331,7 @@ class CompressedSparseAttention(FleetLayer):
                     index_k_comp,
                     weights,
                     ratio=self.compress_ratio,
-                    topk_effective=attn_topk_effective,
+                    topk_effective=topk_effective,
                     valid_range=valid_range,
                 )
 
@@ -2385,7 +2366,7 @@ class CompressedSparseAttention(FleetLayer):
                     query.detach(),
                     key_for_loss.detach(),
                     self.softmax_scale,
-                    min(self.indexer.index_topk, n_compressed),
+                    topk_effective,
                     indexer_loss_coeff,
                     mask_for_loss,
                     getattr(self.config, "dsa_indexer_use_sparse_loss", True),
@@ -2426,10 +2407,10 @@ class CompressedSparseAttention(FleetLayer):
             )
 
         if (
-            topk_indices_compressed.shape[-1] > attn_topk_effective
+            topk_indices_compressed.shape[-1] > topk_effective
         ):  # Loss path may return wider top-k than attention consumes.
             topk_indices_compressed = topk_indices_compressed[
-                ..., :attn_topk_effective
+                ..., :topk_effective
             ].contiguous()
 
         compress_topk_idxs = _map_compressed_topk_to_kv_full(
@@ -2735,6 +2716,7 @@ class CompressedSparseAttention(FleetLayer):
             sq,
             docmask_meta=docmask_meta,
         )
+        window_idxs = window_idxs.astype("int32").contiguous()
 
         # Step 4: Compressed indices
         indexer_loss = None
@@ -2772,6 +2754,7 @@ class CompressedSparseAttention(FleetLayer):
                     offset,
                     docmask_meta=docmask_meta,
                 )
+            compress_topk_idxs = compress_topk_idxs.astype("int32")
 
             # For cudnn's second forward (both indexer and SA should be cudnn),
             # use [compress, window] order to generate lse_indexer. Otherwise,
@@ -3027,6 +3010,7 @@ class CompressedSparseAttention(FleetLayer):
             window_idxs = full_window_idxs[
                 :, position_offset : position_offset + sq, ...
             ]
+        window_idxs = window_idxs.astype("int32").contiguous()
 
         # Step 2: All-gather KV + compress
         kv_local = key.squeeze(2)  # [b, sq, hn]
@@ -3099,11 +3083,8 @@ class CompressedSparseAttention(FleetLayer):
                     and self.training
                     and paddle.is_grad_enabled()
                 )
-                loss_topk_effective = _resolve_csa_indexer_loss_topk_effective(
-                    self.config, self.indexer.index_topk, n_compressed_global
-                )
-                attn_topk_effective = _resolve_csa_indexer_attn_topk_effective(
-                    self.indexer.index_topk, n_compressed_global
+                topk_effective = self._resolve_topk_effective(
+                    n_compressed_global
                 )
 
                 # valid_range for varlen: [b, sq_local, 2] or None
@@ -3149,7 +3130,7 @@ class CompressedSparseAttention(FleetLayer):
                                     k_indexer_global,
                                     weights_indexer_bf,
                                     ratio=self.compress_ratio,
-                                    topk_effective=attn_topk_effective,
+                                    topk_effective=topk_effective,
                                     valid_range=valid_range,
                                     startend_row_indices=docmask_meta.startend_row_indices
                                     if docmask_meta is not None
@@ -3179,7 +3160,7 @@ class CompressedSparseAttention(FleetLayer):
                                     k_indexer_global,
                                     weights_indexer_bf,
                                     ratio=self.compress_ratio,
-                                    topk_effective=attn_topk_effective,
+                                    topk_effective=topk_effective,
                                     seq_offset=position_offset,
                                     valid_range=valid_range,
                                 )
@@ -3242,7 +3223,7 @@ class CompressedSparseAttention(FleetLayer):
                         query.detach(),
                         key_for_loss.detach(),
                         self.softmax_scale,
-                        min(self.indexer.index_topk, n_compressed_global),
+                        topk_effective,
                         indexer_loss_coeff,
                         mask_for_loss,
                         getattr(
@@ -3289,15 +3270,15 @@ class CompressedSparseAttention(FleetLayer):
                         q_indexer_bf,
                         k_indexer_global,
                         weights_indexer_bf,
-                        attn_topk_effective,
+                        topk_effective,
                         causal_mask,
                     )
 
                 if (
-                    topk_indices_compressed.shape[-1] > attn_topk_effective
+                    topk_indices_compressed.shape[-1] > topk_effective
                 ):  # CP loss path may return wider top-k than attention consumes.
                     topk_indices_compressed = topk_indices_compressed[
-                        ..., :attn_topk_effective
+                        ..., :topk_effective
                     ].contiguous()
 
                 compress_topk_idxs = map_compressed_topk_to_kv_full_cp(
@@ -3323,6 +3304,8 @@ class CompressedSparseAttention(FleetLayer):
                     compress_topk_idxs = compress_topk_idxs[
                         :, position_offset : position_offset + sq, ...
                     ]
+
+            compress_topk_idxs = compress_topk_idxs.astype("int32")
 
             if (
                 self.indexer is not None

--- a/src/paddlefleet/triton_ops/document_mask_fusion.py
+++ b/src/paddlefleet/triton_ops/document_mask_fusion.py
@@ -341,9 +341,6 @@ def window_topk_idxs_kernel(
     Trailing padding is supported: a position ``i`` is a valid query iff
     ``pos_in_doc[i] = i - doc_start[i] < doc_len[i]`` (equivalently ``i`` is
     inside a real document). Invalid (padding) query rows are filled with -1.
-
-    All arithmetic stays in int32: seqlen fits comfortably, so this avoids
-    mixed-width issues while the output buffer is int64.
     """
     pid = tl.program_id(0)  # position index i
     pos = pid
@@ -386,7 +383,7 @@ def window_topk_idxs_triton(
         window_size: positive window length.
 
     Returns:
-        int64 tensor [1, seqlen, window_size]; each valid row holds the
+        int32 tensor [1, seqlen, window_size]; each valid row holds the
         sliding-window source indices for a position, with out-of-window slots
         set to -1; padding-query rows are all -1.
     """
@@ -401,7 +398,7 @@ def window_topk_idxs_triton(
     dl = doc_len_per_pos.contiguous()
 
     (seqlen,) = ds.shape
-    out = paddle.empty([seqlen, window_size], dtype="int64")
+    out = paddle.empty([seqlen, window_size], dtype="int32")
 
     BLOCK_W = min(triton.next_power_of_2(window_size), 2048)
     grid = (seqlen,)

--- a/tests/multi_card_tests/transformer/test_csa_attention_cp.py
+++ b/tests/multi_card_tests/transformer/test_csa_attention_cp.py
@@ -992,6 +992,7 @@ class TestCudnnIndexerDocmaskCP(unittest.TestCase):
             startend_row_indices=None,
             doc_lens=None,
             seq_offset=0,
+            **kwargs,
         ):
             captured["q_shape"] = list(q.shape)
             captured["k_shape"] = list(k.shape)

--- a/tests/single_card_tests/custom_ops/test_tilelang_csa_indexer.py
+++ b/tests/single_card_tests/custom_ops/test_tilelang_csa_indexer.py
@@ -1364,12 +1364,12 @@ class TestTileLangCSAIndexerLossAutoScaler(unittest.TestCase):
         DSAIndexerLossAutoScaler._main_loss_backward_scale = None
         result = TileLangCSAIndexerLossAutoScaler.apply(
             output,
+            target.detach(),
             index_q_d,
             weights_d,
             index_k_d,
             topk_indices.detach(),
             topk_probs.detach(),
-            target.detach(),
             loss_coeff,
         )
         # Backward through the auto-scaler

--- a/tests/single_card_tests/transformer/test_csa_loss_mask.py
+++ b/tests/single_card_tests/transformer/test_csa_loss_mask.py
@@ -49,21 +49,19 @@ class TestComputeTileLangLossMask(unittest.TestCase):
         _skip_no_cuda(self)
         paddle.set_device("gpu")
 
-    @patch("paddlefleet.tilelang_ops.csa_indexer_topk_fwd")
     @patch("paddlefleet.tilelang_ops.csa_attn_target_reducesum")
-    def test_loss_mask_reduces_loss(self, mock_target, mock_topk):
-        """Call _compute_fused_csa_indexer_loss_forward with loss_mask."""
+    def test_loss_mask_reduces_loss(self, mock_target):
+        """Call _compute_fused_indexer_target with loss_mask."""
         from paddlefleet.transformer.csa_attention import (
-            _compute_fused_csa_indexer_loss_forward,
+            CompressedSparseAttention as CSA,
+            DSAIndexerLossLoggingHelper as Logging,
         )
 
         b, sq, topk, d = 2, 8, 4, 16
-        # Mock topk_fwd to return indices and probs
         topk_indices = paddle.randint(0, 2, [b, sq, topk]).cast("int64")
         topk_probs = paddle.nn.functional.softmax(
             paddle.randn([b, sq, topk], dtype="float32"), axis=-1
         )
-        mock_topk.return_value = (topk_indices, topk_probs)
 
         # Mock target computation
         target = paddle.nn.functional.softmax(
@@ -82,32 +80,35 @@ class TestComputeTileLangLossMask(unittest.TestCase):
         loss_mask[:, sq // 2 :] = 0.0
         global_valid_count = max(float(loss_mask.sum()), 1.0)
 
-        loss_with, _, _, _ = _compute_fused_csa_indexer_loss_forward(
-            index_q,
-            weights,
-            index_k,
-            query_mla,
-            key_mla,
-            valid_range,
-            4,
-            topk,
-            0.125,
-            1.0,
-            loss_mask=loss_mask,
-            global_valid_count=global_valid_count,
+        ctx = MagicMock(
+            indexer_backend="tilelang",
+            indexer_loss_coeff=0.5,
         )
-        loss_without, _, _, _ = _compute_fused_csa_indexer_loss_forward(
-            index_q,
-            weights,
-            index_k,
-            query_mla,
-            key_mla,
-            valid_range,
-            4,
-            topk,
-            0.125,
-            1.0,
-        )
+
+        with (
+            patch.object(Logging, "save_loss_to_tracker") as mock_save,
+            patch.object(Logging, "get_total_num_layers"),
+        ):
+            CSA._compute_fused_indexer_target(
+                ctx,
+                index_q,
+                index_k,
+                topk_indices,
+                topk_probs,
+                loss_mask=loss_mask,
+                global_valid_count=global_valid_count,
+            )
+            loss_with = mock_save.call_args.kwargs["loss"]
+
+            CSA._compute_fused_indexer_target(
+                ctx,
+                index_q,
+                index_k,
+                topk_indices,
+                topk_probs,
+            )
+            loss_without = mock_save.call_args.kwargs["loss"]
+
         self.assertFalse(paddle.allclose(loss_with, loss_without).item())
 
 
@@ -160,12 +161,12 @@ class TestAutoScalerBackwardLossMask(unittest.TestCase):
 
         result = TileLangCSAIndexerLossAutoScaler.apply(
             output,
+            target,
             index_q,
             weights,
             index_k,
             topk_indices,
             topk_probs,
-            target,
             1.0,
             "tilelang",
             10.0,
@@ -343,12 +344,12 @@ class TestCSAForwardLossMaskComputation(unittest.TestCase):
         self.assertIsNone(loss_mask)
         self.assertIsNone(global_valid_count)
 
-    @patch(
-        "paddlefleet.transformer.csa_attention._compute_fused_csa_indexer_loss_forward"
-    )
     @patch("paddlefleet.fusions.csa_sparse_attn.csa_sparse_attn")
-    def test_csa_forward_with_input_ids(self, mock_sparse_attn, mock_loss_fwd):
-        """Call CompressedSparseAttention.forward with input_ids to cover lines 1784-1805."""
+    def test_csa_forward_with_input_ids(self, mock_sparse_attn):
+        """
+        Call CompressedSparseAttention.forward with input_ids to cover
+        loss_mask & global_valid_count generation.
+        """
         from paddlefleet.transformer.csa_attention import (
             CompressedSparseAttention,
             CompressedSparseAttentionSublayersSpec,
@@ -377,6 +378,7 @@ class TestCSAForwardLossMaskComputation(unittest.TestCase):
             attention_type="self",
             compress_ratio=0,
         )
+        csa.indexer = nn.Identity()  # mock indexer existence (never called)
 
         query = paddle.randn([b, sq, np_heads, hn], dtype="float32")
         key = paddle.randn([b, sq, 1, hn], dtype="float32")

--- a/tests/single_card_tests/transformer/test_dsv4_hybrid_attention.py
+++ b/tests/single_card_tests/transformer/test_dsv4_hybrid_attention.py
@@ -15,7 +15,7 @@
 import sys
 import unittest
 from functools import wraps
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import paddle
@@ -85,8 +85,6 @@ from paddlefleet.transformer.csa_attention import (
     CSADocMaskMetadata,
     _apply_rope,
     _build_compressed_causal_mask,
-    _resolve_csa_indexer_attn_topk_effective,
-    _resolve_csa_indexer_loss_topk_effective,
     get_compress_topk_idxs,
     get_mqa_causal_topk_idxs,
     get_valid_range,
@@ -517,29 +515,30 @@ class TestDSv4HybridConfigAndSpec(unittest.TestCase):
                 compress_ratio=4,
             )
 
-    def test_phase2_loss_topk_does_not_expand_attention_topk(self):
+    def test_topk_effective_in_phase2_and_phase3(self):
         config = _make_config(
             dsa_index_topk=2,
         )
         n_compressed = 8
 
+        ctx = MagicMock(
+            config=config,
+            indexer=MagicMock(index_topk=config.dsa_index_topk),
+        )
+
+        # phase2 uses full range
         self.assertEqual(
-            _resolve_csa_indexer_loss_topk_effective(
-                config, config.dsa_index_topk, n_compressed
+            CompressedSparseAttention._resolve_topk_effective(
+                ctx, n_compressed
             ),
             n_compressed,
         )
-        self.assertEqual(
-            _resolve_csa_indexer_attn_topk_effective(
-                config.dsa_index_topk, n_compressed
-            ),
-            config.dsa_index_topk,
-        )
 
+        # phase 3 uses the configured topk
         config.dsa_indexer_use_sparse_loss = True
         self.assertEqual(
-            _resolve_csa_indexer_loss_topk_effective(
-                config, config.dsa_index_topk, n_compressed
+            CompressedSparseAttention._resolve_topk_effective(
+                ctx, n_compressed
             ),
             config.dsa_index_topk,
         )
@@ -1490,6 +1489,89 @@ class TestDSv4HybridDocumentRoPE(unittest.TestCase):
             ).item(),
             "cuDNN-indexer docmask: packed doc1 != doc1 alone",
         )
+
+    def test_cudnn_indexer_with_cudnn_sparse_attn(self):
+        """Test the path where both indexer and sparse_attn use cudnn."""
+        import paddlefleet_ops.cudnn.deepseek_sparse_attention as DSA
+
+        import paddlefleet.cudnn_ops.attn.csa_sparse_attn_fwd_cudnn as SA
+        import paddlefleet.cudnn_ops.indexer.csa_indexer_fwd_cudnn as IND
+
+        paddle.seed(_SEED)
+        ratio = 4
+        config = _make_config(
+            csa_compress_ratios=[ratio],
+            num_layers=1,
+            csa_indexer_backend="cudnn",
+            csa_sparse_attn_backend="cudnn",
+        )
+        model_parallel_cuda_manual_seed(_SEED)
+        attn = _build_attention(config, layer_number=0)
+        attn.train()
+
+        seq_len = 128
+        seq_len_comp = seq_len // ratio
+        hidden_states = paddle.randn(
+            [1, seq_len, config.hidden_size], dtype="bfloat16"
+        )
+        startend_row_indices = paddle.full(
+            [1, 1, seq_len, 1], seq_len, dtype="int32"
+        )
+
+        # Mock cudnn kernel outputs
+        valid_mask = paddle.arange(1, seq_len + 1).unsqueeze(
+            1
+        ) >= paddle.arange(ratio, seq_len + ratio, ratio)
+        topk_indices = paddle.arange(seq_len_comp, dtype="int32").broadcast_to(
+            [1, seq_len, seq_len_comp]
+        )
+        topk_indices = paddle.where(
+            valid_mask, topk_indices, paddle.to_tensor(-1, dtype="int32")
+        )
+
+        topk_scores = paddle.randn([1, seq_len, seq_len_comp], dtype="float32")
+        topk_scores = paddle.where(
+            valid_mask,
+            topk_scores,
+            paddle.to_tensor(float("-inf"), dtype="float32"),
+        )
+
+        def _mock_indexer_topk(index_q, index_k_comp, weights, **kwargs):
+            self.assertEqual(kwargs.get("topk_effective"), seq_len_comp)
+            self.assertTrue(kwargs.get("return_topk_scores"))
+            return topk_indices, None, topk_scores
+
+        def _mock_flash_mla(q, kv, attn_sink, topk_idxs, **kwargs):
+            self.assertEqual(kwargs.get("indexer_topk"), seq_len_comp)
+            output = paddle.randn(
+                [*q.shape[:3], kv.shape[-1]], dtype="bfloat16"
+            )
+            lse = paddle.randn(q.shape[:3], dtype="float32")
+            return output, lse, lse
+
+        def _mock_target(
+            q_attn, k_attn, lse, topk_indices, softmax_scale, **kwargs
+        ):
+            self.assertEqual(type(q_attn.shape), tuple)
+            self.assertEqual(type(q_attn.stride()), tuple)
+            self.assertEqual(type(q_attn.stride(0)), int)
+            target = paddle.randn([1, seq_len, seq_len_comp], dtype="float32")
+            return {"target": target}
+
+        with (
+            patch.object(IND, "cudnn_indexer_topk_fwd", _mock_indexer_topk),
+            patch.object(SA, "flash_mla_sparse_attn", _mock_flash_mla),
+            patch.object(
+                DSA, "sparse_attn_score_recompute_wrapper", _mock_target
+            ),
+        ):
+            output, _ = attn(
+                hidden_states,
+                attention_mask=None,
+                attn_mask_startend_row_indices=startend_row_indices,
+            )
+
+        self.assertTrue(output.isfinite().all().item())
 
 
 class TestDSv4HybridAttentionConstructor(unittest.TestCase):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
Operator Mechanism


### PR Types
Performance


### Description

本 PR 包括两项重大改进：
* 接入 cudnn 的`sparse_attn_score_recompute_wrapper`用于平行替换 tilelang 的`target_kernel`，单算子<b>性能提高 20 倍</b>
* 调整了 CSA 的前向计算顺序：
  * 原来是: `compressor -> topk_indices -> target_loss -> sparse_attn`
  * 现在是: `compressor -> topk_indices -> sparse_attn -> target_loss`
  * 这样计算 target 的时候就可以利用 sparse_attn 输出的 lse_indexer 减少重复计算


### 是否引起精度变化
是

本 PR 的两项修改对精度的影响要分开看，调整 CSA 前向顺序这个是完全不影响精度的（在实现正确的情况下），只有换 target_kernel 这个影响，当然应该是零偏的

下面对不同的 backend 和是否开 CP 进行分类测试：

| indexer | sparse_attn | CP | 前向逐位 | 反向逐位 | 收敛零偏 |
| :-: | :-: | :-: | :-: | :-: | :-: |
| tilelang | tilelang | 1 | ✅ | ✅ | 无需测试
| tilelang | cudnn | 1 | ✅ | 合理误差 | ✅
| cudnn | cudnn | 1 | 合理误差 | 合理误差 | ✅
| tilelang | tilelang | 4 | ✅ | ✅ | 无需测试
| tilelang | cudnn | 4 | ✅ | 合理误差 | ✅
| cudnn | cudnn | 4 | 合理误差 | 合理误差 | ✅

（baseline 均为相同配置的老代码，收敛使用 8K 数据集对比 phase2 的 indexer_loss）