### PR TITLE
[release/0.4] [hysparse] Add the full-causal MQA layer via csa_compress_ratios=-1 (#1568)

### DIFF
--- a/src/paddlefleet/cudnn_ops/attn/csa_sparse_attn_fwd_cudnn.py
+++ b/src/paddlefleet/cudnn_ops/attn/csa_sparse_attn_fwd_cudnn.py
@@ -47,7 +47,14 @@ def _get_topk_alignment() -> int:
 
 
 def flash_mla_sparse_attn(
-    q, kv, attn_sink, topk_idxs, sm_scale=None, indexer_topk: int = 0, d_v=None
+    q,
+    kv,
+    attn_sink,
+    topk_idxs,
+    sm_scale=None,
+    indexer_topk: int = 0,
+    d_v=None,
+    topk_length=None,
 ):
     if _flash_mla_sparse_fwd is None:
         raise RuntimeError("flash_mla is not available")
@@ -63,6 +70,12 @@ def flash_mla_sparse_attn(
     q_flat = q.reshape([b * sq, h, d])
     kv_flat = kv.reshape([b * skv, d])
     global_idxs = _local_to_global_flat(topk_idxs, skv)
+    # [b, sq] -> [b * sq]: one valid-prefix length per flattened query row.
+    topk_length_flat = (
+        None
+        if topk_length is None
+        else topk_length.reshape([b * sq]).cast("int32")
+    )
 
     topk_align = _get_topk_alignment()
     topk_padded = (topk + topk_align - 1) // topk_align * topk_align
@@ -76,7 +89,7 @@ def flash_mla_sparse_attn(
         sm_scale,
         d_v=d_v,
         attn_sink=attn_sink,
-        topk_length=None,
+        topk_length=topk_length_flat,
         indexer_topk=indexer_topk,
     )
     if indexer_topk > 0:

--- a/src/paddlefleet/fusions/csa_sparse_attn.py
+++ b/src/paddlefleet/fusions/csa_sparse_attn.py
@@ -31,6 +31,7 @@ def unfused_compressed_sparse_attn(
     attn_sink: Tensor,
     topk_indices: Tensor,
     softmax_scale: float,
+    topk_length: Tensor | None = None,
 ) -> Tensor:
     """Sparse attention with MQA and learnable attention sink.
 
@@ -40,6 +41,8 @@ def unfused_compressed_sparse_attn(
         attn_sink: [np] per-head learnable bias (attention sink)
         topk_indices: [b, sq, topk] indices into kv_full dim=1 (-1 = invalid)
         softmax_scale: attention scale factor
+        topk_length: optional [b, sq] int32 valid prefix length; slots at
+            ``>= topk_length[b, i]`` are ignored for query row ``i``.
 
     Returns:
         output: [b, sq, np * hn]
@@ -69,7 +72,13 @@ def unfused_compressed_sparse_attn(
             paddle.einsum("bnsh,bskh->bnsk", q, kv_g) * softmax_scale
         )  # [b, np, sq, topk]
         # Mask invalid positions (topk_indices < 0) with -inf
-        invalid_mask = (topk_indices < 0).unsqueeze(1)  # [b, 1, sq, topk]
+        invalid = topk_indices < 0  # [b, sq, topk]
+        if topk_length is not None:
+            slots = paddle.arange(topk, dtype="int32").reshape([1, 1, topk])
+            invalid = invalid | (
+                slots >= topk_length.reshape([b, sq, 1]).cast("int32")
+            )
+        invalid_mask = invalid.unsqueeze(1)  # [b, 1, sq, topk]
         scores = scores.masked_fill(invalid_mask, float("-inf"))
 
         # Softmax with attention sink
@@ -120,7 +129,14 @@ def _csa_compute_topk_length(topk_idxs_flat: Tensor) -> Tensor:
 class CSASparseAttention(paddle.autograd.PyLayer):
     @staticmethod
     def forward(
-        ctx, query, kv_full, attn_sink, topk_idxs, softmax_scale, backend
+        ctx,
+        query,
+        kv_full,
+        attn_sink,
+        topk_idxs,
+        softmax_scale,
+        backend,
+        topk_length=None,
     ):
         from paddlefleet.fusions.csa_sparse_attn_utils import prepare_inputs
 
@@ -129,6 +145,12 @@ class CSASparseAttention(paddle.autograd.PyLayer):
         ctx.softmax_scale = float(softmax_scale)
         ctx.attn_sink_dtype = attn_sink.dtype
         ctx.backend = backend
+        # ``topk_length`` is a forward-only early-stop hint: correctness comes
+        # from the ``-1`` padding in ``topk_idxs``, which backward already turns
+        # into its own bound via ``_csa_compute_topk_length``. Only remember
+        # whether it was passed, so backward can return the matching number of
+        # placeholder gradients.
+        ctx.has_topk_length = topk_length is not None
 
         query, kv_full, attn_sink, topk_idxs = prepare_inputs(
             query,
@@ -147,8 +169,14 @@ class CSASparseAttention(paddle.autograd.PyLayer):
                 attn_sink,
                 topk_idxs,
                 sm_scale=ctx.softmax_scale,
+                topk_length=topk_length,
             )
         else:
+            if topk_length is not None:
+                raise NotImplementedError(
+                    "topk_length is only supported by the 'cudnn' and "
+                    f"'unfused' backends, got backend={backend!r}."
+                )
             from paddlefleet.tilelang_ops.attn.sparse_mqa import sparse_attn
 
             output, lse = sparse_attn(
@@ -219,16 +247,31 @@ class CSASparseAttention(paddle.autograd.PyLayer):
                 ctx.attn_sink_dtype
             )
 
-        return (dq, dkv, d_attn_sink, None)
+        grads = (dq, dkv, d_attn_sink, None)
+        if ctx.has_topk_length:
+            # ``topk_length`` was passed as an extra (non-differentiable) tensor
+            # input, so an extra placeholder gradient is required.
+            grads = (*grads, None)
+        return grads
 
 
 def csa_sparse_attn(
-    query, kv_full, attn_sink, topk_idxs, softmax_scale, backend="tilelang"
+    query,
+    kv_full,
+    attn_sink,
+    topk_idxs,
+    softmax_scale,
+    backend="tilelang",
+    topk_length=None,
 ):
     """Unified CSA sparse attention entry point.
 
     Args:
         backend: one of {"unfused", "tilelang", "cudnn"}.
+        topk_length: optional ``[b, sq]`` int32 valid prefix length per query
+            row. Only the "cudnn" and "unfused" backends support it; it lets
+            the kernel stop early instead of walking all ``topk`` slots, which
+            is what makes the full-causal MQA layers affordable.
     """
     if backend == "unfused":
         return unfused_compressed_sparse_attn(
@@ -237,6 +280,7 @@ def csa_sparse_attn(
             attn_sink,
             topk_idxs,
             softmax_scale,
+            topk_length=topk_length,
         )
     if backend not in ("tilelang", "cudnn"):
         raise ValueError(
@@ -250,4 +294,5 @@ def csa_sparse_attn(
         topk_idxs,
         softmax_scale,
         backend,
+        topk_length,
     )

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -26,6 +26,7 @@ Components:
 from __future__ import annotations
 
 import os
+import warnings
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -67,6 +68,11 @@ from paddlefleet.transformer.cp_utils import (
     get_window_topk_idxs_cp,
     map_compressed_topk_to_kv_full_cp,
 )
+
+# Sentinel value in ``config.csa_compress_ratios`` selecting the full-causal
+# MQA layer: no compressor, no indexer and no sliding window, every query
+# attends to all preceding original KV positions of its own document.
+CSA_MQA_RATIO = -1
 
 
 def _normalize_csa_docmask_args(
@@ -158,6 +164,42 @@ def _build_window_topk_idxs_from_doc_bounds(
     )
     result = paddle.where(invalid, paddle.full_like(indices, -1), indices)
     return result.unsqueeze(0).expand([batch_size, -1, -1])
+
+
+def _build_mqa_causal_topk_idxs_from_doc_bounds(
+    batch_size: int,
+    seqlen: int,
+    doc_start_per_pos: Tensor,
+    is_valid: Tensor,
+) -> tuple[Tensor, Tensor]:
+    """Build full-causal (per-document) indices + valid lengths for MQA layers.
+
+    Row ``i`` holds ``[doc_start[i], ..., i]`` followed by ``-1`` padding, so a
+    packed multi-document batch is bit-identical to running each document on
+    its own. Padding rows (``is_valid == False``) get a single ``-1`` slot,
+    which degenerates to the attention-sink-only output used by the window
+    path.
+
+    Returns:
+        (topk_idxs, topk_length) with shapes ``[batch_size, seqlen, seqlen]``
+        int32 and ``[batch_size, seqlen]`` int32.
+    """
+    positions = paddle.arange(seqlen, dtype="int64")
+    offsets = paddle.arange(seqlen, dtype="int64").unsqueeze(0)
+    indices = doc_start_per_pos.unsqueeze(1) + offsets
+    invalid = (indices > positions.unsqueeze(1)) | (~is_valid).unsqueeze(
+        1
+    ).expand_as(indices)
+    indices = paddle.where(
+        invalid, paddle.full_like(indices, -1), indices
+    ).cast("int32")
+    lengths = (positions - doc_start_per_pos + 1).cast("int32")
+    # Padding rows keep a single masked slot instead of length 0.
+    lengths = paddle.where(is_valid, lengths, paddle.ones_like(lengths))
+    return (
+        indices.unsqueeze(0).expand([batch_size, -1, -1]),
+        lengths.unsqueeze(0).expand([batch_size, -1]),
+    )
 
 
 def _build_compress_topk_idxs_from_valid_range(
@@ -398,6 +440,7 @@ class CSADocMaskMetadata:
     _compress_offset: int | None = None
     _compressed_causal_mask: Tensor | None = None
     _is_first_compressed_group: Tensor | None = None
+    _mqa_causal_topk: tuple[Tensor, Tensor] | None = None
 
     @classmethod
     def build(
@@ -620,6 +663,40 @@ class CSADocMaskMetadata:
             )
         return self._compressed_causal_mask
 
+    def get_mqa_causal_topk_idxs(self) -> tuple[Tensor, Tensor]:
+        """Return ``([b, seqlen, seqlen], [b, seqlen])`` MQA causal indices.
+
+        Indices reset at each document boundary and ``topk_length`` gives the
+        per-row valid prefix so the kernel can stop early.
+
+        Cached on this metadata object. NOTE: the current DSv4 forward builds a
+        fresh ``CSADocMaskMetadata`` per layer (see
+        ``dsv4_hybrid_attention.py``), so today this cache is effectively
+        per-layer and never hits across layers. Reusing one metadata instance
+        across the MQA layers of a forward would make this build once, but that
+        optimisation requires keying the cache on ``(seqlen, doc layout)``
+        first: the table is a function of build-time document boundaries, and a
+        table built for one layout is silently wrong for another (grad
+        accumulation, ``variable_seq_lengths`` and ``document_mask_prob_text``
+        all produce differing layouts across microbatches).
+        """
+        if self._mqa_causal_topk is None:
+            # ``build`` only derives ``is_valid`` for the indexer path
+            # (``ratio > 1 and not dense_mode``); an MQA layer builds its
+            # metadata with ratio=1, so recover it from the always-present
+            # per-position document bounds using the same definition as
+            # ``_derive_csa_doc_boundaries``.
+            is_valid = self.is_valid
+            if is_valid is None:
+                is_valid = self.pos_in_doc < self.doc_len_per_pos
+            self._mqa_causal_topk = _build_mqa_causal_topk_idxs_from_doc_bounds(
+                self.batch_size,
+                self.seqlen,
+                self.doc_start_per_pos,
+                is_valid,
+            )
+        return self._mqa_causal_topk
+
     def get_is_first_compressed_group(self) -> Tensor:
         """Return ``[actual_n_compressed]`` bool flags marking each document's
         first compressed group (used by overlap transforms to avoid reusing
@@ -717,6 +794,41 @@ def get_window_topk_idxs(
         1, batch_size, seqlen, startend_row_indices, seqlen
     )
     return docmask_meta.get_window_topk_idxs(window_size)
+
+
+def get_mqa_causal_topk_idxs(
+    batch_size: int,
+    seqlen: int,
+    startend_row_indices: Tensor | None = None,
+    docmask_meta: CSADocMaskMetadata | None = None,
+) -> tuple[Tensor, Tensor]:
+    """Get full-causal MQA indices + valid lengths.
+
+    Returns ``([b, seqlen, seqlen] int32, [b, seqlen] int32)``. With document
+    boundaries the causal range restarts at each document start, which makes a
+    packed batch equivalent to attending within each document separately.
+    """
+    if docmask_meta is not None:
+        return docmask_meta.get_mqa_causal_topk_idxs()
+
+    if startend_row_indices is None:
+        positions = paddle.arange(seqlen, dtype="int64")
+        matrix = positions.unsqueeze(0).expand([seqlen, -1])
+        matrix = paddle.where(
+            matrix > positions.unsqueeze(1),
+            paddle.full_like(matrix, -1),
+            matrix,
+        ).cast("int32")
+        lengths = (positions + 1).cast("int32")
+        return (
+            matrix.unsqueeze(0).expand([batch_size, -1, -1]),
+            lengths.unsqueeze(0).expand([batch_size, -1]),
+        )
+
+    docmask_meta = CSADocMaskMetadata.build(
+        1, batch_size, seqlen, startend_row_indices, seqlen
+    )
+    return docmask_meta.get_mqa_causal_topk_idxs()
 
 
 def get_valid_range(
@@ -1891,6 +2003,7 @@ class CompressedSparseAttention(FleetLayer):
     """Core attention combining sliding window + compressed KV attention.
 
     Conditionally builds Compressor and CSAIndexer based on compress_ratio:
+      - ratio=-1 (``CSA_MQA_RATIO``): full-causal MQA, no window/compressor
       - ratio=0: window-only attention
       - ratio=4: window + 4x compressed + learned CSAIndexer
       - ratio=128: window + 128x compressed, attend to all compressed positions
@@ -1933,6 +2046,25 @@ class CompressedSparseAttention(FleetLayer):
             )
         self.tp_group = None
         self.compress_ratio = compress_ratio
+        self.is_mqa_layer = compress_ratio == CSA_MQA_RATIO
+        if self.is_mqa_layer:
+            backend = getattr(config, "csa_sparse_attn_backend", "tilelang")
+            if backend not in ("cudnn", "unfused"):
+                raise NotImplementedError(
+                    f"csa_compress_ratios={CSA_MQA_RATIO} (full-causal MQA) "
+                    "requires csa_sparse_attn_backend='cudnn' (the tilelang "
+                    "kernel has no topk_length support), got "
+                    f"{backend!r}."
+                )
+            if backend == "unfused":
+                warnings.warn(
+                    f"csa_compress_ratios={CSA_MQA_RATIO} (full-causal MQA) "
+                    "with csa_sparse_attn_backend='unfused' materialises a "
+                    "dense [b, sq, sq, head_dim] gather and only fits tiny "
+                    "sequences (~68 TB at sq=8192). Use 'cudnn' for training; "
+                    "'unfused' is a reference path for tests.",
+                    stacklevel=2,
+                )
         self.window_size = config.csa_window_size
         self.v_head_dim = config.v_head_dim
         self.n_local_heads = config.num_attention_heads
@@ -2314,6 +2446,12 @@ class CompressedSparseAttention(FleetLayer):
             global_valid_count = None
 
         if self.cp_enabled:
+            if self.is_mqa_layer:
+                raise NotImplementedError(
+                    f"csa_compress_ratios={CSA_MQA_RATIO} (full-causal MQA) "
+                    "does not support context parallelism yet, got "
+                    f"cp={self.cp_size}."
+                )
             return self._forward_cp(
                 query,
                 key,
@@ -2323,6 +2461,9 @@ class CompressedSparseAttention(FleetLayer):
                 global_valid_count=global_valid_count,
                 docmask_meta=docmask_meta,
             )
+
+        if self.is_mqa_layer:
+            return self._forward_mqa(query, key, docmask_meta=docmask_meta)
 
         if docmask_meta is not None and self.compress_ratio > 1:
             actual_n_compressed = docmask_meta.actual_n_compressed
@@ -2428,6 +2569,36 @@ class CompressedSparseAttention(FleetLayer):
             output = DSAIndexerLossAutoScaler.apply(output, indexer_loss)
 
         return output
+
+    def _forward_mqa(
+        self,
+        query: Tensor,
+        key: Tensor,
+        docmask_meta: CSADocMaskMetadata | None = None,
+    ) -> Tensor:
+        """Full-causal MQA forward (``compress_ratio == CSA_MQA_RATIO``).
+
+        No sliding window, no compressor and no indexer: every query attends to
+        all preceding original KV positions inside its own document. The CSA
+        sparse kernel is reused with a dense causal index table plus
+        ``topk_length`` so it stops at the diagonal instead of scanning all
+        ``sq`` slots.
+        """
+        b, sq, _, _ = query.shape
+        kv_full = key.squeeze(2)  # [b, sq, v_head_dim]
+        topk_idxs, topk_length = get_mqa_causal_topk_idxs(
+            b,
+            sq,
+            docmask_meta=docmask_meta,
+        )
+        return self.compressed_sparse_attn(
+            query,
+            kv_full,
+            self.attn_sink,
+            topk_idxs,
+            self.softmax_scale,
+            topk_length=topk_length,
+        )
 
     def _forward_cp(
         self,
@@ -2827,6 +2998,7 @@ class CompressedSparseAttention(FleetLayer):
         attn_sink: Tensor,
         topk_idxs: Tensor,
         softmax_scale: float,
+        topk_length: Tensor | None = None,
     ):
         from paddlefleet.fusions.csa_sparse_attn import csa_sparse_attn
 
@@ -2845,4 +3017,5 @@ class CompressedSparseAttention(FleetLayer):
             topk_idxs,
             softmax_scale,
             backend=sparse_attn_backend,
+            topk_length=topk_length,
         )

--- a/src/paddlefleet/transformer/dsv4_hybrid_attention.py
+++ b/src/paddlefleet/transformer/dsv4_hybrid_attention.py
@@ -359,7 +359,12 @@ class DSv4HybridAttention(Attention):
         # Per-layer RoPE (potentially different base for compressed layers)
         rope_base = getattr(config, "rotary_base", 10000)
         if compress_ratio > 1:
-            rope_base = config.csa_compress_rotary_base
+            # Every shipped model_config.json writes csa_compress_rotary_base as
+            # a *string* ("160000.0"). pretrain.py coerces numeric strings
+            # before building the config, but any path that calls from_config
+            # directly (unit tests, offline inference, tooling) would reach
+            # YarnRotaryEmbedding's math.log() with a str and raise TypeError.
+            rope_base = float(config.csa_compress_rotary_base)
 
         use_compressed_yarn = compress_ratio > 1
         if not use_compressed_yarn:

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -1380,10 +1380,18 @@ class TransformerConfig(ModelParallelConfig):
                     f"must equal num_hidden_layers ({self.num_hidden_layers + mtp_num_layers})."
                 )
             for i, r in enumerate(self.csa_compress_ratios):
-                if not (isinstance(r, int) and (r == 0 or 2 <= r <= 128)):
+                # Accept python int and numpy integer scalars (a ratios list
+                # loaded from npy/np.load yields np.int64, which would otherwise
+                # be rejected); reject bool / np.bool_ so True does not sneak
+                # through as 1, and reject floats.
+                is_integral = hasattr(r, "__index__") and type(
+                    r
+                ).__name__ not in ("bool", "bool_")
+                if not (is_integral and (r == -1 or r == 0 or 2 <= r <= 128)):
                     raise ValueError(
                         f"csa_compress_ratios[{i}]={r} is invalid. "
-                        f"Each value must be 0 (window), an integer in [2, 127] "
+                        f"Each value must be -1 (full-causal MQA), 0 (window), "
+                        f"an integer in [2, 127] "
                         f"(CSA, overlap + Lightning Indexer), or 128 (HCA)."
                     )
 

--- a/tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_utils.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_utils.py
@@ -305,7 +305,13 @@ class TestCudnnBackendDispatch(unittest.TestCase):
         b, sq, h, hn, s_kv, topk = 1, 2, 3, 4, 6, 4
 
         def fake_fwd(
-            q, kv, attn_sink, topk_idxs, sm_scale=None, indexer_topk=0
+            q,
+            kv,
+            attn_sink,
+            topk_idxs,
+            sm_scale=None,
+            indexer_topk=0,
+            topk_length=None,
         ):
             bb, ss, hh, dd = q.shape
             out = paddle.ones([bb, ss, hh, dd], dtype=q.dtype)
@@ -349,7 +355,52 @@ class TestCudnnBackendDispatch(unittest.TestCase):
             self.assertEqual(q.grad.shape, [b, sq, h, hn])
             self.assertEqual(kv.grad.shape, [b, s_kv, hn])
             self.assertEqual(sink.grad.shape, [h])
+
+            # With topk_length the PyLayer takes one extra (non-differentiable)
+            # input, so backward has to return one extra placeholder gradient.
+            q2 = paddle.randn([b, sq, h, hn], dtype="float32")
+            q2.stop_gradient = False
+            kv2 = paddle.randn([b, s_kv, hn], dtype="float32")
+            kv2.stop_gradient = False
+            sink2 = paddle.randn([h], dtype="float32")
+            sink2.stop_gradient = False
+            length = paddle.full([b, sq], topk, dtype="int32")
+
+            out = csa_sparse_attn(
+                q2,
+                kv2,
+                sink2,
+                idx,
+                0.5,
+                backend="cudnn",
+                topk_length=length,
+            )
+            out.sum().backward()
+            self.assertEqual(q2.grad.shape, [b, sq, h, hn])
+            self.assertEqual(kv2.grad.shape, [b, s_kv, hn])
+            self.assertEqual(sink2.grad.shape, [h])
         finally:
             fwd.flash_mla_sparse_attn = orig_fwd
             if orig_bwd is not None:
                 cudnn_pkg.csa_sparse_attn_bwd_cudnn = orig_bwd
+
+    def test_topk_length_rejected_by_tilelang_backend(self):
+        from paddlefleet.fusions.csa_sparse_attn import csa_sparse_attn
+
+        b, sq, h, hn, s_kv, topk = 1, 2, 3, 4, 6, 4
+        q = paddle.randn([b, sq, h, hn], dtype="float32")
+        kv = paddle.randn([b, s_kv, hn], dtype="float32")
+        sink = paddle.randn([h], dtype="float32")
+        idx = paddle.randint(0, s_kv, [b, sq, topk]).cast("int32")
+        length = paddle.full([b, sq], topk, dtype="int32")
+
+        with self.assertRaisesRegex(NotImplementedError, "backend='tilelang'"):
+            csa_sparse_attn(
+                q,
+                kv,
+                sink,
+                idx,
+                0.5,
+                backend="tilelang",
+                topk_length=length,
+            )

--- a/tests/single_card_tests/transformer/test_dsv4_hybrid_attention.py
+++ b/tests/single_card_tests/transformer/test_dsv4_hybrid_attention.py
@@ -42,6 +42,7 @@ from paddlefleet.transformer.csa_attention import (
     _resolve_csa_indexer_attn_topk_effective,
     _resolve_csa_indexer_loss_topk_effective,
     get_compress_topk_idxs,
+    get_mqa_causal_topk_idxs,
     get_valid_range,
     get_window_topk_idxs,
 )
@@ -201,10 +202,10 @@ class TestDSv4HybridConfigAndSpec(unittest.TestCase):
             _make_config(num_layers=1, csa_compress_ratios=[129])
 
     def test_csa_compress_ratios_accepts_general_set(self):
-        # window (0), CSA over the full [2, 127] range (including non-power-of-2
-        # 3 and the boundary 127), and HCA (128) must all be accepted and
-        # round-trip through the config.
-        ratios = [0, 2, 3, 4, 8, 16, 32, 64, 127, 128]
+        # full-causal MQA (-1), window (0), CSA over the full [2, 127] range
+        # (including non-power-of-2 3 and the boundary 127), and HCA (128) must
+        # all be accepted and round-trip through the config.
+        ratios = [-1, 0, 2, 3, 4, 8, 16, 32, 64, 127, 128]
         cfg = _make_config(num_layers=len(ratios), csa_compress_ratios=ratios)
         self.assertEqual(cfg.csa_compress_ratios, ratios)
 
@@ -1003,7 +1004,7 @@ class TestDSv4HybridDocumentRoPE(unittest.TestCase):
 
     def test_attention_module_document_mask_matches_separate_documents(self):
         paddle.seed(_SEED)
-        for ratio in [0, 4, 128]:
+        for ratio in [-1, 0, 4, 128]:
             config = _make_config(
                 hidden_size=64,
                 num_attention_heads=2,
@@ -1364,6 +1365,161 @@ class TestDSv4HybridAttentionConstructor(unittest.TestCase):
         # ratio 129 is above HCA (128) -> rejected.
         with self.assertRaisesRegex(ValueError, "is invalid"):
             _make_config(num_layers=1, csa_compress_ratios=[129])
+
+    def test_mqa_ratio_matches_window_covering_full_sequence(self):
+        # ratio=-1 is full-causal MQA: no compressor, no indexer, no window.
+        # A window-only layer (ratio=0) whose window covers the whole sequence
+        # attends to exactly the same key set, so both must agree bit-exactly.
+        seq_len = 32
+        kwargs = {
+            "hidden_size": 64,
+            "num_attention_heads": 2,
+            "v_head_dim": 32,
+            "q_lora_rank": 32,
+            "o_groups": 2,
+            "o_lora_rank": 16,
+            "dsa_indexer_loss_coeff": 0.0,
+            "num_layers": 1,
+        }
+        mqa_config = _make_config(
+            csa_compress_ratios=[-1], csa_window_size=8, **kwargs
+        )
+        window_config = _make_config(
+            csa_compress_ratios=[0], csa_window_size=seq_len, **kwargs
+        )
+
+        paddle.seed(_SEED)
+        model_parallel_cuda_manual_seed(_SEED)
+        mqa_attn = _build_attention(mqa_config, layer_number=0)
+        mqa_attn.eval()
+        paddle.seed(_SEED)
+        model_parallel_cuda_manual_seed(_SEED)
+        window_attn = _build_attention(window_config, layer_number=0)
+        window_attn.eval()
+
+        core = mqa_attn.core_attention
+        self.assertTrue(core.is_mqa_layer)
+        self.assertIsNone(core.compressor)
+        self.assertIsNone(core.indexer)
+        # MQA uses plain RoPE (base rotary_base), never the compressed YaRN.
+        self.assertNotIsInstance(mqa_attn.rotary_pos_emb, YarnRotaryEmbedding)
+
+        hidden = paddle.randn(
+            [1, seq_len, mqa_config.hidden_size], dtype="bfloat16"
+        )
+        with paddle.no_grad():
+            mqa_out, _ = mqa_attn(hidden_states=hidden, attention_mask=None)
+            window_out, _ = window_attn(
+                hidden_states=hidden, attention_mask=None
+            )
+        self.assertTrue(
+            paddle.equal_all(
+                mqa_out.cast("float32"), window_out.cast("float32")
+            ).item()
+        )
+
+    def test_mqa_topk_length_matches_mask_only_indices(self):
+        # The MQA index table carries both -1 padding and topk_length; dropping
+        # topk_length must not change the result (the kernel only stops early).
+        paddle.seed(_SEED)
+        seqlen, heads, dim = 24, 2, 16
+        query = paddle.randn([1, seqlen, heads, dim], dtype="bfloat16")
+        kv = paddle.randn([1, seqlen, dim], dtype="bfloat16")
+        sink = paddle.randn([heads], dtype="float32") * 0.1
+        startend_row_indices = _make_startend_row_indices([10, 9], seqlen)
+        meta = CSADocMaskMetadata.build(
+            1, 1, seqlen, startend_row_indices, seqlen
+        )
+        topk_idxs, topk_length = get_mqa_causal_topk_idxs(
+            1, seqlen, docmask_meta=meta
+        )
+        expected_length = [
+            min(i, 9) + 1 if i < 10 else (i - 10 + 1 if i < 19 else 1)
+            for i in range(seqlen)
+        ]
+        self.assertEqual(topk_length[0].numpy().tolist(), expected_length)
+
+        with_length = unfused_compressed_sparse_attn(
+            query, kv, sink, topk_idxs, dim**-0.5, topk_length=topk_length
+        )
+        mask_only = unfused_compressed_sparse_attn(
+            query, kv, sink, topk_idxs, dim**-0.5
+        )
+        self.assertTrue(
+            paddle.equal_all(
+                with_length.cast("float32"), mask_only.cast("float32")
+            ).item()
+        )
+        # Padding rows (19..23) fall back to the attention sink only.
+        self.assertEqual(
+            float(with_length[:, 19:].cast("float32").abs().max()), 0.0
+        )
+
+    def test_mqa_causal_topk_idxs_from_startend_row_indices(self):
+        # Without a prebuilt metadata object the helper builds one itself from
+        # startend_row_indices; both entry points must agree.
+        seqlen = 16
+        startend_row_indices = _make_startend_row_indices([7, 9], seqlen)
+        idxs, lengths = get_mqa_causal_topk_idxs(
+            1, seqlen, startend_row_indices=startend_row_indices
+        )
+        meta = CSADocMaskMetadata.build(
+            1, 1, seqlen, startend_row_indices, seqlen
+        )
+        meta_idxs, meta_lengths = get_mqa_causal_topk_idxs(
+            1, seqlen, docmask_meta=meta
+        )
+        self.assertEqual(idxs.shape, [1, seqlen, seqlen])
+        self.assertEqual(lengths.shape, [1, seqlen])
+        self.assertTrue(paddle.equal_all(idxs, meta_idxs).item())
+        self.assertTrue(paddle.equal_all(lengths, meta_lengths).item())
+        # The causal range restarts at the second document's start (7).
+        self.assertEqual(
+            lengths[0].numpy().tolist(),
+            [i + 1 for i in range(7)] + [i - 7 + 1 for i in range(7, 16)],
+        )
+
+    def test_mqa_rejects_tilelang_backend(self):
+        # tilelang has no topk_length support, so the MQA layer cannot use it.
+        config = _make_config(
+            num_layers=1,
+            csa_compress_ratios=[-1],
+            csa_sparse_attn_backend="tilelang",
+        )
+        with self.assertRaisesRegex(NotImplementedError, "'tilelang'"):
+            CompressedSparseAttention(
+                config=config,
+                sublayers_spec=CompressedSparseAttentionSublayersSpec(),
+                layer_number=0,
+                attn_mask_type=AttnMaskType.causal,
+                attention_type="self",
+                pg_collection=_FakePGCollection(),
+                compress_ratio=-1,
+            )
+
+    def test_mqa_rejects_context_parallelism(self):
+        # CP must fail loudly instead of taking the CSA CP path, which assumes
+        # a compressed KV stream the MQA layer never builds.
+        paddle.seed(_SEED)
+        config = _make_config(num_layers=1, csa_compress_ratios=[-1])
+        core = CompressedSparseAttention(
+            config=config,
+            sublayers_spec=CompressedSparseAttentionSublayersSpec(),
+            layer_number=0,
+            attn_mask_type=AttnMaskType.causal,
+            attention_type="self",
+            pg_collection=_FakePGCollection(cp_nranks=2),
+            compress_ratio=-1,
+        )
+        self.assertTrue(core.cp_enabled)
+        b, sq = 1, 8
+        query = paddle.randn(
+            [b, sq, config.num_attention_heads, config.v_head_dim],
+            dtype="bfloat16",
+        )
+        key = paddle.randn([b, sq, 1, config.v_head_dim], dtype="bfloat16")
+        with self.assertRaisesRegex(NotImplementedError, "cp=2"):
+            core(query, key, key)
 
     def test_q_head_dim_equals_v_head_dim(self):
         paddle.seed(_SEED)


### PR DESCRIPTION
### PR Category

Operator Mechanism

### PR Types

New features

### Description

Merged in dev: #1568

Cherry-pick of #1568 (`233180a94c95cac4903c4c50de04ee611f1102e5`) from `develop` into `release/0.4`.

#### 内容

给 `csa_compress_ratios` 增加 `-1` 作为**全因果 MQA 层**的哨兵值（`CSA_MQA_RATIO`）：不建 compressor、不建 indexer、不开滑窗，每个 query 注意到本 document 内它之前的全部原始 KV 位置，单头 KV 被所有 query head 共享，沿用已有的可学习 per-head attention sink。

实现上复用现成的 CSA 稀疏 kernel：喂一张稠密因果 index 表，再给前向补一个 `topk_length`（每行有效前缀长度），让 kernel 在对角线处停下。后端限制为 `cudnn` / `unfused`，`tilelang` 在构造期即报错；CP 同样显式 `NotImplementedError`。

#### Cherry-pick 说明

- 无冲突，diff 与 develop 上的 `233180a` **逐行完全一致**（7 files, +466/-15），仅 hunk 行号偏移。
- 前置依赖已在本分支：per-query `topk_length` 反向支持来自 #1541（`712fd29`，即 #1540 的 backport），因此本 PR 只补前向那一路，不改既有 saved-tensor 布局。

#### 测试

单卡（SM100）：

```
tests/single_card_tests/transformer/test_dsv4_hybrid_attention.py
tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_utils.py
=> 77 passed, 29 subtests passed
```

与 develop 上 `233180a` 的基线结果完全一致，无回归。
