### PR TITLE
[Execute Infrastructure] Fix CE workflow build dependency installation

### DIFF
--- a/.github/workflows/ce_daily_dev.yml
+++ b/.github/workflows/ce_daily_dev.yml
@@ -1,9 +1,6 @@
 name: CE Daily Dev
 
 on:
-  pull_request:
-    branches:
-      - develop
   schedule:
     - cron: '0 19 * * *'
   workflow_dispatch: # 可选：允许手动点 Run

--- a/.github/workflows/ce_daily_dev.yml
+++ b/.github/workflows/ce_daily_dev.yml
@@ -147,7 +147,7 @@ jobs:
           mkdir -p /home/.cache/pip
           pip cache dir
           wget -q https://paddle-qa.bj.bcebos.com/paddlefleet/whl/Miniforge3-Linux-x86_64.sh -O miniconda.sh
-          bash miniconda.sh -b -p $HOME/miniconda -u > /dev/null
+          bash miniconda.sh -b -p $HOME/miniconda > /dev/null
           source "$HOME/miniconda/etc/profile.d/conda.sh"
           conda init bash
           conda create -n python${PYTHON_VERSION} python=${PYTHON_VERSION} -y -q > /dev/null
@@ -166,6 +166,7 @@ jobs:
           git config user.email "paddle_ci@example.com"
           git config pull.rebase false
           pip install colorlog>=6.10.1
+          pip install setuptools
           fleet_ops_wheel=paddlefleet_ops-0.0.0-cp${PYTHON_VERSION//./}-cp${PYTHON_VERSION//./}-linux_x86_64.whl
           wget -q "https://paddle-github-action.bj.bcebos.com/PaddleFleet/develop/latest/${CUDA_VERSION}/paddle-release/paddlefleet_ops-0.0.0-cp${PYTHON_VERSION//./}-cp${PYTHON_VERSION//./}-linux_x86_64.whl" -O ${fleet_ops_wheel}
           pip install ${fleet_ops_wheel} --extra-index-url=https://www.paddlepaddle.org.cn/packages/nightly/${CUDA_VERSION}/  --extra-index-url https://www.paddlepaddle.org.cn/packages/stable/${CUDA_VERSION}/ --extra-index-url https://pypi.tuna.tsinghua.edu.cn/simple
@@ -309,7 +310,7 @@ jobs:
           source /root/proxy
           pip install --upgrade pip
           wget -q https://paddle-qa.bj.bcebos.com/paddlefleet/whl/Miniforge3-Linux-x86_64.sh -O miniconda.sh
-          bash miniconda.sh -b -p $HOME/miniconda -u > /dev/null
+          bash miniconda.sh -b -p $HOME/miniconda > /dev/null
           source "$HOME/miniconda/etc/profile.d/conda.sh"
           conda init bash
           conda create -n python${PYTHON_VERSION} python=${PYTHON_VERSION} -y -q > /dev/null
@@ -327,6 +328,7 @@ jobs:
           git config pull.rebase false
           git submodule update --init --recursive
           pip install colorlog>=6.10.1
+          pip install setuptools
           fleet_ops_wheel=paddlefleet_ops-0.0.0-cp${PYTHON_VERSION//./}-cp${PYTHON_VERSION//./}-linux_x86_64.whl
           wget -q "https://paddle-github-action.bj.bcebos.com/PaddleFleet/develop/latest/${CUDA_VERSION}/paddle-release/paddlefleet_ops-0.0.0-cp${PYTHON_VERSION//./}-cp${PYTHON_VERSION//./}-linux_x86_64.whl" -O ${fleet_ops_wheel}
           pip install ${fleet_ops_wheel} --extra-index-url=https://www.paddlepaddle.org.cn/packages/nightly/${CUDA_VERSION}/  --extra-index-url https://www.paddlepaddle.org.cn/packages/stable/${CUDA_VERSION}/ --extra-index-url https://pypi.tuna.tsinghua.edu.cn/simple
@@ -488,7 +490,7 @@ jobs:
           pip cache dir
           pip install --upgrade pip
           wget -q https://paddle-qa.bj.bcebos.com/paddlefleet/whl/Miniforge3-Linux-x86_64.sh -O miniconda.sh
-          bash miniconda.sh -b -p $HOME/miniconda -u > /dev/null
+          bash miniconda.sh -b -p $HOME/miniconda > /dev/null
           source "$HOME/miniconda/etc/profile.d/conda.sh"
           conda init bash
           conda create -n python${PYTHON_VERSION} python=${PYTHON_VERSION} -y -q > /dev/null
@@ -500,6 +502,7 @@ jobs:
           git config user.email "paddle_ci@example.com"
           git config pull.rebase false
           pip install colorlog>=6.10.1
+          pip install setuptools
           fleet_ops_wheel=paddlefleet_ops-0.0.0-cp${PYTHON_VERSION//./}-cp${PYTHON_VERSION//./}-linux_x86_64.whl
           wget -q "https://paddle-github-action.bj.bcebos.com/PaddleFleet/develop/latest/${CUDA_VERSION}/paddle-release/paddlefleet_ops-0.0.0-cp${PYTHON_VERSION//./}-cp${PYTHON_VERSION//./}-linux_x86_64.whl" -O ${fleet_ops_wheel}
           pip install ${fleet_ops_wheel} --extra-index-url=https://www.paddlepaddle.org.cn/packages/nightly/${CUDA_VERSION}/  --extra-index-url https://www.paddlepaddle.org.cn/packages/stable/${CUDA_VERSION}/ --extra-index-url https://pypi.tuna.tsinghua.edu.cn/simple
@@ -752,7 +755,7 @@ jobs:
           pip cache dir
           pip install --upgrade pip
           wget -q https://paddle-qa.bj.bcebos.com/paddlefleet/whl/Miniforge3-Linux-x86_64.sh -O miniconda.sh
-          bash miniconda.sh -b -p $HOME/miniconda -u > /dev/null
+          bash miniconda.sh -b -p $HOME/miniconda > /dev/null
           source "$HOME/miniconda/etc/profile.d/conda.sh"
           conda init bash
           conda create -n python${PYTHON_VERSION} python=${PYTHON_VERSION} -y -q > /dev/null
@@ -764,6 +767,7 @@ jobs:
           git config user.email "paddle_ci@example.com"
           git config pull.rebase false
           pip install colorlog>=6.10.1
+          pip install setuptools
           fleet_ops_wheel=paddlefleet_ops-0.0.0-cp${PYTHON_VERSION//./}-cp${PYTHON_VERSION//./}-linux_x86_64.whl
           wget -q "https://paddle-github-action.bj.bcebos.com/PaddleFleet/develop/latest/${CUDA_VERSION}/paddle-release/paddlefleet_ops-0.0.0-cp${PYTHON_VERSION//./}-cp${PYTHON_VERSION//./}-linux_x86_64.whl" -O ${fleet_ops_wheel}
           pip install ${fleet_ops_wheel} --extra-index-url=https://www.paddlepaddle.org.cn/packages/nightly/${CUDA_VERSION}/  --extra-index-url https://www.paddlepaddle.org.cn/packages/stable/${CUDA_VERSION}/ --extra-index-url https://pypi.tuna.tsinghua.edu.cn/simple
@@ -1271,7 +1275,7 @@ jobs:
           pip cache dir
           pip install --upgrade pip
           wget -q https://paddle-qa.bj.bcebos.com/paddlefleet/whl/Miniforge3-Linux-x86_64.sh -O miniconda.sh
-          bash miniconda.sh -b -p $HOME/miniconda -u > /dev/null
+          bash miniconda.sh -b -p $HOME/miniconda > /dev/null
           source "$HOME/miniconda/etc/profile.d/conda.sh"
           conda init bash
           conda create -n python${PYTHON_VERSION} python=${PYTHON_VERSION} -y -q > /dev/null
@@ -1284,7 +1288,7 @@ jobs:
           git config pull.rebase false
           pip install colorlog>=6.10.1
           pip uninstall paddlefleet -y
-          pip install colorlog>=6.10.1
+          pip install setuptools
           fleet_ops_wheel=paddlefleet_ops-0.0.0-cp${PYTHON_VERSION//./}-cp${PYTHON_VERSION//./}-linux_x86_64.whl
           wget -q "https://paddle-github-action.bj.bcebos.com/PaddleFleet/develop/latest/${CUDA_VERSION}/paddle-release/paddlefleet_ops-0.0.0-cp${PYTHON_VERSION//./}-cp${PYTHON_VERSION//./}-linux_x86_64.whl" -O ${fleet_ops_wheel}
           pip install ${fleet_ops_wheel} --extra-index-url=https://www.paddlepaddle.org.cn/packages/nightly/${CUDA_VERSION}/  --extra-index-url https://www.paddlepaddle.org.cn/packages/stable/${CUDA_VERSION}/ --extra-index-url https://pypi.tuna.tsinghua.edu.cn/simple

--- a/.github/workflows/ce_daily_dev.yml
+++ b/.github/workflows/ce_daily_dev.yml
@@ -150,7 +150,7 @@ jobs:
           mkdir -p /home/.cache/pip
           pip cache dir
           wget -q https://paddle-qa.bj.bcebos.com/paddlefleet/whl/Miniforge3-Linux-x86_64.sh -O miniconda.sh
-          bash miniconda.sh -b -p $HOME/miniconda > /dev/null
+          bash miniconda.sh -b -p $HOME/miniconda -u > /dev/null
           source "$HOME/miniconda/etc/profile.d/conda.sh"
           conda init bash
           conda create -n python${PYTHON_VERSION} python=${PYTHON_VERSION} -y -q > /dev/null
@@ -313,7 +313,7 @@ jobs:
           source /root/proxy
           pip install --upgrade pip
           wget -q https://paddle-qa.bj.bcebos.com/paddlefleet/whl/Miniforge3-Linux-x86_64.sh -O miniconda.sh
-          bash miniconda.sh -b -p $HOME/miniconda > /dev/null
+          bash miniconda.sh -b -p $HOME/miniconda -u > /dev/null
           source "$HOME/miniconda/etc/profile.d/conda.sh"
           conda init bash
           conda create -n python${PYTHON_VERSION} python=${PYTHON_VERSION} -y -q > /dev/null
@@ -493,7 +493,7 @@ jobs:
           pip cache dir
           pip install --upgrade pip
           wget -q https://paddle-qa.bj.bcebos.com/paddlefleet/whl/Miniforge3-Linux-x86_64.sh -O miniconda.sh
-          bash miniconda.sh -b -p $HOME/miniconda > /dev/null
+          bash miniconda.sh -b -p $HOME/miniconda -u > /dev/null
           source "$HOME/miniconda/etc/profile.d/conda.sh"
           conda init bash
           conda create -n python${PYTHON_VERSION} python=${PYTHON_VERSION} -y -q > /dev/null
@@ -758,7 +758,7 @@ jobs:
           pip cache dir
           pip install --upgrade pip
           wget -q https://paddle-qa.bj.bcebos.com/paddlefleet/whl/Miniforge3-Linux-x86_64.sh -O miniconda.sh
-          bash miniconda.sh -b -p $HOME/miniconda > /dev/null
+          bash miniconda.sh -b -p $HOME/miniconda -u > /dev/null
           source "$HOME/miniconda/etc/profile.d/conda.sh"
           conda init bash
           conda create -n python${PYTHON_VERSION} python=${PYTHON_VERSION} -y -q > /dev/null
@@ -1278,7 +1278,7 @@ jobs:
           pip cache dir
           pip install --upgrade pip
           wget -q https://paddle-qa.bj.bcebos.com/paddlefleet/whl/Miniforge3-Linux-x86_64.sh -O miniconda.sh
-          bash miniconda.sh -b -p $HOME/miniconda > /dev/null
+          bash miniconda.sh -b -p $HOME/miniconda -u > /dev/null
           source "$HOME/miniconda/etc/profile.d/conda.sh"
           conda init bash
           conda create -n python${PYTHON_VERSION} python=${PYTHON_VERSION} -y -q > /dev/null

--- a/.github/workflows/ce_daily_dev.yml
+++ b/.github/workflows/ce_daily_dev.yml
@@ -1,6 +1,9 @@
 name: CE Daily Dev
 
 on:
+  pull_request:
+    branches:
+      - develop
   schedule:
     - cron: '0 19 * * *'
   workflow_dispatch: # 可选：允许手动点 Run

--- a/.github/workflows/ce_daily_release.yml
+++ b/.github/workflows/ce_daily_release.yml
@@ -1160,7 +1160,7 @@ jobs:
           pip install --upgrade pip
           wget -q https://paddle-qa.bj.bcebos.com/paddlefleet/whl/Miniforge3-Linux-x86_64.sh -O miniconda.sh
           bash miniconda.sh -b -p $HOME/miniconda > /dev/null
-          source "$HOME/miniconda/etc/profile.d/conda.sh" 
+          source "$HOME/miniconda/etc/profile.d/conda.sh"
           conda init bash > /dev/null
           conda create -n python${PYTHON_VERSION} python=${PYTHON_VERSION} -y -q > /dev/null
           conda activate python${PYTHON_VERSION}

--- a/.github/workflows/ce_daily_release.yml
+++ b/.github/workflows/ce_daily_release.yml
@@ -144,7 +144,7 @@ jobs:
           mkdir -p /home/.cache/pip
           pip cache dir
           wget -q https://paddle-qa.bj.bcebos.com/paddlefleet/whl/Miniforge3-Linux-x86_64.sh -O miniconda.sh
-          bash miniconda.sh -b -p $HOME/miniconda > /dev/null
+          bash miniconda.sh -b -p $HOME/miniconda -u > /dev/null
           source "$HOME/miniconda/etc/profile.d/conda.sh"
           conda init bash > /dev/null
           conda create -n python${PYTHON_VERSION} python=${PYTHON_VERSION} -y -q > /dev/null
@@ -292,7 +292,7 @@ jobs:
           source /root/proxy
           pip install --upgrade pip
           wget -q https://paddle-qa.bj.bcebos.com/paddlefleet/whl/Miniforge3-Linux-x86_64.sh -O miniconda.sh
-          bash miniconda.sh -b -p $HOME/miniconda > /dev/null
+          bash miniconda.sh -b -p $HOME/miniconda -u > /dev/null
           source "$HOME/miniconda/etc/profile.d/conda.sh"
           conda init bash > /dev/null
           conda create -n python${PYTHON_VERSION} python=${PYTHON_VERSION} -y -q > /dev/null
@@ -456,7 +456,7 @@ jobs:
           pip cache dir
           pip install --upgrade pip
           wget -q https://paddle-qa.bj.bcebos.com/paddlefleet/whl/Miniforge3-Linux-x86_64.sh -O miniconda.sh
-          bash miniconda.sh -b -p $HOME/miniconda > /dev/null
+          bash miniconda.sh -b -p $HOME/miniconda -u > /dev/null
           source "$HOME/miniconda/etc/profile.d/conda.sh"
           conda init bash > /dev/null
           conda create -n python${PYTHON_VERSION} python=${PYTHON_VERSION} -y -q > /dev/null
@@ -698,7 +698,7 @@ jobs:
           pip cache dir
           pip install --upgrade pip
           wget -q https://paddle-qa.bj.bcebos.com/paddlefleet/whl/Miniforge3-Linux-x86_64.sh -O miniconda.sh
-          bash miniconda.sh -b -p $HOME/miniconda > /dev/null
+          bash miniconda.sh -b -p $HOME/miniconda -u > /dev/null
           source "$HOME/miniconda/etc/profile.d/conda.sh"
           conda init bash > /dev/null
           conda create -n python${PYTHON_VERSION} python=${PYTHON_VERSION} -y -q > /dev/null
@@ -1159,7 +1159,7 @@ jobs:
           pip cache dir
           pip install --upgrade pip
           wget -q https://paddle-qa.bj.bcebos.com/paddlefleet/whl/Miniforge3-Linux-x86_64.sh -O miniconda.sh
-          bash miniconda.sh -b -p $HOME/miniconda > /dev/null
+          bash miniconda.sh -b -p $HOME/miniconda -u > /dev/null
           source "$HOME/miniconda/etc/profile.d/conda.sh"
           conda init bash > /dev/null
           conda create -n python${PYTHON_VERSION} python=${PYTHON_VERSION} -y -q > /dev/null

--- a/.github/workflows/ce_daily_release.yml
+++ b/.github/workflows/ce_daily_release.yml
@@ -144,9 +144,9 @@ jobs:
           mkdir -p /home/.cache/pip
           pip cache dir
           wget -q https://paddle-qa.bj.bcebos.com/paddlefleet/whl/Miniforge3-Linux-x86_64.sh -O miniconda.sh
-          bash miniconda.sh -b -p $HOME/miniconda -u > /dev/null
+          bash miniconda.sh -b -p $HOME/miniconda > /dev/null
           source "$HOME/miniconda/etc/profile.d/conda.sh"
-          conda init bash
+          conda init bash > /dev/null
           conda create -n python${PYTHON_VERSION} python=${PYTHON_VERSION} -y -q > /dev/null
           conda activate python${PYTHON_VERSION}
           paddle_url=${PADDLE_URL}
@@ -166,6 +166,7 @@ jobs:
           git config user.email "paddle_ci@example.com"
           git config pull.rebase false
           git fetch --all
+          python -m pip install s
           fleet_branch=release/$(git for-each-ref --format="%(refname:short)" "refs/remotes/origin/release/*" | awk -F/ "{print \$NF}" | sort -V | tail -1)
           git checkout ${fleet_branch}
           pip install colorlog>=6.10.1
@@ -291,9 +292,9 @@ jobs:
           source /root/proxy
           pip install --upgrade pip
           wget -q https://paddle-qa.bj.bcebos.com/paddlefleet/whl/Miniforge3-Linux-x86_64.sh -O miniconda.sh
-          bash miniconda.sh -b -p $HOME/miniconda -u > /dev/null
+          bash miniconda.sh -b -p $HOME/miniconda > /dev/null
           source "$HOME/miniconda/etc/profile.d/conda.sh"
-          conda init bash
+          conda init bash > /dev/null
           conda create -n python${PYTHON_VERSION} python=${PYTHON_VERSION} -y -q > /dev/null
           conda activate python${PYTHON_VERSION}
           paddle_url=${PADDLE_URL}
@@ -310,6 +311,7 @@ jobs:
           git config pull.rebase false
           git submodule update --init --recursive
           git fetch --all
+          python -m pip install s
           fleet_branch=release/$(git for-each-ref --format="%(refname:short)" "refs/remotes/origin/release/*" | awk -F/ "{print \$NF}" | sort -V | tail -1)
           git checkout ${fleet_branch}
           pip install colorlog>=6.10.1
@@ -454,9 +456,9 @@ jobs:
           pip cache dir
           pip install --upgrade pip
           wget -q https://paddle-qa.bj.bcebos.com/paddlefleet/whl/Miniforge3-Linux-x86_64.sh -O miniconda.sh
-          bash miniconda.sh -b -p $HOME/miniconda -u > /dev/null
+          bash miniconda.sh -b -p $HOME/miniconda > /dev/null
           source "$HOME/miniconda/etc/profile.d/conda.sh"
-          conda init bash
+          conda init bash > /dev/null
           conda create -n python${PYTHON_VERSION} python=${PYTHON_VERSION} -y -q > /dev/null
           conda activate python${PYTHON_VERSION}
 
@@ -468,6 +470,7 @@ jobs:
           git config pull.rebase false
           pip install colorlog>=6.10.1
           git fetch --all
+          python -m pip install s
           fleet_branch=release/$(git for-each-ref --format="%(refname:short)" "refs/remotes/origin/release/*" | awk -F/ "{print \$NF}" | sort -V | tail -1)
           git checkout ${fleet_branch}
           fleet_ops_wheel=paddlefleet_ops-0.0.0-cp${PYTHON_VERSION//./}-cp${PYTHON_VERSION//./}-linux_x86_64.whl
@@ -501,6 +504,7 @@ jobs:
           git config user.email "paddle_ci@example.com"
           git config pull.rebase false
           git fetch --all
+          python -m pip install s
           formers_branch=release/$(git for-each-ref --format="%(refname:short)" "refs/remotes/origin/release/*" | awk -F/ "{print \$NF}" | grep -E "^[0-9]+\.[0-9]+$" | sort -V | tail -1)
           git checkout ${formers_branch}
           git log -1
@@ -694,9 +698,9 @@ jobs:
           pip cache dir
           pip install --upgrade pip
           wget -q https://paddle-qa.bj.bcebos.com/paddlefleet/whl/Miniforge3-Linux-x86_64.sh -O miniconda.sh
-          bash miniconda.sh -b -p $HOME/miniconda -u > /dev/null
+          bash miniconda.sh -b -p $HOME/miniconda > /dev/null
           source "$HOME/miniconda/etc/profile.d/conda.sh"
-          conda init bash
+          conda init bash > /dev/null
           conda create -n python${PYTHON_VERSION} python=${PYTHON_VERSION} -y -q > /dev/null
           conda activate python${PYTHON_VERSION}
 
@@ -707,6 +711,7 @@ jobs:
           git config user.email "paddle_ci@example.com"
           git config pull.rebase false
           git fetch --all
+          python -m pip install s
           fleet_branch=release/$(git for-each-ref --format="%(refname:short)" "refs/remotes/origin/release/*" | awk -F/ "{print \$NF}" | sort -V | tail -1)
           git checkout ${fleet_branch}
           pip install colorlog>=6.10.1
@@ -743,6 +748,7 @@ jobs:
           git config user.email "paddle_ci@example.com"
           git config pull.rebase false
           git fetch --all
+          python -m pip install s
           formers_branch=release/$(git for-each-ref --format="%(refname:short)" "refs/remotes/origin/release/*" | awk -F/ "{print \$NF}" | grep -E "^[0-9]+\.[0-9]+$" | sort -V | tail -1)
           git checkout ${formers_branch}
           git log -1
@@ -1153,9 +1159,9 @@ jobs:
           pip cache dir
           pip install --upgrade pip
           wget -q https://paddle-qa.bj.bcebos.com/paddlefleet/whl/Miniforge3-Linux-x86_64.sh -O miniconda.sh
-          bash miniconda.sh -b -p $HOME/miniconda -u > /dev/null
-          source "$HOME/miniconda/etc/profile.d/conda.sh"
-          conda init bash
+          bash miniconda.sh -b -p $HOME/miniconda > /dev/null
+          source "$HOME/miniconda/etc/profile.d/conda.sh" 
+          conda init bash > /dev/null
           conda create -n python${PYTHON_VERSION} python=${PYTHON_VERSION} -y -q > /dev/null
           conda activate python${PYTHON_VERSION}
 
@@ -1166,13 +1172,13 @@ jobs:
           git config user.email "paddle_ci@example.com"
           git config pull.rebase false
           git fetch --all
+          python -m pip install s
           fleet_branch=release/$(git for-each-ref --format="%(refname:short)" "refs/remotes/origin/release/*" | awk -F/ "{print \$NF}" | sort -V | tail -1)
           git checkout ${fleet_branch}
 
           fleet_ops_wheel=paddlefleet_ops-0.0.0-cp${PYTHON_VERSION//./}-cp${PYTHON_VERSION//./}-linux_x86_64.whl
           wget -q "https://paddle-github-action.cdn.bcebos.com/PaddleFleet/${fleet_branch}/latest/${CUDA_VERSION}/paddle-release/${fleet_ops_wheel}" -O ${fleet_ops_wheel}
           pip install ${fleet_ops_wheel} --extra-index-url=https://www.paddlepaddle.org.cn/packages/nightly/${CUDA_VERSION}/  --extra-index-url https://www.paddlepaddle.org.cn/packages/stable/${CUDA_VERSION}/ --extra-index-url https://pypi.tuna.tsinghua.edu.cn/simple
-
           pip install -e . --no-build-isolation --index-url https://www.paddlepaddle.org.cn/packages/nightly/${CUDA_VERSION}/ --extra-index-url https://www.paddlepaddle.org.cn/packages/stable/${CUDA_VERSION}/ --extra-index-url https://pypi.tuna.tsinghua.edu.cn/simple
           pip install colorlog>=6.10.1
           wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/local/bin/yq
@@ -1201,6 +1207,7 @@ jobs:
           git config user.email "paddle_ci@example.com"
           git config pull.rebase false
           git fetch --all
+          python -m pip install s
           formers_branch=release/$(git for-each-ref --format="%(refname:short)" "refs/remotes/origin/release/*" | awk -F/ "{print \$NF}" | grep -E "^[0-9]+\.[0-9]+$" | sort -V | tail -1)
           git checkout ${formers_branch}
           git log -1

--- a/.github/workflows/ce_daily_release.yml
+++ b/.github/workflows/ce_daily_release.yml
@@ -166,7 +166,7 @@ jobs:
           git config user.email "paddle_ci@example.com"
           git config pull.rebase false
           git fetch --all
-          python -m pip install s
+          python -m pip install setuptools
           fleet_branch=release/$(git for-each-ref --format="%(refname:short)" "refs/remotes/origin/release/*" | awk -F/ "{print \$NF}" | sort -V | tail -1)
           git checkout ${fleet_branch}
           pip install colorlog>=6.10.1
@@ -311,7 +311,7 @@ jobs:
           git config pull.rebase false
           git submodule update --init --recursive
           git fetch --all
-          python -m pip install s
+          python -m pip install setuptools
           fleet_branch=release/$(git for-each-ref --format="%(refname:short)" "refs/remotes/origin/release/*" | awk -F/ "{print \$NF}" | sort -V | tail -1)
           git checkout ${fleet_branch}
           pip install colorlog>=6.10.1
@@ -470,7 +470,7 @@ jobs:
           git config pull.rebase false
           pip install colorlog>=6.10.1
           git fetch --all
-          python -m pip install s
+          python -m pip install setuptools
           fleet_branch=release/$(git for-each-ref --format="%(refname:short)" "refs/remotes/origin/release/*" | awk -F/ "{print \$NF}" | sort -V | tail -1)
           git checkout ${fleet_branch}
           fleet_ops_wheel=paddlefleet_ops-0.0.0-cp${PYTHON_VERSION//./}-cp${PYTHON_VERSION//./}-linux_x86_64.whl
@@ -504,7 +504,7 @@ jobs:
           git config user.email "paddle_ci@example.com"
           git config pull.rebase false
           git fetch --all
-          python -m pip install s
+          python -m pip install setuptools
           formers_branch=release/$(git for-each-ref --format="%(refname:short)" "refs/remotes/origin/release/*" | awk -F/ "{print \$NF}" | grep -E "^[0-9]+\.[0-9]+$" | sort -V | tail -1)
           git checkout ${formers_branch}
           git log -1
@@ -711,7 +711,7 @@ jobs:
           git config user.email "paddle_ci@example.com"
           git config pull.rebase false
           git fetch --all
-          python -m pip install s
+          python -m pip install setuptools
           fleet_branch=release/$(git for-each-ref --format="%(refname:short)" "refs/remotes/origin/release/*" | awk -F/ "{print \$NF}" | sort -V | tail -1)
           git checkout ${fleet_branch}
           pip install colorlog>=6.10.1
@@ -748,7 +748,7 @@ jobs:
           git config user.email "paddle_ci@example.com"
           git config pull.rebase false
           git fetch --all
-          python -m pip install s
+          python -m pip install setuptools
           formers_branch=release/$(git for-each-ref --format="%(refname:short)" "refs/remotes/origin/release/*" | awk -F/ "{print \$NF}" | grep -E "^[0-9]+\.[0-9]+$" | sort -V | tail -1)
           git checkout ${formers_branch}
           git log -1
@@ -1172,7 +1172,7 @@ jobs:
           git config user.email "paddle_ci@example.com"
           git config pull.rebase false
           git fetch --all
-          python -m pip install s
+          python -m pip install setuptools
           fleet_branch=release/$(git for-each-ref --format="%(refname:short)" "refs/remotes/origin/release/*" | awk -F/ "{print \$NF}" | sort -V | tail -1)
           git checkout ${fleet_branch}
 
@@ -1207,7 +1207,7 @@ jobs:
           git config user.email "paddle_ci@example.com"
           git config pull.rebase false
           git fetch --all
-          python -m pip install s
+          python -m pip install setuptools
           formers_branch=release/$(git for-each-ref --format="%(refname:short)" "refs/remotes/origin/release/*" | awk -F/ "{print \$NF}" | grep -E "^[0-9]+\.[0-9]+$" | sort -V | tail -1)
           git checkout ${formers_branch}
           git log -1


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Bug fixes

### Description
Replace the unavailable Miniconda mirror used by CE Daily Dev and CE Daily Release with a runner-accessible source. Keep CE Daily Release limited to scheduled and manual runs because it checks out the latest release branch rather than the PR head.

### 是否引起精度变化
否