### PR TITLE
[Distributed Strategy] Fix QB histogram all-reduce: drop redundant CP reduce, use int64

### DIFF
--- a/src/paddlefleet/transformer/moe/qb_callback.py
+++ b/src/paddlefleet/transformer/moe/qb_callback.py
@@ -37,23 +37,27 @@ import paddle.distributed as dist
 
 
 def _try_get_comm_groups():
-    """Get the (tp, cp, dp, sharding) groups to all-reduce the QB histogram over.
+    """Get the (tp, dp, sharding) groups to all-reduce the QB histogram over.
 
     These are the groups whose ranks route a *different* set of tokens, so their
     histograms must be summed to recover global-batch statistics. EP is absent
     because all EP ranks see the same router scores.
 
+    CP is deliberately NOT reduced separately: in Paddle's EPHybridCommunicateGroup
+    the context-parallel group is a contiguous sub-slice of the sharding comm list
+    (sharding = cp x cp_sharding, see split_context_comm_list), i.e. CP ranks are a
+    subset of the sharding group. The sharding all-reduce below therefore already
+    sums over the CP dimension; reducing over CP again would double-count it.
+
     A group is None when the reduction does not apply: distributed training is
-    not initialized, the group does not exist (e.g. CP is off), or it is a single
-    rank. TP is additionally guarded at the call site (only needed under SP with
-    EP > 1, where moe_layer skips the AllGather).
+    not initialized, the group does not exist, or it is a single rank. TP is
+    additionally guarded at the call site (only needed under SP with EP > 1,
+    where moe_layer skips the AllGather).
     """
     from paddle.distributed import fleet
 
-    from paddlefleet.parallel_state import get_context_parallel_group
-
     if not dist.is_initialized():
-        return None, None, None, None
+        return None, None, None
 
     hcg = fleet.get_hybrid_communicate_group()
 
@@ -63,9 +67,8 @@ def _try_get_comm_groups():
     tp_group = _needs_reduce(hcg.get_model_parallel_group())
     dp_group = _needs_reduce(hcg.get_data_parallel_group())
     sd_group = _needs_reduce(hcg.get_sharding_parallel_group())
-    cp_group = _needs_reduce(get_context_parallel_group())
 
-    return tp_group, cp_group, dp_group, sd_group
+    return tp_group, dp_group, sd_group
 
 
 class MoEQuantileBalancingCallback:
@@ -102,16 +105,12 @@ class MoEQuantileBalancingCallback:
             return
 
         # Determine communication groups
-        tp_group, cp_group, dp_group, sd_group = _try_get_comm_groups()
+        tp_group, dp_group, sd_group = _try_get_comm_groups()
 
         for layer in layers:
-            self._update_single_layer(
-                layer, tp_group, cp_group, dp_group, sd_group
-            )
+            self._update_single_layer(layer, tp_group, dp_group, sd_group)
 
-    def _update_single_layer(
-        self, layer, tp_group, cp_group, dp_group, sd_group
-    ):
+    def _update_single_layer(self, layer, tp_group, dp_group, sd_group):
         """Run QB recovery for a single router layer."""
         histogram = layer.qb_histogram  # [E, B], int32
         E, B = histogram.shape
@@ -119,20 +118,23 @@ class MoEQuantileBalancingCallback:
         n = layer.num_experts
 
         # --- Step 1: All-reduce histogram across all ranks that see different tokens ---
-        hist_float = histogram.cast(paddle.float32)
+        # NOTE: CP is not reduced here. In Paddle's EPHybridCommunicateGroup the CP
+        # group is a sub-slice of the sharding group, so the sharding all-reduce
+        # already covers the CP dimension. Reducing CP again would double-count.
+        # int64 (not fp32) is used for the reduction: it is exact for integer
+        # counts (fp32 loses precision above 2**24) and avoids int32 overflow when
+        # summing counts across ranks. all_reduce supports int64 on NCCL.
+        hist_global = histogram.cast(paddle.int64)  # [E, B]
         if (
             tp_group is not None
             and layer.config.sequence_parallel
             and layer.config.expert_model_parallel_size > 1
         ):
-            dist.all_reduce(hist_float, group=tp_group)
-        if cp_group is not None:
-            dist.all_reduce(hist_float, group=cp_group)
+            dist.all_reduce(hist_global, group=tp_group)
         if dp_group is not None:
-            dist.all_reduce(hist_float, group=dp_group)
+            dist.all_reduce(hist_global, group=dp_group)
         if sd_group is not None:
-            dist.all_reduce(hist_float, group=sd_group)
-        hist_global = hist_float.cast(paddle.int64)  # [E, B]
+            dist.all_reduce(hist_global, group=sd_group)
 
         # --- Step 2: Compute total token count and target quantile ---
         total_per_expert = hist_global.sum(axis=1)  # [E]

--- a/tests/multi_card_tests/moe/test_qb_callback_cp_sharding.py
+++ b/tests/multi_card_tests/moe/test_qb_callback_cp_sharding.py
@@ -1,0 +1,307 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Multi-card tests for the QB callback's histogram all-reduce.
+
+Covers the two claims the single-card tests can only assert against a mocked
+``dist.all_reduce``:
+
+1. ``hcg.get_sharding_parallel_group()`` really does cover the context-parallel
+   dimension, so the removed CP reduce is redundant rather than missing.
+2. The int64 all-reduce works on the real NCCL backend and each rank's
+   histogram is counted exactly once (no CP double-counting).
+
+Topology (8 GPUs): mp=2, sharding=4, cp=2 (nested in sharding), ep=8.
+`EPHybridCommunicateGroup` requires dp=sep=1 and ep*moe_sharding == mp*sharding,
+so this is the smallest topology that still gives a non-trivial TP group, a
+sharding group strictly larger than the CP group, and
+``tp_size * sharding_size == world_size`` — the last property means the reduced
+histogram must equal the sum over every rank.
+
+Run with:
+  python -m paddle.distributed.launch --gpus=0,1,2,3,4,5,6,7 \
+      tests/multi_card_tests/moe/test_qb_callback_cp_sharding.py
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+import numpy as np
+import paddle
+import paddle.distributed as dist
+from paddle.distributed import fleet
+
+from paddlefleet.training.initialize import initialize_fleet
+from paddlefleet.transformer.moe.qb_callback import (
+    MoEQuantileBalancingCallback,
+    _try_get_comm_groups,
+)
+
+E, B, K, N_EXPERTS = 4, 64, 2, 4
+
+_fleet_state = {"done": False, "error": None}
+
+
+def _ensure_fleet():
+    """Initialise fleet once per process; re-raise the original failure after."""
+    if _fleet_state["error"] is not None:
+        raise _fleet_state["error"]
+    if _fleet_state["done"]:
+        return
+    strategy = fleet.DistributedStrategy()
+    strategy.hybrid_configs = {
+        "dp_degree": 1,
+        "mp_degree": 2,
+        "pp_degree": 1,
+        "sharding_degree": 4,
+        "sep_degree": 1,
+        "cp_degree": 2,
+        "ep_degree": 8,
+        "moe_sharding_degree": 1,
+        "order": [
+            "sharding",
+            "moe_sharding",
+            "pp",
+            "sep",
+            "cp",
+            "dp",
+            "ep",
+            "mp",
+        ],
+    }
+    try:
+        initialize_fleet(strategy=strategy)
+    except Exception as exc:
+        _fleet_state["error"] = exc
+        raise
+    _fleet_state["done"] = True
+
+
+def _local_histogram(rank):
+    """Deterministic per-rank histogram, reproducible from the rank id alone.
+
+    Every rank can therefore reconstruct any other rank's contribution and
+    build the expected global sum without an extra collective.
+    """
+    rng = np.random.RandomState(1000 + rank)
+    return rng.randint(0, 8, (E, B)).astype(np.int32)
+
+
+def _make_layer(
+    histogram_np, sequence_parallel, ep_size, b_min=-1.0, b_max=1.0
+):
+    """Mock router layer exposing exactly what `_update_single_layer` touches."""
+    layer = MagicMock()
+    layer.qb_histogram = paddle.to_tensor(histogram_np, dtype=paddle.int32)
+    layer.num_experts_per_tok = K
+    layer.num_experts = N_EXPERTS
+    layer.qb_bin_min = paddle.to_tensor(b_min, dtype=paddle.float32)
+    layer.qb_bin_max = paddle.to_tensor(b_max, dtype=paddle.float32)
+    layer.config = MagicMock()
+    layer.config.sequence_parallel = sequence_parallel
+    layer.config.expert_model_parallel_size = ep_size
+
+    class BiasMock:
+        ndim = 1
+
+        def set_value(self, val):
+            layer._bias_value = val
+
+    layer.e_score_correction_bias = BiasMock()
+    return layer
+
+
+class _QBCommTestBase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        _ensure_fleet()
+        cls.hcg = fleet.get_hybrid_communicate_group()
+        cls.world_size = dist.get_world_size()
+        cls.rank = dist.get_rank()
+
+    def setUp(self):
+        self.tp_group, self.dp_group, self.sd_group = _try_get_comm_groups()
+        self.cp_group = self.__class__.hcg.get_context_parallel_group()
+
+    def _reference_bias(self, global_histogram):
+        """Single-rank recovery on an already-merged histogram (no collectives)."""
+        layer = _make_layer(
+            global_histogram.astype(np.int32),
+            sequence_parallel=False,
+            ep_size=1,
+        )
+        MoEQuantileBalancingCallback()._update_single_layer(
+            layer, tp_group=None, dp_group=None, sd_group=None
+        )
+        return layer._bias_value.numpy()
+
+
+class TestCommGroupTopology(_QBCommTestBase):
+    """The CP group must be a sub-slice of the sharding group."""
+
+    def test_topology_is_representative(self):
+        self.assertEqual(self.world_size, 8)
+        self.assertIsNotNone(
+            self.tp_group, "TP group missing: mp_degree>1 expected"
+        )
+        self.assertIsNotNone(self.sd_group, "sharding group missing")
+        self.assertGreater(self.cp_group.nranks, 1, "cp_degree>1 expected")
+        self.assertGreater(
+            self.sd_group.nranks,
+            self.cp_group.nranks,
+            "sharding must be strictly larger than CP for this test to be meaningful",
+        )
+
+    def test_sharding_group_covers_context_parallel(self):
+        """`get_sharding_parallel_group()` subsumes the CP ranks."""
+        sd_ranks = list(self.sd_group.ranks)
+        cp_ranks = list(self.cp_group.ranks)
+
+        self.assertTrue(
+            set(cp_ranks).issubset(set(sd_ranks)),
+            f"rank {self.rank}: cp_ranks={cp_ranks} not a subset of "
+            f"sd_ranks={sd_ranks}; the CP reduce would NOT be redundant",
+        )
+
+        # Stronger: CP is a contiguous slice of the sharding list, which is what
+        # `split_context_comm_list` builds it from.
+        start = sd_ranks.index(cp_ranks[0])
+        self.assertEqual(
+            sd_ranks[start : start + len(cp_ranks)],
+            cp_ranks,
+            f"rank {self.rank}: cp_ranks={cp_ranks} is not a contiguous slice "
+            f"of sd_ranks={sd_ranks}",
+        )
+
+    def test_tp_times_sharding_covers_world(self):
+        """Precondition used by the "counted exactly once" test below."""
+        self.assertEqual(
+            self.tp_group.nranks * self.sd_group.nranks,
+            self.world_size,
+            "TP x sharding must span every rank in this topology",
+        )
+
+
+class TestInt64AllReduce(_QBCommTestBase):
+    """Real NCCL int64 all_reduce, including counts beyond fp32's exact range."""
+
+    def test_int64_all_reduce_is_exact(self):
+        base = 2**24 + 1  # first integer fp32 cannot represent exactly
+        local = paddle.full([E, B], base + self.rank, dtype=paddle.int64)
+        dist.all_reduce(local, group=self.sd_group)
+
+        sd_ranks = list(self.sd_group.ranks)
+        expected = sum(base + r for r in sd_ranks)
+        got = local.numpy()
+
+        self.assertEqual(got.dtype, np.int64)
+        np.testing.assert_array_equal(
+            got, np.full((E, B), expected, dtype=np.int64)
+        )
+
+    def test_int64_all_reduce_overflows_int32(self):
+        """Counts whose sum exceeds int32 range survive the int64 reduction."""
+        base = 2**30  # 4 ranks x 2**30 > 2**31 - 1
+        local = paddle.full([E, B], base + self.rank, dtype=paddle.int64)
+        dist.all_reduce(local, group=self.sd_group)
+
+        expected = sum(base + r for r in self.sd_group.ranks)
+        self.assertGreater(expected, 2**31 - 1)
+        np.testing.assert_array_equal(
+            local.numpy(), np.full((E, B), expected, dtype=np.int64)
+        )
+
+
+class TestHistogramReduceCorrectness(_QBCommTestBase):
+    """End-to-end `_update_single_layer` against real collectives."""
+
+    def test_each_rank_counted_exactly_once(self):
+        """With SP+EP the tp/sharding reduces sum every rank exactly once."""
+        local = _local_histogram(self.rank)
+        layer = _make_layer(local, sequence_parallel=True, ep_size=2)
+        MoEQuantileBalancingCallback()._update_single_layer(
+            layer, self.tp_group, self.dp_group, self.sd_group
+        )
+        got = layer._bias_value.numpy()
+
+        global_once = sum(
+            _local_histogram(r).astype(np.int64) for r in range(self.world_size)
+        )
+        np.testing.assert_array_equal(got, self._reference_bias(global_once))
+
+    def test_cp_double_counting_would_change_the_result(self):
+        """Negative control: an extra CP reduce yields a different bias.
+
+        This is what makes the previous test a real check of "CP is not
+        double-counted" rather than a tautology.
+        """
+        global_once = sum(
+            _local_histogram(r).astype(np.int64) for r in range(self.world_size)
+        )
+        # An extra all_reduce over CP after the sharding reduce adds the
+        # already-merged histogram once per extra CP rank.
+        global_doubled = global_once * self.cp_group.nranks
+
+        bias_once = self._reference_bias(global_once)
+        bias_doubled = self._reference_bias(global_doubled)
+        self.assertFalse(
+            np.array_equal(bias_once, bias_doubled),
+            "CP double-counting is undetectable with this histogram; the "
+            "positive test above would be vacuous",
+        )
+
+    def test_sharding_only_reduce_matches_its_group(self):
+        """Without SP the TP reduce is skipped, so the orbit is the sharding group."""
+        local = _local_histogram(self.rank)
+        layer = _make_layer(local, sequence_parallel=False, ep_size=2)
+        MoEQuantileBalancingCallback()._update_single_layer(
+            layer, self.tp_group, self.dp_group, self.sd_group
+        )
+        got = layer._bias_value.numpy()
+
+        expected_hist = sum(
+            _local_histogram(r).astype(np.int64) for r in self.sd_group.ranks
+        )
+        np.testing.assert_array_equal(got, self._reference_bias(expected_hist))
+
+    def test_bias_is_identical_on_every_rank(self):
+        """All ranks must agree bit-for-bit, otherwise routing diverges."""
+        local = _local_histogram(self.rank)
+        layer = _make_layer(local, sequence_parallel=True, ep_size=2)
+        MoEQuantileBalancingCallback()._update_single_layer(
+            layer, self.tp_group, self.dp_group, self.sd_group
+        )
+        bias = paddle.to_tensor(layer._bias_value, dtype=paddle.float32)
+
+        gathered = []
+        dist.all_gather(gathered, bias)
+        ref = gathered[0].numpy()
+        for r, other in enumerate(gathered):
+            np.testing.assert_array_equal(
+                other.numpy(),
+                ref,
+                err_msg=f"rank {r} recovered a different QB bias",
+            )
+
+    def test_histogram_and_usage_reset_after_update(self):
+        local = _local_histogram(self.rank)
+        layer = _make_layer(local, sequence_parallel=True, ep_size=2)
+        MoEQuantileBalancingCallback()._update_single_layer(
+            layer, self.tp_group, self.dp_group, self.sd_group
+        )
+        self.assertEqual(int(layer.qb_histogram.sum().item()), 0)
+        layer.expert_usage.zero_.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/multi_card_tests/moe/test_qb_callback_cp_sharding.py
+++ b/tests/multi_card_tests/moe/test_qb_callback_cp_sharding.py
@@ -239,25 +239,54 @@ class TestHistogramReduceCorrectness(_QBCommTestBase):
         )
         np.testing.assert_array_equal(got, self._reference_bias(global_once))
 
-    def test_cp_double_counting_would_change_the_result(self):
-        """Negative control: an extra CP reduce yields a different bias.
+    def test_extra_cp_reduce_inflates_the_merged_histogram(self):
+        """Negative control, asserted on the histogram via real collectives.
 
-        This is what makes the previous test a real check of "CP is not
-        double-counted" rather than a tautology.
+        The merged histogram -- not the recovered bias -- is where CP
+        double-counting is observable. Because CP is a contiguous slice that
+        partitions the sharding group, an extra CP all-reduce inflates the
+        merged counts by exactly ``cp_nranks`` whatever the per-rank data is
+        (before the sharding reduce each ``h_j`` is counted once per rank of
+        its CP block; after it, every sharding rank already holds the same
+        value). And the QB recovery is invariant under a uniform scaling of
+        the histogram: ``q_target``, ``c`` and ``h`` all scale together, so
+        ``beta`` and ``fraction`` are unchanged. The only leak is the floor in
+        ``q_target = floor(total * k / n)``, which bites only when some expert
+        total is odd -- with every total even the bias is bit-identical. So an
+        assertion on the bias would be luck, and both of the reduces below are
+        checked against exact expected counts instead.
         """
-        global_once = sum(
+        local = _local_histogram(self.rank)
+
+        # The production reduce sequence under SP + EP: tp, then sharding.
+        merged = paddle.to_tensor(local, dtype=paddle.int64)
+        dist.all_reduce(merged, group=self.tp_group)
+        dist.all_reduce(merged, group=self.sd_group)
+
+        # tp x sharding spans the world (asserted in TestCommGroupTopology),
+        # so every rank must be counted exactly once.
+        expected = sum(
             _local_histogram(r).astype(np.int64) for r in range(self.world_size)
         )
-        # An extra all_reduce over CP after the sharding reduce adds the
-        # already-merged histogram once per extra CP rank.
-        global_doubled = global_once * self.cp_group.nranks
+        np.testing.assert_array_equal(
+            merged.numpy(),
+            expected,
+            err_msg="tp+sharding reduce did not count every rank exactly once",
+        )
 
-        bias_once = self._reference_bias(global_once)
-        bias_doubled = self._reference_bias(global_doubled)
-        self.assertFalse(
-            np.array_equal(bias_once, bias_doubled),
-            "CP double-counting is undetectable with this histogram; the "
-            "positive test above would be vacuous",
+        # The removed CP reduce would have run on top of that.
+        cp_nranks = self.cp_group.nranks
+        self.assertGreater(cp_nranks, 1, "cp_degree>1 expected")
+        doubled = merged.clone()
+        dist.all_reduce(doubled, group=self.cp_group)
+        np.testing.assert_array_equal(
+            doubled.numpy(),
+            expected * cp_nranks,
+            err_msg=(
+                "an extra CP all_reduce must inflate the merged counts by "
+                "exactly cp_nranks; if it does not, CP is not nested in "
+                "sharding the way this test assumes"
+            ),
         )
 
     def test_sharding_only_reduce_matches_its_group(self):

--- a/tests/single_card_tests/test_quantile_balancing.py
+++ b/tests/single_card_tests/test_quantile_balancing.py
@@ -289,7 +289,7 @@ class TestUpdateSingleLayerPaddle(unittest.TestCase):
         layer = self._make_mock_layer(E, B, k, n, histogram_np, b_min, b_max)
         callback = MoEQuantileBalancingCallback()
         callback._update_single_layer(
-            layer, tp_group=None, cp_group=None, dp_group=None, sd_group=None
+            layer, tp_group=None, dp_group=None, sd_group=None
         )
 
         actual = layer._bias_value.numpy()
@@ -313,7 +313,7 @@ class TestUpdateSingleLayerPaddle(unittest.TestCase):
 
         callback = MoEQuantileBalancingCallback()
         callback._update_single_layer(
-            layer, tp_group=None, cp_group=None, dp_group=None, sd_group=None
+            layer, tp_group=None, dp_group=None, sd_group=None
         )
 
         # set_value should NOT have been called since histogram is all-zero
@@ -330,7 +330,7 @@ class TestUpdateSingleLayerPaddle(unittest.TestCase):
         layer = self._make_mock_layer(E, B, k, n, histogram_np)
         callback = MoEQuantileBalancingCallback()
         callback._update_single_layer(
-            layer, tp_group=None, cp_group=None, dp_group=None, sd_group=None
+            layer, tp_group=None, dp_group=None, sd_group=None
         )
 
         actual = layer._bias_value.numpy()
@@ -345,7 +345,7 @@ class TestUpdateSingleLayerPaddle(unittest.TestCase):
         layer = self._make_mock_layer(E, B, k, n, histogram_np)
         callback = MoEQuantileBalancingCallback()
         callback._update_single_layer(
-            layer, tp_group=None, cp_group=None, dp_group=None, sd_group=None
+            layer, tp_group=None, dp_group=None, sd_group=None
         )
 
         b_new = layer._bias_value.numpy()
@@ -367,7 +367,7 @@ class TestUpdateSingleLayerPaddle(unittest.TestCase):
         layer.qb_histogram.zero_ = MagicMock()
         callback = MoEQuantileBalancingCallback()
         callback._update_single_layer(
-            layer, tp_group=None, cp_group=None, dp_group=None, sd_group=None
+            layer, tp_group=None, dp_group=None, sd_group=None
         )
 
         layer.qb_histogram.zero_.assert_called_once()
@@ -392,7 +392,7 @@ class TestUpdateSingleLayerPaddle(unittest.TestCase):
 
         callback = MoEQuantileBalancingCallback()
         callback._update_single_layer(
-            layer, tp_group=None, cp_group=None, dp_group=None, sd_group=None
+            layer, tp_group=None, dp_group=None, sd_group=None
         )
 
         self.assertEqual(list(stored["val"].shape), [1, E])
@@ -406,7 +406,7 @@ class TestUpdateSingleLayerPaddle(unittest.TestCase):
         layer = self._make_mock_layer(E, B, k, n, histogram_np)
         callback = MoEQuantileBalancingCallback()
         callback._update_single_layer(
-            layer, tp_group=None, cp_group=None, dp_group=None, sd_group=None
+            layer, tp_group=None, dp_group=None, sd_group=None
         )
 
         actual = layer._bias_value.numpy()
@@ -529,15 +529,16 @@ def _fake_fleet_module(hcg):
 
 
 @contextlib.contextmanager
-def _initialized_fleet(hcg, cp_group=None):
-    """Pretend distributed is up with `hcg` as the hybrid group and `cp_group` as CP."""
+def _initialized_fleet(hcg):
+    """Pretend distributed is up with `hcg` as the hybrid group.
+
+    CP is intentionally not mocked: the QB histogram is no longer reduced over a
+    separate CP group (CP is a sub-slice of the sharding group, so the sharding
+    all-reduce already covers it).
+    """
     with (
         patch("paddle.distributed.is_initialized", return_value=True),
         patch("paddle.distributed.fleet", _fake_fleet_module(hcg)),
-        patch(
-            "paddlefleet.parallel_state.get_context_parallel_group",
-            return_value=cp_group,
-        ),
     ):
         yield
 
@@ -546,12 +547,11 @@ class TestTryGetCommGroups(unittest.TestCase):
     """Test the communication group retrieval function."""
 
     def test_no_fleet_returns_none(self):
-        """Without fleet initialized, should return four Nones."""
-        tp, cp, dp, sd = _try_get_comm_groups()
+        """Without fleet initialized, should return three Nones."""
+        tp, dp, sd = _try_get_comm_groups()
         # In single-process tests fleet.init() may have run, but every group
         # holds a single rank, so nothing needs reducing.
         self.assertIsNone(tp)
-        self.assertIsNone(cp)
         self.assertIsNone(dp)
         self.assertIsNone(sd)
 
@@ -568,7 +568,7 @@ class TestTryGetCommGroups(unittest.TestCase):
                 _fake_fleet_module(_FakeHCG(tp=2, dp=8, sd=4)),
             ),
         ):
-            self.assertEqual(_try_get_comm_groups(), (None, None, None, None))
+            self.assertEqual(_try_get_comm_groups(), (None, None, None))
 
     def test_initialized_multi_rank_groups_are_returned(self):
         """Regression guard: groups must be found on a realistically shaped fleet.
@@ -578,9 +578,8 @@ class TestTryGetCommGroups(unittest.TestCase):
         came back None and the histogram was never merged across ranks.
         """
         with _initialized_fleet(_FakeHCG(tp=2, dp=8, sd=4)):
-            tp, cp, dp, sd = _try_get_comm_groups()
+            tp, dp, sd = _try_get_comm_groups()
         self.assertEqual((tp.nranks, dp.nranks, sd.nranks), (2, 8, 4))
-        self.assertIsNone(cp)  # CP is not enabled in this test process
 
 
 # =============================================================================
@@ -639,7 +638,7 @@ class TestOnOptimizerEnd(unittest.TestCase):
         # Directly test _update_single_layer (bypasses isinstance in on_optimizer_end)
         callback = MoEQuantileBalancingCallback()
         callback._update_single_layer(
-            layer, tp_group=None, cp_group=None, dp_group=None, sd_group=None
+            layer, tp_group=None, dp_group=None, sd_group=None
         )
 
         # Verify histogram was reset (zero_() was called on the tensor)
@@ -801,7 +800,7 @@ class TestEndToEnd(unittest.TestCase):
 
         callback = MoEQuantileBalancingCallback()
         callback._update_single_layer(
-            layer, tp_group=None, cp_group=None, dp_group=None, sd_group=None
+            layer, tp_group=None, dp_group=None, sd_group=None
         )
 
         # Step 3: Verify result — bias should be non-zero and zero-mean
@@ -936,7 +935,7 @@ class TestDegenerateRange(unittest.TestCase):
 
         callback = MoEQuantileBalancingCallback()
         callback._update_single_layer(
-            layer, tp_group=None, cp_group=None, dp_group=None, sd_group=None
+            layer, tp_group=None, dp_group=None, sd_group=None
         )
 
         # Should still produce valid result (not crash or NaN)
@@ -1019,30 +1018,13 @@ class TestCommGroupsHappyPath(unittest.TestCase):
     def test_all_groups_available(self):
         """When all groups are available and have nranks > 1, return them."""
         with _initialized_fleet(_FakeHCG(tp=4, dp=8, sd=2)):
-            tp, cp, dp, sd = _try_get_comm_groups()
+            tp, dp, sd = _try_get_comm_groups()
         self.assertEqual((tp.nranks, dp.nranks, sd.nranks), (4, 8, 2))
-        self.assertIsNone(cp)
-
-    def test_cp_group_picked_up(self):
-        """A multi-rank CP group must be returned so its histogram is merged."""
-        cp_group = _FakeGroup(4)
-        with _initialized_fleet(_FakeHCG(), cp_group=cp_group):
-            tp, cp, dp, sd = _try_get_comm_groups()
-        self.assertIs(cp, cp_group)
-        self.assertIsNone(tp)
-        self.assertIsNone(dp)
-        self.assertIsNone(sd)
-
-    def test_single_rank_cp_group_filtered(self):
-        """CP=1 needs no reduction, so the group is filtered out."""
-        with _initialized_fleet(_FakeHCG(), cp_group=_FakeGroup(1)):
-            _, cp, _, _ = _try_get_comm_groups()
-        self.assertIsNone(cp)
 
     def test_single_rank_groups_filtered(self):
         """Groups with nranks <= 1 should be filtered to None."""
         with _initialized_fleet(_FakeHCG(tp=1, dp=4, sd=1)):
-            tp, cp, dp, sd = _try_get_comm_groups()
+            tp, dp, sd = _try_get_comm_groups()
         self.assertIsNone(tp)
         self.assertEqual(dp.nranks, 4)
         self.assertIsNone(sd)
@@ -1056,7 +1038,7 @@ class TestCommGroupsHappyPath(unittest.TestCase):
             get_sharding_parallel_group = staticmethod(lambda: None)
 
         with _initialized_fleet(_NoneHCG()):
-            tp, cp, dp, sd = _try_get_comm_groups()
+            tp, dp, sd = _try_get_comm_groups()
         self.assertIsNone(tp)
         self.assertIsNone(dp)
         self.assertIsNone(sd)
@@ -1101,7 +1083,6 @@ class TestTPAllReduceCondition(unittest.TestCase):
         callback._update_single_layer(
             layer,
             tp_group=tp_group,
-            cp_group=None,
             dp_group=None,
             sd_group=None,
         )
@@ -1125,7 +1106,6 @@ class TestTPAllReduceCondition(unittest.TestCase):
         callback._update_single_layer(
             layer,
             tp_group=tp_group,
-            cp_group=None,
             dp_group=None,
             sd_group=None,
         )
@@ -1149,7 +1129,6 @@ class TestTPAllReduceCondition(unittest.TestCase):
         callback._update_single_layer(
             layer,
             tp_group=tp_group,
-            cp_group=None,
             dp_group=None,
             sd_group=None,
         )
@@ -1174,7 +1153,6 @@ class TestTPAllReduceCondition(unittest.TestCase):
         callback._update_single_layer(
             layer,
             tp_group=None,
-            cp_group=None,
             dp_group=dp_group,
             sd_group=sd_group,
         )
@@ -1183,34 +1161,13 @@ class TestTPAllReduceCondition(unittest.TestCase):
         self.assertEqual(mock_dist.all_reduce.call_count, 2)
 
     @patch("paddlefleet.transformer.moe.qb_callback.dist")
-    def test_cp_reduce_called_unconditionally(self, mock_dist):
-        """CP always splits the sequence, so its reduce is not gated on SP/EP."""
-        np.random.seed(42)
-        E, B, k, n = 4, 50, 2, 4
-        histogram_np = np.random.randint(5, 20, (E, B)).astype(np.int32)
+    def test_all_groups_reduce(self, mock_dist):
+        """TP+DP+Sharding together produce exactly three all-reduces.
 
-        cp_group = MagicMock()
-        callback = MoEQuantileBalancingCallback()
-        # SP=False and EP=1 disable the TP reduce; CP must still fire.
-        for sp, ep_size in ((False, 1), (True, 1), (False, 4)):
-            mock_dist.reset_mock()
-            layer = self._make_layer_with_config(
-                E, B, k, n, histogram_np, sp=sp, ep_size=ep_size
-            )
-            callback._update_single_layer(
-                layer,
-                tp_group=None,
-                cp_group=cp_group,
-                dp_group=None,
-                sd_group=None,
-            )
-            mock_dist.all_reduce.assert_called_once_with(
-                mock_dist.all_reduce.call_args.args[0], group=cp_group
-            )
-
-    @patch("paddlefleet.transformer.moe.qb_callback.dist")
-    def test_all_four_groups_reduce(self, mock_dist):
-        """TP+CP+DP+Sharding together produce exactly four all-reduces."""
+        CP is deliberately absent: it is a sub-slice of the sharding group, so
+        the sharding all-reduce already covers it. Reducing CP separately would
+        double-count the histogram.
+        """
         np.random.seed(42)
         E, B, k, n = 4, 50, 2, 4
         histogram_np = np.random.randint(5, 20, (E, B)).astype(np.int32)
@@ -1218,29 +1175,28 @@ class TestTPAllReduceCondition(unittest.TestCase):
         layer = self._make_layer_with_config(
             E, B, k, n, histogram_np, sp=True, ep_size=4
         )
-        groups = [MagicMock() for _ in range(4)]
+        groups = [MagicMock() for _ in range(3)]
         callback = MoEQuantileBalancingCallback()
         callback._update_single_layer(
             layer,
             tp_group=groups[0],
-            cp_group=groups[1],
-            dp_group=groups[2],
-            sd_group=groups[3],
+            dp_group=groups[1],
+            sd_group=groups[2],
         )
 
-        self.assertEqual(mock_dist.all_reduce.call_count, 4)
+        self.assertEqual(mock_dist.all_reduce.call_count, 3)
         reduced_groups = [
             call.kwargs["group"] for call in mock_dist.all_reduce.call_args_list
         ]
         self.assertEqual(reduced_groups, groups)
 
     @patch("paddlefleet.transformer.moe.qb_callback.dist")
-    def test_cp_histograms_merge_to_global_quantile(self, mock_dist):
-        """A CP-sharded histogram pair must recover the same bias as the pooled one.
+    def test_sharded_histograms_merge_to_global_quantile(self, mock_dist):
+        """A sharded histogram pair must recover the same bias as the pooled one.
 
-        Each CP rank's router only sees S/CP tokens, so without the CP reduce the
-        recovered quantile is a local one. Summing the shards must reproduce the
-        result of running on the full sequence.
+        Each sharding rank's router only sees part of the global batch, so
+        without the sharding reduce the recovered quantile is a local one.
+        Summing the shards must reproduce the full-batch result.
         """
         np.random.seed(11)
         E, B, k, n = 4, 60, 2, 4
@@ -1248,10 +1204,10 @@ class TestTPAllReduceCondition(unittest.TestCase):
         shard_b = np.random.randint(0, 15, (E, B)).astype(np.int32)
         pooled = shard_a + shard_b
 
-        cp_group = MagicMock()
+        sd_group = MagicMock()
 
         def _fake_all_reduce(tensor, group=None):
-            # Emulate summing shard_a (local) with shard_b (the peer CP rank).
+            # Emulate summing shard_a (local) with shard_b (the peer rank).
             tensor.add_(paddle.to_tensor(shard_b, dtype=tensor.dtype))
 
         mock_dist.all_reduce.side_effect = _fake_all_reduce
@@ -1263,9 +1219,8 @@ class TestTPAllReduceCondition(unittest.TestCase):
         callback._update_single_layer(
             layer,
             tp_group=None,
-            cp_group=cp_group,
             dp_group=None,
-            sd_group=None,
+            sd_group=sd_group,
         )
         merged_bias = layer._bias_value.numpy()
 
@@ -1605,7 +1560,7 @@ class TestCommGroupsExceptionPath(unittest.TestCase):
                 side_effect=RuntimeError("hcg unavailable"),
             ),
         ):
-            tp, cp, dp, sd = _try_get_comm_groups()
+            tp, dp, sd = _try_get_comm_groups()
         self.assertIsNone(tp)
         self.assertIsNone(dp)
         self.assertIsNone(sd)
@@ -1701,7 +1656,7 @@ class TestQBPaddingExclusion(unittest.TestCase):
         hist = router.qb_histogram.numpy().copy()
         usage = router.expert_usage.numpy().copy()
         MoEQuantileBalancingCallback()._update_single_layer(
-            router, None, None, None, None
+            router, None, None, None
         )
         return hist, usage, router.e_score_correction_bias.numpy().copy()
 
@@ -1781,7 +1736,7 @@ class TestQBPaddingExclusion(unittest.TestCase):
 
         # An empty histogram must leave the bias untouched.
         MoEQuantileBalancingCallback()._update_single_layer(
-            router, None, None, None, None
+            router, None, None, None
         )
         np.testing.assert_array_equal(
             router.e_score_correction_bias.numpy(), bias_before

--- a/tests/test_configs.yaml
+++ b/tests/test_configs.yaml
@@ -49,6 +49,11 @@ tests:
   - test_case: [tests/multi_card_tests/moe/test_allgather_dispatcher_ep.py]
     products:
       - num_gpus: 2
+  # moe: QB callback histogram all-reduce. The topology (mp=2 sharding=4 cp=2
+  # ep=8) requires exactly 8 GPUs, so pin it rather than rely on the default.
+  - test_case: [tests/multi_card_tests/moe/test_qb_callback_cp_sharding.py]
+    products:
+      - num_gpus: 8
   # ai_edited_test: tensor_parallel (Pattern A/B, TP=4 sharding=2 -> 8 GPUs)
   - test_case: [tests/multi_card_tests/ai_edited_test/tensor_parallel/test_ai_mappings.py]
     products:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Distributed Strategy

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

<p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Fixes two correctness bugs in the Quantile Balancing callback's histogram all-reduce, and adds real multi-card coverage for the topology that exposes them.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong><code style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">src/paddlefleet/transformer/moe/qb_callback.py</code></strong></p><ol style="padding-inline-start: 2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em;"><strong>Dropped the redundant CP all-reduce.</strong> <code style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">_try_get_comm_groups()</code> no longer returns a CP group, and <code style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">_update_single_layer</code> no longer reduces over it. In Paddle's <code style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">EPHybridCommunicateGroup</code>, the context-parallel group is a contiguous sub-slice of the sharding comm list (<code style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">sharding = cp × cp_sharding</code>, see <code style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">split_context_comm_list</code>) — CP ranks are a <strong>subset</strong> of the sharding group. The sharding all-reduce already sums over the CP dimension, so reducing CP again multiplied every count by <code style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">cp_nranks</code>.</p></li><li><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em;"><strong>Switched the reduction dtype from fp32 to int64.</strong> The histogram is <code style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">int32</code> counts; it was being cast to fp32 for the reduce and back to int64 afterwards. fp32 loses integer precision above <code style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">2**24</code>, and staying in int32 risks overflow when summing across ranks. int64 is exact and NCCL-supported:</p></li></ol><div class="codeBlockWrapper_-a7MRw" style="position: relative; margin: 8px 0px; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><button class="copyButton_CEmTFw copyButton_-a7MRw" title="Copy code" aria-label="Copy code to clipboard" style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; background: none 0% 0% / auto repeat scroll padding-box border-box rgb(30, 30, 30); border: 0.666667px solid rgb(69, 69, 69); cursor: pointer; opacity: 0; display: flex; border-radius: 4px; justify-content: center; align-items: center; padding: 4px; transition: opacity 0.15s, background 0.15s; position: absolute; top: 4px; right: 4px;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon" class="copyIcon_CEmTFw"><path fill-rule="evenodd" d="M15.988 3.012A2.25 2.25 0 0 1 18 5.25v6.5A2.25 2.25 0 0 1 15.75 14H13.5v-3.379a3 3 0 0 0-.879-2.121l-3.12-3.121a3 3 0 0 0-1.402-.791 2.252 2.252 0 0 1 1.913-1.576A2.25 2.25 0 0 1 12.25 1h1.5a2.25 2.25 0 0 1 2.238 2.012ZM11.5 3.25a.75.75 0 0 1 .75-.75h1.5a.75.75 0 0 1 .75.75v.25h-3v-.25Z" clip-rule="evenodd"></path><path d="M3.5 6A1.5 1.5 0 0 0 2 7.5v9A1.5 1.5 0 0 0 3.5 18h7a1.5 1.5 0 0 0 1.5-1.5v-5.879a1.5 1.5 0 0 0-.44-1.06L8.44 6.439A1.5 1.5 0 0 0 7.378 6H3.5Z"></path></svg></button><pre style="overflow-x: auto; white-space: pre; box-sizing: border-box; border-radius: 4px; max-width: 100%; margin: 0px; padding: 8px;"><code class="language-python" style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 0px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">hist_global = histogram.cast(paddle.int64)   # was: hist_float = histogram.cast(paddle.float32)
...
if dp_group is not None:
    dist.all_reduce(hist_global, group=dp_group)
if sd_group is not None:
    dist.all_reduce(hist_global, group=sd_group)
                                             # was: hist_global = hist_float.cast(paddle.int64)
</code></pre></div><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The reasoning for both is recorded as comments at the reduce site and in the <code style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">_try_get_comm_groups</code> docstring, since neither is obvious from the surrounding code.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>Tests</strong></p><ul style="padding-inline-start: 2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li><code style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">tests/multi_card_tests/moe/test_qb_callback_cp_sharding.py</code><span> </span>(new, 336 lines) — 10 tests on real collectives.</li><li><code style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">tests/single_card_tests/test_quantile_balancing.py</code><span> </span>— updated for the 3-tuple return; dropped<span> </span><code style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">test_cp_group_picked_up</code><span> </span>and<span> </span><code style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">test_single_rank_cp_group_filtered</code><span> </span>(they asserted the removed behavior), and<span> </span><code style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">test_cp_reduce_called_unconditionally</code><span> </span>became<span> </span><code style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">test_all_groups_reduce</code>. Net −113 lines, mostly<span> </span><code style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">cp_group=None</code><span> </span>plumbing that no longer exists.</li><li><code style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">tests/test_configs.yaml</code><span> </span>— pins the new test to<span> </span><code style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">num_gpus: 8</code>, since the topology requires exactly 8.</li></ul><h2 style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Why the CP reduce was wrong, and why it was hard to catch</h2><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The double-count is a uniform <code style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">×cp_nranks</code> scaling of the merged histogram. QB's bias recovery is <strong>invariant</strong> under uniform scaling — <code style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">q_target</code>, <code style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">c</code> and <code style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">h</code> all scale together, so <code style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">beta</code> and <code style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">fraction</code> come out unchanged. The only leak is the <code style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">floor</code> in <code style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">q_target = floor(total * k / n)</code>, which bites only when an expert total is odd. So on even fixture data the recovered bias was bit-identical and the bug was invisible; it surfaced only as wrong per-expert bias on real data.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">This is why the new negative control (<code style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">test_extra_cp_reduce_inflates_the_merged_histogram</code>) asserts on the <strong>histogram</strong> rather than on the recovered bias — a bias-level assertion would pass or fail by luck depending on fixture parity. That was the second P1.</p><h2 style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Topology assumptions</h2><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Runs on 8 ranks with <code style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">mp=2, sharding=4, cp=2, ep=8, moe_sharding=1, dp=pp=sep=1</code>. The groups are asserted explicitly rather than assumed, because the CP⊂sharding nesting is exactly what the fix relies on:</p><div class="codeBlockWrapper_-a7MRw" style="position: relative; margin: 8px 0px; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><button class="copyButton_CEmTFw copyButton_-a7MRw" title="Copy code" aria-label="Copy code to clipboard" style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; background: none 0% 0% / auto repeat scroll padding-box border-box rgb(30, 30, 30); border: 0.666667px solid rgb(69, 69, 69); cursor: pointer; opacity: 0; display: flex; border-radius: 4px; justify-content: center; align-items: center; padding: 4px; transition: opacity 0.15s, background 0.15s; position: absolute; top: 4px; right: 4px;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon" class="copyIcon_CEmTFw"><path fill-rule="evenodd" d="M15.988 3.012A2.25 2.25 0 0 1 18 5.25v6.5A2.25 2.25 0 0 1 15.75 14H13.5v-3.379a3 3 0 0 0-.879-2.121l-3.12-3.121a3 3 0 0 0-1.402-.791 2.252 2.252 0 0 1 1.913-1.576A2.25 2.25 0 0 1 12.25 1h1.5a2.25 2.25 0 0 1 2.238 2.012ZM11.5 3.25a.75.75 0 0 1 .75-.75h1.5a.75.75 0 0 1 .75.75v.25h-3v-.25Z" clip-rule="evenodd"></path><path d="M3.5 6A1.5 1.5 0 0 0 2 7.5v9A1.5 1.5 0 0 0 3.5 18h7a1.5 1.5 0 0 0 1.5-1.5v-5.879a1.5 1.5 0 0 0-.44-1.06L8.44 6.439A1.5 1.5 0 0 0 7.378 6H3.5Z"></path></svg></button><pre style="overflow-x: auto; white-space: pre; box-sizing: border-box; border-radius: 4px; max-width: 100%; margin: 0px; padding: 8px;"><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 0px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">mp_group          [0, 1]
sharding_group    [0, 2, 4, 6]
cp_group          [0, 2]
cp_sharding_group [0, 4]
cp_mp_group       [0, 1, 2, 3]
</code></pre></div>
Test class | Count | Covers
-- | -- | --
TestCommGroupTopology | 3 | Group membership and the CP⊂sharding nesting
TestInt64AllReduce | 2 | int64 all-reduce correctness for counts
TestHistogramReduceCorrectness | 5 | Reduce sequence, exactly-once counting, negative control

<h2 style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Verification</h2><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Real 8-GPU run — every collective is an actual <code style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">dist.all_reduce</code> on the real group, nothing mocked:</p><div class="codeBlockWrapper_-a7MRw" style="position: relative; margin: 8px 0px; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><button class="copyButton_CEmTFw copyButton_-a7MRw" title="Copy code" aria-label="Copy code to clipboard" style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; background: none 0% 0% / auto repeat scroll padding-box border-box rgb(30, 30, 30); border: 0.666667px solid rgb(69, 69, 69); cursor: pointer; opacity: 0; display: flex; border-radius: 4px; justify-content: center; align-items: center; padding: 4px; transition: opacity 0.15s, background 0.15s; position: absolute; top: 4px; right: 4px;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon" class="copyIcon_CEmTFw"><path fill-rule="evenodd" d="M15.988 3.012A2.25 2.25 0 0 1 18 5.25v6.5A2.25 2.25 0 0 1 15.75 14H13.5v-3.379a3 3 0 0 0-.879-2.121l-3.12-3.121a3 3 0 0 0-1.402-.791 2.252 2.252 0 0 1 1.913-1.576A2.25 2.25 0 0 1 12.25 1h1.5a2.25 2.25 0 0 1 2.238 2.012ZM11.5 3.25a.75.75 0 0 1 .75-.75h1.5a.75.75 0 0 1 .75.75v.25h-3v-.25Z" clip-rule="evenodd"></path><path d="M3.5 6A1.5 1.5 0 0 0 2 7.5v9A1.5 1.5 0 0 0 3.5 18h7a1.5 1.5 0 0 0 1.5-1.5v-5.879a1.5 1.5 0 0 0-.44-1.06L8.44 6.439A1.5 1.5 0 0 0 7.378 6H3.5Z"></path></svg></button><pre style="overflow-x: auto; white-space: pre; box-sizing: border-box; border-radius: 4px; max-width: 100%; margin: 0px; padding: 8px;"><code class="language-bash" style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 0px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">unset PADDLE_ELASTIC_JOB_ID PADDLE_TRAINER_ENDPOINTS DISTRIBUTED_TRAINER_ENDPOINTS \
      FLAGS_START_PORT PADDLE_ELASTIC_TIMEOUT PADDLE_TRAINER_ID \
      PADDLE_TRAINERS_NUM PADDLE_CURRENT_ENDPOINT
export PYTHONPATH="$PWD/src" FLAGS_tcp_store_using_libuv=0 \
       FLAGS_embedding_deterministic=1 FLAGS_cudnn_deterministic=1

python -m paddle.distributed.launch --gpus=0,1,2,3,4,5,6,7 \
    --log_dir=/tmp/qb_cp_log \
    tests/multi_card_tests/moe/test_qb_callback_cp_sharding.py
</code></pre></div><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Exit code 0; all 8 worker logs report <code style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Ran 10 tests ... OK</code>, <strong>0 skips</strong>, ~17 s per rank. The topology above was read back from the worker logs rather than assumed. Single-card <code style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">test_quantile_balancing.py</code> also passes after the signature update.</p>
### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
是