### PR TITLE
[MoE] 新增 MoE 配置校验：字段归属登记表 + 路由推导 + 启动期诊断报告

### DIFF
--- a/src/paddlefleet/transformer/moe/moe_config_check.py
+++ b/src/paddlefleet/transformer/moe/moe_config_check.py
@@ -1,0 +1,1264 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""MoE 配置检查: 路由推导、可判定规则、诊断报告与构造期入口。
+
+MoE 会按路由决策(EP size、dispatcher 类型、expert 组合、精度、设备算力)只读取配置
+字段的一个子集。归属于其他路径的字段配了也不会被读取, 而目前没有任何机制会告诉用
+户这件事。本模块就是那个机制, 归属数据在 ``moe_config_registry`` 里。
+
+按处理顺序分四段:
+
+1. **路由推导** ``resolve_moe_plan()``: ``MoELayer.__init__`` 路由决策的只读镜像,
+   输入 config 加上驱动决策的两个环境事实(EP size、设备算力), 输出命中了哪些子模块
+   以及过程中改写了哪些字段。它不建任何东西、不改任何东西, 因此能在建层之前跑, 也
+   能在 CPU 上覆盖任何单机装不出来的组合。
+2. **可判定规则** ``MOE_CONFIG_RULES``: 登记表里的 ``requires`` / ``conflicts`` 是
+   自由文本无法求值, 这里把其中**已对照源码核实**的部分写成可执行规则, 每条标注源
+   码位置。相当一部分组合现有代码已经会报错, 只是报得晚(构造到一半、甚至跑到
+   forward)且一次只报一个; 把它们前移到配置阶段并一次报全是主要价值。
+3. **诊断报告** ``collect_findings()`` / ``format_report()``: 把计划与登记表对起
+   来, 一次性给出全部结论。
+4. **构造期入口** ``run_moe_config_check()``: 由
+   ``TransformerConfig.__post_init__`` 调用, 三种模式见 ``MOE_CONFIG_CHECK_MODES``。
+
+两个贯穿全模块的约定:
+
+* **只有用户显式配置过的字段才参与诊断。** config 对象本身分不清"用户配的"和"框架
+  默认值"(上游 PretrainedConfig 会把自身默认值一并灌进去, 实测约五成 MoE 字段会被
+  误判), 所以显式字段集合必须由调用方传入; 拿不到时自动降级为只打印执行计划。
+* **本模块不修改 config, 也不参与任何计算。** 除 strict 模式下抛
+  ``MoEConfigError`` 之外没有任何副作用。
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from ..activations import situ
+from .moe_config_registry import MOE_FIELD_REGISTRY, Policy, Status
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    # 路由推导
+    "Adjustment",
+    "MoEPlan",
+    "resolve_moe_plan",
+    "VALID_DISPATCHER_TYPES",
+    # 可判定规则
+    "Rule",
+    "MOE_CONFIG_RULES",
+    "evaluate_rules",
+    # 诊断报告
+    "Finding",
+    "MoEConfigError",
+    "STATUS_LABELS",
+    "collect_findings",
+    "format_report",
+    "format_errors",
+    # 构造期入口
+    "run_moe_config_check",
+    "MOE_CONFIG_CHECK_MODES",
+]
+
+
+# ======================================================================
+# 路由推导: MoELayer.__init__ 路由决策的只读镜像
+# ======================================================================
+
+VALID_DISPATCHER_TYPES = ("allgather", "alltoall", "deepep", "hybridep")
+
+
+@dataclass(frozen=True)
+class Adjustment:
+    """一个生效值与配置请求值不一致的字段。"""
+
+    name: str
+    requested: object
+    effective: object
+    reason: str
+
+    def __str__(self):
+        return f"{self.name}: {self.requested!r} -> {self.effective!r} ({self.reason})"
+
+
+@dataclass(frozen=True)
+class MoEPlan:
+    """一份配置最终落到的子模块组合, 以及为此付出的改写代价。"""
+
+    expert_parallel_size: int
+
+    dispatcher: str | None
+    """选中的 dispatcher; EP <= 1 时为 None, 表示根本没有 dispatcher 参与。
+    ``None`` 对诊断很重要: EP == 1 时无论 ``moe_token_dispatcher_type`` 配成什么,
+    所有 dispatcher 专属字段都是无效的。"""
+
+    router_branch: str
+    hash_routing: bool
+    expert_branch: str
+    precision: str
+    shared_expert: bool
+
+    moe_use_fusion_node: bool
+    moe_expert_fusion: bool
+    """forward 实际读到的字段值。它不总是等于 ``expert_weights_fused``, 见该字段
+    的说明。"""
+
+    expert_weights_fused: bool
+    """是否真的构造了 fused expert 权重。在 fp8 + ``moe_expert_fusion=True`` +
+    无 DeepGEMM + 非 Sonic 的组合下, 构造期通过一个局部变量回退成了非 fused, 而
+    ``moe_expert_fusion`` 仍保持原值, 于是两者不一致。"""
+
+    moe_deep_gemm: bool
+    moe_shared_expert_overlap: bool
+    fp8_dispatch: bool
+    fp8_dispatch_bwd: bool
+
+    active_submodules: frozenset = field(default_factory=frozenset)
+    adjustments: tuple = ()
+
+
+_ROUTER_BRANCH_BY_TOPK_METHOD = {
+    "greedy": "greedy",
+    "group_limited_greedy": "group_limited",
+    "noaux_tc": "noaux_tc",
+    "quantile_balancing": "quantile_balancing",
+}
+
+
+def _device_capability_major(device_capability):
+    """传 None 表示"非 CUDA 或算力未知", 此时跳过算力回退, 与
+    ``paddle.is_compiled_with_cuda()`` 为 False 的行为一致。"""
+    if device_capability is None:
+        return None
+    if isinstance(device_capability, int):
+        return device_capability
+    return device_capability[0]
+
+
+def resolve_moe_plan(
+    config,
+    expert_parallel_size,
+    device_capability=None,
+    hybrid_ep_available=True,
+):
+    """推导一份配置会选中哪些 MoE 子模块。
+
+    Args:
+        config: 建层时会用的 ``TransformerConfig``。
+        expert_parallel_size: EP 组大小; 为 1 表示没有 dispatcher 参与。
+        device_capability: ``(major, minor)`` 或只给 major。传 None 则跳过算力回
+            退, 对应非 CUDA 编译的情况。
+        hybrid_ep_available: HybridEP runtime 能否 import。真实的层在无法 import
+            时会抛 ImportError; 这里改为把回退记录下来, 好让诊断能一次给出完整
+            图景, 而不是卡在第一个问题上就退出。
+
+    Returns:
+        MoEPlan。遇到不支持的组合也不会抛异常: 报错是调用方的职责, 而报错本身需要
+        先有一份 plan 作为依据。
+    """
+    adjustments = []
+
+    def adjust(name, requested, effective, reason):
+        if requested != effective:
+            adjustments.append(Adjustment(name, requested, effective, reason))
+        return effective
+
+    fp8 = getattr(config, "fp8", None)
+    use_w4a8 = getattr(config, "use_w4a8", False)
+    using_sonic_moe = getattr(config, "using_sonic_moe", False)
+    fp8_wgrad = getattr(config, "fp8_wgrad", True)
+
+    # moe_layer.py:202-206 -- 派生值, 从不从 config 读取。
+    fp8_dispatch = bool(fp8) and not use_w4a8
+    fp8_dispatch_bwd = fp8_dispatch and using_sonic_moe and bool(fp8_wgrad)
+
+    moe_expert_fusion = getattr(config, "moe_expert_fusion", False)
+    moe_use_fusion_node = getattr(config, "moe_use_fusion_node", True)
+    moe_shared_expert_overlap = getattr(
+        config, "moe_shared_expert_overlap", False
+    )
+    dispatcher_type = getattr(config, "moe_token_dispatcher_type", "deepep")
+
+    # moe_layer.py:226-236 -- grouped GEMM 需要 fused expert 权重。
+    moe_deep_gemm = getattr(config, "moe_deep_gemm", True)
+    if moe_deep_gemm and not moe_expert_fusion:
+        moe_deep_gemm = adjust(
+            "moe_deep_gemm",
+            True,
+            False,
+            "DeepGEMM 要求 moe_expert_fusion=True",
+        )
+
+    # moe_layer.py:309-324 -- Hopper 之前的回退, 与 EP size 无关。
+    capability_major = _device_capability_major(device_capability)
+    if capability_major is not None and capability_major < 9:
+        if dispatcher_type in ("deepep", "hybridep"):
+            dispatcher_type = adjust(
+                "moe_token_dispatcher_type",
+                dispatcher_type,
+                "alltoall",
+                f"设备算力 {capability_major}.x < 9.0",
+            )
+        if moe_deep_gemm:
+            moe_deep_gemm = adjust(
+                "moe_deep_gemm",
+                True,
+                False,
+                f"设备算力 {capability_major}.x < 9.0",
+            )
+
+    if dispatcher_type == "hybridep" and not hybrid_ep_available:
+        # 真实的层在这里会抛 ImportError; plan 继续往下走, 以便一次性报出配置的
+        # 其余问题。
+        dispatcher_type = adjust(
+            "moe_token_dispatcher_type",
+            "hybridep",
+            "alltoall",
+            "HybridEP runtime 不可用(真实的层会抛 ImportError)",
+        )
+
+    # moe_layer.py:327-352 -- 只有 EP > 1 时才存在 dispatcher。
+    dispatcher = None
+    if expert_parallel_size > 1:
+        dispatcher = dispatcher_type
+        if dispatcher in ("deepep", "hybridep"):
+            if (
+                dispatcher == "hybridep"
+                and moe_use_fusion_node
+                and moe_shared_expert_overlap
+            ):
+                moe_shared_expert_overlap = adjust(
+                    "moe_shared_expert_overlap",
+                    True,
+                    False,
+                    "HybridEP 后端没有 overlap 窗口",
+                )
+        elif dispatcher == "allgather":
+            # moe_layer.py:855-887 -- allgather 会改写三个开关。
+            moe_use_fusion_node = adjust(
+                "moe_use_fusion_node",
+                moe_use_fusion_node,
+                True,
+                "allgather 只能配合 fusion node 运行",
+            )
+            moe_expert_fusion = adjust(
+                "moe_expert_fusion",
+                moe_expert_fusion,
+                True,
+                "allgather 要求 fused expert 权重",
+            )
+            moe_deep_gemm = adjust(
+                "moe_deep_gemm",
+                moe_deep_gemm,
+                False,
+                "allgather 不支持 DeepGEMM",
+            )
+        else:
+            moe_use_fusion_node = adjust(
+                "moe_use_fusion_node",
+                moe_use_fusion_node,
+                False,
+                "alltoall 没有融合引擎",
+            )
+            fp8_dispatch = adjust(
+                "fp8_dispatch",
+                fp8_dispatch,
+                False,
+                "alltoall 不承载 FP8 payload",
+            )
+            fp8_dispatch_bwd = fp8_dispatch_bwd and fp8_dispatch
+
+    # moe_layer.py:374-393 -- 实际会构造出哪种 expert 权重。
+    expert_weights_fused = moe_expert_fusion
+    if fp8 and moe_expert_fusion and not moe_deep_gemm and not using_sonic_moe:
+        expert_weights_fused = False
+        adjustments.append(
+            Adjustment(
+                "moe_expert_fusion",
+                moe_expert_fusion,
+                False,
+                "fp8 且无 DeepGEMM、非 Sonic 时构造的是非 fused expert 权重, 但该"
+                "字段本身保持原值, forward 仍会读到 True(REPORT 11.10 issue#2)",
+            )
+        )
+
+    if using_sonic_moe:
+        expert_branch = "sonic"
+    elif expert_weights_fused:
+        expert_branch = "grouped"
+    else:
+        expert_branch = "standard"
+
+    if use_w4a8:
+        precision = "w4a8"
+    elif fp8:
+        precision = "fp8"
+    else:
+        precision = "bf16"
+
+    topk_method = getattr(config, "topk_method", "greedy")
+    router_branch = _ROUTER_BRANCH_BY_TOPK_METHOD.get(topk_method, topk_method)
+    hash_routing = bool(getattr(config, "moe_n_hash_layers", 0))
+
+    n_shared_experts = getattr(config, "n_shared_experts", None)
+    shared_expert = bool(n_shared_experts)
+
+    active = {
+        "architecture",
+        "router",
+        f"router.{router_branch}",
+        "expert",
+        f"expert.{expert_branch}",
+        "precision",
+        f"precision.{precision}",
+        "subbatch_recompute",
+    }
+    if hash_routing:
+        active.add("router.hash")
+    if dispatcher is not None:
+        active.add(f"dispatcher.{dispatcher}")
+    if shared_expert:
+        active.add("shared_expert")
+
+    return MoEPlan(
+        expert_parallel_size=expert_parallel_size,
+        dispatcher=dispatcher,
+        router_branch=router_branch,
+        hash_routing=hash_routing,
+        expert_branch=expert_branch,
+        precision=precision,
+        shared_expert=shared_expert,
+        moe_use_fusion_node=moe_use_fusion_node,
+        moe_expert_fusion=moe_expert_fusion,
+        expert_weights_fused=expert_weights_fused,
+        moe_deep_gemm=moe_deep_gemm,
+        moe_shared_expert_overlap=moe_shared_expert_overlap,
+        fp8_dispatch=fp8_dispatch,
+        fp8_dispatch_bwd=fp8_dispatch_bwd,
+        active_submodules=frozenset(active),
+        adjustments=tuple(adjustments),
+    )
+
+
+# ======================================================================
+# 可判定规则: 已对照源码核实、能在配置期求值的条件
+# ======================================================================
+
+
+@dataclass(frozen=True)
+class Rule:
+    """一条可判定的规则。"""
+
+    code: str
+    """规则编号, 出现在报错信息里, 方便用户和维护者对同一条规则对话。"""
+
+    category: str
+    fields: tuple[str, ...]
+    """规则涉及的字段。只要其中任意一个被用户显式配置过, 规则就参与判定。"""
+
+    check: Callable
+    """``(config, plan, capability_major) -> str | None``。返回问题描述表示命中,
+    返回 None 表示通过。"""
+
+    suggestion: str
+    doc_ref: str
+    policy: Policy = Policy.ERROR
+
+
+def _dispatcher(plan):
+    return plan.dispatcher
+
+
+def _topk_method(config):
+    return getattr(config, "topk_method", "greedy")
+
+
+def _bias_enabled(config):
+    """routed expert 的 bias 由 moe_routed_expert_use_bias 覆盖 use_bias;
+    为 None 时沿用全局 use_bias(moe_layer.py:169-171)。"""
+    override = getattr(config, "moe_routed_expert_use_bias", None)
+    if override is not None:
+        return bool(override)
+    return bool(getattr(config, "use_bias", False))
+
+
+def _cuda_version():
+    try:
+        import paddle
+
+        return paddle.version.cuda()
+    except Exception:  # pragma: no cover - 取不到就当作"未知,不判定"
+        return None
+
+
+def _sonic_moe_available():
+    """返回 True/False, 环境里根本没有 paddlefleet_ops 时返回 None(不判定)。"""
+    try:
+        import paddlefleet_ops
+
+        return bool(paddlefleet_ops.is_sonic_moe_available())
+    except Exception:  # pragma: no cover
+        return None
+
+
+_DEPENDENCY_RULES = (
+    Rule(
+        code="B1",
+        category="依赖缺失",
+        fields=("use_w4a8_fused_quant",),
+        check=lambda config, plan, cap: (
+            "use_w4a8_fused_quant=True 但 use_w4a8=False, 融合量化 kernel 不会被调用"
+            if getattr(config, "use_w4a8_fused_quant", False)
+            and not getattr(config, "use_w4a8", False)
+            else None
+        ),
+        suggestion="要么开启 use_w4a8, 要么去掉 use_w4a8_fused_quant。",
+        doc_ref="fp8_utils.py:271-274, 仅 W4A8 量化路径会传入该参数",
+    ),
+    Rule(
+        code="B2",
+        category="依赖缺失",
+        fields=("actual_vocab_size",),
+        check=lambda config, plan, cap: (
+            "actual_vocab_size 已设置但 moe_n_hash_layers=0, hash 路由没有启用"
+            if getattr(config, "actual_vocab_size", None)
+            and not getattr(config, "moe_n_hash_layers", 0)
+            else None
+        ),
+        suggestion="hash 路由请设 moe_n_hash_layers>0; 否则删除 actual_vocab_size。",
+        doc_ref="moe_router.py:1429",
+    ),
+    Rule(
+        code="B3",
+        category="依赖缺失",
+        fields=("moe_n_hash_layers",),
+        check=lambda config, plan, cap: (
+            "moe_n_hash_layers>0 但未设置 actual_vocab_size, hash 层构造时会报错"
+            if getattr(config, "moe_n_hash_layers", 0)
+            and not getattr(config, "actual_vocab_size", None)
+            else None
+        ),
+        suggestion="补上 actual_vocab_size。这条现有代码也会报, 但要等到 "
+        "set_layer_number 调用时才报。",
+        doc_ref="moe_router.py:1429-1432",
+    ),
+    Rule(
+        code="B4",
+        category="依赖缺失",
+        fields=("moe_shared_expert_gate",),
+        check=lambda config, plan, cap: (
+            "moe_shared_expert_gate=True 但没有 shared expert(n_shared_experts 为空)"
+            if getattr(config, "moe_shared_expert_gate", False)
+            and not plan.shared_expert
+            else None
+        ),
+        suggestion="门控在 shared expert 内部实现; 请设 n_shared_experts>0, 否则该"
+        "开关无效。",
+        doc_ref="moe_shared_expert.py:53",
+    ),
+    Rule(
+        code="B5",
+        category="依赖缺失",
+        fields=("auto_subbatch_mode",),
+        check=lambda config, plan, cap: (
+            "auto_subbatch_mode 已设置但 use_auto_subbatch=False, 分块策略不会启用"
+            if getattr(config, "auto_subbatch_mode", None)
+            and not getattr(config, "use_auto_subbatch", False)
+            else None
+        ),
+        suggestion="use_auto_subbatch 是总开关, 单独设 mode 不生效。",
+        doc_ref="fusion_layer_utils.py:554-559",
+    ),
+    Rule(
+        code="B6",
+        category="依赖缺失",
+        fields=("use_ue8m0",),
+        check=lambda config, plan, cap: (
+            "use_ue8m0=True 但 fp8 未开启, UE8M0 缩放格式不会被使用"
+            if getattr(config, "use_ue8m0", False)
+            and not getattr(config, "fp8", None)
+            else None
+        ),
+        suggestion="UE8M0 是 FP8 的缩放格式; 不开 fp8 时它静默无效(代码里也没有联"
+        "动校验)。",
+        doc_ref="CONFIGS 2.10 / REPORT 11.9",
+    ),
+    Rule(
+        code="B7",
+        category="依赖缺失",
+        fields=("moe_shared_expert_overlap",),
+        check=lambda config, plan, cap: (
+            "moe_shared_expert_overlap=True 但没有 shared expert"
+            f"(n_shared_experts={getattr(config, 'n_shared_experts', None)!r})"
+            if getattr(config, "moe_shared_expert_overlap", False)
+            and not plan.shared_expert
+            else None
+        ),
+        suggestion="overlap 把 shared expert 的计算塞进 combine 的通信窗口; 没有 "
+        "shared expert 就没有东西可重叠, 该开关会被静默跳过。请设 "
+        "n_shared_experts>0, 或去掉 moe_shared_expert_overlap。",
+        doc_ref="moe_layer.py:1358-1362(四个条件的 and, 不满足则静默不重叠)",
+    ),
+    Rule(
+        code="B8",
+        category="依赖缺失",
+        fields=("moe_shared_expert_overlap",),
+        check=lambda config, plan, cap: (
+            "moe_shared_expert_overlap=True 但最终 moe_use_fusion_node=False"
+            if getattr(config, "moe_shared_expert_overlap", False)
+            and plan.shared_expert
+            and not plan.moe_use_fusion_node
+            else None
+        ),
+        suggestion="overlap 窗口由 fusion node 提供; alltoall 会强制关闭 "
+        "moe_use_fusion_node, 从而让 overlap 静默失效。",
+        doc_ref="moe_layer.py:1358-1362",
+    ),
+    Rule(
+        code="B9",
+        category="依赖缺失",
+        fields=("moe_shared_expert_overlap",),
+        check=lambda config, plan, cap: (
+            f"moe_shared_expert_overlap=True 但 EP={plan.expert_parallel_size}, "
+            "没有专家并行通信可供重叠"
+            if getattr(config, "moe_shared_expert_overlap", False)
+            and plan.expert_parallel_size <= 1
+            else None
+        ),
+        suggestion="overlap 要重叠的是 EP 的 dispatch/combine 通信; EP=1 时不存在这"
+        "段通信, 该开关无效。",
+        doc_ref="moe_layer.py:1358-1362",
+    ),
+)
+
+_CONFLICT_RULES = (
+    Rule(
+        code="C1",
+        category="互斥组合",
+        fields=("topk_method", "moe_topk_fusion"),
+        check=lambda config, plan, cap: (
+            "topk_method=quantile_balancing 与 moe_topk_fusion=True 不兼容"
+            if _topk_method(config) == "quantile_balancing"
+            and getattr(config, "moe_topk_fusion", False)
+            else None
+        ),
+        suggestion="quantile_balancing 明确禁止 topk fusion, 请设 "
+        "moe_topk_fusion=False。",
+        doc_ref="moe_router.py:455-460(构造期已 raise)",
+    ),
+    Rule(
+        code="C2",
+        category="互斥组合",
+        fields=("topk_method", "n_group"),
+        check=lambda config, plan, cap: (
+            f"topk_method=quantile_balancing 要求 n_group=1, 实际 "
+            f"{getattr(config, 'n_group', 1)}"
+            if _topk_method(config) == "quantile_balancing"
+            and getattr(config, "n_group", 1) != 1
+            else None
+        ),
+        suggestion="QB 的直方图无法表达多组预选; 请设 n_group=1。",
+        doc_ref="moe_router.py:1153(forward 期才 raise)",
+    ),
+    Rule(
+        code="C3",
+        category="互斥组合",
+        fields=("topk_method", "moe_topk_fusion"),
+        check=lambda config, plan, cap: (
+            f"moe_topk_fusion=True 但 topk_method={_topk_method(config)}, 该分支不构造 "
+            f"e_score_correction_bias"
+            if getattr(config, "moe_topk_fusion", False)
+            and _topk_method(config) in ("greedy", "group_limited_greedy")
+            else None
+        ),
+        suggestion="只有 topk_method=noaux_tc 完整支持 moe_topk_fusion; 当前组合会在"
+        "运行期抛 AttributeError, 而不是在构造期被拒绝。",
+        doc_ref="BRANCHES 5.3 issue#3",
+    ),
+)
+
+_PRECISION_CONFLICT_RULES = (
+    Rule(
+        code="C4",
+        category="互斥组合",
+        fields=("fp8", "moe_use_fusion_node", "moe_token_dispatcher_type"),
+        check=lambda config, plan, cap: (
+            "fp8 已开启但最终 moe_use_fusion_node=False"
+            + (
+                "(被 alltoall 强制关闭)"
+                if _dispatcher(plan) == "alltoall"
+                else ""
+            )
+            if getattr(config, "fp8", None) and not plan.moe_use_fusion_node
+            else None
+        ),
+        suggestion="fp8 只能在 fusion node 上运行; 换 deepep/hybridep, 或关闭 fp8。",
+        doc_ref="moe_layer.py:359(assert)",
+    ),
+    Rule(
+        code="C5",
+        category="互斥组合",
+        fields=("fp8", "hidden_act"),
+        check=lambda config, plan, cap: (
+            "fp8 已开启但 hidden_act=situ, SiTU-GLU 融合只支持 BF16"
+            if getattr(config, "fp8", None)
+            and getattr(config, "hidden_act", None) is situ
+            else None
+        ),
+        suggestion="SiTU 激活下请关闭 fp8。",
+        doc_ref="moe_layer.py:209-213",
+    ),
+    Rule(
+        code="C6",
+        category="互斥组合",
+        fields=("fp8", "moe_expert_fusion", "moe_deep_gemm"),
+        check=lambda config, plan, cap: (
+            "fp8 + moe_deep_gemm 要求 moe_expert_fusion=True"
+            if getattr(config, "fp8", None)
+            and getattr(config, "moe_deep_gemm", True)
+            and not getattr(config, "moe_expert_fusion", False)
+            else None
+        ),
+        suggestion="fp8 下的 k-grouped gemm 反向需要 fused 权重; 请开启 "
+        "moe_expert_fusion, 或关闭 moe_deep_gemm。",
+        doc_ref="moe_layer.py:375-382(ValueError)",
+    ),
+)
+
+_PATH_CONFLICT_RULES = (
+    Rule(
+        code="C7",
+        category="互斥组合",
+        fields=("moe_token_dispatcher_type", "moe_expert_fusion"),
+        check=lambda config, plan, cap: (
+            "dispatcher 为 alltoall 但 moe_expert_fusion=True"
+            if _dispatcher(plan) == "alltoall"
+            and getattr(config, "moe_expert_fusion", False)
+            else None
+        ),
+        suggestion="alltoall 没有融合引擎, 该组合会被直接拒绝; 请设 "
+        "moe_expert_fusion=False, 或换 deepep/hybridep。注意算力低于 9.0 时 "
+        "deepep/hybridep 会被回退成 alltoall, 从而间接触发这条。",
+        doc_ref="moe_layer.py:348-351(ValueError)",
+    ),
+    Rule(
+        code="C8",
+        category="互斥组合",
+        fields=("moe_token_dispatcher_type", "using_sonic_moe"),
+        check=lambda config, plan, cap: (
+            "dispatcher 为 allgather 但 using_sonic_moe=False"
+            if _dispatcher(plan) == "allgather"
+            and not getattr(config, "using_sonic_moe", False)
+            else None
+        ),
+        suggestion="allgather 路径只实现了 SonicMoE 融合 kernel; 请开启 "
+        "using_sonic_moe。",
+        doc_ref="moe_layer.py:864-869(ValueError)",
+    ),
+    Rule(
+        code="C9",
+        category="互斥组合",
+        fields=("moe_routed_expert_use_bias", "use_bias", "moe_expert_fusion"),
+        check=lambda config, plan, cap: (
+            f"expert 分支为 {plan.expert_branch} 但 routed expert 启用了 bias"
+            if plan.expert_branch in ("grouped", "sonic")
+            and _bias_enabled(config)
+            else None
+        ),
+        suggestion="Grouped GEMM 尚不支持 bias; 请设 "
+        "moe_routed_expert_use_bias=False, 或改用 standard expert。",
+        doc_ref="moe_expert.py:192(assert)",
+    ),
+    Rule(
+        code="C10",
+        category="互斥组合",
+        fields=("using_sonic_moe", "moe_expert_fusion"),
+        check=lambda config, plan, cap: (
+            "using_sonic_moe=True 但最终没有构造 fused expert 权重"
+            if getattr(config, "using_sonic_moe", False)
+            and not plan.expert_weights_fused
+            else None
+        ),
+        suggestion="Sonic expert 必须使用 fused 权重; 请开启 moe_expert_fusion。",
+        doc_ref="moe_layer.py:390-393(assert)",
+    ),
+)
+
+_SCORING_FUNCS = (
+    "softmax",
+    "sigmoid",
+    "tanh",
+    "relu",
+    "gelu",
+    "leaky_relu",
+    "sftplus",
+    "sqrtsoftplus",
+)
+"""moe_router.py:536-553 逐个 elif 支持的取值, 其余走 NotImplementedError。"""
+
+_NON_NEGATIVE_SCORING_FUNCS = (
+    "softmax",
+    "sigmoid",
+    "relu",
+    "sftplus",
+    "sqrtsoftplus",
+)
+"""seq_aux_loss 要求非负打分函数(moe_router.py:351-361)。"""
+
+_HASH_SCORING_FUNCS = ("softmax", "sigmoid", "sqrtsoftplus")
+"""hash 路由支持的取值(moe_router.py:1423-1427)。"""
+
+_ROUTER_VALUE_RULES = (
+    Rule(
+        code="C11",
+        category="互斥组合",
+        fields=("n_group", "n_routed_experts", "topk_method"),
+        check=lambda config, plan, cap: (
+            f"n_routed_experts={getattr(config, 'n_routed_experts', None)} 不能被 "
+            f"n_group={getattr(config, 'n_group', 1)} 整除"
+            if plan.router_branch in ("group_limited", "noaux_tc")
+            and getattr(config, "n_routed_experts", None)
+            and getattr(config, "n_group", 1)
+            and config.n_routed_experts % config.n_group != 0
+            else None
+        ),
+        suggestion="分组预选要求专家数能被组数整除; 请调整 n_group。",
+        doc_ref="moe_router.py:1025 / 1067(assert)",
+    ),
+    Rule(
+        code="C12",
+        category="互斥组合",
+        fields=("scoring_func",),
+        check=lambda config, plan, cap: (
+            f"scoring_func={getattr(config, 'scoring_func', None)!r} 不在支持列表内"
+            if getattr(config, "scoring_func", "softmax") not in _SCORING_FUNCS
+            else None
+        ),
+        suggestion=f"可选值: {', '.join(_SCORING_FUNCS)}。",
+        doc_ref="moe_router.py:536-553(NotImplementedError)",
+    ),
+    Rule(
+        code="C13",
+        category="互斥组合",
+        fields=("scoring_func", "moe_router_load_balancing_type"),
+        check=lambda config, plan, cap: (
+            "moe_router_load_balancing_type=seq_aux_loss 要求非负打分函数, 实际 "
+            f"{getattr(config, 'scoring_func', None)!r}"
+            if getattr(config, "moe_router_load_balancing_type", "aux_loss")
+            == "seq_aux_loss"
+            and getattr(config, "scoring_func", "softmax")
+            not in _NON_NEGATIVE_SCORING_FUNCS
+            else None
+        ),
+        suggestion=f"可选值: {', '.join(_NON_NEGATIVE_SCORING_FUNCS)}。",
+        doc_ref="moe_router.py:351-361(ValueError)",
+    ),
+    Rule(
+        code="C14",
+        category="互斥组合",
+        fields=("scoring_func", "moe_n_hash_layers"),
+        check=lambda config, plan, cap: (
+            f"hash 路由要求 scoring_func 属于 {_HASH_SCORING_FUNCS}, 实际 "
+            f"{getattr(config, 'scoring_func', None)!r}"
+            if plan.hash_routing
+            and getattr(config, "scoring_func", "softmax")
+            not in _HASH_SCORING_FUNCS
+            else None
+        ),
+        suggestion="换成 softmax / sigmoid / sqrtsoftplus, 或关闭 hash 路由。",
+        doc_ref="moe_router.py:1423-1427(ValueError)",
+    ),
+    Rule(
+        code="C15",
+        category="互斥组合",
+        fields=("moe_split_feature_routing", "scoring_func"),
+        check=lambda config, plan, cap: (
+            "moe_split_feature_routing=True 要求 scoring_func='sigmoid', 实际 "
+            f"{getattr(config, 'scoring_func', None)!r}"
+            if getattr(config, "moe_split_feature_routing", False)
+            and getattr(config, "scoring_func", "softmax") != "sigmoid"
+            else None
+        ),
+        suggestion="双视图路由的契约是 sigmoid + sigmoid。",
+        doc_ref="moe_router.py:1415-1418 / 1592-1595(ValueError)",
+    ),
+)
+
+_CAPABILITY_RULES = (
+    Rule(
+        code="E1",
+        category="能力不足",
+        fields=("use_ue8m0",),
+        check=lambda config, plan, cap: (
+            f"use_ue8m0=True 需要 SM100(Blackwell), 当前设备算力为 {cap}.x"
+            if getattr(config, "use_ue8m0", False)
+            and cap is not None
+            and cap != 10
+            else None
+        ),
+        suggestion="换到 SM100 机型, 或关闭 use_ue8m0。",
+        doc_ref="moe_layer.py:363-366(assert)",
+    ),
+    Rule(
+        code="E2",
+        category="能力不足",
+        fields=("fp8",),
+        check=lambda config, plan, cap: (
+            "fp8 已开启但当前 CUDA 版本是 12.6, 该组合未实现"
+            if getattr(config, "fp8", None) and _cuda_version() == "12.6"
+            else None
+        ),
+        suggestion="换一个 CUDA 版本, 或关闭 fp8。",
+        doc_ref="moe_layer.py:354-358(NotImplementedError)",
+    ),
+    Rule(
+        code="E3",
+        category="能力不足",
+        fields=("using_sonic_moe",),
+        check=lambda config, plan, cap: (
+            "using_sonic_moe=True 但当前环境的 sonicmoe kernel 不可用"
+            if getattr(config, "using_sonic_moe", False)
+            and _sonic_moe_available() is False
+            else None
+        ),
+        suggestion="装上 paddlefleet_ops.sonicmoe, 或关闭 using_sonic_moe。",
+        doc_ref="moe_layer.py:217-222(assert)",
+    ),
+)
+
+MOE_CONFIG_RULES = (
+    _DEPENDENCY_RULES
+    + _CONFLICT_RULES
+    + _PRECISION_CONFLICT_RULES
+    + _PATH_CONFLICT_RULES
+    + _ROUTER_VALUE_RULES
+    + _CAPABILITY_RULES
+)
+
+
+def evaluate_rules(config, plan, device_capability, user_specified_keys):
+    """逐条判定规则, 返回 ``(rule, 问题描述)`` 列表。
+
+    只判定那些至少涉及一个"用户显式配置过"字段的规则; 全是默认值的组合不算用户的
+    问题, 报出来只会制造噪音。
+    """
+    capability_major = None
+    if device_capability is not None:
+        capability_major = (
+            device_capability
+            if isinstance(device_capability, int)
+            else device_capability[0]
+        )
+
+    results = []
+    user_keys = set(user_specified_keys)
+    for rule in MOE_CONFIG_RULES:
+        if not (set(rule.fields) & user_keys):
+            continue
+        problem = rule.check(config, plan, capability_major)
+        if problem:
+            results.append((rule, problem))
+    return results
+
+
+# ======================================================================
+# 诊断报告: 把执行计划与归属登记表对起来
+# ======================================================================
+
+STATUS_LABELS = {
+    Status.DEAD: "死配置",
+    Status.FOREIGN: "属其他子系统",
+    Status.DERIVED: "内部派生值",
+    Status.UNDECLARED: "未声明字段",
+}
+
+SCOPE_LABEL = "作用域错误"
+ADJUSTED_LABEL = "配置被改写"
+
+
+@dataclass(frozen=True)
+class Finding:
+    """一条诊断结论。"""
+
+    kind: str
+    """给用户看的分类标签, 取自 ``STATUS_LABELS`` / ``SCOPE_LABEL`` /
+    ``ADJUSTED_LABEL``。"""
+
+    field: str
+    value: object
+    policy: Policy
+    message: str
+
+    def __str__(self):
+        return (
+            f"[{self.kind}] {self.field}={self.value!r}\n      {self.message}"
+        )
+
+
+def collect_findings(config, plan, user_specified_keys, device_capability=None):
+    """比对一份配置与它命中的执行计划, 返回全部诊断结论。
+
+    Args:
+        config: 已构造好的 ``TransformerConfig``。
+        plan: ``resolve_moe_plan`` 的返回值。
+        user_specified_keys: 用户真正显式配过的字段名集合(YAML 键 ∪ JSON 键)。
+            **必须由调用方提供**: config 对象本身分不清"用户配的"和"框架默认值",
+            上游 PretrainedConfig 会把自己的默认值一并灌进去, 实测会让近半数 MoE
+            字段被误判成用户显式设置。只诊断这个集合里的字段, 是避免误报的唯一
+            办法。
+        device_capability: ``(major, minor)`` 或 major; 判定 E 类(能力不足)规则时
+            需要。传 None 则跳过这类规则。
+
+    Returns:
+        Finding 元组。**一次性返回全部问题**, 不在第一条就中断: 让用户改一轮就能
+        全部改完, 而不是启动一次只暴露一个问题。
+    """
+    findings = []
+    rule_covered_fields = set()
+
+    for name in sorted(user_specified_keys):
+        spec = MOE_FIELD_REGISTRY.get(name)
+        if spec is None:
+            # 与 MoE 无关的字段(数据、优化器、并行策略等), 不在本工具职责内。
+            continue
+
+        if spec.status is not Status.ACTIVE:
+            findings.append(
+                Finding(
+                    kind=STATUS_LABELS[spec.status],
+                    field=name,
+                    value=getattr(config, name, None),
+                    policy=spec.policy,
+                    message=spec.suggestion or spec.activation,
+                )
+            )
+            continue
+
+        if not (set(spec.owner) & plan.active_submodules):
+            if spec.selector:
+                # 分支选择器被无条件读取, 是它决定自己那个分支存不存在。把
+                # n_shared_experts=0 报成"归属 shared_expert, 不会被读取"是倒因为
+                # 果; 这类字段只能靠本模块的规则段判定。
+                continue
+            value = getattr(config, name, None)
+            # 关掉一个本来就不生效的开关不会造成任何后果: 用户没有要求任何行为, 只
+            # 是把它显式写成了关。这种情况降级为提示, 免得把"必须修复"的列表撑满无
+            # 需修复的条目。
+            requested_something = bool(value)
+            findings.append(
+                Finding(
+                    kind=SCOPE_LABEL,
+                    field=name,
+                    value=value,
+                    policy=spec.policy if requested_something else Policy.INFO,
+                    message=(
+                        (
+                            f"该字段归属 {'/'.join(spec.owner)}, 当前执行路径不包含"
+                            f"这些子模块, 因此不会被读取。{spec.suggestion}"
+                            if requested_something
+                            else f"该字段归属 {'/'.join(spec.owner)}, 当前路径不读"
+                            f"取; 但配的是 {value!r}(等于没有请求该行为), 无需修改。"
+                        ).strip()
+                    ),
+                )
+            )
+
+    for adjustment in plan.adjustments:
+        if adjustment.name not in user_specified_keys:
+            # 用户没配过, 只是默认值与路由要求不同, 不构成"配置被改写"。
+            continue
+        findings.append(
+            Finding(
+                kind=ADJUSTED_LABEL,
+                field=adjustment.name,
+                value=adjustment.requested,
+                policy=Policy.ERROR,
+                message=(
+                    f"你配置的 {adjustment.name}={adjustment.requested!r} 被改写为 "
+                    f"{adjustment.effective!r}, 原因: {adjustment.reason}"
+                ),
+            )
+        )
+
+    for rule, problem in evaluate_rules(
+        config, plan, device_capability, user_specified_keys
+    ):
+        involved = [name for name in rule.fields if name in user_specified_keys]
+        rule_covered_fields.update(involved)
+        findings.append(
+            Finding(
+                kind=rule.category,
+                field="/".join(involved) or rule.fields[0],
+                value=tuple(getattr(config, name, None) for name in involved),
+                policy=rule.policy,
+                message=f"[{rule.code}] {problem}。{rule.suggestion} "
+                f"(依据 {rule.doc_ref})",
+            )
+        )
+
+    # 同一个字段既命中通用作用域判定、又命中具体规则时, 只留规则那条: 规则给出的
+    # 是"缺哪个前置条件、怎么修", 比"归属的子模块没命中"更具体。
+    findings = [
+        finding
+        for finding in findings
+        if not (
+            finding.kind == SCOPE_LABEL and finding.field in rule_covered_fields
+        )
+    ]
+    return tuple(findings)
+
+
+class MoEConfigError(ValueError):
+    """MoE 配置校验失败。消息里包含**本轮全部**必须修复的问题。"""
+
+    def __init__(self, findings, plan=None):
+        self.findings = tuple(findings)
+        self.plan = plan
+        super().__init__(format_errors(self.findings, plan))
+
+
+def format_errors(findings, plan=None):
+    """把必须修复的问题排成一条多行消息。
+
+    一次性列出全部问题是刻意设计: 逐个报错会让用户反复"改一个、跑一次、再报一个",
+    在需要排队等资源的训练任务上代价很高。
+    """
+    errors = [f for f in findings if f.policy is Policy.ERROR]
+    lines = [f"MoE 配置检查未通过, 共 {len(errors)} 个问题需要修复:"]
+    if plan is not None:
+        lines.append(
+            f"当前执行路径: dispatcher={plan.dispatcher} router={plan.router_branch} "
+            f"expert={plan.expert_branch} precision={plan.precision} "
+            f"(EP={plan.expert_parallel_size})"
+        )
+    for index, finding in enumerate(errors, start=1):
+        lines.append(f"  {index}. {finding}")
+    lines.append(
+        "以上问题一次性全部列出, 请一并修改; 如需临时放行, 把 "
+        "moe_config_check 设为 report。"
+    )
+    return "\n".join(lines)
+
+
+def format_report(plan, findings, config=None, user_specified_keys=()):
+    """把执行计划与诊断结论排成一份可读报告。
+
+    ``config`` 与 ``user_specified_keys`` 都给出时, 报告末尾会附上"需人工确认的前置
+    条件": 那些用户配过、当前生效、但登记表标注了 ``requires`` 的字段。这些条件是
+    自然语言, 本工具不做求值, 只负责提醒。
+    """
+    lines = ["=" * 72, "MoE 配置检查报告", "=" * 72]
+
+    lines.append("")
+    lines.append(f"EP size            : {plan.expert_parallel_size}")
+    lines.append(
+        f"dispatcher         : {plan.dispatcher if plan.dispatcher else 'none(EP<=1, 不走 dispatcher)'}"
+    )
+    lines.append(
+        f"router             : {plan.router_branch}"
+        + ("  (叠加 hash 路由)" if plan.hash_routing else "")
+    )
+    lines.append(f"expert             : {plan.expert_branch}")
+    lines.append(f"precision          : {plan.precision}")
+    lines.append(f"shared expert      : {'有' if plan.shared_expert else '无'}")
+    lines.append(
+        f"派生值             : fp8_dispatch={plan.fp8_dispatch} "
+        f"fp8_dispatch_bwd={plan.fp8_dispatch_bwd}"
+    )
+
+    lines.append("")
+    lines.append(
+        f"-- 路由过程中被改写的字段({len(plan.adjustments)} 项) " + "-" * 20
+    )
+    if plan.adjustments:
+        for adjustment in plan.adjustments:
+            lines.append(f"  {adjustment}")
+    else:
+        lines.append("  (无)")
+
+    errors = [f for f in findings if f.policy is Policy.ERROR]
+    others = [f for f in findings if f.policy is not Policy.ERROR]
+
+    lines.append("")
+    lines.append(f"-- 需要修复的问题({len(errors)} 项) " + "-" * 28)
+    if errors:
+        for finding in errors:
+            lines.append(f"  {finding}")
+    else:
+        lines.append("  (无)")
+
+    lines.append("")
+    lines.append(f"-- 提示({len(others)} 项) " + "-" * 38)
+    if others:
+        for finding in others:
+            lines.append(f"  {finding}")
+    else:
+        lines.append("  (无)")
+
+    if config is not None:
+        pending = []
+        for name in sorted(user_specified_keys):
+            spec = MOE_FIELD_REGISTRY.get(name)
+            if spec is None or spec.status is not Status.ACTIVE:
+                continue
+            if not spec.unverifiable:
+                continue
+            if not (set(spec.owner) & plan.active_submodules):
+                continue
+            value = getattr(config, name, None)
+            if not value:
+                # 配成关的字段不会请求任何行为, 它的前置条件也就无需确认。
+                continue
+            pending.append(
+                f"  {name}={value!r}: " + "; ".join(spec.unverifiable)
+            )
+        lines.append("")
+        lines.append(
+            f"-- 依赖运行时状态、无法在配置期判定的条件({len(pending)} 项) "
+            + "-" * 6
+        )
+        lines.extend(pending or ["  (无)"])
+
+    lines.append("=" * 72)
+    return "\n".join(lines)
+
+
+# ======================================================================
+# 构造期入口: 由 TransformerConfig.__post_init__ 调用
+# ======================================================================
+
+MOE_CONFIG_CHECK_MODES = ("off", "report", "strict")
+
+_REPORTED_FINGERPRINTS = set()
+
+
+def _is_first_rank():
+    """构造期分布式通信组可能还没初始化, 所以看启动器设置的环境变量而不是
+    ``paddle.distributed.get_rank()``。"""
+    return os.environ.get("PADDLE_TRAINER_ID", "0") == "0"
+
+
+def _device_capability():
+    try:
+        import paddle
+
+        if paddle.is_compiled_with_cuda() and paddle.device.cuda.device_count():
+            return paddle.device.cuda.get_device_capability()
+    except Exception:  # pragma: no cover - 取不到就退化为"算力未知"
+        pass
+    return None
+
+
+def run_moe_config_check(
+    config,
+    mode=None,
+    expert_parallel_size=None,
+    device_capability=None,
+    user_specified_keys=None,
+):
+    """执行一次配置检查。
+
+    Args:
+        config: 已完成 ``__post_init__`` 主体的 ``TransformerConfig``。
+        mode: 覆盖 ``config.moe_config_check``; 取值见 ``MOE_CONFIG_CHECK_MODES``。
+        expert_parallel_size: 覆盖 ``config.expert_model_parallel_size``。
+        device_capability: 覆盖自动探测的设备算力。
+        user_specified_keys: 覆盖 ``config.user_specified_keys``。没有这个集合时,
+            只会打印执行计划而不做字段级诊断——否则框架默认值会被当成用户配置,
+            实测误报率约五成。
+
+    Returns:
+        ``(plan, findings)``; 模式为 off 或不是 MoE 模型时返回 ``(None, ())``。
+
+    Raises:
+        MoEConfigError: 仅在 strict 模式且存在必须修复的问题时。
+    """
+    if mode is None:
+        mode = getattr(config, "moe_config_check", "off") or "off"
+    if mode not in MOE_CONFIG_CHECK_MODES:
+        raise ValueError(
+            f"moe_config_check 必须是 {MOE_CONFIG_CHECK_MODES} 之一, 收到 {mode!r}"
+        )
+    if mode == "off":
+        return None, ()
+    if not getattr(config, "n_routed_experts", None):
+        # 稠密模型, 没有 MoE 层可检查。
+        return None, ()
+
+    if expert_parallel_size is None:
+        expert_parallel_size = (
+            getattr(config, "expert_model_parallel_size", 1) or 1
+        )
+    if device_capability is None:
+        device_capability = _device_capability()
+    if user_specified_keys is None:
+        user_specified_keys = getattr(config, "user_specified_keys", None)
+
+    plan = resolve_moe_plan(
+        config,
+        expert_parallel_size=expert_parallel_size,
+        device_capability=device_capability,
+    )
+
+    findings = ()
+    if user_specified_keys:
+        findings = collect_findings(
+            config,
+            plan,
+            set(user_specified_keys),
+            device_capability=device_capability,
+        )
+
+    # 同一份配置可能被构造多次(provider、deepcopy、多次 from_config), 相同结论只打
+    # 一遍, 否则日志会被刷屏。
+    fingerprint = (
+        plan.dispatcher,
+        plan.router_branch,
+        plan.expert_branch,
+        plan.precision,
+        plan.expert_parallel_size,
+        tuple(str(adjustment) for adjustment in plan.adjustments),
+        tuple(str(finding) for finding in findings),
+    )
+    if fingerprint not in _REPORTED_FINGERPRINTS:
+        _REPORTED_FINGERPRINTS.add(fingerprint)
+        if _is_first_rank():
+            report = format_report(
+                plan,
+                findings,
+                config=config,
+                user_specified_keys=user_specified_keys or (),
+            )
+            logger.info("MoE 配置检查:\n%s", report)
+            if not user_specified_keys:
+                logger.info(
+                    "未提供 user_specified_keys, 已跳过字段级诊断。上游可以把 "
+                    "YAML 键与 model_config.json 键的并集赋给 "
+                    "config.user_specified_keys 来启用。"
+                )
+
+    if mode == "strict":
+        errors = [f for f in findings if f.policy.value == "error"]
+        if errors:
+            raise MoEConfigError(findings, plan)
+
+    return plan, findings

--- a/src/paddlefleet/transformer/moe/moe_config_registry.py
+++ b/src/paddlefleet/transformer/moe/moe_config_registry.py
@@ -1,0 +1,869 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""MoE 配置开关的归属登记表。
+
+MoE 子系统读取哪些 ``TransformerConfig`` 字段, 取决于路由决策变量选中了哪条执行
+路径(EP size、``moe_token_dispatcher_type``、``moe_expert_fusion``、
+``using_sonic_moe``、``fp8``、``use_w4a8``、设备算力)。归属于其他路径的字段不会
+被任何代码读取, 因此配了等于没配, 而目前没有任何机制会告诉用户这件事。
+
+本模块只有数据和查询辅助函数: 声明每个字段归哪个子模块所有、在什么条件下才真正
+被消费。它在 import 期不依赖 paddle, 自身也不做任何校验, 因此可以脱离 GPU 做单
+测。校验与报错建立在它之上。
+
+归属按两级记录, 表示为点号路径: 由路由决策直接选中的顶层子模块(``router``、
+``dispatcher.deepep`` ...), 以及子模块内部再次分支时命中的次级子模块
+(``router.quantile_balancing``、``expert.grouped``、``precision.fp8``)。只写一级
+表示该字段被这个子模块的全部次级分支共用。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+__all__ = [
+    "Stage",
+    "Status",
+    "Policy",
+    "MoEFieldSpec",
+    "MOE_FIELD_REGISTRY",
+    "TOP_LEVEL_SUBMODULES",
+    "SECONDARY_SUBMODULES",
+    "DISPATCHER_SUBMODULES",
+    "VALID_OWNERS",
+    "is_secondary_owner",
+    "spec_for",
+    "fields_owned_by",
+    "fields_with_status",
+]
+
+
+class Stage(str, Enum):
+    """字段在哪个阶段被读取。
+
+    构造期之后才读取的字段无法在启动时完整校验: 只有跑到那个阶段, 才知道这个值
+    到底起不起作用。
+    """
+
+    CONSTRUCT = "construct"
+    FORWARD = "forward"
+    BACKWARD = "backward"
+    OPTIMIZER_STEP = "optimizer_step"
+
+
+class Status(str, Enum):
+    """该字段究竟有没有消费者, 以及消费者在哪。"""
+
+    ACTIVE = "active"
+    """MoE 子系统至少有一条执行路径会读它。"""
+
+    DEAD = "dead"
+    """config 里声明了, 但全仓库没有任何消费者。"""
+
+    FOREIGN = "foreign"
+    """消费者在 MoE 之外(dense/TP 层、attention、CP)。配了确实有用, 只是对 MoE
+    没用, 因此绝不能报成死配置。"""
+
+    UNDECLARED = "undeclared"
+    """通过 ``getattr(config, name, default)`` 读取, 没有声明成
+    ``TransformerConfig`` 字段。这类字段名拼错会被 ``getattr`` 的默认值吸收,
+    靠字段名比对是查不出来的。"""
+
+    DERIVED = "derived"
+    """根本不是用户开关: 由其他字段内部推导得出。在配置文件里写它, 会在任何代码
+    读到之前就被覆盖。"""
+
+
+class Policy(str, Enum):
+    """该字段出现不匹配时, 报错应该有多严格。"""
+
+    ERROR = "error"
+    WARN = "warn"
+    INFO = "info"
+
+
+TOP_LEVEL_SUBMODULES = (
+    "router",
+    "dispatcher.alltoall",
+    "dispatcher.deepep",
+    "dispatcher.hybridep",
+    "dispatcher.allgather",
+    "expert",
+    "shared_expert",
+    "subbatch_recompute",
+    "precision",
+    # 不是被路由选中的子模块, 而是每条路径都会读的纯结构维度。放进登记表是为了
+    # 不让任何 MoE 字段处于无人归属的状态。
+    "architecture",
+)
+
+SECONDARY_SUBMODULES = {
+    "router": (
+        "greedy",
+        "group_limited",
+        "noaux_tc",
+        "quantile_balancing",
+        "hash",
+    ),
+    "expert": ("standard", "grouped", "sonic"),
+    "precision": ("bf16", "fp8", "w4a8"),
+}
+
+DISPATCHER_SUBMODULES = tuple(
+    name for name in TOP_LEVEL_SUBMODULES if name.startswith("dispatcher.")
+)
+
+VALID_OWNERS = frozenset(TOP_LEVEL_SUBMODULES) | frozenset(
+    f"{top}.{secondary}"
+    for top, secondaries in SECONDARY_SUBMODULES.items()
+    for secondary in secondaries
+)
+
+
+def is_secondary_owner(owner):
+    """``owner`` 指的是子模块内部的分支而非子模块本身时返回 True。
+    ``dispatcher.deepep`` 属于顶层(四条 dispatcher 路径本身就是独立子模块),
+    ``router.hash`` 属于次级。"""
+    return owner not in TOP_LEVEL_SUBMODULES
+
+
+@dataclass(frozen=True)
+class MoEFieldSpec:
+    """单个 MoE 配置字段的归属与生效条件元数据。"""
+
+    name: str
+
+    owner: tuple[str, ...]
+    """会读取该字段的子模块路径。多于一项表示该字段被多条路径读取(例如
+    ``moe_ep_barrier`` 被四条 dispatcher 路径共用)。"""
+
+    activation: str
+    """该字段何时生效的自然语言说明。"""
+
+    requires: tuple[str, ...] = ()
+    """该字段要起作用必须先满足的前置条件。自由文本, 供文档与报错解释使用; 其中可
+    判定的条件已在 ``moe_config_check`` 的规则段里写成规则自动检查。"""
+
+    unverifiable: tuple[str, ...] = ()
+    """**在配置阶段无法判定**的前置条件, 因为它们取决于运行时状态(调用路径、实际
+    token 数、能否拿到某个输入)。报告会把这些条件单独列出来提示人工确认——列在这里
+    的条件必须确实判不了, 而不是"还没写规则", 否则就变成了拿噪音掩盖缺失的检查。"""
+
+    conflicts: tuple[str, ...] = ()
+    """已知不支持或互斥的组合。"""
+
+    stage: Stage = Stage.CONSTRUCT
+    status: Status = Status.ACTIVE
+    policy: Policy = Policy.ERROR
+
+    selector: bool = False
+    """该字段是分支选择器: 它被无条件读取, 用来决定进入哪个子模块。
+
+    选择器**不能**按"归属子模块是否命中"来判断作用域, 否则会得出自相矛盾的结论:
+    ``n_shared_experts=0`` 会让 shared_expert 子模块不存在, 于是反过来报告
+    "n_shared_experts 不会被读取"——而正是这个字段决定了它不存在。同理适用于
+    ``moe_n_hash_layers=0``、``use_w4a8=False`` 等把自己的分支关掉的取值。
+
+    这类字段配错的表现是"它开启的功能没生效", 只能靠 moe_config_check 里的规则
+    逐条判定, 作用域检查对它们无能为力。
+    """
+
+    neutral_values: tuple = ()
+    """作用域检查中视为"未请求任何行为"的真值。布尔开关写 False 天然是中性的,
+    但有些数值字段的某个真值在语义上同样等价于关闭(``n_group=1`` 表示不分组):
+    用户在不读该字段的路径下写这种值不构成需要修复的问题, 报 ERROR 会把无害的
+    常见写法拦在 strict 模式外, 因此只降级为提示。"""
+
+    suggestion: str = ""
+    """报错时给用户的修复建议, 会被直接引用进诊断信息。"""
+
+    doc_ref: str = ""
+    """该归属结论的来源, 供审计核对。"""
+
+
+def _f(name, owner, activation, **kwargs):
+    """精简构造器: ``owner`` 既可以传单个点号路径, 也可以传元组。"""
+    if isinstance(owner, str):
+        owner = (owner,)
+    return MoEFieldSpec(name=name, owner=owner, activation=activation, **kwargs)
+
+
+_ROUTER_FIELDS = (
+    _f(
+        "num_experts_per_tok",
+        "router",
+        "总是生效; router 的每个次级分支都会读",
+        doc_ref="CONFIGS 2.2",
+    ),
+    _f(
+        "scoring_func",
+        "router",
+        "总是生效",
+        requires=("router.hash 只支持 softmax / sigmoid / sqrtsoftplus",),
+        doc_ref="CONFIGS 2.2",
+    ),
+    _f(
+        "topk_method",
+        "router",
+        "总是生效; 它决定进入哪个 router 次级子模块",
+        selector=True,
+        doc_ref="CONFIGS 2.2",
+    ),
+    _f(
+        "moe_router_load_balancing_type",
+        "router",
+        "总是生效, 但除 seq_aux_loss 之外的取值全部退化为同一套实现",
+        policy=Policy.WARN,
+        doc_ref="CONFIGS 2.2 / BRANCHES 5.3 issue#1",
+    ),
+    _f(
+        "router_aux_loss_coef",
+        "router",
+        "总是生效; coef=0 等价于关闭该 loss",
+        doc_ref="CONFIGS 2.2",
+    ),
+    _f("router_z_loss_coef", "router", "总是生效", doc_ref="CONFIGS 2.2"),
+    _f(
+        "norm_topk_prob",
+        "router",
+        "总是生效; 可与 routed_scaling_factor 叠加",
+        doc_ref="CONFIGS 2.2",
+    ),
+)
+
+_ROUTER_SECONDARY_FIELDS = (
+    _f(
+        "n_group",
+        (
+            "router.group_limited",
+            "router.noaux_tc",
+            "router.quantile_balancing",
+        ),
+        "group_limited_greedy 与 noaux_tc 用它做分组预选; quantile_balancing 只把"
+        "它当作必须等于 1 的守卫来检查",
+        requires=("n_routed_experts % n_group == 0",),
+        conflicts=("quantile_balancing 下 n_group != 1 会直接报错",),
+        neutral_values=(1,),
+        suggestion="只有 topk_method=greedy 完全不读 n_group。与 noaux_tc 一起配"
+        "是正确用法, 现有全部线上 model config 都是这么配的。",
+        doc_ref="moe_router.py:1006, 1048, 1153; CONFIGS 2.2(已修正)",
+    ),
+    _f(
+        "topk_group",
+        ("router.group_limited", "router.noaux_tc"),
+        "group_limited_greedy 与 noaux_tc 用它做分组预选",
+        neutral_values=(1,),
+        suggestion="topk_method=greedy 不读 topk_group; quantile_balancing 虽然会"
+        "收到该参数但从不使用, 因为它要求 n_group == 1。",
+        doc_ref="moe_router.py:1006, 1048",
+    ),
+    _f(
+        "qb_n_bins",
+        "router.quantile_balancing",
+        "仅 topk_method=quantile_balancing 时生效",
+        conflicts=(
+            "quantile_balancing 下 moe_topk_fusion 被禁止",
+            "n_group != 1",
+            "router aux loss 系数非零",
+        ),
+        suggestion="qb_n_bins 不被任何其他 router 分支读取; 请改配 "
+        "topk_method=quantile_balancing, 或删掉该字段。",
+        doc_ref="CONFIGS 2.2",
+    ),
+    _f(
+        "moe_n_hash_layers",
+        "router.hash",
+        ">0 时在命中的层上启用 hash 路由, 与 topk_method 正交叠加",
+        selector=True,
+        requires=("必须设置 actual_vocab_size",),
+        unverifiable=(
+            "input_ids 必须能传到该层(取决于运行时入口路径, 配置期判不了)",
+        ),
+        doc_ref="CONFIGS 2.2 / GPT 5 P0",
+    ),
+    _f(
+        "actual_vocab_size",
+        "router.hash",
+        "仅 hash 路由下生效",
+        requires=("moe_n_hash_layers > 0",),
+        suggestion="actual_vocab_size 只被 hash 路由读取; moe_n_hash_layers 不 "
+        "> 0 时它不起任何作用。",
+        doc_ref="CONFIGS 2.2",
+    ),
+)
+
+_ROUTER_FUSION_FIELDS = (
+    _f(
+        "routed_scaling_factor",
+        "router",
+        "总是生效",
+        doc_ref="CONFIGS 2.2",
+    ),
+    _f(
+        "routed_scaling_factor_learnable",
+        "router",
+        "总是生效",
+        doc_ref="CONFIGS 2.2",
+    ),
+    _f(
+        "moe_router_force_load_balancing",
+        "router",
+        "总是生效, 但它是诊断用的强制覆盖, 不是训练策略",
+        policy=Policy.WARN,
+        suggestion="moe_router_force_load_balancing 会用均衡分配替换真实路由结果, "
+        "不应在正式训练中保持开启。",
+        doc_ref="CONFIGS 2.2 / GPT 5 P1",
+    ),
+    _f(
+        "moe_split_feature_routing",
+        "router",
+        "总是生效",
+        requires=("scoring_func 必须是 sigmoid",),
+        conflicts=("不作用于 hash 路由",),
+        doc_ref="CONFIGS 2.2",
+    ),
+    _f(
+        "moe_topk_fusion",
+        "router",
+        "条件生效: 只有 router.noaux_tc 提供完整支持",
+        requires=("依赖 e_score_correction_bias, 只有 noaux_tc 会构造它",),
+        conflicts=(
+            "greedy / group_limited 缺少构造期校验, 会在运行期抛 AttributeError",
+            "quantile_balancing 直接禁止该组合",
+        ),
+        stage=Stage.FORWARD,
+        suggestion="在 greedy / group_limited 下要等到 forward 才会失败; 请改配 "
+        "topk_method=noaux_tc, 或关闭 moe_topk_fusion。",
+        doc_ref="CONFIGS 2.2 / BRANCHES 5.3 issue#3",
+    ),
+    _f(
+        "routing_map_fusion",
+        "router",
+        "条件生效; 与 reference 路径语义等价",
+        policy=Policy.INFO,
+        doc_ref="CONFIGS 2.2",
+    ),
+    _f(
+        "moe_router_fusion",
+        "router",
+        "从不生效: 字段有声明但没有任何消费者",
+        status=Status.DEAD,
+        policy=Policy.WARN,
+        suggestion="moe_router_fusion 没有任何读取点, 请删除。router 侧的融合请用 "
+        "moe_topk_fusion / routing_map_fusion。",
+        doc_ref="CONFIGS 2.2 / REPORT 11.4",
+    ),
+)
+
+_ALL_DISPATCHERS = (
+    "dispatcher.alltoall",
+    "dispatcher.deepep",
+    "dispatcher.hybridep",
+    "dispatcher.allgather",
+)
+
+_DISPATCHER_FIELDS = (
+    _f(
+        "moe_token_dispatcher_type",
+        _ALL_DISPATCHERS,
+        "总是生效; EP > 1 时由它选中 dispatcher 路径",
+        conflicts=(
+            "设备算力低于 9.0 时 deepep / hybridep 会静默回退为 alltoall",
+            "hybridep runtime 缺失时直接抛 ImportError",
+            "allgather 要求 using_sonic_moe=True",
+        ),
+        doc_ref="CONFIGS 2.3-2.6",
+    ),
+    _f(
+        "moe_ep_barrier",
+        _ALL_DISPATCHERS,
+        "EP > 1 时总是生效; 位于通信热路径上",
+        doc_ref="CONFIGS 2.3-2.6 / REPORT 11.5",
+    ),
+    _f(
+        "moe_use_fusion_node",
+        ("dispatcher.deepep", "dispatcher.hybridep", "dispatcher.allgather"),
+        "条件生效: deepep / hybridep 支持, allgather 强制开启, alltoall 强制关闭",
+        conflicts=(
+            "alltoall 会强制关闭它, 并拒绝 moe_expert_fusion=True",
+            "与 moe_expert_fusion 之间缺少成组校验",
+        ),
+        suggestion="在 alltoall 下这个开关会被覆盖; 需要融合引擎请改用 deepep 或 "
+        "hybridep。",
+        doc_ref="CONFIGS 2.3-2.6 / REPORT 11.10 issue#1",
+    ),
+    _f(
+        "deepep_buffer_configs",
+        "dispatcher.deepep",
+        "仅 deepep 下生效; 它会改动进程级的 DeepEP buffer 大小",
+        suggestion="deepep_buffer_configs 不被任何其他 dispatcher 读取。",
+        doc_ref="CONFIGS 2.4",
+    ),
+    _f(
+        "use_rr_deepep_combine",
+        "dispatcher.deepep",
+        "派生值: 由 recompute_modules 是否含 'moe_combine' 推导, 从不从 config 读取",
+        requires=(
+            "moe_token_dispatcher_type=deepep",
+            "moe_shared_expert_overlap=True",
+            "已设置 recompute_granularity, 且 full 或 MLP recompute 处于激活状态, "
+            "否则抛 ValueError",
+        ),
+        status=Status.DERIVED,
+        policy=Policy.WARN,
+        suggestion="在 config 里设置 use_rr_deepep_combine 不起作用: 它会被 "
+        "recompute_modules['moe_combine'] 覆盖。请改配 recompute_modules。",
+        doc_ref="moe_layer.py:622-660; CONFIGS 2.4(已修正)",
+    ),
+    _f(
+        "hybridep_buffer_configs",
+        "dispatcher.hybridep",
+        "仅 hybridep 下生效, 且通过 getattr 读取而非声明成 config 字段",
+        status=Status.UNDECLARED,
+        policy=Policy.WARN,
+        suggestion="hybridep_buffer_configs 不在 config schema 里, 所以字段名拼错"
+        "会被 getattr 的默认值静默吸收。",
+        doc_ref="CONFIGS 2.5 / moe_layer.py:507",
+    ),
+    _f(
+        "moe_allgather_gate_overlap",
+        "dispatcher.allgather",
+        "仅 allgather 下生效(默认 True)",
+        suggestion="其他所有 dispatcher 都会静默忽略该字段。",
+        doc_ref="CONFIGS 2.6",
+    ),
+)
+
+_EXPERT_FIELDS = (
+    _f(
+        "moe_expert_fusion",
+        "expert",
+        "总是生效; 它决定使用 standard 还是 grouped expert 实现",
+        selector=True,
+        conflicts=(
+            "alltoall 会拒绝该组合",
+            "allgather 会强制开启它",
+            "fp8 且无 deep_gemm、非 sonic 时, 对象是按局部回退值构造的, 而 "
+            "forward 仍读该字段, 两者不一致",
+        ),
+        suggestion="expert 的次级分支由多个布尔字段组合隐式决定, 而不是单一枚举; "
+        "请看 effective plan 的判定结果, 不要只看这个字段。",
+        doc_ref="CONFIGS 2.7 / REPORT 11.10 issue#2",
+    ),
+    _f(
+        "moe_deep_gemm",
+        "expert.grouped",
+        "仅在 grouped expert 内部生效",
+        selector=True,
+        requires=(
+            "moe_expert_fusion=True",
+            "设备算力 >= 9.0",
+            "非 allgather 路径, 因为 allgather 会强制关闭它",
+        ),
+        suggestion="moe_deep_gemm 默认 True 而 moe_expert_fusion 默认 False, 这对"
+        "默认值本身自相矛盾, 结果是静默地不走 DeepGEMM。",
+        doc_ref="CONFIGS 2.7 / REPORT 11.9",
+    ),
+    _f(
+        "using_sonic_moe",
+        "expert",
+        "总是生效; 它决定是否使用 Sonic expert 实现",
+        selector=True,
+        requires=(
+            "moe_expert_fusion=True",
+            "只支持 SwiGLU 激活",
+            "sonicmoe 生态库必须可 import",
+        ),
+        doc_ref="CONFIGS 2.7",
+    ),
+    _f(
+        "moe_routed_expert_use_bias",
+        "expert.standard",
+        "只有 standard expert 支持 bias",
+        conflicts=("grouped 与 sonic expert 会对 bias 直接 assert",),
+        suggestion="routed expert 上的 bias 要求 moe_expert_fusion=False 且 "
+        "using_sonic_moe=False; grouped 与 Sonic expert 不是忽略它, 而是 assert。",
+        doc_ref="CONFIGS 2.7",
+    ),
+    _f(
+        "fp8_weight_quant_format",
+        "expert.sonic",
+        "只有 Sonic expert 会读它",
+        requires=("必须开启 fp8",),
+        suggestion="standard 与 grouped expert 只会对该字段打一条 warning, 值并不"
+        "会被应用。",
+        doc_ref="CONFIGS 2.7 / REPORT 11.6",
+    ),
+    _f(
+        "moe_dequant_input",
+        "expert",
+        "从不生效: fusion node 内部把 dequant_input 硬编码为 True",
+        status=Status.DEAD,
+        policy=Policy.WARN,
+        suggestion="moe_dequant_input 没有任何读取点; fusion node 总是会做反量化。"
+        "请从 config 里删除。",
+        doc_ref="CONFIGS 2.7 / REPORT 11.4",
+    ),
+)
+
+_SHARED_EXPERT_FIELDS = (
+    _f(
+        "n_shared_experts",
+        "shared_expert",
+        "决定 shared expert 是否存在",
+        selector=True,
+        conflicts=("默认值 None 会在需要与之相乘的路径上于构造期抛 TypeError",),
+        doc_ref="CONFIGS 2.8 / REPORT 11.9",
+    ),
+    _f(
+        "moe_shared_expert_gate",
+        "shared_expert",
+        "shared expert 存在时总是生效",
+        requires=("n_shared_experts > 0",),
+        suggestion="没有 shared expert 却配 shared expert gate, 不起任何作用。",
+        doc_ref="CONFIGS 2.8 / GPT 5 P1",
+    ),
+    _f(
+        "moe_shared_expert_overlap",
+        "shared_expert",
+        "条件生效; 四个条件必须同时满足(shared expert 存在、fusion node 开启、"
+        "EP > 1、dispatcher 后端有 overlap 窗口)",
+        requires=(
+            "n_shared_experts > 0",
+            "moe_use_fusion_node=True",
+            "EP > 1",
+        ),
+        unverifiable=("不在 scheduler 路径上(取决于运行时调度方式)",),
+        conflicts=("hybridep + fusion node 组合会在构造期强制关闭 overlap",),
+        suggestion="前三个条件任一不满足时, overlap 会被静默跳过(既不报错也不打"
+        "warning); hybridep 下则会被构造期强制关闭。",
+        doc_ref="moe_layer.py:1358-1362 / BRANCHES 3.3",
+    ),
+)
+
+_SUBBATCH_FIELDS = (
+    _f(
+        "use_auto_subbatch",
+        "subbatch_recompute",
+        "条件生效; 它启用自动分块路径",
+        doc_ref="CONFIGS 2.9",
+    ),
+    _f(
+        "auto_subbatch_mode",
+        "subbatch_recompute",
+        "只有与 use_auto_subbatch 一起配才生效",
+        requires=(
+            "use_auto_subbatch=True; 只设 mode 不起作用",
+            "pre_permute 还额外要求 expert fusion",
+        ),
+        suggestion="单独配 auto_subbatch_mode 是无效的; 请同时打开 "
+        "use_auto_subbatch。",
+        doc_ref="CONFIGS 2.9",
+    ),
+    _f(
+        "moe_subbatch_token_num_after_dispatch",
+        "subbatch_recompute",
+        "条件生效; 它选中固定分块路径",
+        unverifiable=(
+            "tile 对齐与 fusion/DeepGEMM token 数一致性取决于运行时实际 token 数",
+        ),
+        doc_ref="CONFIGS 2.9",
+    ),
+    _f(
+        "moe_subbatch_token_num_before_dispatch",
+        "subbatch_recompute",
+        "从不生效: 字段有声明但没有任何消费者",
+        status=Status.DEAD,
+        policy=Policy.WARN,
+        suggestion="请改用 moe_subbatch_token_num_after_dispatch; before_dispatch "
+        "这一版没有任何读取点。",
+        doc_ref="CONFIGS 2.9",
+    ),
+    _f(
+        "recompute_moe_gate_up",
+        "subbatch_recompute",
+        "条件生效; 固定 subbatch 也会隐式打开它, 且不回写配置快照",
+        status=Status.UNDECLARED,
+        policy=Policy.WARN,
+        suggestion="通过 getattr 读取, 也可由 recompute_granularity=selective 加 "
+        "recompute_modules 推导出来; 字段名拼错会被静默吸收。",
+        doc_ref="CONFIGS 2.9 / moe_layer.py:550",
+    ),
+    _f(
+        "recompute_moe_premute",
+        "subbatch_recompute",
+        "条件生效",
+        requires=("必须同时开启 recompute_moe_gate_up",),
+        status=Status.UNDECLARED,
+        policy=Policy.WARN,
+        suggestion="通过 getattr 读取, 也可由 recompute_granularity=selective 加 "
+        "recompute_modules 推导出来; 字段名拼错会被静默吸收。",
+        doc_ref="CONFIGS 2.9 / moe_layer.py:557",
+    ),
+    _f(
+        "moe_subbatch_diag",
+        "subbatch_recompute",
+        "总是生效; 纯观测项, 既不改变数学也不改变显存策略",
+        policy=Policy.INFO,
+        doc_ref="CONFIGS 2.9",
+    ),
+)
+
+_PRECISION_FIELDS = (
+    _f(
+        "fp8",
+        ("precision", "expert", "dispatcher.deepep"),
+        "总是生效; 它选中精度分支, 并同时改变 dispatch payload、expert kernel 和 "
+        "wgrad dtype",
+        selector=True,
+        requires=(
+            "moe_use_fusion_node=True, 否则会触发 assert",
+            "CUDA 版本不能是 12.6",
+            "不能是 SiTU 激活, 该激活只支持 BF16",
+        ),
+        doc_ref="CONFIGS 2.10",
+    ),
+    _f(
+        "use_w4a8",
+        "precision.w4a8",
+        "只有在 deepep + grouped expert + fusion + deep_gemm 的组合下才真正生效; "
+        "其余路径下它只是关掉 fp8 dispatch",
+        selector=True,
+        requires=(
+            "dispatcher.deepep",
+            "expert.grouped, 且 moe_expert_fusion 与 moe_deep_gemm 均开启",
+            "已开启 fp8",
+        ),
+        conflicts=(
+            "hybridep 不会把该参数传给 kernel",
+            "allgather 强制走 Sonic, 而 Sonic 不接收 W4A8 参数",
+        ),
+        suggestion="在其他任何路径上, use_w4a8 会静默退化成只关闭 fp8 dispatch, "
+        "没有任何 W4A8 计算。",
+        doc_ref="CONFIGS 2.10 / REPORT 11.9",
+    ),
+    _f(
+        "use_w4a8_fused_quant",
+        "precision.w4a8",
+        "只有 use_w4a8 生效时才生效",
+        requires=("use_w4a8=True",),
+        suggestion="没有 use_w4a8 却配 use_w4a8_fused_quant, 不起任何作用。",
+        doc_ref="CONFIGS 2.10 / GPT 5 P1",
+    ),
+    _f(
+        "use_ue8m0",
+        "precision.fp8",
+        "只有在 SM100 且已开启 fp8 时才生效",
+        requires=("设备算力为 10(Blackwell)", "已开启 fp8"),
+        conflicts=("与 fp8 之间没有联动校验, 所以 BF16 下它是静默无效的",),
+        suggestion="use_ue8m0 在非 SM100 硬件上会 assert, 但 fp8 关闭时只是被静默"
+        "忽略。",
+        doc_ref="CONFIGS 2.10 / REPORT 11.9",
+    ),
+    _f(
+        "fp8_wgrad",
+        "precision.fp8",
+        "仅 fp8 下生效; 它同时决定 wgrad dtype 和派生出的 combine 精度",
+        requires=("已开启 fp8",),
+        stage=Stage.BACKWARD,
+        suggestion="一个字段耦合了两个本应独立的精度维度(wgrad dtype 与 dispatch "
+        "combine 精度), 二者无法分别设置。",
+        doc_ref="CONFIGS 2.10",
+    ),
+    _f(
+        "fp8_recipe",
+        "precision",
+        "MoE 不读它; 消费者是 dense/TP linear 层与 context parallel 的 padding 计算",
+        status=Status.FOREIGN,
+        policy=Policy.INFO,
+        suggestion="fp8_recipe 不是死配置, 只是 MoE 路径不读它; 其他子系统目前只接"
+        "受 'blockwise'。",
+        doc_ref="tensor_parallel/layers.py:1453, fp8/quantization.py:43",
+    ),
+    _f(
+        "full_fp8_computation",
+        "precision",
+        "MoE 不读它; 消费者是 dense/TP linear 层与 hybrid attention",
+        status=Status.FOREIGN,
+        policy=Policy.INFO,
+        suggestion="full_fp8_computation 控制的是 dense 侧的 FP8 路径, 不是 MoE; "
+        "要切换 MoE 精度请用 fp8。",
+        doc_ref="tensor_parallel/layers.py:1433, dsv4_hybrid_attention.py:1109",
+    ),
+    _f(
+        "fp8_dispatch",
+        ("precision", "dispatcher.deepep", "dispatcher.hybridep"),
+        "由 ``fp8 and not use_w4a8`` 派生; alltoall 还会额外把它强制关闭, 因为该路"
+        "径不承载 FP8 payload",
+        status=Status.DERIVED,
+        policy=Policy.WARN,
+        suggestion="fp8_dispatch 无法设置: 它跟随 fp8 与 use_w4a8。",
+        doc_ref="moe_layer.py:202, moe_layer.py:352",
+    ),
+    _f(
+        "fp8_dispatch_bwd",
+        ("precision", "dispatcher.deepep"),
+        "由 ``fp8_dispatch and using_sonic_moe and fp8_wgrad`` 派生",
+        stage=Stage.BACKWARD,
+        status=Status.DERIVED,
+        policy=Policy.WARN,
+        suggestion="fp8_dispatch_bwd 无法设置: 它跟随 fp8、using_sonic_moe 与 "
+        "fp8_wgrad。",
+        doc_ref="moe_layer.py:204",
+    ),
+)
+
+_ARCHITECTURE_FIELDS = (
+    _f(
+        "n_routed_experts",
+        "architecture",
+        "总是生效; routed expert 的数量",
+        policy=Policy.INFO,
+        doc_ref="transformer_config.py:555",
+    ),
+    _f(
+        "moe_intermediate_size",
+        "architecture",
+        "总是生效; expert FFN 的宽度",
+        policy=Policy.INFO,
+        doc_ref="transformer_config.py:571",
+    ),
+    _f(
+        "moe_layer_freq",
+        "architecture",
+        "总是生效; 决定哪些层是 MoE 层",
+        policy=Policy.INFO,
+        doc_ref="transformer_config.py:594",
+    ),
+    _f(
+        "moe_latent_size",
+        "architecture",
+        "条件生效; >0 时在 MoE block 两侧启用 latent 投影",
+        policy=Policy.INFO,
+        doc_ref="moe_layer.py:240",
+    ),
+)
+
+# 基于容量的 token 丢弃从未接入这套 MoE 实现。与上面那些死配置不同, 这几个字段
+# 设计文档里没有提到, 因此单独成组并附上各自的说明。
+_UNWIRED_CAPACITY_FIELDS = (
+    _f(
+        "moe_expert_capacity_factor",
+        "expert",
+        "从不生效: 这套实现里没有基于容量的 token 丢弃",
+        status=Status.DEAD,
+        policy=Policy.WARN,
+        suggestion="不存在任何容量上限, 所有被路由的 token 都会送到 expert。请删除"
+        "该字段。",
+        doc_ref="全仓库无消费者",
+    ),
+    _f(
+        "moe_pad_expert_input_to_capacity",
+        "expert",
+        "从不生效: 这套实现里没有基于容量的 padding",
+        status=Status.DEAD,
+        policy=Policy.WARN,
+        suggestion="它依赖 moe_expert_capacity_factor, 而后者同样没有消费者。请删除"
+        "该字段。",
+        doc_ref="全仓库无消费者",
+    ),
+    _f(
+        "moe_token_drop_policy",
+        "expert",
+        "从不生效: 不会丢弃任何 token, 所以这个策略无人查询",
+        status=Status.DEAD,
+        policy=Policy.WARN,
+        suggestion="请删除该字段; token 丢弃功能没有实现。",
+        doc_ref="全仓库无消费者",
+    ),
+    _f(
+        "moe_logging",
+        "subbatch_recompute",
+        "从不生效: 字段有声明但没有任何消费者",
+        status=Status.DEAD,
+        policy=Policy.WARN,
+        suggestion="MoE 侧的观测请用 moe_subbatch_diag; moe_logging 没有任何读取"
+        "点, 尽管大量实验配置仍在设置它。",
+        doc_ref="全仓库无消费者",
+    ),
+    _f(
+        "moe_extended_tp",
+        "architecture",
+        "从不生效: 在 ModelParallelConfig 里有声明但没有任何消费者",
+        status=Status.DEAD,
+        policy=Policy.WARN,
+        suggestion="expert 侧的张量并行不由这个字段决定; 请删除。",
+        doc_ref="model_parallel_config.py:87, 全仓库无消费者",
+    ),
+)
+
+
+def _build_registry():
+    registry = {}
+    for group in (
+        _ROUTER_FIELDS,
+        _ROUTER_SECONDARY_FIELDS,
+        _ROUTER_FUSION_FIELDS,
+        _DISPATCHER_FIELDS,
+        _EXPERT_FIELDS,
+        _SHARED_EXPERT_FIELDS,
+        _SUBBATCH_FIELDS,
+        _PRECISION_FIELDS,
+        _ARCHITECTURE_FIELDS,
+        _UNWIRED_CAPACITY_FIELDS,
+    ):
+        for spec in group:
+            if spec.name in registry:
+                raise RuntimeError(
+                    f"MoE 字段 {spec.name!r} 被重复登记: 每个字段只能声明一次, "
+                    "多个归属子模块应写在同一条 owner 元组里"
+                )
+            registry[spec.name] = spec
+    return registry
+
+
+MOE_FIELD_REGISTRY: dict[str, MoEFieldSpec] = _build_registry()
+
+
+def spec_for(name):
+    """返回 ``name`` 对应的 spec; 该字段与 MoE 无关时返回 None。"""
+    return MOE_FIELD_REGISTRY.get(name)
+
+
+def fields_owned_by(owner, include_secondary=True):
+    """返回归 ``owner`` 所有的字段名。
+
+    ``fields_owned_by("router")`` 返回全部 router 次级分支共用的字段, 并默认额外
+    带上归属于某个具体次级分支(如 ``router.quantile_balancing``)的字段; 传
+    ``include_secondary=False`` 则只返回共用字段。
+    """
+    prefix = owner + "."
+    names = []
+    for spec in MOE_FIELD_REGISTRY.values():
+        for own in spec.owner:
+            if own == owner or (include_secondary and own.startswith(prefix)):
+                names.append(spec.name)
+                break
+    return tuple(names)
+
+
+def fields_with_status(status):
+    """返回 status 为 ``status`` 的全部字段名。"""
+    return tuple(
+        spec.name
+        for spec in MOE_FIELD_REGISTRY.values()
+        if spec.status is status
+    )

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -730,6 +730,29 @@ class TransformerConfig(ModelParallelConfig):
     """Apply RMSNorm to routed latent-MoE output before projecting it back to
     the model hidden size."""
 
+    moe_config_check: str = "off"
+    """MoE 配置检查模式, 取值 off / report / strict。
+
+    MoE 会按路由决策(EP size、dispatcher 类型、expert 组合、精度、设备算力)只读取
+    配置字段的一个子集, 归属于其他路径的字段配了也不会被读取, 目前没有任何提示。
+
+    - ``off``(默认): 不检查, 行为与开启此功能前完全一致。
+    - ``report``: 启动时打印一次执行计划, 以及"配了但当前路径不读"的字段。
+    - ``strict``: 存在必须修复的问题时直接报错, 一次性列出全部问题。
+
+    字段级诊断需要 ``user_specified_keys``; 没有它时只打印执行计划。
+    """
+
+    user_specified_keys: tuple[str, ...] | None = None
+    """上游真正显式配置过的字段名集合(对 ERNIEBot 而言是 YAML 键 ∪
+    model_config.json 键)。
+
+    不能靠 config 自己反推: 上游 ``PretrainedConfig`` 会把自身默认值一并写入
+    ``__dict__``, 实测 47 个 MoE 字段里有 13 个会被误判成用户显式设置(其中包含
+    ``moe_token_dispatcher_type``、``moe_expert_fusion`` 这些最关键的开关)。因此
+    严格模式必须由上游把这个集合传进来, 拿不到时诊断自动降级为只打印执行计划。
+    """
+
     ##################
     # Context Parallel
     ##################
@@ -2674,3 +2697,9 @@ class TransformerConfig(ModelParallelConfig):
                         "Forcing separate_mtp_headloss=False."
                     )
                     self.separate_mtp_headloss = False
+
+        # MoE 配置检查。默认 moe_config_check="off", 此时该调用直接返回, 不改变任何
+        # 现有行为; 设为 report/strict 才会生效。放在 __post_init__ 末尾是为了让检查
+        # 看到的是完整推导后的配置。延迟 import 避免 import 期的循环依赖。
+        from .moe.moe_config_check import run_moe_config_check
+        run_moe_config_check(self)

--- a/tests/single_card_tests/transformer/test_moe_config_check.py
+++ b/tests/single_card_tests/transformer/test_moe_config_check.py
@@ -1,0 +1,997 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""MoE 配置检查的全部单测: 登记表契约、路由推导、可判定规则、诊断入口。
+
+全部在 CPU 上跑: 设备算力是 resolve_moe_plan 的入参而不是从设备读, 所以一台机器就能
+覆盖 Ampere 回退、Blackwell 专属等任何组合。
+
+按 YAML 检查真实配置的示例见 test_moe_config_check_example.py。
+"""
+
+import dataclasses
+import re
+import unittest
+from types import SimpleNamespace
+
+from paddlefleet.transformer.moe import moe_config_registry as registry
+from paddlefleet.transformer.moe.moe_config_check import (
+    MOE_CONFIG_RULES,
+    MoEConfigError,
+    collect_findings,
+    evaluate_rules,
+    resolve_moe_plan,
+    run_moe_config_check,
+)
+from paddlefleet.transformer.transformer_config import TransformerConfig
+
+Status = registry.Status
+HOPPER = (9, 0)
+AMPERE = (8, 0)
+
+
+# ======================================================================
+# 登记表契约: 防止登记表与 config schema 漂移
+# ======================================================================
+
+Status = registry.Status
+
+SCHEMA_BACKED = (Status.ACTIVE, Status.DEAD, Status.FOREIGN)
+NOT_SCHEMA_BACKED = (Status.UNDECLARED, Status.DERIVED)
+
+# Fields whose name matches the MoE pattern but which the registry deliberately
+# leaves out, with the reason. Anything else matching the pattern must be
+# registered, so a newly added switch cannot slip in unowned.
+UNREGISTERED_BY_DESIGN = {
+    "moe_grad_group": "process group plumbing, not a user switch",
+    "latent_moe_use_norm": "sub-option of moe_latent_size, shares its owner",
+    "moe_config_check": "本套诊断机制自己的开关, 不参与 MoE 计算",
+}
+
+_MOE_FIELD_PATTERN = re.compile(
+    r"^(moe_|n_routed_experts|n_shared_experts|num_experts_per_tok|scoring_func"
+    r"|topk_|n_group|norm_topk_prob|routed_scaling_factor|router_"
+    r"|qb_n_bins|actual_vocab_size|routing_map_fusion|using_sonic_moe"
+    r"|use_w4a8|use_ue8m0|use_auto_subbatch|auto_subbatch_mode"
+    r"|use_rr_deepep|deepep_|hybridep_)"
+)
+
+
+def _schema_fields():
+    return {f.name for f in dataclasses.fields(TransformerConfig)}
+
+
+class TestRegistryMatchesConfigSchema(unittest.TestCase):
+    def test_schema_backed_entries_are_real_config_fields(self):
+        schema = _schema_fields()
+        missing = sorted(
+            name
+            for name, spec in registry.MOE_FIELD_REGISTRY.items()
+            if spec.status in SCHEMA_BACKED and name not in schema
+        )
+        self.assertEqual(
+            missing,
+            [],
+            "registry describes fields that TransformerConfig does not declare; "
+            "either the field was renamed/removed, or its status should be "
+            "UNDECLARED (read via getattr) or DERIVED (computed internally)",
+        )
+
+    def test_non_schema_entries_are_not_config_fields(self):
+        schema = _schema_fields()
+        unexpected = sorted(
+            name
+            for name, spec in registry.MOE_FIELD_REGISTRY.items()
+            if spec.status in NOT_SCHEMA_BACKED and name in schema
+        )
+        self.assertEqual(
+            unexpected,
+            [],
+            "these fields are now declared in TransformerConfig, so they are no "
+            "longer getattr-only or purely derived; update their status",
+        )
+
+    def test_every_moe_config_field_has_an_owner(self):
+        unowned = sorted(
+            name
+            for name in _schema_fields()
+            if _MOE_FIELD_PATTERN.match(name)
+            and name not in registry.MOE_FIELD_REGISTRY
+            and name not in UNREGISTERED_BY_DESIGN
+        )
+        self.assertEqual(
+            unowned,
+            [],
+            "new MoE config fields must be added to MOE_FIELD_REGISTRY (or to "
+            "UNREGISTERED_BY_DESIGN with a reason), otherwise no diagnostic can "
+            "tell a user whether the field applies to their execution path",
+        )
+
+
+class TestRegistryInternalConsistency(unittest.TestCase):
+    def test_owner_paths_are_known_submodules(self):
+        for name, spec in registry.MOE_FIELD_REGISTRY.items():
+            self.assertTrue(spec.owner, f"{name} has no owner")
+            for owner in spec.owner:
+                self.assertIn(
+                    owner,
+                    registry.VALID_OWNERS,
+                    f"{name} claims unknown submodule {owner!r}",
+                )
+
+    def test_fields_that_do_nothing_explain_what_to_do_instead(self):
+        for name, spec in registry.MOE_FIELD_REGISTRY.items():
+            if spec.status in (Status.DEAD, Status.FOREIGN, Status.DERIVED):
+                self.assertTrue(
+                    spec.suggestion,
+                    f"{name} is {spec.status.value}: a diagnostic about it is "
+                    "useless without a suggestion of what to set instead",
+                )
+
+    def test_secondary_owned_fields_explain_their_scope(self):
+        """A field read by only some of the paths of its submodule is silently
+        ignored on the others, so the registry must carry something the
+        diagnostic can quote."""
+        all_dispatchers = set(registry.DISPATCHER_SUBMODULES)
+        for name, spec in registry.MOE_FIELD_REGISTRY.items():
+            if spec.status is not Status.ACTIVE:
+                continue
+            owners = set(spec.owner)
+            partial_dispatcher = bool(owners & all_dispatchers) and not (
+                all_dispatchers <= owners
+            )
+            secondary = any(registry.is_secondary_owner(o) for o in spec.owner)
+            if not (partial_dispatcher or secondary):
+                continue
+            self.assertTrue(
+                spec.suggestion or spec.requires,
+                f"{name} is read by only part of its submodule "
+                f"({sorted(owners)}), so it is silently ignored elsewhere; it "
+                "needs either a suggestion or explicit requires",
+            )
+
+    def test_lookup_helpers(self):
+        self.assertIsNone(registry.spec_for("hidden_size"))
+        self.assertEqual(
+            registry.spec_for("qb_n_bins").owner,
+            ("router.quantile_balancing",),
+        )
+
+        router_fields = registry.fields_owned_by("router")
+        self.assertIn("topk_method", router_fields)
+        self.assertIn("qb_n_bins", router_fields)
+        self.assertNotIn(
+            "qb_n_bins",
+            registry.fields_owned_by("router", include_secondary=False),
+        )
+
+        self.assertIn(
+            "moe_ep_barrier", registry.fields_owned_by("dispatcher.deepep")
+        )
+        self.assertIn(
+            "moe_ep_barrier", registry.fields_owned_by("dispatcher.alltoall")
+        )
+
+
+# ======================================================================
+# 路由推导: resolve_moe_plan 复刻的决策
+# ======================================================================
+
+HOPPER = (9, 0)
+AMPERE = (8, 0)
+
+
+def _plan_config(**overrides):
+    """A config with the real TransformerConfig defaults for the fields the
+    resolver reads, so a test only states what it changes."""
+    base = {
+        "moe_token_dispatcher_type": "deepep",
+        "moe_use_fusion_node": True,
+        "moe_expert_fusion": False,
+        "moe_deep_gemm": True,
+        "moe_shared_expert_overlap": False,
+        "using_sonic_moe": False,
+        "fp8": None,
+        "fp8_wgrad": True,
+        "use_w4a8": False,
+        "topk_method": "greedy",
+        "moe_n_hash_layers": 0,
+        "n_shared_experts": None,
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _plan_adjusted(plan):
+    return {
+        adjustment.name: adjustment.effective for adjustment in plan.adjustments
+    }
+
+
+class TestDispatcherSelection(unittest.TestCase):
+    def test_no_dispatcher_without_expert_parallelism(self):
+        """With EP == 1 the dispatcher branch in MoELayer is never entered, so
+        moe_token_dispatcher_type does not select anything."""
+        plan = resolve_moe_plan(
+            _plan_config(), expert_parallel_size=1, device_capability=HOPPER
+        )
+
+        self.assertIsNone(plan.dispatcher)
+        self.assertNotIn("dispatcher.deepep", plan.active_submodules)
+
+    def test_deepep_survives_on_hopper(self):
+        plan = resolve_moe_plan(
+            _plan_config(moe_expert_fusion=True),
+            expert_parallel_size=8,
+            device_capability=HOPPER,
+        )
+
+        self.assertEqual(plan.dispatcher, "deepep")
+        self.assertEqual(plan.adjustments, ())
+
+    def test_default_config_contradicts_itself_on_deep_gemm(self):
+        """moe_deep_gemm defaults to True and moe_expert_fusion to False, so the
+        untouched defaults already resolve DeepGEMM away (REPORT 11.9)."""
+        plan = resolve_moe_plan(
+            _plan_config(), expert_parallel_size=8, device_capability=HOPPER
+        )
+
+        self.assertFalse(plan.moe_deep_gemm)
+        self.assertEqual(_plan_adjusted(plan), {"moe_deep_gemm": False})
+
+    def test_pre_hopper_falls_back_to_alltoall(self):
+        plan = resolve_moe_plan(
+            _plan_config(moe_expert_fusion=True),
+            expert_parallel_size=8,
+            device_capability=AMPERE,
+        )
+
+        self.assertEqual(plan.dispatcher, "alltoall")
+        self.assertEqual(
+            _plan_adjusted(plan),
+            {
+                "moe_token_dispatcher_type": "alltoall",
+                "moe_deep_gemm": False,
+                "moe_use_fusion_node": False,
+            },
+        )
+
+    def test_unknown_capability_skips_the_fallback(self):
+        plan = resolve_moe_plan(
+            _plan_config(), expert_parallel_size=8, device_capability=None
+        )
+
+        self.assertEqual(plan.dispatcher, "deepep")
+
+    def test_missing_hybridep_runtime_is_recorded_not_raised(self):
+        plan = resolve_moe_plan(
+            _plan_config(moe_token_dispatcher_type="hybridep"),
+            expert_parallel_size=8,
+            device_capability=HOPPER,
+            hybrid_ep_available=False,
+        )
+
+        self.assertEqual(plan.dispatcher, "alltoall")
+        self.assertIn("moe_token_dispatcher_type", _plan_adjusted(plan))
+
+
+class TestAllGatherOverwrites(unittest.TestCase):
+    """moe_layer.py:855-887 rewrites three switches; a diagnostic can only tell
+    the user which of their values were discarded if the plan records them."""
+
+    def test_allgather_forces_three_switches(self):
+        plan = resolve_moe_plan(
+            _plan_config(
+                moe_token_dispatcher_type="allgather",
+                using_sonic_moe=True,
+                moe_use_fusion_node=False,
+                moe_expert_fusion=False,
+                moe_deep_gemm=True,
+            ),
+            expert_parallel_size=8,
+            device_capability=HOPPER,
+        )
+
+        self.assertEqual(plan.dispatcher, "allgather")
+        self.assertTrue(plan.moe_use_fusion_node)
+        self.assertTrue(plan.moe_expert_fusion)
+        self.assertFalse(plan.moe_deep_gemm)
+        self.assertEqual(plan.expert_branch, "sonic")
+
+        overwritten = _plan_adjusted(plan)
+        self.assertEqual(overwritten["moe_use_fusion_node"], True)
+        self.assertEqual(overwritten["moe_expert_fusion"], True)
+        self.assertEqual(overwritten["moe_deep_gemm"], False)
+
+    def test_allgather_records_nothing_when_config_already_agrees(self):
+        plan = resolve_moe_plan(
+            _plan_config(
+                moe_token_dispatcher_type="allgather",
+                using_sonic_moe=True,
+                moe_use_fusion_node=True,
+                moe_expert_fusion=True,
+                moe_deep_gemm=False,
+            ),
+            expert_parallel_size=8,
+            device_capability=HOPPER,
+        )
+
+        self.assertEqual(plan.adjustments, ())
+
+
+class TestAllToAllDowngrades(unittest.TestCase):
+    def test_alltoall_disables_fusion_node_and_fp8_payload(self):
+        plan = resolve_moe_plan(
+            _plan_config(
+                moe_token_dispatcher_type="alltoall",
+                moe_use_fusion_node=True,
+                fp8="blockwise",
+            ),
+            expert_parallel_size=8,
+            device_capability=HOPPER,
+        )
+
+        self.assertFalse(plan.moe_use_fusion_node)
+        self.assertFalse(plan.fp8_dispatch)
+        self.assertEqual(plan.precision, "fp8")
+
+
+class TestExpertAndPrecisionBranches(unittest.TestCase):
+    def test_fp8_without_deep_gemm_splits_field_from_reality(self):
+        """REPORT 11.10 issue#2: construction unfuses the weights through a local
+        variable while moe_expert_fusion keeps saying True."""
+        plan = resolve_moe_plan(
+            _plan_config(
+                fp8="blockwise", moe_expert_fusion=True, moe_deep_gemm=False
+            ),
+            expert_parallel_size=8,
+            device_capability=HOPPER,
+        )
+
+        self.assertTrue(plan.moe_expert_fusion)
+        self.assertFalse(plan.expert_weights_fused)
+        self.assertEqual(plan.expert_branch, "standard")
+        self.assertIn(
+            "forward 仍会读到 True",
+            "".join(adjustment.reason for adjustment in plan.adjustments),
+        )
+
+    def test_grouped_expert_when_fusion_and_deep_gemm_agree(self):
+        plan = resolve_moe_plan(
+            _plan_config(
+                fp8="blockwise", moe_expert_fusion=True, moe_deep_gemm=True
+            ),
+            expert_parallel_size=8,
+            device_capability=HOPPER,
+        )
+
+        self.assertEqual(plan.expert_branch, "grouped")
+        self.assertTrue(plan.expert_weights_fused)
+
+    def test_w4a8_wins_over_fp8_and_kills_fp8_dispatch(self):
+        plan = resolve_moe_plan(
+            _plan_config(
+                fp8="blockwise", use_w4a8=True, moe_expert_fusion=True
+            ),
+            expert_parallel_size=8,
+            device_capability=HOPPER,
+        )
+
+        self.assertEqual(plan.precision, "w4a8")
+        self.assertFalse(plan.fp8_dispatch)
+
+    def test_fp8_dispatch_bwd_needs_sonic_and_wgrad(self):
+        common = {
+            "fp8": "blockwise",
+            "moe_expert_fusion": True,
+            "moe_deep_gemm": False,
+        }
+
+        sonic = resolve_moe_plan(
+            _plan_config(using_sonic_moe=True, **common),
+            expert_parallel_size=8,
+            device_capability=HOPPER,
+        )
+        no_wgrad = resolve_moe_plan(
+            _plan_config(using_sonic_moe=True, fp8_wgrad=False, **common),
+            expert_parallel_size=8,
+            device_capability=HOPPER,
+        )
+
+        self.assertTrue(sonic.fp8_dispatch_bwd)
+        self.assertFalse(no_wgrad.fp8_dispatch_bwd)
+
+
+class TestActiveSubmodules(unittest.TestCase):
+    def test_active_submodules_are_registry_owners(self):
+        """The validator matches these names against registry owners, so an
+        unknown name would silently make every field look out of scope."""
+        for dispatcher in ("alltoall", "deepep", "allgather"):
+            plan = resolve_moe_plan(
+                _plan_config(
+                    moe_token_dispatcher_type=dispatcher,
+                    using_sonic_moe=dispatcher == "allgather",
+                    moe_expert_fusion=dispatcher == "allgather",
+                    n_shared_experts=2,
+                    moe_n_hash_layers=1,
+                    topk_method="noaux_tc",
+                ),
+                expert_parallel_size=8,
+                device_capability=HOPPER,
+            )
+            unknown = plan.active_submodules - registry.VALID_OWNERS
+            self.assertEqual(unknown, set(), f"{dispatcher}: unknown owners")
+
+    def test_shared_expert_absent_when_not_configured(self):
+        plan = resolve_moe_plan(
+            _plan_config(n_shared_experts=None),
+            expert_parallel_size=8,
+            device_capability=HOPPER,
+        )
+
+        self.assertFalse(plan.shared_expert)
+        self.assertNotIn("shared_expert", plan.active_submodules)
+
+    def test_router_branch_follows_topk_method(self):
+        for topk_method, branch in (
+            ("greedy", "greedy"),
+            ("group_limited_greedy", "group_limited"),
+            ("noaux_tc", "noaux_tc"),
+            ("quantile_balancing", "quantile_balancing"),
+        ):
+            plan = resolve_moe_plan(
+                _plan_config(topk_method=topk_method),
+                expert_parallel_size=8,
+                device_capability=HOPPER,
+            )
+            self.assertEqual(plan.router_branch, branch)
+            self.assertIn(f"router.{branch}", plan.active_submodules)
+
+
+# ======================================================================
+# 可判定规则与诊断入口
+# ======================================================================
+
+HOPPER = (9, 0)
+
+
+def _config(**overrides):
+    base = {
+        "n_routed_experts": 64,
+        "moe_token_dispatcher_type": "deepep",
+        "moe_use_fusion_node": True,
+        "moe_expert_fusion": True,
+        "moe_deep_gemm": True,
+        "moe_shared_expert_overlap": False,
+        "using_sonic_moe": False,
+        "fp8": None,
+        "fp8_wgrad": True,
+        "use_w4a8": False,
+        "use_w4a8_fused_quant": False,
+        "use_ue8m0": False,
+        "topk_method": "noaux_tc",
+        "moe_topk_fusion": False,
+        "n_group": 1,
+        "moe_n_hash_layers": 0,
+        "actual_vocab_size": None,
+        "n_shared_experts": 1,
+        "moe_shared_expert_gate": False,
+        "use_auto_subbatch": False,
+        "auto_subbatch_mode": None,
+        "moe_routed_expert_use_bias": None,
+        "use_bias": False,
+        "hidden_act": "silu",
+        "expert_model_parallel_size": 8,
+        "moe_config_check": "report",
+        "user_specified_keys": None,
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _rule_codes(config, keys, capability=HOPPER, ep_size=8):
+    plan = resolve_moe_plan(
+        config, expert_parallel_size=ep_size, device_capability=capability
+    )
+    return {
+        rule.code for rule, _ in evaluate_rules(config, plan, capability, keys)
+    }
+
+
+class TestRulesOnlyFireForUserConfiguredFields(unittest.TestCase):
+    def test_default_only_config_reports_nothing(self):
+        """全默认值的配置不该产出任何规则命中——即使默认值组合本身矛盾, 那也不是
+        用户的错。"""
+        self.assertEqual(_rule_codes(_config(), keys=set()), set())
+
+    def test_same_problem_is_silent_until_the_user_sets_the_field(self):
+        config = _config(use_ue8m0=True, fp8=None)
+
+        self.assertEqual(_rule_codes(config, keys=set()), set())
+        self.assertIn("B6", _rule_codes(config, keys={"use_ue8m0"}))
+
+
+class TestDependencyRules(unittest.TestCase):
+    def test_b1_w4a8_fused_quant_without_w4a8(self):
+        codes = _rule_codes(
+            _config(use_w4a8_fused_quant=True, use_w4a8=False),
+            keys={"use_w4a8_fused_quant"},
+        )
+        self.assertIn("B1", codes)
+
+    def test_b2_actual_vocab_size_without_hash_routing(self):
+        codes = _rule_codes(
+            _config(actual_vocab_size=100000, moe_n_hash_layers=0),
+            keys={"actual_vocab_size"},
+        )
+        self.assertIn("B2", codes)
+
+    def test_b3_hash_routing_without_actual_vocab_size(self):
+        codes = _rule_codes(
+            _config(moe_n_hash_layers=2, actual_vocab_size=None),
+            keys={"moe_n_hash_layers"},
+        )
+        self.assertIn("B3", codes)
+
+    def test_b4_shared_expert_gate_without_shared_expert(self):
+        codes = _rule_codes(
+            _config(moe_shared_expert_gate=True, n_shared_experts=None),
+            keys={"moe_shared_expert_gate"},
+        )
+        self.assertIn("B4", codes)
+
+    def test_b5_subbatch_mode_without_master_switch(self):
+        codes = _rule_codes(
+            _config(auto_subbatch_mode="post_permute", use_auto_subbatch=False),
+            keys={"auto_subbatch_mode"},
+        )
+        self.assertIn("B5", codes)
+
+    def test_dependencies_satisfied_produce_no_finding(self):
+        codes = _rule_codes(
+            _config(
+                moe_n_hash_layers=2,
+                actual_vocab_size=100000,
+                auto_subbatch_mode="post_permute",
+                use_auto_subbatch=True,
+                moe_shared_expert_gate=True,
+                n_shared_experts=1,
+            ),
+            keys={
+                "moe_n_hash_layers",
+                "actual_vocab_size",
+                "auto_subbatch_mode",
+                "use_auto_subbatch",
+                "moe_shared_expert_gate",
+            },
+        )
+        self.assertEqual(codes, set())
+
+
+class TestConflictRules(unittest.TestCase):
+    def test_c1_and_c2_quantile_balancing_conflicts(self):
+        codes = _rule_codes(
+            _config(
+                topk_method="quantile_balancing",
+                moe_topk_fusion=True,
+                n_group=4,
+            ),
+            keys={"topk_method", "moe_topk_fusion", "n_group"},
+        )
+        self.assertIn("C1", codes)
+        self.assertIn("C2", codes)
+
+    def test_c3_topk_fusion_without_noaux_tc(self):
+        codes = _rule_codes(
+            _config(topk_method="greedy", moe_topk_fusion=True),
+            keys={"topk_method", "moe_topk_fusion"},
+        )
+        self.assertIn("C3", codes)
+
+    def test_c4_fp8_loses_the_fusion_node_on_alltoall(self):
+        codes = _rule_codes(
+            _config(
+                fp8="e4m3",
+                moe_token_dispatcher_type="alltoall",
+                moe_expert_fusion=False,
+                moe_deep_gemm=False,
+            ),
+            keys={"fp8", "moe_token_dispatcher_type"},
+        )
+        self.assertIn("C4", codes)
+
+    def test_c5_fp8_with_situ_activation(self):
+        from paddlefleet.transformer.activations import situ
+
+        codes = _rule_codes(
+            _config(fp8="e4m3", hidden_act=situ),
+            keys={"fp8", "hidden_act"},
+        )
+        self.assertIn("C5", codes)
+
+    def test_c6_fp8_deep_gemm_without_expert_fusion(self):
+        codes = _rule_codes(
+            _config(fp8="e4m3", moe_expert_fusion=False, moe_deep_gemm=True),
+            keys={"fp8", "moe_expert_fusion", "moe_deep_gemm"},
+        )
+        self.assertIn("C6", codes)
+
+    def test_c7_alltoall_rejects_expert_fusion(self):
+        codes = _rule_codes(
+            _config(
+                moe_token_dispatcher_type="alltoall", moe_expert_fusion=True
+            ),
+            keys={"moe_token_dispatcher_type", "moe_expert_fusion"},
+        )
+        self.assertIn("C7", codes)
+
+    def test_c7_also_fires_after_a_capability_fallback(self):
+        """算力低于 9.0 时 deepep 会被回退成 alltoall, 于是间接触发同一条冲突。
+        这正是"配置本身看不出问题、换机型才炸"的那类场景。"""
+        codes = _rule_codes(
+            _config(moe_token_dispatcher_type="deepep", moe_expert_fusion=True),
+            keys={"moe_token_dispatcher_type", "moe_expert_fusion"},
+            capability=(8, 0),
+        )
+        self.assertIn("C7", codes)
+
+    def test_c8_allgather_requires_sonic(self):
+        codes = _rule_codes(
+            _config(
+                moe_token_dispatcher_type="allgather", using_sonic_moe=False
+            ),
+            keys={"moe_token_dispatcher_type", "using_sonic_moe"},
+        )
+        self.assertIn("C8", codes)
+
+    def test_c9_grouped_expert_rejects_bias(self):
+        codes = _rule_codes(
+            _config(moe_routed_expert_use_bias=True, moe_expert_fusion=True),
+            keys={"moe_routed_expert_use_bias"},
+        )
+        self.assertIn("C9", codes)
+
+    def test_c10_sonic_requires_fused_weights(self):
+        codes = _rule_codes(
+            _config(using_sonic_moe=True, moe_expert_fusion=False),
+            keys={"using_sonic_moe", "moe_expert_fusion"},
+        )
+        self.assertIn("C10", codes)
+
+
+class TestCapabilityRules(unittest.TestCase):
+    def test_e1_ue8m0_needs_blackwell(self):
+        config = _config(use_ue8m0=True, fp8="e4m3")
+
+        self.assertIn(
+            "E1", _rule_codes(config, {"use_ue8m0"}, capability=(9, 0))
+        )
+        self.assertEqual(
+            _rule_codes(config, {"use_ue8m0"}, capability=(10, 0)) & {"E1"},
+            set(),
+        )
+
+    def test_e1_is_skipped_when_capability_is_unknown(self):
+        codes = _rule_codes(
+            _config(use_ue8m0=True, fp8="e4m3"), {"use_ue8m0"}, capability=None
+        )
+        self.assertNotIn("E1", codes)
+
+
+class TestRuleTableHygiene(unittest.TestCase):
+    def test_codes_are_unique_and_documented(self):
+        codes = [rule.code for rule in MOE_CONFIG_RULES]
+        self.assertEqual(len(codes), len(set(codes)), "规则编号重复")
+        for rule in MOE_CONFIG_RULES:
+            self.assertTrue(rule.fields, f"{rule.code} 没有声明涉及的字段")
+            self.assertTrue(rule.suggestion, f"{rule.code} 缺少修复建议")
+            self.assertTrue(rule.doc_ref, f"{rule.code} 缺少源码依据")
+
+
+class TestAllProblemsAreReportedAtOnce(unittest.TestCase):
+    def test_one_run_lists_every_problem(self):
+        """逐个报错会让用户"改一个、跑一次、再报一个", 在排队等卡的训练任务上代价
+        很高, 所以一次必须报全。"""
+        config = _config(
+            topk_method="quantile_balancing",
+            moe_topk_fusion=True,
+            n_group=4,
+            use_ue8m0=True,
+            use_w4a8_fused_quant=True,
+            moe_shared_expert_gate=True,
+            n_shared_experts=None,
+        )
+        keys = {
+            "topk_method",
+            "moe_topk_fusion",
+            "n_group",
+            "use_ue8m0",
+            "use_w4a8_fused_quant",
+            "moe_shared_expert_gate",
+        }
+        plan = resolve_moe_plan(
+            config, expert_parallel_size=8, device_capability=HOPPER
+        )
+
+        findings = collect_findings(
+            config, plan, keys, device_capability=HOPPER
+        )
+        message = str(MoEConfigError(findings, plan))
+
+        for code in ("B1", "B4", "B6", "C1", "C2"):
+            self.assertIn(code, message, f"{code} 没有出现在汇总报错里")
+
+
+class TestSharedExpertOverlapPreconditions(unittest.TestCase):
+    """overlap 的四个前置条件是一串 and(moe_layer.py:1358-1362), 任一不满足就静默
+    不重叠——既不报错也不打 warning, 属于最典型的"配了没用"。"""
+
+    def _findings(self, keys, ep_size=8, **overrides):
+        config = _config(**overrides)
+        plan = resolve_moe_plan(
+            config, expert_parallel_size=ep_size, device_capability=HOPPER
+        )
+        return (
+            config,
+            plan,
+            collect_findings(config, plan, keys, device_capability=HOPPER),
+        )
+
+    def test_b7_overlap_without_shared_expert(self):
+        _, _, findings = self._findings(
+            {"moe_shared_expert_overlap", "n_shared_experts"},
+            moe_shared_expert_overlap=True,
+            n_shared_experts=0,
+        )
+
+        self.assertIn("B7", "".join(f.message for f in findings))
+
+    def test_b7_is_not_duplicated_by_the_generic_scope_check(self):
+        """规则和作用域判定会指向同一个字段; 只保留更具体的规则那条。"""
+        _, _, findings = self._findings(
+            {"moe_shared_expert_overlap", "n_shared_experts"},
+            moe_shared_expert_overlap=True,
+            n_shared_experts=0,
+        )
+
+        overlap_findings = [
+            f for f in findings if "moe_shared_expert_overlap" in f.field
+        ]
+        self.assertEqual(len(overlap_findings), 1, overlap_findings)
+        self.assertEqual(overlap_findings[0].kind, "依赖缺失")
+
+    def test_b8_overlap_loses_the_fusion_node_on_alltoall(self):
+        _, plan, findings = self._findings(
+            {"moe_shared_expert_overlap", "moe_token_dispatcher_type"},
+            moe_shared_expert_overlap=True,
+            n_shared_experts=1,
+            moe_token_dispatcher_type="alltoall",
+            moe_expert_fusion=False,
+            moe_deep_gemm=False,
+        )
+
+        self.assertFalse(plan.moe_use_fusion_node)
+        self.assertIn("B8", "".join(f.message for f in findings))
+
+    def test_b9_overlap_without_expert_parallelism(self):
+        _, _, findings = self._findings(
+            {"moe_shared_expert_overlap"},
+            ep_size=1,
+            moe_shared_expert_overlap=True,
+            n_shared_experts=1,
+        )
+
+        self.assertIn("B9", "".join(f.message for f in findings))
+
+    def test_all_preconditions_met_is_silent(self):
+        _, _, findings = self._findings(
+            {"moe_shared_expert_overlap", "n_shared_experts"},
+            moe_shared_expert_overlap=True,
+            n_shared_experts=1,
+        )
+
+        self.assertEqual(findings, ())
+
+
+class TestBranchSelectorsAreNeverOutOfScope(unittest.TestCase):
+    """选择器把自己的分支关掉后, 不能反过来说这个选择器本身无效——那是倒因为果。"""
+
+    def _scope_fields(self, keys, **overrides):
+        config = _config(**overrides)
+        plan = resolve_moe_plan(
+            config, expert_parallel_size=8, device_capability=HOPPER
+        )
+        return {
+            f.field
+            for f in collect_findings(
+                config, plan, keys, device_capability=HOPPER
+            )
+            if f.kind == "作用域错误"
+        }
+
+    def test_n_shared_experts_zero(self):
+        self.assertNotIn(
+            "n_shared_experts",
+            self._scope_fields({"n_shared_experts"}, n_shared_experts=0),
+        )
+
+    def test_use_w4a8_false(self):
+        self.assertNotIn(
+            "use_w4a8", self._scope_fields({"use_w4a8"}, use_w4a8=False)
+        )
+
+    def test_moe_n_hash_layers_zero(self):
+        self.assertNotIn(
+            "moe_n_hash_layers",
+            self._scope_fields({"moe_n_hash_layers"}, moe_n_hash_layers=0),
+        )
+
+    def test_non_selector_fields_still_report_scope_errors(self):
+        """对照组: qb_n_bins 不是选择器, 在非 QB 路径下必须照常报。"""
+        self.assertIn(
+            "qb_n_bins",
+            self._scope_fields(
+                {"qb_n_bins"}, topk_method="noaux_tc", qb_n_bins=512
+            ),
+        )
+
+
+class TestRouterValueRules(unittest.TestCase):
+    """这些条件原先只作为自由文本挂在 requires 上, 靠"人工确认"; 实际上都能算, 现在
+    都写成规则了。"""
+
+    def test_c11_expert_count_not_divisible_by_group_count(self):
+        codes = _rule_codes(
+            _config(topk_method="noaux_tc", n_routed_experts=64, n_group=6),
+            keys={"n_group", "n_routed_experts"},
+        )
+        self.assertIn("C11", codes)
+
+    def test_c11_is_silent_for_greedy_which_ignores_groups(self):
+        codes = _rule_codes(
+            _config(topk_method="greedy", n_routed_experts=64, n_group=6),
+            keys={"n_group", "n_routed_experts"},
+        )
+        self.assertNotIn("C11", codes)
+
+    def test_c12_unknown_scoring_func(self):
+        codes = _rule_codes(
+            _config(scoring_func="swish"), keys={"scoring_func"}
+        )
+        self.assertIn("C12", codes)
+
+    def test_c13_seq_aux_loss_needs_a_non_negative_scoring_func(self):
+        codes = _rule_codes(
+            _config(
+                moe_router_load_balancing_type="seq_aux_loss",
+                scoring_func="tanh",
+            ),
+            keys={"scoring_func", "moe_router_load_balancing_type"},
+        )
+        self.assertIn("C13", codes)
+
+    def test_c14_hash_routing_restricts_scoring_func(self):
+        codes = _rule_codes(
+            _config(
+                moe_n_hash_layers=2, actual_vocab_size=1000, scoring_func="relu"
+            ),
+            keys={"scoring_func", "moe_n_hash_layers"},
+        )
+        self.assertIn("C14", codes)
+
+    def test_c15_split_feature_routing_needs_sigmoid(self):
+        codes = _rule_codes(
+            _config(moe_split_feature_routing=True, scoring_func="softmax"),
+            keys={"moe_split_feature_routing", "scoring_func"},
+        )
+        self.assertIn("C15", codes)
+
+    def test_valid_router_values_are_silent(self):
+        codes = _rule_codes(
+            _config(
+                topk_method="noaux_tc",
+                n_routed_experts=64,
+                n_group=8,
+                scoring_func="sigmoid",
+                moe_router_load_balancing_type="seq_aux_loss",
+                moe_split_feature_routing=True,
+            ),
+            keys={
+                "topk_method",
+                "n_group",
+                "n_routed_experts",
+                "scoring_func",
+                "moe_router_load_balancing_type",
+                "moe_split_feature_routing",
+            },
+        )
+        self.assertEqual(codes, set())
+
+
+class TestRunMoEConfigCheck(unittest.TestCase):
+    def test_off_mode_does_nothing(self):
+        plan, findings = run_moe_config_check(
+            _config(moe_config_check="off"), device_capability=HOPPER
+        )
+
+        self.assertIsNone(plan)
+        self.assertEqual(findings, ())
+
+    def test_dense_model_is_skipped(self):
+        plan, findings = run_moe_config_check(
+            _config(moe_config_check="strict", n_routed_experts=None),
+            device_capability=HOPPER,
+        )
+
+        self.assertIsNone(plan)
+        self.assertEqual(findings, ())
+
+    def test_report_mode_never_raises(self):
+        plan, findings = run_moe_config_check(
+            _config(
+                moe_config_check="report",
+                topk_method="quantile_balancing",
+                moe_topk_fusion=True,
+                user_specified_keys=("topk_method", "moe_topk_fusion"),
+            ),
+            device_capability=HOPPER,
+        )
+
+        self.assertIsNotNone(plan)
+        self.assertTrue(findings)
+
+    def test_strict_mode_raises_with_every_problem(self):
+        with self.assertRaises(MoEConfigError) as caught:
+            run_moe_config_check(
+                _config(
+                    moe_config_check="strict",
+                    topk_method="quantile_balancing",
+                    moe_topk_fusion=True,
+                    n_group=4,
+                    user_specified_keys=(
+                        "topk_method",
+                        "moe_topk_fusion",
+                        "n_group",
+                    ),
+                ),
+                device_capability=HOPPER,
+            )
+
+        message = str(caught.exception)
+        self.assertIn("C1", message)
+        self.assertIn("C2", message)
+
+    def test_without_user_keys_it_only_resolves_the_plan(self):
+        """拿不到"用户显式配了哪些字段"时不做字段级诊断: 上游 PretrainedConfig 会把
+        自身默认值灌进 config, 实测约五成 MoE 字段会被误判成用户设置。"""
+        plan, findings = run_moe_config_check(
+            _config(
+                moe_config_check="strict",
+                topk_method="quantile_balancing",
+                moe_topk_fusion=True,
+                user_specified_keys=None,
+            ),
+            device_capability=HOPPER,
+        )
+
+        self.assertIsNotNone(plan)
+        self.assertEqual(findings, ())
+
+    def test_invalid_mode_is_rejected(self):
+        with self.assertRaises(ValueError):
+            run_moe_config_check(_config(moe_config_check="yes"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/transformer/test_moe_config_check_example.py
+++ b/tests/single_card_tests/transformer/test_moe_config_check_example.py
@@ -1,0 +1,205 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""用一份训练 YAML 检查 MoE 配置的示例。
+
+复制本文件, 只改下面 CONFIG 区的三个常量, 就能检查任意一份配置。
+
+它读取 YAML, 从 YAML 的 ``model_name_or_path`` 找到同目录下的 ``model_config.json``,
+把两者合并成 ERNIEBot 实际使用的扁平配置, 然后报告:
+
+* 当前配置会命中哪条 dispatcher / router / expert / precision 路径;
+* 哪些字段被路由过程改写了;
+* 哪些字段配了但当前路径不会读取(作用域错误 / 死配置 / 派生值 / 属其他子系统)。
+
+**YAML 键与 JSON 键的并集就是"用户显式配过的字段"**, 这正是诊断需要的输入。直接
+去问 config 对象是不行的: 上游 PretrainedConfig 会把自己的默认值一并写进去, 实测
+会让近半数 MoE 字段被误判成用户显式设置。
+
+运行方式:
+
+    cd third_party/PaddleFleet
+    PYTHONPATH=src python -m unittest \\
+        tests.single_card_tests.transformer.test_moe_config_check_example
+
+因为 YAML 在 ERNIEBot 仓库里而不在 PaddleFleet 里, 找不到文件时本测试自动跳过,
+不会影响 PaddleFleet 自身的 CI。
+"""
+
+import json
+import os
+import sys
+import unittest
+from types import SimpleNamespace
+
+# Prefer the in-tree PaddleFleet over a site-packages install. Relative
+# PYTHONPATH entries (e.g. ./third_party/PaddleFleet/src/) break after cd,
+# and the installed package does not ship moe_config_check.
+_PADDLEFLEET_SRC = os.path.abspath(
+    os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "..", "..", "..", "src"
+    )
+)
+if _PADDLEFLEET_SRC not in sys.path:
+    sys.path.insert(0, _PADDLEFLEET_SRC)
+
+import paddle
+import yaml
+
+from paddlefleet.transformer.moe.moe_config_check import (
+    collect_findings,
+    format_report,
+    resolve_moe_plan,
+)
+from paddlefleet.transformer.transformer_config import TransformerConfig
+
+# ==================== 改这里 ====================
+
+# 要检查的 YAML。可以写绝对路径, 也可以写相对 ERNIEBot 仓库根目录的路径。
+# YAML_PATH = "conf/online/ernielite_layer43_pretrain_mla_hca.yaml"
+YAML_PATH = "conf/online/mimo_flash_pretrain32k_fleet_0702.yaml"
+# YAML_PATH = "conf/experiment/eb5_v2/eb5_v2_A10B_230B_pretrain_0419_8k_bzz3_fleet_backend.yaml"
+
+# EP 组大小。None 表示读 YAML 里的 expert_model_parallel_size。
+# 这个值必须对: EP=1 时根本不走 dispatcher, 所有 dispatcher 专属字段都是无效的。
+EXPERT_PARALLEL_SIZE = None
+
+# 设备算力。None 表示用当前机器的算力; 想检查换到别的机型上会怎样, 就直接写死,
+# 例如 (9, 0) 表示 Hopper, (8, 0) 表示 Ampere(会触发 deepep -> alltoall 回退)。
+DEVICE_CAPABILITY = None
+
+# ================================================
+
+
+def _erniebot_root():
+    """本文件位于 <erniebot>/third_party/PaddleFleet/tests/single_card_tests/
+    transformer/, 上溯 6 层即 ERNIEBot 仓库根目录。"""
+    path = os.path.abspath(__file__)
+    for _ in range(6):
+        path = os.path.dirname(path)
+    return path
+
+
+def _resolve(path):
+    if os.path.isabs(path):
+        return path
+    return os.path.join(_erniebot_root(), path)
+
+
+def _load_flat_config(yaml_path):
+    """把 YAML 与 model_config.json 合并成 ERNIEBot 实际使用的扁平配置。
+
+    Returns:
+        (merged, yaml_keys, json_keys): merged 是合并后的 dict, 后两者用于区分字段
+        来源——报告只诊断这两个集合里的字段。
+
+    注: 用 yaml.safe_load 而不是 OmegaConf, 所以 YAML 里的 ``${...}`` 插值不会被
+    求值。现有 conf/ 下的配置都没有用到插值。
+    """
+    with open(yaml_path, "r", encoding="utf-8") as f:
+        flat = yaml.safe_load(f) or {}
+
+    model_name_or_path = flat.get("model_name_or_path")
+    if not model_name_or_path:
+        raise ValueError(
+            f"{yaml_path} 里没有 model_name_or_path, 无法定位 JSON"
+        )
+
+    json_path = os.path.join(_resolve(model_name_or_path), "model_config.json")
+    if not os.path.exists(json_path):
+        raise FileNotFoundError(f"model_config.json 不存在: {json_path}")
+    with open(json_path, "r", encoding="utf-8") as f:
+        structure = json.load(f)
+
+    return {**structure, **flat}, set(flat), set(structure)
+
+
+def _device_capability():
+    if DEVICE_CAPABILITY is not None:
+        return DEVICE_CAPABILITY
+    if paddle.is_compiled_with_cuda() and paddle.device.cuda.device_count():
+        return paddle.device.cuda.get_device_capability()
+    return None
+
+
+@unittest.skipUnless(
+    os.path.exists(_resolve(YAML_PATH)),
+    f"找不到 {YAML_PATH}(单独跑 PaddleFleet 仓库时正常)",
+)
+class TestMoEConfigCheckFromYaml(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        yaml_path = _resolve(YAML_PATH)
+        cls.merged, cls.yaml_keys, cls.json_keys = _load_flat_config(yaml_path)
+        cls.user_keys = cls.yaml_keys | cls.json_keys
+        cls.config = TransformerConfig.from_config(
+            SimpleNamespace(**cls.merged)
+        )
+        cls.ep_size = (
+            EXPERT_PARALLEL_SIZE
+            if EXPERT_PARALLEL_SIZE is not None
+            else cls.merged.get("expert_model_parallel_size", 1)
+        )
+        cls.capability = _device_capability()
+        cls.plan = resolve_moe_plan(
+            cls.config,
+            expert_parallel_size=cls.ep_size,
+            device_capability=cls.capability,
+        )
+        cls.findings = collect_findings(
+            cls.config,
+            cls.plan,
+            cls.user_keys,
+            device_capability=cls.capability,
+        )
+
+    def test_no_field_is_configured_against_the_selected_path(self):
+        """报告全文打到 stdout, 只有存在必须修复的问题时才判失败。
+
+        死配置、派生值、跨子系统字段都只是提示: 现存实验配置里有约 20 份在设置死配
+        置, 让它们直接失败没有意义。真正判失败的是"用户显式配了但当前路径不读"和
+        "用户显式配的值被路由改写"这两类。
+        """
+        print(
+            "\n"
+            + format_report(
+                self.plan,
+                self.findings,
+                config=self.config,
+                user_specified_keys=self.user_keys,
+            )
+        )
+
+        must_fix = [f for f in self.findings if f.policy.value == "error"]
+        self.assertEqual(
+            must_fix,
+            [],
+            "\n\n以下问题需要改配置, 不是工具本身报错: 这些字段都是显式配置过的, 但"
+            "当前执行路径不会读取它们, 或者配的值在路由过程中被改写掉了。\n"
+            + "\n".join(str(f) for f in must_fix),
+        )
+
+    def test_yaml_does_not_redeclare_model_structure_fields(self):
+        """ERNIEBot 的约定是模型结构字段只写在 JSON、其余只写在 YAML, 两边不得重
+        叠(ernie5/pretrain.py 的 _check_yaml_not_override_json 也在查这件事)。重叠
+        意味着同一个开关有两个可信来源, 后合并的那个静默生效。"""
+        self.assertEqual(
+            sorted(self.yaml_keys & self.json_keys),
+            [],
+            "这些字段同时出现在 YAML 和 model_config.json 里",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### PR Category
User Experience


### PR Types
Improvements


### Description
#### 背景

MoE 子系统读取哪些 config 字段, 取决于路由决策选中的执行路径(EP size、
dispatcher 类型、expert fusion、精度开关、设备算力等)。当前存在三类长期问题:

1. 配了不生效: 字段归属其他执行路径, 没有任何代码会读它, 用户毫无感知
   (如 greedy 路由下配 n_group、非 hash 路由下配 actual_vocab_size);
2. 静默改写: 构造期把用户配置覆盖成别的值(如 allgather 强制改写三个开关、
   低算力机型 deepep 静默回退 alltoall), 换机型才暴露;
3. 死配置: 字段有声明但全仓库无消费者(moe_router_fusion、moe_logging、
   容量丢弃系列等), 大量实验配置仍在设置它们。

这些问题轻则浪费排查时间, 重则跑完整个实验才发现关键开关没生效。

#### 方案

新增两个模块, 在 TransformerConfig.__post_init__ 中做启动期诊断:

- moe_config_registry.py: 60 个 MoE 配置字段的归属登记表。声明每个字段归哪个
  子模块所有、什么条件下真正被消费、状态(active/dead/foreign/derived/
  undeclared)与修复建议。纯数据, import 期不依赖 paddle, 可脱离 GPU 单测。

- moe_config_check.py:
  - resolve_moe_plan(): 只读复刻 MoELayer.__init__ 的路由决策(dispatcher
    选择与回退、allgather 改写、expert/精度分支), 输出生效执行计划和全部
    被改写字段;
  - 27 条可判定规则: 依赖缺失(B1-B9)、互斥组合(C1-C15)、算力不足(E1-E3),
    每条带编号、修复建议和源码依据;
  - 一次跑完所有检查, 汇总报告全部问题, 避免"改一个、跑一次、再报一个"。

#### 使用方式

由 moe_config_check 开关控制, 默认 off, 对现有任务零影响:

- off: 完全关闭(默认);
- report: 只在 rank 0 打印诊断报告, 不阻断训练;
- strict: 存在 ERROR 级问题时抛 MoEConfigError, 启动即失败。

字段级诊断依赖 user_specified_keys(用户显式配置的字段列表)由上游传入;
拿不到时只做执行计划推导, 不做字段归因, 避免把上游灌入的默认值误判成用户配置。

#### 测试

- tests/single_card_tests/transformer/test_moe_config_check.py: 67 个单测,
  全部在 CPU 上运行(设备算力是入参而非从设备读取), 覆盖:
  - 登记表与 config schema 的双向契约(新增 MoE 字段不登记会直接挂 CI);
  - 路由推导对构造期决策的复刻(回退、改写、分支选择);
  - 全部规则的命中与不命中场景;
  - off/report/strict 三种模式的入口行为。
- tests/single_card_tests/transformer/test_moe_config_check_example.py:
  从 YAML 加载真实配置的端到端示例。


### 是否引起精度变化
否
