### PR TITLE
Exclude triton_ops from diff coverage check

### DIFF
--- a/.github/workflows/Test-release.yml
+++ b/.github/workflows/Test-release.yml
@@ -1369,7 +1369,20 @@ jobs:
             fi
           done
           git diff origin/${{ github.event.pull_request.base.ref }}...HEAD  --unified=0 > diff.txt
-          echo "=== DIFF FILE ==="
+          echo "=== DIFF FILE (before exclusion) ==="
+          cat diff.txt
+          echo "================="
+
+          # 豁免文件/目录列表：这些路径下的改动不计入覆盖率检查
+          EXCLUDE_PATHS=(
+            "src/paddlefleet/triton_ops/"
+          )
+
+          for EXCLUDE_PATH in "${EXCLUDE_PATHS[@]}"; do
+            python ci/exclude_diff_file.py diff.txt "$EXCLUDE_PATH"
+          done
+
+          echo "=== DIFF FILE (after exclusion) ==="
           cat diff.txt
           echo "================="
           python -m pip install diff-cover

--- a/ci/exclude_diff_file.py
+++ b/ci/exclude_diff_file.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Remove diff hunks belonging to a specified path prefix from a unified diff file.
+
+Usage:
+    python ci/exclude_diff_file.py diff.txt "src/paddlefleet/triton_ops/"
+
+This rewrites diff.txt in-place, stripping all diff blocks whose file path
+starts with the given prefix. Useful for excluding directories from
+diff-cover coverage checks.
+"""
+
+import sys
+
+
+def exclude_path_from_diff(diff_file: str, exclude_path: str) -> None:
+    """Remove all diff hunks for files matching *exclude_path* prefix."""
+    with open(diff_file, "r", encoding="utf-8", errors="ignore") as f:
+        lines = f.readlines()
+
+    output_lines: list[str] = []
+    skip = False
+
+    for line in lines:
+        # Each file in unified diff starts with "diff --git a/... b/..."
+        if line.startswith("diff --git "):
+            # Extract b-side path: "diff --git a/foo b/foo"
+            parts = line.split(" b/", 1)
+            if len(parts) == 2:
+                file_path = parts[1].strip()
+                skip = file_path.startswith(exclude_path)
+            else:
+                skip = False
+
+        if not skip:
+            output_lines.append(line)
+
+    with open(diff_file, "w", encoding="utf-8") as f:
+        f.writelines(output_lines)
+
+    excluded_count = len(lines) - len(output_lines)
+    print(
+        f"[exclude_diff_file] Removed {excluded_count} lines "
+        f"matching '{exclude_path}' from {diff_file}"
+    )
+
+
+def main() -> None:
+    if len(sys.argv) < 3:
+        print(
+            "Usage: python ci/exclude_diff_file.py <diff_file> <exclude_path>"
+        )
+        sys.exit(1)
+
+    diff_file = sys.argv[1]
+    exclude_path = sys.argv[2]
+    exclude_path_from_diff(diff_file, exclude_path)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Devs

### Description
在 Test-release 的 coverage_check 步骤中，增加豁免路径逻辑：`src/paddlefleet/triton_ops/` 下的改动不计入 diff 覆盖率检查（Triton kernel 难以被单测行覆盖统计）。

- 新增 `ci/exclude_diff_file.py`：从 diff.txt 中剔除指定路径前缀的 diff hunk
- 在 `diff-cover` 前调用，按 `EXCLUDE_PATHS` 列表逐一排除

### 是否引起精度变化
否