### PR TITLE
[CI] Exclude triton_ops from diff coverage check (#1640)

### DIFF
--- a/.github/workflows/Test-release.yml
+++ b/.github/workflows/Test-release.yml
@@ -1368,8 +1368,21 @@ jobs:
                 wget "${base_url}/${filepath}" -O "$filename" --no-proxy
             fi
           done
-          git diff origin/${{ github.event.pull_request.base.ref }}...HEAD  --unified=0 > diff.txt
-          echo "=== DIFF FILE ==="
+          # 豁免文件/目录列表：这些路径下的改动不计入覆盖率检查
+          EXCLUDE_PATHS=(
+            "src/paddlefleet/triton_ops/"
+          )
+
+          # 直接用 Git pathspec 排除豁免目录，避免自行解析 diff 头时
+          # 无法正确处理 Git 对非 ASCII 路径的 quoted-path 转义。
+          EXCLUDE_ARGS=()
+          for EXCLUDE_PATH in "${EXCLUDE_PATHS[@]}"; do
+            EXCLUDE_ARGS+=(":(exclude)${EXCLUDE_PATH}**")
+          done
+
+          git diff origin/${{ github.event.pull_request.base.ref }}...HEAD --unified=0 \
+            -- . "${EXCLUDE_ARGS[@]}" > diff.txt
+          echo "=== DIFF FILE (after exclusion) ==="
           cat diff.txt
           echo "================="
           python -m pip install diff-cover


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Devs

### Description
在 `Test-release` 的 `coverage_check` 步骤中构造 Git pathspec，排除 `src/paddlefleet/triton_ops/**`；生成 `diff.txt` 时直接应用排除规则，避免自行解析 Git quoted-path 头。

### 是否引起精度变化
否
dev merge in: #1640 