### PR TITLE
[release/0.4][CSA] Support query heads below the sparse-attn kernel tile

### DIFF
--- a/src/paddlefleet/fusions/csa_sparse_attn.py
+++ b/src/paddlefleet/fusions/csa_sparse_attn.py
@@ -19,12 +19,125 @@ final sparse MQA attention:
   - "unfused": pure-Paddle einsum forward + Paddle autograd backward
   - "tilelang": TileLang sparse MQA forward + TileLang backward
   - "cudnn": FlashMLA sparse forward + cuDNN DSA backward
+
+Head counts below a kernel tile are supported by zero-padding, see
+``_pad_query_heads``.
 """
 
 import functools
 
 import paddle
 from paddle import Tensor
+
+# Query-head counts the "cudnn" backend can run natively. FlashMLA's sparse
+# prefill only instantiates these two tiles (``csrc/api/sparse_fwd.h`` raises
+# "Unsupported h_q" for anything else), and the tile width is the M extent of
+# the tcgen05 / wgmma instruction behind it (``B_H`` in
+# ``sm100/prefill/sparse/fwd/head64/config.h``), so a layer with fewer heads
+# cannot be given a narrower tile without a new kernel.
+_DSA_HEAD_TILES = (64, 128)
+# Sink logit that makes ``exp(sink - m) -> 0``, i.e. plain softmax. Used for the
+# padded heads so they cannot perturb the real ones.
+_NEG_SINK = -1e30
+
+
+def _dsa_head_tile(num_heads: int) -> int:
+    """Smallest cuDNN/FlashMLA query-head tile that fits ``num_heads``."""
+    for tile in _DSA_HEAD_TILES:
+        if num_heads <= tile:
+            return tile
+    raise ValueError(
+        f"csa_sparse_attn 'cudnn' backend supports at most "
+        f"{_DSA_HEAD_TILES[-1]} query heads per rank, got {num_heads}. "
+        "Reduce num_attention_heads (per-rank after TP)."
+    )
+
+
+@functools.lru_cache(maxsize=16)
+def _real_head_rows(num_tokens: int, num_heads: int, head_tile: int) -> Tensor:
+    """Row ids of the real heads in a ``[num_tokens * head_tile, hn]`` view.
+
+    Cached because it only depends on the shape. One entry is
+    ``num_tokens * num_heads`` int32 (1 MiB at 8k tokens x 32 heads), and a
+    process only ever sees one device, so a plain shape-keyed cache is enough.
+    """
+    return (
+        (paddle.arange(num_tokens, dtype="int32") * head_tile).unsqueeze(1)
+        + paddle.arange(num_heads, dtype="int32").unsqueeze(0)
+    ).flatten()
+
+
+def _drop_padded_head_rows(x: Tensor, num_heads: int, head_tile: int) -> Tensor:
+    """Keep the first ``num_heads`` of every ``head_tile`` head-rows of ``x``.
+
+    ``x`` is any tensor whose last axis is the head dim and whose remaining
+    axes flatten to ``num_tokens * head_tile`` rows.
+
+    Implemented as a row ``gather`` rather than a slice: both move the same
+    bytes, but Paddle's strided-slice copy runs at roughly a quarter of the
+    achievable bandwidth here while ``gather`` saturates it (measured on B30Z at
+    8192 tokens x 64->32 heads x 512: 0.53 ms for ``x[:, :h*hn]``, 0.11 ms for
+    the gather).
+    """
+    hn = x.shape[-1]
+    rows = x.reshape([-1, hn])
+    num_tokens = rows.shape[0] // head_tile
+    idx = _real_head_rows(num_tokens, num_heads, head_tile)
+    return paddle.gather(rows, idx, axis=0)
+
+
+@functools.cache
+def _dsa_bwd_runs_sub_tile_heads(num_heads: int) -> bool:
+    """Whether the cuDNN DSA backward accepts this head count below its tile.
+
+    ``flash_attn_bwd_sm100`` derives ``num_head_blocks = ceil(num_head / 64)``
+    and predicates the partial tile, so SM100 returns exactly the same ``dq`` /
+    ``d_sink`` for ``h`` real heads as for the zero-padded problem (verified
+    bit-identical for h=24/32/40/96; ``dkv`` matches to the usual atomic noise).
+    That lets the backward -- the expensive half -- skip the padding entirely,
+    which also keeps the saved ``q``/``out`` at the real head count.
+
+    Two exclusions fall back to the padded (always even, tile-wide) path:
+
+    * **odd head counts**: the kernel reads the ``[N, H]`` fp32 LSE / sum(OdO)
+      rows with a 2-float vector access, so an odd ``H`` leaves every other row
+      only 4-byte aligned and the kernel dies with CUDA 716 (misaligned
+      address). Measured: 31/33/35/63/65 crash, 34/62/66/96/126 are fine.
+    * **SM90**: its kernel packs heads differently
+      (``qhead_per_kvhead`` tiling) and is not validated here.
+    """
+    major, _ = paddle.device.cuda.get_device_capability()
+    return major >= 10 and num_heads % 2 == 0
+
+
+def _pad_query_heads(query: Tensor, attn_sink: Tensor, head_tile: int):
+    """Widen ``query``/``attn_sink`` from ``h`` to ``head_tile`` heads.
+
+    The padded query rows are zeros and their sink logit is ``-1e30``, so they
+    run a plain softmax over the same columns and cannot change the real heads'
+    result; their output rows are dropped by the caller. Hence they receive a
+    zero output gradient, which makes their contribution to ``dkv`` and
+    ``d_sink`` exactly zero (both are ``dO``-weighted sums) and their ``dq``
+    rows unused. So this is numerically exact, not an approximation, and the
+    ``h == head_tile`` path stays bit-for-bit unchanged.
+
+    Padding is used instead of a narrower kernel because the tile width is the
+    MMA M extent (see ``_DSA_HEAD_TILES``): the cost is that the forward keeps
+    doing ``head_tile`` rows of work for ``h`` real heads.
+    """
+    b, sq, h, hn = query.shape
+    query = paddle.concat(
+        [query, paddle.zeros([b, sq, head_tile - h, hn], dtype=query.dtype)],
+        axis=2,
+    )
+    attn_sink = paddle.concat(
+        [
+            attn_sink.cast("float32"),
+            paddle.full([head_tile - h], _NEG_SINK, dtype="float32"),
+        ],
+        axis=0,
+    )
+    return query, attn_sink
 
 
 def unfused_compressed_sparse_attn(
@@ -258,20 +371,52 @@ class CSASparseAttention(paddle.autograd.PyLayer):
             # pre-compact (e.g. CP without cached docmask metadata).
             topk_idxs, topk_length = _csa_compact_topk_idxs(topk_idxs)
 
+        # Heads the kernels are driven with. The FlashMLA forward only has 64-
+        # and 128-head tiles, so a smaller layer is zero-padded up to one; the
+        # cuDNN backward takes the real count on SM100 and only needs the same
+        # padding on SM90. ``ctx.bwd_heads`` records which width the tensors
+        # saved below are in.
+        head_tile = _dsa_head_tile(np_heads) if backend == "cudnn" else np_heads
+        ctx.bwd_heads = (
+            np_heads
+            if head_tile == np_heads or _dsa_bwd_runs_sub_tile_heads(np_heads)
+            else head_tile
+        )
         if backend == "cudnn":
             from paddlefleet.cudnn_ops.attn.csa_sparse_attn_fwd_cudnn import (
                 flash_mla_sparse_attn,
             )
 
+            q_in, sink_in = query, attn_sink
+            if head_tile != np_heads:
+                q_in, sink_in = _pad_query_heads(query, attn_sink, head_tile)
+
             output, lse, lse_indexer = flash_mla_sparse_attn(
-                query,
+                q_in,
                 kv_full,
-                attn_sink,
+                sink_in,
                 topk_idxs,
                 sm_scale=ctx.softmax_scale,
                 topk_length=topk_length,
                 indexer_topk=indexer_topk,
             )
+            output_real, lse_real = output, lse
+            if head_tile != np_heads:
+                output_real = _drop_padded_head_rows(
+                    output, np_heads, head_tile
+                ).reshape([b, sq, np_heads, hn])
+                lse_real = lse[:, :, :np_heads].contiguous()
+                if lse_indexer is not None:
+                    lse_indexer = lse_indexer[:, :, :np_heads].contiguous()
+            if ctx.bwd_heads == np_heads:
+                # The backward runs on the real heads, so the padded forward
+                # tensors are dropped here instead of being kept alive until
+                # backward.
+                save_q, save_sink = query, attn_sink
+                save_out, save_lse = output_real, lse_real
+            else:
+                save_q, save_sink = q_in, sink_in
+                save_out, save_lse = output, lse
             CSASparseAttention._lse_indexer = lse_indexer
         else:
             if topk_length is not None:
@@ -288,13 +433,25 @@ class CSASparseAttention(paddle.autograd.PyLayer):
                 topk_idxs,
                 sm_scale=ctx.softmax_scale,
             )
-        ctx.save_for_backward(query, kv_full, attn_sink, topk_idxs, output, lse)
-        return output.reshape([b, sq, np_heads * hn])
+            output_real = output
+            save_q, save_sink, save_out, save_lse = (
+                query,
+                attn_sink,
+                output,
+                lse,
+            )
+        ctx.save_for_backward(
+            save_q, kv_full, save_sink, topk_idxs, save_out, save_lse
+        )
+        return output_real.reshape([b, sq, np_heads * hn])
 
     @staticmethod
     def backward(ctx, grad_output):
         query, kv_full, attn_sink, topk_idxs, output, lse = ctx.saved_tensor()
         b, sq, np_heads, hn = ctx.query_shape
+        # Kernel-side head count: equal to ``np_heads`` except on the SM90
+        # padded path, where the saved tensors are one head tile wide.
+        kh = ctx.bwd_heads
 
         if ctx.backend == "cudnn":
             from paddlefleet.cudnn_ops import csa_sparse_attn_bwd_cudnn
@@ -304,11 +461,25 @@ class CSASparseAttention(paddle.autograd.PyLayer):
 
             _, s_kv, dkv_dim = kv_full.shape
 
-            q_flat = query.reshape([b * sq, np_heads, hn])
-            o_flat = output.reshape([b * sq, np_heads, hn])
-            do_flat = grad_output.reshape([b * sq, np_heads, hn])
+            if kh != np_heads:
+                # SM90 padded path: widen the incoming gradient to the saved
+                # tensors' head tile. The padded rows get a zero gradient, so
+                # they add nothing to ``dkv`` / ``d_sink``.
+                grad_output = paddle.concat(
+                    [
+                        grad_output.reshape([b, sq, np_heads, hn]),
+                        paddle.zeros(
+                            [b, sq, kh - np_heads, hn], dtype=grad_output.dtype
+                        ),
+                    ],
+                    axis=2,
+                )
+
+            q_flat = query.reshape([b * sq, kh, hn])
+            o_flat = output.reshape([b * sq, kh, hn])
+            do_flat = grad_output.reshape([b * sq, kh, hn])
             kv_flat = kv_full.reshape([b * s_kv, dkv_dim])
-            lse_flat = lse.reshape([b * sq, np_heads])
+            lse_flat = lse.reshape([b * sq, kh])
             topk_idxs_flat = _local_to_global_flat(topk_idxs, s_kv)
 
             # ``topk_idxs`` was already densified in the forward for the compacted
@@ -339,11 +510,15 @@ class CSASparseAttention(paddle.autograd.PyLayer):
                 softmax_scale=ctx.softmax_scale,
                 topk_length=topk_length,
             )
-            dq = dq_flat.reshape(query.shape)
             dkv = dkv_flat.reshape(kv_full.shape)
-            d_attn_sink = d_sink.reshape(attn_sink.shape).cast(
-                ctx.attn_sink_dtype
-            )
+            if kh != np_heads:
+                dq = _drop_padded_head_rows(dq_flat, np_heads, kh).reshape(
+                    [b, sq, np_heads, hn]
+                )
+                d_sink = d_sink[:np_heads]
+            else:
+                dq = dq_flat.reshape([b, sq, np_heads, hn])
+            d_attn_sink = d_sink.reshape([np_heads]).cast(ctx.attn_sink_dtype)
         else:
             from paddlefleet.tilelang_ops.attn import sparse_mqa_bwd
 
@@ -395,6 +570,11 @@ def csa_sparse_attn(
             row. Only the "cudnn" and "unfused" backends support it; it lets
             the kernel stop early instead of walking all ``topk`` slots, which
             is what makes the full-causal MQA layers affordable.
+
+    ``query`` may carry any head count up to 128 on the "cudnn" backend; counts
+    that are not one of the kernel's head tiles (e.g. 32 or 24) are handled
+    inside ``CSASparseAttention`` by padding the forward, which is exact but
+    keeps the forward cost of the tile.
     """
     if backend == "unfused":
         return unfused_compressed_sparse_attn(

--- a/tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_backends.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_backends.py
@@ -590,6 +590,9 @@ class TestCsaBwdTopkLengthDispatch(unittest.TestCase):
             global_kv_idx_remap_fusion=False,
             compacted_idxs=compacted,
             has_topk_length=False,
+            # Head count the saved tensors are in; equal to np_heads unless the
+            # forward padded them up to a kernel head tile.
+            bwd_heads=np_heads,
             query_needs_grad=not query.stop_gradient,
             kv_full_needs_grad=not kv_full.stop_gradient,
             attn_sink_needs_grad=not attn_sink.stop_gradient,

--- a/tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_sub_tile_heads.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_sub_tile_heads.py
@@ -1,0 +1,464 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Query-head counts below a kernel tile on the CSA "cudnn" backend.
+
+FlashMLA's sparse prefill only instantiates 64- and 128-head tiles, so an HCA /
+CSA layer with 32 or 24 heads zero-pads the forward up to the tile and (on
+SM100) drives the backward at the real head count. Three properties are pinned:
+
+1. agreement with the fp32 ``unfused`` reference at the same error level as the
+   tile-native 64-head case -- the padding must not cost accuracy;
+2. non-interference -- whatever occupies the padded rows cannot change the real
+   heads' ``out`` / ``dq``, bit-for-bit;
+3. the backward really runs at the real head count on SM100, which is what stops
+   the padded forward from making a sub-tile layer cost more than a 64-head one.
+"""
+
+import functools
+import unittest
+
+import paddle
+
+try:
+    import paddlefleet_ops
+
+    from paddlefleet.cudnn_ops.attn import csa_sparse_attn_fwd_cudnn
+
+    _HAS_FLASH_MLA = (
+        paddlefleet_ops.is_flash_mla_available()
+        and csa_sparse_attn_fwd_cudnn._flash_mla_sparse_fwd is not None
+    )
+except (ImportError, RuntimeError, AttributeError):
+    _HAS_FLASH_MLA = False
+
+try:
+    import paddlefleet_ops
+
+    from paddlefleet.cudnn_ops import csa_sparse_attn_bwd_cudnn
+
+    _HAS_CUDNN_FRONTEND = paddlefleet_ops.is_cudnn_frontend_available() and (
+        callable(csa_sparse_attn_bwd_cudnn)
+    )
+except (ImportError, RuntimeError, AttributeError):
+    _HAS_CUDNN_FRONTEND = False
+
+_HEAD_TILE = 64
+_D = 512
+
+# b, sq, skv, topk, invalid_frac, name. ``invalid_frac`` seeds ``-1`` columns
+# anywhere in the row (not just a trailing pad), which is what document masking
+# produces and what the backward's trailing ``topk_length`` bound must survive.
+_SHAPES = [
+    (1, 128, 256, 64, 0.0, "dense"),
+    (1, 128, 256, 64, 0.3, "holes"),
+    (2, 256, 512, 192, 0.2, "batch2-topk192"),
+    (1, 64, 8192, 192, 0.1, "hca-like"),
+    (1, 1, 64, 64, 0.0, "single-token"),
+]
+
+
+def _rel_l2(a, b):
+    a_f = a.flatten().cast("float32")
+    b_f = b.flatten().cast("float32")
+    return float(
+        paddle.linalg.norm(a_f - b_f) / (paddle.linalg.norm(b_f) + 1e-12)
+    )
+
+
+def _max_abs_diff(a, b):
+    return float((a.cast("float32") - b.cast("float32")).abs().max())
+
+
+def _make_inputs(b, sq, skv, num_heads, topk, invalid_frac, seed=0, sink=None):
+    paddle.seed(seed)
+    q = paddle.randn([b, sq, num_heads, _D]).cast("bfloat16")
+    kv = paddle.randn([b, skv, _D]).cast("bfloat16")
+    attn_sink = (paddle.randn([num_heads]) * 0.5).cast("float32")
+    if sink is not None:
+        attn_sink = _make_sink(num_heads, sink)
+    topk_idxs = paddle.randint(0, skv, [b, sq, topk]).cast("int32")
+    if invalid_frac > 0:
+        holes = paddle.rand([b, sq, topk]) < invalid_frac
+        topk_idxs = paddle.where(
+            holes, paddle.full_like(topk_idxs, -1), topk_idxs
+        )
+        # Keep one valid column per row; an all-invalid row has no reference.
+        topk_idxs[:, :, 0] = paddle.randint(0, skv, [b, sq]).cast("int32")
+    return q, kv, attn_sink, topk_idxs, 1.0 / _D**0.5
+
+
+def _make_sink(num_heads, spec):
+    """``spec`` is a constant logit, or "split" for half dominant/half ignored."""
+    if spec == "split":
+        half = num_heads // 2
+        return paddle.concat(
+            [
+                paddle.full([half], 8.0, dtype="float32"),
+                paddle.full([num_heads - half], -8.0, dtype="float32"),
+            ]
+        )
+    return paddle.full([num_heads], float(spec), dtype="float32")
+
+
+def _run(q, kv, attn_sink, topk_idxs, scale, backend, junk_heads=0):
+    """One fwd+bwd. ``junk_heads`` appends random extra heads.
+
+    Returns the first ``num_heads`` heads of ``out`` and ``dq`` plus ``dkv`` and
+    ``d_sink``, so a junk-head run stays comparable to a plain one.
+    """
+    from paddlefleet.fusions.csa_sparse_attn import csa_sparse_attn
+
+    b, sq, num_heads, _ = q.shape
+    if junk_heads:
+        q = paddle.concat(
+            [q, paddle.randn([b, sq, junk_heads, _D]).cast(q.dtype)], axis=2
+        )
+        attn_sink = paddle.concat(
+            [attn_sink, (paddle.randn([junk_heads]) * 0.5).cast("float32")],
+            axis=0,
+        )
+    q = q.detach().clone()
+    q.stop_gradient = False
+    kv = kv.detach().clone()
+    kv.stop_gradient = False
+    attn_sink = attn_sink.detach().clone()
+    attn_sink.stop_gradient = False
+
+    out = csa_sparse_attn(q, kv, attn_sink, topk_idxs, scale, backend=backend)
+    out.sum().backward()
+    out = out.reshape([b, sq, num_heads + junk_heads, _D])[:, :, :num_heads, :]
+    return {
+        "out": out,
+        "dq": q.grad[:, :, :num_heads, :],
+        "dkv": kv.grad,
+        "d_sink": attn_sink.grad[:num_heads],
+    }
+
+
+# Ceilings are ~2x the worst observed bf16 error of the tile-native 64-head
+# case; ``test_no_accuracy_loss_vs_tile_native`` additionally ties the sub-tile
+# error to the 64-head one, which is the part that catches a real regression.
+_REL_L2_CEILING = {"out": 6e-3, "dq": 6e-3, "dkv": 6e-3, "d_sink": 8e-3}
+
+
+@functools.lru_cache(maxsize=1)
+def _cudnn_sparse_bwd_runs():
+    """Whether the cuDNN sparse backward can actually execute here.
+
+    ``is_cudnn_frontend_available()`` is not a usable proxy. Some builds of the
+    vendored frontend import a *top-level* ``cudnn`` module while executing,
+    which the loader has already renamed to ``paddlefleet_ops.cudnn``, so the
+    call dies with ``ModuleNotFoundError`` while the probe says "available".
+    One tile-native backward settles it; anything other than a missing module
+    is re-raised, so a real kernel regression still fails loudly.
+    """
+    if not (_HAS_FLASH_MLA and _HAS_CUDNN_FRONTEND):
+        return False
+    try:
+        _run(*_make_inputs(1, 8, 64, _HEAD_TILE, 64, 0.0), backend="cudnn")
+    except Exception as exc:
+        if isinstance(exc, ImportError) or "No module named" in str(exc):
+            return False
+        raise
+    return True
+
+
+def _skip_without_cudnn_sparse_bwd():
+    if not _cudnn_sparse_bwd_runs():
+        raise unittest.SkipTest(
+            "the cuDNN sparse backward does not run in this environment"
+        )
+
+
+@unittest.skipUnless(
+    paddle.is_compiled_with_cuda(), "sub-tile head tests require CUDA"
+)
+class TestSubTileHeads(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        _skip_without_cudnn_sparse_bwd()
+
+    def test_matches_unfused_reference(self):
+        for num_heads in (32, 24):
+            for b, sq, skv, topk, inv, name in _SHAPES:
+                with self.subTest(heads=num_heads, shape=name):
+                    args = _make_inputs(b, sq, skv, num_heads, topk, inv)
+                    ref = _run(*args, backend="unfused")
+                    got = _run(*args, backend="cudnn")
+                    for key, ceiling in _REL_L2_CEILING.items():
+                        self.assertLess(
+                            _rel_l2(got[key], ref[key]),
+                            ceiling,
+                            f"{key} diverges from the fp32 reference",
+                        )
+
+    def test_no_accuracy_loss_vs_tile_native(self):
+        """Padding must not make a sub-tile layer less accurate than h=64.
+
+        ``d_sink`` is excluded: it is one value per head, so its relative L2 is
+        a 24- to 64-element statistic that swings an order of magnitude with the
+        head count alone (measured 2.1e-3 at h=64, 2.4e-4 at h=32, 1.2e-3 at
+        h=24 on SM100, and the same numbers whether the backward runs at the
+        real head count or fully padded). A ratio against the 64-head draw
+        therefore says nothing here; the sink is bounded absolutely by
+        ``test_matches_unfused_reference`` and ``test_sink_magnitudes``, and
+        pinned bit-exactly by ``TestBackwardHeadWidth``.
+        """
+        ratio_keys = [key for key in _REL_L2_CEILING if key != "d_sink"]
+        b, sq, skv, topk, inv = 2, 256, 512, 192, 0.2
+        baseline = _make_inputs(b, sq, skv, _HEAD_TILE, topk, inv)
+        base_ref = _run(*baseline, backend="unfused")
+        base_got = _run(*baseline, backend="cudnn")
+        base_err = {
+            key: _rel_l2(base_got[key], base_ref[key]) for key in ratio_keys
+        }
+        for num_heads in (32, 24):
+            args = _make_inputs(b, sq, skv, num_heads, topk, inv)
+            ref = _run(*args, backend="unfused")
+            got = _run(*args, backend="cudnn")
+            for key in ratio_keys:
+                with self.subTest(heads=num_heads, tensor=key):
+                    self.assertLess(
+                        _rel_l2(got[key], ref[key]),
+                        2.0 * base_err[key],
+                        f"{key} is materially worse than at {_HEAD_TILE} heads",
+                    )
+
+    def test_padded_rows_cannot_leak(self):
+        """Real heads are bit-identical whatever occupies the padded rows.
+
+        The library pads with zeros; here the same call is repeated with
+        *random* q and *random* finite sinks in the trailing rows. ``out`` and
+        ``dq`` are per-head, so they must not move at all. ``dkv`` / ``d_sink``
+        are sums over heads and legitimately change, so they are not compared.
+        """
+        for num_heads in (32, 24):
+            for b, sq, skv, topk, inv, name in _SHAPES:
+                with self.subTest(heads=num_heads, shape=name):
+                    args = _make_inputs(b, sq, skv, num_heads, topk, inv)
+                    padded = _run(*args, backend="cudnn")
+                    junked = _run(
+                        *args,
+                        backend="cudnn",
+                        junk_heads=_HEAD_TILE - num_heads,
+                    )
+                    for key in ("out", "dq"):
+                        self.assertEqual(
+                            _max_abs_diff(padded[key], junked[key]),
+                            0.0,
+                            f"{key} depends on the padded rows",
+                        )
+
+    def test_sink_magnitudes(self):
+        """The learnable sink must survive the padding at any magnitude.
+
+        The padded rows carry a ``-1e30`` sink while the real ones keep the
+        learnable logit, and ``d_sink`` comes back from a differently shaped
+        kernel call, so the sink is the part of this path most likely to break
+        silently. A dominant sink (``+8``: the sink wins the denominator and the
+        output nearly vanishes) and a per-head split are the cases where a
+        leaked pad row or a mis-aligned ``d_sink`` slice would show up.
+        """
+        for num_heads in (32, 24):
+            for spec in (-8.0, 0.0, 8.0, "split"):
+                with self.subTest(heads=num_heads, sink=spec):
+                    args = _make_inputs(
+                        2, 256, 512, num_heads, 192, 0.2, sink=spec
+                    )
+                    ref = _run(*args, backend="unfused")
+                    got = _run(*args, backend="cudnn")
+                    for key, ceiling in _REL_L2_CEILING.items():
+                        self.assertLess(
+                            _rel_l2(got[key], ref[key]),
+                            ceiling,
+                            f"{key} diverges at sink={spec}",
+                        )
+
+    def test_odd_head_count_uses_the_padded_backward(self):
+        """An odd head count must still be correct, via the padded backward.
+
+        The cuDNN backward reads the ``[N, H]`` fp32 LSE with a 2-float vector
+        access and dies with CUDA 716 on an odd ``H``, so those fall back to the
+        (even) padded tile. Without the fallback this test crashes the process
+        rather than failing, which is exactly why it is here.
+        """
+        from paddlefleet.fusions.csa_sparse_attn import (
+            _dsa_bwd_runs_sub_tile_heads,
+        )
+
+        self.assertFalse(_dsa_bwd_runs_sub_tile_heads(31))
+        args = _make_inputs(1, 128, 256, 31, 64, 0.2)
+        ref = _run(*args, backend="unfused")
+        got = _run(*args, backend="cudnn")
+        for key, ceiling in _REL_L2_CEILING.items():
+            self.assertLess(_rel_l2(got[key], ref[key]), ceiling, key)
+
+
+@unittest.skipUnless(
+    paddle.is_compiled_with_cuda(), "sub-tile head tests require CUDA"
+)
+@unittest.skipUnless(
+    _HAS_FLASH_MLA, "sub-tile head forward tests require FlashMLA"
+)
+class TestSubTileHeadsForward(unittest.TestCase):
+    """Forward-only properties, so they also run where the backward cannot."""
+
+    def test_rejects_more_heads_than_the_widest_tile(self):
+        from paddlefleet.fusions.csa_sparse_attn import csa_sparse_attn
+
+        args = _make_inputs(1, 8, 64, 160, 64, 0.0)
+        with self.assertRaisesRegex(ValueError, "at most 128 query heads"):
+            csa_sparse_attn(*args, backend="cudnn")
+
+    def test_indexer_lse_is_returned_at_the_real_head_count(self):
+        """``lse_indexer`` feeds the indexer loss and must lose the pad too."""
+        from paddlefleet.fusions.csa_sparse_attn import (
+            _pad_query_heads,
+            csa_sparse_attn,
+        )
+
+        indexer_topk = 512
+        for num_heads in (32, 24):
+            with self.subTest(heads=num_heads):
+                q, kv, sink, idxs, scale = _make_inputs(
+                    1, 64, 1024, num_heads, indexer_topk + 128, 0.0
+                )
+                _, lse_indexer = csa_sparse_attn(
+                    q,
+                    kv,
+                    sink,
+                    idxs,
+                    scale,
+                    backend="cudnn",
+                    indexer_topk=indexer_topk,
+                )
+                self.assertEqual(list(lse_indexer.shape), [1, 64, num_heads])
+                q_pad, sink_pad = _pad_query_heads(q, sink, _HEAD_TILE)
+                _, lse_ref = csa_sparse_attn(
+                    q_pad,
+                    kv,
+                    sink_pad,
+                    idxs,
+                    scale,
+                    backend="cudnn",
+                    indexer_topk=indexer_topk,
+                )
+                self.assertEqual(
+                    _max_abs_diff(lse_indexer, lse_ref[:, :, :num_heads]),
+                    0.0,
+                )
+
+
+@unittest.skipUnless(
+    paddle.is_compiled_with_cuda(), "sub-tile head tests require CUDA"
+)
+class TestBackwardHeadWidth(unittest.TestCase):
+    """The backward is driven at the real head count, not the forward's tile.
+
+    That is the whole reason a 32-head layer costs about what a 64-head one does
+    instead of ~1.6x: only the forward pays for the padded tile. If the cuDNN
+    kernel ever stops predicating its partial head tile this test fails, and
+    ``_dsa_bwd_runs_sub_tile_heads`` has to be switched off for the arch.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        _skip_without_cudnn_sparse_bwd()
+
+    def _bwd(self, q, kv, out, dout, lse, sink, gidx, scale, num_heads):
+        from paddlefleet.fusions.csa_sparse_attn import _csa_compute_topk_length
+
+        b, sq = q.shape[0], q.shape[1]
+        s_kv = kv.shape[1]
+        return csa_sparse_attn_bwd_cudnn(
+            q.reshape([b * sq, num_heads, _D]),
+            kv.reshape([b * s_kv, _D]),
+            out.reshape([b * sq, num_heads, _D]),
+            dout.reshape([b * sq, num_heads, _D]),
+            lse.reshape([b * sq, num_heads]),
+            sink,
+            gidx,
+            softmax_scale=scale,
+            topk_length=_csa_compute_topk_length(gidx),
+        )
+
+    def test_real_head_count_matches_the_padded_backward(self):
+        from paddlefleet.cudnn_ops.attn.csa_sparse_attn_fwd_cudnn import (
+            flash_mla_sparse_attn,
+        )
+        from paddlefleet.fusions.csa_sparse_attn import (
+            _dsa_bwd_runs_sub_tile_heads,
+            _pad_query_heads,
+        )
+        from paddlefleet.fusions.csa_sparse_attn_utils import (
+            _local_to_global_flat,
+        )
+
+        for num_heads in (32, 24):
+            if not _dsa_bwd_runs_sub_tile_heads(num_heads):
+                self.skipTest("this arch keeps the fully padded backward")
+            for b, sq, skv, topk, inv, name in _SHAPES:
+                with self.subTest(heads=num_heads, shape=name):
+                    q, kv, sink, idxs, scale = _make_inputs(
+                        b, sq, skv, num_heads, topk, inv
+                    )
+                    dout = paddle.randn([b, sq, num_heads, _D]).cast("bfloat16")
+                    q_pad, sink_pad = _pad_query_heads(q, sink, _HEAD_TILE)
+                    dout_pad, _ = _pad_query_heads(dout, sink, _HEAD_TILE)
+                    out_pad, lse_pad, _ = flash_mla_sparse_attn(
+                        q_pad, kv, sink_pad, idxs, sm_scale=scale
+                    )
+                    gidx = _local_to_global_flat(idxs, skv)
+
+                    dq_t, dkv_t, dsink_t = self._bwd(
+                        q_pad,
+                        kv,
+                        out_pad,
+                        dout_pad,
+                        lse_pad,
+                        sink_pad,
+                        gidx,
+                        scale,
+                        _HEAD_TILE,
+                    )
+                    dq_h, dkv_h, dsink_h = self._bwd(
+                        q,
+                        kv,
+                        out_pad.reshape([b, sq, _HEAD_TILE, _D])[
+                            :, :, :num_heads, :
+                        ].contiguous(),
+                        dout,
+                        lse_pad[:, :, :num_heads].contiguous(),
+                        sink,
+                        gidx,
+                        scale,
+                        num_heads,
+                    )
+                    dq_t = dq_t.reshape([b * sq, _HEAD_TILE, _D])[
+                        :, :num_heads, :
+                    ]
+                    dq_h = dq_h.reshape([b * sq, num_heads, _D])
+                    self.assertEqual(_max_abs_diff(dq_h, dq_t), 0.0, "dq moved")
+                    self.assertEqual(
+                        _max_abs_diff(dsink_h, dsink_t[:num_heads]),
+                        0.0,
+                        "d_sink moved",
+                    )
+                    # dKV is accumulated with atomics, so only near-equal.
+                    self.assertLess(_rel_l2(dkv_h, dkv_t), 1e-3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### PR Category

Distributed Strategy

### PR Types

New features

### Description

release/0.4 版本，与 develop 的 #1821 为同一改动（代码逐字相同，develop 上多一个 `global_kv_idx_remap_fusion` 形参的适配）。

FlashMLA 的 sparse prefill 只实例化了 64 / 128 两种 query-head tile（`csrc/api/sparse_fwd.h` 对其它值直接 `TORCH_CHECK(false, "Unsupported h_q")`），而 tile 宽度就是其后 tcgen05 MMA 的 M 维（`sm100/prefill/sparse/fwd/head64/config.h` 里的 `B_H`），所以 head 数 32 / 24 的 HCA / CSA 层此前无法运行。本 PR 让 `csa_sparse_attn` 的 `cudnn` 后端支持任意 ≤128 的 query head 数。

**前向补齐。** q 补零到最近的 tile，补出来的行 sink 取 `-1e30`，因此它们在相同的列上跑普通 softmax；输出行随后被丢弃，对应的输出梯度为零，于是它们对 `dkv` / `d_sink` 的贡献恒为 0（两者都是 `dO` 加权和），`dq` 行也不被使用。这是**精确**的，不是近似；`h == head_tile` 的路径逐位不变。

**反向按真实 head 数跑（SM100）。** `flash_attn_bwd_sm100` 用 `num_head_blocks = ceil(h / 64)` 并对不满的 tile 做 predicate，实测在 h=24/32/40/96 下返回的 `dq` / `d_sink` 与补齐到整 tile 的问题**逐位相同**（`dkv` 在其固有的 atomics 噪声内）。于是只有前向付 padding 的代价，`save_for_backward` 里的 `q` / `out` 也保持真实 head 宽度（省一半激活）。两种情况回退到补齐后的反向：

* **奇数 head 数** —— kernel 以 2-float 向量访问 `[N, H]` 的 fp32 LSE / sum(OdO)，H 为奇数时行只有 4B 对齐，会 `CUDA error(716) misaligned address`（实测 31/33/35/63/65 崩，34/62/66/96/126 正常）；
* **SM90** —— 其 kernel 的 head 打包方式不同，本 PR 未做验证。

**去 padding 用行 `gather` 而不是切片。** 搬运字节数相同，但 Paddle 的 strided-slice 拷贝在这里只能跑到可用带宽的约 1/4（8192 token × 64→32 head × 512：切片 0.53 ms，gather 0.11 ms）。

### 性能

B30Z，b=1，d=512，topk = 128 + seq/128，单位 ms（fwd / fwd+bwd）：

| shape | h=64 | h=32 | h=24 |
| --- | --- | --- | --- |
| seq 8k | 0.47 / 2.34 | 0.82 / 2.37 (1.01x) | 0.80 / 2.29 (0.98x) |
| seq 32k | 2.49 / 13.50 | 3.76 / 13.36 (0.99x) | 3.74 / 13.00 (0.96x) |

前向多花的补齐开销被反向按真实 head 数运行省回来，**32 / 24 头的 fwd+bwd 总耗时与 64 头持平**。

### 是否引起精度变化

否。`h` 等于 tile 宽度（现网的 64）时逐位不变。

新增 `tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_sub_tile_heads.py`（8 test / 48 subtest）：与 fp32 `unfused` 参考的一致性且误差不劣于 64 头基线、补齐行放随机 q 与随机 sink 时真实头 `out` / `dq` 逐位不变、sink 量级扫描（-8 / 0 / +8 / 半正半负）、奇数头回退、`lse_indexer` 头宽度、反向 head 宽度不变性、>128 头报错。`test_csa_sparse_attn_backends.py` 里手工构造 backward ctx 的用例补上了新增的 `bwd_heads` 字段。

回归（B30Z 单卡）：`test_csa_sparse_attn_{sub_tile_heads,backends,utils}.py` + `test_dsv4_hybrid_attention.py` + `test_csa_loss_mask.py` 全通过。另外在 `dsv4_hybrid_attention`（HCA，`v_head_dim=512`，`o_groups=8`）上做了层级端到端对比，h=64/32/24 的 cudnn 与 unfused loss 一致到 6 位小数。
