### PR TITLE
[release/0.4][Performance] Optimize VHA postmix performance -- Fused version

### DIFF
--- a/src/paddlefleet/transformer/attention.py
+++ b/src/paddlefleet/transformer/attention.py
@@ -1462,18 +1462,17 @@ class SelfAttentionVHA(Attention):
         )
 
     def _apply_vha_postmix(self, attn_out: Tensor) -> Tensor:
-        # Head-axis low-rank mixing out = (I + V @ U^T) @ mixed, with v_head_dim
-        # as a batch axis. Expressed as two contraction-aligned matmuls (nh is
-        # the contracted dim in both, so no transpose is needed): bit-exact to
-        # the einsum form but faster and more memory-frugal.
+        # Fused dense M = I + V @ U^T, then a single [nh,nh] GEMM on the head
+        # axis: rank-independent and faster than the split low-rank form; differs
+        # from the two-matmul path only by bf16 contraction order.
         b, sq = attn_out.shape[0], attn_out.shape[1]
         nh, d = self.num_attention_heads, self.v_head_dim
         mixed = attn_out.reshape([b * sq, nh, d])
-        z = paddle.matmul(
-            self.vha_postmix_U, mixed, transpose_x=True
-        )  # [r,nh]@[B,nh,d]->[B,r,d]
-        delta = paddle.matmul(self.vha_postmix_V, z)  # [nh,r]@[B,r,d]->[B,nh,d]
-        out = mixed + delta
+        M = paddle.matmul(
+            self.vha_postmix_V, self.vha_postmix_U, transpose_y=True
+        )  # [nh,r]@[r,nh]->[nh,nh]
+        M = M + paddle.eye(nh, dtype=M.dtype)
+        out = paddle.matmul(M, mixed)  # [nh,nh]@[B,nh,d]->[B,nh,d]
         return out.reshape([b, sq, nh * d])
 
     def _apply_shared_kv_inverse_rope(

--- a/src/paddlefleet/transformer/dsv4_hybrid_attention.py
+++ b/src/paddlefleet/transformer/dsv4_hybrid_attention.py
@@ -877,16 +877,17 @@ class DSv4HybridAttention(Attention):
             return mixed.reshape(
                 [b, sq, self.num_attention_heads * self.v_head_dim]
             )
-        # ungrouped: (I + V @ U^T) on the head axis via two contraction-aligned
-        # matmuls (nh contracted in both -> no transpose): bit-exact to the
-        # einsum form but faster and more memory-frugal.
+        # ungrouped: fused dense M = I + V @ U^T, then a single [nh,nh] GEMM on
+        # the head axis. Rank-independent and faster than the split low-rank
+        # form (whose r-sized contraction underutilizes the GPU); differs from
+        # the two-matmul path only by bf16 contraction order.
         nh, d = self.num_attention_heads, self.v_head_dim
         mixed = attn_out.reshape([b * sq, nh, d])
-        z = paddle.matmul(
-            self.vha_postmix_U, mixed, transpose_x=True
-        )  # [r,nh]@[B,nh,d]->[B,r,d]
-        delta = paddle.matmul(self.vha_postmix_V, z)  # [nh,r]@[B,r,d]->[B,nh,d]
-        out = mixed + delta
+        M = paddle.matmul(
+            self.vha_postmix_V, self.vha_postmix_U, transpose_y=True
+        )  # [nh,r]@[r,nh]->[nh,nh]
+        M = M + paddle.eye(nh, dtype=M.dtype)
+        out = paddle.matmul(M, mixed)  # [nh,nh]@[B,nh,d]->[B,nh,d]
         return out.reshape([b, sq, nh * d])
 
     def get_query_key_value_tensors(

--- a/src/paddlefleet/transformer/multi_latent_attention.py
+++ b/src/paddlefleet/transformer/multi_latent_attention.py
@@ -748,9 +748,9 @@ class MultiLatentAttention(Attention):
 
     def _apply_vha_postmix(self, attn_out, U=None, V=None):
         # attn_out: [b, sq, nh_pp * v_head_dim] (head space, pre-gate / pre output proj).
-        # Head-axis low-rank mixing (I + V @ U^T) via two contraction-aligned
-        # matmuls (nh contracted in both -> no transpose): bit-exact to the
-        # einsum form but faster and more memory-frugal.
+        # Fused dense M = I + V @ U^T, then a single [nh,nh] GEMM on the head
+        # axis: rank-independent and faster than the split low-rank form; differs
+        # from the two-matmul path only by bf16 contraction order.
         if U is None:
             U = self.vha_postmix_U
         if V is None:
@@ -758,11 +758,9 @@ class MultiLatentAttention(Attention):
         b, sq = attn_out.shape[0], attn_out.shape[1]
         nh, d = self.num_attention_heads_per_partition, self.v_head_dim
         mixed = attn_out.reshape([b * sq, nh, d])
-        z = paddle.matmul(
-            U, mixed, transpose_x=True
-        )  # [r,nh]@[B,nh,d]->[B,r,d]
-        delta = paddle.matmul(V, z)  # [nh,r]@[B,r,d]->[B,nh,d]
-        out = mixed + delta
+        M = paddle.matmul(V, U, transpose_y=True)  # [nh,r]@[r,nh]->[nh,nh]
+        M = M + paddle.eye(nh, dtype=M.dtype)
+        out = paddle.matmul(M, mixed)  # [nh,nh]@[B,nh,d]->[B,nh,d]
         return out.reshape([b, sq, nh * d])
 
     def _compute_absorbed_q(self, query):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->

  Replace the split low-rank VHA postmix (z=Uᵀ·mixed; delta=V·z; out=mixed+delta) with a fused dense form: precompute M = I + V·Uᵀ once, then apply a single [nh,nh] GEMM on the head axis (out = M·mixed).

  Rank-independent and faster than the split form, whose r-sized contraction underutilizes the GPU. Applied to the ungrouped postmix path in dsv4_hybrid_attention, multi_latent_attention, and attention; grouped dsv4 keeps the block-diagonal einsum. Identity at init (V=0) is preserved.

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
是


Cherry-pick of #1641 to `release/0.4`.

Merged in dev: #1641  <!-- For pass CI -->