### PR TITLE
[cherry-pick][Tools] config_adapter: sharding-shrink compensations, MTP/VPP invariants and an EP-first shrink order

### DIFF
--- a/src/paddlefleet/config_adapter/README.md
+++ b/src/paddlefleet/config_adapter/README.md
@@ -21,9 +21,11 @@ sharding 与 batch，必要时缩小 EP/PP 并联动改写 `model_config.json`�
 
 两种组合都遵守同一条硬规则：**源配置里大于 1 的并行度，最小只能缩到 2，不允许
 缩成 1**（EP8 最多缩到 EP2，不会变成 EP1）。把一个维度缩成 1 等于把待测的通信
-组直接去掉，测出来的结果没有参考价值。
+组直接去掉，测出来的结果没有参考价值。唯一例外是 VPP：框架硬断言 VPP>1 需要
+PP>2，PP 缩到 2 时 VPP 只能是 1。
 
-TP 与 SEP 永远不改：减小 TP 会增大单卡显存占用，有 OOM 风险。
+TP 与 SEP 永远不改：减小 TP 会增大单卡显存占用，有 OOM 风险。EP 与 PP 都要缩时按
+**EP 优先于 PP** 的顺序缩（缩 EP 只损失路由专家数，缩 PP 会连带改层数与逐层配置）。
 
 ---
 
@@ -123,6 +125,7 @@ C3/C5 只取决于并行度本身，与卡数无关：这两项冲突时不会�
   -> model_config.json 有改动时另存一份，并把 model_name_or_path 指过去
   -> 应用并行度改动并复核 C1..C4
   -> 缩放 batch、sharding、data_parallel_size
+  -> sharding 路数变小时注入补偿开关（数据流路数 / 优化器 offload）
   -> 写出 YAML 并打印报告
 ```
 
@@ -141,7 +144,19 @@ C3/C5 只取决于并行度本身，与卡数无关：这两项冲突时不会�
   因长度不符直接启动失败。源列表长度本身与 `num_hidden_layers` 不一致，或裁剪会让
   `csa_compress_ratios` 丢掉某一类注意力层（框架要求每类至少一层）时，该候选会被
   拒绝而不是硬改。
-- 联合缩：EP × PP 笛卡尔积，平局时先取最大 EP，再取最大 PP。
+- 联合缩：EP × PP 笛卡尔积，按 **EP 优先于 PP** 的缩容顺序取点 —— 先把 EP 压到可行
+  下限，再取该 EP 下最大的 PP。缩 EP 只损失路由专家数，缩 PP 会连带改层数、逐层配置、
+  VPP 和空尾层，所以宁可多缩 EP、少缩 PP。
+
+两条按框架真实行为兜住的不变量：
+
+- `mtp_shared_last_layer` 为真且有 MTP 层时，末层 decoder 与 MTP 层通过
+  `SharedLayerDesc` 共享 attention 权重，两者注意力类型必须一致；裁剪后末层
+  `csa_compress_ratios` 会被**改写成** MTP 项的值，否则共享权重跨 stage broadcast
+  时几何不匹配，训练直接挂死（不报错）。
+- VPP>1 需要 PP>2（框架硬断言 `virtual pipeline must run under pp degree > 2`）。
+  PP 缩到 2 时 VPP 一并置 1，冻结 / 只缩 EP / 维度已合法这几条不动 PP 的路径同样会
+  兜一次，避免把源里 PP≤2 且 VPP>1 的组合原样透传成启动即挂的配置。
 
 写盘时机：所有规划与校验都在内存里完成后才落盘，中途任何一步失败都不改动源文件；
 写文件走临时文件 + 原子替换，`--in-place` 下若 YAML 写失败会回滚已写的
@@ -181,6 +196,35 @@ C/E/M 全部不通过时，报错会给出候选淘汰明细和最近的合法�
 
 ---
 
+## sharding 缩容的补偿开关
+
+卡数变少 → `sharding` 变小，有两件事按缩容倍数一起变差：数据流被切成
+`dataset_world_size = sharding / CP` 份，每份要走更长的文件列表才拿到第一个 batch；
+优化器状态按同一个度切分，单卡优化器显存按倍数放大。目标路数比源窄时自动注入：
+
+| 字段 | 值 | 原因 |
+|---|---|---|
+| `debug_reeao_dataset_world_size` | 源路数 | 把**数据切分**的份数固定回源规模（rank 仍是真实 rank，各 rank 读到的切片依旧互不重叠） |
+| `tensorwise_offload_optimizer` | `true` | 优化器状态放到 host 内存，防止单卡放大若干倍后 OOM |
+
+offload 有一条全由框架硬报错撑起来的依赖链，按顺序一并关掉；只改源里**显式声明且
+取值冲突**的键（框架默认 `false` / `0` 本来就兼容），`--set tensorwise_offload_optimizer=false`
+时整条链都不动：
+
+```
+tensorwise_offload_optimizer=true
+  -> fuse_optimizer_states=false        # fuse 与 offload 冲突，框架直接报错
+  -> enable_zero_cost_checkpoint=false  # ZCC 断言 fuse_optimizer_states=true
+  -> flash_device_save_steps=0          # >0 断言 enable_zero_cost_checkpoint=true
+```
+
+线上 YAML 常把 `global_batch_size` 注释掉、也不写 `sharding_parallel_size`，源规模推
+不出来；这两个开关在那种配置上同样必要，所以此时按「源配置自己的 `dense_sharding`
+（= `EP/(TP·SEP)`，实际加载数据的卡数）× 96」估计源路数。路数往大估只会让每路切片更
+短，没有代价。
+
+---
+
 ## 输出
 
 只列**真正发生了变化**的字段（值没变的写入不会出现在日志里），每条都带上
@@ -189,26 +233,46 @@ C/E/M 全部不通过时，报错会给出候选淘汰明细和最近的合法�
 `MODEL_CONFIG_OUTPUT=`）：
 
 ```
-===== config_adapter: 适配成功 =====
+========================================================================================
+config_adapter: 适配成功
+========================================================================================
 输入      ：big.yaml
 模式      ：accuracy（--test-accuracy），batch 策略 scale_accumulation
 机器规模  ：96 节点 / 768 卡 -> 1 节点 / 8 卡（每节点 8 卡）
-并行度    ：TP 1->1  PP 8->2  EP 64->4  CP 1->1  SEP 1->1
-sharding  ：96 -> 4（moe_sharding=1, dense_sharding=4）
-缩容方案  ：EP+PP 联合缩容：EP 64 -> 4，PP 8 -> 2
-YAML 改动（6 项）-> adapted_configs/big_adapted_8cards.yaml
-  CHANGE field=expert_model_parallel_size old=64 new=4
-      原因：缩小 EP 64 -> 4：单独缩 EP 或单独缩 PP 都无法适配 8 卡，改为联合缩容
+并行度    ：TP 1->1  PP 8->4  EP 64->2  CP 1->1  SEP 1->1
+sharding  ：96 -> 2（moe_sharding=1, dense_sharding=2）
+缩容方案  ：EP+PP 联合缩容：EP 64 -> 2，PP 8 -> 4
+
+--- YAML 改动（9 项） ------------------------------------------------------------------
+写入      ：adapted_configs/big_adapted_8cards.yaml
+
+  CHANGE field=expert_model_parallel_size old=64 new=2
+      原因：缩小 EP 64 -> 2：单独缩 EP 或单独缩 PP 都无法适配 8 卡，改为联合缩容；按 EP
+            优先于 PP 的缩容顺序，先把 EP 压到可行下限，再尽量少缩 PP（缩 PP 会连带改层
+            数/VPP/尾部空层/逐层配置）
+
   CHANGE field=gradient_accumulation_steps old=2 new=192
       原因：保持等效 batch：GBS 保持 1536 不变，acc 放大为 2 × 768 / 8 = 192
+
+  ADD field=tensorwise_offload_optimizer new=True
+      原因：sharding 路数 96 -> 2，单卡优化器状态放大 48 倍，offload 到 host 内存防 OOM
+
   ...
-model_config.json 改动（3 项）-> adapted_configs/model_config_separated/model_dir_adapted_8cards/model_config.json
-  CHANGE field=n_routed_experts old=256 new=16
-      原因：随 EP 64 -> 4 等比缩减专家数 256 -> 16（>= top-k=8）
+
+--- model_config.json 改动（3 项） -----------------------------------------------------
+写入      ：adapted_configs/model_config_separated/model_dir_adapted_8cards/model_config.json
+
+  CHANGE field=n_routed_experts old=256 new=8
+      原因：随 EP 64 -> 2 等比缩减专家数 256 -> 8（>= top-k=8）
+
   ...
+
+--- 机器可读摘要 -----------------------------------------------------------------------
 ORIGINAL_CARDS=768
+ORIGINAL_NODES=96
 TARGET_CARDS=8
 OUTPUT=adapted_configs/big_adapted_8cards.yaml
+MODEL_CONFIG_OUTPUT=adapted_configs/model_config_separated/model_dir_adapted_8cards/model_config.json
 ```
 
 ---
@@ -223,6 +287,7 @@ config_adapter/
 ├── planner.py                # 并行度规划：冻结 / EP-PP 分层缩容
 ├── plan.py                   # ParallelismPlan
 ├── precision.py              # 精度开关表
+├── sharding_shrink.py        # sharding 缩容的补偿开关
 ├── strategies.py             # scale_batch / scale_accumulation
 ├── topology.py               # C1..C4 通信组约束
 ├── constraints.py            # E/M 族约束 + 候选枚举 + 层对齐

--- a/src/paddlefleet/config_adapter/__init__.py
+++ b/src/paddlefleet/config_adapter/__init__.py
@@ -17,7 +17,9 @@
 Without any switch the adapter simply makes the config fit the target scale:
 it recomputes ``sharding`` / batch and, when the target is incompatible with
 the source parallelism, shrinks EP / PP (never below 2) and rewrites a copy of
-``model_config.json`` accordingly.
+``model_config.json`` accordingly.  A smaller ``sharding`` also gets the
+compensations in :mod:`paddlefleet.config_adapter.sharding_shrink` (data-stream
+width, optimizer offload).
 
 Two orthogonal, optional test dimensions refine that:
 
@@ -42,9 +44,16 @@ from .options import AdaptOptions
 from .plan import ParallelismPlan
 from .planner import ShrinkPlanner, plan_frozen, plan_parallelism
 from .precision import PRECISION_SWITCHES, plan_precision_switches
+from .sharding_shrink import (
+    DEFAULT_SHRINK_FACTOR,
+    OFFLOAD_PREREQUISITES,
+    plan_sharding_shrink_switches,
+)
 from .topology import TopologyValidator
 
 __all__ = [
+    "DEFAULT_SHRINK_FACTOR",
+    "OFFLOAD_PREREQUISITES",
     "PRECISION_SWITCHES",
     "AdaptOptions",
     "ConfigAdapter",
@@ -58,4 +67,5 @@ __all__ = [
     "plan_frozen",
     "plan_parallelism",
     "plan_precision_switches",
+    "plan_sharding_shrink_switches",
 ]

--- a/src/paddlefleet/config_adapter/constraints.py
+++ b/src/paddlefleet/config_adapter/constraints.py
@@ -24,7 +24,9 @@ Shrinking EP / PP additionally requires:
 Hard rule shared by every candidate generator: **a parallel degree that is
 greater than 1 in the source config is never collapsed to 1.** Dropping a
 dimension entirely (EP 8 -> 1) removes the communication group under test,
-so the smallest legal shrink target is :data:`MIN_PARALLEL_DEGREE`.
+so the smallest legal shrink target is :data:`MIN_PARALLEL_DEGREE`.  VPP is
+the one exception, because the framework refuses to interleave fewer than
+:data:`MIN_PP_FOR_VPP` stages.
 
 All functions here are pure: no I/O, no mutation of the arguments.
 """
@@ -37,6 +39,16 @@ DEFAULT_MIN_HIDDEN_LAYERS = 4
 
 #: A source degree > 1 may shrink no further than this.
 MIN_PARALLEL_DEGREE = 2
+
+#: Pipeline stages required before ``virtual_pipeline_model_parallel_size``
+#: may exceed 1.
+#:
+#: Every interleaved schedule asserts ``num_stages > 2`` ("virtual pipeline
+#: must run under pp degree > 2") while it is being built, so a PP <= 2 config
+#: with VPP > 1 dies at startup instead of falling back to a plain 1F1B
+#: schedule.  Being a hard framework assert, this outranks the no-collapse
+#: rule: VPP does go to 1 when PP has to shrink that far.
+MIN_PP_FOR_VPP = 3
 
 
 def divisors(n):
@@ -102,23 +114,45 @@ def pp_candidates(pp_orig):
     )
 
 
-def align_layers(layers_new, head, tail_orig, pp_new, vpp_orig):
+def align_layers(layers_new, head, pp_new, vpp_orig, min_tail=0):
     """Align pipeline layers to ``pp_new * vpp_new`` with empty tail layers.
 
-    Returns ``(vpp_new, tail_new)``, or ``(None, None)`` when no divisor of
-    ``vpp_orig`` can be aligned.  ``pp_new`` is always >= 2 here because a
-    source PP > 1 never collapses to 1.
+    The framework segments ``head + layers_new + tail_new`` layers into
+    ``pp_new * vpp_new`` virtual stages, so that total must be a multiple of
+    the product.  Empty tail layers exist *only* to make that division work,
+    so ``tail_new`` is recomputed from scratch -- the source value is not a
+    floor, otherwise a shrunk 10-layer model would keep the padding of the
+    43-layer original.  ``min_tail`` is the smallest tail the framework
+    tolerates (1 when it silently consumes one tail layer for MTP).
+
+    Among the divisors of ``vpp_orig`` the one needing the least padding
+    wins, ties going to the largest VPP (closest to the source).  A source
+    ``vpp_orig > 1`` never collapses to 1, same no-collapse rule as the other
+    degrees -- except below :data:`MIN_PP_FOR_VPP` stages, where the framework
+    assert leaves 1 as the only legal VPP.  Returns ``(vpp_new, tail_new)``,
+    or ``(None, None)`` when ``pp_new`` is below the floor.
     """
     if pp_new < MIN_PARALLEL_DEGREE:
         return None, None
     if vpp_orig is None or vpp_orig < 1:
         vpp_orig = 1
-    for vpp_new in sorted(divisors(vpp_orig), reverse=True):
+    floor = shrink_floor(vpp_orig)
+    candidates = [
+        vpp_new
+        for vpp_new in sorted(divisors(vpp_orig), reverse=True)
+        if vpp_new >= floor
+    ]
+    if pp_new < MIN_PP_FOR_VPP:
+        candidates = [1]
+    best = None
+    for vpp_new in candidates:
         divisor = pp_new * vpp_new
-        pad = (-(layers_new + head + tail_orig)) % divisor
-        if pad < divisor:
-            return vpp_new, tail_orig + pad
-    return None, None
+        pad = (-(layers_new + head + min_tail)) % divisor
+        if best is None or min_tail + pad < best[1]:
+            best = (vpp_new, min_tail + pad)
+    if best is None:
+        return None, None
+    return best
 
 
 def min_shrink_cards(tp, pp, ep, cp, sep, cards_per_node):
@@ -220,12 +254,15 @@ def check_pp_shrink(
     vpp,
     first_k_dense_replace=0,
     min_hidden_layers=DEFAULT_MIN_HIDDEN_LAYERS,
+    min_tail=0,
 ):
     """M3 + M4 + M5 for one ``pp_new``.
 
     Returns ``(ok, reason, meta)`` where ``meta`` carries ``layers_new``,
     ``vpp_new``, ``tail_new`` and an optional soft ``warning``.  M4 is a
     warning rather than a rejection; the hard floor is one hidden layer.
+    ``tail`` is only the source value reported back when nothing shrinks;
+    the padding actually needed is recomputed from ``min_tail``.
     """
     if pp_new >= pp_orig:
         return (
@@ -266,12 +303,14 @@ def check_pp_shrink(
         )
 
     # M3: layer alignment feasibility.
-    vpp_new, tail_new = align_layers(layers_new, head, tail, pp_new, vpp)
+    vpp_new, tail_new = align_layers(
+        layers_new, head, pp_new, vpp, min_tail=min_tail
+    )
     if vpp_new is None:
         return (
             False,
             f"M3 不满足：(layers_new={layers_new} + head={head} + "
-            f"tail>={tail}) 无法对齐到 pp_new={pp_new} × vpp_new",
+            f"tail>={min_tail}) 无法对齐到 pp_new={pp_new} × vpp_new",
             meta,
         )
 

--- a/src/paddlefleet/config_adapter/core.py
+++ b/src/paddlefleet/config_adapter/core.py
@@ -28,7 +28,8 @@
       -> write model_config.json when it changed, and point
          model_name_or_path at it
       -> apply the plan's YAML writes and re-validate C1..C4
-      -> scale the batch settings, sharding and data_parallel_size
+      -> scale the batch settings, sharding and data_parallel_size, and add
+         the switches that compensate for a smaller sharding degree
       -> write the YAML and render the report
 
 Every write goes through the change log, so the report can attribute each
@@ -49,6 +50,7 @@ from .model_config_resolver import (
 from .planner import plan_parallelism
 from .precision import plan_precision_switches
 from .report import ChangeLog, format_header, format_report
+from .sharding_shrink import plan_sharding_shrink_switches
 from .strategies import BATCH_STRATEGIES
 from .topology import TopologyValidator
 from .utils import PARALLEL_FIELDS, extract_parallel_params
@@ -234,7 +236,7 @@ class ConfigAdapter:
             plan.warnings.append(scale_warning)
 
         err = self._scale_batch_and_sharding(
-            config, log, scale_source, orig_cards, dims_after
+            config, log, scale_source, orig_cards, dims_before, dims_after
         )
         if err:
             return False, f"{input_path.name}: {err}"
@@ -489,7 +491,7 @@ class ConfigAdapter:
         return None, None, None
 
     def _scale_batch_and_sharding(
-        self, config, log, scale_source, orig_cards, dims_after
+        self, config, log, scale_source, orig_cards, dims_before, dims_after
     ):
         """Rewrite batch / sharding / data_parallel_size. Returns an error."""
         gbs = scale_source["global_batch_size"]
@@ -548,7 +550,53 @@ class ConfigAdapter:
                 "Fleet 要求纯 sharding 数据并行：data_parallel_size 固定为 1，"
                 "数据并行度由 sharding 承担",
             )
+
+        # C4 was validated above, so both divisions are exact.
+        switches = plan_sharding_shrink_switches(
+            config,
+            self._dataset_ways(orig_cards, dims_before),
+            new_sharding // cp,
+            overrides=self.yaml_overrides,
+            base_ways=self._dense_sharding_ways(dims_before),
+        )
+        for key, value, reason in switches:
+            log.record(
+                "yaml",
+                self.yaml_writer.apply_config_map(
+                    config, {key: value}, protected=self.yaml_overrides
+                ),
+                reason,
+            )
         return None
+
+    @staticmethod
+    def _dataset_ways(cards, dims):
+        """``dataset_world_size`` for a scale: ``cards / (TP*SEP*PP*CP)``.
+
+        ``None`` when the card count is unknown or does not divide evenly (a
+        source YAML whose declared degrees and batch fields disagree).
+        """
+        if not cards:
+            return None
+        tp, pp, _ep, cp, sep = dims
+        divisor = tp * sep * pp * cp
+        if divisor <= 0 or cards % divisor != 0:
+            return None
+        return cards // divisor
+
+    @staticmethod
+    def _dense_sharding_ways(dims):
+        """``dense_sharding`` for a set of degrees: ``EP / (TP * SEP)``.
+
+        C3 makes that ratio exact, and it depends on the degrees alone, so it
+        survives degrees the target card count could not actually run.  Without
+        expert parallel there is no such ratio and ``None`` is returned.
+        """
+        tp, _pp, ep, _cp, sep = dims
+        divisor = tp * sep
+        if ep <= 1 or divisor <= 0 or ep % divisor != 0:
+            return None
+        return ep // divisor
 
     # ---------------------------------------------------------------- report
     def _build_info(

--- a/src/paddlefleet/config_adapter/io_writers.py
+++ b/src/paddlefleet/config_adapter/io_writers.py
@@ -32,6 +32,10 @@ import os
 from pathlib import Path
 
 from ruamel.yaml import YAML
+from ruamel.yaml.comments import CommentedMap, CommentedSeq
+
+#: Fallback nested-mapping indent, and ruamel's own default.
+DEFAULT_MAP_INDENT = 2
 
 
 def make_yaml():
@@ -40,6 +44,39 @@ def make_yaml():
     yaml.preserve_quotes = True
     yaml.width = 4096
     return yaml
+
+
+def detect_map_indent(document, default=DEFAULT_MAP_INDENT):
+    """Nested-mapping indent step ``document`` uses most, ``default`` if none.
+
+    ruamel indents on dump from one global setting, not per node, so a
+    round-trip rewrites every nested block to whatever width we pick -- a
+    4-space ``muon_configs`` block comes back as 2 and shows up as a dozen
+    spurious lines in the diff.  Reading the width back off the parsed source
+    (``lc.col`` is the column each collection started at) keeps the rewritten
+    file's diff limited to the fields that actually changed.  Steps are
+    weighted by how many keys they cover, so the dominant style wins when a
+    file mixes them.
+    """
+    steps = {}
+
+    def visit(node):
+        if isinstance(node, CommentedMap):
+            for value in node.values():
+                if isinstance(value, CommentedMap) and len(value):
+                    step = value.lc.col - node.lc.col
+                    if step > 0:
+                        steps[step] = steps.get(step, 0) + len(value)
+                visit(value)
+        elif isinstance(node, CommentedSeq):
+            for item in node:
+                visit(item)
+
+    visit(document)
+    if not steps:
+        return default
+    # Most keys first, then the narrower step, so ties stay deterministic.
+    return max(steps, key=lambda step: (steps[step], -step))
 
 
 def _apply(document, config_map, protected=None):
@@ -83,9 +120,14 @@ class YamlWriter:
         self.yaml = yaml or make_yaml()
 
     def load(self, path):
-        """Load the YAML document (``None`` for an empty file)."""
+        """Load the YAML document (``None`` for an empty file).
+
+        Also aligns the dump indentation with the source's own style.
+        """
         with open(path, encoding="utf-8") as f:
-            return self.yaml.load(f)
+            document = self.yaml.load(f)
+        self.yaml.indent(mapping=detect_map_indent(document))
+        return document
 
     def apply_config_map(self, config, config_map, protected=None):
         """Merge a flat map into ``config``; see the module docstring."""

--- a/src/paddlefleet/config_adapter/layer_fields.py
+++ b/src/paddlefleet/config_adapter/layer_fields.py
@@ -25,7 +25,10 @@ Shrinking PP shrinks ``num_hidden_layers``, and every per-layer list in
 The rewrite keeps the first ``layers_new`` entries -- so the dense prefix
 (``first_k_dense_replace``) and the leading attention pattern survive -- and
 re-appends the trailing MTP entries verbatim for the fields whose length counts
-them.
+them.  ``csa_compress_ratios`` then gets one extra fix: with
+``mtp_shared_last_layer`` the MTP layer aliases the last decoder layer's
+attention weights, so the truncated tail is forced back to the MTP layer's own
+attention type (see :func:`_shares_mtp_attention`).
 
 Truncation is refused, rather than silently producing an unusable config, when
 
@@ -83,6 +86,22 @@ def _csa_family(ratio):
     return "CSA(2..127)"
 
 
+def _shares_mtp_attention(model_config, mtp_layers):
+    """Whether the MTP layer aliases the last decoder layer's attention.
+
+    ``GPTModel.get_sequential_layers`` wraps both the backbone's last
+    transformer layer and every MTP layer in
+    ``SharedLayerDesc("mtp_reuse_transformer", ...,
+    shared_weight_attr="transformer_layer_weights")`` once
+    ``mtp_shared_last_layer`` is set and MTP is present.  Paddle then
+    broadcasts that parameter list across the two pipeline stages attribute by
+    attribute, so the two layers must be the same kind of attention: MLA and
+    HCA/CSA expose different parameters, and the mismatched broadcast hangs the
+    job instead of raising.
+    """
+    return bool(model_config.get("mtp_shared_last_layer")) and mtp_layers > 0
+
+
 def plan_layer_field_shrink(model_config, layers_old, layers_new, mtp_layers):
     """Plan the per-layer list rewrites implied by a layer-count shrink.
 
@@ -94,6 +113,8 @@ def plan_layer_field_shrink(model_config, layers_old, layers_new, mtp_layers):
     changes = []
     if model_config is None or layers_new >= layers_old:
         return changes, None
+
+    shares_mtp = _shares_mtp_attention(model_config, mtp_layers)
 
     for field in LAYER_FIELDS:
         key = next((a for a in field.aliases if a in model_config), None)
@@ -116,8 +137,17 @@ def plan_layer_field_shrink(model_config, layers_old, layers_new, mtp_layers):
 
         layer_part, mtp_part = value[:layers_old], value[layers_old:]
         kept = layer_part[:layers_new]
+        extra = ""
 
         if field.families:
+            if shares_mtp and kept and mtp_part and kept[-1] != mtp_part[0]:
+                extra = (
+                    f"；并把末层的 {kept[-1]} 改成 MTP 层的 {mtp_part[0]}"
+                    f"（mtp_shared_last_layer 让末层与 MTP 层共享 attention "
+                    f"权重，两者注意力类型必须一致，"
+                    f"否则共享权重跨 stage broadcast 时几何不匹配、训练挂死）"
+                )
+                kept = [*kept[:-1], mtp_part[0]]
             lost = {_csa_family(r) for r in layer_part} - {
                 _csa_family(r) for r in kept
             }
@@ -135,7 +165,8 @@ def plan_layer_field_shrink(model_config, layers_old, layers_new, mtp_layers):
                 f"逐层配置随层数 {layers_old} -> {layers_new} 裁剪："
                 f"保留前 {layers_new} 层"
                 + (f" + 末尾 {len(mtp_part)} 个 MTP 层" if mtp_part else "")
-                + f"，长度 {len(value)} -> {len(kept + mtp_part)}",
+                + f"，长度 {len(value)} -> {len(kept + mtp_part)}"
+                + extra,
             )
         )
 

--- a/src/paddlefleet/config_adapter/model_config_resolver.py
+++ b/src/paddlefleet/config_adapter/model_config_resolver.py
@@ -48,7 +48,7 @@ def resolve_model_config(model_name_or_path, yaml_dir):
     if not model_name_or_path:
         raise ModelConfigResolveError(
             "YAML 里没有 model_name_or_path，无法定位 model_config.json；"
-            "精度模式需要它来缩减模型结构"
+            "缩减模型结构（专家数 / 层数）需要它"
         )
 
     yaml_dir = Path(yaml_dir)

--- a/src/paddlefleet/config_adapter/planner.py
+++ b/src/paddlefleet/config_adapter/planner.py
@@ -30,9 +30,15 @@
   ``num_hidden_layers`` and realigns VPP / empty tail layers -- those writes
   land in a *separate* copy of ``model_config.json``, never in the source.
 
+  Within a tier the rule is "shrink as little as possible", except for the
+  joint tier, where the two axes follow the shrink priority ``EP > PP``: EP
+  goes down to its floor first and PP absorbs only the remainder.
+
 TP and SEP are never shrunk: a smaller TP raises per-card memory and risks
 OOM.  No dimension that is > 1 in the source is ever reduced to 1, because
-that would delete the communication group under test.
+that would delete the communication group under test.  VPP is the exception:
+whichever planner ran, :func:`enforce_vpp_limit` switches it off when the
+final PP is too small for an interleaved schedule.
 """
 
 from __future__ import annotations
@@ -41,6 +47,7 @@ import re
 
 from .constraints import (
     MIN_PARALLEL_DEGREE,
+    MIN_PP_FOR_VPP,
     check_ep_shrink,
     check_hardware,
     check_pp_shrink,
@@ -57,16 +64,52 @@ from .topology import TopologyValidator
 # can put the more actionable model-structure reasons first.
 _CONSTRAINT_RE = re.compile(r"C[1-4]\s*不满足")
 
+VPP_FIELD = "virtual_pipeline_model_parallel_size"
+
+
+def _vpp_off_reason(vpp_old, pp):
+    """Why VPP must be 1 at this PP."""
+    return (
+        f"PP={pp} 时不能开虚拟流水：框架断言 VPP>1 需要 PP>"
+        f"{MIN_PP_FOR_VPP - 1}"
+        f"（virtual pipeline must run under pp degree > 2），"
+        f"VPP {vpp_old} -> 1"
+    )
+
 
 def plan_parallelism(
     config, dims, target_cards, cards_per_node, options, context=None
 ):
     """Plan the final parallel dims. Returns ``(plan, error_or_None)``."""
     if options.freeze_parallel:
-        return plan_frozen(dims, target_cards, cards_per_node)
-    return ShrinkPlanner().plan(
-        config, dims, target_cards, cards_per_node, context
-    )
+        plan, err = plan_frozen(dims, target_cards, cards_per_node)
+    else:
+        plan, err = ShrinkPlanner().plan(
+            config, dims, target_cards, cards_per_node, context
+        )
+    if err:
+        return None, err
+    enforce_vpp_limit(config, plan)
+    return plan, None
+
+
+def enforce_vpp_limit(config, plan):
+    """Turn VPP off when the planned PP cannot run an interleaved schedule.
+
+    :data:`~.constraints.MIN_PP_FOR_VPP` is a hard framework assert, and the
+    PP-shrink planner already respects it, which leaves the plans that never
+    touch PP -- a frozen plan, an EP-only shrink, a source that already fits
+    the target -- carrying whatever VPP the source declared.  Dropping it to 1
+    cannot break the layer alignment: the number of segments goes from
+    ``PP * VPP`` down to ``PP``, which divides it.
+    """
+    if plan.pp >= MIN_PP_FOR_VPP:
+        return
+    planned = {key: value for key, value, _reason in plan.yaml_changes}
+    vpp = planned.get(VPP_FIELD, config.get(VPP_FIELD, 1) or 1)
+    if int(vpp) <= 1:
+        return
+    plan.yaml_changes.append((VPP_FIELD, 1, _vpp_off_reason(vpp, plan.pp)))
 
 
 def plan_frozen(dims, target_cards, cards_per_node):
@@ -253,7 +296,7 @@ class ShrinkPlanner:
     def _pipeline_layout(config, resolved, missing, model_config):
         """Collect everything PP shrinking needs. ``(layout, error)``."""
         if "num_hidden_layers" in missing:
-            return None, "精度模式：" + describe_missing(
+            return None, describe_missing(
                 "num_hidden_layers", missing["num_hidden_layers"]
             )
 
@@ -265,18 +308,30 @@ class ShrinkPlanner:
         # alias: mtp_num_layers wins when non-zero.
         mtp = effective_mtp_layers(model_config)
 
-        # MTP layers only take part in the stage division when
-        # separate_mtp_headloss is on; otherwise they are weight-0 free
-        # passengers pinned to the last stage.
+        # What the framework actually segments (gpt_builders.build_gpt_model
+        # + GPTModel.get_sequential_layers) is
+        #     head_empty + num_hidden_layers + mtp + tail_empty
+        # and the MTP layers only join that count when
+        # separate_mtp_headloss puts MultiTokenPredictionLayer into
+        # seg_method.  In that case the builder also drops exactly one tail
+        # empty layer to make room for them
+        # (``num_empty_layers_add_in_tail -= 1``), so the yaml tail must stay
+        # >= 1 and contributes ``tail - 1`` segmented layers.  Net effect on
+        # the total: ``mtp - 1``, which is zero for the usual single MTP
+        # layer -- adding the full ``mtp`` here would overshoot by one and
+        # produce a config that dies in do_segment().
         head = int(config.get("num_empty_layers_add_in_head", 0) or 0)
+        min_tail = 0
         if config.get("separate_mtp_headloss"):
-            head += mtp
+            head += mtp - 1
+            min_tail = 1
 
         return {
             "layers": value_of("num_hidden_layers"),
             "layers_key": resolved["num_hidden_layers"].writeback_key,
             "head": head,
             "tail": int(config.get("num_empty_layers_add_in_tail", 0) or 0),
+            "min_tail": min_tail,
             "vpp": int(
                 config.get("virtual_pipeline_model_parallel_size", 1) or 1
             ),
@@ -298,20 +353,20 @@ class ShrinkPlanner:
             )
         ]
         if meta["vpp_new"] != layout["vpp"]:
-            yaml_changes.append(
-                (
-                    "virtual_pipeline_model_parallel_size",
-                    meta["vpp_new"],
+            if meta["vpp_new"] == 1 and pp_new < MIN_PP_FOR_VPP:
+                reason = _vpp_off_reason(layout["vpp"], pp_new)
+            else:
+                reason = (
                     f"PP 缩容后重新对齐 VPP "
-                    f"{layout['vpp']} -> {meta['vpp_new']}",
+                    f"{layout['vpp']} -> {meta['vpp_new']}"
                 )
-            )
+            yaml_changes.append((VPP_FIELD, meta["vpp_new"], reason))
         if meta["tail_new"] != layout["tail"]:
             yaml_changes.append(
                 (
                     "num_empty_layers_add_in_tail",
                     meta["tail_new"],
-                    f"补空层把总层数对齐到 PP×VPP："
+                    f"调整尾部空层把总层数对齐到 PP×VPP："
                     f"{layout['tail']} -> {meta['tail_new']}",
                 )
             )
@@ -357,6 +412,7 @@ class ShrinkPlanner:
                 layout["tail"],
                 layout["vpp"],
                 first_k_dense_replace=layout["first_k"],
+                min_tail=layout["min_tail"],
             )
             if not ok:
                 rejections.append(f"PP {pp} -> {pp_new}：{why}")
@@ -414,6 +470,14 @@ class ShrinkPlanner:
         Reached only when neither single-axis shrink survives -- e.g. a source
         ``(pp=8, ep=8)`` targeting 8 cards, where any one-dimension shrink
         still overshoots the card count.
+
+        The two axes are not interchangeable, so they follow the shrink
+        priority ``EP > PP``: EP absorbs the reduction down to its floor and PP
+        is only shrunk for whatever is left over.  Shrinking EP costs routed
+        experts and nothing else, while shrinking PP scales
+        ``num_hidden_layers`` -- and with it every per-layer list, the VPP
+        degree and the empty tail -- so a shallower pipeline cut is worth a
+        deeper expert cut.
         """
         tp, pp, ep, cp, sep = dims
         num_experts, topk, experts_key = moe
@@ -434,6 +498,7 @@ class ShrinkPlanner:
                     layout["tail"],
                     layout["vpp"],
                     first_k_dense_replace=layout["first_k"],
+                    min_tail=layout["min_tail"],
                 )
                 if not ok:
                     continue
@@ -458,10 +523,10 @@ class ShrinkPlanner:
         if not pool:
             return None
 
-        # Prefer the largest EP first, then the largest PP: one unit of EP
-        # change is less intrusive on the model structure than one of PP.
-        ep_new, pp_new, experts_new, meta, layer_changes = max(
-            pool, key=lambda item: (item[0], item[1])
+        # Shrink priority EP > PP: smallest feasible EP first, then the
+        # largest PP that still fits under it.
+        ep_new, pp_new, experts_new, meta, layer_changes = min(
+            pool, key=lambda item: (item[0], -item[1])
         )
         yaml_changes, json_changes = self._pp_changes(
             pp,
@@ -478,7 +543,9 @@ class ShrinkPlanner:
                 "expert_model_parallel_size",
                 ep_new,
                 f"缩小 EP {ep} -> {ep_new}：单独缩 EP 或单独缩 PP 都无法"
-                f"适配 {target_cards} 卡，改为联合缩容",
+                f"适配 {target_cards} 卡，改为联合缩容；按 EP 优先于 PP 的"
+                f"缩容顺序，先把 EP 压到可行下限，再尽量少缩 PP"
+                f"（缩 PP 会连带改层数/VPP/尾部空层/逐层配置）",
             ),
         )
         json_changes.insert(
@@ -574,7 +641,7 @@ class ShrinkPlanner:
                 "必须先修改 TP/SEP/EP/CP"
             )
             return (
-                f"精度模式：{target_cards} 卡下找不到合法的 EP/PP 缩容方案 "
+                f"{target_cards} 卡下找不到合法的 EP/PP 缩容方案 "
                 f"(tp={tp}, pp={pp}, ep={ep}, cp={cp}, sep={sep})。\n"
                 f"  阻断原因：\n    "
                 + "\n    ".join(reasons)
@@ -595,7 +662,7 @@ class ShrinkPlanner:
                 f"整除的值>），或手动降低源 YAML 的 TP/PP/EP 后重试"
             )
         return (
-            f"精度模式：{target_cards} 卡下找不到合法的 EP/PP 缩容方案 "
+            f"{target_cards} 卡下找不到合法的 EP/PP 缩容方案 "
             f"(tp={tp}, pp={pp}, ep={ep}, cp={cp}, sep={sep})。\n"
             f"  阻断原因：\n    " + "\n    ".join(reasons) + detail_block + "\n"
             "  建议：" + advice

--- a/src/paddlefleet/config_adapter/report.py
+++ b/src/paddlefleet/config_adapter/report.py
@@ -26,10 +26,17 @@ shape::
 with the reason on the following indented line, and the machine-readable
 summary (``ORIGINAL_CARDS=`` / ``TARGET_CARDS=`` / ``OUTPUT=``) at the very
 end for upstream scripts.
+
+The reasons are full sentences and the values can be whole per-layer lists, so
+everything is wrapped to :data:`LINE_WIDTH` with a hanging indent and the
+report is split into ruled sections -- an unwrapped report turns into a wall of
+text the moment a terminal folds those lines.  Wrapping is done here rather
+than with :mod:`textwrap` because Chinese prose has no spaces to break on.
 """
 
 from __future__ import annotations
 
+import unicodedata
 from collections import namedtuple
 from datetime import date
 
@@ -37,8 +44,74 @@ Change = namedtuple(
     "Change", ["target", "kind", "field", "old", "new", "reason"]
 )
 
+#: Console width the report wraps to.
+LINE_WIDTH = 88
+
 _KIND_LABEL = {"modified": "CHANGE", "added": "ADD", "removed": "DELETE"}
 _TARGET_LABEL = {"yaml": "YAML", "json": "model_config.json"}
+_WIDE = frozenset("WF")
+
+
+def _width(text):
+    """Terminal columns ``text`` occupies: CJK glyphs take two."""
+    return sum(
+        2 if unicodedata.east_asian_width(ch) in _WIDE else 1 for ch in text
+    )
+
+
+def _chunks(text):
+    """Split ``text`` into unbreakable pieces.
+
+    A CJK glyph and a space are each their own chunk, so a line may break
+    between them; a run of narrow characters (an identifier, a number, a path)
+    stays in one piece.
+    """
+    pieces, word = [], ""
+    for ch in text:
+        if ch == " " or unicodedata.east_asian_width(ch) in _WIDE:
+            if word:
+                pieces.append(word)
+                word = ""
+            pieces.append(ch)
+        else:
+            word += ch
+    if word:
+        pieces.append(word)
+    return pieces
+
+
+def _wrap(text, first_prefix="", cont_prefix=None):
+    """``text`` as prefixed lines no wider than :data:`LINE_WIDTH`.
+
+    Continuation lines get ``cont_prefix`` (spaces as wide as ``first_prefix``
+    by default), which keeps a wrapped reason visually attached to its field.
+    """
+    if cont_prefix is None:
+        cont_prefix = " " * _width(first_prefix)
+    lines, prefix = [], first_prefix
+    limit = LINE_WIDTH - _width(prefix)
+    line, used = "", 0
+    for chunk in _chunks(text):
+        size = _width(chunk)
+        if line and used + size > limit:
+            lines.append((prefix + line).rstrip())
+            prefix = cont_prefix
+            limit = LINE_WIDTH - _width(prefix)
+            line, used = "", 0
+            if chunk == " ":
+                continue
+        line += chunk
+        used += size
+    lines.append((prefix + line).rstrip())
+    return lines
+
+
+def _rule(title=None):
+    """A full-width ``-`` rule, optionally naming the section it opens."""
+    if title is None:
+        return "-" * LINE_WIDTH
+    lead = f"--- {title} "
+    return lead + "-" * max(LINE_WIDTH - _width(lead), 3)
 
 
 class ChangeLog:
@@ -86,58 +159,83 @@ def format_header(info):
     return "\n".join(lines) + "\n\n"
 
 
+def _format_change(item):
+    """One change as its ``CHANGE``/``ADD``/``DELETE`` line plus reason."""
+    kind = _KIND_LABEL[item.kind]
+    values = []
+    if item.kind != "added":
+        values.append(f"old={item.old!r}")
+    if item.kind != "removed":
+        values.append(f"new={item.new!r}")
+    head = f"  {kind} field={item.field} " + " ".join(values)
+    if _width(head) <= LINE_WIDTH:
+        lines = [head]
+    else:
+        # A per-layer list does not fit next to its field name.
+        lines = [f"  {kind} field={item.field}"]
+        for value in values:
+            lines += _wrap(value, "      ", "          ")
+    return lines + _wrap(item.reason, "      原因：", " " * 12)
+
+
 def _format_changes(changes, target, destination):
     """Render one document's change block."""
     label = _TARGET_LABEL[target]
     if not changes:
-        return [f"{label} 改动：无"]
+        return [_rule(f"{label} 改动：无")]
 
-    lines = [f"{label} 改动（{len(changes)} 项）-> {destination}"]
+    lines = [
+        _rule(f"{label} 改动（{len(changes)} 项）"),
+        f"写入      ：{destination}",
+    ]
     for item in changes:
-        kind = _KIND_LABEL[item.kind]
-        if item.kind == "modified":
-            head = (
-                f"  {kind} field={item.field} old={item.old!r} new={item.new!r}"
-            )
-        elif item.kind == "added":
-            head = f"  {kind} field={item.field} new={item.new!r}"
-        else:
-            head = f"  {kind} field={item.field} old={item.old!r}"
-        lines.append(head)
-        lines.append(f"      原因：{item.reason}")
+        lines.append("")
+        lines += _format_change(item)
     return lines
 
 
 def format_report(info, changelog):
     """Render the full console report for a successful adaptation."""
-    lines = [
-        "===== config_adapter: 适配成功 =====",
-        f"输入      ：{info['input']}",
-        f"模式      ：{info['profile']}（{info['profile_flag']}），"
-        f"batch 策略 {info['batch_strategy']}",
-        f"机器规模  ：{info['orig_scale_label']} -> "
-        f"{info['target_nodes']} 节点 / {info['target_cards']} 卡"
-        f"（每节点 {info['cards_per_node']} 卡）",
-        f"并行度    ：{info['dims_line']}",
-        f"sharding  ：{info['sharding_line']}",
-        f"缩容方案  ：{info['plan_note']}",
-    ]
+    lines = ["=" * LINE_WIDTH, "config_adapter: 适配成功", "=" * LINE_WIDTH]
+    for label, value in (
+        ("输入      ", info["input"]),
+        (
+            "模式      ",
+            f"{info['profile']}（{info['profile_flag']}），"
+            f"batch 策略 {info['batch_strategy']}",
+        ),
+        (
+            "机器规模  ",
+            f"{info['orig_scale_label']} -> {info['target_nodes']} 节点 / "
+            f"{info['target_cards']} 卡（每节点 {info['cards_per_node']} 卡）",
+        ),
+        ("并行度    ", info["dims_line"]),
+        ("sharding  ", info["sharding_line"]),
+        ("缩容方案  ", info["plan_note"]),
+    ):
+        lines += _wrap(str(value), f"{label}：")
 
+    lines.append("")
     lines += _format_changes(
         changelog.by_target("yaml"), "yaml", info["output"]
     )
     if info.get("model_config_output"):
+        lines.append("")
         lines += _format_changes(
             changelog.by_target("json"),
             "json",
             info["model_config_output"],
         )
 
-    for note in info.get("skipped_switches") or []:
-        lines.append(f"跳过的精度开关：{note}")
-    for warning in info.get("warnings") or []:
-        lines.append(f"WARNING：{warning}")
+    notes = [
+        f"跳过的精度开关：{note}" for note in info.get("skipped_switches") or []
+    ] + [f"WARNING：{warning}" for warning in info.get("warnings") or []]
+    if notes:
+        lines += ["", _rule("提醒")]
+        for note in notes:
+            lines += _wrap(note)
 
+    lines += ["", _rule("机器可读摘要")]
     lines.append(f"ORIGINAL_CARDS={info['orig_cards_label']}")
     lines.append(f"ORIGINAL_NODES={info['orig_nodes_label']}")
     lines.append(f"TARGET_CARDS={info['target_cards']}")

--- a/src/paddlefleet/config_adapter/sharding_shrink.py
+++ b/src/paddlefleet/config_adapter/sharding_shrink.py
@@ -1,0 +1,164 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Switches that compensate for a smaller sharding degree.
+
+Fewer cards means a smaller ``sharding``, and two things get worse in
+proportion to the shrink factor:
+
+* the data stream is split into ``dataset_world_size = sharding / CP`` shards,
+  so each rank has to walk a proportionally longer slice of a production file
+  list before the first step;
+* optimizer states are sharded over the same degree, so per-card optimizer
+  memory grows by exactly that factor and a config that fits at full scale can
+  OOM on one node.
+
+The training entry point already understands a switch for each:
+``debug_reeao_dataset_world_size`` overrides the shard count used for *data
+loading only* (the rank stays the real one, so ranks still read distinct
+slices), and ``tensorwise_offload_optimizer`` keeps the optimizer states in
+host memory.
+
+The offload switch drags in prerequisites, each enforced by a hard framework
+error, hence :data:`OFFLOAD_PREREQUISITES`: offload conflicts with
+``fuse_optimizer_states``, zero-cost checkpointing requires that same fused
+storage, and flash-device saving requires zero-cost checkpointing.  Only the
+keys the source actually declares with a conflicting value are rewritten -- the
+framework defaults (``false`` / ``0``) are already compatible, and a ``--set``
+that turns offload off skips the cascade entirely.
+
+A production YAML often hides its own scale (``global_batch_size`` commented
+out, no ``sharding_parallel_size``), and both switches still matter there, so an
+underivable source width is assumed to be :data:`DEFAULT_SHRINK_FACTOR` times
+the source's own ``dense_sharding`` -- the cards that actually load data --
+rather than nothing at all.
+
+All functions here are pure: nothing is written, the caller decides.
+"""
+
+from __future__ import annotations
+
+OFFLOAD_KEY = "tensorwise_offload_optimizer"
+
+#: Assumed source/target scale ratio when the source scale is unknown.
+#:
+#: A production YAML often comments ``global_batch_size`` out and declares no
+#: ``sharding_parallel_size``, so the source card count cannot be derived.  The
+#: source is then assumed to have run this many times its own ``dense_sharding``
+#: (``EP / (TP * SEP)``, the width that actually loads data): that ratio comes
+#: from the source's *own* degrees, so EP/PP shrinking cannot deflate it.
+DEFAULT_SHRINK_FACTOR = 96
+
+#: ``(key, value_required_by_offload, why)`` in cascade order.
+OFFLOAD_PREREQUISITES = (
+    (
+        "fuse_optimizer_states",
+        False,
+        "offload 每步把优化器状态搬到 host，fuse 会发现状态不再与 GPU 上的 "
+        "fused buffer 共享存储，于是每步重建整块 buffer，显存反而更高，"
+        "框架直接报错",
+    ),
+    (
+        "enable_zero_cost_checkpoint",
+        False,
+        "zero-cost checkpoint 断言 fuse_optimizer_states=true，"
+        "而它已被 offload 关闭",
+    ),
+    (
+        "flash_device_save_steps",
+        0,
+        "flash_device_save_steps>0 断言 enable_zero_cost_checkpoint=true，"
+        "而它已被关闭",
+    ),
+)
+
+
+def _format_factor(orig_ways, new_ways):
+    """``orig_ways / new_ways`` as text: exact ratios stay integers.
+
+    Integer division would round 96 / 64 down to ``1`` and claim the shrink
+    changed nothing, so inexact ratios keep one decimal.
+    """
+    if orig_ways % new_ways == 0:
+        return str(orig_ways // new_ways)
+    return f"{orig_ways / new_ways:.1f}"
+
+
+def plan_sharding_shrink_switches(
+    config, orig_ways, new_ways, overrides=None, base_ways=None
+):
+    """Decide the switches a sharding shrink needs.
+
+    ``orig_ways`` / ``new_ways`` are the source and target
+    ``dataset_world_size``; a falsy ``orig_ways`` means the source scale could
+    not be derived, so :data:`DEFAULT_SHRINK_FACTOR` times ``base_ways`` is
+    assumed instead and the reason text says so.  ``base_ways`` is the source's
+    own ``dense_sharding``, the width that actually loads data; it is measured
+    from the source's degrees rather than the target's because EP/PP shrinking
+    would otherwise deflate it, and it falls back to ``new_ways`` when the
+    source declares no expert parallel.  ``overrides`` are the user's ``--set``
+    values, which own :data:`OFFLOAD_KEY` when they mention it -- turning
+    offload off that way must not drag its prerequisites down with it.  Returns
+    ``[(key, value, reason), ...]`` for the YAML, empty when the target is no
+    narrower than the source.
+    """
+    if not new_ways:
+        return []
+    assumed = not orig_ways
+    if assumed:
+        base_ways = base_ways or new_ways
+        orig_ways = base_ways * DEFAULT_SHRINK_FACTOR
+    # Nothing to compensate for unless the target is actually narrower, and an
+    # assumed source width is no exception: a target wide enough to reach the
+    # estimate needs neither a pinned data-split width nor offload.
+    if orig_ways <= new_ways:
+        return []
+
+    factor = _format_factor(orig_ways, new_ways)
+    if assumed:
+        shrink = (
+            f"源规模推不出来，按源配置实际加载数据的路数（dense_sharding）"
+            f"{base_ways} 的 {DEFAULT_SHRINK_FACTOR} 倍"
+            f"估计源规模为 {orig_ways} 路"
+        )
+    else:
+        shrink = f"sharding 路数 {orig_ways} -> {new_ways}"
+    switches = [
+        (
+            "debug_reeao_dataset_world_size",
+            orig_ways,
+            f"{shrink}，每路数据量放大 {factor} 倍、数据加载明显变慢；"
+            f"把数据流路数固定回 {orig_ways}"
+            f"（只影响数据切分，rank 仍是真实 rank）",
+        ),
+    ]
+    overrides = overrides or {}
+    if OFFLOAD_KEY in overrides:
+        offload = bool(overrides[OFFLOAD_KEY])
+    else:
+        offload = True
+        switches.append(
+            (
+                OFFLOAD_KEY,
+                True,
+                f"{shrink}，单卡优化器状态放大 {factor} 倍，"
+                f"offload 到 host 内存防 OOM",
+            )
+        )
+    if not offload:
+        return switches
+    for key, value, why in OFFLOAD_PREREQUISITES:
+        if key in config and config[key] != value:
+            switches.append((key, value, f"为开启 {OFFLOAD_KEY}：{why}"))
+    return switches

--- a/tests/single_card_tests/config_adapter/test_config_adapter.py
+++ b/tests/single_card_tests/config_adapter/test_config_adapter.py
@@ -26,14 +26,18 @@ from pathlib import Path
 from unittest import mock
 
 from paddlefleet.config_adapter import (
+    DEFAULT_SHRINK_FACTOR,
+    OFFLOAD_PREREQUISITES,
     AdaptOptions,
     ConfigAdapter,
     inspect_config,
     main,
     parse_overrides,
     plan_precision_switches,
+    plan_sharding_shrink_switches,
 )
 from paddlefleet.config_adapter.constraints import (
+    MIN_PP_FOR_VPP,
     align_layers,
     check_ep_shrink,
     check_hardware,
@@ -47,7 +51,11 @@ from paddlefleet.config_adapter.field_spec import (
     describe_missing,
     resolve_fields,
 )
-from paddlefleet.config_adapter.io_writers import JsonWriter, YamlWriter
+from paddlefleet.config_adapter.io_writers import (
+    JsonWriter,
+    YamlWriter,
+    detect_map_indent,
+)
 from paddlefleet.config_adapter.layer_fields import (
     effective_mtp_layers,
     plan_layer_field_shrink,
@@ -59,7 +67,9 @@ from paddlefleet.config_adapter.model_config_resolver import (
     rewrite_model_name_or_path,
 )
 from paddlefleet.config_adapter.report import (
+    LINE_WIDTH,
     ChangeLog,
+    _width,
     format_header,
     format_report,
 )
@@ -250,6 +260,93 @@ class TestPrecisionSwitches(unittest.TestCase):
         targets = {(t, k) for t, k, _v, _r in applied}
         self.assertIn(("yaml", "mqa_sparse_attn_backward_backend"), targets)
         self.assertIn(("json", "mqa_sparse_attn_backward_backend"), targets)
+
+
+class TestShardingShrinkSwitches(unittest.TestCase):
+    """A smaller sharding degree gets its two compensations."""
+
+    def plan(self, config, orig_ways, new_ways, base_ways=None):
+        """``{key: value}`` of the planned switches."""
+        return {
+            key: value
+            for key, value, _reason in plan_sharding_shrink_switches(
+                config, orig_ways, new_ways, base_ways=base_ways
+            )
+        }
+
+    def test_shrink_pins_the_data_width_and_offloads(self):
+        planned = self.plan({}, 96, 4)
+        self.assertEqual(planned["debug_reeao_dataset_world_size"], 96)
+        self.assertIs(planned["tensorwise_offload_optimizer"], True)
+
+    def test_no_switches_without_a_shrink(self):
+        self.assertEqual(plan_sharding_shrink_switches({}, 96, 96), [])
+        self.assertEqual(plan_sharding_shrink_switches({}, 4, 96), [])
+
+    def test_no_switches_when_a_scale_is_unknown(self):
+        self.assertEqual(plan_sharding_shrink_switches({}, 96, None), [])
+
+    def test_an_assumed_source_width_still_needs_a_real_shrink(self):
+        # The estimate is only a stand-in for the source width, so it obeys
+        # the same "target must be narrower" guard: a target that already
+        # reaches the estimate needs no compensation.
+        self.assertEqual(
+            plan_sharding_shrink_switches(
+                {}, None, 2 * DEFAULT_SHRINK_FACTOR, base_ways=2
+            ),
+            [],
+        )
+        self.assertEqual(
+            plan_sharding_shrink_switches(
+                {}, None, 4 * DEFAULT_SHRINK_FACTOR, base_ways=2
+            ),
+            [],
+        )
+
+    def test_unknown_source_scale_multiplies_the_source_data_width(self):
+        # The base is the source's own dense_sharding, not the width the
+        # target actually runs at after EP/PP shrinking.
+        planned = self.plan({}, None, 4, base_ways=8)
+        self.assertEqual(
+            planned["debug_reeao_dataset_world_size"],
+            8 * DEFAULT_SHRINK_FACTOR,
+        )
+        self.assertIs(planned["tensorwise_offload_optimizer"], True)
+
+    def test_the_target_width_stands_in_for_a_missing_base(self):
+        planned = self.plan({}, None, 4)
+        self.assertEqual(
+            planned["debug_reeao_dataset_world_size"],
+            4 * DEFAULT_SHRINK_FACTOR,
+        )
+
+    def test_the_assumed_width_is_called_out(self):
+        reasons = [
+            r for _k, _v, r in plan_sharding_shrink_switches({}, None, 4)
+        ]
+        self.assertTrue(all("源规模推不出来" in reason for reason in reasons))
+        known = [r for _k, _v, r in plan_sharding_shrink_switches({}, 96, 4)]
+        self.assertTrue(all("源规模推不出来" not in reason for reason in known))
+
+    def test_declared_prerequisites_are_all_turned_off(self):
+        config = {key: not value for key, value, _why in OFFLOAD_PREREQUISITES}
+        config["flash_device_save_steps"] = 50
+        planned = self.plan(config, 96, 4)
+        for key, value, _why in OFFLOAD_PREREQUISITES:
+            self.assertEqual(planned[key], value)
+
+    def test_compatible_prerequisites_are_left_alone(self):
+        config = {key: value for key, value, _why in OFFLOAD_PREREQUISITES}
+        planned = self.plan(config, 96, 4)
+        for key, _value, _why in OFFLOAD_PREREQUISITES:
+            self.assertNotIn(key, planned)
+
+    def test_inexact_ratio_is_not_rounded_down_to_one(self):
+        reasons = [r for _k, _v, r in plan_sharding_shrink_switches({}, 96, 64)]
+        self.assertTrue(reasons)
+        for reason in reasons:
+            self.assertNotIn("放大 1 倍", reason)
+            self.assertIn("1.5", reason)
 
 
 class TestOverrideParsing(unittest.TestCase):
@@ -455,9 +552,9 @@ class TestHardwareAndModelConstraints(unittest.TestCase):
         self.assertEqual(experts, 64)
 
     def test_pp_shrink_reports_layer_and_alignment(self):
-        ok, why, meta = check_pp_shrink(8, 2, 64, 0, 0, 2)
+        ok, why, meta = check_pp_shrink(8, 4, 64, 0, 0, 2)
         self.assertTrue(ok, why)
-        self.assertEqual(meta["layers_new"], 16)
+        self.assertEqual(meta["layers_new"], 32)
         self.assertEqual(meta["vpp_new"], 2)
 
     def test_pp_shrink_warns_on_few_layers(self):
@@ -476,13 +573,46 @@ class TestHardwareAndModelConstraints(unittest.TestCase):
         self.assertFalse(ok)
         self.assertIn("M5", why)
 
+    def test_pp_shrink_recomputes_the_tail_instead_of_padding_it(self):
+        # 43 -> 10 layers: the source tail (11 empty layers, sized for the
+        # 43-layer stack) must not survive as a floor, and PP 2 leaves no
+        # room for the interleave scheduler, so VPP 6 collapses to 1.
+        ok, why, meta = check_pp_shrink(8, 2, 43, 2, 11, 6, min_tail=1)
+        self.assertTrue(ok, why)
+        self.assertEqual(meta["layers_new"], 10)
+        self.assertEqual((meta["vpp_new"], meta["tail_new"]), (1, 2))
+
     def test_align_layers_pads_the_tail(self):
-        vpp_new, tail_new = align_layers(15, 0, 0, 2, 2)
+        vpp_new, tail_new = align_layers(15, 0, 4, 2)
         self.assertEqual(vpp_new, 2)
         self.assertEqual(tail_new, 1)
 
+    def test_align_layers_prefers_the_least_padding(self):
+        # vpp 6 would need 11 empty layers for 13 real ones; vpp 2 needs 3.
+        self.assertEqual(align_layers(13, 0, 4, 6), (2, 3))
+
+    def test_align_layers_honours_the_tail_floor(self):
+        # separate_mtp_headloss silently consumes one tail layer, so the yaml
+        # tail must stay >= 1.
+        self.assertEqual(align_layers(10, 2, 4, 6, min_tail=1), (2, 4))
+
+    def test_align_layers_keeps_vpp_when_padding_ties(self):
+        self.assertEqual(align_layers(24, 0, 4, 6), (6, 0))
+
+    def test_align_layers_never_collapses_vpp_to_one(self):
+        # vpp_new=1 would need less padding (3 vs 7) but dropping the
+        # interleave scheduler is not allowed.
+        self.assertEqual(align_layers(9, 0, 4, 2), (2, 7))
+
+    def test_align_layers_turns_vpp_off_below_three_stages(self):
+        # Paddle asserts "virtual pipeline must run under pp degree > 2", so
+        # at PP 2 that hard failure outranks the no-collapse rule.
+        self.assertEqual(MIN_PP_FOR_VPP, 3)
+        self.assertEqual(align_layers(9, 0, 2, 6), (1, 1))
+        self.assertEqual(align_layers(9, 0, 3, 6), (3, 0))
+
     def test_align_layers_refuses_pp_below_the_floor(self):
-        self.assertEqual(align_layers(16, 0, 0, 1, 2), (None, None))
+        self.assertEqual(align_layers(16, 0, 1, 2), (None, None))
 
 
 class TestSourceScaleInference(unittest.TestCase):
@@ -725,6 +855,42 @@ class TestChangeReporting(unittest.TestCase):
         text = format_report(self._info(), ChangeLog())
         self.assertIn("YAML 改动：无", text)
 
+    def test_every_report_line_fits_the_console(self):
+        log = ChangeLog()
+        log.record(
+            "yaml",
+            [("added", "debug_reeao_dataset_world_size", None, 768)],
+            "源规模推不出来，按源配置实际加载数据的路数（dense_sharding）8 的 "
+            "96 倍估计源规模为 768 路，每路数据量放大 192 倍、数据加载明显变慢；"
+            "把数据流路数固定回 768（只影响数据切分，rank 仍是真实 rank）",
+        )
+        log.record(
+            "yaml", [("modified", "ratios", [128] * 44, [128] * 11)], "裁剪"
+        )
+        lines = format_report(self._info(), log).splitlines()
+        for line in lines:
+            self.assertLessEqual(_width(line), LINE_WIDTH, line)
+            self.assertEqual(line, line.rstrip())
+
+    def test_a_wrapped_reason_hangs_under_its_field(self):
+        log = ChangeLog()
+        log.record("yaml", [("modified", "ep", 64, 4)], "缩容原因" * 30)
+        lines = format_report(self._info(), log).splitlines()
+        start = lines.index("  CHANGE field=ep old=64 new=4")
+        self.assertTrue(lines[start + 1].startswith("      原因："))
+        self.assertTrue(lines[start + 2].startswith(" " * 12))
+        self.assertFalse(lines[start + 2].startswith(" " * 13))
+
+    def test_a_long_value_moves_off_the_field_line(self):
+        log = ChangeLog()
+        log.record("yaml", [("modified", "ratios", [128] * 44, [-2])], "裁剪")
+        lines = format_report(self._info(), log).splitlines()
+        self.assertIn("  CHANGE field=ratios", lines)
+        self.assertTrue(
+            any(line.startswith("      old=[128,") for line in lines)
+        )
+        self.assertIn("      new=[-2]", lines)
+
     def test_header_is_a_comment_block(self):
         header = format_header(self._info())
         self.assertTrue(
@@ -771,6 +937,52 @@ class TestLayerFieldPlanning(unittest.TestCase):
         self.assertEqual(len(by_key["window_attn_skip_freq"]), 17)
         self.assertEqual(len(by_key["layer_types"]), 16)
 
+    def _mtp_shared_config(self, ratios, **overrides):
+        """43 decoder layers + 1 MTP layer, MTP sharing the last layer."""
+        return {
+            "num_hidden_layers": 43,
+            "num_nextn_predict_layers": 1,
+            "mtp_shared_last_layer": True,
+            "csa_compress_ratios": ratios,
+            "window_attn_skip_freq": [0] * 44,
+            "layer_types": ["full_attention"] * 43,
+            **overrides,
+        }
+
+    def test_last_layer_is_realigned_with_the_shared_mtp_layer(self):
+        # HCA(128) everywhere but layer 7 and the MTP layer, which are MLA(-2).
+        ratios = [128] * 7 + [-2] + [128] * 35 + [-2]
+        changes, err = plan_layer_field_shrink(
+            self._mtp_shared_config(ratios), 43, 10, 1
+        )
+        self.assertIsNone(err)
+        by_key = {key: value for key, value, _reason in changes}
+        reasons = {key: reason for key, _value, reason in changes}
+        kept = by_key["csa_compress_ratios"]
+        # A plain truncation would end [..., 128, -2]: the last decoder layer
+        # and the MTP layer must be the same attention type.
+        self.assertEqual(len(kept), 11)
+        self.assertEqual(kept[-2:], [-2, -2])
+        self.assertIn("mtp_shared_last_layer", reasons["csa_compress_ratios"])
+
+    def test_no_realignment_without_mtp_shared_last_layer(self):
+        ratios = [128] * 7 + [-2] + [128] * 35 + [-2]
+        config = self._mtp_shared_config(ratios, mtp_shared_last_layer=False)
+        changes, err = plan_layer_field_shrink(config, 43, 10, 1)
+        self.assertIsNone(err)
+        by_key = {key: value for key, value, _reason in changes}
+        self.assertEqual(by_key["csa_compress_ratios"][-2:], [128, -2])
+
+    def test_realignment_that_erases_a_family_is_refused(self):
+        # HCA(128) survives the truncation only as the last kept layer, so
+        # realigning it to the MTP layer's MLA(-2) would erase the family.
+        ratios = [-2] * 9 + [128] + [-2] * 33 + [-2]
+        _changes, err = plan_layer_field_shrink(
+            self._mtp_shared_config(ratios), 43, 10, 1
+        )
+        self.assertIsNotNone(err)
+        self.assertIn("丢掉注意力类型", err)
+
     def test_growing_or_equal_layer_counts_change_nothing(self):
         changes, err = plan_layer_field_shrink(self._config(), 64, 64, 1)
         self.assertIsNone(err)
@@ -813,12 +1025,13 @@ class TestDefaultAdaptation(ConfigAdapterTestBase):
         config = self.load_output_yaml(8)
         model_config = self.load_output_json(8)
 
-        # EP and PP shrink together; neither collapses to 1.
-        self.assertEqual(config["expert_model_parallel_size"], 4)
-        self.assertEqual(config["pipeline_model_parallel_size"], 2)
-        self.assertEqual(config["sharding_parallel_size"], 4)
-        self.assertEqual(model_config["n_routed_experts"], 16)
-        self.assertEqual(model_config["num_hidden_layers"], 16)
+        # EP absorbs the shrink first (priority EP > PP), so it lands on its
+        # floor and PP only gives up what is left; neither collapses to 1.
+        self.assertEqual(config["expert_model_parallel_size"], 2)
+        self.assertEqual(config["pipeline_model_parallel_size"], 4)
+        self.assertEqual(config["sharding_parallel_size"], 2)
+        self.assertEqual(model_config["n_routed_experts"], 8)
+        self.assertEqual(model_config["num_hidden_layers"], 32)
         # Default batch strategy shrinks GBS and leaves acc alone.
         self.assertEqual(config["global_batch_size"], 2)
         self.assertEqual(config["gradient_accumulation_steps"], 2)
@@ -827,6 +1040,29 @@ class TestDefaultAdaptation(ConfigAdapterTestBase):
         self.assertEqual(model_config["multimax_modules"], ["lm_head"])
         # Environment-specific pin is always dropped.
         self.assertNotIn("fa_version", config)
+
+    def test_pp_is_shrunk_as_little_as_the_card_count_allows(self):
+        # EP 64 -> 2 alone cannot reach 8 cards, but it lets PP stop at 4
+        # instead of 2: shrinking PP also scales num_hidden_layers, VPP, the
+        # empty tail and every per-layer list, so it goes last.
+        ok, message = self.adapt(target_nodes=1)
+        self.assertTrue(ok, message)
+        config = self.load_output_yaml(8)
+        self.assertEqual(config["pipeline_model_parallel_size"], 4)
+        self.assertEqual(config["virtual_pipeline_model_parallel_size"], 2)
+        self.assertIn("先把 EP 压到可行下限", message)
+
+    def test_vpp_is_switched_off_when_pp_drops_below_three(self):
+        # Paddle asserts "virtual pipeline must run under pp degree > 2" while
+        # building any interleaved schedule, so PP 2 leaves VPP no choice.
+        # 4 cards leave no room for PP 4: C2 wants 4 % (PP x EP) == 0 and EP
+        # cannot go below 2, so the joint tier lands on EP 2 / PP 2.
+        ok, message = self.adapt(target_nodes=1, cards_per_node=4)
+        self.assertTrue(ok, message)
+        config = self.load_output_yaml(4)
+        self.assertEqual(config["pipeline_model_parallel_size"], 2)
+        self.assertEqual(config["virtual_pipeline_model_parallel_size"], 1)
+        self.assertIn("框架断言 VPP>1 需要 PP>2", message)
 
     def test_existing_output_dir_needs_force(self):
         ok, message = self.adapt(target_nodes=1)
@@ -838,6 +1074,50 @@ class TestDefaultAdaptation(ConfigAdapterTestBase):
 
         ok, message = self.adapt(target_nodes=1, force=True)
         self.assertTrue(ok, message)
+
+    def test_mtp_aware_layer_alignment(self):
+        # separate_mtp_headloss pulls the MTP layer into the segmentation and
+        # silently consumes one tail empty layer, so the emitted layout must
+        # still divide evenly -- otherwise do_segment() aborts the run.
+        self.write_yaml(
+            SOURCE_YAML.replace(
+                "num_empty_layers_add_in_head: 0",
+                "num_empty_layers_add_in_head: 2",
+            )
+            .replace(
+                "num_empty_layers_add_in_tail: 0",
+                "num_empty_layers_add_in_tail: 3",
+            )
+            .replace(
+                "separate_mtp_headloss: false",
+                "separate_mtp_headloss: true",
+            )
+            .replace(
+                "virtual_pipeline_model_parallel_size: 2",
+                "virtual_pipeline_model_parallel_size: 6",
+            )
+        )
+        self.write_json(dict(MODEL_CONFIG, num_hidden_layers=43))
+
+        ok, message = self.adapt(target_nodes=1)
+        self.assertTrue(ok, message)
+        config = self.load_output_yaml(8)
+        model_config = self.load_output_json(8)
+
+        tail = config["num_empty_layers_add_in_tail"]
+        self.assertGreaterEqual(tail, 1)
+        segmented = (
+            config["num_empty_layers_add_in_head"]
+            + model_config["num_hidden_layers"]
+            + model_config["num_nextn_predict_layers"]
+            + tail
+            - 1
+        )
+        parts = (
+            config["pipeline_model_parallel_size"]
+            * config["virtual_pipeline_model_parallel_size"]
+        )
+        self.assertEqual(segmented % parts, 0)
 
     def test_unchanged_keys_are_not_reported(self):
         ok, message = self.adapt(
@@ -874,6 +1154,22 @@ class TestPerformanceSwitch(ConfigAdapterTestBase):
         self.assertEqual(
             JsonWriter().load(self.json_path)["n_routed_experts"], 256
         )
+
+    def test_vpp_is_switched_off_even_when_the_dims_are_frozen(self):
+        # Freezing never touches PP, so a source that already declares PP 2
+        # with VPP 2 would sail through into a config that dies on Paddle's
+        # "virtual pipeline must run under pp degree > 2" assert.
+        self.write_yaml(
+            SOURCE_YAML.replace(
+                "pipeline_model_parallel_size: 8",
+                "pipeline_model_parallel_size: 2",
+            )
+        )
+        ok, message = self.adapt(target_nodes=16, test_performance=True)
+        self.assertTrue(ok, message)
+        config = self.load_output_yaml(128)
+        self.assertEqual(config["pipeline_model_parallel_size"], 2)
+        self.assertEqual(config["virtual_pipeline_model_parallel_size"], 1)
 
 
 class TestAccuracySwitch(ConfigAdapterTestBase):
@@ -996,6 +1292,73 @@ class TestAutoOverrideRouting(ConfigAdapterTestBase):
         self.assertTrue(ok, message)
         self.assertEqual(self.load_output_json(8)["brand_new_field"], 7)
         self.assertNotIn("brand_new_field", self.load_output_yaml(8))
+
+
+class TestShardingShrinkCompensation(ConfigAdapterTestBase):
+    """End-to-end view of the data-width and offload switches."""
+
+    PREREQUISITES = """\
+fuse_optimizer_states: true
+enable_zero_cost_checkpoint: true
+flash_device_save_steps: 50
+"""
+
+    def test_both_switches_land_in_the_yaml(self):
+        ok, message = self.adapt(target_nodes=1)
+        self.assertTrue(ok, message)
+        output = self.load_output_yaml(8)
+        # 768 source cards / (TP 1 * SEP 1 * PP 8 * CP 1) = 96 source ways.
+        self.assertEqual(output["debug_reeao_dataset_world_size"], 96)
+        self.assertIs(output["tensorwise_offload_optimizer"], True)
+
+    def test_prerequisite_chain_is_disabled(self):
+        self.write_yaml(SOURCE_YAML + self.PREREQUISITES)
+        ok, message = self.adapt(target_nodes=1)
+        self.assertTrue(ok, message)
+        output = self.load_output_yaml(8)
+        self.assertIs(output["fuse_optimizer_states"], False)
+        self.assertIs(output["enable_zero_cost_checkpoint"], False)
+        self.assertEqual(output["flash_device_save_steps"], 0)
+
+    def test_set_can_opt_out_of_the_offload(self):
+        self.write_yaml(SOURCE_YAML + self.PREREQUISITES)
+        ok, message = self.adapt(
+            target_nodes=1,
+            auto_overrides={"tensorwise_offload_optimizer": False},
+        )
+        self.assertTrue(ok, message)
+        output = self.load_output_yaml(8)
+        self.assertIs(output["tensorwise_offload_optimizer"], False)
+        # The cascade only exists to serve the offload, so it stays put.
+        self.assertIs(output["fuse_optimizer_states"], True)
+        self.assertIs(output["enable_zero_cost_checkpoint"], True)
+        self.assertEqual(output["flash_device_save_steps"], 50)
+
+    def test_no_switches_when_the_data_width_is_unchanged(self):
+        # 96 target ways = the source's, so nothing is amplified.
+        ok, message = self.adapt(target_nodes=96)
+        self.assertTrue(ok, message)
+        output = self.load_output_yaml(768)
+        self.assertNotIn("debug_reeao_dataset_world_size", output)
+        self.assertNotIn("tensorwise_offload_optimizer", output)
+
+    def test_unknown_source_scale_still_gets_the_switches(self):
+        # A production YAML that declares neither its batch nor its sharding.
+        hidden = "".join(
+            line + "\n"
+            for line in SOURCE_YAML.splitlines()
+            if not line.startswith(("global_batch_size", "sharding_parallel"))
+        )
+        self.write_yaml(hidden)
+        ok, message = self.adapt(target_nodes=1)
+        self.assertTrue(ok, message)
+        output = self.load_output_yaml(8)
+        # The base is the source's dense_sharding = EP 64 / (TP 1 * SEP 1).
+        self.assertEqual(
+            output["debug_reeao_dataset_world_size"],
+            64 * DEFAULT_SHRINK_FACTOR,
+        )
+        self.assertIs(output["tensorwise_offload_optimizer"], True)
 
 
 class TestErrorPaths(ConfigAdapterTestBase):
@@ -1223,16 +1586,37 @@ class TestLayerFields(ConfigAdapterTestBase):
         ok, message = self.adapt(target_nodes=1)
         self.assertTrue(ok, message)
         model_config = self.load_output_json(8)
-        # 64 -> 16 layers, MTP entries kept at the tail.
-        self.assertEqual(model_config["num_hidden_layers"], 16)
-        self.assertEqual(len(model_config["csa_compress_ratios"]), 17)
+        # 64 -> 32 layers, MTP entries kept at the tail.
+        self.assertEqual(model_config["num_hidden_layers"], 32)
+        self.assertEqual(len(model_config["csa_compress_ratios"]), 33)
         self.assertEqual(model_config["csa_compress_ratios"][-1], -2)
-        self.assertEqual(len(model_config["window_attn_skip_freq"]), 17)
-        self.assertEqual(len(model_config["layer_types"]), 16)
+        self.assertEqual(len(model_config["window_attn_skip_freq"]), 33)
+        self.assertEqual(len(model_config["layer_types"]), 32)
         # Both attention families of the source pattern survive.
-        self.assertIn(128, model_config["csa_compress_ratios"][:16])
-        self.assertIn(-2, model_config["csa_compress_ratios"][:16])
+        self.assertIn(128, model_config["csa_compress_ratios"][:32])
+        self.assertIn(-2, model_config["csa_compress_ratios"][:32])
         self.assertIn("逐层配置", message)
+
+    def test_last_layer_is_realigned_with_the_shared_mtp_layer(self):
+        # mtp_shared_last_layer aliases the MTP layer's attention onto the last
+        # decoder layer, so a truncation that ends on HCA(128) next to an
+        # MLA(-2) MTP layer would hang the run instead of failing.
+        self.write_json(
+            {
+                **MODEL_CONFIG,
+                "mtp_shared_last_layer": True,
+                "csa_compress_ratios": [-2] + [128] * 63 + [-2],
+                "window_attn_skip_freq": [0] * 65,
+                "layer_types": ["full_attention"] * 64,
+            }
+        )
+        ok, message = self.adapt(target_nodes=1)
+        self.assertTrue(ok, message)
+        ratios = self.load_output_json(8)["csa_compress_ratios"]
+        self.assertEqual(len(ratios), 33)
+        self.assertEqual(ratios[-2:], [-2, -2])
+        self.assertIn(128, ratios[:32])
+        self.assertIn("mtp_shared_last_layer", message)
 
     def test_refuses_when_an_attention_family_would_vanish(self):
         # Every -2 layer sits beyond the shrunk layer range.
@@ -1269,10 +1653,10 @@ class TestLayerFields(ConfigAdapterTestBase):
         ok, message = self.adapt(target_nodes=1)
         self.assertTrue(ok, message)
         model_config = self.load_output_json(8)
-        self.assertEqual(model_config["num_hidden_layers"], 16)
-        # 16 layers + the 2 MTP entries.
-        self.assertEqual(len(model_config["csa_compress_ratios"]), 18)
-        self.assertEqual(len(model_config["layer_types"]), 16)
+        self.assertEqual(model_config["num_hidden_layers"], 32)
+        # 32 layers + the 2 MTP entries.
+        self.assertEqual(len(model_config["csa_compress_ratios"]), 34)
+        self.assertEqual(len(model_config["layer_types"]), 32)
 
 
 class TestFailureLeavesSourcesUntouched(ConfigAdapterTestBase):
@@ -1309,6 +1693,41 @@ class TestFailureLeavesSourcesUntouched(ConfigAdapterTestBase):
         self.assertFalse((self.output_dir / "model_config_separated").exists())
 
 
+class TestYamlIndentPreservation(ConfigAdapterTestBase):
+    """A round-trip keeps the source's own nested-mapping indentation."""
+
+    NESTED = """\
+deepep_buffer_configs:
+  num_sms: 52
+muon_configs:
+    muon_momentum: 0.95
+    muon_version: 3
+    muon_exclude_patterns:
+    - "embed"
+    - "bias"
+"""
+
+    def test_detect_map_indent_takes_the_dominant_style(self):
+        self.write_yaml(SOURCE_YAML + self.NESTED)
+        document = YamlWriter().load(self.yaml_path)
+        self.assertEqual(detect_map_indent(document), 4)
+
+    def test_detect_map_indent_falls_back_without_nesting(self):
+        self.assertEqual(
+            detect_map_indent(YamlWriter().load(self.yaml_path)), 2
+        )
+
+    def test_nested_block_is_not_reindented(self):
+        self.write_yaml(SOURCE_YAML + self.NESTED)
+        ok, message = self.adapt(target_nodes=1)
+        self.assertTrue(ok, message)
+        text = (self.output_dir / "source_adapted_8cards.yaml").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("    muon_momentum: 0.95", text)
+        self.assertIn('    - "embed"', text)
+
+
 class TestPinnedModelPathConflict(ConfigAdapterTestBase):
     """A pinned model_name_or_path cannot coexist with a JSON rewrite."""
 
@@ -1342,13 +1761,13 @@ class TestInPlace(ConfigAdapterTestBase):
         )
         self.assertTrue(ok, message)
         config = YamlWriter().load(self.yaml_path)
-        self.assertEqual(config["pipeline_model_parallel_size"], 2)
+        self.assertEqual(config["pipeline_model_parallel_size"], 4)
         self.assertEqual(config["model_name_or_path"], "./model_dir")
         self.assertNotIn(
             "[config_adapter]", self.yaml_path.read_text(encoding="utf-8")
         )
         self.assertEqual(
-            JsonWriter().load(self.json_path)["num_hidden_layers"], 16
+            JsonWriter().load(self.json_path)["num_hidden_layers"], 32
         )
 
 


### PR DESCRIPTION
### PR Category
Distributed Strategy

### PR Types
Improvements

### Description
Cherry-pick of #1817 to `release/0.4`. Merged in dev: #1817

Changes to the standalone `paddlefleet.config_adapter` CLI (no runtime/training code touched):

- **Sharding-shrink compensations** (new `sharding_shrink.py`): when the target `dataset_world_size` is narrower than the source, pin `debug_reeao_dataset_world_size` back to the source width (data split only, ranks stay real) and enable `tensorwise_offload_optimizer` to avoid per-card optimizer-state OOM, cascading its framework-asserted prerequisites (`fuse_optimizer_states=false` -> `enable_zero_cost_checkpoint=false` -> `flash_device_save_steps=0`). When the source scale is underivable (production YAMLs comment out `global_batch_size` and declare no `sharding_parallel_size`), the source width is estimated as the source-side `dense_sharding` x 96.
- **EP-first shrink order** in the EP+PP joint tier: push EP to its feasible floor first, then take the largest PP under that EP -- shrinking EP only loses routed experts, while shrinking PP also rewrites layer counts, per-layer lists, VPP and tail empty layers.
- **Two invariants enforced from real framework behaviour**: (1) with `mtp_shared_last_layer`, the trimmed last decoder layer's `csa_compress_ratios` entry is rewritten to match the MTP entry, otherwise the shared attention weights mismatch geometrically across PP stages and training hangs silently; (2) VPP>1 requires PP>2 (`virtual pipeline must run under pp degree > 2`), so VPP is forced to 1 whenever PP<3.
- Report layout rework (CJK-aware wrapping) and unit tests: 162 tests pass.

### 是否引起精度变化
否