### PR TITLE
[Performance] Add CuTe DSL CLC backend for DSA indexer top-k

### DIFF
--- a/src/paddlefleet/cudnn_ops/indexer/csa_indexer_fwd_cudnn.py
+++ b/src/paddlefleet/cudnn_ops/indexer/csa_indexer_fwd_cudnn.py
@@ -127,6 +127,7 @@ def _indexer_top_k_unfused(
     seq_lens: paddle.Tensor,
     top_k: int,
     return_val: bool = True,
+    topk_backend: str = "unfused",
 ):
     """
     Deterministic topk in replacement of cudnn indexer_top_k_wrapper.
@@ -141,6 +142,24 @@ def _indexer_top_k_unfused(
     output slots past ``seq_lens`` does not remove them. Mask the columns first.
     For the pure-causal callers this is a no-op (already ``-inf`` there).
     """
+    if topk_backend not in {"unfused", "cutedsl"}:
+        raise ValueError(
+            f"topk_backend={topk_backend!r} is invalid. "
+            "Must be one of {'unfused', 'cutedsl'}."
+        )
+    if topk_backend == "cutedsl":
+        from paddlefleet.cutedsl_ops.indexer_topk_prefill import (
+            indexer_topk_prefill,
+        )
+
+        indices, values = indexer_topk_prefill(
+            input_values.contiguous(),
+            seq_lens.cast("int32").contiguous(),
+            int(top_k),
+            return_val=return_val,
+        )
+        return {"indices": indices, "values": values}
+
     seq_lens_col = seq_lens.reshape([-1, 1]).cast("int32")
     input_values = paddle.where(
         paddle.arange(input_values.shape[-1], dtype="int32") < seq_lens_col,
@@ -222,7 +241,15 @@ def cudnn_indexer_forward(
     return result["scores"]
 
 
-def cudnn_indexer_topk(scores, sq, ratio, topk, valid_range=None, seq_offset=0):
+def cudnn_indexer_topk(
+    scores,
+    sq,
+    ratio,
+    topk,
+    valid_range=None,
+    seq_offset=0,
+    topk_backend="unfused",
+):
     """Select top-K indices using cuDNN TRT-LLM radix kernel (SM100).
 
     Args:
@@ -282,6 +309,7 @@ def cudnn_indexer_topk(scores, sq, ratio, topk, valid_range=None, seq_offset=0):
         seq_lens,
         top_k=topk_k,
         return_val=False,
+        topk_backend=topk_backend,
     )
     topk_indices = result["indices"].reshape([batch, sq, topk_k]).cast("int32")
 
@@ -309,6 +337,7 @@ def cudnn_indexer_topk_fwd(
     doc_lens=None,
     seq_offset=0,
     return_topk_scores=False,
+    topk_backend="unfused",
 ):
     """Run cuDNN-frontend DSA indexer forward on Paddle tensors.
 
@@ -353,6 +382,7 @@ def cudnn_indexer_topk_fwd(
         doc_lens=doc_lens,
         seq_offset=seq_offset,
         return_topk_scores=return_topk_scores,
+        topk_backend=topk_backend,
     )
 
 
@@ -368,6 +398,7 @@ def _cudnn_indexer_topk_fwd_impl(
     doc_lens=None,
     seq_offset=0,
     return_topk_scores=False,
+    topk_backend="unfused",
 ):
     _validate_indexer_inputs(index_q, index_k_comp, weights)
     if int(topk_effective) <= 0:
@@ -395,6 +426,7 @@ def _cudnn_indexer_topk_fwd_impl(
             seq_offset,
             doc_lens=doc_lens,
             return_topk_scores=return_topk_scores,
+            topk_backend=topk_backend,
         )
         if thd_result is not None:
             return thd_result
@@ -414,6 +446,7 @@ def _cudnn_indexer_topk_fwd_impl(
             valid_range,
             seq_offset,
             return_topk_scores,
+            topk_backend,
         )
 
     # Tile the query dimension: each tile's forward + top-k is independent of
@@ -435,6 +468,7 @@ def _cudnn_indexer_topk_fwd_impl(
             vr_chunk,
             seq_offset + start,
             return_topk_scores,
+            topk_backend,
         )
         if return_topk_scores:
             idx_chunk, len_chunk, score_chunk = chunk
@@ -524,6 +558,7 @@ def _cudnn_indexer_topk_fwd_docmask_thd(
     seq_offset: int,
     doc_lens: list[int],
     return_topk_scores: bool = False,
+    topk_backend: str = "unfused",
 ):
     batch, seq_len, _, _ = index_q.shape
     if batch != 1:
@@ -576,6 +611,7 @@ def _cudnn_indexer_topk_fwd_docmask_thd(
         counts.squeeze(0),
         top_k=topk_effective,
         return_val=return_topk_scores,
+        topk_backend=topk_backend,
     )
 
     topk_global = topk_local_to_global(
@@ -599,6 +635,7 @@ def _dense_indexer_topk_single(
     valid_range,
     seq_offset,
     return_topk_scores,
+    topk_backend="unfused",
 ):
     """Single-shot packed-global forward + top-k over the full query slice."""
     scores = cudnn_indexer_forward(
@@ -616,6 +653,7 @@ def _dense_indexer_topk_single(
         topk_effective,
         valid_range=valid_range,
         seq_offset=seq_offset,
+        topk_backend=topk_backend,
     )
     if not return_topk_scores:
         return topk_indices, topk_length

--- a/src/paddlefleet/cudnn_ops/indexer/csa_indexer_fwd_cudnn.py
+++ b/src/paddlefleet/cudnn_ops/indexer/csa_indexer_fwd_cudnn.py
@@ -128,6 +128,7 @@ def _indexer_top_k_unfused(
     top_k: int,
     return_val: bool = True,
     topk_backend: str = "unfused",
+    cutedsl_min_cols: int = 0,
 ):
     """
     Deterministic topk in replacement of cudnn indexer_top_k_wrapper.
@@ -142,12 +143,23 @@ def _indexer_top_k_unfused(
     output slots past ``seq_lens`` does not remove them. Mask the columns first.
     For the pure-causal callers this is a no-op (already ``-inf`` there).
     """
-    if topk_backend not in {"unfused", "cutedsl"}:
+    if topk_backend not in {"unfused", "cutedsl", "cutedsl_index"}:
         raise ValueError(
             f"topk_backend={topk_backend!r} is invalid. "
-            "Must be one of {'unfused', 'cutedsl'}."
+            "Must be one of {'unfused', 'cutedsl', 'cutedsl_index'}."
         )
-    if topk_backend == "cutedsl":
+    if topk_backend == "cutedsl_index" and top_k < 1:
+        raise ValueError(
+            f"topk_backend='cutedsl_index' requires top_k >= 1, got {top_k}"
+        )
+    if cutedsl_min_cols < 0:
+        raise ValueError(
+            f"cutedsl_min_cols must be non-negative, got {cutedsl_min_cols}"
+        )
+    use_cutedsl = topk_backend in {"cutedsl", "cutedsl_index"} and (
+        input_values.shape[-1] >= cutedsl_min_cols
+    )
+    if use_cutedsl:
         from paddlefleet.cutedsl_ops.indexer_topk_prefill import (
             indexer_topk_prefill,
         )
@@ -157,6 +169,7 @@ def _indexer_top_k_unfused(
             seq_lens.cast("int32").contiguous(),
             int(top_k),
             return_val=return_val,
+            sort_mode="index" if topk_backend == "cutedsl_index" else "score",
         )
         return {"indices": indices, "values": values}
 
@@ -249,6 +262,7 @@ def cudnn_indexer_topk(
     valid_range=None,
     seq_offset=0,
     topk_backend="unfused",
+    cutedsl_min_cols=0,
 ):
     """Select top-K indices using cuDNN TRT-LLM radix kernel (SM100).
 
@@ -310,6 +324,7 @@ def cudnn_indexer_topk(
         top_k=topk_k,
         return_val=False,
         topk_backend=topk_backend,
+        cutedsl_min_cols=cutedsl_min_cols,
     )
     topk_indices = result["indices"].reshape([batch, sq, topk_k]).cast("int32")
 
@@ -338,6 +353,7 @@ def cudnn_indexer_topk_fwd(
     seq_offset=0,
     return_topk_scores=False,
     topk_backend="unfused",
+    cutedsl_min_cols=0,
 ):
     """Run cuDNN-frontend DSA indexer forward on Paddle tensors.
 
@@ -383,6 +399,7 @@ def cudnn_indexer_topk_fwd(
         seq_offset=seq_offset,
         return_topk_scores=return_topk_scores,
         topk_backend=topk_backend,
+        cutedsl_min_cols=cutedsl_min_cols,
     )
 
 
@@ -399,6 +416,7 @@ def _cudnn_indexer_topk_fwd_impl(
     seq_offset=0,
     return_topk_scores=False,
     topk_backend="unfused",
+    cutedsl_min_cols=0,
 ):
     _validate_indexer_inputs(index_q, index_k_comp, weights)
     if int(topk_effective) <= 0:
@@ -427,6 +445,7 @@ def _cudnn_indexer_topk_fwd_impl(
             doc_lens=doc_lens,
             return_topk_scores=return_topk_scores,
             topk_backend=topk_backend,
+            cutedsl_min_cols=cutedsl_min_cols,
         )
         if thd_result is not None:
             return thd_result
@@ -447,6 +466,7 @@ def _cudnn_indexer_topk_fwd_impl(
             seq_offset,
             return_topk_scores,
             topk_backend,
+            cutedsl_min_cols,
         )
 
     # Tile the query dimension: each tile's forward + top-k is independent of
@@ -469,6 +489,7 @@ def _cudnn_indexer_topk_fwd_impl(
             seq_offset + start,
             return_topk_scores,
             topk_backend,
+            cutedsl_min_cols,
         )
         if return_topk_scores:
             idx_chunk, len_chunk, score_chunk = chunk
@@ -559,6 +580,7 @@ def _cudnn_indexer_topk_fwd_docmask_thd(
     doc_lens: list[int],
     return_topk_scores: bool = False,
     topk_backend: str = "unfused",
+    cutedsl_min_cols: int = 0,
 ):
     batch, seq_len, _, _ = index_q.shape
     if batch != 1:
@@ -612,6 +634,7 @@ def _cudnn_indexer_topk_fwd_docmask_thd(
         top_k=topk_effective,
         return_val=return_topk_scores,
         topk_backend=topk_backend,
+        cutedsl_min_cols=cutedsl_min_cols,
     )
 
     topk_global = topk_local_to_global(
@@ -636,6 +659,7 @@ def _dense_indexer_topk_single(
     seq_offset,
     return_topk_scores,
     topk_backend="unfused",
+    cutedsl_min_cols=0,
 ):
     """Single-shot packed-global forward + top-k over the full query slice."""
     scores = cudnn_indexer_forward(
@@ -654,6 +678,7 @@ def _dense_indexer_topk_single(
         valid_range=valid_range,
         seq_offset=seq_offset,
         topk_backend=topk_backend,
+        cutedsl_min_cols=cutedsl_min_cols,
     )
     if not return_topk_scores:
         return topk_indices, topk_length

--- a/src/paddlefleet/cutedsl_ops/__init__.py
+++ b/src/paddlefleet/cutedsl_ops/__init__.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Optional CuTe DSL operators for PaddleFleet.
+
+The CuTe DSL dependency is intentionally imported lazily.  Importing
+``paddlefleet`` must continue to work on installations that do not include
+CUDA Python and CuTe DSL.
+"""
+
+
+def indexer_topk_prefill(*args, **kwargs):
+    """Lazily dispatch to the standalone Paddle CuTe DSL operator."""
+    from .indexer_topk_prefill import indexer_topk_prefill as _impl
+
+    return _impl(*args, **kwargs)
+
+
+def precompile_indexer_topk_clc(*args, **kwargs):
+    """Lazily precompile the process-local CLC top-k variants."""
+    from .indexer_topk_prefill import (
+        precompile_indexer_topk_clc as _impl,
+    )
+
+    return _impl(*args, **kwargs)
+
+
+__all__ = [
+    "indexer_topk_prefill",
+    "precompile_indexer_topk_clc",
+]

--- a/src/paddlefleet/cutedsl_ops/block_scan.py
+++ b/src/paddlefleet/cutedsl_ops/block_scan.py
@@ -1,0 +1,182 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CTA block-scan helpers adapted from cuDNN Frontend.
+
+The implementation follows the DSA indexer ``block_scan.py`` reference:
+warp-level inclusive scans use shuffle instructions, warp totals are reduced
+in shared memory, and a CTA barrier completes the cross-warp scan.  The
+standalone PaddleFleet operator uses the helper for its 256-bin radix
+histograms.
+"""
+
+from __future__ import annotations
+
+import math
+
+import cutlass
+from cutlass import cute
+from cutlass._mlir.dialects import llvm
+from cutlass.utils.smem_allocator import SmemAllocator
+
+
+@cute.jit
+def fence_acq_rel_cta(*, loc=None, ip=None):
+    """Make CTA-scoped global/shared writes visible before a barrier."""
+    llvm.inline_asm(
+        res=None,
+        operands_=[],
+        asm_string="membar.cta;",
+        constraints="",
+        has_side_effects=True,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@cute.jit
+def warp_scan(
+    val: cutlass.Int32,
+    tidx,
+    lane_id,
+    num_threads_per_warp: cutlass.Constexpr,
+):
+    """Inclusive scan within one warp or a power-of-two warp subgroup."""
+    mask_val = cutlass.const_expr(
+        ((1 << num_threads_per_warp) - 1) & 0xFFFFFFFF
+    )
+    mask_and_clamp_val = 0
+    iteration = cute.arch.log2_of_pow2_int(cutlass.Int32(num_threads_per_warp))
+    for i in cutlass.range(iteration, unroll_full=True):
+        offset = 1 << i
+        other = cute.arch.shuffle_sync_up(
+            val,
+            offset,
+            mask=mask_val,
+            mask_and_clamp=mask_and_clamp_val,
+        )
+        if lane_id >= offset:
+            val = val + other
+    return val
+
+
+@cute.jit
+def block_prefix_sum_kernel(
+    val: cutlass.Int32,
+    warp_sums: cute.Tensor,
+    tidx,
+    num_threads,
+    num_warps,
+    barrier_id=1,
+    need_total_sum=False,
+):
+    """Compute an inclusive block prefix sum using warp shuffles."""
+    warp_id = tidx // 32
+    lane_id = tidx % 32
+
+    assert num_threads % 32 == 0
+    assert num_warps > 1
+    assert num_warps == 2 ** int(math.log2(num_warps))
+
+    val = warp_scan(val, tidx, lane_id, num_threads_per_warp=32)
+    if lane_id == 31:
+        warp_sums[warp_id] = val
+    cute.arch.barrier(
+        barrier_id=barrier_id,
+        number_of_threads=num_threads,
+    )
+
+    if warp_id == 0:
+        if lane_id < num_warps:
+            warp_val = warp_sums[lane_id]
+            warp_val = warp_scan(
+                warp_val,
+                tidx,
+                lane_id,
+                num_threads_per_warp=num_warps,
+            )
+            warp_sums[lane_id] = warp_val
+    cute.arch.barrier(
+        barrier_id=barrier_id,
+        number_of_threads=num_threads,
+    )
+
+    if warp_id > 0:
+        val = val + warp_sums[warp_id - 1]
+
+    total_sum = 0
+    if need_total_sum:
+        total_sum = warp_sums[num_warps - 1]
+    return val, total_sum
+
+
+@cute.kernel
+def block_prefix_sum(
+    num_bins: cutlass.Constexpr,
+    num_threads_per_block: cutlass.Constexpr,
+    input: cute.Tensor,
+    output: cute.Tensor,
+):
+    """Standalone block-prefix-sum kernel from the reference implementation."""
+    tidx, _, _ = cute.arch.thread_idx()
+    num_warps = cutlass.const_expr(min(num_bins, num_threads_per_block) // 32)
+    smem = SmemAllocator()
+    warp_sums = smem.allocate_tensor(
+        element_type=cutlass.Int32,
+        layout=cute.make_ordered_layout((num_warps,), order=(0,)),
+        byte_alignment=128,
+    )
+
+    if cutlass.const_expr(num_bins < num_threads_per_block):
+        if tidx < num_bins:
+            val = input[tidx]
+            val, _ = block_prefix_sum_kernel(
+                val,
+                warp_sums,
+                tidx,
+                num_bins,
+                num_warps,
+                barrier_id=1,
+            )
+            output[tidx] = val
+    elif cutlass.const_expr(num_bins == num_threads_per_block):
+        val = input[tidx]
+        val, _ = block_prefix_sum_kernel(
+            val,
+            warp_sums,
+            tidx,
+            num_bins,
+            num_warps,
+            barrier_id=1,
+        )
+        output[tidx] = val
+    else:
+        assert num_bins % num_threads_per_block == 0
+        previous_sum = 0
+        val = 0
+        total_sum = 0
+        for i in range(tidx, num_bins, num_threads_per_block):
+            val = input[i]
+            val, total_sum = block_prefix_sum_kernel(
+                val,
+                warp_sums,
+                tidx,
+                num_threads_per_block,
+                num_warps,
+                barrier_id=0,
+                need_total_sum=True,
+            )
+            output[i] = val + previous_sum
+            previous_sum = previous_sum + total_sum

--- a/src/paddlefleet/cutedsl_ops/compiler.py
+++ b/src/paddlefleet/cutedsl_ops/compiler.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Local CuTe DSL compiler options for PaddleFleet operators."""
+
+from functools import cache
+
+_ARCH_MAP = {
+    (9, 0): "sm_90a",
+    (10, 0): "sm_100a",
+    (10, 3): "sm_103a",
+    (10, 7): "sm_100f",
+}
+
+
+@cache
+def gpu_arch_flag() -> str:
+    """Return the CuTe DSL architecture flag for the current CUDA device."""
+    import paddle
+
+    if not paddle.is_compiled_with_cuda():
+        raise RuntimeError("CuTe DSL compilation requires a CUDA Paddle build")
+    capability = paddle.device.cuda.get_device_capability()
+    arch = _ARCH_MAP.get(tuple(capability))
+    if arch is None:
+        raise RuntimeError(
+            f"unsupported CUDA compute capability {capability}; "
+            f"please extend {__name__}._ARCH_MAP"
+        )
+    return arch
+
+
+def compile_options(extra: str = "") -> str:
+    """Build options for ``cute.compile`` without importing cuDNN Frontend."""
+    parts = ["--enable-tvm-ffi", f"--gpu-arch {gpu_arch_flag()}"]
+    if extra:
+        parts.append(extra)
+    return " ".join(parts)

--- a/src/paddlefleet/cutedsl_ops/dlpack.py
+++ b/src/paddlefleet/cutedsl_ops/dlpack.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Paddle-to-CuTe DLPack bridge.
+
+This adapter is deliberately kept independent of cuDNN Frontend.  It exposes
+Paddle's explicit capsule API through the Python DLPack protocol expected by
+CuTe DSL.  Conversion is zero-copy.
+"""
+
+
+class _PaddleDLPackAdapter:
+    """Expose Paddle's capsule API through the Python DLPack protocol."""
+
+    def __init__(self, tensor):
+        self._tensor = tensor
+
+    def __dlpack__(self, stream=None):
+        import paddle
+
+        # Paddle's protocol implementation accepts the consumer CUDA stream
+        # and inserts the required producer/consumer dependency. Calling
+        # ``to_dlpack`` directly would discard that stream argument.
+        exporter = getattr(self._tensor, "__dlpack__", None)
+        if exporter is not None:
+            if stream is None:
+                return exporter()
+            return exporter(stream=stream)
+        return paddle.utils.dlpack.to_dlpack(self._tensor)
+
+    def __dlpack_device__(self):
+        return self._tensor.__dlpack_device__()
+
+
+def current_paddle_stream_ptr() -> int:
+    """Return the raw pointer of Paddle's current CUDA stream."""
+    import paddle
+
+    stream = paddle.device.current_stream()
+    base = getattr(stream, "stream_base", stream)
+    for name in ("cuda_stream", "raw_stream"):
+        value = getattr(base, name, None)
+        if value is not None:
+            return int(value)
+    raise RuntimeError("cannot obtain the current Paddle CUDA stream pointer")
+
+
+def current_cu_stream():
+    """Return Paddle's current stream as ``cuda.bindings.driver.CUstream``."""
+    import cuda.bindings.driver as cuda
+
+    return cuda.CUstream(current_paddle_stream_ptr())
+
+
+def paddle_to_cute_tensor(
+    tensor,
+    *,
+    assumed_align: int,
+    leading_dim: int | None = None,
+    stream_ptr: int | None = None,
+):
+    """Create a dynamic-layout CuTe tensor sharing a Paddle CUDA allocation.
+
+    No copy is made.  ``assumed_align`` must describe the actual allocation:
+    use 16 for contiguous Q/KV floating-point tensors and 4 for contiguous
+    int32 metadata/output tensors.
+    """
+    from cutlass.cute.runtime import from_dlpack
+
+    # CuTe DSL expects an object implementing the Python DLPack protocol,
+    # whereas Paddle's explicit API returns a raw capsule.
+    del stream_ptr
+    result = from_dlpack(
+        _PaddleDLPackAdapter(tensor),
+        assumed_align=assumed_align,
+        enable_tvm_ffi=True,
+    )
+    if leading_dim is None:
+        return result.mark_layout_dynamic()
+    return result.mark_layout_dynamic(leading_dim=leading_dim)

--- a/src/paddlefleet/cutedsl_ops/indexer_topk_prefill.py
+++ b/src/paddlefleet/cutedsl_ops/indexer_topk_prefill.py
@@ -96,10 +96,44 @@ _CUTEDSL_AVAILABLE = cutlass is not None
 
 _SMEM_CANDIDATE_CAPACITY = 16384
 _MAX_THREADS_PER_SM = 2048
+_SMEM_BYTES_PER_SM100_SM = 228 * 1024
+_MAX_TOP_K = 32768
+_MAX_TOP_K_FLOAT32 = 16384
+# The integer index-order network is valid for every positive top_k. Its
+# compile-time sorting extent is the next power of two, with invalid slots
+# padded by -1.
+_INDEX_SORT_MIN_TOP_K = 1
+_SORT_MODES = {"score", "index"}
 
 
 def _next_power_of_two(value: int) -> int:
     return 1 if value <= 1 else 1 << (value - 1).bit_length()
+
+
+def _validate_sort_mode(sort_mode: str, top_k: int) -> str:
+    sort_mode = str(sort_mode)
+    if sort_mode not in _SORT_MODES:
+        raise ValueError(
+            f"sort_mode={sort_mode!r} is invalid. "
+            "Must be one of {'score', 'index'}."
+        )
+    if sort_mode == "index" and top_k < _INDEX_SORT_MIN_TOP_K:
+        raise ValueError(
+            "sort_mode='index' requires "
+            f"top_k >= {_INDEX_SORT_MIN_TOP_K}, got {top_k}"
+        )
+    return sort_mode
+
+
+def _validate_top_k_for_dtype(top_k: int, dtype, cutlass) -> None:
+    max_top_k = _MAX_TOP_K_FLOAT32 if dtype == cutlass.Float32 else _MAX_TOP_K
+    if top_k > max_top_k:
+        dtype_name = (
+            "float32" if dtype == cutlass.Float32 else "float16/bfloat16"
+        )
+        raise ValueError(
+            f"top_k must be in [1, {max_top_k}] for {dtype_name}, got {top_k}"
+        )
 
 
 def _compile_num_cols_bucket(num_cols: int) -> int:
@@ -150,22 +184,57 @@ def _workspace_slot_count(
     num_threads: int,
     persistent: bool,
     schedule_mode: str,
+    smem_bytes_per_cta: int = 0,
 ) -> int:
     """Return the maximum number of concurrently allocated CLC slots.
 
     CLC launches one CTA per logical row, but only resident CTAs execute the
-    slot allocation.  The thread-resource bound is conservative here; shared
-    memory and registers can only reduce the actual resident CTA count.
+    slot allocation. Bound the resident count by both threads and the
+    allocator-rounded shared-memory footprint. Registers can only reduce the
+    actual resident CTA count further, so this remains a safe upper bound.
     """
     if not persistent:
         return num_rows
     if schedule_mode != "clc":
         return num_persistent_ctas
     max_ctas_per_sm = max(1, _MAX_THREADS_PER_SM // num_threads)
+    if smem_bytes_per_cta > 0:
+        max_ctas_per_sm = min(
+            max_ctas_per_sm,
+            max(1, _SMEM_BYTES_PER_SM100_SM // smem_bytes_per_cta),
+        )
     # The workspace is indexed by resident CTA, not by logical row.  Allocate
     # the resident upper bound even for a small input so the CLC binary can
     # share one runtime-bounded layout across all row counts.
     return num_persistent_ctas * max_ctas_per_sm
+
+
+def _estimate_smem_bytes_per_cta(
+    num_threads: int,
+    top_k: int,
+    num_candidate_pages: int,
+    candidate_capacity: int,
+    schedule_mode: str,
+) -> int:
+    """Estimate allocator-rounded shared memory used by one top-k CTA."""
+    alignment = 128
+
+    def align(size):
+        return ((size + alignment - 1) // alignment) * alignment
+
+    num_warps = num_threads // 32
+    sizes = (
+        (num_warps * 256 + 1) * 4,  # replicated histogram + threshold
+        4 * 4,  # counters
+        _next_power_of_two(top_k) * 4,  # selected indices
+        num_warps * 4,  # scan warp sums
+        2 * 4,  # shared candidate counts
+        2 * 4,  # global candidate counts
+        num_candidate_pages * candidate_capacity * 4,
+    )
+    if schedule_mode == "clc":
+        sizes += (2 * 8, 4 * 4, 4 * 4)  # mbarriers, response, work metadata
+    return sum(align(size) for size in sizes)
 
 
 def _require_cutedsl():
@@ -272,6 +341,7 @@ class IndexerTopKPrefillKernel:
         schedule_mode: str = "clc",
         num_rows: int = 0,
         num_workspace_slots: int = 0,
+        sort_mode: str = "score",
     ):
         cutlass, cute, _, _ = _require_cutedsl()
         self.cutlass = cutlass
@@ -279,6 +349,7 @@ class IndexerTopKPrefillKernel:
         self.dtype = dtype
         self.max_num_cols = int(max_num_cols)
         self.top_k = int(top_k)
+        self.sort_mode = _validate_sort_mode(sort_mode, self.top_k)
         self.return_val = bool(return_val)
         self.num_persistent_ctas = int(num_persistent_ctas)
         self.rows_per_cta = int(rows_per_cta)
@@ -293,12 +364,20 @@ class IndexerTopKPrefillKernel:
             _SMEM_CANDIDATE_CAPACITY, self.max_num_cols
         )
         self.num_threads = 256 if self.max_num_cols < 8192 else 512
+        self.num_warps = self.num_threads // 32
+        self.histogram_warp_base = 0
+        self.histogram_threshold_idx = (
+            self.histogram_warp_base + self.num_warps * 256
+        )
         self.num_workspace_slots = int(
             num_workspace_slots or self.num_persistent_ctas
         )
         self.sort_size = _next_power_of_two(self.top_k)
         self.first_refine_shift = 24 if dtype == cutlass.Float32 else 0
         self.num_refine_rounds = 4 if dtype == cutlass.Float32 else 1
+        # Production DSA sequence lengths are bounded by 262144 columns, so
+        # three index-refinement bytes fully order every valid column index.
+        self.num_index_refine_rounds = 3
 
     @cute.jit
     def _topk_per_row(
@@ -311,7 +390,65 @@ class IndexerTopKPrefillKernel:
         s_histogram,
         s_counter,
         s_indices,
-        s_values,
+        s_warp_sums,
+        s_num_input,
+        g_num_input,
+        s_input_idx,
+        row_idx,
+        workspace_slot,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        neg_inf = self.dtype(self.dtype.inf * self.dtype(-1.0))
+        length = row_lengths[row_idx]
+        if length > input_values.shape[1]:
+            length = input_values.shape[1]
+        if length < 0:
+            length = 0
+        short_row = length < self.top_k
+
+        # This is a CTA-wide branch: every thread takes the same path, and
+        # the barriers remain balanced for both short and ordinary rows.
+        if short_row:
+            for i in cutlass.range(tidx, self.top_k, self.num_threads):
+                if i < length:
+                    output_indices[row_idx, i] = i
+                    if cutlass.const_expr(self.return_val):
+                        output_values[row_idx, i] = input_values[row_idx, i]
+                else:
+                    output_indices[row_idx, i] = -1
+                    if cutlass.const_expr(self.return_val):
+                        output_values[row_idx, i] = neg_inf
+        cute.arch.barrier()
+        if not short_row:
+            self._topk_per_row_full(
+                input_values,
+                row_lengths,
+                output_indices,
+                output_values,
+                overflow,
+                s_histogram,
+                s_counter,
+                s_indices,
+                s_warp_sums,
+                s_num_input,
+                g_num_input,
+                s_input_idx,
+                row_idx,
+                workspace_slot,
+            )
+        cute.arch.barrier()
+
+    @cute.jit
+    def _topk_per_row_full(
+        self,
+        input_values,
+        row_lengths,
+        output_indices,
+        output_values,
+        overflow,
+        s_histogram,
+        s_counter,
+        s_indices,
         s_warp_sums,
         s_num_input,
         g_num_input,
@@ -322,9 +459,7 @@ class IndexerTopKPrefillKernel:
         tidx, _, _ = cute.arch.thread_idx()
         bidx = row_idx
 
-        neg_inf = s_values.element_type(
-            s_values.element_type.inf * s_values.element_type(-1.0)
-        )
+        neg_inf = self.dtype(self.dtype.inf * self.dtype(-1.0))
         val_one = cutlass.Int32(1)
         if tidx < self.num_candidate_pages:
             s_num_input[tidx] = 0
@@ -335,30 +470,30 @@ class IndexerTopKPrefillKernel:
         # buffer and must survive into the refinement/output phases.
         for i in cutlass.range(tidx, self.sort_size, self.num_threads):
             s_indices[i] = -1
-        for i in cutlass.range(tidx, self.top_k, self.num_threads):
-            s_values[i] = neg_inf
         cute.arch.barrier()
 
         # Stage 1: build a coarse radix histogram.  This is the same ordered
         # floating-point key used by the extracted cuDNN Frontend kernel.
-        if tidx < 256:
-            s_histogram[tidx] = 0
-        cute.arch.barrier()
+        self._clear_histogram(tidx, s_histogram)
 
         length = row_lengths[row_idx]
         if length > input_values.shape[1]:
             length = input_values.shape[1]
         if length < 0:
             length = 0
-        for col in cutlass.range(tidx, input_values.shape[1], self.num_threads):
-            if col < length:
-                key = self._to_coarse_key(input_values[row_idx, col])
-                atomicAdd(s_histogram.iterator + cutlass.Int32(key), val_one)
+        for col in cutlass.range(tidx, length, self.num_threads):
+            key = self._to_coarse_key(input_values[row_idx, col])
+            bin_offset = self.histogram_warp_base + (tidx // 32) * 256
+            atomicAdd(
+                s_histogram.iterator
+                + cutlass.Int32(bin_offset)
+                + cutlass.Int32(key),
+                val_one,
+            )
         fence_acq_rel_cta()
-        cute.arch.barrier()
+        self._reduce_histogram(tidx, s_histogram)
         if tidx == 0:
-            s_histogram[256] = 255
-            s_histogram[257] = 0
+            s_histogram[self.histogram_threshold_idx] = 255
 
         # Convert the histogram to an inclusive prefix sum.  This follows the
         # reference block-scan path: one thread handles one radix bin and
@@ -381,33 +516,33 @@ class IndexerTopKPrefillKernel:
             if tidx > 0:
                 previous = s_histogram[tidx - 1]
             if previous < self.top_k and val >= self.top_k:
-                s_histogram[256] = tidx
+                s_histogram[self.histogram_threshold_idx] = tidx
         if tidx == 0:
             s_counter[0] = 0  # selected count
-            s_counter[1] = 0  # next-round count
+            s_counter[1] = 0  # final boundary-score candidate count
             s_counter[2] = 0  # final threshold remaining count
+            s_counter[3] = -1  # no index threshold unless a tie overflows
         cute.arch.barrier()
 
-        threshold = s_histogram[256]
+        threshold = s_histogram[self.histogram_threshold_idx]
         # Store only candidates in the selected coarse prefix.  The exact
         # ordering inside this final bin is resolved below.
-        for col in cutlass.range(tidx, input_values.shape[1], self.num_threads):
-            if col < length:
-                key = self._to_coarse_key(input_values[row_idx, col])
-                if key < threshold:
-                    pos = atomicAdd(s_counter.iterator, val_one)
-                    if pos < self.top_k:
-                        s_indices[pos] = col
-                elif key == threshold:
-                    pos = atomicAdd(s_num_input.iterator, val_one)
-                    if pos < self.smem_candidate_capacity:
-                        s_input_idx[0, pos] = col
-                    else:
-                        overflow_pos = atomicAdd(
-                            g_num_input.iterator,
-                            val_one,
-                        )
-                        overflow[workspace_slot, 0, overflow_pos] = col
+        for col in cutlass.range(tidx, length, self.num_threads):
+            key = self._to_coarse_key(input_values[row_idx, col])
+            if key < threshold:
+                pos = atomicAdd(s_counter.iterator, val_one)
+                if pos < self.top_k:
+                    s_indices[pos] = col
+            elif key == threshold:
+                pos = atomicAdd(s_num_input.iterator, val_one)
+                if pos < self.smem_candidate_capacity:
+                    s_input_idx[0, pos] = col
+                else:
+                    overflow_pos = atomicAdd(
+                        g_num_input.iterator,
+                        val_one,
+                    )
+                    overflow[workspace_slot, 0, overflow_pos] = col
         fence_acq_rel_cta()
         cute.arch.barrier()
 
@@ -419,13 +554,11 @@ class IndexerTopKPrefillKernel:
             next_buffer = current ^ 1
             candidate_count = s_num_input[current]
             run_refinement = s_counter[0] < self.top_k
-            if tidx < 256:
-                s_histogram[tidx] = 0
+            self._clear_histogram(tidx, s_histogram)
             if tidx == 0:
                 s_num_input[next_buffer] = 0
                 g_num_input[next_buffer] = 0
-                s_histogram[256] = 255
-                s_histogram[257] = 0
+                s_histogram[self.histogram_threshold_idx] = 255
             cute.arch.barrier()
 
             if run_refinement:
@@ -440,8 +573,12 @@ class IndexerTopKPrefillKernel:
                         self._to_ordered(input_values[bidx, col])
                         >> (self.first_refine_shift - refine_round * 8)
                     ) & 0xFF
+                    bin_offset = self.histogram_warp_base + (tidx // 32) * 256
                     atomicAdd(
-                        s_histogram.iterator + cutlass.Int32(key), val_one
+                        s_histogram.iterator
+                        + cutlass.Int32(bin_offset)
+                        + cutlass.Int32(key),
+                        val_one,
                     )
                 for candidate in cutlass.range(
                     tidx, g_num_input[current], self.num_threads
@@ -451,10 +588,15 @@ class IndexerTopKPrefillKernel:
                         self._to_ordered(input_values[bidx, col])
                         >> (self.first_refine_shift - refine_round * 8)
                     ) & 0xFF
+                    bin_offset = self.histogram_warp_base + (tidx // 32) * 256
                     atomicAdd(
-                        s_histogram.iterator + cutlass.Int32(key), val_one
+                        s_histogram.iterator
+                        + cutlass.Int32(bin_offset)
+                        + cutlass.Int32(key),
+                        val_one,
                     )
-            cute.arch.barrier()
+            fence_acq_rel_cta()
+            self._reduce_histogram(tidx, s_histogram)
 
             remaining = cutlass.Int32(0)
             val = cutlass.Int32(0)
@@ -476,19 +618,46 @@ class IndexerTopKPrefillKernel:
                 if tidx > 0:
                     previous = s_histogram[tidx - 1]
                 if previous < remaining and val >= remaining:
-                    s_histogram[256] = tidx
-                    s_histogram[257] = previous
+                    s_histogram[self.histogram_threshold_idx] = tidx
                     s_counter[2] = remaining - previous
+                    if refine_round == self.num_refine_rounds - 1:
+                        s_counter[1] = val - previous
                 if tidx == 255 and val < remaining:
                     # No radix bin reaches the remaining K.  All candidates
                     # are selected and the rest are sentinel padding.
-                    s_histogram[256] = 255
-                    s_histogram[257] = val
+                    s_histogram[self.histogram_threshold_idx] = 255
                     s_counter[2] = val - previous
+                    if refine_round == self.num_refine_rounds - 1:
+                        s_counter[1] = val - previous
             cute.arch.barrier()
 
             if run_refinement:
-                threshold = s_histogram[256]
+                threshold = s_histogram[self.histogram_threshold_idx]
+                if (
+                    refine_round == self.num_refine_rounds - 1
+                    and s_counter[1] > s_counter[2]
+                ):
+                    # The final score byte identifies the exact boundary
+                    # score. Select the smallest required column indices from
+                    # that tie group before committing candidates. Membership
+                    # is now data-defined rather than atomic-arrival-defined.
+                    self._select_boundary_index(
+                        tidx,
+                        input_values,
+                        overflow,
+                        s_histogram,
+                        s_counter,
+                        s_warp_sums,
+                        s_num_input,
+                        g_num_input,
+                        s_input_idx,
+                        bidx,
+                        workspace_slot,
+                        current,
+                        candidate_count,
+                        threshold,
+                        self.first_refine_shift - refine_round * 8,
+                    )
                 smem_count = candidate_count
                 if smem_count > self.smem_candidate_capacity:
                     smem_count = self.smem_candidate_capacity
@@ -506,10 +675,7 @@ class IndexerTopKPrefillKernel:
                             s_indices[pos] = col
                     elif key == threshold:
                         if refine_round == self.num_refine_rounds - 1:
-                            remaining_pos = atomicAdd(
-                                s_counter.iterator + 2, cutlass.Int32(-1)
-                            )
-                            if remaining_pos > 0:
+                            if s_counter[3] < 0 or col <= s_counter[3]:
                                 pos = atomicAdd(s_counter.iterator, val_one)
                                 if pos < self.top_k:
                                     s_indices[pos] = col
@@ -542,10 +708,7 @@ class IndexerTopKPrefillKernel:
                             s_indices[pos] = col
                     elif key == threshold:
                         if refine_round == self.num_refine_rounds - 1:
-                            remaining_pos = atomicAdd(
-                                s_counter.iterator + 2, cutlass.Int32(-1)
-                            )
-                            if remaining_pos > 0:
+                            if s_counter[3] < 0 or col <= s_counter[3]:
                                 pos = atomicAdd(s_counter.iterator, val_one)
                                 if pos < self.top_k:
                                     s_indices[pos] = col
@@ -569,84 +732,25 @@ class IndexerTopKPrefillKernel:
             fence_acq_rel_cta()
             cute.arch.barrier()
 
-        # The radix collector does not define the order of selected entries.
-        # Sort selected members by score descending and index ascending on a
-        # tie, matching the extracted cuDNN Frontend output phase.
-        self._sort_selected_by_score(
-            tidx, s_indices, s_values, input_values, bidx
-        )
+        if cutlass.const_expr(self.sort_mode == "index"):
+            self._sort_selected_by_index(tidx, s_indices)
+        else:
+            # The score implementation accepts a value scratch tensor, but the
+            # bitonic network reads score keys directly from input_values.
+            # s_indices is passed as the unused compatibility argument so the
+            # score kernel keeps its original interface without extra smem.
+            self._sort_selected_by_score(
+                tidx,
+                s_indices,
+                s_indices,
+                input_values,
+                bidx,
+            )
         cute.arch.barrier()
 
-        # The last radix byte fully identifies the floating-point score.
-        # s_counter[2] is decremented once for every candidate in that exact
-        # boundary-score bin.  A negative final value therefore means that
-        # more equal-score candidates existed than available top-k slots.
-        #
-        # Atomic arrival order is not a deterministic tie-break.  Repair only
-        # those rare boundary ties by replacing the selected tie block with
-        # the smallest column indices under an explicit score-desc/index-asc
-        # contract.  Non-tie rows do not pay for the extra input scan.
-        if length >= self.top_k:
-            if s_counter[2] < 0:
-                boundary_index = s_indices[self.top_k - 1]
-                boundary_key = self._to_ordered(
-                    input_values[bidx, boundary_index]
-                )
-                if tidx == 0:
-                    s_counter[1] = -1  # last selected tie index
-                    s_counter[2] = 0  # selected boundary-score slot count
-                cute.arch.barrier()
-
-                for i in cutlass.range(tidx, self.top_k, self.num_threads):
-                    index = s_indices[i]
-                    if index >= 0:
-                        key = self._to_ordered(input_values[bidx, index])
-                        if key == boundary_key:
-                            atomicAdd(s_counter.iterator + 2, val_one)
-                cute.arch.barrier()
-
-                tie_slots = s_counter[2]
-                tie_start = self.top_k - tie_slots
-                for tie_rank in cutlass.range(0, self.top_k, 1):
-                    if tie_rank < tie_slots:
-                        if tidx == 0:
-                            s_counter[3] = length
-                        cute.arch.barrier()
-
-                        last_index = s_counter[1]
-                        for col in cutlass.range(
-                            tidx,
-                            input_values.shape[1],
-                            self.num_threads,
-                        ):
-                            if col < length:
-                                if col > last_index:
-                                    key = self._to_ordered(
-                                        input_values[bidx, col]
-                                    )
-                                    if key == boundary_key:
-                                        cute.arch.atomic_min(
-                                            ptr=(
-                                                s_counter.iterator + 3
-                                            ).llvm_ptr,
-                                            val=cutlass.Int32(col),
-                                            sem="relaxed",
-                                            scope="cta",
-                                        )
-                        cute.arch.barrier()
-
-                        if tidx == 0:
-                            next_index = s_counter[3]
-                            s_indices[tie_start + tie_rank] = next_index
-                            s_counter[1] = next_index
-                        cute.arch.barrier()
-
         for i in cutlass.range(tidx, self.top_k, self.num_threads):
-            # ``row_lengths`` is a hard validity boundary.  When
-            # length < top_k, the radix collector may have selected
-            # arbitrary entries from the -inf tail to fill the output.
-            # Never expose those entries (or an accidentally corrupted
-            # candidate) to the caller.
+            # ``row_lengths`` remains a hard validity boundary even on the
+            # full selection path. Never expose a corrupted candidate.
             index = s_indices[i]
             if i < length:
                 if index >= 0:
@@ -681,7 +785,10 @@ class IndexerTopKPrefillKernel:
         smem = SmemAllocator()
         s_histogram = smem.allocate_tensor(
             element_type=cutlass.Int32,
-            layout=cute.make_ordered_layout((258,), order=(0,)),
+            layout=cute.make_ordered_layout(
+                (self.histogram_threshold_idx + 1,),
+                order=(0,),
+            ),
             byte_alignment=128,
         )
         s_counter = smem.allocate_tensor(
@@ -692,11 +799,6 @@ class IndexerTopKPrefillKernel:
         s_indices = smem.allocate_tensor(
             element_type=cutlass.Int32,
             layout=cute.make_ordered_layout((self.sort_size,), order=(0,)),
-            byte_alignment=128,
-        )
-        s_values = smem.allocate_tensor(
-            element_type=self.dtype,
-            layout=cute.make_ordered_layout((self.top_k,), order=(0,)),
             byte_alignment=128,
         )
         s_warp_sums = smem.allocate_tensor(
@@ -741,7 +843,6 @@ class IndexerTopKPrefillKernel:
                     s_histogram,
                     s_counter,
                     s_indices,
-                    s_values,
                     s_warp_sums,
                     s_num_input,
                     g_num_input,
@@ -749,6 +850,31 @@ class IndexerTopKPrefillKernel:
                     row_idx,
                     slot_idx,
                 )
+
+    @cute.jit
+    def _clear_histogram(self, tidx, s_histogram):
+        for i in cutlass.range(
+            self.histogram_warp_base + tidx,
+            self.histogram_threshold_idx,
+            self.num_threads,
+        ):
+            s_histogram[i] = 0
+        cute.arch.barrier()
+
+    @cute.jit
+    def _reduce_histogram(self, tidx, s_histogram):
+        cute.arch.barrier()
+        if tidx < 256:
+            total = cutlass.Int32(0)
+            for warp_idx in range(self.num_warps):
+                total = (
+                    total
+                    + s_histogram[
+                        self.histogram_warp_base + warp_idx * 256 + tidx
+                    ]
+                )
+            s_histogram[tidx] = total
+        cute.arch.barrier()
 
     @cute.jit
     def _to_coarse_key(self, value):
@@ -803,6 +929,7 @@ class IndexerTopKPrefillKernel:
     def _sort_selected_by_score(
         self, tidx, s_indices, s_values, input_values, bidx
     ):
+        """Original score-descending/index-ascending bitonic output path."""
         sentinel = -1
         for p in cutlass.range(tidx, self.sort_size, self.num_threads):
             if p >= self.top_k:
@@ -840,6 +967,151 @@ class IndexerTopKPrefillKernel:
                 cute.arch.barrier()
                 j >>= 1
             k <<= 1
+
+    @cute.jit
+    def _select_boundary_index(
+        self,
+        tidx,
+        input_values,
+        overflow,
+        s_histogram,
+        s_counter,
+        s_warp_sums,
+        s_num_input,
+        g_num_input,
+        s_input_idx,
+        bidx,
+        workspace_slot,
+        current,
+        candidate_count,
+        score_threshold,
+        score_shift,
+    ):
+        """Find the smallest index prefix containing the boundary tie slots."""
+        val_one = cutlass.Int32(1)
+        if tidx == 0:
+            s_counter[1] = 0  # selected high-order index prefix
+            s_counter[3] = -1  # final inclusive index threshold
+        cute.arch.barrier()
+
+        for index_round in range(self.num_index_refine_rounds):
+            self._clear_histogram(tidx, s_histogram)
+
+            index_prefix = s_counter[1]
+            index_shift = (self.num_index_refine_rounds - index_round - 1) * 8
+            smem_count = candidate_count
+            if smem_count > self.smem_candidate_capacity:
+                smem_count = self.smem_candidate_capacity
+            for candidate in cutlass.range(tidx, smem_count, self.num_threads):
+                col = s_input_idx[current, candidate]
+                score_key = (
+                    self._to_ordered(input_values[bidx, col]) >> score_shift
+                ) & 0xFF
+                candidate_prefix = col >> (index_shift + 8)
+                if score_key == score_threshold:
+                    if candidate_prefix == index_prefix:
+                        index_key = (col >> index_shift) & 0xFF
+                        bin_offset = (
+                            self.histogram_warp_base + (tidx // 32) * 256
+                        )
+                        atomicAdd(
+                            s_histogram.iterator
+                            + cutlass.Int32(bin_offset)
+                            + cutlass.Int32(index_key),
+                            val_one,
+                        )
+            for candidate in cutlass.range(
+                tidx, g_num_input[current], self.num_threads
+            ):
+                col = overflow[workspace_slot, current, candidate]
+                score_key = (
+                    self._to_ordered(input_values[bidx, col]) >> score_shift
+                ) & 0xFF
+                candidate_prefix = col >> (index_shift + 8)
+                if score_key == score_threshold:
+                    if candidate_prefix == index_prefix:
+                        index_key = (col >> index_shift) & 0xFF
+                        bin_offset = (
+                            self.histogram_warp_base + (tidx // 32) * 256
+                        )
+                        atomicAdd(
+                            s_histogram.iterator
+                            + cutlass.Int32(bin_offset)
+                            + cutlass.Int32(index_key),
+                            val_one,
+                        )
+            fence_acq_rel_cta()
+            self._reduce_histogram(tidx, s_histogram)
+
+            remaining = s_counter[2]
+            val = cutlass.Int32(0)
+            if tidx < 256:
+                val = s_histogram[tidx]
+                val, _ = block_prefix_sum_kernel(
+                    val,
+                    s_warp_sums,
+                    tidx,
+                    256,
+                    8,
+                    barrier_id=1,
+                )
+                s_histogram[tidx] = val
+            cute.arch.barrier()
+            if tidx < 256:
+                previous = 0
+                if tidx > 0:
+                    previous = s_histogram[tidx - 1]
+                if previous < remaining and val >= remaining:
+                    s_counter[1] = index_prefix * 256 + tidx
+                    s_counter[2] = remaining - previous
+            cute.arch.barrier()
+
+        if tidx == 0:
+            s_counter[3] = s_counter[1]
+        cute.arch.barrier()
+
+    @cute.jit
+    def _sort_selected_by_index(
+        self,
+        tidx,
+        s_indices,
+    ):
+        """Sort selected indices ascending with an integer-only network."""
+        for p in cutlass.range(tidx, self.sort_size, self.num_threads):
+            if p >= self.top_k:
+                s_indices[p] = -1
+        cute.arch.barrier()
+        k = 2
+        while k <= self.sort_size:
+            j = k >> 1
+            while j > 0:
+                for p in cutlass.range(tidx, self.sort_size, self.num_threads):
+                    partner = p ^ j
+                    if partner > p:
+                        lhs = s_indices[p]
+                        rhs = s_indices[partner]
+                        lhs_invalid = lhs < 0
+                        rhs_invalid = rhs < 0
+                        ascending = (p & k) == 0
+                        swap = False
+                        if lhs_invalid != rhs_invalid:
+                            swap = lhs_invalid if ascending else not lhs_invalid
+                        elif not lhs_invalid:
+                            if ascending:
+                                swap = lhs > rhs
+                            else:
+                                swap = lhs < rhs
+                        if swap:
+                            s_indices[p] = rhs
+                            s_indices[partner] = lhs
+                cute.arch.barrier()
+                j >>= 1
+            k <<= 1
+
+        # Keep the output phase's selected-buffer contract explicit.
+        for p in cutlass.range(tidx, self.sort_size, self.num_threads):
+            if p >= self.top_k:
+                s_indices[p] = -1
 
     @cute.jit
     def __call__(
@@ -897,7 +1169,10 @@ class IndexerTopKPrefillClcKernel(IndexerTopKPrefillKernel):
         smem = SmemAllocator()
         s_histogram = smem.allocate_tensor(
             element_type=cutlass.Int32,
-            layout=cute.make_ordered_layout((258,), order=(0,)),
+            layout=cute.make_ordered_layout(
+                (self.histogram_threshold_idx + 1,),
+                order=(0,),
+            ),
             byte_alignment=128,
         )
         s_counter = smem.allocate_tensor(
@@ -908,11 +1183,6 @@ class IndexerTopKPrefillClcKernel(IndexerTopKPrefillKernel):
         s_indices = smem.allocate_tensor(
             element_type=cutlass.Int32,
             layout=cute.make_ordered_layout((self.sort_size,), order=(0,)),
-            byte_alignment=128,
-        )
-        s_values = smem.allocate_tensor(
-            element_type=self.dtype,
-            layout=cute.make_ordered_layout((self.top_k,), order=(0,)),
             byte_alignment=128,
         )
         s_warp_sums = smem.allocate_tensor(
@@ -941,7 +1211,6 @@ class IndexerTopKPrefillClcKernel(IndexerTopKPrefillKernel):
             ),
             byte_alignment=128,
         )
-
         # PipelineClcFetchAsync uses one full and one empty mbarrier per
         # stage.  Keep both barriers in the CLC-only kernel; the old branch
         # allocated only one barrier and could not represent the protocol.
@@ -1061,7 +1330,6 @@ class IndexerTopKPrefillClcKernel(IndexerTopKPrefillKernel):
                     s_histogram,
                     s_counter,
                     s_indices,
-                    s_values,
                     s_warp_sums,
                     s_num_input,
                     g_num_input,
@@ -1109,7 +1377,9 @@ def _compile_kernel(
     schedule_mode: str,
     num_rows: int,
     num_workspace_slots: int,
+    sort_mode: str = "score",
 ):
+    sort_mode = _validate_sort_mode(sort_mode, int(top_k))
     if schedule_mode == "clc":
         import paddle
 
@@ -1136,6 +1406,7 @@ def _compile_kernel(
         schedule_mode,
         None,
         num_workspace_slots,
+        sort_mode,
     )
     if key in _COMPILE_CACHE:
         return _COMPILE_CACHE[key]
@@ -1199,6 +1470,7 @@ def _compile_kernel(
         schedule_mode,
         num_rows,
         num_workspace_slots,
+        sort_mode,
     )
     # CuTe's kernel compiler does not always materialize nested ``@cute.jit``
     # methods before executing the outer host wrapper.  Preprocess the
@@ -1206,9 +1478,14 @@ def _compile_kernel(
     # before ``cute.compile`` enters the kernel body.
     for method in (
         IndexerTopKPrefillKernel._topk_per_row,
+        IndexerTopKPrefillKernel._topk_per_row_full,
+        IndexerTopKPrefillKernel._clear_histogram,
+        IndexerTopKPrefillKernel._reduce_histogram,
         IndexerTopKPrefillKernel._to_coarse_key,
         IndexerTopKPrefillKernel._to_ordered,
         IndexerTopKPrefillKernel._sort_selected_by_score,
+        IndexerTopKPrefillKernel._select_boundary_index,
+        IndexerTopKPrefillKernel._sort_selected_by_index,
         block_prefix_sum_kernel,
         fence_acq_rel_cta,
     ):
@@ -1244,6 +1521,7 @@ def precompile_indexer_topk_clc(
     *,
     dtype=None,
     return_values: tuple[bool, ...] = (False, True),
+    sort_mode: str = "score",
 ) -> tuple[int, ...]:
     """Precompile every CLC variant needed up to ``max_num_cols``.
 
@@ -1257,6 +1535,8 @@ def precompile_indexer_topk_clc(
     same generated code and therefore cover 256k sequences without additional
     compilation.
 
+    ``sort_mode="score"`` compiles the original score-order bitonic path.
+    ``sort_mode="index"`` compiles the selected integer index algorithm.
     Returns:
         The compile buckets covered by this call.
     """
@@ -1273,10 +1553,11 @@ def precompile_indexer_topk_clc(
 
     max_num_cols = int(max_num_cols)
     top_k = int(top_k)
+    sort_mode = _validate_sort_mode(sort_mode, top_k)
     if max_num_cols <= 0:
         raise ValueError(f"max_num_cols must be positive, got {max_num_cols}")
-    if top_k <= 0 or top_k > 2048:
-        raise ValueError(f"top_k must be in [1, 2048], got {top_k}")
+    if top_k <= 0 or top_k > _MAX_TOP_K:
+        raise ValueError(f"top_k must be in [1, {_MAX_TOP_K}], got {top_k}")
     if max_num_cols < top_k:
         raise ValueError(
             f"max_num_cols must be >= top_k, got {max_num_cols} < {top_k}"
@@ -1288,6 +1569,7 @@ def precompile_indexer_topk_clc(
         dtype = paddle.float32
     cutlass, _, _, _ = _require_cutedsl()
     cutlass_dtype = _cutlass_dtype(dtype, cutlass)
+    _validate_top_k_for_dtype(top_k, cutlass_dtype, cutlass)
     max_bucket = _compile_num_cols_bucket(max_num_cols)
     bucket = _compile_num_cols_bucket(top_k)
     buckets = []
@@ -1302,6 +1584,7 @@ def precompile_indexer_topk_clc(
         tuple(buckets),
         top_k,
         tuple(bool(value) for value in return_values),
+        sort_mode,
     )
     if precompile_key in _CLC_PRECOMPILE_CACHE:
         return tuple(buckets)
@@ -1313,11 +1596,20 @@ def precompile_indexer_topk_clc(
         f" max_num_cols={max_num_cols}"
         f" buckets={buckets}"
         f" top_k={top_k}"
+        f" sort_mode={sort_mode}"
         f" return_values={tuple(bool(v) for v in return_values)}",
         flush=True,
     )
     for compile_bucket in buckets:
         num_threads = 256 if compile_bucket < 8192 else 512
+        num_candidate_pages = 2 if cutlass_dtype == cutlass.Float32 else 1
+        smem_bytes_per_cta = _estimate_smem_bytes_per_cta(
+            num_threads,
+            top_k,
+            num_candidate_pages,
+            min(_SMEM_CANDIDATE_CAPACITY, compile_bucket),
+            "clc",
+        )
         num_persistent_ctas, rows_per_cta = _persistent_launch_config(
             1, persistent=True, schedule_mode="clc"
         )
@@ -1327,8 +1619,8 @@ def precompile_indexer_topk_clc(
             num_threads,
             persistent=True,
             schedule_mode="clc",
+            smem_bytes_per_cta=smem_bytes_per_cta,
         )
-        num_candidate_pages = 2 if cutlass_dtype == cutlass.Float32 else 1
         for return_val in return_values:
             _compile_kernel(
                 cutlass_dtype,
@@ -1341,6 +1633,7 @@ def precompile_indexer_topk_clc(
                 "clc",
                 1,
                 num_workspace_slots,
+                sort_mode,
             )
 
     _CLC_PRECOMPILE_CACHE.add(precompile_key)
@@ -1359,14 +1652,22 @@ def indexer_topk_prefill(
     persistent: bool = True,
     schedule_mode: str = "clc",
     scheduler_state=None,
+    sort_mode: str = "score",
 ):
     """Run standalone DSA indexer top-k on Paddle CUDA tensors.
 
     Args:
         input_values: Contiguous Paddle tensor ``[num_rows, num_cols]``.
         row_lengths: Contiguous int32 Paddle tensor ``[num_rows]``.  Each
-            element is the valid prefix length of the corresponding row.
-        top_k: Number of entries to return, at most 2048.
+            element is the valid prefix length of the corresponding row. When
+            the clamped length is smaller than ``top_k``, the kernel returns
+            that complete prefix in index order and pads the remaining slots.
+        top_k: Number of entries to return. The maximum is 32768 for
+            float16/bfloat16 and 16384 for float32.
+        sort_mode: ``"score"`` preserves the original score-descending,
+            index-ascending tie order. ``"index"`` uses the deterministic
+            index-ascending kernel for any positive ``top_k``. Short rows
+            return their complete valid prefix in index order in either mode.
         return_val: Whether to return values alongside indices.
         out_indices: Optional reusable contiguous int32 output tensor with
             shape ``[num_rows, top_k]``.
@@ -1377,8 +1678,9 @@ def indexer_topk_prefill(
             shape ``[num_workspace_slots, num_candidate_pages,
             overflow_capacity]``. Static scheduling uses one slot per
             persistent CTA. CLC uses a conservative resident-CTA upper bound
-            based on the device SM count and 2048 threads per SM, rather than
-            allocating one slot per logical row. ``num_candidate_pages`` is
+            based on the device SM count plus thread and shared-memory limits,
+            rather than allocating one slot per logical row.
+            ``num_candidate_pages`` is
             two for float32 and one otherwise; ``overflow_capacity`` is
             ``max(1, num_cols - min(16384, num_cols))``.
         persistent: Use a fixed SM-sized CTA grid and reuse workspace slots
@@ -1410,13 +1712,15 @@ def indexer_topk_prefill(
         raise ValueError("input_values and row_lengths must be contiguous")
     if row_lengths.dtype != paddle.int32:
         raise TypeError("row_lengths must have dtype paddle.int32")
-    if top_k <= 0 or top_k > 2048:
-        raise ValueError(f"top_k must be in [1, 2048], got {top_k}")
+    if top_k <= 0 or top_k > _MAX_TOP_K:
+        raise ValueError(f"top_k must be in [1, {_MAX_TOP_K}], got {top_k}")
+    sort_mode = _validate_sort_mode(sort_mode, int(top_k))
     if input_values.shape[1] <= 0:
         raise ValueError("input_values must have a non-empty column dimension")
 
     cutlass, _, _, _ = _require_cutedsl()
     dtype = _cutlass_dtype(input_values.dtype, cutlass)
+    _validate_top_k_for_dtype(int(top_k), dtype, cutlass)
     num_candidate_pages = 2 if dtype == cutlass.Float32 else 1
     num_persistent_ctas, rows_per_cta = _persistent_launch_config(
         int(input_values.shape[0]),
@@ -1426,12 +1730,20 @@ def indexer_topk_prefill(
     num_rows = int(input_values.shape[0])
     bucketed_num_cols = _compile_num_cols_bucket(int(input_values.shape[1]))
     num_threads = 256 if bucketed_num_cols < 8192 else 512
+    smem_bytes_per_cta = _estimate_smem_bytes_per_cta(
+        num_threads,
+        int(top_k),
+        num_candidate_pages,
+        min(_SMEM_CANDIDATE_CAPACITY, bucketed_num_cols),
+        schedule_mode,
+    )
     num_workspace_slots = _workspace_slot_count(
         num_rows,
         num_persistent_ctas,
         num_threads,
         persistent,
         schedule_mode,
+        smem_bytes_per_cta=smem_bytes_per_cta,
     )
     compiled = _compile_kernel(
         dtype,
@@ -1444,6 +1756,7 @@ def indexer_topk_prefill(
         schedule_mode,
         num_rows,
         num_workspace_slots,
+        sort_mode,
     )
 
     overflow_capacity = max(

--- a/src/paddlefleet/cutedsl_ops/indexer_topk_prefill.py
+++ b/src/paddlefleet/cutedsl_ops/indexer_topk_prefill.py
@@ -1,0 +1,1574 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Paddle-facing DSA indexer top-k prefill operator.
+
+This is a standalone CuTe DSL operator adapted from the cuDNN Frontend DSA
+indexer top-k implementation.  It intentionally has a smaller first-stage
+scope:
+
+* prefill only;
+* one persistent CTA per SM, with each CTA processing multiple rows;
+* ``next_n == 1``;
+* no multi-CTA or merge-block path;
+* no autograd integration.
+
+The public entry point accepts Paddle CUDA tensors.  Tensor conversion is
+zero-copy through :mod:`.dlpack`.
+"""
+
+from __future__ import annotations
+
+import os
+import warnings
+from typing import Any
+
+try:
+    import cutlass
+    from cutlass import cute
+    from cutlass._mlir.dialects import llvm
+    from cutlass.cute.runtime import make_fake_stream
+    from cutlass.pipeline import (
+        Agent,
+        CooperativeGroup,
+        PipelineClcFetchAsync,
+        PipelineUserType,
+        make_pipeline_state,
+        pipeline_init_arrive,
+        pipeline_init_wait,
+    )
+    from cutlass.utils import (
+        ClcDynamicPersistentTileScheduler,
+        ClcDynamicPersistentTileSchedulerParams,
+    )
+    from cutlass.utils.distributed import atomicAdd
+    from cutlass.utils.smem_allocator import SmemAllocator
+
+    from .block_scan import (
+        block_prefix_sum_kernel,
+        fence_acq_rel_cta,
+    )
+except ImportError:
+    cutlass = None
+
+    class _MissingCute:
+        @staticmethod
+        def jit(*args, **kwargs):
+            if args and callable(args[0]) and len(args) == 1:
+                return args[0]
+            return lambda fn: fn
+
+        kernel = jit
+
+    cute = _MissingCute()
+    llvm = None
+    make_fake_stream = None
+    atomicAdd = None
+    SmemAllocator = None
+    ClcDynamicPersistentTileScheduler = None
+    ClcDynamicPersistentTileSchedulerParams = None
+    Agent = None
+    CooperativeGroup = None
+    PipelineClcFetchAsync = None
+    PipelineUserType = None
+    make_pipeline_state = None
+    pipeline_init_arrive = None
+    pipeline_init_wait = None
+    block_prefix_sum_kernel = None
+    fence_acq_rel_cta = None
+
+_COMPILE_CACHE: dict[tuple[Any, ...], Any] = {}
+_CLC_PRECOMPILE_CACHE: set[tuple[Any, ...]] = set()
+_OUTPUT_ALLOC_WARNING_EMITTED = False
+_CUTEDSL_AVAILABLE = cutlass is not None
+
+
+_SMEM_CANDIDATE_CAPACITY = 16384
+_MAX_THREADS_PER_SM = 2048
+
+
+def _next_power_of_two(value: int) -> int:
+    return 1 if value <= 1 else 1 << (value - 1).bit_length()
+
+
+def _compile_num_cols_bucket(num_cols: int) -> int:
+    """Return the largest compile bucket needed by the CLC implementation.
+
+    The kernel reads the actual column extent at runtime.  Its only
+    compile-time column-dependent resource is the candidate capacity, which
+    saturates at ``_SMEM_CANDIDATE_CAPACITY``.  Consequently all larger
+    sequence lengths can share the saturated binary (including 256k and
+    beyond).
+    """
+    return min(_next_power_of_two(int(num_cols)), _SMEM_CANDIDATE_CAPACITY)
+
+
+def _persistent_launch_config(
+    num_rows: int, persistent: bool = True, schedule_mode: str = "clc"
+) -> tuple[int, int]:
+    import paddle
+
+    if num_rows <= 0:
+        raise ValueError("input_values must have a non-empty row dimension")
+    if schedule_mode not in {"static", "clc"}:
+        raise ValueError(
+            f"unsupported schedule_mode={schedule_mode!r}; "
+            "expected 'static' or 'clc'"
+        )
+    if schedule_mode == "clc" and not persistent:
+        raise ValueError("schedule_mode='clc' requires persistent=True")
+    if not persistent:
+        return num_rows, 1
+    sm_count = int(
+        paddle.device.cuda.get_device_properties().multi_processor_count
+    )
+    if schedule_mode == "static":
+        # Static persistent kernels use a runtime-bounded strided row loop.
+        # Keep the resident CTA count independent of the current batch shape
+        # so one compiled kernel can serve different num_rows values.
+        return max(1, sm_count), 1
+    # CLC also receives the row count at runtime.  Keep the resident CTA
+    # count independent of the current shape so its compiled kernel can be
+    # reused across different num_rows values.
+    return max(1, sm_count), 1
+
+
+def _workspace_slot_count(
+    num_rows: int,
+    num_persistent_ctas: int,
+    num_threads: int,
+    persistent: bool,
+    schedule_mode: str,
+) -> int:
+    """Return the maximum number of concurrently allocated CLC slots.
+
+    CLC launches one CTA per logical row, but only resident CTAs execute the
+    slot allocation.  The thread-resource bound is conservative here; shared
+    memory and registers can only reduce the actual resident CTA count.
+    """
+    if not persistent:
+        return num_rows
+    if schedule_mode != "clc":
+        return num_persistent_ctas
+    max_ctas_per_sm = max(1, _MAX_THREADS_PER_SM // num_threads)
+    # The workspace is indexed by resident CTA, not by logical row.  Allocate
+    # the resident upper bound even for a small input so the CLC binary can
+    # share one runtime-bounded layout across all row counts.
+    return num_persistent_ctas * max_ctas_per_sm
+
+
+def _require_cutedsl():
+    global _CUTEDSL_AVAILABLE
+    if not _CUTEDSL_AVAILABLE:
+        try:
+            import cutlass as _cutlass
+            import cutlass.cute as _cute
+            from cutlass._mlir.dialects import llvm as _llvm
+            from cutlass.cute.runtime import (
+                make_fake_stream as _make_fake_stream,
+            )
+            from cutlass.pipeline import (
+                Agent as _agent,
+                CooperativeGroup as _cooperative_group,
+                PipelineClcFetchAsync as _pipeline_clc_fetch_async,
+                PipelineUserType as _pipeline_user_type,
+                make_pipeline_state as _make_pipeline_state,
+                pipeline_init_arrive as _pipeline_init_arrive,
+                pipeline_init_wait as _pipeline_init_wait,
+            )
+            from cutlass.utils import (
+                ClcDynamicPersistentTileScheduler as _clc_scheduler,
+                ClcDynamicPersistentTileSchedulerParams as _clc_params,
+            )
+            from cutlass.utils.distributed import atomicAdd as _atomic_add
+            from cutlass.utils.smem_allocator import (
+                SmemAllocator as _smem_allocator,
+            )
+
+            from .block_scan import (
+                block_prefix_sum_kernel as _block_prefix_sum_kernel,
+                fence_acq_rel_cta as _fence_acq_rel_cta,
+            )
+        except ImportError as exc:
+            raise ImportError(
+                "paddlefleet.cutedsl_ops requires the CuTe DSL Python runtime"
+            ) from exc
+        globals().update(
+            cutlass=_cutlass,
+            cute=_cute,
+            llvm=_llvm,
+            make_fake_stream=_make_fake_stream,
+            atomicAdd=_atomic_add,
+            SmemAllocator=_smem_allocator,
+            ClcDynamicPersistentTileScheduler=_clc_scheduler,
+            ClcDynamicPersistentTileSchedulerParams=_clc_params,
+            Agent=_agent,
+            CooperativeGroup=_cooperative_group,
+            PipelineClcFetchAsync=_pipeline_clc_fetch_async,
+            PipelineUserType=_pipeline_user_type,
+            make_pipeline_state=_make_pipeline_state,
+            pipeline_init_arrive=_pipeline_init_arrive,
+            pipeline_init_wait=_pipeline_init_wait,
+            block_prefix_sum_kernel=_block_prefix_sum_kernel,
+            fence_acq_rel_cta=_fence_acq_rel_cta,
+        )
+        _CUTEDSL_AVAILABLE = True
+    return cutlass, cute, make_fake_stream, SmemAllocator
+
+
+def _cutlass_dtype(paddle_dtype, cutlass):
+    import paddle
+
+    mapping = {
+        paddle.float16: cutlass.Float16,
+        paddle.bfloat16: cutlass.BFloat16,
+        paddle.float32: cutlass.Float32,
+    }
+    try:
+        return mapping[paddle_dtype]
+    except KeyError as exc:
+        raise TypeError(
+            "indexer_topk_prefill supports paddle.float16, "
+            "paddle.bfloat16, and paddle.float32"
+        ) from exc
+
+
+def _is_cuda_tensor(tensor) -> bool:
+    place = getattr(tensor, "place", None)
+    checker = getattr(place, "is_gpu_place", None)
+    if checker is not None:
+        return bool(checker())
+    return "gpu" in str(place).lower() or "cuda" in str(place).lower()
+
+
+class IndexerTopKPrefillKernel:
+    """Single-CTA-per-row CuTe DSL radix-select top-k kernel.
+
+    The implementation is adapted from the cuDNN Frontend DSA indexer
+    ``IndexerTopKKernelVarlen``.  Its ordinary one-CTA-per-row algorithm is
+    scheduled through a persistent CTA grid; decode scheduling, multi-CTA
+    collection, and merge-block payloads are intentionally absent.
+    """
+
+    def __init__(
+        self,
+        dtype,
+        max_num_cols: int,
+        top_k: int,
+        return_val: bool,
+        num_persistent_ctas: int,
+        rows_per_cta: int,
+        schedule_mode: str = "clc",
+        num_rows: int = 0,
+        num_workspace_slots: int = 0,
+    ):
+        cutlass, cute, _, _ = _require_cutedsl()
+        self.cutlass = cutlass
+        self.cute = cute
+        self.dtype = dtype
+        self.max_num_cols = int(max_num_cols)
+        self.top_k = int(top_k)
+        self.return_val = bool(return_val)
+        self.num_persistent_ctas = int(num_persistent_ctas)
+        self.rows_per_cta = int(rows_per_cta)
+        self.schedule_mode = str(schedule_mode)
+        self.use_clc = self.schedule_mode == "clc"
+        # Both schedulers use a shape-independent compiled kernel.  Static
+        # launches a fixed resident grid; CLC launches the runtime row count
+        # from the input tensor in its host wrapper.
+        self.num_launch_ctas = self.num_persistent_ctas
+        self.num_candidate_pages = 2 if dtype == cutlass.Float32 else 1
+        self.smem_candidate_capacity = min(
+            _SMEM_CANDIDATE_CAPACITY, self.max_num_cols
+        )
+        self.num_threads = 256 if self.max_num_cols < 8192 else 512
+        self.num_workspace_slots = int(
+            num_workspace_slots or self.num_persistent_ctas
+        )
+        self.sort_size = _next_power_of_two(self.top_k)
+        self.first_refine_shift = 24 if dtype == cutlass.Float32 else 0
+        self.num_refine_rounds = 4 if dtype == cutlass.Float32 else 1
+
+    @cute.jit
+    def _topk_per_row(
+        self,
+        input_values,
+        row_lengths,
+        output_indices,
+        output_values,
+        overflow,
+        s_histogram,
+        s_counter,
+        s_indices,
+        s_values,
+        s_warp_sums,
+        s_num_input,
+        g_num_input,
+        s_input_idx,
+        row_idx,
+        workspace_slot,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx = row_idx
+
+        neg_inf = s_values.element_type(
+            s_values.element_type.inf * s_values.element_type(-1.0)
+        )
+        val_one = cutlass.Int32(1)
+        if tidx < self.num_candidate_pages:
+            s_num_input[tidx] = 0
+            g_num_input[tidx] = 0
+
+        # Initialize the selected buffer before coarse collection.  Entries
+        # from bins strictly better than the threshold are written into this
+        # buffer and must survive into the refinement/output phases.
+        for i in cutlass.range(tidx, self.sort_size, self.num_threads):
+            s_indices[i] = -1
+        for i in cutlass.range(tidx, self.top_k, self.num_threads):
+            s_values[i] = neg_inf
+        cute.arch.barrier()
+
+        # Stage 1: build a coarse radix histogram.  This is the same ordered
+        # floating-point key used by the extracted cuDNN Frontend kernel.
+        if tidx < 256:
+            s_histogram[tidx] = 0
+        cute.arch.barrier()
+
+        length = row_lengths[row_idx]
+        if length > input_values.shape[1]:
+            length = input_values.shape[1]
+        if length < 0:
+            length = 0
+        for col in cutlass.range(tidx, input_values.shape[1], self.num_threads):
+            if col < length:
+                key = self._to_coarse_key(input_values[row_idx, col])
+                atomicAdd(s_histogram.iterator + cutlass.Int32(key), val_one)
+        fence_acq_rel_cta()
+        cute.arch.barrier()
+        if tidx == 0:
+            s_histogram[256] = 255
+            s_histogram[257] = 0
+
+        # Convert the histogram to an inclusive prefix sum.  This follows the
+        # reference block-scan path: one thread handles one radix bin and
+        # warp shuffles handle the intra-warp scan.
+        val = cutlass.Int32(0)
+        if tidx < 256:
+            val = s_histogram[tidx]
+            val, _ = block_prefix_sum_kernel(
+                val,
+                s_warp_sums,
+                tidx,
+                256,
+                8,
+                barrier_id=1,
+            )
+            s_histogram[tidx] = val
+        cute.arch.barrier()
+        if tidx < 256:
+            previous = 0
+            if tidx > 0:
+                previous = s_histogram[tidx - 1]
+            if previous < self.top_k and val >= self.top_k:
+                s_histogram[256] = tidx
+        if tidx == 0:
+            s_counter[0] = 0  # selected count
+            s_counter[1] = 0  # next-round count
+            s_counter[2] = 0  # final threshold remaining count
+        cute.arch.barrier()
+
+        threshold = s_histogram[256]
+        # Store only candidates in the selected coarse prefix.  The exact
+        # ordering inside this final bin is resolved below.
+        for col in cutlass.range(tidx, input_values.shape[1], self.num_threads):
+            if col < length:
+                key = self._to_coarse_key(input_values[row_idx, col])
+                if key < threshold:
+                    pos = atomicAdd(s_counter.iterator, val_one)
+                    if pos < self.top_k:
+                        s_indices[pos] = col
+                elif key == threshold:
+                    pos = atomicAdd(s_num_input.iterator, val_one)
+                    if pos < self.smem_candidate_capacity:
+                        s_input_idx[0, pos] = col
+                    else:
+                        overflow_pos = atomicAdd(
+                            g_num_input.iterator,
+                            val_one,
+                        )
+                        overflow[workspace_slot, 0, overflow_pos] = col
+        fence_acq_rel_cta()
+        cute.arch.barrier()
+
+        # Refine the selected coarse bin one byte at a time.  Candidates
+        # below the threshold are committed to s_indices; candidates equal
+        # to it are carried to the shared/global ping-pong candidate buffers.
+        for refine_round in range(self.num_refine_rounds):
+            current = refine_round & 1
+            next_buffer = current ^ 1
+            candidate_count = s_num_input[current]
+            run_refinement = s_counter[0] < self.top_k
+            if tidx < 256:
+                s_histogram[tidx] = 0
+            if tidx == 0:
+                s_num_input[next_buffer] = 0
+                g_num_input[next_buffer] = 0
+                s_histogram[256] = 255
+                s_histogram[257] = 0
+            cute.arch.barrier()
+
+            if run_refinement:
+                smem_count = candidate_count
+                if smem_count > self.smem_candidate_capacity:
+                    smem_count = self.smem_candidate_capacity
+                for candidate in cutlass.range(
+                    tidx, smem_count, self.num_threads
+                ):
+                    col = s_input_idx[current, candidate]
+                    key = (
+                        self._to_ordered(input_values[bidx, col])
+                        >> (self.first_refine_shift - refine_round * 8)
+                    ) & 0xFF
+                    atomicAdd(
+                        s_histogram.iterator + cutlass.Int32(key), val_one
+                    )
+                for candidate in cutlass.range(
+                    tidx, g_num_input[current], self.num_threads
+                ):
+                    col = overflow[workspace_slot, current, candidate]
+                    key = (
+                        self._to_ordered(input_values[bidx, col])
+                        >> (self.first_refine_shift - refine_round * 8)
+                    ) & 0xFF
+                    atomicAdd(
+                        s_histogram.iterator + cutlass.Int32(key), val_one
+                    )
+            cute.arch.barrier()
+
+            remaining = cutlass.Int32(0)
+            val = cutlass.Int32(0)
+            if run_refinement and tidx < 256:
+                remaining = self.top_k - s_counter[0]
+                val = s_histogram[tidx]
+                val, _ = block_prefix_sum_kernel(
+                    val,
+                    s_warp_sums,
+                    tidx,
+                    256,
+                    8,
+                    barrier_id=1,
+                )
+                s_histogram[tidx] = val
+            cute.arch.barrier()
+            if run_refinement and tidx < 256:
+                previous = 0
+                if tidx > 0:
+                    previous = s_histogram[tidx - 1]
+                if previous < remaining and val >= remaining:
+                    s_histogram[256] = tidx
+                    s_histogram[257] = previous
+                    s_counter[2] = remaining - previous
+                if tidx == 255 and val < remaining:
+                    # No radix bin reaches the remaining K.  All candidates
+                    # are selected and the rest are sentinel padding.
+                    s_histogram[256] = 255
+                    s_histogram[257] = val
+                    s_counter[2] = val - previous
+            cute.arch.barrier()
+
+            if run_refinement:
+                threshold = s_histogram[256]
+                smem_count = candidate_count
+                if smem_count > self.smem_candidate_capacity:
+                    smem_count = self.smem_candidate_capacity
+                for candidate in cutlass.range(
+                    tidx, smem_count, self.num_threads
+                ):
+                    col = s_input_idx[current, candidate]
+                    key = (
+                        self._to_ordered(input_values[bidx, col])
+                        >> (self.first_refine_shift - refine_round * 8)
+                    ) & 0xFF
+                    if key < threshold:
+                        pos = atomicAdd(s_counter.iterator, val_one)
+                        if pos < self.top_k:
+                            s_indices[pos] = col
+                    elif key == threshold:
+                        if refine_round == self.num_refine_rounds - 1:
+                            remaining_pos = atomicAdd(
+                                s_counter.iterator + 2, cutlass.Int32(-1)
+                            )
+                            if remaining_pos > 0:
+                                pos = atomicAdd(s_counter.iterator, val_one)
+                                if pos < self.top_k:
+                                    s_indices[pos] = col
+                        else:
+                            pos = atomicAdd(
+                                s_num_input.iterator + next_buffer,
+                                val_one,
+                            )
+                            if pos < self.smem_candidate_capacity:
+                                s_input_idx[next_buffer, pos] = col
+                            else:
+                                overflow_pos = atomicAdd(
+                                    g_num_input.iterator + next_buffer,
+                                    val_one,
+                                )
+                                overflow[
+                                    workspace_slot, next_buffer, overflow_pos
+                                ] = col
+                for candidate in cutlass.range(
+                    tidx, g_num_input[current], self.num_threads
+                ):
+                    col = overflow[workspace_slot, current, candidate]
+                    key = (
+                        self._to_ordered(input_values[bidx, col])
+                        >> (self.first_refine_shift - refine_round * 8)
+                    ) & 0xFF
+                    if key < threshold:
+                        pos = atomicAdd(s_counter.iterator, val_one)
+                        if pos < self.top_k:
+                            s_indices[pos] = col
+                    elif key == threshold:
+                        if refine_round == self.num_refine_rounds - 1:
+                            remaining_pos = atomicAdd(
+                                s_counter.iterator + 2, cutlass.Int32(-1)
+                            )
+                            if remaining_pos > 0:
+                                pos = atomicAdd(s_counter.iterator, val_one)
+                                if pos < self.top_k:
+                                    s_indices[pos] = col
+                        else:
+                            pos = atomicAdd(
+                                s_num_input.iterator + next_buffer,
+                                val_one,
+                            )
+                            if pos < self.smem_candidate_capacity:
+                                s_input_idx[next_buffer, pos] = col
+                            else:
+                                overflow_pos = atomicAdd(
+                                    g_num_input.iterator + next_buffer,
+                                    val_one,
+                                )
+                                overflow[
+                                    workspace_slot, next_buffer, overflow_pos
+                                ] = col
+                cute.arch.barrier()
+
+            fence_acq_rel_cta()
+            cute.arch.barrier()
+
+        # The radix collector does not define the order of selected entries.
+        # Sort selected members by score descending and index ascending on a
+        # tie, matching the extracted cuDNN Frontend output phase.
+        self._sort_selected_by_score(
+            tidx, s_indices, s_values, input_values, bidx
+        )
+        cute.arch.barrier()
+
+        # The last radix byte fully identifies the floating-point score.
+        # s_counter[2] is decremented once for every candidate in that exact
+        # boundary-score bin.  A negative final value therefore means that
+        # more equal-score candidates existed than available top-k slots.
+        #
+        # Atomic arrival order is not a deterministic tie-break.  Repair only
+        # those rare boundary ties by replacing the selected tie block with
+        # the smallest column indices under an explicit score-desc/index-asc
+        # contract.  Non-tie rows do not pay for the extra input scan.
+        if length >= self.top_k:
+            if s_counter[2] < 0:
+                boundary_index = s_indices[self.top_k - 1]
+                boundary_key = self._to_ordered(
+                    input_values[bidx, boundary_index]
+                )
+                if tidx == 0:
+                    s_counter[1] = -1  # last selected tie index
+                    s_counter[2] = 0  # selected boundary-score slot count
+                cute.arch.barrier()
+
+                for i in cutlass.range(tidx, self.top_k, self.num_threads):
+                    index = s_indices[i]
+                    if index >= 0:
+                        key = self._to_ordered(input_values[bidx, index])
+                        if key == boundary_key:
+                            atomicAdd(s_counter.iterator + 2, val_one)
+                cute.arch.barrier()
+
+                tie_slots = s_counter[2]
+                tie_start = self.top_k - tie_slots
+                for tie_rank in cutlass.range(0, self.top_k, 1):
+                    if tie_rank < tie_slots:
+                        if tidx == 0:
+                            s_counter[3] = length
+                        cute.arch.barrier()
+
+                        last_index = s_counter[1]
+                        for col in cutlass.range(
+                            tidx,
+                            input_values.shape[1],
+                            self.num_threads,
+                        ):
+                            if col < length:
+                                if col > last_index:
+                                    key = self._to_ordered(
+                                        input_values[bidx, col]
+                                    )
+                                    if key == boundary_key:
+                                        cute.arch.atomic_min(
+                                            ptr=(
+                                                s_counter.iterator + 3
+                                            ).llvm_ptr,
+                                            val=cutlass.Int32(col),
+                                            sem="relaxed",
+                                            scope="cta",
+                                        )
+                        cute.arch.barrier()
+
+                        if tidx == 0:
+                            next_index = s_counter[3]
+                            s_indices[tie_start + tie_rank] = next_index
+                            s_counter[1] = next_index
+                        cute.arch.barrier()
+
+        for i in cutlass.range(tidx, self.top_k, self.num_threads):
+            # ``row_lengths`` is a hard validity boundary.  When
+            # length < top_k, the radix collector may have selected
+            # arbitrary entries from the -inf tail to fill the output.
+            # Never expose those entries (or an accidentally corrupted
+            # candidate) to the caller.
+            index = s_indices[i]
+            if i < length:
+                if index >= 0:
+                    if index < length:
+                        output_indices[bidx, i] = index
+                        if cutlass.const_expr(self.return_val):
+                            output_values[bidx, i] = input_values[bidx, index]
+                    else:
+                        output_indices[bidx, i] = -1
+                        if cutlass.const_expr(self.return_val):
+                            output_values[bidx, i] = neg_inf
+                else:
+                    output_indices[bidx, i] = -1
+                    if cutlass.const_expr(self.return_val):
+                        output_values[bidx, i] = neg_inf
+            else:
+                output_indices[bidx, i] = -1
+                if cutlass.const_expr(self.return_val):
+                    output_values[bidx, i] = neg_inf
+        cute.arch.barrier()
+
+    @cute.kernel
+    def _topk_static_kernel(
+        self,
+        input_values,
+        row_lengths,
+        output_indices,
+        output_values,
+        overflow,
+        scheduler_state,
+    ):
+        smem = SmemAllocator()
+        s_histogram = smem.allocate_tensor(
+            element_type=cutlass.Int32,
+            layout=cute.make_ordered_layout((258,), order=(0,)),
+            byte_alignment=128,
+        )
+        s_counter = smem.allocate_tensor(
+            element_type=cutlass.Int32,
+            layout=cute.make_ordered_layout((4,), order=(0,)),
+            byte_alignment=128,
+        )
+        s_indices = smem.allocate_tensor(
+            element_type=cutlass.Int32,
+            layout=cute.make_ordered_layout((self.sort_size,), order=(0,)),
+            byte_alignment=128,
+        )
+        s_values = smem.allocate_tensor(
+            element_type=self.dtype,
+            layout=cute.make_ordered_layout((self.top_k,), order=(0,)),
+            byte_alignment=128,
+        )
+        s_warp_sums = smem.allocate_tensor(
+            element_type=cutlass.Int32,
+            layout=cute.make_ordered_layout(
+                (self.num_threads // 32,),
+                order=(0,),
+            ),
+            byte_alignment=128,
+        )
+        s_num_input = smem.allocate_tensor(
+            element_type=cutlass.Int32,
+            layout=cute.make_ordered_layout((2,), order=(0,)),
+            byte_alignment=128,
+        )
+        g_num_input = smem.allocate_tensor(
+            element_type=cutlass.Int32,
+            layout=cute.make_ordered_layout((2,), order=(0,)),
+            byte_alignment=128,
+        )
+        s_input_idx = smem.allocate_tensor(
+            element_type=cutlass.Int32,
+            layout=cute.make_ordered_layout(
+                (self.num_candidate_pages, self.smem_candidate_capacity),
+                order=(1, 0),
+            ),
+            byte_alignment=128,
+        )
+        slot_idx, _, _ = cute.arch.block_idx()
+        for row_idx in cutlass.range(
+            slot_idx,
+            input_values.shape[0],
+            self.num_persistent_ctas,
+        ):
+            if row_idx < input_values.shape[0]:
+                self._topk_per_row(
+                    input_values,
+                    row_lengths,
+                    output_indices,
+                    output_values,
+                    overflow,
+                    s_histogram,
+                    s_counter,
+                    s_indices,
+                    s_values,
+                    s_warp_sums,
+                    s_num_input,
+                    g_num_input,
+                    s_input_idx,
+                    row_idx,
+                    slot_idx,
+                )
+
+    @cute.jit
+    def _to_coarse_key(self, value):
+        """Return the descending-order coarse radix key for ``value``."""
+        if cutlass.const_expr(self.dtype == cutlass.Float32):
+            # Match the cuDNN Frontend source: FP32 uses an FP16 coarse
+            # histogram, then refines with the full FP32 ordered key.
+            coarse = value.to(cutlass.Float16)
+            bits = llvm.bitcast(cutlass.Uint16.mlir_type, coarse.ir_value())
+            ordered = cutlass.Uint16(0)
+            if bits & 0x8000:
+                ordered = cutlass.Uint16(bits)
+            else:
+                ordered = (bits ^ cutlass.Uint16(0xFFFF)) & cutlass.Uint16(
+                    0x7FFF
+                )
+            coarse_key = cutlass.Uint8((ordered >> 8) & 0xFF)
+            return coarse_key
+
+        bits = llvm.bitcast(cutlass.Uint16.mlir_type, value.ir_value())
+        ordered = cutlass.Uint16(0)
+        if bits & 0x8000:
+            ordered = cutlass.Uint16(bits)
+        else:
+            ordered = (bits ^ cutlass.Uint16(0xFFFF)) & cutlass.Uint16(0x7FFF)
+        coarse_key = cutlass.Uint8((ordered >> 8) & 0xFF)
+        return coarse_key
+
+    @cute.jit
+    def _to_ordered(self, value):
+        if cutlass.const_expr(self.dtype == cutlass.Float32):
+            bits = llvm.bitcast(cutlass.Uint32.mlir_type, value.ir_value())
+            ordered = cutlass.Uint32(0)
+            if bits & 0x80000000:
+                ordered = cutlass.Uint32(bits)
+            else:
+                ordered = cutlass.Uint32(
+                    bits ^ cutlass.Uint32(0xFFFFFFFF)
+                ) & cutlass.Uint32(0x7FFFFFFF)
+        else:
+            bits = llvm.bitcast(cutlass.Uint16.mlir_type, value.ir_value())
+            ordered = cutlass.Uint16(0)
+            if bits & 0x8000:
+                ordered = cutlass.Uint16(bits)
+            else:
+                ordered = cutlass.Uint16(
+                    bits ^ cutlass.Uint16(0xFFFF)
+                ) & cutlass.Uint16(0x7FFF)
+        return ordered
+
+    @cute.jit
+    def _sort_selected_by_score(
+        self, tidx, s_indices, s_values, input_values, bidx
+    ):
+        sentinel = -1
+        for p in cutlass.range(tidx, self.sort_size, self.num_threads):
+            if p >= self.top_k:
+                s_indices[p] = sentinel
+        cute.arch.barrier()
+        k = 2
+        while k <= self.sort_size:
+            j = k >> 1
+            while j > 0:
+                for p in cutlass.range(tidx, self.sort_size, self.num_threads):
+                    partner = p ^ j
+                    if partner > p:
+                        lhs = s_indices[p]
+                        rhs = s_indices[partner]
+                        lhs_invalid = lhs < 0
+                        rhs_invalid = rhs < 0
+                        ascending = (p & k) == 0
+                        swap = False
+                        if lhs_invalid != rhs_invalid:
+                            swap = lhs_invalid if ascending else not lhs_invalid
+                        elif not lhs_invalid:
+                            lhs_key = self._to_ordered(input_values[bidx, lhs])
+                            rhs_key = self._to_ordered(input_values[bidx, rhs])
+                            if ascending:
+                                swap = lhs_key > rhs_key or (
+                                    lhs_key == rhs_key and lhs > rhs
+                                )
+                            else:
+                                swap = lhs_key < rhs_key or (
+                                    lhs_key == rhs_key and lhs < rhs
+                                )
+                        if swap:
+                            s_indices[p] = rhs
+                            s_indices[partner] = lhs
+                cute.arch.barrier()
+                j >>= 1
+            k <<= 1
+
+    @cute.jit
+    def __call__(
+        self,
+        input_values,
+        row_lengths,
+        output_indices,
+        output_values,
+        overflow,
+        scheduler_state,
+        stream,
+    ):
+        self._topk_static_kernel(
+            input_values,
+            row_lengths,
+            output_indices,
+            output_values,
+            overflow,
+            scheduler_state,
+        ).launch(
+            grid=(self.num_launch_ctas, 1, 1),
+            block=(self.num_threads, 1, 1),
+            stream=stream,
+        )
+
+
+class IndexerTopKPrefillClcKernel(IndexerTopKPrefillKernel):
+    """Experimental CLC-only kernel with a dedicated scheduler warp.
+
+    The static kernel deliberately has no CLC code in its lowering graph.
+    This class keeps the dynamic scheduler in a separate kernel and uses the
+    CUTLASS ``PipelineClcFetchAsync`` protocol:
+
+    * warp 0 issues CLC queries;
+    * the CTA consumes the 16-byte response through a full/empty mbarrier
+      pipeline;
+    * the next row is published in shared memory before the CTA-wide top-k
+      barriers are entered.
+
+    The row being computed is held in a local SSA value while the scheduler
+    publishes the next row.  This keeps ``row_idx`` (global input/output
+    coordinate) separate from ``workspace_slot`` (resident CTA storage).
+    """
+
+    @cute.kernel
+    def _topk_clc_kernel(
+        self,
+        input_values,
+        row_lengths,
+        output_indices,
+        output_values,
+        overflow,
+        scheduler_state,
+    ):
+        smem = SmemAllocator()
+        s_histogram = smem.allocate_tensor(
+            element_type=cutlass.Int32,
+            layout=cute.make_ordered_layout((258,), order=(0,)),
+            byte_alignment=128,
+        )
+        s_counter = smem.allocate_tensor(
+            element_type=cutlass.Int32,
+            layout=cute.make_ordered_layout((4,), order=(0,)),
+            byte_alignment=128,
+        )
+        s_indices = smem.allocate_tensor(
+            element_type=cutlass.Int32,
+            layout=cute.make_ordered_layout((self.sort_size,), order=(0,)),
+            byte_alignment=128,
+        )
+        s_values = smem.allocate_tensor(
+            element_type=self.dtype,
+            layout=cute.make_ordered_layout((self.top_k,), order=(0,)),
+            byte_alignment=128,
+        )
+        s_warp_sums = smem.allocate_tensor(
+            element_type=cutlass.Int32,
+            layout=cute.make_ordered_layout(
+                (self.num_threads // 32,),
+                order=(0,),
+            ),
+            byte_alignment=128,
+        )
+        s_num_input = smem.allocate_tensor(
+            element_type=cutlass.Int32,
+            layout=cute.make_ordered_layout((2,), order=(0,)),
+            byte_alignment=128,
+        )
+        g_num_input = smem.allocate_tensor(
+            element_type=cutlass.Int32,
+            layout=cute.make_ordered_layout((2,), order=(0,)),
+            byte_alignment=128,
+        )
+        s_input_idx = smem.allocate_tensor(
+            element_type=cutlass.Int32,
+            layout=cute.make_ordered_layout(
+                (self.num_candidate_pages, self.smem_candidate_capacity),
+                order=(1, 0),
+            ),
+            byte_alignment=128,
+        )
+
+        # PipelineClcFetchAsync uses one full and one empty mbarrier per
+        # stage.  Keep both barriers in the CLC-only kernel; the old branch
+        # allocated only one barrier and could not represent the protocol.
+        s_clc_mbar = smem.allocate_tensor(
+            element_type=cutlass.Int64,
+            layout=cute.make_ordered_layout((2,), order=(0,)),
+            byte_alignment=128,
+        )
+        s_clc_response = smem.allocate_tensor(
+            element_type=cutlass.Int32,
+            layout=cute.make_ordered_layout((4,), order=(0,)),
+            byte_alignment=128,
+        )
+        # [0] = resident CTA workspace slot, [1] = current/next row,
+        # [2] = next-row validity.  [3] is reserved for future double
+        # buffering of the row metadata.
+        s_clc_work = smem.allocate_tensor(
+            element_type=cutlass.Int32,
+            layout=cute.make_ordered_layout((4,), order=(0,)),
+            byte_alignment=128,
+        )
+
+        tidx, _, _ = cute.arch.thread_idx()
+        if tidx == 0:
+            cute.arch.mbarrier_init(s_clc_mbar.iterator, 1)
+            cute.arch.mbarrier_init(
+                s_clc_mbar.iterator + 1,
+                self.num_threads,
+            )
+            # CLC launches one logical CTA per row.  Only CTAs that actually
+            # become resident execute this allocation.
+            s_clc_work[0] = atomicAdd(
+                scheduler_state.iterator,
+                cutlass.Int32(1),
+            )
+            block_idx, _, _ = cute.arch.block_idx()
+            s_clc_work[1] = block_idx
+            s_clc_work[2] = 1
+
+        # The pipeline was created with defer_sync=True.  Publish the
+        # mbarrier initialization before any producer/consumer operation.
+        pipeline_init_arrive()
+        pipeline_init_wait()
+
+        clc_pipeline = PipelineClcFetchAsync.create(
+            barrier_storage=s_clc_mbar.iterator,
+            num_stages=1,
+            producer_group=CooperativeGroup(Agent.Thread, 1),
+            consumer_group=CooperativeGroup(
+                Agent.Thread,
+                self.num_threads,
+            ),
+            tx_count=16,
+            cta_layout_vmnk=None,
+            defer_sync=True,
+        )
+        clc_producer_state = make_pipeline_state(
+            PipelineUserType.ProducerConsumer,
+            1,
+        )
+        clc_consumer_state = make_pipeline_state(
+            PipelineUserType.Consumer,
+            1,
+        )
+        tile_sched = ClcDynamicPersistentTileScheduler.create(
+            ClcDynamicPersistentTileSchedulerParams(
+                (input_values.shape[0], 1, 1),
+                (1, 1, 1),
+            ),
+            cute.arch.block_idx(),
+            cute.arch.grid_dim(),
+            s_clc_response.iterator,
+        )
+
+        while s_clc_work[2] != 0:
+            # Capture the current row before the scheduler publishes the next
+            # response into the same shared metadata slot.  The CTA barrier is
+            # required here: without it, warp 0 can overwrite s_clc_work[1:3]
+            # while later warps are still loading the current row, causing one
+            # CTA to mix row_idx/row_length values from two different rows.
+            row_idx = s_clc_work[1]
+            work_valid = s_clc_work[2] != 0
+            cute.arch.barrier()
+
+            # Only warp 0 is the scheduler producer.  The remainder of the
+            # CTA stays out of the CLC query path and participates as the
+            # consumer of the response pipeline.
+            if tidx < 32:
+                clc_pipeline.producer_acquire(clc_producer_state)
+                mbarrier_addr = clc_pipeline.producer_get_barrier(
+                    clc_producer_state
+                )
+                tile_sched.advance_to_next_work(mbarrier_addr)
+                clc_producer_state.advance()
+
+            clc_pipeline.consumer_wait(clc_consumer_state)
+            if tidx < 32:
+                next_tile = tile_sched.get_current_work()
+                if tidx == 0:
+                    s_clc_work[1] = next_tile.tile_idx[0]
+                    s_clc_work[2] = cutlass.Int32(next_tile.is_valid_tile)
+            clc_pipeline.consumer_release(clc_consumer_state)
+            clc_consumer_state.advance()
+
+            # Row metadata is now stable for all top-k participants.  The
+            # second barrier keeps the scheduler warp in lockstep with the
+            # CTA-wide body and prevents a later response from changing the
+            # shared row before the current body has consumed it.
+            cute.arch.barrier()
+            if work_valid:
+                self._topk_per_row(
+                    input_values,
+                    row_lengths,
+                    output_indices,
+                    output_values,
+                    overflow,
+                    s_histogram,
+                    s_counter,
+                    s_indices,
+                    s_values,
+                    s_warp_sums,
+                    s_num_input,
+                    g_num_input,
+                    s_input_idx,
+                    row_idx,
+                    s_clc_work[0],
+                )
+            cute.arch.barrier()
+
+    @cute.jit
+    def __call__(
+        self,
+        input_values,
+        row_lengths,
+        output_indices,
+        output_values,
+        overflow,
+        scheduler_state,
+        stream,
+    ):
+        self._topk_clc_kernel(
+            input_values,
+            row_lengths,
+            output_indices,
+            output_values,
+            overflow,
+            scheduler_state,
+        ).launch(
+            # CLC needs one logical CTA for every possible row so it can
+            # cancel not-yet-started CTAs and return their block indices.
+            grid=(input_values.shape[0], 1, 1),
+            block=(self.num_threads, 1, 1),
+            stream=stream,
+        )
+
+
+def _compile_kernel(
+    dtype,
+    bucketed_num_cols: int,
+    top_k: int,
+    return_val: bool,
+    num_candidate_pages: int,
+    num_persistent_ctas: int,
+    rows_per_cta: int,
+    schedule_mode: str,
+    num_rows: int,
+    num_workspace_slots: int,
+):
+    if schedule_mode == "clc":
+        import paddle
+
+        capability = tuple(paddle.device.cuda.get_device_capability())
+        if len(capability) != 2 or capability[0] != 10:
+            raise RuntimeError(
+                "paddlefleet CUTEDSL CLC top-k requires an SM100-family GPU "
+                "(compute capability 10.x); "
+                f"got compute capability {capability!r}"
+            )
+    cutlass, cute, make_fake_stream, _ = _require_cutedsl()
+    from cutlass.base_dsl.dsl import BaseDSL
+
+    from .compiler import compile_options
+
+    key = (
+        dtype,
+        bucketed_num_cols,
+        top_k,
+        return_val,
+        num_candidate_pages,
+        num_persistent_ctas,
+        None,
+        schedule_mode,
+        None,
+        num_workspace_slots,
+    )
+    if key in _COMPILE_CACHE:
+        return _COMPILE_CACHE[key]
+
+    n_rows = cute.sym_int()
+    n_cols = cute.sym_int()
+    overflow_capacity = cute.sym_int()
+    input_fake = cute.runtime.make_fake_compact_tensor(
+        dtype,
+        (n_rows, n_cols),
+        stride_order=(1, 0),
+        assumed_align=16,
+    )
+    lengths_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (n_rows,),
+        stride_order=(0,),
+        assumed_align=4,
+    )
+    indices_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (n_rows, top_k),
+        stride_order=(1, 0),
+        assumed_align=4,
+    )
+    values_fake = (
+        cute.runtime.make_fake_compact_tensor(
+            dtype,
+            (n_rows, top_k),
+            stride_order=(1, 0),
+            assumed_align=16,
+        )
+        if return_val
+        else None
+    )
+    overflow_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (num_workspace_slots, num_candidate_pages, overflow_capacity),
+        stride_order=(2, 1, 0),
+        assumed_align=4,
+    )
+    scheduler_state_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (1,),
+        stride_order=(0,),
+        assumed_align=4,
+    )
+    fake_stream = make_fake_stream(use_tvm_ffi_env_stream=True)
+    kernel_cls = (
+        IndexerTopKPrefillClcKernel
+        if schedule_mode == "clc"
+        else IndexerTopKPrefillKernel
+    )
+    kernel = kernel_cls(
+        dtype,
+        bucketed_num_cols,
+        top_k,
+        return_val,
+        num_persistent_ctas,
+        rows_per_cta,
+        schedule_mode,
+        num_rows,
+        num_workspace_slots,
+    )
+    # CuTe's kernel compiler does not always materialize nested ``@cute.jit``
+    # methods before executing the outer host wrapper.  Preprocess the
+    # per-row method explicitly so dynamic ``cutlass.range`` loops are lowered
+    # before ``cute.compile`` enters the kernel body.
+    for method in (
+        IndexerTopKPrefillKernel._topk_per_row,
+        IndexerTopKPrefillKernel._to_coarse_key,
+        IndexerTopKPrefillKernel._to_ordered,
+        IndexerTopKPrefillKernel._sort_selected_by_score,
+        block_prefix_sum_kernel,
+        fence_acq_rel_cta,
+    ):
+        BaseDSL._preprocess_and_replace_code(
+            getattr(method, "__wrapped__", method)
+        )
+    if schedule_mode == "clc":
+        BaseDSL._preprocess_and_replace_code(
+            getattr(
+                IndexerTopKPrefillClcKernel._topk_clc_kernel,
+                "__wrapped__",
+                IndexerTopKPrefillClcKernel._topk_clc_kernel,
+            )
+        )
+    compiled = cute.compile(
+        kernel,
+        input_fake,
+        lengths_fake,
+        indices_fake,
+        values_fake,
+        overflow_fake,
+        scheduler_state_fake,
+        fake_stream,
+        options=compile_options(),
+    )
+    _COMPILE_CACHE[key] = compiled
+    return compiled
+
+
+def precompile_indexer_topk_clc(
+    max_num_cols: int,
+    top_k: int,
+    *,
+    dtype=None,
+    return_values: tuple[bool, ...] = (False, True),
+) -> tuple[int, ...]:
+    """Precompile every CLC variant needed up to ``max_num_cols``.
+
+    CuTe DSL executors are process-local, so this must run in each training
+    process after its CUDA device is selected.  Only CLC binaries are emitted;
+    the static scheduler is intentionally excluded.
+
+    Column buckets start at ``next_power_of_two(top_k)`` because production
+    clamps ``top_k`` when fewer candidates exist.  Buckets saturate at the
+    shared-memory candidate capacity: larger runtime column extents use the
+    same generated code and therefore cover 256k sequences without additional
+    compilation.
+
+    Returns:
+        The compile buckets covered by this call.
+    """
+    import paddle
+
+    capability = tuple(paddle.device.cuda.get_device_capability())
+    if len(capability) != 2 or capability[0] != 10:
+        raise RuntimeError(
+            "paddlefleet CUTEDSL CLC top-k requires an SM100-family GPU "
+            "(compute capability 10.x); "
+            f"got compute capability {capability!r}"
+        )
+    _require_cutedsl()
+
+    max_num_cols = int(max_num_cols)
+    top_k = int(top_k)
+    if max_num_cols <= 0:
+        raise ValueError(f"max_num_cols must be positive, got {max_num_cols}")
+    if top_k <= 0 or top_k > 2048:
+        raise ValueError(f"top_k must be in [1, 2048], got {top_k}")
+    if max_num_cols < top_k:
+        raise ValueError(
+            f"max_num_cols must be >= top_k, got {max_num_cols} < {top_k}"
+        )
+    if not return_values:
+        raise ValueError("return_values must contain at least one variant")
+
+    if dtype is None:
+        dtype = paddle.float32
+    cutlass, _, _, _ = _require_cutedsl()
+    cutlass_dtype = _cutlass_dtype(dtype, cutlass)
+    max_bucket = _compile_num_cols_bucket(max_num_cols)
+    bucket = _compile_num_cols_bucket(top_k)
+    buckets = []
+    while True:
+        buckets.append(bucket)
+        if bucket >= max_bucket:
+            break
+        bucket = min(bucket * 2, max_bucket)
+
+    precompile_key = (
+        cutlass_dtype,
+        tuple(buckets),
+        top_k,
+        tuple(bool(value) for value in return_values),
+    )
+    if precompile_key in _CLC_PRECOMPILE_CACHE:
+        return tuple(buckets)
+
+    print(
+        "[CUTEDSL PRECOMPILE]"
+        f" pid={os.getpid()}"
+        f" schedule_mode=clc"
+        f" max_num_cols={max_num_cols}"
+        f" buckets={buckets}"
+        f" top_k={top_k}"
+        f" return_values={tuple(bool(v) for v in return_values)}",
+        flush=True,
+    )
+    for compile_bucket in buckets:
+        num_threads = 256 if compile_bucket < 8192 else 512
+        num_persistent_ctas, rows_per_cta = _persistent_launch_config(
+            1, persistent=True, schedule_mode="clc"
+        )
+        num_workspace_slots = _workspace_slot_count(
+            1,
+            num_persistent_ctas,
+            num_threads,
+            persistent=True,
+            schedule_mode="clc",
+        )
+        num_candidate_pages = 2 if cutlass_dtype == cutlass.Float32 else 1
+        for return_val in return_values:
+            _compile_kernel(
+                cutlass_dtype,
+                compile_bucket,
+                top_k,
+                bool(return_val),
+                num_candidate_pages,
+                num_persistent_ctas,
+                rows_per_cta,
+                "clc",
+                1,
+                num_workspace_slots,
+            )
+
+    _CLC_PRECOMPILE_CACHE.add(precompile_key)
+    return tuple(buckets)
+
+
+def indexer_topk_prefill(
+    input_values,
+    row_lengths,
+    top_k: int,
+    *,
+    return_val: bool = True,
+    out_indices=None,
+    out_values=None,
+    workspace=None,
+    persistent: bool = True,
+    schedule_mode: str = "clc",
+    scheduler_state=None,
+):
+    """Run standalone DSA indexer top-k on Paddle CUDA tensors.
+
+    Args:
+        input_values: Contiguous Paddle tensor ``[num_rows, num_cols]``.
+        row_lengths: Contiguous int32 Paddle tensor ``[num_rows]``.  Each
+            element is the valid prefix length of the corresponding row.
+        top_k: Number of entries to return, at most 2048.
+        return_val: Whether to return values alongside indices.
+        out_indices: Optional reusable contiguous int32 output tensor with
+            shape ``[num_rows, top_k]``.
+        out_values: Optional reusable contiguous value output tensor with
+            shape ``[num_rows, top_k]`` and the same dtype as
+            ``input_values``. Ignored when ``return_val`` is false.
+        workspace: Optional reusable contiguous int32 overflow tensor with
+            shape ``[num_workspace_slots, num_candidate_pages,
+            overflow_capacity]``. Static scheduling uses one slot per
+            persistent CTA. CLC uses a conservative resident-CTA upper bound
+            based on the device SM count and 2048 threads per SM, rather than
+            allocating one slot per logical row. ``num_candidate_pages`` is
+            two for float32 and one otherwise; ``overflow_capacity`` is
+            ``max(1, num_cols - min(16384, num_cols))``.
+        persistent: Use a fixed SM-sized CTA grid and reuse workspace slots
+            across rows. ``False`` restores the one-CTA-per-row baseline for
+            controlled performance comparisons.
+        schedule_mode: ``"static"`` uses the current strided persistent
+            scheduler. ``"clc"`` uses Blackwell CLC to dynamically assign
+            rows; it requires ``persistent=True``.
+        scheduler_state: Optional contiguous int32 ``[1]`` state buffer used
+            by the CLC active-CTA workspace-slot allocator.
+
+    Returns:
+        ``(indices, values)`` where indices has dtype int32 and invalid
+        entries are ``-1``.  Values are ``-inf`` for invalid entries.
+    """
+    import paddle
+
+    if not _is_cuda_tensor(input_values) or not _is_cuda_tensor(row_lengths):
+        raise ValueError(
+            "input_values and row_lengths must be Paddle CUDA tensors"
+        )
+    if input_values.ndim != 2:
+        raise ValueError(f"input_values must be 2-D, got {input_values.shape}")
+    if row_lengths.ndim != 1:
+        raise ValueError(f"row_lengths must be 1-D, got {row_lengths.shape}")
+    if input_values.shape[0] != row_lengths.shape[0]:
+        raise ValueError("row_lengths must have one entry per input row")
+    if not input_values.is_contiguous() or not row_lengths.is_contiguous():
+        raise ValueError("input_values and row_lengths must be contiguous")
+    if row_lengths.dtype != paddle.int32:
+        raise TypeError("row_lengths must have dtype paddle.int32")
+    if top_k <= 0 or top_k > 2048:
+        raise ValueError(f"top_k must be in [1, 2048], got {top_k}")
+    if input_values.shape[1] <= 0:
+        raise ValueError("input_values must have a non-empty column dimension")
+
+    cutlass, _, _, _ = _require_cutedsl()
+    dtype = _cutlass_dtype(input_values.dtype, cutlass)
+    num_candidate_pages = 2 if dtype == cutlass.Float32 else 1
+    num_persistent_ctas, rows_per_cta = _persistent_launch_config(
+        int(input_values.shape[0]),
+        persistent=persistent,
+        schedule_mode=schedule_mode,
+    )
+    num_rows = int(input_values.shape[0])
+    bucketed_num_cols = _compile_num_cols_bucket(int(input_values.shape[1]))
+    num_threads = 256 if bucketed_num_cols < 8192 else 512
+    num_workspace_slots = _workspace_slot_count(
+        num_rows,
+        num_persistent_ctas,
+        num_threads,
+        persistent,
+        schedule_mode,
+    )
+    compiled = _compile_kernel(
+        dtype,
+        bucketed_num_cols,
+        int(top_k),
+        bool(return_val),
+        num_candidate_pages,
+        num_persistent_ctas,
+        rows_per_cta,
+        schedule_mode,
+        num_rows,
+        num_workspace_slots,
+    )
+
+    overflow_capacity = max(
+        1,
+        int(input_values.shape[1])
+        - min(_SMEM_CANDIDATE_CAPACITY, int(input_values.shape[1])),
+    )
+    if out_indices is None or (return_val and out_values is None):
+        global _OUTPUT_ALLOC_WARNING_EMITTED
+        if not _OUTPUT_ALLOC_WARNING_EMITTED:
+            warnings.warn(
+                "out_indices/out_values is None; "
+                "CUTEDSL indexer_topk_prefill allocates temporary output "
+                "tensors on every call. Pass reusable output buffers to "
+                "avoid repeated allocations.",
+                UserWarning,
+                stacklevel=2,
+            )
+            _OUTPUT_ALLOC_WARNING_EMITTED = True
+    indices = out_indices
+    if indices is None:
+        indices = paddle.full(
+            [input_values.shape[0], top_k], -1, dtype=paddle.int32
+        )
+    values = out_values
+    if return_val and values is None:
+        values = paddle.full(
+            [input_values.shape[0], top_k],
+            float("-inf"),
+            dtype=input_values.dtype,
+        )
+    if not return_val:
+        values = None
+    if workspace is None:
+        # TODO: Let the owning layer reuse a bounded workspace once its
+        # lifetime and multi-stream synchronization are explicit. A global
+        # cache is intentionally avoided because long-sequence buffers can be
+        # very large and would otherwise remain resident for the process.
+        workspace = paddle.empty(
+            [num_workspace_slots, num_candidate_pages, overflow_capacity],
+            dtype=paddle.int32,
+        )
+    if schedule_mode == "clc":
+        if scheduler_state is None:
+            scheduler_state = paddle.zeros([1], dtype=paddle.int32)
+        elif (
+            list(scheduler_state.shape) != [1]
+            or scheduler_state.dtype != paddle.int32
+            or not scheduler_state.is_contiguous()
+        ):
+            raise ValueError(
+                "scheduler_state must be contiguous paddle.int32 [1]"
+            )
+        else:
+            paddle.assign(
+                paddle.zeros_like(scheduler_state),
+                output=scheduler_state,
+            )
+    else:
+        scheduler_state = paddle.zeros([1], dtype=paddle.int32)
+    if list(indices.shape) != [input_values.shape[0], top_k]:
+        raise ValueError("out_indices must have shape [num_rows, top_k]")
+    if indices.dtype != paddle.int32 or not indices.is_contiguous():
+        raise ValueError("out_indices must be contiguous paddle.int32")
+    if return_val:
+        if list(values.shape) != [input_values.shape[0], top_k]:
+            raise ValueError("out_values must have shape [num_rows, top_k]")
+        if values.dtype != input_values.dtype or not values.is_contiguous():
+            raise ValueError(
+                "out_values must be contiguous and match input dtype"
+            )
+    if (
+        list(workspace.shape)
+        != [num_workspace_slots, num_candidate_pages, overflow_capacity]
+        or workspace.dtype != paddle.int32
+        or not workspace.is_contiguous()
+    ):
+        raise ValueError(
+            "workspace must be contiguous int32 "
+            "[num_workspace_slots, num_candidate_pages, overflow_capacity]"
+        )
+
+    # The adapters keep Paddle allocations zero-copy. The compiled TVM-FFI
+    # callable obtains the current stream from its environment because the
+    # fake stream was created with ``use_tvm_ffi_env_stream=True``. Keep all
+    # Paddle tensors alive until this call returns because the launch is
+    # asynchronous.
+    from .dlpack import paddle_to_cute_tensor
+
+    input_cute = paddle_to_cute_tensor(
+        input_values, assumed_align=16, leading_dim=1
+    )
+    lengths_cute = paddle_to_cute_tensor(
+        row_lengths, assumed_align=4, leading_dim=0
+    )
+    indices_cute = paddle_to_cute_tensor(
+        indices, assumed_align=4, leading_dim=1
+    )
+    values_cute = (
+        paddle_to_cute_tensor(values, assumed_align=16, leading_dim=1)
+        if return_val
+        else None
+    )
+    overflow_cute = paddle_to_cute_tensor(
+        workspace, assumed_align=4, leading_dim=2
+    )
+    scheduler_state_cute = paddle_to_cute_tensor(
+        scheduler_state, assumed_align=4, leading_dim=0
+    )
+
+    # The tensors alias Paddle storage through DLPack. The stream is an
+    # implicit TVM-FFI environment parameter, not a callable argument.
+    compiled(
+        input_cute,
+        lengths_cute,
+        indices_cute,
+        values_cute,
+        overflow_cute,
+        scheduler_state_cute,
+    )
+    return indices, values
+
+
+__all__ = [
+    "IndexerTopKPrefillKernel",
+    "IndexerTopKPrefillClcKernel",
+    "indexer_topk_prefill",
+]

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -2310,6 +2310,9 @@ class CompressedSparseAttention(FleetLayer):
                     startend_row_indices=startend_row_indices,
                     doc_lens=doc_lens_list,
                     return_topk_scores=need_indexer_loss,
+                    topk_backend=getattr(
+                        self.config, "dsa_indexer_topk_backend", "unfused"
+                    ),
                 )
 
             topk_indices_compressed = topk_indices
@@ -3143,6 +3146,11 @@ class CompressedSparseAttention(FleetLayer):
                                     else None,
                                     seq_offset=position_offset,
                                     return_topk_scores=use_fused_indexer_loss_path,
+                                    topk_backend=getattr(
+                                        self.config,
+                                        "dsa_indexer_topk_backend",
+                                        "unfused",
+                                    ),
                                 )
                             )
 

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -2313,6 +2313,9 @@ class CompressedSparseAttention(FleetLayer):
                     topk_backend=getattr(
                         self.config, "dsa_indexer_topk_backend", "unfused"
                     ),
+                    cutedsl_min_cols=getattr(
+                        self.config, "dsa_indexer_topk_min_cols", 65536
+                    ),
                 )
 
             topk_indices_compressed = topk_indices
@@ -3150,6 +3153,11 @@ class CompressedSparseAttention(FleetLayer):
                                         self.config,
                                         "dsa_indexer_topk_backend",
                                         "unfused",
+                                    ),
+                                    cutedsl_min_cols=getattr(
+                                        self.config,
+                                        "dsa_indexer_topk_min_cols",
+                                        65536,
                                     ),
                                 )
                             )

--- a/src/paddlefleet/transformer/mqa_latent_attention.py
+++ b/src/paddlefleet/transformer/mqa_latent_attention.py
@@ -718,21 +718,25 @@ class MQALatentAttention(FleetLayer):
             if sublayers_spec.indexer is not None
             else None
         )
-        if (
-            self.indexer is not None
-            and getattr(config, "dsa_indexer_topk_backend", "unfused")
-            == "cutedsl"
-        ):
+        if self.indexer is not None and getattr(
+            config, "dsa_indexer_topk_backend", "unfused"
+        ) in {"cutedsl", "cutedsl_index"}:
             import paddle
 
             if "gpu" in paddle.get_device().lower():
                 from paddlefleet.cutedsl_ops import precompile_indexer_topk_clc
 
-                precompile_indexer_topk_clc(
+                precompile_kwargs = {
                     # All larger runtime lengths share this saturated bucket.
-                    max_num_cols=16 * 1024,
-                    top_k=int(self.indexer.index_topk),
-                )
+                    "max_num_cols": 16 * 1024,
+                    "top_k": int(self.indexer.index_topk),
+                }
+                if (
+                    getattr(config, "dsa_indexer_topk_backend", "unfused")
+                    == "cutedsl_index"
+                ):
+                    precompile_kwargs["sort_mode"] = "index"
+                precompile_indexer_topk_clc(**precompile_kwargs)
         self.indexer_loss_coeff = float(
             getattr(config, "dsa_indexer_loss_coeff", 0.0) or 0.0
         )

--- a/src/paddlefleet/transformer/mqa_latent_attention.py
+++ b/src/paddlefleet/transformer/mqa_latent_attention.py
@@ -796,6 +796,9 @@ class MQALatentAttention(FleetLayer):
         # (``core_attention.softmax_offset``) and the switch are shared with the
         # dense MHA phase. ``None`` keeps the kernel on its sinkless ``-1e30``
         # path, bit-for-bit unchanged.
+        self.indexer_topk_backend = str(
+            getattr(self.config, "dsa_indexer_topk_backend", "unfused")
+        )
         self.softmax_offset = build_softmax_offset(
             self,
             config,
@@ -928,6 +931,7 @@ class MQALatentAttention(FleetLayer):
                 doc_lens=doc_lens_arg,
                 seq_offset=chunk_id * m,
                 return_topk_scores=need_loss,
+                topk_backend=self.indexer_topk_backend,
             )
 
         r_lo = _chunk(slice(0, m), lo)
@@ -2142,10 +2146,8 @@ class MQALatentAttention(FleetLayer):
                     doc_lens=doc_lens_arg,
                     seq_offset=position_offset,
                     return_topk_scores=need_loss,
-                    topk_backend=getattr(
-                    self.config, "dsa_indexer_topk_backend", "unfused"
-                ),
-            )
+                    topk_backend=self.indexer_topk_backend,
+                )
             topk_indices = paddle.where(
                 row_empty, paddle.full_like(selected, -1), selected
             )

--- a/src/paddlefleet/transformer/mqa_latent_attention.py
+++ b/src/paddlefleet/transformer/mqa_latent_attention.py
@@ -718,6 +718,21 @@ class MQALatentAttention(FleetLayer):
             if sublayers_spec.indexer is not None
             else None
         )
+        if (
+            self.indexer is not None
+            and getattr(config, "dsa_indexer_topk_backend", "unfused")
+            == "cutedsl"
+        ):
+            import paddle
+
+            if "gpu" in paddle.get_device().lower():
+                from paddlefleet.cutedsl_ops import precompile_indexer_topk_clc
+
+                precompile_indexer_topk_clc(
+                    # All larger runtime lengths share this saturated bucket.
+                    max_num_cols=16 * 1024,
+                    top_k=int(self.indexer.index_topk),
+                )
         self.indexer_loss_coeff = float(
             getattr(config, "dsa_indexer_loss_coeff", 0.0) or 0.0
         )

--- a/src/paddlefleet/transformer/mqa_latent_attention.py
+++ b/src/paddlefleet/transformer/mqa_latent_attention.py
@@ -2127,7 +2127,10 @@ class MQALatentAttention(FleetLayer):
                     doc_lens=doc_lens_arg,
                     seq_offset=position_offset,
                     return_topk_scores=need_loss,
-                )
+                    topk_backend=getattr(
+                    self.config, "dsa_indexer_topk_backend", "unfused"
+                ),
+            )
             topk_indices = paddle.where(
                 row_empty, paddle.full_like(selected, -1), selected
             )

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -1366,13 +1366,28 @@ class TransformerConfig(ModelParallelConfig):
     dsa_indexer_topk_backend: str = "unfused"
     """Top-k implementation used after production DSA indexer scores.
 
-    One of {"unfused", "cutedsl"}:
+    One of {"unfused", "cutedsl", "cutedsl_index"}:
       * "unfused" (default): Paddle ``topk`` reference implementation.
-      * "cutedsl": standalone Paddle CuTe DSL prefill top-k implementation.
+      * "cutedsl": standalone Paddle CuTe DSL prefill top-k implementation
+        with the original score-descending output kernel.
+      * "cutedsl_index": CuTe DSL index-ascending output kernel. The standalone
+        kernel supports larger dtype-dependent limits, while this production
+        transformer config remains capped at 2048 for cuDNN-path compatibility.
 
     This switch only changes the top-k stage after the indexer score forward.
     It does not change warmup/full-candidate selection, TileLang score paths,
     sparse attention backends, or indexer-loss autograd.
+    """
+
+    dsa_indexer_topk_min_cols: int = 65536
+    """Minimum score width required to use the CuTe DSL top-k backend.
+
+    CuTe DSL is selected only when
+    ``dsa_indexer_topk_backend`` is ``"cutedsl"`` or ``"cutedsl_index"``
+    and the real score width is strictly greater than this threshold.
+    Smaller score matrices use the Paddle top-k fallback. This is useful for
+    packed-document and dual-chunk paths, where each score matrix may have a
+    different compact column width.
     """
 
     csa_sparse_attn_backend: str = "tilelang"
@@ -1932,10 +1947,25 @@ class TransformerConfig(ModelParallelConfig):
                     "dsa_indexer_use_sparse_loss=True with a trainable backbone."
                 )
 
-        if self.dsa_indexer_topk_backend not in {"unfused", "cutedsl"}:
+        if self.dsa_indexer_topk_backend not in {
+            "unfused",
+            "cutedsl",
+            "cutedsl_index",
+        }:
             raise ValueError(
                 f"dsa_indexer_topk_backend={self.dsa_indexer_topk_backend!r} "
-                "is invalid. Must be one of {'unfused', 'cutedsl'}."
+                "is invalid. Must be one of "
+                "{'unfused', 'cutedsl', 'cutedsl_index'}."
+            )
+        if not isinstance(self.dsa_indexer_topk_min_cols, int):
+            raise ValueError(
+                "dsa_indexer_topk_min_cols must be an integer, got "
+                f"{self.dsa_indexer_topk_min_cols!r}"
+            )
+        if self.dsa_indexer_topk_min_cols < 0:
+            raise ValueError(
+                "dsa_indexer_topk_min_cols must be non-negative, got "
+                f"{self.dsa_indexer_topk_min_cols}"
             )
 
         # Hyper-connection (mHC) validation

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -1363,6 +1363,18 @@ class TransformerConfig(ModelParallelConfig):
       * "cudnn": cuDNN indexer top-k/forward path.
     """
 
+    dsa_indexer_topk_backend: str = "unfused"
+    """Top-k implementation used after production DSA indexer scores.
+
+    One of {"unfused", "cutedsl"}:
+      * "unfused" (default): Paddle ``topk`` reference implementation.
+      * "cutedsl": standalone Paddle CuTe DSL prefill top-k implementation.
+
+    This switch only changes the top-k stage after the indexer score forward.
+    It does not change warmup/full-candidate selection, TileLang score paths,
+    sparse attention backends, or indexer-loss autograd.
+    """
+
     csa_sparse_attn_backend: str = "tilelang"
     """CSA sparse attention backend. Single switch selecting one of three
     implementations of the final sparse MQA attention.
@@ -1919,6 +1931,12 @@ class TransformerConfig(ModelParallelConfig):
                     "train_indexer_only=True; the sparse training phase pairs "
                     "dsa_indexer_use_sparse_loss=True with a trainable backbone."
                 )
+
+        if self.dsa_indexer_topk_backend not in {"unfused", "cutedsl"}:
+            raise ValueError(
+                f"dsa_indexer_topk_backend={self.dsa_indexer_topk_backend!r} "
+                "is invalid. Must be one of {'unfused', 'cutedsl'}."
+            )
 
         # Hyper-connection (mHC) validation
         if self.use_fused_mhc:

--- a/tests/single_card_tests/custom_ops/test_cutedsl_indexer_topk.py
+++ b/tests/single_card_tests/custom_ops/test_cutedsl_indexer_topk.py
@@ -1,0 +1,616 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Coverage and unfused-regression tests for the CuTe DSL indexer top-k."""
+
+import importlib
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import paddle
+
+import paddlefleet.cutedsl_ops.compiler as compiler_mod
+import paddlefleet.cutedsl_ops.dlpack as dlpack_mod
+import paddlefleet.cutedsl_ops.indexer_topk_prefill as topk_mod
+from paddlefleet import cutedsl_ops
+from paddlefleet.cudnn_ops.indexer.csa_indexer_fwd_cudnn import (
+    _indexer_top_k_unfused,
+)
+from paddlefleet.cutedsl_ops.dlpack import _PaddleDLPackAdapter
+
+
+def _has_cutedsl_sm100():
+    if not paddle.device.is_compiled_with_cuda():
+        return False
+    if paddle.device.cuda.device_count() == 0:
+        return False
+    try:
+        if paddle.device.cuda.get_device_capability()[0] != 10:
+            return False
+        topk_mod._require_cutedsl()
+    except (ImportError, RuntimeError, AttributeError):
+        return False
+    return True
+
+
+_HAS_CUTEDSL_SM100 = _has_cutedsl_sm100()
+_CUTEDSL_SKIP_REASON = "CuTe DSL CLC top-k requires CUTLASS DSL and SM10x"
+
+
+def setUpModule():
+    if _HAS_CUTEDSL_SM100:
+        paddle.set_device("gpu")
+
+
+class TestIndexerTopKCoverage(unittest.TestCase):
+    """Exercise host-side helpers without requiring a CUDA device."""
+
+    def test_lazy_public_wrappers(self):
+        package = importlib.reload(cutedsl_ops)
+        index_result = object()
+        precompile_result = object()
+        with (
+            patch.object(
+                topk_mod,
+                "indexer_topk_prefill",
+                return_value=index_result,
+            ) as index_impl,
+            patch.object(
+                topk_mod,
+                "precompile_indexer_topk_clc",
+                return_value=precompile_result,
+            ) as precompile_impl,
+        ):
+            self.assertIs(
+                package.indexer_topk_prefill("scores", return_val=False),
+                index_result,
+            )
+            self.assertIs(
+                package.precompile_indexer_topk_clc(16384, 2048),
+                precompile_result,
+            )
+        index_impl.assert_called_once_with("scores", return_val=False)
+        precompile_impl.assert_called_once_with(16384, 2048)
+
+    def test_compile_bucket_saturates(self):
+        cases = {
+            1: 1,
+            3: 4,
+            2048: 2048,
+            8193: 16384,
+            16384: 16384,
+            256 * 1024: 16384,
+        }
+        for num_cols, expected in cases.items():
+            with self.subTest(num_cols=num_cols):
+                self.assertEqual(
+                    topk_mod._compile_num_cols_bucket(num_cols), expected
+                )
+
+    def test_launch_and_workspace_helpers(self):
+        self.assertEqual(
+            topk_mod._persistent_launch_config(
+                7, persistent=False, schedule_mode="static"
+            ),
+            (7, 1),
+        )
+        with self.assertRaisesRegex(ValueError, "non-empty row"):
+            topk_mod._persistent_launch_config(0)
+        with self.assertRaisesRegex(ValueError, "unsupported schedule_mode"):
+            topk_mod._persistent_launch_config(1, schedule_mode="invalid")
+        with self.assertRaisesRegex(ValueError, "requires persistent=True"):
+            topk_mod._persistent_launch_config(
+                1, persistent=False, schedule_mode="clc"
+            )
+
+        self.assertEqual(
+            topk_mod._workspace_slot_count(9, 4, 256, False, "clc"), 9
+        )
+        self.assertEqual(
+            topk_mod._workspace_slot_count(9, 4, 256, True, "static"), 4
+        )
+        self.assertEqual(
+            topk_mod._workspace_slot_count(9, 4, 512, True, "clc"), 16
+        )
+
+    def test_clc_capability_guard(self):
+        capability = "paddle.device.cuda.get_device_capability"
+        with (
+            patch(capability, return_value=(9, 0)),
+            self.assertRaisesRegex(RuntimeError, "SM100-family"),
+        ):
+            # The mocked capability fails before CUTLASS compilation;
+            # calling the public precompile entry verifies its guard.
+            topk_mod.precompile_indexer_topk_clc(max_num_cols=16, top_k=1)
+
+    def test_compiler_arch_flags_and_options(self):
+        capability = "paddle.device.cuda.get_device_capability"
+        for compute_capability, expected in compiler_mod._ARCH_MAP.items():
+            with self.subTest(compute_capability=compute_capability):
+                compiler_mod.gpu_arch_flag.cache_clear()
+                with (
+                    patch("paddle.is_compiled_with_cuda", return_value=True),
+                    patch(capability, return_value=compute_capability),
+                ):
+                    self.assertEqual(compiler_mod.gpu_arch_flag(), expected)
+
+        compiler_mod.gpu_arch_flag.cache_clear()
+        with (
+            patch("paddle.is_compiled_with_cuda", return_value=False),
+            self.assertRaisesRegex(
+                RuntimeError, "requires a CUDA Paddle build"
+            ),
+        ):
+            compiler_mod.gpu_arch_flag()
+
+        compiler_mod.gpu_arch_flag.cache_clear()
+        with (
+            patch("paddle.is_compiled_with_cuda", return_value=True),
+            patch(capability, return_value=(8, 0)),
+            self.assertRaisesRegex(RuntimeError, "unsupported CUDA"),
+        ):
+            compiler_mod.gpu_arch_flag()
+
+        with patch.object(
+            compiler_mod, "gpu_arch_flag", return_value="sm_100a"
+        ):
+            self.assertEqual(
+                compiler_mod.compile_options(),
+                "--enable-tvm-ffi --gpu-arch sm_100a",
+            )
+            self.assertEqual(
+                compiler_mod.compile_options("--debug"),
+                "--enable-tvm-ffi --gpu-arch sm_100a --debug",
+            )
+        compiler_mod.gpu_arch_flag.cache_clear()
+
+    def test_precompile_enumeration_and_process_cache(self):
+        fake_cutlass = SimpleNamespace(
+            Float16=object(),
+            BFloat16=object(),
+            Float32=object(),
+        )
+        topk_mod._CLC_PRECOMPILE_CACHE.clear()
+        with (
+            patch(
+                "paddle.device.cuda.get_device_capability",
+                return_value=(10, 3),
+            ),
+            patch.object(
+                topk_mod,
+                "_require_cutedsl",
+                return_value=(fake_cutlass, None, None, None),
+            ),
+            patch.object(
+                topk_mod,
+                "_persistent_launch_config",
+                return_value=(8, 1),
+            ),
+            patch.object(topk_mod, "_compile_kernel") as compile_kernel,
+        ):
+            buckets = topk_mod.precompile_indexer_topk_clc(
+                max_num_cols=256 * 1024,
+                top_k=2048,
+                dtype=paddle.float16,
+            )
+            self.assertEqual(buckets, (2048, 4096, 8192, 16384))
+            self.assertEqual(compile_kernel.call_count, 8)
+            for call in compile_kernel.call_args_list:
+                self.assertEqual(call.args[7], "clc")
+
+            repeated = topk_mod.precompile_indexer_topk_clc(
+                max_num_cols=256 * 1024,
+                top_k=2048,
+                dtype=paddle.float16,
+            )
+            self.assertEqual(repeated, buckets)
+            self.assertEqual(compile_kernel.call_count, 8)
+        topk_mod._CLC_PRECOMPILE_CACHE.clear()
+
+    def test_precompile_rejects_invalid_arguments(self):
+        fake_cutlass = SimpleNamespace(
+            Float16=object(),
+            BFloat16=object(),
+            Float32=object(),
+        )
+        cases = (
+            (
+                {"max_num_cols": 0, "top_k": 1},
+                "max_num_cols must be positive",
+            ),
+            (
+                {"max_num_cols": 16, "top_k": 0},
+                r"top_k must be in \[1, 2048\]",
+            ),
+            (
+                {"max_num_cols": 16, "top_k": 32},
+                "max_num_cols must be >= top_k",
+            ),
+            (
+                {
+                    "max_num_cols": 16,
+                    "top_k": 1,
+                    "return_values": (),
+                },
+                "return_values must contain",
+            ),
+        )
+        with (
+            patch(
+                "paddle.device.cuda.get_device_capability",
+                return_value=(10, 3),
+            ),
+            patch.object(
+                topk_mod,
+                "_require_cutedsl",
+                return_value=(fake_cutlass, None, None, None),
+            ),
+        ):
+            for kwargs, message in cases:
+                with (
+                    self.subTest(kwargs=kwargs),
+                    self.assertRaisesRegex(ValueError, message),
+                ):
+                    topk_mod.precompile_indexer_topk_clc(**kwargs)
+
+    def test_dlpack_adapter_forwards_consumer_stream(self):
+        sentinel = object()
+
+        class Tensor:
+            def __init__(self):
+                self.stream = None
+
+            def __dlpack__(self, *, stream=None):
+                self.stream = stream
+                return sentinel
+
+            def __dlpack_device__(self):
+                return (2, 0)
+
+        tensor = Tensor()
+        adapter = _PaddleDLPackAdapter(tensor)
+        self.assertIs(adapter.__dlpack__(stream=12345), sentinel)
+        self.assertEqual(tensor.stream, 12345)
+        self.assertEqual(adapter.__dlpack_device__(), (2, 0))
+
+    def test_dlpack_adapter_falls_back_to_paddle_capsule(self):
+        tensor = object()
+        capsule = object()
+        with patch(
+            "paddle.utils.dlpack.to_dlpack", return_value=capsule
+        ) as to_dlpack:
+            self.assertIs(
+                _PaddleDLPackAdapter(tensor).__dlpack__(stream=12345),
+                capsule,
+            )
+        to_dlpack.assert_called_once_with(tensor)
+
+    def test_paddle_stream_pointer_variants(self):
+        cuda_stream = SimpleNamespace(
+            stream_base=SimpleNamespace(cuda_stream=12345)
+        )
+        raw_stream = SimpleNamespace(raw_stream=67890)
+        with patch("paddle.device.current_stream", return_value=cuda_stream):
+            self.assertEqual(dlpack_mod.current_paddle_stream_ptr(), 12345)
+        with patch("paddle.device.current_stream", return_value=raw_stream):
+            self.assertEqual(dlpack_mod.current_paddle_stream_ptr(), 67890)
+        with (
+            patch("paddle.device.current_stream", return_value=object()),
+            self.assertRaisesRegex(RuntimeError, "cannot obtain"),
+        ):
+            dlpack_mod.current_paddle_stream_ptr()
+
+    def test_current_cu_stream_wraps_paddle_pointer(self):
+        import cuda.bindings.driver as cuda_driver
+
+        cu_stream = object()
+        with (
+            patch.object(
+                dlpack_mod,
+                "current_paddle_stream_ptr",
+                return_value=12345,
+            ),
+            patch.object(
+                cuda_driver,
+                "CUstream",
+                return_value=cu_stream,
+            ) as constructor,
+        ):
+            self.assertIs(dlpack_mod.current_cu_stream(), cu_stream)
+        constructor.assert_called_once_with(12345)
+
+    def test_paddle_to_cute_tensor_dynamic_layouts(self):
+        result = MagicMock()
+        dynamic = object()
+        result.mark_layout_dynamic.return_value = dynamic
+        with patch(
+            "cutlass.cute.runtime.from_dlpack",
+            return_value=result,
+        ) as from_dlpack:
+            tensor = object()
+            self.assertIs(
+                dlpack_mod.paddle_to_cute_tensor(
+                    tensor,
+                    assumed_align=16,
+                    stream_ptr=12345,
+                ),
+                dynamic,
+            )
+            result.mark_layout_dynamic.assert_called_once_with()
+            adapter = from_dlpack.call_args.args[0]
+            self.assertIs(adapter._tensor, tensor)
+            self.assertEqual(
+                from_dlpack.call_args.kwargs,
+                {"assumed_align": 16, "enable_tvm_ffi": True},
+            )
+
+            result.mark_layout_dynamic.reset_mock()
+            result.mark_layout_dynamic.return_value = dynamic
+            self.assertIs(
+                dlpack_mod.paddle_to_cute_tensor(
+                    tensor,
+                    assumed_align=4,
+                    leading_dim=1,
+                ),
+                dynamic,
+            )
+            result.mark_layout_dynamic.assert_called_once_with(leading_dim=1)
+
+
+@unittest.skipUnless(_HAS_CUTEDSL_SM100, _CUTEDSL_SKIP_REASON)
+class TestIndexerTopKUnfusedRegression(unittest.TestCase):
+    """Compare the production CUTEDSL dispatch against unfused Paddle top-k."""
+
+    @staticmethod
+    def _scores(rows, cols, dtype):
+        # The largest selected value is 0 and the tested top-k range is exactly
+        # representable in fp16/bf16, avoiding tie-breaking differences.
+        base = -paddle.arange(cols, dtype=paddle.float32).reshape([1, cols])
+        return paddle.tile(base, [rows, 1]).cast(dtype).contiguous()
+
+    def _compare_backends(self, scores, lengths, top_k, return_val):
+        reference = _indexer_top_k_unfused(
+            scores,
+            lengths,
+            top_k,
+            return_val=return_val,
+            topk_backend="unfused",
+        )
+        actual = _indexer_top_k_unfused(
+            scores,
+            lengths,
+            top_k,
+            return_val=return_val,
+            topk_backend="cutedsl",
+        )
+        paddle.device.synchronize()
+        self.assertTrue(
+            bool(paddle.all(actual["indices"] == reference["indices"]).item())
+        )
+        if return_val:
+            self.assertTrue(
+                bool(paddle.all(actual["values"] == reference["values"]).item())
+            )
+        else:
+            self.assertIsNone(actual["values"])
+            self.assertIsNone(reference["values"])
+
+    def test_input_validation_errors(self):
+        gpu_input = paddle.zeros([2, 8], dtype=paddle.float32)
+        gpu_lengths = paddle.full([2], 8, dtype=paddle.int32)
+        cpu_input = paddle.to_tensor(
+            [[0.0] * 8] * 2,
+            dtype=paddle.float32,
+            place=paddle.CPUPlace(),
+        )
+        cpu_lengths = paddle.to_tensor(
+            [8, 8],
+            dtype=paddle.int32,
+            place=paddle.CPUPlace(),
+        )
+        cases = (
+            (cpu_input, cpu_lengths, 1, ValueError, "CUDA tensors"),
+            (
+                paddle.zeros([8], dtype=paddle.float32),
+                paddle.full([8], 8, dtype=paddle.int32),
+                1,
+                ValueError,
+                "must be 2-D",
+            ),
+            (
+                gpu_input,
+                paddle.full([2, 1], 8, dtype=paddle.int32),
+                1,
+                ValueError,
+                "must be 1-D",
+            ),
+            (
+                gpu_input,
+                paddle.full([3], 8, dtype=paddle.int32),
+                1,
+                ValueError,
+                "one entry per input row",
+            ),
+            (
+                gpu_input,
+                paddle.full([2], 8, dtype=paddle.int64),
+                1,
+                TypeError,
+                "dtype paddle.int32",
+            ),
+            (gpu_input, gpu_lengths, 0, ValueError, r"\[1, 2048\]"),
+            (gpu_input, gpu_lengths, 2049, ValueError, r"\[1, 2048\]"),
+            (
+                paddle.empty([2, 0], dtype=paddle.float32),
+                paddle.zeros([2], dtype=paddle.int32),
+                1,
+                ValueError,
+                "non-empty column",
+            ),
+        )
+        for input_values, row_lengths, top_k, error, message in cases:
+            with (
+                self.subTest(message=message),
+                self.assertRaisesRegex(error, message),
+            ):
+                topk_mod.indexer_topk_prefill(input_values, row_lengths, top_k)
+
+    def test_output_and_workspace_validation_errors(self):
+        rows, cols, top_k = 2, 64, 4
+        scores = self._scores(rows, cols, paddle.float32)
+        lengths = paddle.full([rows], cols, dtype=paddle.int32)
+        cases = (
+            (
+                {
+                    "out_indices": paddle.empty(
+                        [rows, top_k + 1], dtype=paddle.int32
+                    )
+                },
+                "out_indices must have shape",
+            ),
+            (
+                {
+                    "out_indices": paddle.empty(
+                        [rows, top_k], dtype=paddle.float32
+                    )
+                },
+                "out_indices must be contiguous",
+            ),
+            (
+                {
+                    "out_values": paddle.empty(
+                        [rows, top_k + 1], dtype=paddle.float32
+                    )
+                },
+                "out_values must have shape",
+            ),
+            (
+                {
+                    "out_values": paddle.empty(
+                        [rows, top_k], dtype=paddle.float16
+                    )
+                },
+                "out_values must be contiguous",
+            ),
+            (
+                {"workspace": paddle.empty([1, 1, 1], dtype=paddle.int32)},
+                "workspace must be contiguous",
+            ),
+            (
+                {"scheduler_state": paddle.zeros([2], dtype=paddle.int32)},
+                "scheduler_state must be contiguous",
+            ),
+        )
+        with patch.object(
+            topk_mod, "_compile_kernel", return_value=MagicMock()
+        ):
+            for kwargs, message in cases:
+                with (
+                    self.subTest(message=message),
+                    self.assertRaisesRegex(ValueError, message),
+                ):
+                    topk_mod.indexer_topk_prefill(
+                        scores,
+                        lengths,
+                        top_k,
+                        **kwargs,
+                    )
+
+    def test_preallocated_outputs_workspace_and_scheduler_state(self):
+        rows, cols, top_k = 2, 64, 4
+        scores = self._scores(rows, cols, paddle.float32)
+        lengths = paddle.full([rows], cols, dtype=paddle.int32)
+        indices = paddle.empty([rows, top_k], dtype=paddle.int32)
+        values = paddle.empty([rows, top_k], dtype=paddle.float32)
+        scheduler_state = paddle.ones([1], dtype=paddle.int32)
+        num_ctas, _ = topk_mod._persistent_launch_config(rows)
+        slots = topk_mod._workspace_slot_count(rows, num_ctas, 256, True, "clc")
+        workspace = paddle.empty([slots, 2, 1], dtype=paddle.int32)
+        compiled = MagicMock()
+        cute_tensor = object()
+        with (
+            patch.object(
+                topk_mod,
+                "_compile_kernel",
+                return_value=compiled,
+            ),
+            patch.object(
+                dlpack_mod,
+                "paddle_to_cute_tensor",
+                return_value=cute_tensor,
+            ),
+        ):
+            actual_indices, actual_values = topk_mod.indexer_topk_prefill(
+                scores,
+                lengths,
+                top_k,
+                out_indices=indices,
+                out_values=values,
+                workspace=workspace,
+                scheduler_state=scheduler_state,
+            )
+        self.assertIs(actual_indices, indices)
+        self.assertIs(actual_values, values)
+        self.assertEqual(compiled.call_count, 1)
+        self.assertEqual(len(compiled.call_args.args), 6)
+
+    def test_matches_unfused_for_supported_dtypes_and_prefixes(self):
+        rows, cols, top_k = 4, 4096, 64
+        lengths = paddle.to_tensor([cols, 3073, top_k, 0], dtype=paddle.int32)
+        for dtype in (paddle.float16, paddle.bfloat16, paddle.float32):
+            with self.subTest(dtype=str(dtype)):
+                self._compare_backends(
+                    self._scores(rows, cols, dtype),
+                    lengths,
+                    top_k,
+                    return_val=True,
+                )
+
+    def test_matches_unfused_without_return_values(self):
+        rows, cols, top_k = 3, 4096, 64
+        lengths = paddle.to_tensor([cols, 127, 0], dtype=paddle.int32)
+        self._compare_backends(
+            self._scores(rows, cols, paddle.float16),
+            lengths,
+            top_k,
+            return_val=False,
+        )
+
+    def test_matches_unfused_for_long_overflow_columns(self):
+        rows, cols, top_k = 2, 32768, 64
+        lengths = paddle.to_tensor([cols, 20001], dtype=paddle.int32)
+        self._compare_backends(
+            self._scores(rows, cols, paddle.float16),
+            lengths,
+            top_k,
+            return_val=True,
+        )
+
+    def test_clc_compiled_kernel_reuses_runtime_row_shapes(self):
+        cols, top_k = 2048, 32
+        topk_mod._COMPILE_CACHE.clear()
+        for rows in (2, 5):
+            lengths = paddle.arange(cols, cols - rows, -1, dtype=paddle.int32)
+            self._compare_backends(
+                self._scores(rows, cols, paddle.float32),
+                lengths,
+                top_k,
+                return_val=True,
+            )
+            self.assertEqual(len(topk_mod._COMPILE_CACHE), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/custom_ops/test_cutedsl_indexer_topk.py
+++ b/tests/single_card_tests/custom_ops/test_cutedsl_indexer_topk.py
@@ -57,6 +57,48 @@ def setUpModule():
 class TestIndexerTopKCoverage(unittest.TestCase):
     """Exercise host-side helpers without requiring a CUDA device."""
 
+    def test_cutedsl_backend_dispatch(self):
+        input_values = MagicMock()
+        contiguous_values = input_values.contiguous.return_value
+        seq_lens = MagicMock()
+        int32_lengths = seq_lens.cast.return_value
+        contiguous_lengths = int32_lengths.contiguous.return_value
+        indices = object()
+        values = object()
+
+        with patch.object(
+            topk_mod,
+            "indexer_topk_prefill",
+            return_value=(indices, values),
+        ) as topk:
+            result = _indexer_top_k_unfused(
+                input_values,
+                seq_lens,
+                64,
+                return_val=False,
+                topk_backend="cutedsl",
+            )
+
+        self.assertEqual(result, {"indices": indices, "values": values})
+        seq_lens.cast.assert_called_once_with("int32")
+        topk.assert_called_once_with(
+            contiguous_values,
+            contiguous_lengths,
+            64,
+            return_val=False,
+        )
+
+    def test_invalid_topk_backend_raises(self):
+        with self.assertRaisesRegex(
+            ValueError, "topk_backend='invalid_backend' is invalid"
+        ):
+            _indexer_top_k_unfused(
+                MagicMock(),
+                MagicMock(),
+                64,
+                topk_backend="invalid_backend",
+            )
+
     def test_lazy_public_wrappers(self):
         package = importlib.reload(cutedsl_ops)
         index_result = object()
@@ -281,6 +323,8 @@ class TestIndexerTopKCoverage(unittest.TestCase):
 
         tensor = Tensor()
         adapter = _PaddleDLPackAdapter(tensor)
+        self.assertIs(adapter.__dlpack__(), sentinel)
+        self.assertIsNone(tensor.stream)
         self.assertIs(adapter.__dlpack__(stream=12345), sentinel)
         self.assertEqual(tensor.stream, 12345)
         self.assertEqual(adapter.__dlpack_device__(), (2, 0))

--- a/tests/single_card_tests/custom_ops/test_cutedsl_indexer_topk.py
+++ b/tests/single_card_tests/custom_ops/test_cutedsl_indexer_topk.py
@@ -59,6 +59,7 @@ class TestIndexerTopKCoverage(unittest.TestCase):
 
     def test_cutedsl_backend_dispatch(self):
         input_values = MagicMock()
+        input_values.shape = (1, 128)
         contiguous_values = input_values.contiguous.return_value
         seq_lens = MagicMock()
         int32_lengths = seq_lens.cast.return_value
@@ -77,6 +78,7 @@ class TestIndexerTopKCoverage(unittest.TestCase):
                 64,
                 return_val=False,
                 topk_backend="cutedsl",
+                cutedsl_min_cols=64,
             )
 
         self.assertEqual(result, {"indices": indices, "values": values})
@@ -86,7 +88,65 @@ class TestIndexerTopKCoverage(unittest.TestCase):
             contiguous_lengths,
             64,
             return_val=False,
+            sort_mode="score",
         )
+
+    def test_cutedsl_index_backend_selects_index_kernel(self):
+        input_values = MagicMock()
+        input_values.shape = (1, 4096)
+        seq_lens = MagicMock()
+        with patch.object(
+            topk_mod,
+            "indexer_topk_prefill",
+            return_value=(object(), None),
+        ) as topk:
+            _indexer_top_k_unfused(
+                input_values,
+                seq_lens,
+                2048,
+                return_val=False,
+                topk_backend="cutedsl_index",
+            )
+        self.assertEqual(topk.call_args.kwargs["sort_mode"], "index")
+
+    def test_cutedsl_backend_falls_back_for_short_scores(self):
+        input_values = paddle.to_tensor([[1.0, 3.0, 2.0, 4.0]])
+        seq_lens = paddle.to_tensor([4], dtype="int32")
+        with patch.object(topk_mod, "indexer_topk_prefill") as topk:
+            result = _indexer_top_k_unfused(
+                input_values,
+                seq_lens,
+                2,
+                return_val=True,
+                topk_backend="cutedsl",
+                cutedsl_min_cols=5,
+            )
+
+        topk.assert_not_called()
+        self.assertEqual(result["indices"].tolist(), [[3, 1]])
+        self.assertEqual(result["values"].tolist(), [[4.0, 3.0]])
+
+    def test_cutedsl_backend_uses_inclusive_column_threshold(self):
+        input_values = MagicMock()
+        input_values.shape = (1, 5)
+        seq_lens = MagicMock()
+        indices = object()
+        values = object()
+        with patch.object(
+            topk_mod,
+            "indexer_topk_prefill",
+            return_value=(indices, values),
+        ) as topk:
+            result = _indexer_top_k_unfused(
+                input_values,
+                seq_lens,
+                64,
+                topk_backend="cutedsl",
+                cutedsl_min_cols=5,
+            )
+
+        self.assertEqual(result, {"indices": indices, "values": values})
+        topk.assert_called_once()
 
     def test_invalid_topk_backend_raises(self):
         with self.assertRaisesRegex(
@@ -97,6 +157,18 @@ class TestIndexerTopKCoverage(unittest.TestCase):
                 MagicMock(),
                 64,
                 topk_backend="invalid_backend",
+            )
+
+    def test_cutedsl_index_backend_rejects_nonpositive_topk(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            r"topk_backend='cutedsl_index' requires top_k >= 1",
+        ):
+            _indexer_top_k_unfused(
+                MagicMock(),
+                MagicMock(),
+                0,
+                topk_backend="cutedsl_index",
             )
 
     def test_lazy_public_wrappers(self):
@@ -274,11 +346,15 @@ class TestIndexerTopKCoverage(unittest.TestCase):
             ),
             (
                 {"max_num_cols": 16, "top_k": 0},
-                r"top_k must be in \[1, 2048\]",
+                r"top_k must be in \[1, 32768\]",
             ),
             (
                 {"max_num_cols": 16, "top_k": 32},
                 "max_num_cols must be >= top_k",
+            ),
+            (
+                {"max_num_cols": 32768, "top_k": 16385},
+                r"top_k must be in \[1, 16384\] for float32",
             ),
             (
                 {
@@ -306,6 +382,41 @@ class TestIndexerTopKCoverage(unittest.TestCase):
                     self.assertRaisesRegex(ValueError, message),
                 ):
                     topk_mod.precompile_indexer_topk_clc(**kwargs)
+
+    def test_index_sort_mode_has_explicit_topk_boundary(self):
+        self.assertEqual(
+            topk_mod._validate_sort_mode("score", 64),
+            "score",
+        )
+        self.assertEqual(
+            topk_mod._validate_sort_mode("index", 1),
+            "index",
+        )
+        self.assertEqual(
+            topk_mod._validate_sort_mode("index", 64),
+            "index",
+        )
+        with self.assertRaisesRegex(
+            ValueError,
+            r"sort_mode='index' requires top_k >= 1",
+        ):
+            topk_mod._validate_sort_mode("index", 0)
+
+    def test_precompile_index_sort_mode_accepts_small_topk(self):
+        with (
+            patch(
+                "paddle.device.cuda.get_device_capability",
+                return_value=(10, 3),
+            ),
+            patch.object(topk_mod, "_compile_kernel"),
+        ):
+            buckets = topk_mod.precompile_indexer_topk_clc(
+                max_num_cols=4096,
+                top_k=64,
+                sort_mode="index",
+            )
+            self.assertEqual(buckets, (64, 128, 256, 512, 1024, 2048, 4096))
+        topk_mod._CLC_PRECOMPILE_CACHE.clear()
 
     def test_dlpack_adapter_forwards_consumer_stream(self):
         sentinel = object()
@@ -424,7 +535,14 @@ class TestIndexerTopKUnfusedRegression(unittest.TestCase):
         base = -paddle.arange(cols, dtype=paddle.float32).reshape([1, cols])
         return paddle.tile(base, [rows, 1]).cast(dtype).contiguous()
 
-    def _compare_backends(self, scores, lengths, top_k, return_val):
+    def _compare_backends(
+        self,
+        scores,
+        lengths,
+        top_k,
+        return_val,
+        topk_backend="cutedsl",
+    ):
         reference = _indexer_top_k_unfused(
             scores,
             lengths,
@@ -437,15 +555,89 @@ class TestIndexerTopKUnfusedRegression(unittest.TestCase):
             lengths,
             top_k,
             return_val=return_val,
-            topk_backend="cutedsl",
+            topk_backend=topk_backend,
         )
         paddle.device.synchronize()
+        actual_indices = actual["indices"]
+        reference_indices = reference["indices"]
+        valid_counts = paddle.minimum(
+            lengths.reshape([-1, 1]),
+            paddle.full(
+                [lengths.shape[0], 1],
+                top_k,
+                dtype=lengths.dtype,
+            ),
+        )
+        valid_slots = (
+            paddle.arange(top_k, dtype=lengths.dtype).reshape([1, -1])
+            < valid_counts
+        )
+        adjacent_valid = valid_slots[:, 1:] & valid_slots[:, :-1]
         self.assertTrue(
-            bool(paddle.all(actual["indices"] == reference["indices"]).item())
+            bool(
+                paddle.all(
+                    (~adjacent_valid)
+                    | (actual_indices[:, 1:] > actual_indices[:, :-1])
+                ).item()
+            )
+        )
+        self.assertTrue(
+            bool(
+                paddle.all(
+                    paddle.where(
+                        valid_slots,
+                        (actual_indices >= 0)
+                        & (actual_indices < lengths.reshape([-1, 1])),
+                        actual_indices == -1,
+                    )
+                ).item()
+            )
+        )
+        normalized_indices = paddle.where(
+            valid_slots,
+            actual_indices,
+            paddle.full_like(actual_indices, scores.shape[1]),
+        )
+        sorted_indices = paddle.sort(normalized_indices, axis=1)
+        duplicate_indices = (
+            sorted_indices[:, 1:] == sorted_indices[:, :-1]
+        ) & (sorted_indices[:, 1:] != scores.shape[1])
+        self.assertTrue(bool(paddle.all(~duplicate_indices).item()))
+
+        safe_actual = paddle.clip(
+            actual_indices, min=0, max=scores.shape[1] - 1
+        )
+        safe_reference = paddle.clip(
+            reference_indices, min=0, max=scores.shape[1] - 1
+        )
+        actual_scores = paddle.take_along_axis(
+            scores, safe_actual, axis=1
+        ).cast("float32")
+        reference_scores = paddle.take_along_axis(
+            scores, safe_reference, axis=1
+        ).cast("float32")
+        neg_inf = paddle.full_like(actual_scores, float("-inf"))
+        actual_scores = paddle.where(valid_slots, actual_scores, neg_inf)
+        reference_scores = paddle.where(valid_slots, reference_scores, neg_inf)
+        self.assertTrue(
+            bool(
+                paddle.all(
+                    paddle.sort(actual_scores, axis=1)
+                    == paddle.sort(reference_scores, axis=1)
+                ).item()
+            )
         )
         if return_val:
             self.assertTrue(
-                bool(paddle.all(actual["values"] == reference["values"]).item())
+                bool(
+                    paddle.all(
+                        paddle.where(
+                            valid_slots,
+                            actual["values"].cast("float32") == actual_scores,
+                            actual["values"] == actual["values"],
+                        )
+                    ).item()
+                )
             )
         else:
             self.assertIsNone(actual["values"])
@@ -494,8 +686,15 @@ class TestIndexerTopKUnfusedRegression(unittest.TestCase):
                 TypeError,
                 "dtype paddle.int32",
             ),
-            (gpu_input, gpu_lengths, 0, ValueError, r"\[1, 2048\]"),
-            (gpu_input, gpu_lengths, 2049, ValueError, r"\[1, 2048\]"),
+            (gpu_input, gpu_lengths, 0, ValueError, r"\[1, 32768\]"),
+            (
+                gpu_input,
+                gpu_lengths,
+                16385,
+                ValueError,
+                r"\[1, 16384\] for float32",
+            ),
+            (gpu_input, gpu_lengths, 32769, ValueError, r"\[1, 32768\]"),
             (
                 paddle.empty([2, 0], dtype=paddle.float32),
                 paddle.zeros([2], dtype=paddle.int32),
@@ -580,7 +779,21 @@ class TestIndexerTopKUnfusedRegression(unittest.TestCase):
         values = paddle.empty([rows, top_k], dtype=paddle.float32)
         scheduler_state = paddle.ones([1], dtype=paddle.int32)
         num_ctas, _ = topk_mod._persistent_launch_config(rows)
-        slots = topk_mod._workspace_slot_count(rows, num_ctas, 256, True, "clc")
+        smem_bytes = topk_mod._estimate_smem_bytes_per_cta(
+            256,
+            top_k,
+            2,
+            min(16384, cols),
+            "clc",
+        )
+        slots = topk_mod._workspace_slot_count(
+            rows,
+            num_ctas,
+            256,
+            True,
+            "clc",
+            smem_bytes_per_cta=smem_bytes,
+        )
         workspace = paddle.empty([slots, 2, 1], dtype=paddle.int32)
         compiled = MagicMock()
         cute_tensor = object()
@@ -654,6 +867,64 @@ class TestIndexerTopKUnfusedRegression(unittest.TestCase):
                 return_val=True,
             )
             self.assertEqual(len(topk_mod._COMPILE_CACHE), 1)
+
+    def test_index_kernel_matches_candidate_set_at_boundary(self):
+        rows, cols, top_k = 2, 4096, 2048
+        lengths = paddle.to_tensor([cols, 3073], dtype=paddle.int32)
+        self._compare_backends(
+            self._scores(rows, cols, paddle.float16),
+            lengths,
+            top_k,
+            return_val=True,
+            topk_backend="cutedsl_index",
+        )
+
+    def test_short_rows_write_prefix_directly_for_static_and_clc(self):
+        rows, cols, top_k = 3, 4096, 64
+        scores = paddle.tile(
+            -paddle.arange(cols, dtype=paddle.float32).reshape([1, -1]),
+            [rows, 1],
+        ).cast(paddle.float16)
+        lengths = paddle.to_tensor([0, 31, cols], dtype=paddle.int32)
+
+        for persistent, schedule_mode in ((False, "static"), (True, "clc")):
+            with self.subTest(schedule_mode=schedule_mode):
+                indices, values = topk_mod.indexer_topk_prefill(
+                    scores,
+                    lengths,
+                    top_k,
+                    return_val=True,
+                    persistent=persistent,
+                    schedule_mode=schedule_mode,
+                    sort_mode="index",
+                )
+                paddle.device.synchronize()
+
+                self.assertTrue(bool(paddle.all(indices[0] == -1).item()))
+                self.assertTrue(
+                    bool(
+                        paddle.all(
+                            paddle.isinf(values[0]) & (values[0] < 0)
+                        ).item()
+                    )
+                )
+                self.assertEqual(indices[1, :31].tolist(), list(range(31)))
+                self.assertEqual(
+                    values[1, :31].cast("float32").tolist(),
+                    [-float(i) for i in range(31)],
+                )
+                self.assertTrue(bool(paddle.all(indices[1, 31:] == -1).item()))
+                self.assertTrue(
+                    bool(
+                        paddle.all(
+                            paddle.isinf(values[1, 31:]) & (values[1, 31:] < 0)
+                        ).item()
+                    )
+                )
+                self.assertEqual(
+                    indices[2].tolist(),
+                    list(range(top_k)),
+                )
 
 
 if __name__ == "__main__":

--- a/tests/single_card_tests/test_transformer_config.py
+++ b/tests/single_card_tests/test_transformer_config.py
@@ -201,12 +201,35 @@ class TestDsaIndexerTopKBackendConfig(unittest.TestCase):
         config = TransformerConfig(dsa_indexer_topk_backend="cutedsl")
         self.assertEqual(config.dsa_indexer_topk_backend, "cutedsl")
 
+    def test_valid_cutedsl_index_value(self):
+        config = TransformerConfig(dsa_indexer_topk_backend="cutedsl_index")
+        self.assertEqual(config.dsa_indexer_topk_backend, "cutedsl_index")
+
     def test_invalid_value_raises(self):
         with self.assertRaisesRegex(
             ValueError,
             "dsa_indexer_topk_backend='invalid_backend' is invalid",
         ):
             TransformerConfig(dsa_indexer_topk_backend="invalid_backend")
+
+    def test_min_cols_default_and_override(self):
+        self.assertEqual(TransformerConfig().dsa_indexer_topk_min_cols, 16384)
+        self.assertEqual(
+            TransformerConfig(
+                dsa_indexer_topk_min_cols=131072
+            ).dsa_indexer_topk_min_cols,
+            131072,
+        )
+
+    def test_min_cols_rejects_invalid_values(self):
+        with self.assertRaisesRegex(
+            ValueError, "dsa_indexer_topk_min_cols must be non-negative"
+        ):
+            TransformerConfig(dsa_indexer_topk_min_cols=-1)
+        with self.assertRaisesRegex(
+            ValueError, "dsa_indexer_topk_min_cols must be an integer"
+        ):
+            TransformerConfig(dsa_indexer_topk_min_cols=1.5)
 
 
 class TestRoutedScalingFactorConfig(unittest.TestCase):

--- a/tests/single_card_tests/test_transformer_config.py
+++ b/tests/single_card_tests/test_transformer_config.py
@@ -190,6 +190,25 @@ class TestMoeLayerFreqAndFirstKDenseReplace(unittest.TestCase):
         self.assertEqual(config.moe_n_hash_layers, 0)
 
 
+class TestDsaIndexerTopKBackendConfig(unittest.TestCase):
+    """Tests for the DSA indexer top-k backend configuration."""
+
+    def test_default_value(self):
+        config = TransformerConfig()
+        self.assertEqual(config.dsa_indexer_topk_backend, "unfused")
+
+    def test_valid_cutedsl_value(self):
+        config = TransformerConfig(dsa_indexer_topk_backend="cutedsl")
+        self.assertEqual(config.dsa_indexer_topk_backend, "cutedsl")
+
+    def test_invalid_value_raises(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "dsa_indexer_topk_backend='invalid_backend' is invalid",
+        ):
+            TransformerConfig(dsa_indexer_topk_backend="invalid_backend")
+
+
 class TestRoutedScalingFactorConfig(unittest.TestCase):
     """Tests for the routed_scaling_factor and routed_scaling_factor_learnable fields
     in TransformerConfig."""

--- a/tests/single_card_tests/transformer/test_mqa_latent_attention.py
+++ b/tests/single_card_tests/transformer/test_mqa_latent_attention.py
@@ -157,6 +157,35 @@ class TestMQAGuards(unittest.TestCase):
         w_v = paddle.zeros([DV, H, V_HEAD_DIM], dtype="bfloat16")
         return query, key, w_v
 
+    def test_cutedsl_backend_precompiles_by_default_on_gpu(self):
+        config = _create_mqa_config("mqa_dsa")
+        config.dsa_indexer_topk_backend = "cutedsl"
+        with (
+            mock.patch("paddle.get_device", return_value="gpu:0"),
+            mock.patch(
+                "paddlefleet.cutedsl_ops.precompile_indexer_topk_clc"
+            ) as precompile,
+        ):
+            _build_module(config)
+
+        precompile.assert_called_once_with(
+            max_num_cols=16 * 1024,
+            top_k=INDEX_TOPK,
+        )
+
+    def test_cutedsl_backend_skips_precompile_without_gpu(self):
+        config = _create_mqa_config("mqa_dsa")
+        config.dsa_indexer_topk_backend = "cutedsl"
+        with (
+            mock.patch("paddle.get_device", return_value="cpu"),
+            mock.patch(
+                "paddlefleet.cutedsl_ops.precompile_indexer_topk_clc"
+            ) as precompile,
+        ):
+            _build_module(config)
+
+        precompile.assert_not_called()
+
     def test_packed_seq_params_rejected(self):
         query, key, w_v = self._args()
         with self.assertRaises(NotImplementedError):


### PR DESCRIPTION
### PR Category
Performance Optimization

### PR Types
Performance

### Description
新增 DSA indexer top-k 的 CuTe DSL CLC backend，并完成训练侧集成。

主要改动：

- 为 _indexer_top_k_unfused 增加 topk_backend 选择，支持 unfused 和 cutedsl 两种实现。
- 新增 dsa_indexer_topk_backend 配置，默认保持使用 unfused。
- 新增基于 CuTe DSL 的 DSA indexer prefill top-k kernel，采用 CLC persistent scheduling。
- 增加 CuTe DSL 编译、Paddle DLPack tensor 转换及相关运行时支持。
- 在 CSA/MQA attention 路径中接入 CUTEDSL top-k backend。
- 增加 CLC kernel 预编译入口，并对目标 GPU 架构和 CuTe DSL 依赖进行检查。
- 增加 CUTEDSL top-k 单测及与 unfused 实现的回归测试，覆盖不同数据类型、序列长度、返回值配置和运行时 shape。

### 是否引起精度变化
是

当存在同分值时，可以保证选中元素的分数集合一致，但由于不同实现的 tie-breaking 规则可能不同，无法保证最终选择的元素 ID 完全一致。