### PR TITLE
[Kimi-K3] Fix ViT to LLM

### DIFF
--- a/src/paddlefleet/models/kimi_k3/merge_input_ids.py
+++ b/src/paddlefleet/models/kimi_k3/merge_input_ids.py
@@ -25,7 +25,8 @@ def _where_2d(cond: paddle.Tensor):
     if nz.shape[0] == 0:
         empty = paddle.zeros([0], dtype="int64")
         return empty, empty
-    return nz[:, 0], nz[:, 1]
+    # ``nz[:, i]`` is strided view; make contiguous for ``paddle.index_put``.
+    return nz[:, 0].contiguous(), nz[:, 1].contiguous()
 
 
 def merge_input_ids_with_image_features(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Distributed Strategy

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复 Kimi-K3 视觉与语言模型衔接。
`paddle.nonzero(cond)[:, i]` 是 strided view，`paddle.index_put` 要求索引 contiguous。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否