### PR TITLE
[alignment] add KimiK2_EP2 precision alignment case

### DIFF
--- a/scripts/alignment_model_accuracy/KimiK2_EP2/KimiK2.yaml
+++ b/scripts/alignment_model_accuracy/KimiK2_EP2/KimiK2.yaml
@@ -1,0 +1,77 @@
+### data
+train_dataset_type: erniekit
+eval_dataset_type: erniekit
+train_dataset_path: /home/.cache/PaddleFormers/Kimi-K2-bf16_2EP/alignment_paddle.jsonl
+train_dataset_prob: "1.0"
+eval_dataset_path: /home/.cache/PaddleFormers/Kimi-K2-bf16_2EP/alignment_paddle.jsonl
+eval_dataset_prob: "1.0"
+max_seq_len: 8192
+dataset_type: map
+packing: false
+truncate_packing: false
+truncation_strategy: right
+mix_strategy: concat
+random_shuffle: false
+dataloader_shuffle: false
+use_template: false
+dataloader_num_workers: 4
+
+### model
+model_name_or_path: /home/.cache/PaddleFormers/Kimi-K2-bf16_2EP
+_attn_implementation: eager
+apply_rope_fusion: false
+
+### finetuning
+stage: SFT
+fine_tuning: full
+seed: 23
+do_train: true
+do_eval: false
+per_device_eval_batch_size: 1
+per_device_train_batch_size: 1
+num_train_epochs: 1
+# 单 step md5 对齐：监控用例固定单 step（step1 前向 loss），只校验首个 step；
+# 多 step 反向的 bf16 累加差异（bf16 精度极限）会被严格 md5 判为不一致。
+# 注：2 卡 EP2 配置的 step1 md5 基线需首次 smoke 后确立（此前 bit-exact 结论来自 8 卡 TP8/EP8）。
+max_steps: 1
+eval_steps: 200
+evaluation_strategy: steps
+save_steps: 300
+save_strategy: steps
+logging_steps: 1
+gradient_accumulation_steps: 1
+logging_dir: ./logs/paddle/default/vdl
+output_dir: ./logs/paddle/default/trainer
+disable_tqdm: true
+eval_accumulation_steps: 16
+
+# train - 与 MG 对齐
+warmup_steps: 0
+learning_rate: 1.0e-5
+
+# performance - 单机 2 卡 TP=1 / EP=2 / PP=1 与 MG 对齐
+tensor_model_parallel_size: 1
+sequence_parallel: false
+pipeline_model_parallel_size: 1
+expert_model_parallel_size: 2
+use_expert_parallel: true
+recompute_granularity: "full"
+recompute_method: uniform
+recompute_num_layers: 1
+bf16: true
+amp_master_grad: true
+fp16_opt_level: O2
+unified_checkpoint: false
+save_checkpoint_format: flex_checkpoint
+load_checkpoint_format: flex_checkpoint
+continue_training: true
+
+# MoE - 与 MG 对齐（aux loss 置 0，关闭所有 fusion 以走可比对的 unfused 路径）
+router_aux_loss_coef: 0.0
+moe_expert_fusion: false
+moe_shared_expert_overlap: false
+moe_token_dispatcher_type: alltoall
+moe_router_bias_update_rate: 0.0
+
+# 精度对齐锚点：打印 per_token_loss / final_loss 的 md5，供 compare_loss.py 逐 step 比对
+use_accuracy_compatible: true

--- a/scripts/alignment_model_accuracy/KimiK2_EP2/README.md
+++ b/scripts/alignment_model_accuracy/KimiK2_EP2/README.md
@@ -1,0 +1,98 @@
+# KimiK2_EP2 对齐用例
+
+Kimi-K2 在 **PaddleFormers+PaddleFleet ↔ ms-swift+Megatron-LM** 下的精度对齐监控用例，
+接入 `scripts/alignment_model_accuracy/` 框架（见上级 `README.md`）。
+配置约定对标同目录 `GLM45Air_EP2`（TP=1/EP=2/PP=1，单机 2 卡）。
+
+## 文件
+
+| 文件 | 说明 |
+|---|---|
+| `KimiK2.yaml` | paddle 侧训练配置（TP=1/EP=2/PP=1，SFT，`use_accuracy_compatible: true`，单 step）|
+| `run_paddle_kimik2.sh` | paddle 侧启动：清分布式 env + 对齐 flags + `paddleformers-cli train` |
+| `run_torch_kimik2.sh` | torch 侧启动：对齐 flags + `megatron sft <ARGS>` |
+
+## 注册到测试入口
+
+`scripts/alignment_model_accuracy/run_alignment_test.sh` 的 `CASES` 数组中本用例
+**当前是注释状态**，待首次 smoke 确立 step1 md5 基线后再放开：
+
+```bash
+CASES=(
+    "MinimaxV2.5_EP2 ./MinimaxV2.5_EP2/run_paddle_minimax.sh ./MinimaxV2.5_EP2/run_torch_minimax.sh"
+    "GLM45Air_EP2 ./GLM45Air_EP2/run_paddle_glm45.sh ./GLM45Air_EP2/run_torch_glm45.sh"
+    # "KimiK2_EP2 ./KimiK2_EP2/run_paddle_kimik2.sh ./KimiK2_EP2/run_torch_kimik2.sh"
+)
+```
+
+也可绕过入口单独跑：先 `bash KimiK2_EP2/run_paddle_kimik2.sh`，再
+`bash KimiK2_EP2/run_torch_kimik2.sh`，最后 `python3 compare_loss.py logs/paddle logs/torch`。
+
+## 判定口径：单 step md5
+
+- 判定依据：`compare_loss.py` 解析两侧日志的 `per_token_loss`/`final_loss` md5，逐 step 要求完全一致。
+- 本用例固定 `max_steps=1`/`train_iters=1`，只监控首个 step 的前向 loss md5；多 step 反向的
+  bf16 累加差异（bf16 精度极限，非算法 bug）会被严格 md5 判为不一致。
+- 注：2 卡 EP2 配置的 step1 md5 基线需首次 smoke 后确立（既往 bit-exact 结论来自 8 卡 TP8/EP8 复现）。
+
+## 两侧关键配置对应关系
+
+为让严格 md5 可比，以下项两侧必须成对出现，改动任一侧都要同步另一侧：
+
+| 项 | paddle (`KimiK2.yaml`) | torch (`run_torch_kimik2.sh`) |
+|---|---|---|
+| attention | `_attn_implementation: eager` | `--attention_backend unfused` + `NVTE_FLASH_ATTN=0` / `NVTE_FUSED_ATTN=0` |
+| template | `use_template: false` | `--template dummy --template_backend swift` |
+| 截断 | `truncation_strategy: right` | `--truncation_strategy right` |
+| 样本顺序 | `mix_strategy: concat` / `random_shuffle: false` / `dataloader_shuffle: false` | `--dataset_shuffle False --train_dataloader_shuffle False` |
+| MoE aux loss | `router_aux_loss_coef: 0.0` | `--moe_aux_loss_coeff 0` |
+| MoE fusion | `moe_expert_fusion: false` / `moe_shared_expert_overlap: false` | `--moe_grouped_gemm False --moe_permute_fusion False` |
+| dispatcher | `moe_token_dispatcher_type: alltoall` | `--moe_token_dispatcher_type alltoall` |
+| rope | `apply_rope_fusion: false` | 未开 rope fusion |
+| 梯度累加 | `amp_master_grad: true` | `--accumulate_allreduce_grads_in_fp32 True` |
+| 梯度裁剪 | 默认 `max_grad_norm: 1.0` | `--clip_grad 1.0` |
+| 优化器 | 不开 offload / 不开 sharding | `--use_precision_aware_optimizer False --use_distributed_optimizer False` |
+
+## 端口分配
+
+框架内各用例串行执行但端口独占，避免残留连接互相干扰：
+
+| 用例 | paddle | torch |
+|---|---|---|
+| MinimaxV2.5_EP2 | 29501 | 29500 |
+| GLM45Air_EP2 | 29503 | 29502 |
+| KimiK2_EP2 | 29505 | 29504 |
+
+## 逐层 md5 hook（默认关闭）
+
+排查首个 diff 层时按需打开，会产生大量 IO：
+
+```bash
+ENABLE_SAVE_HOOK=1 SAVE_TENSOR_GRAD=1 bash KimiK2_EP2/run_paddle_kimik2.sh
+```
+
+paddle 侧落到 `logs/pf/`，torch 侧落到 `logs/mg/`。
+
+## 依赖资产（运行前需 stage 到缓存目录，可用环境变量覆盖）
+
+| 资产 | 默认路径 | 覆盖方式 |
+|---|---|---|
+| PF ckpt（flex_checkpoint）| `/home/.cache/PaddleFormers/Kimi-K2-bf16_2EP` | 改 `KimiK2.yaml` 的 `model_name_or_path` |
+| PF 对齐数据 | `/home/.cache/PaddleFormers/Kimi-K2-bf16_2EP/alignment_paddle.jsonl` | 改 `KimiK2.yaml` 的 `train/eval_dataset_path` |
+| MG ckpt（mcore）| `/home/.cache/PaddleFormers/Kimi-K2-bf16_2EP` | 环境变量 `KIMIK2_MODEL` |
+| MG 对齐数据 | `/home/.cache/PaddleFormers/Kimi-K2-bf16_2EP/alignment_torch.jsonl` | 环境变量 `KIMIK2_DATASET` |
+| Megatron-LM | `${WORKSPACE_DIR}/Megatron-LM` | 环境变量 `KIMIK2_MEGATRON_LM_PATH` |
+
+> 路径沿用框架内既有用例的 `/home/.cache/PaddleFormers/` 约定，不写死任何个人共享盘路径；
+> 运行方按上表把 Kimi-K2 权重/数据 stage 到对应缓存目录，或用环境变量指向实际位置。
+
+## 已知前置 / 未验证项
+
+- 需单机 2 卡空闲；框架 venv（`venv/paddle`、`venv/torch`）由上级 `setup_venvs.sh` 构建。
+- 本用例在既有 Kimi-K2 PF↔MG 精度对齐基础上，按 2 卡 TP=1/EP=2/PP=1 整理而来，
+  但**尚未在本框架 venv 下端到端跑通验证**；落地时需先 smoke 一次确认 md5 锚点正常打印并确立 step1 基线，
+  之后才放开 `run_alignment_test.sh` 里的 `CASES` 注册。
+- 若两侧日志未出现 `per_token_loss:`/`final_loss:` 锚点，检查 paddle 侧
+  `use_accuracy_compatible`/`FLAGS_use_accuracy_compatible_kernel` 与 torch 侧 `--use_accuracy_compatible`。
+- paddle 侧脚本先 `unset MASTER_PORT` 再取默认值，因此外部传入的 `MASTER_PORT` 不生效（与同目录既有用例同源行为）。
+- torch 侧 `--torch_dtype float32` 配 `--bf16 True` 沿用 Megatron master weight 惯例，未单独验证可否去掉。

--- a/scripts/alignment_model_accuracy/KimiK2_EP2/run_paddle_kimik2.sh
+++ b/scripts/alignment_model_accuracy/KimiK2_EP2/run_paddle_kimik2.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+# Kimi-K2 (PaddleFormers + PaddleFleet) 单机 2 卡精度对齐用例 —— paddle 侧
+# 对标 GLM45Air_EP2/run_paddle_glm45.sh（TP=1/EP=2/PP=1）
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE_DIR="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+CONFIG="${SCRIPT_DIR}/KimiK2.yaml"
+
+# ---- 环境 ----
+# shellcheck disable=SC1091
+source "${WORKSPACE_DIR}/venv/paddle/bin/activate"
+cd "${WORKSPACE_DIR}"
+
+# Match scripts/run_paddle.sh: clear stale distributed envs before launching.
+unset PADDLE_ELASTIC_JOB_ID
+unset PADDLE_ELASTIC_TIMEOUT
+unset PADDLE_TRAINER_ENDPOINTS
+unset DISTRIBUTED_TRAINER_ENDPOINTS
+unset PADDLE_CURRENT_ENDPOINT
+unset PADDLE_TRAINERS_NUM
+unset PADDLE_TRAINER_ID
+unset PADDLE_RANK_IN_NODE
+unset PADDLE_LOCAL_DEVICE_IDS
+unset PADDLE_DISTRI_BACKEND
+unset FLAGS_START_PORT
+unset NVSHMEM_ENABLE_NIC_PE_MAPPING
+unset MASTER_ADDR
+unset MASTER_PORT
+unset NNODES
+unset RANK
+unset WORLD_SIZE
+unset NODE_RANK
+unset NPROC_PER_NODE
+unset LOCAL_RANK
+unset LOCAL_WORLD_SIZE
+
+export CUDA_VISIBLE_DEVICES=0,1
+export MASTER_ADDR="127.0.0.1"
+# 端口按用例错开：Minimax 29501 / GLM45Air 29503 / KimiK2 29505
+export MASTER_PORT="${MASTER_PORT:-29505}"
+
+# 单机 2 卡：TP=1 / EP=2 / PP=1
+export NNODES="1"
+export RANK="0"
+export NODE_RANK="0"
+export NPROC_PER_NODE="2"
+export WORLD_SIZE="2"
+export LOCAL_WORLD_SIZE="2"
+
+# Match canonical Paddle alignment runtime knobs from scripts/run_paddle.sh.
+export FLAGS_use_accuracy_compatible_kernel="1"
+export USE_ACCURACY_COMPATIBLE="1"
+export FLAGS_set_to_1d="False"
+export FLAGS_dataloader_use_file_descriptor="False"
+export CUBLAS_WORKSPACE_CONFIG=":4096:8"
+# 本机 NVLS multicast 内存注册失败（CUDA error 401），NCCL init 会直接崩：
+# "Failed to bind NVLink SHARP (NVLS) Multicast memory ... Disable NVLS (NCCL_NVLS_ENABLE=0)"
+export NCCL_NVLS_ENABLE=0
+export NVIDIA_TF32_OVERRIDE=0
+
+# ---- 精度对齐 Flag ----
+export FLAGS_embedding_deterministic="1"
+export FLAGS_cudnn_deterministic="1"
+
+# ---- 精度对齐：逐层输出 md5（默认关闭，排查时按需打开）----
+export ENABLE_SAVE_HOOK="${ENABLE_SAVE_HOOK:-0}"
+export ENABLE_BACKWARD_HOOK="${ENABLE_BACKWARD_HOOK:-0}"
+export SAVE_TENSOR_GRAD="${SAVE_TENSOR_GRAD:-0}"
+export SAVE_TENSOR_SAVE_NPY="${SAVE_TENSOR_SAVE_NPY:-0}"
+export SAVE_TENSOR_NAMES=output,grad,input
+
+RUN_TS="$(date +%Y%m%d-%H%M%S)"
+export PADDLEFORMERS_DIST_LOG="${WORKSPACE_DIR}/logs/paddle/${RUN_TS}"
+export PF_TENSOR_DEBUG_DIR="${WORKSPACE_DIR}/logs/pf"
+mkdir -p "${PADDLEFORMERS_DIST_LOG}" "${PF_TENSOR_DEBUG_DIR}"
+
+exec "${WORKSPACE_DIR}/venv/paddle/bin/paddleformers-cli" train "${CONFIG}"

--- a/scripts/alignment_model_accuracy/KimiK2_EP2/run_torch_kimik2.sh
+++ b/scripts/alignment_model_accuracy/KimiK2_EP2/run_torch_kimik2.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+# Kimi-K2 (ms-swift + Megatron-LM) 单机 2 卡精度对齐用例 —— torch 侧
+# 对标 GLM45Air_EP2/run_torch_glm45.sh（TP=1/EP=2/PP=1）
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE_DIR="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+
+# 资产路径（可用环境变量覆盖；默认放在 torch 侧缓存目录）
+KIMIK2_MODEL="${KIMIK2_MODEL:-/home/.cache/PaddleFormers/Kimi-K2-bf16_2EP}"
+KIMIK2_DATASET="${KIMIK2_DATASET:-/home/.cache/PaddleFormers/Kimi-K2-bf16_2EP/alignment_torch.jsonl}"
+
+# ---- 环境 ----
+# shellcheck disable=SC1091
+source "${WORKSPACE_DIR}/venv/torch/bin/activate"
+cd "${WORKSPACE_DIR}"
+
+export KIMIK2_MEGATRON_LM_PATH="${KIMIK2_MEGATRON_LM_PATH:-${WORKSPACE_DIR}/Megatron-LM}"
+export MEGATRON_LM_PATH="${KIMIK2_MEGATRON_LM_PATH}"
+
+# 单机 2 卡：TP=1 / EP=2 / PP=1
+export CUDA_VISIBLE_DEVICES=0,1
+export NPROC_PER_NODE=2
+export NNODES="${NNODES:-1}"
+export NODE_RANK="${NODE_RANK:-0}"
+export MASTER_ADDR="${MASTER_ADDR:-127.0.0.1}"
+# 端口按用例错开：Minimax 29500 / GLM45Air 29502 / KimiK2 29504
+export MASTER_PORT="${MASTER_PORT:-29504}"
+
+export FLAGS_use_accuracy_compatible_kernel=1
+export USE_ACCURACY_COMPATIBLE=1
+export CUBLAS_WORKSPACE_CONFIG=":4096:8"
+# 本机 NVLS multicast 内存注册失败（CUDA error 401），NCCL init 会直接崩：
+# "Failed to bind NVLink SHARP (NVLS) Multicast memory ... Disable NVLS (NCCL_NVLS_ENABLE=0)"
+export NCCL_NVLS_ENABLE=0
+export TORCHDYNAMO_DISABLE=1
+export TORCH_USE_CUDA_DSA=1
+export PYTORCH_ALLOC_CONF='expandable_segments:True'
+
+# unfused attention 路径（与 paddle 侧 _attn_implementation: eager 对齐）
+export NVTE_FLASH_ATTN=0
+export NVTE_FUSED_ATTN=0
+
+# ---- 精度对齐：逐层输出 md5（默认关闭，排查时按需打开）----
+export ENABLE_SAVE_HOOK="${ENABLE_SAVE_HOOK:-0}"
+export ENABLE_BACKWARD_HOOK="${ENABLE_BACKWARD_HOOK:-0}"
+export SAVE_TENSOR_GRAD="${SAVE_TENSOR_GRAD:-0}"
+export SAVE_TENSOR_SAVE_NPY="${SAVE_TENSOR_SAVE_NPY:-0}"
+export SAVE_TENSOR_NAMES=output,grad,input
+export MG_TENSOR_DEBUG_DIR="${WORKSPACE_DIR}/logs/mg"
+
+RUN_TS="$(date +%Y%m%d-%H%M%S)"
+TORCH_LOG_DIR="${WORKSPACE_DIR}/logs/torch/${RUN_TS}"
+mkdir -p "${TORCH_LOG_DIR}" "${MG_TENSOR_DEBUG_DIR}"
+
+# ------- 训练参数（与 paddle 侧 KimiK2.yaml 对齐）-----
+ARGS=(
+    ### model
+    --model_type deepseek_v3
+    --model "${KIMIK2_MODEL}"
+
+    ### data
+    --dataset "${KIMIK2_DATASET}"
+    --columns '{"src": "query", "tgt": "response"}'
+    --max_length 8192
+    --packing False
+    --padding_free False
+    --truncation_strategy right
+    --split_dataset_ratio 0
+    --template dummy
+    --template_backend swift
+    --dataset_shuffle False
+    --train_dataloader_shuffle False
+    --dataloader_num_workers 4
+    --dataloader_persistent_workers False
+
+    ### finetuning
+    --seed 23
+    --finetune True
+    --train_type full
+    --train_iters 1
+    --logging_steps 1
+    --eval_iters 0
+    --eval_steps 200
+    --save_steps 300
+    --output_dir "${TORCH_LOG_DIR}/trainer"
+
+    ### parallel
+    --tensor_model_parallel_size 1
+    --pipeline_model_parallel_size 1
+    --expert_model_parallel_size 2
+    --sequence_parallel False
+
+    ### MoE
+    --moe_aux_loss_coeff 0
+    --moe_router_dtype fp32
+    --moe_grouped_gemm False
+    --moe_permute_fusion False
+    --moe_enable_deepep False
+    --moe_token_dispatcher_type alltoall
+
+    ### overlap
+    --overlap_grad_reduce False
+    --overlap_param_gather False
+
+    ### memory / recompute
+    --recompute_granularity full
+    --recompute_method uniform
+    --recompute_num_layers 1
+
+    ### compute
+    --bf16 True
+    --fp16 False
+    --torch_dtype float32
+    --attention_backend unfused
+    --bias_activation_fusion False
+    --gradient_accumulation_fusion False
+    --cross_entropy_loss_fusion False
+    --calculate_per_token_loss False
+    --micro_batch_size 1
+    --global_batch_size 2
+
+    ### optimizer
+    --optimizer adam
+    --lr 1e-5
+    --clip_grad 1.0
+    --use_precision_aware_optimizer False
+    --use_distributed_optimizer False
+    --accumulate_allreduce_grads_in_fp32 True
+    --streaming False
+
+    --use_accuracy_compatible True
+)
+
+# ------- 运行 -----
+megatron sft "${ARGS[@]}" 2>&1 | tee "${TORCH_LOG_DIR}/run_torch.log"

--- a/scripts/alignment_model_accuracy/run_alignment_test.sh
+++ b/scripts/alignment_model_accuracy/run_alignment_test.sh
@@ -23,6 +23,8 @@ cd "${SCRIPT_DIR}"
 CASES=(
     "MinimaxV2.5_EP2 ./MinimaxV2.5_EP2/run_paddle_minimax.sh ./MinimaxV2.5_EP2/run_torch_minimax.sh"
     "GLM45Air_EP2 ./GLM45Air_EP2/run_paddle_glm45.sh ./GLM45Air_EP2/run_torch_glm45.sh"
+    # KimiK2_EP2: 用例文件已就位，2 卡 TP1/EP2 的 step1 md5 基线待首次 smoke 确立后再放开
+    # "KimiK2_EP2 ./KimiK2_EP2/run_paddle_kimik2.sh ./KimiK2_EP2/run_torch_kimik2.sh"
     # "transformer ./paddlepaddle_transformer/run_paddle_minimax.sh ./pytorch_transformer/run_torch_minimax.sh"
 )
 


### PR DESCRIPTION
## What

在 `scripts/alignment_model_accuracy/` 新增 Kimi-K2 精度对齐监控用例 `KimiK2_EP2/`，配置约定对标同目录 `GLM45Air_EP2`（#1903）。

- 并行配置：单机 **2 卡，TP=1 / EP=2 / PP=1**
- 精度：bf16，`seed=23`，单 step（`max_steps=1` / `--train_iters 1`）
- 判定：`compare_loss.py` 逐 step 比对两侧 `per_token_loss` / `final_loss` 的 md5

> 说明：本 PR 早期版本为 `KimiK2_TP8EP8`（单机 8 卡 TP=8/EP=8），因测试环境只有 2 卡，已改为 `KimiK2_EP2`。
> 本次同时 rebase 到最新 develop，解决了 `run_alignment_test.sh` 与 `GLM45Air_EP2` 的登记位置冲突，历史收敛为单 commit。

## Files

| 文件 | 说明 |
|---|---|
| `KimiK2_EP2/KimiK2.yaml` | paddle 侧训练配置（TP=1/EP=2/PP=1，SFT，`use_accuracy_compatible: true`，单 step）|
| `KimiK2_EP2/run_paddle_kimik2.sh` | paddle 侧启动：清分布式 env + 对齐 flags + `paddleformers-cli train` |
| `KimiK2_EP2/run_torch_kimik2.sh` | torch 侧启动：对齐 flags + `megatron sft <ARGS>` |
| `KimiK2_EP2/README.md` | 用例目标、判定口径、两侧配置对应表、端口分配、资产依赖 |
| `run_alignment_test.sh` | 在 `CASES` 中登记本用例（当前为注释状态，见下） |

## 两侧配置对齐

为让严格 md5 可比，以下项两侧成对设置，改动任一侧都需同步另一侧：

| 项 | paddle (`KimiK2.yaml`) | torch (`run_torch_kimik2.sh`) |
|---|---|---|
| attention | `_attn_implementation: eager` | `--attention_backend unfused` + `NVTE_FLASH_ATTN=0` / `NVTE_FUSED_ATTN=0` |
| template | `use_template: false` | `--template dummy --template_backend swift` |
| 截断 | `truncation_strategy: right` | `--truncation_strategy right` |
| padding_free | 未设（默认 false） | `--padding_free False` |
| 样本顺序 | `mix_strategy: concat` / `random_shuffle: false` / `dataloader_shuffle: false` | `--dataset_shuffle False --train_dataloader_shuffle False` |
| MoE aux loss | `router_aux_loss_coef: 0.0` | `--moe_aux_loss_coeff 0` |
| MoE fusion | `moe_expert_fusion: false` / `moe_shared_expert_overlap: false` | `--moe_grouped_gemm False --moe_permute_fusion False` |
| dispatcher | `moe_token_dispatcher_type: alltoall` | `--moe_token_dispatcher_type alltoall` |
| rope | `apply_rope_fusion: false` | 未开 rope fusion |
| 梯度累加 | `amp_master_grad: true` | `--accumulate_allreduce_grads_in_fp32 True` |
| 梯度裁剪 | 默认 `max_grad_norm: 1.0` | `--clip_grad 1.0` |
| 优化器 | 不开 offload / 不开 sharding | `--use_precision_aware_optimizer False --use_distributed_optimizer False` |

资产路径两侧统一到 `/home/.cache/PaddleFormers/Kimi-K2-bf16_2EP/`，保留 `KIMIK2_MODEL` / `KIMIK2_DATASET` 环境变量覆盖口，不写死任何个人共享盘路径。

## 其他约定

- **端口**：paddle 29505 / torch 29504，与 `MinimaxV2.5_EP2`（29501/29500）、`GLM45Air_EP2`（29503/29502）错开。
- **逐层 md5 hook 默认关闭**（`${ENABLE_SAVE_HOOK:-0}` 等），排查首个 diff 层时按需打开，与 `GLM45Air_EP2` 约定一致。
- 两个新增 `.sh` 已补齐 Apache 2.0 版权头，本地 `python3 ci/hooks/copyright.py` 返回 0 且未回写文件。

## `CASES` 当前为注释状态

```bash
CASES=(
    "MinimaxV2.5_EP2 ..."
    "GLM45Air_EP2 ..."
    # "KimiK2_EP2 ./KimiK2_EP2/run_paddle_kimik2.sh ./KimiK2_EP2/run_torch_kimik2.sh"
)
```

`run_case` 任一用例 FAIL 即整体 `exit 1`。2 卡 EP2 配置的 step1 md5 基线尚未 smoke 验证（既往 bit-exact 结论来自 8 卡 TP8/EP8 复现），为避免未验证用例阻塞整条 alignment CI，先以注释形式登记，待 smoke 通过确立基线后单独放开。

## 验证情况

- `bash -n` 三个脚本语法通过
- `yaml.safe_load` 解析 `KimiK2.yaml` 通过
- `ci/hooks/copyright.py` 通过且无回写
- `git rebase origin/develop` 无冲突
- **未做端到端 smoke**（需 2 卡 GPU 与 Kimi-K2 资产），README 已标注该未验证项
