### PR TITLE
[Execute Infrastructure] Fix ms-swift reference link in config switch review rules

### DIFF
--- a/.agents/skills/ai-review/references/user-configuration-rules.md
+++ b/.agents/skills/ai-review/references/user-configuration-rules.md
@@ -55,7 +55,7 @@
 参考来源：
 
 - Huggingface Transformers：https://github.com/huggingface/transformers 、https://github.com/huggingface/transformers/blob/8e7d47a325d647d9e78b832b8e003c9d676b658a/docs/source/en/custom_models.md?plain=1#L26
-- ms-swift：https://github.com/modelscope/ms-swift 、https://swift.readthedocs.io/zh-cn/latest/Instruction/Command-line-parameters.html
+- ms-swift：https://github.com/modelscope/ms-swift 、https://swift.readthedocs.io/en/latest/Megatron-SWIFT/Command-line-parameters.html
 - Megatron-LM：https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/core/transformer/transformer_config.py
 
 ## 跨版本兼容性


### PR DESCRIPTION
### PR Category

Execute Infrastructure

### PR Types

Others

### Description

修正 #1700 引入的 `.agents/skills/ai-review/references/user-configuration-rules.md` 中「生态一致性」一节的 ms-swift 参考链接。

原链接指向 `Instruction/Command-line-parameters`，那是 `swift sft` 的参数文档，描述的是基于 transformers / PEFT 的训练栈（`target_modules`、`lora_rank`、`per_device_train_batch_size` 等），与 PaddleFleet 的配置体系不对应，AI review 按它检索上游等价开关会查不到或对错字段。

本仓库的 `TransformerConfig` 是 Megatron 系配置，ms-swift 侧的可比对面是 **Megatron-SWIFT**（`https://swift.readthedocs.io/en/latest/Megatron-SWIFT/Command-line-parameters.html`），其参数与本仓库同构，例如 `freeze_llm`、`expert_model_parallel_size`、`expert_tensor_parallel_size`、`sequence_parallel`、`context_parallel_size`、`moe_router_load_balancing_type`、`moe_token_dispatcher_type`、`moe_expert_capacity_factor`、`recompute_granularity`、`recompute_modules`、`mtp_num_layers`、`attention_backend`、`attention_softmax_in_fp32`。

改动只有一行：把参考来源里的 ms-swift 链接换成 Megatron-SWIFT 的参数文档。

### 是否引起精度变化

不涉及。本 PR 只改 AI review 规则文档中的一个参考链接，不改动任何训练代码、配置默认值或算子实现。
