### PR TITLE
[release/0.4][Deps] Bump Paddle to 3cc38fddf4b

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ description = "Fleet Core - Core Functional Library for Large Scale Distributed 
 requires-python = ">=3.10"
 dependencies = [
     "colorlog>=6.10.1",
-    "paddlepaddle-gpu==3.4.0.post20260730+0fbc62db73b",
+    "paddlepaddle-gpu==3.4.0.post20260731+3cc38fddf4b",
     "tilelang-paddle",
 ]
 license = { text = "Apache 2.0" }


### PR DESCRIPTION
### PR Category
Environment Adaptation

### PR Types
Others

### Description
Bump the pinned CUDA 12.9 Paddle dependency on `release/0.4` from `paddlepaddle-gpu==3.4.0.post20260730+0fbc62db73b` to `paddlepaddle-gpu==3.4.0.post20260731+3cc38fddf4b`.

Target Paddle commit: [`3cc38fddf4ba1530ed90f9d3fd17cb567a0bb5b9`](https://github.com/PaddlePaddle/Paddle/commit/3cc38fddf4ba1530ed90f9d3fd17cb567a0bb5b9) on `release/3.4`.

Dev PR: #1615 (pending merge; this release PR must remain blocked until it merges).

The exact official release-nightly artifact confirms Paddle/PaddleFleet's convention: `3.4.0.post<UTC commit date>+<first 11 commit characters>`.

**Artifact verification:** the official CUDA 12.9 Linux x86_64 CPython 3.12 wheel is indexed. Its `METADATA` reports `paddlepaddle-gpu==3.4.0.post20260731+3cc38fddf4b`; `paddle/version/__init__.py` embeds the full target commit and CUDA 12.9; and `WHEEL` reports `cp312-cp312-linux_x86_64`. An isolated cross-platform `pip install --no-deps` completed successfully without importing Paddle.

**Local validation:** TOML and PEP 508 parsing, `git diff --check`, exact one-file/one-line delta review, and `pre-commit run --files pyproject.toml` all pass.

### 是否引起精度变化
否
