### PR TITLE
[New features] Latent MQA full-causal attention runs as dense FA4 flashmask, with context parallel

### DIFF
--- a/packages/paddlefleet_ops/src/paddlefleet_ops/flash_mask_facade.py
+++ b/packages/paddlefleet_ops/src/paddlefleet_ops/flash_mask_facade.py
@@ -54,6 +54,11 @@ def get_fa_version(
           * ``head_dim <= 128`` and ``head_dim_v <= 128``
           * ``head_dim == 192`` and ``head_dim_v == 128``
           * ``head_dim == 256`` and ``head_dim_v == 256``
+          * ``head_dim == 512`` and ``head_dim_v == 512``, unless deterministic
+            is required
+          * ``head_dim == 576`` and ``head_dim_v == 512``, unless deterministic
+            is required -- both of these pairs take FA4's big-head-dim backward,
+            which has no ordered-accumulation variant.
         - ``mask_ok``: ``startend_row_indices is None`` or
           ``startend_row_indices.shape[-1] != 4``
 
@@ -91,8 +96,13 @@ def get_fa_version(
             (head_dim <= 128 and _head_dim_v <= 128)
             or (head_dim == 192 and _head_dim_v == 128)
             or (head_dim == 256 and _head_dim_v == 256)
-            or (head_dim == 512 and _head_dim_v == 512)
-            or (head_dim == 576 and _head_dim_v == 512)
+            # Both of these exceed 256 and so take FA4's big-head-dim backward,
+            # which asserts ``not deterministic`` (``flash_mask/cute/
+            # interface.py``: ``is_bigd_bwd`` -> "deterministic reduction is not
+            # supported by big-headdim bwd"). Degrade instead of aborting, the
+            # same way FA3 degrades above.
+            or (head_dim == 512 and _head_dim_v == 512 and not deterministic)
+            or (head_dim == 576 and _head_dim_v == 512 and not deterministic)
         )
         fa4_mask_ok = (
             startend_row_indices is None or startend_row_indices.shape[-1] != 4

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -2250,7 +2250,7 @@ class CompressedSparseAttention(FleetLayer):
         # indexer that is still being learned must not steer attention, so
         # ``_resolve_topk_effective`` returns ``n_compressed`` and the single
         # ``topk_effective`` below feeds the attention selection and
-        # ``FusedDSAIndexerLoss`` alike. Phase 3/4 narrows both to
+        # ``FusedDSAIndexerLoss`` alike. Phase 3 narrows both to
         # ``min(index_topk, n_compressed)``.
         indexer_backend = getattr(
             self.config, "csa_indexer_backend", "tilelang"

--- a/src/paddlefleet/transformer/mqa_latent_attention.py
+++ b/src/paddlefleet/transformer/mqa_latent_attention.py
@@ -24,8 +24,7 @@ phase has its own ``_forward_*`` with no loss code shared between them:
 * ``"mqa_full_causal"`` -> ``_forward_full_causal``. Latent MQA with the indexer
   dropped, attending to the full per-document causal set. Mathematically
   identical to the dense MHA phase, so it isolates the absorption from the
-  sparsity for equivalence experiments; ``O(s^2)`` in index memory and therefore
-  not a production mode.
+  sparsity for equivalence experiments.
 * ``"mqa_dsa"`` + ``dsa_indexer_use_sparse_loss=False`` -> ``_forward_warmup``
   (phase 2, DSA warmup, paired with ``train_indexer_only``). The backbone is
   frozen and the indexer is random, so **neither side uses top-k**: attention
@@ -38,6 +37,14 @@ phase has its own ``_forward_*`` with no loss code shared between them:
   selected set. This is the only phase that reads ``index_topk``.
 
 The indexer reuses the model-wide ``index_n_heads`` / ``index_head_dim``.
+
+The two full-causal phases attend over the whole per-document causal span, which
+is exactly what the caller's ``attn_mask_startend_row_indices`` already says, so
+they run as dense FA4 flashmask (``_dense_attn``), context parallel included.
+FA4 is their only backend: ``_assert_dense_fa4`` refuses to start rather than
+substitute one that would need an ``O(s^2)`` column table (see
+``_dense_attn`` for what that costs). Only phase 3 genuinely selects columns,
+and only it builds a table.
 
 Note the ``mqa_*`` modes here are *latent* MQA (this module). A
 ``csa_compress_ratios`` entry of ``-1`` is *CSA full-causal MQA*, a different
@@ -81,11 +88,14 @@ space the all-gathered KV is indexed in. ``attn_mask_startend_row_indices``
 already arrives at the global length under CP
 (``dsv4_hybrid_attention.py:634``), while ``query`` / ``key`` / ``x`` / ``qr``
 arrive local but RoPE'd with global positions
-(``multi_latent_attention.py:1485-1545``).
+(``multi_latent_attention.py:1485-1545``). The dense full-causal backend needs
+one extra step for the same reason -- its mask is a *row* bound, not a column id
+-- which ``_cp_row_bounds`` does.
 """
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -94,12 +104,14 @@ import paddle.nn.functional as F
 from paddle import Tensor
 from paddle.distributed.fleet.meta_parallel import LayerSpec, build_spec_layer
 
-from paddlefleet.context_parallel_utils import ContextParallelGatherOp
+from paddlefleet.context_parallel_utils import (
+    ContextParallelGatherOp,
+    preprocess_index,
+)
 from paddlefleet.process_groups_config import ProcessGroupCollection
 from paddlefleet.transformer.cp_utils import all_gather_cp
 from paddlefleet.transformer.csa_attention import (
     TileLangCSAIndexerLossAutoScaler,
-    _build_mqa_causal_topk_idxs_from_doc_bounds,
     _build_window_topk_idxs_from_doc_bounds,
     _derive_csa_doc_boundaries,
     _validate_csa_docmask_shape,
@@ -128,6 +140,50 @@ _LSE_INDEXER_TOPKS = (512, 1024, 2048)
 _TARGET_QHEAD_MIN = 16
 _NEG_INF = -1e30
 _EPS = 1e-10
+
+logger = logging.getLogger(__name__)
+
+
+def _dense_pylayer_inputs(
+    query: Tensor, key: Tensor, value: Tensor, sink: Tensor | None
+) -> tuple[Tensor, Tensor, Tensor, Tensor | None]:
+    """Make the flashmask ``PyLayer``'s differentiable inputs agree on freezing.
+
+    ``flashmask_attention`` is a ``PyLayer``, and Paddle requires its backward to
+    return ``None`` at exactly the positions whose forward input had
+    ``stop_gradient=True``. The flash kernel returns a dense gradient at every
+    position instead, so any *partially* frozen call aborts with
+    ``FlashMaskFunc's backward function should return None at N position``
+    (``py_layer_node.cc:213``). Frozen inputs are not exotic here: the warmup
+    phase runs under ``train_indexer_only``, which freezes the backbone, and the
+    attention sink is a parameter of its own, so which subset arrives frozen
+    depends on the configuration rather than on this layer.
+
+    Two regimes, and this returns the right thing for both:
+
+    * nothing wants a gradient -- pass everything through, so no grad node is
+      built at all and the contract never comes up;
+    * something wants one -- hand the kernel a detached ``stop_gradient=False``
+      view of each frozen input. The unwanted gradient lands on that throwaway
+      view and is dropped, the real tensor stays frozen and receives nothing,
+      and the forward is bit-identical (measured). Neither ``detach()`` alone
+      nor ``* 1.0`` works: both inherit ``stop_gradient``.
+
+    The sparse backend needs none of this -- it records
+    ``attn_sink_needs_grad`` itself (``csa_sparse_attn.py:178-182``).
+    """
+    tensors = (query, key, value, sink)
+    if all(t is None or t.stop_gradient for t in tensors):
+        return tensors
+
+    def proxy(t):
+        if t is None or not t.stop_gradient:
+            return t
+        out = t.detach()
+        out.stop_gradient = False
+        return out
+
+    return tuple(proxy(t) for t in tensors)
 
 
 class _HashableTensor(paddle.Tensor):
@@ -446,12 +502,8 @@ class MQALatentAttention(FleetLayer):
                 query,
                 kv,
                 v_b_proj_weight,
-                doc_start,
-                is_valid,
                 kv_lora_rank,
-                position_offset,
-                s,
-                s_global,
+                row_end,
             )
 
         if phase == "warmup":
@@ -469,6 +521,7 @@ class MQALatentAttention(FleetLayer):
                 position_offset,
                 s,
                 s_global,
+                row_end,
             )
 
         return self._forward_sparse(
@@ -494,12 +547,8 @@ class MQALatentAttention(FleetLayer):
         query: Tensor,
         kv: Tensor,
         v_b_proj_weight: Tensor,
-        doc_start: Tensor,
-        is_valid: Tensor,
         kv_lora_rank: int,
-        position_offset: int,
-        s_local: int,
-        s_global: int,
+        row_end: Tensor,
     ) -> Tensor:
         """Per-document full-causal attention on the absorbed latent.
 
@@ -511,14 +560,15 @@ class MQALatentAttention(FleetLayer):
         Used by two phases -- ``hybrid_mla_attention="mqa_full_causal"``, and
         the attention half of the phase-2 warmup, which must not consume the
         indexer's ranking while the indexer is still being learned.
+
+        One backend: dense FA4 flashmask (``_dense_attn``). "The whole causal
+        span" is already what ``attn_mask_startend_row_indices`` says, so the
+        mask stays ``O(s)``; ``_assert_dense_fa4`` rejects an environment where
+        FA4 would not serve it.
         """
-        b = int(query.shape[0])
-        token_indices = self._build_full_causal_indices(
-            b, s_global, doc_start, is_valid, position_offset, s_local
-        )
-        core_out = self._sparse_attn(
-            query, kv, token_indices, self.softmax_scale, kv_lora_rank
-        )
+        q_dim = int(query.shape[-1])
+        self._assert_dense_fa4(q_dim, kv_lora_rank, row_end)
+        core_out = self._dense_attn(query, kv, row_end, kv_lora_rank)
         return self._deabsorb(core_out, v_b_proj_weight, self.split_kv_b)
 
     # ------------------------------------------------------------------
@@ -539,31 +589,34 @@ class MQALatentAttention(FleetLayer):
         position_offset: int,
         s_local: int,
         s_global: int,
+        row_end: Tensor,
     ) -> Tensor:
         """Phase 2: frozen backbone, full-causal attention, full-causal KL.
 
         No top-k on either side. The two halves:
 
-        * **attention** is the same deterministic full-causal set phase 1 uses
-          (``_forward_full_causal``), so the frozen backbone sees exactly the
-          activations it was pretrained with while the indexer is still random.
+        * **attention** is the same deterministic full-causal set phase 1 uses,
+          so the frozen backbone sees exactly the activations it was pretrained
+          with while the indexer is still random -- literally the same
+          ``_forward_full_causal`` call.
         * **the indexer** is supervised over the *whole* per-document causal
           span, so it cannot reinforce its own initial ranking.
 
-        Both come from one tilelang call with ``topk_effective = s_global``, which
-        is the "full-candidate selection" mode ``csa_indexer_topk_fwd`` documents
-        for exactly this phase -- the CSA layers use it the same way with
-        ``topk_effective = n_compressed``. The kernel returns the softmax
+        The indexer half is one tilelang call with ``topk_effective = s_global``,
+        which is the "full-candidate selection" mode ``csa_indexer_topk_fwd``
+        documents for exactly this phase -- the CSA layers use it the same way
+        with ``topk_effective = n_compressed``. The kernel returns the softmax
         probabilities over every candidate column plus the column ids, and the
         head dimension never leaves the kernel; the backward is upstream's
         ``csa_indexer_bwd`` via ``TileLangCSAIndexerLossAutoScaler``, whose
         tilelang branch computes exactly ``(P - Q) * coeff / valid_rows``.
 
-        Recompute: the attention column table depends only on the document
-        boundaries, so the two forwards of a recompute segment are bit-identical
-        and there is no top-k tie-break to worry about. The loss is attached on
-        the grad-enabled forward only, so it is counted once; the no-grad forward
-        skips the indexer entirely rather than computing and discarding it.
+        Recompute: the attention mask is the caller's own row-end vector, so the
+        two forwards of a recompute segment are bit-identical and there is no
+        top-k tie-break to worry about. The loss is
+        attached on the grad-enabled forward only, so it is counted once; the
+        no-grad forward skips the indexer entirely rather than computing and
+        discarding it.
 
         CP: ``index_k`` is all-gathered to ``s_global`` inside
         ``forward_before_topk`` and ``kv`` by the caller, ``valid_range`` is built
@@ -577,12 +630,8 @@ class MQALatentAttention(FleetLayer):
             query,
             kv,
             v_b_proj_weight,
-            doc_start,
-            is_valid,
             kv_lora_rank,
-            position_offset,
-            s_local,
-            s_global,
+            row_end,
         )
         if not self._needs_indexer_loss():
             return output
@@ -704,28 +753,6 @@ class MQALatentAttention(FleetLayer):
     # ------------------------------------------------------------------
     # index construction / kernel plumbing
     # ------------------------------------------------------------------
-    @staticmethod
-    def _build_full_causal_indices(
-        b, s_global, doc_start, is_valid, position_offset=0, s_local=None
-    ) -> Tensor:
-        """Per-document full-causal ``[b, s_local, s_global]`` int32 (``-1`` pad).
-
-        Built over the global sequence and row-sliced to this CP rank, so the
-        column values stay global token ids. ``O(s_global^2)`` while building,
-        which is why this mode is an equivalence experiment, not production.
-        """
-        with paddle.no_grad():
-            indices, _ = _build_mqa_causal_topk_idxs_from_doc_bounds(
-                b, s_global, doc_start, is_valid
-            )
-            if s_local is not None and s_local != s_global:
-                indices = indices[
-                    :, position_offset : position_offset + s_local
-                ]
-            indices = indices.contiguous()
-        indices.stop_gradient = True
-        return indices
-
     def _indexer_projections(self, x, qr, position_offset, grad_enabled):
         """``(index_q, index_k, weights)`` from the DSA indexer.
 
@@ -825,6 +852,171 @@ class MQALatentAttention(FleetLayer):
             attn_sink=self.softmax_offset,
             indexer_topk=indexer_topk,
             sink_grad_fusion=self.sink_grad_fusion,
+        )
+
+    @staticmethod
+    def _assert_dense_fa4(q_dim: int, v_dim: int, row_end: Tensor) -> None:
+        """Refuse to run the full-causal phases on anything but FA4.
+
+        Applies to both phases that attend over the whole per-document causal
+        span -- ``mqa_full_causal`` and the attention half of the warmup. FA4 is
+        the only backend they support: query/key are
+        ``kv_lora_rank + qk_rope_head_dim`` wide while the value is only
+        ``kv_lora_rank``, a pair FA2/FA3 serve by padding the value out to the
+        query width, and the alternative of expanding the document mask into a
+        ``[b, s, s]`` column table for the sparse kernel costs ``O(s^2)`` memory
+        (100 GiB at s=65536 on the production geometry -- see ``_dense_attn``)
+        and is not addressable in int32 past s=46336. Neither is worth having as
+        a silent substitution, so fail here instead.
+
+        ``get_fa_version`` answers from the head-dim whitelist *and* two
+        process-global flags, so all three inputs go into the message -- the
+        head-dim pair alone rarely explains the answer. In particular
+        ``FLAGS_flash_attn_version`` must be 4, which production sets from the
+        compute capability (``TrainingArguments.__post_init__``, SM100 -> 4), and
+        ``FLAGS_cudnn_deterministic`` must be off, since FA4's big-head-dim
+        backward has no ordered-accumulation variant
+        (``flash_mask/cute/interface.py:1238,1249``).
+
+        Checked every forward rather than in ``__init__``: the flags are
+        settable at any point and the check is a whitelist lookup.
+        """
+        from paddlefleet_ops.flash_mask_facade import get_fa_version
+
+        fa_version = get_fa_version(q_dim, v_dim, row_end)
+        if fa_version != 4:
+            flags = paddle.get_flags(
+                ["FLAGS_flash_attn_version", "FLAGS_cudnn_deterministic"]
+            )
+            raise RuntimeError(
+                "latent MQA full-causal attention requires FA4 dense "
+                f"flashmask, but head dims ({q_dim}, {v_dim}) resolve to "
+                f"FA{fa_version}. FLAGS_flash_attn_version="
+                f"{flags['FLAGS_flash_attn_version']}, "
+                "FLAGS_cudnn_deterministic="
+                f"{flags['FLAGS_cudnn_deterministic']}. Run on a device whose "
+                "compute capability selects FA4 (SM100+, which is also what the "
+                "sparse phase-3 kernels require), leave "
+                "FLAGS_flash_attn_version at the value the trainer derives, and "
+                "keep FLAGS_cudnn_deterministic off -- FA4 has no deterministic "
+                "backward for this head-dim pair."
+            )
+
+    def _dense_attn(
+        self, query: Tensor, kv: Tensor, row_end: Tensor, kv_lora_rank: int
+    ) -> Tensor:
+        """Per-document dense causal MQA on the absorbed latent, via FA4.
+
+        Mathematically the same softmax over the same column set the phase-3
+        sparse kernel would compute from an explicit ``[b, s, s]`` table, but the
+        causal/document structure stays in ``startend_row_indices`` -- the
+        caller's own ``attn_mask_startend_row_indices``, already in flashmask's
+        per-column "masked from this row on" convention -- so the mask never gets
+        expanded.
+
+        That expansion is what would make the full-causal phases quadratic.
+        Measured peaks at s = 8192 / 32768 / 65536, production geometry (h=64,
+        d_v=256), net allocated over the module's own steady state:
+
+        * building the table alone: 1.6 / 25.0 / 100.0 GiB -- 6.25x the table's
+          own ``s^2`` int32 (0.25 / 4.0 / 16.0 GiB), the rest being int64
+          intermediates in ``_derive_csa_doc_boundaries``;
+        * dense forward + backward: 3.3 / 13.0 / 26.0 GiB, i.e. linear.
+
+        Past s=46336 that table is not merely expensive but unusable: the sparse
+        kernel flattens it with int32 ids
+        (``csa_sparse_attn_utils.py::_local_to_global_flat``, ``row * topk + col``
+        after padding ``topk`` up to 64), so the row base wraps -- measured
+        s=46337 returns finite but wrong numbers for its last 55 rows (cosine
+        0.7296 against this backend) and only s=46341 crashes.
+
+        The key is broadcast MQA (one head against ``h`` query heads) and the
+        value is its first ``kv_lora_rank`` channels, so nothing is materialised
+        per head. Output is flattened to the ``[b, s, h * kv_lora_rank]`` layout
+        ``_deabsorb`` consumes.
+
+        Under CP the row bounds are localised first and the kernel's own causal
+        mode is turned off; see ``_cp_row_bounds``.
+        """
+        from paddlefleet_ops.flash_mask_facade import flashmask_attention
+
+        if self.cp_size > 1:
+            row_end = self._cp_row_bounds(row_end, int(query.shape[1]))
+
+        key = kv.unsqueeze(2)
+        query, key, value, sink = _dense_pylayer_inputs(
+            query, key, key[..., :kv_lora_rank], self.softmax_offset
+        )
+        core_out = flashmask_attention(
+            query,
+            key,
+            value,
+            startend_row_indices=row_end,
+            causal=self.cp_size == 1,
+            learnable_sink=sink,
+            softmax_scale=self.softmax_scale,
+        )
+        b, s = core_out.shape[:2]
+        return core_out.reshape([b, s, -1])
+
+    def _cp_row_bounds(self, row_end: Tensor, s_local: int) -> Tensor:
+        """Global ``[LTS]`` row bounds -> this rank's local ``[LTS, UTE]`` pair.
+
+        ``flashmask_attention``'s own ``causal=True`` bottom-right-aligns the
+        diagonal: it masks column ``j`` above row ``j + seqlen_k - seqlen_q``
+        (``flash_mask/cute/flashmask_utils.py:650``, ``:411``, and the comment at
+        ``flash_bwd_sm100_bigd.py:2009``). Under CP this rank holds query rows
+        ``[cp_rank * s_local, (cp_rank + 1) * s_local)`` against an all-gathered
+        ``s_global`` key, so that implied offset -- ``s_global - s_local`` -- is
+        only the right one for the last rank. Handing the kernel the global
+        ``row_end`` with ``causal=True`` therefore returns *silently* wrong
+        numbers on every other rank (measured cosine 2.7e-1 at cp_size=2, no
+        exception), and the document bounds are wrong on every rank including the
+        last, since their values are global row ids compared against local ones.
+
+        The fix is the contract the rest of the model's CP attention already
+        uses: express the diagonal as an explicit second flashmask bound instead
+        of asking the kernel for it, then shift both bounds into this rank's row
+        space. ``DotProductAttention`` does exactly this at
+        ``dot_product_attention.py:614-617`` (``is_causal = False`` plus a
+        two-column mask), the HySparse MLA scorer at
+        ``multi_latent_attention.py:1233-1245``, and ``FlashMaskContextParallel``
+        rejects ``causal=True`` outright for the same reason
+        (``context_parallel_utils.py:1116-1119``).
+
+        With ``causal=False`` and two bounds the kernel reads them as
+        ``[LTS, UTE]`` (``flashmask_utils.py:261-270``) and masks
+        ``row >= LTS or row < UTE`` (``mask.py:513-518``), i.e. column ``j`` is
+        visible on rows ``[UTE_j, LTS_j)``. So ``UTE_j = j`` reproduces the
+        causal diagonal in *global* rows, ``LTS_j`` stays the caller's document
+        end, and ``preprocess_index`` -- the same helper
+        ``cp_flashmask_allgatherkv_balance_forward`` uses for this mode
+        (``context_parallel_utils.py:716-721``) -- shifts both by
+        ``cp_rank * s_local`` and clips to ``[0, s_local]``. Only
+        ``contiguous_allgather`` is localised this way, which is the only mode
+        this class accepts (``__init__``).
+
+        Worked example, ``s_global=8``, two documents ``0-3`` / ``4-7``,
+        ``cp_size=2``. Global bounds ``LTS=[4,4,4,4,8,8,8,8]``,
+        ``UTE=[0,1,2,...,7]``. On rank 1 (rows 4-7) they become
+        ``LTS'=[0,0,0,0,4,4,4,4]`` and ``UTE'=[0,0,0,0,0,1,2,3]``: document A's
+        columns are masked on every local row (``LTS'=0``), and column 5 is
+        visible on local rows 1-3, i.e. global rows 5-7. Both correct, where
+        ``causal=True`` on the unshifted bounds would have left document A fully
+        visible.
+        """
+        s_global = int(row_end.shape[2])
+        causal_end = paddle.arange(s_global, dtype=row_end.dtype).reshape(
+            [1, 1, s_global, 1]
+        )
+        bounds = paddle.concat(
+            [row_end, paddle.expand_as(causal_end, row_end)], axis=-1
+        )
+        return preprocess_index(
+            bounds,
+            chunk_id=self.cp_rank,
+            seq_blocksize=s_local,
+            max_seqlen_q=s_local,
         )
 
     @staticmethod

--- a/src/paddlefleet/transformer/mqa_latent_attention.py
+++ b/src/paddlefleet/transformer/mqa_latent_attention.py
@@ -878,25 +878,38 @@ class MQALatentAttention(FleetLayer):
         backward has no ordered-accumulation variant
         (``flash_mask/cute/interface.py:1238,1249``).
 
+        ``get_fa_version`` answers from flags alone and never checks that an FA4
+        backend exists, so the extension's availability is a separate condition
+        here. Without it the facade binds ``_flashmask_attention`` to Paddle's
+        native implementation (``flash_mask_facade.py``, the ``else`` branch of
+        the ``is_flash_mask_available()`` import guard), which serves neither
+        this head-dim pair nor the sink, and the failure would surface from
+        inside the kernel call as ``Invalid flash attention version: 4`` -- true
+        but not actionable.
+
         Checked every forward rather than in ``__init__``: the flags are
         settable at any point and the check is a whitelist lookup.
         """
+        from paddlefleet_ops import is_flash_mask_available
         from paddlefleet_ops.flash_mask_facade import get_fa_version
 
         fa_version = get_fa_version(q_dim, v_dim, row_end)
-        if fa_version != 4:
+        flash_mask_ok = is_flash_mask_available()
+        if fa_version != 4 or not flash_mask_ok:
             flags = paddle.get_flags(
                 ["FLAGS_flash_attn_version", "FLAGS_cudnn_deterministic"]
             )
             raise RuntimeError(
                 "latent MQA full-causal attention requires FA4 dense "
                 f"flashmask, but head dims ({q_dim}, {v_dim}) resolve to "
-                f"FA{fa_version}. FLAGS_flash_attn_version="
+                f"FA{fa_version} and flash_mask_available="
+                f"{flash_mask_ok}. FLAGS_flash_attn_version="
                 f"{flags['FLAGS_flash_attn_version']}, "
                 "FLAGS_cudnn_deterministic="
                 f"{flags['FLAGS_cudnn_deterministic']}. Run on a device whose "
                 "compute capability selects FA4 (SM100+, which is also what the "
-                "sparse phase-3 kernels require), leave "
+                "sparse phase-3 kernels require) with the flash_mask (cute) "
+                "extension built into paddlefleet_ops, leave "
                 "FLAGS_flash_attn_version at the value the trainer derives, and "
                 "keep FLAGS_cudnn_deterministic off -- FA4 has no deterministic "
                 "backward for this head-dim pair."

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -1798,9 +1798,14 @@ class TransformerConfig(ModelParallelConfig):
                 )
         if self.hybrid_mla_attention == "mqa_full_causal":
             logger.warning(
-                "hybrid_mla_attention='mqa_full_causal' builds a [b, s, s] int32 "
-                "index table per MLA layer (268 MB per layer at s=8192). It "
-                "exists to isolate absorption from sparsity, not to save memory."
+                "hybrid_mla_attention='mqa_full_causal' attends over the whole "
+                "per-document causal span on every MLA layer. It exists to "
+                "isolate absorption from sparsity, not to save memory. FA4 "
+                "dense flashmask is its only backend -- context parallelism "
+                "included -- so it needs an SM100+ box (as the sparse phases "
+                "do) with FLAGS_cudnn_deterministic off; anything else raises "
+                "in the first forward. See "
+                "MQALatentAttention._assert_dense_fa4."
             )
         if self.hybrid_mla_attention == "mqa_dsa":
             # On the ``-2`` layers ``dsa_indexer_use_sparse_loss`` decides both

--- a/tests/multi_card_tests/transformer/test_csa_attention_cp.py
+++ b/tests/multi_card_tests/transformer/test_csa_attention_cp.py
@@ -937,7 +937,7 @@ class TestCudnnIndexerDocmaskCP(unittest.TestCase):
     ``dsa_indexer_use_sparse_loss=False`` (phase 2, which is what
     ``_build_csa_config`` sets) the *main* attention widens to the full
     compressed range ``n_compressed``, because an indexer that is still being
-    learned must not steer attention; with ``True`` (phase 3/4) it narrows to
+    learned must not steer attention; with ``True`` (phase 3) it narrows to
     ``min(index_topk, n_compressed)``.
 
     The assertion below used to hard-code ``index_topk`` and only ran the
@@ -1079,7 +1079,7 @@ class TestCudnnIndexerDocmaskCP(unittest.TestCase):
                 n_compressed = run["n_compressed"]
                 sq_local = run["sq_local"]
                 # ``_resolve_topk_effective``: phase 2 hands the main attention
-                # the full compressed range, phase 3/4 the indexer's top-k.
+                # the full compressed range, phase 3 the indexer's top-k.
                 expected_topk = (
                     min(dsa_index_topk, n_compressed)
                     if use_sparse_loss

--- a/tests/multi_card_tests/transformer/test_mla_cp_contiguous_allgather.py
+++ b/tests/multi_card_tests/transformer/test_mla_cp_contiguous_allgather.py
@@ -468,7 +468,14 @@ class TestMLAContiguousAllgatherCP(unittest.TestCase):
     # absorption (:1913-1939), ``o_proj``, and every parameter gradient after
     # the CP all-reduce.
     def _check_mqa(self, attn_mode):
-        r = run_mla_cp(_row_end([200, 150, 162], 512), attn_mode=attn_mode)
+        # ``mqa_full_causal`` (and the phase-2 warmup) accept dense FA4 only --
+        # ``MQALatentAttention._assert_dense_fa4`` raises otherwise -- and a bare
+        # launcher process leaves the flag at the image default 2. Pin it to the
+        # value ``TrainingArguments.__post_init__`` derives on these SM100 boxes.
+        # Call-site scoped, not module scoped: ``test_4`` asserts on the refusal
+        # the *default* flag produces.
+        with U._flash_attn_version(4):
+            r = run_mla_cp(_row_end([200, 150, 162], 512), attn_mode=attn_mode)
         self.assertLess(r["fwd"], FWD_RTOL, f"{attn_mode}: forward")
         self.assertLess(r["dH"], GRAD_RTOL, f"{attn_mode}: dH")
         for n, v in r["param_err"].items():

--- a/tests/multi_card_tests/transformer/test_mla_cp_recompute.py
+++ b/tests/multi_card_tests/transformer/test_mla_cp_recompute.py
@@ -60,9 +60,26 @@ from paddle.distributed.fleet.utils import recompute
 FWD_RTOL = 1e-5
 GRAD_RTOL = 5e-3
 
+# ``"mqa"`` (``mqa_full_causal``) accepts dense FA4 only --
+# ``MQALatentAttention._assert_dense_fa4`` raises otherwise -- and a bare
+# launcher process leaves ``FLAGS_flash_attn_version`` at the image default 2.
+# Pin the value ``TrainingArguments.__post_init__`` derives on these SM100 boxes,
+# which is also production's for the ``mha`` and ``mqa_dsa`` cases. ``_fa4_pin``
+# stands down where no FA4 backend exists, because ``test_mha_recompute_cp`` is
+# not ``_GPU``-gated and has to keep running on the cc 9.0 CI images. Module
+# scope: nothing here asserts on the refusal
+# (``test_mla_cp_contiguous_allgather``'s ``test_4`` does, which is why that
+# file scopes its pin per call).
+_FA4_PIN = H.U._fa4_pin()
+
 
 def setUpModule():
     H.setUpModule()
+    _FA4_PIN.__enter__()
+
+
+def tearDownModule():
+    _FA4_PIN.__exit__(None, None, None)
 
 
 def _run_recompute_pair(mask_full, attn_mode, sink=False, seed=2026):

--- a/tests/multi_card_tests/transformer/test_mqa_dsa_cp.py
+++ b/tests/multi_card_tests/transformer/test_mqa_dsa_cp.py
@@ -43,6 +43,15 @@ the full-MLA integration):
 6. The attention sink under CP.
 7. The ``cp_balance_mode`` guard.
 
+Backend note: the full-causal phases (``mqa_full_causal`` and the phase-2 warmup)
+have dense FA4 as their only backend -- ``_assert_dense_fa4`` raises when the
+process flags do not resolve to it -- and a bare launcher process leaves
+``FLAGS_flash_attn_version`` at the image default 2. ``setUpModule`` therefore
+pins 4, the value ``TrainingArguments.__post_init__`` derives on the SM100 boxes
+these tests are gated to. A consequence is that no ``[b, s, s]`` column table
+exists on those phases, so the column-set assertion applies to the phase-3 DSA
+tests only.
+
 Run (2 GPUs), from the repository root::
 
     PYTHONPATH=.:./src python -m paddle.distributed.launch \
@@ -85,11 +94,19 @@ GRAD_RTOL = 2e-2
 # reproducible, so the index-set test below can demand exact equality.
 S_GLOBAL = 512
 
+# The full-causal phases refuse to run on anything but dense FA4, and a bare
+# launcher process never constructs ``TrainingArguments``, so the flag has to be
+# pinned to the value production derives on these boxes -- and left alone where
+# no FA4 backend exists, or the non-``_GPU``-gated cases would break. Module
+# scope: nothing here asserts on the refusal.
+_FA4_PIN = U._fa4_pin()
+
 
 def setUpModule():
     global CP_SIZE, CP_RANK, CP_GROUP
     if dist.get_world_size() < 2:
         raise unittest.SkipTest("MQA context-parallel tests require >= 2 GPUs")
+    _FA4_PIN.__enter__()
     world = dist.get_world_size()
     strategy = fleet.DistributedStrategy()
     strategy.hybrid_configs = {
@@ -116,6 +133,10 @@ def setUpModule():
     CP_GROUP = fleet.get_hybrid_communicate_group().get_context_parallel_group()
     CP_RANK = CP_GROUP.rank
     CP_SIZE = CP_GROUP.nranks
+
+
+def tearDownModule():
+    _FA4_PIN.__exit__(None, None, None)
 
 
 def _build(mode, cp_group, loss_coeff=0.0, sink=None, sparse_loss=True, seed=7):
@@ -200,6 +221,17 @@ def _logged_indexer_loss(layer_number=1):
     return float(values[layer_number - 1])
 
 
+def _last_captured():
+    """Last ``token_indices`` the sparse kernel saw, or ``None``.
+
+    ``None`` means no column table was built, which on these paths means a
+    full-causal phase ran: dense FA4 is their only backend. Which backend ran is
+    itself an assertion target (``test_mqa_dsa_warmup_cp.py::TestDenseFA4CP``),
+    so this returns ``None`` rather than raising.
+    """
+    return U._CAPTURED[-1] if U._CAPTURED else None
+
+
 def run_core_cp(
     mode,
     doc_lens,
@@ -248,7 +280,7 @@ def run_core_cp(
         input_ids=ids,
     )
     oa.sum().backward()
-    idx_ref = U._CAPTURED[-1]
+    idx_ref = _last_captured()
     logged_ref = _logged_indexer_loss()
 
     U._CAPTURED.clear()
@@ -272,7 +304,7 @@ def run_core_cp(
         input_ids=ids,
     )
     ob.sum().backward()
-    idx_cp = U._CAPTURED[-1]
+    idx_cp = _last_captured()
     logged_cp = _logged_indexer_loss()
 
     # Parameter grads: this rank only saw its own query rows, so the CP group's
@@ -308,7 +340,9 @@ def run_core_cp(
         "dw": _rel(dw, ra["w_v"].grad),
         "param_err": param_err,
         "per_pos": per_pos,
-        "idx_ref_slice": idx_ref[:, off : off + sl],
+        "idx_ref_slice": (
+            None if idx_ref is None else idx_ref[:, off : off + sl]
+        ),
         "idx_cp": idx_cp,
         # Raw tensors + the logged indexer loss, for the assertions that are not
         # a relative error: bitwise mode-vs-mode output equality, pad-row
@@ -364,7 +398,17 @@ class TestMQADSACP(unittest.TestCase):
         all-gathered ``kv``), so this is a plain set equality per row -- no
         offset arithmetic. Set equality rather than sequence equality because
         the top-k order churns; see the top-k reproducibility audit.
+
+        Only applicable to the phase-3 DSA path. The full-causal phases run dense
+        FA4 and build no column table at all, so ``None`` here means the caller
+        pointed this assertion at a phase that cannot support it.
         """
+        for key in ("idx_ref_slice", "idx_cp"):
+            self.assertIsNotNone(
+                res[key],
+                f"{tag}: {key} is None, so no column table was built; this "
+                "assertion only applies to the phase-3 sparse path",
+            )
         ref_sets = _row_sets(res["idx_ref_slice"])
         cp_sets = _row_sets(res["idx_cp"])
         self.assertEqual(len(ref_sets), len(cp_sets), f"{tag}: row count")
@@ -393,10 +437,13 @@ class TestMQADSACP(unittest.TestCase):
         A per-rank build would clip every row at ``q - position_offset``, i.e.
         drop the whole prefix owned by lower ranks, which shows up here as an
         O(1) forward error on rank > 0.
+
+        Dense FA4 encodes that table as an ``O(s)`` row bound rather than a
+        column list, so the forward/gradient equivalence is the whole
+        observable; ``_check_index_sets`` has nothing to read on this phase.
         """
         res = run_core_cp("mqa", _STRADDLE)
         self._check(res, "dense/3doc")
-        self._check_index_sets(res, "dense/3doc")
 
     # ------------------------------------------------------------------
     # 2. DSA path

--- a/tests/multi_card_tests/transformer/test_mqa_dsa_warmup_cp.py
+++ b/tests/multi_card_tests/transformer/test_mqa_dsa_warmup_cp.py
@@ -14,7 +14,7 @@
 
 """Context parallel for the DSA **warmup** phase, and for padded layouts.
 
-Two gaps in ``test_mqa_dsa_cp.py`` / ``test_mla_cp_contiguous_allgather.py``:
+Three gaps in ``test_mqa_dsa_cp.py`` / ``test_mla_cp_contiguous_allgather.py``:
 
 1. ``hybrid_mla_attention="mqa_dsa"`` with ``dsa_indexer_use_sparse_loss=False``
    -- the phase-2 (DSA warmup) pairing, where attention consumes the full
@@ -38,11 +38,28 @@ Two gaps in ``test_mqa_dsa_cp.py`` / ``test_mla_cp_contiguous_allgather.py``:
    audited on one card. ``[475] @ s=512`` puts 37 pad rows on the last rank
    only, which is also the pad-imbalance the loss denominator has to survive.
 
-Everything reuses ``test_mqa_dsa_cp``'s harness (fleet init, CP globals,
-``run_core_cp``, ``_check``, ``_check_index_sets``). No ``if rank == X``
-short-circuit exists in this file: every collective (``run_core_cp``'s
-all-reduces, the all-gather inside the layer) is issued on all ranks and only
-the assertions are rank-conditional.
+3. The way the **dense FA4** backend expresses the mask under CP. FA4 is the
+   only backend the full-causal phases have, and its mask is an ``O(s)`` *row*
+   bound rather than a column list, so localising it is a step the sparse phase-3
+   path simply does not have: the kernel's own ``causal=True`` bottom-right-aligns
+   the diagonal, which is wrong for every rank but the last, and the caller's
+   bounds carry global row ids. ``MQALatentAttention._cp_row_bounds`` replaces the
+   causal mode with an explicit second bound and shifts both into this rank's row
+   space. Neither error raises, so ``TestDenseFA4CP`` carries the control that
+   proves the checks can see an un-localised bound.
+
+Everything reuses ``test_mqa_dsa_cp``'s harness (fleet init, CP globals -- which
+includes its module-level ``FLAGS_flash_attn_version=4`` pin --, ``run_core_cp``,
+``_check``, ``_check_index_sets``). No ``if rank == X`` short-circuit exists in
+this file: every collective (``run_core_cp``'s all-reduces, the all-gather inside
+the layer) is issued on all ranks and only the assertions are rank-conditional.
+
+Note which observables exist on which phase. ``RecordingMQA`` captures a column
+table for the phase-3 sparse kernel, and for the dense backend only at CP=1,
+where it decodes the row bound it was handed; under CP the dense layer's bound is
+localised and its values are local row ids, so no ``[b, s, s]`` table is an
+honest reconstruction and ``idx_cp is None`` there. Dense CP claims are therefore
+made against outputs, gradients and the bounds themselves.
 
 Run (2 or 4 GPUs)::
 
@@ -54,7 +71,9 @@ test_mqa_dsa_warmup_cp.py
 """
 
 import unittest
+from unittest import mock
 
+import numpy as np
 import paddle
 import paddle.distributed as dist
 
@@ -116,6 +135,41 @@ def _local_slice():
     return H.CP_RANK * rows, rows
 
 
+def _bounds_column_sets(bounds, rows):
+    """Per-local-row visible column set implied by a ``[LTS, UTE]`` pair.
+
+    With ``causal=False`` and two bounds the kernel masks ``row >= LTS`` or
+    ``row < UTE`` (``mask.py:513-518``), i.e. column ``j`` is visible exactly on
+    rows ``[UTE_j, LTS_j)``. Inverting that per row is a decoding of the flashmask
+    semantics, independent of how ``_cp_row_bounds`` computed the numbers, which
+    is what makes it usable as the expectation's counterpart.
+    """
+    lts = bounds[0, 0, :, 0].tolist()
+    ute = bounds[0, 0, :, 1].tolist()
+    return [
+        {j for j in range(len(lts)) if ute[j] <= r < lts[j]}
+        for r in range(rows)
+    ]
+
+
+def _unlocalised_row_bounds(self, row_end, s_local):
+    """``_cp_row_bounds`` without the ``preprocess_index`` shift -- the bug.
+
+    Global ``[LTS, UTE]`` bounds compared against *local* row ids: the shapes
+    still check out and the kernel still runs, which is what made the naive
+    dense-under-CP call return silently wrong numbers. Used two ways -- decoded
+    directly (``TestWarmupCP::test_2``) and patched over the real method
+    (``TestDenseFA4CP::test_2``) -- to prove both levels of check can see it.
+    """
+    s_global = int(row_end.shape[2])
+    causal_end = paddle.arange(s_global, dtype=row_end.dtype).reshape(
+        [1, 1, s_global, 1]
+    )
+    return paddle.concat(
+        [row_end, paddle.expand_as(causal_end, row_end)], axis=-1
+    )
+
+
 class _CPChecks(unittest.TestCase):
     """Shared assertions, borrowed from the harness class.
 
@@ -137,7 +191,15 @@ class _CPChecks(unittest.TestCase):
         This is what separates the warmup mode from phase 3: under
         ``window + top-k`` a row longer than ``window + index_topk`` selects a
         strict subset, so this assertion would fail there.
+
+        ``idx`` is a ``[b, s_local, k]`` column table, which on the full-causal
+        phases only the CP=1 reference produces (``RecordingMQA`` decodes the row
+        bound it hands FA4); the CP layer's own set is checked through
+        ``_cp_row_bounds`` instead (``TestWarmupCP::test_2``).
         """
+        self.assertIsNotNone(
+            idx, f"{tag}: no column table was captured, nothing to check"
+        )
         off, rows = _local_slice()
         doc_start, is_valid = _doc_bounds(row_end, S_GLOBAL)
         for r in range(rows):
@@ -147,6 +209,70 @@ class _CPChecks(unittest.TestCase):
             self.assertEqual(
                 got, want, f"{tag}: row {r} (global {q}) is not full-causal"
             )
+
+    def _check_dense_pad(self, res, tag):
+        """Pad rows on the dense backend: zero output, zero ``dq``, no NaN.
+
+        The column table expresses a pad row as an all-``-1`` row; dense has no
+        table, so the same emptiness has to come out of the row bounds -- a pad
+        row's ``LTS`` clips to its document end, which is at or below the row, so
+        every column is masked. FA4 must then return an exactly zero row rather
+        than a NaN from an empty softmax. Rank-conditional assertions only; the
+        run itself is issued everywhere.
+        """
+        off, rows = _local_slice()
+        _, is_valid = _doc_bounds(res["row_end"], S_GLOBAL)
+        local_pad = [r for r in range(rows) if not is_valid[off + r]]
+        n_pad = paddle.to_tensor([len(local_pad)], dtype="int64")
+        dist.all_reduce(n_pad, group=H.CP_GROUP)
+        self.assertEqual(
+            int(n_pad[0]),
+            _N_PAD,
+            f"{tag}: the layout produced {int(n_pad[0])} pad rows, expected "
+            f"{_N_PAD} -- the fixture no longer tests what it claims",
+        )
+        out = res["out"].cast("float32")
+        dq = res["dq_local"].cast("float32")
+        for r in local_pad:
+            worst = float(out[0, r].abs().max())
+            self.assertEqual(
+                worst,
+                0.0,
+                f"{tag}: pad row {r} (global {off + r}) output max|.|={worst}",
+            )
+            worst = float(dq[0, r].abs().max())
+            self.assertEqual(
+                worst,
+                0.0,
+                f"{tag}: pad row {r} (global {off + r}) dq max|.|={worst}",
+            )
+        print(
+            f"[pad cp{H.CP_SIZE} rank{H.CP_RANK}] {tag}: "
+            f"local_pad_rows={len(local_pad)} fwd={res['fwd']:.2e}",
+            flush=True,
+        )
+
+    def _assert_loss_cp_sum(self, res, tag):
+        """Sum the per-rank logged loss and compare to the CP=1 value."""
+        total = paddle.to_tensor([res["logged_cp"]], dtype="float64")
+        dist.all_reduce(total, group=H.CP_GROUP)
+        got, want = float(total[0]), res["logged_ref"]
+        self.assertGreater(abs(want), 0.0, f"{tag}: reference logged no loss")
+        rel = abs(got - want) / abs(want)
+        print(
+            f"[warmup-cp{H.CP_SIZE} rank{H.CP_RANK}] {tag}: "
+            f"this_rank={res['logged_cp']:.6e} sum(loss)={got:.6e} "
+            f"ref={want:.6e} rel={rel:.3e}",
+            flush=True,
+        )
+        self.assertLess(
+            rel,
+            LOSS_RTOL,
+            f"{tag}: CP loss sum {got:.6e} != CP=1 {want:.6e} "
+            f"(rel {rel:.3e}); a per-rank denominator would be off by "
+            f"~{H.CP_SIZE}x",
+        )
+        return want
 
 
 class TestWarmupCP(_CPChecks):
@@ -162,6 +288,11 @@ class TestWarmupCP(_CPChecks):
         (``csa_indexer_topk_fwd`` with ``topk_effective=s_global``) over the
         whole causal set. Neither may perturb the attention output, so both are
         checked against the same reference.
+
+        The attended column set is read off the CP=1 reference, which is the
+        only side that can be decoded: dense FA4 is this phase's only backend and
+        ``RecordingMQA`` only reconstructs its row bound at ``cp_size == 1``. The
+        CP layer's own bound is checked in ``test_2``.
         """
         for coeff in (0.0, 0.1):
             with self.subTest(loss_coeff=coeff):
@@ -174,64 +305,70 @@ class TestWarmupCP(_CPChecks):
                     sparse_loss=False,
                 )
                 self._check(res, tag)
-                self._check_index_sets(res, tag)
-                self._assert_full_causal(res["idx_cp"], res["row_end"], tag)
+                self.assertIsNone(res["idx_cp"], f"{tag}: not dense")
+                self._assert_full_causal(
+                    res["idx_ref_slice"], res["row_end"], tag
+                )
 
     @H.U._GPU
-    def test_2_warmup_token_indices_are_the_global_table_row_sliced(self):
-        """The kernel's table == the global build, sliced -- bitwise.
+    def test_2_warmup_row_bounds_are_the_global_causal_set_localised(self):
+        """``_cp_row_bounds`` selects exactly this rank's full causal set.
 
-        A per-rank build (``s_local`` rows, ``doc_start`` sliced first) clips
-        each row at ``q - position_offset`` and drops the prefix owned by lower
-        ranks. The control at the end constructs exactly that and asserts it
-        differs, so this comparison cannot be vacuous on rank > 0.
+        The warmup's mask is the global per-document causal set restricted to
+        this rank's rows, and on the dense backend it is carried by an ``O(s)``
+        ``[LTS, UTE]`` pair rather than a column list. So decode the pair back
+        into per-row column sets (``_bounds_column_sets``, which only knows the
+        flashmask masking rule) and compare against the set the documents imply:
+        for local row ``r``, global ``q = off + r``, that is
+        ``[doc_start[q], q]`` -- and empty on a pad row.
+
+        No collectives here: the bounds are a pure function of ``row_end``,
+        ``cp_rank`` and ``s_local``, so the control can run unconditionally and
+        the assertions need no rank gating beyond the one place localisation is
+        provably a no-op.
         """
         off, rows = _local_slice()
-        res = H.run_core_cp("mqa_dsa", _STRADDLE, sparse_loss=False)
-        row_end = res["row_end"]
-        doc_start, _, is_valid, _, _ = _derive_csa_doc_boundaries(
-            row_end, S_GLOBAL
-        )
-        want = MQALatentAttention._build_full_causal_indices(
-            1, S_GLOBAL, doc_start, is_valid
-        )[:, off : off + rows]
-        got = paddle.to_tensor(res["idx_cp"])
-        self.assertEqual(list(got.shape), list(want.shape), "table shape")
-        drift = int((got.cast("int64") != want.cast("int64")).sum())
-        self.assertEqual(
-            drift,
-            0,
-            f"{drift} of {int(got.numel())} slots differ from the global table",
-        )
+        row_end = H.U._row_end(_STRADDLE, S_GLOBAL)
+        doc_start, is_valid = _doc_bounds(row_end, S_GLOBAL)
+        layer = H._build("mqa_dsa", H.CP_GROUP, sparse_loss=False)
 
-        # Control: the same builder driven at the local length, with the
-        # document starts rebased (and clipped) into local coordinates -- the
-        # shape a CP-unaware implementation would produce.
-        local = MQALatentAttention._build_full_causal_indices(
-            1,
-            rows,
-            paddle.clip(doc_start[off : off + rows] - off, min=0),
-            is_valid[off : off + rows],
-        )
+        got = _bounds_column_sets(layer._cp_row_bounds(row_end, rows), rows)
+        for r in range(rows):
+            q = off + r
+            want = set(range(doc_start[q], q + 1)) if is_valid[q] else set()
+            self.assertEqual(
+                got[r],
+                want,
+                f"local row {r} (global {q}) is visible over "
+                f"{sorted(got[r])[:8]}..., expected {sorted(want)[:8]}...",
+            )
         print(
-            f"[warmup-cp{H.CP_SIZE} rank{H.CP_RANK}] token_indices drift vs "
-            f"global table = {drift}",
+            f"[warmup-cp{H.CP_SIZE} rank{H.CP_RANK}] row bounds decode to the "
+            f"global causal set on all {rows} local rows",
             flush=True,
         )
+
+        # Control: the same bounds without the ``preprocess_index`` shift, i.e.
+        # global row ids compared against local ones. Rank 0's localisation is
+        # ``clip(x, 0, s_local)``, and clipping an over-large bound masks the
+        # same rows as leaving it over-large, so only rank > 0 can see this.
         if H.CP_RANK == 0:
             return
-        self.assertGreater(
-            int((local.cast("int64") != want[:, :, :rows].cast("int64")).sum()),
-            0,
-            "a per-rank index build was indistinguishable from the global "
-            "one, so this test is vacuous",
+        bad = _bounds_column_sets(
+            _unlocalised_row_bounds(layer, row_end, rows), rows
+        )
+        self.assertNotEqual(
+            bad,
+            got,
+            "un-localised row bounds decoded to the same column sets, so this "
+            "test cannot see a missing preprocess_index",
         )
 
     @H.U._GPU
     def test_3_warmup_equals_mqa_full_causal_under_cp(self):
         """Warmup output == ``hybrid_mla_attention="mqa_full_causal"`` output.
 
-        Both modes call ``_build_full_causal_indices`` and then the same sparse
+        Both modes reach the same ``_cp_row_bounds`` and then the same dense FA4
         kernel with the same inputs -- ``_forward_warmup`` reaches it *through*
         ``_forward_full_causal`` -- so on each rank this must be *bitwise* equal,
         not merely close. The single-card claim (maxabs 0.0) is asserted here
@@ -338,28 +475,6 @@ class TestWarmupCP(_CPChecks):
             "test_4 is width-blind",
         )
 
-    def _assert_loss_cp_sum(self, res, tag):
-        """Sum the per-rank logged loss and compare to the CP=1 value."""
-        total = paddle.to_tensor([res["logged_cp"]], dtype="float64")
-        dist.all_reduce(total, group=H.CP_GROUP)
-        got, want = float(total[0]), res["logged_ref"]
-        self.assertGreater(abs(want), 0.0, f"{tag}: reference logged no loss")
-        rel = abs(got - want) / abs(want)
-        print(
-            f"[warmup-cp{H.CP_SIZE} rank{H.CP_RANK}] {tag}: "
-            f"this_rank={res['logged_cp']:.6e} sum(loss)={got:.6e} "
-            f"ref={want:.6e} rel={rel:.3e}",
-            flush=True,
-        )
-        self.assertLess(
-            rel,
-            LOSS_RTOL,
-            f"{tag}: CP loss sum {got:.6e} != CP=1 {want:.6e} "
-            f"(rel {rel:.3e}); a per-rank denominator would be off by "
-            f"~{H.CP_SIZE}x",
-        )
-        return want
-
 
 class TestPadRowsCP(_CPChecks):
     """``[475] @ s=512``: 37 real pad rows, all on the last CP rank.
@@ -383,73 +498,138 @@ class TestPadRowsCP(_CPChecks):
         )
 
     def _check_pad(self, res, tag):
+        """``_check_dense_pad`` plus the column table's own emptiness.
+
+        Phase 3 keeps a real ``[b, s, k]`` table, so a pad row must additionally
+        show up there as an all-``-1`` row. The full-causal phases have no table
+        (dense FA4 only), which is why the zero-output/zero-``dq`` half lives in
+        ``_CPChecks`` on its own.
+        """
+        self._check_dense_pad(res, tag)
         off, rows = _local_slice()
         _, is_valid = _doc_bounds(res["row_end"], S_GLOBAL)
-        local_pad = [r for r in range(rows) if not is_valid[off + r]]
-
-        # The layout must actually produce pad rows *somewhere*: assert it on
-        # the group, not on this rank, since only the last rank owns them.
-        n_pad = paddle.to_tensor([len(local_pad)], dtype="int64")
-        dist.all_reduce(n_pad, group=H.CP_GROUP)
-        self.assertEqual(
-            int(n_pad[0]),
-            _N_PAD,
-            f"{tag}: the layout produced {int(n_pad[0])} pad rows, expected "
-            f"{_N_PAD} -- the fixture no longer tests what it claims",
-        )
-
-        out = res["out"].cast("float32")
-        dq = res["dq_local"].cast("float32")
-        for r in local_pad:
-            self.assertEqual(
-                float(out[0, r].abs().max()),
-                0.0,
-                f"{tag}: pad row {r} (global {off + r}) has a non-zero output",
-            )
-            self.assertEqual(
-                float(dq[0, r].abs().max()),
-                0.0,
-                f"{tag}: pad row {r} (global {off + r}) has a non-zero dq",
-            )
+        for r in range(rows):
+            if is_valid[off + r]:
+                continue
             cols = res["idx_cp"][0][r]
             self.assertEqual(
                 int((cols >= 0).sum()),
                 0,
                 f"{tag}: pad row {r} (global {off + r}) selected columns",
             )
-        print(
-            f"[padrows-cp{H.CP_SIZE} rank{H.CP_RANK}] {tag}: "
-            f"local_pad_rows={len(local_pad)} fwd={res['fwd']:.2e} "
-            f"per_pos_max={max(res['per_pos']):.3e}",
-            flush=True,
-        )
 
     @H.U._GPU
     def test_1_pad_rows_mqa_full_causal(self):
         res = self._run("mqa", True)
         self._check(res, "pad/mqa_full_causal")
-        self._check_index_sets(res, "pad/mqa_full_causal")
-        self._check_pad(res, "pad/mqa_full_causal")
+        self.assertIsNone(res["idx_cp"], "pad/mqa_full_causal: not dense")
+        self._check_dense_pad(res, "pad/mqa_full_causal")
 
     @H.U._GPU
     def test_2_pad_rows_warmup(self):
         res = self._run("mqa_dsa", False)
         self._check(res, "pad/warmup")
-        self._check_index_sets(res, "pad/warmup")
-        self._assert_full_causal(res["idx_cp"], res["row_end"], "pad/warmup")
-        self._check_pad(res, "pad/warmup")
+        self.assertIsNone(res["idx_cp"], "pad/warmup: not dense")
+        self._assert_full_causal(
+            res["idx_ref_slice"], res["row_end"], "pad/warmup"
+        )
+        self._check_dense_pad(res, "pad/warmup")
 
     @H.U._GPU
     def test_3_pad_rows_sparse(self):
         """Same layout on the phase-3 (``window + top-k``) path.
 
         Included so a pad-row failure can be attributed: if it reproduces here
-        it is not specific to the warmup branch this change introduced.
+        it is not specific to the warmup branch this change introduced. This is
+        also the only one of the three that still has a column table to check.
         """
         res = self._run("mqa_dsa", True)
         self._check(res, "pad/sparse")
         self._check_index_sets(res, "pad/sparse")
         self._check_pad(res, "pad/sparse")
+
+
+class TestDenseFA4CP(_CPChecks):
+    """The dense FA4 full-causal backend under CP -- the production path.
+
+    Dense FA4 is the *only* backend the full-causal phases have, so every test
+    in this file already runs it; what is left here is the part of the contract
+    only this backend has. FA4's ``causal=True`` bottom-right-aligns the diagonal
+    from the *shapes*, which under CP is right for the last rank alone, and the
+    caller's row bounds carry global row ids. So ``_dense_attn`` turns the
+    kernel's causal mode off and localises both bounds through
+    ``preprocess_index`` (``MQALatentAttention._cp_row_bounds``). Neither error
+    raises -- both return finite numbers -- hence ``test_2``'s control, which is
+    the end-to-end counterpart of ``TestWarmupCP::test_2``'s decoding of the
+    bounds themselves.
+    """
+
+    @H.U._GPU
+    def test_1_dense_cp_equals_dense_cp1_with_a_sink(self):
+        """The CP contract with the attention sink live, both full-causal phases.
+
+        The sink is a per-head logit that FA4 takes as ``learnable_sink`` -- in
+        bf16, which is why the fixture creates it in the module dtype -- and
+        whose gradient is accumulated over this rank's rows only, so the group's
+        SUM is what has to match (``param_err['softmax_offset']``). Sinkless
+        equivalence on the same layout is ``TestWarmupCP::test_1`` and
+        ``test_mqa_dsa_cp::test_2``.
+        """
+        sink = np.linspace(-1.0, 1.0, H.U.H)
+        for mode, sparse_loss in (("mqa", True), ("mqa_dsa", False)):
+            with self.subTest(mode=mode):
+                tag = f"dense-sink/{mode}"
+                res = H.run_core_cp(
+                    mode,
+                    _STRADDLE,
+                    sparse_loss=sparse_loss,
+                    sink=sink,
+                    loss_coeff=0.1 if mode == "mqa_dsa" else 0.0,
+                    with_input_ids=mode == "mqa_dsa",
+                )
+                self.assertIsNone(res["idx_cp"], f"{tag}: not dense")
+                self._check(res, tag)
+                self.assertIn(
+                    "softmax_offset",
+                    res["param_err"],
+                    f"{tag}: the sink received no gradient",
+                )
+
+    @H.U._GPU
+    def test_2_unlocalised_bounds_are_detectably_wrong(self):
+        """Control: drop the ``preprocess_index`` shift and the checks must fail.
+
+        Global bounds against local rows is the naive call, and it neither raises
+        nor produces obviously broken output -- it is a plausible
+        implementation. Every forward equivalence claim in this file is only
+        worth something if it can see it.
+
+        Observable on rank > 0 only: ``preprocess_index`` at ``chunk_id == 0`` is
+        ``clip(x, 0, s_local)``, and clipping a bound to ``s_local`` masks
+        exactly the same rows as leaving it above ``s_local``, so rank 0's
+        localisation is a no-op by construction. The run itself happens on every
+        rank -- it all-gathers the KV -- and only the assertion is
+        rank-conditional.
+        """
+        good = H.run_core_cp("mqa", _STRADDLE)
+        with mock.patch.object(
+            MQALatentAttention, "_cp_row_bounds", _unlocalised_row_bounds
+        ):
+            bad = H.run_core_cp("mqa", _STRADDLE)
+        print(
+            f"[dense-cp{H.CP_SIZE} rank{H.CP_RANK}] control: localised "
+            f"fwd={good['fwd']:.3e} unlocalised fwd={bad['fwd']:.3e}",
+            flush=True,
+        )
+        if H.CP_RANK == 0:
+            return
+        self.assertGreater(
+            bad["fwd"],
+            100.0 * max(good["fwd"], 1e-6),
+            "un-localised row bounds were indistinguishable from localised "
+            f"ones (good={good['fwd']:.3e} bad={bad['fwd']:.3e}), so this "
+            "file's forward equivalence cannot see a CP mask bug",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/single_card_tests/transformer/hybrid_mla_utils.py
+++ b/tests/single_card_tests/transformer/hybrid_mla_utils.py
@@ -40,7 +40,10 @@ import paddle
 import paddle.nn.functional as F
 from paddle.distributed.fleet.meta_parallel import LayerSpec
 
-from paddlefleet.transformer.csa_attention import _derive_csa_doc_boundaries
+from paddlefleet.transformer.csa_attention import (
+    _build_mqa_causal_topk_idxs_from_doc_bounds,
+    _derive_csa_doc_boundaries,
+)
 from paddlefleet.transformer.dsa_attention import (
     DSAIndexer,
     DSAIndexerSublayersSpec,
@@ -52,6 +55,23 @@ from paddlefleet.transformer.mqa_latent_attention import (
 )
 from paddlefleet.transformer.transformer_config import TransformerConfig
 from paddlefleet.utils import init_method_normal, scaled_init_method_normal
+
+# An installed ``paddlefleet`` wheel shadows this checkout whenever the source
+# tree misses from ``sys.path`` -- a mistyped ``PYTHONPATH`` is enough, and the
+# symptom is not an ImportError but a stale class: every test that touches a
+# method added after the wheel was built dies with a bare
+# ``AttributeError: 'RecordingMQA' object has no attribute '_dense_attn'`` out of
+# ``Layer.__getattr__``, which says nothing about where the class came from.
+# Name the resolved file instead. ``_dense_attn`` is only a marker; any method
+# this file's fixtures rely on would do.
+if not hasattr(MQALatentAttention, "_dense_attn"):
+    raise ImportError(
+        "MQALatentAttention was imported from "
+        f"{sys.modules[MQALatentAttention.__module__].__file__}, which predates "
+        "the code these fixtures test (no _dense_attn). Put the PaddleFleet "
+        "source tree ahead of site-packages on PYTHONPATH -- e.g. "
+        "PYTHONPATH=<checkout>:<checkout>/src."
+    )
 
 # ---------------------------------------------------------------------------
 # Geometry. DK/DV are hard requirements of the FlashMLA sparse kernel
@@ -211,7 +231,20 @@ _CAPTURED = []
 
 
 class RecordingMQA(MQALatentAttention):
-    """Captures the ``token_indices`` handed to the sparse kernel."""
+    """Captures, as a column table, what each backend was asked to attend over.
+
+    ``_sparse_attn`` (phase 3) receives that table literally. The full-causal
+    phases hand FA4 an ``O(s)`` flashmask row bound instead and never materialise
+    anything, so ``_dense_attn`` records the column set that bound *implies*,
+    derived from the very tensor the kernel is about to get. Both land in
+    ``_CAPTURED`` in call order, so a test can ask "what did attention see"
+    without caring which backend served it, and a recompute test still counts two
+    entries per recomputed step.
+
+    Skipped when ``cp_size > 1``: the bound is localised inside ``_dense_attn``
+    and its values are global row ids, so no per-rank ``[b, s, s]`` table is the
+    honest reconstruction. The CP suites assert on outputs and gradients instead.
+    """
 
     def _sparse_attn(
         self, query, kv, token_indices, sm_scale, d_v, indexer_topk=0
@@ -220,6 +253,29 @@ class RecordingMQA(MQALatentAttention):
         return super()._sparse_attn(
             query, kv, token_indices, sm_scale, d_v, indexer_topk
         )
+
+    def _dense_attn(self, query, kv, row_end, kv_lora_rank):
+        if self.cp_size == 1:
+            _CAPTURED.append(_row_end_column_table(row_end).numpy())
+        return super()._dense_attn(query, kv, row_end, kv_lora_rank)
+
+
+def _row_end_column_table(row_end):
+    """``[b, s, s]`` int32 column set implied by a flashmask row bound.
+
+    The dense backend's ``O(s)`` mask, written out. Same builder the CP suites
+    use (``_full_causal_indices``), fed from the document boundaries the
+    production deriver reads out of the bound itself, so this is a decoding of
+    what the kernel was told rather than a second opinion about it.
+    """
+    seqlen = int(row_end.shape[-2])
+    with paddle.no_grad():
+        doc_start, _, is_valid, _, _ = _derive_csa_doc_boundaries(
+            row_end, seqlen
+        )
+    return _full_causal_indices(
+        int(row_end.shape[0]), seqlen, doc_start, is_valid
+    )
 
 
 def _build_module(
@@ -304,9 +360,58 @@ def _row_end(doc_lens, seqlen):
     return paddle.to_tensor(out).reshape([1, 1, seqlen, 1])
 
 
+def _pad_row_end(doc_lens, seqlen):
+    """``[1, 1, s, 1]`` int32 ``row_end`` that produces real pad rows.
+
+    ``_row_end`` fills the trailing gap with ``seqlen``, which
+    ``_derive_csa_doc_boundaries`` reads as one more document, so every row comes
+    back ``is_valid``. Repeating the *last document's* end instead leaves
+    ``doc_len_per_pos`` short of ``pos_in_doc`` for the tail, which is the
+    ``is_valid == False`` state a packed batch's padding actually takes.
+    """
+    out = np.empty([seqlen], dtype="int32")
+    pos, end = 0, 0
+    for length in doc_lens:
+        end = pos + length
+        out[pos : min(end, seqlen)] = end
+        pos = end
+        if pos >= seqlen:
+            break
+    if pos < seqlen:
+        out[pos:] = end
+    return paddle.to_tensor(out).reshape([1, 1, seqlen, 1])
+
+
 def _doc_meta(row_end, seqlen):
     doc_start, _, is_valid, _, _ = _derive_csa_doc_boundaries(row_end, seqlen)
     return doc_start.numpy(), is_valid.numpy()
+
+
+def _full_causal_indices(
+    b, s_global, doc_start, is_valid, position_offset=0, s_local=None
+):
+    """Per-document full-causal ``[b, s_local, s_global]`` int32 (``-1`` pad).
+
+    The column set the two full-causal phases attend over, written out as an
+    explicit table. Production never materialises it -- ``_dense_attn`` hands the
+    same set to FA4 as an ``O(s)`` row bound -- so this lives on the test side,
+    with two uses: as an independent derivation of what the dense mask must be,
+    and as the input for feeding the sparse kernel directly (``_sparse_attn``)
+    when a test wants the two backends compared.
+
+    Built over the global sequence and row-sliced afterwards, so the column
+    values stay global token ids -- which is what the all-gathered KV of a CP
+    rank is indexed in.
+    """
+    with paddle.no_grad():
+        indices, _ = _build_mqa_causal_topk_idxs_from_doc_bounds(
+            b, s_global, doc_start, is_valid
+        )
+        if s_local is not None and s_local != s_global:
+            indices = indices[:, position_offset : position_offset + s_local]
+        indices = indices.contiguous()
+    indices.stop_gradient = True
+    return indices
 
 
 def _make_inputs(seqlen, seed=0, with_hidden=False):
@@ -326,6 +431,79 @@ def _rel(actual, expected):
     a = actual.cast("float32")
     e = expected.cast("float32")
     return float((a - e).norm() / e.norm().clip(min=1e-12))
+
+
+# One bf16 ULP, relative: bf16 carries 8 significant bits, so the smallest
+# representable step at magnitude ``m`` is ``m * 2**-8``.
+_BF16_ULP = 2.0**-8
+
+# How many of those steps a re-reduction is allowed to move the result by. The
+# measured worst case over every layout these suites use is 1.63 ULPs of the
+# compared slice's own maximum (layout ``[127]`` at ``s=256``, second document,
+# with a sink: 3.906e-03 at slice scale 0.613); 4 leaves ~2.5x headroom without
+# coming near the ~240 ULPs that losing document isolation costs on the same
+# tensors.
+_ULP_BUDGET = 4
+
+
+def _assert_agrees_to_bf16_ulps(test, actual, expected, msg):
+    """Two runs of the same mathematical softmax agree to a few bf16 ULPs.
+
+    Bit equality is the wrong bar whenever the two sides do not reduce in the
+    same order, and on these paths there are two ways that happens:
+
+    * *repacking* -- FA4 derives its tile scheduling, hence its accumulation
+      order, from the flashmask row bounds, so a packed batch and a
+      single-document run of the same rows are not bitwise equal even though
+      they sum over the same columns;
+    * *changing backend* -- the phase-3 sparse kernel reduces each query row over
+      an explicit column list in a fixed order, dense FA4 does not, so a claim
+      that the two agree on a layout where their column sets coincide is also
+      only an ULP claim.
+
+    A bit-equality assertion written against the sparse backend therefore does
+    not transfer. The tolerance is ``_ULP_BUDGET`` ULPs of the compared slice's
+    own scale; see that constant for the measurement behind it. Losing document
+    isolation -- the property most callers are actually testing -- costs the
+    output scale itself, some 240 ULPs, so the assertion still fails on a real
+    leak. ``_assert_isolation_is_observable`` pins that separation down where the
+    non-isolated variant is cheap to build.
+
+    Both arguments are fp32 numpy (the bf16 widening is exact).
+    """
+    worst = float(np.abs(actual - expected).max())
+    bound = _ulp_bound(actual)
+    test.assertLessEqual(
+        worst,
+        bound,
+        f"{msg}: maxabs {worst:.3e} > {_ULP_BUDGET} bf16 ULP {bound:.3e}",
+    )
+    return worst
+
+
+def _ulp_bound(reference):
+    return _ULP_BUDGET * _BF16_ULP * max(float(np.abs(reference).max()), 1e-6)
+
+
+def _assert_isolation_is_observable(test, worst, leaked, packed):
+    """The ULP bound of ``_assert_agrees_to_bf16_ulps`` is not vacuous.
+
+    ``leaked`` is the same comparison run against a deliberately non-isolated
+    forward (one document spanning the whole sequence). It has to miss by at
+    least an order of magnitude more than the tolerance the isolated case was
+    allowed, or the tolerance would be hiding cross-document attention.
+
+    Only meaningful for a document that does not start at row 0: the *first*
+    document's causal set is the same with and without isolation, so there the
+    control is identically zero and proves nothing either way.
+    """
+    bound = _ulp_bound(packed)
+    test.assertGreater(
+        leaked,
+        10.0 * bound,
+        f"a non-isolated forward only differs by {leaked:.3e}, so the "
+        f"{bound:.3e} tolerance on {worst:.3e} proves nothing",
+    )
 
 
 def _dense_reference(query, key, w_v, row_end, scale, sink=None):
@@ -456,7 +634,7 @@ _FULL_CAUSAL_CFG = "ernielite_layer43_non_absorbed_mqa_dense"
 # Phase 2 (DSA warmup): ``hybrid_mla_attention="mqa_dsa"`` +
 # ``dsa_indexer_use_sparse_loss=false`` + YAML ``train_indexer_only=true``.
 _DSA_CFG = "ernielite_layer43_non_absorbed_mqa_hca_dsa"
-# Phase 3/4: ``hybrid_mla_attention="mqa_dsa"`` +
+# Phase 3: ``hybrid_mla_attention="mqa_dsa"`` +
 # ``dsa_indexer_use_sparse_loss=true``, backbone unfrozen.
 _DSA_SPARSE_LOSS_CFG = "ernielite_layer43_non_absorbed_mqa_hca_dsa_sparse_loss"
 # CSA full-causal MQA (``csa_compress_ratios == -1``). NOT a hybrid-MLA config:
@@ -598,6 +776,62 @@ def _flash_attn_version(value):
         paddle.set_flags({key: previous})
 
 
+def _fa4_can_serve():
+    """Whether pinning ``FLAGS_flash_attn_version=4`` can actually be served.
+
+    ``flash_mask_facade.get_fa_version`` answers from the flag and the head dims
+    alone -- it never checks that a FA4 backend exists. With no cute kernel the
+    facade's ``_flashmask_attention`` is ``paddle.nn.functional``'s, which knows
+    only 2 and 3 and raises ``ValueError: Invalid flash attention version: 4``
+    (``paddle/nn/functional/flash_attention.py:2179``) for *every* head-dim pair
+    the facade whitelists, ``(256, 256)`` plain MHA included. The upstream CI
+    images are cc 9.0 without the kernel, so pinning 4 unconditionally would
+    break the ``mha`` cases, which are not ``_GPU``-gated and used to run there
+    on the image default 2.
+    """
+    try:
+        from paddlefleet_ops import is_flash_mask_available
+    except ImportError:  # pragma: no cover - packaged build always has it
+        return False
+    return bool(is_flash_mask_available()) and _production_fa_version() == 4
+
+
+@contextlib.contextmanager
+def _fa4_pin():
+    """``_flash_attn_version(4)`` where FA4 can serve, a no-op where it cannot.
+
+    The full-causal phases have exactly one backend, and
+    ``MQALatentAttention._assert_dense_fa4`` raises when the process flags do not
+    resolve to FA4, so a module running such a forward has to reproduce the
+    production flag value. Those cases are all ``_GPU``-gated to the SM100 boxes,
+    where ``_fa4_can_serve()`` is True -- and the same modules also hold ``mha``
+    cases that do run without FA4, which is why the pin has to stand down rather
+    than force a value the box cannot honour.
+    """
+    if not _fa4_can_serve():
+        yield
+        return
+    with _flash_attn_version(4):
+        yield
+
+
+def _fa4_module_hooks():
+    """``(setUpModule, tearDownModule)`` wrapping the module in ``_fa4_pin()``.
+
+    Doing it once per module beats repeating the pin at every call site, and the
+    restore keeps it from leaking into modules that assert on the refusal.
+    """
+    pin = _fa4_pin()
+
+    def setUpModule():
+        pin.__enter__()
+
+    def tearDownModule():
+        pin.__exit__(None, None, None)
+
+    return setUpModule, tearDownModule
+
+
 def _production_fa_version():
     """The ``fa_version`` the production trainer would pick on this box."""
     major, minor = paddle.device.cuda.get_device_capability()
@@ -606,6 +840,24 @@ def _production_fa_version():
     if (major, minor) == (9, 0):
         return 3
     return 2
+
+
+@contextlib.contextmanager
+def _cudnn_deterministic(value):
+    """Temporarily pin the process-global ``FLAGS_cudnn_deterministic``.
+
+    Set by the accuracy-diff harnesses (``script/test_aadiff/check_aadiff.sh``,
+    ``script/run_compare_fleet_ec.sh``), and read by
+    ``paddlefleet_ops.flash_mask_facade.get_fa_version``, so it takes part in
+    backend selection rather than only in kernel behaviour.
+    """
+    key = "FLAGS_cudnn_deterministic"
+    previous = paddle.get_flags([key])[key]
+    paddle.set_flags({key: value})
+    try:
+        yield
+    finally:
+        paddle.set_flags({key: previous})
 
 
 def _load_provider(name):

--- a/tests/single_card_tests/transformer/test_hybrid_mla_config_pipeline.py
+++ b/tests/single_card_tests/transformer/test_hybrid_mla_config_pipeline.py
@@ -912,7 +912,7 @@ class TestConfigDeltas(unittest.TestCase):
             # (``modeling.py`` hard-errors on ``None``), so both mqa_dsa phases
             # set it -- with opposite values, which is the point: phase 2
             # resumes a phase-1 checkpoint that has no indexer tensors, phase
-            # 3/4 resumes a phase-2 checkpoint that does.
+            # 3 resumes a phase-2 checkpoint that does.
             allowed["indexer_init_from_scratch"] = (
                 self._MISSING,
                 name == _DSA,

--- a/tests/single_card_tests/transformer/test_hybrid_mla_doc_equivalence.py
+++ b/tests/single_card_tests/transformer/test_hybrid_mla_doc_equivalence.py
@@ -63,14 +63,19 @@ from .hybrid_mla_utils import (
     V_HEAD_DIM,
     WINDOW,
     H,
+    _assert_agrees_to_bf16_ulps,
+    _assert_isolation_is_observable,
     _build_module,
     _check_index_invariants,
     _create_mqa_config,
     _dense_reference,
     _doc_meta,
+    _fa4_module_hooks,
     _make_inputs,
     _row_end,
 )
+
+setUpModule, tearDownModule = _fa4_module_hooks()
 
 
 def _doc_segments(layout, seqlen):
@@ -492,73 +497,90 @@ def _run_mqa(module, query, key, w_v, row_end, upstream, **extra):
 @_GPU
 class TestMQAKernelPackedVsSingle(unittest.TestCase):
     """Task 1, ``mqa`` mode: the absorbed-MQA kernel packed run equals the
-    per-document runs, elementwise on the output AND on every gradient, with
-    the sink both OFF and ON. Also equals the fp32 dense reference."""
-
-    @classmethod
-    def setUpClass(cls):
-        try:
-            paddle.set_flags({"FLAGS_cudnn_deterministic": True})
-        except Exception:
-            pass
+    per-document runs, on the output AND on every gradient, with the sink both
+    OFF and ON. Also equals the fp32 dense reference."""
 
     def _module(self, sink=None):
-        return _build_module(_create_mqa_config("mqa"), sink=sink)
+        # bf16 throughout: the full-causal phase hands the sink to dense FA4 as
+        # ``learnable_sink``, which asserts bf16 on it
+        # (``flash_mask/cute/interface.py:598``), and that is what production's
+        # ``build_softmax_offset`` gives via ``params_dtype``.
+        return _build_module(_create_mqa_config("mqa"), bf16=True, sink=sink)
 
-    def _fwd_stats(self, sink):
-        """Forward: packed vs single (bit-exact) + vs dense reference."""
+    def _fp32(self, tensor):
+        return tensor.cast("float32").numpy()
+
+    def _check_forward(self, sink, label):
+        """Forward: packed vs single, to a few ULPs, + vs the fp32 dense reference.
+
+        Not bit equality: dense FA4 derives its accumulation order from the
+        flashmask row bounds, which repacking changes
+        (``hybrid_mla_utils._assert_agrees_to_bf16_ulps``). Each multi-document
+        layout also measures a deliberately non-isolated forward, so the
+        tolerance is demonstrably too tight to hide cross-document attention.
+        """
         module = self._module(sink=sink)
-        stats = []
         for layout, seqlen in _LAYOUTS:
-            query, key, w_v = _make_inputs(seqlen, seed=1)
-            row_end = _row_end(layout, seqlen)
-            packed = (
-                module(query, key, None, None, row_end, v_b_proj_weight=w_v)
-                .cast("float32")
-                .numpy()
-            )
-            worst = 0.0
-            for start, length in _doc_segments(layout, seqlen):
-                piece = (
+            with self.subTest(layout=layout):
+                query, key, w_v = _make_inputs(seqlen, seed=1)
+                row_end = _row_end(layout, seqlen)
+                packed = self._fp32(
+                    module(query, key, None, None, row_end, v_b_proj_weight=w_v)
+                )
+                # Control: the same inputs with every document boundary gone.
+                no_isolation = self._fp32(
                     module(
-                        query[:, start : start + length].contiguous(),
-                        key[:, start : start + length].contiguous(),
+                        query,
+                        key,
                         None,
                         None,
-                        _row_end([length], length),
+                        _row_end([seqlen], seqlen),
                         v_b_proj_weight=w_v,
                     )
-                    .cast("float32")
-                    .numpy()
                 )
-                _, max_abs, _ = _relerr_maxmean(
-                    packed[:, start : start + length], piece
-                )
-                worst = max(worst, max_abs)
-            ref = _dense_reference(
-                query,
-                key,
-                w_v,
-                row_end,
-                module.softmax_scale,
-                sink=(None if sink is None else np.asarray(sink)),
-            ).numpy()
-            ref_rel, _, _ = _relerr_maxmean(packed, ref)
-            stats.append((layout, worst, ref_rel))
-        return stats
+                for start, length in _doc_segments(layout, seqlen):
+                    sl = slice(start, start + length)
+                    piece = self._fp32(
+                        module(
+                            query[:, sl].contiguous(),
+                            key[:, sl].contiguous(),
+                            None,
+                            None,
+                            _row_end([length], length),
+                            v_b_proj_weight=w_v,
+                        )
+                    )
+                    worst = _assert_agrees_to_bf16_ulps(
+                        self,
+                        packed[:, sl],
+                        piece,
+                        f"packed!=single (fwd, {label}) doc@{start}",
+                    )
+                    # Row 0's causal set is the same either way, so the
+                    # control is informative from the second document on.
+                    if start > 0:
+                        _assert_isolation_is_observable(
+                            self,
+                            worst,
+                            float(np.abs(no_isolation[:, sl] - piece).max()),
+                            packed[:, sl],
+                        )
+                ref = _dense_reference(
+                    query,
+                    key,
+                    w_v,
+                    row_end,
+                    module.softmax_scale,
+                    sink=(None if sink is None else np.asarray(sink)),
+                ).numpy()
+                ref_rel, _, _ = _relerr_maxmean(packed, ref)
+                self.assertLess(ref_rel, 5e-3, "kernel != dense reference")
 
     def test_forward_sinkless(self):
-        for layout, worst, ref_rel in self._fwd_stats(None):
-            with self.subTest(layout=layout):
-                self.assertEqual(worst, 0.0, "packed!=single (fwd)")
-                self.assertLess(ref_rel, 5e-3, "kernel != dense reference")
+        self._check_forward(None, "sinkless")
 
     def test_forward_with_sink(self):
-        sink = np.linspace(1.0, 3.0, H)
-        for layout, worst, ref_rel in self._fwd_stats(sink):
-            with self.subTest(layout=layout):
-                self.assertEqual(worst, 0.0, "packed!=single (fwd, sink)")
-                self.assertLess(ref_rel, 5e-3, "kernel != dense reference")
+        self._check_forward(np.linspace(1.0, 3.0, H), "sink")
 
     def _bwd_check(self, sink):
         module = self._module(sink=sink)
@@ -637,13 +659,6 @@ class TestMQADSAKernelPackedVsSingle(unittest.TestCase):
     the dense reference and the per-document runs exactly (up to bf16); sink
     ON/OFF. Genuinely-sparse soundness is covered by the capture class below.
     """
-
-    @classmethod
-    def setUpClass(cls):
-        try:
-            paddle.set_flags({"FLAGS_cudnn_deterministic": True})
-        except Exception:
-            pass
 
     def setUp(self):
         _CAPTURED.clear()
@@ -784,13 +799,6 @@ class TestForcedWindowAndSuperset(unittest.TestCase):
     whose available column count fits the budget.
     """
 
-    @classmethod
-    def setUpClass(cls):
-        try:
-            paddle.set_flags({"FLAGS_cudnn_deterministic": True})
-        except Exception:
-            pass
-
     def setUp(self):
         _CAPTURED.clear()
         self.module = _build_module(
@@ -906,17 +914,16 @@ class TestSinkNormalizationFP64(unittest.TestCase):
     that the sink is present for the first token of every document, and that it
     is applied exactly once (not duplicated per document)."""
 
-    @classmethod
-    def setUpClass(cls):
-        try:
-            paddle.set_flags({"FLAGS_cudnn_deterministic": True})
-        except Exception:
-            pass
-
     def test_mqa_sink_matches_fp64_oracle(self):
         seqlen, layout = 256, [40, 88, 128]
         sink = np.linspace(1.0, 3.0, H)
-        module = _build_module(_create_mqa_config("mqa"), sink=sink)
+        # bf16 sink: dense FA4 asserts that dtype on ``learnable_sink``
+        # (``flash_mask/cute/interface.py:598``), matching production's
+        # ``params_dtype``. The oracle is then fed the rounded values the kernel
+        # actually saw, so the comparison isolates the softmax arithmetic rather
+        # than re-measuring bf16 storage of the sink.
+        module = _build_module(_create_mqa_config("mqa"), bf16=True, sink=sink)
+        sink = module.softmax_offset.cast("float64").numpy()
         query, key, w_v = _make_inputs(seqlen, seed=6)
         row_end = _row_end(layout, seqlen)
         out = (
@@ -943,7 +950,7 @@ class TestSinkNormalizationFP64(unittest.TestCase):
         duplication would scale the sink mass by the document index."""
         seqlen, layout = 256, [50, 50, 50, 106]
         sink = np.full(H, 20.0)  # dominant -> first-token output ~ 0
-        module = _build_module(_create_mqa_config("mqa"), sink=sink)
+        module = _build_module(_create_mqa_config("mqa"), bf16=True, sink=sink)
         query, key, w_v = _make_inputs(seqlen, seed=6)
         row_end = _row_end(layout, seqlen)
         out = (
@@ -974,13 +981,6 @@ class TestMTPDocumentMaskShift(unittest.TestCase):
     with the shrunk, re-expressed layout and require packed==single and
     in-document-only selection on both the dense and the DSA path.
     """
-
-    @classmethod
-    def setUpClass(cls):
-        try:
-            paddle.set_flags({"FLAGS_cudnn_deterministic": True})
-        except Exception:
-            pass
 
     _BASE = [40, 88, 128]
     _SEQ = 256
@@ -1031,9 +1031,10 @@ class TestMTPDocumentMaskShift(unittest.TestCase):
                         .cast("float32")
                         .numpy()
                     )
-                    self.assertEqual(
-                        float(np.abs(packed[:, sl] - piece).max()),
-                        0.0,
+                    _assert_agrees_to_bf16_ulps(
+                        self,
+                        packed[:, sl],
+                        piece,
                         f"depth {depth} shifted doc@{start} not isolated",
                     )
 

--- a/tests/single_card_tests/transformer/test_hybrid_mla_grad_health.py
+++ b/tests/single_card_tests/transformer/test_hybrid_mla_grad_health.py
@@ -92,7 +92,13 @@ from paddlefleet.transformer.transformer_config import (
     TransformerConfig,
 )
 
-from .hybrid_mla_utils import _row_end as _row_end_from_docs
+from .hybrid_mla_utils import _fa4_module_hooks, _row_end as _row_end_from_docs
+
+# The full-causal phases have exactly one backend: ``_assert_dense_fa4`` raises
+# unless the process flags resolve to FA4, and the ``mha`` sink parameter is
+# likewise only created under FA3/FA4. Reproducing the flag the trainer derives
+# once per module covers both.
+setUpModule, tearDownModule = _fa4_module_hooks()
 
 try:
     from paddlefleet.cudnn_ops.block_sparse_mqa_dsa import is_dsa_available
@@ -233,9 +239,12 @@ def _fa4_for_mha_sink(mode, sink):
     unless ``FLAGS_flash_attn_version in (3, 4)``, because ``mha`` consumes it as
     ``flashmask_attention_func(learnable_sink=...)`` which only exists on the
     cute path (multi_latent_attention.py, guard next to the parameter creation).
-    The default flag value in this image is 2. These tests only inspect the
-    parameter, so we flip the flag around construction and restore it -- the
-    process-global default must stay untouched for the other suites.
+
+    The module-level ``_fa4_pin()`` cannot cover this: it stands down where no
+    FA4 backend can serve, which is every upstream CI box, and these ``mha``
+    cases are not gated to SM100. Creating the parameter launches no kernel, so
+    the flag only has to hold across the construction -- pin it here and restore,
+    exactly as this file did before the pin moved to module scope.
     """
     if not (sink and mode == "mha"):
         yield

--- a/tests/single_card_tests/transformer/test_hybrid_mla_hf_roundtrip.py
+++ b/tests/single_card_tests/transformer/test_hybrid_mla_hf_roundtrip.py
@@ -25,7 +25,7 @@ runs the statements through the real engine: it drives
 real ``csa_compress_ratios == -2`` layer built from the production
 ``model_config.json``.
 
-What is proven here, and why each one matters for the phase-1 -> phase-2/3/4
+What is proven here, and why each one matters for the phase-1 -> phase-2/3
 continuation story:
 
 1. **Save is complete.** Every tensor of the built module reaches disk exactly
@@ -345,45 +345,50 @@ class TestHFSaveCoverage(unittest.TestCase):
             tuple(module["core_attention.softmax_offset"].shape),
         )
 
-    def test_documented_bug_gate_proj_is_saved_untransposed(self):
-        """``self_attn.gate_proj`` has no AOA statement in either direction
-        (the generators test ``use_gated_attn`` while the production JSON says
-        ``gated_attention``), already pinned at the statement level by
-        ``test_hybrid_mla_config_pipeline.py::
-        test_documented_bug_attention_gate_proj_dropped_from_aoa``.
+    def test_gate_proj_is_saved_transposed_like_every_other_2d_weight(self):
+        """``self_attn.gate_proj`` takes the normal transposing path.
 
-        The consequence on disk: the save path builds its engine with
+        WAS a documented bug, pinned here as "saved untransposed": the AOA
+        statements gated on ``config.use_gated_attn`` while the production JSON
+        spells the switch ``gated_attention``, so no statement mentioned
+        ``gate_proj`` in either direction. The save path builds its engine with
         ``destination_state_shard_info=None`` (``full_param.py:103-126``), so
-        ``aoa_engine.py:697-710`` passes every unconsumed input through under
-        its own name. The tensor is therefore not lost -- it is written with
-        Fleet orientation while every other 2-D weight is transposed, i.e. it
-        would be wrong for a genuine torch-produced checkpoint but round trips
-        inside this codebase.
+        ``aoa_engine.py:697-710`` passed the tensor through under its own name --
+        not lost, but written in Fleet orientation while every other 2-D weight
+        was transposed, i.e. wrong for a genuine torch-produced checkpoint.
+
+        Fixed in erniebot's ``fleet_model/ernie5_v2/modeling.py``, which now ORs
+        the two spellings and widens the guard to the whole dsv4-hybrid family,
+        emitting ``self_attn.gate_proj.weight^T ->
+        self_attn.gate_proj.weight``. So the contrast this test used to assert is
+        gone and the pin is inverted: the statement must exist and the tensor
+        must land transposed, exactly like ``q_a_proj``. The statement-level
+        counterpart is
+        ``test_hybrid_mla_config_pipeline.py::test_attention_gate_proj_is_in_aoa``,
+        which counts one per gated layer.
         """
         attn = _attn(_DSA, seed=11)
         module_keys = {PREFIX + k for k in attn.state_dict()}
         _, inverse = _aoa(_DSA, indexer_init_from_scratch=True)
         inv = _filter(inverse, module_keys, fleet_on_left=True)
         gate = PREFIX + "gate_proj.weight"
-        self.assertNotIn(
-            gate, [s.split("->")[1].strip() for s in inv], "bug fixed?"
+        self.assertIn(
+            gate,
+            [s.split("->")[1].strip() for s in inv],
+            "gate_proj lost its AOA statement again",
         )
         with TemporaryDirectory() as tmp:
             path = Path(tmp) / "hf"
             _save_hf(attn, inv, path)
             disk = _on_disk(path)
-        self.assertIn(gate, disk, "pass-through must still write the tensor")
-        self.assertEqual(
-            tuple(disk[gate]),
-            tuple(attn.state_dict()["gate_proj.weight"].shape),
-            "gate_proj is expected to be saved untransposed",
-        )
-        other = PREFIX + "q_a_proj.weight"
-        self.assertEqual(
-            tuple(disk[other]),
-            tuple(attn.state_dict()["q_a_proj.weight"].shape)[::-1],
-            "every mapped 2-D weight is transposed, so the contrast is real",
-        )
+        self.assertIn(gate, disk)
+        for key in ("gate_proj.weight", "q_a_proj.weight"):
+            with self.subTest(key=key):
+                self.assertEqual(
+                    tuple(disk[PREFIX + key]),
+                    tuple(attn.state_dict()[key].shape)[::-1],
+                    "every mapped 2-D weight is stored transposed",
+                )
 
 
 @_requires_cuda

--- a/tests/single_card_tests/transformer/test_hybrid_mla_recompute_mtp_ckpt.py
+++ b/tests/single_card_tests/transformer/test_hybrid_mla_recompute_mtp_ckpt.py
@@ -436,7 +436,7 @@ class TestCheckpointKeySets(unittest.TestCase):
     indexer keys. Since ``"mqa_dsa"`` always wires the indexer, the old DSA-less
     ``mqa`` surface no longer exists, so the tests that purely contrasted
     mqa-vs-mqa_dsa were dropped as redundant; the second ``"mqa_dsa"`` config is
-    the phase-3/4 sparse-loss one, which must have the identical key set.
+    the phase-3 sparse-loss one, which must have the identical key set.
 
     SINK: the learnable sink used to be introduced *by* the absorbed phase, so it
     showed up as "one extra key per -2 layer". The baseline
@@ -582,13 +582,6 @@ class TestRecomputeEquivalence(unittest.TestCase):
     ``TestRecomputeIndicesReplay``.
     """
 
-    @classmethod
-    def setUpClass(cls):
-        try:
-            paddle.set_flags({"FLAGS_cudnn_deterministic": True})
-        except Exception:
-            pass
-
     def _run(self, module, query, key, w_v, x, qr, row_end, use_recompute):
         from paddle.distributed.fleet.utils import recompute
 
@@ -620,21 +613,29 @@ class TestRecomputeEquivalence(unittest.TestCase):
         row_end = _row_end(layout, seqlen)
         module = _build_module(
             _create_mqa_config(mode, loss_coeff=0.0),
-            bf16=(mode == "mqa_dsa"),
+            # bf16 for both modes: ``"mqa"`` is the full-causal phase, which
+            # hands the sink to dense FA4 as ``learnable_sink`` and asserts that
+            # dtype on it (``flash_mask/cute/interface.py:598``), matching
+            # production's ``params_dtype``.
+            bf16=True,
             sink=sink,
         )
 
-        _CAPTURED.clear()
-        out_off, g_off = self._run(
-            module, query, key, w_v, x, qr, row_end, use_recompute=False
-        )
-        n_off = len(_CAPTURED)
-        idx_off = _CAPTURED[-1]
+        # Pinned per call site rather than per module: the full-causal phase has
+        # exactly one backend and ``_assert_dense_fa4`` raises otherwise, but
+        # ``test_production_dims_are_not_fa4`` in this same file asserts on the
+        # *unpinned* resolution, so a module-wide pin would falsify it.
+        with _flash_attn_version(4):
+            _CAPTURED.clear()
+            out_off, g_off = self._run(
+                module, query, key, w_v, x, qr, row_end, use_recompute=False
+            )
+            idx_off = _CAPTURED[-1]
 
-        _CAPTURED.clear()
-        out_on, g_on = self._run(
-            module, query, key, w_v, x, qr, row_end, use_recompute=True
-        )
+            _CAPTURED.clear()
+            out_on, g_on = self._run(
+                module, query, key, w_v, x, qr, row_end, use_recompute=True
+            )
         # Recompute re-runs the forward during backward: the sparse kernel is
         # therefore called twice, and BOTH calls must select identical columns.
         self.assertGreaterEqual(
@@ -683,13 +684,6 @@ class TestRecomputeIndicesReplay(unittest.TestCase):
     runs pass 1 under ``no_grad`` (indices only) and pass 2 with grad (loss
     attached). The top-k must be deterministic across the two passes, and the
     indexer parameters must receive finite gradients through the recompute."""
-
-    @classmethod
-    def setUpClass(cls):
-        try:
-            paddle.set_flags({"FLAGS_cudnn_deterministic": True})
-        except Exception:
-            pass
 
     def test_dsa_recompute_indices_and_indexer_grads(self):
         from paddle.distributed.fleet.utils import recompute

--- a/tests/single_card_tests/transformer/test_hybrid_mla_warmup_dense_fa4.py
+++ b/tests/single_card_tests/transformer/test_hybrid_mla_warmup_dense_fa4.py
@@ -1,0 +1,770 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The full-causal phases run as dense FA4, and refuse to run as anything else.
+
+Phase 1 (``hybrid_mla_attention="mqa_full_causal"``) and phase 2
+(``"mqa_dsa"`` + ``dsa_indexer_use_sparse_loss=False``) both attend over the
+*whole* per-document causal span. Expressing that span as an explicit
+``[b, s, s]`` column table for the FlashMLA sparse kernel costs ``O(s^2)`` memory
+for no benefit: measured net allocation for the table alone is 1.6 GiB at s=8192,
+25.0 GiB at s=32768 and 100.0 GiB at s=65536 (against 3.3 / 13.0 / 26.0 GiB for a
+dense forward *and* backward), and past s=46336 the sparse kernel's own
+``(b*s-1)*topk_padded`` index arithmetic overflows int32 -- which does *not*
+reliably crash: s=46337 returns finite but wrong numbers for its last 55 rows.
+So ``MQALatentAttention._dense_attn`` hands the same softmax to FA4's dense
+flashmask instead, keeping the document structure in the caller's own
+``startend_row_indices`` -- and ``_assert_dense_fa4`` raises rather than
+substituting the table when FA4 is not what the environment resolves to.
+
+What is pinned here:
+
+* ``TestBackendSelection`` -- the dense path is taken whenever it can be, and
+  every way of not resolving to FA4 raises instead of degrading. Phase 1 shares
+  ``_forward_full_causal`` with the warmup's attention half, so both are covered
+  by one selection point; phase 3, which genuinely selects 640 columns, keeps
+  ``_sparse_attn`` and is *not* subject to the assertion.
+* ``TestCpRowBounds`` -- context parallelism keeps the dense path, which needs
+  the causal diagonal expressed as an explicit flashmask bound in this rank's
+  row space instead of the kernel's own bottom-right-aligned one.
+* ``TestDenseWarmupPrecision`` -- the numerical case. Both backends are compared
+  against the same fp32 eager reference, and the sparse path is used as the
+  *yardstick*: replacing it is only legitimate if dense is at least as close to
+  fp32 as sparse is, forward and backward. No hand-picked tolerance decides the
+  verdict. Since production has no sparse full-causal path any more, the
+  yardstick is built here, by feeding ``_sparse_attn`` the explicit table from
+  ``hybrid_mla_utils._full_causal_indices``.
+* ``TestDenseWarmupPadRows`` -- a pad row is a query row with *every* column
+  masked, which is a softmax-over-nothing hazard the sparse path avoids
+  structurally (all ``-1`` columns). FA4 returns exact zeros there instead of
+  NaN; that is a kernel property, so it needs a regression test.
+* ``TestFrozenInputs`` -- ``train_indexer_only`` freezes the backbone and can
+  freeze ``softmax_offset``, and a ``PyLayer`` whose input has
+  ``stop_gradient=True`` must get ``None`` back at that position, which
+  ``flashmask_attention`` does not do. ``_dense_pylayer_inputs`` works around
+  it, for the sink and for a frozen q/k/v alike; the workaround must be
+  forward-neutral.
+
+``FLAGS_flash_attn_version`` is process-global and a bare pytest process never
+constructs ``TrainingArguments``, so it keeps the image default 2. Production on
+this SM100 box gets 4 from ``training_args.py:1764-1780``. Every case that runs a
+full-causal forward therefore has to pin it with
+``hybrid_mla_utils._flash_attn_version(4)`` -- without that the forward now
+raises rather than quietly taking a second backend.
+
+Run:
+    R=<erniebot checkout>
+    PYTHONPATH=$R/third_party/PaddleFleet/src \\
+        CUDA_VISIBLE_DEVICES=0 FLAGS_selected_gpus=0 \\
+        python -m pytest <this file> -q
+"""
+
+import contextlib
+import types
+import unittest
+
+import numpy as np
+import paddle
+
+from paddlefleet.transformer.csa_attention import _derive_csa_doc_boundaries
+
+from .hybrid_mla_utils import (
+    _GPU,
+    DV,
+    H,
+    MQALatentAttention,
+    _build_module,
+    _create_mqa_config,
+    _cudnn_deterministic,
+    _dense_reference,
+    _flash_attn_version,
+    _full_causal_indices,
+    _make_inputs,
+    _pad_row_end,
+    _production_fa_version,
+    _rel,
+    _row_end,
+)
+
+# Per-head sink logits, ``H == 8``. Mixed signs and magnitudes so the sink is
+# not a no-op on any head and its gradient is not symmetric.
+_SINK = [0.5, -0.25, 0.0, 1.0, -1.5, 0.75, 0.25, -0.5]
+
+# ``(doc_lens, seqlen)``. seqlen=512 is the discriminating shape: the phase-3
+# sparse budget (WINDOW + INDEX_TOPK == 256) covers at most half of a row's
+# causal span there, so "full causal" is distinguishable from "top-k".
+_LAYOUTS = [
+    ([512], 512),  # one document spanning the buffer
+    ([200, 312], 512),  # two documents
+    ([100, 50, 106], 256),  # three, none a multiple of the window
+]
+
+# Real pad rows: the trailing gap stays outside every document.
+_PAD_LAYOUT = ([100, 50, 60], 256)
+
+
+def _fa4_is_the_production_kernel():
+    """``_production_fa_version()`` needs a CUDA device to answer.
+
+    Evaluated at import time by the ``skipUnless`` below, so it must not raise on
+    a CPU-only box -- an exception here would abort collection instead of
+    skipping (and upstream CI only accepts pytest exit 0).
+    """
+    try:
+        return _production_fa_version() == 4
+    except Exception:
+        return False
+
+
+_FA4 = unittest.skipUnless(
+    _fa4_is_the_production_kernel(),
+    "the dense warmup path needs the FA4 (cute) kernel, which production only "
+    "selects on SM100",
+)
+
+
+def _module(mode="mqa_dsa", sparse_loss=False, sink=None, loss_coeff=0.0):
+    """A hybrid-MLA latent module with the phase fixed from construction.
+
+    ``loss_coeff=0.0`` is deliberate for the numerical tests: it makes
+    ``_needs_indexer_loss()`` false, so the forward is the attention half alone
+    and a backward reaches only the attention inputs. Path-selection tests do not
+    care either way.
+    """
+    config = _create_mqa_config(mode, loss_coeff=loss_coeff)
+    config.dsa_indexer_use_sparse_loss = sparse_loss
+    config.pad_token_id = 0
+    module = _build_module(config, bf16=True, sink=sink)
+    return module
+
+
+@contextlib.contextmanager
+def _backend_spy(module):
+    """Record ``"dense"`` / ``"sparse"`` per attention call, in order."""
+    calls = []
+    real_dense, real_sparse = module._dense_attn, module._sparse_attn
+
+    def dense(*args, **kwargs):
+        calls.append("dense")
+        return real_dense(*args, **kwargs)
+
+    def sparse(*args, **kwargs):
+        calls.append("sparse")
+        return real_sparse(*args, **kwargs)
+
+    module._dense_attn, module._sparse_attn = dense, sparse
+    try:
+        yield calls
+    finally:
+        module._dense_attn, module._sparse_attn = real_dense, real_sparse
+
+
+def _inputs(seqlen, seed=1):
+    """``((query, key, x, qr), w_v)`` as differentiable leaves."""
+    query, key, w_v, x, qr = _make_inputs(seqlen, seed=seed, with_hidden=True)
+    tensors = [query, key, x, qr]
+    for tensor in tensors:
+        tensor.stop_gradient = False
+    w_v.stop_gradient = False
+    return tensors, w_v
+
+
+def _forward(module, tensors, row_end, w_v, training=True):
+    module.train() if training else module.eval()
+    query, key, x, qr = tensors
+    return module(
+        query,
+        key,
+        None,
+        None,
+        row_end,
+        v_b_proj_weight=w_v,
+        x=x,
+        qr=qr,
+    )
+
+
+def _sparse_full_causal(module, tensors, row_end, w_v):
+    """The full-causal softmax through the *sparse* kernel, as a yardstick.
+
+    Production no longer has this path: ``_forward_full_causal`` only knows
+    ``_dense_attn``. But the sparse kernel is what the dense one replaced, and
+    "at least as accurate as what it replaced" is the only tolerance-free way to
+    judge the replacement, so the comparison is reconstructed here out of the
+    same two production pieces the phase-3 forward uses -- ``_sparse_attn`` on an
+    explicit column table, then ``_deabsorb``.
+
+    Mirrors ``_forward_sparse``'s tail exactly (``mqa_latent_attention.py``
+    ``:1147-1150``): no indexer, no ``indexer_topk``, and the table is the whole
+    per-document causal span rather than window + top-k.
+    """
+    query, key = tensors[0], tensors[1]
+    seqlen = int(query.shape[1])
+    kv = key.squeeze(2).contiguous()
+    with paddle.no_grad():
+        doc_start, _, is_valid, _, _ = _derive_csa_doc_boundaries(
+            row_end, seqlen
+        )
+    table = _full_causal_indices(1, seqlen, doc_start, is_valid)
+    core_out = module._sparse_attn(query, kv, table, module.softmax_scale, DV)
+    return module._deabsorb(core_out, w_v, module.split_kv_b)
+
+
+@_GPU
+@_FA4
+class TestBackendSelection(unittest.TestCase):
+    """Dense whenever FA4 serves it, a hard error whenever it does not.
+
+    The full-causal phases have one backend. Not resolving to FA4 used to mean
+    falling back to an ``O(s^2)`` column table; it now means refusing to start,
+    so each way of not resolving to FA4 has to be pinned as a raise -- otherwise
+    a silent change of backend could reappear and only show up as a memory
+    figure.
+    """
+
+    def _calls(self, module, fa_version, seqlen=256):
+        row_end = _row_end([seqlen], seqlen)
+        tensors, w_v = _inputs(seqlen)
+        with _flash_attn_version(fa_version), _backend_spy(module) as calls:
+            _forward(module, tensors, row_end, w_v)
+        return calls
+
+    def _assert_forward_refuses(self, module, fa_version=4, deterministic=0):
+        """The forward must raise, and must do so before touching a backend."""
+        seqlen = 256
+        row_end = _row_end([seqlen], seqlen)
+        tensors, w_v = _inputs(seqlen)
+        with (
+            _flash_attn_version(fa_version),
+            _cudnn_deterministic(deterministic),
+            _backend_spy(module) as calls,
+            self.assertRaisesRegex(RuntimeError, "requires FA4"),
+        ):
+            _forward(module, tensors, row_end, w_v)
+        self.assertEqual(calls, [])
+
+    def test_fa4_takes_the_dense_path(self):
+        module = _module()
+        self.assertEqual(self._calls(module, 4), ["dense"])
+
+    def test_fa2_raises(self):
+        """No FA4, no full-causal attention -- and no s^2 table either."""
+        self._assert_forward_refuses(_module(), fa_version=2)
+
+    def test_the_message_names_all_three_inputs(self):
+        """The head-dim pair alone rarely explains ``get_fa_version``'s answer.
+
+        It reads a whitelist *and* two process-global flags, so a message that
+        only quoted the head dims would send the reader looking at the layer
+        when the cause is the environment.
+        """
+        module = _module()
+        seqlen = 256
+        row_end = _row_end([seqlen], seqlen)
+        tensors, w_v = _inputs(seqlen)
+        with _flash_attn_version(2), self.assertRaises(RuntimeError) as caught:
+            _forward(module, tensors, row_end, w_v)
+        message = str(caught.exception)
+        self.assertIn("(576, 512)", message)
+        self.assertIn("FLAGS_flash_attn_version=2", message)
+        self.assertIn("FLAGS_cudnn_deterministic", message)
+
+    def test_cp_is_not_a_rejection_condition(self):
+        """CP keeps the dense path -- ``_cp_row_bounds`` handles it.
+
+        The row indices in ``row_end`` address *global* rows while this rank owns
+        a row slice, so they cannot be handed to the kernel as they are; but
+        localising them is arithmetic, not an obstacle, and it is the same
+        contract the rest of the model's CP attention uses. An earlier revision
+        did refuse under CP, which is precisely the geometry where the ``s^2``
+        table is least affordable -- its column count is ``s_global``. The
+        localisation itself is checked by ``TestCpRowBounds`` and end to end by
+        ``tests/multi_card_tests/transformer/test_mqa_dsa_warmup_cp.py``.
+        """
+        module = _module()
+        row_end = _row_end([256], 256)
+        with _flash_attn_version(4):
+            module.cp_size, module.cp_rank = 2, 1
+            self.assertIsNone(module._assert_dense_fa4(576, 512, row_end))
+
+    def test_unsupported_head_dims_raise(self):
+        """The head-dim pair comes from the layer, not from a constant."""
+        module = _module()
+        row_end = _row_end([256], 256)
+        with (
+            _flash_attn_version(4),
+            self.assertRaisesRegex(RuntimeError, r"\(576, 511\)"),
+        ):
+            module._assert_dense_fa4(576, 511, row_end)
+
+    def test_deterministic_raises(self):
+        """(576, 512) has no deterministic FA4 backward.
+
+        FA4 solves it with the big-head-dim kernel, which asserts
+        ``not deterministic`` (``flash_mask/cute/interface.py:1238,1249``), so
+        ``get_fa_version`` degrades the pair under ``FLAGS_cudnn_deterministic``.
+        For these phases that degradation is not usable, and a Python error
+        naming the flag is more actionable than the kernel's own assert firing in
+        the middle of a backward.
+        """
+        module = _module()
+        row_end = _row_end([256], 256)
+        with (
+            _flash_attn_version(4),
+            _cudnn_deterministic(1),
+            self.assertRaisesRegex(RuntimeError, "cudnn_deterministic"),
+        ):
+            module._assert_dense_fa4(576, 512, row_end)
+        # Nothing else about the layer changed: the same call is fine again
+        # once determinism is off.
+        with _flash_attn_version(4), _cudnn_deterministic(0):
+            self.assertIsNone(module._assert_dense_fa4(576, 512, row_end))
+
+    def test_deterministic_forward_raises_before_the_backward(self):
+        """The error has to arrive in the forward, not in the backward.
+
+        Reaching the kernel's own ``assert not deterministic`` would mean a step
+        that had already spent its forward, with a message that names neither
+        the layer nor the flag.
+        """
+        self._assert_forward_refuses(_module(), deterministic=1)
+
+    def test_full_causal_phase_also_takes_the_dense_path(self):
+        """Phase 1 attends over the same whole causal span, so same backend.
+
+        It shares ``_forward_full_causal`` with the warmup's attention half --
+        the point of routing the check there rather than into the warmup is that
+        there is exactly one selection point for both phases.
+        """
+        module = _module(mode="mqa")
+        self.assertEqual(self._calls(module, 4), ["dense"])
+
+    def test_full_causal_phase_raises_on_fa2(self):
+        self._assert_forward_refuses(_module(mode="mqa"), fa_version=2)
+
+    def test_sparse_phase_is_untouched(self):
+        """Phase 3 selects 640 columns, not s -- 544 MiB at s=65536."""
+        module = _module(sparse_loss=True)
+        self.assertEqual(self._calls(module, 4), ["sparse"])
+
+    def test_the_assertion_is_scoped_to_the_full_causal_phases(self):
+        """Phase 3 does not go through FA4 at all, so it must not be gated.
+
+        Its forward is the FlashMLA sparse kernel, whose availability has nothing
+        to do with ``FLAGS_flash_attn_version``. Pinning this keeps the new hard
+        error from spreading into the phase that legitimately selects columns.
+        """
+        module = _module(sparse_loss=True)
+        self.assertEqual(self._calls(module, 2), ["sparse"])
+
+
+class TestCpRowBounds(unittest.TestCase):
+    """``_cp_row_bounds`` must reproduce the global mask on every rank.
+
+    Under CP the dense path cannot use the kernel's own ``causal=True``: FA4
+    bottom-right-aligns the diagonal at ``seqlen_k - seqlen_q``, which is this
+    rank's offset only on the last rank, and ``row_end``'s values are global row
+    ids compared against local rows. So the diagonal becomes an explicit second
+    bound and both bounds are shifted into local row space -- the contract
+    ``DotProductAttention`` and the HySparse MLA scorer already use.
+
+    The assertion is the mask itself rather than the numbers in the bounds: with
+    ``causal=False`` and two bounds the kernel masks ``row >= LTS or row < UTE``
+    (``flash_mask/cute/mask.py:513-518``), i.e. column ``j`` is visible on rows
+    ``[UTE_j, LTS_j)``. Decoding the returned pair through *that* rule and
+    comparing against a brute-force per-document causal mask, sliced to this
+    rank's rows, is what makes the test independent of how the shift is spelled.
+
+    Pure integer arithmetic on 1-element-wide bounds, so no device is needed --
+    ``preprocess_index`` is a subtract plus a clip.
+    """
+
+    @staticmethod
+    def _localise(row_end, cp_rank, s_local):
+        """The method under test, on a stand-in carrying only ``cp_rank``.
+
+        Bound as a plain function so the case does not need a built layer (and
+        therefore a GPU) to exercise index arithmetic.
+        """
+        return MQALatentAttention._cp_row_bounds(
+            types.SimpleNamespace(cp_rank=cp_rank), row_end, s_local
+        )
+
+    @staticmethod
+    def _global_mask(doc_lens, s_global):
+        """``[s_global, s_global]`` bool: per-document causal, brute force."""
+        mask = np.zeros([s_global, s_global], dtype=bool)
+        pos = 0
+        for length in doc_lens:
+            end = min(pos + length, s_global)
+            for row in range(pos, end):
+                mask[row, pos : row + 1] = True
+            pos = end
+        return mask
+
+    def _assert_rank_mask(self, doc_lens, s_global, cp_size):
+        row_end = _row_end(doc_lens, s_global)
+        s_local = s_global // cp_size
+        expected = self._global_mask(doc_lens, s_global)
+        for cp_rank in range(cp_size):
+            bounds = self._localise(row_end, cp_rank, s_local).numpy()[0, 0]
+            lts, ute = bounds[:, 0], bounds[:, 1]
+            rows = np.arange(s_local).reshape([s_local, 1])
+            got = ~((rows >= lts) | (rows < ute))
+            base = cp_rank * s_local
+            with self.subTest(cp_size=cp_size, cp_rank=cp_rank, docs=doc_lens):
+                self.assertEqual(bounds.shape, (s_global, 2))
+                np.testing.assert_array_equal(
+                    got, expected[base : base + s_local]
+                )
+
+    def test_single_rank_reproduces_the_kernel_causal_mask(self):
+        """cp_size=1 is the calibration: the pair must equal ``causal=True``.
+
+        ``_dense_attn`` does not take this branch at cp_size=1, but if the two
+        formulations disagreed here they would disagree everywhere, and this is
+        the one shape where the kernel's own diagonal is known to be right.
+        """
+        for doc_lens in ([16], [7, 9], [5, 3, 8]):
+            self._assert_rank_mask(doc_lens, 16, 1)
+
+    def test_every_rank_sees_its_own_slice(self):
+        for cp_size in (2, 4):
+            for doc_lens in ([16], [8, 8], [7, 9], [5, 3, 8], [1, 14, 1]):
+                self._assert_rank_mask(doc_lens, 16, cp_size)
+
+    def test_documents_are_not_leaked_across_ranks(self):
+        """The failure mode the localisation exists to prevent.
+
+        Handing the kernel the *unshifted* global bounds with ``causal=True``
+        leaves an earlier document fully visible to a later rank -- rank 1's
+        local row 0 is global row 8, and every column of document A (0-7) sits
+        below the bottom-right diagonal with ``LTS`` values it never reaches. So
+        pin that document A contributes nothing on rank 1, and that rank 0 sees
+        nothing of document B.
+        """
+        row_end = _row_end([8, 8], 16)
+        first = self._localise(row_end, cp_rank=1, s_local=8).numpy()[0, 0]
+        # Document A masked from local row 0 on == masked everywhere.
+        np.testing.assert_array_equal(first[:8, 0], np.zeros(8, dtype="int32"))
+        # Document B keeps its own diagonal, now in local rows.
+        np.testing.assert_array_equal(first[8:, 1], np.arange(8, dtype="int32"))
+
+        second = self._localise(row_end, cp_rank=0, s_local=8).numpy()[0, 0]
+        # Document B is entirely in the future: visible from local row 8, which
+        # this rank does not have.
+        np.testing.assert_array_equal(second[8:, 1], np.full(8, 8, "int32"))
+        np.testing.assert_array_equal(second[:8, 0], np.full(8, 8, "int32"))
+
+    def test_pad_rows_stay_empty_on_every_rank(self):
+        """A pad row must not acquire columns from the shift.
+
+        ``_pad_row_end`` repeats the last document's end, so the tail rows are
+        past every ``LTS``. Clipping must keep them that way rather than folding
+        them to ``s_local``, which would make them fully *visible*.
+        """
+        doc_lens, s_global = [4, 4], 16
+        row_end = _pad_row_end(doc_lens, s_global)
+        for cp_size in (2, 4):
+            s_local = s_global // cp_size
+            for cp_rank in range(cp_size):
+                bounds = self._localise(row_end, cp_rank, s_local).numpy()[0, 0]
+                lts, ute = bounds[:, 0], bounds[:, 1]
+                rows = np.arange(s_local).reshape([s_local, 1])
+                got = ~((rows >= lts) | (rows < ute))
+                base = cp_rank * s_local
+                pad = max(0, min(s_local, base + s_local - sum(doc_lens)))
+                with self.subTest(cp_size=cp_size, cp_rank=cp_rank):
+                    self.assertFalse(got[s_local - pad :].any())
+
+
+def _loss_weight(seqlen, seed=7):
+    """A fixed non-uniform output weighting, so ``dq`` is not the ``sum``
+    special case (every row weighted identically) that hides row-dependent
+    errors."""
+    paddle.seed(seed)
+    return paddle.randn([1, seqlen, H * 64], dtype="float32")
+
+
+@_GPU
+@_FA4
+class TestDenseWarmupPrecision(unittest.TestCase):
+    """Dense must be at least as close to fp32 as the sparse path it replaces.
+
+    Both backends run on bitwise-identical inputs against one fp32 eager
+    reference (``hybrid_mla_utils._dense_reference``, which *is* the mathematical
+    dense-MHA path -- absorption is exactly score preserving). The sparse path's
+    own error is the yardstick, so the verdict does not rest on a hand-picked
+    tolerance; the absolute floors below only stop the assertion from tightening
+    to zero when the yardstick happens to be unusually good on a shape.
+
+    The yardstick is built by ``_sparse_full_causal`` rather than by flipping a
+    flag: production has one backend for these phases, so the sparse comparison
+    exists only here, out of ``_sparse_attn`` plus an explicit column table.
+
+    Measured relative Frobenius error against fp32, over the three layouts with
+    and without a sink (dense / sparse):
+
+        out    2.54-2.78e-3 / 2.53-2.78e-3   dense within 0.1% of sparse
+        dq     3.54-3.86e-3 / 3.58-4.03e-3   dense *better* on every shape
+        dkv    4.05-4.16e-3 / 3.56-3.69e-3   dense worse, worst ratio 1.13
+        dw_v   3.36-3.58e-3 / 3.34-3.58e-3   within 0.3%
+
+    So the only quantity where dense loses is ``dkv``, by 13% of an error that is
+    itself bf16 rounding; the floors below are set just above the measured band.
+    """
+
+    # Both backends sit in the 3-4e-3 band against fp32 and neither is a
+    # "reference" -- the fp32 eager path is. The floors are the measured worst
+    # case plus ~40%, so a real regression cannot hide behind them, while
+    # ``_SLACK`` absorbs which of two equally-wrong accumulation orders lands
+    # closer on a given shape.
+    _FORWARD_FLOOR = 3e-3
+    _GRAD_FLOOR = 6e-3
+    _SLACK = 1.5
+
+    def _measure(self, row_end, seqlen, sink):
+        """``(expected, got)``: fp32 autograd reference vs both backends."""
+        module = _module(sink=sink)
+        weight = _loss_weight(seqlen)
+
+        tensors, w_v = _inputs(seqlen)
+        ref = _dense_reference(
+            tensors[0], tensors[1], w_v, row_end, module.softmax_scale, sink
+        )
+        paddle.autograd.backward((ref * weight).sum())
+        expected = (ref, tensors[0].grad, tensors[1].grad, w_v.grad)
+
+        got = {}
+        for tag in ("dense", "sparse"):
+            module.clear_gradients()
+            tensors, w_v = _inputs(seqlen)
+            if tag == "dense":
+                # The production path, through the module's own forward.
+                with _flash_attn_version(4), _backend_spy(module) as calls:
+                    out = _forward(module, tensors, row_end, w_v)
+                self.assertEqual(calls, ["dense"])
+            else:
+                # The yardstick, assembled from the same two production pieces
+                # phase 3 uses. Not reachable through the module's forward any
+                # more, which is the point of the comparison.
+                module.train()
+                out = _sparse_full_causal(module, tensors, row_end, w_v)
+            paddle.autograd.backward((out.cast("float32") * weight).sum())
+            sink_grad = (
+                None
+                if module.softmax_offset is None
+                else module.softmax_offset.grad.clone()
+            )
+            got[tag] = (
+                out,
+                tensors[0].grad,
+                tensors[1].grad,
+                w_v.grad,
+                sink_grad,
+            )
+        return expected, got
+
+    def _assert_no_worse(self, doc_lens, seqlen, sink):
+        row_end = _row_end(doc_lens, seqlen)
+        expected, got = self._measure(row_end, seqlen, sink)
+        for i, name in enumerate(("out", "dq", "dkv", "dw_v")):
+            floor = self._FORWARD_FLOOR if i == 0 else self._GRAD_FLOOR
+            dense = _rel(got["dense"][i], expected[i])
+            sparse = _rel(got["sparse"][i], expected[i])
+            with self.subTest(
+                quantity=name, docs=doc_lens, sink=sink is not None
+            ):
+                self.assertTrue(
+                    paddle.isfinite(got["dense"][i].cast("float32")).all()
+                )
+                self.assertLessEqual(
+                    dense,
+                    max(sparse * self._SLACK, floor),
+                    f"{name}: dense rel {dense:.3e} vs fp32 is worse than the "
+                    f"sparse path's {sparse:.3e} (docs={doc_lens}, s={seqlen}, "
+                    f"sink={sink is not None})",
+                )
+        return got
+
+    def test_forward_and_grads_no_worse_than_sparse_sinkless(self):
+        for doc_lens, seqlen in _LAYOUTS:
+            self._assert_no_worse(doc_lens, seqlen, None)
+
+    def test_forward_and_grads_no_worse_than_sparse_with_sink(self):
+        for doc_lens, seqlen in _LAYOUTS:
+            self._assert_no_worse(doc_lens, seqlen, _SINK)
+
+    def test_sink_gradient_cross_validates(self):
+        """Two independent computations of ``d_sink`` must agree.
+
+        FA4 differentiates the sink column natively. The sparse backend cannot:
+        the SM100 kernel returns an all-zero ``d_sink`` on the ``d_qk != d_v``
+        branch, so ``mqa_sparse_attn`` computes it analytically from the KV-only
+        LSE. Neither is a reference for the other, which is exactly why their
+        agreement is worth pinning -- a sign or scale error on either side would
+        show up here and nowhere else.
+
+        Measured: identical to the last bit on all three layouts (max abs diff
+        0.0, with ``|d_sink|`` up to 4.4), though ``d_sink`` is bf16, so read that
+        as agreement within bf16 resolution rather than as identical arithmetic.
+        """
+        for doc_lens, seqlen in _LAYOUTS:
+            row_end = _row_end(doc_lens, seqlen)
+            _, got = self._measure(row_end, seqlen, _SINK)
+            dense, sparse = got["dense"][4], got["sparse"][4]
+            with self.subTest(docs=doc_lens):
+                self.assertIsNotNone(dense)
+                self.assertTrue(paddle.isfinite(dense.cast("float32")).all())
+                self.assertGreater(
+                    float(dense.cast("float32").abs().max()), 0.0
+                )
+                self.assertLessEqual(_rel(dense, sparse), self._GRAD_FLOOR)
+
+
+@_GPU
+@_FA4
+class TestDenseWarmupPadRows(unittest.TestCase):
+    """A fully-masked query row must give zeros, not NaN.
+
+    ``_row_end`` fills the trailing gap with ``seqlen``, which
+    ``_derive_csa_doc_boundaries`` reads as one more document, so it produces no
+    pad rows at all; ``_pad_row_end`` repeats the last document's end instead,
+    which is the ``is_valid == False`` state a packed batch's padding actually
+    takes. On the sparse path such a row gets an all-``-1`` column list and the
+    kernel is structurally safe. On the dense path it is softmax over an
+    all-masked row -- a kernel property of FA4, hence a regression test.
+    """
+
+    def _run(self, sink):
+        doc_lens, seqlen = _PAD_LAYOUT
+        row_end = _pad_row_end(doc_lens, seqlen)
+        module = _module(sink=sink)
+        tensors, w_v = _inputs(seqlen)
+        with _flash_attn_version(4), _backend_spy(module) as calls:
+            out = _forward(module, tensors, row_end, w_v)
+        self.assertEqual(calls, ["dense"])
+        paddle.autograd.backward(out.cast("float32").sum())
+        return out.cast("float32"), tensors, w_v
+
+    def _assert_pad_rows_vanish(self, sink):
+        out, tensors, w_v = self._run(sink)
+        body = sum(_PAD_LAYOUT[0])
+        with self.subTest(sink=sink is not None):
+            self.assertTrue(paddle.isfinite(out).all())
+            self.assertEqual(float(out[0, body:].abs().max()), 0.0)
+            self.assertGreater(float(out[0, :body].abs().max()), 0.0)
+            for name, tensor in (
+                ("dq", tensors[0].grad),
+                ("dkv", tensors[1].grad),
+                ("dw_v", w_v.grad),
+            ):
+                self.assertIsNotNone(tensor, name)
+                self.assertTrue(
+                    paddle.isfinite(tensor.cast("float32")).all(), name
+                )
+
+    def test_pad_rows_are_zero_sinkless(self):
+        self._assert_pad_rows_vanish(None)
+
+    def test_pad_rows_are_zero_with_sink(self):
+        """With a sink the row is *not* empty -- the sink column is always there.
+
+        So this is the stronger statement: the zeroing comes from the caller's
+        ``is_valid`` masking downstream of the kernel, not from an accidental
+        ``exp(-inf)/exp(-inf)``.
+        """
+        self._assert_pad_rows_vanish(_SINK)
+
+
+@_GPU
+@_FA4
+class TestFrozenInputs(unittest.TestCase):
+    """Frozen inputs on the dense path, which ``train_indexer_only`` produces.
+
+    A ``PyLayer`` whose input arrives with ``stop_gradient=True`` must get
+    ``None`` back at that position, and ``flashmask_attention`` does not do that
+    -- it aborts with "backward function should return None at N position".
+    ``_dense_pylayer_inputs`` hands the kernel a ``stop_gradient=False``
+    detached proxy of every frozen input instead. Neither ``.detach()`` alone
+    nor ``* 1.0`` works, and the sparse backend needs none of this
+    (``csa_sparse_attn.py:178-182`` records ``attn_sink_needs_grad`` itself), so
+    the workaround is dense-only and its forward-neutrality is what has to be
+    pinned.
+
+    Which subset arrives frozen is a property of the configuration, not of this
+    layer: ``train_indexer_only`` freezes the backbone (so q/kv reach the kernel
+    frozen) while the sink is a parameter of its own, so all four combinations
+    below are reachable.
+    """
+
+    def _forward_with(self, freeze, freeze_qkv=False):
+        doc_lens, seqlen = _LAYOUTS[1]
+        row_end = _row_end(doc_lens, seqlen)
+        module = _module(sink=_SINK)
+        module.softmax_offset.stop_gradient = freeze
+        tensors, w_v = _inputs(seqlen)
+        if freeze_qkv:
+            # ``query`` / ``key`` are what become the kernel's q/k/v; freezing
+            # them while the sink stays trainable is the *partially* frozen case
+            # that trips the contract at position 1 rather than 3.
+            tensors[0].stop_gradient = True
+            tensors[1].stop_gradient = True
+        with _flash_attn_version(4), _backend_spy(module) as calls:
+            out = _forward(module, tensors, row_end, w_v)
+        self.assertEqual(calls, ["dense"])
+        paddle.autograd.backward(out.cast("float32").sum())
+        return out, module.softmax_offset, tensors
+
+    def test_frozen_sink_backward_runs_and_gets_no_gradient(self):
+        out, sink, tensors = self._forward_with(freeze=True)
+        self.assertTrue(paddle.isfinite(out.cast("float32")).all())
+        self.assertIsNone(sink.grad)
+        self.assertIsNotNone(tensors[0].grad)
+        self.assertTrue(paddle.isfinite(tensors[0].grad.cast("float32")).all())
+
+    def test_frozen_qkv_backward_runs_and_leaves_them_alone(self):
+        """Frozen q/kv with a trainable sink: only the sink may receive."""
+        out, sink, tensors = self._forward_with(freeze=False, freeze_qkv=True)
+        self.assertTrue(paddle.isfinite(out.cast("float32")).all())
+        self.assertIsNotNone(sink.grad)
+        self.assertTrue(paddle.isfinite(sink.grad.cast("float32")).all())
+        self.assertIsNone(tensors[0].grad, "frozen query received a gradient")
+        self.assertIsNone(tensors[1].grad, "frozen key received a gradient")
+
+    def test_everything_frozen_builds_no_grad_node(self):
+        """Nothing wants a gradient, so no proxy and no contract to satisfy."""
+        out, sink, tensors = self._forward_with(freeze=True, freeze_qkv=True)
+        self.assertTrue(paddle.isfinite(out.cast("float32")).all())
+        self.assertIsNone(sink.grad)
+        self.assertIsNone(tensors[0].grad)
+        self.assertIsNone(tensors[1].grad)
+
+    def test_freezing_does_not_change_the_forward(self):
+        """The proxy must be numerically the same tensor, bit for bit."""
+        trainable, sink, _ = self._forward_with(freeze=False)
+        self.assertIsNotNone(sink.grad)
+        reference = trainable.cast("float32")
+        for label, kwargs in (
+            ("frozen sink", {"freeze": True}),
+            ("frozen q/kv", {"freeze": False, "freeze_qkv": True}),
+            ("all frozen", {"freeze": True, "freeze_qkv": True}),
+        ):
+            with self.subTest(case=label):
+                out, _, _ = self._forward_with(**kwargs)
+                # ``equal_all`` has no bfloat16 kernel; the cast is exact.
+                self.assertTrue(
+                    paddle.equal_all(out.cast("float32"), reference),
+                    f"{label} changed the forward",
+                )

--- a/tests/single_card_tests/transformer/test_hybrid_mla_warmup_dense_fa4.py
+++ b/tests/single_card_tests/transformer/test_hybrid_mla_warmup_dense_fa4.py
@@ -340,6 +340,40 @@ class TestBackendSelection(unittest.TestCase):
         """
         self._assert_forward_refuses(_module(), deterministic=1)
 
+    def test_missing_flash_mask_extension_raises(self):
+        """FA4 as a flag value is not FA4 as a backend.
+
+        ``get_fa_version`` reads flags and head dims only, so on an image built
+        without the flash_mask (cute) extension it still answers 4 while the
+        facade has bound ``_flashmask_attention`` to Paddle's native one
+        (``flash_mask_facade.py``, ``else`` branch of the
+        ``is_flash_mask_available()`` guard) -- which serves neither this
+        head-dim pair nor the sink. Left to the kernel the failure reads
+        ``Invalid flash attention version: 4``, from a frame that names nothing
+        about this layer, so availability is part of the check here.
+        """
+        import paddlefleet_ops
+
+        module = _module()
+        row_end = _row_end([256], 256)
+        original = paddlefleet_ops.is_flash_mask_available
+        paddlefleet_ops.is_flash_mask_available = lambda: False
+        try:
+            with (
+                _flash_attn_version(4),
+                self.assertRaises(RuntimeError) as caught,
+            ):
+                module._assert_dense_fa4(576, 512, row_end)
+        finally:
+            paddlefleet_ops.is_flash_mask_available = original
+        message = str(caught.exception)
+        self.assertIn("requires FA4", message)
+        self.assertIn("flash_mask_available=False", message)
+        # Same call passes again with the extension back, so nothing but the
+        # availability answer decided it.
+        with _flash_attn_version(4):
+            self.assertIsNone(module._assert_dense_fa4(576, 512, row_end))
+
     def test_full_causal_phase_also_takes_the_dense_path(self):
         """Phase 1 attends over the same whole causal span, so same backend.
 

--- a/tests/single_card_tests/transformer/test_hybrid_mla_warmup_doc_mask_loss.py
+++ b/tests/single_card_tests/transformer/test_hybrid_mla_warmup_doc_mask_loss.py
@@ -16,9 +16,9 @@
 
 The warmup phase is ``hybrid_mla_attention="mqa_dsa"`` with
 ``dsa_indexer_use_sparse_loss=False``: the indexer is still being learned, so
-**attention** consumes the full per-document causal table
-(``MQALatentAttention._build_full_causal_indices`` ->
-``_build_mqa_causal_topk_idxs_from_doc_bounds``) and the KL is scored over that
+**attention** spans the full per-document causal set -- handed to dense FA4 as
+an ``O(s)`` flashmask row bound and never materialised
+(``_forward_full_causal`` -> ``_dense_attn``) -- and the KL is scored over that
 same full causal set (``MQALatentAttention._forward_warmup`` -> one
 ``paddlefleet.tilelang_ops.csa_indexer_topk_fwd`` call at
 ``topk_effective = s_global``). The phase-3 cuDNN top-k kernel runs zero times
@@ -28,15 +28,21 @@ need pinning here and not only on the phase-3 path
 ``test_hybrid_mla_doc_equivalence.py`` and ``test_mqa_latent_attention.py``
 already cover them.
 
+Column sets are read through ``hybrid_mla_utils._CAPTURED``: the sparse kernel's
+table literally, and on the dense path the column set the row bound the kernel
+received implies (``RecordingMQA._dense_attn``).
+
 What is proven here, and nowhere else:
 
-* ``TestWarmupFullCausalTable`` -- row ``i`` of the attention table is
-  *exactly* the column set ``[doc_start[i], i]``, on the layouts below plus a
+* ``TestWarmupFullCausalTable`` -- row ``i`` of that column set is *exactly*
+  ``[doc_start[i], i]``, on the layouts below plus a
   layout with genuine pad rows.
-* ``TestWarmupCrossDocumentIsolation`` -- zero cross-document leakage, in the
-  strong form the builder's docstring claims ("bit-identical to running each
-  document on its own"): measured ``maxabs == 0.0`` exactly, in both eval (the
-  ``:495`` early exit) and train (the ``:600`` branch).
+* ``TestWarmupCrossDocumentIsolation`` -- zero cross-document leakage: a packed
+  batch equals per-document runs, in both eval (the ``:495`` early exit) and
+  train (the ``:600`` branch). Dense FA4 derives its accumulation order from the
+  flashmask row bounds, so repacking is only reproducible to a few bf16 ULPs, not
+  bitwise; each layout therefore also measures a deliberately non-isolated
+  forward, which misses by ~60x that bound.
 * ``TestWarmupPadRows`` -- rows with ``is_valid == False``. ``_row_end`` cannot
   produce them (it turns the trailing gap into one final valid document), so
   ``_pad_row_end`` below keeps the gap folded into the last document instead,
@@ -82,13 +88,20 @@ from .hybrid_mla_utils import (
     V_HEAD_DIM,
     WINDOW,
     H,
+    _assert_agrees_to_bf16_ulps,
+    _assert_isolation_is_observable,
     _build_module,
     _check_index_invariants,
     _create_mqa_config,
     _doc_meta,
+    _fa4_module_hooks,
+    _full_causal_indices,
     _make_inputs,
+    _pad_row_end,
     _row_end,
 )
+
+setUpModule, tearDownModule = _fa4_module_hooks()
 
 _EPS = 1e-10  # mqa_latent_attention._EPS, the KL/renormalisation epsilon
 
@@ -119,28 +132,6 @@ _PAD_LAYOUTS = [
     ([40, 88], 256),  # 128 pad rows after two documents
     ([100, 50, 60], 256),  # 46 pad rows after three documents
 ]
-
-
-def _pad_row_end(doc_lens, seqlen):
-    """``[1, 1, s, 1]`` int32 ``row_end`` that produces real pad rows.
-
-    ``hybrid_mla_utils._row_end`` fills the trailing gap with ``seqlen``, which
-    ``_derive_csa_doc_boundaries`` reads as one more document, so every row comes
-    back ``is_valid``. Repeating the *last document's* end instead leaves
-    ``doc_len_per_pos`` short of ``pos_in_doc`` for the tail, which is the
-    ``is_valid == False`` state a packed batch's padding actually takes.
-    """
-    out = np.empty([seqlen], dtype="int32")
-    pos, end = 0, 0
-    for length in doc_lens:
-        end = pos + length
-        out[pos : min(end, seqlen)] = end
-        pos = end
-        if pos >= seqlen:
-            break
-    if pos < seqlen:
-        out[pos:] = end
-    return paddle.to_tensor(out).reshape([1, 1, seqlen, 1])
 
 
 def _segments(row_end, seqlen):
@@ -342,21 +333,21 @@ def _fp32(tensor):
 
 
 class TestWarmupFullCausalTable(unittest.TestCase):
-    """Row ``i`` of the warmup attention table is exactly ``[doc_start[i], i]``.
+    """Row ``i`` of the warmup column set is exactly ``[doc_start[i], i]``.
 
-    ``_build_full_causal_indices`` is ``indices = doc_start + offsets`` masked by
+    The set is ``indices = doc_start + offsets`` masked by
     ``(indices > positions) | ~is_valid``, a pure integer function of the
     document bounds -- no kernel, no float -- so it is assertable as an exact set
-    equality rather than a bound. Kernel-free, hence not GPU gated.
+    equality rather than a bound. Kernel-free, hence not GPU gated: production
+    hands the same set to FA4 as an ``O(s)`` row bound, and that the bound really
+    decodes to this set is what the ``_CAPTURED``-based classes below check.
     """
 
     def _assert_exact(self, row_end, seqlen):
         doc_start, _, is_valid, _, _ = _derive_csa_doc_boundaries(
             row_end, seqlen
         )
-        table = mqa_mod.MQALatentAttention._build_full_causal_indices(
-            1, seqlen, doc_start, is_valid
-        ).numpy()
+        table = _full_causal_indices(1, seqlen, doc_start, is_valid).numpy()
         self.assertEqual(list(table.shape), [1, seqlen, seqlen])
         starts = doc_start.numpy()
         valid = is_valid.numpy().astype(bool)
@@ -400,31 +391,26 @@ class TestWarmupFullCausalTable(unittest.TestCase):
 
 @_GPU
 class TestWarmupCrossDocumentIsolation(unittest.TestCase):
-    """Zero cross-document leakage, in the builder's own strong form.
+    """Zero cross-document leakage: a packed batch equals per-document runs.
 
-    ``_build_mqa_causal_topk_idxs_from_doc_bounds`` claims a packed batch is
-    "bit-identical to running each document on its own". Measured on the warmup
-    path: ``maxabs == 0.0`` exactly for every layout, in both modes -- eval takes
-    the ``:495`` early exit (indexer projections skipped entirely) and train
-    takes the ``:600`` branch (indexer runs, for the loss only). Exactness is
-    expected rather than merely hoped for, because the sparse kernel reduces each
-    query row over its own listed columns only, and those columns are identical
-    in the packed and the single-document run once the column ids are shifted.
+    Measured on the warmup path in both modes -- eval takes the ``:495`` early
+    exit (indexer projections skipped entirely) and train takes the ``:600``
+    branch (indexer runs, for the loss only).
+
+    The comparison is allowed a few bf16 ULPs rather than bit equality, because the
+    dense FA4 backend accumulates in an order it derives from the flashmask row
+    bounds and repacking changes those bounds
+    (``hybrid_mla_utils._assert_agrees_to_bf16_ulps``). Each layout also measures a
+    deliberately non-isolated forward, which misses by ~500x that bound, so the
+    tolerance cannot be hiding a leak.
     """
-
-    @classmethod
-    def setUpClass(cls):
-        try:
-            paddle.set_flags({"FLAGS_cudnn_deterministic": True})
-        except Exception:
-            pass
 
     def setUp(self):
         _CAPTURED.clear()
         DSAIndexerLossLoggingHelper.tracker.clear()
         self.module = _warmup_module()
 
-    def _worst_leak(self, layout, seqlen, training):
+    def _check_isolation(self, layout, seqlen, training):
         tensors, w_v = _leaves(seqlen)
         query, key, x, qr = tensors
         row_end = _row_end(layout, seqlen)
@@ -432,7 +418,18 @@ class TestWarmupCrossDocumentIsolation(unittest.TestCase):
         packed = _fp32(
             _forward(self.module, tensors, row_end, w_v, training=training)
         )
-        worst = 0.0
+        # Control: the same inputs with every document boundary removed. This is
+        # what a mask that failed to isolate would compute.
+        DSAIndexerLossLoggingHelper.tracker.clear()
+        no_isolation = _fp32(
+            _forward(
+                self.module,
+                tensors,
+                _row_end([seqlen], seqlen),
+                w_v,
+                training=training,
+            )
+        )
         for start, length in _segments(row_end, seqlen):
             sl = slice(start, start + length)
             DSAIndexerLossLoggingHelper.tracker.clear()
@@ -450,45 +447,47 @@ class TestWarmupCrossDocumentIsolation(unittest.TestCase):
                     training=training,
                 )
             )
-            worst = max(worst, float(np.abs(packed[:, sl] - piece).max()))
-        return worst
-
-    def test_packed_equals_single_bitwise_eval(self):
-        for layout, seqlen in _LAYOUTS:
-            with self.subTest(layout=layout):
-                worst = self._worst_leak(layout, seqlen, training=False)
-                self.assertEqual(
-                    worst, 0.0, f"{layout}: packed != single (eval)"
+            worst = _assert_agrees_to_bf16_ulps(
+                self,
+                packed[:, sl],
+                piece,
+                f"{layout} doc@{start} ({'train' if training else 'eval'})",
+            )
+            # Row 0's causal set is the same either way, so the control is
+            # only informative from the second document on.
+            if start > 0:
+                _assert_isolation_is_observable(
+                    self,
+                    worst,
+                    float(np.abs(no_isolation[:, sl] - piece).max()),
+                    packed[:, sl],
                 )
 
-    def test_packed_equals_single_bitwise_train(self):
+    def test_packed_equals_single_eval(self):
         for layout, seqlen in _LAYOUTS:
             with self.subTest(layout=layout):
-                worst = self._worst_leak(layout, seqlen, training=True)
-                self.assertEqual(
-                    worst, 0.0, f"{layout}: packed != single (train)"
-                )
+                self._check_isolation(layout, seqlen, training=False)
+
+    def test_packed_equals_single_train(self):
+        for layout, seqlen in _LAYOUTS:
+            with self.subTest(layout=layout):
+                self._check_isolation(layout, seqlen, training=True)
 
 
 @_GPU
 class TestWarmupPadRows(unittest.TestCase):
     """Rows outside every document must produce nothing and receive nothing.
 
-    A pad row's table entry is all ``-1`` with a forced per-query length of 1
-    (``_build_mqa_causal_topk_idxs_from_doc_bounds`` line 197-198), so the kernel
-    softmaxes over an empty set. Both the output and ``dq`` must be exactly zero:
-    a non-zero output would inject padding into the residual stream, and a
-    non-zero ``dq`` would train on it. Checked with the sink OFF and ON, because
-    the sink is the one column that survives the masking -- it is value-less, so
-    it must still contribute nothing.
+    The warmup's mask is the caller's ``O(s)`` row bound handed to dense FA4, and
+    on a pad row that bound leaves the visible span empty, so the kernel
+    softmaxes over nothing. ``RecordingMQA`` writes the bound out as the column
+    set it denotes (``_row_end_column_table``), where a pad row shows up as an
+    all-``-1`` row -- checked here alongside the numbers. Both the output and
+    ``dq`` must be exactly zero: a non-zero output would inject padding into the
+    residual stream, and a non-zero ``dq`` would train on it. Checked with the
+    sink OFF and ON, because the sink is the one column that survives the
+    masking -- it is value-less, so it must still contribute nothing.
     """
-
-    @classmethod
-    def setUpClass(cls):
-        try:
-            paddle.set_flags({"FLAGS_cudnn_deterministic": True})
-        except Exception:
-            pass
 
     def setUp(self):
         _CAPTURED.clear()
@@ -551,13 +550,6 @@ class TestWarmupIndexerLossPrecision(unittest.TestCase):
     boundary, i.e. exactly what the backward differentiates, and cross-checked
     against an independent fp32 recomputation of the logged scalar.
     """
-
-    @classmethod
-    def setUpClass(cls):
-        try:
-            paddle.set_flags({"FLAGS_cudnn_deterministic": True})
-        except Exception:
-            pass
 
     def setUp(self):
         _CAPTURED.clear()
@@ -882,13 +874,6 @@ class TestWarmupGradHealth(unittest.TestCase):
     CSA/HCA layouts, so its exact value is not a warmup property.
     """
 
-    @classmethod
-    def setUpClass(cls):
-        try:
-            paddle.set_flags({"FLAGS_cudnn_deterministic": True})
-        except Exception:
-            pass
-
     def setUp(self):
         _CAPTURED.clear()
         DSAIndexerLossLoggingHelper.tracker.clear()
@@ -981,19 +966,14 @@ class TestStarvedIndexerCandidates(unittest.TestCase):
       attention table still contains the complete per-document causal set --
       asserted as ``want - got == empty set``, not as a count;
     * consequently all three ``hybrid_mla_attention`` shapes (phase 3, warmup,
-      ``mqa_full_causal``) must produce **bit-identical** output on these
-      layouts, which is a much stronger statement than "no crash";
+      ``mqa_full_causal``) must produce the **same** output on these layouts,
+      which is a much stronger statement than "no crash" -- bitwise for the two
+      that share a backend and a row bound, and to a few bf16 ULPs across the
+      sparse/dense backend boundary (``_assert_agrees_to_bf16_ulps``);
     * an all-``-1`` candidate row means a softmax over an empty set, the classic
       NaN source, so output and every gradient are checked finite;
     * and no starved row may borrow a column from a neighbouring document.
     """
-
-    @classmethod
-    def setUpClass(cls):
-        try:
-            paddle.set_flags({"FLAGS_cudnn_deterministic": True})
-        except Exception:
-            pass
 
     def _module(self, mode, sparse_loss):
         config = _create_mqa_config(mode, loss_coeff=0.01)
@@ -1057,7 +1037,7 @@ class TestStarvedIndexerCandidates(unittest.TestCase):
                         f"row {row}: table has columns outside its document",
                     )
 
-    def test_all_three_modes_agree_bitwise_when_starved(self):
+    def test_all_three_modes_agree_when_starved(self):
         for layout, seqlen, note in _STARVED_LAYOUTS:
             _, starved = self._starved_rows(_row_end(layout, seqlen), seqlen)
             if starved < seqlen:
@@ -1066,11 +1046,18 @@ class TestStarvedIndexerCandidates(unittest.TestCase):
                 phase3, _ = self._run("mqa_dsa", True, seqlen, layout, False)
                 warmup, _ = self._run("mqa_dsa", False, seqlen, layout, False)
                 causal, _ = self._run("mqa", None, seqlen, layout, False)
-                self.assertEqual(
-                    float(np.abs(_fp32(phase3) - _fp32(warmup)).max()),
-                    0.0,
+                # phase 3 runs the sparse kernel and warmup runs dense FA4, so
+                # this is a cross-backend comparison: the column sets coincide
+                # here, the reduction order does not
+                # (``_assert_agrees_to_bf16_ulps``).
+                _assert_agrees_to_bf16_ulps(
+                    self,
+                    _fp32(phase3),
+                    _fp32(warmup),
                     "phase 3 != warmup although the window covers everything",
                 )
+                # Both of these are dense FA4 with the *same* row bound, so here
+                # bit equality is the right bar and it holds.
                 self.assertEqual(
                     float(np.abs(_fp32(warmup) - _fp32(causal)).max()),
                     0.0,

--- a/tests/single_card_tests/transformer/test_hybrid_mla_warmup_recompute_mtp_rope.py
+++ b/tests/single_card_tests/transformer/test_hybrid_mla_warmup_recompute_mtp_rope.py
@@ -28,9 +28,10 @@ compose *around* it and were previously only exercised in phase 3
    ``_forward_impl``. ON must equal OFF, the ``token_indices`` must be
    re-derived bit-identically, and the indexer loss must be attached exactly
    once, on the grad-enabled pass. Warmup is strictly stronger than phase 3
-   here: the table is ``_build_full_causal_indices``, a pure integer function of
-   the document bounds, so it is bit-identical even on the single-document
-   layout whose top-k order phase 3 cannot reproduce. It also *skips the indexer
+   here: the column set is a pure integer function of the document bounds (the
+   dense FA4 row bound, ``hybrid_mla_utils._full_causal_indices`` written out),
+   so it is bit-identical even on the single-document layout whose top-k order
+   phase 3 cannot reproduce. It also *skips the indexer
    entirely* on the ``no_grad`` pass (the ``mqa_latent_attention.py:495`` early
    exit), which phase 3 does not.
 2. **MTP** (``TestWarmupMTP``) -- ``MultiTokenPredictionLayer`` builds its
@@ -83,6 +84,7 @@ from .hybrid_mla_utils import (
     _build_module,
     _check_index_invariants,
     _create_mqa_config,
+    _fa4_module_hooks,
     _make_inputs,
     _rel,
     _row_end,
@@ -94,6 +96,8 @@ from .test_hybrid_mla_rope_audit import (
     ref_rope_halfsplit,
 )
 from .test_mqa_latent_attention import _fp32, _full_causal_table
+
+setUpModule, tearDownModule = _fa4_module_hooks()
 
 SEQLEN = 256
 # Two documents, the second longer than the forced window (so the indexer's
@@ -150,13 +154,6 @@ class TestWarmupRecompute(unittest.TestCase):
     during backward. Both forwards must agree on the sparsity pattern, or the
     backward differentiates a set of columns the forward never used.
     """
-
-    @classmethod
-    def setUpClass(cls):
-        try:
-            paddle.set_flags({"FLAGS_cudnn_deterministic": True})
-        except Exception:
-            pass
 
     def setUp(self):
         _CAPTURED.clear()
@@ -363,13 +360,6 @@ class TestWarmupMTP(unittest.TestCase):
     ``test_hybrid_mla_mtp_layer43_w6._build_mtp_module`` but with the phase-2
     switch off.
     """
-
-    @classmethod
-    def setUpClass(cls):
-        try:
-            paddle.set_flags({"FLAGS_cudnn_deterministic": True})
-        except Exception:
-            pass
 
     def setUp(self):
         _CAPTURED.clear()
@@ -828,13 +818,6 @@ class TestRecomputeInnerForwardBitIdentical(unittest.TestCase):
     document bounds. The captured-call count is asserted first, otherwise a
     single-forward implementation would make the comparison vacuous.
     """
-
-    @classmethod
-    def setUpClass(cls):
-        try:
-            paddle.set_flags({"FLAGS_cudnn_deterministic": True})
-        except Exception:
-            pass
 
     # ``mqa`` -> "mqa_full_causal"; the two ``mqa_dsa`` rows are warmup (wide
     # loss, full-causal attention) and phase 3 (narrow loss, top-k attention).

--- a/tests/single_card_tests/transformer/test_mqa_latent_attention.py
+++ b/tests/single_card_tests/transformer/test_mqa_latent_attention.py
@@ -100,10 +100,14 @@ from .hybrid_mla_utils import (
     _check_index_invariants,
     _create_mqa_config,
     _dense_reference,
+    _fa4_module_hooks,
+    _full_causal_indices,
     _make_inputs,
     _rel,
     _row_end,
 )
+
+setUpModule, tearDownModule = _fa4_module_hooks()
 
 # Adversarial document layouts: shorter than / equal to / longer than the
 # forced window, single-token documents, and a document overrunning the buffer.
@@ -122,14 +126,16 @@ _LAYOUTS = [
 
 
 def _full_causal_table(layout, seqlen):
-    """The per-document full-causal ``[1, s, s]`` table, from the production
-    builder itself -- it is a pure integer function of the document bounds.
+    """The per-document full-causal ``[1, s, s]`` table.
+
+    A pure integer function of the document bounds, shared with the CP suites
+    (``hybrid_mla_utils._full_causal_indices``). Production never materialises
+    it -- the dense FA4 backend gets the same column set as an ``O(s)`` row
+    bound -- so this is an independent derivation of what that mask must be.
     """
     row_end = _row_end(layout, seqlen)
     doc_start, _, is_valid, _, _ = _derive_csa_doc_boundaries(row_end, seqlen)
-    table = MQALatentAttention._build_full_causal_indices(
-        1, seqlen, doc_start, is_valid
-    )
+    table = _full_causal_indices(1, seqlen, doc_start, is_valid)
     return table.numpy()
 
 
@@ -774,13 +780,6 @@ class TestHybridMLAConfig(unittest.TestCase):
 class TestMQAEquivalence(unittest.TestCase):
     """The indexer-less full-causal path is mathematically identical to MHA."""
 
-    @classmethod
-    def setUpClass(cls):
-        try:
-            paddle.set_flags({"FLAGS_cudnn_deterministic": True})
-        except Exception:
-            pass
-
     def setUp(self):
         _CAPTURED.clear()
         self.module = _build_module(_create_mqa_config("mqa"))
@@ -825,8 +824,12 @@ class TestMQAEquivalence(unittest.TestCase):
         """The learnable sink is one extra value-less softmax column."""
         seqlen, layout = 256, [40, 88, 128]
         sink = np.linspace(1.0, 3.0, H)
-        module = _build_module(_create_mqa_config("mqa"), sink=sink)
-        self.assertEqual(module.softmax_offset.dtype, paddle.float32)
+        module = _build_module(_create_mqa_config("mqa"), bf16=True, sink=sink)
+        # The dense FA4 backend takes the sink as ``learnable_sink`` and asserts
+        # bf16 on it (``flash_mask/cute/interface.py:598``), which is what
+        # ``build_softmax_offset``'s ``params_dtype`` gives in production. An
+        # fp32 sink here would be testing a configuration the phase cannot run.
+        self.assertEqual(module.softmax_offset.dtype, paddle.bfloat16)
         self.assertEqual(list(module.softmax_offset.shape), [H])
         query, key, w_v = _make_inputs(seqlen)
         row_end = _row_end(layout, seqlen)
@@ -850,13 +853,6 @@ class TestMQAEquivalence(unittest.TestCase):
 @_GPU
 class TestMQADSA(unittest.TestCase):
     """The DSA (indexer) path: forced window + Lightning-indexer top-k."""
-
-    @classmethod
-    def setUpClass(cls):
-        try:
-            paddle.set_flags({"FLAGS_cudnn_deterministic": True})
-        except Exception:
-            pass
 
     def setUp(self):
         _CAPTURED.clear()
@@ -1041,10 +1037,13 @@ class TestMQADSA(unittest.TestCase):
           ``window + index_topk`` and the KL is restricted to that same set, so
           ``_attn_target`` is called once per step at exactly ``index_topk``.
 
-        Both column sets are asserted. The ``False`` attention table is *exactly*
-        assertable: it is ``_build_full_causal_indices``, a pure integer function
-        of the document bounds with no floating-point scoring in it, so it is
-        reproducible and equal to the builder's own output element for element.
+        Both column sets are asserted. The ``False`` branch has no column table
+        of its own -- dense FA4 is its only backend and carries the mask as an
+        ``O(s)`` row bound -- so ``RecordingMQA`` writes that bound out as the
+        ``[b, s, s]`` set it denotes (``_row_end_column_table``). That decoding is
+        a pure integer function of the document bounds with no floating-point
+        scoring in it, so it is reproducible and *exactly* assertable, element for
+        element, against ``_full_causal_table``.
 
         The ``True`` path stays statistical, which is the pre-existing measured
         fact this test still records: on a single full-length document neither
@@ -1301,13 +1300,6 @@ class TestMQADSAWarmupPhase(unittest.TestCase):
     # candidate range is non-empty on the late rows yet still excludes them.
     LAYOUT = [40, 216]
 
-    @classmethod
-    def setUpClass(cls):
-        try:
-            paddle.set_flags({"FLAGS_cudnn_deterministic": True})
-        except Exception:
-            pass
-
     def setUp(self):
         _CAPTURED.clear()
         DSAIndexerLossLoggingHelper.tracker.clear()
@@ -1347,13 +1339,15 @@ class TestMQADSAWarmupPhase(unittest.TestCase):
     def test_attention_output_equals_the_indexer_less_full_causal_path(self):
         """The core invariant: the indexer's *existence* must not move a bit.
 
-        Both paths call the same ``_build_full_causal_indices`` and then the
-        same sparse kernel, so the outputs must be bit-identical, not merely
-        close. Nothing needs weight copying: on this path attention consumes no
-        module parameter at all -- the query/key/``v_b_proj_weight`` are inputs
-        and ``softmax_offset`` is ``None`` in both -- so the only thing that
-        could differ is the index table. Asserted in both modes, so the
-        ``:495`` early exit and the full ``:600`` branch are each covered.
+        Both paths reach the same ``_forward_full_causal`` -- phase 1 directly
+        (``:500``), the warmup through it (``:629``) -- and so the same dense FA4
+        kernel with the same caller row bound, so the outputs must be
+        bit-identical, not merely close. Nothing needs weight copying: on this
+        path attention consumes no module parameter at all -- the
+        query/key/``v_b_proj_weight`` are inputs and ``softmax_offset`` is
+        ``None`` in both -- so the only thing that could differ is the mask.
+        Asserted in both modes, so the warmup's ``:636`` eval early exit and its
+        full indexer-loss branch are each covered.
         """
         query, key, w_v, x, qr = self._inputs()
         reference = _build_module(_create_mqa_config("mqa"), bf16=True)
@@ -1721,13 +1715,6 @@ class TestMQADSACudnnTarget(unittest.TestCase):
 
     TOPK = 512
     SEQLEN = 768  # > WINDOW + TOPK, so the table stays genuinely sparse
-
-    @classmethod
-    def setUpClass(cls):
-        try:
-            paddle.set_flags({"FLAGS_cudnn_deterministic": True})
-        except Exception:
-            pass
 
     def _build(self, topk):
         config = _create_mqa_config("mqa_dsa", loss_coeff=0.01)


### PR DESCRIPTION
### PR Category

Operator Mechanism

### PR Types

New features

### Description

Phase 1 (`hybrid_mla_attention="mqa_full_causal"`) and the phase-2 indexer
warmup of the DSv4 hybrid MLA both attend over the whole per-document causal
span. Until now both expressed that span as an explicit `[b, s, s]` int32 column
table for the FlashMLA sparse kernel, which is `O(s^2)` for no benefit: the
document structure is already in the caller's `startend_row_indices`, so FA4's
dense flashmask serves the same mask in `O(s)`. This PR makes dense FA4 the
**only** backend for those two phases, and makes it work under context parallel.

Net allocation on the production geometry (`h=64`, `d_v=256`, one document):

| s | table alone (old path) | dense forward + backward |
| --- | --- | --- |
| 8192 | 1.6 GiB | 3.3 GiB |
| 32768 | 25.0 GiB | 13.0 GiB |
| 65536 | 100.0 GiB | 26.0 GiB |

The table costs 6.25x its own `s^2` int32 (0.25 / 4.0 / 16.0 GiB); the rest is
int64 intermediates in the boundary derivation.

**No fallback: `_assert_dense_fa4`.** An environment where `get_fa_version` does
not resolve to FA4 for `(576, 512)` now raises `RuntimeError` naming both head
dims, `FLAGS_flash_attn_version` and `FLAGS_cudnn_deterministic`, rather than
silently substituting the column table. The two conditions are the same ones
phase 3 already needs (SM100+ selects FA4 in
`TrainingArguments.__post_init__`; FA4's big-head-dim backward asserts
`not deterministic` at `flash_mask/cute/interface.py:1238,1249`), so a config
that could take the fallback could not run phase 3 either. Past s=46336 the
fallback was not even correct: the sparse kernel flattens the table with int32
ids (`row * ceil64(topk) + col`), and s=46337 returns finite but **wrong**
numbers for its last 55 rows (cosine 0.7296) while only s=46341 crashes.

**Context parallel: `_cp_row_bounds`.** `flashmask_attention`'s `causal=True`
bottom-right-aligns the diagonal from the shapes alone
(`flashmask_utils.py:650,411`), which under CP is the correct offset for the
last rank only, and the caller's row bounds carry *global* row ids. Handing the
kernel the global bounds with `causal=True` returns silently wrong numbers on
the other ranks (measured cosine 2.7e-1 at cp_size=2, no exception). So
`_dense_attn` turns the kernel's causal mode off, appends `arange(s_global)` as
an explicit upper bound, and localises both bounds through
`preprocess_index(chunk_id=cp_rank, seq_blocksize=s_local)`. This is the
contract the rest of the model's CP attention already uses -- see
`dot_product_attention.py:614-617`, `multi_latent_attention.py:1233-1245`, and
`FlashMaskContextParallel` rejecting `causal=True` outright at
`context_parallel_utils.py:1116-1119`. Only `contiguous_allgather` is localised
this way, the one mode this class accepts.

**`_dense_pylayer_inputs`.** `flashmask_attention` is a `PyLayer`, and Paddle
requires its backward to return `None` at exactly the positions whose forward
input was `stop_gradient=True`; the flash kernel returns a dense gradient
everywhere, so a *partially* frozen call aborts with `FlashMaskFunc's backward
function should return None at N position`. Frozen inputs are the normal case
here -- the warmup runs under `train_indexer_only`, and the sink is a parameter
of its own. The helper passes everything through when nothing wants a gradient,
and otherwise substitutes a detached `stop_gradient=False` view for each frozen
input, so the unwanted gradient is dropped and the real tensor stays frozen.
Forward is bit-identical either way (measured).

**`flash_mask_facade`.**

* whitelist `(576, 512)` for FA4, but not under `FLAGS_cudnn_deterministic` --
  that pair is the only whitelisted one above 256, so it takes the big-head-dim
  backward. Without the extra term the accuracy-diff harnesses
  (`script/test_aadiff/check_aadiff.sh`, `script/run_compare_fleet_ec.sh`, both
  of which set the flag) abort in their first backward where they used to run on
  FA2. Degrading is what `fa_version == 3` already does a few lines above.
* extract `_needs_value_padding()`. The predicate was duplicated in
  `flashmask_attention` and `flash_attention` and had already drifted; padding
  `value` out to 576 makes the dims `(576, 576, 576)`, which
  `_is_valid_flash_dims` rejects. `dot_product_attention.py`'s
  `need_value_padding` gets the same exemption.

**Numerics.** Audited over three document layouts x {with, without sink} against
one fp32 eager autograd reference:

* dense is at least as close to fp32 as the sparse path it replaces on **every**
  quantity -- worst `1 - cos` is 8.2e-6 and `l2rel` stays within 1.3-2.6x of the
  bf16 rounding floor;
* `d_sink` agrees with the sparse path's analytic KV-only-LSE formula **bit for
  bit** (max abs diff 0.0), and both are within 1-2 ULP of an fp32 oracle
  cross-checked by central differences;
* cross-document leakage is zero in both directions: forward spans compare
  bit-identical, `dq` bit-identical between the two backends, `dkv` within 2 ULP
  against a 1-ULP run-to-run noise floor (a deliberately merged-document
  counterexample moves the same statistic by 770 ULP);
* padding rows produce an exactly empty softmax (`max|out| = 0.0`, `dq` and
  `dkv` identically zero), with and without sink;
* under `recompute` the two forward passes are bit-identical.

Under CP, on 8 GPUs at cp_size = 2 / 4 / 8: forward is **bit-identical** to the
single-card reference on every rank (`per_pos_max = 0.0`), `dq` likewise
(`0.00e+00`), and the phase-2 warmup equals phase 1 exactly (`maxabs = 0.0`),
which is what pins the frozen backbone's attention set. Residuals appear only in
`dkv` / `dw` / parameter gradients at 3.3e-3 -- 9.2e-3, the known bf16
reduction-order term. The indexer loss reassembles across ranks to
`rel <= 1.0e-7`.

Two kernel-level behaviour differences are documented in the code rather than
worked around, since neither is reachable from a healthy model: dense returns
finite values where a NaN `softmax_offset` is injected (sparse propagates the
NaN), and dense's backward overflows to Inf at `|q| ~ 5e4`, a regime in which
the fp32 reference gradient is already exactly 0 and both backends have long
since diverged from it.

**Tests.** `test_hybrid_mla_warmup_dense_fa4.py` (new) covers the FA4 refusal,
dense-vs-sparse-vs-fp32 agreement, and the deterministic-flag degradation.
Four multi-card suites cover CP: `test_mqa_dsa_warmup_cp.py`,
`test_mqa_dsa_cp.py`, `test_mla_cp_recompute.py`,
`test_mla_cp_contiguous_allgather.py`. The warmup CP suite decodes the row
bounds the kernel is actually handed back into per-row column sets and asserts
they are the global causal set localised to this rank, with an un-localised
control -- neither CP error raises on its own, so both are pinned by controls
rather than by shape assertions. `test_hybrid_mla_flex_checkpoint.py` is
removed: phase switching is specified to go through HF safetensors only, which
`test_hybrid_mla_hf_roundtrip.py` covers.

Behaviour of phase 3 (`dsa_indexer_use_sparse_loss=True`), of the CSA/HCA
layers, and of every other head-dim pair in the facade is unchanged.

### Port note

This is the forward port of #1725 (merged to `release/0.4` as `29d28310`),
applied with `git cherry-pick -x`. The only conflict was one docstring line in
`tests/multi_card_tests/transformer/test_mqa_dsa_cp.py` (`develop` words the run
recipe as "Run (2 GPUs), from the repository root::"), resolved in `develop`'s
favour. `tests/single_card_tests/transformer/test_hybrid_mla_flex_checkpoint.py`
does not exist on `develop`, so the deletion in #1725 has no counterpart here;
everything else applied unchanged. `develop`'s own additions to the files this
touches are preserved, including the `pad_token_id` `assert` -> `raise` rewrite
in `mqa_latent_attention.py` and the extra `split_kv_b_proj` / config-validation
/ sink-dtype cases in the test files.

Verified on this branch: ten single-card suites green
(`test_hybrid_mla_grad_health` 23, `test_mqa_latent_attention` 60,
`test_hybrid_mla_doc_equivalence` 35, `test_hybrid_mla_warmup_dense_fa4` 24,
`test_hybrid_mla_recompute_mtp_ckpt` 20, `test_hybrid_mla_warmup_doc_mask_loss`
17, `test_hybrid_mla_warmup_recompute_mtp_rope` 12, `test_hybrid_mla_hf_roundtrip`
9, `test_dsv4_hybrid_attention` 96, plus the CP suites below), and the five
multi-card CP suites green on 2 GPUs, run serially.

**Known CI gates on this PR:**

* `Coverage Upload And Check` will be red. Every test that exercises this code
  is gated on `is_dsa_available()` (SM100+ FlashMLA sparse fwd + cuDNN DSA bwd),
  and the coverage runners are A100 / H20, so the new lines are skipped rather
  than uncovered. Same situation as #1682 and as #1725 itself.
* `Check approval`: this touches
  `src/paddlefleet/transformer/transformer_config.py` (one `logger.warning`
  rewrite) and `packages/paddlefleet_ops`, so it needs the corresponding manual
  approvals.
