### PR TITLE
[Deps] Bump Paddle to `1b89cc6828f`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ description = "Fleet Core - Core Functional Library for Large Scale Distributed 
 requires-python = ">=3.10"
 dependencies = [
     "colorlog>=6.10.1",
-    "paddlepaddle-gpu==3.4.0.post20260812+a136cd3594a",
+    "paddlepaddle-gpu==3.4.0.post20260820+1b89cc6828f",
     "ruamel.yaml>=0.17",
     "tilelang-paddle==0.1.12",
 ]


### PR DESCRIPTION
### PR Category
Environment Adaptation

### PR Types
Others

### Description
Bump the pinned CUDA 12.9 Paddle dependency from `paddlepaddle-gpu==3.4.0.post20260812+a136cd3594a` to `paddlepaddle-gpu==3.4.0.post20260820+1b89cc6828f`.

Target Paddle commit: [`1b89cc6828f2ae3a5f8919f24d996f8973493077`](https://github.com/PaddlePaddle/Paddle/commit/1b89cc6828f2ae3a5f8919f24d996f8973493077), verified as the live HEAD of Paddle's numeric latest release branch `release/3.4`.

**Artifact verification:** the specified self-hosted CUDA 12.9 CPython 3.12 Linux x86_64 [wheel](https://paddle-whl.bj.bcebos.com/nightly/cu129/paddlepaddle-gpu/paddlepaddle_gpu-3.4.0.post20260820%2B1b89cc6828f-cp312-cp312-linux_x86_64.whl) appears exactly in the cu129 nightly index. The BCE object returns HTTP 200 to HEAD with `Content-Length: 3342308608` and `Last-Modified: Thu, 20 Aug 2026 13:25:50 GMT`; a `Range: bytes=0-0` request returns HTTP 206 with `Content-Range: bytes 0-0/3342308608`.

**Local validation:** TOML and PEP 508 parsing, `git diff --check`, exact one-file/one-line delta, independent-base review, and `pre-commit run --files pyproject.toml` all pass.

### 是否引起精度变化
否
