### PR TITLE
[Test] disable vmm v2 in non-vmm auto subbatch tests

### DIFF
--- a/tests/single_card_tests/test_moe_auto_subbatch_deep_gemm_non_vmm.py
+++ b/tests/single_card_tests/test_moe_auto_subbatch_deep_gemm_non_vmm.py
@@ -31,6 +31,7 @@ import unittest
 import numpy as np
 
 os.environ["FLAGS_use_virtual_memory_auto_growth"] = "False"
+os.environ["FLAGS_use_vmm_auto_growth_best_fit_allocator_v2"] = "False"
 os.environ["FLAGS_cudnn_deterministic"] = "True"
 
 from types import SimpleNamespace

--- a/tests/single_card_tests/test_moe_auto_subbatch_non_vmm.py
+++ b/tests/single_card_tests/test_moe_auto_subbatch_non_vmm.py
@@ -40,6 +40,7 @@ import unittest
 import numpy as np
 
 os.environ["FLAGS_use_virtual_memory_auto_growth"] = "False"
+os.environ["FLAGS_use_vmm_auto_growth_best_fit_allocator_v2"] = "False"
 os.environ["FLAGS_cudnn_deterministic"] = "True"
 
 from types import SimpleNamespace


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] --> Performance Optimization


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] --> Not User Facing


### Description
<!-- Describe what you’ve done --> disable vmm v2 in non-vmm auto subbatch tests


### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]--> 否
