### PR TITLE
[Deps] Bump Paddle to 733f3454aa0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ description = "Fleet Core - Core Functional Library for Large Scale Distributed 
 requires-python = ">=3.10"
 dependencies = [
     "colorlog>=6.10.1",
-    "paddlepaddle-gpu==3.4.0.post20260820+1b89cc6828f",
+    "paddlepaddle-gpu==3.4.0.post20260808+733f3454aa0",
     "ruamel.yaml>=0.17",
     "tilelang-paddle==0.1.12",
 ]


### PR DESCRIPTION
### PR Category
Environment Adaptation

### PR Types
Not User Facing

### Description
Update the Paddle GPU dependency in `pyproject.toml` to the requested Paddle commit for external dependency switch task #11.

- Previous pin: `paddlepaddle-gpu==3.4.0.post20260820+1b89cc6828f`
- New pin: `paddlepaddle-gpu==3.4.0.post20260808+733f3454aa0`
- Paddle commit: https://github.com/PaddlePaddle/Paddle/commit/733f3454aa05d3e6024d0acb22a6ad2aad396b74

Validation completed:
- Parsed `pyproject.toml` with Python `tomllib`.
- `git diff --check` passed.
- The local `uv lock --check` attempt is blocked by the repository build backend importing removed Python 3.12 `distutils`; required CI is requested for the target head.

### 是否引起精度变化
否
