### PR TITLE
[Distributed Strategy] fix kda cp when use formers and remove unused ops

### DIFF
--- a/src/paddlefleet/transformer/kimi_delta_attention.py
+++ b/src/paddlefleet/transformer/kimi_delta_attention.py
@@ -43,6 +43,7 @@ from paddlefleet.jit import jit_fuser
 from paddlefleet.process_groups_config import ProcessGroupCollection
 from paddlefleet.transformer.identity_op import IdentityOp
 from paddlefleet.transformer.layer import FleetLayer
+from paddlefleet.triton_ops.utils import is_torch_compat_available
 from paddlefleet.utils import (
     get_pg_size,
     log_single_rank,
@@ -167,6 +168,19 @@ def build_cu_seqlens(
         )
     # Column 0 is the exclusive document end.
     ends = startend_row_indices[:, 0, :, 0].astype("int64")
+
+    # Fused Triton path: the same boundary detection + start compaction done in
+    # a single kernel. Only available under torch-compat (CUDA); fall back to
+    # the pure-paddle implementation below otherwise (e.g. CPU).
+    if is_torch_compat_available():
+        from paddlefleet.triton_ops.document_mask_fusion import (
+            cu_seqlens_triton,
+        )
+
+        return cu_seqlens_triton(
+            ends.flatten(), seq_len, keep_single_segment=keep_single_segment
+        )
+
     doc_edges = ends[:, 1:] != ends[:, :-1]
 
     # Position 0 of every row is always a start, so the row seams become
@@ -540,17 +554,6 @@ class KimiDeltaAttention(FleetLayer):
             # (part_len = total // world_size, rank_start = part_len * rank),
             # which is exactly scatter_contiguous. Other balance modes reorder
             # tokens, so the rank ranges would not match.
-            max_seq_len = getattr(self.config, "max_sequence_length", None)
-            if (
-                max_seq_len is not None
-                and seq_len * self.cp_size != max_seq_len
-            ):
-                raise ValueError(
-                    "KDA context parallel expects hidden_states to be a "
-                    "1/cp_size contiguous shard of the full sequence: "
-                    f"seq_len={seq_len} * cp_size={self.cp_size} != "
-                    f"max_sequence_length={max_seq_len}"
-                )
             if batch != 1:
                 raise NotImplementedError(
                     "KDA context parallel requires batch == 1 (the packed "

--- a/src/paddlefleet/transformer/kimi_delta_attention.py
+++ b/src/paddlefleet/transformer/kimi_delta_attention.py
@@ -43,7 +43,7 @@ from paddlefleet.jit import jit_fuser
 from paddlefleet.process_groups_config import ProcessGroupCollection
 from paddlefleet.transformer.identity_op import IdentityOp
 from paddlefleet.transformer.layer import FleetLayer
-from paddlefleet.triton_ops.utils import is_torch_compat_available
+from paddlefleet.triton_ops.utils import is_triton_available
 from paddlefleet.utils import (
     get_pg_size,
     log_single_rank,
@@ -170,9 +170,10 @@ def build_cu_seqlens(
     ends = startend_row_indices[:, 0, :, 0].astype("int64")
 
     # Fused Triton path: the same boundary detection + start compaction done in
-    # a single kernel. Only available under torch-compat (CUDA); fall back to
-    # the pure-paddle implementation below otherwise (e.g. CPU).
-    if is_torch_compat_available():
+    # a single kernel. Requires a CUDA-enabled build with an initialized Triton
+    # driver AND the mask living on a GPU place; on a CPU build / CPU device we
+    # must fall back to the pure-paddle implementation below.
+    if is_triton_available() and ends.place.is_gpu_place():
         from paddlefleet.triton_ops.document_mask_fusion import (
             cu_seqlens_triton,
         )

--- a/src/paddlefleet/transformer/multi_latent_attention.py
+++ b/src/paddlefleet/transformer/multi_latent_attention.py
@@ -1581,46 +1581,48 @@ class MLASelfAttention(MultiLatentAttention):
         mscale = 1.0
         rotary_pos_cos = None
         rotary_pos_sin = None
+        rotary_pos_emb = None
         packed_seq = (
             packed_seq_params is not None
             and packed_seq_params.qkv_format == "thd"
         )
-        if self.config.rope_type == "rope":
-            rotary_pos_emb = self.rotary_pos_emb(
-                rotary_seq_len,
-                packed_seq=packed_seq,
-                position_ids=None if self.training else position_ids,
-            )
-        else:
-            if bool(self.config.apply_rope_fusion) and not self.mqa_latent:
-                rotary_pos_cos, rotary_pos_sin = (
-                    self.rotary_pos_emb.get_cached_cos_sin(
-                        rotary_seq_len,
-                        dtype=hidden_states.dtype,
-                        packed_seq=packed_seq,
-                    )
-                )
-                rotary_pos_emb = None
-                from paddlefleet.triton_ops.fused_mla_yarn_rope_apply import (
-                    fused_apply_mla_rope_for_kv,
-                    fused_apply_mla_rope_for_q,
-                )
-
-                assert (
-                    fused_apply_mla_rope_for_q is not None
-                    and fused_apply_mla_rope_for_kv is not None
-                ), "Fused MLA RoPE apply is not imported successfully"
-            else:
-                rotary_pos_emb, mscale = self.rotary_pos_emb(
+        if not getattr(self.config, "mla_use_nope", False):
+            if self.config.rope_type == "rope":
+                rotary_pos_emb = self.rotary_pos_emb(
                     rotary_seq_len,
                     packed_seq=packed_seq,
                     position_ids=None if self.training else position_ids,
                 )
-                # mscale is already accounted for in self.softmax_scale; set to 1.0 to avoid double-applying
-                # mscale = 1.0
+            else:
+                if bool(self.config.apply_rope_fusion) and not self.mqa_latent:
+                    rotary_pos_cos, rotary_pos_sin = (
+                        self.rotary_pos_emb.get_cached_cos_sin(
+                            rotary_seq_len,
+                            dtype=hidden_states.dtype,
+                            packed_seq=packed_seq,
+                        )
+                    )
+                    rotary_pos_emb = None
+                    from paddlefleet.triton_ops.fused_mla_yarn_rope_apply import (
+                        fused_apply_mla_rope_for_kv,
+                        fused_apply_mla_rope_for_q,
+                    )
+
+                    assert (
+                        fused_apply_mla_rope_for_q is not None
+                        and fused_apply_mla_rope_for_kv is not None
+                    ), "Fused MLA RoPE apply is not imported successfully"
+                else:
+                    rotary_pos_emb, mscale = self.rotary_pos_emb(
+                        rotary_seq_len,
+                        packed_seq=packed_seq,
+                        position_ids=None if self.training else position_ids,
+                    )
+                    # mscale is already accounted for in self.softmax_scale; set to 1.0 to avoid double-applying
+                    # mscale = 1.0
 
         cp_size = get_context_parallel_world_size()
-        if cp_size > 1:
+        if cp_size > 1 and not getattr(self.config, "mla_use_nope", False):
             # Keep RoPE inputs local to the current CP rank before the fused
             # and non-fused apply paths consume them.
             if packed_seq_params is not None:

--- a/src/paddlefleet/triton_ops/document_mask_fusion.py
+++ b/src/paddlefleet/triton_ops/document_mask_fusion.py
@@ -133,6 +133,122 @@ def document_mask_triton(start_end_row_indices: Tensor):
 
 
 @triton.jit
+def cu_seqlens_fwd_kernel(
+    End_ptr,  # flattened per-row-relative ends [total]
+    CuSeqlens_ptr,  # output [total + 1]; first (n_seg + 1) entries are valid
+    NSeg_ptr,  # output [1]; number of segments (cu_seqlens length = n_seg + 1)
+    total,  # batch * seq_len (length of the flattened sequence)
+    seq_len,  # row length s, used for row-seam detection (runtime scalar)
+    BLOCK_N: tl.constexpr,  # power of 2 block along the flattened axis
+):
+    """Packed cu_seqlens for a ``[b, s] -> [1, b*s]`` flattening.
+
+    ``End_ptr`` is the flattened ``startend_row_indices[:, 0, :, 0]`` where each
+    entry is the exclusive document end *relative to its own row*. A flat
+    position ``i`` starts a new segment iff it is column 0 of its row
+    (``i % seq_len == 0``) or its end value differs from the previous position.
+    The row-seam test is what a plain ``end != end_prev`` on the already
+    flattened array would miss: adjacent rows routinely share the same end
+    value (e.g. both end at ``s``) and would be wrongly merged.
+
+    Segment starts are compacted (prefix-sum) to the front of ``CuSeqlens_ptr``;
+    ``total`` is appended as the final entry and the segment count is written to
+    ``NSeg_ptr``. One program per row, streaming in BLOCK_N chunks with a running
+    start-count carried across blocks.
+    """
+    running_count = tl.zeros((), tl.int32)
+
+    for start in range(0, total, BLOCK_N):
+        cols = start + tl.arange(0, BLOCK_N)
+        mask = cols < total
+
+        end = tl.load(End_ptr + cols, mask=mask, other=0).to(tl.int32)
+
+        # previous position's end; read straight from global memory so lane 0 of
+        # each block correctly picks up the previous block's tail.
+        prev_cols = cols - 1
+        prev_mask = (prev_cols >= 0) & mask
+        end_prev = tl.load(End_ptr + prev_cols, mask=prev_mask, other=-1).to(
+            tl.int32
+        )
+
+        # row-local column: column 0 of every row is always a segment start, so
+        # row seams stay boundaries even when neighbouring rows share an end.
+        c = cols % seq_len
+        is_start = ((c == 0) | (end != end_prev)) & mask
+        m = is_start.to(tl.int32)
+
+        # exclusive prefix count within the row = destination slot in the output.
+        incl = tl.cumsum(m, axis=0)
+        dest = running_count + incl - m
+        tl.store(
+            CuSeqlens_ptr + dest,
+            cols.to(CuSeqlens_ptr.dtype.element_ty),
+            mask=is_start,
+        )
+
+        running_count += tl.sum(m, axis=0)
+
+    # append the flattened length as the closing edge, then record the count.
+    tl.store(
+        CuSeqlens_ptr + running_count + tl.arange(0, 1),
+        tl.full((1,), total, CuSeqlens_ptr.dtype.element_ty),
+    )
+    tl.store(
+        NSeg_ptr + tl.arange(0, 1),
+        running_count.to(NSeg_ptr.dtype.element_ty),
+    )
+
+
+def cu_seqlens_triton(
+    ends_flat: Tensor, seq_len: int, keep_single_segment=False
+):
+    """Fused version of ``kimi_delta_attention.build_cu_seqlens``' core.
+
+    Args:
+        ends_flat: 1-D int tensor [batch * seq_len]; the flattened
+            ``startend_row_indices[:, 0, :, 0]`` (per-row-relative exclusive
+            document ends).
+        seq_len: row length ``s``; ``batch`` is inferred from the input length.
+        keep_single_segment: when True, return ``[0, total]`` instead of ``None``
+            for a single-segment sequence (context parallel needs a cu_seqlens).
+
+    Returns:
+        int64 cu_seqlens tensor, or ``None`` when the whole flattened sequence is
+        a single segment and ``keep_single_segment`` is False.
+    """
+    assert ends_flat.ndim == 1, "expect 1-D flattened ends [batch * seq_len]"
+    (total,) = ends_flat.shape
+    assert total % seq_len == 0, "ends length must be a multiple of seq_len"
+
+    x = ends_flat.astype("int32")
+    if not x.is_contiguous():
+        x = x.contiguous()
+
+    cu_seqlens = paddle.empty([total + 1], dtype="int64")
+    n_seg = paddle.empty([1], dtype="int64")
+
+    BLOCK_N = 4096
+    grid = (1,)
+    cu_seqlens_fwd_kernel[grid](
+        x,
+        cu_seqlens,
+        n_seg,
+        total,
+        int(seq_len),
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+    )
+
+    # data-dependent length; syncs like the original paddle.nonzero path.
+    k = int(n_seg)
+    cu_seqlens = cu_seqlens[: k + 1]
+    if cu_seqlens.shape[0] <= 2 and not keep_single_segment:
+        return None
+    return cu_seqlens
+
+
+@triton.jit
 def cutoff_compact_kernel(
     PosInDoc_ptr,  # pos_in_doc [seq_len]
     DocLen_ptr,  # doc_len_per_pos [seq_len]

--- a/src/paddlefleet/triton_ops/utils.py
+++ b/src/paddlefleet/triton_ops/utils.py
@@ -29,15 +29,20 @@ def is_triton_available() -> bool:
     """Return True if Triton CUDA kernels can actually be launched.
 
     Stronger than :func:`is_torch_compat_available`: it also requires a
-    CUDA-enabled Paddle build and a successfully initialized Triton driver
-    (see ``_paddle_driver`` below). Callers that may run on CPU should gate the
-    Triton path on this *and* verify the operand tensor is on a GPU place; on a
-    CPU build / CPU device the pure-paddle fallback must be used instead.
+    CUDA-enabled Paddle build and an installed Triton package. It deliberately
+    does *not* require torch / ``_paddle_driver``: the document_mask_fusion
+    kernels run purely through ``paddle.enable_compat(scope={"triton"})`` and
+    are not wrapped with :func:`swap_driver_guard`, so they work in a
+    torch-free environment (e.g. the CI image ships triton without torch).
+
+    Callers that may run on CPU should gate the Triton path on this *and*
+    verify the operand tensor is on a GPU place; on a CPU build / CPU device
+    the pure-paddle fallback must be used instead.
     """
     return (
         is_torch_compat_available()
         and paddle.is_compiled_with_cuda()
-        and _paddle_driver is not None
+        and _is_package_installed("triton")
     )
 
 

--- a/src/paddlefleet/triton_ops/utils.py
+++ b/src/paddlefleet/triton_ops/utils.py
@@ -25,6 +25,22 @@ def is_torch_compat_available() -> bool:
     return hasattr(paddle, "enable_compat")
 
 
+def is_triton_available() -> bool:
+    """Return True if Triton CUDA kernels can actually be launched.
+
+    Stronger than :func:`is_torch_compat_available`: it also requires a
+    CUDA-enabled Paddle build and a successfully initialized Triton driver
+    (see ``_paddle_driver`` below). Callers that may run on CPU should gate the
+    Triton path on this *and* verify the operand tensor is on a GPU place; on a
+    CPU build / CPU device the pure-paddle fallback must be used instead.
+    """
+    return (
+        is_torch_compat_available()
+        and paddle.is_compiled_with_cuda()
+        and _paddle_driver is not None
+    )
+
+
 def dispatch_to(dispatch_fn, *, cond=None):
     """Decorator: call dispatch_fn when cond is True, else fall back to fn.
 

--- a/tests/single_card_tests/test_document_mask_fusion.py
+++ b/tests/single_card_tests/test_document_mask_fusion.py
@@ -31,13 +31,37 @@ from paddlefleet.transformer.csa_attention import (
     _build_window_topk_idxs_from_doc_bounds,
     compact_kv_score_cutoff,
 )
+from paddlefleet.transformer.kimi_delta_attention import build_cu_seqlens
 from paddlefleet.triton_ops.document_mask_fusion import (
     compressed_doc_start_triton,
     compressed_topk_idxs_triton,
+    cu_seqlens_triton,
     cutoff_compact_triton,
     document_mask_triton,
     window_topk_idxs_triton,
 )
+
+
+def _cu_seqlens_paddle_ref(startend, batch, seq_len, keep_single_segment=False):
+    """Independent pure-paddle reference (the pre-fusion algorithm).
+
+    This is the ground truth for ``cu_seqlens_triton`` and the triton-dispatched
+    ``build_cu_seqlens``; it must NOT go through the triton path itself.
+    """
+    total = batch * seq_len
+    if startend is None:
+        if not keep_single_segment:
+            return None
+        return paddle.to_tensor([0, total], dtype="int64")
+    ends = startend[:, 0, :, 0].astype("int64")
+    doc_edges = ends[:, 1:] != ends[:, :-1]
+    head = paddle.ones([batch, 1], dtype="bool")
+    is_start = paddle.concat([head, doc_edges], axis=1) if seq_len > 1 else head
+    starts = paddle.nonzero(is_start.reshape([-1])).flatten()
+    cu = paddle.concat([starts, paddle.full([1], total, dtype=starts.dtype)])
+    if cu.shape[0] <= 2 and not keep_single_segment:
+        return None
+    return cu
 
 
 class TestDocumentMaskFusion(unittest.TestCase):
@@ -132,6 +156,101 @@ class TestDocumentMaskFusion(unittest.TestCase):
         np.testing.assert_array_equal(
             compressed_pos[:actual_n_compressed], compressed_pos_ref
         )
+
+    @staticmethod
+    def _rand_mask(batch, seq_len, avg_doc, seed):
+        """[b,1,s,1] int32 mask of per-row-relative exclusive document ends."""
+        rng = np.random.default_rng(seed)
+        ends = np.empty((batch, seq_len), dtype=np.int64)
+        for r in range(batch):
+            col, cum = [], 0
+            while len(col) < seq_len:
+                length = int(rng.integers(max(1, avg_doc // 2), avg_doc * 2))
+                cum += length
+                col += [cum] * length
+            ends[r] = np.array(col[:seq_len], dtype=np.int64)
+        return paddle.to_tensor(
+            ends.reshape(batch, 1, seq_len, 1), dtype="int32"
+        )
+
+    def _check_cu_seqlens(self, startend, batch, seq_len):
+        flat = startend[:, 0, :, 0].flatten()
+        for keep in (False, True):
+            ref = _cu_seqlens_paddle_ref(startend, batch, seq_len, keep)
+            out = cu_seqlens_triton(flat, seq_len, keep_single_segment=keep)
+            msg = f"{batch}x{seq_len} keep={keep}"
+            if ref is None:
+                self.assertIsNone(out, msg)
+            else:
+                np.testing.assert_array_equal(out, ref, msg)
+
+    def test_cu_seqlens_kernel(self):
+        """cu_seqlens_fwd_kernel -> packed cu_seqlens for [b, s] flattening.
+
+        Validated against an independent pure-paddle reference. Covers the
+        row-seam corner (adjacent rows sharing an end value), seq_len == 1,
+        single-segment with/without keep_single_segment, and multi-block
+        streaming (total > BLOCK_N == 4096, exercising the cross-block
+        running-count carry and the previous-position load at block edges).
+        """
+        fixed = [
+            (1, 8, [[3, 3, 3, 5, 5, 8, 8, 8]]),
+            # two rows both ending at s -> seam must stay a boundary
+            (2, 4, [[4, 4, 4, 4], [4, 4, 4, 4]]),
+            (2, 5, [[2, 2, 5, 5, 5], [3, 3, 3, 5, 5]]),
+            # single global segment -> None unless keep_single_segment
+            (1, 6, [[6, 6, 6, 6, 6, 6]]),
+            # seq_len == 1: every position is a start
+            (1, 1, [[1]]),
+            (3, 1, [[1], [1], [1]]),
+        ]
+        for batch, seq_len, ends in fixed:
+            startend = paddle.to_tensor(ends, dtype="int32").reshape(
+                [batch, 1, seq_len, 1]
+            )
+            self._check_cu_seqlens(startend, batch, seq_len)
+
+        # multi-block streaming (total > 4096) with real boundaries, plus a
+        # large single document (single segment spanning >1 block).
+        for batch, seq_len, avg in [(1, 5000, 512), (2, 8192, 700)]:
+            mask = self._rand_mask(batch, seq_len, avg, seed=batch * seq_len)
+            self._check_cu_seqlens(mask, batch, seq_len)
+        big_single = paddle.full([1, 1, 8192, 1], 8192, dtype="int32")
+        self._check_cu_seqlens(big_single, 1, 8192)
+
+    def test_build_cu_seqlens_dispatch(self):
+        """Public build_cu_seqlens (triton dispatch) matches the paddle ref.
+
+        Covers the integration code in kimi_delta_attention: None input,
+        keep_single_segment, value correctness through the dispatch, and the
+        [b,1,s,1] / head-dim==1 shape validation.
+        """
+        # None input is handled before dispatch.
+        self.assertIsNone(build_cu_seqlens(None, 2, 8))
+        np.testing.assert_array_equal(
+            build_cu_seqlens(None, 2, 8, keep_single_segment=True), [0, 16]
+        )
+        # value cases through the public API vs the independent reference.
+        for batch, seq_len, ends in [
+            (2, 4, [[4, 4, 4, 4], [4, 4, 4, 4]]),
+            (1, 6, [[2, 2, 5, 5, 6, 6]]),
+            (1, 6, [[6, 6, 6, 6, 6, 6]]),
+        ]:
+            startend = paddle.to_tensor(ends, dtype="int32").reshape(
+                [batch, 1, seq_len, 1]
+            )
+            for keep in (False, True):
+                ref = _cu_seqlens_paddle_ref(startend, batch, seq_len, keep)
+                out = build_cu_seqlens(
+                    startend, batch, seq_len, keep_single_segment=keep
+                )
+                if ref is None:
+                    self.assertIsNone(out)
+                else:
+                    np.testing.assert_array_equal(out, ref)
+        # head dim must be 1 (a linear recurrence is single-segment layout).
+        with self.assertRaises(ValueError):
+            build_cu_seqlens(paddle.ones([2, 2, 4, 1], dtype="int32"), 2, 4)
 
     def test_window_topk_idxs_kernel(self):
         """window_topk_idxs_kernel -> [1, seqlen, window_size]."""

--- a/tests/single_card_tests/test_document_mask_fusion.py
+++ b/tests/single_card_tests/test_document_mask_fusion.py
@@ -252,6 +252,31 @@ class TestDocumentMaskFusion(unittest.TestCase):
         with self.assertRaises(ValueError):
             build_cu_seqlens(paddle.ones([2, 2, 4, 1], dtype="int32"), 2, 4)
 
+    def test_build_cu_seqlens_cpu_fallback(self):
+        """On a CPU device / CPU tensor build_cu_seqlens must NOT launch the
+        CUDA Triton kernel; it has to take the pure-paddle fallback.
+
+        Guards the dispatch condition: a CUDA-compiled Paddle keeps
+        ``is_compiled_with_cuda()`` True even on ``set_device('cpu')``, so the
+        gate has to consult the tensor's place, not just torch-compat. Without
+        that check this call would try to run a GPU kernel on a CPU tensor and
+        crash.
+        """
+        prev = paddle.device.get_device()
+        try:
+            paddle.device.set_device("cpu")
+            startend = paddle.to_tensor(
+                [[2, 2, 5, 5, 6, 6]], dtype="int32"
+            ).reshape([1, 1, 6, 1])
+            self.assertTrue(startend.place.is_cpu_place())
+            out = build_cu_seqlens(startend, 1, 6)
+            # result stays on CPU -> the paddle path ran, not the GPU kernel.
+            self.assertTrue(out.place.is_cpu_place())
+            ref = _cu_seqlens_paddle_ref(startend, 1, 6)
+            np.testing.assert_array_equal(out, ref)
+        finally:
+            paddle.device.set_device(prev)
+
     def test_window_topk_idxs_kernel(self):
         """window_topk_idxs_kernel -> [1, seqlen, window_size]."""
         window_ref = _build_window_topk_idxs_from_doc_bounds(

--- a/tests/single_card_tests/test_document_mask_fusion.py
+++ b/tests/single_card_tests/test_document_mask_fusion.py
@@ -277,6 +277,28 @@ class TestDocumentMaskFusion(unittest.TestCase):
         finally:
             paddle.device.set_device(prev)
 
+    def test_build_cu_seqlens_triton_branch(self):
+        """Force build_cu_seqlens through the fused Triton branch.
+
+        The other build_cu_seqlens tests build tensors on the *default* device,
+        so on a CPU test run the ``is_gpu_place()`` guard short-circuits and the
+        triton dispatch branch is never executed. This test puts the mask
+        explicitly on a GPU place so the branch is covered; it is skipped when
+        Triton is unavailable.
+        """
+        from paddlefleet.triton_ops.utils import is_triton_available
+
+        if not is_triton_available():
+            self.skipTest("Triton not available")
+        startend = paddle.to_tensor(
+            [[2, 2, 5, 5, 6, 6]], dtype="int32", place=paddle.CUDAPlace(0)
+        ).reshape([1, 1, 6, 1])
+        self.assertTrue(startend.place.is_gpu_place())
+        # is_triton_available() and is_gpu_place() -> the triton branch runs.
+        out = build_cu_seqlens(startend, 1, 6)
+        ref = _cu_seqlens_paddle_ref(startend, 1, 6)
+        np.testing.assert_array_equal(out, ref)
+
     def test_window_topk_idxs_kernel(self):
         """window_topk_idxs_kernel -> [1, seqlen, window_size]."""
         window_ref = _build_window_topk_idxs_from_doc_bounds(

--- a/tests/single_card_tests/transformer/test_kimi_delta_attention.py
+++ b/tests/single_card_tests/transformer/test_kimi_delta_attention.py
@@ -85,6 +85,7 @@ class _FakeGroup:
 class _FakePGCollection:
     def __init__(self):
         self.tp = _FakeGroup()
+        self.cp = _FakeGroup()
 
 
 # ---- Test dimensions ----
@@ -864,13 +865,25 @@ class TestContextParallelGuards(unittest.TestCase):
         kda.cp_size = cp_size
         kda.config.context_parallel_size = cp_size
         kda.config.cp_balance_mode = "contiguous_allgather"
-        kda.config.max_sequence_length = SEQ_LENGTH * cp_size
         return kda
 
-    def test_shard_must_be_one_over_cp_size(self):
+    def test_dynamic_seq_len_enters_cp_path(self):
+        """Without max_sequence_length, CP path passes all guards and reaches build_cp_context."""
         kda = self._kda()
-        kda.config.max_sequence_length = SEQ_LENGTH  # not SEQ_LENGTH * cp_size
-        with self.assertRaises(ValueError):
+        # Ensure max_sequence_length is not set (dynamic length scenario)
+        if hasattr(kda.config, "max_sequence_length"):
+            delattr(kda.config, "max_sequence_length")
+
+        # Sentinel to prove execution reached build_cp_context (past all guards)
+        class _ReachedBuildCpContext(Exception):
+            pass
+
+        with (
+            patch.object(
+                kda_mod, "build_cp_context", side_effect=_ReachedBuildCpContext
+            ),
+            self.assertRaises(_ReachedBuildCpContext),
+        ):
             kda(hidden_states=paddle.randn([1, SEQ_LENGTH, HIDDEN_SIZE]))
 
     def test_requires_batch_one(self):

--- a/tests/single_card_tests/transformer/test_mla_get_qkv_rope_cp.py
+++ b/tests/single_card_tests/transformer/test_mla_get_qkv_rope_cp.py
@@ -577,6 +577,139 @@ class TestMLAGetQKVRopeContextParallel(unittest.TestCase):
         self._assert_equal(key, expected_key, "NoPE key")
         self._assert_equal(value, expected_value, "NoPE value")
 
+    def _run_nope_cp4(self, rope_type, apply_rope_fusion):
+        """NoPE with CP=4 must not construct RoPE tables, apply rotary, or scatter."""
+        hidden_full = self._hidden(batch=2, seq=8)
+        ref_layer = self._make_layer(
+            rope_type=rope_type,
+            apply_rope_fusion=apply_rope_fusion,
+            context_parallel_size=1,
+            mla_use_nope=True,
+        )
+        # Poison both RoPE table construction and application on the reference layer
+        ref_layer.rotary_pos_emb = mock.MagicMock(
+            side_effect=AssertionError("NoPE must not call rotary_pos_emb()")
+        )
+        ref_layer.rotary_pos_emb.get_rotary_seq_len = _FakeRotaryEmbedding(
+            ref_layer.qk_rope_head_dim
+        ).get_rotary_seq_len
+        ref_layer.rotary_pos_emb.get_cached_cos_sin = mock.MagicMock(
+            side_effect=AssertionError(
+                "NoPE must not call get_cached_cos_sin()"
+            )
+        )
+
+        with mock.patch.object(
+            mla_mod,
+            "apply_rotary_pos_emb",
+            side_effect=AssertionError("NoPE must bypass rotary application"),
+        ):
+            q_ref, k_ref, v_ref, *_ = self._run_layer(
+                ref_layer, hidden_full, cp_size=1, cp_rank=0
+            )
+
+        for rank in range(4):
+            cp_layer = self._make_layer(
+                rope_type=rope_type,
+                apply_rope_fusion=apply_rope_fusion,
+                context_parallel_size=4,
+                mla_use_nope=True,
+            )
+            # Poison RoPE table construction paths
+            cp_layer.rotary_pos_emb = mock.MagicMock(
+                side_effect=AssertionError(
+                    "NoPE CP=4 must not call rotary_pos_emb()"
+                )
+            )
+            cp_layer.rotary_pos_emb.get_rotary_seq_len = _FakeRotaryEmbedding(
+                cp_layer.qk_rope_head_dim
+            ).get_rotary_seq_len
+            cp_layer.rotary_pos_emb.get_cached_cos_sin = mock.MagicMock(
+                side_effect=AssertionError(
+                    "NoPE CP=4 must not call get_cached_cos_sin()"
+                )
+            )
+
+            hidden_local = _scatter_for_rank(
+                hidden_full,
+                axis=1,
+                mode="dualchunk_allgather",
+                rank=rank,
+                size=4,
+            )
+            scatter_calls = []
+            with mock.patch.object(
+                mla_mod,
+                "apply_rotary_pos_emb",
+                side_effect=AssertionError(
+                    "NoPE must bypass rotary application"
+                ),
+            ):
+                q_cp, k_cp, v_cp, *_ = self._run_layer(
+                    cp_layer,
+                    hidden_local,
+                    cp_size=4,
+                    cp_rank=rank,
+                    scatter_calls=scatter_calls,
+                )
+
+            # No RoPE scatter calls should happen under NoPE
+            rope_table_calls = [
+                call for call in scatter_calls if call[0][0] == 1
+            ]
+            self.assertEqual(
+                len(rope_table_calls),
+                0,
+                f"NoPE CP=4 rank {rank} rope_type={rope_type} "
+                f"fused={apply_rope_fusion}: unexpected RoPE scatter calls",
+            )
+
+            self._assert_equal(
+                q_cp,
+                _scatter_for_rank(
+                    q_ref,
+                    axis=1,
+                    mode="dualchunk_allgather",
+                    rank=rank,
+                    size=4,
+                ),
+                f"NoPE CP=4 query rank {rank} rope_type={rope_type} fused={apply_rope_fusion}",
+            )
+            self._assert_equal(
+                k_cp,
+                _scatter_for_rank(
+                    k_ref,
+                    axis=1,
+                    mode="dualchunk_allgather",
+                    rank=rank,
+                    size=4,
+                ),
+                f"NoPE CP=4 key rank {rank} rope_type={rope_type} fused={apply_rope_fusion}",
+            )
+            self._assert_equal(
+                v_cp,
+                _scatter_for_rank(
+                    v_ref,
+                    axis=1,
+                    mode="dualchunk_allgather",
+                    rank=rank,
+                    size=4,
+                ),
+                f"NoPE CP=4 value rank {rank} rope_type={rope_type} fused={apply_rope_fusion}",
+            )
+
+    def test_nope_cp4_non_fused_rope(self):
+        self._run_nope_cp4("rope", apply_rope_fusion=False)
+
+    def test_nope_cp4_fused_rope(self):
+        self._run_nope_cp4("rope", apply_rope_fusion=True)
+
+    def test_nope_cp4_non_fused_yarn(self):
+        self._run_nope_cp4("yarn", apply_rope_fusion=False)
+
+    def test_nope_cp4_fused_yarn(self):
+        self._run_nope_cp4("yarn", apply_rope_fusion=True)
+
     def test_context_parallel_requires_prepared_rope_tensor(self):
         layer = self._make_layer(
             rope_type="rope",


### PR DESCRIPTION
### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library  | Environment Adaptation ] -->
Distributed Strategy
### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes
### Description
<!-- Describe what you’ve done -->
1. 调整 KDA Context Parallel 对当前输入序列长度的处理，移除其与配置最大长度的强绑定
2. 在 `mla_use_nope=True` 时跳过MLA中多余的rope计算
3. 增加计算cu_lens的fusion op