### PR TITLE
update cudnn-frontend to v1.27.0

### DIFF
--- a/packages/paddlefleet_ops/setup.py
+++ b/packages/paddlefleet_ops/setup.py
@@ -38,7 +38,7 @@ def get_special_setup_deps():
         deps = [
             "triton",  # for deep_gemm, flashmask
             "einops",  # for flash-linear-attention
-            "nvidia-cutlass-dsl[cu13]==4.4.1",  # for sonic_moe and flash_attention
+            "nvidia-cutlass-dsl[cu13]==4.5.0",  # for sonic_moe and flash_attention
             "filelock",  # for sonic_moe
             "apache-tvm-ffi>=0.1.3,<0.1.12",  # for supersonic_moe
         ]


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
升级cudnn-frontend到1.27.0，官方nvidia-cudnn-frontend需要nvidia-cutlass-dsl 4.5.0，paddlefleet之前的submodule sonic-moe、flsh_attention、cudnn-frontend 1.26都是依赖的4.4.1，导致不兼容，故此PR顺带升级nvidia-cutlass-dsl 到4.5.0

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
