### PR TITLE
[Operator Mechanism] Enable FA3 cutedsl on SM90

### DIFF
--- a/packages/paddlefleet_ops/src/paddlefleet_ops/__init__.py
+++ b/packages/paddlefleet_ops/src/paddlefleet_ops/__init__.py
@@ -176,7 +176,7 @@ else:
 
 FLASH_MASK_HINT = (
     "For developers: guard imports with `is_flash_mask_available()` and only call `paddlefleet_ops.flash_mask` when flag branch enabled.\n"
-    "For users: use a GPU with compute capability >= 10.0 (Blackwell) to enable."
+    "For users: use a GPU with compute capability >= 9.0 (Hopper or Blackwell) to enable."
 )
 
 
@@ -438,7 +438,7 @@ if paddle.is_compiled_with_cuda():
     if is_flash_mask_available():
         _safe_load_ecosystem_lib("flash_mask", ops_dir, globals())
     else:
-        warning, error = _blackwell_requirement(
+        warning, error = _hopper_requirement(
             "paddlefleet_ops.flash_mask", hint=FLASH_MASK_HINT
         )
         logger.warning(warning)

--- a/packages/paddlefleet_ops/src/paddlefleet_ops/__init__.py
+++ b/packages/paddlefleet_ops/src/paddlefleet_ops/__init__.py
@@ -253,10 +253,9 @@ if paddle.is_compiled_with_cuda():
         _DEEP_EP_AVAILABLE = True
         _FLASH_MLA_AVAILABLE = True
         _MOON_EP_AVAILABLE = True
+        _FLASH_MASK_AVAILABLE = True
         if _cuda_version >= (12, 9):
             _HYBRID_EP_AVAILABLE = True
-    if paddle.cuda.get_device_capability()[0] >= 10:
-        _FLASH_MASK_AVAILABLE = True
     if (
         sys.version_info >= (3, 12)
         and paddle.cuda.get_device_capability()[0] >= 10

--- a/packages/paddlefleet_ops/src/paddlefleet_ops/flash_mask_facade.py
+++ b/packages/paddlefleet_ops/src/paddlefleet_ops/flash_mask_facade.py
@@ -19,21 +19,38 @@ import paddle
 from . import is_flash_mask_available
 
 if is_flash_mask_available():
+    # ``_safe_load_ecosystem_lib`` already re-raises when ``flash_mask`` itself
+    # cannot be loaded, so only its submodules can still fail here. Swallowing
+    # that would leave ``get_fa_version()`` free to pick FA3/FA4 while
+    # ``_flash_attn_fwd`` is undefined -- fail loudly instead.
     try:
         from .flash_mask import (
             flash_attention as _flash_attention,
             flashmask_attention as _flashmask_attention,
         )
-    except (ImportError, ModuleNotFoundError):
+        from .flash_mask.cute.flashmask_utils import FlashMaskInfoPaddle
         from .flash_mask.cute.interface import (
-            flash_attention as _flash_attention,
-            flashmask_attention as _flashmask_attention,
+            _flash_attn_bwd,
+            _flash_attn_fwd,
         )
+        from .flash_mask.utils import bshd_slice_contiguous_kv
+    except (ImportError, AttributeError, RuntimeError) as exc:
+        raise ImportError(
+            "paddlefleet_ops reports flash_mask as available, but its cutedsl "
+            "interface failed to import, so FA3/FA4 dispatch would reference "
+            "undefined kernels. Install a paddlefleet_ops whose flash_mask "
+            "extension matches this paddlefleet."
+        ) from exc
 else:
     from paddle.nn.functional.flash_attention import (
         flash_attention as _flash_attention,
         flashmask_attention as _flashmask_attention,
     )
+
+    # ``get_fa_version()`` always returns 2 here, so these names exist only to
+    # keep the FA3/FA4 call sites' imports unconditional.
+    FlashMaskInfoPaddle = _flash_attn_fwd = _flash_attn_bwd = None
+    bshd_slice_contiguous_kv = None
 
 
 def get_fa_version(
@@ -299,4 +316,9 @@ __all__ = [
     "flash_attention",
     "get_fa_version",
     "is_value_padding_needed",
+    # cutedsl symbols re-exported for the FA3/FA4 call sites
+    "FlashMaskInfoPaddle",
+    "_flash_attn_fwd",
+    "_flash_attn_bwd",
+    "bshd_slice_contiguous_kv",
 ]

--- a/packages/paddlefleet_ops/src/paddlefleet_ops/flash_mask_facade.py
+++ b/packages/paddlefleet_ops/src/paddlefleet_ops/flash_mask_facade.py
@@ -46,6 +46,7 @@ def get_fa_version(
     Dispatch rules:
       * XPU device -> FA2.
       * Otherwise, respect ``FLAGS_flash_attn_version`` by default.
+      * FA3/FA4 need the cutedsl backend; without it -> FA2.
       * FA3 and FA4 both require ``hdim_ok``; FA4 additionally requires
         ``mask_ok``:
 
@@ -86,6 +87,13 @@ def get_fa_version(
     ]
 
     if fa_version in (3, 4):
+        # FA3/FA4 both run on the cutedsl backend. When ``paddlefleet_ops.
+        # flash_mask`` is not loadable (capability below 9.0, a mismatched
+        # paddlefleet_ops build, or a broken cute import) the kernels do not
+        # exist, so degrade here rather than letting call sites reference an
+        # undefined ``_flash_attn_fwd`` / ``_flash_attn_bwd``.
+        if not is_flash_mask_available():
+            return 2
         _head_dim_v = head_dim_v if head_dim_v is not None else head_dim
         cutedsl_hdim_ok = (
             (head_dim <= 128 and _head_dim_v <= 128)

--- a/packages/paddlefleet_ops/src/paddlefleet_ops/flash_mask_facade.py
+++ b/packages/paddlefleet_ops/src/paddlefleet_ops/flash_mask_facade.py
@@ -46,9 +46,8 @@ def get_fa_version(
     Dispatch rules:
       * XPU device -> FA2.
       * Otherwise, respect ``FLAGS_flash_attn_version`` by default.
-      * If ``fa_version == 3`` and deterministic is required, FA3 only supports
-        ``head_dim <= 128``. For ``head_dim > 128``, fall back to FA2.
-      * FA4 is only used when both ``hdim_ok`` and ``mask_ok`` hold:
+      * FA3 and FA4 both require ``hdim_ok``; FA4 additionally requires
+        ``mask_ok``:
 
         - ``hdim_ok``: one of
           * ``head_dim <= 128`` and ``head_dim_v <= 128``
@@ -86,31 +85,54 @@ def get_fa_version(
         "FLAGS_cudnn_deterministic"
     ]
 
-    if fa_version == 3:
-        if deterministic and head_dim > 128:
-            return 2
-
-    if fa_version == 4:
+    if fa_version in (3, 4):
         _head_dim_v = head_dim_v if head_dim_v is not None else head_dim
-        fa4_hdim_ok = (
+        cutedsl_hdim_ok = (
             (head_dim <= 128 and _head_dim_v <= 128)
             or (head_dim == 192 and _head_dim_v == 128)
             or (head_dim == 256 and _head_dim_v == 256)
-            # Both of these exceed 256 and so take FA4's big-head-dim backward,
-            # which asserts ``not deterministic`` (``flash_mask/cute/
-            # interface.py``: ``is_bigd_bwd`` -> "deterministic reduction is not
-            # supported by big-headdim bwd"). Degrade instead of aborting, the
-            # same way FA3 degrades above.
-            or (head_dim == 512 and _head_dim_v == 512 and not deterministic)
-            or (head_dim == 576 and _head_dim_v == 512 and not deterministic)
         )
+        # FA4 additionally supports larger head dims (non-deterministic only)
+        if fa_version == 4 and not deterministic:
+            cutedsl_hdim_ok = cutedsl_hdim_ok or (
+                (head_dim == 512 and _head_dim_v == 512)
+                or (head_dim == 576 and _head_dim_v == 512)
+            )
+        if not cutedsl_hdim_ok:
+            return 2
         fa4_mask_ok = (
             startend_row_indices is None or startend_row_indices.shape[-1] != 4
         )
-        if not (fa4_hdim_ok and fa4_mask_ok):
-            return 2
+        if fa_version == 4:
+            if not fa4_mask_ok:
+                return 2
 
     return fa_version
+
+
+def is_value_padding_needed(
+    fa_version: int,
+    head_dim: int,
+    head_dim_v: int,
+) -> bool:
+    """Whether ``value`` must be zero-padded from ``head_dim_v`` to ``head_dim``.
+
+    Args:
+        fa_version: The version returned by :func:`get_fa_version`.
+        head_dim: Query/Key head dim.
+        head_dim_v: Value head dim.
+
+    Returns:
+        ``True`` when ``value`` needs padding.
+    """
+    fa3_native_pair = (fa_version == 3) and (
+        head_dim == 192 and head_dim_v == 128
+    )
+    fa4_native_pair = (fa_version == 4) and (
+        (head_dim == 192 and head_dim_v == 128)
+        or (head_dim == 576 and head_dim_v == 512)
+    )
+    return head_dim != head_dim_v and not (fa3_native_pair or fa4_native_pair)
 
 
 def flashmask_attention(
@@ -144,10 +166,10 @@ def flashmask_attention(
             not in inspect.signature(_flashmask_attention).parameters
         ):
             raise NotImplementedError(
-                "learnable_sink (softmax sink) requires FA4 (cute backend); the "
-                "installed flash_mask / current device (e.g. H-card fa2/fa3) does "
-                "not support it. Disable the attention sink or run on a "
-                "FA4-capable device."
+                "learnable_sink (softmax sink) requires FA3 or FA4 (cutedsl "
+                "backend); the installed flash_mask / current device does not "
+                "support it. Disable the attention sink or run on a "
+                "FA3/FA4-capable device."
             )
 
     bsz, q_len, num_heads, q_head_dim = query.shape
@@ -155,19 +177,13 @@ def flashmask_attention(
 
     fa_version = get_fa_version(q_head_dim, v_head_dim, startend_row_indices)
 
-    need_value_padding = (
-        not (
-            fa_version == 4
-            and (
-                (q_head_dim == 192 and v_head_dim == 128)
-                or (q_head_dim == 576 and v_head_dim == 512)
-            )
-        )
-    ) and q_head_dim != v_head_dim
+    need_value_padding = is_value_padding_needed(
+        fa_version, q_head_dim, v_head_dim
+    )
 
     if need_value_padding:
         value_padding = paddle.zeros(
-            [bsz, q_len, value.shape[2], q_head_dim - v_head_dim],
+            [*value.shape[:-1], q_head_dim - v_head_dim],
             dtype=value.dtype,
         )
         value = paddle.concat([value, value_padding], axis=-1)
@@ -237,19 +253,13 @@ def flash_attention(
     # startend_row_indices is None
     fa_version = get_fa_version(q_head_dim, v_head_dim)
 
-    need_value_padding = (
-        not (
-            fa_version == 4
-            and (
-                (q_head_dim == 192 and v_head_dim == 128)
-                or (q_head_dim == 576 and v_head_dim == 512)
-            )
-        )
-    ) and q_head_dim != v_head_dim
+    need_value_padding = is_value_padding_needed(
+        fa_version, q_head_dim, v_head_dim
+    )
 
     if need_value_padding:
         value_padding = paddle.zeros(
-            [bsz, q_len, value.shape[2], q_head_dim - v_head_dim],
+            [*value.shape[:-1], q_head_dim - v_head_dim],
             dtype=value.dtype,
         )
         value = paddle.concat([value, value_padding], axis=-1)
@@ -280,4 +290,5 @@ __all__ = [
     "flashmask_attention",
     "flash_attention",
     "get_fa_version",
+    "is_value_padding_needed",
 ]

--- a/src/paddlefleet/context_parallel_utils.py
+++ b/src/paddlefleet/context_parallel_utils.py
@@ -19,28 +19,13 @@ from paddle import distributed as dist
 from paddle.autograd.py_layer import PyLayer
 from paddle.distributed import fleet
 from paddle.nn.functional.flash_attention import flashmask_attention
-from paddlefleet_ops import is_flash_mask_available
-from paddlefleet_ops.flash_mask_facade import get_fa_version
-
-_flash_mask_available = False
-try:
-    # Ask paddlefleet_ops rather than re-deriving the capability threshold: the
-    # blocker installed for an unavailable flash_mask raises RuntimeError (not
-    # ImportError) from its meta-path finder, so guessing wrong here takes the
-    # whole module import down instead of degrading to FA2.
-    if is_flash_mask_available():
-        from paddlefleet_ops.flash_mask.cute.flashmask_utils import (
-            FlashMaskInfoPaddle,
-        )
-        from paddlefleet_ops.flash_mask.cute.interface import (
-            _flash_attn_bwd,
-            _flash_attn_fwd,
-        )
-        from paddlefleet_ops.flash_mask.utils import bshd_slice_contiguous_kv
-
-        _flash_mask_available = True
-except (ImportError, AttributeError, RuntimeError):
-    _flash_mask_available = False
+from paddlefleet_ops.flash_mask_facade import (
+    FlashMaskInfoPaddle,
+    _flash_attn_bwd,
+    _flash_attn_fwd,
+    bshd_slice_contiguous_kv,
+    get_fa_version,
+)
 
 
 def mark_context_parallel_parameter_disable_scale_grad(param_or_layer):
@@ -1924,8 +1909,14 @@ def flashmask_attention_cp(
         hcg = fleet.get_hybrid_communicate_group()
         cp_group = hcg.get_context_parallel_group()
 
-        assert _flash_mask_available, (
-            "P2P SWA fast path requires flashmask installed. Please check."
+        q_head_dim = query.shape[-1]
+        v_head_dim = value.shape[-1]
+        fa_version = get_fa_version(
+            q_head_dim, v_head_dim, startend_row_indices
+        )
+
+        assert fa_version == 4, (
+            f"current fa version is {fa_version}, but P2P SWA fast path requires flashmask 4.0 installed. Please check."
         )
 
         return FlashMaskSwaP2P.apply(

--- a/src/paddlefleet/context_parallel_utils.py
+++ b/src/paddlefleet/context_parallel_utils.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import inspect
 
 import paddle
 import paddlefleet_ops.flash_mask_facade
@@ -26,7 +25,7 @@ _flash_mask_available = False
 try:
     if (
         paddle.cuda.is_available()
-        and paddle.cuda.get_device_capability()[0] == 10
+        and paddle.cuda.get_device_capability()[0] >= 9
     ):
         from paddlefleet_ops.flash_mask.cute.flashmask_utils import (
             FlashMaskInfoPaddle,
@@ -740,7 +739,7 @@ def cp_flashmask_allgatherkv_balance_forward(
     v_head_dim = value_gathered.shape[-1]
     fa_version = get_fa_version(q_head_dim, v_head_dim, startend_row_indices)
 
-    if fa_version == 4 and _flash_mask_available:
+    if fa_version in (3, 4):
         output, log_sum_exp = _flash_attn_fwd(
             query,
             key_gathered,
@@ -755,7 +754,7 @@ def cp_flashmask_allgatherkv_balance_forward(
     else:
         if learnable_sink is not None:
             raise NotImplementedError(
-                "learnable_sink only supported on fa_version==4 cute backend"
+                "learnable_sink only supported on fa3 or fa4 cute backend"
             )
         output, log_sum_exp = flashmask_attention(
             query,
@@ -827,7 +826,7 @@ def cp_flashmask_allgatherkv_balance_backward(
     if fa_version == 2:
         if learnable_sink is not None:
             raise NotImplementedError(
-                "learnable_sink only supported on fa_version==4 cute backend"
+                "learnable_sink only supported on fa3 or fa4 cute backend"
             )
         if softmax_scale is not None:
             raise NotImplementedError(
@@ -853,65 +852,7 @@ def cp_flashmask_allgatherkv_balance_backward(
                 causal,
             )
         )
-    elif fa_version == 3:
-        if learnable_sink is not None:
-            raise NotImplementedError(
-                "learnable_sink only supported on fa_version==4 cute backend"
-            )
-        sig_params = inspect.signature(flashmask_attention).parameters
-        if "group" in sig_params:
-            query_grad, key_grad_gathered, value_grad_gathered = (
-                paddle._C_ops.flashmask_attention_v2_grad(
-                    query,
-                    key_gathered,
-                    value_gathered,
-                    output,
-                    log_sum_exp,
-                    startend_row_indices,
-                    None,  # block_mask
-                    output_grad,
-                    query.shape[-1] ** (-0.5)
-                    if softmax_scale is None
-                    else softmax_scale,
-                    False,
-                    0,  # rank
-                    1,  # nranks
-                )
-            )
-        elif "block_mask" in sig_params:
-            query_grad, key_grad_gathered, value_grad_gathered = (
-                paddle._C_ops.flashmask_attention_v2_grad(
-                    query,
-                    key_gathered,
-                    value_gathered,
-                    output,
-                    log_sum_exp,
-                    startend_row_indices,
-                    None,  # block_mask
-                    output_grad,
-                    query.shape[-1] ** (-0.5)
-                    if softmax_scale is None
-                    else softmax_scale,
-                    False,
-                )
-            )
-        else:
-            query_grad, key_grad_gathered, value_grad_gathered = (
-                paddle._C_ops.flashmask_attention_v2_grad(
-                    query,
-                    key_gathered,
-                    value_gathered,
-                    output,
-                    log_sum_exp,
-                    startend_row_indices,
-                    output_grad,
-                    query.shape[-1] ** (-0.5)
-                    if softmax_scale is None
-                    else softmax_scale,
-                    False,
-                )
-            )
-    elif fa_version == 4 and _flash_mask_available:
+    elif fa_version in (3, 4):
         if startend_row_indices is not None:
             flashmask_info = FlashMaskInfoPaddle(
                 startend_row_indices=startend_row_indices,

--- a/src/paddlefleet/context_parallel_utils.py
+++ b/src/paddlefleet/context_parallel_utils.py
@@ -19,14 +19,16 @@ from paddle import distributed as dist
 from paddle.autograd.py_layer import PyLayer
 from paddle.distributed import fleet
 from paddle.nn.functional.flash_attention import flashmask_attention
+from paddlefleet_ops import is_flash_mask_available
 from paddlefleet_ops.flash_mask_facade import get_fa_version
 
 _flash_mask_available = False
 try:
-    if (
-        paddle.cuda.is_available()
-        and paddle.cuda.get_device_capability()[0] >= 9
-    ):
+    # Ask paddlefleet_ops rather than re-deriving the capability threshold: the
+    # blocker installed for an unavailable flash_mask raises RuntimeError (not
+    # ImportError) from its meta-path finder, so guessing wrong here takes the
+    # whole module import down instead of degrading to FA2.
+    if is_flash_mask_available():
         from paddlefleet_ops.flash_mask.cute.flashmask_utils import (
             FlashMaskInfoPaddle,
         )
@@ -37,7 +39,7 @@ try:
         from paddlefleet_ops.flash_mask.utils import bshd_slice_contiguous_kv
 
         _flash_mask_available = True
-except (ImportError, AttributeError):
+except (ImportError, AttributeError, RuntimeError):
     _flash_mask_available = False
 
 

--- a/src/paddlefleet/refined_recompute/flash_attn.py
+++ b/src/paddlefleet/refined_recompute/flash_attn.py
@@ -1051,9 +1051,9 @@ def ulysses_local_flashmask_first_fwd(
     fa_version = get_fa_version(
         query_states.shape[-1], value_states.shape[-1], startend_row_indices
     )
-    if learnable_sink is not None and fa_version != 4:
+    if learnable_sink is not None and fa_version not in (3, 4):
         raise NotImplementedError(
-            "learnable_sink only supported on fa_version==4 cute backend"
+            "learnable_sink only supported on fa3 or fa4 cute backend"
         )
     if fa_version == 2:
         if softmax_scale is not None:

--- a/src/paddlefleet/refined_recompute/flash_attn.py
+++ b/src/paddlefleet/refined_recompute/flash_attn.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import inspect
 import logging
 import queue
 
@@ -20,7 +19,6 @@ import paddle
 from paddle import _C_ops, framework
 from paddle.autograd import PyLayer
 from paddle.distributed import fleet
-from paddle.nn.functional.flash_attention import flashmask_attention
 from paddlefleet_ops import is_flash_mask_available
 from paddlefleet_ops.flash_mask_facade import get_fa_version
 
@@ -123,14 +121,7 @@ class FlashAttnFunctor(PyLayer):
                 dropout,
                 causal,
             )
-        elif fa_version == 3:
-            result_attention = hold_tensors["result_attention"]
-            softmax_lse = hold_tensors["softmax_lse"]
-            causal = hold_tensors["causal"]
-            ctx.save_for_backward(
-                q, k, v, result_attention, softmax_lse, causal
-            )
-        elif fa_version == 4:
+        elif fa_version in (3, 4):
             result_attention = hold_tensors["result_attention"]
             softmax_lse = hold_tensors["softmax_lse"]
             causal = hold_tensors["causal"]
@@ -185,25 +176,7 @@ class FlashAttnFunctor(PyLayer):
                 causal,
             )
             seed_offset._clear_dataptr()
-        elif fa_version == 3:
-            q, k, v, result_attention, softmax_lse, causal = ctx.saved_tensor()
-            q_grad, k_grad, v_grad = _C_ops.flash_attn_v3_grad(
-                q.detach(),
-                k.detach(),
-                v.detach(),
-                result_attention,
-                softmax_lse,
-                grad,
-                q.shape[-1] ** (-0.5)
-                if ctx.softmax_scale is None
-                else ctx.softmax_scale,  # softmax_scale
-                causal,
-                -1,  # window_size_left
-                -1,  # window_size_right
-                0.0,  # softcap
-                0,  # sm_margin
-            )
-        elif fa_version == 4:
+        elif fa_version in (3, 4):
             flashmask_info = None
             q, k, v, result_attention, softmax_lse, causal = ctx.saved_tensor()
             q_grad, k_grad, v_grad, _ = _flash_attn_bwd(
@@ -336,35 +309,7 @@ class RefinedRcomputeFlashAttention:
                 "dropout": dropout,
                 "causal": causal,
             }
-        elif fa_version == 3:
-            (result_attention, softmax_lse) = _C_ops.flash_attn_v3(
-                query_states,
-                key_states,
-                value_states,
-                None,
-                None,
-                None,
-                None,
-                query_states.shape[-1] ** (-0.5)
-                if softmax_scale is None
-                else softmax_scale,
-                causal,
-                -1,
-                -1,
-                0.0,
-                1,
-                False,
-                False,
-                0,
-            )
-            hold_tensors = {
-                "result_attention": result_attention,
-                "softmax_lse": softmax_lse,
-                "causal": causal,
-                "softmax_scale": softmax_scale,
-            }
-            result_softmax = None  # FA v3 does not return softmax.
-        elif fa_version == 4:
+        elif fa_version in (3, 4):
             (result_attention, softmax_lse) = _flash_attn_fwd(
                 query_states,
                 key_states,
@@ -455,20 +400,7 @@ class FlashMaskAttnFunctor(PyLayer):
                 dropout,
                 causal,
             )
-        elif fa_version == 3:
-            result_attention = hold_tensors["result_attention"]
-            softmax_lse = hold_tensors["softmax_lse"]
-            causal = hold_tensors["causal"]
-            ctx.save_for_backward(
-                q,
-                k,
-                v,
-                startend_row_indices,
-                result_attention,
-                softmax_lse,
-                causal,
-            )
-        elif fa_version == 4:
+        elif fa_version in (3, 4):
             result_attention = hold_tensors["result_attention"]
             softmax_lse = hold_tensors["softmax_lse"]
             causal = hold_tensors["causal"]
@@ -521,66 +453,7 @@ class FlashMaskAttnFunctor(PyLayer):
                 causal,
             )
             seed_offset._clear_dataptr()
-        elif fa_version == 3:
-            (
-                q,
-                k,
-                v,
-                startend_row_indices,
-                result_attention,
-                softmax_lse,
-                causal,
-            ) = ctx.saved_tensor()
-
-            sig_params = inspect.signature(flashmask_attention).parameters
-
-            softmax_scale = (
-                q.shape[-1] ** (-0.5)
-                if ctx.softmax_scale is None
-                else ctx.softmax_scale
-            )
-
-            if "group" in sig_params:
-                q_grad, k_grad, v_grad = _C_ops.flashmask_attention_v2_grad(
-                    q.detach(),
-                    k.detach(),
-                    v.detach(),
-                    result_attention,
-                    softmax_lse,
-                    startend_row_indices,
-                    None,  # block_mask
-                    grad,
-                    softmax_scale,
-                    causal,
-                    0,  # rank
-                    1,  # nranks
-                )
-            elif "block_mask" in sig_params:
-                q_grad, k_grad, v_grad = _C_ops.flashmask_attention_v2_grad(
-                    q.detach(),
-                    k.detach(),
-                    v.detach(),
-                    result_attention,
-                    softmax_lse,
-                    startend_row_indices,
-                    None,  # block_mask
-                    grad,
-                    softmax_scale,
-                    causal,
-                )
-            else:
-                q_grad, k_grad, v_grad = _C_ops.flashmask_attention_v2_grad(
-                    q.detach(),
-                    k.detach(),
-                    v.detach(),
-                    result_attention,
-                    softmax_lse,
-                    startend_row_indices,
-                    grad,
-                    softmax_scale,
-                    causal,
-                )
-        elif fa_version == 4:
+        elif fa_version in (3, 4):
             (
                 q,
                 k,
@@ -668,9 +541,9 @@ class RefinedRcomputeFlashMaskAttention:
                 value_states.shape[-1],
                 startend_row_indices,
             )
-            if fa_version != 4:
+            if fa_version not in (3, 4):
                 raise NotImplementedError(
-                    "learnable_sink only supported on fa_version==4 cute backend"
+                    "learnable_sink only supported on fa3 or fa4 cute backend"
                 )
         if not framework._dygraph_tracer()._has_grad:
             # This is the initial, normal forward pass.
@@ -752,52 +625,7 @@ class RefinedRcomputeFlashMaskAttention:
                 "dropout": dropout,
                 "causal": causal,
             }
-        elif fa_version == 3:
-            sig_params = inspect.signature(flashmask_attention).parameters
-            scale = (
-                query_states.shape[-1] ** (-0.5)
-                if softmax_scale is None
-                else softmax_scale
-            )
-            if "group" in sig_params:
-                (result_attention, softmax_lse) = _C_ops.flashmask_attention_v2(
-                    query_states,
-                    key_states,
-                    value_states,
-                    startend_row_indices,
-                    None,  # block_mask
-                    None,  # nvshmem unique id
-                    scale,
-                    causal,
-                    0,  # rank
-                    1,  # nranks
-                )
-            elif "block_mask" in sig_params:
-                (result_attention, softmax_lse) = _C_ops.flashmask_attention_v2(
-                    query_states,
-                    key_states,
-                    value_states,
-                    startend_row_indices,
-                    None,  # block_mask
-                    scale,
-                    causal,
-                )
-            else:
-                (result_attention, softmax_lse) = _C_ops.flashmask_attention_v2(
-                    query_states,
-                    key_states,
-                    value_states,
-                    startend_row_indices,
-                    scale,
-                    causal,
-                )
-            hold_tensors = {
-                "result_attention": result_attention,
-                "softmax_lse": softmax_lse,
-                "causal": causal,
-                "softmax_scale": softmax_scale,
-            }
-        elif fa_version == 4:
+        elif fa_version in (3, 4):
             (result_attention, softmax_lse) = _flash_attn_fwd(
                 query_states,
                 key_states,
@@ -1044,54 +872,7 @@ class FlashMaskUlyssesCpFunctor(PyLayer):
                 causal,
             )
             seed_offset._clear_dataptr()
-        elif ctx.fa_version == 3:
-            sig_params = inspect.signature(flashmask_attention).parameters
-            scale = (
-                q.shape[-1] ** (-0.5)
-                if ctx.softmax_scale is None
-                else ctx.softmax_scale
-            )
-            if "group" in sig_params:
-                q_grad, k_grad, v_grad = _C_ops.flashmask_attention_v2_grad(
-                    q.detach(),
-                    k.detach(),
-                    v.detach(),
-                    result_attention,
-                    softmax_lse,
-                    startend_row_indices,
-                    None,
-                    local_grad,
-                    scale,
-                    causal,
-                    0,
-                    1,
-                )
-            elif "block_mask" in sig_params:
-                q_grad, k_grad, v_grad = _C_ops.flashmask_attention_v2_grad(
-                    q.detach(),
-                    k.detach(),
-                    v.detach(),
-                    result_attention,
-                    softmax_lse,
-                    startend_row_indices,
-                    None,
-                    local_grad,
-                    scale,
-                    causal,
-                )
-            else:
-                q_grad, k_grad, v_grad = _C_ops.flashmask_attention_v2_grad(
-                    q.detach(),
-                    k.detach(),
-                    v.detach(),
-                    result_attention,
-                    softmax_lse,
-                    startend_row_indices,
-                    local_grad,
-                    scale,
-                    causal,
-                )
-        elif ctx.fa_version == 4:
+        elif ctx.fa_version in (3, 4):
             if startend_row_indices is not None:
                 flashmask_info = FlashMaskInfoPaddle(
                     startend_row_indices=startend_row_indices,
@@ -1301,52 +1082,7 @@ def ulysses_local_flashmask_first_fwd(
             "dropout": 0.0,
             "causal": causal,
         }
-    elif fa_version == 3:
-        sig_params = inspect.signature(flashmask_attention).parameters
-        scale = (
-            query_states.shape[-1] ** (-0.5)
-            if softmax_scale is None
-            else softmax_scale
-        )
-        if "group" in sig_params:
-            result_attention, softmax_lse = _C_ops.flashmask_attention_v2(
-                query_states,
-                key_states,
-                value_states,
-                startend_row_indices,
-                None,
-                None,
-                scale,
-                causal,
-                0,
-                1,
-            )
-        elif "block_mask" in sig_params:
-            result_attention, softmax_lse = _C_ops.flashmask_attention_v2(
-                query_states,
-                key_states,
-                value_states,
-                startend_row_indices,
-                None,
-                scale,
-                causal,
-            )
-        else:
-            result_attention, softmax_lse = _C_ops.flashmask_attention_v2(
-                query_states,
-                key_states,
-                value_states,
-                startend_row_indices,
-                scale,
-                causal,
-            )
-        hold_tensors = {
-            "result_attention": result_attention,
-            "softmax_lse": softmax_lse,
-            "causal": causal,
-            "softmax_scale": softmax_scale,
-        }
-    elif fa_version == 4:
+    elif fa_version in (3, 4):
         result_attention, softmax_lse = _flash_attn_fwd(
             query_states,
             key_states,
@@ -1408,9 +1144,9 @@ class RefinedRcomputeFlashMaskCpAttention:
                 value_states.shape[-1],
                 startend_row_indices,
             )
-            if not fa_version == 4:
+            if fa_version not in (3, 4):
                 raise NotImplementedError(
-                    "learnable_sink only supported on fa_version==4 cute backend"
+                    "learnable_sink only supported on fa3 or fa4 cute backend"
                 )
         if not framework._dygraph_tracer()._has_grad:
             # This is the initial, normal forward pass.

--- a/src/paddlefleet/refined_recompute/flash_attn.py
+++ b/src/paddlefleet/refined_recompute/flash_attn.py
@@ -20,7 +20,12 @@ from paddle import _C_ops, framework
 from paddle.autograd import PyLayer
 from paddle.distributed import fleet
 from paddlefleet_ops import is_flash_mask_available
-from paddlefleet_ops.flash_mask_facade import get_fa_version
+from paddlefleet_ops.flash_mask_facade import (
+    FlashMaskInfoPaddle,
+    _flash_attn_bwd,
+    _flash_attn_fwd,
+    get_fa_version,
+)
 
 from paddlefleet.context_parallel_utils import (
     UlyssesAlltoAll,
@@ -33,15 +38,6 @@ from paddlefleet.context_parallel_utils import (
     cp_flashmask_swa_p2p_forward,
 )
 from paddlefleet.refined_recompute.queue_check import global_rr_queue_log
-
-if is_flash_mask_available():
-    from paddlefleet_ops.flash_mask.cute.flashmask_utils import (
-        FlashMaskInfoPaddle,
-    )
-    from paddlefleet_ops.flash_mask.cute.interface import (
-        _flash_attn_bwd,
-        _flash_attn_fwd,
-    )
 
 logger = logging.getLogger(__name__)
 

--- a/src/paddlefleet/transformer/dot_product_attention.py
+++ b/src/paddlefleet/transformer/dot_product_attention.py
@@ -33,6 +33,7 @@ from paddlefleet_ops.flash_mask_facade import (
     flash_attention,
     flashmask_attention,
     get_fa_version,
+    is_value_padding_needed,
 )
 
 from paddlefleet.context_parallel_utils import (
@@ -788,22 +789,15 @@ class DotProductAttention(FleetLayer):
                 q_head_dim, v_head_dim, attn_mask_startend_row_indices
             )
 
-            need_value_padding = (
-                not (
-                    fa_version == 4
-                    and (
-                        (q_head_dim == 192 and v_head_dim == 128)
-                        or (q_head_dim == 576 and v_head_dim == 512)
-                    )
-                )
-            ) and q_head_dim != v_head_dim
+            need_value_padding = is_value_padding_needed(
+                fa_version, q_head_dim, v_head_dim
+            )
 
             if need_value_padding:
                 # Pad value to match query head_dim
-                # value: [b, s, h, v_head_dim] -> [b, s, h, q_head_dim]
-                bsz, seq_len, num_heads, _ = value.shape
+                # value: [b, s_kv, h, v_head_dim] -> [b, s_kv, h, q_head_dim]
                 value_padding = paddle.zeros(
-                    [bsz, seq_len, num_heads, q_head_dim - v_head_dim],
+                    [*value.shape[:-1], q_head_dim - v_head_dim],
                     dtype=value.dtype,
                 )
                 value_padded = paddle.concat([value, value_padding], axis=-1)

--- a/tests/multi_card_tests/transformer/test_flash_mask_cp_a2a.py
+++ b/tests/multi_card_tests/transformer/test_flash_mask_cp_a2a.py
@@ -312,8 +312,9 @@ def _mocked_kernel():
             ("_flash_attn_bwd", _mock_flash_attn_bwd),
             ("FlashMaskInfoPaddle", _FakeFlashMaskInfo),
         ):
-            # create=True: these names only exist when the cute backend does.
-            stack.enter_context(patch.object(rr_fa, name, impl, create=True))
+            # These come from ``flash_mask_facade``; on FA2-only devices they
+            # are bound to ``None`` rather than to the cute kernels.
+            stack.enter_context(patch.object(rr_fa, name, impl))
         yield
 
 

--- a/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_context_parallel_flashmask_modes.py
+++ b/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_context_parallel_flashmask_modes.py
@@ -20,6 +20,7 @@ import unittest
 from unittest.mock import patch
 
 import paddle
+import paddlefleet_ops
 
 REPO_ROOT = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "..", "..", "..", "..")
@@ -81,74 +82,128 @@ def assert_tensor_equal(testcase, actual, expected):
     testcase.assertTrue(bool((actual == expected).all().item()))
 
 
-class TestFlashMaskImportPath(unittest.TestCase):
-    def test_sm100_imports_vendored_flashmask_utils(self):
-        def fake_flash_attn_fwd(*args, **kwargs):
-            return None
+def fake_kernel(*args, **kwargs):
+    return None
 
-        def fake_flash_attn_bwd(*args, **kwargs):
-            return None
 
-        def fake_slice(*args, **kwargs):
-            return None
+def fake_module(name, is_package=False):
+    module = types.ModuleType(name)
+    if is_package:
+        module.__path__ = []
+    return module
 
-        def fake_module(name, is_package=False):
-            module = types.ModuleType(name)
-            if is_package:
-                module.__path__ = []
-            return module
 
-        fake_modules = {
-            "paddlefleet_ops.flash_mask": fake_module(
-                "paddlefleet_ops.flash_mask", is_package=True
-            ),
-            "paddlefleet_ops.flash_mask.cute": fake_module(
-                "paddlefleet_ops.flash_mask.cute", is_package=True
-            ),
-            "paddlefleet_ops.flash_mask.cute.flashmask_utils": fake_module(
-                "paddlefleet_ops.flash_mask.cute.flashmask_utils"
-            ),
-            "paddlefleet_ops.flash_mask.cute.interface": fake_module(
-                "paddlefleet_ops.flash_mask.cute.interface"
-            ),
-            "paddlefleet_ops.flash_mask.utils": fake_module(
-                "paddlefleet_ops.flash_mask.utils", is_package=True
-            ),
-        }
-        fake_modules[
-            "paddlefleet_ops.flash_mask.cute.flashmask_utils"
-        ].FlashMaskInfoPaddle = FakeFlashMaskInfoPaddle
-        fake_modules[
-            "paddlefleet_ops.flash_mask.cute.interface"
-        ]._flash_attn_fwd = fake_flash_attn_fwd
-        fake_modules[
-            "paddlefleet_ops.flash_mask.cute.interface"
-        ]._flash_attn_bwd = fake_flash_attn_bwd
-        fake_modules[
+def fake_flash_mask_modules(with_kernels=True):
+    """Stub out the ``paddlefleet_ops.flash_mask`` ecosystem library tree."""
+    modules = {
+        name: fake_module(name, is_package)
+        for name, is_package in (
+            ("paddlefleet_ops.flash_mask", True),
+            ("paddlefleet_ops.flash_mask.cute", True),
+            ("paddlefleet_ops.flash_mask.cute.flashmask_utils", False),
+            ("paddlefleet_ops.flash_mask.cute.interface", False),
+            ("paddlefleet_ops.flash_mask.utils", True),
+        )
+    }
+    # The two public entry points come from the top-level package and the
+    # cutedsl kernels from the cute submodules -- same split as the facade.
+    flash_mask = modules["paddlefleet_ops.flash_mask"]
+    flash_mask.flash_attention = fake_kernel
+    flash_mask.flashmask_attention = fake_kernel
+    modules[
+        "paddlefleet_ops.flash_mask.cute.flashmask_utils"
+    ].FlashMaskInfoPaddle = FakeFlashMaskInfoPaddle
+    if with_kernels:
+        interface = modules["paddlefleet_ops.flash_mask.cute.interface"]
+        interface._flash_attn_fwd = fake_kernel
+        interface._flash_attn_bwd = fake_kernel
+        modules[
             "paddlefleet_ops.flash_mask.utils"
-        ].bshd_slice_contiguous_kv = fake_slice
+        ].bshd_slice_contiguous_kv = fake_bshd_slice_contiguous_kv
+    return modules
 
-        module_path = os.path.join(
-            REPO_ROOT, "src", "paddlefleet", "context_parallel_utils.py"
-        )
+
+class TestFlashMaskImportPath(unittest.TestCase):
+    """The cutedsl import guard lives in ``flash_mask_facade`` only.
+
+    ``context_parallel_utils`` and ``refined_recompute.flash_attn`` re-import
+    the kernels from the facade instead of repeating the guard, so exercising
+    the facade covers every FA3/FA4 dispatch site.
+    """
+
+    FACADE_PATH = os.path.join(
+        REPO_ROOT,
+        "packages",
+        "paddlefleet_ops",
+        "src",
+        "paddlefleet_ops",
+        "flash_mask_facade.py",
+    )
+
+    def _load_facade(self, name):
+        # The facade uses relative imports, so it has to be loaded as a
+        # ``paddlefleet_ops`` submodule for ``from .flash_mask`` to resolve.
         spec = importlib.util.spec_from_file_location(
-            "_test_context_parallel_utils_sm100", module_path
+            f"paddlefleet_ops.{name}", self.FACADE_PATH
         )
-        module = importlib.util.module_from_spec(spec)
+        return spec, importlib.util.module_from_spec(spec)
+
+    def test_sm100_imports_vendored_flashmask_utils(self):
+        spec, module = self._load_facade("_test_facade_sm100")
         with (
-            patch.dict(sys.modules, fake_modules),
-            patch.object(paddle.cuda, "is_available", return_value=True),
+            patch.dict(sys.modules, fake_flash_mask_modules()),
             patch.object(
-                paddle.cuda, "get_device_capability", return_value=(10, 0)
+                paddlefleet_ops, "is_flash_mask_available", lambda: True
             ),
         ):
             spec.loader.exec_module(module)
 
-        self.assertTrue(module._flash_mask_available)
         self.assertIs(module.FlashMaskInfoPaddle, FakeFlashMaskInfoPaddle)
-        self.assertIs(module._flash_attn_fwd, fake_flash_attn_fwd)
-        self.assertIs(module._flash_attn_bwd, fake_flash_attn_bwd)
-        self.assertIs(module.bshd_slice_contiguous_kv, fake_slice)
+        self.assertIs(module._flash_attn_fwd, fake_kernel)
+        self.assertIs(module._flash_attn_bwd, fake_kernel)
+        self.assertIs(
+            module.bshd_slice_contiguous_kv, fake_bshd_slice_contiguous_kv
+        )
+
+    def test_cute_interface_import_failure_raises(self):
+        """A broken cute interface must fail the import, not degrade silently.
+
+        Swallowing it would leave ``get_fa_version()`` free to pick FA3/FA4 --
+        it only knows about CUDA and compute capability -- while the FA3/FA4
+        call sites never bound ``_flash_attn_fwd``.
+        """
+        # The package and both cute modules import fine; the interface simply
+        # does not export the kernels (a mismatched paddlefleet_ops build).
+        spec, module = self._load_facade("_test_facade_broken_cute")
+        with (
+            patch.dict(
+                sys.modules, fake_flash_mask_modules(with_kernels=False)
+            ),
+            patch.object(
+                paddlefleet_ops, "is_flash_mask_available", lambda: True
+            ),
+            self.assertRaises(ImportError) as ctx,
+        ):
+            spec.loader.exec_module(module)
+
+        self.assertIn("cutedsl interface failed to import", str(ctx.exception))
+
+    def test_fa2_only_device_binds_none_kernels(self):
+        """Without flashmask the cutedsl names exist but are ``None``.
+
+        They only keep the consumers' imports unconditional; ``get_fa_version``
+        degrades to FA2 here, so no call site ever reaches them.
+        """
+        spec, module = self._load_facade("_test_facade_fa2_only")
+        with patch.object(
+            paddlefleet_ops, "is_flash_mask_available", lambda: False
+        ):
+            spec.loader.exec_module(module)
+
+        self.assertIsNone(module.FlashMaskInfoPaddle)
+        self.assertIsNone(module._flash_attn_fwd)
+        self.assertIsNone(module._flash_attn_bwd)
+        self.assertIsNone(module.bshd_slice_contiguous_kv)
 
 
 class TestFlashMaskAllGatherModes(unittest.TestCase):
@@ -1057,7 +1112,7 @@ class TestFlashMaskSwaP2PPath(unittest.TestCase):
 
     def test_flashmask_attention_cp_requires_flashmask_for_p2p_mode(self):
         with (
-            patch.object(cp_utils, "_flash_mask_available", False),
+            patch.object(cp_utils, "is_flash_mask_available", lambda: False),
             patch.object(
                 cp_utils.fleet,
                 "get_hybrid_communicate_group",
@@ -1083,7 +1138,7 @@ class TestFlashMaskSwaP2PPath(unittest.TestCase):
             return result
 
         with (
-            patch.object(cp_utils, "_flash_mask_available", True),
+            patch.object(cp_utils, "is_flash_mask_available", lambda: True),
             patch.object(
                 cp_utils.fleet,
                 "get_hybrid_communicate_group",

--- a/tests/single_card_tests/ai_edited_test/distributed/test_ai_context_parallel_utils_3.py
+++ b/tests/single_card_tests/ai_edited_test/distributed/test_ai_context_parallel_utils_3.py
@@ -351,16 +351,18 @@ class TestCpFlashmaskForwardDeterministicOverride(unittest.TestCase):
     cp_flashmask_allgatherkv_balance_forward, which now delegates to
     ``flash_mask_facade.get_fa_version``.
 
-    Under FA3, deterministic mode only falls back to FA2 when head_dim > 128;
-    the ``block_mask`` signature no longer affects the decision.
+    Since FA3 moved to the cutedsl backend it shares FA4's head-dim table, so
+    the fallback to FA2 is driven by the (head_dim, head_dim_v) pair rather
+    than by ``deterministic``; the ``block_mask`` signature no longer affects
+    the decision either.
 
-      A) deterministic + hdim>128 -> override to 2
+      A) unsupported hdim pair -> override to 2
       B) deterministic + hdim<=128 -> no override (stays 3)
       C) deterministic + small hdim -> no override (stays 3)
       D) no deterministic -> no override (stays 3)
     """
 
-    def _run_forward(self, *, has_block_mask, deterministic, hdim, fa_flag=3):
+    def _run_forward(self, *, deterministic, hdim, fa_flag=3):
         from paddlefleet import context_parallel_utils as cpu
 
         group = mock.MagicMock()
@@ -372,41 +374,31 @@ class TestCpFlashmaskForwardDeterministicOverride(unittest.TestCase):
         value = paddle.randn([1, 4, 1, hdim])
         indices = paddle.randint(0, 4, [4, 2])
 
-        # Build a fake flashmask_attention whose inspect.signature carries or
-        # omits the `block_mask` parameter.
-        if has_block_mask:
+        # Used by the fa2 fallback branch.
+        def fake_flashmask(
+            q,
+            k,
+            v,
+            startend_row_indices=None,
+            causal=False,
+            return_softmax_lse=False,
+            training=False,
+            softmax_scale=None,
+        ):
+            return paddle.zeros_like(q), paddle.zeros([1, 1, 4])
 
-            def fake_flashmask(
-                q,
-                k,
-                v,
-                startend_row_indices=None,
-                causal=False,
-                return_softmax_lse=False,
-                training=False,
-                block_mask=None,
-                softmax_scale=None,
-            ):
-                return paddle.zeros_like(q), paddle.zeros([1, 1, 4])
-        else:
-
-            def fake_flashmask(
-                q,
-                k,
-                v,
-                startend_row_indices=None,
-                causal=False,
-                return_softmax_lse=False,
-                training=False,
-                softmax_scale=None,
-            ):
-                return paddle.zeros_like(q), paddle.zeros([1, 1, 4])
+        # Used by the shared fa3/fa4 cutedsl branch.
+        def fake_flash_attn_fwd(q, k, v, **kwargs):
+            return paddle.zeros_like(q), paddle.zeros([1, 1, 4])
 
         flags_base = {"FLAGS_flash_attn_version": fa_flag}
         flags_det = {"FLAGS_cudnn_deterministic": deterministic}
 
         with (
             mock.patch.object(cpu, "flashmask_attention", fake_flashmask),
+            mock.patch.object(
+                cpu, "_flash_attn_fwd", fake_flash_attn_fwd, create=True
+            ),
             mock.patch.object(
                 cpu, "all_gather_balance", side_effect=lambda t, axis, group: t
             ),
@@ -425,32 +417,24 @@ class TestCpFlashmaskForwardDeterministicOverride(unittest.TestCase):
             )
         return out[-1]  # fa_version
 
-    def test_branch_a_block_mask_det_hdim_gt_128(self):
-        """A) deterministic + hdim>128 -> 2."""
-        fa = self._run_forward(
-            has_block_mask=True, deterministic=True, hdim=192, fa_flag=3
-        )
+    def test_branch_a_unsupported_hdim_pair(self):
+        """A) 192/192 is not a cutedsl-supported pair -> 2."""
+        fa = self._run_forward(deterministic=True, hdim=192, fa_flag=3)
         self.assertEqual(fa, 2)
 
     def test_branch_b_block_mask_det_hdim_le_128(self):
         """B) deterministic but hdim<=128 -> no override."""
-        fa = self._run_forward(
-            has_block_mask=True, deterministic=True, hdim=128, fa_flag=3
-        )
+        fa = self._run_forward(deterministic=True, hdim=128, fa_flag=3)
         self.assertEqual(fa, 3)
 
     def test_branch_c_no_block_mask_deterministic(self):
         """C) deterministic + small hdim -> no override (stays 3)."""
-        fa = self._run_forward(
-            has_block_mask=False, deterministic=True, hdim=64, fa_flag=3
-        )
+        fa = self._run_forward(deterministic=True, hdim=64, fa_flag=3)
         self.assertEqual(fa, 3)
 
     def test_branch_d_no_block_mask_no_deterministic(self):
         """D) no deterministic -> no override."""
-        fa = self._run_forward(
-            has_block_mask=False, deterministic=False, hdim=64, fa_flag=3
-        )
+        fa = self._run_forward(deterministic=False, hdim=64, fa_flag=3)
         self.assertEqual(fa, 3)
 
 

--- a/tests/single_card_tests/ai_edited_test/distributed/test_ai_flash_attn.py
+++ b/tests/single_card_tests/ai_edited_test/distributed/test_ai_flash_attn.py
@@ -12,17 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""FA3/FA4 dispatch coverage for the flashmask backward/forward paths.
+
+Since FA3 was enabled on the cutedsl backend, ``fa_version`` 3 and 4 share a
+single branch that calls ``_flash_attn_fwd`` / ``_flash_attn_bwd`` instead of
+the old ``paddle._C_ops.flashmask_attention_v2*`` operators. These tests pin
+that dispatch down for both versions. The ``fa_version == 2`` branch is
+naturally covered by CI.
+"""
+
 import unittest
 from unittest.mock import MagicMock, patch
 
 import paddle
 
-# fmt: off
-# Parameters dicts used to control which branch the signature check enters.
-# The code does:  if "group" in sig_params  ->  elif "block_mask" in sig_params  ->  else
-_SIG_HAS_GROUP      = {"block_mask": MagicMock(), "group": MagicMock()}
-_SIG_HAS_BLOCK_MASK = {"block_mask": MagicMock()}
-# fmt: on
+_CUTEDSL_VERSIONS = (3, 4)
 
 
 # ---------------------------------------------------------------------------
@@ -31,14 +35,10 @@ _SIG_HAS_BLOCK_MASK = {"block_mask": MagicMock()}
 
 
 class TestCpFlashmaskBackwardDispatch(unittest.TestCase):
-    """Cover the "group" and "block_mask" branches in
-    cp_flashmask_allgatherkv_balance_backward (fa_version==3).
-    The "else" branch is naturally covered by CI."""
+    """fa_version 3 and 4 both reach ``_flash_attn_bwd`` in the CP backward."""
 
-    def _call_backward(self, sig_params):
-        from paddlefleet.context_parallel_utils import (
-            cp_flashmask_allgatherkv_balance_backward,
-        )
+    def _call_backward(self, fa_version):
+        from paddlefleet import context_parallel_utils as cpu
 
         B, S, H, D = 1, 8, 2, 16
         q = paddle.randn([B, S, H, D])
@@ -48,32 +48,24 @@ class TestCpFlashmaskBackwardDispatch(unittest.TestCase):
         out = paddle.randn([B, S, H, D])
         lse = paddle.randn([B, H, S])
         out_grad = paddle.randn([B, S, H, D])
-
-        config = MagicMock(fa_version=3, deterministic_mode=False)
-        group = MagicMock()
         dummy = paddle.randn([B, S, H, D])
-        mock_v2_grad = MagicMock(return_value=(dummy, dummy, dummy))
+
+        mock_bwd = MagicMock(return_value=(dummy, dummy, dummy, None))
+        mock_info = MagicMock(name="FlashMaskInfoPaddle")
 
         with (
-            patch(
-                "paddlefleet.context_parallel_utils.inspect.signature"
-            ) as mock_sig,
-            patch(
-                "paddlefleet.context_parallel_utils.all_gather_balance",
-                side_effect=lambda x, **kw: x,
+            patch.object(cpu, "_flash_attn_bwd", mock_bwd, create=True),
+            patch.object(cpu, "FlashMaskInfoPaddle", mock_info, create=True),
+            patch.object(
+                cpu, "all_gather_balance", side_effect=lambda x, **kw: x
             ),
-            patch(
-                "paddlefleet.context_parallel_utils.reduce_scatter_any_axis_balance",
+            patch.object(
+                cpu,
+                "reduce_scatter_any_axis_balance",
                 side_effect=lambda x, **kw: x,
-            ),
-            patch(
-                "paddle._C_ops.flashmask_attention_v2_grad",
-                mock_v2_grad,
-                create=True,
             ),
         ):
-            mock_sig.return_value.parameters = sig_params
-            cp_flashmask_allgatherkv_balance_backward(
+            cpu.cp_flashmask_allgatherkv_balance_backward(
                 q,
                 k,
                 v,
@@ -81,43 +73,77 @@ class TestCpFlashmaskBackwardDispatch(unittest.TestCase):
                 out,
                 lse,
                 out_grad,
-                None,
-                group,
-                False,
-                config.fa_version,
+                None,  # learnable_sink
+                MagicMock(),  # group
+                False,  # causal
+                fa_version,
                 None,  # softmax_scale
             )
 
-        return mock_v2_grad
+        return mock_bwd, mock_info
 
-    def test_group_branch(self):
-        m = self._call_backward(_SIG_HAS_GROUP)
-        args = m.call_args[0]
-        self.assertEqual(len(args), 12)
-        self.assertEqual(args[-2], 0)  # rank
-        self.assertEqual(args[-1], 1)  # nranks
+    def test_cutedsl_backward_dispatch(self):
+        for fa_version in _CUTEDSL_VERSIONS:
+            with self.subTest(fa_version=fa_version):
+                mock_bwd, mock_info = self._call_backward(fa_version)
 
-    def test_block_mask_branch(self):
-        m = self._call_backward(_SIG_HAS_BLOCK_MASK)
-        args = m.call_args[0]
-        self.assertEqual(len(args), 10)
-        self.assertIsNone(args[6])  # block_mask
+                mock_bwd.assert_called_once()
+                args, kwargs = mock_bwd.call_args
+                # q, k, v, out, out_grad, lse, flashmask_info
+                self.assertEqual(len(args), 7)
+                self.assertIs(args[6], mock_info.return_value)
+                self.assertIsNone(kwargs["learnable_sink"])
+                self.assertFalse(kwargs["causal"])
+                self.assertIsNone(kwargs["softmax_scale"])
+                self.assertIn("deterministic", kwargs)
+
+    def test_no_mask_skips_flashmask_info(self):
+        """``startend_row_indices is None`` passes ``flashmask_info=None``."""
+        from paddlefleet import context_parallel_utils as cpu
+
+        B, S, H, D = 1, 8, 2, 16
+        dummy = paddle.randn([B, S, H, D])
+        mock_bwd = MagicMock(return_value=(dummy, dummy, dummy, None))
+
+        with (
+            patch.object(cpu, "_flash_attn_bwd", mock_bwd, create=True),
+            patch.object(
+                cpu, "all_gather_balance", side_effect=lambda x, **kw: x
+            ),
+            patch.object(
+                cpu,
+                "reduce_scatter_any_axis_balance",
+                side_effect=lambda x, **kw: x,
+            ),
+        ):
+            cpu.cp_flashmask_allgatherkv_balance_backward(
+                dummy,
+                dummy,
+                dummy,
+                None,  # startend_row_indices
+                dummy,
+                paddle.randn([B, H, S]),
+                dummy,
+                None,
+                MagicMock(),
+                False,
+                4,
+                None,
+            )
+
+        self.assertIsNone(mock_bwd.call_args[0][6])
 
 
 # ---------------------------------------------------------------------------
-# 2) FlashMaskAttnFunctor.backward  (flash_attn)
+# 2) FlashMaskAttnFunctor.backward  (refined_recompute.flash_attn)
 # ---------------------------------------------------------------------------
 
 
 class TestFlashMaskAttnFunctorBackwardDispatch(unittest.TestCase):
-    """Cover the "group" and "block_mask" branches in
-    FlashMaskAttnFunctor.backward (fa_version==3).
-    The "else" branch is naturally covered by CI."""
+    """fa_version 3 and 4 both reach ``_flash_attn_bwd`` in the functor."""
 
-    def _call_backward(self, sig_params):
-        from paddlefleet.refined_recompute.flash_attn import (
-            FlashMaskAttnFunctor,
-        )
+    def _call_backward(self, fa_version):
+        from paddlefleet.refined_recompute import flash_attn as fa
 
         B, S, H, D = 1, 8, 2, 16
         q = paddle.randn([B, S, H, D])
@@ -133,67 +159,59 @@ class TestFlashMaskAttnFunctorBackwardDispatch(unittest.TestCase):
         lse._clear_dataptr = MagicMock()
 
         mock_ctx = MagicMock()
-        mock_ctx.fa_version = 3
+        mock_ctx.fa_version = fa_version
         mock_ctx.sink_requires_grad = False
-        mock_ctx.saved_tensor.return_value = (q, k, v, indices, out, lse, False)
+        mock_ctx.softmax_scale = None
+        # The cutedsl branch unpacks 8 items -- learnable_sink is now saved too.
+        mock_ctx.saved_tensor.return_value = (
+            q,
+            k,
+            v,
+            indices,
+            out,
+            lse,
+            False,
+            None,
+        )
 
-        mock_v2_grad = MagicMock(return_value=(dummy, dummy, dummy))
+        mock_bwd = MagicMock(return_value=(dummy, dummy, dummy, None))
+        mock_info = MagicMock(name="FlashMaskInfoPaddle")
 
         with (
-            patch(
-                "paddlefleet.refined_recompute.flash_attn.inspect.signature"
-            ) as mock_sig,
-            patch(
-                "paddlefleet.refined_recompute.flash_attn._C_ops.flashmask_attention_v2_grad",
-                mock_v2_grad,
-                create=True,
-            ),
+            patch.object(fa, "_flash_attn_bwd", mock_bwd, create=True),
+            patch.object(fa, "FlashMaskInfoPaddle", mock_info, create=True),
         ):
-            mock_sig.return_value.parameters = sig_params
-            FlashMaskAttnFunctor.backward(mock_ctx, grad)
+            grads = fa.FlashMaskAttnFunctor.backward(mock_ctx, grad)
 
-        return mock_v2_grad
+        return mock_bwd, mock_info, grads
 
-    def test_group_branch(self):
-        m = self._call_backward(_SIG_HAS_GROUP)
-        args = m.call_args[0]
-        self.assertEqual(len(args), 12)
-        self.assertEqual(args[-2], 0)  # rank
-        self.assertEqual(args[-1], 1)  # nranks
+    def test_cutedsl_backward_dispatch(self):
+        for fa_version in _CUTEDSL_VERSIONS:
+            with self.subTest(fa_version=fa_version):
+                mock_bwd, mock_info, grads = self._call_backward(fa_version)
 
-    def test_block_mask_branch(self):
-        m = self._call_backward(_SIG_HAS_BLOCK_MASK)
-        args = m.call_args[0]
-        self.assertEqual(len(args), 10)
-        self.assertIsNone(args[6])  # block_mask
+                mock_bwd.assert_called_once()
+                args, kwargs = mock_bwd.call_args
+                # q, k, v, result_attention, grad, softmax_lse, flashmask_info
+                self.assertEqual(len(args), 7)
+                self.assertIs(args[6], mock_info.return_value)
+                self.assertIsNone(kwargs["learnable_sink"])
+                self.assertIsNone(kwargs["softmax_scale"])
+                self.assertIn("deterministic", kwargs)
+                # sink_requires_grad is False -> only q/k/v grads returned.
+                self.assertEqual(len(grads), 3)
 
 
 # ---------------------------------------------------------------------------
-# 3) RefinedRcomputeFlashMaskAttention._first_fwd  (flash_attn)
+# 3) RefinedRcomputeFlashMaskAttention._first_fwd  (refined_recompute.flash_attn)
 # ---------------------------------------------------------------------------
 
 
 class TestRefinedRecomputeFirstFwdDispatch(unittest.TestCase):
-    """Cover the "group" branch in RefinedRcomputeFlashMaskAttention._first_fwd
-    (fa_version==3). The "block_mask" and "else" branches are already covered
-    by test_ai_flash_attn.py."""
+    """fa_version 3 and 4 both reach ``_flash_attn_fwd`` in ``_first_fwd``."""
 
-    @patch("paddlefleet.refined_recompute.flash_attn.framework._dygraph_tracer")
-    @patch(
-        "paddlefleet.refined_recompute.flash_attn._C_ops.flashmask_attention_v2",
-        create=True,
-    )
-    @patch(
-        "paddlefleet.refined_recompute.flash_attn.get_fa_version",
-        return_value=3,
-    )
-    @patch("paddlefleet.refined_recompute.flash_attn.inspect.signature")
-    def test_group_branch(self, mock_sig, mock_version, mock_v2, mock_tracer):
-        mock_tracer_obj = MagicMock()
-        mock_tracer_obj._has_grad = False
-        mock_tracer.return_value = mock_tracer_obj
-
-        mock_sig.return_value.parameters = _SIG_HAS_GROUP
+    def _call_forward(self, fa_version):
+        from paddlefleet.refined_recompute import flash_attn as fa
 
         B, S, H, D = 1, 8, 2, 16
         q = paddle.randn([B, S, H, D], dtype=paddle.bfloat16)
@@ -201,22 +219,46 @@ class TestRefinedRecomputeFirstFwdDispatch(unittest.TestCase):
         v = paddle.randn([B, S, H, D], dtype=paddle.bfloat16)
         startend = paddle.zeros([B, 2, S], dtype="int64")
 
-        mock_v2.return_value = (
-            paddle.randn([B, S, H, D], dtype=paddle.bfloat16),
-            paddle.randn([B, H, S], dtype=paddle.float32),
+        mock_fwd = MagicMock(
+            return_value=(
+                paddle.randn([B, S, H, D], dtype=paddle.bfloat16),
+                paddle.randn([B, H, S], dtype=paddle.float32),
+            )
         )
 
-        from paddlefleet.refined_recompute.flash_attn import (
-            RefinedRcomputeFlashMaskAttention,
-        )
+        mock_tracer_obj = MagicMock()
+        mock_tracer_obj._has_grad = False
 
-        obj = RefinedRcomputeFlashMaskAttention()
-        obj.forward(q, k, v, startend, causal=False)
+        with (
+            patch.object(
+                fa.framework, "_dygraph_tracer", return_value=mock_tracer_obj
+            ),
+            patch.object(fa, "get_fa_version", return_value=fa_version),
+            patch.object(fa, "_flash_attn_fwd", mock_fwd, create=True),
+        ):
+            obj = fa.RefinedRcomputeFlashMaskAttention()
+            obj.forward(q, k, v, startend, causal=False)
+            hold = obj._hold_tensors_queue.get()
 
-        args = mock_v2.call_args[0]
-        self.assertEqual(len(args), 10)
-        self.assertEqual(args[-2], 0)  # rank
-        self.assertEqual(args[-1], 1)  # nranks
+        return mock_fwd, hold
+
+    def test_cutedsl_forward_dispatch(self):
+        for fa_version in _CUTEDSL_VERSIONS:
+            with self.subTest(fa_version=fa_version):
+                mock_fwd, hold = self._call_forward(fa_version)
+
+                mock_fwd.assert_called_once()
+                args, kwargs = mock_fwd.call_args
+                # q, k, v positionally, everything else by keyword.
+                self.assertEqual(len(args), 3)
+                self.assertFalse(kwargs["causal"])
+                self.assertTrue(kwargs["return_lse"])
+                self.assertFalse(kwargs["pack_gqa"])
+                self.assertIsNone(kwargs["learnable_sink"])
+                # The cutedsl branch stores sink/scale instead of seed_offset.
+                self.assertIn("learnable_sink", hold)
+                self.assertIn("softmax_scale", hold)
+                self.assertNotIn("seed_offset", hold)
 
 
 if __name__ == "__main__":

--- a/tests/single_card_tests/ai_edited_test/recompute/test_ai_flash_attn.py
+++ b/tests/single_card_tests/ai_edited_test/recompute/test_ai_flash_attn.py
@@ -173,14 +173,14 @@ class TestRefinedRcomputeFlashMaskAttention(unittest.TestCase):
         return_value=3,
     )
     @patch(
-        "paddlefleet.refined_recompute.flash_attn._C_ops.flashmask_attention_v2"
+        "paddlefleet.refined_recompute.flash_attn._flash_attn_fwd",
+        create=True,
     )
-    @patch("paddlefleet.refined_recompute.flash_attn.inspect.signature")
     @patch("paddlefleet.refined_recompute.flash_attn.framework._dygraph_tracer")
-    def test_first_fwd_version_3_with_block_mask(
-        self, mock_tracer, mock_sig, mock_flashmask_v2, mock_version
+    def test_first_fwd_version_3_uses_cutedsl(
+        self, mock_tracer, mock_flash_fwd, mock_version
     ):
-        """Test _first_fwd v3 with block_mask parameter in signature."""
+        """Test _first_fwd v3 dispatches to the cutedsl _flash_attn_fwd."""
         from paddlefleet.refined_recompute.flash_attn import (
             RefinedRcomputeFlashMaskAttention,
         )
@@ -189,16 +189,13 @@ class TestRefinedRcomputeFlashMaskAttention(unittest.TestCase):
         mock_tracer_obj._has_grad = False
         mock_tracer.return_value = mock_tracer_obj
 
-        # flashmask_attention has block_mask in its signature
-        mock_sig.return_value.parameters = {"block_mask": MagicMock()}
-
         q = paddle.randn([2, 4, 8], dtype=paddle.bfloat16)
         k = paddle.randn([2, 4, 8], dtype=paddle.bfloat16)
         v = paddle.randn([2, 4, 8], dtype=paddle.bfloat16)
         startend = paddle.to_tensor([0, 4, 8], dtype=paddle.int32)
         out = paddle.randn([2, 4, 8], dtype=paddle.bfloat16)
 
-        mock_flashmask_v2.return_value = (
+        mock_flash_fwd.return_value = (
             out,
             paddle.randn([2, 4], dtype=paddle.float32),
         )
@@ -206,45 +203,8 @@ class TestRefinedRcomputeFlashMaskAttention(unittest.TestCase):
         attn = RefinedRcomputeFlashMaskAttention()
         result = attn.forward(q, k, v, startend, causal=False)
         self.assertTrue(result is not None)
-
-    @patch(
-        "paddlefleet.refined_recompute.flash_attn.get_fa_version",
-        return_value=3,
-    )
-    @patch(
-        "paddlefleet.refined_recompute.flash_attn._C_ops.flashmask_attention_v2"
-    )
-    @patch("paddlefleet.refined_recompute.flash_attn.inspect.signature")
-    @patch("paddlefleet.refined_recompute.flash_attn.framework._dygraph_tracer")
-    def test_first_fwd_version_3_without_block_mask(
-        self, mock_tracer, mock_sig, mock_flashmask_v2, mock_version
-    ):
-        """Test _first_fwd v3 without block_mask parameter in signature."""
-        from paddlefleet.refined_recompute.flash_attn import (
-            RefinedRcomputeFlashMaskAttention,
-        )
-
-        mock_tracer_obj = MagicMock()
-        mock_tracer_obj._has_grad = False
-        mock_tracer.return_value = mock_tracer_obj
-
-        # flashmask_attention does NOT have block_mask in its signature
-        mock_sig.return_value.parameters = {"q": MagicMock()}
-
-        q = paddle.randn([2, 4, 8], dtype=paddle.bfloat16)
-        k = paddle.randn([2, 4, 8], dtype=paddle.bfloat16)
-        v = paddle.randn([2, 4, 8], dtype=paddle.bfloat16)
-        startend = paddle.to_tensor([0, 4, 8], dtype=paddle.int32)
-        out = paddle.randn([2, 4, 8], dtype=paddle.bfloat16)
-
-        mock_flashmask_v2.return_value = (
-            out,
-            paddle.randn([2, 4], dtype=paddle.float32),
-        )
-
-        attn = RefinedRcomputeFlashMaskAttention()
-        result = attn.forward(q, k, v, startend, causal=False)
-        self.assertTrue(result is not None)
+        mock_flash_fwd.assert_called_once()
+        self.assertTrue(mock_flash_fwd.call_args.kwargs["return_lse"])
 
 
 class TestFlashMaskAttnCpFunctor(unittest.TestCase):

--- a/tests/single_card_tests/ai_edited_test/recompute/test_ai_flash_attn_2.py
+++ b/tests/single_card_tests/ai_edited_test/recompute/test_ai_flash_attn_2.py
@@ -184,17 +184,20 @@ class TestRefinedRcomputeFlashAttentionFirstFwd(unittest.TestCase):
         "paddlefleet.refined_recompute.flash_attn.get_fa_version",
         return_value=3,
     )
-    @patch("paddlefleet.refined_recompute.flash_attn._C_ops.flash_attn_v3")
+    @patch(
+        "paddlefleet.refined_recompute.flash_attn._flash_attn_fwd",
+        create=True,
+    )
     @patch("paddlefleet.refined_recompute.flash_attn.framework._dygraph_tracer")
     def test_first_fwd_version_3(
-        self, mock_tracer, mock_flash_v3, mock_version
+        self, mock_tracer, mock_flash_fwd, mock_version
     ):
         """Test _first_fwd with version 3 puts tensors in queue."""
         mock_tracer_obj = MagicMock()
         mock_tracer_obj._has_grad = False
         mock_tracer.return_value = mock_tracer_obj
 
-        mock_flash_v3.return_value = (
+        mock_flash_fwd.return_value = (
             paddle.randn([2, 4, 8], dtype=paddle.bfloat16),
             paddle.randn([2, 4], dtype=paddle.float32),
         )
@@ -303,20 +306,19 @@ class TestRefinedRcomputeFlashMaskAttentionFirstFwdV3(unittest.TestCase):
         return_value=3,
     )
     @patch(
-        "paddlefleet.refined_recompute.flash_attn._C_ops.flashmask_attention_v2"
+        "paddlefleet.refined_recompute.flash_attn._flash_attn_fwd",
+        create=True,
     )
-    @patch("paddlefleet.refined_recompute.flash_attn.inspect.signature")
     @patch("paddlefleet.refined_recompute.flash_attn.framework._dygraph_tracer")
-    def test_first_fwd_v3_with_block_mask(
-        self, mock_tracer, mock_sig, mock_flash_v2, mock_version
+    def test_first_fwd_v3_uses_cutedsl(
+        self, mock_tracer, mock_flash_fwd, mock_version
     ):
-        """Test _first_fwd with v3 and block_mask parameter."""
+        """Test _first_fwd with v3 dispatches to the cutedsl kernel."""
         mock_tracer_obj = MagicMock()
         mock_tracer_obj._has_grad = False
         mock_tracer.return_value = mock_tracer_obj
-        mock_sig.return_value.parameters = {"block_mask": MagicMock()}
 
-        mock_flash_v2.return_value = (
+        mock_flash_fwd.return_value = (
             paddle.randn([2, 4, 8], dtype=paddle.bfloat16),
             paddle.randn([2, 4], dtype=paddle.float32),
         )
@@ -329,6 +331,7 @@ class TestRefinedRcomputeFlashMaskAttentionFirstFwdV3(unittest.TestCase):
 
         result = attn.forward(q, k, v, startend, causal=False)
         self.assertTrue(result is not None)
+        mock_flash_fwd.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/tests/single_card_tests/ai_edited_test/recompute/test_ai_flash_attn_7.py
+++ b/tests/single_card_tests/ai_edited_test/recompute/test_ai_flash_attn_7.py
@@ -101,7 +101,9 @@ class TestGetFAVersionGPU(unittest.TestCase):
 class TestGetFAVersionDeterministic(unittest.TestCase):
     """Tests for get_fa_version with deterministic mode (FA3).
 
-    FA3 only falls back to FA2 under deterministic mode when head_dim > 128.
+    Since FA3 moved to the cutedsl backend it shares FA4's head-dim table and
+    no longer degrades on ``deterministic`` alone -- it degrades to FA2 only
+    when the (head_dim, head_dim_v) pair is unsupported.
     """
 
     @patch(
@@ -113,12 +115,46 @@ class TestGetFAVersionDeterministic(unittest.TestCase):
         "paddlefleet_ops.flash_mask_facade.paddle.get_flags",
         return_value={"FLAGS_cudnn_deterministic": True},
     )
-    def test_deterministic_large_hdim_returns_2(
+    def test_deterministic_native_pair_keeps_3(
         self, mock_get_flags, mock_base_flags, mock_device
     ):
-        """Deterministic FA3 with hdim>128 falls back to version 2."""
+        """Deterministic FA3 keeps version 3 for the native 256/256 pair."""
         mock_base_flags.return_value = {"FLAGS_flash_attn_version": 3}
         result = get_fa_version(256)
+        self.assertEqual(result, 3)
+
+    @patch(
+        "paddlefleet_ops.flash_mask_facade.paddle.get_device",
+        return_value="gpu:0",
+    )
+    @patch("paddlefleet_ops.flash_mask_facade.paddle.base.framework.get_flags")
+    @patch(
+        "paddlefleet_ops.flash_mask_facade.paddle.get_flags",
+        return_value={"FLAGS_cudnn_deterministic": True},
+    )
+    def test_unsupported_hdim_returns_2(
+        self, mock_get_flags, mock_base_flags, mock_device
+    ):
+        """FA3 falls back to version 2 for an unsupported head_dim."""
+        mock_base_flags.return_value = {"FLAGS_flash_attn_version": 3}
+        result = get_fa_version(160)
+        self.assertEqual(result, 2)
+
+    @patch(
+        "paddlefleet_ops.flash_mask_facade.paddle.get_device",
+        return_value="gpu:0",
+    )
+    @patch("paddlefleet_ops.flash_mask_facade.paddle.base.framework.get_flags")
+    @patch(
+        "paddlefleet_ops.flash_mask_facade.paddle.get_flags",
+        return_value={"FLAGS_cudnn_deterministic": True},
+    )
+    def test_deterministic_big_hdim_returns_2(
+        self, mock_get_flags, mock_base_flags, mock_device
+    ):
+        """The 512/512 big-head-dim pair stays FA4-only, so FA3 degrades."""
+        mock_base_flags.return_value = {"FLAGS_flash_attn_version": 3}
+        result = get_fa_version(512, 512)
         self.assertEqual(result, 2)
 
     @patch(
@@ -137,6 +173,35 @@ class TestGetFAVersionDeterministic(unittest.TestCase):
         mock_base_flags.return_value = {"FLAGS_flash_attn_version": 3}
         result = get_fa_version(128)
         self.assertEqual(result, 3)
+
+    @patch(
+        "paddlefleet_ops.flash_mask_facade.is_flash_mask_available",
+        return_value=False,
+    )
+    @patch(
+        "paddlefleet_ops.flash_mask_facade.paddle.get_device",
+        return_value="gpu:0",
+    )
+    @patch("paddlefleet_ops.flash_mask_facade.paddle.base.framework.get_flags")
+    @patch(
+        "paddlefleet_ops.flash_mask_facade.paddle.get_flags",
+        return_value={"FLAGS_cudnn_deterministic": False},
+    )
+    def test_cutedsl_unavailable_degrades_to_2(
+        self, mock_get_flags, mock_base_flags, mock_device, mock_available
+    ):
+        """Without the cutedsl backend, FA3/FA4 must degrade to FA2.
+
+        Otherwise the CP / refined-recompute call sites would reference an
+        undefined ``_flash_attn_fwd`` -- the kernels are never imported when
+        ``paddlefleet_ops.flash_mask`` is unavailable.
+        """
+        for flag_version in (3, 4):
+            with self.subTest(flag_version=flag_version):
+                mock_base_flags.return_value = {
+                    "FLAGS_flash_attn_version": flag_version
+                }
+                self.assertEqual(get_fa_version(128), 2)
 
     @patch(
         "paddlefleet_ops.flash_mask_facade.paddle.get_device",

--- a/tests/single_card_tests/ai_edited_test/recompute/test_ai_flash_attn_7.py
+++ b/tests/single_card_tests/ai_edited_test/recompute/test_ai_flash_attn_7.py
@@ -192,8 +192,8 @@ class TestGetFAVersionDeterministic(unittest.TestCase):
     ):
         """Without the cutedsl backend, FA3/FA4 must degrade to FA2.
 
-        Otherwise the CP / refined-recompute call sites would reference an
-        undefined ``_flash_attn_fwd`` -- the kernels are never imported when
+        Otherwise the CP / refined-recompute call sites would call the FA3/FA4
+        kernels, which ``flash_mask_facade`` binds to ``None`` when
         ``paddlefleet_ops.flash_mask`` is unavailable.
         """
         for flag_version in (3, 4):

--- a/tests/single_card_tests/ai_edited_test/recompute/test_ai_flash_attn_8.py
+++ b/tests/single_card_tests/ai_edited_test/recompute/test_ai_flash_attn_8.py
@@ -141,20 +141,18 @@ class TestRefinedRcomputeFlashMaskAttentionFirstFwdV4(unittest.TestCase):
     @patch("paddlefleet.refined_recompute.flash_attn.framework._dygraph_tracer")
     def test_first_fwd_v4(self, mock_tracer, mock_version):
         """Test _first_fwd with version 4."""
-        # _flash_attn_fwd is conditionally imported (sm_10x only).
-        # Create it on the module if it doesn't exist so the test can run.
+        # ``_flash_attn_fwd`` is always bound as a module global (it comes from
+        # ``flash_mask_facade``, which binds ``None`` on FA2-only devices), so a
+        # plain ``patch.object`` restores it correctly either way.
         import paddlefleet.refined_recompute.flash_attn as fa_mod
-
-        _orig_flash_fwd = getattr(fa_mod, "_flash_attn_fwd", None)
 
         mock_flash_fwd = MagicMock()
         mock_flash_fwd.return_value = (
             paddle.randn([2, 4, 8], dtype=paddle.bfloat16),
             paddle.randn([2, 4], dtype=paddle.float32),
         )
-        fa_mod._flash_attn_fwd = mock_flash_fwd
 
-        try:
+        with patch.object(fa_mod, "_flash_attn_fwd", mock_flash_fwd):
             mock_tracer_obj = MagicMock()
             mock_tracer_obj._has_grad = False
             mock_tracer.return_value = mock_tracer_obj
@@ -170,12 +168,6 @@ class TestRefinedRcomputeFlashMaskAttentionFirstFwdV4(unittest.TestCase):
             hold_tensors = attn._hold_tensors_queue.get()
             self.assertIn("result_attention", hold_tensors)
             self.assertIn("softmax_lse", hold_tensors)
-        finally:
-            # Restore original state
-            if _orig_flash_fwd is not None:
-                fa_mod._flash_attn_fwd = _orig_flash_fwd
-            elif hasattr(fa_mod, "_flash_attn_fwd"):
-                delattr(fa_mod, "_flash_attn_fwd")
 
 
 class TestFlashMaskAttnFunctorCpForward(unittest.TestCase):

--- a/tests/single_card_tests/ai_edited_test/recompute/test_ai_flash_attn_cp_rr_modes.py
+++ b/tests/single_card_tests/ai_edited_test/recompute/test_ai_flash_attn_cp_rr_modes.py
@@ -135,9 +135,6 @@ class TestFlashMaskAttnFunctor(unittest.TestCase):
         }
         ctx = FakeCtx()
 
-        def fake_flashmask_attention(query, key, value, block_mask=None):
-            return None
-
         with patch.object(fa, "get_fa_version", return_value=3):
             self.assertIs(
                 fa.FlashMaskAttnFunctor.forward(
@@ -145,16 +142,15 @@ class TestFlashMaskAttnFunctor(unittest.TestCase):
                 ),
                 out,
             )
+        mock_bwd = MagicMock(return_value=(q, k, v, None))
         with (
-            patch.object(fa, "flashmask_attention", fake_flashmask_attention),
-            patch.object(fa, "_C_ops") as mock_c_ops,
+            patch.object(fa, "_flash_attn_bwd", mock_bwd, create=True),
+            patch.object(fa, "FlashMaskInfoPaddle", create=True),
         ):
-            mock_c_ops.flashmask_attention_v2_grad.return_value = (q, k, v)
             grads = fa.FlashMaskAttnFunctor.backward(ctx, paddle.ones_like(out))
 
         self.assertIs(grads[0], q)
-        scale_arg = mock_c_ops.flashmask_attention_v2_grad.call_args.args[-2]
-        self.assertIsInstance(scale_arg, float)
+        scale_arg = mock_bwd.call_args.kwargs["softmax_scale"]
         self.assertNotIsInstance(scale_arg, tuple)
 
 
@@ -270,23 +266,25 @@ class TestUlyssesHelpers(unittest.TestCase):
         sink = paddle.randn([2])
         startend = paddle.zeros([1, 1, 4, 2], dtype="int32")
 
-        with (
-            patch.object(fa, "get_fa_version", return_value=4),
-            patch.object(
-                fa,
-                "_flash_attn_fwd",
-                return_value=(q, paddle.randn([1, 2, 4])),
-                create=True,
-            ) as mock_fwd,
-        ):
-            fa.ulysses_local_flashmask_first_fwd(
-                q, q, q, startend, False, sink, None
-            )
-        self.assertIs(mock_fwd.call_args.kwargs["learnable_sink"], sink)
+        for fa_version in (3, 4):
+            with self.subTest(fa_version=fa_version):
+                with (
+                    patch.object(fa, "get_fa_version", return_value=fa_version),
+                    patch.object(
+                        fa,
+                        "_flash_attn_fwd",
+                        return_value=(q, paddle.randn([1, 2, 4])),
+                        create=True,
+                    ) as mock_fwd,
+                ):
+                    fa.ulysses_local_flashmask_first_fwd(
+                        q, q, q, startend, False, sink, None
+                    )
+                self.assertIs(mock_fwd.call_args.kwargs["learnable_sink"], sink)
 
-        # fa2/fa3 have no sink support, so fail loudly instead of dropping it.
+        # fa2 has no sink support, so fail loudly instead of dropping it.
         with (
-            patch.object(fa, "get_fa_version", return_value=3),
+            patch.object(fa, "get_fa_version", return_value=2),
             self.assertRaises(NotImplementedError),
         ):
             fa.ulysses_local_flashmask_first_fwd(
@@ -301,45 +299,36 @@ class TestUlyssesHelpers(unittest.TestCase):
         seed = paddle.zeros([1], dtype="int64")
         startend = paddle.zeros([1, 1, 4, 2], dtype="int32")
 
-        def fake_flashmask_attention(query, key, value, block_mask=None):
-            return None
-
         cases = (
             (2, "flashmask_attention", (out, softmax, lse, seed)),
-            (3, "flashmask_attention_v2", (out, lse)),
+            (3, "_flash_attn_fwd", (out, lse)),
             (4, "_flash_attn_fwd", (out, lse)),
         )
         for version, target, return_value in cases:
             with self.subTest(version=version):
                 with patch.object(fa, "get_fa_version", return_value=version):
-                    if version == 4:
+                    if version == 2:
+                        patcher = patch.object(fa, "_C_ops")
+                    else:
                         patcher = patch.object(
                             fa, target, return_value=return_value, create=True
                         )
-                    else:
-                        patcher = patch.object(fa, "_C_ops")
                     with patcher as mock_op:
-                        if version != 4:
+                        if version == 2:
                             getattr(mock_op, target).return_value = return_value
-                        with patch.object(
-                            fa, "flashmask_attention", fake_flashmask_attention
-                        ):
-                            result, hold = fa.ulysses_local_flashmask_first_fwd(
-                                q, q, q, startend, False, None, None
-                            )
+                        result, hold = fa.ulysses_local_flashmask_first_fwd(
+                            q, q, q, startend, False, None, None
+                        )
 
                 self.assertIs(result, out)
                 self.assertIs(hold["result_attention"], out)
                 self.assertIs(hold["softmax_lse"], lse)
                 self.assertFalse(hold["causal"])
+                self.assertEqual(hold["fa_version"], version)
                 if version == 2:
                     self.assertIs(hold["seed_offset"], seed)
-                if version == 3:
-                    scale_arg = mock_op.flashmask_attention_v2.call_args.args[
-                        -2
-                    ]
-                    self.assertIsInstance(scale_arg, float)
-                if version == 4:
+                else:
+                    # fa3 and fa4 share the cutedsl kernel.
                     self.assertIs(
                         mock_op.call_args.kwargs["startend_row_indices"],
                         startend,
@@ -366,29 +355,18 @@ class TestUlyssesHelpers(unittest.TestCase):
         lse = paddle.randn([1, 2, 4])
         startend = paddle.zeros([1, 1, 4, 2], dtype="int32")
 
-        def flashmask_attention_with_group(query, key, value, group=None):
-            return None
-
-        def flashmask_attention_legacy(query, key, value):
-            return None
-
-        for fake_attention in (
-            flashmask_attention_with_group,
-            flashmask_attention_legacy,
+        with (
+            patch.object(fa, "get_fa_version", return_value=3),
+            patch.object(
+                fa, "_flash_attn_fwd", return_value=(out, lse), create=True
+            ),
         ):
-            with self.subTest(signature=fake_attention.__name__):
-                with (
-                    patch.object(fa, "get_fa_version", return_value=3),
-                    patch.object(fa, "flashmask_attention", fake_attention),
-                    patch.object(fa, "_C_ops") as mock_c_ops,
-                ):
-                    mock_c_ops.flashmask_attention_v2.return_value = (out, lse)
-                    result, hold = fa.ulysses_local_flashmask_first_fwd(
-                        q, q, q, startend, False, None, None
-                    )
+            result, hold = fa.ulysses_local_flashmask_first_fwd(
+                q, q, q, startend, False, None, None
+            )
 
-                self.assertIs(result, out)
-                self.assertEqual(hold["fa_version"], 3)
+        self.assertIs(result, out)
+        self.assertEqual(hold["fa_version"], 3)
 
 
 class TestRefinedRcomputeFlashMaskCpAttentionModes(unittest.TestCase):
@@ -764,64 +742,35 @@ class TestRefinedRcomputeFlashMaskCpAttentionModes(unittest.TestCase):
             mock_c_ops.flashmask_attention_grad.call_args.args[7], local_grad
         )
 
-    def test_ulysses_functor_backward_fa3_signature_variants(self):
+    def test_ulysses_functor_backward_fa3_uses_cutedsl(self):
+        """fa3 backward routes to _flash_attn_bwd with the all-to-all'd grad."""
         local_grad = paddle.ones_like(self.out)
-
-        def flashmask_attention_with_group(query, key, value, group=None):
-            return None
-
-        def flashmask_attention_with_block_mask(
-            query, key, value, block_mask=None
-        ):
-            return None
-
-        def flashmask_attention_legacy(query, key, value):
-            return None
-
-        cases = (
-            (flashmask_attention_with_group, -5),
-            (flashmask_attention_with_block_mask, -3),
-            (flashmask_attention_legacy, -3),
+        ctx = FakeCtx()
+        out = paddle.randn([1, 4, 2, 4])
+        lse = paddle.randn([1, 2, 4])
+        hold = self._ulysses_hold(3, result_attention=out, softmax_lse=lse)
+        fa.FlashMaskUlyssesCpFunctor.forward(
+            ctx, self.q, self.k, self.v, None, hold
         )
-        for fake_attention, scale_arg_index in cases:
-            with self.subTest(signature=fake_attention.__name__):
-                ctx = FakeCtx()
-                out = paddle.randn([1, 4, 2, 4])
-                lse = paddle.randn([1, 2, 4])
-                hold = self._ulysses_hold(
-                    3, result_attention=out, softmax_lse=lse
-                )
-                fa.FlashMaskUlyssesCpFunctor.forward(
-                    ctx, self.q, self.k, self.v, None, hold
-                )
-                with (
-                    patch.object(fa, "flashmask_attention", fake_attention),
-                    patch.object(
-                        fa, "_ulysses_fused_supported", return_value=False
-                    ),
-                    patch.object(
-                        fa,
-                        "_ulysses_single_all_to_all",
-                        side_effect=(local_grad, self.q, self.k, self.v),
-                    ),
-                    patch.object(fa, "_C_ops") as mock_c_ops,
-                ):
-                    mock_c_ops.flashmask_attention_v2_grad.return_value = (
-                        self.q,
-                        self.k,
-                        self.v,
-                    )
-                    grads = fa.FlashMaskUlyssesCpFunctor.backward(
-                        ctx, paddle.ones([1, 4, 2, 4])
-                    )
+        mock_bwd = MagicMock(return_value=(self.q, self.k, self.v, None))
+        with (
+            patch.object(fa, "_flash_attn_bwd", mock_bwd, create=True),
+            patch.object(fa, "_ulysses_fused_supported", return_value=False),
+            patch.object(
+                fa,
+                "_ulysses_single_all_to_all",
+                side_effect=(local_grad, self.q, self.k, self.v),
+            ),
+        ):
+            grads = fa.FlashMaskUlyssesCpFunctor.backward(
+                ctx, paddle.ones([1, 4, 2, 4])
+            )
 
-                self.assertIs(grads[0], self.q)
-                self.assertIs(
-                    mock_c_ops.flashmask_attention_v2_grad.call_args.args[
-                        scale_arg_index
-                    ],
-                    local_grad,
-                )
+        self.assertIs(grads[0], self.q)
+        # q, k, v, result_attention, local_grad, softmax_lse, flashmask_info
+        self.assertIs(mock_bwd.call_args.args[4], local_grad)
+        # The saved mask is non-None here, so a FlashMaskInfoPaddle is built.
+        self.assertIsNotNone(mock_bwd.call_args.args[6])
 
     def test_ulysses_functor_backward_sink_grad(self):
         """The sink grad slot is returned only when the sink needs a grad."""

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_dot_product_attention_softmax_scale.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_dot_product_attention_softmax_scale.py
@@ -551,20 +551,25 @@ class TestCpFlashmaskSoftmaxScaleNotImplemented(unittest.TestCase):
     """
     Tests that context_parallel_utils.py correctly handles softmax_scale
     for different fa_version values in the forward path:
-    - The else branch (fa_version 2/3) passes softmax_scale unconditionally
+    - The else branch (fa_version 2) passes softmax_scale unconditionally
       to flashmask_attention (the kernel itself may ignore unsupported values).
+      FLAGS=3 reaches this branch only when flashmask is unavailable and
+      ``get_fa_version`` degrades to 2.
     - The backward path for fa_version==2 raises NotImplementedError
       when softmax_scale is not None.
     - fa_version==4: passes softmax_scale to _flash_attn_fwd (covered elsewhere)
     """
 
     @patch(
+        "paddlefleet_ops.flash_mask_facade.is_flash_mask_available",
+        lambda: False,
+    )
+    @patch(
         "paddlefleet.context_parallel_utils.preprocess_index_dual_chunks",
         return_value=paddle.zeros([1, 1, 4, 2], dtype="int32"),
     )
     @patch("paddlefleet.context_parallel_utils.flashmask_attention")
     @patch("paddlefleet.context_parallel_utils.paddle.distributed.all_gather")
-    @patch("paddlefleet.context_parallel_utils._flash_mask_available", False)
     @patch(
         "paddlefleet.context_parallel_utils.paddle.get_flags",
         return_value={"FLAGS_cudnn_deterministic": False},
@@ -589,7 +594,11 @@ class TestCpFlashmaskSoftmaxScaleNotImplemented(unittest.TestCase):
         mock_fm,
         mock_preprocess,
     ):
-        """fa_version==3 (else branch): softmax_scale is always passed to flashmask_attention."""
+        """FLAGS=3 without flashmask: softmax_scale always reaches flashmask_attention.
+
+        FA3 now runs on the cutedsl backend, so the paddle ``flashmask_attention``
+        branch is only taken once ``get_fa_version`` degrades the flag to 2.
+        """
         from paddlefleet.context_parallel_utils import (
             cp_flashmask_allgatherkv_balance_forward,
         )
@@ -634,7 +643,6 @@ class TestCpFlashmaskSoftmaxScaleNotImplemented(unittest.TestCase):
     )
     @patch("paddlefleet.context_parallel_utils.flashmask_attention")
     @patch("paddlefleet.context_parallel_utils.paddle.distributed.all_gather")
-    @patch("paddlefleet.context_parallel_utils._flash_mask_available", False)
     @patch(
         "paddlefleet.context_parallel_utils.paddle.get_flags",
         return_value={"FLAGS_cudnn_deterministic": False},
@@ -700,12 +708,15 @@ class TestCpFlashmaskSoftmaxScaleNotImplemented(unittest.TestCase):
             )
 
     @patch(
+        "paddlefleet_ops.flash_mask_facade.is_flash_mask_available",
+        lambda: False,
+    )
+    @patch(
         "paddlefleet.context_parallel_utils.preprocess_index_dual_chunks",
         return_value=paddle.zeros([1, 1, 4, 2], dtype="int32"),
     )
     @patch("paddlefleet.context_parallel_utils.flashmask_attention")
     @patch("paddlefleet.context_parallel_utils.paddle.distributed.all_gather")
-    @patch("paddlefleet.context_parallel_utils._flash_mask_available", False)
     @patch(
         "paddlefleet.context_parallel_utils.paddle.get_flags",
         return_value={"FLAGS_cudnn_deterministic": False},
@@ -730,7 +741,10 @@ class TestCpFlashmaskSoftmaxScaleNotImplemented(unittest.TestCase):
         mock_fm,
         mock_preprocess,
     ):
-        """fa_version==3: softmax_scale passed to flashmask_attention unconditionally."""
+        """FLAGS=3 without flashmask: softmax_scale passed on unconditionally.
+
+        Degrading to FA2 is what routes this to paddle's ``flashmask_attention``.
+        """
         from paddlefleet.context_parallel_utils import (
             cp_flashmask_allgatherkv_balance_forward,
         )
@@ -776,7 +790,6 @@ class TestCpFlashmaskSoftmaxScaleNotImplemented(unittest.TestCase):
     )
     @patch("paddlefleet.context_parallel_utils.flashmask_attention")
     @patch("paddlefleet.context_parallel_utils.paddle.distributed.all_gather")
-    @patch("paddlefleet.context_parallel_utils._flash_mask_available", False)
     @patch(
         "paddlefleet.context_parallel_utils.paddle.get_flags",
         return_value={"FLAGS_cudnn_deterministic": False},
@@ -851,7 +864,6 @@ class TestCpFlashmaskSoftmaxScaleNotImplemented(unittest.TestCase):
     )
     @patch("paddlefleet.context_parallel_utils.flashmask_attention")
     @patch("paddlefleet.context_parallel_utils.paddle.distributed.all_gather")
-    @patch("paddlefleet.context_parallel_utils._flash_mask_available", False)
     @patch(
         "paddlefleet.context_parallel_utils.paddle.get_flags",
         return_value={"FLAGS_cudnn_deterministic": False},
@@ -917,12 +929,15 @@ class TestCpFlashmaskSoftmaxScaleNotImplemented(unittest.TestCase):
             )
 
     @patch(
+        "paddlefleet_ops.flash_mask_facade.is_flash_mask_available",
+        lambda: False,
+    )
+    @patch(
         "paddlefleet.context_parallel_utils.preprocess_index_dual_chunks",
         return_value=paddle.zeros([1, 1, 4, 2], dtype="int32"),
     )
     @patch("paddlefleet.context_parallel_utils.flashmask_attention")
     @patch("paddlefleet.context_parallel_utils.paddle.distributed.all_gather")
-    @patch("paddlefleet.context_parallel_utils._flash_mask_available", False)
     @patch(
         "paddlefleet.context_parallel_utils.paddle.get_flags",
         return_value={"FLAGS_cudnn_deterministic": False},
@@ -947,7 +962,10 @@ class TestCpFlashmaskSoftmaxScaleNotImplemented(unittest.TestCase):
         mock_fm,
         mock_preprocess,
     ):
-        """fa_version==3: when softmax_scale is None, softmax_scale=None is passed through."""
+        """FLAGS=3 without flashmask: softmax_scale=None is passed through as None.
+
+        Degrading to FA2 is what routes this to paddle's ``flashmask_attention``.
+        """
         from paddlefleet.context_parallel_utils import (
             cp_flashmask_allgatherkv_balance_forward,
         )

--- a/tests/single_card_tests/transformer/test_flash_mask_sink.py
+++ b/tests/single_card_tests/transformer/test_flash_mask_sink.py
@@ -692,9 +692,9 @@ class TestRefinedRecomputeFlashMaskSink(unittest.TestCase):
     def test_rr_fixed_sink_no_grad(self):
         self._run(causal=True, use_sink=True, sink_trainable=False)
 
-    def test_rr_non_fa4_sink_raises(self):
-        # Sink is only supported on the fa_version==4 cute backend; forcing v3
-        # must make the rr entry point reject a non-None sink.
+    def test_rr_fa2_sink_raises(self):
+        # Sink needs the cutedsl backend (fa3/fa4); forcing fa2 must make the
+        # rr entry point reject a non-None sink.
         from paddlefleet.refined_recompute.flash_attn import (
             RefinedRcomputeFlashMaskAttention,
         )
@@ -709,7 +709,7 @@ class TestRefinedRecomputeFlashMaskSink(unittest.TestCase):
         old = paddle.get_flags(["FLAGS_flash_attn_version"])[
             "FLAGS_flash_attn_version"
         ]
-        paddle.set_flags({"FLAGS_flash_attn_version": 3})
+        paddle.set_flags({"FLAGS_flash_attn_version": 2})
         try:
             with self.assertRaises(NotImplementedError):
                 rr_attn.forward(q, q, q, idx, learnable_sink=sink)

--- a/tests/single_card_tests/transformer/test_hybrid_mla_recompute_mtp_ckpt.py
+++ b/tests/single_card_tests/transformer/test_hybrid_mla_recompute_mtp_ckpt.py
@@ -28,7 +28,7 @@ Coverage map (see validation_reports/A7_recompute_mtp_ckpt.md for the analysis):
      re-derived bit-identically on the recompute forward (a mismatch would
      silently differentiate a different sparsity pattern).
   2. Refined recompute guard: ``RefinedRcomputeFlashMaskAttention`` raises for a
-     learnable sink unless ``fa_version==4``; production dims are not fa4.
+     learnable sink unless the cutedsl backend (fa3/fa4) is active.
   3. MTP tracker slot arithmetic: MTP ``layer_number==0`` -> ``values[-1]`` is
      only accidentally correct for a 44-entry tracker; two MTP layers collide.
   4. Checkpoint key-set compat: MHA <-> MQA byte-identical; mqa_dsa adds the
@@ -79,9 +79,9 @@ _add_repo_root_to_sys_path()
 # ===========================================================================
 class TestRefinedRecomputeSinkGuard(unittest.TestCase):
     """``RefinedRcomputeFlashMaskAttention.forward`` refuses a learnable sink
-    unless the fa cute backend (version 4) is active. The guard sits at the top
-    of ``forward`` (flash_attn.py:665-674), before any kernel call, so it can be
-    exercised on tiny CPU tensors by forcing ``get_fa_version``'s return.
+    unless the fa cute backend (version 3 or 4) is active. The guard sits at the
+    top of ``forward``, before any kernel call, so it can be exercised on tiny
+    CPU tensors by forcing ``get_fa_version``'s return.
     """
 
     def _forward_module(self):
@@ -91,7 +91,7 @@ class TestRefinedRecomputeSinkGuard(unittest.TestCase):
 
         return RefinedRcomputeFlashMaskAttention()
 
-    def test_guard_raises_for_non_fa4_versions(self):
+    def test_guard_raises_for_non_cutedsl_versions(self):
         import paddlefleet.refined_recompute.flash_attn as fa_mod
 
         mod = self._forward_module()
@@ -101,11 +101,12 @@ class TestRefinedRecomputeSinkGuard(unittest.TestCase):
         sink = paddle.zeros([2])
         orig = fa_mod.get_fa_version
         try:
-            for version in (2, 3):
-                fa_mod.get_fa_version = lambda *a, **k_: version
-                with self.assertRaises(NotImplementedError) as ctx:
-                    mod.forward(q, k, v, None, learnable_sink=sink)
-                self.assertIn("fa_version==4", str(ctx.exception))
+            # fa3 now shares FA4's cutedsl backend and supports the sink, so
+            # fa2 is the only version left for the guard to reject.
+            fa_mod.get_fa_version = lambda *a, **k_: 2
+            with self.assertRaises(NotImplementedError) as ctx:
+                mod.forward(q, k, v, None, learnable_sink=sink)
+            self.assertIn("fa3 or fa4", str(ctx.exception))
         finally:
             fa_mod.get_fa_version = orig
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Operator Mechanism


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
在 SM90（Hopper）上启用 FA3 的 cutedsl 版本，让 FA3 与 FA4 共用同一条 kernel 路径。


### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
是