### PR TITLE
[CSA] Use deterministic topk for cudnn indexer

### DIFF
--- a/src/paddlefleet/cudnn_ops/indexer/csa_indexer_fwd_cudnn.py
+++ b/src/paddlefleet/cudnn_ops/indexer/csa_indexer_fwd_cudnn.py
@@ -122,6 +122,45 @@ def _validate_indexer_inputs(index_q, index_k_comp, weights):
         raise ValueError(f"cuDNN IndexerForward requires D_i=128, got {dim}")
 
 
+def _indexer_top_k_unfused(
+    input_values: paddle.Tensor,
+    seq_lens: paddle.Tensor,
+    top_k: int,
+    return_val: bool = True,
+):
+    """
+    Deterministic topk in replacement of cudnn indexer_top_k_wrapper.
+
+    Expects input_values be masked by seq_lens (as indexer_forward_wrapper does).
+    """
+    # Note: paddle.topk doesn't allow k greater than the axis size.
+    k = min(top_k, input_values.shape[-1])
+    topk_values, topk_indices = paddle.topk(input_values, k, axis=-1)
+    topk_indices = topk_indices.astype("int32")
+
+    if k < top_k:
+        topk_values = paddle.nn.functional.pad(
+            topk_values, (0, 0, 0, top_k - k), value=float("-inf")
+        )
+        topk_indices = paddle.nn.functional.pad(
+            topk_indices, (0, 0, 0, top_k - k), value=-1
+        )
+
+    # Entries outside each row's valid prefix [0, seq_lens) are already -inf.
+    # Since topk returns results in descending order, these invalid entries occupy
+    # output slots [seq_lens, top_k), whose indices can therefore be set to -1.
+    topk_indices = paddle.where(
+        paddle.arange(top_k, dtype="int32") < seq_lens[:, None],
+        topk_indices,
+        paddle.full_like(topk_indices, -1),
+    )
+
+    return {
+        "indices": topk_indices,
+        "values": topk_values if return_val else None,
+    }
+
+
 def cudnn_indexer_forward(
     index_q, index_k_comp, weights, ratio=4, sm_scale=None, seq_offset=0
 ):
@@ -194,11 +233,6 @@ def cudnn_indexer_topk(scores, sq, ratio, topk, valid_range=None, seq_offset=0):
     seq_offset = int(seq_offset)
     topk_k = min(topk, sk)
 
-    _require_cudnn_frontend()
-    from paddlefleet_ops.cudnn.deepseek_sparse_attention.indexer_top_k.api import (
-        indexer_top_k_wrapper,
-    )
-
     if valid_range is None:
         # Causal-only (single-document): the radix kernel's per-row prefix
         # length is exactly the ratio-causal limit. No id remap needed —
@@ -229,11 +263,10 @@ def cudnn_indexer_topk(scores, sq, ratio, topk, valid_range=None, seq_offset=0):
         seq_lens = counts.reshape([batch * sq]).cast("int32")
         valid_range_for_remap = valid_range
 
-    result = indexer_top_k_wrapper(
+    result = _indexer_top_k_unfused(
         scores_for_topk.reshape([batch * sq, sk]).contiguous(),
         seq_lens,
         top_k=topk_k,
-        next_n=1,
         return_val=False,
     )
     topk_indices = result["indices"].reshape([batch, sq, topk_k]).cast("int32")
@@ -486,9 +519,6 @@ def _cudnn_indexer_topk_fwd_docmask_thd(
     from paddlefleet_ops.cudnn.deepseek_sparse_attention.indexer_forward.api import (
         indexer_forward_wrapper,
     )
-    from paddlefleet_ops.cudnn.deepseek_sparse_attention.indexer_top_k.api import (
-        indexer_top_k_wrapper,
-    )
 
     from .docmask_utils import topk_local_to_global, valid_range_to_counts
 
@@ -527,7 +557,7 @@ def _cudnn_indexer_topk_fwd_docmask_thd(
     counts = valid_range_to_counts(valid_range)
 
     # Compute topk indices [local_seqlen, topk]
-    results = indexer_top_k_wrapper(
+    results = _indexer_top_k_unfused(
         scores,
         counts.squeeze(0),
         top_k=topk_effective,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
Operator Mechanism


### PR Types
Bug fixes


### Description
将 cudnn 的非确定的 topk 临时换成确定性的 paddle.topk，原来的非确定性无法接受，后续再进行融合算子优化

性能其实还可以，至少比语法有缺陷的 triton 快了5倍，triton 根本没法写出高性能的 radix select，因为没有 shared memory 也没法精确操作寄存器，性能拉爆了


### 是否引起精度变化
否

原来的 cudnn 实现根本没有精度可言，所以可以认为没有精度变化