### PR TITLE
[Bug fixes] Fix Qwen3.5 vision and Gated DeltaNet compatibility

### DIFF
--- a/src/paddlefleet/models/qwen3_5/layer_specs.py
+++ b/src/paddlefleet/models/qwen3_5/layer_specs.py
@@ -95,8 +95,15 @@ def get_qwen3_5_vision_spec(config: TransformerConfig) -> LayerSpec:
     merger_spec = LayerSpec(
         layer=Qwen3VLVisionPathMerger,
         sublayers_spec=Qwen3VLVisionPatchMergerSpec(
-            norm=backend.layer_norm(
-                rms_norm=(config.normalization == "RMSNorm"), for_qk=False
+            # The reference merger hardcodes ``nn.LayerNorm(..., eps=1e-6)``
+            # instead of reusing the model-wide norm epsilon, so pass it
+            # explicitly rather than falling back to ``WrappedPaddleNorm``'s
+            # 1e-5 default.
+            norm=LayerSpec(
+                layer=backend.layer_norm(
+                    rms_norm=(config.normalization == "RMSNorm"), for_qk=False
+                ),
+                extra_kwargs={"eps": 1e-6},
             ),
         ),
         extra_kwargs={

--- a/src/paddlefleet/transformer/gated_delta_net.py
+++ b/src/paddlefleet/transformer/gated_delta_net.py
@@ -192,18 +192,28 @@ class GatedDeltaNet(FleetLayer):
         # Time step projection (discretization)
         self.num_v_heads_local_tp = self.num_value_heads // self.tp_size
 
-        # dt_bias parameter — fp32 for numerical stability in softplus
+        # The reference implementation declares ``dt_bias``/``A_log`` as plain
+        # parameters, so they live in the model dtype (BF16) and are promoted to
+        # FP32 only at the softplus/exp computation boundary below. Creating FP32
+        # leaves instead changes the parameter, gradient and optimizer-state
+        # dtype relative to the official checkpoint, so honor the declared dtype
+        # in accuracy-compatible mode. The default path keeps the FP32 leaves.
+        state_param_dtype = (
+            config.params_dtype
+            if getattr(config, "use_accuracy_compatible", False)
+            else "float32"
+        )
+
         self.dt_bias = self.create_parameter(
             shape=[self.num_v_heads_local_tp],
-            dtype="float32",
+            dtype=state_param_dtype,
             default_initializer=nn.initializer.Constant(1.0),
         )
         self.dt_bias.is_distributed = True if self.tp_size > 1 else False
 
-        # A_log parameter — fp32 to avoid exp() overflow in bf16
         self.A_log = self.create_parameter(
             shape=[self.num_v_heads_local_tp],
-            dtype="float32",
+            dtype=state_param_dtype,
             default_initializer=nn.initializer.Constant(0.0),
         )
         self.A_log.is_distributed = True if self.tp_size > 1 else False
@@ -258,7 +268,7 @@ class GatedDeltaNet(FleetLayer):
             nn.initializer.Uniform(
                 low=self.A_init_range[0], high=self.A_init_range[1]
             )(A)
-            paddle.assign(paddle.log(A), self.A_log)
+            paddle.assign(paddle.log(A).astype(self.A_log.dtype), self.A_log)
 
     def _build_padding_mask(
         self,
@@ -270,32 +280,56 @@ class GatedDeltaNet(FleetLayer):
         """Derive a padding mask (1.0=valid, 0.0=padding) for GDN."""
         is_sp = self.config.sequence_parallel and self.sp_size > 1
 
-        if attention_mask is not None and attention_mask.ndim == 2:
-            full_seq = attention_mask.shape[-1]
-            if is_sp:
-                if full_seq != seq_len:
-                    # Shape mismatch under SP – fall through to startend indices.
+        if attention_mask is not None:
+            if attention_mask.ndim == 4:
+                if attention_mask.shape[-2:] != [seq_len, seq_len]:
+                    # Shape mismatch – fall through to startend indices.
                     pass
                 else:
-                    # attention_mask is [b, full_s], slice to local chunk
-                    seq_len_local = seq_len // self.sp_size
-                    tp_rank = get_pg_rank(self.pg_collection.tp)
-                    offset = tp_rank * seq_len_local
-                    local_mask = attention_mask[
-                        :, offset : offset + seq_len_local
-                    ]
-                    if local_mask.astype("bool").all():
-                        return None
-                    return local_mask.astype(paddle.float32).T.unsqueeze(-1)
-            else:
-                if full_seq == seq_len:
-                    mask = attention_mask.unsqueeze(-1).astype(paddle.float32)
-                    if mask.all():
-                        return None
-                    return mask
-                # full_seq != seq_len: attention_mask shape does not match the
-                # current sequence length (e.g. stale mask from a previous stage).
-                # Fall through to try attn_mask_startend_row_indices instead.
+                    # The multimodal collator provides a block-causal
+                    # ``[b, 1, s, s]`` mask, but GDN is a recurrence and only
+                    # needs per-token validity. A token is valid iff its own
+                    # causal diagonal entry is enabled; padding rows have a zero
+                    # diagonal. Reduce to ``[b, s]`` and reuse the 2D/SP logic
+                    # below instead of rejecting the mask. ``paddle.diagonal``
+                    # returns a strided view, so materialize it — reductions
+                    # over a non-contiguous float buffer read the wrong memory.
+                    attention_mask = paddle.diagonal(
+                        attention_mask[:, 0, :, :], axis1=-2, axis2=-1
+                    ).contiguous()
+
+            if attention_mask.ndim == 2:
+                full_seq = attention_mask.shape[-1]
+                if is_sp:
+                    if full_seq != seq_len:
+                        # Shape mismatch under SP – fall through to startend indices.
+                        pass
+                    else:
+                        # attention_mask is [b, full_s], slice to local chunk
+                        seq_len_local = seq_len // self.sp_size
+                        tp_rank = get_pg_rank(self.pg_collection.tp)
+                        offset = tp_rank * seq_len_local
+                        local_mask = attention_mask[
+                            :, offset : offset + seq_len_local
+                        ]
+                        if local_mask.astype("bool").all():
+                            return None
+                        return local_mask.astype(paddle.float32).T.unsqueeze(-1)
+                else:
+                    if full_seq == seq_len:
+                        mask = attention_mask.unsqueeze(-1).astype(
+                            paddle.float32
+                        )
+                        # Reduce through bool like the SP branch above: ``all()``
+                        # on a float tensor is not reliable, so a float mask of
+                        # all-ones would otherwise fail this check and skip the
+                        # ``None`` fast path.
+                        if mask.astype("bool").all():
+                            return None
+                        return mask
+                    # full_seq != seq_len: attention_mask shape does not match the
+                    # current sequence length (e.g. stale mask from a previous stage).
+                    # Fall through to try attn_mask_startend_row_indices instead.
 
         if attn_mask_startend_row_indices is not None:
             indices = attn_mask_startend_row_indices[:, 0, :, 0]

--- a/src/paddlefleet/transformer/mlp.py
+++ b/src/paddlefleet/transformer/mlp.py
@@ -156,8 +156,16 @@ class MLP(FleetLayer):
             disable_fp8=disable_fp8,
         )
 
-        # Ensure hidden_act is a callable function, not a bound method
-        hidden_act_value = self.config.hidden_act
+        # Ensure hidden_act is a callable function, not a bound method.
+        # A spec-level ``hidden_act`` wins over ``config.hidden_act``: modules
+        # such as the Qwen3-VL / Qwen3.5 patch merger and the Kimi-K2.5 tpool
+        # merge declare their own activation in ``MLPSublayersSpec`` because it
+        # differs from the model-wide ``config.hidden_act``.
+        hidden_act_value = (
+            sublayers_spec.hidden_act
+            if sublayers_spec.hidden_act is not None
+            else self.config.hidden_act
+        )
         if hasattr(hidden_act_value, "__self__") and hasattr(
             hidden_act_value, "__func__"
         ):

--- a/tests/single_card_tests/model/test_gdn_param_dtype.py
+++ b/tests/single_card_tests/model/test_gdn_param_dtype.py
@@ -1,0 +1,229 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``GatedDeltaNet`` state-parameter dtype (``A_log`` / ``dt_bias``).
+
+The reference implementation declares both as plain parameters, so the official
+checkpoint stores them in the model dtype and they are promoted to FP32 only at
+the ``softplus`` / ``exp`` boundary. Creating FP32 leaves instead changes the
+parameter, gradient and optimizer-state dtype relative to that checkpoint, so
+``use_accuracy_compatible`` honors ``params_dtype`` while the default path keeps
+the historical FP32 leaves.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+import paddle
+import paddle.nn.functional as F
+from paddle import nn
+
+from paddlefleet.transformer.gated_delta_net import (
+    GatedDeltaNet,
+    GatedDeltaNetSublayersSpec,
+)
+from paddlefleet.transformer.transformer_config import TransformerConfig
+
+H, B, S = 64, 2, 16
+A_INIT_RANGE = (1, 16)
+
+
+class NoBiasLinear(nn.Layer):
+    def __init__(self, in_features, out_features, **kwargs):
+        super().__init__()
+        self.linear = nn.Linear(in_features, out_features, bias_attr=False)
+
+    def forward(self, x):
+        return self.linear(x), None
+
+    def backward_dw(self):
+        pass
+
+
+class SimpleRMSNorm(nn.Layer):
+    def __init__(self, normalized_shape, eps=1e-5, **kwargs):
+        super().__init__()
+        self.weight = self.create_parameter(
+            shape=[normalized_shape],
+            default_initializer=nn.initializer.Constant(1.0),
+        )
+        self.eps = eps
+
+    def forward(self, x):
+        x_float = x.astype(paddle.float32)
+        rms = paddle.rsqrt(
+            x_float.pow(2).mean(axis=-1, keepdim=True) + self.eps
+        )
+        return (x_float * rms * self.weight.astype(paddle.float32)).astype(
+            x.dtype
+        )
+
+
+class _FakeGroup:
+    ranks = [0]
+    nranks = 1
+    rank = 0
+
+
+class _FakePGCollection:
+    def __init__(self):
+        self.tp = _FakeGroup()
+
+
+def _make_gdn(*, use_accuracy_compatible=False, params_dtype=None):
+    kwargs = {}
+    if params_dtype is not None:
+        kwargs["params_dtype"] = params_dtype
+    config = TransformerConfig(
+        hidden_size=H,
+        num_attention_heads=4,
+        num_hidden_layers=2,
+        hidden_act=F.silu,
+        rms_norm_eps=1e-5,
+        normalization="RMSNorm",
+        deterministic_mode=True,
+        use_accuracy_compatible=use_accuracy_compatible,
+        **kwargs,
+    )
+    spec = GatedDeltaNetSublayersSpec(
+        in_proj=NoBiasLinear,
+        out_norm=SimpleRMSNorm,
+        out_proj=NoBiasLinear,
+    )
+    return GatedDeltaNet(
+        config=config,
+        sublayers_spec=spec,
+        layer_number=1,
+        bias=False,
+        conv_bias=False,
+        conv_init=1.0,
+        use_qk_l2norm=True,
+        A_init_range=A_INIT_RANGE,
+        pg_collection=_FakePGCollection(),
+        conv_kernel_dim=4,
+        key_head_dim=16,
+        value_head_dim=16,
+        num_key_heads=4,
+        num_value_heads=4,
+    )
+
+
+class TestStateParamDtypeDefault(unittest.TestCase):
+    """Default path: FP32 leaves regardless of ``params_dtype``."""
+
+    def test_fp32_config_gives_fp32_leaves(self):
+        gdn = _make_gdn()
+        self.assertEqual(gdn.A_log.dtype, paddle.float32)
+        self.assertEqual(gdn.dt_bias.dtype, paddle.float32)
+
+    def test_bf16_config_still_gives_fp32_leaves(self):
+        gdn = _make_gdn(params_dtype="bfloat16")
+        self.assertEqual(gdn.A_log.dtype, paddle.float32)
+        self.assertEqual(gdn.dt_bias.dtype, paddle.float32)
+
+    def test_accuracy_flag_alone_follows_fp32_default_params_dtype(self):
+        """``use_accuracy_compatible`` selects ``params_dtype``, which is FP32
+        by default — so the flag on its own must not change anything."""
+        gdn = _make_gdn(use_accuracy_compatible=True)
+        self.assertEqual(gdn.A_log.dtype, paddle.float32)
+        self.assertEqual(gdn.dt_bias.dtype, paddle.float32)
+
+
+class TestStateParamDtypeAccuracyCompatible(unittest.TestCase):
+    """``use_accuracy_compatible`` + BF16 ``params_dtype`` gives BF16 leaves."""
+
+    def setUp(self):
+        self.gdn = _make_gdn(
+            use_accuracy_compatible=True, params_dtype="bfloat16"
+        )
+
+    def test_leaves_are_bf16(self):
+        self.assertEqual(self.gdn.A_log.dtype, paddle.bfloat16)
+        self.assertEqual(self.gdn.dt_bias.dtype, paddle.bfloat16)
+
+    def test_dt_bias_initialized_to_ones(self):
+        np.testing.assert_allclose(
+            self.gdn.dt_bias.astype("float32").numpy(),
+            np.ones(self.gdn.num_v_heads_local_tp),
+        )
+
+    def test_a_log_init_assigned_in_leaf_dtype(self):
+        """``paddle.log(A)`` is FP32; without the cast the assign would either
+        fail or silently widen the leaf back to FP32."""
+        a_log = self.gdn.A_log.astype("float32").numpy()
+        self.assertTrue(np.isfinite(a_log).all())
+        lo, hi = np.log(A_INIT_RANGE[0]), np.log(A_INIT_RANGE[1])
+        # BF16 has ~3 decimal digits, so allow a rounding margin on the bounds.
+        self.assertTrue((a_log >= lo - 1e-2).all())
+        self.assertTrue((a_log <= hi + 1e-2).all())
+        self.assertEqual(self.gdn.A_log.dtype, paddle.bfloat16)
+
+    def test_a_log_values_are_bf16_rounded(self):
+        """The leaf really is stored at BF16 precision, not FP32 in disguise."""
+        a_log = self.gdn.A_log.astype("float32")
+        round_tripped = a_log.astype("bfloat16").astype("float32")
+        np.testing.assert_array_equal(a_log.numpy(), round_tripped.numpy())
+
+    def test_gradients_are_bf16(self):
+        x = paddle.randn([B, S, H])
+        x.stop_gradient = False
+        out, _ = self.gdn(x, attention_mask=None)
+        out.sum().backward()
+        for name, param in (
+            ("A_log", self.gdn.A_log),
+            ("dt_bias", self.gdn.dt_bias),
+        ):
+            self.assertIsNotNone(param.grad, f"{name} received no gradient")
+            self.assertEqual(param.grad.dtype, paddle.bfloat16, name)
+
+    def test_forward_promotes_at_the_computation_boundary(self):
+        """BF16 leaves must not produce inf/nan: ``A_log`` is exponentiated and
+        ``dt_bias`` goes through ``softplus``, both in FP32."""
+        x = paddle.randn([B, S, H])
+        out, _ = self.gdn(x, attention_mask=None)
+        self.assertTrue(paddle.isfinite(out.astype("float32")).all().item())
+
+    def test_reset_parameters_is_idempotent_in_bf16(self):
+        before = self.gdn.A_log.astype("float32").numpy().copy()
+        self.gdn.reset_parameters()
+        after = self.gdn.A_log.astype("float32").numpy()
+        self.assertEqual(self.gdn.A_log.dtype, paddle.bfloat16)
+        # Re-initialization redraws from the same uniform range.
+        self.assertTrue(np.isfinite(after).all())
+        self.assertEqual(before.shape, after.shape)
+
+
+class TestStateParamDtypeParity(unittest.TestCase):
+    def test_both_modes_build_and_run(self):
+        """Whichever leaf dtype is selected, the layer stays trainable."""
+        for kwargs in (
+            {},
+            {"use_accuracy_compatible": True, "params_dtype": "bfloat16"},
+        ):
+            with self.subTest(**kwargs):
+                gdn = _make_gdn(**kwargs)
+                x = paddle.randn([B, S, H])
+                x.stop_gradient = False
+                out, _ = gdn(x, attention_mask=None)
+                out.sum().backward()
+                self.assertEqual(list(out.shape), [B, S, H])
+                self.assertTrue(
+                    paddle.isfinite(x.grad.astype("float32")).all().item()
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/model/test_mlp_spec_hidden_act.py
+++ b/tests/single_card_tests/model/test_mlp_spec_hidden_act.py
@@ -1,0 +1,191 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``MLPSublayersSpec.hidden_act`` must win over ``config.hidden_act``.
+
+Modules such as the Qwen3-VL / Qwen3.5 patch merger and the Kimi-K2.5 tpool
+merge declare their own activation in the spec precisely because it differs from
+the model-wide ``config.hidden_act``. That declaration used to be dropped on the
+floor, so the merger silently ran the text model's activation.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import unittest
+
+import paddle
+import paddle.nn.functional as F
+
+from paddlefleet.models.gpt.gpt_layer_specs import get_gpt_layer_local_spec
+from paddlefleet.transformer.mlp import MLP, MLPSublayersSpec
+from paddlefleet.transformer.transformer_config import TransformerConfig
+
+S, BATCH, HIDDEN = 8, 4, 12
+
+
+def _make_config(**overrides):
+    kwargs = {
+        "num_hidden_layers": 2,
+        "hidden_size": HIDDEN,
+        "intermediate_size": 48,
+        "num_attention_heads": 4,
+        # Keep the plain activation path: the fused branches only accept
+        # gelu/swiglu and would mask which activation object is in play.
+        "gated_linear_unit": False,
+        "bias_activation_fusion": False,
+        "use_bias": False,
+    }
+    kwargs.update(overrides)
+    return TransformerConfig(**kwargs)
+
+
+def _base_spec(config) -> MLPSublayersSpec:
+    return get_gpt_layer_local_spec(config).sublayers_spec.mlp.sublayers_spec
+
+
+def _make_mlp(config, hidden_act="unset"):
+    spec = _base_spec(config)
+    if hidden_act != "unset":
+        spec = dataclasses.replace(spec, hidden_act=hidden_act)
+    return MLP(config, spec)
+
+
+class _ActivationOwner:
+    """Provides a *bound method* activation, which must be unwrapped."""
+
+    def act(self, x):
+        return F.gelu(x)
+
+
+class TestSpecHiddenActPrecedence(unittest.TestCase):
+    def test_spec_none_falls_back_to_config(self):
+        config = _make_config(hidden_act=F.silu)
+        mlp = _make_mlp(config, hidden_act=None)
+        self.assertIs(mlp.hidden_act, F.silu)
+
+    def test_spec_absent_falls_back_to_config(self):
+        """``MLPSublayersSpec.hidden_act`` defaults to ``None``."""
+        config = _make_config(hidden_act=F.silu)
+        self.assertIsNone(_base_spec(config).hidden_act)
+        self.assertIs(_make_mlp(config).hidden_act, F.silu)
+
+    def test_spec_overrides_config(self):
+        config = _make_config(hidden_act=F.silu)
+        mlp = _make_mlp(config, hidden_act=F.gelu)
+        self.assertIs(mlp.hidden_act, F.gelu)
+        self.assertIs(config.hidden_act, F.silu)
+
+    def test_spec_bound_method_is_unwrapped(self):
+        config = _make_config(hidden_act=F.silu)
+        owner = _ActivationOwner()
+        mlp = _make_mlp(config, hidden_act=owner.act)
+        self.assertIs(mlp.hidden_act, _ActivationOwner.act)
+        self.assertFalse(hasattr(mlp.hidden_act, "__self__"))
+
+    def test_config_bound_method_still_unwrapped(self):
+        """The pre-existing unwrap must keep applying to the fallback value."""
+        config = _make_config()
+        config.hidden_act = _ActivationOwner().act
+        mlp = _make_mlp(config, hidden_act=None)
+        self.assertIs(mlp.hidden_act, _ActivationOwner.act)
+
+
+class TestSpecHiddenActForward(unittest.TestCase):
+    """The spec activation must be the one actually applied in ``forward``."""
+
+    def _run(self, mlp):
+        x = paddle.ones((S, BATCH, HIDDEN))
+        out, _ = mlp(x)
+        return out
+
+    def test_forward_uses_spec_activation(self):
+        calls = []
+
+        def tracking_act(x):
+            calls.append(x.shape)
+            return F.gelu(x)
+
+        config = _make_config(hidden_act=F.silu)
+        self._run(_make_mlp(config, hidden_act=tracking_act))
+        self.assertEqual(len(calls), 1, "spec activation was not invoked")
+
+    def test_forward_does_not_use_config_activation_when_spec_set(self):
+        calls = []
+
+        def tracking_config_act(x):
+            calls.append(x.shape)
+            return F.silu(x)
+
+        config = _make_config()
+        config.hidden_act = tracking_config_act
+        self._run(_make_mlp(config, hidden_act=F.gelu))
+        self.assertEqual(calls, [], "config activation leaked into forward")
+
+    def test_spec_activation_changes_the_numbers(self):
+        """Same weights, different declared activation → different output."""
+        config = _make_config(hidden_act=F.silu)
+        silu_mlp = _make_mlp(config, hidden_act=None)
+        gelu_mlp = _make_mlp(config, hidden_act=F.gelu)
+        gelu_mlp.set_state_dict(silu_mlp.state_dict())
+
+        silu_out = self._run(silu_mlp)
+        gelu_out = self._run(gelu_mlp)
+        self.assertFalse(
+            paddle.allclose(silu_out, gelu_out, atol=1e-6).item(),
+            "spec activation had no effect on the output",
+        )
+
+    def test_spec_gelu_matches_config_gelu(self):
+        """Declaring gelu in the spec == declaring it on the config."""
+        via_config = _make_mlp(_make_config(hidden_act=F.gelu), hidden_act=None)
+        via_spec = _make_mlp(_make_config(hidden_act=F.silu), hidden_act=F.gelu)
+        via_spec.set_state_dict(via_config.state_dict())
+        self.assertTrue(
+            paddle.allclose(
+                self._run(via_config), self._run(via_spec), atol=1e-6
+            ).item()
+        )
+
+
+class TestGatedPathKnownGap(unittest.TestCase):
+    """Documents that the GLU branch still reads ``config.hidden_act``.
+
+    ``MLP.forward``'s inner ``glu()`` closure calls
+    ``self.config.hidden_act(x_glu)`` rather than ``self.hidden_act``, so a
+    spec-level activation is ignored when ``gated_linear_unit=True``. No current
+    caller hits that combination — the patch merger and the tpool merge are both
+    non-GLU — so this is left as-is rather than silently changing GLU models. If
+    that call is ever switched to ``self.hidden_act``, this test should fail and
+    be deleted.
+    """
+
+    def test_glu_branch_ignores_spec_activation(self):
+        calls = []
+
+        def tracking_act(x):
+            calls.append(x.shape)
+            return F.gelu(x)
+
+        config = _make_config(gated_linear_unit=True, hidden_act=F.silu)
+        mlp = _make_mlp(config, hidden_act=tracking_act)
+        # The constructor honors the spec ...
+        self.assertIs(mlp.hidden_act, tracking_act)
+        mlp(paddle.ones((S, BATCH, HIDDEN)))
+        # ... but the GLU closure does not consult it.
+        self.assertEqual(calls, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/model/test_qwen35_merger_eps.py
+++ b/tests/single_card_tests/model/test_qwen35_merger_eps.py
@@ -1,0 +1,182 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The Qwen3.5 patch merger's ``LayerNorm`` epsilon is pinned to 1e-6.
+
+The reference merger hardcodes ``nn.LayerNorm(..., eps=1e-6)``. The merger spec
+used to pass no ``eps`` at all, so it silently inherited
+``WrappedPaddleNorm``'s ``eps=1e-5`` default — the model-wide ``rms_norm_eps``
+was not consulted either, so declaring it on the config did not help.
+"""
+
+from __future__ import annotations
+
+import unittest
+from dataclasses import dataclass
+
+import paddle
+import paddle.nn.functional as F
+from paddle.distributed.fleet.meta_parallel import LayerSpec, build_spec_layer
+
+from paddlefleet.models.qwen3_5.layer_specs import get_qwen3_5_vision_spec
+from paddlefleet.models.qwen3_vl.patch_merger import Qwen3VLVisionPathMerger
+from paddlefleet.transformer.transformer_config import TransformerConfig
+
+MERGER_EPS = 1e-6
+WRAPPED_NORM_DEFAULT_EPS = 1e-5
+
+
+@dataclass
+class _VisionConfig(TransformerConfig):
+    """Trimmed-down stand-in for ``Qwen3_5VisionProvider``."""
+
+    patch_size: int = 16
+    use_bias: bool = True
+    add_qkv_bias: bool = True
+    num_position_embeddings: int = 64
+    hidden_size: int = 32
+    out_hidden_size: int = 64
+    in_channels: int = 3
+    spatial_merge_size: int = 2
+    spatial_patch_size: int = 16
+    temporal_patch_size: int = 2
+    intermediate_size: int = 64
+    num_attention_heads: int = 4
+    num_hidden_layers: int = 2
+    gated_linear_unit: bool = False
+    bias_activation_fusion: bool = False
+    normalization: str = "LayerNorm"
+    rms_norm_eps: float = 1e-6
+    model_version: str = "qwen3_5"
+
+
+def _make_config(**overrides):
+    config = _VisionConfig(**overrides)
+    config.hidden_act = F.gelu
+    return config
+
+
+def _merger_spec(config) -> LayerSpec:
+    return get_qwen3_5_vision_spec(config).sublayers_spec.merger
+
+
+def _build_merger(config):
+    return build_spec_layer(_merger_spec(config))
+
+
+class TestMergerNormSpec(unittest.TestCase):
+    """The epsilon is carried explicitly on the spec, not left to a default."""
+
+    def test_norm_is_a_layerspec_with_explicit_eps(self):
+        norm_spec = _merger_spec(_make_config()).sublayers_spec.norm
+        self.assertIsInstance(
+            norm_spec,
+            LayerSpec,
+            "the merger norm must be a LayerSpec so eps can be attached",
+        )
+        self.assertEqual(norm_spec.extra_kwargs.get("eps"), MERGER_EPS)
+
+    def test_eps_is_not_the_wrapped_norm_default(self):
+        norm_spec = _merger_spec(_make_config()).sublayers_spec.norm
+        self.assertNotEqual(
+            norm_spec.extra_kwargs["eps"], WRAPPED_NORM_DEFAULT_EPS
+        )
+
+
+class TestMergerNormBuilt(unittest.TestCase):
+    """The built layer really uses 1e-6."""
+
+    def test_built_norm_eps(self):
+        merger = _build_merger(_make_config())
+        self.assertIsInstance(merger, Qwen3VLVisionPathMerger)
+        self.assertAlmostEqual(
+            float(merger.norm.variance_epsilon), MERGER_EPS, places=12
+        )
+
+    def test_eps_does_not_track_rms_norm_eps(self):
+        """A different model-wide epsilon must not move the merger's."""
+        for rms_norm_eps in (1e-5, 1e-4, 1e-8):
+            with self.subTest(rms_norm_eps=rms_norm_eps):
+                merger = _build_merger(_make_config(rms_norm_eps=rms_norm_eps))
+                self.assertAlmostEqual(
+                    float(merger.norm.variance_epsilon), MERGER_EPS, places=12
+                )
+
+    def test_norm_is_layernorm_not_rmsnorm(self):
+        """Qwen3.5's vision tower normalizes with LayerNorm."""
+        merger = _build_merger(_make_config())
+        self.assertTrue(hasattr(merger.norm, "bias"))
+
+    def test_rmsnorm_config_still_gets_the_same_eps(self):
+        """The ``rms_norm=`` switch selects the class; eps stays pinned."""
+        merger = _build_merger(_make_config(normalization="RMSNorm"))
+        self.assertAlmostEqual(
+            float(merger.norm.variance_epsilon), MERGER_EPS, places=12
+        )
+
+
+class TestMergerNormNumerics(unittest.TestCase):
+    def test_forward_matches_reference_layernorm_at_1e_6(self):
+        config = _make_config()
+        merger = _build_merger(config)
+        x = paddle.randn([16, config.hidden_size])
+
+        normed = merger.norm(x)
+        expected = F.layer_norm(
+            x,
+            normalized_shape=[config.hidden_size],
+            weight=merger.norm.weight,
+            bias=merger.norm.bias,
+            epsilon=MERGER_EPS,
+        )
+        self.assertTrue(paddle.allclose(normed, expected, atol=1e-6).item())
+
+    def test_forward_differs_from_1e_5_on_low_variance_input(self):
+        """1e-6 vs 1e-5 is observable when the variance is small."""
+        config = _make_config()
+        merger = _build_merger(config)
+        x = paddle.randn([16, config.hidden_size]) * 1e-3
+
+        normed = merger.norm(x)
+        at_1e_5 = F.layer_norm(
+            x,
+            normalized_shape=[config.hidden_size],
+            weight=merger.norm.weight,
+            bias=merger.norm.bias,
+            epsilon=WRAPPED_NORM_DEFAULT_EPS,
+        )
+        self.assertFalse(
+            paddle.allclose(normed, at_1e_5, atol=1e-4).item(),
+            "the merger epsilon is indistinguishable from the old default",
+        )
+
+
+class TestMergerActivation(unittest.TestCase):
+    """Cross-check: the merger MLP runs exact gelu, not ``config.hidden_act``.
+
+    ``Qwen3VLVisionPathMerger`` declares ``hidden_act=F.gelu`` in its
+    ``MLPSublayersSpec``; the reference merger uses exact GELU while the vision
+    config carries ``gelu_pytorch_tanh``.
+    """
+
+    def test_merger_mlp_uses_spec_gelu(self):
+        config = _make_config()
+        config.hidden_act = F.silu  # stand-in for a differing config activation
+        merger = _build_merger(config)
+        self.assertIs(merger.mlp.hidden_act, F.gelu)
+        self.assertIs(config.hidden_act, F.silu)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/transformer/test_gdn_padding_mask.py
+++ b/tests/single_card_tests/transformer/test_gdn_padding_mask.py
@@ -157,6 +157,43 @@ def _make_startend_indices(batch, seq_len, padding_start=None):
     return indices
 
 
+def _keep_vector(batch, seq_len, padding_start=None, sample=None):
+    """Build a [b, s] 0/1 keep mask. ``sample=None`` pads every sample."""
+    keep = paddle.ones([batch, seq_len], dtype="int64")
+    if padding_start is not None:
+        if sample is None:
+            keep[:, padding_start:] = 0
+        else:
+            keep[sample, padding_start:] = 0
+    return keep
+
+
+def _to_4d_causal(keep, dtype="float32"):
+    """Expand a [b, s] keep vector into the collator's [b, 1, s, s] mask.
+
+    Entry ``[i, j]`` is enabled iff ``j <= i`` and both tokens are real, so a
+    padding row has a zero diagonal — which is exactly the signal
+    ``_build_padding_mask`` reduces back to per-token validity.
+    """
+    batch, seq_len = keep.shape
+    causal = paddle.tril(paddle.ones([seq_len, seq_len], dtype="float32"))
+    keep_f = keep.astype("float32")
+    mask = causal.unsqueeze(0) * keep_f.unsqueeze(1) * keep_f.unsqueeze(2)
+    return mask.unsqueeze(1).astype(dtype)
+
+
+def _to_4d_block_diagonal(seq_len, doc_lens, dtype="float32"):
+    """Packed-sequence mask: causal within each document, blocked across."""
+    mask = paddle.zeros([seq_len, seq_len], dtype="float32")
+    start = 0
+    for length in doc_lens:
+        end = start + length
+        block = paddle.tril(paddle.ones([length, length], dtype="float32"))
+        mask[start:end, start:end] = block
+        start = end
+    return mask.unsqueeze(0).unsqueeze(0).astype(dtype)
+
+
 class TestBuildPaddingMaskNoSP(unittest.TestCase):
     """_build_padding_mask without sequence parallel."""
 
@@ -354,6 +391,190 @@ class TestForwardPaddingMask(unittest.TestCase):
         # Padding positions get zero gradient
         np.testing.assert_array_equal(x.grad[0, -8:].numpy(), np.zeros([8, H]))
         # Valid positions get non-zero gradient
+        self.assertFalse(np.allclose(x.grad[0, :24].numpy(), 0))
+
+
+class TestBuildPaddingMask4D(unittest.TestCase):
+    """4D ``[b, 1, s, s]`` masks, which the multimodal collator emits.
+
+    GDN is a recurrence and only needs per-token validity, so the block-causal
+    matrix is reduced to its diagonal. Before that reduction existed a 4D mask
+    fell through to ``attn_mask_startend_row_indices`` and, when the VL collator
+    supplied no indices, raised outright.
+    """
+
+    def setUp(self):
+        self.gdn = _make_gdn()
+
+    def test_4d_all_valid_returns_none(self):
+        mask = _to_4d_causal(_keep_vector(B, S))
+        self.assertIsNone(self.gdn._build_padding_mask(mask, None, B, S))
+
+    def test_4d_with_padding_returns_mask(self):
+        mask = _to_4d_causal(_keep_vector(B, S, padding_start=24, sample=0))
+        result = self.gdn._build_padding_mask(mask, None, B, S)
+        self.assertEqual(list(result.shape), [B, S, 1])
+        np.testing.assert_array_equal(result[0, :24, 0].numpy(), np.ones(24))
+        np.testing.assert_array_equal(result[0, 24:, 0].numpy(), np.zeros(8))
+        np.testing.assert_array_equal(result[1, :, 0].numpy(), np.ones(S))
+
+    def test_4d_matches_equivalent_2d(self):
+        keep = _keep_vector(B, S, padding_start=20, sample=0)
+        from_2d = self.gdn._build_padding_mask(keep, None, B, S)
+        from_4d = self.gdn._build_padding_mask(_to_4d_causal(keep), None, B, S)
+        np.testing.assert_array_equal(from_4d.numpy(), from_2d.numpy())
+
+    def test_4d_bool_dtype(self):
+        keep = _keep_vector(B, S, padding_start=28, sample=1)
+        mask = _to_4d_causal(keep, dtype="bool")
+        result = self.gdn._build_padding_mask(mask, None, B, S)
+        np.testing.assert_array_equal(result[1, 28:, 0].numpy(), np.zeros(4))
+        np.testing.assert_array_equal(result[0, :, 0].numpy(), np.ones(S))
+
+    def test_4d_packed_block_diagonal_is_all_valid(self):
+        """Document isolation is not padding: every token's diagonal is set.
+
+        GDN takes document boundaries from ``attn_mask_startend_row_indices``,
+        so a packed block-diagonal mask must not be mistaken for padding.
+        """
+        mask = _to_4d_block_diagonal(S, [12, 20])
+        self.assertIsNone(self.gdn._build_padding_mask(mask, None, 1, S))
+
+    def test_4d_shape_mismatch_falls_through_to_startend(self):
+        wrong = _to_4d_causal(_keep_vector(B, S + 4))
+        indices = _make_startend_indices(B, S, padding_start=24)
+        result = self.gdn._build_padding_mask(wrong, indices, B, S)
+        self.assertEqual(list(result.shape), [B, S, 1])
+        np.testing.assert_array_equal(result[0, 24:, 0].numpy(), np.zeros(8))
+
+    def test_4d_shape_mismatch_without_startend_raises(self):
+        wrong = _to_4d_causal(_keep_vector(B, S + 4))
+        with self.assertRaises(ValueError):
+            self.gdn._build_padding_mask(wrong, None, B, S)
+
+    def test_4d_non_square_falls_through(self):
+        """A ``[b, 1, s, s_kv]`` cross-attention-shaped mask is not reducible."""
+        mask = paddle.ones([B, 1, S, S + 8], dtype="float32")
+        with self.assertRaises(ValueError):
+            self.gdn._build_padding_mask(mask, None, B, S)
+
+    def test_4d_takes_priority_over_startend(self):
+        mask = _to_4d_causal(_keep_vector(B, S, padding_start=28, sample=0))
+        indices = _make_startend_indices(B, S, padding_start=None)
+        result = self.gdn._build_padding_mask(mask, indices, B, S)
+        np.testing.assert_array_equal(result[0, 28:, 0].numpy(), np.zeros(4))
+
+    def test_all_valid_check_survives_strided_input(self):
+        """Pin the reduction: ``all()`` over a strided float buffer lies.
+
+        ``paddle.diagonal`` returns a non-contiguous view, and
+        ``paddle.Tensor.all()`` on such a float tensor reports ``False`` even
+        when every element is 1.0 — which would return an all-ones mask instead
+        of ``None``. Assert the raw primitive still misbehaves (so this test
+        starts failing once Paddle fixes it and the guard can be dropped) and
+        that ``_build_padding_mask`` is nonetheless correct.
+        """
+        ones_4d = _to_4d_causal(_keep_vector(1, S))
+        strided = paddle.diagonal(
+            ones_4d[:, 0, :, :], axis1=-2, axis2=-1
+        ).unsqueeze(-1)
+        self.assertFalse(strided.is_contiguous())
+        np.testing.assert_array_equal(strided.numpy().ravel(), np.ones(S))
+        self.assertFalse(bool(strided.all()))
+        self.assertTrue(bool(strided.astype("bool").all()))
+        self.assertIsNone(self.gdn._build_padding_mask(ones_4d, None, 1, S))
+
+    def test_4d_returns_contiguous_mask(self):
+        mask = _to_4d_causal(_keep_vector(B, S, padding_start=24, sample=0))
+        result = self.gdn._build_padding_mask(mask, None, B, S)
+        self.assertTrue(result.is_contiguous())
+
+
+class TestBuildPaddingMask4DWithSP(unittest.TestCase):
+    """4D masks reuse the SP slicing path after being reduced to 2D."""
+
+    def setUp(self):
+        self.gdn = _make_gdn_sp()
+
+    def test_4d_rank0_all_valid(self):
+        mask = _to_4d_causal(_keep_vector(B, S))
+        with patch(f"{_GDN_MODULE}.get_pg_rank", return_value=0):
+            self.assertIsNone(self.gdn._build_padding_mask(mask, None, B, S))
+
+    def test_4d_rank1_with_padding(self):
+        mask = _to_4d_causal(_keep_vector(B, S, padding_start=28, sample=0))
+        with patch(f"{_GDN_MODULE}.get_pg_rank", return_value=1):
+            result = self.gdn._build_padding_mask(mask, None, B, S)
+        # SP layout is [s_local, b, 1]; rank 1 owns [16, 32) so 28-31 → 12-15.
+        self.assertEqual(list(result.shape), [16, B, 1])
+        np.testing.assert_array_equal(result[:12, 0, 0].numpy(), np.ones(12))
+        np.testing.assert_array_equal(result[12:, 0, 0].numpy(), np.zeros(4))
+        np.testing.assert_array_equal(result[:, 1, 0].numpy(), np.ones(16))
+
+    def test_4d_rank0_clean_rank1_padded(self):
+        mask = _to_4d_causal(_keep_vector(B, S, padding_start=20))
+        with patch(f"{_GDN_MODULE}.get_pg_rank", return_value=0):
+            self.assertIsNone(self.gdn._build_padding_mask(mask, None, B, S))
+        with patch(f"{_GDN_MODULE}.get_pg_rank", return_value=1):
+            result = self.gdn._build_padding_mask(mask, None, B, S)
+        np.testing.assert_array_equal(result[:4, 0, 0].numpy(), np.ones(4))
+        np.testing.assert_array_equal(result[4:, 0, 0].numpy(), np.zeros(12))
+
+    def test_4d_shape_mismatch_raises_under_sp(self):
+        wrong = _to_4d_causal(_keep_vector(B, S + 4))
+        with (
+            patch(f"{_GDN_MODULE}.get_pg_rank", return_value=0),
+            self.assertRaises(ValueError),
+        ):
+            self.gdn._build_padding_mask(wrong, None, B, S)
+
+
+class TestForward4DMask(unittest.TestCase):
+    """Forward-level checks that a VL-style 4D mask is honored, not rejected."""
+
+    def setUp(self):
+        self.gdn = _make_gdn()
+        self.gdn.eval()
+
+    def test_forward_accepts_4d_mask(self):
+        x = paddle.randn([B, S, H])
+        keep = _keep_vector(B, S, padding_start=24, sample=0)
+        out_4d, _ = self.gdn(x, attention_mask=_to_4d_causal(keep))
+        out_2d, _ = self.gdn(x, attention_mask=keep)
+        np.testing.assert_allclose(
+            out_4d.numpy(), out_2d.numpy(), rtol=1e-5, atol=1e-5
+        )
+
+    def test_forward_4d_all_valid_equals_no_mask(self):
+        x = paddle.randn([B, S, H])
+        out_4d, _ = self.gdn(
+            x, attention_mask=_to_4d_causal(_keep_vector(B, S))
+        )
+        out_none, _ = self.gdn(x, attention_mask=None)
+        np.testing.assert_allclose(
+            out_4d.numpy(), out_none.numpy(), rtol=1e-5, atol=1e-5
+        )
+
+    def test_forward_4d_padding_changes_output(self):
+        x = paddle.randn([B, S, H])
+        keep = _keep_vector(B, S, padding_start=0, sample=0)
+        out_pad, _ = self.gdn(x, attention_mask=_to_4d_causal(keep))
+        out_none, _ = self.gdn(x, attention_mask=None)
+        self.assertFalse(
+            np.allclose(out_pad[0].numpy(), out_none[0].numpy(), atol=1e-6)
+        )
+        np.testing.assert_allclose(
+            out_pad[1].numpy(), out_none[1].numpy(), rtol=1e-5, atol=1e-5
+        )
+
+    def test_forward_4d_backward_zeroes_padding_grad(self):
+        x = paddle.randn([B, S, H])
+        x.stop_gradient = False
+        keep = _keep_vector(B, S, padding_start=24, sample=0)
+        out, _ = self.gdn(x, attention_mask=_to_4d_causal(keep))
+        out.sum().backward()
+        self.assertTrue(paddle.isfinite(x.grad).all().item())
+        np.testing.assert_array_equal(x.grad[0, 24:].numpy(), np.zeros([8, H]))
         self.assertFalse(np.allclose(x.grad[0, :24].numpy(), 0))
 
 


### PR DESCRIPTION
### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复 Qwen3.5 视觉分支的 merger 归一化 epsilon 和 MLP 激活函数 spec 传递问题；修正 Gated DeltaNet 对 4D attention mask、padding 以及参数 dtype 的处理，并补充对应单卡回归测试。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否