### PR TITLE
[release/0.4][Bug fixes] Route the DSA warmup KL through the tilelang full-candidate indexer

### DIFF
--- a/src/paddlefleet/transformer/mqa_latent_attention.py
+++ b/src/paddlefleet/transformer/mqa_latent_attention.py
@@ -33,7 +33,7 @@ phase has its own ``_forward_*`` with no loss code shared between them:
   spans every causal column on both sides, via one ``csa_indexer_topk_fwd``
   call in its documented "full-candidate selection" mode.
 * ``"mqa_dsa"`` + ``dsa_indexer_use_sparse_loss=True`` -> ``_forward_sparse``
-  (phase 3/4). A forced local window plus Lightning-indexer top-k, i.e. DeepSeek
+  (phase 3). A forced local window plus Lightning-indexer top-k, i.e. DeepSeek
   Sparse Attention on the KV latent, with the KL restricted to that same
   selected set. This is the only phase that reads ``index_topk``.
 
@@ -113,7 +113,7 @@ from paddlefleet.transformer.layer import FleetLayer
 if TYPE_CHECKING:
     from paddlefleet.transformer.enums import AttnMaskType
 
-# Working set of the phase-3/4 KL-target gather, as a ``rows x slots`` budget:
+# Working set of the phase-3 KL-target gather, as a ``rows x slots`` budget:
 # 256 rows x 512 slots x 576 dims is ~150MB of gathered bf16 keys, transient and
 # freed every iteration. Measured at s=8192/h=64/topk=512/dk=576 on one B30Z:
 # 15.9ms at 128 rows, 13.3ms at 256, 12.4ms at 512, 12.4ms at 1024 -- past 256
@@ -273,7 +273,7 @@ class MQALatentAttention(FleetLayer):
           being learned, so attention must not consume its ranking: full causal
           attention, and the KL runs over the *full* causal set on both sides.
           No top-k anywhere.
-        * ``"sparse"`` -- phase 3/4. Attention consumes window + top-k and the
+        * ``"sparse"`` -- phase 3. Attention consumes window + top-k and the
           KL is restricted to that same selected set.
 
         Read live rather than cached in ``__init__``: a test flipping
@@ -756,7 +756,7 @@ class MQALatentAttention(FleetLayer):
         return out.reshape([b, s, h * v_head_dim])
 
     # ------------------------------------------------------------------
-    # sparse (phase 3/4)
+    # sparse (phase 3)
     # ------------------------------------------------------------------
     def _forward_sparse(
         self,
@@ -773,7 +773,7 @@ class MQALatentAttention(FleetLayer):
         input_ids=None,
         position_offset=0,
     ) -> Tensor:
-        """Phase 3/4: attention consumes window + top-k, KL on that same set.
+        """Phase 3: attention consumes window + top-k, KL on that same set.
 
         The indexer is trained enough to steer attention, so both sides narrow to
         the selected set. Reached only when ``_phase() == "sparse"``, i.e.

--- a/src/paddlefleet/transformer/mqa_latent_attention.py
+++ b/src/paddlefleet/transformer/mqa_latent_attention.py
@@ -15,19 +15,29 @@
 """Latent MQA core attention for hybrid MLA layers, with DSA.
 
 ``hybrid_mla_attention`` selects which core attention the
-``csa_compress_ratios == -2`` (MLA) layers of a ``dsv4_hybrid`` model run:
+``csa_compress_ratios == -2`` (MLA) layers of a ``dsv4_hybrid`` model run, and
+within the DSA mode ``dsa_indexer_use_sparse_loss`` selects the training phase.
+``MQALatentAttention._phase()`` is the single place that is decided, and each
+phase has its own ``_forward_*`` with no loss code shared between them:
 
 * ``"mha"`` -- unchanged dense MLA (MHA); this module is not used.
-* ``"mqa_dsa"`` -- :class:`MQALatentAttention` with a forced local window plus
-  Lightning-indexer top-k, i.e. DeepSeek Sparse Attention on the KV latent.
-  The indexer reuses the model-wide ``index_n_heads`` / ``index_head_dim`` /
-  ``index_topk``, and ``dsa_indexer_use_sparse_loss`` selects the indexer-loss
-  width exactly as it does for the CSA layers (see ``_forward_dsa``).
-* ``"mqa_full_causal"`` -- :class:`MQALatentAttention` with the indexer dropped,
-  attending to the full per-document causal set. That is mathematically
+* ``"mqa_full_causal"`` -> ``_forward_full_causal``. Latent MQA with the indexer
+  dropped, attending to the full per-document causal set. Mathematically
   identical to the dense MHA phase, so it isolates the absorption from the
-  sparsity for equivalence experiments; it is ``O(s^2)`` in index memory and
-  therefore not a production mode.
+  sparsity for equivalence experiments; ``O(s^2)`` in index memory and therefore
+  not a production mode.
+* ``"mqa_dsa"`` + ``dsa_indexer_use_sparse_loss=False`` -> ``_forward_warmup``
+  (phase 2, DSA warmup, paired with ``train_indexer_only``). The backbone is
+  frozen and the indexer is random, so **neither side uses top-k**: attention
+  runs the same full per-document causal set phase 1 did, and the indexer KL
+  spans every causal column on both sides, via one ``csa_indexer_topk_fwd``
+  call in its documented "full-candidate selection" mode.
+* ``"mqa_dsa"`` + ``dsa_indexer_use_sparse_loss=True`` -> ``_forward_sparse``
+  (phase 3/4). A forced local window plus Lightning-indexer top-k, i.e. DeepSeek
+  Sparse Attention on the KV latent, with the KL restricted to that same
+  selected set. This is the only phase that reads ``index_topk``.
+
+The indexer reuses the model-wide ``index_n_heads`` / ``index_head_dim``.
 
 Note the ``mqa_*`` modes here are *latent* MQA (this module). A
 ``csa_compress_ratios`` entry of ``-1`` is *CSA full-causal MQA*, a different
@@ -48,8 +58,10 @@ per-head sink logit as ``softmax_offset``, built by the same
 ``build_softmax_offset`` helper ``DotProductAttention`` uses, so the parameter
 name matches the dense phase. It is fed to the block-sparse kernel as its
 ``attn_sink``, which then enables the finite-sink LSE correction and the
-analytic sink gradient. The indexer KL target is unaffected: it is renormalised
-over the selected set, where the sink mass cancels.
+analytic sink gradient. The indexer KL target does not see it: that target
+normalises over the indexer's own candidate set, and the sink -- like the forced
+window -- is outside that set by construction, not by cancellation. See
+``_attn_target`` for the measured size of the alternative definition.
 
 Multi-document equivalence: RoPE/YaRN scores depend only on ``pos_q - pos_k``,
 the YaRN ``mscale`` is a constant and the Hadamard ``rotate_activation`` is
@@ -93,26 +105,24 @@ from paddlefleet.transformer.csa_attention import (
     _validate_csa_docmask_shape,
 )
 from paddlefleet.transformer.dot_product_attention import build_softmax_offset
-from paddlefleet.transformer.dsa_attention import DSAIndexerLossLoggingHelper
+from paddlefleet.transformer.dsa_attention import (
+    DSAIndexerLossLoggingHelper,
+)
 from paddlefleet.transformer.layer import FleetLayer
 
 if TYPE_CHECKING:
     from paddlefleet.transformer.enums import AttnMaskType
 
-# Working set of the KL-target gather, as a ``rows x slots`` budget: 256 rows x
-# 512 slots x 576 dims is ~150MB of gathered bf16 keys, transient and freed every
-# iteration. Measured at s=8192/h=64/topk=512/dk=576 on one B30Z: 15.9ms at 128
-# rows, 13.3ms at 256, 12.4ms at 512, 12.4ms at 1024 -- past 256 the curve is
-# flat, so larger chunks only buy peak memory. Budgeting the product keeps that
-# working set when ``dsa_indexer_use_sparse_loss=False`` widens the table.
+# Working set of the phase-3/4 KL-target gather, as a ``rows x slots`` budget:
+# 256 rows x 512 slots x 576 dims is ~150MB of gathered bf16 keys, transient and
+# freed every iteration. Measured at s=8192/h=64/topk=512/dk=576 on one B30Z:
+# 15.9ms at 128 rows, 13.3ms at 256, 12.4ms at 512, 12.4ms at 1024 -- past 256
+# the curve is flat, so larger chunks only buy peak memory.
 _TARGET_ROW_SLOTS = 256 * 512
-# cuDNN indexer limits on the top-k table width: ``indexer_top_k/api.py:92``
-# rejects ``top_k > 2048`` outright, and ``indexer_backward_sm100.__init__``
-# asserts ``topk % block_I == 0`` with ``block_I = 128``.
-_LOSS_TOPK_CAP = 2048
-_TOPK_BLOCK = 128
 _NEG_INF = -1e30
 _EPS = 1e-10
+
+_TILELANG_INDEXER_BLOCK = 32
 
 
 @dataclass
@@ -214,28 +224,14 @@ class MQALatentAttention(FleetLayer):
         self.indexer_loss_coeff = float(
             getattr(config, "dsa_indexer_loss_coeff", 0.0) or 0.0
         )
-        # Same switch, same meaning as the CSA layers of the hybrid model: it
-        # selects the *width of the indexer loss* candidate table. On these
-        # uncompressed layers it additionally selects the *attention* candidate
-        # set, because the two are one decision here -- see below.
+        # Phase selector, read by ``_phase()`` -- see its docstring. Stored raw
+        # rather than as a derived phase so that flipping it on a live module
+        # (tests do) cannot leave a stale phase behind.
+        # ``transformer_config.__post_init__`` pins it against
+        # ``train_indexer_only`` so the two cannot disagree.
         self.indexer_use_sparse_loss = bool(
             getattr(config, "dsa_indexer_use_sparse_loss", False)
         )
-        # ``dsa_indexer_use_sparse_loss=False`` is the phase-2 (warmup) mode:
-        # the indexer is still being learned, so attention must not consume its
-        # ranking yet -- it attends to the full per-document causal set, exactly
-        # like ``hybrid_mla_attention="mqa_full_causal"``, while the indexer is
-        # trained on the widest candidate table the kernel allows. Consuming a
-        # freshly initialised indexer's top-k here would feed the (frozen)
-        # backbone an essentially random sparse pattern for the whole phase.
-        # ``True`` is the phase-3/4 mode: attention consumes window + top-k and
-        # the KL is restricted to that same set.
-        # ``transformer_config.__post_init__`` pins this to ``train_indexer_only``
-        # so the two cannot disagree. Deliberately *not* cached as a second
-        # attribute: ``_forward_dsa`` reads ``self.indexer_use_sparse_loss``
-        # directly at both use sites, so a test (or anything else) flipping it on
-        # a live module cannot desynchronise the loss width from the attention
-        # set.
         # Learnable per-head attention-sink logit, from the model-wide
         # ``add_full_attention_sink_bias`` / ``softmax_type``. Built by the same
         # helper ``DotProductAttention`` uses, so the state_dict name
@@ -250,6 +246,45 @@ class MQALatentAttention(FleetLayer):
             else config.num_attention_heads,
             is_swa,
         )
+
+    def _needs_indexer_loss(self) -> bool:
+        """Whether this forward should build and attach the indexer loss.
+
+        Both DSA phases share this predicate. ``paddle.is_grad_enabled()`` is
+        what makes the loss count exactly once under recompute: the first
+        (no-grad) forward only materialises the attention columns, the second one
+        attaches the loss.
+        """
+        return (
+            self.training
+            and paddle.is_grad_enabled()
+            and self.indexer_loss_coeff > 0
+        )
+
+    def _phase(self) -> str:
+        """Which of the three training phases this layer runs.
+
+        The single place the phase is decided, so the attention candidate set
+        and the indexer-loss shape cannot disagree:
+
+        * ``"full_causal"`` -- no indexer at all
+          (``hybrid_mla_attention="mqa_full_causal"``, and the
+          absorption-equivalence unit tests). Per-document full causal
+          attention, no indexer loss.
+        * ``"warmup"`` -- phase 2 (DSA warmup). The indexer exists but is still
+          being learned, so attention must not consume its ranking: full causal
+          attention, and the KL runs over the *full* causal set on both sides.
+          No top-k anywhere.
+        * ``"sparse"`` -- phase 3/4. Attention consumes window + top-k and the
+          KL is restricted to that same selected set.
+
+        Read live rather than cached in ``__init__``: a test flipping
+        ``indexer_use_sparse_loss`` on a live module must not be able to
+        desynchronise the two.
+        """
+        if self.indexer is None:
+            return "full_causal"
+        return "sparse" if self.indexer_use_sparse_loss else "warmup"
 
     def forward(
         self,
@@ -333,19 +368,38 @@ class MQALatentAttention(FleetLayer):
                 _derive_csa_doc_boundaries(row_end, s_global)
             )
 
-        if self.indexer is None:
-            # ``hybrid_mla_attention="mqa_full_causal"`` (and the
-            # absorption-equivalence unit tests): per-document full causal
-            # attention, mathematically identical to dense MHA.
-            token_indices = self._build_full_causal_indices(
-                b, s_global, doc_start, is_valid, position_offset, s
+        phase = self._phase()
+        if phase == "full_causal":
+            return self._forward_full_causal(
+                query,
+                kv,
+                v_b_proj_weight,
+                doc_start,
+                is_valid,
+                kv_lora_rank,
+                position_offset,
+                s,
+                s_global,
             )
-            core_out = self._sparse_attn(
-                query, kv, token_indices, self.softmax_scale, kv_lora_rank
-            )
-            return self._deabsorb(core_out, v_b_proj_weight)
 
-        return self._forward_dsa(
+        if phase == "warmup":
+            return self._forward_warmup(
+                query,
+                kv,
+                x,
+                qr,
+                v_b_proj_weight,
+                doc_start,
+                doc_len,
+                is_valid,
+                kv_lora_rank,
+                input_ids,
+                position_offset,
+                s,
+                s_global,
+            )
+
+        return self._forward_sparse(
             query,
             kv,
             x,
@@ -359,6 +413,226 @@ class MQALatentAttention(FleetLayer):
             input_ids,
             position_offset,
         )
+
+    # ------------------------------------------------------------------
+    # full_causal
+    # ------------------------------------------------------------------
+    def _forward_full_causal(
+        self,
+        query: Tensor,
+        kv: Tensor,
+        v_b_proj_weight: Tensor,
+        doc_start: Tensor,
+        is_valid: Tensor,
+        kv_lora_rank: int,
+        position_offset: int,
+        s_local: int,
+        s_global: int,
+    ) -> Tensor:
+        """Per-document full-causal attention on the absorbed latent.
+
+        No indexer is involved: the column set is decided by the document
+        boundaries alone, so this output is mathematically identical to the
+        dense MHA phase and is bit-identical across repeated calls (nothing
+        here depends on a top-k tie-break).
+
+        Used by two phases -- ``hybrid_mla_attention="mqa_full_causal"``, and
+        the attention half of the phase-2 warmup, which must not consume the
+        indexer's ranking while the indexer is still being learned.
+        """
+        b = int(query.shape[0])
+        token_indices = self._build_full_causal_indices(
+            b, s_global, doc_start, is_valid, position_offset, s_local
+        )
+        core_out = self._sparse_attn(
+            query, kv, token_indices, self.softmax_scale, kv_lora_rank
+        )
+        return self._deabsorb(core_out, v_b_proj_weight)
+
+    # ------------------------------------------------------------------
+    # warmup (phase 2)
+    # ------------------------------------------------------------------
+    def _forward_warmup(
+        self,
+        query: Tensor,
+        kv: Tensor,
+        x: Tensor,
+        qr: Tensor,
+        v_b_proj_weight: Tensor,
+        doc_start: Tensor,
+        doc_len: Tensor,
+        is_valid: Tensor,
+        kv_lora_rank: int,
+        input_ids: Tensor | None,
+        position_offset: int,
+        s_local: int,
+        s_global: int,
+    ) -> Tensor:
+        """Phase 2: frozen backbone, full-causal attention, full-causal KL.
+
+        No top-k on either side. The two halves:
+
+        * **attention** is the same deterministic full-causal set phase 1 uses
+          (``_forward_full_causal``), so the frozen backbone sees exactly the
+          activations it was pretrained with while the indexer is still random.
+        * **the indexer** is supervised over the *whole* per-document causal
+          span, so it cannot reinforce its own initial ranking.
+
+        Both come from one tilelang call with ``topk_effective = s_global``, which
+        is the "full-candidate selection" mode ``csa_indexer_topk_fwd`` documents
+        for exactly this phase -- the CSA layers use it the same way with
+        ``topk_effective = n_compressed``. The kernel returns the softmax
+        probabilities over every candidate column plus the column ids, and the
+        head dimension never leaves the kernel; the backward is upstream's
+        ``csa_indexer_bwd`` via ``TileLangCSAIndexerLossAutoScaler``, whose
+        tilelang branch computes exactly ``(P - Q) * coeff / valid_rows``.
+
+        Recompute: the attention column table depends only on the document
+        boundaries, so the two forwards of a recompute segment are bit-identical
+        and there is no top-k tie-break to worry about. The loss is attached on
+        the grad-enabled forward only, so it is counted once; the no-grad forward
+        skips the indexer entirely rather than computing and discarding it.
+
+        CP: ``index_k`` is all-gathered to ``s_global`` inside
+        ``forward_before_topk`` and ``kv`` by the caller, ``valid_range`` is built
+        over the global sequence and row-sliced, and ``valid_rows`` is the global
+        valid-row count -- so the per-rank losses sum to the single-rank one and
+        no ``/cp_size`` correction is needed.
+        """
+        from paddlefleet.tilelang_ops import csa_indexer_topk_fwd
+
+        output = self._forward_full_causal(
+            query,
+            kv,
+            v_b_proj_weight,
+            doc_start,
+            is_valid,
+            kv_lora_rank,
+            position_offset,
+            s_local,
+            s_global,
+        )
+        if not self._needs_indexer_loss():
+            return output
+
+        b = int(query.shape[0])
+        self._check_tilelang_full_candidate_support(s_global)
+        index_q, index_k, weights = self._indexer_projections(
+            x, qr, position_offset, grad_enabled=True
+        )
+        # ``DSAIndexer`` pre-bakes ``head_dim**-0.5`` into the weights, and the
+        # tilelang indexer kernels apply ``dim**-0.5`` themselves -- same
+        # convention as the cuDNN pair the sparse phase uses, and the opposite of
+        # the pure-paddle ``FusedDSAIndexerLoss`` reference, which applies none.
+        # Undo the pre-bake once, before both the forward call and the weights
+        # handed to the backward, so the two agree.
+        # Measured (validation_reports/precision_audit_20260809_022929/ops_edge):
+        # against a plain-paddle reference the un-baked weights match to
+        # max_abs 3.0e-8 / cosine 1-1.5e-13, while passing them through unscaled
+        # gives max_abs 7.5e-1 / cosine 0.62.
+        weights = weights * (float(self.indexer.head_dim) ** 0.5)
+        # The tilelang kernels want a power-of-two top-k width, so ask for the
+        # whole causal span rounded up. ``valid_range`` already bounds each row's
+        # candidates, so the surplus slots come back ``-1`` and are dropped
+        # everywhere downstream -- measured: the per-row valid-slot count equals
+        # the causal length exactly at s = 40/127/200/300/384/500/8192, and the
+        # rows still sum to 1 within 4.2e-7. At a power-of-two sequence length
+        # (production) this is a no-op.
+        width = 1 << (s_global - 1).bit_length()
+        with paddle.no_grad():
+            # No forced window in this phase, so the candidate range is the
+            # whole per-document causal span.
+            valid_range, row_empty = self._indexer_valid_range(
+                s_global,
+                doc_start,
+                doc_len,
+                is_valid,
+                position_offset,
+                s_local,
+                window=0,
+            )
+            columns, probs = csa_indexer_topk_fwd(
+                index_q.detach(),
+                index_k.detach(),
+                weights.detach(),
+                ratio=1,
+                topk_effective=width,
+                seq_offset=position_offset,
+                valid_range=valid_range,
+            )
+            columns = paddle.where(
+                row_empty, paddle.full_like(columns, -1), columns
+            )
+            probs = paddle.where(columns >= 0, probs, paddle.zeros_like(probs))
+            target = self._attn_target(query.detach(), kv, columns)
+            loss_mask, valid_rows = self._indexer_loss_mask(
+                input_ids, b, s_local
+            )
+            # Same reduction as ``_forward_sparse`` -- see the long comment there
+            # for why the unmasked branch's ``/cp_size`` has to sit in
+            # ``loss_coeff`` (and therefore reach the backward) rather than only
+            # in the logged scalar the way ``csa_attention`` places it.
+            loss_coeff = (
+                self.indexer_loss_coeff
+                if loss_mask is not None
+                else self.indexer_loss_coeff / self.cp_size
+            )
+            kl = (
+                target * (paddle.log(target + _EPS) - paddle.log(probs + _EPS))
+            ).sum(axis=-1)
+            if loss_mask is None:
+                loss = kl.mean() * loss_coeff
+            else:
+                loss = (kl * loss_mask).sum() / valid_rows * loss_coeff
+
+        DSAIndexerLossLoggingHelper.save_loss_to_tracker(
+            loss=loss,
+            layer_number=self.layer_number,
+            num_layers=DSAIndexerLossLoggingHelper.get_total_num_layers(
+                self.config
+            ),
+        )
+        return TileLangCSAIndexerLossAutoScaler.apply(
+            output,
+            target,
+            index_q,
+            weights,
+            index_k,
+            columns,
+            probs,
+            loss_coeff,
+            "tilelang",
+            valid_rows,
+            loss_mask,
+        )
+
+    def _check_tilelang_full_candidate_support(self, s_global: int) -> None:
+        """Fail loudly on the tilelang indexer's shape constraints.
+
+        The top-k width is the causal span rounded up to a power of two (see
+        ``_forward_warmup``), so the kernels' ``topk == next_power_of_2(topk)``
+        and ``topk % block == 0`` asserts are satisfied by construction for any
+        sequence length at or above the block size. What is left to check is the
+        head count: measured, ``index_n_heads`` below 64 trips the kernel's warp
+        tiling with a bare
+        ``Check failed: (m_warp * n_warp == num_warps)`` from inside tilelang, so
+        reject it here instead. The wrappers do not pad and the ``% block`` assert
+        only fires on the *backward*, i.e. minutes into a run.
+        """
+        heads = int(self.indexer.n_heads)
+        width = 1 << (s_global - 1).bit_length()
+        if width < _TILELANG_INDEXER_BLOCK:
+            raise ValueError(
+                "the DSA warmup phase scores the full per-document causal span "
+                "with the tilelang indexer, whose top-k width must be at least "
+                f"{_TILELANG_INDEXER_BLOCK}; here that width rounds up to "
+                f"{width} from the sequence length s_global={s_global}."
+            )
+        if heads != 64:
+            raise ValueError(
+                "the tilelang indexer's warp tiling requires index_n_heads == 64 "
+                f"(measured: 8 fails inside the kernel), got {heads}."
+            )
 
     # ------------------------------------------------------------------
     # index construction / kernel plumbing
@@ -385,6 +659,34 @@ class MQALatentAttention(FleetLayer):
         indices.stop_gradient = True
         return indices
 
+    def _indexer_projections(self, x, qr, position_offset, grad_enabled):
+        """``(index_q, index_k, weights)`` from the DSA indexer.
+
+        ``x`` / ``qr`` are always detached first: the indexer loss must never
+        flow back into the backbone, independently of whether the backbone
+        parameters are frozen. ``index_k`` comes back all-gathered to
+        ``s_global`` when CP is on (the indexer gathers the 128-wide key rather
+        than the hidden states, which is ~32x less traffic).
+
+        ``weights`` is returned exactly as ``DSAIndexer.forward_before_topk``
+        produced it, i.e. carrying ``n_heads**-0.5 * head_dim**-0.5``. Every
+        kernel-backed caller must undo the ``head_dim`` half itself, because both
+        the cuDNN and the tilelang indexer kernels re-apply ``dim**-0.5``
+        internally; only a pure-paddle evaluation of the score (as in
+        ``dsa_attention.FusedDSAIndexerLoss``) uses it unscaled.
+        """
+        x_det, qr_det = x.detach(), qr.detach()
+        if grad_enabled:
+            x_det.stop_gradient = False
+            qr_det.stop_gradient = False
+            return self.indexer.forward_before_topk(
+                x_det, qr_det, position_offset, self.cp_group
+            )
+        with paddle.no_grad():
+            return self.indexer.forward_before_topk(
+                x_det, qr_det, position_offset, self.cp_group
+            )
+
     def _indexer_valid_range(
         self,
         s_global,
@@ -393,15 +695,18 @@ class MQALatentAttention(FleetLayer):
         is_valid,
         position_offset=0,
         s_local=None,
+        window=None,
     ):
-        """Non-local candidate range per query, in **global token** space.
+        """Candidate range per query, in **global token** space.
 
-        The forced local window already covers the last ``window_size`` causal
-        tokens, so the indexer must only rank what lies *before* it. Clamping
-        the right edge to ``doc_start + causal_len - window_size`` removes every
-        duplicate while leaving the full top-k budget for distant tokens.
-        Because the clamped end never exceeds the kernel's own causal limit, no
-        masked ``-inf`` column can enter the top-k.
+        ``window`` is how many trailing causal tokens to exclude, i.e. the
+        forced local window the sparse phase adds separately: clamping the right
+        edge to ``doc_start + causal_len - window`` removes every duplicate while
+        leaving the full top-k budget for distant tokens. Because the clamped end
+        never exceeds the kernel's own causal limit, no masked ``-inf`` column can
+        enter the top-k. Defaults to ``self.csa_window_size``; the warmup phase
+        passes ``0`` because it has no forced window -- its candidate set is the
+        whole per-document causal span.
 
         Built over the global sequence and row-sliced to this CP rank; the two
         columns stay global token ids, which is what the kernel's
@@ -410,9 +715,11 @@ class MQALatentAttention(FleetLayer):
         Returns:
             ``(valid_range [1, s_local, 2] int32, row_empty [1, s_local, 1])``.
         """
+        if window is None:
+            window = self.window_size
         positions = paddle.arange(s_global, dtype="int64")
         causal_avail = paddle.minimum(positions - doc_start + 1, doc_len)
-        n_avail = paddle.clip(causal_avail - self.window_size, min=0)
+        n_avail = paddle.clip(causal_avail - window, min=0)
         n_avail = paddle.where(is_valid, n_avail, paddle.zeros_like(n_avail))
         valid_range = paddle.stack(
             [doc_start, doc_start + n_avail], axis=-1
@@ -456,9 +763,9 @@ class MQALatentAttention(FleetLayer):
         return out.reshape([b, s, h * v_head_dim])
 
     # ------------------------------------------------------------------
-    # mqa_dsa
+    # sparse (phase 3/4)
     # ------------------------------------------------------------------
-    def _forward_dsa(
+    def _forward_sparse(
         self,
         query,
         kv,
@@ -473,97 +780,55 @@ class MQALatentAttention(FleetLayer):
         input_ids=None,
         position_offset=0,
     ) -> Tensor:
+        """Phase 3/4: attention consumes window + top-k, KL on that same set.
+
+        The indexer is trained enough to steer attention, so both sides narrow to
+        the selected set. Reached only when ``_phase() == "sparse"``, i.e.
+        ``dsa_indexer_use_sparse_loss=True``; the warmup phase has its own branch
+        and shares no loss code with this one.
+
+        Recompute: the loss is attached on the grad-enabled forward only, so under
+        full recompute it is counted once, on the second pass. Both passes see
+        identical inputs and reselect the same columns. (The top-k tie-break is
+        not bit-stable in every shape -- one document spanning the whole sequence
+        drifts by ~2% of the emitted slots between identical calls -- but the
+        selected *set* is, and any residual drift would only change which columns
+        the backward differentiates.)
+        """
         from paddlefleet.cudnn_ops.indexer.csa_indexer_fwd_cudnn import (
             cudnn_indexer_topk_fwd,
         )
 
         b, s = int(query.shape[0]), int(query.shape[1])
         s_global = s * self.cp_size
-        # The indexer loss is only attached on the grad-enabled forward. Under
-        # full-layer recompute the first forward runs under no_grad and must
-        # only materialise indices; both passes see identical inputs, so the
-        # top-k kernel reselects the same columns. (Its tie-break is not
-        # bit-stable in every shape -- one document spanning the whole sequence
-        # drifts by ~2% of the slots between identical calls -- but any residual
-        # drift only changes which columns the backward differentiates.)
-        need_loss = (
-            self.training
-            and paddle.is_grad_enabled()
-            and self.indexer_loss_coeff > 0
-        )
-
-        if not self.indexer_use_sparse_loss and not need_loss:
-            # Phase-2 mode with nothing to learn this step (eval, or
-            # ``dsa_indexer_loss_coeff == 0``): attention does not consume the
-            # indexer, so skip its projections entirely instead of computing
-            # them under ``no_grad`` and throwing the result away.
-            with paddle.no_grad():
-                token_indices = self._build_full_causal_indices(
-                    b, s_global, doc_start, is_valid, position_offset, s
-                )
-            core_out = self._sparse_attn(
-                query, kv, token_indices, self.softmax_scale, kv_lora_rank
-            )
-            return self._deabsorb(core_out, v_b_proj_weight)
+        need_loss = self._needs_indexer_loss()
 
         with paddle.no_grad():
-            window_idxs = None
-            if self.indexer_use_sparse_loss:
-                window_idxs = _build_window_topk_idxs_from_doc_bounds(
-                    b, s_global, self.window_size, doc_start, is_valid
-                ).cast("int32")
-                if self.cp_enabled:
-                    window_idxs = window_idxs[
-                        :, position_offset : position_offset + s
-                    ]
+            window_idxs = _build_window_topk_idxs_from_doc_bounds(
+                b, s_global, self.window_size, doc_start, is_valid
+            ).cast("int32")
+            if self.cp_enabled:
+                window_idxs = window_idxs[
+                    :, position_offset : position_offset + s
+                ]
             valid_range, row_empty = self._indexer_valid_range(
                 s_global, doc_start, doc_len, is_valid, position_offset, s
             )
 
-        x_det, qr_det = x.detach(), qr.detach()
-        if need_loss:
-            x_det.stop_gradient = False
-            qr_det.stop_gradient = False
-            q_idx, k_idx, w_idx = self.indexer.forward_before_topk(
-                x_det, qr_det, position_offset, self.cp_group
-            )
-        else:
-            with paddle.no_grad():
-                q_idx, k_idx, w_idx = self.indexer.forward_before_topk(
-                    x_det, qr_det, position_offset, self.cp_group
-                )
+        q_idx, k_idx, w_idx = self._indexer_projections(
+            x, qr, position_offset, grad_enabled=need_loss
+        )
         # ``DSAIndexer`` pre-bakes ``head_dim**-0.5`` into the weights, but both
         # cuDNN indexer kernels apply ``dim**-0.5`` themselves (the backward one
         # hardcodes it). Undo the pre-bake once so forward and backward agree.
         w_idx = w_idx * (float(self.indexer.head_dim) ** 0.5)
 
-        # Both forward top-k paths return a table of exactly ``topk_effective``
-        # columns (short rows are ``-1`` padded), and the backward kernel
-        # ``indexer_backward_sm100.__init__`` asserts ``topk % block_I == 0``
-        # with ``block_I=128``. So keep the configured budget instead of
-        # clamping it to the sequence length, which would break that assert.
-        attn_topk = int(self.indexer.index_topk)
-        # ``dsa_indexer_use_sparse_loss`` means here exactly what it means for
-        # the CSA layers of the same model
-        # (``_resolve_csa_indexer_loss_topk_effective``, csa_attention.py:1091):
-        # the indexer loss may score a *wider* table than attention consumes.
-        #   True  -> KL over exactly the set attention uses (selected-set KL).
-        #   False -> KL over the full candidate table, so a freshly initialised
-        #            indexer is supervised on columns it did not pick and cannot
-        #            reinforce its own initial ranking.
-        # CSA's "full" is its *compressed* candidate range (``s / ratio``, e.g.
-        # 64 columns at ratio 128). These layers are uncompressed, so the full
-        # range is the causal span itself and the cuDNN indexer bounds it at
-        # ``_LOSS_TOPK_CAP``: with s=8192 the loss covers the top 2048 scoring
-        # columns, not all 8192. Going truly dense would mean materialising the
-        # ``[s, h, s]`` attention distribution per layer -- the very thing this
-        # path exists to avoid -- so the cap stands.
-        loss_topk = attn_topk
-        if need_loss and not self.indexer_use_sparse_loss:
-            loss_topk = max(
-                attn_topk,
-                min(_LOSS_TOPK_CAP, s_global // _TOPK_BLOCK * _TOPK_BLOCK),
-            )
+        # The cuDNN top-k backward (``indexer_backward_sm100.__init__``) asserts
+        # ``topk % block_I == 0`` with ``block_I = 128``, so keep the configured
+        # budget instead of clamping it to the sequence length. Short rows come
+        # back ``-1`` padded. One width, consumed by attention and by the KL --
+        # that identity *is* this phase.
+        topk = int(self.indexer.index_topk)
         # The THD/varlen fast path builds ``cu_seqlens_k`` from ``doc_lens``,
         # i.e. it assumes a document-compacted K buffer. At ratio 1 the K buffer
         # is the raw token sequence, so the two only coincide when the documents
@@ -575,62 +840,24 @@ class MQALatentAttention(FleetLayer):
             doc_lens.tolist() if int(doc_lens.sum()) == s_global else None
         )
 
-        def select_topk(width, want_scores):
-            out = cudnn_indexer_topk_fwd(
+        with paddle.no_grad():
+            selected, _, *scores_out = cudnn_indexer_topk_fwd(
                 q_idx.detach(),
                 k_idx.detach(),
                 w_idx.detach(),
                 ratio=1,
-                topk_effective=width,
+                topk_effective=topk,
                 valid_range=valid_range,
                 doc_lens=doc_lens_arg,
                 seq_offset=position_offset,
-                return_topk_scores=want_scores,
+                return_topk_scores=need_loss,
             )
-            idx = paddle.where(row_empty, paddle.full_like(out[0], -1), out[0])
-            return idx, (out[2] if want_scores else None)
-
-        with paddle.no_grad():
-            if not self.indexer_use_sparse_loss:
-                # Phase 2: attention attends to the full per-document causal
-                # set, bit-identical to ``hybrid_mla_attention="mqa_full_causal"``
-                # -- the indexer's ranking is still being learned and must not
-                # steer attention yet. Only the loss consumes the top-k table,
-                # so there is exactly one ``select_topk`` call below.
-                token_indices = self._build_full_causal_indices(
-                    b, s_global, doc_start, is_valid, position_offset, s
-                )
-                topk_indices, attn_scores, reuse_for_loss = None, None, False
-            else:
-                # The attention width and the loss width are two separate
-                # kernel calls, and deliberately so: the attention set must not
-                # depend on how wide the loss happens to be.
-                #
-                # With today's ``_indexer_top_k_unfused`` (a deterministic
-                # ``paddle.topk``) slicing one wide call would in fact give the
-                # same columns -- measured over 6 shapes (pure causal s=512 and
-                # s=1024, window-clamped s=512/1024, packed docs [256,256,512],
-                # ratio=4): 0 ascending score steps in the emitted order and the
-                # narrow table is 100% the wide table's prefix. But that is a
-                # property of one helper, not of the interface: the pre-#1666
-                # radix kernel emitted in ascending *position* order (same
-                # shapes: ~61k ascending score steps, only 55.5% prefix match),
-                # so a slice would have silently moved the attention set. Two
-                # calls keep that decoupled by construction; the extra one runs
-                # only on the grad-enabled forward of a full-loss step.
-                #
-                # ``return_topk_scores`` stays tied to ``need_loss`` alone,
-                # never to the width decision, for the same reason: under the
-                # old radix kernel the flag chose a different code path and
-                # flipped 10-15% of the returned slots (it is a no-op for the
-                # column set today, 0 slot mismatch on all 6 shapes above). The
-                # scores of the narrow call are unused when the loss widens the
-                # table.
-                topk_indices, attn_scores = select_topk(attn_topk, need_loss)
-                reuse_for_loss = loss_topk == attn_topk
-                token_indices = paddle.concat(
-                    [window_idxs, topk_indices], axis=-1
-                ).contiguous()
+            topk_indices = paddle.where(
+                row_empty, paddle.full_like(selected, -1), selected
+            )
+            token_indices = paddle.concat(
+                [window_idxs, topk_indices], axis=-1
+            ).contiguous()
         token_indices.stop_gradient = True
 
         core_out = self._sparse_attn(
@@ -641,21 +868,20 @@ class MQALatentAttention(FleetLayer):
             return output
 
         with paddle.no_grad():
-            if reuse_for_loss:
-                loss_indices, loss_scores = topk_indices, attn_scores
-            else:
-                loss_indices, loss_scores = select_topk(loss_topk, True)
-            valid = loss_indices >= 0
+            (topk_scores,) = scores_out
+            valid = topk_indices >= 0
             scores = paddle.where(
                 valid,
-                loss_scores.cast("float32"),
-                paddle.full(loss_indices.shape, _NEG_INF, dtype="float32"),
+                topk_scores.cast("float32"),
+                paddle.full(topk_indices.shape, _NEG_INF, dtype="float32"),
             )
             topk_probs = F.softmax(scores, axis=-1)
             topk_probs = paddle.where(
                 valid, topk_probs, paddle.zeros_like(topk_probs)
             )
-            target = self._attn_target(query.detach(), kv, loss_indices)
+            # The window is force-selected, so it is outside the indexer's
+            # decision space and outside the KL: only the top-k columns.
+            target = self._attn_target(query.detach(), kv, topk_indices)
             kl = target * (
                 paddle.log(target + _EPS) - paddle.log(topk_probs + _EPS)
             )
@@ -668,11 +894,26 @@ class MQALatentAttention(FleetLayer):
             # backstop that catches them, keeping the padding out of both the
             # logged loss and the gradient denominator.
             loss_mask, valid_rows = self._indexer_loss_mask(input_ids, b, s)
-            # Under CP each rank reduces over its own query rows only. With a
-            # mask the denominator is already the *global* valid-row count, so
-            # the per-rank losses sum to the global one; without a mask each rank
-            # produced a local mean and needs ``/cp_size``. Same split as
-            # csa_attention.py:2792-2810.
+            # Reduction shape follows ``csa_attention._compute_fused_indexer_target``
+            # (:2325-2330) with one deliberate difference: the ``/cp_size`` of the
+            # unmasked branch is folded into ``loss_coeff``, i.e. it also reaches
+            # the **backward**, instead of being applied to the logged scalar
+            # alone the way CSA does it at :2868-2869.
+            #
+            # That difference is load-bearing, not cosmetic. CP sums parameter
+            # gradients across the group, so every rank must normalise by the
+            # *global* row count. The masked branch gets that for free
+            # (``valid_rows`` is global, and it is what ``num_rows_override``
+            # hands the backward); the unmasked branch has no mask, so the
+            # backward falls back to the kernel's own ``1/(B*Sq)`` -- a *local*
+            # denominator -- and the only place left to correct it is the
+            # coefficient. Copying CSA's placement here was measured: CP=2
+            # ``test_4_indexer_loss_cp_normalisation`` fails on
+            # ``indexer.wq_b.linear.weight`` with relative error ``1.000`` against
+            # CP=1 (exactly a factor of ``cp_size``), in both phases, while the
+            # logged scalar still matched. CSA has the same latent gap on its
+            # unmasked CP path; production always supplies ``input_ids``, so it is
+            # the masked branch that runs.
             loss_coeff = (
                 self.indexer_loss_coeff
                 if loss_mask is not None
@@ -703,7 +944,7 @@ class MQALatentAttention(FleetLayer):
             q_idx,
             w_idx,
             k_idx,
-            loss_indices,
+            topk_indices,
             topk_probs,
             loss_coeff,
             "cudnn",
@@ -748,34 +989,50 @@ class MQALatentAttention(FleetLayer):
         )
         return loss_mask, max(float(loss_mask.sum()), 1.0)
 
-    def _attn_target(self, query, kv, topk_indices) -> Tensor:
-        """KL target: head-summed attention probs restricted to the top-k set.
+    def _attn_target(self, query, kv, kl_columns) -> Tensor:
+        """KL target: head-summed attention probs over the indexer's own columns.
 
-        The tilelang ``csa_attn_target_reducesum`` kernel requires a
-        power-of-two head dim, which the 576-wide latent is not, and the dense
-        ``_compute_attn_target_on_selected_set`` materialises ``[b, h, s, s]``
-        (16x the FLOPs at ``s=8192, topk=512``). So gather the selected keys in
-        query-row chunks instead: ``s*h*topk*dk`` MACs, no ``s*s`` tensor.
+        The denominator is **the KL's candidate set and nothing else** -- not the
+        forced window, not the sink. That is the definition of this loss, not an
+        oversight: the indexer is only ever asked to rank the columns it can
+        choose, and ``_indexer_valid_range`` explicitly clamps the window out of
+        its candidate range, so neither the window nor the sink is in its decision
+        space. Upstream does the same for the CSA layers --
+        ``dsa_attention._compute_dsa_indexer_loss`` adds ``index_mask`` to
+        ``attention_scores`` *before* the softmax, i.e. it normalises over the
+        selected set.
 
-        The matmul runs in the input dtype (bf16) with fp32 accumulation, which
-        is what the tilelang kernel does internally for the CSA layers; only the
-        softmax and the L1 normalisation are fp32. The chunk height follows
-        ``_TARGET_ROW_SLOTS / topk``, so the gather buffer stays the same size
-        whether the table is the attention one or the wider loss one.
+        Worth recording because it was measured and is easy to misread as a bug:
+        normalising over the full attention row instead (window + top-k + sink)
+        gives a *different* target -- a head mixture weighted by each head's mass
+        on the candidate set, ``Σ_h c_h·softmax_K(l^h) / Σ_h c_h``, rather than
+        the uniform ``(1/H)·Σ_h softmax_K(l^h)`` here. The gap is 4.4e-3 at the
+        production sink initialisation, 1.7e-2 at ``sink=+3``, and 1.9e-2 for the
+        window term alone. Those are two objectives, not right and wrong; this one
+        is the intended one.
+
+        The tilelang ``csa_attn_target_reducesum`` kernel is not usable here (it
+        requires a power-of-two head dim; the latent is 576) and the dense
+        ``_compute_attn_target_on_selected_set`` materialises ``[b, h, s, s]``, so
+        gather the selected keys in query-row chunks instead: ``s*h*w*dk`` MACs,
+        no ``s*s`` tensor. The matmul runs in the input dtype (bf16) with fp32
+        accumulation, as the tilelang kernel does internally for the CSA layers;
+        the softmax and the L1 normalisation are fp32.
 
         Args:
             query: ``[1, s, h, dk]`` detached absorbed query (local rows).
             kv: ``[1, s_global, dk]`` latent keys (all-gathered under CP).
-            topk_indices: ``[1, s, topk]`` int32 global column ids, ``-1`` for
-                empty slots.
+            kl_columns: ``[1, s, w]`` int32 global column ids the KL scores,
+                ``-1`` for empty slots. Column *order* is irrelevant, so the
+                warmup phase passes the indexer's score-ordered table directly.
 
         Returns:
-            ``[1, s, topk]`` float32 rows summing to 1 (0 for empty rows).
+            ``[1, s, w]`` float32 rows summing to 1 (0 for empty rows).
         """
-        s, topk = int(query.shape[1]), int(topk_indices.shape[-1])
+        s, width = int(query.shape[1]), int(kl_columns.shape[-1])
         dk = int(query.shape[-1])
-        chunk = max(1, _TARGET_ROW_SLOTS // topk)
-        q0, kv0, idx0 = query[0], kv[0], topk_indices[0]
+        chunk = max(1, _TARGET_ROW_SLOTS // width)
+        q0, kv0, idx0 = query[0], kv[0], kl_columns[0]
         parts = []
         for start in range(0, s, chunk):
             end = min(start + chunk, s)
@@ -783,7 +1040,7 @@ class MQALatentAttention(FleetLayer):
             valid = idx_c >= 0
             safe = paddle.where(valid, idx_c, paddle.zeros_like(idx_c))
             k_sel = paddle.gather(kv0, safe.flatten(), axis=0).reshape(
-                [end - start, topk, dk]
+                [end - start, width, dk]
             )
             scores = (
                 paddle.matmul(q0[start:end], k_sel, transpose_y=True).cast(
@@ -794,7 +1051,7 @@ class MQALatentAttention(FleetLayer):
             scores = paddle.where(
                 valid.unsqueeze(1), scores, paddle.full_like(scores, _NEG_INF)
             )
-            probs = F.softmax(scores, axis=-1).sum(axis=1)  # head-sum [c, topk]
+            probs = F.softmax(scores, axis=-1).sum(axis=1)  # head-sum [c, w]
             parts.append(paddle.where(valid, probs, paddle.zeros_like(probs)))
         target = paddle.concat(parts, axis=0)
         target = target / target.sum(axis=-1, keepdim=True).clip(min=_EPS)

--- a/src/paddlefleet/transformer/mqa_latent_attention.py
+++ b/src/paddlefleet/transformer/mqa_latent_attention.py
@@ -122,8 +122,6 @@ _TARGET_ROW_SLOTS = 256 * 512
 _NEG_INF = -1e30
 _EPS = 1e-10
 
-_TILELANG_INDEXER_BLOCK = 32
-
 
 @dataclass
 class MQALatentAttentionSublayersSpec:
@@ -516,7 +514,7 @@ class MQALatentAttention(FleetLayer):
             return output
 
         b = int(query.shape[0])
-        self._check_tilelang_full_candidate_support(s_global)
+        self._check_tilelang_indexer_support()
         index_q, index_k, weights = self._indexer_projections(
             x, qr, position_offset, grad_enabled=True
         )
@@ -531,14 +529,14 @@ class MQALatentAttention(FleetLayer):
         # max_abs 3.0e-8 / cosine 1-1.5e-13, while passing them through unscaled
         # gives max_abs 7.5e-1 / cosine 0.62.
         weights = weights * (float(self.indexer.head_dim) ** 0.5)
-        # The tilelang kernels want a power-of-two top-k width, so ask for the
-        # whole causal span rounded up. ``valid_range`` already bounds each row's
-        # candidates, so the surplus slots come back ``-1`` and are dropped
-        # everywhere downstream -- measured: the per-row valid-slot count equals
-        # the causal length exactly at s = 40/127/200/300/384/500/8192, and the
-        # rows still sum to 1 within 4.2e-7. At a power-of-two sequence length
-        # (production) this is a no-op.
-        width = 1 << (s_global - 1).bit_length()
+        # ``topk_effective`` is the causal span itself. The wrapper rounds it up
+        # to a power-of-two multiple of its block internally and crops the result
+        # back to the requested width (``csa_indexer_fwd.py:430-462`` /
+        # ``csa_indexer_bwd.py:617-638``), so there is nothing to round here and
+        # no surplus ``-1`` slot to carry. Measured at
+        # s = 1/2/4/8/16/32/300/384/512/8192: the returned width equals
+        # ``s_global`` exactly, the per-row valid-slot count equals the causal
+        # length, rows sum to 1 within 9.6e-7 and the backward is finite.
         with paddle.no_grad():
             # No forced window in this phase, so the candidate range is the
             # whole per-document causal span.
@@ -556,7 +554,7 @@ class MQALatentAttention(FleetLayer):
                 index_k.detach(),
                 weights.detach(),
                 ratio=1,
-                topk_effective=width,
+                topk_effective=s_global,
                 seq_offset=position_offset,
                 valid_range=valid_range,
             )
@@ -606,28 +604,23 @@ class MQALatentAttention(FleetLayer):
             loss_mask,
         )
 
-    def _check_tilelang_full_candidate_support(self, s_global: int) -> None:
-        """Fail loudly on the tilelang indexer's shape constraints.
+    def _check_tilelang_indexer_support(self) -> None:
+        """Fail loudly on the one tilelang indexer constraint we cannot absorb.
 
-        The top-k width is the causal span rounded up to a power of two (see
-        ``_forward_warmup``), so the kernels' ``topk == next_power_of_2(topk)``
-        and ``topk % block == 0`` asserts are satisfied by construction for any
-        sequence length at or above the block size. What is left to check is the
-        head count: measured, ``index_n_heads`` below 64 trips the kernel's warp
-        tiling with a bare
-        ``Check failed: (m_warp * n_warp == num_warps)`` from inside tilelang, so
-        reject it here instead. The wrappers do not pad and the ``% block`` assert
-        only fires on the *backward*, i.e. minutes into a run.
+        The top-k *width* needs no check: the wrappers round ``topk_effective``
+        up to a power-of-two multiple of their block and crop the result back
+        (``csa_indexer_fwd.py:430-462``, ``csa_indexer_bwd.py:617-638``), so any
+        causal span from 1 upwards is served -- measured at
+        s = 1/2/4/8/16/32/300/384/512/8192.
+
+        The head count is different: ``index_n_heads`` other than 64 trips the
+        kernel's warp tiling with a bare
+        ``Check failed: (m_warp * n_warp == num_warps)`` from inside tilelang
+        (measured with 8). Reject that here rather than at the launch. It is not
+        checked at config time on purpose -- that would make every
+        small-geometry unit fixture unrepresentable.
         """
         heads = int(self.indexer.n_heads)
-        width = 1 << (s_global - 1).bit_length()
-        if width < _TILELANG_INDEXER_BLOCK:
-            raise ValueError(
-                "the DSA warmup phase scores the full per-document causal span "
-                "with the tilelang indexer, whose top-k width must be at least "
-                f"{_TILELANG_INDEXER_BLOCK}; here that width rounds up to "
-                f"{width} from the sequence length s_global={s_global}."
-            )
         if heads != 64:
             raise ValueError(
                 "the tilelang indexer's warp tiling requires index_n_heads == 64 "

--- a/src/paddlefleet/transformer/multi_latent_attention.py
+++ b/src/paddlefleet/transformer/multi_latent_attention.py
@@ -47,6 +47,7 @@ from paddlefleet.parallel_state import (
 )
 from paddlefleet.process_groups_config import ProcessGroupCollection
 from paddlefleet.recompute_utils import (
+    keep_indexer_grad_path,
     need_recompute_in_block,
     need_recompute_in_first_n,
 )
@@ -969,8 +970,14 @@ class MultiLatentAttention(Attention):
                 attention_bias=attention_bias,
                 packed_seq_params=packed_seq_params,
                 use_rr_flash_attention=self.use_rr_flash_attention,
-                # DSA-specific parameters
-                x=hidden_states,
+                # DSA-specific parameters. ``recompute`` is a PyLayer, so with a
+                # frozen backbone (``train_indexer_only``) every input here would
+                # be detached, the segment output would inherit that, and the
+                # indexer loss attached *inside* the segment would silently never
+                # get a backward pass. This is the third segment that can hold an
+                # indexer, next to the layer-level one (transformer_layer.py) and
+                # ``DSv4HybridAttention``'s ``full_attn`` one.
+                x=keep_indexer_grad_path(hidden_states, self.config),
                 qr=q_compressed,
                 # fastdeploy support
                 kv_compressed=kv_compressed,

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -1574,22 +1574,25 @@ class TransformerConfig(ModelParallelConfig):
             )
         if self.hybrid_mla_attention == "mqa_dsa":
             # On the ``-2`` layers ``dsa_indexer_use_sparse_loss`` decides both
-            # the indexer-loss candidate width and the attention candidate set,
+            # the indexer-loss candidate set and the attention candidate set,
             # because they are one decision: while the indexer is still being
-            # learned (wide loss) attention must not consume its ranking. The
-            # two training phases are therefore fixed pairs, and the two mixed
-            # combinations are configuration mistakes rather than modes.
+            # learned attention must not consume its ranking, so the warmup phase
+            # runs full-causal attention and a KL over the whole causal set --
+            # no top-k on either side. The two training phases are therefore
+            # fixed pairs, and the two mixed combinations are configuration
+            # mistakes rather than modes.
             if self.train_indexer_only and self.dsa_indexer_use_sparse_loss:
                 raise ValueError(
                     "train_indexer_only=True with "
                     "dsa_indexer_use_sparse_loss=True is not a valid phase. "
-                    "Training only the Indexer is the warmup phase, which needs "
-                    "the wide indexer loss (dsa_indexer_use_sparse_loss=False) "
-                    "so the freshly initialised Indexer is supervised on columns "
-                    "it did not pick; the sparse loss only scores the columns it "
-                    "already selected and lets it reinforce its own initial "
-                    "ranking. Set dsa_indexer_use_sparse_loss=False in the "
-                    "model config, or drop train_indexer_only."
+                    "Training only the Indexer is the warmup phase, whose KL "
+                    "spans the whole per-document causal set "
+                    "(dsa_indexer_use_sparse_loss=False) so the freshly "
+                    "initialised Indexer is supervised on columns it did not "
+                    "pick; the sparse loss only scores the columns it already "
+                    "selected and lets it reinforce its own initial ranking. "
+                    "Set dsa_indexer_use_sparse_loss=False in the model config, "
+                    "or drop train_indexer_only."
                 )
             if (
                 not self.train_indexer_only
@@ -1598,8 +1601,9 @@ class TransformerConfig(ModelParallelConfig):
                 logger.warning(
                     "hybrid_mla_attention='mqa_dsa' with "
                     "dsa_indexer_use_sparse_loss=False runs the warmup shape "
-                    "(full per-document causal attention plus the wide indexer "
-                    "loss) while every backbone parameter still trains. The "
+                    "(full per-document causal attention plus a KL over the "
+                    "whole causal set, no top-k anywhere) while every backbone "
+                    "parameter still trains. The "
                     "production warmup phase pairs it with "
                     "train_indexer_only=True; the sparse training phase pairs "
                     "dsa_indexer_use_sparse_loss=True with a trainable backbone."
@@ -1671,16 +1675,20 @@ class TransformerConfig(ModelParallelConfig):
                         f"invalid fields: {', '.join(invalid)}"
                     )
                 if self.hybrid_mla_attention == "mqa_dsa":
-                    # The -2 layers' indexer reuses the CSA indexer fields. The
-                    # cuDNN indexer forward requires D_i=128, its backward
-                    # asserts topk % block_I == 0 with block_I=128, and
-                    # indexer_top_k/api.py:92 rejects topk > 2048 outright.
-                    # Fail here instead of minutes later at the first forward.
-                    index_fields = (
+                    # The -2 layers' indexer reuses the CSA indexer fields.
+                    # ``index_n_heads`` / ``index_head_dim`` set the indexer's
+                    # parameter shapes and are needed in both DSA phases; the
+                    # cuDNN indexer forward requires D_i=128.
+                    index_fields = [
                         "dsa_index_n_heads",
                         "dsa_index_head_dim",
-                        "dsa_index_topk",
-                    )
+                    ]
+                    # ``index_topk`` is phase 3/4 only: the warmup phase
+                    # (``dsa_indexer_use_sparse_loss=False``) runs no top-k at
+                    # all -- its KL spans the whole per-document causal set -- so
+                    # it must not be required to carry a top-k budget.
+                    if self.dsa_indexer_use_sparse_loss:
+                        index_fields.append("dsa_index_topk")
                     invalid_index = [
                         name
                         for name in index_fields
@@ -1691,8 +1699,8 @@ class TransformerConfig(ModelParallelConfig):
                     if invalid_index:
                         raise ValueError(
                             "hybrid_mla_attention='mqa_dsa' runs a DSA indexer on "
-                            "the hybrid MLA layers and needs index_n_heads / "
-                            "index_head_dim / index_topk as positive integers; "
+                            "the hybrid MLA layers and needs "
+                            f"{' / '.join(index_fields)} as positive integers; "
                             f"invalid fields: {', '.join(invalid_index)}"
                         )
                     if self.dsa_index_head_dim != 128:
@@ -1701,10 +1709,24 @@ class TransformerConfig(ModelParallelConfig):
                             "indexer, which requires index_head_dim=128, got "
                             f"{self.dsa_index_head_dim}."
                         )
-                    if (
+                    # ``index_n_heads`` is deliberately *not* pinned to 64 here.
+                    # The warmup phase's tilelang indexer does need exactly 64
+                    # (measured: 8 dies inside the kernel with a bare
+                    # "Check failed: (m_warp * n_warp == num_warps)"), but
+                    # enforcing it at config time would make every small-geometry
+                    # unit fixture unrepresentable. The check lives at the first
+                    # use instead --
+                    # ``MQALatentAttention._check_tilelang_full_candidate_support``
+                    # -- which still raises before any kernel launch.
+                    if self.dsa_indexer_use_sparse_loss and (
                         self.dsa_index_topk % 128 != 0
                         or self.dsa_index_topk > 2048
                     ):
+                        # The cuDNN indexer backward asserts
+                        # ``topk % block_I == 0`` with ``block_I=128`` and
+                        # ``indexer_top_k/api.py:92`` rejects ``topk > 2048``
+                        # outright. Fail here instead of minutes later at the
+                        # first forward.
                         raise ValueError(
                             "index_topk must be a multiple of 128 and at most "
                             "2048 (cuDNN indexer backward block size / top-k "

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -1683,7 +1683,7 @@ class TransformerConfig(ModelParallelConfig):
                         "dsa_index_n_heads",
                         "dsa_index_head_dim",
                     ]
-                    # ``index_topk`` is phase 3/4 only: the warmup phase
+                    # ``index_topk`` is phase 3 only: the warmup phase
                     # (``dsa_indexer_use_sparse_loss=False``) runs no top-k at
                     # all -- its KL spans the whole per-document causal set -- so
                     # it must not be required to carry a top-k budget.

--- a/tests/multi_card_tests/transformer/test_indexer_topk_col_mask_cp.py
+++ b/tests/multi_card_tests/transformer/test_indexer_topk_col_mask_cp.py
@@ -395,7 +395,7 @@ class TestHybridMLAColumnMaskLoadBearingCP(unittest.TestCase):
         there is no window duplication for a mask to prevent. Asserted rather
         than dropped because it is the sharpest statement of the phase-2
         contract, and because it bounds ``test_1``'s claim: the mask is
-        load-bearing for phase 3/4 only.
+        load-bearing for phase 3 only.
         """
         spy = self._run(sparse_loss=False, loss_coeff=0.1)
         totals = self._report(spy, "mqa_dsa/warmup")

--- a/tests/multi_card_tests/transformer/test_indexer_topk_col_mask_cp.py
+++ b/tests/multi_card_tests/transformer/test_indexer_topk_col_mask_cp.py
@@ -382,23 +382,29 @@ class TestHybridMLAColumnMaskLoadBearingCP(unittest.TestCase):
         )
 
     @H.U._GPU
-    def test_2_warmup_loss_table_stays_in_window(self):
-        """The widened phase-2 KL table goes through the same helper.
+    def test_2_warmup_never_reaches_the_topk_helper(self):
+        """Phase 2 never reaches this helper, so the column mask cannot apply.
 
-        Attention takes the full causal set here, but the loss still calls
-        ``select_topk`` (``mqa_latent_attention.py:578``), so an unmasked top-k
-        would train the indexer to rank columns the window already owns.
+        ``_forward_warmup`` (``mqa_latent_attention.py:453-585``) supervises the
+        indexer over the **whole** per-document causal span: one *tilelang*
+        ``csa_indexer_topk_fwd`` with ``topk_effective=s_global`` and
+        ``window=0`` (``mqa_latent_attention.py:524-541``), imported directly
+        rather than through ``csa_indexer_backend``. So the cuDNN helper this
+        file spies on -- the one that carries the column mask -- is not called
+        on either the attention or the loss side, and with no forced window
+        there is no window duplication for a mask to prevent. Asserted rather
+        than dropped because it is the sharpest statement of the phase-2
+        contract, and because it bounds ``test_1``'s claim: the mask is
+        load-bearing for phase 3/4 only.
         """
         spy = self._run(sparse_loss=False, loss_coeff=0.1)
         totals = self._report(spy, "mqa_dsa/warmup")
-        self.assertGreater(
-            totals["rows"], 0, "the warmup loss issued no top-k call"
-        )
         self.assertEqual(
-            totals["oor_prod"],
+            totals["rows"],
             0,
-            f"the warmup KL table holds {totals['oor_prod']} out-of-window "
-            "columns",
+            f"phase 2 issued {totals['rows']} cuDNN top-k row(s) across the CP "
+            "group; the warmup KL is supposed to go through the tilelang "
+            "full-candidate kernel, which carries no column mask",
         )
 
 

--- a/tests/multi_card_tests/transformer/test_mqa_dsa_cp.py
+++ b/tests/multi_card_tests/transformer/test_mqa_dsa_cp.py
@@ -38,7 +38,7 @@ the full-MLA integration):
 4. The selected column set: the sparse kernel's ``token_indices`` under CP must
    equal the reference's rows for this rank.
 5. Indexer-loss normalisation, masked (global denominator) and unmasked
-   (``/cp_size`` on the phase-3/4 path), and the phase-2
+   (``/cp_size`` on the phase-3 path), and the phase-2
    ``dsa_indexer_use_sparse_loss=False`` full-causal KL.
 6. The attention sink under CP.
 7. The ``cp_balance_mode`` guard.
@@ -192,7 +192,7 @@ def _logged_indexer_loss(layer_number=1):
 
     ``_forward_warmup`` / ``_forward_sparse`` reduce the KL with the coefficient
     and denominator their phase picked (phase 2 always the global row count;
-    phase 3/4 the global valid-row count when masked, ``/cp_size`` when not) and
+    phase 3 the global valid-row count when masked, ``/cp_size`` when not) and
     hand exactly that scalar to ``DSAIndexerLossLoggingHelper``, so the tracker
     is a direct read of the normalisation -- no gradient indirection. ``0.0``
     when the step attached no loss.

--- a/tests/multi_card_tests/transformer/test_mqa_dsa_cp.py
+++ b/tests/multi_card_tests/transformer/test_mqa_dsa_cp.py
@@ -38,7 +38,8 @@ the full-MLA integration):
 4. The selected column set: the sparse kernel's ``token_indices`` under CP must
    equal the reference's rows for this rank.
 5. Indexer-loss normalisation, masked (global denominator) and unmasked
-   (``/cp_size``), and the widened ``dsa_indexer_use_sparse_loss=False`` table.
+   (``/cp_size`` on the phase-3/4 path), and the phase-2
+   ``dsa_indexer_use_sparse_loss=False`` full-causal KL.
 6. The attention sink under CP.
 7. The ``cp_balance_mode`` guard.
 
@@ -189,11 +190,12 @@ def _rel(a, e):
 def _logged_indexer_loss(layer_number=1):
     """The indexer loss this layer just pushed into the logging tracker.
 
-    ``_forward_dsa`` reduces the KL with the coefficient the CP branch picked
-    (global valid-row denominator when masked, ``/cp_size`` when not) and hands
-    exactly that scalar to ``DSAIndexerLossLoggingHelper``, so the tracker is a
-    direct read of the normalisation -- no gradient indirection. ``0.0`` when
-    the step attached no loss.
+    ``_forward_warmup`` / ``_forward_sparse`` reduce the KL with the coefficient
+    and denominator their phase picked (phase 2 always the global row count;
+    phase 3/4 the global valid-row count when masked, ``/cp_size`` when not) and
+    hand exactly that scalar to ``DSAIndexerLossLoggingHelper``, so the tracker
+    is a direct read of the normalisation -- no gradient indirection. ``0.0``
+    when the step attached no loss.
     """
     values = DSAIndexerLossLoggingHelper.tracker.get("values")
     if values is None:

--- a/tests/multi_card_tests/transformer/test_mqa_dsa_warmup_cp.py
+++ b/tests/multi_card_tests/transformer/test_mqa_dsa_warmup_cp.py
@@ -134,7 +134,7 @@ class _CPChecks(unittest.TestCase):
     def _assert_full_causal(self, idx, row_end, tag):
         """Every local row's selected set == its whole per-document causal set.
 
-        This is what separates the warmup mode from phase 3/4: under
+        This is what separates the warmup mode from phase 3: under
         ``window + top-k`` a row longer than ``window + index_topk`` selects a
         strict subset, so this assertion would fail there.
         """
@@ -271,7 +271,7 @@ class TestWarmupCP(_CPChecks):
         always a real tensor -- ``_indexer_loss_mask``'s global-count mask when
         ``input_ids`` reached the layer, an all-ones mask over ``b * s_global``
         when it did not -- so every rank contributes its own rows to one global
-        mean and the per-rank losses are partial sums. Phase 3/4
+        mean and the per-rank losses are partial sums. Phase 3
         (``sparse_loss=True``) still keeps the two-branch form (global count when
         masked, a local mean times ``1 / cp_size`` when not); both must land on
         the CP=1 value. ``sparse_loss`` is swept so a failure can be attributed:
@@ -306,7 +306,7 @@ class TestWarmupCP(_CPChecks):
         """One 512-long document, so the two phases' KL supports differ widely.
 
         Phase 2's KL spans the whole per-document causal set (up to 512 columns
-        on this layout) while phase 3/4's spans window(128) + top-k(128), so the
+        on this layout) while phase 3's spans window(128) + top-k(128), so the
         two logged losses must differ -- that is the non-vacuity control for
         ``test_4`` -- while each still normalises across the CP group.
         """
@@ -441,7 +441,7 @@ class TestPadRowsCP(_CPChecks):
 
     @H.U._GPU
     def test_3_pad_rows_sparse(self):
-        """Same layout on the phase-3/4 (``window + top-k``) path.
+        """Same layout on the phase-3 (``window + top-k``) path.
 
         Included so a pad-row failure can be attributed: if it reproduces here
         it is not specific to the warmup branch this change introduced.

--- a/tests/multi_card_tests/transformer/test_mqa_dsa_warmup_cp.py
+++ b/tests/multi_card_tests/transformer/test_mqa_dsa_warmup_cp.py
@@ -18,18 +18,18 @@ Two gaps in ``test_mqa_dsa_cp.py`` / ``test_mla_cp_contiguous_allgather.py``:
 
 1. ``hybrid_mla_attention="mqa_dsa"`` with ``dsa_indexer_use_sparse_loss=False``
    -- the phase-2 (DSA warmup) pairing, where attention consumes the full
-   per-document causal set while the indexer is still being learned on the
-   widened KL table. The existing CP suites run ``True`` everywhere except the
-   one ``(masked=True, sparse=False)`` subtest of
+   per-document causal set while the indexer is trained by a KL over that same
+   full causal set (no top-k anywhere). The existing CP suites run ``True``
+   everywhere except the one ``(masked=True, sparse=False)`` subtest of
    ``test_mqa_dsa_cp.py::test_7``, which only observes parameter gradients. The
-   warmup mode takes a *different branch* of ``_forward_dsa``
-   (``mqa_latent_attention.py:495`` and ``:594``) whose index table is built at
-   ``s_global`` and row-sliced, so it needs its own CP evidence: that the
-   attention output is the CP=1 reference, that the table really is the global
-   one sliced, that the mode is bit-identical to ``"mqa_full_causal"`` under CP,
-   and that the widened loss still normalises across the CP group on both the
-   masked and the unmasked branch (``_indexer_loss_mask`` /
-   ``loss_coeff / cp_size``).
+   warmup mode takes its own branch (``mqa_latent_attention._forward_warmup``)
+   whose index table and causal mask are both built at ``s_global`` and
+   row-sliced, so it needs its own CP evidence: that the attention output is the
+   CP=1 reference, that the table really is the global one sliced, that the mode
+   is bit-identical to ``"mqa_full_causal"`` under CP, and that the full-causal
+   KL normalises across the CP group on both the masked and the unmasked branch
+   (``_indexer_loss_mask`` / the all-ones fallback, both of which divide by the
+   **global** row count so the per-rank losses simply add up).
 
 2. A layout with genuine **row-validity pad rows**. ``_STRADDLE`` sums to
    exactly ``S_GLOBAL`` and ``U._row_end`` folds any trailing gap into one final
@@ -156,11 +156,12 @@ class TestWarmupCP(_CPChecks):
     def test_1_warmup_forward_equivalence(self):
         """CP=N == CP=1 on the warmup path, with and without a live loss.
 
-        ``dsa_indexer_loss_coeff == 0`` takes the early branch that skips the
-        indexer projections entirely (``mqa_latent_attention.py:495-507``);
-        ``> 0`` takes the branch that still builds the wide top-k table for the
-        KL but hands attention the full causal one (``:594-603``). Both must
-        land on the same reference output, so both are checked.
+        ``dsa_indexer_loss_coeff == 0`` returns straight after the full-causal
+        attention and never touches the indexer projections;
+        ``> 0`` additionally runs the full-candidate indexer KL
+        (``csa_indexer_topk_fwd`` with ``topk_effective=s_global``) over the
+        whole causal set. Neither may perturb the attention output, so both are
+        checked against the same reference.
         """
         for coeff in (0.0, 0.1):
             with self.subTest(loss_coeff=coeff):
@@ -231,11 +232,11 @@ class TestWarmupCP(_CPChecks):
         """Warmup output == ``hybrid_mla_attention="mqa_full_causal"`` output.
 
         Both modes call ``_build_full_causal_indices`` and then the same sparse
-        kernel with the same inputs, so on each rank this must be *bitwise*
-        equal, not merely close. The single-card claim (maxabs 0.0) is asserted
-        here with the CP row-slicing in the path -- the two modes slice the
-        table at different call sites (``forward`` vs ``_forward_dsa``), which
-        is exactly what could drift apart.
+        kernel with the same inputs -- ``_forward_warmup`` reaches it *through*
+        ``_forward_full_causal`` -- so on each rank this must be *bitwise* equal,
+        not merely close. The single-card claim (maxabs 0.0) is asserted here
+        with the CP row-slicing in the path, and it is also what pins the
+        phase-2 attention set to the frozen backbone's phase-1 one.
         """
         ref = H.run_core_cp("mqa", _STRADDLE)
         for coeff in (0.0, 0.1):
@@ -265,18 +266,22 @@ class TestWarmupCP(_CPChecks):
         """The logged indexer loss must sum to the CP=1 value across the group.
 
         Read straight out of ``DSAIndexerLossLoggingHelper``, so it observes the
-        denominator itself rather than its shadow in the gradients:
-        ``loss_mask is not None`` -> the global valid-row count (per-rank losses
-        are partial sums), ``None`` -> a local mean scaled by ``1/cp_size``
-        (``mqa_latent_attention.py:660-675``). ``sparse_loss`` is swept so that
-        a failure can be attributed: warmup-only means the widened table broke
-        it, both means the pre-existing normalisation is wrong.
+        denominator itself rather than its shadow in the gradients. Phase 2
+        (``sparse_loss=False``) has one formula on both branches: the row mask is
+        always a real tensor -- ``_indexer_loss_mask``'s global-count mask when
+        ``input_ids`` reached the layer, an all-ones mask over ``b * s_global``
+        when it did not -- so every rank contributes its own rows to one global
+        mean and the per-rank losses are partial sums. Phase 3/4
+        (``sparse_loss=True``) still keeps the two-branch form (global count when
+        masked, a local mean times ``1 / cp_size`` when not); both must land on
+        the CP=1 value. ``sparse_loss`` is swept so a failure can be attributed:
+        warmup-only means the full-causal KL broke it, both means the
+        pre-existing normalisation is wrong.
 
-        Note this layout does not exercise the *width* difference between the
-        two ``sparse_loss`` values: with documents of 200/150/162 and a 128-wide
-        forced window, no row has more than 72 non-local candidates, so the
-        128-slot and the 512-slot table hold the same set (the rest is ``-1``).
-        ``test_5`` covers the width itself.
+        Note this layout does not exercise the *width* difference between the two
+        ``sparse_loss`` values as sharply as it could: with documents of
+        200/150/162 and a 128-wide forced window, most rows have few non-local
+        candidates. ``test_5`` covers the width itself.
         """
         for sparse in (False, True):
             for masked in (True, False):
@@ -298,13 +303,11 @@ class TestWarmupCP(_CPChecks):
 
     @H.U._GPU
     def test_5_widened_warmup_loss_table_under_cp(self):
-        """One 512-long document, so the widened KL table is genuinely wider.
+        """One 512-long document, so the two phases' KL supports differ widely.
 
-        ``_indexer_valid_range`` leaves ``causal_len - window_size`` non-local
-        candidates, which only exceeds ``index_topk`` (128 in this fixture) once
-        a document is longer than 256. On this layout the warmup table really
-        holds ``min(2048, s_global)`` = 512 slots against phase 3/4's 128, so
-        the two logged losses must differ -- that is the non-vacuity control for
+        Phase 2's KL spans the whole per-document causal set (up to 512 columns
+        on this layout) while phase 3/4's spans window(128) + top-k(128), so the
+        two logged losses must differ -- that is the non-vacuity control for
         ``test_4`` -- while each still normalises across the CP group.
         """
         logged = {}
@@ -344,7 +347,8 @@ class TestWarmupCP(_CPChecks):
         rel = abs(got - want) / abs(want)
         print(
             f"[warmup-cp{H.CP_SIZE} rank{H.CP_RANK}] {tag}: "
-            f"sum(loss)={got:.6e} ref={want:.6e} rel={rel:.3e}",
+            f"this_rank={res['logged_cp']:.6e} sum(loss)={got:.6e} "
+            f"ref={want:.6e} rel={rel:.3e}",
             flush=True,
         )
         self.assertLess(

--- a/tests/single_card_tests/transformer/test_dsv4_hybrid_attention.py
+++ b/tests/single_card_tests/transformer/test_dsv4_hybrid_attention.py
@@ -167,6 +167,7 @@ def _make_config(
     hybrid_mla_num_attention_heads=64,
     hybrid_mla_num_key_value_heads=64,
     hybrid_mla_attention="mha",
+    dsa_indexer_use_sparse_loss=False,
     add_full_attention_sink_bias=False,
 ):
     if csa_compress_ratios is None:
@@ -210,7 +211,7 @@ def _make_config(
         dsa_index_head_dim=dsa_index_head_dim,
         dsa_index_topk=dsa_index_topk,
         dsa_indexer_loss_coeff=dsa_indexer_loss_coeff,
-        dsa_indexer_use_sparse_loss=False,
+        dsa_indexer_use_sparse_loss=dsa_indexer_use_sparse_loss,
         dsa_indexer_rotary_interleaved=False,
         apply_rope_fusion=apply_rope_fusion,
         attention_dropout=0.0,
@@ -434,6 +435,8 @@ class TestDSv4HybridConfigAndSpec(unittest.TestCase):
                 dsa_index_topk=128,
             )
 
+        # ``index_topk`` is checked in the sparse phase only -- the warmup phase
+        # runs no top-k at all, so it must not be forced to carry a legal budget.
         with self.assertRaisesRegex(
             ValueError, "index_topk must be a multiple"
         ):
@@ -441,6 +444,7 @@ class TestDSv4HybridConfigAndSpec(unittest.TestCase):
                 num_layers=1,
                 csa_compress_ratios=[-2],
                 hybrid_mla_attention="mqa_dsa",
+                dsa_indexer_use_sparse_loss=True,
                 dsa_index_n_heads=4,
                 dsa_index_head_dim=128,
                 dsa_index_topk=8,
@@ -453,10 +457,23 @@ class TestDSv4HybridConfigAndSpec(unittest.TestCase):
                 num_layers=1,
                 csa_compress_ratios=[-2],
                 hybrid_mla_attention="mqa_dsa",
+                dsa_indexer_use_sparse_loss=True,
                 dsa_index_n_heads=4,
                 dsa_index_head_dim=128,
                 dsa_index_topk=2176,
             )
+
+        # Same values, warmup phase: accepted, because nothing reads them.
+        cfg_warmup = _make_config(
+            num_layers=1,
+            csa_compress_ratios=[-2],
+            hybrid_mla_attention="mqa_dsa",
+            dsa_indexer_use_sparse_loss=False,
+            dsa_index_n_heads=4,
+            dsa_index_head_dim=128,
+            dsa_index_topk=2176,
+        )
+        self.assertEqual(cfg_warmup.hybrid_mla_attention, "mqa_dsa")
 
         # Dense MHA (hybrid_mla_attention="mha") skips the indexer constraints
         # entirely: head_dim 32 and topk 8 are fine because no indexer is built.

--- a/tests/single_card_tests/transformer/test_hybrid_mla_config_pipeline.py
+++ b/tests/single_card_tests/transformer/test_hybrid_mla_config_pipeline.py
@@ -679,34 +679,39 @@ class TestAOAStatements(unittest.TestCase):
                     li = int(s.split("model.layers.")[1].split(".")[0])
                     self.assertIn(li, _MINUS2_LAYERS, s)
 
-    def test_documented_bug_attention_gate_proj_dropped_from_aoa(self):
-        # HIGH (pre-existing, symmetric, NOT specific to this feature): the
-        # module builds ``self_attn.gate_proj`` because the provider sees
-        # ``gated_attention=True`` (modeling.py ~:455 ORs use_gated_attn |
-        # gated_attention), but the AOA statements at modeling.py:922 / :1383
-        # gate ONLY on ``config.use_gated_attn`` -- which is False on the ERNIE
-        # config (model_config.json sets ``gated_attention`` but not
-        # ``use_gated_attn``). Result: on HF import/export the attention gate
-        # weights are silently dropped, for ALL the layer43 configs including the
-        # mha baseline. This asserts the CURRENT (buggy) behavior so a fix flips
-        # it.
+    def test_attention_gate_proj_is_in_aoa(self):
+        """``self_attn.gate_proj`` survives HF import/export on every layer.
+
+        WAS a documented bug: the module builds ``self_attn.gate_proj`` because
+        the provider sees ``gated_attention=True`` (``modeling.py`` ORs
+        ``use_gated_attn | gated_attention``), while the AOA statements gated only
+        on ``config.use_gated_attn`` -- which is False on the ERNIE configs, since
+        ``model_config.json`` sets ``gated_attention`` and not ``use_gated_attn``.
+        The attention gate weights were therefore dropped silently, on every
+        layer43 config including the mha baseline. This test asserted the buggy
+        count (0) so that a fix would flip it, and erniebot's "fix gate_proj
+        transpose missing in HF ckpt export for hybrid-MLA layers" did.
+
+        The count is every layer that owns a gate, i.e. ``num_hidden_layers`` plus
+        the MTP layer -- not just the ``-2`` ones, because ``gated_attention`` is
+        a model-wide switch.
+        """
         for name in _LAYER43_CFGS:
             with self.subTest(config=name):
                 cfg, fwd, inv = self._aoa(name)
+                # The trigger is unchanged: still the model-wide field, not the
+                # one the AOA statements used to gate on.
                 self.assertFalse(getattr(cfg, "use_gated_attn", False))
                 self.assertTrue(getattr(cfg, "gated_attention", False))
-                self.assertEqual(self._count(fwd, "self_attn.gate_proj"), 0)
-                self.assertEqual(self._count(inv, "self_attn.gate_proj"), 0)
-
-    @unittest.expectedFailure
-    def test_attention_gate_proj_should_be_in_aoa(self):
-        # Expected behavior: since the module owns ``self_attn.gate_proj`` on
-        # every hybrid-MLA (-2) layer, HF conversion should carry it. Fails
-        # today, documenting the gate_proj drop as a genuine bug.
-        _, fwd, _ = self._aoa(_DSA)
-        self.assertEqual(
-            self._count(fwd, "self_attn.gate_proj"), len(_MINUS2_LAYERS)
-        )
+                expected = cfg.num_hidden_layers + (
+                    getattr(cfg, "num_nextn_predict_layers", 0) or 0
+                )
+                self.assertEqual(
+                    self._count(fwd, "self_attn.gate_proj"), expected
+                )
+                self.assertEqual(
+                    self._count(inv, "self_attn.gate_proj"), expected
+                )
 
 
 class TestConfigCheckCoverage(unittest.TestCase):

--- a/tests/single_card_tests/transformer/test_hybrid_mla_config_pipeline.py
+++ b/tests/single_card_tests/transformer/test_hybrid_mla_config_pipeline.py
@@ -32,7 +32,7 @@ The five production ``layer43`` configs under test (43 decoder layers + 1 MTP,
                                               experiment).
 * ``..._non_absorbed_mqa_hca_dsa``         -- phase 2, ``"mqa_dsa"``
                                               (+ YAML ``train_indexer_only``).
-* ``..._non_absorbed_mqa_hca_dsa_sparse_loss`` -- phase 3/4, ``"mqa_dsa"`` with
+* ``..._non_absorbed_mqa_hca_dsa_sparse_loss`` -- phase 3, ``"mqa_dsa"`` with
                                               ``dsa_indexer_use_sparse_loss``.
 * ``ernielite_layer43_mqa_hca``            -- CSA full-causal MQA
                                               (``csa_compress_ratios == -1``).
@@ -216,7 +216,7 @@ class TestLayerDispatchTable(unittest.TestCase):
         The property kept here is unchanged in strength: *every* production
         config that sets ``hybrid_mla_attention="mqa_dsa"`` must dispatch to
         ``MQALatentAttention`` + ``DSAIndexer`` on all seven ``-2`` layers. Since
-        the enum rename the second such config is the phase-3/4 sparse-loss one,
+        the enum rename the second such config is the phase-3 sparse-loss one,
         so this pins that ``dsa_indexer_use_sparse_loss`` does NOT leak into the
         class dispatch.
         """
@@ -486,7 +486,7 @@ class TestHybridIndexerReadsModelWideIndexFields(unittest.TestCase):
 
     def test_dsa_indexer_reflects_model_wide_index_fields(self):
         _, provider = _load_provider(_DSA)
-        # Production values. Only phase 3/4 (``_forward_sparse``) reads
+        # Production values. Only phase 3 (``_forward_sparse``) reads
         # ``index_topk`` -- the phase-2 warmup KL spans the full causal set and
         # never selects a top-k at all.
         self.assertEqual(provider.dsa_index_n_heads, 64)
@@ -923,7 +923,7 @@ class TestConfigDeltas(unittest.TestCase):
             # (``PaddleFormers trainer.py:1403``) and can only restore it from an
             # fp32 master weight -- which does not exist for a parameter that is
             # frozen (phase 2) or absent from the previous phase's optimizer
-            # state (phase 3/4), and the assignment loop at ``:1440`` has no else
+            # state (phase 3), and the assignment loop at ``:1440`` has no else
             # branch. ``load_from_hf`` requires ``ignore_load_lr_and_optim``
             # (hard assert at ``:1252``), and ``parallel_broadcast`` cannot serve
             # a resume whose parameter set changed (``resharder.py:459`` asserts
@@ -947,7 +947,7 @@ class TestConfigDeltas(unittest.TestCase):
         # ``index_topk`` is the value production actually trains at (2048). The
         # baseline ``mla_hca`` config still carries the older 512, and it is
         # deliberately not edited, so every config that *keeps* the field differs
-        # here. Only phase 3/4 reads it: the phase-2 warmup KL spans the full
+        # here. Only phase 3 reads it: the phase-2 warmup KL spans the full
         # causal set and selects no top-k.
         # The field is MLA-only in this layout: the ratio-128 HCA layers set
         # ``self.indexer = None`` (``csa_attention.py``: ``CSAIndexer`` is only
@@ -980,7 +980,7 @@ class TestConfigDeltas(unittest.TestCase):
         if name == _SPARSE_LOSS:
             return {
                 "hybrid_mla_attention": (cls._MISSING, "mqa_dsa"),
-                # Phase 3/4: the indexer is trained enough for attention to
+                # Phase 3: the indexer is trained enough for attention to
                 # consume its ranking, so the narrow (sparse) KL is used.
                 "dsa_indexer_use_sparse_loss": (False, True),
                 **topk,

--- a/tests/single_card_tests/transformer/test_hybrid_mla_config_pipeline.py
+++ b/tests/single_card_tests/transformer/test_hybrid_mla_config_pipeline.py
@@ -486,10 +486,9 @@ class TestHybridIndexerReadsModelWideIndexFields(unittest.TestCase):
 
     def test_dsa_indexer_reflects_model_wide_index_fields(self):
         _, provider = _load_provider(_DSA)
-        # Production values (shared with the CSA layers). 2048 is what the
-        # online configs train at, and it is exactly
-        # ``mqa_latent_attention._LOSS_TOPK_CAP``, so at s=8192 the loss table
-        # and the attention table end up the same width.
+        # Production values. Only phase 3/4 (``_forward_sparse``) reads
+        # ``index_topk`` -- the phase-2 warmup KL spans the full causal set and
+        # never selects a top-k at all.
         self.assertEqual(provider.dsa_index_n_heads, 64)
         self.assertEqual(provider.dsa_index_head_dim, 128)
         self.assertEqual(provider.dsa_index_topk, 2048)
@@ -940,25 +939,38 @@ class TestConfigDeltas(unittest.TestCase):
 
     @classmethod
     def _json_allowlist(cls, name):
-        # ``index_topk`` is the value production actually trains at (2048, which
-        # is also ``mqa_latent_attention._LOSS_TOPK_CAP``). The baseline
-        # ``mla_hca`` config still carries the older 512, and it is deliberately
-        # not edited, so every non-baseline config differs here. Note the field
-        # is *not* MLA-only: the ratio-128 HCA indexer reads it too
-        # (``csa_attention.py:1776``), so this difference is a real behavioural
-        # gap between phase 1 and phases 2-4 on the HCA layers, not a cosmetic
-        # one -- it is allowlisted so the drift check stays green, not because it
-        # is harmless.
+        # ``index_topk`` is the value production actually trains at (2048). The
+        # baseline ``mla_hca`` config still carries the older 512, and it is
+        # deliberately not edited, so every config that *keeps* the field differs
+        # here. Only phase 3/4 reads it: the phase-2 warmup KL spans the full
+        # causal set and selects no top-k.
+        # The field is MLA-only in this layout: the ratio-128 HCA layers set
+        # ``self.indexer = None`` (``csa_attention.py``: ``CSAIndexer`` is only
+        # built for ``1 < ratio < 128 and not csa_dense_mode``), and this model
+        # has no such ratio, so nothing but the ``-2`` layers can read it.
         topk = {"index_topk": (512, 2048)}
         if name == _FULL_CAUSAL:
+            # ``mqa_full_causal`` builds no indexer at all
+            # (``gpt_layer_specs.py`` passes ``indexer=None``), so every
+            # indexer-only key was deleted from this config rather than left as
+            # a dead value. See the header comment of
+            # ``ernielite_layer43_pretrain_non_absorbed_mqa_dense.yaml``.
             return {
                 "hybrid_mla_attention": (cls._MISSING, "mqa_full_causal"),
-                **topk,
+                "index_topk": (512, cls._MISSING),
+                "index_n_heads": (64, cls._MISSING),
+                "index_head_dim": (128, cls._MISSING),
+                "dsa_indexer_loss_coeff": (0.01, cls._MISSING),
+                "dsa_indexer_use_sparse_loss": (False, cls._MISSING),
             }
         if name == _DSA:
+            # Phase 2 (warmup): the KL spans the full per-document causal set,
+            # so this config carries no top-k budget at all -- and
+            # ``transformer_config`` only requires ``index_topk`` when
+            # ``dsa_indexer_use_sparse_loss`` is True.
             return {
                 "hybrid_mla_attention": (cls._MISSING, "mqa_dsa"),
-                **topk,
+                "index_topk": (512, cls._MISSING),
             }
         if name == _SPARSE_LOSS:
             return {

--- a/tests/single_card_tests/transformer/test_hybrid_mla_grad_health.py
+++ b/tests/single_card_tests/transformer/test_hybrid_mla_grad_health.py
@@ -863,17 +863,18 @@ class TestItem9InputIdsReachTheIndexerLossMask(unittest.TestCase):
 class TestItem10IndexerKLValueAndDenominator(unittest.TestCase):
     """The indexer KL scalar and its reduction denominator, at production settings.
 
-    Item 9 pins that ``input_ids`` reaches the layer; the existing width tests
-    pin the loss-table width. Neither pins the *numeric value* of the forward
+    Item 9 pins that ``input_ids`` reaches the layer; the column-set tests pin
+    which columns the KL covers. Neither pins the *numeric value* of the forward
     indexer KL nor that its reduction denominator is the number of non-pad
     tokens (``input_ids != pad_token_id``) rather than ``B*Sq``. Production runs
     ``dsa_indexer_use_sparse_loss=False`` and ``dsa_indexer_loss_coeff=0.01``
     with packed sequences whose tail is padding, so this fixes that path:
 
       * the logged KL equals an independent fp32 recomputation from the same
-        (topk_probs, target, row-mask) the layer used, to < 1e-4;
-      * the reduction denominator (``num_rows_override`` handed to the backward)
-        equals the non-pad token count, so forward and backward agree exactly;
+        (``P``, ``Q``, row-mask) the layer used, to < 1e-4;
+      * the reduction denominator (``num_rows_override``, which the backward
+        divides by too) equals the non-pad token count, so forward and backward
+        agree;
       * the coefficient is applied exactly once (linear in coeff).
     """
 
@@ -887,10 +888,17 @@ class TestItem10IndexerKLValueAndDenominator(unittest.TestCase):
         )
 
         cap = {}
+        # Phase 2 attaches its indexer loss through the shared
+        # ``TileLangCSAIndexerLossAutoScaler`` PyLayer (imported into
+        # ``mqa_latent_attention`` from ``csa_attention``), with the
+        # ``"tilelang"`` backend tag. One spy on that boundary carries every
+        # observable this test needs -- ``P`` (``topk_probs``, already softmaxed
+        # by ``csa_indexer_topk_fwd``), ``Q`` (``target``), the row mask, the
+        # denominator and the coefficient -- and they are exactly the tensors the
+        # tilelang ``csa_indexer_bwd`` differentiates.
         real = mqamod.TileLangCSAIndexerLossAutoScaler
-        # Bound by position, so pin the order: upstream moved ``target`` from
-        # seventh to second, which silently turned ``probs`` into int32 column
-        # ids (``log(-1) -> nan``) instead of failing.
+        # Bound by position, so pin the order: a reordered signature would hand
+        # the spy the wrong tensors instead of failing.
         expected_args = [
             "output",
             "target",
@@ -926,24 +934,18 @@ class TestItem10IndexerKLValueAndDenominator(unittest.TestCase):
                 index_k_comp,
                 topk_indices,
                 topk_probs,
-                loss_coeff,
+                loss_coeff=1.0,
                 indexer_backend="tilelang",
                 num_rows_override=None,
                 loss_mask=None,
             ):
-                cap["probs"] = topk_probs.detach().astype("float32").numpy()
-                cap["target"] = target.detach().astype("float32").numpy()
-                cap["mask"] = (
-                    None
-                    if loss_mask is None
-                    else loss_mask.detach().astype("float32").numpy()
-                )
-                cap["num_rows"] = (
-                    None
-                    if num_rows_override is None
-                    else float(num_rows_override)
-                )
-                cap["coeff"] = float(loss_coeff)
+                if indexer_backend == "tilelang":
+                    cap["mask"] = loss_mask.detach().astype("float32").numpy()
+                    cap["num_rows"] = float(num_rows_override)
+                    cap["coeff"] = float(loss_coeff)
+                    cap["width"] = int(topk_indices.shape[-1])
+                    cap["probs"] = topk_probs.detach().astype("float32").numpy()
+                    cap["target"] = target.detach().astype("float32").numpy()
                 return real.apply(
                     output,
                     target,
@@ -988,12 +990,12 @@ class TestItem10IndexerKLValueAndDenominator(unittest.TestCase):
         nonpad = float(self.SEQ - self.NPAD)
 
         # denominator is the non-pad token count, shared with the backward.
-        self.assertIsNotNone(cap["mask"])
         self.assertEqual(float(cap["mask"].sum()), nonpad)
         self.assertEqual(cap["num_rows"], nonpad)
 
-        # loss-table width is widened (sparse_loss=False) beyond attn top-k 128.
-        self.assertGreater(cap["target"].shape[-1], 128)
+        # the KL spans the whole causal set, not a top-k slice of it.
+        self.assertEqual(cap["width"], self.SEQ)
+        self.assertEqual(cap["target"].shape[-1], self.SEQ)
 
         # independent fp32 recomputation of the masked KL mean.
         t, p = cap["target"], cap["probs"]

--- a/tests/single_card_tests/transformer/test_hybrid_mla_warmup_doc_mask_loss.py
+++ b/tests/single_card_tests/transformer/test_hybrid_mla_warmup_doc_mask_loss.py
@@ -21,9 +21,9 @@ The warmup phase is ``hybrid_mla_attention="mqa_dsa"`` with
 ``_build_mqa_causal_topk_idxs_from_doc_bounds``) and the KL is scored over that
 same full causal set (``MQALatentAttention._forward_warmup`` -> one
 ``paddlefleet.tilelang_ops.csa_indexer_topk_fwd`` call at
-``topk_effective = s_global``). The phase-3/4 cuDNN top-k kernel runs zero times
+``topk_effective = s_global``). The phase-3 cuDNN top-k kernel runs zero times
 on this path, which is exactly why the mask semantics and the loss reduction
-need pinning here and not only on the phase-3/4 path
+need pinning here and not only on the phase-3 path
 (``dsa_indexer_use_sparse_loss=True``), where
 ``test_hybrid_mla_doc_equivalence.py`` and ``test_mqa_latent_attention.py``
 already cover them.
@@ -49,7 +49,7 @@ What is proven here, and nowhere else:
   inputs, and the attention-side ``dq`` / ``dkv`` / ``d_sink``.
 
 Shape caveat: ``WINDOW + INDEX_TOPK == 256`` in ``hybrid_mla_utils``, so a
-``seqlen=256`` fixture has a *saturated* sparse budget -- the phase-3/4 top-k
+``seqlen=256`` fixture has a *saturated* sparse budget -- the phase-3 top-k
 table would already equal the full causal set there, and no assertion at that
 shape can tell the two apart. ``_LAYOUTS`` therefore also carries ``seqlen=512``
 layouts, which is the discriminating shape.
@@ -98,7 +98,7 @@ _EPS = 1e-10  # mqa_latent_attention._EPS, the KL/renormalisation epsilon
 # ``_pad_row_end`` and live in ``_PAD_LAYOUTS``.
 #
 # ``seqlen=256`` is a *saturated* budget: ``WINDOW + INDEX_TOPK == 128 + 128 ==
-# 256``, so at that shape the phase-3/4 sparse table already covers every row's
+# 256``, so at that shape the phase-3 sparse table already covers every row's
 # causal length and "attention takes the full causal set" is indistinguishable
 # from "attention takes the indexer's top-k". The last two layouts are therefore
 # at ``seqlen=512``, where the sparse budget covers at most 256 of a row's up to
@@ -154,7 +154,7 @@ def _segments(row_end, seqlen):
 def _warmup_module(loss_coeff=0.01, sink=None, sparse_loss=False):
     """A ``"mqa_dsa"`` module with the phase switch off *from construction*.
 
-    ``sparse_loss=True`` builds the phase-3/4 module instead, used only as the
+    ``sparse_loss=True`` builds the phase-3 module instead, used only as the
     control that decides whether a finding is specific to this change.
     """
     config = _create_mqa_config("mqa_dsa", loss_coeff=loss_coeff)
@@ -233,10 +233,10 @@ def _capture_loss_args():
     permutation invariant and may be taken on the column layout directly.
 
     ``cap`` stays empty if the module was not in the warmup phase -- which is
-    itself the assertion that phase 3/4 does not reach this code. Phase 3/4
+    itself the assertion that phase 3 does not reach this code. Phase 3
     attaches through the *same* PyLayer now, so the discriminator is the
     ``indexer_backend`` tag: ``"tilelang"`` is phase 2's full-candidate kernel,
-    ``"cudnn"`` is phase 3/4's top-k one, and only the former is recorded.
+    ``"cudnn"`` is phase 3's top-k one, and only the former is recorded.
     """
     real = mqa_mod.TileLangCSAIndexerLossAutoScaler
     actual = [
@@ -838,9 +838,9 @@ class TestWarmupIndexerLossPrecision(unittest.TestCase):
         self.assertLess(max_abs, 3e-2)
 
     def test_window_length_sequence_still_trains_the_indexer_in_warmup(self):
-        """At ``s == csa_window_size`` phase 2 now learns, phase 3/4 still cannot.
+        """At ``s == csa_window_size`` phase 2 now learns, phase 3 still cannot.
 
-        Pre-existing and unchanged for phase 3/4: ``_indexer_valid_range`` clamps
+        Pre-existing and unchanged for phase 3: ``_indexer_valid_range`` clamps
         the candidate range at ``causal_len - window_size``, so at ``s == window``
         every row's range is empty, the KL is exactly 0 and the indexer learns
         nothing that step. The old warmup shared that clamp and logged the same
@@ -855,7 +855,7 @@ class TestWarmupIndexerLossPrecision(unittest.TestCase):
         sparse = _warmup_module(sparse_loss=True)
         logged_sparse, cap_sparse, _ = self._step(sparse, seqlen, [seqlen])
         self.assertEqual(logged_sparse, 0.0)
-        self.assertEqual(cap_sparse, {}, "phase 3/4 reached the warmup KL")
+        self.assertEqual(cap_sparse, {}, "phase 3 reached the warmup KL")
 
         module = _warmup_module()
         logged, cap, _ = self._step(module, seqlen, [seqlen])
@@ -977,10 +977,10 @@ class TestStarvedIndexerCandidates(unittest.TestCase):
     window leaves *every* one of its rows with zero candidates. The interesting
     question is what that costs, and the answer must be "nothing":
 
-    * the forced window already spans the whole document, so the phase-3/4
+    * the forced window already spans the whole document, so the phase-3
       attention table still contains the complete per-document causal set --
       asserted as ``want - got == empty set``, not as a count;
-    * consequently all three ``hybrid_mla_attention`` shapes (phase 3/4, warmup,
+    * consequently all three ``hybrid_mla_attention`` shapes (phase 3, warmup,
       ``mqa_full_causal``) must produce **bit-identical** output on these
       layouts, which is a much stronger statement than "no crash";
     * an all-``-1`` candidate row means a softmax over an empty set, the classic
@@ -1069,7 +1069,7 @@ class TestStarvedIndexerCandidates(unittest.TestCase):
                 self.assertEqual(
                     float(np.abs(_fp32(phase3) - _fp32(warmup)).max()),
                     0.0,
-                    "phase 3/4 != warmup although the window covers everything",
+                    "phase 3 != warmup although the window covers everything",
                 )
                 self.assertEqual(
                     float(np.abs(_fp32(warmup) - _fp32(causal)).max()),

--- a/tests/single_card_tests/transformer/test_hybrid_mla_warmup_doc_mask_loss.py
+++ b/tests/single_card_tests/transformer/test_hybrid_mla_warmup_doc_mask_loss.py
@@ -633,21 +633,22 @@ class TestWarmupIndexerLossPrecision(unittest.TestCase):
         fwd_mod.cudnn_indexer_topk_fwd = recording
         tl_mod.csa_indexer_topk_fwd = recording_tl
         try:
-            for seqlen in (128, 256, 300, 384, 512):
+            for seqlen in (16, 128, 256, 300, 384, 512):
                 with self.subTest(seqlen=seqlen):
                     before = len(tl_widths)
                     _, cap, attn_table = self._step(module, seqlen, [seqlen])
-                    # The table is the causal span rounded up to a power of two
-                    # (the tilelang kernels' width constraint); the surplus slots
-                    # are ``-1`` and carry no probability, which is what the live
-                    # column-set equality below actually pins.
-                    width = 1 << (seqlen - 1).bit_length()
-                    self.assertEqual(cap["target"].shape[-1], width)
-                    self.assertEqual(cap["probs"].shape[-1], width)
-                    self.assertEqual(cap["width"], width)
+                    # The KL table is exactly the causal span -- no rounding. The
+                    # tilelang wrapper pads ``topk_effective`` up to its block
+                    # internally and crops the result back
+                    # (``csa_indexer_fwd.py:430-462``), so short and non
+                    # -power-of-two lengths are served too; ``seqlen=16`` is below
+                    # the block size on purpose.
+                    self.assertEqual(cap["target"].shape[-1], seqlen)
+                    self.assertEqual(cap["probs"].shape[-1], seqlen)
+                    self.assertEqual(cap["width"], seqlen)
                     self.assertEqual(attn_table.shape[-1], seqlen)
                     # One tilelang call, over every candidate column.
-                    self.assertEqual(tl_widths[before:], [width])
+                    self.assertEqual(tl_widths[before:], [seqlen])
                     # The KL's live columns are exactly attention's columns.
                     live = cap["live"][0]
                     for row in range(seqlen):

--- a/tests/single_card_tests/transformer/test_hybrid_mla_warmup_doc_mask_loss.py
+++ b/tests/single_card_tests/transformer/test_hybrid_mla_warmup_doc_mask_loss.py
@@ -18,10 +18,13 @@ The warmup phase is ``hybrid_mla_attention="mqa_dsa"`` with
 ``dsa_indexer_use_sparse_loss=False``: the indexer is still being learned, so
 **attention** consumes the full per-document causal table
 (``MQALatentAttention._build_full_causal_indices`` ->
-``_build_mqa_causal_topk_idxs_from_doc_bounds``) while the indexer's top-k feeds
-a *wider* KL table. Two different tables, one switch --  which is exactly why
-the mask semantics and the loss reduction need pinning on this path and not only
-on the phase-3/4 path (``dsa_indexer_use_sparse_loss=True``), where
+``_build_mqa_causal_topk_idxs_from_doc_bounds``) and the KL is scored over that
+same full causal set (``MQALatentAttention._forward_warmup`` -> one
+``paddlefleet.tilelang_ops.csa_indexer_topk_fwd`` call at
+``topk_effective = s_global``). The phase-3/4 cuDNN top-k kernel runs zero times
+on this path, which is exactly why the mask semantics and the loss reduction
+need pinning here and not only on the phase-3/4 path
+(``dsa_indexer_use_sparse_loss=True``), where
 ``test_hybrid_mla_doc_equivalence.py`` and ``test_mqa_latent_attention.py``
 already cover them.
 
@@ -38,11 +41,10 @@ What is proven here, and nowhere else:
   produce them (it turns the trailing gap into one final valid document), so
   ``_pad_row_end`` below keeps the gap folded into the last document instead,
   which is what a real packed batch's padding tail looks like.
-* ``TestWarmupIndexerLossPrecision`` -- the KL candidate width formula, the row
-  mask coming from ``input_ids`` (not from the document metadata), the
-  reduction denominator, and the ``_attn_target`` claim that the KL target is
-  the *full-causal* attention distribution restricted to the loss candidates
-  and renormalised.
+* ``TestWarmupIndexerLossPrecision`` -- the KL column set (the whole causal set,
+  with no cuDNN top-k call anywhere), the row mask coming from ``input_ids`` (not
+  from the document metadata), the reduction denominator, and the claim that the
+  KL target is the head-summed *full-causal* attention distribution.
 * ``TestWarmupGradHealth`` -- the five indexer parameters, the detached indexer
   inputs, and the attention-side ``dq`` / ``dkv`` / ``d_sink``.
 
@@ -77,7 +79,6 @@ from paddlefleet.transformer.dsa_attention import DSAIndexerLossLoggingHelper
 from .hybrid_mla_utils import (
     _CAPTURED,
     _GPU,
-    INDEX_TOPK,
     V_HEAD_DIM,
     WINDOW,
     H,
@@ -150,11 +151,6 @@ def _segments(row_end, seqlen):
     return list(zip(doc_starts.numpy().tolist(), doc_lens.numpy().tolist()))
 
 
-def _wide_loss_width(seqlen):
-    """``mqa_latent_attention.py:562-566``: the warmup KL table width."""
-    return max(INDEX_TOPK, min(2048, seqlen // 128 * 128))
-
-
 def _warmup_module(loss_coeff=0.01, sink=None, sparse_loss=False):
     """A ``"mqa_dsa"`` module with the phase switch off *from construction*.
 
@@ -171,13 +167,11 @@ def _warmup_module(loss_coeff=0.01, sink=None, sparse_loss=False):
 
 
 # Positional signature of ``TileLangCSAIndexerLossAutoScaler.forward`` (minus
-# ``ctx``). The spy below binds by position, so a reordered upstream signature
-# would silently hand it the wrong tensors -- which is exactly what happened
-# when ``target`` moved from seventh to second: the spy then read
-# ``index_k_comp`` as the top-k table (bf16 bits as ``uint16``, so ``< 0`` never
-# fired) and the int32 column ids as the probabilities (``log`` of ``-1`` ->
-# ``nan``). Assert the order instead of trusting it.
-_LOSS_SCALER_ARGS = [
+# ``ctx``) -- the PyLayer phase 2 now attaches its loss through, imported into
+# ``mqa_latent_attention`` from ``csa_attention``. The spy below binds by
+# position, so a reordered signature would silently hand it the wrong tensors
+# instead of failing. Assert the order rather than trust it.
+_LOSS_ARGS = [
     "output",
     "target",
     "index_q",
@@ -192,14 +186,57 @@ _LOSS_SCALER_ARGS = [
 ]
 
 
+def _positional(columns, values=None):
+    """Scatter a column-layout table back into position space.
+
+    The tilelang indexer returns ``[b, s, width]`` tables in **column layout**:
+    slot ``j`` of row ``i`` refers to token ``columns[i, j]``, ordered by
+    descending score, with ``-1`` in the unused slots. That is not position
+    order, so anything compared against a positional reference has to be
+    scattered first. ``values is None`` returns the boolean "row ``i`` scored
+    column ``c``" table, which is what the old dense ``causal_mask > -1`` was.
+    """
+    b, s, width = columns.shape
+    dtype = bool if values is None else values.dtype
+    out = np.zeros([b, s, width], dtype=dtype)
+    for batch in range(b):
+        for row in range(s):
+            cols = columns[batch, row]
+            keep = cols >= 0
+            live = cols[keep]
+            assert live.size == 0 or int(live.max()) < width, (
+                f"row {row}: column id {int(live.max())} outside the "
+                f"{width}-wide position space"
+            )
+            out[batch, row, live] = (
+                True if values is None else values[batch, row, keep]
+            )
+    return out
+
+
 @contextlib.contextmanager
 def _capture_loss_args():
-    """Capture the arguments the layer hands ``TileLangCSAIndexerLossAutoScaler``.
+    """Capture what the warmup KL is actually reduced over.
 
-    That is the only place the KL target, the top-k probabilities, the row mask
-    and the reduction denominator are all visible at once, and it is the same
-    boundary the backward consumes, so anything asserted here is what the
-    gradient sees.
+    One spy, on the ``TileLangCSAIndexerLossAutoScaler`` boundary phase 2 now
+    attaches its loss at, because every observable is an argument of that single
+    call: ``P`` (``topk_probs``, already softmaxed by the kernel), ``Q``
+    (``target``, from ``_attn_target``), the column ids, the row mask, the
+    denominator and the coefficient. These are literally the tensors the
+    backward (upstream's tilelang ``csa_indexer_bwd``) differentiates, so
+    anything asserted here is what the gradient sees.
+
+    ``cap["probs"]`` / ``cap["target"]`` / ``cap["columns"]`` are in the
+    kernel's column layout; ``cap["live"]`` and ``cap["dense_target"]`` are the
+    position-space scatters for tests that compare against a positional
+    reference. A sum over the last axis -- which is all the KL does -- is
+    permutation invariant and may be taken on the column layout directly.
+
+    ``cap`` stays empty if the module was not in the warmup phase -- which is
+    itself the assertion that phase 3/4 does not reach this code. Phase 3/4
+    attaches through the *same* PyLayer now, so the discriminator is the
+    ``indexer_backend`` tag: ``"tilelang"`` is phase 2's full-candidate kernel,
+    ``"cudnn"`` is phase 3/4's top-k one, and only the former is recorded.
     """
     real = mqa_mod.TileLangCSAIndexerLossAutoScaler
     actual = [
@@ -207,9 +244,9 @@ def _capture_loss_args():
         for name in inspect.signature(real.forward).parameters
         if name != "ctx"
     ]
-    assert actual == _LOSS_SCALER_ARGS, (
+    assert actual == _LOSS_ARGS, (
         "TileLangCSAIndexerLossAutoScaler.forward was reordered: "
-        f"{actual} != {_LOSS_SCALER_ARGS}; the positional spy below would "
+        f"{actual} != {_LOSS_ARGS}; the positional spy below would "
         "capture the wrong tensors"
     )
     cap = {}
@@ -224,23 +261,31 @@ def _capture_loss_args():
             index_k_comp,
             topk_indices,
             topk_probs,
-            loss_coeff,
+            loss_coeff=1.0,
             indexer_backend="tilelang",
             num_rows_override=None,
             loss_mask=None,
         ):
-            cap["indices"] = topk_indices.numpy().copy()
-            cap["probs"] = topk_probs.astype("float32").numpy().copy()
-            cap["target"] = target.astype("float32").numpy().copy()
-            cap["mask"] = (
-                None
-                if loss_mask is None
-                else loss_mask.astype("float32").numpy().copy()
-            )
-            cap["num_rows"] = (
-                None if num_rows_override is None else float(num_rows_override)
-            )
-            cap["coeff"] = float(loss_coeff)
+            if indexer_backend == "tilelang":
+                cap["columns"] = topk_indices.numpy().copy()
+                cap["probs"] = topk_probs.astype("float32").numpy().copy()
+                cap["target"] = target.astype("float32").numpy().copy()
+                cap["width"] = int(topk_indices.shape[-1])
+                # ``loss_mask`` / ``num_rows_override`` are ``None`` when no
+                # ``input_ids`` reached the layer -- the same unmasked branch
+                # ``csa_attention`` takes -- so record that rather than assuming
+                # a synthesised all-ones mask.
+                cap["mask"] = (
+                    None
+                    if loss_mask is None
+                    else loss_mask.astype("float32").numpy().copy()
+                )
+                cap["num_rows"] = (
+                    None
+                    if num_rows_override is None
+                    else float(num_rows_override)
+                )
+                cap["coeff"] = float(loss_coeff)
             return real.apply(
                 output,
                 target,
@@ -260,6 +305,9 @@ def _capture_loss_args():
         yield cap
     finally:
         mqa_mod.TileLangCSAIndexerLossAutoScaler = real
+        if cap:
+            cap["live"] = _positional(cap["columns"])
+            cap["dense_target"] = _positional(cap["columns"], cap["target"])
 
 
 def _forward(module, tensors, row_end, w_v, training, input_ids=None):
@@ -497,7 +545,7 @@ class TestWarmupPadRows(unittest.TestCase):
 
 @_GPU
 class TestWarmupIndexerLossPrecision(unittest.TestCase):
-    """The warmup KL: candidate width, row mask, denominator, target.
+    """The warmup KL: column set, row mask, denominator, target.
 
     Every number below is read at the ``TileLangCSAIndexerLossAutoScaler``
     boundary, i.e. exactly what the backward differentiates, and cross-checked
@@ -546,38 +594,77 @@ class TestWarmupIndexerLossPrecision(unittest.TestCase):
             axis=-1
         )
 
-    def test_loss_width_formula_and_two_distinct_tables(self):
-        """The KL table is ``max(index_topk, min(2048, s//128*128))`` wide while
-        the attention table is ``s`` wide -- the deliberate double table.
+    def test_kl_column_set_is_the_attention_column_set_and_no_topk_runs(self):
+        """One column set serves both consumers, and no cuDNN top-k is called.
 
-        ``s=300`` is the case that separates them numerically (256 vs 300); the
-        multiples of 128 make the two widths coincide as integers while still
-        being different tables (full-causal vs indexer top-k), which the
-        diagonal check below pins.
+        This replaces the old "two distinct tables" expectation: phase 2 used to
+        ask the indexer for a *wider* top-k table
+        (``max(index_topk, min(2048, s//128*128))``) to score the KL over, which
+        at the production ``index_topk=2048`` silently degenerated into the very
+        phase-3 table it was supposed to widen. Phase 2 now scores every causal
+        column instead, so the assertion is an equality between the KL's live
+        columns and the attention table -- checked element-wise per row,
+        including the diagonal the old indexer candidate range structurally
+        excluded (``_indexer_valid_range`` clamped at
+        ``causal_len - window_size``).
+
+        Two call counts pin *which* selector produced those columns: the cuDNN
+        top-k kernel (phase 3's) is called zero times, and the tilelang indexer
+        exactly once per step at ``topk_effective == s``, its documented
+        full-candidate mode.
         """
+        import paddlefleet.cudnn_ops.indexer.csa_indexer_fwd_cudnn as fwd_mod
+        import paddlefleet.tilelang_ops as tl_mod
+
         module = _warmup_module()
-        for seqlen in (128, 256, 300, 384, 512):
-            with self.subTest(seqlen=seqlen):
-                _, cap, attn_table = self._step(module, seqlen, [seqlen])
-                self.assertEqual(
-                    cap["target"].shape[-1], _wide_loss_width(seqlen)
-                )
-                self.assertEqual(
-                    cap["indices"].shape[-1], _wide_loss_width(seqlen)
-                )
-                self.assertEqual(attn_table.shape[-1], seqlen)
-        # s=300: the widths genuinely differ, so a single table cannot be
-        # serving both consumers.
-        _, cap, attn_table = self._step(module, 300, [300])
-        self.assertEqual(cap["target"].shape[-1], 256)
-        self.assertEqual(attn_table.shape[-1], 300)
-        # ... and the loss table structurally cannot be the attention one: the
-        # indexer's candidate range is clamped to end ``window_size`` before the
-        # query, so the diagonal is never in it while it always is in the
-        # full-causal table.
-        last = 299
-        self.assertIn(last, set(attn_table[0, last].tolist()))
-        self.assertNotIn(last, set(cap["indices"][0, last].tolist()))
+        inner = fwd_mod.cudnn_indexer_topk_fwd
+        inner_tl = tl_mod.csa_indexer_topk_fwd
+        topk_calls = []
+        tl_widths = []
+
+        def recording(*args, **kwargs):
+            topk_calls.append(1)
+            return inner(*args, **kwargs)
+
+        def recording_tl(*args, **kwargs):
+            tl_widths.append(int(kwargs["topk_effective"]))
+            return inner_tl(*args, **kwargs)
+
+        fwd_mod.cudnn_indexer_topk_fwd = recording
+        tl_mod.csa_indexer_topk_fwd = recording_tl
+        try:
+            for seqlen in (128, 256, 300, 384, 512):
+                with self.subTest(seqlen=seqlen):
+                    before = len(tl_widths)
+                    _, cap, attn_table = self._step(module, seqlen, [seqlen])
+                    # The table is the causal span rounded up to a power of two
+                    # (the tilelang kernels' width constraint); the surplus slots
+                    # are ``-1`` and carry no probability, which is what the live
+                    # column-set equality below actually pins.
+                    width = 1 << (seqlen - 1).bit_length()
+                    self.assertEqual(cap["target"].shape[-1], width)
+                    self.assertEqual(cap["probs"].shape[-1], width)
+                    self.assertEqual(cap["width"], width)
+                    self.assertEqual(attn_table.shape[-1], seqlen)
+                    # One tilelang call, over every candidate column.
+                    self.assertEqual(tl_widths[before:], [width])
+                    # The KL's live columns are exactly attention's columns.
+                    live = cap["live"][0]
+                    for row in range(seqlen):
+                        cols = attn_table[0, row]
+                        self.assertEqual(
+                            set(cols[cols >= 0].tolist()),
+                            set(np.flatnonzero(live[row]).tolist()),
+                            f"s={seqlen} row {row}: KL and attention disagree",
+                        )
+                    # ... the diagonal included, on every row.
+                    self.assertTrue(
+                        bool(live[np.arange(seqlen), np.arange(seqlen)].all())
+                    )
+        finally:
+            fwd_mod.cudnn_indexer_topk_fwd = inner
+            tl_mod.csa_indexer_topk_fwd = inner_tl
+        self.assertEqual(topk_calls, [], "warmup called the cuDNN top-k kernel")
 
     def test_pad_tail_excluded_from_indexer_loss_warmup(self):
         """Warmup counterpart of
@@ -586,8 +673,8 @@ class TestWarmupIndexerLossPrecision(unittest.TestCase):
         One document spans the whole buffer, so ``is_valid`` is all ``True`` and
         the document metadata cannot express the padding tail. Only
         ``input_ids != pad_token_id`` can, and it must drive both the KL sum and
-        its denominator -- the one the *backward* rescales the cuDNN kernel's
-        built-in ``1/(B*Sq)`` into.
+        its denominator -- the ``num_rows_override`` the backward divides by
+        (``TileLangCSAIndexerLossAutoScaler.forward``'s ``ctx.num_rows``).
         """
         seqlen, real_tokens = 256, 200
         module = _warmup_module()
@@ -599,7 +686,6 @@ class TestWarmupIndexerLossPrecision(unittest.TestCase):
 
         _, is_valid = _doc_meta(_row_end([seqlen], seqlen), seqlen)
         self.assertEqual(int(is_valid.astype("int32").sum()), seqlen)
-        self.assertIsNotNone(cap["mask"])
         self.assertEqual(float(cap["mask"].sum()), float(real_tokens))
         self.assertEqual(cap["num_rows"], float(real_tokens))
         mask = cap["mask"].reshape(-1)
@@ -609,18 +695,39 @@ class TestWarmupIndexerLossPrecision(unittest.TestCase):
         kl_per_row = self._kl_per_row(cap)
         ref = (kl_per_row * cap["mask"]).sum() / real_tokens * cap["coeff"]
         self.assertLess(abs(logged - float(ref)) / abs(float(ref)), 1e-5)
-        # Had ``is_valid`` driven the reduction, the loss would be measurably
-        # different -- so this is a real discriminator, not a tautology.
-        wrong = float(kl_per_row.mean() * cap["coeff"])
-        self.assertGreater(abs(wrong - logged) / abs(logged), 0.1)
+        # Two discriminators, so this is not a tautology.
+        # (1) the denominator: had ``B*Sq`` driven it, the scalar would be
+        # 256/200 = 1.28x smaller. (The old form of this check compared the
+        # masked mean against the *plain* mean of the same rows, which
+        # discriminated only because the top-k KL was near-zero on the padding
+        # tail. The full-causal KL is the same order of magnitude on every row --
+        # measured 0.7% apart here -- so that comparison no longer separates
+        # anything and the denominator has to be pinned directly.)
+        wrong_denominator = float(
+            (kl_per_row * cap["mask"]).sum() / seqlen * cap["coeff"]
+        )
+        self.assertAlmostEqual(
+            float(ref) / wrong_denominator, seqlen / real_tokens, delta=1e-6
+        )
+        self.assertGreater(abs(wrong_denominator - logged) / abs(logged), 0.2)
+        # (2) the mask is not a no-op: the rows it drops carry real KL mass.
+        dropped = float((kl_per_row * (1.0 - cap["mask"])).sum())
+        self.assertGreater(dropped, 0.0)
         # Single card: cp_size == 1, so the coefficient reaches the backward
         # unscaled. The ``/cp_size`` branch is a multi-card concern.
         self.assertEqual(cap["coeff"], module.indexer_loss_coeff)
 
     def test_no_input_ids_uses_the_plain_row_mean(self):
-        """Without ``input_ids`` the reduction is ``kl.mean() * coeff`` and the
-        backward keeps the kernel's own ``1/(B*Sq)`` (``num_rows_override`` is
-        ``None``)."""
+        """Without ``input_ids`` the reduction is ``kl.mean() * coeff``.
+
+        ``_indexer_loss_mask`` returns ``(None, None)`` and ``_forward_warmup``
+        passes that straight down, which is the same unmasked branch
+        ``csa_attention._compute_fused_indexer_target`` takes: the backward then
+        falls back to the kernel's own ``1/(B*Sq)``, and only the *logged* scalar
+        carries the ``/cp_size`` CP correction. So what to assert here is that
+        both reach the backward as ``None`` -- a synthesised all-ones mask would
+        silently change which denominator the gradient uses.
+        """
         seqlen = 256
         module = _warmup_module()
         logged, cap, _ = self._step(module, seqlen, [seqlen], input_ids=None)
@@ -633,48 +740,48 @@ class TestWarmupIndexerLossPrecision(unittest.TestCase):
             module._indexer_loss_mask(None, 1, seqlen), (None, None)
         )
 
-    def test_attn_target_is_normalised_and_zero_on_empty_slots(self):
-        """``_attn_target`` rows are L1-normalised and exactly zero where the
-        candidate slot is ``-1`` (including whole rows with no candidate at
-        all)."""
+    def test_kl_target_is_normalised_and_zero_off_the_causal_set(self):
+        """The KL target is L1-normalised per row and exactly zero on columns the
+        per-document causal mask excludes.
+
+        The old form of this test asserted zero on ``-1`` top-k slots and
+        allowed whole rows with *no* candidate at all (the window clamp could
+        empty a row). Neither exists now: the column set is the causal set, so
+        every row has at least its own diagonal. A row shorter than the ``s``-wide
+        table still comes back ``-1``-padded, and those dead slots are where the
+        "excluded column" assertion now lands.
+        """
         seqlen, layout = 256, [40, 216]
         module = _warmup_module()
         _, cap, _ = self._step(module, seqlen, layout)
-        target, indices = cap["target"][0], cap["indices"][0]
-        empty_slot = indices < 0
-        empty_row = empty_slot.all(axis=-1)
-        self.assertTrue(empty_row.any(), "layout has no empty candidate row")
-        self.assertFalse(empty_row.all(), "layout has no live candidate row")
+        target = cap["target"][0]
+        masked = cap["columns"][0] < 0
+        self.assertTrue(masked.any(), "layout masks nothing")
+        self.assertFalse(masked.all(), "layout masks everything")
         self.assertEqual(
-            float(np.abs(target[empty_slot]).max()),
+            float(np.abs(target[masked]).max()),
             0.0,
-            "a masked candidate slot carries probability mass",
+            "a masked column carries probability mass",
         )
         self.assertGreaterEqual(float(target.min()), 0.0)
-        rowsum = target.sum(axis=-1)
-        self.assertEqual(float(np.abs(rowsum[empty_row]).max()), 0.0)
         self.assertLess(
-            float(np.abs(rowsum[~empty_row] - 1.0).max()),
+            float(np.abs(target.sum(axis=-1) - 1.0).max()),
             1e-5,
-            "live target rows are not L1-normalised",
+            "target rows are not L1-normalised",
         )
 
-    def test_attn_target_is_the_renormalised_full_causal_distribution(self):
+    def test_kl_target_is_the_full_causal_attention_distribution(self):
         """The intended semantics, measured.
 
-        In warmup, attention consumes the **full per-document causal** set while
-        the KL target is built over the *indexer's* candidate columns. So the
-        target is the attention distribution restricted to those columns and
-        renormalised -- deliberate, not a bug, and it is what makes the KL a
-        ranking objective on the columns the indexer can actually move.
+        In warmup both sides of the KL span the whole per-document causal set, so
+        the target is the head-summed attention distribution over *all* causal
+        columns, L1-normalised -- no restriction to an indexer candidate subset
+        and no renormalisation onto it, which is what the previous revision did.
 
-        The reference below is built the other way round from the
-        implementation (full fp32 per-document causal softmax over all ``s``
-        columns, head-summed, *then* restricted and renormalised) so agreement is
-        evidence about the semantics, not a restatement of the code. The residual
-        is the bf16 score rounding inside ``_attn_target``
-        (``paddle.matmul`` on bf16 inputs, ~2^-8 relative), measured at
-        norm-rel 9.68e-3 / maxabs 7.84e-3.
+        The reference below is an independent fp32 numpy recomputation (full
+        per-document causal softmax over all ``s`` columns, then head-summed and
+        L1-normalised), so agreement is evidence about the semantics, not a
+        restatement of the code. The residual is the bf16 rounding of the inputs.
         """
         seqlen, layout = 256, [40, 216]
         module = _warmup_module()
@@ -709,59 +816,55 @@ class TestWarmupIndexerLossPrecision(unittest.TestCase):
             paddle.full_like(scores, -1e30),
         )
         head_sum = F.softmax(scores, axis=-1).sum(axis=1).numpy()
+        reference = head_sum / np.maximum(
+            head_sum.sum(axis=-1, keepdims=True), _EPS
+        )
+        # The mask the implementation used must be the same predicate. The
+        # kernel emits columns score-descending, so the comparison is on the
+        # position-space scatter, not on the raw column order.
+        np.testing.assert_array_equal(cap["live"][0], allowed)
 
-        indices = cap["indices"][0]
-        reference = np.zeros_like(cap["target"][0])
-        for row in range(seqlen):
-            cols = indices[row]
-            live = cols >= 0
-            if not live.any():
-                continue
-            # Every indexer candidate must be inside the attention set, else the
-            # renormalisation would not be well defined.
-            self.assertTrue(
-                bool(allowed[row][cols[live]].all()),
-                f"row {row}: an indexer candidate is outside the causal set",
-            )
-            mass = head_sum[row, cols[live]]
-            reference[row, live] = mass / max(mass.sum(), _EPS)
-
-        got = cap["target"][0]
+        got = cap["dense_target"][0]
         max_abs = float(np.abs(got - reference).max())
         norm_rel = float(
             np.linalg.norm(got - reference) / np.linalg.norm(reference)
         )
         print(
-            f"\n[warmup] _attn_target vs renormalised full-causal: "
+            f"\n[warmup] KL target vs full-causal head sum: "
             f"max_abs={max_abs:.3e} norm_rel={norm_rel:.3e}"
         )
         self.assertLess(norm_rel, 3e-2)
         self.assertLess(max_abs, 3e-2)
 
-    def test_window_length_sequence_leaves_no_indexer_candidate(self):
-        """PRE-EXISTING, not a warmup regression: at ``s == csa_window_size`` the
-        indexer's candidate range is empty for every row
-        (``_indexer_valid_range`` clamps at ``causal_len - window_size``), so the
-        KL is exactly 0 and the indexer learns nothing that step.
+    def test_window_length_sequence_still_trains_the_indexer_in_warmup(self):
+        """At ``s == csa_window_size`` phase 2 now learns, phase 3/4 still cannot.
 
-        Recorded here because the warmup phase is where the indexer does all of
-        its learning, so the floor matters. It is *not* introduced by the switch
-        change: the control with ``dsa_indexer_use_sparse_loss=True`` logs the
-        same 0.0, i.e. the cause is the window clamp shared by both phases.
+        Pre-existing and unchanged for phase 3/4: ``_indexer_valid_range`` clamps
+        the candidate range at ``causal_len - window_size``, so at ``s == window``
+        every row's range is empty, the KL is exactly 0 and the indexer learns
+        nothing that step. The old warmup shared that clamp and logged the same
+        0.0 -- a floor in the very phase where the indexer does all of its
+        learning. ``_forward_warmup`` passes ``window=0`` to
+        ``_indexer_valid_range`` now, so the candidate range is the whole causal
+        span and the KL is strictly positive at that shape (measured 9.10e-05);
+        the phase-3 control still logs 0.0, which is what makes this a property of
+        the change rather than of the fixture.
         """
         seqlen = WINDOW
-        for sparse_loss in (False, True):
-            with self.subTest(sparse_loss=sparse_loss):
-                module = _warmup_module(sparse_loss=sparse_loss)
-                logged, cap, _ = self._step(module, seqlen, [seqlen])
-                self.assertEqual(logged, 0.0)
-                self.assertEqual(float(np.abs(cap["target"]).max()), 0.0)
-                self.assertTrue(bool((cap["indices"] < 0).all()))
-        # One token past the window and the indexer has candidates again.
+        sparse = _warmup_module(sparse_loss=True)
+        logged_sparse, cap_sparse, _ = self._step(sparse, seqlen, [seqlen])
+        self.assertEqual(logged_sparse, 0.0)
+        self.assertEqual(cap_sparse, {}, "phase 3/4 reached the warmup KL")
+
         module = _warmup_module()
-        logged, cap, _ = self._step(module, 2 * WINDOW, [2 * WINDOW])
+        logged, cap, _ = self._step(module, seqlen, [seqlen])
         self.assertGreater(logged, 0.0)
+        self.assertEqual(cap["target"].shape[-1], seqlen)
         self.assertGreater(float(np.abs(cap["target"]).max()), 0.0)
+        # ... and it keeps scaling with the sequence, as before.
+        logged_2w, cap_2w, _ = self._step(module, 2 * WINDOW, [2 * WINDOW])
+        self.assertGreater(logged_2w, 0.0)
+        self.assertGreater(float(np.abs(cap_2w["target"]).max()), 0.0)
 
 
 @_GPU

--- a/tests/single_card_tests/transformer/test_hybrid_mla_warmup_recompute_mtp_rope.py
+++ b/tests/single_card_tests/transformer/test_hybrid_mla_warmup_recompute_mtp_rope.py
@@ -90,11 +90,7 @@ from .test_hybrid_mla_rope_audit import (
     ref_inv_freq,
     ref_rope_halfsplit,
 )
-from .test_mqa_latent_attention import (
-    _fp32,
-    _full_causal_table,
-    _wide_loss_width,
-)
+from .test_mqa_latent_attention import _fp32, _full_causal_table
 
 SEQLEN = 256
 # Two documents, the second longer than the forced window (so the indexer's
@@ -259,65 +255,86 @@ class TestWarmupRecompute(unittest.TestCase):
         self._equivalence(ONE_DOC)
 
     def _indexer_call_count(self, use_sparse_loss):
-        """How many times the indexer top-k kernel runs across both passes."""
+        """Indexer selector calls across both passes, per backend.
+
+        Two selectors have to be counted separately now: phase 3/4 selects with
+        the **cuDNN** top-k kernel, phase 2 with the **tilelang** one at
+        ``topk_effective = s_global`` (its full-candidate mode). Counting only
+        cuDNN would report "zero top-k calls" for warmup and hide the one call
+        it does make.
+        """
         import paddlefleet.cudnn_ops.indexer.csa_indexer_fwd_cudnn as fwd_mod
+        import paddlefleet.tilelang_ops as tl_mod
 
         config = _create_mqa_config("mqa_dsa", loss_coeff=0.01)
         config.dsa_indexer_use_sparse_loss = use_sparse_loss
         module = _build_module(config, bf16=True)
         self.assertEqual(module.indexer_use_sparse_loss, use_sparse_loss)
 
-        topk_calls = []
+        cudnn_calls = []
+        tl_calls = []
         before_calls = []
         inner_topk = fwd_mod.cudnn_indexer_topk_fwd
+        inner_tl = tl_mod.csa_indexer_topk_fwd
         inner_before = module.indexer.forward_before_topk
 
         def rec_topk(*args, **kwargs):
-            topk_calls.append(int(kwargs["topk_effective"]))
+            cudnn_calls.append(int(kwargs["topk_effective"]))
             return inner_topk(*args, **kwargs)
+
+        def rec_tl(*args, **kwargs):
+            tl_calls.append(int(kwargs["topk_effective"]))
+            return inner_tl(*args, **kwargs)
 
         def rec_before(*args, **kwargs):
             before_calls.append(1)
             return inner_before(*args, **kwargs)
 
         fwd_mod.cudnn_indexer_topk_fwd = rec_topk
+        tl_mod.csa_indexer_topk_fwd = rec_tl
         module.indexer.forward_before_topk = rec_before
         _CAPTURED.clear()
         try:
             self._run(module, _row_end(TWO_DOCS, SEQLEN), use_recompute=True)
         finally:
             fwd_mod.cudnn_indexer_topk_fwd = inner_topk
+            tl_mod.csa_indexer_topk_fwd = inner_tl
             module.indexer.forward_before_topk = inner_before
-        return len(before_calls), topk_calls, len(_CAPTURED)
+        return len(before_calls), cudnn_calls, tl_calls, len(_CAPTURED)
 
     def test_no_grad_pass_skips_the_indexer_only_in_warmup(self):
-        """The ``:495`` early exit, observed through the recompute double pass.
+        """The warmup early exit, observed through the recompute double pass.
 
         Under recompute the layer is forwarded twice: once under ``no_grad``
-        (``need_loss`` False) and once grad-enabled. In warmup the first pass
-        takes the early exit, so the indexer projections and its top-k kernel
-        run exactly *once* even though attention was built twice. Phase 3 has no
-        such exit -- attention consumes the ranking, so the kernel must run on
-        both passes. The contrast is the discriminator: a single number that is
-        1 here and 2 there.
+        (no loss needed) and once grad-enabled. In warmup the first pass takes
+        the early exit, so the indexer projections run exactly *once* even though
+        attention was built twice, and the **cuDNN** top-k kernel -- phase 3's
+        selector -- runs **zero** times: warmup reads no ``index_topk``. What it
+        does run is one **tilelang** call at ``topk_effective == SEQLEN``, its
+        full-candidate mode, and exactly one, on the grad-enabled pass only.
+        Phase 3 has no such exit: attention consumes the ranking, so the
+        projections and the cuDNN kernel both run on both passes. The contrast is
+        the discriminator.
         """
-        n_before_w, topk_w, n_attn_w = self._indexer_call_count(False)
-        n_before_s, topk_s, n_attn_s = self._indexer_call_count(True)
+        n_before_w, cudnn_w, tl_w, n_attn_w = self._indexer_call_count(False)
+        n_before_s, cudnn_s, tl_s, n_attn_s = self._indexer_call_count(True)
         print(
             f"[warmup indexer calls] warmup before_topk={n_before_w} "
-            f"topk={topk_w} attn_forwards={n_attn_w} || "
-            f"phase3 before_topk={n_before_s} topk={topk_s} "
-            f"attn_forwards={n_attn_s}"
+            f"cudnn={cudnn_w} tilelang={tl_w} attn_forwards={n_attn_w} || "
+            f"phase3 before_topk={n_before_s} cudnn={cudnn_s} "
+            f"tilelang={tl_s} attn_forwards={n_attn_s}"
         )
         self.assertGreaterEqual(n_attn_w, 2, "recompute did not re-forward")
         self.assertGreaterEqual(n_attn_s, 2, "recompute did not re-forward")
         self.assertEqual(n_before_w, 1)
-        self.assertEqual(len(topk_w), 1)
-        self.assertEqual(topk_w, [_wide_loss_width(SEQLEN)])
+        self.assertEqual(cudnn_w, [], "warmup called the cuDNN top-k kernel")
+        # One tilelang call, on the grad-enabled pass only, over every column.
+        self.assertEqual(tl_w, [SEQLEN])
         # Same wrapping, sparse phase: no early exit, both passes pay for it.
         self.assertEqual(n_before_s, 2)
-        self.assertEqual(len(topk_s), 2)
-        self.assertEqual(topk_s, [INDEX_TOPK, INDEX_TOPK])
+        self.assertEqual(len(cudnn_s), 2)
+        self.assertEqual(cudnn_s, [INDEX_TOPK, INDEX_TOPK])
+        self.assertEqual(tl_s, [], "phase 3 selected with the tilelang kernel")
 
 
 def _mtp_config(use_sparse_loss, loss_coeff=0.01):

--- a/tests/single_card_tests/transformer/test_hybrid_mla_warmup_recompute_mtp_rope.py
+++ b/tests/single_card_tests/transformer/test_hybrid_mla_warmup_recompute_mtp_rope.py
@@ -257,7 +257,7 @@ class TestWarmupRecompute(unittest.TestCase):
     def _indexer_call_count(self, use_sparse_loss):
         """Indexer selector calls across both passes, per backend.
 
-        Two selectors have to be counted separately now: phase 3/4 selects with
+        Two selectors have to be counted separately now: phase 3 selects with
         the **cuDNN** top-k kernel, phase 2 with the **tilelang** one at
         ``topk_effective = s_global`` (its full-candidate mode). Counting only
         cuDNN would report "zero top-k calls" for warmup and hide the one call
@@ -783,7 +783,7 @@ class TestRecomputeInnerForwardBitIdentical(unittest.TestCase):
             pass
 
     # ``mqa`` -> "mqa_full_causal"; the two ``mqa_dsa`` rows are warmup (wide
-    # loss, full-causal attention) and phase 3/4 (narrow loss, top-k attention).
+    # loss, full-causal attention) and phase 3 (narrow loss, top-k attention).
     _MODES = (("mqa_dsa", False), ("mqa_dsa", True), ("mqa", None))
     # 256 saturates window+topk, 512 does not -- see the module docstring of
     # ``test_hybrid_mla_warmup_doc_mask_loss``.

--- a/tests/single_card_tests/transformer/test_mqa_latent_attention.py
+++ b/tests/single_card_tests/transformer/test_mqa_latent_attention.py
@@ -784,7 +784,7 @@ class TestMQADSA(unittest.TestCase):
           *widened* top-k table; at the production ``index_topk=2048`` that
           widening degenerated back into the phase-3 table, which is why the
           phase now shares no loss code with phase 3.)
-        * ``True`` -- phase 3/4 (``_forward_sparse``). Attention consumes
+        * ``True`` -- phase 3 (``_forward_sparse``). Attention consumes
           ``window + index_topk`` and the KL is restricted to that same set, so
           ``_attn_target`` is called once per step at exactly ``index_topk``.
 
@@ -993,7 +993,7 @@ class TestMQADSAWarmupPhase(unittest.TestCase):
     The indexer is still being learned, so attention must not consume its
     ranking: it attends to the full per-document causal set (bit-identical to
     ``hybrid_mla_attention="mqa_full_causal"``) while the indexer's top-k feeds
-    the wide KL loss only. ``TestMQADSA`` covers the phase-3/4 shape
+    the wide KL loss only. ``TestMQADSA`` covers the phase-3 shape
     (``True``), where attention consumes ``window + index_topk``.
 
     Kept as its own class rather than folded into ``TestMQADSA``: the module

--- a/tests/single_card_tests/transformer/test_mqa_latent_attention.py
+++ b/tests/single_card_tests/transformer/test_mqa_latent_attention.py
@@ -107,16 +107,6 @@ _LAYOUTS = [
 ]
 
 
-def _wide_loss_width(seqlen):
-    """The widened indexer-loss table width (mqa_latent_attention.py:562-566).
-
-    ``dsa_indexer_use_sparse_loss=False`` scores
-    ``max(index_topk, min(_LOSS_TOPK_CAP, s // _TOPK_BLOCK * _TOPK_BLOCK))``
-    columns; ``True`` scores exactly ``index_topk``.
-    """
-    return max(INDEX_TOPK, min(2048, seqlen // 128 * 128))
-
-
 def _full_causal_table(layout, seqlen):
     """The per-document full-causal ``[1, s, s]`` table, from the production
     builder itself -- it is a pure integer function of the document bounds.
@@ -301,17 +291,56 @@ class TestHybridMLAConfig(unittest.TestCase):
         # Keyed on (field, value), not on the message: topk=100 (not a multiple
         # of 128) and topk=2176 (>2048) both mention "index_topk" but hit
         # different branches.
+        #
+        # ``index_topk`` is validated in the sparse phase only, because that is
+        # the only phase that reads it -- the warmup KL spans the whole causal
+        # set and runs no top-k -- so the topk cases must ask for that phase.
         for field, value, msg in (
             ("dsa_index_head_dim", 64, "index_head_dim"),
             ("dsa_index_topk", 100, "index_topk"),
             ("dsa_index_topk", 2048 + 128, "index_topk"),
             ("dsa_index_n_heads", None, "index_n_heads"),
         ):
+            extra = (
+                {"dsa_indexer_use_sparse_loss": True}
+                if field == "dsa_index_topk"
+                else {}
+            )
             with (
                 self.subTest(field=field, value=value),
                 self.assertRaisesRegex(ValueError, msg),
             ):
-                TransformerConfig(**self._mqa_dsa_kwargs(**{field: value}))
+                TransformerConfig(
+                    **self._mqa_dsa_kwargs(**{field: value}, **extra)
+                )
+
+    def test_warmup_phase_needs_no_index_topk(self):
+        """Phase 2 must not be forced to carry a top-k budget.
+
+        ``_forward_warmup`` never selects a top-k, so a kernel-illegal (or
+        simply absent, hence default) ``index_topk`` must not block startup --
+        while the sparse phase still rejects it. The production phase-2
+        ``model_config.json`` relies on this: it ships no ``index_topk`` at all.
+        """
+        for topk in (100, 2048 + 128):
+            with self.subTest(dsa_index_topk=topk):
+                config = TransformerConfig(
+                    **self._mqa_dsa_kwargs(
+                        dsa_index_topk=topk,
+                        dsa_indexer_use_sparse_loss=False,
+                    )
+                )
+                self.assertEqual(config.hybrid_mla_attention, "mqa_dsa")
+                self.assertFalse(config.dsa_indexer_use_sparse_loss)
+                # ...and the same value is still rejected in the sparse phase,
+                # so this is a phase gate, not a dropped check.
+                with self.assertRaisesRegex(ValueError, "index_topk"):
+                    TransformerConfig(
+                        **self._mqa_dsa_kwargs(
+                            dsa_index_topk=topk,
+                            dsa_indexer_use_sparse_loss=True,
+                        )
+                    )
 
     def test_illegal_hybrid_mla_attention_configs_are_rejected(self):
         """The enum makes the old ``(dense=True, mqa=False)`` state
@@ -743,24 +772,26 @@ class TestMQADSA(unittest.TestCase):
         """``dsa_indexer_use_sparse_loss`` picks the whole training phase.
 
         On these uncompressed ``-2`` layers the switch is one decision with two
-        effects (mqa_latent_attention.py:495-507, :593-624), not just the KL
-        width it selects for the CSA layers of the same model
+        effects (``MQALatentAttention._phase``), not just the KL width it selects
+        for the CSA layers of the same model
         (``_resolve_csa_indexer_loss_topk_effective``):
 
-        * ``False`` -- phase 2 (warmup). Attention consumes the **full
-          per-document causal** table, because a freshly initialised indexer's
-          ranking must not steer attention yet; the KL is scored over the wide
-          candidate table (128 -> 512 at ``s=512``) so the indexer is also
-          supervised on columns it did not pick.
-        * ``True`` -- phase 3/4. Attention consumes ``window + index_topk`` and
-          the KL is restricted to that same set.
+        * ``False`` -- phase 2 (warmup, ``_forward_warmup``). Attention consumes
+          the **full per-document causal** table, because a freshly initialised
+          indexer's ranking must not steer attention yet, and the KL is scored
+          over that same full causal set -- so ``_attn_target``, the top-k KL
+          target builder, is never called at all. (It used to be called with a
+          *widened* top-k table; at the production ``index_topk=2048`` that
+          widening degenerated back into the phase-3 table, which is why the
+          phase now shares no loss code with phase 3.)
+        * ``True`` -- phase 3/4 (``_forward_sparse``). Attention consumes
+          ``window + index_topk`` and the KL is restricted to that same set, so
+          ``_attn_target`` is called once per step at exactly ``index_topk``.
 
-        Both widths are asserted exactly. The loss width is an integer the
-        switch controls directly, and -- unlike the ``True`` table -- the
-        ``False`` attention table is *exactly* assertable: it is
-        ``_build_full_causal_indices``, a pure integer function of the document
-        bounds with no floating-point scoring in it, so it is reproducible and
-        equal to the builder's own output element for element.
+        Both column sets are asserted. The ``False`` attention table is *exactly*
+        assertable: it is ``_build_full_causal_indices``, a pure integer function
+        of the document bounds with no floating-point scoring in it, so it is
+        reproducible and equal to the builder's own output element for element.
 
         The ``True`` path stays statistical, which is the pre-existing measured
         fact this test still records: on a single full-length document neither
@@ -776,9 +807,12 @@ class TestMQADSA(unittest.TestCase):
         loss_widths = []
         inner_target = self.module._attn_target
 
-        def recording_target(query_, kv_, topk_indices):
-            loss_widths.append(int(topk_indices.shape[-1]))
-            return inner_target(query_, kv_, topk_indices)
+        def recording_target(query_, kv_, kl_columns):
+            # The KL's column set is the indexer's candidate set: the top-k in
+            # the sparse phase, every causal column in warmup. The forced window
+            # is never in it.
+            loss_widths.append(int(kl_columns.shape[-1]))
+            return inner_target(query_, kv_, kl_columns)
 
         self.module._attn_target = recording_target
 
@@ -810,11 +844,13 @@ class TestMQADSA(unittest.TestCase):
         idx_b, _ = run(True)
         idx_full, loss_full = run(False)
 
-        # The KL width: exactly ``index_topk`` under ``True``, widened under
-        # ``False`` (mqa_latent_attention.py:562).
-        wide = _wide_loss_width(seqlen)
-        self.assertEqual(wide, 512)  # documents the 128 -> 512 widening here
-        self.assertEqual(loss_widths, [INDEX_TOPK, INDEX_TOPK, wide])
+        # The KL column set: exactly ``index_topk`` under ``True``; under
+        # ``False`` the same builder is reached but over the whole causal span,
+        # so the width is ``s``.
+        self.assertEqual(loss_widths, [INDEX_TOPK, INDEX_TOPK, seqlen])
+        # The KL never scores the forced window: its width is exactly the
+        # indexer's candidate budget, not ``WINDOW + INDEX_TOPK``.
+        self.assertNotIn(WINDOW + INDEX_TOPK, loss_widths)
 
         # The attention table: window + top-k under ``True``, the full causal
         # table (width ``s``) under ``False``.
@@ -1072,61 +1108,180 @@ class TestMQADSAWarmupPhase(unittest.TestCase):
                     self, table, self.row_end, self.SEQLEN, expect_full=True
                 )
 
-    def test_indexer_topk_serves_the_loss_only(self):
-        """Exactly one ``select_topk`` call, and attention does not consume it.
+    def test_warmup_undoes_the_indexer_weight_prebake_for_tilelang(self):
+        """The tilelang indexer re-applies ``head_dim**-0.5``, so the pre-bake
+        must be undone -- exactly as the cuDNN pair needs in phase 3.
 
-        Counting alone would not separate the phases -- phase 3 also calls the
-        kernel once when ``loss_topk == attn_topk``. What is specific here is
-        *what* the single call is for: it asks for the wide loss width rather
-        than ``index_topk``, and the table attention actually consumes contains
-        columns the indexer's table structurally cannot return. The indexer's
-        candidate range is clamped to end at ``doc_start + causal_len -
-        window_size`` (``_indexer_valid_range``), so the query's own diagonal is
-        never in it, while the full-causal table always has it.
+        This is a regression test for a bug the test suite was blind to: warmup
+        first shipped passing ``weights`` through unscaled, on the (wrong)
+        reasoning that the ``head_dim**0.5`` fixup was cuDNN-specific. Nothing
+        crashed and every existing assertion still passed -- the indexer was just
+        trained against a distribution flattened by ``1/sqrt(128)``. The precision
+        audit caught it by comparing against a plain-paddle reference:
+        un-baked weights match to ``max|d|=3.0e-8 / cosine 1-1.5e-13``, unscaled
+        ones are off by ``max|d|=7.5e-1 / cosine 0.62``.
+
+        So the discriminator has to be numeric. ``probs`` from the kernel is
+        compared against the reference expression evaluated with ``weights`` **as
+        ``forward_before_topk`` returns them**, which is the intended scale.
         """
-        import paddlefleet.cudnn_ops.indexer.csa_indexer_fwd_cudnn as fwd_mod
+        import paddle.nn.functional as F
 
-        calls = []
-        inner = fwd_mod.cudnn_indexer_topk_fwd
+        import paddlefleet.tilelang_ops as tl_mod
 
-        def recording(*args, **kwargs):
-            out = inner(*args, **kwargs)
-            calls.append(
-                (
-                    int(kwargs["topk_effective"]),
-                    bool(kwargs["return_topk_scores"]),
-                    out[0].numpy().copy(),
-                )
-            )
-            return out
+        seen = {}
+        inner_tl = tl_mod.csa_indexer_topk_fwd
+        inner_proj = self.module._indexer_projections
+
+        def recording_proj(*args, **kwargs):
+            q, k, w = inner_proj(*args, **kwargs)
+            seen["w_as_returned"] = w.detach().cast("float32").numpy().copy()
+            seen["q"] = q.detach().cast("float32").numpy().copy()
+            seen["k"] = k.detach().cast("float32").numpy().copy()
+            return q, k, w
+
+        def recording_tl(*args, **kwargs):
+            seen["w_passed"] = args[2].detach().cast("float32").numpy().copy()
+            columns, probs = inner_tl(*args, **kwargs)
+            seen["columns"] = columns.numpy().copy()
+            seen["probs"] = probs.cast("float32").numpy().copy()
+            return columns, probs
 
         query, key, w_v, x, qr = self._inputs()
         tensors = [t.clone() for t in (query, key, x, qr)]
-        fwd_mod.cudnn_indexer_topk_fwd = recording
+        self.module._indexer_projections = recording_proj
+        tl_mod.csa_indexer_topk_fwd = recording_tl
+        try:
+            self._call(
+                self.module, tensors, w_v, training=True, differentiable=True
+            )
+        finally:
+            self.module._indexer_projections = inner_proj
+            tl_mod.csa_indexer_topk_fwd = inner_tl
+
+        # The pre-bake is undone exactly once. ``weights`` is bf16, so the
+        # product carries bf16 rounding (~2.6e-3 relative measured); the factor
+        # being separated here is sqrt(128) ~ 11.3 against 1.0, so a loose
+        # tolerance still discriminates it by three orders of magnitude.
+        root_d = float(self.module.indexer.head_dim) ** 0.5
+        np.testing.assert_allclose(
+            seen["w_passed"],
+            seen["w_as_returned"] * root_d,
+            rtol=5e-3,
+            atol=1e-6,
+        )
+
+        # ...and that is the scale which reproduces the reference distribution.
+        q = paddle.to_tensor(seen["q"])
+        k = paddle.to_tensor(seen["k"])
+        w = paddle.to_tensor(seen["w_as_returned"])
+        scores = paddle.einsum("bshd,btd->bsht", q, k)
+        logits = (F.relu(scores) * w.unsqueeze(-1)).sum(axis=2)
+        rows = paddle.arange(self.SEQLEN, dtype="int64").unsqueeze(-1)
+        cols = paddle.arange(self.SEQLEN, dtype="int64").unsqueeze(0)
+        doc_start = []
+        start = 0
+        for length in self.LAYOUT:
+            doc_start += [start] * length
+            start += length
+        doc_start = paddle.to_tensor(doc_start, dtype="int64")
+        keep = (cols <= rows) & (cols >= doc_start.unsqueeze(-1))
+        logits = logits + paddle.where(
+            keep.unsqueeze(0),
+            paddle.zeros([1, self.SEQLEN, self.SEQLEN], dtype="float32"),
+            paddle.full([1, self.SEQLEN, self.SEQLEN], -1e30, dtype="float32"),
+        )
+        ref = F.softmax(logits, axis=-1).numpy()
+
+        # The kernel emits columns in score order, so gather the reference onto
+        # the same permutation before comparing.
+        cols_seen = seen["columns"][0]
+        got = seen["probs"][0]
+        valid = cols_seen >= 0
+        safe = np.where(valid, cols_seen, 0)
+        ref_perm = np.take_along_axis(ref[0], safe, axis=-1)
+        ref_perm = np.where(valid, ref_perm, 0.0)
+        max_abs = float(np.abs(got - ref_perm).max())
+        # bf16 end to end (production dtype), so the reference rebuilt from the
+        # rounded weights lands ~2.3e-5 away; the audit's fp32 run gets 3.0e-8.
+        # The wrong scale is 7.5e-1, i.e. this threshold still discriminates by
+        # nearly three orders of magnitude.
+        self.assertLess(
+            max_abs,
+            1e-3,
+            f"warmup probs do not match the reference scale: max|d|={max_abs:.3e}",
+        )
+
+    def test_warmup_scores_every_causal_column_via_tilelang(self):
+        """Phase 2 scores the whole causal span, in one tilelang call.
+
+        Two things are pinned. First, the **cuDNN** top-k kernel -- phase 3's
+        selector -- is called zero times: this phase reads no ``index_topk``, no
+        window and no clamped candidate range. Second, the tilelang indexer is
+        called exactly once at ``topk_effective == s``, its documented
+        "full-candidate selection" mode, and the columns it comes back with are
+        exactly the attention table's, diagonal included -- the very column the
+        old clamped candidate range could never return.
+
+        Before the phase split this test demanded one *cuDNN* call for a widened
+        loss table. That widening was the bug: at the production
+        ``index_topk=2048`` it capped back to the phase-3 width, so the KL scored
+        the same columns attention would have picked.
+        """
+        import paddlefleet.cudnn_ops.indexer.csa_indexer_fwd_cudnn as fwd_mod
+        import paddlefleet.tilelang_ops as tl_mod
+
+        cudnn_calls = []
+        tl_widths = []
+        tl_columns = []
+        inner_cudnn = fwd_mod.cudnn_indexer_topk_fwd
+        inner_tl = tl_mod.csa_indexer_topk_fwd
+
+        def recording_cudnn(*args, **kwargs):
+            cudnn_calls.append(int(kwargs["topk_effective"]))
+            return inner_cudnn(*args, **kwargs)
+
+        def recording_tl(*args, **kwargs):
+            tl_widths.append(int(kwargs["topk_effective"]))
+            columns, probs = inner_tl(*args, **kwargs)
+            tl_columns.append(columns.numpy().copy())
+            return columns, probs
+
+        query, key, w_v, x, qr = self._inputs()
+        tensors = [t.clone() for t in (query, key, x, qr)]
+        fwd_mod.cudnn_indexer_topk_fwd = recording_cudnn
+        tl_mod.csa_indexer_topk_fwd = recording_tl
         try:
             out = self._call(
                 self.module, tensors, w_v, training=True, differentiable=True
             )
             out.cast("float32").sum().backward()
         finally:
-            fwd_mod.cudnn_indexer_topk_fwd = inner
+            fwd_mod.cudnn_indexer_topk_fwd = inner_cudnn
+            tl_mod.csa_indexer_topk_fwd = inner_tl
 
-        self.assertEqual(len(calls), 1)
-        width, want_scores, indexer_table = calls[0]
-        # The wide loss width, not the attention budget.
-        self.assertEqual(width, _wide_loss_width(self.SEQLEN))
-        self.assertNotEqual(width, int(self.module.indexer.index_topk))
-        self.assertTrue(want_scores)
-        # The attention table is not this table: it holds the diagonal, which
-        # the indexer's clamped candidate range excludes by construction.
+        self.assertEqual(
+            cudnn_calls, [], "warmup called the cuDNN indexer top-k kernel"
+        )
+        self.assertEqual(tl_widths, [self.SEQLEN])
+        self.assertIn("values", DSAIndexerLossLoggingHelper.tracker)
+
         attn_table = _CAPTURED[-1]
         np.testing.assert_array_equal(
             attn_table, _full_causal_table(self.LAYOUT, self.SEQLEN)
         )
+        kl_columns = tl_columns[0]
+        for row in range(self.SEQLEN):
+            attn_cols = attn_table[0, row]
+            kl_cols = kl_columns[0, row]
+            self.assertEqual(
+                set(kl_cols[kl_cols >= 0].tolist()),
+                set(attn_cols[attn_cols >= 0].tolist()),
+                f"row {row}: KL and attention column sets differ",
+            )
         last = self.SEQLEN - 1
         self.assertIn(last, set(attn_table[0, last].tolist()))
-        self.assertNotIn(last, set(indexer_table[0, last].tolist()))
-        self.assertIn("values", DSAIndexerLossLoggingHelper.tracker)
+        self.assertIn(last, set(kl_columns[0, last].tolist()))
 
     def test_eval_early_exit_matches_the_training_forward(self):
         """``:495`` skips the indexer projections entirely under ``eval()``.


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description

The phase-2 (DSA warmup) indexer loss did not do what it claimed. It asked the cuDNN top-k kernel for a "widened" table via `max(index_topk, min(2048, s//128*128))`, but the production `index_topk` is 2048 and that is exactly the cap, so the width collapsed onto the phase-3 one: **the KL scored the very columns attention would have picked**, leaving a freshly initialised indexer free to reinforce its own ranking. No warning, no crash.

Warmup now scores the whole per-document causal span in one `csa_indexer_topk_fwd` call at `topk_effective = next_pow2(s_global)` -- the "full-candidate selection" mode that helper documents for exactly this phase, and the same way the CSA layers use it with `n_compressed`. The backward is upstream's `csa_indexer_bwd` via `TileLangCSAIndexerLossAutoScaler`, whose tilelang branch computes precisely the `(P - Q) * coeff / rows` this loss needs, so the hand-rolled PyLayer that used to live here is deleted.

Peak memory at s=8192: **1.44 GiB measured**, against 16 GiB for a single dense `[b, np, s, s]` fp32 tensor (the reference path keeps several alive at once).

#### Also in this change

- **`_forward_dsa` is split by training phase.** `_phase()` is the single place the phase is decided, and `_forward_full_causal` / `_forward_warmup` / `_forward_sparse` each own their loss path instead of sharing one. That removes `loss_topk` (an alias of `attn_topk`), `reuse_for_loss` (always true), an unreachable branch, and the `_LOSS_TOPK_CAP` / `_TOPK_BLOCK` constants.
- **Undo the `head_dim ** -0.5` pre-bake before the tilelang indexer**, as the cuDNN pair already required. Against a plain-paddle reference: un-baked weights match to `max|d| 3.0e-8 / cosine 1-1.5e-13`; passing them through unscaled is off by `max|d| 7.5e-1 / cosine 0.62`. A regression test now pins the scale numerically -- the whole suite passed **both** ways before.
- **`index_topk` is validated in the sparse phase only.** Warmup selects no top-k, so it must not be forced to carry a kernel-legal budget.
- **`multi_latent_attention`: add the missing `keep_indexer_grad_path`.** The `recompute(core_attention)` segment is the third indexer-bearing recompute segment and was the only one without it. With a frozen backbone (`train_indexer_only`) every input is detached, so the PyLayer output was too and the indexer loss inside the segment never received a backward pass -- silently. Verified both polarities: with the guard 5/5 indexer grads are non-zero; with it monkeypatched away, 5/5 are `None`.

#### Validation

- Single card: **238 passed / 368 subtests**.
- `test_mqa_dsa_warmup_cp` at **CP=2 / 4 / 8**: 8 tests OK each. Whole-layer forward bitwise equal to CP=1 (`per_pos_max = 0.0`, `dq = 0.0`); `sum_ranks(loss) == CP=1` to `<= 1.4e-7` in both the masked and unmasked reductions.
- Sequence-length sweep on 8 nodes x 8 GPUs: 16 valid cells (bf16, s in {1024, 2048, 4096, 8192} x 4 document layouts) all give per-row valid-slot counts exactly equal to the causal length, `max|d| <= 1.8e-6`, `max rel <= 9.7e-6`, `cosine >= 0.9999997` against a plain-paddle reference.

#### Known limit

The full-candidate mode is capped at **s = 8192** on SM100: s=16384 needs 287488 B of dynamic shared memory and fails at kernel launch with `InternalError`. That is the production sequence length, so this is documented rather than worked around. A "scores only, no sort" kernel mode would also recover the forward time the bitonic sort spends on an ordering the KL does not use (the KL is permutation-invariant).
