### PR TITLE
[Optim] HCA CP and local computation optimization

### DIFF
--- a/src/paddlefleet/context_parallel_utils.py
+++ b/src/paddlefleet/context_parallel_utils.py
@@ -437,9 +437,12 @@ def all_gather_contiguous(input_tensor, group=None, axis=0):
     nranks = group.nranks
     if nranks == 1:
         return input_tensor.clone()
-    if axis == 0:
+    # NCCL concatenates rank contributions along the flat leading axis, so any
+    # ``axis`` whose preceding dims are all 1 is already an axis-0 gather: one
+    # collective instead of nranks buffers plus a paddle.concat.
+    if list(input_tensor.shape[:axis]) == [1] * axis:
         shape = list(input_tensor.shape)
-        shape[0] *= nranks
+        shape[axis] *= nranks
         gathered = paddle.empty(shape=shape, dtype=input_tensor.dtype)
         dist.stream.all_gather(
             gathered,

--- a/src/paddlefleet/transformer/cp_utils.py
+++ b/src/paddlefleet/transformer/cp_utils.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import paddle
 import paddle.distributed as dist
 from paddle import Tensor
+from paddle.autograd.py_layer import PyLayer
 
 # ===========================================================================
 # Differentiable all-gather — delegates to ContextParallelAllGatherOp
@@ -43,6 +44,76 @@ def all_gather_cp(x: Tensor, dim: int, group) -> Tensor:
     if group is None or group.nranks <= 1:
         return x
     return ContextParallelAllGatherOp.apply(x, dim, "contiguous_allgather")
+
+
+# ===========================================================================
+# One-hop window exchange with the previous CP rank
+# ===========================================================================
+
+
+def wait(ops):
+    """Post a batch of P2P ops and wait for them."""
+    for task in dist.batch_isend_irecv(ops):
+        task.wait()
+
+
+class PrependPrevWindow(PyLayer):
+    """Prepend the previous CP rank's last ``window`` rows; rank 0 gets zeros.
+
+    Only ``window`` rows cross the wire, versus ``s_local`` for an all-gather.
+    Backward is the mirror: the prefix gradient goes back to ``rank - 1`` and
+    the one arriving from ``rank + 1`` is added to this rank's tail.
+    """
+
+    @staticmethod
+    def forward(ctx, x, window, group):
+        ctx.window, ctx.group = window, group
+        r, peers = group.rank, group.ranks
+        prefix = paddle.zeros([x.shape[0], window, x.shape[2]], dtype=x.dtype)
+        ops = []
+        if r > 0:
+            ops.append(dist.P2POp(dist.irecv, prefix, peers[r - 1], group))
+        if r < group.nranks - 1:
+            tail = x[:, -window:, :].contiguous()
+            ops.append(dist.P2POp(dist.isend, tail, peers[r + 1], group))
+        wait(ops)
+        return paddle.concat([prefix, x], axis=1)
+
+    @staticmethod
+    def backward(ctx, grad):
+        window, group = ctx.window, ctx.group
+        r, peers = group.rank, group.ranks
+        grad_x = grad[:, window:, :].clone()  # clone: grad must stay untouched
+        tail_grad = paddle.zeros_like(grad[:, :window, :])
+        ops = []
+        if r < group.nranks - 1:
+            ops.append(dist.P2POp(dist.irecv, tail_grad, peers[r + 1], group))
+        if r > 0:
+            prefix_grad = grad[:, :window, :].contiguous()
+            ops.append(dist.P2POp(dist.isend, prefix_grad, peers[r - 1], group))
+        wait(ops)
+        grad_x[:, -window:, :] += tail_grad
+        return grad_x
+
+
+def prepend_prev_window(x: Tensor, window: int, group) -> Tensor:
+    """``[b, s, d]`` -> ``[b, window + s, d]``, prefixed by the previous rank.
+
+    Row 0 of the result has global position ``rank * s - window``. A single hop
+    only reaches ``rank - 1``, so ``window`` must not exceed ``s``.
+    """
+    if window <= 0:
+        return x
+    if window > x.shape[1]:
+        raise ValueError(
+            f"prepend_prev_window window ({window}) exceeds the local sequence "
+            f"length ({x.shape[1]}): a single hop only reaches rank - 1, so the "
+            "window may not span more than one CP shard"
+        )
+    if group is None or group.nranks <= 1:
+        prefix = paddle.zeros([x.shape[0], window, x.shape[2]], dtype=x.dtype)
+        return paddle.concat([prefix, x], axis=1)
+    return PrependPrevWindow.apply(x, window, group)
 
 
 # ===========================================================================

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -68,6 +68,7 @@ from paddlefleet.transformer.cp_utils import (
     get_compress_topk_idxs_cp,
     get_window_topk_idxs_cp,
     map_compressed_topk_to_kv_full_cp,
+    prepend_prev_window,
 )
 
 # Sentinel value in ``config.csa_compress_ratios`` selecting the full-causal
@@ -438,7 +439,7 @@ class CSADocMaskMetadata:
     _window_topk_idxs: Tensor | None = None
     _window_size: int | None = None
     _compress_topk_idxs: Tensor | None = None
-    _compress_offset: int | None = None
+    _compress_offset: tuple[int, int, int] | None = None
     _compressed_causal_mask: Tensor | None = None
     _is_first_compressed_group: Tensor | None = None
     _mqa_causal_topk: tuple[Tensor, Tensor] | None = None
@@ -613,19 +614,23 @@ class CSADocMaskMetadata:
             self._window_size = window_size
         return self._window_topk_idxs
 
-    def get_compress_topk_idxs(self, offset: int) -> Tensor:
-        """Return ``[batch_size, seqlen, n_compressed]`` compressed indices.
+    def get_compress_topk_idxs(
+        self, offset: int, row_start: int = 0, row_count: int | None = None
+    ) -> Tensor:
+        """Return ``[batch_size, row_count, n_compressed]`` compressed indices.
 
         For each query position, valid compressed positions (within the
         document's causal valid range) carry ``compressed_id + offset``;
-        invalid slots are ``-1``. Cached and keyed by ``offset``.
+        invalid slots are ``-1``. ``row_start`` / ``row_count`` restrict the
+        query rows to build, which under CP lets a rank ask for its own shard
+        instead of the whole table. Cached and keyed by all three.
         """
-        offset = int(offset)
-        cache_hit = (
-            self._compress_topk_idxs is not None
-            and self._compress_offset == offset
+        key = (
+            int(offset),
+            int(row_start),
+            self.seqlen if row_count is None else int(row_count),
         )
-        if not cache_hit:
+        if self._compress_topk_idxs is None or self._compress_offset != key:
             from paddlefleet.triton_ops.document_mask_fusion import (
                 compressed_doc_start_triton,
                 compressed_topk_idxs_triton,
@@ -641,9 +646,11 @@ class CSADocMaskMetadata:
                 self.pos_in_doc,
                 self.doc_len_per_pos,
                 self.ratio,
-                offset,
+                key[0],
+                row_start=key[1],
+                row_count=key[2],
             )
-            self._compress_offset = offset
+            self._compress_offset = key
         return self._compress_topk_idxs
 
     def get_compressed_causal_mask(self) -> Tensor:
@@ -1643,12 +1650,13 @@ class Compressor(nn.Layer):
             kv, _ = self.linear_wkv(x)  # [b, sq, coff * head_dim]
             score, _ = self.linear_wgate(x)  # [b, sq, coff * head_dim]
 
+        cp_size = getattr(cp_group, "nranks", 1) if cp_group is not None else 1
+        cp_rank = cp_group.rank if cp_size > 1 else 0
+
         # CP: gather projected KV globally before pooling (Miles pattern).
-        # This lets the compressor pool across the full sequence while keeping
-        # communication cheap (projected dim << hidden_size).
         # After all-gather, kv/score are global and sq is updated to sq_global.
         # The rest of the compression logic is shared with the non-CP path.
-        if cp_group is not None and getattr(cp_group, "nranks", 1) > 1:
+        if cp_size > 1:
             kv = all_gather_cp(kv, dim=1, group=cp_group)
             score = all_gather_cp(score, dim=1, group=cp_group)
             b, sq, _ = kv.shape
@@ -1659,6 +1667,31 @@ class Compressor(nn.Layer):
             n_compressed = sq // ratio
             actual_n_compressed = docmask_meta.actual_n_compressed
             cutoff_gather_indices = docmask_meta.cutoff_gather_indices
+
+            # Without the overlap transform a compressed group only reads its own
+            # ``ratio`` cutoff tokens, so the groups can be split across CP ranks.
+            n_shard = (
+                (actual_n_compressed + cp_size - 1) // cp_size
+                if cp_size > 1 and not self.overlap
+                else 0
+            )
+            if n_shard:
+                start = cp_rank * n_shard * ratio
+                cutoff_gather_indices = cutoff_gather_indices[
+                    start : start + n_shard * ratio
+                ]
+                pad_len = n_shard * ratio - cutoff_gather_indices.shape[0]
+                if pad_len > 0:
+                    # Slots past the last real group; dropped after the gather.
+                    cutoff_gather_indices = paddle.concat(
+                        [
+                            cutoff_gather_indices,
+                            paddle.zeros(
+                                [pad_len], dtype=cutoff_gather_indices.dtype
+                            ),
+                        ]
+                    )
+                actual_n_compressed = n_shard
 
             # Pack only valid cutoff data contiguously (no padding)
             kv = paddle.gather(kv, cutoff_gather_indices, axis=1)
@@ -1695,6 +1728,14 @@ class Compressor(nn.Layer):
                 )
             else:
                 kv = self.norm(kv.cast(x.dtype))
+
+            if n_shard:
+                # Shards concatenate into the dense group order; the tail beyond
+                # the last real group is padding and is re-added below.
+                actual_n_compressed = docmask_meta.actual_n_compressed
+                kv = all_gather_cp(kv, dim=1, group=cp_group)[
+                    :, :actual_n_compressed
+                ]
 
             # Pad to n_compressed before RoPE
             if actual_n_compressed < n_compressed:
@@ -2183,6 +2224,13 @@ class CompressedSparseAttention(FleetLayer):
             )
         else:
             self.compressor = None
+
+        # HCA layers pool with the non-overlapping compressor (ratio >= 128), so
+        # a query reads raw KV only through its sliding window. CP relies on this
+        # to replace the global KV all-gather with a one-hop window exchange.
+        self.is_hca_layer = (
+            self.compressor is not None and not self.compressor.overlap
+        )
 
         # Conditionally build Indexer for CSA layers (1 < ratio < 128) and not dense_mode.
         # ratio 128 (HCA) intentionally falls through to the attend-to-all path.
@@ -2981,13 +3029,16 @@ class CompressedSparseAttention(FleetLayer):
         """CP-aware forward: local compress + all-gather, sparse attention.
 
         Mirrors the non-CP forward() structure exactly, with CP adaptations:
-          1. All-gather KV + compress (Miles pattern: gather projected, pool globally)
+          1. All-gather KV + compress; on HCA layers the sliding window is the
+             only raw-KV reader, so the all-gather shrinks to a one-hop
+             ``window_size`` exchange and the column ids are rebased onto it
           2. Indexer topk + fused loss (same three-branch logic as non-CP)
           3. Sparse attention (same compressed_sparse_attn dispatch)
           4. Attach loss (TileLangCSAIndexerLossAutoScaler or DSAIndexerLossAutoScaler)
 
         Gradient correctness:
-          - all_gather_cp backward (reduce-scatter) routes attention/loss grads
+          - all_gather_cp / prepend_prev_window backward route attention and
+            loss grads back to the ranks that own the KV
           - indexer_loss / cp_size corrects local-mean to global-mean scaling
           - param grads are partial (each rank sees local Q); production ZeRO
             reduce_scatter(SUM) + optimizer x cp_size aggregates them correctly
@@ -3013,11 +3064,22 @@ class CompressedSparseAttention(FleetLayer):
             window_idxs = full_window_idxs[
                 :, position_offset : position_offset + sq, ...
             ]
-        window_idxs = window_idxs.astype("int32").contiguous()
-
-        # Step 2: All-gather KV + compress
         kv_local = key.squeeze(2)  # [b, sq, hn]
-        kv_global = all_gather_cp(kv_local, dim=1, group=self.cp_group)
+        if self.is_hca_layer:
+            # A window query looks back at most ``window_size - 1`` rows, so
+            # kv_full can start at ``position_offset - window_size``: only that
+            # many rows cross the wire, and rebasing the ids onto the shorter
+            # kv_full reads the same values. ``-1`` slots must stay ``-1``.
+            kv_reach = prepend_prev_window(
+                kv_local, self.window_size, self.cp_group
+            )
+            kv_base = position_offset - self.window_size
+            window_idxs = paddle.where(
+                window_idxs >= 0, window_idxs - kv_base, window_idxs
+            )
+        else:
+            kv_reach = all_gather_cp(kv_local, dim=1, group=self.cp_group)
+        window_idxs = window_idxs.astype("int32").contiguous()
 
         compressed_kv_global = None
         n_compressed_local = 0
@@ -3040,7 +3102,7 @@ class CompressedSparseAttention(FleetLayer):
         else:
             actual_n_compressed = 0
 
-        offset = sq_global  # compressed indices follow vanilla KV in kv_full
+        offset = kv_reach.shape[1]  # compressed ids follow the reachable KV
 
         if (
             self.compressor is not None
@@ -3054,9 +3116,9 @@ class CompressedSparseAttention(FleetLayer):
                 cp_group=self.cp_group,
                 docmask_meta=docmask_meta,
             )
-            kv_full = paddle.concat([kv_global, compressed_kv_global], axis=1)
+            kv_full = paddle.concat([kv_reach, compressed_kv_global], axis=1)
         else:
-            kv_full = kv_global
+            kv_full = kv_reach
 
         # Step 3: Compressed topk + optional fused indexer loss
         indexer_loss = None
@@ -3301,12 +3363,12 @@ class CompressedSparseAttention(FleetLayer):
                         n_compressed_global,
                     )
                 else:
+                    # Build only this rank's query rows: the table is
+                    # [sq_global, n_compressed] and only sq of those rows are
+                    # ever read here.
                     compress_topk_idxs = docmask_meta.get_compress_topk_idxs(
-                        offset
+                        offset, row_start=position_offset, row_count=sq
                     )
-                    compress_topk_idxs = compress_topk_idxs[
-                        :, position_offset : position_offset + sq, ...
-                    ]
 
             compress_topk_idxs = compress_topk_idxs.astype("int32")
 

--- a/src/paddlefleet/triton_ops/document_mask_fusion.py
+++ b/src/paddlefleet/triton_ops/document_mask_fusion.py
@@ -635,11 +635,12 @@ def compressed_topk_idxs_kernel(
     CompDocStart_ptr,  # compressed_doc_start_per_pos [seqlen]
     PosInDoc_ptr,  # pos_in_doc [seqlen]
     DocLen_ptr,  # doc_len_per_pos [seqlen]
-    Out_ptr,  # output [seqlen, n_groups]
+    Out_ptr,  # output [row_count, n_groups]
     seqlen,
     n_groups,
     ratio,  # compression ratio (runtime scalar, need NOT be power of 2)
     offset,  # constant added to every accessible slot index (-1 kept as -1)
+    row_start,  # first query position to emit; output row 0 maps to it
     BLOCK_G: tl.constexpr,  # power of 2 block along the compressed-kv axis
 ):
     """
@@ -664,10 +665,11 @@ def compressed_topk_idxs_kernel(
     ``[compressed_doc_start[i], compressed_doc_start[i] + (pos_in_doc[i]+1)//ratio)``.
     One program per position, streaming the compressed axis in BLOCK_G chunks.
     """
-    pid = tl.program_id(0)  # query position i
-    cds = tl.load(CompDocStart_ptr + pid).to(tl.int32)
-    pos = tl.load(PosInDoc_ptr + pid).to(tl.int32)
-    dlen = tl.load(DocLen_ptr + pid).to(tl.int32)
+    pid = tl.program_id(0)  # output row
+    q = row_start + pid  # query position i
+    cds = tl.load(CompDocStart_ptr + q).to(tl.int32)
+    pos = tl.load(PosInDoc_ptr + q).to(tl.int32)
+    dlen = tl.load(DocLen_ptr + q).to(tl.int32)
 
     # padding query (pos_in_doc >= doc_len) sees nothing.
     valid_q = pos < dlen
@@ -696,6 +698,8 @@ def compressed_topk_idxs_triton(
     doc_len_per_pos: Tensor,
     ratio: int,
     offset: int = 0,
+    row_start: int = 0,
+    row_count: int | None = None,
 ) -> Tensor:
     """Build ``compressed_topk_ids`` for KV-compressed sparse attention.
 
@@ -712,12 +716,17 @@ def compressed_topk_idxs_triton(
         offset: int constant added to every accessible compressed-kv id; ``-1``
             padding is preserved. Use this when the compressed kv are appended
             after the uncompressed kv (offset == number of uncompressed kv).
+        row_start, row_count: emit only query rows
+            ``[row_start, row_start + row_count)``. Rows are independent, so the
+            result equals the full table sliced to that range -- under CP each
+            rank only owns ``seqlen // cp_size`` rows and materialising the
+            other ``cp_size - 1`` shards costs the same table again.
 
     Returns:
-        int32 tensor [1, seqlen, seqlen // ratio]; entry ``[0, i, g]`` is
-        ``g + offset`` if query ``i`` may attend to compressed slot ``g`` (valid
-        query, same doc, causally complete), else ``-1``. The last axis aligns
-        with ``compressed_is_first``.
+        int32 tensor [1, row_count, seqlen // ratio]; entry ``[0, i, g]`` is
+        ``g + offset`` if query ``row_start + i`` may attend to compressed slot
+        ``g`` (valid query, same doc, causally complete), else ``-1``. The last
+        axis aligns with ``compressed_is_first``.
     """
     assert (
         compressed_doc_start_per_pos.ndim == 1
@@ -738,12 +747,19 @@ def compressed_topk_idxs_triton(
     (seqlen,) = cds.shape
     ratio = int(ratio)
     offset = int(offset)
+    row_start = int(row_start)
+    row_count = seqlen if row_count is None else int(row_count)
+    if row_start < 0 or row_count < 1 or row_start + row_count > seqlen:
+        raise ValueError(
+            f"row range [{row_start}, {row_start + row_count}) is not a "
+            f"non-empty sub-range of [0, {seqlen})"
+        )
     n_groups = seqlen // ratio
 
-    out = paddle.empty([seqlen, n_groups], dtype="int32")
+    out = paddle.empty([row_count, n_groups], dtype="int32")
 
     BLOCK_G = min(triton.next_power_of_2(max(n_groups, 1)), 2048)
-    grid = (seqlen,)
+    grid = (row_count,)
     compressed_topk_idxs_kernel[grid](
         cds,
         pos,
@@ -753,6 +769,7 @@ def compressed_topk_idxs_triton(
         n_groups,
         ratio,
         offset,
+        row_start,
         BLOCK_G=BLOCK_G,
         num_warps=4,
     )

--- a/tests/multi_card_tests/transformer/test_hca_cp_optim.py
+++ b/tests/multi_card_tests/transformer/test_hca_cp_optim.py
@@ -1,0 +1,530 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Multi-card (CP=2) tests for the HCA context-parallel optimizations.
+
+The optimizations are HCA-only accelerations; CSA must keep running on the
+pre-existing global-all-gather path. This file checks both halves:
+
+  * ``all_gather_contiguous`` fuses any ``axis`` whose leading dims are 1 into a
+    single collective, and still matches the buffers-plus-concat result
+  * ``prepend_prev_window`` forward equals the global all-gather slice and its
+    backward routes the prefix gradient to the owning rank
+  * the HCA compressor's group-index sharding reproduces the global pooling,
+    while the CSA (overlap) compressor never enters the sharded path
+  * ``_forward_cp`` takes the one-hop window on HCA layers, and the global
+    all-gather branch it replaced still matches the same non-CP reference
+
+Run with:
+    python -m paddle.distributed.launch --gpus 0,1 \
+        tests/multi_card_tests/transformer/test_hca_cp_optim.py
+"""
+
+import contextlib
+import types
+import unittest
+
+import numpy as np
+import paddle
+import paddle.distributed as dist
+from paddle import nn
+from paddle.distributed import fleet
+from paddle.distributed.fleet.meta_parallel import LayerSpec
+
+import paddlefleet.transformer.csa_attention as csa_mod
+from paddlefleet.context_parallel_utils import all_gather_contiguous
+from paddlefleet.models.common.embeddings.rotary_pos_embedding import (
+    RotaryEmbedding,
+)
+from paddlefleet.transformer.cp_utils import all_gather_cp, prepend_prev_window
+from paddlefleet.transformer.csa_attention import (
+    CSA_MQA_RATIO,
+    CompressedSparseAttention,
+    CompressedSparseAttentionSublayersSpec,
+    Compressor,
+    CompressorSublayersSpec,
+    CSADocMaskMetadata,
+    CSAIndexer,
+    CSAIndexerSublayersSpec,
+)
+
+CP_SIZE = None
+CP_RANK = None
+CP_GROUP = None
+
+DTYPE = "float32"
+FWD_RTOL = 1e-6
+BWD_RTOL = 1e-4
+
+
+def setUpModule():
+    global CP_SIZE, CP_RANK, CP_GROUP
+    world = dist.get_world_size()
+    strategy = fleet.DistributedStrategy()
+    strategy.hybrid_configs = {
+        "dp_degree": 1,
+        "mp_degree": 1,
+        "pp_degree": 1,
+        "sharding_degree": world,
+        "sep_degree": 1,
+        "cp_degree": world,
+        "ep_degree": world,
+        "moe_sharding_degree": 1,
+        "order": [
+            "sharding",
+            "moe_sharding",
+            "pp",
+            "sep",
+            "cp",
+            "dp",
+            "ep",
+            "mp",
+        ],
+    }
+    fleet.init(is_collective=True, strategy=strategy)
+    CP_GROUP = fleet.get_hybrid_communicate_group().get_context_parallel_group()
+    CP_RANK = CP_GROUP.rank
+    CP_SIZE = CP_GROUP.nranks
+
+
+# ---------------------------------------------------------------------------
+# Stubs and helpers
+# ---------------------------------------------------------------------------
+class _TestLinear(nn.Layer):
+    def __init__(self, input_size, output_size, dtype=None, **kwargs):
+        super().__init__()
+        self.weight = self.create_parameter(
+            shape=[output_size, input_size],
+            dtype=dtype or DTYPE,
+            default_initializer=nn.initializer.Normal(std=0.02),
+        )
+
+    def forward(self, x):
+        return paddle.matmul(x, self.weight.T), None
+
+
+class _TestRMSNorm(nn.Layer):
+    def __init__(self, hidden_size=None, eps=1e-5, **kwargs):
+        super().__init__()
+        self.eps = eps
+        self.weight = self.create_parameter(
+            shape=[hidden_size],
+            dtype="float32",
+            default_initializer=nn.initializer.Constant(1.0),
+        )
+
+    def forward(self, x, **kwargs):
+        normed = x * paddle.rsqrt(x.square().mean(-1, keepdim=True) + self.eps)
+        return normed * self.weight.cast(x.dtype)
+
+
+_COMPRESSOR_SPEC = CompressorSublayersSpec(
+    linear_wkv=_TestLinear, linear_wgate=_TestLinear, norm=_TestRMSNorm
+)
+
+
+def _startend(doc_lens):
+    """``[1, 1, seqlen, 1]`` int32 exclusive document ends."""
+    rows, cum = [], 0
+    for length in doc_lens:
+        cum += length
+        rows += [cum] * length
+    return paddle.to_tensor(rows, dtype="int32").reshape([1, 1, len(rows), 1])
+
+
+def _meta(doc_lens, ratio):
+    startend = _startend(doc_lens)
+    return CSADocMaskMetadata.build(
+        ratio, 1, startend.shape[2], startend, dense_mode=False
+    )
+
+
+def _rel_err(actual, expected):
+    a = actual.cast("float32")
+    b = expected.cast("float32")
+    return ((a - b).norm() / (b.norm() + 1e-30)).item()
+
+
+def _local(x_global, sq):
+    """This rank's contiguous CP shard along the sequence axis."""
+    start = CP_RANK * sq
+    return x_global[:, start : start + sq]
+
+
+@contextlib.contextmanager
+def _trace_cp_comm():
+    """Record the CP collectives ``csa_attention`` issues during a forward."""
+    seen = {"gather": [], "prepend": []}
+    orig_gather, orig_prepend = (
+        csa_mod.all_gather_cp,
+        csa_mod.prepend_prev_window,
+    )
+
+    def gather(x, dim, group):
+        seen["gather"].append(list(x.shape))
+        return orig_gather(x, dim, group)
+
+    def prepend(x, window, group):
+        seen["prepend"].append((list(x.shape), window))
+        return orig_prepend(x, window, group)
+
+    csa_mod.all_gather_cp, csa_mod.prepend_prev_window = gather, prepend
+    try:
+        yield seen
+    finally:
+        csa_mod.all_gather_cp = orig_gather
+        csa_mod.prepend_prev_window = orig_prepend
+
+
+class TestAllGatherContiguousAxis(unittest.TestCase):
+    """Fused single-buffer all-gather for axes with all-ones leading dims."""
+
+    def _reference(self, x, axis):
+        bufs = [paddle.empty(x.shape, dtype=x.dtype) for _ in range(CP_SIZE)]
+        dist.stream.all_gather(
+            bufs, x.contiguous(), group=CP_GROUP, use_calc_stream=True
+        )
+        return paddle.concat(bufs, axis=axis)
+
+    def test_matches_buffers_plus_concat(self):
+        cases = (([8, 4], 0), ([1, 8, 4], 1), ([1, 1, 8, 4], 2), ([2, 8, 4], 1))
+        for shape, axis in cases:
+            paddle.seed(3 + CP_RANK)
+            x = paddle.randn(shape, dtype=DTYPE)
+            got = all_gather_contiguous(x, group=CP_GROUP, axis=axis)
+            expected_shape = list(shape)
+            expected_shape[axis] *= CP_SIZE
+            self.assertEqual(got.shape, expected_shape)
+            np.testing.assert_array_equal(
+                got.numpy(),
+                self._reference(x, axis).numpy(),
+                err_msg=f"shape={shape} axis={axis}",
+            )
+
+    def test_fused_branch_is_taken(self):
+        """One collective into one buffer when the leading dims are all 1."""
+        into_list = []
+        orig = dist.stream.all_gather
+
+        def spy(out, tensor, **kwargs):
+            into_list.append(isinstance(out, (list, tuple)))
+            return orig(out, tensor, **kwargs)
+
+        dist.stream.all_gather = spy
+        try:
+            all_gather_contiguous(
+                paddle.randn([1, 8, 4], dtype=DTYPE), group=CP_GROUP, axis=1
+            )
+            all_gather_contiguous(
+                paddle.randn([2, 8, 4], dtype=DTYPE), group=CP_GROUP, axis=1
+            )
+        finally:
+            dist.stream.all_gather = orig
+        self.assertEqual(into_list, [False, True])
+
+
+class TestPrependPrevWindowCP(unittest.TestCase):
+    """One-hop window exchange versus the global all-gather it replaces."""
+
+    def test_forward_matches_global_slice(self):
+        window, sq, d = 4, 16, 8
+        paddle.seed(7)
+        x_global = paddle.randn([1, sq * CP_SIZE, d], dtype=DTYPE)
+        x = _local(x_global, sq).clone()
+        out = prepend_prev_window(x, window, CP_GROUP)
+
+        self.assertEqual(out.shape, [1, window + sq, d])
+        start = CP_RANK * sq
+        if CP_RANK == 0:
+            expected = paddle.concat(
+                [paddle.zeros([1, window, d], dtype=DTYPE), x], axis=1
+            )
+        else:
+            expected = x_global[:, start - window : start + sq]
+        np.testing.assert_array_equal(out.numpy(), expected.numpy())
+
+    def test_backward_routes_prefix_grad_to_owner(self):
+        window, sq, d = 4, 16, 8
+        x = paddle.randn([1, sq, d], dtype=DTYPE)
+        x.stop_gradient = False
+        out = prepend_prev_window(x, window, CP_GROUP)
+        # rank-dependent upstream grad, so each contribution is identifiable
+        upstream = paddle.full(
+            [1, window + sq, d], float(CP_RANK + 1), dtype=DTYPE
+        )
+        (out * upstream).sum().backward()
+
+        expected = paddle.full([1, sq, d], float(CP_RANK + 1), dtype=DTYPE)
+        if CP_RANK < CP_SIZE - 1:
+            # the next rank sends back the gradient of the tail it borrowed
+            expected[:, -window:] += float(CP_RANK + 2)
+        np.testing.assert_array_equal(x.grad.numpy(), expected.numpy())
+
+
+class TestCompressorGroupSharding(unittest.TestCase):
+    """Pooling ``ceil(G / cp_size)`` groups per rank versus pooling all of them.
+
+    The reference is the pre-optimization path, reachable without touching the
+    network code: hand the compressor an already-gathered sequence and
+    ``cp_group=None``, which disables both its internal all-gathers and the
+    group sharding.
+    """
+
+    def _build(self, hidden_size, ratio, head_dim):
+        config = types.SimpleNamespace(
+            hidden_size=hidden_size,
+            qk_pos_emb_head_dim=0,
+            init_method=None,
+            init_method_std=0.02,
+            rms_norm_eps=1e-5,
+        )
+        return Compressor(
+            config=config,
+            sublayers_spec=_COMPRESSOR_SPEC,
+            compress_ratio=ratio,
+            head_dim=head_dim,
+            rotate=False,
+            rotary_pos_emb=None,
+        )
+
+    def _compare(self, ratio, doc_lens, expect_gathers):
+        sq_global = sum(doc_lens)
+        sq = sq_global // CP_SIZE
+        hidden_size, head_dim = 64, 32
+        meta = _meta(doc_lens, ratio)
+
+        paddle.seed(2026)
+        sharded = self._build(hidden_size, ratio, head_dim)
+        paddle.seed(2026)
+        reference = self._build(hidden_size, ratio, head_dim)
+
+        paddle.seed(11)
+        x_global = paddle.randn([1, sq_global, hidden_size], dtype=DTYPE)
+        x_a = _local(x_global, sq).clone()
+        x_a.stop_gradient = False
+        x_b = _local(x_global, sq).clone()
+        x_b.stop_gradient = False
+
+        with _trace_cp_comm() as seen:
+            out_a = sharded(x_a, cp_group=CP_GROUP, docmask_meta=meta)
+        self.assertEqual(len(seen["gather"]), expect_gathers)
+        if expect_gathers == 3:
+            n_shard = (meta.actual_n_compressed + CP_SIZE - 1) // CP_SIZE
+            self.assertEqual(seen["gather"][2][1], n_shard)
+
+        out_b = reference(
+            all_gather_cp(x_b, dim=1, group=CP_GROUP),
+            cp_group=None,
+            docmask_meta=meta,
+        )
+        # not bitwise: the reference projects sq_global rows in one matmul
+        self.assertLess(_rel_err(out_a, out_b), FWD_RTOL)
+
+        paddle.seed(5)
+        upstream = paddle.randn(out_a.shape, dtype=DTYPE)
+        (out_a * upstream).sum().backward()
+        (out_b * upstream).sum().backward()
+        self.assertLess(_rel_err(x_a.grad, x_b.grad), BWD_RTOL)
+
+    def test_hca_shards_divide_evenly(self):
+        self._compare(ratio=128, doc_lens=[512], expect_gathers=3)
+
+    def test_hca_last_shard_is_padded(self):
+        # 300 -> 2 groups, 212 -> 1 group: 3 groups over 2 ranks
+        self._compare(ratio=128, doc_lens=[300, 212], expect_gathers=3)
+
+    def test_csa_overlap_keeps_the_global_path(self):
+        # overlap pulls the previous group's projection, so groups cannot be
+        # split: the sharding must stay disabled and only kv/score are gathered
+        self._compare(ratio=4, doc_lens=[100, 156], expect_gathers=2)
+
+
+def _csa_config(ratio, window_size, hidden_size=256, head_dim=64):
+    return types.SimpleNamespace(
+        num_attention_heads=8,
+        v_head_dim=head_dim,
+        hidden_size=hidden_size,
+        q_lora_rank=64,
+        qk_pos_emb_head_dim=32,
+        csa_window_size=window_size,
+        csa_compress_ratios=[ratio],
+        csa_dense_mode=False,
+        dsa_index_n_heads=16,
+        dsa_index_head_dim=32,
+        dsa_index_topk=16,
+        dsa_indexer_loss_coeff=0.0,
+        dsa_indexer_use_sparse_loss=False,
+        csa_indexer_backend="unfused",
+        csa_sparse_attn_backend="unfused",
+        init_method=None,
+        init_method_std=0.02,
+        layernorm_epsilon=1e-5,
+        num_hidden_layers=1,
+    )
+
+
+def _build_csa(config, ratio, cp_enabled):
+    rope = RotaryEmbedding(32, rotary_percent=1.0, rotary_base=160000)
+    spec = CompressedSparseAttentionSublayersSpec(
+        compressor=LayerSpec(layer=Compressor, sublayers_spec=_COMPRESSOR_SPEC),
+        indexer=LayerSpec(
+            layer=CSAIndexer,
+            sublayers_spec=CSAIndexerSublayersSpec(
+                linear_wq_b=_TestLinear,
+                linear_weights_proj=_TestLinear,
+                compressor=LayerSpec(
+                    layer=Compressor, sublayers_spec=_COMPRESSOR_SPEC
+                ),
+            ),
+        ),
+    )
+    layer = CompressedSparseAttention(
+        config=config,
+        sublayers_spec=spec,
+        layer_number=1,
+        attn_mask_type=None,
+        attention_type="self",
+        k_channels=config.v_head_dim,
+        v_channels=config.v_head_dim,
+        compress_ratio=ratio,
+        rotary_pos_emb=rope,
+    )
+    layer.cp_group = CP_GROUP if cp_enabled else None
+    layer.cp_size = CP_SIZE if cp_enabled else 1
+    layer.cp_rank = CP_RANK if cp_enabled else 0
+    layer.cp_enabled = cp_enabled
+    return layer
+
+
+class TestHCAGate(unittest.TestCase):
+    """``is_hca_layer`` is the only switch, and it follows the compressor."""
+
+    def test_flag_follows_compressor_overlap(self):
+        for ratio, is_hca in ((128, True), (4, False)):
+            layer = _build_csa(_csa_config(ratio, 64), ratio, cp_enabled=True)
+            self.assertEqual(layer.compressor.overlap, not is_hca)
+            self.assertIs(layer.is_hca_layer, is_hca)
+
+    def test_mqa_layer_has_no_compressor_and_is_not_hca(self):
+        ratio = CSA_MQA_RATIO
+        layer = _build_csa(_csa_config(ratio, 64), ratio, cp_enabled=True)
+        self.assertIsNone(layer.compressor)
+        self.assertIs(layer.is_hca_layer, False)
+
+
+# 512 tokens over 2 ranks: 3 real compressed groups out of 4 slots, so the
+# compressor's group sharding also hits its padded tail here.
+_HCA_CASE = {"ratio": 128, "doc_lens": [300, 212], "window_size": 128}
+
+
+class TestForwardCPPathSelection(unittest.TestCase):
+    """``_forward_cp``: the fast window path and the path it replaced.
+
+    Both are compared against the same non-CP reference, so the ``else`` branch
+    is pinned to the pre-optimization behaviour rather than merely unused.
+    """
+
+    def _run(self, ratio, doc_lens, window_size, legacy=False):
+        sq_global = sum(doc_lens)
+        sq = sq_global // CP_SIZE
+        config = _csa_config(ratio, window_size)
+        head_dim = config.v_head_dim
+        meta = _meta(doc_lens, ratio)
+
+        paddle.seed(2026)
+        ref = _build_csa(config, ratio, cp_enabled=False)
+        paddle.seed(2026)
+        cp = _build_csa(config, ratio, cp_enabled=True)
+        if legacy:
+            # what a non-HCA layer runs: global KV all-gather, window ids left
+            # in global coordinates
+            cp.is_hca_layer = False
+
+        paddle.seed(1000)
+        shape = [1, sq_global, config.num_attention_heads, head_dim]
+        query = paddle.randn(shape, dtype=DTYPE)
+        key = paddle.randn([1, sq_global, 1, head_dim], dtype=DTYPE)
+        x = paddle.randn([1, sq_global, config.hidden_size], dtype=DTYPE)
+        qr = paddle.randn([1, sq_global, config.q_lora_rank], dtype=DTYPE)
+
+        def sides(tensors):
+            out = []
+            for t in tensors:
+                t = t.clone()
+                t.stop_gradient = False
+                out.append(t)
+            return out
+
+        q_r, k_r, x_r, qr_r = sides([query, key, x, qr])
+        out_ref = ref.forward(
+            q_r, k_r, k_r, None, x=x_r, qr=qr_r, docmask_meta=meta
+        )
+        out_ref.sum().backward()
+
+        q_c, k_c, x_c, qr_c = sides(
+            [_local(t, sq) for t in (query, key, x, qr)]
+        )
+        with _trace_cp_comm() as seen:
+            out_cp = cp.forward(
+                q_c, k_c, k_c, None, x=x_c, qr=qr_c, docmask_meta=meta
+            )
+        out_cp.sum().backward()
+
+        for p in cp.parameters():
+            if p.grad is not None:
+                grad = p.grad.contiguous()
+                dist.all_reduce(grad, group=CP_GROUP)
+                paddle.assign(grad, p.grad)
+
+        return {
+            "cp": cp,
+            "seen": seen,
+            "sq": sq,
+            "hn": head_dim,
+            "out": (out_cp, _local(out_ref, sq)),
+            "dq": (q_c.grad, _local(q_r.grad, sq)),
+            "dx": (x_c.grad, _local(x_r.grad, sq)),
+            "dwkv": (
+                cp.compressor.linear_wkv.weight.grad,
+                ref.compressor.linear_wkv.weight.grad,
+            ),
+        }
+
+    def _assert_close(self, got, tol=2e-2):
+        for name in ("out", "dq", "dx", "dwkv"):
+            actual, expected = got[name]
+            err = _rel_err(actual, expected)
+            self.assertLess(err, tol, f"{name} relative error {err:.3e}")
+
+    def test_hca_takes_the_one_hop_window(self):
+        got = self._run(**_HCA_CASE)
+        self.assertTrue(got["cp"].is_hca_layer)
+        # the raw KV crosses the wire once, window_size rows instead of a shard
+        self.assertEqual(
+            got["seen"]["prepend"], [([1, got["sq"], got["hn"]], 128)]
+        )
+        # only the compressor's kv/score/reassembly all-gathers are left
+        self.assertEqual(len(got["seen"]["gather"]), 3)
+        self._assert_close(got)
+
+    def test_legacy_path_still_matches_the_reference(self):
+        got = self._run(**_HCA_CASE, legacy=True)
+        self.assertEqual(got["seen"]["prepend"], [])
+        # the KV all-gather is back, on top of the compressor's three
+        self.assertEqual(len(got["seen"]["gather"]), 4)
+        self._assert_close(got)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/transformer/test_hca_cp_optim.py
+++ b/tests/single_card_tests/transformer/test_hca_cp_optim.py
@@ -1,0 +1,287 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Rank-local unit tests for the HCA context-parallel optimizations.
+
+The optimizations replace whole-sequence work with per-rank work. Every such
+replacement rests on a local invariant that can be checked without any
+collective:
+
+  * ``compressed_topk_idxs_triton`` row window == the same rows of the full
+    table, and the ``cp_size`` windows partition it exactly
+  * ``CSADocMaskMetadata.get_compress_topk_idxs`` caches on the row window too,
+    so a rank cannot be handed another rank's rows
+  * ``prepend_prev_window`` single-process path, and its one-hop range guard
+  * a sliding-window query reaches back at most ``window_size - 1`` rows, which
+    is what makes rebasing the column ids onto the short ``kv_full`` exact
+  * every ``ratio``-slot group of ``cutoff_gather_indices`` is a contiguous run
+    inside one document, which is what makes group-index sharding exact
+"""
+
+import unittest
+
+import numpy as np
+import paddle
+
+from paddlefleet.transformer.cp_utils import (
+    get_window_topk_idxs_cp,
+    prepend_prev_window,
+)
+from paddlefleet.transformer.csa_attention import CSADocMaskMetadata
+from paddlefleet.triton_ops.document_mask_fusion import (
+    compressed_doc_start_triton,
+    compressed_topk_idxs_triton,
+)
+
+# All regimes pack to seqlen 32: exact multiples of the ratio, remainders on
+# either side of a group boundary, single-token documents, trailing padding.
+REGIMES = [
+    ([32], 0),
+    ([16, 16], 0),
+    ([13, 19], 0),
+    ([5, 14, 3, 8], 2),
+    ([1, 1, 30], 0),
+    ([31], 1),
+]
+
+
+def _startend(doc_lens, pad):
+    """``[1, 1, seqlen, 1]`` int32 exclusive ends; padding repeats the last."""
+    rows, cum = [], 0
+    for length in doc_lens:
+        cum += length
+        rows += [cum] * length
+    rows += [cum] * pad
+    return paddle.to_tensor(rows, dtype="int32").reshape([1, 1, len(rows), 1])
+
+
+def _meta(doc_lens, pad, ratio):
+    startend = _startend(doc_lens, pad)
+    return CSADocMaskMetadata.build(
+        ratio, 1, startend.shape[2], startend, dense_mode=False
+    )
+
+
+def _topk_rows(meta, ratio, offset, row_start, row_count):
+    cds = compressed_doc_start_triton(
+        meta.startend_row_indices.flatten(), meta.doc_start_per_pos, ratio
+    )
+    return compressed_topk_idxs_triton(
+        cds,
+        meta.pos_in_doc,
+        meta.doc_len_per_pos,
+        ratio,
+        offset,
+        row_start=row_start,
+        row_count=row_count,
+    )
+
+
+class TestCompressedTopkIdxsRowWindow(unittest.TestCase):
+    """Row windows of the compressed-topk table."""
+
+    def test_window_equals_full_slice(self):
+        for doc_lens, pad in REGIMES:
+            for ratio in (4, 8):
+                meta = _meta(doc_lens, pad, ratio)
+                s = meta.seqlen
+                full = _topk_rows(meta, ratio, 100, 0, None)
+                self.assertEqual(full.shape, [1, s, s // ratio])
+                windows = [(0, s), (0, 1), (s - 1, 1), (3, 5), (s // 2, s // 2)]
+                for row_start, row_count in windows:
+                    win = _topk_rows(meta, ratio, 100, row_start, row_count)
+                    np.testing.assert_array_equal(
+                        win.numpy(),
+                        full[:, row_start : row_start + row_count].numpy(),
+                        err_msg=(
+                            f"docs={doc_lens} pad={pad} ratio={ratio} "
+                            f"rows=[{row_start}, {row_start + row_count})"
+                        ),
+                    )
+
+    def test_cp_shards_partition_the_full_table(self):
+        for doc_lens, pad in REGIMES:
+            meta = _meta(doc_lens, pad, 4)
+            full = _topk_rows(meta, 4, 0, 0, None)
+            for cp_size in (2, 4, 8):
+                sq = meta.seqlen // cp_size
+                shards = [
+                    _topk_rows(meta, 4, 0, rank * sq, sq)
+                    for rank in range(cp_size)
+                ]
+                np.testing.assert_array_equal(
+                    paddle.concat(shards, axis=1).numpy(),
+                    full.numpy(),
+                    err_msg=f"docs={doc_lens} pad={pad} cp_size={cp_size}",
+                )
+
+    def test_row_range_guard(self):
+        meta = _meta([32], 0, 4)
+        for row_start, row_count in ((-1, 4), (0, 0), (30, 4), (32, 1)):
+            with self.assertRaises(ValueError):
+                _topk_rows(meta, 4, 0, row_start, row_count)
+
+
+class TestCompressTopkIdxsCache(unittest.TestCase):
+    """The metadata cache must key on the row window, not only the offset."""
+
+    def test_cache_key_covers_offset_and_row_window(self):
+        meta = _meta([13, 19], 0, 4)
+        n_comp = meta.seqlen // 4
+        full = meta.get_compress_topk_idxs(0).clone()
+
+        win = meta.get_compress_topk_idxs(0, row_start=8, row_count=8)
+        self.assertEqual(win.shape, [1, 8, n_comp])
+        np.testing.assert_array_equal(win.numpy(), full[:, 8:16].numpy())
+
+        # same rows, different offset: the valid slots must shift, -1 stays -1
+        shifted = meta.get_compress_topk_idxs(1000, row_start=8, row_count=8)
+        np.testing.assert_array_equal(
+            paddle.where(win >= 0, win + 1000, win).numpy(), shifted.numpy()
+        )
+        # identical key hits the cache
+        self.assertIs(shifted, meta.get_compress_topk_idxs(1000, 8, 8))
+        # same offset, other rows: a cache hit here would hand this rank
+        # another rank's queries
+        other = meta.get_compress_topk_idxs(1000, 0, 8)
+        np.testing.assert_array_equal(
+            other.numpy(),
+            paddle.where(full >= 0, full + 1000, full)[:, 0:8].numpy(),
+        )
+
+
+class TestPrependPrevWindowLocal(unittest.TestCase):
+    """Single-process behaviour and the one-hop range guard."""
+
+    def test_zeros_prefix_and_gradient(self):
+        x = paddle.randn([2, 8, 4], dtype="float32")
+        x.stop_gradient = False
+        out = prepend_prev_window(x, 3, None)
+        self.assertEqual(out.shape, [2, 11, 4])
+        np.testing.assert_array_equal(
+            out[:, :3].numpy(), np.zeros([2, 3, 4], "float32")
+        )
+        np.testing.assert_array_equal(out[:, 3:].numpy(), x.numpy())
+        (out * 2).sum().backward()
+        np.testing.assert_array_equal(
+            x.grad.numpy(), np.full([2, 8, 4], 2.0, "float32")
+        )
+
+    def test_zero_window_is_identity(self):
+        x = paddle.randn([1, 4, 2], dtype="float32")
+        self.assertIs(prepend_prev_window(x, 0, None), x)
+
+    def test_window_beyond_one_shard_raises(self):
+        x = paddle.randn([1, 4, 2], dtype="float32")
+        with self.assertRaises(ValueError):
+            prepend_prev_window(x, 5, None)
+
+
+class TestWindowReachAndRebase(unittest.TestCase):
+    """``kv_full`` may start at ``position_offset - window_size``."""
+
+    def _assert_reachable(self, idxs, positions, window, offset, sq):
+        idxs = idxs.astype("int64")
+        valid = idxs >= 0
+        pos = positions.reshape([1, -1, 1])
+        in_reach = (idxs >= pos - (window - 1)) & (idxs <= pos)
+        self.assertTrue(bool((in_reach | ~valid).all()))
+
+        rebased = paddle.where(valid, idxs - (offset - window), idxs)
+        in_kv_full = (rebased >= 0) & (rebased < window + sq)
+        self.assertTrue(bool((in_kv_full | (rebased == -1)).all()))
+
+    def test_causal_window(self):
+        sq_global, window = 64, 16
+        for cp_size in (2, 4):
+            sq = sq_global // cp_size
+            for rank in range(cp_size):
+                offset = rank * sq
+                positions = paddle.arange(offset, offset + sq, dtype="int64")
+                self._assert_reachable(
+                    get_window_topk_idxs_cp(positions, window, 1, sq_global),
+                    positions,
+                    window,
+                    offset,
+                    sq,
+                )
+
+    def test_document_window(self):
+        window, cp_size = 8, 4
+        for doc_lens, pad in REGIMES:
+            meta = _meta(doc_lens, pad, 4)
+            full = meta.get_window_topk_idxs(window)
+            sq = meta.seqlen // cp_size
+            for rank in range(cp_size):
+                offset = rank * sq
+                positions = paddle.arange(offset, offset + sq, dtype="int64")
+                self._assert_reachable(
+                    full[:, offset : offset + sq],
+                    positions,
+                    window,
+                    offset,
+                    sq,
+                )
+
+
+class TestCutoffGroupGeometry(unittest.TestCase):
+    """Group-index sharding of ``cutoff_gather_indices``."""
+
+    def test_groups_are_contiguous_runs_inside_one_document(self):
+        for doc_lens, pad in REGIMES:
+            for ratio in (4, 8):
+                meta = _meta(doc_lens, pad, ratio)
+                idxs = meta.cutoff_gather_indices.astype("int64")
+                n = meta.actual_n_compressed
+                self.assertEqual(idxs.shape[0], n * ratio)
+                self.assertTrue(bool((idxs[1:] > idxs[:-1]).all()))
+
+                groups = idxs.reshape([n, ratio]).numpy()
+                doc_start = meta.doc_start_per_pos.numpy()
+                for group in groups:
+                    np.testing.assert_array_equal(
+                        group, np.arange(group[0], group[0] + ratio)
+                    )
+                    self.assertEqual(len(set(doc_start[group].tolist())), 1)
+
+    def test_group_shards_reassemble_in_dense_order(self):
+        ratio = 4
+        for doc_lens, pad in REGIMES:
+            meta = _meta(doc_lens, pad, ratio)
+            idxs = meta.cutoff_gather_indices
+            n = meta.actual_n_compressed
+            for cp_size in (2, 4, 8):
+                n_shard = (n + cp_size - 1) // cp_size
+                shards = []
+                for rank in range(cp_size):
+                    start = rank * n_shard * ratio
+                    shard = idxs[start : start + n_shard * ratio]
+                    pad_len = n_shard * ratio - shard.shape[0]
+                    if pad_len > 0:
+                        shard = paddle.concat(
+                            [
+                                shard,
+                                paddle.zeros([pad_len], dtype=shard.dtype),
+                            ]
+                        )
+                    shards.append(shard)
+                np.testing.assert_array_equal(
+                    paddle.concat(shards)[: n * ratio].numpy(),
+                    idxs.numpy(),
+                    err_msg=f"docs={doc_lens} pad={pad} cp_size={cp_size}",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_configs.yaml
+++ b/tests/test_configs.yaml
@@ -162,6 +162,10 @@ tests:
   - test_case: [tests/multi_card_tests/transformer/test_csa_attention_cp.py]
     products:
       - num_gpus: 2
+  # transformer: HCA context-parallel optimizations (CP=2)
+  - test_case: [tests/multi_card_tests/transformer/test_hca_cp_optim.py]
+    products:
+      - num_gpus: 2
   # transformer: KDA context-parallel (packed varlen split across CP=4 ranks)
   - test_case: [tests/multi_card_tests/transformer/test_kimi_delta_attention_cp.py]
     products:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
Performance Optimization


### PR Types
Performance


### Description
优化 HCA CP 通信操作：
- HCA 只需要从前一个 rank 收 window size 大小的 token chunk 即可（其实是 window_size - 1，但是为了凑齐2的幂次，保留 window_size）。类似 SWAP2P layer。

优化本地计算操作：
- topk indices 的生成不再【先生成全量再切】
- HCA compression 不再全量压缩，而是先切，再用一个小的 allgather 将压缩 tokens 取回来。 （这部分会引起 compressor backward 精度变化，数学上是零偏的）。

优化 batch = 1 下的 allgather 通信：
- B=1 情况下，通信轴如果前序的所有 shape value 都是 1 （例如 [1, 1, 1, 128, 128] 在前三个轴任意一个位置通信），其实都等价于 axis = 0 的 pass。axis = 0 通信用的是 NCCL 直接对 tensor 发起的 allgather 而非切 list of tensors，更快。 

### 是否引起精度变化
是
