### PR TITLE
[New features] Add VHA premix/postmix for DSv4 hybrid and MLA attention

### DIFF
--- a/src/paddlefleet/transformer/dsv4_hybrid_attention.py
+++ b/src/paddlefleet/transformer/dsv4_hybrid_attention.py
@@ -1317,7 +1317,7 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
             # matrices and must be split along axis 0.
             "linear_o_group_proj": (
                 ortho_per_head,
-                {"heads": self.o_local_groups, "axis": 0},
+                {"heads": self.o_local_groups, "axis": -2},
             ),
         }
         if self.use_vha_premix:

--- a/src/paddlefleet/transformer/dsv4_hybrid_attention.py
+++ b/src/paddlefleet/transformer/dsv4_hybrid_attention.py
@@ -45,6 +45,10 @@ from paddlefleet.models.common.embeddings.rotary_pos_embedding import (
 from paddlefleet.models.common.embeddings.yarn_rotary_pos_embedding import (
     YarnRotaryEmbedding,
 )
+from paddlefleet.recompute_utils import (
+    need_recompute_in_block,
+    need_recompute_in_first_n,
+)
 from paddlefleet.tensor_parallel import RecomputeWithoutOutput
 from paddlefleet.transformer.attention import Attention
 from paddlefleet.transformer.csa_attention import (
@@ -742,10 +746,9 @@ class DSv4HybridAttention(Attention):
         # after inverse RoPE (head space) and before the grouped output projection.
         # Two topologies, selected by config.vha_postmix_grouped:
         #   grouped=False (default): ungrouped full cross-head mixing over all heads
-        #                  (the earlier VHA design). Higher capacity, but NOT absorbable.
-        #   grouped=True:  within-group block-diagonal mixing (per o_group), which folds
-        #                  into linear_o_group_proj at inference
-        #                  (fuse_vha_postmix_into_o_group_proj).
+        #                  (the earlier VHA design). Higher capacity.
+        #   grouped=True:  within-group block-diagonal mixing (per o_group); mixing
+        #                  stays within each o_group.
         # Reuses the shared use_vha_attention / vha_postmix_rank knobs; premix is
         # wired separately (use_vha_premix).
         self.use_vha_postmix = getattr(config, "use_vha_attention", False)
@@ -790,12 +793,33 @@ class DSv4HybridAttention(Attention):
                 default_initializer=nn.initializer.Constant(0.0),
             )
         # Selective recompute for the VHA postmix scatter chain (independently
-        # configurable via the "vha_postmix" entry in recompute_modules).
-        self.recompute_vha_postmix = (
-            config.recompute_granularity == "selective"
-            and config.recompute_modules is not None
-            and "vha_postmix" in config.recompute_modules
-        )
+        # configurable via the "vha_postmix" entry in recompute_modules). Only
+        # list configuration is supported; honours recompute_num_layers +
+        # recompute_method (first_n / block) like the other selective modules.
+        modules = config.recompute_modules
+        self.recompute_vha_postmix = False
+        if config.recompute_granularity == "selective" and modules is not None:
+            if isinstance(modules, dict) and "vha_postmix" in modules:
+                raise ValueError(
+                    "recompute_modules['vha_postmix'] only supports list "
+                    "configuration"
+                )
+            if isinstance(modules, list) and "vha_postmix" in modules:
+                n = config.recompute_num_layers
+                if n is None:
+                    self.recompute_vha_postmix = True
+                elif config.recompute_method == "block":
+                    self.recompute_vha_postmix = need_recompute_in_block(
+                        self.layer_number, config, n
+                    )
+                elif config.recompute_method == "first_n":
+                    self.recompute_vha_postmix = need_recompute_in_first_n(
+                        self.layer_number, config, n
+                    )
+                else:
+                    raise ValueError(
+                        "recompute_method must be 'first_n' or 'block'"
+                    )
 
     def forward(
         self,
@@ -1081,13 +1105,11 @@ class DSv4HybridAttention(Attention):
         - grouped=True: reshape to [b, sq, o_groups, group_heads, v_head_dim] and,
           within each o_group, recombine that group's heads via a low-rank
           correction (I + U_g V_g^T) on the head axis, shared across v_head_dim.
-          Block-diagonal w.r.t. o_groups, so at inference it folds into
-          linear_o_group_proj (see fuse_vha_postmix_into_o_group_proj).
+          Block-diagonal w.r.t. o_groups (mixing stays within a group).
 
         - grouped=False: reshape to [b, sq, nh, v_head_dim] and recombine ALL heads
           via a single low-rank correction (I + U V^T) on the nh axis. Full
-          cross-head mixing (higher capacity); NOT absorbable into the grouped
-          output projection.
+          cross-head mixing (higher capacity).
 
         V is zero-initialized so this is identity at the start of training.
         """
@@ -1108,52 +1130,6 @@ class DSv4HybridAttention(Attention):
         return mixed.reshape(
             [b, sq, self.num_attention_heads * self.v_head_dim]
         )
-
-    def fuse_vha_postmix_into_o_group_proj(self) -> Tensor:
-        """Fold the VHA postmix into linear_o_group_proj for inference.
-
-        Since the postmix head mixing is block-diagonal w.r.t. o_groups, it can
-        be absorbed into the grouped output projection weight, after which the
-        vha_postmix_U/V parameters are no longer needed at inference time.
-
-        Per group g (with B_g = I + U_g V_g^T, shape [group_heads, group_heads]),
-        the fused weight is
-            W_fused[g][r, j', d] = sum_j B_g[j', j] * W[g][r, j, d]
-        where W[g] = linear_o_group_proj.reshape(o_groups, o_lora_rank,
-        group_heads, v_head_dim). The returned tensor has the exact same shape
-        as linear_o_group_proj ([o_groups * o_lora_rank, group_heads *
-        v_head_dim]) and can replace it directly; inference cost is unchanged.
-
-        Returns a detached tensor in linear_o_group_proj's dtype. If postmix is
-        disabled, returns a clone of linear_o_group_proj unchanged.
-        """
-        with paddle.no_grad():
-            if not self.use_vha_postmix:
-                return self.linear_o_group_proj.clone()
-            if not self.vha_postmix_grouped:
-                raise RuntimeError(
-                    "Ungrouped VHA postmix (vha_postmix_grouped=False) performs "
-                    "full cross-head mixing and cannot be folded into the "
-                    "block-diagonal linear_o_group_proj. Use grouped postmix if "
-                    "inference-time absorption is required."
-                )
-            g = self.o_local_groups
-            gh = self.num_attention_heads // g
-            vd = self.v_head_dim
-            r_out = self.config.o_lora_rank
-            orig_dtype = self.linear_o_group_proj.dtype
-            # M_g[j', j] = sum_r U[g, j', r] * V[g, j, r]; B_g = I + M_g.
-            U = self.vha_postmix_U.astype("float32")
-            V = self.vha_postmix_V.astype("float32")
-            M = paddle.einsum("gpr,gjr->gpj", U, V)
-            B = paddle.eye(gh, dtype="float32").unsqueeze(0) + M
-            W = self.linear_o_group_proj.astype("float32").reshape(
-                [g, r_out, gh, vd]
-            )
-            # W_fused[g, r, p, d] = sum_j B[g, p, j] * W[g, r, j, d], p = j'.
-            W_fused = paddle.einsum("gpj,grjd->grpd", B, W)
-            W_fused = W_fused.reshape([g * r_out, gh * vd])
-            return W_fused.astype(orig_dtype)
 
     def get_query_key_value_tensors(
         self,
@@ -1262,8 +1238,8 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
             # of k = nh // g_q expansion matrices [d_q, q_head_dim] is broadcast
             # across all groups (weight has no group axis -> 3-D, matching the
             # attention.py premix convention). Head (kk, g) reads only group g's
-            # d_q dims, so it is still block-diagonal and materializes to a
-            # standard up_proj at inference via export_premix_as_up_proj().
+            # d_q dims, so it is still block-diagonal (mathematically equivalent
+            # to a dense up_proj on the compressed Q).
             # Init matches the prior VHA premix (attention.py) non-square branch:
             # each [d_q, q_head_dim] block is semi-orthogonal, scaled by
             # sqrt(q_head_dim / d_q) so the pre-(q_rms_norm) per-element RMS is
@@ -1408,7 +1384,7 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
             # Structured premix (Variant A / shared): reshape compressed Q into
             # g_q groups, then expand each group into k heads with a single set of
             # k weight matrices broadcast across all groups. Head layout is
-            # kk * g_q + g (k outer, g inner), matching export_premix_as_up_proj().
+            # kk * g_q + g (k outer, g inner).
             g_q = self.vha_premix_groups
             q = q_compressed.reshape([b, sq, g_q, self.vha_premix_dq])
             q = paddle.einsum(
@@ -1517,34 +1493,3 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
         value = key
 
         return query, key, value, q_compressed, hidden_states
-
-    def export_premix_as_up_proj(self) -> Tensor:
-        """Materialize the structured VHA premix into a dense standard up-projection
-        weight ``[q_lora_rank, num_attention_heads * q_head_dim]`` (absorption type 1).
-
-        Placement is block-diagonal: group ``g``'s ``d_q`` latent dims feed only the
-        heads ``kk * g_q + g`` (kk = 0..k-1); all other entries are zero. Because the
-        premix is Variant A (shared), every group reuses the same ``k`` weight blocks.
-        The result is equivalent to the training-time einsum and can be dropped into a
-        plain up_proj. NOTE: the structured einsum is cheaper at inference; this dense
-        export exists only for compatibility with kernels expecting a standard up_proj.
-        """
-        with paddle.no_grad():
-            if not self.use_vha_premix:
-                raise RuntimeError(
-                    "export_premix_as_up_proj requires use_vha_premix=True"
-                )
-            g_q = self.vha_premix_groups
-            k = self.vha_premix_expand
-            d_q = self.vha_premix_dq
-            hd = self.v_head_dim
-            nh = self.num_attention_heads
-            orig_dtype = self.vha_premix_weight.dtype
-            W = self.vha_premix_weight.astype("float32")  # [k, d_q, hd]
-            # W_up[g, rr, head, d] = W[kk, rr, d] for head = kk*g_q + g; else 0.
-            W_up = paddle.zeros([g_q, d_q, nh, hd], dtype="float32")
-            for g in range(g_q):
-                for kk in range(k):
-                    W_up[g, :, kk * g_q + g, :] = W[kk]  # [d_q, hd]
-            W_up = W_up.reshape([g_q * d_q, nh * hd])
-            return W_up.astype(orig_dtype)

--- a/src/paddlefleet/transformer/dsv4_hybrid_attention.py
+++ b/src/paddlefleet/transformer/dsv4_hybrid_attention.py
@@ -753,6 +753,20 @@ class DSv4HybridAttention(Attention):
         if self.use_vha_postmix:
             group_heads = self.num_attention_heads // self.o_local_groups
             if self.vha_postmix_grouped:
+                # Grouped postmix mixes heads within each o_group on the
+                # group_heads axis, so it requires an exact head split across
+                # groups. The constructor only guarantees
+                # (num_attention_heads * v_head_dim) % o_groups == 0, which is
+                # weaker (e.g. nh=6, v_head_dim=4, o_groups=4 passes but yields
+                # group_heads=1 and a 6->4 head reshape mismatch). Enforce the
+                # stronger head-level divisibility here with an explicit
+                # ValueError (assertions are stripped under `python -O`).
+                if self.num_attention_heads % self.o_local_groups != 0:
+                    raise ValueError(
+                        "grouped VHA postmix requires num_attention_heads "
+                        f"({self.num_attention_heads}) to be divisible by "
+                        f"o_groups ({self.o_local_groups})"
+                    )
                 # Per-group mixing on the group_heads axis; rank capped at
                 # group_heads (full-rank), beyond which it is redundant.
                 mix_heads = group_heads
@@ -1218,15 +1232,28 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
         ) and getattr(config, "use_vha_premix", False)
         if self.use_vha_premix:
             g_q = config.vha_premix_groups
-            assert g_q is not None, (
-                "use_vha_premix=True requires config.vha_premix_groups to be set"
-            )
-            assert self.num_attention_heads % g_q == 0, (
-                "num_attention_heads must be divisible by vha_premix_groups"
-            )
-            assert self.q_lora_rank % g_q == 0, (
-                "q_lora_rank must be divisible by vha_premix_groups"
-            )
+            # Explicit ValueError (not assert): assertions are stripped under
+            # `python -O`, which would let an invalid grouping silently produce
+            # a wrong Q expansion instead of failing fast at construction.
+            if g_q is None:
+                raise ValueError(
+                    "use_vha_premix=True requires config.vha_premix_groups "
+                    "to be set"
+                )
+            if g_q <= 0:
+                raise ValueError(
+                    f"vha_premix_groups must be a positive integer, got {g_q}"
+                )
+            if self.num_attention_heads % g_q != 0:
+                raise ValueError(
+                    f"num_attention_heads ({self.num_attention_heads}) must be "
+                    f"divisible by vha_premix_groups ({g_q})"
+                )
+            if self.q_lora_rank % g_q != 0:
+                raise ValueError(
+                    f"q_lora_rank ({self.q_lora_rank}) must be divisible by "
+                    f"vha_premix_groups ({g_q})"
+                )
             self.vha_premix_groups = g_q
             self.vha_premix_expand = self.num_attention_heads // g_q  # k
             self.vha_premix_dq = self.q_lora_rank // g_q  # d_q

--- a/src/paddlefleet/transformer/dsv4_hybrid_attention.py
+++ b/src/paddlefleet/transformer/dsv4_hybrid_attention.py
@@ -25,6 +25,7 @@ Components:
 
 from __future__ import annotations
 
+import math
 import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -32,6 +33,7 @@ from typing import TYPE_CHECKING
 import paddle
 from paddle import Tensor, nn
 from paddle.distributed.fleet.meta_parallel import LayerSpec, build_spec_layer
+from paddle.distributed.fleet.utils import recompute
 
 from paddlefleet.fp8.qat import fp8_simulate_qat
 from paddlefleet.models.common.embeddings.rope_utils import (
@@ -736,6 +738,51 @@ class DSv4HybridAttention(Attention):
         self._full_attn_recompute = None
         self._gate_recompute = None
 
+        # VHA postmix: low-rank cross-head mixing of the attention output, applied
+        # after inverse RoPE (head space) and before the grouped output projection.
+        # Two topologies, selected by config.vha_postmix_grouped:
+        #   grouped=False (default): ungrouped full cross-head mixing over all heads
+        #                  (the earlier VHA design). Higher capacity, but NOT absorbable.
+        #   grouped=True:  within-group block-diagonal mixing (per o_group), which folds
+        #                  into linear_o_group_proj at inference
+        #                  (fuse_vha_postmix_into_o_group_proj).
+        # Reuses the shared use_vha_attention / vha_postmix_rank knobs; premix is
+        # wired separately (use_vha_premix).
+        self.use_vha_postmix = getattr(config, "use_vha_attention", False)
+        self.vha_postmix_grouped = getattr(config, "vha_postmix_grouped", False)
+        if self.use_vha_postmix:
+            group_heads = self.num_attention_heads // self.o_local_groups
+            if self.vha_postmix_grouped:
+                # Per-group mixing on the group_heads axis; rank capped at
+                # group_heads (full-rank), beyond which it is redundant.
+                mix_heads = group_heads
+                u_shape = [self.o_local_groups, group_heads, None]
+            else:
+                # Full cross-head mixing on the nh axis; rank capped at nh.
+                mix_heads = self.num_attention_heads
+                u_shape = [self.num_attention_heads, None]
+            vha_postmix_rank = config.vha_postmix_rank
+            if vha_postmix_rank is None:
+                vha_postmix_rank = mix_heads // 4
+            vha_postmix_rank = max(1, min(vha_postmix_rank, mix_heads))
+            self.vha_postmix_rank = vha_postmix_rank
+            u_shape[-1] = vha_postmix_rank
+            self.vha_postmix_U = self.create_parameter(
+                shape=u_shape,
+                default_initializer=nn.initializer.Normal(mean=0.0, std=0.01),
+            )
+            self.vha_postmix_V = self.create_parameter(
+                shape=u_shape,
+                default_initializer=nn.initializer.Constant(0.0),
+            )
+        # Selective recompute for the VHA postmix scatter chain (independently
+        # configurable via the "vha_postmix" entry in recompute_modules).
+        self.recompute_vha_postmix = (
+            config.recompute_granularity == "selective"
+            and config.recompute_modules is not None
+            and "vha_postmix" in config.recompute_modules
+        )
+
     def forward(
         self,
         hidden_states: Tensor,
@@ -935,6 +982,23 @@ class DSv4HybridAttention(Attention):
                 core_attn_out = paddle.concat([content_part, rot_part], axis=-1)
                 core_attn_out = core_attn_out.reshape([b, sq, -1])
 
+        # VHA postmix: low-rank cross-head mixing while still in head space
+        # ([b, sq, nh, v_head_dim]), after inverse RoPE and before the grouped
+        # output projection. When the whole block is already wrapped in a
+        # full_attn RecomputeWithoutOutput, skip the nested selective recompute
+        # (the full block recompute already frees these activations).
+        if self.use_vha_postmix:
+            if (
+                self.recompute_vha_postmix
+                and self.training
+                and not _in_full_recompute
+            ):
+                core_attn_out = recompute(
+                    self._apply_vha_postmix, core_attn_out
+                )
+            else:
+                core_attn_out = self._apply_vha_postmix(core_attn_out)
+
         # Grouped output projection
         core_attn_out = core_attn_out.reshape([b, sq, self.o_local_groups, -1])
         if (
@@ -992,6 +1056,90 @@ class DSv4HybridAttention(Attention):
         else:
             core_attn_out = core_attn_out * paddle.nn.functional.sigmoid(gate)
         return core_attn_out
+
+    def _apply_vha_postmix(self, attn_out: Tensor) -> Tensor:
+        """Low-rank cross-head mixing of the attention output.
+
+        attn_out: [b, sq, nh * v_head_dim] (head space, post inverse RoPE).
+
+        Two topologies (config.vha_postmix_grouped):
+
+        - grouped=True: reshape to [b, sq, o_groups, group_heads, v_head_dim] and,
+          within each o_group, recombine that group's heads via a low-rank
+          correction (I + U_g V_g^T) on the head axis, shared across v_head_dim.
+          Block-diagonal w.r.t. o_groups, so at inference it folds into
+          linear_o_group_proj (see fuse_vha_postmix_into_o_group_proj).
+
+        - grouped=False: reshape to [b, sq, nh, v_head_dim] and recombine ALL heads
+          via a single low-rank correction (I + U V^T) on the nh axis. Full
+          cross-head mixing (higher capacity); NOT absorbable into the grouped
+          output projection.
+
+        V is zero-initialized so this is identity at the start of training.
+        """
+        b, sq = attn_out.shape[0], attn_out.shape[1]
+        if self.vha_postmix_grouped:
+            g = self.o_local_groups
+            gh = self.num_attention_heads // g
+            mixed = attn_out.reshape([b, sq, g, gh, self.v_head_dim])
+            z = paddle.einsum("btgjd,gjr->btgrd", mixed, self.vha_postmix_U)
+            delta = paddle.einsum("btgrd,gjr->btgjd", z, self.vha_postmix_V)
+            mixed = mixed + delta
+        else:
+            nh = self.num_attention_heads
+            mixed = attn_out.reshape([b, sq, nh, self.v_head_dim])
+            z = paddle.einsum("bthd,hr->btrd", mixed, self.vha_postmix_U)
+            delta = paddle.einsum("btrd,hr->bthd", z, self.vha_postmix_V)
+            mixed = mixed + delta
+        return mixed.reshape(
+            [b, sq, self.num_attention_heads * self.v_head_dim]
+        )
+
+    def fuse_vha_postmix_into_o_group_proj(self) -> Tensor:
+        """Fold the VHA postmix into linear_o_group_proj for inference.
+
+        Since the postmix head mixing is block-diagonal w.r.t. o_groups, it can
+        be absorbed into the grouped output projection weight, after which the
+        vha_postmix_U/V parameters are no longer needed at inference time.
+
+        Per group g (with B_g = I + U_g V_g^T, shape [group_heads, group_heads]),
+        the fused weight is
+            W_fused[g][r, j', d] = sum_j B_g[j', j] * W[g][r, j, d]
+        where W[g] = linear_o_group_proj.reshape(o_groups, o_lora_rank,
+        group_heads, v_head_dim). The returned tensor has the exact same shape
+        as linear_o_group_proj ([o_groups * o_lora_rank, group_heads *
+        v_head_dim]) and can replace it directly; inference cost is unchanged.
+
+        Returns a detached tensor in linear_o_group_proj's dtype. If postmix is
+        disabled, returns a clone of linear_o_group_proj unchanged.
+        """
+        with paddle.no_grad():
+            if not self.use_vha_postmix:
+                return self.linear_o_group_proj.clone()
+            if not self.vha_postmix_grouped:
+                raise RuntimeError(
+                    "Ungrouped VHA postmix (vha_postmix_grouped=False) performs "
+                    "full cross-head mixing and cannot be folded into the "
+                    "block-diagonal linear_o_group_proj. Use grouped postmix if "
+                    "inference-time absorption is required."
+                )
+            g = self.o_local_groups
+            gh = self.num_attention_heads // g
+            vd = self.v_head_dim
+            r_out = self.config.o_lora_rank
+            orig_dtype = self.linear_o_group_proj.dtype
+            # M_g[j', j] = sum_r U[g, j', r] * V[g, j, r]; B_g = I + M_g.
+            U = self.vha_postmix_U.astype("float32")
+            V = self.vha_postmix_V.astype("float32")
+            M = paddle.einsum("gpr,gjr->gpj", U, V)
+            B = paddle.eye(gh, dtype="float32").unsqueeze(0) + M
+            W = self.linear_o_group_proj.astype("float32").reshape(
+                [g, r_out, gh, vd]
+            )
+            # W_fused[g, r, p, d] = sum_j B[g, p, j] * W[g, r, j, d], p = j'.
+            W_fused = paddle.einsum("gpj,grjd->grpd", B, W)
+            W_fused = W_fused.reshape([g * r_out, gh * vd])
+            return W_fused.astype(orig_dtype)
 
     def get_query_key_value_tensors(
         self,
@@ -1062,20 +1210,70 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
             eps=getattr(config, "rms_norm_eps", 1e-5),
         )
 
-        # Q up projection: q_lora_rank -> num_heads * q_head_dim (column parallel)
-        self.linear_q_up_proj = build_spec_layer(
-            sublayers_spec.linear_q_up_proj,
-            self.q_lora_rank,
-            self.num_attention_heads * q_head_dim,
-            config=config,
-            init_method=config.init_method,
-            gather_output=False,
-            bias=False,
-            skip_bias_add=False,
-            is_expert=False,
-            tp_group=self.pg_collection.tp,
-        )
-        self.linear_q_up_proj.save_original_input = True
+        # Q up projection: q_lora_rank -> num_heads * q_head_dim (column parallel).
+        # When use_vha_premix is enabled, linear_q_up_proj is replaced by a
+        # structured VHA premix (block-diagonal per group), built below.
+        self.use_vha_premix = getattr(
+            config, "use_vha_attention", False
+        ) and getattr(config, "use_vha_premix", False)
+        if self.use_vha_premix:
+            g_q = config.vha_premix_groups
+            assert g_q is not None, (
+                "use_vha_premix=True requires config.vha_premix_groups to be set"
+            )
+            assert self.num_attention_heads % g_q == 0, (
+                "num_attention_heads must be divisible by vha_premix_groups"
+            )
+            assert self.q_lora_rank % g_q == 0, (
+                "q_lora_rank must be divisible by vha_premix_groups"
+            )
+            self.vha_premix_groups = g_q
+            self.vha_premix_expand = self.num_attention_heads // g_q  # k
+            self.vha_premix_dq = self.q_lora_rank // g_q  # d_q
+            # Structured up-projection (VHA premix, Variant A / shared): the
+            # compressed Q is split into g_q groups of d_q dims, and a SINGLE set
+            # of k = nh // g_q expansion matrices [d_q, q_head_dim] is broadcast
+            # across all groups (weight has no group axis -> 3-D, matching the
+            # attention.py premix convention). Head (kk, g) reads only group g's
+            # d_q dims, so it is still block-diagonal and materializes to a
+            # standard up_proj at inference via export_premix_as_up_proj().
+            # Init matches the prior VHA premix (attention.py) non-square branch:
+            # each [d_q, q_head_dim] block is semi-orthogonal, scaled by
+            # sqrt(q_head_dim / d_q) so the pre-(q_rms_norm) per-element RMS is
+            # preserved across the d_q -> q_head_dim expansion. Cannot zero-init
+            # (there is no residual around Q).
+            premix_scale = math.sqrt(q_head_dim / self.vha_premix_dq)
+            init_blocks = []
+            for _ in range(self.vha_premix_expand):
+                block = paddle.empty([self.vha_premix_dq, q_head_dim])
+                nn.initializer.Orthogonal()(block)
+                init_blocks.append(block * premix_scale)
+            init_weight = paddle.stack(init_blocks).reshape(
+                [self.vha_premix_expand, self.vha_premix_dq, q_head_dim]
+            )
+            self.vha_premix_weight = self.create_parameter(
+                shape=[
+                    self.vha_premix_expand,
+                    self.vha_premix_dq,
+                    q_head_dim,
+                ],
+                default_initializer=nn.initializer.Assign(init_weight),
+            )
+            self.linear_q_up_proj = None
+        else:
+            self.linear_q_up_proj = build_spec_layer(
+                sublayers_spec.linear_q_up_proj,
+                self.q_lora_rank,
+                self.num_attention_heads * q_head_dim,
+                config=config,
+                init_method=config.init_method,
+                gather_output=False,
+                bias=False,
+                skip_bias_add=False,
+                is_expert=False,
+                tp_group=self.pg_collection.tp,
+            )
+            self.linear_q_up_proj.save_original_input = True
 
         # KV projection: hidden_size -> v_head_dim (single head)
         self.linear_kv_proj = build_spec_layer(
@@ -1102,7 +1300,10 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
 
     def muon_slice_specs(self, muon_configs):
         """Muon orthogonal-slice specs for the DSv4 hybrid projections."""
-        from paddlefleet.transformer.muon_utils import ortho_per_head
+        from paddlefleet.transformer.muon_utils import (
+            ortho_per_head,
+            ortho_stacked,
+        )
 
         if (
             muon_configs.get("muon_qkv_update_mode", "split_head")
@@ -1111,10 +1312,6 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
             return {}
 
         specs = {
-            "linear_q_up_proj.weight": (
-                ortho_per_head,
-                {"heads": self.num_attention_heads_per_partition},
-            ),
             # Stored as [o_groups * o_lora_rank, d] but used as [g, r, d] in a
             # grouped gemm, so the leading axis packs o_groups independent
             # matrices and must be split along axis 0.
@@ -1123,6 +1320,19 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
                 {"heads": self.o_local_groups, "axis": 0},
             ),
         }
+        if self.use_vha_premix:
+            # VHA premix replaces linear_q_up_proj (which is None here). The
+            # premix weight is a 3D grouped fuse [k, d_q, q_head_dim] whose
+            # leading axis enumerates the k independent expansion matrices, so
+            # orthogonalise per leading-axis slice (split along dim 0). Postmix
+            # (vha_postmix_U/V) is a plain 2D matrix and is intentionally left
+            # unmarked so muon handles it directly.
+            specs["vha_premix_weight"] = (ortho_stacked, {})
+        else:
+            specs["linear_q_up_proj.weight"] = (
+                ortho_per_head,
+                {"heads": self.num_attention_heads_per_partition},
+            )
         if getattr(self, "gate_proj", None) is not None:
             # The gate multiplies the flattened grouped-projection output, whose
             # columns are group-major (group g owns o_lora_rank columns), so the
@@ -1167,8 +1377,22 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
         )  # [b, sq, q_lora_rank]
         q_compressed = self.q_layernorm(q_compressed)
 
-        q, _ = self.linear_q_up_proj(q_compressed)  # [b, sq, n * v_head_dim]
-        q = q.reshape([b, sq, self.num_attention_heads, self.v_head_dim])
+        if self.use_vha_premix:
+            # Structured premix (Variant A / shared): reshape compressed Q into
+            # g_q groups, then expand each group into k heads with a single set of
+            # k weight matrices broadcast across all groups. Head layout is
+            # kk * g_q + g (k outer, g inner), matching export_premix_as_up_proj().
+            g_q = self.vha_premix_groups
+            q = q_compressed.reshape([b, sq, g_q, self.vha_premix_dq])
+            q = paddle.einsum(
+                "btgr,krd->btkgd", q, self.vha_premix_weight
+            )  # [b, sq, k, g_q, q_head_dim]
+            q = q.reshape([b, sq, self.num_attention_heads, self.v_head_dim])
+        else:
+            q, _ = self.linear_q_up_proj(
+                q_compressed
+            )  # [b, sq, n * v_head_dim]
+            q = q.reshape([b, sq, self.num_attention_heads, self.v_head_dim])
         q = _q_rms_norm(
             q,
             getattr(self.config, "rms_norm_eps", 1e-5),
@@ -1266,3 +1490,34 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
         value = key
 
         return query, key, value, q_compressed, hidden_states
+
+    def export_premix_as_up_proj(self) -> Tensor:
+        """Materialize the structured VHA premix into a dense standard up-projection
+        weight ``[q_lora_rank, num_attention_heads * q_head_dim]`` (absorption type 1).
+
+        Placement is block-diagonal: group ``g``'s ``d_q`` latent dims feed only the
+        heads ``kk * g_q + g`` (kk = 0..k-1); all other entries are zero. Because the
+        premix is Variant A (shared), every group reuses the same ``k`` weight blocks.
+        The result is equivalent to the training-time einsum and can be dropped into a
+        plain up_proj. NOTE: the structured einsum is cheaper at inference; this dense
+        export exists only for compatibility with kernels expecting a standard up_proj.
+        """
+        with paddle.no_grad():
+            if not self.use_vha_premix:
+                raise RuntimeError(
+                    "export_premix_as_up_proj requires use_vha_premix=True"
+                )
+            g_q = self.vha_premix_groups
+            k = self.vha_premix_expand
+            d_q = self.vha_premix_dq
+            hd = self.v_head_dim
+            nh = self.num_attention_heads
+            orig_dtype = self.vha_premix_weight.dtype
+            W = self.vha_premix_weight.astype("float32")  # [k, d_q, hd]
+            # W_up[g, rr, head, d] = W[kk, rr, d] for head = kk*g_q + g; else 0.
+            W_up = paddle.zeros([g_q, d_q, nh, hd], dtype="float32")
+            for g in range(g_q):
+                for kk in range(k):
+                    W_up[g, :, kk * g_q + g, :] = W[kk]  # [d_q, hd]
+            W_up = W_up.reshape([g_q * d_q, nh * hd])
+            return W_up.astype(orig_dtype)

--- a/src/paddlefleet/transformer/multi_latent_attention.py
+++ b/src/paddlefleet/transformer/multi_latent_attention.py
@@ -582,6 +582,55 @@ class MultiLatentAttention(Attention):
                     )
                 )
 
+        # VHA postmix: ungrouped low-rank cross-head mixing (I + U Vᵀ) on the head
+        # axis, applied to the attention output (head space) before the output
+        # projection. Reuses use_vha_attention / vha_postmix_rank. Ungrouped only:
+        # MLA/MQA have no grouped o_proj to fold a block-diagonal mixer into.
+        self.use_vha_postmix = getattr(config, "use_vha_attention", False)
+        if self.use_vha_postmix:
+            assert get_pg_size(self.pg_collection.tp) == 1, (
+                "VHA postmix currently supports tensor parallel size 1 only."
+            )
+            nh = (
+                self.num_attention_heads_per_partition
+            )  # == num_attention_heads (TP=1)
+            rank = getattr(config, "vha_postmix_rank", None)
+            if rank is None:
+                rank = nh // 4
+            rank = max(1, min(rank, nh))
+            self.vha_postmix_rank = rank
+            self.vha_postmix_U = self.create_parameter(
+                shape=[nh, rank],
+                default_initializer=paddle.nn.initializer.Normal(
+                    mean=0.0, std=0.01
+                ),
+            )
+            self.vha_postmix_V = self.create_parameter(
+                shape=[nh, rank],
+                default_initializer=paddle.nn.initializer.Constant(
+                    0.0
+                ),  # identity at init
+            )
+        self.recompute_vha_postmix = (
+            self.config.recompute_granularity == "selective"
+            and self.config.recompute_modules is not None
+            and "vha_postmix" in self.config.recompute_modules
+        )
+
+    def _apply_vha_postmix(self, attn_out, U=None, V=None):
+        # attn_out: [b, sq, nh_pp * v_head_dim] (head space, pre-gate / pre output proj).
+        if U is None:
+            U = self.vha_postmix_U
+        if V is None:
+            V = self.vha_postmix_V
+        b, sq = attn_out.shape[0], attn_out.shape[1]
+        nh = self.num_attention_heads_per_partition
+        mixed = attn_out.reshape([b, sq, nh, self.v_head_dim])
+        z = paddle.einsum("bthd,hr->btrd", mixed, U)
+        delta = paddle.einsum("btrd,hr->bthd", z, V)
+        mixed = mixed + delta
+        return mixed.reshape([b, sq, nh * self.v_head_dim])
+
     def _compute_absorbed_q(self, query):
         """
         Compute absorbed query for FD MLA decode kernel.
@@ -827,6 +876,21 @@ class MultiLatentAttention(Attention):
         # =================
         if self.config.sequence_parallel:
             core_attn_out = core_attn_out.transpose([1, 0, 2]).contiguous()
+
+        # VHA postmix: low-rank cross-head mixing in head space, before the gate
+        # (mix-then-gate). Skip the nested selective recompute when already
+        # inside a layer-level recompute.
+        if self.use_vha_postmix:
+            if (
+                self.recompute_vha_postmix
+                and self.training
+                and not in_recompute
+            ):
+                core_attn_out = recompute(
+                    self._apply_vha_postmix, core_attn_out
+                )
+            else:
+                core_attn_out = self._apply_vha_postmix(core_attn_out)
 
         # Apply gated attention
         if self.gated_attention:
@@ -1852,6 +1916,24 @@ class MQASelfAttention(MLASelfAttention):
                 self.swa_attn_sink = None
                 self.sparse_attn_sink = None
 
+            # VHA postmix for the block-sparse branch. The MQA path has two
+            # independent gated branches (sliding-window main + block-sparse),
+            # so each gets its own postmix params: the base vha_postmix_U/V
+            # serve the main branch, this set serves the sparse branch.
+            if self.use_vha_postmix:
+                nh = self.num_attention_heads_per_partition  # TP==1 for MQA
+                rank = self.vha_postmix_rank
+                self.sparse_vha_postmix_U = self.create_parameter(
+                    shape=[nh, rank],
+                    default_initializer=paddle.nn.initializer.Normal(
+                        mean=0.0, std=0.01
+                    ),
+                )
+                self.sparse_vha_postmix_V = self.create_parameter(
+                    shape=[nh, rank],
+                    default_initializer=paddle.nn.initializer.Constant(0.0),
+                )
+
     def forward(
         self,
         hidden_states,
@@ -2017,6 +2099,19 @@ class MQASelfAttention(MLASelfAttention):
 
         core_attn_out = compute_absorbed_v(core_attn_out)
 
+        # VHA postmix (main branch): mix in head space before the gate.
+        if self.use_vha_postmix:
+            if (
+                self.recompute_vha_postmix
+                and self.training
+                and not in_recompute
+            ):
+                core_attn_out = recompute(
+                    self._apply_vha_postmix, core_attn_out
+                )
+            else:
+                core_attn_out = self._apply_vha_postmix(core_attn_out)
+
         # =================
         # Sparse attention computation
         # =================
@@ -2087,6 +2182,22 @@ class MQASelfAttention(MLASelfAttention):
         )
 
         sparse_core_attn_out = compute_absorbed_v(sparse_core_attn_out)
+
+        # VHA postmix (sparse branch): own param set, mix before the sparse gate.
+        if self.use_vha_postmix:
+            U, V = self.sparse_vha_postmix_U, self.sparse_vha_postmix_V
+            if (
+                self.recompute_vha_postmix
+                and self.training
+                and not in_recompute
+            ):
+                sparse_core_attn_out = recompute(
+                    self._apply_vha_postmix, sparse_core_attn_out, U, V
+                )
+            else:
+                sparse_core_attn_out = self._apply_vha_postmix(
+                    sparse_core_attn_out, U, V
+                )
 
         # =================
         # Output. [b, sq, h]

--- a/src/paddlefleet/transformer/multi_latent_attention.py
+++ b/src/paddlefleet/transformer/multi_latent_attention.py
@@ -588,9 +588,15 @@ class MultiLatentAttention(Attention):
         # MLA/MQA have no grouped o_proj to fold a block-diagonal mixer into.
         self.use_vha_postmix = getattr(config, "use_vha_attention", False)
         if self.use_vha_postmix:
-            assert get_pg_size(self.pg_collection.tp) == 1, (
-                "VHA postmix currently supports tensor parallel size 1 only."
-            )
+            # Use an explicit ValueError (not assert): assertions are stripped
+            # under `python -O`, which would silently let TP>1 mix only the
+            # local heads of each rank and deviate from the declared full-head
+            # postmix semantics.
+            if get_pg_size(self.pg_collection.tp) != 1:
+                raise ValueError(
+                    "VHA postmix currently supports tensor parallel size 1 "
+                    f"only, got tp={get_pg_size(self.pg_collection.tp)}."
+                )
             nh = (
                 self.num_attention_heads_per_partition
             )  # == num_attention_heads (TP=1)

--- a/src/paddlefleet/transformer/multi_latent_attention.py
+++ b/src/paddlefleet/transformer/multi_latent_attention.py
@@ -617,11 +617,36 @@ class MultiLatentAttention(Attention):
                     0.0
                 ),  # identity at init
             )
-        self.recompute_vha_postmix = (
+        # Selective recompute for the VHA postmix. Only list configuration is
+        # supported; honours recompute_num_layers + recompute_method
+        # (first_n / block) like the other selective modules.
+        modules = self.config.recompute_modules
+        self.recompute_vha_postmix = False
+        if (
             self.config.recompute_granularity == "selective"
-            and self.config.recompute_modules is not None
-            and "vha_postmix" in self.config.recompute_modules
-        )
+            and modules is not None
+        ):
+            if isinstance(modules, dict) and "vha_postmix" in modules:
+                raise ValueError(
+                    "recompute_modules['vha_postmix'] only supports list "
+                    "configuration"
+                )
+            if isinstance(modules, list) and "vha_postmix" in modules:
+                n = self.config.recompute_num_layers
+                if n is None:
+                    self.recompute_vha_postmix = True
+                elif self.config.recompute_method == "block":
+                    self.recompute_vha_postmix = need_recompute_in_block(
+                        self.layer_number, self.config, n
+                    )
+                elif self.config.recompute_method == "first_n":
+                    self.recompute_vha_postmix = need_recompute_in_first_n(
+                        self.layer_number, self.config, n
+                    )
+                else:
+                    raise ValueError(
+                        "recompute_method must be 'first_n' or 'block'"
+                    )
 
     def _apply_vha_postmix(self, attn_out, U=None, V=None):
         # attn_out: [b, sq, nh_pp * v_head_dim] (head space, pre-gate / pre output proj).

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -221,10 +221,9 @@ class TransformerConfig(ModelParallelConfig):
 
     vha_postmix_grouped: bool = False
     """Postmix head-mixing topology (DSv4 hybrid only). False (default): ungrouped
-    full cross-head mixing over all num_attention_heads (the earlier VHA design),
-    which is NOT absorbable into the grouped output projection. True: within-group
-    block-diagonal mixing that only recombines heads inside each o_group, so it folds
-    into linear_o_group_proj at inference (fuse_vha_postmix_into_o_group_proj)."""
+    full cross-head mixing over all num_attention_heads (the earlier VHA design).
+    True: within-group block-diagonal mixing that only recombines heads inside each
+    o_group (mixing stays within a group)."""
 
     use_vha_premix: bool = False
     """If True (and use_vha_attention is also True), replaces the DSv4 hybrid Q up-projection

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -219,6 +219,26 @@ class TransformerConfig(ModelParallelConfig):
     vha_postmix_rank: int | None = None
     """Rank of the VHA postmix low-rank head mixing matrices."""
 
+    vha_postmix_grouped: bool = False
+    """Postmix head-mixing topology (DSv4 hybrid only). False (default): ungrouped
+    full cross-head mixing over all num_attention_heads (the earlier VHA design),
+    which is NOT absorbable into the grouped output projection. True: within-group
+    block-diagonal mixing that only recombines heads inside each o_group, so it folds
+    into linear_o_group_proj at inference (fuse_vha_postmix_into_o_group_proj)."""
+
+    use_vha_premix: bool = False
+    """If True (and use_vha_attention is also True), replaces the DSv4 hybrid Q up-projection
+    (linear_q_up_proj) with a structured VHA premix: the compressed Q is reshaped into
+    vha_premix_groups groups of dim d_q = q_lora_rank // vha_premix_groups, and each group is
+    expanded into k = num_attention_heads // vha_premix_groups heads via a per-group weight.
+    Requires q_lora_rank % vha_premix_groups == 0 and num_attention_heads % vha_premix_groups
+    == 0. DSv4 hybrid attention only; postmix is unaffected (still keyed on use_vha_attention)."""
+
+    vha_premix_groups: int | None = None
+    """Number of groups g_q the compressed Q is split into for the VHA premix. Per-group latent
+    dim is q_lora_rank // vha_premix_groups; per-group head expansion is num_attention_heads //
+    vha_premix_groups. Only used when use_vha_premix is True."""
+
     vha_q_lora_rank: int | None = None
     """Rank of the VHA Q low-rank projection. When set, Q projects to this rank per head before premix expansion."""
 

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_dsv4_hybrid_attention_recompute.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_dsv4_hybrid_attention_recompute.py
@@ -101,6 +101,11 @@ def _make_dsv4_instance(
     inst._full_attn_recompute = None
     inst._gate_recompute = None
 
+    # VHA postmix disabled for these recompute-path tests (forward() reads
+    # these flags; the real module sets them in __init__).
+    inst.use_vha_postmix = False
+    inst.recompute_vha_postmix = False
+
     # Gated attention
     inst.gated_attention = gated_attention
     inst.gated_attn_use_q_lora = gated_attn_use_q_lora

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_multi_latent_attention_2.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_multi_latent_attention_2.py
@@ -774,6 +774,8 @@ class TestForwardDiscardOutputAndRegisterRecompute(unittest.TestCase):
         instance.config = MagicMock()
         instance.config.sequence_parallel = False
         instance.gated_attention = False
+        instance.use_vha_postmix = False
+        instance.recompute_vha_postmix = False
         instance.config.dw_p2p_overlap = False
         instance.config.use_bias = True
 

--- a/tests/single_card_tests/transformer/test_muon_slice_specs.py
+++ b/tests/single_card_tests/transformer/test_muon_slice_specs.py
@@ -423,6 +423,7 @@ class TestDSv4HybridSpecs(unittest.TestCase):
         return SimpleNamespace(
             num_attention_heads_per_partition=4,
             o_local_groups=2,
+            use_vha_premix=False,
             gate_proj=object() if gated else None,
         )
 

--- a/tests/single_card_tests/transformer/test_vha_dsv4.py
+++ b/tests/single_card_tests/transformer/test_vha_dsv4.py
@@ -1,0 +1,632 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for VHA (Virtual Head Attention) in DSv4 hybrid attention.
+
+Covers the postmix (grouped / ungrouped low-rank cross-head mixing) and premix
+(structured Q up-projection) additions to ``DSv4HybridSelfAttention`` /
+``DSv4HybridAttention``, plus the config-validation ValueErrors, the
+muon_slice_specs branching, and forward / backward (gradient) coverage of the
+postmix and premix parameters.
+"""
+
+import unittest
+
+import paddle
+from paddle.distributed.fleet.meta_parallel import build_spec_layer
+
+from paddlefleet.models.gpt.gpt_layer_specs import get_attention_spec
+from paddlefleet.tensor_parallel.random import model_parallel_cuda_manual_seed
+from paddlefleet.training.initialize import initialize_fleet
+from paddlefleet.transformer.enums import AttnMaskType
+from paddlefleet.transformer.muon_utils import ortho_per_head, ortho_stacked
+from paddlefleet.transformer.transformer_config import TransformerConfig
+from paddlefleet.utils import init_method_normal, scaled_init_method_normal
+
+initialize_fleet(strategy=paddle.distributed.fleet.DistributedStrategy())
+
+_SEED = 42
+
+
+def _make_config(
+    num_layers=4,
+    hidden_size=256,
+    num_attention_heads=8,
+    v_head_dim=32,
+    qk_nope_head_dim=16,
+    qk_rope_head_dim=16,
+    q_lora_rank=64,
+    o_groups=4,
+    o_lora_rank=32,
+    params_dtype=paddle.float32,
+    bf16=False,
+    csa_compress_ratios=None,
+    **overrides,
+):
+    """Minimal dsv4-hybrid config; VHA knobs passed via **overrides."""
+    if csa_compress_ratios is None:
+        csa_compress_ratios = [0, 4, 128, 4]
+    kwargs = {
+        "num_hidden_layers": num_layers,
+        "hidden_size": hidden_size,
+        "num_attention_heads": num_attention_heads,
+        "params_dtype": params_dtype,
+        "bf16": bf16,
+        "use_bias": False,
+        "multi_latent_attention": True,
+        "experimental_attention_variant": "dsv4_hybrid",
+        "q_lora_rank": q_lora_rank,
+        "kv_lora_rank": v_head_dim - qk_rope_head_dim,
+        "qk_nope_head_dim": qk_nope_head_dim,
+        "qk_rope_head_dim": qk_rope_head_dim,
+        "qk_pos_emb_head_dim": qk_rope_head_dim,
+        "v_head_dim": v_head_dim,
+        "hybrid_mla_q_lora_rank": 1536,
+        "hybrid_mla_kv_lora_rank": 512,
+        "hybrid_mla_qk_nope_head_dim": 192,
+        "hybrid_mla_qk_rope_head_dim": 64,
+        "hybrid_mla_v_head_dim": 256,
+        "hybrid_mla_num_attention_heads": 64,
+        "hybrid_mla_num_key_value_heads": 64,
+        "hybrid_index_n_heads": 4,
+        "hybrid_index_head_dim": 128,
+        "hybrid_index_topk": 8,
+        "o_groups": o_groups,
+        "o_lora_rank": o_lora_rank,
+        "rope_type": "rope",
+        "rotary_base": 10000.0,
+        "rotary_percent": 1.0,
+        "normalization": "RMSNorm",
+        "use_qk_norm": True,
+        "csa_compress_ratios": csa_compress_ratios,
+        "csa_window_size": 16,
+        "dsa_index_n_heads": 4,
+        "dsa_index_head_dim": 32,
+        "dsa_index_topk": 8,
+        "dsa_indexer_loss_coeff": 1.0,
+        "dsa_indexer_use_sparse_loss": False,
+        "dsa_indexer_rotary_interleaved": False,
+        "apply_rope_fusion": False,
+        "attention_dropout": 0.0,
+        "attention_softmax_in_fp32": True,
+        "masked_softmax_fusion": False,
+        "softmax_type": "vanilla",
+        "csa_indexer_backend": "unfused",
+        "csa_sparse_attn_backend": "unfused",
+        "tensor_model_parallel_size": 1,
+        "context_parallel_size": 1,
+        "csa_dense_mode": False,
+        "init_method": init_method_normal(0.02),
+        "output_layer_init_method": scaled_init_method_normal(0.02, 1, 2.0),
+        "rms_norm_eps": 1e-5,
+    }
+    kwargs.update(overrides)
+    config = TransformerConfig(**kwargs)
+    # Force float32 weights (config.dtype drives create_parameter for the
+    # grouped o-proj and premix). Real training uses bf16 via amp, but these
+    # are numerical unit tests; float32 keeps postmix / fuse / forward dtypes
+    # consistent (bf16 has no GPU allclose kernel and breaks the grouped matmul
+    # when mixed with the float32 postmix params).
+    config.dtype = "float32"
+    return config
+
+
+def _build(config, layer_number=0):
+    model_parallel_cuda_manual_seed(_SEED)
+    spec = get_attention_spec(
+        config=config,
+        attention_layer_type="dsv4_hybrid_attention",
+        attn_mask_type=AttnMaskType.causal,
+    )
+    return build_spec_layer(spec, config=config, layer_number=layer_number)
+
+
+class TestPostmixInit(unittest.TestCase):
+    def test_ungrouped_shapes(self):
+        attn = _build(_make_config(use_vha_attention=True, vha_postmix_rank=4))
+        self.assertTrue(attn.use_vha_postmix)
+        self.assertFalse(attn.vha_postmix_grouped)
+        self.assertEqual(attn.vha_postmix_U.shape, [8, 4])
+        self.assertEqual(attn.vha_postmix_V.shape, [8, 4])
+
+    def test_grouped_shapes(self):
+        attn = _build(
+            _make_config(
+                use_vha_attention=True,
+                vha_postmix_grouped=True,
+                vha_postmix_rank=2,
+            )
+        )
+        # o_groups=4, group_heads = nh(8)//4 = 2
+        self.assertEqual(attn.vha_postmix_U.shape, [4, 2, 2])
+        self.assertEqual(attn.vha_postmix_V.shape, [4, 2, 2])
+
+    def test_rank_default_ungrouped(self):
+        # rank None -> mix_heads // 4 = nh(8)//4 = 2
+        attn = _build(
+            _make_config(use_vha_attention=True, vha_postmix_rank=None)
+        )
+        self.assertEqual(attn.vha_postmix_rank, 2)
+
+    def test_rank_default_grouped_clamped_min1(self):
+        # grouped: mix_heads = group_heads = 2; 2//4 = 0 -> clamped to 1
+        attn = _build(
+            _make_config(
+                use_vha_attention=True,
+                vha_postmix_grouped=True,
+                vha_postmix_rank=None,
+            )
+        )
+        self.assertEqual(attn.vha_postmix_rank, 1)
+
+    def test_rank_clamped_to_mix_heads(self):
+        # rank far above nh is clamped down to nh (=8)
+        attn = _build(
+            _make_config(use_vha_attention=True, vha_postmix_rank=999)
+        )
+        self.assertEqual(attn.vha_postmix_rank, 8)
+
+    def test_grouped_head_divisibility_error(self):
+        # nh=6, v_head_dim=32, o_groups=4: 6*32 % 4 == 0 (base check passes) but
+        # 6 % 4 != 0, so grouped postmix must raise.
+        with self.assertRaises(ValueError):
+            _build(
+                _make_config(
+                    num_attention_heads=6,
+                    v_head_dim=32,
+                    o_groups=4,
+                    use_vha_attention=True,
+                    vha_postmix_grouped=True,
+                    vha_postmix_rank=1,
+                )
+            )
+
+    def test_recompute_flag_on(self):
+        attn = _build(
+            _make_config(
+                use_vha_attention=True,
+                recompute_granularity="selective",
+                recompute_modules=["vha_postmix"],
+            )
+        )
+        self.assertTrue(attn.recompute_vha_postmix)
+
+    def test_recompute_flag_off(self):
+        attn = _build(_make_config(use_vha_attention=True))
+        self.assertFalse(attn.recompute_vha_postmix)
+
+    def test_recompute_first_n_hit(self):
+        # num_layers=4, first_n with n=2 -> layers 0,1 recompute.
+        attn = _build(
+            _make_config(
+                use_vha_attention=True,
+                recompute_granularity="selective",
+                recompute_modules=["vha_postmix"],
+                recompute_method="first_n",
+                recompute_num_layers=2,
+            ),
+            layer_number=1,
+        )
+        self.assertTrue(attn.recompute_vha_postmix)
+
+    def test_recompute_first_n_miss(self):
+        # first_n with n=2 -> layer 3 is beyond the window -> no recompute.
+        attn = _build(
+            _make_config(
+                use_vha_attention=True,
+                recompute_granularity="selective",
+                recompute_modules=["vha_postmix"],
+                recompute_method="first_n",
+                recompute_num_layers=2,
+            ),
+            layer_number=3,
+        )
+        self.assertFalse(attn.recompute_vha_postmix)
+
+    def test_recompute_block_hit(self):
+        # single chunk (pp=vpp=1), block n=2 -> layers 0,1 recompute.
+        attn = _build(
+            _make_config(
+                use_vha_attention=True,
+                recompute_granularity="selective",
+                recompute_modules=["vha_postmix"],
+                recompute_method="block",
+                recompute_num_layers=2,
+            ),
+            layer_number=0,
+        )
+        self.assertTrue(attn.recompute_vha_postmix)
+
+    def test_recompute_block_miss(self):
+        # block n=2 -> layer 2 falls outside the per-chunk window.
+        attn = _build(
+            _make_config(
+                use_vha_attention=True,
+                recompute_granularity="selective",
+                recompute_modules=["vha_postmix"],
+                recompute_method="block",
+                recompute_num_layers=2,
+            ),
+            layer_number=2,
+        )
+        self.assertFalse(attn.recompute_vha_postmix)
+
+    def test_recompute_dict_config_raises(self):
+        # dict recompute_modules is rejected for vha_postmix (a valid method is
+        # supplied so the base Attention dict-assert passes and control reaches
+        # the vha_postmix guard).
+        with self.assertRaises(ValueError):
+            _build(
+                _make_config(
+                    use_vha_attention=True,
+                    recompute_granularity="selective",
+                    recompute_modules={"vha_postmix": 1},
+                    recompute_method="first_n",
+                )
+            )
+
+
+class TestPostmixApply(unittest.TestCase):
+    def test_ungrouped_identity_at_init(self):
+        # V is zero-initialised -> postmix is identity at construction.
+        attn = _build(_make_config(use_vha_attention=True, vha_postmix_rank=4))
+        x = paddle.randn([2, 16, 8 * 32])
+        out = attn._apply_vha_postmix(x)
+        self.assertEqual(out.shape, [2, 16, 8 * 32])
+        self.assertTrue(paddle.allclose(out, x, atol=1e-6).item())
+
+    def test_grouped_identity_at_init(self):
+        attn = _build(
+            _make_config(
+                use_vha_attention=True,
+                vha_postmix_grouped=True,
+                vha_postmix_rank=2,
+            )
+        )
+        x = paddle.randn([2, 16, 8 * 32])
+        out = attn._apply_vha_postmix(x)
+        self.assertEqual(out.shape, [2, 16, 8 * 32])
+        self.assertTrue(paddle.allclose(out, x, atol=1e-6).item())
+
+    def test_ungrouped_matches_manual_einsum(self):
+        attn = _build(_make_config(use_vha_attention=True, vha_postmix_rank=4))
+        # Randomise V so the correction is non-trivial.
+        attn.vha_postmix_V.set_value(paddle.randn(attn.vha_postmix_V.shape))
+        x = paddle.randn([2, 16, 8 * 32])
+        out = attn._apply_vha_postmix(x)
+        nh, vd = 8, 32
+        xm = x.reshape([2, 16, nh, vd])
+        z = paddle.einsum("bthd,hr->btrd", xm, attn.vha_postmix_U)
+        delta = paddle.einsum("btrd,hr->bthd", z, attn.vha_postmix_V)
+        ref = (xm + delta).reshape([2, 16, nh * vd])
+        self.assertTrue(paddle.allclose(out, ref, atol=1e-5).item())
+
+
+class TestPremixInit(unittest.TestCase):
+    def test_shapes_and_replaces_up_proj(self):
+        # nh=8, q_lora_rank=64, g_q=2 -> k=4, d_q=32, q_head_dim=32.
+        attn = _build(
+            _make_config(
+                use_vha_attention=True, use_vha_premix=True, vha_premix_groups=2
+            )
+        )
+        self.assertTrue(attn.use_vha_premix)
+        self.assertIsNone(attn.linear_q_up_proj)
+        self.assertEqual(attn.vha_premix_groups, 2)
+        self.assertEqual(attn.vha_premix_expand, 4)  # k = nh // g_q
+        self.assertEqual(attn.vha_premix_dq, 32)  # d_q = q_lora_rank // g_q
+        self.assertEqual(attn.vha_premix_weight.shape, [4, 32, 32])
+
+    def test_disabled_builds_up_proj(self):
+        attn = _build(
+            _make_config(use_vha_attention=True, use_vha_premix=False)
+        )
+        self.assertFalse(attn.use_vha_premix)
+        self.assertIsNotNone(attn.linear_q_up_proj)
+        self.assertTrue(attn.linear_q_up_proj.save_original_input)
+
+    def test_premix_requires_vha_attention(self):
+        # use_vha_premix is gated by use_vha_attention: off unless both set.
+        attn = _build(
+            _make_config(
+                use_vha_attention=False,
+                use_vha_premix=True,
+                vha_premix_groups=2,
+            )
+        )
+        self.assertFalse(attn.use_vha_premix)
+        self.assertIsNotNone(attn.linear_q_up_proj)
+
+    def test_groups_none_raises(self):
+        with self.assertRaises(ValueError):
+            _build(
+                _make_config(
+                    use_vha_attention=True,
+                    use_vha_premix=True,
+                    vha_premix_groups=None,
+                )
+            )
+
+    def test_groups_nonpositive_raises(self):
+        with self.assertRaises(ValueError):
+            _build(
+                _make_config(
+                    use_vha_attention=True,
+                    use_vha_premix=True,
+                    vha_premix_groups=0,
+                )
+            )
+
+    def test_groups_nh_indivisible_raises(self):
+        # nh=8, g_q=3 -> 8 % 3 != 0.
+        with self.assertRaises(ValueError):
+            _build(
+                _make_config(
+                    use_vha_attention=True,
+                    use_vha_premix=True,
+                    vha_premix_groups=3,
+                )
+            )
+
+    def test_groups_qlora_indivisible_raises(self):
+        # nh=8, q_lora_rank=20, g_q=8: 8 % 8 == 0 but 20 % 8 != 0.
+        with self.assertRaises(ValueError):
+            _build(
+                _make_config(
+                    q_lora_rank=20,
+                    use_vha_attention=True,
+                    use_vha_premix=True,
+                    vha_premix_groups=8,
+                )
+            )
+
+
+class TestMuonSliceSpecs(unittest.TestCase):
+    def test_non_split_head_returns_empty(self):
+        attn = _build(
+            _make_config(
+                use_vha_attention=True, use_vha_premix=True, vha_premix_groups=2
+            )
+        )
+        self.assertEqual(
+            attn.muon_slice_specs({"muon_qkv_update_mode": "tp"}), {}
+        )
+
+    def test_premix_on_marks_premix_weight(self):
+        attn = _build(
+            _make_config(
+                use_vha_attention=True, use_vha_premix=True, vha_premix_groups=2
+            )
+        )
+        specs = attn.muon_slice_specs({"muon_qkv_update_mode": "split_head"})
+        self.assertIn("vha_premix_weight", specs)
+        self.assertIs(specs["vha_premix_weight"][0], ortho_stacked)
+        # premix replaces linear_q_up_proj (None) -> not marked.
+        self.assertNotIn("linear_q_up_proj.weight", specs)
+        self.assertIn("linear_o_group_proj", specs)
+
+    def test_premix_off_marks_up_proj(self):
+        attn = _build(
+            _make_config(use_vha_attention=True, use_vha_premix=False)
+        )
+        specs = attn.muon_slice_specs({"muon_qkv_update_mode": "split_head"})
+        self.assertIn("linear_q_up_proj.weight", specs)
+        self.assertIs(specs["linear_q_up_proj.weight"][0], ortho_per_head)
+        self.assertEqual(
+            specs["linear_q_up_proj.weight"][1]["heads"],
+            attn.num_attention_heads_per_partition,
+        )
+        self.assertNotIn("vha_premix_weight", specs)
+
+    def test_default_mode_is_split_head(self):
+        # muon_slice_specs defaults muon_qkv_update_mode to "split_head".
+        attn = _build(
+            _make_config(use_vha_attention=True, use_vha_premix=False)
+        )
+        specs = attn.muon_slice_specs({})
+        self.assertIn("linear_o_group_proj", specs)
+
+
+class TestPostmixBackward(unittest.TestCase):
+    """Gradients must flow to the postmix U/V params through _apply_vha_postmix.
+
+    V is randomised (non-zero) so both U and V carry a non-trivial gradient; at
+    the V=0 init the correction vanishes and dL/dU would be zero.
+    """
+
+    def _check(self, attn):
+        attn.vha_postmix_V.set_value(
+            paddle.randn(attn.vha_postmix_V.shape) * 0.1
+        )
+        x = paddle.randn([2, 16, 8 * 32])
+        x.stop_gradient = False
+        out = attn._apply_vha_postmix(x)
+        out.sum().backward()
+        self.assertIsNotNone(attn.vha_postmix_U.grad)
+        self.assertIsNotNone(attn.vha_postmix_V.grad)
+        self.assertGreater(float(attn.vha_postmix_U.grad.abs().sum()), 0.0)
+        self.assertGreater(float(attn.vha_postmix_V.grad.abs().sum()), 0.0)
+        self.assertIsNotNone(x.grad)
+
+    def test_ungrouped_param_grads(self):
+        self._check(
+            _build(_make_config(use_vha_attention=True, vha_postmix_rank=4))
+        )
+
+    def test_grouped_param_grads(self):
+        self._check(
+            _build(
+                _make_config(
+                    use_vha_attention=True,
+                    vha_postmix_grouped=True,
+                    vha_postmix_rank=2,
+                )
+            )
+        )
+
+
+class TestPremixBackward(unittest.TestCase):
+    """Gradients must flow to vha_premix_weight through the structured einsum."""
+
+    def test_premix_weight_grad_via_einsum(self):
+        attn = _build(
+            _make_config(
+                use_vha_attention=True, use_vha_premix=True, vha_premix_groups=2
+            )
+        )
+        g_q = attn.vha_premix_groups
+        d_q = attn.vha_premix_dq
+        nh = attn.num_attention_heads
+        vd = attn.v_head_dim
+        b, sq = 2, 5
+        q_comp = paddle.randn([b, sq, attn.q_lora_rank])
+        q_comp.stop_gradient = False
+        # Mirrors the get_query_key_value_tensors premix branch.
+        qg = q_comp.reshape([b, sq, g_q, d_q])
+        q_struct = paddle.einsum(
+            "btgr,krd->btkgd", qg, attn.vha_premix_weight
+        ).reshape([b, sq, nh, vd])
+        q_struct.sum().backward()
+        self.assertIsNotNone(attn.vha_premix_weight.grad)
+        self.assertGreater(float(attn.vha_premix_weight.grad.abs().sum()), 0.0)
+        self.assertIsNotNone(q_comp.grad)
+
+
+class TestForward(unittest.TestCase):
+    # batch_size must be 1: DSv4HybridAttention rejects b>1 in indexer mode.
+    def _run(self, attn, b=1, sq=16):
+        attn.eval()
+        x = paddle.randn([b, sq, attn.config.hidden_size])
+        out, bias = attn(x, attention_mask=None)
+        return out
+
+    def test_forward_ungrouped_postmix(self):
+        attn = _build(_make_config(use_vha_attention=True, vha_postmix_rank=4))
+        out = self._run(attn)
+        self.assertEqual(out.shape, [1, 16, 256])
+
+    def test_forward_grouped_postmix(self):
+        attn = _build(
+            _make_config(
+                use_vha_attention=True,
+                vha_postmix_grouped=True,
+                vha_postmix_rank=2,
+            )
+        )
+        out = self._run(attn)
+        self.assertEqual(out.shape, [1, 16, 256])
+
+    def test_forward_premix(self):
+        # Exercises the premix branch in get_query_key_value_tensors.
+        attn = _build(
+            _make_config(
+                use_vha_attention=True, use_vha_premix=True, vha_premix_groups=2
+            )
+        )
+        out = self._run(attn)
+        self.assertEqual(out.shape, [1, 16, 256])
+
+    def test_forward_premix_and_postmix(self):
+        attn = _build(
+            _make_config(
+                use_vha_attention=True,
+                use_vha_premix=True,
+                vha_premix_groups=2,
+                vha_postmix_grouped=True,
+                vha_postmix_rank=2,
+            )
+        )
+        out = self._run(attn)
+        self.assertEqual(out.shape, [1, 16, 256])
+
+    def test_forward_postmix_recompute_branch(self):
+        # recompute_vha_postmix True + training -> selective-recompute path.
+        attn = _build(
+            _make_config(
+                use_vha_attention=True,
+                vha_postmix_rank=4,
+                recompute_granularity="selective",
+                recompute_modules=["vha_postmix"],
+            )
+        )
+        self.assertTrue(attn.recompute_vha_postmix)
+        attn.train()
+        x = paddle.randn([1, 16, 256])
+        out, bias = attn(x, attention_mask=None)
+        self.assertEqual(out.shape, [1, 16, 256])
+
+    def test_forward_postmix_identity_at_init(self):
+        # postmix V=0 at init -> _apply_vha_postmix is the identity, so a forward
+        # with postmix active must equal the same layer with postmix bypassed.
+        attn = _build(_make_config(use_vha_attention=True, vha_postmix_rank=4))
+        attn.eval()
+        x = paddle.randn([1, 16, 256])
+        out_with, _ = attn(x, attention_mask=None)
+        attn.use_vha_postmix = False  # bypass the (identity) postmix
+        out_without, _ = attn(x, attention_mask=None)
+        self.assertTrue(
+            paddle.allclose(out_with, out_without, atol=1e-6).item()
+        )
+
+    def test_backward_premix_and_postmix_params(self):
+        # Full forward + backward: gradients must reach both the premix weight
+        # and the postmix U/V params (V randomised so the correction is active).
+        attn = _build(
+            _make_config(
+                use_vha_attention=True,
+                use_vha_premix=True,
+                vha_premix_groups=2,
+                vha_postmix_rank=4,
+            )
+        )
+        attn.vha_postmix_V.set_value(
+            paddle.randn(attn.vha_postmix_V.shape) * 0.1
+        )
+        attn.train()
+        x = paddle.randn([1, 16, 256])
+        x.stop_gradient = False
+        out, _ = attn(x, attention_mask=None)
+        out.sum().backward()
+        self.assertIsNotNone(attn.vha_premix_weight.grad)
+        self.assertIsNotNone(attn.vha_postmix_U.grad)
+        self.assertIsNotNone(attn.vha_postmix_V.grad)
+        self.assertIsNotNone(x.grad)
+
+    def test_backward_postmix_recompute_branch(self):
+        # recompute_vha_postmix True + training + backward: gradients must reach
+        # the postmix params and the input through the recomputed postmix.
+        attn = _build(
+            _make_config(
+                use_vha_attention=True,
+                vha_postmix_rank=4,
+                recompute_granularity="selective",
+                recompute_modules=["vha_postmix"],
+            )
+        )
+        self.assertTrue(attn.recompute_vha_postmix)
+        attn.vha_postmix_V.set_value(
+            paddle.randn(attn.vha_postmix_V.shape) * 0.1
+        )
+        attn.train()
+        x = paddle.randn([1, 16, 256])
+        x.stop_gradient = False
+        out, _ = attn(x, attention_mask=None)
+        out.sum().backward()
+        self.assertIsNotNone(x.grad)
+        self.assertIsNotNone(attn.vha_postmix_U.grad)
+        self.assertIsNotNone(attn.vha_postmix_V.grad)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/transformer/test_vha_mla.py
+++ b/tests/single_card_tests/transformer/test_vha_mla.py
@@ -1,0 +1,684 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for VHA postmix on the MLA / MQA attention path.
+
+Covers the low-rank cross-head postmix (I + U Vᵀ) added to
+``MultiLatentAttention`` (base, ungrouped) and the extra per-branch
+``sparse_vha_postmix_U/V`` created by ``MQASelfAttention`` for the
+block-sparse HySparse branch.
+"""
+
+import sys
+import types
+import unittest
+from unittest import mock
+
+import paddle
+
+import paddlefleet.transformer.multi_latent_attention as mla_mod
+from paddlefleet.transformer.dot_product_attention import (
+    DotProductAttention,
+)
+from paddlefleet.transformer.multi_latent_attention import (
+    MLASelfAttention,
+    MLASelfAttentionSublayersSpec,
+    MQASelfAttention,
+)
+from paddlefleet.transformer.transformer_config import (
+    TransformerConfig,
+)
+from paddlefleet.utils import (
+    init_method_normal,
+    scaled_init_method_normal,
+)
+
+_SEED = 1234
+
+
+class BiasedLinear(paddle.nn.Layer):
+    """Linear that returns (output, bias) like ColumnParallelLinear."""
+
+    def __init__(self, in_features, out_features, **kwargs):
+        super().__init__()
+        self.linear = paddle.nn.Linear(in_features, out_features)
+
+    @property
+    def weight(self):
+        # Expose the wrapped Linear weight so the absorbed-MQA path
+        # (kv_b_proj.weight.reshape(...)) works with this fake spec.
+        return self.linear.weight
+
+    def forward(self, x):
+        return self.linear(x), self.linear.bias
+
+
+class SimpleRMSNorm(paddle.nn.Layer):
+    def __init__(self, **kwargs):
+        super().__init__()
+        hidden_size = kwargs.get("normalized_shape", kwargs.get("hidden_size"))
+        eps = kwargs.get("norm_eps", kwargs.get("eps", 1e-5))
+        self.weight = paddle.create_parameter(
+            shape=[hidden_size],
+            dtype="float32",
+            default_initializer=paddle.nn.initializer.Constant(1.0),
+        )
+        self.eps = eps
+
+    def forward(self, x):
+        d_norm = paddle.rsqrt(x.pow(2).mean(axis=-1, keepdim=True) + self.eps)
+        return x * d_norm * self.weight
+
+
+def _make_mla_config(**overrides):
+    """Minimal TransformerConfig for MLA/MQA VHA testing (nh=4, v=32)."""
+    defaults = {
+        "num_hidden_layers": 2,
+        "hidden_size": 128,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 4,
+        "head_dim": 32,
+        "softmax_scale": None,
+        "use_bias": False,
+        "recompute_granularity": None,
+        "recompute_method": None,
+        "recompute_num_layers": None,
+        "recompute_modules": None,
+        "apply_rope_fusion": False,
+        "rotary_interleaved": False,
+        "multi_latent_attention": True,
+        "init_method": init_method_normal(0.02),
+        "output_layer_init_method": scaled_init_method_normal(0.02, 1, 2.0),
+        "rms_norm_eps": 1e-5,
+        "context_parallel_size": 1,
+        "sequence_parallel": False,
+        "apply_query_key_layer_scaling": False,
+        "sliding_window": None,
+        "window_attn_skip_freq": None,
+        "fp16": False,
+        "bf16": False,
+        "masked_softmax_fusion": False,
+        "attention_softmax_in_fp32": True,
+        "attention_dropout": 0.0,
+        "softmax_type": "vanilla",
+        "fa_version": None,
+        "kv_lora_rank": 32,
+        "q_lora_rank": 64,
+        "qk_nope_head_dim": 24,
+        "qk_rope_head_dim": 8,
+        "v_head_dim": 32,
+        "rope_type": "rope",
+    }
+    defaults.update(overrides)
+    config = TransformerConfig(**defaults)
+    config.dtype = "float32"
+    return config
+
+
+def _make_sublayers_spec(gate_proj_cls=None):
+    return MLASelfAttentionSublayersSpec(
+        q_proj=BiasedLinear,
+        q_a_proj=BiasedLinear,
+        q_b_proj=BiasedLinear,
+        kv_a_proj_with_mqa=BiasedLinear,
+        kv_b_proj=BiasedLinear,
+        core_attention=DotProductAttention,
+        o_proj=BiasedLinear,
+        q_a_layernorm=SimpleRMSNorm,
+        kv_a_layernorm=SimpleRMSNorm,
+        gate_proj=gate_proj_cls,
+    )
+
+
+def _build_mla(gated_attention=False, layer_number=1, **config_overrides):
+    config = _make_mla_config(
+        gated_attention=gated_attention, **config_overrides
+    )
+    gate_cls = BiasedLinear if gated_attention else None
+    spec = _make_sublayers_spec(gate_proj_cls=gate_cls)
+    return MLASelfAttention(
+        config=config, sublayers_spec=spec, layer_number=layer_number
+    )
+
+
+def _build_mqa(gated_attention=False, sliding_window=128, **config_overrides):
+    """Build an MQASelfAttention that is a HySparse SWA layer (is_mqa=True)."""
+    config = _make_mla_config(
+        gated_attention=gated_attention,
+        enable_hy_sparse_attention=True,
+        sliding_window=sliding_window,
+        window_attn_skip_freq=None,
+        **config_overrides,
+    )
+    gate_cls = BiasedLinear if gated_attention else None
+    spec = _make_sublayers_spec(gate_proj_cls=gate_cls)
+    return MQASelfAttention(config=config, sublayers_spec=spec, layer_number=1)
+
+
+# ===========================================================================
+# MLA base postmix: __init__
+# ===========================================================================
+class TestMLAPostmixInit(unittest.TestCase):
+    def test_disabled_no_postmix(self):
+        attn = _build_mla(use_vha_attention=False)
+        self.assertFalse(attn.use_vha_postmix)
+        self.assertFalse(hasattr(attn, "vha_postmix_U"))
+
+    def test_enabled_creates_params(self):
+        attn = _build_mla(use_vha_attention=True)
+        self.assertTrue(attn.use_vha_postmix)
+        # nh=4, default rank = nh//4 = 1
+        self.assertEqual(attn.vha_postmix_U.shape, [4, 1])
+        self.assertEqual(attn.vha_postmix_V.shape, [4, 1])
+
+    def test_v_is_zero_init(self):
+        attn = _build_mla(use_vha_attention=True)
+        self.assertTrue(
+            paddle.all(attn.vha_postmix_V == 0).item(),
+            "V must be zero-initialised (identity at init)",
+        )
+
+    def test_rank_default(self):
+        # nh=4 -> nh//4 = 1
+        attn = _build_mla(use_vha_attention=True)
+        self.assertEqual(attn.vha_postmix_rank, 1)
+
+    def test_rank_explicit(self):
+        attn = _build_mla(use_vha_attention=True, vha_postmix_rank=2)
+        self.assertEqual(attn.vha_postmix_rank, 2)
+        self.assertEqual(attn.vha_postmix_U.shape, [4, 2])
+
+    def test_rank_clamped_high(self):
+        # rank clamped to nh=4
+        attn = _build_mla(use_vha_attention=True, vha_postmix_rank=100)
+        self.assertEqual(attn.vha_postmix_rank, 4)
+
+    def test_rank_clamped_low(self):
+        # rank clamped up to 1
+        attn = _build_mla(use_vha_attention=True, vha_postmix_rank=0)
+        self.assertEqual(attn.vha_postmix_rank, 1)
+
+    def test_recompute_flag_off_by_default(self):
+        attn = _build_mla(use_vha_attention=True)
+        self.assertFalse(attn.recompute_vha_postmix)
+
+    def test_recompute_flag_on(self):
+        attn = _build_mla(
+            use_vha_attention=True,
+            recompute_granularity="selective",
+            recompute_modules=["vha_postmix"],
+        )
+        self.assertTrue(attn.recompute_vha_postmix)
+
+    def test_recompute_first_n_hit(self):
+        # num_hidden_layers=2, first_n with n=1 -> only layer 0 recomputes.
+        attn = _build_mla(
+            layer_number=0,
+            use_vha_attention=True,
+            recompute_granularity="selective",
+            recompute_modules=["vha_postmix"],
+            recompute_method="first_n",
+            recompute_num_layers=1,
+        )
+        self.assertTrue(attn.recompute_vha_postmix)
+
+    def test_recompute_first_n_miss(self):
+        # first_n with n=1 -> layer 1 is beyond the window -> no recompute.
+        attn = _build_mla(
+            layer_number=1,
+            use_vha_attention=True,
+            recompute_granularity="selective",
+            recompute_modules=["vha_postmix"],
+            recompute_method="first_n",
+            recompute_num_layers=1,
+        )
+        self.assertFalse(attn.recompute_vha_postmix)
+
+    def test_recompute_block_hit(self):
+        # single chunk (pp=vpp=1), block n=1 -> layer 0 recomputes.
+        attn = _build_mla(
+            layer_number=0,
+            use_vha_attention=True,
+            recompute_granularity="selective",
+            recompute_modules=["vha_postmix"],
+            recompute_method="block",
+            recompute_num_layers=1,
+        )
+        self.assertTrue(attn.recompute_vha_postmix)
+
+    def test_recompute_block_miss(self):
+        # block n=1 -> layer 1 falls outside the per-chunk window.
+        attn = _build_mla(
+            layer_number=1,
+            use_vha_attention=True,
+            recompute_granularity="selective",
+            recompute_modules=["vha_postmix"],
+            recompute_method="block",
+            recompute_num_layers=1,
+        )
+        self.assertFalse(attn.recompute_vha_postmix)
+
+    def test_recompute_dict_config_raises(self):
+        # dict recompute_modules is rejected for vha_postmix (a valid method is
+        # supplied so the base Attention dict-assert passes and control reaches
+        # the vha_postmix guard).
+        with self.assertRaises(ValueError):
+            _build_mla(
+                use_vha_attention=True,
+                recompute_granularity="selective",
+                recompute_modules={"vha_postmix": 1},
+                recompute_method="first_n",
+            )
+
+
+# ===========================================================================
+# MLA base postmix: _apply_vha_postmix
+# ===========================================================================
+class TestMLAPostmixApply(unittest.TestCase):
+    def test_identity_at_init(self):
+        attn = _build_mla(use_vha_attention=True, vha_postmix_rank=2)
+        b, sq, nh, vd = 2, 5, 4, 32
+        x = paddle.randn([b, sq, nh * vd], dtype="float32")
+        out = attn._apply_vha_postmix(x)
+        self.assertEqual(out.shape, [b, sq, nh * vd])
+        self.assertTrue(
+            paddle.allclose(out, x, atol=1e-6).item(),
+            "V=0 => postmix must be the identity map",
+        )
+
+    def test_matches_manual_einsum(self):
+        attn = _build_mla(use_vha_attention=True, vha_postmix_rank=2)
+        # Break the identity by setting V to non-zero.
+        new_v = paddle.randn(attn.vha_postmix_V.shape, dtype="float32") * 0.1
+        attn.vha_postmix_V.set_value(new_v)
+
+        b, sq, nh, vd = 2, 3, 4, 32
+        x = paddle.randn([b, sq, nh * vd], dtype="float32")
+        out = attn._apply_vha_postmix(x)
+
+        U = attn.vha_postmix_U
+        V = attn.vha_postmix_V
+        mixed = x.reshape([b, sq, nh, vd])
+        z = paddle.einsum("bthd,hr->btrd", mixed, U)
+        delta = paddle.einsum("btrd,hr->bthd", z, V)
+        ref = (mixed + delta).reshape([b, sq, nh * vd])
+        self.assertTrue(paddle.allclose(out, ref, atol=1e-6).item())
+
+
+# ===========================================================================
+# MLA forward with postmix
+# ===========================================================================
+class TestMLAPostmixForward(unittest.TestCase):
+    def test_forward_shape(self):
+        attn = _build_mla(use_vha_attention=True)
+        attn.eval()
+        x = paddle.randn([2, 4, 128])
+        out, bias = attn(x, attention_mask=None)
+        self.assertEqual(out.shape, [2, 4, 128])
+
+    def test_forward_identity_at_init(self):
+        """With V=0 the postmix is identity, so toggling it must not change
+        the forward output (same layer, same weights)."""
+        attn = _build_mla(use_vha_attention=True)
+        attn.eval()
+        x = paddle.randn([2, 4, 128])
+
+        out_with, _ = attn(x, attention_mask=None)
+        attn.use_vha_postmix = False  # bypass the postmix branch
+        out_without, _ = attn(x, attention_mask=None)
+
+        self.assertTrue(
+            paddle.allclose(out_with, out_without, atol=1e-6).item(),
+            "V=0 postmix must not alter the forward output",
+        )
+
+    def test_forward_recompute_branch(self):
+        attn = _build_mla(
+            use_vha_attention=True,
+            recompute_granularity="selective",
+            recompute_modules=["vha_postmix"],
+        )
+        attn.train()
+        self.assertTrue(attn.recompute_vha_postmix)
+        x = paddle.randn([2, 4, 128])
+        x.stop_gradient = False
+        out, _ = attn(x, attention_mask=None)
+        self.assertEqual(out.shape, [2, 4, 128])
+        out.sum().backward()
+        self.assertIsNotNone(x.grad)
+
+
+# ===========================================================================
+# MQA sparse-branch postmix: __init__
+# ===========================================================================
+class TestMQAPostmixInit(unittest.TestCase):
+    def test_is_mqa_layer(self):
+        attn = _build_mqa(use_vha_attention=True)
+        self.assertTrue(attn.is_mqa)
+        self.assertTrue(attn.is_swa)
+
+    def test_sparse_postmix_params_created(self):
+        attn = _build_mqa(use_vha_attention=True, vha_postmix_rank=2)
+        self.assertTrue(attn.use_vha_postmix)
+        # Base (main-branch) params.
+        self.assertEqual(attn.vha_postmix_U.shape, [4, 2])
+        # Sparse-branch params: own set, same shape.
+        self.assertTrue(hasattr(attn, "sparse_vha_postmix_U"))
+        self.assertEqual(attn.sparse_vha_postmix_U.shape, [4, 2])
+        self.assertEqual(attn.sparse_vha_postmix_V.shape, [4, 2])
+
+    def test_sparse_postmix_v_zero_init(self):
+        attn = _build_mqa(use_vha_attention=True)
+        self.assertTrue(
+            paddle.all(attn.sparse_vha_postmix_V == 0).item(),
+            "sparse V must be zero-initialised (identity at init)",
+        )
+
+    def test_sparse_postmix_independent_of_main(self):
+        """Sparse U/V are distinct parameter tensors from the main branch."""
+        attn = _build_mqa(use_vha_attention=True)
+        self.assertIsNot(attn.sparse_vha_postmix_U, attn.vha_postmix_U)
+        self.assertIsNot(attn.sparse_vha_postmix_V, attn.vha_postmix_V)
+
+    def test_disabled_no_sparse_params(self):
+        attn = _build_mqa(use_vha_attention=False)
+        self.assertTrue(attn.is_mqa)
+        self.assertFalse(attn.use_vha_postmix)
+        self.assertFalse(hasattr(attn, "sparse_vha_postmix_U"))
+
+
+# ===========================================================================
+# MLA base postmix: backward / gradient
+# ===========================================================================
+class TestMLAPostmixBackward(unittest.TestCase):
+    def test_apply_param_grads(self):
+        attn = _build_mla(use_vha_attention=True, vha_postmix_rank=2)
+        # Randomise V (zero at init -> dL/dU would be zero) so both U and V get
+        # a non-trivial gradient.
+        attn.vha_postmix_V.set_value(
+            paddle.randn(attn.vha_postmix_V.shape) * 0.1
+        )
+        b, sq, nh, vd = 2, 5, 4, 32
+        x = paddle.randn([b, sq, nh * vd], dtype="float32")
+        x.stop_gradient = False
+        out = attn._apply_vha_postmix(x)
+        out.sum().backward()
+        self.assertIsNotNone(attn.vha_postmix_U.grad)
+        self.assertIsNotNone(attn.vha_postmix_V.grad)
+        self.assertIsNotNone(x.grad)
+        self.assertGreater(attn.vha_postmix_U.grad.abs().sum().item(), 0.0)
+        self.assertGreater(attn.vha_postmix_V.grad.abs().sum().item(), 0.0)
+
+    def test_forward_param_grads(self):
+        attn = _build_mla(use_vha_attention=True)
+        attn.vha_postmix_V.set_value(
+            paddle.randn(attn.vha_postmix_V.shape) * 0.1
+        )
+        attn.train()
+        x = paddle.randn([2, 4, 128])
+        x.stop_gradient = False
+        out, _ = attn(x, attention_mask=None)
+        out.sum().backward()
+        self.assertIsNotNone(attn.vha_postmix_U.grad)
+        self.assertIsNotNone(attn.vha_postmix_V.grad)
+        self.assertIsNotNone(x.grad)
+
+
+# ===========================================================================
+# MQA sparse-branch postmix: apply + backward
+# ===========================================================================
+class TestMQASparsePostmixBackward(unittest.TestCase):
+    def test_sparse_apply_matches_manual_einsum(self):
+        attn = _build_mqa(use_vha_attention=True, vha_postmix_rank=2)
+        U = attn.sparse_vha_postmix_U
+        V = attn.sparse_vha_postmix_V
+        new_v = paddle.randn(V.shape, dtype="float32") * 0.1
+        V.set_value(new_v)
+
+        b, sq, nh, vd = 2, 3, 4, 32
+        x = paddle.randn([b, sq, nh * vd], dtype="float32")
+        out = attn._apply_vha_postmix(x, U, V)
+
+        mixed = x.reshape([b, sq, nh, vd])
+        z = paddle.einsum("bthd,hr->btrd", mixed, U)
+        delta = paddle.einsum("btrd,hr->bthd", z, V)
+        ref = (mixed + delta).reshape([b, sq, nh * vd])
+        self.assertTrue(paddle.allclose(out, ref, atol=1e-6).item())
+
+    def test_sparse_param_grads(self):
+        attn = _build_mqa(use_vha_attention=True, vha_postmix_rank=2)
+        U = attn.sparse_vha_postmix_U
+        V = attn.sparse_vha_postmix_V
+        V.set_value(paddle.randn(V.shape, dtype="float32") * 0.1)
+
+        b, sq, nh, vd = 2, 3, 4, 32
+        x = paddle.randn([b, sq, nh * vd], dtype="float32")
+        x.stop_gradient = False
+        out = attn._apply_vha_postmix(x, U, V)
+        out.sum().backward()
+        self.assertIsNotNone(U.grad)
+        self.assertIsNotNone(V.grad)
+        self.assertGreater(U.grad.abs().sum().item(), 0.0)
+        self.assertGreater(V.grad.abs().sum().item(), 0.0)
+        # The main-branch params must not receive gradient from the sparse apply.
+        main_u_grad = attn.vha_postmix_U.grad
+        self.assertTrue(
+            main_u_grad is None or main_u_grad.abs().sum().item() == 0.0
+        )
+
+
+# ===========================================================================
+# MQA end-to-end forward/backward: drives MQASelfAttention.forward through the
+# sliding-window (main) AND block-sparse branches with the TileLang / cuDNN
+# kernels mocked, verifying sparse-branch parameter wiring + the merge result.
+# ===========================================================================
+_KLR = 32  # kv_lora_rank
+_ROPE = 8  # qk_rope_head_dim
+_NH = 4  # num_attention_heads
+_VD = 32  # v_head_dim
+
+
+def _fake_swa(
+    q, k, v, valid_range, attn_sink=None, sm_scale=None, block_B=None
+):
+    # Windowed main branch: deterministic differentiable function of q.
+    return q[..., :_KLR] * 1.5, None
+
+
+def _fake_bsa(
+    q,
+    k,
+    block_indices,
+    valid_range,
+    sm_scale=None,
+    block_B=None,
+    kv_lora_rank=None,
+    attn_sink=None,
+):
+    # Block-sparse branch: distinct scale so the two branches are separable.
+    return q[..., :kv_lora_rank] * 0.5, None
+
+
+def _install_fake_kernels():
+    """Inject fake TileLang MQA kernel modules into sys.modules.
+
+    ``MQASelfAttention.forward`` imports the kernels lazily
+    (``from paddlefleet.tilelang_ops.hysparse import ...``), so patching
+    sys.modules at call time is sufficient and avoids the SM100/FlashMLA/cuDNN
+    hardware dependency.
+    """
+    tilelang_ops = types.ModuleType("paddlefleet.tilelang_ops")
+    hysparse = types.ModuleType("paddlefleet.tilelang_ops.hysparse")
+    hysparse.sliding_window_mqa_attention = _fake_swa
+    bsa_tl = types.ModuleType(
+        "paddlefleet.tilelang_ops.hysparse.block_sparse_mqa_tl"
+    )
+    bsa_tl.block_sparse_mqa_attention_tl = _fake_bsa
+    tilelang_ops.hysparse = hysparse
+    hysparse.block_sparse_mqa_tl = bsa_tl
+    return mock.patch.dict(
+        sys.modules,
+        {
+            "paddlefleet.tilelang_ops": tilelang_ops,
+            "paddlefleet.tilelang_ops.hysparse": hysparse,
+            "paddlefleet.tilelang_ops.hysparse.block_sparse_mqa_tl": bsa_tl,
+        },
+    )
+
+
+class TestMQAForwardSparseBranch(unittest.TestCase):
+    """Real MQASelfAttention.forward regression (both branches, mocked kernels)."""
+
+    def _build(self, rank=2):
+        return _build_mqa(
+            gated_attention=False,
+            sliding_window=(128, 0),
+            hy_sparse_block_sparse_use_tilelang=True,
+            use_vha_attention=True,
+            vha_postmix_rank=rank,
+        )
+
+    def _canned_qkv(self, attn, b, s, s_kv, requires_grad):
+        """Return the (query, key, value) an MQA gqkv would produce (absorbed)."""
+        dk = _KLR + _ROPE
+        query = paddle.randn([b, s, _NH, dk], dtype="float32")
+        query.stop_gradient = not requires_grad
+        key = paddle.randn([b, s_kv, 1, dk], dtype="float32")
+        value = paddle.randn([b, s_kv, 1, _KLR], dtype="float32")
+        return query, key, value
+
+    def _absorb(self, attn, x_klr):
+        """Reference for forward's compute_absorbed_v: [b,s,nh*klr]->[b,s,nh*vd]."""
+        b, s = x_klr.shape[0], x_klr.shape[1]
+        w = attn.kv_b_proj.weight.reshape([_KLR, _NH, -1])[
+            :, :, attn.qk_nope_head_dim :
+        ]
+        m = x_klr.reshape([b, s, _NH, _KLR])
+        o = paddle.einsum("bshl,lhv->bshv", m, w)
+        return o.reshape([b, s, _NH * _VD])
+
+    def _postmix(self, x, U, V):
+        """Reference for _apply_vha_postmix (ungrouped)."""
+        b, s = x.shape[0], x.shape[1]
+        m = x.reshape([b, s, _NH, _VD])
+        z = paddle.einsum("bthd,hr->btrd", m, U)
+        delta = paddle.einsum("btrd,hr->bthd", z, V)
+        return (m + delta).reshape([b, s, _NH * _VD])
+
+    def test_forward_merges_main_and_sparse_branches(self):
+        attn = self._build(rank=2)
+        attn.eval()
+        # Main postmix V stays 0 (identity); make the sparse postmix non-trivial
+        # so the merged output can only match if the sparse branch is wired to
+        # sparse_vha_postmix_U/V (not the main params).
+        attn.sparse_vha_postmix_V.set_value(
+            paddle.randn(attn.sparse_vha_postmix_V.shape, dtype="float32") * 0.1
+        )
+
+        b, s, s_kv = 2, 4, 4
+        query, key, value = self._canned_qkv(attn, b, s, s_kv, False)
+        hidden = paddle.zeros([b, s, attn.config.hidden_size], dtype="float32")
+
+        with self._patched(attn, query, key, value):
+            out, _ = attn(
+                hidden,
+                attention_mask=None,
+                shared_kv=[key, None],
+            )
+
+        # Reference merge: absorbed(swa) + sparse_postmix(absorbed(bsa)).
+        a_swa = self._absorb(
+            attn, (query[..., :_KLR] * 1.5).reshape([b, s, _NH * _KLR])
+        )
+        a_bsa = self._absorb(
+            attn, (query[..., :_KLR] * 0.5).reshape([b, s, _NH * _KLR])
+        )
+        a_bsa = self._postmix(
+            a_bsa, attn.sparse_vha_postmix_U, attn.sparse_vha_postmix_V
+        )
+        ref, _ = attn.o_proj(a_swa + a_bsa)
+
+        self.assertEqual(out.shape, [b, s, attn.config.hidden_size])
+        self.assertTrue(
+            paddle.allclose(out, ref, atol=1e-5).item(),
+            "MQA forward must merge main + sparse-postmix branches",
+        )
+
+    def test_backward_both_branch_postmix_params(self):
+        attn = self._build(rank=2)
+        attn.train()
+        # Randomise both Vs so U and V both receive gradient (dL/dU=0 at V=0).
+        attn.vha_postmix_V.set_value(
+            paddle.randn(attn.vha_postmix_V.shape, dtype="float32") * 0.1
+        )
+        attn.sparse_vha_postmix_V.set_value(
+            paddle.randn(attn.sparse_vha_postmix_V.shape, dtype="float32") * 0.1
+        )
+
+        b, s, s_kv = 2, 4, 4
+        query, key, value = self._canned_qkv(attn, b, s, s_kv, True)
+        hidden = paddle.zeros([b, s, attn.config.hidden_size], dtype="float32")
+
+        with self._patched(attn, query, key, value):
+            out, _ = attn(
+                hidden,
+                attention_mask=None,
+                shared_kv=[key, None],
+            )
+            out.sum().backward()
+
+        for name, p in [
+            ("vha_postmix_U", attn.vha_postmix_U),
+            ("vha_postmix_V", attn.vha_postmix_V),
+            ("sparse_vha_postmix_U", attn.sparse_vha_postmix_U),
+            ("sparse_vha_postmix_V", attn.sparse_vha_postmix_V),
+        ]:
+            self.assertIsNotNone(p.grad, f"{name} grad must exist")
+            self.assertGreater(
+                p.grad.abs().sum().item(), 0.0, f"{name} grad must be non-zero"
+            )
+        self.assertIsNotNone(query.grad)
+        self.assertGreater(query.grad.abs().sum().item(), 0.0)
+
+    def _patched(self, attn, query, key, value):
+        """Context manager: fake kernels + canned gqkv + no-op valid_range."""
+
+        class _Ctx:
+            def __enter__(ctx):
+                ctx._km = _install_fake_kernels()
+                ctx._km.__enter__()
+                ctx._vr = mock.patch.object(
+                    mla_mod,
+                    "build_hysparse_valid_range",
+                    lambda *a, **k: None,
+                )
+                ctx._vr.__enter__()
+                ctx._qkv = mock.patch.object(
+                    attn,
+                    "get_query_key_value_tensors",
+                    lambda *a, **k: (query, key, value, None, None, None),
+                )
+                ctx._qkv.__enter__()
+                return ctx
+
+            def __exit__(ctx, *exc):
+                ctx._qkv.__exit__(*exc)
+                ctx._vr.__exit__(*exc)
+                ctx._km.__exit__(*exc)
+                return False
+
+        return _Ctx()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
Summary

  Introduces Virtual Head Attention (VHA) low-rank head-mixing to the DSv4 hybrid attention path and MLA standard path. VHA adds two independently-toggled mechanisms:

  - Postmix — a low-rank cross-head mixing (I + U·Vᵀ) applied to the attention output in head space. V is zero-initialized, so at init postmix is exactly identity: enabling
  use_vha_attention alone reproduces the baseline loss, making it a safe drop-in.
  - Premix (DSv4 hybrid only) — replaces the dense Q up-projection (linear_q_up_proj) with a structured, block-diagonal per-group expansion (vha_premix_weight). Semi-orthogonal init
  scaled by sqrt(q_head_dim/d_q) preserves per-element RMS. Not identity (Q has no residual), so it changes behavior immediately.

  Changes

  transformer/transformer_config.py
  - New fields: vha_postmix_grouped, use_vha_premix, vha_premix_groups.

  transformer/dsv4_hybrid_attention.py
  - Base DSv4HybridAttention: postmix params (vha_postmix_U/V), grouped + ungrouped topologies, _apply_vha_postmix.
  - Postmix applied after inverse-RoPE, before the grouped output projection, with optional selective recompute (vha_postmix).

  transformer/multi_latent_attention.py
  - MLA standard-path postmix (ungrouped). Asserts TP=1 (params are per-head, no head-axis TP sharding). Applied after the SP transpose, before the gate, guarded against recompute
  nesting.

  Config / behavior notes

  - Fully gated behind use_vha_attention / use_vha_premix; all defaults off ⇒ zero behavior change.
  - TP=1 required when postmix is enabled.
  - Postmix U/V (2D) are left as direct muon params; premix (3D) uses per-expert (dim-0) slicing.

  Testing

  - py_compile clean on all changed files.
  - Identity anchor: use_vha_attention=true, premix off ⇒ step-0/early loss matches the no-VHA baseline (validates the V=0 identity path).
  - Premix enabled: training runs; loss diverges from baseline as expected.

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否