### PR TITLE
[release/0.4][New features] Support context parallel for DSv4 hybrid MLA (MHA / non-absorbed MQA / DSA)

### DIFF
--- a/src/paddlefleet/transformer/dsa_attention.py
+++ b/src/paddlefleet/transformer/dsa_attention.py
@@ -47,6 +47,7 @@ from paddlefleet.process_groups_config import ProcessGroupCollection
 from paddlefleet.tensor_parallel.mappings import (
     gather_from_sequence_parallel_region,
 )
+from paddlefleet.transformer.cp_utils import all_gather_cp
 from paddlefleet.transformer.enums import AttnMaskType
 from paddlefleet.transformer.layer import FleetLayer
 
@@ -427,6 +428,8 @@ class DSAIndexer(paddle.nn.Layer):
         self,
         hidden_states: Tensor,  # [b, s, hidden_size] or [s/TP, b, hidden_size] (SP mode)
         q_latent: Tensor,  # [b, s, q_lora_rank] or [s/TP, b, q_lora_rank] (SP mode)
+        position_offset: int = 0,
+        cp_group=None,
     ):
         """Compute q, k, weights before top-k selection.
 
@@ -435,6 +438,21 @@ class DSAIndexer(paddle.nn.Layer):
         When sequence_parallel is enabled, inputs are seq-first sharded
         [s/TP, b, h]. This method gathers them internally (like Megatron DSA)
         and transposes to batch-first [b, s, h] before processing.
+
+        Context parallel (``cp_group`` with ``nranks > 1``, contiguous layout):
+        ``hidden_states`` / ``q_latent`` hold this rank's query slice
+        ``[position_offset, position_offset + s)`` of the global sequence, so
+
+        * RoPE frequencies are built at the **global** length and Q takes the
+          rows of its own slice while K takes all of them;
+        * K is all-gathered to the global length right after ``wk``, i.e. at
+          ``head_dim`` (128) instead of ``hidden_size`` -- 32x less traffic --
+          and before ``k_norm`` / RoPE / ``rotate_activation``, all three of
+          which act per token and therefore commute with a seq-dim gather;
+        * ``weights`` is a per-query row quantity and stays sharded.
+
+        Returns ``q [b, s_local, n_heads, head_dim]``, ``k [b, s_global,
+        head_dim]``, ``weights [b, s_local, n_heads]``.
         """
         # Gather from sequence parallel region if needed
         if self.config.sequence_parallel and self.pg_collection.tp.nranks > 1:
@@ -449,9 +467,14 @@ class DSAIndexer(paddle.nn.Layer):
             q_latent = q_latent.transpose([1, 0, 2])
 
         bsz, seqlen, _ = hidden_states.shape
+        cp_size = (
+            cp_group.nranks
+            if cp_group is not None and cp_group.nranks > 1
+            else 1
+        )
 
-        # Compute RoPE internally
-        rotary_seq_len = seqlen
+        # Compute RoPE internally, at the global sequence length under CP.
+        rotary_seq_len = seqlen * cp_size
         if self.config.rope_type == "rope":
             freqs = self.rotary_pos_emb(rotary_seq_len, packed_seq=False)
             mscale = 1.0
@@ -459,12 +482,20 @@ class DSAIndexer(paddle.nn.Layer):
             freqs, mscale = self.rotary_pos_emb(
                 rotary_seq_len, packed_seq=False
             )
+        # freqs is [1, rotary_seq_len, 1, dim]; Q only needs its own slice.
+        freqs_q = (
+            freqs[:, position_offset : position_offset + seqlen]
+            if cp_size > 1
+            else freqs
+        )
 
         q, _ = self.wq_b(q_latent)  # [b, s, n_heads * head_dim]
         q = q.reshape([bsz, seqlen, self.n_heads, self.head_dim])
-        q = self._apply_rope(q, freqs, mscale)
+        q = self._apply_rope(q, freqs_q, mscale)
 
         k, _ = self.wk(hidden_states)  # [b, s, head_dim]
+        if cp_size > 1:
+            k = all_gather_cp(k, dim=1, group=cp_group)  # [b, s_global, hd]
         k = self.k_norm(k)
         k = self._apply_rope(k.unsqueeze(2), freqs, mscale).squeeze(2)
 

--- a/src/paddlefleet/transformer/mqa_latent_attention.py
+++ b/src/paddlefleet/transformer/mqa_latent_attention.py
@@ -52,6 +52,20 @@ the YaRN ``mscale`` is a constant and the Hadamard ``rotate_activation`` is
 orthogonal, so no per-document position reset is needed. Equivalence to running
 every document on its own therefore reduces to index correctness, which is what
 ``_derive_csa_doc_boundaries`` plus the index builders below guarantee.
+
+Context parallel (``contiguous_allgather`` only, as the HCA layers of the same
+model require at ``dsv4_hybrid_attention.py:607-611``) follows the same
+"Miles pattern" as ``CSASelfAttention._forward_cp``: the query slice stays
+sharded, only the low-dimensional KV latent is all-gathered to the global
+length, and the output comes back sharded with no reduce-scatter. The index
+tables are built over the *global* sequence and then row-sliced to this rank,
+which is exactly right because ``_derive_csa_doc_boundaries`` and the builders
+are ``seqlen``-agnostic and their column values are global token ids -- the same
+space the all-gathered KV is indexed in. ``attn_mask_startend_row_indices``
+already arrives at the global length under CP
+(``dsv4_hybrid_attention.py:634``), while ``query`` / ``key`` / ``x`` / ``qr``
+arrive local but RoPE'd with global positions
+(``multi_latent_attention.py:1485-1545``).
 """
 
 from __future__ import annotations
@@ -64,8 +78,9 @@ import paddle.nn.functional as F
 from paddle import Tensor
 from paddle.distributed.fleet.meta_parallel import LayerSpec, build_spec_layer
 
-from paddlefleet.parallel_state import get_context_parallel_world_size
+from paddlefleet.context_parallel_utils import ContextParallelGatherOp
 from paddlefleet.process_groups_config import ProcessGroupCollection
+from paddlefleet.transformer.cp_utils import all_gather_cp
 from paddlefleet.transformer.csa_attention import (
     TileLangCSAIndexerLossAutoScaler,
     _build_mqa_causal_topk_idxs_from_doc_bounds,
@@ -144,6 +159,34 @@ class MQALatentAttention(FleetLayer):
             pg_collection = ProcessGroupCollection.use_mpu_process_groups()
         self.pg_collection = pg_collection
 
+        # CP state, same derivation as csa_attention.py:2079-2090.
+        cp_pg = pg_collection.cp if pg_collection is not None else None
+        if cp_pg is not None and getattr(cp_pg, "nranks", 1) > 1:
+            self.cp_group = cp_pg
+            self.cp_size = cp_pg.nranks
+            self.cp_rank = cp_pg.rank
+            self.cp_enabled = True
+            # Deliberately the *same* constraint the HCA layers of this model
+            # assert (dsv4_hybrid_attention.py:607-611), not a weaker one: the
+            # contiguous layout is what makes "build the index table over the
+            # global sequence, then row-slice this rank's queries" correct, and
+            # it is what makes the all-gathered KV land in natural global order.
+            if (
+                getattr(config, "cp_balance_mode", None)
+                != "contiguous_allgather"
+            ):
+                raise NotImplementedError(
+                    "non_absorbed_mqa=True under context parallel requires "
+                    "cp_balance_mode='contiguous_allgather' (the same mode the "
+                    "hybrid model's HCA layers require), got "
+                    f"{getattr(config, 'cp_balance_mode', None)!r}."
+                )
+        else:
+            self.cp_group = None
+            self.cp_size = 1
+            self.cp_rank = 0
+            self.cp_enabled = False
+
         # ``k_channels`` is the MHA q_head_dim (qk_nope + qk_rope), NOT the 576
         # latent width: absorption is exactly score-preserving, so the MHA
         # softmax scale must be kept.
@@ -217,7 +260,8 @@ class MQALatentAttention(FleetLayer):
             key:   ``[b, s, 1, kv_lora_rank + qk_rope_head_dim]`` shared latent.
             value: unused (``None``); the V side lives inside ``key``.
             attn_mask_startend_row_indices: ``[b, 1, s, 1]`` exclusive per-token
-                document end rows. ``None`` means a single document.
+                document end rows, at the **global** sequence length under CP.
+                ``None`` means a single document.
             x / qr: hidden states / q latent, inputs of the DSA indexer.
             v_b_proj_weight: ``[kv_lora_rank, h, v_head_dim]`` de-absorption
                 weight (the V slice of ``kv_b_proj``).
@@ -226,21 +270,13 @@ class MQALatentAttention(FleetLayer):
                 row mean, as CSA does at ``csa_attention.py:1306``.
 
         Returns:
-            ``[b, s, h * v_head_dim]``
+            ``[b, s, h * v_head_dim]`` (this rank's query slice under CP)
         """
         if packed_seq_params is not None:
             raise NotImplementedError(
                 "non_absorbed_mqa=True does not support packed_seq_params; "
                 "document masking is driven by "
                 "attn_mask_startend_row_indices."
-            )
-        if get_context_parallel_world_size() > 1:
-            raise NotImplementedError(
-                "non_absorbed_mqa=True does not support context parallel yet: "
-                "the document metadata below is derived in local token space, "
-                "while a CP rank only holds a query slice of the globally "
-                "all-gathered KV. Keep non_absorbed_mqa=false for CP runs (the "
-                "dense MHA path supports contiguous_allgather)."
             )
         if v_b_proj_weight is None:
             raise ValueError(
@@ -254,16 +290,27 @@ class MQALatentAttention(FleetLayer):
                 "non_absorbed_mqa=True requires micro batch size 1 (documents "
                 f"are packed along the sequence), got b={b}."
             )
+        # Under CP this rank owns global query positions
+        # [position_offset, position_offset + s). Everything index-related is
+        # derived at s_global and row-sliced; the KV is all-gathered so that the
+        # global column ids in those tables address it directly.
+        s_global = s * self.cp_size
+        position_offset = self.cp_rank * s
         kv = key.squeeze(2).contiguous()  # [b, s, kv_lora + qk_rope]
+        kv = all_gather_cp(
+            kv, dim=1, group=self.cp_group
+        )  # -> [b, s_global, .]
         kv_lora_rank = int(v_b_proj_weight.shape[0])
 
         with paddle.no_grad():
             row_end = attn_mask_startend_row_indices
             if row_end is None:
-                row_end = paddle.full([b, 1, s, 1], s, dtype="int32")
-            _validate_csa_docmask_shape(row_end, b, s)
+                row_end = paddle.full(
+                    [b, 1, s_global, 1], s_global, dtype="int32"
+                )
+            _validate_csa_docmask_shape(row_end, b, s_global)
             doc_start, doc_len, is_valid, doc_lens, _ = (
-                _derive_csa_doc_boundaries(row_end, s)
+                _derive_csa_doc_boundaries(row_end, s_global)
             )
 
         if self.indexer is None:
@@ -271,7 +318,7 @@ class MQALatentAttention(FleetLayer):
             # tests): per-document full causal attention, mathematically
             # identical to dense MHA.
             token_indices = self._build_full_causal_indices(
-                b, s, doc_start, is_valid
+                b, s_global, doc_start, is_valid, position_offset, s
             )
             core_out = self._sparse_attn(
                 query, kv, token_indices, self.softmax_scale, kv_lora_rank
@@ -290,23 +337,43 @@ class MQALatentAttention(FleetLayer):
             doc_lens,
             kv_lora_rank,
             input_ids,
+            position_offset,
         )
 
     # ------------------------------------------------------------------
     # index construction / kernel plumbing
     # ------------------------------------------------------------------
     @staticmethod
-    def _build_full_causal_indices(b, s, doc_start, is_valid) -> Tensor:
-        """Per-document full-causal ``[b, s, s]`` int32 table (``-1`` padded)."""
+    def _build_full_causal_indices(
+        b, s_global, doc_start, is_valid, position_offset=0, s_local=None
+    ) -> Tensor:
+        """Per-document full-causal ``[b, s_local, s_global]`` int32 (``-1`` pad).
+
+        Built over the global sequence and row-sliced to this CP rank, so the
+        column values stay global token ids. ``O(s_global^2)`` while building,
+        which is why this mode is an equivalence experiment, not production.
+        """
         with paddle.no_grad():
             indices, _ = _build_mqa_causal_topk_idxs_from_doc_bounds(
-                b, s, doc_start, is_valid
+                b, s_global, doc_start, is_valid
             )
+            if s_local is not None and s_local != s_global:
+                indices = indices[
+                    :, position_offset : position_offset + s_local
+                ]
             indices = indices.contiguous()
         indices.stop_gradient = True
         return indices
 
-    def _indexer_valid_range(self, s, doc_start, doc_len, is_valid):
+    def _indexer_valid_range(
+        self,
+        s_global,
+        doc_start,
+        doc_len,
+        is_valid,
+        position_offset=0,
+        s_local=None,
+    ):
         """Non-local candidate range per query, in **global token** space.
 
         The forced local window already covers the last ``window_size`` causal
@@ -316,19 +383,27 @@ class MQALatentAttention(FleetLayer):
         Because the clamped end never exceeds the kernel's own causal limit, no
         masked ``-inf`` column can enter the top-k.
 
+        Built over the global sequence and row-sliced to this CP rank; the two
+        columns stay global token ids, which is what the kernel's
+        ``seq_offset``-aware causal bound expects.
+
         Returns:
-            ``(valid_range [1, s, 2] int32, row_empty [1, s, 1] bool)``.
+            ``(valid_range [1, s_local, 2] int32, row_empty [1, s_local, 1])``.
         """
-        positions = paddle.arange(s, dtype="int64")
+        positions = paddle.arange(s_global, dtype="int64")
         causal_avail = paddle.minimum(positions - doc_start + 1, doc_len)
         n_avail = paddle.clip(causal_avail - self.window_size, min=0)
         n_avail = paddle.where(is_valid, n_avail, paddle.zeros_like(n_avail))
-        valid_range = (
-            paddle.stack([doc_start, doc_start + n_avail], axis=-1)
-            .cast("int32")
-            .unsqueeze(0)
-        )
-        return valid_range, (n_avail == 0).reshape([1, s, 1])
+        valid_range = paddle.stack(
+            [doc_start, doc_start + n_avail], axis=-1
+        ).cast("int32")
+        if s_local is not None and s_local != s_global:
+            valid_range = valid_range[
+                position_offset : position_offset + s_local
+            ]
+            n_avail = n_avail[position_offset : position_offset + s_local]
+        rows = int(valid_range.shape[0])
+        return valid_range.unsqueeze(0), (n_avail == 0).reshape([1, rows, 1])
 
     def _sparse_attn(self, query, kv, token_indices, sm_scale, d_v):
         """Sparse MQA over the absorbed latent, via the shared cudnn backend.
@@ -376,12 +451,14 @@ class MQALatentAttention(FleetLayer):
         doc_lens,
         kv_lora_rank,
         input_ids=None,
+        position_offset=0,
     ) -> Tensor:
         from paddlefleet.cudnn_ops.indexer.csa_indexer_fwd_cudnn import (
             cudnn_indexer_topk_fwd,
         )
 
         b, s = int(query.shape[0]), int(query.shape[1])
+        s_global = s * self.cp_size
         # The indexer loss is only attached on the grad-enabled forward. Under
         # full-layer recompute the first forward runs under no_grad and must
         # only materialise indices; both passes see identical inputs, so the
@@ -397,10 +474,14 @@ class MQALatentAttention(FleetLayer):
 
         with paddle.no_grad():
             window_idxs = _build_window_topk_idxs_from_doc_bounds(
-                b, s, self.window_size, doc_start, is_valid
+                b, s_global, self.window_size, doc_start, is_valid
             ).cast("int32")
+            if self.cp_enabled:
+                window_idxs = window_idxs[
+                    :, position_offset : position_offset + s
+                ]
             valid_range, row_empty = self._indexer_valid_range(
-                s, doc_start, doc_len, is_valid
+                s_global, doc_start, doc_len, is_valid, position_offset, s
             )
 
         x_det, qr_det = x.detach(), qr.detach()
@@ -408,12 +489,12 @@ class MQALatentAttention(FleetLayer):
             x_det.stop_gradient = False
             qr_det.stop_gradient = False
             q_idx, k_idx, w_idx = self.indexer.forward_before_topk(
-                x_det, qr_det
+                x_det, qr_det, position_offset, self.cp_group
             )
         else:
             with paddle.no_grad():
                 q_idx, k_idx, w_idx = self.indexer.forward_before_topk(
-                    x_det, qr_det
+                    x_det, qr_det, position_offset, self.cp_group
                 )
         # ``DSAIndexer`` pre-bakes ``head_dim**-0.5`` into the weights, but both
         # cuDNN indexer kernels apply ``dim**-0.5`` themselves (the backward one
@@ -444,13 +525,19 @@ class MQALatentAttention(FleetLayer):
         loss_topk = attn_topk
         if need_loss and not self.indexer_use_sparse_loss:
             loss_topk = max(
-                attn_topk, min(_LOSS_TOPK_CAP, s // _TOPK_BLOCK * _TOPK_BLOCK)
+                attn_topk,
+                min(_LOSS_TOPK_CAP, s_global // _TOPK_BLOCK * _TOPK_BLOCK),
             )
         # The THD/varlen fast path builds ``cu_seqlens_k`` from ``doc_lens``,
         # i.e. it assumes a document-compacted K buffer. At ratio 1 the K buffer
         # is the raw token sequence, so the two only coincide when the documents
         # exactly tile the sequence; otherwise fall back to the dense path.
-        doc_lens_arg = doc_lens.tolist() if int(doc_lens.sum()) == s else None
+        # ``doc_lens`` stays global: ``_make_cu_seqlens`` is CP-aware and uses
+        # ``seq_offset`` to pick out the documents this rank queries
+        # (csa_indexer_fwd_cudnn.py:407-466).
+        doc_lens_arg = (
+            doc_lens.tolist() if int(doc_lens.sum()) == s_global else None
+        )
 
         def select_topk(width, want_scores):
             out = cudnn_indexer_topk_fwd(
@@ -461,6 +548,7 @@ class MQALatentAttention(FleetLayer):
                 topk_effective=width,
                 valid_range=valid_range,
                 doc_lens=doc_lens_arg,
+                seq_offset=position_offset,
                 return_topk_scores=want_scores,
             )
             idx = paddle.where(row_empty, paddle.full_like(out[0], -1), out[0])
@@ -522,15 +610,21 @@ class MQALatentAttention(FleetLayer):
             # backstop that catches them, keeping the padding out of both the
             # logged loss and the gradient denominator.
             loss_mask, valid_rows = self._indexer_loss_mask(input_ids, b, s)
+            # Under CP each rank reduces over its own query rows only. With a
+            # mask the denominator is already the *global* valid-row count, so
+            # the per-rank losses sum to the global one; without a mask each rank
+            # produced a local mean and needs ``/cp_size``. Same split as
+            # csa_attention.py:2792-2810.
+            loss_coeff = (
+                self.indexer_loss_coeff
+                if loss_mask is not None
+                else self.indexer_loss_coeff / self.cp_size
+            )
             kl_per_pos = kl.sum(axis=-1)
             if loss_mask is None:
-                loss = kl_per_pos.mean() * self.indexer_loss_coeff
+                loss = kl_per_pos.mean() * loss_coeff
             else:
-                loss = (
-                    (kl_per_pos * loss_mask).sum()
-                    / valid_rows
-                    * self.indexer_loss_coeff
-                )
+                loss = (kl_per_pos * loss_mask).sum() / valid_rows * loss_coeff
 
         DSAIndexerLossLoggingHelper.save_loss_to_tracker(
             loss=loss,
@@ -547,7 +641,7 @@ class MQALatentAttention(FleetLayer):
             loss_indices,
             topk_probs,
             target,
-            self.indexer_loss_coeff,
+            loss_coeff,
             "cudnn",
             # ``num_rows_override`` + ``loss_mask``: the backward zeroes the pad
             # rows and rescales the cuDNN kernel's built-in ``1/(B*Sq)`` into
@@ -562,7 +656,11 @@ class MQALatentAttention(FleetLayer):
 
         ``(None, None)`` when no ``input_ids`` reached this layer (inference and
         the direct-construction unit tests), which keeps the plain row mean.
-        Context parallel needs no branch here: ``forward`` rejects it outright.
+
+        Under CP the mask is this rank's row slice but the denominator is the
+        **global** valid-row count, so summing the per-rank losses reproduces the
+        single-rank reduction. ``input_ids`` arrives sharded unless
+        ``experimental_dataflow``, exactly as at ``csa_attention.py:2419-2428``.
         """
         if input_ids is None:
             return None, None
@@ -570,6 +668,17 @@ class MQALatentAttention(FleetLayer):
         assert pad_token_id is not None, (
             "pad_token_id must be set in config when input_ids is provided"
         )
+        if self.cp_enabled:
+            if not getattr(self.config, "experimental_dataflow", False):
+                input_ids = ContextParallelGatherOp.apply(
+                    input_ids, axis=1, mode=self.config.cp_balance_mode
+                )
+            loss_mask_global = (
+                input_ids.reshape([b, self.cp_size * s]) != pad_token_id
+            ).astype(paddle.float32)
+            valid_rows = max(float(loss_mask_global.sum()), 1.0)
+            offset = self.cp_rank * s
+            return loss_mask_global[:, offset : offset + s], valid_rows
         loss_mask = (input_ids.reshape([b, s]) != pad_token_id).astype(
             paddle.float32
         )
@@ -591,9 +700,10 @@ class MQALatentAttention(FleetLayer):
         whether the table is the attention one or the wider loss one.
 
         Args:
-            query: ``[1, s, h, dk]`` detached absorbed query.
-            kv: ``[1, s, dk]`` latent keys.
-            topk_indices: ``[1, s, topk]`` int32, ``-1`` for empty slots.
+            query: ``[1, s, h, dk]`` detached absorbed query (local rows).
+            kv: ``[1, s_global, dk]`` latent keys (all-gathered under CP).
+            topk_indices: ``[1, s, topk]`` int32 global column ids, ``-1`` for
+                empty slots.
 
         Returns:
             ``[1, s, topk]`` float32 rows summing to 1 (0 for empty rows).

--- a/tests/multi_card_tests/transformer/test_mla_cp_contiguous_allgather.py
+++ b/tests/multi_card_tests/transformer/test_mla_cp_contiguous_allgather.py
@@ -40,6 +40,8 @@ Run (2 GPUs)::
 test_mla_cp_contiguous_allgather.py
 """
 
+import os
+import sys
 import types
 import unittest
 
@@ -48,16 +50,40 @@ import paddle
 import paddle.distributed as dist
 from paddle import nn
 from paddle.distributed import fleet
+from paddle.distributed.fleet.meta_parallel import LayerSpec
 
 import paddlefleet.parallel_state as ps
 from paddlefleet.transformer.dot_product_attention import DotProductAttention
+from paddlefleet.transformer.dsa_attention import (
+    DSAIndexer,
+    DSAIndexerSublayersSpec,
+)
 from paddlefleet.transformer.enums import AttnMaskType
+from paddlefleet.transformer.mqa_latent_attention import (
+    MQALatentAttention,
+    MQALatentAttentionSublayersSpec,
+)
 from paddlefleet.transformer.multi_latent_attention import (
     MLASelfAttention,
     MLASelfAttentionSublayersSpec,
 )
 from paddlefleet.transformer.transformer_config import TransformerConfig
 from paddlefleet.utils import init_method_normal, scaled_init_method_normal
+
+# ``hybrid_mla_utils`` owns the sublayer stubs and the SM100 kernel-availability
+# skip shared with the single-card hybrid-MLA suites.
+sys.path.insert(
+    0,
+    os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        "..",
+        "..",
+        "single_card_tests",
+        "transformer",
+    ),
+)
+
+import hybrid_mla_utils as U
 
 DTYPE = "bfloat16"
 
@@ -157,12 +183,28 @@ def build_cfg(cp_size, sink=False, attn_mode="mha"):
     # "mqa"/"mqa_dsa" -> runtime-absorbed MQALatentAttention.
     c.non_absorbed_mqa = attn_mode != "mha"
     c.hybrid_mla_q_lora_rank = 64
-    c.hybrid_mla_kv_lora_rank = 128
-    c.hybrid_mla_qk_nope_head_dim = 64
+    if attn_mode == "mha":
+        c.hybrid_mla_kv_lora_rank = 128
+        c.hybrid_mla_qk_nope_head_dim = 64
+    else:
+        # The absorbed query is [kv_lora_rank + qk_rope_head_dim] wide and the
+        # absorbed value is [kv_lora_rank]. FlashMLA's sparse kernel only
+        # accepts d_qk in {512, 576} with d_v == 512 (mqa_sparse_attn.py:299),
+        # so the MQA fixture has to use the production latent width.
+        c.hybrid_mla_kv_lora_rank = 512
+        c.hybrid_mla_qk_nope_head_dim = 192
     c.hybrid_mla_qk_rope_head_dim = 64
     c.hybrid_mla_v_head_dim = 64
     c.hybrid_mla_num_attention_heads = H
     c.hybrid_mla_num_key_value_heads = H
+    # Indexer dims are model-wide; only ``mqa_dsa`` actually builds one.
+    c.dsa_index_n_heads = 64
+    c.dsa_index_head_dim = 128
+    c.dsa_index_topk = 128
+    c.dsa_indexer_rotary_interleaved = False
+    c.dsa_indexer_use_sparse_loss = True
+    c.csa_window_size = 128
+    c.non_absorbed_mqa_dense = attn_mode == "mqa"
     c.add_full_attention_sink_bias = sink
     c.rope_type = "rope"
     c.rope_theta = 10000.0
@@ -189,7 +231,27 @@ def build_cfg(cp_size, sink=False, attn_mode="mha"):
     return c
 
 
-def build_mla(cfg, cp_group):
+def _mqa_core_spec(attn_mode):
+    """``core_attention`` spec for ``non_absorbed_mqa``, per gpt_layer_specs.py:342."""
+    indexer = None
+    if attn_mode == "mqa_dsa":
+        indexer = LayerSpec(
+            layer=DSAIndexer,
+            sublayers_spec=DSAIndexerSublayersSpec(
+                linear_wq_b=U.BiasedLinear,
+                linear_wk=U.BiasedLinear,
+                k_norm=U.LayerNormStub,
+                linear_weights_proj=U.BiasedLinear,
+            ),
+            extra_kwargs={"is_hybrid_mla_indexer": True},
+        )
+    return LayerSpec(
+        layer=MQALatentAttention,
+        sublayers_spec=MQALatentAttentionSublayersSpec(indexer=indexer),
+    )
+
+
+def build_mla(cfg, cp_group, attn_mode="mha"):
     spec = MLASelfAttentionSublayersSpec(
         q_a_layernorm=_TestRMSNorm,
         kv_a_layernorm=_TestRMSNorm,
@@ -198,18 +260,27 @@ def build_mla(cfg, cp_group):
         q_b_proj=_TestLinear,
         kv_a_proj_with_mqa=_TestLinear,
         kv_b_proj=_TestLinear,
-        core_attention=DotProductAttention,
+        core_attention=(
+            DotProductAttention
+            if attn_mode == "mha"
+            else _mqa_core_spec(attn_mode)
+        ),
         o_proj=_TestLinear,
         gate_proj=None,
     )
     pg = types.SimpleNamespace(tp=None, cp=cp_group)
-    return MLASelfAttention(
+    layer = MLASelfAttention(
         config=cfg,
         sublayers_spec=spec,
         layer_number=1,
         attn_mask_type=AttnMaskType.causal,
         pg_collection=pg,
     )
+    if attn_mode != "mha":
+        # ``rotate_activation`` (indexer) and the sparse kernel both require
+        # bf16; ``U.BiasedLinear`` / ``U.LayerNormStub`` default to fp32.
+        layer.to(dtype=DTYPE)
+    return layer
 
 
 def _rel(a, x):
@@ -233,7 +304,7 @@ def _row_end(doc_lens, seqlen):
     return paddle.to_tensor(out).reshape([1, 1, seqlen, 1])
 
 
-def run_mla_cp(mask_full, seed=2026, sink=False):
+def run_mla_cp(mask_full, seed=2026, sink=False, attn_mode="mha"):
     """Build+run ref (CP off) then CP layer (CP on). Returns a metrics dict.
 
     Raises are propagated (used by the sink tests to observe NotImplementedError).
@@ -243,7 +314,9 @@ def run_mla_cp(mask_full, seed=2026, sink=False):
 
     _cp_disable()
     paddle.seed(seed)
-    ref = build_mla(build_cfg(1, sink=sink), None)
+    ref = build_mla(
+        build_cfg(1, sink=sink, attn_mode=attn_mode), None, attn_mode
+    )
 
     paddle.seed(1000)
     hf = paddle.randn([b, sg, 256], dtype=DTYPE)
@@ -255,7 +328,12 @@ def run_mla_cp(mask_full, seed=2026, sink=False):
 
     _cp_enable()
     paddle.seed(seed)
-    cpl = build_mla(build_cfg(CP_SIZE, sink=sink), CP_GROUP)
+    cpl = build_mla(
+        build_cfg(CP_SIZE, sink=sink, attn_mode=attn_mode), CP_GROUP, attn_mode
+    )
+    # ``paddle.seed`` alone does not guarantee identical weights once the two
+    # builds differ in kernel-side init order, so copy explicitly.
+    cpl.set_state_dict(ref.state_dict())
 
     s, e = CP_RANK * sl, (CP_RANK + 1) * sl
     hb = hf[:, s:e].clone()
@@ -377,50 +455,72 @@ class TestMLAContiguousAllgatherCP(unittest.TestCase):
             ratio, 1.0, delta=0.05, msg="grad-norm ratio deviates from 1"
         )
 
-    # ---- Item 6: MQA / MQA_DSA must reject CP with a clear NotImplementedError
-    def test_6_mqa_cp_not_implemented(self):
-        from paddlefleet.transformer.mqa_latent_attention import (
-            MQALatentAttention,
-            MQALatentAttentionSublayersSpec,
+    # ---- Item 6: non_absorbed_mqa (+DSA) CP equivalence at the MLA level ----
+    #
+    # This used to assert ``NotImplementedError``. MQA now implements
+    # ``contiguous_allgather`` CP, so the same slot must prove equivalence
+    # instead. The core-attention-only equivalence lives in
+    # ``test_mqa_dsa_cp.py``; what is new here is the *whole* MLA layer: the
+    # shared RoPE CP scatter (multi_latent_attention.py:1485-1545), the runtime
+    # absorption (:1913-1939), ``o_proj``, and every parameter gradient after
+    # the CP all-reduce.
+    def _check_mqa(self, attn_mode):
+        r = run_mla_cp(_row_end([200, 150, 162], 512), attn_mode=attn_mode)
+        self.assertLess(r["fwd"], FWD_RTOL, f"{attn_mode}: forward")
+        self.assertLess(r["dH"], GRAD_RTOL, f"{attn_mode}: dH")
+        for n, v in r["param_err"].items():
+            self.assertIsNotNone(v, f"{attn_mode}: ref grad missing for {n}")
+            self.assertLess(v, GRAD_RTOL, f"{attn_mode}: param grad {n}")
+        print(
+            f"[mla-cp{CP_SIZE} rank{CP_RANK}] {attn_mode}: fwd={r['fwd']:.2e} "
+            f"dH={r['dH']:.2e} "
+            f"param_max={max(r['param_err'].values(), default=0.0):.2e} "
+            f"per_pos_max={max(r['per_pos']):.3e}",
+            flush=True,
+        )
+        return r
+
+    @U._GPU
+    def test_6_mqa_dense_cp_equivalence(self):
+        """Absorbed MQA over the full per-document causal set, under CP.
+
+        The documents [0,200) [200,350) [350,512) all straddle the rank
+        boundaries for CP=2 (256) and CP=4 (128/256/384), so a per-rank index
+        table -- one clipped at ``q - position_offset`` instead of at the global
+        ``q`` -- drops the prefix owned by lower ranks and shows up as an O(1)
+        forward error on rank > 0.
+        """
+        r = self._check_mqa("mqa")
+        self.assertTrue(
+            any(n.endswith("kv_b_proj.weight") for n in r["param_err"]),
+            "kv_b_proj must still receive a gradient through the absorption",
         )
 
+    @U._GPU
+    def test_6b_mqa_dsa_cp_equivalence(self):
+        """Same, with the DSA indexer selecting the columns.
+
+        Additionally covers the indexer's own CP path end to end: its K is
+        all-gathered to the global length while its Q stays sharded and takes
+        the ``position_offset`` RoPE slice (dsa_attention.py:426-511).
+        """
+        r = self._check_mqa("mqa_dsa")
+        self.assertTrue(
+            any(".indexer." in n for n in r["param_err"]),
+            "the indexer parameters must receive gradients under CP",
+        )
+
+    def test_6c_mqa_rejects_other_cp_balance_modes(self):
+        """Only ``contiguous_allgather`` is implemented, same as HCA
+        (``dsv4_hybrid_attention.py:607-611``)."""
         _cp_enable()
         self.assertGreater(ps.get_context_parallel_world_size(), 1)
-
-        cfg = build_cfg(CP_SIZE, attn_mode="mqa")
-        kv_lora, qk_rope, v_head = 128, 64, 64
-        k_channels = kv_lora + qk_rope
-        try:
-            core = MQALatentAttention(
-                config=cfg,
-                sublayers_spec=MQALatentAttentionSublayersSpec(indexer=None),
-                layer_number=1,
-                attn_mask_type=AttnMaskType.causal,
-                attention_type="self",
-                k_channels=k_channels,
-            )
-        except Exception as ex:
-            # Construction-time rejection is also acceptable early failure.
-            self.assertIsInstance(
-                ex, (NotImplementedError, ValueError, AssertionError)
-            )
-            return
-
-        b, s, h = 1, 8, cfg.hybrid_mla_num_attention_heads
-        q = paddle.randn([b, s, h, kv_lora + qk_rope], dtype=DTYPE)
-        k = paddle.randn([b, s, 1, k_channels], dtype=DTYPE)
-        v = paddle.randn([b, s, 1, kv_lora], dtype=DTYPE)
-        row_end = _row_end([s], s)
-        with self.assertRaises(NotImplementedError) as cm:
-            core(
-                q,
-                k,
-                v,
-                None,
-                attn_mask_startend_row_indices=row_end,
-                v_b_proj_weight=paddle.randn([kv_lora, h, v_head], dtype=DTYPE),
-            )
-        self.assertIn("context", str(cm.exception).lower())
+        for mode in ("p2p", "zigzag", "dualchunk_allgather", None):
+            with self.subTest(cp_balance_mode=mode):
+                cfg = build_cfg(CP_SIZE, attn_mode="mqa")
+                cfg.cp_balance_mode = mode
+                with self.assertRaises(NotImplementedError):
+                    build_mla(cfg, CP_GROUP, "mqa")
 
 
 if __name__ == "__main__":

--- a/tests/multi_card_tests/transformer/test_mla_cp_recompute.py
+++ b/tests/multi_card_tests/transformer/test_mla_cp_recompute.py
@@ -1,0 +1,162 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Task #18 -- CP x recompute equivalence for the hybrid-MLA (MHA/MQA/DSA) layer.
+
+Proves that full-layer activation recompute is a transparent compute/memory
+trade UNDER context parallel: for the CP layer, recompute ON must equal
+recompute OFF elementwise on the forward output and on every parameter / input
+gradient, on each CP rank. The load-bearing invariant is that the DSA
+``token_indices`` -- selected from the CP-*global* index table (built at
+``s_global = s * cp_size`` and sliced at ``position_offset = cp_rank * s``,
+mqa_latent_attention.py:297-298) -- are re-derived bit-identically on the
+recompute re-forward; a mismatch would silently differentiate a *different*
+sparsity pattern and corrupt gradients with no error.
+
+This is the CP analogue of the single-card
+``test_hybrid_mla_recompute_mtp_ckpt.py::TestRecomputeEquivalence`` and closes
+the recompute leg of the MTP x CP audit: an MTP layer's inner attention IS this
+same TransformerLayer, recomputed via ``multi_token_prediction.py`` uniform
+checkpointing (:747-753), and it inherits the process-global CP group through
+``use_mpu_process_groups()`` (transformer_layer.py:233-234).
+
+Both branches (OFF then ON) run the identical collective sequence on every
+rank -- there is NO ``if rank == X`` short-circuit -- so the CP NCCL streams
+stay in lockstep across the recompute re-forward's extra ``all_gather_cp``.
+
+Run (2 GPUs)::
+
+    PYTHONPATH=./third_party/PaddleFleet/src:./third_party/PaddleFormers \
+    python -m paddle.distributed.launch --devices <a>,<b> --nnodes 1 \
+        --master 127.0.0.1:<port> \
+        third_party/PaddleFleet/tests/multi_card_tests/transformer/\
+test_mla_cp_recompute.py
+"""
+
+import unittest
+
+import paddle
+
+# Reuse the proven CP harness (fleet init, cfg/layer builders, CP globals).
+# Run via ``paddle.distributed.launch <thisfile>`` puts this dir on sys.path[0],
+# so the sibling test module imports as a top-level name.
+import test_mla_cp_contiguous_allgather as H
+from paddle.distributed.fleet.utils import recompute
+
+# Same-rank ON vs OFF is the identical function of identical inputs, so the
+# forward is bit-exact up to kernel nondeterminism; grads take one extra bf16
+# re-forward. Tolerances mirror the single-card recompute suite.
+FWD_RTOL = 1e-5
+GRAD_RTOL = 5e-3
+
+
+def setUpModule():
+    H.setUpModule()
+
+
+def _run_recompute_pair(mask_full, attn_mode, sink=False, seed=2026):
+    """Build ONE CP layer, then run fwd+bwd twice on the same rank-local shard:
+    recompute OFF, then recompute ON. Returns ``(out_off, out_on, g_off, g_on)``
+    with grads as ``{name: fp32 tensor or None}`` (``__hidden__`` = dH)."""
+    H._cp_enable()
+    b, sg = 1, mask_full.shape[2]
+    sl = sg // H.CP_SIZE
+
+    paddle.seed(seed)
+    cpl = H.build_mla(
+        H.build_cfg(H.CP_SIZE, sink=sink, attn_mode=attn_mode),
+        H.CP_GROUP,
+        attn_mode,
+    )
+
+    paddle.seed(1000)
+    hf = paddle.randn([b, sg, 256], dtype=H.DTYPE)
+    s, e = H.CP_RANK * sl, (H.CP_RANK + 1) * sl
+
+    def _one(use_rc):
+        cpl.clear_gradients()
+        h = hf[:, s:e].clone()
+        h.stop_gradient = False
+
+        def fn(x):
+            out, _ = cpl(
+                x, None, attn_mask_startend_row_indices=mask_full.clone()
+            )
+            return out
+
+        out = recompute(fn, h) if use_rc else fn(h)
+        out.cast("float32").sum().backward()
+        grads = {
+            n: (None if p.grad is None else p.grad.detach().cast("float32"))
+            for n, p in cpl.named_parameters()
+        }
+        grads["__hidden__"] = (
+            None if h.grad is None else h.grad.detach().cast("float32")
+        )
+        return out.detach().cast("float32"), grads
+
+    out_off, g_off = _one(False)
+    out_on, g_on = _one(True)
+    return out_off, out_on, g_off, g_on
+
+
+class TestMLACPRecompute(unittest.TestCase):
+    """recompute ON == OFF, per CP rank, on output and every gradient."""
+
+    def _check(self, attn_mode, mask, sink=False):
+        out_off, out_on, g_off, g_on = _run_recompute_pair(
+            mask, attn_mode, sink=sink
+        )
+        self.assertLess(
+            H._rel(out_on, out_off),
+            FWD_RTOL,
+            f"{attn_mode} sink={sink}: recompute output drifted",
+        )
+        # recompute must not change which params receive a gradient.
+        self.assertEqual(set(g_on), set(g_off), f"{attn_mode}: grad key set")
+        reforwarded = 0
+        for n in g_off:
+            if g_off[n] is None and g_on[n] is None:
+                continue
+            self.assertIsNotNone(g_on[n], f"{attn_mode}: ON missing grad {n}")
+            self.assertIsNotNone(g_off[n], f"{attn_mode}: OFF missing grad {n}")
+            rel = H._rel(g_on[n], g_off[n])
+            self.assertLess(
+                rel, GRAD_RTOL, f"{attn_mode} sink={sink}: grad[{n}] rel={rel}"
+            )
+            reforwarded += 1
+        self.assertGreater(reforwarded, 0, f"{attn_mode}: no grads compared")
+        print(
+            f"[cp-recompute cp{H.CP_SIZE} rank{H.CP_RANK}] {attn_mode} "
+            f"sink={sink}: fwd={H._rel(out_on, out_off):.2e} "
+            f"grads_ok={reforwarded}",
+            flush=True,
+        )
+
+    def test_mha_recompute_cp(self):
+        self._check("mha", H._row_end([128], 128))
+
+    @H.U._GPU
+    def test_mqa_recompute_cp(self):
+        # documents straddle the CP=2/4 rank boundaries so the CP-global index
+        # table (sliced per rank) is genuinely exercised on the re-forward.
+        self._check("mqa", H._row_end([200, 150, 162], 512))
+
+    @H.U._GPU
+    def test_mqa_dsa_recompute_cp(self):
+        self._check("mqa_dsa", H._row_end([200, 150, 162], 512))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/multi_card_tests/transformer/test_mqa_dsa_cp.py
+++ b/tests/multi_card_tests/transformer/test_mqa_dsa_cp.py
@@ -1,0 +1,540 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Context parallel for the ``non_absorbed_mqa`` hybrid-MLA core attention.
+
+Gold standard: a CP=N :class:`MQALatentAttention` must reproduce the CP=1
+reference on its own query slice -- forward output, input gradients and every
+parameter gradient (after the SUM all-reduce over the CP group) -- given the
+same weights and the same global packed batch.
+
+The layer takes its CP state from ``pg_collection.cp`` alone, so a reference and
+a CP layer coexist in one process: the reference gets ``cp=None``.
+``ContextParallelAllGatherOp`` however reads the *process-global* fleet CP group
+(``context_parallel_utils.py:570-578``), which is fine because the fleet hybrid
+config below sets ``cp_degree == world_size``.
+
+Covered here (see ``test_mla_cp_contiguous_allgather.py`` for the MHA layer and
+the full-MLA integration):
+
+1. ``non_absorbed_mqa_dense`` (``indexer is None``) equivalence.
+2. ``non_absorbed_mqa`` + DSA equivalence, single and multi document, including
+   a document that straddles a rank boundary.
+3. The indexer's RoPE under CP -- ``DSAIndexer.forward_before_topk`` must be
+   **bitwise** equal to the global call, sliced. This is the load-bearing rope
+   check: Q takes ``freqs[position_offset : position_offset + s]`` while K is
+   all-gathered right after ``wk`` and rope'd with the full ``freqs``.
+4. The selected column set: the sparse kernel's ``token_indices`` under CP must
+   equal the reference's rows for this rank.
+5. Indexer-loss normalisation, masked (global denominator) and unmasked
+   (``/cp_size``), and the widened ``dsa_indexer_use_sparse_loss=False`` table.
+6. The attention sink under CP.
+7. The ``cp_balance_mode`` guard.
+
+Run (2 GPUs)::
+
+    PYTHONPATH=./third_party/PaddleFleet/src python -m paddle.distributed.launch \
+        --devices 0,1 --nnodes 1 --master 127.0.0.1:<port> \
+        third_party/PaddleFleet/tests/multi_card_tests/transformer/test_mqa_dsa_cp.py
+"""
+
+import os
+import sys
+import types
+import unittest
+
+import numpy as np
+import paddle
+import paddle.distributed as dist
+from paddle.distributed import fleet
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(
+    0,
+    os.path.normpath(
+        os.path.join(_HERE, "..", "..", "single_card_tests", "transformer")
+    ),
+)
+
+import hybrid_mla_utils as U
+
+CP_SIZE = None
+CP_RANK = None
+CP_GROUP = None
+
+# bf16 tolerances. The all-gather/reduce-scatter reorders bf16 reductions and
+# ``csa_sparse_attn_bwd_cudnn`` accumulates ``dkv`` atomically (a ~2e-3
+# run-to-run property of the kernel itself, not of CP), so gradients get a
+# looser bound than the forward.
+FWD_RTOL = 5e-3
+GRAD_RTOL = 2e-2
+
+# s_global for the equivalence runs. 512 keeps the O(s^2) dense-mode index table
+# small and stays inside the regime where the top-k support set is bit
+# reproducible, so the index-set test below can demand exact equality.
+S_GLOBAL = 512
+
+
+def setUpModule():
+    global CP_SIZE, CP_RANK, CP_GROUP
+    if dist.get_world_size() < 2:
+        raise unittest.SkipTest("MQA context-parallel tests require >= 2 GPUs")
+    world = dist.get_world_size()
+    strategy = fleet.DistributedStrategy()
+    strategy.hybrid_configs = {
+        "dp_degree": 1,
+        "mp_degree": 1,
+        "pp_degree": 1,
+        "sharding_degree": world,
+        "sep_degree": 1,
+        "cp_degree": world,
+        "ep_degree": world,
+        "moe_sharding_degree": 1,
+        "order": [
+            "sharding",
+            "moe_sharding",
+            "pp",
+            "sep",
+            "cp",
+            "dp",
+            "ep",
+            "mp",
+        ],
+    }
+    fleet.init(is_collective=True, strategy=strategy)
+    CP_GROUP = fleet.get_hybrid_communicate_group().get_context_parallel_group()
+    CP_RANK = CP_GROUP.rank
+    CP_SIZE = CP_GROUP.nranks
+
+
+def _build(mode, cp_group, loss_coeff=0.0, sink=None, sparse_loss=True, seed=7):
+    """CP=1 reference (``cp_group is None``) or CP layer, identical weights."""
+    cfg = U._create_mqa_config(mode=mode, loss_coeff=loss_coeff)
+    cfg.dsa_indexer_use_sparse_loss = sparse_loss
+    cfg.cp_balance_mode = "contiguous_allgather"
+    # Production EB dataflow hands every rank the *global* input_ids, which is
+    # what ``_indexer_loss_mask`` assumes when this flag is set
+    # (same branch as csa_attention.py:2419-2428).
+    cfg.experimental_dataflow = True
+    cfg.pad_token_id = 0
+    cfg.context_parallel_size = 1 if cp_group is None else cp_group.nranks
+    paddle.seed(seed)
+    return U._build_module(
+        cfg,
+        bf16=True,
+        sink=sink,
+        pg_collection=types.SimpleNamespace(tp=None, cp=cp_group),
+    )
+
+
+def _inputs(s_global, seed=1234):
+    """Global-length inputs, bitwise identical on every rank.
+
+    ``paddle.randn`` would also agree across identical devices, but numpy makes
+    that independent of the device RNG state, which the two module builds move.
+    """
+    rng = np.random.RandomState(seed)
+
+    def t(shape, scale):
+        return paddle.to_tensor(
+            (rng.standard_normal(shape) * scale).astype("float32")
+        ).cast("bfloat16")
+
+    return {
+        "query": t([1, s_global, U.H, U.DK], 0.5),
+        "key": t([1, s_global, 1, U.DK], 0.5),
+        "w_v": t([U.DV, U.H, U.V_HEAD_DIM], 0.05),
+        "x": t([1, s_global, U.HIDDEN], 0.5),
+        "qr": t([1, s_global, U.Q_LORA], 0.5),
+    }
+
+
+def _input_ids(s_global, n_pad=37):
+    """``[1, s_global]`` int64 with a padded tail, so the row mask is non-trivial.
+
+    ``n_pad`` is deliberately not a multiple of ``s_global / cp_size``: the pad
+    rows must land on the last rank only, which is exactly the asymmetry that
+    catches a per-rank (instead of global) loss denominator.
+    """
+    ids = np.arange(1, s_global + 1, dtype="int64")
+    ids[s_global - n_pad :] = 0
+    return paddle.to_tensor(ids).reshape([1, s_global])
+
+
+def _leaf(t):
+    out = t.clone().detach()
+    out.stop_gradient = False
+    return out
+
+
+def _rel(a, e):
+    a = a.cast("float32").flatten()
+    e = e.cast("float32").flatten()
+    return float((a - e).norm() / e.norm().clip(min=1e-12))
+
+
+def run_core_cp(
+    mode,
+    doc_lens,
+    s_global=S_GLOBAL,
+    loss_coeff=0.0,
+    sink=None,
+    with_input_ids=False,
+    sparse_loss=True,
+):
+    """CP=1 reference then CP layer, on the same global batch.
+
+    ``attn_mask_startend_row_indices`` is handed to *both* at the global length,
+    which is what the layer sees in production (``dsv4_hybrid_attention.py:634``
+    for the HCA layers, and the all-gathered ``kv_s`` for the MLA ones).
+    ``input_ids`` is global too (``experimental_dataflow``).
+    """
+    sl = s_global // CP_SIZE
+    off = CP_RANK * sl
+    row_end = U._row_end(doc_lens, s_global)
+    inp = _inputs(s_global)
+    ids = _input_ids(s_global) if with_input_ids else None
+
+    ref = _build(mode, None, loss_coeff, sink, sparse_loss)
+    cpl = _build(mode, CP_GROUP, loss_coeff, sink, sparse_loss)
+    cpl.set_state_dict(ref.state_dict())
+
+    U._CAPTURED.clear()
+    ra = {k: _leaf(v) for k, v in inp.items()}
+    oa = ref(
+        ra["query"],
+        ra["key"],
+        None,
+        None,
+        attn_mask_startend_row_indices=row_end.clone(),
+        x=ra["x"],
+        qr=ra["qr"],
+        v_b_proj_weight=ra["w_v"],
+        input_ids=ids,
+    )
+    oa.sum().backward()
+    idx_ref = U._CAPTURED[-1]
+
+    U._CAPTURED.clear()
+    rb = {
+        "query": _leaf(inp["query"][:, off : off + sl]),
+        "key": _leaf(inp["key"][:, off : off + sl]),
+        "w_v": _leaf(inp["w_v"]),
+        "x": _leaf(inp["x"][:, off : off + sl]),
+        "qr": _leaf(inp["qr"][:, off : off + sl]),
+    }
+    ob = cpl(
+        rb["query"],
+        rb["key"],
+        None,
+        None,
+        attn_mask_startend_row_indices=row_end.clone(),
+        x=rb["x"],
+        qr=rb["qr"],
+        v_b_proj_weight=rb["w_v"],
+        input_ids=ids,
+    )
+    ob.sum().backward()
+    idx_cp = U._CAPTURED[-1]
+
+    # Parameter grads: this rank only saw its own query rows, so the CP group's
+    # SUM is the reference. (``loss_coeff == 0`` leaves the indexer out of the
+    # graph entirely, so only ``softmax_offset`` shows up there.)
+    ref_named = dict(ref.named_parameters())
+    param_err = {}
+    for n, p in cpl.named_parameters():
+        if p.grad is None:
+            continue
+        g = p.grad.contiguous()
+        dist.all_reduce(g, group=CP_GROUP)
+        rg = ref_named[n].grad
+        param_err[n] = None if rg is None else _rel(g, rg)
+
+    # ``w_v`` is a plain input tensor shared by every row, so it reduces the same
+    # way; ``query``/``key``/``x``/``qr`` are per-row and compare sliced. ``key``
+    # goes through the all-gather, whose backward reduce-scatters the global
+    # ``dkv`` back to this rank's slice -- that is the interesting one.
+    dw = rb["w_v"].grad.contiguous()
+    dist.all_reduce(dw, group=CP_GROUP)
+    per_pos = (
+        (ob.cast("float32") - oa[:, off : off + sl].cast("float32"))
+        .abs()
+        .max(axis=-1)
+        .flatten()
+        .tolist()
+    )
+    return {
+        "fwd": _rel(ob, oa[:, off : off + sl]),
+        "dq": _rel(rb["query"].grad, ra["query"].grad[:, off : off + sl]),
+        "dkv": _rel(rb["key"].grad, ra["key"].grad[:, off : off + sl]),
+        "dw": _rel(dw, ra["w_v"].grad),
+        "param_err": param_err,
+        "per_pos": per_pos,
+        "idx_ref_slice": idx_ref[:, off : off + sl],
+        "idx_cp": idx_cp,
+    }
+
+
+def _row_sets(idx):
+    """Per-row set of selected columns, dropping the ``-1`` padding."""
+    return [{int(c) for c in row if c >= 0} for row in idx[0]]
+
+
+# Documents chosen so that every one of them straddles a rank boundary for both
+# cp=2 (boundary 256) and cp=4 (128/256/384): [0,200) [200,350) [350,512).
+_STRADDLE = [200, 150, 162]
+
+
+class TestMQADSACP(unittest.TestCase):
+    """A CP=N layer must reproduce the CP=1 reference on its own query slice."""
+
+    def _check(self, res, tag):
+        self.assertLess(
+            res["fwd"], FWD_RTOL, f"{tag}: forward {res['fwd']:.3e}"
+        )
+        for key in ("dq", "dkv", "dw"):
+            self.assertLess(res[key], GRAD_RTOL, f"{tag}: {key} {res[key]:.3e}")
+        for name, err in res["param_err"].items():
+            self.assertIsNotNone(
+                err, f"{tag}: reference has no grad for {name}"
+            )
+            self.assertLess(err, GRAD_RTOL, f"{tag}: param {name} {err:.3e}")
+        worst = max(res["param_err"].values(), default=0.0)
+        print(
+            f"[cp{CP_SIZE} rank{CP_RANK}] {tag}: fwd={res['fwd']:.2e} "
+            f"dq={res['dq']:.2e} dkv={res['dkv']:.2e} dw={res['dw']:.2e} "
+            f"param_max={worst:.2e} "
+            f"per_pos_max={max(res['per_pos']):.3e}",
+            flush=True,
+        )
+
+    def _check_index_sets(self, res, tag):
+        """The sparse kernel must be handed the reference's own columns.
+
+        Column ids are *global* on both sides (the CP layer indexes the
+        all-gathered ``kv``), so this is a plain set equality per row -- no
+        offset arithmetic. Set equality rather than sequence equality because
+        the top-k order churns; see the top-k reproducibility audit.
+        """
+        ref_sets = _row_sets(res["idx_ref_slice"])
+        cp_sets = _row_sets(res["idx_cp"])
+        self.assertEqual(len(ref_sets), len(cp_sets), f"{tag}: row count")
+        for row, (want, got) in enumerate(zip(ref_sets, cp_sets)):
+            self.assertEqual(
+                got,
+                want,
+                f"{tag}: row {row} (global {CP_RANK * len(ref_sets) + row}) "
+                f"selected a different column set: "
+                f"missing={sorted(want - got)[:8]} "
+                f"extra={sorted(got - want)[:8]}",
+            )
+
+    # ------------------------------------------------------------------
+    # 1. dense path (``indexer is None``)
+    # ------------------------------------------------------------------
+    @U._GPU
+    def test_1_dense_single_doc(self):
+        res = run_core_cp("mqa", [S_GLOBAL])
+        self._check(res, "dense/1doc")
+
+    @U._GPU
+    def test_2_dense_straddling_docs(self):
+        """The full-causal index table is built at ``s_global`` then row-sliced.
+
+        A per-rank build would clip every row at ``q - position_offset``, i.e.
+        drop the whole prefix owned by lower ranks, which shows up here as an
+        O(1) forward error on rank > 0.
+        """
+        res = run_core_cp("mqa", _STRADDLE)
+        self._check(res, "dense/3doc")
+        self._check_index_sets(res, "dense/3doc")
+
+    # ------------------------------------------------------------------
+    # 2. DSA path
+    # ------------------------------------------------------------------
+    @U._GPU
+    def test_3_dsa_single_doc(self):
+        res = run_core_cp("mqa_dsa", [S_GLOBAL])
+        self._check(res, "dsa/1doc")
+        self._check_index_sets(res, "dsa/1doc")
+
+    @U._GPU
+    def test_4_dsa_straddling_docs(self):
+        res = run_core_cp("mqa_dsa", _STRADDLE)
+        self._check(res, "dsa/3doc")
+        self._check_index_sets(res, "dsa/3doc")
+
+    @U._GPU
+    def test_5_dsa_sink(self):
+        """The sink is a per-head logit, independent of the query's position.
+
+        Its gradient is accumulated per row, so the CP group's SUM must match
+        the reference -- covered by ``param_err['softmax_offset']``.
+        """
+        sink = np.linspace(-1.0, 1.0, U.H)
+        res = run_core_cp("mqa_dsa", _STRADDLE, sink=sink)
+        self._check(res, "dsa/sink")
+        self.assertIn(
+            "softmax_offset",
+            res["param_err"],
+            "the sink must receive a gradient under CP",
+        )
+
+    # ------------------------------------------------------------------
+    # 3. the indexer's RoPE -- the load-bearing check
+    # ------------------------------------------------------------------
+    @U._GPU
+    def test_6_indexer_rope_under_cp(self):
+        """``forward_before_topk`` under CP == the global call, sliced.
+
+        Q is rope'd with ``freqs[position_offset : position_offset + s]`` while
+        K is all-gathered right after ``wk`` and rope'd with the *full*
+        ``freqs``, so a positional off-by-``position_offset`` on either side is
+        invisible in the shapes and only shows up numerically. The control at
+        the end feeds ``position_offset=0`` on purpose to prove this comparison
+        actually has the power to see a wrong offset.
+        """
+        sl = S_GLOBAL // CP_SIZE
+        off = CP_RANK * sl
+        inp = _inputs(S_GLOBAL)
+        ref = _build("mqa_dsa", None)
+        cpl = _build("mqa_dsa", CP_GROUP)
+        cpl.set_state_dict(ref.state_dict())
+
+        with paddle.no_grad():
+            q_r, k_r, w_r = ref.indexer.forward_before_topk(inp["x"], inp["qr"])
+            q_c, k_c, w_c = cpl.indexer.forward_before_topk(
+                inp["x"][:, off : off + sl],
+                inp["qr"][:, off : off + sl],
+                off,
+                CP_GROUP,
+            )
+
+        # K must come back at the *global* length: the top-k scores every
+        # global column, so a sharded K would silently truncate the support.
+        self.assertEqual(
+            list(k_c.shape),
+            list(k_r.shape),
+            "K must be all-gathered to the global length",
+        )
+        self.assertEqual(int(q_c.shape[1]), sl, "Q must stay sharded")
+
+        errs = {}
+        for name, got, want in (
+            ("q", q_c, q_r[:, off : off + sl]),
+            ("k", k_c, k_r),
+            ("w", w_c, w_r[:, off : off + sl]),
+        ):
+            a = got.cast("float32")
+            e = want.cast("float32")
+            errs[name] = float((a - e).abs().max())
+            scale = max(float(e.abs().max()), 1.0)
+            self.assertLess(
+                errs[name],
+                1e-3 * scale,
+                f"indexer {name}: max|diff|={errs[name]:.3e} "
+                f"(scale {scale:.3e})",
+            )
+        print(
+            f"[cp{CP_SIZE} rank{CP_RANK}] indexer rope max|diff| "
+            f"q={errs['q']:.3e} k={errs['k']:.3e} w={errs['w']:.3e}",
+            flush=True,
+        )
+
+        # ``forward_before_topk`` all-gathers K, so the control call must be
+        # issued on *every* rank even though only rank > 0 can observe a
+        # difference. Skipping it on rank 0 would leave the CP group's
+        # collective streams off by one and deadlock the next test.
+        with paddle.no_grad():
+            q_bad, _, _ = cpl.indexer.forward_before_topk(
+                inp["x"][:, off : off + sl],
+                inp["qr"][:, off : off + sl],
+                0,
+                CP_GROUP,
+            )
+        if CP_RANK == 0:
+            return
+        bad = float(
+            (q_bad.cast("float32") - q_r[:, off : off + sl].cast("float32"))
+            .abs()
+            .max()
+        )
+        self.assertGreater(
+            bad,
+            100.0 * max(errs["q"], 1e-6),
+            "position_offset=0 was indistinguishable from the correct offset, "
+            f"so this check is vacuous (good={errs['q']:.3e} bad={bad:.3e})",
+        )
+        print(
+            f"[cp{CP_SIZE} rank{CP_RANK}] rope control: wrong offset gives "
+            f"{bad:.3e} vs {errs['q']:.3e}",
+            flush=True,
+        )
+
+    # ------------------------------------------------------------------
+    # 4. indexer-loss normalisation
+    # ------------------------------------------------------------------
+    @U._GPU
+    def test_7_indexer_loss_normalisation(self):
+        """With ``loss_coeff > 0`` the indexer joins the backward graph.
+
+        That makes its parameter gradients the observable for the loss
+        denominator: masked rows divide by the *global* valid-row count and
+        unmasked rows by ``cp_size``, so in both cases the CP group's SUM has
+        to land on the CP=1 reference. A per-rank denominator is off by
+        ``cp_size`` (or by the pad imbalance, which ``_input_ids`` puts on the
+        last rank only) and fails here.
+        """
+        for masked, sparse in ((True, True), (False, True), (True, False)):
+            with self.subTest(masked=masked, sparse_loss=sparse):
+                res = run_core_cp(
+                    "mqa_dsa",
+                    _STRADDLE,
+                    loss_coeff=0.1,
+                    with_input_ids=masked,
+                    sparse_loss=sparse,
+                )
+                self.assertTrue(
+                    any(n.startswith("indexer.") for n in res["param_err"]),
+                    "the indexer must receive gradients when loss_coeff > 0",
+                )
+                self._check(res, f"loss/masked={masked}/sparse={sparse}")
+
+    # ------------------------------------------------------------------
+    # 5. the HCA-compatibility guard
+    # ------------------------------------------------------------------
+    def test_8_cp_balance_mode_guard(self):
+        """Only ``contiguous_allgather`` is implemented.
+
+        The hybrid model's HCA layers assert the same mode
+        (``dsv4_hybrid_attention.py:607-611``); the MQA layer must refuse the
+        others rather than silently attend against a permuted KV.
+        """
+        cfg = U._create_mqa_config(mode="mqa_dsa")
+        cfg.context_parallel_size = CP_SIZE
+        for mode in ("p2p", "zigzag", None):
+            with self.subTest(cp_balance_mode=mode):
+                cfg.cp_balance_mode = mode
+                with self.assertRaises(NotImplementedError):
+                    U._build_module(
+                        cfg,
+                        bf16=True,
+                        pg_collection=types.SimpleNamespace(
+                            tp=None, cp=CP_GROUP
+                        ),
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/single_card_tests/transformer/hybrid_mla_utils.py
+++ b/tests/single_card_tests/transformer/hybrid_mla_utils.py
@@ -205,7 +205,22 @@ class RecordingMQA(MQALatentAttention):
         return super()._sparse_attn(query, kv, token_indices, sm_scale, d_v)
 
 
-def _build_module(config, layer_number=1, bf16=False, sink=None, is_mtp=False):
+def _build_module(
+    config,
+    layer_number=1,
+    bf16=False,
+    sink=None,
+    is_mtp=False,
+    pg_collection=None,
+):
+    """Build a ``RecordingMQA``.
+
+    ``pg_collection`` must be passed explicitly by the context-parallel tests
+    (``tests/multi_card_tests/transformer/test_mqa_dsa_cp.py``): left ``None``
+    the layer falls back to ``ProcessGroupCollection.use_mpu_process_groups()``,
+    which inside a ``fleet.init``-ed process would hand the CP=1 reference the
+    real CP group.
+    """
     indexer = None
     if getattr(config, "_build_dsa_indexer", False):
         indexer = LayerSpec(
@@ -226,6 +241,7 @@ def _build_module(config, layer_number=1, bf16=False, sink=None, is_mtp=False):
         attention_type="self",
         k_channels=K_CHANNELS,
         is_mtp_layer=is_mtp,
+        pg_collection=pg_collection,
     )
     if bf16:
         # ``rotate_activation`` asserts bf16 inputs, so the indexer projections

--- a/tests/test_configs.yaml
+++ b/tests/test_configs.yaml
@@ -147,6 +147,18 @@ tests:
   - test_case: [tests/multi_card_tests/transformer/test_csa_attention_cp.py]
     products:
       - num_gpus: 2
+  # transformer: non_absorbed_mqa (+DSA) context-parallel core attention (CP=2)
+  - test_case: [tests/multi_card_tests/transformer/test_mqa_dsa_cp.py]
+    products:
+      - num_gpus: 2
+  # transformer: hybrid-MLA (MHA/MQA) contiguous_allgather context-parallel (CP=2)
+  - test_case: [tests/multi_card_tests/transformer/test_mla_cp_contiguous_allgather.py]
+    products:
+      - num_gpus: 2
+  # transformer: hybrid-MLA context-parallel recompute equivalence (CP=2)
+  - test_case: [tests/multi_card_tests/transformer/test_mla_cp_recompute.py]
+    products:
+      - num_gpus: 2
   # default fallback for remaining multi_card_tests
   - test_case: [tests/multi_card_tests/pipeline_parallel/*.py]
     products:


### PR DESCRIPTION
### PR Category

Operator Mechanism

### PR Types

New features

### Description

The `csa_compress_ratios == -2` hybrid-MLA layers had no context-parallel
support: `MQALatentAttention` raised `NotImplementedError` whenever
`cp_size > 1`, and `DSAIndexer.forward_before_topk` built its RoPE at the
rank-local length, so the indexer would have silently mis-positioned every
rank > 0. HCA/CSA already implement `contiguous_allgather` CP
(`dsv4_hybrid_attention.py:607-611`, `csa_attention.py:2609-2728`), so this
makes the MLA family match it **without touching the HCA path**.

#### Design (identical to CSA's)

Keep Q sharded, all-gather the low-dimensional projected KV to the global
sequence length, attend against the full KV, emit a sharded output. There is
no output reduce-scatter, so the layer stays a drop-in replacement.

#### `dsa_attention.py`

`forward_before_topk(self, hidden_states, q_latent, position_offset=0, cp_group=None)`
(`:426-511`): RoPE frequencies are built at `seqlen * cp_size`; Q takes the
`[position_offset, position_offset + seqlen)` slice while K is all-gathered to
the global length. The gather is placed right after `wk` (128 dims) rather
than on `hidden_states` — 32x less traffic, and valid because `k_norm`,
`_apply_rope` and `rotate_activation` are all per-token and therefore commute
with a sequence-dim gather.

#### `mqa_latent_attention.py`

- Derive `cp_group` / `cp_size` / `cp_rank` from `pg_collection.cp` in
  `__init__` (`:162-188`); only `contiguous_allgather` is accepted, every
  other balance mode raises `NotImplementedError` exactly like HCA.
- `forward` (`:293-341`) computes `s_global = s * cp_size` and
  `position_offset = cp_rank * s`, then all-gathers the latent KV.
- `_build_full_causal_indices` / `_indexer_valid_range` build their tables at
  the **global** `s_global` and only then slice the local rows. Clipping at
  the rank-local row index instead would drop the prefix owned by lower ranks
  and show up as an O(1) forward error on rank > 0.
- `position_offset` is passed into the indexer and as `seq_offset` into
  `cudnn_indexer_topk_fwd`; the indexer-loss `valid_rows` are counted on the
  global mask and the unmasked branch normalises by `indexer_loss_coeff /
  cp_size` so the loss magnitude is CP-degree invariant.

#### Tests

New `tests/multi_card_tests/transformer/`, registered at `num_gpus: 2` in
`tests/test_configs.yaml`. All kernel cases are guarded by the shared SM100
availability skip in `hybrid_mla_utils.py`, so they skip cleanly on the cc9.0
CI runner.

- `test_mqa_dsa_cp.py` (8 cases) — core-attention CP=1 vs CP=N equivalence for
  dense MQA, DSA, DSA+sink; per-row equality of the selected **global** column
  sets; indexer RoPE precision with a self-calibrating wrong-offset control;
  indexer-loss normalisation; and the balance-mode guard.
- `test_mla_cp_contiguous_allgather.py` (+4 cases) — whole-layer equivalence,
  which is what covers the shared MLA RoPE CP scatter
  (`multi_latent_attention.py:1485-1545`), the runtime absorption (`:1913-1939`),
  `o_proj`, and every parameter gradient after the CP all-reduce. The stale
  "MQA rejects CP" case is replaced by the equivalence proof plus an explicit
  guard test for the other balance modes.
- `test_mla_cp_recompute.py` (3 cases) — recompute ON == OFF under CP. This is
  load-bearing: the DSA `token_indices` are selected from the CP-global index
  table, and if the recompute re-forward re-derived a *different* sparsity
  pattern the backward would differentiate the wrong function with no error.

#### Measured (8x SM100, CP=2 and CP=4)

The whole-layer forward and the indexer RoPE are **bit-identical** to the CP=1
reference on every rank, in all three modes (per-position max abs diff = 0).
The wrong-offset control gives 3.7e-1, so the check is not vacuous. Residuals
appear only in the input gradient (the all-gather's reduce-scatter backward)
and in the CP all-reduced parameter gradients, at 2.3e-3 (CP=2) to 4.6e-3
(CP=4) relative L2 — bf16 reduction reordering, growing with the depth of the
reduction tree as expected. The global grad-norm ratio CP=N / CP=1 is
1.00 +/- 0.05, ruling out a loss-scaling or averaging bug. Recompute ON vs OFF
is bit-exact on the forward with all gradients within 5e-3.

The 16 single-card hybrid-MLA suites were re-run at CP=1 and are unchanged.
Merged in dev: #1235
