### PR TITLE
[cp release/0.4]Add missing muon slice specs for DSv4 hybrid grouped weights

### DIFF
--- a/src/paddlefleet/transformer/dsv4_hybrid_attention.py
+++ b/src/paddlefleet/transformer/dsv4_hybrid_attention.py
@@ -748,7 +748,7 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
         )
 
     def muon_slice_specs(self, muon_configs):
-        """Muon orthogonal-slice spec for the DSv4 hybrid q-up projection."""
+        """Muon orthogonal-slice specs for the DSv4 hybrid projections."""
         from paddlefleet.transformer.muon_utils import ortho_per_head
 
         if (
@@ -757,12 +757,28 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
         ):
             return {}
 
-        return {
+        specs = {
             "linear_q_up_proj.weight": (
                 ortho_per_head,
                 {"heads": self.num_attention_heads_per_partition},
             ),
+            # Stored as [o_groups * o_lora_rank, d] but used as [g, r, d] in a
+            # grouped gemm, so the leading axis packs o_groups independent
+            # matrices and must be split along axis 0.
+            "linear_o_group_proj": (
+                ortho_per_head,
+                {"heads": self.o_local_groups, "axis": 0},
+            ),
         }
+        if getattr(self, "gate_proj", None) is not None:
+            # The gate multiplies the flattened grouped-projection output, whose
+            # columns are group-major (group g owns o_lora_rank columns), so the
+            # gate weight is fused per o-group rather than per head.
+            specs["gate_proj.weight"] = (
+                ortho_per_head,
+                {"heads": self.o_local_groups},
+            )
+        return specs
 
     def get_query_key_value_tensors(
         self,

--- a/tests/single_card_tests/transformer/test_muon_slice_specs.py
+++ b/tests/single_card_tests/transformer/test_muon_slice_specs.py
@@ -27,14 +27,19 @@ from types import SimpleNamespace
 
 import paddle
 
-from paddlefleet.transformer.attention import SelfAttention, SelfAttentionVHA
+from paddlefleet.transformer.attention import (
+    SelfAttention,
+    SelfAttentionVHA,
+)
 from paddlefleet.transformer.csa_attention import Compressor, CSAIndexer
 from paddlefleet.transformer.dsv4_hybrid_attention import (
     DSv4HybridSelfAttention,
 )
 from paddlefleet.transformer.mlp import MLP
 from paddlefleet.transformer.moe.moe_expert import GroupedMLPExpert
-from paddlefleet.transformer.multi_latent_attention import MLASelfAttention
+from paddlefleet.transformer.multi_latent_attention import (
+    MLASelfAttention,
+)
 from paddlefleet.transformer.muon_utils import (
     ortho_blocks,
     ortho_gate_up,
@@ -396,16 +401,65 @@ class TestMLASpecs(unittest.TestCase):
 
 
 class TestDSv4HybridSpecs(unittest.TestCase):
+    def _fake(self, gated=False):
+        return SimpleNamespace(
+            num_attention_heads_per_partition=4,
+            o_local_groups=2,
+            gate_proj=object() if gated else None,
+        )
+
     def test_specs(self):
-        fake = SimpleNamespace(num_attention_heads_per_partition=4)
+        fake = self._fake()
         specs = DSv4HybridSelfAttention.muon_slice_specs(fake, {})
-        self.assertEqual(set(specs), {"linear_q_up_proj.weight"})
-        _run_specs(specs, {"linear_q_up_proj.weight": [HIDDEN, 4 * 4]})
+        self.assertEqual(
+            set(specs), {"linear_q_up_proj.weight", "linear_o_group_proj"}
+        )
+        recorders = _run_specs(
+            specs,
+            {
+                "linear_q_up_proj.weight": [HIDDEN, 4 * 4],
+                # [o_local_groups * o_lora_rank, d], split along axis 0.
+                "linear_o_group_proj": [2 * 3, HIDDEN],
+            },
+        )
+        self.assertEqual(
+            recorders["linear_o_group_proj"].shapes,
+            [(3, HIDDEN), (3, HIDDEN)],
+        )
+
+    def test_gated_slices_gate_per_o_group(self):
+        fake = self._fake(gated=True)
+        specs = DSv4HybridSelfAttention.muon_slice_specs(fake, {})
+        self.assertEqual(
+            set(specs),
+            {
+                "linear_q_up_proj.weight",
+                "linear_o_group_proj",
+                "gate_proj.weight",
+            },
+        )
+        # gate width == o_local_groups * o_lora_rank, sliced into o_lora_rank
+        # wide blocks.
+        recorders = _run_specs(
+            specs,
+            {
+                "linear_q_up_proj.weight": [HIDDEN, 4 * 4],
+                "linear_o_group_proj": [2 * 3, HIDDEN],
+                "gate_proj.weight": [HIDDEN, 2 * 3],
+            },
+        )
+        self.assertEqual(
+            recorders["gate_proj.weight"].shapes,
+            [(HIDDEN, 3), (HIDDEN, 3)],
+        )
+
+    def test_gate_proj_absent_is_guarded(self):
+        specs = DSv4HybridSelfAttention.muon_slice_specs(self._fake(), {})
+        self.assertNotIn("gate_proj.weight", specs)
 
     def test_non_split_head_mode(self):
-        fake = SimpleNamespace(num_attention_heads_per_partition=4)
         specs = DSv4HybridSelfAttention.muon_slice_specs(
-            fake, {"muon_qkv_update_mode": "split_qkv"}
+            self._fake(gated=True), {"muon_qkv_update_mode": "split_qkv"}
         )
         self.assertEqual(specs, {})
 


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description

`DSv4HybridSelfAttention.muon_slice_specs` 只声明了 `linear_q_up_proj`，漏掉了同一继承链上
`DSv4HybridAttention` 创建的两个按 o-group 打包的权重，它们会被 Muon 当作单个矩阵整块正交化：

- `linear_o_group_proj`：存储形状是 `[o_groups * o_lora_rank, d]`，但 forward 中
  reshape 成 `[g, r, d]` 后走 grouped gemm `"...gd,grd->...gr"`（dsv4_hybrid_attention.py:852-857，
  FP8 路径同理见 `GroupedOutputFP8`），首轴枚举的是 `o_groups` 个互不相干的 `[r, d]` 矩阵，
  等价于一个块对角权重。整块正交化会在本该恒为 0 的非对角位置产生耦合。
- `gate_proj`：输出宽度是 `o_groups * o_lora_rank`，作用在展平后的 grouped projection 输出上
  （dsv4_hybrid_attention.py:890-897），列布局是 group-major，每组占 `o_lora_rank` 列，
  同样是逐组融合的权重。

修复方式是补两条 spec，复用现有 helper `ortho_per_head`，不新增切分逻辑：
`linear_o_group_proj` 用 `axis=0` 沿首轴切成 `o_groups` 块，`gate_proj` 沿列切成 `o_groups` 块。
`gate_proj` 是条件创建的（`gated_attention` 关闭时为 `None`），因此加了 `getattr(..., None)` 保护，
与 `MLASelfAttention.muon_slice_specs` 的写法一致。

对照过其余 7 个已有 `muon_slice_specs` 的模块（`SelfAttention`、`SelfAttentionVHA`、
`MLASelfAttention`、`Compressor`、`CSAIndexer`、`MLP`、`GroupedMLPExpert`），切分尺寸与权重创建宽度、
forward 中的真实列布局一致，无同类遗漏。

### 是否引起精度变化
是

Merged in dev: #1607