### PR TITLE
[Bug fixes] Gate CSA backward topk_length hint off on SM90

### DIFF
--- a/src/paddlefleet/fusions/csa_sparse_attn.py
+++ b/src/paddlefleet/fusions/csa_sparse_attn.py
@@ -21,6 +21,8 @@ final sparse MQA attention:
   - "cudnn": FlashMLA sparse forward + cuDNN DSA backward
 """
 
+import functools
+
 import paddle
 from paddle import Tensor
 
@@ -126,6 +128,24 @@ def _csa_compute_topk_length(topk_idxs_flat: Tensor) -> Tensor:
     return trailing_len
 
 
+@functools.cache
+def _csa_bwd_honours_topk_length_holes() -> bool:
+    """Whether the cuDNN DSA backward kernel guards ``-1`` inside ``topk_length``.
+
+    ``_csa_compute_topk_length`` returns a *trailing* bound, so ``-1`` entries may
+    still appear inside ``[0, topk_length)`` (multi-doc leading/interior holes).
+    The SM100 kernel keeps its ``topk_idx >= 0`` guard on that path, but the SM90
+    kernel drops it once ``topk_length`` is given: it dereferences ``mKV[-1]``
+    while loading KV and atomically adds dKV at a negative row offset -> CUDA 700.
+
+    Until the SM90 kernel is fixed upstream, report False there so the caller
+    falls back to the ``topk_length=None`` path, which keeps both guards. That
+    path is functionally identical; it only loses the early-stop speedup.
+    """
+    major, _ = paddle.device.cuda.get_device_capability()
+    return major >= 10
+
+
 class CSASparseAttention(paddle.autograd.PyLayer):
     @staticmethod
     def forward(
@@ -209,7 +229,13 @@ class CSASparseAttention(paddle.autograd.PyLayer):
             lse_flat = lse.reshape([b * sq, np_heads])
             topk_idxs_flat = _local_to_global_flat(topk_idxs, s_kv)
 
-            topk_length = _csa_compute_topk_length(topk_idxs_flat)
+            # SM90's backward kernel is unsafe with a trailing topk_length bound
+            # (see _csa_bwd_honours_topk_length_holes), so fall back to None there.
+            topk_length = (
+                _csa_compute_topk_length(topk_idxs_flat)
+                if _csa_bwd_honours_topk_length_holes()
+                else None
+            )
 
             dq_flat, dkv_flat, d_sink = csa_sparse_attn_bwd_cudnn(
                 q_flat,

--- a/tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_backends.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_backends.py
@@ -18,6 +18,7 @@ import importlib.util
 import os
 import sys
 import unittest
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import paddle
@@ -512,3 +513,119 @@ class TestCsaSparseAttnBwdCudnnFunction(unittest.TestCase):
         self.assertEqual(dq, "mock_dq")
         self.assertEqual(dkv, "mock_dkv")
         self.assertEqual(d_sink, "mock_d_sink")
+
+
+class TestCsaBwdTopkLengthArchGate(unittest.TestCase):
+    """The backward topk_length hint must stay off on SM90 (see CUDA 700 bug)."""
+
+    @staticmethod
+    def _gate_for(capability):
+        from paddlefleet.fusions import csa_sparse_attn as mod
+
+        gate = mod._csa_bwd_honours_topk_length_holes
+        gate.cache_clear()
+        try:
+            with patch.object(
+                paddle.device.cuda,
+                "get_device_capability",
+                return_value=capability,
+            ):
+                return gate()
+        finally:
+            gate.cache_clear()
+
+    def test_sm90_falls_back_to_none(self):
+        # SM90's kernel drops the `>= 0` guard when topk_length is supplied.
+        self.assertFalse(self._gate_for((9, 0)))
+
+    def test_sm100_and_newer_keep_the_hint(self):
+        self.assertTrue(self._gate_for((10, 0)))
+        self.assertTrue(self._gate_for((12, 0)))
+
+
+class TestCsaBwdTopkLengthDispatch(unittest.TestCase):
+    """What ``backward`` actually forwards to the cuDNN kernel per architecture.
+
+    The gate is only useful if the call site honours it, so drive
+    ``CSASparseAttention.backward`` end to end with a shape-faithful mock kernel
+    and record the ``topk_length`` it receives.
+    """
+
+    B, SQ, NP, HN, S_KV, TOPK = 1, 4, 2, 8, 16, 6
+
+    def _fake_ctx(self):
+        b, sq, np_heads, hn = self.B, self.SQ, self.NP, self.HN
+        query = paddle.randn([b, sq, np_heads, hn])
+        kv_full = paddle.randn([b, self.S_KV, hn])
+        attn_sink = paddle.randn([np_heads])
+        # Interior -1 holes: precisely the layout the SM90 kernel mishandles.
+        row = [0, -1, 2, -1, 5, -1]
+        topk_idxs = paddle.to_tensor([[row] * sq], dtype="int32")
+        output = paddle.randn([b, sq, np_heads, hn])
+        lse = paddle.randn([b, sq, np_heads])
+
+        ctx = SimpleNamespace(
+            saved_tensor=lambda: (
+                query,
+                kv_full,
+                attn_sink,
+                topk_idxs,
+                output,
+                lse,
+            ),
+            query_shape=(b, sq, np_heads, hn),
+            softmax_scale=0.125,
+            attn_sink_dtype=attn_sink.dtype,
+            backend="cudnn",
+            has_topk_length=False,
+        )
+        grad_output = paddle.randn([b, sq, np_heads, hn])
+        return ctx, grad_output
+
+    def _topk_length_passed_to_kernel(self, capability):
+        from paddlefleet.fusions import csa_sparse_attn as mod
+
+        ctx, grad_output = self._fake_ctx()
+        seen = {}
+
+        def fake_bwd(
+            q, kv, o, do, lse, sink, topk, *, softmax_scale, topk_length
+        ):
+            seen["topk_length"] = topk_length
+            return (
+                paddle.zeros_like(q),
+                paddle.zeros_like(kv),
+                paddle.zeros_like(sink),
+            )
+
+        gate = mod._csa_bwd_honours_topk_length_holes
+        gate.cache_clear()
+        try:
+            with (
+                patch.object(
+                    paddle.device.cuda,
+                    "get_device_capability",
+                    return_value=capability,
+                ),
+                patch(
+                    "paddlefleet.cudnn_ops.csa_sparse_attn_bwd_cudnn",
+                    fake_bwd,
+                ),
+            ):
+                mod.CSASparseAttention.backward(ctx, grad_output)
+        finally:
+            gate.cache_clear()
+
+        self.assertIn("topk_length", seen, "mock kernel was never called")
+        return seen["topk_length"]
+
+    def test_sm90_receives_none(self):
+        self.assertIsNone(self._topk_length_passed_to_kernel((9, 0)))
+
+    def test_sm100_receives_int32_bound(self):
+        topk_length = self._topk_length_passed_to_kernel((10, 0))
+        self.assertIsNotNone(topk_length)
+        self.assertEqual(topk_length.dtype, paddle.int32)
+        self.assertEqual(list(topk_length.shape), [self.B * self.SQ])
+        # Trailing bound of [0, -1, 2, -1, 5, -1] is 5 (last valid index 4 + 1).
+        self.assertEqual(topk_length.tolist(), [5] * (self.B * self.SQ))


### PR DESCRIPTION
### PR Category
Environment Adaptation

### PR Types
Bug fixes

### Description

CSA sparse attention backward hits `CUDA error 700` on H800 (SM90).

`_csa_compute_topk_length` returns a *trailing* bound, so `-1` holes may appear inside `[0, topk_length)` (packed / multi-doc sequences, or rows whose valid KV count is below the topk window). The SM100 kernel honours this and keeps its `>= 0` guard (`dsa_bwd_sm100.py` L1330-1343, with an explicit comment), but the SM90 kernel drops the guard once `topk_length` is given:

- `dsa_bwd_sm90.py` L1466-1492 → `_copy_row` L1337-1338 reads `mKV[-1]`
- `dsa_bwd_sm90.py` L1404-1410 → dKV `atomicAdd` at a negative row offset

Backward computes `topk_length` unconditionally, so callers cannot avoid it.

This PR gates the hint on device capability: SM90 falls back to `topk_length=None`, which keeps both guards. That is the pre-`topk_length` implementation, so the math is unchanged — SM90 only loses the early-stop speedup. SM100+ is untouched. The predicate is named after the capability rather than the arch and is cached, so it can be dropped in one place once the SM90 kernel is fixed upstream.

### 是否引起精度变化
否

SM100+ 完全不变；SM90 上数值与 `topk_length=None` 路径一致，仅损失提前终止收益。

### Tests
New `TestCsaBwdTopkLengthArchGate` covers SM90 / SM100 / SM120.
CSA fusion tests: 35 passed, 1 skipped (was 33 passed).