### PR TITLE
Fix CSA single test issue

### DIFF
--- a/tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_backends.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_backends.py
@@ -578,6 +578,9 @@ class TestCsaBwdTopkLengthDispatch(unittest.TestCase):
             attn_sink_dtype=attn_sink.dtype,
             backend="cudnn",
             has_topk_length=False,
+            query_needs_grad=not query.stop_gradient,
+            kv_full_needs_grad=not kv_full.stop_gradient,
+            attn_sink_needs_grad=not attn_sink.stop_gradient,
         )
         grad_output = paddle.randn([b, sq, np_heads, hn])
         return ctx, grad_output


### PR DESCRIPTION
### PR Category

Execute Infrastructure

### PR Types

Bug fixes

### Description

#### 问题背景

`CSASparseAttention.forward()` 会在 PyLayer 的 `ctx` 中记录三个输入是否需要梯度：

```python
ctx.query_needs_grad = not query.stop_gradient
ctx.kv_full_needs_grad = not kv_full.stop_gradient
ctx.attn_sink_needs_grad = not attn_sink.stop_gradient
```

`CSASparseAttention.backward()` 根据这些属性决定返回对应的梯度张量还是 `None`：

```python
grads = (
    dq if ctx.query_needs_grad else None,
    dkv if ctx.kv_full_needs_grad else None,
    d_attn_sink if ctx.attn_sink_needs_grad else None,
    None,
)
```

#### 错误现象

单卡 CI 中以下两个测试失败：

```text
TestCsaBwdTopkLengthDispatch::test_sm90_receives_none
TestCsaBwdTopkLengthDispatch::test_sm100_receives_int32_bound
```

报错信息为：

```text
AttributeError: 'types.SimpleNamespace' object has no attribute 'query_needs_grad'
```

#### 根因分析

`TestCsaBwdTopkLengthDispatch` 为了验证不同 GPU 架构下 `topk_length` 参数的分发行为，绕过了正常的 `CSASparseAttention.forward()` 调用链，使用 `SimpleNamespace` 手动构造 fake `ctx`，并直接调用 `CSASparseAttention.backward()`。

生产代码中的 `ctx` 接口新增了 `query_needs_grad`、`kv_full_needs_grad` 和 `attn_sink_needs_grad` 三个属性，但测试中的 fake `ctx` 没有同步更新。因此 mock backward kernel 执行完成后，`CSASparseAttention.backward()` 在组装梯度返回值时访问缺失属性，最终抛出 `AttributeError`。

该问题只存在于手动构造的测试 fixture。正常运行路径会由 `CSASparseAttention.forward()` 初始化上述属性，因此不影响真实训练逻辑。

该失败由其他 PR 的全量单卡 CI 暴露，触发失败的 PR 本身没有修改 CSA sparse attention 相关代码。

#### 修复方案

在 `_fake_ctx()` 中按照生产代码的相同语义补齐三个梯度状态属性：

```python
query_needs_grad=not query.stop_gradient,
kv_full_needs_grad=not kv_full.stop_gradient,
attn_sink_needs_grad=not attn_sink.stop_gradient,
```

修复后，测试 fixture 与 `CSASparseAttention.forward()` 创建的真实 `ctx` 保持一致。

#### 影响范围

本次修改只更新测试 fixture，不修改 CSA 生产逻辑、梯度计算逻辑或不同 GPU 架构下的 `topk_length` 分发行为。

#### 验证

- `python -m py_compile tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_backends.py`：通过。
- `git diff --check`：通过。
- 目标测试覆盖 SM90 下 `topk_length=None` 和 SM100+ 下传递 int32 trailing bound 两条分发路径。

### 是否引起精度变化

否

单测修复cherry-pick from: Merged in dev: #1649
