### PR TITLE
[Feat] hybrid MLA supports a2a & learnable sink & RR

### DIFF
--- a/src/paddlefleet/context_parallel_utils.py
+++ b/src/paddlefleet/context_parallel_utils.py
@@ -1881,10 +1881,11 @@ def flashmask_attention_ulysses(
     # The softmax sink holds one entry per query head and is replicated on every
     # rank, so it needs the same head partition as Q/K/V (which the all-to-all below applies)
     if learnable_sink is not None:
-        assert learnable_sink.shape[0] == num_q_heads, (
-            f"learnable_sink must have one entry per query head ({num_q_heads}), "
-            f"got shape {learnable_sink.shape}"
-        )
+        if learnable_sink.shape[0] != num_q_heads:
+            raise ValueError(
+                f"learnable_sink must have one entry per query head ({num_q_heads}), "
+                f"got shape {learnable_sink.shape}"
+            )
         heads_per_rank = num_q_heads // cp_size
         learnable_sink = learnable_sink[
             cp_rank * heads_per_rank : (cp_rank + 1) * heads_per_rank

--- a/src/paddlefleet/context_parallel_utils.py
+++ b/src/paddlefleet/context_parallel_utils.py
@@ -1831,6 +1831,8 @@ def flashmask_attention_ulysses(
         value: [batch, seq_len/P, num_kv_heads, head_dim] - sequence-partitioned value
         startend_row_indices: [b, num_mask_heads, seq_len, cols] attention mask indices
             num_mask_heads must be 1 (broadcast) or equal to num_kv_heads.
+        learnable_sink: [num_heads] softmax sink, replicated on every rank. Sliced
+            to this rank's head group to match the post-all-to-all layout.
         dropout: dropout probability
         causal: whether to use causal attention
         training: whether in training mode
@@ -1838,12 +1840,6 @@ def flashmask_attention_ulysses(
     Returns:
         [batch, seq_len/P, num_heads, head_dim] - sequence-partitioned output
     """
-    if learnable_sink is not None:
-        raise NotImplementedError(
-            "flashmask_attention_ulysses does not support learnable_sink "
-            "(softmax sink)"
-        )
-
     if softmax_scale is not None:
         raise NotImplementedError(
             "flashmask_attention_ulysses does not support setting softmax_scale"
@@ -1882,6 +1878,18 @@ def flashmask_attention_ulysses(
             :, head_start:head_end, :, :
         ]
 
+    # The softmax sink holds one entry per query head and is replicated on every
+    # rank, so it needs the same head partition as Q/K/V (which the all-to-all below applies)
+    if learnable_sink is not None:
+        assert learnable_sink.shape[0] == num_q_heads, (
+            f"learnable_sink must have one entry per query head ({num_q_heads}), "
+            f"got shape {learnable_sink.shape}"
+        )
+        heads_per_rank = num_q_heads // cp_size
+        learnable_sink = learnable_sink[
+            cp_rank * heads_per_rank : (cp_rank + 1) * heads_per_rank
+        ]  # slice part of the sink
+
     # Before attention: scatter heads across ranks, gather full sequence from all ranks
     # [b, N/P, h, d] -> [b, N, h/P, d]
     query = UlyssesAlltoAll.apply(
@@ -1902,6 +1910,7 @@ def flashmask_attention_ulysses(
         startend_row_indices=startend_row_indices,
         causal=causal,
         softmax_scale=softmax_scale,
+        learnable_sink=learnable_sink,
     )
 
     # After attention: scatter sequence across ranks, gather full heads from all ranks

--- a/src/paddlefleet/refined_recompute/flash_attn.py
+++ b/src/paddlefleet/refined_recompute/flash_attn.py
@@ -1247,10 +1247,11 @@ def slice_ulysses_sink_heads(learnable_sink, num_q_heads, cp_group):
     """Slice the per-query-head softmax sink for the local Ulysses head shard."""
     if learnable_sink is None:
         return None
-    assert learnable_sink.shape[0] == num_q_heads, (
-        f"learnable_sink must have one entry per query head ({num_q_heads}), "
-        f"got shape {learnable_sink.shape}"
-    )
+    if learnable_sink.shape[0] != num_q_heads:
+        raise ValueError(
+            f"learnable_sink must have one entry per query head ({num_q_heads}), "
+            f"got shape {learnable_sink.shape}"
+        )
     heads_per_rank = num_q_heads // cp_group.nranks
     head_start = cp_group.rank * heads_per_rank
     return learnable_sink[head_start : head_start + heads_per_rank]

--- a/src/paddlefleet/refined_recompute/flash_attn.py
+++ b/src/paddlefleet/refined_recompute/flash_attn.py
@@ -963,13 +963,17 @@ class FlashMaskUlyssesCpFunctor(PyLayer):
     """Surrogate PyLayer for RR Ulysses FlashMask CP attention."""
 
     @staticmethod
-    def forward(ctx, q, k, v, hold_tensors):
+    def forward(ctx, q, k, v, learnable_sink, hold_tensors):
         """Return saved final output and keep local tensors for backward."""
         local_hold_tensors = hold_tensors["local_hold_tensors"]
         ctx.group = hold_tensors["group"]
         ctx.softmax_scale = local_hold_tensors.get("softmax_scale")
         ctx.fa_version = local_hold_tensors["fa_version"]
         ctx.dropout = local_hold_tensors.get("dropout", 0.0)
+        ctx.learnable_sink = learnable_sink
+        ctx.sink_requires_grad = (
+            learnable_sink is not None and not learnable_sink.stop_gradient
+        )
         if ctx.fa_version == 2:
             ctx.save_for_backward(
                 hold_tensors["local_query"],
@@ -1095,7 +1099,7 @@ class FlashMaskUlyssesCpFunctor(PyLayer):
                 )
             else:
                 flashmask_info = None
-            q_grad, k_grad, v_grad, _ = _flash_attn_bwd(
+            q_grad, k_grad, v_grad, sink_grad = _flash_attn_bwd(
                 q.detach(),
                 k.detach(),
                 v.detach(),
@@ -1103,7 +1107,7 @@ class FlashMaskUlyssesCpFunctor(PyLayer):
                 local_grad,
                 softmax_lse,
                 flashmask_info,
-                learnable_sink=None,
+                learnable_sink=ctx.learnable_sink,
                 softmax_scale=ctx.softmax_scale,
                 causal=causal,
                 deterministic=bool(
@@ -1140,6 +1144,10 @@ class FlashMaskUlyssesCpFunctor(PyLayer):
         )
         result_attention._clear_dataptr()
         softmax_lse._clear_dataptr()
+        # sink_grad is already in local head space; the differentiable slice
+        # outside this PyLayer maps it back into the full sink parameter.
+        if ctx.sink_requires_grad:
+            return query_grad, key_grad, value_grad, sink_grad
         return query_grad, key_grad, value_grad
 
 
@@ -1235,18 +1243,36 @@ def slice_ulysses_mask_heads(startend_row_indices, num_k_heads, cp_group):
     ]
 
 
+def slice_ulysses_sink_heads(learnable_sink, num_q_heads, cp_group):
+    """Slice the per-query-head softmax sink for the local Ulysses head shard."""
+    if learnable_sink is None:
+        return None
+    assert learnable_sink.shape[0] == num_q_heads, (
+        f"learnable_sink must have one entry per query head ({num_q_heads}), "
+        f"got shape {learnable_sink.shape}"
+    )
+    heads_per_rank = num_q_heads // cp_group.nranks
+    head_start = cp_group.rank * heads_per_rank
+    return learnable_sink[head_start : head_start + heads_per_rank]
+
+
 def ulysses_local_flashmask_first_fwd(
     query_states,
     key_states,
     value_states,
     startend_row_indices,
     causal,
+    learnable_sink,
     softmax_scale,
 ):
     """Run local Ulysses FlashMask first forward and save RR tensors."""
     fa_version = get_fa_version(
         query_states.shape[-1], value_states.shape[-1], startend_row_indices
     )
+    if learnable_sink is not None and fa_version != 4:
+        raise NotImplementedError(
+            "learnable_sink only supported on fa_version==4 cute backend"
+        )
     if fa_version == 2:
         if softmax_scale is not None:
             raise NotImplementedError(
@@ -1328,6 +1354,7 @@ def ulysses_local_flashmask_first_fwd(
             return_lse=True,
             startend_row_indices=startend_row_indices,
             pack_gqa=False,
+            learnable_sink=learnable_sink,
             softmax_scale=softmax_scale,
         )
         hold_tensors = {
@@ -1579,11 +1606,6 @@ class RefinedRcomputeFlashMaskCpAttention:
         softmax_scale,
     ):
         """Run first forward for RR Ulysses FlashMask CP."""
-        if learnable_sink is not None:
-            raise NotImplementedError(
-                "flashmask_attention_ulysses does not support learnable_sink "
-                "(softmax sink)"
-            )
         if softmax_scale is not None:
             raise NotImplementedError(
                 "flashmask_attention_ulysses does not support setting softmax_scale"
@@ -1611,6 +1633,7 @@ class RefinedRcomputeFlashMaskCpAttention:
             value,
             startend_row_indices,
             causal,
+            slice_ulysses_sink_heads(learnable_sink, num_q_heads, group),
             softmax_scale,
         )
         result_attention = self._ulysses_alltoall_output(local_attention, group)
@@ -1654,8 +1677,19 @@ class RefinedRcomputeFlashMaskCpAttention:
                 hold_tensors,
             )
         elif mode == "contiguous_a2a":
+            # slice differentiably here: the local grad is routed back into the
+            # full sink parameter by this getitem node, exactly as on the
+            # non-RR Ulysses path.
             return FlashMaskUlyssesCpFunctor.apply(
-                query_states, key_states, value_states, hold_tensors
+                query_states,
+                key_states,
+                value_states,
+                slice_ulysses_sink_heads(
+                    learnable_sink,
+                    query_states.shape[2],
+                    hold_tensors["group"],
+                ),
+                hold_tensors,
             )
         else:
             raise ValueError(f"invalid cp_balance_mode: {mode}")

--- a/src/paddlefleet/transformer/dot_product_attention.py
+++ b/src/paddlefleet/transformer/dot_product_attention.py
@@ -269,6 +269,16 @@ class DotProductAttention(FleetLayer):
 
         self.context_parallel_size = get_context_parallel_world_size()
 
+        # following is None by default. We allow MLA to set its own comm mode
+        self.hybrid_mla_cp_mode = getattr(config, "hybrid_mla_cp_mode", None)
+        # The SWA fast path that rewrites ``contiguous_a2a`` into
+        # ``contiguous_swap2p`` keys on ``config.multi_latent_attention``, which
+        # is False in a DSV4 hybrid, so an SWA layer here would silently run on
+        # the non-SWA Ulysses path. ``is_swa`` is per layer, hence the check.
+        assert self.hybrid_mla_cp_mode is None or not is_swa, (
+            "When hybrid_mla_cp_mode is set, setting SWA is not supported."
+        )
+
         self.layer_number = layer_number
         self.attn_mask_type = attn_mask_type
         self.attention_type = attention_type  # unused for now
@@ -508,6 +518,7 @@ class DotProductAttention(FleetLayer):
             )
 
         use_mla = bool(getattr(self.config, "multi_latent_attention", False))
+        cp_balance_mode = self.hybrid_mla_cp_mode or self.config.cp_balance_mode
 
         if self.context_parallel_size > 1:
             assert packed_seq_params is None, (
@@ -516,9 +527,7 @@ class DotProductAttention(FleetLayer):
             assert not self.config.flashmask_use_varlen, (
                 "flashmask_use_varlen does not support context parallel now."
             )
-            if self.config.cp_balance_mode != "contiguous_a2a" or (
-                self.is_swa and use_mla
-            ):
+            if cp_balance_mode != "contiguous_a2a" or (self.is_swa and use_mla):
                 attn_mask_startend_row_indices = (
                     self.expand_attn_mask_startend_row_indices_for_cp(
                         attn_mask_startend_row_indices, key
@@ -718,12 +727,9 @@ class DotProductAttention(FleetLayer):
                             "RefinedRcomputeFlashMaskAttention does not support custom softmax_scale. "
                             "Disable refined_recompute or use default softmax_scale."
                         )
-                extra_kwargs["mode"] = self.config.cp_balance_mode
-                if self.config.cp_balance_mode == "contiguous_a2a":
-                    if not self.config.multi_latent_attention:
-                        raise NotImplementedError(
-                            "cp_balance_mode contiguous_a2a only supports mla now"
-                        )
+                extra_kwargs["mode"] = cp_balance_mode
+                if cp_balance_mode == "contiguous_a2a":
+                    # allow non-MLA (for DSV4 hybrid attn)
                     if self.is_swa and use_mla:
                         extra_kwargs["mode"] = "contiguous_swap2p"
                         left_window = get_sliding_window_left_size(

--- a/src/paddlefleet/transformer/dot_product_attention.py
+++ b/src/paddlefleet/transformer/dot_product_attention.py
@@ -275,9 +275,10 @@ class DotProductAttention(FleetLayer):
         # ``contiguous_swap2p`` keys on ``config.multi_latent_attention``, which
         # is False in a DSV4 hybrid, so an SWA layer here would silently run on
         # the non-SWA Ulysses path. ``is_swa`` is per layer, hence the check.
-        assert self.hybrid_mla_cp_mode is None or not is_swa, (
-            "When hybrid_mla_cp_mode is set, setting SWA is not supported."
-        )
+        if self.hybrid_mla_cp_mode is not None and is_swa:
+            raise ValueError(
+                "When hybrid_mla_cp_mode is set, setting SWA is not supported."
+            )
 
         self.layer_number = layer_number
         self.attn_mask_type = attn_mask_type

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -986,6 +986,15 @@ class TransformerConfig(ModelParallelConfig):
     layer still absorbs against ``kv_b_proj.weight``.
     """
 
+    hybrid_mla_cp_mode: str | None = None
+    """Context parallel mode for the MLA layers only, overriding ``cp_balance_mode``.
+
+    ``None`` (default) inherits ``cp_balance_mode``. Set to ``contiguous_a2a``
+    to run Ulysses on the MLA layers of a DSV4 MLA+HCA hybrid while the HCA
+    layers keep ``contiguous_allgather``; both modes share one global token
+    layout, which is what makes mixing them safe.
+    """
+
     v_head_dim: int | None = None
     """Dimension of the head in the V projection."""
 
@@ -2330,4 +2339,17 @@ class TransformerConfig(ModelParallelConfig):
             raise ValueError(
                 f"cp_balance_mode={self.cp_balance_mode!r} is invalid. "
                 "Must be one of {'dualchunk_allgather', 'contiguous_allgather', 'contiguous_a2a'}."
+            )
+
+        # only support hybrid_mla_cp_mode == contiguous_a2a if not None
+        if self.hybrid_mla_cp_mode is not None and (
+            self.hybrid_mla_cp_mode != "contiguous_a2a"
+            or not self.cp_balance_mode.startswith("contiguous")
+        ):
+            raise ValueError(
+                f"hybrid_mla_cp_mode={self.hybrid_mla_cp_mode!r} with "
+                f"cp_balance_mode={self.cp_balance_mode!r} is invalid: "
+                "hybrid_mla_cp_mode must be None or 'contiguous_a2a' "
+                "(other paths are simply not currently supported yet), "
+                "and cp_balance_mode must be in the same token layout."
             )

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -2342,14 +2342,25 @@ class TransformerConfig(ModelParallelConfig):
             )
 
         # only support hybrid_mla_cp_mode == contiguous_a2a if not None
-        if self.hybrid_mla_cp_mode is not None and (
-            self.hybrid_mla_cp_mode != "contiguous_a2a"
-            or not self.cp_balance_mode.startswith("contiguous")
-        ):
-            raise ValueError(
-                f"hybrid_mla_cp_mode={self.hybrid_mla_cp_mode!r} with "
-                f"cp_balance_mode={self.cp_balance_mode!r} is invalid: "
-                "hybrid_mla_cp_mode must be None or 'contiguous_a2a' "
-                "(other paths are simply not currently supported yet), "
-                "and cp_balance_mode must be in the same token layout."
-            )
+        if self.hybrid_mla_cp_mode is not None:
+            if (
+                self.hybrid_mla_cp_mode != "contiguous_a2a"
+                or not self.cp_balance_mode.startswith("contiguous")
+            ):
+                raise ValueError(
+                    f"hybrid_mla_cp_mode={self.hybrid_mla_cp_mode!r} with "
+                    f"cp_balance_mode={self.cp_balance_mode!r} is invalid: "
+                    "hybrid_mla_cp_mode must be None or 'contiguous_a2a' "
+                    "(other paths are simply not currently supported yet), "
+                    "and cp_balance_mode must be in the same token layout."
+                )
+            # ``csa_compress_ratios`` defaults to None off a dsv4_hybrid, so
+            # ``or ()`` keeps the membership test total instead of relying on
+            # the left operand short-circuiting it.
+            if self.experimental_attention_variant != "dsv4_hybrid" or (
+                -2 not in (self.csa_compress_ratios or ())
+            ):
+                raise ValueError(
+                    "hybrid_mla_cp_mode can only be set in dsv4_hybrid with "
+                    "-2 in csa_compress_ratios."
+                )

--- a/tests/multi_card_tests/transformer/test_flash_mask_cp_a2a.py
+++ b/tests/multi_card_tests/transformer/test_flash_mask_cp_a2a.py
@@ -1,0 +1,507 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Real 2-GPU coverage of the ``contiguous_a2a`` (Ulysses) FlashMask CP switch.
+
+``contiguous_a2a`` is a parallel switch: it moves Q/K/V from a sequence shard to
+a head shard through an all-to-all, and it rewrites both the plain and the
+refined-recompute backward. The single-card suites mock the process group, so
+they cannot observe collective ordering, per-rank slicing, or replica
+consistency. Every all-to-all below is a real NCCL call on 2 ranks.
+
+Covered for the plain path and the RR path, against a CP=1 reference:
+forward, ``dq``/``dk``/``dv`` (the QKV/input grads) and ``dsink`` (the parameter
+grad), plus RR-vs-plain equality.
+
+``dsink`` is the interesting one. The sink parameter is replicated on every rank
+and sliced per head shard by a differentiable ``getitem``, so each rank's
+``dsink`` is a *partial*: only its own heads are non-zero. Summing it over the
+CP group must reproduce the reference exactly -- that is what the sharding/DP
+reduce does in real training, and it is what proves nothing is lost or double
+counted. The test asserts both halves of that statement: the local partial must
+*differ* from the reference, and the CP sum must *match* it.
+
+Why the kernel is mocked (and why that is sound)
+------------------------------------------------
+``learnable_sink`` exists only in the FA4 cute backend, which is built for
+sm100; on an H-card CI machine the real sink kernel cannot run at all, yet the
+sink gradient is exactly what needs CP coverage. So the kernel -- and only the
+kernel -- is replaced by ``_attn_math``, pure-Paddle attention honouring the
+same contract (``out, lse`` forward; ``dq, dk, dv, dsink`` backward), with the
+backward obtained by autograd over the very same forward so the two cannot
+disagree. The reference and the CP run then share one kernel, which means every
+difference the test can see is CP plumbing -- the thing under test. Process
+groups, all-to-all, head/sequence slicing and the RR two-forward protocol all
+run for real.
+
+Run (2 GPUs), from the repository root::
+
+    PYTHONPATH=.:./src python -m paddle.distributed.launch --devices 0,1 \
+        tests/multi_card_tests/transformer/test_flash_mask_cp_a2a.py
+"""
+
+import contextlib
+import math
+import unittest
+from unittest.mock import patch
+
+import paddle
+import paddle.distributed as dist
+import paddlefleet_ops.flash_mask_facade as facade
+from paddle import framework
+from paddle.distributed import fleet
+
+import paddlefleet.refined_recompute.flash_attn as rr_fa
+from paddlefleet.context_parallel_utils import (
+    flashmask_attention_cp,
+    scatter_contiguous,
+)
+
+DTYPE = paddle.bfloat16
+SEED = 2026
+BATCH, SEQ, NUM_HEADS, HEAD_DIM = 2, 256, 4, 64
+
+# The mocked kernel is shared by both sides, so agreement is near bit-exact; the
+# slack only covers the fp32 accumulation order changing with the per-rank head
+# count. Any real plumbing bug (wrong shard, wrong collective order) is O(1),
+# which is why the paired "wrong shard must be far" check uses 0.1.
+REL_L2_TOL = 1e-3
+WRONG_SHARD_MIN = 0.1
+
+CP_SIZE = None
+CP_RANK = None
+CP_GROUP = None
+
+
+def setUpModule():
+    """Build a CP group over the whole world. No kernel gate: see module doc."""
+    global CP_SIZE, CP_RANK, CP_GROUP
+    world = dist.get_world_size()
+    if world < 2:
+        # The discriminative checks compare against another rank's shard and
+        # against a partial sink grad, neither of which exists at CP=1.
+        raise unittest.SkipTest(
+            "Ulysses a2a CP coverage needs at least 2 ranks"
+        )
+    strategy = fleet.DistributedStrategy()
+    strategy.hybrid_configs = {
+        "dp_degree": 1,
+        "mp_degree": 1,
+        "pp_degree": 1,
+        "sharding_degree": world,
+        "sep_degree": 1,
+        "cp_degree": world,
+        "ep_degree": world,
+        "moe_sharding_degree": 1,
+        "order": [
+            "sharding",
+            "moe_sharding",
+            "pp",
+            "sep",
+            "cp",
+            "dp",
+            "ep",
+            "mp",
+        ],
+    }
+    fleet.init(is_collective=True, strategy=strategy)
+    CP_GROUP = fleet.get_hybrid_communicate_group().get_context_parallel_group()
+    CP_RANK = CP_GROUP.rank
+    CP_SIZE = CP_GROUP.nranks
+
+
+# ------------------------------- mocked kernel -------------------------------
+
+
+class _FakeFlashMaskInfo:
+    """Stand-in for ``FlashMaskInfoPaddle``, which lives in the cute backend."""
+
+    def __init__(self, startend_row_indices=None, is_causal=False):
+        self.startend_row_indices = startend_row_indices
+        self.is_causal = is_causal
+
+
+def _mask_bias(startend_row_indices, seq_q):
+    """Additive mask from the repo's 2-column non-causal FlashMask convention.
+
+    ``[..., 0]`` is down_start (rows >= it are masked for that key) and
+    ``[..., 1]`` is up_end (rows < it are masked), matching
+    ``generate_non_causal_mask``. ``-1e30`` rather than ``-inf`` keeps a fully
+    masked row finite, since the sink still gives it a denominator.
+    """
+    down = startend_row_indices[..., 0].unsqueeze(2).astype("int64")
+    up = startend_row_indices[..., 1].unsqueeze(2).astype("int64")
+    rows = paddle.arange(seq_q, dtype="int64").reshape([seq_q, 1])
+    masked = paddle.logical_or(rows >= down, rows < up)
+    return masked.astype("float32") * -1e30
+
+
+def _attn_probs(query, key, value, learnable_sink, startend_row_indices):
+    """Shared fp32 softmax internals, all in [b, h, s, *] layout.
+
+    Returns the transposed q/k/v, the attention probabilities, the sink's share
+    of the same denominator, and the row shift used for stabilisation.
+    """
+    qf = query.astype("float32").transpose([0, 2, 1, 3])
+    kf = key.astype("float32").transpose([0, 2, 1, 3])
+    vf = value.astype("float32").transpose([0, 2, 1, 3])
+    scores = paddle.matmul(
+        qf * (1.0 / math.sqrt(qf.shape[-1])), kf, transpose_y=True
+    )
+    if startend_row_indices is not None:
+        scores = scores + _mask_bias(startend_row_indices, scores.shape[-2])
+
+    row_max = scores.max(axis=-1, keepdim=True)
+    if learnable_sink is not None:
+        sink = learnable_sink.astype("float32").reshape([1, -1, 1, 1])
+        row_max = paddle.maximum(row_max, sink)
+        exp_sink = paddle.exp(sink - row_max)
+    else:
+        exp_sink = paddle.zeros_like(row_max)
+    exp_scores = paddle.exp(scores - row_max)
+    denom = exp_scores.sum(axis=-1, keepdim=True) + exp_sink
+    return qf, kf, vf, exp_scores / denom, exp_sink / denom, denom, row_max
+
+
+def _attn_math(query, key, value, learnable_sink, startend_row_indices, causal):
+    """fp32 non-causal attention with sink. q/k/v: [b, s, h, d]; sink: [h]."""
+    if causal:
+        raise NotImplementedError("mock kernel covers the non-causal path only")
+    _, _, vf, probs, _, denom, row_max = _attn_probs(
+        query, key, value, learnable_sink, startend_row_indices
+    )
+    out = paddle.matmul(probs, vf)
+    lse = (paddle.log(denom) + row_max).squeeze(-1)
+    return out.transpose([0, 2, 1, 3]).astype(query.dtype), lse
+
+
+def _attn_grads(
+    query, key, value, learnable_sink, startend_row_indices, dout, causal
+):
+    """Closed-form gradient of ``_attn_math``.
+
+    Written out by hand rather than obtained from ``paddle.grad`` because this
+    runs inside ``PyLayer.backward``: re-entering the autograd engine from a
+    PyLayer grad node segfaults this Paddle build.
+
+    With ``P`` the probabilities (masked entries are exactly 0, so they need no
+    special casing) and ``r_i = dO_i . O_i``::
+
+        dV = P^T dO                 dS = P * (dO V^T - r)
+        dq = (dS K) * scale         dK = (dS^T Q) * scale
+        dsink_h = -sum_{b,i} p_sink * r     (the sink carries no value vector,
+                                            it only inflates the denominator)
+    """
+    if causal:
+        raise NotImplementedError("mock kernel covers the non-causal path only")
+    qf, kf, vf, probs, sink_prob, _, _ = _attn_probs(
+        query, key, value, learnable_sink, startend_row_indices
+    )
+    scale = 1.0 / math.sqrt(qf.shape[-1])
+    grad_out = dout.astype("float32").transpose([0, 2, 1, 3])
+    out = paddle.matmul(probs, vf)
+
+    dvalue = paddle.matmul(probs, grad_out, transpose_x=True)
+    row_dot = (grad_out * out).sum(axis=-1, keepdim=True)
+    dscores = probs * (paddle.matmul(grad_out, vf, transpose_y=True) - row_dot)
+    dquery = paddle.matmul(dscores, kf) * scale
+    dkey = paddle.matmul(dscores, qf, transpose_x=True) * scale
+
+    dsink = None
+    if learnable_sink is not None:
+        dsink = -(sink_prob * row_dot).sum(axis=[0, 2, 3])
+        dsink = dsink.astype(learnable_sink.dtype)
+    return (
+        dquery.transpose([0, 2, 1, 3]).astype(query.dtype),
+        dkey.transpose([0, 2, 1, 3]).astype(key.dtype),
+        dvalue.transpose([0, 2, 1, 3]).astype(value.dtype),
+        dsink,
+    )
+
+
+def _mock_flash_attn_fwd(
+    query,
+    key,
+    value,
+    causal=False,
+    return_lse=False,
+    startend_row_indices=None,
+    pack_gqa=False,
+    learnable_sink=None,
+    softmax_scale=None,
+):
+    """RR first forward: runs under no_grad and must hand back ``lse``."""
+    assert softmax_scale is None, "the CP a2a path rejects softmax_scale"
+    with paddle.no_grad():
+        out, lse = _attn_math(
+            query, key, value, learnable_sink, startend_row_indices, causal
+        )
+    return (out, lse) if return_lse else out
+
+
+def _mock_flash_attn_bwd(
+    query,
+    key,
+    value,
+    out,
+    dout,
+    lse,
+    flashmask_info,
+    learnable_sink=None,
+    softmax_scale=None,
+    causal=False,
+    deterministic=False,
+):
+    """RR backward: the closed-form gradient of the mocked forward."""
+    assert softmax_scale is None, "the CP a2a path rejects softmax_scale"
+    indices = (
+        None if flashmask_info is None else flashmask_info.startend_row_indices
+    )
+    with paddle.no_grad():
+        return _attn_grads(
+            query, key, value, learnable_sink, indices, dout, causal
+        )
+
+
+def _mock_facade_flashmask_attention(
+    query,
+    key,
+    value,
+    startend_row_indices=None,
+    *,
+    causal=False,
+    learnable_sink=None,
+    softmax_scale=None,
+    **kwargs,
+):
+    """Differentiable stand-in for the facade used by the plain Ulysses path."""
+    assert softmax_scale is None, "the CP a2a path rejects softmax_scale"
+    out, _ = _attn_math(
+        query, key, value, learnable_sink, startend_row_indices, causal
+    )
+    return out
+
+
+@contextlib.contextmanager
+def _mocked_kernel():
+    """Swap in the mock kernel on both paths, leaving all collectives real."""
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(
+            patch.object(
+                facade, "flashmask_attention", _mock_facade_flashmask_attention
+            )
+        )
+        # Pin the RR dispatch to the sink-capable branch; the kernels behind it
+        # are the mocks below, so no sm100 backend is needed.
+        stack.enter_context(
+            patch.object(rr_fa, "get_fa_version", lambda *a, **kw: 4)
+        )
+        for name, impl in (
+            ("_flash_attn_fwd", _mock_flash_attn_fwd),
+            ("_flash_attn_bwd", _mock_flash_attn_bwd),
+            ("FlashMaskInfoPaddle", _FakeFlashMaskInfo),
+        ):
+            # create=True: these names only exist when the cute backend does.
+            stack.enter_context(patch.object(rr_fa, name, impl, create=True))
+        yield
+
+
+# ------------------------------ inputs / reference ---------------------------
+
+
+def _per_head_startend_row_indices():
+    """Per-head [b, NUM_HEADS, SEQ, 2] indices, deliberately head-dependent.
+
+    A head dim of ``NUM_HEADS`` (not 1) is what makes the head slicing of the
+    mask observable: if a rank used the wrong head block, or skipped the slice,
+    its columns would be masked differently and the output would move. The band
+    ``down_start[j] = j + 32 + 16*head`` masks rows ``r >= down_start[j]`` for
+    key ``j``, so every row keeps a non-empty, head-specific key set.
+    """
+    keys = paddle.arange(SEQ, dtype="int32").reshape([1, 1, SEQ])
+    heads = paddle.arange(NUM_HEADS, dtype="int32").reshape([1, NUM_HEADS, 1])
+    down = paddle.clip(keys + 32 + 16 * heads, max=SEQ)
+    down = paddle.broadcast_to(down, [BATCH, NUM_HEADS, SEQ]).unsqueeze(-1)
+    return paddle.concat([down, paddle.zeros_like(down)], axis=-1)
+
+
+def _make_inputs():
+    """Identical full-sequence inputs on every rank (same seed, same order)."""
+    paddle.seed(SEED)
+    shape = [BATCH, SEQ, NUM_HEADS, HEAD_DIM]
+    query, key, value, dout = (
+        paddle.randn(shape).astype(DTYPE) for _ in range(4)
+    )
+    # fp32 like a master-weight sink; the +2.0 bias keeps it competitive with
+    # the row max so it actually shapes the softmax (and thus has real grad).
+    sink = paddle.randn([NUM_HEADS]).astype("float32") + 2.0
+    return query, key, value, sink, _per_head_startend_row_indices(), dout
+
+
+def _leaf(tensor):
+    out = tensor.detach()
+    out.stop_gradient = False
+    return out
+
+
+def _reference(query, key, value, sink, indices, dout):
+    """CP=1 semantics: with cp_size==1 both all-to-all are the identity."""
+    leaves = [_leaf(t) for t in (query, key, value, sink)]
+    out, _ = _attn_math(*leaves[:3], leaves[3], indices, False)
+    grads = paddle.grad(out, leaves, grad_outputs=dout)
+    return out.detach(), grads
+
+
+def _rel_l2(actual, expected):
+    a = actual.astype("float32").flatten()
+    b = expected.astype("float32").flatten()
+    return ((a - b).norm() / (b.norm() + 1e-30)).item()
+
+
+def _shard(full_tensor, rank):
+    chunk = full_tensor.shape[1] // CP_SIZE
+    return paddle.slice(
+        full_tensor, axes=[1], starts=[rank * chunk], ends=[(rank + 1) * chunk]
+    )
+
+
+# ---------------------------------- the test ---------------------------------
+
+
+class TestFlashMaskCpUlyssesA2A(unittest.TestCase):
+    """CP=2 ``contiguous_a2a`` forward/backward vs a CP=1 reference."""
+
+    def _run_cp(self, use_rr):
+        """Run one CP step and return the local results plus the reference."""
+        query, key, value, sink, indices, dout = _make_inputs()
+        ref_out, ref_grads = _reference(query, key, value, sink, indices, dout)
+
+        # contiguous_a2a shards the sequence contiguously in rank order, so the
+        # input leaf and the reference slice must both use contiguous slicing.
+        q_local = _leaf(scatter_contiguous(query, CP_GROUP, 1))
+        k_local = _leaf(scatter_contiguous(key, CP_GROUP, 1))
+        v_local = _leaf(scatter_contiguous(value, CP_GROUP, 1))
+        # The sink is replicated, never scattered: the CP path slices it itself.
+        sink_local = _leaf(sink)
+        dout_local = scatter_contiguous(dout, CP_GROUP, 1)
+
+        kwargs = {
+            "causal": False,
+            "learnable_sink": sink_local,
+            "mode": "contiguous_a2a",
+        }
+        if use_rr:
+            rr_attn = rr_fa.RefinedRcomputeFlashMaskCpAttention()
+            tracer = framework._dygraph_tracer()
+            prev_has_grad = tracer._has_grad
+            # First forward: the real attention, stashed for the RR backward.
+            tracer._has_grad = False
+            try:
+                rr_attn(q_local, k_local, v_local, indices, **kwargs)
+            finally:
+                tracer._has_grad = prev_has_grad
+            # Second forward: graph rebuild only, via the surrogate PyLayer.
+            tracer._has_grad = True
+            try:
+                out = rr_attn(q_local, k_local, v_local, indices, **kwargs)
+            finally:
+                tracer._has_grad = prev_has_grad
+        else:
+            out = flashmask_attention_cp(
+                q_local, k_local, v_local, indices, **kwargs
+            )
+
+        # The RR backward frees the saved output buffer, so snapshot first.
+        out_local = out.detach().clone()
+        grads = paddle.grad(
+            out,
+            [q_local, k_local, v_local, sink_local],
+            grad_outputs=dout_local,
+        )
+        dsink_partial = grads[3].clone()
+        dsink_summed = grads[3].clone()
+        dist.all_reduce(dsink_summed, group=CP_GROUP)
+        return {
+            "out": out_local,
+            "dq": grads[0],
+            "dk": grads[1],
+            "dv": grads[2],
+            "dsink_partial": dsink_partial,
+            "dsink": dsink_summed,
+            "ref_out": ref_out,
+            "ref_grads": ref_grads,
+        }
+
+    def _check_against_reference(self, got, tag):
+        for name, ref in (
+            ("out", got["ref_out"]),
+            ("dq", got["ref_grads"][0]),
+            ("dk", got["ref_grads"][1]),
+            ("dv", got["ref_grads"][2]),
+        ):
+            err = _rel_l2(got[name], _shard(ref, CP_RANK))
+            self.assertLess(
+                err, REL_L2_TOL, f"[{tag}] {name} rel L2 {err:.3e} vs reference"
+            )
+            # Discriminative: an off-by-rank shard must be plainly worse, so a
+            # loose tolerance cannot hide a wrong sequence partition.
+            other = _rel_l2(got[name], _shard(ref, (CP_RANK + 1) % CP_SIZE))
+            self.assertGreater(
+                other,
+                WRONG_SHARD_MIN,
+                f"[{tag}] {name} matches another rank's shard as well "
+                f"({other:.3e}); the comparison is not discriminative",
+            )
+
+        ref_sink = got["ref_grads"][3]
+        err = _rel_l2(got["dsink"], ref_sink)
+        self.assertLess(
+            err,
+            REL_L2_TOL,
+            f"[{tag}] dsink summed over the CP group is off by {err:.3e}; the "
+            "sink head shards do not reconstruct the full parameter grad",
+        )
+        # The other half of the same statement: per rank it must be a partial.
+        # If this ever matched, the sink would be getting a full (double
+        # counted) grad on every rank instead of its head shard.
+        partial = _rel_l2(got["dsink_partial"], ref_sink)
+        self.assertGreater(
+            partial,
+            WRONG_SHARD_MIN,
+            f"[{tag}] per-rank dsink already equals the full reference "
+            f"({partial:.3e}); the head slice is not taking effect",
+        )
+
+    def test_plain_a2a_matches_reference(self):
+        with _mocked_kernel():
+            self._check_against_reference(self._run_cp(False), "plain")
+
+    def test_rr_a2a_matches_reference(self):
+        with _mocked_kernel():
+            self._check_against_reference(self._run_cp(True), "rr")
+
+    def test_rr_matches_plain(self):
+        """The RR switch must not change any value it computes."""
+        with _mocked_kernel():
+            plain = self._run_cp(False)
+            rr = self._run_cp(True)
+        for name in ("out", "dq", "dk", "dv", "dsink"):
+            err = _rel_l2(rr[name], plain[name])
+            self.assertLess(
+                err, REL_L2_TOL, f"rr vs plain {name} rel L2 {err:.3e}"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/ai_edited_test/distributed/test_cp_balance_mode_dispatch.py
+++ b/tests/single_card_tests/ai_edited_test/distributed/test_cp_balance_mode_dispatch.py
@@ -805,6 +805,22 @@ class TestTransformerConfigCpBalanceMode(unittest.TestCase):
 class TestTransformerConfigHybridMlaCpMode(unittest.TestCase):
     """Tests for the hybrid_mla_cp_mode per-layer override."""
 
+    # The only context where the override is legal: a dsv4_hybrid whose
+    # csa_compress_ratios declares an MLA layer. That -2 also mandates the
+    # explicit MLA dimensions below.
+    MLA_HYBRID = {
+        "experimental_attention_variant": "dsv4_hybrid",
+        "num_hidden_layers": 2,
+        "csa_compress_ratios": [-2, 128],
+        "hybrid_mla_q_lora_rank": 8,
+        "hybrid_mla_kv_lora_rank": 8,
+        "hybrid_mla_qk_nope_head_dim": 8,
+        "hybrid_mla_qk_rope_head_dim": 8,
+        "hybrid_mla_v_head_dim": 8,
+        "hybrid_mla_num_attention_heads": 4,
+        "hybrid_mla_num_key_value_heads": 4,
+    }
+
     @staticmethod
     def _config(**kwargs):
         from paddlefleet.transformer.transformer_config import (
@@ -822,6 +838,7 @@ class TestTransformerConfigHybridMlaCpMode(unittest.TestCase):
         config = self._config(
             cp_balance_mode="contiguous_allgather",
             hybrid_mla_cp_mode="contiguous_a2a",
+            **self.MLA_HYBRID,
         )
         self.assertEqual(config.hybrid_mla_cp_mode, "contiguous_a2a")
 
@@ -841,6 +858,26 @@ class TestTransformerConfigHybridMlaCpMode(unittest.TestCase):
                 cp_balance_mode="dualchunk_allgather",
                 hybrid_mla_cp_mode="contiguous_a2a",
             )
+
+    def test_requires_dsv4_hybrid_with_mla_layer(self):
+        """The override only reaches MLA layers, so a config declaring none is
+        a dead setting: neither a plain model (no csa_compress_ratios at all)
+        nor a hybrid without a -2 layer may set it."""
+        for kwargs in (
+            {},
+            {**self.MLA_HYBRID, "csa_compress_ratios": [128, 0]},
+        ):
+            with (
+                self.subTest(ratios=kwargs.get("csa_compress_ratios")),
+                self.assertRaisesRegex(
+                    ValueError, "only be set in dsv4_hybrid"
+                ),
+            ):
+                self._config(
+                    cp_balance_mode="contiguous_allgather",
+                    hybrid_mla_cp_mode="contiguous_a2a",
+                    **kwargs,
+                )
 
 
 if __name__ == "__main__":

--- a/tests/single_card_tests/ai_edited_test/distributed/test_cp_balance_mode_dispatch.py
+++ b/tests/single_card_tests/ai_edited_test/distributed/test_cp_balance_mode_dispatch.py
@@ -802,5 +802,46 @@ class TestTransformerConfigCpBalanceMode(unittest.TestCase):
         self.assertEqual(config.cp_balance_mode, "contiguous_allgather")
 
 
+class TestTransformerConfigHybridMlaCpMode(unittest.TestCase):
+    """Tests for the hybrid_mla_cp_mode per-layer override."""
+
+    @staticmethod
+    def _config(**kwargs):
+        from paddlefleet.transformer.transformer_config import (
+            TransformerConfig,
+        )
+
+        return TransformerConfig(**kwargs)
+
+    def test_default_is_none(self):
+        """Unset means 'inherit cp_balance_mode'."""
+        self.assertIsNone(self._config().hybrid_mla_cp_mode)
+
+    def test_same_layout_family_accepted(self):
+        """contiguous_a2a on MLA next to contiguous_allgather elsewhere."""
+        config = self._config(
+            cp_balance_mode="contiguous_allgather",
+            hybrid_mla_cp_mode="contiguous_a2a",
+        )
+        self.assertEqual(config.hybrid_mla_cp_mode, "contiguous_a2a")
+
+    def test_invalid_value_rejected(self):
+        """Only the two contiguous modes are overridable per layer."""
+        for mode in ("nonexistent_mode", "dualchunk_allgather"):
+            with (
+                self.subTest(mode=mode),
+                self.assertRaisesRegex(ValueError, "hybrid_mla_cp_mode"),
+            ):
+                self._config(hybrid_mla_cp_mode=mode)
+
+    def test_cross_layout_family_rejected(self):
+        """dualchunk and contiguous place tokens differently, so no mixing."""
+        with self.assertRaisesRegex(ValueError, "same token layout"):
+            self._config(
+                cp_balance_mode="dualchunk_allgather",
+                hybrid_mla_cp_mode="contiguous_a2a",
+            )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/single_card_tests/ai_edited_test/recompute/test_ai_flash_attn_cp_rr_modes.py
+++ b/tests/single_card_tests/ai_edited_test/recompute/test_ai_flash_attn_cp_rr_modes.py
@@ -250,6 +250,49 @@ class TestUlyssesHelpers(unittest.TestCase):
             bool(paddle.all(sliced == per_head[:, 2:4, :, :]).item())
         )
 
+    def test_slice_ulysses_sink_heads(self):
+        self.assertIsNone(fa.slice_ulysses_sink_heads(None, 4, CpGroup()))
+
+        # The sink is replicated on every rank, so a wrong length silently
+        # mismatching the head shard would corrupt the attention numerics.
+        with self.assertRaisesRegex(AssertionError, "one entry per query head"):
+            fa.slice_ulysses_sink_heads(paddle.zeros([3]), 4, CpGroup())
+
+        # rank 1 of 2 owns the second contiguous head block, which is exactly
+        # what all-to-all(scatter_idx=2) hands this rank.
+        sliced = fa.slice_ulysses_sink_heads(
+            paddle.arange(4, dtype="float32"), 4, CpGroup()
+        )
+        self.assertEqual(sliced.tolist(), [2.0, 3.0])
+
+    def test_ulysses_local_first_forward_sink(self):
+        q = paddle.randn([1, 4, 2, 4])
+        sink = paddle.randn([2])
+        startend = paddle.zeros([1, 1, 4, 2], dtype="int32")
+
+        with (
+            patch.object(fa, "get_fa_version", return_value=4),
+            patch.object(
+                fa,
+                "_flash_attn_fwd",
+                return_value=(q, paddle.randn([1, 2, 4])),
+                create=True,
+            ) as mock_fwd,
+        ):
+            fa.ulysses_local_flashmask_first_fwd(
+                q, q, q, startend, False, sink, None
+            )
+        self.assertIs(mock_fwd.call_args.kwargs["learnable_sink"], sink)
+
+        # fa2/fa3 have no sink support, so fail loudly instead of dropping it.
+        with (
+            patch.object(fa, "get_fa_version", return_value=3),
+            self.assertRaises(NotImplementedError),
+        ):
+            fa.ulysses_local_flashmask_first_fwd(
+                q, q, q, startend, False, sink, None
+            )
+
     def test_ulysses_local_first_forward_versions_save_rr_tensors(self):
         q = paddle.randn([1, 4, 2, 4])
         out = paddle.randn([1, 4, 2, 4])
@@ -282,7 +325,7 @@ class TestUlyssesHelpers(unittest.TestCase):
                             fa, "flashmask_attention", fake_flashmask_attention
                         ):
                             result, hold = fa.ulysses_local_flashmask_first_fwd(
-                                q, q, q, startend, False, None
+                                q, q, q, startend, False, None, None
                             )
 
                 self.assertIs(result, out)
@@ -305,13 +348,17 @@ class TestUlyssesHelpers(unittest.TestCase):
             patch.object(fa, "get_fa_version", return_value=2),
             self.assertRaises(NotImplementedError),
         ):
-            fa.ulysses_local_flashmask_first_fwd(q, q, q, startend, False, 0.5)
+            fa.ulysses_local_flashmask_first_fwd(
+                q, q, q, startend, False, None, 0.5
+            )
 
         with (
             patch.object(fa, "get_fa_version", return_value=0),
             self.assertRaises(ValueError),
         ):
-            fa.ulysses_local_flashmask_first_fwd(q, q, q, startend, False, None)
+            fa.ulysses_local_flashmask_first_fwd(
+                q, q, q, startend, False, None, None
+            )
 
     def test_ulysses_local_v3_forward_signature_variants(self):
         q = paddle.randn([1, 4, 2, 4])
@@ -337,7 +384,7 @@ class TestUlyssesHelpers(unittest.TestCase):
                 ):
                     mock_c_ops.flashmask_attention_v2.return_value = (out, lse)
                     result, hold = fa.ulysses_local_flashmask_first_fwd(
-                        q, q, q, startend, False, None
+                        q, q, q, startend, False, None, None
                     )
 
                 self.assertIs(result, out)
@@ -530,6 +577,46 @@ class TestRefinedRcomputeFlashMaskCpAttentionModes(unittest.TestCase):
             self.assertIs(attn._second_fwd(self.q, self.k, self.v), self.out)
         mock_apply.assert_called_once()
 
+    def test_ulysses_sink_sliced_on_both_forwards(self):
+        """Both RR forwards must hand the local head shard of the sink down."""
+        attn = fa.RefinedRcomputeFlashMaskCpAttention()
+        sink = paddle.arange(2, dtype="float32")  # setUp tensors have 2 heads
+        local_hold = {
+            "result_attention": self.out,
+            "softmax_lse": self.lse,
+            "causal": False,
+            "fa_version": 4,
+        }
+        with (
+            patch.object(
+                fa.UlyssesAlltoAll, "apply", side_effect=lambda t, **kw: t
+            ),
+            patch.object(
+                fa,
+                "ulysses_local_flashmask_first_fwd",
+                return_value=(self.out, local_hold),
+            ) as mock_local,
+        ):
+            attn._ulysses_first_fwd(
+                self.q,
+                self.k,
+                self.v,
+                self.startend,
+                self.group,
+                False,
+                sink,
+                None,
+            )
+        self.assertEqual(mock_local.call_args.args[5].tolist(), [1.0])
+
+        hold = attn._hold_tensors_queue.get_nowait()
+        attn._hold_tensors_queue.put(hold)
+        with patch.object(
+            fa.FlashMaskUlyssesCpFunctor, "apply", return_value=self.out
+        ) as mock_apply:
+            attn._second_fwd(self.q, self.k, self.v, learnable_sink=sink)
+        self.assertEqual(mock_apply.call_args.args[3].tolist(), [1.0])
+
     def _ulysses_hold(self, fa_version, **local_extra):
         local_hold = {
             "result_attention": self.out,
@@ -555,7 +642,7 @@ class TestRefinedRcomputeFlashMaskCpAttentionModes(unittest.TestCase):
 
         self.assertIs(
             fa.FlashMaskUlyssesCpFunctor.forward(
-                ctx, self.q, self.k, self.v, hold
+                ctx, self.q, self.k, self.v, None, hold
             ),
             self.out,
         )
@@ -604,7 +691,9 @@ class TestRefinedRcomputeFlashMaskCpAttentionModes(unittest.TestCase):
         local_grad = paddle.ones_like(self.out)
         hold = self._ulysses_hold(4)
 
-        fa.FlashMaskUlyssesCpFunctor.forward(ctx, self.q, self.k, self.v, hold)
+        fa.FlashMaskUlyssesCpFunctor.forward(
+            ctx, self.q, self.k, self.v, None, hold
+        )
         with (
             patch.object(fa, "_ulysses_fused_supported", return_value=True),
             patch.object(
@@ -646,7 +735,9 @@ class TestRefinedRcomputeFlashMaskCpAttentionModes(unittest.TestCase):
         local_grad = paddle.ones_like(self.out)
         hold = self._ulysses_hold(2, seed_offset=seed)
 
-        fa.FlashMaskUlyssesCpFunctor.forward(ctx, self.q, self.k, self.v, hold)
+        fa.FlashMaskUlyssesCpFunctor.forward(
+            ctx, self.q, self.k, self.v, None, hold
+        )
         with (
             patch.object(fa, "_ulysses_fused_supported", return_value=False),
             patch.object(
@@ -701,7 +792,7 @@ class TestRefinedRcomputeFlashMaskCpAttentionModes(unittest.TestCase):
                     3, result_attention=out, softmax_lse=lse
                 )
                 fa.FlashMaskUlyssesCpFunctor.forward(
-                    ctx, self.q, self.k, self.v, hold
+                    ctx, self.q, self.k, self.v, None, hold
                 )
                 with (
                     patch.object(fa, "flashmask_attention", fake_attention),
@@ -732,10 +823,63 @@ class TestRefinedRcomputeFlashMaskCpAttentionModes(unittest.TestCase):
                     local_grad,
                 )
 
+    def test_ulysses_functor_backward_sink_grad(self):
+        """The sink grad slot is returned only when the sink needs a grad."""
+        local_grad = paddle.ones_like(self.out)
+        sink_grad = paddle.randn([1])
+        for requires_grad, expected_len in ((True, 4), (False, 3)):
+            with self.subTest(requires_grad=requires_grad):
+                sink = paddle.zeros([1])
+                sink.stop_gradient = not requires_grad
+                # backward clears the saved output/LSE data pointers, so each
+                # subtest needs its own tensors.
+                out, lse = paddle.randn([1, 4, 2, 4]), paddle.randn([1, 2, 4])
+                hold = self._ulysses_hold(
+                    4, result_attention=out, softmax_lse=lse
+                )
+                hold["result_attention"] = out
+                ctx = FakeCtx()
+                fa.FlashMaskUlyssesCpFunctor.forward(
+                    ctx, self.q, self.k, self.v, sink, hold
+                )
+                with (
+                    patch.object(
+                        fa, "_ulysses_fused_supported", return_value=False
+                    ),
+                    patch.object(
+                        fa,
+                        "_ulysses_single_all_to_all",
+                        side_effect=(local_grad, self.q, self.k, self.v),
+                    ),
+                    patch.object(
+                        fa,
+                        "FlashMaskInfoPaddle",
+                        return_value=object(),
+                        create=True,
+                    ),
+                    patch.object(
+                        fa,
+                        "_flash_attn_bwd",
+                        return_value=(self.q, self.k, self.v, sink_grad),
+                        create=True,
+                    ) as mock_backward,
+                ):
+                    grads = fa.FlashMaskUlyssesCpFunctor.backward(
+                        ctx, paddle.ones_like(self.out)
+                    )
+                self.assertIs(
+                    mock_backward.call_args.kwargs["learnable_sink"], sink
+                )
+                self.assertEqual(len(grads), expected_len)
+                if requires_grad:
+                    self.assertIs(grads[3], sink_grad)
+
     def test_ulysses_functor_backward_rejects_invalid_fa_version(self):
         ctx = FakeCtx()
         hold = self._ulysses_hold(0)
-        fa.FlashMaskUlyssesCpFunctor.forward(ctx, self.q, self.k, self.v, hold)
+        fa.FlashMaskUlyssesCpFunctor.forward(
+            ctx, self.q, self.k, self.v, None, hold
+        )
         with (
             patch.object(fa, "_ulysses_fused_supported", return_value=False),
             patch.object(
@@ -765,7 +909,9 @@ class TestRefinedRcomputeFlashMaskCpAttentionModes(unittest.TestCase):
                 )
                 mock_apply.assert_called_once()
 
-        attn._hold_tensors_queue.put({"mode": "contiguous_a2a"})
+        attn._hold_tensors_queue.put(
+            {"mode": "contiguous_a2a", "group": self.group}
+        )
         with (
             patch.object(
                 fa.FlashMaskUlyssesCpFunctor, "apply", return_value=self.out
@@ -793,21 +939,17 @@ class TestRefinedRcomputeFlashMaskCpAttentionModes(unittest.TestCase):
             attn._first_fwd(self.q, self.k, self.v, self.startend, dropout=0.1)
         with self._patch_group(), self.assertRaises(AssertionError):
             attn._first_fwd(self.q[:, :3], self.k, self.v, self.startend)
-        for kwargs in ({"learnable_sink": self.q}, {"softmax_scale": 0.5}):
-            with (
-                self.subTest(kwargs=kwargs),
-                self.assertRaises(NotImplementedError),
-            ):
-                attn._ulysses_first_fwd(
-                    self.q,
-                    self.k,
-                    self.v,
-                    self.startend,
-                    self.group,
-                    False,
-                    kwargs.get("learnable_sink"),
-                    kwargs.get("softmax_scale"),
-                )
+        with self.assertRaises(NotImplementedError):
+            attn._ulysses_first_fwd(
+                self.q,
+                self.k,
+                self.v,
+                self.startend,
+                self.group,
+                False,
+                None,
+                0.5,
+            )
 
 
 if __name__ == "__main__":

--- a/tests/single_card_tests/ai_edited_test/recompute/test_ai_flash_attn_cp_rr_modes.py
+++ b/tests/single_card_tests/ai_edited_test/recompute/test_ai_flash_attn_cp_rr_modes.py
@@ -255,7 +255,7 @@ class TestUlyssesHelpers(unittest.TestCase):
 
         # The sink is replicated on every rank, so a wrong length silently
         # mismatching the head shard would corrupt the attention numerics.
-        with self.assertRaisesRegex(AssertionError, "one entry per query head"):
+        with self.assertRaisesRegex(ValueError, "one entry per query head"):
             fa.slice_ulysses_sink_heads(paddle.zeros([3]), 4, CpGroup())
 
         # rank 1 of 2 owns the second contiguous head block, which is exactly

--- a/tests/single_card_tests/test_ulysses_context_parallel.py
+++ b/tests/single_card_tests/test_ulysses_context_parallel.py
@@ -416,7 +416,7 @@ class TestFlashmaskAttentionUlysses(unittest.TestCase):
             "paddle.distributed.fleet.get_hybrid_communicate_group",
             return_value=mock_hcg,
         ):
-            with self.assertRaises(AssertionError) as ctx:
+            with self.assertRaises(ValueError) as ctx:
                 flashmask_attention_ulysses(
                     query=paddle.randn([2, 4, 4, 8]),
                     key=paddle.randn([2, 4, 4, 8]),
@@ -1279,9 +1279,12 @@ class TestDotProductAttentionContiguousA2a(unittest.TestCase):
 
         config = self._make_config(
             cp_balance_mode="contiguous_allgather",
-            hybrid_mla_cp_mode="contiguous_a2a",
             multi_latent_attention=False,
         )
+        # Set past __post_init__ on purpose: whether this field may be set at
+        # all is a config-level concern (it needs a dsv4_hybrid with a -2
+        # layer), while this test only covers how DPA dispatches on it.
+        config.hybrid_mla_cp_mode = "contiguous_a2a"
         attn = self._make_attn_instance(config)
         attn.eval()
 
@@ -1327,16 +1330,14 @@ class TestDotProductAttentionContiguousA2a(unittest.TestCase):
         )
         from paddlefleet.transformer.enums import AttnMaskType
 
-        config = self._make_config(
-            cp_balance_mode="contiguous_allgather",
-            hybrid_mla_cp_mode="contiguous_a2a",
-        )
+        config = self._make_config(cp_balance_mode="contiguous_allgather")
+        config.hybrid_mla_cp_mode = "contiguous_a2a"
         with (
             patch(
                 "paddlefleet.transformer.dot_product_attention.get_context_parallel_world_size",
                 return_value=2,
             ),
-            self.assertRaises(AssertionError) as ctx,
+            self.assertRaises(ValueError) as ctx,
         ):
             DotProductAttention(
                 config=config,

--- a/tests/single_card_tests/test_ulysses_context_parallel.py
+++ b/tests/single_card_tests/test_ulysses_context_parallel.py
@@ -405,8 +405,8 @@ class TestFlashmaskAttentionUlysses(unittest.TestCase):
         mock_hcg.get_context_parallel_group.return_value = mock_cp_group
         return mock_hcg, mock_cp_group
 
-    def test_learnable_sink_raises(self):
-        """Should raise NotImplementedError if learnable_sink is provided."""
+    def test_learnable_sink_wrong_shape_raises(self):
+        """Should assert if learnable_sink has no entry per query head."""
         from paddlefleet.context_parallel_utils import (
             flashmask_attention_ulysses,
         )
@@ -416,7 +416,7 @@ class TestFlashmaskAttentionUlysses(unittest.TestCase):
             "paddle.distributed.fleet.get_hybrid_communicate_group",
             return_value=mock_hcg,
         ):
-            with self.assertRaises(NotImplementedError) as ctx:
+            with self.assertRaises(AssertionError) as ctx:
                 flashmask_attention_ulysses(
                     query=paddle.randn([2, 4, 4, 8]),
                     key=paddle.randn([2, 4, 4, 8]),
@@ -426,7 +426,7 @@ class TestFlashmaskAttentionUlysses(unittest.TestCase):
                     ),
                     learnable_sink=paddle.randn([1]),
                 )
-            self.assertIn("learnable_sink", str(ctx.exception))
+            self.assertIn("one entry per query head", str(ctx.exception))
 
     def test_softmax_scale_raises(self):
         """Should raise NotImplementedError if softmax_scale is provided."""
@@ -598,6 +598,78 @@ class TestFlashmaskAttentionUlysses(unittest.TestCase):
             else fm_call_kwargs[0][3]
         )
         self.assertEqual(used_mask.shape[1], 2)  # sliced from 4 to 2
+
+    @patch("paddlefleet_ops.flash_mask_facade.flashmask_attention")
+    @patch("paddlefleet.context_parallel_utils.UlyssesAlltoAll.apply")
+    def test_learnable_sink_sliced_to_rank_head_group(
+        self, mock_a2a_apply, mock_fm_attn
+    ):
+        """learnable_sink must be sliced to this rank's head group."""
+        from paddlefleet.context_parallel_utils import (
+            flashmask_attention_ulysses,
+        )
+
+        mock_hcg, _ = self._mock_fleet_context(cp_size=2, cp_rank=1)
+
+        def a2a_side_effect(inp, scatter_idx, gather_idx, batch_dim_idx, group):
+            if scatter_idx == 2:
+                return paddle.randn([2, 8, 2, 8])
+            return paddle.randn([2, 4, 4, 8])
+
+        mock_a2a_apply.side_effect = a2a_side_effect
+        mock_fm_attn.return_value = paddle.randn([2, 8, 2, 8])
+
+        sink = paddle.arange(4, dtype="float32")
+
+        with patch(
+            "paddle.distributed.fleet.get_hybrid_communicate_group",
+            return_value=mock_hcg,
+        ):
+            flashmask_attention_ulysses(
+                query=paddle.randn([2, 4, 4, 8]),
+                key=paddle.randn([2, 4, 4, 8]),
+                value=paddle.randn([2, 4, 4, 8]),
+                startend_row_indices=paddle.zeros([2, 1, 8, 2], dtype="int32"),
+                learnable_sink=sink,
+            )
+
+        # rank=1, heads_per_rank=2 -> global heads [2, 4)
+        used_sink = mock_fm_attn.call_args[1]["learnable_sink"]
+        self.assertEqual(used_sink.shape, [2])
+        self.assertEqual(used_sink.tolist(), [2.0, 3.0])
+
+    @patch("paddlefleet_ops.flash_mask_facade.flashmask_attention")
+    @patch("paddlefleet.context_parallel_utils.UlyssesAlltoAll.apply")
+    def test_learnable_sink_none_forwarded_as_none(
+        self, mock_a2a_apply, mock_fm_attn
+    ):
+        """Without a sink, None must reach the kernel unchanged."""
+        from paddlefleet.context_parallel_utils import (
+            flashmask_attention_ulysses,
+        )
+
+        mock_hcg, _ = self._mock_fleet_context(cp_size=2, cp_rank=0)
+
+        def a2a_side_effect(inp, scatter_idx, gather_idx, batch_dim_idx, group):
+            if scatter_idx == 2:
+                return paddle.randn([2, 8, 2, 8])
+            return paddle.randn([2, 4, 4, 8])
+
+        mock_a2a_apply.side_effect = a2a_side_effect
+        mock_fm_attn.return_value = paddle.randn([2, 8, 2, 8])
+
+        with patch(
+            "paddle.distributed.fleet.get_hybrid_communicate_group",
+            return_value=mock_hcg,
+        ):
+            flashmask_attention_ulysses(
+                query=paddle.randn([2, 4, 4, 8]),
+                key=paddle.randn([2, 4, 4, 8]),
+                value=paddle.randn([2, 4, 4, 8]),
+                startend_row_indices=paddle.zeros([2, 1, 8, 2], dtype="int32"),
+            )
+
+        self.assertIsNone(mock_fm_attn.call_args[1]["learnable_sink"])
 
 
 # PLACEHOLDER_SECTION_5
@@ -1109,37 +1181,6 @@ class TestDotProductAttentionContiguousA2a(unittest.TestCase):
         call_kwargs = mock_rr_cp.call_args.kwargs
         self.assertEqual(call_kwargs.get("mode"), "contiguous_a2a")
 
-    def test_forward_contiguous_a2a_without_mla_raises(self):
-        """contiguous_a2a without multi_latent_attention should raise."""
-        config = self._make_config(
-            cp_balance_mode="contiguous_a2a", multi_latent_attention=False
-        )
-        attn = self._make_attn_instance(config)
-        attn.eval()
-
-        q = paddle.randn([2, 4, 4, 32], dtype="bfloat16")
-        k = paddle.randn([2, 4, 4, 32], dtype="bfloat16")
-        v = paddle.randn([2, 4, 4, 32], dtype="bfloat16")
-        mask = paddle.zeros([2, 1, 4, 2], dtype="int32")
-
-        with (
-            patch(
-                "paddlefleet.transformer.dot_product_attention.get_context_parallel_world_size",
-                return_value=2,
-            ),
-            self.assertRaises(NotImplementedError) as ctx,
-        ):
-            attn(
-                q,
-                k,
-                v,
-                None,
-                attn_mask_startend_row_indices=mask,
-                use_rr_flash_attention=False,
-            )
-
-        self.assertIn("only supports mla", str(ctx.exception))
-
     @patch(
         "paddlefleet.transformer.dot_product_attention.flashmask_attention_cp"
     )
@@ -1221,6 +1262,90 @@ class TestDotProductAttentionContiguousA2a(unittest.TestCase):
 
         call_kwargs = mock_cp_attn.call_args[1]
         self.assertFalse(call_kwargs.get("causal", True))
+
+    @patch(
+        "paddlefleet.transformer.dot_product_attention.flashmask_attention_cp"
+    )
+    def test_hybrid_mla_cp_mode_overrides_model_wide_mode(self, mock_cp_attn):
+        """hybrid_mla_cp_mode wins over cp_balance_mode, and non-MLA is allowed.
+
+        This is the DSV4 MLA+HCA hybrid setup: the model stays on
+        contiguous_allgather (which the HCA layers require) while this layer
+        runs Ulysses. multi_latent_attention is False because in a hybrid that
+        flag is model-wide, which is exactly why the old "a2a only supports
+        mla" restriction had to go.
+        """
+        from paddlefleet.transformer.enums import AttnMaskType
+
+        config = self._make_config(
+            cp_balance_mode="contiguous_allgather",
+            hybrid_mla_cp_mode="contiguous_a2a",
+            multi_latent_attention=False,
+        )
+        attn = self._make_attn_instance(config)
+        attn.eval()
+
+        mock_cp_attn.return_value = paddle.randn(
+            [2, 4, 4, 32], dtype="bfloat16"
+        )
+        mask = paddle.zeros([2, 1, 4, 1], dtype="int32")
+
+        with (
+            patch(
+                "paddlefleet.transformer.dot_product_attention.get_context_parallel_world_size",
+                return_value=2,
+            ),
+            patch.object(
+                attn,
+                "expand_attn_mask_startend_row_indices_for_cp",
+                side_effect=AssertionError("Should not be called"),
+            ) as mock_expand,
+        ):
+            attn(
+                paddle.randn([2, 4, 4, 32], dtype="bfloat16"),
+                paddle.randn([2, 4, 4, 32], dtype="bfloat16"),
+                paddle.randn([2, 4, 4, 32], dtype="bfloat16"),
+                None,
+                attn_mask_startend_row_indices=mask,
+                # dsv4_hybrid layer specs hardcode a causal mask type
+                attn_mask_type=AttnMaskType.causal,
+                use_rr_flash_attention=False,
+            )
+
+        mock_expand.assert_not_called()
+        call_kwargs = mock_cp_attn.call_args[1]
+        self.assertEqual(call_kwargs.get("mode"), "contiguous_a2a")
+        # The global-length mask must reach Ulysses unexpanded and causal must
+        # stay True: that pair is what makes a2a equivalent to CP=1 flashmask.
+        self.assertIs(call_kwargs.get("startend_row_indices"), mask)
+        self.assertTrue(call_kwargs.get("causal"))
+
+    def test_hybrid_mla_cp_mode_rejects_swa_layer(self):
+        """An SWA layer would silently miss the swap2p rewrite, so reject it."""
+        from paddlefleet.transformer.dot_product_attention import (
+            DotProductAttention,
+        )
+        from paddlefleet.transformer.enums import AttnMaskType
+
+        config = self._make_config(
+            cp_balance_mode="contiguous_allgather",
+            hybrid_mla_cp_mode="contiguous_a2a",
+        )
+        with (
+            patch(
+                "paddlefleet.transformer.dot_product_attention.get_context_parallel_world_size",
+                return_value=2,
+            ),
+            self.assertRaises(AssertionError) as ctx,
+        ):
+            DotProductAttention(
+                config=config,
+                layer_number=1,
+                attn_mask_type=AttnMaskType.causal,
+                attention_type="self",
+                is_swa=True,
+            )
+        self.assertIn("hybrid_mla_cp_mode", str(ctx.exception))
 
 
 # =============================================================================

--- a/tests/test_configs.yaml
+++ b/tests/test_configs.yaml
@@ -143,6 +143,10 @@ tests:
   - test_case: [tests/multi_card_tests/transformer/test_flash_mask_sink_cp.py]
     products:
       - num_gpus: 2
+  # transformer: FlashMask Ulysses a2a context-parallel, plain + RR (CP=2)
+  - test_case: [tests/multi_card_tests/transformer/test_flash_mask_cp_a2a.py]
+    products:
+      - num_gpus: 2
   # transformer: CSA context-parallel, including cuDNN indexer docmask path (CP=2)
   - test_case: [tests/multi_card_tests/transformer/test_csa_attention_cp.py]
     products:


### PR DESCRIPTION
### PR Category
Operator Mechanism


### PR Types
Performance


### Description

支持动态 MLA 设置下的 MLA Ulysses All to All, learnable sink 处理以及 RR attention。

- 目前 hybrid MLA 只支持单独开 contiguous_a2a。对应开关默认值是 None，None 情况下对应 MLA layer 的 CP 通信模式跟着全局的 cp_balance_mode 走。

### 是否引起精度变化
否
