### PR TITLE
Optimize DSA indexer target computation with cuDNN kernel

### DIFF
--- a/src/paddlefleet/fusions/mqa_sparse_attn.py
+++ b/src/paddlefleet/fusions/mqa_sparse_attn.py
@@ -64,8 +64,23 @@ class _MQASparseAttention(paddle.autograd.PyLayer):
     ``attn_sink``.
     """
 
+    # Side channel for ``lse_indexer``: a PyLayer's returned tensors all become
+    # autograd outputs needing a matching backward grad, and this LSE is a
+    # by-product consumed under no_grad. ``mqa_sparse_attn`` pops it right after
+    # ``apply`` so it never outlives one call.
+    _lse_indexer = None
+
     @staticmethod
-    def forward(ctx, query, kv, token_indices, sm_scale, d_v, attn_sink=None):
+    def forward(
+        ctx,
+        query,
+        kv,
+        token_indices,
+        sm_scale,
+        d_v,
+        attn_sink=None,
+        indexer_topk=0,
+    ):
         from paddlefleet.cudnn_ops.attn.csa_sparse_attn_fwd_cudnn import (
             flash_mla_sparse_attn,
         )
@@ -131,7 +146,7 @@ class _MQASparseAttention(paddle.autograd.PyLayer):
             token_indices.reshape([b * s, -1])
         )
 
-        out, lse, _ = flash_mla_sparse_attn(
+        out, lse, lse_indexer = flash_mla_sparse_attn(
             q_pad,
             kv,
             sink,
@@ -139,7 +154,9 @@ class _MQASparseAttention(paddle.autograd.PyLayer):
             sm_scale=ctx.sm_scale,
             d_v=d_v,
             topk_length=topk_len_flat.reshape([b, s]),
+            indexer_topk=int(indexer_topk),
         )  # out [b, s, 64, d_v], lse [b, s, 64]
+        _MQASparseAttention._lse_indexer = lse_indexer
 
         # ``token_indices`` is saved rather than recomputed so the backward always
         # differentiates the exact support the forward used. Under full recompute
@@ -296,7 +313,9 @@ class _MQASparseAttention(paddle.autograd.PyLayer):
         return tuple(grads)
 
 
-def mqa_sparse_attn(query, kv, token_indices, sm_scale, d_v, attn_sink=None):
+def mqa_sparse_attn(
+    query, kv, token_indices, sm_scale, d_v, attn_sink=None, indexer_topk=0
+):
     """Absorbed-MQA sparse attention (FlashMLA sparse fwd + cuDNN DSA bwd).
 
     Args:
@@ -311,15 +330,27 @@ def mqa_sparse_attn(query, kv, token_indices, sm_scale, d_v, attn_sink=None):
                        ``d_qk in {512, 576}``).
         attn_sink:     ``[h]`` learnable per-head sink logit, or ``None`` for a
                        sinkless softmax.
+        indexer_topk:  when > 0, also return the per-head LSE restricted to the
+                       **first** ``indexer_topk`` columns of ``token_indices``.
+                       That is the normalizer the indexer-loss target needs, so
+                       the caller must put the indexer-selected columns first.
+                       ``0`` keeps the single-output signature.
 
     Returns:
-        ``[b, s, h * d_v]``.
+        ``[b, s, h * d_v]``, or ``(output, lse_indexer [b, s, 64] fp32)`` when
+        ``indexer_topk > 0``.
     """
-    return _MQASparseAttention.apply(
+    output = _MQASparseAttention.apply(
         query,
         kv,
         token_indices,
         float(sm_scale),
         int(d_v),
         attn_sink,
+        int(indexer_topk),
     )
+    lse_indexer = _MQASparseAttention._lse_indexer
+    _MQASparseAttention._lse_indexer = None
+    if indexer_topk > 0:
+        return output, lse_indexer
+    return output

--- a/src/paddlefleet/transformer/mqa_latent_attention.py
+++ b/src/paddlefleet/transformer/mqa_latent_attention.py
@@ -119,8 +119,33 @@ if TYPE_CHECKING:
 # 15.9ms at 128 rows, 13.3ms at 256, 12.4ms at 512, 12.4ms at 1024 -- past 256
 # the curve is flat, so larger chunks only buy peak memory.
 _TARGET_ROW_SLOTS = 256 * 512
+# ``lse_indexer`` widths ``flash_mla_sparse_fwd`` implements; anything else is
+# rejected outright (FlashMLA ``sparse_fwd.h:160``). Narrower budgets keep the
+# Python target path.
+_LSE_INDEXER_TOPKS = (512, 1024, 2048)
+# Narrowest query-head count the score-recompute kernel's MMA ``M`` tile
+# handles; see ``_attn_target_cudnn``.
+_TARGET_QHEAD_MIN = 16
 _NEG_INF = -1e30
 _EPS = 1e-10
+
+
+class _HashableTensor(paddle.Tensor):
+    """``paddle.Tensor`` with hashable ``shape`` / ``stride()``.
+
+    The cuDNN score-recompute wrapper keys its kernel cache on
+    ``(dtype, shape, stride(), ...)``, and Paddle returns those as lists, which
+    are unhashable.
+    """
+
+    @property
+    def shape(self):
+        return tuple(super().shape)
+
+    def stride(self, dim=None):
+        if dim is None:
+            return tuple(super().stride())
+        return super().stride(dim)
 
 
 @dataclass
@@ -725,7 +750,9 @@ class MQALatentAttention(FleetLayer):
         rows = int(valid_range.shape[0])
         return valid_range.unsqueeze(0), (n_avail == 0).reshape([1, rows, 1])
 
-    def _sparse_attn(self, query, kv, token_indices, sm_scale, d_v):
+    def _sparse_attn(
+        self, query, kv, token_indices, sm_scale, d_v, indexer_topk=0
+    ):
         """Sparse MQA over the absorbed latent, via the shared cudnn backend.
 
         Same FlashMLA sparse forward + cuDNN DSA backward pair that the CSA/HCA
@@ -734,6 +761,9 @@ class MQALatentAttention(FleetLayer):
         ``softmax_offset`` is ``None`` when ``add_full_attention_sink_bias`` is
         off, which the backend turns into a sinkless softmax. Query-head padding
         to the DSA-fixed ``h_q == 64`` is the backend's job.
+
+        ``indexer_topk > 0`` additionally returns the LSE over the first
+        ``indexer_topk`` columns, which is the indexer-loss target's normalizer.
         """
         from paddlefleet.fusions.mqa_sparse_attn import mqa_sparse_attn
 
@@ -744,6 +774,7 @@ class MQALatentAttention(FleetLayer):
             sm_scale,
             d_v,
             attn_sink=self.softmax_offset,
+            indexer_topk=indexer_topk,
         )
 
     @staticmethod
@@ -848,14 +879,42 @@ class MQALatentAttention(FleetLayer):
             topk_indices = paddle.where(
                 row_empty, paddle.full_like(selected, -1), selected
             )
+            # ``[indexer topk, window]``, not the other way round: the kernel's
+            # ``lse_indexer`` covers the *first* ``indexer_topk`` columns
+            # (``flash_mla_sparse_fwd``), and that restricted per-head LSE is
+            # exactly the normalizer the loss target needs -- with it every head
+            # contributes mass 1 over the selected set, matching the per-head
+            # softmax of ``_attn_target_python``. Feeding the *attention* LSE
+            # instead (window + sink included) would turn the target into a
+            # head-mass-weighted mixture: a different objective, invisible in the
+            # forward output.
+            #
+            # Attention itself is a softmax over a set, so the order changes only
+            # the accumulation order (hence the last bits), not the value. The
+            # order is unconditional on purpose: gating it on ``need_loss`` would
+            # make the two forwards of a full-recompute step disagree on the
+            # table layout and on ``topk_length``.
             token_indices = paddle.concat(
-                [window_idxs, topk_indices], axis=-1
+                [topk_indices, window_idxs], axis=-1
             ).contiguous()
         token_indices.stop_gradient = True
 
-        core_out = self._sparse_attn(
-            query, kv, token_indices, self.softmax_scale, kv_lora_rank
-        )
+        # The kernel only implements a handful of ``lse_indexer`` widths; other
+        # budgets fall back to the Python target path.
+        if topk in _LSE_INDEXER_TOPKS:
+            core_out, lse_indexer = self._sparse_attn(
+                query,
+                kv,
+                token_indices,
+                self.softmax_scale,
+                kv_lora_rank,
+                indexer_topk=topk,
+            )
+        else:
+            lse_indexer = None
+            core_out = self._sparse_attn(
+                query, kv, token_indices, self.softmax_scale, kv_lora_rank
+            )
         output = self._deabsorb(core_out, v_b_proj_weight)
         if not need_loss:
             return output
@@ -874,7 +933,9 @@ class MQALatentAttention(FleetLayer):
             )
             # The window is force-selected, so it is outside the indexer's
             # decision space and outside the KL: only the top-k columns.
-            target = self._attn_target(query.detach(), kv, topk_indices)
+            target = self._attn_target(
+                query.detach(), kv, topk_indices, lse_indexer
+            )
             kl = target * (
                 paddle.log(target + _EPS) - paddle.log(topk_probs + _EPS)
             )
@@ -982,7 +1043,7 @@ class MQALatentAttention(FleetLayer):
         )
         return loss_mask, max(float(loss_mask.sum()), 1.0)
 
-    def _attn_target(self, query, kv, kl_columns) -> Tensor:
+    def _attn_target(self, query, kv, kl_columns, lse_indexer=None) -> Tensor:
         """KL target: head-summed attention probs over the indexer's own columns.
 
         The denominator is **the KL's candidate set and nothing else** -- not the
@@ -1004,6 +1065,92 @@ class MQALatentAttention(FleetLayer):
         window term alone. Those are two objectives, not right and wrong; this one
         is the intended one.
 
+        Args:
+            query: ``[1, s, h, dk]`` detached absorbed query (local rows).
+            kv: ``[1, s_global, dk]`` latent keys (all-gathered under CP).
+            kl_columns: ``[1, s, w]`` int32 global column ids the KL scores,
+                ``-1`` for empty slots. Column *order* is irrelevant, so the
+                warmup phase passes the indexer's score-ordered table directly.
+            lse_indexer: ``[1, s, 64]`` float32 per-head LSE over exactly
+                ``kl_columns`` (``mqa_sparse_attn(indexer_topk=...)``). When
+                present the cuDNN score-recompute kernel does the whole thing in
+                one launch. ``None`` in the warmup phase -- its candidate set is
+                not the attention set, so no matching LSE exists -- and when the
+                budget is not one of ``_LSE_INDEXER_TOPKS``, so the Python path
+                stays as the reference and the fallback.
+
+        Returns:
+            ``[1, s, w]`` float32 rows summing to 1 (0 for empty rows).
+        """
+        if lse_indexer is not None:
+            return self._attn_target_cudnn(query, kv, kl_columns, lse_indexer)
+        return self._attn_target_python(query, kv, kl_columns)
+
+    def _attn_target_cudnn(self, query, kv, kl_columns, lse_indexer) -> Tensor:
+        """``_attn_target`` via the cuDNN DSA score-recompute kernel.
+
+        The kernel computes ``sum_h exp(Q_h·K_i*scale - LSE_h)`` L1-normalised
+        over the selected columns. With ``LSE_h`` restricted to those same
+        columns each head contributes mass 1, which is what the per-head softmax
+        of :meth:`_attn_target_python` produces.
+
+        Two different head paddings meet here, and they pull in opposite
+        directions:
+
+        * The *attention* kernel pads the query to its fixed ``h_q == 64``, and
+          those pad heads must stay out of the head sum. Hence the LSE is sliced
+          down to the layer's real ``h`` -- the query itself is already the
+          unpadded one.
+        * The *target* kernel uses the query-head count as its MMA ``M`` tile
+          (``_dispatch_sparse_attn_tile_params``: ``m = qhead_per_kv_head``), and
+          only powers of two from 16 up work: 24/40/48/80 raise, and ``h == 8``
+          -- the unit fixture's width -- silently returns an all-zero target,
+          which would make the KL target uniform-after-renormalisation with no
+          error anywhere. So pad back up to ``_TARGET_QHEAD_MIN`` when the layer
+          is narrower.
+
+        The pad heads carry an **infinite** LSE, so ``exp(score - inf) == 0``
+        keeps them out of the head sum exactly rather than approximately (the
+        query pad rows are zeros, whose score is a finite 0). Measured against
+        :meth:`_attn_target_python` at ``h=8 -> 16``: 7.5e-4 max abs error, i.e.
+        bf16 matmul noise.
+        """
+        from paddlefleet_ops.cudnn.deepseek_sparse_attention import (
+            sparse_attn_score_recompute_wrapper,
+        )
+
+        b, s, h, dk = (int(dim) for dim in query.shape)
+        idx = kl_columns.cast("int32").contiguous()
+        lse = lse_indexer[:, :, :h].cast("float32")
+        h_padded = max(_TARGET_QHEAD_MIN, 1 << (h - 1).bit_length())
+        if h_padded != h:
+            pad = h_padded - h
+            query = paddle.concat(
+                [query, paddle.zeros([b, s, pad, dk], dtype=query.dtype)],
+                axis=2,
+            )
+            lse = paddle.concat(
+                [lse, paddle.full([b, s, pad], float("inf"), dtype="float32")],
+                axis=2,
+            )
+        target = sparse_attn_score_recompute_wrapper(
+            _HashableTensor(query.contiguous()),
+            _HashableTensor(kv.contiguous()),
+            _HashableTensor(lse.contiguous()),
+            _HashableTensor(idx),
+            self.softmax_scale,
+        )["target"]
+
+        # Empty slots / all-empty rows: the kernel is not contracted to return
+        # zeros there, and a row of zeros must stay a row of zeros (the KL
+        # reduction divides by the valid-row count, not by the row sum).
+        valid = idx >= 0
+        target = paddle.where(valid, target, paddle.zeros_like(target))
+        return target / target.sum(axis=-1, keepdim=True).clip(min=_EPS)
+
+    def _attn_target_python(self, query, kv, kl_columns) -> Tensor:
+        """Reference ``_attn_target``: per-head softmax over gathered keys.
+
         The tilelang ``csa_attn_target_reducesum`` kernel is not usable here (it
         requires a power-of-two head dim; the latent is 576) and the dense
         ``_compute_attn_target_on_selected_set`` materialises ``[b, h, s, s]``, so
@@ -1011,16 +1158,6 @@ class MQALatentAttention(FleetLayer):
         no ``s*s`` tensor. The matmul runs in the input dtype (bf16) with fp32
         accumulation, as the tilelang kernel does internally for the CSA layers;
         the softmax and the L1 normalisation are fp32.
-
-        Args:
-            query: ``[1, s, h, dk]`` detached absorbed query (local rows).
-            kv: ``[1, s_global, dk]`` latent keys (all-gathered under CP).
-            kl_columns: ``[1, s, w]`` int32 global column ids the KL scores,
-                ``-1`` for empty slots. Column *order* is irrelevant, so the
-                warmup phase passes the indexer's score-ordered table directly.
-
-        Returns:
-            ``[1, s, w]`` float32 rows summing to 1 (0 for empty rows).
         """
         s, width = int(query.shape[1]), int(kl_columns.shape[-1])
         dk = int(query.shape[-1])

--- a/tests/single_card_tests/transformer/hybrid_mla_utils.py
+++ b/tests/single_card_tests/transformer/hybrid_mla_utils.py
@@ -213,9 +213,13 @@ _CAPTURED = []
 class RecordingMQA(MQALatentAttention):
     """Captures the ``token_indices`` handed to the sparse kernel."""
 
-    def _sparse_attn(self, query, kv, token_indices, sm_scale, d_v):
+    def _sparse_attn(
+        self, query, kv, token_indices, sm_scale, d_v, indexer_topk=0
+    ):
         _CAPTURED.append(token_indices.numpy().copy())
-        return super()._sparse_attn(query, kv, token_indices, sm_scale, d_v)
+        return super()._sparse_attn(
+            query, kv, token_indices, sm_scale, d_v, indexer_topk
+        )
 
 
 def _build_module(

--- a/tests/single_card_tests/transformer/test_mqa_latent_attention.py
+++ b/tests/single_card_tests/transformer/test_mqa_latent_attention.py
@@ -52,10 +52,19 @@ Coverage:
      ``csa_train_indexer_only``, ``csa_indexer_init_from_scratch``) ship without
      an alias, so a stale config must raise rather than be absorbed into a
      silent default.
+  9. The fused indexer-loss target's plumbing with both kernels stubbed out:
+     the ``_attn_target`` dispatch, ``_attn_target_cudnn``'s call contract and
+     empty-slot handling, ``mqa_sparse_attn``'s ``lse_indexer`` side channel and
+     the ``_forward_sparse`` branch that asks for it. The kernels themselves need
+     SM100+ (see 5 and ``TestMQADSACudnnTarget``); everything around them is
+     plain Python and stays checked on machines that lack them.
 """
 
+import sys
+import types
 import unittest
 from types import SimpleNamespace
+from unittest import mock
 
 import numpy as np
 import paddle
@@ -65,7 +74,11 @@ from paddlefleet.transformer.csa_attention import (
     _derive_csa_doc_boundaries,
 )
 from paddlefleet.transformer.dsa_attention import DSAIndexerLossLoggingHelper
-from paddlefleet.transformer.mqa_latent_attention import MQALatentAttention
+from paddlefleet.transformer.mqa_latent_attention import (
+    _LSE_INDEXER_TOPKS,
+    MQALatentAttention,
+    _HashableTensor,
+)
 from paddlefleet.transformer.transformer_config import TransformerConfig
 
 from .hybrid_mla_utils import (
@@ -807,12 +820,12 @@ class TestMQADSA(unittest.TestCase):
         loss_widths = []
         inner_target = self.module._attn_target
 
-        def recording_target(query_, kv_, kl_columns):
+        def recording_target(query_, kv_, kl_columns, lse_indexer=None):
             # The KL's column set is the indexer's candidate set: the top-k in
             # the sparse phase, every causal column in warmup. The forced window
             # is never in it.
             loss_widths.append(int(kl_columns.shape[-1]))
-            return inner_target(query_, kv_, kl_columns)
+            return inner_target(query_, kv_, kl_columns, lse_indexer)
 
         self.module._attn_target = recording_target
 
@@ -1391,6 +1404,600 @@ class TestMQADSAWarmupPhase(unittest.TestCase):
         np.testing.assert_array_equal(first, second)
         np.testing.assert_array_equal(first, expected)
         self.assertIn("values", DSAIndexerLossLoggingHelper.tracker)
+
+
+class TestHashableTensor(unittest.TestCase):
+    """``_HashableTensor`` exists only to make the kernel cache key hashable.
+
+    The cuDNN score-recompute wrapper hashes ``(dtype, shape, stride(), ...)``;
+    Paddle returns both as lists, which ``dict`` rejects. No GPU needed -- the
+    contract is purely about the container types.
+    """
+
+    def test_shape_and_stride_are_hashable_tuples(self):
+        tensor = _HashableTensor(paddle.zeros([2, 3, 4], dtype="float32"))
+        self.assertIsInstance(tensor.shape, tuple)
+        self.assertEqual(tensor.shape, (2, 3, 4))
+        self.assertIsInstance(tensor.stride(), tuple)
+        self.assertEqual(tensor.stride(), (12, 4, 1))
+        # Per-dim form: the wrapper does not use it, but it is the half of the
+        # override that would silently return a plain int if dropped.
+        self.assertEqual(tensor.stride(0), 12)
+        hash((tensor.shape, tensor.stride()))
+
+
+@_GPU
+class TestMQADSACudnnTarget(unittest.TestCase):
+    """The fused indexer-loss target (``_attn_target_cudnn``).
+
+    The kernel needs an LSE taken over exactly the scored column set, which
+    exists only when attention and loss share one table (phase 3,
+    ``dsa_indexer_use_sparse_loss=True``) and the budget is a width
+    ``flash_mla_sparse_fwd`` implements (``_LSE_INDEXER_TOPKS``). The
+    module-wide fixture runs ``INDEX_TOPK = 128``, which is not one of them, so
+    every test here raises the budget to 512 -- the narrowest supported width.
+    """
+
+    TOPK = 512
+    SEQLEN = 768  # > WINDOW + TOPK, so the table stays genuinely sparse
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            paddle.set_flags({"FLAGS_cudnn_deterministic": True})
+        except Exception:
+            pass
+
+    def _build(self, topk):
+        config = _create_mqa_config("mqa_dsa", loss_coeff=0.01)
+        config.dsa_index_topk = topk
+        module = _build_module(config, bf16=True)
+        self.assertEqual(int(module.indexer.index_topk), topk)
+        return module
+
+    def setUp(self):
+        _CAPTURED.clear()
+        DSAIndexerLossLoggingHelper.tracker.clear()
+        self.module = self._build(self.TOPK)
+
+    def _train_step(self, module, seed=0):
+        """One grad-enabled forward + backward, capturing the target's inputs.
+
+        Returns the ``_attn_target`` arguments so a test can re-run the Python
+        reference on the *same* columns; recomputing them from a second forward
+        would not work, the top-k table drifts between identical calls on a
+        single full-length document (``TestMQADSA``
+        ``test_use_sparse_loss_switches_both_attention_and_loss_width``).
+        """
+        query, key, w_v, x, qr = _make_inputs(
+            self.SEQLEN, seed=seed, with_hidden=True
+        )
+        captured = {}
+        inner = module._attn_target
+
+        def spy(query_, kv_, topk_indices, lse_indexer=None):
+            captured["args"] = (query_, kv_, topk_indices)
+            captured["lse_indexer"] = lse_indexer
+            target = inner(query_, kv_, topk_indices, lse_indexer)
+            captured["target"] = target
+            return target
+
+        module._attn_target = spy
+        try:
+            tensors = [t.clone() for t in (query, key, x, qr)]
+            for tensor in tensors:
+                tensor.stop_gradient = False
+            module.train()
+            out = module(
+                tensors[0],
+                tensors[1],
+                None,
+                None,
+                _row_end([self.SEQLEN], self.SEQLEN),
+                v_b_proj_weight=w_v,
+                x=tensors[2],
+                qr=tensors[3],
+            )
+            out.cast("float32").sum().backward()
+        finally:
+            module._attn_target = inner
+        return captured
+
+    def test_supported_budget_takes_the_fused_path(self):
+        """A 512 budget routes the target through the kernel, and the KL lands.
+
+        Asserts the plumbing end to end: ``mqa_sparse_attn`` returns the second
+        output at all (the ``indexer_topk > 0`` signature), the LSE has the
+        kernel's fixed ``h_q == 64`` head count rather than the layer's 8, and
+        the loss built on top of it is finite and non-zero.
+
+        The LSE is finite exactly on the rows that have a candidate: it is a
+        log-sum-exp over the ``indexer_topk`` prefix of the table, so the rows
+        whose prefix is all ``-1`` -- the first ``window_size`` tokens of a
+        document, which ``_indexer_valid_range`` leaves without candidates --
+        come back ``+inf``. Those rows have to end up as a zero target row, not
+        as a NaN one, which is what the KL's valid-row denominator assumes.
+        """
+        captured = self._train_step(self.module)
+        lse = captured["lse_indexer"]
+        self.assertIsNotNone(lse, "the fused path did not receive an LSE")
+        self.assertEqual(list(lse.shape), [1, self.SEQLEN, 64])
+        self.assertEqual(lse.dtype, paddle.float32)
+        has_candidate = (captured["args"][2] >= 0).any(axis=-1)
+        self.assertTrue(
+            bool(has_candidate.any()) and not bool(has_candidate.all())
+        )
+        self.assertTrue(bool(paddle.isfinite(lse[has_candidate]).all()))
+        self.assertTrue(bool(paddle.isinf(lse[~has_candidate]).all()))
+
+        target = captured["target"]
+        self.assertEqual(list(target.shape), [1, self.SEQLEN, self.TOPK])
+        self.assertTrue(bool(paddle.isfinite(target).all()))
+        self.assertEqual(float(target[~has_candidate].abs().max()), 0.0)
+        np.testing.assert_allclose(
+            target.sum(axis=-1)[has_candidate].numpy(), 1.0, atol=1e-5
+        )
+        loss = float(DSAIndexerLossLoggingHelper.tracker["values"][0])
+        self.assertTrue(np.isfinite(loss))
+        self.assertGreater(loss, 0.0)
+
+    def test_fused_target_matches_the_python_reference(self):
+        """The kernel and ``_attn_target_python`` must agree on the same table.
+
+        Both produce ``sum_h softmax_h`` over the selected columns, L1
+        normalised, so this is the correctness contract of the whole change: the
+        head-sum's normalizer is the LSE restricted to those columns, and
+        getting that wrong (e.g. feeding the attention LSE, which also covers
+        the window and the sink) changes the objective without changing the
+        forward output.
+        """
+        captured = self._train_step(self.module)
+        query, kv, topk_indices = captured["args"]
+        fused = captured["target"]
+        reference = self.module._attn_target_python(query, kv, topk_indices)
+
+        self.assertLess(_rel(fused, reference), 5e-3)
+        # Every non-empty row is a distribution; empty slots stay exactly zero
+        # (the KL divides by the valid-row count, not by the row sum).
+        valid_rows = (topk_indices >= 0).any(axis=-1)
+        row_sums = fused.sum(axis=-1)
+        np.testing.assert_allclose(row_sums[valid_rows].numpy(), 1.0, atol=1e-5)
+        empty_slots = topk_indices < 0
+        self.assertEqual(float(fused[empty_slots].abs().max()), 0.0)
+
+    def test_unsupported_budget_falls_back_to_python(self):
+        """384 is a legal ``index_topk`` the kernel does not implement.
+
+        ``dsa_index_topk`` only has to be a multiple of 128 and at most 2048
+        (``transformer_config.py``), while ``indexer_topk`` accepts
+        0/512/1024/2048 only. Without the ``_LSE_INDEXER_TOPKS`` guard the
+        illegal width would reach the kernel; with it the target silently uses
+        the Python reference instead.
+        """
+        self.assertNotIn(384, _LSE_INDEXER_TOPKS)
+        module = self._build(384)
+        captured = self._train_step(module)
+        self.assertIsNone(captured["lse_indexer"])
+        loss = float(DSAIndexerLossLoggingHelper.tracker["values"][0])
+        self.assertTrue(np.isfinite(loss))
+
+
+def _fake_score_recompute(fn):
+    """Put ``fn`` in place of the cuDNN score-recompute wrapper.
+
+    ``_attn_target_cudnn`` imports it lazily from
+    ``paddlefleet_ops.cudnn.deepseek_sparse_attention``, so swapping the module
+    in ``sys.modules`` intercepts the call without importing (or owning a GPU
+    able to run) the real op.
+    """
+    module = types.ModuleType("paddlefleet_ops.cudnn.deepseek_sparse_attention")
+    module.sparse_attn_score_recompute_wrapper = fn
+    return mock.patch.dict(
+        sys.modules,
+        {"paddlefleet_ops.cudnn.deepseek_sparse_attention": module},
+    )
+
+
+class TestAttnTargetDispatch(unittest.TestCase):
+    """``_attn_target`` picks its implementation from ``lse_indexer`` alone.
+
+    No GPU: the dispatch is what decides whether the loss target comes from the
+    kernel or from the reference, and it must not consult anything else (the
+    caller has already resolved the phase and the budget).
+    """
+
+    def setUp(self):
+        self.calls = []
+        self.stub = SimpleNamespace(
+            _attn_target_cudnn=lambda *a: self.calls.append("cudnn") or "cudnn",
+            _attn_target_python=lambda *a: self.calls.append("python")
+            or "python",
+        )
+
+    def test_lse_present_selects_the_kernel(self):
+        got = MQALatentAttention._attn_target(
+            self.stub, "q", "kv", "idx", "lse"
+        )
+        self.assertEqual((got, self.calls), ("cudnn", ["cudnn"]))
+
+    def test_lse_absent_selects_the_reference(self):
+        got = MQALatentAttention._attn_target(self.stub, "q", "kv", "idx", None)
+        self.assertEqual((got, self.calls), ("python", ["python"]))
+        # The default is the fallback too: phase 2 calls it with three args.
+        self.assertEqual(
+            MQALatentAttention._attn_target(self.stub, "q", "kv", "idx"),
+            "python",
+        )
+
+
+class TestAttnTargetCudnnMocked(unittest.TestCase):
+    """``_attn_target_cudnn``'s call contract, kernel mocked out.
+
+    The kernel itself needs SM100+ (covered by ``TestMQADSACudnnTarget``); what
+    is checked here is everything the wrapper is responsible for and the kernel
+    is not: hashable cache-key metadata, the LSE sliced down to the real head
+    count and then both it and the query padded back up to the kernel's
+    narrowest MMA tile, int32 indices, and the empty-slot handling on the way
+    out.
+    """
+
+    H_Q, S, TOPK, DK_ = 4, 3, 4, 8
+    SCALE = 0.25
+
+    def _inputs(self, h_q=None):
+        h_q = self.H_Q if h_q is None else h_q
+        query = paddle.zeros([1, self.S, h_q, self.DK_], dtype="bfloat16")
+        kv = paddle.zeros([1, self.S, self.DK_], dtype="bfloat16")
+        # Row 0 has two valid columns, row 1 one, row 2 none (a fully padded
+        # query row, which a short document's first token produces).
+        idx = paddle.to_tensor(
+            [[[0, 1, -1, -1], [0, -1, -1, -1], [-1, -1, -1, -1]]],
+            dtype="int64",
+        )
+        # The kernel's LSE always has the DSA-fixed 64 heads, not the layer's.
+        lse = paddle.full([1, self.S, 64], 1.5, dtype="bfloat16")
+        return query, kv, idx, lse
+
+    def _run(self, target_value=2.0, h_q=None):
+        seen = {}
+
+        def fake(q, kv, lse, idx, scale):
+            seen["types"] = [type(t) for t in (q, kv, lse, idx)]
+            # The real wrapper keys its kernel cache on this tuple; lists would
+            # raise TypeError here, which is the whole point of
+            # ``_HashableTensor``.
+            seen["key"] = hash(
+                tuple((t.dtype, t.shape, t.stride()) for t in (q, kv, lse, idx))
+            )
+            seen["q_shape"] = list(q.shape)
+            seen["q"] = q.cast("float32").numpy().copy()
+            seen["lse_shape"] = list(lse.shape)
+            seen["lse"] = lse.numpy().copy()
+            seen["lse_dtype"] = lse.dtype
+            seen["idx_dtype"] = idx.dtype
+            seen["scale"] = scale
+            return {
+                "target": paddle.full(idx.shape, target_value, dtype="float32")
+            }
+
+        query, kv, idx, lse = self._inputs(h_q)
+        with _fake_score_recompute(fake):
+            target = MQALatentAttention._attn_target_cudnn(
+                SimpleNamespace(softmax_scale=self.SCALE), query, kv, idx, lse
+            )
+        return seen, target
+
+    def test_kernel_arguments(self):
+        seen, _ = self._run()
+        self.assertEqual(seen["types"], [_HashableTensor] * 4)
+        self.assertEqual(seen["lse_dtype"], paddle.float32)
+        self.assertEqual(seen["idx_dtype"], paddle.int32)
+        self.assertEqual(seen["scale"], self.SCALE)
+
+    def test_narrow_head_count_is_padded_with_an_infinite_lse(self):
+        """``h < 16`` is padded up, and the pad heads contribute nothing.
+
+        The kernel's MMA ``M`` tile is the query-head count and it silently
+        returns an all-zero target below 16 heads, so the wrapper pads. The pad
+        heads must not join the head sum, which an infinite LSE guarantees
+        exactly: ``exp(finite - inf) == 0``.
+        """
+        seen, _ = self._run()
+        self.assertEqual(seen["q_shape"], [1, self.S, 16, self.DK_])
+        self.assertEqual(seen["lse_shape"], [1, self.S, 16])
+        # Real heads keep the layer's LSE, sliced out of the kernel's 64-wide
+        # one; the pad heads are +inf.
+        np.testing.assert_array_equal(seen["lse"][:, :, : self.H_Q], 1.5)
+        self.assertTrue(bool(np.isposinf(seen["lse"][:, :, self.H_Q :]).all()))
+        np.testing.assert_array_equal(seen["q"][:, :, self.H_Q :], 0.0)
+
+    def test_supported_head_count_is_passed_through(self):
+        """A power-of-two ``h >= 16`` (production is 64) is not padded."""
+        seen, _ = self._run(h_q=64)
+        self.assertEqual(seen["q_shape"], [1, self.S, 64, self.DK_])
+        self.assertEqual(seen["lse_shape"], [1, self.S, 64])
+        self.assertTrue(bool(np.isfinite(seen["lse"]).all()))
+
+    def test_empty_slots_are_zeroed_and_rows_renormalised(self):
+        """Whatever the kernel writes at ``-1`` slots is discarded.
+
+        A uniform kernel output makes the expectation exact: each row becomes
+        uniform over its valid columns, and the all-empty row stays all zeros
+        rather than turning into ``0/0`` -- the KL reduction divides by the
+        valid-row count, so a padded row must contribute nothing.
+        """
+        _, target = self._run()
+        np.testing.assert_allclose(
+            target.numpy(),
+            np.array([[[0.5, 0.5, 0.0, 0.0], [1.0, 0, 0, 0], [0, 0, 0, 0]]]),
+            atol=1e-6,
+        )
+        self.assertEqual(target.dtype, paddle.float32)
+
+
+class TestMQASparseAttnLseSideChannelMocked(unittest.TestCase):
+    """``mqa_sparse_attn``'s ``lse_indexer`` side channel, kernel mocked out.
+
+    The LSE cannot be a PyLayer output (every returned tensor would demand a
+    matching backward gradient), so it travels on a class attribute that the
+    wrapper pops. That popping is pure Python and is what this checks, together
+    with the ``indexer_topk`` pass-through and the two return signatures.
+    """
+
+    S, H_Q, DK_, DV_ = 4, 8, 576, 512
+    SCALE = 0.1
+
+    def _inputs(self):
+        query = paddle.zeros([1, self.S, self.H_Q, self.DK_], dtype="bfloat16")
+        kv = paddle.zeros([1, self.S, self.DK_], dtype="bfloat16")
+        idx = paddle.arange(self.S, dtype="int32").reshape([1, 1, self.S])
+        idx = paddle.where(
+            idx <= paddle.arange(self.S, dtype="int32").reshape([1, self.S, 1]),
+            idx.tile([1, self.S, 1]),
+            paddle.full([1, self.S, self.S], -1, dtype="int32"),
+        )
+        return query, kv, idx.contiguous()
+
+    def _patched_kernel(self, calls):
+        import paddlefleet.cudnn_ops.attn.csa_sparse_attn_fwd_cudnn as fwd_mod
+
+        def fake(q_pad, kv, sink, token_indices, **kwargs):
+            calls.append(kwargs)
+            b, s = int(q_pad.shape[0]), int(q_pad.shape[1])
+            out = paddle.zeros([b, s, 64, kwargs["d_v"]], dtype=q_pad.dtype)
+            lse = paddle.zeros([b, s, 64], dtype="float32")
+            # The kernel returns ``None`` for a 0 budget; a non-None value for
+            # a real one, so a leak would be visible on the next call.
+            lse_indexer = (
+                None
+                if kwargs["indexer_topk"] == 0
+                else paddle.full([b, s, 64], 1.5, dtype="float32")
+            )
+            return out, lse, lse_indexer
+
+        return mock.patch.object(fwd_mod, "flash_mla_sparse_attn", fake)
+
+    def _call(self, indexer_topk, calls):
+        from paddlefleet.fusions.mqa_sparse_attn import mqa_sparse_attn
+
+        query, kv, idx = self._inputs()
+        with self._patched_kernel(calls):
+            return mqa_sparse_attn(
+                query,
+                kv,
+                idx,
+                self.SCALE,
+                self.DV_,
+                attn_sink=None,
+                indexer_topk=indexer_topk,
+            )
+
+    def tearDown(self):
+        from paddlefleet.fusions.mqa_sparse_attn import _MQASparseAttention
+
+        _MQASparseAttention._lse_indexer = None
+
+    def test_zero_budget_keeps_the_single_output_signature(self):
+        calls = []
+        out = self._call(0, calls)
+        self.assertIsInstance(out, paddle.Tensor)
+        self.assertEqual(list(out.shape), [1, self.S, self.H_Q * self.DV_])
+        self.assertEqual(calls[0]["indexer_topk"], 0)
+
+    def test_positive_budget_returns_and_forwards_the_lse(self):
+        calls = []
+        out, lse_indexer = self._call(512, calls)
+        self.assertEqual(calls[0]["indexer_topk"], 512)
+        self.assertEqual(list(out.shape), [1, self.S, self.H_Q * self.DV_])
+        self.assertEqual(list(lse_indexer.shape), [1, self.S, 64])
+        self.assertEqual(lse_indexer.dtype, paddle.float32)
+
+    def test_the_side_channel_never_outlives_one_call(self):
+        """Popped on every call, so a stale LSE cannot reach the next one.
+
+        Without the reset a 0-budget call following a 512 one would still find
+        the previous tensor on the class -- harmless today (the return value is
+        gated on ``indexer_topk``) but it would pin one LSE per layer alive for
+        the whole step.
+        """
+        from paddlefleet.fusions.mqa_sparse_attn import _MQASparseAttention
+
+        calls = []
+        self._call(512, calls)
+        self.assertIsNone(_MQASparseAttention._lse_indexer)
+        self._call(0, calls)
+        self.assertIsNone(_MQASparseAttention._lse_indexer)
+
+
+class TestSparseAttnPlumbingMocked(unittest.TestCase):
+    """``_sparse_attn`` forwards the sink and the budget, and nothing else.
+
+    Mocking ``mqa_sparse_attn`` keeps this off the SM100 kernels; the method's
+    only job is to hand over ``self.softmax_offset`` and ``indexer_topk``.
+    """
+
+    def setUp(self):
+        _CAPTURED.clear()
+        self.module = _build_module(_create_mqa_config("mqa_dsa"), bf16=True)
+
+    def _patched(self, calls):
+        import paddlefleet.fusions.mqa_sparse_attn as fusion
+
+        def fake(query, kv, token_indices, sm_scale, d_v, **kwargs):
+            calls.append((float(sm_scale), int(d_v), kwargs))
+            return "core_out"
+
+        return mock.patch.object(fusion, "mqa_sparse_attn", fake)
+
+    def test_budget_and_sink_are_forwarded(self):
+        calls = []
+        with self._patched(calls):
+            got = self.module._sparse_attn(
+                paddle.zeros([1, 2, H, DK], dtype="bfloat16"),
+                paddle.zeros([1, 2, DK], dtype="bfloat16"),
+                paddle.zeros([1, 2, 4], dtype="int32"),
+                self.module.softmax_scale,
+                DV,
+                indexer_topk=512,
+            )
+        self.assertEqual(got, "core_out")
+        scale, d_v, kwargs = calls[0]
+        self.assertEqual((scale, d_v), (self.module.softmax_scale, DV))
+        self.assertEqual(kwargs["indexer_topk"], 512)
+        # No sink configured in this fixture: the backend reads ``None`` as
+        # "sinkless softmax", it is not an omitted argument.
+        self.assertIsNone(kwargs["attn_sink"])
+        self.assertIn("attn_sink", kwargs)
+
+
+class TestForwardDsaFusedDispatchMocked(unittest.TestCase):
+    """Which target path ``_forward_sparse`` selects, with both kernels mocked.
+
+    ``TestMQADSACudnnTarget`` covers the same decision on real kernels; this
+    reaches it without any, so the branch stays checked on machines below
+    SM100. Mocked: the indexer top-k kernel, the sparse-attention call and the
+    target itself -- everything between them (window table, concat order, KL,
+    loss logging) is the real code.
+    """
+
+    S = 256
+    WIDE_TOPK = 384  # a legal index_topk the kernel does not implement
+
+    def _build(self, topk):
+        config = _create_mqa_config("mqa_dsa", loss_coeff=0.01)
+        config.dsa_index_topk = topk
+        module = _build_module(config, bf16=True)
+        module.train()
+        return module
+
+    def _topk_table(self, topk):
+        """``[1, S, topk]`` causal-ish table, right-padded with ``-1``."""
+        cols = paddle.arange(topk, dtype="int32").reshape([1, 1, topk])
+        rows = paddle.arange(self.S, dtype="int32").reshape([1, self.S, 1])
+        return paddle.where(
+            cols <= rows,
+            cols.tile([1, self.S, 1]),
+            paddle.full([1, self.S, topk], -1, dtype="int32"),
+        ).contiguous()
+
+    def _run(self, topk):
+        module = self._build(topk)
+        DSAIndexerLossLoggingHelper.tracker.clear()
+        seen = {}
+        table = self._topk_table(topk)
+
+        import paddlefleet.cudnn_ops.indexer.csa_indexer_fwd_cudnn as fwd_mod
+
+        def fake_topk(q, k, w, **kwargs):
+            width = int(kwargs["topk_effective"])
+            scores = paddle.rand([1, self.S, width], dtype="float32")
+            return self._topk_table(width), None, scores
+
+        def fake_indexer(x, qr, position_offset, cp_group):
+            return (
+                paddle.zeros(
+                    [1, self.S, INDEX_HEADS, INDEX_HEAD_DIM], dtype="bfloat16"
+                ),
+                paddle.zeros([1, self.S, INDEX_HEAD_DIM], dtype="bfloat16"),
+                paddle.zeros([1, self.S, INDEX_HEADS], dtype="bfloat16"),
+            )
+
+        def fake_sparse_attn(
+            query, kv, token_indices, sm_scale, d_v, indexer_topk=0
+        ):
+            seen["indexer_topk"] = int(indexer_topk)
+            seen["token_indices"] = token_indices.numpy().copy()
+            core_out = query.reshape([1, self.S, H * DK])[:, :, : H * DV]
+            if indexer_topk == 0:
+                return core_out
+            return core_out, paddle.full([1, self.S, 64], 1.5, dtype="float32")
+
+        def fake_target(query, kv, topk_indices, lse_indexer=None):
+            seen["lse_indexer"] = lse_indexer
+            width = int(topk_indices.shape[-1])
+            return paddle.full([1, self.S, width], 1.0 / width, dtype="float32")
+
+        query, key, w_v, x, qr = _make_inputs(self.S, seed=0, with_hidden=True)
+        tensors = [t.clone() for t in (query, key, x, qr)]
+        for tensor in tensors:
+            tensor.stop_gradient = False
+        module.indexer.forward_before_topk = fake_indexer
+        module._sparse_attn = fake_sparse_attn
+        module._attn_target = fake_target
+        with mock.patch.object(fwd_mod, "cudnn_indexer_topk_fwd", fake_topk):
+            out = module(
+                tensors[0],
+                tensors[1],
+                None,
+                None,
+                _row_end([self.S], self.S),
+                v_b_proj_weight=w_v,
+                x=tensors[2],
+                qr=tensors[3],
+            )
+        seen["output"] = out
+        seen["table"] = table.numpy()
+        return seen
+
+    def test_supported_budget_requests_the_lse_and_reuses_it(self):
+        topk = _LSE_INDEXER_TOPKS[0]
+        seen = self._run(topk)
+        self.assertEqual(seen["indexer_topk"], topk)
+        # The indexer columns must come first: the kernel's LSE covers the
+        # leading ``indexer_topk`` columns of the table, so the window has to
+        # sit in the tail.
+        table = seen["token_indices"]
+        self.assertEqual(table.shape[-1], topk + WINDOW)
+        doc_start, _, is_valid, _, _ = _derive_csa_doc_boundaries(
+            _row_end([self.S], self.S), self.S
+        )
+        window = (
+            _build_window_topk_idxs_from_doc_bounds(
+                1, self.S, WINDOW, doc_start, is_valid
+            )
+            .cast("int32")
+            .numpy()
+        )
+        np.testing.assert_array_equal(table[:, :, topk:], window)
+        # ``_forward_sparse`` blanks the rows whose candidate range is empty (the
+        # first ``window_size`` tokens of a document), so compare where the
+        # prefix survived.
+        prefix, selected = table[:, :, :topk], seen["table"]
+        kept = prefix != -1
+        self.assertGreater(int(kept.sum()), 0)
+        np.testing.assert_array_equal(prefix[kept], selected[kept])
+        self.assertIsNotNone(seen["lse_indexer"])
+        self.assertEqual(list(seen["lse_indexer"].shape), [1, self.S, 64])
+        loss = float(DSAIndexerLossLoggingHelper.tracker["values"][0])
+        self.assertTrue(np.isfinite(loss))
+
+    def test_unsupported_budget_asks_for_no_lse(self):
+        self.assertNotIn(self.WIDE_TOPK, _LSE_INDEXER_TOPKS)
+        seen = self._run(self.WIDE_TOPK)
+        self.assertEqual(seen["indexer_topk"], 0)
+        self.assertIsNone(seen["lse_indexer"])
+        loss = float(DSAIndexerLossLoggingHelper.tracker["values"][0])
+        self.assertTrue(np.isfinite(loss))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
非吸收 MQA 层（`csa_compress_ratios == -2`）的 indexer loss target 原本用纯 Paddle 算子分块实现，s=8192 下要循环 32 次、反复 gather key 做 matmul，等于把 attention 打分重算一遍。

nsys 实测单次 15.7 ms，比该层真正的 sparse attention kernel 贵 15 倍。本 PR 改用 cudnn 的`sparse_attn_score_recompute_wrapper`（与 #1596 在 CSA 层的做法一致），实测该段加速约 20 倍。

kernel 需要限定在选中列上的 per-head LSE，因此 `mqa_sparse_attn` 增加 `indexer_topk` 参数透传 FlashMLA 的 `lse_indexer`，并把 index 表顺序从 `[window, topk]` 改为 `[topk, window]`—— `lse_indexer` 只覆盖表内前 `indexer_topk` 列。`dsa_indexer_use_sparse_loss=False` 情况下自动回退到保留的 Python 参考实现。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
是

新feature, Developed from: Merged in dev: #1675