### PR TITLE
[release/0.4][Bug fixes] Normalise dense indexer KL grad_loss to an fp32 tensor

### DIFF
--- a/src/paddlefleet/cudnn_ops/indexer/dense_indexer_kl_cudnn.py
+++ b/src/paddlefleet/cudnn_ops/indexer/dense_indexer_kl_cudnn.py
@@ -174,6 +174,15 @@ def dense_indexer_kl_bwd(
     divided by something else (a valid-token count, say) has to pre-multiply
     ``loss_coeff`` by ``total_q / its_own_denominator``.
 
+    ``grad_loss`` is normalised to a single-element fp32 tensor here, Python
+    scalars included: the kernel validates it with ``torch.is_tensor``
+    (``indexer_backward/api.py`` ``_validate_grad_loss_tensor``, which sees
+    Paddle tensors through ``paddle.enable_compat``) and raises
+    ``TypeError: grad_loss must be a torch.Tensor`` for anything else. A float
+    therefore never survived the call, which is what the ``None`` default used
+    to build and what ``DenseWarmupIndexerLossAutoScaler.backward`` passes
+    whenever ``DSAIndexerLossAutoScaler`` has no main-loss scale set.
+
     ``attn_score`` and ``index_score`` are consumed **in place** by the
     score-gradient stage and are *not* copied here: at 64k/cp=8 one of them is
     2 GiB, so cloning both would double the backward's width-proportional
@@ -200,11 +209,10 @@ def dense_indexer_kl_bwd(
     )
 
     if grad_loss is None:
-        grad_loss = 1.0
-    if (
-        isinstance(grad_loss, paddle.Tensor)
-        and grad_loss.dtype != paddle.float32
-    ):
+        grad_loss = paddle.ones([], dtype=paddle.float32)
+    elif not isinstance(grad_loss, paddle.Tensor):
+        grad_loss = paddle.to_tensor(float(grad_loss), dtype=paddle.float32)
+    elif grad_loss.dtype != paddle.float32:
         grad_loss = grad_loss.cast(paddle.float32)
 
     out = dense_indexer_backward_wrapper(

--- a/tests/single_card_tests/custom_ops/test_cudnn_dsa_indexer_bwd.py
+++ b/tests/single_card_tests/custom_ops/test_cudnn_dsa_indexer_bwd.py
@@ -16,6 +16,7 @@
 
 Covers:
 - csa_indexer_bwd_cudnn.py (wrapper + _to_bf16 helper)
+- dense_indexer_kl_cudnn.py (grad_loss normalisation, wrapper stubbed)
 - cudnn_ops/__init__.py (lazy __getattr__)
 - csa_attention.py (TileLangCSAIndexerLossAutoScaler cudnn backward branch)
 - transformer_config.py (csa_indexer_backend field + validation)
@@ -903,6 +904,114 @@ class TestIndexerSubpackageInit(unittest.TestCase):
         import paddlefleet.cudnn_ops.indexer as indexer_mod
 
         self.assertIn("csa_indexer_bwd", indexer_mod.__all__)
+
+
+# ---------------------------------------------------------------------------
+# Tests: dense_indexer_kl_cudnn.py grad_loss normalisation
+# ---------------------------------------------------------------------------
+
+
+class TestDenseIndexerKlGradLoss(unittest.TestCase):
+    """``dense_indexer_kl_bwd`` hands the kernel an fp32 *tensor* grad_loss.
+
+    The kernel's ``_validate_grad_loss_tensor`` rejects a non-tensor with
+    ``TypeError: grad_loss must be a torch.Tensor``, so the Python ``1.0``
+    that ``DenseWarmupIndexerLossAutoScaler.backward`` passes whenever
+    ``DSAIndexerLossAutoScaler`` has no main-loss scale set never reached it.
+    The wrapper is stubbed here, so this runs without a Blackwell GPU or the
+    cuDNN frontend -- the conversion is pure Python and that is the part the
+    hardware tests could not reach.
+    """
+
+    def _captured_grad_loss(self, grad_loss):
+        import sys
+        import types
+        from unittest import mock
+
+        import paddlefleet.cudnn_ops.indexer.dense_indexer_kl_cudnn as mod
+
+        captured = {}
+
+        def fake_wrapper(
+            index_q,
+            weights,
+            index_k,
+            attn_score,
+            attn_l1norm,
+            index_score,
+            index_lse,
+            **kwargs,
+        ):
+            captured["grad_loss"] = kwargs["grad_loss"]
+            return {
+                "d_index_q": paddle.zeros_like(index_q),
+                "d_weights": paddle.zeros_like(weights),
+                "d_index_k": kwargs["d_index_k"],
+            }
+
+        api = types.ModuleType("api")
+        api.dense_indexer_backward_wrapper = fake_wrapper
+        api_path = (
+            "paddlefleet_ops.cudnn.deepseek_sparse_attention"
+            ".indexer_backward.api"
+        )
+
+        s, h, d, width = 4, 64, 128, 4
+        index_q = paddle.zeros([s, h, d], dtype="bfloat16")
+        weights = paddle.zeros([s, h], dtype="bfloat16")
+        index_k = paddle.zeros([s, d], dtype="bfloat16")
+        attn_score = paddle.zeros([s, width], dtype="float32")
+        index_score = paddle.zeros([s, width], dtype="float32")
+        attn_l1norm = paddle.ones([s], dtype="float32")
+        index_lse = paddle.zeros([s], dtype="float32")
+        cu_seqlens = paddle.to_tensor([0, s], dtype="int32")
+
+        with (
+            mock.patch.dict(sys.modules, {api_path: api}),
+            mock.patch.object(mod, "is_cudnn_frontend_available", lambda: True),
+        ):
+            mod.dense_indexer_kl_bwd(
+                index_q,
+                weights,
+                index_k,
+                attn_score,
+                attn_l1norm,
+                index_score,
+                index_lse,
+                loss_coeff=0.01,
+                cu_seqlens_q=cu_seqlens,
+                cu_seqlens_k=cu_seqlens,
+                max_seqlen_q=s,
+                max_seqlen_k=s,
+                grad_loss=grad_loss,
+            )
+        return captured["grad_loss"]
+
+    def _assert_fp32_scalar(self, got, expected):
+        self.assertIsInstance(got, paddle.Tensor)
+        self.assertEqual(got.dtype, paddle.float32)
+        self.assertEqual(got.numel().item(), 1)
+        self.assertAlmostEqual(
+            float(got.astype("float32").flatten()[0]), expected, places=6
+        )
+
+    def test_none_becomes_a_one_tensor(self):
+        self._assert_fp32_scalar(self._captured_grad_loss(None), 1.0)
+
+    def test_python_float_becomes_a_tensor(self):
+        """The regression: ``1.0`` used to be forwarded as a Python float."""
+        self._assert_fp32_scalar(self._captured_grad_loss(1.0), 1.0)
+
+    def test_python_int_becomes_a_tensor(self):
+        self._assert_fp32_scalar(self._captured_grad_loss(3), 3.0)
+
+    def test_non_fp32_tensor_is_cast(self):
+        scale = paddle.full([1], 2.5, dtype="bfloat16")
+        self._assert_fp32_scalar(self._captured_grad_loss(scale), 2.5)
+
+    def test_fp32_tensor_is_forwarded_unchanged(self):
+        scale = paddle.full([1], 2.5, dtype="float32")
+        self.assertIs(self._captured_grad_loss(scale), scale)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

The DSA warmup phase (`train_indexer_only: true` + `csa_indexer_backend: cudnn`) dies in its **first backward** on every rank:

```
TypeError: grad_loss must be a torch.Tensor
  paddlefleet_ops/.../indexer_backward/api.py(37): _validate_grad_loss_tensor
  paddlefleet_ops/.../indexer_backward/api.py(402): execute
  paddlefleet/cudnn_ops/indexer/dense_indexer_kl_cudnn.py(210): dense_indexer_kl_bwd
  paddlefleet/transformer/mqa_latent_attention.py(380): backward
```

## Root cause

`dense_indexer_kl_bwd` declares `grad_loss: paddle.Tensor | float | None`, but the body only handled two of the three:

```python
if grad_loss is None:
    grad_loss = 1.0            # <- a Python float, not a tensor
if isinstance(grad_loss, paddle.Tensor) and grad_loss.dtype != paddle.float32:
    grad_loss = grad_loss.cast(paddle.float32)
```

A float falls through both branches and reaches the kernel, whose `_validate_grad_loss_tensor` starts with `torch.is_tensor(grad_loss)` (Paddle tensors pass through `paddle.enable_compat`, a float does not).

`DenseWarmupIndexerLossAutoScaler.backward` passes exactly that float:

```python
scale = DSAIndexerLossAutoScaler._main_loss_backward_scale
grad_loss = 1.0 if scale is None else scale   # mqa_latent_attention.py:377
```

and nothing in the tree calls `DSAIndexerLossAutoScaler.set_loss_scale`, so `scale` is always `None` and the failure is deterministic at step 1.

## Fix

Normalise in the wrapper, so it honours its own signature and both callers are covered:

```python
if grad_loss is None:
    grad_loss = paddle.ones([], dtype=paddle.float32)
elif not isinstance(grad_loss, paddle.Tensor):
    grad_loss = paddle.to_tensor(float(grad_loss), dtype=paddle.float32)
elif grad_loss.dtype != paddle.float32:
    grad_loss = grad_loss.cast(paddle.float32)
```

The sparse path already converts at its call site (`csa_attention.py:1253-1262`); the dense path is left as the only one relying on the wrapper, which is where the conversion belongs. No behaviour change for callers that already pass an fp32 tensor (forwarded unchanged, asserted in the tests).

## Tests

Five mock-based cases in `tests/single_card_tests/custom_ops/test_cudnn_dsa_indexer_bwd.py` (`TestDenseIndexerKlGradLoss`): `None`, Python float, Python int, bf16 tensor cast, fp32 passthrough. The kernel wrapper is stubbed, so they run without a Blackwell GPU or the cuDNN frontend -- which is why the existing hardware-gated `test_hybrid_mla_warmup_kl_cudnn.py` could not catch this.

```
$ pytest tests/single_card_tests/custom_ops/test_cudnn_dsa_indexer_bwd.py -k DenseIndexerKlGradLoss -q
5 passed

# with the fix reverted:
3 failed, 2 passed
```

Also verified end-to-end: the 43-layer latent-MQA + HCA + DSA warmup run gets past the failing backward with this change applied.
