### PR TITLE
[Improvements] remove fastdeploy dynamic_infer fallback branch

### DIFF
--- a/src/paddlefleet/transformer/multi_latent_attention.py
+++ b/src/paddlefleet/transformer/multi_latent_attention.py
@@ -909,6 +909,15 @@ class MultiLatentAttention(Attention):
             "MLA does not support Flash Decoding"
         )
 
+        # Extract inference kwargs early: ``is_decode`` is needed both by
+        # ``get_query_key_value_tensors`` (RoPE apply) and by core_attention.
+        past_key_values = kwargs.get("past_key_values")
+        layer_idx = kwargs.get("layer_idx")
+        use_cache = kwargs.get("use_cache", False)
+        is_decode = _is_incremental_decode(
+            past_key_values, layer_idx, use_cache
+        )
+
         # =====================
         # Query, Key, and Value
         # =====================
@@ -920,6 +929,7 @@ class MultiLatentAttention(Attention):
                 key_value_states,
                 position_ids,
                 packed_seq_params,
+                is_decode=is_decode,
             )
         )
 
@@ -947,14 +957,6 @@ class MultiLatentAttention(Attention):
             query = query.transpose([1, 0, 2, 3]).contiguous()
             key = key.transpose([1, 0, 2, 3]).contiguous()
             value = value.transpose([1, 0, 2, 3]).contiguous()
-
-        # Extract inference kwargs to pass through to core_attention
-        past_key_values = kwargs.get("past_key_values")
-        layer_idx = kwargs.get("layer_idx")
-        use_cache = kwargs.get("use_cache", False)
-        is_decode = _is_incremental_decode(
-            past_key_values, layer_idx, use_cache
-        )
 
         # The indexer-loss row mask needs ``input_ids``: the packed sequence's
         # trailing padding is invisible to ``attn_mask_startend_row_indices``.
@@ -1679,6 +1681,7 @@ class MLASelfAttention(MultiLatentAttention):
         key_value_states=None,
         position_ids=None,
         packed_seq_params=None,
+        is_decode=False,
     ):
         """
         Derives `query`, `key` and `value` tensors from `hidden_states`.
@@ -1975,6 +1978,10 @@ class MLASelfAttention(MultiLatentAttention):
                 )
                 key = paddle.cat([k_no_pe, k_pos_emb], axis=-1)
             elif bool(self.config.apply_rope_fusion) and not self.mqa_latent:
+                if is_decode:
+                    raise NotImplementedError(
+                        "fused MLA YaRN RoPE does not support incremental decode yet."
+                    )
                 from paddlefleet.triton_ops.fused_mla_yarn_rope_apply import (
                     fused_apply_mla_rope_for_kv,
                     fused_apply_mla_rope_for_q,
@@ -2611,6 +2618,7 @@ class MQASelfAttention(MLASelfAttention):
                 key_value_states,
                 position_ids,
                 packed_seq_params,
+                is_decode=is_decode,
             )
         )
 
@@ -2902,6 +2910,7 @@ class MQASelfAttention(MLASelfAttention):
         key_value_states=None,
         position_ids=None,
         packed_seq_params=None,
+        is_decode=False,
     ):
         """
         Derives `query`, `key` and `value` tensors from `hidden_states`.
@@ -2912,6 +2921,7 @@ class MQASelfAttention(MLASelfAttention):
                 key_value_states=key_value_states,
                 position_ids=position_ids,
                 packed_seq_params=packed_seq_params,
+                is_decode=is_decode,
             )
 
         # b = batch size, s = sequence length, h = hidden size, n = num attention heads

--- a/src/paddlefleet/transformer/multi_latent_attention.py
+++ b/src/paddlefleet/transformer/multi_latent_attention.py
@@ -2033,12 +2033,6 @@ class MLASelfAttention(MultiLatentAttention):
                     cp_size,
                 )
 
-                # dynamic_inference not supported for now
-                if not self.training:
-                    raise NotImplementedError(
-                        "apply_rope_fusion does not support dynamic inference yet."
-                    )
-
                 k_pe = None
             else:
                 # Determine seq length:

--- a/src/paddlefleet/transformer/multi_latent_attention.py
+++ b/src/paddlefleet/transformer/multi_latent_attention.py
@@ -1980,7 +1980,7 @@ class MLASelfAttention(MultiLatentAttention):
             elif bool(self.config.apply_rope_fusion) and not self.mqa_latent:
                 if is_decode:
                     raise NotImplementedError(
-                        "apply_rope_fusion does not support dynamic inference yet."
+                        "apply_rope_fusion does not support incremental decode in MLA yet."
                     )
                 from paddlefleet.triton_ops.fused_mla_yarn_rope_apply import (
                     fused_apply_mla_rope_for_kv,

--- a/src/paddlefleet/transformer/multi_latent_attention.py
+++ b/src/paddlefleet/transformer/multi_latent_attention.py
@@ -1980,7 +1980,7 @@ class MLASelfAttention(MultiLatentAttention):
             elif bool(self.config.apply_rope_fusion) and not self.mqa_latent:
                 if is_decode:
                     raise NotImplementedError(
-                        "fused MLA YaRN RoPE does not support incremental decode yet."
+                        "apply_rope_fusion does not support dynamic inference yet."
                     )
                 from paddlefleet.triton_ops.fused_mla_yarn_rope_apply import (
                     fused_apply_mla_rope_for_kv,

--- a/tests/single_card_tests/test_hysparse_decode_unit.py
+++ b/tests/single_card_tests/test_hysparse_decode_unit.py
@@ -392,7 +392,7 @@ class TestMLAHySparseForwardRouting(unittest.TestCase):
             use_vha_postmix=False,
             layer_number=0,
             o_proj=lambda x: (x, None),
-            get_query_key_value_tensors=lambda *_: (
+            get_query_key_value_tensors=lambda *_, **__: (
                 query,
                 key,
                 value,
@@ -486,7 +486,7 @@ class TestMQAHySparseForwardRouting(unittest.TestCase):
             o_proj=lambda x: (x, None),
             layer_number=0,
             attn_mask_type=None,
-            get_query_key_value_tensors=lambda *_: (
+            get_query_key_value_tensors=lambda *_, **__: (
                 query,
                 key,
                 value,

--- a/tests/single_card_tests/transformer/test_mla_ec_rope_and_absorbed_q.py
+++ b/tests/single_card_tests/transformer/test_mla_ec_rope_and_absorbed_q.py
@@ -29,6 +29,7 @@ import numpy as np
 import paddle
 from paddle.distributed.fleet.meta_parallel import build_spec_layer
 
+from paddlefleet.generation.greedy_generator import DynamicKVCache
 from paddlefleet.models.gpt.gpt_config import GPTConfig
 from paddlefleet.models.gpt.gpt_layer_specs import (
     get_gpt_layer_local_spec,
@@ -909,54 +910,119 @@ class TestNonExperimentalVersionPositionIds(unittest.TestCase):
 
 
 class TestApplyRopeFusionNotSupportedInference(unittest.TestCase):
-    """Test that apply_rope_fusion raises NotImplementedError in eval mode (L994-1000).
+    """Fused MLA RoPE inference contract: prefill passes, incremental decode raises.
 
-    Both tests below flip ``config.apply_rope_fusion`` on the *already built*
+    All tests below flip ``config.apply_rope_fusion`` on the *already built*
     model and rely on the change taking effect at forward time. They are the
     regression guard for that contract: the effective fusion decision
     (``config.apply_rope_fusion and not mqa_latent``) is read at each use site
     rather than snapshotted in ``__init__``, so toggling the config after
     construction -- as generation/greedy_generator.py does for KV cache -- still
-    works. A construction-time snapshot would leave the flag False here and this
-    test would stop raising.
+    works.
+
+    The decode test additionally guards the ``is_decode`` gate at the fused
+    branch entry (multi_latent_attention.py, ``qkv_up_proj_and_rope_apply``):
+    once a layer has written its prefill KV into ``past_key_values``, the next
+    single-token call is an incremental decode step and must raise
+    NotImplementedError. Eval + prefill (cache still empty) must pass.
     """
 
-    def test_apply_rope_fusion_raises_in_eval(self):
-        """apply_rope_fusion=True in eval mode should raise NotImplementedError."""
+    def _build_fused_eval_model(self):
+        """Build the MLA GPT model, enable apply_rope_fusion, switch to eval."""
         model, config = _build_gpt_model(
             gpt_model_use_experimental_version=False
         )
-        # Enable apply_rope_fusion on all MLA layers
         for sublayer in model.sublayers():
             if hasattr(sublayer, "config") and hasattr(
                 sublayer.config, "apply_rope_fusion"
             ):
                 sublayer.config.apply_rope_fusion = True
-
         model.eval()
+        return model, config
 
-        sequence_length = 16
-        micro_batch_size = 2
+    def _run_prefill(self, model, config, cache, sequence_length, batch_size):
+        """Prefill through the fused branch, writing the layer KV cache.
+
+        Mirrors the ``greedy_generator.generate`` prefill call: full prompt,
+        ``past_key_values`` + ``use_cache=True``, no attention mask (causal
+        default).
+        """
         input_ids = paddle.randint(
-            0, config.vocab_size, [micro_batch_size, sequence_length]
+            0, config.vocab_size, [batch_size, sequence_length]
         )
         position_ids = (
             paddle.arange(sequence_length, dtype=paddle.int64)
             .unsqueeze(0)
-            .expand([micro_batch_size, sequence_length])
+            .expand([batch_size, sequence_length])
         )
-        attention_mask = paddle.ones(
-            (micro_batch_size, 1, sequence_length, sequence_length), dtype=bool
+        return model(
+            {
+                "input_ids": input_ids,
+                "position_ids": position_ids,
+                "past_key_values": cache,
+                "use_cache": True,
+            }
         )
 
-        dict_args = {
-            "input_ids": input_ids,
-            "position_ids": position_ids,
-            "attention_mask": attention_mask,
-        }
+    def test_apply_rope_fusion_eval_prefill_succeeds(self):
+        """Eval + prefill must pass: the cache is still empty, so the
+        ``is_decode`` gate stays open even with ``use_cache=True``."""
+        model, config = self._build_fused_eval_model()
+
+        sequence_length = 16
+        micro_batch_size = 2
+        cache = DynamicKVCache(config.num_hidden_layers)
+
+        result = self._run_prefill(
+            model, config, cache, sequence_length, micro_batch_size
+        )
+
+        if isinstance(result, dict):
+            hidden_states = result["hidden_states"]
+        else:
+            hidden_states = result
+        self.assertEqual(
+            hidden_states.shape,
+            [micro_batch_size, sequence_length, config.vocab_size],
+        )
+        self.assertTrue(
+            cache.has_layer_cache(0),
+            "prefill should have written the layer KV cache",
+        )
+
+    def test_apply_rope_fusion_raises_in_decode(self):
+        """A single-token decode step on a populated cache must raise at the
+        fused-branch entry (``is_decode`` gate)."""
+        model, config = self._build_fused_eval_model()
+
+        sequence_length = 16
+        micro_batch_size = 2
+        cache = DynamicKVCache(config.num_hidden_layers)
+
+        self._run_prefill(
+            model, config, cache, sequence_length, micro_batch_size
+        )
+        self.assertTrue(
+            cache.has_layer_cache(0),
+            "prefill should have written the layer KV cache",
+        )
+
+        # Single-token decode step: same cache, non-zero position_ids
+        # (mirrors the greedy_generator decode loop).
+        next_tok = paddle.randint(0, config.vocab_size, [micro_batch_size, 1])
+        decode_position_ids = paddle.full(
+            [micro_batch_size, 1], sequence_length, dtype="int64"
+        )
 
         with self.assertRaises(NotImplementedError) as ctx:
-            model(dict_args)
+            model(
+                {
+                    "input_ids": next_tok,
+                    "position_ids": decode_position_ids,
+                    "past_key_values": cache,
+                    "use_cache": True,
+                }
+            )
 
         self.assertIn(
             "apply_rope_fusion does not support dynamic inference yet",

--- a/tests/single_card_tests/transformer/test_mla_ec_rope_and_absorbed_q.py
+++ b/tests/single_card_tests/transformer/test_mla_ec_rope_and_absorbed_q.py
@@ -1025,7 +1025,7 @@ class TestApplyRopeFusionNotSupportedInference(unittest.TestCase):
             )
 
         self.assertIn(
-            "apply_rope_fusion does not support dynamic inference yet",
+            "apply_rope_fusion does not support incremental decode in MLA yet.",
             str(ctx.exception),
         )
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Distributed Strategy

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
允许eval+prefill模式下 mla 应用 rope_fusion，之前if not training控制面太广，缩小为只在eval+decode下raise error

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否