### PR TITLE
[Improvements] remove fastdeploy dynamic_infer fallback branch

### DIFF
--- a/src/paddlefleet/transformer/multi_latent_attention.py
+++ b/src/paddlefleet/transformer/multi_latent_attention.py
@@ -1909,12 +1909,6 @@ class MLASelfAttention(MultiLatentAttention):
                     cp_size,
                 )
 
-                # dynamic_inference not supported for now
-                if not self.training:
-                    raise NotImplementedError(
-                        "apply_rope_fusion does not support dynamic inference yet."
-                    )
-
                 k_pe = None
             else:
                 # Determine seq length:

--- a/tests/single_card_tests/transformer/test_mla_ec_rope_and_absorbed_q.py
+++ b/tests/single_card_tests/transformer/test_mla_ec_rope_and_absorbed_q.py
@@ -921,48 +921,6 @@ class TestApplyRopeFusionNotSupportedInference(unittest.TestCase):
     test would stop raising.
     """
 
-    def test_apply_rope_fusion_raises_in_eval(self):
-        """apply_rope_fusion=True in eval mode should raise NotImplementedError."""
-        model, config = _build_gpt_model(
-            gpt_model_use_experimental_version=False
-        )
-        # Enable apply_rope_fusion on all MLA layers
-        for sublayer in model.sublayers():
-            if hasattr(sublayer, "config") and hasattr(
-                sublayer.config, "apply_rope_fusion"
-            ):
-                sublayer.config.apply_rope_fusion = True
-
-        model.eval()
-
-        sequence_length = 16
-        micro_batch_size = 2
-        input_ids = paddle.randint(
-            0, config.vocab_size, [micro_batch_size, sequence_length]
-        )
-        position_ids = (
-            paddle.arange(sequence_length, dtype=paddle.int64)
-            .unsqueeze(0)
-            .expand([micro_batch_size, sequence_length])
-        )
-        attention_mask = paddle.ones(
-            (micro_batch_size, 1, sequence_length, sequence_length), dtype=bool
-        )
-
-        dict_args = {
-            "input_ids": input_ids,
-            "position_ids": position_ids,
-            "attention_mask": attention_mask,
-        }
-
-        with self.assertRaises(NotImplementedError) as ctx:
-            model(dict_args)
-
-        self.assertIn(
-            "apply_rope_fusion does not support dynamic inference yet",
-            str(ctx.exception),
-        )
-
     def test_apply_rope_fusion_train_mode(self):
         """apply_rope_fusion=True in train mode should succeed and set k_pe=None (L1000)."""
         model, config = _build_gpt_model(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Distributed Strategy

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
允许eval+prefill模式下 mla 应用 rope_fusion，之前if not training控制面太广，缩小为只在eval+decode下raise error

Merged in dev: #1787 
### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否