### PR TITLE
[Tools][release/0.4] config_adapter: fix an E2 crash, the SEP factor and a fa_version pin

### DIFF
--- a/src/paddlefleet/config_adapter/README.md
+++ b/src/paddlefleet/config_adapter/README.md
@@ -97,7 +97,7 @@ python -m paddlefleet.config_adapter --input config.yaml \
 
 源作业卡数按两条证据推断并交叉校验：通信组
 （`DP × sharding × TP × SEP × PP`）与 batch 字段
-（`GBS / (micro_bs × acc) × TP × PP × CP`）。两者都能算且不一致时，取「没漏因子」
+（`GBS / (micro_bs × acc) × TP × SEP × PP × CP`）。两者都能算且不一致时，取「没漏因子」
 的那个 —— 源 YAML 声明了 `data_parallel_size` 就用通信组，没声明则用 batch 字段
 （未声明的 DP 正是通信组公式缺的那一项）—— 并在报告里给出 WARNING。
 

--- a/src/paddlefleet/config_adapter/constraints.py
+++ b/src/paddlefleet/config_adapter/constraints.py
@@ -122,9 +122,14 @@ def align_layers(layers_new, head, tail_orig, pp_new, vpp_orig):
 
 
 def min_shrink_cards(tp, pp, ep, cp, sep, cards_per_node):
-    """Smallest GPU count reachable without collapsing any degree to 1."""
+    """Smallest GPU count reachable without collapsing any degree to 1.
+
+    ``None`` when the dims break a card-count-independent rule (C3 or C5), so
+    no scale exists and callers must talk about the dims instead.
+    """
     validator = TopologyValidator(cards_per_node, cards_per_node)
-    return validator.suggest_valid_cards(*floor_dims(tp, pp, ep, cp, sep))[0]
+    cards = validator.suggest_valid_cards(*floor_dims(tp, pp, ep, cp, sep))
+    return cards[0] if cards else None
 
 
 def check_hardware(target_cards, cards_per_node, tp, pp, ep, cp, sep):
@@ -156,6 +161,13 @@ def check_hardware(target_cards, cards_per_node, tp, pp, ep, cp, sep):
     max_intra = min(cards_per_node, target_cards)
     if tp * sep > max_intra:
         min_cards = min_shrink_cards(tp, pp, ep, cp, sep, cards_per_node)
+        if min_cards is None:
+            return False, (
+                f"E2 不满足：TP={tp} × SEP={sep} 需要单机内 {tp * sep} 张卡，"
+                f"但目标只有 {target_cards} 张卡；而且当前维度组合本身就不合法"
+                f"（C3 要求 EP % (TP×SEP) == 0，C5 禁止 SEP 与 CP 同时 >1），"
+                f"任何卡数都无法适配，必须先修改 TP/SEP/EP/CP"
+            )
         return False, (
             f"E2 不满足：TP={tp} × SEP={sep} 需要单机内 {tp * sep} 张卡，"
             f"但目标只有 {target_cards} 张卡。\n"

--- a/src/paddlefleet/config_adapter/core.py
+++ b/src/paddlefleet/config_adapter/core.py
@@ -142,7 +142,10 @@ class ConfigAdapter:
                 "用户通过 --set yaml: 指定，自动适配不会再覆盖该字段",
             )
 
-        if "fa_version" in config and "fa_version" not in self.yaml_overrides:
+        fa_pinned = "fa_version" in self.yaml_overrides or (
+            "fa_version" in self.auto_overrides
+        )
+        if "fa_version" in config and not fa_pinned:
             log.record_removed(
                 "yaml",
                 "fa_version",
@@ -416,7 +419,10 @@ class ConfigAdapter:
         * comm groups: ``DP * sharding * TP * SEP * PP`` -- ``sharding`` alone
           is a group size, not the world size, so a dense job with ``DP > 1``
           would otherwise be under-counted;
-        * batch settings: ``GBS / (micro_bs * acc) * TP * PP * CP``.
+        * batch settings: ``GBS / (micro_bs * acc) * TP * SEP * PP * CP`` --
+          the trainer defines ``dataset_world_size = DP * sharding`` (or
+          ``sharding / CP`` when CP > 1), so every other degree multiplies
+          back in.
 
         When both exist and disagree, the estimate that is not missing a
         factor wins: the comm-group one only if ``data_parallel_size`` is
@@ -442,7 +448,7 @@ class ConfigAdapter:
         if gbs and micro_bs and grad_accum:
             dataset_world_size = int(gbs) // (int(micro_bs) * int(grad_accum))
             if dataset_world_size > 0:
-                batch_based = dataset_world_size * tp * pp * cp
+                batch_based = dataset_world_size * tp * sep * pp * cp
 
         if group_based is not None and batch_based is not None:
             if group_based == batch_based:
@@ -452,7 +458,7 @@ class ConfigAdapter:
                 f"源卡数的两种推断不一致：按通信组"
                 f"（DP={dp}×sharding={sharding}×TP={tp}×SEP={sep}×PP={pp}）"
                 f"为 {group_based}，按 batch 字段"
-                f"（GBS/(micro×acc)×TP×PP×CP）为 {batch_based}；"
+                f"（GBS/(micro×acc)×TP×SEP×PP×CP）为 {batch_based}；"
                 + (
                     f"源 YAML 未声明 data_parallel_size，"
                     f"通信组公式会漏掉这个因子，因此取 batch 字段的 {chosen}。"

--- a/src/paddlefleet/config_adapter/planner.py
+++ b/src/paddlefleet/config_adapter/planner.py
@@ -567,6 +567,20 @@ class ShrinkPlanner:
             detail_block = "\n  候选淘汰明细：\n    " + "\n    ".join(detail)
 
         min_cards = min_shrink_cards(tp, pp, ep, cp, sep, cards_per_node)
+        if min_cards is None:
+            advice = (
+                "当前维度组合本身不合法（C3 要求 EP % (TP×SEP) == 0，"
+                "C5 禁止 SEP 与 CP 同时 >1），任何卡数都无法适配，"
+                "必须先修改 TP/SEP/EP/CP"
+            )
+            return (
+                f"精度模式：{target_cards} 卡下找不到合法的 EP/PP 缩容方案 "
+                f"(tp={tp}, pp={pp}, ep={ep}, cp={cp}, sep={sep})。\n"
+                f"  阻断原因：\n    "
+                + "\n    ".join(reasons)
+                + detail_block
+                + f"\n  建议：{advice}"
+            )
         min_nodes = max(min_cards // cards_per_node, 1)
         if min_cards > target_cards:
             advice = (

--- a/tests/single_card_tests/config_adapter/test_config_adapter.py
+++ b/tests/single_card_tests/config_adapter/test_config_adapter.py
@@ -401,6 +401,18 @@ class TestHardwareAndModelConstraints(unittest.TestCase):
         ok, why = check_hardware(8, 8, 1, 8, 64, 1, 1)
         self.assertTrue(ok, why)
 
+    def test_min_shrink_cards_is_none_for_dim_only_conflicts(self):
+        # C3 can never be satisfied here, so there is no minimum scale.
+        self.assertIsNone(min_shrink_cards(1, 1, 2, 1, 4, 8))
+
+    def test_e2_reports_dim_conflicts_instead_of_crashing(self):
+        # TP*SEP exceeds the target, and the dims themselves are illegal:
+        # the E2 diagnostic used to raise IndexError here.
+        ok, why = check_hardware(2, 8, 1, 1, 2, 1, 4)
+        self.assertFalse(ok)
+        self.assertIn("E2", why)
+        self.assertIn("任何卡数都无法适配", why)
+
     def test_min_shrink_cards_respects_the_floor(self):
         # PP and EP may only shrink to 2, so 2*2 = 4 cards is the floor here.
         self.assertEqual(min_shrink_cards(1, 8, 8, 1, 1, 8), 8)
@@ -512,6 +524,20 @@ class TestSourceScaleInference(unittest.TestCase):
         self.assertIsNone(err)
         self.assertEqual(cards, 96)
         self.assertIn("两种推断不一致", warning)
+
+    def test_batch_evidence_includes_sep(self):
+        # dataset_world_size = DP * sharding, so SEP multiplies back in:
+        # 8 / (1*1) * TP1 * SEP4 * PP1 * CP1 = 32.
+        cards, _warning, err = ConfigAdapter._infer_orig_cards(
+            self._source(
+                sharding_parallel_size=None,
+                global_batch_size=8,
+                gradient_accumulation_steps=1,
+            ),
+            (1, 1, 1, 1, 4),
+        )
+        self.assertIsNone(err)
+        self.assertEqual(cards, 32)
 
     def test_batch_only_source(self):
         cards, _warning, err = ConfigAdapter._infer_orig_cards(
@@ -1061,6 +1087,14 @@ class TestPinnedFieldRejection(ConfigAdapterTestBase):
         )
         self.assertFalse(ok)
         self.assertIn("pipeline_model_parallel_size", message)
+
+    def test_prefix_less_fa_version_pin_is_kept(self):
+        ok, message = self.adapt(
+            target_nodes=1, auto_overrides={"fa_version": 4}
+        )
+        self.assertTrue(ok, message)
+        self.assertEqual(self.load_output_yaml(8)["fa_version"], 4)
+        self.assertNotIn("DELETE field=fa_version", message)
 
     def test_pinned_fa_version_is_kept(self):
         ok, message = self.adapt(


### PR DESCRIPTION
### PR Category
User Experience

### PR Types
Bug fixes

### Description
Merged in dev: #1768

把 #1768（已合入 develop）cherry-pick 回 release/0.4，让两个分支的 `src/paddlefleet/config_adapter/**` 与测试重新完全一致（tree sha 与本地验证过的 commit 相同）。

修复内容（都是 release/0.4 当前仍带着的问题）：

1. **`min_shrink_cards()` 抛 IndexError**（`constraints.py`）：`suggest_valid_cards()` 在 C3/C5 维度冲突时返回空列表，而 `min_shrink_cards()` 仍无条件取 `[0]`。`--target-nodes 1 --cards-per-node 2` + `TP=1, SEP=4, EP=2, CP=1` 会走到 E2 分支并抛未处理异常。现在返回 `None`，E2 与 planner 的兜底诊断改为说明「维度组合本身不合法（C3/C5），任何卡数都无法适配，必须先改 TP/SEP/EP/CP」，而不是给出一个不存在的建议卡数。
2. **源卡数的 batch 证据漏了 SEP**（`core.py`）：trainer 里 `dataset_world_size = DP × sharding`（CP>1 时是 `sharding / CP`），所以其余并行度都要乘回来。公式修正为 `GBS/(micro×acc) × TP × SEP × PP × CP`，与通信组证据 `DP × sharding × TP × SEP × PP` 交叉校验时不再误报不一致。
3. **显式 `--set fa_version=...` 仍被当作环境相关的 pin 删除**：之前只认 `yaml:fa_version`，无前缀形式会被删掉。现在两种形式都视为锁定。

测试：`test_config_adapter.py` 增加 3 组用例（E2 的维度冲突分支、带 SEP 的源卡数推断、无前缀 `--set fa_version`），共 125 个，单卡 CI 会真实执行。

### 是否引起精度变化
否。独立命令行工具，不参与训练执行路径，不改动任何现有模块。