### PR TITLE
[Deps] Bump Paddle to `ff058482e72`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ description = "Fleet Core - Core Functional Library for Large Scale Distributed 
 requires-python = ">=3.10"
 dependencies = [
     "colorlog>=6.10.1",
-    "paddlepaddle-gpu==3.4.0.post20260812+a136cd3594a",
+    "paddlepaddle-gpu==3.4.0.post20260819+ff058482e72",
     "ruamel.yaml>=0.17",
     "tilelang-paddle==0.1.12",
 ]


### PR DESCRIPTION
### PR Category
Environment Adaptation

### PR Types
Others

### Description
Bump the pinned CUDA 12.9 Paddle dependency from `paddlepaddle-gpu==3.4.0.post20260812+a136cd3594a` to `paddlepaddle-gpu==3.4.0.post20260819+ff058482e72`.

Target Paddle commit: [`ff058482e726e7ea5356d2c42de8afd3b327efd6`](https://github.com/PaddlePaddle/Paddle/commit/ff058482e726e7ea5356d2c42de8afd3b327efd6), verified on Paddle's `release/3.4` branch.

**Artifact verification:** the official CUDA 12.9 CPython 3.12 Linux x86_64 [wheel](https://paddle-whl.bj.bcebos.com/nightly/cu129/paddlepaddle-gpu/paddlepaddle_gpu-3.4.0.post20260819%2Bff058482e72-cp312-cp312-linux_x86_64.whl) required by the current PaddleFleet dependency CI returns HTTP 200. Its wheel metadata reports `paddlepaddle-gpu` version `3.4.0.post20260819+ff058482e72`, CUDA 12.9, and full commit `ff058482e726e7ea5356d2c42de8afd3b327efd6`.

**Local validation:** TOML and PEP 508 parsing, `git diff --check`, exact one-file/one-line delta, independent-base review, and `pre-commit run --files pyproject.toml` all pass.

### 是否引起精度变化
否
