### PR TITLE
[DSv4 Hybrid] Support staged selective recompute for the HCA attention block (pre-CSA / CSA / post-CSA)

### DIFF
--- a/src/paddlefleet/transformer/dsv4_hybrid_attention.py
+++ b/src/paddlefleet/transformer/dsv4_hybrid_attention.py
@@ -83,6 +83,41 @@ def _q_rms_norm(
         return result
 
 
+def _resolve_selective_recompute_flag(
+    config: TransformerConfig,
+    layer_number: int,
+    module_name: str,
+) -> bool:
+    """Resolve a per-layer selective-recompute flag for ``module_name``.
+
+    Honours ``recompute_num_layers`` together with ``recompute_method``
+    (``first_n`` / ``block``) the same way the other selective modules do.
+    Only list configuration of ``recompute_modules`` is supported; a dict entry
+    is rejected explicitly rather than silently ignored.
+    """
+    if config.recompute_granularity != "selective":
+        return False
+    modules = config.recompute_modules
+    if modules is None:
+        return False
+    if isinstance(modules, dict):
+        if module_name in modules:
+            raise ValueError(
+                f"recompute_modules['{module_name}'] only supports list "
+                "configuration"
+            )
+        return False
+    if module_name not in modules:
+        return False
+    num_layers = config.recompute_num_layers
+    if num_layers is None:
+        return True
+    if config.recompute_method == "block":
+        return need_recompute_in_block(layer_number, config, num_layers)
+    # TransformerConfig already asserts block/first_n for selective granularity.
+    return need_recompute_in_first_n(layer_number, config, num_layers)
+
+
 def _validate_dsv4_boundary_values(
     startend_row_indices: Tensor,
     upper_bound: int,
@@ -516,8 +551,38 @@ class DSv4HybridAttention(Attention):
             and config.recompute_modules is not None
             and "full_attn" in config.recompute_modules
         )
-        self._full_attn_recompute = None
+        # Stage-level selective recompute. The three stages partition exactly
+        # what "full_attn" covers, so they can be enabled independently:
+        #   hca_pre_csa  -> _pre_csa_forward  (q/kv projections, qk norm, RoPE)
+        #   hca_csa      -> _csa_forward      (Compressor + Indexer + sparse attn)
+        #   hca_post_csa -> _post_csa_forward (inverse RoPE, VHA postmix,
+        #                                     grouped o_group_proj, gated_attn)
+        # Unlike "full_attn"/"gated_attn" (plain membership tests kept for
+        # backward compatibility), these honour recompute_num_layers +
+        # recompute_method, like "vha_postmix".
+        self.recompute_pre_csa = _resolve_selective_recompute_flag(
+            config, layer_number, "hca_pre_csa"
+        )
+        self.recompute_csa = _resolve_selective_recompute_flag(
+            config, layer_number, "hca_csa"
+        )
+        self.recompute_post_csa = _resolve_selective_recompute_flag(
+            config, layer_number, "hca_post_csa"
+        )
+        if self.recompute_full_attn and (
+            self.recompute_pre_csa
+            or self.recompute_csa
+            or self.recompute_post_csa
+        ):
+            raise ValueError(
+                "recompute_modules cannot combine 'full_attn' with the "
+                "stage-level entries 'hca_pre_csa'/'hca_csa'/'hca_post_csa'; "
+                "'full_attn' already covers all three stages"
+            )
         self._gate_recompute = None
+        # Holder for the segment that ends right before o_proj (csa+post, or
+        # post alone), whose output can be discarded instead of kept.
+        self._stage_recompute = None
 
         # VHA postmix: low-rank cross-head mixing of the attention output, applied
         # after inverse RoPE (head space) and before the grouped output projection.
@@ -658,92 +723,294 @@ class DSv4HybridAttention(Attention):
                 dense_mode=self.config.csa_dense_mode,
             )
 
-        # Full attention recompute: wrap qkv + core_attn + inv_rope + o_group_proj + gated_attn
-        # into one RecomputeWithoutOutput block. All intermediates (query, key, value, etc.)
-        # are freed after forward (no_grad), and the output is discarded after o_proj.
+        # The block runs as pre-CSA -> CSA -> post-CSA; which of those stages
+        # sit inside a recompute segment is decided in _attn_forward.
         input_ids = kwargs.get("input_ids", None)
-        if self.recompute_full_attn and self.training:
-            self._full_attn_recompute = RecomputeWithoutOutput()
-            core_attn_out = self._full_attn_recompute.recompute(
-                self._full_attn_forward,
-                # This segment contains core_attention, i.e. the CSA Indexer and its
-                # side-attached loss. RecomputeWithoutOutput is a PyLayer whose
-                # output is differentiable only if some input is, and with a frozen
-                # backbone (train_indexer_only) hidden_states is detached. It
-                # would then skip registering its recompute hook altogether
-                # (tensor_parallel/random.py:590 checks stop_gradient) and the
-                # Indexer would get no gradient, with no error and no warning.
-                keep_indexer_grad_path(hidden_states, self.config),
-                attention_mask,
-                position_offset,
-                docmask_meta,
-                input_ids,
-                True,  # _in_full_recompute
-                preserve_rng_state=False,
-                share_grad_holder=True,
-            )
+        if self.training and (
+            self.recompute_full_attn
+            or self.recompute_pre_csa
+            or self.recompute_csa
+            or self.recompute_post_csa
+        ):
+            # A segment can contain core_attention, i.e. the CSA Indexer and its
+            # side-attached loss. Every recompute wrapper is a PyLayer whose
+            # output is differentiable only if some input is, and with a frozen
+            # backbone (train_indexer_only) hidden_states is detached. The
+            # wrapper would then skip registering its recompute hook altogether
+            # (tensor_parallel/random.py:590 checks stop_gradient) and the
+            # Indexer would get no gradient, with no error and no warning.
+            # Anchor once here: the first segment's output inherits it, so the
+            # later ones short-circuit.
+            hidden_states = keep_indexer_grad_path(hidden_states, self.config)
 
-            # Output projection
-            output, bias = self.o_proj(core_attn_out)
+        core_attn_out = self._attn_forward(
+            hidden_states,
+            attention_mask,
+            position_offset,
+            docmask_meta,
+            input_ids,
+        )
 
-            # Discard full_attn output (core_attn_out) — frees ~512 MB
-            self._full_attn_recompute.discard_output_and_register_recompute(
-                output
-            )
-            self._full_attn_recompute = None
-        else:
-            core_attn_out = self._full_attn_forward(
-                hidden_states,
-                attention_mask,
-                position_offset,
-                docmask_meta,
-                input_ids,
-            )
+        # Output projection
+        output, bias = self.o_proj(core_attn_out)
 
-            # Output projection
-            output, bias = self.o_proj(core_attn_out)
+        # A segment ending right before o_proj had its output discarded (frees
+        # ~512 MB for the full_attn span); it is re-materialized from o_proj's
+        # output during backward.
+        if self._stage_recompute is not None:
+            self._stage_recompute.discard_output_and_register_recompute(output)
+            self._stage_recompute = None
 
-            # Discard gated_attn output if it was independently recomputed
-            if (
-                hasattr(self, "_gate_recompute")
-                and self._gate_recompute is not None
-            ):
-                self._gate_recompute.discard_output_and_register_recompute(
-                    output
-                )
-                self._gate_recompute = None
+        # Discard gated_attn output if it was independently recomputed
+        if self._gate_recompute is not None:
+            self._gate_recompute.discard_output_and_register_recompute(output)
+            self._gate_recompute = None
 
         if original_b > 1:
             output = _unpack_dsv4_logical_batch(output, original_b, original_sq)
 
         return output, bias
 
-    def _full_attn_forward(
+    def _attn_forward(
         self,
         hidden_states: Tensor,
         attention_mask,
         position_offset: int,
         docmask_meta,
         input_ids,
-        _in_full_recompute: bool = False,
     ) -> Tensor:
-        """Full attention forward: qkv_proj + core_attn + inv_rope + o_group_proj + gated_attn.
+        """The attention block: pre-CSA -> CSA -> post-CSA.
 
-        Factored out so that paddle.distributed.fleet.utils.recompute can wrap it.
-        The large intermediate tensors (query, key, value) are internal to this function
-        and will be freed after this function returns during forward, then recomputed
-        during backward.
+        The stage order lives here; the selective-recompute flags only move the
+        segment boundaries. How a stage is wrapped follows from what stays alive
+        after it:
+
+        - a segment that ends right before ``o_proj`` (the ``full_attn`` span,
+          csa+post, or post alone) uses ``RecomputeWithoutOutput``: its output is
+          dead once ``o_proj`` consumed it, so ``forward`` discards it.
+        - ``hca_pre_csa`` keeps ``query``/``key``/``value`` -- they are segment
+          outputs consumed by the CSA stage -- so a plain ``recompute`` only
+          frees the projection/norm/RoPE intermediates.
+        - ``hca_csa`` alone is a plain ``recompute``; its output feeds post-CSA.
+
+        csa+post are fused into one segment rather than nested: discarding the
+        CSA output would invalidate the input a separate post-CSA segment saved
+        for its own replay.
         """
-        query, key, value, q_compressed, kv_compressed = (
-            self.get_query_key_value_tensors(
-                hidden_states=hidden_states,
-                position_offset=position_offset,
-                docmask_meta=docmask_meta,
+        training = self.training
+        rc_full = self.recompute_full_attn and training
+        rc_pre = self.recompute_pre_csa and training
+        rc_csa = self.recompute_csa and training
+        rc_post = self.recompute_post_csa and training
+
+        # All three stages in one segment. Mutually exclusive with the per-stage
+        # entries (rejected in __init__) and the only span that also frees
+        # query/key/value.
+        if rc_full:
+            self._stage_recompute = RecomputeWithoutOutput()
+            return self._stage_recompute.recompute(
+                self._all_stages_forward,
+                hidden_states,
+                attention_mask,
+                position_offset,
+                docmask_meta,
+                input_ids,
+                True,  # in_outer_recompute
+                preserve_rng_state=False,
+                share_grad_holder=True,
             )
+
+        # Stage 1: pre-CSA
+        if rc_pre:
+            # _pre_csa_deduped_forward drops the key/value alias; see there.
+            pre_outputs = recompute(
+                self._pre_csa_deduped_forward,
+                hidden_states,
+                position_offset,
+                docmask_meta,
+                preserve_rng_state=False,
+            )
+            if len(pre_outputs) == 4:
+                query, key, q_compressed, kv_compressed = pre_outputs
+                value = key
+            else:
+                query, key, value, q_compressed, kv_compressed = pre_outputs
+        else:
+            query, key, value, q_compressed, kv_compressed = (
+                self._pre_csa_forward(
+                    hidden_states, position_offset, docmask_meta
+                )
+            )
+
+        csa_args = (
+            query,
+            key,
+            value,
+            attention_mask,
+            hidden_states,
+            q_compressed,
+            input_ids,
+            docmask_meta,
         )
 
-        # Core attention (CompressedSparseAttention)
-        core_attn_out = self.core_attention(
+        # Stages 2 and 3
+        if rc_csa and rc_post:
+            self._stage_recompute = RecomputeWithoutOutput()
+            return self._stage_recompute.recompute(
+                self._csa_post_forward,
+                *csa_args,
+                position_offset,
+                True,  # in_outer_recompute
+                preserve_rng_state=False,
+                share_grad_holder=True,
+            )
+
+        if rc_csa:
+            core_attn_out = recompute(
+                self._csa_forward, *csa_args, preserve_rng_state=False
+            )
+        else:
+            core_attn_out = self._csa_forward(*csa_args)
+
+        if rc_post:
+            self._stage_recompute = RecomputeWithoutOutput()
+            return self._stage_recompute.recompute(
+                self._post_csa_forward,
+                core_attn_out,
+                hidden_states,
+                q_compressed,
+                position_offset,
+                docmask_meta,
+                True,  # in_outer_recompute
+                preserve_rng_state=False,
+                share_grad_holder=True,
+            )
+
+        return self._post_csa_forward(
+            core_attn_out,
+            hidden_states,
+            q_compressed,
+            position_offset,
+            docmask_meta,
+        )
+
+    def _csa_post_forward(
+        self,
+        query: Tensor,
+        key: Tensor,
+        value: Tensor,
+        attention_mask,
+        hidden_states: Tensor,
+        q_compressed: Tensor,
+        input_ids,
+        docmask_meta,
+        position_offset: int,
+        in_outer_recompute: bool = False,
+    ) -> Tensor:
+        """Stages 2 and 3 back to back (the csa+post span)."""
+        core_attn_out = self._csa_forward(
+            query,
+            key,
+            value,
+            attention_mask,
+            hidden_states,
+            q_compressed,
+            input_ids,
+            docmask_meta,
+        )
+        return self._post_csa_forward(
+            core_attn_out,
+            hidden_states,
+            q_compressed,
+            position_offset,
+            docmask_meta,
+            in_outer_recompute,
+        )
+
+    def _all_stages_forward(
+        self,
+        hidden_states: Tensor,
+        attention_mask,
+        position_offset: int,
+        docmask_meta,
+        input_ids,
+        in_outer_recompute: bool = False,
+    ) -> Tensor:
+        """All three stages back to back (the ``full_attn`` span).
+
+        query/key/value are internal to this call, so wrapping it in a single
+        recompute segment frees them for the whole forward.
+        """
+        query, key, value, q_compressed, _ = self._pre_csa_forward(
+            hidden_states, position_offset, docmask_meta
+        )
+        return self._csa_post_forward(
+            query,
+            key,
+            value,
+            attention_mask,
+            hidden_states,
+            q_compressed,
+            input_ids,
+            docmask_meta,
+            position_offset,
+            in_outer_recompute,
+        )
+
+    def _pre_csa_forward(
+        self,
+        hidden_states: Tensor,
+        position_offset: int,
+        docmask_meta,
+    ):
+        """Stage 1: everything before the CSA core attention.
+
+        q_down/q_up projections, qk norm, kv projection and RoPE.
+        Returns (query, key, value, q_compressed, kv_compressed).
+        """
+        return self.get_query_key_value_tensors(
+            hidden_states=hidden_states,
+            position_offset=position_offset,
+            docmask_meta=docmask_meta,
+        )
+
+    def _pre_csa_deduped_forward(
+        self,
+        hidden_states: Tensor,
+        position_offset: int,
+        docmask_meta,
+    ):
+        """:meth:`_pre_csa_forward` with the key/value alias removed.
+
+        ``DSv4HybridSelfAttention`` produces a single-head KV and returns the
+        same tensor object as both key and value. A recompute segment that
+        returns one object twice makes ``paddle.autograd.backward`` fail with
+        "contains duplicate paddle.Tensor object", so the duplicate is dropped
+        here and restored by the caller (4 outputs => value is key).
+        """
+        query, key, value, q_compressed, kv_compressed = self._pre_csa_forward(
+            hidden_states, position_offset, docmask_meta
+        )
+        if value is key:
+            return query, key, q_compressed, kv_compressed
+        return query, key, value, q_compressed, kv_compressed
+
+    def _csa_forward(
+        self,
+        query: Tensor,
+        key: Tensor,
+        value: Tensor,
+        attention_mask,
+        hidden_states: Tensor,
+        q_compressed: Tensor,
+        input_ids,
+        docmask_meta,
+    ) -> Tensor:
+        """Stage 2: the CSA core attention (Compressor + Indexer + sparse attn).
+
+        Returns core_attn_out [b, sq, np * v_head_dim].
+        """
+        return self.core_attention(
             query,
             key,
             value,
@@ -753,8 +1020,22 @@ class DSv4HybridAttention(Attention):
             input_ids=input_ids,
             docmask_meta=docmask_meta,
         )
-        # core_attn_out: [b, sq, np * v_head_dim]
 
+    def _post_csa_forward(
+        self,
+        core_attn_out: Tensor,
+        hidden_states: Tensor,
+        q_compressed: Tensor,
+        position_offset: int,
+        docmask_meta,
+        in_outer_recompute: bool = False,
+    ) -> Tensor:
+        """Stage 3: everything after the CSA core attention.
+
+        Inverse RoPE, VHA postmix, grouped output projection and gated attention.
+        ``in_outer_recompute`` suppresses the nested per-submodule recompute of
+        vha_postmix / gated_attn when an enclosing segment already frees them.
+        """
         # Inverse RoPE on last qk_pos_emb_head_dim of each head
         b, sq, _ = core_attn_out.shape
         pos_dim = self.qk_pos_emb_head_dim
@@ -806,14 +1087,15 @@ class DSv4HybridAttention(Attention):
 
         # VHA postmix: low-rank cross-head mixing while still in head space
         # ([b, sq, nh, v_head_dim]), after inverse RoPE and before the grouped
-        # output projection. When the whole block is already wrapped in a
-        # full_attn RecomputeWithoutOutput, skip the nested selective recompute
-        # (the full block recompute already frees these activations).
+        # output projection. When an enclosing segment (full_attn, or the
+        # staged csa+post / post-only segment) already wraps this block, skip
+        # the nested selective recompute — the outer segment already frees
+        # these activations.
         if self.use_vha_postmix:
             if (
                 self.recompute_vha_postmix
                 and self.training
-                and not _in_full_recompute
+                and not in_outer_recompute
             ):
                 core_attn_out = recompute(
                     self._apply_vha_postmix, core_attn_out
@@ -836,12 +1118,13 @@ class DSv4HybridAttention(Attention):
             gate_source = (
                 q_compressed if self.gated_attn_use_q_lora else hidden_states
             )
-            # When NOT inside full_attn recompute, gated_attn can have its own
-            # independent RecomputeWithoutOutput wrapper for lighter memory saving.
+            # When NOT inside an enclosing recompute segment, gated_attn can
+            # have its own independent RecomputeWithoutOutput wrapper for
+            # lighter memory saving.
             if (
                 self.recompute_gated_attn
                 and self.training
-                and not _in_full_recompute
+                and not in_outer_recompute
             ):
                 self._gate_recompute = RecomputeWithoutOutput()
                 core_attn_out = self._gate_recompute.recompute(

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_dsv4_hybrid_attention_recompute.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_dsv4_hybrid_attention_recompute.py
@@ -51,7 +51,7 @@ def _make_dsv4_instance(
     """Create a SimpleNamespace that behaves like DSv4HybridAttention for forward().
 
     Uses SimpleNamespace to avoid paddle.nn.Layer.__setattr__ restrictions.
-    Binds the real forward / _full_attn_forward / _gate methods from DSv4HybridAttention.
+    Binds the real forward / _all_stages_forward / _gate methods from DSv4HybridAttention.
     """
     import types
 
@@ -98,8 +98,23 @@ def _make_dsv4_instance(
         and recompute_modules is not None
         and "full_attn" in recompute_modules
     )
-    inst._full_attn_recompute = None
+    inst._stage_recompute = None
     inst._gate_recompute = None
+    inst.recompute_pre_csa = (
+        recompute_granularity == "selective"
+        and recompute_modules is not None
+        and "hca_pre_csa" in recompute_modules
+    )
+    inst.recompute_csa = (
+        recompute_granularity == "selective"
+        and recompute_modules is not None
+        and "hca_csa" in recompute_modules
+    )
+    inst.recompute_post_csa = (
+        recompute_granularity == "selective"
+        and recompute_modules is not None
+        and "hca_post_csa" in recompute_modules
+    )
 
     # VHA postmix disabled for these recompute-path tests (forward() reads
     # these flags; the real module sets them in __init__).
@@ -177,8 +192,21 @@ def _make_dsv4_instance(
 
     # Bind the real methods from DSv4HybridAttention
     inst.forward = types.MethodType(DSv4HybridAttention.forward, inst)
-    inst._full_attn_forward = types.MethodType(
-        DSv4HybridAttention._full_attn_forward, inst
+    inst._all_stages_forward = types.MethodType(
+        DSv4HybridAttention._all_stages_forward, inst
+    )
+    inst._attn_forward = types.MethodType(
+        DSv4HybridAttention._attn_forward, inst
+    )
+    inst._pre_csa_forward = types.MethodType(
+        DSv4HybridAttention._pre_csa_forward, inst
+    )
+    inst._csa_forward = types.MethodType(DSv4HybridAttention._csa_forward, inst)
+    inst._post_csa_forward = types.MethodType(
+        DSv4HybridAttention._post_csa_forward, inst
+    )
+    inst._csa_post_forward = types.MethodType(
+        DSv4HybridAttention._csa_post_forward, inst
     )
     inst._gate = types.MethodType(DSv4HybridAttention._gate, inst)
 
@@ -235,7 +263,7 @@ class TestDSv4FullAttnRecompute(unittest.TestCase):
     def setUp(self):
         paddle.seed(42)
 
-    def test_full_attn_recompute_uses_RecomputeWithoutOutput(self):
+    def test_stage_recompute_uses_RecomputeWithoutOutput(self):
         """Verify full_attn branch instantiates RecomputeWithoutOutput."""
         inst = _make_dsv4_instance(recompute_modules=["full_attn"])
 
@@ -267,7 +295,7 @@ class TestDSv4FullAttnRecompute(unittest.TestCase):
         self.assertEqual(output.shape, [1, 8, 64])
         self.assertIsNone(bias)
 
-    def test_full_attn_recompute_output_matches_else_branch(self):
+    def test_stage_recompute_output_matches_else_branch(self):
         """full_attn path and else path should produce same shape output."""
         paddle.seed(123)
         inst_full = _make_dsv4_instance(recompute_modules=["full_attn"])
@@ -298,7 +326,7 @@ class TestDSv4FullAttnRecompute(unittest.TestCase):
         self.assertEqual(out_full.shape, out_else.shape)
 
     def test_full_attn_sets_and_clears_recompute_attr(self):
-        """_full_attn_recompute is set during forward and cleared after."""
+        """_stage_recompute is set during forward and cleared after."""
         inst = _make_dsv4_instance(recompute_modules=["full_attn"])
 
         from paddlefleet.transformer import dsv4_hybrid_attention as mod
@@ -325,8 +353,8 @@ class TestDSv4FullAttnRecompute(unittest.TestCase):
         with patch.object(mod, "RecomputeWithoutOutput", _TrackingRecompute):
             inst.forward(hidden, attention_mask=None)
 
-        # After forward, _full_attn_recompute should be None
-        self.assertIsNone(inst._full_attn_recompute)
+        # After forward, _stage_recompute should be None
+        self.assertIsNone(inst._stage_recompute)
 
 
 # ---------------------------------------------------------------------------
@@ -394,7 +422,7 @@ class TestDSv4GatedAttnRecompute(unittest.TestCase):
                 preserve_rng_state=True,
                 share_grad_holder=False,
             ):
-                # Distinguish: _full_attn_forward has 6 args (with _in_full_recompute), _gate has 2
+                # Distinguish: _all_stages_forward has 6 args (with _in_full_recompute), _gate has 2
                 if len(args) >= 5:
                     full_recompute_count[0] += 1
                 else:
@@ -472,28 +500,28 @@ class TestDSv4DirectPath(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# Test: _full_attn_forward method
+# Test: _all_stages_forward method
 # ---------------------------------------------------------------------------
 
 
 class TestDSv4FullAttnForwardMethod(unittest.TestCase):
-    """Tests for the _full_attn_forward helper method."""
+    """Tests for the _all_stages_forward helper method."""
 
     def setUp(self):
         paddle.seed(42)
 
-    def test_full_attn_forward_returns_correct_shape(self):
-        """_full_attn_forward should return [b, sq, o_groups * o_lora_rank]."""
+    def test_all_stages_forward_returns_correct_shape(self):
+        """_all_stages_forward should return [b, sq, o_groups * o_lora_rank]."""
         inst = _make_dsv4_instance(
             recompute_modules=["full_attn"], gated_attention=True
         )
         hidden = paddle.randn([1, 8, 64])
-        result = inst._full_attn_forward(hidden, None, 0, None, None)
+        result = inst._all_stages_forward(hidden, None, 0, None, None)
         # o_groups=2, o_lora_rank=8 => 16
         self.assertEqual(result.shape, [1, 8, 16])
 
-    def test_full_attn_forward_includes_gate(self):
-        """_full_attn_forward should call _gate when gated_attention=True."""
+    def test_all_stages_forward_includes_gate(self):
+        """_all_stages_forward should call _gate when gated_attention=True."""
         inst = _make_dsv4_instance(
             recompute_modules=["full_attn"], gated_attention=True
         )
@@ -507,12 +535,12 @@ class TestDSv4FullAttnForwardMethod(unittest.TestCase):
         inst._gate = _tracking_gate
 
         hidden = paddle.randn([1, 8, 64])
-        inst._full_attn_forward(hidden, None, 0, None, None)
+        inst._all_stages_forward(hidden, None, 0, None, None)
 
         self.assertTrue(gate_called[0])
 
-    def test_full_attn_forward_skips_gate_when_disabled(self):
-        """_full_attn_forward should not call _gate when gated_attention=False."""
+    def test_all_stages_forward_skips_gate_when_disabled(self):
+        """_all_stages_forward should not call _gate when gated_attention=False."""
         inst = _make_dsv4_instance(
             recompute_modules=["full_attn"], gated_attention=False
         )
@@ -525,7 +553,7 @@ class TestDSv4FullAttnForwardMethod(unittest.TestCase):
         inst._gate = _tracking_gate
 
         hidden = paddle.randn([1, 8, 64])
-        inst._full_attn_forward(hidden, None, 0, None, None)
+        inst._all_stages_forward(hidden, None, 0, None, None)
 
         self.assertFalse(gate_called[0])
 
@@ -670,7 +698,7 @@ class TestDSv4RecomputeBackwardGradients(unittest.TestCase):
     def _make_startend(self, batch_size, seq_len):
         return paddle.full([batch_size, 1, seq_len, 1], seq_len, dtype="int32")
 
-    def test_full_attn_recompute_backward_gradient_flow(self):
+    def test_stage_recompute_backward_gradient_flow(self):
         """full_attn recompute produces finite, non-None gradients on backward."""
         paddle.seed(_SEED)
         model_parallel_cuda_manual_seed(_SEED)
@@ -939,7 +967,7 @@ class TestDSv4RecomputeBackwardGradients(unittest.TestCase):
                     f"Grad mismatch for param {name}",
                 )
 
-    def test_full_attn_recompute_gradient_matches_no_recompute(self):
+    def test_stage_recompute_gradient_matches_no_recompute(self):
         """Gradients with full_attn recompute (no gated) match those without recompute."""
         paddle.seed(_SEED)
         model_parallel_cuda_manual_seed(_SEED)

--- a/tests/single_card_tests/transformer/test_hca_staged_recompute.py
+++ b/tests/single_card_tests/transformer/test_hca_staged_recompute.py
@@ -1,0 +1,576 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Stage-level selective recompute for the HCA/CSA attention block.
+
+``recompute_modules`` gains three entries that partition exactly what the coarse
+``full_attn`` entry covers:
+
+- ``hca_pre_csa``  : q/kv projections, qk norm, RoPE
+- ``hca_csa``      : the CSA core attention (Compressor + Indexer + sparse attn)
+- ``hca_post_csa`` : inverse RoPE, VHA postmix, grouped o_group_proj, gated_attn
+
+Recompute must not change the math, so every combination is compared **bitwise**
+(``paddle.equal_all``, not ``allclose``) against the no-recompute reference:
+forward output, input gradient and every parameter gradient.
+
+Determinism
+-----------
+A bitwise comparison is only meaningful if the kernels are run-to-run
+deterministic, otherwise the reference itself moves. Three things are pinned:
+
+- ``FLAGS_cudnn_deterministic`` / ``FLAGS_embedding_deterministic`` are set
+  before paddle is imported.
+- ``attention_dropout=0`` and ``preserve_rng_state=False`` on every segment: no
+  RNG is consumed inside a segment, so a replayed forward cannot diverge.
+- the attention backends are pinned per test. ``unfused`` is pure paddle;
+  ``tilelang`` has a deterministic backward. The cuDNN DSA backward's dKV
+  scatter-add is *not* deterministic (see ``test_block_sparse_dsa_gradcheck.py``)
+  and is therefore not covered here.
+
+Scope
+-----
+The bitwise tests use HCA layers (``csa_compress_ratios`` entry 128, no Indexer),
+which is what the layer43 configs run. CSA layers with an active Indexer (ratio
+2..127 with ``csa_dense_mode=false``) are deliberately not compared bitwise:
+``csa_attention.py`` gates the indexer-loss path on ``need_indexer_loss =
+self.training and paddle.is_grad_enabled()``, so whether the CSA core sits inside
+a recomputed segment decides which branch its first, no-grad pass takes, and the
+top-k handed to the sparse attention comes out different (~20% relative on the
+layer output in this harness). That predates the stage split -- plain
+``full_attn`` shows the same offset against no-recompute -- so recompute is not
+value-preserving there and asserting equality would encode a property the code
+does not have. What is checked for that shape is that the Indexer still receives
+a gradient through the recomputed segment.
+
+Also not covered: the VHA postmix inside the post-CSA stage. Its parameters are
+created without an explicit dtype, so in this harness they stay fp32 while the
+activations are bf16; production only lines up because of the O2 amp cast. The
+``vha_postmix`` entry is still exercised as a no-op in the combinations below.
+"""
+
+import os
+import unittest
+
+os.environ.setdefault("FLAGS_cudnn_deterministic", "True")
+os.environ.setdefault("FLAGS_embedding_deterministic", "1")
+
+import paddle
+from paddle.distributed.fleet.meta_parallel import build_spec_layer
+
+from paddlefleet.models.gpt.gpt_layer_specs import get_attention_spec
+from paddlefleet.tensor_parallel.random import model_parallel_cuda_manual_seed
+from paddlefleet.transformer.enums import AttnMaskType
+from paddlefleet.transformer.transformer_config import TransformerConfig
+
+_SEED = 42
+_HIDDEN_SIZE = 256
+
+# Every stage combination that must stay bitwise identical to no-recompute.
+_STAGE_COMBOS = [
+    ["hca_pre_csa"],
+    ["hca_csa"],
+    ["hca_post_csa"],
+    ["hca_pre_csa", "hca_csa"],
+    ["hca_csa", "hca_post_csa"],
+    ["hca_pre_csa", "hca_post_csa"],
+    ["hca_pre_csa", "hca_csa", "hca_post_csa"],
+    # full_attn covers the same span; kept here as a regression anchor.
+    ["full_attn"],
+    # Nested submodule recompute must be suppressed inside an outer segment
+    # without changing the result.
+    ["hca_pre_csa", "hca_csa", "hca_post_csa", "gated_attn", "vha_postmix"],
+    ["hca_csa", "gated_attn", "vha_postmix"],
+]
+
+
+def _make_config(
+    *,
+    recompute_modules=None,
+    compress_ratio=128,
+    csa_dense_mode=True,
+    indexer_backend="unfused",
+    sparse_attn_backend="unfused",
+    gated_attention=True,
+    recompute_num_layers=None,
+    recompute_method=None,
+    v_head_dim=32,
+):
+    """DSv4 hybrid attention config, single layer, HCA (ratio 128) by default."""
+    return TransformerConfig(
+        num_hidden_layers=1,
+        hidden_size=_HIDDEN_SIZE,
+        num_attention_heads=8,
+        params_dtype=paddle.bfloat16,
+        bf16=True,
+        use_bias=False,
+        multi_latent_attention=True,
+        experimental_attention_variant="dsv4_hybrid",
+        q_lora_rank=64,
+        kv_lora_rank=16,
+        qk_nope_head_dim=16,
+        qk_rope_head_dim=16,
+        qk_pos_emb_head_dim=16,
+        v_head_dim=v_head_dim,
+        o_groups=4,
+        o_lora_rank=32,
+        rope_type="rope",
+        rotary_base=10000.0,
+        rotary_percent=1.0,
+        normalization="RMSNorm",
+        use_qk_norm=True,
+        csa_compress_ratios=[compress_ratio],
+        csa_window_size=16,
+        dsa_index_n_heads=4,
+        dsa_index_head_dim=32,
+        dsa_index_topk=8,
+        dsa_indexer_loss_coeff=1.0,
+        dsa_indexer_use_sparse_loss=False,
+        dsa_indexer_rotary_interleaved=False,
+        apply_rope_fusion=False,
+        attention_dropout=0.0,
+        attention_softmax_in_fp32=True,
+        masked_softmax_fusion=False,
+        softmax_type="vanilla",
+        csa_indexer_backend=indexer_backend,
+        csa_sparse_attn_backend=sparse_attn_backend,
+        tensor_model_parallel_size=1,
+        context_parallel_size=1,
+        csa_dense_mode=csa_dense_mode,
+        gated_attention=gated_attention,
+        gated_attn_use_q_lora=False,
+        recompute_granularity=(
+            "selective" if recompute_modules is not None else None
+        ),
+        recompute_modules=recompute_modules,
+        recompute_num_layers=recompute_num_layers,
+        recompute_method=recompute_method,
+    )
+
+
+def _build_attention(config, layer_number=0):
+    spec = get_attention_spec(
+        config=config,
+        attention_layer_type="dsv4_hybrid_attention",
+        attn_mask_type=AttnMaskType.causal,
+    )
+    return build_spec_layer(spec, config=config, layer_number=layer_number)
+
+
+def _startend(batch_size, seq_len):
+    return paddle.full([batch_size, 1, seq_len, 1], seq_len, dtype="int32")
+
+
+def _grad_source(hidden):
+    """Return (leaf, layer_input) where layer_input is a NON-leaf tensor.
+
+    ``paddle.distributed.fleet.utils.recompute`` rejects a leaf tensor that
+    requires grad as a segment input ("Leaf Var ... can't use inplace
+    strategy"). In a real model the attention input is always the output of a
+    preceding op, so multiply by one to reproduce that. The multiplication is
+    exact, so it does not perturb the bitwise comparison.
+    """
+    leaf = hidden.clone()
+    leaf.stop_gradient = False
+    return leaf, leaf * 1.0
+
+
+def _forward_backward(attn, hidden, startend):
+    leaf, x = _grad_source(hidden)
+    output, _ = attn(
+        hidden_states=x,
+        attention_mask=None,
+        attn_mask_startend_row_indices=startend,
+    )
+    output.cast("float32").sum().backward()
+    grads = {
+        name: (None if p.grad is None else p.grad.clone())
+        for name, p in attn.named_parameters()
+    }
+    return output.detach().clone(), leaf.grad.clone(), grads
+
+
+class TestHCAStagedRecompute(unittest.TestCase):
+    """Bitwise forward/backward alignment of the three HCA recompute stages."""
+
+    @classmethod
+    def setUpClass(cls):
+        if not paddle.device.is_compiled_with_cuda():
+            raise unittest.SkipTest("CUDA build of Paddle is required")
+        if paddle.device.cuda.device_count() == 0:
+            raise unittest.SkipTest("No CUDA device available")
+        paddle.set_flags({"FLAGS_cudnn_deterministic": True})
+
+    def setUp(self):
+        self.batch_size, self.seq_len = 1, 64
+        paddle.seed(_SEED)
+        model_parallel_cuda_manual_seed(_SEED)
+
+    def _assert_bitwise(self, ref, got, what):
+        # equal_all has no bf16 GPU kernel; the bf16 -> fp32 cast is lossless,
+        # so equality after the cast is still an exact bit comparison.
+        ref32, got32 = ref.cast("float32"), got.cast("float32")
+        self.assertTrue(
+            paddle.equal_all(ref32, got32).item(),
+            f"{what} is not bitwise identical; max abs diff = "
+            f"{(ref32 - got32).abs().max().item()}",
+        )
+
+    def _run_combo(self, combo, **config_kwargs):
+        """Compare one recompute_modules combo against no-recompute, bitwise."""
+        paddle.seed(_SEED)
+        model_parallel_cuda_manual_seed(_SEED)
+        attn_ref = _build_attention(_make_config(**config_kwargs))
+        attn_rc = _build_attention(
+            _make_config(recompute_modules=combo, **config_kwargs)
+        )
+        attn_rc.set_state_dict(attn_ref.state_dict())
+        attn_ref.train()
+        attn_rc.train()
+
+        hidden = paddle.randn(
+            [self.batch_size, self.seq_len, _HIDDEN_SIZE],
+            dtype=paddle.bfloat16,
+        )
+        startend = _startend(self.batch_size, self.seq_len)
+
+        out_ref, xgrad_ref, grads_ref = _forward_backward(
+            attn_ref, hidden, startend
+        )
+        out_rc, xgrad_rc, grads_rc = _forward_backward(
+            attn_rc, hidden, startend
+        )
+
+        self._assert_bitwise(out_ref, out_rc, "forward output")
+        self._assert_bitwise(xgrad_ref, xgrad_rc, "input gradient")
+
+        self.assertEqual(set(grads_ref), set(grads_rc))
+        compared = 0
+        for name, g_ref in grads_ref.items():
+            g_rc = grads_rc[name]
+            self.assertEqual(
+                g_ref is None,
+                g_rc is None,
+                f"gradient presence differs for {name}",
+            )
+            if g_ref is None:
+                continue
+            self._assert_bitwise(g_ref, g_rc, f"gradient of {name}")
+            compared += 1
+        self.assertGreater(compared, 0, "no parameter gradient was compared")
+
+    def test_hca_unfused_backend(self):
+        for combo in _STAGE_COMBOS:
+            with self.subTest(modules=combo):
+                self._run_combo(combo)
+
+    def test_hca_tilelang_backend(self):
+        try:
+            import paddlefleet.tilelang_ops  # noqa: F401
+        except ImportError:
+            self.skipTest("TileLang CSA ops not available")
+        for combo in _STAGE_COMBOS:
+            with self.subTest(modules=combo):
+                self._run_combo(
+                    combo,
+                    sparse_attn_backend="tilelang",
+                    indexer_backend="tilelang",
+                    # The TileLang sparse-attention kernel rejects a head dim of
+                    # 32 ("warp_col_tiles must be greater than 8").
+                    v_head_dim=64,
+                )
+
+    def test_csa_indexer_receives_gradient_under_staged_recompute(self):
+        """The Indexer still trains through the recomputed CSA segment.
+
+        The indexer loss is created *inside* ``core_attention`` and only on the
+        grad-enabled pass, so a broken segment boundary shows up as a silently
+        missing gradient rather than as an error.
+        """
+        config = _make_config(
+            recompute_modules=["hca_pre_csa", "hca_csa", "hca_post_csa"],
+            compress_ratio=4,
+            csa_dense_mode=False,
+        )
+        attn = _build_attention(config)
+        attn.train()
+        hidden = paddle.randn(
+            [self.batch_size, self.seq_len, _HIDDEN_SIZE],
+            dtype=paddle.bfloat16,
+        )
+        leaf, x = _grad_source(hidden)
+        output, _ = attn(
+            hidden_states=x,
+            attention_mask=None,
+            attn_mask_startend_row_indices=_startend(
+                self.batch_size, self.seq_len
+            ),
+        )
+        output.cast("float32").sum().backward()
+        self.assertIsNotNone(leaf.grad)
+
+        indexer_params = [
+            (name, p)
+            for name, p in attn.named_parameters()
+            if "indexer" in name and not p.stop_gradient
+        ]
+        self.assertGreater(len(indexer_params), 0, "no indexer parameter found")
+        for name, p in indexer_params:
+            self.assertIsNotNone(p.grad, f"indexer param {name} has no grad")
+            self.assertTrue(
+                paddle.isfinite(p.grad.cast("float32")).all().item(),
+                f"indexer param {name} has non-finite grad",
+            )
+
+
+class TestHCAStagedRecomputeShapesAndModes(unittest.TestCase):
+    """Bitwise alignment in configurations the combination sweep does not cover.
+
+    Representative stage combinations only -- the point is to catch a change in
+    behaviour for a *shape* (batch > 1, gate disabled) or a *mode* (eval), not to
+    re-run the full sweep.
+    """
+
+    # One combination per wrapping kind exercised by _attn_forward:
+    # plain recompute (csa), RecomputeWithoutOutput on the tail (csa+post),
+    # and pre as its own segment plus a tail segment (all three).
+    REPRESENTATIVE = [
+        ["hca_csa"],
+        ["hca_csa", "hca_post_csa"],
+        ["hca_pre_csa", "hca_csa", "hca_post_csa"],
+    ]
+
+    @classmethod
+    def setUpClass(cls):
+        if not paddle.device.is_compiled_with_cuda():
+            raise unittest.SkipTest("CUDA build of Paddle is required")
+        if paddle.device.cuda.device_count() == 0:
+            raise unittest.SkipTest("No CUDA device available")
+        paddle.set_flags({"FLAGS_cudnn_deterministic": True})
+
+    def setUp(self):
+        self.batch_size, self.seq_len = 1, 64
+        paddle.seed(_SEED)
+        model_parallel_cuda_manual_seed(_SEED)
+
+    _assert_bitwise = TestHCAStagedRecompute._assert_bitwise
+    _run_combo = TestHCAStagedRecompute._run_combo
+
+    def test_batch_size_two(self):
+        """Covers the logical-batch pack/unpack around the staged segments."""
+        self.batch_size = 2
+        for combo in self.REPRESENTATIVE:
+            with self.subTest(modules=combo):
+                self._run_combo(combo)
+
+    def test_gated_attention_disabled(self):
+        """post-CSA without the gate: o_group_proj is then the last op."""
+        for combo in self.REPRESENTATIVE:
+            with self.subTest(modules=combo):
+                self._run_combo(combo, gated_attention=False)
+
+    def test_eval_mode_ignores_recompute(self):
+        """No segment is created outside training, and the result is unchanged."""
+        combo = ["hca_pre_csa", "hca_csa", "hca_post_csa"]
+        paddle.seed(_SEED)
+        model_parallel_cuda_manual_seed(_SEED)
+        attn_ref = _build_attention(_make_config())
+        attn_rc = _build_attention(_make_config(recompute_modules=combo))
+        attn_rc.set_state_dict(attn_ref.state_dict())
+        attn_ref.eval()
+        attn_rc.eval()
+
+        hidden = paddle.randn(
+            [self.batch_size, self.seq_len, _HIDDEN_SIZE],
+            dtype=paddle.bfloat16,
+        )
+        startend = _startend(self.batch_size, self.seq_len)
+        with paddle.no_grad():
+            out_ref, _ = attn_ref(
+                hidden_states=hidden,
+                attention_mask=None,
+                attn_mask_startend_row_indices=startend,
+            )
+            out_rc, _ = attn_rc(
+                hidden_states=hidden,
+                attention_mask=None,
+                attn_mask_startend_row_indices=startend,
+            )
+        self._assert_bitwise(out_ref, out_rc, "eval-mode forward output")
+        self.assertIsNone(attn_rc._stage_recompute)
+
+    def test_recompute_holders_cleared_after_forward(self):
+        """The holders are per-forward state and must not leak between steps."""
+        for combo in (["hca_csa", "hca_post_csa"], ["full_attn"]):
+            with self.subTest(modules=combo):
+                paddle.seed(_SEED)
+                model_parallel_cuda_manual_seed(_SEED)
+                attn = _build_attention(_make_config(recompute_modules=combo))
+                attn.train()
+                hidden = paddle.randn(
+                    [self.batch_size, self.seq_len, _HIDDEN_SIZE],
+                    dtype=paddle.bfloat16,
+                )
+                _forward_backward(
+                    attn, hidden, _startend(self.batch_size, self.seq_len)
+                )
+                self.assertIsNone(attn._stage_recompute)
+                self.assertIsNone(attn._gate_recompute)
+
+    def test_all_stages_forward_matches_stage_by_stage(self):
+        """The span delegates must stay pure composition of the three stages."""
+        paddle.seed(_SEED)
+        model_parallel_cuda_manual_seed(_SEED)
+        attn = _build_attention(_make_config())
+        attn.train()
+        hidden = paddle.randn(
+            [self.batch_size, self.seq_len, _HIDDEN_SIZE],
+            dtype=paddle.bfloat16,
+        )
+        with paddle.no_grad():
+            fused = attn._all_stages_forward(hidden, None, 0, None, None)
+            query, key, value, q_compressed, _ = attn._pre_csa_forward(
+                hidden, 0, None
+            )
+            core = attn._csa_forward(
+                query, key, value, None, hidden, q_compressed, None, None
+            )
+            staged = attn._post_csa_forward(core, hidden, q_compressed, 0, None)
+        self._assert_bitwise(fused, staged, "_all_stages_forward output")
+
+    def test_pre_csa_dedupe_drops_key_value_alias(self):
+        """key and value are one tensor; a segment may not return it twice.
+
+        Returning the same object twice makes paddle.autograd.backward reject the
+        segment with "contains duplicate paddle.Tensor object".
+        """
+        paddle.seed(_SEED)
+        model_parallel_cuda_manual_seed(_SEED)
+        attn = _build_attention(_make_config())
+        attn.train()
+        hidden = paddle.randn(
+            [self.batch_size, self.seq_len, _HIDDEN_SIZE],
+            dtype=paddle.bfloat16,
+        )
+        with paddle.no_grad():
+            query, key, value, q_compressed, kv_compressed = (
+                attn._pre_csa_forward(hidden, 0, None)
+            )
+            deduped = attn._pre_csa_deduped_forward(hidden, 0, None)
+        self.assertIs(value, key, "expected the single-head KV alias")
+        self.assertEqual(len(deduped), 4)
+        self.assertEqual(len({id(t) for t in deduped}), 4)
+
+
+class TestHCAStagedRecomputeConfig(unittest.TestCase):
+    """Flag resolution for the three stage entries."""
+
+    def setUp(self):
+        # RowParallelLinear initialisation forks the model-parallel RNG.
+        paddle.seed(_SEED)
+        model_parallel_cuda_manual_seed(_SEED)
+
+    def _flags(self, **kwargs):
+        attn = _build_attention(_make_config(**kwargs), layer_number=0)
+        return (
+            attn.recompute_pre_csa,
+            attn.recompute_csa,
+            attn.recompute_post_csa,
+        )
+
+    def test_individual_entries(self):
+        self.assertEqual(
+            self._flags(recompute_modules=["hca_pre_csa"]),
+            (True, False, False),
+        )
+        self.assertEqual(
+            self._flags(recompute_modules=["hca_csa"]), (False, True, False)
+        )
+        self.assertEqual(
+            self._flags(recompute_modules=["hca_post_csa"]),
+            (False, False, True),
+        )
+
+    def test_ignored_without_selective_granularity(self):
+        config = _make_config(recompute_modules=["hca_csa"])
+        config.recompute_granularity = "full"
+        config.recompute_num_layers = 1
+        config.recompute_method = "uniform"
+        attn = _build_attention(config, layer_number=0)
+        self.assertFalse(attn.recompute_csa)
+
+    def test_honours_recompute_num_layers(self):
+        # first_n with n=0 selects no layer
+        self.assertEqual(
+            self._flags(
+                recompute_modules=["hca_csa"],
+                recompute_num_layers=0,
+                recompute_method="first_n",
+            ),
+            (False, False, False),
+        )
+        self.assertEqual(
+            self._flags(
+                recompute_modules=["hca_csa"],
+                recompute_num_layers=1,
+                recompute_method="first_n",
+            ),
+            (False, True, False),
+        )
+
+    def test_honours_block_method(self):
+        # block with n=1 on a 1-layer model selects the layer
+        self.assertEqual(
+            self._flags(
+                recompute_modules=["hca_post_csa"],
+                recompute_num_layers=1,
+                recompute_method="block",
+            ),
+            (False, False, True),
+        )
+
+    def test_rejects_unknown_recompute_method(self):
+        # Rejected by TransformerConfig itself, so the flag resolution can
+        # assume block/first_n.
+        with self.assertRaises(AssertionError):
+            _build_attention(
+                _make_config(
+                    recompute_modules=["hca_csa"],
+                    recompute_num_layers=1,
+                    recompute_method="uniform",
+                )
+            )
+
+    def test_unrelated_entries_leave_stage_flags_off(self):
+        self.assertEqual(
+            self._flags(recompute_modules=["norm", "mlp", "gated_attn"]),
+            (False, False, False),
+        )
+
+    def test_rejects_combination_with_full_attn(self):
+        with self.assertRaises(ValueError):
+            _build_attention(
+                _make_config(recompute_modules=["full_attn", "hca_csa"])
+            )
+
+    def test_rejects_dict_configuration(self):
+        # Rejected either by the stage flag resolution (ValueError) or already
+        # upstream while building the layer (AssertionError); never silently
+        # ignored.
+        with self.assertRaises((ValueError, AssertionError)):
+            _build_attention(_make_config(recompute_modules={"hca_csa": 1}))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### PR Category
Performance Optimization

### PR Types
New features

### Description

HCA 层（`csa_compress_ratios=128` 的 dsv4_hybrid 层）此前只能整块 recompute（`recompute_modules=["full_attn"]`），粒度太粗，无法按显存/算力预算权衡。

本 PR 将该块切成 **CSA 前 / CSA / CSA 后** 三段，可通过 `recompute_modules` 独立开启：

- `hca_pre_csa`：q/kv 投影、qk norm、RoPE
- `hca_csa`：CSA core attention（Compressor + Indexer + sparse attn）
- `hca_post_csa`：inverse RoPE、VHA postmix、`o_group_proj`、gated_attn

```yaml
recompute_granularity: selective
recompute_method: block
recompute_num_layers: -1
recompute_modules: ["hca_csa", "hca_post_csa", "norm", "mlp"]
```

三个新入口与 `vha_postmix` 一致，遵循 `recompute_num_layers` + `recompute_method`（`block` / `first_n`）；`full_attn` / `gated_attn` 旧语义不变，且 `full_attn` 与新入口同时配置会在 `__init__` 直接报错。

#### 实现要点

1. 合并 `forward()` 中 `full_attn` / 非 `full_attn` 两条分支，`_attn_forward` 作为唯一 driver，段边界由 flag 动态决定。
2. 包装方式按段后存活对象选择：以 `o_proj` 结尾的段用 `RecomputeWithoutOutput`；`hca_pre_csa`、单开的 `hca_csa` 输出要被下游消费，用普通 `recompute`。
3. `csa + post` 同开时融合为一段，避免丢弃 CSA 输出导致独立 post 段的 replay 输入失效。
4. `keep_indexer_grad_path` 在 `forward` 入口统一锚定一次：recompute wrapper 是 PyLayer，`train_indexer_only` 下 `hidden_states` 为 detached 时会静默跳过 hook 注册，Indexer 拿不到梯度。
5. 修复 key/value 为同一张量对象导致 `paddle.autograd.backward` 报 `duplicate paddle.Tensor object` 的问题（段内去重、调用侧还原）。

#### 测试

新增 `tests/single_card_tests/transformer/test_hca_staged_recompute.py`：10 种 stage 组合 × `unfused`/`tilelang` 两种 backend，用 `paddle.equal_all` 对 forward 输出、输入梯度与全部参数梯度做**逐 bit 对齐**；另覆盖 batch>1、关闭 gate、eval 不建段、holder 不跨 step 泄漏、key/value 去重回归及配置解析（层选择、冲突报错、非法配置）。随机性通过 deterministic FLAGS、`attention_dropout=0`、`preserve_rng_state=False` 控制。

已知边界（PR 之前即存在，已在测试中记录）：带 Indexer 的 CSA 层（ratio 2~127 且 `csa_dense_mode=false`）在任何 recompute 下都非数值保持——`csa_attention.py` 的 `need_indexer_loss = self.training and paddle.is_grad_enabled()` 使段内首次 no-grad 前向走另一分支、top-k 不同；这类 shape 仅断言 Indexer 仍有梯度。

本地结果：新增用例 40 passed / 28 subtests；连同相关既有用例共 151 passed / 61 subtests。

### 是否引起精度变化
否。HCA 层在所有 stage 组合下前反向与 no-recompute 逐 bit 对齐，`full_attn` 语义与数值均未改变。
