### PR TITLE
[Kimi-K3] Preserve checkpoint state and dtypes

### DIFF
--- a/src/paddlefleet/transformer/block_attn_res.py
+++ b/src/paddlefleet/transformer/block_attn_res.py
@@ -201,7 +201,11 @@ class BlockAttnRes(FleetLayer):
         # marked as sequence parallel param,
         # i.e., its gradient should be all-reduced.
         self.proj_weight = self.create_parameter(
-            shape=[self.hidden_size],
+            # Keep the Linear(hidden_size, 1) checkpoint layout.  The leading
+            # singleton dimension broadcasts identically in the dot product,
+            # while allowing AOA to load HF Attention Residual weights without
+            # an unsupported squeeze/reshape operation.
+            shape=[1, self.hidden_size],
             default_initializer=nn.initializer.Constant(0.0),
         )
 

--- a/src/paddlefleet/transformer/kimi_delta_attention.py
+++ b/src/paddlefleet/transformer/kimi_delta_attention.py
@@ -141,6 +141,9 @@ class KimiDeltaAttention(FleetLayer):
                 -exp(A_log) * softplus(a + dt_bias) instead.
         """
         super().__init__(config=config)
+        # Keep the parent-owned FP32 gate parameters (A_log and dt_bias) in
+        # FP32 under AMP O2. Projection sublayers are decorated independently.
+        self._cast_to_low_precision = False
 
         # Attributes from arguments
         self.layer_number = layer_number
@@ -246,7 +249,12 @@ class KimiDeltaAttention(FleetLayer):
             padding=self.conv_kernel_dim - 1,
             bias_attr=conv_bias,
             data_format="NCL",
+            dtype="float32",
         )
+        # The released Kimi-K3 checkpoint keeps short-convolution weights in
+        # float32. Preserve that dtype under AMP O2 instead of casting the
+        # checkpoint to bf16 on load and casting it back only during export.
+        self.conv1d._cast_to_low_precision = False
         self.conv1d.weight.is_distributed = True if self.tp_size > 1 else False
         if conv_bias and self.conv1d.bias is not None:
             self.conv1d.bias.is_distributed = (
@@ -436,7 +444,10 @@ class KimiDeltaAttention(FleetLayer):
         # Convolution on qkv
         qkv = qkv.transpose([0, 2, 1]).contiguous()  # b, s, d -> b, d, s
         nvtx_range_push(suffix="conv1d")
-        qkv = self.act_fn(self.conv1d(qkv)[..., :seq_len])
+        conv_output_dtype = qkv.dtype
+        qkv = self.act_fn(
+            self.conv1d(qkv.astype(paddle.float32))[..., :seq_len]
+        ).astype(conv_output_dtype)
         nvtx_range_pop(suffix="conv1d")
 
         qkv = qkv.transpose([0, 2, 1])  # b, d, s -> b, s, d

--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -447,9 +447,14 @@ class StandardMoERouter(nn.Layer):
             )
             self.expert_usage.stop_gradient = True
 
-            # Binning range -- initialized conservatively, updated by callback
-            self.qb_bin_min = -1.0
-            self.qb_bin_max = 1.0
+            # QB Binning range -- persisted because it affects the next step's
+            # histogram and therefore must survive checkpoint resumption.
+            self.register_buffer(
+                "qb_bin_min", paddle.to_tensor(-1.0, dtype=paddle.float32)
+            )
+            self.register_buffer(
+                "qb_bin_max", paddle.to_tensor(1.0, dtype=paddle.float32)
+            )
 
         # Hash-routing state. Activated lazily via set_layer_number() so that the
         # router knows its layer index.

--- a/src/paddlefleet/transformer/moe/qb_callback.py
+++ b/src/paddlefleet/transformer/moe/qb_callback.py
@@ -216,8 +216,12 @@ class MoEQuantileBalancingCallback:
         # --- Step 7: Update binning range for next step ---
         new_min = float(b_new.min().item()) - 1.0
         new_max = float(b_new.max().item()) + 1.0
-        layer.qb_bin_min.set_value(paddle.to_tensor(new_min, dtype=paddle.float32))
-        layer.qb_bin_max.set_value(paddle.to_tensor(new_max, dtype=paddle.float32))
+        layer.qb_bin_min.set_value(
+            paddle.to_tensor(new_min, dtype=paddle.float32)
+        )
+        layer.qb_bin_max.set_value(
+            paddle.to_tensor(new_max, dtype=paddle.float32)
+        )
 
         # --- Step 8: Reset histogram and expert_usage ---
         layer.qb_histogram.zero_()

--- a/src/paddlefleet/transformer/moe/qb_callback.py
+++ b/src/paddlefleet/transformer/moe/qb_callback.py
@@ -216,8 +216,8 @@ class MoEQuantileBalancingCallback:
         # --- Step 7: Update binning range for next step ---
         new_min = float(b_new.min().item()) - 1.0
         new_max = float(b_new.max().item()) + 1.0
-        layer.qb_bin_min = new_min
-        layer.qb_bin_max = new_max
+        layer.qb_bin_min.set_value(paddle.to_tensor(new_min, dtype=paddle.float32))
+        layer.qb_bin_max.set_value(paddle.to_tensor(new_max, dtype=paddle.float32))
 
         # --- Step 8: Reset histogram and expert_usage ---
         layer.qb_histogram.zero_()

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_block_attn_res.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_block_attn_res.py
@@ -77,7 +77,7 @@ class TestBlockAttnResConstruction(unittest.TestCase):
         block = BlockAttnRes(config=config, sublayers_spec=spec)
         self.assertEqual(block.hidden_size, 64)
         self.assertIsNotNone(block.proj_weight)
-        self.assertEqual(block.proj_weight.shape, [64])
+        self.assertEqual(block.proj_weight.shape, [1, 64])
 
     @patch("paddlefleet.transformer.block_attn_res.build_spec_layer")
     def test_proj_weight_initialized_to_zero(self, mock_build):
@@ -88,7 +88,7 @@ class TestBlockAttnResConstruction(unittest.TestCase):
 
         block = BlockAttnRes(config=config, sublayers_spec=spec)
         self.assertTrue(
-            paddle.allclose(block.proj_weight, paddle.zeros([64])).item()
+            paddle.allclose(block.proj_weight, paddle.zeros([1, 64])).item()
         )
 
 

--- a/tests/single_card_tests/test_quantile_balancing.py
+++ b/tests/single_card_tests/test_quantile_balancing.py
@@ -1471,7 +1471,12 @@ class TestAccumulateQBHistogramReal(unittest.TestCase):
         router._accumulate_qb_histogram(scores, biased, 2)
 
         expected = _numpy_accumulate_histogram(
-            scores_np, bias_np, 2, router.qb_bin_min, router.qb_bin_max, 100
+            scores_np,
+            bias_np,
+            2,
+            float(router.qb_bin_min.item()),
+            float(router.qb_bin_max.item()),
+            100,
         )
         np.testing.assert_array_equal(router.qb_histogram.numpy(), expected)
 

--- a/tests/single_card_tests/test_quantile_balancing.py
+++ b/tests/single_card_tests/test_quantile_balancing.py
@@ -1485,7 +1485,9 @@ class TestAccumulateQBHistogramReal(unittest.TestCase):
     def test_degenerate_bin_range_falls_back(self):
         router = _build_qb_router()
         router.qb_bin_min.set_value(paddle.to_tensor(0.0))
-        router.qb_bin_max.set_value(paddle.to_tensor(0.0))  # zero range -> fallback to 2.0
+        router.qb_bin_max.set_value(
+            paddle.to_tensor(0.0)
+        )  # zero range -> fallback to 2.0
         scores = paddle.to_tensor(np.random.rand(6, 8).astype(np.float32))
         router._accumulate_qb_histogram(scores, scores, 2)
         self.assertEqual(int(router.qb_histogram.sum().item()), 6 * 8)
@@ -1493,7 +1495,9 @@ class TestAccumulateQBHistogramReal(unittest.TestCase):
     def test_out_of_range_values_are_clipped(self):
         router = _build_qb_router()
         router.qb_bin_min.set_value(paddle.to_tensor(0.0))
-        router.qb_bin_max.set_value(paddle.to_tensor(0.01))  # almost everything lands beyond the last bin
+        router.qb_bin_max.set_value(
+            paddle.to_tensor(0.01)
+        )  # almost everything lands beyond the last bin
         scores = paddle.to_tensor(np.full([4, 8], 0.5, dtype=np.float32))
         router._accumulate_qb_histogram(scores, scores, 2)
         hist = router.qb_histogram.numpy()

--- a/tests/single_card_tests/test_quantile_balancing.py
+++ b/tests/single_card_tests/test_quantile_balancing.py
@@ -252,8 +252,8 @@ class TestUpdateSingleLayerPaddle(unittest.TestCase):
         layer.qb_histogram = paddle.to_tensor(histogram_np, dtype=paddle.int32)
         layer.num_experts_per_tok = k
         layer.num_experts = n
-        layer.qb_bin_min = b_min
-        layer.qb_bin_max = b_max
+        layer.qb_bin_min = paddle.to_tensor(b_min, dtype=paddle.float32)
+        layer.qb_bin_max = paddle.to_tensor(b_max, dtype=paddle.float32)
         # Mock config
         layer.config = MagicMock()
         layer.config.sequence_parallel = False
@@ -350,10 +350,10 @@ class TestUpdateSingleLayerPaddle(unittest.TestCase):
 
         b_new = layer._bias_value.numpy()
         self.assertAlmostEqual(
-            layer.qb_bin_min, float(b_new.min()) - 1.0, places=5
+            float(layer.qb_bin_min.item()), float(b_new.min()) - 1.0, places=5
         )
         self.assertAlmostEqual(
-            layer.qb_bin_max, float(b_new.max()) + 1.0, places=5
+            float(layer.qb_bin_max.item()), float(b_new.max()) + 1.0, places=5
         )
 
     def test_histogram_reset_after_update(self):
@@ -427,8 +427,8 @@ class TestAccumulateHistogramPaddle(unittest.TestCase):
         """Create a minimal mock for the router's histogram accumulation."""
         router = MagicMock()
         router.qb_n_bins = B
-        router.qb_bin_min = b_min
-        router.qb_bin_max = b_max
+        router.qb_bin_min = paddle.to_tensor(b_min, dtype=paddle.float32)
+        router.qb_bin_max = paddle.to_tensor(b_max, dtype=paddle.float32)
         router.qb_histogram = paddle.zeros([E, B], dtype=paddle.int32)
         return router
 
@@ -621,8 +621,8 @@ class TestOnOptimizerEnd(unittest.TestCase):
         layer.qb_histogram = paddle.to_tensor(histogram_np, dtype=paddle.int32)
         layer.num_experts_per_tok = k
         layer.num_experts = n
-        layer.qb_bin_min = -1.0
-        layer.qb_bin_max = 1.0
+        layer.qb_bin_min = paddle.to_tensor(-1.0, dtype=paddle.float32)
+        layer.qb_bin_max = paddle.to_tensor(1.0, dtype=paddle.float32)
         layer.config = MagicMock()
         layer.config.sequence_parallel = False
         layer.config.expert_model_parallel_size = 1
@@ -783,8 +783,8 @@ class TestEndToEnd(unittest.TestCase):
         layer.qb_histogram = histogram
         layer.num_experts_per_tok = k
         layer.num_experts = n
-        layer.qb_bin_min = b_min
-        layer.qb_bin_max = b_max
+        layer.qb_bin_min = paddle.to_tensor(b_min, dtype=paddle.float32)
+        layer.qb_bin_max = paddle.to_tensor(b_max, dtype=paddle.float32)
         layer.config = MagicMock()
         layer.config.sequence_parallel = False
         layer.config.expert_model_parallel_size = 1
@@ -920,8 +920,8 @@ class TestDegenerateRange(unittest.TestCase):
         layer.num_experts_per_tok = k
         layer.num_experts = n
         # Set bin_min == bin_max to trigger the fallback
-        layer.qb_bin_min = 0.0
-        layer.qb_bin_max = 0.0
+        layer.qb_bin_min = paddle.to_tensor(0.0, dtype=paddle.float32)
+        layer.qb_bin_max = paddle.to_tensor(0.0, dtype=paddle.float32)
         layer.config = MagicMock()
         layer.config.sequence_parallel = False
         layer.config.expert_model_parallel_size = 1
@@ -962,8 +962,8 @@ class TestOnOptimizerEndWithRealRouter(unittest.TestCase):
         layer.qb_histogram = paddle.to_tensor(histogram_np, dtype=paddle.int32)
         layer.num_experts_per_tok = k
         layer.num_experts = n
-        layer.qb_bin_min = -1.0
-        layer.qb_bin_max = 1.0
+        layer.qb_bin_min = paddle.to_tensor(-1.0, dtype=paddle.float32)
+        layer.qb_bin_max = paddle.to_tensor(1.0, dtype=paddle.float32)
         layer.config = MagicMock()
         layer.config.sequence_parallel = False
         layer.config.expert_model_parallel_size = 1
@@ -1070,8 +1070,8 @@ class TestTPAllReduceCondition(unittest.TestCase):
         layer.qb_histogram = paddle.to_tensor(histogram_np, dtype=paddle.int32)
         layer.num_experts_per_tok = k
         layer.num_experts = n
-        layer.qb_bin_min = -1.0
-        layer.qb_bin_max = 1.0
+        layer.qb_bin_min = paddle.to_tensor(-1.0, dtype=paddle.float32)
+        layer.qb_bin_max = paddle.to_tensor(1.0, dtype=paddle.float32)
         layer.config = MagicMock()
         layer.config.sequence_parallel = sp
         layer.config.expert_model_parallel_size = ep_size
@@ -1345,8 +1345,8 @@ class TestQBRouterInit(unittest.TestCase):
         self.assertTrue(router.qb_histogram.stop_gradient)
         self.assertEqual(router.expert_usage.shape, [8])
         self.assertTrue(router.expert_usage.stop_gradient)
-        self.assertEqual(router.qb_bin_min, -1.0)
-        self.assertEqual(router.qb_bin_max, 1.0)
+        self.assertEqual(float(router.qb_bin_min.item()), -1.0)
+        self.assertEqual(float(router.qb_bin_max.item()), 1.0)
         self.assertFalse(router._cast_to_low_precision)
 
     def test_experimental_version_bias_is_2d(self):
@@ -1365,6 +1365,17 @@ class TestQBRouterInit(unittest.TestCase):
             router = TopKRouter(config)
         self.assertEqual(router.qb_n_bins, 1000)
         self.assertEqual(router.qb_histogram.shape, [8, 1000])
+
+    def test_bin_range_is_restored_from_state_dict(self):
+        router = _build_qb_router()
+        router.qb_bin_min.set_value(paddle.to_tensor(-1.75))
+        router.qb_bin_max.set_value(paddle.to_tensor(2.25))
+
+        restored = _build_qb_router()
+        restored.set_state_dict(router.state_dict())
+
+        self.assertEqual(float(restored.qb_bin_min.item()), -1.75)
+        self.assertEqual(float(restored.qb_bin_max.item()), 2.25)
 
     def test_moe_topk_fusion_is_rejected(self):
         with self.assertRaises(ValueError) as ctx:
@@ -1473,16 +1484,16 @@ class TestAccumulateQBHistogramReal(unittest.TestCase):
 
     def test_degenerate_bin_range_falls_back(self):
         router = _build_qb_router()
-        router.qb_bin_min = 0.0
-        router.qb_bin_max = 0.0  # zero range -> fallback to 2.0
+        router.qb_bin_min.set_value(paddle.to_tensor(0.0))
+        router.qb_bin_max.set_value(paddle.to_tensor(0.0))  # zero range -> fallback to 2.0
         scores = paddle.to_tensor(np.random.rand(6, 8).astype(np.float32))
         router._accumulate_qb_histogram(scores, scores, 2)
         self.assertEqual(int(router.qb_histogram.sum().item()), 6 * 8)
 
     def test_out_of_range_values_are_clipped(self):
         router = _build_qb_router()
-        router.qb_bin_min = 0.0
-        router.qb_bin_max = 0.01  # almost everything lands beyond the last bin
+        router.qb_bin_min.set_value(paddle.to_tensor(0.0))
+        router.qb_bin_max.set_value(paddle.to_tensor(0.01))  # almost everything lands beyond the last bin
         scores = paddle.to_tensor(np.full([4, 8], 0.5, dtype=np.float32))
         router._accumulate_qb_histogram(scores, scores, 2)
         hist = router.qb_histogram.numpy()

--- a/tests/single_card_tests/transformer/test_kimi_delta_attention.py
+++ b/tests/single_card_tests/transformer/test_kimi_delta_attention.py
@@ -346,6 +346,34 @@ class TestKimiDeltaAttention(unittest.TestCase):
             qk_dim * 2 + v_dim + NUM_VALUE_HEADS,
         )
 
+    def test_conv_weight_stays_fp32_in_o2(self):
+        original_dtype = paddle.get_default_dtype()
+        try:
+            paddle.set_default_dtype("bfloat16")
+            kda = _build_kda()
+        finally:
+            paddle.set_default_dtype(original_dtype)
+
+        self.assertEqual(kda.conv1d.weight.dtype, paddle.float32)
+        self.assertEqual(kda.in_proj.linear.weight.dtype, paddle.bfloat16)
+        paddle.amp.decorate(models=kda, level="O2", dtype="bfloat16")
+        self.assertEqual(kda.conv1d.weight.dtype, paddle.float32)
+
+        x = paddle.randn(
+            [MICRO_BATCH_SIZE, SEQ_LENGTH, HIDDEN_SIZE], dtype="bfloat16"
+        )
+        x.stop_gradient = False
+        with patch.object(
+            kda_mod.fla.ops.kda,
+            "chunk_kda",
+            wraps=paddle_chunk_kda,
+        ):
+            out, _ = kda(hidden_states=x, attention_mask=None)
+            self.assertEqual(out.dtype, paddle.bfloat16)
+            out.astype(paddle.float32).square().mean().backward()
+        self.assertEqual(kda.conv1d.weight.grad.dtype, paddle.float32)
+        self.assertEqual(x.grad.dtype, paddle.bfloat16)
+
     def test_forward_shape(self):
         x = paddle.randn([MICRO_BATCH_SIZE, SEQ_LENGTH, HIDDEN_SIZE])
         out, out_bias = self.kda(hidden_states=x, attention_mask=None)


### PR DESCRIPTION
### PR Category
Distributed Strategy

### PR Types
Bug fixes

### Description
- 对齐 BlockAttnRes.proj_weight 与 Kimi-K3 HF checkpoint 的 [1, hidden_size] 布局。
- 在 AMP O2 下保持 KDA gate 与 short-convolution 参数为 FP32。
- 将 QB bin range 注册为 buffer，保证 checkpoint save/resume 后状态连续。

### 是否引起精度变化
是