### PR TITLE
[MoE] Support SiTU in fused expert paths

### DIFF
--- a/src/paddlefleet/transformer/activations.py
+++ b/src/paddlefleet/transformer/activations.py
@@ -56,6 +56,73 @@ def situ_glu(
     return (gate * up).astype(input_dtype)
 
 
+def situ_glu_scale_forward(
+    x: paddle.Tensor,
+    probs: paddle.Tensor,
+    beta: float = 1.0,
+    linear_beta: float | None = None,
+) -> paddle.Tensor:
+    """Apply SiTU-GLU and router scaling with float32 intermediates."""
+
+    input_dtype = x.dtype
+    probs = probs.astype("float32")
+    if probs.ndim == 1:
+        probs = probs.unsqueeze(-1)
+    return (
+        situ_glu(x.astype("float32"), beta=beta, linear_beta=linear_beta)
+        * probs
+    ).astype(input_dtype)
+
+
+def situ_glu_scale_backward(
+    x: paddle.Tensor,
+    probs: paddle.Tensor,
+    out_grad: paddle.Tensor,
+    beta: float = 1.0,
+    linear_beta: float | None = None,
+) -> tuple[paddle.Tensor, paddle.Tensor, paddle.Tensor]:
+    """Backward for :func:`situ_glu_scale_forward`."""
+
+    assert beta > 0
+    assert linear_beta is None or linear_beta > 0
+
+    gate, up = paddle.chunk(x, chunks=2, axis=-1)
+    gate = gate.astype("float32")
+    up = up.astype("float32")
+    out_grad = out_grad.astype("float32")
+    probs_view = probs.astype("float32")
+    if probs_view.ndim == 1:
+        probs_view = probs_view.unsqueeze(-1)
+
+    gate_tanh = paddle.tanh(gate / beta)
+    gate_sigmoid = F.sigmoid(gate)
+    gate_act = beta * gate_tanh * gate_sigmoid
+    gate_grad = (
+        1.0 - gate_tanh.square()
+    ) * gate_sigmoid + beta * gate_tanh * gate_sigmoid * (1.0 - gate_sigmoid)
+
+    if linear_beta is None:
+        up_act = up
+        up_grad = paddle.ones_like(up)
+    else:
+        up_tanh = paddle.tanh(up / linear_beta)
+        up_act = linear_beta * up_tanh
+        up_grad = 1.0 - up_tanh.square()
+
+    scaled_grad = out_grad * probs_view
+    gate_input_grad = scaled_grad * up_act * gate_grad
+    up_input_grad = scaled_grad * gate_act * up_grad
+    input_grad = paddle.concat(
+        [gate_input_grad, up_input_grad], axis=-1
+    ).astype(x.dtype)
+
+    unscaled_output = gate_act * up_act
+    probs_grad = (out_grad * unscaled_output).sum(axis=-1, keepdim=True)
+    probs_grad = probs_grad.reshape(probs.shape).astype(probs.dtype)
+    scaled_output = (unscaled_output * probs_view).astype(x.dtype)
+    return input_grad, scaled_output, probs_grad
+
+
 class SituAndMul(paddle.nn.Layer):
     """Layer wrapper matching the official Kimi-K3 ``SituAndMul`` contract."""
 
@@ -76,4 +143,10 @@ class SituAndMul(paddle.nn.Layer):
         )
 
 
-__all__ = ["SituAndMul", "situ", "situ_glu"]
+__all__ = [
+    "SituAndMul",
+    "situ",
+    "situ_glu",
+    "situ_glu_scale_backward",
+    "situ_glu_scale_forward",
+]

--- a/src/paddlefleet/transformer/moe/fp8_utils.py
+++ b/src/paddlefleet/transformer/moe/fp8_utils.py
@@ -109,6 +109,11 @@ from paddle.distributed.fleet.meta_parallel.zero_bubble_utils import (
     WeightGradStore,
 )
 
+from paddlefleet.transformer.activations import (
+    situ_glu_scale_backward,
+    situ_glu_scale_forward,
+)
+
 __all__ = [
     "ExpertsGroupGemmContiguousNode",
 ]
@@ -843,7 +848,7 @@ class ExpertsGroupGemmContiguousNode:
             recompute_moe_gate_up (bool, optional): Whether to recompute forward gate up. Defaults to False.
             dequant_input (bool, optional): Whether to dequantize input. Defaults to False.
             name (str, optional): Name of the node. Defaults to "experts_group_gemm_contiguous_node".
-            activation_type (str, optional): Activation function type. "swiglu" or "geglu". Defaults to "swiglu".
+            activation_type (str, optional): Activation function type. "swiglu", "geglu", or "situ". Defaults to "swiglu".
         """
         if moe_deep_gemm and expert_id is not None:
             # Per-expert node for deep_gemm: slice stacked weight to [1, K, N]
@@ -903,6 +908,11 @@ class ExpertsGroupGemmContiguousNode:
         self.moe_expert_fusion = moe_expert_fusion
         self.clamp_value = clamp_value
         self.activation_type = activation_type
+        config = getattr(custom_map, "config", None)
+        self.activation_situ_beta = getattr(config, "activation_situ_beta", 1.0)
+        self.activation_situ_linear_beta = getattr(
+            config, "activation_situ_linear_beta", None
+        )
         self.use_accuracy_compatible = use_accuracy_compatible
         self.token_padding_alignment = moe_token_padding_alignment(
             use_fp8_mlp=use_fp8_mlp,
@@ -1356,8 +1366,10 @@ class ExpertsGroupGemmContiguousNode:
         #   forward is gelu on both paths and pairs with the analytic GeGLU
         #   backward, which is not gated on is_split_group_gemm.
         # ==================================================================
-        if self.use_accuracy_compatible and (
-            self.activation_type == "geglu" or self.is_split_group_gemm
+        if (
+            self.use_accuracy_compatible
+            and self.activation_type != "situ"
+            and (self.activation_type == "geglu" or self.is_split_group_gemm)
         ):
             x_glu, x_linear = paddle.chunk(o1, chunks=2, axis=-1)
             probs = unzipped_probs
@@ -1386,7 +1398,14 @@ class ExpertsGroupGemmContiguousNode:
                     o1.dtype
                 )
         else:
-            if self.activation_type == "geglu":
+            if self.activation_type == "situ":
+                o2 = situ_glu_scale_forward(
+                    o1,
+                    unzipped_probs,
+                    self.activation_situ_beta,
+                    self.activation_situ_linear_beta,
+                )
+            elif self.activation_type == "geglu":
                 # GeGLU: gelu_tanh(gate) * up, then scale by probs
                 # F.gelu promotes bf16 to float32, cast back to bf16 for downstream ops
                 gate, up = paddle.chunk(o1, 2, dim=-1)
@@ -1449,11 +1468,10 @@ class ExpertsGroupGemmContiguousNode:
         if not self.use_fp8_mlp:
             return self.fwd_down_bf16(o1, unzipped_probs, expert_w2, clear_o1)
         else:
-            assert self.activation_type != "geglu", (
-                "FP8 MoE path does not support activation_type='geglu' yet. "
-                "The fwd_down_fp8 branch uses fused SwiGLU FP8 kernels which are "
-                "incompatible with GeGLU. Please disable fp8 for Gemma4 MoE or "
-                "implement a GeGLU FP8 kernel."
+            assert self.activation_type not in ("geglu", "situ"), (
+                "FP8 MoE path only supports activation_type='swiglu' yet, "
+                f"but got {self.activation_type!r}. Please disable fp8 or "
+                "implement the corresponding FP8 activation kernel."
             )
             return self.fwd_down_fp8(
                 o1, unzipped_probs, expert_w2, num_expert, o3, clear_o1
@@ -1622,7 +1640,7 @@ class ExpertsGroupGemmContiguousNode:
         # ==================================================================
         if (
             self.use_accuracy_compatible
-            and self.activation_type != "geglu"
+            and self.activation_type not in ("geglu", "situ")
             and self.is_split_group_gemm
             and numpy.prod(unzipped_grad.shape) != 0
         ):
@@ -1676,6 +1694,15 @@ class ExpertsGroupGemmContiguousNode:
             o2_s = o2_f32.detach().astype(o1.dtype)
             probs_grad = d_scale_f32.astype(unzipped_probs.dtype)
             return do1, o2_s, probs_grad
+
+        if self.activation_type == "situ":
+            return situ_glu_scale_backward(
+                o1,
+                unzipped_probs,
+                do2_s,
+                self.activation_situ_beta,
+                self.activation_situ_linear_beta,
+            )
 
         if self.activation_type == "geglu":
             # GeGLU forward recompute (needed for backward weight computation)

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -205,13 +205,11 @@ class MoELayer(nn.Layer):
             self.fp8_dispatch and self.using_sonic_moe and self.fp8_wgrad
         )
         self.moe_expert_fusion = config.moe_expert_fusion
-        if self.hidden_act == situ and (
-            config.moe_use_fusion_node or self.moe_expert_fusion
-        ):
+        self._activation_type = "situ" if self.hidden_act == situ else "swiglu"
+        if self.hidden_act == situ and self.fp8:
             raise ValueError(
-                "SiTU-GLU does not support moe_use_fusion_node=True or "
-                "moe_expert_fusion=True yet; support will be added in a future "
-                "release. Please set both options to False."
+                "SiTU-GLU MoE fusion currently supports BF16 expert compute "
+                "only; please disable fp8."
             )
         self.moe_subbatch_token_num_after_dispatch = (
             config.moe_subbatch_token_num_after_dispatch

--- a/tests/single_card_tests/transformer/test_situ_glu.py
+++ b/tests/single_card_tests/transformer/test_situ_glu.py
@@ -20,8 +20,18 @@ import paddle.nn.functional as F
 
 from paddlefleet.models.gpt.gpt_layer_specs import get_gpt_layer_local_spec
 from paddlefleet.tensor_parallel.random import model_parallel_cuda_manual_seed
-from paddlefleet.transformer.activations import SituAndMul, situ, situ_glu
+from paddlefleet.transformer.activations import (
+    SituAndMul,
+    situ,
+    situ_glu,
+    situ_glu_scale_backward,
+    situ_glu_scale_forward,
+)
 from paddlefleet.transformer.mlp import MLP
+from paddlefleet.transformer.moe.fp8_utils import (
+    ExpertsGroupGemmContiguousNode,
+)
+from paddlefleet.transformer.moe.fusion_layer_utils import FusionMoePyLayer
 from paddlefleet.transformer.moe.moe_expert import (
     GroupedMLPExpert,
     SonicMoEExpert,
@@ -62,6 +72,8 @@ class TestSituGLU(unittest.TestCase):
 
     def test_rejects_non_positive_scales(self):
         x = paddle.ones([2, 8])
+        probs = paddle.ones([2])
+        out_grad = paddle.ones([2, 4])
         invalid_scales = (-1.0, 0.0)
 
         for beta in invalid_scales:
@@ -75,13 +87,47 @@ class TestSituGLU(unittest.TestCase):
                 self.assertRaises(AssertionError),
             ):
                 situ_glu(x, beta=beta)
+            with (
+                self.subTest(beta=beta, function="situ_glu_scale_forward"),
+                self.assertRaises(AssertionError),
+            ):
+                situ_glu_scale_forward(x, probs, beta=beta)
+            with (
+                self.subTest(beta=beta, function="situ_glu_scale_backward"),
+                self.assertRaises(AssertionError),
+            ):
+                situ_glu_scale_backward(x, probs, out_grad, beta=beta)
 
         for linear_beta in invalid_scales:
             with (
-                self.subTest(linear_beta=linear_beta),
+                self.subTest(
+                    linear_beta=linear_beta,
+                    function="situ_glu",
+                ),
                 self.assertRaises(AssertionError),
             ):
                 situ_glu(x, linear_beta=linear_beta)
+            with (
+                self.subTest(
+                    linear_beta=linear_beta,
+                    function="situ_glu_scale_forward",
+                ),
+                self.assertRaises(AssertionError),
+            ):
+                situ_glu_scale_forward(x, probs, linear_beta=linear_beta)
+            with (
+                self.subTest(
+                    linear_beta=linear_beta,
+                    function="situ_glu_scale_backward",
+                ),
+                self.assertRaises(AssertionError),
+            ):
+                situ_glu_scale_backward(
+                    x,
+                    probs,
+                    out_grad,
+                    linear_beta=linear_beta,
+                )
 
     def test_grouped_bf16_expert_forward_backward(self):
         model_parallel_cuda_manual_seed(2026)
@@ -125,7 +171,135 @@ class TestSituGLU(unittest.TestCase):
             )
         )
 
-    def test_moe_layer_rejects_situ_fusion_options(self):
+    def test_grouped_deep_gemm_situ_forward_backward(self):
+        model_parallel_cuda_manual_seed(2026)
+        config = TransformerConfig(
+            hidden_size=512,
+            num_hidden_layers=1,
+            num_attention_heads=8,
+            intermediate_size=256,
+            moe_intermediate_size=256,
+            gated_linear_unit=True,
+            hidden_act=situ,
+            activation_situ_beta=4.0,
+            activation_situ_linear_beta=25.0,
+            params_dtype="bfloat16",
+        )
+        expert = GroupedMLPExpert(
+            num_local_experts=2,
+            config=config,
+            moe_deep_gemm=True,
+        )
+        with paddle.no_grad():
+            expert.weight1.set_value(
+                paddle.randn(expert.weight1.shape, dtype="bfloat16") * 0.01
+            )
+            expert.weight2.set_value(
+                paddle.randn(expert.weight2.shape, dtype="bfloat16") * 0.01
+            )
+        hidden_states = paddle.randn([256, 512], dtype="bfloat16")
+        hidden_states.stop_gradient = False
+
+        output, output_bias = expert(
+            hidden_states,
+            paddle.to_tensor([128, 128], dtype="int64"),
+        )
+        output.sum().backward()
+
+        self.assertIsNone(output_bias)
+        for name, tensor in (
+            ("output", output),
+            ("input_grad", hidden_states.grad),
+            ("weight1_grad", expert.weight1.grad),
+            ("weight2_grad", expert.weight2.grad),
+        ):
+            with self.subTest(name=name):
+                self.assertIsNotNone(tensor)
+                self.assertTrue(
+                    bool(paddle.isfinite(tensor.astype("float32")).all())
+                )
+
+    def test_situ_glu_scale_matches_autograd(self):
+        paddle.seed(2026)
+        x = paddle.randn([7, 16], dtype="bfloat16")
+        out_grad = paddle.randn([7, 8], dtype="bfloat16")
+
+        for linear_beta, probs_shape in ((25.0, [7]), (None, [7, 1])):
+            with self.subTest(
+                linear_beta=linear_beta,
+                probs_shape=probs_shape,
+            ):
+                probs = paddle.rand(probs_shape, dtype="float32")
+                x_ref = x.detach()
+                probs_ref = probs.detach()
+                x_ref.stop_gradient = False
+                probs_ref.stop_gradient = False
+                gate, up = paddle.chunk(x_ref, chunks=2, axis=-1)
+                gate = gate.astype("float32")
+                up = up.astype("float32")
+                gate = 4.0 * paddle.tanh(gate / 4.0) * F.sigmoid(gate)
+                if linear_beta is not None:
+                    up = linear_beta * paddle.tanh(up / linear_beta)
+                probs_view = (
+                    probs_ref.unsqueeze(-1)
+                    if probs_ref.ndim == 1
+                    else probs_ref
+                )
+                expected = (gate * up * probs_view).astype(x.dtype)
+                paddle.autograd.backward([expected], [out_grad])
+
+                actual = situ_glu_scale_forward(
+                    x,
+                    probs,
+                    4.0,
+                    linear_beta,
+                )
+                x_grad, recomputed, probs_grad = situ_glu_scale_backward(
+                    x,
+                    probs,
+                    out_grad,
+                    4.0,
+                    linear_beta,
+                )
+
+                self.assertTrue(
+                    paddle.equal_all(
+                        actual.astype("float32"),
+                        expected.detach().astype("float32"),
+                    )
+                )
+                self.assertTrue(
+                    paddle.equal_all(
+                        recomputed.astype("float32"),
+                        actual.astype("float32"),
+                    )
+                )
+                self.assertTrue(
+                    paddle.equal_all(
+                        x_grad.astype("float32"),
+                        x_ref.grad.astype("float32"),
+                    )
+                )
+                self.assertTrue(
+                    paddle.allclose(
+                        probs_grad,
+                        probs_ref.grad,
+                        atol=1e-6,
+                        rtol=1e-6,
+                    )
+                )
+
+    def test_fused_node_rejects_situ_fp8(self):
+        node = ExpertsGroupGemmContiguousNode.__new__(
+            ExpertsGroupGemmContiguousNode
+        )
+        node.use_fp8_mlp = True
+        node.activation_type = "situ"
+
+        with self.assertRaisesRegex(AssertionError, "only supports.*swiglu"):
+            node.fwd_down(None, None, None, 0)
+
+    def test_moe_layer_accepts_situ_fusion_options(self):
         model_parallel_cuda_manual_seed(2026)
         config_kwargs = {
             "hidden_size": 8,
@@ -136,40 +310,241 @@ class TestSituGLU(unittest.TestCase):
             "n_shared_experts": 0,
             "num_experts_per_tok": 1,
             "moe_intermediate_size": 4,
-            "moe_deep_gemm": False,
             "gated_linear_unit": True,
             "hidden_act": situ,
+            "activation_situ_beta": 4.0,
+            "activation_situ_linear_beta": 25.0,
         }
 
-        for option in ("moe_use_fusion_node", "moe_expert_fusion"):
-            with self.subTest(option=option):
+        for expert_fusion, deep_gemm in (
+            (False, False),
+            (True, False),
+            (True, True),
+        ):
+            with self.subTest(
+                expert_fusion=expert_fusion,
+                deep_gemm=deep_gemm,
+            ):
                 config = TransformerConfig(
                     **config_kwargs,
-                    moe_use_fusion_node=option == "moe_use_fusion_node",
-                    moe_expert_fusion=option == "moe_expert_fusion",
+                    moe_use_fusion_node=True,
+                    moe_expert_fusion=expert_fusion,
+                    moe_deep_gemm=deep_gemm,
                 )
-                with self.assertRaisesRegex(
-                    ValueError,
-                    "support will be added in a future release",
-                ):
-                    MoELayer(config)
+                layer_spec = get_gpt_layer_local_spec(
+                    config,
+                    num_experts=config.n_routed_experts,
+                )
+                layer = MoELayer(
+                    config,
+                    layer_spec.sublayers_spec.mlp.extra_kwargs["sublayers"],
+                    SimpleNamespace(ep=None, expt_dp=None),
+                )
+                self.assertEqual(layer._activation_type, "situ")
+                self.assertTrue(layer.moe_use_fusion_node)
+                self.assertEqual(layer.moe_expert_fusion, expert_fusion)
+                self.assertEqual(layer.moe_deep_gemm, deep_gemm)
 
-        config = TransformerConfig(
+        fp8_config = TransformerConfig(
             **config_kwargs,
-            moe_use_fusion_node=False,
-            moe_expert_fusion=False,
+            moe_use_fusion_node=True,
+            moe_expert_fusion=True,
+            moe_deep_gemm=True,
+            fp8="e4m3",
         )
-        layer_spec = get_gpt_layer_local_spec(
-            config,
-            num_experts=config.n_routed_experts,
+        with self.assertRaisesRegex(ValueError, "supports BF16"):
+            MoELayer(fp8_config)
+
+    def test_situ_fused_grouped_deep_gemm_forward_backward(self):
+        model_parallel_cuda_manual_seed(2026)
+        paddle.seed(2026)
+        hidden_size = 512
+        intermediate_size = 256
+        tokens_per_expert = [128, 128]
+        config = TransformerConfig(
+            hidden_size=hidden_size,
+            num_hidden_layers=1,
+            num_attention_heads=8,
+            intermediate_size=intermediate_size,
+            moe_intermediate_size=intermediate_size,
+            gated_linear_unit=True,
+            hidden_act=situ,
+            activation_situ_beta=4.0,
+            activation_situ_linear_beta=25.0,
+            params_dtype="bfloat16",
         )
-        layer = MoELayer(
-            config,
-            layer_spec.sublayers_spec.mlp.extra_kwargs["sublayers"],
-            SimpleNamespace(ep=None, expt_dp=None),
+        weight1 = (
+            paddle.randn(
+                [2, hidden_size, 2 * intermediate_size], dtype="bfloat16"
+            )
+            * 0.01
         )
-        self.assertFalse(layer.moe_use_fusion_node)
-        self.assertFalse(layer.moe_expert_fusion)
+        weight2 = (
+            paddle.randn([2, intermediate_size, hidden_size], dtype="bfloat16")
+            * 0.01
+        )
+        hidden_states = paddle.randn([256, hidden_size], dtype="bfloat16")
+        probs = paddle.rand([256], dtype="float32")
+        out_grad = paddle.randn([256, hidden_size], dtype="bfloat16")
+
+        def run(deep_gemm, use_accuracy_compatible=False):
+            expert = GroupedMLPExpert(
+                num_local_experts=2,
+                config=config,
+                moe_deep_gemm=deep_gemm,
+            )
+            expert.weight1.set_value(weight1)
+            expert.weight2.set_value(weight2)
+            expert.weight1.main_grad = None
+            expert.weight2.main_grad = None
+            custom_map = SimpleNamespace(
+                config=config,
+                grouped_gemm_experts=expert,
+                token_dispatcher=SimpleNamespace(
+                    _comm_manager=SimpleNamespace(
+                        tokens_per_expert=tokens_per_expert
+                    )
+                ),
+            )
+            node = ExpertsGroupGemmContiguousNode(
+                custom_map,
+                use_fp8_mlp=False,
+                moe_expert_fusion=True,
+                moe_deep_gemm=deep_gemm,
+                activation_type="situ",
+                use_accuracy_compatible=use_accuracy_compatible,
+            )
+            output = node.forward(hidden_states, probs, tokens_per_expert)
+            input_grad, probs_grad = node.backward(out_grad, probs)
+            return (
+                output,
+                input_grad,
+                probs_grad,
+                expert.weight1.main_grad,
+                expert.weight2.main_grad,
+            )
+
+        grouped = run(False)
+        deep_gemm = run(True)
+        accuracy_compatible = run(False, use_accuracy_compatible=True)
+        tolerances = (
+            (1e-3, 1e-3),
+            (1e-3, 1e-3),
+            (1e-4, 1e-4),
+            (5e-3, 5e-3),
+            (5e-3, 5e-3),
+        )
+        for path, actuals in (
+            ("deep_gemm", deep_gemm),
+            ("accuracy_compatible", accuracy_compatible),
+        ):
+            for name, expected, actual, (atol, rtol) in zip(
+                (
+                    "output",
+                    "input_grad",
+                    "probs_grad",
+                    "weight1_grad",
+                    "weight2_grad",
+                ),
+                grouped,
+                actuals,
+                tolerances,
+            ):
+                with self.subTest(path=path, name=name):
+                    expected_fp32 = expected.astype("float32")
+                    actual_fp32 = actual.astype("float32")
+                    self.assertTrue(
+                        paddle.allclose(
+                            expected_fp32,
+                            actual_fp32,
+                            atol=atol,
+                            rtol=rtol,
+                        ),
+                        msg=(
+                            f"{path} {name} max_abs="
+                            f"{float((expected_fp32 - actual_fp32).abs().max())}"
+                        ),
+                    )
+
+    def test_situ_fusion_moe_deep_gemm_smoke(self):
+        model_parallel_cuda_manual_seed(2026)
+        paddle.seed(2026)
+        hidden_size = 512
+        intermediate_size = 256
+        tokens_per_expert = [128, 128]
+        config = TransformerConfig(
+            hidden_size=hidden_size,
+            num_hidden_layers=1,
+            num_attention_heads=8,
+            intermediate_size=intermediate_size,
+            moe_intermediate_size=intermediate_size,
+            gated_linear_unit=True,
+            hidden_act=situ,
+            activation_situ_beta=4.0,
+            activation_situ_linear_beta=25.0,
+            params_dtype="bfloat16",
+        )
+        expert = GroupedMLPExpert(
+            num_local_experts=2,
+            config=config,
+            moe_deep_gemm=True,
+        )
+        with paddle.no_grad():
+            expert.weight1.set_value(
+                paddle.randn(expert.weight1.shape, dtype="bfloat16") * 0.01
+            )
+            expert.weight2.set_value(
+                paddle.randn(expert.weight2.shape, dtype="bfloat16") * 0.01
+            )
+        expert.weight1.main_grad = None
+        expert.weight2.main_grad = None
+        moe_layer = SimpleNamespace(
+            config=config,
+            _activation_type="situ",
+            moe_use_fusion_node=True,
+            grouped_gemm_experts=expert,
+            token_dispatcher=SimpleNamespace(
+                _comm_manager=SimpleNamespace(
+                    tokens_per_expert=tokens_per_expert
+                )
+            ),
+        )
+        hidden_states = paddle.randn([256, hidden_size], dtype="bfloat16")
+        hidden_states.stop_gradient = False
+        probs = paddle.rand([256, 1], dtype="float32")
+        probs.stop_gradient = False
+        indices = paddle.concat(
+            [
+                paddle.zeros([128, 1], dtype="int64"),
+                paddle.ones([128, 1], dtype="int64"),
+            ],
+            axis=0,
+        )
+
+        output = FusionMoePyLayer.apply(
+            hidden_states,
+            probs,
+            indices,
+            moe_layer,
+            1,
+            use_fp8_mlp=False,
+            moe_deep_gemm=True,
+            moe_expert_fusion=True,
+        )
+        output.sum().backward()
+
+        for name, tensor in (
+            ("output", output),
+            ("input_grad", hidden_states.grad),
+            ("probs_grad", probs.grad),
+            ("weight1_grad", expert.weight1.main_grad),
+            ("weight2_grad", expert.weight2.main_grad),
+        ):
+            with self.subTest(name=name):
+                self.assertIsNotNone(tensor)
+                self.assertTrue(
+                    bool(paddle.isfinite(tensor.astype("float32")).all())
+                )
 
     def test_grouped_expert_preserves_standard_activation_config(self):
         model_parallel_cuda_manual_seed(2026)


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
New features

### Description
- 为 BF16 MoE expert fusion 和 FusionMoe 接入 SiTU-GLU 前反向。
- 支持 grouped GEMM、DeepGEMM 以及 router probability 梯度，FP8 路径保持显式拒绝。
- 补齐各融合组合、数值公式和保护分支的行为级单测。

### 是否引起精度变化
否
