### PR TITLE
[CI] Use HongKong-Clone runner group

### DIFF
--- a/.github/workflows/_clone.yml
+++ b/.github/workflows/_clone.yml
@@ -39,7 +39,7 @@ jobs:
     name: Clone Paddle
     if: ${{ github.repository_owner == 'PaddlePaddle' }}
     runs-on:
-      group: HK-Clone
+      group: HongKong-Clone
     steps:
       - name: Clone paddle
         uses: actions/checkout@v6


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Improvements

### Description
Replace the obsolete `HK-Clone` GitHub Actions runner group with `HongKong-Clone` in `.github/workflows/_clone.yml`.

Validation: confirmed the diff is limited to this workflow file and no `HK-Clone` runner group remains under `.github/workflows/`.

### 是否引起精度变化
否
