### PR TITLE
[MoE] Fix MTP balance log key collision

### DIFF
--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -905,6 +905,7 @@ class MoELayer(nn.Layer):
                 self.moe_group,
                 self.num_experts_per_tok,
                 self.token_dispatcher.get_dispatched_routing()[2],
+                is_mtp_layer=self.is_mtp_layer,
             )
         with profile("fusion_mlp"):
             hidden_states = self.routed_experts_compute(hidden_states)
@@ -943,6 +944,7 @@ class MoELayer(nn.Layer):
                 self.moe_group,
                 self.num_experts_per_tok,
                 tokens_per_expert,
+                is_mtp_layer=self.is_mtp_layer,
             )
         fp8_combine_grad_handle = {} if self.fp8_dispatch_bwd else None
         # fp8_combine_grad_handle = None

--- a/src/paddlefleet/transformer/moe/moe_utils.py
+++ b/src/paddlefleet/transformer/moe/moe_utils.py
@@ -448,7 +448,7 @@ def _all_gather_local_tokens(local_tokens_per_expert, group):
     return output.reshape([get_pg_size(group), -1])
 
 
-def _log_summary(key, layer_number, summary_data):
+def _log_summary(key, layer_number, summary_data, is_mtp_layer=False):
     logs = get_global_training_logs()
     if logs is None or not hasattr(logs, "update"):
         return
@@ -466,7 +466,8 @@ def _log_summary(key, layer_number, summary_data):
     max_mean_ratio = max_value / mean_value if mean_value != 0 else 1.0
     min_mean_ratio = min_value / mean_value if mean_value != 0 else 1.0
 
-    prefix = f"{key}_layer_{layer_number}"
+    layer_prefix = "mtp_layer" if is_mtp_layer else "layer"
+    prefix = f"{key}_{layer_prefix}_{layer_number}"
     logs.update(
         **{
             f"{prefix}_max": max_value,
@@ -480,21 +481,42 @@ def _log_summary(key, layer_number, summary_data):
     )
 
 
-def _log_tokens_per_expert(layer_number, key, summary_data, count):
+def _log_tokens_per_expert(
+    layer_number,
+    key,
+    summary_data,
+    count,
+    is_mtp_layer=False,
+):
     count = count.reshape([1]).astype("float32")
     count = paddle.ones_like(count) if count.item() == 0 else count
     avg_data = summary_data.astype("float32") / count
 
-    _log_summary(f"{key}_avg", layer_number, avg_data)
-    _log_summary(key, layer_number, summary_data)
+    _log_summary(
+        f"{key}_avg",
+        layer_number,
+        avg_data,
+        is_mtp_layer=is_mtp_layer,
+    )
+    _log_summary(
+        key,
+        layer_number,
+        summary_data,
+        is_mtp_layer=is_mtp_layer,
+    )
 
 
-def _log_local_tokens_per_card(layer_number, local_tokens_by_rank):
+def _log_local_tokens_per_card(
+    layer_number,
+    local_tokens_by_rank,
+    is_mtp_layer=False,
+):
     card_totals = local_tokens_by_rank.sum(axis=1)
     _log_summary(
         "local_tokens_per_card",
         layer_number,
         card_totals,
+        is_mtp_layer=is_mtp_layer,
     )
 
 
@@ -503,6 +525,7 @@ def log_moe_balance(
     moe_group,
     num_experts_per_tok,
     tokens_per_expert,
+    is_mtp_layer=False,
 ):
     """Log fixed-topk MoE balance summaries from dispatched expert counts."""
     if tokens_per_expert is None:
@@ -536,8 +559,13 @@ def log_moe_balance(
             "tokens_per_expert",
             summary.clone() if isinstance(summary, paddle.Tensor) else summary,
             count,
+            is_mtp_layer=is_mtp_layer,
         )
-        _log_local_tokens_per_card(layer_number, local_tokens_by_rank)
+        _log_local_tokens_per_card(
+            layer_number,
+            local_tokens_by_rank,
+            is_mtp_layer=is_mtp_layer,
+        )
 
 
 def is_tensor(data):

--- a/tests/single_card_tests/transformer/test_moe_log_balance.py
+++ b/tests/single_card_tests/transformer/test_moe_log_balance.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import paddle
 
@@ -23,6 +25,7 @@ from paddlefleet.training.global_vars import (
     unset_global_variables,
 )
 from paddlefleet.transformer.moe import moe_utils
+from paddlefleet.transformer.moe.moe_layer import MoELayer
 from paddlefleet.transformer.moe.moe_utils import (
     _all_gather_local_tokens,
     global_moe_balance_training_logs_enabled,
@@ -120,6 +123,130 @@ class TestMoeBalanceLogging(unittest.TestCase):
         self.assertAlmostEqual(logs["local_tokens_per_card_layer_1_mean"], 16.0)
         self.assertAlmostEqual(
             logs["local_tokens_per_card_layer_1_max_mean_ratio"], 1.0
+        )
+
+    def test_mtp_balance_logs_do_not_overwrite_backbone_layer(self):
+        log_moe_balance(
+            layer_number=0,
+            moe_group=None,
+            num_experts_per_tok=2,
+            tokens_per_expert=[2, 4, 6, 8],
+        )
+        log_moe_balance(
+            layer_number=0,
+            moe_group=None,
+            num_experts_per_tok=2,
+            tokens_per_expert=[1, 3, 5, 7],
+            is_mtp_layer=True,
+        )
+        logs = get_global_training_logs()
+
+        self.assertAlmostEqual(logs["tokens_per_expert_layer_0_mean"], 5.0)
+        self.assertAlmostEqual(logs["tokens_per_expert_mtp_layer_0_mean"], 4.0)
+        self.assertAlmostEqual(logs["tokens_per_expert_avg_layer_0_mean"], 0.5)
+        self.assertAlmostEqual(
+            logs["tokens_per_expert_avg_mtp_layer_0_mean"], 0.5
+        )
+        self.assertAlmostEqual(logs["local_tokens_per_card_layer_0_mean"], 20.0)
+        self.assertAlmostEqual(
+            logs["local_tokens_per_card_mtp_layer_0_mean"], 16.0
+        )
+
+    def test_custom_forward_marks_mtp_balance_logs(self):
+        tokens_per_expert = paddle.to_tensor([1, 3, 5, 7], dtype="int64")
+        hidden_states = paddle.ones([2, 4])
+        moe_layer = SimpleNamespace(
+            use_latent_moe=False,
+            dispatch=MagicMock(return_value=(hidden_states, None)),
+            layer_number=0,
+            is_mtp_layer=True,
+            moe_group=None,
+            num_experts_per_tok=2,
+            token_dispatcher=SimpleNamespace(
+                get_dispatched_routing=MagicMock(
+                    return_value=(None, None, tokens_per_expert)
+                )
+            ),
+            routed_experts_compute=lambda value: value,
+            combine=lambda value: value,
+        )
+
+        with (
+            patch(
+                "paddlefleet.transformer.moe.moe_layer.framework."
+                "_dygraph_tracer",
+                return_value=SimpleNamespace(_has_grad=True),
+            ),
+            patch(
+                "paddlefleet.transformer.moe.moe_layer."
+                "global_moe_balance_training_logs_enabled",
+                return_value=True,
+            ),
+            patch(
+                "paddlefleet.transformer.moe.moe_layer.log_moe_balance"
+            ) as log_moe_balance_mock,
+        ):
+            MoELayer.custom_forward(moe_layer, hidden_states, None, None)
+
+        log_moe_balance_mock.assert_called_once_with(
+            0,
+            None,
+            2,
+            tokens_per_expert,
+            is_mtp_layer=True,
+        )
+
+    def test_fusion_forward_marks_mtp_balance_logs(self):
+        tokens_per_expert = paddle.to_tensor([1, 3, 5, 7], dtype="int64")
+        hidden_states = paddle.ones([2, 4])
+        moe_layer = SimpleNamespace(
+            _project_to_latent=lambda value: value,
+            dispatch=MagicMock(return_value=(hidden_states, None)),
+            layer_number=0,
+            is_mtp_layer=True,
+            moe_group=None,
+            num_experts_per_tok=2,
+            token_dispatcher=SimpleNamespace(
+                get_dispatched_routing=MagicMock(
+                    return_value=(None, None, tokens_per_expert)
+                )
+            ),
+            fp8_dispatch_bwd=False,
+            _use_hybrid_ep_fusion=lambda: True,
+            _run_hybrid_ep_fusion=lambda value, probs, **kwargs: value,
+            combine=lambda value, **kwargs: value,
+            use_latent_moe=False,
+        )
+
+        with (
+            patch(
+                "paddlefleet.transformer.moe.moe_layer.framework."
+                "_dygraph_tracer",
+                return_value=SimpleNamespace(_has_grad=True),
+            ),
+            patch(
+                "paddlefleet.transformer.moe.moe_layer."
+                "global_moe_balance_training_logs_enabled",
+                return_value=True,
+            ),
+            patch(
+                "paddlefleet.transformer.moe.moe_layer.log_moe_balance"
+            ) as log_moe_balance_mock,
+        ):
+            MoELayer.fusion_moe_forward(
+                moe_layer,
+                hidden_states,
+                None,
+                None,
+                combine_overlap_handle={},
+            )
+
+        log_moe_balance_mock.assert_called_once_with(
+            0,
+            None,
+            2,
+            tokens_per_expert,
+            is_mtp_layer=True,
         )
 
     def test_logs_object_enable_balance_gate(self):


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
- 修复 MTP 层与主干层 `layer_number` 相同时 MoE balance 指标 key 冲突，避免 MTP 指标覆盖主干指标。
- 保持主干 `*_layer_<idx>_*` key 不变，MTP 指标使用独立的 `*_mtp_layer_<idx>_*` 命名空间。

### 是否引起精度变化
否
