### PR TITLE
[cherry-pick][Tools] Add config_adapter for shrinking training configs to a smaller scale

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ requires-python = ">=3.10"
 dependencies = [
     "colorlog>=6.10.1",
     "paddlepaddle-gpu==3.4.0.post20260812+a136cd3594a",
+    "ruamel.yaml>=0.17",
     "tilelang-paddle==0.1.12",
 ]
 license = { text = "Apache 2.0" }

--- a/src/paddlefleet/config_adapter/README.md
+++ b/src/paddlefleet/config_adapter/README.md
@@ -1,0 +1,226 @@
+# config_adapter
+
+把面向大集群的训练 YAML 自动改写成能在**更小机器规模**上跑起来的配置：重算
+sharding 与 batch，必要时缩小 EP/PP 并联动改写 `model_config.json`，并保证改写
+后的配置满足 Fleet 的通信组约束。
+
+`--test-performance` 与 `--test-accuracy` 是**两个正交的、可选的**测试维度，各管
+一件事，可以单独给、同时给、也可以都不给：
+
+| 组合 | 并行度 | acc | batch 策略 | 精度开关 |
+|---|---|---|---|---|
+| 都不给 | 需要时缩小 EP/PP | 不变 | `scale_batch` | 不注入 |
+| `--test-performance` | 全部冻结 | 冻结 | `scale_batch` | 不注入 |
+| `--test-accuracy` | 需要时缩小 EP/PP | 等比放大 | `scale_accumulation` | 注入 |
+| 两个都给 | 全部冻结 | 冻结 | `scale_batch` | 注入 |
+
+- `--test-performance` 负责「测出来的单步耗时可比」：冻结 TP/PP/EP/CP/SEP 与
+  `gradient_accumulation_steps`，只动 sharding 和 `global_batch_size`。
+- `--test-accuracy` 负责「结果可复现、不 aadiff」：注入确定性开关；只要没同时给
+  `--test-performance`，就用放大 acc 的方式保持等效 batch。
+
+两种组合都遵守同一条硬规则：**源配置里大于 1 的并行度，最小只能缩到 2，不允许
+缩成 1**（EP8 最多缩到 EP2，不会变成 EP1）。把一个维度缩成 1 等于把待测的通信
+组直接去掉，测出来的结果没有参考价值。
+
+TP 与 SEP 永远不改：减小 TP 会增大单卡显存占用，有 OOM 风险。
+
+---
+
+## 用法
+
+```bash
+# 1) 只看这份配置能跑在哪些机器规模上（不生成任何文件）
+python -m paddlefleet.config_adapter --input config.yaml
+
+# 2) 只要能跑起来：适配到 2 台机器（默认每台 8 卡），必要时自动缩 EP/PP
+python -m paddlefleet.config_adapter --input config.yaml --target-nodes 2
+
+# 3) 测速：冻结并行策略与 acc，只改 sharding 和 GBS
+python -m paddlefleet.config_adapter --input config.yaml \
+    --target-nodes 2 --test-performance
+
+# 4) 精度测试：注入避免 aadiff 的开关，并保持等效 batch
+python -m paddlefleet.config_adapter --input config.yaml \
+    --target-nodes 1 --test-accuracy
+
+# 5) 两个维度同时给：既冻结并行策略，又注入精度开关
+python -m paddlefleet.config_adapter --input config.yaml \
+    --target-nodes 8 --test-performance --test-accuracy
+
+# 6) 非 8 卡机型用 --cards-per-node 表达（这里是单机 2 卡）
+python -m paddlefleet.config_adapter --input config.yaml \
+    --target-nodes 1 --cards-per-node 2 --test-accuracy
+
+# 7) 就地改写源文件，并额外生成 <input>.patch
+python -m paddlefleet.config_adapter --input config.yaml \
+    --target-nodes 1 --test-accuracy --in-place
+
+# 8) 自定义字段：不带前缀时工具自己判断该改 yaml 还是 model_config.json
+python -m paddlefleet.config_adapter --input config.yaml \
+    --target-nodes 1 --test-accuracy \
+    --set max_steps=10 --set n_routed_experts=32
+```
+
+改写 YAML 时用 `ruamel.yaml` 保留注释与字段顺序，它是 paddlefleet 的运行时依赖，随包一起安装，无需额外操作。
+
+### 命令行参数
+
+| 参数 | 必填 | 默认 | 说明 |
+|---|---|---|---|
+| `--input` | 是 | — | 源 YAML 路径 |
+| `--target-nodes N` | 否 | — | 目标机器台数；总卡数 = N × `--cards-per-node`。不传 = 只列出合法规模，不生成文件 |
+| `--cards-per-node` | 否 | 8 | 每台机器的卡数 |
+| `--test-performance` | 否 | 关 | 测速维度，可与 `--test-accuracy` 叠加 |
+| `--test-accuracy` | 否 | 关 | 精度维度，可与 `--test-performance` 叠加 |
+| `--output-dir` | 否 | `./adapted_configs` | 输出目录；`--in-place` 时忽略 |
+| `--set [yaml:\|json:]KEY=VALUE` | 否 | — | 自定义覆盖，可重复 |
+| `-i` / `--in-place` | 否 | 关 | 就地改写源文件，并生成 `<input>.patch` |
+| `-f` / `--force` | 否 | 关 | 允许覆盖已存在的 model_config 生成目录 |
+
+`--set` 的前缀是可选的：
+
+- `yaml:KEY=VALUE` / `json:KEY=VALUE`：显式指定改哪个文件；
+- `KEY=VALUE`：工具扫描两个文件自己判断 —— 谁声明了这个 key 就改谁，两边都声明
+  就**两边都改**（框架两边都读），两边都没有则**默认新增到 yaml**；想把新字段加到
+  `model_config.json` 必须显式写 `json:KEY=VALUE`。
+
+取值类型自动推断（整数→int、`true/false`→bool、`null/none`→None、其余→字符串）。
+被 `--set` 指定的字段是**受保护**的：后续任何自动规则都不会再覆盖它。当某个模型
+结构字段在 `model_config.json` 里读不到（不同模型家族命名不一致）时，也用
+`--set <字段>=<值>` 兜底。
+
+`model_config.json` 的位置永远从 YAML 的 `model_name_or_path` 推断：绝对路径直接
+用，相对路径先按 YAML 所在目录、再按当前工作目录（Fleet 的解析方式）尝试。
+
+---
+
+## 适配流程
+
+```
+加载 YAML
+  -> 应用 --set yaml:（并锁定这些字段）
+  -> 删除 fa_version（与环境强绑定的 flash-attention 版本 pin）
+  -> 需要时加载 model_config.json 并应用 --set json:
+  -> 扫描两个文件，落定不带前缀的 --set
+  -> 规划最终 TP/PP/EP/CP/SEP（冻结或缩容）
+  -> 写入 model_config.json 的结构改动（专家数 / 层数）
+  -> 注入精度开关（给了 --test-accuracy 时）
+  -> model_config.json 有改动时另存一份，并把 model_name_or_path 指过去
+  -> 应用并行度改动并复核 C1..C4
+  -> 缩放 batch、sharding、data_parallel_size
+  -> 写出 YAML 并打印报告
+```
+
+不冻结并行度时（默认，或只给了 `--test-accuracy`），按「改动越小越优先」的顺序
+尝试，命中第一个可行方案就停：
+
+```
+维度已合法  <  只缩 EP  <  只缩 PP  <  EP+PP 联合缩
+```
+
+- 缩 EP：专家数等比缩减，要求每个 EP rank 专家数相等（M1）且不小于 top-k（M2）。
+- 缩 PP：`num_hidden_layers` 等比缩减，再用 VPP/空尾层重新对齐（M3）；层数低于
+  推荐值只告警不拒绝（M4）；dense 前缀层必须放得下（M5）。同时**逐层配置列表**
+  （`csa_compress_ratios` / `window_attn_skip_freq` / `layer_types` / 列表形式的
+  `moe_layer_freq`）按新层数裁剪：保留前 N 层，并原样接回末尾的 MTP 项，否则框架会
+  因长度不符直接启动失败。源列表长度本身与 `num_hidden_layers` 不一致，或裁剪会让
+  `csa_compress_ratios` 丢掉某一类注意力层（框架要求每类至少一层）时，该候选会被
+  拒绝而不是硬改。
+- 联合缩：EP × PP 笛卡尔积，平局时先取最大 EP，再取最大 PP。
+
+写盘时机：所有规划与校验都在内存里完成后才落盘，中途任何一步失败都不改动源文件；
+写文件走临时文件 + 原子替换，`--in-place` 下若 YAML 写失败会回滚已写的
+`model_config.json`。另外需要另存 `model_config.json` 时，`model_name_or_path`
+必须指向新目录，因此不允许同时用 `--set` 锁定它（会直接报错并提示改用 `--in-place`）。
+
+### 约束体系
+
+| 族 | 约束 | 含义 |
+|---|---|---|
+| C1 | `N % (TP·SEP·PP) == 0` | sharding 为正整数 |
+| C2 | `N % (PP·EP) == 0`（EP>1） | moe_sharding 为正整数 |
+| C3 | `EP % TP == 0`（EP>1） | dense_sharding 为正整数 |
+| C4 | `sharding % CP == 0` | cp_sharding 为正整数 |
+| E1 | 跨机必须整节点分配 | Fleet 的 rank 映射要求各机对称 |
+| E2 | `TP·SEP` 放得进单机 | TP/SEP 不缩，缩了有 OOM 风险 |
+| E3 | 所有并行度是 ≥1 的整数 | — |
+
+C/E/M 全部不通过时，报错会给出候选淘汰明细和最近的合法机器规模。
+
+---
+
+## 精度开关（避免 aadiff）
+
+给了 `--test-accuracy` 就会把下面这些开关钉到确定性实现上；键在 YAML 和
+`model_config.json` 里都声明时，两份都会改（框架两边都读）。
+
+| 目标 | 字段 | 值 | 原因 |
+|---|---|---|---|
+| yaml | `csa_sparse_attn_backend` | `tilelang` | HCA/CSA 的 cudnn 后端（FlashMLA 前向 + cuDNN 反向）与 tilelang 结果不一致 |
+| yaml | `csa_indexer_backend` | `tilelang` | indexer 的 cudnn top-k 与 tilelang 有差异，与上一项取齐 |
+| json | `multimax_modules` | `null` | multimax 的可学习 range/ts 引入非确定性 |
+
+新增开关只需在 `precision.py` 的 `PRECISION_SWITCHES` 里加一行，报告与日志会自动
+带上原因。
+
+---
+
+## 输出
+
+只列**真正发生了变化**的字段（值没变的写入不会出现在日志里），每条都带上
+「为什么改」，并保留可被上游脚本正则匹配的形状（`CHANGE field=… old=… new=…` /
+`ADD` / `DELETE`，以及末尾的 `ORIGINAL_CARDS=` / `TARGET_CARDS=` / `OUTPUT=` /
+`MODEL_CONFIG_OUTPUT=`）：
+
+```
+===== config_adapter: 适配成功 =====
+输入      ：big.yaml
+模式      ：accuracy（--test-accuracy），batch 策略 scale_accumulation
+机器规模  ：96 节点 / 768 卡 -> 1 节点 / 8 卡（每节点 8 卡）
+并行度    ：TP 1->1  PP 8->2  EP 64->4  CP 1->1  SEP 1->1
+sharding  ：96 -> 4（moe_sharding=1, dense_sharding=4）
+缩容方案  ：EP+PP 联合缩容：EP 64 -> 4，PP 8 -> 2
+YAML 改动（6 项）-> adapted_configs/big_adapted_8cards.yaml
+  CHANGE field=expert_model_parallel_size old=64 new=4
+      原因：缩小 EP 64 -> 4：单独缩 EP 或单独缩 PP 都无法适配 8 卡，改为联合缩容
+  CHANGE field=gradient_accumulation_steps old=2 new=192
+      原因：保持等效 batch：GBS 保持 1536 不变，acc 放大为 2 × 768 / 8 = 192
+  ...
+model_config.json 改动（3 项）-> adapted_configs/model_config_separated/model_dir_adapted_8cards/model_config.json
+  CHANGE field=n_routed_experts old=256 new=16
+      原因：随 EP 64 -> 4 等比缩减专家数 256 -> 16（>= top-k=8）
+  ...
+ORIGINAL_CARDS=768
+TARGET_CARDS=8
+OUTPUT=adapted_configs/big_adapted_8cards.yaml
+```
+
+---
+
+## 目录结构
+
+```
+config_adapter/
+├── cli.py                    # 参数解析 + main()
+├── core.py                   # ConfigAdapter：编排整个适配流程
+├── options.py                # AdaptOptions：两个正交开关的派生行为
+├── planner.py                # 并行度规划：冻结 / EP-PP 分层缩容
+├── plan.py                   # ParallelismPlan
+├── precision.py              # 精度开关表
+├── strategies.py             # scale_batch / scale_accumulation
+├── topology.py               # C1..C4 通信组约束
+├── constraints.py            # E/M 族约束 + 候选枚举 + 层对齐
+├── layer_fields.py           # 逐层配置列表的裁剪与校验
+├── field_spec.py             # model_config.json 字段别名注册表
+├── model_config_resolver.py  # 定位/改写 model_config 路径
+├── io_writers.py             # YAML / JSON 读改写
+├── report.py                 # 改动记录与报告渲染
+└── utils.py                  # 通用小工具
+```
+
+## 测试
+
+```bash
+pytest -s tests/single_card_tests/config_adapter/test_config_adapter.py
+```

--- a/src/paddlefleet/config_adapter/README.md
+++ b/src/paddlefleet/config_adapter/README.md
@@ -86,9 +86,17 @@ python -m paddlefleet.config_adapter --input config.yaml \
   `model_config.json` 必须显式写 `json:KEY=VALUE`。
 
 取值类型自动推断（整数→int、`true/false`→bool、`null/none`→None、其余→字符串）。
-被 `--set` 指定的字段是**受保护**的：后续任何自动规则都不会再覆盖它。当某个模型
+被 `--set` 指定的字段是**受保护**的：后续任何自动规则都不会再覆盖它。但由适配器
+统一计算的字段（TP/PP/EP/CP/SEP、VPP、`num_empty_layers_add_in_tail`、
+`sharding_parallel_size`、`data_parallel_size`、`model_name_or_path`）**不允许**
+用 `--set` 锁定，否则生成的文件会与报告里的并行度对不上 —— 遇到这种组合会直接报错。当某个模型
 结构字段在 `model_config.json` 里读不到（不同模型家族命名不一致）时，也用
 `--set <字段>=<值>` 兜底。
+
+源作业卡数按两条证据推断并交叉校验：通信组
+（`DP × sharding × TP × SEP × PP`）与 batch 字段
+（`GBS / (micro_bs × acc) × TP × PP × CP`）。两者都能算且不一致时，取通信组的结果
+并在报告里给出 WARNING，提示源 YAML 自身不自洽。
 
 `model_config.json` 的位置永远从 YAML 的 `model_name_or_path` 推断：绝对路径直接
 用，相对路径先按 YAML 所在目录、再按当前工作目录（Fleet 的解析方式）尝试。
@@ -140,8 +148,9 @@ python -m paddlefleet.config_adapter --input config.yaml \
 |---|---|---|
 | C1 | `N % (TP·SEP·PP) == 0` | sharding 为正整数 |
 | C2 | `N % (PP·EP) == 0`（EP>1） | moe_sharding 为正整数 |
-| C3 | `EP % TP == 0`（EP>1） | dense_sharding 为正整数 |
+| C3 | `EP % (TP·SEP) == 0`（EP>1） | dense_sharding = EP/(TP·SEP) 为正整数 |
 | C4 | `sharding % CP == 0` | cp_sharding 为正整数 |
+| C5 | 不允许 SEP>1 且 CP>1 | 框架禁止 sep 与 context 并行同时使用 |
 | E1 | 跨机必须整节点分配 | Fleet 的 rank 映射要求各机对称 |
 | E2 | `TP·SEP` 放得进单机 | TP/SEP 不缩，缩了有 OOM 风险 |
 | E3 | 所有并行度是 ≥1 的整数 | — |

--- a/src/paddlefleet/config_adapter/README.md
+++ b/src/paddlefleet/config_adapter/README.md
@@ -95,8 +95,12 @@ python -m paddlefleet.config_adapter --input config.yaml \
 
 源作业卡数按两条证据推断并交叉校验：通信组
 （`DP × sharding × TP × SEP × PP`）与 batch 字段
-（`GBS / (micro_bs × acc) × TP × PP × CP`）。两者都能算且不一致时，取通信组的结果
-并在报告里给出 WARNING，提示源 YAML 自身不自洽。
+（`GBS / (micro_bs × acc) × TP × PP × CP`）。两者都能算且不一致时，取「没漏因子」
+的那个 —— 源 YAML 声明了 `data_parallel_size` 就用通信组，没声明则用 batch 字段
+（未声明的 DP 正是通信组公式缺的那一项）—— 并在报告里给出 WARNING。
+
+C3/C5 只取决于并行度本身，与卡数无关：这两项冲突时不会再列出「合法节点数」，而是
+直接说明必须先改 TP/SEP/EP/CP 的组合。
 
 `model_config.json` 的位置永远从 YAML 的 `model_name_or_path` 推断：绝对路径直接
 用，相对路径先按 YAML 所在目录、再按当前工作目录（Fleet 的解析方式）尝试。

--- a/src/paddlefleet/config_adapter/README.md
+++ b/src/paddlefleet/config_adapter/README.md
@@ -89,7 +89,9 @@ python -m paddlefleet.config_adapter --input config.yaml \
 被 `--set` 指定的字段是**受保护**的：后续任何自动规则都不会再覆盖它。但由适配器
 统一计算的字段（TP/PP/EP/CP/SEP、VPP、`num_empty_layers_add_in_tail`、
 `sharding_parallel_size`、`data_parallel_size`、`model_name_or_path`）**不允许**
-用 `--set` 锁定，否则生成的文件会与报告里的并行度对不上 —— 遇到这种组合会直接报错。当某个模型
+用 `--set` 锁定（带不带前缀都一样），否则生成的文件会与报告里的并行度对不上 ——
+遇到这种组合会直接报错。`model_name_or_path` 即使在 `--in-place` 下也不允许锁定：
+改它会决定「到底加载/缩容/快照哪一份 `model_config.json`」。当某个模型
 结构字段在 `model_config.json` 里读不到（不同模型家族命名不一致）时，也用
 `--set <字段>=<值>` 兜底。
 

--- a/src/paddlefleet/config_adapter/README.md
+++ b/src/paddlefleet/config_adapter/README.md
@@ -145,8 +145,7 @@ C3/C5 只取决于并行度本身，与卡数无关：这两项冲突时不会�
 
 写盘时机：所有规划与校验都在内存里完成后才落盘，中途任何一步失败都不改动源文件；
 写文件走临时文件 + 原子替换，`--in-place` 下若 YAML 写失败会回滚已写的
-`model_config.json`。另外需要另存 `model_config.json` 时，`model_name_or_path`
-必须指向新目录，因此不允许同时用 `--set` 锁定它（会直接报错并提示改用 `--in-place`）。
+`model_config.json`。
 
 ### 约束体系
 

--- a/src/paddlefleet/config_adapter/__init__.py
+++ b/src/paddlefleet/config_adapter/__init__.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Adapt a large-cluster training YAML to a smaller machine scale.
+
+Without any switch the adapter simply makes the config fit the target scale:
+it recomputes ``sharding`` / batch and, when the target is incompatible with
+the source parallelism, shrinks EP / PP (never below 2) and rewrites a copy of
+``model_config.json`` accordingly.
+
+Two orthogonal, optional test dimensions refine that:
+
+* ``--test-performance`` -- freeze every parallel dimension and
+  ``gradient_accumulation_steps`` so the step time stays comparable; only
+  ``sharding`` and ``global_batch_size`` move.
+* ``--test-accuracy`` -- pin the determinism switches in
+  :mod:`paddlefleet.config_adapter.precision` so the run does not aadiff, and
+  (unless the performance switch froze ``acc``) keep the effective batch.
+
+Usage::
+
+    python -m paddlefleet.config_adapter --input config.yaml \\
+        --target-nodes 1 --test-accuracy
+"""
+
+from __future__ import annotations
+
+from .cli import build_parser, main, parse_overrides
+from .core import ConfigAdapter, inspect_config
+from .options import AdaptOptions
+from .plan import ParallelismPlan
+from .planner import ShrinkPlanner, plan_frozen, plan_parallelism
+from .precision import PRECISION_SWITCHES, plan_precision_switches
+from .topology import TopologyValidator
+
+__all__ = [
+    "PRECISION_SWITCHES",
+    "AdaptOptions",
+    "ConfigAdapter",
+    "ParallelismPlan",
+    "ShrinkPlanner",
+    "TopologyValidator",
+    "build_parser",
+    "inspect_config",
+    "main",
+    "parse_overrides",
+    "plan_frozen",
+    "plan_parallelism",
+    "plan_precision_switches",
+]

--- a/src/paddlefleet/config_adapter/__main__.py
+++ b/src/paddlefleet/config_adapter/__main__.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``python -m paddlefleet.config_adapter`` entry point."""
+
+from __future__ import annotations
+
+import sys
+
+from .cli import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/paddlefleet/config_adapter/cli.py
+++ b/src/paddlefleet/config_adapter/cli.py
@@ -1,0 +1,282 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Command line entry point for the config adapter."""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import os
+import sys
+from pathlib import Path
+
+from .core import ConfigAdapter, inspect_config
+from .io_writers import YamlWriter
+from .model_config_resolver import (
+    ModelConfigResolveError,
+    resolve_model_config,
+)
+from .options import AdaptOptions
+from .utils import parse_value
+
+EPILOG = """\
+示例：
+  # 1) 只看这份配置能跑在哪些机器规模上（不生成文件）
+  python -m paddlefleet.config_adapter --input config.yaml
+
+  # 2) 适配到 2 台机器（默认每台 8 卡 = 16 卡），必要时自动缩小 EP/PP
+  python -m paddlefleet.config_adapter --input config.yaml --target-nodes 2
+
+  # 3) 测速：冻结 TP/PP/EP/CP/SEP 与 acc，只改 sharding 和 GBS
+  python -m paddlefleet.config_adapter --input config.yaml \\
+      --target-nodes 2 --test-performance
+
+  # 4) 精度测试：注入避免 aadiff 的开关，并保持等效 batch
+  python -m paddlefleet.config_adapter --input config.yaml \\
+      --target-nodes 1 --test-accuracy
+
+  # 5) 两个维度可以同时给：既冻结并行策略，又注入精度开关
+  python -m paddlefleet.config_adapter --input config.yaml \\
+      --target-nodes 8 --test-performance --test-accuracy
+
+  # 6) 单机 2 卡（用 --cards-per-node 表达非 8 卡机型）
+  python -m paddlefleet.config_adapter --input config.yaml \\
+      --target-nodes 1 --cards-per-node 2 --test-accuracy
+
+  # 7) 就地改写源文件，并额外生成 <input>.patch
+  python -m paddlefleet.config_adapter --input config.yaml \\
+      --target-nodes 1 --test-accuracy --in-place
+
+  # 8) 自定义字段：不带前缀时自动判断改 yaml 还是 model_config.json
+  python -m paddlefleet.config_adapter --input config.yaml \\
+      --target-nodes 1 --test-accuracy \\
+      --set max_steps=10 --set n_routed_experts=32 \\
+      --set json:some_new_field=1
+"""
+
+
+def build_parser():
+    """Build the argument parser."""
+    parser = argparse.ArgumentParser(
+        prog="python -m paddlefleet.config_adapter",
+        description=(
+            "把面向大集群的训练 YAML 适配到更小的机器规模："
+            "重算 sharding 与 batch，必要时缩小 EP/PP 并联动改写 "
+            "model_config.json。"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=EPILOG,
+    )
+    parser.add_argument("--input", required=True, help="源 YAML 路径")
+    parser.add_argument(
+        "--target-nodes",
+        type=int,
+        default=None,
+        help="目标机器台数；总卡数 = target-nodes × cards-per-node。"
+        "不传则只列出合法的机器规模，不生成任何文件",
+    )
+    parser.add_argument(
+        "--cards-per-node",
+        type=int,
+        default=8,
+        help="每台机器的卡数（默认 8）",
+    )
+    parser.add_argument(
+        "--test-performance",
+        action="store_true",
+        help="测速维度：冻结 TP/PP/EP/CP/SEP 与 acc，只改 sharding 和 GBS。"
+        "与 --test-accuracy 正交，可单独给、可同时给、也可都不给"
+        "（都不给时默认允许缩小 EP/PP）",
+    )
+    parser.add_argument(
+        "--test-accuracy",
+        action="store_true",
+        help="精度维度：注入避免 aadiff 的开关；未同时指定 "
+        "--test-performance 时还会保持等效 batch（GBS 不变、acc 放大）",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="./adapted_configs",
+        help="输出目录（默认 ./adapted_configs）；--in-place 时忽略",
+    )
+    parser.add_argument(
+        "--set",
+        dest="overrides",
+        action="append",
+        default=[],
+        metavar="[yaml:|json:]KEY=VALUE",
+        help="自定义覆盖，可重复。不带前缀时自动判断改哪个文件"
+        "（谁声明了这个 key 就改谁，两边都有就都改，两边都没有则新增到 "
+        "yaml）；要把新字段加到 model_config.json 请显式写 json:KEY=VALUE。"
+        "这些字段会被保护，不再参与自动适配",
+    )
+    parser.add_argument(
+        "-i",
+        "--in-place",
+        action="store_true",
+        help="就地改写源 YAML（同时就地改写 model_config.json），"
+        "并生成 <input>.patch；请确保源文件已纳入版本管理",
+    )
+    parser.add_argument(
+        "-f",
+        "--force",
+        action="store_true",
+        help="允许覆盖已存在的 model_config 生成目录；"
+        "默认遇到同名目录会中止，避免覆盖上一次的产物",
+    )
+    return parser
+
+
+def parse_overrides(items):
+    """Split ``--set`` items into ``(yaml_map, json_map, auto_map)``.
+
+    ``yaml:KEY=VALUE`` / ``json:KEY=VALUE`` state the target document
+    explicitly; a prefix-less ``KEY=VALUE`` goes into ``auto_map`` and the
+    adapter decides later by looking at which document declares the key.
+    """
+    yaml_map, json_map, auto_map = {}, {}, {}
+    for item in items:
+        target, _, rest = item.partition(":")
+        if target in ("yaml", "json") and rest:
+            bucket = yaml_map if target == "yaml" else json_map
+            payload = rest
+        else:
+            bucket = auto_map
+            payload = item
+
+        key, sep, raw_value = payload.partition("=")
+        if not sep or not key.strip():
+            raise ValueError(
+                f"--set 必须写成 KEY=VALUE（可带 yaml:/json: 前缀），"
+                f"收到：{item!r}"
+            )
+        bucket[key.strip()] = parse_value(raw_value.strip())
+    return yaml_map, json_map, auto_map
+
+
+def _companion_json_path(yaml_path):
+    """Best-effort ``model_config.json`` path, for in-place patch snapshots."""
+    try:
+        config = YamlWriter().load(yaml_path)
+        if not config:
+            return None
+        _model_dir, json_path = resolve_model_config(
+            config.get("model_name_or_path"), Path(yaml_path).parent
+        )
+        return json_path
+    except (ModelConfigResolveError, ValueError, OSError):
+        return None
+
+
+def _read_lines(path):
+    """Read a file as a list of lines, or ``None`` when it does not exist."""
+    path = Path(path) if path else None
+    if not path or not path.is_file():
+        return None
+    return path.read_text(encoding="utf-8").splitlines(keepends=True)
+
+
+def _unified_diff(path, before):
+    """Unified diff of ``path`` against its ``before`` snapshot."""
+    if before is None:
+        return []
+    after = _read_lines(path)
+    if after is None:
+        return []
+    rel = os.path.relpath(str(path), str(Path.cwd()))
+    return list(
+        difflib.unified_diff(
+            before, after, fromfile=f"a/{rel}", tofile=f"b/{rel}"
+        )
+    )
+
+
+def main(argv=None):
+    """Parse arguments and run the adaptation."""
+    args = build_parser().parse_args(argv)
+
+    input_path = Path(args.input)
+    if not input_path.is_file():
+        print(f"错误：输入文件不存在：{input_path}", file=sys.stderr)
+        return 1
+
+    if args.cards_per_node < 1:
+        print("错误：--cards-per-node 必须 >= 1", file=sys.stderr)
+        return 1
+
+    try:
+        yaml_overrides, json_overrides, auto_overrides = parse_overrides(
+            args.overrides
+        )
+    except ValueError as exc:
+        print(f"错误：{exc}", file=sys.stderr)
+        return 1
+
+    # ---- inspection mode: no target scale, nothing is written ------------
+    if args.target_nodes is None:
+        orig_cards, orig_nodes, valid_nodes = inspect_config(
+            input_path, cards_per_node=args.cards_per_node
+        )
+        print(f"ORIGINAL_CARDS={orig_cards if orig_cards else 'UNKNOWN'}")
+        print(f"ORIGINAL_NODES={orig_nodes if orig_nodes else 'UNKNOWN'}")
+        print("VALID_NODES=" + ",".join(str(n) for n in valid_nodes))
+        print(
+            "提示：加 --target-nodes <目标机器台数> 才会生成配置；"
+            "按需叠加 --test-performance / --test-accuracy"
+        )
+        return 0
+
+    if args.target_nodes < 1:
+        print("错误：--target-nodes 必须 >= 1", file=sys.stderr)
+        return 1
+
+    options = AdaptOptions(
+        test_performance=args.test_performance,
+        test_accuracy=args.test_accuracy,
+    )
+
+    before_yaml = before_json = None
+    json_path = None
+    if args.in_place:
+        before_yaml = _read_lines(input_path)
+        json_path = _companion_json_path(input_path)
+        before_json = _read_lines(json_path)
+
+    adapter = ConfigAdapter(
+        options=options,
+        target_nodes=args.target_nodes,
+        cards_per_node=args.cards_per_node,
+        yaml_overrides=yaml_overrides,
+        json_overrides=json_overrides,
+        auto_overrides=auto_overrides,
+        output_dir=args.output_dir,
+        in_place=args.in_place,
+        force=args.force,
+    )
+    ok, message = adapter.adapt(input_path)
+    if not ok:
+        print(f"适配失败：{message}", file=sys.stderr)
+        return 1
+
+    print(message)
+
+    if args.in_place:
+        diff = _unified_diff(input_path, before_yaml) + _unified_diff(
+            json_path, before_json
+        )
+        patch_path = input_path.parent / (input_path.name + ".patch")
+        patch_path.write_text("".join(diff), encoding="utf-8")
+        print(f"PATCH={patch_path}")
+    return 0

--- a/src/paddlefleet/config_adapter/constraints.py
+++ b/src/paddlefleet/config_adapter/constraints.py
@@ -1,0 +1,266 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Hardware (E) and model-structure (M) constraints, plus dim candidates.
+
+The topology validator only covers the C1..C4 communication-group rules.
+Shrinking EP / PP additionally requires:
+
+* E-family -- hardware / allocation prerequisites (:func:`check_hardware`)
+* M-family -- model-structure feasibility (:func:`check_ep_shrink`,
+  :func:`check_pp_shrink`)
+
+Hard rule shared by every candidate generator: **a parallel degree that is
+greater than 1 in the source config is never collapsed to 1.** Dropping a
+dimension entirely (EP 8 -> 1) removes the communication group under test,
+so the smallest legal shrink target is :data:`MIN_PARALLEL_DEGREE`.
+
+All functions here are pure: no I/O, no mutation of the arguments.
+"""
+
+from __future__ import annotations
+
+from .topology import TopologyValidator
+
+DEFAULT_MIN_HIDDEN_LAYERS = 4
+
+#: A source degree > 1 may shrink no further than this.
+MIN_PARALLEL_DEGREE = 2
+
+
+def divisors(n):
+    """Ascending list of positive divisors of ``n``."""
+    if n <= 0:
+        return []
+    out = []
+    i = 1
+    while i * i <= n:
+        if n % i == 0:
+            out.append(i)
+            if i != n // i:
+                out.append(n // i)
+        i += 1
+    return sorted(out)
+
+
+def shrink_floor(degree):
+    """Smallest degree ``degree`` is allowed to shrink to."""
+    return 1 if degree <= 1 else MIN_PARALLEL_DEGREE
+
+
+def floor_dims(tp, pp, ep, cp, sep):
+    """Dims after shrinking EP / PP as far as the no-collapse rule allows."""
+    return tp, shrink_floor(pp), shrink_floor(ep), cp, sep
+
+
+def ep_candidates(ep_orig, tp):
+    """EP-shrink candidates, largest first.
+
+    Set: ``({powers of 2} | {multiples of 8})`` restricted to
+    ``[MIN_PARALLEL_DEGREE, ep_orig)`` and filtered by ``ep_new % tp == 0``
+    (C3).  Real deployments only ever pick EP from those two families, which
+    keeps the search space small and avoids exotic values like EP=3.
+    """
+    if ep_orig <= MIN_PARALLEL_DEGREE:
+        return []
+    powers_of_2 = {1 << k for k in range(ep_orig.bit_length())}
+    multiples_of_8 = {8 * k for k in range(1, ep_orig // 8 + 1)}
+    pool = (powers_of_2 | multiples_of_8) & set(
+        range(MIN_PARALLEL_DEGREE, ep_orig)
+    )
+    return sorted(
+        (c for c in pool if tp == 1 or c % tp == 0),
+        reverse=True,
+    )
+
+
+def pp_candidates(pp_orig):
+    """PP-shrink candidates, largest first.
+
+    Divisors of ``pp_orig`` in ``[MIN_PARALLEL_DEGREE, pp_orig)``.  Requiring
+    divisibility keeps ``num_hidden_layers * pp_new // pp_orig`` an integer;
+    the residual VPP / tail padding is handled by :func:`align_layers`.
+    """
+    if pp_orig <= MIN_PARALLEL_DEGREE:
+        return []
+    return sorted(
+        (d for d in divisors(pp_orig) if MIN_PARALLEL_DEGREE <= d < pp_orig),
+        reverse=True,
+    )
+
+
+def align_layers(layers_new, head, tail_orig, pp_new, vpp_orig):
+    """Align pipeline layers to ``pp_new * vpp_new`` with empty tail layers.
+
+    Returns ``(vpp_new, tail_new)``, or ``(None, None)`` when no divisor of
+    ``vpp_orig`` can be aligned.  ``pp_new`` is always >= 2 here because a
+    source PP > 1 never collapses to 1.
+    """
+    if pp_new < MIN_PARALLEL_DEGREE:
+        return None, None
+    if vpp_orig is None or vpp_orig < 1:
+        vpp_orig = 1
+    for vpp_new in sorted(divisors(vpp_orig), reverse=True):
+        divisor = pp_new * vpp_new
+        pad = (-(layers_new + head + tail_orig)) % divisor
+        if pad < divisor:
+            return vpp_new, tail_orig + pad
+    return None, None
+
+
+def min_shrink_cards(tp, pp, ep, cp, sep, cards_per_node):
+    """Smallest GPU count reachable without collapsing any degree to 1."""
+    validator = TopologyValidator(cards_per_node, cards_per_node)
+    return validator.suggest_valid_cards(*floor_dims(tp, pp, ep, cp, sep))[0]
+
+
+def check_hardware(target_cards, cards_per_node, tp, pp, ep, cp, sep):
+    """E1/E2/E3 pre-checks, run once per plan. Returns ``(ok, reason)``.
+
+    A failure aborts the whole plan (rather than skipping one candidate):
+    these depend only on the fixed inputs.
+    """
+    for name, value in (
+        ("tp", tp),
+        ("pp", pp),
+        ("ep", ep),
+        ("cp", cp),
+        ("sep", sep),
+    ):
+        if not isinstance(value, int) or value < 1:
+            return False, f"E3 不满足：{name}={value!r} 必须是 >=1 的整数"
+
+    # E1: Fleet's rank mapping assumes symmetric per-node allocation, so a
+    # multi-machine job must take whole nodes.
+    if target_cards > cards_per_node and target_cards % cards_per_node != 0:
+        return False, (
+            f"E1 不满足：target_cards={target_cards} 超过单机 "
+            f"{cards_per_node} 卡但不是其整数倍；跨机必须整节点分配"
+        )
+
+    # E2: TP*SEP must fit into one node -- neither is ever shrunk, because a
+    # smaller TP raises per-card memory and risks OOM.
+    max_intra = min(cards_per_node, target_cards)
+    if tp * sep > max_intra:
+        min_cards = min_shrink_cards(tp, pp, ep, cp, sep, cards_per_node)
+        return False, (
+            f"E2 不满足：TP={tp} × SEP={sep} 需要单机内 {tp * sep} 张卡，"
+            f"但目标只有 {target_cards} 张卡。\n"
+            f"  说明：适配不会修改 TP/SEP（减小 TP 会增大单卡显存，"
+            f"有 OOM 风险）。\n"
+            f"  建议：至少使用 {min_cards} 张卡 "
+            f"（--target-nodes {max(min_cards // cards_per_node, 1)}）"
+        )
+
+    return True, ""
+
+
+def check_ep_shrink(ep_orig, ep_new, num_experts, num_experts_per_tok):
+    """M1 + M2 for one ``ep_new``.
+
+    Returns ``(ok, reason, experts_new)``.  ``experts_new`` is meaningful even
+    on failure so callers can log it.
+    """
+    if ep_new >= ep_orig:
+        return True, "", num_experts
+
+    experts_new = num_experts * ep_new // ep_orig
+
+    # M1: every EP rank must hold the same number of experts.
+    if experts_new % ep_new != 0:
+        return (
+            False,
+            f"M1 不满足：experts_new={experts_new} 不能被 ep_new={ep_new} 整除",
+            experts_new,
+        )
+
+    # M2: the routing width must remain satisfiable.
+    if experts_new < num_experts_per_tok:
+        return (
+            False,
+            f"M2 不满足：experts_new={experts_new} < "
+            f"num_experts_per_tok={num_experts_per_tok}",
+            experts_new,
+        )
+
+    return True, "", experts_new
+
+
+def check_pp_shrink(
+    pp_orig,
+    pp_new,
+    num_hidden_layers,
+    head,
+    tail,
+    vpp,
+    first_k_dense_replace=0,
+    min_hidden_layers=DEFAULT_MIN_HIDDEN_LAYERS,
+):
+    """M3 + M4 + M5 for one ``pp_new``.
+
+    Returns ``(ok, reason, meta)`` where ``meta`` carries ``layers_new``,
+    ``vpp_new``, ``tail_new`` and an optional soft ``warning``.  M4 is a
+    warning rather than a rejection; the hard floor is one hidden layer.
+    """
+    if pp_new >= pp_orig:
+        return (
+            True,
+            "",
+            {
+                "layers_new": num_hidden_layers,
+                "vpp_new": vpp,
+                "tail_new": tail,
+                "warning": None,
+            },
+        )
+
+    layers_new = num_hidden_layers * pp_new // pp_orig
+    meta = {
+        "layers_new": layers_new,
+        "vpp_new": None,
+        "tail_new": None,
+        "warning": None,
+    }
+
+    if layers_new < 1:
+        return False, f"layers_new={layers_new}，模型至少需要 1 层", meta
+
+    if layers_new < min_hidden_layers:
+        meta["warning"] = (
+            f"num_hidden_layers 缩减至 {layers_new}"
+            f"（推荐 >= {min_hidden_layers}），仅适合调试，训练效果不保证"
+        )
+
+    # M5: the dense-only prefix must still fit in the shrunk stack.
+    if layers_new < first_k_dense_replace:
+        return (
+            False,
+            f"M5 不满足：layers_new={layers_new} < "
+            f"first_k_dense_replace={first_k_dense_replace}",
+            meta,
+        )
+
+    # M3: layer alignment feasibility.
+    vpp_new, tail_new = align_layers(layers_new, head, tail, pp_new, vpp)
+    if vpp_new is None:
+        return (
+            False,
+            f"M3 不满足：(layers_new={layers_new} + head={head} + "
+            f"tail>={tail}) 无法对齐到 pp_new={pp_new} × vpp_new",
+            meta,
+        )
+
+    meta["vpp_new"] = vpp_new
+    meta["tail_new"] = tail_new
+    return True, "", meta

--- a/src/paddlefleet/config_adapter/constraints.py
+++ b/src/paddlefleet/config_adapter/constraints.py
@@ -64,13 +64,14 @@ def floor_dims(tp, pp, ep, cp, sep):
     return tp, shrink_floor(pp), shrink_floor(ep), cp, sep
 
 
-def ep_candidates(ep_orig, tp):
+def ep_candidates(ep_orig, tp, sep=1):
     """EP-shrink candidates, largest first.
 
     Set: ``({powers of 2} | {multiples of 8})`` restricted to
-    ``[MIN_PARALLEL_DEGREE, ep_orig)`` and filtered by ``ep_new % tp == 0``
-    (C3).  Real deployments only ever pick EP from those two families, which
-    keeps the search space small and avoids exotic values like EP=3.
+    ``[MIN_PARALLEL_DEGREE, ep_orig)`` and filtered by
+    ``ep_new % (tp * sep) == 0`` (C3: dense_sharding = EP / (TP * SEP)).
+    Real deployments only ever pick EP from those two families, which keeps
+    the search space small and avoids exotic values like EP=3.
     """
     if ep_orig <= MIN_PARALLEL_DEGREE:
         return []
@@ -79,8 +80,9 @@ def ep_candidates(ep_orig, tp):
     pool = (powers_of_2 | multiples_of_8) & set(
         range(MIN_PARALLEL_DEGREE, ep_orig)
     )
+    dense_factor = tp * sep
     return sorted(
-        (c for c in pool if tp == 1 or c % tp == 0),
+        (c for c in pool if dense_factor == 1 or c % dense_factor == 0),
         reverse=True,
     )
 

--- a/src/paddlefleet/config_adapter/core.py
+++ b/src/paddlefleet/config_adapter/core.py
@@ -1,0 +1,575 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The adaptation pipeline.
+
+``ConfigAdapter.adapt`` runs the whole rewrite in one pass::
+
+    load YAML
+      -> apply --set yaml: overrides (and pin them: nothing else may touch
+         those keys afterwards)
+      -> drop fa_version (an environment-specific flash-attention pin)
+      -> load model_config.json + apply --set json: overrides, when the
+         profile or the user needs it
+      -> profile.plan(): decide the final TP/PP/EP/CP/SEP
+      -> apply the plan's model_config.json writes
+      -> inject the determinism switches (accuracy profile only)
+      -> write model_config.json when it changed, and point
+         model_name_or_path at it
+      -> apply the plan's YAML writes and re-validate C1..C4
+      -> scale the batch settings, sharding and data_parallel_size
+      -> write the YAML and render the report
+
+Every write goes through the change log, so the report can attribute each
+field to the decision that produced it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .io_writers import JsonWriter, YamlWriter
+from .model_config_resolver import (
+    ModelConfigResolveError,
+    build_adapted_dir,
+    resolve_model_config,
+    rewrite_model_name_or_path,
+)
+from .planner import plan_parallelism
+from .precision import plan_precision_switches
+from .report import ChangeLog, format_header, format_report
+from .strategies import BATCH_STRATEGIES
+from .topology import TopologyValidator
+from .utils import PARALLEL_FIELDS, extract_parallel_params
+
+
+class ConfigAdapter:
+    """Rewrites one training YAML (and its model_config.json) for a scale."""
+
+    def __init__(
+        self,
+        options,
+        target_nodes,
+        cards_per_node=8,
+        yaml_overrides=None,
+        json_overrides=None,
+        auto_overrides=None,
+        output_dir="./adapted_configs",
+        in_place=False,
+        force=False,
+    ):
+        self.options = options
+        self.target_nodes = target_nodes
+        self.cards_per_node = cards_per_node
+        self.target_cards = target_nodes * cards_per_node
+        # --set values, split by how the target document was decided:
+        # explicitly prefixed (yaml:/json:) versus auto-detected.
+        self.yaml_overrides = dict(yaml_overrides or {})
+        self.json_overrides = dict(json_overrides or {})
+        self.auto_overrides = dict(auto_overrides or {})
+        self.output_dir = Path(output_dir)
+        self.in_place = in_place
+        self.force = force
+
+        self.scale_tag = f"{self.target_cards}cards"
+        self.yaml_writer = YamlWriter()
+        self.json_writer = JsonWriter()
+        # Original bytes of an in-place rewritten model_config.json, used to
+        # roll back if the YAML write then fails.
+        self._json_backup = None
+
+    # ------------------------------------------------------------------ main
+    def adapt(self, input_path):
+        """Adapt one YAML file. Returns ``(ok, message)``."""
+        input_path = Path(input_path)
+        log = ChangeLog()
+
+        config = self.yaml_writer.load(input_path)
+        if config is None:
+            return False, f"配置文件为空：{input_path}"
+
+        if self.yaml_overrides:
+            log.record(
+                "yaml",
+                self.yaml_writer.apply_config_map(config, self.yaml_overrides),
+                "用户通过 --set yaml: 指定，自动适配不会再覆盖该字段",
+            )
+
+        if "fa_version" in config:
+            log.record_removed(
+                "yaml",
+                "fa_version",
+                config.pop("fa_version"),
+                "fa_version 是与环境强绑定的 flash-attention 版本 pin，"
+                "适配后的配置不携带",
+            )
+
+        dims_before = extract_parallel_params(config)
+        scale_source = {
+            key: config.get(key)
+            for key in (
+                "sharding_parallel_size",
+                "global_batch_size",
+                "per_device_train_batch_size",
+                "gradient_accumulation_steps",
+            )
+        }
+
+        model_config, model_dir, json_path, json_error = self._load_json(
+            config, input_path
+        )
+        if self.json_overrides:
+            if model_config is None:
+                return False, f"--set json: 无法应用：{json_error}"
+            log.record(
+                "json",
+                self.json_writer.apply_config_map(
+                    model_config, self.json_overrides
+                ),
+                "用户通过 --set json: 指定，自动适配不会再覆盖该字段",
+            )
+
+        self._apply_auto_overrides(config, model_config, log)
+
+        plan, err = plan_parallelism(
+            config,
+            dims_before,
+            self.target_cards,
+            self.cards_per_node,
+            self.options,
+            context={
+                "model_config": model_config,
+                "model_config_error": json_error,
+                "input_path": input_path,
+            },
+        )
+        if err:
+            return False, f"{input_path.name}: {err}"
+
+        for key, value, reason in plan.json_changes:
+            log.record(
+                "json",
+                self.json_writer.apply_config_map(
+                    model_config, {key: value}, protected=self.json_overrides
+                ),
+                reason,
+            )
+
+        skipped_switches = []
+        if self.options.inject_precision:
+            skipped_switches = self._inject_precision(config, model_config, log)
+
+        for key, value, reason in plan.yaml_changes:
+            log.record(
+                "yaml",
+                self.yaml_writer.apply_config_map(
+                    config, {key: value}, protected=self.yaml_overrides
+                ),
+                reason,
+            )
+
+        dims_after = plan.dims()
+        validator = TopologyValidator(self.target_cards, self.cards_per_node)
+        ok, message, details = validator.validate(*dims_after)
+        if not ok:
+            return False, f"{input_path.name}: {message}"
+
+        orig_cards, err = self._infer_orig_cards(scale_source, dims_before)
+        if err:
+            return False, f"{input_path.name}: {err}"
+
+        err = self._scale_batch_and_sharding(
+            config, log, scale_source, orig_cards, dims_after
+        )
+        if err:
+            return False, f"{input_path.name}: {err}"
+
+        # Nothing has touched the filesystem up to this point: every rewrite
+        # above happened in memory, so a validation failure leaves both source
+        # files exactly as they were.
+        model_config_output, err = self._write_model_config(
+            config, log, model_config, model_dir, json_path, input_path
+        )
+        if err:
+            return False, f"{input_path.name}: {err}"
+
+        info = self._build_info(
+            input_path,
+            orig_cards,
+            dims_before,
+            dims_after,
+            details,
+            plan,
+            model_config_output,
+            skipped_switches,
+        )
+        output_path = Path(info["output"])
+        # In-place runs must not accumulate a new banner on every rewrite.
+        header = "" if self.in_place else format_header(info)
+        try:
+            self.yaml_writer.write(config, output_path, header=header)
+        except OSError as exc:
+            # The companion JSON was already persisted; put it back so an
+            # in-place run cannot leave the two source files disagreeing.
+            if self._json_backup is not None:
+                Path(json_path).write_bytes(self._json_backup)
+            return False, f"{input_path.name}: 写出 {output_path} 失败：{exc}"
+        return True, format_report(info, log)
+
+    # --------------------------------------------------------------- stages
+    def _apply_auto_overrides(self, config, model_config, log):
+        """Route prefix-less ``--set`` values to whoever declares the key.
+
+        * declared in the YAML only -> YAML;
+        * declared in ``model_config.json`` only -> JSON;
+        * declared in both -> both (the framework reads either);
+        * declared nowhere -> added to the YAML (use ``--set json:KEY=VALUE``
+          to create a brand-new model_config field instead).
+
+        Keys routed here are remembered as protected, exactly like the
+        explicitly prefixed ones.
+        """
+        for key, value in self.auto_overrides.items():
+            in_yaml = key in config
+            in_json = model_config is not None and key in model_config
+
+            if in_yaml or not in_json:
+                where = "yaml 与 json 都声明了该字段" if in_json else None
+                if not in_yaml:
+                    where = "yaml 与 json 都没有该字段，按默认新增到 yaml"
+                elif where is None:
+                    where = "自动匹配到 yaml"
+                self.yaml_overrides[key] = value
+                log.record(
+                    "yaml",
+                    self.yaml_writer.apply_config_map(config, {key: value}),
+                    f"用户通过 --set 指定（{where}）",
+                )
+            if in_json:
+                self.json_overrides[key] = value
+                log.record(
+                    "json",
+                    self.json_writer.apply_config_map(
+                        model_config, {key: value}
+                    ),
+                    "用户通过 --set 指定（"
+                    + (
+                        "yaml 与 json 都声明了该字段"
+                        if in_yaml
+                        else "自动匹配到 model_config.json"
+                    )
+                    + "）",
+                )
+
+    def _load_json(self, config, input_path):
+        """Load ``model_config.json`` when it may be needed.
+
+        Returns ``(model_config, model_dir, json_path, error)``.  A failure is
+        not fatal here: shrinking only *needs* the JSON when EP / PP actually
+        have to move, so the error is carried forward and reported by whoever
+        needs it.
+        """
+        needed = (
+            self.options.needs_model_config
+            or bool(self.json_overrides)
+            or bool(self.auto_overrides)
+        )
+        if not needed:
+            return None, None, None, "本次运行不需要 model_config.json"
+
+        try:
+            model_dir, json_path = resolve_model_config(
+                config.get("model_name_or_path"), input_path.parent
+            )
+            return self.json_writer.load(json_path), model_dir, json_path, None
+        except (ModelConfigResolveError, ValueError) as exc:
+            return None, None, None, str(exc)
+
+    def _inject_precision(self, config, model_config, log):
+        """Pin the determinism switches. Returns notes for skipped ones."""
+        applied, skipped = plan_precision_switches(config, model_config)
+        for target, key, value, reason in applied:
+            if target == "yaml":
+                diffs = self.yaml_writer.apply_config_map(
+                    config, {key: value}, protected=self.yaml_overrides
+                )
+            else:
+                diffs = self.json_writer.apply_config_map(
+                    model_config, {key: value}, protected=self.json_overrides
+                )
+            log.record(target, diffs, reason)
+        return skipped
+
+    def _write_model_config(
+        self, config, log, model_config, model_dir, json_path, input_path
+    ):
+        """Persist ``model_config.json`` when it changed.
+
+        Returns ``(path_or_None, error_or_None)``.  Called only after every
+        check has passed, so this is the first filesystem write of the run.
+        A pre-existing adapted directory is refused unless ``--force`` was
+        given: it usually means a stale artefact the user should look at.
+        """
+        self._json_backup = None
+        if model_config is None or not log.by_target("json"):
+            return None, None
+
+        if self.in_place:
+            # Keep the original bytes so a later YAML write failure can be
+            # rolled back (see adapt()).
+            self._json_backup = Path(json_path).read_bytes()
+            self.json_writer.write(model_config, json_path)
+            return str(json_path), None
+
+        # The generated YAML must point at the generated JSON, so this field
+        # cannot be pinned by the user at the same time.
+        if "model_name_or_path" in self.yaml_overrides:
+            return None, (
+                "本次需要改写模型结构并另存 model_config.json，"
+                "因此 model_name_or_path 必须指向新生成的目录，"
+                "不能同时用 --set 锁定它；"
+                "请去掉 --set yaml:model_name_or_path=...，"
+                "或改用 --in-place（就地改写源 model_config.json，"
+                "不改 model_name_or_path）"
+            )
+
+        adapted_dir = build_adapted_dir(
+            self.output_dir, model_dir.name, self.scale_tag
+        )
+        try:
+            adapted_dir.mkdir(parents=True, exist_ok=self.force)
+        except FileExistsError:
+            return None, (
+                f"已存在生成目录 {adapted_dir}，为避免覆盖上一次的产物而中止；"
+                f"确认可以覆盖请加 -f/--force"
+            )
+        except OSError as exc:
+            return None, f"无法创建 {adapted_dir}：{exc}"
+
+        target_json = adapted_dir / "model_config.json"
+        self.json_writer.write(model_config, target_json)
+
+        raw = config.get("model_name_or_path")
+        log.record(
+            "yaml",
+            self.yaml_writer.apply_config_map(
+                config,
+                {
+                    "model_name_or_path": rewrite_model_name_or_path(
+                        adapted_dir,
+                        input_path.parent,
+                        bool(raw) and str(raw).startswith("/"),
+                    )
+                },
+            ),
+            "指向本次生成的 model_config 目录（源 model_config.json 不修改）",
+        )
+        return str(target_json), None
+
+    @staticmethod
+    def _infer_orig_cards(scale_source, dims_before):
+        """Infer the source job's GPU count. Returns ``(cards, error)``."""
+        tp, pp, ep, cp, sep = dims_before
+
+        sharding = scale_source["sharding_parallel_size"]
+        if sharding is not None and int(sharding) > 0:
+            return int(sharding) * tp * sep * pp, None
+
+        gbs = scale_source["global_batch_size"]
+        micro_bs = scale_source["per_device_train_batch_size"]
+        grad_accum = scale_source["gradient_accumulation_steps"]
+        if gbs and micro_bs and grad_accum:
+            dataset_world_size = int(gbs) // (int(micro_bs) * int(grad_accum))
+            if dataset_world_size > 0:
+                return dataset_world_size * tp * pp * cp, None
+
+        if gbs is not None:
+            return None, (
+                "无法推断源作业的卡数：既没有可用的 sharding_parallel_size"
+                "（>0），也无法用 global_batch_size / "
+                "per_device_train_batch_size / gradient_accumulation_steps "
+                "反推。请在 YAML 里补全，或用 "
+                "--set yaml:sharding_parallel_size=<源 sharding> 指定"
+            )
+        return None, None
+
+    def _scale_batch_and_sharding(
+        self, config, log, scale_source, orig_cards, dims_after
+    ):
+        """Rewrite batch / sharding / data_parallel_size. Returns an error."""
+        gbs = scale_source["global_batch_size"]
+        grad_accum = scale_source["gradient_accumulation_steps"]
+        gbs = int(gbs) if gbs is not None else None
+        grad_accum = int(grad_accum) if grad_accum else 1
+
+        if orig_cards is None:
+            batch_map = {"gradient_accumulation_steps": grad_accum}
+            reason = (
+                f"推断不出源卡数，acc 保持 {grad_accum} 不变，"
+                f"GBS 由框架按实际卡数反推"
+            )
+        else:
+            strategy = BATCH_STRATEGIES[self.options.batch_strategy]
+            batch_map, reason, err = strategy(
+                gbs, grad_accum, orig_cards, self.target_cards
+            )
+            if err:
+                return err
+
+        # Only rewrite batch fields the source actually declares.
+        batch_map = {k: v for k, v in batch_map.items() if k in config}
+        log.record(
+            "yaml",
+            self.yaml_writer.apply_config_map(
+                config, batch_map, protected=self.yaml_overrides
+            ),
+            reason,
+        )
+
+        tp, pp, ep, cp, sep = dims_after
+        new_sharding = self.target_cards // (tp * sep * pp)
+        sharding_field = "sharding_parallel_size"
+        current = config.get(sharding_field)
+        if current is not None and int(current) != -1:
+            log.record(
+                "yaml",
+                self.yaml_writer.apply_config_map(
+                    config,
+                    {sharding_field: new_sharding},
+                    protected=self.yaml_overrides,
+                ),
+                f"sharding = 目标卡数 / (TP×SEP×PP) = {self.target_cards} / "
+                f"({tp}×{sep}×{pp}) = {new_sharding}",
+            )
+
+        if "data_parallel_size" in config:
+            log.record(
+                "yaml",
+                self.yaml_writer.apply_config_map(
+                    config,
+                    {"data_parallel_size": 1},
+                    protected=self.yaml_overrides,
+                ),
+                "Fleet 要求纯 sharding 数据并行：data_parallel_size 固定为 1，"
+                "数据并行度由 sharding 承担",
+            )
+        return None
+
+    # ---------------------------------------------------------------- report
+    def _build_info(
+        self,
+        input_path,
+        orig_cards,
+        dims_before,
+        dims_after,
+        details,
+        plan,
+        model_config_output,
+        skipped_switches,
+    ):
+        """Assemble everything the header / report need."""
+        tp0, pp0, ep0, cp0, sep0 = dims_before
+        tp1, pp1, ep1, cp1, sep1 = dims_after
+
+        dims_line = "  ".join(
+            f"{name.upper()} {before}->{after}"
+            for name, before, after in zip(
+                PARALLEL_FIELDS,
+                dims_before,
+                dims_after,
+                strict=True,
+            )
+        )
+
+        orig_sharding = orig_cards // (tp0 * sep0 * pp0) if orig_cards else "?"
+        sharding_line = f"{orig_sharding} -> {details['sharding']}"
+        derived = []
+        if ep1 > 1:
+            derived.append(f"moe_sharding={details['moe_sharding']}")
+            derived.append(f"dense_sharding={details['dense_sharding']}")
+        if cp1 > 1:
+            derived.append(f"cp_sharding={details['cp_sharding']}")
+        if derived:
+            sharding_line += "（" + ", ".join(derived) + "）"
+
+        if orig_cards and orig_cards % self.cards_per_node == 0:
+            orig_nodes_label = orig_cards // self.cards_per_node
+            orig_scale_label = f"{orig_nodes_label} 节点 / {orig_cards} 卡"
+        elif orig_cards:
+            orig_nodes_label = "UNKNOWN"
+            orig_scale_label = f"{orig_cards} 卡"
+        else:
+            orig_nodes_label = "UNKNOWN"
+            orig_scale_label = "未知规模"
+
+        if self.in_place:
+            output = input_path
+        else:
+            output = self.output_dir / (
+                f"{input_path.stem}_adapted_{self.scale_tag}{input_path.suffix}"
+            )
+
+        return {
+            "input": str(input_path),
+            "output": str(output),
+            "profile": self.options.label,
+            "profile_flag": self.options.flags,
+            "batch_strategy": self.options.batch_strategy,
+            "orig_cards_label": orig_cards if orig_cards else "UNKNOWN",
+            "orig_nodes_label": orig_nodes_label,
+            "orig_scale_label": orig_scale_label,
+            "target_cards": self.target_cards,
+            "target_nodes": self.target_nodes,
+            "cards_per_node": self.cards_per_node,
+            "dims_line": dims_line,
+            "sharding_line": sharding_line,
+            "plan_note": plan.note or "无",
+            "model_config_output": model_config_output,
+            "skipped_switches": skipped_switches,
+            "warnings": plan.warnings,
+        }
+
+
+def inspect_config(input_path, cards_per_node=8, max_nodes=16):
+    """Read-only inspection used when no target scale is given.
+
+    Returns ``(orig_cards, orig_nodes, valid_nodes)``: the inferred source
+    scale plus every node count within ``max_nodes`` whose GPU count satisfies
+    C1..C4 for the source parallelism.  Nothing is written.
+    """
+    config = YamlWriter().load(input_path)
+    if config is None:
+        raise ValueError(f"配置文件为空：{input_path}")
+
+    dims = extract_parallel_params(config)
+    scale_source = {
+        key: config.get(key)
+        for key in (
+            "sharding_parallel_size",
+            "global_batch_size",
+            "per_device_train_batch_size",
+            "gradient_accumulation_steps",
+        )
+    }
+    orig_cards, _err = ConfigAdapter._infer_orig_cards(scale_source, dims)
+    orig_nodes = (
+        orig_cards // cards_per_node
+        if orig_cards and orig_cards % cards_per_node == 0
+        else None
+    )
+
+    validator = TopologyValidator(cards_per_node, cards_per_node)
+    cards = validator.suggest_valid_cards(*dims, max_nodes=max_nodes)
+    valid_nodes = sorted({max(c // cards_per_node, 1) for c in cards})
+    return orig_cards, orig_nodes, valid_nodes

--- a/src/paddlefleet/config_adapter/core.py
+++ b/src/paddlefleet/config_adapter/core.py
@@ -115,9 +115,14 @@ class ConfigAdapter:
         # not rewrite it: repointing it mid-run would decide *which*
         # model_config.json is loaded, shrunk and snapshotted for the patch,
         # and the answer differs between the prefixed and prefix-less forms.
-        # Prefix-less --set values are routed to the YAML later, so they have
-        # to be checked here as well.
-        requested = set(self.yaml_overrides) | set(self.auto_overrides)
+        # Every --set form counts: prefix-less values are routed to the YAML
+        # later, and a json: prefix would park a training-parallelism key in
+        # model_config.json while the YAML keeps the adapter's own value.
+        requested = (
+            set(self.yaml_overrides)
+            | set(self.json_overrides)
+            | set(self.auto_overrides)
+        )
         pinned = sorted(ADAPTER_CONTROLLED_FIELDS & requested)
         if pinned:
             return False, (

--- a/src/paddlefleet/config_adapter/core.py
+++ b/src/paddlefleet/config_adapter/core.py
@@ -53,6 +53,20 @@ from .strategies import BATCH_STRATEGIES
 from .topology import TopologyValidator
 from .utils import PARALLEL_FIELDS, extract_parallel_params
 
+#: Fields whose value the adapter derives itself. A ``--set`` pin on any of
+#: them is refused rather than silently skipped, because the plan, the
+#: validation and the report all assume the adapter's own value.
+ADAPTER_CONTROLLED_FIELDS = frozenset(
+    set(PARALLEL_FIELDS.values())
+    | {
+        "virtual_pipeline_model_parallel_size",
+        "num_empty_layers_add_in_tail",
+        "sharding_parallel_size",
+        "data_parallel_size",
+        "model_name_or_path",
+    }
+)
+
 
 class ConfigAdapter:
     """Rewrites one training YAML (and its model_config.json) for a scale."""
@@ -95,6 +109,21 @@ class ConfigAdapter:
         input_path = Path(input_path)
         log = ChangeLog()
 
+        # Fields the adapter must own: pinning them with --set would make the
+        # generated file disagree with the reported parallelism / sharding.
+        # In-place runs never rewrite model_name_or_path, so pinning that one
+        # is harmless there.
+        controlled = ADAPTER_CONTROLLED_FIELDS
+        if self.in_place:
+            controlled = controlled - {"model_name_or_path"}
+        pinned = sorted(controlled & set(self.yaml_overrides))
+        if pinned:
+            return False, (
+                f"以下字段由适配器统一计算，不能用 --set 锁定：{pinned}。"
+                f"锁定后生成的配置会与报告里的并行度 / sharding 不一致；"
+                f"请去掉对应的 --set，或直接改源 YAML 后再适配"
+            )
+
         config = self.yaml_writer.load(input_path)
         if config is None:
             return False, f"配置文件为空：{input_path}"
@@ -106,7 +135,7 @@ class ConfigAdapter:
                 "用户通过 --set yaml: 指定，自动适配不会再覆盖该字段",
             )
 
-        if "fa_version" in config:
+        if "fa_version" in config and "fa_version" not in self.yaml_overrides:
             log.record_removed(
                 "yaml",
                 "fa_version",
@@ -120,6 +149,7 @@ class ConfigAdapter:
             key: config.get(key)
             for key in (
                 "sharding_parallel_size",
+                "data_parallel_size",
                 "global_batch_size",
                 "per_device_train_batch_size",
                 "gradient_accumulation_steps",
@@ -185,9 +215,13 @@ class ConfigAdapter:
         if not ok:
             return False, f"{input_path.name}: {message}"
 
-        orig_cards, err = self._infer_orig_cards(scale_source, dims_before)
+        orig_cards, scale_warning, err = self._infer_orig_cards(
+            scale_source, dims_before
+        )
         if err:
             return False, f"{input_path.name}: {err}"
+        if scale_warning:
+            plan.warnings.append(scale_warning)
 
         err = self._scale_batch_and_sharding(
             config, log, scale_source, orig_cards, dims_after
@@ -332,18 +366,6 @@ class ConfigAdapter:
             self.json_writer.write(model_config, json_path)
             return str(json_path), None
 
-        # The generated YAML must point at the generated JSON, so this field
-        # cannot be pinned by the user at the same time.
-        if "model_name_or_path" in self.yaml_overrides:
-            return None, (
-                "本次需要改写模型结构并另存 model_config.json，"
-                "因此 model_name_or_path 必须指向新生成的目录，"
-                "不能同时用 --set 锁定它；"
-                "请去掉 --set yaml:model_name_or_path=...，"
-                "或改用 --in-place（就地改写源 model_config.json，"
-                "不改 model_name_or_path）"
-            )
-
         adapted_dir = build_adapted_dir(
             self.output_dir, model_dir.name, self.scale_tag
         )
@@ -379,30 +401,69 @@ class ConfigAdapter:
 
     @staticmethod
     def _infer_orig_cards(scale_source, dims_before):
-        """Infer the source job's GPU count. Returns ``(cards, error)``."""
+        """Infer the source job's GPU count.
+
+        Returns ``(cards, warning, error)``.  Two independent estimates are
+        computed when the config carries enough information:
+
+        * comm groups: ``DP * sharding * TP * SEP * PP`` -- ``sharding`` alone
+          is a group size, not the world size, so a dense job with ``DP > 1``
+          would otherwise be under-counted;
+        * batch settings: ``GBS / (micro_bs * acc) * TP * PP * CP``.
+
+        The comm-group estimate wins when both exist, but a mismatch is
+        surfaced as a warning: it means the source YAML is not self-consistent
+        and every derived batch value inherits that ambiguity.
+        """
         tp, pp, ep, cp, sep = dims_before
 
         sharding = scale_source["sharding_parallel_size"]
+        dp = scale_source["data_parallel_size"]
+        dp = int(dp) if dp and int(dp) > 0 else 1
+        group_based = None
         if sharding is not None and int(sharding) > 0:
-            return int(sharding) * tp * sep * pp, None
+            group_based = dp * int(sharding) * tp * sep * pp
 
         gbs = scale_source["global_batch_size"]
         micro_bs = scale_source["per_device_train_batch_size"]
         grad_accum = scale_source["gradient_accumulation_steps"]
+        batch_based = None
         if gbs and micro_bs and grad_accum:
             dataset_world_size = int(gbs) // (int(micro_bs) * int(grad_accum))
             if dataset_world_size > 0:
-                return dataset_world_size * tp * pp * cp, None
+                batch_based = dataset_world_size * tp * pp * cp
+
+        warning = None
+        if group_based is not None and batch_based is not None:
+            if group_based != batch_based:
+                warning = (
+                    f"源卡数的两种推断不一致：按通信组"
+                    f"（DP={dp}×sharding={sharding}×TP={tp}×SEP={sep}×"
+                    f"PP={pp}）为 {group_based}，按 batch 字段"
+                    f"（GBS/(micro×acc)×TP×PP×CP）为 {batch_based}；"
+                    f"取通信组的 {group_based}。"
+                    f"如果不对，请修正源 YAML 的 data_parallel_size 或 "
+                    f"batch 字段后重新适配"
+                )
+            return group_based, warning, None
+        if group_based is not None:
+            return group_based, None, None
+        if batch_based is not None:
+            return batch_based, None, None
 
         if gbs is not None:
-            return None, (
-                "无法推断源作业的卡数：既没有可用的 sharding_parallel_size"
-                "（>0），也无法用 global_batch_size / "
-                "per_device_train_batch_size / gradient_accumulation_steps "
-                "反推。请在 YAML 里补全，或用 "
-                "--set yaml:sharding_parallel_size=<源 sharding> 指定"
+            return (
+                None,
+                None,
+                (
+                    "无法推断源作业的卡数：既没有可用的 sharding_parallel_size"
+                    "（>0），也无法用 global_batch_size / "
+                    "per_device_train_batch_size / gradient_accumulation_steps "
+                    "反推。请在源 YAML 里补上 sharding_parallel_size / "
+                    "data_parallel_size，或补全 batch 字段"
+                ),
             )
-        return None, None
+        return None, None, None
 
     def _scale_batch_and_sharding(
         self, config, log, scale_source, orig_cards, dims_after
@@ -557,12 +618,15 @@ def inspect_config(input_path, cards_per_node=8, max_nodes=16):
         key: config.get(key)
         for key in (
             "sharding_parallel_size",
+            "data_parallel_size",
             "global_batch_size",
             "per_device_train_batch_size",
             "gradient_accumulation_steps",
         )
     }
-    orig_cards, _err = ConfigAdapter._infer_orig_cards(scale_source, dims)
+    orig_cards, _warning, _err = ConfigAdapter._infer_orig_cards(
+        scale_source, dims
+    )
     orig_nodes = (
         orig_cards // cards_per_node
         if orig_cards and orig_cards % cards_per_node == 0

--- a/src/paddlefleet/config_adapter/core.py
+++ b/src/paddlefleet/config_adapter/core.py
@@ -116,7 +116,10 @@ class ConfigAdapter:
         controlled = ADAPTER_CONTROLLED_FIELDS
         if self.in_place:
             controlled = controlled - {"model_name_or_path"}
-        pinned = sorted(controlled & set(self.yaml_overrides))
+        # Prefix-less --set values are routed to the YAML later, so they have
+        # to be checked here as well.
+        requested = set(self.yaml_overrides) | set(self.auto_overrides)
+        pinned = sorted(controlled & requested)
         if pinned:
             return False, (
                 f"以下字段由适配器统一计算，不能用 --set 锁定：{pinned}。"
@@ -411,15 +414,19 @@ class ConfigAdapter:
           would otherwise be under-counted;
         * batch settings: ``GBS / (micro_bs * acc) * TP * PP * CP``.
 
-        The comm-group estimate wins when both exist, but a mismatch is
-        surfaced as a warning: it means the source YAML is not self-consistent
-        and every derived batch value inherits that ambiguity.
+        When both exist and disagree, the estimate that is not missing a
+        factor wins: the comm-group one only if ``data_parallel_size`` is
+        declared, otherwise the batch one (an undeclared DP is exactly the
+        factor the comm-group formula would be missing).  Either way the
+        mismatch is reported as a warning, because it means the source YAML is
+        not self-consistent.
         """
         tp, pp, ep, cp, sep = dims_before
 
         sharding = scale_source["sharding_parallel_size"]
-        dp = scale_source["data_parallel_size"]
-        dp = int(dp) if dp and int(dp) > 0 else 1
+        raw_dp = scale_source["data_parallel_size"]
+        dp_declared = raw_dp is not None and int(raw_dp) > 0
+        dp = int(raw_dp) if dp_declared else 1
         group_based = None
         if sharding is not None and int(sharding) > 0:
             group_based = dp * int(sharding) * tp * sep * pp
@@ -433,19 +440,25 @@ class ConfigAdapter:
             if dataset_world_size > 0:
                 batch_based = dataset_world_size * tp * pp * cp
 
-        warning = None
         if group_based is not None and batch_based is not None:
-            if group_based != batch_based:
-                warning = (
-                    f"源卡数的两种推断不一致：按通信组"
-                    f"（DP={dp}×sharding={sharding}×TP={tp}×SEP={sep}×"
-                    f"PP={pp}）为 {group_based}，按 batch 字段"
-                    f"（GBS/(micro×acc)×TP×PP×CP）为 {batch_based}；"
-                    f"取通信组的 {group_based}。"
-                    f"如果不对，请修正源 YAML 的 data_parallel_size 或 "
-                    f"batch 字段后重新适配"
+            if group_based == batch_based:
+                return group_based, None, None
+            chosen = group_based if dp_declared else batch_based
+            warning = (
+                f"源卡数的两种推断不一致：按通信组"
+                f"（DP={dp}×sharding={sharding}×TP={tp}×SEP={sep}×PP={pp}）"
+                f"为 {group_based}，按 batch 字段"
+                f"（GBS/(micro×acc)×TP×PP×CP）为 {batch_based}；"
+                + (
+                    f"源 YAML 未声明 data_parallel_size，"
+                    f"通信组公式会漏掉这个因子，因此取 batch 字段的 {chosen}。"
+                    if not dp_declared
+                    else f"取通信组的 {chosen}。"
                 )
-            return group_based, warning, None
+                + "如果不对，请在源 YAML 里写明 data_parallel_size "
+                "或修正 batch 字段后重新适配"
+            )
+            return chosen, warning, None
         if group_based is not None:
             return group_based, None, None
         if batch_based is not None:

--- a/src/paddlefleet/config_adapter/core.py
+++ b/src/paddlefleet/config_adapter/core.py
@@ -111,15 +111,14 @@ class ConfigAdapter:
 
         # Fields the adapter must own: pinning them with --set would make the
         # generated file disagree with the reported parallelism / sharding.
-        # In-place runs never rewrite model_name_or_path, so pinning that one
-        # is harmless there.
-        controlled = ADAPTER_CONTROLLED_FIELDS
-        if self.in_place:
-            controlled = controlled - {"model_name_or_path"}
+        # model_name_or_path is in the set even for --in-place runs, which do
+        # not rewrite it: repointing it mid-run would decide *which*
+        # model_config.json is loaded, shrunk and snapshotted for the patch,
+        # and the answer differs between the prefixed and prefix-less forms.
         # Prefix-less --set values are routed to the YAML later, so they have
         # to be checked here as well.
         requested = set(self.yaml_overrides) | set(self.auto_overrides)
-        pinned = sorted(controlled & requested)
+        pinned = sorted(ADAPTER_CONTROLLED_FIELDS & requested)
         if pinned:
             return False, (
                 f"以下字段由适配器统一计算，不能用 --set 锁定：{pinned}。"

--- a/src/paddlefleet/config_adapter/field_spec.py
+++ b/src/paddlefleet/config_adapter/field_spec.py
@@ -1,0 +1,125 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Alias registry for the ``model_config.json`` fields shrinking depends on.
+
+The same structural quantity is spelled differently per model family::
+
+    routed experts : n_routed_experts (ERNIE5 / DeepSeek / GLM / Kimi),
+                     num_local_experts (MiniMax / GPT-OSS),
+                     num_experts (Qwen), moe_num_experts (ERNIE4.5)
+    top-k          : num_experts_per_tok (most), moe_k (ERNIE4.5)
+    dense prefix   : first_k_dense_replace, moe_layer_start_index
+    MTP layers     : num_nextn_predict_layers, mtp_num_layers
+
+Centralising the aliases means supporting a new family is a one-line edit to
+:data:`FIELD_SPECS`.  The resolver also remembers which physical key matched,
+so a write-back never invents a second spelling of the same field.
+
+Pure module: no I/O, no mutation of inputs.
+"""
+
+from __future__ import annotations
+
+from collections import namedtuple
+
+# needed_by only phrases diagnostics; ``default is None`` marks the field as
+# required for that shrink axis.
+FieldSpec = namedtuple("FieldSpec", ["aliases", "default", "needed_by"])
+
+FIELD_SPECS = {
+    "num_hidden_layers": FieldSpec(
+        aliases=("num_hidden_layers",),
+        default=None,
+        needed_by="PP",
+    ),
+    "num_experts": FieldSpec(
+        aliases=(
+            "n_routed_experts",
+            "num_local_experts",
+            "num_experts",
+            "moe_num_experts",
+        ),
+        default=None,
+        needed_by="EP",
+    ),
+    "num_experts_per_tok": FieldSpec(
+        aliases=("num_experts_per_tok", "moe_k"),
+        default=None,
+        needed_by="EP",
+    ),
+    "first_k_dense_replace": FieldSpec(
+        aliases=("first_k_dense_replace", "moe_layer_start_index"),
+        default=0,
+        needed_by="PP",
+    ),
+    "num_nextn_predict_layers": FieldSpec(
+        aliases=("num_nextn_predict_layers", "mtp_num_layers"),
+        default=0,
+        needed_by="PP",
+    ),
+}
+
+ResolvedField = namedtuple(
+    "ResolvedField", ["logical", "value", "origin", "writeback_key"]
+)
+
+
+def _writeback_key(spec, model_config):
+    """First alias present in ``model_config``, else the canonical alias."""
+    for alias in spec.aliases:
+        if alias in model_config:
+            return alias
+    return spec.aliases[0]
+
+
+def resolve_fields(model_config):
+    """Resolve every registered field against ``model_config``.
+
+    Returns ``(resolved, missing)``: ``resolved`` maps a logical name to a
+    :class:`ResolvedField`, ``missing`` maps a logical name to its
+    :class:`FieldSpec` for required fields that could not be found.
+    """
+    resolved = {}
+    missing = {}
+
+    for logical, spec in FIELD_SPECS.items():
+        writeback_key = _writeback_key(spec, model_config)
+        hit = next(
+            (a for a in spec.aliases if model_config.get(a) is not None),
+            None,
+        )
+        if hit is not None:
+            resolved[logical] = ResolvedField(
+                logical, model_config[hit], hit, writeback_key
+            )
+        elif spec.default is not None:
+            resolved[logical] = ResolvedField(
+                logical, spec.default, "<default>", writeback_key
+            )
+        else:
+            missing[logical] = spec
+
+    return resolved, missing
+
+
+def describe_missing(logical, spec):
+    """One-line actionable explanation for an unresolved required field."""
+    tried = " / ".join(spec.aliases)
+    return (
+        f"{logical}（{spec.needed_by} 缩容所需）在 model_config.json 中读不到"
+        f"（已尝试字段名 {tried}）；"
+        f"请用 --set json:{spec.aliases[0]}=<值> 显式补上，"
+        f"或在 field_spec.py 的 FIELD_SPECS[{logical!r}] 里登记新别名"
+    )

--- a/src/paddlefleet/config_adapter/io_writers.py
+++ b/src/paddlefleet/config_adapter/io_writers.py
@@ -1,0 +1,132 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""YAML / JSON read-modify-write layer.
+
+All document mutation and serialization lives here so the rest of the package
+only decides *what* to set, never *how* it is written.  ``apply_config_map``
+semantics for both writers, given a flat ``{key: value}`` map:
+
+* key already present -> overwritten in place (ruamel keeps the original
+  position, comments and quote style);
+* key missing -> appended as a new field;
+* key listed in ``protected`` -> left untouched.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+from pathlib import Path
+
+from ruamel.yaml import YAML
+
+
+def make_yaml():
+    """Return a ruamel YAML that preserves quotes and never wraps lines."""
+    yaml = YAML()
+    yaml.preserve_quotes = True
+    yaml.width = 4096
+    return yaml
+
+
+def _apply(document, config_map, protected=None):
+    """Merge ``config_map`` into ``document`` in place, returning the diff."""
+    protected = set(protected or ())
+    changes = []
+    for key, value in config_map.items():
+        if key in protected:
+            continue
+        if key in document:
+            old = document[key]
+            if old != value:
+                changes.append(("modified", key, old, value))
+        else:
+            changes.append(("added", key, None, value))
+        document[key] = value
+    return changes
+
+
+def _write_atomically(output_path, text):
+    """Write ``text`` through a temp file + rename.
+
+    Never truncates the destination in place, so an interrupted run cannot
+    leave a half-written config behind.
+    """
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = output_path.with_name(output_path.name + ".config_adapter.tmp")
+    try:
+        tmp_path.write_text(text, encoding="utf-8")
+        os.replace(tmp_path, output_path)
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
+
+
+class YamlWriter:
+    """Loads a YAML document, applies a config map, serializes it back."""
+
+    def __init__(self, yaml=None):
+        self.yaml = yaml or make_yaml()
+
+    def load(self, path):
+        """Load the YAML document (``None`` for an empty file)."""
+        with open(path, encoding="utf-8") as f:
+            return self.yaml.load(f)
+
+    def apply_config_map(self, config, config_map, protected=None):
+        """Merge a flat map into ``config``; see the module docstring."""
+        return _apply(config, config_map, protected)
+
+    def write(self, config, output_path, header=""):
+        """Write ``config``, prepending an optional comment ``header``."""
+        buffer = io.StringIO()
+        if header:
+            buffer.write(header)
+        self.yaml.dump(config, buffer)
+        _write_atomically(output_path, buffer.getvalue())
+
+
+class JsonWriter:
+    """Loads a JSON document, applies a config map, serializes it back."""
+
+    def __init__(self, indent=2, ensure_ascii=False):
+        self.indent = indent
+        self.ensure_ascii = ensure_ascii
+
+    def load(self, path):
+        """Load the JSON document.
+
+        Raises ``ValueError`` when the file is empty or malformed.
+        """
+        text = Path(path).read_text(encoding="utf-8")
+        if not text.strip():
+            raise ValueError(f"JSON 文件为空：{path}")
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"JSON 解析失败 {path}: {exc}") from exc
+
+    def apply_config_map(self, config, config_map, protected=None):
+        """Merge a flat map into ``config``; see the module docstring."""
+        return _apply(config, config_map, protected)
+
+    def write(self, config, output_path):
+        """Write ``config`` with a trailing newline (POSIX friendly)."""
+        text = json.dumps(
+            config, indent=self.indent, ensure_ascii=self.ensure_ascii
+        )
+        _write_atomically(output_path, text + "\n")

--- a/src/paddlefleet/config_adapter/layer_fields.py
+++ b/src/paddlefleet/config_adapter/layer_fields.py
@@ -1,0 +1,142 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Per-layer list fields that must follow ``num_hidden_layers``.
+
+Shrinking PP shrinks ``num_hidden_layers``, and every per-layer list in
+``model_config.json`` has to shrink with it or the framework refuses to start::
+
+    csa_compress_ratios    len == num_hidden_layers + mtp layers
+    window_attn_skip_freq  len == num_hidden_layers + mtp layers (list form)
+    layer_types            len == num_hidden_layers
+    moe_layer_freq         len == num_hidden_layers (list form)
+
+The rewrite keeps the first ``layers_new`` entries -- so the dense prefix
+(``first_k_dense_replace``) and the leading attention pattern survive -- and
+re-appends the trailing MTP entries verbatim for the fields whose length counts
+them.
+
+Truncation is refused, rather than silently producing an unusable config, when
+
+* a source list length does not match the source ``num_hidden_layers`` (the
+  input config is already inconsistent, so there is nothing safe to derive), or
+* it would drop the last layer of an attention family that the source used
+  (``csa_compress_ratios`` only).  The framework has several "at least one
+  layer must be X" rules, and a truncation that erases a family turns a
+  successful adaptation into a startup failure.
+"""
+
+from __future__ import annotations
+
+from collections import namedtuple
+
+# includes_mtp: the expected length counts the trailing MTP layers.
+# families: entries encode an attention family whose presence must survive.
+LayerField = namedtuple("LayerField", ["aliases", "includes_mtp", "families"])
+
+LAYER_FIELDS = (
+    LayerField(("csa_compress_ratios",), includes_mtp=True, families=True),
+    LayerField(("window_attn_skip_freq",), includes_mtp=True, families=False),
+    LayerField(("layer_types",), includes_mtp=False, families=False),
+    LayerField(("moe_layer_freq",), includes_mtp=False, families=False),
+)
+
+
+def effective_mtp_layers(model_config):
+    """MTP layer count the framework actually uses.
+
+    ``TransformerConfig`` resolves it as ``mtp_num_layers or
+    num_nextn_predict_layers``, i.e. ``mtp_num_layers`` wins whenever it is
+    non-zero.  A plain "first alias that is not None" lookup would read
+    ``num_nextn_predict_layers: 0`` and miss a valid ``mtp_num_layers: 2``,
+    which then makes every per-layer list look inconsistent.
+    """
+    if model_config is None:
+        return 0
+    primary = int(model_config.get("mtp_num_layers") or 0)
+    fallback = int(model_config.get("num_nextn_predict_layers") or 0)
+    return primary or fallback
+
+
+def _csa_family(ratio):
+    """Attention family encoded by one ``csa_compress_ratios`` entry."""
+    value = int(ratio)
+    if value == -2:
+        return "MLA(-2)"
+    if value == -1:
+        return "full-causal MQA(-1)"
+    if value == 0:
+        return "window(0)"
+    if value == 128:
+        return "HCA(128)"
+    return "CSA(2..127)"
+
+
+def plan_layer_field_shrink(model_config, layers_old, layers_new, mtp_layers):
+    """Plan the per-layer list rewrites implied by a layer-count shrink.
+
+    Returns ``(changes, error)`` where ``changes`` is
+    ``[(key, value, reason), ...]`` ready to apply to ``model_config.json``.
+    A non-empty ``error`` means this layer count cannot be adapted safely and
+    the caller must reject the candidate.
+    """
+    changes = []
+    if model_config is None or layers_new >= layers_old:
+        return changes, None
+
+    for field in LAYER_FIELDS:
+        key = next((a for a in field.aliases if a in model_config), None)
+        if key is None:
+            continue
+        value = model_config[key]
+        # Scalar forms (e.g. an int window_attn_skip_freq) are layer-count
+        # independent and need no rewrite.
+        if not isinstance(value, list):
+            continue
+
+        tail = mtp_layers if field.includes_mtp else 0
+        expected_old = layers_old + tail
+        if len(value) != expected_old:
+            return [], (
+                f"{key} 长度为 {len(value)}，与源 num_hidden_layers"
+                f"{'+MTP' if tail else ''}={expected_old} 不一致，"
+                f"源 model_config.json 本身不自洽，无法安全裁剪逐层配置"
+            )
+
+        layer_part, mtp_part = value[:layers_old], value[layers_old:]
+        kept = layer_part[:layers_new]
+
+        if field.families:
+            lost = {_csa_family(r) for r in layer_part} - {
+                _csa_family(r) for r in kept
+            }
+            if lost:
+                return [], (
+                    f"把层数缩到 {layers_new} 会让 {key} 丢掉注意力类型 "
+                    f"{sorted(lost)}（框架要求这些类型至少各有一层），"
+                    f"该缩容方案不安全"
+                )
+
+        changes.append(
+            (
+                key,
+                kept + mtp_part,
+                f"逐层配置随层数 {layers_old} -> {layers_new} 裁剪："
+                f"保留前 {layers_new} 层"
+                + (f" + 末尾 {len(mtp_part)} 个 MTP 层" if mtp_part else "")
+                + f"，长度 {len(value)} -> {len(kept + mtp_part)}",
+            )
+        )
+
+    return changes, None

--- a/src/paddlefleet/config_adapter/model_config_resolver.py
+++ b/src/paddlefleet/config_adapter/model_config_resolver.py
@@ -1,0 +1,114 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Locate the ``model_config.json`` that belongs to a training YAML.
+
+The path is always inferred from the YAML's own ``model_name_or_path`` -- the
+same value the training entry point consumes -- so there is no separate CLI
+flag to keep in sync:
+
+1. an absolute value is used verbatim;
+2. a relative value is tried against the YAML's directory first (co-located
+   layout), then against the current working directory (Fleet resolves
+   ``model_name_or_path`` against the launch CWD);
+3. the first existing directory must contain ``model_config.json``, otherwise
+   we fail fast listing every path tried.
+
+Registry lookups (HuggingFace hub, model zoo) are deliberately not attempted:
+adaptation only supports local file-based configs.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+class ModelConfigResolveError(RuntimeError):
+    """Raised when the source ``model_config.json`` cannot be located."""
+
+
+def resolve_model_config(model_name_or_path, yaml_dir):
+    """Return ``(model_dir, model_config_json_path)``.
+
+    Raises :class:`ModelConfigResolveError` when the value is empty or nothing
+    on disk matches it.
+    """
+    if not model_name_or_path:
+        raise ModelConfigResolveError(
+            "YAML 里没有 model_name_or_path，无法定位 model_config.json；"
+            "精度模式需要它来缩减模型结构"
+        )
+
+    yaml_dir = Path(yaml_dir)
+    raw = Path(str(model_name_or_path)).expanduser()
+
+    if raw.is_absolute():
+        candidates = [raw]
+    else:
+        candidates = list(dict.fromkeys([yaml_dir / raw, Path.cwd() / raw]))
+
+    tried = []
+    model_dir = None
+    for candidate in candidates:
+        resolved = candidate.resolve(strict=False)
+        tried.append(resolved)
+        if resolved.is_dir():
+            model_dir = resolved
+            break
+
+    if model_dir is None:
+        tried_str = ", ".join(str(p) for p in tried)
+        raise ModelConfigResolveError(
+            f"模型目录不存在：已尝试 [{tried_str}]"
+            f"（来自 model_name_or_path={model_name_or_path!r}，"
+            f"yaml_dir={yaml_dir}，cwd={Path.cwd()}）"
+        )
+
+    json_path = model_dir / "model_config.json"
+    if not json_path.is_file():
+        raise ModelConfigResolveError(f"{model_dir} 下缺少 model_config.json")
+
+    return model_dir, json_path
+
+
+def build_adapted_dir(output_dir, source_stem, scale_tag):
+    """Directory that receives the shrunk ``model_config.json``.
+
+    Layout: ``<output_dir>/model_config_separated/<stem>_adapted_<tag>/``.
+    The directory is not created here; the caller decides that.
+    """
+    return (
+        Path(output_dir)
+        / "model_config_separated"
+        / f"{source_stem}_adapted_{scale_tag}"
+    )
+
+
+def rewrite_model_name_or_path(new_dir, yaml_dir, source_was_absolute):
+    """Value to write back into ``model_name_or_path``.
+
+    A relative source value stays relative only when the generated directory
+    actually sits under the YAML's directory.  Otherwise an absolute path is
+    written: a relative value would be resolved against the *launch CWD* by
+    the training entry point, which need not be the YAML's directory, and a
+    ``../../..`` chain out of the repo is both fragile and unreadable.
+    """
+    new_dir = Path(new_dir).resolve()
+    if source_was_absolute:
+        return str(new_dir)
+    relative = os.path.relpath(str(new_dir), str(Path(yaml_dir).resolve()))
+    if relative.startswith(".."):
+        return str(new_dir)
+    return relative

--- a/src/paddlefleet/config_adapter/options.py
+++ b/src/paddlefleet/config_adapter/options.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""What the caller asked for: two orthogonal, optional test dimensions.
+
+``--test-performance`` and ``--test-accuracy`` are independent switches, not
+alternatives, and neither is required::
+
+    (none)                              缩到目标规模即可：允许缩小 EP/PP
+    --test-performance                  冻结 TP/PP/EP/CP/SEP 与 acc
+    --test-accuracy                     注入避免 aadiff 的开关，保持等效 batch
+    --test-performance --test-accuracy  冻结并行策略 + 注入精度开关
+
+Each switch owns one concern:
+
+* ``--test-performance`` freezes the parallelism and
+  ``gradient_accumulation_steps`` so a step time stays comparable with the
+  full-scale job -- only ``sharding`` and ``global_batch_size`` move.
+* ``--test-accuracy`` pins the determinism switches in
+  :mod:`paddlefleet.config_adapter.precision`, and (unless the performance
+  switch already froze ``acc``) keeps the effective batch by raising ``acc``.
+"""
+
+from __future__ import annotations
+
+
+class AdaptOptions:
+    """Derived behaviour of the two test switches."""
+
+    def __init__(self, test_performance=False, test_accuracy=False):
+        self.test_performance = bool(test_performance)
+        self.test_accuracy = bool(test_accuracy)
+
+    @property
+    def freeze_parallel(self):
+        """True when no parallel dimension (nor ``acc``) may be rewritten."""
+        return self.test_performance
+
+    @property
+    def inject_precision(self):
+        """True when the determinism switches must be pinned."""
+        return self.test_accuracy
+
+    @property
+    def batch_strategy(self):
+        """Batch strategy name from ``strategies.BATCH_STRATEGIES``.
+
+        The performance switch wins: it freezes ``acc``, so the only way to
+        follow the card count is to scale ``global_batch_size``.
+        """
+        if self.test_accuracy and not self.test_performance:
+            return "scale_accumulation"
+        return "scale_batch"
+
+    @property
+    def needs_model_config(self):
+        """True when planning may have to read ``model_config.json``."""
+        return not self.freeze_parallel or self.inject_precision
+
+    @property
+    def label(self):
+        """Short name used in the report and the generated file header."""
+        if self.test_performance and self.test_accuracy:
+            return "performance+accuracy"
+        if self.test_performance:
+            return "performance"
+        if self.test_accuracy:
+            return "accuracy"
+        return "default"
+
+    @property
+    def flags(self):
+        """The switches as typed on the command line."""
+        given = []
+        if self.test_performance:
+            given.append("--test-performance")
+        if self.test_accuracy:
+            given.append("--test-accuracy")
+        return " ".join(given) if given else "未指定测试维度"

--- a/src/paddlefleet/config_adapter/plan.py
+++ b/src/paddlefleet/config_adapter/plan.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The planning result shared by both planners."""
+
+from __future__ import annotations
+
+
+class ParallelismPlan:
+    """Outcome of parallelism planning.
+
+    Attributes:
+        tp, pp, ep, cp, sep: the FINAL parallel dims used downstream by
+            validation, sharding computation and reporting.
+        yaml_changes: ``[(key, value, reason), ...]`` writes for the YAML.
+        json_changes: ``[(key, value, reason), ...]`` writes for the
+            companion ``model_config.json``.
+        warnings: user-facing warnings raised while planning.
+        note: one-line description of what the plan did, for the report.
+    """
+
+    def __init__(
+        self,
+        tp,
+        pp,
+        ep,
+        cp,
+        sep,
+        yaml_changes=None,
+        json_changes=None,
+        warnings=None,
+        note="",
+    ):
+        self.tp = tp
+        self.pp = pp
+        self.ep = ep
+        self.cp = cp
+        self.sep = sep
+        self.yaml_changes = list(yaml_changes or [])
+        self.json_changes = list(json_changes or [])
+        self.warnings = list(warnings or [])
+        self.note = note
+
+    def dims(self):
+        """Return ``(tp, pp, ep, cp, sep)``."""
+        return self.tp, self.pp, self.ep, self.cp, self.sep

--- a/src/paddlefleet/config_adapter/planner.py
+++ b/src/paddlefleet/config_adapter/planner.py
@@ -1,0 +1,597 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Parallelism planning: keep the dims frozen, or shrink EP / PP to fit.
+
+:func:`plan_parallelism` picks one of two planners from the options:
+
+* frozen (``--test-performance``) -- every parallel dimension stays as the
+  source declares it; an incompatible target scale is rejected with the list
+  of legal node counts rather than forced through.
+* shrink (default) -- candidates are tried in order of increasing structural
+  intrusion and the first feasible one wins::
+
+      Case A (dims already legal) < EP-only < PP-only < EP+PP joint
+
+  Every candidate must pass the communication-group constraints (C1..C4) and
+  the model-structure constraints (M1/M2 for EP, M3/M4/M5 for PP).  Shrinking
+  EP scales the routed-expert count, shrinking PP scales
+  ``num_hidden_layers`` and realigns VPP / empty tail layers -- those writes
+  land in a *separate* copy of ``model_config.json``, never in the source.
+
+TP and SEP are never shrunk: a smaller TP raises per-card memory and risks
+OOM.  No dimension that is > 1 in the source is ever reduced to 1, because
+that would delete the communication group under test.
+"""
+
+from __future__ import annotations
+
+import re
+
+from .constraints import (
+    MIN_PARALLEL_DEGREE,
+    check_ep_shrink,
+    check_hardware,
+    check_pp_shrink,
+    ep_candidates,
+    min_shrink_cards,
+    pp_candidates,
+)
+from .field_spec import describe_missing, resolve_fields
+from .layer_fields import effective_mtp_layers, plan_layer_field_shrink
+from .plan import ParallelismPlan
+from .topology import TopologyValidator
+
+# Matches a communication-group rejection ("C2 不满足：..."), so the diagnostic
+# can put the more actionable model-structure reasons first.
+_CONSTRAINT_RE = re.compile(r"C[1-4]\s*不满足")
+
+
+def plan_parallelism(
+    config, dims, target_cards, cards_per_node, options, context=None
+):
+    """Plan the final parallel dims. Returns ``(plan, error_or_None)``."""
+    if options.freeze_parallel:
+        return plan_frozen(dims, target_cards, cards_per_node)
+    return ShrinkPlanner().plan(
+        config, dims, target_cards, cards_per_node, context
+    )
+
+
+def plan_frozen(dims, target_cards, cards_per_node):
+    """Keep every parallel dim; fail when the target scale needs changes."""
+    tp, pp, ep, cp, sep = dims
+    validator = TopologyValidator(target_cards, cards_per_node)
+    ok, message, _details = validator.validate(tp, pp, ep, cp, sep)
+    if not ok:
+        return None, (
+            f"{message}\n"
+            f"  说明：--test-performance 只调整 sharding 与 "
+            f"global_batch_size，不修改 TP/PP/EP/CP/SEP 和 acc，"
+            f"因此目标机器规模必须与源并行度兼容。\n"
+            f"  建议：换用上面列出的合法节点数，"
+            f"或去掉 --test-performance（默认允许缩小 EP/PP）"
+        )
+    return (
+        ParallelismPlan(
+            tp,
+            pp,
+            ep,
+            cp,
+            sep,
+            note="并行度全部保持不变（--test-performance 冻结 "
+            "TP/PP/EP/CP/SEP 与 acc）",
+        ),
+        None,
+    )
+
+
+class ShrinkPlanner:
+    """Shrinks EP / PP just enough to fit the target scale."""
+
+    def plan(self, config, dims, target_cards, cards_per_node, context=None):
+        """Plan the final dims, shrinking EP / PP only as much as needed."""
+        tp, pp, ep, cp, sep = dims
+        context = context or {}
+
+        ok, why = check_hardware(
+            target_cards, cards_per_node, tp, pp, ep, cp, sep
+        )
+        if not ok:
+            return None, why
+
+        validator = TopologyValidator(target_cards, cards_per_node)
+
+        # ---- Case A: the source dims already fit the target scale --------
+        ok, _msg, _details = validator.validate(tp, pp, ep, cp, sep)
+        if ok:
+            return (
+                ParallelismPlan(
+                    tp,
+                    pp,
+                    ep,
+                    cp,
+                    sep,
+                    note="源并行度已满足目标机器规模的通信组约束，未做缩容",
+                ),
+                None,
+            )
+
+        # ---- Everything below needs the model structure ------------------
+        model_config = context.get("model_config")
+        if model_config is None:
+            return None, (
+                f"需要缩小 EP/PP 才能适配 {target_cards} 卡，"
+                f"但读不到 model_config.json："
+                f"{context.get('model_config_error') or '未提供'}"
+            )
+
+        resolved, missing = resolve_fields(model_config)
+
+        def value_of(name):
+            field = resolved.get(name)
+            return field.value if field is not None else None
+
+        num_experts = value_of("num_experts")
+        topk = value_of("num_experts_per_tok")
+        experts_key = (
+            resolved["num_experts"].writeback_key
+            if "num_experts" in resolved
+            else "n_routed_experts"
+        )
+        # MoE detection is structural: EP > 1 means expert parallelism is on,
+        # regardless of any use_moe flag (MiniMax only sets EP + the flag).
+        can_shrink_ep = (
+            ep > MIN_PARALLEL_DEGREE
+            and num_experts is not None
+            and topk is not None
+        )
+
+        # ---- Tier 1: EP only ---------------------------------------------
+        rejections = []
+        if can_shrink_ep:
+            pool = []
+            for ep_new in ep_candidates(ep, tp):
+                ok, why, experts_new = check_ep_shrink(
+                    ep, ep_new, num_experts, topk
+                )
+                if not ok:
+                    rejections.append(f"EP {ep} -> {ep_new}：{why}")
+                    continue
+                ok, why, _d = validator.validate(tp, pp, ep_new, cp, sep)
+                if not ok:
+                    rejections.append(
+                        f"EP {ep} -> {ep_new}：{_first_constraint(why)}"
+                    )
+                    continue
+                pool.append((ep_new, experts_new))
+
+            if pool:
+                # Largest surviving EP = least intrusive within the tier.
+                ep_new, experts_new = max(pool, key=lambda item: item[0])
+                return (
+                    ParallelismPlan(
+                        tp,
+                        pp,
+                        ep_new,
+                        cp,
+                        sep,
+                        yaml_changes=[
+                            (
+                                "expert_model_parallel_size",
+                                ep_new,
+                                f"缩小 EP {ep} -> {ep_new} 以满足 "
+                                f"{target_cards} 卡下的 C2/C3 约束"
+                                f"（PP/TP/CP/SEP 不变）",
+                            )
+                        ],
+                        json_changes=[
+                            (
+                                experts_key,
+                                experts_new,
+                                f"随 EP {ep} -> {ep_new} 等比缩减专家数 "
+                                f"{num_experts} -> {experts_new}"
+                                f"（保证每个 EP rank 专家数相等且 >= top-k"
+                                f"={topk}）",
+                            )
+                        ],
+                        note=f"仅缩 EP：{ep} -> {ep_new}",
+                    ),
+                    None,
+                )
+
+        # ---- Tier 2 / Tier 3 need the pipeline layout --------------------
+        layout, err = self._pipeline_layout(
+            config, resolved, missing, model_config
+        )
+        if pp > MIN_PARALLEL_DEGREE and err:
+            return None, err
+
+        if pp > MIN_PARALLEL_DEGREE and layout is not None:
+            plan = self._plan_pp_only(
+                validator, dims, layout, target_cards, rejections, model_config
+            )
+            if plan is not None:
+                return plan, None
+
+            if can_shrink_ep:
+                plan = self._plan_joint(
+                    validator,
+                    dims,
+                    layout,
+                    (num_experts, topk, experts_key),
+                    target_cards,
+                    rejections,
+                    model_config,
+                )
+                if plan is not None:
+                    return plan, None
+
+        return None, self._diagnose(
+            dims,
+            target_cards,
+            cards_per_node,
+            missing,
+            can_shrink_ep,
+            layout,
+            rejections,
+        )
+
+    # -------------------------------------------------------------- helpers
+    @staticmethod
+    def _pipeline_layout(config, resolved, missing, model_config):
+        """Collect everything PP shrinking needs. ``(layout, error)``."""
+        if "num_hidden_layers" in missing:
+            return None, "精度模式：" + describe_missing(
+                "num_hidden_layers", missing["num_hidden_layers"]
+            )
+
+        def value_of(name):
+            field = resolved.get(name)
+            return field.value if field is not None else None
+
+        # Follow the framework's effective-MTP rule rather than a single
+        # alias: mtp_num_layers wins when non-zero.
+        mtp = effective_mtp_layers(model_config)
+
+        # MTP layers only take part in the stage division when
+        # separate_mtp_headloss is on; otherwise they are weight-0 free
+        # passengers pinned to the last stage.
+        head = int(config.get("num_empty_layers_add_in_head", 0) or 0)
+        if config.get("separate_mtp_headloss"):
+            head += mtp
+
+        return {
+            "layers": value_of("num_hidden_layers"),
+            "layers_key": resolved["num_hidden_layers"].writeback_key,
+            "head": head,
+            "tail": int(config.get("num_empty_layers_add_in_tail", 0) or 0),
+            "vpp": int(
+                config.get("virtual_pipeline_model_parallel_size", 1) or 1
+            ),
+            "first_k": int(value_of("first_k_dense_replace") or 0),
+            "mtp": mtp,
+        }, None
+
+    @staticmethod
+    def _pp_changes(
+        pp, pp_new, layout, meta, target_cards, layer_changes, note_extra=""
+    ):
+        """YAML + JSON writes implied by a PP shrink."""
+        yaml_changes = [
+            (
+                "pipeline_model_parallel_size",
+                pp_new,
+                f"缩小 PP {pp} -> {pp_new} 以满足 {target_cards} 卡下的 "
+                f"C1/C2 约束{note_extra}",
+            )
+        ]
+        if meta["vpp_new"] != layout["vpp"]:
+            yaml_changes.append(
+                (
+                    "virtual_pipeline_model_parallel_size",
+                    meta["vpp_new"],
+                    f"PP 缩容后重新对齐 VPP "
+                    f"{layout['vpp']} -> {meta['vpp_new']}",
+                )
+            )
+        if meta["tail_new"] != layout["tail"]:
+            yaml_changes.append(
+                (
+                    "num_empty_layers_add_in_tail",
+                    meta["tail_new"],
+                    f"补空层把总层数对齐到 PP×VPP："
+                    f"{layout['tail']} -> {meta['tail_new']}",
+                )
+            )
+        json_changes = [
+            (
+                layout["layers_key"],
+                meta["layers_new"],
+                f"随 PP {pp} -> {pp_new} 等比缩减层数 "
+                f"{layout['layers']} -> {meta['layers_new']}",
+            )
+        ]
+        # Every per-layer list must follow num_hidden_layers or the framework
+        # refuses to start.
+        json_changes.extend(layer_changes)
+        return yaml_changes, json_changes
+
+    @staticmethod
+    def _layer_field_changes(model_config, layout, meta, rejections, label):
+        """Per-layer list rewrites for a candidate. ``(changes, ok)``."""
+        changes, err = plan_layer_field_shrink(
+            model_config,
+            layout["layers"],
+            meta["layers_new"],
+            layout["mtp"],
+        )
+        if err:
+            rejections.append(f"{label}：{err}")
+            return [], False
+        return changes, True
+
+    def _plan_pp_only(
+        self, validator, dims, layout, target_cards, rejections, model_config
+    ):
+        """Tier 2: shrink PP only. Returns a plan or ``None``."""
+        tp, pp, ep, cp, sep = dims
+        pool = []
+        for pp_new in pp_candidates(pp):
+            ok, why, meta = check_pp_shrink(
+                pp,
+                pp_new,
+                layout["layers"],
+                layout["head"],
+                layout["tail"],
+                layout["vpp"],
+                first_k_dense_replace=layout["first_k"],
+            )
+            if not ok:
+                rejections.append(f"PP {pp} -> {pp_new}：{why}")
+                continue
+            ok, why, _d = validator.validate(tp, pp_new, ep, cp, sep)
+            if not ok:
+                rejections.append(
+                    f"PP {pp} -> {pp_new}：{_first_constraint(why)}"
+                )
+                continue
+            layer_changes, ok = self._layer_field_changes(
+                model_config, layout, meta, rejections, f"PP {pp} -> {pp_new}"
+            )
+            if not ok:
+                continue
+            pool.append((pp_new, meta, layer_changes))
+
+        if not pool:
+            return None
+
+        pp_new, meta, layer_changes = max(pool, key=lambda item: item[0])
+        yaml_changes, json_changes = self._pp_changes(
+            pp,
+            pp_new,
+            layout,
+            meta,
+            target_cards,
+            layer_changes,
+            "（EP/TP/CP/SEP 不变）",
+        )
+        return ParallelismPlan(
+            tp,
+            pp_new,
+            ep,
+            cp,
+            sep,
+            yaml_changes=yaml_changes,
+            json_changes=json_changes,
+            warnings=[meta["warning"]] if meta.get("warning") else [],
+            note=f"仅缩 PP：{pp} -> {pp_new}",
+        )
+
+    def _plan_joint(
+        self,
+        validator,
+        dims,
+        layout,
+        moe,
+        target_cards,
+        rejections,
+        model_config,
+    ):
+        """Tier 3: shrink EP and PP together. Returns a plan or ``None``.
+
+        Reached only when neither single-axis shrink survives -- e.g. a source
+        ``(pp=8, ep=8)`` targeting 8 cards, where any one-dimension shrink
+        still overshoots the card count.
+        """
+        tp, pp, ep, cp, sep = dims
+        num_experts, topk, experts_key = moe
+
+        pool = []
+        for ep_new in ep_candidates(ep, tp):
+            ok, why, experts_new = check_ep_shrink(
+                ep, ep_new, num_experts, topk
+            )
+            if not ok:
+                continue
+            for pp_new in pp_candidates(pp):
+                ok, why, meta = check_pp_shrink(
+                    pp,
+                    pp_new,
+                    layout["layers"],
+                    layout["head"],
+                    layout["tail"],
+                    layout["vpp"],
+                    first_k_dense_replace=layout["first_k"],
+                )
+                if not ok:
+                    continue
+                ok, why, _d = validator.validate(tp, pp_new, ep_new, cp, sep)
+                if not ok:
+                    rejections.append(
+                        f"EP {ep} -> {ep_new} + PP {pp} -> {pp_new}："
+                        f"{_first_constraint(why)}"
+                    )
+                    continue
+                layer_changes, ok = self._layer_field_changes(
+                    model_config,
+                    layout,
+                    meta,
+                    rejections,
+                    f"PP {pp} -> {pp_new}",
+                )
+                if not ok:
+                    continue
+                pool.append((ep_new, pp_new, experts_new, meta, layer_changes))
+
+        if not pool:
+            return None
+
+        # Prefer the largest EP first, then the largest PP: one unit of EP
+        # change is less intrusive on the model structure than one of PP.
+        ep_new, pp_new, experts_new, meta, layer_changes = max(
+            pool, key=lambda item: (item[0], item[1])
+        )
+        yaml_changes, json_changes = self._pp_changes(
+            pp,
+            pp_new,
+            layout,
+            meta,
+            target_cards,
+            layer_changes,
+            "（与 EP 联合缩容）",
+        )
+        yaml_changes.insert(
+            0,
+            (
+                "expert_model_parallel_size",
+                ep_new,
+                f"缩小 EP {ep} -> {ep_new}：单独缩 EP 或单独缩 PP 都无法"
+                f"适配 {target_cards} 卡，改为联合缩容",
+            ),
+        )
+        json_changes.insert(
+            0,
+            (
+                experts_key,
+                experts_new,
+                f"随 EP {ep} -> {ep_new} 等比缩减专家数 "
+                f"{num_experts} -> {experts_new}（>= top-k={topk}）",
+            ),
+        )
+        return ParallelismPlan(
+            tp,
+            pp_new,
+            ep_new,
+            cp,
+            sep,
+            yaml_changes=yaml_changes,
+            json_changes=json_changes,
+            warnings=[meta["warning"]] if meta.get("warning") else [],
+            note=f"EP+PP 联合缩容：EP {ep} -> {ep_new}，PP {pp} -> {pp_new}",
+        )
+
+    @staticmethod
+    def _diagnose(
+        dims,
+        target_cards,
+        cards_per_node,
+        missing,
+        can_shrink_ep,
+        layout,
+        rejections,
+    ):
+        """Explain why no candidate survived, with an actionable suggestion."""
+        tp, pp, ep, cp, sep = dims
+        reasons = []
+
+        if ep > 1 and not can_shrink_ep:
+            if ep == MIN_PARALLEL_DEGREE:
+                reasons.append(
+                    f"EP={ep} 已是允许的最小值"
+                    f"（不允许把 EP 从 >1 缩到 1，否则等于去掉专家并行）"
+                )
+            for name in ("num_experts", "num_experts_per_tok"):
+                if name in missing:
+                    reasons.append(describe_missing(name, missing[name]))
+
+        if pp > 1 and pp == MIN_PARALLEL_DEGREE:
+            reasons.append(
+                f"PP={pp} 已是允许的最小值"
+                f"（不允许把 PP 从 >1 缩到 1，否则等于去掉流水并行）"
+            )
+        elif pp > MIN_PARALLEL_DEGREE and layout is not None:
+            floor_layers = layout["layers"] * MIN_PARALLEL_DEGREE // pp
+            reasons.append(
+                f"PP 最多缩到 {MIN_PARALLEL_DEGREE}，此时层数为 "
+                f"{floor_layers}（={layout['layers']}×"
+                f"{MIN_PARALLEL_DEGREE}/{pp}），仍不满足约束"
+            )
+
+        floor = tp * sep * MIN_PARALLEL_DEGREE if pp > 1 else tp * sep
+        if target_cards % (tp * sep) != 0:
+            reasons.append(
+                f"C1 约束：target_cards={target_cards} 不能被 TP×SEP="
+                f"{tp}×{sep}={tp * sep} 整除"
+            )
+        elif target_cards < floor:
+            reasons.append(
+                f"目标卡数 {target_cards} 小于并行度下限 {floor}"
+                f"（TP×SEP×PP_min）"
+            )
+
+        if not reasons:
+            reasons.append("所有候选组合都不满足通信组约束或模型结构约束")
+
+        # De-duplicated, truncated candidate rejections: the concrete reason a
+        # given (EP, PP) pair was thrown away is usually the fastest way to
+        # see what to change.  Model-structure reasons come first -- they are
+        # actionable, while the C-constraint ones repeat the same arithmetic.
+        unique = list(dict.fromkeys(rejections))
+        topological = [r for r in unique if _CONSTRAINT_RE.search(r)]
+        structural = [r for r in unique if r not in topological]
+        detail = (structural + topological)[:6]
+        detail_block = ""
+        if detail:
+            detail_block = "\n  候选淘汰明细：\n    " + "\n    ".join(detail)
+
+        min_cards = min_shrink_cards(tp, pp, ep, cp, sep, cards_per_node)
+        min_nodes = max(min_cards // cards_per_node, 1)
+        if min_cards > target_cards:
+            advice = (
+                f"改用 --target-nodes {min_nodes}"
+                f"（{min_cards} 卡，缩容下限），"
+                f"或手动降低源 YAML 的 TP/PP 后重试"
+            )
+        else:
+            advice = (
+                f"{target_cards} 卡已达到该配置的缩容下限，"
+                f"请调整模型结构（如 --set json:<专家数字段>=<能被目标 EP "
+                f"整除的值>），或手动降低源 YAML 的 TP/PP/EP 后重试"
+            )
+        return (
+            f"精度模式：{target_cards} 卡下找不到合法的 EP/PP 缩容方案 "
+            f"(tp={tp}, pp={pp}, ep={ep}, cp={cp}, sep={sep})。\n"
+            f"  阻断原因：\n    " + "\n    ".join(reasons) + detail_block + "\n"
+            "  建议：" + advice
+        )
+
+
+def _first_constraint(message):
+    """Pull the first ``Cx`` line out of a validator message."""
+    for line in message.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("C") and "不满足" in stripped:
+            return stripped
+    return message.splitlines()[0].strip()

--- a/src/paddlefleet/config_adapter/planner.py
+++ b/src/paddlefleet/config_adapter/planner.py
@@ -162,7 +162,7 @@ class ShrinkPlanner:
         rejections = []
         if can_shrink_ep:
             pool = []
-            for ep_new in ep_candidates(ep, tp):
+            for ep_new in ep_candidates(ep, tp, sep):
                 ok, why, experts_new = check_ep_shrink(
                     ep, ep_new, num_experts, topk
                 )
@@ -419,7 +419,7 @@ class ShrinkPlanner:
         num_experts, topk, experts_key = moe
 
         pool = []
-        for ep_new in ep_candidates(ep, tp):
+        for ep_new in ep_candidates(ep, tp, sep):
             ok, why, experts_new = check_ep_shrink(
                 ep, ep_new, num_experts, topk
             )

--- a/src/paddlefleet/config_adapter/precision.py
+++ b/src/paddlefleet/config_adapter/precision.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Determinism switches injected by ``--test-accuracy``.
+
+Some kernels and features are numerically fine for throughput runs but make an
+accuracy comparison unreproducible (aadiff): the same config replayed on the
+same data yields slightly different losses.  Accuracy adaptation therefore
+pins them to their deterministic variant.
+
+Adding a switch = one more row in :data:`PRECISION_SWITCHES`.  Each row says
+which document owns the key by default; when the key already exists in the
+YAML *and* in ``model_config.json`` both copies are pinned, because either one
+can feed the framework's transformer config.
+"""
+
+from __future__ import annotations
+
+from collections import namedtuple
+
+PrecisionSwitch = namedtuple(
+    "PrecisionSwitch", ["target", "key", "value", "reason"]
+)
+
+PRECISION_SWITCHES = (
+    PrecisionSwitch(
+        target="yaml",
+        key="csa_sparse_attn_backend",
+        value="tilelang",
+        reason=(
+            "精度对齐：HCA/CSA 稀疏注意力的 cudnn 后端"
+            "（FlashMLA 前向 + cuDNN 反向）与 tilelang 结果不一致，"
+            "精度测试统一走 tilelang"
+        ),
+    ),
+    PrecisionSwitch(
+        target="yaml",
+        key="csa_indexer_backend",
+        value="tilelang",
+        reason=(
+            "精度对齐：indexer 的 cudnn top-k 与 tilelang 存在差异，"
+            "与 sparse attention 后端取齐为 tilelang"
+        ),
+    ),
+    PrecisionSwitch(
+        target="json",
+        key="multimax_modules",
+        value=None,
+        reason=(
+            "精度对齐：multimax 的可学习 range/ts 会引入非确定性，"
+            "精度测试关闭（null 等价于不启用）"
+        ),
+    ),
+)
+
+
+def plan_precision_switches(yaml_config, model_config=None):
+    """Decide where each determinism switch must be written.
+
+    Returns ``(applied, skipped)``:
+
+    * ``applied`` -- list of ``(target, key, value, reason)`` where ``target``
+      is ``"yaml"`` or ``"json"``;
+    * ``skipped`` -- human-readable notes for switches that had nowhere to go
+      (e.g. a ``json`` switch while no ``model_config.json`` is being written).
+    """
+    applied = []
+    skipped = []
+
+    for switch in PRECISION_SWITCHES:
+        targets = []
+        if yaml_config is not None and switch.key in yaml_config:
+            targets.append("yaml")
+        if model_config is not None and switch.key in model_config:
+            targets.append("json")
+
+        if not targets:
+            if switch.target == "json" and model_config is None:
+                skipped.append(
+                    f"{switch.key}：yaml 与 model_config.json 均未声明该字段，"
+                    f"且本次没有可写的 model_config.json，已跳过"
+                )
+                continue
+            targets = [switch.target]
+
+        for target in targets:
+            applied.append((target, switch.key, switch.value, switch.reason))
+
+    return applied, skipped

--- a/src/paddlefleet/config_adapter/report.py
+++ b/src/paddlefleet/config_adapter/report.py
@@ -1,0 +1,147 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Change bookkeeping and human-readable reporting.
+
+Every write the adapter performs is recorded together with the reason it was
+performed, so the console report can explain *what* changed and *why* instead
+of only dumping the final values.  Change lines keep a stable, greppable
+shape::
+
+    CHANGE field=<key> old=<value> new=<value>
+    ADD    field=<key> new=<value>
+    DELETE field=<key> old=<value>
+
+with the reason on the following indented line, and the machine-readable
+summary (``ORIGINAL_CARDS=`` / ``TARGET_CARDS=`` / ``OUTPUT=``) at the very
+end for upstream scripts.
+"""
+
+from __future__ import annotations
+
+from collections import namedtuple
+from datetime import date
+
+Change = namedtuple(
+    "Change", ["target", "kind", "field", "old", "new", "reason"]
+)
+
+_KIND_LABEL = {"modified": "CHANGE", "added": "ADD", "removed": "DELETE"}
+_TARGET_LABEL = {"yaml": "YAML", "json": "model_config.json"}
+
+
+class ChangeLog:
+    """Ordered record of every *effective* write, tagged with its reason.
+
+    Writes that leave the value untouched are dropped: a report should only
+    list keys that actually changed.
+    """
+
+    def __init__(self):
+        self.items = []
+
+    def record(self, target, diffs, reason):
+        """Record writer diffs (``[(kind, field, old, new), ...]``)."""
+        for kind, field, old, new in diffs:
+            if kind == "modified" and old == new:
+                continue
+            self.items.append(Change(target, kind, field, old, new, reason))
+
+    def record_removed(self, target, field, old, reason):
+        """Record a deletion the writers cannot express."""
+        self.items.append(Change(target, "removed", field, old, None, reason))
+
+    def by_target(self, target):
+        """Changes for one document, in the order they were applied."""
+        return [item for item in self.items if item.target == target]
+
+    def __len__(self):
+        return len(self.items)
+
+
+def format_header(info):
+    """Comment header prepended to the generated YAML."""
+    lines = [
+        f"# [config_adapter] source: {info['input']}",
+        f"# [config_adapter] profile: {info['profile']} "
+        f"(batch: {info['batch_strategy']})",
+        f"# [config_adapter] scale: {info['orig_cards_label']} cards -> "
+        f"{info['target_cards']} cards "
+        f"({info['target_nodes']} node(s) x {info['cards_per_node']})",
+        f"# [config_adapter] parallelism: {info['dims_line']}",
+        f"# [config_adapter] sharding: {info['sharding_line']}",
+        f"# [config_adapter] generated: {date.today().isoformat()}",
+    ]
+    return "\n".join(lines) + "\n\n"
+
+
+def _format_changes(changes, target, destination):
+    """Render one document's change block."""
+    label = _TARGET_LABEL[target]
+    if not changes:
+        return [f"{label} 改动：无"]
+
+    lines = [f"{label} 改动（{len(changes)} 项）-> {destination}"]
+    for item in changes:
+        kind = _KIND_LABEL[item.kind]
+        if item.kind == "modified":
+            head = (
+                f"  {kind} field={item.field} old={item.old!r} new={item.new!r}"
+            )
+        elif item.kind == "added":
+            head = f"  {kind} field={item.field} new={item.new!r}"
+        else:
+            head = f"  {kind} field={item.field} old={item.old!r}"
+        lines.append(head)
+        lines.append(f"      原因：{item.reason}")
+    return lines
+
+
+def format_report(info, changelog):
+    """Render the full console report for a successful adaptation."""
+    lines = [
+        "===== config_adapter: 适配成功 =====",
+        f"输入      ：{info['input']}",
+        f"模式      ：{info['profile']}（{info['profile_flag']}），"
+        f"batch 策略 {info['batch_strategy']}",
+        f"机器规模  ：{info['orig_scale_label']} -> "
+        f"{info['target_nodes']} 节点 / {info['target_cards']} 卡"
+        f"（每节点 {info['cards_per_node']} 卡）",
+        f"并行度    ：{info['dims_line']}",
+        f"sharding  ：{info['sharding_line']}",
+        f"缩容方案  ：{info['plan_note']}",
+    ]
+
+    lines += _format_changes(
+        changelog.by_target("yaml"), "yaml", info["output"]
+    )
+    if info.get("model_config_output"):
+        lines += _format_changes(
+            changelog.by_target("json"),
+            "json",
+            info["model_config_output"],
+        )
+
+    for note in info.get("skipped_switches") or []:
+        lines.append(f"跳过的精度开关：{note}")
+    for warning in info.get("warnings") or []:
+        lines.append(f"WARNING：{warning}")
+
+    lines.append(f"ORIGINAL_CARDS={info['orig_cards_label']}")
+    lines.append(f"ORIGINAL_NODES={info['orig_nodes_label']}")
+    lines.append(f"TARGET_CARDS={info['target_cards']}")
+    lines.append(f"OUTPUT={info['output']}")
+    if info.get("model_config_output"):
+        lines.append(f"MODEL_CONFIG_OUTPUT={info['model_config_output']}")
+    return "\n".join(lines)

--- a/src/paddlefleet/config_adapter/strategies.py
+++ b/src/paddlefleet/config_adapter/strategies.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""How batch settings follow the GPU count. One strategy per test profile.
+
+* ``--test-performance`` -> :func:`scale_batch`: shrink ``global_batch_size``
+  proportionally and keep ``gradient_accumulation_steps``, so per-step work
+  per card is unchanged and the measured step time stays comparable.
+* ``--test-accuracy`` -> :func:`scale_accumulation`: keep
+  ``global_batch_size`` and raise ``gradient_accumulation_steps`` by the same
+  factor, so the effective batch (and therefore the loss curve) matches the
+  full-scale run.
+
+Neither strategy touches parallelism dimensions.  Both return
+``(config_map, reason, error)``; a non-empty ``error`` aborts adaptation
+rather than silently rounding.
+"""
+
+from __future__ import annotations
+
+
+def scale_batch(gbs, grad_accum, orig_cards, target_cards):
+    """Shrink GBS proportionally to the card count, keep grad_accum."""
+    if gbs is None:
+        return (
+            {"gradient_accumulation_steps": grad_accum},
+            f"源配置未写 global_batch_size，acc 保持 {grad_accum} 不变，"
+            f"由框架反推 GBS",
+            None,
+        )
+
+    if gbs * target_cards % orig_cards != 0:
+        return (
+            None,
+            "",
+            f"GBS 无法整除：{gbs} × {target_cards} / {orig_cards} = "
+            f"{gbs * target_cards / orig_cards}，"
+            f"请换一个能整除的目标机器规模",
+        )
+
+    new_gbs = gbs * target_cards // orig_cards
+    if new_gbs <= 0:
+        return None, "", f"缩放后 GBS={new_gbs} <= 0，目标机器规模太小"
+
+    return (
+        {
+            "global_batch_size": new_gbs,
+            "gradient_accumulation_steps": grad_accum,
+        },
+        f"GBS 按卡数等比缩放 {gbs} × {target_cards} / "
+        f"{orig_cards} = {new_gbs}，acc 保持 {grad_accum} 不变",
+        None,
+    )
+
+
+def scale_accumulation(gbs, grad_accum, orig_cards, target_cards):
+    """Keep GBS, raise grad_accum so the effective batch is unchanged."""
+    if gbs is None:
+        return (
+            {"gradient_accumulation_steps": grad_accum},
+            f"源配置未写 global_batch_size，acc 保持 {grad_accum} 不变",
+            None,
+        )
+
+    if grad_accum * orig_cards % target_cards != 0:
+        return (
+            None,
+            "",
+            f"acc 无法整除：{grad_accum} × {orig_cards} / {target_cards} = "
+            f"{grad_accum * orig_cards / target_cards}，"
+            f"请换一个能整除的目标机器规模",
+        )
+
+    new_grad_accum = grad_accum * orig_cards // target_cards
+    if new_grad_accum <= 0:
+        return None, "", f"缩放后 acc={new_grad_accum} <= 0"
+
+    return (
+        {
+            "global_batch_size": gbs,
+            "gradient_accumulation_steps": new_grad_accum,
+        },
+        f"保持等效 batch：GBS 保持 {gbs} 不变，acc 放大为 {grad_accum} × "
+        f"{orig_cards} / {target_cards} = {new_grad_accum}",
+        None,
+    )
+
+
+BATCH_STRATEGIES = {
+    "scale_batch": scale_batch,
+    "scale_accumulation": scale_accumulation,
+}

--- a/src/paddlefleet/config_adapter/topology.py
+++ b/src/paddlefleet/config_adapter/topology.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Communication-group constraints for a given GPU count (C1..C4)."""
+
+from __future__ import annotations
+
+from .utils import multi_lcm
+
+
+class TopologyValidator:
+    """Validates Fleet communication-group constraints.
+
+    Constraints (derived from PaddlePaddle's topology.py):
+      C1: N % (TP * SEP * PP) == 0 -> sharding is a positive integer
+      C2: N % (PP * EP) == 0       -> moe_sharding is a positive integer
+      C3: EP % TP == 0             -> dense_sharding is a positive integer
+      C4: sharding % CP == 0       -> cp_sharding is a positive integer
+    """
+
+    def __init__(self, target_cards, cards_per_node=8):
+        self.target_cards = target_cards
+        self.cards_per_node = cards_per_node
+
+    def validate(self, tp, pp, ep, cp, sep=1):
+        """Check C1..C4. Returns ``(is_valid, message, details)``."""
+        n = self.target_cards
+        errors = []
+
+        if n % (tp * sep * pp) != 0:
+            errors.append(
+                f"C1 不满足：{n} % (TP={tp} × SEP={sep} × PP={pp}) = "
+                f"{n % (tp * sep * pp)} != 0，sharding 不是整数"
+            )
+
+        if ep > 1 and n % (pp * ep) != 0:
+            errors.append(
+                f"C2 不满足：{n} % (PP={pp} × EP={ep}) = {n % (pp * ep)} "
+                f"!= 0，moe_sharding 不是整数"
+            )
+
+        if ep > 1 and ep % tp != 0:
+            errors.append(
+                f"C3 不满足：EP={ep} % TP={tp} != 0，dense_sharding 不是整数"
+            )
+
+        if n % (tp * sep * pp) == 0:
+            sharding = n // (tp * sep * pp)
+            if sharding % cp != 0:
+                errors.append(
+                    f"C4 不满足：sharding={sharding} % CP={cp} = "
+                    f"{sharding % cp} != 0，cp_sharding 不是整数"
+                )
+
+        if errors:
+            cards = self.suggest_valid_cards(tp, pp, ep, cp, sep)
+            nodes = [c // self.cards_per_node for c in cards]
+            msg = "目标卡数 {} 不满足通信组约束：\n  {}".format(
+                n, "\n  ".join(errors)
+            )
+            msg += (
+                f"\n  16 节点内的合法节点数：{nodes}"
+                f"（每节点 {self.cards_per_node} 卡）"
+            )
+            return False, msg, {}
+
+        sharding = n // (tp * sep * pp)
+        moe_sharding = n // (pp * ep) if ep > 1 else 1
+        details = {
+            "sharding": sharding,
+            "moe_sharding": moe_sharding,
+            "dense_sharding": (
+                sharding // moe_sharding if moe_sharding > 0 else sharding
+            ),
+            "cp_sharding": sharding // cp,
+        }
+        return True, "通信组约束校验通过", details
+
+    def suggest_valid_cards(self, tp, pp, ep, cp, sep=1, max_nodes=16):
+        """List every valid GPU count within ``max_nodes``."""
+        factors = [tp * sep * pp, self.cards_per_node]
+        if ep > 1:
+            factors.append(pp * ep)
+        if cp > 1:
+            factors.append(tp * sep * pp * cp)
+        min_unit = multi_lcm(*factors)
+
+        max_cards = max_nodes * self.cards_per_node
+        suggestions = [
+            min_unit * k for k in range(1, max_cards // min_unit + 1)
+        ]
+        return suggestions or [min_unit]

--- a/src/paddlefleet/config_adapter/topology.py
+++ b/src/paddlefleet/config_adapter/topology.py
@@ -75,15 +75,21 @@ class TopologyValidator:
             )
 
         if errors:
-            cards = self.suggest_valid_cards(tp, pp, ep, cp, sep)
-            nodes = [c // self.cards_per_node for c in cards]
             msg = "目标卡数 {} 不满足通信组约束：\n  {}".format(
                 n, "\n  ".join(errors)
             )
-            msg += (
-                f"\n  16 节点内的合法节点数：{nodes}"
-                f"（每节点 {self.cards_per_node} 卡）"
-            )
+            cards = self.suggest_valid_cards(tp, pp, ep, cp, sep)
+            if cards:
+                nodes = [c // self.cards_per_node for c in cards]
+                msg += (
+                    f"\n  16 节点内的合法节点数：{nodes}"
+                    f"（每节点 {self.cards_per_node} 卡）"
+                )
+            else:
+                msg += (
+                    "\n  没有任何卡数能满足：上面的 C3/C5 只取决于并行度本身，"
+                    "与卡数无关，必须先修改 TP/SEP/EP/CP 的组合"
+                )
             return False, msg, {}
 
         sharding = n // (tp * sep * pp)
@@ -99,7 +105,16 @@ class TopologyValidator:
         return True, "通信组约束校验通过", details
 
     def suggest_valid_cards(self, tp, pp, ep, cp, sep=1, max_nodes=16):
-        """List every valid GPU count within ``max_nodes``."""
+        """List every valid GPU count within ``max_nodes``.
+
+        Returns ``[]`` when the dims violate a card-count-independent rule
+        (C3 or C5): no target scale can rescue those, so offering "legal"
+        node counts would be misleading.
+        """
+        if ep > 1 and ep % (tp * sep) != 0:
+            return []
+        if sep > 1 and cp > 1:
+            return []
         factors = [tp * sep * pp, self.cards_per_node]
         if ep > 1:
             factors.append(pp * ep)

--- a/src/paddlefleet/config_adapter/topology.py
+++ b/src/paddlefleet/config_adapter/topology.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Communication-group constraints for a given GPU count (C1..C4)."""
+"""Communication-group constraints for a given GPU count (C1..C5)."""
 
 from __future__ import annotations
 
@@ -22,11 +22,15 @@ from .utils import multi_lcm
 class TopologyValidator:
     """Validates Fleet communication-group constraints.
 
-    Constraints (derived from PaddlePaddle's topology.py):
+    Constraints (derived from PaddlePaddle's topology.py plus the trainer's
+    own assertions):
       C1: N % (TP * SEP * PP) == 0 -> sharding is a positive integer
       C2: N % (PP * EP) == 0       -> moe_sharding is a positive integer
-      C3: EP % TP == 0             -> dense_sharding is a positive integer
+      C3: EP % (TP * SEP) == 0     -> dense_sharding is a positive integer,
+          since dense_sharding = sharding / moe_sharding = EP / (TP * SEP)
       C4: sharding % CP == 0       -> cp_sharding is a positive integer
+      C5: not (SEP > 1 and CP > 1) -> "sep parallel and context parallel
+          cannot be used together" (PaddleFormers training_args.py)
     """
 
     def __init__(self, target_cards, cards_per_node=8):
@@ -34,7 +38,7 @@ class TopologyValidator:
         self.cards_per_node = cards_per_node
 
     def validate(self, tp, pp, ep, cp, sep=1):
-        """Check C1..C4. Returns ``(is_valid, message, details)``."""
+        """Check C1..C5. Returns ``(is_valid, message, details)``."""
         n = self.target_cards
         errors = []
 
@@ -50,9 +54,10 @@ class TopologyValidator:
                 f"!= 0，moe_sharding 不是整数"
             )
 
-        if ep > 1 and ep % tp != 0:
+        if ep > 1 and ep % (tp * sep) != 0:
             errors.append(
-                f"C3 不满足：EP={ep} % TP={tp} != 0，dense_sharding 不是整数"
+                f"C3 不满足：EP={ep} % (TP={tp} × SEP={sep}) != 0，"
+                f"dense_sharding = EP/(TP×SEP) 不是正整数"
             )
 
         if n % (tp * sep * pp) == 0:
@@ -62,6 +67,12 @@ class TopologyValidator:
                     f"C4 不满足：sharding={sharding} % CP={cp} = "
                     f"{sharding % cp} != 0，cp_sharding 不是整数"
                 )
+
+        if sep > 1 and cp > 1:
+            errors.append(
+                f"C5 不满足：SEP={sep} 与 CP={cp} 不能同时大于 1"
+                f"（框架禁止 sep parallel 与 context parallel 同时使用）"
+            )
 
         if errors:
             cards = self.suggest_valid_cards(tp, pp, ep, cp, sep)

--- a/src/paddlefleet/config_adapter/utils.py
+++ b/src/paddlefleet/config_adapter/utils.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Small helpers shared across the config adapter."""
+
+from __future__ import annotations
+
+import math
+
+# YAML key of every parallel dimension the adapter reasons about.
+PARALLEL_FIELDS = {
+    "tp": "tensor_model_parallel_size",
+    "pp": "pipeline_model_parallel_size",
+    "ep": "expert_model_parallel_size",
+    "cp": "context_parallel_size",
+    "sep": "sep_parallel_size",
+}
+
+
+def lcm(a, b):
+    """Least common multiple of two integers."""
+    return abs(a * b) // math.gcd(a, b)
+
+
+def multi_lcm(*args):
+    """Least common multiple of an arbitrary number of integers."""
+    result = args[0]
+    for x in args[1:]:
+        result = lcm(result, x)
+    return result
+
+
+def parse_value(value_str):
+    """Infer a Python value from a CLI string.
+
+    Supports bool / None / int / float, falling back to the raw string.
+    """
+    lowered = value_str.lower()
+    if lowered == "true":
+        return True
+    if lowered == "false":
+        return False
+    if lowered in ("null", "none"):
+        return None
+    try:
+        return int(value_str)
+    except ValueError:
+        pass
+    try:
+        return float(value_str)
+    except ValueError:
+        pass
+    return value_str
+
+
+def extract_parallel_params(config):
+    """Return ``(tp, pp, ep, cp, sep)`` read from a training YAML.
+
+    Missing / commented-out / null values default to 1.
+    """
+    dims = []
+    for key in ("tp", "pp", "ep", "cp", "sep"):
+        raw = config.get(PARALLEL_FIELDS[key], 1)
+        dims.append(max(int(raw), 1) if raw is not None else 1)
+    return tuple(dims)

--- a/tests/single_card_tests/config_adapter/__init__.py
+++ b/tests/single_card_tests/config_adapter/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/single_card_tests/config_adapter/test_config_adapter.py
+++ b/tests/single_card_tests/config_adapter/test_config_adapter.py
@@ -1,0 +1,1240 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for paddlefleet.config_adapter (pure Python, no device)."""
+
+import contextlib
+import io
+import json
+import runpy
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from paddlefleet.config_adapter import (
+    AdaptOptions,
+    ConfigAdapter,
+    inspect_config,
+    main,
+    parse_overrides,
+    plan_precision_switches,
+)
+from paddlefleet.config_adapter.constraints import (
+    align_layers,
+    check_ep_shrink,
+    check_hardware,
+    check_pp_shrink,
+    ep_candidates,
+    min_shrink_cards,
+    pp_candidates,
+)
+from paddlefleet.config_adapter.field_spec import (
+    FIELD_SPECS,
+    describe_missing,
+    resolve_fields,
+)
+from paddlefleet.config_adapter.io_writers import JsonWriter, YamlWriter
+from paddlefleet.config_adapter.layer_fields import (
+    effective_mtp_layers,
+    plan_layer_field_shrink,
+)
+from paddlefleet.config_adapter.model_config_resolver import (
+    ModelConfigResolveError,
+    build_adapted_dir,
+    resolve_model_config,
+    rewrite_model_name_or_path,
+)
+from paddlefleet.config_adapter.report import (
+    ChangeLog,
+    format_header,
+    format_report,
+)
+from paddlefleet.config_adapter.strategies import (
+    scale_accumulation,
+    scale_batch,
+)
+from paddlefleet.config_adapter.topology import TopologyValidator
+from paddlefleet.config_adapter.utils import (
+    extract_parallel_params,
+    multi_lcm,
+    parse_value,
+)
+
+SOURCE_YAML = """\
+model_name_or_path: ./model_dir
+num_empty_layers_add_in_head: 0
+num_empty_layers_add_in_tail: 0
+separate_mtp_headloss: false
+fa_version: 3
+global_batch_size: 1536
+per_device_train_batch_size: 1
+gradient_accumulation_steps: 2
+sharding_parallel_size: 96
+data_parallel_size: 1
+tensor_model_parallel_size: 1
+expert_model_parallel_size: 64
+pipeline_model_parallel_size: 8
+virtual_pipeline_model_parallel_size: 2
+context_parallel_size: 1
+csa_indexer_backend: tilelang
+csa_sparse_attn_backend: cudnn
+max_steps: 1000000
+"""
+
+MODEL_CONFIG = {
+    "num_hidden_layers": 64,
+    "n_routed_experts": 256,
+    "num_experts_per_tok": 8,
+    "first_k_dense_replace": 1,
+    "num_nextn_predict_layers": 1,
+    "multimax_modules": ["lm_head"],
+}
+
+
+class ConfigAdapterTestBase(unittest.TestCase):
+    """Builds a throw-away source YAML + model_config.json per test."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        self.yaml_path = self.root / "source.yaml"
+        self.yaml_path.write_text(SOURCE_YAML, encoding="utf-8")
+        self.model_dir = self.root / "model_dir"
+        self.model_dir.mkdir()
+        self.json_path = self.model_dir / "model_config.json"
+        self.write_json(MODEL_CONFIG)
+        self.output_dir = self.root / "out"
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def write_yaml(self, text):
+        """Overwrite the source YAML with ``text``."""
+        self.yaml_path.write_text(text, encoding="utf-8")
+
+    def write_json(self, data):
+        """Overwrite the source model_config.json with ``data``."""
+        self.json_path.write_text(
+            json.dumps(data, indent=2) + "\n", encoding="utf-8"
+        )
+
+    def adapt(
+        self,
+        target_nodes,
+        test_performance=False,
+        test_accuracy=False,
+        **kwargs,
+    ):
+        """Run one adaptation, returning ``(ok, message)``."""
+        kwargs.setdefault("output_dir", self.output_dir)
+        adapter = ConfigAdapter(
+            options=AdaptOptions(test_performance, test_accuracy),
+            target_nodes=target_nodes,
+            **kwargs,
+        )
+        return adapter.adapt(self.yaml_path)
+
+    def load_output_yaml(self, target_cards):
+        """Load the generated YAML for a target card count."""
+        path = self.output_dir / f"source_adapted_{target_cards}cards.yaml"
+        return YamlWriter().load(path)
+
+    def load_output_json(self, target_cards):
+        """Load the generated model_config.json for a target card count."""
+        path = (
+            self.output_dir
+            / "model_config_separated"
+            / f"model_dir_adapted_{target_cards}cards"
+            / "model_config.json"
+        )
+        return JsonWriter().load(path)
+
+
+class TestOptions(unittest.TestCase):
+    """The two switches are orthogonal and both optional."""
+
+    def test_default_shrinks_and_scales_batch(self):
+        options = AdaptOptions()
+        self.assertFalse(options.freeze_parallel)
+        self.assertFalse(options.inject_precision)
+        self.assertEqual(options.batch_strategy, "scale_batch")
+        self.assertEqual(options.label, "default")
+
+    def test_accuracy_keeps_effective_batch(self):
+        options = AdaptOptions(test_accuracy=True)
+        self.assertFalse(options.freeze_parallel)
+        self.assertTrue(options.inject_precision)
+        self.assertEqual(options.batch_strategy, "scale_accumulation")
+
+    def test_performance_freezes_acc_even_with_accuracy(self):
+        options = AdaptOptions(test_performance=True, test_accuracy=True)
+        self.assertTrue(options.freeze_parallel)
+        self.assertTrue(options.inject_precision)
+        self.assertEqual(options.batch_strategy, "scale_batch")
+        self.assertEqual(options.label, "performance+accuracy")
+
+
+class TestCandidates(unittest.TestCase):
+    """A degree greater than 1 must never shrink to 1."""
+
+    def test_ep_candidates_never_reach_one(self):
+        self.assertNotIn(1, ep_candidates(64, tp=1))
+        self.assertEqual(min(ep_candidates(64, tp=1)), 2)
+        self.assertEqual(ep_candidates(2, tp=1), [])
+
+    def test_pp_candidates_never_reach_one(self):
+        self.assertEqual(pp_candidates(8), [4, 2])
+        self.assertEqual(pp_candidates(2), [])
+
+    def test_ep_candidates_respect_tp(self):
+        # C3 requires ep_new % tp == 0.
+        self.assertTrue(all(c % 4 == 0 for c in ep_candidates(64, tp=4)))
+
+
+class TestPrecisionSwitches(unittest.TestCase):
+    """Switch routing: pin whichever document declares the key."""
+
+    def test_yaml_key_pinned_in_yaml(self):
+        applied, skipped = plan_precision_switches(
+            {"csa_sparse_attn_backend": "cudnn"}, {}
+        )
+        self.assertIn(
+            ("yaml", "csa_sparse_attn_backend", "tilelang"),
+            [(t, k, v) for t, k, v, _r in applied],
+        )
+        self.assertEqual(skipped, [])
+
+    def test_key_declared_in_json_is_pinned_there_too(self):
+        applied, _skipped = plan_precision_switches(
+            {}, {"csa_sparse_attn_backend": "cudnn"}
+        )
+        targets = {(t, k) for t, k, _v, _r in applied}
+        self.assertIn(("json", "csa_sparse_attn_backend"), targets)
+
+    def test_json_switch_skipped_without_model_config(self):
+        _applied, skipped = plan_precision_switches({}, None)
+        self.assertTrue(any("multimax_modules" in note for note in skipped))
+
+
+class TestOverrideParsing(unittest.TestCase):
+    """``--set`` may name its target file, or let the tool decide."""
+
+    def test_explicit_prefix_wins(self):
+        yaml_map, json_map, auto_map = parse_overrides(
+            ["yaml:max_steps=10", "json:n_routed_experts=32"]
+        )
+        self.assertEqual(yaml_map, {"max_steps": 10})
+        self.assertEqual(json_map, {"n_routed_experts": 32})
+        self.assertEqual(auto_map, {})
+
+    def test_prefix_less_goes_to_auto(self):
+        yaml_map, json_map, auto_map = parse_overrides(["max_steps=10"])
+        self.assertEqual((yaml_map, json_map), ({}, {}))
+        self.assertEqual(auto_map, {"max_steps": 10})
+
+    def test_missing_value_is_an_error(self):
+        with self.assertRaises(ValueError):
+            parse_overrides(["max_steps"])
+
+
+class TestValueParsing(unittest.TestCase):
+    """``--set`` value inference and parallel-dim extraction."""
+
+    def test_parse_value_types(self):
+        self.assertIs(parse_value("true"), True)
+        self.assertIs(parse_value("False"), False)
+        self.assertIsNone(parse_value("null"))
+        self.assertIsNone(parse_value("None"))
+        self.assertEqual(parse_value("42"), 42)
+        self.assertEqual(parse_value("1e-5"), 1e-05)
+        self.assertEqual(parse_value("tilelang"), "tilelang")
+
+    def test_extract_parallel_params_defaults(self):
+        self.assertEqual(extract_parallel_params({}), (1, 1, 1, 1, 1))
+        self.assertEqual(
+            extract_parallel_params(
+                {
+                    "tensor_model_parallel_size": 2,
+                    "pipeline_model_parallel_size": None,
+                    "expert_model_parallel_size": 8,
+                    "context_parallel_size": -1,
+                    "sep_parallel_size": 4,
+                }
+            ),
+            (2, 1, 8, 1, 4),
+        )
+
+    def test_multi_lcm(self):
+        self.assertEqual(multi_lcm(4, 6, 8), 24)
+
+
+class TestBatchStrategies(unittest.TestCase):
+    """Batch scaling maths, including every refusal path."""
+
+    def test_scale_batch_happy_path(self):
+        config_map, reason, err = scale_batch(1536, 2, 768, 8)
+        self.assertIsNone(err)
+        self.assertEqual(config_map["global_batch_size"], 16)
+        self.assertEqual(config_map["gradient_accumulation_steps"], 2)
+        self.assertIn("等比缩放", reason)
+
+    def test_scale_batch_without_gbs_keeps_acc(self):
+        config_map, reason, err = scale_batch(None, 4, 768, 8)
+        self.assertIsNone(err)
+        self.assertEqual(config_map, {"gradient_accumulation_steps": 4})
+        self.assertIn("global_batch_size", reason)
+
+    def test_scale_batch_refuses_non_divisible(self):
+        _map, _reason, err = scale_batch(1537, 2, 768, 8)
+        self.assertIn("无法整除", err)
+
+    def test_scale_batch_refuses_zero(self):
+        # A source config declaring global_batch_size: 0 scales to 0.
+        _map, _reason, err = scale_batch(0, 2, 768, 8)
+        self.assertIn("<= 0", err)
+
+    def test_scale_accumulation_happy_path(self):
+        config_map, reason, err = scale_accumulation(1536, 2, 768, 8)
+        self.assertIsNone(err)
+        self.assertEqual(config_map["global_batch_size"], 1536)
+        self.assertEqual(config_map["gradient_accumulation_steps"], 192)
+        self.assertIn("等效 batch", reason)
+
+    def test_scale_accumulation_without_gbs_keeps_acc(self):
+        config_map, _reason, err = scale_accumulation(None, 4, 768, 8)
+        self.assertIsNone(err)
+        self.assertEqual(config_map, {"gradient_accumulation_steps": 4})
+
+    def test_scale_accumulation_refuses_non_divisible(self):
+        _map, _reason, err = scale_accumulation(1536, 3, 768, 7)
+        self.assertIn("无法整除", err)
+
+
+class TestTopologyConstraints(unittest.TestCase):
+    """C1..C4 and the suggestion helper."""
+
+    def test_valid_topology_reports_derived_groups(self):
+        ok, _msg, details = TopologyValidator(8, 8).validate(1, 2, 4, 1, 1)
+        self.assertTrue(ok)
+        self.assertEqual(details["sharding"], 4)
+        self.assertEqual(details["moe_sharding"], 1)
+
+    def test_c1_violation(self):
+        ok, msg, _d = TopologyValidator(8, 8).validate(3, 1, 1, 1, 1)
+        self.assertFalse(ok)
+        self.assertIn("C1", msg)
+
+    def test_c2_violation(self):
+        ok, msg, _d = TopologyValidator(8, 8).validate(1, 8, 64, 1, 1)
+        self.assertFalse(ok)
+        self.assertIn("C2", msg)
+
+    def test_c3_violation(self):
+        ok, msg, _d = TopologyValidator(8, 8).validate(4, 1, 2, 1, 1)
+        self.assertFalse(ok)
+        self.assertIn("C3", msg)
+
+    def test_c4_violation(self):
+        ok, msg, _d = TopologyValidator(8, 8).validate(1, 1, 1, 3, 1)
+        self.assertFalse(ok)
+        self.assertIn("C4", msg)
+
+    def test_suggestions_are_multiples_of_the_minimum_unit(self):
+        cards = TopologyValidator(8, 8).suggest_valid_cards(1, 2, 8, 1, 1)
+        self.assertTrue(all(c % 16 == 0 for c in cards), cards)
+
+
+class TestHardwareAndModelConstraints(unittest.TestCase):
+    """E-family and M-family checks."""
+
+    def test_e3_rejects_non_integer_dims(self):
+        ok, why = check_hardware(8, 8, 1, 1, "2", 1, 1)
+        self.assertFalse(ok)
+        self.assertIn("E3", why)
+
+    def test_e1_rejects_asymmetric_multi_node(self):
+        ok, why = check_hardware(12, 8, 1, 1, 1, 1, 1)
+        self.assertFalse(ok)
+        self.assertIn("E1", why)
+
+    def test_e2_rejects_tp_larger_than_the_node(self):
+        ok, why = check_hardware(8, 8, 16, 1, 1, 1, 1)
+        self.assertFalse(ok)
+        self.assertIn("E2", why)
+
+    def test_hardware_prereqs_pass(self):
+        ok, why = check_hardware(8, 8, 1, 8, 64, 1, 1)
+        self.assertTrue(ok, why)
+
+    def test_min_shrink_cards_respects_the_floor(self):
+        # PP and EP may only shrink to 2, so 2*2 = 4 cards is the floor here.
+        self.assertEqual(min_shrink_cards(1, 8, 8, 1, 1, 8), 8)
+
+    def test_m1_rejects_uneven_experts(self):
+        ok, why, experts = check_ep_shrink(64, 56, 32, 8)
+        self.assertFalse(ok)
+        self.assertIn("M1", why)
+        self.assertEqual(experts, 28)
+
+    def test_m2_rejects_fewer_experts_than_topk(self):
+        ok, why, _experts = check_ep_shrink(64, 2, 64, 8)
+        self.assertFalse(ok)
+        self.assertIn("M2", why)
+
+    def test_ep_growth_is_vacuous(self):
+        ok, _why, experts = check_ep_shrink(8, 8, 64, 8)
+        self.assertTrue(ok)
+        self.assertEqual(experts, 64)
+
+    def test_pp_shrink_reports_layer_and_alignment(self):
+        ok, why, meta = check_pp_shrink(8, 2, 64, 0, 0, 2)
+        self.assertTrue(ok, why)
+        self.assertEqual(meta["layers_new"], 16)
+        self.assertEqual(meta["vpp_new"], 2)
+
+    def test_pp_shrink_warns_on_few_layers(self):
+        _ok, _why, meta = check_pp_shrink(8, 2, 8, 0, 0, 1)
+        self.assertIn("推荐", meta["warning"])
+
+    def test_pp_shrink_rejects_zero_layers(self):
+        ok, why, _meta = check_pp_shrink(8, 2, 3, 0, 0, 1)
+        self.assertFalse(ok)
+        self.assertIn("至少需要 1 层", why)
+
+    def test_m5_rejects_a_dense_prefix_that_does_not_fit(self):
+        ok, why, _meta = check_pp_shrink(
+            8, 2, 64, 0, 0, 1, first_k_dense_replace=32
+        )
+        self.assertFalse(ok)
+        self.assertIn("M5", why)
+
+    def test_align_layers_pads_the_tail(self):
+        vpp_new, tail_new = align_layers(15, 0, 0, 2, 2)
+        self.assertEqual(vpp_new, 2)
+        self.assertEqual(tail_new, 1)
+
+    def test_align_layers_refuses_pp_below_the_floor(self):
+        self.assertEqual(align_layers(16, 0, 0, 1, 2), (None, None))
+
+
+class TestFieldSpec(unittest.TestCase):
+    """Alias resolution for model_config.json fields."""
+
+    def test_resolves_aliases_and_remembers_the_key(self):
+        resolved, missing = resolve_fields(
+            {
+                "num_hidden_layers": 8,
+                "num_local_experts": 16,
+                "moe_k": 4,
+            }
+        )
+        self.assertEqual(missing, {})
+        self.assertEqual(resolved["num_experts"].value, 16)
+        self.assertEqual(
+            resolved["num_experts"].writeback_key, "num_local_experts"
+        )
+        self.assertEqual(resolved["num_experts_per_tok"].value, 4)
+        # Optional fields fall back to their declared default.
+        self.assertEqual(resolved["first_k_dense_replace"].value, 0)
+        self.assertEqual(resolved["first_k_dense_replace"].origin, "<default>")
+
+    def test_missing_required_fields_are_reported(self):
+        resolved, missing = resolve_fields({"num_hidden_layers": 8})
+        self.assertIn("num_experts", missing)
+        self.assertNotIn("num_experts", resolved)
+        # Write-back falls back to the canonical spelling.
+        message = describe_missing("num_experts", FIELD_SPECS["num_experts"])
+        self.assertIn("n_routed_experts", message)
+        self.assertIn("--set json:", message)
+
+
+class TestModelConfigResolution(unittest.TestCase):
+    """Locating and re-pointing model_config.json."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        self.model_dir = self.root / "model_dir"
+        self.model_dir.mkdir()
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_empty_value_is_refused(self):
+        with self.assertRaises(ModelConfigResolveError) as ctx:
+            resolve_model_config(None, self.root)
+        self.assertIn("model_name_or_path", str(ctx.exception))
+
+    def test_missing_directory_lists_what_was_tried(self):
+        with self.assertRaises(ModelConfigResolveError) as ctx:
+            resolve_model_config("./nope", self.root)
+        self.assertIn("已尝试", str(ctx.exception))
+
+    def test_directory_without_json_is_refused(self):
+        with self.assertRaises(ModelConfigResolveError) as ctx:
+            resolve_model_config("./model_dir", self.root)
+        self.assertIn("model_config.json", str(ctx.exception))
+
+    def test_relative_and_absolute_values_both_resolve(self):
+        (self.model_dir / "model_config.json").write_text("{}\n")
+        for value in ("./model_dir", str(self.model_dir)):
+            found_dir, json_path = resolve_model_config(value, self.root)
+            self.assertEqual(found_dir, self.model_dir.resolve())
+            self.assertTrue(json_path.is_file())
+
+    def test_adapted_dir_layout(self):
+        path = build_adapted_dir("/out", "model_dir", "8cards")
+        self.assertEqual(
+            path,
+            Path("/out/model_config_separated/model_dir_adapted_8cards"),
+        )
+
+    def test_absolute_source_stays_absolute(self):
+        value = rewrite_model_name_or_path(
+            self.model_dir, self.root, source_was_absolute=True
+        )
+        self.assertTrue(Path(value).is_absolute())
+
+    def test_relative_source_stays_relative_inside_the_yaml_dir(self):
+        value = rewrite_model_name_or_path(
+            self.model_dir, self.root, source_was_absolute=False
+        )
+        self.assertEqual(value, "model_dir")
+
+
+class TestChangeReporting(unittest.TestCase):
+    """Change bookkeeping and the rendered report."""
+
+    def _info(self, **overrides):
+        return {
+            "input": "src.yaml",
+            "output": "out.yaml",
+            "profile": "accuracy",
+            "profile_flag": "--test-accuracy",
+            "batch_strategy": "scale_accumulation",
+            "orig_cards_label": 768,
+            "orig_nodes_label": 96,
+            "orig_scale_label": "96 节点 / 768 卡",
+            "target_cards": 8,
+            "target_nodes": 1,
+            "cards_per_node": 8,
+            "dims_line": "TP 1->1",
+            "sharding_line": "96 -> 4",
+            "plan_note": "仅缩 EP",
+            "model_config_output": None,
+            "skipped_switches": [],
+            "warnings": [],
+            **overrides,
+        }
+
+    def test_no_op_writes_are_dropped(self):
+        log = ChangeLog()
+        log.record("yaml", [("modified", "a", 1, 1)], "no-op")
+        log.record("yaml", [("modified", "b", 1, 2)], "real change")
+        log.record("json", [("added", "c", None, 3)], "added")
+        log.record_removed("yaml", "d", 9, "removed")
+        self.assertEqual(len(log), 3)
+        self.assertEqual([c.field for c in log.by_target("yaml")], ["b", "d"])
+
+    def test_report_lists_every_kind_with_its_reason(self):
+        log = ChangeLog()
+        log.record("yaml", [("modified", "ep", 64, 4)], "EP 缩容")
+        log.record("yaml", [("added", "new_key", None, 1)], "新增")
+        log.record_removed("yaml", "fa_version", 3, "环境相关")
+        log.record("json", [("modified", "experts", 256, 16)], "专家数")
+        text = format_report(
+            self._info(
+                model_config_output="out.json",
+                skipped_switches=["skipped one"],
+                warnings=["watch out"],
+            ),
+            log,
+        )
+        self.assertIn("CHANGE field=ep old=64 new=4", text)
+        self.assertIn("ADD field=new_key new=1", text)
+        self.assertIn("DELETE field=fa_version old=3", text)
+        self.assertIn("原因：EP 缩容", text)
+        self.assertIn("model_config.json 改动", text)
+        self.assertIn("跳过的精度开关：skipped one", text)
+        self.assertIn("WARNING：watch out", text)
+        self.assertIn("MODEL_CONFIG_OUTPUT=out.json", text)
+
+    def test_report_says_so_when_nothing_changed(self):
+        text = format_report(self._info(), ChangeLog())
+        self.assertIn("YAML 改动：无", text)
+
+    def test_header_is_a_comment_block(self):
+        header = format_header(self._info())
+        self.assertTrue(
+            all(
+                line.startswith("# [config_adapter]")
+                for line in header.strip().splitlines()
+            )
+        )
+
+
+class TestLayerFieldPlanning(unittest.TestCase):
+    """Per-layer list rewrites, exercised without touching any file."""
+
+    def _config(self, **overrides):
+        return {
+            "num_hidden_layers": 64,
+            "num_nextn_predict_layers": 1,
+            "csa_compress_ratios": [128, 128, 128, -2] * 16 + [-2],
+            "window_attn_skip_freq": [0] * 65,
+            "layer_types": ["full_attention"] * 64,
+            **overrides,
+        }
+
+    def test_effective_mtp_follows_the_framework_rule(self):
+        # mtp_num_layers wins whenever it is non-zero.
+        self.assertEqual(
+            effective_mtp_layers(
+                {"mtp_num_layers": 2, "num_nextn_predict_layers": 0}
+            ),
+            2,
+        )
+        self.assertEqual(
+            effective_mtp_layers({"num_nextn_predict_layers": 3}), 3
+        )
+        self.assertEqual(effective_mtp_layers({}), 0)
+        self.assertEqual(effective_mtp_layers(None), 0)
+
+    def test_truncates_layer_part_and_keeps_the_mtp_tail(self):
+        changes, err = plan_layer_field_shrink(self._config(), 64, 16, 1)
+        self.assertIsNone(err)
+        by_key = {key: value for key, value, _reason in changes}
+        self.assertEqual(len(by_key["csa_compress_ratios"]), 17)
+        self.assertEqual(by_key["csa_compress_ratios"][-1], -2)
+        self.assertEqual(len(by_key["window_attn_skip_freq"]), 17)
+        self.assertEqual(len(by_key["layer_types"]), 16)
+
+    def test_growing_or_equal_layer_counts_change_nothing(self):
+        changes, err = plan_layer_field_shrink(self._config(), 64, 64, 1)
+        self.assertIsNone(err)
+        self.assertEqual(changes, [])
+
+    def test_scalar_fields_are_ignored(self):
+        config = self._config(window_attn_skip_freq=4)
+        changes, err = plan_layer_field_shrink(config, 64, 16, 1)
+        self.assertIsNone(err)
+        self.assertNotIn(
+            "window_attn_skip_freq", [key for key, _v, _r in changes]
+        )
+
+    def test_inconsistent_source_length_is_refused(self):
+        config = self._config(csa_compress_ratios=[128] * 10)
+        _changes, err = plan_layer_field_shrink(config, 64, 16, 1)
+        self.assertIsNotNone(err)
+        self.assertIn("不自洽", err)
+
+    def test_losing_an_attention_family_is_refused(self):
+        config = self._config(csa_compress_ratios=[128] * 60 + [-2] * 4 + [-2])
+        _changes, err = plan_layer_field_shrink(config, 64, 16, 1)
+        self.assertIsNotNone(err)
+        self.assertIn("丢掉注意力类型", err)
+
+    def test_missing_lists_need_no_rewrite(self):
+        changes, err = plan_layer_field_shrink(
+            {"num_hidden_layers": 64}, 64, 16, 0
+        )
+        self.assertIsNone(err)
+        self.assertEqual(changes, [])
+
+
+class TestDefaultAdaptation(ConfigAdapterTestBase):
+    """No switch: just make the config fit, shrinking EP/PP if needed."""
+
+    def test_shrinks_ep_and_pp_without_precision_switches(self):
+        ok, message = self.adapt(target_nodes=1)
+        self.assertTrue(ok, message)
+        config = self.load_output_yaml(8)
+        model_config = self.load_output_json(8)
+
+        # EP and PP shrink together; neither collapses to 1.
+        self.assertEqual(config["expert_model_parallel_size"], 4)
+        self.assertEqual(config["pipeline_model_parallel_size"], 2)
+        self.assertEqual(config["sharding_parallel_size"], 4)
+        self.assertEqual(model_config["n_routed_experts"], 16)
+        self.assertEqual(model_config["num_hidden_layers"], 16)
+        # Default batch strategy shrinks GBS and leaves acc alone.
+        self.assertEqual(config["global_batch_size"], 16)
+        self.assertEqual(config["gradient_accumulation_steps"], 2)
+        # No determinism switches unless --test-accuracy is given.
+        self.assertEqual(config["csa_sparse_attn_backend"], "cudnn")
+        self.assertEqual(model_config["multimax_modules"], ["lm_head"])
+        # Environment-specific pin is always dropped.
+        self.assertNotIn("fa_version", config)
+
+    def test_existing_output_dir_needs_force(self):
+        ok, message = self.adapt(target_nodes=1)
+        self.assertTrue(ok, message)
+
+        ok, message = self.adapt(target_nodes=1)
+        self.assertFalse(ok)
+        self.assertIn("--force", message)
+
+        ok, message = self.adapt(target_nodes=1, force=True)
+        self.assertTrue(ok, message)
+
+    def test_unchanged_keys_are_not_reported(self):
+        ok, message = self.adapt(
+            target_nodes=1, auto_overrides={"max_steps": 1000000}
+        )
+        self.assertTrue(ok, message)
+        # The value equals the source value, so nothing is logged for it.
+        self.assertNotIn("max_steps", message)
+
+
+class TestPerformanceSwitch(ConfigAdapterTestBase):
+    """``--test-performance``: sharding + GBS only, everything else frozen."""
+
+    def test_scales_gbs_and_sharding(self):
+        ok, message = self.adapt(target_nodes=64, test_performance=True)
+        self.assertTrue(ok, message)
+        config = self.load_output_yaml(512)
+        self.assertEqual(config["global_batch_size"], 1024)
+        self.assertEqual(config["gradient_accumulation_steps"], 2)
+        self.assertEqual(config["sharding_parallel_size"], 64)
+        self.assertEqual(config["expert_model_parallel_size"], 64)
+        self.assertEqual(config["pipeline_model_parallel_size"], 8)
+
+    def test_rejects_incompatible_scale(self):
+        ok, message = self.adapt(target_nodes=1, test_performance=True)
+        self.assertFalse(ok)
+        self.assertIn("C2", message)
+        self.assertIn("--test-performance", message)
+
+    def test_no_model_config_written(self):
+        ok, message = self.adapt(target_nodes=64, test_performance=True)
+        self.assertTrue(ok, message)
+        self.assertFalse((self.output_dir / "model_config_separated").exists())
+        self.assertEqual(
+            JsonWriter().load(self.json_path)["n_routed_experts"], 256
+        )
+
+
+class TestAccuracySwitch(ConfigAdapterTestBase):
+    """``--test-accuracy``: determinism switches + equivalent batch."""
+
+    def test_keeps_effective_batch_and_pins_switches(self):
+        ok, message = self.adapt(target_nodes=1, test_accuracy=True)
+        self.assertTrue(ok, message)
+        config = self.load_output_yaml(8)
+        self.assertEqual(config["global_batch_size"], 1536)
+        self.assertEqual(config["gradient_accumulation_steps"], 192)
+        self.assertEqual(config["csa_sparse_attn_backend"], "tilelang")
+        self.assertIsNone(self.load_output_json(8)["multimax_modules"])
+        self.assertIn("精度对齐", message)
+
+    def test_combined_with_performance_freezes_dims(self):
+        ok, message = self.adapt(
+            target_nodes=64, test_performance=True, test_accuracy=True
+        )
+        self.assertTrue(ok, message)
+        config = self.load_output_yaml(512)
+        # Frozen dims and acc, but the determinism switches still land.
+        self.assertEqual(config["expert_model_parallel_size"], 64)
+        self.assertEqual(config["gradient_accumulation_steps"], 2)
+        self.assertEqual(config["global_batch_size"], 1024)
+        self.assertEqual(config["csa_sparse_attn_backend"], "tilelang")
+        self.assertIsNone(self.load_output_json(512)["multimax_modules"])
+
+    def test_source_model_config_is_never_touched(self):
+        ok, message = self.adapt(target_nodes=1, test_accuracy=True)
+        self.assertTrue(ok, message)
+        source = JsonWriter().load(self.json_path)
+        self.assertEqual(source["num_hidden_layers"], 64)
+        self.assertEqual(source["multimax_modules"], ["lm_head"])
+        self.assertIn(
+            "model_dir_adapted_8cards",
+            self.load_output_yaml(8)["model_name_or_path"],
+        )
+
+    def test_ep_shrinks_to_two_not_one(self):
+        self.write_yaml(
+            SOURCE_YAML.replace(
+                "pipeline_model_parallel_size: 8",
+                "pipeline_model_parallel_size: 1",
+            ).replace(
+                "expert_model_parallel_size: 64",
+                "expert_model_parallel_size: 8",
+            )
+        )
+        ok, message = self.adapt(
+            target_nodes=1, test_accuracy=True, cards_per_node=4
+        )
+        self.assertTrue(ok, message)
+        self.assertEqual(
+            self.load_output_yaml(4)["expert_model_parallel_size"], 4
+        )
+
+    def test_refuses_to_remove_the_last_ep_group(self):
+        self.write_yaml(
+            SOURCE_YAML.replace(
+                "pipeline_model_parallel_size: 8",
+                "pipeline_model_parallel_size: 1",
+            ).replace(
+                "expert_model_parallel_size: 64",
+                "expert_model_parallel_size: 2",
+            )
+        )
+        ok, message = self.adapt(
+            target_nodes=1, test_accuracy=True, cards_per_node=1
+        )
+        self.assertFalse(ok)
+        self.assertIn("最小值", message)
+
+
+class TestAutoOverrideRouting(ConfigAdapterTestBase):
+    """Prefix-less ``--set`` routes by which document declares the key."""
+
+    def test_key_only_in_yaml(self):
+        ok, message = self.adapt(
+            target_nodes=1, auto_overrides={"max_steps": 10}
+        )
+        self.assertTrue(ok, message)
+        self.assertEqual(self.load_output_yaml(8)["max_steps"], 10)
+        self.assertNotIn("max_steps", self.load_output_json(8))
+
+    def test_key_only_in_model_config_is_also_protected(self):
+        ok, message = self.adapt(
+            target_nodes=1, auto_overrides={"n_routed_experts": 128}
+        )
+        self.assertTrue(ok, message)
+        # Routed to the JSON, and the EP shrink may not overwrite a --set.
+        self.assertEqual(self.load_output_json(8)["n_routed_experts"], 128)
+        self.assertNotIn("n_routed_experts", self.load_output_yaml(8))
+
+    def test_key_in_both_documents_updates_both(self):
+        self.write_yaml(SOURCE_YAML + "shared_flag: 1\n")
+        self.write_json({**MODEL_CONFIG, "shared_flag": 1})
+        ok, message = self.adapt(
+            target_nodes=1, auto_overrides={"shared_flag": 2}
+        )
+        self.assertTrue(ok, message)
+        self.assertEqual(self.load_output_yaml(8)["shared_flag"], 2)
+        self.assertEqual(self.load_output_json(8)["shared_flag"], 2)
+
+    def test_unknown_key_is_added_to_yaml(self):
+        ok, message = self.adapt(
+            target_nodes=1, auto_overrides={"brand_new_field": 7}
+        )
+        self.assertTrue(ok, message)
+        self.assertEqual(self.load_output_yaml(8)["brand_new_field"], 7)
+        self.assertNotIn("brand_new_field", self.load_output_json(8))
+
+    def test_new_model_config_field_needs_explicit_prefix(self):
+        ok, message = self.adapt(
+            target_nodes=1, json_overrides={"brand_new_field": 7}
+        )
+        self.assertTrue(ok, message)
+        self.assertEqual(self.load_output_json(8)["brand_new_field"], 7)
+        self.assertNotIn("brand_new_field", self.load_output_yaml(8))
+
+
+class TestErrorPaths(ConfigAdapterTestBase):
+    """Failure branches of the adapter."""
+
+    def test_empty_yaml_is_refused(self):
+        self.write_yaml("")
+        ok, message = self.adapt(target_nodes=1)
+        self.assertFalse(ok)
+        self.assertIn("配置文件为空", message)
+
+    def test_json_override_without_a_model_config(self):
+        self.write_yaml(SOURCE_YAML.replace("./model_dir", "./nope"))
+        ok, message = self.adapt(
+            target_nodes=1, json_overrides={"n_routed_experts": 32}
+        )
+        self.assertFalse(ok)
+        self.assertIn("--set json:", message)
+
+    def test_shrink_without_a_model_config(self):
+        self.write_yaml(SOURCE_YAML.replace("./model_dir", "./nope"))
+        ok, message = self.adapt(target_nodes=1)
+        self.assertFalse(ok)
+        self.assertIn("model_config.json", message)
+
+    def test_unknown_source_scale_is_refused(self):
+        # global_batch_size is present but nothing lets us infer the scale.
+        self.write_yaml(
+            SOURCE_YAML.replace("sharding_parallel_size: 96", "").replace(
+                "gradient_accumulation_steps: 2", ""
+            )
+        )
+        ok, message = self.adapt(target_nodes=1)
+        self.assertFalse(ok)
+        self.assertIn("无法推断源作业的卡数", message)
+
+    def test_pp_only_shrink_for_a_dense_model(self):
+        # EP=1 (no expert parallelism) leaves PP as the only axis to shrink,
+        # and 4 cards cannot host PP=8 (C1).
+        self.write_yaml(
+            SOURCE_YAML.replace(
+                "expert_model_parallel_size: 64",
+                "expert_model_parallel_size: 1",
+            )
+        )
+        ok, message = self.adapt(
+            target_nodes=1, cards_per_node=4, test_accuracy=True
+        )
+        self.assertTrue(ok, message)
+        config = self.load_output_yaml(4)
+        self.assertEqual(config["pipeline_model_parallel_size"], 4)
+        self.assertEqual(config["expert_model_parallel_size"], 1)
+        self.assertEqual(self.load_output_json(4)["num_hidden_layers"], 32)
+        self.assertIn("仅缩 PP", message)
+
+    def test_missing_layer_count_blocks_pp_shrink(self):
+        self.write_json(
+            {k: v for k, v in MODEL_CONFIG.items() if k != "num_hidden_layers"}
+        )
+        self.write_yaml(
+            SOURCE_YAML.replace(
+                "expert_model_parallel_size: 64",
+                "expert_model_parallel_size: 1",
+            )
+        )
+        ok, message = self.adapt(target_nodes=1, cards_per_node=4)
+        self.assertFalse(ok)
+        self.assertIn("num_hidden_layers", message)
+
+
+class TestCliErrorPaths(ConfigAdapterTestBase):
+    """Argument validation, straight through main()."""
+
+    def _run(self, argv):
+        buffer, err = io.StringIO(), io.StringIO()
+        with (
+            contextlib.redirect_stdout(buffer),
+            contextlib.redirect_stderr(err),
+        ):
+            code = main(argv)
+        return code, buffer.getvalue() + err.getvalue()
+
+    def test_missing_input_file(self):
+        code, out = self._run(["--input", str(self.root / "nope.yaml")])
+        self.assertEqual(code, 1)
+        self.assertIn("输入文件不存在", out)
+
+    def test_non_positive_cards_per_node(self):
+        code, out = self._run(
+            ["--input", str(self.yaml_path), "--cards-per-node", "0"]
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("cards-per-node", out)
+
+    def test_non_positive_target_nodes(self):
+        code, out = self._run(
+            ["--input", str(self.yaml_path), "--target-nodes", "0"]
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("target-nodes", out)
+
+    def test_malformed_set(self):
+        code, out = self._run(
+            [
+                "--input",
+                str(self.yaml_path),
+                "--target-nodes",
+                "1",
+                "--set",
+                "json:",
+            ]
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("--set", out)
+
+    def test_adaptation_failure_is_reported(self):
+        code, out = self._run(
+            [
+                "--input",
+                str(self.yaml_path),
+                "--target-nodes",
+                "1",
+                "--test-performance",
+                "--output-dir",
+                str(self.output_dir),
+            ]
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("适配失败", out)
+
+    def test_python_m_entry_point(self):
+        # `python -m paddlefleet.config_adapter` must reach the same main().
+        argv = ["paddlefleet.config_adapter", "--input", str(self.yaml_path)]
+        buffer = io.StringIO()
+        with (
+            mock.patch.object(sys, "argv", argv),
+            contextlib.redirect_stdout(buffer),
+            self.assertRaises(SystemExit) as ctx,
+        ):
+            runpy.run_module("paddlefleet.config_adapter", run_name="__main__")
+        self.assertEqual(ctx.exception.code, 0)
+        self.assertIn("VALID_NODES=", buffer.getvalue())
+
+
+class TestLayerFields(ConfigAdapterTestBase):
+    """Per-layer lists must follow num_hidden_layers, or the shrink is refused."""
+
+    def _with_layer_fields(self, ratios):
+        """Source JSON carrying per-layer lists consistent with 64 layers."""
+        self.write_json(
+            {
+                **MODEL_CONFIG,
+                "csa_compress_ratios": [*ratios, -2],  # 64 layers + 1 MTP
+                "window_attn_skip_freq": [0] * 65,
+                "layer_types": ["full_attention"] * 64,
+            }
+        )
+
+    def test_lists_are_truncated_with_the_layer_count(self):
+        self._with_layer_fields([128, 128, 128, -2] * 16)
+        ok, message = self.adapt(target_nodes=1)
+        self.assertTrue(ok, message)
+        model_config = self.load_output_json(8)
+        # 64 -> 16 layers, MTP entries kept at the tail.
+        self.assertEqual(model_config["num_hidden_layers"], 16)
+        self.assertEqual(len(model_config["csa_compress_ratios"]), 17)
+        self.assertEqual(model_config["csa_compress_ratios"][-1], -2)
+        self.assertEqual(len(model_config["window_attn_skip_freq"]), 17)
+        self.assertEqual(len(model_config["layer_types"]), 16)
+        # Both attention families of the source pattern survive.
+        self.assertIn(128, model_config["csa_compress_ratios"][:16])
+        self.assertIn(-2, model_config["csa_compress_ratios"][:16])
+        self.assertIn("逐层配置", message)
+
+    def test_refuses_when_an_attention_family_would_vanish(self):
+        # Every -2 layer sits beyond the shrunk layer range.
+        self._with_layer_fields([128] * 60 + [-2] * 4)
+        ok, message = self.adapt(target_nodes=1)
+        self.assertFalse(ok)
+        self.assertIn("丢掉注意力类型", message)
+
+    def test_refuses_when_the_source_lists_are_inconsistent(self):
+        self.write_json({**MODEL_CONFIG, "csa_compress_ratios": [128] * 10})
+        ok, message = self.adapt(target_nodes=1)
+        self.assertFalse(ok)
+        self.assertIn("不自洽", message)
+
+    def test_scalar_forms_are_left_alone(self):
+        self.write_json({**MODEL_CONFIG, "window_attn_skip_freq": 4})
+        ok, message = self.adapt(target_nodes=1)
+        self.assertTrue(ok, message)
+        self.assertEqual(self.load_output_json(8)["window_attn_skip_freq"], 4)
+
+    def test_mtp_num_layers_alias_wins_over_a_zero(self):
+        # The framework resolves the MTP count as
+        # `mtp_num_layers or num_nextn_predict_layers`, so a zero in the
+        # second key must not hide a valid value in the first.
+        self.write_json(
+            {
+                **MODEL_CONFIG,
+                "num_nextn_predict_layers": 0,
+                "mtp_num_layers": 2,
+                "csa_compress_ratios": [128, 128, 128, -2] * 16 + [-2, -2],
+                "layer_types": ["full_attention"] * 64,
+            }
+        )
+        ok, message = self.adapt(target_nodes=1)
+        self.assertTrue(ok, message)
+        model_config = self.load_output_json(8)
+        self.assertEqual(model_config["num_hidden_layers"], 16)
+        # 16 layers + the 2 MTP entries.
+        self.assertEqual(len(model_config["csa_compress_ratios"]), 18)
+        self.assertEqual(len(model_config["layer_types"]), 16)
+
+
+class TestFailureLeavesSourcesUntouched(ConfigAdapterTestBase):
+    """Nothing is written until every check has passed."""
+
+    def test_batch_failure_does_not_touch_either_source(self):
+        # 1537 * 8 / 768 is not an integer, so batch scaling fails *after*
+        # the model structure has been planned.
+        self.write_yaml(
+            SOURCE_YAML.replace(
+                "global_batch_size: 1536", "global_batch_size: 1537"
+            )
+        )
+        ok, message = self.adapt(target_nodes=1, in_place=True)
+        self.assertFalse(ok)
+        self.assertIn("无法整除", message)
+        # Source model_config.json keeps its original structure ...
+        source_json = JsonWriter().load(self.json_path)
+        self.assertEqual(source_json["num_hidden_layers"], 64)
+        self.assertEqual(source_json["n_routed_experts"], 256)
+        # ... and the YAML still declares the original parallelism.
+        config = YamlWriter().load(self.yaml_path)
+        self.assertEqual(config["pipeline_model_parallel_size"], 8)
+        self.assertEqual(config["expert_model_parallel_size"], 64)
+
+    def test_no_adapted_dir_is_created_on_failure(self):
+        self.write_yaml(
+            SOURCE_YAML.replace(
+                "global_batch_size: 1536", "global_batch_size: 1537"
+            )
+        )
+        ok, _message = self.adapt(target_nodes=1)
+        self.assertFalse(ok)
+        self.assertFalse((self.output_dir / "model_config_separated").exists())
+
+
+class TestPinnedModelPathConflict(ConfigAdapterTestBase):
+    """A pinned model_name_or_path cannot coexist with a JSON rewrite."""
+
+    def test_pinning_the_path_is_rejected(self):
+        ok, message = self.adapt(
+            target_nodes=1,
+            yaml_overrides={"model_name_or_path": "./model_dir"},
+        )
+        self.assertFalse(ok)
+        self.assertIn("model_name_or_path", message)
+        self.assertIn("--in-place", message)
+
+    def test_in_place_accepts_a_pinned_path(self):
+        ok, message = self.adapt(
+            target_nodes=1,
+            in_place=True,
+            yaml_overrides={"model_name_or_path": "./model_dir"},
+        )
+        self.assertTrue(ok, message)
+        config = YamlWriter().load(self.yaml_path)
+        self.assertEqual(config["model_name_or_path"], "./model_dir")
+        self.assertEqual(
+            JsonWriter().load(self.json_path)["num_hidden_layers"], 16
+        )
+
+
+class TestInPlace(ConfigAdapterTestBase):
+    """In-place rewrites both sources and keeps model_name_or_path."""
+
+    def test_rewrites_sources_without_a_banner(self):
+        ok, message = self.adapt(
+            target_nodes=1, test_accuracy=True, in_place=True
+        )
+        self.assertTrue(ok, message)
+        config = YamlWriter().load(self.yaml_path)
+        self.assertEqual(config["pipeline_model_parallel_size"], 2)
+        self.assertEqual(config["model_name_or_path"], "./model_dir")
+        self.assertNotIn(
+            "[config_adapter]", self.yaml_path.read_text(encoding="utf-8")
+        )
+        self.assertEqual(
+            JsonWriter().load(self.json_path)["num_hidden_layers"], 16
+        )
+
+
+class TestGeneratedPaths(ConfigAdapterTestBase):
+    """model_name_or_path must stay resolvable."""
+
+    def test_absolute_when_output_escapes_the_yaml_dir(self):
+        outside = Path(tempfile.mkdtemp())
+        try:
+            ok, message = self.adapt(target_nodes=1, output_dir=outside)
+            self.assertTrue(ok, message)
+            path = YamlWriter().load(outside / "source_adapted_8cards.yaml")[
+                "model_name_or_path"
+            ]
+            self.assertTrue(Path(path).is_absolute(), path)
+            self.assertTrue(Path(path, "model_config.json").is_file())
+        finally:
+            shutil.rmtree(outside, ignore_errors=True)
+
+
+class TestInspection(ConfigAdapterTestBase):
+    """No target scale: report the source scale and legal node counts."""
+
+    def test_reports_source_scale_and_valid_nodes(self):
+        orig_cards, orig_nodes, valid_nodes = inspect_config(
+            self.yaml_path, cards_per_node=8
+        )
+        self.assertEqual(orig_cards, 768)
+        self.assertEqual(orig_nodes, 96)
+        self.assertEqual(valid_nodes, [64])
+
+
+class TestCli(ConfigAdapterTestBase):
+    """End-to-end checks through the argv entry point."""
+
+    def _run(self, argv):
+        """Run the CLI, returning ``(exit_code, stdout)``."""
+        buffer = io.StringIO()
+        with (
+            contextlib.redirect_stdout(buffer),
+            contextlib.redirect_stderr(io.StringIO()),
+        ):
+            code = main(argv)
+        return code, buffer.getvalue()
+
+    def test_target_without_any_switch_still_adapts(self):
+        code, out = self._run(
+            [
+                "--input",
+                str(self.yaml_path),
+                "--target-nodes",
+                "1",
+                "--output-dir",
+                str(self.output_dir),
+            ]
+        )
+        self.assertEqual(code, 0, out)
+        self.assertIn("未指定测试维度", out)
+
+    def test_both_switches_accepted(self):
+        code, out = self._run(
+            [
+                "--input",
+                str(self.yaml_path),
+                "--target-nodes",
+                "64",
+                "--test-performance",
+                "--test-accuracy",
+                "--output-dir",
+                str(self.output_dir),
+            ]
+        )
+        self.assertEqual(code, 0, out)
+        self.assertIn("performance+accuracy", out)
+
+    def test_inspection_output_is_machine_readable(self):
+        code, out = self._run(["--input", str(self.yaml_path)])
+        self.assertEqual(code, 0)
+        self.assertIn("ORIGINAL_CARDS=768", out)
+        self.assertIn("VALID_NODES=64", out)
+
+    def test_in_place_writes_a_patch(self):
+        code, out = self._run(
+            [
+                "--input",
+                str(self.yaml_path),
+                "--target-nodes",
+                "1",
+                "--test-accuracy",
+                "--in-place",
+            ]
+        )
+        self.assertEqual(code, 0, out)
+        patch = self.yaml_path.parent / (self.yaml_path.name + ".patch")
+        self.assertTrue(patch.is_file())
+        text = patch.read_text(encoding="utf-8")
+        self.assertIn("pipeline_model_parallel_size", text)
+        self.assertIn("model_config.json", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/config_adapter/test_config_adapter.py
+++ b/tests/single_card_tests/config_adapter/test_config_adapter.py
@@ -1028,6 +1028,15 @@ class TestPinnedFieldRejection(ConfigAdapterTestBase):
         self.assertIn("expert_model_parallel_size", message)
         self.assertIn("不能用 --set 锁定", message)
 
+    def test_pinning_a_parallel_dim_with_a_json_prefix_is_refused(self):
+        ok, message = self.adapt(
+            target_nodes=1,
+            json_overrides={"expert_model_parallel_size": 64},
+        )
+        self.assertFalse(ok)
+        self.assertIn("expert_model_parallel_size", message)
+        self.assertIn("不能用 --set 锁定", message)
+
     def test_pinning_a_parallel_dim_is_refused(self):
         ok, message = self.adapt(
             target_nodes=1,

--- a/tests/single_card_tests/config_adapter/test_config_adapter.py
+++ b/tests/single_card_tests/config_adapter/test_config_adapter.py
@@ -1254,18 +1254,16 @@ class TestPinnedModelPathConflict(ConfigAdapterTestBase):
         self.assertIn("model_name_or_path", message)
         self.assertIn("--set", message)
 
-    def test_in_place_accepts_a_pinned_path(self):
-        ok, message = self.adapt(
-            target_nodes=1,
-            in_place=True,
-            yaml_overrides={"model_name_or_path": "./model_dir"},
-        )
-        self.assertTrue(ok, message)
-        config = YamlWriter().load(self.yaml_path)
-        self.assertEqual(config["model_name_or_path"], "./model_dir")
-        self.assertEqual(
-            JsonWriter().load(self.json_path)["num_hidden_layers"], 16
-        )
+    def test_in_place_also_refuses_a_pinned_path(self):
+        # Repointing the model dir would decide which model_config.json gets
+        # loaded, shrunk and snapshotted for the patch.
+        for overrides in (
+            {"yaml_overrides": {"model_name_or_path": "./other_model"}},
+            {"auto_overrides": {"model_name_or_path": "./other_model"}},
+        ):
+            ok, message = self.adapt(target_nodes=1, in_place=True, **overrides)
+            self.assertFalse(ok)
+            self.assertIn("model_name_or_path", message)
 
 
 class TestInPlace(ConfigAdapterTestBase):

--- a/tests/single_card_tests/config_adapter/test_config_adapter.py
+++ b/tests/single_card_tests/config_adapter/test_config_adapter.py
@@ -365,6 +365,15 @@ class TestTopologyConstraints(unittest.TestCase):
         self.assertFalse(ok)
         self.assertIn("C5", msg)
 
+    def test_no_suggestions_for_dim_only_conflicts(self):
+        validator = TopologyValidator(8, 8)
+        # C3 and C5 depend only on the dims, so no card count can help.
+        self.assertEqual(validator.suggest_valid_cards(1, 1, 2, 1, 4), [])
+        self.assertEqual(validator.suggest_valid_cards(1, 1, 1, 2, 2), [])
+        _ok, msg, _d = validator.validate(1, 1, 2, 1, 4)
+        self.assertIn("没有任何卡数能满足", msg)
+        self.assertNotIn("合法节点数", msg)
+
     def test_suggestions_are_multiples_of_the_minimum_unit(self):
         cards = TopologyValidator(8, 8).suggest_valid_cards(1, 2, 8, 1, 1)
         self.assertTrue(all(c % 16 == 0 for c in cards), cards)
@@ -478,6 +487,22 @@ class TestSourceScaleInference(unittest.TestCase):
         )
         self.assertIsNone(err)
         self.assertEqual(cards, 8)
+
+    def test_batch_evidence_wins_when_dp_is_not_declared(self):
+        # sharding=4 without data_parallel_size, but the batch fields say 8:
+        # the comm-group formula is the one missing a factor.
+        cards, warning, err = ConfigAdapter._infer_orig_cards(
+            self._source(
+                sharding_parallel_size=4,
+                data_parallel_size=None,
+                global_batch_size=8,
+                gradient_accumulation_steps=1,
+            ),
+            (1, 1, 1, 1, 1),
+        )
+        self.assertIsNone(err)
+        self.assertEqual(cards, 8)
+        self.assertIn("未声明 data_parallel_size", warning)
 
     def test_mismatch_is_surfaced_as_a_warning(self):
         cards, warning, err = ConfigAdapter._infer_orig_cards(
@@ -993,6 +1018,15 @@ class TestErrorPaths(ConfigAdapterTestBase):
 
 class TestPinnedFieldRejection(ConfigAdapterTestBase):
     """Adapter-controlled fields may not be pinned with --set."""
+
+    def test_pinning_a_parallel_dim_without_a_prefix_is_refused(self):
+        ok, message = self.adapt(
+            target_nodes=1,
+            auto_overrides={"expert_model_parallel_size": 64},
+        )
+        self.assertFalse(ok)
+        self.assertIn("expert_model_parallel_size", message)
+        self.assertIn("不能用 --set 锁定", message)
 
     def test_pinning_a_parallel_dim_is_refused(self):
         ok, message = self.adapt(

--- a/tests/single_card_tests/config_adapter/test_config_adapter.py
+++ b/tests/single_card_tests/config_adapter/test_config_adapter.py
@@ -80,7 +80,7 @@ num_empty_layers_add_in_head: 0
 num_empty_layers_add_in_tail: 0
 separate_mtp_headloss: false
 fa_version: 3
-global_batch_size: 1536
+global_batch_size: 192
 per_device_train_batch_size: 1
 gradient_accumulation_steps: 2
 sharding_parallel_size: 96
@@ -201,8 +201,9 @@ class TestCandidates(unittest.TestCase):
         self.assertEqual(pp_candidates(2), [])
 
     def test_ep_candidates_respect_tp(self):
-        # C3 requires ep_new % tp == 0.
+        # C3 requires ep_new % (tp * sep) == 0.
         self.assertTrue(all(c % 4 == 0 for c in ep_candidates(64, tp=4)))
+        self.assertTrue(all(c % 8 == 0 for c in ep_candidates(64, tp=2, sep=4)))
 
 
 class TestPrecisionSwitches(unittest.TestCase):
@@ -353,6 +354,17 @@ class TestTopologyConstraints(unittest.TestCase):
         self.assertFalse(ok)
         self.assertIn("C4", msg)
 
+    def test_c3_accounts_for_sep(self):
+        # dense_sharding = EP / (TP * SEP) = 2 / 4 is not a positive integer.
+        ok, msg, _d = TopologyValidator(8, 8).validate(1, 1, 2, 1, 4)
+        self.assertFalse(ok)
+        self.assertIn("C3", msg)
+
+    def test_c5_forbids_sep_and_cp_together(self):
+        ok, msg, _d = TopologyValidator(8, 8).validate(1, 1, 1, 2, 2)
+        self.assertFalse(ok)
+        self.assertIn("C5", msg)
+
     def test_suggestions_are_multiples_of_the_minimum_unit(self):
         cards = TopologyValidator(8, 8).suggest_valid_cards(1, 2, 8, 1, 1)
         self.assertTrue(all(c % 16 == 0 for c in cards), cards)
@@ -429,6 +441,70 @@ class TestHardwareAndModelConstraints(unittest.TestCase):
 
     def test_align_layers_refuses_pp_below_the_floor(self):
         self.assertEqual(align_layers(16, 0, 0, 1, 2), (None, None))
+
+
+class TestSourceScaleInference(unittest.TestCase):
+    """The source world size, and how the two estimates are combined."""
+
+    def _source(self, **overrides):
+        base = {
+            "sharding_parallel_size": 96,
+            "data_parallel_size": 1,
+            "global_batch_size": 192,
+            "per_device_train_batch_size": 1,
+            "gradient_accumulation_steps": 2,
+        }
+        base.update(overrides)
+        return base
+
+    def test_consistent_estimates_agree_without_a_warning(self):
+        cards, warning, err = ConfigAdapter._infer_orig_cards(
+            self._source(), (1, 8, 64, 1, 1)
+        )
+        self.assertIsNone(err)
+        self.assertIsNone(warning)
+        self.assertEqual(cards, 768)
+
+    def test_data_parallel_size_multiplies_the_group_estimate(self):
+        # 8 cards with sharding=4 and DP=2: sharding alone would say 4.
+        cards, _warning, err = ConfigAdapter._infer_orig_cards(
+            self._source(
+                sharding_parallel_size=4,
+                data_parallel_size=2,
+                global_batch_size=8,
+                gradient_accumulation_steps=1,
+            ),
+            (1, 1, 1, 1, 1),
+        )
+        self.assertIsNone(err)
+        self.assertEqual(cards, 8)
+
+    def test_mismatch_is_surfaced_as_a_warning(self):
+        cards, warning, err = ConfigAdapter._infer_orig_cards(
+            self._source(global_batch_size=8, gradient_accumulation_steps=1),
+            (1, 1, 1, 1, 1),
+        )
+        self.assertIsNone(err)
+        self.assertEqual(cards, 96)
+        self.assertIn("两种推断不一致", warning)
+
+    def test_batch_only_source(self):
+        cards, _warning, err = ConfigAdapter._infer_orig_cards(
+            self._source(sharding_parallel_size=None), (1, 8, 1, 1, 1)
+        )
+        self.assertIsNone(err)
+        self.assertEqual(cards, 768)
+
+    def test_nothing_to_infer_from(self):
+        cards, _warning, err = ConfigAdapter._infer_orig_cards(
+            self._source(
+                sharding_parallel_size=None,
+                gradient_accumulation_steps=None,
+            ),
+            (1, 1, 1, 1, 1),
+        )
+        self.assertIsNone(cards)
+        self.assertIn("无法推断源作业的卡数", err)
 
 
 class TestFieldSpec(unittest.TestCase):
@@ -672,7 +748,7 @@ class TestDefaultAdaptation(ConfigAdapterTestBase):
         self.assertEqual(model_config["n_routed_experts"], 16)
         self.assertEqual(model_config["num_hidden_layers"], 16)
         # Default batch strategy shrinks GBS and leaves acc alone.
-        self.assertEqual(config["global_batch_size"], 16)
+        self.assertEqual(config["global_batch_size"], 2)
         self.assertEqual(config["gradient_accumulation_steps"], 2)
         # No determinism switches unless --test-accuracy is given.
         self.assertEqual(config["csa_sparse_attn_backend"], "cudnn")
@@ -707,7 +783,7 @@ class TestPerformanceSwitch(ConfigAdapterTestBase):
         ok, message = self.adapt(target_nodes=64, test_performance=True)
         self.assertTrue(ok, message)
         config = self.load_output_yaml(512)
-        self.assertEqual(config["global_batch_size"], 1024)
+        self.assertEqual(config["global_batch_size"], 128)
         self.assertEqual(config["gradient_accumulation_steps"], 2)
         self.assertEqual(config["sharding_parallel_size"], 64)
         self.assertEqual(config["expert_model_parallel_size"], 64)
@@ -735,7 +811,7 @@ class TestAccuracySwitch(ConfigAdapterTestBase):
         ok, message = self.adapt(target_nodes=1, test_accuracy=True)
         self.assertTrue(ok, message)
         config = self.load_output_yaml(8)
-        self.assertEqual(config["global_batch_size"], 1536)
+        self.assertEqual(config["global_batch_size"], 192)
         self.assertEqual(config["gradient_accumulation_steps"], 192)
         self.assertEqual(config["csa_sparse_attn_backend"], "tilelang")
         self.assertIsNone(self.load_output_json(8)["multimax_modules"])
@@ -750,7 +826,7 @@ class TestAccuracySwitch(ConfigAdapterTestBase):
         # Frozen dims and acc, but the determinism switches still land.
         self.assertEqual(config["expert_model_parallel_size"], 64)
         self.assertEqual(config["gradient_accumulation_steps"], 2)
-        self.assertEqual(config["global_batch_size"], 1024)
+        self.assertEqual(config["global_batch_size"], 128)
         self.assertEqual(config["csa_sparse_attn_backend"], "tilelang")
         self.assertIsNone(self.load_output_json(512)["multimax_modules"])
 
@@ -915,6 +991,44 @@ class TestErrorPaths(ConfigAdapterTestBase):
         self.assertIn("num_hidden_layers", message)
 
 
+class TestPinnedFieldRejection(ConfigAdapterTestBase):
+    """Adapter-controlled fields may not be pinned with --set."""
+
+    def test_pinning_a_parallel_dim_is_refused(self):
+        ok, message = self.adapt(
+            target_nodes=1,
+            yaml_overrides={"expert_model_parallel_size": 64},
+        )
+        self.assertFalse(ok)
+        self.assertIn("expert_model_parallel_size", message)
+        self.assertIn("不能用 --set 锁定", message)
+
+    def test_pinning_sharding_is_refused(self):
+        ok, message = self.adapt(
+            target_nodes=1, yaml_overrides={"sharding_parallel_size": 3}
+        )
+        self.assertFalse(ok)
+        self.assertIn("sharding_parallel_size", message)
+
+    def test_in_place_still_refuses_parallel_dims(self):
+        ok, message = self.adapt(
+            target_nodes=1,
+            in_place=True,
+            yaml_overrides={"pipeline_model_parallel_size": 8},
+        )
+        self.assertFalse(ok)
+        self.assertIn("pipeline_model_parallel_size", message)
+
+    def test_pinned_fa_version_is_kept(self):
+        ok, message = self.adapt(
+            target_nodes=1, yaml_overrides={"fa_version": 4}
+        )
+        self.assertTrue(ok, message)
+        # The pin wins: the field is neither deleted nor reported as deleted.
+        self.assertEqual(self.load_output_yaml(8)["fa_version"], 4)
+        self.assertNotIn("DELETE field=fa_version", message)
+
+
 class TestCliErrorPaths(ConfigAdapterTestBase):
     """Argument validation, straight through main()."""
 
@@ -1068,7 +1182,7 @@ class TestFailureLeavesSourcesUntouched(ConfigAdapterTestBase):
         # the model structure has been planned.
         self.write_yaml(
             SOURCE_YAML.replace(
-                "global_batch_size: 1536", "global_batch_size: 1537"
+                "global_batch_size: 192", "global_batch_size: 193"
             )
         )
         ok, message = self.adapt(target_nodes=1, in_place=True)
@@ -1086,7 +1200,7 @@ class TestFailureLeavesSourcesUntouched(ConfigAdapterTestBase):
     def test_no_adapted_dir_is_created_on_failure(self):
         self.write_yaml(
             SOURCE_YAML.replace(
-                "global_batch_size: 1536", "global_batch_size: 1537"
+                "global_batch_size: 192", "global_batch_size: 193"
             )
         )
         ok, _message = self.adapt(target_nodes=1)
@@ -1104,7 +1218,7 @@ class TestPinnedModelPathConflict(ConfigAdapterTestBase):
         )
         self.assertFalse(ok)
         self.assertIn("model_name_or_path", message)
-        self.assertIn("--in-place", message)
+        self.assertIn("--set", message)
 
     def test_in_place_accepts_a_pinned_path(self):
         ok, message = self.adapt(


### PR DESCRIPTION
### PR Category
User Experience

### PR Types
New features

### Description
Cherry-pick of #1757 onto release/0.4.

Merged in dev: #1757

Adds `paddlefleet.config_adapter`, a CLI that rewrites a large-cluster training YAML so it runs on a smaller machine scale, and explains every field it touched.

Two orthogonal, optional test dimensions:

- `--test-performance`: freezes TP/PP/EP/CP/SEP and `gradient_accumulation_steps`, so only `sharding` and `global_batch_size` move and the step time stays comparable with the full-scale job.
- `--test-accuracy`: pins the determinism switches (`csa_sparse_attn_backend` / `csa_indexer_backend` to `tilelang`, `multimax_modules` off) so a loss comparison does not aadiff, and keeps the effective batch by raising `acc`.

With neither switch the adapter just makes the config fit: it shrinks EP/PP as little as possible (Case A < EP-only < PP-only < joint) and rewrites a **separate copy** of `model_config.json` — routed experts, `num_hidden_layers`, VPP / empty tail layers and every per-layer list (`csa_compress_ratios`, `window_attn_skip_freq`, `layer_types`, list-form `moe_layer_freq`). A degree that is greater than 1 in the source is never collapsed to 1, and TP / SEP are never shrunk.

All planning happens in memory; the first filesystem write comes after every check has passed, writes go through a temp file plus atomic rename, and an in-place JSON write is rolled back if the YAML write then fails. `--set` takes an optional `yaml:` / `json:` prefix; without one the target document is picked by scanning both files.

`ruamel.yaml` becomes a runtime dependency (one line in `[project.dependencies]`) because rewriting a training YAML must preserve comments and key order.

Tests: `tests/single_card_tests/config_adapter/test_config_adapter.py`, 106 pure-Python cases (no device needed), 95% statement+branch coverage of the new package.

### 是否引起精度变化
否。新增的独立命令行工具，不参与训练执行路径，不改动任何现有模块。
