### PR TITLE
[Performance Optimization] Add recompute  for KDA rmsnorm_gated

### DIFF
--- a/src/paddlefleet/transformer/kimi_delta_attention.py
+++ b/src/paddlefleet/transformer/kimi_delta_attention.py
@@ -41,6 +41,10 @@ from paddle.distributed.flex_checkpoint.dcp.sharded_weight import (
 
 from paddlefleet.jit import jit_fuser
 from paddlefleet.process_groups_config import ProcessGroupCollection
+from paddlefleet.recompute_utils import (
+    need_recompute_in_block,
+    need_recompute_in_first_n,
+)
 from paddlefleet.tensor_parallel import RecomputeWithoutOutput
 from paddlefleet.transformer.identity_op import IdentityOp
 from paddlefleet.transformer.layer import FleetLayer
@@ -310,12 +314,24 @@ class KimiDeltaAttention(FleetLayer):
         # Selectively recompute the gated RMSNorm in backward instead of keeping
         # its output activation around. Uses RecomputeWithoutOutput so the norm
         # output buffer is discarded after the forward and rebuilt just before
-        # out_proj's backward needs it.
-        self.recompute_rms_norm_gated = (
-            self.config.recompute_granularity == "selective"
-            and self.config.recompute_modules is not None
-            and "rms_norm_gated" in self.config.recompute_modules
-        )
+        # out_proj's backward needs it. Honour the same layer-range semantics as
+        # the other selective modules (Attention.core_attn / MLA.mla_qkv): a list
+        # entry with recompute_num_layers, or a dict entry whose value is the
+        # per-module layer count, restricts recompute to first_n / block layers.
+        self.recompute_rms_norm_gated = False
+        if self.config.recompute_granularity == "selective":
+            modules = self.config.recompute_modules
+            if isinstance(modules, list) and "rms_norm_gated" in modules:
+                if self.config.recompute_num_layers is None:
+                    self.recompute_rms_norm_gated = True
+                else:
+                    self.recompute_rms_norm_gated = self._need_recompute_layer(
+                        self.config.recompute_num_layers
+                    )
+            elif isinstance(modules, dict) and "rms_norm_gated" in modules:
+                self.recompute_rms_norm_gated = self._need_recompute_layer(
+                    modules["rms_norm_gated"]
+                )
 
         # q/k/v/beta are all sharded by head, so both head counts must divide
         # evenly; otherwise the per-tensor split sizes in forward() silently stop
@@ -452,6 +468,24 @@ class KimiDeltaAttention(FleetLayer):
         )
 
         self.reset_parameters()
+
+    def _need_recompute_layer(self, recompute_num_layers):
+        """Whether this layer_number is in the selective-recompute set.
+
+        Mirrors Attention/MLA: recompute_method picks first_n vs block, and
+        recompute_num_layers is the per-module layer count.
+        """
+        assert self.config.recompute_method in ["first_n", "block"], (
+            "selective recompute of rms_norm_gated with a layer count requires "
+            "recompute_method to be 'first_n' or 'block'"
+        )
+        if self.config.recompute_method == "block":
+            return need_recompute_in_block(
+                self.layer_number, self.config, recompute_num_layers
+            )
+        return need_recompute_in_first_n(
+            self.layer_number, self.config, recompute_num_layers
+        )
 
     def _build_lora_pair(self, a_spec, b_spec):
         """hidden -> gate_lora_rank (replicated) -> v_dim (column parallel)."""

--- a/src/paddlefleet/transformer/kimi_delta_attention.py
+++ b/src/paddlefleet/transformer/kimi_delta_attention.py
@@ -473,18 +473,22 @@ class KimiDeltaAttention(FleetLayer):
         """Whether this layer_number is in the selective-recompute set.
 
         Mirrors Attention/MLA: recompute_method picks first_n vs block, and
-        recompute_num_layers is the per-module layer count.
+        recompute_num_layers is the per-module layer count. Uses an explicit
+        raise (not assert) so an invalid method cannot silently fall through to
+        first_n under ``python -O``, which would change the recompute set.
         """
-        assert self.config.recompute_method in ["first_n", "block"], (
-            "selective recompute of rms_norm_gated with a layer count requires "
-            "recompute_method to be 'first_n' or 'block'"
-        )
         if self.config.recompute_method == "block":
             return need_recompute_in_block(
                 self.layer_number, self.config, recompute_num_layers
             )
-        return need_recompute_in_first_n(
-            self.layer_number, self.config, recompute_num_layers
+        if self.config.recompute_method == "first_n":
+            return need_recompute_in_first_n(
+                self.layer_number, self.config, recompute_num_layers
+            )
+        raise ValueError(
+            "selective recompute of rms_norm_gated with a layer count requires "
+            "recompute_method to be 'first_n' or 'block', got "
+            f"{self.config.recompute_method!r}"
         )
 
     def _build_lora_pair(self, a_spec, b_spec):

--- a/src/paddlefleet/transformer/kimi_delta_attention.py
+++ b/src/paddlefleet/transformer/kimi_delta_attention.py
@@ -41,6 +41,7 @@ from paddle.distributed.flex_checkpoint.dcp.sharded_weight import (
 
 from paddlefleet.jit import jit_fuser
 from paddlefleet.process_groups_config import ProcessGroupCollection
+from paddlefleet.tensor_parallel import RecomputeWithoutOutput
 from paddlefleet.transformer.identity_op import IdentityOp
 from paddlefleet.transformer.layer import FleetLayer
 from paddlefleet.triton_ops.utils import is_triton_available
@@ -305,6 +306,16 @@ class KimiDeltaAttention(FleetLayer):
         if self.use_fused_kernels and not _FUSED_KERNEL_LOGGED:
             _FUSED_KERNEL_LOGGED = True
             log_single_rank(logger, logging.INFO, "KDA will use fused kernel")
+
+        # Selectively recompute the gated RMSNorm in backward instead of keeping
+        # its output activation around. Uses RecomputeWithoutOutput so the norm
+        # output buffer is discarded after the forward and rebuilt just before
+        # out_proj's backward needs it.
+        self.recompute_rms_norm_gated = (
+            self.config.recompute_granularity == "selective"
+            and self.config.recompute_modules is not None
+            and "rms_norm_gated" in self.config.recompute_modules
+        )
 
         # q/k/v/beta are all sharded by head, so both head counts must divide
         # evenly; otherwise the per-tensor split sizes in forward() silently stop
@@ -793,6 +804,42 @@ class KimiDeltaAttention(FleetLayer):
 
         # Gated norm
         nvtx_range_push(suffix="gated_norm")
+        gated_norm_recompute = None
+        if self.recompute_rms_norm_gated and self.training:
+            # Drop the norm output activation now and re-run the gated norm
+            # in backward. The recompute hook is registered on out_proj's
+            # output below, so it fires right before out_proj needs its input.
+            # The reshape/transpose are folded into the recomputed function so
+            # the discarded tensor is exactly the one out_proj saves; otherwise
+            # out_proj would hold a separate reshape view and nothing is freed.
+            gated_norm_recompute = RecomputeWithoutOutput()
+            norm_out = gated_norm_recompute.recompute(
+                lambda c, g: self._gated_norm(c, g, batch, seq_len),
+                core_attn_out,
+                gate,
+                preserve_rng_state=False,
+                share_grad_holder=True,
+            )
+        else:
+            norm_out = self._gated_norm(core_attn_out, gate, batch, seq_len)
+        nvtx_range_pop(suffix="gated_norm")
+
+        nvtx_range_push(suffix="out_proj")
+        out, out_bias = self.out_proj(norm_out)
+        nvtx_range_pop(suffix="out_proj")
+
+        if gated_norm_recompute is not None:
+            gated_norm_recompute.discard_output_and_register_recompute(out)
+
+        return out, out_bias
+
+    def _gated_norm(self, core_attn_out, gate, batch, seq_len):
+        """Per-head gated RMSNorm, returning the [b, s, v_dim] output.
+
+        Wraps both the fused FLA kernel and the paddle-native fallback, and
+        folds in the final reshape (and the sequence-parallel transpose) so the
+        whole gated-norm block is a single self-contained recompute segment.
+        """
         if self.use_fused_kernels:
             norm_out = rms_norm_gated(
                 core_attn_out.reshape([-1, self.value_head_dim]),
@@ -804,19 +851,13 @@ class KimiDeltaAttention(FleetLayer):
             )
         else:
             norm_out = self._apply_gated_norm(core_attn_out, gate)
-        nvtx_range_pop(suffix="gated_norm")
 
         # [b, s, num_heads, head_dim] -> [b, s, v_dim]
         norm_out = norm_out.reshape([batch, seq_len, -1])
 
         if self.config.sequence_parallel:
             norm_out = norm_out.transpose([1, 0, 2]).contiguous()
-
-        nvtx_range_push(suffix="out_proj")
-        out, out_bias = self.out_proj(norm_out)
-        nvtx_range_pop(suffix="out_proj")
-
-        return out, out_bias
+        return norm_out
 
     def _check_decode_supported(
         self, cu_seqlens, attn_mask_startend_row_indices

--- a/tests/single_card_tests/transformer/test_kimi_delta_attention.py
+++ b/tests/single_card_tests/transformer/test_kimi_delta_attention.py
@@ -1128,6 +1128,42 @@ class TestGatedNormRecompute(unittest.TestCase):
         # no recompute configured at all
         self.assertFalse(_build_kda().recompute_rms_norm_gated)
 
+    def test_layer_range_restricts_recompute(self):
+        """recompute_num_layers / dict values must scope recompute by layer.
+
+        With the test config (num_hidden_layers=2, pp=vpp=1) first_n/block with
+        a count of 1 selects only layer 0, so layer 1 must stay off instead of
+        every KDA layer recomputing.
+        """
+
+        def flag(layer_number, modules, num_layers=None, method="first_n"):
+            overrides = {
+                "recompute_granularity": "selective",
+                "recompute_modules": modules,
+                "recompute_method": method,
+            }
+            if num_layers is not None:
+                overrides["recompute_num_layers"] = num_layers
+            kda = _build_kda(
+                layer_number=layer_number, config_overrides=overrides
+            )
+            return kda.recompute_rms_norm_gated
+
+        # list + recompute_num_layers=1, first_n -> only layer 0
+        self.assertTrue(flag(0, ["rms_norm_gated"], num_layers=1))
+        self.assertFalse(flag(1, ["rms_norm_gated"], num_layers=1))
+
+        # block behaves the same for a single-stage config
+        self.assertTrue(flag(0, ["rms_norm_gated"], num_layers=1, method="block"))
+        self.assertFalse(flag(1, ["rms_norm_gated"], num_layers=1, method="block"))
+
+        # dict form: the value is the per-module layer count
+        self.assertTrue(flag(0, {"rms_norm_gated": 1}))
+        self.assertFalse(flag(1, {"rms_norm_gated": 1}))
+
+        # list without a count still recomputes every layer
+        self.assertTrue(flag(1, ["rms_norm_gated"]))
+
     def _assert_matches_baseline(self, deterministic):
         paddle.seed(0)
         baseline = _build_kda(deterministic_mode=deterministic)

--- a/tests/single_card_tests/transformer/test_kimi_delta_attention.py
+++ b/tests/single_card_tests/transformer/test_kimi_delta_attention.py
@@ -1154,8 +1154,12 @@ class TestGatedNormRecompute(unittest.TestCase):
         self.assertFalse(flag(1, ["rms_norm_gated"], num_layers=1))
 
         # block behaves the same for a single-stage config
-        self.assertTrue(flag(0, ["rms_norm_gated"], num_layers=1, method="block"))
-        self.assertFalse(flag(1, ["rms_norm_gated"], num_layers=1, method="block"))
+        self.assertTrue(
+            flag(0, ["rms_norm_gated"], num_layers=1, method="block")
+        )
+        self.assertFalse(
+            flag(1, ["rms_norm_gated"], num_layers=1, method="block")
+        )
 
         # dict form: the value is the per-module layer count
         self.assertTrue(flag(0, {"rms_norm_gated": 1}))

--- a/tests/single_card_tests/transformer/test_kimi_delta_attention.py
+++ b/tests/single_card_tests/transformer/test_kimi_delta_attention.py
@@ -273,6 +273,7 @@ def _build_kda(
     hidden_act=F.silu,
     deterministic_mode=True,
     out_norm=SimpleRMSNorm,
+    config_overrides=None,
     **overrides,
 ):
     config = TransformerConfig(
@@ -284,6 +285,7 @@ def _build_kda(
         normalization="RMSNorm",
         sequence_parallel=sequence_parallel,
         deterministic_mode=deterministic_mode,
+        **(config_overrides or {}),
     )
     spec = KimiDeltaAttentionSublayersSpec(
         in_proj=NoBiasLinear,
@@ -1083,6 +1085,103 @@ class TestCuSeqlensFromEmbedding(unittest.TestCase):
         np.testing.assert_array_equal(
             out["cu_seqlens"].numpy(), expected.numpy()
         )
+
+
+class TestGatedNormRecompute(unittest.TestCase):
+    """Selective recompute of the gated RMSNorm via RecomputeWithoutOutput.
+
+    The gated norm output is dropped after the forward and re-run in backward,
+    so the result must stay bit-exact while the norm is executed a second time.
+    """
+
+    def _forward_backward(self, kda, seed=1):
+        paddle.seed(seed)
+        x = paddle.randn([MICRO_BATCH_SIZE, SEQ_LENGTH, HIDDEN_SIZE])
+        x.stop_gradient = False
+        out, _ = kda(hidden_states=x, attention_mask=None)
+        out.pow(2).mean().backward()
+        return (
+            out.numpy(),
+            x.grad.numpy(),
+            {n: p.grad.numpy() for n, p in kda.named_parameters()},
+        )
+
+    def test_flag_follows_recompute_modules(self):
+        """The flag is on only for selective recompute listing rms_norm_gated."""
+        on = _build_kda(
+            config_overrides={
+                "recompute_granularity": "selective",
+                "recompute_modules": ["rms_norm_gated"],
+            }
+        )
+        self.assertTrue(on.recompute_rms_norm_gated)
+
+        # selective, but a different module is requested
+        other = _build_kda(
+            config_overrides={
+                "recompute_granularity": "selective",
+                "recompute_modules": ["gated_attn"],
+            }
+        )
+        self.assertFalse(other.recompute_rms_norm_gated)
+
+        # no recompute configured at all
+        self.assertFalse(_build_kda().recompute_rms_norm_gated)
+
+    def _assert_matches_baseline(self, deterministic):
+        paddle.seed(0)
+        baseline = _build_kda(deterministic_mode=deterministic)
+        baseline.train()
+        o0, gx0, g0 = self._forward_backward(baseline)
+
+        paddle.seed(0)
+        recomputed = _build_kda(deterministic_mode=deterministic)
+        recomputed.recompute_rms_norm_gated = True
+        recomputed.train()
+        o1, gx1, g1 = self._forward_backward(recomputed)
+
+        np.testing.assert_array_equal(o0, o1, err_msg="output")
+        np.testing.assert_array_equal(gx0, gx1, err_msg="grad_x")
+        for name in g0:
+            np.testing.assert_array_equal(g0[name], g1[name], err_msg=name)
+
+    def test_matches_baseline_native(self):
+        """Paddle-native fallback: recompute is bit-exact with the baseline."""
+        self._assert_matches_baseline(deterministic=True)
+
+    @unittest.skipUnless(
+        HAVE_FLA, "paddlefleet_ops fla kernels are not available"
+    )
+    def test_matches_baseline_fused(self):
+        """Fused FLA kernel: recompute is bit-exact with the baseline."""
+        self._assert_matches_baseline(deterministic=False)
+
+    def test_reruns_gated_norm_in_backward(self):
+        """With the flag on and training, the gated norm runs twice."""
+        kda = _build_kda()
+        kda.recompute_rms_norm_gated = True
+        kda.train()
+        with patch.object(kda, "_gated_norm", wraps=kda._gated_norm) as spy:
+            self._forward_backward(kda)
+        # once in forward, once when the backward hook recomputes it
+        self.assertEqual(spy.call_count, 2)
+
+    def test_no_recompute_without_flag(self):
+        """Baseline path runs the gated norm exactly once."""
+        kda = _build_kda()
+        kda.train()
+        with patch.object(kda, "_gated_norm", wraps=kda._gated_norm) as spy:
+            self._forward_backward(kda)
+        self.assertEqual(spy.call_count, 1)
+
+    def test_no_recompute_in_eval(self):
+        """Recompute is skipped outside training even when the flag is set."""
+        kda = _build_kda()
+        kda.recompute_rms_norm_gated = True
+        kda.eval()
+        with patch.object(kda, "_gated_norm", wraps=kda._gated_norm) as spy:
+            self._forward_backward(kda)
+        self.assertEqual(spy.call_count, 1)
 
 
 if __name__ == "__main__":

--- a/tests/single_card_tests/transformer/test_kimi_delta_attention.py
+++ b/tests/single_card_tests/transformer/test_kimi_delta_attention.py
@@ -1168,6 +1168,22 @@ class TestGatedNormRecompute(unittest.TestCase):
         # list without a count still recomputes every layer
         self.assertTrue(flag(1, ["rms_norm_gated"]))
 
+    def test_layer_count_without_valid_method_raises(self):
+        """A layer count with no first_n/block method must raise, not silently
+        fall through to first_n (which an assert would under python -O)."""
+        # recompute_method=None is accepted by the config for selective, so the
+        # guard has to live in the layer resolver itself.
+        for modules in (["rms_norm_gated"], {"rms_norm_gated": 1}):
+            overrides = {
+                "recompute_granularity": "selective",
+                "recompute_modules": modules,
+                "recompute_method": None,
+            }
+            if isinstance(modules, list):
+                overrides["recompute_num_layers"] = 1
+            with self.assertRaises(ValueError):
+                _build_kda(layer_number=0, config_overrides=overrides)
+
     def _assert_matches_baseline(self, deterministic):
         paddle.seed(0)
         baseline = _build_kda(deterministic_mode=deterministic)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->

Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
增加rms_norm_gated 的SR

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否


### 简要测试报告
<strong>配置</strong></p>
项 | 值
-- | --
来源 | K3 config.json KDA 层
hidden_size | 7168
num_heads / head_dim | 96 / 128
use_full_rank_gate | true
batch × seq | 1 × 8192
dtype / kernel | bf16 / fused FLA
度量 | fwd+bwd 时延(30 iter 均值),前向后驻留激活 memory_allocated

<strong>结果</strong></p>
  | 时延 (fwd+bwd) | 前向后驻留激活
-- | -- | --
recompute OFF | 33.58 ms | 2129.0 MiB
recompute ON | 33.58 ms | 1934.0 MiB
差异 | +0.00 ms (0.0%) | 省 195.0 MiB（～10%）
