### PR TITLE
[Improvements] Align Block Attention Residuals with Kimi K3

### DIFF
--- a/src/paddlefleet/models/gpt/gpt_layer_specs.py
+++ b/src/paddlefleet/models/gpt/gpt_layer_specs.py
@@ -951,7 +951,7 @@ def get_gpt_spec(
     )
 
     # Build output_block_attn_res spec: a pipeline layer placed BEFORE the
-    # final RMSNorm (K3 alignment, see BLOCK_ATTN_RES_K3_ALIGNMENT.md Diff 2).
+    # final RMSNorm (K3 alignment).
     # LM heads no longer own the block_attn_res module.
     output_block_attn_res_spec = None
     if config.block_attention_residuals:

--- a/src/paddlefleet/models/gpt/gpt_layer_specs.py
+++ b/src/paddlefleet/models/gpt/gpt_layer_specs.py
@@ -57,6 +57,7 @@ from paddlefleet.transformer.attention import (
 from paddlefleet.transformer.block_attn_res import (
     BlockAttnRes,
     BlockAttnResSublayersSpec,
+    OutputBlockAttnResPipe,
 )
 from paddlefleet.transformer.csa_attention import (
     CompressedSparseAttention,
@@ -949,20 +950,27 @@ def get_gpt_spec(
         rope_embedding=rope_embedding_spec,
     )
 
-    # Build block_attn_res spec for GPTLMHead
-    lm_head_block_attn_res = IdentityOp
+    # Build output_block_attn_res spec: a pipeline layer placed BEFORE the
+    # final RMSNorm (K3 alignment, see BLOCK_ATTN_RES_K3_ALIGNMENT.md Diff 2).
+    # LM heads no longer own the block_attn_res module.
+    output_block_attn_res_spec = None
     if config.block_attention_residuals:
         backend = LocalSpecProvider()
-        lm_head_norm = backend.layer_norm(
+        output_attn_res_norm = backend.layer_norm(
             rms_norm=(config.normalization == "RMSNorm"),
             for_qk=False,
         )
-        lm_head_block_attn_res = LayerSpec(
-            layer=BlockAttnRes,
-            sublayers_spec=BlockAttnResSublayersSpec(
-                norm=lm_head_norm,
-            ),
+        output_block_attn_res_spec = LayerSpec(
+            layer=OutputBlockAttnResPipe,
+            extra_kwargs={
+                "config": config,
+                "sublayers_spec": BlockAttnResSublayersSpec(
+                    norm=output_attn_res_norm,
+                ),
+            },
         )
+    # LM heads no longer own attn-res; pass IdentityOp for backward-compat kwargs.
+    lm_head_block_attn_res = IdentityOp
 
     # separate mtp head & loss
     mtp_lm_head_spec = None
@@ -1065,6 +1073,7 @@ def get_gpt_spec(
             mtp=mtp_layers_spec,
             mtp_lm_head=mtp_lm_head_spec,
             mtp_loss=mtp_loss_spec,
+            output_block_attn_res=output_block_attn_res_spec,
             layer_norm=LayerSpec(
                 layer=WrappedPaddleNormPipe,
                 extra_kwargs={

--- a/src/paddlefleet/models/gpt/gpt_model.py
+++ b/src/paddlefleet/models/gpt/gpt_model.py
@@ -341,19 +341,18 @@ class GPTModel(PipelineLayer):
                 f"{name_prefix}.mhc_contract",
             )
 
-        if spec.output_block_attn_res is not None:
-            self.add_sequential_layer(
-                layers,
-                LayerDesc(spec.output_block_attn_res),
-                f"{name_prefix}.output_attn_res",
-            )
-
         # Always place layer_norm after transformer_layers and before tail_empty_layers/MTP,
         # so that the model structure is consistent regardless of whether MTP is enabled.
         if not (
             self.config.gpt_model_use_experimental_version
             and self.config.num_nextn_predict_layers >= 1
         ):
+            if spec.output_block_attn_res is not None:
+                self.add_sequential_layer(
+                    layers,
+                    LayerDesc(spec.output_block_attn_res),
+                    f"{name_prefix}.output_attn_res",
+                )
             self.add_sequential_layer(
                 layers, LayerDesc(spec.layer_norm), name_prefix
             )

--- a/src/paddlefleet/models/gpt/gpt_model.py
+++ b/src/paddlefleet/models/gpt/gpt_model.py
@@ -143,6 +143,7 @@ class GPTSublayersSpec:
     mhc_contract: LayerSpec | None = None
     tail_empty_layers: list[LayerSpec] | None = None
     mtp: list[LayerSpec] | None = None
+    output_block_attn_res: LayerSpec | None = None
     layer_norm: LayerSpec | None = None
     lm_head: LayerSpec | None = None
     mtp_lm_head: LayerDesc | None = None
@@ -340,6 +341,13 @@ class GPTModel(PipelineLayer):
                 f"{name_prefix}.mhc_contract",
             )
 
+        if spec.output_block_attn_res is not None:
+            self.add_sequential_layer(
+                layers,
+                LayerDesc(spec.output_block_attn_res),
+                f"{name_prefix}.output_attn_res",
+            )
+
         # Always place layer_norm after transformer_layers and before tail_empty_layers/MTP,
         # so that the model structure is consistent regardless of whether MTP is enabled.
         if not (
@@ -393,6 +401,12 @@ class GPTModel(PipelineLayer):
             self.config.gpt_model_use_experimental_version
             and self.config.num_nextn_predict_layers >= 1
         ):
+            if spec.output_block_attn_res is not None:
+                self.add_sequential_layer(
+                    layers,
+                    LayerDesc(spec.output_block_attn_res),
+                    f"{name_prefix}.output_attn_res",
+                )
             self.add_sequential_layer(
                 layers, LayerDesc(spec.layer_norm), name_prefix
             )

--- a/src/paddlefleet/models/gpt/lm_head.py
+++ b/src/paddlefleet/models/gpt/lm_head.py
@@ -65,7 +65,6 @@ import warnings
 import paddle
 from paddle.distributed.fleet.meta_parallel import (
     ScheduleNode,
-    build_spec_layer,
 )
 from paddle.distributed.fleet.utils import recompute
 from paddle.distributed.flex_checkpoint.dcp.sharded_weight import (
@@ -77,7 +76,6 @@ from paddlefleet.tensor_parallel.layers import (
     _initialize_affine_weight_cpu,
     _initialize_affine_weight_gpu,
 )
-from paddlefleet.transformer.identity_op import IdentityOp
 
 
 def SegLU(x, ranges, ts):
@@ -131,8 +129,7 @@ class GPTLMHead(ColumnParallelLinear):
         ]
         self._dtype = self.config.params_dtype
 
-        # Extract block_attn_res spec before passing kwargs to super
-        block_attn_res_spec = kwargs.pop("block_attn_res", IdentityOp)
+        kwargs.pop("block_attn_res", None)
 
         kwargs["skip_weight_param_allocation"] = True
         if self.config.gpt_model_use_experimental_version:
@@ -185,11 +182,6 @@ class GPTLMHead(ColumnParallelLinear):
                         is_expert=self.is_expert,
                     )
             self.weight.is_distributed = True if self.world_size > 1 else False
-
-        # Final Block Attention Residual (applied before LM head projection)
-        self.block_attn_res = build_spec_layer(
-            block_attn_res_spec, config=self.config
-        )
 
         # Multimax: learnable SegLU-style modulation on logits before softmax.
         # Names contain the "multimax" substring so the trainer's no-decay
@@ -314,11 +306,6 @@ class GPTLMHead(ColumnParallelLinear):
     def forward(self, dict_args: dict):
         hidden_states = dict_args["hidden_states"]
 
-        # Apply final Block Attention Residual if enabled
-        if self.config.block_attention_residuals:
-            blocks = dict_args.get("blocks", [])
-            hidden_states = self.block_attn_res(hidden_states, blocks)
-
         if (
             self.config.num_nextn_predict_layers is not None
             and self.config.num_nextn_predict_layers > 0
@@ -361,14 +348,11 @@ class GPTLMHead(ColumnParallelLinear):
 
 
 class GPTMainLMHead(GPTLMHead):
-    """Main LM Head with block_attn_res, single prediction."""
+    """Main LM Head, single prediction."""
 
     def __init__(self, **kwargs):
-        block_attn_res_spec = kwargs.pop("block_attn_res", IdentityOp)
+        kwargs.pop("block_attn_res", None)
         super().__init__(**kwargs)
-        self.block_attn_res = build_spec_layer(
-            block_attn_res_spec, config=self.config
-        )
 
     def build_schedule_node(self):
         return ScheduleNode(self.forward, name="GPTMainLMHead")
@@ -376,9 +360,6 @@ class GPTMainLMHead(GPTLMHead):
     def forward(self, dict_args: dict):
         hidden_states = dict_args["hidden_states"]
         mtp_loss = dict_args.get("mtp_loss", None)
-        if self.config.block_attention_residuals:
-            blocks = dict_args.get("blocks", [])
-            hidden_states = self.block_attn_res(hidden_states, blocks)
 
         tensor_list = paddle.split(
             hidden_states,

--- a/src/paddlefleet/transformer/block_attn_res.py
+++ b/src/paddlefleet/transformer/block_attn_res.py
@@ -270,3 +270,58 @@ class BlockAttnRes(FleetLayer):
             h = h.to(partial_block.dtype)
 
         return h
+
+
+class OutputBlockAttnResPipe(paddle.nn.Layer):
+    """Pipeline-compatible wrapper: run output BlockAttnRes BEFORE the final norm."""
+
+    def __init__(
+        self,
+        config: TransformerConfig,
+        sublayers_spec: BlockAttnResSublayersSpec,
+    ):
+        super().__init__()
+        self.config = config
+        self.block_attn_res = BlockAttnRes(config, sublayers_spec)
+
+    def _mtp_active(self) -> bool:
+        # Guard mirrors WrappedPaddleNormPipe.forward (paddle_norm.py) so that
+        # this pipe splits under exactly the same conditions as the final norm.
+        return (
+            self.config.num_nextn_predict_layers is not None
+            and self.config.num_nextn_predict_layers > 0
+            and not self.config.mtp_load_weight_only
+            and not (
+                not self.config.gpt_model_use_experimental_version
+                and self.config.enable_mtp_magic_send
+            )
+        )
+
+    def forward(self, dict_args: dict):
+        if not self.config.block_attention_residuals:
+            return dict_args
+
+        hidden_states = dict_args["hidden_states"]
+        blocks = dict_args.get("blocks", []) or []
+
+        if self._mtp_active():
+            tensor_list = paddle.split(
+                hidden_states, self.config.num_nextn_predict_layers + 1
+            )
+            main_hidden = self.block_attn_res(tensor_list[0], blocks)
+            hidden_states = paddle.concat([main_hidden, *tensor_list[1:]])
+        else:
+            hidden_states = self.block_attn_res(hidden_states, blocks)
+
+        rst = {**dict_args, "hidden_states": hidden_states}
+        # Blocks have been consumed; downstream (final norm, LM head) no
+        # longer needs them.
+        rst.pop("blocks", None)
+        return rst
+
+    def build_schedule_node(self):
+        from paddle.distributed.fleet.meta_parallel.pipeline_parallel import (
+            ScheduleNode,
+        )
+
+        return ScheduleNode(self.forward, name="OutputBlockAttnResPipe")

--- a/src/paddlefleet/transformer/moe/qb_callback.py
+++ b/src/paddlefleet/transformer/moe/qb_callback.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/paddlefleet/transformer/transformer_layer.py
+++ b/src/paddlefleet/transformer/transformer_layer.py
@@ -546,14 +546,14 @@ class TransformerLayer(nn.Layer):
     def _is_block_boundary(self):
         """Determine if this layer is a block boundary for attention residuals.
 
-        Each block spans ``attn_res_block_size // 2`` transformer layers, and
-        the layer whose index is a multiple of that span closes the previous
-        block.
+        Each block spans ``attn_res_block_size`` transformer layers, and the
+        layer whose index is a multiple of that span closes the previous
+        block. This matches Kimi K3's ``layer_idx % attn_res_block_size == 0``.
         """
-        block_span = self.attn_res_block_size // 2
+        block_span = self.attn_res_block_size
         if block_span <= 0:
             raise ValueError(
-                "attn_res_block_size must be at least 2 when "
+                "attn_res_block_size must be at least 1 when "
                 "block_attention_residuals is enabled."
             )
         return self.layer_number % block_span == 0

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_language_loss_7.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_language_loss_7.py
@@ -201,6 +201,11 @@ class TestGPTMainLMHead(unittest.TestCase):
         self.assertEqual(head._forward.call_count, 1)
 
     def test_forward_applies_block_attn_res(self):
+        """Output BlockAttnRes no longer runs inside the LM head.
+
+        The aggregation was moved into ``OutputBlockAttnResPipe`` (K3-aligned:
+        pre-norm). ``GPTMainLMHead.forward`` must not invoke ``block_attn_res``.
+        """
         from paddlefleet.models.gpt.lm_head import GPTMainLMHead
 
         head = GPTMainLMHead.__new__(GPTMainLMHead)
@@ -213,7 +218,7 @@ class TestGPTMainLMHead(unittest.TestCase):
         head.block_attn_res = MagicMock(return_value=applied)
 
         out = head.forward({"hidden_states": hidden, "blocks": ["b"]})
-        head.block_attn_res.assert_called_once()
+        head.block_attn_res.assert_not_called()
         self.assertEqual(out["logits"], "L")
 
 

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_lm_head.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_lm_head.py
@@ -69,7 +69,12 @@ class TestGPTLMHeadForward(unittest.TestCase):
         self.assertIsNotNone(result)
 
     def test_forward_with_block_attn_res(self):
-        """Test forward with block_attention_residuals enabled."""
+        """Output BlockAttnRes is no longer applied by the LM head.
+
+        The aggregation was moved into ``OutputBlockAttnResPipe``, which runs
+        BEFORE the final norm (K3-aligned ordering). The LM head must therefore
+        forward ``hidden_states`` untouched even when the feature is enabled.
+        """
         head = _make_head(
             GPTLMHead,
             config=MagicMock(
@@ -81,12 +86,12 @@ class TestGPTLMHeadForward(unittest.TestCase):
         head._forward = MagicMock(return_value=paddle.randn([2, 10, 100]))
         head.block_attn_res = MagicMock(return_value=paddle.randn([2, 10, 64]))
 
-        dict_args = {
-            "hidden_states": paddle.randn([2, 10, 64]),
-            "blocks": ["block1"],
-        }
+        hidden = paddle.randn([2, 10, 64])
+        dict_args = {"hidden_states": hidden, "blocks": ["block1"]}
         result = head.forward(dict_args)
-        head.block_attn_res.assert_called_once()
+        head.block_attn_res.assert_not_called()
+        # `_forward` receives the raw hidden states, not an aggregated tensor.
+        self.assertIs(head._forward.call_args[0][0], hidden)
         self.assertIsNotNone(result)
 
     def test_forward_with_mtp(self):

--- a/tests/single_card_tests/model/test_block_attn_res_recompute.py
+++ b/tests/single_card_tests/model/test_block_attn_res_recompute.py
@@ -990,5 +990,141 @@ class TestUsePylayerGating(unittest.TestCase):
         self.assertTrue(paddle.isfinite(blocks[0].grad).all().item())
 
 
+# ---------------------------------------------------------------------------
+# Test: OutputBlockAttnResPipe layout uniqueness, forward/backward, state_dict
+# ---------------------------------------------------------------------------
+class TestOutputBlockAttnResPipe(unittest.TestCase):
+    """Verify OutputBlockAttnResPipe is inserted exactly once in all layouts."""
+
+    def setUp(self):
+        self.strategy = _init_fleet()
+
+    def _make_config(self, experimental=False, num_mtp=0):
+        return GPTConfig(
+            num_hidden_layers=4,
+            hidden_size=128,
+            rotary_base=10000,
+            vocab_size=100,
+            rotary_percent=1.0,
+            rope_scaling=1.0,
+            position_embedding_type="rope",
+            num_attention_heads=4,
+            intermediate_size=256,
+            max_sequence_length=32,
+            normalization="RMSNorm",
+            hidden_dropout_prob=0.0,
+            attention_dropout=0.0,
+            init_method=functools.partial(
+                paddle.nn.init.xavier_uniform_, gain=1.0
+            ),
+            output_layer_init_method=functools.partial(
+                paddle.nn.init.xavier_uniform_, gain=1.0
+            ),
+            tie_word_embeddings=True,
+            use_qk_norm=True,
+            block_attention_residuals=True,
+            attn_res_block_size=2,
+            gpt_model_use_experimental_version=experimental,
+            num_nextn_predict_layers=num_mtp,
+        )
+
+    def _count_output_attn_res_layers(self, model):
+        """Count OutputBlockAttnResPipe instances in model sublayers."""
+        from paddlefleet.transformer.block_attn_res import (
+            OutputBlockAttnResPipe,
+        )
+
+        return sum(
+            1
+            for m in model.sublayers()
+            if isinstance(m, OutputBlockAttnResPipe)
+        )
+
+    def test_standard_layout_has_exactly_one(self):
+        """Standard layout (no experimental, no MTP) has one OutputBlockAttnResPipe."""
+        config = self._make_config(experimental=False, num_mtp=0)
+        model = gpt_builder(config, num_stages=1)
+        self.assertEqual(self._count_output_attn_res_layers(model), 1)
+
+    def test_experimental_mtp_layout_has_exactly_one(self):
+        """Experimental MTP layout has one OutputBlockAttnResPipe (not duplicated)."""
+        config = self._make_config(experimental=True, num_mtp=1)
+        model = gpt_builder(config, num_stages=1)
+        self.assertEqual(self._count_output_attn_res_layers(model), 1)
+
+    def test_experimental_mtp_forward_backward(self):
+        """Experimental MTP: OutputBlockAttnResPipe handles concat/split correctly.
+
+        Directly exercise the pipe with MTP-shaped inputs (avoids the full
+        model's data pipeline dependencies).
+        """
+        from paddlefleet.transformer.block_attn_res import (
+            BlockAttnResSublayersSpec,
+            OutputBlockAttnResPipe,
+        )
+        from paddlefleet.transformer.paddle_norm import RMSNorm
+
+        config = self._make_config(experimental=True, num_mtp=1)
+        pipe = OutputBlockAttnResPipe(
+            config, BlockAttnResSublayersSpec(norm=RMSNorm)
+        )
+        pipe.train()
+
+        B, S, H = 2, 8, config.hidden_size
+        num_mtp = config.num_nextn_predict_layers  # 1
+        # hidden_states = concat of [main, mtp_0, ...] along axis=0
+        hidden = paddle.randn([(num_mtp + 1) * S, B, H])
+        hidden.stop_gradient = False
+        blocks = [paddle.randn([S, B, H]) for _ in range(2)]
+        for b in blocks:
+            b.stop_gradient = False
+
+        out = pipe({"hidden_states": hidden, "blocks": blocks})
+        self.assertIn("hidden_states", out)
+        # Output shape preserved
+        self.assertEqual(out["hidden_states"].shape, [(num_mtp + 1) * S, B, H])
+        # blocks consumed
+        self.assertNotIn("blocks", out)
+
+        # Backward path
+        loss = out["hidden_states"].sum()
+        loss.backward()
+        self.assertIsNotNone(pipe.block_attn_res.proj_weight.grad)
+        self.assertTrue(
+            paddle.isfinite(pipe.block_attn_res.proj_weight.grad).all().item()
+        )
+        self.assertIsNotNone(blocks[0].grad)
+        self.assertIsNotNone(hidden.grad)
+
+    def test_state_dict_round_trip(self):
+        """state_dict has exactly one set of output_attn_res keys; round-trip preserves values."""
+        config = self._make_config(experimental=True, num_mtp=1)
+        model = gpt_builder(config, num_stages=1)
+
+        sd = model.state_dict()
+        attn_res_keys = [k for k in sd.keys() if "output_attn_res" in k]
+        # Should have proj_weight and norm.weight (exactly 2 keys)
+        self.assertEqual(len(attn_res_keys), 2)
+
+        # No duplicate keys (dict guarantees uniqueness, but verify naming)
+        proj_keys = [k for k in attn_res_keys if "proj_weight" in k]
+        norm_keys = [k for k in attn_res_keys if "norm" in k]
+        self.assertEqual(len(proj_keys), 1)
+        self.assertEqual(len(norm_keys), 1)
+
+        # Mutate and reload. Save expected values first because
+        # set_state_dict may consume/clear the input dict.
+        expected = {}
+        for k in attn_res_keys:
+            v = paddle.ones_like(sd[k]) * 3.14
+            sd[k] = v
+            expected[k] = v.numpy().copy()
+        model.set_state_dict(sd)
+
+        sd2 = model.state_dict()
+        for k in attn_res_keys:
+            np.testing.assert_allclose(sd2[k].numpy(), expected[k], rtol=1e-6)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/single_card_tests/model/test_block_attn_res_recompute.py
+++ b/tests/single_card_tests/model/test_block_attn_res_recompute.py
@@ -27,6 +27,7 @@ Covers:
 import functools
 import random
 import unittest
+from unittest.mock import MagicMock
 
 import numpy as np
 import paddle
@@ -1124,6 +1125,92 @@ class TestOutputBlockAttnResPipe(unittest.TestCase):
         sd2 = model.state_dict()
         for k in attn_res_keys:
             np.testing.assert_allclose(sd2[k].numpy(), expected[k], rtol=1e-6)
+
+    def test_forward_passthrough_when_disabled(self):
+        """block_attention_residuals=False: pipe returns dict_args untouched."""
+        from paddlefleet.transformer.block_attn_res import (
+            BlockAttnResSublayersSpec,
+            OutputBlockAttnResPipe,
+        )
+        from paddlefleet.transformer.paddle_norm import RMSNorm
+
+        config = self._make_config(experimental=False, num_mtp=0)
+        config.block_attention_residuals = False
+        pipe = OutputBlockAttnResPipe(
+            config, BlockAttnResSublayersSpec(norm=RMSNorm)
+        )
+        hidden = paddle.randn([8, 2, config.hidden_size])
+        dict_args = {"hidden_states": hidden, "blocks": ["b"]}
+        out = pipe(dict_args)
+        # Passthrough: same object, blocks retained, no aggregation.
+        self.assertIs(out, dict_args)
+        self.assertIs(out["hidden_states"], hidden)
+        self.assertIn("blocks", out)
+
+    def test_build_schedule_node(self):
+        """build_schedule_node wraps forward with the expected name."""
+        import sys
+        import types
+        from unittest.mock import patch
+
+        from paddlefleet.transformer.block_attn_res import (
+            BlockAttnResSublayersSpec,
+            OutputBlockAttnResPipe,
+        )
+        from paddlefleet.transformer.paddle_norm import RMSNorm
+
+        config = self._make_config(experimental=False, num_mtp=0)
+        pipe = OutputBlockAttnResPipe(
+            config, BlockAttnResSublayersSpec(norm=RMSNorm)
+        )
+
+        # ScheduleNode is imported lazily inside build_schedule_node from the
+        # paddle pipeline module; stub it so the test does not depend on the
+        # installed paddle version exposing that symbol.
+        pp_mod = types.ModuleType(
+            "paddle.distributed.fleet.meta_parallel.pipeline_parallel"
+        )
+
+        class _FakeSN:
+            def __init__(self, fn, name):
+                self.fn = fn
+                self.name = name
+
+        pp_mod.ScheduleNode = _FakeSN
+        with patch.dict(
+            sys.modules,
+            {
+                "paddle.distributed.fleet.meta_parallel.pipeline_parallel": (
+                    pp_mod
+                )
+            },
+        ):
+            node = pipe.build_schedule_node()
+        self.assertEqual(node.name, "OutputBlockAttnResPipe")
+        self.assertEqual(node.fn.__func__, OutputBlockAttnResPipe.forward)
+
+
+class TestGPTMainLMHeadInit(unittest.TestCase):
+    """GPTMainLMHead.__init__ must drop the block_attn_res kwarg.
+
+    Output BlockAttnRes moved to OutputBlockAttnResPipe, so the head must not
+    forward that kwarg to ColumnParallelLinear (covers lm_head.py pop line).
+    """
+
+    def test_init_pops_block_attn_res_kwarg(self):
+        from unittest.mock import patch
+
+        from paddlefleet.models.gpt.lm_head import GPTLMHead, GPTMainLMHead
+
+        sentinel = object()
+        captured = {}
+
+        def fake_gptlmhead_init(self, **kwargs):
+            captured.update(kwargs)
+
+        with patch.object(GPTLMHead, "__init__", fake_gptlmhead_init):
+            GPTMainLMHead(block_attn_res=sentinel, config=MagicMock())
+        self.assertNotIn("block_attn_res", captured)
 
 
 if __name__ == "__main__":

--- a/tests/single_card_tests/model/test_block_attn_res_recompute.py
+++ b/tests/single_card_tests/model/test_block_attn_res_recompute.py
@@ -419,7 +419,7 @@ class TestTransformerLayerHelpers(unittest.TestCase):
                 break
 
     def test_is_block_boundary(self):
-        """_is_block_boundary correct for block_size=4 (span=2)."""
+        """_is_block_boundary correct for block_size=4 (span=4, K3 semantics)."""
         config = self._make_config(block_size=4, num_layers=6)
         model = gpt_builder(config, num_stages=1)
         from paddlefleet.transformer.transformer_layer import TransformerLayer
@@ -429,21 +429,28 @@ class TestTransformerLayerHelpers(unittest.TestCase):
             if isinstance(m, TransformerLayer):
                 if m._is_block_boundary():
                     boundaries.append(m.layer_number)
-        # block_span = 4//2 = 2, so layers 0,2,4 are boundaries
-        # (layer_number % 2 == 0)
+        # block_span == attn_res_block_size == 4 (matches K3's
+        # `layer_idx % attn_res_block_size == 0`), so layers 0 and 4 are
+        # boundaries.
+        self.assertTrue(len(boundaries) > 0)
         for b in boundaries:
-            self.assertEqual(b % 2, 0)
+            self.assertEqual(b % 4, 0)
 
     def test_is_block_boundary_block_size_2(self):
-        """block_size=2 => span=1, every layer is a boundary."""
+        """block_size=2 => span=2, every other layer is a boundary."""
         config = self._make_config(block_size=2, num_layers=4)
         model = gpt_builder(config, num_stages=1)
         from paddlefleet.transformer.transformer_layer import TransformerLayer
 
+        checked = 0
         for m in model.sublayers():
             if isinstance(m, TransformerLayer):
                 if hasattr(m, "attn_res_block_size") and m.attn_res_block_size:
-                    self.assertTrue(m._is_block_boundary())
+                    self.assertEqual(
+                        m._is_block_boundary(), m.layer_number % 2 == 0
+                    )
+                    checked += 1
+        self.assertTrue(checked > 0)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### PR Category
Distributed Strategy
### PR Types
Improvements
### Description
Align Block Attention Residuals with Kimi K3:
- Use `attn_res_block_size` directly as the transformer-layer span between block boundaries.
- Move the output BlockAttnRes aggregation before the final normalization through a pipeline-compatible wrapper.
- Update the block-boundary unit tests for the aligned semantics.