### PR TITLE
[Muon Slice] Orthogonalise allgather-EP expert weights on the full intermediate dim

### DIFF
--- a/src/paddlefleet/transformer/moe/moe_expert.py
+++ b/src/paddlefleet/transformer/moe/moe_expert.py
@@ -278,22 +278,61 @@ class GroupedMLPExpert(FleetLayer):
         self.weight1.is_distributed = self.expert_parallel
         self.weight2.is_distributed = self.expert_parallel
 
+    @property
+    def intermediate_ep_sharded(self):
+        """Whether this rank owns all experts but only ``I // EP`` of each.
+
+        The 'allgather' dispatcher shards the experts along their intermediate
+        dim instead of along the expert dim, so a rank holds every expert.
+        ``sharded_state_dict`` keys off the same condition; keep the two in sync.
+        """
+        return (
+            getattr(self.config, "moe_token_dispatcher_type", None)
+            == "allgather"
+            and self.expert_parallel
+        )
+
     def muon_slice_specs(self, muon_configs):
         """Muon orthogonal-slice specs for fused grouped-gemm expert weights.
 
         weight1 (fused gate/up) is split by shape when ``muon_ffn_split`` is on;
         weight2 (down) is always orthogonalised per-expert (grouped gemm is
         inherently a fused 3D expert tensor).
+
+        When this rank only holds a slice of every expert's intermediate dim
+        (allgather dispatcher with EP > 1) both weights must first be
+        redistributed to the traditional EP layout, otherwise Newton-Schulz runs
+        on a slab instead of the real matrix. ``muon_ffn_split`` keeps
+        controlling whether gate and up are orthogonalised independently.
         """
         from paddlefleet.transformer.muon_utils import (
+            ortho_ep_full_intermediate,
             ortho_gate_up,
             ortho_stacked,
         )
 
+        gate_up_fused = self.config.gated_linear_unit
+        ffn_split = muon_configs.get("muon_ffn_split", False)
+
+        if self.intermediate_ep_sharded:
+            return {
+                "weight1": (
+                    ortho_ep_full_intermediate,
+                    {
+                        "ep_group": self.ep_group,
+                        "shard_axis": -1,
+                        "gate_up": gate_up_fused,
+                        "split_gate_up": ffn_split,
+                    },
+                ),
+                "weight2": (
+                    ortho_ep_full_intermediate,
+                    {"ep_group": self.ep_group, "shard_axis": -2},
+                ),
+            }
+
         specs = {}
-        if self.config.gated_linear_unit and muon_configs.get(
-            "muon_ffn_split", False
-        ):
+        if gate_up_fused and ffn_split:
             specs["weight1"] = (ortho_gate_up, {})
         specs["weight2"] = (ortho_stacked, {})
         return specs
@@ -369,15 +408,9 @@ class GroupedMLPExpert(FleetLayer):
         # allgather: shard on intermediate dim, each rank owns all experts.
         # Cross-topology reshard is handled by the DCP resharder.
         # See _get_intermediate_sharded_state_dict for allgather details.
-        is_intermediate_sharded = (
-            getattr(self.config, "moe_token_dispatcher_type", None)
-            == "allgather"
-            and self.expert_parallel
-        )
-
         state_dict = self.state_dict(structured_name_prefix="")
 
-        if is_intermediate_sharded:
+        if self.intermediate_ep_sharded:
             return self._get_intermediate_sharded_state_dict(
                 state_dict, structured_name_prefix
             )

--- a/src/paddlefleet/transformer/muon_utils.py
+++ b/src/paddlefleet/transformer/muon_utils.py
@@ -13,6 +13,7 @@ know nothing about muon configs or module structure.
 """
 
 import paddle
+import paddle.distributed as dist
 
 
 def ortho_blocks(weight, ortho_fn, sizes, axis=-1):
@@ -64,6 +65,96 @@ def ortho_stacked(weight, ortho_fn):
         )
 
     return ortho_fn(weight)
+
+
+def ortho_ep_full_intermediate(
+    weight,
+    ortho_fn,
+    ep_group=None,
+    shard_axis=-1,
+    gate_up=False,
+    split_gate_up=True,
+):
+    """Orthogonalise EP-sharded expert weights on their full intermediate dim.
+
+    With the 'allgather' MoE dispatcher and EP > 1 a rank holds *every* expert
+    but only ``moe_intermediate_size // EP`` of each one, so a local
+    Newton-Schulz would orthogonalise a slab instead of the real matrix. This
+    wrapper redistributes to the traditional EP layout (``E // EP`` experts,
+    full intermediate) with an all-to-all, orthogonalises there, and sends the
+    result back the same way, reproducing the update a non-EP run would make.
+
+    ``shard_axis`` is the axis the intermediate dim was sharded along: -1 for
+    the fc1 weight ``[E, H, 2I/EP]``, -2 for the fc2 weight ``[E, I/EP, H]``.
+
+    Set ``gate_up`` when ``shard_axis`` packs a fused ``[gate | up]`` pair: each
+    rank then owns ``[gate_shard | up_shard]``, so the halves must be
+    de-interleaved before they can be concatenated into full-width matrices.
+    ``split_gate_up`` (i.e. ``muon_ffn_split``) then decides whether gate and up
+    are orthogonalised independently or as one fused matrix.
+    """
+    if weight.ndim != 3:
+        raise ValueError(
+            f"EP redistribution expects a 3D expert tensor, got {weight.shape}"
+        )
+    if ep_group is None:
+        raise ValueError(
+            "EP redistribution requires an expert-parallel process group"
+        )
+
+    ep_size = ep_group.nranks
+    if weight.shape[0] % ep_size != 0:
+        raise ValueError(
+            f"Expert axis {weight.shape[0]} is not divisible by EP={ep_size}."
+        )
+    if gate_up and weight.shape[shard_axis] % 2 != 0:
+        raise ValueError(
+            f"Fused gate/up axis must be even, got shape {weight.shape}."
+        )
+
+    # Splitting a contiguous tensor along axis 0 yields contiguous blocks, so
+    # the forward all-to-all needs no extra copy.
+    send = list(paddle.split(weight, ep_size, axis=0))
+    recv = [paddle.empty_like(send[0]) for _ in send]
+    dist.alltoall(recv, send, group=ep_group)
+
+    if not gate_up:
+        owned = ortho_fn(paddle.concat(recv, axis=shard_axis))
+        back = [
+            chunk.contiguous()
+            for chunk in paddle.split(owned, ep_size, axis=shard_axis)
+        ]
+    else:
+        gates, ups = zip(
+            *(paddle.split(chunk, 2, axis=shard_axis) for chunk in recv)
+        )
+        gate_in = paddle.concat(gates, axis=shard_axis)
+        up_in = paddle.concat(ups, axis=shard_axis)
+
+        if split_gate_up:
+            # Stack on the expert axis so a single batched Newton-Schulz still
+            # treats gate and up as independent matrices.
+            n_experts = gate_in.shape[0]
+            stacked = ortho_fn(paddle.concat([gate_in, up_in], axis=0))
+            gate_out, up_out = stacked[:n_experts], stacked[n_experts:]
+        else:
+            gate_out, up_out = paddle.split(
+                ortho_fn(paddle.concat([gate_in, up_in], axis=shard_axis)),
+                2,
+                axis=shard_axis,
+            )
+
+        back = [
+            paddle.concat([gate, up], axis=shard_axis)
+            for gate, up in zip(
+                paddle.split(gate_out, ep_size, axis=shard_axis),
+                paddle.split(up_out, ep_size, axis=shard_axis),
+            )
+        ]
+
+    reverse = [paddle.empty_like(back[0]) for _ in back]
+    dist.alltoall(reverse, back, group=ep_group)
+    return paddle.concat(reverse, axis=0)
 
 
 def ortho_qkv_interleaved(

--- a/tests/multi_card_tests/moe/test_muon_ep_slice.py
+++ b/tests/multi_card_tests/moe/test_muon_ep_slice.py
@@ -1,0 +1,219 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Multi-card (EP>1) test for ``muon_utils.ortho_ep_full_intermediate``.
+
+Under the 'allgather' MoE dispatcher a rank holds every expert but only
+``moe_intermediate_size // EP`` of each one, so Muon has to redistribute before
+orthogonalising. Both directions of that redistribution are exercised here: the
+helper returns a tensor in the rank-local layout, so a wrong expert/rank/gate-up
+permutation on either leg shows up as a mismatch against the reference.
+
+Every rank builds the *same* full-width weights from a fixed seed and keeps its
+own column range, so each rank's shard is distinguishable and a mis-permutation
+cannot pass by accident.
+
+Run with:
+  python -m paddle.distributed.launch --gpus=0,1 \
+      tests/multi_card_tests/moe/test_muon_ep_slice.py
+"""
+
+import unittest
+
+import numpy as np
+import paddle
+import paddle.distributed as dist
+from paddle.distributed import fleet
+
+from paddlefleet.process_groups_config import ProcessGroupCollection
+from paddlefleet.training.initialize import initialize_fleet
+from paddlefleet.transformer.muon_utils import ortho_ep_full_intermediate
+
+DTYPE = "float64"
+
+_pg_collection = None
+
+
+def _ensure_fleet():
+    global _pg_collection
+    if _pg_collection is not None:
+        return _pg_collection
+    ep_degree = dist.get_world_size()
+    strategy = fleet.DistributedStrategy()
+    strategy.hybrid_configs = {
+        "dp_degree": 1,
+        "mp_degree": 1,
+        "pp_degree": 1,
+        "sharding_degree": ep_degree,
+        "sep_degree": 1,
+        "cp_degree": 1,
+        "ep_degree": ep_degree,
+        "moe_sharding_degree": 1,
+        "order": [
+            "sharding",
+            "moe_sharding",
+            "pp",
+            "sep",
+            "cp",
+            "dp",
+            "ep",
+            "mp",
+        ],
+    }
+    initialize_fleet(strategy=strategy)
+    _pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+    return _pg_collection
+
+
+def _ortho(matrix):
+    """Deterministic stand-in for Newton-Schulz.
+
+    Not separable across a column or row block, so orthogonalising a shard
+    gives a different answer than orthogonalising the full matrix -- which is
+    exactly the regression under test. The leading axis is a batch, matching
+    how Muon feeds stacked expert weights to ``ortho_fn``.
+    """
+    norm = paddle.linalg.norm(matrix, axis=[-2, -1], keepdim=True)
+    return matrix / (norm + 1e-9) + 0.5 * matrix.mean(axis=-1, keepdim=True)
+
+
+class TestMuonEPFullIntermediate(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.pg_collection = _ensure_fleet()
+
+    def setUp(self):
+        self.ep_group = self.__class__.pg_collection.ep
+        self.ep_size = self.ep_group.nranks
+        self.rank = dist.get_rank(self.ep_group)
+
+        # experts and intermediate width both scale with EP so the test runs
+        # unchanged on 2 or 4 cards.
+        self.num_experts = 2 * self.ep_size
+        self.hidden = 8
+        self.intermediate = 4 * self.ep_size
+        self.per_rank = self.intermediate // self.ep_size
+
+        rng = np.random.RandomState(0)
+        shape_up = (self.num_experts, self.hidden, self.intermediate)
+        shape_down = (self.num_experts, self.intermediate, self.hidden)
+        self.gate = paddle.to_tensor(rng.randn(*shape_up), dtype=DTYPE)
+        self.up = paddle.to_tensor(rng.randn(*shape_up), dtype=DTYPE)
+        self.down = paddle.to_tensor(rng.randn(*shape_down), dtype=DTYPE)
+
+        self.cols = slice(
+            self.rank * self.per_rank, (self.rank + 1) * self.per_rank
+        )
+
+    def _local_weight1(self):
+        """fc1 shard: ``[E, H, 2 * I/EP]`` laid out as [gate_shard | up_shard]."""
+        return paddle.concat(
+            [self.gate[:, :, self.cols], self.up[:, :, self.cols]], axis=-1
+        )
+
+    def _local_weight2(self):
+        """fc2 shard: ``[E, I/EP, H]``."""
+        return self.down[:, self.cols, :]
+
+    def _assert_close(self, got, want):
+        self.assertEqual(list(got.shape), list(want.shape))
+        np.testing.assert_allclose(
+            got.astype("float64").numpy(),
+            want.astype("float64").numpy(),
+            rtol=0,
+            atol=1e-10,
+        )
+
+    def test_weight1_ffn_split_orthogonalises_gate_and_up_separately(self):
+        got = ortho_ep_full_intermediate(
+            self._local_weight1(),
+            _ortho,
+            ep_group=self.ep_group,
+            shard_axis=-1,
+            gate_up=True,
+            split_gate_up=True,
+        )
+        want = paddle.concat(
+            [
+                _ortho(self.gate)[:, :, self.cols],
+                _ortho(self.up)[:, :, self.cols],
+            ],
+            axis=-1,
+        )
+        self._assert_close(got, want)
+
+    def test_weight1_without_ffn_split_orthogonalises_fused_matrix(self):
+        got = ortho_ep_full_intermediate(
+            self._local_weight1(),
+            _ortho,
+            ep_group=self.ep_group,
+            shard_axis=-1,
+            gate_up=True,
+            split_gate_up=False,
+        )
+        fused = _ortho(paddle.concat([self.gate, self.up], axis=-1))
+        want = paddle.concat(
+            [
+                fused[:, :, self.cols],
+                fused[:, :, self.intermediate :][:, :, self.cols],
+            ],
+            axis=-1,
+        )
+        self._assert_close(got, want)
+
+    def test_weight2_uses_full_intermediate(self):
+        got = ortho_ep_full_intermediate(
+            self._local_weight2(),
+            _ortho,
+            ep_group=self.ep_group,
+            shard_axis=-2,
+        )
+        self._assert_close(got, _ortho(self.down)[:, self.cols, :])
+
+    def test_shard_local_orthogonalisation_would_differ(self):
+        """Guard: the pre-fix behaviour must not match, else nothing is proven."""
+        local = self._local_weight1()
+        naive = paddle.concat(
+            [
+                _ortho(local[:, :, : self.per_rank]),
+                _ortho(local[:, :, self.per_rank :]),
+            ],
+            axis=-1,
+        )
+        want = paddle.concat(
+            [
+                _ortho(self.gate)[:, :, self.cols],
+                _ortho(self.up)[:, :, self.cols],
+            ],
+            axis=-1,
+        )
+        self.assertGreater(float((naive - want).abs().max()), 1e-6)
+
+    def test_rejects_missing_ep_group(self):
+        with self.assertRaises(ValueError):
+            ortho_ep_full_intermediate(
+                self._local_weight2(), _ortho, ep_group=None, shard_axis=-2
+            )
+
+    def test_rejects_non_3d_weight(self):
+        with self.assertRaises(ValueError):
+            ortho_ep_full_intermediate(
+                paddle.randn([self.hidden, self.intermediate]).astype(DTYPE),
+                _ortho,
+                ep_group=self.ep_group,
+                shard_axis=-1,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/ai_edited_test/moe/test_ai_allgather_dispatcher.py
+++ b/tests/single_card_tests/ai_edited_test/moe/test_ai_allgather_dispatcher.py
@@ -1530,7 +1530,17 @@ class TestGroupedMLPExpertShardedStateDict(unittest.TestCase):
         """Duck-typed expert for direct method testing."""
         from paddlefleet.transformer.moe.moe_expert import GroupedMLPExpert
 
-        e = type("E", (), {})()
+        # ``intermediate_ep_sharded`` is a property on the real class, and
+        # sharded_state_dict routes on it, so the stand-in has to carry it too;
+        # attaching it to the class keeps it dynamic (a test that flips
+        # ``config.moe_token_dispatcher_type`` afterwards still takes effect).
+        e = type(
+            "E",
+            (),
+            {
+                "intermediate_ep_sharded": GroupedMLPExpert.intermediate_ep_sharded
+            },
+        )()
         e._get_intermediate_sharded_state_dict = (
             GroupedMLPExpert._get_intermediate_sharded_state_dict.__get__(e)
         )

--- a/tests/single_card_tests/transformer/test_muon_slice_specs.py
+++ b/tests/single_card_tests/transformer/test_muon_slice_specs.py
@@ -42,6 +42,7 @@ from paddlefleet.transformer.multi_latent_attention import (
 )
 from paddlefleet.transformer.muon_utils import (
     ortho_blocks,
+    ortho_ep_full_intermediate,
     ortho_gate_up,
     ortho_per_head,
     ortho_qkv_contiguous,
@@ -535,10 +536,18 @@ class TestMLPSpecs(unittest.TestCase):
 
 
 class TestGroupedMLPExpertSpecs(unittest.TestCase):
+    @staticmethod
+    def _fake(gated=True, ep_sharded=False):
+        """Stand-in layer. ``ep_group`` is only forwarded, never called here."""
+        return SimpleNamespace(
+            config=SimpleNamespace(gated_linear_unit=gated),
+            intermediate_ep_sharded=ep_sharded,
+            ep_group=SimpleNamespace(nranks=2),
+        )
+
     def test_gated_with_ffn_split(self):
-        fake = SimpleNamespace(config=SimpleNamespace(gated_linear_unit=True))
         specs = GroupedMLPExpert.muon_slice_specs(
-            fake, {"muon_ffn_split": True}
+            self._fake(), {"muon_ffn_split": True}
         )
         self.assertEqual(set(specs), {"weight1", "weight2"})
         _run_specs(
@@ -547,11 +556,40 @@ class TestGroupedMLPExpertSpecs(unittest.TestCase):
         )
 
     def test_non_gated_keeps_weight2_only(self):
-        fake = SimpleNamespace(config=SimpleNamespace(gated_linear_unit=False))
         specs = GroupedMLPExpert.muon_slice_specs(
-            fake, {"muon_ffn_split": True}
+            self._fake(gated=False), {"muon_ffn_split": True}
         )
         self.assertEqual(set(specs), {"weight2"})
+
+    def test_ep_sharded_routes_both_weights(self):
+        """An EP-sharded rank must redistribute instead of slicing locally."""
+        for ffn_split in (True, False):
+            with self.subTest(muon_ffn_split=ffn_split):
+                fake = self._fake(ep_sharded=True)
+                specs = GroupedMLPExpert.muon_slice_specs(
+                    fake, {"muon_ffn_split": ffn_split}
+                )
+                self.assertEqual(set(specs), {"weight1", "weight2"})
+
+                fn, kwargs = specs["weight1"]
+                self.assertIs(fn, ortho_ep_full_intermediate)
+                self.assertIs(kwargs["ep_group"], fake.ep_group)
+                self.assertEqual(kwargs["shard_axis"], -1)
+                self.assertTrue(kwargs["gate_up"])
+                # muon_ffn_split keeps deciding gate/up independence
+                self.assertEqual(kwargs["split_gate_up"], ffn_split)
+
+                fn, kwargs = specs["weight2"]
+                self.assertIs(fn, ortho_ep_full_intermediate)
+                self.assertIs(kwargs["ep_group"], fake.ep_group)
+                self.assertEqual(kwargs["shard_axis"], -2)
+                self.assertNotIn("gate_up", kwargs)
+
+    def test_ep_sharded_non_gated_has_no_fused_gate_up(self):
+        specs = GroupedMLPExpert.muon_slice_specs(
+            self._fake(gated=False, ep_sharded=True), {"muon_ffn_split": True}
+        )
+        self.assertFalse(specs["weight1"][1]["gate_up"])
 
 
 class TestCSASpecs(unittest.TestCase):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
#### Problem

  With `moe_token_dispatcher_type="allgather"` and EP > 1, every rank holds all experts but only `moe_intermediate_size // EP` of each one's intermediate dim (`weight1: [E, H, 2I/EP]`, `weight2: [E, I/EP, H]`).

  `GroupedMLPExpert.muon_slice_specs` orthogonalised those local shards directly, so Newton-Schulz ran on a slab of each expert matrix instead of the matrix itself — the Muon update did not match a non-EP run.

  #### Fix

  - `muon_utils.ortho_ep_full_intermediate`: all-to-all into the traditional EP layout (`E // EP` experts, full intermediate), orthogonalise there, send the result back the same way.
  - `GroupedMLPExpert` routes `weight1` / `weight2` through it when its intermediate dim is EP-sharded; other layouts are unchanged.
  - `muon_ffn_split` still controls whether gate and up are orthogonalised independently or as one fused matrix.

  `SonicMoEExpert` inherits the fix.

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
是