### PR TITLE
[Kimi-K3] Align forward numerics with official implementation

### DIFF
--- a/src/paddlefleet/transformer/block_attn_res.py
+++ b/src/paddlefleet/transformer/block_attn_res.py
@@ -66,6 +66,37 @@ class BlockAttnResSublayersSpec:
     norm: LayerSpec | type = IdentityOp
 
 
+def _block_attn_res_rmsnorm(
+    partial_block: Tensor,
+    blocks: list[Tensor],
+    proj_weight: Tensor,
+    norm_weight: Tensor,
+    norm_eps: float,
+) -> Tensor:
+    """Apply the official FP32 AttentionRes reduction for RMSNorm inputs."""
+    with paddle.amp.auto_cast(enable=False):
+        all_repr = [*blocks, partial_block]
+        hidden_size = partial_block.shape[-1]
+        values = paddle.stack(
+            [
+                representation.reshape([-1, hidden_size])
+                for representation in all_repr
+            ],
+            axis=1,
+        ).astype("float32")
+        variance = values.pow(2).mean(axis=-1, keepdim=True)
+        normalized = values * paddle.rsqrt(variance + norm_eps)
+        score_weight = norm_weight.astype("float32") * proj_weight.astype(
+            "float32"
+        ).reshape([-1])
+        scores = (normalized * score_weight).sum(axis=-1)
+        probabilities = paddle.nn.functional.softmax(scores, axis=-1).unsqueeze(
+            1
+        )
+        output = paddle.matmul(probabilities, values).squeeze(1)
+    return output.reshape(partial_block.shape)
+
+
 class BlockAttnResFunc(paddle.autograd.PyLayer):
     """Custom forward/backward for BlockAttnRes to save memory.
 
@@ -84,26 +115,14 @@ class BlockAttnResFunc(paddle.autograd.PyLayer):
         ctx.num_blocks = len(blocks)
 
         # Compute forward without building autograd graph
-        all_repr = [*blocks, partial_block]
-
         with paddle.no_grad():
-            logits_list = []
-            for repr_i in all_repr:
-                variance = (
-                    repr_i.astype("float32").pow(2).mean(axis=-1, keepdim=True)
-                )
-                rms = paddle.sqrt(variance + norm_eps)
-                k_i = repr_i / rms * norm_weight
-                logit_i = (k_i * proj_weight).sum(axis=-1)
-                logits_list.append(logit_i)
-
-            logits = paddle.stack(logits_list, axis=0)  # [N+1, B, S]
-            weights = paddle.nn.functional.softmax(logits, axis=0)
-
-            # Weighted sum (iterative to avoid large stacked tensor)
-            h = weights[0].unsqueeze(-1) * all_repr[0]
-            for i in range(1, len(all_repr)):
-                h = h + weights[i].unsqueeze(-1) * all_repr[i]
+            h = _block_attn_res_rmsnorm(
+                partial_block,
+                list(blocks),
+                proj_weight,
+                norm_weight,
+                norm_eps,
+            )
 
         return h
 
@@ -138,22 +157,13 @@ class BlockAttnResFunc(paddle.autograd.PyLayer):
             norm_weight_d = norm_weight.detach()
             norm_weight_d.stop_gradient = False
 
-            logits_list = []
-            for rd in repr_detached:
-                variance = (
-                    rd.astype("float32").pow(2).mean(axis=-1, keepdim=True)
-                )
-                rms = paddle.sqrt(variance + norm_eps)
-                k_i = rd / rms * norm_weight_d
-                logit_i = (k_i * proj_weight_d).sum(axis=-1)
-                logits_list.append(logit_i)
-
-            logits = paddle.stack(logits_list, axis=0)
-            weights = paddle.nn.functional.softmax(logits, axis=0)
-
-            h = weights[0].unsqueeze(-1) * repr_detached[0]
-            for i in range(1, num_repr):
-                h = h + weights[i].unsqueeze(-1) * repr_detached[i]
+            h = _block_attn_res_rmsnorm(
+                repr_detached[-1],
+                repr_detached[:-1],
+                proj_weight_d,
+                norm_weight_d,
+                norm_eps,
+            )
 
             # Compute gradients via autograd
             grad_targets = [*repr_detached, proj_weight_d, norm_weight_d]
@@ -183,6 +193,12 @@ class BlockAttnResFunc(paddle.autograd.PyLayer):
         for need, g in zip(needs_grad, raw_grads):
             result.append(g if need else None)
 
+        # This PyLayer only supports first-order backward.  Release the saved
+        # distributed activations as soon as their gradients are materialized;
+        # otherwise the Python context can retain the AttentionRes graph until
+        # interpreter shutdown, after NCCL communicators have already begun
+        # teardown.
+        ctx.container = ()
         return tuple(result)
 
 

--- a/src/paddlefleet/transformer/kimi_delta_attention.py
+++ b/src/paddlefleet/transformer/kimi_delta_attention.py
@@ -169,7 +169,6 @@ class KimiDeltaAttention(FleetLayer):
 
         # Attributes from config
         self.hidden_size = config.hidden_size
-        self.act_fn = config.hidden_act
         self.conv_kernel_dim = conv_kernel_dim
         self.key_head_dim = key_head_dim
         self.value_head_dim = value_head_dim
@@ -437,7 +436,9 @@ class KimiDeltaAttention(FleetLayer):
         else:
             qk, value, beta = paddle.split(qkvbz, split_sizes, axis=-1)
         qkv = paddle.concat([qk, value], axis=-1)
-        beta = beta.reshape([batch, seq_len, -1])
+        # The official router-strength projection is promoted before the
+        # in-kernel sigmoid; keeping BF16 here changes the KDA state update.
+        beta = beta.astype(paddle.float32).reshape([batch, seq_len, -1])
         gate = gate.reshape([batch, seq_len, -1, self.value_head_dim])
         alpha = alpha.reshape([batch, seq_len, -1, self.value_head_dim])
 
@@ -445,7 +446,7 @@ class KimiDeltaAttention(FleetLayer):
         qkv = qkv.transpose([0, 2, 1]).contiguous()  # b, s, d -> b, d, s
         nvtx_range_push(suffix="conv1d")
         conv_output_dtype = qkv.dtype
-        qkv = self.act_fn(
+        qkv = F.silu(
             self.conv1d(qkv.astype(paddle.float32))[..., :seq_len]
         ).astype(conv_output_dtype)
         nvtx_range_pop(suffix="conv1d")
@@ -464,10 +465,6 @@ class KimiDeltaAttention(FleetLayer):
         key = key.reshape([batch, seq_len, -1, self.key_head_dim])
         value = value.reshape([batch, seq_len, -1, self.value_head_dim])
 
-        if self.use_qk_l2norm:
-            query = _l2norm(query.contiguous())
-            key = _l2norm(key.contiguous())
-
         nvtx_range_push(suffix="kimi_delta_rule")
         core_attn_out, _ = fla.ops.kda.chunk_kda(
             query.contiguous(),
@@ -477,6 +474,7 @@ class KimiDeltaAttention(FleetLayer):
             beta=beta.contiguous(),
             A_log=self.A_log,
             dt_bias=self.dt_bias,
+            use_qk_l2norm_in_kernel=self.use_qk_l2norm,
             use_gate_in_kernel=True,
             use_beta_sigmoid_in_kernel=True,
             safe_gate=self.gate_lower_bound is not None,
@@ -503,13 +501,15 @@ class KimiDeltaAttention(FleetLayer):
 
     @jit_fuser
     def _apply_gated_norm(self, x, gate):
-        """Per-head RMSNorm with a sigmoid output gate (KDA uses sigmoid, GDN silu)."""
-        x_dtype = x.dtype
-        x = x.reshape([-1, x.shape[-1]])
-        y = self.out_norm(x)
-        gate = gate.reshape([-1, gate.shape[-1]])
-        y = y * F.sigmoid(gate.astype(paddle.float32))
-        return y.astype(x_dtype)
+        """Official FLA fused per-head RMSNorm with a sigmoid output gate."""
+        return fla.modules.fused_norm_gate.rms_norm_gated(
+            x,
+            gate,
+            self.out_norm.weight,
+            None,
+            activation="sigmoid",
+            eps=self.config.rms_norm_eps,
+        )
 
     def sharded_state_dict(self, structured_name_prefix: str = ""):
         """Sharding along axis 0 for dt_bias / A_log and the depthwise conv1d.

--- a/src/paddlefleet/transformer/kimi_delta_attention.py
+++ b/src/paddlefleet/transformer/kimi_delta_attention.py
@@ -272,9 +272,6 @@ class KimiDeltaAttention(FleetLayer):
 
         # Attributes from config
         self.hidden_size = config.hidden_size
-        # KDA short convolution is SiLU by architecture, independently of the
-        # decoder MLP activation configured through hidden_act.
-        self.activation = "silu"
         self.conv_kernel_dim = conv_kernel_dim
         self.key_head_dim = key_head_dim
         self.value_head_dim = value_head_dim
@@ -664,7 +661,7 @@ class KimiDeltaAttention(FleetLayer):
                 qkv.contiguous(),
                 weight=self.conv1d.weight.squeeze(1),
                 bias=self.conv1d.bias,
-                activation=self.activation,
+                activation="silu",
                 cu_seqlens=cu_seqlens,
                 cu_seqlens_cpu=cu_seqlens_cpu,
                 cp_context=cp_context,
@@ -736,7 +733,14 @@ class KimiDeltaAttention(FleetLayer):
         # Gated norm
         nvtx_range_push(suffix="gated_norm")
         if self.use_fused_kernels:
-            norm_out = self._apply_fused_gated_norm(core_attn_out, gate)
+            norm_out = rms_norm_gated(
+                core_attn_out.reshape([-1, self.value_head_dim]),
+                gate.reshape([-1, self.value_head_dim]),
+                self.out_norm.weight,
+                None,
+                activation="sigmoid",
+                eps=self.config.rms_norm_eps,
+            )
         else:
             norm_out = self._apply_gated_norm(core_attn_out, gate)
         nvtx_range_pop(suffix="gated_norm")
@@ -754,20 +758,8 @@ class KimiDeltaAttention(FleetLayer):
         return out, out_bias
 
     @jit_fuser
-    def _apply_fused_gated_norm(self, x, gate):
-        """Official FLA fused per-head RMSNorm with a sigmoid output gate."""
-        return rms_norm_gated(
-            x.reshape([-1, self.value_head_dim]),
-            gate.reshape([-1, self.value_head_dim]),
-            self.out_norm.weight,
-            None,
-            activation="sigmoid",
-            eps=self.config.rms_norm_eps,
-        )
-
-    @jit_fuser
     def _apply_gated_norm(self, x, gate):
-        """Paddle-native per-head norm with a sigmoid output gate."""
+        """Per-head RMSNorm with a sigmoid output gate (KDA uses sigmoid, GDN silu)."""
         x_dtype = x.dtype
         x = x.reshape([-1, x.shape[-1]])
         y = self.out_norm(x)

--- a/src/paddlefleet/transformer/multi_latent_attention.py
+++ b/src/paddlefleet/transformer/multi_latent_attention.py
@@ -1334,19 +1334,22 @@ class MLASelfAttention(MultiLatentAttention):
             tp_group=pg_collection.tp,
         )
 
+        qk_norm_eps = getattr(self.config, "qk_norm_eps", None)
+        if qk_norm_eps is None:
+            qk_norm_eps = self.config.rms_norm_eps
         if q_lora_rank is not None:
             self.q_a_layernorm = build_spec_layer(
                 sublayers_spec.q_a_layernorm,
                 hidden_size=q_lora_rank,
                 config=self.config,
-                eps=self.config.rms_norm_eps,
+                eps=qk_norm_eps,
             )
 
         self.kv_a_layernorm = build_spec_layer(
             sublayers_spec.kv_a_layernorm,
             hidden_size=kv_lora_rank,
             config=self.config,
-            eps=self.config.rms_norm_eps,
+            eps=qk_norm_eps,
         )
 
     def muon_slice_specs(self, muon_configs):

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -411,6 +411,9 @@ class TransformerConfig(ModelParallelConfig):
     use_qk_norm: bool = False
     """Whether to apply `normalization` type of normalization to the query and key embeddings."""
 
+    qk_norm_eps: float | None = None
+    """Epsilon for query/key normalization. If None, falls back to rms_norm_eps."""
+
     qk_norm_fusion: bool = False
     """If True, use Triton fused RMSNorm kernel for QK norm."""
 

--- a/tests/multi_card_tests/tensor_parallel/test_gpt_model_dense.py
+++ b/tests/multi_card_tests/tensor_parallel/test_gpt_model_dense.py
@@ -195,7 +195,12 @@ def run_tp_sp(
 
     loss = gpt_pipe_model.forward_backward_pipeline(inputs)
 
-    assert loss == loss_baseline
+    paddle.testing.assert_close(
+        loss,
+        loss_baseline,
+        rtol=1e-6,
+        atol=5e-7,
+    )
     check_grads(gpt_pipe_model, gpt_model_baseline, tp_group)
 
 

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_multi_latent_attention_2.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_multi_latent_attention_2.py
@@ -594,7 +594,10 @@ class TestRecomputeQKVSelectiveBranches(unittest.TestCase):
             self_obj.attention_type = "self"
             self_obj.is_mtp_layer = False
 
+        build_calls = []
+
         def _fake_build_spec_layer(*args, **kwargs):
+            build_calls.append(kwargs.copy())
             return MagicMock()
 
         with (
@@ -624,7 +627,44 @@ class TestRecomputeQKVSelectiveBranches(unittest.TestCase):
                 attn_mask_type=MagicMock(),
                 pg_collection=MagicMock(),
             )
+        instance._test_build_spec_calls = build_calls
         return instance
+
+    def test_qk_norm_eps_overrides_decoder_rms_norm_eps(self):
+        config = self._make_config()
+        config.q_lora_rank = 32
+        config.rms_norm_eps = 1e-5
+        config.qk_norm_eps = 1e-6
+
+        inst = self._build_mla_instance(config)
+        norm_calls = [
+            call
+            for call in inst._test_build_spec_calls
+            if call.get("hidden_size")
+            in (config.q_lora_rank, config.kv_lora_rank)
+            and "eps" in call
+        ]
+
+        self.assertEqual(len(norm_calls), 2)
+        self.assertTrue(all(call["eps"] == 1e-6 for call in norm_calls))
+
+    def test_qk_norm_eps_defaults_to_decoder_rms_norm_eps(self):
+        config = self._make_config()
+        config.q_lora_rank = 32
+        config.rms_norm_eps = 2e-5
+        config.qk_norm_eps = None
+
+        inst = self._build_mla_instance(config)
+        norm_calls = [
+            call
+            for call in inst._test_build_spec_calls
+            if call.get("hidden_size")
+            in (config.q_lora_rank, config.kv_lora_rank)
+            and "eps" in call
+        ]
+
+        self.assertEqual(len(norm_calls), 2)
+        self.assertTrue(all(call["eps"] == 2e-5 for call in norm_calls))
 
     def test_non_selective_granularity_returns_false(self):
         """Branch: recompute_granularity != 'selective' -> False."""

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_config.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_config.py
@@ -74,6 +74,14 @@ class TestTransformerConfigDefaults(unittest.TestCase):
         cfg = _make_config()
         self.assertEqual(cfg.rms_norm_eps, 1e-5)
 
+    def test_default_qk_norm_eps(self):
+        cfg = _make_config()
+        self.assertIsNone(cfg.qk_norm_eps)
+
+    def test_explicit_qk_norm_eps(self):
+        cfg = _make_config(qk_norm_eps=1e-6)
+        self.assertEqual(cfg.qk_norm_eps, 1e-6)
+
     def test_default_hidden_dropout(self):
         cfg = _make_config()
         self.assertEqual(cfg.hidden_dropout_prob, 0.0)

--- a/tests/single_card_tests/model/test_block_attn_res_recompute.py
+++ b/tests/single_card_tests/model/test_block_attn_res_recompute.py
@@ -103,23 +103,21 @@ class TestBlockAttnResFunc(unittest.TestCase):
     def _reference_forward(
         self, partial_block, proj_weight, norm_weight, blocks
     ):
-        """Reference implementation without PyLayer."""
-        all_repr = [*blocks, partial_block]
-        logits_list = []
-        for repr_i in all_repr:
-            variance = (
-                repr_i.astype("float32").pow(2).mean(axis=-1, keepdim=True)
+        """Official FP32 batched reduction without calling the product helper."""
+        with paddle.amp.auto_cast(enable=False):
+            values = paddle.stack([*blocks, partial_block], axis=-2).astype(
+                "float32"
             )
-            rms = paddle.sqrt(variance + self.norm_eps)
-            k_i = repr_i / rms * norm_weight
-            logit_i = (k_i * proj_weight).sum(axis=-1)
-            logits_list.append(logit_i)
-        logits = paddle.stack(logits_list, axis=0)
-        weights = paddle.nn.functional.softmax(logits, axis=0)
-        h = weights[0].unsqueeze(-1) * all_repr[0]
-        for i in range(1, len(all_repr)):
-            h = h + weights[i].unsqueeze(-1) * all_repr[i]
-        return h
+            variance = values.pow(2).mean(axis=-1, keepdim=True)
+            normalized = values * paddle.rsqrt(variance + self.norm_eps)
+            score_weight = norm_weight.astype("float32") * proj_weight.astype(
+                "float32"
+            ).reshape([-1])
+            scores = (normalized * score_weight).sum(axis=-1)
+            probabilities = paddle.nn.functional.softmax(
+                scores, axis=-1
+            ).unsqueeze(-2)
+            return paddle.matmul(probabilities, values).squeeze(-2)
 
     def test_forward_matches_reference(self):
         """BlockAttnResFunc.forward output matches naive implementation."""
@@ -255,6 +253,71 @@ class TestBlockAttnResFunc(unittest.TestCase):
         self.assertIsNotNone(partial_block.grad)
         self.assertIsNotNone(norm_weight.grad)
         self.assertIsNotNone(blocks[1].grad)
+
+    def test_backward_releases_saved_context(self):
+        """First-order backward must release the saved distributed tensors."""
+
+        class _Context:
+            def save_for_backward(self, *tensors):
+                self.container = tensors
+
+            def saved_tensor(self):
+                return self.container
+
+        partial_block, proj_weight, norm_weight, blocks = self._make_inputs(
+            num_blocks=2, requires_grad=True
+        )
+        ctx = _Context()
+        output = BlockAttnResFunc.forward(
+            ctx,
+            partial_block,
+            proj_weight,
+            norm_weight,
+            self.norm_eps,
+            *blocks,
+        )
+        self.assertEqual(len(ctx.container), 5)
+
+        grads = BlockAttnResFunc.backward(ctx, paddle.ones_like(output))
+
+        self.assertEqual(len(grads), 5)
+        self.assertEqual(ctx.container, ())
+        for grad in grads:
+            self.assertTrue(paddle.isfinite(grad).all().item())
+
+    @unittest.skipUnless(paddle.is_compiled_with_cuda(), "requires CUDA AMP")
+    def test_bf16_amp_forward_matches_fp32_batched_reference(self):
+        """BF16 O2 must not downcast the official FP32 reduction."""
+        original_device = paddle.device.get_device()
+        try:
+            paddle.set_device("gpu")
+            paddle.manual_seed(2026)
+            partial_block = paddle.randn([1, 4, self.H], dtype="bfloat16")
+            blocks = [
+                paddle.randn([1, 4, self.H], dtype="bfloat16"),
+                paddle.randn([1, 4, self.H], dtype="bfloat16"),
+            ]
+            proj_weight = paddle.randn([1, self.H], dtype="bfloat16")
+            norm_weight = paddle.randn([self.H], dtype="bfloat16")
+
+            expected = self._reference_forward(
+                partial_block, proj_weight, norm_weight, blocks
+            )
+            with paddle.amp.auto_cast(
+                enable=True, dtype="bfloat16", level="O2"
+            ):
+                actual = BlockAttnResFunc.apply(
+                    partial_block,
+                    proj_weight,
+                    norm_weight,
+                    self.norm_eps,
+                    *blocks,
+                )
+
+            self.assertEqual(actual.dtype, paddle.float32)
+            self.assertTrue(paddle.equal_all(actual, expected).item())
+        finally:
+            paddle.set_device(original_device)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/single_card_tests/transformer/test_kimi_delta_attention.py
+++ b/tests/single_card_tests/transformer/test_kimi_delta_attention.py
@@ -468,7 +468,7 @@ class TestKimiDeltaAttention(unittest.TestCase):
         """KDA short convolution uses the official SiLU, not hidden_act."""
         kda = _build_kda(hidden_act=F.relu)
         self.assertFalse(hasattr(kda, "act_fn"))
-        self.assertEqual(kda.activation, "silu")
+        self.assertFalse(hasattr(kda, "activation"))
         x = paddle.randn([MICRO_BATCH_SIZE, SEQ_LENGTH, HIDDEN_SIZE])
 
         with patch.object(kda_mod.F, "silu", wraps=kda_mod.F.silu) as mock_silu:
@@ -482,24 +482,40 @@ class TestKimiDeltaAttention(unittest.TestCase):
     def test_fused_sigmoid_gated_norm_contract(self):
         """Output gating delegates to FLA RMSNorm with sigmoid and Fleet eps."""
         kda = _build_kda(deterministic_mode=False)
-        x = paddle.randn(
+        hidden_states = paddle.randn(
+            [MICRO_BATCH_SIZE, SEQ_LENGTH, HIDDEN_SIZE]
+        )
+        core_attn_out = paddle.randn(
             [MICRO_BATCH_SIZE, SEQ_LENGTH, NUM_VALUE_HEADS, VALUE_HEAD_DIM]
         )
-        gate = paddle.randn(x.shape)
         fused_shape = [
             MICRO_BATCH_SIZE * SEQ_LENGTH * NUM_VALUE_HEADS,
             VALUE_HEAD_DIM,
         ]
         expected = paddle.randn(fused_shape)
 
-        with patch.object(
-            kda_mod,
-            "rms_norm_gated",
-            return_value=expected,
-        ) as mock_rms_norm_gated:
-            actual = kda._apply_fused_gated_norm(x, gate)
+        with (
+            patch.object(
+                kda_mod,
+                "causal_conv1d",
+                side_effect=lambda x, **kwargs: (x, None),
+            ),
+            patch.object(
+                kda_mod,
+                "chunk_kda",
+                return_value=(core_attn_out, None),
+            ),
+            patch.object(
+                kda_mod,
+                "rms_norm_gated",
+                return_value=expected,
+            ) as mock_rms_norm_gated,
+        ):
+            actual, _ = kda(hidden_states=hidden_states, attention_mask=None)
 
-        self.assertIs(actual, expected)
+        self.assertEqual(
+            list(actual.shape), [MICRO_BATCH_SIZE, SEQ_LENGTH, HIDDEN_SIZE]
+        )
         args = mock_rms_norm_gated.call_args.args
         kwargs = mock_rms_norm_gated.call_args.kwargs
         self.assertEqual(list(args[0].shape), fused_shape)
@@ -537,7 +553,14 @@ class TestKimiDeltaAttention(unittest.TestCase):
                 gate_ref.stop_gradient = False
                 weight_ref.stop_gradient = False
 
-                actual = kda._apply_fused_gated_norm(x, gate).reshape(shape)
+                actual = kda_mod.rms_norm_gated(
+                    x.reshape([-1, VALUE_HEAD_DIM]),
+                    gate.reshape([-1, VALUE_HEAD_DIM]),
+                    kda.out_norm.weight,
+                    None,
+                    activation="sigmoid",
+                    eps=kda.config.rms_norm_eps,
+                ).reshape(shape)
                 x_ref_fp32 = x_ref.astype("float32")
                 expected = x_ref_fp32 * paddle.rsqrt(
                     x_ref_fp32.square().mean(axis=-1, keepdim=True)

--- a/tests/single_card_tests/transformer/test_kimi_delta_attention.py
+++ b/tests/single_card_tests/transformer/test_kimi_delta_attention.py
@@ -261,12 +261,17 @@ class TestPaddleChunkKda(unittest.TestCase):
         self.assertGreater(float(diff[t]), 1e-4)
 
 
-def _build_kda(use_full_rank_gate=True, sequence_parallel=False, **overrides):
+def _build_kda(
+    use_full_rank_gate=True,
+    sequence_parallel=False,
+    hidden_act=F.silu,
+    **overrides,
+):
     config = TransformerConfig(
         hidden_size=HIDDEN_SIZE,
         num_attention_heads=NUM_KEY_HEADS,
         num_hidden_layers=2,
-        hidden_act=F.silu,
+        hidden_act=hidden_act,
         rms_norm_eps=1e-5,
         normalization="RMSNorm",
         sequence_parallel=sequence_parallel,
@@ -397,6 +402,8 @@ class TestKimiDeltaAttention(unittest.TestCase):
 
         mock_chunk_kda.assert_called_once()
         call_kwargs = mock_chunk_kda.call_args.kwargs
+        self.assertEqual(call_kwargs["beta"].dtype, paddle.float32)
+        self.assertTrue(call_kwargs["use_qk_l2norm_in_kernel"])
         self.assertTrue(call_kwargs["use_gate_in_kernel"])
         self.assertTrue(call_kwargs["use_beta_sigmoid_in_kernel"])
         self.assertTrue(call_kwargs["safe_gate"])
@@ -404,6 +411,49 @@ class TestKimiDeltaAttention(unittest.TestCase):
         self.assertEqual(
             list(out.shape), [MICRO_BATCH_SIZE, SEQ_LENGTH, HIDDEN_SIZE]
         )
+
+    def test_short_conv_always_uses_silu(self):
+        """KDA short convolution uses the official SiLU, not hidden_act."""
+        kda = _build_kda(hidden_act=F.relu)
+        self.assertFalse(hasattr(kda, "act_fn"))
+        x = paddle.randn([MICRO_BATCH_SIZE, SEQ_LENGTH, HIDDEN_SIZE])
+
+        with (
+            patch.object(kda_mod.F, "silu", wraps=kda_mod.F.silu) as mock_silu,
+            patch.object(
+                kda_mod.fla.ops.kda,
+                "chunk_kda",
+                wraps=paddle_chunk_kda,
+            ),
+        ):
+            kda(hidden_states=x, attention_mask=None)
+
+        mock_silu.assert_called_once()
+
+    def test_fused_sigmoid_gated_norm_contract(self):
+        """Output gating delegates to FLA RMSNorm with sigmoid and Fleet eps."""
+        x = paddle.randn(
+            [MICRO_BATCH_SIZE, SEQ_LENGTH, NUM_VALUE_HEADS, VALUE_HEAD_DIM]
+        )
+        gate = paddle.randn(x.shape)
+        expected = paddle.randn(x.shape)
+
+        with patch.object(
+            kda_mod.fla.modules.fused_norm_gate,
+            "rms_norm_gated",
+            return_value=expected,
+        ) as mock_rms_norm_gated:
+            actual = self.kda._apply_gated_norm(x, gate)
+
+        self.assertIs(actual, expected)
+        args = mock_rms_norm_gated.call_args.args
+        kwargs = mock_rms_norm_gated.call_args.kwargs
+        self.assertIs(args[0], x)
+        self.assertIs(args[1], gate)
+        self.assertIs(args[2], self.kda.out_norm.weight)
+        self.assertIsNone(args[3])
+        self.assertEqual(kwargs["activation"], "sigmoid")
+        self.assertEqual(kwargs["eps"], self.kda.config.rms_norm_eps)
 
     def test_forward_low_rank_gate(self):
         kda = _build_kda(use_full_rank_gate=False)

--- a/tests/single_card_tests/transformer/test_kimi_delta_attention.py
+++ b/tests/single_card_tests/transformer/test_kimi_delta_attention.py
@@ -455,6 +455,65 @@ class TestKimiDeltaAttention(unittest.TestCase):
         self.assertEqual(kwargs["activation"], "sigmoid")
         self.assertEqual(kwargs["eps"], self.kda.config.rms_norm_eps)
 
+    def test_fused_sigmoid_gated_norm_forward_backward(self):
+        """Fused RMSNorm+sigmoid matches an independent FP32 oracle."""
+        shape = [2, 7, NUM_VALUE_HEADS, VALUE_HEAD_DIM]
+        for dtype, rtol, atol in (
+            ("float32", 1e-5, 1e-5),
+            ("bfloat16", 1e-2, 1e-2),
+        ):
+            with self.subTest(dtype=dtype):
+                paddle.seed(2026)
+                kda = _build_kda()
+                kda.out_norm.weight.set_value(
+                    paddle.linspace(0.5, 1.5, VALUE_HEAD_DIM, dtype="float32")
+                )
+
+                x = paddle.randn(shape, dtype=dtype)
+                gate = paddle.randn(shape, dtype=dtype)
+                x.stop_gradient = False
+                gate.stop_gradient = False
+                x_ref = x.detach().clone()
+                gate_ref = gate.detach().clone()
+                weight_ref = kda.out_norm.weight.detach().clone()
+                x_ref.stop_gradient = False
+                gate_ref.stop_gradient = False
+                weight_ref.stop_gradient = False
+
+                actual = kda._apply_gated_norm(x, gate)
+                x_ref_fp32 = x_ref.astype("float32")
+                expected = x_ref_fp32 * paddle.rsqrt(
+                    x_ref_fp32.square().mean(axis=-1, keepdim=True)
+                    + kda.config.rms_norm_eps
+                )
+                expected = (
+                    expected
+                    * weight_ref.astype("float32")
+                    * F.sigmoid(gate_ref.astype("float32"))
+                ).astype(dtype)
+
+                output_gradient = paddle.randn(shape, dtype=dtype)
+                (
+                    actual.astype("float32") * output_gradient.astype("float32")
+                ).sum().backward()
+                (
+                    expected.astype("float32")
+                    * output_gradient.astype("float32")
+                ).sum().backward()
+
+                for actual_value, expected_value in (
+                    (actual, expected),
+                    (x.grad, x_ref.grad),
+                    (gate.grad, gate_ref.grad),
+                    (kda.out_norm.weight.grad, weight_ref.grad),
+                ):
+                    paddle.testing.assert_close(
+                        actual_value.astype("float32"),
+                        expected_value.astype("float32"),
+                        rtol=rtol,
+                        atol=atol,
+                    )
+
     def test_forward_low_rank_gate(self):
         kda = _build_kda(use_full_rank_gate=False)
         x = paddle.randn([MICRO_BATCH_SIZE, SEQ_LENGTH, HIDDEN_SIZE])


### PR DESCRIPTION
### PR Category
Distributed Strategy

### PR Types
Bug fixes

### Description
- 对齐 Kimi-K3 AttentionRes 的 FP32 batched reduction，并在 backward 后及时释放 PyLayer 保存的 activation。
- 对齐 KDA 的 causal SiLU conv、FP32 beta、in-kernel Q/K L2Norm 与 fused RMSNorm+sigmoid gate。
- 为 MLA 增加独立的 `qk_norm_eps` 配置，并保留对 `rms_norm_eps` 的默认回退。

### 是否引起精度变化
是
