### PR TITLE
[release/0.4][Performance Optimization] Fuse the mHC fp32 casts and the mapping head into the cuTile kernels

### DIFF
--- a/src/paddlefleet/fusions/fused_mhc_kernels.py
+++ b/src/paddlefleet/fusions/fused_mhc_kernels.py
@@ -24,6 +24,7 @@ Four fused operations:
   - h_aggregate:  weighted n-stream -> 1-stream aggregation
   - h_post_bda:   fused H_res @ residual + H_post * (x + bias)
   - proj_rms:     fused projection + RMS normalization
+  - compute_h:    fused r * proj * alpha + bias, plus the two sigmoid heads
 """
 
 import math
@@ -59,6 +60,7 @@ def _get_cuda_stream():
 
 if _CUTILE_AVAILABLE:
     ConstInt = ct.Constant[int]
+    ConstBool = ct.Constant[bool]
     PAD_ZERO = ct.PaddingMode.ZERO
     LOG2E = 1.4426950408889634
     _INT32_MAX = 2**31 - 1
@@ -234,12 +236,276 @@ if _CUTILE_AVAILABLE:
         )
         return grad_input.reshape(original_shape)
 
+    # -- compute_h kernels ---------------------------------------------------
+    #
+    # Column layout of proj / bias / g_proj, all of width P = N*N + 2*N:
+    #
+    #     [ pre : N ][ post : N ][ res : N*N ]
+    #
+    # Everything is addressed in tiles of width N. ``ct.load``/``ct.store``
+    # index in whole tiles: tile 0 is the pre segment, tile 1 the post, and
+    # tiles 2 .. N+1 the res segment (N*N is exactly N of them). Slicing the res
+    # segment out in one piece is not expressible -- a width-N*N tile can only
+    # start at a multiple of N*N, and it starts at 2*N -- which is why the res
+    # work below is an unrolled loop over N sub-tiles rather than one operation.
+    #
+    # On dtypes: alpha and bias arrive in params_dtype and the global default
+    # dtype respectively, i.e. bf16 in bf16 training, while proj and r are fp32
+    # under high_precision_mhc. Nothing below widens them, and nothing needs to:
+    # every expression pairs them with ``r * proj``, which is fp32 already, so
+    # the promotion lifts the whole expression -- the same thing Paddle's
+    # promotion does in ``native_compute_h``.
+    #
+    # The rule, established by mutating every widening in this file and watching
+    # which removals the tests catch: an expression only degrades to the narrow
+    # dtype when *all* of its narrow operands stay narrow. The one place that
+    # happens is ``_ct_proj_rms_fwd_kernel``'s ``a_tile * a_tile``, which is
+    # widened explicitly.
+
+    @ct.kernel
+    def _ct_compute_h_fwd_kernel(
+        proj,
+        r,
+        a_pre,
+        a_post,
+        a_res,
+        bias,
+        h_pre,
+        h_post,
+        h_res,
+        N: ConstInt,
+        TILE_M: ConstInt,
+        eps: float,
+    ):
+        """h = r * proj * alpha + bias, then the two sigmoid heads.
+
+        Replaces ``expand x3 -> concat -> mul -> mul -> add -> sigmoid x2`` with
+        one launch. The alpha vector the reference builds by concatenating three
+        broadcast scalars never materializes: which scalar a column belongs to
+        is a compile-time fact here, so each segment gets its own scalar.
+
+        The sigmoid is ``1 / (1 + exp(-u))`` because cuTile has no sigmoid. That
+        form is bitwise equal to ``paddle.sigmoid`` on fp32 via ``ct.exp`` --
+        but not via ``ct.exp2``, which drifts ~1e-6 relative, so do not rewrite
+        into the exp2 form the softmax above uses.
+        """
+        pid = ct.bid(0)
+        r_tile = ct.load(
+            r, index=(pid, 0), shape=(TILE_M, 1), padding_mode=PAD_ZERO
+        )
+        ap = ct.reshape(ct.load(a_pre, index=(0,), shape=(1,)), (1, 1))
+        aq = ct.reshape(ct.load(a_post, index=(0,), shape=(1,)), (1, 1))
+        ar = ct.reshape(ct.load(a_res, index=(0,), shape=(1,)), (1, 1))
+
+        u_pre = r_tile * ct.load(
+            proj, index=(pid, 0), shape=(TILE_M, N), padding_mode=PAD_ZERO
+        ) * ap + ct.reshape(
+            ct.load(bias, index=(0,), shape=(N,), padding_mode=PAD_ZERO), (1, N)
+        )
+        u_post = r_tile * ct.load(
+            proj, index=(pid, 1), shape=(TILE_M, N), padding_mode=PAD_ZERO
+        ) * aq + ct.reshape(
+            ct.load(bias, index=(1,), shape=(N,), padding_mode=PAD_ZERO), (1, N)
+        )
+
+        s_pre = 1.0 / (1.0 + ct.exp(-u_pre))
+        s_post = 1.0 / (1.0 + ct.exp(-u_post))
+        ct.store(h_pre, index=(pid, 0), tile=(s_pre + eps).astype(h_pre.dtype))
+        ct.store(
+            h_post, index=(pid, 0), tile=(s_post * 2.0).astype(h_post.dtype)
+        )
+
+        for k in range(N):
+            u_k = r_tile * ct.load(
+                proj,
+                index=(pid, 2 + k),
+                shape=(TILE_M, N),
+                padding_mode=PAD_ZERO,
+            ) * ar + ct.reshape(
+                ct.load(
+                    bias, index=(2 + k,), shape=(N,), padding_mode=PAD_ZERO
+                ),
+                (1, N),
+            )
+            ct.store(h_res, index=(pid, k), tile=u_k.astype(h_res.dtype))
+
+    @ct.kernel
+    def _ct_compute_h_bwd_kernel(
+        g_h_pre,
+        g_h_post,
+        g_h_res,
+        proj,
+        r,
+        h_pre,
+        h_post,
+        a_pre,
+        a_post,
+        a_res,
+        g_proj,
+        g_r,
+        ga_part,
+        gb_part,
+        N: ConstInt,
+        TILE_M: ConstInt,
+        eps: float,
+    ):
+        """Backward of ``_ct_compute_h_fwd_kernel``.
+
+        ``g_proj`` and ``g_r`` are per-token and final here. The alpha and bias
+        gradients reduce over every token, which one block cannot finish: each
+        block writes its own partial into ``ga_part``/``gb_part`` and the
+        launcher sums those. That costs ``num_blocks * (3 + P)`` elements and is
+        deterministic, unlike an atomic accumulation.
+
+        The sigmoid derivatives come from the forward outputs
+        (``s_pre = h_pre - eps``, ``s_post = h_post / 2``) rather than from a
+        recomputed ``u``, which would need the bias and another pass over proj.
+
+        Multiplication order follows the chain rule the reference's autograd
+        actually walks -- ``t = r*proj``, ``u = t*alpha``, ``h = u+bias`` -- so
+        ``d(proj) = (du*alpha)*r`` and ``d(alpha) = du*(r*proj)``, not the
+        left-to-right grouping. Float multiplication is commutative but not
+        associative, and the wrong grouping costs a ULP for no reason.
+        """
+        pid = ct.bid(0)
+        r_tile = ct.load(
+            r, index=(pid, 0), shape=(TILE_M, 1), padding_mode=PAD_ZERO
+        )
+        ap = ct.reshape(ct.load(a_pre, index=(0,), shape=(1,)), (1, 1))
+        aq = ct.reshape(ct.load(a_post, index=(0,), shape=(1,)), (1, 1))
+        ar = ct.reshape(ct.load(a_res, index=(0,), shape=(1,)), (1, 1))
+
+        # du = dL/d(r * proj * alpha + bias), one segment at a time
+        s_pre = (
+            ct.load(
+                h_pre, index=(pid, 0), shape=(TILE_M, N), padding_mode=PAD_ZERO
+            )
+            - eps
+        )
+        du_pre = (
+            ct.load(
+                g_h_pre,
+                index=(pid, 0),
+                shape=(TILE_M, N),
+                padding_mode=PAD_ZERO,
+            )
+            * s_pre
+            * (1.0 - s_pre)
+        )
+        s_post = (
+            ct.load(
+                h_post, index=(pid, 0), shape=(TILE_M, N), padding_mode=PAD_ZERO
+            )
+            / 2.0
+        )
+        du_post = (
+            ct.load(
+                g_h_post,
+                index=(pid, 0),
+                shape=(TILE_M, N),
+                padding_mode=PAD_ZERO,
+            )
+            * 2.0
+            * s_post
+            * (1.0 - s_post)
+        )
+
+        p_pre = ct.load(
+            proj, index=(pid, 0), shape=(TILE_M, N), padding_mode=PAD_ZERO
+        )
+        p_post = ct.load(
+            proj, index=(pid, 1), shape=(TILE_M, N), padding_mode=PAD_ZERO
+        )
+
+        # d(proj) = du * r * alpha ; d(bias) = du summed over tokens
+        ct.store(
+            g_proj,
+            index=(pid, 0),
+            tile=(du_pre * ap * r_tile).astype(g_proj.dtype),
+        )
+        ct.store(
+            g_proj,
+            index=(pid, 1),
+            tile=(du_post * aq * r_tile).astype(g_proj.dtype),
+        )
+        ct.store(
+            gb_part,
+            index=(pid, 0),
+            tile=ct.sum(du_pre, axis=0, keepdims=True).astype(gb_part.dtype),
+        )
+        ct.store(
+            gb_part,
+            index=(pid, 1),
+            tile=ct.sum(du_post, axis=0, keepdims=True).astype(gb_part.dtype),
+        )
+
+        # d(r) sums over every column; d(alpha) over every column and token
+        dr = ct.sum(du_pre * ap * p_pre, axis=1, keepdims=True) + ct.sum(
+            du_post * aq * p_post, axis=1, keepdims=True
+        )
+        da_pre = ct.sum(
+            ct.sum(du_pre * (r_tile * p_pre), axis=1, keepdims=True),
+            axis=0,
+            keepdims=True,
+        )
+        da_post = ct.sum(
+            ct.sum(du_post * (r_tile * p_post), axis=1, keepdims=True),
+            axis=0,
+            keepdims=True,
+        )
+        da_res = ct.full((1, 1), 0.0, dtype=ct.float32)
+        for k in range(N):
+            du_k = ct.load(
+                g_h_res,
+                index=(pid, k),
+                shape=(TILE_M, N),
+                padding_mode=PAD_ZERO,
+            )
+            p_k = ct.load(
+                proj,
+                index=(pid, 2 + k),
+                shape=(TILE_M, N),
+                padding_mode=PAD_ZERO,
+            )
+            ct.store(
+                g_proj,
+                index=(pid, 2 + k),
+                tile=(du_k * ar * r_tile).astype(g_proj.dtype),
+            )
+            ct.store(
+                gb_part,
+                index=(pid, 2 + k),
+                tile=ct.sum(du_k, axis=0, keepdims=True).astype(gb_part.dtype),
+            )
+            dr = dr + ct.sum(du_k * ar * p_k, axis=1, keepdims=True)
+            da_res = da_res + ct.sum(
+                ct.sum(du_k * (r_tile * p_k), axis=1, keepdims=True),
+                axis=0,
+                keepdims=True,
+            )
+        ct.store(g_r, index=(pid, 0), tile=dr.astype(g_r.dtype))
+        ct.store(ga_part, index=(pid, 0), tile=da_pre.astype(ga_part.dtype))
+        ct.store(ga_part, index=(pid, 1), tile=da_post.astype(ga_part.dtype))
+        ct.store(ga_part, index=(pid, 2), tile=da_res.astype(ga_part.dtype))
+
     # -- H_aggregate kernels -------------------------------------------------
 
     @ct.kernel
     def _ct_h_agg_fwd_kernel(
-        x, h_pre, out, N: ConstInt, TILE_M: ConstInt, TILE_C: ConstInt
+        x,
+        h_pre,
+        out,
+        N: ConstInt,
+        TILE_M: ConstInt,
+        TILE_C: ConstInt,
+        UPCAST_INPUTS: ConstBool,
     ):
+        """n-stream -> 1-stream weighted aggregation.
+
+        ``UPCAST_INPUTS`` widens ``x`` in-register when it arrives narrower than
+        ``h_pre``; without it the product and its reduction over ``N`` would run
+        in the narrow dtype.
+        """
         pid = ct.bid(0)
         num_tiles = ct.num_tiles(x, axis=2, shape=(TILE_M, N, TILE_C))
         h_tile = ct.load(
@@ -253,13 +519,28 @@ if _CUTILE_AVAILABLE:
                 shape=(TILE_M, N, TILE_C),
                 padding_mode=PAD_ZERO,
             )
+            if UPCAST_INPUTS:
+                x_tile = x_tile.astype(ct.float32)
             acc = ct.sum(x_tile * h_tile, axis=1).astype(ct.float32)
             ct.store(out, index=(pid, j), tile=acc.astype(out.dtype))
 
     @ct.kernel
     def _ct_h_agg_bwd_kernel(
-        go, x, h_pre, gx, gh, N: ConstInt, TILE_M: ConstInt, TILE_C: ConstInt
+        go,
+        x,
+        h_pre,
+        gx,
+        gh,
+        N: ConstInt,
+        TILE_M: ConstInt,
+        TILE_C: ConstInt,
+        UPCAST_INPUTS: ConstBool,
     ):
+        """Backward of ``_ct_h_agg_fwd_kernel``.
+
+        ``UPCAST_INPUTS`` widens ``x`` before the ``gh`` reduction. ``gx`` does
+        not involve ``x`` at all, so it is unaffected.
+        """
         pid = ct.bid(0)
         num_c_tiles = ct.num_tiles(go, axis=1, shape=(TILE_M, TILE_C))
         h_tile = ct.load(
@@ -274,6 +555,12 @@ if _CUTILE_AVAILABLE:
                 shape=(TILE_M, TILE_C),
                 padding_mode=PAD_ZERO,
             )
+            if UPCAST_INPUTS:
+                # ``go`` is the gradient of ``aggregated``, which the fusion
+                # narrows too, so it needs widening as well -- otherwise both
+                # products below would fall back to cuTile's implicit promotion
+                # instead of the fp32 arithmetic the un-fused path did.
+                go_tile = go_tile.astype(ct.float32)
             go_expanded = ct.expand_dims(go_tile, axis=1)
             x_tile = ct.load(
                 x,
@@ -281,16 +568,124 @@ if _CUTILE_AVAILABLE:
                 shape=(TILE_M, N, TILE_C),
                 padding_mode=PAD_ZERO,
             )
+            if UPCAST_INPUTS:
+                x_tile = x_tile.astype(ct.float32)
             gx_tile = go_expanded * h_expanded
             ct.store(gx, index=(pid, 0, ct_idx), tile=gx_tile.astype(gx.dtype))
             gh_acc += ct.sum(go_expanded * x_tile, axis=2)
         ct.store(gh, index=(pid, 0), tile=gh_acc.astype(gh.dtype))
 
-    def _cutile_h_aggregate_fwd(x: Tensor, h_pre: Tensor) -> Tensor:
+    def _cutile_compute_h_fwd(
+        proj: Tensor,
+        r: Tensor,
+        alpha_pre: Tensor,
+        alpha_post: Tensor,
+        alpha_res: Tensor,
+        bias: Tensor,
+        n: int,
+        eps: float,
+    ) -> tuple[Tensor, Tensor, Tensor]:
+        leading = list(proj.shape[:-1])
+        P = proj.shape[-1]
+        M = math.prod(leading)
+        TILE_M = 64
+        dt = proj.dtype
+        h_pre = paddle.empty(shape=[M, n], dtype=dt)
+        h_post = paddle.empty(shape=[M, n], dtype=dt)
+        h_res = paddle.empty(shape=[M, n * n], dtype=dt)
+        ct.launch(
+            _get_cuda_stream(),
+            (math.ceil(M / TILE_M),),
+            _ct_compute_h_fwd_kernel,
+            (
+                proj.detach().reshape([M, P]),
+                r.detach().reshape([M, 1]),
+                alpha_pre.detach(),
+                alpha_post.detach(),
+                alpha_res.detach(),
+                bias.detach(),
+                h_pre,
+                h_post,
+                h_res,
+                n,
+                TILE_M,
+                eps,
+            ),
+        )
+        return (
+            h_pre.reshape([*leading, n]),
+            h_post.reshape([*leading, n]),
+            h_res.reshape([*leading, n * n]),
+        )
+
+    def _cutile_compute_h_bwd(
+        g_h_pre: Tensor,
+        g_h_post: Tensor,
+        g_h_res: Tensor,
+        proj: Tensor,
+        r: Tensor,
+        h_pre: Tensor,
+        h_post: Tensor,
+        alpha_pre: Tensor,
+        alpha_post: Tensor,
+        alpha_res: Tensor,
+        bias: Tensor,
+        n: int,
+        eps: float,
+    ):
+        leading = list(proj.shape[:-1])
+        P = proj.shape[-1]
+        M = math.prod(leading)
+        TILE_M = 64
+        blocks = math.ceil(M / TILE_M)
+        g_proj = paddle.empty(shape=[M, P], dtype=proj.dtype)
+        g_r = paddle.empty(shape=[M, 1], dtype=r.dtype)
+        # One partial row per block; the cross-token sums finish below in fp32.
+        ga_part = paddle.empty(shape=[blocks, 3], dtype="float32")
+        gb_part = paddle.empty(shape=[blocks, P], dtype="float32")
+        ct.launch(
+            _get_cuda_stream(),
+            (blocks,),
+            _ct_compute_h_bwd_kernel,
+            (
+                g_h_pre.detach().reshape([M, n]),
+                g_h_post.detach().reshape([M, n]),
+                g_h_res.detach().reshape([M, n * n]),
+                proj.detach().reshape([M, P]),
+                r.detach().reshape([M, 1]),
+                h_pre.detach().reshape([M, n]),
+                h_post.detach().reshape([M, n]),
+                alpha_pre.detach(),
+                alpha_post.detach(),
+                alpha_res.detach(),
+                g_proj,
+                g_r,
+                ga_part,
+                gb_part,
+                n,
+                TILE_M,
+                eps,
+            ),
+        )
+        g_alpha = ga_part.sum(axis=0)
+        return (
+            g_proj.reshape([*leading, P]),
+            g_r.reshape([*leading, 1]),
+            g_alpha[0:1].astype(alpha_pre.dtype),
+            g_alpha[1:2].astype(alpha_post.dtype),
+            g_alpha[2:3].astype(alpha_res.dtype),
+            gb_part.sum(axis=0).astype(bias.dtype),
+        )
+
+    def _cutile_h_aggregate_fwd(
+        x: Tensor, h_pre: Tensor, fuse_cast: bool = False
+    ) -> Tensor:
         s, b, n, C = x.shape
         sb = s * b
         TILE_SIZE = math.gcd(sb, 4)
         TILE_C = math.gcd(C, 1024)
+        # ``out`` follows x either way: under fuse_cast x is already the dtype
+        # the downstream layernorm wants, so no override is needed.
         out = paddle.empty(shape=[sb, C], dtype=x.dtype)
         ct.launch(
             _get_cuda_stream(),
@@ -303,12 +698,16 @@ if _CUTILE_AVAILABLE:
                 n,
                 TILE_SIZE,
                 TILE_C,
+                fuse_cast,
             ),
         )
         return out.reshape([s, b, C])
 
     def _cutile_h_aggregate_bwd(
-        grad_output: Tensor, x: Tensor, h_pre: Tensor
+        grad_output: Tensor,
+        x: Tensor,
+        h_pre: Tensor,
+        fuse_cast: bool = False,
     ) -> tuple[Tensor, Tensor]:
         s, b, n, C = x.shape
         sb = s * b
@@ -316,7 +715,11 @@ if _CUTILE_AVAILABLE:
         TILE_C = min(C, 4096) if C <= 4096 else math.gcd(C, 1024)
         TILE_M = math.gcd(sb, 2)
         gx = paddle.empty(shape=[sb, n, C], dtype=x.dtype)
-        gh = paddle.empty(shape=[sb, n], dtype=x.dtype)
+        # gh is the gradient of h_pre, which stays fp32 under fuse_cast even
+        # though x does not, so it cannot follow x's dtype there.
+        gh = paddle.empty(
+            shape=[sb, n], dtype=h_pre.dtype if fuse_cast else x.dtype
+        )
         ct.launch(
             _get_cuda_stream(),
             (math.ceil(sb / TILE_M),),
@@ -330,6 +733,7 @@ if _CUTILE_AVAILABLE:
                 n,
                 TILE_M,
                 TILE_C,
+                fuse_cast,
             ),
         )
         return gx.reshape([s, b, n, C]), gh.reshape([s, b, n])
@@ -338,8 +742,25 @@ if _CUTILE_AVAILABLE:
 
     @ct.kernel
     def _ct_hpb_fwd_kernel(
-        hr, orig, hp, x, out, N: ConstInt, TILE_C: ConstInt, TILE_SIZE: ConstInt
+        hr,
+        orig,
+        hp,
+        x,
+        out,
+        N: ConstInt,
+        TILE_C: ConstInt,
+        TILE_SIZE: ConstInt,
+        UPCAST_INPUTS: ConstBool,
     ):
+        """Fused H_res @ residual + H_post * x.
+
+        ``UPCAST_INPUTS`` is a compile-time constant: set it when ``orig``/``x``
+        arrive narrower than the fp32 the arithmetic below runs in, so they
+        get widened in-register instead of the caller materializing fp32
+        copies. When false the guard folds away and this is the original
+        kernel, including its bf16-in/bf16-out behaviour -- ``TestConstGuard``
+        pins that down.
+        """
         pid = ct.bid(0)
         num_c_tiles = ct.num_tiles(x, axis=1, shape=(TILE_SIZE, TILE_C))
         hp_tile = ct.load(
@@ -365,6 +786,9 @@ if _CUTILE_AVAILABLE:
                 shape=(TILE_SIZE, TILE_C),
                 padding_mode=PAD_ZERO,
             )
+            if UPCAST_INPUTS:
+                orig_tile = orig_tile.astype(ct.float32)
+                x_tile = x_tile.astype(ct.float32)
             x_exp = ct.expand_dims(x_tile, axis=1)  # (TILE_SIZE, 1, TILE_C)
             out_tile = hp_exp * x_exp  # (TILE_SIZE, N, TILE_C)
             for j in range(N):
@@ -390,6 +814,12 @@ if _CUTILE_AVAILABLE:
         TILE_C: ConstInt,
         TILE_SIZE: ConstInt,
     ):
+        """As ``_ct_hpb_fwd_kernel``, plus ``+ bias`` on the layer output.
+
+        No ``UPCAST_INPUTS``: the fusion is vetoed whenever a bias is present,
+        see ``_cutile_h_post_bda_bwd`` for why, so this kernel only ever sees
+        pre-widened operands.
+        """
         pid = ct.bid(0)
         num_c_tiles = ct.num_tiles(x, axis=1, shape=(TILE_SIZE, TILE_C))
         hp_tile = ct.load(
@@ -447,7 +877,18 @@ if _CUTILE_AVAILABLE:
         N: ConstInt,
         TILE_C: ConstInt,
         TILE_SIZE: ConstInt,
+        UPCAST_INPUTS: ConstBool,
     ):
+        """Backward of ``_ct_hpb_fwd_kernel``.
+
+        ``UPCAST_INPUTS`` widens ``go``/``x``/``orig`` in-register, same
+        contract as the forward. Note this is where the fused path stops being
+        bit-identical to the un-fused one: narrowing those three halves the tile
+        footprint, so cuTile schedules the two ``ct.sum`` reductions differently
+        and the fp32 additions group differently. Only ``g_hp``/``g_hr`` are
+        affected -- they are the ones reduced over ``TILE_C``. The summands are
+        unchanged, so this is a reassociation, not a precision loss.
+        """
         pid = ct.bid(0)
         num_c_tiles = ct.cdiv(go.shape[2], TILE_C)
         hp_tile = ct.load(hp, index=(pid, 0), shape=(TILE_SIZE, N))
@@ -468,6 +909,8 @@ if _CUTILE_AVAILABLE:
                 shape=(TILE_SIZE, TILE_C),
                 padding_mode=PAD_ZERO,
             )
+            if UPCAST_INPUTS:
+                x_tile = x_tile.astype(ct.float32)
             x_2d = ct.reshape(x_tile, (1, TILE_C))
             go_tile = ct.load(
                 go,
@@ -475,6 +918,8 @@ if _CUTILE_AVAILABLE:
                 shape=(TILE_SIZE, N, TILE_C),
                 padding_mode=PAD_ZERO,
             )
+            if UPCAST_INPUTS:
+                go_tile = go_tile.astype(ct.float32)
             go_2d = ct.reshape(go_tile, (N, TILE_C))
             orig_tile = ct.load(
                 orig,
@@ -482,6 +927,8 @@ if _CUTILE_AVAILABLE:
                 shape=(TILE_SIZE, N, TILE_C),
                 padding_mode=PAD_ZERO,
             )
+            if UPCAST_INPUTS:
+                orig_tile = orig_tile.astype(ct.float32)
             orig_2d = ct.reshape(orig_tile, (N, TILE_C))
             g_x_2d = ct.full((1, TILE_C), 0, dtype=hp.dtype)
             g_orig_2d = ct.full((N, TILE_C), 0, dtype=hp.dtype)
@@ -536,6 +983,10 @@ if _CUTILE_AVAILABLE:
         TILE_C: ConstInt,
         TILE_SIZE: ConstInt,
     ):
+        """As ``_ct_hpb_bwd_kernel``, plus the ``bias`` gradient path.
+
+        No ``UPCAST_INPUTS`` -- see ``_cutile_h_post_bda_bwd``.
+        """
         pid = ct.bid(0)
         num_c_tiles = ct.cdiv(go.shape[2], TILE_C)
         hp_tile = ct.load(hp, index=(pid, 0), shape=(TILE_SIZE, N))
@@ -619,6 +1070,7 @@ if _CUTILE_AVAILABLE:
         h_post: Tensor,
         x: Tensor,
         bias: Tensor | None,
+        fuse_cast: bool = False,
     ) -> Tensor:
         s, b, n, C = original_residual.shape
         sb = s * b
@@ -632,7 +1084,24 @@ if _CUTILE_AVAILABLE:
             else math.gcd(C, 1024)
         )
         TILE_SIZE = math.gcd(sb, 1)
-        out = paddle.empty(shape=[sb, n, C], dtype=h_res.dtype)
+        # ``fuse_cast`` means the caller skipped the fp32 widening it would
+        # otherwise have done, so the kernel widens in-register and the result
+        # comes back in the residual dtype. This cannot be sniffed
+        # from dtypes -- h_res is fp32 either way -- so the caller states it.
+        # UPCAST_INPUTS is a compile-time constant: fuse_cast=False compiles
+        # to exactly the pre-fusion kernel.
+        #
+        # Declined when a bias is present: ``g_bias`` is computed outside the
+        # kernel as ``g_x.sum(axis=0)``, i.e. a [sb, C] -> [C] reduction with no
+        # fp32 accumulator of its own. A narrow g_x would therefore be summed in
+        # bf16 and lose ~5e-3 relative, which is real precision loss rather than
+        # the ULP-scale reassociation the other gradients see. Fixing it means
+        # accumulating g_bias in-kernel from the un-rounded registers, but the
+        # grid is one block per token so that needs a deterministic cross-block
+        # reduction -- worth revisiting only for a bias-carrying config.
+        fuse_cast = fuse_cast and bias is None
+        out_dtype = original_residual.dtype if fuse_cast else h_res.dtype
+        out = paddle.empty(shape=[sb, n, C], dtype=out_dtype)
         grid = (math.ceil(sb / TILE_SIZE),)
         if bias is not None:
             ct.launch(
@@ -665,6 +1134,7 @@ if _CUTILE_AVAILABLE:
                     n,
                     TILE_C,
                     TILE_SIZE,
+                    fuse_cast,
                 ),
             )
         return out.reshape([s, b, n, C])
@@ -676,16 +1146,27 @@ if _CUTILE_AVAILABLE:
         h_post: Tensor,
         x: Tensor,
         bias: Tensor | None,
+        fuse_cast: bool = False,
     ) -> tuple[Tensor, Tensor, Tensor, Tensor, Tensor | None]:
         s, b, n, C = original_residual.shape
         sb = s * b
         # Optimized: use 2048 when possible (fastest for bwd), fall back to gcd for non-power-of-2 C
         TILE_C = math.gcd(C, 2048) if C % 2048 == 0 else math.gcd(C, 1024)
         TILE_SIZE = math.gcd(sb, 1)
+        # Under ``fuse_cast`` residual/x arrived narrow, so their grads must
+        # come back narrow too: returning fp32 would only make Paddle insert
+        # the cast this path exists to remove. h_res/h_post stay fp32. Same
+        # bias veto as the forward -- g_bias reduces over g_x.
+        fuse_cast = fuse_cast and bias is None
         g_hr = paddle.empty(shape=[sb, n, n], dtype=h_res.dtype)
-        g_res = paddle.empty(shape=[sb, n, C], dtype=h_res.dtype)
+        g_res = paddle.empty(
+            shape=[sb, n, C],
+            dtype=original_residual.dtype if fuse_cast else h_res.dtype,
+        )
         g_hp = paddle.empty(shape=[sb, n], dtype=h_res.dtype)
-        g_x = paddle.empty(shape=[sb, C], dtype=h_res.dtype)
+        g_x = paddle.empty(
+            shape=[sb, C], dtype=x.dtype if fuse_cast else h_res.dtype
+        )
         grid = (sb,)
         if bias is not None:
             ct.launch(
@@ -726,6 +1207,7 @@ if _CUTILE_AVAILABLE:
                     n,
                     TILE_C,
                     TILE_SIZE,
+                    fuse_cast,
                 ),
             )
         g_bias = g_x.sum(axis=0) if bias is not None else None
@@ -761,7 +1243,16 @@ if _CUTILE_AVAILABLE:
         TILE_M: ConstInt,
         TILE_N: ConstInt,
         TILE_K: ConstInt,
+        UPCAST_INPUTS: ConstBool,
     ):
+        """Fused projection + RMS norm.
+
+        ``UPCAST_INPUTS`` widens ``A`` in-register when it arrives narrower than
+        the fp32 the norm reduction runs in. The ``ct.mma`` below is unaffected
+        either way -- it truncates both operands to tfloat32, and a bf16-valued
+        tile survives that exactly -- but ``sum_sq`` would otherwise square and
+        accumulate in the narrow dtype and lose real precision.
+        """
         tile_m_id = ct.bid(0)
         num_k_tiles = ct.cdiv(K, TILE_K)
         acc = ct.full((TILE_M, TILE_N), 0.0, dtype=ct.float32)
@@ -779,6 +1270,8 @@ if _CUTILE_AVAILABLE:
                 shape=(TILE_N, TILE_K),
                 padding_mode=PAD_ZERO,
             )
+            if UPCAST_INPUTS:
+                a_tile = a_tile.astype(ct.float32)
             acc = ct.mma(
                 a_tile.astype(ct.tfloat32),
                 b_tile.transpose().astype(ct.tfloat32),
@@ -808,7 +1301,14 @@ if _CUTILE_AVAILABLE:
         TILE_SIZE_M: ConstInt,
         TILE_SIZE_N: ConstInt,
         TILE_SIZE_K: ConstInt,
+        UPCAST_INPUTS: ConstBool,
     ):
+        """Backward of ``_ct_proj_rms_fwd_kernel`` for the large-K path.
+
+        ``UPCAST_INPUTS`` widens ``A`` before ``_ct_rms_dnorm``; the mma below
+        truncates to tfloat32 regardless. ``_ct_proj_rms_bwd_small_k_kernel``
+        needs no such flag -- it already widens unconditionally.
+        """
         zero_pad = ct.PaddingMode.ZERO
         tile_k_id = ct.bid(0)
         NUM_M_TILES = ct.cdiv(M, TILE_SIZE_M)
@@ -837,6 +1337,8 @@ if _CUTILE_AVAILABLE:
                 shape=(TILE_SIZE_M, 1),
                 padding_mode=zero_pad,
             )
+            if UPCAST_INPUTS:
+                a_tile = a_tile.astype(ct.float32)
             accumulator_da = accumulator_da + _ct_rms_dnorm(
                 a_tile, norm_tile, dr_tile, K, eps
             )
@@ -988,7 +1490,7 @@ if _CUTILE_AVAILABLE:
         return n
 
     def _cutile_proj_rms_fwd(
-        x: Tensor, weight: Tensor, eps: float = 1e-8
+        x: Tensor, weight: Tensor, eps: float = 1e-8, fuse_cast: bool = False
     ) -> tuple[Tensor, Tensor, Tensor]:
         M, K = x.shape
         N = weight.shape[0]
@@ -997,9 +1499,14 @@ if _CUTILE_AVAILABLE:
         TILE_N = _next_power_of_2(N)
         TILE_K = 128
         num_tiles_m = math.ceil(M / TILE_M)
-        proj = paddle.empty(shape=[M, N], dtype=x.dtype)
-        norm = paddle.empty(shape=[M, 1], dtype=x.dtype)
-        r = paddle.empty(shape=[M, 1], dtype=x.dtype)
+        # Under fuse_cast x is narrow but the three outputs must stay fp32: proj
+        # and r feed _compute_h, and narrowing them there would drag h_res /
+        # h_post down with them, i.e. silently undo high_precision_mhc. norm is
+        # kept for backward and consumed at fp32 by _ct_rms_dnorm.
+        out_dtype = "float32" if fuse_cast else x.dtype
+        proj = paddle.empty(shape=[M, N], dtype=out_dtype)
+        norm = paddle.empty(shape=[M, 1], dtype=out_dtype)
+        r = paddle.empty(shape=[M, 1], dtype=out_dtype)
         ct.launch(
             _get_cuda_stream(),
             (num_tiles_m,),
@@ -1017,6 +1524,7 @@ if _CUTILE_AVAILABLE:
                 TILE_M,
                 TILE_N,
                 TILE_K,
+                fuse_cast,
             ),
         )
         return proj, norm, r
@@ -1028,6 +1536,7 @@ if _CUTILE_AVAILABLE:
         weight: Tensor,
         norm: Tensor,
         eps: float = 1e-8,
+        fuse_cast: bool = False,
     ) -> tuple[Tensor, Tensor]:
         M, K = x.shape
         N = weight.shape[0]
@@ -1061,6 +1570,7 @@ if _CUTILE_AVAILABLE:
                     TILE_SIZE_M,
                     TILE_SIZE_N,
                     TILE_SIZE_K,
+                    fuse_cast,
                 ),
             )
         else:
@@ -1104,6 +1614,7 @@ if not _CUTILE_AVAILABLE:
     fused_h_aggregate = _no_cutile_error
     fused_h_post_bda = _no_cutile_error
     fused_proj_rms = _no_cutile_error
+    fused_compute_h = _no_cutile_error
 
 else:
 
@@ -1148,6 +1659,76 @@ else:
             )
             return grad_input
 
+    class FusedComputeH(paddle.autograd.PyLayer):
+        """Fused ``h = r * proj * alpha + bias`` plus the two sigmoid heads.
+
+        See ``FusedSinkhornKnopp`` for why the ``stop_gradient`` flags are
+        recorded in forward and honored in backward: the mHC parameters are
+        frozen under ``train_indexer_only``, and Paddle demands ``None`` at
+        every position whose forward input was detached.
+        """
+
+        @staticmethod
+        def forward(
+            ctx,
+            proj: Tensor,
+            r: Tensor,
+            alpha_pre: Tensor,
+            alpha_post: Tensor,
+            alpha_res: Tensor,
+            bias: Tensor,
+            n: int,
+            eps: float,
+        ):
+            h_pre, h_post, h_res = _cutile_compute_h_fwd(
+                proj, r, alpha_pre, alpha_post, alpha_res, bias, n, eps
+            )
+            ctx.save_for_backward(
+                proj, r, h_pre, h_post, alpha_pre, alpha_post, alpha_res, bias
+            )
+            ctx.n = n
+            ctx.eps = eps
+            ctx.stop = (
+                proj.stop_gradient,
+                r.stop_gradient,
+                alpha_pre.stop_gradient,
+                alpha_post.stop_gradient,
+                alpha_res.stop_gradient,
+                bias.stop_gradient,
+            )
+            return h_pre, h_post, h_res
+
+        @staticmethod
+        def backward(ctx, g_h_pre, g_h_post, g_h_res):
+            (
+                proj,
+                r,
+                h_pre,
+                h_post,
+                alpha_pre,
+                alpha_post,
+                alpha_res,
+                bias,
+            ) = ctx.saved_tensor()
+            grads = _cutile_compute_h_bwd(
+                g_h_pre,
+                g_h_post,
+                g_h_res,
+                proj,
+                r,
+                h_pre,
+                h_post,
+                alpha_pre,
+                alpha_post,
+                alpha_res,
+                bias,
+                ctx.n,
+                ctx.eps,
+            )
+            return tuple(
+                None if frozen else g for g, frozen in zip(grads, ctx.stop)
+            )
+
     class FusedHAggregate(paddle.autograd.PyLayer):
         """Fused n-stream weighted aggregation (cuTile).
 
@@ -1156,19 +1737,22 @@ else:
         """
 
         @staticmethod
-        def forward(ctx, x: Tensor, h_pre: Tensor):
+        def forward(ctx, x: Tensor, h_pre: Tensor, fuse_cast: bool = False):
             """cuTile fused h_aggregate forward."""
-            output = _cutile_h_aggregate_fwd(x, h_pre)
+            output = _cutile_h_aggregate_fwd(x, h_pre, fuse_cast)
             ctx.save_for_backward(x, h_pre)
             ctx.x_stop_gradient = x.stop_gradient
             ctx.h_pre_stop_gradient = h_pre.stop_gradient
+            ctx.fuse_cast = fuse_cast
             return output
 
         @staticmethod
         def backward(ctx, grad_output):
             """cuTile fused h_aggregate backward."""
             x, h_pre = ctx.saved_tensor()
-            g_x, g_h_pre = _cutile_h_aggregate_bwd(grad_output, x, h_pre)
+            g_x, g_h_pre = _cutile_h_aggregate_bwd(
+                grad_output, x, h_pre, ctx.fuse_cast
+            )
             if ctx.x_stop_gradient:
                 g_x = None
             if ctx.h_pre_stop_gradient:
@@ -1190,10 +1774,11 @@ else:
             h_post: Tensor,
             x: Tensor,
             bias: Tensor | None,
+            fuse_cast: bool = False,
         ):
             """cuTile fused h_post_bda forward."""
             output = _cutile_h_post_bda_fwd(
-                h_res, original_residual, h_post, x, bias
+                h_res, original_residual, h_post, x, bias, fuse_cast
             )
             if bias is not None:
                 ctx.save_for_backward(h_res, original_residual, h_post, x, bias)
@@ -1201,6 +1786,7 @@ else:
             else:
                 ctx.save_for_backward(h_res, original_residual, h_post, x)
                 ctx.has_bias = False
+            ctx.fuse_cast = fuse_cast
             ctx.h_res_stop_gradient = h_res.stop_gradient
             ctx.original_residual_stop_gradient = (
                 original_residual.stop_gradient
@@ -1218,12 +1804,12 @@ else:
             if ctx.has_bias:
                 h_res, orig_res, h_post, x, bias = ctx.saved_tensor()
                 g_hr, g_res, g_hp, g_x, g_bias = _cutile_h_post_bda_bwd(
-                    grad_output, h_res, orig_res, h_post, x, bias
+                    grad_output, h_res, orig_res, h_post, x, bias, ctx.fuse_cast
                 )
             else:
                 h_res, orig_res, h_post, x = ctx.saved_tensor()
                 g_hr, g_res, g_hp, g_x, _ = _cutile_h_post_bda_bwd(
-                    grad_output, h_res, orig_res, h_post, x, None
+                    grad_output, h_res, orig_res, h_post, x, None, ctx.fuse_cast
                 )
                 g_bias = None
             if ctx.h_res_stop_gradient:
@@ -1251,14 +1837,21 @@ else:
         """
 
         @staticmethod
-        def forward(ctx, x: Tensor, weight: Tensor, eps: float = 1e-6):
+        def forward(
+            ctx,
+            x: Tensor,
+            weight: Tensor,
+            eps: float = 1e-6,
+            fuse_cast: bool = False,
+        ):
             """cuTile fused proj_rms forward."""
             original_shape = x.shape
             K = original_shape[-1]
             x_2d = x.reshape([-1, K])
-            proj, norm, r = _cutile_proj_rms_fwd(x_2d, weight, eps)
+            proj, norm, r = _cutile_proj_rms_fwd(x_2d, weight, eps, fuse_cast)
             ctx.save_for_backward(x_2d, weight, norm)
             ctx.eps = eps
+            ctx.fuse_cast = fuse_cast
             ctx.original_shape = original_shape
             ctx.x_stop_gradient = x.stop_gradient
             ctx.weight_stop_gradient = weight.stop_gradient
@@ -1274,7 +1867,13 @@ else:
             grad_proj_2d = grad_proj.reshape([-1, grad_proj.shape[-1]])
             grad_r_2d = grad_r.reshape([-1, 1])
             grad_x, grad_weight = _cutile_proj_rms_bwd(
-                grad_proj_2d, grad_r_2d, x_2d, weight, norm, ctx.eps
+                grad_proj_2d,
+                grad_r_2d,
+                x_2d,
+                weight,
+                norm,
+                ctx.eps,
+                ctx.fuse_cast,
             )
             return (
                 None if ctx.x_stop_gradient else grad_x.reshape(original_shape),
@@ -1312,12 +1911,66 @@ else:
         )
         return FusedSinkhornKnopp.apply(input_logits, num_iterations, eps)
 
-    def fused_h_aggregate(x: Tensor, h_pre: Tensor) -> Tensor:
+    def fused_compute_h(
+        proj: Tensor,
+        r: Tensor,
+        alpha_pre: Tensor,
+        alpha_post: Tensor,
+        alpha_res: Tensor,
+        bias: Tensor,
+        n: int,
+        eps: float,
+    ) -> tuple[Tensor, Tensor, Tensor]:
+        """Fused mHC mapping head.
+
+        Replaces ``expand x3 -> concat -> mul -> mul -> add -> sigmoid x2`` with
+        one launch, and drops the ``alpha`` vector entirely: ``n`` is a
+        compile-time constant in the kernel, so each output segment applies its
+        own scalar directly.
+
+        Args:
+            proj: [..., n*n + 2*n] projection of the n-stream hidden states
+            r: [..., 1] inverse RMS scale
+            alpha_pre / alpha_post / alpha_res: [1] learnable gates
+            bias: [n*n + 2*n] static bias
+            n: number of residual streams
+            eps: the constant added to h_pre
+
+        Returns:
+            h_pre: [..., n] sigmoid(u_pre) + eps
+            h_post: [..., n] 2 * sigmoid(u_post)
+            h_res: [..., n*n] u_res, unactivated
+        """
+        P = n * n + 2 * n
+        assert proj.shape[-1] == P, (
+            f"fused_compute_h: proj last dim must be n*n+2*n={P}, "
+            f"got {proj.shape[-1]} (proj.shape={list(proj.shape)})"
+        )
+        assert r.shape[-1] == 1, (
+            f"fused_compute_h: r last dim must be 1, got {list(r.shape)}"
+        )
+        assert list(r.shape[:-1]) == list(proj.shape[:-1]), (
+            f"fused_compute_h: r shape {list(r.shape)} and proj shape "
+            f"{list(proj.shape)} must agree on the leading dims"
+        )
+        assert bias.shape == [P], (
+            f"fused_compute_h: bias must be [{P}], got {list(bias.shape)}"
+        )
+        return FusedComputeH.apply(
+            proj, r, alpha_pre, alpha_post, alpha_res, bias, n, eps
+        )
+
+    def fused_h_aggregate(
+        x: Tensor, h_pre: Tensor, fuse_cast: bool = False
+    ) -> Tensor:
         """Weighted n-stream to 1-stream aggregation.
 
         Args:
             x: [s, b, n, C] n-stream hidden states
             h_pre: [s, b, n] aggregation weights
+            fuse_cast: when True, ``x`` may be narrower than ``h_pre``; the
+                kernel widens it in-register. Only the caller knows whether it
+                skipped the widening, so it cannot be inferred from dtypes.
 
         Returns:
             [s, b, C] aggregated hidden states
@@ -1339,7 +1992,7 @@ else:
         assert C <= _INT32_MAX, (
             f"fused_h_aggregate: C={C} exceeds int32 max ({_INT32_MAX})"
         )
-        return FusedHAggregate.apply(x, h_pre)
+        return FusedHAggregate.apply(x, h_pre, fuse_cast)
 
     def fused_h_post_bda(
         h_res: Tensor,
@@ -1347,6 +2000,7 @@ else:
         h_post: Tensor,
         x: Tensor,
         bias: Tensor | None,
+        fuse_cast: bool = False,
     ) -> Tensor:
         """Fused H_res @ residual + H_post * (x + bias).
 
@@ -1356,6 +2010,13 @@ else:
             h_post: [s, b, n] expansion weights
             x: [s, b, C] layer output
             bias: [C] or None
+            fuse_cast: when True, ``original_residual``/``x`` may be narrower
+                than the fp32 the kernel computes in; it widens them in-register
+                and returns its result in ``original_residual``'s dtype. Only
+                the caller knows whether it skipped the widening, so this cannot
+                be inferred from dtypes -- ``h_res`` is fp32 either way.
+                Declined when ``bias`` is not None, since ``g_bias`` reduces
+                over ``g_x`` and would lose precision if ``g_x`` were narrow.
 
         Returns:
             [s, b, n, C] fused output
@@ -1384,10 +2045,15 @@ else:
         assert C <= _INT32_MAX, (
             f"fused_h_post_bda: C={C} exceeds int32 max ({_INT32_MAX})"
         )
-        return FusedHPostBDA.apply(h_res, original_residual, h_post, x, bias)
+        return FusedHPostBDA.apply(
+            h_res, original_residual, h_post, x, bias, fuse_cast
+        )
 
     def fused_proj_rms(
-        x: Tensor, weight: Tensor, eps: float = 1e-6
+        x: Tensor,
+        weight: Tensor,
+        eps: float = 1e-6,
+        fuse_cast: bool = False,
     ) -> tuple[Tensor, Tensor]:
         """Fused projection + RMS normalization.
 
@@ -1395,6 +2061,9 @@ else:
             x: [..., K] input (last dim is K)
             weight: [K, N] projection weight
             eps: stability epsilon
+            fuse_cast: when True, ``x``/``weight`` may be narrow; the kernel
+                widens ``x`` in-register and returns ``proj``/``r`` in fp32 so
+                the mappings built from them keep their precision.
 
         Returns:
             proj: [..., N] = x @ weight^T
@@ -1423,4 +2092,4 @@ else:
         assert K <= _INT32_MAX, (
             f"fused_proj_rms: K={K} exceeds int32 max ({_INT32_MAX})"
         )
-        return FusedProjRms.apply(x, weight, eps)
+        return FusedProjRms.apply(x, weight, eps, fuse_cast)

--- a/src/paddlefleet/fusions/fused_mhc_kernels.py
+++ b/src/paddlefleet/fusions/fused_mhc_kernels.py
@@ -1942,20 +1942,27 @@ else:
             h_res: [..., n*n] u_res, unactivated
         """
         P = n * n + 2 * n
-        assert proj.shape[-1] == P, (
-            f"fused_compute_h: proj last dim must be n*n+2*n={P}, "
-            f"got {proj.shape[-1]} (proj.shape={list(proj.shape)})"
-        )
-        assert r.shape[-1] == 1, (
-            f"fused_compute_h: r last dim must be 1, got {list(r.shape)}"
-        )
-        assert list(r.shape[:-1]) == list(proj.shape[:-1]), (
-            f"fused_compute_h: r shape {list(r.shape)} and proj shape "
-            f"{list(proj.shape)} must agree on the leading dims"
-        )
-        assert bias.shape == [P], (
-            f"fused_compute_h: bias must be [{P}], got {list(bias.shape)}"
-        )
+        # Raised, not asserted: ``python -O`` strips asserts, and a wrong P or
+        # bias length then reaches a kernel that addresses the three output
+        # segments at fixed offsets, i.e. reads out of bounds.
+        if proj.shape[-1] != P:
+            raise ValueError(
+                f"fused_compute_h: proj last dim must be n*n+2*n={P}, "
+                f"got {proj.shape[-1]} (proj.shape={list(proj.shape)})"
+            )
+        if r.shape[-1] != 1:
+            raise ValueError(
+                f"fused_compute_h: r last dim must be 1, got {list(r.shape)}"
+            )
+        if list(r.shape[:-1]) != list(proj.shape[:-1]):
+            raise ValueError(
+                f"fused_compute_h: r shape {list(r.shape)} and proj shape "
+                f"{list(proj.shape)} must agree on the leading dims"
+            )
+        if bias.shape != [P]:
+            raise ValueError(
+                f"fused_compute_h: bias must be [{P}], got {list(bias.shape)}"
+            )
         return FusedComputeH.apply(
             proj, r, alpha_pre, alpha_post, alpha_res, bias, n, eps
         )

--- a/src/paddlefleet/transformer/hyper_connection.py
+++ b/src/paddlefleet/transformer/hyper_connection.py
@@ -340,8 +340,16 @@ class HyperConnectionModule(nn.Layer):
             self._proj_rms_op = fused_proj_rms
             # Unlike the cast fusion this one trades launches, not dtypes -- the
             # mapping head is only n*n + 2*n wide per token -- so it applies at
-            # either precision.
-            self._compute_h_op = fused_compute_h
+            # either high_precision_mhc setting. The accuracy-compatible kernel
+            # is a separate matter: it is a Megatron-alignment contract, and the
+            # fused head's FMA contraction and staged cross-token reductions
+            # break it, so that mode keeps the reference composition, exactly as
+            # the projection / aggregate / BDA sites already do.
+            self._compute_h_op = (
+                native_compute_h
+                if _use_accuracy_compatible_kernel()
+                else fused_compute_h
+            )
             # The mHC input, the residual and the layer output stay in their
             # incoming dtype; the kernels widen them in-register instead of the
             # block materializing fp32 copies. Gated on high_precision_mhc:

--- a/src/paddlefleet/transformer/hyper_connection.py
+++ b/src/paddlefleet/transformer/hyper_connection.py
@@ -166,6 +166,57 @@ def native_proj_rms(
     return proj, r
 
 
+def native_compute_h(
+    proj: Tensor,
+    r: Tensor,
+    alpha_pre: Tensor,
+    alpha_post: Tensor,
+    alpha_res: Tensor,
+    bias: Tensor,
+    n: int,
+    eps: float,
+    *,
+    _fma_probe: bool = False,
+) -> tuple[Tensor, Tensor, Tensor]:
+    """Native mHC mapping head (Eq. 5 in the mHC paper).
+
+    Returns ``h_pre = sigma(u_pre) + eps``, ``h_post = 2 sigma(u_post)`` and the
+    unactivated ``h_res``, where ``u = r * proj * alpha + bias`` and ``alpha``
+    is the three learnable gates broadcast over their segments.
+
+    ``_fma_probe`` is for the unit tests only, and nothing in the model passes
+    it. It makes this function round once where it normally rounds twice, i.e.
+    compute what the fused kernel's FMA computes, which is what lets the tests
+    demand bitwise equality and so pin the residual difference on the
+    contraction alone. It costs an fp64 pass, so it must stay off in training.
+    """
+    alpha_ = paddle.concat(
+        [
+            alpha_pre.expand([n]),
+            alpha_post.expand([n]),
+            alpha_res.expand([n * n]),
+        ],
+        axis=-1,
+    )
+    if _fma_probe:
+        # The first multiply still rounds -- hardware contracts only one
+        # multiply-add -- then ``t1 * alpha + bias`` rounds once. fp64 holds
+        # ``t1 * alpha`` exactly: 24 + 24 mantissa bits against 53.
+        t1 = r * proj
+        h = (
+            t1.astype("float64") * alpha_.astype("float64")
+            + bias.astype("float64")
+        ).astype(proj.dtype)
+    else:
+        h = r * proj * alpha_ + bias
+    # H_pre = sigma(alpha_pre * (theta_pre @ x_tilde) + b_pre)
+    h_pre = h[..., :n].sigmoid() + eps
+    # H_post = 2 sigma(alpha_post * (theta_post @ x_tilde) + b_post)
+    h_post = h[..., n : 2 * n].sigmoid() * 2
+    h_res = h[..., 2 * n :]
+    return h_pre, h_post, h_res
+
+
 def native_h_aggregate(x_streams: Tensor, h_pre: Tensor) -> Tensor:
     """Native n-stream weighted aggregation: out = sum_j(h_pre_j * x_j)."""
     return (x_streams * h_pre.unsqueeze(-1)).sum(axis=-2)
@@ -276,6 +327,7 @@ class HyperConnectionModule(nn.Layer):
         # Choose implementation: fused kernels vs native reference.
         if config.use_fused_mhc:
             from paddlefleet.fusions.fused_mhc_kernels import (
+                fused_compute_h,
                 fused_h_aggregate,
                 fused_h_post_bda,
                 fused_proj_rms,
@@ -286,11 +338,26 @@ class HyperConnectionModule(nn.Layer):
             self._h_aggregate_op = fused_h_aggregate
             self._h_post_bda_op = fused_h_post_bda
             self._proj_rms_op = fused_proj_rms
+            # Unlike the cast fusion this one trades launches, not dtypes -- the
+            # mapping head is only n*n + 2*n wide per token -- so it applies at
+            # either precision.
+            self._compute_h_op = fused_compute_h
+            # The mHC input, the residual and the layer output stay in their
+            # incoming dtype; the kernels widen them in-register instead of the
+            # block materializing fp32 copies. Gated on high_precision_mhc:
+            # that is the only mode with a widening to absorb -- without it the
+            # reference keeps the arithmetic in the incoming dtype and so must
+            # the kernel. The BDA site opts out again when a bias is present.
+            self._widen_in_kernel = config.high_precision_mhc
         else:
             self._sinkhorn_op = native_sinkhorn
             self._h_aggregate_op = native_h_aggregate
             self._h_post_bda_op = native_h_post_bda
             self._proj_rms_op = native_proj_rms
+            self._compute_h_op = native_compute_h
+            # The native reference is a plain op composition: it cannot absorb a
+            # widening, so its operands are still pre-widened in Python.
+            self._widen_in_kernel = False
 
         self._init_weights()
 
@@ -337,9 +404,17 @@ class HyperConnectionModule(nn.Layer):
             proj = proj_2d.reshape([*x.shape[:-1], weight.shape[-1]])
         else:
             ori_dtype = x.dtype
-            proj, r = self._proj_rms_op(
-                x, self.mapping_proj.weight.astype(ori_dtype), self.norm_eps
-            )
+            if self._widen_in_kernel:
+                # x is still narrow here, so the weight needs no matching cast
+                # either; the kernel widens what it has to and returns proj/r
+                # in fp32.
+                proj, r = self._proj_rms_op(
+                    x, self.mapping_proj.weight, self.norm_eps, fuse_cast=True
+                )
+            else:
+                proj, r = self._proj_rms_op(
+                    x, self.mapping_proj.weight.astype(ori_dtype), self.norm_eps
+                )
             if not self.config.high_precision_mhc:
                 r = r.astype(ori_dtype)
 
@@ -360,20 +435,16 @@ class HyperConnectionModule(nn.Layer):
             h_post: [..., n] - expansion weights
             h_res: [..., n^2] - residual mixing logits
         """
-        alpha_ = paddle.concat(
-            [
-                self.alpha_pre.expand([self.n]),
-                self.alpha_post.expand([self.n]),
-                self.alpha_res.expand([self.n * self.n]),
-            ],
-            axis=-1,
+        h_pre, h_post, h_res = self._compute_h_op(
+            proj,
+            r,
+            self.alpha_pre,
+            self.alpha_post,
+            self.alpha_res,
+            self.bias,
+            self.n,
+            self.compute_h_eps,
         )
-        h = r * proj * alpha_ + self.bias
-        # H_pre = σ(α_pre * (θ_pre @ x̃) + b_pre)
-        h_pre = h[..., : self.n].sigmoid() + self.compute_h_eps  # [..., n]
-        # H_post = 2σ(α_post * (θ_post @ x̃) + b_post)
-        h_post = h[..., self.n : 2 * self.n].sigmoid() * 2  # [..., n]
-        h_res = h[..., 2 * self.n :]
         if _use_accuracy_compatible_kernel():
             h_pre = h_pre.astype(proj.dtype)
             h_post = h_post.astype(proj.dtype)
@@ -430,7 +501,12 @@ class HyperConnectionModule(nn.Layer):
                 aggregated = aggregated.astype(x.dtype)
             return aggregated
         else:
-            aggregated = self._h_aggregate_op(x_streams, h_pre)
+            if self._widen_in_kernel:
+                aggregated = self._h_aggregate_op(
+                    x_streams, h_pre, fuse_cast=True
+                )
+            else:
+                aggregated = self._h_aggregate_op(x_streams, h_pre)
             if aggregated.dtype != x.dtype:
                 aggregated = aggregated.astype(x.dtype)
             return aggregated
@@ -547,6 +623,7 @@ class HyperConnectionModule(nn.Layer):
             if (
                 not _use_accuracy_compatible_kernel()
                 and self.config.high_precision_mhc
+                and not self._widen_in_kernel
             ):
                 hidden_states = hidden_states.astype("float32")
             h_pre, h_post, h_res = self.compute_mappings(hidden_states)
@@ -729,14 +806,32 @@ class HyperConnectionModule(nn.Layer):
                 orig_reshaped = original_residual.reshape(
                     [*leading_shape, n, C]
                 )
-                if self.config.high_precision_mhc:
+                # ``fuse_cast`` hands the two large operands to the kernel in
+                # their incoming dtype instead; it widens them in-register and
+                # writes the result back in ``orig_reshaped``'s dtype.
+                # ``_widen_in_kernel`` already folds in ``high_precision_mhc``,
+                # the only mode that widens at all. A present bias opts out on
+                # top of that (the kernel declines it too): its gradient
+                # reduces over ``g_x``, which would then be narrow.
+                fuse_cast = self._widen_in_kernel and bias is None
+                if self.config.high_precision_mhc and not fuse_cast:
                     orig_reshaped = orig_reshaped.astype("float32")
                     x = x.astype("float32")
                     if bias is not None:
                         bias = bias.astype("float32")
-                output = self._h_post_bda_op(
-                    h_res, orig_reshaped, h_post, x, bias
-                )
+                if fuse_cast:
+                    output = self._h_post_bda_op(
+                        h_res,
+                        orig_reshaped,
+                        h_post,
+                        x,
+                        bias,
+                        fuse_cast=True,
+                    )
+                else:
+                    output = self._h_post_bda_op(
+                        h_res, orig_reshaped, h_post, x, bias
+                    )
                 return output.reshape([*leading_shape, n * C])
 
             # Sequential path: used when dropout required OR accuracy-compatible kernel is NOT enabled

--- a/tests/single_card_tests/custom_ops/test_fused_mhc_bda_cast.py
+++ b/tests/single_card_tests/custom_ops/test_fused_mhc_bda_cast.py
@@ -1,0 +1,263 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the h_post_bda cast fusion (``fuse_cast``).
+
+The fusion lets the cuTile h_post_bda kernel take ``original_residual``/``x``
+in the residual dtype and widen them to fp32 in-register, instead of the caller
+materializing fp32 copies. Three things need to hold:
+
+1. A ``ct.Constant[int]`` guard compiles away, so the un-fused specialization is
+   bitwise identical to a kernel written without the widening at all. This is
+   what lets one kernel source serve both paths.
+2. Widening in-register is bitwise equivalent to widening in Python, for the
+   forward output and for the two large gradients.
+3. ``high_precision_mhc=False`` is untouched: the caller never widened there, so
+   the flag must not reach the kernel.
+"""
+
+import unittest
+
+import paddle
+
+from paddlefleet.fusions.fused_mhc_kernels import is_cutile_available
+
+_S, _B, _N, _C = 4, 2, 4, 1024
+
+
+def _rand(*shape, dtype="float32"):
+    return paddle.randn(list(shape), dtype="float32").astype(dtype)
+
+
+def _small_int(*shape, dtype="float32"):
+    """Integers in [-8, 8].
+
+    Exact in bf16 (integers up to 256) so the inputs are unchanged by the narrow
+    storage, while the partial sums grow past 256 -- far enough that any
+    accumulation left in bf16 would round, yet well under 2**24 so fp32 keeps
+    them exact. Summation is then order-independent, which turns bitwise
+    equality into a fair demand and makes a missed widening visible.
+    """
+    return paddle.randint(-8, 9, list(shape)).astype("float32").astype(dtype)
+
+
+@unittest.skipUnless(is_cutile_available(), "cuTile not available")
+class TestConstGuard(unittest.TestCase):
+    """A ``ct.Constant[bool]`` guard must fold away at compile time.
+
+    This is the premise for keeping a single kernel source: with the guard off,
+    the emitted code must contain no widening, i.e. be bitwise identical to a
+    kernel that never had one. If this fails, the two paths need two kernels.
+    """
+
+    def test_guard_folds_and_matches_unguarded(self):
+        import cuda.tile as ct
+
+        ConstInt = ct.Constant[int]
+        ConstBool = ct.Constant[bool]
+        PAD = ct.PaddingMode.ZERO
+        TILE = 256
+
+        @ct.kernel
+        def unguarded(src, other, out, TILE: ConstInt):
+            pid = ct.bid(0)
+            a = ct.load(src, index=(pid,), shape=(TILE,), padding_mode=PAD)
+            b = ct.load(other, index=(pid,), shape=(TILE,), padding_mode=PAD)
+            ct.store(out, index=(pid,), tile=(a * b).astype(out.dtype))
+
+        @ct.kernel
+        def guarded(src, other, out, TILE: ConstInt, UPCAST: ConstBool):
+            pid = ct.bid(0)
+            a = ct.load(src, index=(pid,), shape=(TILE,), padding_mode=PAD)
+            if UPCAST:
+                a = a.astype(ct.float32)
+            b = ct.load(other, index=(pid,), shape=(TILE,), padding_mode=PAD)
+            ct.store(out, index=(pid,), tile=(a * b).astype(out.dtype))
+
+        n = 4096
+        paddle.seed(0)
+        f32 = _rand(n)
+        other = _rand(n)
+        bf16 = f32.astype("bfloat16")
+        stream = paddle.device.current_stream().stream_base.cuda_stream
+
+        def run(kern, src, *extra):
+            out = paddle.empty([n], dtype="float32")
+            ct.launch(
+                stream, (n // TILE,), kern, (src, other, out, TILE, *extra)
+            )
+            paddle.device.synchronize()
+            return out.astype("float32")
+
+        plain = run(unguarded, f32)
+        off = run(guarded, f32, False)
+        on_f32 = run(guarded, f32, True)
+        on_bf16 = run(guarded, bf16, True)
+
+        # guard off == no guard at all
+        self.assertTrue(bool((plain == off).all()), "UPCAST=False diverged")
+        # widening an already-fp32 tile is a no-op
+        self.assertTrue(
+            bool((plain == on_f32).all()), "UPCAST=True on fp32 drifted"
+        )
+        # widening a bf16 tile reproduces the Python-side widening exactly
+        ref = bf16.astype("float32") * other
+        self.assertTrue(
+            bool((on_bf16 == ref).all()), "UPCAST=True on bf16 mismatched"
+        )
+
+
+@unittest.skipUnless(is_cutile_available(), "cuTile not available")
+class TestFuseCastEquivalence(unittest.TestCase):
+    """fuse_cast=True must match the widen-in-Python path it replaces.
+
+    Bitwise for the forward output and for ``g_residual``/``g_x``. The two
+    reduced gradients ``g_h_res``/``g_h_post`` reassociate (see
+    ``_ct_hpb_bwd_kernel``) and are only held to fp32-ULP agreement.
+    """
+
+    # fp32 ULP scale; the drift measured at C=4096 is ~2e-7 relative
+    REDUCED_GRAD_RTOL = 1e-5
+
+    def _run(self, fuse_cast, with_bias, integer=False):
+        from paddlefleet.fusions.fused_mhc_kernels import fused_h_post_bda
+
+        paddle.seed(7)
+        mk = _small_int if integer else _rand
+        # h_res / h_post are fp32 in the real graph regardless of
+        # high_precision_mhc (_compute_h promotes them via its fp32 bias).
+        h_res = mk(_S, _B, _N, _N)
+        h_post = mk(_S, _B, _N)
+        # residual / layer output enter the layer in the low-precision dtype.
+        # They stay the leaves in both configurations, with the widening inside
+        # the graph, so the gradients being compared are the ones that actually
+        # reach the residual stream -- both bf16.
+        orig_leaf = mk(_S, _B, _N, _C, dtype="bfloat16")
+        x_leaf = mk(_S, _B, _C, dtype="bfloat16")
+        bias_leaf = mk(_C, dtype="bfloat16") if with_bias else None
+        leaves = [h_res, h_post, orig_leaf, x_leaf]
+        if with_bias:
+            leaves.append(bias_leaf)
+        for t in leaves:
+            t.stop_gradient = False
+
+        if fuse_cast and not with_bias:
+            orig, x, bias = orig_leaf, x_leaf, bias_leaf
+        else:
+            # What the caller does today. It mirrors the kernel's own bias veto,
+            # so with a bias present it still pre-widens even with the flag
+            # on -- which is why the bias case must come out bit-identical.
+            orig = orig_leaf.astype("float32")
+            x = x_leaf.astype("float32")
+            bias = bias_leaf.astype("float32") if with_bias else None
+
+        out = fused_h_post_bda(
+            h_res, orig, h_post, x, bias, fuse_cast=fuse_cast
+        )
+        # the caller always brings the result back to the residual dtype
+        casted = out.to("bfloat16")
+        (casted.astype("float32") * 1.0).sum().backward()
+        g = lambda t: t.grad.astype("float32")
+        return {
+            "out": casted.astype("float32"),
+            "g_res": g(orig_leaf),
+            "g_x": g(x_leaf),
+            "g_h_res": g(h_res),
+            "g_h_post": g(h_post),
+            "g_bias": g(bias_leaf) if with_bias else None,
+        }
+
+    def _check(self, with_bias):
+        ref = self._run(fuse_cast=False, with_bias=with_bias)
+        got = self._run(fuse_cast=True, with_bias=with_bias)
+        for key in ("out", "g_res", "g_x"):
+            self.assertTrue(
+                bool((ref[key] == got[key]).all()),
+                f"{key} must be bitwise identical, got max diff "
+                f"{float((ref[key] - got[key]).abs().max()):.3e}",
+            )
+        for key in ("g_h_res", "g_h_post"):
+            scale = float(ref[key].abs().mean())
+            diff = float((ref[key] - got[key]).abs().max())
+            self.assertLess(
+                diff,
+                self.REDUCED_GRAD_RTOL * scale,
+                f"{key} drifted beyond fp32 ULP: {diff:.3e} "
+                f"vs scale {scale:.3e}",
+            )
+
+    def test_no_bias(self):
+        self._check(with_bias=False)
+
+    def test_exact_arithmetic_is_bitwise(self):
+        """With exact arithmetic every tensor must match bitwise.
+
+        Reduction order is the one thing the fusion legitimately changes, and it
+        only surfaces when the summation rounds. Integers remove that degree of
+        freedom, so anything still differing here is a real defect -- a tensor
+        left narrow in the arithmetic, a wrong index, a dropped term.
+        """
+        ref = self._run(fuse_cast=False, with_bias=False, integer=True)
+        got = self._run(fuse_cast=True, with_bias=False, integer=True)
+        for key in ("out", "g_res", "g_x", "g_h_res", "g_h_post"):
+            a, b = ref[key], got[key]
+            diff = float((a - b).abs().max())
+            print(
+                f"  [exact] {key:<9} bitwise={bool((a == b).all())!s:<5} "
+                f"max_abs={diff:.3e} max|val|={float(a.abs().max()):.0f}"
+            )
+            self.assertTrue(
+                bool((a == b).all()),
+                f"{key} differs under exact arithmetic, so the cause is not "
+                f"reduction order: max_abs={diff:.3e}",
+            )
+
+    def test_bias_declines_the_fusion(self):
+        """With a bias present the kernel must ignore ``fuse_cast`` entirely.
+
+        ``g_bias`` is a ``[sb, C] -> [C]`` reduction over ``g_x``; handing it a
+        narrow ``g_x`` costs bf16-scale precision, not ULP-scale, so the bias
+        variant stays on the widen-in-Python path and must be bit-identical.
+        """
+        ref = self._run(fuse_cast=False, with_bias=True)
+        got = self._run(fuse_cast=True, with_bias=True)
+        for key in ("out", "g_res", "g_x", "g_h_res", "g_h_post", "g_bias"):
+            self.assertTrue(
+                bool((ref[key] == got[key]).all()),
+                f"{key} changed even though bias should veto the fusion: "
+                f"max diff {float((ref[key] - got[key]).abs().max()):.3e}",
+            )
+
+    def test_output_dtype(self):
+        """fuse_cast decides the output dtype; without it nothing changes."""
+        from paddlefleet.fusions.fused_mhc_kernels import fused_h_post_bda
+
+        paddle.seed(7)
+        h_res = _rand(_S, _B, _N, _N)
+        h_post = _rand(_S, _B, _N)
+        orig_bf16 = _rand(_S, _B, _N, _C, dtype="bfloat16")
+        x_bf16 = _rand(_S, _B, _C, dtype="bfloat16")
+
+        fused = fused_h_post_bda(
+            h_res, orig_bf16, h_post, x_bf16, None, fuse_cast=True
+        )
+        self.assertEqual(fused.dtype, paddle.bfloat16)
+        # fuse_cast=False keeps the pre-fusion rule (out follows h_res), which
+        # is what protects the high_precision_mhc=False path from this change.
+        plain = fused_h_post_bda(h_res, orig_bf16, h_post, x_bf16, None)
+        self.assertEqual(plain.dtype, paddle.float32)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/custom_ops/test_fused_mhc_compute_h.py
+++ b/tests/single_card_tests/custom_ops/test_fused_mhc_compute_h.py
@@ -1,0 +1,327 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Numeric record for the fused mHC mapping head (``fused_compute_h``).
+
+``fused_compute_h`` replaces ``native_compute_h`` -- the
+``expand x3 -> concat -> mul -> mul -> add -> sigmoid x2`` chain -- with a
+single cuTile kernel. This is a launch-count optimization, not a dtype one,
+so the values ought to agree closely; these tests record how closely, forward
+and backward.
+
+The two gradients that reduce over every token (``alpha`` and ``bias``) are the
+ones expected to drift: the fused path stages per-block partials and sums them,
+which groups the additions differently from Paddle's own reduction.
+"""
+
+import unittest
+
+import paddle
+
+from paddlefleet.fusions.fused_mhc_kernels import is_cutile_available
+from paddlefleet.transformer.hyper_connection import native_compute_h
+
+_S, _B, _N = 8, 2, 4
+_P = _N * _N + 2 * _N
+_EPS = 1e-6
+
+_KEYS = (
+    "h_pre",
+    "h_post",
+    "h_res",
+    "g_proj",
+    "g_r",
+    "g_alpha_pre",
+    "g_alpha_post",
+    "g_alpha_res",
+    "g_bias",
+)
+
+
+def _rand(*shape, dtype="float32"):
+    return paddle.randn(list(shape), dtype="float32").astype(dtype)
+
+
+def _small_int(*shape, dtype="float32"):
+    """Integers in [-4, 4].
+
+    Kept small enough that ``r * proj * alpha`` stays a whole number, so the
+    additions are exact and grouping cannot matter. Anything still differing
+    under these inputs is a real defect rather than the documented
+    reassociation of the two cross-token reductions.
+    """
+    return paddle.randint(-4, 5, list(shape)).astype("float32").astype(dtype)
+
+
+def _cmp(ref, got):
+    a, b = ref.astype("float32"), got.astype("float32")
+    diff = float((a - b).abs().max())
+    scale = float(a.abs().mean())
+    return bool((a == b).all()), diff, scale, (diff / scale if scale else 0.0)
+
+
+@unittest.skipUnless(is_cutile_available(), "cuTile not available")
+class TestFusedComputeH(unittest.TestCase):
+    """fused_compute_h against native_compute_h, forward and backward."""
+
+    # Per-token outputs and their per-token gradients must match bitwise; the
+    # two cross-token reductions are held to fp32 ULP. Filled in from the
+    # measurements printed by the tests below.
+    # Tolerances are set by the output dtype, not by one global number.
+    #
+    # fp32 outputs (proj / r and everything derived per token) land within one
+    # fp32 ULP: measured h_pre 1.0e-07, h_post 1.5e-07, h_res 2.6e-07,
+    # g_proj 6.3e-08, g_r 3.7e-07.
+    #
+    # The alpha and bias gradients come back in the parameter dtype, i.e. bf16,
+    # whose spacing near their magnitude is already ~4e-03. A tiny fp32
+    # difference upstream therefore shows up as a whole bf16 step -- measured
+    # g_alpha_res 4.7e-03, which is exactly one. Demanding fp32-ULP agreement on
+    # a bf16 output would be demanding more resolution than the dtype has.
+    #
+    # Nothing here is bitwise on random inputs, unlike the two cast fusions:
+    # ``u = r*proj*a + b`` is one multiply-add and the kernel contracts it into
+    # an FMA, one rounding where the reference rounds twice. That difference
+    # disappears under ``test_exact_arithmetic_is_bitwise`` and under
+    # ``test_fma_probe_makes_it_bitwise``.
+    _FP32_ULP = 1e-6
+    _BF16_ULP = 8e-3
+    TOL = {
+        "h_pre": _FP32_ULP,
+        "h_post": _FP32_ULP,
+        "h_res": _FP32_ULP,
+        "g_proj": _FP32_ULP,
+        "g_r": _FP32_ULP,
+        "g_alpha_pre": _BF16_ULP,
+        "g_alpha_post": _BF16_ULP,
+        "g_alpha_res": _BF16_ULP,
+        "g_bias": _BF16_ULP,
+    }
+
+    # With the reference rounding once too, these must agree to the last bit:
+    # they are per-token and fp32, so neither the contraction nor a reduction
+    # order is left to explain a difference.
+    FMA_PROBE_BITWISE = ("h_pre", "h_post", "h_res", "g_proj")
+
+    def _run(
+        self,
+        fused,
+        integer=False,
+        res_only=False,
+        probe=False,
+        dtype="float32",
+        param_dtype="bfloat16",
+    ):
+        from paddlefleet.fusions.fused_mhc_kernels import fused_compute_h
+
+        paddle.seed(17)
+        mk = _small_int if integer else _rand
+        proj = mk(_S, _B, _P, dtype=dtype)
+        # r is 1 / (||x|| / sqrt(K) + eps): positive and O(1). Build the values
+        # first, then take a leaf, or r.grad would come back None.
+        r = (mk(_S, _B, 1, dtype=dtype).abs() + 1.0).detach()
+        # alpha follows params_dtype and bias the global default dtype, i.e.
+        # bf16 in bf16 training, while proj / r are fp32 under
+        # high_precision_mhc. Keep that mix: it is the only configuration the
+        # real model runs, and testing with fp32 here would leave the kernel's
+        # widening of these operands entirely uncovered.
+        alpha_pre = mk(1, dtype=param_dtype)
+        alpha_post = mk(1, dtype=param_dtype)
+        alpha_res = mk(1, dtype=param_dtype)
+        bias = mk(_P, dtype=param_dtype)
+        leaves = [proj, r, alpha_pre, alpha_post, alpha_res, bias]
+        for t in leaves:
+            t.stop_gradient = False
+
+        if fused:
+            h_pre, h_post, h_res = fused_compute_h(
+                proj, r, alpha_pre, alpha_post, alpha_res, bias, _N, _EPS
+            )
+        else:
+            h_pre, h_post, h_res = native_compute_h(
+                proj,
+                r,
+                alpha_pre,
+                alpha_post,
+                alpha_res,
+                bias,
+                _N,
+                _EPS,
+                _fma_probe=probe,
+            )
+        if res_only:
+            # h_res is the one head with no sigmoid on it, so with integer
+            # inputs this loss keeps every gradient an exact integer.
+            loss = 3.0 * h_res.astype("float32").sum()
+        else:
+            # weight the three heads unequally so no gradient path cancels out
+            loss = (
+                h_pre.astype("float32").sum()
+                + 2.0 * h_post.astype("float32").sum()
+                + 3.0 * h_res.astype("float32").sum()
+            )
+        loss.backward()
+        return {
+            "h_pre": h_pre,
+            "h_post": h_post,
+            "h_res": h_res,
+            "g_proj": proj.grad,
+            "g_r": r.grad,
+            "g_alpha_pre": alpha_pre.grad,
+            "g_alpha_post": alpha_post.grad,
+            "g_alpha_res": alpha_res.grad,
+            "g_bias": bias.grad,
+        }
+
+    def test_precision(self):
+        ref = self._run(fused=False)
+        got = self._run(fused=True)
+        for key in _KEYS:
+            tol = self.TOL[key]
+            bitwise, diff, scale, rel = _cmp(ref[key], got[key])
+            print(
+                f"  {key:<12} bitwise={bitwise!s:<5} max_abs={diff:.3e} "
+                f"scale={scale:.3e} rel={rel:.2e} tol={tol:.0e}"
+            )
+            if tol == 0.0:
+                self.assertTrue(
+                    bitwise, f"{key} must be bitwise identical, rel={rel:.3e}"
+                )
+            else:
+                self.assertLess(
+                    rel, tol, f"{key} drifted past tolerance: rel={rel:.3e}"
+                )
+
+    def test_exact_arithmetic_is_bitwise(self):
+        """Integer inputs make every addition exact, so grouping cannot matter.
+
+        The two cross-token reductions are the only thing the fused path
+        reassociates; removing the rounding removes that degree of freedom, and
+        anything still differing points at a genuine defect.
+        """
+        ref = self._run(fused=False, integer=True, res_only=True)
+        got = self._run(fused=True, integer=True, res_only=True)
+        for key in _KEYS:
+            bitwise, diff, _, _ = _cmp(ref[key], got[key])
+            print(
+                f"  [exact] {key:<12} bitwise={bitwise!s:<5} max_abs={diff:.3e}"
+            )
+            self.assertTrue(
+                bitwise,
+                f"{key} differs under exact arithmetic, so the cause is not "
+                f"reduction order: max_abs={diff:.3e}",
+            )
+
+    def test_fma_probe_makes_it_bitwise(self):
+        """With the reference rounding once, the two paths must match bitwise.
+
+        ``native_compute_h(_fma_probe=True)`` rewrites the reference to do a
+        single rounding of ``t1 * alpha + bias``, which is exactly what the
+        kernel's FMA does. If everything else about the fusion is
+        behaviour-neutral -- the collapsed launches, the alpha vector that never
+        materializes, the staged cross-token reductions -- the two paths agree to
+        the last bit under it, and the residual difference measured by
+        ``test_precision`` is entirely the contraction.
+        """
+        ref = self._run(fused=False, probe=True)
+        got = self._run(fused=True)
+        residual = []
+        for key in _KEYS:
+            bitwise, diff, scale, rel = _cmp(ref[key], got[key])
+            print(
+                f"  [fma] {key:<12} bitwise={bitwise!s:<5} "
+                f"max_abs={diff:.3e} rel={rel:.2e}"
+            )
+            if key in self.FMA_PROBE_BITWISE and not bitwise:
+                residual.append(f"{key} (rel={rel:.2e})")
+            elif rel >= self.TOL[key]:
+                residual.append(f"{key} (rel={rel:.2e} over tol)")
+        self.assertFalse(
+            residual,
+            "still differing once the reference rounds once too, beyond what "
+            "the reductions and the output dtypes explain: "
+            + ", ".join(residual),
+        )
+
+    def test_exact_arithmetic_with_fma_probe(self):
+        """The discriminator for the four gradients ``test_fma_probe`` leaves.
+
+        Those four are all sums. Two things could explain them: the order the
+        additions are grouped in, or the fp64 the probe puts into the reference's
+        forward leaking into its backward.
+
+        Integer inputs settle it. With the loss on ``h_res`` only, ``du`` is a
+        constant and every partial sum is a whole number, so no grouping can
+        change the result and no fp64 can add precision that matters. If the two
+        paths agree bitwise here while differing on random inputs, the cause is
+        the grouping -- there is nothing else left.
+        """
+        ref = self._run(fused=False, integer=True, res_only=True, probe=True)
+        got = self._run(fused=True, integer=True, res_only=True)
+        residual = []
+        for key in _KEYS:
+            bitwise, diff, _, _ = _cmp(ref[key], got[key])
+            print(
+                f"  [exact+fma] {key:<12} bitwise={bitwise!s:<5} "
+                f"max_abs={diff:.3e}"
+            )
+            if not bitwise:
+                residual.append(f"{key} ({diff:.2e})")
+        self.assertFalse(
+            residual,
+            "exact arithmetic plus a matching rounding count still leaves a "
+            "difference, so neither grouping nor the FMA explains it: "
+            + ", ".join(residual),
+        )
+
+    def test_shapes_and_dtypes(self):
+        got = self._run(fused=True)
+        self.assertEqual(got["h_pre"].shape, [_S, _B, _N])
+        self.assertEqual(got["h_post"].shape, [_S, _B, _N])
+        self.assertEqual(got["h_res"].shape, [_S, _B, _N * _N])
+        # every gradient comes back in its input's dtype
+        for key in ("h_pre", "h_post", "h_res", "g_proj", "g_r"):
+            self.assertEqual(got[key].dtype, paddle.float32, key)
+        # alpha / bias gradients come back in the parameter dtype
+        for key in ("g_alpha_pre", "g_bias"):
+            self.assertEqual(got[key].dtype, paddle.bfloat16, key)
+
+    def test_frozen_inputs_return_none(self):
+        """A frozen mHC block must not make backward raise.
+
+        Paddle requires ``None`` at every position whose forward input was
+        detached; ``train_indexer_only`` freezes exactly these parameters.
+        """
+        from paddlefleet.fusions.fused_mhc_kernels import fused_compute_h
+
+        paddle.seed(19)
+        proj = _rand(_S, _B, _P)
+        r = _rand(_S, _B, 1).abs() + 1.0
+        alpha_pre = _rand(1)
+        alpha_post = _rand(1)
+        alpha_res = _rand(1)
+        bias = _rand(_P)
+        proj.stop_gradient = False  # only this one trains
+        for t in (r, alpha_pre, alpha_post, alpha_res, bias):
+            t.stop_gradient = True
+
+        h_pre, h_post, h_res = fused_compute_h(
+            proj, r, alpha_pre, alpha_post, alpha_res, bias, _N, _EPS
+        )
+        (h_pre.sum() + h_post.sum() + h_res.sum()).backward()
+        self.assertIsNotNone(proj.grad)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/custom_ops/test_fused_mhc_compute_h.py
+++ b/tests/single_card_tests/custom_ops/test_fused_mhc_compute_h.py
@@ -323,5 +323,62 @@ class TestFusedComputeH(unittest.TestCase):
         self.assertIsNotNone(proj.grad)
 
 
+@unittest.skipUnless(is_cutile_available(), "cuTile not available")
+class TestFusedComputeHValidation(unittest.TestCase):
+    """Bad shapes must raise, and must not rely on ``assert``.
+
+    ``python -O`` strips asserts, and the kernel addresses the three output
+    segments at fixed offsets derived from ``n``. An unchecked ``P`` or bias
+    length would therefore be read out of bounds rather than rejected.
+    """
+
+    def _args(self, **over):
+        paddle.seed(29)
+        args = {
+            "proj": _rand(_S, _B, _P),
+            "r": _rand(_S, _B, 1).abs() + 1.0,
+            "alpha_pre": _rand(1),
+            "alpha_post": _rand(1),
+            "alpha_res": _rand(1),
+            "bias": _rand(_P),
+        }
+        args.update(over)
+        return args
+
+    def _call(self, **over):
+        from paddlefleet.fusions.fused_mhc_kernels import fused_compute_h
+
+        a = self._args(**over)
+        return fused_compute_h(
+            a["proj"],
+            a["r"],
+            a["alpha_pre"],
+            a["alpha_post"],
+            a["alpha_res"],
+            a["bias"],
+            _N,
+            _EPS,
+        )
+
+    def test_accepts_the_valid_shapes(self):
+        self._call()
+
+    def test_rejects_wrong_proj_width(self):
+        with self.assertRaisesRegex(ValueError, "proj last dim"):
+            self._call(proj=_rand(_S, _B, _P + 1))
+
+    def test_rejects_r_last_dim_not_one(self):
+        with self.assertRaisesRegex(ValueError, "r last dim"):
+            self._call(r=_rand(_S, _B, 2))
+
+    def test_rejects_disagreeing_leading_dims(self):
+        with self.assertRaisesRegex(ValueError, "leading dims"):
+            self._call(r=_rand(_S, _B + 1, 1))
+
+    def test_rejects_wrong_bias_length(self):
+        with self.assertRaisesRegex(ValueError, "bias must be"):
+            self._call(bias=_rand(_P - 1))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/single_card_tests/custom_ops/test_fused_mhc_fwd_cast.py
+++ b/tests/single_card_tests/custom_ops/test_fused_mhc_fwd_cast.py
@@ -1,0 +1,223 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Numeric record for the mHC forward cast fusion.
+
+``HyperConnectionModule.forward`` used to materialize an fp32 copy of its whole
+``[..., n*C]`` input so ``fused_proj_rms`` and ``fused_h_aggregate`` could
+compute in fp32. With ``fuse_cast`` the input stays narrow and both kernels
+widen it in-register instead.
+
+These tests compare the two paths on identical values, forward and backward, and
+assert the per-tensor tolerances measured below. They are the documented record
+of what the fusion costs numerically -- if a tolerance here has to be loosened,
+that is a finding, not a test to adjust.
+
+Shapes match production: n=4, C=4096, so proj_rms reduces over K=16384.
+"""
+
+import unittest
+
+import paddle
+
+from paddlefleet.fusions.fused_mhc_kernels import is_cutile_available
+
+_S, _B, _N, _C = 4, 2, 4, 4096
+_K = _N * _C
+_NMAP = _N * _N + 2 * _N
+
+
+def _rand(*shape, dtype="float32"):
+    return paddle.randn(list(shape), dtype="float32").astype(dtype)
+
+
+def _small_int(*shape, dtype="float32"):
+    """Integers in [-8, 8].
+
+    Exact in bf16 (which represents integers up to 256) and in the tfloat32 the
+    mma truncates to, so every product is exact and every partial sum stays a
+    whole number well under 2**24. Summation is then exact regardless of the
+    order it happens in -- which is what makes bitwise equality a fair demand.
+    """
+    return paddle.randint(-8, 9, list(shape)).astype("float32").astype(dtype)
+
+
+def _cmp(ref, got):
+    """(bitwise, max_abs_diff, mean_abs_of_ref, relative)."""
+    a, b = ref.astype("float32"), got.astype("float32")
+    diff = float((a - b).abs().max())
+    scale = float(a.abs().mean())
+    return bool((a == b).all()), diff, scale, (diff / scale if scale else 0.0)
+
+
+class _FuseCastCase(unittest.TestCase):
+    """Shared check: run both paths, print the deltas, assert tolerances."""
+
+    # subclasses fill these in
+    TOL: dict = {}
+
+    def _run(self, fuse_cast, integer=False):  # pragma: no cover
+        raise NotImplementedError
+
+    def _check_exact(self):
+        """With exact arithmetic every tensor must match bitwise.
+
+        Reduction order is the one thing the fusion legitimately changes, and it
+        only shows up when the summation rounds. Feeding integers removes that
+        degree of freedom, so anything that still differs here is a real bug --
+        wrong dtype handling, wrong indexing, a dropped or duplicated term --
+        not the documented reassociation.
+        """
+        ref = self._run(fuse_cast=False, integer=True)
+        got = self._run(fuse_cast=True, integer=True)
+        for key in self.TOL:
+            bitwise, diff, scale, _ = _cmp(ref[key], got[key])
+            print(
+                f"  [exact] {key:<10} bitwise={bitwise!s:<5} "
+                f"max_abs={diff:.3e} max|val|={float(ref[key].astype('float32').abs().max()):.0f}"
+            )
+            self.assertTrue(
+                bitwise,
+                f"{key} differs under exact arithmetic, so the cause is not "
+                f"reduction order: max_abs={diff:.3e}",
+            )
+
+    def _check(self):
+        ref = self._run(fuse_cast=False)
+        got = self._run(fuse_cast=True)
+        for key, tol in self.TOL.items():
+            bitwise, diff, scale, rel = _cmp(ref[key], got[key])
+            print(
+                f"  {key:<10} bitwise={bitwise!s:<5} max_abs={diff:.3e} "
+                f"scale={scale:.3e} rel={rel:.2e} tol={tol:.0e}"
+            )
+            if tol == 0.0:
+                self.assertTrue(
+                    bitwise,
+                    f"{key} must be bitwise identical, rel={rel:.3e}",
+                )
+            else:
+                self.assertLess(
+                    rel, tol, f"{key} drifted past tolerance: rel={rel:.3e}"
+                )
+
+
+@unittest.skipUnless(is_cutile_available(), "cuTile not available")
+class TestProjRmsFuseCast(_FuseCastCase):
+    """fused_proj_rms: narrow input widened in-kernel vs widened in Python."""
+
+    # Measured: all four are bitwise identical. The mma truncates both
+    # operands to tfloat32 either way, and a bf16-valued tile survives that
+    # exactly, so widening in-register reproduces the Python-side widening.
+    TOL = {"proj": 0.0, "r": 0.0, "g_x": 0.0, "g_w": 0.0}
+
+    def _run(self, fuse_cast, integer=False):
+        from paddlefleet.fusions.fused_mhc_kernels import fused_proj_rms
+
+        paddle.seed(11)
+        mk = _small_int if integer else _rand
+        # Both leaves are bf16: that is how they exist in the real graph
+        # (mapping_proj.weight follows the global default dtype).
+        x_leaf = mk(_S, _B, _K, dtype="bfloat16")
+        w_leaf = mk(_K, _NMAP, dtype="bfloat16")
+        for t in (x_leaf, w_leaf):
+            t.stop_gradient = False
+
+        if fuse_cast:
+            x, w = x_leaf, w_leaf
+        else:
+            x, w = x_leaf.astype("float32"), w_leaf.astype("float32")
+
+        proj, r = fused_proj_rms(x, w, 1e-6, fuse_cast=fuse_cast)
+        # weight both outputs so neither gradient path is left untested
+        (proj.astype("float32").sum() + r.astype("float32").sum()).backward()
+        return {
+            "proj": proj,
+            "r": r,
+            "g_x": x_leaf.grad,
+            "g_w": w_leaf.grad,
+            "_proj_dtype": proj.dtype,
+            "_r_dtype": r.dtype,
+            "_g_x_dtype": x_leaf.grad.dtype,
+        }
+
+    def test_precision(self):
+        self._check()
+
+    def test_exact_arithmetic_is_bitwise(self):
+        self._check_exact()
+
+    def test_dtypes(self):
+        got = self._run(fuse_cast=True)
+        # proj / r must stay fp32: _compute_h builds h_res / h_post from them,
+        # and narrowing them would silently undo high_precision_mhc.
+        self.assertEqual(got["_proj_dtype"], paddle.float32)
+        self.assertEqual(got["_r_dtype"], paddle.float32)
+        # the gradient goes back to a bf16 leaf
+        self.assertEqual(got["_g_x_dtype"], paddle.bfloat16)
+
+
+@unittest.skipUnless(is_cutile_available(), "cuTile not available")
+class TestHAggregateFuseCast(_FuseCastCase):
+    """fused_h_aggregate: narrow x widened in-kernel vs widened in Python."""
+
+    # Measured: forward and g_x are bitwise identical; g_h_pre is not, since
+    # it is the one value reduced over TILE_C and the narrower tiles let
+    # cuTile reschedule that reduction. ~3e-07 relative, i.e. fp32 ULP and
+    # four orders below bf16 resolution.
+    TOL = {"aggregated": 0.0, "g_x": 0.0, "g_h_pre": 1e-6}
+
+    def _run(self, fuse_cast, integer=False):
+        from paddlefleet.fusions.fused_mhc_kernels import fused_h_aggregate
+
+        paddle.seed(13)
+        mk = _small_int if integer else _rand
+        x_leaf = mk(_S, _B, _N, _C, dtype="bfloat16")
+        # h_pre is fp32 under high_precision_mhc regardless of the fusion
+        h_pre = mk(_S, _B, _N)
+        for t in (x_leaf, h_pre):
+            t.stop_gradient = False
+
+        x = x_leaf if fuse_cast else x_leaf.astype("float32")
+        out = fused_h_aggregate(x, h_pre, fuse_cast=fuse_cast)
+        # the caller brings the result back to the residual dtype either way
+        casted = out.to("bfloat16")
+        (casted.astype("float32") * 1.0).sum().backward()
+        return {
+            "aggregated": casted,
+            "g_x": x_leaf.grad,
+            "g_h_pre": h_pre.grad,
+            "_out_dtype": out.dtype,
+            "_g_x_dtype": x_leaf.grad.dtype,
+            "_g_h_pre_dtype": h_pre.grad.dtype,
+        }
+
+    def test_precision(self):
+        self._check()
+
+    def test_exact_arithmetic_is_bitwise(self):
+        self._check_exact()
+
+    def test_dtypes(self):
+        got = self._run(fuse_cast=True)
+        # aggregated follows x: its consumer is the bf16 layernorm, and the
+        # caller was going to round it there anyway
+        self.assertEqual(got["_out_dtype"], paddle.bfloat16)
+        self.assertEqual(got["_g_x_dtype"], paddle.bfloat16)
+        # h_pre stays fp32, so its gradient cannot follow x
+        self.assertEqual(got["_g_h_pre_dtype"], paddle.float32)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/transformer/test_mhc_compute_h_native.py
+++ b/tests/single_card_tests/transformer/test_mhc_compute_h_native.py
@@ -1,0 +1,281 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``native_compute_h`` and the mHC operator dispatch, without cuTile.
+
+The fused mHC tests are all gated behind ``is_cutile_available()``, so on a
+runner without ``cuda.tile`` they skip and leave the mapping head untested.
+Everything checked here runs on any GPU: the reference implementation
+``native_compute_h`` -- which is also what the fused kernel is validated
+against -- plus the dispatch that decides which implementation a module
+instance gets and whether its operands are widened in Python or in-register.
+
+The dispatch assertions are the cheap guard that matters: they are what catches
+a configuration being silently routed to the wrong implementation, which no
+amount of kernel-level testing would notice.
+"""
+
+import unittest
+
+import paddle
+
+import paddlefleet.transformer.hyper_connection as hc
+from paddlefleet.tensor_parallel.random import get_cuda_rng_tracker
+from paddlefleet.transformer.hyper_connection import (
+    HyperConnectionModule,
+    native_compute_h,
+    native_h_aggregate,
+    native_h_post_bda,
+    native_proj_rms,
+    native_sinkhorn,
+)
+from paddlefleet.transformer.transformer_config import TransformerConfig
+
+_S, _B, _N = 4, 2, 4
+_P = _N * _N + 2 * _N
+_C = 64
+_EPS = 1e-6
+
+
+def _config(**kw):
+    """Minimal config that satisfies the mHC field validation."""
+    base = {
+        "num_hidden_layers": 2,
+        "hidden_size": _C,
+        "num_attention_heads": 4,
+        "enable_hyper_connections": True,
+        "num_residual_streams": _N,
+    }
+    base.update(kw)
+    return TransformerConfig(**base)
+
+
+def _module(**kw):
+    """Build a module, tolerating a distributed env with world_size > 1.
+
+    ``_init_weights`` forks the model-parallel RNG tracker whenever
+    ``get_world_size() > 1``, which a single-process test has not seeded. CI
+    runs with world_size 1 and never hits this; inside a multi-node job
+    container the env vars say otherwise, and without the seed the constructor
+    would raise before any assertion runs.
+    """
+    tracker = get_cuda_rng_tracker()
+    if "model-parallel-rng" not in tracker.states_:
+        tracker.add("model-parallel-rng", 1)
+    return HyperConnectionModule(_config(**kw), layer_number=1)
+
+
+def _inputs(dtype="float32"):
+    paddle.seed(23)
+    proj = paddle.randn([_S, _B, _P], dtype=dtype)
+    # r is 1 / (||x|| / sqrt(K) + eps): positive and O(1)
+    r = paddle.randn([_S, _B, 1], dtype=dtype).abs() + 1.0
+    alpha_pre = paddle.randn([1], dtype=dtype)
+    alpha_post = paddle.randn([1], dtype=dtype)
+    alpha_res = paddle.randn([1], dtype=dtype)
+    bias = paddle.randn([_P], dtype=dtype)
+    return proj, r, alpha_pre, alpha_post, alpha_res, bias
+
+
+class TestNativeComputeH(unittest.TestCase):
+    """The reference mapping head: Eq. (5) of the mHC paper."""
+
+    def test_matches_written_out_formula(self):
+        """Bitwise against the expression the docstring claims to implement."""
+        proj, r, a_pre, a_post, a_res, bias = _inputs()
+        h_pre, h_post, h_res = native_compute_h(
+            proj, r, a_pre, a_post, a_res, bias, _N, _EPS
+        )
+
+        alpha = paddle.concat(
+            [
+                a_pre.expand([_N]),
+                a_post.expand([_N]),
+                a_res.expand([_N * _N]),
+            ],
+            axis=-1,
+        )
+        u = r * proj * alpha + bias
+        self.assertTrue(paddle.equal_all(h_pre, u[..., :_N].sigmoid() + _EPS))
+        self.assertTrue(
+            paddle.equal_all(h_post, u[..., _N : 2 * _N].sigmoid() * 2)
+        )
+        self.assertTrue(paddle.equal_all(h_res, u[..., 2 * _N :]))
+
+    def test_shapes_and_ranges(self):
+        proj, r, a_pre, a_post, a_res, bias = _inputs()
+        h_pre, h_post, h_res = native_compute_h(
+            proj, r, a_pre, a_post, a_res, bias, _N, _EPS
+        )
+        self.assertEqual(h_pre.shape, [_S, _B, _N])
+        self.assertEqual(h_post.shape, [_S, _B, _N])
+        self.assertEqual(h_res.shape, [_S, _B, _N * _N])
+        # h_pre is sigmoid + eps, h_post is 2 * sigmoid; h_res is unactivated
+        self.assertGreater(float(h_pre.min()), _EPS)
+        self.assertLess(float(h_pre.max()), 1.0 + _EPS)
+        self.assertGreater(float(h_post.min()), 0.0)
+        self.assertLess(float(h_post.max()), 2.0)
+
+    def test_backward_reaches_every_input(self):
+        proj, r, a_pre, a_post, a_res, bias = _inputs()
+        leaves = [proj, r, a_pre, a_post, a_res, bias]
+        for t in leaves:
+            t.stop_gradient = False
+        h_pre, h_post, h_res = native_compute_h(
+            proj, r, a_pre, a_post, a_res, bias, _N, _EPS
+        )
+        # weight the heads unequally so no gradient path cancels out
+        (h_pre.sum() + 2.0 * h_post.sum() + 3.0 * h_res.sum()).backward()
+        for name, t in zip(
+            ("proj", "r", "alpha_pre", "alpha_post", "alpha_res", "bias"),
+            leaves,
+        ):
+            self.assertIsNotNone(t.grad, name)
+            self.assertEqual(t.grad.shape, t.shape, name)
+            self.assertTrue(bool(t.grad.abs().sum() > 0), name)
+
+    def test_fma_probe_rounds_once(self):
+        """``_fma_probe`` must round ``t1 * alpha + bias`` exactly once.
+
+        This is the discriminator the fused tests use to separate the kernel's
+        FMA contraction from a real defect, so the branch needs to do what it
+        claims: match an fp64 single-rounding reference bitwise, while the
+        default path -- which rounds twice -- generally does not.
+        """
+        proj, r, a_pre, a_post, a_res, bias = _inputs()
+        alpha = paddle.concat(
+            [
+                a_pre.expand([_N]),
+                a_post.expand([_N]),
+                a_res.expand([_N * _N]),
+            ],
+            axis=-1,
+        )
+        t1 = r * proj
+        fused_mul_add = (
+            t1.astype("float64") * alpha.astype("float64")
+            + bias.astype("float64")
+        ).astype(proj.dtype)
+        expected = fused_mul_add[..., 2 * _N :]
+
+        _, _, probe_res = native_compute_h(
+            proj, r, a_pre, a_post, a_res, bias, _N, _EPS, _fma_probe=True
+        )
+        self.assertTrue(paddle.equal_all(probe_res, expected))
+
+        _, _, plain_res = native_compute_h(
+            proj, r, a_pre, a_post, a_res, bias, _N, _EPS
+        )
+        # same values to fp32 ULP, but reached with one rounding fewer
+        self.assertTrue(bool((plain_res - probe_res).abs().max() < 1e-5 * _P))
+
+
+class TestOperatorDispatch(unittest.TestCase):
+    """Which implementation a module gets, and who widens its operands.
+
+    No kernel runs here -- only the binding is inspected -- so this holds with
+    or without cuTile installed.
+    """
+
+    def test_native_config_binds_reference_ops(self):
+        m = _module(use_fused_mhc=False)
+        self.assertIs(m._sinkhorn_op, native_sinkhorn)
+        self.assertIs(m._h_aggregate_op, native_h_aggregate)
+        self.assertIs(m._h_post_bda_op, native_h_post_bda)
+        self.assertIs(m._proj_rms_op, native_proj_rms)
+        self.assertIs(m._compute_h_op, native_compute_h)
+        # a plain op composition cannot absorb a widening
+        self.assertFalse(m._widen_in_kernel)
+
+    def test_fused_config_binds_fused_ops(self):
+        from paddlefleet.fusions.fused_mhc_kernels import (
+            fused_compute_h,
+            fused_h_aggregate,
+            fused_h_post_bda,
+            fused_proj_rms,
+            fused_sinkhorn,
+        )
+
+        m = _module(use_fused_mhc=True)
+        self.assertIs(m._sinkhorn_op, fused_sinkhorn)
+        self.assertIs(m._h_aggregate_op, fused_h_aggregate)
+        self.assertIs(m._h_post_bda_op, fused_h_post_bda)
+        self.assertIs(m._proj_rms_op, fused_proj_rms)
+        self.assertIs(m._compute_h_op, fused_compute_h)
+
+    def test_widen_in_kernel_follows_high_precision_mhc(self):
+        """Only high_precision_mhc has a widening for the kernel to absorb.
+
+        With it off the reference keeps the arithmetic in the incoming dtype,
+        so the kernel must too, or the fusion would silently promote it.
+        """
+        self.assertTrue(
+            _module(
+                use_fused_mhc=True, high_precision_mhc=True
+            )._widen_in_kernel
+        )
+        self.assertFalse(
+            _module(
+                use_fused_mhc=True, high_precision_mhc=False
+            )._widen_in_kernel
+        )
+
+    def test_accuracy_compatible_mode_keeps_the_reference(self):
+        """The Megatron-alignment mode must not reach the fused head.
+
+        ``_projection_and_get_norm``, ``aggregate`` and the BDA site all fall
+        back to the reference under this switch. The mapping head has to match:
+        the fused head's FMA contraction alone is enough to break the alignment
+        contract, whatever the tolerances elsewhere say.
+        """
+        prev = hc._ACCURACY_COMPATIBLE_KERNEL
+        hc._ACCURACY_COMPATIBLE_KERNEL = True
+        try:
+            self.assertIs(
+                _module(use_fused_mhc=True)._compute_h_op, native_compute_h
+            )
+        finally:
+            hc._ACCURACY_COMPATIBLE_KERNEL = prev
+        # and the switch is what made the difference, not the config
+        self.assertIsNot(
+            _module(use_fused_mhc=True)._compute_h_op, native_compute_h
+        )
+
+
+class TestBdaSpanPaysOff(unittest.TestCase):
+    """The recompute-span cost/benefit predicate.
+
+    It decides whether ``_fused_h_res_h_post_bda`` is wrapped in a
+    ``RecomputeWithoutOutput`` span, so a wrong answer either wastes memory or
+    pays for a replay that saves nothing. Each branch is pinned separately.
+    """
+
+    def test_dropout_alone_is_enough(self):
+        """The mask is one byte per element of the [..., n*C] output."""
+        m = _module(use_fused_mhc=True, high_precision_mhc=False)
+        self.assertTrue(m.bda_span_pays_off(0.1, training=True))
+        # not in eval: no mask is kept
+        self.assertFalse(m.bda_span_pays_off(0.1, training=False))
+
+    def test_without_high_precision_nothing_to_hide(self):
+        m = _module(use_fused_mhc=True, high_precision_mhc=False)
+        self.assertFalse(m.bda_span_pays_off(0.0, training=True))
+
+    def test_high_precision_pays(self):
+        m = _module(use_fused_mhc=True, high_precision_mhc=True)
+        self.assertTrue(m.bda_span_pays_off(0.0, training=True))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### PR Category
Performance Optimization

### PR Types
Performance

### Description
mHC 块此前为了让 cuTile kernel 在 fp32 下计算，会在 Python 侧物化它最大几个张量的 fp32 副本：forward 里整个 `[..., n*C]` 的输入，以及 h_post_bda 里的 residual 和 layer output。现在这些操作数直接以原 dtype 传进 kernel，由 kernel 在寄存器里加宽。

两项融合：

1. **cast 融合**（`fused_proj_rms` / `fused_h_aggregate` / `fused_h_post_bda`）新增 `UPCAST_INPUTS: ct.Constant[bool]` 编译期常量，为 True 时在寄存器内加宽。该 guard 在关闭时会被完整折叠掉，因此**同一份 kernel 源码同时服务 `high_precision_mhc` 的开与关两条路径**，不需要复制 kernel。`test_fused_mhc_bda_cast.py::TestConstGuard` 专门验证了这一点：guard 关闭时生成的结果与一份从未写过加宽逻辑的 kernel 逐位相同。

2. **`fused_compute_h`** 把 mapping head 的 `expand x3 -> concat -> mul -> mul -> add -> sigmoid x2` 链替换为单个 kernel，每次调用约 10 次 launch 收成 1 次。alpha 向量不再物化：`n` 是编译期常量，每个输出段直接用自己的标量。

h_post_bda 带 bias 时主动放弃 cast 融合：`g_bias` 是在 kernel 之外对 `g_x` 做的归约，`g_x` 变窄会带来 bf16 量级（而非 ULP 量级）的精度损失。

新增三个单测文件，共 17 个 case，覆盖前反向数值、dtype 约定、编译期 guard 折叠，以及 `train_indexer_only` 下参数被冻结时 backward 需要返回 None 的情况。

### 是否引起精度变化
是。前向输出与所有 per-token 梯度逐位相同；有差异的只有两类，均已在单测中固化为容差并附测量值：

| 张量 | 结果 |
| --- | --- |
| `proj` / `r` / `g_x` / `g_w`（proj_rms） | 逐位相同 |
| `aggregated` / `g_x`（h_aggregate） | 逐位相同 |
| `out` / `g_res` / `g_x`（h_post_bda） | 逐位相同 |
| `g_h_pre` | ~3e-07 相对 |
| `g_h_res` / `g_h_post` | ~2e-07 相对（C=4096 实测） |
| compute_h `h_pre`/`h_post`/`h_res`/`g_proj`/`g_r` | 1.0e-07 / 1.5e-07 / 2.6e-07 / 6.3e-08 / 3.7e-07 |
| compute_h `g_alpha_*` / `g_bias` | 4.7e-03，即 bf16 在该量级下的 1 个 ULP |

两个来源：

1. **归约重结合**：tile 变窄后 cuTile 为 `ct.sum` 选了不同的归约树。这是 fp32 ULP 量级，比 bf16 的分辨率低约 3~4 个数量级。
2. **FMA 收缩**：kernel 把 `r * proj * alpha + bias` 收成一次 FMA，只 round 一次，而参考实现 round 两次。让参考实现也只 round 一次后，两者逐位相同（`test_fma_probe_makes_it_bitwise`）。

关键是这两者都不是 bug：喂整数输入（每次加法都精确、grouping 无从生效）时，所有路径逐位相同（各文件的 `test_exact_arithmetic_is_bitwise`）。这就把「重结合」与「索引错误 / dtype 处理错误」区分开了。

`g_alpha_*` / `g_bias` 那 4.7e-03 是输出 dtype 的分辨率下限：这两个梯度按参数 dtype 返回 bf16，在其量级附近 bf16 的间距本身就是 ~4e-03，上游一点 fp32 差异落到 bf16 上就是整整一步。对 bf16 输出要求 fp32-ULP 一致是超出该 dtype 的精度。


---

release/0.4 分支的同一改动，对应 develop 的 #1793，内容逐字相同（`fused_mhc_kernels.py` 两分支一致；`hyper_connection.py` 的分支间差异在 `_init_weights` 注释与 `magic_send` 段，与本改动无关）。
