### PR TITLE
[Devs] Enable dynamic p2p shape in BlockAttnRes VPP regression test

### DIFF
--- a/tests/multi_card_tests/pipeline_parallel/test_block_attn_res_vpp.py
+++ b/tests/multi_card_tests/pipeline_parallel/test_block_attn_res_vpp.py
@@ -142,6 +142,14 @@ class TestBlockAttnResVPPEquivalence(unittest.TestCase):
         self.batch_size = 12
         self.seq_len = 128
         self.vocab_size = 1024
+        self._env_backup = os.environ.get("BLOCK_ATTEN_RES_COMM_OPT")
+
+    def tearDown(self):
+        # _build_and_run flips this switch; do not leak it to other tests.
+        if self._env_backup is None:
+            os.environ.pop("BLOCK_ATTEN_RES_COMM_OPT", None)
+        else:
+            os.environ["BLOCK_ATTEN_RES_COMM_OPT"] = self._env_backup
 
     @unittest.skipUnless(
         FEATURE_AVAILABLE,
@@ -175,9 +183,14 @@ class TestBlockAttnResVPPEquivalence(unittest.TestCase):
                 "mp",
             ],
             # BlockAttnRes comm opt does not support the overlap scheduler.
+            # BlockAttnRes sends "hidden + blocks", and the number of blocks
+            # grows along the pipeline, so the p2p shape meta must not be
+            # cached across sends -> dynamic shape is required (VPP itself
+            # requires p2p_cache_shape, so this is the only way).
             "pp_configs": {
                 "forward_backward_overlap_scheduler": False,
                 "overlap_p2p_comm": False,
+                "enable_dynamic_shape": True,
             },
         }
         strategy.pipeline_configs = {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
修复 #1706 引入的 test_block_attn_res_vpp.py 在多卡下无法运行的问题。该用例在 pp=4/vpp=2 的基线跑（BLOCK_ATTEN_RES_COMM_OPT=0）中会在 _send_meta → check_send_message 处报 send_shape_message: (Size([1,128,512]),) vs actual_shape: (... ×5)：BlockAttnRes 场景下 PP 传输的是 hidden + blocks，blocks 数量沿流水线递增，每次 send 的 tensor 个数在变，而非 dynamic shape 模式下 p2p 的 shape meta 只发一次并缓存、后续 send 只做一致性校验，因此必然 assert 失败；VPP 调度又强制 p2p_cache_shape=True，关缓存不可行，故开启 pp_configs.enable_dynamic_shape，与 test_gpt_pp.py 等既有 VPP 多卡测试一致。同时在 tearDown 中还原 BLOCK_ATTEN_RES_COMM_OPT，避免环境变量泄漏到同进程其他用例。该用例在 PaddleFleet CI（发布版 paddle）仍为 skip，在 Paddle PR PaddlePaddle/Paddle#79517 的 Fleet 多卡 CI 中会实际执行，本次问题即由那里暴露。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否