### PR TITLE
[release/0.4][Performance] Support separate_mtp_input to drop per-layer MTP split/concat

### DIFF
--- a/src/paddlefleet/models/gpt/gpt_embedding.py
+++ b/src/paddlefleet/models/gpt/gpt_embedding.py
@@ -699,8 +699,19 @@ class GPTEmbedding(FleetLayer):
                 and not self.config.mtp_load_weight_only
             )
             assert len(mtp_emb_res) == self.config.num_nextn_predict_layers + 1
-            hidden_states_concat = paddle.concat(mtp_emb_res)
-            preproc_output["hidden_states"] = hidden_states_concat
+            if self.config.separate_mtp_input:
+                # Keep hidden_states free of MTP chunks so the backbone layers do not
+                # have to split/concat them. The shifted embeddings travel to the MTP
+                # layer through a dedicated key instead. Every entry of mtp_emb_res is
+                # already CP/SP-scattered above, so stack() is a pure container op and
+                # MultiTokenPredictionLayer must not re-scatter them.
+                preproc_output["hidden_states"] = mtp_emb_res[0].contiguous()
+                preproc_output["mtp_decoder_inputs"] = paddle.stack(
+                    mtp_emb_res[1:]
+                )
+            else:
+                hidden_states_concat = paddle.concat(mtp_emb_res)
+                preproc_output["hidden_states"] = hidden_states_concat
 
         # Pass through KV cache kwargs for inference
         for key in ("past_key_values", "use_cache"):

--- a/src/paddlefleet/transformer/hyper_connection.py
+++ b/src/paddlefleet/transformer/hyper_connection.py
@@ -799,6 +799,7 @@ class HyperConnectionContractLayer(FleetLayer):
 
         self.num_mtp = getattr(config, "num_nextn_predict_layers", 0) or 0
         self.magic_send = getattr(config, "enable_mtp_magic_send", False)
+        self.separate_mtp_input = getattr(config, "separate_mtp_input", False)
 
         # Learned contraction parameters (DSv4 style, always used)
         n = self.n
@@ -835,7 +836,7 @@ class HyperConnectionContractLayer(FleetLayer):
         ):
             dict_args["mhc_multistream"] = hidden_states
 
-            if self.magic_send or self.config.separate_mtp_input:
+            if self.magic_send or self.separate_mtp_input:
                 # magic_send / separate_mtp_input: hidden_states is pure backbone [B, S, n*H]
                 # Backbone processes only the main sequence, no MTP chunks concatenated.
                 # Simply contract the entire tensor.

--- a/src/paddlefleet/transformer/hyper_connection.py
+++ b/src/paddlefleet/transformer/hyper_connection.py
@@ -835,9 +835,9 @@ class HyperConnectionContractLayer(FleetLayer):
         ):
             dict_args["mhc_multistream"] = hidden_states
 
-            if self.magic_send:
-                # magic_send: hidden_states is pure backbone [B, S, n*H]
-                # Magic send: backbone processes only main sequence, no MTP chunks concatenated.
+            if self.magic_send or self.config.separate_mtp_input:
+                # magic_send / separate_mtp_input: hidden_states is pure backbone [B, S, n*H]
+                # Backbone processes only the main sequence, no MTP chunks concatenated.
                 # Simply contract the entire tensor.
                 dict_args["hidden_states"] = (
                     HyperConnectionModule.learned_output_contract(

--- a/src/paddlefleet/transformer/multi_token_prediction.py
+++ b/src/paddlefleet/transformer/multi_token_prediction.py
@@ -787,7 +787,9 @@ class MultiTokenPredictionLayer(FleetLayer):
             # Save backbone output for downstream GPTMainLMHead (main logits computation)
             dict_args["_backbone_hidden_states"] = hidden_states
             mtp_input_embeds = dict_args.get("mtp_input_embeds", None)
-            mtp_decoder_inputs = dict_args.get("mtp_decoder_inputs", None)
+            # Consumed by this layer only: pop it so it does not ride along in
+            # the **kwargs passthrough of _proj_and_transformer_layer.
+            mtp_decoder_inputs = dict_args.pop("mtp_decoder_inputs", None)
             if self.config.enable_mtp_magic_send and mtp_input_embeds is None:
                 raise RuntimeError(
                     "enable_mtp_magic_send=True but mtp_input_embeds not found in dict_args. "

--- a/src/paddlefleet/transformer/multi_token_prediction.py
+++ b/src/paddlefleet/transformer/multi_token_prediction.py
@@ -778,10 +778,7 @@ class MultiTokenPredictionLayer(FleetLayer):
         # embeddings arrive either as mtp_input_embeds (magic_send, produced by
         # MTPEmbeddingLayer at full unscattered length) or as mtp_decoder_inputs
         # (separate_mtp_input, produced by GPTEmbedding already CP/SP-scattered).
-        if (
-            self.config.enable_mtp_magic_send
-            or self.config.separate_mtp_input
-        ):
+        if self.config.enable_mtp_magic_send or self.config.separate_mtp_input:
             hidden_states = dict_args["hidden_states"]
             mhc_multistream = dict_args.pop("mhc_multistream", None)
             # Save backbone output for downstream GPTMainLMHead (main logits computation)
@@ -842,18 +839,14 @@ class MultiTokenPredictionLayer(FleetLayer):
                     )
 
                 if self.config.sequence_parallel:
-                    batch_size, local_seq_len, hidden_size = (
-                        decoder_input.shape
-                    )
+                    batch_size, local_seq_len, hidden_size = decoder_input.shape
                     decoder_input = decoder_input.reshape(
                         [-1, decoder_input.shape[-1]]
                     )
                     decoder_input = ScatterOp.apply(decoder_input)
                     if not self.config.gpt_model_use_experimental_version:
                         decoder_input = (
-                            decoder_input.reshape(
-                                [batch_size, -1, hidden_size]
-                            )
+                            decoder_input.reshape([batch_size, -1, hidden_size])
                             .permute(1, 0, 2)
                             .contiguous()
                         )  # [S/tp, B, H]

--- a/src/paddlefleet/transformer/multi_token_prediction.py
+++ b/src/paddlefleet/transformer/multi_token_prediction.py
@@ -773,28 +773,38 @@ class MultiTokenPredictionLayer(FleetLayer):
                 "multi token prediction + sequence packing is not yet supported."
             )
 
-        # === Magic Send branch ===
-        # hidden_states is pure backbone output (not concatenated); mtp_input_embeds provided by MTPEmbeddingLayer
-        if self.config.enable_mtp_magic_send:
+        # === MTP input arrives outside hidden_states (magic_send / separate_mtp_input) ===
+        # hidden_states is pure backbone output (not concatenated). The shifted MTP
+        # embeddings arrive either as mtp_input_embeds (magic_send, produced by
+        # MTPEmbeddingLayer at full unscattered length) or as mtp_decoder_inputs
+        # (separate_mtp_input, produced by GPTEmbedding already CP/SP-scattered).
+        if (
+            self.config.enable_mtp_magic_send
+            or self.config.separate_mtp_input
+        ):
             hidden_states = dict_args["hidden_states"]
             mhc_multistream = dict_args.pop("mhc_multistream", None)
             # Save backbone output for downstream GPTMainLMHead (main logits computation)
             dict_args["_backbone_hidden_states"] = hidden_states
             mtp_input_embeds = dict_args.get("mtp_input_embeds", None)
-            if mtp_input_embeds is None:
+            mtp_decoder_inputs = dict_args.get("mtp_decoder_inputs", None)
+            if self.config.enable_mtp_magic_send and mtp_input_embeds is None:
                 raise RuntimeError(
                     "enable_mtp_magic_send=True but mtp_input_embeds not found in dict_args. "
                     "MTPEmbeddingLayer may not have been executed."
                 )
+            if self.config.separate_mtp_input and mtp_decoder_inputs is None:
+                raise RuntimeError(
+                    "separate_mtp_input=True but mtp_decoder_inputs not found in "
+                    "dict_args. GPTEmbedding may not have produced the shifted MTP "
+                    "embeddings."
+                )
 
-            # mtp_input_embeds: [B, S+num_mtp, H] (full embedding of original input_ids)
-            # Extract shifted slice for current depth as decoder_input
             num_mtp = self.config.num_nextn_predict_layers
-            # Compute global main sequence length S (before CP/SP scatter).
-            # hidden_states arriving here is already CP-local and/or SP-local,
-            # so we must recover the full sequence length for correct slicing of
-            # mtp_input_embeds (which is always kept at full [B, S+num_mtp, H]).
-            cp_world_size = get_context_parallel_world_size()
+            depth = self.layer_number
+            # Main sequence length as seen from hidden_states, which is already CP-local
+            # and/or SP-local. Used to trim rotary_pos_emb/cos/sin below, and (magic_send
+            # only) scaled back up to the global length for slicing mtp_input_embeds.
             if self.config.sequence_parallel:
                 # SP format: hidden_states is [S_local/tp, B, H]
                 seq_len = (
@@ -804,39 +814,47 @@ class MultiTokenPredictionLayer(FleetLayer):
             else:
                 # Non-SP: hidden_states is [B, S_local, H]
                 seq_len = hidden_states.shape[1]
-            # Recover global seq_len if CP is active
-            if cp_world_size > 1 and self.config.experimental_dataflow:
-                seq_len = seq_len * cp_world_size
+            cp_world_size = get_context_parallel_world_size()
+            if self.config.enable_mtp_magic_send:
+                # Recover global seq_len if CP is active
+                if cp_world_size > 1 and self.config.experimental_dataflow:
+                    seq_len = seq_len * cp_world_size
 
-            # shifted embedding for depth k: mtp_input_embeds[:, (k+1):(k+1+seq_len), :]
-            depth = self.layer_number
-            decoder_input = mtp_input_embeds[
-                :, (depth + 1) : (depth + 1 + seq_len), :
-            ]
+            if self.config.separate_mtp_input:
+                # mtp_decoder_inputs: [num_mtp, ...] stacked shifted embeddings from
+                # GPTEmbedding. Each entry already carries exactly the same CP/SP layout
+                # as hidden_states, so there is nothing to slice and nothing to scatter.
+                decoder_input = mtp_decoder_inputs[depth]
+            else:
+                # shifted embedding for depth k: mtp_input_embeds[:, (k+1):(k+1+seq_len), :]
+                decoder_input = mtp_input_embeds[
+                    :, (depth + 1) : (depth + 1 + seq_len), :
+                ]
 
-            # Apply CP/SP scatter to decoder_input to match the format of hidden_states.
-            # In the non-magic-send path, GPTEmbedding applies these transforms to each
-            # shifted MTP embedding before it enters MultiTokenPredictionLayer.
-            if (
-                get_context_parallel_world_size() > 1
-                and self.config.experimental_dataflow
-            ):
-                decoder_input = ContextParallelScatterOp.apply(
-                    decoder_input, axis=1, mode=self.config.cp_balance_mode
-                )
+                # Apply CP/SP scatter to decoder_input to match the format of hidden_states.
+                # In the non-magic-send path, GPTEmbedding applies these transforms to each
+                # shifted MTP embedding before it enters MultiTokenPredictionLayer.
+                if cp_world_size > 1 and self.config.experimental_dataflow:
+                    decoder_input = ContextParallelScatterOp.apply(
+                        decoder_input, axis=1, mode=self.config.cp_balance_mode
+                    )
 
-            if self.config.sequence_parallel:
-                batch_size, local_seq_len, hidden_size = decoder_input.shape
-                decoder_input = decoder_input.reshape(
-                    [-1, decoder_input.shape[-1]]
-                )
-                decoder_input = ScatterOp.apply(decoder_input)
-                if not self.config.gpt_model_use_experimental_version:
-                    decoder_input = (
-                        decoder_input.reshape([batch_size, -1, hidden_size])
-                        .permute(1, 0, 2)
-                        .contiguous()
-                    )  # [S/tp, B, H]
+                if self.config.sequence_parallel:
+                    batch_size, local_seq_len, hidden_size = (
+                        decoder_input.shape
+                    )
+                    decoder_input = decoder_input.reshape(
+                        [-1, decoder_input.shape[-1]]
+                    )
+                    decoder_input = ScatterOp.apply(decoder_input)
+                    if not self.config.gpt_model_use_experimental_version:
+                        decoder_input = (
+                            decoder_input.reshape(
+                                [batch_size, -1, hidden_size]
+                            )
+                            .permute(1, 0, 2)
+                            .contiguous()
+                        )  # [S/tp, B, H]
 
             # Pop auxiliary data
             origin_start_row_indices = dict_args.pop(
@@ -914,9 +932,7 @@ class MultiTokenPredictionLayer(FleetLayer):
             dict_args.pop("decoder_input", None)
 
             # Concat [backbone_hidden | mtp_hidden] for unified split in downstream LM heads.
-            backbone_hs = dict_args.get(
-                "_backbone_hidden_states", hidden_states
-            )
+            backbone_hs = dict_args["_backbone_hidden_states"]
             dict_args["hidden_states"] = paddle.concat(
                 [backbone_hs, hidden_states]
             )

--- a/src/paddlefleet/transformer/paddle_norm.py
+++ b/src/paddlefleet/transformer/paddle_norm.py
@@ -269,7 +269,10 @@ class WrappedPaddleNormPipe(paddle.nn.Layer):
             and not self.config.mtp_load_weight_only
             and not (
                 not self.config.gpt_model_use_experimental_version
-                and self.config.enable_mtp_magic_send
+                and (
+                    self.config.enable_mtp_magic_send
+                    or self.config.separate_mtp_input
+                )
             )
         ):
             hidden_states_concat = dict_args["hidden_states"]
@@ -287,7 +290,10 @@ class WrappedPaddleNormPipe(paddle.nn.Layer):
             and not self.config.mtp_load_weight_only
             and not (
                 not self.config.gpt_model_use_experimental_version
-                and self.config.enable_mtp_magic_send
+                and (
+                    self.config.enable_mtp_magic_send
+                    or self.config.separate_mtp_input
+                )
             )
         ):
             # normalize MTP hidden_states

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -88,6 +88,16 @@ class TransformerConfig(ModelParallelConfig):
     and re-embed there, instead of pre-computing shifted embeddings at first stage
     and concatenating them through the pipeline."""
 
+    separate_mtp_input: bool = False
+    """When True, the shifted MTP embeddings computed by GPTEmbedding are handed to the
+    MTP layer through a dedicated ``mtp_decoder_inputs`` entry in ``dict_args`` instead
+    of being concatenated into ``hidden_states``. This removes the per-layer
+    split/concat of the MTP chunks while leaving GPTEmbedding's shifted-embedding
+    computation (including its CP/SP scatter) untouched, so the MTP layer must not
+    re-scatter them. Intended for pipeline_model_parallel_size == 1, where there is no
+    P2P send for the embeddings to piggyback on; ``enable_mtp_magic_send`` covers the
+    PP > 1 case."""
+
     experimental_dataflow: bool = False
     """When True, use new experimental dataflow where mtp_startend_row_indices_all is passed as a
     separate input instead of being appended to attn_mask_startend_row_indices.
@@ -1512,6 +1522,21 @@ class TransformerConfig(ModelParallelConfig):
             # use_dense_mtp so the MTP layer matches whatever the backbone is.
             assert not self.use_dense_mtp, (
                 "mtp_shared_last_layer cannot be True if use_dense_mtp= True"
+            )
+
+        if self.separate_mtp_input:
+            assert self.num_nextn_predict_layers == 1, (
+                "separate_mtp_input only supports num_nextn_predict_layers=1"
+            )
+            assert self.pipeline_model_parallel_size == 1, (
+                "separate_mtp_input requires pipeline_model_parallel_size == 1; "
+                "use enable_mtp_magic_send for pipeline_model_parallel_size > 1"
+            )
+            assert not self.enable_mtp_magic_send, (
+                "separate_mtp_input and enable_mtp_magic_send are mutually exclusive"
+            )
+            assert not self.mtp_load_weight_only, (
+                "separate_mtp_input is incompatible with mtp_load_weight_only"
             )
 
         if self.enable_mtp_magic_send:

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -1525,19 +1525,39 @@ class TransformerConfig(ModelParallelConfig):
             )
 
         if self.separate_mtp_input:
-            assert self.num_nextn_predict_layers == 1, (
-                "separate_mtp_input only supports num_nextn_predict_layers=1"
-            )
-            assert self.pipeline_model_parallel_size == 1, (
-                "separate_mtp_input requires pipeline_model_parallel_size == 1; "
-                "use enable_mtp_magic_send for pipeline_model_parallel_size > 1"
-            )
-            assert not self.enable_mtp_magic_send, (
-                "separate_mtp_input and enable_mtp_magic_send are mutually exclusive"
-            )
-            assert not self.mtp_load_weight_only, (
-                "separate_mtp_input is incompatible with mtp_load_weight_only"
-            )
+            # Raise instead of assert: with ``python -O`` assertions are stripped,
+            # and an unsupported combination would then silently enter a path that
+            # only holds for the layout below -- or crash much later inside
+            # MultiTokenPredictionLayer with a missing ``mtp_decoder_inputs``.
+            if self.num_nextn_predict_layers != 1:
+                raise ValueError(
+                    "separate_mtp_input only supports "
+                    "num_nextn_predict_layers == 1, got "
+                    f"num_nextn_predict_layers={self.num_nextn_predict_layers}. "
+                    "The MTP input is consumed once and stripped from dict_args, "
+                    "so deeper MTP layers would not receive it."
+                )
+            if self.pipeline_model_parallel_size != 1:
+                raise ValueError(
+                    "separate_mtp_input requires pipeline_model_parallel_size "
+                    "== 1, got pipeline_model_parallel_size="
+                    f"{self.pipeline_model_parallel_size}. Use "
+                    "enable_mtp_magic_send for pipeline_model_parallel_size > 1."
+                )
+            if self.enable_mtp_magic_send:
+                raise ValueError(
+                    "separate_mtp_input and enable_mtp_magic_send are mutually "
+                    "exclusive, got separate_mtp_input=True and "
+                    "enable_mtp_magic_send=True. They are two transports for the "
+                    "same tensor; pick the one matching the pipeline degree."
+                )
+            if self.mtp_load_weight_only:
+                raise ValueError(
+                    "separate_mtp_input is incompatible with "
+                    "mtp_load_weight_only=True. GPTEmbedding does not build the "
+                    "shifted MTP embeddings in that mode, so separate_mtp_input "
+                    "would silently do nothing."
+                )
 
         if self.enable_mtp_magic_send:
             assert self.num_nextn_predict_layers == 1, (

--- a/src/paddlefleet/transformer/transformer_layer.py
+++ b/src/paddlefleet/transformer/transformer_layer.py
@@ -570,6 +570,7 @@ class TransformerLayer(nn.Layer):
             and not is_mtp
             and not self.config.mtp_load_weight_only
             and not self.config.enable_mtp_magic_send
+            and not self.config.separate_mtp_input
         ):
             # process hidden_states
             hidden_states_concat = dict_args["hidden_states"]
@@ -777,6 +778,7 @@ class TransformerLayer(nn.Layer):
             and not is_mtp
             and not self.config.mtp_load_weight_only
             and not self.config.enable_mtp_magic_send
+            and not self.config.separate_mtp_input
         ):
             hidden_states_concat = paddle.concat([output, *mtp_input])
             rst["hidden_states"] = hidden_states_concat
@@ -1810,6 +1812,7 @@ class HySparseTransformerLayer(TransformerLayer):
             and not is_mtp
             and not self.config.mtp_load_weight_only
             and not self.config.enable_mtp_magic_send
+            and not self.config.separate_mtp_input
         )
 
     def _mtp_split(self, dict_args, is_mtp):

--- a/tests/multi_card_tests/tensor_parallel/test_separate_mtp_input_tp_sp.py
+++ b/tests/multi_card_tests/tensor_parallel/test_separate_mtp_input_tp_sp.py
@@ -37,18 +37,18 @@ import unittest
 _repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
 sys.path.insert(0, os.path.join(_repo_root, "src"))
 
-import numpy as np  # noqa: E402
-import paddle  # noqa: E402
-import paddle.distributed as dist  # noqa: E402
-from paddle.distributed import fleet  # noqa: E402
-from paddle.distributed.fleet.meta_parallel import (  # noqa: E402
+import numpy as np
+import paddle
+import paddle.distributed as dist
+from paddle.distributed import fleet
+from paddle.distributed.fleet.meta_parallel import (
     NoPipelineParallel,
 )
 
-import paddlefleet.parallel_state as ps  # noqa: E402
-from paddlefleet.gpt_builders import gpt_builder  # noqa: E402
-from paddlefleet.models.gpt import GPTConfig  # noqa: E402
-from paddlefleet.tensor_parallel.random import (  # noqa: E402
+import paddlefleet.parallel_state as ps
+from paddlefleet.gpt_builders import gpt_builder
+from paddlefleet.models.gpt import GPTConfig
+from paddlefleet.tensor_parallel.random import (
     model_parallel_cuda_manual_seed,
 )
 
@@ -145,9 +145,7 @@ def _make_inputs():
     position_ids = (
         paddle.arange(total, dtype=paddle.int64).reshape([1, -1]).cuda()
     )
-    mask_all = paddle.ones(
-        [BATCH, NUM_MTP, SEQ], dtype=paddle.float32
-    ).cuda()
+    mask_all = paddle.ones([BATCH, NUM_MTP, SEQ], dtype=paddle.float32).cuda()
     mask_all[:, :, -2:] = 0.0
     startend_all = paddle.zeros(
         [BATCH, NUM_MTP, SEQ, 1], dtype=paddle.int32

--- a/tests/multi_card_tests/tensor_parallel/test_separate_mtp_input_tp_sp.py
+++ b/tests/multi_card_tests/tensor_parallel/test_separate_mtp_input_tp_sp.py
@@ -1,0 +1,247 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tensor/sequence-parallel bitwise equivalence test for ``separate_mtp_input``.
+
+Under ``sequence_parallel=True`` the shifted MTP embeddings are laid out as
+``[S/tp, B, H]`` by ``GPTEmbedding``.  ``separate_mtp_input`` forwards exactly
+those tensors to ``MultiTokenPredictionLayer`` through ``mtp_decoder_inputs``
+(no second scatter), so loss and every parameter gradient must match the
+concat/split baseline bit for bit.
+
+Two models are built in one process group, given identical weights, and fed
+identical inputs.
+
+Run with:
+    python -m paddle.distributed.launch --gpus=0,1 \
+        tests/multi_card_tests/tensor_parallel/test_separate_mtp_input_tp_sp.py
+"""
+
+import functools
+import os
+import sys
+import unittest
+
+# Prefer the local source tree over an installed paddlefleet.
+_repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(_repo_root, "src"))
+
+import numpy as np  # noqa: E402
+import paddle  # noqa: E402
+import paddle.distributed as dist  # noqa: E402
+from paddle.distributed import fleet  # noqa: E402
+from paddle.distributed.fleet.meta_parallel import (  # noqa: E402
+    NoPipelineParallel,
+)
+
+import paddlefleet.parallel_state as ps  # noqa: E402
+from paddlefleet.gpt_builders import gpt_builder  # noqa: E402
+from paddlefleet.models.gpt import GPTConfig  # noqa: E402
+from paddlefleet.tensor_parallel.random import (  # noqa: E402
+    model_parallel_cuda_manual_seed,
+)
+
+VOCAB = 512
+SEQ = 64  # main decoder length; must stay divisible by TP for SP scatter
+NUM_MTP = 1
+BATCH = 1
+SEED = 20260819
+
+TP_SIZE = None
+STRATEGY = None
+
+
+def setUpModule():
+    global TP_SIZE, STRATEGY
+    TP_SIZE = dist.get_world_size()
+    STRATEGY = fleet.DistributedStrategy()
+    STRATEGY.hybrid_configs = {
+        "dp_degree": 1,
+        "mp_degree": TP_SIZE,
+        "pp_degree": 1,
+        "sharding_degree": 1,
+        "sep_degree": 1,
+        "cp_degree": 1,
+        "ep_degree": 1,
+        "moe_sharding_degree": 1,
+        "order": [
+            "sharding",
+            "moe_sharding",
+            "pp",
+            "sep",
+            "cp",
+            "dp",
+            "ep",
+            "mp",
+        ],
+    }
+    fleet.init(is_collective=True, strategy=STRATEGY)
+    hcg = fleet.get_hybrid_communicate_group()
+    ps.initialize_model_parallel(hcg)
+    model_parallel_cuda_manual_seed(SEED)
+
+
+def _make_config(separate, mhc):
+    extra = (
+        {"enable_hyper_connections": True, "num_residual_streams": 4}
+        if mhc
+        else {}
+    )
+    return GPTConfig(
+        vocab_size=VOCAB,
+        max_sequence_length=SEQ + NUM_MTP,
+        num_hidden_layers=2,
+        hidden_size=256,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        intermediate_size=512,
+        # MTP
+        num_nextn_predict_layers=NUM_MTP,
+        mtp_loss_scaling_factor=0.3,
+        use_dense_mtp=True,
+        separate_mtp_input=separate,
+        # TP / SP
+        tensor_model_parallel_size=TP_SIZE,
+        sequence_parallel=True,
+        context_parallel_size=1,
+        pipeline_model_parallel_size=1,
+        # general
+        normalization="RMSNorm",
+        rms_norm_eps=1e-6,
+        hidden_dropout_prob=0.0,
+        attention_dropout=0.0,
+        use_bias=False,
+        position_embedding_type="rope",
+        rotary_percent=1.0,
+        rotary_base=10000,
+        rope_scaling=1.0,
+        tie_word_embeddings=True,
+        gpt_model_use_experimental_version=False,
+        init_method=functools.partial(paddle.nn.init.xavier_uniform_, gain=1.0),
+        output_layer_init_method=functools.partial(
+            paddle.nn.init.xavier_uniform_, gain=1.0
+        ),
+        **extra,
+    )
+
+
+def _make_inputs():
+    """Identical inputs for both runs, broadcast so every TP rank agrees."""
+    total = SEQ + NUM_MTP
+    paddle.seed(SEED)
+    data = paddle.randint(low=1, high=VOCAB, shape=(BATCH, total + 1)).cuda()
+    dist.broadcast(data, src=0)
+    position_ids = (
+        paddle.arange(total, dtype=paddle.int64).reshape([1, -1]).cuda()
+    )
+    mask_all = paddle.ones(
+        [BATCH, NUM_MTP, SEQ], dtype=paddle.float32
+    ).cuda()
+    mask_all[:, :, -2:] = 0.0
+    startend_all = paddle.zeros(
+        [BATCH, NUM_MTP, SEQ, 1], dtype=paddle.int32
+    ).cuda()
+    return {
+        "input_ids": data[:, :-1].contiguous(),
+        "labels": data[:, 1:].contiguous(),
+        "position_ids": position_ids.expand([BATCH, total]).contiguous(),
+        "mtp_hidden_inputs_mask_all": mask_all,
+        "mtp_startend_row_indices_all": startend_all,
+    }
+
+
+def _forward_backward(model, raw_inputs):
+    """Run one fwd+bwd step and return (loss, {param_name: grad})."""
+    pipe_model = NoPipelineParallel(model, STRATEGY)
+    labels = raw_inputs["labels"].clone()
+    inputs = (
+        {
+            "input_ids": [raw_inputs["input_ids"].clone()],
+            "position_ids": [raw_inputs["position_ids"].clone()],
+            "mtp_startend_row_indices_all": raw_inputs[
+                "mtp_startend_row_indices_all"
+            ].clone(),
+            "mtp_hidden_inputs_mask_all": raw_inputs[
+                "mtp_hidden_inputs_mask_all"
+            ].clone(),
+        },
+        [labels],
+    )
+    loss = pipe_model.forward_backward_pipeline(inputs)
+    grads = {
+        name: param.grad.clone()
+        for name, param in model.named_parameters()
+        if param.grad is not None
+    }
+    return loss, grads
+
+
+class TestSeparateMTPInputTPSP(unittest.TestCase):
+    """separate_mtp_input must be bit-identical to the baseline under TP/SP."""
+
+    def _assert_bitwise(self, a, b, what):
+        self.assertEqual(list(a.shape), list(b.shape), f"{what}: shape differs")
+        self.assertEqual(a.dtype, b.dtype, f"{what}: dtype differs")
+        # float32 widening is lossless for bf16/fp16, so equality on the widened
+        # values is equivalent to a bit-for-bit comparison (and equal_all has no
+        # bfloat16 kernel).
+        left = np.asarray(a.astype("float32").numpy())
+        right = np.asarray(b.astype("float32").numpy())
+        if not np.array_equal(left, right):
+            diff = np.max(np.abs(left - right))
+            self.fail(f"{what}: not bitwise equal (max abs diff {diff})")
+
+    def _compare(self, mhc):
+        raw_inputs = _make_inputs()
+
+        paddle.seed(SEED)
+        base_model = gpt_builder(_make_config(False, mhc), num_stages=1)
+        sep_model = gpt_builder(_make_config(True, mhc), num_stages=1)
+        # identical weights: the flag changes dataflow only, never parameters
+        sep_model.set_state_dict(base_model.state_dict())
+
+        base_loss, base_grads = _forward_backward(base_model, raw_inputs)
+        sep_loss, sep_grads = _forward_backward(sep_model, raw_inputs)
+
+        self.assertTrue(
+            paddle.isfinite(base_loss).item(),
+            f"baseline loss is not finite: {base_loss.item()}",
+        )
+        self._assert_bitwise(sep_loss, base_loss, "loss")
+
+        self.assertEqual(
+            sorted(base_grads), sorted(sep_grads), "gradient key sets differ"
+        )
+        self.assertGreater(len(base_grads), 0, "no gradients were produced")
+        for name in base_grads:
+            self._assert_bitwise(
+                sep_grads[name], base_grads[name], f"grad[{name}]"
+            )
+
+        if dist.get_rank() == 0:
+            print(
+                f"[tp={TP_SIZE} sp=True mhc={mhc}] loss="
+                f"{np.array(base_loss.astype('float32'))} "
+                f"{len(base_grads)} grads bitwise equal"
+            )
+
+    def test_sequence_parallel(self):
+        self._compare(mhc=False)
+
+    def test_sequence_parallel_with_mhc(self):
+        self._compare(mhc=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/multi_card_tests/test_separate_mtp_input_cp.py
+++ b/tests/multi_card_tests/test_separate_mtp_input_cp.py
@@ -39,21 +39,21 @@ import unittest
 _repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, os.path.join(_repo_root, "src"))
 
-import numpy as np  # noqa: E402
-import paddle  # noqa: E402
-import paddle.distributed as dist  # noqa: E402
-import paddle.nn.functional as F  # noqa: E402
-from paddle.distributed import fleet  # noqa: E402
-from paddle.distributed.fleet.meta_parallel import (  # noqa: E402
+import numpy as np
+import paddle
+import paddle.distributed as dist
+import paddle.nn.functional as F
+from paddle.distributed import fleet
+from paddle.distributed.fleet.meta_parallel import (
     NoPipelineParallel,
 )
 
-from paddlefleet.gpt_builders import gpt_builder  # noqa: E402
-from paddlefleet.models.gpt import GPTConfig  # noqa: E402
-from paddlefleet.tensor_parallel.random import (  # noqa: E402
+from paddlefleet.gpt_builders import gpt_builder
+from paddlefleet.models.gpt import GPTConfig
+from paddlefleet.tensor_parallel.random import (
     model_parallel_cuda_manual_seed,
 )
-from paddlefleet.training.initialize import initialize_fleet  # noqa: E402
+from paddlefleet.training.initialize import initialize_fleet
 
 VOCAB = 512
 SEQ = 64  # main decoder length; MTP consumes num_nextn extra positions
@@ -286,6 +286,3 @@ class TestSeparateMTPInputCP(unittest.TestCase):
 if __name__ == "__main__":
     paddle.set_default_dtype("bfloat16")
     unittest.main()
-
-
-

--- a/tests/multi_card_tests/test_separate_mtp_input_cp.py
+++ b/tests/multi_card_tests/test_separate_mtp_input_cp.py
@@ -1,0 +1,291 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Context-parallel bitwise equivalence test for ``separate_mtp_input``.
+
+``separate_mtp_input`` only changes *how* the shifted MTP embeddings reach
+``MultiTokenPredictionLayer`` (dedicated ``mtp_decoder_inputs`` key instead of
+being concatenated into ``hidden_states`` and split again in every backbone
+layer).  The tensors themselves -- including their CP scatter -- are still
+produced by ``GPTEmbedding``, so loss and every parameter gradient must match
+the concat/split baseline bit for bit.
+
+The comparison is done inside one process group: two models are built, given
+identical weights, and fed identical inputs.
+
+Run with:
+    python -m paddle.distributed.launch --gpus=0,1 \
+        tests/multi_card_tests/test_separate_mtp_input_cp.py
+"""
+
+import functools
+import os
+import sys
+import unittest
+
+# Prefer the local source tree over an installed paddlefleet, mirroring
+# PYTHONPATH in script/train_gpu.sh.
+_repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(_repo_root, "src"))
+
+import numpy as np  # noqa: E402
+import paddle  # noqa: E402
+import paddle.distributed as dist  # noqa: E402
+import paddle.nn.functional as F  # noqa: E402
+from paddle.distributed import fleet  # noqa: E402
+from paddle.distributed.fleet.meta_parallel import (  # noqa: E402
+    NoPipelineParallel,
+)
+
+from paddlefleet.gpt_builders import gpt_builder  # noqa: E402
+from paddlefleet.models.gpt import GPTConfig  # noqa: E402
+from paddlefleet.tensor_parallel.random import (  # noqa: E402
+    model_parallel_cuda_manual_seed,
+)
+from paddlefleet.training.initialize import initialize_fleet  # noqa: E402
+
+VOCAB = 512
+SEQ = 64  # main decoder length; MTP consumes num_nextn extra positions
+NUM_MTP = 1
+BATCH = 1
+SEED = 20260819
+
+CP_SIZE = None
+STRATEGY = None
+
+
+def setUpModule():
+    global CP_SIZE, STRATEGY
+    CP_SIZE = dist.get_world_size()
+    STRATEGY = fleet.DistributedStrategy()
+    STRATEGY.hybrid_configs = {
+        "dp_degree": 1,
+        "mp_degree": 1,
+        "pp_degree": 1,
+        # CP is layered on top of the sharding dimension.  ep_degree > 1 selects
+        # paddle's expert-aware HybridCommunicateGroup, which is what makes the
+        # overlapping sharding/cp/ep dims legal (same shape as the other CP
+        # tests in this directory).
+        "sharding_degree": CP_SIZE,
+        "sep_degree": 1,
+        "cp_degree": CP_SIZE,
+        "ep_degree": CP_SIZE,
+        "moe_sharding_degree": 1,
+        "order": [
+            "sharding",
+            "moe_sharding",
+            "pp",
+            "sep",
+            "cp",
+            "dp",
+            "ep",
+            "mp",
+        ],
+    }
+    initialize_fleet(STRATEGY)
+    paddle.seed(SEED)
+    model_parallel_cuda_manual_seed(SEED)
+
+
+def _make_config(separate, cp_mode, mhc):
+    extra = (
+        {"enable_hyper_connections": True, "num_residual_streams": 4}
+        if mhc
+        else {}
+    )
+    return GPTConfig(
+        vocab_size=VOCAB,
+        max_sequence_length=SEQ,
+        num_hidden_layers=2,
+        hidden_size=256,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        intermediate_size=512,
+        # MLA, matching the shape constraints used by the CP dataflow test
+        multi_latent_attention=True,
+        q_lora_rank=128,
+        kv_lora_rank=64,
+        qk_nope_head_dim=32,
+        qk_rope_head_dim=16,
+        v_head_dim=48,
+        rope_theta=10000,
+        gated_linear_unit=True,
+        hidden_act=F.silu,
+        # MTP
+        num_nextn_predict_layers=NUM_MTP,
+        mtp_loss_scaling_factor=0.3,
+        use_dense_mtp=True,
+        separate_mtp_input=separate,
+        # CP
+        context_parallel_size=CP_SIZE,
+        cp_balance_mode=cp_mode,
+        experimental_dataflow=True,
+        sequence_parallel=False,
+        tensor_model_parallel_size=1,
+        pipeline_model_parallel_size=1,
+        # general
+        normalization="RMSNorm",
+        rms_norm_eps=1e-6,
+        apply_rope_fusion=False,
+        hidden_dropout_prob=0.0,
+        attention_dropout=0.0,
+        use_cpu_initialization=False,
+        parallel_output=True,
+        tie_word_embeddings=True,
+        position_embedding_type="rope",
+        rotary_percent=1.0,
+        rotary_base=10000,
+        rope_scaling=1.0,
+        bf16=True,
+        autocast_dtype=paddle.bfloat16,
+        params_dtype=paddle.bfloat16,
+        gpt_model_use_experimental_version=False,
+        init_method=functools.partial(paddle.nn.init.xavier_uniform_, gain=1.0),
+        output_layer_init_method=functools.partial(
+            paddle.nn.init.xavier_uniform_, gain=1.0
+        ),
+        **extra,
+    )
+
+
+def _make_inputs():
+    """Identical inputs for both runs (built once, cloned per run)."""
+    paddle.seed(SEED)
+    total = SEQ + NUM_MTP
+    data = paddle.randint(low=1, high=VOCAB, shape=(BATCH, total + 1)).cuda()
+    dist.broadcast(data, src=0)
+    input_ids = data[:, :-1].contiguous()
+    labels = data[:, 1:].contiguous()
+
+    # causal boundaries, last dim = 2 (experimental dataflow)
+    attn_mask_startend_row_indices = paddle.zeros(
+        [BATCH, 1, SEQ, 2], dtype=paddle.int32
+    ).cuda()
+    for i in range(SEQ):
+        attn_mask_startend_row_indices[:, :, i, 0] = SEQ
+        attn_mask_startend_row_indices[:, :, i, 1] = i
+
+    mtp_hidden_inputs_mask_all = paddle.ones(
+        [BATCH, NUM_MTP, SEQ], dtype=paddle.int32
+    ).cuda()
+    mtp_hidden_inputs_mask_all[:, :, -2:] = 0
+    mtp_startend_row_indices_all = paddle.full(
+        [BATCH, NUM_MTP, SEQ, 1], fill_value=SEQ, dtype=paddle.int32
+    ).cuda()
+
+    return {
+        "input_ids": input_ids,
+        "labels": labels,
+        "attn_mask_startend_row_indices": attn_mask_startend_row_indices,
+        "mtp_startend_row_indices_all": mtp_startend_row_indices_all,
+        "mtp_hidden_inputs_mask_all": mtp_hidden_inputs_mask_all,
+    }
+
+
+def _forward_backward(model, raw_inputs):
+    """Run one fwd+bwd step and return (loss, {param_name: grad})."""
+    pipe_model = NoPipelineParallel(model, STRATEGY)
+    labels = raw_inputs["labels"].clone()
+    inputs = (
+        {
+            "input_ids": [raw_inputs["input_ids"].clone()],
+            "labels": [labels],
+            "attn_mask_startend_row_indices": [
+                raw_inputs["attn_mask_startend_row_indices"].clone()
+            ],
+            "mtp_startend_row_indices_all": [
+                raw_inputs["mtp_startend_row_indices_all"].clone()
+            ],
+            "mtp_hidden_inputs_mask_all": [
+                raw_inputs["mtp_hidden_inputs_mask_all"].clone()
+            ],
+        },
+        labels,
+    )
+    loss = pipe_model.forward_backward_pipeline(inputs)
+    grads = {
+        name: param.grad.clone()
+        for name, param in model.named_parameters()
+        if param.grad is not None
+    }
+    return loss, grads
+
+
+class TestSeparateMTPInputCP(unittest.TestCase):
+    """separate_mtp_input must be bit-identical to the baseline under CP > 1."""
+
+    def _assert_bitwise(self, a, b, what):
+        self.assertEqual(list(a.shape), list(b.shape), f"{what}: shape differs")
+        self.assertEqual(a.dtype, b.dtype, f"{what}: dtype differs")
+        # float32 widening is lossless for bf16/fp16, so equality on the widened
+        # values is equivalent to a bit-for-bit comparison (and equal_all has no
+        # bfloat16 kernel).
+        left = np.asarray(a.astype("float32").numpy())
+        right = np.asarray(b.astype("float32").numpy())
+        if not np.array_equal(left, right):
+            diff = np.max(np.abs(left - right))
+            self.fail(f"{what}: not bitwise equal (max abs diff {diff})")
+
+    def _compare(self, cp_mode, mhc):
+        raw_inputs = _make_inputs()
+
+        paddle.seed(SEED)
+        base_model = gpt_builder(
+            _make_config(False, cp_mode, mhc), num_stages=1
+        )
+        sep_model = gpt_builder(_make_config(True, cp_mode, mhc), num_stages=1)
+        # identical weights: the flag changes dataflow only, never parameters
+        sep_model.set_state_dict(base_model.state_dict())
+
+        base_loss, base_grads = _forward_backward(base_model, raw_inputs)
+        sep_loss, sep_grads = _forward_backward(sep_model, raw_inputs)
+
+        self.assertTrue(
+            paddle.isfinite(base_loss).item(),
+            f"baseline loss is not finite: {base_loss.item()}",
+        )
+        self._assert_bitwise(sep_loss, base_loss, "loss")
+
+        self.assertEqual(
+            sorted(base_grads), sorted(sep_grads), "gradient key sets differ"
+        )
+        self.assertGreater(len(base_grads), 0, "no gradients were produced")
+        for name in base_grads:
+            self._assert_bitwise(
+                sep_grads[name], base_grads[name], f"grad[{name}]"
+            )
+
+        if dist.get_rank() == 0:
+            print(
+                f"[cp={CP_SIZE} mode={cp_mode} mhc={mhc}] loss="
+                f"{np.array(base_loss.astype('float32'))} "
+                f"{len(base_grads)} grads bitwise equal"
+            )
+
+    def test_contiguous_allgather(self):
+        self._compare("contiguous_allgather", mhc=False)
+
+    def test_dualchunk_allgather(self):
+        self._compare("dualchunk_allgather", mhc=False)
+
+    def test_contiguous_allgather_with_mhc(self):
+        self._compare("contiguous_allgather", mhc=True)
+
+
+if __name__ == "__main__":
+    paddle.set_default_dtype("bfloat16")
+    unittest.main()
+
+
+

--- a/tests/single_card_tests/transformer/test_separate_mtp_input.py
+++ b/tests/single_card_tests/transformer/test_separate_mtp_input.py
@@ -1,0 +1,898 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the ``separate_mtp_input`` feature.
+
+``separate_mtp_input`` hands the shifted MTP embeddings computed by
+``GPTEmbedding`` to ``MultiTokenPredictionLayer`` through a dedicated
+``mtp_decoder_inputs`` entry in ``dict_args`` instead of concatenating them into
+``hidden_states``.  That removes the per-layer split/concat from every backbone
+TransformerLayer.  It is the ``pipeline_model_parallel_size == 1`` counterpart of
+``enable_mtp_magic_send``.
+
+End-to-end bitwise equivalence (forward + backward) against the concat/split
+baseline is covered on real devices by
+
+* ``tests/multi_card_tests/test_separate_mtp_input_cp.py`` (CP > 1)
+* ``tests/multi_card_tests/tensor_parallel/test_separate_mtp_input_tp_sp.py``
+  (TP > 1 + sequence_parallel)
+
+This file covers the branches those runs cannot reach on a single card.
+"""
+
+import unittest
+from contextlib import ExitStack, nullcontext
+from dataclasses import dataclass
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import paddle
+from paddle import nn
+
+from paddlefleet.models.gpt import GPTConfig
+from paddlefleet.transformer.enums import AttnMaskType
+from paddlefleet.transformer.transformer_config import TransformerConfig
+
+# =====================================================================
+# Helpers
+# =====================================================================
+
+_BASE_CFG = {
+    "vocab_size": 512,
+    "hidden_size": 64,
+    "num_attention_heads": 4,
+    "num_key_value_heads": 4,
+    "tensor_model_parallel_size": 1,
+    "expert_model_parallel_size": 1,
+}
+
+
+def _cfg(**kw):
+    """separate_mtp_input config (always PP == 1)."""
+    return GPTConfig(
+        **{
+            **_BASE_CFG,
+            "separate_mtp_input": True,
+            "num_nextn_predict_layers": 1,
+            "pipeline_model_parallel_size": 1,
+            **kw,
+        }
+    )
+
+
+def _cfg_baseline(**kw):
+    """Concat/split baseline: neither separate_mtp_input nor magic send."""
+    return _cfg(separate_mtp_input=False, **kw)
+
+
+def _cfg_magic(**kw):
+    """magic send config, used for contrast assertions."""
+    return GPTConfig(
+        **{
+            **_BASE_CFG,
+            "enable_mtp_magic_send": True,
+            "num_nextn_predict_layers": 1,
+            "pipeline_model_parallel_size": 2,
+            **kw,
+        }
+    )
+
+
+class _FakeNorm(nn.Layer):
+    def __init__(self, *a, **kw):
+        super().__init__()
+
+    def forward(self, x):
+        return x
+
+
+class _FakeLinear(nn.Layer):
+    def __init__(self, in_f=128, out_f=64, *a, **kw):
+        super().__init__()
+        self.linear = nn.Linear(in_f, out_f, bias_attr=False)
+
+    def forward(self, x):
+        return self.linear(x), None
+
+
+class _FakeTransformerLayer(nn.Layer):
+    def __init__(self, *a, **kw):
+        super().__init__()
+
+    def forward(self, d):
+        return {"hidden_states": d["hidden_states"]}
+
+
+@dataclass
+class _FakeMTPSpec:
+    enorm: object = None
+    hnorm: object = None
+    eh_proj: object = None
+    e_proj: object = None
+    h_proj: object = None
+    transformer_layer: object = None
+    layer_norm: object = None
+
+    def __post_init__(self):
+        tl = MagicMock()
+        tl.sublayers_spec = MagicMock()
+        tl.sublayers_spec.self_attn = MagicMock()
+        tl.sublayers_spec.self_attn.extra_kwargs = {
+            "attn_mask_type": AttnMaskType.causal
+        }
+        self.transformer_layer = tl
+
+
+def _build_mtp_layer(config, layer_number=0):
+    from paddlefleet.transformer.multi_token_prediction import (
+        MultiTokenPredictionLayer,
+    )
+
+    spec = _FakeMTPSpec()
+    mock_pg = MagicMock(cp=None, tp=None)
+    with (
+        patch(
+            "paddlefleet.transformer.multi_token_prediction.build_spec_layer",
+            side_effect=lambda s, *a, **kw: _FakeTransformerLayer()
+            if s is spec.transformer_layer
+            else _FakeNorm(),
+        ),
+        patch(
+            "paddlefleet.transformer.multi_token_prediction.ProcessGroupCollection.use_mpu_process_groups",
+            return_value=mock_pg,
+        ),
+        patch(
+            "paddlefleet.transformer.multi_token_prediction.paddle.distributed.get_world_size",
+            return_value=1,
+        ),
+    ):
+        layer = MultiTokenPredictionLayer(
+            config=config,
+            sublayers_spec=spec,
+            layer_number=layer_number,
+            pg_collection=mock_pg,
+        )
+
+    if layer.eh_proj is not None:
+        layer.eh_proj = _FakeLinear(config.hidden_size * 2, config.hidden_size)
+    layer.enorm = _FakeNorm()
+    layer.hnorm = _FakeNorm()
+    if hasattr(layer, "norm") and layer.norm is not None:
+        layer.norm = _FakeNorm()
+    layer.transformer_layer = _FakeTransformerLayer()
+    return layer
+
+
+class _Emb(nn.Layer):
+    """Minimal stand-in for the language embedding sublayer."""
+
+    def __init__(self, v, h):
+        super().__init__()
+        self.embed_tokens = nn.Embedding(v, h)
+        self.reduce_scatter_embeddings = self.scatter_to_sequence_parallel = (
+            self.sequence_parallel
+        ) = False
+
+    @property
+    def embedding_weight(self):
+        return self.embed_tokens.weight
+
+    def forward(self, input_ids, position_ids=None):
+        return self.embed_tokens(input_ids)
+
+
+def _build_gpt_embedding(config, emb_layer=None):
+    """Build GPTEmbedding; pass ``emb_layer`` to share weights across instances."""
+    from paddlefleet.models.gpt.gpt_embedding import GPTEmbedding
+
+    mock_spec = MagicMock(rope_embedding=None)
+    if emb_layer is None:
+        emb_layer = _Emb(config.vocab_size, config.hidden_size)
+    with (
+        patch(
+            "paddlefleet.models.gpt.gpt_embedding.build_spec_layer",
+            side_effect=lambda s, *a, **kw: emb_layer
+            if s is mock_spec.language_embedding
+            else None,
+        ),
+        patch(
+            "paddlefleet.models.gpt.gpt_embedding.mark_context_parallel_parameter_disable_scale_grad"
+        ),
+    ):
+        return GPTEmbedding(
+            sublayers_spec=mock_spec,
+            config=config,
+            vocab_size=config.vocab_size,
+            max_sequence_length=128,
+            position_embedding_type="rope",
+        )
+
+
+def _run_emb(config, input_ids, cp_world_size=1, emb_layer=None):
+    """Run GPTEmbedding.forward with CP/SP scatter replaced by identity."""
+    emb = _build_gpt_embedding(config, emb_layer=emb_layer)
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                "paddlefleet.models.gpt.gpt_embedding.get_context_parallel_world_size",
+                return_value=cp_world_size,
+            )
+        )
+        sc = stack.enter_context(
+            patch("paddlefleet.models.gpt.gpt_embedding.ScatterOp")
+        )
+        sc.apply = lambda x: x
+        cp = stack.enter_context(
+            patch(
+                "paddlefleet.models.gpt.gpt_embedding.ContextParallelScatterOp"
+            )
+        )
+        cp.apply = lambda x, axis=0, **kwargs: x
+        return emb.forward({"input_ids": input_ids})
+
+
+def _mtp_forward_ctx(
+    cp_world_size=1,
+    scatter_fn=None,
+    cp_scatter_fn=None,
+    proj_override=None,
+    layer=None,
+):
+    """Context manager wiring up the mocks MTP forward needs on a single card."""
+    stack = ExitStack()
+
+    def _enter(stack_ref):
+        stack_ref.enter_context(
+            patch(
+                "paddlefleet.transformer.multi_token_prediction.get_context_parallel_world_size",
+                return_value=cp_world_size,
+            )
+        )
+        tp = stack_ref.enter_context(
+            patch(
+                "paddlefleet.transformer.multi_token_prediction.tensor_parallel"
+            )
+        )
+        tp.get_cuda_rng_tracker.return_value.fork.return_value = nullcontext()
+
+        if scatter_fn is not None:
+            so = stack_ref.enter_context(
+                patch(
+                    "paddlefleet.transformer.multi_token_prediction.ScatterOp"
+                )
+            )
+            so.apply = scatter_fn
+        if cp_scatter_fn is not None:
+            co = stack_ref.enter_context(
+                patch(
+                    "paddlefleet.transformer.multi_token_prediction.ContextParallelScatterOp"
+                )
+            )
+            co.apply = cp_scatter_fn
+        if proj_override is not None and layer is not None:
+            stack_ref.enter_context(
+                patch.object(
+                    layer,
+                    "_proj_and_transformer_layer",
+                    side_effect=proj_override,
+                )
+            )
+
+    class _Ctx:
+        def __enter__(self):
+            _enter(stack)
+            return stack
+
+        def __exit__(self, *a):
+            stack.__exit__(*a)
+
+    return _Ctx()
+
+
+def _assert_bitwise_equal(testcase, a, b, msg):
+    """Bit-for-bit tensor comparison (no tolerance)."""
+    testcase.assertEqual(list(a.shape), list(b.shape), f"{msg}: shape differs")
+    testcase.assertTrue(
+        paddle.equal_all(a, b).item(),
+        f"{msg}: values differ (max abs diff "
+        f"{paddle.max(paddle.abs(a.astype('float32') - b.astype('float32'))).item()})",
+    )
+
+
+# =====================================================================
+# Tests
+# =====================================================================
+
+
+class TestSeparateMTPInputConfig(unittest.TestCase):
+    """TransformerConfig.__post_init__ validation for separate_mtp_input."""
+
+    def test_default_is_off(self):
+        self.assertFalse(TransformerConfig().separate_mtp_input)
+
+    def test_valid_config_accepted(self):
+        cfg = TransformerConfig(
+            separate_mtp_input=True,
+            num_nextn_predict_layers=1,
+            pipeline_model_parallel_size=1,
+        )
+        self.assertTrue(cfg.separate_mtp_input)
+
+    def test_rejects_multiple_mtp_layers(self):
+        with self.assertRaisesRegex(
+            AssertionError, "num_nextn_predict_layers=1"
+        ):
+            TransformerConfig(
+                separate_mtp_input=True,
+                num_nextn_predict_layers=2,
+                pipeline_model_parallel_size=1,
+            )
+
+    def test_rejects_pipeline_parallel(self):
+        with self.assertRaisesRegex(
+            AssertionError, "pipeline_model_parallel_size == 1"
+        ):
+            TransformerConfig(
+                separate_mtp_input=True,
+                num_nextn_predict_layers=1,
+                pipeline_model_parallel_size=2,
+            )
+
+    def test_mutually_exclusive_with_magic_send(self):
+        with self.assertRaisesRegex(AssertionError, "mutually exclusive"):
+            TransformerConfig(
+                separate_mtp_input=True,
+                enable_mtp_magic_send=True,
+                num_nextn_predict_layers=1,
+                pipeline_model_parallel_size=1,
+            )
+
+    def test_rejects_mtp_load_weight_only(self):
+        with self.assertRaisesRegex(
+            AssertionError, "mtp_load_weight_only"
+        ):
+            TransformerConfig(
+                separate_mtp_input=True,
+                mtp_load_weight_only=True,
+                num_nextn_predict_layers=1,
+                pipeline_model_parallel_size=1,
+            )
+
+
+class TestGPTEmbeddingSeparateOutput(unittest.TestCase):
+    """GPTEmbedding hands the shifted MTP embedding over a dedicated key."""
+
+    B, S, H = 2, 10, 64  # main decoder length is S - num_nextn_predict_layers
+
+    def _input_ids(self):
+        paddle.seed(20260819)
+        return paddle.randint(0, _BASE_CFG["vocab_size"], [self.B, self.S])
+
+    def test_hidden_states_carries_backbone_only(self):
+        main_len = self.S - 1
+        out = _run_emb(_cfg(), self._input_ids())
+        self.assertEqual(
+            out["hidden_states"].shape, [self.B, main_len, self.H]
+        )
+        self.assertIn("mtp_decoder_inputs", out)
+        self.assertEqual(
+            out["mtp_decoder_inputs"].shape, [1, self.B, main_len, self.H]
+        )
+
+    def test_baseline_concatenates_instead(self):
+        main_len = self.S - 1
+        out = _run_emb(_cfg_baseline(), self._input_ids())
+        self.assertEqual(
+            out["hidden_states"].shape, [self.B * 2, main_len, self.H]
+        )
+        self.assertNotIn("mtp_decoder_inputs", out)
+
+    def _assert_matches_baseline(self, cfg_kw, cp_world_size=1):
+        """Same weights + same input => bitwise identical tensors, only regrouped."""
+        input_ids = self._input_ids()
+        shared_emb = _Emb(_BASE_CFG["vocab_size"], self.H)
+
+        base = _run_emb(
+            _cfg_baseline(**cfg_kw),
+            input_ids,
+            cp_world_size=cp_world_size,
+            emb_layer=shared_emb,
+        )
+        sep = _run_emb(
+            _cfg(**cfg_kw),
+            input_ids,
+            cp_world_size=cp_world_size,
+            emb_layer=shared_emb,
+        )
+
+        # baseline packs [backbone, mtp_0] along axis 0
+        chunks = paddle.split(base["hidden_states"], 2)
+        _assert_bitwise_equal(
+            self, sep["hidden_states"], chunks[0], "backbone embedding"
+        )
+        _assert_bitwise_equal(
+            self,
+            sep["mtp_decoder_inputs"][0],
+            chunks[1],
+            "shifted MTP embedding",
+        )
+
+    def test_bitwise_equal_to_baseline(self):
+        self._assert_matches_baseline({})
+
+    def test_bitwise_equal_to_baseline_with_cp(self):
+        self._assert_matches_baseline(
+            {"experimental_dataflow": True}, cp_world_size=2
+        )
+
+    def test_bitwise_equal_to_baseline_with_sp(self):
+        self._assert_matches_baseline(
+            {"sequence_parallel": True, "tensor_model_parallel_size": 2}
+        )
+
+
+class TestMTPLayerSeparateForward(unittest.TestCase):
+    """MultiTokenPredictionLayer.forward(): separate_mtp_input branch."""
+
+    B, S, H = 2, 8, 64
+
+    def _dict_args(self, **extra):
+        args = {
+            "hidden_states": paddle.randn([self.B, self.S, self.H]),
+            "mtp_decoder_inputs": paddle.stack(
+                [paddle.randn([self.B, self.S, self.H])]
+            ),
+            "mtp_startend_row_indices_all": paddle.randn(
+                [self.B, 1, self.S, 4]
+            ),
+            "mtp_hidden_inputs_mask_all": paddle.ones([self.B, 1, self.S]),
+            "mtp_input_ids_for_moe_mask": paddle.randint(
+                0, 512, [self.B, 1, self.S]
+            ),
+            "input_ids": paddle.randint(0, 512, [self.B, self.S]),
+            "rotary_pos_emb": paddle.randn([1, self.S + 2, 32]),
+            "rotary_pos_cos": paddle.randn([1, self.S + 2, 32]),
+            "rotary_pos_sin": paddle.randn([1, self.S + 2, 32]),
+            "labels": paddle.randint(0, 100, [self.B, self.S]),
+        }
+        args.update(extra)
+        return args
+
+    def test_forward_output_shape_and_keys(self):
+        layer = _build_mtp_layer(_cfg())
+        with _mtp_forward_ctx():
+            result = layer.forward(self._dict_args())
+        # [backbone | mtp] concatenated on axis 0 for the downstream LM heads
+        self.assertEqual(
+            result["hidden_states"].shape, [2 * self.B, self.S, self.H]
+        )
+        self.assertEqual(set(result.keys()), {"hidden_states", "labels"})
+
+    def test_decoder_input_passed_through_untouched(self):
+        """mtp_decoder_inputs[depth] must reach the MTP block unmodified."""
+        layer = _build_mtp_layer(_cfg())
+        args = self._dict_args()
+        expected = args["mtp_decoder_inputs"][0]
+        captured = {}
+
+        def _capture(**kwargs):
+            captured.update(kwargs)
+            return kwargs["hidden_states"]
+
+        with _mtp_forward_ctx(proj_override=_capture, layer=layer):
+            layer.forward(args)
+
+        self.assertIn("decoder_input", captured)
+        _assert_bitwise_equal(
+            self, captured["decoder_input"], expected, "decoder_input"
+        )
+
+    def test_backbone_hidden_states_preserved_in_output(self):
+        layer = _build_mtp_layer(_cfg())
+        args = self._dict_args()
+        backbone = args["hidden_states"]
+        marker = paddle.full([self.B, self.S, self.H], 7.0)
+
+        with _mtp_forward_ctx(
+            proj_override=lambda **kw: marker, layer=layer
+        ):
+            result = layer.forward(args)
+
+        halves = paddle.split(result["hidden_states"], 2)
+        _assert_bitwise_equal(self, halves[0], backbone, "backbone half")
+        _assert_bitwise_equal(self, halves[1], marker, "mtp half")
+
+    def test_missing_mtp_decoder_inputs_raises(self):
+        layer = _build_mtp_layer(_cfg())
+        args = self._dict_args()
+        args.pop("mtp_decoder_inputs")
+        with (
+            self.assertRaisesRegex(RuntimeError, "mtp_decoder_inputs"),
+            _mtp_forward_ctx(),
+        ):
+            layer.forward(args)
+
+    def test_per_depth_mask_slice_by_experimental_version(self):
+        """The shared branch slices the depth mask differently per dataflow."""
+        for exp_ver, last_dim in ((True, 4), (False, 1)):
+            layer = _build_mtp_layer(
+                _cfg(gpt_model_use_experimental_version=exp_ver)
+            )
+            captured = {}
+
+            def _capture(**kwargs):
+                captured.update(kwargs)
+                return kwargs["hidden_states"]
+
+            with _mtp_forward_ctx(proj_override=_capture, layer=layer):
+                layer.forward(self._dict_args())
+
+            self.assertEqual(
+                captured["attn_mask_startend_row_indices"].shape,
+                [self.B, 1, self.S, last_dim],
+                f"gpt_model_use_experimental_version={exp_ver}",
+            )
+
+
+class TestMTPLayerNoDoubleScatter(unittest.TestCase):
+    """The scatter already happened in GPTEmbedding: never scatter again here.
+
+    ``magic_send`` re-embeds ``input_ids`` at full global length, so it has to
+    slice and then apply the very same CP/SP scatter GPTEmbedding would have
+    applied.  ``separate_mtp_input`` receives tensors that are already CP/SP
+    local, so a second scatter would corrupt the layout.
+    """
+
+    B, S, H = 2, 8, 64
+
+    def _scatter_spies(self):
+        return (
+            MagicMock(side_effect=lambda x, **kw: x),
+            MagicMock(side_effect=lambda x, axis=0, **kw: x),
+        )
+
+    def test_separate_does_not_scatter(self):
+        cfg = _cfg(
+            sequence_parallel=True,
+            tensor_model_parallel_size=2,
+            experimental_dataflow=True,
+        )
+        layer = _build_mtp_layer(cfg)
+        sp_spy, cp_spy = self._scatter_spies()
+        # SP layout: hidden_states / decoder_input are [S_local, B, H]
+        args = {
+            "hidden_states": paddle.randn([self.S, self.B, self.H]),
+            "mtp_decoder_inputs": paddle.stack(
+                [paddle.randn([self.S, self.B, self.H])]
+            ),
+            "labels": paddle.randint(0, 100, [self.B, self.S]),
+        }
+        with _mtp_forward_ctx(
+            cp_world_size=4,
+            scatter_fn=sp_spy,
+            cp_scatter_fn=cp_spy,
+            proj_override=lambda **kw: kw["hidden_states"],
+            layer=layer,
+        ):
+            layer.forward(args)
+
+        sp_spy.assert_not_called()
+        cp_spy.assert_not_called()
+
+    def test_magic_send_does_scatter(self):
+        """Contrast case: guards against a refactor silently breaking magic send."""
+        cfg = _cfg_magic(experimental_dataflow=True)
+        layer = _build_mtp_layer(cfg)
+        sp_spy, cp_spy = self._scatter_spies()
+        args = {
+            "hidden_states": paddle.randn([self.B, self.S, self.H]),
+            "mtp_input_embeds": paddle.randn(
+                [self.B, self.S * 4 + 1, self.H]
+            ),
+            "labels": paddle.randint(0, 100, [self.B, self.S]),
+        }
+        with _mtp_forward_ctx(
+            cp_world_size=4,
+            scatter_fn=sp_spy,
+            cp_scatter_fn=cp_spy,
+            proj_override=lambda **kw: kw["hidden_states"],
+            layer=layer,
+        ):
+            layer.forward(args)
+
+        cp_spy.assert_called_once()
+
+
+class TestTransformerLayerSplitGuard(unittest.TestCase):
+    """Backbone layers must not split hidden_states when separate_mtp_input is on.
+
+    ``TransformerLayer.forward`` has the condition inline, so it is mirrored
+    here; the real code path is covered end to end by
+    ``tests/multi_card_tests/test_separate_mtp_input_cp.py`` (dropping the guard
+    there makes ``paddle.split`` fail on the un-concatenated hidden_states).
+    ``HySparseTransformerLayer`` exposes it as a method, so that one is called
+    for real.
+    """
+
+    def test_split_guard_logic(self):
+        def should_split(cfg, is_mtp=False):
+            return (
+                cfg.num_nextn_predict_layers is not None
+                and cfg.num_nextn_predict_layers > 0
+                and not is_mtp
+                and not cfg.mtp_load_weight_only
+                and not cfg.enable_mtp_magic_send
+                and not cfg.separate_mtp_input
+            )
+
+        self.assertFalse(should_split(_cfg()))
+        self.assertFalse(should_split(_cfg_magic()))
+        self.assertTrue(should_split(_cfg_baseline()))
+        self.assertFalse(should_split(_cfg_baseline(), is_mtp=True))
+
+    def test_hysparse_mtp_enabled(self):
+        from paddlefleet.transformer.transformer_layer import (
+            HySparseTransformerLayer,
+        )
+
+        def mtp_enabled(cfg, is_mtp=False):
+            return HySparseTransformerLayer._mtp_enabled(
+                SimpleNamespace(config=cfg), is_mtp
+            )
+
+        self.assertFalse(mtp_enabled(_cfg()))
+        self.assertFalse(mtp_enabled(_cfg_magic()))
+        self.assertTrue(mtp_enabled(_cfg_baseline()))
+        self.assertFalse(mtp_enabled(_cfg_baseline(), is_mtp=True))
+
+
+class TestHySparseLayerMTPSplit(unittest.TestCase):
+    """``HySparseTransformerLayer`` is the layer class the production DSA config
+    uses, and it is the only one that implements the MTP split/restore as
+    methods (``_mtp_split`` / ``_mtp_restore``) instead of inline in ``forward``.
+    They only touch ``self.config``, so they can be exercised on a bare instance
+    without the FA4/DSA attention backend.
+    """
+
+    B, S, H = 2, 8, 64
+
+    def _layer(self, cfg):
+        from paddlefleet.transformer.transformer_layer import (
+            HySparseTransformerLayer,
+        )
+
+        layer = HySparseTransformerLayer.__new__(HySparseTransformerLayer)
+        layer.config = cfg
+        return layer
+
+    def _dict_args(self, hidden_states):
+        return {
+            "hidden_states": hidden_states,
+            "position_ids": paddle.arange(self.S + 1).reshape([1, -1]),
+            "rotary_pos_emb": paddle.randn([1, self.S + 1, 32]),
+        }
+
+    def test_separate_skips_split(self):
+        layer = self._layer(_cfg())
+        hidden_states = paddle.randn([self.B, self.S, self.H])
+        dict_args = self._dict_args(hidden_states)
+        rotary_before = dict_args["rotary_pos_emb"]
+
+        ctx = layer._mtp_split(dict_args, is_mtp=False)
+
+        self.assertIsNone(ctx, "separate_mtp_input must not split in the layer")
+        _assert_bitwise_equal(
+            self, dict_args["hidden_states"], hidden_states, "hidden_states"
+        )
+        # untouched: no trimming of the auxiliary tensors either
+        self.assertIs(dict_args["rotary_pos_emb"], rotary_before)
+        self.assertEqual(dict_args["position_ids"].shape, [1, self.S + 1])
+
+    def test_baseline_splits_and_restores(self):
+        layer = self._layer(_cfg_baseline())
+        chunks = [
+            paddle.randn([self.B, self.S, self.H]),
+            paddle.randn([self.B, self.S, self.H]),
+        ]
+        dict_args = self._dict_args(paddle.concat(chunks))
+
+        ctx = layer._mtp_split(dict_args, is_mtp=False)
+
+        self.assertIsNotNone(ctx)
+        _assert_bitwise_equal(
+            self, dict_args["hidden_states"], chunks[0], "main chunk"
+        )
+        self.assertEqual(len(ctx["mtp_input"]), 1)
+        _assert_bitwise_equal(
+            self, ctx["mtp_input"][0], chunks[1], "mtp chunk"
+        )
+        self.assertEqual(dict_args["position_ids"].shape, [1, self.S])
+        self.assertEqual(dict_args["rotary_pos_emb"].shape, [1, self.S, 32])
+
+        restored = layer._mtp_restore(dict_args, chunks[0], ctx)
+        self.assertEqual(restored.shape, [2 * self.B, self.S, self.H])
+        _assert_bitwise_equal(
+            self, restored, paddle.concat(chunks), "restored hidden_states"
+        )
+        self.assertEqual(dict_args["position_ids"].shape, [1, self.S + 1])
+        self.assertEqual(dict_args["rotary_pos_emb"].shape, [1, self.S + 1, 32])
+
+    def test_magic_send_also_skips_split(self):
+        layer = self._layer(_cfg_magic())
+        hidden_states = paddle.randn([self.B, self.S, self.H])
+        dict_args = self._dict_args(hidden_states)
+        self.assertIsNone(layer._mtp_split(dict_args, is_mtp=False))
+
+
+class TestWrappedPaddleNormPipeSeparate(unittest.TestCase):
+    """WrappedPaddleNormPipe treats separate_mtp_input like magic send."""
+
+    def _norm_out(self, cfg, hidden_states):
+        from paddlefleet.transformer.paddle_norm import WrappedPaddleNormPipe
+
+        return WrappedPaddleNormPipe(cfg, hidden_size=64).forward(
+            {"hidden_states": hidden_states}
+        )["hidden_states"]
+
+    def test_separate_normalizes_without_split(self):
+        cfg = TransformerConfig(
+            separate_mtp_input=True,
+            num_nextn_predict_layers=1,
+            pipeline_model_parallel_size=1,
+            hidden_size=64,
+            normalization="RMSNorm",
+            tensor_model_parallel_size=1,
+        )
+        out = self._norm_out(cfg, paddle.ones([1, 4, 64]) * 2.0)
+        self.assertTrue(
+            paddle.allclose(out, paddle.ones([1, 4, 64]), atol=1e-5).item()
+        )
+
+    def test_matches_magic_send_behaviour(self):
+        common = dict(
+            num_nextn_predict_layers=1,
+            hidden_size=64,
+            normalization="RMSNorm",
+            tensor_model_parallel_size=1,
+        )
+        hidden_states = paddle.randn([2, 4, 64])
+        sep = self._norm_out(
+            TransformerConfig(
+                separate_mtp_input=True,
+                pipeline_model_parallel_size=1,
+                **common,
+            ),
+            hidden_states,
+        )
+        magic = self._norm_out(
+            TransformerConfig(
+                enable_mtp_magic_send=True,
+                pipeline_model_parallel_size=2,
+                **common,
+            ),
+            hidden_states,
+        )
+        _assert_bitwise_equal(self, sep, magic, "final norm output")
+
+    def test_baseline_still_splits(self):
+        cfg = TransformerConfig(
+            num_nextn_predict_layers=1,
+            hidden_size=64,
+            normalization="RMSNorm",
+            tensor_model_parallel_size=1,
+        )
+        out = self._norm_out(cfg, paddle.randn([4, 8, 64]))
+        self.assertEqual(out.shape, [4, 8, 64])
+
+    def test_experimental_version_splits_and_norms_every_chunk(self):
+        """gpt_model_use_experimental_version flips the guard back to the split
+        path: by then hidden_states is the [backbone | mtp] concat rebuilt by the
+        MTP layer, and the MTP chunk gets normalized too."""
+        from paddlefleet.transformer.paddle_norm import WrappedPaddleNormPipe
+
+        cfg = TransformerConfig(
+            separate_mtp_input=True,
+            num_nextn_predict_layers=1,
+            pipeline_model_parallel_size=1,
+            hidden_size=64,
+            normalization="RMSNorm",
+            tensor_model_parallel_size=1,
+            gpt_model_use_experimental_version=True,
+        )
+        pipe = WrappedPaddleNormPipe(cfg, hidden_size=64)
+        x = paddle.randn([4, 8, 64])  # [backbone | mtp_0] stacked on axis 0
+        expected = [pipe.norm(chunk) for chunk in paddle.split(x, 2)]
+
+        out = pipe.forward({"hidden_states": x.clone()})["hidden_states"]
+        self.assertEqual(out.shape, [4, 8, 64])
+        got = paddle.split(out, 2)
+        _assert_bitwise_equal(self, got[0], expected[0], "backbone chunk norm")
+        _assert_bitwise_equal(self, got[1], expected[1], "mtp chunk norm")
+
+
+class TestHyperConnectionContractSeparate(unittest.TestCase):
+    """mHC contract layer: hidden_states is pure backbone, contract it whole."""
+
+    def _build(self, **kw):
+        from paddlefleet.transformer.hyper_connection import (
+            HyperConnectionContractLayer,
+        )
+
+        return HyperConnectionContractLayer(
+            TransformerConfig(
+                hidden_size=64,
+                num_residual_streams=4,
+                num_nextn_predict_layers=1,
+                tensor_model_parallel_size=1,
+                **kw,
+            )
+        )
+
+    def test_separate_contracts_entire_tensor(self):
+        """The whole tensor is contracted, not just its first 1/(num_mtp+1)."""
+        from paddlefleet.transformer.hyper_connection import (
+            HyperConnectionModule,
+        )
+
+        layer = self._build(
+            separate_mtp_input=True, pipeline_model_parallel_size=1
+        )
+        B, S, H, n = 2, 8, 64, 4
+        x = paddle.randn([B, S, H * n])
+        expected = HyperConnectionModule.learned_output_contract(
+            x,
+            layer.hc_head_fn,
+            layer.hc_head_base,
+            layer.hc_head_scale,
+            n,
+            layer.config.rms_norm_eps,
+        )
+        result = layer.forward({"hidden_states": x.clone()})
+        self.assertEqual(result["hidden_states"].shape, [B, S, H])
+        self.assertEqual(result["mhc_multistream"].shape, [B, S, H * n])
+        self.assertFalse(layer.magic_send)
+        _assert_bitwise_equal(
+            self, result["hidden_states"], expected, "mHC contract output"
+        )
+
+    def test_separate_matches_magic_send(self):
+        B, S, H, n = 2, 8, 64, 4
+        x = paddle.randn([B, S, H * n])
+        sep = self._build(
+            separate_mtp_input=True, pipeline_model_parallel_size=1
+        )
+        magic = self._build(
+            enable_mtp_magic_send=True, pipeline_model_parallel_size=2
+        )
+        magic.hc_head_fn.set_value(sep.hc_head_fn)
+        magic.hc_head_base.set_value(sep.hc_head_base)
+        magic.hc_head_scale.set_value(sep.hc_head_scale)
+
+        out_sep = sep.forward({"hidden_states": x.clone()})["hidden_states"]
+        out_magic = magic.forward({"hidden_states": x.clone()})[
+            "hidden_states"
+        ]
+        _assert_bitwise_equal(self, out_sep, out_magic, "mHC contract output")
+
+    def test_baseline_splits_before_contracting(self):
+        layer = self._build(pipeline_model_parallel_size=1)
+        B, S, H, n = 2, 8, 64, 4
+        result = layer.forward(
+            {"hidden_states": paddle.randn([B * 2, S, H * n])}
+        )
+        self.assertEqual(result["hidden_states"].shape, [B * 2, S, H])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/transformer/test_separate_mtp_input.py
+++ b/tests/single_card_tests/transformer/test_separate_mtp_input.py
@@ -331,9 +331,7 @@ class TestSeparateMTPInputConfig(unittest.TestCase):
 
     def test_rejects_multiple_mtp_layers(self):
         # ValueError, not assert: must survive ``python -O``.
-        with self.assertRaisesRegex(
-            ValueError, "num_nextn_predict_layers=2"
-        ):
+        with self.assertRaisesRegex(ValueError, "num_nextn_predict_layers=2"):
             TransformerConfig(
                 separate_mtp_input=True,
                 num_nextn_predict_layers=2,
@@ -395,9 +393,7 @@ class TestGPTEmbeddingSeparateOutput(unittest.TestCase):
     def test_hidden_states_carries_backbone_only(self):
         main_len = self.S - 1
         out = _run_emb(_cfg(), self._input_ids())
-        self.assertEqual(
-            out["hidden_states"].shape, [self.B, main_len, self.H]
-        )
+        self.assertEqual(out["hidden_states"].shape, [self.B, main_len, self.H])
         self.assertIn("mtp_decoder_inputs", out)
         self.assertEqual(
             out["mtp_decoder_inputs"].shape, [1, self.B, main_len, self.H]
@@ -517,9 +513,7 @@ class TestMTPLayerSeparateForward(unittest.TestCase):
         backbone = args["hidden_states"]
         marker = paddle.full([self.B, self.S, self.H], 7.0)
 
-        with _mtp_forward_ctx(
-            proj_override=lambda **kw: marker, layer=layer
-        ):
+        with _mtp_forward_ctx(proj_override=lambda **kw: marker, layer=layer):
             result = layer.forward(args)
 
         halves = paddle.split(result["hidden_states"], 2)
@@ -610,9 +604,7 @@ class TestMTPLayerNoDoubleScatter(unittest.TestCase):
         sp_spy, cp_spy = self._scatter_spies()
         args = {
             "hidden_states": paddle.randn([self.B, self.S, self.H]),
-            "mtp_input_embeds": paddle.randn(
-                [self.B, self.S * 4 + 1, self.H]
-            ),
+            "mtp_input_embeds": paddle.randn([self.B, self.S * 4 + 1, self.H]),
             "labels": paddle.randint(0, 100, [self.B, self.S]),
         }
         with _mtp_forward_ctx(
@@ -727,9 +719,7 @@ class TestHySparseLayerMTPSplit(unittest.TestCase):
             self, dict_args["hidden_states"], chunks[0], "main chunk"
         )
         self.assertEqual(len(ctx["mtp_input"]), 1)
-        _assert_bitwise_equal(
-            self, ctx["mtp_input"][0], chunks[1], "mtp chunk"
-        )
+        _assert_bitwise_equal(self, ctx["mtp_input"][0], chunks[1], "mtp chunk")
         self.assertEqual(dict_args["position_ids"].shape, [1, self.S])
         self.assertEqual(dict_args["rotary_pos_emb"].shape, [1, self.S, 32])
 
@@ -773,12 +763,12 @@ class TestWrappedPaddleNormPipeSeparate(unittest.TestCase):
         )
 
     def test_matches_magic_send_behaviour(self):
-        common = dict(
-            num_nextn_predict_layers=1,
-            hidden_size=64,
-            normalization="RMSNorm",
-            tensor_model_parallel_size=1,
-        )
+        common = {
+            "num_nextn_predict_layers": 1,
+            "hidden_size": 64,
+            "normalization": "RMSNorm",
+            "tensor_model_parallel_size": 1,
+        }
         hidden_states = paddle.randn([2, 4, 64])
         sep = self._norm_out(
             TransformerConfig(
@@ -893,9 +883,7 @@ class TestHyperConnectionContractSeparate(unittest.TestCase):
         magic.hc_head_scale.set_value(sep.hc_head_scale)
 
         out_sep = sep.forward({"hidden_states": x.clone()})["hidden_states"]
-        out_magic = magic.forward({"hidden_states": x.clone()})[
-            "hidden_states"
-        ]
+        out_magic = magic.forward({"hidden_states": x.clone()})["hidden_states"]
         _assert_bitwise_equal(self, out_sep, out_magic, "mHC contract output")
 
     def test_baseline_splits_before_contracting(self):

--- a/tests/single_card_tests/transformer/test_separate_mtp_input.py
+++ b/tests/single_card_tests/transformer/test_separate_mtp_input.py
@@ -330,8 +330,9 @@ class TestSeparateMTPInputConfig(unittest.TestCase):
         self.assertTrue(cfg.separate_mtp_input)
 
     def test_rejects_multiple_mtp_layers(self):
+        # ValueError, not assert: must survive ``python -O``.
         with self.assertRaisesRegex(
-            AssertionError, "num_nextn_predict_layers=1"
+            ValueError, "num_nextn_predict_layers=2"
         ):
             TransformerConfig(
                 separate_mtp_input=True,
@@ -341,7 +342,7 @@ class TestSeparateMTPInputConfig(unittest.TestCase):
 
     def test_rejects_pipeline_parallel(self):
         with self.assertRaisesRegex(
-            AssertionError, "pipeline_model_parallel_size == 1"
+            ValueError, "pipeline_model_parallel_size=2"
         ):
             TransformerConfig(
                 separate_mtp_input=True,
@@ -350,7 +351,7 @@ class TestSeparateMTPInputConfig(unittest.TestCase):
             )
 
     def test_mutually_exclusive_with_magic_send(self):
-        with self.assertRaisesRegex(AssertionError, "mutually exclusive"):
+        with self.assertRaisesRegex(ValueError, "mutually exclusive"):
             TransformerConfig(
                 separate_mtp_input=True,
                 enable_mtp_magic_send=True,
@@ -359,15 +360,27 @@ class TestSeparateMTPInputConfig(unittest.TestCase):
             )
 
     def test_rejects_mtp_load_weight_only(self):
-        with self.assertRaisesRegex(
-            AssertionError, "mtp_load_weight_only"
-        ):
+        with self.assertRaisesRegex(ValueError, "mtp_load_weight_only=True"):
             TransformerConfig(
                 separate_mtp_input=True,
                 mtp_load_weight_only=True,
                 num_nextn_predict_layers=1,
                 pipeline_model_parallel_size=1,
             )
+
+    def test_validation_survives_python_O(self):
+        """The checks must not be assert-based (stripped by ``python -O``)."""
+        import inspect
+        import textwrap
+
+        source = textwrap.dedent(
+            inspect.getsource(TransformerConfig.__post_init__)
+        )
+        block = source.split("if self.separate_mtp_input:", 1)[1]
+        # stop at the next top-level statement of __post_init__ (4-space indent)
+        block = block.split("\n    if ", 1)[0]
+        self.assertNotIn("assert ", block)
+        self.assertEqual(block.count("raise ValueError"), 4)
 
 
 class TestGPTEmbeddingSeparateOutput(unittest.TestCase):

--- a/tests/test_configs.yaml
+++ b/tests/test_configs.yaml
@@ -176,6 +176,10 @@ tests:
   - test_case: [tests/multi_card_tests/transformer/test_indexer_topk_col_mask_cp.py]
     products:
       - num_gpus: 2
+  # separate_mtp_input: bitwise fwd/bwd equivalence vs concat/split baseline (CP=2)
+  - test_case: [tests/multi_card_tests/test_separate_mtp_input_cp.py]
+    products:
+      - num_gpus: 2
   # default fallback for remaining multi_card_tests
   - test_case: [tests/multi_card_tests/pipeline_parallel/*.py]
     products:


### PR DESCRIPTION
### PR Category
Distributed Strategy

### PR Types
Performance

### Description

Merged in dev: #1795 (same change on `develop`; this PR is the `release/0.4` counterpart and must land after it).

When `pipeline_model_parallel_size == 1`, the shifted MTP embeddings computed by
`GPTEmbedding` are handed to `MultiTokenPredictionLayer` through a dedicated
`mtp_decoder_inputs` entry in `dict_args` instead of being concatenated into
`hidden_states`. Backbone `TransformerLayer`s therefore stop splitting the MTP
chunks off at the start of every layer and concatenating them back at the end.

This is the `pipeline_model_parallel_size == 1` counterpart of
`enable_mtp_magic_send` (which covers PP > 1 by re-embedding `input_ids` on the
last stage). The two are mutually exclusive; `separate_mtp_input` additionally
requires `num_nextn_predict_layers == 1` and is rejected together with
`mtp_load_weight_only`. All four checks raise `ValueError` so that they survive
`python -O`.

Key point for reviewers: `GPTEmbedding`'s shifted-embedding computation,
**including its CP/SP scatter**, is left untouched -- the tensors are only routed
differently. Every entry of `mtp_decoder_inputs` therefore already carries the
same CP/SP layout as `hidden_states`, and the MTP layer must not scatter them
again (unlike the magic-send path, which re-embeds at full global length and has
to slice + scatter itself).

Changes:
- `transformer_config.py`: new `separate_mtp_input` flag + validation.
- `gpt_embedding.py`: publish `mtp_decoder_inputs` instead of concatenating.
- `multi_token_prediction.py`: share the magic-send branch; take
  `mtp_decoder_inputs[depth]` as `decoder_input` with no slicing/scatter.
- `transformer_layer.py`, `paddle_norm.py`, `hyper_connection.py`: skip the
  per-layer MTP split/concat, same as magic send already does.

Performance, 43-layer ernielite config (64 cards, 50 steps, two runs each):
forward-backward 4515.69ms -> 4458.29ms (-1.27%), tokens/s/card 3394.1 ->
3434.7, peak memory unchanged.

Tests added:
- `tests/single_card_tests/transformer/test_separate_mtp_input.py` (31 cases:
  config validation, embedding output, no double scatter under CP/SP,
  `HySparseTransformerLayer._mtp_split/_mtp_restore`, final-norm and mHC guards).
- `tests/multi_card_tests/test_separate_mtp_input_cp.py` (CP=2, both
  `cp_balance_mode`s, with and without mHC).
- `tests/multi_card_tests/tensor_parallel/test_separate_mtp_input_tp_sp.py`
  (TP=4 + sequence parallel, with and without mHC).

Both multi-card tests build two models with identical weights, feed identical
inputs, and assert that the loss and **every parameter gradient** are
bit-identical to the concat/split baseline.

### 是否引起精度变化
否

On the 43-layer config, the 12 logged loss fields (`loss`, `loss_cur_dp`,
`pure_text_loss`, `mtp_1_loss`, `mtp_1_loss_cur_dp`, `indexer_loss`, ...) matched
bit for bit for 10 steps against the baseline under
`FLAGS_embedding_deterministic=1` + `FLAGS_cudnn_deterministic=1`.
