### PR TITLE
[release/0.4][BugFix] Support dense model when n_routed_experts is 0

### DIFF
--- a/src/paddlefleet/models/gpt/gpt_layer_specs.py
+++ b/src/paddlefleet/models/gpt/gpt_layer_specs.py
@@ -721,7 +721,8 @@ def get_mlp_layer_spec_for_backend(
     down_proj = backend.row_parallel_linear()
     hidden_act = None
 
-    if num_experts is None:
+    # num_experts may be 0 or None
+    if not num_experts:
         # Dense MLP w/ or w/o TE layers.
         layer = MLP
         if backend.fuse_layernorm_and_linear():


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
0 experts == dense (not a degenerate MoE). 原来只判 `is None`, 导致 num_experts==0 的层被建成 MoE, 其 gate 权重 shape=[0, hidden] (numel=0) -> 分布式广播时 `Size of tensor should be greater than 0` 报错。把 0 也当 dense。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否

Cherry-pick of #1671 to `release/0.4`.

Merged in dev: #1671  <!-- For pass CI -->