### PR TITLE
[Feature] Add deterministic TileLang backend for absorbed-MQA sparse backward

### DIFF
--- a/src/paddlefleet/config_adapter/README.md
+++ b/src/paddlefleet/config_adapter/README.md
@@ -173,6 +173,7 @@ C/E/M 全部不通过时，报错会给出候选淘汰明细和最近的合法�
 |---|---|---|---|
 | yaml | `csa_sparse_attn_backend` | `tilelang` | HCA/CSA 的 cudnn 后端（FlashMLA 前向 + cuDNN 反向）与 tilelang 结果不一致 |
 | yaml | `csa_indexer_backend` | `tilelang` | indexer 的 cudnn top-k 与 tilelang 有差异，与上一项取齐 |
+| yaml | `mqa_sparse_attn_backward_backend` | `tilelang` | absorbed-MQA（`csa_compress_ratios=-2`）层的 dKV 反向默认走 cuDNN，原子累加不可逐位复现 |
 | json | `multimax_modules` | `null` | multimax 的可学习 range/ts 引入非确定性 |
 
 新增开关只需在 `precision.py` 的 `PRECISION_SWITCHES` 里加一行，报告与日志会自动

--- a/src/paddlefleet/config_adapter/precision.py
+++ b/src/paddlefleet/config_adapter/precision.py
@@ -54,6 +54,16 @@ PRECISION_SWITCHES = (
         ),
     ),
     PrecisionSwitch(
+        target="yaml",
+        key="mqa_sparse_attn_backward_backend",
+        value="tilelang",
+        reason=(
+            "精度对齐：absorbed-MQA（csa_compress_ratios=-2）层的 dKV 反向"
+            "默认走 cuDNN，其原子累加不可逐位复现，"
+            "与 CSA 后端一起统一切到确定性的 tilelang"
+        ),
+    ),
+    PrecisionSwitch(
         target="json",
         key="multimax_modules",
         value=None,

--- a/src/paddlefleet/fusions/mqa_sparse_attn.py
+++ b/src/paddlefleet/fusions/mqa_sparse_attn.py
@@ -14,11 +14,20 @@
 
 """Sparse attention over the **absorbed** MQA latent (``d_qk=576`` / ``d_v=512``).
 
-Drives exactly the same kernel pair as ``csa_sparse_attn(backend="cudnn")``:
+Always uses FlashMLA sparse forward.  The backward is selected by
+``mqa_sparse_attn_backward_backend``:
 
-  - forward  ``paddlefleet.cudnn_ops.attn.csa_sparse_attn_fwd_cudnn
-    .flash_mla_sparse_attn`` (FlashMLA sparse prefill)
-  - backward ``paddlefleet.cudnn_ops.csa_sparse_attn_bwd_cudnn`` (cuDNN DSA)
+  - ``"cudnn"`` (default): ``paddlefleet.cudnn_ops.csa_sparse_attn_bwd_cudnn``
+    (cuDNN DSA).  Fast but ``dkv`` is not run-to-run reproducible (atomics);
+    ``test_block_sparse_dsa_gradcheck.py::TestDeterminism`` bounds the drift.
+  - ``"tilelang"``: ``paddlefleet.tilelang_ops.attn.mqa_latent_sparse_bwd``
+    (deterministic).  ~14x slower on SM100, bitwise stable across runs for
+    identical inputs.  That does not depend on ``FLAGS_cudnn_deterministic``:
+    it always runs the atomic-free kernel, unlike the symmetric
+    ``sparse_mqa_bwd``, which reads that flag to pick one.
+
+The forward cannot be tilelang because ``sparse_mqa_fwd`` asserts
+``dim == next_power_of_2(dim)`` and ``d_qk = 576`` is not a power of two.
 
 It is kept as a separate ``PyLayer`` instead of a fourth ``backend`` branch of
 ``CSASparseAttention`` because the absorbed layout needs three things the 38
@@ -48,17 +57,19 @@ _NEG_SINK = -1e30
 
 
 class _MQASparseAttention(paddle.autograd.PyLayer):
-    """FlashMLA sparse forward + cuDNN DSA backward for absorbed MQA.
+    """FlashMLA sparse forward + selectable backward for absorbed MQA.
 
     forward inputs:
-        query:         ``[b, s, h, d_qk]`` (``d_qk`` = 576), ``h <= 64``.
-        kv:            ``[b, s_kv, d_qk]`` single shared K/V latent; the value is
-                       its leading ``d_v`` slice.
-        token_indices: ``[b, s, L]`` int32 per-batch-local key columns (``-1``
-                       invalid), already causal/doc masked.
-        sm_scale, d_v: softmax scale and value width.
-        attn_sink:     ``[h]`` learnable per-head sink logit, or ``None`` for a
-                       sinkless softmax.
+        query:            ``[b, s, h, d_qk]`` (``d_qk`` = 576), ``h <= 64``.
+        kv:               ``[b, s_kv, d_qk]`` single shared K/V latent; the value is
+                          its leading ``d_v`` slice.
+        token_indices:    ``[b, s, L]`` int32 per-batch-local key columns (``-1``
+                          invalid), already causal/doc masked.
+        sm_scale, d_v:    softmax scale and value width.
+        attn_sink:        ``[h]`` learnable per-head sink logit, or ``None`` for a
+                          sinkless softmax.
+        backward_backend: ``"cudnn"`` (default, fast, non-deterministic dkv) or
+                          ``"tilelang"`` (deterministic, ~14x slower on SM100).
 
     output: ``[b, s, h * d_v]``, differentiable in ``query``, ``kv`` and
     ``attn_sink``.
@@ -81,6 +92,7 @@ class _MQASparseAttention(paddle.autograd.PyLayer):
         attn_sink=None,
         indexer_topk=0,
         sink_grad_fusion=False,
+        backward_backend="cudnn",
     ):
         from paddlefleet.cudnn_ops.attn.csa_sparse_attn_fwd_cudnn import (
             flash_mla_sparse_attn,
@@ -93,6 +105,12 @@ class _MQASparseAttention(paddle.autograd.PyLayer):
         ctx.sm_scale = float(sm_scale)
         ctx.query_dtype = query.dtype
         ctx.kv_dtype = kv.dtype
+        if backward_backend not in ("cudnn", "tilelang"):
+            raise ValueError(
+                f"mqa_sparse_attn backward_backend must be 'cudnn' or "
+                f"'tilelang', got {backward_backend!r}"
+            )
+        ctx.backward_backend = backward_backend
 
         # Pad query heads up to the DSA-supported h_q == 64. The FlashMLA
         # sparse backend fixes h_q at _DSA_HEADS (sink is [_DSA_HEADS]); it can
@@ -184,11 +202,6 @@ class _MQASparseAttention(paddle.autograd.PyLayer):
 
     @staticmethod
     def backward(ctx, grad_output):
-        from paddlefleet.cudnn_ops import csa_sparse_attn_bwd_cudnn
-        from paddlefleet.fusions.csa_sparse_attn_utils import (
-            _local_to_global_flat,
-        )
-
         (
             q_pad,
             kv,
@@ -214,140 +227,182 @@ class _MQASparseAttention(paddle.autograd.PyLayer):
             do = grad_output
         do = do.contiguous()
 
-        q_flat = q_pad.reshape([b * s, hpad, dk])
-        o_flat = out.reshape([b * s, hpad, d_v])
-        do_flat = do.reshape([b * s, hpad, d_v])
-        kv_flat = kv.reshape([b * skv, dk])
-        gidx_flat = _local_to_global_flat(token_indices, skv)
-
-        # dq/dkv softmax normalization for the finite-sink absorbed-MQA path.
-        #
-        # The forward output was formed with the sink competing in the softmax
-        # denominator: p_k = exp(l_k - lse_full), lse_full = logaddexp(lse_kv,
-        # sink). But the forward kernel returns a KV-only ``lse`` (the sink is
-        # excluded), and the cuDNN DSA backward's ``d_qk != d_v`` branch (the
-        # absorbed-MQA Dk=576 / Dv=512 layout used here) consumes the passed LSE
-        # verbatim -- it does NOT fold the sink into the denominator itself.
-        # Feeding it the KV-only LSE therefore overestimates every p_k for a
-        # finite sink and corrupts dq (confirmed: packed finite-sink dQ cos
-        # 0.976 vs the dense reference). Fix: for a finite (learnable) sink on
-        # this Dk!=Dv path, pass a sink-inclusive LSE and neutralize the sink
-        # argument (a -1e30 sink can no longer double-count in the kernel), so
-        # p_k matches the forward exactly.
-        #
-        # Sinkless keeps the KV-only ``lse`` and the -1e30 ``sink`` untouched
-        # (logaddexp(lse, -1e30) == lse), so that path is bit-for-bit unchanged.
-        # The analytic d_sink below intentionally keeps using the original
-        # KV-only ``lse`` (it re-derives lse_full from it).
-        lse_bwd = lse
-        sink_bwd = sink
-        # This correction is load-bearing and silent: dropping it leaves the
-        # forward output bit-identical (it only touches the backward), while
-        # ``dq`` gets ~75x and ``dkv`` ~120x worse against an autograd
-        # reference. Do not use forward agreement to conclude the backward is
-        # fine. See ``tests/.../test_block_sparse_dsa_gradcheck.py::
-        # test_finite_sink_lse_fix_matters``, which re-drives the raw kernels
-        # with the uncorrected KV-only LSE to pin the gap.
-        if ctx.learnable_sink and dk != d_v:
-            lse_bwd = paddle.logaddexp(
-                lse.astype("float32"),
-                sink.astype("float32").reshape([1, 1, hpad]),
-            ).astype(lse.dtype)
-            sink_bwd = paddle.full([hpad], _NEG_SINK, dtype="float32")
-        lse_flat = lse_bwd.reshape([b * s, hpad])
-
-        dq_flat, dkv_flat, _d_sink_unused = csa_sparse_attn_bwd_cudnn(
-            q_flat,
-            kv_flat,
-            o_flat,
-            do_flat,
-            lse_flat,
-            sink_bwd,
-            gidx_flat,
-            softmax_scale=ctx.sm_scale,
-            topk_length=topk_len_flat,
-        )
-        # ``dkv`` is not run-to-run reproducible: this kernel accumulates the KV
-        # gradient with atomics, so two calls on identical inputs differ by
-        # rel ~2e-3 (measured for both the MQA latent layout and the symmetric
-        # Dk=Dv layout the plain CSA/HCA layers use, i.e. this is a pre-existing
-        # property of the shared kernel, not of the non-absorbed MQA path).
-        # ``dq_flat`` is bit-stable.
-
         gq, gk, gsink = ctx.needs_grad
-        # The cuDNN backward allocates ``dq``/``dkv`` with ``empty_like(q)`` /
-        # ``dtype=kv.dtype`` (``_interface_sm100.py:85,91``), so both already
-        # match the dtypes recorded in the forward and these casts are no-ops.
-        # Paddle's ``cast`` copies even when the dtype is unchanged (measured:
-        # different ``data_ptr``), which for dq is a pointless
-        # ``[b, s, h, d_qk]`` round trip -- 1.2 GB of traffic at
-        # b=1/s=8192/h=64/d_qk=576. Guard on the dtype instead of dropping the
-        # cast, so a backend that starts returning fp32 still converts.
-        dq = None
-        if gq:
-            dq = dq_flat.reshape([b, s, hpad, dk])[:, :, :h, :].contiguous()
-            if dq.dtype != ctx.query_dtype:
-                dq = dq.cast(ctx.query_dtype)
-        dkv = None
-        if gk:
-            dkv = dkv_flat.reshape([b, skv, dk])
-            if dkv.dtype != ctx.kv_dtype:
-                dkv = dkv.cast(ctx.kv_dtype)
-        d_attn_sink = None
-        if gsink:
-            # The cuDNN DSA backward (SM100) allocates ``d_sink`` but its kernel
-            # never populates it -- it always returns zeros. So compute the sink
-            # gradient analytically here from the saved forward tensors.
-            #
-            # For a virtual sink logit ``s_h`` competing in the softmax denom
-            # ``Z = sum_k exp(logit_k) + exp(s_h)``, weight ``p_k = exp(l_k)/Z``
-            # and sink mass ``p_sink = exp(s_h)/Z``. Since
-            # ``d p_k / d s_h = -p_k * p_sink`` and ``out = sum_k p_k v_k``:
-            #   d out / d s_h = -p_sink * out
-            #   d_sink[h] = sum_{b,s}( dO . (d out / d s_h) )
-            #             = -sum_{b,s}( p_sink * (dO . out) )
-            #             = -sum_{b,s}( p_sink * Delta )
-            # with ``Delta[b,s,h] = sum_dv(out * dO)``. The forward LSE is
-            # KV-only (excludes the sink), so the full log-denominator is
-            # ``logaddexp(lse_kv, s_h)`` and ``p_sink = exp(s_h - lse_full)``.
-            #
-            # ``dsa_sink_grad_fusion`` runs that formula as a single Triton
-            # kernel, reading out/do once in their native dtype instead of
-            # materialising three ``[b, s, h, d_v]`` fp32 temporaries (~3.0 GiB
-            # at b=1/s=8192/h=64/d_v=512). Both paths are kept so the switch can
-            # be flipped mid-run to isolate a regression.
-            if ctx.sink_grad_fusion:
-                from paddlefleet.triton_ops.fused_sink_grad import (
-                    fused_sink_grad,
-                )
 
-                d_attn_sink = fused_sink_grad(out, do, lse, sink, h)
-                # ``fused_sink_grad`` always returns fp32; match the dtype of
-                # the ``attn_sink`` the forward received, the way
-                # ``csa_sparse_attn.py`` does. A float32 grad on a bf16
-                # parameter breaks the PyLayer contract and the optimizer's
-                # master-weight path. Skip the cast when it is already fp32.
+        if ctx.backward_backend == "tilelang":
+            from paddlefleet.tilelang_ops.attn.mqa_latent_sparse_bwd import (
+                mqa_latent_sparse_bwd,
+            )
+
+            # The tilelang backward takes the un-padded q/do/lse at the real
+            # head count ``h``, and the sink as [h] (sinkless = -1e30 [hpad]
+            # was built in the forward for the FlashMLA kernel, slice back).
+            sink_h = sink[:h].contiguous()
+            dq_full, dkv_full, d_sink_h = mqa_latent_sparse_bwd(
+                q_pad[:, :, :h, :].contiguous(),
+                kv,
+                out[:, :, :h, :].contiguous(),
+                do[:, :, :h, :].contiguous(),
+                lse[:, :, :h].contiguous(),
+                sink_h,
+                token_indices,
+                ctx.sm_scale,
+            )
+            dq = dq_full if gq else None
+            dkv = dkv_full.cast(ctx.kv_dtype) if gk else None
+            # The kernel's ``d_sink`` reduction is fp32; hand the parameter back
+            # the dtype the forward received (bf16 under AMP), the same contract
+            # the cuDNN branch below and ``csa_sparse_attn.py`` follow.
+            d_attn_sink = None
+            if gsink:
+                d_attn_sink = d_sink_h
                 if d_attn_sink.dtype != ctx.attn_sink_dtype:
                     d_attn_sink = d_attn_sink.cast(ctx.attn_sink_dtype)
-            else:
-                out_h = out[:, :, :h, :].astype("float32")
-                do_h = do[:, :, :h, :].astype("float32")
-                delta = (out_h * do_h).sum(axis=-1)  # [b, s, h]
-                sink_real = sink[:h].astype("float32").reshape([1, 1, h])
-                lse_h = lse[:, :, :h].astype("float32")
-                lse_full = paddle.logaddexp(lse_h, sink_real)
-                p_sink = paddle.exp(sink_real - lse_full)  # [b, s, h]
-                d_attn_sink = (-(delta * p_sink).sum(axis=[0, 1])).contiguous()
-                # Match the dtype of the ``attn_sink`` the forward received, the
-                # way ``csa_sparse_attn.py`` does; a float32 grad on a bf16
-                # parameter breaks the PyLayer contract and the optimizer's
-                # master-weight path.
-                d_attn_sink = d_attn_sink.cast(ctx.attn_sink_dtype)
+        else:
+            from paddlefleet.cudnn_ops import csa_sparse_attn_bwd_cudnn
+            from paddlefleet.fusions.csa_sparse_attn_utils import (
+                _local_to_global_flat,
+            )
+
+            q_flat = q_pad.reshape([b * s, hpad, dk])
+            o_flat = out.reshape([b * s, hpad, d_v])
+            do_flat = do.reshape([b * s, hpad, d_v])
+            kv_flat = kv.reshape([b * skv, dk])
+            gidx_flat = _local_to_global_flat(token_indices, skv)
+
+            # dq/dkv softmax normalization for the finite-sink absorbed-MQA path.
+            #
+            # The forward output was formed with the sink competing in the softmax
+            # denominator: p_k = exp(l_k - lse_full), lse_full = logaddexp(lse_kv,
+            # sink). But the forward kernel returns a KV-only ``lse`` (the sink is
+            # excluded), and the cuDNN DSA backward's ``d_qk != d_v`` branch (the
+            # absorbed-MQA Dk=576 / Dv=512 layout used here) consumes the passed LSE
+            # verbatim -- it does NOT fold the sink into the denominator itself.
+            # Feeding it the KV-only LSE therefore overestimates every p_k for a
+            # finite sink and corrupts dq (confirmed: packed finite-sink dQ cos
+            # 0.976 vs the dense reference). Fix: for a finite (learnable) sink on
+            # this Dk!=Dv path, pass a sink-inclusive LSE and neutralize the sink
+            # argument (a -1e30 sink can no longer double-count in the kernel), so
+            # p_k matches the forward exactly.
+            #
+            # Sinkless keeps the KV-only ``lse`` and the -1e30 ``sink`` untouched
+            # (logaddexp(lse, -1e30) == lse), so that path is bit-for-bit unchanged.
+            # The analytic d_sink below intentionally keeps using the original
+            # KV-only ``lse`` (it re-derives lse_full from it).
+            lse_bwd = lse
+            sink_bwd = sink
+            # This correction is load-bearing and silent: dropping it leaves the
+            # forward output bit-identical (it only touches the backward), while
+            # ``dq`` gets ~75x and ``dkv`` ~120x worse against an autograd
+            # reference. Do not use forward agreement to conclude the backward is
+            # fine. See ``tests/.../test_block_sparse_dsa_gradcheck.py::
+            # test_finite_sink_lse_fix_matters``, which re-drives the raw kernels
+            # with the uncorrected KV-only LSE to pin the gap.
+            if ctx.learnable_sink and dk != d_v:
+                lse_bwd = paddle.logaddexp(
+                    lse.astype("float32"),
+                    sink.astype("float32").reshape([1, 1, hpad]),
+                ).astype(lse.dtype)
+                sink_bwd = paddle.full([hpad], _NEG_SINK, dtype="float32")
+            lse_flat = lse_bwd.reshape([b * s, hpad])
+
+            dq_flat, dkv_flat, _d_sink_unused = csa_sparse_attn_bwd_cudnn(
+                q_flat,
+                kv_flat,
+                o_flat,
+                do_flat,
+                lse_flat,
+                sink_bwd,
+                gidx_flat,
+                softmax_scale=ctx.sm_scale,
+                topk_length=topk_len_flat,
+            )
+            # ``dkv`` is not run-to-run reproducible: this kernel accumulates the KV
+            # gradient with atomics, so two calls on identical inputs differ --
+            # for the MQA latent layout and for the symmetric Dk=Dv layout the
+            # plain CSA/HCA layers use, i.e. this is a pre-existing property of
+            # the shared kernel, not of the non-absorbed MQA path. The magnitude
+            # is bounded by
+            # ``test_block_sparse_dsa_gradcheck.py::TestDeterminism`` rather
+            # than restated here, so one measurement lives in one place.
+            # ``dq_flat`` is bit-stable. Use ``backward_backend="tilelang"`` for
+            # deterministic dkv.
+            #
+            # The cuDNN backward allocates ``dq``/``dkv`` with ``empty_like(q)``
+            # / ``dtype=kv.dtype`` (``_interface_sm100.py:85,91``), so both
+            # already match the dtypes recorded in the forward and these casts
+            # are no-ops. Paddle's ``cast`` copies even when the dtype is
+            # unchanged (measured: different ``data_ptr``), which for dq is a
+            # pointless ``[b, s, h, d_qk]`` round trip -- 1.2 GB of traffic at
+            # b=1/s=8192/h=64/d_qk=576. Guard on the dtype instead of dropping
+            # the cast, so a backend that starts returning fp32 still converts.
+            dq = None
+            if gq:
+                dq = dq_flat.reshape([b, s, hpad, dk])[:, :, :h, :].contiguous()
+                if dq.dtype != ctx.query_dtype:
+                    dq = dq.cast(ctx.query_dtype)
+            dkv = None
+            if gk:
+                dkv = dkv_flat.reshape([b, skv, dk])
+                if dkv.dtype != ctx.kv_dtype:
+                    dkv = dkv.cast(ctx.kv_dtype)
+            d_attn_sink = None
+            if gsink:
+                # The cuDNN DSA backward (SM100) allocates ``d_sink`` but its kernel
+                # never populates it -- it always returns zeros. So compute the sink
+                # gradient analytically here from the saved forward tensors.
+                #
+                # For a virtual sink logit ``s_h`` competing in the softmax denom
+                # ``Z = sum_k exp(logit_k) + exp(s_h)``, weight ``p_k = exp(l_k)/Z``
+                # and sink mass ``p_sink = exp(s_h)/Z``. Since
+                # ``d p_k / d s_h = -p_k * p_sink`` and ``out = sum_k p_k v_k``:
+                #   d out / d s_h = -p_sink * out
+                #   d_sink[h] = sum_{b,s}( dO . (d out / d s_h) )
+                #             = -sum_{b,s}( p_sink * (dO . out) )
+                #             = -sum_{b,s}( p_sink * Delta )
+                # with ``Delta[b,s,h] = sum_dv(out * dO)``. The forward LSE is
+                # KV-only (excludes the sink), so the full log-denominator is
+                # ``logaddexp(lse_kv, s_h)`` and ``p_sink = exp(s_h - lse_full)``.
+                #
+                # ``dsa_sink_grad_fusion`` runs that formula as a single Triton
+                # kernel, reading out/do once in their native dtype instead of
+                # materialising three ``[b, s, h, d_v]`` fp32 temporaries (~3.0
+                # GiB at b=1/s=8192/h=64/d_v=512). Both paths are kept so the
+                # switch can be flipped mid-run to isolate a regression.
+                if ctx.sink_grad_fusion:
+                    from paddlefleet.triton_ops.fused_sink_grad import (
+                        fused_sink_grad,
+                    )
+
+                    d_attn_sink = fused_sink_grad(out, do, lse, sink, h)
+                    # ``fused_sink_grad`` always returns fp32; match the dtype
+                    # of the ``attn_sink`` the forward received, the way
+                    # ``csa_sparse_attn.py`` does. A float32 grad on a bf16
+                    # parameter breaks the PyLayer contract and the optimizer's
+                    # master-weight path. Skip the cast when it is already fp32.
+                    if d_attn_sink.dtype != ctx.attn_sink_dtype:
+                        d_attn_sink = d_attn_sink.cast(ctx.attn_sink_dtype)
+                else:
+                    out_h = out[:, :, :h, :].astype("float32")
+                    do_h = do[:, :, :h, :].astype("float32")
+                    delta = (out_h * do_h).sum(axis=-1)  # [b, s, h]
+                    sink_real = sink[:h].astype("float32").reshape([1, 1, h])
+                    lse_h = lse[:, :, :h].astype("float32")
+                    lse_full = paddle.logaddexp(lse_h, sink_real)
+                    p_sink = paddle.exp(sink_real - lse_full)  # [b, s, h]
+                    d_attn_sink = (
+                        -(delta * p_sink).sum(axis=[0, 1])
+                    ).contiguous()
+                    # Match the dtype of the ``attn_sink`` the forward received,
+                    # the way ``csa_sparse_attn.py`` does; a float32 grad on a
+                    # bf16 parameter breaks the PyLayer contract and the
+                    # optimizer's master-weight path.
+                    d_attn_sink = d_attn_sink.cast(ctx.attn_sink_dtype)
 
         # One returned grad per **tensor** input, in order. Non-tensor inputs
-        # (sm_scale, d_v) occupy no slot. ``attn_sink`` occupies a slot only when
-        # it was passed as a tensor (sinkless -> None -> no slot), so the
-        # returned count is 3 (sinkless) or 4 (learnable sink).
+        # (sm_scale, d_v, backward_backend) occupy no slot. ``attn_sink``
+        # occupies a slot only when it was passed as a tensor (sinkless -> None
+        # -> no slot), so the returned count is 3 (sinkless) or 4 (learnable sink).
         grads = [dq, dkv, None]  # query, kv, token_indices
         if ctx.learnable_sink:
             grads.append(d_attn_sink)
@@ -363,8 +418,9 @@ def mqa_sparse_attn(
     attn_sink=None,
     indexer_topk=0,
     sink_grad_fusion=False,
+    backward_backend="cudnn",
 ):
-    """Absorbed-MQA sparse attention (FlashMLA sparse fwd + cuDNN DSA bwd).
+    """Absorbed-MQA sparse attention (FlashMLA sparse fwd + selectable bwd).
 
     Args:
         query:         ``[b, s, h, d_qk]``, ``h <= 64``.
@@ -390,6 +446,8 @@ def mqa_sparse_attn(
                        from the ``dsa_sink_grad_fusion`` config field; HySparse's
                        ``block_sparse_mqa_attention_dsa`` leaves it at the default
                        and keeps the eager epilogue by design.
+        backward_backend: ``"cudnn"`` (default, fast, non-deterministic dkv) or
+                       ``"tilelang"`` (deterministic, ~14x slower on SM100).
 
     Returns:
         ``[b, s, h * d_v]``, or ``(output, lse_indexer [b, s, 64] fp32)`` when
@@ -404,6 +462,7 @@ def mqa_sparse_attn(
         attn_sink,
         int(indexer_topk),
         sink_grad_fusion,
+        str(backward_backend),
     )
     lse_indexer = _MQASparseAttention._lse_indexer
     _MQASparseAttention._lse_indexer = None

--- a/src/paddlefleet/tilelang_ops/attn/mqa_latent_sparse_bwd.py
+++ b/src/paddlefleet/tilelang_ops/attn/mqa_latent_sparse_bwd.py
@@ -1,0 +1,369 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Deterministic TileLang backward for the absorbed-MQA latent (``Dk != Dv``).
+
+Drop-in replacement for the ``csa_sparse_attn_bwd_cudnn`` half of
+:mod:`paddlefleet.fusions.mqa_sparse_attn`. The FlashMLA sparse forward is left
+alone; only the backward changes, because the cuDNN DSA backward accumulates
+``dkv`` with atomics and is therefore not run-to-run reproducible (bounded by
+``test_block_sparse_dsa_gradcheck.py::TestDeterminism``), which is the one
+remaining source of step-to-step aadiff in the non-absorbed MQA layers once the
+38 CSA/HCA layers are on ``csa_sparse_attn_backend=tilelang``.
+
+Two host-side tricks let this reuse the already-CI-covered *symmetric* kernels in
+:mod:`paddlefleet.tilelang_ops.attn.sparse_mqa_bwd` verbatim, with no new kernel:
+
+1. **Zero-pad ``dO`` from ``Dv`` to ``Dk``.** The absorbed latent's value is the
+   leading ``Dv`` slice of the ``Dk``-wide key, so padding the cotangent with
+   ``Dk - Dv`` zero columns turns the asymmetric problem into the symmetric one
+   the kernel already solves, *exactly*:
+
+   - ``dP = P * (dO_pad . KV^T - Delta)`` -- the padded columns multiply
+     ``KV[:, Dv:]`` and contribute 0, so this equals ``P * (dO . V^T - Delta)``.
+   - ``dKV = dP^T . Q + P^T . dO_pad`` -- the first term is the full ``Dk``-wide
+     key gradient, the second lands only in the leading ``Dv`` columns. That is
+     precisely the shared-latent gradient combination the cuDNN path produces.
+   - ``dQ = dP . KV`` is ``Dk``-wide either way.
+   - ``Delta = sum_Dv(O * dO)`` is computed on the *unpadded* tensors, so ``O``
+     never needs a padded copy (and the kernel never reads ``O`` at all).
+
+   The only cost is running two of the four GEMMs at ``Dk`` instead of ``Dv``
+   (~12% extra FLOPs at 576/512). ``Dk`` need not be a power of two: that assert
+   lives in the *forward* kernel (``sparse_mqa_fwd.py:38``), not the backward.
+
+2. **Tile heads and query rows on the host** instead of touching the kernel.
+   ``bwd_det`` stores ``dKV_buf[b, s, slot, :]`` with a plain (non-atomic) write,
+   which is only race-free while its head-group grid dim is 1, i.e. while
+   ``block_H == padded_H``. At ``Dk = 576`` the three ``[64, Dk]`` bf16 shared
+   buffers (Q, dO, dQ) alone are 216 KB and do not fit SM100's 227 KB budget, so
+   heads *must* be tiled -- done here by calling the kernel once per
+   ``block_h``-wide head group with ``H = block_h``, which keeps its internal
+   ``NH == 1``. Query rows are chunked the same way to bound the
+   ``[B, Sc, L, Dk]`` fp32 ``dKV_buf``: unchunked that is 11.25 GB at
+   ``S=8192, L=640, Dk=576`` (the 38 HCA layers already pay 3.0 GB for it at
+   ``L=192, D=512``).
+
+**Determinism.** ``dq`` is a private per-(row, head-group) accumulator. ``dkv``
+goes through ``bwd_det``'s atomic-free per-slot buffer plus the stable-argsort
+CSR reduction in ``dkv_reduce``; the cross-chunk / cross-head-group combination
+is a fixed-order Python loop. Chunking changes the summation order, so results
+are *not* bitwise equal to a hypothetical unchunked run -- but they are a
+deterministic function of the input shapes, which is what aadiff needs. None of
+this is conditional on ``FLAGS_cudnn_deterministic``: ``bwd_det`` is called
+unconditionally here, unlike the symmetric ``sparse_mqa_bwd``, which reads that
+flag to choose between an atomic and an atomic-free kernel.
+
+**LSE convention bridge.** FlashMLA returns a natural-log, **sink-exclusive**
+LSE, while this backward wants base-2 and **sink-inclusive**: it evaluates
+``P = exp2(score * sm_scale * log2e - Lse)`` and
+``d_sink = -Delta * exp2(sink * log2e - Lse)``. Both are satisfied by
+``lse_tl = logaddexp(lse_kv, sink) * log2(e)`` with ``attn_sink`` passed through
+unscaled. Sinkless callers pass ``sink = -1e30``, for which
+``logaddexp(lse, -1e30) == lse`` and ``exp2(-1e30 * log2e - lse) == 0``, so the
+bridge degenerates correctly and ``d_sink`` comes back as zeros.
+
+**Cost.** This is materially slower than the cuDNN DSA backward it replaces:
+measured on B30Z (SM100) at ``B=1, S=8192, S_kv=8192, H=64, Dk=576, Dv=512,
+L=640``, one full fwd+bwd is 6.2 ms with ``backend="cudnn"`` and 59 ms with this
+one, i.e. ~14x on the backward alone. Three reasons, in order:
+
+1. The ``[B, S, L, Dk]`` fp32 per-slot buffer is written and then read back --
+   24 GB of DRAM traffic where the atomic version keeps its accumulation in L2.
+2. ``block_h`` is capped at 32 by shared memory, so the scores are recomputed
+   once per head group (2 groups at ``H=64``). 64 compiles but spills and
+   measured 3x *worse* (178 ms); 16 is also worse (73 ms).
+3. There is no ``topk_length`` early-stop, so every query row scans the full
+   index width even where it is mostly ``-1``.
+
+Accept that trade only where reproducibility is the point.
+"""
+
+import paddle
+
+from paddlefleet.tilelang_ops.attn.sparse_mqa_bwd import (
+    _build_csr_index,
+    bwd_det,
+    dkv_reduce,
+    postprocess,
+    preprocess,
+)
+
+_LOG2E = 1.4426950408889634
+
+# ``bwd_det`` requires ``topk % _BLOCK_SIZE == 0`` (sparse_mqa_bwd.py:336) and
+# ``preprocess`` tiles S by 32, so every chunk length must be a multiple of this.
+_BLOCK_SIZE = 32
+
+# Default byte budget for the ``[B, Sc, L, Dk]`` fp32 per-slot gradient buffer.
+# 12 GiB is deliberately above the 11.25 GiB the online shape
+# (B=1, S=8192, L=640, Dk=576) needs, i.e. **no chunking by default**, because
+# chunking is the slower option: measured on B30Z (SM100, 275 GB) at that shape,
+# 1 chunk = 59 ms, 8 chunks of 1024 rows = 73 ms, for 15.1 GB vs 4.3 GB of peak
+# allocation. Lower this only under real memory pressure. The budget is the
+# whole buffer including the batch axis, so the same number holds at B > 1 (it
+# chunks there instead of silently allocating B times as much).
+_DEFAULT_DKV_BUF_BYTES = 12 << 30
+
+
+def _pick_chunk(b, s, topk, dk, budget_bytes):
+    """Query-row chunk length for the ``[b, Sc, topk, Dk]`` fp32 buffer.
+
+    Prefers an exact divisor of ``s`` so every chunk has the same length: that
+    keeps a single ``@tilelang.jit`` variant and lets one ``dKV_buf`` allocation
+    be reused across all chunks (``bwd_det`` overwrites every slot, so the buffer
+    needs no clearing between launches).
+
+    ``b`` is part of the row cost because the buffer carries the batch axis:
+    budgeting per ``[topk, Dk]`` row instead would keep the whole sequence in
+    one chunk at ``B=2`` and allocate twice the budget.
+    """
+    row_bytes = b * topk * dk * 4
+    sc_max = max(int(budget_bytes // row_bytes), _BLOCK_SIZE)
+    sc_max = min(sc_max // _BLOCK_SIZE * _BLOCK_SIZE, s)
+    sc_max = max(sc_max, _BLOCK_SIZE)
+    for cand in range(sc_max, 0, -_BLOCK_SIZE):
+        if s % cand == 0:
+            return cand
+    # ``s`` is not a multiple of _BLOCK_SIZE; fall back to a padded tail.
+    return sc_max
+
+
+def _pick_block_h(h):
+    """Largest power-of-two head-group width that divides ``h``, capped at 32.
+
+    ``bwd_det`` needs ``block_h == padded_H`` (its ``dKV_buf`` store is a plain
+    write, so its head-group grid dim must stay 1) and shared memory caps that
+    at 32 for ``Dk = 576``. Smaller widths are legal and measured just as
+    accurate, so a head count the cuDNN backward accepts (anything
+    ``h <= 64``) must not become a hard error here only because 32 does not
+    divide it: per-rank counts of 8 or 16 are what the hybrid-MLA fixtures and
+    any TP > 2 split produce.
+    """
+    for cand in (32, 16, 8, 4, 2):
+        if h % cand == 0:
+            return cand
+    return 1
+
+
+def _reduce_threads(dk):
+    """Thread count for ``dkv_reduce``, which maps ``T.Parallel(Dk)`` onto threads.
+
+    Its layout inference fails outright ("no available layout found") unless the
+    block width divides ``Dk``, so the default 128 is unusable at ``Dk = 576``.
+    """
+    for cand in (256, 192, 128, 96, 64, 32):
+        if dk % cand == 0:
+            return cand
+    return 32
+
+
+def _pad_rows(x, s_pad, fill=0):
+    """``fill``-pad ``x`` along axis 1 up to ``s_pad`` rows."""
+    pad_shape = list(x.shape)
+    pad_shape[1] = s_pad - x.shape[1]
+    return paddle.concat(
+        [x, paddle.full(pad_shape, fill, dtype=x.dtype)], axis=1
+    )
+
+
+def mqa_latent_sparse_bwd(
+    query,
+    kv,
+    out,
+    grad_out,
+    lse,
+    attn_sink,
+    token_indices,
+    sm_scale,
+    block_h=None,
+    dkv_buf_bytes=_DEFAULT_DKV_BUF_BYTES,
+):
+    """Deterministic backward for absorbed-MQA sparse attention.
+
+    Args:
+        query:         ``[B, S, H, Dk]`` bf16.
+        kv:            ``[B, S_kv, Dk]`` bf16 shared latent; the value is its
+                       leading ``Dv`` slice.
+        out:           ``[B, S, H, Dv]`` bf16 normalized forward output.
+        grad_out:      ``[B, S, H, Dv]`` bf16 cotangent.
+        lse:           ``[B, S, H]`` natural-log, **sink-exclusive** LSE, i.e.
+                       exactly what ``flash_mla_sparse_attn`` returns.
+        attn_sink:     ``[H]`` fp32 pre-scaled sink logit in natural-log space.
+                       Sinkless callers pass ``-1e30``.
+        token_indices: ``[B, S, L]`` int32 per-batch-local key columns, ``-1``
+                       for invalid. Width is padded to a multiple of 32 here.
+        sm_scale:      softmax scale applied to the raw ``q.k`` logits.
+        block_h:       query heads per kernel launch. Must divide ``H``. Bounded
+                       by shared memory: three ``[block_h, Dk]`` bf16 buffers
+                       plus ``[32, Dk]`` for the gathered latent must fit, which
+                       at ``Dk=576`` rules out 64. ``None`` (default) picks the
+                       largest power of two that divides ``H``, capped at 32.
+        dkv_buf_bytes: byte budget for the per-slot fp32 gradient buffer, which
+                       sets the query-row chunk length.
+
+    Returns:
+        ``(dq [B, S, H, Dk] bf16, dkv [B, S_kv, Dk] bf16, d_attn_sink [H] fp32)``
+    """
+    b, s, h, dk = query.shape
+    _, s_kv, kv_dk = kv.shape
+    dv = grad_out.shape[-1]
+    if block_h is None:
+        block_h = _pick_block_h(h)
+
+    # Explicit raises rather than ``assert``: these guard a TileLang JIT
+    # specialisation and a multi-GiB allocation, and ``python -O`` strips
+    # asserts, which would turn an illegal Dk/Dv, head count or ``block_h``
+    # into an opaque kernel failure (or an out-of-bounds write) much later.
+    if kv_dk != dk:
+        raise ValueError(f"kv width {kv_dk} != query width {dk}")
+    if dv > dk:
+        raise ValueError(f"Dv ({dv}) must be <= Dk ({dk})")
+    if dk % 16 or dv % 16:
+        raise ValueError(f"Dk/Dv must be a multiple of 16: {dk}/{dv}")
+    if list(out.shape) != [b, s, h, dv]:
+        raise ValueError(f"out {out.shape} != {[b, s, h, dv]}")
+    if list(grad_out.shape) != [b, s, h, dv]:
+        raise ValueError(f"grad_out {grad_out.shape} != {[b, s, h, dv]}")
+    if list(lse.shape) != [b, s, h]:
+        raise ValueError(f"lse {lse.shape} != {[b, s, h]}")
+    if list(attn_sink.shape) != [h]:
+        raise ValueError(f"attn_sink {attn_sink.shape} != {[h]}")
+    if list(token_indices.shape[:2]) != [b, s]:
+        raise ValueError(
+            f"token_indices {token_indices.shape} != [{b}, {s}, L]"
+        )
+    if h % block_h:
+        raise ValueError(f"H ({h}) must be divisible by block_h ({block_h})")
+    # The reused kernels are JIT-specialised on bf16 and assert it internally
+    # (``sparse_mqa_bwd.py:33,86,129,337``), so a caller in an fp16 run would
+    # otherwise land on a bf16 kernel reading fp16 memory -- silently wrong, or
+    # an opaque TileLang AssertionError. Name the offending tensor instead.
+    for name, tensor in (
+        ("query", query),
+        ("kv", kv),
+        ("out", out),
+        ("grad_out", grad_out),
+    ):
+        if tensor.dtype != paddle.bfloat16:
+            raise ValueError(
+                f"{name} must be bfloat16 (the TileLang kernels are built for "
+                f"it); got {tensor.dtype}"
+            )
+
+    # ``Delta[b, s, h] = sum_Dv(O * dO)`` -- computed at the *value* width, so
+    # ``out`` is never padded (and the backward kernel never reads it).
+    delta = preprocess(b, s, h, dv)(out.contiguous(), grad_out.contiguous())
+
+    # LSE convention bridge: natural-log sink-exclusive -> base-2 sink-inclusive.
+    sink32 = attn_sink.astype("float32").contiguous()
+    lse_tl = (
+        paddle.logaddexp(lse.astype("float32"), sink32.reshape([1, 1, h]))
+        * _LOG2E
+    )
+
+    # Zero-pad the cotangent to the key width; see the module docstring for why
+    # this makes the Dk != Dv problem an exact instance of the symmetric one.
+    if dv < dk:
+        grad_out = paddle.concat(
+            [
+                grad_out,
+                paddle.zeros([b, s, h, dk - dv], dtype=grad_out.dtype),
+            ],
+            axis=-1,
+        )
+    grad_out = grad_out.contiguous()
+
+    topk = token_indices.shape[-1]
+    idx = token_indices.astype("int32")
+    if topk % _BLOCK_SIZE:
+        padded = (topk + _BLOCK_SIZE - 1) // _BLOCK_SIZE * _BLOCK_SIZE
+        idx = paddle.concat(
+            [idx, paddle.full([b, s, padded - topk], -1, dtype="int32")],
+            axis=-1,
+        )
+        topk = padded
+
+    sc = _pick_chunk(b, s, topk, dk, dkv_buf_bytes)
+    n_chunks = (s + sc - 1) // sc
+    s_pad = n_chunks * sc
+    n_hg = h // block_h
+
+    # Pad the query axis up to a whole number of chunks once, so the loop body is
+    # uniform (one JIT variant, one reusable buffer) and the tail needs no
+    # special case. Padded rows are inert: q/dO are zero and their whole index
+    # row is -1, so every score masks to -inf, P underflows to 0, and the row
+    # adds nothing to dq / dkv / d_sink (Delta is 0 there too).
+    if s_pad != s:
+        query = _pad_rows(query, s_pad)
+        grad_out = _pad_rows(grad_out, s_pad)
+        lse_tl = _pad_rows(lse_tl, s_pad)
+        delta = _pad_rows(delta, s_pad)
+        idx = _pad_rows(idx, s_pad, fill=-1)
+    idx = idx.contiguous()
+    lse_tl = lse_tl.contiguous()
+
+    # One batched CSR build for *all* chunks instead of one per chunk. Paddle's
+    # stable ``argsort`` is launch-bound at these sizes (measured ~6 ms whether
+    # the input is 0.6M or 5.2M elements), so folding the chunk axis into the
+    # batch axis turns n_chunks sorts into one and was worth ~55% of this
+    # backward's wall time at S=8192 / L=640 / 8 chunks.
+    sort_perm, seg_offsets = _build_csr_index(
+        idx.reshape([b * n_chunks, sc, topk]), s_kv
+    )
+    sort_perm = sort_perm.reshape([b, n_chunks, sc * topk])
+    seg_offsets = seg_offsets.reshape([b, n_chunks, s_kv + 1])
+
+    bwd_kernel = bwd_det(b, sc, s_kv, block_h, dk, topk, float(sm_scale))
+    reduce_kernel = dkv_reduce(
+        b, sc, s_kv, topk, dk, threads=_reduce_threads(dk)
+    )
+    cast_kernel = postprocess(b, s_kv, dk)
+
+    # Reused across every launch: ``bwd_det`` writes every slot unconditionally.
+    dkv_buf = paddle.empty([b, sc, topk, dk], dtype="float32")
+    dsink_buf = paddle.empty([sc, b, block_h], dtype="float32")
+
+    dq = paddle.empty([b, s, h, dk], dtype=query.dtype)
+    dkv_f32 = paddle.zeros([b, s_kv, dk], dtype="float32")
+    dsink_parts = [None] * n_hg
+
+    kv = kv.contiguous()
+    for c in range(n_chunks):
+        s0 = c * sc
+        n = min(sc, s - s0)  # real (unpadded) rows in this chunk
+        idx_c = idx[:, s0 : s0 + sc].contiguous()
+        sort_perm_c = sort_perm[:, c].contiguous()
+        seg_offsets_c = seg_offsets[:, c].contiguous()
+        for g in range(n_hg):
+            h0, h1 = g * block_h, (g + 1) * block_h
+            dq_c = bwd_kernel(
+                query[:, s0 : s0 + sc, h0:h1, :].contiguous(),
+                kv,
+                grad_out[:, s0 : s0 + sc, h0:h1, :].contiguous(),
+                sink32[h0:h1].contiguous(),
+                idx_c,
+                lse_tl[:, s0 : s0 + sc, h0:h1].contiguous(),
+                delta[:, s0 : s0 + sc, h0:h1].contiguous(),
+                dkv_buf,
+                dsink_buf,
+            )
+            dq[:, s0 : s0 + n, h0:h1, :] = dq_c[:, :n]
+            dkv_f32 += reduce_kernel(dkv_buf, sort_perm_c, seg_offsets_c)
+            part = dsink_buf[:n].sum(axis=[0, 1])
+            dsink_parts[g] = (
+                part if dsink_parts[g] is None else dsink_parts[g] + part
+            )
+
+    return dq, cast_kernel(dkv_f32), paddle.concat(dsink_parts).contiguous()

--- a/src/paddlefleet/transformer/mqa_latent_attention.py
+++ b/src/paddlefleet/transformer/mqa_latent_attention.py
@@ -725,6 +725,52 @@ class MQALatentAttention(FleetLayer):
         self.indexer_use_sparse_loss = bool(
             getattr(config, "dsa_indexer_use_sparse_loss", False)
         )
+        # ``dsa_indexer_use_sparse_loss=False`` is the phase-2 (warmup) mode:
+        # the indexer is still being learned, so attention must not consume its
+        # ranking yet -- it attends to the full per-document causal set, exactly
+        # like ``hybrid_mla_attention="mqa_full_causal"``, while the indexer is
+        # trained on the widest candidate table the kernel allows. Consuming a
+        # freshly initialised indexer's top-k here would feed the (frozen)
+        # backbone an essentially random sparse pattern for the whole phase.
+        # ``True`` is the phase-3/4 mode: attention consumes window + top-k and
+        # the KL is restricted to that same set.
+        # ``transformer_config.__post_init__`` pins this to ``train_indexer_only``
+        # so the two cannot disagree. Deliberately *not* cached as a second
+        # attribute: ``_forward_dsa`` reads ``self.indexer_use_sparse_loss``
+        # directly at both use sites, so a test (or anything else) flipping it on
+        # a live module cannot desynchronise the loss width from the attention
+        # set.
+        # Backward kernel for the indexer loss scaler, same switch the CSA layers
+        # read (csa_attention.py:2054). cuDNN's ``d_index_k`` scatters each query
+        # row's gradient to arbitrary key positions with atomics and is not
+        # run-to-run reproducible; "tilelang" has an atomic-free path gated on
+        # ``FLAGS_cudnn_deterministic``. Both apply the same
+        # ``sm_scale = dim**-0.5``, so switching does not change the forward or
+        # the scale. Default matches csa_attention.py's default ("tilelang").
+        #
+        # ``"unfused"`` -- the third value the config accepts -- is served by
+        # tilelang here, and must be: the scaler
+        # (``TileLangCSAIndexerLossAutoScaler.backward``) implements only
+        # "cudnn" and "tilelang" and raises ``NotImplementedError`` otherwise,
+        # so forwarding the name verbatim would turn a configuration the
+        # validation accepts into a crash at the *first sparse backward*, long
+        # after construction. This is the same substitution the warmup KL
+        # already makes for the same reason (see ``_forward_warmup``:
+        # ``unfused`` has no full-candidate implementation to offer either), so
+        # one config value now means one kernel across both phases of the layer.
+        backend = str(getattr(config, "csa_indexer_backend", "tilelang"))
+        self.indexer_backend = "tilelang" if backend == "unfused" else backend
+        # Backward kernel for the sparse MQA attention (dkv). cuDNN accumulates
+        # dkv with atomics and is not run-to-run reproducible (bounded by
+        # ``test_block_sparse_dsa_gradcheck.py::TestDeterminism``); "tilelang"
+        # (mqa_latent_sparse_bwd) is bitwise stable for identical inputs -- by
+        # construction, not via ``FLAGS_cudnn_deterministic`` -- but ~14x slower
+        # on SM100. The forward is always FlashMLA regardless of this switch
+        # (the tilelang forward cannot accept d_qk=576, which is not a power of
+        # two). Default "cudnn" preserves the previous behaviour.
+        self.sparse_attn_backward_backend = str(
+            getattr(config, "mqa_sparse_attn_backward_backend", "cudnn")
+        )
         # Learnable per-head attention-sink logit, from the model-wide
         # ``add_full_attention_sink_bias`` / ``softmax_type``. Built by the same
         # helper ``DotProductAttention`` uses, so the state_dict name
@@ -1614,6 +1660,9 @@ class MQALatentAttention(FleetLayer):
         off, which the backend turns into a sinkless softmax. Query-head padding
         to the DSA-fixed ``h_q == 64`` is the backend's job.
 
+        The forward is always FlashMLA sparse; the backward kernel is selected
+        by ``mqa_sparse_attn_backward_backend`` (see ``__init__``).
+
         ``indexer_topk > 0`` additionally returns the LSE over the first
         ``indexer_topk`` columns, which is the indexer-loss target's normalizer.
         """
@@ -1628,6 +1677,7 @@ class MQALatentAttention(FleetLayer):
             attn_sink=self.softmax_offset,
             indexer_topk=indexer_topk,
             sink_grad_fusion=self.sink_grad_fusion,
+            backward_backend=self.sparse_attn_backward_backend,
         )
 
     @staticmethod
@@ -2056,7 +2106,7 @@ class MQALatentAttention(FleetLayer):
             topk_indices,
             topk_probs,
             loss_coeff,
-            "cudnn",
+            self.indexer_backend,
             # ``num_rows_override`` + ``loss_mask``: the backward zeroes the pad
             # rows and rescales the cuDNN kernel's built-in ``1/(B*Sq)`` into
             # ``1/valid_rows``, matching the forward reduction above. Both

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -1345,6 +1345,22 @@ class TransformerConfig(ModelParallelConfig):
         kernel.
     """
 
+    mqa_sparse_attn_backward_backend: str = "cudnn"
+    """Backward kernel for the absorbed-MQA latent sparse attention (dkv).
+
+    One of {"cudnn", "tilelang"}:
+      * "cudnn" (default): cuDNN DSA backward. Fast, but ``dkv`` accumulates
+        with atomics and is **not** run-to-run reproducible; the drift is
+        bounded by ``test_block_sparse_dsa_gradcheck.py::TestDeterminism``.
+      * "tilelang": deterministic backward via
+        ``tilelang_ops.attn.mqa_latent_sparse_bwd``. ~14x slower on SM100 and
+        bitwise stable for identical inputs, independent of
+        ``FLAGS_cudnn_deterministic`` -- it always runs the atomic-free kernel
+        rather than selecting one from that flag.
+    The forward is always FlashMLA regardless of this switch; the tilelang
+    forward kernel cannot accept ``d_qk=576`` (not a power of two).
+    """
+
     csa_share_docmask_meta: bool = False
     """Share one ``CSADocMaskMetadata`` per (micro-batch, ratio, mask group).
 
@@ -1464,6 +1480,7 @@ class TransformerConfig(ModelParallelConfig):
         "qk_pos_emb_head_dim": "qk_pos_emb_head_dim",
         "hca_rope_type": "hca_rope_type",
         "csa_rope_type": "csa_rope_type",
+        "mqa_sparse_attn_backward_backend": "mqa_sparse_attn_backward_backend",
     }
 
     # Config keys that were renamed and deliberately left without a silent
@@ -2173,6 +2190,15 @@ class TransformerConfig(ModelParallelConfig):
                 raise ValueError(
                     f"csa_sparse_attn_backend={self.csa_sparse_attn_backend!r} is invalid. "
                     "Must be one of {'unfused', 'tilelang', 'cudnn'}."
+                )
+            if self.mqa_sparse_attn_backward_backend not in {
+                "cudnn",
+                "tilelang",
+            }:
+                raise ValueError(
+                    f"mqa_sparse_attn_backward_backend="
+                    f"{self.mqa_sparse_attn_backward_backend!r} is invalid. "
+                    "Must be one of {'cudnn', 'tilelang'}."
                 )
 
             # Per-attention-type RoPE variant validation (HCA / CSA).

--- a/tests/single_card_tests/ai_edited_test/triton_ops/test_fused_sink_grad.py
+++ b/tests/single_card_tests/ai_edited_test/triton_ops/test_fused_sink_grad.py
@@ -361,6 +361,10 @@ def _make_bwd_case(
         attn_sink_dtype=paddle.empty([0], dtype=attn_sink_dtype).dtype,
         learnable_sink=learnable_sink,
         sink_grad_fusion=fusion,
+        # The sink-gradient epilogue under test lives on the cuDNN branch only:
+        # the tilelang backward takes ``d_sink`` from its own kernel and never
+        # reaches ``fused_sink_grad`` (see ``mqa_sparse_attn.backward``).
+        backward_backend="cudnn",
         needs_grad=(True, True, learnable_sink),
     )
     grad_output = (paddle.randn([b, s, h * d_v]) * 0.5).cast(dtype)

--- a/tests/single_card_tests/config_adapter/test_config_adapter.py
+++ b/tests/single_card_tests/config_adapter/test_config_adapter.py
@@ -230,6 +230,27 @@ class TestPrecisionSwitches(unittest.TestCase):
         _applied, skipped = plan_precision_switches({}, None)
         self.assertTrue(any("multimax_modules" in note for note in skipped))
 
+    def test_mqa_backward_backend_is_pinned_even_when_absent(self):
+        # The absorbed-MQA dKV backward defaults to cuDNN, whose atomic
+        # accumulation is not bit-reproducible, so accuracy runs must pin it
+        # like the two CSA backends -- including when no document declares it
+        # yet, which is the common case for existing YAMLs.
+        applied, skipped = plan_precision_switches({}, {})
+        self.assertIn(
+            ("yaml", "mqa_sparse_attn_backward_backend", "tilelang"),
+            [(t, k, v) for t, k, v, _r in applied],
+        )
+        self.assertEqual(skipped, [])
+
+    def test_mqa_backward_backend_follows_the_declaring_document(self):
+        applied, _skipped = plan_precision_switches(
+            {"mqa_sparse_attn_backward_backend": "cudnn"},
+            {"mqa_sparse_attn_backward_backend": "cudnn"},
+        )
+        targets = {(t, k) for t, k, _v, _r in applied}
+        self.assertIn(("yaml", "mqa_sparse_attn_backward_backend"), targets)
+        self.assertIn(("json", "mqa_sparse_attn_backward_backend"), targets)
+
 
 class TestOverrideParsing(unittest.TestCase):
     """``--set`` may name its target file, or let the tool decide."""
@@ -865,6 +886,9 @@ class TestAccuracySwitch(ConfigAdapterTestBase):
         self.assertEqual(config["global_batch_size"], 192)
         self.assertEqual(config["gradient_accumulation_steps"], 192)
         self.assertEqual(config["csa_sparse_attn_backend"], "tilelang")
+        # Written even though the source YAML never declared it: the field's
+        # own default is the non-deterministic cuDNN backward.
+        self.assertEqual(config["mqa_sparse_attn_backward_backend"], "tilelang")
         self.assertIsNone(self.load_output_json(8)["multimax_modules"])
         self.assertIn("精度对齐", message)
 

--- a/tests/single_card_tests/transformer/test_dsv4_hybrid_attention.py
+++ b/tests/single_card_tests/transformer/test_dsv4_hybrid_attention.py
@@ -163,6 +163,7 @@ def _make_config(
     num_nextn_predict_layers=0,
     csa_indexer_backend="unfused",
     csa_sparse_attn_backend="unfused",
+    mqa_sparse_attn_backward_backend="cudnn",
     tensor_model_parallel_size=1,
     context_parallel_size=1,
     csa_dense_mode=False,
@@ -230,6 +231,7 @@ def _make_config(
         softmax_type="vanilla",
         csa_indexer_backend=csa_indexer_backend,
         csa_sparse_attn_backend=csa_sparse_attn_backend,
+        mqa_sparse_attn_backward_backend=mqa_sparse_attn_backward_backend,
         tensor_model_parallel_size=tensor_model_parallel_size,
         context_parallel_size=context_parallel_size,
         csa_dense_mode=csa_dense_mode,
@@ -524,6 +526,25 @@ class TestDSv4HybridConfigAndSpec(unittest.TestCase):
             ValueError, "csa_sparse_attn_backend='paddle' is invalid"
         ):
             _make_config(csa_sparse_attn_backend="paddle")
+
+    def test_mqa_sparse_attn_backward_backend_validation(self):
+        # Only the absorbed-MQA *backward* is switchable (the forward is always
+        # FlashMLA sparse), so this list is deliberately shorter than the two
+        # above -- there is no "unfused" backward for the Dk != Dv layout.
+        for backend in ("cudnn", "tilelang"):
+            cfg = _make_config(mqa_sparse_attn_backward_backend=backend)
+            self.assertEqual(cfg.mqa_sparse_attn_backward_backend, backend)
+
+        with self.assertRaisesRegex(
+            ValueError, "mqa_sparse_attn_backward_backend='unfused' is invalid"
+        ):
+            _make_config(mqa_sparse_attn_backward_backend="unfused")
+
+    def test_mqa_sparse_attn_backward_backend_defaults_to_cudnn(self):
+        # The deterministic backward is ~14x slower, so it must stay opt-in.
+        self.assertEqual(
+            _make_config().mqa_sparse_attn_backward_backend, "cudnn"
+        )
 
     def test_csa_cudnn_indexer_allows_config_with_cp(self):
         cfg = _make_config(csa_indexer_backend="cudnn", context_parallel_size=2)

--- a/tests/single_card_tests/transformer/test_mqa_latent_attention.py
+++ b/tests/single_card_tests/transformer/test_mqa_latent_attention.py
@@ -965,6 +965,88 @@ class TestMQADSA(unittest.TestCase):
             )
         self.assertIn("values", DSAIndexerLossLoggingHelper.tracker)
 
+    def test_deterministic_sparse_backward_runs_at_the_fixture_head_count(self):
+        # ``mqa_sparse_attn_backward_backend="tilelang"`` must be usable on the
+        # same layers as the default: this fixture has H=8 heads per rank, well
+        # below the 32-wide head group the tilelang backward prefers, and the
+        # cuDNN backward it replaces accepts any ``h <= 64``. Two runs must also
+        # give bitwise identical gradients -- that is the whole point of the
+        # switch (cuDNN's dkv scatter-add is not reproducible).
+        config = _create_mqa_config("mqa_dsa", loss_coeff=0.01)
+        config.mqa_sparse_attn_backward_backend = "tilelang"
+        module = _build_module(config, bf16=True)
+        self.assertEqual(module.sparse_attn_backward_backend, "tilelang")
+        module.train()
+        seqlen = WINDOW + INDEX_TOPK
+
+        def once():
+            # Fresh input leaves each time (the module and its weights are
+            # shared, so only the inputs' own gradients are compared).
+            query, key, w_v, x, qr = self._inputs(seqlen)
+            for tensor in (query, key, x, qr):
+                tensor.stop_gradient = False
+            out = module(
+                query,
+                key,
+                None,
+                None,
+                _row_end([seqlen], seqlen),
+                v_b_proj_weight=w_v,
+                x=x,
+                qr=qr,
+            )
+            out.cast("float32").sum().backward()
+            return (
+                query.grad.cast("float32").numpy().copy(),
+                key.grad.cast("float32").numpy().copy(),
+            )
+
+        dq1, dkv1 = once()
+        for name, grad in (("query", dq1), ("key", dkv1)):
+            self.assertTrue(
+                bool(np.isfinite(grad).all()), f"{name} grad is not finite"
+            )
+        dq2, dkv2 = once()
+        self.assertTrue(np.array_equal(dq1, dq2), "dq is not reproducible")
+        self.assertTrue(np.array_equal(dkv1, dkv2), "dkv is not reproducible")
+
+    def test_unfused_indexer_backend_survives_the_sparse_backward(self):
+        # ``csa_indexer_backend="unfused"`` is accepted by the config validation
+        # and used by several hybrid-MLA fixtures, but the loss scaler
+        # (``TileLangCSAIndexerLossAutoScaler.backward``) implements only
+        # "cudnn" and "tilelang". Forwarding the name verbatim made a legal
+        # configuration raise ``NotImplementedError`` on the *first* sparse
+        # backward, so the layer maps it onto tilelang -- the same substitution
+        # the warmup KL makes. This runs the real backward to prove it.
+        config = _create_mqa_config("mqa_dsa", loss_coeff=0.01)
+        config.csa_indexer_backend = "unfused"
+        module = _build_module(config, bf16=True)
+        self.assertEqual(module.indexer_backend, "tilelang")
+
+        seqlen = WINDOW + INDEX_TOPK
+        query, key, w_v, x, qr = self._inputs(seqlen)
+        for tensor in (query, key, x, qr):
+            tensor.stop_gradient = False
+        module.train()
+        out = module(
+            query,
+            key,
+            None,
+            None,
+            _row_end([seqlen], seqlen),
+            v_b_proj_weight=w_v,
+            x=x,
+            qr=qr,
+        )
+        out.cast("float32").sum().backward()
+        for name in ("wq_b", "wk", "weights_proj"):
+            grad = getattr(module.indexer, name).linear.weight.grad
+            self.assertIsNotNone(grad, f"indexer.{name} has no gradient")
+            self.assertTrue(
+                bool(paddle.isfinite(grad.cast("float32")).all()),
+                f"indexer.{name} gradient is not finite",
+            )
+
     def test_indexer_loss_mask_comes_from_input_ids(self):
         """Padding rows must not dilute the KL loss, and only ``input_ids`` sees them.
 
@@ -2136,6 +2218,51 @@ class TestSparseAttnPlumbingMocked(unittest.TestCase):
         # "sinkless softmax", it is not an omitted argument.
         self.assertIsNone(kwargs["attn_sink"])
         self.assertIn("attn_sink", kwargs)
+
+    def _call(self, module, calls):
+        with self._patched(calls):
+            module._sparse_attn(
+                paddle.zeros([1, 2, H, DK], dtype="bfloat16"),
+                paddle.zeros([1, 2, DK], dtype="bfloat16"),
+                paddle.zeros([1, 2, 4], dtype="int32"),
+                module.softmax_scale,
+                DV,
+            )
+
+    def test_backward_backend_is_read_from_the_config(self):
+        # ``mqa_sparse_attn_backward_backend`` picks the dkv backward: "cudnn"
+        # (fast, atomics, non-reproducible) or "tilelang" (deterministic, ~14x
+        # slower). The layer only forwards it, but it must forward the
+        # *configured* value -- a silent default here would make the
+        # determinism switch a no-op.
+        calls = []
+        self._call(self.module, calls)
+        self.assertEqual(calls[0][2]["backward_backend"], "cudnn")
+
+        config = _create_mqa_config("mqa_dsa")
+        config.mqa_sparse_attn_backward_backend = "tilelang"
+        calls = []
+        self._call(_build_module(config, bf16=True), calls)
+        self.assertEqual(calls[0][2]["backward_backend"], "tilelang")
+
+    def test_indexer_backend_is_read_from_the_config(self):
+        # The indexer-loss scaler shares the CSA layers' ``csa_indexer_backend``
+        # switch; cuDNN's ``d_index_k`` scatter is the non-reproducible half.
+        module = _build_module(_create_mqa_config("mqa_dsa"), bf16=True)
+        self.assertEqual(module.indexer_backend, "tilelang")
+        config = _create_mqa_config("mqa_dsa")
+        config.csa_indexer_backend = "cudnn"
+        self.assertEqual(
+            _build_module(config, bf16=True).indexer_backend, "cudnn"
+        )
+        # "unfused" has no scaler backward of its own, so it is served by
+        # tilelang instead of reaching the scaler's NotImplementedError. The
+        # real backward is exercised in ``TestMQADSA``.
+        config = _create_mqa_config("mqa_dsa")
+        config.csa_indexer_backend = "unfused"
+        self.assertEqual(
+            _build_module(config, bf16=True).indexer_backend, "tilelang"
+        )
 
 
 class TestForwardDsaFusedDispatchMocked(unittest.TestCase):

--- a/tests/single_card_tests/transformer/test_mqa_latent_sparse_bwd.py
+++ b/tests/single_card_tests/transformer/test_mqa_latent_sparse_bwd.py
@@ -1,0 +1,611 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Determinism and numerics for the TileLang absorbed-MQA backward.
+
+``mqa_sparse_attn_backward_backend="tilelang"`` swaps the cuDNN DSA backward of
+:mod:`paddlefleet.fusions.mqa_sparse_attn` for
+:func:`paddlefleet.tilelang_ops.attn.mqa_latent_sparse_bwd`. The FlashMLA
+sparse forward is untouched by the switch. The reason the switch exists is
+reproducibility: cuDNN accumulates ``dkv`` with atomics, so two backward passes
+over identical inputs differ (rel ~8e-6, bounded in
+``test_block_sparse_dsa_gradcheck.TestDeterminism``), which is the last source
+of step-to-step aadiff in the latent-MQA layers. The tilelang path is
+atomic-free and must be *bitwise* stable.
+
+What is checked, and against what:
+
+* **Numerics** -- ``dq`` / ``dkv`` / ``d_sink`` against the fp32 differentiable
+  reference forward of ``test_block_sparse_dsa_gradcheck``
+  (``_analytic_ref_grads``), i.e. an independent oracle, never the cuDNN
+  backward alone. The floor is bf16-limited (measured ~3.8e-3 dq, ~2.8e-3 dkv,
+  ~2.5e-3 d_sink -- the same order that suite measures for cuDNN).
+* **Determinism** -- repeated identical runs must be bitwise equal.
+* **Host-side tiling** in ``mqa_latent_sparse_bwd``: head groups (``block_h``),
+  query-row chunking (``dkv_buf_bytes``), the ``topk`` padding up to a multiple
+  of 32 and the padded query tail. A tiling bug shows up as a wrong *sum*, not
+  as a crash, so each variant is compared against the same reference.
+"""
+
+import unittest
+
+import numpy as np
+import paddle
+
+from paddlefleet.fusions.mqa_sparse_attn import (
+    _DSA_HEADS,
+    _NEG_SINK,
+    mqa_sparse_attn,
+)
+from paddlefleet.tilelang_ops.attn.mqa_latent_sparse_bwd import (
+    _BLOCK_SIZE,
+    _pad_rows,
+    _pick_block_h,
+    _pick_chunk,
+    _reduce_threads,
+    mqa_latent_sparse_bwd,
+)
+
+from .hybrid_mla_utils import _GPU
+from .test_block_sparse_dsa_gradcheck import (
+    DK,
+    DV,
+    SM,
+    _analytic_ref_grads,
+    _causal_indices,
+    _rand,
+    _relerr,
+    _to_bf16,
+)
+
+# ``mqa_latent_sparse_bwd`` launches one kernel per head group; the group width
+# defaults to the largest power of two dividing ``H`` (capped at 32 by shared
+# memory), so every head count the forward accepts is reachable.
+H_SMALL = 32
+H_FULL = 64  # production head count -> two head groups
+
+# bf16 round-off floor, measured on B30Z (SM100): dq 3.8e-3, dkv 2.8e-3,
+# d_sink 2.5e-3 against the fp32 reference. 8e-3 leaves ~2x headroom.
+REF_TOL = 8e-3
+# Reordering-only differences (chunked vs unchunked summation, tilelang vs
+# cuDNN accumulation order). Measured 2.7e-6 and 6.2e-4 respectively.
+REORDER_TOL = 1e-3
+
+
+# The tilelang backward needs CUDA and a tilelang JIT, and nothing else: it is
+# deliberately *not* behind ``_GPU`` (``is_dsa_available()``), which refuses
+# anything below SM100 on behalf of the FlashMLA forward + cuDNN DSA backward.
+# Only the end-to-end dispatch tests, which do run those two, keep that gate.
+_TILELANG = unittest.skipUnless(
+    paddle.is_compiled_with_cuda(),
+    "tilelang absorbed-MQA backward requires CUDA (but not SM100)",
+)
+
+
+def _inputs(h, s, topk, seed):
+    """``(q [1,s,h,DK], kv [1,s,DK], ti [1,s,topk], dO [1,s,h*DV])``."""
+    return (
+        _rand([1, s, h, DK], 0.3, seed),
+        _rand([1, s, DK], 0.3, seed + 1),
+        _causal_indices(s, topk, seed=seed + 2),
+        _rand([1, s, h * DV], 1.0, seed + 3),
+    )
+
+
+def _layer_run(q, kv, ti, dO, backend, sink_mag=None):
+    """One fwd+bwd through the PyLayer. Returns fp32 numpy copies of
+    ``(out, dq, dkv, d_sink)``; ``d_sink`` is ``None`` when sinkless."""
+    qb, kvb = _to_bf16(q), _to_bf16(kv)
+    qb.stop_gradient = False
+    kvb.stop_gradient = False
+    sink_t = None
+    if sink_mag is not None:
+        sink_t = paddle.full([q.shape[2]], float(sink_mag), dtype="float32")
+        sink_t.stop_gradient = False
+    out = mqa_sparse_attn(
+        qb,
+        kvb,
+        paddle.to_tensor(ti),
+        float(SM),
+        DV,
+        sink_t,
+        backward_backend=backend,
+    )
+    dO_t = paddle.to_tensor(dO.reshape(out.shape))
+    (out.cast("float32") * dO_t).sum().backward()
+    return (
+        out.cast("float32").numpy().copy(),
+        qb.grad.cast("float32").numpy()[0].copy(),
+        kvb.grad.cast("float32").numpy()[0].copy(),
+        None if sink_t is None else sink_t.grad.numpy().copy(),
+    )
+
+
+def _eager_forward(q, kv, ti, sink_mag):
+    """The backward's inputs built in fp32 paddle -- no FlashMLA, no SM100.
+
+    ``mqa_latent_sparse_bwd`` needs ``out`` and ``lse``, and both are pure
+    definitions over the selected columns: ``lse`` is the natural-log,
+    **sink-exclusive** logsumexp of the masked logits and ``out`` is the
+    softmax-weighted value sum *with* the sink in the denominator, exactly what
+    ``flash_mla_sparse_attn`` returns. Building them here instead of calling
+    that kernel does two things: it takes the tilelang backward off the
+    ``is_dsa_available()`` SM100 gate (the tilelang kernels have no such
+    requirement -- only the FlashMLA forward does), and it makes the backward
+    tests independent of the forward kernel, so a forward regression cannot
+    mask a backward bug.
+
+    ``sink_mag=None`` is the sinkless contract: ``-1e30``, for which
+    ``logaddexp(lse, -1e30) == lse`` and ``d_sink`` comes back as zeros.
+
+    Returns ``(q_bf16, kv_bf16, out, lse, sink[h], token_indices)``.
+    """
+    b, s, h, _ = q.shape
+    topk = ti.shape[-1]
+    qb, kvb = _to_bf16(q), _to_bf16(kv)
+    q32 = paddle.to_tensor(q[0])
+    kv32 = paddle.to_tensor(kv[0])
+    cols = paddle.to_tensor(ti.reshape([s, topk])).cast("int64")
+    valid = cols >= 0
+    safe = paddle.where(valid, cols, paddle.zeros_like(cols))
+    ksel = paddle.gather(kv32, safe.flatten(), axis=0).reshape([s, topk, DK])
+    logit = paddle.einsum("shd,sld->shl", q32, ksel) * float(SM)
+    logit = paddle.where(
+        valid.unsqueeze(1), logit, paddle.full_like(logit, _NEG_SINK)
+    )
+    lse = paddle.logsumexp(logit, axis=-1)  # [s, h], sink-exclusive
+    real = _NEG_SINK if sink_mag is None else float(sink_mag)
+    sink = paddle.full([h], real, dtype="float32")
+    lse_full = paddle.logaddexp(lse, sink.reshape([1, h]))
+    p = paddle.exp(logit - lse_full.unsqueeze(-1))
+    out = paddle.einsum("shl,sld->shd", p, ksel[:, :, :DV])
+    return (
+        qb,
+        kvb,
+        out.unsqueeze(0).cast("bfloat16").contiguous(),
+        lse.unsqueeze(0).cast("float32").contiguous(),
+        sink,
+        paddle.to_tensor(ti),
+    )
+
+
+def _kernel_run(q, kv, ti, dO, sink_mag=None, **kwargs):
+    """``mqa_latent_sparse_bwd`` on eager-built inputs. fp32 numpy copies."""
+    b, s, h, _ = q.shape
+    qb, kvb, out, lse, sink, ti_t = _eager_forward(q, kv, ti, sink_mag)
+    do = paddle.to_tensor(dO.reshape([b, s, h, DV])).cast(out.dtype)
+    dq, dkv, dsink = mqa_latent_sparse_bwd(
+        qb, kvb, out, do, lse, sink, ti_t, float(SM), **kwargs
+    )
+    return (
+        dq.cast("float32").numpy()[0].copy(),
+        dkv.cast("float32").numpy()[0].copy(),
+        dsink.numpy().copy(),
+    )
+
+
+class _Base(unittest.TestCase):
+    """GPU device only -- deliberately no ``FLAGS_cudnn_deterministic`` pin.
+
+    ``mqa_latent_sparse_bwd`` calls ``bwd_det`` unconditionally, unlike the
+    symmetric ``sparse_mqa_bwd`` (``sparse_mqa_bwd.py:613``) which reads that
+    flag to choose between an atomic and an atomic-free kernel. So the
+    determinism asserted below is a property of the code path, not of a process
+    flag, and pinning one here would both weaken the test and leak: the flag is
+    process-global and feeds ``flash_mask_facade.get_fa_version``, which pushes
+    the other hybrid-MLA suites off FA4 when pytest shares a process.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        paddle.set_device("gpu")
+
+    def _assert_matches_reference(self, got, q, kv, ti, dO, sink_mag=None):
+        """dq / dkv (/ d_sink) within the bf16 floor of the fp32 oracle."""
+        dq, dkv, dsink = got
+        ref_q, ref_kv, ref_sink = _analytic_ref_grads(q, kv, ti, dO, sink_mag)
+        self.assertLess(_relerr(dq, ref_q), REF_TOL, "dq")
+        self.assertLess(_relerr(dkv, ref_kv), REF_TOL, "dkv")
+        if sink_mag is not None:
+            self.assertLess(_relerr(dsink, ref_sink), REF_TOL, "d_sink")
+
+
+# ===========================================================================
+# 1. Backend dispatch through ``mqa_sparse_attn``
+# ===========================================================================
+@_GPU
+class TestBackendDispatch(_Base):
+    """The switch selects a backward and changes nothing else."""
+
+    def test_tilelang_backward_matches_fp32_reference(self):
+        for sink_mag in (None, 0.5):
+            with self.subTest(sink=sink_mag):
+                q, kv, ti, dO = _inputs(H_SMALL, 64, 64, 300)
+                _, dq, dkv, dsink = _layer_run(
+                    q, kv, ti, dO, "tilelang", sink_mag
+                )
+                self._assert_matches_reference(
+                    (dq, dkv, dsink), q, kv, ti, dO, sink_mag
+                )
+
+    def test_forward_is_identical_across_backends(self):
+        # The forward is FlashMLA either way, so it must be bit-identical; only
+        # the gradients may differ, and then only by accumulation order.
+        q, kv, ti, dO = _inputs(H_SMALL, 64, 64, 310)
+        o_c, dq_c, dkv_c, ds_c = _layer_run(q, kv, ti, dO, "cudnn", 0.25)
+        o_t, dq_t, dkv_t, ds_t = _layer_run(q, kv, ti, dO, "tilelang", 0.25)
+        self.assertTrue(
+            np.array_equal(o_c, o_t), "backward_backend changed the forward"
+        )
+        self.assertLess(_relerr(dq_t, dq_c), REORDER_TOL * 4, "dq")
+        self.assertLess(_relerr(dkv_t, dkv_c), REORDER_TOL, "dkv")
+        # The two d_sink values come from different code entirely -- the eager
+        # analytic epilogue for cuDNN (whose kernel returns zeros) versus the
+        # tilelang kernel's own reduction -- so agreement here is a real
+        # cross-check of both, not a tautology.
+        self.assertLess(_relerr(ds_t, ds_c), REORDER_TOL, "d_sink")
+
+    def test_default_backend_is_cudnn(self):
+        # Omitting the argument must keep the fast path, i.e. the switch is
+        # opt-in and cannot silently cost 14x.
+        q, kv, ti, dO = _inputs(H_SMALL, 32, 32, 320)
+        qb, kvb = _to_bf16(q), _to_bf16(kv)
+        qb.stop_gradient = False
+        out = mqa_sparse_attn(qb, kvb, paddle.to_tensor(ti), float(SM), DV)
+        dO_t = paddle.to_tensor(dO.reshape(out.shape))
+        (out.cast("float32") * dO_t).sum().backward()
+        default = _layer_run(q, kv, ti, dO, "cudnn")[1]
+        self.assertTrue(
+            np.array_equal(qb.grad.cast("float32").numpy()[0], default)
+        )
+
+    def test_fixture_head_count_works_end_to_end(self):
+        # The hybrid-MLA fixtures run 8 heads per rank, which used to be a hard
+        # error on this backend. The rest of the head-count range, and the
+        # numerics, are covered ungated in ``TestTilelangBackward``; this only
+        # pins that the *layer* path survives it.
+        q, kv, ti, dO = _inputs(8, 64, 64, 340)
+        _, dq_t, dkv_t, _ = _layer_run(q, kv, ti, dO, "tilelang", 0.25)
+        _, dq_c, dkv_c, _ = _layer_run(q, kv, ti, dO, "cudnn", 0.25)
+        self.assertLess(_relerr(dq_t, dq_c), REORDER_TOL * 4, "dq")
+        self.assertLess(_relerr(dkv_t, dkv_c), REORDER_TOL, "dkv")
+
+    def test_cudnn_dkv_is_the_baseline_this_replaces(self):
+        # Pins *why* the tilelang backward exists: same inputs, same flags,
+        # different dkv. Only bounded (not asserted unequal) because the drift
+        # is a race and a lucky run can come out equal; the bitwise assertion
+        # lives in ``TestTilelangBackward``.
+        q, kv, ti, dO = _inputs(H_SMALL, 64, 64, 410)
+        _, dq1, dkv1, _ = _layer_run(q, kv, ti, dO, "cudnn")
+        _, dq2, dkv2, _ = _layer_run(q, kv, ti, dO, "cudnn")
+        self.assertTrue(np.array_equal(dq1, dq2), "cuDNN dq should be stable")
+        self.assertLess(_relerr(dkv1, dkv2), 1e-4)
+
+
+# ===========================================================================
+# 2. The tilelang backward itself: numerics + determinism, no FlashMLA
+# ===========================================================================
+@_TILELANG
+class TestTilelangBackward(_Base):
+    """Driven with eager-built ``out``/``lse``, so no SM100 gate applies.
+
+    This is where the backend's actual promise is checked, and it is checked
+    against the fp32 oracle rather than against the cuDNN backward, so the two
+    implementations never validate each other.
+    """
+
+    def test_matches_the_fp32_reference(self):
+        for sink_mag in (None, 0.5):
+            with self.subTest(sink=sink_mag):
+                q, kv, ti, dO = _inputs(H_SMALL, 64, 64, 400)
+                self._assert_matches_reference(
+                    _kernel_run(q, kv, ti, dO, sink_mag),
+                    q,
+                    kv,
+                    ti,
+                    dO,
+                    sink_mag,
+                )
+
+    def test_all_three_gradients_are_bitwise_reproducible(self):
+        q, kv, ti, dO = _inputs(H_SMALL, 64, 64, 405)
+        first = _kernel_run(q, kv, ti, dO, 0.25)
+        second = _kernel_run(q, kv, ti, dO, 0.25)
+        for name, a, b in zip(("dq", "dkv", "d_sink"), first, second):
+            self.assertTrue(
+                np.array_equal(a, b), f"{name} is not bitwise deterministic"
+            )
+
+    def test_sinkless_gives_a_zero_sink_gradient(self):
+        # The sinkless contract is a ``-1e30`` sink, for which the kernel's
+        # ``exp2(sink * log2e - lse)`` underflows to 0 rather than to a NaN.
+        q, kv, ti, dO = _inputs(H_SMALL, 64, 64, 410)
+        _, _, dsink = _kernel_run(q, kv, ti, dO, None)
+        self.assertTrue(np.all(dsink == 0.0), f"d_sink not zero: {dsink[:4]}")
+
+    def test_unknown_backend_is_rejected(self):
+        # The PyLayer validates the name before it touches a kernel, so this
+        # runs anywhere -- which is the point: a typo in a YAML must fail on the
+        # box that reads the YAML, not only on an SM100 one.
+        q, kv, ti, _ = _inputs(H_SMALL, 32, 32, 430)
+        with self.assertRaisesRegex(
+            ValueError, "backward_backend must be 'cudnn' or 'tilelang'"
+        ):
+            mqa_sparse_attn(
+                _to_bf16(q),
+                _to_bf16(kv),
+                paddle.to_tensor(ti),
+                float(SM),
+                DV,
+                backward_backend="paddle",
+            )
+
+    def test_head_counts_the_forward_accepts(self):
+        # Any ``h <= 64`` is legal for the forward and for the cuDNN backward,
+        # including the 8 the hybrid-MLA fixtures use, so this backward must
+        # cover the same range: the head-group width adapts to ``h`` instead of
+        # demanding a multiple of 32. H=64 additionally exercises two head
+        # groups, whose dkv parts are summed on the host.
+        for h in (8, 16, H_SMALL, H_FULL):
+            with self.subTest(h=h):
+                q, kv, ti, dO = _inputs(h, 64, 64, 420 + h)
+                got = _kernel_run(q, kv, ti, dO, 0.25)
+                self._assert_matches_reference(got, q, kv, ti, dO, 0.25)
+                again = _kernel_run(q, kv, ti, dO, 0.25)
+                for name, a, b in zip(("dq", "dkv", "d_sink"), got, again):
+                    self.assertTrue(np.array_equal(a, b), name)
+
+
+# ===========================================================================
+# 3. Host-side tiling in ``mqa_latent_sparse_bwd``
+# ===========================================================================
+@_TILELANG
+class TestKernelTiling(_Base):
+    """``block_h`` / ``dkv_buf_bytes`` / padding paths the PyLayer cannot reach.
+
+    These arguments are host-side only: the PyLayer always takes the defaults,
+    so they are driven directly against the same fp32 oracle.
+    """
+
+    # A budget of exactly ``_BLOCK_SIZE`` query rows forces chunking.
+    def _tight_budget(self, topk):
+        return topk * DK * 4 * _BLOCK_SIZE
+
+    def test_chunked_equals_unchunked(self):
+        q, kv, ti, dO = _inputs(H_SMALL, 128, 64, 500)
+        whole = _kernel_run(q, kv, ti, dO, 0.25)
+        chunked = _kernel_run(
+            q, kv, ti, dO, 0.25, dkv_buf_bytes=self._tight_budget(64)
+        )
+        self._assert_matches_reference(chunked, q, kv, ti, dO, 0.25)
+        # dq is a private per-row accumulator, so chunking cannot move it at
+        # all. dkv and d_sink are cross-chunk sums, so they may differ by
+        # summation order -- deterministically, but not bitwise.
+        self.assertTrue(np.array_equal(chunked[0], whole[0]), "dq")
+        self.assertLess(_relerr(chunked[1], whole[1]), REORDER_TOL, "dkv")
+        self.assertLess(_relerr(chunked[2], whole[2]), REORDER_TOL, "d_sink")
+        again = _kernel_run(
+            q, kv, ti, dO, 0.25, dkv_buf_bytes=self._tight_budget(64)
+        )
+        for name, a, b in zip(("dq", "dkv", "d_sink"), chunked, again):
+            self.assertTrue(np.array_equal(a, b), f"chunked {name} unstable")
+
+    def test_topk_width_not_a_multiple_of_the_block(self):
+        # 48 columns are padded up to 64 with -1 inside the kernel wrapper;
+        # the pad slots must contribute nothing.
+        q, kv, ti, dO = _inputs(H_SMALL, 64, 48, 510)
+        self._assert_matches_reference(
+            _kernel_run(q, kv, ti, dO, 0.25), q, kv, ti, dO, 0.25
+        )
+
+    def test_query_rows_not_a_multiple_of_the_chunk(self):
+        # s=100 with a 32-row chunk pads the query axis to 128. The pad rows
+        # are inert (q/dO zero, index row all -1), so the result must equal the
+        # reference over the 100 real rows.
+        q, kv, ti, dO = _inputs(H_SMALL, 100, 64, 520)
+        got = _kernel_run(
+            q, kv, ti, dO, 0.25, dkv_buf_bytes=self._tight_budget(64)
+        )
+        self.assertEqual(got[0].shape, (100, H_SMALL, DK))
+        self._assert_matches_reference(got, q, kv, ti, dO, 0.25)
+
+    def test_non_bf16_inputs_are_rejected(self):
+        # The reused kernels are JIT-built for bf16, so an fp16 tensor would
+        # otherwise be read by a bf16 kernel: wrong numbers, or an opaque
+        # TileLang assert. The guard must name the tensor.
+        b, s, h = 1, _BLOCK_SIZE, H_SMALL
+        q, kv, ti, dO = _inputs(h, s, 32, 550)
+        qb, kvb, out, lse, sink, ti_t = _eager_forward(q, kv, ti, 0.25)
+        do = paddle.to_tensor(dO.reshape([b, s, h, DV])).cast(out.dtype)
+        cases = {
+            "query": (qb.cast("float16"), kvb, out, do),
+            "kv": (qb, kvb.cast("float16"), out, do),
+            "out": (qb, kvb, out.cast("float16"), do),
+            "grad_out": (qb, kvb, out, do.cast("float16")),
+        }
+        for name, (q_t, kv_t, o_t, do_t) in cases.items():
+            with (
+                self.subTest(tensor=name),
+                self.assertRaisesRegex(ValueError, f"{name} must be bfloat16"),
+            ):
+                mqa_latent_sparse_bwd(
+                    q_t, kv_t, o_t, do_t, lse, sink, ti_t, float(SM)
+                )
+
+    def test_block_h_must_divide_the_head_count(self):
+        q, kv, ti, dO = _inputs(H_SMALL, 32, 32, 530)
+        with self.assertRaisesRegex(ValueError, "divisible by block_h"):
+            _kernel_run(q, kv, ti, dO, 0.25, block_h=48)
+
+    def test_shape_guards_raise_valueerror_not_assert(self):
+        # ``python -O`` strips ``assert``, and these guard a TileLang JIT
+        # specialisation plus a multi-GiB allocation, so they must be real
+        # raises. ``AssertionError`` is not a subclass of ``ValueError``, so
+        # each case here also pins that the conversion happened.
+        b, s, h = 1, 32, H_SMALL
+        q, kv, ti, dO = _inputs(h, s, 32, 540)
+        qb, kvb, out, lse, sink, ti_t = _eager_forward(q, kv, ti, 0.25)
+        do = paddle.to_tensor(dO.reshape([b, s, h, DV])).cast(out.dtype)
+        good = (qb, kvb, out, do, lse, sink, ti_t, float(SM))
+        cases = {
+            "kv width": (
+                qb,
+                kvb[:, :, : DK - 16].contiguous(),
+                out,
+                do,
+                lse,
+                sink,
+                ti_t,
+                float(SM),
+            ),
+            # ``dv`` is read off ``grad_out``, so this one perturbs the head
+            # axis instead: a truncated last axis would make ``out`` the first
+            # guard to fire.
+            "grad_out": (qb, kvb, out, do[:, :, :1, :], lse, sink, ti_t, SM),
+            "out": (qb, kvb, out[:, :, :, :16], do, lse, sink, ti_t, SM),
+            "lse": (qb, kvb, out, do, lse[:, :, :1], sink, ti_t, SM),
+            "attn_sink": (qb, kvb, out, do, lse, sink[:1], ti_t, SM),
+            "token_indices": (
+                qb,
+                kvb,
+                out,
+                do,
+                lse,
+                sink,
+                ti_t[:, :1],
+                float(SM),
+            ),
+        }
+        for name, args in cases.items():
+            with (
+                self.subTest(guard=name),
+                self.assertRaisesRegex(ValueError, name),
+            ):
+                mqa_latent_sparse_bwd(*args)
+        # The same call with nothing perturbed must still go through, so a
+        # guard cannot pass this test by rejecting everything.
+        self.assertEqual(mqa_latent_sparse_bwd(*good)[0].shape, [b, s, h, DK])
+
+    def test_width_guards_raise_before_any_kernel(self):
+        # ``Dv > Dk`` and a non-multiple-of-16 width are rejected on the widths
+        # alone, before the JIT and before ``dkv_buf`` is allocated, so these
+        # need no real forward -- which is the point: an illegal width must not
+        # reach TileLang at all.
+        def call(dk, dv):
+            b, s, h = 1, _BLOCK_SIZE, H_SMALL
+            zeros = paddle.zeros
+            return mqa_latent_sparse_bwd(
+                zeros([b, s, h, dk], dtype="bfloat16"),
+                zeros([b, s, dk], dtype="bfloat16"),
+                zeros([b, s, h, dv], dtype="bfloat16"),
+                zeros([b, s, h, dv], dtype="bfloat16"),
+                zeros([b, s, h], dtype="float32"),
+                zeros([h], dtype="float32"),
+                paddle.full([b, s, _BLOCK_SIZE], -1, dtype="int32"),
+                float(SM),
+            )
+
+        with self.assertRaisesRegex(ValueError, r"must be <= Dk"):
+            call(DK, DK + 64)
+        with self.assertRaisesRegex(ValueError, "multiple of 16"):
+            call(24, 24)
+
+
+# ===========================================================================
+# 4. Host helpers -- pure Python, no kernels
+# ===========================================================================
+class TestHostHelpers(unittest.TestCase):
+    """The three sizing helpers, which decide launch geometry.
+
+    Getting these wrong is either a wrong answer (a chunk length the kernel's
+    ``topk % 32`` / S-tiling contract rejects) or a layout-inference failure in
+    ``dkv_reduce``, so they are checked without a GPU.
+    """
+
+    def test_pick_chunk_prefers_an_exact_divisor(self):
+        # Budget large enough for all of s: one chunk, no padding.
+        self.assertEqual(_pick_chunk(1, 64, 64, DK, 12 << 30), 64)
+        # Budget for 32 rows: 32 divides 128 exactly.
+        self.assertEqual(_pick_chunk(1, 128, 64, DK, 64 * DK * 4 * 32), 32)
+
+    def test_pick_chunk_budgets_the_batch_axis(self):
+        # ``dkv_buf`` is [b, sc, topk, dk]: at the same budget, doubling the
+        # batch must halve the chunk, not silently double the allocation.
+        budget = 64 * DK * 4 * 64
+        self.assertEqual(_pick_chunk(1, 128, 64, DK, budget), 64)
+        self.assertEqual(_pick_chunk(2, 128, 64, DK, budget), 32)
+        for b in (1, 2, 4, 8):
+            sc = _pick_chunk(b, 8192, 640, DK, 12 << 30)
+            with self.subTest(b=b):
+                self.assertLessEqual(b * sc * 640 * DK * 4, 12 << 30)
+
+    def test_pick_chunk_is_always_block_aligned(self):
+        for s in (32, 64, 96, 100, 128, 8192):
+            for rows in (1, 8, 32, 4096):
+                sc = _pick_chunk(1, s, 64, DK, 64 * DK * 4 * rows)
+                with self.subTest(s=s, rows=rows):
+                    self.assertGreaterEqual(sc, _BLOCK_SIZE)
+                    self.assertLessEqual(sc, max(s, _BLOCK_SIZE))
+                    # Multi-chunk lengths must be block aligned; the one
+                    # exception is the single chunk that covers all of ``s``,
+                    # where the kernel sees the sequence length itself.
+                    self.assertTrue(
+                        sc % _BLOCK_SIZE == 0 or sc == s, f"sc={sc}"
+                    )
+
+    def test_pick_chunk_falls_back_to_a_padded_tail(self):
+        # No multiple of 32 divides 100, so the tail must be padded instead.
+        sc = _pick_chunk(1, 100, 64, DK, 64 * DK * 4 * 32)
+        self.assertEqual(sc, 32)
+        self.assertNotEqual(100 % sc, 0)
+
+    def test_pick_block_h_divides_every_legal_head_count(self):
+        # The cuDNN backward takes any ``h <= 64``; the group width must too,
+        # and stay within the 32 the shared-memory budget allows.
+        for h in range(1, _DSA_HEADS + 1):
+            bh = _pick_block_h(h)
+            with self.subTest(h=h):
+                self.assertEqual(h % bh, 0)
+                self.assertLessEqual(bh, 32)
+                self.assertGreaterEqual(bh, 1)
+        self.assertEqual(_pick_block_h(64), 32)
+        self.assertEqual(_pick_block_h(48), 16)
+        self.assertEqual(_pick_block_h(24), 8)
+        self.assertEqual(_pick_block_h(8), 8)
+        # Odd head counts fall back to one head per launch rather than raising.
+        self.assertEqual(_pick_block_h(7), 1)
+
+    def test_reduce_threads_divides_dk(self):
+        # ``dkv_reduce`` maps ``T.Parallel(Dk)`` onto threads and its layout
+        # inference fails outright unless the block width divides Dk -- the
+        # reason the library default of 128 is unusable at the absorbed 576.
+        for dk in (DK, DV, 192, 64):
+            with self.subTest(dk=dk):
+                self.assertEqual(dk % _reduce_threads(dk), 0)
+        self.assertEqual(_reduce_threads(DK), 192)
+        self.assertEqual(_reduce_threads(DV), 256)
+        # Nothing in the candidate list divides 48: fall back to 32.
+        self.assertEqual(_reduce_threads(48), 32)
+
+    def test_pad_rows_extends_axis_one_with_the_fill(self):
+        x = paddle.ones([2, 3, 4], dtype="int32")
+        padded = _pad_rows(x, 5, fill=-1)
+        self.assertEqual(padded.shape, [2, 5, 4])
+        got = padded.numpy()
+        self.assertTrue(np.all(got[:, :3] == 1))
+        self.assertTrue(np.all(got[:, 3:] == -1))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Distributed Strategy

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
增加mqa tilelang的backend

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否