### PR TITLE
[Devs] Keep overlap_p2p_comm on in BlockAttnRes VPP regression test

### DIFF
--- a/tests/multi_card_tests/pipeline_parallel/test_block_attn_res_vpp.py
+++ b/tests/multi_card_tests/pipeline_parallel/test_block_attn_res_vpp.py
@@ -182,14 +182,20 @@ class TestBlockAttnResVPPEquivalence(unittest.TestCase):
                 "ep",
                 "mp",
             ],
-            # BlockAttnRes comm opt does not support the overlap scheduler.
             # BlockAttnRes sends "hidden + blocks", and the number of blocks
             # grows along the pipeline, so the p2p shape meta must not be
-            # cached across sends -> dynamic shape is required (VPP itself
-            # requires p2p_cache_shape, so this is the only way).
+            # cached across sends -> dynamic shape is required.
+            #
+            # These two overlap switches are unrelated, do not flip them
+            # together:
+            #   - forward_backward_overlap_scheduler must stay off, the
+            #     overlapped forward/backward path bypasses _merge_block_cache.
+            #   - overlap_p2p_comm must stay on. With it off, VPP falls back to
+            #     send_forward_backward_recv_forward_backward, which asserts
+            #     `not self._dynamic_shape`.
             "pp_configs": {
                 "forward_backward_overlap_scheduler": False,
-                "overlap_p2p_comm": False,
+                "overlap_p2p_comm": True,
                 "enable_dynamic_shape": True,
             },
         }


### PR DESCRIPTION
### PR Category
Distributed Strategy

### PR Types
Others

### Description
Fix the `pp_configs` of the BlockAttnRes VPP regression test.

The test needs dynamic p2p shape: BlockAttnRes sends "hidden + blocks" and the
number of blocks grows along the pipeline, so the p2p shape meta must not be
cached across sends. But it also set `overlap_p2p_comm: False`, which is a
**different** switch from `forward_backward_overlap_scheduler`.

With `overlap_p2p_comm` off, `PipelineParallelWithInterleave.forward_backward_pipeline`
takes the fused four-direction path (`send_forward_backward_recv_forward_backward`),
which starts with `assert not self._dynamic_shape`, so the test dies at the last
startup step:

    AssertionError: p2p_helper.send_forward_backward_recv_forward_backward
    function doesn't support dynamic_shape now

Only `forward_backward_overlap_scheduler` is incompatible with the BlockAttnRes
comm optimization (the overlapped forward/backward path bypasses
`_merge_block_cache`). `overlap_p2p_comm` is not: its code path uses
`send_forward_recv_forward` / `send_backward_recv_backward`, which are
dynamic-shape aware and already forward `block_cache_meta`.

This turns `overlap_p2p_comm` back on and splits the comment so the two switches
are not conflated again.

Blocks PaddlePaddle/Paddle#79517: its `Fleet Unit test (multi-card)` job pulls
this test and fails on it.

Note: this test skips itself unless the installed paddle ships the BlockAttnRes
feature (`hasattr(PipelineParallelWithInterleave, "_merge_block_cache")`), which
is still unmerged, so it cannot be validated outside the Paddle PR's Fleet CI.

### 是否引起精度变化
否