### PR TITLE
[Performance] DSAIndexer 的多头 Q / 共享 K 打分结构 支持 use_fast_hadamard

### DIFF
--- a/src/paddlefleet/transformer/dsa_attention.py
+++ b/src/paddlefleet/transformer/dsa_attention.py
@@ -317,6 +317,7 @@ class DSAIndexer(paddle.nn.Layer):
             self.rope_head_dim = config.qk_rope_head_dim
         self.nope_head_dim = self.head_dim - self.rope_head_dim
         self.softmax_scale = self.head_dim**-0.5
+        self.use_fast_hadamard = getattr(config, "use_fast_hadamard", False)
 
         # wq_b: q_lora_rank -> n_heads * head_dim (duplicated)
         self.wq_b = build_spec_layer(
@@ -475,8 +476,8 @@ class DSAIndexer(paddle.nn.Layer):
         k = self._apply_rope(k.unsqueeze(2), freqs, mscale).squeeze(2)
 
         # Rotate activation (Hadamard transform)
-        q = rotate_activation(q)
-        k = rotate_activation(k)
+        q = rotate_activation(q, use_fast_hadamard=self.use_fast_hadamard)
+        k = rotate_activation(k, use_fast_hadamard=self.use_fast_hadamard)
 
         weights, _ = self.weights_proj(hidden_states)
         weights = weights * (self.n_heads**-0.5) * self.softmax_scale

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_dsa_attention.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_dsa_attention.py
@@ -243,7 +243,7 @@ class TestIndexer(unittest.TestCase):
 
     @patch("paddlefleet.transformer.dsa_attention.rotate_activation")
     def test_forward_before_topk_shape(self, mock_rotate):
-        mock_rotate.side_effect = lambda x: x
+        mock_rotate.side_effect = lambda x, use_fast_hadamard=False: x
         config = _make_config()
         spec = _make_indexer_sublayers_spec()
         indexer = Indexer(config, sublayers_spec=spec, layer_number=1)
@@ -253,6 +253,27 @@ class TestIndexer(unittest.TestCase):
         self.assertEqual(q.shape, [2, 4, 1, 16])
         self.assertEqual(k.shape, [2, 4, 16])
         self.assertEqual(weights.shape, [2, 4, 1])
+        # rotate_activation must be called with use_fast_hadamard following the
+        # indexer's config (defaults to False here).
+        for call in mock_rotate.call_args_list:
+            self.assertEqual(call.kwargs.get("use_fast_hadamard"), False)
+
+    @patch("paddlefleet.transformer.dsa_attention.rotate_activation")
+    def test_forward_before_topk_use_fast_hadamard(self, mock_rotate):
+        mock_rotate.side_effect = lambda x, use_fast_hadamard=False: x
+        config = _make_config(use_fast_hadamard=True)
+        spec = _make_indexer_sublayers_spec()
+        indexer = Indexer(config, sublayers_spec=spec, layer_number=1)
+        hidden = paddle.randn([2, 4, 64], dtype="float32")
+        q_latent = paddle.randn([2, 4, 16], dtype="float32")
+        q, k, weights = indexer.forward_before_topk(hidden, q_latent)
+        self.assertEqual(q.shape, [2, 4, 1, 16])
+        self.assertEqual(k.shape, [2, 4, 16])
+        self.assertEqual(weights.shape, [2, 4, 1])
+        # Both q and k rotations must go through the fast Hadamard path.
+        self.assertEqual(mock_rotate.call_count, 2)
+        for call in mock_rotate.call_args_list:
+            self.assertEqual(call.kwargs.get("use_fast_hadamard"), True)
 
 
 class TestFusedDSAIndexerLoss(unittest.TestCase):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
Performance Optimization 


### PR Types
 Performance 


### Description
DSAIndexer 的多头 Q / 共享 K 打分结构 支持 use_fast_hadamard


### 是否引起精度变化
否
