### PR TITLE
[release/0.4][Deps] Bump Paddle to 733f3454aa0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ description = "Fleet Core - Core Functional Library for Large Scale Distributed 
 requires-python = ">=3.10"
 dependencies = [
     "colorlog>=6.10.1",
-    "paddlepaddle-gpu==3.4.0.post20260731+3cc38fddf4b",
+    "paddlepaddle-gpu==3.4.0.post20260808+733f3454aa0",
     "tilelang-paddle==0.1.12",
 ]
 license = { text = "Apache 2.0" }


### PR DESCRIPTION
### PR Category
Environment Adaptation

### PR Types
Others

### Description
Bump the pinned CUDA 12.9 Paddle dependency on `release/0.4` from `paddlepaddle-gpu==3.4.0.post20260731+3cc38fddf4b` to the verified release-nightly artifact `paddlepaddle-gpu==3.4.0.post20260808+733f3454aa0`.

Target Paddle commit: [`733f3454aa05d3e6024d0acb22a6ad2aad396b74`](https://github.com/PaddlePaddle/Paddle/commit/733f3454aa05d3e6024d0acb22a6ad2aad396b74), the protected `release/3.4` head at verification time.

Merge sequencing: develop PR [#1677](https://github.com/PaddlePaddle/PaddleFleet/pull/1677) was created in parallel and must merge first; this release PR must remain blocked until then.

**Artifact verification:** the [official CUDA 12.9 Linux x86_64 CPython 3.12 wheel](https://paddle-whl.bj.bcebos.com/nightly/cu129/paddlepaddle-gpu/paddlepaddle_gpu-3.4.0.post20260808+733f3454aa0-cp312-cp312-linux_x86_64.whl) is present on Paddle's authoritative nightly index. Its `METADATA` reports `Name: paddlepaddle-gpu` and `Version: 3.4.0.post20260808+733f3454aa0`; `paddle/version/__init__.py` embeds the full target commit and `cuda_version = '12.9'`; and `WHEEL` reports `cp312-cp312-linux_x86_64`. SHA-256: `070c9fd0de73d967c8004020264761755544af2454689f2b7c2e752949837c81`.

A fresh CPython 3.12 virtual environment successfully installed this exact Linux wheel into an empty cross-platform target with `--no-index --no-deps --no-cache-dir --only-binary`; the installed metadata, full commit, CUDA version, and wheel tag were re-checked without importing Paddle.

**Local validation:** TOML and PEP 508 parsing, `git diff --check`, exact one-file/one-line delta review for the real `release/0.4` head, and `pre-commit run --files pyproject.toml` all pass.

### 是否引起精度变化
否
