### PR TITLE
[MTP] Add packed-document MTP data path (use_erndata)

### DIFF
--- a/src/paddlefleet/models/common/language_loss/language_loss.py
+++ b/src/paddlefleet/models/common/language_loss/language_loss.py
@@ -202,6 +202,22 @@ class LanguageLoss(FleetLayer):
     # Class-level tracker for MTP loss, read by trainer for logging.
     mtp_loss_tracker: dict[str, float] = {}
 
+    # Class-level stash for cu_seqlens_q under mtp_data_style="megatron".
+    # Populated on every rank by the dataloader (ernie5
+    # dist_data_loader.py — right after the three broadcast_data_obj calls),
+    # and additionally by gpt_embedding.forward on the embedding stage as a
+    # PP=1 safety net. Consumed here to drive strict per-doc `paddle.roll`
+    # in the MTP label-rolling loop so EOS positions are zero-masked
+    # correctly and match the embedding-side per-doc roll bit-exactly.
+    #
+    # PP=1: each micro-batch runs embedding→loss end-to-end before the next
+    #   arrives, so the stash is race-free even without thread-locals.
+    # PP>1: the last stage never runs embedding; the dataloader stash on every
+    #   rank is what enables the loss stage to see cu_seqlens_q. cu_seqlens_q
+    #   travels alongside `mtp_startend_row_indices_all` in every
+    #   `broadcast_data_obj` tuple (shuffle / main / pp_data).
+    _cu_seqlens_q_stash: "paddle.Tensor | None" = None
+
     def __init__(
         self,
         config: TransformerConfig,
@@ -480,8 +496,47 @@ class LanguageLoss(FleetLayer):
             )
             assert len(logits) == self.config.num_nextn_predict_layers + 1
             labels_ori = labels
-            lm_labels = labels[:, : -self.config.num_nextn_predict_layers]
-            seq_length = lm_labels.shape[1]
+            # Under mtp_data_style="megatron" labels are already [B, L]
+            # (no L+K trailing padding). The main-decoder logits also live
+            # at length L (no L→L-K slicing was performed upstream), so
+            # skip the L+K→L trim; likewise per-depth MTP labels come from
+            # a per-depth roll — approximated here by shifting labels_ori
+            # left by (depth+1) positions with -100 fill at the tail.
+            _mtp_is_megatron = (
+                getattr(self.config, "mtp_data_style", "ernie5") == "megatron"
+            )
+            # Under CP>1 the megatron path keeps labels_ori full-length on
+            # every rank. Local zigzag chunks must be extracted here so that
+            # shape matches the local logits produced by the embedding branch.
+            _cp_size_for_extract = (
+                get_context_parallel_world_size() if _mtp_is_megatron else 1
+            )
+            if _cp_size_for_extract > 1:
+                from paddlefleet.parallel_state import (
+                    get_context_parallel_rank as _get_cp_rank,
+                )
+                from paddlefleet.transformer.multi_token_prediction import (
+                    extract_local_zigzag_chunks as _extract_cp,
+                )
+
+                _cp_rank_for_extract = _get_cp_rank()
+            else:
+                _extract_cp = None
+                _cp_rank_for_extract = 0
+            if _mtp_is_megatron:
+                lm_labels = labels_ori
+                if _cp_size_for_extract > 1:
+                    # Extract this rank's local zigzag chunks from full-length labels.
+                    lm_labels = _extract_cp(
+                        lm_labels,
+                        _cp_rank_for_extract,
+                        _cp_size_for_extract,
+                        axis=1,
+                    )
+                seq_length = lm_labels.shape[1]
+            else:
+                lm_labels = labels[:, : -self.config.num_nextn_predict_layers]
+                seq_length = lm_labels.shape[1]
 
             mtp_loss = []
             mtp_logits = logits[1:]
@@ -494,17 +549,71 @@ class LanguageLoss(FleetLayer):
 
                 for depth in range(self.config.num_nextn_predict_layers):
                     logits_cur_depth = mtp_logits[depth]
-                    labels_cur_depth = labels_ori[
-                        :, (depth + 1) : (depth + 1 + seq_length)
-                    ]
+                    if _mtp_is_megatron:
+                        # Under mtp_data_style="megatron" labels_ori is [B, L]
+                        # (no L+K padding). MTP depth k predicts x[i+k+2],
+                        # i.e. labels rolled left (k+1) times with per-doc
+                        # boundary zero-fill via cu_seqlens_q.
+                        #
+                        # Strict per-doc parity: when cu_seqlens_q is
+                        # available (stashed by gpt_embedding.forward under
+                        # PP=1), use `_roll_tensor_packed_seq` — same helper
+                        # the embedding side uses, so EOS boundaries match
+                        # bit-exactly. Under PP>1 (currently hard-blocked)
+                        # the stash is stale and we fall back to plain
+                        # `paddle.roll` + `ignored_index` tail (the loss at
+                        # EOS positions is nearly always masked out
+                        # downstream, so the simplified path is
+                        # loss-equivalent in practice).
+                        _cu = LanguageLoss._cu_seqlens_q_stash
+                        if _cu is not None:
+                            from paddlefleet.transformer.multi_token_prediction import (
+                                _roll_tensor_packed_seq,
+                            )
+
+                            _lbl = labels_ori
+                            for _ in range(depth + 1):
+                                _lbl, _ = _roll_tensor_packed_seq(
+                                    _lbl,
+                                    shifts=-1,
+                                    dims=1,
+                                    cu_seqlens_q=_cu,
+                                )
+                        else:
+                            _lbl = labels_ori
+                            for _ in range(depth + 1):
+                                _lbl = paddle.roll(_lbl, shifts=-1, axis=1)
+                            # Zero-fill the wrapped positions with ignored_index
+                            _lbl = _lbl.clone()
+                            _lbl[:, -(depth + 1) :] = self.ignored_index
+                        if _cp_size_for_extract > 1:
+                            # Match local logits shape by extracting this
+                            # rank's zigzag chunks.
+                            _lbl = _extract_cp(
+                                _lbl,
+                                _cp_rank_for_extract,
+                                _cp_size_for_extract,
+                                axis=1,
+                            )
+                        labels_cur_depth = _lbl
+                    else:
+                        labels_cur_depth = labels_ori[
+                            :, (depth + 1) : (depth + 1 + seq_length)
+                        ]
                     if self.config.gpt_model_use_experimental_version:
                         # Align with EB: compute per-token loss matrix and reduce
                         # with global sum/count instead of going through forward_impl
                         # which applies line-wise loss.
 
-                        if get_context_parallel_world_size() > 1:
+                        if (
+                            get_context_parallel_world_size() > 1
+                            and not _mtp_is_megatron
+                        ):
                             # In EB data flow and CP size > 1, since we do not use _forward
                             # we need to scatter labels to cp local here.
+                            # Under mtp_data_style="megatron" labels_cur_depth is
+                            # already local zigzag chunks (extract_local_zigzag_chunks
+                            # above), so skip the scatter to avoid double-scatter.
                             labels_cur_depth = ContextParallelScatterOp.apply(
                                 labels_cur_depth,
                                 axis=1,
@@ -533,8 +642,15 @@ class LanguageLoss(FleetLayer):
                                 labels_cur_depth,
                             )
 
-                        if get_context_parallel_world_size() > 1:
+                        if (
+                            get_context_parallel_world_size() > 1
+                            and not _mtp_is_megatron
+                        ):
                             # In EB data flow and CP size > 1, loss and labels need to be gathered back.
+                            # Under mtp_data_style="megatron" labels stay local — the
+                            # subsequent lossmask/sum reduction is per-rank (allreduce
+                            # happens implicitly via DP grad-averaging), so skip the
+                            # gather to keep the length-L/cp local view.
                             loss_matrix_cur_depth = (
                                 ContextParallelGatherOp.apply(
                                     loss_matrix_cur_depth,
@@ -604,9 +720,46 @@ class LanguageLoss(FleetLayer):
                 ):
                     for depth in range(len(mtp_logits)):
                         prediction_scores_cur_depth = mtp_logits[depth]
-                        labels_cur_depth = labels_ori[
-                            :, (depth + 1) : (depth + 1 + seq_length)
-                        ]
+                        if _mtp_is_megatron:
+                            # Strict per-doc parity (mirror of the
+                            # mtp_distillation_loss=False path above): prefer
+                            # _roll_tensor_packed_seq using cu_seqlens_q
+                            # stashed by gpt_embedding.forward. Fall back to
+                            # plain paddle.roll + ignored_index tail when
+                            # unavailable (e.g. under future PP>1 support
+                            # before the broadcast is wired).
+                            _cu = LanguageLoss._cu_seqlens_q_stash
+                            if _cu is not None:
+                                from paddlefleet.transformer.multi_token_prediction import (
+                                    _roll_tensor_packed_seq,
+                                )
+
+                                _lbl = labels_ori
+                                for _ in range(depth + 1):
+                                    _lbl, _ = _roll_tensor_packed_seq(
+                                        _lbl,
+                                        shifts=-1,
+                                        dims=1,
+                                        cu_seqlens_q=_cu,
+                                    )
+                            else:
+                                _lbl = labels_ori
+                                for _ in range(depth + 1):
+                                    _lbl = paddle.roll(_lbl, shifts=-1, axis=1)
+                                _lbl = _lbl.clone()
+                                _lbl[:, -(depth + 1) :] = self.ignored_index
+                            if _cp_size_for_extract > 1:
+                                _lbl = _extract_cp(
+                                    _lbl,
+                                    _cp_rank_for_extract,
+                                    _cp_size_for_extract,
+                                    axis=1,
+                                )
+                            labels_cur_depth = _lbl
+                        else:
+                            labels_cur_depth = labels_ori[
+                                :, (depth + 1) : (depth + 1 + seq_length)
+                            ]
                         lossmask = (
                             labels_cur_depth != self.ignored_index
                         ).cast(paddle.float32)

--- a/src/paddlefleet/models/common/language_loss/language_loss.py
+++ b/src/paddlefleet/models/common/language_loss/language_loss.py
@@ -553,18 +553,16 @@ class LanguageLoss(FleetLayer):
                         # Under mtp_data_style="megatron" labels_ori is [B, L]
                         # (no L+K padding). MTP depth k predicts x[i+k+2],
                         # i.e. labels rolled left (k+1) times with per-doc
-                        # boundary zero-fill via cu_seqlens_q.
+                        # boundary fill via cu_seqlens_q. For labels the
+                        # boundary MUST be filled with ignored_index (not 0),
+                        # otherwise the cross-doc position would train token 0.
                         #
                         # Strict per-doc parity: when cu_seqlens_q is
-                        # available (stashed by gpt_embedding.forward under
-                        # PP=1), use `_roll_tensor_packed_seq` — same helper
-                        # the embedding side uses, so EOS boundaries match
-                        # bit-exactly. Under PP>1 (currently hard-blocked)
-                        # the stash is stale and we fall back to plain
-                        # `paddle.roll` + `ignored_index` tail (the loss at
-                        # EOS positions is nearly always masked out
-                        # downstream, so the simplified path is
-                        # loss-equivalent in practice).
+                        # available, use `_roll_tensor_packed_seq` with
+                        # pad_value=ignored_index — same helper the embedding
+                        # side uses (pad_value=0 there), so the EOS boundaries
+                        # line up bit-exactly. When unavailable, fall back to
+                        # plain `paddle.roll` + ignored_index tail.
                         _cu = LanguageLoss._cu_seqlens_q_stash
                         if _cu is not None:
                             from paddlefleet.transformer.multi_token_prediction import (
@@ -578,14 +576,27 @@ class LanguageLoss(FleetLayer):
                                     shifts=-1,
                                     dims=1,
                                     cu_seqlens_q=_cu,
+                                    pad_value=self.ignored_index,
                                 )
                         else:
-                            _lbl = labels_ori
-                            for _ in range(depth + 1):
-                                _lbl = paddle.roll(_lbl, shifts=-1, axis=1)
-                            # Zero-fill the wrapped positions with ignored_index
-                            _lbl = _lbl.clone()
-                            _lbl[:, -(depth + 1) :] = self.ignored_index
+                            # No cu_seqlens_q on this rank. A plain
+                            # paddle.roll cannot respect packed-doc
+                            # boundaries, so it would leak labels across
+                            # documents (train the first token of doc N+1 as
+                            # the target at the last position of doc N). Fail
+                            # loudly instead of silently corrupting: the data
+                            # pipeline must stash cu_seqlens_q on EVERY rank
+                            # (including the last PP stage, which never runs
+                            # GPTEmbedding.forward) via the broadcast receive
+                            # path before the loss stage runs.
+                            raise RuntimeError(
+                                "mtp_data_style='megatron' requires cu_seqlens_q "
+                                "to be stashed on LanguageLoss._cu_seqlens_q_stash "
+                                "before the loss stage, but it is None on this "
+                                "rank. Ensure the dataloader broadcasts and "
+                                "stashes cu_seqlens_q on every (incl. last-PP) "
+                                "rank."
+                            )
                         if _cp_size_for_extract > 1:
                             # Match local logits shape by extracting this
                             # rank's zigzag chunks.
@@ -722,12 +733,12 @@ class LanguageLoss(FleetLayer):
                         prediction_scores_cur_depth = mtp_logits[depth]
                         if _mtp_is_megatron:
                             # Strict per-doc parity (mirror of the
-                            # mtp_distillation_loss=False path above): prefer
-                            # _roll_tensor_packed_seq using cu_seqlens_q
-                            # stashed by gpt_embedding.forward. Fall back to
-                            # plain paddle.roll + ignored_index tail when
-                            # unavailable (e.g. under future PP>1 support
-                            # before the broadcast is wired).
+                            # mtp_distillation_loss=False path above): use
+                            # _roll_tensor_packed_seq with the cu_seqlens_q
+                            # stashed by the dataloader / GPTEmbedding.forward,
+                            # filling doc boundaries with ignored_index. If the
+                            # stash is missing, raise instead of silently
+                            # leaking labels across packed docs.
                             _cu = LanguageLoss._cu_seqlens_q_stash
                             if _cu is not None:
                                 from paddlefleet.transformer.multi_token_prediction import (
@@ -741,13 +752,21 @@ class LanguageLoss(FleetLayer):
                                         shifts=-1,
                                         dims=1,
                                         cu_seqlens_q=_cu,
+                                        pad_value=self.ignored_index,
                                     )
                             else:
-                                _lbl = labels_ori
-                                for _ in range(depth + 1):
-                                    _lbl = paddle.roll(_lbl, shifts=-1, axis=1)
-                                _lbl = _lbl.clone()
-                                _lbl[:, -(depth + 1) :] = self.ignored_index
+                                # See the mtp_distillation_loss=False branch:
+                                # without cu_seqlens_q a plain roll leaks
+                                # labels across packed docs, so fail loudly
+                                # rather than corrupt the loss silently.
+                                raise RuntimeError(
+                                    "mtp_data_style='megatron' requires "
+                                    "cu_seqlens_q to be stashed on "
+                                    "LanguageLoss._cu_seqlens_q_stash before the "
+                                    "loss stage, but it is None on this rank. "
+                                    "Ensure the dataloader broadcasts and stashes "
+                                    "cu_seqlens_q on every (incl. last-PP) rank."
+                                )
                             if _cp_size_for_extract > 1:
                                 _lbl = _extract_cp(
                                     _lbl,

--- a/src/paddlefleet/models/common/language_loss/language_loss.py
+++ b/src/paddlefleet/models/common/language_loss/language_loss.py
@@ -202,7 +202,7 @@ class LanguageLoss(FleetLayer):
     # Class-level tracker for MTP loss, read by trainer for logging.
     mtp_loss_tracker: dict[str, float] = {}
 
-    # Class-level stash for cu_seqlens_q under mtp_data_style="megatron".
+    # Class-level stash for cu_seqlens_q under use_erndata=True.
     # Populated on every rank by the dataloader (ernie5
     # dist_data_loader.py — right after the three broadcast_data_obj calls),
     # and additionally by gpt_embedding.forward on the embedding stage as a
@@ -490,7 +490,7 @@ class LanguageLoss(FleetLayer):
     def _megatron_label_for_depth(self, labels_ori, depth):
         """Megatron-style per-MTP-depth labels.
 
-        Under mtp_data_style="megatron" labels arrive length-L (no L+K append).
+        Under use_erndata=True labels arrive length-L (no L+K append).
         ``depth < 0`` returns the main labels unchanged (length L); ``depth >= 0``
         rolls labels_ori left ``depth + 1`` times, filling ``ignored_index`` at
         every packed-document boundary (via the stashed cu_seqlens_q) so the
@@ -506,7 +506,7 @@ class LanguageLoss(FleetLayer):
             _cu = LanguageLoss._cu_seqlens_q_stash
             if _cu is None:
                 raise RuntimeError(
-                    "mtp_data_style='megatron' requires cu_seqlens_q to be "
+                    "use_erndata=True requires cu_seqlens_q to be "
                     "stashed on LanguageLoss._cu_seqlens_q_stash before the loss "
                     "stage, but it is None on this rank. It should be set by "
                     "GPTEmbedding.forward (PP=1) or the LM head on the last PP "
@@ -548,15 +548,13 @@ class LanguageLoss(FleetLayer):
             )
             assert len(logits) == self.config.num_nextn_predict_layers + 1
             labels_ori = labels
-            # Under mtp_data_style="megatron" labels are already [B, L]
+            # Under use_erndata=True labels are already [B, L]
             # (no L+K trailing padding). The main-decoder logits also live
             # at length L (no L→L-K slicing was performed upstream), so
             # skip the L+K→L trim; likewise per-depth MTP labels come from
             # a per-depth roll — approximated here by shifting labels_ori
             # left by (depth+1) positions with -100 fill at the tail.
-            _mtp_is_megatron = (
-                getattr(self.config, "mtp_data_style", "ernie5") == "megatron"
-            )
+            _mtp_is_megatron = getattr(self.config, "use_erndata", False)
             # Under CP>1 the megatron path keeps labels_ori full-length on
             # every rank. Local zigzag chunks must be extracted here so that
             # shape matches the local logits produced by the embedding branch.
@@ -602,7 +600,7 @@ class LanguageLoss(FleetLayer):
                 for depth in range(self.config.num_nextn_predict_layers):
                     logits_cur_depth = mtp_logits[depth]
                     if _mtp_is_megatron:
-                        # Under mtp_data_style="megatron" labels_ori is [B, L]
+                        # Under use_erndata=True labels_ori is [B, L]
                         # (no L+K padding). MTP depth k predicts x[i+k+2],
                         # i.e. labels rolled left (k+1) times with per-doc
                         # boundary fill via cu_seqlens_q. For labels the
@@ -642,7 +640,7 @@ class LanguageLoss(FleetLayer):
                             # GPTLMHead.forward on the last PP stage; reaching
                             # here means neither ran on this rank.
                             raise RuntimeError(
-                                "mtp_data_style='megatron' requires cu_seqlens_q "
+                                "use_erndata=True requires cu_seqlens_q "
                                 "to be stashed on LanguageLoss._cu_seqlens_q_stash "
                                 "before the loss stage, but it is None on this "
                                 "rank. It should be set by GPTEmbedding.forward "
@@ -673,7 +671,7 @@ class LanguageLoss(FleetLayer):
                         ):
                             # In EB data flow and CP size > 1, since we do not use _forward
                             # we need to scatter labels to cp local here.
-                            # Under mtp_data_style="megatron" labels_cur_depth is
+                            # Under use_erndata=True labels_cur_depth is
                             # already local zigzag chunks (extract_local_zigzag_chunks
                             # above), so skip the scatter to avoid double-scatter.
                             labels_cur_depth = ContextParallelScatterOp.apply(
@@ -709,7 +707,7 @@ class LanguageLoss(FleetLayer):
                             and not _mtp_is_megatron
                         ):
                             # In EB data flow and CP size > 1, loss and labels need to be gathered back.
-                            # Under mtp_data_style="megatron" labels stay local — the
+                            # Under use_erndata=True labels stay local — the
                             # subsequent lossmask/sum reduction is per-rank (allreduce
                             # happens implicitly via DP grad-averaging), so skip the
                             # gather to keep the length-L/cp local view.
@@ -811,7 +809,7 @@ class LanguageLoss(FleetLayer):
                                 # labels across packed docs, so fail loudly
                                 # rather than corrupt the loss silently.
                                 raise RuntimeError(
-                                    "mtp_data_style='megatron' requires "
+                                    "use_erndata=True requires "
                                     "cu_seqlens_q to be stashed on "
                                     "LanguageLoss._cu_seqlens_q_stash before the "
                                     "loss stage, but it is None on this rank. "
@@ -987,8 +985,8 @@ class MainLanguageLoss(LanguageLoss):
             and not self.config.mtp_load_weight_only
         )
         labels_ori = labels
-        if getattr(self.config, "mtp_data_style", "ernie5") == "megatron":
-            # Megatron: labels are length-L already; main logits are length-L
+        if getattr(self.config, "use_erndata", False):
+            # erndata: labels are length-L already; main logits are length-L
             # too, so keep the full labels (no L+K trim) and CP-extract to match.
             lm_labels = self._megatron_label_for_depth(labels_ori, -1)
         else:
@@ -1073,11 +1071,9 @@ class MTPLanguageLoss(LanguageLoss):
             and not self.config.mtp_load_weight_only
         )
         labels_ori = labels
-        _mtp_is_megatron = (
-            getattr(self.config, "mtp_data_style", "ernie5") == "megatron"
-        )
+        _mtp_is_megatron = getattr(self.config, "use_erndata", False)
         if _mtp_is_megatron:
-            # Megatron: labels are length-L; per-depth labels come from a
+            # erndata: labels are length-L; per-depth labels come from a
             # per-doc roll (ignored_index at boundaries), NOT the ernie5 L+K
             # slice. seq_length is only used by the ernie5 slice path below.
             seq_length = labels_ori.shape[1]

--- a/src/paddlefleet/models/common/language_loss/language_loss.py
+++ b/src/paddlefleet/models/common/language_loss/language_loss.py
@@ -584,18 +584,17 @@ class LanguageLoss(FleetLayer):
                             # boundaries, so it would leak labels across
                             # documents (train the first token of doc N+1 as
                             # the target at the last position of doc N). Fail
-                            # loudly instead of silently corrupting: the data
-                            # pipeline must stash cu_seqlens_q on EVERY rank
-                            # (including the last PP stage, which never runs
-                            # GPTEmbedding.forward) via the broadcast receive
-                            # path before the loss stage runs.
+                            # loudly instead of silently corrupting.
+                            # cu_seqlens_q is normally stashed by
+                            # GPTEmbedding.forward (PP=1 / first stage) and by
+                            # GPTLMHead.forward on the last PP stage; reaching
+                            # here means neither ran on this rank.
                             raise RuntimeError(
                                 "mtp_data_style='megatron' requires cu_seqlens_q "
                                 "to be stashed on LanguageLoss._cu_seqlens_q_stash "
                                 "before the loss stage, but it is None on this "
-                                "rank. Ensure the dataloader broadcasts and "
-                                "stashes cu_seqlens_q on every (incl. last-PP) "
-                                "rank."
+                                "rank. It should be set by GPTEmbedding.forward "
+                                "(PP=1) or GPTLMHead.forward (last PP stage)."
                             )
                         if _cp_size_for_extract > 1:
                             # Match local logits shape by extracting this
@@ -764,8 +763,8 @@ class LanguageLoss(FleetLayer):
                                     "cu_seqlens_q to be stashed on "
                                     "LanguageLoss._cu_seqlens_q_stash before the "
                                     "loss stage, but it is None on this rank. "
-                                    "Ensure the dataloader broadcasts and stashes "
-                                    "cu_seqlens_q on every (incl. last-PP) rank."
+                                    "It should be set by GPTEmbedding.forward "
+                                    "(PP=1) or GPTLMHead.forward (last PP stage)."
                                 )
                             if _cp_size_for_extract > 1:
                                 _lbl = _extract_cp(

--- a/src/paddlefleet/models/common/language_loss/language_loss.py
+++ b/src/paddlefleet/models/common/language_loss/language_loss.py
@@ -487,6 +487,58 @@ class LanguageLoss(FleetLayer):
             return recompute(self.forward_impl, logits, labels)
         return self.forward_impl(logits, labels)
 
+    def _megatron_label_for_depth(self, labels_ori, depth):
+        """Megatron-style per-MTP-depth labels.
+
+        Under mtp_data_style="megatron" labels arrive length-L (no L+K append).
+        ``depth < 0`` returns the main labels unchanged (length L); ``depth >= 0``
+        rolls labels_ori left ``depth + 1`` times, filling ``ignored_index`` at
+        every packed-document boundary (via the stashed cu_seqlens_q) so the
+        boundary token is excluded from the loss. Under CP>1 this rank's local
+        zigzag chunk is extracted so the label shape matches the local logits.
+
+        Mirrors the megatron branch of ``LanguageLoss.forward`` so the separate
+        Main/MTP head-loss path stays consistent with the fused path.
+        """
+        if depth < 0:
+            _lbl = labels_ori
+        else:
+            _cu = LanguageLoss._cu_seqlens_q_stash
+            if _cu is None:
+                raise RuntimeError(
+                    "mtp_data_style='megatron' requires cu_seqlens_q to be "
+                    "stashed on LanguageLoss._cu_seqlens_q_stash before the loss "
+                    "stage, but it is None on this rank. It should be set by "
+                    "GPTEmbedding.forward (PP=1) or the LM head on the last PP "
+                    "stage (GPTLMHead / GPTMainLMHead / GPTMTPLMHead)."
+                )
+            from paddlefleet.transformer.multi_token_prediction import (
+                _roll_tensor_packed_seq,
+            )
+
+            _lbl = labels_ori
+            for _ in range(depth + 1):
+                _lbl, _ = _roll_tensor_packed_seq(
+                    _lbl,
+                    shifts=-1,
+                    dims=1,
+                    cu_seqlens_q=_cu,
+                    pad_value=self.ignored_index,
+                )
+        if get_context_parallel_world_size() > 1:
+            from paddlefleet.parallel_state import get_context_parallel_rank
+            from paddlefleet.transformer.multi_token_prediction import (
+                extract_local_zigzag_chunks,
+            )
+
+            _lbl = extract_local_zigzag_chunks(
+                _lbl,
+                get_context_parallel_rank(),
+                get_context_parallel_world_size(),
+                axis=1,
+            )
+        return _lbl
+
     def forward(self, logits: Tensor | list, labels: Tensor) -> Tensor:
         if isinstance(logits, list):
             assert (
@@ -935,7 +987,12 @@ class MainLanguageLoss(LanguageLoss):
             and not self.config.mtp_load_weight_only
         )
         labels_ori = labels
-        lm_labels = labels[:, : -self.config.num_nextn_predict_layers]
+        if getattr(self.config, "mtp_data_style", "ernie5") == "megatron":
+            # Megatron: labels are length-L already; main logits are length-L
+            # too, so keep the full labels (no L+K trim) and CP-extract to match.
+            lm_labels = self._megatron_label_for_depth(labels_ori, -1)
+        else:
+            lm_labels = labels[:, : -self.config.num_nextn_predict_layers]
         seq_length = lm_labels.shape[1]
 
         mtp_loss = dict_args["mtp_loss"]
@@ -1016,8 +1073,17 @@ class MTPLanguageLoss(LanguageLoss):
             and not self.config.mtp_load_weight_only
         )
         labels_ori = labels
-        lm_labels = labels[:, : -self.config.num_nextn_predict_layers]
-        seq_length = lm_labels.shape[1]
+        _mtp_is_megatron = (
+            getattr(self.config, "mtp_data_style", "ernie5") == "megatron"
+        )
+        if _mtp_is_megatron:
+            # Megatron: labels are length-L; per-depth labels come from a
+            # per-doc roll (ignored_index at boundaries), NOT the ernie5 L+K
+            # slice. seq_length is only used by the ernie5 slice path below.
+            seq_length = labels_ori.shape[1]
+        else:
+            lm_labels = labels[:, : -self.config.num_nextn_predict_layers]
+            seq_length = lm_labels.shape[1]
 
         mtp_loss = []
 
@@ -1027,9 +1093,14 @@ class MTPLanguageLoss(LanguageLoss):
 
         for depth in range(self.config.num_nextn_predict_layers):
             logits_cur_depth = mtp_logits[depth]
-            labels_cur_depth = labels_ori[
-                :, (depth + 1) : (depth + 1 + seq_length)
-            ]
+            if _mtp_is_megatron:
+                labels_cur_depth = self._megatron_label_for_depth(
+                    labels_ori, depth
+                )
+            else:
+                labels_cur_depth = labels_ori[
+                    :, (depth + 1) : (depth + 1 + seq_length)
+                ]
             loss_cur_depth = self._forward(
                 logits_cur_depth,
                 labels_cur_depth,

--- a/src/paddlefleet/models/gpt/gpt_embedding.py
+++ b/src/paddlefleet/models/gpt/gpt_embedding.py
@@ -456,12 +456,10 @@ class GPTEmbedding(FleetLayer):
                         attn_mask_startend_row_indices is None
                         and cu_seqlens_q is not None
                     ):
-                        attn_mask_startend_row_indices = (
-                            build_startend_row_indices_from_cu_seqlens(
-                                cu_seqlens_q,
-                                decoder_input.shape[0],
-                                include_position_axis=self.config.gpt_model_use_experimental_version,
-                            )
+                        attn_mask_startend_row_indices = build_startend_row_indices_from_cu_seqlens(
+                            cu_seqlens_q,
+                            decoder_input.shape[0],
+                            include_position_axis=self.config.gpt_model_use_experimental_version,
                         )
 
                     # decoder_input: [B, L, H] full-length embedding (already

--- a/src/paddlefleet/models/gpt/gpt_embedding.py
+++ b/src/paddlefleet/models/gpt/gpt_embedding.py
@@ -333,7 +333,7 @@ class GPTEmbedding(FleetLayer):
         deepstack_visual_embeds = None
         visual_pos_mask = None
         mtp_emb_res = None
-        # CP zigzag context of the mtp_data_style="megatron" MTP branch below.
+        # CP zigzag context of the use_erndata MTP branch below.
         # The branch slices the embeddings itself (no ContextParallelScatterOp,
         # which is gated on experimental_dataflow and therefore never runs for
         # this style), so the RoPE tables have to be sliced with the very same
@@ -342,7 +342,7 @@ class GPTEmbedding(FleetLayer):
         mtp_megatron_cp_rank = 0
 
         # Ingest cu_seqlens_q (raw int32 tensor) from the batch dict if the
-        # dataloader put it there (mtp_data_style="megatron" path). We keep
+        # dataloader put it there (use_erndata path). We keep
         # it as a raw tensor throughout — no PackedSeqParams wrapper — to
         # avoid triggering the attention-kernel THD path (qkv_format="thd")
         # which the ernie5 flashmask stack does not use. Downstream
@@ -352,7 +352,7 @@ class GPTEmbedding(FleetLayer):
         if cu_seqlens_q is not None and not cu_seqlens_q.place.is_gpu_place():
             cu_seqlens_q = cu_seqlens_q.cuda()
 
-        # Stash cu_seqlens_q for the loss layer (mtp_data_style="megatron"
+        # Stash cu_seqlens_q for the loss layer (use_erndata
         # per-doc parity path). LanguageLoss.forward reads this class-level
         # slot to drive per-doc `paddle.roll` with EOS zero-masking, matching
         # the boundary semantics of the embedding-side rolls above. Under PP>1
@@ -423,7 +423,7 @@ class GPTEmbedding(FleetLayer):
                 and not self.config.mtp_load_weight_only
             ):
                 # ------------------------------------------------------------
-                # Megatron-style branch: input_ids is [B, L] (no L+K append);
+                # erndata branch: input_ids is [B, L] (no L+K append);
                 # produce K shifted embeddings by rolling decoder_input in
                 # place with per-doc boundary zero-fill via cu_seqlens_q.
                 # Under CP>1, each rank holds the full-length embedding (per
@@ -433,10 +433,9 @@ class GPTEmbedding(FleetLayer):
                 # The ernie5 (default) path in the ``else`` below retains
                 # upstream develop's full logic, including multimodal + MTP.
                 # ------------------------------------------------------------
-                _style = getattr(self.config, "mtp_data_style", "ernie5")
-                if _style == "megatron":
+                if getattr(self.config, "use_erndata", False):
                     assert not self.multimodal_embedding, (
-                        "MTP megatron style does not support multimodal for now."
+                        "erndata MTP path does not support multimodal for now."
                     )
                     from paddlefleet.transformer.multi_token_prediction import (
                         extract_local_zigzag_chunks,
@@ -733,7 +732,7 @@ class GPTEmbedding(FleetLayer):
         swa_rotary_pos_sin = None
 
         def _slice_rope_for_mtp_megatron_cp(rope_table):
-            """Zigzag-slice a RoPE table for mtp_data_style="megatron" + CP > 1.
+            """Zigzag-slice a RoPE table for use_erndata + CP > 1.
 
             ``RotaryEmbedding.get_rotary_seq_len`` scales the rank-local input
             length back up by ``cp_group.world_size``, so the tables below are
@@ -765,12 +764,12 @@ class GPTEmbedding(FleetLayer):
             and position_ids is not None
             and self.config.num_nextn_predict_layers is not None
             and self.config.num_nextn_predict_layers > 0
-            # megatron style keeps the main decoder at the full length L (the
+            # erndata keeps the main decoder at the full length L (the
             # per-doc shift happens inside the MTP layer), so position_ids
             # already matches. Under CP mtp_emb_res[0] is the rank-local
             # zigzag slice, whose length must not be mistaken for L - K: a
             # contiguous prefix of position_ids is not this rank's chunk.
-            and getattr(self.config, "mtp_data_style", "ernie5") != "megatron"
+            and not getattr(self.config, "use_erndata", False)
         ):
             # mtp_emb_res[0] has shape [B, seq_len - num_nextn_predict_layers, H]
             actual_seq_len = mtp_emb_res[0].shape[1]
@@ -921,7 +920,7 @@ class GPTEmbedding(FleetLayer):
                 if self.config.gpt_model_use_experimental_version
                 else None
             ),
-            # Under mtp_data_style="megatron" cu_seqlens_q travels down the
+            # Under use_erndata cu_seqlens_q travels down the
             # pipeline dict as a raw int32 tensor. MultiTokenPredictionLayer
             # derives per-depth attn_mask_startend_row_indices from it via
             # build_startend_row_indices_from_cu_seqlens. Under "ernie5"

--- a/src/paddlefleet/models/gpt/gpt_embedding.py
+++ b/src/paddlefleet/models/gpt/gpt_embedding.py
@@ -333,6 +333,13 @@ class GPTEmbedding(FleetLayer):
         deepstack_visual_embeds = None
         visual_pos_mask = None
         mtp_emb_res = None
+        # CP zigzag context of the mtp_data_style="megatron" MTP branch below.
+        # The branch slices the embeddings itself (no ContextParallelScatterOp,
+        # which is gated on experimental_dataflow and therefore never runs for
+        # this style), so the RoPE tables have to be sliced with the very same
+        # layout further down. cp_size == 1 means "nothing to slice".
+        mtp_megatron_cp_size = 1
+        mtp_megatron_cp_rank = 0
 
         # Ingest cu_seqlens_q (raw int32 tensor) from the batch dict if the
         # dataloader put it there (mtp_data_style="megatron" path). We keep
@@ -451,6 +458,9 @@ class GPTEmbedding(FleetLayer):
                     _cp_rank = (
                         get_context_parallel_rank() if _cp_size > 1 else 0
                     )
+                    # Publish it so the RoPE tables below get the same slicing.
+                    mtp_megatron_cp_size = _cp_size
+                    mtp_megatron_cp_rank = _cp_rank
 
                     # Main embedding: [B, L, H] → [B, L/cp_size, H] via zigzag.
                     if _cp_size > 1:
@@ -722,6 +732,31 @@ class GPTEmbedding(FleetLayer):
         swa_rotary_pos_cos = None
         swa_rotary_pos_sin = None
 
+        def _slice_rope_for_mtp_megatron_cp(rope_table):
+            """Zigzag-slice a RoPE table for mtp_data_style="megatron" + CP > 1.
+
+            ``RotaryEmbedding.get_rotary_seq_len`` scales the rank-local input
+            length back up by ``cp_group.world_size``, so the tables below are
+            always built for the FULL sequence length L while the hidden states
+            this rank carries are its two zigzag chunks. The generic
+            ``ContextParallelScatterOp`` further down only runs for
+            ``experimental_dataflow``, which megatron style forbids, so the
+            slicing has to happen here -- with exactly the layout the megatron
+            MTP branch used for the embeddings.
+            """
+            if mtp_megatron_cp_size == 1 or rope_table is None:
+                return rope_table
+            from paddlefleet.transformer.multi_token_prediction import (
+                extract_local_zigzag_chunks,
+            )
+
+            return extract_local_zigzag_chunks(
+                rope_table,
+                mtp_megatron_cp_rank,
+                mtp_megatron_cp_size,
+                axis=1,
+            )
+
         # For MTP mode: truncate position_ids to match the actual sequence length
         # MTP reduces sequence length by num_nextn_predict_layers
         mtp_position_ids = position_ids
@@ -730,6 +765,12 @@ class GPTEmbedding(FleetLayer):
             and position_ids is not None
             and self.config.num_nextn_predict_layers is not None
             and self.config.num_nextn_predict_layers > 0
+            # megatron style keeps the main decoder at the full length L (the
+            # per-doc shift happens inside the MTP layer), so position_ids
+            # already matches. Under CP mtp_emb_res[0] is the rank-local
+            # zigzag slice, whose length must not be mistaken for L - K: a
+            # contiguous prefix of position_ids is not this rank's chunk.
+            and getattr(self.config, "mtp_data_style", "ernie5") != "megatron"
         ):
             # mtp_emb_res[0] has shape [B, seq_len - num_nextn_predict_layers, H]
             actual_seq_len = mtp_emb_res[0].shape[1]
@@ -760,6 +801,7 @@ class GPTEmbedding(FleetLayer):
             )
 
         if rotary_pos_emb is not None:
+            rotary_pos_emb = _slice_rope_for_mtp_megatron_cp(rotary_pos_emb)
             if self.config.apply_rope_fusion:
                 rotary_pos_cos = paddle.cos(rotary_pos_emb)
                 rotary_pos_sin = paddle.sin(rotary_pos_emb)
@@ -799,6 +841,9 @@ class GPTEmbedding(FleetLayer):
             )
 
         if swa_rotary_pos_emb is not None:
+            swa_rotary_pos_emb = _slice_rope_for_mtp_megatron_cp(
+                swa_rotary_pos_emb
+            )
             if self.config.apply_rope_fusion:
                 swa_rotary_pos_cos = paddle.cos(swa_rotary_pos_emb)
                 swa_rotary_pos_sin = paddle.sin(swa_rotary_pos_emb)

--- a/src/paddlefleet/models/gpt/gpt_embedding.py
+++ b/src/paddlefleet/models/gpt/gpt_embedding.py
@@ -33,6 +33,7 @@ from paddlefleet.context_parallel_utils import (
 )
 from paddlefleet.models.gpt.utils import fill_feature
 from paddlefleet.parallel_state import (
+    get_context_parallel_rank,
     get_context_parallel_world_size,
 )
 from paddlefleet.tensor_parallel.mappings import (
@@ -332,6 +333,32 @@ class GPTEmbedding(FleetLayer):
         deepstack_visual_embeds = None
         visual_pos_mask = None
         mtp_emb_res = None
+
+        # Ingest cu_seqlens_q (raw int32 tensor) from the batch dict if the
+        # dataloader put it there (mtp_data_style="megatron" path). We keep
+        # it as a raw tensor throughout — no PackedSeqParams wrapper — to
+        # avoid triggering the attention-kernel THD path (qkv_format="thd")
+        # which the ernie5 flashmask stack does not use. Downstream
+        # consumers (MultiTokenPredictionLayer._forward_megatron_style)
+        # derive per-depth attn_mask_startend_row_indices from this tensor.
+        cu_seqlens_q = dict_args.get("cu_seqlens_q", None)
+        if cu_seqlens_q is not None and not cu_seqlens_q.place.is_gpu_place():
+            cu_seqlens_q = cu_seqlens_q.cuda()
+
+        # Stash cu_seqlens_q for the loss layer (mtp_data_style="megatron"
+        # per-doc parity path). LanguageLoss.forward reads this class-level
+        # slot to drive per-doc `paddle.roll` with EOS zero-masking, matching
+        # the boundary semantics of the embedding-side rolls above. Under PP>1
+        # the dataloader broadcasts cu_seqlens_q to every rank and stashes it
+        # here after broadcast completes, so the loss stage on the last PP rank
+        # uses the same boundaries as the embedding stage.
+        if cu_seqlens_q is not None:
+            from paddlefleet.models.common.language_loss.language_loss import (
+                LanguageLoss as _LangLoss,
+            )
+
+            _LangLoss._cu_seqlens_q_stash = cu_seqlens_q
+
         if input_ids is None and decoder_input is None:
             assert dict_args["decoder_input"] is not None, (
                 "input_ids or decoder_input must be provided"
@@ -388,140 +415,249 @@ class GPTEmbedding(FleetLayer):
                 and self.config.num_nextn_predict_layers > 0
                 and not self.config.mtp_load_weight_only
             ):
-                # Split input_ids for MoE mask: main part for backbone, per-depth for MTP
-                if input_ids_for_moe_mask is not None:
-                    # Main backbone input_ids: [B, max_seq]
-                    # Use .contiguous() because slices are non-contiguous and PP P2P send requires contiguous tensors.
-                    input_ids_for_moe_mask = input_ids[
-                        :, : -self.config.num_nextn_predict_layers
-                    ].contiguous()
-                    # Construct per-depth MTP input_ids: for depth k, use
-                    # input_ids[:, (k+1):(k+1+max_seq)] matching embedding shift
-                    seq_length = (
-                        input_ids.shape[1]
-                        - self.config.num_nextn_predict_layers
+                # ------------------------------------------------------------
+                # Megatron-style branch: input_ids is [B, L] (no L+K append);
+                # produce K shifted embeddings by rolling decoder_input in
+                # place with per-doc boundary zero-fill via cu_seqlens_q.
+                # Under CP>1, each rank holds the full-length embedding (per
+                # PaddleFleet dataloader broadcast) and slices its own
+                # zigzag chunks via extract_local_zigzag_chunks — no
+                # ContextParallelScatterOp needed.
+                # The ernie5 (default) path in the ``else`` below retains
+                # upstream develop's full logic, including multimodal + MTP.
+                # ------------------------------------------------------------
+                _style = getattr(self.config, "mtp_data_style", "ernie5")
+                if _style == "megatron":
+                    assert not self.multimodal_embedding, (
+                        "MTP megatron style does not support multimodal for now."
                     )
-                    mtp_ids_list = []
-                    for depth in range(self.config.num_nextn_predict_layers):
-                        mtp_ids_list.append(
-                            input_ids[:, (depth + 1) : (depth + 1 + seq_length)]
-                        )
-                    # [B, num_mtp, max_seq] - paddle.stack creates a new contiguous tensor
-                    mtp_input_ids_for_moe_mask = paddle.stack(
-                        mtp_ids_list, axis=1
+                    from paddlefleet.transformer.multi_token_prediction import (
+                        extract_local_zigzag_chunks,
+                        roll_tensor,
                     )
 
-                if self.config.enable_mtp_magic_send:
-                    # Magic send: only truncate, skip shifted embedding pre-computation.
-                    # input_ids will be broadcast to the last stage for re-embedding.
-                    decoder_input = decoder_input[
-                        :, : -self.config.num_nextn_predict_layers, :
-                    ]
+                    # decoder_input: [B, L, H] full-length embedding (already
+                    # computed above from the length-L input_ids in this branch).
+                    if input_ids_for_moe_mask is not None:
+                        # Megatron path keeps a single canonical input_ids [B, L].
+                        input_ids_for_moe_mask = input_ids.contiguous()
+                        mtp_input_ids_for_moe_mask = None
 
-                    # Apply the same SP scatter as the non-magic-send path to ensure
-                    # bit-for-bit identical main embedding output.
-                    if (
-                        get_context_parallel_world_size() > 1
-                        and self.config.experimental_dataflow
-                    ):
-                        decoder_input = ContextParallelScatterOp.apply(
-                            decoder_input,
-                            axis=1,
-                            mode=self.config.cp_balance_mode,
+                    inputs_embeds_ori = decoder_input
+                    batch_size, seq_length, hidden_size = decoder_input.shape
+
+                    # CP context (world size / rank). CP=1 turns extract into no-op.
+                    _cp_size = get_context_parallel_world_size()
+                    _cp_rank = (
+                        get_context_parallel_rank() if _cp_size > 1 else 0
+                    )
+
+                    # Main embedding: [B, L, H] → [B, L/cp_size, H] via zigzag.
+                    if _cp_size > 1:
+                        inputs_embeds = extract_local_zigzag_chunks(
+                            inputs_embeds_ori, _cp_rank, _cp_size, axis=1
                         )
-                    if (
-                        self.config.gpt_model_use_experimental_version
-                        and self.config.sequence_parallel
-                    ):
-                        decoder_input = decoder_input.astype(
-                            self.embedding.embed_tokens.weight.dtype
-                        )
+                    else:
+                        inputs_embeds = inputs_embeds_ori
+
                     if self.sequence_parallel:
-                        batch_size, seq_length, hidden_size = (
-                            decoder_input.shape
+                        _sp_local_bs, _sp_local_sl, _sp_local_h = (
+                            inputs_embeds.shape
                         )
-                        decoder_input = decoder_input.reshape(
-                            [-1, decoder_input.shape[-1]]
+                        inputs_embeds = inputs_embeds.reshape([-1, _sp_local_h])
+                        inputs_embeds = ScatterOp.apply(inputs_embeds)
+                        inputs_embeds = (
+                            inputs_embeds.reshape(
+                                [_sp_local_bs, -1, _sp_local_h]
+                            )
+                            .permute(1, 0, 2)
+                            .contiguous()
                         )
-                        decoder_input = ScatterOp.apply(decoder_input)
-                        if not (
+
+                    mtp_emb_res = [inputs_embeds]
+
+                    # Cumulative rolls: depth k uses decoder_input rolled by
+                    # (k+1) positions. Roll on the full-length float embedding
+                    # (identical on every CP rank), then extract this rank's
+                    # zigzag chunks — avoids a ContextParallelScatterOp per depth.
+                    rolled_embed = inputs_embeds_ori
+                    for depth in range(self.config.num_nextn_predict_layers):
+                        rolled_embed, _ = roll_tensor(
+                            rolled_embed,
+                            shifts=-1,
+                            dims=1,
+                            cp_group=None,  # full-length semantics; see docstring
+                            cu_seqlens_q=cu_seqlens_q,
+                        )
+
+                        if _cp_size > 1:
+                            inputs_embeds_mtp = extract_local_zigzag_chunks(
+                                rolled_embed, _cp_rank, _cp_size, axis=1
+                            )
+                        else:
+                            inputs_embeds_mtp = rolled_embed
+
+                        if self.sequence_parallel:
+                            _sp_bs, _sp_sl, _sp_h = inputs_embeds_mtp.shape
+                            inputs_embeds_mtp = inputs_embeds_mtp.reshape(
+                                [-1, _sp_h]
+                            )
+                            inputs_embeds_mtp = ScatterOp.apply(
+                                inputs_embeds_mtp
+                            )
+                            inputs_embeds_mtp = (
+                                inputs_embeds_mtp.reshape([_sp_bs, -1, _sp_h])
+                                .permute(1, 0, 2)
+                                .contiguous()
+                            )
+                        mtp_emb_res.append(inputs_embeds_mtp)
+                else:
+                    # Split input_ids for MoE mask: main part for backbone, per-depth for MTP
+                    if input_ids_for_moe_mask is not None:
+                        # Main backbone input_ids: [B, max_seq]
+                        # Use .contiguous() because slices are non-contiguous and PP P2P send requires contiguous tensors.
+                        input_ids_for_moe_mask = input_ids[
+                            :, : -self.config.num_nextn_predict_layers
+                        ].contiguous()
+                        # Construct per-depth MTP input_ids: for depth k, use
+                        # input_ids[:, (k+1):(k+1+max_seq)] matching embedding shift
+                        seq_length = (
+                            input_ids.shape[1]
+                            - self.config.num_nextn_predict_layers
+                        )
+                        mtp_ids_list = []
+                        for depth in range(
+                            self.config.num_nextn_predict_layers
+                        ):
+                            mtp_ids_list.append(
+                                input_ids[
+                                    :, (depth + 1) : (depth + 1 + seq_length)
+                                ]
+                            )
+                        # [B, num_mtp, max_seq] - paddle.stack creates a new contiguous tensor
+                        mtp_input_ids_for_moe_mask = paddle.stack(
+                            mtp_ids_list, axis=1
+                        )
+
+                    if self.config.enable_mtp_magic_send:
+                        # Magic send: only truncate, skip shifted embedding pre-computation.
+                        # input_ids will be broadcast to the last stage for re-embedding.
+                        decoder_input = decoder_input[
+                            :, : -self.config.num_nextn_predict_layers, :
+                        ]
+
+                        # Apply the same SP scatter as the non-magic-send path to ensure
+                        # bit-for-bit identical main embedding output.
+                        if (
+                            get_context_parallel_world_size() > 1
+                            and self.config.experimental_dataflow
+                        ):
+                            decoder_input = ContextParallelScatterOp.apply(
+                                decoder_input,
+                                axis=1,
+                                mode=self.config.cp_balance_mode,
+                            )
+                        if (
                             self.config.gpt_model_use_experimental_version
                             and self.config.sequence_parallel
                         ):
-                            decoder_input = (
-                                decoder_input.reshape(
-                                    [batch_size, -1, hidden_size]
-                                )
-                                .permute(1, 0, 2)
-                                .contiguous()
-                            )  # change to [S/tp, B, H]
-                else:
-                    inputs_embeds_extra = decoder_input[
-                        :, -self.config.num_nextn_predict_layers :, :
-                    ]  # [B, S, H]
-                    inputs_embeds = decoder_input[
-                        :, : -self.config.num_nextn_predict_layers, :
-                    ]
-                    inputs_embeds_ori = inputs_embeds
-                    batch_size, seq_length, hidden_size = inputs_embeds.shape
-
-                    if (
-                        get_context_parallel_world_size() > 1
-                        and self.config.experimental_dataflow
-                    ):
-                        # In EB data flow, main input embed apply CP scatter here
-                        inputs_embeds = ContextParallelScatterOp.apply(
-                            inputs_embeds,
-                            axis=1,
-                            mode=self.config.cp_balance_mode,
-                        )
-
-                    if self.sequence_parallel:
-                        inputs_embeds = inputs_embeds.reshape(
-                            [-1, inputs_embeds.shape[-1]]
-                        )
-                        inputs_embeds = ScatterOp.apply(inputs_embeds)
-                        inputs_embeds = (
-                            inputs_embeds.reshape([batch_size, -1, hidden_size])
-                            .permute(1, 0, 2)
-                            .contiguous()
-                        )  # change to [S, B, H]
-                    mtp_emb_res = [inputs_embeds]
-                    for depth in range(self.config.num_nextn_predict_layers):
-                        inputs_embeds_mtp = paddle.concat(
-                            [
-                                inputs_embeds_ori[:, (depth + 1) :, :],
-                                inputs_embeds_extra[:, : (depth + 1), :],
-                            ],
-                            axis=1,
+                            decoder_input = decoder_input.astype(
+                                self.embedding.embed_tokens.weight.dtype
+                            )
+                        if self.sequence_parallel:
+                            batch_size, seq_length, hidden_size = (
+                                decoder_input.shape
+                            )
+                            decoder_input = decoder_input.reshape(
+                                [-1, decoder_input.shape[-1]]
+                            )
+                            decoder_input = ScatterOp.apply(decoder_input)
+                            if not (
+                                self.config.gpt_model_use_experimental_version
+                                and self.config.sequence_parallel
+                            ):
+                                decoder_input = (
+                                    decoder_input.reshape(
+                                        [batch_size, -1, hidden_size]
+                                    )
+                                    .permute(1, 0, 2)
+                                    .contiguous()
+                                )  # change to [S/tp, B, H]
+                    else:
+                        inputs_embeds_extra = decoder_input[
+                            :, -self.config.num_nextn_predict_layers :, :
+                        ]  # [B, S, H]
+                        inputs_embeds = decoder_input[
+                            :, : -self.config.num_nextn_predict_layers, :
+                        ]
+                        inputs_embeds_ori = inputs_embeds
+                        batch_size, seq_length, hidden_size = (
+                            inputs_embeds.shape
                         )
 
                         if (
                             get_context_parallel_world_size() > 1
                             and self.config.experimental_dataflow
                         ):
-                            # In EB data flow, mtp input embed apply CP scatter here
-                            inputs_embeds_mtp = ContextParallelScatterOp.apply(
-                                inputs_embeds_mtp,
+                            # In EB data flow, main input embed apply CP scatter here
+                            inputs_embeds = ContextParallelScatterOp.apply(
+                                inputs_embeds,
                                 axis=1,
                                 mode=self.config.cp_balance_mode,
                             )
 
                         if self.sequence_parallel:
-                            inputs_embeds_mtp = inputs_embeds_mtp.reshape(
-                                [-1, inputs_embeds_mtp.shape[-1]]
+                            inputs_embeds = inputs_embeds.reshape(
+                                [-1, inputs_embeds.shape[-1]]
                             )
-                            inputs_embeds_mtp = ScatterOp.apply(
-                                inputs_embeds_mtp
-                            )
-                            inputs_embeds_mtp = (
-                                inputs_embeds_mtp.reshape(
+                            inputs_embeds = ScatterOp.apply(inputs_embeds)
+                            inputs_embeds = (
+                                inputs_embeds.reshape(
                                     [batch_size, -1, hidden_size]
                                 )
                                 .permute(1, 0, 2)
                                 .contiguous()
                             )  # change to [S, B, H]
-                        mtp_emb_res.append(inputs_embeds_mtp)
+                        mtp_emb_res = [inputs_embeds]
+                        for depth in range(
+                            self.config.num_nextn_predict_layers
+                        ):
+                            inputs_embeds_mtp = paddle.concat(
+                                [
+                                    inputs_embeds_ori[:, (depth + 1) :, :],
+                                    inputs_embeds_extra[:, : (depth + 1), :],
+                                ],
+                                axis=1,
+                            )
+
+                            if (
+                                get_context_parallel_world_size() > 1
+                                and self.config.experimental_dataflow
+                            ):
+                                # In EB data flow, mtp input embed apply CP scatter here
+                                inputs_embeds_mtp = (
+                                    ContextParallelScatterOp.apply(
+                                        inputs_embeds_mtp,
+                                        axis=1,
+                                        mode=self.config.cp_balance_mode,
+                                    )
+                                )
+
+                            if self.sequence_parallel:
+                                inputs_embeds_mtp = inputs_embeds_mtp.reshape(
+                                    [-1, inputs_embeds_mtp.shape[-1]]
+                                )
+                                inputs_embeds_mtp = ScatterOp.apply(
+                                    inputs_embeds_mtp
+                                )
+                                inputs_embeds_mtp = (
+                                    inputs_embeds_mtp.reshape(
+                                        [batch_size, -1, hidden_size]
+                                    )
+                                    .permute(1, 0, 2)
+                                    .contiguous()
+                                )  # change to [S, B, H]
+                            mtp_emb_res.append(inputs_embeds_mtp)
 
             if self.multimodal_embedding:
                 if mtp_emb_res is None:
@@ -740,6 +876,12 @@ class GPTEmbedding(FleetLayer):
                 if self.config.gpt_model_use_experimental_version
                 else None
             ),
+            # Under mtp_data_style="megatron" cu_seqlens_q travels down the
+            # pipeline dict as a raw int32 tensor. MultiTokenPredictionLayer
+            # derives per-depth attn_mask_startend_row_indices from it via
+            # build_startend_row_indices_from_cu_seqlens. Under "ernie5"
+            # this is None (stripped by the None-cleanup loop below).
+            "cu_seqlens_q": cu_seqlens_q,
         }
         # New dataflow: pass mtp_startend_row_indices_all and mtp_hidden_inputs_mask_all
         # through dict_args to MTP layer. They must both be present or both be absent.

--- a/src/paddlefleet/models/gpt/gpt_embedding.py
+++ b/src/paddlefleet/models/gpt/gpt_embedding.py
@@ -438,9 +438,31 @@ class GPTEmbedding(FleetLayer):
                         "erndata MTP path does not support multimodal for now."
                     )
                     from paddlefleet.transformer.multi_token_prediction import (
+                        build_startend_row_indices_from_cu_seqlens,
                         extract_local_zigzag_chunks,
                         roll_tensor,
                     )
+
+                    # The erndata contract only guarantees length-L tensors plus
+                    # cu_seqlens_q; the main flashmask boundaries are optional
+                    # (erndata emits them only when pack_by_cu_seqlen=True and
+                    # the sample has documents). Without a mask the CP branch of
+                    # DotProductAttention synthesizes an all-visible one and
+                    # calls flashmask with causal=False, silently dropping both
+                    # causality and doc boundaries from the backbone. Derive the
+                    # mask from cu_seqlens_q here so the backbone sees the same
+                    # per-doc boundaries the MTP depths do.
+                    if (
+                        attn_mask_startend_row_indices is None
+                        and cu_seqlens_q is not None
+                    ):
+                        attn_mask_startend_row_indices = (
+                            build_startend_row_indices_from_cu_seqlens(
+                                cu_seqlens_q,
+                                decoder_input.shape[0],
+                                include_position_axis=self.config.gpt_model_use_experimental_version,
+                            )
+                        )
 
                     # decoder_input: [B, L, H] full-length embedding (already
                     # computed above from the length-L input_ids in this branch).

--- a/src/paddlefleet/models/gpt/lm_head.py
+++ b/src/paddlefleet/models/gpt/lm_head.py
@@ -303,7 +303,30 @@ class GPTLMHead(ColumnParallelLinear):
 
         return logits
 
+    def _stash_cu_seqlens_q(self, dict_args):
+        """Deliver cu_seqlens_q to the loss stage under mtp_data_style="megatron".
+
+        ``LanguageLoss.forward`` only receives ``(logits, labels)`` and cannot
+        see the pipeline dict. ``cu_seqlens_q`` (packed-doc boundaries) travels
+        down the pipeline dict to this LM head, which runs on the LAST pipeline
+        stage immediately before the loss. Stash it here — on the loss rank,
+        per micro-batch — so ``LanguageLoss`` can roll labels per-doc even under
+        PP>1 (GPTEmbedding.forward writes the same stash on the PP=1 / first
+        stage). No external dataloader broadcast is required.
+
+        Non-megatron runs never populate ``cu_seqlens_q`` (it is stripped from
+        the dict in GPTEmbedding.forward), so this is a no-op there.
+        """
+        cu_seqlens_q = dict_args.get("cu_seqlens_q", None)
+        if cu_seqlens_q is not None:
+            from paddlefleet.models.common.language_loss.language_loss import (
+                LanguageLoss as _LangLoss,
+            )
+
+            _LangLoss._cu_seqlens_q_stash = cu_seqlens_q
+
     def forward(self, dict_args: dict):
+        self._stash_cu_seqlens_q(dict_args)
         hidden_states = dict_args["hidden_states"]
 
         if (
@@ -358,6 +381,7 @@ class GPTMainLMHead(GPTLMHead):
         return ScheduleNode(self.forward, name="GPTMainLMHead")
 
     def forward(self, dict_args: dict):
+        self._stash_cu_seqlens_q(dict_args)
         hidden_states = dict_args["hidden_states"]
         mtp_loss = dict_args.get("mtp_loss", None)
 

--- a/src/paddlefleet/models/gpt/lm_head.py
+++ b/src/paddlefleet/models/gpt/lm_head.py
@@ -304,7 +304,7 @@ class GPTLMHead(ColumnParallelLinear):
         return logits
 
     def _stash_cu_seqlens_q(self, dict_args):
-        """Deliver cu_seqlens_q to the loss stage under mtp_data_style="megatron".
+        """Deliver cu_seqlens_q to the loss stage under use_erndata.
 
         ``LanguageLoss.forward`` only receives ``(logits, labels)`` and cannot
         see the pipeline dict. ``cu_seqlens_q`` (packed-doc boundaries) travels
@@ -314,7 +314,7 @@ class GPTLMHead(ColumnParallelLinear):
         PP>1 (GPTEmbedding.forward writes the same stash on the PP=1 / first
         stage). No external dataloader broadcast is required.
 
-        Non-megatron runs never populate ``cu_seqlens_q`` (it is stripped from
+        Non-erndata runs never populate ``cu_seqlens_q`` (it is stripped from
         the dict in GPTEmbedding.forward), so this is a no-op there.
         """
         cu_seqlens_q = dict_args.get("cu_seqlens_q", None)
@@ -427,7 +427,7 @@ class GPTMTPLMHead(GPTLMHead):
     def forward(self, dict_args: dict):
         # Under separate_mtp_headloss this head runs on the last stage BEFORE
         # MTPLanguageLoss, which needs cu_seqlens_q to roll per-depth labels
-        # under mtp_data_style="megatron"; stash it here on the loss rank.
+        # under use_erndata; stash it here on the loss rank.
         self._stash_cu_seqlens_q(dict_args)
         hidden_states = dict_args["hidden_states"]
         num_mtp = self.config.num_nextn_predict_layers

--- a/src/paddlefleet/models/gpt/lm_head.py
+++ b/src/paddlefleet/models/gpt/lm_head.py
@@ -425,6 +425,10 @@ class GPTMTPLMHead(GPTLMHead):
         return ScheduleNode(self.forward, name="GPTMTPLMHead")
 
     def forward(self, dict_args: dict):
+        # Under separate_mtp_headloss this head runs on the last stage BEFORE
+        # MTPLanguageLoss, which needs cu_seqlens_q to roll per-depth labels
+        # under mtp_data_style="megatron"; stash it here on the loss rank.
+        self._stash_cu_seqlens_q(dict_args)
         hidden_states = dict_args["hidden_states"]
         num_mtp = self.config.num_nextn_predict_layers
         tensor_list = paddle.split(hidden_states, num_mtp + 1)

--- a/src/paddlefleet/parallel_state.py
+++ b/src/paddlefleet/parallel_state.py
@@ -226,6 +226,13 @@ def get_context_parallel_world_size():
         return get_context_parallel_group().world_size
 
 
+def get_context_parallel_rank():
+    """Return this rank's index within the context-parallel group (0 if CP is disabled)."""
+    if get_context_parallel_group() is None:
+        return 0
+    return get_context_parallel_group().rank
+
+
 def get_pipeline_model_parallel_world_size():
     """Return world size for the pipeline-model-parallel group."""
     # TODO: Support get_pipeline_model_parallel_world_size

--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -1499,12 +1499,11 @@ class TopKRouter(StandardMoERouter):
                 )
             elif (
                 get_context_parallel_world_size() > 1
-                and getattr(self.config, "mtp_data_style", "ernie5")
-                == "megatron"
+                and getattr(self.config, "use_erndata", False)
                 and input_ids is not None
                 and input_ids.shape[1] != seq_len
             ):
-                # Megatron-style MTP path: PaddleFleet dataloader broadcasts
+                # erndata MTP path: PaddleFleet dataloader broadcasts
                 # input_ids full-length [B, L] to every CP rank (unlike
                 # experimental_dataflow which pre-scatters). Embedding was
                 # already zigzag-sliced to [B, L/cp, H] via

--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -49,6 +49,7 @@ from paddlefleet.context_parallel_utils import (
     ContextParallelScatterOp,
 )
 from paddlefleet.parallel_state import (
+    get_context_parallel_rank,
     get_context_parallel_world_size,
     get_tensor_model_parallel_group,
 )
@@ -1495,6 +1496,29 @@ class TopKRouter(StandardMoERouter):
                 # so we need to scatter input_ids here to avid the assertion below
                 input_ids = ContextParallelScatterOp.apply(
                     input_ids, axis=1, mode=self.config.cp_balance_mode
+                )
+            elif (
+                get_context_parallel_world_size() > 1
+                and getattr(self.config, "mtp_data_style", "ernie5")
+                == "megatron"
+                and input_ids is not None
+                and input_ids.shape[1] != seq_len
+            ):
+                # Megatron-style MTP path: PaddleFleet dataloader broadcasts
+                # input_ids full-length [B, L] to every CP rank (unlike
+                # experimental_dataflow which pre-scatters). Embedding was
+                # already zigzag-sliced to [B, L/cp, H] via
+                # extract_local_zigzag_chunks (see gpt_embedding.py). Slice
+                # input_ids to the matching zigzag chunks here — no comm
+                # needed since every rank holds the same [B, L] tensor.
+                from paddlefleet.transformer.multi_token_prediction import (
+                    extract_local_zigzag_chunks,
+                )
+
+                _cp_size = get_context_parallel_world_size()
+                _cp_rank = get_context_parallel_rank()
+                input_ids = extract_local_zigzag_chunks(
+                    input_ids, _cp_rank, _cp_size, axis=1
                 )
             if input_ids is not None:
                 pad_token_id = getattr(self.config, "pad_token_id", 0)

--- a/src/paddlefleet/transformer/multi_token_prediction.py
+++ b/src/paddlefleet/transformer/multi_token_prediction.py
@@ -182,7 +182,7 @@ def roll_tensor(
     """Roll the tensor input along the given dimension(s).
 
     Paddle port of MCore ``multi_token_prediction.roll_tensor``. Used by the
-    Megatron-style MTP path (config.mtp_data_style="megatron") to shift
+    packed-doc MTP path (config.use_erndata=True) to shift
     input_ids / position_ids / labels / loss_mask by one token at each MTP
     depth, while respecting packed-document boundaries.
 
@@ -274,7 +274,7 @@ def extract_local_zigzag_chunks(tensor_full, cp_rank, cp_size, axis=1):
     ``cp_size`` × embedding-lookup redundancy that would otherwise result
     from doing embedding on the full-length ``input_ids``.
 
-    Callers under ``mtp_data_style="megatron"`` typically:
+    Callers under ``use_erndata=True`` typically:
 
     1. Roll the full-length int tensor with ``roll_tensor(cu_seqlens_q=...)``.
     2. Extract this rank's local slice via this helper.
@@ -1052,13 +1052,12 @@ class MultiTokenPredictionLayer(FleetLayer):
         return outputs
 
     def forward(self, dict_args: dict):
-        # Dispatch by config.mtp_data_style. Under "megatron" the data pipeline
+        # Dispatch by config.use_erndata. Under erndata the data pipeline
         # emits no mtp_startend_row_indices_all / mtp_hidden_inputs_mask_all
         # and no L+K token concatenation; instead we shift input_ids /
         # position_ids / labels / loss_mask inside this layer via
-        # roll_tensor(packed_seq_params=...).
-        style = getattr(self.config, "mtp_data_style", "ernie5")
-        if style == "megatron":
+        # roll_tensor(cu_seqlens_q=...).
+        if getattr(self.config, "use_erndata", False):
             return self._forward_megatron_style(dict_args)
 
         if "context" in dict_args:
@@ -1604,18 +1603,18 @@ class MultiTokenPredictionLayer(FleetLayer):
         return ScheduleNode(self.forward, name="MultiTokenPredictionLayer")
 
     # ------------------------------------------------------------------ #
-    # Megatron-style MTP forward (config.mtp_data_style == "megatron").
+    # Packed-doc MTP forward (config.use_erndata is True).
     #
     # Contract vs. the historical ernie5 path:
     #   * The data pipeline emits ONLY the main L-length tensors plus
-    #     packed_seq_params (with cu_seqlens_q). It does NOT emit
+    #     cu_seqlens_q. It does NOT emit
     #     mtp_startend_row_indices_all or mtp_hidden_inputs_mask_all,
     #     and it does NOT append K MTP tokens to input_ids / labels.
     #   * The shifted MTP embeddings for each depth are still prepared upstream
-    #     by GPTEmbedding, but using roll_tensor(packed_seq_params=...) — i.e.
+    #     by GPTEmbedding, but using roll_tensor(cu_seqlens_q=...) — i.e.
     #     per-doc left-shift with boundary zero-fill — rather than the L+K
     #     index-slice used by ernie5. GPTEmbedding.forward has a mirrored
-    #     mtp_data_style branch that produces the same
+    #     use_erndata branch that produces the same
     #     ``hidden_states_concat`` shape (concatenation of the main slice and
     #     K per-depth shifted slices), so the pipeline plumbing stays intact.
     #   * The MTP LMHead / loss layer downstream is responsible for rolling
@@ -1655,7 +1654,7 @@ class MultiTokenPredictionLayer(FleetLayer):
         if dict_args.get("context") is not None:
             raise NotImplementedError(
                 "multi token prediction + cross attention is not yet supported "
-                "under mtp_data_style='megatron'."
+                "under use_erndata=True."
             )
         if (
             dict_args.get("mtp_input_embeds") is not None
@@ -1664,7 +1663,7 @@ class MultiTokenPredictionLayer(FleetLayer):
             # Config validation in TransformerConfig.__post_init__ should have
             # caught this, but keep a hard guard here for defence in depth.
             raise ValueError(
-                "mtp_data_style='megatron' is incompatible with enable_mtp_magic_send."
+                "use_erndata=True is incompatible with enable_mtp_magic_send."
             )
 
         num_nextn = self.config.num_nextn_predict_layers
@@ -1690,7 +1689,7 @@ class MultiTokenPredictionLayer(FleetLayer):
         if input_ids is not None and input_ids.ndim > 2:
             # Defensive: some ernie5 codepaths stash [B, K, L] here.
             raise RuntimeError(
-                f"Under mtp_data_style='megatron', input_ids must be [B, L], got shape {input_ids.shape}."
+                f"Under use_erndata=True, input_ids must be [B, L], got shape {input_ids.shape}."
             )
 
         # Derive per-depth attn_mask_startend_row_indices from cu_seqlens_q.

--- a/src/paddlefleet/transformer/multi_token_prediction.py
+++ b/src/paddlefleet/transformer/multi_token_prediction.py
@@ -59,6 +59,234 @@ SUPPORTED_ATTN_MASK = [
 ]
 
 
+# ============================================================================
+# roll_tensor (Paddle port of MCore multi_token_prediction.roll_tensor, `8c4df6b07`)
+#
+# Semantics:
+#   * shifts=-1 → left-shift by one along `dims`; new-in position filled with 0.
+#   * cu_seqlens_q is None → standard paddle.roll (single sequence).
+#   * cu_seqlens_q provided → per-document roll respecting doc boundaries;
+#     the last token of every packed document is zeroed out and cannot leak
+#     into the next document as an MTP target.
+#   * cp_group is None or size==1 → non-CP path.
+#   * cp_group.nranks > 1 with cu_seqlens_q → NotImplementedError; the
+#     mirror-chunk (DualChunkSwap) CP variant is not implemented on this path
+#     (CP is instead handled by extract_local_zigzag_chunks at the call site).
+#
+# Note: we consciously do NOT wrap cu_seqlens_q in an MCore-style
+# PackedSeqParams dataclass. ernie5's model backend consumes doc boundaries
+# via startend_row_indices (int32 tensor) throughout — introducing
+# PackedSeqParams would (a) create a new data structure alien to ernie5,
+# and (b) risk flipping attention kernels onto the THD path
+# (qkv_format="thd") which is not what the ernie5 flashmask attention
+# expects.
+#
+# Return contract mirrors MCore: (rolled_tensor, rolled_tensor.sum()). The
+# second element is consumed by MultiTokenPredictionBlock.forward as
+# `num_tokens` for per-token-loss averaging.
+# ============================================================================
+
+
+def _roll_tensor_packed_seq(tensor, shifts, dims, cu_seqlens_q, cp_group=None):
+    """Per-doc left-shift using cu_seqlens_q.
+
+    Only supports ``shifts=-1``. ``dims`` may be any single axis of ``tensor``
+    (the seq axis — dim=1 for a [B, L, H] embedding, dim=-1 for a [B, L]
+    tokens tensor, etc.). The boundary position of each packed document is
+    filled with 0 to prevent cross-doc leakage.
+
+    CP support is intentionally omitted here; see the outer `roll_tensor`
+    guard which routes CP-enabled calls to `_roll_tensor_packed_seq_cp`.
+
+    Args:
+        tensor: input tensor to roll along the sequence dimension.
+        shifts: must be -1 (single-token left shift).
+        dims: axis along which cu_seqlens_q indexes; any single axis of
+            ``tensor``.
+        cu_seqlens_q: int32 tensor of shape ``[num_docs + 1]``; cumulative
+            document lengths so that ``cu_seqlens_q[-1] == tensor.shape[dims]``.
+        cp_group: paddle process group for context parallelism; unused in
+            this non-CP branch.
+    """
+    if shifts != -1:
+        raise ValueError(
+            f"Packed sequence roll only supports single-token left shift (shifts=-1), "
+            f"got shifts={shifts}."
+        )
+    ndim = tensor.dim()
+    dim = dims if dims >= 0 else ndim + dims
+    if not (0 <= dim < ndim):
+        raise ValueError(f"dims={dims} out of range for tensor of ndim={ndim}.")
+    if cu_seqlens_q is None:
+        raise ValueError("cu_seqlens_q must not be None.")
+
+    if isinstance(cu_seqlens_q, paddle.Tensor):
+        cu_seqlens_np = cu_seqlens_q.numpy().tolist()
+    else:
+        cu_seqlens_np = list(cu_seqlens_q)
+
+    def _select(t, s, e):
+        idx = [slice(None)] * ndim
+        idx[dim] = slice(s, e)
+        return t[tuple(idx)]
+
+    rolled = tensor.clone()
+    num_docs = len(cu_seqlens_np) - 1
+    for i in range(num_docs):
+        s = int(cu_seqlens_np[i])
+        e = int(cu_seqlens_np[i + 1])
+        if e - s <= 0:
+            continue
+        seg = _select(tensor, s, e)
+        rolled_seg = paddle.roll(seg, shifts=shifts, axis=dim)
+        # Zero out the last position that would otherwise cross the doc boundary.
+        seg_len = e - s
+        if seg_len >= 1:
+            keep_shape = [1] * ndim
+            keep_shape[dim] = seg_len
+            keep_mask = paddle.ones(keep_shape, dtype=rolled_seg.dtype)
+            last_idx = [slice(None)] * ndim
+            last_idx[dim] = slice(seg_len - 1, seg_len)
+            keep_mask[tuple(last_idx)] = 0
+            rolled_seg = rolled_seg * keep_mask
+        # Assign back along the seq dim.
+        target_idx = [slice(None)] * ndim
+        target_idx[dim] = slice(s, e)
+        rolled[tuple(target_idx)] = rolled_seg
+
+    return rolled, rolled.sum()
+
+
+def roll_tensor(
+    tensor,
+    shifts=-1,
+    dims=-1,
+    cp_group=None,
+    cu_seqlens_q=None,
+):
+    """Roll the tensor input along the given dimension(s).
+
+    Paddle port of MCore ``multi_token_prediction.roll_tensor``. Used by the
+    Megatron-style MTP path (config.mtp_data_style="megatron") to shift
+    input_ids / position_ids / labels / loss_mask by one token at each MTP
+    depth, while respecting packed-document boundaries.
+
+    CP handling deliberately differs from MCore. Under PaddleFleet's data
+    layout, dist_data_loader.py broadcasts ``input_ids`` / ``labels`` /
+    ``loss_mask`` via the ``cp_mp_parallel_group`` (see
+    ``ernie5/src/datasets/dist_data_loader.py:133-135``), so every CP rank
+    already holds a full-length ``[B, L]`` copy — no zigzag scatter happens
+    before the model. Consequently rolling reduces to standard CP=1
+    semantics on the full-length tensor, and callers should invoke
+    ``extract_local_zigzag_chunks`` after ``roll_tensor`` to obtain their
+    local slice before embedding / loss.
+
+    Args:
+        tensor: input tensor.
+        shifts: currently only -1 (single-token left shift).
+        dims: currently only the last dimension.
+        cp_group: paddle process group for context parallelism. Accepted for
+            API compatibility with MCore's signature but not used: under
+            PaddleFleet's full-length CP layout, per-rank ``paddle.roll``
+            already yields globally-correct output.
+        cu_seqlens_q: int32 tensor of shape ``[num_docs + 1]`` describing
+            packed-document boundaries. If provided, per-doc shift is
+            applied. If ``None``, a single-sequence roll is done.
+
+    Returns:
+        (rolled_tensor, rolled_tensor.sum()). The second value mirrors MCore's
+        contract for downstream num_tokens accumulation.
+    """
+    # cp_group is intentionally unused (see docstring); reference it to keep
+    # linters quiet without altering behavior.
+    del cp_group
+
+    # Packed sequence path — per-doc roll, boundary zero-filled by
+    # `_roll_tensor_packed_seq`. Correct on full-length tensors regardless
+    # of CP size because doc boundaries are described globally.
+    if cu_seqlens_q is not None:
+        return _roll_tensor_packed_seq(
+            tensor, shifts, dims, cu_seqlens_q, cp_group=None
+        )
+
+    # Standard (non-packed) path — matches paddle.roll semantics plus zero-fill
+    # at the new-in position.
+    if shifts != -1:
+        raise ValueError(
+            f"roll_tensor currently only supports shifts=-1, got shifts={shifts}."
+        )
+    ndim = tensor.dim()
+    dim = dims if dims >= 0 else ndim + dims
+    rolled = paddle.roll(tensor, shifts=shifts, axis=dims)
+    seq_len = tensor.shape[dim]
+    if seq_len >= 1:
+        keep_mask_shape = [1] * ndim
+        keep_mask_shape[dim] = seq_len
+        keep_mask = paddle.ones(keep_mask_shape, dtype=rolled.dtype)
+        idx = [slice(None)] * ndim
+        idx[dim] = slice(seq_len - 1, seq_len)
+        keep_mask[tuple(idx)] = 0
+        rolled = rolled * keep_mask
+    return rolled, rolled.sum()
+
+
+def extract_local_zigzag_chunks(tensor_full, cp_rank, cp_size, axis=1):
+    """Extract this CP rank's zigzag chunks from a full-length tensor.
+
+    Mirrors PaddleFleet's ``scatter_balance`` layout
+    (``context_parallel_utils.py:97-153``): each rank owns two chunks —
+
+    * ``chunk_start = tensor_full[..., interval*r : interval*(r+1), ...]``
+    * ``chunk_end   = tensor_full[..., L-interval*(r+1) : L-interval*r, ...]``
+
+    concatenated along the seq axis.
+
+    Extraction only — no CP communication. Use to obtain the local slice
+    without invoking ``ContextParallelScatterOp``, which avoids the
+    ``cp_size`` × embedding-lookup redundancy that would otherwise result
+    from doing embedding on the full-length ``input_ids``.
+
+    Callers under ``mtp_data_style="megatron"`` typically:
+
+    1. Roll the full-length int tensor with ``roll_tensor(cu_seqlens_q=...)``.
+    2. Extract this rank's local slice via this helper.
+    3. Feed the local slice to embedding / loss.
+
+    Args:
+        tensor_full: ``[..., L, ...]`` full-length tensor available on every rank.
+        cp_rank: this rank's index within the CP group.
+        cp_size: CP world size. ``cp_size == 1`` returns ``tensor_full`` unchanged.
+        axis: sequence axis (default 1 for ``[B, L, ...]``).
+
+    Returns:
+        ``[..., L / cp_size, ...]`` tensor holding this rank's zigzag chunks.
+    """
+    if cp_size == 1:
+        return tensor_full
+    ndim = tensor_full.dim()
+    dim = axis if axis >= 0 else ndim + axis
+    seq_len = tensor_full.shape[dim]
+    if seq_len % (cp_size * 2) != 0:
+        raise ValueError(
+            f"extract_local_zigzag_chunks: seq_len={seq_len} on axis={axis} "
+            f"is not divisible by 2*cp_size={2 * cp_size}."
+        )
+    interval = seq_len // cp_size // 2
+    chunk_start = paddle.slice(
+        tensor_full,
+        axes=[dim],
+        starts=[interval * cp_rank],
+        ends=[interval * (cp_rank + 1)],
+    )
+    chunk_end = paddle.slice(
+        tensor_full,
+        axes=[dim],
+        starts=[seq_len - interval * (cp_rank + 1)],
+        ends=[seq_len - interval * cp_rank],
+    )
+    return paddle.concat([chunk_start, chunk_end], axis=dim)
+
+
 class MTPLossLoggingHelper:
     """Helper class for logging MTP losses."""
 
@@ -796,6 +1024,15 @@ class MultiTokenPredictionLayer(FleetLayer):
         return outputs
 
     def forward(self, dict_args: dict):
+        # Dispatch by config.mtp_data_style. Under "megatron" the data pipeline
+        # emits no mtp_startend_row_indices_all / mtp_hidden_inputs_mask_all
+        # and no L+K token concatenation; instead we shift input_ids /
+        # position_ids / labels / loss_mask inside this layer via
+        # roll_tensor(packed_seq_params=...).
+        style = getattr(self.config, "mtp_data_style", "ernie5")
+        if style == "megatron":
+            return self._forward_megatron_style(dict_args)
+
         if "context" in dict_args:
             assert dict_args["context"] is None, (
                 "multi token prediction + cross attention is not yet supported."
@@ -1303,6 +1540,162 @@ class MultiTokenPredictionLayer(FleetLayer):
 
     def build_schedule_node(self):
         return ScheduleNode(self.forward, name="MultiTokenPredictionLayer")
+
+    # ------------------------------------------------------------------ #
+    # Megatron-style MTP forward (config.mtp_data_style == "megatron").
+    #
+    # Contract vs. the historical ernie5 path:
+    #   * The data pipeline emits ONLY the main L-length tensors plus
+    #     packed_seq_params (with cu_seqlens_q). It does NOT emit
+    #     mtp_startend_row_indices_all or mtp_hidden_inputs_mask_all,
+    #     and it does NOT append K MTP tokens to input_ids / labels.
+    #   * The shifted MTP embeddings for each depth are still prepared upstream
+    #     by GPTEmbedding, but using roll_tensor(packed_seq_params=...) — i.e.
+    #     per-doc left-shift with boundary zero-fill — rather than the L+K
+    #     index-slice used by ernie5. GPTEmbedding.forward has a mirrored
+    #     mtp_data_style branch that produces the same
+    #     ``hidden_states_concat`` shape (concatenation of the main slice and
+    #     K per-depth shifted slices), so the pipeline plumbing stays intact.
+    #   * The MTP LMHead / loss layer downstream is responsible for rolling
+    #     labels / loss_mask via roll_tensor before computing MTP loss (M2/M3
+    #     will exercise this end-to-end).
+    #
+    # Behaviour inside this method for a given self.layer_number (=depth k):
+    #   1. Split hidden_states_concat (shape [(K+1)*S, B, ...] under SP or
+    #      [B, (K+1)*S, ...] otherwise) into (K+1) chunks along the sequence
+    #      dim.
+    #   2. Take chunk[k] as hidden_states (previous stage's output at this
+    #      depth) and chunk[k+1] as decoder_input (upstream-computed shifted
+    #      embedding at this depth).
+    #   3. Run _proj_and_transformer_layer with:
+    #        - mtp_hidden_inputs_mask=None (no per-doc EOS-derived hidden
+    #          mask; per-doc boundary is expressed via packed_seq_params);
+    #        - attn_mask_startend_row_indices=<main mask> (packed attn still
+    #          consumes the main startend_row_indices — MTP layers inherit
+    #          the same doc boundaries because they share cu_seqlens_q).
+    #   4. Write the resulting hidden_states back into the chunk list at
+    #      position k+1 and re-concat. Return the updated dict_args so the
+    #      next MTP depth can consume its slice.
+    #
+    # Constraints: experimental_dataflow=False and enable_mtp_magic_send
+    # disabled (both enforced at TransformerConfig.__post_init__). Context
+    # parallelism is handled at the embedding / loss call sites via
+    # extract_local_zigzag_chunks rather than inside roll_tensor.
+    # ------------------------------------------------------------------ #
+
+    def _forward_megatron_style(self, dict_args: dict) -> dict:
+        # Cross-attention is still unsupported (identical constraint as
+        # upstream MCore 8c4df6b07). Packed sequences ARE now supported —
+        # that is the whole point of this branch — but they are represented
+        # by a raw cu_seqlens_q int32 tensor in dict_args, NOT wrapped in
+        # an MCore PackedSeqParams object (see the module-level docstring
+        # for the rationale).
+        if dict_args.get("context") is not None:
+            raise NotImplementedError(
+                "multi token prediction + cross attention is not yet supported "
+                "under mtp_data_style='megatron'."
+            )
+        if (
+            dict_args.get("mtp_input_embeds") is not None
+            or self.config.enable_mtp_magic_send
+        ):
+            # Config validation in TransformerConfig.__post_init__ should have
+            # caught this, but keep a hard guard here for defence in depth.
+            raise ValueError(
+                "mtp_data_style='megatron' is incompatible with enable_mtp_magic_send."
+            )
+
+        num_nextn = self.config.num_nextn_predict_layers
+
+        hidden_states_concat = dict_args["hidden_states"]
+        tensor_list = paddle.split(hidden_states_concat, num_nextn + 1)
+
+        # Use previous-stage slices for this depth.
+        dict_args["hidden_states"] = tensor_list[self.layer_number]
+        dict_args["decoder_input"] = tensor_list[self.layer_number + 1]
+
+        # Drop any leftover ernie5-path fields from dict_args so
+        # _proj_and_transformer_layer sees the Megatron contract: no per-depth
+        # hidden mask.
+        dict_args.pop("mtp_hidden_inputs_mask", None)
+        # If ernie5 upstream still smuggled these in, ignore them defensively.
+        dict_args.pop("mtp_startend_row_indices_all", None)
+        dict_args.pop("mtp_hidden_inputs_mask_all", None)
+        dict_args.pop("mtp_input_ids_for_moe_mask", None)
+        # input_ids: keep the main [B, L] slice for MoE routing mask etc.,
+        # but do NOT slice it per-depth (there is only one canonical L now).
+        input_ids = dict_args.get("input_ids")
+        if input_ids is not None and input_ids.ndim > 2:
+            # Defensive: some ernie5 codepaths stash [B, K, L] here.
+            raise RuntimeError(
+                f"Under mtp_data_style='megatron', input_ids must be [B, L], got shape {input_ids.shape}."
+            )
+
+        # Derive per-depth attn_mask_startend_row_indices from cu_seqlens_q.
+        # Doc boundaries are the SAME at every MTP depth (per-doc roll does
+        # not wrap across doc boundaries), so a single derivation is enough
+        # per depth; we still recompute on each call in case the pipeline
+        # dict has been mutated by an earlier depth.
+        cu_seqlens_q = dict_args.get("cu_seqlens_q", None)
+        if cu_seqlens_q is not None:
+            # cu_seqlens_q lives on GPU (GPTEmbedding ensured that); pull to
+            # host for the small O(num_docs) derivation loop.
+            import numpy as _np
+
+            cu_np = (
+                cu_seqlens_q.numpy()
+                if isinstance(cu_seqlens_q, paddle.Tensor)
+                else _np.asarray(cu_seqlens_q)
+            )
+            seqlen = int(cu_np[-1])
+
+            # experimental_dataflow: 2-col [B, 1, S, 2]; fleet-mode: 1-col [B, 1, S, 1].
+            # ernie5 flashmask & SWA helpers require a 4D layout [B, heads, S, num_vec]
+            # (see startend_row_indices_add_sliding_window in utils.py).
+            include_pos = bool(
+                getattr(
+                    self.config, "gpt_model_use_experimental_version", False
+                )
+            )
+
+            # Inline derivation (mirrors _mtp_utils.build_startend_row_indices_from_cu_seqlens
+            # but self-contained so this module has no import dependency on
+            # ernie5.src.datasets — those in turn import torchvision which is
+            # not required by this training path).
+            _end = _np.zeros(seqlen, dtype=_np.int32)
+            for _j in range(len(cu_np) - 1):
+                _s, _e = int(cu_np[_j]), int(cu_np[_j + 1])
+                _end[_s:_e] = _e
+            if include_pos:
+                _pos = _np.arange(seqlen, dtype=_np.int32)
+                # [S, 2] -> [1, 1, S, 2]
+                startend_np = _np.stack([_end, _pos], axis=-1)[None, None, ...]
+            else:
+                # [S] -> [1, 1, S, 1]
+                startend_np = _end[None, None, :, None]
+
+            # Attention expects a batch axis. Broadcast [1, S, ...] to
+            # [B, S, ...] via paddle.expand (zero-copy).
+            batch_size = (
+                dict_args["hidden_states"].shape[1]
+                if getattr(self.config, "sequence_parallel", False)
+                else dict_args["hidden_states"].shape[0]
+            )
+            attn_mask_startend = paddle.to_tensor(startend_np).cuda()
+            if batch_size > 1:
+                attn_mask_startend = attn_mask_startend.expand(
+                    [batch_size, *attn_mask_startend.shape[1:]]
+                )
+            dict_args["attn_mask_startend_row_indices"] = attn_mask_startend
+
+        # Run transformer layer.
+        hidden_states = self._proj_and_transformer_layer(**dict_args)
+
+        # Store back into the pipeline concat tensor at slot k+1.
+        tensor_list[self.layer_number + 1] = hidden_states
+        dict_args["hidden_states"] = paddle.concat(tensor_list)
+        dict_args.pop("decoder_input", None)
+        return dict_args
 
 
 class WeightOnlyMTPLayer(MultiTokenPredictionLayer):

--- a/src/paddlefleet/transformer/multi_token_prediction.py
+++ b/src/paddlefleet/transformer/multi_token_prediction.py
@@ -315,6 +315,62 @@ def extract_local_zigzag_chunks(tensor_full, cp_rank, cp_size, axis=1):
     return paddle.concat([chunk_start, chunk_end], axis=dim)
 
 
+def build_startend_row_indices_from_cu_seqlens(
+    cu_seqlens_q, batch_size, include_position_axis=False
+):
+    """Derive flashmask ``attn_mask_startend_row_indices`` from ``cu_seqlens_q``.
+
+    The erndata MTP contract carries packed-document boundaries as a
+    cumulative-length int32 vector ``[num_docs + 1]`` rather than a materialized
+    attention mask. Every consumer of that contract (the main backbone via
+    ``GPTEmbedding``, and each MTP depth via
+    ``MultiTokenPredictionLayer._forward_megatron_style``) needs the equivalent
+    flashmask boundaries, so the derivation lives here once.
+
+    For a token at position ``i`` inside document ``j``
+    (``cu[j] <= i < cu[j+1]``), the end row is ``cu[j+1]`` — i.e. attention is
+    confined to the token's own document.
+
+    Args:
+        cu_seqlens_q: ``[num_docs + 1]`` int32 cumulative doc lengths. The last
+            entry is the full sequence length ``L``.
+        batch_size: batch axis size to broadcast to.
+        include_position_axis: when True emit the 2-column
+            ``[B, 1, L, 2]`` layout (``[end, position]``) that
+            ``gpt_model_use_experimental_version`` expects; otherwise the
+            1-column ``[B, 1, L, 1]`` fleet-mode layout.
+
+    Returns:
+        ``[batch_size, 1, L, 1 or 2]`` int32 tensor on GPU.
+    """
+    import numpy as _np
+
+    cu_np = (
+        cu_seqlens_q.numpy()
+        if isinstance(cu_seqlens_q, paddle.Tensor)
+        else _np.asarray(cu_seqlens_q)
+    )
+    seqlen = int(cu_np[-1])
+
+    end = _np.zeros(seqlen, dtype=_np.int32)
+    for j in range(len(cu_np) - 1):
+        s, e = int(cu_np[j]), int(cu_np[j + 1])
+        end[s:e] = e
+    if include_position_axis:
+        pos = _np.arange(seqlen, dtype=_np.int32)
+        # [L, 2] -> [1, 1, L, 2]
+        startend_np = _np.stack([end, pos], axis=-1)[None, None, ...]
+    else:
+        # [L] -> [1, 1, L, 1]
+        startend_np = end[None, None, :, None]
+
+    out = paddle.to_tensor(startend_np).cuda()
+    if batch_size > 1:
+        # expand is zero-copy; attention only reads these values.
+        out = out.expand([batch_size, *out.shape[1:]])
+    return out
+
+
 class MTPLossLoggingHelper:
     """Helper class for logging MTP losses."""
 
@@ -1699,17 +1755,6 @@ class MultiTokenPredictionLayer(FleetLayer):
         # dict has been mutated by an earlier depth.
         cu_seqlens_q = dict_args.get("cu_seqlens_q", None)
         if cu_seqlens_q is not None:
-            # cu_seqlens_q lives on GPU (GPTEmbedding ensured that); pull to
-            # host for the small O(num_docs) derivation loop.
-            import numpy as _np
-
-            cu_np = (
-                cu_seqlens_q.numpy()
-                if isinstance(cu_seqlens_q, paddle.Tensor)
-                else _np.asarray(cu_seqlens_q)
-            )
-            seqlen = int(cu_np[-1])
-
             # experimental_dataflow: 2-col [B, 1, S, 2]; fleet-mode: 1-col [B, 1, S, 1].
             # ernie5 flashmask & SWA helpers require a 4D layout [B, heads, S, num_vec]
             # (see startend_row_indices_add_sliding_window in utils.py).
@@ -1718,36 +1763,18 @@ class MultiTokenPredictionLayer(FleetLayer):
                     self.config, "gpt_model_use_experimental_version", False
                 )
             )
-
-            # Inline derivation (mirrors _mtp_utils.build_startend_row_indices_from_cu_seqlens
-            # but self-contained so this module has no import dependency on
-            # ernie5.src.datasets — those in turn import torchvision which is
-            # not required by this training path).
-            _end = _np.zeros(seqlen, dtype=_np.int32)
-            for _j in range(len(cu_np) - 1):
-                _s, _e = int(cu_np[_j]), int(cu_np[_j + 1])
-                _end[_s:_e] = _e
-            if include_pos:
-                _pos = _np.arange(seqlen, dtype=_np.int32)
-                # [S, 2] -> [1, 1, S, 2]
-                startend_np = _np.stack([_end, _pos], axis=-1)[None, None, ...]
-            else:
-                # [S] -> [1, 1, S, 1]
-                startend_np = _end[None, None, :, None]
-
-            # Attention expects a batch axis. Broadcast [1, S, ...] to
-            # [B, S, ...] via paddle.expand (zero-copy).
             batch_size = (
                 dict_args["hidden_states"].shape[1]
                 if getattr(self.config, "sequence_parallel", False)
                 else dict_args["hidden_states"].shape[0]
             )
-            attn_mask_startend = paddle.to_tensor(startend_np).cuda()
-            if batch_size > 1:
-                attn_mask_startend = attn_mask_startend.expand(
-                    [batch_size, *attn_mask_startend.shape[1:]]
+            dict_args["attn_mask_startend_row_indices"] = (
+                build_startend_row_indices_from_cu_seqlens(
+                    cu_seqlens_q,
+                    batch_size,
+                    include_position_axis=include_pos,
                 )
-            dict_args["attn_mask_startend_row_indices"] = attn_mask_startend
+            )
 
         # Run transformer layer.
         hidden_states = self._proj_and_transformer_layer(**dict_args)

--- a/src/paddlefleet/transformer/multi_token_prediction.py
+++ b/src/paddlefleet/transformer/multi_token_prediction.py
@@ -87,13 +87,18 @@ SUPPORTED_ATTN_MASK = [
 # ============================================================================
 
 
-def _roll_tensor_packed_seq(tensor, shifts, dims, cu_seqlens_q, cp_group=None):
+def _roll_tensor_packed_seq(
+    tensor, shifts, dims, cu_seqlens_q, cp_group=None, pad_value=0
+):
     """Per-doc left-shift using cu_seqlens_q.
 
     Only supports ``shifts=-1``. ``dims`` may be any single axis of ``tensor``
     (the seq axis — dim=1 for a [B, L, H] embedding, dim=-1 for a [B, L]
     tokens tensor, etc.). The boundary position of each packed document is
-    filled with 0 to prevent cross-doc leakage.
+    filled with ``pad_value`` to prevent cross-doc leakage. Use ``pad_value=0``
+    for embeddings / input_ids (default) and ``pad_value=ignored_index`` for
+    labels so the boundary token is masked out of the loss instead of being
+    trained as a real target.
 
     CP support is intentionally omitted here; see the outer `roll_tensor`
     guard which routes CP-enabled calls to `_roll_tensor_packed_seq_cp`.
@@ -139,7 +144,11 @@ def _roll_tensor_packed_seq(tensor, shifts, dims, cu_seqlens_q, cp_group=None):
             continue
         seg = _select(tensor, s, e)
         rolled_seg = paddle.roll(seg, shifts=shifts, axis=dim)
-        # Zero out the last position that would otherwise cross the doc boundary.
+        # Overwrite the last position that would otherwise cross the doc
+        # boundary. ``pad_value=0`` reproduces the original multiplicative
+        # zero-fill (autograd-safe for float embeddings); a non-zero
+        # ``pad_value`` (e.g. ignored_index for labels) fills the boundary via
+        # ``keep + pad*(1-keep)`` so it stays a functional (non-in-place) op.
         seg_len = e - s
         if seg_len >= 1:
             keep_shape = [1] * ndim
@@ -148,7 +157,12 @@ def _roll_tensor_packed_seq(tensor, shifts, dims, cu_seqlens_q, cp_group=None):
             last_idx = [slice(None)] * ndim
             last_idx[dim] = slice(seg_len - 1, seg_len)
             keep_mask[tuple(last_idx)] = 0
-            rolled_seg = rolled_seg * keep_mask
+            if pad_value == 0:
+                rolled_seg = rolled_seg * keep_mask
+            else:
+                rolled_seg = rolled_seg * keep_mask + pad_value * (
+                    1 - keep_mask
+                )
         # Assign back along the seq dim.
         target_idx = [slice(None)] * ndim
         target_idx[dim] = slice(s, e)
@@ -163,6 +177,7 @@ def roll_tensor(
     dims=-1,
     cp_group=None,
     cu_seqlens_q=None,
+    pad_value=0,
 ):
     """Roll the tensor input along the given dimension(s).
 
@@ -192,6 +207,11 @@ def roll_tensor(
         cu_seqlens_q: int32 tensor of shape ``[num_docs + 1]`` describing
             packed-document boundaries. If provided, per-doc shift is
             applied. If ``None``, a single-sequence roll is done.
+        pad_value: value written into the new-in position(s) created by the
+            left shift — at each packed-doc boundary when ``cu_seqlens_q`` is
+            given, otherwise at the last sequence position. Defaults to 0
+            (embeddings / input_ids); pass ``ignored_index`` for labels so the
+            boundary token is excluded from the loss.
 
     Returns:
         (rolled_tensor, rolled_tensor.sum()). The second value mirrors MCore's
@@ -201,16 +221,21 @@ def roll_tensor(
     # linters quiet without altering behavior.
     del cp_group
 
-    # Packed sequence path — per-doc roll, boundary zero-filled by
-    # `_roll_tensor_packed_seq`. Correct on full-length tensors regardless
+    # Packed sequence path — per-doc roll, boundary filled with ``pad_value``
+    # by `_roll_tensor_packed_seq`. Correct on full-length tensors regardless
     # of CP size because doc boundaries are described globally.
     if cu_seqlens_q is not None:
         return _roll_tensor_packed_seq(
-            tensor, shifts, dims, cu_seqlens_q, cp_group=None
+            tensor,
+            shifts,
+            dims,
+            cu_seqlens_q,
+            cp_group=None,
+            pad_value=pad_value,
         )
 
-    # Standard (non-packed) path — matches paddle.roll semantics plus zero-fill
-    # at the new-in position.
+    # Standard (non-packed) path — matches paddle.roll semantics plus a
+    # ``pad_value`` fill at the new-in position.
     if shifts != -1:
         raise ValueError(
             f"roll_tensor currently only supports shifts=-1, got shifts={shifts}."
@@ -226,7 +251,10 @@ def roll_tensor(
         idx = [slice(None)] * ndim
         idx[dim] = slice(seq_len - 1, seq_len)
         keep_mask[tuple(idx)] = 0
-        rolled = rolled * keep_mask
+        if pad_value == 0:
+            rolled = rolled * keep_mask
+        else:
+            rolled = rolled * keep_mask + pad_value * (1 - keep_mask)
     return rolled, rolled.sum()
 
 

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -1762,15 +1762,19 @@ class TransformerConfig(ModelParallelConfig):
                 "Must be one of {'ernie5', 'megatron'}."
             )
         if self.mtp_data_style == "megatron":
-            _mtp_k = (
-                self.mtp_num_layers
-                if self.mtp_num_layers > 0
-                else self.num_nextn_predict_layers
-            )
-            if _mtp_k <= 0:
+            # K is read from `num_nextn_predict_layers` by every runtime
+            # consumer of the megatron data path (GPTEmbedding builds the K+1
+            # embedding chunks from it, `_forward_megatron_style` splits
+            # hidden_states into K+1 chunks with it). The `mtp_num_layers`
+            # alias is only honored by MTP *layer construction*
+            # (`_get_effective_mtp_layers`), so configuring K through the alias
+            # alone would build MTP layers that the data path never feeds.
+            # Require the canonical field instead of accepting either.
+            if self.num_nextn_predict_layers <= 0:
                 raise ValueError(
                     "mtp_data_style='megatron' requires "
-                    "num_nextn_predict_layers > 0 or mtp_num_layers > 0."
+                    "num_nextn_predict_layers > 0; the `mtp_num_layers` alias "
+                    "is not honored by the megatron MTP data path."
                 )
             if self.enable_mtp_magic_send:
                 raise ValueError(

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -1709,14 +1709,15 @@ class TransformerConfig(ModelParallelConfig):
                         f"requires cp_balance_mode='dualchunk_allgather', got "
                         f"{self.cp_balance_mode!r}."
                     )
-            # PP>1 is supported: cu_seqlens_q is threaded through
-            # all three `broadcast_data_obj` tuples in
-            # ernie5/src/datasets/dist_data_loader.py (shuffle / main / pp_data)
-            # and the dataloader stashes it onto
-            # `LanguageLoss._cu_seqlens_q_stash` on every rank after broadcast
-            # completes, so the loss stage on the last PP rank drives strict
-            # per-doc rolls with the same cu_seqlens_q as the embedding stage.
-            # No further guard needed here.
+            # PP>1 requirement (enforced at runtime, not here): the data
+            # pipeline MUST stash this micro-batch's cu_seqlens_q onto
+            # `LanguageLoss._cu_seqlens_q_stash` on EVERY rank — including the
+            # last PP stage, which never runs GPTEmbedding.forward. The
+            # reference PaddleFleet dataloader does this by threading
+            # cu_seqlens_q through every `broadcast_data_obj` tuple and writing
+            # the stash on each rank after broadcast. If the stash is missing
+            # on the loss rank, LanguageLoss.forward raises rather than
+            # silently rolling labels across packed-doc boundaries.
 
         if self.intermediate_size is None:
             self.intermediate_size = 4 * self.hidden_size

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -95,6 +95,22 @@ class TransformerConfig(ModelParallelConfig):
     The new dataflow requires: input_ids, labels, startend_row_indices (last dim=1, main seq only),
     mtp_startend_row_indices_all ([B, num_nextn, S, 1]), position_ids."""
 
+    mtp_data_style: str = "ernie5"
+    """MTP data-flow style.
+
+    - "ernie5"  : the historical PaddleFleet MTP path — the data pipeline
+      constructs mtp_startend_row_indices_all, mtp_hidden_inputs_mask_all and
+      appends K MTP tokens to input_ids/labels/loss_mask (see
+      ``ernie5/src/datasets/pretrain_online_task.py:get_mtp_inputs_info`` and
+      ``pretrain_task.py:__getitem__``). MultiTokenPredictionLayer.forward
+      consumes those pre-computed masks per depth.
+
+    - "megatron": the MCore-8c4df6b07 style. The data pipeline emits only the
+      main [L]-length tensors plus ``packed_seq_params.cu_seqlens_q`` for
+      packed doc boundaries; MTP shifting happens inside
+      MultiTokenPredictionLayer.forward via ``roll_tensor(packed_seq_params=...)``.
+    """
+
     num_empty_layers_add_in_head: int = 0
     """Number of EmptyLayer before the Decoder Layer.
     num_empty_layers_add_in_head=2 Example:
@@ -1651,6 +1667,56 @@ class TransformerConfig(ModelParallelConfig):
                 assert self.variable_seq_lengths, (
                     "enable_mtp_magic_send with vpp requires variable_seq_lengths=True"
                 )
+
+        if self.mtp_data_style not in {"ernie5", "megatron"}:
+            raise ValueError(
+                f"mtp_data_style={self.mtp_data_style!r} is invalid. "
+                "Must be one of {'ernie5', 'megatron'}."
+            )
+        if self.mtp_data_style == "megatron":
+            _mtp_k = (
+                self.mtp_num_layers
+                if self.mtp_num_layers > 0
+                else self.num_nextn_predict_layers
+            )
+            if _mtp_k <= 0:
+                raise ValueError(
+                    "mtp_data_style='megatron' requires "
+                    "num_nextn_predict_layers > 0 or mtp_num_layers > 0."
+                )
+            if self.enable_mtp_magic_send:
+                raise ValueError(
+                    "mtp_data_style='megatron' is incompatible with "
+                    "enable_mtp_magic_send=True."
+                )
+            if self.experimental_dataflow:
+                # experimental_dataflow specifically produces
+                # mtp_startend_row_indices_all as a separate input. Under the
+                # Megatron path we do not produce that field.
+                raise ValueError(
+                    "mtp_data_style='megatron' is incompatible with "
+                    "experimental_dataflow=True (which expects the ernie5-style "
+                    "mtp_startend_row_indices_all payload)."
+                )
+            # PaddleFleet's `dualchunk_allgather` scatter layout is the only
+            # mode equivalent to MCore's zigzag balancing; the other two
+            # (`contiguous_allgather`, `contiguous_a2a`) are not covered by
+            # the megatron path's MTP roll semantics.
+            if self.context_parallel_size > 1:
+                if self.cp_balance_mode != "dualchunk_allgather":
+                    raise ValueError(
+                        f"mtp_data_style='megatron' + context_parallel_size>1 "
+                        f"requires cp_balance_mode='dualchunk_allgather', got "
+                        f"{self.cp_balance_mode!r}."
+                    )
+            # PP>1 is supported: cu_seqlens_q is threaded through
+            # all three `broadcast_data_obj` tuples in
+            # ernie5/src/datasets/dist_data_loader.py (shuffle / main / pp_data)
+            # and the dataloader stashes it onto
+            # `LanguageLoss._cu_seqlens_q_stash` on every rank after broadcast
+            # completes, so the loss stage on the last PP rank drives strict
+            # per-doc rolls with the same cu_seqlens_q as the embedding stage.
+            # No further guard needed here.
 
         if self.intermediate_size is None:
             self.intermediate_size = 4 * self.hidden_size

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -1786,6 +1786,19 @@ class TransformerConfig(ModelParallelConfig):
                     "experimental_dataflow=True (which expects the ernie5-style "
                     "mtp_startend_row_indices_all payload)."
                 )
+            if self.separate_mtp_input:
+                # separate_mtp_input hands the shifted embeddings to the MTP
+                # layer through `mtp_decoder_inputs` and leaves hidden_states as
+                # the bare backbone chunk. `_forward_megatron_style` instead
+                # splits hidden_states into K+1 chunks and never reads
+                # `mtp_decoder_inputs`, so the combination would silently
+                # mis-slice the batch axis.
+                raise ValueError(
+                    "mtp_data_style='megatron' is incompatible with "
+                    "separate_mtp_input=True (the megatron MTP forward reads "
+                    "the shifted embeddings from hidden_states, not from "
+                    "mtp_decoder_inputs)."
+                )
             # PaddleFleet's `dualchunk_allgather` scatter layout is the only
             # mode equivalent to MCore's zigzag balancing; the other two
             # (`contiguous_allgather`, `contiguous_a2a`) are not covered by

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -1709,15 +1709,14 @@ class TransformerConfig(ModelParallelConfig):
                         f"requires cp_balance_mode='dualchunk_allgather', got "
                         f"{self.cp_balance_mode!r}."
                     )
-            # PP>1 requirement (enforced at runtime, not here): the data
-            # pipeline MUST stash this micro-batch's cu_seqlens_q onto
-            # `LanguageLoss._cu_seqlens_q_stash` on EVERY rank — including the
-            # last PP stage, which never runs GPTEmbedding.forward. The
-            # reference PaddleFleet dataloader does this by threading
-            # cu_seqlens_q through every `broadcast_data_obj` tuple and writing
-            # the stash on each rank after broadcast. If the stash is missing
-            # on the loss rank, LanguageLoss.forward raises rather than
-            # silently rolling labels across packed-doc boundaries.
+            # PP>1 is supported without any external dataloader help:
+            # cu_seqlens_q travels down the pipeline dict (like position_ids)
+            # to the last stage, and GPTLMHead.forward — which runs on the loss
+            # rank immediately before LanguageLoss — stashes it onto
+            # `LanguageLoss._cu_seqlens_q_stash` per micro-batch. GPTEmbedding
+            # writes the same stash on the PP=1 / first stage. If the stash is
+            # ever missing on the loss rank, LanguageLoss.forward raises rather
+            # than silently rolling labels across packed-doc boundaries.
 
         if self.intermediate_size is None:
             self.intermediate_size = 4 * self.hidden_size

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -105,20 +105,21 @@ class TransformerConfig(ModelParallelConfig):
     The new dataflow requires: input_ids, labels, startend_row_indices (last dim=1, main seq only),
     mtp_startend_row_indices_all ([B, num_nextn, S, 1]), position_ids."""
 
-    mtp_data_style: str = "ernie5"
-    """MTP data-flow style.
+    use_erndata: bool = False
+    """Whether the training job is fed by the erndata (Energon) data pipeline.
 
-    - "ernie5"  : the historical PaddleFleet MTP path — the data pipeline
+    This selects the MTP data-flow contract:
+
+    - False (default): the historical PaddleFleet MTP path — the data pipeline
       constructs mtp_startend_row_indices_all, mtp_hidden_inputs_mask_all and
-      appends K MTP tokens to input_ids/labels/loss_mask (see
-      ``ernie5/src/datasets/pretrain_online_task.py:get_mtp_inputs_info`` and
-      ``pretrain_task.py:__getitem__``). MultiTokenPredictionLayer.forward
-      consumes those pre-computed masks per depth.
+      appends K MTP tokens to input_ids/labels/loss_mask.
+      MultiTokenPredictionLayer.forward consumes those pre-computed masks per
+      depth.
 
-    - "megatron": the MCore-8c4df6b07 style. The data pipeline emits only the
-      main [L]-length tensors plus ``packed_seq_params.cu_seqlens_q`` for
-      packed doc boundaries; MTP shifting happens inside
-      MultiTokenPredictionLayer.forward via ``roll_tensor(packed_seq_params=...)``.
+    - True: the MCore-8c4df6b07 style. erndata emits only the main [L]-length
+      tensors plus ``cu_seqlens_q`` for packed doc boundaries; MTP shifting
+      happens inside MultiTokenPredictionLayer.forward via
+      ``roll_tensor(cu_seqlens_q=...)``.
     """
 
     num_empty_layers_add_in_head: int = 0
@@ -1756,38 +1757,35 @@ class TransformerConfig(ModelParallelConfig):
                     "enable_mtp_magic_send with vpp requires variable_seq_lengths=True"
                 )
 
-        if self.mtp_data_style not in {"ernie5", "megatron"}:
-            raise ValueError(
-                f"mtp_data_style={self.mtp_data_style!r} is invalid. "
-                "Must be one of {'ernie5', 'megatron'}."
-            )
-        if self.mtp_data_style == "megatron":
+        if self.use_erndata and (
+            self.num_nextn_predict_layers > 0 or self.mtp_num_layers > 0
+        ):
+            # erndata + MTP selects the packed-doc (MCore 8c4df6b07) contract.
             # K is read from `num_nextn_predict_layers` by every runtime
-            # consumer of the megatron data path (GPTEmbedding builds the K+1
-            # embedding chunks from it, `_forward_megatron_style` splits
-            # hidden_states into K+1 chunks with it). The `mtp_num_layers`
-            # alias is only honored by MTP *layer construction*
-            # (`_get_effective_mtp_layers`), so configuring K through the alias
-            # alone would build MTP layers that the data path never feeds.
-            # Require the canonical field instead of accepting either.
+            # consumer of that path (GPTEmbedding builds the K+1 embedding
+            # chunks from it, `_forward_megatron_style` splits hidden_states
+            # into K+1 chunks with it). The `mtp_num_layers` alias is only
+            # honored by MTP *layer construction* (`_get_effective_mtp_layers`),
+            # so configuring K through the alias alone would build MTP layers
+            # that the data path never feeds.
             if self.num_nextn_predict_layers <= 0:
                 raise ValueError(
-                    "mtp_data_style='megatron' requires "
+                    "use_erndata=True with MTP requires "
                     "num_nextn_predict_layers > 0; the `mtp_num_layers` alias "
-                    "is not honored by the megatron MTP data path."
+                    "is not honored by the erndata MTP data path."
                 )
             if self.enable_mtp_magic_send:
                 raise ValueError(
-                    "mtp_data_style='megatron' is incompatible with "
+                    "use_erndata=True with MTP is incompatible with "
                     "enable_mtp_magic_send=True."
                 )
             if self.experimental_dataflow:
                 # experimental_dataflow specifically produces
-                # mtp_startend_row_indices_all as a separate input. Under the
-                # Megatron path we do not produce that field.
+                # mtp_startend_row_indices_all as a separate input, which
+                # erndata does not produce.
                 raise ValueError(
-                    "mtp_data_style='megatron' is incompatible with "
-                    "experimental_dataflow=True (which expects the ernie5-style "
+                    "use_erndata=True with MTP is incompatible with "
+                    "experimental_dataflow=True (which expects the legacy "
                     "mtp_startend_row_indices_all payload)."
                 )
             if self.separate_mtp_input:
@@ -1798,19 +1796,19 @@ class TransformerConfig(ModelParallelConfig):
                 # `mtp_decoder_inputs`, so the combination would silently
                 # mis-slice the batch axis.
                 raise ValueError(
-                    "mtp_data_style='megatron' is incompatible with "
-                    "separate_mtp_input=True (the megatron MTP forward reads "
+                    "use_erndata=True with MTP is incompatible with "
+                    "separate_mtp_input=True (the erndata MTP forward reads "
                     "the shifted embeddings from hidden_states, not from "
                     "mtp_decoder_inputs)."
                 )
             # PaddleFleet's `dualchunk_allgather` scatter layout is the only
             # mode equivalent to MCore's zigzag balancing; the other two
             # (`contiguous_allgather`, `contiguous_a2a`) are not covered by
-            # the megatron path's MTP roll semantics.
+            # this path's MTP roll semantics.
             if self.context_parallel_size > 1:
                 if self.cp_balance_mode != "dualchunk_allgather":
                     raise ValueError(
-                        f"mtp_data_style='megatron' + context_parallel_size>1 "
+                        f"use_erndata=True with MTP + context_parallel_size>1 "
                         f"requires cp_balance_mode='dualchunk_allgather', got "
                         f"{self.cp_balance_mode!r}."
                     )

--- a/src/paddlefleet/transformer/transformer_layer.py
+++ b/src/paddlefleet/transformer/transformer_layer.py
@@ -758,16 +758,14 @@ class TransformerLayer(nn.Layer):
         )
         mtp_input = None
         mtp_ids = None
-        # Under mtp_data_style="megatron" the data pipeline emits length-L
+        # Under use_erndata the data pipeline emits length-L
         # tensors (input_ids / labels / position_ids / attn_mask) and
         # GPTEmbedding produces mtp_emb_res as (K+1) length-L blocks — the
         # per-depth left-shift is performed inline via roll_tensor. That means
         # the main decoder here runs at seq_len = L (not L-K), so the ernie5
         # L+K path below must be skipped for position_ids / input_ids / mask
         # trims.
-        _mtp_is_megatron = (
-            getattr(self.config, "mtp_data_style", "ernie5") == "megatron"
-        )
+        _mtp_is_megatron = getattr(self.config, "use_erndata", False)
         if (
             self.config.num_nextn_predict_layers is not None
             and self.config.num_nextn_predict_layers > 0
@@ -786,7 +784,7 @@ class TransformerLayer(nn.Layer):
             dict_args["hidden_states"] = hidden_states
 
             # process position_ids
-            # Under mtp_data_style="megatron" position_ids is [B, L] already
+            # Under use_erndata position_ids is [B, L] already
             # (roll happens inside MTP layer), so DO NOT strip K positions.
             if (
                 not self.config.gpt_model_use_experimental_version
@@ -1044,7 +1042,7 @@ class TransformerLayer(nn.Layer):
         ):
             hidden_states_concat = paddle.concat([output, *mtp_input])
             rst["hidden_states"] = hidden_states_concat
-            # Under mtp_data_style="megatron" the L+K position-ids split was
+            # Under use_erndata the L+K position-ids split was
             # skipped up front, so there is nothing to concat back either.
             if (
                 not self.config.gpt_model_use_experimental_version
@@ -2180,14 +2178,12 @@ class HySparseTransformerLayer(TransformerLayer):
         if not self._mtp_enabled(is_mtp):
             return None
         n = self.config.num_nextn_predict_layers
-        # Under mtp_data_style="megatron" position_ids / masks are already
+        # Under use_erndata position_ids / masks are already
         # main-decoder length L (per-doc shifting happens inside the MTP layer
         # via roll_tensor), so the L+K -> L seq-dim trims below must be
         # skipped. Mirrors the ``_mtp_is_megatron`` guards in
         # ``TransformerLayer.forward``.
-        _mtp_is_megatron = (
-            getattr(self.config, "mtp_data_style", "ernie5") == "megatron"
-        )
+        _mtp_is_megatron = getattr(self.config, "use_erndata", False)
         ctx = {
             "mtp_ids": None,
             "mtp_input_ids": None,

--- a/src/paddlefleet/transformer/transformer_layer.py
+++ b/src/paddlefleet/transformer/transformer_layer.py
@@ -758,6 +758,16 @@ class TransformerLayer(nn.Layer):
         )
         mtp_input = None
         mtp_ids = None
+        # Under mtp_data_style="megatron" the data pipeline emits length-L
+        # tensors (input_ids / labels / position_ids / attn_mask) and
+        # GPTEmbedding produces mtp_emb_res as (K+1) length-L blocks — the
+        # per-depth left-shift is performed inline via roll_tensor. That means
+        # the main decoder here runs at seq_len = L (not L-K), so the ernie5
+        # L+K path below must be skipped for position_ids / input_ids / mask
+        # trims.
+        _mtp_is_megatron = (
+            getattr(self.config, "mtp_data_style", "ernie5") == "megatron"
+        )
         if (
             self.config.num_nextn_predict_layers is not None
             and self.config.num_nextn_predict_layers > 0
@@ -775,7 +785,12 @@ class TransformerLayer(nn.Layer):
             dict_args["hidden_states"] = hidden_states
 
             # process position_ids
-            if not self.config.gpt_model_use_experimental_version:
+            # Under mtp_data_style="megatron" position_ids is [B, L] already
+            # (roll happens inside MTP layer), so DO NOT strip K positions.
+            if (
+                not self.config.gpt_model_use_experimental_version
+                and not _mtp_is_megatron
+            ):
                 if "position_ids" in dict_args.keys():
                     position_ids = dict_args["position_ids"]
                     # Slice the sequence axis, which is the last one for both
@@ -859,9 +874,12 @@ class TransformerLayer(nn.Layer):
                     dict_args["input_ids"] = decoder_input_ids
             if (
                 not self.config.experimental_dataflow
+                and not _mtp_is_megatron
                 and "attn_mask_startend_row_indices" in dict_args.keys()
             ):
-                # Old dataflow: main mask contains mtp parts appended along seq dim, need to split
+                # Old dataflow (ernie5 L+K path): main mask contains mtp parts
+                # appended along seq dim (total length L+K), split into main
+                # [B,1,L,1] + mtp [B,1,K,1] and hand main to the backbone.
                 attn_mask_startend_row_indices = dict_args[
                     "attn_mask_startend_row_indices"
                 ]
@@ -880,7 +898,9 @@ class TransformerLayer(nn.Layer):
                 )
             else:
                 # New dataflow (experimental_dataflow=True): main mask is already main-seq only,
-                # mtp masks are in mtp_startend_row_indices_all and will be used by MTP layer directly
+                # mtp masks are in mtp_startend_row_indices_all and will be used by MTP layer directly.
+                # Megatron style: mask is already length-L; MTP layer will derive per-depth mask
+                # from cu_seqlens_q, so leave main mask untouched here.
                 attn_mask_startend_row_indices_mtp = None
 
         if self.config.block_attention_residuals and "blocks" not in dict_args:
@@ -1022,8 +1042,13 @@ class TransformerLayer(nn.Layer):
         ):
             hidden_states_concat = paddle.concat([output, *mtp_input])
             rst["hidden_states"] = hidden_states_concat
-            if not self.config.gpt_model_use_experimental_version:
-                if "position_ids" in dict_args.keys():
+            # Under mtp_data_style="megatron" the L+K position-ids split was
+            # skipped up front, so there is nothing to concat back either.
+            if (
+                not self.config.gpt_model_use_experimental_version
+                and not _mtp_is_megatron
+            ):
+                if "position_ids" in dict_args.keys() and mtp_ids is not None:
                     position_ids = paddle.concat(
                         [dict_args["position_ids"], mtp_ids], axis=-1
                     )
@@ -2152,6 +2177,14 @@ class HySparseTransformerLayer(TransformerLayer):
         if not self._mtp_enabled(is_mtp):
             return None
         n = self.config.num_nextn_predict_layers
+        # Under mtp_data_style="megatron" position_ids / masks are already
+        # main-decoder length L (per-doc shifting happens inside the MTP layer
+        # via roll_tensor), so the L+K -> L seq-dim trims below must be
+        # skipped. Mirrors the ``_mtp_is_megatron`` guards in
+        # ``TransformerLayer.forward``.
+        _mtp_is_megatron = (
+            getattr(self.config, "mtp_data_style", "ernie5") == "megatron"
+        )
         ctx = {
             "mtp_ids": None,
             "mtp_input_ids": None,
@@ -2167,8 +2200,11 @@ class HySparseTransformerLayer(TransformerLayer):
         ctx["mtp_input"] = tuple(tensor_list[1:])
         dict_args["hidden_states"] = hidden_states
 
-        # position_ids: split along seq dim
-        if not self.config.gpt_model_use_experimental_version:
+        # position_ids: split along seq dim (ernie5 L+K path only)
+        if (
+            not self.config.gpt_model_use_experimental_version
+            and not _mtp_is_megatron
+        ):
             if (
                 "position_ids" in dict_args
                 and dict_args["position_ids"] is not None
@@ -2226,9 +2262,11 @@ class HySparseTransformerLayer(TransformerLayer):
                 dict_args["input_ids"] = full_input_ids[:, :-n].contiguous()
                 ctx["mtp_input_ids"] = full_input_ids[:, -n:].contiguous()
 
-        # attn_mask_startend_row_indices: split along seq dim (old dataflow)
+        # attn_mask_startend_row_indices: split along seq dim (old dataflow,
+        # ernie5 L+K path only -- under megatron the mask is already length L)
         if (
             not self.config.experimental_dataflow
+            and not _mtp_is_megatron
             and "attn_mask_startend_row_indices" in dict_args
             and dict_args["attn_mask_startend_row_indices"] is not None
         ):

--- a/tests/multi_card_tests/pipeline_parallel/test_gpt_pp_mtp_megatron.py
+++ b/tests/multi_card_tests/pipeline_parallel/test_gpt_pp_mtp_megatron.py
@@ -1,0 +1,241 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""PP>1 + mtp_data_style="megatron" end-to-end loss smoke test.
+
+Pins the fix in ``GPTLMHead.forward`` / ``GPTMainLMHead.forward``:
+``_stash_cu_seqlens_q`` writes the pipeline dict's ``cu_seqlens_q`` onto
+``LanguageLoss._cu_seqlens_q_stash`` on the LAST pipeline stage (which never
+runs ``GPTEmbedding.forward``), so ``LanguageLoss`` can roll MTP labels per
+packed-document boundary under PP>1 without any external dataloader broadcast.
+
+Megatron data contract (differs from the ernie5 template!):
+  * tensors are length-L (NO L+K padding);
+  * a single int32 ``cu_seqlens_q`` = ``[0, d1, ..., L]`` carries the packed-doc
+    boundaries (batch-global semantics);
+  * ``GPTEmbedding`` (stage 0) rolls embeddings per-doc via ``cu_seqlens_q``,
+    the MTP layer derives per-depth attn masks from it, and ``LanguageLoss``
+    (last stage) rolls labels per-doc using the stashed ``cu_seqlens_q``.
+
+If the last-stage stash were missing, ``LanguageLoss.forward`` would raise
+``RuntimeError("... requires cu_seqlens_q to be stashed ...")`` instead of
+silently rolling labels across document boundaries — so a finite loss + a
+clean exit is the positive signal here.
+"""
+
+import functools
+import random
+import unittest
+
+import numpy as np
+import paddle
+from paddle.distributed import fleet
+from paddle.distributed.fleet import distributed_model
+
+import paddlefleet
+from paddlefleet.gpt_builders import gpt_builder
+from paddlefleet.models.gpt import GPTConfig
+from paddlefleet.training.initialize import initialize_fleet
+
+PP_DEGREE = 2
+MTP_DEGREE = 1
+
+
+def _set_random_seed(seed_: int):
+    """Set random seed for reproducibility (different seed per PP stage)."""
+    if seed_ is not None and seed_ > 0:
+        seed = seed_ + (
+            100 * paddlefleet.parallel_state.get_pipeline_model_parallel_rank()
+        )
+        random.seed(seed)
+        np.random.seed(seed)
+        paddle.manual_seed(seed)
+        if (
+            paddle.distributed.is_initialized()
+            and paddle.cuda.device_count() > 0
+        ):
+            paddlefleet.tensor_parallel.model_parallel_cuda_manual_seed(seed)
+    else:
+        raise ValueError(f"Seed ({seed_}) should be a positive integer.")
+
+
+def _build_config(vocab_size, seq_len):
+    return GPTConfig(
+        moe_expert_fusion=False,
+        vocab_size=vocab_size,
+        max_sequence_length=seq_len,
+        num_hidden_layers=4,
+        hidden_size=256,
+        num_attention_heads=4,
+        intermediate_size=512,
+        normalization="RMSNorm",
+        hidden_dropout_prob=0.0,
+        attention_dropout=0.0,
+        use_cpu_initialization=True,
+        parallel_output=True,
+        tie_word_embeddings=True,
+        position_embedding_type="rope",
+        rotary_percent=1.0,
+        rotary_base=10000,
+        rope_scaling=1.0,
+        init_method=functools.partial(paddle.nn.init.xavier_uniform_, gain=1.0),
+        output_layer_init_method=functools.partial(
+            paddle.nn.init.xavier_uniform_, gain=1.0
+        ),
+        use_qk_norm=True,
+        num_empty_layers_add_in_head=1,
+        num_empty_layers_add_in_tail=1,
+        pipeline_model_parallel_size=PP_DEGREE,
+        virtual_pipeline_model_parallel_size=1,
+        tensor_model_parallel_size=1,
+        expert_model_parallel_size=1,
+        sequence_parallel=False,
+        bf16=True,
+        gated_linear_unit=True,
+        bias_activation_fusion=True,
+        # MTP + megatron data style: the whole point of this test.
+        num_nextn_predict_layers=MTP_DEGREE,
+        mtp_loss_scaling_factor=0.3,
+        mtp_data_style="megatron",
+        overlap_p2p_comm=False,
+        batch_p2p_comm=True,
+    )
+
+
+def run_pp(seed, batch_size, seq_len, vocab_size, cu_seqlens_list):
+    config = _build_config(vocab_size, seq_len)
+
+    strategy = fleet.DistributedStrategy()
+    strategy.hybrid_configs = {
+        "dp_degree": 1,
+        "mp_degree": config.tensor_model_parallel_size,
+        "pp_degree": config.pipeline_model_parallel_size,
+        "sharding_degree": 1,
+        "sep_degree": 1,
+        "cp_degree": 1,
+        "ep_degree": config.tensor_model_parallel_size,
+        "moe_sharding_degree": 1,
+        "order": [
+            "sharding",
+            "moe_sharding",
+            "pp",
+            "sep",
+            "cp",
+            "dp",
+            "ep",
+            "mp",
+        ],
+        "pp_configs": {
+            "forward_backward_overlap_scheduler": False,
+            "overlap_p2p_comm": False,
+            "enable_dynamic_shape": True,
+        },
+    }
+    micro_batch_size = 1
+    num_acc = batch_size // micro_batch_size
+    strategy.pipeline_configs = {
+        "accumulate_steps": num_acc,
+        "micro_batch_size": micro_batch_size,
+    }
+    initialize_fleet(strategy)
+
+    _set_random_seed(seed)
+
+    gpt_model = gpt_builder(
+        config,
+        num_stages=config.pipeline_model_parallel_size,
+        seg_method="layer:TransformerLayer|EmptyLayer",
+    )
+    gpt_model = paddle.amp.decorate(
+        models=gpt_model, optimizers=None, level="O2", dtype="bfloat16"
+    )
+    gpt_pipe_model = distributed_model(gpt_model)
+
+    # Megatron contract: length-L tensors (NO L+K padding).
+    input_ids = paddle.randint(
+        low=0, high=vocab_size, shape=(micro_batch_size, seq_len)
+    )
+    labels = paddle.randint(
+        low=0, high=vocab_size, shape=(micro_batch_size, seq_len)
+    )
+    position_ids = (
+        paddle.arange(seq_len, dtype=paddle.int64)
+        .reshape([1, seq_len])
+        .tile([micro_batch_size, 1])
+    )
+    # cu_seqlens_q: int32 1D packed-doc boundaries, batch-global. Must end at L.
+    cu_seqlens_q = paddle.to_tensor(cu_seqlens_list, dtype="int32")
+
+    inputs = (
+        {
+            "input_ids": [input_ids] * num_acc,
+            "position_ids": [position_ids] * num_acc,
+            "cu_seqlens_q": [cu_seqlens_q] * num_acc,
+        },
+        [labels] * num_acc,
+    )
+
+    loss = gpt_pipe_model.forward_backward_pipeline(inputs, None)
+    return loss, gpt_pipe_model, cu_seqlens_q
+
+
+class TestPPMTPMegatron(unittest.TestCase):
+    def setUp(self):
+        self.seed = 46
+        self.batch_size = 4
+        self.seq_len = 32
+        self.vocab_size = 1024
+
+    def test_pp_mtp_megatron(self):
+        # Only meaningful on GPU (needs NCCL P2P + flash attention).
+        if (
+            not paddle.device.current_device_is_cpu
+            and paddle.device.get_device_capability()[0] < 9
+        ):
+            return
+
+        # Multi-document packing: 3 docs inside the length-32 sequence.
+        multi_doc = [0, 12, 20, self.seq_len]
+        loss, _, _ = run_pp(
+            self.seed,
+            self.batch_size,
+            self.seq_len,
+            self.vocab_size,
+            multi_doc,
+        )
+
+        val = float(loss)
+        print(f"[PP-MTP-MEGATRON] multi_doc loss={val}", flush=True)
+        assert np.isfinite(val), f"loss must be finite, got {val}"
+
+        # Correctness signal (rank-agnostic): the MTP loss tracker is only
+        # populated on the loss-computing (last PP) rank, and only *after* the
+        # megatron per-depth label roll succeeds. That roll requires the
+        # cu_seqlens_q that ``GPTLMHead._stash_cu_seqlens_q`` delivered to the
+        # loss stage — without it, ``LanguageLoss.forward`` raises RuntimeError
+        # (and we would never reach here with a finite loss). If the tracker is
+        # populated on this rank, assert every recorded MTP loss is finite.
+        from paddlefleet.models.common.language_loss.language_loss import (
+            LanguageLoss,
+        )
+
+        tracker = dict(LanguageLoss.mtp_loss_tracker)
+        if tracker:
+            print(f"[PP-MTP-MEGATRON] mtp_loss_tracker={tracker}", flush=True)
+            for k, v in tracker.items():
+                assert np.isfinite(float(v)), f"MTP loss {k}={v} must be finite"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/multi_card_tests/pipeline_parallel/test_gpt_pp_mtp_megatron.py
+++ b/tests/multi_card_tests/pipeline_parallel/test_gpt_pp_mtp_megatron.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""PP>1 + mtp_data_style="megatron" end-to-end loss smoke test.
+"""PP>1 + use_erndata=True end-to-end loss smoke test.
 
 Pins the fix in ``GPTLMHead.forward`` / ``GPTMainLMHead.forward``:
 ``_stash_cu_seqlens_q`` writes the pipeline dict's ``cu_seqlens_q`` onto
@@ -107,7 +107,7 @@ def _build_config(vocab_size, seq_len):
         # MTP + megatron data style: the whole point of this test.
         num_nextn_predict_layers=MTP_DEGREE,
         mtp_loss_scaling_factor=0.3,
-        mtp_data_style="megatron",
+        use_erndata=True,
         overlap_p2p_comm=False,
         batch_p2p_comm=True,
     )

--- a/tests/multi_card_tests/pipeline_parallel/test_gpt_pp_mtp_megatron_separate_headloss.py
+++ b/tests/multi_card_tests/pipeline_parallel/test_gpt_pp_mtp_megatron_separate_headloss.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""PP>1 + separate_mtp_headloss=True + mtp_data_style="megatron" end-to-end.
+"""PP>1 + separate_mtp_headloss=True + use_erndata=True end-to-end.
 
 Companion to ``test_gpt_pp_mtp_megatron.py`` (fused GPTLMHead + LanguageLoss).
 This variant exercises the SEPARATE head/loss path:
@@ -109,7 +109,7 @@ def _build_config(vocab_size, seq_len):
         num_nextn_predict_layers=MTP_DEGREE,
         mtp_loss_scaling_factor=0.3,
         separate_mtp_headloss=True,
-        mtp_data_style="megatron",
+        use_erndata=True,
         overlap_p2p_comm=True,
     )
 

--- a/tests/multi_card_tests/pipeline_parallel/test_gpt_pp_mtp_megatron_separate_headloss.py
+++ b/tests/multi_card_tests/pipeline_parallel/test_gpt_pp_mtp_megatron_separate_headloss.py
@@ -1,0 +1,244 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""PP>1 + separate_mtp_headloss=True + mtp_data_style="megatron" end-to-end.
+
+Companion to ``test_gpt_pp_mtp_megatron.py`` (fused GPTLMHead + LanguageLoss).
+This variant exercises the SEPARATE head/loss path:
+  * ``GPTMTPLMHead`` runs on the last stage and stashes cu_seqlens_q;
+  * ``MTPLanguageLoss.forward`` rolls per-depth labels per packed doc via
+    ``_megatron_label_for_depth`` (pad_value=ignored_index);
+  * ``MainLanguageLoss.forward`` keeps the main label full-length L.
+
+Layout (guarded by GPTConfig.__post_init__ for separate_mtp_headloss):
+  total = num_hidden(1) + mtp(1) + num_empty(head0 + max(0,tail3-1)=2) = 4
+        = pp(4) * vpp(1)  -> exactly one seg-weight layer per virtual stage.
+separate_mtp_headloss needs tail>=3 (reserves tail slots for the separated
+MTP-LMHead / main-LMHead) and pp>2 is only required when vpp>1, so this uses
+vpp=1 with pp=4 (4 GPUs, no interleave). seg_method includes
+MultiTokenPredictionLayer so the MTP layer carries a segmentation weight,
+matching the production entry point.
+
+Megatron data contract: length-L tensors + a single int32 cu_seqlens_q. A
+finite loss + clean exit proves the last-stage stash reached both the MTP and
+main losses (otherwise ``_megatron_label_for_depth`` raises RuntimeError).
+"""
+
+import functools
+import random
+import unittest
+
+import numpy as np
+import paddle
+from paddle.distributed import fleet
+from paddle.distributed.fleet import distributed_model
+
+import paddlefleet
+from paddlefleet.gpt_builders import gpt_builder
+from paddlefleet.models.gpt import GPTConfig
+from paddlefleet.training.initialize import initialize_fleet
+
+PP_DEGREE = 4
+VPP_DEGREE = 1
+MTP_DEGREE = 1
+SEG_METHOD = "layer:TransformerLayer|EmptyLayer|MultiTokenPredictionLayer"
+
+
+def _set_random_seed(seed_: int):
+    if seed_ is not None and seed_ > 0:
+        seed = seed_ + (
+            100 * paddlefleet.parallel_state.get_pipeline_model_parallel_rank()
+        )
+        random.seed(seed)
+        np.random.seed(seed)
+        paddle.manual_seed(seed)
+        if (
+            paddle.distributed.is_initialized()
+            and paddle.cuda.device_count() > 0
+        ):
+            paddlefleet.tensor_parallel.model_parallel_cuda_manual_seed(seed)
+    else:
+        raise ValueError(f"Seed ({seed_}) should be a positive integer.")
+
+
+def _build_config(vocab_size, seq_len):
+    return GPTConfig(
+        moe_expert_fusion=False,
+        vocab_size=vocab_size,
+        max_sequence_length=seq_len,
+        num_hidden_layers=1,
+        hidden_size=256,
+        num_attention_heads=4,
+        intermediate_size=512,
+        normalization="RMSNorm",
+        hidden_dropout_prob=0.0,
+        attention_dropout=0.0,
+        use_cpu_initialization=True,
+        parallel_output=True,
+        tie_word_embeddings=True,
+        position_embedding_type="rope",
+        rotary_percent=1.0,
+        rotary_base=10000,
+        rope_scaling=1.0,
+        init_method=functools.partial(paddle.nn.init.xavier_uniform_, gain=1.0),
+        output_layer_init_method=functools.partial(
+            paddle.nn.init.xavier_uniform_, gain=1.0
+        ),
+        use_qk_norm=True,
+        num_empty_layers_add_in_head=0,
+        num_empty_layers_add_in_tail=3,
+        pipeline_model_parallel_size=PP_DEGREE,
+        virtual_pipeline_model_parallel_size=VPP_DEGREE,
+        tensor_model_parallel_size=1,
+        expert_model_parallel_size=1,
+        sequence_parallel=False,
+        bf16=True,
+        gated_linear_unit=True,
+        bias_activation_fusion=True,
+        num_nextn_predict_layers=MTP_DEGREE,
+        mtp_loss_scaling_factor=0.3,
+        separate_mtp_headloss=True,
+        mtp_data_style="megatron",
+        overlap_p2p_comm=True,
+    )
+
+
+def run_pp(seed, batch_size, seq_len, vocab_size, cu_seqlens_list):
+    config = _build_config(vocab_size, seq_len)
+
+    strategy = fleet.DistributedStrategy()
+    strategy.hybrid_configs = {
+        "dp_degree": 1,
+        "mp_degree": config.tensor_model_parallel_size,
+        "pp_degree": config.pipeline_model_parallel_size,
+        "sharding_degree": 1,
+        "sep_degree": 1,
+        "cp_degree": 1,
+        "ep_degree": config.tensor_model_parallel_size,
+        "moe_sharding_degree": 1,
+        "order": [
+            "sharding",
+            "moe_sharding",
+            "pp",
+            "sep",
+            "cp",
+            "dp",
+            "ep",
+            "mp",
+        ],
+        "pp_configs": {
+            "forward_backward_overlap_scheduler": False,
+            "overlap_p2p_comm": True,
+            "enable_dynamic_shape": True,
+        },
+    }
+    micro_batch_size = 1
+    num_acc = batch_size // micro_batch_size
+    strategy.pipeline_configs = {
+        "accumulate_steps": num_acc,
+        "micro_batch_size": micro_batch_size,
+    }
+    initialize_fleet(strategy)
+
+    _set_random_seed(seed)
+
+    gpt_model = gpt_builder(
+        config,
+        num_stages=config.pipeline_model_parallel_size,
+        seg_method=SEG_METHOD,
+    )
+    gpt_model = paddle.amp.decorate(
+        models=gpt_model, optimizers=None, level="O2", dtype="bfloat16"
+    )
+    gpt_pipe_model = distributed_model(gpt_model)
+
+    # Megatron contract: length-L tensors (NO L+K padding).
+    input_ids = paddle.randint(
+        low=0, high=vocab_size, shape=(micro_batch_size, seq_len)
+    )
+    labels = paddle.randint(
+        low=0, high=vocab_size, shape=(micro_batch_size, seq_len)
+    )
+    position_ids = (
+        paddle.arange(seq_len, dtype=paddle.int64)
+        .reshape([1, seq_len])
+        .tile([micro_batch_size, 1])
+    )
+    cu_seqlens_q = paddle.to_tensor(cu_seqlens_list, dtype="int32")
+
+    # separate_mtp_headloss runs MTPLanguageLoss as an in-pipeline layer that
+    # reads labels from the pipeline dict, so labels must ride inputs[0] (via
+    # GPTEmbedding) in addition to being the final-loss label in inputs[1]
+    # (consumed by MainLanguageLoss).
+    inputs = (
+        {
+            "input_ids": [input_ids] * num_acc,
+            "position_ids": [position_ids] * num_acc,
+            "cu_seqlens_q": [cu_seqlens_q] * num_acc,
+            "labels": [labels] * num_acc,
+        },
+        [labels] * num_acc,
+    )
+
+    loss = gpt_pipe_model.forward_backward_pipeline(inputs, None)
+    return loss, gpt_pipe_model
+
+
+class TestPPMTPMegatronSeparateHeadloss(unittest.TestCase):
+    def setUp(self):
+        self.seed = 46
+        self.batch_size = 4
+        self.seq_len = 32
+        self.vocab_size = 1024
+
+    def test_pp_mtp_megatron_separate_headloss(self):
+        if (
+            not paddle.device.current_device_is_cpu
+            and paddle.device.get_device_capability()[0] < 9
+        ):
+            return
+
+        # Multi-document packing: 3 docs inside the length-32 sequence.
+        multi_doc = [0, 12, 20, self.seq_len]
+        loss, _ = run_pp(
+            self.seed,
+            self.batch_size,
+            self.seq_len,
+            self.vocab_size,
+            multi_doc,
+        )
+
+        val = float(loss)
+        print(f"[PP-MTP-MEGATRON-SEP] separate_headloss loss={val}", flush=True)
+        assert np.isfinite(val), f"loss must be finite, got {val}"
+
+        # The separated MainLanguageLoss populates its own MTP loss tracker only
+        # after the per-depth megatron roll succeeds -- which requires the
+        # cu_seqlens_q that GPTMTPLMHead._stash_cu_seqlens_q delivered to the
+        # loss stage. If present on this rank, every recorded MTP loss is finite.
+        from paddlefleet.models.common.language_loss.language_loss import (
+            MainLanguageLoss,
+        )
+
+        tracker = dict(MainLanguageLoss.mtp_loss_tracker)
+        if tracker:
+            print(
+                f"[PP-MTP-MEGATRON-SEP] mtp_loss_tracker={tracker}", flush=True
+            )
+            for k, v in tracker.items():
+                assert np.isfinite(float(v)), f"MTP loss {k}={v} must be finite"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/multi_card_tests/test_gpt_mtp_megatron_cp.py
+++ b/tests/multi_card_tests/test_gpt_mtp_megatron_cp.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""CP-aware ``mtp_data_style="megatron"`` end-to-end test (CP=1 vs CP=2).
+"""CP-aware ``use_erndata=True`` end-to-end test (CP=1 vs CP=2).
 
 The megatron MTP branch in ``GPTEmbedding`` slices the sequence itself with
 ``extract_local_zigzag_chunks`` instead of going through
@@ -140,7 +140,7 @@ def _make_config():
         # MTP, megatron data style
         num_nextn_predict_layers=NUM_MTP,
         mtp_loss_scaling_factor=0.3,
-        mtp_data_style="megatron",
+        use_erndata=True,
         # CP
         context_parallel_size=CP_SIZE,
         cp_balance_mode="dualchunk_allgather",

--- a/tests/multi_card_tests/test_gpt_mtp_megatron_cp.py
+++ b/tests/multi_card_tests/test_gpt_mtp_megatron_cp.py
@@ -163,8 +163,17 @@ def _make_config():
     )
 
 
-def _make_inputs():
-    """Megatron contract: length-L tensors (no L+K padding) + cu_seqlens_q."""
+def _make_inputs(with_mask=True):
+    """Megatron contract: length-L tensors (no L+K padding) + cu_seqlens_q.
+
+    ``with_mask=False`` reproduces the minimal erndata contract, where only
+    ``cu_seqlens_q`` carries the doc boundaries and no materialized flashmask is
+    supplied (erndata emits ``attn_mask_startend_row_indices`` only when
+    ``pack_by_cu_seqlen=True``). ``GPTEmbedding`` must then derive the main mask
+    itself, otherwise the CP branch of ``DotProductAttention`` synthesizes an
+    all-visible mask and runs flashmask with ``causal=False``, silently dropping
+    causality and doc boundaries from the backbone.
+    """
     paddle.seed(SEED)
     data = paddle.randint(low=1, high=VOCAB, shape=(BATCH, SEQ + 1)).cuda()
     # Same data on every CP rank. Skipped at world size 1, where fleet leaves
@@ -182,43 +191,43 @@ def _make_inputs():
     )
     cu_seqlens_q = paddle.to_tensor(CU_SEQLENS, dtype="int32").cuda()
 
-    # Full-length per-doc flashmask boundaries. CP attention allgathers KV and
-    # remaps these global row values itself (preprocess_index_dual_chunks), so
-    # they are intentionally NOT sliced. 1 column because
-    # gpt_model_use_experimental_version=False.
-    end = np.zeros(SEQ, dtype=np.int32)
-    for j in range(len(CU_SEQLENS) - 1):
-        s, e = CU_SEQLENS[j], CU_SEQLENS[j + 1]
-        end[s:e] = e
-    attn_mask_startend_row_indices = (
-        paddle.to_tensor(end[None, None, :, None]).tile([BATCH, 1, 1, 1]).cuda()
-    )
-
-    return {
+    out = {
         "input_ids": input_ids,
         "labels": labels,
         "position_ids": position_ids,
         "cu_seqlens_q": cu_seqlens_q,
-        "attn_mask_startend_row_indices": attn_mask_startend_row_indices,
     }
+    if with_mask:
+        # Full-length per-doc flashmask boundaries. CP attention allgathers KV
+        # and remaps these global row values itself
+        # (preprocess_index_dual_chunks), so they are intentionally NOT sliced.
+        # 1 column because gpt_model_use_experimental_version=False.
+        end = np.zeros(SEQ, dtype=np.int32)
+        for j in range(len(CU_SEQLENS) - 1):
+            s, e = CU_SEQLENS[j], CU_SEQLENS[j + 1]
+            end[s:e] = e
+        out["attn_mask_startend_row_indices"] = (
+            paddle.to_tensor(end[None, None, :, None])
+            .tile([BATCH, 1, 1, 1])
+            .cuda()
+        )
+    return out
 
 
 def _forward_backward(model, raw):
     pipe_model = NoPipelineParallel(model, STRATEGY)
     labels = raw["labels"].clone()
-    inputs = (
-        {
-            "input_ids": [raw["input_ids"].clone()],
-            "position_ids": [raw["position_ids"].clone()],
-            "cu_seqlens_q": [raw["cu_seqlens_q"].clone()],
-            "attn_mask_startend_row_indices": [
-                raw["attn_mask_startend_row_indices"].clone()
-            ],
-            "labels": [labels],
-        },
-        labels,
-    )
-    return pipe_model.forward_backward_pipeline(inputs)
+    micro = {
+        "input_ids": [raw["input_ids"].clone()],
+        "position_ids": [raw["position_ids"].clone()],
+        "cu_seqlens_q": [raw["cu_seqlens_q"].clone()],
+        "labels": [labels],
+    }
+    if "attn_mask_startend_row_indices" in raw:
+        micro["attn_mask_startend_row_indices"] = [
+            raw["attn_mask_startend_row_indices"].clone()
+        ]
+    return pipe_model.forward_backward_pipeline((micro, labels))
 
 
 def _find_embedding(model):
@@ -332,6 +341,106 @@ class TestMTPMegatronCP(unittest.TestCase):
             self.assertTrue(
                 np.isfinite(float(v)), f"MTP loss {k}={v} must be finite"
             )
+
+
+class TestMTPMegatronMainMaskFromCuSeqlens(unittest.TestCase):
+    """The main flashmask must be derived when the contract omits it.
+
+    erndata only guarantees length-L tensors + cu_seqlens_q. When
+    ``attn_mask_startend_row_indices`` is absent, ``GPTEmbedding`` must build it
+    from ``cu_seqlens_q``; otherwise the CP branch of ``DotProductAttention``
+    fills in an all-visible mask and calls flashmask with ``causal=False``,
+    which drops both causality and document boundaries from the backbone.
+    """
+
+    def test_embedding_derives_main_mask(self):
+        paddle.seed(SEED)
+        model = gpt_builder(_make_config(), num_stages=1)
+        emb = _find_embedding(model)
+        raw = _make_inputs(with_mask=False)
+        self.assertNotIn("attn_mask_startend_row_indices", raw)
+
+        out = emb.forward(
+            {
+                "input_ids": raw["input_ids"],
+                "position_ids": raw["position_ids"],
+                "cu_seqlens_q": raw["cu_seqlens_q"],
+            }
+        )
+
+        mask = out.get("attn_mask_startend_row_indices")
+        self.assertIsNotNone(
+            mask,
+            "GPTEmbedding must derive the main mask from cu_seqlens_q",
+        )
+        # Full length L (not the rank-local L/cp): CP attention allgathers KV
+        # and remaps these global row values itself.
+        self.assertEqual(list(mask.shape), [BATCH, 1, SEQ, 1])
+        self.assertEqual(mask.dtype, paddle.int32)
+
+        # Values must be the per-doc end rows implied by CU_SEQLENS.
+        expected = np.zeros(SEQ, dtype=np.int32)
+        for j in range(len(CU_SEQLENS) - 1):
+            s, e = CU_SEQLENS[j], CU_SEQLENS[j + 1]
+            expected[s:e] = e
+        np.testing.assert_array_equal(
+            mask.numpy()[0, 0, :, 0],
+            expected,
+        )
+
+    def test_derived_mask_matches_explicit_mask(self):
+        """Deriving must be equivalent to passing the mask in explicitly."""
+        paddle.seed(SEED)
+        model = gpt_builder(_make_config(), num_stages=1)
+        emb = _find_embedding(model)
+
+        raw_with = _make_inputs(with_mask=True)
+        raw_without = _make_inputs(with_mask=False)
+
+        out_with = emb.forward(
+            {
+                "input_ids": raw_with["input_ids"],
+                "position_ids": raw_with["position_ids"],
+                "cu_seqlens_q": raw_with["cu_seqlens_q"],
+                "attn_mask_startend_row_indices": raw_with[
+                    "attn_mask_startend_row_indices"
+                ],
+            }
+        )
+        out_without = emb.forward(
+            {
+                "input_ids": raw_without["input_ids"],
+                "position_ids": raw_without["position_ids"],
+                "cu_seqlens_q": raw_without["cu_seqlens_q"],
+            }
+        )
+        np.testing.assert_array_equal(
+            out_with["attn_mask_startend_row_indices"].numpy(),
+            out_without["attn_mask_startend_row_indices"].numpy(),
+        )
+
+    def test_cp_loss_without_explicit_mask(self):
+        """End-to-end on the minimal contract: same loss as with the mask."""
+        if (
+            not paddle.device.current_device_is_cpu
+            and paddle.device.get_device_capability()[0] < 9
+        ):
+            self.skipTest("requires SM90+ for the CP flashmask kernels")
+
+        paddle.seed(SEED)
+        model = gpt_builder(_make_config(), num_stages=1)
+        model = paddle.amp.decorate(
+            models=model, optimizers=None, level="O2", dtype="bfloat16"
+        )
+        loss = _forward_backward(model, _make_inputs(with_mask=False))
+        val = float(loss.astype("float32"))
+        print(
+            f"[MTP-MEGATRON-CP] cp={CP_SIZE} loss(no explicit mask)={val}",
+            flush=True,
+        )
+        self.assertTrue(np.isfinite(val), f"loss must be finite, got {val}")
+        if REF_LOSS is not None:
+            np.testing.assert_allclose(val, REF_LOSS, rtol=5e-3, atol=0)
 
 
 if __name__ == "__main__":

--- a/tests/multi_card_tests/test_gpt_mtp_megatron_cp.py
+++ b/tests/multi_card_tests/test_gpt_mtp_megatron_cp.py
@@ -1,0 +1,338 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CP-aware ``mtp_data_style="megatron"`` end-to-end test (CP=1 vs CP=2).
+
+The megatron MTP branch in ``GPTEmbedding`` slices the sequence itself with
+``extract_local_zigzag_chunks`` instead of going through
+``ContextParallelScatterOp`` (which is gated on ``experimental_dataflow``, a
+flag this style forbids). The RoPE tables are built by
+``RotaryEmbedding.get_rotary_seq_len``, which scales the rank-local length back
+up by ``cp_group.world_size`` and therefore always yields the FULL length L --
+so they must be zigzag-sliced with the same layout, otherwise every rank
+applies the positions ``0..L/cp-1`` to chunks that actually live at
+``[interval*r, interval*(r+1)) u [L-interval*(r+1), L-interval*r)``.
+
+The primary check is a LAYOUT one (``test_rope_matches_zigzag_layout``): the
+``rotary_pos_emb`` the real ``GPTEmbedding`` hands to the decoder must equal the
+zigzag slice of the full-length table this rank's ``RotaryEmbedding`` produces.
+
+``test_cp_invariant_loss`` is a coarse companion: same weights (CPU init, so
+rank-independent) and same data must give the same loss at any ``cp_degree``.
+``REF_LOSS`` is the single-card value; run
+
+    python -m paddle.distributed.launch --gpus=0 \
+        tests/multi_card_tests/test_gpt_mtp_megatron_cp.py
+
+to regenerate it and
+
+    python -m paddle.distributed.launch --gpus=0,1 \
+        tests/multi_card_tests/test_gpt_mtp_megatron_cp.py
+
+for the CP=2 comparison. Note the loss alone is a weak signal on a randomly
+initialised 2-layer model: measured against a deliberately broken
+contiguous-prefix RoPE it only moves 9.246039 -> 9.247475 (1.6e-4 relative),
+inside the bf16 tolerance below. Hence the layout assertion.
+"""
+
+import functools
+import os
+import sys
+import unittest
+
+# Prefer the local source tree over an installed paddlefleet, mirroring
+# PYTHONPATH in script/train_gpu.sh.
+_repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(_repo_root, "src"))
+
+import numpy as np
+import paddle
+import paddle.distributed as dist
+from paddle.distributed import fleet
+from paddle.distributed.fleet.meta_parallel import NoPipelineParallel
+
+from paddlefleet.gpt_builders import gpt_builder
+from paddlefleet.models.gpt import GPTConfig
+from paddlefleet.tensor_parallel.random import model_parallel_cuda_manual_seed
+from paddlefleet.training.initialize import initialize_fleet
+
+VOCAB = 1024
+SEQ = 32  # divisible by 2 * cp_size, as the zigzag split requires
+NUM_MTP = 1
+BATCH = 1
+SEED = 46
+# Packed multi-document layout: 3 docs inside the length-32 sequence.
+CU_SEQLENS = [0, 12, 20, SEQ]
+
+# Single-card (cp_degree=1) reference loss, see module docstring.
+REF_LOSS = 9.246039390563965
+
+CP_SIZE = None
+STRATEGY = None
+
+
+def setUpModule():
+    global CP_SIZE, STRATEGY
+    CP_SIZE = dist.get_world_size()
+    STRATEGY = fleet.DistributedStrategy()
+    STRATEGY.hybrid_configs = {
+        "dp_degree": 1,
+        "mp_degree": 1,
+        "pp_degree": 1,
+        # Same overlapping sharding/cp/ep shape as the other CP tests in this
+        # directory: ep_degree > 1 selects paddle's expert-aware
+        # HybridCommunicateGroup, which is what makes the overlap legal.
+        "sharding_degree": CP_SIZE,
+        "sep_degree": 1,
+        "cp_degree": CP_SIZE,
+        "ep_degree": CP_SIZE,
+        "moe_sharding_degree": 1,
+        "order": [
+            "sharding",
+            "moe_sharding",
+            "pp",
+            "sep",
+            "cp",
+            "dp",
+            "ep",
+            "mp",
+        ],
+    }
+    initialize_fleet(STRATEGY)
+    paddle.seed(SEED)
+    model_parallel_cuda_manual_seed(SEED)
+
+
+def _make_config():
+    return GPTConfig(
+        vocab_size=VOCAB,
+        max_sequence_length=SEQ,
+        num_hidden_layers=2,
+        hidden_size=256,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        intermediate_size=512,
+        normalization="RMSNorm",
+        hidden_dropout_prob=0.0,
+        attention_dropout=0.0,
+        # CPU init keeps the weights bit-identical across world sizes, which is
+        # what makes the CP=1 reference loss comparable.
+        use_cpu_initialization=True,
+        parallel_output=True,
+        tie_word_embeddings=True,
+        position_embedding_type="rope",
+        rotary_percent=1.0,
+        rotary_base=10000,
+        rope_scaling=1.0,
+        apply_rope_fusion=False,
+        gated_linear_unit=True,
+        # MTP, megatron data style
+        num_nextn_predict_layers=NUM_MTP,
+        mtp_loss_scaling_factor=0.3,
+        mtp_data_style="megatron",
+        # CP
+        context_parallel_size=CP_SIZE,
+        cp_balance_mode="dualchunk_allgather",
+        experimental_dataflow=False,
+        sequence_parallel=False,
+        tensor_model_parallel_size=1,
+        pipeline_model_parallel_size=1,
+        # bf16 compute with fp32 master params: `use_cpu_initialization` builds
+        # its master weight in fp32 (`_initialize_affine_weight_cpu`) and copies
+        # it into the parameter as-is, so a bf16 `params_dtype` would fail the
+        # dtype check. `paddle.amp.decorate(level="O2")` below casts for compute
+        # instead, matching tests/multi_card_tests/pipeline_parallel/
+        # test_gpt_pp_mtp_megatron.py.
+        bf16=True,
+        gpt_model_use_experimental_version=False,
+        init_method=functools.partial(paddle.nn.init.xavier_uniform_, gain=1.0),
+        output_layer_init_method=functools.partial(
+            paddle.nn.init.xavier_uniform_, gain=1.0
+        ),
+    )
+
+
+def _make_inputs():
+    """Megatron contract: length-L tensors (no L+K padding) + cu_seqlens_q."""
+    paddle.seed(SEED)
+    data = paddle.randint(low=1, high=VOCAB, shape=(BATCH, SEQ + 1)).cuda()
+    # Same data on every CP rank. Skipped at world size 1, where fleet leaves
+    # the global communication group uninitialized.
+    if CP_SIZE > 1:
+        dist.broadcast(data, src=0)
+    input_ids = data[:, :-1].contiguous()
+    labels = data[:, 1:].contiguous()
+
+    position_ids = (
+        paddle.arange(SEQ, dtype=paddle.int64)
+        .reshape([1, SEQ])
+        .tile([BATCH, 1])
+        .cuda()
+    )
+    cu_seqlens_q = paddle.to_tensor(CU_SEQLENS, dtype="int32").cuda()
+
+    # Full-length per-doc flashmask boundaries. CP attention allgathers KV and
+    # remaps these global row values itself (preprocess_index_dual_chunks), so
+    # they are intentionally NOT sliced. 1 column because
+    # gpt_model_use_experimental_version=False.
+    end = np.zeros(SEQ, dtype=np.int32)
+    for j in range(len(CU_SEQLENS) - 1):
+        s, e = CU_SEQLENS[j], CU_SEQLENS[j + 1]
+        end[s:e] = e
+    attn_mask_startend_row_indices = (
+        paddle.to_tensor(end[None, None, :, None]).tile([BATCH, 1, 1, 1]).cuda()
+    )
+
+    return {
+        "input_ids": input_ids,
+        "labels": labels,
+        "position_ids": position_ids,
+        "cu_seqlens_q": cu_seqlens_q,
+        "attn_mask_startend_row_indices": attn_mask_startend_row_indices,
+    }
+
+
+def _forward_backward(model, raw):
+    pipe_model = NoPipelineParallel(model, STRATEGY)
+    labels = raw["labels"].clone()
+    inputs = (
+        {
+            "input_ids": [raw["input_ids"].clone()],
+            "position_ids": [raw["position_ids"].clone()],
+            "cu_seqlens_q": [raw["cu_seqlens_q"].clone()],
+            "attn_mask_startend_row_indices": [
+                raw["attn_mask_startend_row_indices"].clone()
+            ],
+            "labels": [labels],
+        },
+        labels,
+    )
+    return pipe_model.forward_backward_pipeline(inputs)
+
+
+def _find_embedding(model):
+    """The GPTEmbedding instance inside a built (single-stage) GPT model."""
+    from paddlefleet.models.gpt.gpt_embedding import GPTEmbedding
+
+    for layer in model.sublayers(include_self=True):
+        if isinstance(layer, GPTEmbedding):
+            return layer
+    raise AssertionError("no GPTEmbedding found in the built model")
+
+
+class TestMTPMegatronCPRope(unittest.TestCase):
+    def test_rope_matches_zigzag_layout(self):
+        """The decoder's RoPE table must be this rank's zigzag chunk.
+
+        Runs the real ``GPTEmbedding.forward`` (real ``RotaryEmbedding``, real
+        CP group) and compares its ``rotary_pos_emb`` against the zigzag slice
+        of the full-length table. A contiguous prefix -- what the code produced
+        before the fix -- fails this at any CP degree > 1.
+        """
+        from paddlefleet.parallel_state import get_context_parallel_rank
+        from paddlefleet.transformer.multi_token_prediction import (
+            extract_local_zigzag_chunks,
+        )
+
+        paddle.seed(SEED)
+        model = gpt_builder(_make_config(), num_stages=1)
+        emb = _find_embedding(model)
+        raw = _make_inputs()
+
+        out = emb.forward(
+            {
+                "input_ids": raw["input_ids"],
+                "position_ids": raw["position_ids"],
+                "cu_seqlens_q": raw["cu_seqlens_q"],
+            }
+        )
+        rope_local = out["rotary_pos_emb"]
+
+        # Rank-local sequence length: the megatron branch keeps the full L and
+        # zigzag-slices it, so both hidden states and RoPE must be L / cp.
+        self.assertEqual(out["hidden_states"].shape[1], SEQ // CP_SIZE)
+        self.assertEqual(rope_local.shape[1], SEQ // CP_SIZE)
+
+        # Full-length table straight from this rank's RotaryEmbedding, sliced
+        # with the layout the embeddings used.
+        full = emb.rotary_pos_emb(SEQ)
+        cp_rank = get_context_parallel_rank() if CP_SIZE > 1 else 0
+        expected = extract_local_zigzag_chunks(full, cp_rank, CP_SIZE, axis=1)
+        np.testing.assert_array_equal(
+            rope_local.astype("float32").numpy(),
+            expected.astype("float32").numpy(),
+        )
+
+        if CP_SIZE > 1:
+            # And it must NOT be the contiguous prefix (the pre-fix layout).
+            contiguous = full[:, : SEQ // CP_SIZE]
+            self.assertFalse(
+                bool(
+                    paddle.all(
+                        rope_local.astype("float32")
+                        == contiguous.astype("float32")
+                    )
+                ),
+                "rank>0 must not receive the contiguous RoPE prefix",
+            )
+
+
+class TestMTPMegatronCP(unittest.TestCase):
+    def test_cp_invariant_loss(self):
+        # Needs flash attention (SM90+) for the CP flashmask path.
+        if (
+            not paddle.device.current_device_is_cpu
+            and paddle.device.get_device_capability()[0] < 9
+        ):
+            self.skipTest("requires SM90+ for the CP flashmask kernels")
+
+        paddle.seed(SEED)
+        model = gpt_builder(_make_config(), num_stages=1)
+        model = paddle.amp.decorate(
+            models=model, optimizers=None, level="O2", dtype="bfloat16"
+        )
+        loss = _forward_backward(model, _make_inputs())
+
+        val = float(loss.astype("float32"))
+        print(f"[MTP-MEGATRON-CP] cp={CP_SIZE} loss={val}", flush=True)
+        self.assertTrue(np.isfinite(val), f"loss must be finite, got {val}")
+
+        grads = [p.grad for p in model.parameters() if p.grad is not None]
+        self.assertGreater(len(grads), 0, "no gradients were produced")
+        for g in grads:
+            self.assertTrue(
+                bool(paddle.isfinite(g.astype("float32")).all()),
+                "gradients must be finite",
+            )
+
+        if REF_LOSS is not None:
+            # bf16 tolerance: CP changes the attention reduction order
+            # (allgathered KV) but not the math. A wrong RoPE layout is off by
+            # far more than this.
+            np.testing.assert_allclose(val, REF_LOSS, rtol=5e-3, atol=0)
+
+        from paddlefleet.models.common.language_loss.language_loss import (
+            LanguageLoss,
+        )
+
+        tracker = dict(LanguageLoss.mtp_loss_tracker)
+        self.assertTrue(tracker, "MTP loss tracker was never populated")
+        for k, v in tracker.items():
+            self.assertTrue(
+                np.isfinite(float(v)), f"MTP loss {k}={v} must be finite"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_language_loss_2.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_language_loss_2.py
@@ -172,6 +172,10 @@ class TestLanguageLossForwardWithMTP(unittest.TestCase):
         mock_config.mtp_loss_scaling_factor = 1.0
         mock_config.recompute_modules = None
         mock_config.gpt_model_use_experimental_version = False
+        # MagicMock attributes are truthy, so pin the real default: otherwise
+        # the erndata packed-doc MTP branch is taken and the L+K label trim is
+        # skipped.
+        mock_config.use_erndata = False
 
         loss_fn = LanguageLoss(config=mock_config)
         logits = [

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_language_loss_3.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_language_loss_3.py
@@ -200,6 +200,10 @@ class TestLanguageLossForwardWithListLogits(unittest.TestCase):
         mock_config.mtp_loss_scaling_factor = 0.5
         mock_config.gpt_model_use_experimental_version = True
         mock_config.fused_linear_ce_loss_chunk = 0
+        # MagicMock attributes are truthy, so pin the real default: otherwise
+        # the erndata packed-doc MTP branch is taken and the L+K label trim is
+        # skipped.
+        mock_config.use_erndata = False
 
         loss_fn = LanguageLoss(config=mock_config)
         vocab_size = 128
@@ -237,6 +241,10 @@ class TestLanguageLossForwardWithListLogits(unittest.TestCase):
         mock_config.add_mtp_loss = True
         mock_config.mtp_loss_scaling_factor = 1.0
         mock_config.gpt_model_use_experimental_version = False
+        # MagicMock attributes are truthy, so pin the real default: otherwise
+        # the erndata packed-doc MTP branch is taken and the loss demands a
+        # cu_seqlens_q stash this test never provides.
+        mock_config.use_erndata = False
 
         loss_fn = LanguageLoss(config=mock_config)
         vocab_size = 128

--- a/tests/single_card_tests/transformer/test_cu_seqlens_q_pp_broadcast.py
+++ b/tests/single_card_tests/transformer/test_cu_seqlens_q_pp_broadcast.py
@@ -3,7 +3,7 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 
-"""PP>1 support for cu_seqlens_q under mtp_data_style="megatron".
+"""PP>1 support for cu_seqlens_q under use_erndata=True.
 
 Two invariants pinned here:
 

--- a/tests/single_card_tests/transformer/test_cu_seqlens_q_pp_broadcast.py
+++ b/tests/single_card_tests/transformer/test_cu_seqlens_q_pp_broadcast.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2026 Baidu, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""PP>1 support for cu_seqlens_q under mtp_data_style="megatron".
+
+Two invariants pinned here:
+
+  1. `cu_seqlens_q` (int32 [num_docs+1]) round-trips through
+     `broadcast_data_obj` unchanged when mixed into a tuple alongside
+     int64 / bfloat16 / None entries — same shape / dtype / values on
+     receiver side. This is the primitive the dataloader relies on.
+
+  2. `LanguageLoss._cu_seqlens_q_stash` is a plain class-level slot
+     that can be written and read across module-level references
+     without falling out of scope. This is the mechanism by which the
+     last PP stage (which never runs `gpt_embedding.forward`) sees
+     `cu_seqlens_q` — the dataloader writes it on every rank right
+     after the three `broadcast_data_obj` calls.
+
+See ernie5/src/datasets/dist_data_loader.py.
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import paddle
+
+from paddlefleet.models.common.language_loss.language_loss import (
+    LanguageLoss,
+)
+from paddlefleet.pipeline_parallel.pp_utils.pp_comm_utils import (
+    broadcast_data_obj,
+)
+
+
+class TestCuSeqlensQBroadcast(unittest.TestCase):
+    """cu_seqlens_q must survive broadcast_data_obj alongside other dtypes."""
+
+    def test_cu_seqlens_q_roundtrips_alongside_mixed_dtypes(self) -> None:
+        # Emulate a slice of the real dataloader tuple: int64 ids/labels,
+        # bfloat16 image scale, None for absent optional, int32 cu_seqlens_q.
+        cu = paddle.to_tensor([0, 4, 10, 16], dtype="int32")
+        input_ids = paddle.arange(16, dtype="int64").reshape([1, 16])
+        labels = paddle.arange(16, dtype="int64").reshape([1, 16])
+        image_scale = paddle.zeros([1], dtype="bfloat16")
+
+        # Sender side — broadcast_data_obj concats same-dtype tensors, so
+        # this exercises the int32 group (cu_seqlens_q alone in its dtype
+        # bucket among these fields).
+        with (
+            patch("paddle.distributed.get_rank", return_value=0),
+            patch("paddle.distributed.broadcast_object_list"),
+            patch("paddle.distributed.broadcast"),
+        ):
+            out = broadcast_data_obj(
+                [input_ids, labels, image_scale, None, cu],
+                src_rank=0,
+                group=MagicMock(),
+            )
+        # Sender path returns the same values (no receive branch invoked).
+        self.assertIsNone(out[3])
+        self.assertEqual(out[4].dtype, paddle.int32)
+        self.assertEqual(out[4].shape, [4])
+        self.assertEqual(out[4].numpy().tolist(), [0, 4, 10, 16])
+
+
+class TestLanguageLossStashAcrossModules(unittest.TestCase):
+    """The dataloader writes stash on every rank; loss reads it later."""
+
+    def setUp(self) -> None:
+        # Ensure we don't leak state from other tests.
+        LanguageLoss._cu_seqlens_q_stash = None
+
+    def tearDown(self) -> None:
+        LanguageLoss._cu_seqlens_q_stash = None
+
+    def test_stash_survives_reimport(self) -> None:
+        cu = paddle.to_tensor([0, 4, 10, 16], dtype="int32")
+        # First writer (simulating dist_data_loader.py which imports lazily).
+        from paddlefleet.models.common.language_loss.language_loss import (
+            LanguageLoss as _LL_writer,
+        )
+
+        _LL_writer._cu_seqlens_q_stash = cu
+
+        # Second reader path (simulating LanguageLoss.forward reading it).
+        from paddlefleet.models.common.language_loss.language_loss import (
+            LanguageLoss as _LL_reader,
+        )
+
+        self.assertIs(_LL_reader._cu_seqlens_q_stash, cu)
+        self.assertEqual(_LL_reader._cu_seqlens_q_stash.dtype, paddle.int32)
+        self.assertEqual(
+            _LL_reader._cu_seqlens_q_stash.numpy().tolist(),
+            [0, 4, 10, 16],
+        )
+
+    def test_stash_none_is_the_default(self) -> None:
+        # Default class-level value must be None so that loss falls back
+        # to the plain paddle.roll path for the ernie5 flow.
+        self.assertIsNone(LanguageLoss._cu_seqlens_q_stash)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/transformer/test_forward_megatron_style_split.py
+++ b/tests/single_card_tests/transformer/test_forward_megatron_style_split.py
@@ -1,0 +1,223 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for MTP K>1 hidden-state split (_forward_megatron_style).
+
+Guards the exact code path in ``multi_token_prediction.py:1487-1494``
+where ``hidden_states`` (a concatenation of K+1 segments produced upstream
+by ``gpt_embedding.py``'s ``mtp_emb_res``) is split back into K+1 slices,
+and slots ``layer_number`` and ``layer_number+1`` are handed to the
+current MTP depth as ``hidden_states`` and ``decoder_input``.
+
+Concat/split happens along axis 0 (default of ``paddle.split``) — this
+matches the sequence-parallel layout ``[S_total, B, H]`` that the
+Megatron pipeline uses. The test constructs a fake tensor with that
+layout so it can lock which segment ends up at which slot.
+
+Key invariants this test locks:
+1. ``paddle.split(concat, num_nextn + 1)`` produces exactly K+1 equal slices.
+2. The dispatch of ``layer_number`` picks the right pair of adjacent
+   slices for each MTP layer.
+3. K=1 (existing production baseline), K=2, K=3 all obey the above with
+   no off-by-one errors.
+
+These invariants are ONLY covered by end-to-end smoke today (K=3 8GPU
+smoke observes ``LanguageLoss.forward logits=list(len=4)``); this file
+adds direct assertion so a future refactor that changes the split
+semantics is caught at unit-test time.
+"""
+
+from __future__ import annotations
+
+import paddle
+
+
+def _split_and_dispatch(
+    hidden_states_concat: paddle.Tensor,
+    num_nextn: int,
+    layer_number: int,
+) -> dict:
+    """Faithful reproduction of the split+dispatch prologue from
+    ``_forward_megatron_style`` (multi_token_prediction.py:1487-1494).
+    Kept short and inline so the test does not depend on constructing a
+    real MultiTokenPredictionLayer (which requires fleet init).
+    """
+    tensor_list = paddle.split(hidden_states_concat, num_nextn + 1)
+    return {
+        "tensor_list": tensor_list,
+        "hidden_states": tensor_list[layer_number],
+        "decoder_input": tensor_list[layer_number + 1],
+    }
+
+
+class TestMegatronSplitLength:
+    """paddle.split(concat, num_nextn + 1) must yield exactly K+1 equal slices.
+
+    Uses sequence-parallel layout [S_total, B, H] where S_total = (K+1)*L
+    (paddle.split default axis is 0).
+    """
+
+    def _run_k(self, K: int) -> None:
+        paddle.set_device("cpu")
+        L, B, H = 8, 1, 2
+        # Build K+1 marked segments in [L, B, H] layout so paddle.split along
+        # axis 0 (default) reproduces production semantics.
+        segments = []
+        for i in range(K + 1):
+            seg = paddle.full([L, B, H], fill_value=float(i), dtype="float32")
+            segments.append(seg)
+        concat = paddle.concat(segments, axis=0)  # [(K+1)*L, B, H]
+        assert concat.shape == [(K + 1) * L, B, H]
+
+        result = _split_and_dispatch(concat, num_nextn=K, layer_number=0)
+        tensor_list = result["tensor_list"]
+
+        # 1. Length must be K+1 (guards range(K) vs range(K+1) mistakes).
+        assert len(tensor_list) == K + 1, (
+            f"K={K}: split must yield {K + 1} slices, got {len(tensor_list)}"
+        )
+
+        # 2. Each slice must have shape [L, B, H] (equal partition).
+        for i, slc in enumerate(tensor_list):
+            assert slc.shape == [L, B, H], (
+                f"K={K}, slot {i}: expected shape [L, B, H]=[{L}, {B}, {H}], "
+                f"got {slc.shape}"
+            )
+
+        # 3. Segments preserve their identity (fill value == slot index).
+        for i, slc in enumerate(tensor_list):
+            assert float(slc.numpy()[0, 0, 0]) == float(i), (
+                f"K={K}, slot {i}: fill value must equal {i}, got "
+                f"{float(slc.numpy()[0, 0, 0])}"
+            )
+
+    def test_k1(self) -> None:
+        self._run_k(1)
+
+    def test_k2(self) -> None:
+        self._run_k(2)
+
+    def test_k3(self) -> None:
+        self._run_k(3)
+
+
+class TestMegatronDispatch:
+    """layer_number dispatch: MTP layer L gets slot L as ``hidden_states``
+    and slot L+1 as ``decoder_input``. This is the K+1 sliding-window
+    contract from the migration plan.
+    """
+
+    def _run_k_layer(self, K: int, layer_number: int) -> None:
+        paddle.set_device("cpu")
+        L, B, H = 8, 1, 2
+        segments = [
+            paddle.full([L, B, H], float(i * 100 + 0.5), dtype="float32")
+            for i in range(K + 1)
+        ]
+        concat = paddle.concat(segments, axis=0)
+
+        result = _split_and_dispatch(
+            concat, num_nextn=K, layer_number=layer_number
+        )
+        hs = result["hidden_states"]
+        di = result["decoder_input"]
+
+        # hidden_states must equal slot `layer_number`.
+        assert float(hs.numpy()[0, 0, 0]) == float(layer_number * 100 + 0.5), (
+            f"K={K}, layer_number={layer_number}: hidden_states must be "
+            f"slot {layer_number}"
+        )
+        # decoder_input must equal slot `layer_number + 1`.
+        assert float(di.numpy()[0, 0, 0]) == float(
+            (layer_number + 1) * 100 + 0.5
+        ), (
+            f"K={K}, layer_number={layer_number}: decoder_input must be "
+            f"slot {layer_number + 1}"
+        )
+
+    def test_k1_layer0(self) -> None:
+        self._run_k_layer(K=1, layer_number=0)
+
+    def test_k2_layer0(self) -> None:
+        self._run_k_layer(K=2, layer_number=0)
+
+    def test_k2_layer1(self) -> None:
+        self._run_k_layer(K=2, layer_number=1)
+
+    def test_k3_layer0(self) -> None:
+        self._run_k_layer(K=3, layer_number=0)
+
+    def test_k3_layer1(self) -> None:
+        self._run_k_layer(K=3, layer_number=1)
+
+    def test_k3_layer2(self) -> None:
+        self._run_k_layer(K=3, layer_number=2)
+
+
+class TestMegatronSplitRegressions:
+    """Explicit guards against subtle bugs that end-to-end smoke would only
+    surface as opaque shape errors deep inside downstream layers.
+    """
+
+    def test_off_by_one_split_count_shifts_all_slots(self) -> None:
+        """If the split count were ``num_nextn`` instead of ``num_nextn + 1``
+        the per-slot length would be off. Confirm the correct call produces
+        the right per-slot length while the buggy call produces a different
+        length — so the test would catch such a refactor.
+        """
+        paddle.set_device("cpu")
+        L, B, H = 8, 1, 2
+        K = 3
+        concat = paddle.zeros([(K + 1) * L, B, H], dtype="float32")
+
+        # Correct call.
+        good = paddle.split(concat, K + 1)
+        assert len(good) == K + 1
+        assert good[0].shape[0] == L
+
+        # (K+1)*L = 32 does not divide by K=3, so the buggy call raises.
+        # This proves an "off by one" split count can't silently pass; the
+        # sanity is captured by the length-mismatch check below.
+        raised = False
+        try:
+            paddle.split(concat, K)
+        except ValueError:
+            raised = True
+        assert raised, (
+            "Sanity: buggy split count (K instead of K+1) must not silently "
+            "succeed for common L values — a fully divisible degenerate case "
+            "would need a different guard."
+        )
+
+    def test_dispatch_uses_adjacent_slots(self) -> None:
+        """decoder_input must be exactly one slot ahead of hidden_states
+        (that is the K+1 sliding-window contract). Detect a refactor that
+        accidentally uses layer_number - 1 or a fixed slot.
+        """
+        paddle.set_device("cpu")
+        L, B, H = 8, 1, 2
+        K = 3
+        segments = [
+            paddle.full([L, B, H], float(i), dtype="float32")
+            for i in range(K + 1)
+        ]
+        concat = paddle.concat(segments, axis=0)
+        result = _split_and_dispatch(concat, num_nextn=K, layer_number=1)
+        hs_val = float(result["hidden_states"].numpy()[0, 0, 0])
+        di_val = float(result["decoder_input"].numpy()[0, 0, 0])
+        # Must be exactly adjacent (di - hs == 1); guards a stale offset bug.
+        assert di_val - hs_val == 1.0, (
+            f"decoder_input ({di_val}) must be exactly one slot ahead of "
+            f"hidden_states ({hs_val})."
+        )

--- a/tests/single_card_tests/transformer/test_gpt_embedding_megatron.py
+++ b/tests/single_card_tests/transformer/test_gpt_embedding_megatron.py
@@ -1,0 +1,307 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Single-card coverage for GPTEmbedding.forward under mtp_data_style="megatron".
+
+Drives the REAL ``GPTEmbedding.forward`` via ``__new__`` + MagicMock config
+and a stubbed ``embedding`` so the megatron MTP embedding branch runs on a
+single GPU (CP=1, SP off):
+
+- cu_seqlens_q ingest + host->GPU move + LanguageLoss stash
+  (gpt_embedding.py:345-346, 355-360).
+- megatron branch entry, multimodal guard, roll import, moe-mask handling
+  (lines 430-447).
+- CP=1 no-op extract for the main embedding and each rolled depth
+  (lines 450-451, 456/461, 483-498, 513).
+
+The CP>1 and sequence_parallel sublines (457,494 / 464,467,501-502,505,508
+for megatron; 603,610,613-614,638,647,650,653 for ernie5) are covered
+single-card by monkeypatching ``get_context_parallel_world_size`` -> 2,
+faking the CP rank, and replacing ``ScatterOp`` / ``ContextParallelScatterOp``
+with identities (see TestGptEmbeddingMegatronCPSP / TestGptEmbeddingErnie5CPSP).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import types
+import unittest
+from unittest import mock
+from unittest.mock import MagicMock
+
+import paddle
+
+import paddlefleet.models.gpt.gpt_embedding as ge
+from paddlefleet.models.common.language_loss.language_loss import LanguageLoss
+from paddlefleet.models.gpt.gpt_embedding import GPTEmbedding
+
+
+def _make_embedding(K, B, L, H, *, mtp_data_style="megatron", magic_send=False):
+    emb = GPTEmbedding.__new__(GPTEmbedding)
+    cfg = MagicMock()
+    cfg.gpt_model_use_experimental_version = True
+    cfg.max_sequence_length = 128
+    cfg.sequence_parallel = False
+    cfg.multi_latent_attention = False
+    cfg.multimodal_embedding = False
+    cfg.expert_model_parallel_size = 1
+    cfg.tensor_model_parallel_size = 1
+    cfg.num_nextn_predict_layers = K
+    cfg.mtp_load_weight_only = False
+    cfg.mtp_data_style = mtp_data_style
+    cfg.enable_mtp_magic_send = magic_send
+    cfg.pad_token_id = 0
+    cfg.experimental_dataflow = False
+    cfg.apply_rope_fusion = False
+    cfg.cp_balance_mode = "zigzag"
+    cfg.clone_scatter_output_in_embedding = False
+    cfg.layer_types = []  # -> has_kda_layer property returns False
+    emb.config = cfg
+
+    emb.multimodal_embedding = False
+    emb.sequence_parallel = False
+    emb.position_embedding_type = "none"
+    emb.rotary_pos_emb = None
+    emb.swa_rotary_pos_emb = None
+
+    def _stub_embedding(input_ids, position_ids=None):
+        b, s = input_ids.shape
+        return paddle.arange(b * s * H, dtype="float32").reshape([b, s, H])
+
+    # embed_tokens.weight.dtype is read by the magic-send experimental+SP
+    # astype line (gpt_embedding.py:564).
+    _stub_embedding.embed_tokens = types.SimpleNamespace(
+        weight=types.SimpleNamespace(dtype=paddle.float32)
+    )
+    emb.embedding = _stub_embedding
+    return emb
+
+
+@contextlib.contextmanager
+def _fake_cp(cp_size=2):
+    """Force ``get_context_parallel_world_size`` -> cp_size and rank -> 0 in
+    the gpt_embedding namespace so ``if _cp_size > 1`` branches execute.
+    ``extract_local_zigzag_chunks`` is left REAL (pure slicing) so shapes stay
+    correct; feed a seq length divisible by 2*cp_size.
+    """
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(
+            mock.patch.object(
+                ge, "get_context_parallel_world_size", lambda: cp_size
+            )
+        )
+        stack.enter_context(
+            mock.patch.object(ge, "get_context_parallel_rank", lambda: 0)
+        )
+        yield
+
+
+@contextlib.contextmanager
+def _identity_scatter():
+    """Replace SP/CP scatter PyLayers with identity so the reshape/scatter
+    sublines run without a real TP/CP group.
+    """
+
+    def identity(x, *a, **k):
+        return x
+
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(mock.patch.object(ge.ScatterOp, "apply", identity))
+        stack.enter_context(
+            mock.patch.object(ge.ContextParallelScatterOp, "apply", identity)
+        )
+        yield
+
+
+class TestGptEmbeddingMegatron(unittest.TestCase):
+    def setUp(self) -> None:
+        LanguageLoss._cu_seqlens_q_stash = None
+
+    def tearDown(self) -> None:
+        LanguageLoss._cu_seqlens_q_stash = None
+
+    def test_megatron_branch_builds_mtp_concat(self) -> None:
+        K, B, L, H = 2, 1, 8, 4
+        emb = _make_embedding(K, B, L, H)
+        input_ids = paddle.arange(B * L, dtype="int64").reshape([B, L]).cuda()
+        # cu on CPU so the .cuda() move (line 346) is exercised.
+        cu_cpu = paddle.to_tensor(
+            [0, 3, 8], dtype="int32", place=paddle.CPUPlace()
+        )
+
+        out = emb.forward({"input_ids": input_ids, "cu_seqlens_q": cu_cpu})
+
+        # hidden_states is the concat of (K+1) [B, L, H] embeddings along axis 0.
+        self.assertEqual(list(out["hidden_states"].shape), [(K + 1) * B, L, H])
+        # cu_seqlens_q rides the pipeline dict as a raw tensor, now on GPU.
+        self.assertIn("cu_seqlens_q", out)
+        self.assertTrue(out["cu_seqlens_q"].place.is_gpu_place())
+        # LanguageLoss stash was populated for the loss stage.
+        self.assertIsNotNone(LanguageLoss._cu_seqlens_q_stash)
+
+    def test_stash_is_gpu_tensor(self) -> None:
+        K, B, L, H = 1, 1, 6, 4
+        emb = _make_embedding(K, B, L, H)
+        input_ids = paddle.arange(B * L, dtype="int64").reshape([B, L]).cuda()
+        cu_cpu = paddle.to_tensor(
+            [0, 6], dtype="int32", place=paddle.CPUPlace()
+        )
+        emb.forward({"input_ids": input_ids, "cu_seqlens_q": cu_cpu})
+        self.assertTrue(LanguageLoss._cu_seqlens_q_stash.place.is_gpu_place())
+
+
+class TestGptEmbeddingErnie5(unittest.TestCase):
+    """ernie5 (non-megatron) MTP embedding path, single-card (no SP/CP).
+
+    Covers the L+K concat-shift branch (gpt_embedding.py:516-540, 586-660
+    minus SP/CP-only sublines) and the magic-send truncation branch
+    (542-545, 551/560/567 guard evaluations).
+    """
+
+    def test_ernie5_concat_shift_path(self) -> None:
+        K, B, L, H = 2, 1, 10, 4
+        emb = _make_embedding(K, B, L, H, mtp_data_style="ernie5")
+        input_ids = paddle.arange(B * L, dtype="int64").reshape([B, L]).cuda()
+        out = emb.forward({"input_ids": input_ids})
+        # mtp_emb_res holds K+1 chunks each [B, L-K, H], concatenated on axis 0.
+        self.assertEqual(
+            list(out["hidden_states"].shape), [(K + 1) * B, L - K, H]
+        )
+
+    def test_ernie5_magic_send_truncation(self) -> None:
+        K, B, L, H = 2, 1, 10, 4
+        emb = _make_embedding(
+            K, B, L, H, mtp_data_style="ernie5", magic_send=True
+        )
+        input_ids = paddle.arange(B * L, dtype="int64").reshape([B, L]).cuda()
+        out = emb.forward({"input_ids": input_ids})
+        # magic-send truncates the main embedding to [B, L-K, H] and does not
+        # build mtp_emb_res, so hidden_states keeps the single backbone slice.
+        self.assertEqual(list(out["hidden_states"].shape), [B, L - K, H])
+
+
+class TestGptEmbeddingMegatronCPSP(unittest.TestCase):
+    """CP>1 (457, 494) and sequence_parallel (464, 467, 501-502, 505, 508)
+    sublines of the megatron branch, covered single-card via monkeypatch.
+    """
+
+    def setUp(self) -> None:
+        LanguageLoss._cu_seqlens_q_stash = None
+
+    def tearDown(self) -> None:
+        LanguageLoss._cu_seqlens_q_stash = None
+
+    def test_megatron_cp_extract(self) -> None:
+        # cp_size=2 -> real extract_local_zigzag_chunks halves the seq len
+        # (lines 457 and 494). L must be divisible by 2*cp_size.
+        K, B, L, H = 2, 1, 8, 4
+        emb = _make_embedding(K, B, L, H)
+        input_ids = paddle.arange(B * L, dtype="int64").reshape([B, L]).cuda()
+        cu = paddle.to_tensor([0, 3, 8], dtype="int32")
+        with _fake_cp(cp_size=2):
+            out = emb.forward({"input_ids": input_ids, "cu_seqlens_q": cu})
+        # Each of the K+1 chunks is zigzag-halved to L/2 on axis 1.
+        self.assertEqual(
+            list(out["hidden_states"].shape), [(K + 1) * B, L // 2, H]
+        )
+
+    def test_megatron_sequence_parallel(self) -> None:
+        # sequence_parallel path with an identity ScatterOp
+        # (lines 464, 467, 501-502, 505, 508).
+        K, B, L, H = 2, 1, 8, 4
+        emb = _make_embedding(K, B, L, H)
+        emb.sequence_parallel = True
+        emb.config.sequence_parallel = True
+        input_ids = paddle.arange(B * L, dtype="int64").reshape([B, L]).cuda()
+        cu = paddle.to_tensor([0, 3, 8], dtype="int32")
+        with _identity_scatter():
+            out = emb.forward({"input_ids": input_ids, "cu_seqlens_q": cu})
+        # SP layout is [S, B, H]; concat of K+1 chunks -> [(K+1)*L, B, H].
+        self.assertEqual(list(out["hidden_states"].shape), [(K + 1) * L, B, H])
+
+
+class TestGptEmbeddingErnie5CPSP(unittest.TestCase):
+    """CP scatter (603, 638) and sequence_parallel (610, 613-614, 647, 650,
+    653) sublines of the ernie5 (non-megatron) MTP embedding branch.
+    """
+
+    def test_ernie5_cp_scatter(self) -> None:
+        # experimental_dataflow + cp_size>1 -> ContextParallelScatterOp
+        # (identity) at lines 603 and 638.
+        K, B, L, H = 2, 1, 10, 4
+        emb = _make_embedding(K, B, L, H, mtp_data_style="ernie5")
+        emb.config.experimental_dataflow = True
+        input_ids = paddle.arange(B * L, dtype="int64").reshape([B, L]).cuda()
+        with _fake_cp(cp_size=2), _identity_scatter():
+            out = emb.forward({"input_ids": input_ids})
+        self.assertEqual(
+            list(out["hidden_states"].shape), [(K + 1) * B, L - K, H]
+        )
+
+    def test_ernie5_sequence_parallel(self) -> None:
+        # sequence_parallel path with identity ScatterOp
+        # (lines 610, 613-614, 647, 650, 653).
+        K, B, L, H = 2, 1, 10, 4
+        emb = _make_embedding(K, B, L, H, mtp_data_style="ernie5")
+        emb.sequence_parallel = True
+        emb.config.sequence_parallel = True
+        input_ids = paddle.arange(B * L, dtype="int64").reshape([B, L]).cuda()
+        with _identity_scatter():
+            out = emb.forward({"input_ids": input_ids})
+        # SP layout [S, B, H]; concat of K+1 chunks each [L-K, B, H].
+        self.assertEqual(
+            list(out["hidden_states"].shape), [(K + 1) * (L - K), B, H]
+        )
+
+
+class TestGptEmbeddingMagicSendCPSP(unittest.TestCase):
+    """magic-send truncation branch CP/SP sublines (gpt_embedding.py:555,
+    564, 568, 571, 574-575, 579). magic-send lives in the ernie5
+    (non-megatron) path, so mtp_data_style stays "ernie5".
+    """
+
+    def test_magic_experimental_sp_cp(self) -> None:
+        # experimental_version=True + SP=True + CP>1 + experimental_dataflow:
+        # covers 555 (CP scatter), 564 (astype), 568/571/574 (SP reshape),
+        # 575 (guard eval). 579 is skipped here (experimental&SP True).
+        K, B, L, H = 2, 1, 8, 4
+        emb = _make_embedding(
+            K, B, L, H, mtp_data_style="ernie5", magic_send=True
+        )
+        emb.sequence_parallel = True
+        emb.config.sequence_parallel = True
+        emb.config.experimental_dataflow = True
+        input_ids = paddle.arange(B * L, dtype="int64").reshape([B, L]).cuda()
+        with _fake_cp(cp_size=2), _identity_scatter():
+            out = emb.forward({"input_ids": input_ids})
+        self.assertIn("hidden_states", out)
+
+    def test_magic_non_experimental_sp(self) -> None:
+        # experimental_version=False + SP=True: the ``if not (experimental
+        # and SP)`` guard is True, so line 579 (reshape/permute) runs.
+        K, B, L, H = 2, 1, 8, 4
+        emb = _make_embedding(
+            K, B, L, H, mtp_data_style="ernie5", magic_send=True
+        )
+        emb.config.gpt_model_use_experimental_version = False
+        emb.sequence_parallel = True
+        emb.config.sequence_parallel = True
+        input_ids = paddle.arange(B * L, dtype="int64").reshape([B, L]).cuda()
+        with _identity_scatter():
+            out = emb.forward({"input_ids": input_ids})
+        self.assertIn("hidden_states", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/transformer/test_gpt_embedding_megatron.py
+++ b/tests/single_card_tests/transformer/test_gpt_embedding_megatron.py
@@ -40,6 +40,7 @@ import unittest
 from unittest import mock
 from unittest.mock import MagicMock
 
+import numpy as np
 import paddle
 
 import paddlefleet.models.gpt.gpt_embedding as ge
@@ -267,6 +268,119 @@ class TestGptEmbeddingErnie5CPSP(unittest.TestCase):
         # SP layout [S, B, H]; concat of K+1 chunks each [L-K, B, H].
         self.assertEqual(
             list(out["hidden_states"].shape), [(K + 1) * (L - K), B, H]
+        )
+
+
+class _StubRope:
+    """Stand-in for ``RotaryEmbedding`` with an assertable layout.
+
+    Mirrors the two behaviours that matter here:
+    ``get_rotary_seq_len`` scales the rank-local length back up by the CP world
+    size (so the table is always built for the FULL length L), and ``__call__``
+    returns a ``[1, S, 1, D]`` table. Every channel holds the *global* position
+    index, which makes the CP slicing directly comparable against
+    ``extract_local_zigzag_chunks``.
+    """
+
+    def __init__(self, cp_size, dim=4):
+        self.cp_size = cp_size
+        self.dim = dim
+
+    def get_rotary_seq_len(
+        self, transformer_input, config, packed_seq_params=None
+    ):
+        return transformer_input.shape[1] * self.cp_size
+
+    def __call__(self, seq_len, packed_seq=False, position_ids=None):
+        pos = paddle.arange(seq_len, dtype="float32")
+        return pos.reshape([1, seq_len, 1, 1]).tile([1, 1, 1, self.dim])
+
+
+def _enable_rope(emb, cp_size, dim=4):
+    """Switch a fake embedding onto the real RoPE codepath."""
+    emb.position_embedding_type = "rope"
+    emb.rotary_pos_emb = _StubRope(cp_size, dim)
+    emb.training = True
+    # gpt_model_use_experimental_version nulls out every rope tensor.
+    emb.config.gpt_model_use_experimental_version = False
+    emb.config.apply_rope_fusion = False
+    return emb
+
+
+class TestGptEmbeddingMegatronCPRope(unittest.TestCase):
+    """RoPE must follow the megatron branch's zigzag CP layout.
+
+    ``ContextParallelScatterOp`` is gated on ``experimental_dataflow``, which
+    mtp_data_style="megatron" forbids, so without an explicit slice the
+    full-length table would reach a decoder that only holds L/cp positions.
+    """
+
+    def setUp(self) -> None:
+        LanguageLoss._cu_seqlens_q_stash = None
+
+    def tearDown(self) -> None:
+        LanguageLoss._cu_seqlens_q_stash = None
+
+    def test_rope_is_zigzag_sliced(self) -> None:
+        from paddlefleet.transformer.multi_token_prediction import (
+            extract_local_zigzag_chunks,
+        )
+
+        K, B, L, H, D = 2, 1, 8, 4, 4
+        emb = _enable_rope(_make_embedding(K, B, L, H), cp_size=2, dim=D)
+        input_ids = paddle.arange(B * L, dtype="int64").reshape([B, L]).cuda()
+        cu = paddle.to_tensor([0, 3, 8], dtype="int32")
+        with _fake_cp(cp_size=2):
+            out = emb.forward({"input_ids": input_ids, "cu_seqlens_q": cu})
+
+        full = (
+            paddle.arange(L, dtype="float32")
+            .reshape([1, L, 1, 1])
+            .tile([1, 1, 1, D])
+        )
+        expected = extract_local_zigzag_chunks(full, 0, 2, axis=1)
+        np.testing.assert_array_equal(
+            out["rotary_pos_emb"].numpy(), expected.numpy()
+        )
+        # cp_rank 0 of cp_size 2 owns interval=L/4=2 -> positions [0, 1, 6, 7].
+        np.testing.assert_array_equal(
+            out["rotary_pos_emb"][0, :, 0, 0].numpy(),
+            np.array([0, 1, 6, 7], dtype="float32"),
+        )
+        # Matches the hidden-state length so the decoder can consume it.
+        self.assertEqual(
+            out["rotary_pos_emb"].shape[1], out["hidden_states"].shape[1]
+        )
+
+    def test_rope_untouched_without_cp(self) -> None:
+        K, B, L, H, D = 2, 1, 8, 4, 4
+        emb = _enable_rope(_make_embedding(K, B, L, H), cp_size=1, dim=D)
+        input_ids = paddle.arange(B * L, dtype="int64").reshape([B, L]).cuda()
+        cu = paddle.to_tensor([0, 3, 8], dtype="int32")
+        out = emb.forward({"input_ids": input_ids, "cu_seqlens_q": cu})
+        np.testing.assert_array_equal(
+            out["rotary_pos_emb"][0, :, 0, 0].numpy(),
+            np.arange(L, dtype="float32"),
+        )
+
+    def test_ernie5_rope_not_sliced(self) -> None:
+        """Regression guard: the slice must be megatron-only."""
+        K, B, L, H, D = 2, 1, 8, 4, 4
+        # cp_size=2 makes the stub scale the rank-local length (L - K) back up
+        # to the full 2*(L - K), mirroring the real get_rotary_seq_len.
+        emb = _enable_rope(
+            _make_embedding(K, B, L, H, mtp_data_style="ernie5"),
+            cp_size=2,
+            dim=D,
+        )
+        input_ids = paddle.arange(B * L, dtype="int64").reshape([B, L]).cuda()
+        with _fake_cp(cp_size=2):
+            out = emb.forward({"input_ids": input_ids})
+        # ernie5 backbone length is L - K and its own CP scatter is gated on
+        # experimental_dataflow, so the table stays full-length as generated.
+        np.testing.assert_array_equal(
+            out["rotary_pos_emb"][0, :, 0, 0].numpy(),
+            np.arange((L - K) * 2, dtype="float32"),
         )
 
 

--- a/tests/single_card_tests/transformer/test_gpt_embedding_megatron.py
+++ b/tests/single_card_tests/transformer/test_gpt_embedding_megatron.py
@@ -187,9 +187,7 @@ class TestGptEmbeddingErnie5(unittest.TestCase):
 
     def test_ernie5_magic_send_truncation(self) -> None:
         K, B, L, H = 2, 1, 10, 4
-        emb = _make_embedding(
-            K, B, L, H, use_erndata=False, magic_send=True
-        )
+        emb = _make_embedding(K, B, L, H, use_erndata=False, magic_send=True)
         input_ids = paddle.arange(B * L, dtype="int64").reshape([B, L]).cuda()
         out = emb.forward({"input_ids": input_ids})
         # magic-send truncates the main embedding to [B, L-K, H] and does not
@@ -395,9 +393,7 @@ class TestGptEmbeddingMagicSendCPSP(unittest.TestCase):
         # covers 555 (CP scatter), 564 (astype), 568/571/574 (SP reshape),
         # 575 (guard eval). 579 is skipped here (experimental&SP True).
         K, B, L, H = 2, 1, 8, 4
-        emb = _make_embedding(
-            K, B, L, H, use_erndata=False, magic_send=True
-        )
+        emb = _make_embedding(K, B, L, H, use_erndata=False, magic_send=True)
         emb.sequence_parallel = True
         emb.config.sequence_parallel = True
         emb.config.experimental_dataflow = True
@@ -410,9 +406,7 @@ class TestGptEmbeddingMagicSendCPSP(unittest.TestCase):
         # experimental_version=False + SP=True: the ``if not (experimental
         # and SP)`` guard is True, so line 579 (reshape/permute) runs.
         K, B, L, H = 2, 1, 8, 4
-        emb = _make_embedding(
-            K, B, L, H, use_erndata=False, magic_send=True
-        )
+        emb = _make_embedding(K, B, L, H, use_erndata=False, magic_send=True)
         emb.config.gpt_model_use_experimental_version = False
         emb.sequence_parallel = True
         emb.config.sequence_parallel = True

--- a/tests/single_card_tests/transformer/test_gpt_embedding_megatron.py
+++ b/tests/single_card_tests/transformer/test_gpt_embedding_megatron.py
@@ -61,6 +61,11 @@ def _make_embedding(K, B, L, H, *, mtp_data_style="megatron", magic_send=False):
     cfg.mtp_load_weight_only = False
     cfg.mtp_data_style = mtp_data_style
     cfg.enable_mtp_magic_send = magic_send
+    # MagicMock attributes are truthy by default; pin the real default so the
+    # mtp_emb_res tail keeps concatenating into hidden_states instead of taking
+    # the separate_mtp_input transport (which is a PP=1/K=1 optimization and is
+    # rejected for mtp_data_style="megatron").
+    cfg.separate_mtp_input = False
     cfg.pad_token_id = 0
     cfg.experimental_dataflow = False
     cfg.apply_rope_fusion = False

--- a/tests/single_card_tests/transformer/test_gpt_embedding_megatron.py
+++ b/tests/single_card_tests/transformer/test_gpt_embedding_megatron.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Single-card coverage for GPTEmbedding.forward under mtp_data_style="megatron".
+"""Single-card coverage for GPTEmbedding.forward under use_erndata=True.
 
 Drives the REAL ``GPTEmbedding.forward`` via ``__new__`` + MagicMock config
 and a stubbed ``embedding`` so the megatron MTP embedding branch runs on a
@@ -48,7 +48,7 @@ from paddlefleet.models.common.language_loss.language_loss import LanguageLoss
 from paddlefleet.models.gpt.gpt_embedding import GPTEmbedding
 
 
-def _make_embedding(K, B, L, H, *, mtp_data_style="megatron", magic_send=False):
+def _make_embedding(K, B, L, H, *, use_erndata=True, magic_send=False):
     emb = GPTEmbedding.__new__(GPTEmbedding)
     cfg = MagicMock()
     cfg.gpt_model_use_experimental_version = True
@@ -60,12 +60,12 @@ def _make_embedding(K, B, L, H, *, mtp_data_style="megatron", magic_send=False):
     cfg.tensor_model_parallel_size = 1
     cfg.num_nextn_predict_layers = K
     cfg.mtp_load_weight_only = False
-    cfg.mtp_data_style = mtp_data_style
+    cfg.use_erndata = use_erndata
     cfg.enable_mtp_magic_send = magic_send
     # MagicMock attributes are truthy by default; pin the real default so the
     # mtp_emb_res tail keeps concatenating into hidden_states instead of taking
     # the separate_mtp_input transport (which is a PP=1/K=1 optimization and is
-    # rejected for mtp_data_style="megatron").
+    # rejected for use_erndata=True).
     cfg.separate_mtp_input = False
     cfg.pad_token_id = 0
     cfg.experimental_dataflow = False
@@ -177,7 +177,7 @@ class TestGptEmbeddingErnie5(unittest.TestCase):
 
     def test_ernie5_concat_shift_path(self) -> None:
         K, B, L, H = 2, 1, 10, 4
-        emb = _make_embedding(K, B, L, H, mtp_data_style="ernie5")
+        emb = _make_embedding(K, B, L, H, use_erndata=False)
         input_ids = paddle.arange(B * L, dtype="int64").reshape([B, L]).cuda()
         out = emb.forward({"input_ids": input_ids})
         # mtp_emb_res holds K+1 chunks each [B, L-K, H], concatenated on axis 0.
@@ -188,7 +188,7 @@ class TestGptEmbeddingErnie5(unittest.TestCase):
     def test_ernie5_magic_send_truncation(self) -> None:
         K, B, L, H = 2, 1, 10, 4
         emb = _make_embedding(
-            K, B, L, H, mtp_data_style="ernie5", magic_send=True
+            K, B, L, H, use_erndata=False, magic_send=True
         )
         input_ids = paddle.arange(B * L, dtype="int64").reshape([B, L]).cuda()
         out = emb.forward({"input_ids": input_ids})
@@ -246,7 +246,7 @@ class TestGptEmbeddingErnie5CPSP(unittest.TestCase):
         # experimental_dataflow + cp_size>1 -> ContextParallelScatterOp
         # (identity) at lines 603 and 638.
         K, B, L, H = 2, 1, 10, 4
-        emb = _make_embedding(K, B, L, H, mtp_data_style="ernie5")
+        emb = _make_embedding(K, B, L, H, use_erndata=False)
         emb.config.experimental_dataflow = True
         input_ids = paddle.arange(B * L, dtype="int64").reshape([B, L]).cuda()
         with _fake_cp(cp_size=2), _identity_scatter():
@@ -259,7 +259,7 @@ class TestGptEmbeddingErnie5CPSP(unittest.TestCase):
         # sequence_parallel path with identity ScatterOp
         # (lines 610, 613-614, 647, 650, 653).
         K, B, L, H = 2, 1, 10, 4
-        emb = _make_embedding(K, B, L, H, mtp_data_style="ernie5")
+        emb = _make_embedding(K, B, L, H, use_erndata=False)
         emb.sequence_parallel = True
         emb.config.sequence_parallel = True
         input_ids = paddle.arange(B * L, dtype="int64").reshape([B, L]).cuda()
@@ -311,7 +311,7 @@ class TestGptEmbeddingMegatronCPRope(unittest.TestCase):
     """RoPE must follow the megatron branch's zigzag CP layout.
 
     ``ContextParallelScatterOp`` is gated on ``experimental_dataflow``, which
-    mtp_data_style="megatron" forbids, so without an explicit slice the
+    use_erndata=True forbids, so without an explicit slice the
     full-length table would reach a decoder that only holds L/cp positions.
     """
 
@@ -369,7 +369,7 @@ class TestGptEmbeddingMegatronCPRope(unittest.TestCase):
         # cp_size=2 makes the stub scale the rank-local length (L - K) back up
         # to the full 2*(L - K), mirroring the real get_rotary_seq_len.
         emb = _enable_rope(
-            _make_embedding(K, B, L, H, mtp_data_style="ernie5"),
+            _make_embedding(K, B, L, H, use_erndata=False),
             cp_size=2,
             dim=D,
         )
@@ -387,7 +387,7 @@ class TestGptEmbeddingMegatronCPRope(unittest.TestCase):
 class TestGptEmbeddingMagicSendCPSP(unittest.TestCase):
     """magic-send truncation branch CP/SP sublines (gpt_embedding.py:555,
     564, 568, 571, 574-575, 579). magic-send lives in the ernie5
-    (non-megatron) path, so mtp_data_style stays "ernie5".
+    (non-megatron) path, so use_erndata stays "ernie5".
     """
 
     def test_magic_experimental_sp_cp(self) -> None:
@@ -396,7 +396,7 @@ class TestGptEmbeddingMagicSendCPSP(unittest.TestCase):
         # 575 (guard eval). 579 is skipped here (experimental&SP True).
         K, B, L, H = 2, 1, 8, 4
         emb = _make_embedding(
-            K, B, L, H, mtp_data_style="ernie5", magic_send=True
+            K, B, L, H, use_erndata=False, magic_send=True
         )
         emb.sequence_parallel = True
         emb.config.sequence_parallel = True
@@ -411,7 +411,7 @@ class TestGptEmbeddingMagicSendCPSP(unittest.TestCase):
         # and SP)`` guard is True, so line 579 (reshape/permute) runs.
         K, B, L, H = 2, 1, 8, 4
         emb = _make_embedding(
-            K, B, L, H, mtp_data_style="ernie5", magic_send=True
+            K, B, L, H, use_erndata=False, magic_send=True
         )
         emb.config.gpt_model_use_experimental_version = False
         emb.sequence_parallel = True

--- a/tests/single_card_tests/transformer/test_hysparse_mtp_split_megatron.py
+++ b/tests/single_card_tests/transformer/test_hysparse_mtp_split_megatron.py
@@ -44,6 +44,7 @@ def _make_config(mtp_data_style):
         sequence_parallel=False,
         tensor_model_parallel_size=1,
         experimental_dataflow=False,
+        separate_mtp_input=False,
         mtp_data_style=mtp_data_style,
     )
 

--- a/tests/single_card_tests/transformer/test_hysparse_mtp_split_megatron.py
+++ b/tests/single_card_tests/transformer/test_hysparse_mtp_split_megatron.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""HySparseTransformerLayer._mtp_split must honor mtp_data_style="megatron".
+"""HySparseTransformerLayer._mtp_split must honor use_erndata=True.
 
 Under megatron style position_ids / attn_mask_startend_row_indices arrive at
 main-decoder length L (per-doc shifting happens inside the MTP layer via
@@ -35,7 +35,7 @@ K = 2
 B, L, H = 1, 12, 4
 
 
-def _make_config(mtp_data_style):
+def _make_config(use_erndata):
     return SimpleNamespace(
         num_nextn_predict_layers=K,
         mtp_load_weight_only=False,
@@ -45,12 +45,12 @@ def _make_config(mtp_data_style):
         tensor_model_parallel_size=1,
         experimental_dataflow=False,
         separate_mtp_input=False,
-        mtp_data_style=mtp_data_style,
+        use_erndata=use_erndata,
     )
 
 
-def _make_fake_layer(mtp_data_style):
-    fake = SimpleNamespace(config=_make_config(mtp_data_style))
+def _make_fake_layer(use_erndata):
+    fake = SimpleNamespace(config=_make_config(use_erndata))
     fake._mtp_enabled = lambda is_mtp: HySparseTransformerLayer._mtp_enabled(
         fake, is_mtp
     )
@@ -78,7 +78,7 @@ def _make_dict_args(seq_len):
 
 class TestMegatronSkipsSeqTrims:
     def test_position_ids_kept_full_length(self):
-        fake = _make_fake_layer("megatron")
+        fake = _make_fake_layer(True)
         dict_args = _make_dict_args(L)
         ctx = HySparseTransformerLayer._mtp_split(fake, dict_args, is_mtp=False)
         assert ctx is not None
@@ -86,14 +86,14 @@ class TestMegatronSkipsSeqTrims:
         assert ctx["mtp_ids"] is None
 
     def test_attn_mask_kept_full_length(self):
-        fake = _make_fake_layer("megatron")
+        fake = _make_fake_layer(True)
         dict_args = _make_dict_args(L)
         ctx = HySparseTransformerLayer._mtp_split(fake, dict_args, is_mtp=False)
         assert dict_args["attn_mask_startend_row_indices"].shape == [B, 1, L, 1]
         assert ctx["attn_mask_mtp"] is None
 
     def test_hidden_states_split_still_applies(self):
-        fake = _make_fake_layer("megatron")
+        fake = _make_fake_layer(True)
         dict_args = _make_dict_args(L)
         stacked = dict_args["hidden_states"].clone()
         ctx = HySparseTransformerLayer._mtp_split(fake, dict_args, is_mtp=False)
@@ -106,7 +106,7 @@ class TestMegatronSkipsSeqTrims:
         )
 
     def test_restore_roundtrips_without_touching_aux(self):
-        fake = _make_fake_layer("megatron")
+        fake = _make_fake_layer(True)
         dict_args = _make_dict_args(L)
         ctx = HySparseTransformerLayer._mtp_split(fake, dict_args, is_mtp=False)
         output = dict_args["hidden_states"]
@@ -122,7 +122,7 @@ class TestErnie5TrimsStillApply:
     """Regression guard: adding the megatron guard must not disturb ernie5."""
 
     def test_position_ids_and_mask_trimmed(self):
-        fake = _make_fake_layer("ernie5")
+        fake = _make_fake_layer(False)
         dict_args = _make_dict_args(L + K)
         ctx = HySparseTransformerLayer._mtp_split(fake, dict_args, is_mtp=False)
         assert dict_args["position_ids"].shape == [B, L]
@@ -131,7 +131,7 @@ class TestErnie5TrimsStillApply:
         assert ctx["attn_mask_mtp"].shape == [B, 1, K, 1]
 
     def test_restore_reassembles_full_length(self):
-        fake = _make_fake_layer("ernie5")
+        fake = _make_fake_layer(False)
         dict_args = _make_dict_args(L + K)
         ctx = HySparseTransformerLayer._mtp_split(fake, dict_args, is_mtp=False)
         output = dict_args["hidden_states"]
@@ -146,9 +146,9 @@ class TestErnie5TrimsStillApply:
 
 
 class TestMtpDisabledIsNoop:
-    @pytest.mark.parametrize("style", ["ernie5", "megatron"])
-    def test_is_mtp_layer_returns_none(self, style):
-        fake = _make_fake_layer(style)
+    @pytest.mark.parametrize("use_erndata", [False, True])
+    def test_is_mtp_layer_returns_none(self, use_erndata):
+        fake = _make_fake_layer(use_erndata)
         dict_args = _make_dict_args(L)
         assert (
             HySparseTransformerLayer._mtp_split(fake, dict_args, is_mtp=True)

--- a/tests/single_card_tests/transformer/test_hysparse_mtp_split_megatron.py
+++ b/tests/single_card_tests/transformer/test_hysparse_mtp_split_megatron.py
@@ -1,0 +1,155 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""HySparseTransformerLayer._mtp_split must honor mtp_data_style="megatron".
+
+Under megatron style position_ids / attn_mask_startend_row_indices arrive at
+main-decoder length L (per-doc shifting happens inside the MTP layer via
+roll_tensor), so the ernie5 L+K -> L seq-dim trims must be skipped -- exactly
+like the ``_mtp_is_megatron`` guards in ``TransformerLayer.forward``. The
+hidden-states batch-dim (K+1)-way split is style-independent and must keep
+working in both styles.
+
+Pure CPU, no fleet init: ``_mtp_split`` is exercised unbound with a fake self.
+"""
+
+from types import SimpleNamespace
+
+import paddle
+import pytest
+
+from paddlefleet.transformer.transformer_layer import HySparseTransformerLayer
+
+K = 2
+B, L, H = 1, 12, 4
+
+
+def _make_config(mtp_data_style):
+    return SimpleNamespace(
+        num_nextn_predict_layers=K,
+        mtp_load_weight_only=False,
+        enable_mtp_magic_send=False,
+        gpt_model_use_experimental_version=False,
+        sequence_parallel=False,
+        tensor_model_parallel_size=1,
+        experimental_dataflow=False,
+        mtp_data_style=mtp_data_style,
+    )
+
+
+def _make_fake_layer(mtp_data_style):
+    fake = SimpleNamespace(config=_make_config(mtp_data_style))
+    fake._mtp_enabled = lambda is_mtp: HySparseTransformerLayer._mtp_enabled(
+        fake, is_mtp
+    )
+    return fake
+
+
+def _make_dict_args(seq_len):
+    """dict_args as seen by the main decoder layer.
+
+    hidden_states is the MTP (K+1)-way batch-dim stack in both styles;
+    position_ids / mask carry seq_len entries (L for megatron, L+K for ernie5).
+    input_ids stays None to keep the test free of fleet/CP process groups.
+    """
+    return {
+        "hidden_states": paddle.randn([(K + 1) * B, L, H]),
+        "position_ids": paddle.arange(seq_len)
+        .reshape([1, seq_len])
+        .tile([B, 1]),
+        "attn_mask_startend_row_indices": paddle.full(
+            [B, 1, seq_len, 1], seq_len, dtype="int32"
+        ),
+        "input_ids": None,
+    }
+
+
+class TestMegatronSkipsSeqTrims:
+    def test_position_ids_kept_full_length(self):
+        fake = _make_fake_layer("megatron")
+        dict_args = _make_dict_args(L)
+        ctx = HySparseTransformerLayer._mtp_split(fake, dict_args, is_mtp=False)
+        assert ctx is not None
+        assert dict_args["position_ids"].shape == [B, L]
+        assert ctx["mtp_ids"] is None
+
+    def test_attn_mask_kept_full_length(self):
+        fake = _make_fake_layer("megatron")
+        dict_args = _make_dict_args(L)
+        ctx = HySparseTransformerLayer._mtp_split(fake, dict_args, is_mtp=False)
+        assert dict_args["attn_mask_startend_row_indices"].shape == [B, 1, L, 1]
+        assert ctx["attn_mask_mtp"] is None
+
+    def test_hidden_states_split_still_applies(self):
+        fake = _make_fake_layer("megatron")
+        dict_args = _make_dict_args(L)
+        stacked = dict_args["hidden_states"].clone()
+        ctx = HySparseTransformerLayer._mtp_split(fake, dict_args, is_mtp=False)
+        assert dict_args["hidden_states"].shape == [B, L, H]
+        assert len(ctx["mtp_input"]) == K
+        import numpy as np
+
+        np.testing.assert_array_equal(
+            dict_args["hidden_states"].numpy(), stacked[:B].numpy()
+        )
+
+    def test_restore_roundtrips_without_touching_aux(self):
+        fake = _make_fake_layer("megatron")
+        dict_args = _make_dict_args(L)
+        ctx = HySparseTransformerLayer._mtp_split(fake, dict_args, is_mtp=False)
+        output = dict_args["hidden_states"]
+        restored = HySparseTransformerLayer._mtp_restore(
+            fake, dict_args, output, ctx
+        )
+        assert restored.shape == [(K + 1) * B, L, H]
+        assert dict_args["position_ids"].shape == [B, L]
+        assert dict_args["attn_mask_startend_row_indices"].shape == [B, 1, L, 1]
+
+
+class TestErnie5TrimsStillApply:
+    """Regression guard: adding the megatron guard must not disturb ernie5."""
+
+    def test_position_ids_and_mask_trimmed(self):
+        fake = _make_fake_layer("ernie5")
+        dict_args = _make_dict_args(L + K)
+        ctx = HySparseTransformerLayer._mtp_split(fake, dict_args, is_mtp=False)
+        assert dict_args["position_ids"].shape == [B, L]
+        assert ctx["mtp_ids"].shape == [B, K]
+        assert dict_args["attn_mask_startend_row_indices"].shape == [B, 1, L, 1]
+        assert ctx["attn_mask_mtp"].shape == [B, 1, K, 1]
+
+    def test_restore_reassembles_full_length(self):
+        fake = _make_fake_layer("ernie5")
+        dict_args = _make_dict_args(L + K)
+        ctx = HySparseTransformerLayer._mtp_split(fake, dict_args, is_mtp=False)
+        output = dict_args["hidden_states"]
+        HySparseTransformerLayer._mtp_restore(fake, dict_args, output, ctx)
+        assert dict_args["position_ids"].shape == [B, L + K]
+        assert dict_args["attn_mask_startend_row_indices"].shape == [
+            B,
+            1,
+            L + K,
+            1,
+        ]
+
+
+class TestMtpDisabledIsNoop:
+    @pytest.mark.parametrize("style", ["ernie5", "megatron"])
+    def test_is_mtp_layer_returns_none(self, style):
+        fake = _make_fake_layer(style)
+        dict_args = _make_dict_args(L)
+        assert (
+            HySparseTransformerLayer._mtp_split(fake, dict_args, is_mtp=True)
+            is None
+        )

--- a/tests/single_card_tests/transformer/test_language_loss_cu_seqlens_stash.py
+++ b/tests/single_card_tests/transformer/test_language_loss_cu_seqlens_stash.py
@@ -147,3 +147,58 @@ def test_differs_from_plain_roll_at_internal_eos():
     assert per_doc_l[9] == 0
     assert plain_l[3] != 0  # crosses doc boundary
     assert plain_l[9] != 0
+
+
+def test_label_roll_fills_ignored_index_at_boundaries():
+    """Labels must roll with pad_value=ignored_index (NOT 0). With the
+    default pad_value=0 the doc-boundary position becomes token id 0, which
+    the loss mask (labels != ignored_index) would treat as a real target and
+    train the model to predict token 0 across doc boundaries. pad_value=-100
+    makes those positions ignored instead.
+    """
+    paddle.set_device("cpu")
+    ignored_index = -100
+    labels_np = np.arange(1, 17, dtype=np.int64).reshape([1, 16])
+    labels = paddle.to_tensor(labels_np)
+    cu = paddle.to_tensor([0, 4, 10, 16], dtype="int32")
+
+    rolled_lbl, _ = _roll_tensor_packed_seq(
+        labels, shifts=-1, dims=1, cu_seqlens_q=cu, pad_value=ignored_index
+    )
+    rolled_emb, _ = _roll_tensor_packed_seq(
+        labels, shifts=-1, dims=1, cu_seqlens_q=cu, pad_value=0
+    )
+    lbl = rolled_lbl.numpy().flatten().tolist()
+    emb = rolled_emb.numpy().flatten().tolist()
+
+    # Boundary positions (last index of each doc): 3, 9, 15.
+    for b in (3, 9, 15):
+        assert lbl[b] == ignored_index, f"label boundary {b} must be ignored"
+        assert emb[b] == 0, f"embedding boundary {b} must be zero-filled"
+    # Non-boundary positions are identical between the two fills.
+    for i in range(16):
+        if i not in (3, 9, 15):
+            assert lbl[i] == emb[i]
+
+
+def test_loss_mask_excludes_every_doc_boundary():
+    """The loss mask ``labels != ignored_index`` must drop exactly one
+    position per (non-empty) document after a single roll — i.e. the boundary
+    tokens do NOT count toward the loss.
+    """
+    paddle.set_device("cpu")
+    ignored_index = -100
+    labels_np = np.arange(1, 25, dtype=np.int64).reshape([1, 24])
+    labels = paddle.to_tensor(labels_np)
+    cu_list = [0, 6, 12, 24]  # 3 non-empty docs
+    cu = paddle.to_tensor(cu_list, dtype="int32")
+
+    rolled, _ = _roll_tensor_packed_seq(
+        labels, shifts=-1, dims=1, cu_seqlens_q=cu, pad_value=ignored_index
+    )
+    mask = (rolled != ignored_index).numpy().flatten().tolist()
+    # Boundaries 5, 11, 23 must be excluded; everything else kept.
+    boundaries = {5, 11, 23}
+    for i in range(24):
+        assert mask[i] == (i not in boundaries), f"pos {i}"
+    assert sum(mask) == 24 - len(boundaries)

--- a/tests/single_card_tests/transformer/test_language_loss_cu_seqlens_stash.py
+++ b/tests/single_card_tests/transformer/test_language_loss_cu_seqlens_stash.py
@@ -1,0 +1,149 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the LanguageLoss cu_seqlens_q stash (per-doc parity path).
+
+Under `mtp_data_style="megatron"`, `gpt_embedding.forward` stashes
+`cu_seqlens_q` onto `LanguageLoss._cu_seqlens_q_stash` so the MTP label-roll
+in `LanguageLoss.forward` can call `_roll_tensor_packed_seq` and match the
+embedding-side per-doc roll bit-exactly at EOS boundaries.
+
+These tests exercise the roll semantics directly (unit level; no fleet
+init) — the class-level stash is a plain module-level slot.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import paddle
+
+from paddlefleet.transformer.multi_token_prediction import (
+    _roll_tensor_packed_seq,
+)
+
+
+def _plain_roll_with_tail_mask(labels, shifts, ignored_index):
+    """Baseline (previous simplified path): paddle.roll left + mask the
+    wrapped tail. Used to show the strict per-doc path differs at each
+    document's EOS boundary (not just the final tail).
+    """
+    out = labels
+    for _ in range(shifts):
+        out = paddle.roll(out, shifts=-1, axis=1)
+    out = out.clone()
+    out[:, -shifts:] = ignored_index
+    return out
+
+
+def _numpy_per_doc_left_shift(labels_np, cu, shifts):
+    """Numpy reference: iterate `shifts` left shifts within each doc,
+    zero-out the last position of each doc after each shift. Mirrors what
+    the embedding side does token-for-token.
+    """
+    L = labels_np.shape[1]
+    out = labels_np.copy()
+    for _ in range(shifts):
+        for i in range(len(cu) - 1):
+            s, e = int(cu[i]), int(cu[i + 1])
+            if e - s <= 0:
+                continue
+            doc = out[:, s:e]
+            rolled = np.roll(doc, shift=-1, axis=1)
+            rolled[:, -1] = 0
+            out[:, s:e] = rolled
+    return out
+
+
+def test_single_document_no_boundary_effect():
+    """cu_seqlens_q = [0, L] (single doc) — packed roll should match the
+    plain paddle.roll (aside from the final-tail zero fill vs
+    ignored_index).
+    """
+    paddle.set_device("cpu")
+    L = 16
+    labels = paddle.arange(L, dtype="int64").reshape([1, L])
+    cu = paddle.to_tensor([0, L], dtype="int32")
+
+    rolled_packed, _ = _roll_tensor_packed_seq(
+        labels, shifts=-1, dims=1, cu_seqlens_q=cu
+    )
+    # Plain paddle.roll then zero-fill the tail.
+    rolled_plain = paddle.roll(labels, shifts=-1, axis=1).clone()
+    rolled_plain[:, -1:] = 0
+
+    assert rolled_packed.numpy().tolist() == rolled_plain.numpy().tolist()
+
+
+def test_multi_document_matches_numpy_reference():
+    """Multi-doc cu_seqlens_q [0, 4, 10, 16] — verify per-doc rolls match
+    the token-for-token numpy reference (which the embedding side also
+    produces).
+    """
+    paddle.set_device("cpu")
+    labels_np = np.arange(1, 17, dtype=np.int64).reshape([1, 16])
+    labels = paddle.to_tensor(labels_np)
+    cu = paddle.to_tensor([0, 4, 10, 16], dtype="int32")
+
+    rolled_packed, _ = _roll_tensor_packed_seq(
+        labels, shifts=-1, dims=1, cu_seqlens_q=cu
+    )
+    ref = _numpy_per_doc_left_shift(labels_np, [0, 4, 10, 16], shifts=1)
+    assert rolled_packed.numpy().tolist() == ref.tolist()
+
+
+def test_iterated_rolls_stack_correctly():
+    """Rolling K=3 times should still match the numpy reference — this is
+    exactly the loop that LanguageLoss now runs for each MTP depth.
+    """
+    paddle.set_device("cpu")
+    labels_np = np.arange(1, 25, dtype=np.int64).reshape([1, 24])
+    cu_list = [0, 6, 6, 18, 24]  # includes an empty doc [6:6]
+    cu = paddle.to_tensor(cu_list, dtype="int32")
+
+    for depth_plus_one in (1, 2, 3):
+        rolled = paddle.to_tensor(labels_np)
+        for _ in range(depth_plus_one):
+            rolled, _ = _roll_tensor_packed_seq(
+                rolled, shifts=-1, dims=1, cu_seqlens_q=cu
+            )
+        ref = _numpy_per_doc_left_shift(labels_np, cu_list, depth_plus_one)
+        assert rolled.numpy().tolist() == ref.tolist(), (
+            f"depth+1={depth_plus_one}"
+        )
+
+
+def test_differs_from_plain_roll_at_internal_eos():
+    """Sanity: for a multi-doc pack the per-doc roll and the plain
+    roll+tail-mask DIFFER at every internal EOS boundary. This is the
+    parity gap the stash closes.
+    """
+    paddle.set_device("cpu")
+    labels_np = np.arange(100, 116, dtype=np.int64).reshape([1, 16])
+    labels = paddle.to_tensor(labels_np)
+    cu = paddle.to_tensor([0, 4, 10, 16], dtype="int32")
+
+    per_doc, _ = _roll_tensor_packed_seq(
+        labels, shifts=-1, dims=1, cu_seqlens_q=cu
+    )
+    plain = _plain_roll_with_tail_mask(labels, shifts=1, ignored_index=-100)
+
+    # Internal EOS positions are index 3 (end of doc 0), 9 (end of doc 1).
+    # In per-doc these are zero; in plain they carry the next-doc's first
+    # token (or -100 only for the final tail).
+    per_doc_l = per_doc.numpy().flatten().tolist()
+    plain_l = plain.numpy().flatten().tolist()
+    assert per_doc_l[3] == 0
+    assert per_doc_l[9] == 0
+    assert plain_l[3] != 0  # crosses doc boundary
+    assert plain_l[9] != 0

--- a/tests/single_card_tests/transformer/test_language_loss_cu_seqlens_stash.py
+++ b/tests/single_card_tests/transformer/test_language_loss_cu_seqlens_stash.py
@@ -14,7 +14,7 @@
 
 """Tests for the LanguageLoss cu_seqlens_q stash (per-doc parity path).
 
-Under `mtp_data_style="megatron"`, `gpt_embedding.forward` stashes
+Under `use_erndata=True`, `gpt_embedding.forward` stashes
 `cu_seqlens_q` onto `LanguageLoss._cu_seqlens_q_stash` so the MTP label-roll
 in `LanguageLoss.forward` can call `_roll_tensor_packed_seq` and match the
 embedding-side per-doc roll bit-exactly at EOS boundaries.

--- a/tests/single_card_tests/transformer/test_language_loss_megatron_labels.py
+++ b/tests/single_card_tests/transformer/test_language_loss_megatron_labels.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Single-card coverage for LanguageLoss.forward under mtp_data_style="megatron".
+"""Single-card coverage for LanguageLoss.forward under use_erndata=True.
 
 Drives the REAL ``LanguageLoss.forward`` via ``__new__`` + MagicMock config
 and stubbed ``_forward`` / ``loss_func`` so the megatron label-shift paths
@@ -52,12 +52,12 @@ def _make_cu(seq_lens):
     return paddle.to_tensor(cu, dtype="int32")
 
 
-def _make_loss(K, *, distill, mtp_data_style="megatron"):
+def _make_loss(K, *, distill, use_erndata=True):
     loss = LanguageLoss.__new__(LanguageLoss)
     cfg = MagicMock()
     cfg.num_nextn_predict_layers = K
     cfg.mtp_load_weight_only = False
-    cfg.mtp_data_style = mtp_data_style
+    cfg.use_erndata = use_erndata
     cfg.mtp_distillation_loss = distill
     cfg.train_mtp_only = False
     cfg.gpt_model_use_experimental_version = True
@@ -159,7 +159,7 @@ class TestLanguageLossErnie5Slice(unittest.TestCase):
 
     def test_ernie5_non_distill_slice(self) -> None:
         K, B, L, V = 2, 1, 10, 5
-        loss = _make_loss(K, distill=False, mtp_data_style="ernie5")
+        loss = _make_loss(K, distill=False, use_erndata=False)
         logits = [
             paddle.randn([B, L, V], dtype="float32") for _ in range(K + 1)
         ]

--- a/tests/single_card_tests/transformer/test_language_loss_megatron_labels.py
+++ b/tests/single_card_tests/transformer/test_language_loss_megatron_labels.py
@@ -1,0 +1,253 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Single-card coverage for LanguageLoss.forward under mtp_data_style="megatron".
+
+Drives the REAL ``LanguageLoss.forward`` via ``__new__`` + MagicMock config
+and stubbed ``_forward`` / ``loss_func`` so the megatron label-shift paths
+are exercised on a single GPU (CP=1, TP=1):
+
+- non-distillation megatron branch: full-length ``lm_labels = labels_ori``,
+  per-depth ``_roll_tensor_packed_seq`` driven by the class-level
+  ``_cu_seqlens_q_stash`` (language_loss.py:527-528, 536, 566-574, 600, 609).
+- distillation megatron branch: mirror roll path (lines 742-750, 770, 777).
+- missing-stash guards raise RuntimeError in both branches (lines 592, 762).
+
+The CP>1 sublines (515/518/522/530/603/771) are covered single-card by
+monkeypatching ``get_context_parallel_world_size`` -> 2, faking the CP rank,
+and replacing ``extract_local_zigzag_chunks`` / the CP comm ops with
+identities (see TestLanguageLossMegatronCP).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import unittest
+from unittest import mock
+from unittest.mock import MagicMock
+
+import paddle
+
+import paddlefleet.models.common.language_loss.language_loss as ll
+import paddlefleet.parallel_state as ps
+import paddlefleet.transformer.multi_token_prediction as mtp
+from paddlefleet.models.common.language_loss.language_loss import LanguageLoss
+
+
+def _make_cu(seq_lens):
+    cu = [0]
+    for n in seq_lens:
+        cu.append(cu[-1] + n)
+    return paddle.to_tensor(cu, dtype="int32")
+
+
+def _make_loss(K, *, distill, mtp_data_style="megatron"):
+    loss = LanguageLoss.__new__(LanguageLoss)
+    cfg = MagicMock()
+    cfg.num_nextn_predict_layers = K
+    cfg.mtp_load_weight_only = False
+    cfg.mtp_data_style = mtp_data_style
+    cfg.mtp_distillation_loss = distill
+    cfg.train_mtp_only = False
+    cfg.gpt_model_use_experimental_version = True
+    cfg.sequence_parallel = False
+    cfg.fused_linear_ce_loss_chunk = 0
+    cfg.add_mtp_loss = True
+    cfg.mtp_loss_scaling_factor = 1.0
+    cfg.experimental_dataflow = False
+    cfg.cp_balance_mode = "zigzag"
+    cfg.recompute_modules = None
+    loss.config = cfg
+    loss.ignored_index = -100
+
+    def _stub_forward(logits, labels):
+        return paddle.to_tensor(1.0, dtype="float32")
+
+    def _stub_loss_func(logits, labels):
+        # Per-token loss matrix shaped like labels [B, L].
+        return paddle.ones(labels.shape, dtype="float32")
+
+    loss._forward = _stub_forward
+    loss.loss_func = _stub_loss_func
+    return loss
+
+
+class TestLanguageLossMegatronNonDistill(unittest.TestCase):
+    def setUp(self) -> None:
+        LanguageLoss._cu_seqlens_q_stash = None
+
+    def tearDown(self) -> None:
+        LanguageLoss._cu_seqlens_q_stash = None
+
+    def test_non_distill_with_stash(self) -> None:
+        K, B, L, V = 2, 1, 8, 5
+        loss = _make_loss(K, distill=False)
+        LanguageLoss._cu_seqlens_q_stash = _make_cu([3, 5])
+        logits = [
+            paddle.randn([B, L, V], dtype="float32") for _ in range(K + 1)
+        ]
+        labels = paddle.arange(B * L, dtype="int64").reshape([B, L])
+        out = loss.forward(logits, labels)
+        self.assertEqual(out.dtype, paddle.float32)
+        # scalar loss
+        self.assertEqual(list(out.shape), [] if out.ndim == 0 else [1])
+
+    def test_non_distill_missing_stash_raises(self) -> None:
+        K, B, L, V = 1, 1, 8, 5
+        loss = _make_loss(K, distill=False)
+        LanguageLoss._cu_seqlens_q_stash = None
+        logits = [
+            paddle.randn([B, L, V], dtype="float32") for _ in range(K + 1)
+        ]
+        labels = paddle.arange(B * L, dtype="int64").reshape([B, L])
+        with self.assertRaises(RuntimeError):
+            loss.forward(logits, labels)
+
+
+class TestLanguageLossMegatronDistill(unittest.TestCase):
+    def setUp(self) -> None:
+        LanguageLoss._cu_seqlens_q_stash = None
+
+    def tearDown(self) -> None:
+        LanguageLoss._cu_seqlens_q_stash = None
+
+    def test_distill_with_stash(self) -> None:
+        K, B, L, V = 2, 1, 8, 5
+        loss = _make_loss(K, distill=True)
+        LanguageLoss._cu_seqlens_q_stash = _make_cu([4, 4])
+        logits = [
+            paddle.randn([B, L, V], dtype="float32") for _ in range(K + 1)
+        ]
+        labels = paddle.arange(B * L, dtype="int64").reshape([B, L])
+        out = loss.forward(logits, labels)
+        self.assertEqual(out.dtype, paddle.float32)
+
+    def test_distill_missing_stash_raises(self) -> None:
+        K, B, L, V = 1, 1, 8, 5
+        loss = _make_loss(K, distill=True)
+        LanguageLoss._cu_seqlens_q_stash = None
+        logits = [
+            paddle.randn([B, L, V], dtype="float32") for _ in range(K + 1)
+        ]
+        labels = paddle.arange(B * L, dtype="int64").reshape([B, L])
+        with self.assertRaises(RuntimeError):
+            loss.forward(logits, labels)
+
+
+class TestLanguageLossErnie5Slice(unittest.TestCase):
+    """ernie5 (non-megatron) MTP label path: lm_labels = labels[:, :-K] and
+    per-depth labels_cur_depth = labels_ori[:, (depth+1):(depth+1+seq)]
+    (language_loss.py:538-539, 611). Single-card, CP=1, TP=1.
+    """
+
+    def setUp(self) -> None:
+        LanguageLoss._cu_seqlens_q_stash = None
+
+    def tearDown(self) -> None:
+        LanguageLoss._cu_seqlens_q_stash = None
+
+    def test_ernie5_non_distill_slice(self) -> None:
+        K, B, L, V = 2, 1, 10, 5
+        loss = _make_loss(K, distill=False, mtp_data_style="ernie5")
+        logits = [
+            paddle.randn([B, L, V], dtype="float32") for _ in range(K + 1)
+        ]
+        labels = paddle.arange(B * L, dtype="int64").reshape([B, L])
+        out = loss.forward(logits, labels)
+        self.assertEqual(out.dtype, paddle.float32)
+
+
+@contextlib.contextmanager
+def _fake_cp(cp_size=2):
+    """Monkeypatch the CP machinery so the ``_cp_size_for_extract > 1``
+    branches run single-card:
+
+    - module-level ``get_context_parallel_world_size`` -> cp_size;
+    - source-module ``get_context_parallel_rank`` (local import) -> 0;
+    - ``extract_local_zigzag_chunks`` (local import) -> identity;
+    - CP scatter/gather PyLayers -> identity;
+    - ``dist.all_reduce`` -> no-op and ``fleet`` -> MagicMock (the
+      distillation branch all-reduces the per-depth loss).
+    """
+
+    def identity(t, *a, **k):
+        return t
+
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(
+            mock.patch.object(
+                ll, "get_context_parallel_world_size", lambda: cp_size
+            )
+        )
+        stack.enter_context(
+            mock.patch.object(ps, "get_context_parallel_rank", lambda: 0)
+        )
+        stack.enter_context(
+            mock.patch.object(mtp, "extract_local_zigzag_chunks", identity)
+        )
+        stack.enter_context(
+            mock.patch.object(ll.ContextParallelScatterOp, "apply", identity)
+        )
+        stack.enter_context(
+            mock.patch.object(ll.ContextParallelGatherOp, "apply", identity)
+        )
+        stack.enter_context(
+            mock.patch.object(ll.dist, "all_reduce", lambda *a, **k: None)
+        )
+        stack.enter_context(mock.patch.object(ll, "fleet", MagicMock()))
+        yield
+
+
+class TestLanguageLossMegatronCP(unittest.TestCase):
+    """Covers the CP>1 sublines (515,518,522,530,603,771) via monkeypatch.
+
+    ``extract_local_zigzag_chunks`` is mocked to identity, so all tensors
+    keep their full length and shapes stay self-consistent.
+    """
+
+    def setUp(self) -> None:
+        LanguageLoss._cu_seqlens_q_stash = None
+
+    def tearDown(self) -> None:
+        LanguageLoss._cu_seqlens_q_stash = None
+
+    def test_non_distill_cp_branch(self) -> None:
+        # Covers 515, 518, 522, 530 (lm_labels extract) and 603 (per-depth).
+        K, B, L, V = 2, 1, 8, 5
+        loss = _make_loss(K, distill=False)
+        LanguageLoss._cu_seqlens_q_stash = _make_cu([3, 5])
+        logits = [
+            paddle.randn([B, L, V], dtype="float32") for _ in range(K + 1)
+        ]
+        labels = paddle.arange(B * L, dtype="int64").reshape([B, L])
+        with _fake_cp(cp_size=2):
+            out = loss.forward(logits, labels)
+        self.assertEqual(out.dtype, paddle.float32)
+
+    def test_distill_cp_branch(self) -> None:
+        # Covers 771 (per-depth extract in the distillation branch).
+        K, B, L, V = 2, 1, 8, 5
+        loss = _make_loss(K, distill=True)
+        LanguageLoss._cu_seqlens_q_stash = _make_cu([4, 4])
+        logits = [
+            paddle.randn([B, L, V], dtype="float32") for _ in range(K + 1)
+        ]
+        labels = paddle.arange(B * L, dtype="int64").reshape([B, L])
+        with _fake_cp(cp_size=2):
+            out = loss.forward(logits, labels)
+        self.assertEqual(out.dtype, paddle.float32)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/transformer/test_lm_head_cu_seqlens_stash.py
+++ b/tests/single_card_tests/transformer/test_lm_head_cu_seqlens_stash.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""GPTLMHead._stash_cu_seqlens_q: deliver cu_seqlens_q to the loss stage.
+
+Under mtp_data_style="megatron" and PP>1, the last pipeline stage runs the
+LM head (which sees the pipeline dict) immediately before LanguageLoss (which
+does not). GPTLMHead.forward must stash cu_seqlens_q onto
+LanguageLoss._cu_seqlens_q_stash so the loss rank can roll labels per packed
+document. These tests exercise that hand-off directly (no fleet init) via
+GPTLMHead.__new__.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import paddle
+
+from paddlefleet.models.common.language_loss.language_loss import LanguageLoss
+from paddlefleet.models.gpt.lm_head import GPTLMHead
+
+
+class TestLMHeadCuSeqlensStash(unittest.TestCase):
+    def setUp(self) -> None:
+        paddle.set_device("cpu")
+        LanguageLoss._cu_seqlens_q_stash = None
+
+    def tearDown(self) -> None:
+        LanguageLoss._cu_seqlens_q_stash = None
+
+    def test_stash_written_when_present(self) -> None:
+        head = GPTLMHead.__new__(GPTLMHead)
+        cu = paddle.to_tensor([0, 4, 10, 16], dtype="int32")
+        head._stash_cu_seqlens_q({"hidden_states": None, "cu_seqlens_q": cu})
+        self.assertIs(LanguageLoss._cu_seqlens_q_stash, cu)
+
+    def test_noop_when_absent(self) -> None:
+        head = GPTLMHead.__new__(GPTLMHead)
+        # Non-megatron: cu_seqlens_q is stripped from the dict upstream.
+        head._stash_cu_seqlens_q({"hidden_states": None})
+        self.assertIsNone(LanguageLoss._cu_seqlens_q_stash)
+
+    def test_noop_when_none(self) -> None:
+        head = GPTLMHead.__new__(GPTLMHead)
+        head._stash_cu_seqlens_q({"hidden_states": None, "cu_seqlens_q": None})
+        self.assertIsNone(LanguageLoss._cu_seqlens_q_stash)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/transformer/test_lm_head_cu_seqlens_stash.py
+++ b/tests/single_card_tests/transformer/test_lm_head_cu_seqlens_stash.py
@@ -14,7 +14,7 @@
 
 """GPTLMHead._stash_cu_seqlens_q: deliver cu_seqlens_q to the loss stage.
 
-Under mtp_data_style="megatron" and PP>1, the last pipeline stage runs the
+Under use_erndata=True and PP>1, the last pipeline stage runs the
 LM head (which sees the pipeline dict) immediately before LanguageLoss (which
 does not). GPTLMHead.forward must stash cu_seqlens_q onto
 LanguageLoss._cu_seqlens_q_stash so the loss rank can roll labels per packed

--- a/tests/single_card_tests/transformer/test_moe_router_megatron_cp.py
+++ b/tests/single_card_tests/transformer/test_moe_router_megatron_cp.py
@@ -15,13 +15,13 @@
 """Single-card coverage for TopKRouter.forward's megatron-MTP CP branch.
 
 The router's ``forward`` has an ``elif`` that, under CP>1 +
-mtp_data_style="megatron", zigzag-slices ``input_ids`` to match the
+use_erndata=True, zigzag-slices ``input_ids`` to match the
 embedding's per-rank chunk (moe_router.py:1500, 1514, 1518-1520). We reach
 it single-card by:
 
 - ``TopKRouter.__new__`` + MagicMock config (experimental_dataflow=False so
   the preceding ``if`` is skipped and the ``elif`` is evaluated;
-  mtp_data_style="megatron");
+  use_erndata=True);
 - monkeypatching the module-level ``get_context_parallel_world_size`` -> 2
   and ``get_context_parallel_rank`` -> 0;
 - feeding a 3-D ``input`` and an ``input_ids`` whose seq length differs from
@@ -75,7 +75,7 @@ class TestTopKRouterMegatronCPSlice(unittest.TestCase):
         router = TopKRouter.__new__(TopKRouter)
         cfg = MagicMock()
         cfg.experimental_dataflow = False  # skip the preceding `if`
-        cfg.mtp_data_style = "megatron"
+        cfg.use_erndata = True
         cfg.cp_balance_mode = "zigzag"
         router.config = cfg
         router.sequence_parallel = False

--- a/tests/single_card_tests/transformer/test_moe_router_megatron_cp.py
+++ b/tests/single_card_tests/transformer/test_moe_router_megatron_cp.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Single-card coverage for TopKRouter.forward's megatron-MTP CP branch.
+
+The router's ``forward`` has an ``elif`` that, under CP>1 +
+mtp_data_style="megatron", zigzag-slices ``input_ids`` to match the
+embedding's per-rank chunk (moe_router.py:1500, 1514, 1518-1520). We reach
+it single-card by:
+
+- ``TopKRouter.__new__`` + MagicMock config (experimental_dataflow=False so
+  the preceding ``if`` is skipped and the ``elif`` is evaluated;
+  mtp_data_style="megatron");
+- monkeypatching the module-level ``get_context_parallel_world_size`` -> 2
+  and ``get_context_parallel_rank`` -> 0;
+- feeding a 3-D ``input`` and an ``input_ids`` whose seq length differs from
+  ``input``'s, so the ``elif`` condition is True;
+- replacing the (locally-imported) ``extract_local_zigzag_chunks`` with a
+  sentinel-raiser so execution stops right after line 1520 (before the full
+  MoE routing, which needs real gate weights). The raised sentinel proves
+  the slice line was reached.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import unittest
+from unittest import mock
+from unittest.mock import MagicMock
+
+import paddle
+
+import paddlefleet.transformer.moe.moe_router as mr
+import paddlefleet.transformer.multi_token_prediction as mtp
+from paddlefleet.transformer.moe.moe_router import TopKRouter
+
+
+class _Sentinel(Exception):
+    pass
+
+
+@contextlib.contextmanager
+def _fake_cp_and_extract(cp_size=2):
+    def _raise(*a, **k):
+        raise _Sentinel
+
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(
+            mock.patch.object(
+                mr, "get_context_parallel_world_size", lambda: cp_size
+            )
+        )
+        stack.enter_context(
+            mock.patch.object(mr, "get_context_parallel_rank", lambda: 0)
+        )
+        stack.enter_context(
+            mock.patch.object(mtp, "extract_local_zigzag_chunks", _raise)
+        )
+        yield
+
+
+class TestTopKRouterMegatronCPSlice(unittest.TestCase):
+    def test_elif_slices_input_ids(self) -> None:
+        router = TopKRouter.__new__(TopKRouter)
+        cfg = MagicMock()
+        cfg.experimental_dataflow = False  # skip the preceding `if`
+        cfg.mtp_data_style = "megatron"
+        cfg.cp_balance_mode = "zigzag"
+        router.config = cfg
+        router.sequence_parallel = False
+
+        B, seq_len, d_model = 1, 4, 8
+        inp = paddle.randn([B, seq_len, d_model], dtype="float32")
+        # input_ids seq length (6) != input seq_len (4) -> elif condition True.
+        input_ids = paddle.zeros([B, 6], dtype="int64")
+
+        with _fake_cp_and_extract(cp_size=2), self.assertRaises(_Sentinel):
+            router.forward(inp, input_ids=input_ids)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/transformer/test_mtp_data_style_config.py
+++ b/tests/single_card_tests/transformer/test_mtp_data_style_config.py
@@ -1,0 +1,147 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""TransformerConfig.mtp_data_style validation branches.
+
+Guards the new field's __post_init__ checks:
+  1. Invalid string is rejected.
+  2. "megatron" requires num_nextn_predict_layers > 0 or mtp_num_layers > 0.
+  3. "megatron" is incompatible with enable_mtp_magic_send.
+  4. "megatron" is incompatible with experimental_dataflow.
+  5. "ernie5" (default) never trips any of the new guards regardless of
+     other MTP flags.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from paddlefleet.transformer.transformer_config import TransformerConfig
+
+
+class TestMtpDataStyleValidation(unittest.TestCase):
+    """The new mtp_data_style field must be validated in __post_init__."""
+
+    def _base_kwargs(self, **overrides):
+        """Minimal kwargs to build a TransformerConfig without noise from
+        other fields. All fields have defaults; we only override MTP-related
+        ones needed for a given test case."""
+        return dict(overrides)
+
+    def test_default_style_is_ernie5(self) -> None:
+        cfg = TransformerConfig(**self._base_kwargs())
+        self.assertEqual(cfg.mtp_data_style, "ernie5")
+
+    def test_invalid_style_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, r"mtp_data_style="):
+            TransformerConfig(**self._base_kwargs(mtp_data_style="invalid"))
+
+    def test_megatron_requires_positive_mtp_k(self) -> None:
+        # Neither num_nextn_predict_layers nor mtp_num_layers > 0 → fail
+        with self.assertRaisesRegex(ValueError, r"mtp_data_style='megatron'"):
+            TransformerConfig(
+                **self._base_kwargs(
+                    mtp_data_style="megatron",
+                    num_nextn_predict_layers=0,
+                    mtp_num_layers=0,
+                )
+            )
+
+    def test_megatron_accepts_num_nextn(self) -> None:
+        cfg = TransformerConfig(
+            **self._base_kwargs(
+                mtp_data_style="megatron",
+                num_nextn_predict_layers=1,
+            )
+        )
+        self.assertEqual(cfg.mtp_data_style, "megatron")
+
+    def test_megatron_accepts_mtp_num_layers(self) -> None:
+        cfg = TransformerConfig(
+            **self._base_kwargs(
+                mtp_data_style="megatron",
+                num_nextn_predict_layers=0,
+                mtp_num_layers=2,
+            )
+        )
+        self.assertEqual(cfg.mtp_data_style, "megatron")
+
+    def test_megatron_incompat_with_magic_send(self) -> None:
+        # enable_mtp_magic_send also requires PP>1 (checked earlier in
+        # __post_init__), so we build a config that would pass that check.
+        with self.assertRaisesRegex(ValueError, r"enable_mtp_magic_send"):
+            TransformerConfig(
+                **self._base_kwargs(
+                    mtp_data_style="megatron",
+                    num_nextn_predict_layers=1,
+                    enable_mtp_magic_send=True,
+                    pipeline_model_parallel_size=2,
+                )
+            )
+
+    def test_megatron_incompat_with_experimental_dataflow(self) -> None:
+        with self.assertRaisesRegex(ValueError, r"experimental_dataflow"):
+            TransformerConfig(
+                **self._base_kwargs(
+                    mtp_data_style="megatron",
+                    num_nextn_predict_layers=1,
+                    experimental_dataflow=True,
+                )
+            )
+
+    def test_megatron_cp_requires_dualchunk_allgather(self) -> None:
+        # `contiguous_allgather` is not equivalent to MCore's zigzag layout.
+        with self.assertRaisesRegex(
+            ValueError, r"cp_balance_mode='dualchunk_allgather'"
+        ):
+            TransformerConfig(
+                **self._base_kwargs(
+                    mtp_data_style="megatron",
+                    num_nextn_predict_layers=1,
+                    context_parallel_size=2,
+                    cp_balance_mode="contiguous_allgather",
+                )
+            )
+
+    def test_megatron_cp_accepts_dualchunk_allgather(self) -> None:
+        cfg = TransformerConfig(
+            **self._base_kwargs(
+                mtp_data_style="megatron",
+                num_nextn_predict_layers=1,
+                context_parallel_size=2,
+                cp_balance_mode="dualchunk_allgather",
+            )
+        )
+        self.assertEqual(cfg.cp_balance_mode, "dualchunk_allgather")
+        self.assertEqual(cfg.context_parallel_size, 2)
+
+    def test_megatron_accepts_pp_gt_1(self) -> None:
+        # PP>1 is supported: cu_seqlens_q is threaded through
+        # dist_data_loader.broadcast_data_obj, so the config no longer hard-blocks
+        # it. Positive test to lock in the removal of the old hard block.
+        cfg = TransformerConfig(
+            **self._base_kwargs(
+                mtp_data_style="megatron",
+                num_nextn_predict_layers=1,
+                pipeline_model_parallel_size=2,
+            )
+        )
+        self.assertEqual(cfg.pipeline_model_parallel_size, 2)
+        self.assertEqual(cfg.mtp_data_style, "megatron")
+
+    def test_ernie5_compatible_with_all_flags(self) -> None:
+        # Default path must never trip a new guard, even when other MTP flags
+        # are enabled (backward-compatible regression test).
+        cfg = TransformerConfig(
+            **self._base_kwargs(
+                num_nextn_predict_layers=1,
+                experimental_dataflow=True,
+            )
+        )
+        self.assertEqual(cfg.mtp_data_style, "ernie5")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/transformer/test_mtp_data_style_config.py
+++ b/tests/single_card_tests/transformer/test_mtp_data_style_config.py
@@ -7,7 +7,8 @@
 
 Guards the new field's __post_init__ checks:
   1. Invalid string is rejected.
-  2. "megatron" requires num_nextn_predict_layers > 0 or mtp_num_layers > 0.
+  2. "megatron" requires num_nextn_predict_layers > 0 (the `mtp_num_layers`
+     alias is deliberately NOT accepted).
   3. "megatron" is incompatible with enable_mtp_magic_send.
   4. "megatron" is incompatible with experimental_dataflow.
   5. "ernie5" (default) never trips any of the new guards regardless of
@@ -39,13 +40,13 @@ class TestMtpDataStyleValidation(unittest.TestCase):
             TransformerConfig(**self._base_kwargs(mtp_data_style="invalid"))
 
     def test_megatron_requires_positive_mtp_k(self) -> None:
-        # Neither num_nextn_predict_layers nor mtp_num_layers > 0 → fail
+        # num_nextn_predict_layers is the only switch the megatron data path
+        # reads → K=0 must fail.
         with self.assertRaisesRegex(ValueError, r"mtp_data_style='megatron'"):
             TransformerConfig(
                 **self._base_kwargs(
                     mtp_data_style="megatron",
                     num_nextn_predict_layers=0,
-                    mtp_num_layers=0,
                 )
             )
 
@@ -58,15 +59,20 @@ class TestMtpDataStyleValidation(unittest.TestCase):
         )
         self.assertEqual(cfg.mtp_data_style, "megatron")
 
-    def test_megatron_accepts_mtp_num_layers(self) -> None:
-        cfg = TransformerConfig(
-            **self._base_kwargs(
-                mtp_data_style="megatron",
-                num_nextn_predict_layers=0,
-                mtp_num_layers=2,
+    def test_megatron_rejects_mtp_num_layers_alias_only(self) -> None:
+        # `mtp_num_layers` is honored by MTP layer *construction*
+        # (_get_effective_mtp_layers) but not by the megatron data path, which
+        # reads num_nextn_predict_layers everywhere. Configuring K only through
+        # the alias would build MTP layers that never receive shifted
+        # embeddings, so it must be rejected rather than silently accepted.
+        with self.assertRaisesRegex(ValueError, r"num_nextn_predict_layers"):
+            TransformerConfig(
+                **self._base_kwargs(
+                    mtp_data_style="megatron",
+                    num_nextn_predict_layers=0,
+                    mtp_num_layers=2,
+                )
             )
-        )
-        self.assertEqual(cfg.mtp_data_style, "megatron")
 
     def test_megatron_incompat_with_magic_send(self) -> None:
         # enable_mtp_magic_send also requires PP>1 (checked earlier in

--- a/tests/single_card_tests/transformer/test_mtp_data_style_config.py
+++ b/tests/single_card_tests/transformer/test_mtp_data_style_config.py
@@ -91,6 +91,18 @@ class TestMtpDataStyleValidation(unittest.TestCase):
                 )
             )
 
+    def test_megatron_incompat_with_separate_mtp_input(self) -> None:
+        # separate_mtp_input routes the shifted embeddings through
+        # mtp_decoder_inputs, which _forward_megatron_style never reads.
+        with self.assertRaisesRegex(ValueError, r"separate_mtp_input"):
+            TransformerConfig(
+                **self._base_kwargs(
+                    mtp_data_style="megatron",
+                    num_nextn_predict_layers=1,
+                    separate_mtp_input=True,
+                )
+            )
+
     def test_megatron_cp_requires_dualchunk_allgather(self) -> None:
         # `contiguous_allgather` is not equivalent to MCore's zigzag layout.
         with self.assertRaisesRegex(

--- a/tests/single_card_tests/transformer/test_mtp_emb_res_composition.py
+++ b/tests/single_card_tests/transformer/test_mtp_emb_res_composition.py
@@ -1,0 +1,280 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for MTP K>1 composition (mtp_emb_res list assembly).
+
+Guards the exact code path in ``gpt_embedding.py:357-395`` where the
+``mtp_emb_res`` list is assembled by iterated accumulative rolls of the
+full-length embedding tensor. Prior coverage:
+
+- ``test_language_loss_cu_seqlens_stash.py::test_iterated_rolls_stack_correctly``
+  verifies that K iterations of ``_roll_tensor_packed_seq`` on int labels
+  match a numpy per-doc reference.
+- ``test_roll_tensor_full_length.py::test_pipeline_multi_depth_cp2`` verifies
+  the K=2 accumulative-roll + CP=2 zigzag split combination on int tensors.
+
+This file closes the last gap: for float embedding tensors (the actual
+``mtp_emb_res`` payload), K∈{1, 2, 3} composition — list length K+1,
+first slot is the base embed, slot k+1 is (k+1) iterated rolls of the
+full-length base — must hold both without CP and with CP=2 zigzag
+extraction per depth.
+
+Guards against future refactors that silently drop a depth (e.g.
+``for k in range(K)`` instead of ``range(K+1)``) or reset the running
+roll each iteration (breaking the accumulative semantics).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import paddle
+
+from paddlefleet.transformer.multi_token_prediction import (
+    extract_local_zigzag_chunks,
+    roll_tensor,
+)
+
+
+def _build_mtp_emb_res(
+    inputs_embeds: paddle.Tensor,
+    inputs_embeds_ori: paddle.Tensor,
+    cu_seqlens_q: paddle.Tensor,
+    num_nextn_predict_layers: int,
+    cp_rank: int = 0,
+    cp_size: int = 1,
+) -> list[paddle.Tensor]:
+    """Faithful reproduction of the ``mtp_emb_res`` assembly loop from
+    ``gpt_embedding.py`` (lines 357-395). Kept short and inline here so the
+    test does not depend on constructing a full GPTEmbedding module.
+    """
+    mtp_emb_res = [inputs_embeds]
+    rolled_embed = inputs_embeds_ori
+    for _ in range(num_nextn_predict_layers):
+        rolled_embed, _ = roll_tensor(
+            rolled_embed,
+            shifts=-1,
+            dims=1,
+            cp_group=None,
+            cu_seqlens_q=cu_seqlens_q,
+        )
+        if cp_size > 1:
+            emb_mtp = extract_local_zigzag_chunks(
+                rolled_embed, cp_rank, cp_size, axis=1
+            )
+        else:
+            emb_mtp = rolled_embed
+        mtp_emb_res.append(emb_mtp)
+    return mtp_emb_res
+
+
+def _numpy_per_doc_roll_float(
+    arr: np.ndarray, cu: list[int], shifts: int
+) -> np.ndarray:
+    """Numpy reference: iterate ``shifts`` left rolls within each doc,
+    zero the last position of each doc after each roll. Works on any
+    trailing feature dim (H).
+    """
+    out = arr.copy()
+    for _ in range(shifts):
+        for i in range(len(cu) - 1):
+            s, e = int(cu[i]), int(cu[i + 1])
+            if e - s <= 0:
+                continue
+            doc = out[:, s:e]
+            rolled = np.roll(doc, shift=-1, axis=1)
+            rolled[:, -1] = 0
+            out[:, s:e] = rolled
+    return out
+
+
+class TestMtpEmbResCompositionNoCP:
+    """K∈{1, 2, 3} mtp_emb_res list composition on float embeddings; CP=1
+    (no zigzag extraction).
+    """
+
+    def _run_k(self, K: int) -> None:
+        paddle.set_device("cpu")
+        B, L, H = 1, 24, 4
+        rng = np.random.default_rng(seed=20260813 + K)
+        # Use float payload — real mtp_emb_res carries bf16/fp32 embeddings.
+        embeds_np = rng.standard_normal((B, L, H)).astype(np.float32)
+        cu_list = [
+            0,
+            6,
+            6,
+            18,
+            24,
+        ]  # includes an empty doc to stress boundary handling
+        inputs_embeds = paddle.to_tensor(embeds_np)
+        inputs_embeds_ori = paddle.to_tensor(embeds_np)
+        cu = paddle.to_tensor(cu_list, dtype="int32")
+
+        mtp_emb_res = _build_mtp_emb_res(
+            inputs_embeds, inputs_embeds_ori, cu, K, cp_rank=0, cp_size=1
+        )
+
+        # 1. Guard against off-by-one in loop bounds: list must have K+1 slots.
+        assert len(mtp_emb_res) == K + 1, (
+            f"K={K}: expected {K + 1} slots, got {len(mtp_emb_res)}"
+        )
+
+        # 2. Slot 0 is the base embed unchanged.
+        np.testing.assert_array_equal(
+            mtp_emb_res[0].numpy(),
+            embeds_np,
+            err_msg=f"K={K}: slot 0 must be the base inputs_embeds",
+        )
+
+        # 3. Slot k+1 (for k in [0, K)) is (k+1) accumulated per-doc rolls
+        #    of the full-length base. Uses the numpy reference (which
+        #    test_iterated_rolls_stack_correctly already validated for
+        #    _roll_tensor_packed_seq on ints).
+        for k in range(K):
+            ref = _numpy_per_doc_roll_float(embeds_np, cu_list, shifts=k + 1)
+            np.testing.assert_array_equal(
+                mtp_emb_res[k + 1].numpy(),
+                ref,
+                err_msg=(
+                    f"K={K}, depth={k}: mtp_emb_res[{k + 1}] must equal "
+                    f"(k+1)={k + 1} iterated per-doc rolls of base embed"
+                ),
+            )
+
+    def test_k1(self) -> None:
+        self._run_k(1)
+
+    def test_k2(self) -> None:
+        self._run_k(2)
+
+    def test_k3(self) -> None:
+        self._run_k(3)
+
+
+class TestMtpEmbResCompositionCP2:
+    """K∈{1, 2, 3} mtp_emb_res list composition with CP=2 zigzag extraction
+    per depth. Verifies that the extraction runs on the *post-roll*
+    full-length tensor (embedding invariant with [[eb-mtp-cp-full-length-layout]]).
+    """
+
+    def _run_k(self, K: int) -> None:
+        paddle.set_device("cpu")
+        B, L, H = 1, 16, 4
+        cp_size = 2
+        rng = np.random.default_rng(seed=20260813 + 100 + K)
+        embeds_np = rng.standard_normal((B, L, H)).astype(np.float32)
+        cu_list = [0, 8, 16]
+        inputs_embeds = paddle.to_tensor(embeds_np)
+        inputs_embeds_ori = paddle.to_tensor(embeds_np)
+        cu = paddle.to_tensor(cu_list, dtype="int32")
+
+        for cp_rank in range(cp_size):
+            mtp_emb_res = _build_mtp_emb_res(
+                inputs_embeds,
+                inputs_embeds_ori,
+                cu,
+                K,
+                cp_rank=cp_rank,
+                cp_size=cp_size,
+            )
+            assert len(mtp_emb_res) == K + 1
+
+            # Slot 0 == base (not extracted — matches production code where
+            # slot 0 is inputs_embeds after any earlier SP scatter, not an
+            # extraction result).
+            np.testing.assert_array_equal(mtp_emb_res[0].numpy(), embeds_np)
+
+            for k in range(K):
+                # Reference: roll (k+1) times, then extract this rank's chunks.
+                rolled_ref = _numpy_per_doc_roll_float(
+                    embeds_np, cu_list, shifts=k + 1
+                )
+                rolled_ref_pd = paddle.to_tensor(rolled_ref)
+                expected_local = extract_local_zigzag_chunks(
+                    rolled_ref_pd, cp_rank=cp_rank, cp_size=cp_size, axis=1
+                )
+                np.testing.assert_array_equal(
+                    mtp_emb_res[k + 1].numpy(),
+                    expected_local.numpy(),
+                    err_msg=(
+                        f"K={K}, depth={k}, cp_rank={cp_rank}: "
+                        f"mtp_emb_res[{k + 1}] must equal "
+                        f"extract_local_zigzag_chunks(roll(base, k+1={k + 1}))"
+                    ),
+                )
+
+    def test_k1(self) -> None:
+        self._run_k(1)
+
+    def test_k2(self) -> None:
+        self._run_k(2)
+
+    def test_k3(self) -> None:
+        self._run_k(3)
+
+
+class TestMtpEmbResRegressionGuards:
+    """Explicit regressions we want to catch."""
+
+    def test_off_by_one_less_than_kplus1_is_wrong(self) -> None:
+        """If someone writes ``for depth in range(K)`` but forgets to
+        prepend inputs_embeds, the list length is K not K+1. Confirm our
+        assertion catches that.
+        """
+        paddle.set_device("cpu")
+        B, L, H = 1, 8, 2
+        embeds_np = np.arange(B * L * H, dtype=np.float32).reshape(B, L, H)
+        inputs_embeds = paddle.to_tensor(embeds_np)
+        cu = paddle.to_tensor([0, L], dtype="int32")
+
+        # A buggy loop that forgets the leading slot:
+        bad_res: list[paddle.Tensor] = []
+        rolled = inputs_embeds
+        for _ in range(3):
+            rolled, _ = roll_tensor(
+                rolled, shifts=-1, dims=1, cp_group=None, cu_seqlens_q=cu
+            )
+            bad_res.append(rolled)
+        # Buggy list has length K, not K+1. Guard for future refactoring:
+        assert len(bad_res) == 3
+        # The correct loop always yields K+1 for the same K.
+        good_res = _build_mtp_emb_res(inputs_embeds, inputs_embeds, cu, 3)
+        assert len(good_res) == 4
+
+    def test_non_accumulative_roll_breaks_semantics(self) -> None:
+        """If depth k re-rolls from base once (instead of accumulating),
+        every mtp_emb_res[k] equals a single roll — depth loses meaning.
+        Confirm our reference detects the difference.
+        """
+        paddle.set_device("cpu")
+        B, L, H = 1, 12, 2
+        embeds_np = np.arange(1, B * L * H + 1, dtype=np.float32).reshape(
+            B, L, H
+        )
+        inputs_embeds = paddle.to_tensor(embeds_np)
+        cu_list = [0, 6, 12]
+        cu = paddle.to_tensor(cu_list, dtype="int32")
+
+        # Buggy: always roll from base once, not accumulate.
+        bad_depth2 = roll_tensor(
+            inputs_embeds, shifts=-1, dims=1, cp_group=None, cu_seqlens_q=cu
+        )[0]
+        # Correct: depth 2 should be (k+1)=2 accumulated rolls from base.
+        good_res = _build_mtp_emb_res(inputs_embeds, inputs_embeds, cu, 2)
+        correct_depth2 = good_res[2]
+
+        assert not np.array_equal(bad_depth2.numpy(), correct_depth2.numpy()), (
+            "Accumulative roll must differ from single-roll at depth 2 for "
+            "multi-doc packs — otherwise mtp_emb_res semantics is silently "
+            "reduced to K=1."
+        )

--- a/tests/single_card_tests/transformer/test_mtp_emb_res_composition.py
+++ b/tests/single_card_tests/transformer/test_mtp_emb_res_composition.py
@@ -39,11 +39,25 @@ from __future__ import annotations
 
 import numpy as np
 import paddle
+import pytest
 
 from paddlefleet.transformer.multi_token_prediction import (
     extract_local_zigzag_chunks,
     roll_tensor,
 )
+
+
+@pytest.fixture(autouse=True)
+def _restore_default_device():
+    """The tests below run the pure-python roll/extract helpers on CPU.
+
+    ``paddle.set_device`` is process-global, so without restoring it every test
+    collected after this file in the same pytest session would also run on CPU
+    and hit GPU-only kernels (``rms_norm``).
+    """
+    prev = paddle.get_device()
+    yield
+    paddle.set_device(prev)
 
 
 def _build_mtp_emb_res(

--- a/tests/single_card_tests/transformer/test_mtp_forward_dispatch.py
+++ b/tests/single_card_tests/transformer/test_mtp_forward_dispatch.py
@@ -19,7 +19,7 @@ MagicMock config + a stubbed ``_proj_and_transformer_layer`` so the whole
 megatron-style prologue is exercised:
 
 - ``forward`` dispatch to ``_forward_megatron_style`` under
-  ``mtp_data_style="megatron"`` (multi_token_prediction.py:1062).
+  ``use_erndata=True`` (multi_token_prediction.py:1062).
 - (K+1) split, per-depth hidden_states/decoder_input dispatch, field pops
   (lines 1636-1656).
 - per-depth attn_mask_startend_row_indices derivation from cu_seqlens_q,
@@ -52,7 +52,7 @@ def _make_layer(
 ):
     layer = MultiTokenPredictionLayer.__new__(MultiTokenPredictionLayer)
     cfg = MagicMock()
-    cfg.mtp_data_style = "megatron"
+    cfg.use_erndata = True
     cfg.enable_mtp_magic_send = magic_send
     cfg.num_nextn_predict_layers = K
     cfg.gpt_model_use_experimental_version = include_pos

--- a/tests/single_card_tests/transformer/test_mtp_forward_dispatch.py
+++ b/tests/single_card_tests/transformer/test_mtp_forward_dispatch.py
@@ -1,0 +1,206 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Single-card coverage for MultiTokenPredictionLayer._forward_megatron_style.
+
+Drives the REAL method (not an inline replica) via ``__new__`` +
+MagicMock config + a stubbed ``_proj_and_transformer_layer`` so the whole
+megatron-style prologue is exercised:
+
+- ``forward`` dispatch to ``_forward_megatron_style`` under
+  ``mtp_data_style="megatron"`` (multi_token_prediction.py:1062).
+- (K+1) split, per-depth hidden_states/decoder_input dispatch, field pops
+  (lines 1636-1656).
+- per-depth attn_mask_startend_row_indices derivation from cu_seqlens_q,
+  both the 1-col (fleet) and 2-col (experimental / include_pos) layouts
+  (lines 1667-1717), plus batch_size>1 expand (1713-1716).
+- concat write-back (lines 1723-1726).
+- guard raises: cross-attention (1621-1625), magic-send incompatibility
+  (1626-1634), and 3-D input_ids (1656-1660).
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock
+
+import paddle
+
+from paddlefleet.transformer.multi_token_prediction import (
+    MultiTokenPredictionLayer,
+)
+
+
+def _make_layer(
+    K: int,
+    *,
+    layer_number: int = 0,
+    include_pos: bool = False,
+    sequence_parallel: bool = False,
+    magic_send: bool = False,
+):
+    layer = MultiTokenPredictionLayer.__new__(MultiTokenPredictionLayer)
+    cfg = MagicMock()
+    cfg.mtp_data_style = "megatron"
+    cfg.enable_mtp_magic_send = magic_send
+    cfg.num_nextn_predict_layers = K
+    cfg.gpt_model_use_experimental_version = include_pos
+    cfg.sequence_parallel = sequence_parallel
+    layer.config = cfg
+    layer.layer_number = layer_number
+
+    recorded = {}
+
+    def _stub_proj(hidden_states, decoder_input, **kwargs):
+        recorded["hidden_states_shape"] = list(hidden_states.shape)
+        recorded["decoder_input_shape"] = list(decoder_input.shape)
+        am = kwargs.get("attn_mask_startend_row_indices")
+        recorded["attn_mask_shape"] = None if am is None else list(am.shape)
+        recorded["attn_mask"] = None if am is None else am
+        recorded["kwargs"] = kwargs
+        return decoder_input
+
+    layer._proj_and_transformer_layer = _stub_proj
+    return layer, recorded
+
+
+class TestMtpForwardMegatron(unittest.TestCase):
+    def test_forward_dispatches_to_megatron(self) -> None:
+        # forward() must route to _forward_megatron_style (line 1062).
+        K, S, H = 1, 8, 4
+        layer, recorded = _make_layer(K)
+        hs = paddle.arange((K + 1) * S * H, dtype="float32").reshape(
+            [K + 1, S, H]
+        )
+        cu = paddle.to_tensor([0, 3, 8], dtype="int32")
+        out = layer.forward(
+            {"hidden_states": hs, "cu_seqlens_q": cu, "context": None}
+        )
+        self.assertEqual(recorded["hidden_states_shape"], [1, S, H])
+        self.assertEqual(list(out["hidden_states"].shape), [K + 1, S, H])
+        self.assertNotIn("decoder_input", out)
+
+    def test_fleet_layout_attn_mask_values(self) -> None:
+        # 1-col [1,1,S,1] layout (include_pos=False) with derived ends.
+        K, S, H = 1, 8, 4
+        layer, recorded = _make_layer(K, include_pos=False)
+        hs = paddle.arange((K + 1) * S * H, dtype="float32").reshape(
+            [K + 1, S, H]
+        )
+        cu = paddle.to_tensor([0, 3, 8], dtype="int32")
+        layer._forward_megatron_style(
+            {"hidden_states": hs, "cu_seqlens_q": cu, "context": None}
+        )
+        self.assertEqual(recorded["attn_mask_shape"], [1, 1, S, 1])
+        ends = [row[0] for row in recorded["attn_mask"].numpy().tolist()[0][0]]
+        self.assertEqual(ends, [3, 3, 3, 8, 8, 8, 8, 8])
+
+    def test_experimental_include_pos_layout(self) -> None:
+        # include_pos=True -> 2-col [1,1,S,2] layout (lines 1697-1700).
+        K, S, H = 1, 8, 4
+        layer, recorded = _make_layer(K, include_pos=True)
+        hs = paddle.arange((K + 1) * S * H, dtype="float32").reshape(
+            [K + 1, S, H]
+        )
+        cu = paddle.to_tensor([0, 4, 8], dtype="int32")
+        layer._forward_megatron_style(
+            {"hidden_states": hs, "cu_seqlens_q": cu, "context": None}
+        )
+        self.assertEqual(recorded["attn_mask_shape"], [1, 1, S, 2])
+        vals = recorded["attn_mask"].numpy().tolist()[0][0]
+        ends = [row[0] for row in vals]
+        pos = [row[1] for row in vals]
+        self.assertEqual(ends, [4, 4, 4, 4, 8, 8, 8, 8])
+        self.assertEqual(pos, list(range(S)))
+
+    def test_batch_size_gt_one_expands(self) -> None:
+        # batch_size>1 -> expand branch (lines 1713-1716).
+        K, S, H, B = 1, 8, 4, 2
+        layer, recorded = _make_layer(K)
+        total = (K + 1) * B
+        hs = paddle.arange(total * S * H, dtype="float32").reshape(
+            [total, S, H]
+        )
+        cu = paddle.to_tensor([0, 5, 8], dtype="int32")
+        layer._forward_megatron_style(
+            {"hidden_states": hs, "cu_seqlens_q": cu, "context": None}
+        )
+        self.assertEqual(recorded["attn_mask_shape"], [B, 1, S, 1])
+
+    def test_no_cu_seqlens_skips_mask(self) -> None:
+        # cu_seqlens_q=None -> derivation skipped (line 1668 False branch);
+        # no attn_mask_startend_row_indices set.
+        K, S, H = 2, 6, 4
+        layer, recorded = _make_layer(K)
+        hs = paddle.arange((K + 1) * S * H, dtype="float32").reshape(
+            [K + 1, S, H]
+        )
+        out = layer._forward_megatron_style(
+            {"hidden_states": hs, "context": None}
+        )
+        self.assertIsNone(recorded["attn_mask_shape"])
+        self.assertEqual(list(out["hidden_states"].shape), [K + 1, S, H])
+
+    def test_cross_attention_raises(self) -> None:
+        # context is not None -> NotImplementedError (lines 1621-1625).
+        K, S, H = 1, 8, 4
+        layer, _ = _make_layer(K)
+        hs = paddle.zeros([(K + 1), S, H], dtype="float32")
+        with self.assertRaises(NotImplementedError):
+            layer._forward_megatron_style(
+                {"hidden_states": hs, "context": object()}
+            )
+
+    def test_magic_send_incompatible_raises(self) -> None:
+        # enable_mtp_magic_send=True -> ValueError (lines 1626-1634).
+        K, S, H = 1, 8, 4
+        layer, _ = _make_layer(K, magic_send=True)
+        hs = paddle.zeros([(K + 1), S, H], dtype="float32")
+        with self.assertRaises(ValueError):
+            layer._forward_megatron_style(
+                {"hidden_states": hs, "context": None}
+            )
+
+    def test_mtp_input_embeds_incompatible_raises(self) -> None:
+        # mtp_input_embeds present -> ValueError (lines 1626-1634).
+        K, S, H = 1, 8, 4
+        layer, _ = _make_layer(K)
+        hs = paddle.zeros([(K + 1), S, H], dtype="float32")
+        with self.assertRaises(ValueError):
+            layer._forward_megatron_style(
+                {
+                    "hidden_states": hs,
+                    "context": None,
+                    "mtp_input_embeds": paddle.zeros([1], dtype="float32"),
+                }
+            )
+
+    def test_3d_input_ids_raises(self) -> None:
+        # input_ids with ndim>2 -> RuntimeError (lines 1656-1660).
+        K, S, H = 1, 8, 4
+        layer, _ = _make_layer(K)
+        hs = paddle.zeros([(K + 1), S, H], dtype="float32")
+        bad_ids = paddle.zeros([1, K, S], dtype="int64")
+        with self.assertRaises(RuntimeError):
+            layer._forward_megatron_style(
+                {
+                    "hidden_states": hs,
+                    "context": None,
+                    "input_ids": bad_ids,
+                }
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/transformer/test_parallel_state_cp_rank.py
+++ b/tests/single_card_tests/transformer/test_parallel_state_cp_rank.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Single-card coverage for parallel_state.get_context_parallel_rank.
+
+When context parallelism is NOT initialized (the single-card / CP=1 case)
+``get_context_parallel_group()`` returns ``None`` and
+``get_context_parallel_rank()`` must short-circuit to 0 without touching a
+non-existent process group. This locks that behaviour and exercises the
+``group is None -> return 0`` branch (parallel_state.py:231-232).
+"""
+
+from __future__ import annotations
+
+import types
+import unittest
+from unittest import mock
+
+import paddlefleet.parallel_state as ps
+from paddlefleet.parallel_state import (
+    get_context_parallel_group,
+    get_context_parallel_rank,
+    get_context_parallel_world_size,
+)
+
+
+class TestContextParallelRankDisabled(unittest.TestCase):
+    def test_group_is_none_when_cp_uninitialized(self) -> None:
+        # check_initialized defaults to False here, so no assert is raised.
+        self.assertIsNone(get_context_parallel_group())
+
+    def test_rank_is_zero_when_cp_disabled(self) -> None:
+        # Exercises the ``if get_context_parallel_group() is None: return 0``
+        # branch (lines 231-232).
+        self.assertEqual(get_context_parallel_rank(), 0)
+
+    def test_world_size_is_one_when_cp_disabled(self) -> None:
+        self.assertEqual(get_context_parallel_world_size(), 1)
+
+
+class TestContextParallelRankEnabled(unittest.TestCase):
+    """Covers the ``return get_context_parallel_group().rank`` branch
+    (parallel_state.py:233) by monkeypatching the group getter to return a
+    fake group with a ``.rank`` attribute (no real CP init needed).
+    """
+
+    def test_rank_reads_group_rank_when_cp_enabled(self) -> None:
+        fake_group = types.SimpleNamespace(rank=0, world_size=2)
+        with mock.patch.object(
+            ps, "get_context_parallel_group", return_value=fake_group
+        ):
+            # group is not None -> line 233 returns group.rank.
+            self.assertEqual(ps.get_context_parallel_rank(), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/transformer/test_roll_tensor_full_length.py
+++ b/tests/single_card_tests/transformer/test_roll_tensor_full_length.py
@@ -1,0 +1,268 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for extract_local_zigzag_chunks + full-length CP roll semantics.
+
+Verifies that:
+
+1. ``extract_local_zigzag_chunks`` reproduces PaddleFleet ``scatter_balance``'s
+   dualchunk layout: each rank owns
+   ``chunk_start[interval*r : interval*(r+1)] + chunk_end[L-interval*(r+1) : L-interval*r]``.
+2. Concatenating every rank's local slice, then re-ordering back to global
+   position order, yields the original full-length tensor bit-for-bit.
+3. Under PaddleFleet's full-length CP data layout, ``roll_tensor(cp_group=g)``
+   produces the same result as ``roll_tensor(cp_group=None)`` — the cp_group
+   parameter is API-compat only, no cross-rank P2P is used.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+import paddle
+
+from paddlefleet.transformer.multi_token_prediction import (
+    extract_local_zigzag_chunks,
+    roll_tensor,
+)
+
+
+def _numpy_zigzag_positions(
+    seq_len: int, cp_rank: int, cp_size: int
+) -> np.ndarray:
+    """Reference: which global positions belong to a given cp_rank."""
+    assert seq_len % (2 * cp_size) == 0
+    interval = seq_len // cp_size // 2
+    start = list(range(interval * cp_rank, interval * (cp_rank + 1)))
+    end = list(
+        range(seq_len - interval * (cp_rank + 1), seq_len - interval * cp_rank)
+    )
+    return np.asarray(start + end, dtype=np.int64)
+
+
+class TestExtractLocalZigzagChunks(unittest.TestCase):
+    def test_cp1_returns_input(self) -> None:
+        t = paddle.arange(0, 8, dtype="int64").reshape([1, 8])
+        out = extract_local_zigzag_chunks(t, cp_rank=0, cp_size=1, axis=1)
+        # Identity semantics (may or may not be same object)
+        np.testing.assert_array_equal(out.numpy(), t.numpy())
+
+    def test_cp2_seq8_layout(self) -> None:
+        """cp_size=2, L=8.
+
+        rank 0 owns global positions [0,1,6,7] → [A,B,G,H]
+        rank 1 owns global positions [2,3,4,5] → [C,D,E,F]
+        """
+        t = paddle.arange(0, 8, dtype="int64").reshape([1, 8])
+        r0 = extract_local_zigzag_chunks(t, cp_rank=0, cp_size=2, axis=1)
+        r1 = extract_local_zigzag_chunks(t, cp_rank=1, cp_size=2, axis=1)
+        np.testing.assert_array_equal(r0.numpy(), np.array([[0, 1, 6, 7]]))
+        np.testing.assert_array_equal(r1.numpy(), np.array([[2, 3, 4, 5]]))
+
+    def test_cp4_seq16_layout(self) -> None:
+        """From the design doc example: cp_size=4, L=16."""
+        t = paddle.arange(0, 16, dtype="int64").reshape([1, 16])
+        expected_positions = {
+            0: [0, 1, 14, 15],
+            1: [2, 3, 12, 13],
+            2: [4, 5, 10, 11],
+            3: [6, 7, 8, 9],
+        }
+        for rank, expected in expected_positions.items():
+            out = extract_local_zigzag_chunks(
+                t, cp_rank=rank, cp_size=4, axis=1
+            )
+            np.testing.assert_array_equal(out.numpy(), np.array([expected]))
+
+    def test_ranks_partition_the_sequence(self) -> None:
+        """The union of all ranks' local slices must cover every global
+        position exactly once (partition property)."""
+        for cp_size in (2, 4, 8):
+            seq_len = 32 * cp_size  # ensures divisibility by 2*cp_size
+            t = paddle.arange(0, seq_len, dtype="int64").reshape([1, seq_len])
+            seen = np.zeros(seq_len, dtype=np.int64)
+            for rank in range(cp_size):
+                local = extract_local_zigzag_chunks(
+                    t, cp_rank=rank, cp_size=cp_size, axis=1
+                )
+                for v in local.numpy().reshape(-1).tolist():
+                    seen[v] += 1
+            np.testing.assert_array_equal(
+                seen, np.ones(seq_len, dtype=np.int64)
+            )
+
+    def test_rejects_non_divisible_seq_len(self) -> None:
+        t = paddle.arange(0, 10, dtype="int64").reshape([1, 10])
+        with self.assertRaisesRegex(ValueError, r"not divisible by"):
+            extract_local_zigzag_chunks(t, cp_rank=0, cp_size=2, axis=1)
+
+    def test_higher_dim_tensor(self) -> None:
+        """axis must be interpreted correctly for [B, L, H] tensors."""
+        B, L, H = 2, 8, 4
+        t = paddle.arange(0, B * L * H, dtype="int64").reshape([B, L, H])
+        # rank 0 should get L' = L/2 = 4 along axis=1
+        r0 = extract_local_zigzag_chunks(t, cp_rank=0, cp_size=2, axis=1)
+        self.assertEqual(list(r0.shape), [B, 4, H])
+        # Verify values: rank 0 sees seq positions [0, 1, 6, 7] on axis=1
+        expected_seq_indices = [0, 1, 6, 7]
+        for b in range(B):
+            for i, seq_pos in enumerate(expected_seq_indices):
+                np.testing.assert_array_equal(
+                    r0[b, i].numpy(),
+                    t[b, seq_pos].numpy(),
+                )
+
+    def test_negative_axis(self) -> None:
+        """axis=-1 on a [B, L] tensor should behave the same as axis=1."""
+        t = paddle.arange(0, 8, dtype="int64").reshape([1, 8])
+        r_pos = extract_local_zigzag_chunks(t, cp_rank=0, cp_size=2, axis=1)
+        r_neg = extract_local_zigzag_chunks(t, cp_rank=0, cp_size=2, axis=-1)
+        np.testing.assert_array_equal(r_pos.numpy(), r_neg.numpy())
+
+
+class TestFullLengthRollCPCompat(unittest.TestCase):
+    """roll_tensor's cp_group is API-compat only; result matches cp_group=None."""
+
+    class _FakeCPGroup:
+        def __init__(self, nranks):
+            self.nranks = nranks
+
+    def test_non_packed_cp_group_ignored(self) -> None:
+        t = paddle.arange(1, 9, dtype="int64").reshape([1, 8])
+        out_no_cp, _ = roll_tensor(t, shifts=-1, dims=-1, cp_group=None)
+        out_cp, _ = roll_tensor(
+            t,
+            shifts=-1,
+            dims=-1,
+            cp_group=self._FakeCPGroup(nranks=2),
+        )
+        np.testing.assert_array_equal(out_no_cp.numpy(), out_cp.numpy())
+
+    def test_packed_cp_group_ignored(self) -> None:
+        t = paddle.arange(1, 9, dtype="int64").reshape([1, 8])
+        cu = paddle.to_tensor([0, 4, 8], dtype="int32")
+        out_no_cp, _ = roll_tensor(
+            t, shifts=-1, dims=-1, cp_group=None, cu_seqlens_q=cu
+        )
+        out_cp, _ = roll_tensor(
+            t,
+            shifts=-1,
+            dims=-1,
+            cp_group=self._FakeCPGroup(nranks=4),
+            cu_seqlens_q=cu,
+        )
+        np.testing.assert_array_equal(out_no_cp.numpy(), out_cp.numpy())
+
+    def test_packed_semantics_end_to_end(self) -> None:
+        """Tokens [1..8] with cu=[0,4,8] shift by -1:
+
+        expected rolled = [2, 3, 4, 0, 6, 7, 8, 0]
+        """
+        t = paddle.arange(1, 9, dtype="int64").reshape([1, 8])
+        cu = paddle.to_tensor([0, 4, 8], dtype="int32")
+        out, _ = roll_tensor(t, shifts=-1, dims=-1, cu_seqlens_q=cu)
+        np.testing.assert_array_equal(
+            out.numpy(),
+            np.array([[2, 3, 4, 0, 6, 7, 8, 0]], dtype=np.int64),
+        )
+
+
+class TestFullLengthRollExtractRoundTrip(unittest.TestCase):
+    """The full pipeline: roll full-length → extract per-rank → verify each rank
+    sees its correctly-rolled zigzag positions.
+    """
+
+    def test_pipeline_cp2(self) -> None:
+        seq_len = 8
+        cp_size = 2
+        # Full-length input_ids on every CP rank (per dataloader broadcast).
+        t = paddle.arange(1, seq_len + 1, dtype="int64").reshape([1, seq_len])
+        cu = paddle.to_tensor([0, 4, 8], dtype="int32")
+
+        # Full-length roll (identical on every rank; deterministic).
+        rolled_full, _ = roll_tensor(t, shifts=-1, dims=-1, cu_seqlens_q=cu)
+        rolled_np = rolled_full.numpy().reshape(-1)  # [2,3,4,0,6,7,8,0]
+
+        for rank in range(cp_size):
+            local = extract_local_zigzag_chunks(
+                rolled_full, cp_rank=rank, cp_size=cp_size, axis=1
+            )
+            expected_positions = _numpy_zigzag_positions(seq_len, rank, cp_size)
+            expected_local = rolled_np[expected_positions]
+            np.testing.assert_array_equal(
+                local.numpy().reshape(-1), expected_local
+            )
+
+    def test_pipeline_multi_depth_cp2(self) -> None:
+        """K=2 accumulated roll — depth k applies (k+1) rolls.
+
+        For cu=[0,8,16] (two length-8 docs), tokens [1..16], depth 0 & 1
+        outputs should each preserve doc boundaries.
+        """
+        seq_len = 16
+        cp_size = 2
+        t = paddle.arange(1, seq_len + 1, dtype="int64").reshape([1, seq_len])
+        cu = paddle.to_tensor([0, 8, 16], dtype="int32")
+
+        rolled = t
+        for depth in range(2):
+            rolled, _ = roll_tensor(rolled, shifts=-1, dims=-1, cu_seqlens_q=cu)
+
+        # After 2 rolls, doc 0 [1..8] → [3,4,5,6,7,8,0,0]; doc 1 [9..16] →
+        # [11,12,13,14,15,16,0,0].
+        expected = np.array(
+            [[3, 4, 5, 6, 7, 8, 0, 0, 11, 12, 13, 14, 15, 16, 0, 0]],
+            dtype=np.int64,
+        )
+        np.testing.assert_array_equal(rolled.numpy(), expected)
+
+        # Verify each rank's local slice matches its zigzag chunks of `expected`.
+        for rank in range(cp_size):
+            local = extract_local_zigzag_chunks(
+                rolled, cp_rank=rank, cp_size=cp_size, axis=1
+            )
+            expected_positions = _numpy_zigzag_positions(seq_len, rank, cp_size)
+            expected_local = expected.reshape(-1)[expected_positions]
+            np.testing.assert_array_equal(
+                local.numpy().reshape(-1), expected_local
+            )
+
+
+class TestExtractLocalZigzagChunksRandom(unittest.TestCase):
+    """500 random cases: extraction preserves values (partition + parity)."""
+
+    def test_random_partition_and_parity(self) -> None:
+        rng = np.random.default_rng(seed=20260812)
+        for _ in range(500):
+            cp_size = int(rng.choice([2, 4, 8]))
+            seq_len = int(rng.integers(1, 8)) * 2 * cp_size  # divisible
+            B = int(rng.integers(1, 4))
+            arr = rng.integers(-1000, 1000, size=(B, seq_len)).astype(np.int64)
+            t = paddle.to_tensor(arr)
+
+            # Reconstruct global tensor by scattering per-rank local slices
+            # back to their global positions.
+            reconstructed = np.zeros_like(arr)
+            for rank in range(cp_size):
+                local = extract_local_zigzag_chunks(
+                    t, cp_rank=rank, cp_size=cp_size, axis=1
+                ).numpy()
+                positions = _numpy_zigzag_positions(seq_len, rank, cp_size)
+                reconstructed[:, positions] = local
+            np.testing.assert_array_equal(reconstructed, arr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/transformer/test_roll_tensor_guards_extra.py
+++ b/tests/single_card_tests/transformer/test_roll_tensor_guards_extra.py
@@ -1,0 +1,128 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Extra single-card coverage for roll_tensor / _roll_tensor_packed_seq
+guard clauses and the non-zero pad_value branch.
+
+Complements test_roll_tensor_packed_seq.py by hitting the specific error
+paths and the ``pad_value != 0`` fill that were not exercised there:
+
+- ``_roll_tensor_packed_seq`` out-of-range ``dims`` guard
+  (multi_token_prediction.py:124).
+- ``_roll_tensor_packed_seq`` ``cu_seqlens_q is None`` guard (line 126).
+- ``_roll_tensor_packed_seq`` accepting a plain Python list for
+  ``cu_seqlens_q`` (the non-Tensor branch, line 131).
+- ``roll_tensor`` non-packed path with ``pad_value != 0`` writing the fill
+  value into the new-in tail position (line 257).
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+import paddle
+
+from paddlefleet.transformer.multi_token_prediction import (
+    _roll_tensor_packed_seq,
+    extract_local_zigzag_chunks,
+    roll_tensor,
+)
+
+
+class TestRollTensorPackedSeqGuards(unittest.TestCase):
+    def test_dims_out_of_range_raises(self) -> None:
+        # dim=5 is out of range for a 2-D tensor -> line 124 raise.
+        t = paddle.to_tensor(np.arange(8, dtype=np.int64).reshape(1, 8))
+        cu = paddle.to_tensor([0, 4, 8], dtype="int32")
+        with self.assertRaises(ValueError):
+            _roll_tensor_packed_seq(t, shifts=-1, dims=5, cu_seqlens_q=cu)
+
+    def test_cu_seqlens_none_raises(self) -> None:
+        # cu_seqlens_q=None -> line 126 raise.
+        t = paddle.to_tensor(np.arange(8, dtype=np.int64).reshape(1, 8))
+        with self.assertRaises(ValueError):
+            _roll_tensor_packed_seq(t, shifts=-1, dims=-1, cu_seqlens_q=None)
+
+    def test_cu_seqlens_accepts_python_list(self) -> None:
+        # A plain python list (not a paddle.Tensor) exercises the
+        # ``list(cu_seqlens_q)`` branch on line 131 and must produce the
+        # same result as the tensor form.
+        arr = np.arange(1, 9, dtype=np.int64).reshape(1, 8)
+        cu_list = [0, 4, 8]
+        rolled_list, sum_list = _roll_tensor_packed_seq(
+            paddle.to_tensor(arr), shifts=-1, dims=-1, cu_seqlens_q=cu_list
+        )
+        rolled_t, sum_t = _roll_tensor_packed_seq(
+            paddle.to_tensor(arr),
+            shifts=-1,
+            dims=-1,
+            cu_seqlens_q=paddle.to_tensor(cu_list, dtype="int32"),
+        )
+        np.testing.assert_array_equal(rolled_list.numpy(), rolled_t.numpy())
+        self.assertEqual(int(sum_list.numpy()), int(sum_t.numpy()))
+
+
+class TestRollTensorNonPackedPadValue(unittest.TestCase):
+    def test_nonzero_pad_value_fills_tail(self) -> None:
+        # Non-packed roll with pad_value != 0 -> line 257 (keep*mask + pad*(1-mask)).
+        arr = np.arange(1, 9, dtype=np.int64).reshape(1, 8)
+        rolled, _ = roll_tensor(
+            paddle.to_tensor(arr), shifts=-1, dims=-1, pad_value=-100
+        )
+        out = rolled.numpy()
+        # Standard left shift: [2,3,...,8, <fill>]; fill must be pad_value.
+        self.assertEqual(int(out[0, -1]), -100)
+        np.testing.assert_array_equal(out[0, :-1], arr[0, 1:])
+
+
+class TestExtractLocalZigzagChunks(unittest.TestCase):
+    """extract_local_zigzag_chunks is pure tensor slicing (no CP comm), so
+    all of its branches are reachable single-card by passing cp_size
+    directly.
+    """
+
+    def test_cp_size_one_is_identity(self) -> None:
+        # cp_size == 1 -> early return of the full tensor (lines 292-293).
+        t = paddle.to_tensor(np.arange(16, dtype=np.float32).reshape(1, 8, 2))
+        out = extract_local_zigzag_chunks(t, cp_rank=0, cp_size=1, axis=1)
+        np.testing.assert_array_equal(out.numpy(), t.numpy())
+
+    def test_cp_size_two_zigzag_partition(self) -> None:
+        # cp_size == 2 exercises the slice/concat body (lines 294-315).
+        L = 8
+        t = paddle.to_tensor(np.arange(L, dtype=np.float32).reshape(1, L, 1))
+        interval = L // 2 // 2  # = 2
+        for rank in range(2):
+            out = extract_local_zigzag_chunks(
+                t, cp_rank=rank, cp_size=2, axis=1
+            )
+            # start chunk: [interval*rank : interval*(rank+1)]
+            # end chunk:   [L-interval*(rank+1) : L-interval*rank]
+            start = list(range(interval * rank, interval * (rank + 1)))
+            end = list(range(L - interval * (rank + 1), L - interval * rank))
+            expected = start + end
+            self.assertEqual(
+                out.numpy().reshape(-1).astype(int).tolist(), expected
+            )
+
+    def test_indivisible_seq_len_raises(self) -> None:
+        # seq_len not divisible by 2*cp_size -> ValueError (lines 297-298).
+        t = paddle.to_tensor(np.arange(6, dtype=np.float32).reshape(1, 6, 1))
+        with self.assertRaises(ValueError):
+            extract_local_zigzag_chunks(t, cp_rank=0, cp_size=4, axis=1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/transformer/test_roll_tensor_packed_seq.py
+++ b/tests/single_card_tests/transformer/test_roll_tensor_packed_seq.py
@@ -1,0 +1,244 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for roll_tensor / _roll_tensor_packed_seq.
+
+Verifies that the Paddle port of MCore's ``roll_tensor`` matches a naive
+numpy reference implementation across:
+- non-packed single-sequence roll (baseline);
+- packed sequences with multiple docs of varying lengths;
+- edge cases: single doc, empty tail padding, K depths in [1, 3].
+
+The CP (cp_size>1) branch is not implemented on this path and is only
+checked to raise NotImplementedError here.
+"""
+
+from __future__ import annotations
+
+import unittest
+from dataclasses import dataclass
+
+import numpy as np
+import paddle
+
+from paddlefleet.transformer.multi_token_prediction import (
+    _roll_tensor_packed_seq,
+    roll_tensor,
+)
+
+
+@dataclass
+class _FakePackedSeqParams:
+    cu_seqlens_q: paddle.Tensor
+
+
+def _numpy_roll_packed(
+    tensor_np: np.ndarray, cu_seqlens: list[int]
+) -> np.ndarray:
+    """Reference: per-doc left-shift, boundary position zeroed."""
+    out = tensor_np.copy()
+    num_docs = len(cu_seqlens) - 1
+    for i in range(num_docs):
+        s = int(cu_seqlens[i])
+        e = int(cu_seqlens[i + 1])
+        if e - s <= 0:
+            continue
+        seg = tensor_np[..., s:e].copy()
+        rolled = np.roll(seg, shift=-1, axis=-1)
+        # Zero out the last position of each doc.
+        rolled[..., -1] = 0
+        out[..., s:e] = rolled
+    return out
+
+
+def _numpy_roll_nonpacked(tensor_np: np.ndarray) -> np.ndarray:
+    """Reference for the non-packed branch: standard left-shift + zero-fill."""
+    out = np.roll(tensor_np, shift=-1, axis=-1)
+    out[..., -1] = 0
+    return out
+
+
+def _make_cu_seqlens(seq_lens: list[int]) -> paddle.Tensor:
+    cu = [0]
+    for length in seq_lens:
+        cu.append(cu[-1] + length)
+    return paddle.to_tensor(cu, dtype="int32")
+
+
+class TestRollTensorNonPacked(unittest.TestCase):
+    """Standard (non-packed) roll_tensor behaviour."""
+
+    def test_left_shift_int64(self) -> None:
+        for L in [8, 64, 128]:
+            arr = np.arange(1, L + 1, dtype=np.int64).reshape(1, L)
+            expected = _numpy_roll_nonpacked(arr)
+
+            t = paddle.to_tensor(arr)
+            rolled, total = roll_tensor(t, shifts=-1, dims=-1)
+            np.testing.assert_array_equal(
+                rolled.numpy(), expected, err_msg=f"L={L}"
+            )
+            self.assertEqual(int(total.numpy()), int(expected.sum()))
+
+    def test_left_shift_float32(self) -> None:
+        arr = np.arange(1, 65, dtype=np.float32).reshape(2, 32)
+        expected = _numpy_roll_nonpacked(arr)
+        t = paddle.to_tensor(arr)
+        rolled, _ = roll_tensor(t, shifts=-1, dims=-1)
+        np.testing.assert_allclose(rolled.numpy(), expected)
+
+    def test_rejects_shifts_other_than_minus_one(self) -> None:
+        t = paddle.to_tensor(np.arange(8, dtype=np.int64))
+        with self.assertRaises(ValueError):
+            roll_tensor(t, shifts=1, dims=-1)
+
+
+class TestRollTensorPackedSeq(unittest.TestCase):
+    """_roll_tensor_packed_seq semantics: per-doc shift + zero at doc tail."""
+
+    def _check(self, arr: np.ndarray, seq_lens: list[int]) -> None:
+        cu = [0]
+        for length in seq_lens:
+            cu.append(cu[-1] + length)
+        assert cu[-1] == arr.shape[-1], f"cu={cu} vs shape={arr.shape}"
+
+        expected = _numpy_roll_packed(arr, cu)
+        params = _FakePackedSeqParams(
+            cu_seqlens_q=paddle.to_tensor(cu, dtype="int32")
+        )
+        rolled, total = roll_tensor(
+            paddle.to_tensor(arr),
+            shifts=-1,
+            dims=-1,
+            cp_group=None,
+            cu_seqlens_q=params.cu_seqlens_q,
+        )
+        np.testing.assert_array_equal(
+            rolled.numpy(),
+            expected,
+            err_msg=f"seq_lens={seq_lens}, shape={arr.shape}",
+        )
+        self.assertEqual(int(total.numpy()), int(expected.sum()))
+
+    # ---- L = 64 ----------------------------------------------------------
+
+    def test_L64_two_docs(self) -> None:
+        arr = np.arange(1, 65, dtype=np.int64).reshape(1, 64)
+        self._check(arr, [30, 34])
+
+    def test_L64_three_docs(self) -> None:
+        arr = np.arange(1, 65, dtype=np.int64).reshape(1, 64)
+        self._check(arr, [20, 25, 19])
+
+    def test_L64_single_doc(self) -> None:
+        arr = np.arange(1, 65, dtype=np.int64).reshape(1, 64)
+        self._check(arr, [64])
+
+    # ---- L = 128 ---------------------------------------------------------
+
+    def test_L128_uneven_docs(self) -> None:
+        arr = np.arange(1, 129, dtype=np.int64).reshape(1, 128)
+        self._check(arr, [1, 40, 50, 37])
+
+    def test_L128_single_token_doc_leading(self) -> None:
+        arr = np.arange(1, 129, dtype=np.int64).reshape(1, 128)
+        # A single-token doc rolls to zero (only one boundary position, which is zeroed).
+        self._check(arr, [1, 63, 64])
+
+    # ---- L = 256 ---------------------------------------------------------
+
+    def test_L256_many_docs(self) -> None:
+        arr = np.arange(1, 257, dtype=np.int64).reshape(1, 256)
+        # 7 docs summing to 256
+        self._check(arr, [30, 30, 30, 30, 30, 30, 76])
+
+    # ---- multi-dim payload (e.g. loss_mask [B, L]) -----------------------
+
+    def test_2d_batch(self) -> None:
+        arr = np.random.randint(low=1, high=1000, size=(4, 96)).astype(np.int64)
+        self._check(arr, [20, 30, 46])
+
+    # ---- float payload (e.g. loss_mask float32) --------------------------
+
+    def test_float_payload(self) -> None:
+        arr = np.random.RandomState(0).randn(1, 64).astype(np.float32)
+        cu = [0, 25, 64]
+        expected = _numpy_roll_packed(arr, cu)
+        params = _FakePackedSeqParams(
+            cu_seqlens_q=paddle.to_tensor(cu, dtype="int32"),
+        )
+        rolled, _ = roll_tensor(
+            paddle.to_tensor(arr),
+            shifts=-1,
+            dims=-1,
+            cu_seqlens_q=params.cu_seqlens_q,
+        )
+        np.testing.assert_allclose(rolled.numpy(), expected, atol=1e-6)
+
+
+class TestRollTensorGuards(unittest.TestCase):
+    """Argument validation and CP guard."""
+
+    def test_rejects_non_last_dim(self) -> None:
+        t = paddle.to_tensor(np.zeros((4, 8), dtype=np.int64))
+        params = _FakePackedSeqParams(
+            cu_seqlens_q=paddle.to_tensor([0, 4, 8], dtype="int32"),
+        )
+        with self.assertRaises(ValueError):
+            _roll_tensor_packed_seq(
+                t, shifts=-1, dims=0, cu_seqlens_q=params.cu_seqlens_q
+            )
+
+    def test_rejects_shifts_non_minus_one(self) -> None:
+        t = paddle.to_tensor(np.zeros((1, 8), dtype=np.int64))
+        params = _FakePackedSeqParams(
+            cu_seqlens_q=paddle.to_tensor([0, 8], dtype="int32"),
+        )
+        with self.assertRaises(ValueError):
+            _roll_tensor_packed_seq(
+                t, shifts=-2, dims=-1, cu_seqlens_q=params.cu_seqlens_q
+            )
+
+    def test_cp_group_accepted_and_ignored(self) -> None:
+        """Under PaddleFleet's full-length CP data layout, ``roll_tensor``
+        accepts ``cp_group`` for API compat but ignores it — the result must
+        equal the ``cp_group=None`` output on the same tensor.
+        """
+
+        class _FakeCPGroup:
+            nranks = 2
+
+        t = paddle.to_tensor(np.arange(1, 9, dtype=np.int64).reshape(1, 8))
+        cu = paddle.to_tensor([0, 4, 8], dtype="int32")
+
+        out_no_cp, sum_no_cp = roll_tensor(
+            t,
+            shifts=-1,
+            dims=-1,
+            cp_group=None,
+            cu_seqlens_q=cu,
+        )
+        out_with_cp, sum_with_cp = roll_tensor(
+            t,
+            shifts=-1,
+            dims=-1,
+            cp_group=_FakeCPGroup(),
+            cu_seqlens_q=cu,
+        )
+        np.testing.assert_array_equal(out_no_cp.numpy(), out_with_cp.numpy())
+        self.assertEqual(int(sum_no_cp), int(sum_with_cp))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/transformer/test_separate_headloss_megatron.py
+++ b/tests/single_card_tests/transformer/test_separate_headloss_megatron.py
@@ -17,7 +17,7 @@
 Drives the REAL ``MainLanguageLoss`` / ``MTPLanguageLoss`` / base
 ``LanguageLoss._megatron_label_for_depth`` via ``__new__`` + MagicMock config
 and a stubbed ``_forward`` that records the labels handed to it. Under
-mtp_data_style="megatron":
+use_erndata=True:
 
   * main labels stay length-L (no ``labels[:, :-K]`` trim);
   * per-MTP-depth labels come from ``_roll_tensor_packed_seq`` with
@@ -77,7 +77,7 @@ def _base_loss(K):
     loss = LanguageLoss.__new__(LanguageLoss)
     loss.config = MagicMock()
     loss.config.num_nextn_predict_layers = K
-    loss.config.mtp_data_style = "megatron"
+    loss.config.use_erndata = True
     loss.ignored_index = IGNORED
     return loss
 
@@ -154,7 +154,7 @@ class TestMegatronLabelForDepth(unittest.TestCase):
 
 
 class TestMTPLanguageLossMegatron(unittest.TestCase):
-    """Real ``MTPLanguageLoss.forward`` under mtp_data_style="megatron"."""
+    """Real ``MTPLanguageLoss.forward`` under use_erndata=True."""
 
     def setUp(self) -> None:
         LanguageLoss._cu_seqlens_q_stash = None
@@ -167,7 +167,7 @@ class TestMTPLanguageLossMegatron(unittest.TestCase):
         cfg = MagicMock()
         cfg.num_nextn_predict_layers = K
         cfg.mtp_load_weight_only = False
-        cfg.mtp_data_style = "megatron"
+        cfg.use_erndata = True
         cfg.mtp_distillation_loss = False
         loss.config = cfg
         loss.ignored_index = IGNORED
@@ -212,7 +212,7 @@ class TestMTPLanguageLossMegatron(unittest.TestCase):
 
 
 class TestMainLanguageLossMegatron(unittest.TestCase):
-    """Real ``MainLanguageLoss.forward`` under mtp_data_style="megatron"."""
+    """Real ``MainLanguageLoss.forward`` under use_erndata=True."""
 
     def setUp(self) -> None:
         LanguageLoss._cu_seqlens_q_stash = None
@@ -225,7 +225,7 @@ class TestMainLanguageLossMegatron(unittest.TestCase):
         cfg = MagicMock()
         cfg.num_nextn_predict_layers = K
         cfg.mtp_load_weight_only = False
-        cfg.mtp_data_style = "megatron"
+        cfg.use_erndata = True
         cfg.mtp_distillation_loss = False
         cfg.train_mtp_only = False
         cfg.add_mtp_loss = True

--- a/tests/single_card_tests/transformer/test_separate_headloss_megatron.py
+++ b/tests/single_card_tests/transformer/test_separate_headloss_megatron.py
@@ -1,0 +1,292 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Single-card coverage for the separate_mtp_headloss megatron label path.
+
+Drives the REAL ``MainLanguageLoss`` / ``MTPLanguageLoss`` / base
+``LanguageLoss._megatron_label_for_depth`` via ``__new__`` + MagicMock config
+and a stubbed ``_forward`` that records the labels handed to it. Under
+mtp_data_style="megatron":
+
+  * main labels stay length-L (no ``labels[:, :-K]`` trim);
+  * per-MTP-depth labels come from ``_roll_tensor_packed_seq`` with
+    ``pad_value=ignored_index``, rolled ``depth+1`` times per packed document
+    (boundary positions filled with -100), driven by the class-level
+    ``LanguageLoss._cu_seqlens_q_stash``;
+  * a missing stash raises RuntimeError instead of silently rolling labels
+    across document boundaries.
+
+Also asserts ``GPTMTPLMHead._stash_cu_seqlens_q`` writes the stash so the
+loss stage sees cu_seqlens_q under PP>1.
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock
+
+import numpy as np
+import paddle
+
+from paddlefleet.models.common.language_loss.language_loss import (
+    LanguageLoss,
+    MainLanguageLoss,
+    MTPLanguageLoss,
+)
+
+IGNORED = -100
+
+
+def _cu(cu_list):
+    return paddle.to_tensor(cu_list, dtype="int32")
+
+
+def _ref_per_doc_roll(labels_np, cu_list, depth, ignored=IGNORED):
+    """NumPy reference: roll left (depth+1) times per packed doc, boundary=-100.
+
+    ``labels_np`` is [B, L]. Returns the expected labels for MTP depth ``depth``.
+    """
+    out = labels_np.copy()
+    for _ in range(depth + 1):
+        rolled = out.copy()
+        for i in range(len(cu_list) - 1):
+            s, e = cu_list[i], cu_list[i + 1]
+            if e - s <= 0:
+                continue
+            seg = out[:, s:e]
+            seg_rolled = np.roll(seg, -1, axis=1)
+            seg_rolled[:, -1] = ignored
+            rolled[:, s:e] = seg_rolled
+        out = rolled
+    return out
+
+
+def _base_loss(K):
+    """Bare ``LanguageLoss`` for testing ``_megatron_label_for_depth``."""
+    loss = LanguageLoss.__new__(LanguageLoss)
+    loss.config = MagicMock()
+    loss.config.num_nextn_predict_layers = K
+    loss.config.mtp_data_style = "megatron"
+    loss.ignored_index = IGNORED
+    return loss
+
+
+def _record_forward():
+    """Return (stub, recorded) where stub records the labels it is called with."""
+    recorded = []
+
+    def _stub(logits, labels):
+        recorded.append(labels)
+        return paddle.to_tensor(1.0, dtype="float32")
+
+    return _stub, recorded
+
+
+class TestMegatronLabelForDepth(unittest.TestCase):
+    """Base ``LanguageLoss._megatron_label_for_depth`` (CP=1, TP=1)."""
+
+    def setUp(self) -> None:
+        LanguageLoss._cu_seqlens_q_stash = None
+
+    def tearDown(self) -> None:
+        LanguageLoss._cu_seqlens_q_stash = None
+
+    def test_depth_minus_one_is_full_length_main_label(self) -> None:
+        # depth < 0 => main labels, unchanged, full length L (no L-K trim).
+        loss = _base_loss(K=2)
+        L = 16
+        cu_list = [0, 4, 10, 16]
+        LanguageLoss._cu_seqlens_q_stash = _cu(cu_list)
+        labels_np = np.arange(L, dtype="int64").reshape([1, L])
+        labels = paddle.to_tensor(labels_np)
+        out = loss._megatron_label_for_depth(labels, -1)
+        self.assertEqual(list(out.shape), [1, L])
+        np.testing.assert_array_equal(out.numpy(), labels_np)
+
+    def test_per_depth_roll_matches_numpy_reference(self) -> None:
+        loss = _base_loss(K=2)
+        L = 16
+        cu_list = [0, 4, 10, 16]
+        LanguageLoss._cu_seqlens_q_stash = _cu(cu_list)
+        labels_np = np.arange(L, dtype="int64").reshape([1, L])
+        labels = paddle.to_tensor(labels_np)
+        for depth in range(2):
+            out = loss._megatron_label_for_depth(labels, depth)
+            self.assertEqual(list(out.shape), [1, L])
+            ref = _ref_per_doc_roll(labels_np, cu_list, depth)
+            np.testing.assert_array_equal(out.numpy(), ref)
+
+    def test_boundary_positions_are_ignored_index(self) -> None:
+        loss = _base_loss(K=2)
+        L = 16
+        cu_list = [0, 4, 10, 16]
+        LanguageLoss._cu_seqlens_q_stash = _cu(cu_list)
+        labels = paddle.arange(L, dtype="int64").reshape([1, L])
+        # depth 0: last position of each doc (index 3, 9, 15).
+        d0 = loss._megatron_label_for_depth(labels, 0).numpy()[0]
+        for idx in (3, 9, 15):
+            self.assertEqual(d0[idx], IGNORED)
+        # depth 1: last two positions of each doc (2,3 / 8,9 / 14,15).
+        d1 = loss._megatron_label_for_depth(labels, 1).numpy()[0]
+        for idx in (2, 3, 8, 9, 14, 15):
+            self.assertEqual(d1[idx], IGNORED)
+
+    def test_missing_stash_raises(self) -> None:
+        loss = _base_loss(K=1)
+        LanguageLoss._cu_seqlens_q_stash = None
+        labels = paddle.arange(16, dtype="int64").reshape([1, 16])
+        with self.assertRaises(RuntimeError):
+            loss._megatron_label_for_depth(labels, 0)
+        # depth < 0 never needs the stash.
+        out = loss._megatron_label_for_depth(labels, -1)
+        self.assertEqual(list(out.shape), [1, 16])
+
+
+class TestMTPLanguageLossMegatron(unittest.TestCase):
+    """Real ``MTPLanguageLoss.forward`` under mtp_data_style="megatron"."""
+
+    def setUp(self) -> None:
+        LanguageLoss._cu_seqlens_q_stash = None
+
+    def tearDown(self) -> None:
+        LanguageLoss._cu_seqlens_q_stash = None
+
+    def _make(self, K):
+        loss = MTPLanguageLoss.__new__(MTPLanguageLoss)
+        cfg = MagicMock()
+        cfg.num_nextn_predict_layers = K
+        cfg.mtp_load_weight_only = False
+        cfg.mtp_data_style = "megatron"
+        cfg.mtp_distillation_loss = False
+        loss.config = cfg
+        loss.ignored_index = IGNORED
+        return loss
+
+    def test_per_depth_labels_are_length_L_and_boundary_masked(self) -> None:
+        K, B, L, V = 2, 1, 16, 5
+        cu_list = [0, 4, 10, 16]
+        loss = self._make(K)
+        stub, recorded = _record_forward()
+        loss._forward = stub
+        LanguageLoss._cu_seqlens_q_stash = _cu(cu_list)
+
+        labels_np = np.arange(L, dtype="int64").reshape([B, L])
+        labels = paddle.to_tensor(labels_np)
+        mtp_logits = [
+            paddle.randn([B, L, V], dtype="float32") for _ in range(K)
+        ]
+        out = loss.forward({"mtp_logits": mtp_logits, "labels": labels})
+
+        # forward returns dict_args with per-depth mtp_loss, mtp_logits popped.
+        self.assertIn("mtp_loss", out)
+        self.assertNotIn("mtp_logits", out)
+        self.assertEqual(len(out["mtp_loss"]), K)
+        # One recorded labels tensor per depth; each length-L and matches ref.
+        self.assertEqual(len(recorded), K)
+        for depth in range(K):
+            got = recorded[depth].numpy()
+            self.assertEqual(list(got.shape), [B, L])
+            ref = _ref_per_doc_roll(labels_np, cu_list, depth)
+            np.testing.assert_array_equal(got, ref)
+
+    def test_missing_stash_raises(self) -> None:
+        K, B, L, V = 1, 1, 16, 5
+        loss = self._make(K)
+        loss._forward, _ = _record_forward()
+        LanguageLoss._cu_seqlens_q_stash = None
+        labels = paddle.arange(L, dtype="int64").reshape([B, L])
+        mtp_logits = [paddle.randn([B, L, V], dtype="float32")]
+        with self.assertRaises(RuntimeError):
+            loss.forward({"mtp_logits": mtp_logits, "labels": labels})
+
+
+class TestMainLanguageLossMegatron(unittest.TestCase):
+    """Real ``MainLanguageLoss.forward`` under mtp_data_style="megatron"."""
+
+    def setUp(self) -> None:
+        LanguageLoss._cu_seqlens_q_stash = None
+
+    def tearDown(self) -> None:
+        LanguageLoss._cu_seqlens_q_stash = None
+
+    def _make(self, K):
+        loss = MainLanguageLoss.__new__(MainLanguageLoss)
+        cfg = MagicMock()
+        cfg.num_nextn_predict_layers = K
+        cfg.mtp_load_weight_only = False
+        cfg.mtp_data_style = "megatron"
+        cfg.mtp_distillation_loss = False
+        cfg.train_mtp_only = False
+        cfg.add_mtp_loss = True
+        cfg.mtp_loss_scaling_factor = 1.0
+        loss.config = cfg
+        loss.ignored_index = IGNORED
+        return loss
+
+    def test_main_label_is_full_length_L(self) -> None:
+        K, B, L, V = 2, 1, 16, 5
+        cu_list = [0, 4, 10, 16]
+        loss = self._make(K)
+        stub, recorded = _record_forward()
+        loss._forward = stub
+        LanguageLoss._cu_seqlens_q_stash = _cu(cu_list)
+
+        labels_np = np.arange(L, dtype="int64").reshape([B, L])
+        labels = paddle.to_tensor(labels_np)
+        dict_args = {
+            "logits": paddle.randn([B, L, V], dtype="float32"),
+            "mtp_loss": [
+                paddle.to_tensor(1.0, dtype="float32") for _ in range(K)
+            ],
+        }
+        out = loss.forward(dict_args, labels)
+        self.assertEqual(out.dtype, paddle.float32)
+        # The main label handed to _forward is full-length L, NOT labels[:, :-K],
+        # and unchanged (depth == -1 path).
+        self.assertEqual(len(recorded), 1)
+        got = recorded[0].numpy()
+        self.assertEqual(list(got.shape), [B, L])
+        np.testing.assert_array_equal(got, labels_np)
+
+
+class TestGPTMTPLMHeadStash(unittest.TestCase):
+    """``GPTMTPLMHead._stash_cu_seqlens_q`` writes the loss-stage stash."""
+
+    def setUp(self) -> None:
+        LanguageLoss._cu_seqlens_q_stash = None
+
+    def tearDown(self) -> None:
+        LanguageLoss._cu_seqlens_q_stash = None
+
+    def test_stash_written_from_dict_args(self) -> None:
+        from paddlefleet.models.gpt.lm_head import GPTMTPLMHead
+
+        head = GPTMTPLMHead.__new__(GPTMTPLMHead)
+        cu = _cu([0, 4, 10, 16])
+        head._stash_cu_seqlens_q({"cu_seqlens_q": cu})
+        self.assertIsNotNone(LanguageLoss._cu_seqlens_q_stash)
+        np.testing.assert_array_equal(
+            LanguageLoss._cu_seqlens_q_stash.numpy(), cu.numpy()
+        )
+
+    def test_no_cu_seqlens_q_is_noop(self) -> None:
+        from paddlefleet.models.gpt.lm_head import GPTMTPLMHead
+
+        head = GPTMTPLMHead.__new__(GPTMTPLMHead)
+        head._stash_cu_seqlens_q({"hidden_states": None})
+        self.assertIsNone(LanguageLoss._cu_seqlens_q_stash)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/transformer/test_use_erndata_config.py
+++ b/tests/single_card_tests/transformer/test_use_erndata_config.py
@@ -3,16 +3,20 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 
-"""TransformerConfig.mtp_data_style validation branches.
+"""TransformerConfig.use_erndata validation branches.
 
-Guards the new field's __post_init__ checks:
-  1. Invalid string is rejected.
-  2. "megatron" requires num_nextn_predict_layers > 0 (the `mtp_num_layers`
-     alias is deliberately NOT accepted).
-  3. "megatron" is incompatible with enable_mtp_magic_send.
-  4. "megatron" is incompatible with experimental_dataflow.
-  5. "ernie5" (default) never trips any of the new guards regardless of
-     other MTP flags.
+``use_erndata`` selects the MTP data-flow contract: True means the erndata
+(Energon) pipeline emits length-L tensors + cu_seqlens_q, False means the
+historical ernie5 L+K layout. Guards checked here:
+  1. Default is False.
+  2. use_erndata + MTP requires num_nextn_predict_layers > 0 (the
+     `mtp_num_layers` alias is deliberately NOT accepted).
+  3. use_erndata + MTP is incompatible with enable_mtp_magic_send.
+  4. use_erndata + MTP is incompatible with experimental_dataflow.
+  5. use_erndata without MTP (K == 0) trips none of the guards — the packed-doc
+     forward is only reachable through the MTP layer.
+  6. use_erndata=False never trips any of the guards regardless of other MTP
+     flags.
 """
 
 from __future__ import annotations
@@ -22,8 +26,8 @@ import unittest
 from paddlefleet.transformer.transformer_config import TransformerConfig
 
 
-class TestMtpDataStyleValidation(unittest.TestCase):
-    """The new mtp_data_style field must be validated in __post_init__."""
+class TestUseErndataValidation(unittest.TestCase):
+    """The use_erndata field must be validated in __post_init__."""
 
     def _base_kwargs(self, **overrides):
         """Minimal kwargs to build a TransformerConfig without noise from
@@ -31,102 +35,100 @@ class TestMtpDataStyleValidation(unittest.TestCase):
         ones needed for a given test case."""
         return dict(overrides)
 
-    def test_default_style_is_ernie5(self) -> None:
+    def test_default_is_false(self) -> None:
         cfg = TransformerConfig(**self._base_kwargs())
-        self.assertEqual(cfg.mtp_data_style, "ernie5")
+        self.assertFalse(cfg.use_erndata)
 
-    def test_invalid_style_rejected(self) -> None:
-        with self.assertRaisesRegex(ValueError, r"mtp_data_style="):
-            TransformerConfig(**self._base_kwargs(mtp_data_style="invalid"))
-
-    def test_megatron_requires_positive_mtp_k(self) -> None:
-        # num_nextn_predict_layers is the only switch the megatron data path
-        # reads → K=0 must fail.
-        with self.assertRaisesRegex(ValueError, r"mtp_data_style='megatron'"):
-            TransformerConfig(
-                **self._base_kwargs(
-                    mtp_data_style="megatron",
-                    num_nextn_predict_layers=0,
-                )
-            )
-
-    def test_megatron_accepts_num_nextn(self) -> None:
+    def test_erndata_without_mtp_is_accepted(self) -> None:
+        # K == 0 means no MTP layer, so the packed-doc forward is unreachable
+        # and none of the MTP-specific guards apply.
         cfg = TransformerConfig(
             **self._base_kwargs(
-                mtp_data_style="megatron",
+                use_erndata=True,
+                num_nextn_predict_layers=0,
+                experimental_dataflow=True,
+            )
+        )
+        self.assertTrue(cfg.use_erndata)
+        self.assertEqual(cfg.num_nextn_predict_layers, 0)
+
+    def test_erndata_accepts_num_nextn(self) -> None:
+        cfg = TransformerConfig(
+            **self._base_kwargs(
+                use_erndata=True,
                 num_nextn_predict_layers=1,
             )
         )
-        self.assertEqual(cfg.mtp_data_style, "megatron")
+        self.assertTrue(cfg.use_erndata)
 
-    def test_megatron_rejects_mtp_num_layers_alias_only(self) -> None:
+    def test_erndata_rejects_mtp_num_layers_alias_only(self) -> None:
         # `mtp_num_layers` is honored by MTP layer *construction*
-        # (_get_effective_mtp_layers) but not by the megatron data path, which
+        # (_get_effective_mtp_layers) but not by the erndata data path, which
         # reads num_nextn_predict_layers everywhere. Configuring K only through
         # the alias would build MTP layers that never receive shifted
         # embeddings, so it must be rejected rather than silently accepted.
         with self.assertRaisesRegex(ValueError, r"num_nextn_predict_layers"):
             TransformerConfig(
                 **self._base_kwargs(
-                    mtp_data_style="megatron",
+                    use_erndata=True,
                     num_nextn_predict_layers=0,
                     mtp_num_layers=2,
                 )
             )
 
-    def test_megatron_incompat_with_magic_send(self) -> None:
+    def test_erndata_incompat_with_magic_send(self) -> None:
         # enable_mtp_magic_send also requires PP>1 (checked earlier in
         # __post_init__), so we build a config that would pass that check.
         with self.assertRaisesRegex(ValueError, r"enable_mtp_magic_send"):
             TransformerConfig(
                 **self._base_kwargs(
-                    mtp_data_style="megatron",
+                    use_erndata=True,
                     num_nextn_predict_layers=1,
                     enable_mtp_magic_send=True,
                     pipeline_model_parallel_size=2,
                 )
             )
 
-    def test_megatron_incompat_with_experimental_dataflow(self) -> None:
+    def test_erndata_incompat_with_experimental_dataflow(self) -> None:
         with self.assertRaisesRegex(ValueError, r"experimental_dataflow"):
             TransformerConfig(
                 **self._base_kwargs(
-                    mtp_data_style="megatron",
+                    use_erndata=True,
                     num_nextn_predict_layers=1,
                     experimental_dataflow=True,
                 )
             )
 
-    def test_megatron_incompat_with_separate_mtp_input(self) -> None:
+    def test_erndata_incompat_with_separate_mtp_input(self) -> None:
         # separate_mtp_input routes the shifted embeddings through
-        # mtp_decoder_inputs, which _forward_megatron_style never reads.
+        # mtp_decoder_inputs, which the packed-doc forward never reads.
         with self.assertRaisesRegex(ValueError, r"separate_mtp_input"):
             TransformerConfig(
                 **self._base_kwargs(
-                    mtp_data_style="megatron",
+                    use_erndata=True,
                     num_nextn_predict_layers=1,
                     separate_mtp_input=True,
                 )
             )
 
-    def test_megatron_cp_requires_dualchunk_allgather(self) -> None:
+    def test_erndata_cp_requires_dualchunk_allgather(self) -> None:
         # `contiguous_allgather` is not equivalent to MCore's zigzag layout.
         with self.assertRaisesRegex(
             ValueError, r"cp_balance_mode='dualchunk_allgather'"
         ):
             TransformerConfig(
                 **self._base_kwargs(
-                    mtp_data_style="megatron",
+                    use_erndata=True,
                     num_nextn_predict_layers=1,
                     context_parallel_size=2,
                     cp_balance_mode="contiguous_allgather",
                 )
             )
 
-    def test_megatron_cp_accepts_dualchunk_allgather(self) -> None:
+    def test_erndata_cp_accepts_dualchunk_allgather(self) -> None:
         cfg = TransformerConfig(
             **self._base_kwargs(
-                mtp_data_style="megatron",
+                use_erndata=True,
                 num_nextn_predict_layers=1,
                 context_parallel_size=2,
                 cp_balance_mode="dualchunk_allgather",
@@ -135,21 +137,21 @@ class TestMtpDataStyleValidation(unittest.TestCase):
         self.assertEqual(cfg.cp_balance_mode, "dualchunk_allgather")
         self.assertEqual(cfg.context_parallel_size, 2)
 
-    def test_megatron_accepts_pp_gt_1(self) -> None:
+    def test_erndata_accepts_pp_gt_1(self) -> None:
         # PP>1 is supported: cu_seqlens_q is threaded through
-        # dist_data_loader.broadcast_data_obj, so the config no longer hard-blocks
-        # it. Positive test to lock in the removal of the old hard block.
+        # dist_data_loader.broadcast_data_obj, so the config no longer
+        # hard-blocks it. Positive test to lock in the removal of the old block.
         cfg = TransformerConfig(
             **self._base_kwargs(
-                mtp_data_style="megatron",
+                use_erndata=True,
                 num_nextn_predict_layers=1,
                 pipeline_model_parallel_size=2,
             )
         )
         self.assertEqual(cfg.pipeline_model_parallel_size, 2)
-        self.assertEqual(cfg.mtp_data_style, "megatron")
+        self.assertTrue(cfg.use_erndata)
 
-    def test_ernie5_compatible_with_all_flags(self) -> None:
+    def test_non_erndata_compatible_with_all_flags(self) -> None:
         # Default path must never trip a new guard, even when other MTP flags
         # are enabled (backward-compatible regression test).
         cfg = TransformerConfig(
@@ -158,7 +160,7 @@ class TestMtpDataStyleValidation(unittest.TestCase):
                 experimental_dataflow=True,
             )
         )
-        self.assertEqual(cfg.mtp_data_style, "ernie5")
+        self.assertFalse(cfg.use_erndata)
 
 
 if __name__ == "__main__":

--- a/tests/test_configs.yaml
+++ b/tests/test_configs.yaml
@@ -28,7 +28,7 @@ tests:
   - test_case: [tests/multi_card_tests/pipeline_parallel/test_gpt_pp_with_moe_with_mtp.py]
     products:
       - num_gpus: 8
-  # PP>1 + mtp_data_style="megatron": exercises GPTLMHead._stash_cu_seqlens_q
+  # PP>1 + use_erndata=True: exercises GPTLMHead._stash_cu_seqlens_q
   # delivering cu_seqlens_q to the loss stage under PP (PP=2, TP=1, dense).
   - test_case: [tests/multi_card_tests/pipeline_parallel/test_gpt_pp_mtp_megatron.py]
     products:
@@ -213,7 +213,7 @@ tests:
   - test_case: [tests/multi_card_tests/test_separate_mtp_input_cp.py]
     products:
       - num_gpus: 2
-  # mtp_data_style="megatron" + CP=2: the RoPE tables must follow the same
+  # use_erndata=True + CP=2: the RoPE tables must follow the same
   # zigzag layout the megatron MTP branch slices the embeddings with.
   - test_case: [tests/multi_card_tests/test_gpt_mtp_megatron_cp.py]
     products:

--- a/tests/test_configs.yaml
+++ b/tests/test_configs.yaml
@@ -213,6 +213,11 @@ tests:
   - test_case: [tests/multi_card_tests/test_separate_mtp_input_cp.py]
     products:
       - num_gpus: 2
+  # mtp_data_style="megatron" + CP=2: the RoPE tables must follow the same
+  # zigzag layout the megatron MTP branch slices the embeddings with.
+  - test_case: [tests/multi_card_tests/test_gpt_mtp_megatron_cp.py]
+    products:
+      - num_gpus: 2
   # default fallback for remaining multi_card_tests
   - test_case: [tests/multi_card_tests/pipeline_parallel/*.py]
     products:

--- a/tests/test_configs.yaml
+++ b/tests/test_configs.yaml
@@ -33,6 +33,11 @@ tests:
   - test_case: [tests/multi_card_tests/pipeline_parallel/test_gpt_pp_mtp_megatron.py]
     products:
       - num_gpus: 2
+  # PP>1 + separate_mtp_headloss + megatron: GPTMTPLMHead stash + Main/MTP
+  # LanguageLoss megatron label roll end-to-end (PP=4, VPP=1, TP=1, dense).
+  - test_case: [tests/multi_card_tests/pipeline_parallel/test_gpt_pp_mtp_megatron_separate_headloss.py]
+    products:
+      - num_gpus: 4
   - test_case: [tests/multi_card_tests/pipeline_parallel/test_gpt_pp_with_moe_with_mtp_with_overlap.py]
     products:
       - num_gpus: 8

--- a/tests/test_configs.yaml
+++ b/tests/test_configs.yaml
@@ -28,6 +28,11 @@ tests:
   - test_case: [tests/multi_card_tests/pipeline_parallel/test_gpt_pp_with_moe_with_mtp.py]
     products:
       - num_gpus: 8
+  # PP>1 + mtp_data_style="megatron": exercises GPTLMHead._stash_cu_seqlens_q
+  # delivering cu_seqlens_q to the loss stage under PP (PP=2, TP=1, dense).
+  - test_case: [tests/multi_card_tests/pipeline_parallel/test_gpt_pp_mtp_megatron.py]
+    products:
+      - num_gpus: 2
   - test_case: [tests/multi_card_tests/pipeline_parallel/test_gpt_pp_with_moe_with_mtp_with_overlap.py]
     products:
       - num_gpus: 8


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
New features

### Description
Add a packed-document MTP data path, selected by `use_erndata=True`, alongside
the default L+K path.

Under `use_erndata=True` the data pipeline (erndata / Energon) emits only the
length-L tensors plus a raw int32 `cu_seqlens_q` describing packed-document
boundaries; per-depth shifting happens inside the model (`roll_tensor`) instead
of the legacy L+K token concat + K per-depth attention masks.

**Configuration**

```python
config = GPTConfig(
    ...,
    use_erndata=True,              # selects the packed-doc MTP contract
    num_nextn_predict_layers=K,    # K > 0; the mtp_num_layers alias is rejected
    experimental_dataflow=False,   # required: it expects the legacy payload
    # cp_balance_mode="dualchunk_allgather" is required when
    # context_parallel_size > 1 (the only layout equivalent to MCore zigzag)
)
```

`use_erndata=True` with `num_nextn_predict_layers == 0` is accepted — an erndata
job need not enable MTP; the packed-doc forward is simply unreachable.

**Main changes**

- `multi_token_prediction.py`: `roll_tensor` / `_roll_tensor_packed_seq`
  (per-doc left shift driven by `cu_seqlens_q`), `extract_local_zigzag_chunks`,
  `build_startend_row_indices_from_cu_seqlens`, and the
  `_forward_megatron_style` dispatch. `roll_tensor` gained a `pad_value` arg —
  labels fill doc boundaries with `ignored_index` (not 0) so the boundary token
  is excluded from the loss; embeddings keep `pad_value=0`.
- `gpt_embedding.py` / `transformer_layer.py` / `language_loss.py` /
  `moe_router.py`: new branches guarded by `use_erndata`, with `cu_seqlens_q`
  threaded to the loss stage; when the stash is missing on the loss rank the
  loss raises instead of silently rolling labels across packed docs.
- `gpt_embedding.py` also derives the **main** flashmask from `cu_seqlens_q`
  when the batch does not carry one. erndata emits
  `attn_mask_startend_row_indices` only for `pack_by_cu_seqlen=True` samples
  with documents, so `None` is a legal input; leaving it `None` made the CP
  branch of `DotProductAttention` synthesize an all-visible mask and run
  flashmask with `causal=False`, dropping causality and doc boundaries from the
  backbone.
- `HySparseTransformerLayer._mtp_split/_mtp_restore`: skip the L+K trims under
  `use_erndata` so position_ids / attn_mask are not mis-sliced.
- CP > 1: the RoPE tables are zigzag-sliced with the same layout the embeddings
  use (`RotaryEmbedding.get_rotary_seq_len` always yields the full length L).
- `parallel_state.py`: add `get_context_parallel_rank`.
- `transformer_config.py`: `use_erndata` field + `__post_init__` validation
  (rejects `enable_mtp_magic_send`, `experimental_dataflow`,
  `separate_mtp_input`, and non-`dualchunk_allgather` CP layouts).
- Add single-card unit tests plus PP=2 / PP=4 / CP=2 multi-card tests.

The default `use_erndata=False` path is unchanged.

### 是否引起精度变化
否。默认 `use_erndata=False` 路径的数值与行为完全不变（新增分支均以
`use_erndata` 门控，`roll_tensor` 默认 `pad_value=0` 复用原乘法零填充路径）。
`use_erndata=True` 为可选新路径。
