### PR TITLE
[release/0.4][New features] Dense cuDNN full-candidate KL for the DSA warmup phase

### DIFF
--- a/ci/multi-card_test.sh
+++ b/ci/multi-card_test.sh
@@ -73,6 +73,11 @@ gen_gpus_arg() {
 export FLAGS_embedding_deterministic=1
 export FLAGS_cudnn_deterministic=1
 export FLAGS_tcp_store_using_libuv=0
+# Tests are launched by path, so ``sys.path[0]`` is the test file's own
+# directory and ``tests`` is not importable as a package. Put the repository
+# root on the path so a test can import a helper that lives in another test
+# directory (e.g. ``tests.single_card_tests.transformer.hybrid_mla_utils``).
+export PYTHONPATH="$work_dir${PYTHONPATH:+:$PYTHONPATH}"
 
 run_count=0
 failed_tests=()

--- a/src/paddlefleet/cudnn_ops/__init__.py
+++ b/src/paddlefleet/cudnn_ops/__init__.py
@@ -25,6 +25,12 @@ from .indexer.csa_indexer_fwd_cudnn import (
     cudnn_indexer_topk,
     cudnn_indexer_topk_fwd,
 )
+from .indexer.dense_indexer_kl_cudnn import (
+    dense_attn_kl_scores,
+    dense_indexer_kl_bwd,
+    dense_indexer_kl_scores,
+    dense_kl_cu_seqlens,
+)
 
 __all__ = [
     "block_sparse_mqa_attention_dsa",
@@ -33,5 +39,9 @@ __all__ = [
     "cudnn_indexer_forward",
     "cudnn_indexer_topk",
     "cudnn_indexer_topk_fwd",
+    "dense_attn_kl_scores",
+    "dense_indexer_kl_bwd",
+    "dense_indexer_kl_scores",
+    "dense_kl_cu_seqlens",
     "is_dsa_available",
 ]

--- a/src/paddlefleet/cudnn_ops/indexer/dense_indexer_kl_cudnn.py
+++ b/src/paddlefleet/cudnn_ops/indexer/dense_indexer_kl_cudnn.py
@@ -1,0 +1,293 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Full-candidate (dense) DSA indexer KL, on the cuDNN-frontend dense triple.
+
+The DSA warmup phase supervises the indexer over **every** causal candidate, so
+there is no top-k to shrink the width. The TileLang full-candidate indexer
+cannot serve that past 8192 columns: its two bitonic buffers are sized
+``2 * topk``, so one block asks for ``16 * topk + 25344`` B of shared memory
+against an SM100 opt-in limit of 232448 B, and the launch fails with
+``Failed to set the allowed dynamic shared memory size``.
+
+The three dense cuDNN-frontend ops used here have no top-k stage at all, hence
+no width-proportional shared memory and no ``[s, width]`` tensor that has to
+survive until the backward:
+
+* :func:`dense_indexer_kl_scores` -- raw indexer score + its LSE, so
+  ``probs = exp(score - lse)`` is the indexer's prediction ``Q``;
+* :func:`dense_attn_kl_scores` -- ``sum_h exp(QK*scale - LSE_h)`` + its L1
+  norm, so ``score / l1norm`` is the KL target ``P``;
+* :func:`dense_indexer_kl_bwd` -- consumes both raw score matrices and emits
+  ``d_index_q / d_weights / d_index_k`` for ``coeff * (Q - P)``.
+
+Everything runs in THD (varlen) layout, which is what per-document packing and
+context parallel both need: ``cu_seqlens_q`` addresses the local query rows and
+``cu_seqlens_k`` the globally-gathered keys, so a query row's candidate set is
+its own document's causal prefix and nothing else. THD also compacts the score
+width to the longest *visible* document instead of the whole packed sequence.
+
+Weight convention: unlike the TileLang indexer and the sparse cuDNN pair, the
+dense indexer score is called with ``sm_scale=1.0`` and ``weights`` exactly as
+``DSAIndexer`` produced them, i.e. still carrying the pre-baked
+``head_dim**-0.5``. That skips the un-bake/re-bake bf16 round trip (measured:
+max_rel 8e-7 against an fp32 reference, versus 4.2e-4 when un-baked), and it
+means ``d_weights`` comes back in the same pre-baked space as ``weights``.
+"""
+
+from __future__ import annotations
+
+import paddle
+from paddlefleet_ops import CUDNN_FRONTEND_HINT, is_cudnn_frontend_available
+
+
+def _require_cudnn_frontend():
+    if not is_cudnn_frontend_available():
+        raise ImportError(CUDNN_FRONTEND_HINT)
+
+
+class _HashableTensor(paddle.Tensor):
+    """``paddle.Tensor`` with hashable ``shape`` / ``stride()``.
+
+    The dense wrappers key their compiled-kernel cache on ``q.shape`` and
+    ``q.stride()`` directly (``score_recompute/api.py`` ``key = (...)``), and
+    Paddle returns both as lists, which are unhashable.
+    """
+
+    @property
+    def shape(self):
+        return tuple(super().shape)
+
+    def stride(self, dim=None):
+        if dim is None:
+            return tuple(super().stride())
+        return super().stride(dim)
+
+
+def dense_kl_cu_seqlens(
+    segment_lens: list[int], seq_offset: int, seq_len: int
+) -> tuple:
+    """``(cu_seqlens_q, cu_seqlens_k, max_q, max_k, q_causal_offsets)``.
+
+    Thin ``ratio=1`` alias of the CP-aware helper the sparse indexer forward
+    already uses, so the two paths cannot drift on where a document border sits.
+
+    ``segment_lens`` must tile the **whole** global sequence, padding included
+    (see ``_doc_segment_lens`` on the caller side): a segment shorter than its
+    slot would let the next document's tokens into the causal prefix.
+    """
+    from .csa_indexer_fwd_cudnn import _make_cu_seqlens
+
+    return _make_cu_seqlens(
+        [int(n) for n in segment_lens], int(seq_offset), int(seq_len), 1
+    )
+
+
+def dense_indexer_kl_scores(
+    index_q: paddle.Tensor,
+    index_k: paddle.Tensor,
+    weights: paddle.Tensor,
+    cu_seqlens_q: paddle.Tensor,
+    cu_seqlens_k: paddle.Tensor,
+    max_seqlen_q: int,
+    max_seqlen_k: int,
+    q_causal_offsets: paddle.Tensor | None = None,
+) -> tuple[paddle.Tensor, paddle.Tensor]:
+    """Raw indexer score over every in-document causal candidate.
+
+    Args:
+        index_q: ``[s_local, H_i, D_i]`` bf16 indexer queries (local rows).
+        index_k: ``[s_global, D_i]`` bf16 indexer keys (globally gathered).
+        weights: ``[s_local, H_i]`` bf16 per-head weights, **pre-baked** with
+            ``head_dim**-0.5`` exactly as ``DSAIndexer`` emits them.
+        cu_seqlens_q, cu_seqlens_k, max_seqlen_q, max_seqlen_k,
+        q_causal_offsets: from :func:`dense_kl_cu_seqlens`.
+
+    Returns:
+        ``(score [s_local, max_seqlen_k] fp32, lse [s_local] fp32)``.
+        ``score`` is ``-inf`` outside the causal candidate set, so
+        ``exp(score - lse[:, None])`` is the softmax prediction with an exact
+        zero everywhere else.
+    """
+    _require_cudnn_frontend()
+    from paddlefleet_ops.cudnn.deepseek_sparse_attention.score_recompute.api import (
+        dense_indexer_score_recompute_wrapper,
+    )
+
+    res = dense_indexer_score_recompute_wrapper(
+        _HashableTensor(index_q.contiguous()),
+        _HashableTensor(index_k.unsqueeze(1).contiguous()),
+        _HashableTensor(weights.contiguous()),
+        qhead_per_kv_head=int(index_q.shape[1]),
+        # Pre-baked weights already carry ``head_dim**-0.5``; see the module
+        # docstring for why this is not the TileLang convention.
+        sm_scale=1.0,
+        ratio=1,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=int(max_seqlen_q),
+        max_seqlen_k=int(max_seqlen_k),
+        q_causal_offsets=q_causal_offsets,
+    )
+    return res["out"], res["denom"]
+
+
+def dense_indexer_kl_bwd(
+    index_q: paddle.Tensor,
+    weights: paddle.Tensor,
+    index_k: paddle.Tensor,
+    attn_score: paddle.Tensor,
+    attn_l1norm: paddle.Tensor,
+    index_score: paddle.Tensor,
+    index_lse: paddle.Tensor,
+    loss_coeff: float,
+    cu_seqlens_q: paddle.Tensor,
+    cu_seqlens_k: paddle.Tensor,
+    max_seqlen_q: int,
+    max_seqlen_k: int,
+    q_causal_offsets: paddle.Tensor | None = None,
+    grad_loss: paddle.Tensor | float | None = None,
+    block_I: int = 128,
+) -> tuple[paddle.Tensor, paddle.Tensor, paddle.Tensor]:
+    """``d_index_q / d_weights / d_index_k`` of the dense full-candidate KL.
+
+    The kernel derives both distributions from the raw score matrices --
+    ``predict = exp(index_score - index_lse)``,
+    ``target = attn_score / attn_l1norm`` -- and emits
+    ``grad_scale * (predict - target)`` as the score gradient, which is the same
+    quantity the TileLang branch spells out as
+    ``(topk_probs - target) * loss_coeff / num_rows``.
+
+    ``grad_scale = loss_coeff * grad_loss / total_q`` is fixed inside the
+    kernel, so the ``1 / total_q`` is *not* optional: a caller whose forward
+    divided by something else (a valid-token count, say) has to pre-multiply
+    ``loss_coeff`` by ``total_q / its_own_denominator``.
+
+    ``attn_score`` and ``index_score`` are consumed **in place** by the
+    score-gradient stage and are *not* copied here: at 64k/cp=8 one of them is
+    2 GiB, so cloning both would double the backward's width-proportional
+    footprint (measured 4.82 vs 3.79 matrix-equivalents of peak at s=16384).
+    Callers must therefore hand over matrices they are done with -- the warmup
+    backward recomputes both immediately before this call and drops them right
+    after. ``attn_l1norm`` and ``index_lse`` are read-only.
+
+    Setting ``index_lse[q] = +inf`` zeroes that row's gradient exactly: it
+    drives both ``predict`` and the kernel's ``log_clip_mask`` to 0. Zeroing
+    ``attn_l1norm`` instead would not -- the target clamp
+    ``max(target, exp(-100))`` leaves a residue.
+
+    ``d_index_k`` is allocated in fp32 and cast back here. The kernel reduces
+    dK through fp32 atomics regardless, and its own bf16 landing path ends in
+    ``d_index_k.copy_(d_index_k_f32)`` (``indexer_backward/api.py:414``), which
+    Paddle's ``copy_`` rejects across dtypes ("Tensor Copy cannot be
+    performed"). Handing it an fp32 buffer takes the branch that reduces in
+    place instead.
+    """
+    _require_cudnn_frontend()
+    from paddlefleet_ops.cudnn.deepseek_sparse_attention.indexer_backward.api import (
+        dense_indexer_backward_wrapper,
+    )
+
+    if grad_loss is None:
+        grad_loss = 1.0
+    if (
+        isinstance(grad_loss, paddle.Tensor)
+        and grad_loss.dtype != paddle.float32
+    ):
+        grad_loss = grad_loss.cast(paddle.float32)
+
+    out = dense_indexer_backward_wrapper(
+        _HashableTensor(index_q.contiguous()),
+        _HashableTensor(weights.contiguous()),
+        _HashableTensor(index_k.contiguous()),
+        _HashableTensor(attn_score),
+        _HashableTensor(attn_l1norm.contiguous()),
+        _HashableTensor(index_score),
+        _HashableTensor(index_lse.contiguous()),
+        # Matches the ``sm_scale=1.0`` / pre-baked-weights convention of
+        # ``dense_indexer_kl_scores``; the two must agree or the gradient is
+        # built on a different score than the forward measured.
+        sm_scale=1.0,
+        loss_coeff=float(loss_coeff),
+        grad_loss=grad_loss,
+        block_I=int(block_I),
+        ratio=1,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=int(max_seqlen_q),
+        max_seqlen_k=int(max_seqlen_k),
+        q_causal_offsets=q_causal_offsets,
+        d_index_k=_HashableTensor(
+            paddle.zeros(index_k.shape, dtype=paddle.float32)
+        ),
+    )
+    return (
+        out["d_index_q"],
+        out["d_weights"],
+        out["d_index_k"].cast(index_k.dtype),
+    )
+
+
+def dense_attn_kl_scores(
+    query: paddle.Tensor,
+    kv: paddle.Tensor,
+    lse: paddle.Tensor,
+    softmax_scale: float,
+    cu_seqlens_q: paddle.Tensor,
+    cu_seqlens_k: paddle.Tensor,
+    max_seqlen_q: int,
+    max_seqlen_k: int,
+    q_causal_offsets: paddle.Tensor | None = None,
+) -> tuple[paddle.Tensor, paddle.Tensor]:
+    """Head-summed attention probabilities, i.e. the raw KL target.
+
+    Computes ``score[q, t] = sum_h exp(Q_h.K_t * softmax_scale - LSE_h)`` and
+    ``l1norm[q] = sum_t score[q, t]``, so ``score / l1norm[:, None]`` is the
+    uniform head mixture ``(1/H) sum_h softmax_h`` the DSA KL uses as its
+    target -- **provided** ``lse`` is the true per-head log-sum-exp over the
+    same candidate set. Any other per-head constant silently produces a
+    *mass-weighted* mixture instead, so ``lse`` is not a free normaliser.
+
+    Args:
+        query: ``[s_local, H, D]`` bf16 absorbed queries (local rows).
+        kv: ``[s_global, D]`` bf16 latent keys (globally gathered).
+        lse: ``[s_local, H]`` fp32 per-head LSE over the candidate set. Rows set
+            to ``+inf`` come back as an all-zero score row, which is how an
+            inactive row is switched out of the loss.
+        softmax_scale: the attention scale, unchanged from the forward.
+
+    Returns:
+        ``(score [s_local, max_seqlen_k] fp32, l1norm [s_local] fp32)``.
+        Masked positions are ``-inf`` in ``score`` while ``l1norm`` only sums
+        the valid ones, so callers must ``clip(min=0)`` before normalising.
+    """
+    _require_cudnn_frontend()
+    from paddlefleet_ops.cudnn.deepseek_sparse_attention.score_recompute.api import (
+        dense_attn_score_recompute_wrapper,
+    )
+
+    res = dense_attn_score_recompute_wrapper(
+        _HashableTensor(query.contiguous()),
+        _HashableTensor(kv.unsqueeze(1).contiguous()),
+        _HashableTensor(lse.contiguous()),
+        float(softmax_scale),
+        qhead_per_kv_head=int(query.shape[1]),
+        ratio=1,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=int(max_seqlen_q),
+        max_seqlen_k=int(max_seqlen_k),
+        q_causal_offsets=q_causal_offsets,
+    )
+    return res["out"], res["denom"]

--- a/src/paddlefleet/transformer/mqa_latent_attention.py
+++ b/src/paddlefleet/transformer/mqa_latent_attention.py
@@ -118,6 +118,7 @@ from paddlefleet.transformer.csa_attention import (
 )
 from paddlefleet.transformer.dot_product_attention import build_softmax_offset
 from paddlefleet.transformer.dsa_attention import (
+    DSAIndexerLossAutoScaler,
     DSAIndexerLossLoggingHelper,
 )
 from paddlefleet.transformer.layer import FleetLayer
@@ -140,6 +141,21 @@ _LSE_INDEXER_TOPKS = (512, 1024, 2048)
 _TARGET_QHEAD_MIN = 16
 _NEG_INF = -1e30
 _EPS = 1e-10
+# Widest full-candidate KL the tilelang indexer can launch. Its two bitonic
+# buffers are sized ``2 * topk``, so one block asks for ``16 * topk + 25344`` B
+# against the SM100 opt-in limit of 232448 B: ``topk <= 12944``, i.e. 8192 as a
+# power of two. Measured: width 16384 fails with ``Failed to set the allowed
+# dynamic shared memory size to 287488``, 8192 launches. Not a config knob --
+# it is a property of the device -- so the warmup KL rejects wider spans and
+# points at ``csa_indexer_backend="cudnn"`` instead.
+_TILELANG_KL_MAX_WIDTH = 8192
+# Row-chunk budgets, in tensor elements, for the two loops of the dense
+# (full-candidate) warmup KL. The LSE loop materialises ``[c, h, k_end]`` twice
+# (bf16 matmul output plus its fp32 mask/where copy), so 16Mi elements is ~128MB
+# transient; the KL reduction materialises ``[c, width]`` a few times over, and
+# 64Mi elements keeps it in the same ballpark.
+_LSE_CHUNK_ELEMS = 1 << 24
+_KL_CHUNK_ELEMS = 1 << 26
 
 logger = logging.getLogger(__name__)
 
@@ -186,6 +202,22 @@ def _dense_pylayer_inputs(
     return tuple(proxy(t) for t in tensors)
 
 
+def _doc_segment_lens(doc_starts: Tensor, s_global: int) -> list[int]:
+    """Segment lengths that tile ``[0, s_global)``, padding slots included.
+
+    ``_derive_csa_doc_boundaries`` returns document *content* lengths, which stop
+    short of the slot when a document is padded. Feeding those to
+    ``dense_kl_cu_seqlens`` would leave a hole between segments and let the next
+    document's tokens into a query's causal prefix, so the borders are taken from
+    the starts instead: consecutive differences, with the tail reaching
+    ``s_global``. Padding rows keep their preceding document's segment, which is
+    what the row gating already assumes.
+    """
+    starts = [int(v) for v in doc_starts.tolist()]
+    ends = [*starts[1:], int(s_global)]
+    return [b - a for a, b in zip(starts, ends)]
+
+
 class _HashableTensor(paddle.Tensor):
     """``paddle.Tensor`` with hashable ``shape`` / ``stride()``.
 
@@ -202,6 +234,179 @@ class _HashableTensor(paddle.Tensor):
         if dim is None:
             return tuple(super().stride())
         return super().stride(dim)
+
+
+@dataclass
+class DenseWarmupKLPlan:
+    """Everything the dense warmup KL backward needs that is not a grad input.
+
+    Passed to :class:`DenseWarmupIndexerLossAutoScaler` as a single opaque
+    object on purpose: Paddle's ``PyLayer`` counts *tensor* arguments to decide
+    how many gradients ``backward`` must return, so bundling the THD descriptors
+    in here keeps that count at the four differentiable tensors instead of
+    making it depend on which of ``q_causal_offsets`` / ``row_active`` happens to
+    be present.
+
+    Attributes:
+        cu_seqlens_q, cu_seqlens_k, max_seqlen_q, max_seqlen_k,
+        q_causal_offsets: THD descriptors from ``dense_kl_cu_seqlens``, shared
+            by the indexer score, the attention score and the backward -- all
+            three must see the same segmentation and the same ``max_seqlen_k``,
+            since the backward's shape check ties the two score matrices
+            together.
+        loss_coeff: already carries the ``total_q / num_rows`` compensation for
+            the backward kernel's built-in ``1 / total_q``; see
+            :meth:`MQALatentAttention._warmup_kl_dense_cudnn`.
+        softmax_scale: the attention scale, needed to recompute the target.
+        block_I: backward tile width.
+    """
+
+    cu_seqlens_q: Tensor
+    cu_seqlens_k: Tensor
+    max_seqlen_q: int
+    max_seqlen_k: int
+    q_causal_offsets: Tensor | None
+    loss_coeff: float
+    softmax_scale: float
+    block_I: int = 128
+
+
+class DenseWarmupIndexerLossAutoScaler(paddle.autograd.PyLayer):
+    """Attach the dense full-candidate warmup KL gradient to the main output.
+
+    The dense counterpart of ``TileLangCSAIndexerLossAutoScaler``, and separate
+    from it on purpose: that class carries a ``[b, s, width]`` ``target`` and
+    ``topk_probs`` pair from forward into backward, which is exactly the
+    ``O(s_local x s_global)`` residency this path exists to remove. Here nothing
+    width-proportional is saved -- the backward recomputes both score matrices
+    from the same inputs the forward used, which is what the cuDNN dense triple
+    is designed for.
+
+    Saved tensors are the recompute inputs (``index_q`` / ``weights`` /
+    ``index_k`` / ``query`` / ``kv``) plus the tiny ``[s_local, h]`` attention
+    LSE. ``attn_lse`` is *not* recomputable cheaply, and it is also where row
+    gating lives: an inactive row carries ``+inf``, which makes its attention
+    score row zero and, together with the ``+inf`` this backward writes into
+    ``index_lse``, drives the row's gradient to an exact zero.
+    """
+
+    @staticmethod
+    def forward(
+        ctx,
+        output: Tensor,
+        index_q: Tensor,
+        weights: Tensor,
+        index_k: Tensor,
+        query: Tensor,
+        kv: Tensor,
+        attn_lse: Tensor,
+        row_active: Tensor,
+        plan: DenseWarmupKLPlan,
+    ) -> Tensor:
+        ctx.save_for_backward(
+            index_q.detach(),
+            weights.detach(),
+            index_k.detach(),
+            query.detach(),
+            kv.detach(),
+            attn_lse.detach(),
+            row_active,
+        )
+        ctx.plan = plan
+        # Same contract as ``TileLangCSAIndexerLossAutoScaler.forward``: with the
+        # backbone frozen, ``output`` is a leaf with ``stop_gradient=True`` and
+        # returning it unchanged would look like an inplace alias.
+        ctx.output_needs_grad = not output.stop_gradient
+        return output if ctx.output_needs_grad else output.clone()
+
+    @staticmethod
+    def backward(ctx, grad_output: Tensor):
+        from paddlefleet.cudnn_ops import (
+            dense_attn_kl_scores,
+            dense_indexer_kl_bwd,
+            dense_indexer_kl_scores,
+        )
+
+        (
+            index_q,
+            weights,
+            index_k,
+            query,
+            kv,
+            attn_lse,
+            row_active,
+        ) = ctx.saved_tensor()
+        plan = ctx.plan
+        thd = {
+            "cu_seqlens_q": plan.cu_seqlens_q,
+            "cu_seqlens_k": plan.cu_seqlens_k,
+            "max_seqlen_q": plan.max_seqlen_q,
+            "max_seqlen_k": plan.max_seqlen_k,
+            "q_causal_offsets": plan.q_causal_offsets,
+        }
+
+        index_score, index_lse = dense_indexer_kl_scores(
+            index_q, index_k, weights, **thd
+        )
+        # Row gating, and the reason it sits on ``index_lse`` rather than on the
+        # attention side: ``+inf`` here zeroes both factors of the kernel's score
+        # gradient (``predict = exp(score - lse) -> 0`` and
+        # ``log_clip_mask -> 0``), so the row contributes exactly nothing.
+        # Zeroing ``attn_l1norm`` instead would leave the target clamp
+        # ``max(target, exp(-100))`` behind as a residue.
+        index_lse = paddle.where(
+            row_active, index_lse, paddle.full_like(index_lse, float("inf"))
+        )
+        attn_score, attn_l1norm = dense_attn_kl_scores(
+            query,
+            kv,
+            attn_lse,
+            plan.softmax_scale,
+            **thd,
+        )
+        # Masked columns come back as ``-inf``; the kernel would survive them
+        # (``log_clip_mask`` is 0 there) but the clamp on a ``-inf`` target is
+        # not worth relying on, and this costs one pass over a matrix that is
+        # about to be consumed in place anyway.
+        attn_score = attn_score.clip_(min=0.0)
+
+        scale = DSAIndexerLossAutoScaler._main_loss_backward_scale
+        grad_loss = 1.0 if scale is None else scale
+
+        grad_q, grad_weights, grad_k = dense_indexer_kl_bwd(
+            index_q,
+            weights,
+            index_k,
+            attn_score,
+            attn_l1norm,
+            index_score,
+            index_lse,
+            loss_coeff=plan.loss_coeff,
+            grad_loss=grad_loss,
+            block_I=plan.block_I,
+            **thd,
+        )
+        if grad_q.dtype != index_q.dtype:
+            grad_q = grad_q.cast(index_q.dtype)
+        if grad_weights.dtype != weights.dtype:
+            grad_weights = grad_weights.cast(weights.dtype)
+        if grad_k.dtype != index_k.dtype:
+            grad_k = grad_k.cast(index_k.dtype)
+
+        grad_main = grad_output if ctx.output_needs_grad else None
+        # Tensor inputs in signature order: output, index_q, weights, index_k,
+        # query, kv, attn_lse, row_active. The last four are recompute inputs
+        # only -- they arrive detached, so ``None`` is the required answer.
+        return (
+            grad_main,
+            grad_q,
+            grad_weights,
+            grad_k,
+            None,
+            None,
+            None,
+            None,
+        )
 
 
 @dataclass
@@ -250,10 +455,12 @@ class MQADocMeta:
     doc_len_per_pos: Tensor
     is_valid: Tensor
     doc_lens: Tensor
+    doc_starts: Tensor
     _window_topk_idxs: Tensor | None = None
     _window_size: int | None = None
     _valid_range: dict[int, tuple[Tensor, Tensor]] | None = None
     _cu_seqlens_arg: tuple[list[int] | None] | None = None
+    _segment_lens: list[int] | None = None
 
     @classmethod
     def build(
@@ -270,7 +477,7 @@ class MQADocMeta:
                     [batch_size, 1, seqlen, 1], seqlen, dtype="int32"
                 )
             _validate_csa_docmask_shape(row_end, batch_size, seqlen)
-            doc_start, doc_len, is_valid, doc_lens, _ = (
+            doc_start, doc_len, is_valid, doc_lens, doc_starts = (
                 _derive_csa_doc_boundaries(row_end, seqlen)
             )
         return cls(
@@ -280,6 +487,7 @@ class MQADocMeta:
             doc_len_per_pos=doc_len,
             is_valid=is_valid,
             doc_lens=doc_lens,
+            doc_starts=doc_starts,
         )
 
     # ------------------------------------------------------------------
@@ -376,6 +584,17 @@ class MQADocMeta:
             )
         return self._cu_seqlens_arg[0]
 
+    def doc_segment_lens(self) -> list[int]:
+        """Host-side segment lengths that tile ``[0, seqlen)``.
+
+        What the dense warmup KL needs instead of ``cu_seqlens_arg``: see
+        :func:`_doc_segment_lens` for why the borders come from the starts and
+        not from ``doc_lens``. Cached for the same reason -- it is a D2H sync.
+        """
+        if self._segment_lens is None:
+            self._segment_lens = _doc_segment_lens(self.doc_starts, self.seqlen)
+        return self._segment_lens
+
     def warm(self, window_size: int) -> None:
         """Build the cheap tables now so no layer builds them inside the forward.
 
@@ -401,6 +620,7 @@ class MQADocMeta:
         self._global_valid_range(window_size)
         self._global_valid_range(0)
         self.cu_seqlens_arg()
+        self.doc_segment_lens()
 
 
 class MQALatentAttention(FleetLayer):
@@ -699,7 +919,7 @@ class MQALatentAttention(FleetLayer):
         # kernel as the mask, so it is needed either way, and normalising it is
         # ``O(1)`` -- the part worth sharing is ``_derive_csa_doc_boundaries``.
         meta = None
-        doc_start = doc_len = is_valid = doc_lens = None
+        doc_start = doc_len = is_valid = doc_lens = doc_starts = None
         if docmask_mb_idx >= 0 and getattr(
             self.config, "mqa_share_docmask_meta", False
         ):
@@ -712,7 +932,7 @@ class MQALatentAttention(FleetLayer):
             )
         if meta is None:
             with paddle.no_grad():
-                doc_start, doc_len, is_valid, doc_lens, _ = (
+                doc_start, doc_len, is_valid, doc_lens, doc_starts = (
                     _derive_csa_doc_boundaries(row_end, s_global)
                 )
 
@@ -736,6 +956,7 @@ class MQALatentAttention(FleetLayer):
                 doc_start,
                 doc_len,
                 is_valid,
+                doc_starts,
                 kv_lora_rank,
                 input_ids,
                 position_offset,
@@ -806,6 +1027,7 @@ class MQALatentAttention(FleetLayer):
         doc_start: Tensor,
         doc_len: Tensor,
         is_valid: Tensor,
+        doc_starts: Tensor,
         kv_lora_rank: int,
         input_ids: Tensor | None,
         position_offset: int,
@@ -846,9 +1068,24 @@ class MQALatentAttention(FleetLayer):
         over the global sequence and row-sliced, and ``valid_rows`` is the global
         valid-row count -- so the per-rank losses sum to the single-rank one and
         no ``/cp_size`` correction is needed.
-        """
-        from paddlefleet.tilelang_ops import csa_indexer_topk_fwd
 
+        Two KL backends, chosen by ``config.csa_indexer_backend``:
+
+        * ``"tilelang"`` (default) -- the single ``csa_indexer_topk_fwd`` call
+          described above. Its two bitonic buffers make the shared-memory
+          request proportional to the candidate width, so it stops at
+          ``_TILELANG_KL_MAX_WIDTH``;
+        * ``"cudnn"`` -- the dense cuDNN triple, which has no top-k stage and
+          therefore neither the shared-memory wall nor an ``[s, width]`` tensor
+          that has to survive into the backward. See
+          :meth:`_warmup_kl_dense_cudnn`.
+
+        Both compute the same objective; the switch is a memory/width trade, not
+        a change of loss. The field's third value, ``"unfused"``, has no
+        full-candidate implementation of its own and is served by tilelang --
+        explicitly, and with tilelang's width and head-count limits still
+        enforced by name.
+        """
         output = self._forward_full_causal(
             query,
             kv,
@@ -859,8 +1096,37 @@ class MQALatentAttention(FleetLayer):
         if not self._needs_indexer_loss():
             return output
 
+        backend = self.config.csa_indexer_backend
+        if backend == "cudnn":
+            return self._warmup_kl_dense_cudnn(
+                output,
+                query,
+                kv,
+                x,
+                qr,
+                doc_start,
+                is_valid,
+                doc_starts,
+                input_ids,
+                position_offset,
+                s_local,
+                s_global,
+                meta=meta,
+            )
+        # ``__post_init__`` narrowed the field to {unfused, tilelang, cudnn}, so
+        # everything left here is ``tilelang`` or ``unfused``, and both are
+        # served by tilelang: this phase's KL never had a pure-paddle
+        # implementation to offer as ``unfused`` (the reference
+        # ``FusedDSAIndexerLoss`` is a top-k loss, not a full-candidate one), and
+        # several existing hybrid-MLA suites configure ``unfused`` while running
+        # this path. Tilelang's own two limits are not silent under that name:
+        # the check below runs before the import and raises naming the width or
+        # head bound and pointing at ``"cudnn"``.
+        self._check_tilelang_indexer_support(s_global)
+
+        from paddlefleet.tilelang_ops import csa_indexer_topk_fwd
+
         b = int(query.shape[0])
-        self._check_tilelang_indexer_support()
         index_q, index_k, weights = self._indexer_projections(
             x, qr, position_offset, grad_enabled=True
         )
@@ -955,22 +1221,304 @@ class MQALatentAttention(FleetLayer):
             loss_mask,
         )
 
-    def _check_tilelang_indexer_support(self) -> None:
-        """Fail loudly on the one tilelang indexer constraint we cannot absorb.
+    # ------------------------------------------------------------------
+    # warmup KL, dense (full-candidate cuDNN) backend
+    # ------------------------------------------------------------------
+    def _warmup_kl_dense_cudnn(
+        self,
+        output: Tensor,
+        query: Tensor,
+        kv: Tensor,
+        x: Tensor,
+        qr: Tensor,
+        doc_start: Tensor,
+        is_valid: Tensor,
+        doc_starts: Tensor,
+        input_ids: Tensor | None,
+        position_offset: int,
+        s_local: int,
+        s_global: int,
+        meta: MQADocMeta | None = None,
+    ) -> Tensor:
+        """Phase-2 KL over every causal candidate, on the dense cuDNN triple.
 
-        The top-k *width* needs no check: the wrappers round ``topk_effective``
-        up to a power-of-two multiple of their block and crop the result back
-        (``csa_indexer_fwd.py:430-462``, ``csa_indexer_bwd.py:617-638``), so any
-        causal span from 1 upwards is served -- measured at
-        s = 1/2/4/8/16/32/300/384/512/8192.
+        Same objective as the tilelang branch, and deliberately the same
+        arithmetic: identical KL expression, identical ``_EPS``, identical
+        denominator convention. What changes is where the ``[s_local, width]``
+        matrices live -- transient inside this forward and *recomputed* in the
+        backward, rather than carried across by the autoscaler. At 64k/cp=8 that
+        is two temporaries against three resident 2 GiB tensors per layer, and it
+        is what removes the tilelang shared-memory ceiling entirely.
 
-        The head count is different: ``index_n_heads`` other than 64 trips the
-        kernel's warp tiling with a bare
-        ``Check failed: (m_warp * n_warp == num_warps)`` from inside tilelang
-        (measured with 8). Reject that here rather than at the launch. It is not
-        checked at config time on purpose -- that would make every
-        small-geometry unit fixture unrepresentable.
+        Row gating collapses into a single ``row_active [s_local]``: a row is in
+        the loss when its document is real (``is_valid``) *and* its token is not
+        padding (``loss_mask``). With ``window=0`` those are exactly the rows the
+        tilelang branch keeps, since ``row_empty == ~is_valid`` there. Setting
+        ``attn_lse = +inf`` on an inactive row zeroes its whole attention-score
+        row, hence ``target == 0`` and a zero KL term -- no separate mask
+        multiply. The backward additionally forces ``index_lse = +inf`` there,
+        which zeroes that row's gradient exactly.
+
+        THD, not BSHD, even though the batch is always 1: the dense op's BSHD
+        mode takes one ``q_causal_offsets`` entry per *batch* element
+        (``_interface_sm100.py:748``), so it can only express a single causal
+        span for the whole packed sequence. ``cu_seqlens`` is what makes
+        per-document masking -- and the CP left border -- expressible at all, and
+        it also compacts ``max_seqlen_k`` to the longest visible document. The
+        layout change itself is free: ``[1, s, ...] -> [s, ...]`` is a view.
         """
+        from paddlefleet.cudnn_ops import (
+            dense_attn_kl_scores,
+            dense_indexer_kl_scores,
+            dense_kl_cu_seqlens,
+        )
+
+        self._check_cudnn_dense_indexer_support()
+        # Prebuilt shared metadata, when the trainer made one: the tables it
+        # holds are the very same global ones the inline path derives, so only
+        # the source changes here -- and the segment-length D2H has already been
+        # paid off the pipeline schedule.
+        if meta is not None:
+            doc_start, is_valid = meta.doc_start_per_pos, meta.is_valid
+            segment_lens = meta.doc_segment_lens()
+        else:
+            segment_lens = _doc_segment_lens(doc_starts, s_global)
+        # Left pre-baked, unlike the tilelang branch: the dense score is called
+        # with ``sm_scale=1.0``, which skips the un-bake/re-bake bf16 round trip
+        # (measured max_rel 8e-7 against an fp32 reference, versus 4.2e-4 when
+        # un-baked). ``d_weights`` therefore comes back in pre-baked space too.
+        index_q, index_k, weights = self._indexer_projections(
+            x, qr, position_offset, grad_enabled=True
+        )
+        # Grad-carrying THD views: slicing off the batch axis is differentiable,
+        # so the gradients this returns still reach the indexer parameters, and
+        # the ``PyLayer`` gets tensors whose shape already matches what the dense
+        # ops (and hence their gradients) use.
+        iq, ik, iw = index_q[0], index_k[0], weights[0]
+        query_thd, kv_thd = query[0].detach(), kv[0].detach()
+        with paddle.no_grad():
+            loss_mask, valid_rows = self._indexer_loss_mask(
+                input_ids, 1, s_local
+            )
+            row_active = is_valid[position_offset : position_offset + s_local]
+            if loss_mask is None:
+                # ``kl.mean()`` on the tilelang side divides by *every* row,
+                # doc-invalid ones included (they contribute 0). Same here.
+                num_rows = float(s_local)
+                coeff = self.indexer_loss_coeff / self.cp_size
+            else:
+                row_active = row_active & (loss_mask.reshape([s_local]) > 0)
+                num_rows = float(valid_rows)
+                coeff = self.indexer_loss_coeff
+
+            cu_q, cu_k, max_q, max_k, q_off = dense_kl_cu_seqlens(
+                segment_lens,
+                position_offset,
+                s_local,
+            )
+            thd = {
+                "cu_seqlens_q": cu_q,
+                "cu_seqlens_k": cu_k,
+                "max_seqlen_q": max_q,
+                "max_seqlen_k": max_k,
+                "q_causal_offsets": q_off,
+            }
+            attn_lse = self._dense_kl_attn_lse(
+                query_thd, kv_thd, doc_start, position_offset, row_active
+            )
+            index_score, index_lse = dense_indexer_kl_scores(
+                iq.detach(), ik.detach(), iw.detach(), **thd
+            )
+            attn_score, attn_l1norm = dense_attn_kl_scores(
+                query_thd, kv_thd, attn_lse, self.softmax_scale, **thd
+            )
+            loss = (
+                self._dense_kl_reduce(
+                    index_score,
+                    index_lse,
+                    # Masked columns come back as ``-inf``; clip before they
+                    # reach the division by ``attn_l1norm``.
+                    attn_score.clip_(min=0.0),
+                    attn_l1norm,
+                    num_rows,
+                )
+                * coeff
+            )
+            del index_score, index_lse, attn_score, attn_l1norm
+
+        DSAIndexerLossLoggingHelper.save_loss_to_tracker(
+            loss=loss,
+            layer_number=self.layer_number,
+            num_layers=DSAIndexerLossLoggingHelper.get_total_num_layers(
+                self.config
+            ),
+        )
+        plan = DenseWarmupKLPlan(
+            cu_seqlens_q=cu_q,
+            cu_seqlens_k=cu_k,
+            max_seqlen_q=max_q,
+            max_seqlen_k=max_k,
+            q_causal_offsets=q_off,
+            # ``dense_indexer_kl_bwd`` hardcodes ``/ total_q`` (= ``s_local``)
+            # inside the kernel, so pre-multiply to land on the ``/ num_rows``
+            # this forward actually used. Same compensation as
+            # ``csa_attention.py:1338-1349``.
+            loss_coeff=coeff * s_local / num_rows,
+            softmax_scale=self.softmax_scale,
+        )
+        return DenseWarmupIndexerLossAutoScaler.apply(
+            output,
+            iq,
+            iw,
+            ik,
+            query_thd,
+            kv_thd,
+            attn_lse,
+            row_active,
+            plan,
+        )
+
+    def _dense_kl_attn_lse(
+        self, query, kv, doc_start, position_offset, row_active
+    ) -> Tensor:
+        """``[s_local, h]`` fp32 per-head LSE over the KL candidate set.
+
+        ``dense_attn_kl_scores`` needs the true per-head log-sum-exp *over the
+        same candidate set* to produce the uniform head mixture the DSA KL
+        targets; any other per-head constant silently yields a mass-weighted
+        mixture instead. It cannot be taken from the attention forward: the
+        flashmask facade flattens its LSE to ``[b, s]``
+        (``flash_mask_facade.py:205``), which cannot hold a per-head one. And the
+        candidate set is narrower than the attention's anyway -- no forced window,
+        no sink -- so even a per-head FA4 LSE would be the wrong normaliser
+        (measured gap 4.4e-3 at the production sink init; see
+        :meth:`_attn_target`).
+
+        So it is computed here, chunked over query rows. The logits are a bf16
+        matmul rounded to bf16 on output while the cuDNN kernel scores in fp32;
+        that shows up as a sub-percent per-head mass error, inside the band bf16
+        reduction reordering already occupies on this path.
+        """
+        h, s_global = int(query.shape[1]), int(kv.shape[0])
+        s_local = int(query.shape[0])
+        seg_start = doc_start[position_offset : position_offset + s_local]
+        rows = paddle.arange(
+            position_offset, position_offset + s_local, dtype="int64"
+        )
+        chunk = max(1, _LSE_CHUNK_ELEMS // max(h * s_global, 1))
+        parts = []
+        for beg in range(0, s_local, chunk):
+            end = min(beg + chunk, s_local)
+            # Columns past the chunk's last row can never be in range, so the
+            # matmul only covers ``[0, k_end)``. Under CP this is what keeps the
+            # first rank from scoring the whole gathered KV.
+            k_end = position_offset + end
+            logits = paddle.matmul(
+                query[beg:end], kv[:k_end], transpose_y=True
+            ).astype("float32")
+            cols = paddle.arange(k_end, dtype="int64").unsqueeze(0)
+            keep = (cols >= seg_start[beg:end].unsqueeze(1)) & (
+                cols <= rows[beg:end].unsqueeze(1)
+            )
+            # Additive rather than ``where``: broadcasting an ``[c, 1, k]`` bias
+            # over ``[c, h, k]`` needs no shape gymnastics, and ``_NEG_INF``
+            # rather than ``-inf`` keeps the sum away from ``nan``.
+            bias = paddle.where(
+                keep,
+                paddle.zeros_like(keep, dtype="float32"),
+                paddle.full(keep.shape, _NEG_INF, dtype="float32"),
+            ).unsqueeze(1)
+            parts.append(
+                paddle.logsumexp(logits * self.softmax_scale + bias, axis=-1)
+            )
+        lse = paddle.concat(parts, axis=0)
+        # ``+inf`` on an inactive row: ``exp(score - inf) == 0`` for every column,
+        # so the score row is all zeros and the row leaves the loss exactly.
+        return paddle.where(
+            row_active.unsqueeze(-1), lse, paddle.full_like(lse, float("inf"))
+        )
+
+    @staticmethod
+    def _dense_kl_reduce(
+        index_score, index_lse, attn_score, attn_l1norm, num_rows
+    ) -> Tensor:
+        """``sum(KL) / num_rows`` over the two dense score matrices, chunked.
+
+        Character-identical to the tilelang branch's reduction --
+        ``target * (log(target + _EPS) - log(probs + _EPS))`` summed over columns
+        -- so the two backends are comparable to the last epsilon. Masked columns
+        arrive as ``probs == 0`` (``exp(-inf - lse)``) and ``target == 0`` (the
+        caller clipped ``-inf`` away), whose term is an exact 0.
+        """
+        rows, width = (int(dim) for dim in index_score.shape)
+        chunk = max(1, _KL_CHUNK_ELEMS // max(width, 1))
+        total = paddle.zeros([], dtype="float32")
+        for beg in range(0, rows, chunk):
+            end = min(beg + chunk, rows)
+            probs = paddle.exp(
+                index_score[beg:end] - index_lse[beg:end].unsqueeze(-1)
+            )
+            target = attn_score[beg:end] / attn_l1norm[beg:end].unsqueeze(
+                -1
+            ).clip(min=_EPS)
+            log_ratio = paddle.log(target + _EPS) - paddle.log(probs + _EPS)
+            total = total + (target * log_ratio).sum()
+        return total / num_rows
+
+    def _check_cudnn_dense_indexer_support(self) -> None:
+        """The one dense-cuDNN constraint that is not implied by the layer.
+
+        ``DenseIndexerBackward.check_support`` rejects fewer than 64 index heads
+        outright (``dense_indexer_backward_sm100.py``), and unlike the forward it
+        does so from inside the backward, i.e. from a recompute replay. Reject it
+        here instead. The batch size needs no check -- ``forward`` already
+        requires 1.
+
+        Not a reason to point at tilelang: that path pins ``index_n_heads`` to
+        exactly 64 as well (see :meth:`_check_tilelang_indexer_support`), so a
+        narrower indexer has no warmup KL backend at all.
+        """
+        heads = int(self.indexer.n_heads)
+        if heads < 64:
+            raise ValueError(
+                "the dense cuDNN indexer backward requires index_n_heads >= 64, "
+                f"got {heads}. Raise index_n_heads to 64; the tilelang backend "
+                "requires exactly 64 too, so it is not a way around this."
+            )
+
+    def _check_tilelang_indexer_support(self, width: int) -> None:
+        """Fail loudly on the two tilelang indexer constraints we cannot absorb.
+
+        Neither is a config-time check, on purpose: both depend on the geometry
+        this layer is actually handed, and hoisting them would make every
+        small-geometry unit fixture unrepresentable.
+
+        **Width.** Any causal span is served *functionally* -- the wrappers round
+        ``topk_effective`` up to a power-of-two multiple of their block and crop
+        the result back (``csa_indexer_fwd.py:430-462``,
+        ``csa_indexer_bwd.py:617-638``), measured at
+        s = 1/2/4/8/16/32/300/384/512/8192. Shared memory is the real limit: the
+        two bitonic buffers are sized ``2 * topk``, so one block requests
+        ``16 * width + 25344`` B against the SM100 opt-in limit of 232448 B.
+        Past ``_TILELANG_KL_MAX_WIDTH`` the launch dies with a bare ``Failed to
+        set the allowed dynamic shared memory size`` raised from wherever the
+        segment is *replayed* (``recompute.py:389``), not from here, so reject it
+        at the call site and name the way out.
+
+        **Head count.** ``index_n_heads`` other than 64 trips the kernel's warp
+        tiling with a bare ``Check failed: (m_warp * n_warp == num_warps)`` from
+        inside tilelang (measured with 8).
+        """
+        if int(width) > _TILELANG_KL_MAX_WIDTH:
+            raise ValueError(
+                "the tilelang full-candidate indexer cannot cover a candidate "
+                f"width of {int(width)}: its shared-memory request "
+                f"({16 * int(width) + 25344} B) exceeds the device limit past "
+                f"{_TILELANG_KL_MAX_WIDTH} columns. Set "
+                'csa_indexer_backend="cudnn" to run the warmup KL on the dense '
+                "cuDNN indexer instead, which has no top-k stage and so no "
+                "width-proportional shared memory."
+            )
         heads = int(self.indexer.n_heads)
         if heads != 64:
             raise ValueError(

--- a/tests/multi_card_tests/transformer/test_mqa_dsa_warmup_cp.py
+++ b/tests/multi_card_tests/transformer/test_mqa_dsa_warmup_cp.py
@@ -68,17 +68,18 @@ localised and its values are local row ids, so no ``[b, s, s]`` table is an
 honest reconstruction and ``idx_cp is None`` there. Dense CP claims are therefore
 made against outputs, gradients and the bounds themselves.
 
-Run (2 or 4 GPUs)::
+Run (2 or 4 GPUs). The repository root has to be importable because the shared
+harness is imported through its package path (``ci/multi-card_test.sh`` puts it
+on ``PYTHONPATH`` for exactly that reason)::
 
-    PYTHONPATH=./third_party/PaddleFleet/src:./third_party/PaddleFormers \
+    PYTHONPATH=./third_party/PaddleFleet:./third_party/PaddleFleet/src:\
+./third_party/PaddleFormers \
     python -m paddle.distributed.launch --devices 0,1 --nnodes 1 \
         --master 127.0.0.1:<port> \
         third_party/PaddleFleet/tests/multi_card_tests/transformer/\
 test_mqa_dsa_warmup_cp.py
 """
 
-import os
-import sys
 import unittest
 from unittest import mock
 
@@ -86,19 +87,14 @@ import numpy as np
 import paddle
 import paddle.distributed as dist
 
-# The sibling harness is imported as a top-level module, so this directory has
-# to be on ``sys.path``. ``python <thisfile>`` -- what
-# ``paddle.distributed.launch`` runs -- puts it there as ``sys.path[0]``, but the
-# coverage-instrumented CI runner starts the same file as ``python -m coverage
-# run <abs path>``, where ``-m`` claims ``sys.path[0]`` for the CWD instead and
-# the import fails before a single test is collected. Add the file's own
-# directory explicitly so both entry points resolve it.
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-
-import test_mqa_dsa_cp as H
-
 from paddlefleet.transformer.csa_attention import _derive_csa_doc_boundaries
 from paddlefleet.transformer.mqa_latent_attention import MQALatentAttention
+
+# Through the package path, not as a top-level sibling: the two entry points put
+# different things on ``sys.path[0]`` (``python <thisfile>`` this directory, the
+# coverage-instrumented CI runner's ``python -m coverage run <abs path>`` the
+# CWD), and the repository root is on ``PYTHONPATH`` under both.
+from tests.multi_card_tests.transformer import test_mqa_dsa_cp as H
 
 S_GLOBAL = H.S_GLOBAL
 _STRADDLE = H._STRADDLE

--- a/tests/multi_card_tests/transformer/test_mqa_dsa_warmup_cp.py
+++ b/tests/multi_card_tests/transformer/test_mqa_dsa_warmup_cp.py
@@ -77,6 +77,8 @@ Run (2 or 4 GPUs)::
 test_mqa_dsa_warmup_cp.py
 """
 
+import os
+import sys
 import unittest
 from unittest import mock
 
@@ -84,9 +86,15 @@ import numpy as np
 import paddle
 import paddle.distributed as dist
 
-# ``paddle.distributed.launch <thisfile>`` puts this directory on ``sys.path``,
-# so the sibling harness imports as a top-level module (same as
-# ``test_mla_cp_recompute`` importing ``test_mla_cp_contiguous_allgather``).
+# The sibling harness is imported as a top-level module, so this directory has
+# to be on ``sys.path``. ``python <thisfile>`` -- what
+# ``paddle.distributed.launch`` runs -- puts it there as ``sys.path[0]``, but the
+# coverage-instrumented CI runner starts the same file as ``python -m coverage
+# run <abs path>``, where ``-m`` claims ``sys.path[0]`` for the CWD instead and
+# the import fails before a single test is collected. Add the file's own
+# directory explicitly so both entry points resolve it.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
 import test_mqa_dsa_cp as H
 
 from paddlefleet.transformer.csa_attention import _derive_csa_doc_boundaries

--- a/tests/multi_card_tests/transformer/test_mqa_dsa_warmup_cp.py
+++ b/tests/multi_card_tests/transformer/test_mqa_dsa_warmup_cp.py
@@ -48,6 +48,13 @@ Three gaps in ``test_mqa_dsa_cp.py`` / ``test_mla_cp_contiguous_allgather.py``:
    space. Neither error raises, so ``TestDenseFA4CP`` carries the control that
    proves the checks can see an un-localised bound.
 
+4. The **dense cuDNN** KL backend (``csa_indexer_backend="cudnn"``), which
+   replaces tilelang's ``[s_local, s_global]`` index table with a THD descriptor
+   over the same candidate set. Localising a table is a row slice; localising THD
+   means ``cu_seqlens_k`` over the gathered keys, ``cu_seqlens_q`` over the local
+   rows and a per-row ``q_causal_offsets`` left border, none of which raises when
+   it is wrong. ``TestWarmupKLBackendsCP`` carries that claim.
+
 Everything reuses ``test_mqa_dsa_cp``'s harness (fleet init, CP globals -- which
 includes its module-level ``FLAGS_flash_attn_version=4`` pin --, ``run_core_cp``,
 ``_check``, ``_check_index_sets``). No ``if rank == X`` short-circuit exists in
@@ -630,6 +637,185 @@ class TestDenseFA4CP(_CPChecks):
             f"ones (good={good['fwd']:.3e} bad={bad['fwd']:.3e}), so this "
             "file's forward equivalence cannot see a CP mask bug",
         )
+
+
+class TestWarmupKLBackendsCP(_CPChecks):
+    """``csa_indexer_backend="cudnn"``: the dense KL triple under CP.
+
+    The single-card suite (``test_hybrid_mla_warmup_kl_cudnn.py``) pins the dense
+    cuDNN KL against tilelang and against an fp32 autograd reference. What it
+    cannot reach is the part of the dense path that only exists under CP: the
+    tilelang branch expresses the candidate set as an ``[s_local, s_global]``
+    index table, while the dense branch expresses it in THD --
+    ``dense_kl_cu_seqlens(segment_lens, position_offset, s_local)`` builds
+    ``cu_seqlens_k`` over the *globally gathered* keys, ``cu_seqlens_q`` over this
+    rank's rows, and ``q_causal_offsets`` carries each visible document's left
+    border. Getting that wrong does not raise: it silently admits a neighbouring
+    document, or this document's non-local prefix, into the KL's support.
+
+    So the claims are the ones a wrong border would break, in order of how
+    directly they see it:
+
+    * the CP=N-vs-CP=1 contract of ``run_core_cp`` on the cuDNN backend
+      (``_check``: forward plus every gradient, the indexer parameters included);
+    * the logged KL summing across the group to the CP=1 value
+      (``_assert_loss_cp_sum``) -- a per-rank denominator is off by ``cp_size``;
+    * the two backends agreeing on that CP-summed scalar, which is what makes
+      this a *dense-THD-under-CP* claim rather than a self-consistency one: both
+      backends would have to mis-slice identically to pass.
+
+    ``hybrid_mla_utils.INDEX_HEADS == 64`` is what lets both backends run this
+    fixture at all; ``_check_cudnn_dense_indexer_support`` rejects narrower
+    geometries from the forward.
+    """
+
+    # Both backends reduce a bf16-fed fp32 KL over the same candidate set, but
+    # in different orders (tilelang: per-row over a column table; dense: chunked
+    # over the raw score matrix), and the CP sum adds ``cp_size`` partial sums on
+    # top. Measured 1.5e-8..1.4e-7 for a backend against its own CP=1 value and
+    # ~1e-4 between backends, so this is three orders off a wrong denominator.
+    BACKEND_RTOL = 5e-3
+
+    # ``dense_indexer_backward_wrapper`` reduces ``d_index_k`` through fp32
+    # atomics, so the two parameters downstream of ``index_k`` -- ``wk`` and
+    # ``k_norm`` -- are not reproducible run to run, and at this fixture's ~9e-3
+    # nat KL the ``predict - target`` cancellation amplifies that into a large
+    # *relative* number on a ~1e-6-norm gradient. Measured single-card,
+    # single-process floor (same module, same leaves, four backwards): cuDNN
+    # 2.9e-2 (single doc) / 6.5e-2 (pad rows) against tilelang's 1.1e-3, with
+    # ``wq_b`` / ``weights_proj`` bitwise identical on both. ``GRAD_RTOL = 2e-2``
+    # therefore measures the atomics rather than CP, so give these two a bound
+    # above the floor and keep the strict one everywhere else. What CP failures
+    # look like by comparison: a wrong loss denominator is 100% at CP=2, and a
+    # mislocalised THD border moves the loss sum itself, which
+    # ``_assert_loss_cp_sum`` pins to 6e-8.
+    DK_GRAD_RTOL = 2e-1
+    _DK_PARAMS = ("indexer.wk.", "indexer.k_norm.")
+
+    def _check(self, res, tag):
+        """Harness ``_check``, with the two dK-atomic parameters split off."""
+        noisy = {
+            name: err
+            for name, err in res["param_err"].items()
+            if name.startswith(self._DK_PARAMS)
+        }
+        strict = {
+            name: err
+            for name, err in res["param_err"].items()
+            if name not in noisy
+        }
+        H.TestMQADSACP._check(self, dict(res, param_err=strict), tag)
+        for name, err in noisy.items():
+            self.assertIsNotNone(
+                err, f"{tag}: reference has no grad for {name}"
+            )
+            self.assertLess(
+                err, self.DK_GRAD_RTOL, f"{tag}: param {name} {err:.3e}"
+            )
+        # The harness' own print covers ``strict`` only, and these are the two
+        # that drift, so keep them on the log.
+        print(
+            f"[cp{H.CP_SIZE} rank{H.CP_RANK}] {tag}: dk_param_max="
+            f"{max(noisy.values(), default=0.0):.2e}",
+            flush=True,
+        )
+
+    def _run(self, backend, doc_lens, masked, row_end=None):
+        """``run_core_cp`` with every module it builds forced onto ``backend``.
+
+        ``_forward_warmup`` reads ``self.config.csa_indexer_backend`` at call
+        time, so overriding it post-build is enough -- and it puts the CP=1
+        reference on the same backend, which is what keeps ``_check`` a CP claim
+        instead of a backend comparison.
+        """
+        original = H._build
+
+        def build(*args, **kwargs):
+            module = original(*args, **kwargs)
+            module.config.csa_indexer_backend = backend
+            return module
+
+        with mock.patch.object(H, "_build", build):
+            return H.run_core_cp(
+                "mqa_dsa",
+                doc_lens,
+                loss_coeff=0.1,
+                with_input_ids=masked,
+                sparse_loss=False,
+                row_end=row_end,
+            )
+
+    def _layouts(self):
+        """``(label, doc_lens, masked, row_end)``.
+
+        ``masked`` flips the loss denominator between ``_indexer_loss_mask``'s
+        global valid-row count and the all-ones fallback; the pad layout adds
+        rows whose ``index_lse`` the dense path sets to ``+inf`` to gate them
+        out, all of them on the last rank.
+        """
+        return [
+            ("straddle masked", _STRADDLE, True, None),
+            ("straddle unmasked", _STRADDLE, False, None),
+            ("single doc", [S_GLOBAL], True, None),
+            ("pad rows", None, True, _pad_row_end(_PAD_DOC_LEN, S_GLOBAL)),
+        ]
+
+    @H.U._GPU
+    def test_1_cudnn_warmup_cp_equivalence(self):
+        """The CP contract holds on the dense cuDNN KL, on four layouts."""
+        for label, doc_lens, masked, row_end in self._layouts():
+            with self.subTest(layout=label):
+                tag = f"cudnn-cp/{label}"
+                res = self._run(
+                    backend="cudnn",
+                    doc_lens=doc_lens,
+                    masked=masked,
+                    row_end=row_end,
+                )
+                self.assertTrue(
+                    any(n.startswith("indexer.") for n in res["param_err"]),
+                    f"{tag}: the indexer received no gradient, so this layout "
+                    f"never ran the KL",
+                )
+                self._check(res, tag)
+                self._assert_loss_cp_sum(res, tag)
+
+    @H.U._GPU
+    def test_2_cudnn_and_tilelang_agree_on_the_cp_summed_loss(self):
+        """Cross-backend: the same objective, the same THD/table slicing.
+
+        Both losses are summed over the CP group first, so a border that is
+        wrong on one rank only still shows up here.
+        """
+        for label, doc_lens, masked, row_end in self._layouts():
+            with self.subTest(layout=label):
+                sums = {}
+                for backend in ("tilelang", "cudnn"):
+                    res = self._run(
+                        backend=backend,
+                        doc_lens=doc_lens,
+                        masked=masked,
+                        row_end=row_end,
+                    )
+                    total = paddle.to_tensor(
+                        [res["logged_cp"]], dtype="float64"
+                    )
+                    dist.all_reduce(total, group=H.CP_GROUP)
+                    sums[backend] = float(total[0])
+                got, want = sums["cudnn"], sums["tilelang"]
+                rel = abs(got - want) / max(abs(want), 1e-30)
+                print(
+                    f"[kl-backends-cp{H.CP_SIZE} rank{H.CP_RANK}] {label}: "
+                    f"tilelang={want:.6e} cudnn={got:.6e} rel={rel:.3e}",
+                    flush=True,
+                )
+                self.assertLess(
+                    rel,
+                    self.BACKEND_RTOL,
+                    f"{label}: the dense cuDNN KL sums to {got:.6e} across the "
+                    f"CP group where tilelang sums to {want:.6e} "
+                    f"(rel {rel:.3e}) -- the two candidate sets differ",
+                )
 
 
 if __name__ == "__main__":

--- a/tests/single_card_tests/transformer/test_doc_mask_meta_registry.py
+++ b/tests/single_card_tests/transformer/test_doc_mask_meta_registry.py
@@ -961,10 +961,7 @@ def _doc_fields(row_end, seqlen):
         _derive_csa_doc_boundaries,
     )
 
-    doc_start, doc_len, is_valid, doc_lens, _ = _derive_csa_doc_boundaries(
-        row_end, seqlen
-    )
-    return doc_start, doc_len, is_valid, doc_lens
+    return _derive_csa_doc_boundaries(row_end, seqlen)
 
 
 def _stub_indexer_loss_leaves(module):
@@ -1002,11 +999,11 @@ class TestMQAWarmupMetaLookup(unittest.TestCase):
         # ``_forward_full_causal`` (whose kernel path is GPU-gated), keep the
         # indexer-range split and the KL machinery real.
         module._forward_full_causal = lambda *a, **k: paddle.zeros([1, 4, 1])
-        module._check_tilelang_indexer_support = lambda: None
+        module._check_tilelang_indexer_support = lambda *a, **k: None
         _stub_indexer_loss_leaves(module)
         query, kv, x, qr, wv = _meta_index_inputs()
         row_end = _row_end([4], 4)
-        doc_start, doc_len, is_valid, _ = _doc_fields(row_end, 4)
+        doc_start, doc_len, is_valid, _, doc_starts = _doc_fields(row_end, 4)
         with (
             unittest.mock.patch(
                 "paddlefleet.tilelang_ops.csa_indexer_topk_fwd",
@@ -1027,6 +1024,7 @@ class TestMQAWarmupMetaLookup(unittest.TestCase):
                 doc_start,
                 doc_len,
                 is_valid,
+                doc_starts,
                 32,  # kv_lora_rank
                 None,  # input_ids
                 0,  # position_offset
@@ -1058,7 +1056,7 @@ class TestMQASparseMetaLookup(unittest.TestCase):
         _stub_indexer_loss_leaves(module)
         query, kv, x, qr, wv = _meta_index_inputs()
         row_end = _row_end([4], 4)
-        doc_start, doc_len, is_valid, doc_lens = _doc_fields(row_end, 4)
+        doc_start, doc_len, is_valid, doc_lens, _ = _doc_fields(row_end, 4)
         with (
             unittest.mock.patch(
                 "paddlefleet.cudnn_ops.indexer.csa_indexer_fwd_cudnn."

--- a/tests/single_card_tests/transformer/test_hybrid_mla_warmup_kl_cudnn.py
+++ b/tests/single_card_tests/transformer/test_hybrid_mla_warmup_kl_cudnn.py
@@ -1,0 +1,497 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The warmup-phase KL on the dense cuDNN indexer backend.
+
+``csa_indexer_backend="cudnn"`` routes ``MQALatentAttention._forward_warmup``
+onto ``_warmup_kl_dense_cudnn`` (``mqa_latent_attention.py:857``), which scores
+the *same* full per-document causal candidate set as the tilelang default but
+through the three dense cuDNN-frontend ops in
+``paddlefleet.cudnn_ops.indexer.dense_indexer_kl_cudnn``. It exists because the
+tilelang full-candidate indexer sizes two bitonic buffers at ``2 * topk`` and so
+cannot be launched past ``_TILELANG_KL_MAX_WIDTH`` columns, which the production
+64k/cp=8 geometry exceeds by 4.6x.
+
+The dense path is not a reimplementation of the same arithmetic: it derives both
+distributions from raw score matrices, keeps the weights in ``DSAIndexer``'s
+pre-baked scaling with ``sm_scale=1.0``, computes the attention per-head LSE
+itself (``_dense_kl_attn_lse``), and folds ``1 / total_q`` into the kernel's
+``grad_scale``. Each of those is a place the two backends could silently
+disagree, so what is pinned here is the *objective*, not the plumbing:
+
+* ``test_logged_kl_matches_tilelang`` -- the forward scalar, over seven layouts
+  (single document, packed, unaligned packed, real pad rows, ``input_ids`` loss
+  mask, and both maskings at once). This is the tight assertion: it covers the
+  THD descriptor, the document borders, the row gating, ``num_rows``/``coeff``
+  and the target definition all at once.
+* ``test_matches_fp32_reference`` -- both backends against the same objective
+  written a third time in plain fp32 paddle with autograd. In warmup the indexer
+  does not touch the attention output, so its parameter gradients are pure KL
+  gradients. cuDNN dense lands 5-8x closer to fp32 than tilelang does, which is
+  why the *inter-backend* gradient gap below is loose.
+* ``test_logged_kl_is_reproducible`` -- two identical steps, needed because
+  warmup runs under recompute in production.
+* ``test_loss_coeff_is_linear`` -- ``dsa_indexer_loss_coeff`` scales the logged
+  scalar and the gradients exactly.
+* ``test_masked_rows_do_not_affect_the_loss`` -- pad rows are switched out
+  through ``index_lse = +inf`` / ``attn_lse = +inf``, not through a clamp.
+* ``test_narrow_index_heads_raise_from_the_forward`` -- the ``>= 64`` head guard
+  fires at the call site, not from a recompute replay of the backward.
+
+Shared fixtures come from ``hybrid_mla_utils``; its ``INDEX_HEADS = 64``
+satisfies both backends' head-count constraints.
+
+Run::
+
+    R=<erniebot checkout>
+    PYTHONPATH=$R/third_party/PaddleFleet/src:$R/third_party/PaddleFormers \\
+        CUDA_VISIBLE_DEVICES=5 FLAGS_selected_gpus=0 \\
+        python -m pytest <this file> -q -p no:randomly
+"""
+
+import traceback
+import unittest
+
+import numpy as np
+import paddle
+import paddle.nn.functional as F
+
+from paddlefleet.transformer.csa_attention import _derive_csa_doc_boundaries
+from paddlefleet.transformer.dsa_attention import DSAIndexerLossLoggingHelper
+
+from .hybrid_mla_utils import (
+    _GPU,
+    _build_module,
+    _create_mqa_config,
+    _fa4_module_hooks,
+    _make_inputs,
+    _pad_row_end,
+    _row_end,
+)
+
+setUpModule, tearDownModule = _fa4_module_hooks()
+
+_EPS = 1e-10  # mqa_latent_attention._EPS
+
+_COEFF = 0.01
+
+# ``(label, seqlen, row_end_fn, doc_lens, with_input_ids)``. ``_row_end`` folds a
+# trailing gap into one more *valid* document, so genuine pad rows need
+# ``_pad_row_end``; ``with_input_ids`` additionally exercises the ``loss_mask``
+# row gating, which uses a different denominator (``valid_rows`` instead of
+# ``s_local``) and drops the ``1 / cp_size`` factor.
+_SCENARIOS = [
+    ("single-doc s=128", 128, _row_end, [128], False),
+    ("single-doc s=512", 512, _row_end, [512], False),
+    ("packed s=512", 512, _row_end, [100, 200, 212], False),
+    ("unaligned packed s=384", 384, _row_end, [1, 130, 253], False),
+    ("pad rows s=512", 512, _pad_row_end, [200, 180], False),
+    ("loss_mask s=512", 512, _row_end, [200, 312], True),
+    ("pad+loss_mask s=512", 512, _pad_row_end, [200, 180], True),
+]
+
+# The forward scalar is the assertion that discriminates: measured 3.0e-06 ..
+# 5.7e-05 across the seven layouts.
+_LOSS_RTOL = 1e-3
+
+# The inter-backend *gradient* gap is deliberately loose. At this fixture's
+# geometry the KL is only ~9e-3 nat, i.e. ``predict ~= target``, so the score
+# gradient ``predict - target`` is a difference of near-equal quantities and a
+# ~3e-3 relative perturbation of the target is amplified ~14x. Measured worst
+# case 5.8e-02, and ``test_matches_fp32_reference`` shows almost all of it is
+# tilelang's own distance to fp32 (cuDNN stays at ~6e-03 there).
+_CROSS_GRAD_RTOL = 1e-1
+
+_FP32_LOSS_RTOL = 1e-4
+_FP32_CUDNN_GRAD_RTOL = 2e-2
+_FP32_TILELANG_GRAD_RTOL = 8e-2
+
+# ``wk`` and ``k_norm`` sit downstream of ``index_k``, whose gradient the dense
+# backward reduces through fp32 atomics, so they move from run to run. The
+# absolute drift is tiny -- ``test_logged_kl_is_reproducible`` pins it at 1e-8 --
+# but the KL here is only ~9e-3 nat, so the ``predict - target`` cancellation
+# turns it into a large *relative* number on a ~1e-6-norm gradient: measured
+# single-process floor (same module, same leaves, four backwards) 2.9e-2 on
+# ``single-doc s=512`` and 6.5e-2 on the padded layout, against tilelang's
+# 1.1e-3. A relative bound tighter than that measures the atomics rather than
+# this backend, so these two get their own; ``wq_b`` / ``weights_proj``, which
+# come back bitwise identical, keep the strict one.
+_DK_PARAMS = ("wk.", "k_norm.")
+_DK_GRAD_RTOL = 2e-1
+
+
+def _grad_rtol(name, strict):
+    """``strict``, loosened on the parameters fed by the atomic ``d_index_k``."""
+    return _DK_GRAD_RTOL if name.startswith(_DK_PARAMS) else strict
+
+
+def _module(loss_coeff=_COEFF, index_n_heads=None, seed=0):
+    """A warmup-phase (``dsa_indexer_use_sparse_loss=False``) layer.
+
+    ``_build_module`` does not seed and ``_make_inputs`` seeds only *after* the
+    module exists, so an unseeded process draws different indexer weights every
+    run. The metrics here are dominated by ``predict - target`` cancellation,
+    which alone moves the reported gaps by ~3x, so seed before the build.
+    """
+    config = _create_mqa_config("mqa_dsa", loss_coeff=loss_coeff)
+    config.dsa_indexer_use_sparse_loss = False
+    config.pad_token_id = 0
+    if index_n_heads is not None:
+        config.dsa_index_n_heads = index_n_heads
+    paddle.seed(seed)
+    module = _build_module(config, bf16=True)
+    assert module.indexer is not None
+    return module
+
+
+def _leaves(seqlen, seed=1):
+    query, key, w_v, x, qr = _make_inputs(seqlen, seed=seed, with_hidden=True)
+    tensors = [query, key, x, qr]
+    for tensor in tensors:
+        tensor.stop_gradient = False
+    return tensors, w_v
+
+
+def _pad_tail_ids(seqlen, n_pad):
+    """``input_ids`` whose last ``n_pad`` rows are ``pad_token_id == 0``."""
+    ids = np.ones([1, seqlen], dtype="int64")
+    ids[0, seqlen - n_pad :] = 0
+    return paddle.to_tensor(ids)
+
+
+def _grads(module):
+    return {
+        name: param.grad.cast("float32").numpy().copy()
+        for name, param in module.indexer.named_parameters()
+        if param.grad is not None
+    }
+
+
+def _step(module, tensors, row_end, w_v, backend, input_ids=None):
+    """One warmup step on ``backend``; ``(logged_kl, {param: grad})``."""
+    module.config.csa_indexer_backend = backend
+    module.train()
+    module.clear_gradients()
+    DSAIndexerLossLoggingHelper.tracker.clear()
+    query, key, x, qr = tensors
+    out = module(
+        query,
+        key,
+        None,
+        None,
+        row_end,
+        v_b_proj_weight=w_v,
+        x=x,
+        qr=qr,
+        input_ids=input_ids,
+    )
+    out.cast("float32").sum().backward()
+    logged = float(
+        DSAIndexerLossLoggingHelper.tracker["values"].astype("float32").sum()
+    )
+    grads = _grads(module)
+    module.clear_gradients()
+    return logged, grads
+
+
+def _rel(actual, expected):
+    denom = float(np.linalg.norm(expected.ravel()))
+    diff = float(np.linalg.norm((actual - expected).ravel()))
+    return diff if denom == 0.0 else diff / denom
+
+
+def _perturb_rows(tensors, rows):
+    """A copy of ``tensors`` with the indexer's ``x`` / ``qr`` rewritten.
+
+    Only the rows selected by the boolean ``rows`` mask move, as
+    ``v -> 3 v + 1``; ``query`` / ``key`` are left alone so the attention side
+    (and hence the KL target on the surviving rows) is untouched.
+    """
+    seqlen = int(tensors[0].shape[1])
+    mask = paddle.to_tensor(
+        np.asarray(rows, dtype="float32").reshape([1, seqlen, 1])
+    )
+    out = list(tensors)
+    for slot in (2, 3):  # x, qr
+        data = tensors[slot].detach().cast("float32")
+        moved = (data * (1.0 + 2.0 * mask) + mask).cast(tensors[slot].dtype)
+        moved.stop_gradient = False
+        out[slot] = moved
+    return out
+
+
+def _fp32_reference(module, tensors, row_end):
+    """The warmup objective in plain fp32 paddle; ``(loss, {param: grad})``.
+
+    The candidate set is rebuilt the way ``_indexer_valid_range(window=0)``
+    does: columns in ``[doc_start, min(row, doc_start + doc_len - 1)]``, with
+    doc-invalid rows contributing a zero target instead of being removed from
+    the denominator. ``weights`` already carries
+    ``n_heads**-0.5 * head_dim**-0.5``, which is exactly the scaling a
+    pure-paddle score evaluation wants, so nothing is un-baked here.
+    """
+    module.train()
+    module.clear_gradients()
+    query, key, x, qr = tensors
+    s = int(query.shape[1])
+    doc_start, doc_len, is_valid, _, _ = _derive_csa_doc_boundaries(row_end, s)
+
+    index_q, index_k, weights = module._indexer_projections(
+        x, qr, 0, grad_enabled=True
+    )
+    iq = index_q[0].cast("float32")
+    ik = index_k[0].cast("float32")
+    iw = weights[0].cast("float32")
+
+    rows = paddle.arange(s, dtype="int64")
+    cols = rows.unsqueeze(0)
+    right = paddle.minimum(rows, doc_start + doc_len - 1).unsqueeze(1)
+    keep = (cols >= doc_start.unsqueeze(1)) & (cols <= right)
+    # An all-``-inf`` row would softmax to ``nan`` and poison the backward, so
+    # every row keeps its diagonal and is removed from the loss through the
+    # target's ``is_valid`` factor instead.
+    keep = keep | (cols == rows.unsqueeze(1))
+    neg = paddle.full([s, s], -1e30, dtype="float32")
+
+    scores = paddle.einsum("qhd,td->qht", iq, ik)
+    index_score = (F.relu(scores) * iw.unsqueeze(-1)).sum(axis=1)
+    probs = F.softmax(paddle.where(keep, index_score, neg), axis=-1)
+
+    with paddle.no_grad():
+        logits = paddle.matmul(
+            query[0].cast("float32"),
+            key[0, :, 0].cast("float32"),
+            transpose_y=True,
+        ) * float(module.softmax_scale)
+        logits = paddle.where(keep.unsqueeze(1), logits, neg.unsqueeze(1))
+        target = F.softmax(logits, axis=-1).mean(axis=1)
+        target = target * is_valid.astype("float32").unsqueeze(1)
+
+    kl = (target * (paddle.log(target + _EPS) - paddle.log(probs + _EPS))).sum(
+        axis=-1
+    )
+    loss = kl.mean() * (module.indexer_loss_coeff / module.cp_size)
+    loss.backward()
+    grads = _grads(module)
+    module.clear_gradients()
+    return float(loss), grads
+
+
+@_GPU
+class TestWarmupKLCudnnBackend(unittest.TestCase):
+    """Dense cuDNN warmup KL against tilelang and against fp32."""
+
+    def test_logged_kl_matches_tilelang(self):
+        module = _module()
+        for label, seqlen, row_end_fn, doc_lens, masked in _SCENARIOS:
+            with self.subTest(label):
+                tensors, w_v = _leaves(seqlen)
+                row_end = row_end_fn(doc_lens, seqlen)
+                ids = _pad_tail_ids(seqlen, seqlen // 4) if masked else None
+                tl, _ = _step(module, tensors, row_end, w_v, "tilelang", ids)
+                cu, _ = _step(module, tensors, row_end, w_v, "cudnn", ids)
+                self.assertGreater(abs(tl), 0.0, "the KL collapsed to zero")
+                self.assertLess(
+                    abs(cu - tl) / abs(tl),
+                    _LOSS_RTOL,
+                    f"{label}: tilelang {tl:.8e} vs cudnn {cu:.8e}",
+                )
+
+    def test_indexer_grads_match_tilelang(self):
+        module = _module()
+        for label, seqlen, row_end_fn, doc_lens, masked in _SCENARIOS:
+            with self.subTest(label):
+                tensors, w_v = _leaves(seqlen)
+                row_end = row_end_fn(doc_lens, seqlen)
+                ids = _pad_tail_ids(seqlen, seqlen // 4) if masked else None
+                _, g_tl = _step(module, tensors, row_end, w_v, "tilelang", ids)
+                _, g_cu = _step(module, tensors, row_end, w_v, "cudnn", ids)
+                self.assertEqual(
+                    sorted(g_cu),
+                    sorted(g_tl),
+                    f"{label}: the two backends reached different parameters",
+                )
+                self.assertEqual(len(g_cu), 8, sorted(g_cu))
+                for name in sorted(g_tl):
+                    self.assertLess(
+                        _rel(g_cu[name], g_tl[name]),
+                        _grad_rtol(name, _CROSS_GRAD_RTOL),
+                        f"{label}: {name}",
+                    )
+
+    def test_matches_fp32_reference(self):
+        """Both backends against fp32 autograd; cuDNN must be the closer one.
+
+        "Closer" is claimed over the reproducible parameters only: on ``wk`` /
+        ``k_norm`` the dense backward's atomic ``d_index_k`` swamps its own bf16
+        distance (see ``_DK_GRAD_RTOL``), so an ordering there would be a
+        coin flip.
+        """
+        module = _module()
+        for label, seqlen, row_end_fn, doc_lens, masked in _SCENARIOS:
+            if masked:
+                continue  # the reference has no ``input_ids`` gating
+            with self.subTest(label):
+                tensors, w_v = _leaves(seqlen)
+                row_end = row_end_fn(doc_lens, seqlen)
+                ref, g_ref = _fp32_reference(module, tensors, row_end)
+                tl, g_tl = _step(module, tensors, row_end, w_v, "tilelang")
+                cu, g_cu = _step(module, tensors, row_end, w_v, "cudnn")
+                self.assertLess(abs(cu - ref) / abs(ref), _FP32_LOSS_RTOL)
+                self.assertLess(abs(tl - ref) / abs(ref), _FP32_LOSS_RTOL)
+                worst_cu = worst_tl = 0.0
+                for name in sorted(g_ref):
+                    r_cu = _rel(g_cu[name], g_ref[name])
+                    r_tl = _rel(g_tl[name], g_ref[name])
+                    self.assertLess(
+                        r_cu,
+                        _grad_rtol(name, _FP32_CUDNN_GRAD_RTOL),
+                        f"{label}: {name}",
+                    )
+                    self.assertLess(
+                        r_tl, _FP32_TILELANG_GRAD_RTOL, f"{label}: {name}"
+                    )
+                    if name.startswith(_DK_PARAMS):
+                        continue
+                    worst_cu = max(worst_cu, r_cu)
+                    worst_tl = max(worst_tl, r_tl)
+                self.assertLess(
+                    worst_cu,
+                    worst_tl,
+                    f"{label}: cudnn {worst_cu:.3e} is no longer closer to "
+                    f"fp32 than tilelang {worst_tl:.3e} on the reproducible "
+                    f"parameters",
+                )
+
+    def test_logged_kl_is_reproducible(self):
+        """Warmup runs under recompute, so a replay must repeat bitwise."""
+        module = _module()
+        for label, seqlen, row_end_fn, doc_lens, masked in _SCENARIOS:
+            with self.subTest(label):
+                tensors, w_v = _leaves(seqlen)
+                row_end = row_end_fn(doc_lens, seqlen)
+                ids = _pad_tail_ids(seqlen, seqlen // 4) if masked else None
+                first, g_first = _step(
+                    module, tensors, row_end, w_v, "cudnn", ids
+                )
+                second, g_second = _step(
+                    module, tensors, row_end, w_v, "cudnn", ids
+                )
+                self.assertEqual(first, second, label)
+                # ``d_index_k`` is reduced through fp32 ``cp.reduce.async.bulk``
+                # atomics inside the kernel, so the two parameters it feeds
+                # (``wk.*``, ``k_norm.*``) are not bitwise reproducible;
+                # measured maxabs 4.7e-10. The tilelang backend shows the same
+                # signature. The other two are exact.
+                for name in sorted(g_first):
+                    if name.startswith(("wk.", "k_norm.")):
+                        np.testing.assert_allclose(
+                            g_second[name],
+                            g_first[name],
+                            rtol=0,
+                            atol=1e-8,
+                            err_msg=f"{label}: {name}",
+                        )
+                    else:
+                        np.testing.assert_array_equal(
+                            g_second[name],
+                            g_first[name],
+                            err_msg=f"{label}: {name}",
+                        )
+
+    def test_loss_coeff_is_linear(self):
+        """``grad_scale = loss_coeff * grad_loss / total_q`` inside the kernel."""
+        tensors, w_v = _leaves(512)
+        row_end = _row_end([100, 200, 212], 512)
+        base = _module(loss_coeff=_COEFF)
+        twice = _module(loss_coeff=2.0 * _COEFF)
+        loss_a, g_a = _step(base, tensors, row_end, w_v, "cudnn")
+        loss_b, g_b = _step(twice, tensors, row_end, w_v, "cudnn")
+        self.assertAlmostEqual(loss_b / loss_a, 2.0, places=6)
+        for name in sorted(g_a):
+            norm_a = float(np.linalg.norm(g_a[name].ravel()))
+            ratio = float(np.linalg.norm(g_b[name].ravel())) / norm_a
+            # ``wk.*`` / ``k_norm.*`` ride the ``d_index_k`` atomics noise
+            # floor; the other two are exact to fp32 rounding.
+            places = 3 if name.startswith(("wk.", "k_norm.")) else 6
+            self.assertAlmostEqual(ratio, 2.0, places=places, msg=name)
+
+    def test_masked_rows_do_not_affect_the_loss(self):
+        """Pad rows are gated by ``+inf`` LSEs, not by a clamp with a residue."""
+        module = _module()
+        seqlen = 512
+        row_end = _pad_row_end([200, 180], seqlen)
+        _, _, is_valid, _, _ = _derive_csa_doc_boundaries(row_end, seqlen)
+        invalid = ~is_valid.numpy().astype(bool)
+        self.assertTrue(invalid.any(), "the fixture produced no pad rows")
+
+        tensors, w_v = _leaves(seqlen)
+        clean, g_clean = _step(module, tensors, row_end, w_v, "cudnn")
+
+        # Pad rows sit past the last document's end, so no valid row can reach
+        # them as either a query or a candidate: perturbing them must be exactly
+        # neutral. The mirror-image perturbation on the *valid* rows is measured
+        # too, otherwise the assertion would also pass on a forward that ignored
+        # ``x`` altogether.
+        masked, _ = _step(
+            module, _perturb_rows(tensors, invalid), row_end, w_v, "cudnn"
+        )
+        active, _ = _step(
+            module, _perturb_rows(tensors, ~invalid), row_end, w_v, "cudnn"
+        )
+        self.assertEqual(clean, masked)
+        self.assertGreater(abs(active - clean) / abs(clean), 1e-2)
+
+        # The gradients are only allclose, not bitwise: ``d_index_k`` is reduced
+        # through fp32 atomics whose order depends on the buffer contents, so
+        # the ``wk.*`` / ``k_norm.*`` pair moves at the ~1e-10 floor measured in
+        # ``test_logged_kl_is_reproducible``.
+        _, g_masked = _step(
+            module, _perturb_rows(tensors, invalid), row_end, w_v, "cudnn"
+        )
+        for name in sorted(g_clean):
+            np.testing.assert_allclose(
+                g_masked[name], g_clean[name], rtol=0, atol=1e-8, err_msg=name
+            )
+
+    def test_narrow_index_heads_raise_from_the_forward(self):
+        """``>= 64`` heads, rejected at the call site and not from a replay.
+
+        ``DenseIndexerBackward.check_support`` would raise from inside the
+        backward, i.e. out of a recompute replay, where the message has no
+        connection to the configuration that caused it.
+        """
+        module = _module(index_n_heads=32)
+        tensors, w_v = _leaves(128)
+        row_end = _row_end([128], 128)
+        # Not ``assertRaises``: it hands back ``exc.with_traceback(None)``, and
+        # the frame list is the whole point of this test.
+        frames, message = [], ""
+        try:
+            _step(module, tensors, row_end, w_v, "cudnn")
+        except ValueError as error:
+            message = str(error)
+            frames = [
+                frame.name
+                for frame in traceback.extract_tb(error.__traceback__)
+            ]
+        else:
+            self.fail("index_n_heads=32 was accepted by the dense backend")
+        self.assertIn("index_n_heads >= 64", message)
+        self.assertIn("_check_cudnn_dense_indexer_support", frames)
+        self.assertNotIn("backward", frames)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### PR Category

Operator Mechanism

### PR Types

New features

### Description

Cherry-pick of the develop-branch change onto `release/0.4`, dev: #1753.
The diff is byte-identical to that PR (verified by comparing the two
patches); only the commit message carries the `[release/0.4]` prefix. The
prerequisite dense-FA4 full-causal path is already on this branch as #1725
(`29d28310`).

The DSA warmup phase (phase 2) supervises the indexer over **every** causal
candidate, so there is no top-k to shrink the KL width. The TileLang
full-candidate indexer cannot serve that past 8192 columns: its two bitonic
buffers are sized `2 * topk`, so one block asks for `16 * topk + 25344` B of
shared memory against an SM100 opt-in limit of 232448 B. At 64k with cp=8 the
launch requests 1073920 B and dies at startup with `Failed to set the allowed
dynamic shared memory size`, reported from the recompute backward replay rather
than the call site.

This PR adds a second warmup-KL backend built on the dense cuDNN-frontend
triple, which has no top-k stage and therefore no width-proportional shared
memory and no `[s, width]` tensor that has to survive until the backward:

- `dense_indexer_kl_scores` -- raw indexer score + its LSE, so
  `exp(score - lse)` is the indexer prediction `Q`;
- `dense_attn_kl_scores` -- `sum_h exp(QK*scale - LSE_h)` + its L1 norm, so
  `score / l1norm` is the KL target `P`;
- `dense_indexer_kl_bwd` -- consumes both raw score matrices and emits
  `d_index_q / d_weights / d_index_k` for `coeff * (Q - P)`.

Everything runs in THD (varlen) layout, which is what per-document packing and
context parallel both need: `cu_seqlens_q` addresses the local query rows and
`cu_seqlens_k` the globally-gathered keys, so a query row's candidate set is its
own document's causal prefix and nothing else. THD also compacts the score width
to the longest *visible* document instead of the whole packed sequence.

Selection goes through the existing `csa_indexer_backend` config field
(`unfused` / `tilelang` / `cudnn`, default unchanged at `tilelang`), read at call
time in `_forward_warmup`. No new environment switches, and no behaviour change
for anyone who does not set it.

Two guards keep an unsupported shape from reaching a kernel that would fail
opaquely: the dense path requires `index_n_heads >= 64`, and the TileLang path
now rejects a width above 8192 up front instead of dying inside the shared
memory allocation.

Weight convention note: the dense indexer score is called with `sm_scale=1.0`
and `weights` exactly as `DSAIndexer` produced them, i.e. still carrying the
pre-baked `head_dim**-0.5`. That skips the un-bake/re-bake bf16 round trip
(measured max_rel 8e-7 against an fp32 reference, versus 4.2e-4 when un-baked),
and it means `d_weights` comes back in the same pre-baked space.

#### Tests

New single-card suite `test_hybrid_mla_warmup_kl_cudnn.py` (7 tests / 26
subtests) over 7 layouts -- single doc, multi doc, padded rows, masked rows,
short docs, unmasked -- covering: the logged KL against TileLang, every indexer
parameter gradient against TileLang, both backends against an fp32 reference
(and that cuDNN lands closer to it), row gating via `index_lse = +inf`, and
reproducibility of the logged KL.

New CP class `TestWarmupKLBackendsCP` in `test_mqa_dsa_warmup_cp.py`: the dense
backend against the CP=1 reference on 4 layouts, plus a cross-backend check that
both backends agree on the CP-summed loss. Full suite green at CP=2 (12 tests)
and CP=4 (12 tests).

One measured caveat is documented in both suites rather than papered over:
`dense_indexer_backward_wrapper` reduces `d_index_k` through fp32 atomics, so
the two parameters downstream of `index_k` -- `indexer.wk.*` and
`indexer.k_norm.*` -- are not reproducible run to run. The absolute drift is
~1e-8, but at this fixture's ~9e-3 nat KL the `predict - target` cancellation
turns it into a large *relative* number on a ~1e-6-norm gradient. Measured
single-process floor (same module, same leaves, four backwards): 2.9e-2 on
single-doc s=512 and 6.5e-2 on the padded layout, against TileLang's 1.1e-3,
with `wq_b` / `weights_proj` bitwise identical on both backends. Those two
parameters therefore get their own bound (2e-1, ~3x the floor) while every other
parameter keeps the strict one, and the CP claim rests on the CP-summed loss
check (rel 3e-8..6e-8 against 5e-3) plus the strict parameters -- a wrong loss
denominator is 100% off at CP=2.
