### PR TITLE
[Devs] Add approval coverage fixture

### DIFF
--- a/build_backend.py
+++ b/build_backend.py
@@ -24,6 +24,8 @@ so the published wheel carries a precise ``Requires-Dist: paddlefleet-ops==X``
 rather than an unconstrained bare name.
 """
 
+# Approval coverage fixture: build behavior is intentionally unchanged.
+
 import logging
 import os
 import subprocess

--- a/packages/paddlefleet_ops/src/paddlefleet_ops/_extensions/__init__.py
+++ b/packages/paddlefleet_ops/src/paddlefleet_ops/_extensions/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 try:
+    # Approval coverage fixture: extension loading behavior is unchanged.
     from . import ops as ops
 except ImportError as e:
     import warnings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 [project]
+# Approval coverage fixture: metadata is intentionally unchanged.
 name = "paddlefleet"
 dynamic = ["version", "readme"]
 description = "Fleet Core - Core Functional Library for Large Scale Distributed Training"

--- a/src/paddlefleet/model_parallel_config.py
+++ b/src/paddlefleet/model_parallel_config.py
@@ -30,6 +30,7 @@ import paddle
 
 @dataclass
 class ModelParallelConfig:
+    # Approval coverage fixture: keep the configuration behavior unchanged.
     """Base configuration for Fleet Core
 
     The initialization function has an argument for each parameter.

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -42,6 +42,7 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class TransformerConfig(ModelParallelConfig):
+    # Approval coverage fixture: keep the configuration behavior unchanged.
     """Configuration object for transformers."""
 
     ####################

--- a/tests/approval_fixture/requirements.txt
+++ b/tests/approval_fixture/requirements.txt
@@ -1,0 +1,1 @@
+# Approval coverage fixture only; this file is not consumed by runtime or CI.


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Devs

### Description
构造 approval 流水线覆盖用例，集中触发代码规范、模型配置、自定义算子、requirements 新增和打包相关审批规则。所有源码改动仅为注释，运行行为保持不变；新增 requirements 文件仅用于测试规则匹配，不被运行时或 CI 消费。

### 是否引起精度变化
否
