### PR TITLE
[BugFix] Pad the tilelang MQA backward heads up to the kernel tile

### DIFF
--- a/src/paddlefleet/tilelang_ops/attn/mqa_latent_sparse_bwd.py
+++ b/src/paddlefleet/tilelang_ops/attn/mqa_latent_sparse_bwd.py
@@ -102,6 +102,11 @@ from paddlefleet.tilelang_ops.attn.sparse_mqa_bwd import (
 
 _LOG2E = 1.4426950408889634
 
+# Sink logit for pad heads: ``exp2(sink * log2e - lse)`` underflows to 0, so a
+# padded head can contribute nothing to ``d_sink``. Same value the sinkless
+# contract uses in ``fusions/mqa_sparse_attn.py``.
+_NEG_SINK = -1e30
+
 # ``bwd_det`` requires ``topk % _BLOCK_SIZE == 0`` (sparse_mqa_bwd.py:336) and
 # ``preprocess`` tiles S by 32, so every chunk length must be a multiple of this.
 _BLOCK_SIZE = 32
@@ -141,20 +146,40 @@ def _pick_chunk(b, s, topk, dk, budget_bytes):
 
 
 def _pick_block_h(h):
-    """Largest power-of-two head-group width that divides ``h``, capped at 32.
+    """Head-group width for ``bwd_det``: 32 when it divides ``h``, else 16.
 
-    ``bwd_det`` needs ``block_h == padded_H`` (its ``dKV_buf`` store is a plain
-    write, so its head-group grid dim must stay 1) and shared memory caps that
-    at 32 for ``Dk = 576``. Smaller widths are legal and measured just as
-    accurate, so a head count the cuDNN backward accepts (anything
-    ``h <= 64``) must not become a hard error here only because 32 does not
-    divide it: per-rank counts of 8 or 16 are what the hybrid-MLA fixtures and
-    any TP > 2 split produce.
+    ``bwd_det`` derives its own tile from the ``H`` it is given --
+    ``padded_H = max(next_power_of_2(H), 16)`` and ``block_H = min(64,
+    padded_H)`` (``sparse_mqa_bwd.py:352``) -- and then copies
+    ``Q[b, s, 0:block_H, :]`` / stores ``dQ[b, s, 0:block_H, :]``. So a group
+    width below 16 does **not** make the kernel read fewer heads: at
+    ``block_h = 8`` it still moves 16 heads, i.e. it reads and *writes* 8 heads
+    past the end of an 8-head tensor. Only 16 and 32 satisfy
+    ``block_h == padded_H``; head counts that are not a multiple of the chosen
+    width are zero-padded by the caller instead (see ``_pad_heads``), which is
+    how ``h = 8`` -- the per-rank count the hybrid-MLA fixtures and any TP > 4
+    split produce -- stays supported.
+
+    32 is preferred where it fits because it halves the number of launches and
+    the score recomputation; the docstring's timings were measured with it.
     """
-    for cand in (32, 16, 8, 4, 2):
-        if h % cand == 0:
-            return cand
-    return 1
+    return 32 if h % 32 == 0 else 16
+
+
+def _pad_heads(x, h_pad, fill=0):
+    """``fill``-pad ``x`` along its head axis (the last or second-to-last).
+
+    ``[b, s, h, d]`` and ``[b, s, h]`` both pad on ``h``; ``[h]`` (the sink)
+    pads on its only axis.
+    """
+    axis = 2 if x.ndim == 4 else (x.ndim - 1)
+    pad_shape = list(x.shape)
+    pad_shape[axis] = h_pad - x.shape[axis]
+    if pad_shape[axis] == 0:
+        return x
+    return paddle.concat(
+        [x, paddle.full(pad_shape, fill, dtype=x.dtype)], axis=axis
+    )
 
 
 def _reduce_threads(dk):
@@ -205,11 +230,15 @@ def mqa_latent_sparse_bwd(
         token_indices: ``[B, S, L]`` int32 per-batch-local key columns, ``-1``
                        for invalid. Width is padded to a multiple of 32 here.
         sm_scale:      softmax scale applied to the raw ``q.k`` logits.
-        block_h:       query heads per kernel launch. Must divide ``H``. Bounded
-                       by shared memory: three ``[block_h, Dk]`` bf16 buffers
-                       plus ``[32, Dk]`` for the gathered latent must fit, which
-                       at ``Dk=576`` rules out 64. ``None`` (default) picks the
-                       largest power of two that divides ``H``, capped at 32.
+        block_h:       query heads per kernel launch, 16 or 32 -- the two widths
+                       for which ``bwd_det``'s own
+                       ``padded_H = max(next_power_of_2(H), 16)`` equals what it
+                       is handed (32 is the upper bound: three
+                       ``[block_h, Dk]`` bf16 buffers plus ``[32, Dk]`` for the
+                       gathered latent must fit shared memory, which at
+                       ``Dk=576`` rules out 64). ``H`` need not be a multiple of
+                       it -- the head axis is zero-padded here. ``None``
+                       (default) picks 32 when it divides ``H``, else 16.
         dkv_buf_bytes: byte budget for the per-slot fp32 gradient buffer, which
                        sets the query-row chunk length.
 
@@ -244,8 +273,12 @@ def mqa_latent_sparse_bwd(
         raise ValueError(
             f"token_indices {token_indices.shape} != [{b}, {s}, L]"
         )
-    if h % block_h:
-        raise ValueError(f"H ({h}) must be divisible by block_h ({block_h})")
+    if block_h not in (16, 32):
+        raise ValueError(
+            f"block_h must be 16 or 32, got {block_h}: ``bwd_det`` rounds its "
+            "tile up to max(next_power_of_2(H), 16), so any other width makes "
+            "the kernel move more heads than the tensors hold"
+        )
     # The reused kernels are JIT-specialised on bf16 and assert it internally
     # (``sparse_mqa_bwd.py:33,86,129,337``), so a caller in an fp16 run would
     # otherwise land on a bf16 kernel reading fp16 memory -- silently wrong, or
@@ -298,7 +331,22 @@ def mqa_latent_sparse_bwd(
     sc = _pick_chunk(b, s, topk, dk, dkv_buf_bytes)
     n_chunks = (s + sc - 1) // sc
     s_pad = n_chunks * sc
-    n_hg = h // block_h
+    # Pad the head axis to a whole number of groups. ``bwd_det`` moves
+    # ``block_h`` heads per launch whatever the tensors hold (see
+    # ``_pick_block_h``), so a head count below the group width -- ``h = 8`` on
+    # the fixtures, anything from a TP split -- must be padded here rather than
+    # left for the kernel to read past. The pad heads are inert: q and dO are
+    # zero, so ``dP`` and both ``dKV`` terms vanish, and ``Delta`` is zero, so
+    # ``d_sink`` is too; only their ``dq`` rows are garbage and those are sliced
+    # off before returning.
+    h_pad = (h + block_h - 1) // block_h * block_h
+    n_hg = h_pad // block_h
+    if h_pad != h:
+        query = _pad_heads(query, h_pad)
+        grad_out = _pad_heads(grad_out, h_pad)
+        delta = _pad_heads(delta, h_pad)
+        lse_tl = _pad_heads(lse_tl, h_pad)
+        sink32 = _pad_heads(sink32, h_pad, fill=_NEG_SINK)
 
     # Pad the query axis up to a whole number of chunks once, so the loop body is
     # uniform (one JIT variant, one reusable buffer) and the tail needs no
@@ -335,7 +383,7 @@ def mqa_latent_sparse_bwd(
     dkv_buf = paddle.empty([b, sc, topk, dk], dtype="float32")
     dsink_buf = paddle.empty([sc, b, block_h], dtype="float32")
 
-    dq = paddle.empty([b, s, h, dk], dtype=query.dtype)
+    dq = paddle.empty([b, s, h_pad, dk], dtype=query.dtype)
     dkv_f32 = paddle.zeros([b, s_kv, dk], dtype="float32")
     dsink_parts = [None] * n_hg
 
@@ -366,4 +414,10 @@ def mqa_latent_sparse_bwd(
                 part if dsink_parts[g] is None else dsink_parts[g] + part
             )
 
-    return dq, cast_kernel(dkv_f32), paddle.concat(dsink_parts).contiguous()
+    # Slice the pad heads back off: their ``dq`` rows are zeros the caller must
+    # not see, and ``d_sink`` carries one entry per real head.
+    d_sink = paddle.concat(dsink_parts)
+    if h_pad != h:
+        dq = dq[:, :, :h, :]
+        d_sink = d_sink[:h]
+    return dq.contiguous(), cast_kernel(dkv_f32), d_sink.contiguous()

--- a/tests/single_card_tests/transformer/test_mqa_latent_sparse_bwd.py
+++ b/tests/single_card_tests/transformer/test_mqa_latent_sparse_bwd.py
@@ -443,10 +443,34 @@ class TestKernelTiling(_Base):
                     q_t, kv_t, o_t, do_t, lse, sink, ti_t, float(SM)
                 )
 
-    def test_block_h_must_divide_the_head_count(self):
+    def test_only_the_kernels_own_tile_widths_are_accepted(self):
+        # 8 is the dangerous one: ``bwd_det`` would round its tile up to 16 and
+        # move 16 heads through 8-head tensors, i.e. an out-of-bounds ``dQ``
+        # store. 48 is simply not a tile width. Both must be refused rather than
+        # silently corrupting memory.
         q, kv, ti, dO = _inputs(H_SMALL, 32, 32, 530)
-        with self.assertRaisesRegex(ValueError, "divisible by block_h"):
-            _kernel_run(q, kv, ti, dO, 0.25, block_h=48)
+        for bad in (8, 48, 64):
+            with (
+                self.subTest(block_h=bad),
+                self.assertRaisesRegex(ValueError, "block_h must be 16 or 32"),
+            ):
+                _kernel_run(q, kv, ti, dO, 0.25, block_h=bad)
+
+    def test_head_count_below_the_tile_is_padded_not_truncated(self):
+        # h=8 (the fixture / TP-split count) and h=24 both need padding up to a
+        # multiple of the 16-wide tile. The pad heads must be inert -- q and dO
+        # are zero there, so they add nothing to dkv or d_sink -- and must not
+        # leak into the returned shapes.
+        for h in (8, 24):
+            with self.subTest(h=h):
+                q, kv, ti, dO = _inputs(h, 64, 64, 560 + h)
+                dq, dkv, dsink = _kernel_run(q, kv, ti, dO, 0.25)
+                self.assertEqual(dq.shape, (64, h, DK))
+                self.assertEqual(dkv.shape, (64, DK))
+                self.assertEqual(dsink.shape, (h,))
+                self._assert_matches_reference(
+                    (dq, dkv, dsink), q, kv, ti, dO, 0.25
+                )
 
     def test_shape_guards_raise_valueerror_not_assert(self):
         # ``python -O`` strips ``assert``, and these guard a TileLang JIT
@@ -570,21 +594,24 @@ class TestHostHelpers(unittest.TestCase):
         self.assertEqual(sc, 32)
         self.assertNotEqual(100 % sc, 0)
 
-    def test_pick_block_h_divides_every_legal_head_count(self):
-        # The cuDNN backward takes any ``h <= 64``; the group width must too,
-        # and stay within the 32 the shared-memory budget allows.
+    def test_pick_block_h_never_goes_below_the_kernel_tile(self):
+        # ``bwd_det`` rounds its own tile up to ``max(next_power_of_2(H), 16)``
+        # and then moves that many heads whatever the tensors hold, so a group
+        # width below 16 would read -- and store ``dQ`` -- past the end of the
+        # buffers. Only 16 and 32 are safe; head counts that are not a multiple
+        # of the width get zero-padded by the caller instead.
         for h in range(1, _DSA_HEADS + 1):
             bh = _pick_block_h(h)
             with self.subTest(h=h):
-                self.assertEqual(h % bh, 0)
-                self.assertLessEqual(bh, 32)
-                self.assertGreaterEqual(bh, 1)
+                self.assertIn(bh, (16, 32))
+                if bh == 32:
+                    self.assertEqual(h % 32, 0)
         self.assertEqual(_pick_block_h(64), 32)
+        self.assertEqual(_pick_block_h(32), 32)
         self.assertEqual(_pick_block_h(48), 16)
-        self.assertEqual(_pick_block_h(24), 8)
-        self.assertEqual(_pick_block_h(8), 8)
-        # Odd head counts fall back to one head per launch rather than raising.
-        self.assertEqual(_pick_block_h(7), 1)
+        self.assertEqual(_pick_block_h(24), 16)
+        self.assertEqual(_pick_block_h(8), 16)
+        self.assertEqual(_pick_block_h(7), 16)
 
     def test_reduce_threads_divides_dk(self):
         # ``dkv_reduce`` maps ``T.Parallel(Dk)`` onto threads and its layout


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Distributed Strategy

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复 #1776 引入的 `mqa_latent_sparse_bwd` 在每卡 head 数小于 16 时的越界访问（release/0.4 侧的同一修复见 #1683）。

**问题**：`bwd_det` 的 tile 不由调用方决定，它自己算 `padded_H = max(next_power_of_2(H), 16)`、`block_H = min(64, padded_H)`（`sparse_mqa_bwd.py:352-353`），然后无条件 `T.copy(Q[b, s, 0:block_H, :])` 并 `T.copy(dQ_shared, dQ[b, s, 0:block_H, :])`。原来的 `_pick_block_h` 会为 `h = 8` 选出 group 宽度 8，kernel 却仍按 16 个 head 搬运：在 8-head 的 `Q` / `Lse` / `Delta` 上越界读，并且**越界写 `dQ`** —— 而 `dq` 只按 `[b, s, 8, dk]` 分配，属于显存破坏。`h = 8` 是 hybrid-MLA 单测 fixture 以及 TP > 4 每卡的 head 数，`h = 24 / 40` 同样会落到小于 16 的宽度。

**修法**（不改 kernel）：把 group 宽度限制为 `bwd_det` 的 tile 恰好等于入参的两个值 16 / 32，`H` 不是其倍数时由 wrapper 在 head 轴零填充，跑完再切回。

- `_pick_block_h(h)` → `32 if h % 32 == 0 else 16`；显式传入 8 / 48 / 64 直接 `ValueError`；
- `h_pad = ceil(h / block_h) * block_h`，对 `query` / `grad_out` / `delta` / `lse_tl` 补 0、`attn_sink` 补 `-1e30`；`dq` 按 `h_pad` 分配，返回前切成 `[b, s, h, dk]`，`d_sink` 切成 `[h]`。

填充 head 是惰性的：q 与 dO 为 0 ⇒ `dP = P * (dO·KV - Delta) * scale = 0`，`dKV` 的 `dP^T·Q` 与 `P^T·dO` 两项皆为 0；`Delta = 0` ⇒ `d_sink = -Delta * exp2(...) = 0`。只有填充 head 的 `dq` 行无意义，返回前被切掉。

**测试**：新增 `test_only_the_kernels_own_tile_widths_are_accepted`（8 / 48 / 64 必须报错）与 `test_head_count_below_the_tile_is_padded_not_truncated`（`h = 8` 与 `h = 24` 走填充路径，校验返回 shape 精确为 `[s, h, DK]` / `[h]` 且与 fp32 参考一致）；`_pick_block_h` 的用例改为遍历 `1..64` 断言结果只能是 16 或 32。本地实测：`test_mqa_latent_sparse_bwd.py` 25 passed / 119 subtests、`test_mqa_latent_attention.py` 64 passed、`test_fused_sink_grad.py` 21 passed。

注：原先 `h = 8` 的用例能通过是因为它只比较前 `h` 个 head 的梯度，而越界写落在分配之外的显存里，既不改变被比较的数值也不必然崩溃 —— 数值断言对这类问题无效，因此改为同时校验 shape 与拒绝非法 tile 宽度。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否

`backward_backend` 默认仍为 `cudnn`，不走本文件；tilelang 路径在 `h` 为 16 / 32 的倍数时行为与修复前一致（同样的 group 宽度、同样的求和顺序），仅 `h` 不是 16 倍数时从「越界」变为「填充后正确」。
