### PR TITLE
[release/0.4][Performance] Split kv_b_proj and drop the strided copy before grouped matmul

### DIFF
--- a/src/paddlefleet/transformer/mqa_latent_attention.py
+++ b/src/paddlefleet/transformer/mqa_latent_attention.py
@@ -269,13 +269,13 @@ class MQALatentAttention(FleetLayer):
             else config.num_attention_heads,
             is_swa,
         )
-        # Shares ``non_absorbed_mqa_split_kv_b_proj`` with the query-side
+        # Shares ``mqa_split_kv_b_proj`` with the query-side
         # absorption: when set, ``MLASelfAttention`` passes its standalone
         # ``v_b_proj`` parameter instead of a view of ``kv_b_proj.weight``, laid
         # out as ``[h, v_head_dim, kv_lora_rank]`` for ``fused_grouped_matmul``
         # rather than the ``[kv_lora_rank, h, v_head_dim]`` the einsum wants.
         self.split_kv_b = bool(
-            getattr(config, "non_absorbed_mqa_split_kv_b_proj", False)
+            getattr(config, "mqa_split_kv_b_proj", False)
         )
         # Latent width, i.e. the value width the sparse kernel sees and the
         # contraction dim of the de-absorption weight. This layer only exists on
@@ -360,7 +360,7 @@ class MQALatentAttention(FleetLayer):
                 v_head_dim]`` (the V slice of ``kv_b_proj``) by default, or the
                 standalone ``v_b_proj`` parameter as ``[h, v_head_dim,
                 kv_lora_rank]`` under
-                ``non_absorbed_mqa_split_kv_b_proj``.
+                ``mqa_split_kv_b_proj``.
             input_ids: ``[b, s]`` token ids, only used to build the indexer-loss
                 row mask (``!= pad_token_id``). ``None`` falls back to the plain
                 row mean, as CSA does at ``csa_attention.py:1306``.
@@ -410,7 +410,7 @@ class MQALatentAttention(FleetLayer):
                 "v_b_proj_weight layout mismatch: expected contraction dim "
                 f"kv_lora_rank={kv_lora_rank}, got shape "
                 f"{v_b_proj_weight.shape} with "
-                f"non_absorbed_mqa_split_kv_b_proj={self.split_kv_b}."
+                f"mqa_split_kv_b_proj={self.split_kv_b}."
             )
 
         with paddle.no_grad():

--- a/src/paddlefleet/transformer/mqa_latent_attention.py
+++ b/src/paddlefleet/transformer/mqa_latent_attention.py
@@ -187,6 +187,21 @@ class MQALatentAttention(FleetLayer):
             else config.num_attention_heads,
             is_swa,
         )
+        # Shares ``non_absorbed_mqa_split_kv_b_proj`` with the query-side
+        # absorption: when set, ``MLASelfAttention`` passes its standalone
+        # ``v_b_proj`` parameter instead of a view of ``kv_b_proj.weight``, laid
+        # out as ``[h, v_head_dim, kv_lora_rank]`` for ``fused_grouped_matmul``
+        # rather than the ``[kv_lora_rank, h, v_head_dim]`` the einsum wants.
+        self.split_kv_b = bool(
+            getattr(config, "non_absorbed_mqa_split_kv_b_proj", False)
+        )
+        # Latent width, i.e. the value width the sparse kernel sees and the
+        # contraction dim of the de-absorption weight. This layer only exists on
+        # the ``dsv4_hybrid`` path, so the hybrid field is the authoritative one.
+        kv_lora_rank = getattr(config, "hybrid_mla_kv_lora_rank", None)
+        if kv_lora_rank is None:
+            kv_lora_rank = config.kv_lora_rank
+        self.kv_lora_rank = int(kv_lora_rank)
 
     def forward(
         self,
@@ -219,8 +234,11 @@ class MQALatentAttention(FleetLayer):
             attn_mask_startend_row_indices: ``[b, 1, s, 1]`` exclusive per-token
                 document end rows. ``None`` means a single document.
             x / qr: hidden states / q latent, inputs of the DSA indexer.
-            v_b_proj_weight: ``[kv_lora_rank, h, v_head_dim]`` de-absorption
-                weight (the V slice of ``kv_b_proj``).
+            v_b_proj_weight: de-absorption weight. ``[kv_lora_rank, h,
+                v_head_dim]`` (the V slice of ``kv_b_proj``) by default, or the
+                standalone ``v_b_proj`` parameter as ``[h, v_head_dim,
+                kv_lora_rank]`` under
+                ``non_absorbed_mqa_split_kv_b_proj``.
             input_ids: ``[b, s]`` token ids, only used to build the indexer-loss
                 row mask (``!= pad_token_id``). ``None`` falls back to the plain
                 row mean, as CSA does at ``csa_attention.py:1306``.
@@ -255,7 +273,19 @@ class MQALatentAttention(FleetLayer):
                 f"are packed along the sequence), got b={b}."
             )
         kv = key.squeeze(2).contiguous()  # [b, s, kv_lora + qk_rope]
-        kv_lora_rank = int(v_b_proj_weight.shape[0])
+        kv_lora_rank = self.kv_lora_rank
+        # The de-absorption weight's contraction dim sits last in the
+        # grouped-matmul layout and first in the einsum one. Checking it here
+        # turns a silently-wrong ``[G, R, D]`` / ``[l, h, v]`` mix-up (both
+        # reshape fine) into an error at the first forward.
+        contraction = v_b_proj_weight.shape[-1 if self.split_kv_b else 0]
+        if int(contraction) != kv_lora_rank:
+            raise ValueError(
+                "v_b_proj_weight layout mismatch: expected contraction dim "
+                f"kv_lora_rank={kv_lora_rank}, got shape "
+                f"{v_b_proj_weight.shape} with "
+                f"non_absorbed_mqa_split_kv_b_proj={self.split_kv_b}."
+            )
 
         with paddle.no_grad():
             row_end = attn_mask_startend_row_indices
@@ -276,7 +306,7 @@ class MQALatentAttention(FleetLayer):
             core_out = self._sparse_attn(
                 query, kv, token_indices, self.softmax_scale, kv_lora_rank
             )
-            return self._deabsorb(core_out, v_b_proj_weight)
+            return self._deabsorb(core_out, v_b_proj_weight, self.split_kv_b)
 
         return self._forward_dsa(
             query,
@@ -352,13 +382,25 @@ class MQALatentAttention(FleetLayer):
         )
 
     @staticmethod
-    def _deabsorb(core_out, v_b_proj_weight) -> Tensor:
+    @staticmethod
+    def _deabsorb(core_out, v_b_proj_weight, split_kv_b=False) -> Tensor:
         """``[b, s, h * kv_lora_rank]`` -> ``[b, s, h * v_head_dim]``."""
         b, s, _ = core_out.shape
-        kv_lora_rank, h, v_head_dim = v_b_proj_weight.shape
-        out = core_out.reshape([b, s, h, kv_lora_rank])
-        out = paddle.einsum("bshl,lhv->bshv", out, v_b_proj_weight)
-        return out.reshape([b, s, h * v_head_dim])
+        if split_kv_b:
+            # ``v_b_proj``: [h, v_head_dim, kv_lora_rank], the grouped-matmul
+            # ``[G, R, D]`` contract -- one Triton GEMM, no transpose.
+            from paddlefleet.triton_ops import fused_grouped_matmul
+
+            h, v_head_dim, kv_lora_rank = v_b_proj_weight.shape
+            out = fused_grouped_matmul(
+                core_out.reshape([b, s, h, kv_lora_rank]), v_b_proj_weight
+            )
+        else:
+            kv_lora_rank, h, v_head_dim = v_b_proj_weight.shape
+            out = core_out.reshape([b, s, h, kv_lora_rank])
+            out = paddle.einsum("bshl,lhv->bshv", out, v_b_proj_weight)
+        out = out.reshape([b, s, h * v_head_dim])
+        return out
 
     # ------------------------------------------------------------------
     # mqa_dsa
@@ -490,7 +532,7 @@ class MQALatentAttention(FleetLayer):
         core_out = self._sparse_attn(
             query, kv, token_indices, self.softmax_scale, kv_lora_rank
         )
-        output = self._deabsorb(core_out, v_b_proj_weight)
+        output = self._deabsorb(core_out, v_b_proj_weight, self.split_kv_b)
         if not need_loss:
             return output
 

--- a/src/paddlefleet/transformer/mqa_latent_attention.py
+++ b/src/paddlefleet/transformer/mqa_latent_attention.py
@@ -405,6 +405,21 @@ class MQALatentAttention(FleetLayer):
         # grouped-matmul layout and first in the einsum one. Checking it here
         # turns a silently-wrong ``[G, R, D]`` / ``[l, h, v]`` mix-up (both
         # reshape fine) into an error at the first forward.
+        # The rank is checked before the contraction dim: a folded 2-D
+        # parameter that was never reshaped back would otherwise pass the
+        # contraction test and fail deeper down, on an unpacking or reshape
+        # whose message says nothing about the layout.
+        if len(v_b_proj_weight.shape) != 3:
+            expected = (
+                "[h, v_head_dim, kv_lora_rank]"
+                if self.split_kv_b
+                else "[kv_lora_rank, h, v_head_dim]"
+            )
+            raise ValueError(
+                f"v_b_proj_weight must be 3-D {expected}, got shape "
+                f"{v_b_proj_weight.shape} with "
+                f"mqa_split_kv_b_proj={self.split_kv_b}."
+            )
         contraction = v_b_proj_weight.shape[-1 if self.split_kv_b else 0]
         if int(contraction) != kv_lora_rank:
             raise ValueError(

--- a/src/paddlefleet/transformer/mqa_latent_attention.py
+++ b/src/paddlefleet/transformer/mqa_latent_attention.py
@@ -480,7 +480,6 @@ class MQALatentAttention(FleetLayer):
         )
 
     @staticmethod
-    @staticmethod
     def _deabsorb(core_out, v_b_proj_weight, split_kv_b=False) -> Tensor:
         """``[b, s, h * kv_lora_rank]`` -> ``[b, s, h * v_head_dim]``."""
         b, s, _ = core_out.shape
@@ -549,7 +548,7 @@ class MQALatentAttention(FleetLayer):
             core_out = self._sparse_attn(
                 query, kv, token_indices, self.softmax_scale, kv_lora_rank
             )
-            return self._deabsorb(core_out, v_b_proj_weight)
+            return self._deabsorb(core_out, v_b_proj_weight, self.split_kv_b)
 
         with paddle.no_grad():
             window_idxs = None

--- a/src/paddlefleet/transformer/mqa_latent_attention.py
+++ b/src/paddlefleet/transformer/mqa_latent_attention.py
@@ -274,9 +274,7 @@ class MQALatentAttention(FleetLayer):
         # ``v_b_proj`` parameter instead of a view of ``kv_b_proj.weight``, laid
         # out as ``[h, v_head_dim, kv_lora_rank]`` for ``fused_grouped_matmul``
         # rather than the ``[kv_lora_rank, h, v_head_dim]`` the einsum wants.
-        self.split_kv_b = bool(
-            getattr(config, "mqa_split_kv_b_proj", False)
-        )
+        self.split_kv_b = bool(getattr(config, "mqa_split_kv_b_proj", False))
         # Latent width, i.e. the value width the sparse kernel sees and the
         # contraction dim of the de-absorption weight. This layer only exists on
         # the ``dsv4_hybrid`` path, so the hybrid field is the authoritative one.

--- a/src/paddlefleet/transformer/multi_latent_attention.py
+++ b/src/paddlefleet/transformer/multi_latent_attention.py
@@ -465,12 +465,13 @@ class MultiLatentAttention(Attention):
             config, "hybrid_mla_attention", "mha"
         ) in ("mqa_dsa", "mqa_full_causal")
         # ``mqa_split_kv_b_proj`` trades that property for speed:
-        # ``kv_b_proj`` is split into standalone ``k_b_proj`` / ``v_b_proj``
+        # ``kv_b_proj`` is replaced by standalone ``k_b_proj`` / ``v_b_proj``
         # absorption parameters, pre-laid-out so each side is one grouped GEMM
-        # instead of a slice + ``einsum``. A checkpoint that predates them must
-        # have both split out of ``kv_b_proj.weight`` by the loader. Applies to
-        # both latent MQA modes -- the split only concerns absorption, not the
-        # indexer.
+        # instead of a slice + ``einsum``. The two together hold exactly the
+        # elements of ``kv_b_proj.weight``, which is therefore not built at all;
+        # a checkpoint that predates them cannot be resumed in this mode until
+        # the AOA statements that split it exist. Applies to both latent MQA
+        # modes -- the split only concerns absorption, not the indexer.
         self.mqa_latent_split_kv_b = self.mqa_latent and getattr(
             config, "mqa_split_kv_b_proj", False
         )
@@ -1394,46 +1395,57 @@ class MLASelfAttention(MultiLatentAttention):
             tp_group=pg_collection.tp,
         )
 
-        self.kv_b_proj = build_spec_layer(
-            sublayers_spec.kv_b_proj,
-            kv_lora_rank,
-            self.num_attention_heads
-            * (self.qk_nope_head_dim + self.v_head_dim),
-            config=self.config,
-            init_method=self.config.init_method,
-            gather_output=False,
-            bias=False,
-            skip_bias_add=False,
-            is_expert=False,
-            tp_comm_buffer_name="kv_b_proj",
-            tp_group=pg_collection.tp,
+        # In split mode ``k_b_proj`` / ``v_b_proj`` below *replace* this
+        # projection: together they hold exactly its elements, nothing in the
+        # forward reads it, and it would never receive a gradient. Building it
+        # anyway would double both the resident parameter bytes and the
+        # checkpoint size for this projection, so it is not built at all.
+        self.kv_b_proj = (
+            None
+            if self.mqa_latent_split_kv_b
+            else build_spec_layer(
+                sublayers_spec.kv_b_proj,
+                kv_lora_rank,
+                self.num_attention_heads
+                * (self.qk_nope_head_dim + self.v_head_dim),
+                config=self.config,
+                init_method=self.config.init_method,
+                gather_output=False,
+                bias=False,
+                skip_bias_add=False,
+                is_expert=False,
+                tp_comm_buffer_name="kv_b_proj",
+                tp_group=pg_collection.tp,
+            )
         )
 
         if self.mqa_latent_split_kv_b:
-            # K absorption half of ``kv_b_proj``. Logically
-            # [heads, kv_lora_rank, qk_nope_head_dim] -- ``fused_grouped_matmul``'s
-            # ``[G, R, D]`` contract, which lets the kernel walk the head dim
-            # through strides -- but *stored* with the leading two dims folded so
-            # the parameter itself is 2-D.
+            # K absorption half of ``kv_b_proj``, which this mode replaces.
+            # Logically [heads, kv_lora_rank, qk_nope_head_dim] --
+            # ``fused_grouped_matmul``'s ``[G, R, D]`` contract, which lets the
+            # kernel walk the head dim through strides -- but *stored* with the
+            # leading two dims folded so the parameter itself is 2-D.
             #
-            # The fold is what the checkpoint needs: the AOA statements that split
-            # this out of ``kv_b_proj`` only have split / concat / permute and no
-            # reshape primitive (``flex_checkpoint/aoa/aoa_engine.py:519``), so
-            # they cannot produce a 3-D tensor. Exposing a reshaped *view* from
-            # ``sharded_state_dict`` instead is not safe: DCP reshapes the
-            # ``ShardedWeight.local_tensor`` in place (``reshape_`` /``flatten_``
-            # at ``dcp/load_state_dict.py:557,741,998``), which on a view that
+            # The fold is what the checkpoint needs: AOA statements have only
+            # split / concat / permute and no reshape primitive
+            # (``flex_checkpoint/aoa/aoa_engine.py:519``), so a conversion from
+            # an unsplit ``kv_b_proj.weight`` cannot produce a 3-D tensor.
+            # Exposing a reshaped *view* from ``sharded_state_dict`` instead is
+            # not safe: DCP reshapes the ``ShardedWeight.local_tensor`` in place
+            # (``reshape_`` /``flatten_`` at
+            # ``dcp/load_state_dict.py:557,741,998``), which on a view that
             # aliases the parameter corrupts the parameter's own shape.
             #
             # The 3-D form is recovered per forward with a zero-copy reshape.
             # TP is forced to 1 in this mode, so ``num_attention_heads_per_partition``
             # is the full head count and the parameter needs no TP attributes.
+            params_dtype = self.config.params_dtype
             self.k_b_proj = self.create_parameter(
                 shape=[
                     self.num_attention_heads_per_partition * kv_lora_rank,
                     self.qk_nope_head_dim,
                 ],
-                dtype=self.kv_b_proj.weight.dtype,
+                dtype=params_dtype,
                 default_initializer=paddle.nn.initializer.Constant(0.0),
             )
             self.config.init_method(self.k_b_proj)
@@ -1445,7 +1457,7 @@ class MLASelfAttention(MultiLatentAttention):
                     self.num_attention_heads_per_partition * self.v_head_dim,
                     kv_lora_rank,
                 ],
-                dtype=self.kv_b_proj.weight.dtype,
+                dtype=params_dtype,
                 default_initializer=paddle.nn.initializer.Constant(0.0),
             )
             self.config.init_method(self.v_b_proj)
@@ -2268,7 +2280,10 @@ class MLASelfAttention(MultiLatentAttention):
 
     def _backward_kv_proj(self):
         """Computes weight gradients of KV projection layers"""
-        self.kv_b_proj.backward_dw()
+        # ``kv_b_proj`` does not exist in the split-absorption mode; the two
+        # parameters that replace it are plain tensors with no delayed dw pass.
+        if self.kv_b_proj is not None:
+            self.kv_b_proj.backward_dw()
         self.kv_a_proj_with_mqa.backward_dw()
 
     def _backward_q_proj(self):

--- a/src/paddlefleet/transformer/multi_latent_attention.py
+++ b/src/paddlefleet/transformer/multi_latent_attention.py
@@ -1460,10 +1460,38 @@ class MLASelfAttention(MultiLatentAttention):
             ortho_per_head,
             {"head_sizes": [kv_lora, qk_rope]},
         )
-        specs["kv_b_proj.weight"] = (
-            ortho_per_head,
-            {"heads": num_heads, "head_sizes": [qk_nope, self.v_head_dim]},
-        )
+        if self.mqa_latent_split_kv_b:
+            # ``kv_b_proj`` is split into the standalone ``k_b_proj`` /
+            # ``v_b_proj`` absorption parameters, so the per-head blocks Muon
+            # must orthogonalise moved with them. Both are 2-D with the head dim
+            # folded into the leading axis, so a head is one equal block along
+            # ``axis=-2`` (``-2`` rather than ``0`` so a 3-D input -- Muon
+            # batching several same-shape parameters -- still splits the head
+            # axis and not the batch axis):
+            #   k_b_proj -> [kv_lora_rank, qk_nope_head_dim] per head, the same
+            #               block as the K half of the unsplit weight
+            #   v_b_proj -> [v_head_dim, kv_lora_rank] per head, i.e. the
+            #               transpose of the V half
+            # The transpose is bit-exact under muon_version 3: Newton-Schulz
+            # transposes any block with rows > cols before iterating and back
+            # after, and the version-3 scale ``max(dout, din) ** 0.5`` is
+            # symmetric in the two dims. Versions 1/2 scale with ``dout / din``
+            # and would break the V-side equivalence.
+            specs["k_b_proj"] = (
+                ortho_per_head,
+                {"heads": num_heads, "axis": -2},
+            )
+            specs["v_b_proj"] = (
+                ortho_per_head,
+                {"heads": num_heads, "axis": -2},
+            )
+            # ``kv_b_proj`` gets no gradient in this mode -- orthogonalising it
+            # would only burn a per-head Newton-Schulz every step.
+        else:
+            specs["kv_b_proj.weight"] = (
+                ortho_per_head,
+                {"heads": num_heads, "head_sizes": [qk_nope, self.v_head_dim]},
+            )
         if getattr(self, "gate_proj", None) is not None:
             specs["gate_proj.weight"] = (ortho_per_head, {"heads": num_heads})
         # MQA (subclass) runs a second gated branch for block-sparse attention.

--- a/src/paddlefleet/transformer/multi_latent_attention.py
+++ b/src/paddlefleet/transformer/multi_latent_attention.py
@@ -461,7 +461,7 @@ class MultiLatentAttention(Attention):
         ) == "dsv4_hybrid" and getattr(
             config, "hybrid_mla_attention", "mha"
         ) in ("mqa_dsa", "mqa_full_causal")
-        # ``non_absorbed_mqa_split_kv_b_proj`` trades that property for speed:
+        # ``mqa_split_kv_b_proj`` trades that property for speed:
         # ``kv_b_proj`` is split into standalone ``k_b_proj`` / ``v_b_proj``
         # absorption parameters, pre-laid-out so each side is one grouped GEMM
         # instead of a slice + ``einsum``. A checkpoint that predates them must
@@ -469,7 +469,7 @@ class MultiLatentAttention(Attention):
         # both latent MQA modes -- the split only concerns absorption, not the
         # indexer.
         self.mqa_latent_split_kv_b = self.mqa_latent and getattr(
-            config, "non_absorbed_mqa_split_kv_b_proj", False
+            config, "mqa_split_kv_b_proj", False
         )
         if self.mqa_latent:
             if self.config.apply_rope_fusion:
@@ -1479,18 +1479,20 @@ class MLASelfAttention(MultiLatentAttention):
             #               block as the K half of the unsplit weight
             #   v_b_proj -> [v_head_dim, kv_lora_rank] per head, i.e. the
             #               transpose of the V half
-            # The transpose is bit-exact under muon_version 3: Newton-Schulz
-            # transposes any block with rows > cols before iterating and back
-            # after, and the version-3 scale ``max(dout, din) ** 0.5`` is
-            # symmetric in the two dims. Versions 1/2 scale with ``dout / din``
-            # and would break the V-side equivalence.
+            # The V side is therefore orthogonalised in its transpose, which
+            # puts the block back in the unsplit weight's orientation before
+            # Muon sees it. Newton-Schulz alone would not care (it transposes
+            # any block with rows > cols and back), but ``_scaling_fn`` does:
+            # only ``muon_version=3``'s ``max(dout, din) ** 0.5`` is symmetric
+            # in the two dims, while versions 1/2 scale with ``dout / din`` and
+            # would apply the reciprocal ratio to a transposed block.
             specs["k_b_proj"] = (
                 ortho_per_head,
                 {"heads": num_heads, "axis": -2},
             )
             specs["v_b_proj"] = (
                 ortho_per_head,
-                {"heads": num_heads, "axis": -2},
+                {"heads": num_heads, "axis": -2, "transposed": True},
             )
             # ``kv_b_proj`` gets no gradient in this mode -- orthogonalising it
             # would only burn a per-head Newton-Schulz every step.

--- a/src/paddlefleet/transformer/multi_latent_attention.py
+++ b/src/paddlefleet/transformer/multi_latent_attention.py
@@ -458,6 +458,14 @@ class MultiLatentAttention(Attention):
         self.mqa_latent = getattr(
             config, "experimental_attention_variant", None
         ) == "dsv4_hybrid" and getattr(config, "non_absorbed_mqa", False)
+        # ``non_absorbed_mqa_split_kv_b_proj`` trades that property for speed:
+        # ``kv_b_proj`` is split into standalone ``k_b_proj`` / ``v_b_proj``
+        # absorption parameters, pre-laid-out so each side is one grouped GEMM
+        # instead of a slice + ``einsum``. A checkpoint that predates them must
+        # have both split out of ``kv_b_proj.weight`` by the loader.
+        self.mqa_latent_split_kv_b = self.mqa_latent and getattr(
+            config, "non_absorbed_mqa_split_kv_b_proj", False
+        )
         if self.mqa_latent:
             if self.config.apply_rope_fusion:
                 raise ValueError(
@@ -909,12 +917,29 @@ class MultiLatentAttention(Attention):
 
         if self.mqa_latent:
             # Query is already absorbed; the core attention only needs the V-side
-            # de-absorption weight, laid out for
-            # ``einsum("bshl,lhv->bshv", out, w_v_b)``.
+            # de-absorption weight.
             q_absorbed = None
-            wv_b = self.kv_b_proj.weight.reshape(
-                [self.kv_lora_rank, self.num_attention_heads_per_partition, -1]
-            )[:, :, self.qk_nope_head_dim :]
+            if self.mqa_latent_split_kv_b:
+                # Standalone parameter; fold back to the core attention's
+                # grouped-matmul layout [n, v_head_dim, kv_lora_rank]. The
+                # reshape is a zero-copy view of the 2-D parameter.
+                wv_b = self.v_b_proj.reshape(
+                    [
+                        self.num_attention_heads_per_partition,
+                        self.v_head_dim,
+                        self.kv_lora_rank,
+                    ]
+                )
+            else:
+                # View of ``kv_b_proj.weight`` laid out for
+                # ``einsum("bshl,lhv->bshv", out, w_v_b)``.
+                wv_b = self.kv_b_proj.weight.reshape(
+                    [
+                        self.kv_lora_rank,
+                        self.num_attention_heads_per_partition,
+                        -1,
+                    ]
+                )[:, :, self.qk_nope_head_dim :]
         elif hasattr(self.core_attention.config, "forward_meta"):  # decode mode
             # Compute absorbed query and V de-absorption weight for FD MLA decode kernel
             # q_absorbed: [b, s, heads, kv_lora_rank + qk_rope_head_dim]
@@ -1347,6 +1372,47 @@ class MLASelfAttention(MultiLatentAttention):
             tp_comm_buffer_name="kv_b_proj",
             tp_group=pg_collection.tp,
         )
+
+        if self.mqa_latent_split_kv_b:
+            # K absorption half of ``kv_b_proj``. Logically
+            # [heads, kv_lora_rank, qk_nope_head_dim] -- ``fused_grouped_matmul``'s
+            # ``[G, R, D]`` contract, which lets the kernel walk the head dim
+            # through strides -- but *stored* with the leading two dims folded so
+            # the parameter itself is 2-D.
+            #
+            # The fold is what the checkpoint needs: the AOA statements that split
+            # this out of ``kv_b_proj`` only have split / concat / permute and no
+            # reshape primitive (``flex_checkpoint/aoa/aoa_engine.py:519``), so
+            # they cannot produce a 3-D tensor. Exposing a reshaped *view* from
+            # ``sharded_state_dict`` instead is not safe: DCP reshapes the
+            # ``ShardedWeight.local_tensor`` in place (``reshape_`` /``flatten_``
+            # at ``dcp/load_state_dict.py:557,741,998``), which on a view that
+            # aliases the parameter corrupts the parameter's own shape.
+            #
+            # The 3-D form is recovered per forward with a zero-copy reshape.
+            # TP is forced to 1 in this mode, so ``num_attention_heads_per_partition``
+            # is the full head count and the parameter needs no TP attributes.
+            self.k_b_proj = self.create_parameter(
+                shape=[
+                    self.num_attention_heads_per_partition * kv_lora_rank,
+                    self.qk_nope_head_dim,
+                ],
+                dtype=self.kv_b_proj.weight.dtype,
+                default_initializer=paddle.nn.initializer.Constant(0.0),
+            )
+            self.config.init_method(self.k_b_proj)
+
+            # V de-absorption half, same contract and same fold: logically
+            # [heads, v_head_dim, kv_lora_rank], stored as 2-D.
+            self.v_b_proj = self.create_parameter(
+                shape=[
+                    self.num_attention_heads_per_partition * self.v_head_dim,
+                    kv_lora_rank,
+                ],
+                dtype=self.kv_b_proj.weight.dtype,
+                default_initializer=paddle.nn.initializer.Constant(0.0),
+            )
+            self.config.init_method(self.v_b_proj)
 
         if q_lora_rank is not None:
             self.q_a_layernorm = build_spec_layer(
@@ -1916,19 +1982,41 @@ class MLASelfAttention(MultiLatentAttention):
                     # the absorbed scores equal the MHA scores exactly, so the
                     # softmax scale must stay the MHA one (mscale^2/sqrt(256)),
                     # NOT 1/sqrt(576).
-                    w_k_b = self.kv_b_proj.weight.reshape(
-                        [
-                            self.kv_lora_rank,
-                            self.num_attention_heads_per_partition,
-                            -1,
-                        ]
-                    )[:, :, : self.qk_nope_head_dim]
+                    if self.mqa_latent_split_kv_b:
+                        # ``k_b_proj`` holds W_k_b as the grouped-matmul weight
+                        # [n, kv_lora_rank, qk_nope_head_dim], stored 2-D; the
+                        # reshape is a zero-copy view. The Triton kernel walks
+                        # q_no_pe's head dim through strides, so there is no
+                        # slice, no einsum and no transpose here.
+                        from paddlefleet.triton_ops import (
+                            fused_grouped_matmul,
+                        )
+
+                        # [num_tokens, n, kv_lora_rank]
+                        q_no_pe_absorbed = fused_grouped_matmul(
+                            q_no_pe,
+                            self.k_b_proj.reshape(
+                                [
+                                    self.num_attention_heads_per_partition,
+                                    self.kv_lora_rank,
+                                    self.qk_nope_head_dim,
+                                ]
+                            ),
+                        )
+                    else:
+                        w_k_b = self.kv_b_proj.weight.reshape(
+                            [
+                                self.kv_lora_rank,
+                                self.num_attention_heads_per_partition,
+                                -1,
+                            ]
+                        )[:, :, : self.qk_nope_head_dim]
+                        q_no_pe_absorbed = paddle.einsum(
+                            "bshd,lhd->bshl", q_no_pe, w_k_b
+                        )
                     # query: [num_tokens, n, kv_lora_rank + qk_rope_head_dim]
                     query = paddle.cat(
-                        [
-                            paddle.einsum("bshd,lhd->bshl", q_no_pe, w_k_b),
-                            q_pos_emb,
-                        ],
+                        [q_no_pe_absorbed, q_pos_emb],
                         axis=-1,
                     )
                     # key: [num_tokens, 1, kv_lora_rank + qk_rope_head_dim].

--- a/src/paddlefleet/transformer/muon_utils.py
+++ b/src/paddlefleet/transformer/muon_utils.py
@@ -28,9 +28,7 @@ def _transposing(ortho_fn):
     def wrapped(block):
         perm = list(range(block.ndim))
         perm[-2], perm[-1] = perm[-1], perm[-2]
-        return paddle.transpose(
-            ortho_fn(paddle.transpose(block, perm)), perm
-        )
+        return paddle.transpose(ortho_fn(paddle.transpose(block, perm)), perm)
 
     return wrapped
 

--- a/src/paddlefleet/transformer/muon_utils.py
+++ b/src/paddlefleet/transformer/muon_utils.py
@@ -15,26 +15,56 @@ know nothing about muon configs or module structure.
 import paddle
 
 
-def ortho_blocks(weight, ortho_fn, sizes, axis=-1):
+def _transposing(ortho_fn):
+    """``ortho_fn`` applied to the transpose of each block, transposed back.
+
+    Muon's scaling is not symmetric in the two matrix dims for
+    ``muon_version`` 1 / 2 (``dout / din``), so a block stored transposed
+    relative to the layout the update was tuned on would be scaled by the
+    reciprocal ratio. Orthogonalising the transpose restores the original
+    semantics for every version. Batched (3-D) blocks swap their last two dims.
+    """
+
+    def wrapped(block):
+        perm = list(range(block.ndim))
+        perm[-2], perm[-1] = perm[-1], perm[-2]
+        return paddle.transpose(
+            ortho_fn(paddle.transpose(block, perm)), perm
+        )
+
+    return wrapped
+
+
+def ortho_blocks(weight, ortho_fn, sizes, axis=-1, transposed=False):
     """Split ``weight`` along ``axis``, orthogonalise each block, concat back.
 
     ``sizes`` is either an int (that many equal-width blocks) or a list of
-    per-block widths, matching ``paddle.split``.
+    per-block widths, matching ``paddle.split``. ``transposed=True`` hands each
+    block to ``ortho_fn`` transposed (see ``_transposing``).
     """
+    if transposed:
+        ortho_fn = _transposing(ortho_fn)
     blocks = paddle.split(weight, sizes, axis=axis)
     return paddle.concat([ortho_fn(b) for b in blocks], axis=axis)
 
 
-def ortho_per_head(weight, ortho_fn, heads=1, head_sizes=None, axis=-1):
+def ortho_per_head(
+    weight, ortho_fn, heads=1, head_sizes=None, axis=-1, transposed=False
+):
     """Orthogonalise a projection head by head.
 
     ``head_sizes`` describes the widths a single head is made of (e.g.
     ``[nope_dim, rope_dim]`` or ``[k_dim, v_dim]``); each of those pieces is
     orthogonalised separately. When it is None a head is one contiguous block
     and the weight is simply cut into ``heads`` equal parts.
+
+    ``transposed=True`` orthogonalises each block in its transpose, for weights
+    stored transposed relative to the layout Muon's scaling was tuned on.
     """
     sizes = heads if head_sizes is None else head_sizes * heads
-    return ortho_blocks(weight, ortho_fn, sizes, axis=axis)
+    return ortho_blocks(
+        weight, ortho_fn, sizes, axis=axis, transposed=transposed
+    )
 
 
 def ortho_gate_up(weight, ortho_fn):

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -937,10 +937,16 @@ class TransformerConfig(ModelParallelConfig):
     with a zero-copy reshape. The fold exists because the AOA engine cannot
     change a tensor's rank, so the checkpoint side has to be 2-D. Each side is
     then one grouped Triton GEMM with no slice, no einsum and no transpose.
-    ``kv_b_proj`` receives no gradient at all in this mode and the parameter set
-    is no longer byte-compatible with a dense MHA phase: a checkpoint without
-    these two keys must have them split out of ``kv_b_proj.weight`` by the loader
-    (``_mla_split_kv_b_statements`` generates the AOA statements that do it).
+    ``kv_b_proj`` is not built at all in this mode -- the two parameters hold
+    exactly its elements, so the resident parameter bytes and the checkpoint
+    size are unchanged -- and the parameter set is no longer byte-compatible
+    with a dense MHA phase: the checkpoint must already contain ``k_b_proj`` /
+    ``v_b_proj``. Converting an older ``kv_b_proj.weight``-only checkpoint needs
+    AOA statements that split it; those are not wired up yet, so such a
+    checkpoint cannot be resumed with this flag on.
+
+    Incompatible with ``enable_hy_sparse_attention``, whose ``MQASelfAttention``
+    layer still absorbs against ``kv_b_proj.weight``.
     """
 
     v_head_dim: int | None = None
@@ -1778,6 +1784,21 @@ class TransformerConfig(ModelParallelConfig):
                         "hybrid_mla_attention='mqa_dsa' or 'mqa_full_causal'; "
                         "it splits those modes' kv_b_proj into standalone "
                         "k_b_proj / v_b_proj absorption parameters."
+                    )
+                if self.mqa_split_kv_b_proj and getattr(
+                    self, "enable_hy_sparse_attention", False
+                ):
+                    # The split replaces ``kv_b_proj`` entirely, but HySparse
+                    # swaps the layer class for ``MQASelfAttention``, whose
+                    # forward and decode paths still read
+                    # ``kv_b_proj.weight``. Allowing the combination would
+                    # either resurrect the duplicate parameter or fail on a
+                    # ``None`` attribute deep in the forward.
+                    raise ValueError(
+                        "mqa_split_kv_b_proj=True is incompatible with "
+                        "enable_hy_sparse_attention: the HySparse MQA layer "
+                        "still absorbs against kv_b_proj.weight, which the "
+                        "split removes."
                     )
                 if self.hybrid_mla_attention == "mqa_dsa":
                     # The -2 layers' indexer reuses the CSA indexer fields.

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -866,7 +866,7 @@ class TransformerConfig(ModelParallelConfig):
     different layer kind that this field does not touch.
     """
 
-    non_absorbed_mqa_split_kv_b_proj: bool = False
+    mqa_split_kv_b_proj: bool = False
     """Split ``kv_b_proj`` into standalone ``k_b_proj`` / ``v_b_proj``
     absorption parameters instead of slicing it on every forward. Requires a
     latent MQA mode, i.e. ``hybrid_mla_attention`` in ``{"mqa_dsa",
@@ -1700,12 +1700,12 @@ class TransformerConfig(ModelParallelConfig):
                         "hybrid MLA dimensions must be explicit positive integers; "
                         f"invalid fields: {', '.join(invalid)}"
                     )
-                if self.non_absorbed_mqa_split_kv_b_proj and (
+                if self.mqa_split_kv_b_proj and (
                     self.hybrid_mla_attention
                     not in ("mqa_dsa", "mqa_full_causal")
                 ):
                     raise ValueError(
-                        "non_absorbed_mqa_split_kv_b_proj=True only means "
+                        "mqa_split_kv_b_proj=True only means "
                         "anything for latent MQA, i.e. "
                         "hybrid_mla_attention='mqa_dsa' or 'mqa_full_causal'; "
                         "it splits those modes' kv_b_proj into standalone "

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -862,6 +862,30 @@ class TransformerConfig(ModelParallelConfig):
     the square of the sequence length (268 MB per layer at ``s=8192``).
     """
 
+    non_absorbed_mqa_split_kv_b_proj: bool = False
+    """Split ``kv_b_proj`` into standalone ``k_b_proj`` / ``v_b_proj``
+    absorption parameters instead of slicing it on every forward. Requires
+    ``non_absorbed_mqa=True``.
+
+    ``False``: both absorption weights are sliced out of ``kv_b_proj.weight`` on
+    every forward and applied with an ``einsum``.
+
+    ``True``: they are separate parameters. Each is logically the ``[G, R, D]``
+    weight ``fused_grouped_matmul`` wants --
+    ``k_b_proj``: ``[heads, kv_lora_rank, qk_nope_head_dim]`` (query absorption),
+    ``v_b_proj``: ``[heads, v_head_dim, kv_lora_rank]`` (V de-absorption) -- but
+    *stored* with the leading two dims folded, i.e. as 2-D
+    ``[heads * kv_lora_rank, qk_nope_head_dim]`` and
+    ``[heads * v_head_dim, kv_lora_rank]``; the 3-D form is recovered per forward
+    with a zero-copy reshape. The fold exists because the AOA engine cannot
+    change a tensor's rank, so the checkpoint side has to be 2-D. Each side is
+    then one grouped Triton GEMM with no slice, no einsum and no transpose.
+    ``kv_b_proj`` receives no gradient at all in this mode and the parameter set
+    is no longer byte-compatible with a dense MHA phase: a checkpoint without
+    these two keys must have them split out of ``kv_b_proj.weight`` by the loader
+    (``_mla_split_kv_b_statements`` generates the AOA statements that do it).
+    """
+
     v_head_dim: int | None = None
     """Dimension of the head in the V projection."""
 
@@ -1543,6 +1567,16 @@ class TransformerConfig(ModelParallelConfig):
                         "non_absorbed_mqa_dense=True only means anything with "
                         "non_absorbed_mqa=True; it replaces that mode's DSA "
                         "indexer with the full per-document causal set."
+                    )
+                if (
+                    self.non_absorbed_mqa_split_kv_b_proj
+                    and not self.non_absorbed_mqa
+                ):
+                    raise ValueError(
+                        "non_absorbed_mqa_split_kv_b_proj=True only means "
+                        "anything with non_absorbed_mqa=True; it splits that "
+                        "mode's kv_b_proj into standalone k_b_proj / v_b_proj "
+                        "absorption parameters."
                     )
                 if self.non_absorbed_mqa and not self.non_absorbed_mqa_dense:
                     # The -2 layers' indexer reuses the CSA indexer fields. The

--- a/src/paddlefleet/triton_ops/grouped_matmul_fusion.py
+++ b/src/paddlefleet/triton_ops/grouped_matmul_fusion.py
@@ -253,6 +253,45 @@ def grouped_matmul_dw_kernel(
     tl.store(dw_ptrs, acc.to(OUT_DTYPE), mask=dw_mask)
 
 
+def _grouped_3d_strides(t):
+    """Describe ``t`` of shape ``[..., G, X]`` as ``[M, G, X]`` without a copy.
+
+    Returns ``(stride_m, stride_g, stride_x)`` when the tensor is a plain
+    non-overlapping strided view whose ``[M, G, X]`` fold is exact, else
+    ``None`` -- in which case the caller materializes a dense copy exactly as
+    the original implementation did.
+
+    A strided view such as ``q[..., :qk_nope_head_dim]`` qualifies: its group
+    stride is the *full* head dim rather than ``X``. Since the kernels take every
+    stride explicitly they can read such a view in place, and the
+    ``.contiguous()`` copy it would otherwise trigger is pure waste -- an
+    expensive one, since phi's strided->dense kernel has no vectorized variant.
+
+    The checks are deliberately conservative: only layouts that a dense copy
+    would linearize element-for-element are accepted, so the kernels see the
+    same values in the same order and the result is bit-identical to the copy
+    path. Broadcast (stride 0), reversed (negative stride) and self-overlapping
+    views are all rejected rather than reasoned about.
+    """
+    shape = t.shape
+    strides = t.strides
+    if len(shape) < 3:
+        return None
+    stride_m, stride_g, stride_x = strides[-3], strides[-2], strides[-1]
+    # Innermost dim must be packed, and neither the group nor the row step may
+    # be degenerate (0 = broadcast, < 0 = reversed) or self-overlapping.
+    if stride_x != 1:
+        return None
+    if stride_g < shape[-1] or stride_m < shape[-2] * stride_g:
+        return None
+    # Leading dims collapse into M only if each is packed w.r.t. the next one.
+    # A size-1 dim contributes nothing to M, so its own stride is irrelevant.
+    for i in range(len(shape) - 3):
+        if shape[i] != 1 and strides[i] != shape[i + 1] * strides[i + 1]:
+            return None
+    return stride_m, stride_g, stride_x
+
+
 class GroupedMatmulTriton(paddle.autograd.PyLayer):
     """Fused grouped matmul: einsum("...gd,grd->...gr") via Triton.
 
@@ -275,8 +314,15 @@ class GroupedMatmulTriton(paddle.autograd.PyLayer):
         for s in orig_shape[:-2]:
             M *= s
 
-        # x is [..., G, D] -> [M, G, D], NO transpose needed
-        x_3d = x.reshape([M, G, D]).contiguous()
+        # x is [..., G, D] -> [M, G, D]. A foldable unit-stride view is read in
+        # place; anything else is materialized as a dense copy as before.
+        x_strides = _grouped_3d_strides(x)
+        if x_strides is None:
+            x_3d = x.reshape([M, G, D]).contiguous()
+            x_strides = (x_3d.strides[0], x_3d.strides[1], x_3d.strides[2])
+        else:
+            x_3d = x
+        stride_xm, stride_xg, stride_xk = x_strides
 
         # Output in [M, G, R] layout directly (no transpose after kernel)
         out = paddle.empty([M, G, R], dtype=x.dtype)
@@ -299,9 +345,9 @@ class GroupedMatmulTriton(paddle.autograd.PyLayer):
             M,
             R,
             D,
-            x_3d.stride()[1],  # stride_xg: step between groups
-            x_3d.stride()[0],  # stride_xm: step between rows (M dim)
-            x_3d.stride()[2],  # stride_xk: step between cols (D dim)
+            stride_xg,  # stride_xg: step between groups
+            stride_xm,  # stride_xm: step between rows (M dim)
+            stride_xk,  # stride_xk: step between cols (D dim)
             w.stride()[0],
             w.stride()[1],
             w.stride()[2],
@@ -312,6 +358,7 @@ class GroupedMatmulTriton(paddle.autograd.PyLayer):
         )
 
         ctx.save_for_backward(x_3d, w)
+        ctx.x_strides = x_strides
         ctx.M = M
         ctx.G = G
         ctx.R = R
@@ -335,8 +382,15 @@ class GroupedMatmulTriton(paddle.autograd.PyLayer):
 
         # No "both frozen" shortcut needed: a PyLayer output is differentiable
         # only if some input is, so backward is never entered in that case.
-        # dy: [..., G, R] -> [M, G, R], NO transpose
-        dy_3d = dy.reshape([M, G, R]).contiguous()
+        # dy: [..., G, R] -> [M, G, R]. Same in-place-view rule as the forward.
+        dy_strides = _grouped_3d_strides(dy)
+        if dy_strides is None:
+            dy_3d = dy.reshape([M, G, R]).contiguous()
+            dy_strides = (dy_3d.strides[0], dy_3d.strides[1], dy_3d.strides[2])
+        else:
+            dy_3d = dy
+        stride_dym, stride_dyg, stride_dyk = dy_strides
+        stride_xm, stride_xg, stride_xk = ctx.x_strides
 
         dx = None
         if ctx.x_needs_grad:
@@ -354,9 +408,9 @@ class GroupedMatmulTriton(paddle.autograd.PyLayer):
                 M,
                 D,  # N = D (output cols)
                 R,  # K = R (reduction)
-                dy_3d.stride()[1],  # stride_dyg
-                dy_3d.stride()[0],  # stride_dym
-                dy_3d.stride()[2],  # stride_dyk
+                stride_dyg,  # stride_dyg
+                stride_dym,  # stride_dym
+                stride_dyk,  # stride_dyk
                 w.stride()[0],
                 w.stride()[1],
                 w.stride()[2],
@@ -384,12 +438,12 @@ class GroupedMatmulTriton(paddle.autograd.PyLayer):
                 M,
                 D,  # N = D (output cols)
                 R,  # K = R (rows of dw, which is the R dim)
-                dy_3d.stride()[1],  # stride_dyg
-                dy_3d.stride()[0],  # stride_dym
-                dy_3d.stride()[2],  # stride_dyr
-                x_3d.stride()[1],  # stride_xg
-                x_3d.stride()[0],  # stride_xm
-                x_3d.stride()[2],  # stride_xd
+                stride_dyg,  # stride_dyg
+                stride_dym,  # stride_dym
+                stride_dyk,  # stride_dyr
+                stride_xg,  # stride_xg
+                stride_xm,  # stride_xm
+                stride_xk,  # stride_xd
                 dw.stride()[0],
                 dw.stride()[1],
                 dw.stride()[2],

--- a/src/paddlefleet/triton_ops/grouped_matmul_fusion.py
+++ b/src/paddlefleet/triton_ops/grouped_matmul_fusion.py
@@ -467,6 +467,19 @@ def fused_grouped_matmul(x, w):
         raise ValueError(
             f"x and w must have the same dtype, got x={x.dtype}, w={w.dtype}"
         )
+    # ``G`` and ``D`` reach the kernel from ``w`` while ``x`` is read through
+    # its own strides, so a mismatching ``x`` would be read past its group (or
+    # out of bounds) instead of failing. The dense path used to get this check
+    # for free from ``x.reshape([M, G, D])``; the zero-copy view path never
+    # reshapes, so state it here for both.
+    if w.ndim != 3:
+        raise ValueError(f"w must be 3-D [G, R, D], got shape {w.shape}")
+    if x.ndim < 2 or tuple(x.shape[-2:]) != (w.shape[0], w.shape[2]):
+        raise ValueError(
+            "x's trailing dims must match w's [G, D]: expected "
+            f"{(w.shape[0], w.shape[2])}, got x shape {x.shape} for w shape "
+            f"{w.shape}"
+        )
     if x.dtype not in _SUPPORTED_DTYPES:
         # fp32 (and any other unsupported dtype) stays on paddle.einsum to
         # preserve numerical equivalence instead of being downcast to fp16.

--- a/src/paddlefleet/triton_ops/grouped_matmul_fusion.py
+++ b/src/paddlefleet/triton_ops/grouped_matmul_fusion.py
@@ -284,11 +284,22 @@ def _grouped_3d_strides(t):
         return None
     if stride_g < shape[-1] or stride_m < shape[-2] * stride_g:
         return None
-    # Leading dims collapse into M only if each is packed w.r.t. the next one.
-    # A size-1 dim contributes nothing to M, so its own stride is irrelevant.
-    for i in range(len(shape) - 3):
-        if shape[i] != 1 and strides[i] != shape[i + 1] * strides[i + 1]:
+    # Leading dims collapse into M only if each is packed against the *span* of
+    # everything inside it. ``span`` is that extent, grown right-to-left.
+    #
+    # A size-1 dim contributes nothing to M, so its own stride is irrelevant and
+    # its span is passed through untouched. Comparing against
+    # ``shape[i + 1] * strides[i + 1]`` instead would make a singleton neighbour
+    # satisfy any outer stride -- shape (2, 1, 3, 4, 6) with strides
+    # (100, 100, 24, 6, 1) would be accepted although the six M rows start at
+    # 0, 24, 48, 100, 124, 148 rather than at multiples of ``stride_m``.
+    span = shape[-3] * stride_m
+    for i in range(len(shape) - 4, -1, -1):
+        if shape[i] == 1:
+            continue
+        if strides[i] != span:
             return None
+        span *= shape[i]
     return stride_m, stride_g, stride_x
 
 

--- a/tests/single_card_tests/transformer/test_dsv4_hybrid_attention.py
+++ b/tests/single_card_tests/transformer/test_dsv4_hybrid_attention.py
@@ -3150,6 +3150,20 @@ class TestGroupedMatmulLayoutGuard(unittest.TestCase):
         self.assertNotEqual(x.strides[0], x.shape[1] * x.strides[1])
         self.assertIsNone(_grouped_3d_strides(x))
 
+    def test_rejects_unfoldable_dims_hidden_behind_a_singleton(self):
+        # A size-1 dim in the middle must not launder an outer stride: its own
+        # stride is arbitrary, so comparing the outer one against
+        # shape[i + 1] * strides[i + 1] would always hold. Here the six M rows
+        # start at 0, 24, 48, 100, 124, 148 -- not at multiples of stride_m=24 --
+        # so the kernel would read six wrong rows if this were accepted.
+        flat = paddle.randn([200])
+        x = paddle.as_strided(flat, [2, 1, 3, 4, 6], [100, 100, 24, 6, 1])
+        self.assertIsNone(_grouped_3d_strides(x))
+        # The same shape *is* foldable once the outer dim spans exactly the
+        # 3 * 24 elements below it.
+        packed = paddle.as_strided(flat, [2, 1, 3, 4, 6], [72, 72, 24, 6, 1])
+        self.assertEqual(_grouped_3d_strides(packed), (24, 6, 1))
+
 
 class TestHybridMLAAttentionSinkParameter(unittest.TestCase):
     """``add_full_attention_sink_bias`` must give the same parameter in both

--- a/tests/single_card_tests/transformer/test_dsv4_hybrid_attention.py
+++ b/tests/single_card_tests/transformer/test_dsv4_hybrid_attention.py
@@ -102,7 +102,11 @@ from paddlefleet.transformer.mqa_latent_attention import (
 )
 from paddlefleet.transformer.multi_latent_attention import MLASelfAttention
 from paddlefleet.transformer.transformer_config import TransformerConfig
-from paddlefleet.triton_ops import fused_grouped_matmul
+from paddlefleet.triton_ops import (
+    fused_grouped_matmul,
+    grouped_matmul_fusion as _gmf,
+)
+from paddlefleet.triton_ops.grouped_matmul_fusion import _grouped_3d_strides
 
 _SEED = 42
 
@@ -3036,6 +3040,53 @@ class TestFusedGroupedMatmul(unittest.TestCase):
         self.assertIsNotNone(x.grad)
         self.assertIsNone(param.grad)
 
+    def test_copy_fallback_matches_the_zero_copy_view(self):
+        """The dense-copy fallback and the zero-copy view must agree bit-exactly.
+
+        A rejected layout falls back to ``x.reshape([M, G, D]).contiguous()``
+        (and the same for ``dy`` in backward). Forcing that fallback on a view
+        the guard *would* accept is what makes the zero-copy path safe to take:
+        same values, same order, same kernel, so the results are identical bit
+        for bit rather than merely close.
+        """
+        wide = paddle.randn(
+            [1, 7, self._G, self._D + 5], dtype="float32"
+        ).astype("bfloat16")
+        w0 = paddle.randn([self._G, self._R, self._D], dtype="float32").astype(
+            "bfloat16"
+        )
+        grad_out = paddle.randn([1, 7, self._G, self._R], dtype="float32")
+
+        def run(force_copy):
+            x = wide[..., : self._D].detach()
+            x.stop_gradient = False
+            wi = w0.detach()
+            wi.stop_gradient = False
+            if force_copy:
+                with patch.object(
+                    _gmf, "_grouped_3d_strides", return_value=None
+                ):
+                    out = fused_grouped_matmul(x, wi)
+                    (out.astype("float32") * grad_out).sum().backward()
+            else:
+                out = fused_grouped_matmul(x, wi)
+                (out.astype("float32") * grad_out).sum().backward()
+            return (
+                out.astype("float32").numpy(),
+                x.grad.astype("float32").numpy(),
+                wi.grad.astype("float32").numpy(),
+            )
+
+        # The unpatched run must actually be on the zero-copy path, otherwise
+        # this compares the fallback against itself.
+        self.assertIsNotNone(_grouped_3d_strides(wide[..., : self._D]))
+        for view, copied, name in zip(
+            run(force_copy=False), run(force_copy=True), ("out", "dx", "dw")
+        ):
+            self.assertTrue(
+                np.array_equal(view, copied), f"{name} is not bit-identical"
+            )
+
     def test_frozen_input_gets_no_dgrad(self):
         x, param, out = self._run_with_frozen(
             x_trainable=False, w_trainable=True
@@ -3051,6 +3102,53 @@ class TestFusedGroupedMatmul(unittest.TestCase):
         self.assertTrue(out.stop_gradient)
         self.assertIsNone(x.grad)
         self.assertIsNone(param.grad)
+
+
+class TestGroupedMatmulLayoutGuard(unittest.TestCase):
+    """``_grouped_3d_strides`` gates the zero-copy path.
+
+    It must accept only layouts a dense copy would linearize element for
+    element; everything else has to fall back to ``.contiguous()``. The guard
+    is pure stride arithmetic, so it needs no device.
+    """
+
+    def test_accepts_a_foldable_strided_view(self):
+        # ``q[..., :qk_nope_head_dim]``-shaped view: group stride is the full
+        # head dim rather than D, which the kernels handle via strides.
+        x = paddle.randn([2, 3, 4, 10])[..., :6]
+        self.assertEqual(_grouped_3d_strides(x), tuple(x.strides[-3:]))
+
+    def test_accepts_size_one_leading_dims(self):
+        # A size-1 dim contributes nothing to M, so its stride is irrelevant.
+        x = paddle.randn([1, 1, 3, 4, 10])[..., :6]
+        self.assertEqual(_grouped_3d_strides(x), tuple(x.strides[-3:]))
+
+    def test_rejects_fewer_than_three_dims(self):
+        self.assertIsNone(_grouped_3d_strides(paddle.randn([4, 6])))
+
+    def test_rejects_non_unit_innermost_stride(self):
+        x = paddle.randn([2, 6, 3]).transpose([0, 2, 1])
+        self.assertNotEqual(x.strides[-1], 1)
+        self.assertIsNone(_grouped_3d_strides(x))
+
+    def test_rejects_degenerate_group_strides(self):
+        # A broadcast (stride 0) or self-overlapping group step reads the same
+        # element from several groups, which no dense copy would reproduce.
+        flat = paddle.randn([2, 30])
+        for stride_g in (0, 3):
+            with self.subTest(stride_g=stride_g):
+                x = paddle.as_strided(flat, [2, 3, 6], [30, stride_g, 1])
+                self.assertIsNone(_grouped_3d_strides(x))
+        # Same for a row step that overlaps the groups below it.
+        x = paddle.as_strided(flat, [2, 3, 6], [6, 6, 1])
+        self.assertIsNone(_grouped_3d_strides(x))
+
+    def test_rejects_unfoldable_leading_dims(self):
+        # Sliced on a middle axis: the leading stride no longer equals
+        # shape[1] * strides[1], so the leading dims cannot collapse into M.
+        x = paddle.randn([4, 3, 2, 5])[:, :2]
+        self.assertNotEqual(x.strides[0], x.shape[1] * x.strides[1])
+        self.assertIsNone(_grouped_3d_strides(x))
 
 
 class TestHybridMLAAttentionSinkParameter(unittest.TestCase):

--- a/tests/single_card_tests/transformer/test_dsv4_hybrid_attention.py
+++ b/tests/single_card_tests/transformer/test_dsv4_hybrid_attention.py
@@ -2976,6 +2976,30 @@ class TestFusedGroupedMatmul(unittest.TestCase):
         with self.assertRaises(ValueError):
             fused_grouped_matmul(x, w)
 
+    def test_shape_mismatch_raises(self):
+        # G and D reach the kernel from w while x is read through its own
+        # strides, so a mismatching x would be read past its group (or out of
+        # bounds) rather than rejected. The dense path got this from
+        # ``x.reshape([M, G, D])``; the zero-copy view path never reshapes.
+        w = paddle.randn([self._G, self._R, self._D], dtype="bfloat16")
+        for shape in (
+            [1, 4, self._G, self._D - 1],  # wrong D
+            [1, 4, self._G + 1, self._D],  # wrong G
+            [self._G * self._D],  # not even 2-D
+        ):
+            with self.subTest(x_shape=shape):
+                x = paddle.randn(shape, dtype="bfloat16")
+                with self.assertRaises(ValueError):
+                    fused_grouped_matmul(x, w)
+        # A strided view of the right trailing shape still goes through.
+        wide = paddle.randn([1, 4, self._G, self._D + 5], dtype="bfloat16")
+        out = fused_grouped_matmul(wide[..., : self._D], w)
+        self.assertEqual(list(out.shape), [1, 4, self._G, self._R])
+        with self.assertRaises(ValueError):
+            fused_grouped_matmul(
+                wide[..., : self._D], w.reshape([self._G * self._R, self._D])
+            )
+
     def _run_with_frozen(self, x_trainable, w_trainable):
         """Phase 2 shape: the o_groups weight is frozen while x stays live.
 

--- a/tests/single_card_tests/transformer/test_hybrid_mla_grad_health.py
+++ b/tests/single_card_tests/transformer/test_hybrid_mla_grad_health.py
@@ -587,6 +587,12 @@ class TestSplitKvBProj(unittest.TestCase):
         orthogonalised as a single matrix with all heads mixed. ``axis=-2``
         (not ``0``) also covers the 3-D input Muon produces when it batches
         several same-shape parameters together.
+
+        The V side is additionally handed to ``ortho_fn`` transposed, i.e. in
+        the unsplit weight's ``[kv_lora_rank, v_head_dim]`` orientation: Muon's
+        ``muon_version`` 1/2 scaling is ``dout / din``, so the stored
+        ``[v_head_dim, kv_lora_rank]`` block would otherwise be scaled by the
+        reciprocal ratio.
         """
         ded = _build("mqa", split_kv_b=True)
         specs = ded.muon_slice_specs({"muon_qkv_update_mode": "split_head"})
@@ -596,13 +602,19 @@ class TestSplitKvBProj(unittest.TestCase):
         self.assertNotIn("kv_b_proj.weight", specs)
 
         expected = {
-            "k_b_proj": [ded.kv_lora_rank, ded.qk_nope_head_dim],
-            "v_b_proj": [ded.v_head_dim, ded.kv_lora_rank],
+            "k_b_proj": (
+                {"heads": heads, "axis": -2},
+                [ded.kv_lora_rank, ded.qk_nope_head_dim],
+            ),
+            "v_b_proj": (
+                {"heads": heads, "axis": -2, "transposed": True},
+                [ded.kv_lora_rank, ded.v_head_dim],
+            ),
         }
-        for name, block in expected.items():
+        for name, (expected_kwargs, block) in expected.items():
             self.assertIn(name, specs)
             slice_fn, kwargs = specs[name]
-            self.assertEqual(kwargs, {"heads": heads, "axis": -2})
+            self.assertEqual(kwargs, expected_kwargs)
             weight = getattr(ded, name)
             for extra in ([], [3]):
                 seen = []

--- a/tests/single_card_tests/transformer/test_hybrid_mla_grad_health.py
+++ b/tests/single_card_tests/transformer/test_hybrid_mla_grad_health.py
@@ -168,7 +168,7 @@ def _make_config(
         hybrid_mla_num_attention_heads=64,
         hybrid_mla_num_key_value_heads=64,
         hybrid_mla_attention=hybrid_mla_attention,
-        non_absorbed_mqa_split_kv_b_proj=split_kv_b,
+        mqa_split_kv_b_proj=split_kv_b,
         add_full_attention_sink_bias=sink,
         o_groups=4,
         o_lora_rank=32,
@@ -452,7 +452,7 @@ class TestItem1StateDictAndGradientMatch(unittest.TestCase):
 
 @_skip_if_no_cuda
 class TestSplitKvBProj(unittest.TestCase):
-    """``non_absorbed_mqa_split_kv_b_proj``: the grouped-matmul ``k_b_proj`` /
+    """``mqa_split_kv_b_proj``: the grouped-matmul ``k_b_proj`` /
     ``v_b_proj`` must reproduce the ``kv_b_proj``-slice einsums, given the split
     the loader performs."""
 

--- a/tests/single_card_tests/transformer/test_hybrid_mla_grad_health.py
+++ b/tests/single_card_tests/transformer/test_hybrid_mla_grad_health.py
@@ -134,7 +134,9 @@ class _FakePGCollection:
 # invariants the kernels require: >= 64 heads, head_dim 128 indexer, topk % 128
 # == 0, kv_lora_rank 512 + qk_rope 64 == 576 latent key width, v == 512.
 # --------------------------------------------------------------------------- #
-def _make_config(mode, sink, indexer=False, dtype=paddle.bfloat16):
+def _make_config(
+    mode, sink, indexer=False, dtype=paddle.bfloat16, split_kv_b=False
+):
     # ``indexer`` is vestigial: the hybrid-MLA layer's DSA indexer is now built
     # unconditionally whenever ``non_absorbed_mqa`` is True (see
     # gpt_layer_specs), so it is retained only for call-site compatibility.
@@ -164,6 +166,7 @@ def _make_config(mode, sink, indexer=False, dtype=paddle.bfloat16):
         hybrid_mla_num_attention_heads=64,
         hybrid_mla_num_key_value_heads=64,
         non_absorbed_mqa=non_absorbed_mqa,
+        non_absorbed_mqa_split_kv_b_proj=split_kv_b,
         add_full_attention_sink_bias=sink,
         o_groups=4,
         o_lora_rank=32,
@@ -198,10 +201,16 @@ def _make_config(mode, sink, indexer=False, dtype=paddle.bfloat16):
     return cfg
 
 
-def _build(mode, sink=False, indexer=False, dtype=paddle.bfloat16):
+def _build(
+    mode,
+    sink=False,
+    indexer=False,
+    dtype=paddle.bfloat16,
+    split_kv_b=False,
+):
     """Build the layer-0 (hybrid-MLA) self-attention for ``mode``."""
     model_parallel_cuda_manual_seed(_SEED)
-    cfg = _make_config(mode, sink, indexer, dtype=dtype)
+    cfg = _make_config(mode, sink, indexer, dtype=dtype, split_kv_b=split_kv_b)
     spec = get_gpt_layer_local_spec(
         config=cfg,
         normalization=cfg.normalization,
@@ -435,6 +444,104 @@ class TestItem1StateDictAndGradientMatch(unittest.TestCase):
             self.assertTrue(
                 0.95 < ratio < 1.05, f"{key} grad-norm ratio off ({ratio})"
             )
+
+
+@_skip_if_no_cuda
+class TestSplitKvBProj(unittest.TestCase):
+    """``non_absorbed_mqa_split_kv_b_proj``: the grouped-matmul ``k_b_proj`` /
+    ``v_b_proj`` must reproduce the ``kv_b_proj``-slice einsums, given the split
+    the loader performs."""
+
+    SEQ = 128
+
+    @staticmethod
+    def _loader_split(state, mod):
+        """What the loader must produce for the two split-out parameters.
+
+        Both are stored 2-D (leading dims folded), which is what the AOA
+        statements can express and what the parameters actually are.
+        """
+        heads = mod.num_attention_heads_per_partition
+        w = state["kv_b_proj.weight"].reshape([mod.kv_lora_rank, heads, -1])
+        state["k_b_proj"] = (
+            w[:, :, : mod.qk_nope_head_dim]
+            .transpose([1, 0, 2])
+            .reshape([heads * mod.kv_lora_rank, mod.qk_nope_head_dim])
+            .contiguous()
+        )
+        state["v_b_proj"] = (
+            w[:, :, mod.qk_nope_head_dim :]
+            .transpose([1, 2, 0])
+            .reshape([heads * mod.v_head_dim, mod.kv_lora_rank])
+            .contiguous()
+        )
+        return state
+
+    def test_absorbed_query_matches_kv_b_proj_slice(self):
+        base = _build("mqa")
+        ded = _build("mqa", split_kv_b=True)
+        self.assertFalse(base.mqa_latent_split_kv_b)
+        self.assertTrue(ded.mqa_latent_split_kv_b)
+
+        state = base.state_dict()
+        self.assertNotIn("k_b_proj", state)
+        self.assertNotIn("v_b_proj", state)
+        ded.set_state_dict(self._loader_split(state, ded))
+
+        x = _hidden(self.SEQ, seed=3)
+        q_base = base.get_query_key_value_tensors(x)[0]
+        q_ded = ded.get_query_key_value_tensors(x)[0]
+        self.assertEqual(q_ded.shape, q_base.shape)
+        err = _rel_err(
+            q_ded.astype("float32").numpy(), q_base.astype("float32").numpy()
+        )
+        self.assertLess(err, 1e-3, f"absorbed query diverged (rel L2 {err})")
+
+    def test_deabsorb_matches_einsum(self):
+        """The V-side de-absorption is layout-switched, so cover both paths on
+        the same numbers via the core attention's own helper."""
+        ded = _build("mqa", split_kv_b=True)
+        core = ded.core_attention
+        self.assertTrue(core.split_kv_b)
+
+        heads = ded.num_attention_heads_per_partition
+        w = ded.kv_b_proj.weight.reshape([ded.kv_lora_rank, heads, -1])
+        w_einsum = w[:, :, ded.qk_nope_head_dim :]  # [l, h, v]
+        w_grouped = w_einsum.transpose([1, 2, 0]).contiguous()  # [h, v, l]
+
+        rng = np.random.RandomState(11)
+        core_out = paddle.to_tensor(
+            rng.randn(1, self.SEQ, heads * ded.kv_lora_rank).astype("float32")
+            / np.sqrt(ded.kv_lora_rank),
+            dtype=ded.kv_b_proj.weight.dtype,
+        )
+        ref = core._deabsorb(core_out, w_einsum, False)
+        got = core._deabsorb(core_out, w_grouped, True)
+        self.assertEqual(got.shape, ref.shape)
+        err = _rel_err(
+            got.astype("float32").numpy(), ref.astype("float32").numpy()
+        )
+        self.assertLess(err, 1e-3, f"de-absorption diverged (rel L2 {err})")
+
+    def test_full_forward_matches_unsplit(self):
+        if not _HAS_DSA:
+            self.skipTest("absorbed MQA forward requires SM100+ DSA kernel")
+        base = _build("mqa")
+        ded = _build("mqa", split_kv_b=True)
+        ded.set_state_dict(self._loader_split(base.state_dict(), ded))
+        re = _row_end(self.SEQ)
+        x = _hidden(self.SEQ, seed=5)
+        out_base, _ = base(
+            x, attention_mask=None, attn_mask_startend_row_indices=re
+        )
+        out_ded, _ = ded(
+            x, attention_mask=None, attn_mask_startend_row_indices=re
+        )
+        err = _rel_err(
+            out_ded.astype("float32").numpy(),
+            out_base.astype("float32").numpy(),
+        )
+        self.assertLess(err, 1e-3, f"layer output diverged (rel L2 {err})")
 
 
 @_skip_if_no_cuda

--- a/tests/single_card_tests/transformer/test_hybrid_mla_grad_health.py
+++ b/tests/single_card_tests/transformer/test_hybrid_mla_grad_health.py
@@ -463,10 +463,11 @@ class TestSplitKvBProj(unittest.TestCase):
         """What the loader must produce for the two split-out parameters.
 
         Both are stored 2-D (leading dims folded), which is what the AOA
-        statements can express and what the parameters actually are.
+        statements can express and what the parameters actually are. The unsplit
+        key is dropped: the split layer does not own that parameter any more.
         """
         heads = mod.num_attention_heads_per_partition
-        w = state["kv_b_proj.weight"].reshape([mod.kv_lora_rank, heads, -1])
+        w = state.pop("kv_b_proj.weight").reshape([mod.kv_lora_rank, heads, -1])
         state["k_b_proj"] = (
             w[:, :, : mod.qk_nope_head_dim]
             .transpose([1, 0, 2])
@@ -480,6 +481,28 @@ class TestSplitKvBProj(unittest.TestCase):
             .contiguous()
         )
         return state
+
+    def test_split_replaces_kv_b_proj_instead_of_duplicating_it(self):
+        """The split must not add a second copy of the projection.
+
+        ``k_b_proj`` and ``v_b_proj`` together hold exactly the elements of
+        ``kv_b_proj.weight``, which gets no gradient once they exist. Keeping it
+        alongside them would double this projection's resident bytes *and* its
+        checkpoint footprint, so it must not be built at all.
+        """
+        base = _build("mqa")
+        ded = _build("mqa", split_kv_b=True)
+        self.assertIsNone(ded.kv_b_proj)
+
+        state = ded.state_dict()
+        self.assertNotIn("kv_b_proj.weight", state)
+        self.assertIn("k_b_proj", state)
+        self.assertIn("v_b_proj", state)
+
+        def _numel(mod):
+            return sum(int(np.prod(p.shape)) for p in mod.parameters())
+
+        self.assertEqual(_numel(ded), _numel(base))
 
     def test_absorbed_query_matches_kv_b_proj_slice(self):
         base = _build("mqa")
@@ -509,7 +532,10 @@ class TestSplitKvBProj(unittest.TestCase):
         self.assertTrue(core.split_kv_b)
 
         heads = ded.num_attention_heads_per_partition
-        w = ded.kv_b_proj.weight.reshape([ded.kv_lora_rank, heads, -1])
+        # The split layer has no ``kv_b_proj``; take the reference weight from an
+        # unsplit one so both branches see the same numbers.
+        kv_b_weight = _build("mqa").kv_b_proj.weight
+        w = kv_b_weight.reshape([ded.kv_lora_rank, heads, -1])
         w_einsum = w[:, :, ded.qk_nope_head_dim :]  # [l, h, v]
         w_grouped = w_einsum.transpose([1, 2, 0]).contiguous()  # [h, v, l]
 
@@ -517,7 +543,7 @@ class TestSplitKvBProj(unittest.TestCase):
         core_out = paddle.to_tensor(
             rng.randn(1, self.SEQ, heads * ded.kv_lora_rank).astype("float32")
             / np.sqrt(ded.kv_lora_rank),
-            dtype=ded.kv_b_proj.weight.dtype,
+            dtype=kv_b_weight.dtype,
         )
         ref = core._deabsorb(core_out, w_einsum, False)
         got = core._deabsorb(core_out, w_grouped, True)

--- a/tests/single_card_tests/transformer/test_hybrid_mla_grad_health.py
+++ b/tests/single_card_tests/transformer/test_hybrid_mla_grad_health.py
@@ -547,6 +547,80 @@ class TestSplitKvBProj(unittest.TestCase):
         )
         self.assertLess(err, 1e-3, f"layer output diverged (rel L2 {err})")
 
+    def test_warmup_eval_forward_matches_unsplit(self):
+        """``_forward_dsa``'s early-exit path must honour the split layout.
+
+        With ``dsa_indexer_use_sparse_loss=False`` and no indexer loss to attach
+        (eval / ``no_grad`` / the first forward of a fully recomputed layer),
+        attention skips the indexer and de-absorbs directly. That call site is
+        separate from the two grad-enabled ones, so it needs its own coverage:
+        reading the ``[h, v, l]`` weight through the ``[l, h, v]`` einsum branch
+        does not just lose accuracy, it fails the reshape outright.
+        """
+        if not _HAS_DSA:
+            self.skipTest("absorbed MQA forward requires SM100+ DSA kernel")
+        base = _build("mqa")
+        ded = _build("mqa", split_kv_b=True)
+        ded.set_state_dict(self._loader_split(base.state_dict(), ded))
+        re = _row_end(self.SEQ)
+        x = _hidden(self.SEQ, seed=7)
+        base.eval()
+        ded.eval()
+        with paddle.no_grad():
+            out_base, _ = base(
+                x, attention_mask=None, attn_mask_startend_row_indices=re
+            )
+            out_ded, _ = ded(
+                x, attention_mask=None, attn_mask_startend_row_indices=re
+            )
+        err = _rel_err(
+            out_ded.astype("float32").numpy(),
+            out_base.astype("float32").numpy(),
+        )
+        self.assertLess(err, 1e-3, f"warmup output diverged (rel L2 {err})")
+
+    def test_muon_slices_the_split_params_per_head(self):
+        """Muon must keep orthogonalising one head at a time.
+
+        Both split parameters are 2-D, so Muon picks them up, but the head dim
+        is folded into the leading axis -- without a spec each would be
+        orthogonalised as a single matrix with all heads mixed. ``axis=-2``
+        (not ``0``) also covers the 3-D input Muon produces when it batches
+        several same-shape parameters together.
+        """
+        ded = _build("mqa", split_kv_b=True)
+        specs = ded.muon_slice_specs({"muon_qkv_update_mode": "split_head"})
+        heads = ded.num_attention_heads_per_partition
+        # The unsplit weight gets no gradient in this mode, so it must not be
+        # orthogonalised either.
+        self.assertNotIn("kv_b_proj.weight", specs)
+
+        expected = {
+            "k_b_proj": [ded.kv_lora_rank, ded.qk_nope_head_dim],
+            "v_b_proj": [ded.v_head_dim, ded.kv_lora_rank],
+        }
+        for name, block in expected.items():
+            self.assertIn(name, specs)
+            slice_fn, kwargs = specs[name]
+            self.assertEqual(kwargs, {"heads": heads, "axis": -2})
+            weight = getattr(ded, name)
+            for extra in ([], [3]):
+                seen = []
+
+                def _record(block_tensor):
+                    seen.append(list(block_tensor.shape))
+                    return block_tensor
+
+                batched = (
+                    weight
+                    if not extra
+                    else paddle.stack([weight] * extra[0], axis=0)
+                )
+                out = slice_fn(batched, _record, **kwargs)
+                self.assertEqual(list(out.shape), list(batched.shape))
+                self.assertEqual(len(seen), heads)
+                self.assertEqual(seen, [extra + block] * heads)
+
 
 @_skip_if_no_cuda
 class TestItem2AbsoluteMagnitudeSanity(unittest.TestCase):

--- a/tests/single_card_tests/transformer/test_mla_get_qkv_rope_cp.py
+++ b/tests/single_card_tests/transformer/test_mla_get_qkv_rope_cp.py
@@ -299,6 +299,10 @@ class TestMLAGetQKVRopeContextParallel(unittest.TestCase):
         # Set in MLASelfAttention.__init__; the absorbed-MQA branch of
         # get_query_key_value_tensors reads it.
         layer.mqa_latent = False
+        # Also set in __init__ (mqa_split_kv_b_proj): picks the grouped-matmul
+        # ``k_b_proj`` over the ``kv_b_proj`` slice + einsum. This fixture only
+        # builds the unsplit layout.
+        layer.mqa_latent_split_kv_b = False
         return layer
 
     def _hidden(self, batch=2, seq=32, hidden=16):
@@ -870,6 +874,9 @@ class TestLatentMQARopeFusion(unittest.TestCase):
         layer.training = True
         layer.recompute_qkv_up_porj_and_rope = False
         layer.mqa_latent = True
+        # This fixture folds W_k_b out of ``kv_b_proj.weight``, i.e. the unsplit
+        # absorption layout.
+        layer.mqa_latent_split_kv_b = False
         return layer
 
     def _hidden(self, batch=2, seq=16):

--- a/tests/single_card_tests/transformer/test_mqa_latent_attention.py
+++ b/tests/single_card_tests/transformer/test_mqa_latent_attention.py
@@ -181,6 +181,14 @@ class TestMQAGuards(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.module(query, key, None, None, v_b_proj_weight=w_v)
 
+    def test_v_b_proj_weight_rank_mismatch_rejected(self):
+        # A folded 2-D parameter that was never reshaped back must be named as
+        # such, not fail later on an unpacking whose message hides the cause.
+        query, key, _ = self._args()
+        w_v = paddle.zeros([H * V_HEAD_DIM, DV], dtype="bfloat16")
+        with self.assertRaisesRegex(ValueError, "must be 3-D"):
+            self.module(query, key, None, None, v_b_proj_weight=w_v)
+
     def test_kv_lora_rank_comes_from_the_hybrid_field(self):
         # The rank is not derivable from ``v_b_proj_weight.shape[0]`` once the
         # grouped-matmul layout is in play, so the layer reads it from the
@@ -429,6 +437,20 @@ class TestHybridMLAConfig(unittest.TestCase):
                     )
                 )
                 self.assertTrue(config.mqa_split_kv_b_proj)
+
+    def test_split_kv_b_proj_rejects_hy_sparse_attention(self):
+        # HySparse swaps the layer class for MQASelfAttention, whose forward and
+        # decode paths still absorb against kv_b_proj.weight -- the parameter the
+        # split removes. Accepting the combination would fail on a None
+        # attribute deep in the forward.
+        with self.assertRaisesRegex(ValueError, "enable_hy_sparse_attention"):
+            TransformerConfig(
+                **self._mqa_dsa_kwargs(
+                    hybrid_mla_attention="mqa_dsa",
+                    mqa_split_kv_b_proj=True,
+                    enable_hy_sparse_attention=True,
+                )
+            )
 
     def test_mqa_full_causal_does_not_require_index_dims(self):
         # No indexer is built, so the index_* validation must be skipped -- these

--- a/tests/single_card_tests/transformer/test_mqa_latent_attention.py
+++ b/tests/single_card_tests/transformer/test_mqa_latent_attention.py
@@ -419,9 +419,7 @@ class TestHybridMLAConfig(unittest.TestCase):
         # v_b_proj absorption parameters. On the dense MHA path there is nothing
         # to split, so silently accepting it would hide a mis-set config.
         with self.assertRaisesRegex(ValueError, "only means"):
-            TransformerConfig(
-                **self._kwargs(mqa_split_kv_b_proj=True)
-            )
+            TransformerConfig(**self._kwargs(mqa_split_kv_b_proj=True))
         for mode in ("mqa_dsa", "mqa_full_causal"):
             with self.subTest(mode=mode):
                 config = TransformerConfig(

--- a/tests/single_card_tests/transformer/test_mqa_latent_attention.py
+++ b/tests/single_card_tests/transformer/test_mqa_latent_attention.py
@@ -172,6 +172,25 @@ class TestMQAGuards(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             self.module(query, key, None, None, v_b_proj_weight=w_v)
 
+    def test_v_b_proj_weight_layout_mismatch_rejected(self):
+        # Both layouts reshape fine, so a ``[h, v, l]`` weight handed to the
+        # einsum path (or the reverse) would silently mis-compute. The
+        # contraction dim is checked against the config rank instead.
+        query, key, _ = self._args()
+        w_v = paddle.zeros([H, V_HEAD_DIM, DV], dtype="bfloat16")
+        with self.assertRaises(ValueError):
+            self.module(query, key, None, None, v_b_proj_weight=w_v)
+
+    def test_kv_lora_rank_comes_from_the_hybrid_field(self):
+        # The rank is not derivable from ``v_b_proj_weight.shape[0]`` once the
+        # grouped-matmul layout is in play, so the layer reads it from the
+        # config: the hybrid field when set, the model-wide one otherwise.
+        self.assertEqual(self.module.kv_lora_rank, DV)
+        config = _create_mqa_config("mqa")
+        config.hybrid_mla_kv_lora_rank = None
+        config.kv_lora_rank = DV
+        self.assertEqual(_build_module(config).kv_lora_rank, DV)
+
     def test_softmax_scale_is_the_mha_scale(self):
         # Absorption is exactly score preserving, so the scale must stay the MHA
         # q_head_dim one (256**-0.5), never the 576-wide latent one.
@@ -394,6 +413,24 @@ class TestHybridMLAConfig(unittest.TestCase):
                             dsa_index_topk=INDEX_TOPK,
                         )
                     )
+
+    def test_split_kv_b_proj_only_means_anything_for_latent_mqa(self):
+        # The switch splits latent MQA's kv_b_proj into standalone k_b_proj /
+        # v_b_proj absorption parameters. On the dense MHA path there is nothing
+        # to split, so silently accepting it would hide a mis-set config.
+        with self.assertRaisesRegex(ValueError, "only means"):
+            TransformerConfig(
+                **self._kwargs(non_absorbed_mqa_split_kv_b_proj=True)
+            )
+        for mode in ("mqa_dsa", "mqa_full_causal"):
+            with self.subTest(mode=mode):
+                config = TransformerConfig(
+                    **self._mqa_dsa_kwargs(
+                        hybrid_mla_attention=mode,
+                        non_absorbed_mqa_split_kv_b_proj=True,
+                    )
+                )
+                self.assertTrue(config.non_absorbed_mqa_split_kv_b_proj)
 
     def test_mqa_full_causal_does_not_require_index_dims(self):
         # No indexer is built, so the index_* validation must be skipped -- these

--- a/tests/single_card_tests/transformer/test_mqa_latent_attention.py
+++ b/tests/single_card_tests/transformer/test_mqa_latent_attention.py
@@ -420,17 +420,17 @@ class TestHybridMLAConfig(unittest.TestCase):
         # to split, so silently accepting it would hide a mis-set config.
         with self.assertRaisesRegex(ValueError, "only means"):
             TransformerConfig(
-                **self._kwargs(non_absorbed_mqa_split_kv_b_proj=True)
+                **self._kwargs(mqa_split_kv_b_proj=True)
             )
         for mode in ("mqa_dsa", "mqa_full_causal"):
             with self.subTest(mode=mode):
                 config = TransformerConfig(
                     **self._mqa_dsa_kwargs(
                         hybrid_mla_attention=mode,
-                        non_absorbed_mqa_split_kv_b_proj=True,
+                        mqa_split_kv_b_proj=True,
                     )
                 )
-                self.assertTrue(config.non_absorbed_mqa_split_kv_b_proj)
+                self.assertTrue(config.mqa_split_kv_b_proj)
 
     def test_mqa_full_causal_does_not_require_index_dims(self):
         # No indexer is built, so the index_* validation must be skipped -- these

--- a/tests/single_card_tests/transformer/test_muon_slice_specs.py
+++ b/tests/single_card_tests/transformer/test_muon_slice_specs.py
@@ -350,7 +350,7 @@ class TestSelfAttentionVHASpecs(unittest.TestCase):
 
 
 class TestMLASpecs(unittest.TestCase):
-    def _fake(self, sparse_gated=False):
+    def _fake(self, sparse_gated=False, split_kv_b=False):
         fake = SimpleNamespace(
             config=SimpleNamespace(kv_lora_rank=8),
             kv_lora_rank=8,
@@ -360,6 +360,7 @@ class TestMLASpecs(unittest.TestCase):
             v_head_dim=4,
             q_b_proj=object(),
             gate_proj=object(),
+            mqa_latent_split_kv_b=split_kv_b,
         )
         if sparse_gated:
             # Only MQASelfAttention builds this second gated branch.
@@ -398,12 +399,45 @@ class TestMLASpecs(unittest.TestCase):
             v_head_dim=4,
             q_b_proj=object(),
             gate_proj=None,
+            mqa_latent_split_kv_b=False,
         )
         specs = MLASelfAttention.muon_slice_specs(fake, {})
         self.assertEqual(
             specs["kv_a_proj_with_mqa.weight"][1]["head_sizes"], [8, 2]
         )
         self.assertEqual(specs["kv_b_proj.weight"][1]["head_sizes"], [4, 4])
+
+    def test_split_kv_b_slices_standalone_absorption_params(self):
+        # ``non_absorbed_mqa_split_kv_b_proj`` moves the per-head blocks Muon
+        # must orthogonalise from ``kv_b_proj`` onto the standalone
+        # ``k_b_proj`` / ``v_b_proj`` parameters, which are split along the
+        # head-major leading axis instead of by ``head_sizes``.
+        fake = self._fake(split_kv_b=True)
+        specs = MLASelfAttention.muon_slice_specs(fake, {})
+        self.assertEqual(
+            set(specs),
+            {
+                "q_b_proj.weight",
+                "kv_a_proj_with_mqa.weight",
+                "k_b_proj",
+                "v_b_proj",
+                "gate_proj.weight",
+            },
+        )
+        recorders = _run_specs(
+            specs,
+            {
+                "q_b_proj.weight": [HIDDEN, 2 * (4 + 2)],
+                "kv_a_proj_with_mqa.weight": [HIDDEN, 8 + 2],
+                # per head: [kv_lora_rank, qk_nope_head_dim] / [v_head_dim,
+                # kv_lora_rank].
+                "k_b_proj": [2 * 8, 4],
+                "v_b_proj": [2 * 4, 8],
+                "gate_proj.weight": [HIDDEN, 2 * 4],
+            },
+        )
+        self.assertEqual(recorders["k_b_proj"].shapes, [(8, 4), (8, 4)])
+        self.assertEqual(recorders["v_b_proj"].shapes, [(4, 8), (4, 8)])
 
     def test_without_optional_projections(self):
         fake = self._fake()

--- a/tests/single_card_tests/transformer/test_muon_slice_specs.py
+++ b/tests/single_card_tests/transformer/test_muon_slice_specs.py
@@ -453,12 +453,8 @@ class TestMLASpecs(unittest.TestCase):
             {k: specs[k] for k in ("k_b_proj", "v_b_proj")},
             {"k_b_proj": [3, 2 * 8, 4], "v_b_proj": [3, 2 * 4, 8]},
         )
-        self.assertEqual(
-            recorders["k_b_proj"].shapes, [(3, 8, 4), (3, 8, 4)]
-        )
-        self.assertEqual(
-            recorders["v_b_proj"].shapes, [(3, 8, 4), (3, 8, 4)]
-        )
+        self.assertEqual(recorders["k_b_proj"].shapes, [(3, 8, 4), (3, 8, 4)])
+        self.assertEqual(recorders["v_b_proj"].shapes, [(3, 8, 4), (3, 8, 4)])
 
     def test_without_optional_projections(self):
         fake = self._fake()

--- a/tests/single_card_tests/transformer/test_muon_slice_specs.py
+++ b/tests/single_card_tests/transformer/test_muon_slice_specs.py
@@ -408,7 +408,7 @@ class TestMLASpecs(unittest.TestCase):
         self.assertEqual(specs["kv_b_proj.weight"][1]["head_sizes"], [4, 4])
 
     def test_split_kv_b_slices_standalone_absorption_params(self):
-        # ``non_absorbed_mqa_split_kv_b_proj`` moves the per-head blocks Muon
+        # ``mqa_split_kv_b_proj`` moves the per-head blocks Muon
         # must orthogonalise from ``kv_b_proj`` onto the standalone
         # ``k_b_proj`` / ``v_b_proj`` parameters, which are split along the
         # head-major leading axis instead of by ``head_sizes``.
@@ -437,7 +437,28 @@ class TestMLASpecs(unittest.TestCase):
             },
         )
         self.assertEqual(recorders["k_b_proj"].shapes, [(8, 4), (8, 4)])
-        self.assertEqual(recorders["v_b_proj"].shapes, [(4, 8), (4, 8)])
+        # The V block is stored transposed relative to the unsplit weight, so
+        # it is orthogonalised in its transpose -- Muon's version 1/2 scaling is
+        # ``dout / din`` and would otherwise apply the reciprocal ratio.
+        self.assertEqual(recorders["v_b_proj"].shapes, [(8, 4), (8, 4)])
+
+    def test_split_kv_b_specs_handle_muon_batched_3d_input(self):
+        # Muon stacks same-shape parameters into one 3-D tensor before calling
+        # ortho_fn, so the head split must stay on axis -2 (not axis 0) and the
+        # V-side transpose must swap only the last two dims.
+        specs = MLASelfAttention.muon_slice_specs(
+            self._fake(split_kv_b=True), {}
+        )
+        recorders = _run_specs(
+            {k: specs[k] for k in ("k_b_proj", "v_b_proj")},
+            {"k_b_proj": [3, 2 * 8, 4], "v_b_proj": [3, 2 * 4, 8]},
+        )
+        self.assertEqual(
+            recorders["k_b_proj"].shapes, [(3, 8, 4), (3, 8, 4)]
+        )
+        self.assertEqual(
+            recorders["v_b_proj"].shapes, [(3, 8, 4), (3, 8, 4)]
+        )
 
     def test_without_optional_projections(self):
         fake = self._fake()


### PR DESCRIPTION

Merged in dev: https://github.com/PaddlePaddle/PaddleFleet/pull/1696

### PR Category
Performance Optimization

### PR Types
Performance

### Description

latent MQA 路径上两处优化。

**1. 拆分 `kv_b_proj` 为独立吸收参数**

新增开关 `mqa_split_kv_b_proj`（仅 `hybrid_mla_attention` 为 `mqa_dsa` / `mqa_full_causal` 时有效）。开启后不再每次 forward 切片 `kv_b_proj.weight` 再走 `einsum`，改用两个已按 `fused_grouped_matmul` 布局存好的参数：`k_b_proj`（query 吸收）与 `v_b_proj`（V 去吸收），每侧一次 grouped GEMM，无切片、无转置。受 AOA 不能改 rank 限制，二者以折叠前两维的 2-D 存储，forward 内零拷贝 reshape 还原；`kv_b_proj` 在该模式下无梯度，缺这两个 key 的 checkpoint 由 loader（`_mla_split_kv_b_statements`）拆出。Muon 侧同步注册逐 head 切片（`axis=-2`），V 块转置回未拆分权重的朝向后再正交化，以保持各 `muon_version` 的缩放语义。

**2. `fused_grouped_matmul` 不再拷贝输入**

kernel 本身接收全部 stride，普通 strided view（如 `q[..., :qk_nope_head_dim]`）无需 `.contiguous()`。原实现每次 forward（含 recompute）及 backward 的 `dy` 都会白拷一次，而 phi 的 strided→dense kernel 无向量化特化（~350 GB/s vs dense ~4400 GB/s），代价与体积不成比例。新增 `_grouped_3d_strides` 只接受“dense 拷贝会逐元素线性化”的布局，broadcast / 负 stride / 自重叠 / 不可折叠一律回退原路径；入口另加 `w` 为 3-D `[G, R, D]`、`x.shape[-2:] == (G, D)` 的校验。

性能（`[1, 16384, 8, 128]` bf16）：fwd+bwd 1.080 → 0.869 ms/step（**1.24x**），`contiguous()` 调用 2/step → 0；8k profile 中约省 266 ms GPU 时间。

Cherry-pick of #1696 to `release/0.4`.

Merged in dev: #1696  <!-- For pass CI -->

### 是否引起精度变化
否

零拷贝路径喂给同一 kernel 的值、顺序与 block 配置完全相同，结果**逐 bit 一致**：强制回退到拷贝路径后对比 `out` / 输入梯度 / `w.grad` 的 md5，312 种组合（13 种输入布局 × 2 dtype × 对齐与非对齐尺寸 × dense/非连续 `dy` × 三种冻结组合）与 3 个生产调用点全部零差异。拆分模式的等价性由 `TestSplitKvBProj` 覆盖：吸收 query、去吸收输出、整层 forward（含 warmup 的 eval/no-grad 早退路径）相对误差均 < 1e-3。