### PR TITLE
[release/0.4][Deps] Bump Paddle to `a136cd3594a`

### DIFF
--- a/.github/workflows/Test-release.yml
+++ b/.github/workflows/Test-release.yml
@@ -19,7 +19,7 @@ env:
   ci_scripts: /paddle/ci
   BRANCH: ${{ github.event.pull_request.base.ref || github.ref_name }}
   CI_name: test
-  no_proxy: "bcebos.com,.bcebos.com,apiin.im.baidu.com,gitee.com,aliyun.com,.baidu.com,.tuna.tsinghua.edu.cn"
+  no_proxy: "bcebos.com,.bcebos.com,apiin.im.baidu.com,gitee.com,aliyun.com,.baidu.com,.tuna.tsinghua.edu.cn,paddlepaddle.org.cn,.paddlepaddle.org.cn,www.paddlepaddle.org.cn"
   docker_image: "ccr-2vdh3abv-pub.cnc.bj.baidubce.com/paddlepaddle/paddle:ubuntu24-cuda129-py312-dev"
   build_image: "ccr-2vdh3abv-pub.cnc.bj.baidubce.com/paddlepaddle/paddle_manylinux_devel:cuda12.9-cudnn9.9-trt10.5-gcc11"
   formers_branch: "release/1.3"
@@ -132,7 +132,6 @@ jobs:
       CCACHE_MAXSIZE: 50G
       CCACHE_LIMIT_MULTIPLE: 0.8
       UV_HTTP_TIMEOUT: 600
-      no_proxy: ".bcebos.com,bcebos.com,apiin.im.baidu.com,gitee.com,aliyun.com,.baidu.com,.tuna.tsinghua.edu.cn"
     steps:
       - name: Check docker image and run container
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ description = "Fleet Core - Core Functional Library for Large Scale Distributed 
 requires-python = ">=3.10"
 dependencies = [
     "colorlog>=6.10.1",
-    "paddlepaddle-gpu==3.4.0.post20260808+733f3454aa0",
+    "paddlepaddle-gpu==3.4.0.post20260814+82457329611",
     "tilelang-paddle==0.1.12",
 ]
 license = { text = "Apache 2.0" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ description = "Fleet Core - Core Functional Library for Large Scale Distributed 
 requires-python = ">=3.10"
 dependencies = [
     "colorlog>=6.10.1",
-    "paddlepaddle-gpu==3.4.0.post20260814+82457329611",
+    "paddlepaddle-gpu==3.4.0.post20260812+a136cd3594a",
     "tilelang-paddle==0.1.12",
 ]
 license = { text = "Apache 2.0" }


### PR DESCRIPTION
### PR Category
Environment Adaptation

### PR Types
Others

### Description
Bump the pinned CUDA 12.9 Paddle dependency on `release/0.4` from `paddlepaddle-gpu==3.4.0.post20260808+733f3454aa0` to `paddlepaddle-gpu==3.4.0.post20260812+a136cd3594a`.

Target Paddle commit: [`a136cd3594a79a5cfe5109116c3085eb567ae509`](https://github.com/PaddlePaddle/Paddle/commit/a136cd3594a79a5cfe5109116c3085eb567ae509), the verified commit selected from Paddle's `release/3.4` history.

Merge sequencing: develop PR [#1747](https://github.com/PaddlePaddle/PaddleFleet/pull/1747) was created in parallel and must merge first; this release PR must remain blocked until then.

**Artifact verification:** the official CUDA 12.9 Linux x86_64 wheels for [CPython 3.10](https://paddle-whl.bj.bcebos.com/nightly/cu129/paddlepaddle-gpu/paddlepaddle_gpu-3.4.0.post20260812%2Ba136cd3594a-cp310-cp310-linux_x86_64.whl), [CPython 3.11](https://paddle-whl.bj.bcebos.com/nightly/cu129/paddlepaddle-gpu/paddlepaddle_gpu-3.4.0.post20260812%2Ba136cd3594a-cp311-cp311-linux_x86_64.whl), [CPython 3.12](https://paddle-whl.bj.bcebos.com/nightly/cu129/paddlepaddle-gpu/paddlepaddle_gpu-3.4.0.post20260812%2Ba136cd3594a-cp312-cp312-linux_x86_64.whl), and [CPython 3.13](https://paddle-whl.bj.bcebos.com/nightly/cu129/paddlepaddle-gpu/paddlepaddle_gpu-3.4.0.post20260812%2Ba136cd3594a-cp313-cp313-linux_x86_64.whl) were each verified to return HTTP 200 from Paddle's authoritative nightly artifact host.

**Local validation:** TOML and PEP 508 parsing, `git diff --check`, exact one-file/one-line delta and independent-base review, and `pre-commit run --files pyproject.toml` all pass.

### 是否引起精度变化
否