### PR TITLE
[Performance] Optimize VHA postmix performance

### DIFF
--- a/src/paddlefleet/transformer/attention.py
+++ b/src/paddlefleet/transformer/attention.py
@@ -1462,24 +1462,19 @@ class SelfAttentionVHA(Attention):
         )
 
     def _apply_vha_postmix(self, attn_out: Tensor) -> Tensor:
-        mixed = attn_out.reshape(
-            [
-                attn_out.shape[0],
-                attn_out.shape[1],
-                self.num_attention_heads,
-                self.v_head_dim,
-            ]
-        )
-        z = paddle.einsum("bthd,hr->btrd", mixed, self.vha_postmix_U)
-        delta = paddle.einsum("btrd,hr->bthd", z, self.vha_postmix_V)
-        mixed = mixed + delta
-        return mixed.reshape(
-            [
-                attn_out.shape[0],
-                attn_out.shape[1],
-                self.num_attention_heads * self.v_head_dim,
-            ]
-        )
+        # Head-axis low-rank mixing out = (I + V @ U^T) @ mixed, with v_head_dim
+        # as a batch axis. Expressed as two contraction-aligned matmuls (nh is
+        # the contracted dim in both, so no transpose is needed): bit-exact to
+        # the einsum form but faster and more memory-frugal.
+        b, sq = attn_out.shape[0], attn_out.shape[1]
+        nh, d = self.num_attention_heads, self.v_head_dim
+        mixed = attn_out.reshape([b * sq, nh, d])
+        z = paddle.matmul(
+            self.vha_postmix_U, mixed, transpose_x=True
+        )  # [r,nh]@[B,nh,d]->[B,r,d]
+        delta = paddle.matmul(self.vha_postmix_V, z)  # [nh,r]@[B,r,d]->[B,nh,d]
+        out = mixed + delta
+        return out.reshape([b, sq, nh * d])
 
     def _apply_shared_kv_inverse_rope(
         self,

--- a/src/paddlefleet/transformer/dsv4_hybrid_attention.py
+++ b/src/paddlefleet/transformer/dsv4_hybrid_attention.py
@@ -1149,15 +1149,20 @@ class DSv4HybridAttention(Attention):
             z = paddle.einsum("btgjd,gjr->btgrd", mixed, self.vha_postmix_U)
             delta = paddle.einsum("btgrd,gjr->btgjd", z, self.vha_postmix_V)
             mixed = mixed + delta
-        else:
-            nh = self.num_attention_heads
-            mixed = attn_out.reshape([b, sq, nh, self.v_head_dim])
-            z = paddle.einsum("bthd,hr->btrd", mixed, self.vha_postmix_U)
-            delta = paddle.einsum("btrd,hr->bthd", z, self.vha_postmix_V)
-            mixed = mixed + delta
-        return mixed.reshape(
-            [b, sq, self.num_attention_heads * self.v_head_dim]
-        )
+            return mixed.reshape(
+                [b, sq, self.num_attention_heads * self.v_head_dim]
+            )
+        # ungrouped: (I + V @ U^T) on the head axis via two contraction-aligned
+        # matmuls (nh contracted in both -> no transpose): bit-exact to the
+        # einsum form but faster and more memory-frugal.
+        nh, d = self.num_attention_heads, self.v_head_dim
+        mixed = attn_out.reshape([b * sq, nh, d])
+        z = paddle.matmul(
+            self.vha_postmix_U, mixed, transpose_x=True
+        )  # [r,nh]@[B,nh,d]->[B,r,d]
+        delta = paddle.matmul(self.vha_postmix_V, z)  # [nh,r]@[B,r,d]->[B,nh,d]
+        out = mixed + delta
+        return out.reshape([b, sq, nh * d])
 
     def get_query_key_value_tensors(
         self,

--- a/src/paddlefleet/transformer/multi_latent_attention.py
+++ b/src/paddlefleet/transformer/multi_latent_attention.py
@@ -650,17 +650,22 @@ class MultiLatentAttention(Attention):
 
     def _apply_vha_postmix(self, attn_out, U=None, V=None):
         # attn_out: [b, sq, nh_pp * v_head_dim] (head space, pre-gate / pre output proj).
+        # Head-axis low-rank mixing (I + V @ U^T) via two contraction-aligned
+        # matmuls (nh contracted in both -> no transpose): bit-exact to the
+        # einsum form but faster and more memory-frugal.
         if U is None:
             U = self.vha_postmix_U
         if V is None:
             V = self.vha_postmix_V
         b, sq = attn_out.shape[0], attn_out.shape[1]
-        nh = self.num_attention_heads_per_partition
-        mixed = attn_out.reshape([b, sq, nh, self.v_head_dim])
-        z = paddle.einsum("bthd,hr->btrd", mixed, U)
-        delta = paddle.einsum("btrd,hr->bthd", z, V)
-        mixed = mixed + delta
-        return mixed.reshape([b, sq, nh * self.v_head_dim])
+        nh, d = self.num_attention_heads_per_partition, self.v_head_dim
+        mixed = attn_out.reshape([b * sq, nh, d])
+        z = paddle.matmul(
+            U, mixed, transpose_x=True
+        )  # [r,nh]@[B,nh,d]->[B,r,d]
+        delta = paddle.matmul(V, z)  # [nh,r]@[B,r,d]->[B,nh,d]
+        out = mixed + delta
+        return out.reshape([b, sq, nh * d])
 
     def _compute_absorbed_q(self, query):
         """

--- a/tests/single_card_tests/transformer/test_vha_mla.py
+++ b/tests/single_card_tests/transformer/test_vha_mla.py
@@ -314,6 +314,48 @@ class TestMLAPostmixApply(unittest.TestCase):
         ref = (mixed + delta).reshape([b, sq, nh * vd])
         self.assertTrue(paddle.allclose(out, ref, atol=1e-6).item())
 
+    def test_backward_matches_manual_einsum(self):
+        """The matmul rewrite must be gradient-equivalent to the einsum form
+        (dx, dU, dV) — locks the optimization against silent regressions."""
+        attn = _build_mla(use_vha_attention=True, vha_postmix_rank=2)
+        attn.vha_postmix_V.set_value(
+            paddle.randn(attn.vha_postmix_V.shape, dtype="float32") * 0.1
+        )
+        b, sq, nh, vd = 2, 3, 4, 32
+        x0 = paddle.randn([b, sq, nh * vd], dtype="float32")
+
+        # Module (matmul) path — squared loss so grads depend on values.
+        x = x0.detach()
+        x.stop_gradient = False
+        out = attn._apply_vha_postmix(x)
+        (out * out).sum().backward()
+        gx = x.grad.clone()
+        gU = attn.vha_postmix_U.grad.clone()
+        gV = attn.vha_postmix_V.grad.clone()
+
+        # einsum reference on independent leaves.
+        xr = x0.detach()
+        xr.stop_gradient = False
+        Ur = attn.vha_postmix_U.detach()
+        Ur.stop_gradient = False
+        Vr = attn.vha_postmix_V.detach()
+        Vr.stop_gradient = False
+        mixed_r = xr.reshape([b, sq, nh, vd])
+        z_r = paddle.einsum("bthd,hr->btrd", mixed_r, Ur)
+        delta_r = paddle.einsum("btrd,hr->bthd", z_r, Vr)
+        ref = (mixed_r + delta_r).reshape([b, sq, nh * vd])
+        (ref * ref).sum().backward()
+
+        self.assertTrue(
+            paddle.allclose(gx, xr.grad, atol=1e-5).item(), "dx mismatch"
+        )
+        self.assertTrue(
+            paddle.allclose(gU, Ur.grad, atol=1e-5).item(), "dU mismatch"
+        )
+        self.assertTrue(
+            paddle.allclose(gV, Vr.grad, atol=1e-5).item(), "dV mismatch"
+        )
+
 
 # ===========================================================================
 # MLA forward with postmix


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->
  Summary                                                                                                    
                                               
  VHA postmix applies a low-rank cross-head correction out = (I + V·Uᵀ)·mixed on the attention output, mixing along the head axis (nh) with v_head_dim (d) as
   a batch-like axis. The original implementation used two paddle.einsum calls. This PR rewrites the ungrouped path as two contraction-aligned paddle.matmul
  calls, which is faster and more memory-frugal while being numerically bit-exact (forward and backward).

  The key insight: nh is the contracted dimension in both matmuls and is already aligned in both operands, so no transpose is needed:

  mixed = attn_out.reshape([b * sq, nh, d])
  z     = paddle.matmul(U, mixed, transpose_x=True)  # [r,nh] @ [B,nh,d] -> [B,r,d]
  delta = paddle.matmul(V, z)                         # [nh,r] @ [B,r,d] -> [B,nh,d]
  out   = mixed + delta

  Changes

  - attention.py (SelfAttentionVHA._apply_vha_postmix): ungrouped einsum → matmul.
  - multi_latent_attention.py (MultiLatentAttention._apply_vha_postmix): ungrouped einsum → matmul. Covers both the standard MLA path and the MQA sparse
  branch (which reuses this method via U/V args).
  - dsv4_hybrid_attention.py (DSv4HybridAttention._apply_vha_postmix): ungrouped branch → matmul. The grouped branch is intentionally left as einsum —
  benchmarking showed the matmul rewrite is slower for small-GEMM grouped topologies (e.g. g=16, gh=4, r=1), so the block-diagonal grouped path keeps its
  einsum form.
  - test_vha_mla.py: added test_backward_matches_manual_einsum, which checks dx, dU, dV against the einsum reference to lock the optimization against silent
  gradient regressions.

  Performance

  Micro-benchmark (bf16, nh=64, d=512, r=16) of the ungrouped postmix:
  - Forward: ~4–5× faster
  - Forward + backward: ~1.6–1.8× faster

  The einsum backward (EinsumGradNode) was the dominant cost; the matmul form avoids it.

  Correctness

  - Bit-exact to the einsum form (forward and gradients) — verified by test_matches_manual_einsum and the new test_backward_matches_manual_einsum.
  - V is zero-initialized, so postmix is the identity at the start of training and does not perturb the baseline until learned.

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否