### PR TITLE
[Tools] config_adapter: port the topology and inference fixes from release/0.4

### DIFF
--- a/src/paddlefleet/config_adapter/README.md
+++ b/src/paddlefleet/config_adapter/README.md
@@ -97,7 +97,7 @@ python -m paddlefleet.config_adapter --input config.yaml \
 
 源作业卡数按两条证据推断并交叉校验：通信组
 （`DP × sharding × TP × SEP × PP`）与 batch 字段
-（`GBS / (micro_bs × acc) × TP × PP × CP`）。两者都能算且不一致时，取「没漏因子」
+（`GBS / (micro_bs × acc) × TP × SEP × PP × CP`）。两者都能算且不一致时，取「没漏因子」
 的那个 —— 源 YAML 声明了 `data_parallel_size` 就用通信组，没声明则用 batch 字段
 （未声明的 DP 正是通信组公式缺的那一项）—— 并在报告里给出 WARNING。
 

--- a/src/paddlefleet/config_adapter/README.md
+++ b/src/paddlefleet/config_adapter/README.md
@@ -86,9 +86,17 @@ python -m paddlefleet.config_adapter --input config.yaml \
   `model_config.json` 必须显式写 `json:KEY=VALUE`。
 
 取值类型自动推断（整数→int、`true/false`→bool、`null/none`→None、其余→字符串）。
-被 `--set` 指定的字段是**受保护**的：后续任何自动规则都不会再覆盖它。当某个模型
+被 `--set` 指定的字段是**受保护**的：后续任何自动规则都不会再覆盖它。但由适配器
+统一计算的字段（TP/PP/EP/CP/SEP、VPP、`num_empty_layers_add_in_tail`、
+`sharding_parallel_size`、`data_parallel_size`、`model_name_or_path`）**不允许**
+用 `--set` 锁定，否则生成的文件会与报告里的并行度对不上 —— 遇到这种组合会直接报错。当某个模型
 结构字段在 `model_config.json` 里读不到（不同模型家族命名不一致）时，也用
 `--set <字段>=<值>` 兜底。
+
+源作业卡数按两条证据推断并交叉校验：通信组
+（`DP × sharding × TP × SEP × PP`）与 batch 字段
+（`GBS / (micro_bs × acc) × TP × PP × CP`）。两者都能算且不一致时，取通信组的结果
+并在报告里给出 WARNING，提示源 YAML 自身不自洽。
 
 `model_config.json` 的位置永远从 YAML 的 `model_name_or_path` 推断：绝对路径直接
 用，相对路径先按 YAML 所在目录、再按当前工作目录（Fleet 的解析方式）尝试。
@@ -140,8 +148,9 @@ python -m paddlefleet.config_adapter --input config.yaml \
 |---|---|---|
 | C1 | `N % (TP·SEP·PP) == 0` | sharding 为正整数 |
 | C2 | `N % (PP·EP) == 0`（EP>1） | moe_sharding 为正整数 |
-| C3 | `EP % TP == 0`（EP>1） | dense_sharding 为正整数 |
+| C3 | `EP % (TP·SEP) == 0`（EP>1） | dense_sharding = EP/(TP·SEP) 为正整数 |
 | C4 | `sharding % CP == 0` | cp_sharding 为正整数 |
+| C5 | 不允许 SEP>1 且 CP>1 | 框架禁止 sep 与 context 并行同时使用 |
 | E1 | 跨机必须整节点分配 | Fleet 的 rank 映射要求各机对称 |
 | E2 | `TP·SEP` 放得进单机 | TP/SEP 不缩，缩了有 OOM 风险 |
 | E3 | 所有并行度是 ≥1 的整数 | — |

--- a/src/paddlefleet/config_adapter/README.md
+++ b/src/paddlefleet/config_adapter/README.md
@@ -95,8 +95,12 @@ python -m paddlefleet.config_adapter --input config.yaml \
 
 源作业卡数按两条证据推断并交叉校验：通信组
 （`DP × sharding × TP × SEP × PP`）与 batch 字段
-（`GBS / (micro_bs × acc) × TP × PP × CP`）。两者都能算且不一致时，取通信组的结果
-并在报告里给出 WARNING，提示源 YAML 自身不自洽。
+（`GBS / (micro_bs × acc) × TP × PP × CP`）。两者都能算且不一致时，取「没漏因子」
+的那个 —— 源 YAML 声明了 `data_parallel_size` 就用通信组，没声明则用 batch 字段
+（未声明的 DP 正是通信组公式缺的那一项）—— 并在报告里给出 WARNING。
+
+C3/C5 只取决于并行度本身，与卡数无关：这两项冲突时不会再列出「合法节点数」，而是
+直接说明必须先改 TP/SEP/EP/CP 的组合。
 
 `model_config.json` 的位置永远从 YAML 的 `model_name_or_path` 推断：绝对路径直接
 用，相对路径先按 YAML 所在目录、再按当前工作目录（Fleet 的解析方式）尝试。

--- a/src/paddlefleet/config_adapter/README.md
+++ b/src/paddlefleet/config_adapter/README.md
@@ -89,7 +89,9 @@ python -m paddlefleet.config_adapter --input config.yaml \
 被 `--set` 指定的字段是**受保护**的：后续任何自动规则都不会再覆盖它。但由适配器
 统一计算的字段（TP/PP/EP/CP/SEP、VPP、`num_empty_layers_add_in_tail`、
 `sharding_parallel_size`、`data_parallel_size`、`model_name_or_path`）**不允许**
-用 `--set` 锁定，否则生成的文件会与报告里的并行度对不上 —— 遇到这种组合会直接报错。当某个模型
+用 `--set` 锁定（带不带前缀都一样），否则生成的文件会与报告里的并行度对不上 ——
+遇到这种组合会直接报错。`model_name_or_path` 即使在 `--in-place` 下也不允许锁定：
+改它会决定「到底加载/缩容/快照哪一份 `model_config.json`」。当某个模型
 结构字段在 `model_config.json` 里读不到（不同模型家族命名不一致）时，也用
 `--set <字段>=<值>` 兜底。
 

--- a/src/paddlefleet/config_adapter/README.md
+++ b/src/paddlefleet/config_adapter/README.md
@@ -145,8 +145,7 @@ C3/C5 只取决于并行度本身，与卡数无关：这两项冲突时不会�
 
 写盘时机：所有规划与校验都在内存里完成后才落盘，中途任何一步失败都不改动源文件；
 写文件走临时文件 + 原子替换，`--in-place` 下若 YAML 写失败会回滚已写的
-`model_config.json`。另外需要另存 `model_config.json` 时，`model_name_or_path`
-必须指向新目录，因此不允许同时用 `--set` 锁定它（会直接报错并提示改用 `--in-place`）。
+`model_config.json`。
 
 ### 约束体系
 

--- a/src/paddlefleet/config_adapter/constraints.py
+++ b/src/paddlefleet/config_adapter/constraints.py
@@ -122,9 +122,14 @@ def align_layers(layers_new, head, tail_orig, pp_new, vpp_orig):
 
 
 def min_shrink_cards(tp, pp, ep, cp, sep, cards_per_node):
-    """Smallest GPU count reachable without collapsing any degree to 1."""
+    """Smallest GPU count reachable without collapsing any degree to 1.
+
+    ``None`` when the dims break a card-count-independent rule (C3 or C5), so
+    no scale exists and callers must talk about the dims instead.
+    """
     validator = TopologyValidator(cards_per_node, cards_per_node)
-    return validator.suggest_valid_cards(*floor_dims(tp, pp, ep, cp, sep))[0]
+    cards = validator.suggest_valid_cards(*floor_dims(tp, pp, ep, cp, sep))
+    return cards[0] if cards else None
 
 
 def check_hardware(target_cards, cards_per_node, tp, pp, ep, cp, sep):
@@ -156,6 +161,13 @@ def check_hardware(target_cards, cards_per_node, tp, pp, ep, cp, sep):
     max_intra = min(cards_per_node, target_cards)
     if tp * sep > max_intra:
         min_cards = min_shrink_cards(tp, pp, ep, cp, sep, cards_per_node)
+        if min_cards is None:
+            return False, (
+                f"E2 不满足：TP={tp} × SEP={sep} 需要单机内 {tp * sep} 张卡，"
+                f"但目标只有 {target_cards} 张卡；而且当前维度组合本身就不合法"
+                f"（C3 要求 EP % (TP×SEP) == 0，C5 禁止 SEP 与 CP 同时 >1），"
+                f"任何卡数都无法适配，必须先修改 TP/SEP/EP/CP"
+            )
         return False, (
             f"E2 不满足：TP={tp} × SEP={sep} 需要单机内 {tp * sep} 张卡，"
             f"但目标只有 {target_cards} 张卡。\n"

--- a/src/paddlefleet/config_adapter/constraints.py
+++ b/src/paddlefleet/config_adapter/constraints.py
@@ -64,13 +64,14 @@ def floor_dims(tp, pp, ep, cp, sep):
     return tp, shrink_floor(pp), shrink_floor(ep), cp, sep
 
 
-def ep_candidates(ep_orig, tp):
+def ep_candidates(ep_orig, tp, sep=1):
     """EP-shrink candidates, largest first.
 
     Set: ``({powers of 2} | {multiples of 8})`` restricted to
-    ``[MIN_PARALLEL_DEGREE, ep_orig)`` and filtered by ``ep_new % tp == 0``
-    (C3).  Real deployments only ever pick EP from those two families, which
-    keeps the search space small and avoids exotic values like EP=3.
+    ``[MIN_PARALLEL_DEGREE, ep_orig)`` and filtered by
+    ``ep_new % (tp * sep) == 0`` (C3: dense_sharding = EP / (TP * SEP)).
+    Real deployments only ever pick EP from those two families, which keeps
+    the search space small and avoids exotic values like EP=3.
     """
     if ep_orig <= MIN_PARALLEL_DEGREE:
         return []
@@ -79,8 +80,9 @@ def ep_candidates(ep_orig, tp):
     pool = (powers_of_2 | multiples_of_8) & set(
         range(MIN_PARALLEL_DEGREE, ep_orig)
     )
+    dense_factor = tp * sep
     return sorted(
-        (c for c in pool if tp == 1 or c % tp == 0),
+        (c for c in pool if dense_factor == 1 or c % dense_factor == 0),
         reverse=True,
     )
 

--- a/src/paddlefleet/config_adapter/core.py
+++ b/src/paddlefleet/config_adapter/core.py
@@ -142,7 +142,10 @@ class ConfigAdapter:
                 "用户通过 --set yaml: 指定，自动适配不会再覆盖该字段",
             )
 
-        if "fa_version" in config and "fa_version" not in self.yaml_overrides:
+        fa_pinned = "fa_version" in self.yaml_overrides or (
+            "fa_version" in self.auto_overrides
+        )
+        if "fa_version" in config and not fa_pinned:
             log.record_removed(
                 "yaml",
                 "fa_version",
@@ -416,7 +419,10 @@ class ConfigAdapter:
         * comm groups: ``DP * sharding * TP * SEP * PP`` -- ``sharding`` alone
           is a group size, not the world size, so a dense job with ``DP > 1``
           would otherwise be under-counted;
-        * batch settings: ``GBS / (micro_bs * acc) * TP * PP * CP``.
+        * batch settings: ``GBS / (micro_bs * acc) * TP * SEP * PP * CP`` --
+          the trainer defines ``dataset_world_size = DP * sharding`` (or
+          ``sharding / CP`` when CP > 1), so every other degree multiplies
+          back in.
 
         When both exist and disagree, the estimate that is not missing a
         factor wins: the comm-group one only if ``data_parallel_size`` is
@@ -442,7 +448,7 @@ class ConfigAdapter:
         if gbs and micro_bs and grad_accum:
             dataset_world_size = int(gbs) // (int(micro_bs) * int(grad_accum))
             if dataset_world_size > 0:
-                batch_based = dataset_world_size * tp * pp * cp
+                batch_based = dataset_world_size * tp * sep * pp * cp
 
         if group_based is not None and batch_based is not None:
             if group_based == batch_based:
@@ -452,7 +458,7 @@ class ConfigAdapter:
                 f"源卡数的两种推断不一致：按通信组"
                 f"（DP={dp}×sharding={sharding}×TP={tp}×SEP={sep}×PP={pp}）"
                 f"为 {group_based}，按 batch 字段"
-                f"（GBS/(micro×acc)×TP×PP×CP）为 {batch_based}；"
+                f"（GBS/(micro×acc)×TP×SEP×PP×CP）为 {batch_based}；"
                 + (
                     f"源 YAML 未声明 data_parallel_size，"
                     f"通信组公式会漏掉这个因子，因此取 batch 字段的 {chosen}。"

--- a/src/paddlefleet/config_adapter/core.py
+++ b/src/paddlefleet/config_adapter/core.py
@@ -115,9 +115,14 @@ class ConfigAdapter:
         # not rewrite it: repointing it mid-run would decide *which*
         # model_config.json is loaded, shrunk and snapshotted for the patch,
         # and the answer differs between the prefixed and prefix-less forms.
-        # Prefix-less --set values are routed to the YAML later, so they have
-        # to be checked here as well.
-        requested = set(self.yaml_overrides) | set(self.auto_overrides)
+        # Every --set form counts: prefix-less values are routed to the YAML
+        # later, and a json: prefix would park a training-parallelism key in
+        # model_config.json while the YAML keeps the adapter's own value.
+        requested = (
+            set(self.yaml_overrides)
+            | set(self.json_overrides)
+            | set(self.auto_overrides)
+        )
         pinned = sorted(ADAPTER_CONTROLLED_FIELDS & requested)
         if pinned:
             return False, (

--- a/src/paddlefleet/config_adapter/core.py
+++ b/src/paddlefleet/config_adapter/core.py
@@ -53,6 +53,20 @@ from .strategies import BATCH_STRATEGIES
 from .topology import TopologyValidator
 from .utils import PARALLEL_FIELDS, extract_parallel_params
 
+#: Fields whose value the adapter derives itself. A ``--set`` pin on any of
+#: them is refused rather than silently skipped, because the plan, the
+#: validation and the report all assume the adapter's own value.
+ADAPTER_CONTROLLED_FIELDS = frozenset(
+    set(PARALLEL_FIELDS.values())
+    | {
+        "virtual_pipeline_model_parallel_size",
+        "num_empty_layers_add_in_tail",
+        "sharding_parallel_size",
+        "data_parallel_size",
+        "model_name_or_path",
+    }
+)
+
 
 class ConfigAdapter:
     """Rewrites one training YAML (and its model_config.json) for a scale."""
@@ -95,6 +109,21 @@ class ConfigAdapter:
         input_path = Path(input_path)
         log = ChangeLog()
 
+        # Fields the adapter must own: pinning them with --set would make the
+        # generated file disagree with the reported parallelism / sharding.
+        # In-place runs never rewrite model_name_or_path, so pinning that one
+        # is harmless there.
+        controlled = ADAPTER_CONTROLLED_FIELDS
+        if self.in_place:
+            controlled = controlled - {"model_name_or_path"}
+        pinned = sorted(controlled & set(self.yaml_overrides))
+        if pinned:
+            return False, (
+                f"以下字段由适配器统一计算，不能用 --set 锁定：{pinned}。"
+                f"锁定后生成的配置会与报告里的并行度 / sharding 不一致；"
+                f"请去掉对应的 --set，或直接改源 YAML 后再适配"
+            )
+
         config = self.yaml_writer.load(input_path)
         if config is None:
             return False, f"配置文件为空：{input_path}"
@@ -106,7 +135,7 @@ class ConfigAdapter:
                 "用户通过 --set yaml: 指定，自动适配不会再覆盖该字段",
             )
 
-        if "fa_version" in config:
+        if "fa_version" in config and "fa_version" not in self.yaml_overrides:
             log.record_removed(
                 "yaml",
                 "fa_version",
@@ -120,6 +149,7 @@ class ConfigAdapter:
             key: config.get(key)
             for key in (
                 "sharding_parallel_size",
+                "data_parallel_size",
                 "global_batch_size",
                 "per_device_train_batch_size",
                 "gradient_accumulation_steps",
@@ -185,9 +215,13 @@ class ConfigAdapter:
         if not ok:
             return False, f"{input_path.name}: {message}"
 
-        orig_cards, err = self._infer_orig_cards(scale_source, dims_before)
+        orig_cards, scale_warning, err = self._infer_orig_cards(
+            scale_source, dims_before
+        )
         if err:
             return False, f"{input_path.name}: {err}"
+        if scale_warning:
+            plan.warnings.append(scale_warning)
 
         err = self._scale_batch_and_sharding(
             config, log, scale_source, orig_cards, dims_after
@@ -332,18 +366,6 @@ class ConfigAdapter:
             self.json_writer.write(model_config, json_path)
             return str(json_path), None
 
-        # The generated YAML must point at the generated JSON, so this field
-        # cannot be pinned by the user at the same time.
-        if "model_name_or_path" in self.yaml_overrides:
-            return None, (
-                "本次需要改写模型结构并另存 model_config.json，"
-                "因此 model_name_or_path 必须指向新生成的目录，"
-                "不能同时用 --set 锁定它；"
-                "请去掉 --set yaml:model_name_or_path=...，"
-                "或改用 --in-place（就地改写源 model_config.json，"
-                "不改 model_name_or_path）"
-            )
-
         adapted_dir = build_adapted_dir(
             self.output_dir, model_dir.name, self.scale_tag
         )
@@ -379,30 +401,69 @@ class ConfigAdapter:
 
     @staticmethod
     def _infer_orig_cards(scale_source, dims_before):
-        """Infer the source job's GPU count. Returns ``(cards, error)``."""
+        """Infer the source job's GPU count.
+
+        Returns ``(cards, warning, error)``.  Two independent estimates are
+        computed when the config carries enough information:
+
+        * comm groups: ``DP * sharding * TP * SEP * PP`` -- ``sharding`` alone
+          is a group size, not the world size, so a dense job with ``DP > 1``
+          would otherwise be under-counted;
+        * batch settings: ``GBS / (micro_bs * acc) * TP * PP * CP``.
+
+        The comm-group estimate wins when both exist, but a mismatch is
+        surfaced as a warning: it means the source YAML is not self-consistent
+        and every derived batch value inherits that ambiguity.
+        """
         tp, pp, ep, cp, sep = dims_before
 
         sharding = scale_source["sharding_parallel_size"]
+        dp = scale_source["data_parallel_size"]
+        dp = int(dp) if dp and int(dp) > 0 else 1
+        group_based = None
         if sharding is not None and int(sharding) > 0:
-            return int(sharding) * tp * sep * pp, None
+            group_based = dp * int(sharding) * tp * sep * pp
 
         gbs = scale_source["global_batch_size"]
         micro_bs = scale_source["per_device_train_batch_size"]
         grad_accum = scale_source["gradient_accumulation_steps"]
+        batch_based = None
         if gbs and micro_bs and grad_accum:
             dataset_world_size = int(gbs) // (int(micro_bs) * int(grad_accum))
             if dataset_world_size > 0:
-                return dataset_world_size * tp * pp * cp, None
+                batch_based = dataset_world_size * tp * pp * cp
+
+        warning = None
+        if group_based is not None and batch_based is not None:
+            if group_based != batch_based:
+                warning = (
+                    f"源卡数的两种推断不一致：按通信组"
+                    f"（DP={dp}×sharding={sharding}×TP={tp}×SEP={sep}×"
+                    f"PP={pp}）为 {group_based}，按 batch 字段"
+                    f"（GBS/(micro×acc)×TP×PP×CP）为 {batch_based}；"
+                    f"取通信组的 {group_based}。"
+                    f"如果不对，请修正源 YAML 的 data_parallel_size 或 "
+                    f"batch 字段后重新适配"
+                )
+            return group_based, warning, None
+        if group_based is not None:
+            return group_based, None, None
+        if batch_based is not None:
+            return batch_based, None, None
 
         if gbs is not None:
-            return None, (
-                "无法推断源作业的卡数：既没有可用的 sharding_parallel_size"
-                "（>0），也无法用 global_batch_size / "
-                "per_device_train_batch_size / gradient_accumulation_steps "
-                "反推。请在 YAML 里补全，或用 "
-                "--set yaml:sharding_parallel_size=<源 sharding> 指定"
+            return (
+                None,
+                None,
+                (
+                    "无法推断源作业的卡数：既没有可用的 sharding_parallel_size"
+                    "（>0），也无法用 global_batch_size / "
+                    "per_device_train_batch_size / gradient_accumulation_steps "
+                    "反推。请在源 YAML 里补上 sharding_parallel_size / "
+                    "data_parallel_size，或补全 batch 字段"
+                ),
             )
-        return None, None
+        return None, None, None
 
     def _scale_batch_and_sharding(
         self, config, log, scale_source, orig_cards, dims_after
@@ -557,12 +618,15 @@ def inspect_config(input_path, cards_per_node=8, max_nodes=16):
         key: config.get(key)
         for key in (
             "sharding_parallel_size",
+            "data_parallel_size",
             "global_batch_size",
             "per_device_train_batch_size",
             "gradient_accumulation_steps",
         )
     }
-    orig_cards, _err = ConfigAdapter._infer_orig_cards(scale_source, dims)
+    orig_cards, _warning, _err = ConfigAdapter._infer_orig_cards(
+        scale_source, dims
+    )
     orig_nodes = (
         orig_cards // cards_per_node
         if orig_cards and orig_cards % cards_per_node == 0

--- a/src/paddlefleet/config_adapter/core.py
+++ b/src/paddlefleet/config_adapter/core.py
@@ -116,7 +116,10 @@ class ConfigAdapter:
         controlled = ADAPTER_CONTROLLED_FIELDS
         if self.in_place:
             controlled = controlled - {"model_name_or_path"}
-        pinned = sorted(controlled & set(self.yaml_overrides))
+        # Prefix-less --set values are routed to the YAML later, so they have
+        # to be checked here as well.
+        requested = set(self.yaml_overrides) | set(self.auto_overrides)
+        pinned = sorted(controlled & requested)
         if pinned:
             return False, (
                 f"以下字段由适配器统一计算，不能用 --set 锁定：{pinned}。"
@@ -411,15 +414,19 @@ class ConfigAdapter:
           would otherwise be under-counted;
         * batch settings: ``GBS / (micro_bs * acc) * TP * PP * CP``.
 
-        The comm-group estimate wins when both exist, but a mismatch is
-        surfaced as a warning: it means the source YAML is not self-consistent
-        and every derived batch value inherits that ambiguity.
+        When both exist and disagree, the estimate that is not missing a
+        factor wins: the comm-group one only if ``data_parallel_size`` is
+        declared, otherwise the batch one (an undeclared DP is exactly the
+        factor the comm-group formula would be missing).  Either way the
+        mismatch is reported as a warning, because it means the source YAML is
+        not self-consistent.
         """
         tp, pp, ep, cp, sep = dims_before
 
         sharding = scale_source["sharding_parallel_size"]
-        dp = scale_source["data_parallel_size"]
-        dp = int(dp) if dp and int(dp) > 0 else 1
+        raw_dp = scale_source["data_parallel_size"]
+        dp_declared = raw_dp is not None and int(raw_dp) > 0
+        dp = int(raw_dp) if dp_declared else 1
         group_based = None
         if sharding is not None and int(sharding) > 0:
             group_based = dp * int(sharding) * tp * sep * pp
@@ -433,19 +440,25 @@ class ConfigAdapter:
             if dataset_world_size > 0:
                 batch_based = dataset_world_size * tp * pp * cp
 
-        warning = None
         if group_based is not None and batch_based is not None:
-            if group_based != batch_based:
-                warning = (
-                    f"源卡数的两种推断不一致：按通信组"
-                    f"（DP={dp}×sharding={sharding}×TP={tp}×SEP={sep}×"
-                    f"PP={pp}）为 {group_based}，按 batch 字段"
-                    f"（GBS/(micro×acc)×TP×PP×CP）为 {batch_based}；"
-                    f"取通信组的 {group_based}。"
-                    f"如果不对，请修正源 YAML 的 data_parallel_size 或 "
-                    f"batch 字段后重新适配"
+            if group_based == batch_based:
+                return group_based, None, None
+            chosen = group_based if dp_declared else batch_based
+            warning = (
+                f"源卡数的两种推断不一致：按通信组"
+                f"（DP={dp}×sharding={sharding}×TP={tp}×SEP={sep}×PP={pp}）"
+                f"为 {group_based}，按 batch 字段"
+                f"（GBS/(micro×acc)×TP×PP×CP）为 {batch_based}；"
+                + (
+                    f"源 YAML 未声明 data_parallel_size，"
+                    f"通信组公式会漏掉这个因子，因此取 batch 字段的 {chosen}。"
+                    if not dp_declared
+                    else f"取通信组的 {chosen}。"
                 )
-            return group_based, warning, None
+                + "如果不对，请在源 YAML 里写明 data_parallel_size "
+                "或修正 batch 字段后重新适配"
+            )
+            return chosen, warning, None
         if group_based is not None:
             return group_based, None, None
         if batch_based is not None:

--- a/src/paddlefleet/config_adapter/core.py
+++ b/src/paddlefleet/config_adapter/core.py
@@ -111,15 +111,14 @@ class ConfigAdapter:
 
         # Fields the adapter must own: pinning them with --set would make the
         # generated file disagree with the reported parallelism / sharding.
-        # In-place runs never rewrite model_name_or_path, so pinning that one
-        # is harmless there.
-        controlled = ADAPTER_CONTROLLED_FIELDS
-        if self.in_place:
-            controlled = controlled - {"model_name_or_path"}
+        # model_name_or_path is in the set even for --in-place runs, which do
+        # not rewrite it: repointing it mid-run would decide *which*
+        # model_config.json is loaded, shrunk and snapshotted for the patch,
+        # and the answer differs between the prefixed and prefix-less forms.
         # Prefix-less --set values are routed to the YAML later, so they have
         # to be checked here as well.
         requested = set(self.yaml_overrides) | set(self.auto_overrides)
-        pinned = sorted(controlled & requested)
+        pinned = sorted(ADAPTER_CONTROLLED_FIELDS & requested)
         if pinned:
             return False, (
                 f"以下字段由适配器统一计算，不能用 --set 锁定：{pinned}。"

--- a/src/paddlefleet/config_adapter/planner.py
+++ b/src/paddlefleet/config_adapter/planner.py
@@ -567,6 +567,20 @@ class ShrinkPlanner:
             detail_block = "\n  候选淘汰明细：\n    " + "\n    ".join(detail)
 
         min_cards = min_shrink_cards(tp, pp, ep, cp, sep, cards_per_node)
+        if min_cards is None:
+            advice = (
+                "当前维度组合本身不合法（C3 要求 EP % (TP×SEP) == 0，"
+                "C5 禁止 SEP 与 CP 同时 >1），任何卡数都无法适配，"
+                "必须先修改 TP/SEP/EP/CP"
+            )
+            return (
+                f"精度模式：{target_cards} 卡下找不到合法的 EP/PP 缩容方案 "
+                f"(tp={tp}, pp={pp}, ep={ep}, cp={cp}, sep={sep})。\n"
+                f"  阻断原因：\n    "
+                + "\n    ".join(reasons)
+                + detail_block
+                + f"\n  建议：{advice}"
+            )
         min_nodes = max(min_cards // cards_per_node, 1)
         if min_cards > target_cards:
             advice = (

--- a/src/paddlefleet/config_adapter/planner.py
+++ b/src/paddlefleet/config_adapter/planner.py
@@ -162,7 +162,7 @@ class ShrinkPlanner:
         rejections = []
         if can_shrink_ep:
             pool = []
-            for ep_new in ep_candidates(ep, tp):
+            for ep_new in ep_candidates(ep, tp, sep):
                 ok, why, experts_new = check_ep_shrink(
                     ep, ep_new, num_experts, topk
                 )
@@ -419,7 +419,7 @@ class ShrinkPlanner:
         num_experts, topk, experts_key = moe
 
         pool = []
-        for ep_new in ep_candidates(ep, tp):
+        for ep_new in ep_candidates(ep, tp, sep):
             ok, why, experts_new = check_ep_shrink(
                 ep, ep_new, num_experts, topk
             )

--- a/src/paddlefleet/config_adapter/topology.py
+++ b/src/paddlefleet/config_adapter/topology.py
@@ -75,15 +75,21 @@ class TopologyValidator:
             )
 
         if errors:
-            cards = self.suggest_valid_cards(tp, pp, ep, cp, sep)
-            nodes = [c // self.cards_per_node for c in cards]
             msg = "目标卡数 {} 不满足通信组约束：\n  {}".format(
                 n, "\n  ".join(errors)
             )
-            msg += (
-                f"\n  16 节点内的合法节点数：{nodes}"
-                f"（每节点 {self.cards_per_node} 卡）"
-            )
+            cards = self.suggest_valid_cards(tp, pp, ep, cp, sep)
+            if cards:
+                nodes = [c // self.cards_per_node for c in cards]
+                msg += (
+                    f"\n  16 节点内的合法节点数：{nodes}"
+                    f"（每节点 {self.cards_per_node} 卡）"
+                )
+            else:
+                msg += (
+                    "\n  没有任何卡数能满足：上面的 C3/C5 只取决于并行度本身，"
+                    "与卡数无关，必须先修改 TP/SEP/EP/CP 的组合"
+                )
             return False, msg, {}
 
         sharding = n // (tp * sep * pp)
@@ -99,7 +105,16 @@ class TopologyValidator:
         return True, "通信组约束校验通过", details
 
     def suggest_valid_cards(self, tp, pp, ep, cp, sep=1, max_nodes=16):
-        """List every valid GPU count within ``max_nodes``."""
+        """List every valid GPU count within ``max_nodes``.
+
+        Returns ``[]`` when the dims violate a card-count-independent rule
+        (C3 or C5): no target scale can rescue those, so offering "legal"
+        node counts would be misleading.
+        """
+        if ep > 1 and ep % (tp * sep) != 0:
+            return []
+        if sep > 1 and cp > 1:
+            return []
         factors = [tp * sep * pp, self.cards_per_node]
         if ep > 1:
             factors.append(pp * ep)

--- a/src/paddlefleet/config_adapter/topology.py
+++ b/src/paddlefleet/config_adapter/topology.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Communication-group constraints for a given GPU count (C1..C4)."""
+"""Communication-group constraints for a given GPU count (C1..C5)."""
 
 from __future__ import annotations
 
@@ -22,11 +22,15 @@ from .utils import multi_lcm
 class TopologyValidator:
     """Validates Fleet communication-group constraints.
 
-    Constraints (derived from PaddlePaddle's topology.py):
+    Constraints (derived from PaddlePaddle's topology.py plus the trainer's
+    own assertions):
       C1: N % (TP * SEP * PP) == 0 -> sharding is a positive integer
       C2: N % (PP * EP) == 0       -> moe_sharding is a positive integer
-      C3: EP % TP == 0             -> dense_sharding is a positive integer
+      C3: EP % (TP * SEP) == 0     -> dense_sharding is a positive integer,
+          since dense_sharding = sharding / moe_sharding = EP / (TP * SEP)
       C4: sharding % CP == 0       -> cp_sharding is a positive integer
+      C5: not (SEP > 1 and CP > 1) -> "sep parallel and context parallel
+          cannot be used together" (PaddleFormers training_args.py)
     """
 
     def __init__(self, target_cards, cards_per_node=8):
@@ -34,7 +38,7 @@ class TopologyValidator:
         self.cards_per_node = cards_per_node
 
     def validate(self, tp, pp, ep, cp, sep=1):
-        """Check C1..C4. Returns ``(is_valid, message, details)``."""
+        """Check C1..C5. Returns ``(is_valid, message, details)``."""
         n = self.target_cards
         errors = []
 
@@ -50,9 +54,10 @@ class TopologyValidator:
                 f"!= 0，moe_sharding 不是整数"
             )
 
-        if ep > 1 and ep % tp != 0:
+        if ep > 1 and ep % (tp * sep) != 0:
             errors.append(
-                f"C3 不满足：EP={ep} % TP={tp} != 0，dense_sharding 不是整数"
+                f"C3 不满足：EP={ep} % (TP={tp} × SEP={sep}) != 0，"
+                f"dense_sharding = EP/(TP×SEP) 不是正整数"
             )
 
         if n % (tp * sep * pp) == 0:
@@ -62,6 +67,12 @@ class TopologyValidator:
                     f"C4 不满足：sharding={sharding} % CP={cp} = "
                     f"{sharding % cp} != 0，cp_sharding 不是整数"
                 )
+
+        if sep > 1 and cp > 1:
+            errors.append(
+                f"C5 不满足：SEP={sep} 与 CP={cp} 不能同时大于 1"
+                f"（框架禁止 sep parallel 与 context parallel 同时使用）"
+            )
 
         if errors:
             cards = self.suggest_valid_cards(tp, pp, ep, cp, sep)

--- a/tests/single_card_tests/config_adapter/test_config_adapter.py
+++ b/tests/single_card_tests/config_adapter/test_config_adapter.py
@@ -401,6 +401,18 @@ class TestHardwareAndModelConstraints(unittest.TestCase):
         ok, why = check_hardware(8, 8, 1, 8, 64, 1, 1)
         self.assertTrue(ok, why)
 
+    def test_min_shrink_cards_is_none_for_dim_only_conflicts(self):
+        # C3 can never be satisfied here, so there is no minimum scale.
+        self.assertIsNone(min_shrink_cards(1, 1, 2, 1, 4, 8))
+
+    def test_e2_reports_dim_conflicts_instead_of_crashing(self):
+        # TP*SEP exceeds the target, and the dims themselves are illegal:
+        # the E2 diagnostic used to raise IndexError here.
+        ok, why = check_hardware(2, 8, 1, 1, 2, 1, 4)
+        self.assertFalse(ok)
+        self.assertIn("E2", why)
+        self.assertIn("任何卡数都无法适配", why)
+
     def test_min_shrink_cards_respects_the_floor(self):
         # PP and EP may only shrink to 2, so 2*2 = 4 cards is the floor here.
         self.assertEqual(min_shrink_cards(1, 8, 8, 1, 1, 8), 8)
@@ -512,6 +524,20 @@ class TestSourceScaleInference(unittest.TestCase):
         self.assertIsNone(err)
         self.assertEqual(cards, 96)
         self.assertIn("两种推断不一致", warning)
+
+    def test_batch_evidence_includes_sep(self):
+        # dataset_world_size = DP * sharding, so SEP multiplies back in:
+        # 8 / (1*1) * TP1 * SEP4 * PP1 * CP1 = 32.
+        cards, _warning, err = ConfigAdapter._infer_orig_cards(
+            self._source(
+                sharding_parallel_size=None,
+                global_batch_size=8,
+                gradient_accumulation_steps=1,
+            ),
+            (1, 1, 1, 1, 4),
+        )
+        self.assertIsNone(err)
+        self.assertEqual(cards, 32)
 
     def test_batch_only_source(self):
         cards, _warning, err = ConfigAdapter._infer_orig_cards(
@@ -1061,6 +1087,14 @@ class TestPinnedFieldRejection(ConfigAdapterTestBase):
         )
         self.assertFalse(ok)
         self.assertIn("pipeline_model_parallel_size", message)
+
+    def test_prefix_less_fa_version_pin_is_kept(self):
+        ok, message = self.adapt(
+            target_nodes=1, auto_overrides={"fa_version": 4}
+        )
+        self.assertTrue(ok, message)
+        self.assertEqual(self.load_output_yaml(8)["fa_version"], 4)
+        self.assertNotIn("DELETE field=fa_version", message)
 
     def test_pinned_fa_version_is_kept(self):
         ok, message = self.adapt(

--- a/tests/single_card_tests/config_adapter/test_config_adapter.py
+++ b/tests/single_card_tests/config_adapter/test_config_adapter.py
@@ -1028,6 +1028,15 @@ class TestPinnedFieldRejection(ConfigAdapterTestBase):
         self.assertIn("expert_model_parallel_size", message)
         self.assertIn("不能用 --set 锁定", message)
 
+    def test_pinning_a_parallel_dim_with_a_json_prefix_is_refused(self):
+        ok, message = self.adapt(
+            target_nodes=1,
+            json_overrides={"expert_model_parallel_size": 64},
+        )
+        self.assertFalse(ok)
+        self.assertIn("expert_model_parallel_size", message)
+        self.assertIn("不能用 --set 锁定", message)
+
     def test_pinning_a_parallel_dim_is_refused(self):
         ok, message = self.adapt(
             target_nodes=1,

--- a/tests/single_card_tests/config_adapter/test_config_adapter.py
+++ b/tests/single_card_tests/config_adapter/test_config_adapter.py
@@ -1254,18 +1254,16 @@ class TestPinnedModelPathConflict(ConfigAdapterTestBase):
         self.assertIn("model_name_or_path", message)
         self.assertIn("--set", message)
 
-    def test_in_place_accepts_a_pinned_path(self):
-        ok, message = self.adapt(
-            target_nodes=1,
-            in_place=True,
-            yaml_overrides={"model_name_or_path": "./model_dir"},
-        )
-        self.assertTrue(ok, message)
-        config = YamlWriter().load(self.yaml_path)
-        self.assertEqual(config["model_name_or_path"], "./model_dir")
-        self.assertEqual(
-            JsonWriter().load(self.json_path)["num_hidden_layers"], 16
-        )
+    def test_in_place_also_refuses_a_pinned_path(self):
+        # Repointing the model dir would decide which model_config.json gets
+        # loaded, shrunk and snapshotted for the patch.
+        for overrides in (
+            {"yaml_overrides": {"model_name_or_path": "./other_model"}},
+            {"auto_overrides": {"model_name_or_path": "./other_model"}},
+        ):
+            ok, message = self.adapt(target_nodes=1, in_place=True, **overrides)
+            self.assertFalse(ok)
+            self.assertIn("model_name_or_path", message)
 
 
 class TestInPlace(ConfigAdapterTestBase):

--- a/tests/single_card_tests/config_adapter/test_config_adapter.py
+++ b/tests/single_card_tests/config_adapter/test_config_adapter.py
@@ -365,6 +365,15 @@ class TestTopologyConstraints(unittest.TestCase):
         self.assertFalse(ok)
         self.assertIn("C5", msg)
 
+    def test_no_suggestions_for_dim_only_conflicts(self):
+        validator = TopologyValidator(8, 8)
+        # C3 and C5 depend only on the dims, so no card count can help.
+        self.assertEqual(validator.suggest_valid_cards(1, 1, 2, 1, 4), [])
+        self.assertEqual(validator.suggest_valid_cards(1, 1, 1, 2, 2), [])
+        _ok, msg, _d = validator.validate(1, 1, 2, 1, 4)
+        self.assertIn("没有任何卡数能满足", msg)
+        self.assertNotIn("合法节点数", msg)
+
     def test_suggestions_are_multiples_of_the_minimum_unit(self):
         cards = TopologyValidator(8, 8).suggest_valid_cards(1, 2, 8, 1, 1)
         self.assertTrue(all(c % 16 == 0 for c in cards), cards)
@@ -478,6 +487,22 @@ class TestSourceScaleInference(unittest.TestCase):
         )
         self.assertIsNone(err)
         self.assertEqual(cards, 8)
+
+    def test_batch_evidence_wins_when_dp_is_not_declared(self):
+        # sharding=4 without data_parallel_size, but the batch fields say 8:
+        # the comm-group formula is the one missing a factor.
+        cards, warning, err = ConfigAdapter._infer_orig_cards(
+            self._source(
+                sharding_parallel_size=4,
+                data_parallel_size=None,
+                global_batch_size=8,
+                gradient_accumulation_steps=1,
+            ),
+            (1, 1, 1, 1, 1),
+        )
+        self.assertIsNone(err)
+        self.assertEqual(cards, 8)
+        self.assertIn("未声明 data_parallel_size", warning)
 
     def test_mismatch_is_surfaced_as_a_warning(self):
         cards, warning, err = ConfigAdapter._infer_orig_cards(
@@ -993,6 +1018,15 @@ class TestErrorPaths(ConfigAdapterTestBase):
 
 class TestPinnedFieldRejection(ConfigAdapterTestBase):
     """Adapter-controlled fields may not be pinned with --set."""
+
+    def test_pinning_a_parallel_dim_without_a_prefix_is_refused(self):
+        ok, message = self.adapt(
+            target_nodes=1,
+            auto_overrides={"expert_model_parallel_size": 64},
+        )
+        self.assertFalse(ok)
+        self.assertIn("expert_model_parallel_size", message)
+        self.assertIn("不能用 --set 锁定", message)
 
     def test_pinning_a_parallel_dim_is_refused(self):
         ok, message = self.adapt(

--- a/tests/single_card_tests/config_adapter/test_config_adapter.py
+++ b/tests/single_card_tests/config_adapter/test_config_adapter.py
@@ -80,7 +80,7 @@ num_empty_layers_add_in_head: 0
 num_empty_layers_add_in_tail: 0
 separate_mtp_headloss: false
 fa_version: 3
-global_batch_size: 1536
+global_batch_size: 192
 per_device_train_batch_size: 1
 gradient_accumulation_steps: 2
 sharding_parallel_size: 96
@@ -201,8 +201,9 @@ class TestCandidates(unittest.TestCase):
         self.assertEqual(pp_candidates(2), [])
 
     def test_ep_candidates_respect_tp(self):
-        # C3 requires ep_new % tp == 0.
+        # C3 requires ep_new % (tp * sep) == 0.
         self.assertTrue(all(c % 4 == 0 for c in ep_candidates(64, tp=4)))
+        self.assertTrue(all(c % 8 == 0 for c in ep_candidates(64, tp=2, sep=4)))
 
 
 class TestPrecisionSwitches(unittest.TestCase):
@@ -353,6 +354,17 @@ class TestTopologyConstraints(unittest.TestCase):
         self.assertFalse(ok)
         self.assertIn("C4", msg)
 
+    def test_c3_accounts_for_sep(self):
+        # dense_sharding = EP / (TP * SEP) = 2 / 4 is not a positive integer.
+        ok, msg, _d = TopologyValidator(8, 8).validate(1, 1, 2, 1, 4)
+        self.assertFalse(ok)
+        self.assertIn("C3", msg)
+
+    def test_c5_forbids_sep_and_cp_together(self):
+        ok, msg, _d = TopologyValidator(8, 8).validate(1, 1, 1, 2, 2)
+        self.assertFalse(ok)
+        self.assertIn("C5", msg)
+
     def test_suggestions_are_multiples_of_the_minimum_unit(self):
         cards = TopologyValidator(8, 8).suggest_valid_cards(1, 2, 8, 1, 1)
         self.assertTrue(all(c % 16 == 0 for c in cards), cards)
@@ -429,6 +441,70 @@ class TestHardwareAndModelConstraints(unittest.TestCase):
 
     def test_align_layers_refuses_pp_below_the_floor(self):
         self.assertEqual(align_layers(16, 0, 0, 1, 2), (None, None))
+
+
+class TestSourceScaleInference(unittest.TestCase):
+    """The source world size, and how the two estimates are combined."""
+
+    def _source(self, **overrides):
+        base = {
+            "sharding_parallel_size": 96,
+            "data_parallel_size": 1,
+            "global_batch_size": 192,
+            "per_device_train_batch_size": 1,
+            "gradient_accumulation_steps": 2,
+        }
+        base.update(overrides)
+        return base
+
+    def test_consistent_estimates_agree_without_a_warning(self):
+        cards, warning, err = ConfigAdapter._infer_orig_cards(
+            self._source(), (1, 8, 64, 1, 1)
+        )
+        self.assertIsNone(err)
+        self.assertIsNone(warning)
+        self.assertEqual(cards, 768)
+
+    def test_data_parallel_size_multiplies_the_group_estimate(self):
+        # 8 cards with sharding=4 and DP=2: sharding alone would say 4.
+        cards, _warning, err = ConfigAdapter._infer_orig_cards(
+            self._source(
+                sharding_parallel_size=4,
+                data_parallel_size=2,
+                global_batch_size=8,
+                gradient_accumulation_steps=1,
+            ),
+            (1, 1, 1, 1, 1),
+        )
+        self.assertIsNone(err)
+        self.assertEqual(cards, 8)
+
+    def test_mismatch_is_surfaced_as_a_warning(self):
+        cards, warning, err = ConfigAdapter._infer_orig_cards(
+            self._source(global_batch_size=8, gradient_accumulation_steps=1),
+            (1, 1, 1, 1, 1),
+        )
+        self.assertIsNone(err)
+        self.assertEqual(cards, 96)
+        self.assertIn("两种推断不一致", warning)
+
+    def test_batch_only_source(self):
+        cards, _warning, err = ConfigAdapter._infer_orig_cards(
+            self._source(sharding_parallel_size=None), (1, 8, 1, 1, 1)
+        )
+        self.assertIsNone(err)
+        self.assertEqual(cards, 768)
+
+    def test_nothing_to_infer_from(self):
+        cards, _warning, err = ConfigAdapter._infer_orig_cards(
+            self._source(
+                sharding_parallel_size=None,
+                gradient_accumulation_steps=None,
+            ),
+            (1, 1, 1, 1, 1),
+        )
+        self.assertIsNone(cards)
+        self.assertIn("无法推断源作业的卡数", err)
 
 
 class TestFieldSpec(unittest.TestCase):
@@ -672,7 +748,7 @@ class TestDefaultAdaptation(ConfigAdapterTestBase):
         self.assertEqual(model_config["n_routed_experts"], 16)
         self.assertEqual(model_config["num_hidden_layers"], 16)
         # Default batch strategy shrinks GBS and leaves acc alone.
-        self.assertEqual(config["global_batch_size"], 16)
+        self.assertEqual(config["global_batch_size"], 2)
         self.assertEqual(config["gradient_accumulation_steps"], 2)
         # No determinism switches unless --test-accuracy is given.
         self.assertEqual(config["csa_sparse_attn_backend"], "cudnn")
@@ -707,7 +783,7 @@ class TestPerformanceSwitch(ConfigAdapterTestBase):
         ok, message = self.adapt(target_nodes=64, test_performance=True)
         self.assertTrue(ok, message)
         config = self.load_output_yaml(512)
-        self.assertEqual(config["global_batch_size"], 1024)
+        self.assertEqual(config["global_batch_size"], 128)
         self.assertEqual(config["gradient_accumulation_steps"], 2)
         self.assertEqual(config["sharding_parallel_size"], 64)
         self.assertEqual(config["expert_model_parallel_size"], 64)
@@ -735,7 +811,7 @@ class TestAccuracySwitch(ConfigAdapterTestBase):
         ok, message = self.adapt(target_nodes=1, test_accuracy=True)
         self.assertTrue(ok, message)
         config = self.load_output_yaml(8)
-        self.assertEqual(config["global_batch_size"], 1536)
+        self.assertEqual(config["global_batch_size"], 192)
         self.assertEqual(config["gradient_accumulation_steps"], 192)
         self.assertEqual(config["csa_sparse_attn_backend"], "tilelang")
         self.assertIsNone(self.load_output_json(8)["multimax_modules"])
@@ -750,7 +826,7 @@ class TestAccuracySwitch(ConfigAdapterTestBase):
         # Frozen dims and acc, but the determinism switches still land.
         self.assertEqual(config["expert_model_parallel_size"], 64)
         self.assertEqual(config["gradient_accumulation_steps"], 2)
-        self.assertEqual(config["global_batch_size"], 1024)
+        self.assertEqual(config["global_batch_size"], 128)
         self.assertEqual(config["csa_sparse_attn_backend"], "tilelang")
         self.assertIsNone(self.load_output_json(512)["multimax_modules"])
 
@@ -915,6 +991,44 @@ class TestErrorPaths(ConfigAdapterTestBase):
         self.assertIn("num_hidden_layers", message)
 
 
+class TestPinnedFieldRejection(ConfigAdapterTestBase):
+    """Adapter-controlled fields may not be pinned with --set."""
+
+    def test_pinning_a_parallel_dim_is_refused(self):
+        ok, message = self.adapt(
+            target_nodes=1,
+            yaml_overrides={"expert_model_parallel_size": 64},
+        )
+        self.assertFalse(ok)
+        self.assertIn("expert_model_parallel_size", message)
+        self.assertIn("不能用 --set 锁定", message)
+
+    def test_pinning_sharding_is_refused(self):
+        ok, message = self.adapt(
+            target_nodes=1, yaml_overrides={"sharding_parallel_size": 3}
+        )
+        self.assertFalse(ok)
+        self.assertIn("sharding_parallel_size", message)
+
+    def test_in_place_still_refuses_parallel_dims(self):
+        ok, message = self.adapt(
+            target_nodes=1,
+            in_place=True,
+            yaml_overrides={"pipeline_model_parallel_size": 8},
+        )
+        self.assertFalse(ok)
+        self.assertIn("pipeline_model_parallel_size", message)
+
+    def test_pinned_fa_version_is_kept(self):
+        ok, message = self.adapt(
+            target_nodes=1, yaml_overrides={"fa_version": 4}
+        )
+        self.assertTrue(ok, message)
+        # The pin wins: the field is neither deleted nor reported as deleted.
+        self.assertEqual(self.load_output_yaml(8)["fa_version"], 4)
+        self.assertNotIn("DELETE field=fa_version", message)
+
+
 class TestCliErrorPaths(ConfigAdapterTestBase):
     """Argument validation, straight through main()."""
 
@@ -1068,7 +1182,7 @@ class TestFailureLeavesSourcesUntouched(ConfigAdapterTestBase):
         # the model structure has been planned.
         self.write_yaml(
             SOURCE_YAML.replace(
-                "global_batch_size: 1536", "global_batch_size: 1537"
+                "global_batch_size: 192", "global_batch_size: 193"
             )
         )
         ok, message = self.adapt(target_nodes=1, in_place=True)
@@ -1086,7 +1200,7 @@ class TestFailureLeavesSourcesUntouched(ConfigAdapterTestBase):
     def test_no_adapted_dir_is_created_on_failure(self):
         self.write_yaml(
             SOURCE_YAML.replace(
-                "global_batch_size: 1536", "global_batch_size: 1537"
+                "global_batch_size: 192", "global_batch_size: 193"
             )
         )
         ok, _message = self.adapt(target_nodes=1)
@@ -1104,7 +1218,7 @@ class TestPinnedModelPathConflict(ConfigAdapterTestBase):
         )
         self.assertFalse(ok)
         self.assertIn("model_name_or_path", message)
-        self.assertIn("--in-place", message)
+        self.assertIn("--set", message)
 
     def test_in_place_accepts_a_pinned_path(self):
         ok, message = self.adapt(


### PR DESCRIPTION
### PR Category
User Experience

### PR Types
Bug fixes

### Description
把 #1759（已合入 release/0.4）里的 config_adapter 修复回灌 develop。#1757 先合入了 develop，随后的 review 在 cherry-pick PR 上又发现并修掉了 8 个问题，所以 develop 目前落后于 release/0.4；本 PR 让两个分支的 `src/paddlefleet/config_adapter/**` 与测试完全一致（已逐文件比对，字节相同）。

修复内容：

1. **C3 漏了 SEP**（`topology.py`）：`dense_sharding = sharding / moe_sharding = EP / (TP × SEP)`，因此 `(N=8, TP=1, PP=1, EP=2, SEP=4)` 原本通过校验却算出 `dense_sharding=0`。约束改为 `EP % (TP × SEP) == 0`，EP 候选枚举按同一因子过滤。
2. **SEP 与 CP 互斥未校验**：PaddleFormers `training_args.py` 断言 `not (sep_parallel_size > 1 and context_parallel_size > 1)`，新增为 C5。
3. **`suggest_valid_cards()` 忽略与卡数无关的约束**：C3/C5 冲突时原本仍列出 1~16 节点「合法」，现在返回空候选并说明必须先改并行度组合。
4. **`--set` 锁定适配器自算字段被静默跳过**：`--set expert_model_parallel_size=64` 曾返回成功、报告写 EP 64→4、文件却是 EP64。现在五个并行度、VPP、`num_empty_layers_add_in_tail`、`sharding_parallel_size`、`data_parallel_size`、`model_name_or_path` 一律拒绝锁定，且三种 `--set` 形式（`yaml:` / `json:` / 无前缀）都走同一检查。`model_name_or_path` 连 `--in-place` 也不例外 —— 它决定加载/缩容/快照哪一份 `model_config.json`。
5. **`fa_version` 无条件删除**：显式 `--set yaml:fa_version=4` 会同时出现 CHANGE 与 DELETE 且字段丢失，现在显式锁定优先。
6. **源卡数推断忽略 DP**：`sharding` 只是通信组大小，稠密作业 DP>1 时会少算。改为 `DP × sharding × TP × SEP × PP`，并与 batch 证据 `GBS/(micro×acc) × TP × PP × CP` 交叉校验；两者冲突时取「没漏因子」的那个（声明了 `data_parallel_size` 用通信组，否则用 batch 证据）并在报告里给出 WARNING。

测试：`tests/single_card_tests/config_adapter/test_config_adapter.py` 从 106 增至 121 个用例，覆盖上述每一条；单卡 CI 会真实执行。

### 是否引起精度变化
否。独立命令行工具，不参与训练执行路径，不改动任何现有模块。
