### PR TITLE
[CI] Add retry for git clone in Test-release workflow

### DIFF
--- a/.github/workflows/Test-release.yml
+++ b/.github/workflows/Test-release.yml
@@ -169,7 +169,14 @@ jobs:
           rm -rf * .[^.]*
           set -x
           source /root/proxy
-          git clone https://github.com/PaddlePaddle/PaddleFleet.git .
+          clone_ok=0
+          for i in $(seq 1 5); do
+            if git clone https://github.com/PaddlePaddle/PaddleFleet.git .; then clone_ok=1; break; fi
+            echo "git clone attempt $i failed, retrying in 10s..."
+            rm -rf * .[^.]* || true
+            sleep 10
+          done
+          [ $clone_ok -eq 1 ] || { echo "git clone failed after 5 attempts"; exit 1; }
           git config --global --add safe.directory /paddle
           git config user.name "PaddleCI"
           git config user.email "paddle_ci@example.com"
@@ -564,7 +571,14 @@ jobs:
           source /root/proxy
           set -x
           python -m pip install --upgrade pip
-          git clone -b develop https://github.com/PaddlePaddle/PaddleFormers.git
+          clone_ok=0
+          for i in $(seq 1 5); do
+            if git clone -b develop https://github.com/PaddlePaddle/PaddleFormers.git; then clone_ok=1; break; fi
+            echo "git clone attempt $i failed, retrying in 10s..."
+            rm -rf PaddleFormers || true
+            sleep 10
+          done
+          [ $clone_ok -eq 1 ] || { echo "git clone failed after 5 attempts"; exit 1; }
           cd PaddleFormers
           git config --global --add safe.directory /workspace/PaddleFormers
           if [ ${BRANCH} != "develop" ]; then
@@ -758,7 +772,14 @@ jobs:
           source /root/proxy
           set -x
           python -m pip install --upgrade pip
-          git clone -b develop https://github.com/PaddlePaddle/PaddleFormers.git
+          clone_ok=0
+          for i in $(seq 1 5); do
+            if git clone -b develop https://github.com/PaddlePaddle/PaddleFormers.git; then clone_ok=1; break; fi
+            echo "git clone attempt $i failed, retrying in 10s..."
+            rm -rf PaddleFormers || true
+            sleep 10
+          done
+          [ $clone_ok -eq 1 ] || { echo "git clone failed after 5 attempts"; exit 1; }
           cd PaddleFormers
           if [ ${BRANCH} != "develop" ]; then
             git checkout ${formers_branch}
@@ -1116,7 +1137,14 @@ jobs:
           source /root/proxy
           set -x
           python -m pip install --upgrade pip
-          git clone -b develop https://github.com/PaddlePaddle/PaddleFormers.git
+          clone_ok=0
+          for i in $(seq 1 5); do
+            if git clone -b develop https://github.com/PaddlePaddle/PaddleFormers.git; then clone_ok=1; break; fi
+            echo "git clone attempt $i failed, retrying in 10s..."
+            rm -rf PaddleFormers || true
+            sleep 10
+          done
+          [ $clone_ok -eq 1 ] || { echo "git clone failed after 5 attempts"; exit 1; }
           cd PaddleFormers
           git config --global --add safe.directory /workspace/PaddleFormers
           if [ ${BRANCH} != "develop" ]; then


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Devs

### Description
为 `.github/workflows/Test-release.yml` 中所有 `git clone` 命令增加失败重试，降低因网络抖动导致的 CI flaky 失败。

共 4 处 `git clone`（1 处 PaddleFleet、3 处 PaddleFormers）统一改为最多 5 次重试：每次失败先清理已下载的残留目录再重试，每次间隔 `sleep 10`，5 次全部失败才 `exit 1`。使用 `if git clone ...; then` 形式规避 `bash -ce` 下 `set -e` 导致的提前退出。

这些包含 `git clone` 的 step 本身未设置 `timeout-minutes`，无需放开时间限制。

### 是否引起精度变化
否。仅修改 CI workflow，不涉及训练执行路径。