### PR TITLE
[Execute Infrastructure] Do-not-merge: AI review replay control for user configuration switch rules

### DIFF
--- a/.agents/skills/ai-review/references/user-configuration-rules.md
+++ b/.agents/skills/ai-review/references/user-configuration-rules.md
@@ -1,0 +1,85 @@
+# PaddleFleet 用户配置开关规则
+
+- 适用路径：`src/paddlefleet/transformer/transformer_config.py`、`src/paddlefleet/model_parallel_config.py`
+- 触发条件：在上述文件中新增、重命名或删除用户配置开关，修改开关默认值、取值集合或行为，或在 `__post_init__` 中新增/修改开关之间的约束
+- 规则来源：`ci/check_approval.sh` 将这两个文件列为需指定审批人的受控配置文件；其余检查项来自两文件现有的命名分区、docstring 和 `__post_init__` 校验约定
+- 引用约定：本文档只用符号名（字段名、函数名、分区注释）定位代码，不写行号
+- 评审范围：只评审本 PR diff 中新增或修改的开关。存量开关（含已有的 `enable_*`、`use_*` 字段和重复声明）不因不符合本规则而报告，除非本 PR 正在改动它们。
+
+## 规则优先级
+
+必要性、跨版本兼容性、二次解析、校验与测试缺失优先于命名、分段与文档问题。生态一致性优先于本文档的命名偏好：上游框架已有等价开关时沿用上游命名，即使其形式与“命名与声明规范”一节冲突。
+
+## 开关必要性
+
+- 新增开关前用 `rg` 检索同一功能域的现有开关。若新开关的行为可由现有一个或多个开关的组合等效表达，应复用现有开关；若确需新增且旧开关因此变为冗余，必须在同一 PR 内删除旧开关并给出迁移方式，保持开关组合低冗余。
+- 若开关实际只有一个取值会被使用，应在代码中实现固定分支而不是新增开关。判定依据：PR 未新增任何使用非默认取值的测试或配置，且 PR 描述未说明其他取值带来的功能点或性能收益。
+- docstring 必须写清每个取值的适用场景。适用场景不清晰的取值视为非必要，报告时引用具体字段位置并指出缺失的说明。
+- 仅用于定位问题的调试开关（例如后端对照、参考实现比对）必须在 docstring 声明它是临时开关还是长期用户接口；临时开关需说明回收条件。
+
+## 生态一致性
+
+为保持跨框架使用体验一致，对外部生态已有的功能点，开关命名、取值语义和默认行为应尽量与外部框架一致：
+
+- 模型结构与算法策略相关开关对齐 Huggingface Transformers 或 ms-swift。
+- 并行配置与性能优化策略相关开关对齐 Megatron-LM（本仓库配置类本身派生自 Megatron-LM，见 `transformer_config.py` 文件头的 `Referred to NVIDIA Megatron-LM` 说明）。
+
+对齐方式：先确认该结构或策略最早由哪个模型/框架提出，再检索上游对应的配置项名称与默认值。若上游存在等价开关而 PR 使用了不同命名或不同默认值，报告时给出上游名称，要求对齐或在 docstring 说明差异原因。沿用上游命名但行为不同时，必须在 docstring 显式标注差异，不得让同名开关产生不同语义。
+
+参考来源：
+
+- Huggingface Transformers：https://github.com/huggingface/transformers 、https://github.com/huggingface/transformers/blob/8e7d47a325d647d9e78b832b8e003c9d676b658a/docs/source/en/custom_models.md?plain=1#L26
+- ms-swift：https://github.com/modelscope/ms-swift 、https://swift.readthedocs.io/zh-cn/latest/Instruction/Command-line-parameters.html
+- Megatron-LM：https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/core/transformer/transformer_config.py
+
+## 跨版本兼容性
+
+- 默认禁止不兼容变更：重命名开关、删除开关、修改默认值、改变同一取值下的行为。这类改动会让既有 YAML/JSON 配置行为静默改变。
+- 确需变更时，同一 PR 必须对旧开关配置显式报错拦截，不允许旧配置静默失效。重命名或删除开关时把旧键登记到 `TransformerConfig.renamed_config_keys`（`_process_attribute` 会据此抛 `ValueError` 并给出迁移提示）；`_process_attribute` 的兜底分支是 `setattr`，未登记的旧键会被当成无用属性吸收，旧配置想打开的功能会静默保持关闭。特殊场景可参考 `sonicmoe_quant_format` 的单独 guard。
+- 拦截必须无条件可达。不要把旧开关检查放在某个取值的条件分支内，否则其他取值下旧配置仍会静默通过；现有对 `csa_tilelang_backend` / `csa_tilelang_enable_indexer` / `csa_tilelang_enable_sparse_attn` 的拦截嵌在 `__post_init__` 里 `experimental_attention_variant == "dsv4_hybrid"` 的分支内部，属于反例。新增拦截应放在 `renamed_config_keys`、`_process_attribute` 或 `__post_init__` 顶层。
+- 仅在 docstring 标注 `Deprecated` / `This flag is ignored` 而保留字段、不给运行时信号的做法，只适用于从 Megatron-LM 继承的存量字段（如 `moe_extended_tp`、`async_tensor_model_parallel_allreduce`），不得用于本 PR 新引入的废弃。
+- 修改默认值必须在 PR 描述中说明对既有配置的影响，并与 PR 模板中“是否引起精度变化”一节一致。
+
+## 命名与声明规范
+
+- 与所在功能域分段中现有开关的命名风格保持一致，沿用既有功能域前缀（`moe_`、`csa_`、`dsa_`、`fp8_`、`cp_`、`tp_comm_`、`recompute_` 等）。
+- 布尔开关使用名词或形容词短语命名，True 表示打开、False 表示关闭，例如 `gated_attention`、`csa_dense_mode`、`qk_norm_fusion`。避免 `enable_xxx` / `disable_xxx`：`enable` 与布尔 True 语义重复，`enable` 与 `disable` 并存会造成语义混乱。名词结构过短不足以表达时，用“功能域前缀 + 动宾”构成名词化短语，例如 `moe_dequant_input`、`train_indexer_only`。
+- 传值开关用 `<功能域>_<对象>` 加类型后缀，例如 `_size`、`_ratio`、`_coeff`、`_backend`、`_mode`、`_type`。多个互斥实现用单个字符串枚举字段表达（参考 `csa_indexer_backend`），不要拆成多个互斥布尔开关。
+- 配置命名空间是扁平的：`TransformerConfig` 继承 `ModelParallelConfig`，所有字段处于同一层命名空间。不要新增子配置 dataclass 制造嵌套。确需结构化取值时用 dict/list 字段，嵌套不超过两级，并在 docstring 列出全部合法键。
+- 禁止重复声明同名字段。新增字段前用 `rg` 确认本类与基类中不存在同名字段；重复声明会让后一次声明静默覆盖前一次，且可能与 docstring 描述的默认值不一致。
+- 不要新增下划线前缀字段作为用户可配置开关。
+
+## 分段与放置
+
+- 两个配置文件用分区注释按功能域分段（例如 `# model architecture`、`# mixed-precision`、`# fusion`、`# activation recomputation`、`# MoE related`、`# Context Parallel`、`# fp8`、`# MLA`、`# DSA`、`# CSA / DSv4 Hybrid Attention`）。新增开关必须插入到所属功能域的分段内、紧邻同类开关，不得追加到类体末尾、插到文件里第一个能编译通过的位置，或塞进不相关分段。
+- 一组相关开关连续声明：主开关在前，依赖它的参数开关紧随其后，使依赖关系在阅读时即可看出。例如某功能的 backend 选择与该 backend 的参数应相邻，不要被无关字段隔开。
+- 若新增开关属于一个尚不存在的功能域，应新增一条分区注释，并把该功能域的开关集中在这一段内，而不是分散插入多个已有分段。
+- 评审时发现新增字段所在位置与其功能域不匹配，要指出应归入的分段名称，并说明分散声明会导致同类开关难以检索、后续容易重复新增等价开关。
+
+## 反面模式：语义不清、结构混乱、配置复杂、二次解析
+
+以下四类问题即使功能正确也应报告，并给出具体的替代设计。
+
+- 命名语义不清：从字段名加 docstring 无法判断“取该值会发生什么”。典型表现：名字描述实现细节而非用户意图；同一概念在不同开关里混用 `_mode` / `_type` / `_variant` / `_backend`；缩写未在 docstring 展开；布尔名带否定语义导致双重否定。报告时给出建议命名和判断依据。
+- 结构混乱：一个开关同时承担多个正交语义（既选实现又调参数），或多个开关的取值互相隐式改写。新增开关必须做到：正交语义拆成正交字段；组合非法时在 `__post_init__` 抛 `ValueError`，而不是静默把某个字段改写成兼容值；确有必要的自动改写要在 docstring 写明改写条件和结果。
+- 配置复杂：启用一个功能需要用户同时正确设置三个以上开关，或需要用户了解内部实现（kernel 名、stage 编号、内部阈值）才能填对取值。这类情况应提供单一入口开关，其余参数给出可用默认值或从已有配置推导。
+- 二次解析：开关取值必须在配置层完成归一化，禁止把多形态取值透传给消费方、让 trainer、model、layer 或算子封装各自再写一遍解析和分支。
+  - 判定条件：同一字段接受多种类型（`bool | str`、`int | list`、`list | dict` 等）、需要按分隔符切分的字符串、或需要消费方补齐缺省键的 dict。
+  - 现网反例：`recompute_modules` 声明为 `list[str] | dict`，`attention.py`、`moe/moe_layer.py` 等多个消费点各自重复 `isinstance(..., list)` / `isinstance(..., dict)` 分支；`moe_layer_freq` 声明为 `int | list`，在 `models/gpt/gpt_layer_specs.py` 里再次按类型分支。新增开关不得引入同类形态。
+  - 要求：新增开关取值类型单一；确需兼容多形态输入时，在 `__post_init__` 中一次性归一化成唯一内部表示，消费方只读归一化后的字段；不得在配置类之外用 `split`、正则、`json.loads`、`literal_eval` 解析开关取值。
+  - 评审动作：对新增开关用 `rg <switch_name>` 列出全部消费点，若出现类型分支、字符串切分或缺省键补齐等重复逻辑，报告并要求把归一化上移到配置层。
+
+## 文档与默认值
+
+- 每个新增字段紧随其后必须有 docstring，说明：语义、完整取值集合（枚举需逐项说明）、默认值及其选择理由、与其他开关的依赖或互斥关系。仅有字段声明而无 docstring 的新增开关必须报告。
+- 默认值必须保持现有行为不变，新功能默认关闭。除非 PR 明确说明行为变更并评估精度影响。
+- 若开关对应 Huggingface `config.json` 中的字段名，需在 `TransformerConfig.transform_rules` 中登记映射，否则从 HF 配置加载时该开关不生效。重命名已登记的开关时必须同步更新 `transform_rules`。
+
+## 校验与测试
+
+- 开关之间的依赖与互斥必须在 `__post_init__` 中校验并抛出 `ValueError`，不使用 `assert`（与基础规则一致）。错误信息要包含冲突的开关名、当前值和期望值。
+- 新增或修改开关必须补充测试，覆盖默认取值路径、至少一个非默认取值路径，以及用 `pytest.raises` 验证非法组合：
+  - `transformer_config.py` 的通用校验放在 `tests/single_card_tests/test_transformer_config.py`；特定功能的开关放在 `tests/single_card_tests/transformer/` 下对应功能的测试文件。
+  - `model_parallel_config.py` 的校验放在 `tests/single_card_tests/ai_edited_test/distributed/test_ai_model_parallel_config.py`。
+  - 开关影响并行行为时需要 `tests/multi_card_tests/` 下的代表性多卡覆盖。
+- `TransformerConfig.from_config` 走 `object.__new__` 并手动调用 `__post_init__`，不经过 dataclass 构造函数。新增字段需确认在配置字典缺少该键时仍能取到声明的默认值，且 `__post_init__` 中对该字段的校验不会因缺键而异常。

--- a/src/paddlefleet/transformer/dsv4_hybrid_attention.py
+++ b/src/paddlefleet/transformer/dsv4_hybrid_attention.py
@@ -624,6 +624,17 @@ class DSv4HybridAttention(Attention):
                 f"DSv4 hybrid attention requires HCA/CSA/window ratio, got {compress_ratio}"
             )
 
+        # Resolve the per-attention-type RoPE variant override.
+        # HCA layers: compress_ratio == 128; CSA layers: 2 <= compress_ratio < 128.
+        # When the per-type field is unset (None), the historical default below
+        # is kept so existing configs behave exactly as before.
+        if compress_ratio == 128:
+            per_type_rope_type = config.hca_rope_type
+        elif 2 <= compress_ratio < 128:
+            per_type_rope_type = config.csa_rope_type
+        else:
+            per_type_rope_type = None
+
         # Per-layer RoPE (potentially different base for compressed layers)
         rope_base = getattr(config, "rotary_base", 10000)
         if compress_ratio > 1:
@@ -634,14 +645,15 @@ class DSv4HybridAttention(Attention):
             # YarnRotaryEmbedding's math.log() with a str and raise TypeError.
             rope_base = float(config.csa_compress_rotary_base)
 
-        use_compressed_yarn = compress_ratio > 1
-        if not use_compressed_yarn:
-            self.rotary_pos_emb = RotaryEmbedding(
-                self.qk_pos_emb_head_dim,
-                rotary_percent=getattr(config, "rotary_percent", 1.0),
-                rotary_base=rope_base,
-            )
-        else:
+        # Resolve the RoPE variant for this layer. Historically compressed
+        # layers (compress_ratio > 1, i.e. HCA/CSA) always used YaRN while
+        # window/MQA layers used plain RoPE. The per-attention-type override
+        # (hca_rope_type / csa_rope_type) lets HCA and CSA independently pick
+        # "rope" or "yarn"; when unset the historical default is preserved.
+        default_rope_type = "yarn" if compress_ratio > 1 else "rope"
+        resolved_rope_type = per_type_rope_type or default_rope_type
+
+        if resolved_rope_type == "yarn":
             self.rotary_pos_emb = YarnRotaryEmbedding(
                 self.qk_pos_emb_head_dim,
                 rotary_base=rope_base,
@@ -656,6 +668,12 @@ class DSv4HybridAttention(Attention):
                 yarn_rope_fusion=getattr(
                     config, "dsv4_yarn_rope_fusion", False
                 ),
+            )
+        else:
+            self.rotary_pos_emb = RotaryEmbedding(
+                self.qk_pos_emb_head_dim,
+                rotary_percent=getattr(config, "rotary_percent", 1.0),
+                rotary_base=rope_base,
             )
 
         self.core_attention = build_spec_layer(

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -1205,6 +1205,18 @@ class TransformerConfig(ModelParallelConfig):
     The positional embedding (RoPE) is applied only to the last qk_pos_emb_head_dim dims.
     """
 
+    hca_rope_type: str | None = None
+    """Per-attention-type RoPE variant for HCA layers (csa_compress_ratios == 128).
+    Options: "rope" (plain RoPE) or "yarn" (YaRN). When None, keeps the historical
+    default (compressed layers use YaRN). The RoPE width stays qk_pos_emb_head_dim.
+    """
+
+    csa_rope_type: str | None = None
+    """Per-attention-type RoPE variant for CSA layers (2 <= csa_compress_ratios < 128).
+    Options: "rope" (plain RoPE) or "yarn" (YaRN). When None, keeps the historical
+    default (compressed layers use YaRN). The RoPE width stays qk_pos_emb_head_dim.
+    """
+
     gpt_model_use_experimental_version: bool = False
     """Enable experimental version code paths for precision alignment."""
 
@@ -1262,6 +1274,8 @@ class TransformerConfig(ModelParallelConfig):
         "o_groups": "o_groups",
         "o_lora_rank": "o_lora_rank",
         "qk_pos_emb_head_dim": "qk_pos_emb_head_dim",
+        "hca_rope_type": "hca_rope_type",
+        "csa_rope_type": "csa_rope_type",
     }
 
     @classmethod
@@ -1676,6 +1690,16 @@ class TransformerConfig(ModelParallelConfig):
                     f"csa_sparse_attn_backend={self.csa_sparse_attn_backend!r} is invalid. "
                     "Must be one of {'unfused', 'tilelang', 'cudnn'}."
                 )
+
+            # Per-attention-type RoPE variant validation (HCA / CSA).
+            valid_rope_types = {"rope", "yarn"}
+            for name in ("hca_rope_type", "csa_rope_type"):
+                val = getattr(self, name, None)
+                if val is not None and val not in valid_rope_types:
+                    raise ValueError(
+                        f"{name}={val!r} is invalid. Must be one of "
+                        "{'rope', 'yarn'} or None (keep default)."
+                    )
             if self.csa_train_indexer_only:
                 if self.csa_dense_mode:
                     raise ValueError(

--- a/tests/single_card_tests/transformer/test_hca_csa_independent_rope.py
+++ b/tests/single_card_tests/transformer/test_hca_csa_independent_rope.py
@@ -1,0 +1,440 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for per-attention-type (HCA / CSA) RoPE variant configuration.
+
+Covers the incremental behavior that lets HCA layers
+(``csa_compress_ratios == 128``) and CSA layers (``2 <= ratio < 128``)
+independently choose the RoPE variant (plain RoPE vs YaRN) through
+``hca_rope_type`` / ``csa_rope_type``, while staying fully backward compatible
+when the fields are unset. The positional-embedding width is not part of this
+feature: it always remains the global ``qk_pos_emb_head_dim``.
+
+``TestLegacyPlainRopeEquivalence`` /
+``TestLegacyPlainRopeForwardEquivalence`` pin the central guarantee: setting
+``hca_rope_type="rope"`` (resp. ``csa_rope_type="rope"``) reproduces bit for
+bit what the pre-feature code produced when its local ``use_compressed_yarn``
+flag was forced to ``False`` -- both for the constructed rotary module and for
+a real forward/backward pass.
+"""
+
+import unittest
+from unittest import mock
+
+import numpy as np
+import paddle
+from paddle.distributed.fleet.meta_parallel import build_spec_layer
+
+from paddlefleet.models.common.embeddings.rotary_pos_embedding import (
+    RotaryEmbedding,
+)
+from paddlefleet.models.common.embeddings.yarn_rotary_pos_embedding import (
+    YarnRotaryEmbedding,
+)
+from paddlefleet.models.gpt.gpt_layer_specs import get_gpt_layer_local_spec
+from paddlefleet.tensor_parallel.random import (
+    model_parallel_cuda_manual_seed,
+)
+from paddlefleet.transformer import dsv4_hybrid_attention
+from paddlefleet.transformer.transformer_config import TransformerConfig
+
+_SEED = 42
+_ROTARY_PERCENT = 1.0
+# csa_compress_rotary_base used by _make_config: compressed layers (HCA/CSA)
+# override the global rotary_base with this value.
+_COMPRESSED_ROPE_BASE = 160000.0
+_GLOBAL_POS_DIM = 16
+
+
+def _try_use_cuda_device():
+    """Return True only when a real CUDA device is usable for kernels."""
+    if not paddle.is_compiled_with_cuda():
+        return False
+    try:
+        paddle.set_device("gpu:0")
+        place = str(paddle.empty([1]).place).lower()
+    except Exception:
+        return False
+    return paddle.get_device().startswith("gpu") and (
+        "gpu" in place or "cuda" in place
+    )
+
+
+_REQUIRES_CUDA = unittest.skipUnless(
+    _try_use_cuda_device(),
+    "requires a usable CUDA device to run the DSv4 hybrid attention forward",
+)
+
+
+class _FakeGroup:
+    def __init__(self, nranks=1):
+        self.nranks = nranks
+        self.world_size = nranks
+        self.ranks = list(range(nranks))
+        self.rank = 0
+
+
+class _FakePGCollection:
+    def __init__(self, tp_nranks=1, cp_nranks=1):
+        self.tp = _FakeGroup(tp_nranks)
+        self.cp = _FakeGroup(cp_nranks)
+
+
+def _make_config(
+    csa_compress_ratios,
+    qk_pos_emb_head_dim=_GLOBAL_POS_DIM,
+    hca_rope_type=None,
+    csa_rope_type=None,
+    num_layers=None,
+):
+    """Build a dsv4_hybrid TransformerConfig forwarding the new per-type fields.
+
+    Mirrors the construction-friendly setup used by test_dsv4_hybrid_attention
+    (CPU-buildable dimensions), plus the two incremental fields under test.
+    """
+    if num_layers is None:
+        num_layers = len(csa_compress_ratios)
+    v_head_dim = 32
+    return TransformerConfig(
+        num_hidden_layers=num_layers,
+        num_nextn_predict_layers=0,
+        hidden_size=256,
+        num_attention_heads=8,
+        params_dtype=paddle.bfloat16,
+        bf16=True,
+        use_bias=False,
+        multi_latent_attention=True,
+        experimental_attention_variant="dsv4_hybrid",
+        q_lora_rank=64,
+        kv_lora_rank=v_head_dim - qk_pos_emb_head_dim,
+        qk_nope_head_dim=v_head_dim - qk_pos_emb_head_dim,
+        qk_rope_head_dim=qk_pos_emb_head_dim,
+        qk_pos_emb_head_dim=qk_pos_emb_head_dim,
+        v_head_dim=v_head_dim,
+        hybrid_mla_q_lora_rank=1536,
+        hybrid_mla_kv_lora_rank=512,
+        hybrid_mla_qk_nope_head_dim=192,
+        hybrid_mla_qk_rope_head_dim=64,
+        hybrid_mla_v_head_dim=256,
+        hybrid_mla_num_attention_heads=64,
+        hybrid_mla_num_key_value_heads=64,
+        o_groups=4,
+        o_lora_rank=32,
+        rope_type="rope",
+        rotary_base=10000.0,
+        rotary_percent=_ROTARY_PERCENT,
+        normalization="RMSNorm",
+        use_qk_norm=True,
+        csa_compress_ratios=csa_compress_ratios,
+        csa_window_size=16,
+        csa_compress_rotary_base=str(_COMPRESSED_ROPE_BASE),
+        dsa_index_n_heads=4,
+        dsa_index_head_dim=32,
+        dsa_index_topk=8,
+        dsa_indexer_loss_coeff=1.0,
+        dsa_indexer_use_sparse_loss=False,
+        dsa_indexer_rotary_interleaved=False,
+        apply_rope_fusion=False,
+        attention_dropout=0.0,
+        attention_softmax_in_fp32=True,
+        masked_softmax_fusion=False,
+        softmax_type="vanilla",
+        csa_indexer_backend="unfused",
+        csa_sparse_attn_backend="unfused",
+        tensor_model_parallel_size=1,
+        context_parallel_size=1,
+        csa_dense_mode=False,
+        hca_rope_type=hca_rope_type,
+        csa_rope_type=csa_rope_type,
+    )
+
+
+def _build_dsv4(config, layer_number):
+    """Construct a DSv4HybridSelfAttention layer (CPU friendly)."""
+    spec = get_gpt_layer_local_spec(
+        config=config,
+        normalization=config.normalization,
+        layer_number=layer_number,
+    ).sublayers_spec.self_attn
+    return build_spec_layer(
+        spec,
+        config=config,
+        layer_number=layer_number,
+        pg_collection=_FakePGCollection(),
+    )
+
+
+def _rope_dim(module):
+    """Return the effective RoPE head dim for either embedding variant.
+
+    YarnRotaryEmbedding stores ``dim`` directly; plain RotaryEmbedding does
+    not, so derive it from ``inv_freq`` (length == dim // 2).
+    """
+    if isinstance(module, YarnRotaryEmbedding):
+        return module.dim
+    return int(module.inv_freq.shape[0]) * 2
+
+
+def _legacy_plain_rope_patch():
+    """Emulate the pre-feature code path with ``use_compressed_yarn = False``.
+
+    Before this feature DSv4HybridAttention picked the RoPE variant with a
+    local flag::
+
+        use_compressed_yarn = compress_ratio > 1
+        if not use_compressed_yarn:
+            self.rotary_pos_emb = RotaryEmbedding(
+                self.qk_pos_emb_head_dim,
+                rotary_percent=getattr(config, "rotary_percent", 1.0),
+                rotary_base=rope_base,
+            )
+        else:
+            self.rotary_pos_emb = YarnRotaryEmbedding(...)
+
+    Forcing that flag to ``False`` on a compressed layer therefore means
+    building a plain ``RotaryEmbedding`` with the very same dim and (compressed)
+    base. Patching the YaRN symbol with a shim that does exactly that gives the
+    reference behavior without editing the shipped source.
+    """
+
+    def _shim(dim, *, rotary_base, **_yarn_only_kwargs):
+        return RotaryEmbedding(
+            dim,
+            rotary_percent=_ROTARY_PERCENT,
+            rotary_base=rotary_base,
+        )
+
+    return mock.patch.object(
+        dsv4_hybrid_attention, "YarnRotaryEmbedding", _shim
+    )
+
+
+# Layer layout used by every test below (csa_compress_ratios):
+# index 0 window(0), 1 CSA(4), 2 HCA(128), 3 full-causal MQA(-1).
+_RATIOS = [0, 4, 128, -1]
+_WINDOW_LAYER, _CSA_LAYER, _HCA_LAYER, _MQA_LAYER = 0, 1, 2, 3
+
+
+class TestConfigDefaultsAndValidation(unittest.TestCase):
+    """Field declaration, transform_rules exposure and __post_init__ checks."""
+
+    def test_new_fields_default_to_none(self):
+        config = _make_config(csa_compress_ratios=_RATIOS)
+        self.assertIsNone(config.hca_rope_type)
+        self.assertIsNone(config.csa_rope_type)
+
+    def test_transform_rules_expose_new_fields(self):
+        rules = TransformerConfig.transform_rules
+        for name in ("hca_rope_type", "csa_rope_type"):
+            self.assertIn(name, rules)
+            self.assertEqual(rules[name], name)
+
+    def test_valid_rope_types_accepted(self):
+        for hca, csa in (
+            ("rope", "yarn"),
+            ("yarn", "rope"),
+            ("rope", "rope"),
+            ("yarn", "yarn"),
+        ):
+            config = _make_config(
+                csa_compress_ratios=_RATIOS,
+                hca_rope_type=hca,
+                csa_rope_type=csa,
+            )
+            self.assertEqual(config.hca_rope_type, hca)
+            self.assertEqual(config.csa_rope_type, csa)
+
+    def test_invalid_hca_rope_type_raises(self):
+        with self.assertRaisesRegex(ValueError, "hca_rope_type"):
+            _make_config(csa_compress_ratios=_RATIOS, hca_rope_type="linear")
+
+    def test_invalid_csa_rope_type_raises(self):
+        with self.assertRaisesRegex(ValueError, "csa_rope_type"):
+            _make_config(csa_compress_ratios=_RATIOS, csa_rope_type="ROPE")
+
+
+class TestPerTypeRopeResolution(unittest.TestCase):
+    """Per-attention-type RoPE variant resolution in DSv4HybridAttention."""
+
+    def _build_all(self, **kwargs):
+        model_parallel_cuda_manual_seed(_SEED)
+        config = _make_config(csa_compress_ratios=_RATIOS, **kwargs)
+        return tuple(
+            _build_dsv4(config, layer_number=i)
+            for i in (_WINDOW_LAYER, _CSA_LAYER, _HCA_LAYER, _MQA_LAYER)
+        )
+
+    def test_default_backward_compatible(self):
+        window, csa, hca, mqa = self._build_all()
+        # Compressed layers (CSA/HCA) historically default to YaRN.
+        self.assertIsInstance(csa.rotary_pos_emb, YarnRotaryEmbedding)
+        self.assertIsInstance(hca.rotary_pos_emb, YarnRotaryEmbedding)
+        # Window / MQA layers default to plain RoPE.
+        self.assertIsInstance(window.rotary_pos_emb, RotaryEmbedding)
+        self.assertIsInstance(mqa.rotary_pos_emb, RotaryEmbedding)
+
+    def test_hca_rope_override_keeps_csa_yarn(self):
+        _, csa, hca, _ = self._build_all(hca_rope_type="rope")
+        self.assertIsInstance(hca.rotary_pos_emb, RotaryEmbedding)
+        self.assertIsInstance(csa.rotary_pos_emb, YarnRotaryEmbedding)
+
+    def test_csa_rope_override_keeps_hca_yarn(self):
+        _, csa, hca, _ = self._build_all(csa_rope_type="rope")
+        self.assertIsInstance(csa.rotary_pos_emb, RotaryEmbedding)
+        self.assertIsInstance(hca.rotary_pos_emb, YarnRotaryEmbedding)
+
+    def test_explicit_yarn_and_rope_mix(self):
+        _, csa, hca, _ = self._build_all(
+            hca_rope_type="yarn", csa_rope_type="rope"
+        )
+        self.assertIsInstance(hca.rotary_pos_emb, YarnRotaryEmbedding)
+        self.assertIsInstance(csa.rotary_pos_emb, RotaryEmbedding)
+
+    def test_window_and_mqa_layers_ignore_overrides(self):
+        # Neither field applies to window(0) / MQA(-1) layers: they keep plain
+        # RoPE even when both compressed types are pinned to YaRN.
+        window, _, _, mqa = self._build_all(
+            hca_rope_type="yarn", csa_rope_type="yarn"
+        )
+        self.assertIsInstance(window.rotary_pos_emb, RotaryEmbedding)
+        self.assertIsInstance(mqa.rotary_pos_emb, RotaryEmbedding)
+
+    def test_override_keeps_global_pos_dim_and_compressed_base(self):
+        # The feature only switches the variant: the RoPE width stays the
+        # global qk_pos_emb_head_dim and the compressed rotary base is still
+        # csa_compress_rotary_base.
+        _, csa, hca, _ = self._build_all(
+            hca_rope_type="rope", csa_rope_type="rope"
+        )
+        reference = RotaryEmbedding(
+            _GLOBAL_POS_DIM,
+            rotary_percent=_ROTARY_PERCENT,
+            rotary_base=_COMPRESSED_ROPE_BASE,
+        )
+        for layer in (csa, hca):
+            self.assertEqual(layer.qk_pos_emb_head_dim, _GLOBAL_POS_DIM)
+            self.assertEqual(_rope_dim(layer.rotary_pos_emb), _GLOBAL_POS_DIM)
+            self.assertTrue(
+                paddle.equal_all(
+                    layer.rotary_pos_emb.inv_freq, reference.inv_freq
+                )
+            )
+
+
+def _build_layer(layer_number, **kwargs):
+    model_parallel_cuda_manual_seed(_SEED)
+    config = _make_config(csa_compress_ratios=_RATIOS, **kwargs)
+    return _build_dsv4(config, layer_number=layer_number)
+
+
+def _build_legacy_plain_rope_layer(layer_number):
+    """Reference layer: pre-feature code with ``use_compressed_yarn = False``."""
+    with _legacy_plain_rope_patch():
+        return _build_layer(layer_number)
+
+
+class TestLegacyPlainRopeEquivalence(unittest.TestCase):
+    """rope_type="rope" builds the same module as legacy use_compressed_yarn=False."""
+
+    def _assert_same_rotary(self, layer_number, **kwargs):
+        legacy = _build_legacy_plain_rope_layer(layer_number)
+        new = _build_layer(layer_number, **kwargs)
+        self.assertIsInstance(legacy.rotary_pos_emb, RotaryEmbedding)
+        self.assertIsInstance(new.rotary_pos_emb, RotaryEmbedding)
+        self.assertEqual(
+            _rope_dim(new.rotary_pos_emb), _rope_dim(legacy.rotary_pos_emb)
+        )
+        self.assertTrue(
+            paddle.equal_all(
+                new.rotary_pos_emb.inv_freq, legacy.rotary_pos_emb.inv_freq
+            )
+        )
+
+    def test_hca_rotary_matches_legacy(self):
+        self._assert_same_rotary(_HCA_LAYER, hca_rope_type="rope")
+
+    def test_csa_rotary_matches_legacy(self):
+        self._assert_same_rotary(_CSA_LAYER, csa_rope_type="rope")
+
+    def test_default_yarn_differs_from_legacy_plain_rope(self):
+        # Guards the assertions above against being vacuous: with the fields
+        # unset the compressed layer really is a different (YaRN) module.
+        legacy = _build_legacy_plain_rope_layer(_HCA_LAYER)
+        default = _build_layer(_HCA_LAYER)
+        self.assertIsInstance(legacy.rotary_pos_emb, RotaryEmbedding)
+        self.assertIsInstance(default.rotary_pos_emb, YarnRotaryEmbedding)
+
+
+@_REQUIRES_CUDA
+class TestLegacyPlainRopeForwardEquivalence(unittest.TestCase):
+    """End-to-end training-step equivalence with legacy use_compressed_yarn=False.
+
+    Runs a real forward + backward on both layers with identical weights and
+    identical inputs, then requires bit-wise identical outputs and input
+    gradients. This is the guarantee an actual training run depends on.
+    """
+
+    SEQ_LEN = 16
+    HIDDEN_SIZE = 256
+
+    def setUp(self):
+        rng = np.random.default_rng(_SEED)
+        shape = [1, self.SEQ_LEN, self.HIDDEN_SIZE]
+        self.hidden_np = rng.standard_normal(shape, dtype=np.float32)
+        self.out_grad_np = rng.standard_normal(shape, dtype=np.float32)
+
+    def _forward_backward(self, layer):
+        layer.train()
+        hidden = paddle.to_tensor(self.hidden_np, dtype="bfloat16")
+        hidden.stop_gradient = False
+        out, _ = layer(hidden_states=hidden, attention_mask=None)
+        self.assertEqual(out.shape, [1, self.SEQ_LEN, self.HIDDEN_SIZE])
+        out.backward(paddle.to_tensor(self.out_grad_np, dtype=out.dtype))
+        self.assertIsNotNone(hidden.grad)
+        return (
+            out.astype("float32").numpy(),
+            hidden.grad.astype("float32").numpy(),
+        )
+
+    def _assert_forward_equivalent(self, layer_number, **kwargs):
+        legacy = _build_legacy_plain_rope_layer(layer_number)
+        new = _build_layer(layer_number, **kwargs)
+        # Neutralize any init nondeterminism: the comparison must isolate the
+        # RoPE path, not the parameter initialization.
+        new.set_state_dict(legacy.state_dict())
+        legacy_out, legacy_grad = self._forward_backward(legacy)
+        new_out, new_grad = self._forward_backward(new)
+        np.testing.assert_array_equal(new_out, legacy_out)
+        np.testing.assert_array_equal(new_grad, legacy_grad)
+        return legacy_out
+
+    def test_hca_forward_matches_legacy(self):
+        self._assert_forward_equivalent(_HCA_LAYER, hca_rope_type="rope")
+
+    def test_csa_forward_matches_legacy(self):
+        self._assert_forward_equivalent(_CSA_LAYER, csa_rope_type="rope")
+
+    def test_default_yarn_forward_differs_from_legacy(self):
+        # Vacuity guard: the equality above must come from the rope_type
+        # override, not from YaRN and plain RoPE happening to agree.
+        legacy = _build_legacy_plain_rope_layer(_HCA_LAYER)
+        default = _build_layer(_HCA_LAYER)
+        default.set_state_dict(legacy.state_dict())
+        legacy_out, _ = self._forward_backward(legacy)
+        default_out, _ = self._forward_backward(default)
+        self.assertFalse(np.array_equal(default_out, legacy_out))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Others

### Description
**DO NOT MERGE. This PR will be closed after the AI review output is collected.**

Purpose: false-positive control for the new `ai-review` extension rule file
`.agents/skills/ai-review/references/user-configuration-rules.md`.

The code diff is a replay of the already-merged #1673 (adds `hca_rope_type` /
`csa_rope_type`, both optional and default `None`, registered in
`transform_rules`, covered by a new single-card test). It is expected to be
compliant with the new rules, so the review should not raise configuration
switch findings on it.

### 是否引起精度变化
否