### PR TITLE
[Performance] Add Triton SiTU-GLU fusion

### DIFF
--- a/src/paddlefleet/transformer/activations.py
+++ b/src/paddlefleet/transformer/activations.py
@@ -75,8 +75,16 @@ def situ_glu_scale_forward(
     probs: paddle.Tensor,
     beta: float = 1.0,
     linear_beta: float | None = None,
+    use_fused_situ_glu: bool = True,
 ) -> paddle.Tensor:
     """Apply SiTU-GLU and router scaling with float32 intermediates."""
+
+    if use_fused_situ_glu:
+        from paddlefleet.triton_ops.situ_glu import (
+            situ_glu_scale_forward_triton,
+        )
+
+        return situ_glu_scale_forward_triton(x, probs, beta, linear_beta)
 
     input_dtype = x.dtype
     probs = probs.astype("float32")
@@ -94,6 +102,7 @@ def situ_glu_scale_backward(
     out_grad: paddle.Tensor,
     beta: float = 1.0,
     linear_beta: float | None = None,
+    use_fused_situ_glu: bool = True,
 ) -> tuple[paddle.Tensor, paddle.Tensor, paddle.Tensor]:
     """Backward for :func:`situ_glu_scale_forward`."""
 
@@ -107,6 +116,14 @@ def situ_glu_scale_backward(
         raise ValueError(
             "SiTU linear_beta must be a positive finite value or None, "
             f"but got {linear_beta!r}."
+        )
+    if use_fused_situ_glu:
+        from paddlefleet.triton_ops.situ_glu import (
+            situ_glu_scale_backward_triton,
+        )
+
+        return situ_glu_scale_backward_triton(
+            x, probs, out_grad, beta, linear_beta
         )
 
     gate, up = paddle.chunk(x, chunks=2, axis=-1)

--- a/src/paddlefleet/transformer/activations.py
+++ b/src/paddlefleet/transformer/activations.py
@@ -19,8 +19,6 @@ import math
 import paddle
 import paddle.nn.functional as F
 
-from paddlefleet.triton_ops.utils import is_triton_available
-
 
 def situ(x: paddle.Tensor, beta: float = 1.0) -> paddle.Tensor:
     """Apply the SiTU gate activation with float32 intermediates."""
@@ -81,12 +79,15 @@ def situ_glu_scale_forward(
 ) -> paddle.Tensor:
     """Apply SiTU-GLU and router scaling with float32 intermediates."""
 
-    if use_fused_situ_glu and is_triton_available():
-        from paddlefleet.triton_ops.situ_glu import (
-            situ_glu_scale_forward_triton,
-        )
+    if use_fused_situ_glu:
+        from paddlefleet.triton_ops.utils import is_triton_available
 
-        return situ_glu_scale_forward_triton(x, probs, beta, linear_beta)
+        if is_triton_available():
+            from paddlefleet.triton_ops.situ_glu import (
+                situ_glu_scale_forward_triton,
+            )
+
+            return situ_glu_scale_forward_triton(x, probs, beta, linear_beta)
 
     input_dtype = x.dtype
     probs = probs.astype("float32")
@@ -119,14 +120,17 @@ def situ_glu_scale_backward(
             "SiTU linear_beta must be a positive finite value or None, "
             f"but got {linear_beta!r}."
         )
-    if use_fused_situ_glu and is_triton_available():
-        from paddlefleet.triton_ops.situ_glu import (
-            situ_glu_scale_backward_triton,
-        )
+    if use_fused_situ_glu:
+        from paddlefleet.triton_ops.utils import is_triton_available
 
-        return situ_glu_scale_backward_triton(
-            x, probs, out_grad, beta, linear_beta
-        )
+        if is_triton_available():
+            from paddlefleet.triton_ops.situ_glu import (
+                situ_glu_scale_backward_triton,
+            )
+
+            return situ_glu_scale_backward_triton(
+                x, probs, out_grad, beta, linear_beta
+            )
 
     gate, up = paddle.chunk(x, chunks=2, axis=-1)
     gate = gate.astype("float32")

--- a/src/paddlefleet/transformer/activations.py
+++ b/src/paddlefleet/transformer/activations.py
@@ -19,6 +19,8 @@ import math
 import paddle
 import paddle.nn.functional as F
 
+from paddlefleet.triton_ops.utils import is_triton_available
+
 
 def situ(x: paddle.Tensor, beta: float = 1.0) -> paddle.Tensor:
     """Apply the SiTU gate activation with float32 intermediates."""
@@ -79,7 +81,7 @@ def situ_glu_scale_forward(
 ) -> paddle.Tensor:
     """Apply SiTU-GLU and router scaling with float32 intermediates."""
 
-    if use_fused_situ_glu:
+    if use_fused_situ_glu and is_triton_available():
         from paddlefleet.triton_ops.situ_glu import (
             situ_glu_scale_forward_triton,
         )
@@ -117,7 +119,7 @@ def situ_glu_scale_backward(
             "SiTU linear_beta must be a positive finite value or None, "
             f"but got {linear_beta!r}."
         )
-    if use_fused_situ_glu:
+    if use_fused_situ_glu and is_triton_available():
         from paddlefleet.triton_ops.situ_glu import (
             situ_glu_scale_backward_triton,
         )

--- a/src/paddlefleet/transformer/activations.py
+++ b/src/paddlefleet/transformer/activations.py
@@ -75,11 +75,11 @@ def situ_glu_scale_forward(
     probs: paddle.Tensor,
     beta: float = 1.0,
     linear_beta: float | None = None,
-    use_fused_situ_glu: bool = True,
+    situ_glu_fusion: bool = True,
 ) -> paddle.Tensor:
     """Apply SiTU-GLU and router scaling with float32 intermediates."""
 
-    if use_fused_situ_glu:
+    if situ_glu_fusion:
         from paddlefleet.triton_ops.utils import is_triton_available
 
         if is_triton_available():
@@ -105,7 +105,7 @@ def situ_glu_scale_backward(
     out_grad: paddle.Tensor,
     beta: float = 1.0,
     linear_beta: float | None = None,
-    use_fused_situ_glu: bool = True,
+    situ_glu_fusion: bool = True,
 ) -> tuple[paddle.Tensor, paddle.Tensor, paddle.Tensor]:
     """Backward for :func:`situ_glu_scale_forward`."""
 
@@ -120,7 +120,7 @@ def situ_glu_scale_backward(
             "SiTU linear_beta must be a positive finite value or None, "
             f"but got {linear_beta!r}."
         )
-    if use_fused_situ_glu:
+    if situ_glu_fusion:
         from paddlefleet.triton_ops.utils import is_triton_available
 
         if is_triton_available():

--- a/src/paddlefleet/transformer/moe/fp8_utils.py
+++ b/src/paddlefleet/transformer/moe/fp8_utils.py
@@ -913,6 +913,7 @@ class ExpertsGroupGemmContiguousNode:
         self.activation_situ_linear_beta = getattr(
             config, "activation_situ_linear_beta", None
         )
+        self.use_fused_situ_glu = getattr(config, "use_fused_situ_glu", True)
         self.use_accuracy_compatible = use_accuracy_compatible
         self.token_padding_alignment = moe_token_padding_alignment(
             use_fp8_mlp=use_fp8_mlp,
@@ -1404,6 +1405,7 @@ class ExpertsGroupGemmContiguousNode:
                     unzipped_probs,
                     self.activation_situ_beta,
                     self.activation_situ_linear_beta,
+                    use_fused_situ_glu=self.use_fused_situ_glu,
                 )
             elif self.activation_type == "geglu":
                 # GeGLU: gelu_tanh(gate) * up, then scale by probs
@@ -1704,6 +1706,7 @@ class ExpertsGroupGemmContiguousNode:
                 do2_s,
                 self.activation_situ_beta,
                 self.activation_situ_linear_beta,
+                use_fused_situ_glu=self.use_fused_situ_glu,
             )
 
         if self.activation_type == "geglu":

--- a/src/paddlefleet/transformer/moe/fp8_utils.py
+++ b/src/paddlefleet/transformer/moe/fp8_utils.py
@@ -913,7 +913,7 @@ class ExpertsGroupGemmContiguousNode:
         self.activation_situ_linear_beta = getattr(
             config, "activation_situ_linear_beta", None
         )
-        self.use_fused_situ_glu = getattr(config, "use_fused_situ_glu", True)
+        self.situ_glu_fusion = getattr(config, "situ_glu_fusion", True)
         self.use_accuracy_compatible = use_accuracy_compatible
         self.token_padding_alignment = moe_token_padding_alignment(
             use_fp8_mlp=use_fp8_mlp,
@@ -1405,7 +1405,7 @@ class ExpertsGroupGemmContiguousNode:
                     unzipped_probs,
                     self.activation_situ_beta,
                     self.activation_situ_linear_beta,
-                    use_fused_situ_glu=self.use_fused_situ_glu,
+                    situ_glu_fusion=self.situ_glu_fusion,
                 )
             elif self.activation_type == "geglu":
                 # GeGLU: gelu_tanh(gate) * up, then scale by probs
@@ -1706,7 +1706,7 @@ class ExpertsGroupGemmContiguousNode:
                 do2_s,
                 self.activation_situ_beta,
                 self.activation_situ_linear_beta,
-                use_fused_situ_glu=self.use_fused_situ_glu,
+                situ_glu_fusion=self.situ_glu_fusion,
             )
 
         if self.activation_type == "geglu":

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -198,6 +198,9 @@ class TransformerConfig(ModelParallelConfig):
     activation_situ_linear_beta: float | None = None
     """Optional tanh scale applied to the linear branch of SiTU-GLU."""
 
+    use_fused_situ_glu: bool = True
+    """Use fused Triton SiTU-GLU in FusionMoe BF16 routed experts."""
+
     use_bias: bool = False
     """Include a bias term in all linear layers (QKV projections and Output projections, after core attention, and two in
     MLP layer)."""

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -198,7 +198,7 @@ class TransformerConfig(ModelParallelConfig):
     activation_situ_linear_beta: float | None = None
     """Optional tanh scale applied to the linear branch of SiTU-GLU."""
 
-    use_fused_situ_glu: bool = True
+    situ_glu_fusion: bool = True
     """Use fused Triton SiTU-GLU in FusionMoe BF16 routed experts."""
 
     use_bias: bool = False

--- a/src/paddlefleet/triton_ops/__init__.py
+++ b/src/paddlefleet/triton_ops/__init__.py
@@ -28,10 +28,6 @@ from .moe_topk_fusion import MoETopkFusion, routing_map_fusion_forward
 from .q_rms_norm_fusion import fused_q_rms_norm
 from .rms_norm_fusion import RMSNormFusionTriton
 from .sigmoid_gate_fusion import SigmoidGateFusionTriton
-from .situ_glu import (
-    situ_glu_scale_backward_triton,
-    situ_glu_scale_forward_triton,
-)
 from .ue8m0_scale_transpose_fusion import (
     FuseStackUe8m0ScaleTransposeTriton,
     fuse_stack_ue8m0_scale_transpose,
@@ -51,8 +47,6 @@ __all__ = [
     "MoETopkFusion",
     "routing_map_fusion_forward",
     "SigmoidGateFusionTriton",
-    "situ_glu_scale_backward_triton",
-    "situ_glu_scale_forward_triton",
     "FuseStackUe8m0ScaleTransposeTriton",
     "fuse_stack_ue8m0_scale_transpose",
     "fused_apply_mla_rope_for_kv",

--- a/src/paddlefleet/triton_ops/__init__.py
+++ b/src/paddlefleet/triton_ops/__init__.py
@@ -28,6 +28,10 @@ from .moe_topk_fusion import MoETopkFusion, routing_map_fusion_forward
 from .q_rms_norm_fusion import fused_q_rms_norm
 from .rms_norm_fusion import RMSNormFusionTriton
 from .sigmoid_gate_fusion import SigmoidGateFusionTriton
+from .situ_glu import (
+    situ_glu_scale_backward_triton,
+    situ_glu_scale_forward_triton,
+)
 from .ue8m0_scale_transpose_fusion import (
     FuseStackUe8m0ScaleTransposeTriton,
     fuse_stack_ue8m0_scale_transpose,
@@ -47,6 +51,8 @@ __all__ = [
     "MoETopkFusion",
     "routing_map_fusion_forward",
     "SigmoidGateFusionTriton",
+    "situ_glu_scale_backward_triton",
+    "situ_glu_scale_forward_triton",
     "FuseStackUe8m0ScaleTransposeTriton",
     "fuse_stack_ue8m0_scale_transpose",
     "fused_apply_mla_rope_for_kv",

--- a/src/paddlefleet/triton_ops/situ_glu.py
+++ b/src/paddlefleet/triton_ops/situ_glu.py
@@ -1,0 +1,345 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Fused Triton kernels for Kimi-K3 SiTU-GLU with router scaling."""
+
+from __future__ import annotations
+
+import math
+
+import paddle
+
+from .utils import enable_compat_on_triton_kernel, is_torch_compat_available
+
+if is_torch_compat_available():
+    paddle.enable_compat(scope={"triton"})
+
+import triton
+import triton.language as tl
+from triton.language.extra.cuda import libdevice
+
+
+@triton.jit
+def _sigmoid_precise(x):
+    return libdevice.div_rn(1.0, 1.0 + libdevice.exp(-x))
+
+
+@enable_compat_on_triton_kernel
+@triton.jit
+def _situ_glu_scale_fwd_kernel(
+    x_ptr,
+    probs_ptr,
+    out_ptr,
+    n_cols: tl.constexpr,
+    beta: tl.constexpr,
+    linear_beta: tl.constexpr,
+    has_linear_tanh: tl.constexpr,
+    block_n: tl.constexpr,
+):
+    # Long-context MoE batches can make row * stride exceed int32. Keep all
+    # flattened pointer offsets in int64.
+    row = tl.program_id(0).to(tl.int64)
+    col_block = tl.program_id(1)
+    cols = col_block * block_n + tl.arange(0, block_n)
+    mask = cols < n_cols
+
+    gate = tl.load(x_ptr + row * (2 * n_cols) + cols, mask=mask).to(tl.float32)
+    up = tl.load(x_ptr + row * (2 * n_cols) + n_cols + cols, mask=mask).to(
+        tl.float32
+    )
+    prob = tl.load(probs_ptr + row).to(tl.float32)
+
+    gate_tanh = libdevice.tanh(gate / beta)
+    gate_act = beta * gate_tanh * _sigmoid_precise(gate)
+    if has_linear_tanh:
+        up = linear_beta * libdevice.tanh(up / linear_beta)
+    out = gate_act * up * prob
+    tl.store(out_ptr + row * n_cols + cols, out, mask=mask)
+
+
+@enable_compat_on_triton_kernel
+@triton.jit
+def _situ_glu_scale_bwd_kernel(
+    x_ptr,
+    probs_ptr,
+    out_grad_ptr,
+    x_grad_ptr,
+    recomputed_ptr,
+    probs_grad_ptr,
+    n_cols: tl.constexpr,
+    beta: tl.constexpr,
+    linear_beta: tl.constexpr,
+    has_linear_tanh: tl.constexpr,
+    block_n: tl.constexpr,
+):
+    # Long-context MoE batches can make row * stride exceed int32. Keep all
+    # flattened pointer offsets in int64.
+    row = tl.program_id(0).to(tl.int64)
+    cols = tl.arange(0, block_n)
+    mask = cols < n_cols
+
+    gate = tl.load(x_ptr + row * (2 * n_cols) + cols, mask=mask).to(tl.float32)
+    up = tl.load(x_ptr + row * (2 * n_cols) + n_cols + cols, mask=mask).to(
+        tl.float32
+    )
+    out_grad = tl.load(
+        out_grad_ptr + row * n_cols + cols, mask=mask, other=0.0
+    ).to(tl.float32)
+    prob = tl.load(probs_ptr + row).to(tl.float32)
+
+    gate_tanh = libdevice.tanh(gate / beta)
+    gate_sigmoid = _sigmoid_precise(gate)
+    gate_act = beta * gate_tanh * gate_sigmoid
+    gate_grad = (
+        1.0 - gate_tanh * gate_tanh
+    ) * gate_sigmoid + beta * gate_tanh * gate_sigmoid * (1.0 - gate_sigmoid)
+    if has_linear_tanh:
+        up_tanh = libdevice.tanh(up / linear_beta)
+        up_act = linear_beta * up_tanh
+        up_grad = 1.0 - up_tanh * up_tanh
+    else:
+        up_act = up
+        up_grad = 1.0
+
+    unscaled = gate_act * up_act
+    scaled_grad = out_grad * prob
+    gate_input_grad = scaled_grad * up_act * gate_grad
+    up_input_grad = scaled_grad * gate_act * up_grad
+
+    tl.store(
+        x_grad_ptr + row * (2 * n_cols) + cols,
+        gate_input_grad,
+        mask=mask,
+    )
+    tl.store(
+        x_grad_ptr + row * (2 * n_cols) + n_cols + cols,
+        up_input_grad,
+        mask=mask,
+    )
+    tl.store(
+        recomputed_ptr + row * n_cols + cols,
+        unscaled * prob,
+        mask=mask,
+    )
+    probs_grad = tl.sum(tl.where(mask, out_grad * unscaled, 0.0), axis=0)
+    tl.store(probs_grad_ptr + row, probs_grad)
+
+
+@enable_compat_on_triton_kernel
+@triton.jit
+def _situ_glu_scale_bwd_segmented_kernel(
+    x_ptr,
+    probs_ptr,
+    out_grad_ptr,
+    x_grad_ptr,
+    recomputed_ptr,
+    probs_grad_ptr,
+    n_cols: tl.constexpr,
+    beta: tl.constexpr,
+    linear_beta: tl.constexpr,
+    has_linear_tanh: tl.constexpr,
+    chunk_n: tl.constexpr,
+):
+    # N=3072 padded to 4096 makes the full-row kernel register-heavy. Process
+    # three exact 1024-element chunks in one CTA so each chunk's intermediates
+    # die before the next one, while preserving one final router-score grad.
+    row = tl.program_id(0).to(tl.int64)
+    lane_cols = tl.arange(0, chunk_n)
+    probs_grad = 0.0
+
+    for chunk_start in tl.range(
+        0,
+        n_cols,
+        chunk_n,
+        loop_unroll_factor=1,
+        disable_licm=True,
+    ):
+        cols = chunk_start + lane_cols
+        gate = tl.load(x_ptr + row * (2 * n_cols) + cols).to(tl.float32)
+        up = tl.load(x_ptr + row * (2 * n_cols) + n_cols + cols).to(tl.float32)
+        out_grad = tl.load(out_grad_ptr + row * n_cols + cols).to(tl.float32)
+        prob = tl.load(probs_ptr + row).to(tl.float32)
+
+        gate_tanh = libdevice.tanh(gate / beta)
+        gate_sigmoid = _sigmoid_precise(gate)
+        gate_act = beta * gate_tanh * gate_sigmoid
+        gate_grad = (
+            1.0 - gate_tanh * gate_tanh
+        ) * gate_sigmoid + beta * gate_tanh * gate_sigmoid * (
+            1.0 - gate_sigmoid
+        )
+        if has_linear_tanh:
+            up_tanh = libdevice.tanh(up / linear_beta)
+            up_act = linear_beta * up_tanh
+            up_grad = 1.0 - up_tanh * up_tanh
+        else:
+            up_act = up
+            up_grad = 1.0
+
+        unscaled = gate_act * up_act
+        scaled_grad = out_grad * prob
+        tl.store(
+            x_grad_ptr + row * (2 * n_cols) + cols,
+            scaled_grad * up_act * gate_grad,
+        )
+        tl.store(
+            x_grad_ptr + row * (2 * n_cols) + n_cols + cols,
+            scaled_grad * gate_act * up_grad,
+        )
+        tl.store(recomputed_ptr + row * n_cols + cols, unscaled * prob)
+        probs_grad += tl.sum(out_grad * unscaled, axis=0)
+
+    tl.store(probs_grad_ptr + row, probs_grad)
+
+
+def _validate_inputs(
+    x: paddle.Tensor,
+    probs: paddle.Tensor,
+    out_grad: paddle.Tensor | None = None,
+) -> tuple[int, int]:
+    if x.ndim != 2 or x.shape[1] % 2:
+        raise ValueError(f"x must have shape [M, 2N], got {list(x.shape)}")
+    if not x.is_contiguous():
+        raise ValueError("x must be contiguous")
+    if x.dtype not in (paddle.float16, paddle.bfloat16, paddle.float32):
+        raise TypeError(f"unsupported x dtype: {x.dtype}")
+    rows, n_cols = int(x.shape[0]), int(x.shape[1]) // 2
+    if list(probs.shape) not in ([rows], [rows, 1]):
+        raise ValueError(
+            f"probs must have shape [M] or [M, 1], got {list(probs.shape)}"
+        )
+    if not probs.is_contiguous():
+        raise ValueError("probs must be contiguous")
+    if probs.dtype not in (paddle.float16, paddle.bfloat16, paddle.float32):
+        raise TypeError(f"unsupported probs dtype: {probs.dtype}")
+    if out_grad is not None:
+        if list(out_grad.shape) != [rows, n_cols]:
+            raise ValueError(
+                f"out_grad must have shape [M, N], got {list(out_grad.shape)}"
+            )
+        if out_grad.dtype != x.dtype:
+            raise TypeError(
+                f"out_grad dtype must match x: {out_grad.dtype} vs {x.dtype}"
+            )
+        if not out_grad.is_contiguous():
+            raise ValueError("out_grad must be contiguous")
+    return rows, n_cols
+
+
+def situ_glu_scale_forward_triton(
+    x: paddle.Tensor,
+    probs: paddle.Tensor,
+    beta: float = 1.0,
+    linear_beta: float | None = None,
+) -> paddle.Tensor:
+    """Compute ``SiTU-GLU(x) * probs`` in one Triton kernel."""
+
+    if not math.isfinite(beta) or beta <= 0:
+        raise ValueError(
+            f"SiTU beta must be a positive finite value, but got {beta!r}."
+        )
+    if linear_beta is not None and (
+        not math.isfinite(linear_beta) or linear_beta <= 0
+    ):
+        raise ValueError(
+            "SiTU linear_beta must be a positive finite value or None, "
+            f"but got {linear_beta!r}."
+        )
+    rows, n_cols = _validate_inputs(x, probs)
+    out = paddle.empty([rows, n_cols], dtype=x.dtype)
+    if rows == 0 or n_cols == 0:
+        return out
+    block_n = min(1024, triton.next_power_of_2(n_cols))
+    grid = (rows, triton.cdiv(n_cols, block_n))
+    _situ_glu_scale_fwd_kernel[grid](
+        x,
+        probs,
+        out,
+        n_cols=n_cols,
+        beta=float(beta),
+        linear_beta=1.0 if linear_beta is None else float(linear_beta),
+        has_linear_tanh=linear_beta is not None,
+        block_n=block_n,
+        num_warps=8 if block_n >= 512 else 4,
+    )
+    return out
+
+
+def situ_glu_scale_backward_triton(
+    x: paddle.Tensor,
+    probs: paddle.Tensor,
+    out_grad: paddle.Tensor,
+    beta: float = 1.0,
+    linear_beta: float | None = None,
+) -> tuple[paddle.Tensor, paddle.Tensor, paddle.Tensor]:
+    """Fused SiTU-GLU backward, including recompute and router-score grad."""
+
+    if not math.isfinite(beta) or beta <= 0:
+        raise ValueError(
+            f"SiTU beta must be a positive finite value, but got {beta!r}."
+        )
+    if linear_beta is not None and (
+        not math.isfinite(linear_beta) or linear_beta <= 0
+    ):
+        raise ValueError(
+            "SiTU linear_beta must be a positive finite value or None, "
+            f"but got {linear_beta!r}."
+        )
+    rows, n_cols = _validate_inputs(x, probs, out_grad)
+    x_grad = paddle.empty_like(x)
+    recomputed = paddle.empty([rows, n_cols], dtype=x.dtype)
+    probs_grad = paddle.empty_like(probs)
+    if rows == 0 or n_cols == 0:
+        return x_grad, recomputed, probs_grad
+    if n_cols == 3072:
+        _situ_glu_scale_bwd_segmented_kernel[(rows,)](
+            x,
+            probs,
+            out_grad,
+            x_grad,
+            recomputed,
+            probs_grad,
+            n_cols=n_cols,
+            beta=float(beta),
+            linear_beta=1.0 if linear_beta is None else float(linear_beta),
+            has_linear_tanh=linear_beta is not None,
+            chunk_n=1024,
+            num_warps=4,
+        )
+        return x_grad, recomputed, probs_grad
+
+    block_n = triton.next_power_of_2(n_cols)
+    if block_n > 65536:
+        raise ValueError(f"SiTU-GLU width is too large for one row: {n_cols}")
+    _situ_glu_scale_bwd_kernel[(rows,)](
+        x,
+        probs,
+        out_grad,
+        x_grad,
+        recomputed,
+        probs_grad,
+        n_cols=n_cols,
+        beta=float(beta),
+        linear_beta=1.0 if linear_beta is None else float(linear_beta),
+        has_linear_tanh=linear_beta is not None,
+        block_n=block_n,
+        num_warps=8 if block_n >= 2048 else 4,
+    )
+    return x_grad, recomputed, probs_grad
+
+
+__all__ = [
+    "situ_glu_scale_backward_triton",
+    "situ_glu_scale_forward_triton",
+]

--- a/src/paddlefleet/triton_ops/situ_glu.py
+++ b/src/paddlefleet/triton_ops/situ_glu.py
@@ -208,6 +208,11 @@ def _validate_inputs(
     probs: paddle.Tensor,
     out_grad: paddle.Tensor | None = None,
 ) -> tuple[int, int]:
+    tensors = (x, probs) if out_grad is None else (x, probs, out_grad)
+    if any(not tensor.place.is_gpu_place() for tensor in tensors):
+        raise ValueError("SiTU-GLU Triton inputs must be GPU tensors")
+    if any(tensor.place != x.place for tensor in tensors[1:]):
+        raise ValueError("SiTU-GLU Triton inputs must be on the same GPU")
     if x.ndim != 2 or x.shape[1] % 2:
         raise ValueError(f"x must have shape [M, 2N], got {list(x.shape)}")
     if not x.is_contiguous():

--- a/tests/single_card_tests/custom_ops/test_situ_glu_fusion.py
+++ b/tests/single_card_tests/custom_ops/test_situ_glu_fusion.py
@@ -120,7 +120,7 @@ for function, args in entries:
         out_grad = paddle.randn([17, 3072], dtype="bfloat16")
 
         expected_forward = situ_glu_scale_forward(
-            x, probs, 4.0, 25.0, use_fused_situ_glu=False
+            x, probs, 4.0, 25.0, situ_glu_fusion=False
         )
         expected_backward = situ_glu_scale_backward(
             x,
@@ -128,7 +128,7 @@ for function, args in entries:
             out_grad,
             4.0,
             25.0,
-            use_fused_situ_glu=False,
+            situ_glu_fusion=False,
         )
 
         actual_forward = situ_glu_scale_forward(x, probs, 4.0, 25.0)
@@ -175,7 +175,7 @@ for function, args in entries:
                     out_grad,
                     4.0,
                     linear_beta,
-                    use_fused_situ_glu=False,
+                    situ_glu_fusion=False,
                 )
                 actual = situ_glu_scale_backward(
                     x,
@@ -211,7 +211,7 @@ for function, args in entries:
         rows = 65536
         x = paddle.ones([rows, 8], dtype="bfloat16")
         probs = paddle.ones([rows], dtype="float32")
-        expected = situ_glu_scale_forward(x, probs, use_fused_situ_glu=False)
+        expected = situ_glu_scale_forward(x, probs, situ_glu_fusion=False)
         actual = situ_glu_scale_forward(x, probs)
         self.assertTrue(
             paddle.equal_all(

--- a/tests/single_card_tests/custom_ops/test_situ_glu_fusion.py
+++ b/tests/single_card_tests/custom_ops/test_situ_glu_fusion.py
@@ -30,6 +30,19 @@ from paddlefleet.triton_ops.situ_glu import (
 
 
 class TestSituGLUFusion(unittest.TestCase):
+    def test_triton_entries_reject_cpu_inputs(self):
+        cpu_place = paddle.CPUPlace()
+        x = paddle.to_tensor([[1.0] * 8] * 2, dtype="float32", place=cpu_place)
+        probs = paddle.to_tensor([1.0, 1.0], dtype="float32", place=cpu_place)
+        out_grad = paddle.to_tensor(
+            [[1.0] * 4] * 2, dtype="float32", place=cpu_place
+        )
+
+        with self.assertRaisesRegex(ValueError, "must be GPU tensors"):
+            situ_glu_scale_forward_triton(x, probs)
+        with self.assertRaisesRegex(ValueError, "must be GPU tensors"):
+            situ_glu_scale_backward_triton(x, probs, out_grad)
+
     def test_triton_entries_reject_invalid_scales(self):
         invalid_scales = (
             -1.0,

--- a/tests/single_card_tests/custom_ops/test_situ_glu_fusion.py
+++ b/tests/single_card_tests/custom_ops/test_situ_glu_fusion.py
@@ -1,0 +1,211 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import subprocess
+import sys
+import unittest
+
+import paddle
+
+from paddlefleet.transformer.activations import (
+    situ_glu_scale_backward,
+    situ_glu_scale_forward,
+)
+from paddlefleet.triton_ops.situ_glu import (
+    situ_glu_scale_backward_triton,
+    situ_glu_scale_forward_triton,
+)
+
+
+class TestSituGLUFusion(unittest.TestCase):
+    def test_triton_entries_reject_invalid_scales(self):
+        invalid_scales = (
+            -1.0,
+            0.0,
+            float("-inf"),
+            float("inf"),
+            float("nan"),
+        )
+        entries = (
+            (situ_glu_scale_forward_triton, (None, None)),
+            (situ_glu_scale_backward_triton, (None, None, None)),
+        )
+
+        for function, args in entries:
+            for beta in invalid_scales:
+                with (
+                    self.subTest(function=function.__name__, beta=beta),
+                    self.assertRaisesRegex(ValueError, "positive finite"),
+                ):
+                    function(*args, beta=beta)
+            for linear_beta in invalid_scales:
+                with (
+                    self.subTest(
+                        function=function.__name__, linear_beta=linear_beta
+                    ),
+                    self.assertRaisesRegex(ValueError, "positive finite"),
+                ):
+                    function(*args, linear_beta=linear_beta)
+
+    def test_triton_guards_survive_optimized_mode(self):
+        repo_root = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "../../..")
+        )
+        env = dict(os.environ)
+        env["PYTHONPATH"] = os.pathsep.join(
+            [
+                os.path.join(repo_root, "src"),
+                env.get("PYTHONPATH", ""),
+            ]
+        )
+        script = """
+from paddlefleet.triton_ops.situ_glu import (
+    situ_glu_scale_backward_triton,
+    situ_glu_scale_forward_triton,
+)
+
+entries = (
+    (situ_glu_scale_forward_triton, (None, None)),
+    (situ_glu_scale_backward_triton, (None, None, None)),
+)
+for function, args in entries:
+    for kwargs in ({"beta": 0.0}, {"linear_beta": float("nan")}):
+        try:
+            function(*args, **kwargs)
+        except ValueError as error:
+            if "positive finite" not in str(error):
+                raise
+        else:
+            raise SystemExit(f"{function.__name__} accepted {kwargs}")
+"""
+        proc = subprocess.run(
+            [sys.executable, "-O", "-c", script],
+            capture_output=True,
+            text=True,
+            env=env,
+            cwd=repo_root,
+        )
+
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+
+    def test_default_fused_matches_disabled_reference(self):
+        paddle.seed(20260812)
+        x = paddle.randn([17, 6144], dtype="bfloat16")
+        probs = paddle.rand([17], dtype="float32")
+        out_grad = paddle.randn([17, 3072], dtype="bfloat16")
+
+        expected_forward = situ_glu_scale_forward(
+            x, probs, 4.0, 25.0, use_fused_situ_glu=False
+        )
+        expected_backward = situ_glu_scale_backward(
+            x,
+            probs,
+            out_grad,
+            4.0,
+            25.0,
+            use_fused_situ_glu=False,
+        )
+
+        actual_forward = situ_glu_scale_forward(x, probs, 4.0, 25.0)
+        actual_backward = situ_glu_scale_backward(x, probs, out_grad, 4.0, 25.0)
+        self.assertTrue(
+            paddle.equal_all(
+                actual_forward.astype("float32"),
+                expected_forward.astype("float32"),
+            )
+        )
+        self.assertTrue(
+            paddle.allclose(
+                actual_backward[0].astype("float32"),
+                expected_backward[0].astype("float32"),
+                rtol=1e-5,
+                atol=2e-8,
+            )
+        )
+        self.assertTrue(
+            paddle.equal_all(
+                actual_backward[1].astype("float32"),
+                expected_backward[1].astype("float32"),
+            )
+        )
+        self.assertTrue(
+            paddle.allclose(
+                actual_backward[2],
+                expected_backward[2],
+                rtol=1e-5,
+                atol=2e-5,
+            )
+        )
+
+    def test_triton_backward_optimized_and_fallback_widths(self):
+        paddle.seed(20260813)
+        for width, linear_beta in ((3072, None), (2048, 25.0)):
+            with self.subTest(width=width, linear_beta=linear_beta):
+                x = paddle.randn([17, 2 * width], dtype="bfloat16")
+                probs = paddle.rand([17], dtype="float32")
+                out_grad = paddle.randn([17, width], dtype="bfloat16")
+                expected = situ_glu_scale_backward(
+                    x,
+                    probs,
+                    out_grad,
+                    4.0,
+                    linear_beta,
+                    use_fused_situ_glu=False,
+                )
+                actual = situ_glu_scale_backward(
+                    x,
+                    probs,
+                    out_grad,
+                    4.0,
+                    linear_beta,
+                )
+
+                self.assertTrue(
+                    paddle.allclose(
+                        actual[0].astype("float32"),
+                        expected[0].astype("float32"),
+                        rtol=1e-5,
+                        # The fused and unfused paths can round one BF16 ULP
+                        # apart after storing the input gradient.
+                        atol=1e-4,
+                    )
+                )
+                self.assertTrue(
+                    paddle.equal_all(
+                        actual[1].astype("float32"),
+                        expected[1].astype("float32"),
+                    )
+                )
+                self.assertTrue(
+                    paddle.allclose(
+                        actual[2], expected[2], rtol=1e-5, atol=2e-5
+                    )
+                )
+
+    def test_default_fused_forward_supports_more_than_65535_rows(self):
+        rows = 65536
+        x = paddle.ones([rows, 8], dtype="bfloat16")
+        probs = paddle.ones([rows], dtype="float32")
+        expected = situ_glu_scale_forward(x, probs, use_fused_situ_glu=False)
+        actual = situ_glu_scale_forward(x, probs)
+        self.assertTrue(
+            paddle.equal_all(
+                actual.astype("float32"), expected.astype("float32")
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/transformer/test_situ_glu.py
+++ b/tests/single_card_tests/transformer/test_situ_glu.py
@@ -54,6 +54,17 @@ class TestSituGLU(unittest.TestCase):
         )
 
         self.assertIs(config.hidden_act, situ)
+        self.assertTrue(config.use_fused_situ_glu)
+
+        disabled_config = TransformerConfig.from_config(
+            SimpleNamespace(
+                hidden_size=8,
+                num_attention_heads=2,
+                hidden_act="situ",
+                use_fused_situ_glu=False,
+            )
+        )
+        self.assertFalse(disabled_config.use_fused_situ_glu)
 
     def test_matches_official_formula(self):
         x = paddle.linspace(-8.0, 8.0, 32).reshape([2, 16])
@@ -430,7 +441,12 @@ class TestSituGLU(unittest.TestCase):
         probs = paddle.rand([256], dtype="float32")
         out_grad = paddle.randn([256, hidden_size], dtype="bfloat16")
 
-        def run(deep_gemm, use_accuracy_compatible=False):
+        def run(
+            deep_gemm,
+            use_accuracy_compatible=False,
+            use_fused_situ_glu=True,
+        ):
+            config.use_fused_situ_glu = use_fused_situ_glu
             expert = GroupedMLPExpert(
                 num_local_experts=2,
                 config=config,
@@ -470,6 +486,7 @@ class TestSituGLU(unittest.TestCase):
         grouped = run(False)
         deep_gemm = run(True)
         accuracy_compatible = run(False, use_accuracy_compatible=True)
+        unfused_situ_glu = run(False, use_fused_situ_glu=False)
         tolerances = (
             (1e-3, 1e-3),
             (1e-3, 1e-3),
@@ -480,6 +497,7 @@ class TestSituGLU(unittest.TestCase):
         for path, actuals in (
             ("deep_gemm", deep_gemm),
             ("accuracy_compatible", accuracy_compatible),
+            ("unfused_situ_glu", unfused_situ_glu),
         ):
             for name, expected, actual, (atol, rtol) in zip(
                 (

--- a/tests/single_card_tests/transformer/test_situ_glu.py
+++ b/tests/single_card_tests/transformer/test_situ_glu.py
@@ -17,6 +17,7 @@ import subprocess
 import sys
 import unittest
 from types import SimpleNamespace
+from unittest import mock
 
 import paddle
 import paddle.nn.functional as F
@@ -44,6 +45,30 @@ from paddlefleet.transformer.transformer_config import TransformerConfig
 
 
 class TestSituGLU(unittest.TestCase):
+    def test_default_fused_falls_back_without_triton(self):
+        x = paddle.randn([3, 8], dtype="float32")
+        probs = paddle.rand([3], dtype="float32")
+        out_grad = paddle.randn([3, 4], dtype="float32")
+        expected_forward = situ_glu_scale_forward(
+            x, probs, use_fused_situ_glu=False
+        )
+        expected_backward = situ_glu_scale_backward(
+            x, probs, out_grad, use_fused_situ_glu=False
+        )
+
+        with mock.patch(
+            "paddlefleet.transformer.activations.is_triton_available",
+            return_value=False,
+        ):
+            actual_forward = situ_glu_scale_forward(x, probs)
+            actual_backward = situ_glu_scale_backward(x, probs, out_grad)
+
+        self.assertTrue(paddle.equal_all(actual_forward, expected_forward))
+        for actual, expected in zip(
+            actual_backward, expected_backward, strict=True
+        ):
+            self.assertTrue(paddle.equal_all(actual, expected))
+
     def test_config_resolves_situ_name(self):
         config = TransformerConfig.from_config(
             SimpleNamespace(

--- a/tests/single_card_tests/transformer/test_situ_glu.py
+++ b/tests/single_card_tests/transformer/test_situ_glu.py
@@ -57,7 +57,7 @@ class TestSituGLU(unittest.TestCase):
         )
 
         with mock.patch(
-            "paddlefleet.transformer.activations.is_triton_available",
+            "paddlefleet.triton_ops.utils.is_triton_available",
             return_value=False,
         ):
             actual_forward = situ_glu_scale_forward(x, probs)

--- a/tests/single_card_tests/transformer/test_situ_glu.py
+++ b/tests/single_card_tests/transformer/test_situ_glu.py
@@ -50,10 +50,10 @@ class TestSituGLU(unittest.TestCase):
         probs = paddle.rand([3], dtype="float32")
         out_grad = paddle.randn([3, 4], dtype="float32")
         expected_forward = situ_glu_scale_forward(
-            x, probs, use_fused_situ_glu=False
+            x, probs, situ_glu_fusion=False
         )
         expected_backward = situ_glu_scale_backward(
-            x, probs, out_grad, use_fused_situ_glu=False
+            x, probs, out_grad, situ_glu_fusion=False
         )
 
         with mock.patch(
@@ -79,17 +79,17 @@ class TestSituGLU(unittest.TestCase):
         )
 
         self.assertIs(config.hidden_act, situ)
-        self.assertTrue(config.use_fused_situ_glu)
+        self.assertTrue(config.situ_glu_fusion)
 
         disabled_config = TransformerConfig.from_config(
             SimpleNamespace(
                 hidden_size=8,
                 num_attention_heads=2,
                 hidden_act="situ",
-                use_fused_situ_glu=False,
+                situ_glu_fusion=False,
             )
         )
-        self.assertFalse(disabled_config.use_fused_situ_glu)
+        self.assertFalse(disabled_config.situ_glu_fusion)
 
     def test_matches_official_formula(self):
         x = paddle.linspace(-8.0, 8.0, 32).reshape([2, 16])
@@ -469,9 +469,9 @@ class TestSituGLU(unittest.TestCase):
         def run(
             deep_gemm,
             use_accuracy_compatible=False,
-            use_fused_situ_glu=True,
+            situ_glu_fusion=True,
         ):
-            config.use_fused_situ_glu = use_fused_situ_glu
+            config.situ_glu_fusion = situ_glu_fusion
             expert = GroupedMLPExpert(
                 num_local_experts=2,
                 config=config,
@@ -511,7 +511,7 @@ class TestSituGLU(unittest.TestCase):
         grouped = run(False)
         deep_gemm = run(True)
         accuracy_compatible = run(False, use_accuracy_compatible=True)
-        unfused_situ_glu = run(False, use_fused_situ_glu=False)
+        unfused_situ_glu = run(False, situ_glu_fusion=False)
         tolerances = (
             (1e-3, 1e-3),
             (1e-3, 1e-3),


### PR DESCRIPTION
### PR Category
Performance Optimization

### PR Types
Performance

### Description
- 为 FusionMoe BF16 routed expert 增加 exact-math Triton SiTU-GLU 前反向融合，并融合 router scaling。
- 新增默认开启的 `situ_glu_fusion` 开关，关闭时回退 Paddle 未融合实现。
- 针对 Kimi `N=3072` 优化 backward，并覆盖通用 width、长 row 和 `python -O` 参数校验。

### 是否引起精度变化
否
