### PR TITLE
[release/0.4][Deps] Bump Paddle to 0fbc62db73b

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ description = "Fleet Core - Core Functional Library for Large Scale Distributed 
 requires-python = ">=3.10"
 dependencies = [
     "colorlog>=6.10.1",
-    "paddlepaddle-gpu==3.4.0.post20260728+8a1040b3d08",
+    "paddlepaddle-gpu==3.4.0.post20260730+0fbc62db73b",
     "tilelang-paddle",
 ]
 license = { text = "Apache 2.0" }


### PR DESCRIPTION
### PR Category
Environment Adaptation

### PR Types
Others

### Description
Bump the pinned CUDA 12.9 Paddle dependency on `release/0.4` from `paddlepaddle-gpu==3.4.0.post20260728+8a1040b3d08` to `paddlepaddle-gpu==3.4.0.post20260730+0fbc62db73b`.

Target Paddle commit: [`0fbc62db73b27dd388a9a38fa79e91b151157ee9`](https://github.com/PaddlePaddle/Paddle/commit/0fbc62db73b27dd388a9a38fa79e91b151157ee9) on `release/3.4`.

Dev PR: #1598 (pending merge; this release PR must remain blocked until it merges).

The version follows Paddle/PaddleFleet's unambiguous release-nightly convention: `3.4.0.post<UTC commit date>+<first 11 commit characters>`.

**Artifact verification:** the CUDA 12.9 wheel is now synchronized. Its package metadata and embedded version data verify `paddlepaddle-gpu==3.4.0.post20260730+0fbc62db73b`, the full target commit, CUDA 12.9, and the `cp312-cp312-linux_x86_64` tag. Linux x86_64 CPython 3.12 [Test-release validation](https://github.com/PaddlePaddle/PaddleFleet/actions/runs/30576018100) completed successfully: PaddleFleet wheel build, single- and multi-card unit tests, A100 integration, H20 single- and multi-card integration, and coverage upload/check all passed.

### 是否引起精度变化
否
