### PR TITLE
[release/0.4][CSA] Support latent widths below the sparse-attn kernel's 512

### DIFF
--- a/src/paddlefleet/fusions/csa_sparse_attn.py
+++ b/src/paddlefleet/fusions/csa_sparse_attn.py
@@ -21,7 +21,8 @@ final sparse MQA attention:
   - "cudnn": FlashMLA sparse forward + cuDNN DSA backward
 
 Head counts below a kernel tile are supported by zero-padding, see
-``_pad_query_heads``.
+``_pad_query_heads``. Latent widths below 512 likewise, see
+``_pad_latent_dim``.
 """
 
 import functools
@@ -36,6 +37,10 @@ from paddle import Tensor
 # ``sm100/prefill/sparse/fwd/head64/config.h``), so a layer with fewer heads
 # cannot be given a narrower tile without a new kernel.
 _DSA_HEAD_TILES = (64, 128)
+# The only latent width the FlashMLA sparse prefill and the cuDNN DSA backward
+# accept on this symmetric path; narrower layers are zero-padded up to it, see
+# ``_pad_latent_dim``.
+_DSA_LATENT_DIM = 512
 # Sink logit that makes ``exp(sink - m) -> 0``, i.e. plain softmax. Used for the
 # padded heads so they cannot perturb the real ones.
 _NEG_SINK = -1e30
@@ -138,6 +143,53 @@ def _pad_query_heads(query: Tensor, attn_sink: Tensor, head_tile: int):
         axis=0,
     )
     return query, attn_sink
+
+
+def _dsa_latent_dim(hn: int) -> int:
+    """Latent width the "cudnn" backend must be driven at for a ``hn`` layer.
+
+    Always ``_DSA_LATENT_DIM``: the FlashMLA sparse prefill accepts
+    ``d_qk in {512, 576}`` and requires ``d_v == 512``
+    (``csrc/api/sparse_fwd.h``), and this CSA path calls it symmetrically
+    (``d_v`` defaults to the query's last dim), so 512 is the only width that
+    passes. The cuDNN DSA backward is equally 512-shaped: its SM100 kernel
+    unrolls ``dQ`` / ``dKV`` into exactly four 128-column sub-tiles.
+    """
+    if hn > _DSA_LATENT_DIM:
+        raise ValueError(
+            f"csa_sparse_attn 'cudnn' backend supports at most "
+            f"{_DSA_LATENT_DIM} latent dims, got {hn}. "
+            "Reduce v_head_dim."
+        )
+    return _DSA_LATENT_DIM
+
+
+def _pad_latent_dim(x: Tensor, latent_dim: int) -> Tensor:
+    """Zero-pad the last (latent) axis of ``x`` up to ``latent_dim``.
+
+    Applied to ``q`` and ``kv`` together, so it is numerically exact rather
+    than an approximation. ``kv`` is a single latent head shared as both key
+    and value, so with both sides zero in the padded columns:
+
+    * ``scores = q . k`` is unchanged bit-for-bit (the added terms are 0 * 0),
+      hence so are the softmax, the ``lse`` and the sink.
+    * ``out = sum_j p_j * kv_j`` has the true result in ``[:hn]`` and exactly
+      zero in the padded columns, so the caller just slices them off.
+    * backward likewise: ``dq = sum_j dp_j * kv_j`` and
+      ``dkv = sum_j p_j * dout_j`` are zero over the padded columns (``dout``
+      is padded with zeros too), and ``d_sink`` is untouched.
+
+    The cost is that both GEMMs run at ``latent_dim`` for ``hn`` real columns.
+    The ``hn == latent_dim`` path is unchanged, and no tensor is saved for
+    backward in padded form -- backward re-pads instead, so activation memory
+    stays at the real width.
+    """
+    pad = latent_dim - x.shape[-1]
+    if pad == 0:
+        return x
+    zeros_shape = list(x.shape)
+    zeros_shape[-1] = pad
+    return paddle.concat([x, paddle.zeros(zeros_shape, dtype=x.dtype)], axis=-1)
 
 
 def unfused_compressed_sparse_attn(
@@ -382,6 +434,12 @@ class CSASparseAttention(paddle.autograd.PyLayer):
             if head_tile == np_heads or _dsa_bwd_runs_sub_tile_heads(np_heads)
             else head_tile
         )
+        # Latent width the kernels are driven with. Both the FlashMLA forward
+        # and the cuDNN backward only exist at 512, so a narrower layer is
+        # zero-padded up to it on the way in and sliced back on the way out.
+        # Unlike the head padding above this never changes what is saved for
+        # backward, so it costs no activation memory.
+        ctx.kernel_hn = _dsa_latent_dim(hn) if backend == "cudnn" else hn
         if backend == "cudnn":
             from paddlefleet.cudnn_ops.attn.csa_sparse_attn_fwd_cudnn import (
                 flash_mla_sparse_attn,
@@ -392,14 +450,17 @@ class CSASparseAttention(paddle.autograd.PyLayer):
                 q_in, sink_in = _pad_query_heads(query, attn_sink, head_tile)
 
             output, lse, lse_indexer = flash_mla_sparse_attn(
-                q_in,
-                kv_full,
+                _pad_latent_dim(q_in, ctx.kernel_hn),
+                _pad_latent_dim(kv_full, ctx.kernel_hn),
                 sink_in,
                 topk_idxs,
                 sm_scale=ctx.softmax_scale,
                 topk_length=topk_length,
                 indexer_topk=indexer_topk,
             )
+            if ctx.kernel_hn != hn:
+                # The padded latent columns of the output are exactly zero.
+                output = output[..., :hn].contiguous()
             output_real, lse_real = output, lse
             if head_tile != np_heads:
                 output_real = _drop_padded_head_rows(
@@ -482,6 +543,15 @@ class CSASparseAttention(paddle.autograd.PyLayer):
             lse_flat = lse.reshape([b * sq, kh])
             topk_idxs_flat = _local_to_global_flat(topk_idxs, s_kv)
 
+            if ctx.kernel_hn != hn:
+                # Same exact zero-padding the forward used (see
+                # ``_pad_latent_dim``); ``out`` is zero over the padded columns
+                # there, so re-padding the saved narrow copy reproduces it.
+                q_flat = _pad_latent_dim(q_flat, ctx.kernel_hn)
+                o_flat = _pad_latent_dim(o_flat, ctx.kernel_hn)
+                do_flat = _pad_latent_dim(do_flat, ctx.kernel_hn)
+                kv_flat = _pad_latent_dim(kv_flat, ctx.kernel_hn)
+
             # ``topk_idxs`` was already densified in the forward for the compacted
             # path (HCA, no indexer loss), so the saved indices have a dense valid
             # prefix with -1 only trailing. Recover the per-row count cheaply (a
@@ -510,6 +580,10 @@ class CSASparseAttention(paddle.autograd.PyLayer):
                 softmax_scale=ctx.softmax_scale,
                 topk_length=topk_length,
             )
+            if ctx.kernel_hn != hn:
+                # ``dq`` / ``dkv`` are exactly zero over the padded columns.
+                dq_flat = dq_flat[..., :hn].contiguous()
+                dkv_flat = dkv_flat[..., :hn].contiguous()
             dkv = dkv_flat.reshape(kv_full.shape)
             if kh != np_heads:
                 dq = _drop_padded_head_rows(dq_flat, np_heads, kh).reshape(
@@ -574,7 +648,9 @@ def csa_sparse_attn(
     ``query`` may carry any head count up to 128 on the "cudnn" backend; counts
     that are not one of the kernel's head tiles (e.g. 32 or 24) are handled
     inside ``CSASparseAttention`` by padding the forward, which is exact but
-    keeps the forward cost of the tile.
+    keeps the forward cost of the tile. The same holds for the latent width:
+    any ``v_head_dim`` up to 512 is accepted and zero-padded to 512, which is
+    the only width both the FlashMLA forward and the cuDNN backward exist at.
     """
     if backend == "unfused":
         return unfused_compressed_sparse_attn(

--- a/tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_backends.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_backends.py
@@ -593,6 +593,9 @@ class TestCsaBwdTopkLengthDispatch(unittest.TestCase):
             # Head count the saved tensors are in; equal to np_heads unless the
             # forward padded them up to a kernel head tile.
             bwd_heads=np_heads,
+            # Latent width the kernels run at; equal to hn unless the forward
+            # zero-padded a narrower latent up to 512.
+            kernel_hn=hn,
             query_needs_grad=not query.stop_gradient,
             kv_full_needs_grad=not kv_full.stop_gradient,
             attn_sink_needs_grad=not attn_sink.stop_gradient,

--- a/tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_sub_512_latent.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_sub_512_latent.py
@@ -1,0 +1,524 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CSA / HCA layers whose latent width is below the sparse-attn kernel's 512.
+
+The FlashMLA sparse prefill accepts ``d_qk in {512, 576}`` and requires
+``d_v == 512`` (``csrc/api/sparse_fwd.h``), and the cuDNN DSA backward unrolls
+``dQ``/``dKV`` into exactly four 128-column sub-tiles, so neither runs at
+``v_head_dim = 256``. ``_pad_latent_dim`` zero-pads ``q`` and ``kv`` up to 512
+instead. Since ``kv`` is one latent head serving as both key and value, zeros on
+both sides leave the scores bit-identical and make the padded output columns --
+and the ``dq``/``dkv`` columns over them -- exactly zero.
+
+This pins that claim: agreement with the fp32 ``unfused`` reference in fwd and
+bwd, the padded columns being exactly (not approximately) zero straight out of
+both kernels, the ``hn == 512`` path staying copy-free and therefore
+bit-for-bit unchanged, and the >512 rejection.
+"""
+
+import functools
+import unittest
+
+import paddle
+
+try:
+    import paddlefleet_ops
+
+    from paddlefleet.cudnn_ops.attn import csa_sparse_attn_fwd_cudnn
+
+    _HAS_FLASH_MLA = (
+        paddlefleet_ops.is_flash_mla_available()
+        and csa_sparse_attn_fwd_cudnn._flash_mla_sparse_fwd is not None
+    )
+except (ImportError, RuntimeError, AttributeError):
+    _HAS_FLASH_MLA = False
+
+try:
+    import paddlefleet_ops
+
+    from paddlefleet.cudnn_ops import csa_sparse_attn_bwd_cudnn
+
+    _HAS_CUDNN_FRONTEND = paddlefleet_ops.is_cudnn_frontend_available() and (
+        callable(csa_sparse_attn_bwd_cudnn)
+    )
+except (ImportError, RuntimeError, AttributeError):
+    _HAS_CUDNN_FRONTEND = False
+
+_KERNEL_LATENT = 512
+# b, sq, skv, topk, invalid_frac, name. ``invalid_frac`` seeds ``-1`` columns
+# anywhere in the row, which is what document masking produces.
+_SHAPES = [
+    (1, 128, 256, 64, 0.0, "dense"),
+    (1, 128, 256, 64, 0.3, "holes"),
+    (2, 256, 512, 192, 0.2, "batch2-topk192"),
+    (1, 64, 8192, 192, 0.1, "hca-like"),
+    (1, 1, 64, 64, 0.0, "single-token"),
+]
+# The exp2 ernielite layer shape this was added for, plus two other widths to
+# keep the padding generic rather than 256-specific.
+_LATENTS = (256, 384, 128)
+
+
+def _rel_l2(a, b):
+    a_f = a.flatten().cast("float32")
+    b_f = b.flatten().cast("float32")
+    return float(
+        paddle.linalg.norm(a_f - b_f) / (paddle.linalg.norm(b_f) + 1e-12)
+    )
+
+
+def _make_inputs(
+    b, sq, skv, num_heads, hn, topk, invalid_frac, seed=0, sink=None
+):
+    paddle.seed(seed)
+    q = paddle.randn([b, sq, num_heads, hn]).cast("bfloat16")
+    kv = paddle.randn([b, skv, hn]).cast("bfloat16")
+    attn_sink = (paddle.randn([num_heads]) * 0.5).cast("float32")
+    if sink is not None:
+        attn_sink = _make_sink(num_heads, sink)
+    topk_idxs = paddle.randint(0, skv, [b, sq, topk]).cast("int32")
+    if invalid_frac > 0:
+        holes = paddle.rand([b, sq, topk]) < invalid_frac
+        topk_idxs = paddle.where(
+            holes, paddle.full_like(topk_idxs, -1), topk_idxs
+        )
+    return q, kv, attn_sink, topk_idxs, hn**-0.5
+
+
+def _make_sink(num_heads, spec):
+    """Attention-sink bias presets.
+
+    ``"split"`` puts half the heads at +8 and half at -8 in one call, so a bug
+    that mixes head rows up cannot hide behind a uniform sink.
+    """
+    if spec == "split":
+        half = num_heads // 2
+        return paddle.concat(
+            [
+                paddle.full([half], 8.0, dtype="float32"),
+                paddle.full([num_heads - half], -8.0, dtype="float32"),
+            ]
+        )
+    return paddle.full([num_heads], float(spec), dtype="float32")
+
+
+def _run(
+    q,
+    kv,
+    attn_sink,
+    topk_idxs,
+    scale,
+    backend,
+    grad_seed=None,
+    topk_length=None,
+):
+    """One fwd+bwd through the public entry point.
+
+    ``grad_seed`` seeds a random ``dO`` instead of the all-ones one an
+    ``out.sum()`` loss gives. That matters here: with ``dO == 1`` every latent
+    column carries the same gradient, so mis-padding ``dO`` at the wrong end --
+    or slicing ``dq``/``dkv`` from the wrong side -- would not show up. The
+    reference and the kernel run re-seed identically, so both see the same
+    ``dO``.
+    """
+    from paddlefleet.fusions.csa_sparse_attn import csa_sparse_attn
+
+    b, sq, num_heads, hn = q.shape
+    q = q.detach().clone()
+    q.stop_gradient = False
+    kv = kv.detach().clone()
+    kv.stop_gradient = False
+    attn_sink = attn_sink.detach().clone()
+    attn_sink.stop_gradient = False
+
+    kwargs = {} if topk_length is None else {"topk_length": topk_length}
+    out = csa_sparse_attn(
+        q, kv, attn_sink, topk_idxs, scale, backend=backend, **kwargs
+    )
+    if grad_seed is None:
+        out.sum().backward()
+    else:
+        paddle.seed(grad_seed)
+        out.backward(paddle.randn(out.shape).cast(out.dtype))
+    return {
+        "out": out.reshape([b, sq, num_heads, hn]),
+        "dq": q.grad,
+        "dkv": kv.grad,
+        "d_sink": attn_sink.grad,
+    }
+
+
+# Worst rel-L2 measured against the fp32 reference with a random dO, over every
+# shape in ``_SHAPES`` and every latent width in 64..512: out 2.4e-3, dq 3.1e-3,
+# dkv 3.3e-3, d_sink 3.9e-3 -- and the hn=512 native case sits at 2.4/2.8/3.2/
+# 3.5e-3, i.e. the padding contributes nothing above bf16 noise. Ceilings are
+# ~2x that; ``test_no_accuracy_loss_vs_native_512`` is the part that ties the
+# padded error to the native one and so catches a real regression.
+_REL_L2_CEILING = {"out": 6e-3, "dq": 6e-3, "dkv": 6e-3, "d_sink": 8e-3}
+
+
+@functools.lru_cache(maxsize=1)
+def _cudnn_sparse_bwd_runs():
+    """Whether the cuDNN sparse backward can actually execute here.
+
+    ``is_cudnn_frontend_available()`` is not a usable proxy: some builds import
+    a top-level ``cudnn`` module while executing, which the loader has already
+    renamed to ``paddlefleet_ops.cudnn``, so the call dies with
+    ``ModuleNotFoundError`` while the probe says "available". One native-width
+    backward settles it; anything other than a missing module is re-raised so a
+    real kernel regression still fails loudly.
+    """
+    if not (_HAS_FLASH_MLA and _HAS_CUDNN_FRONTEND):
+        return False
+    try:
+        _run(
+            *_make_inputs(1, 8, 64, 64, _KERNEL_LATENT, 64, 0.0),
+            backend="cudnn",
+        )
+    except Exception as exc:
+        if isinstance(exc, ImportError) or "No module named" in str(exc):
+            return False
+        raise
+    return True
+
+
+def _skip_without_cudnn_sparse_bwd():
+    if not _cudnn_sparse_bwd_runs():
+        raise unittest.SkipTest(
+            "the cuDNN sparse backward does not run in this environment"
+        )
+
+
+@unittest.skipUnless(
+    paddle.is_compiled_with_cuda(), "sub-512 latent tests require CUDA"
+)
+class TestSubLatentDim(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        _skip_without_cudnn_sparse_bwd()
+
+    def test_matches_unfused_reference(self):
+        for hn in _LATENTS:
+            for b, sq, skv, topk, inv, name in _SHAPES:
+                with self.subTest(hn=hn, shape=name):
+                    args = _make_inputs(b, sq, skv, 64, hn, topk, inv)
+                    ref = _run(*args, backend="unfused", grad_seed=7)
+                    got = _run(*args, backend="cudnn", grad_seed=7)
+                    for key, ceiling in _REL_L2_CEILING.items():
+                        self.assertLess(
+                            _rel_l2(got[key], ref[key]),
+                            ceiling,
+                            f"{key} at hn={hn} shape={name}",
+                        )
+
+    def test_arbitrary_latent_widths(self):
+        """Any width up to 512, including ones that are not multiples of 64.
+
+        The pad target is always 512 and ``paddle.concat`` returns a fresh
+        contiguous tensor, so the kernel's alignment requirements are met by the
+        padded copy regardless of how odd the real width is. Verified for 100 /
+        200 / 260 as well as the tidy multiples.
+        """
+        for hn in (64, 100, 192, 200, 260, 320, 448):
+            with self.subTest(hn=hn):
+                args = _make_inputs(1, 64, 256, 64, hn, 64, 0.1)
+                ref = _run(*args, backend="unfused", grad_seed=7)
+                got = _run(*args, backend="cudnn", grad_seed=7)
+                for key, ceiling in _REL_L2_CEILING.items():
+                    self.assertLess(
+                        _rel_l2(got[key], ref[key]), ceiling, f"{key} hn={hn}"
+                    )
+
+    def test_sink_magnitudes(self):
+        """The learnable sink bias must survive the latent padding.
+
+        The sink enters the softmax denominator only, so a padding bug that
+        perturbed the scores would show up here first: at sink=+20 the sink
+        dominates every row, at -1e4 it drops out entirely (``d_sink`` is then
+        exactly 0 on both sides), and "split" makes neighbouring heads disagree.
+        """
+        for sink in (-8.0, 0.0, 8.0, 20.0, -1e4, "split"):
+            for hn in (256, 128):
+                with self.subTest(sink=sink, hn=hn):
+                    args = _make_inputs(
+                        1, 128, 512, 64, hn, 192, 0.2, sink=sink
+                    )
+                    ref = _run(*args, backend="unfused", grad_seed=7)
+                    got = _run(*args, backend="cudnn", grad_seed=7)
+                    for key, ceiling in _REL_L2_CEILING.items():
+                        self.assertLess(
+                            _rel_l2(got[key], ref[key]),
+                            ceiling,
+                            f"{key} at sink={sink} hn={hn}",
+                        )
+
+    def test_no_accuracy_loss_vs_native_512(self):
+        """Padding must not make a narrow latent less accurate than hn=512.
+
+        Both runs are compared to their own fp32 reference, so the ratio is
+        scale-free; a real regression (wrong columns, stale padding) blows it up
+        far past the slack allowed here.
+        """
+        b, sq, skv, topk = 1, 128, 512, 192
+        base_args = _make_inputs(b, sq, skv, 64, _KERNEL_LATENT, topk, 0.2)
+        base = {
+            k: _rel_l2(v, _run(*base_args, backend="unfused", grad_seed=7)[k])
+            for k, v in _run(*base_args, backend="cudnn", grad_seed=7).items()
+        }
+        for hn in _LATENTS:
+            with self.subTest(hn=hn):
+                args = _make_inputs(b, sq, skv, 64, hn, topk, 0.2)
+                ref = _run(*args, backend="unfused", grad_seed=7)
+                got = _run(*args, backend="cudnn", grad_seed=7)
+                for key in ("out", "dq", "dkv"):
+                    self.assertLess(
+                        _rel_l2(got[key], ref[key]),
+                        max(3.0 * base[key], 1e-4),
+                        f"{key} at hn={hn} is worse than the hn=512 baseline "
+                        f"({base[key]:.3e})",
+                    )
+
+    def test_native_512_is_copy_free(self):
+        """``hn == 512`` must stay bit-for-bit unchanged, i.e. no pad at all."""
+        from paddlefleet.fusions.csa_sparse_attn import _pad_latent_dim
+
+        x = paddle.randn([2, 4, _KERNEL_LATENT]).cast("bfloat16")
+        self.assertIs(_pad_latent_dim(x, _KERNEL_LATENT), x)
+
+    def test_kernel_sees_zero_padded_512_and_output_is_sliced_back(self):
+        """Pin the plumbing bit-exactly by spying on the kernel call itself.
+
+        Checked at the boundary rather than against a hand-rolled second
+        pipeline, because the forward also pre-compacts ``topk_idxs`` and derives
+        its own ``topk_length``; reproducing that outside would either duplicate
+        the wrapper or change the summation order and stop being bit-exact.
+
+        Asserts the kernel is handed exactly 512 columns with zeros above ``hn``
+        (so the scores cannot move), and that what the entry point returns is
+        bit-for-bit the kernel's output sliced to ``hn`` -- which a wrong axis, an
+        off-by-one, or a stale non-contiguous view would all break.
+        """
+        import paddlefleet.cudnn_ops.attn.csa_sparse_attn_fwd_cudnn as fwd_mod
+        from paddlefleet.fusions.csa_sparse_attn import csa_sparse_attn
+
+        for hn in _LATENTS:
+            with self.subTest(hn=hn):
+                q, kv, sink, idxs, scale = _make_inputs(
+                    1, 128, 512, 64, hn, 192, 0.2
+                )
+                seen = {}
+                original = fwd_mod.flash_mla_sparse_attn
+
+                def spy(q_in, kv_in, *args, **kwargs):
+                    res = original(q_in, kv_in, *args, **kwargs)
+                    seen["q"], seen["kv"], seen["out"] = q_in, kv_in, res[0]
+                    return res
+
+                fwd_mod.flash_mla_sparse_attn = spy
+                try:
+                    wrapped = csa_sparse_attn(
+                        q, kv, sink, idxs, scale, backend="cudnn"
+                    )
+                finally:
+                    fwd_mod.flash_mla_sparse_attn = original
+
+                self.assertEqual(seen["q"].shape[-1], _KERNEL_LATENT)
+                self.assertEqual(seen["kv"].shape[-1], _KERNEL_LATENT)
+                for name in ("q", "kv"):
+                    self.assertEqual(
+                        float(seen[name][..., hn:].abs().max()),
+                        0.0,
+                        f"{name} padding is not zero",
+                    )
+                sliced = seen["out"][..., :hn].reshape(wrapped.shape)
+                self.assertEqual(
+                    float(
+                        (wrapped.cast("float32") - sliced.cast("float32"))
+                        .abs()
+                        .max()
+                    ),
+                    0.0,
+                )
+
+    def test_forward_is_deterministic(self):
+        """Two identical forwards must agree bit-for-bit.
+
+        Training runs this layer under ``recompute_modules=["full_attn", ...]``,
+        so the forward executes twice and the backward differentiates the second
+        run. Zero padding is deterministic, but this pins it.
+        """
+        from paddlefleet.fusions.csa_sparse_attn import csa_sparse_attn
+
+        args = _make_inputs(1, 128, 512, 24, 256, 192, 0.2)
+        first = csa_sparse_attn(*args, backend="cudnn")
+        second = csa_sparse_attn(*args, backend="cudnn")
+        self.assertEqual(
+            float((first.cast("float32") - second.cast("float32")).abs().max()),
+            0.0,
+        )
+
+    def test_topk_length_early_stop(self):
+        """The forward early-stop hint must still be honoured under padding.
+
+        ``topk_length`` is a forward-only hint: the backward ignores it and
+        rebuilds its own bound from the ``-1`` entries in ``topk_idxs``
+        (``_csa_compute_topk_length``). So the slots beyond the prefix have to be
+        marked ``-1`` as well, or the two halves differentiate different supports
+        -- measured ``dq`` rel-L2 1.1e+01 without the ``-1`` padding, identically
+        at hn=512 and hn=256, i.e. that is the API's contract and not something
+        the latent padding introduced.
+        """
+        b, sq, skv, hn, topk = 1, 128, 512, 256, 192
+        q, kv, sink, idxs, scale = _make_inputs(b, sq, skv, 64, hn, topk, 0.0)
+        paddle.seed(11)
+        topk_length = paddle.randint(1, topk + 1, [b, sq]).cast("int32")
+        slots = paddle.arange(topk, dtype="int32").reshape([1, 1, topk])
+        idxs = paddle.where(
+            slots >= topk_length.reshape([b, sq, 1]),
+            paddle.full_like(idxs, -1),
+            idxs,
+        )
+        args = (q, kv, sink, idxs, scale)
+        ref = _run(
+            *args, backend="unfused", grad_seed=7, topk_length=topk_length
+        )
+        got = _run(*args, backend="cudnn", grad_seed=7, topk_length=topk_length)
+        for key, ceiling in _REL_L2_CEILING.items():
+            self.assertLess(_rel_l2(got[key], ref[key]), ceiling, key)
+
+    def test_rejects_latent_wider_than_512(self):
+        from paddlefleet.fusions.csa_sparse_attn import (
+            _dsa_latent_dim,
+            csa_sparse_attn,
+        )
+
+        self.assertEqual(_dsa_latent_dim(256), _KERNEL_LATENT)
+        self.assertEqual(_dsa_latent_dim(_KERNEL_LATENT), _KERNEL_LATENT)
+        with self.assertRaisesRegex(ValueError, "at most 512 latent dims"):
+            _dsa_latent_dim(576)
+        args = _make_inputs(1, 8, 64, 64, 576, 64, 0.0)
+        with self.assertRaisesRegex(ValueError, "at most 512 latent dims"):
+            csa_sparse_attn(*args, backend="cudnn")
+
+
+@unittest.skipUnless(
+    paddle.is_compiled_with_cuda(), "sub-512 latent tests require CUDA"
+)
+class TestPaddedLatentColumnsAreZero(unittest.TestCase):
+    """The claim the whole approach rests on, checked at the kernel boundary.
+
+    Exactly zero, not small: if either kernel wrote anything into the padded
+    columns the slice-back in ``CSASparseAttention`` would silently discard real
+    contributions, so this is asserted as an exact 0 rather than a tolerance.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        _skip_without_cudnn_sparse_bwd()
+
+    def test_forward_and_backward_leave_padding_at_zero(self):
+        from paddlefleet.cudnn_ops import csa_sparse_attn_bwd_cudnn
+        from paddlefleet.cudnn_ops.attn.csa_sparse_attn_fwd_cudnn import (
+            flash_mla_sparse_attn,
+        )
+        from paddlefleet.fusions.csa_sparse_attn import (
+            _csa_compute_topk_length,
+            _pad_latent_dim,
+        )
+        from paddlefleet.fusions.csa_sparse_attn_utils import (
+            _local_to_global_flat,
+        )
+
+        b, sq, skv, heads, topk = 1, 128, 512, 64, 192
+        for hn in _LATENTS:
+            with self.subTest(hn=hn):
+                q, kv, sink, idxs, scale = _make_inputs(
+                    b, sq, skv, heads, hn, topk, 0.2
+                )
+                q_pad = _pad_latent_dim(q, _KERNEL_LATENT)
+                kv_pad = _pad_latent_dim(kv, _KERNEL_LATENT)
+                out, lse, _ = flash_mla_sparse_attn(
+                    q_pad, kv_pad, sink, idxs, sm_scale=scale
+                )
+                self.assertEqual(
+                    float(out[:, :, :, hn:].abs().max()), 0.0, "fwd out"
+                )
+
+                idxs_flat = _local_to_global_flat(idxs, skv)
+                dout = _pad_latent_dim(
+                    paddle.randn([b, sq, heads, hn]).cast(out.dtype),
+                    _KERNEL_LATENT,
+                )
+                dq, dkv, _ = csa_sparse_attn_bwd_cudnn(
+                    q_pad.reshape([b * sq, heads, _KERNEL_LATENT]),
+                    kv_pad.reshape([b * skv, _KERNEL_LATENT]),
+                    out.reshape([b * sq, heads, _KERNEL_LATENT]),
+                    dout.reshape([b * sq, heads, _KERNEL_LATENT]),
+                    lse.reshape([b * sq, heads]),
+                    sink,
+                    idxs_flat,
+                    softmax_scale=scale,
+                    topk_length=_csa_compute_topk_length(idxs_flat),
+                )
+                self.assertEqual(
+                    float(dq[:, :, hn:].abs().max()), 0.0, "bwd dq"
+                )
+                self.assertEqual(float(dkv[:, hn:].abs().max()), 0.0, "bwd dkv")
+
+
+@unittest.skipUnless(
+    paddle.is_compiled_with_cuda(), "sub-512 latent tests require CUDA"
+)
+class TestSubLatentWithSubTileHeads(unittest.TestCase):
+    """The ernielite exp2 layer: 24 heads AND a 256 latent, both padded."""
+
+    @classmethod
+    def setUpClass(cls):
+        _skip_without_cudnn_sparse_bwd()
+
+    def test_head_and_latent_padding_compose(self):
+        for heads in (24, 32):
+            for b, sq, skv, topk, inv, name in _SHAPES:
+                with self.subTest(heads=heads, shape=name):
+                    args = _make_inputs(b, sq, skv, heads, 256, topk, inv)
+                    ref = _run(*args, backend="unfused", grad_seed=7)
+                    got = _run(*args, backend="cudnn", grad_seed=7)
+                    for key, ceiling in _REL_L2_CEILING.items():
+                        self.assertLess(
+                            _rel_l2(got[key], ref[key]),
+                            ceiling,
+                            f"{key} at heads={heads} shape={name}",
+                        )
+
+    def test_head_and_latent_padding_compose_with_sink_sweep(self):
+        """Both paddings active *and* a degenerate sink, which is the case where
+        a leak between the padded head rows and the padded latent columns would
+        be easiest to miss: the padded heads carry a -1e30 sink while the real
+        heads carry an extreme one."""
+        for sink in (20.0, -1e4, "split"):
+            with self.subTest(sink=sink):
+                args = _make_inputs(1, 128, 512, 24, 256, 192, 0.2, sink=sink)
+                ref = _run(*args, backend="unfused", grad_seed=7)
+                got = _run(*args, backend="cudnn", grad_seed=7)
+                for key, ceiling in _REL_L2_CEILING.items():
+                    self.assertLess(
+                        _rel_l2(got[key], ref[key]),
+                        ceiling,
+                        f"{key} at sink={sink}",
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### PR Category

Distributed Strategy

### PR Types

New features

### Description

接 #1822。FlashMLA 的 sparse prefill 要求 `d_qk ∈ {512, 576}` 且 `d_v == 512`（`csrc/api/sparse_fwd.h:158-159`），而 CSA 这条路径是**对称**调用的（`d_v` 默认取 query 的最后一维），所以 `v_head_dim = 256` 的 HCA / CSA 层此前被直接拒掉：

```
RuntimeError: Invalid d_qk: 256  [FlashMLA/csrc/api/sparse_fwd.h:158]
```

cuDNN DSA 反向同样是 512 形状的：其 SM100 kernel 把 `dQ` / `dKV` 手工展开成恰好四个 128 列的 sub-tile。本 PR 让 `csa_sparse_attn` 的 `cudnn` 后端支持任意 ≤512 的 latent 宽度。

**补零到 512。** `kv` 是单个 latent head，同时充当 key 和 value，因此 q 与 kv 两侧同时补零后：

- `scores = q·k` 新增项都是 `0 * 0`，score **逐位不变**，softmax、`lse`、sink 也随之不变；
- `out = Σ p_j · kv_j` 在补出来的列上恒为 0，切回 `hn` 不丢任何信息；
- 反向同理，`dq = Σ dp_j · kv_j` 与 `dkv = Σ p_j · dout_j` 在补出来的列上为 0（`dout` 也补零），`d_sink` 完全不受影响。

这是**精确**的，不是近似。`hn == 512` 的路径逐位不变 —— `_pad_latent_dim` 直接返回入参，一次拷贝都没有。

**不额外占显存。** 存给反向的张量一律是真实宽度，反向自己重新 pad，所以 activation 显存维持在 `hn`。这一点与 #1822 的 head padding 不同：那里 SM90 路径必须存 tile 宽的。

**代价。** 两个 GEMM 都按 512 列跑 `hn` 个真实列。

**精度实测**（对 fp32 `unfused` 参考，随机 `dO`，在 dense / 30% `-1` holes / batch2 topk192 / 8192 长 kv / 单 token 五种 shape 上取最坏 rel-L2）：

| hn | out | dq | dkv | d_sink |
|---|---|---|---|---|
| 512（原生基线） | 2.39e-3 | 2.77e-3 | 3.22e-3 | 3.47e-3 |
| 256 | 2.34e-3 | 2.92e-3 | 3.23e-3 | 3.90e-3 |
| 384 | 2.37e-3 | 2.82e-3 | 3.25e-3 | 3.89e-3 |
| 128 | 2.40e-3 | 3.13e-3 | 3.26e-3 | 2.87e-3 |

补零后的误差与原生 512 同一水平，即 padding 没有带来任何超出 bf16 噪声的误差。64 / 192 / 320 / 448 以及非 64 倍数的宽度（100 / 200 / 260）同样验证通过。

反向测试统一用**随机 `dO`** 而非 `out.sum()`：后者 `dO` 全为 1，每个 latent 列梯度相同，`dO` 补错一端或 `dq` / `dkv` 切错一侧都发现不了。

**测试。** 新增 `tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_sub_512_latent.py`（12 个用例），固定住：

- 各 shape、各宽度下与 fp32 参考的一致性，且精度不比 `hn=512` 基线差；
- 两个 kernel 输出的补零列**严格为 0**（不是容差内），前向 `out`、反向 `dq` / `dkv` 都直接在 kernel 边界上断言；
- kernel 收到的确实是 512 列且 `hn` 以上全零，且 entry point 返回的就是 kernel 输出切片后的**逐位**结果（用 spy 拦截 kernel 调用，而不是在外面另搭一条 pipeline —— 前向还会预压实 `topk_idxs` 并自行推导 `topk_length`，在外面复现会改变求和顺序而不再逐位相等）；
- 前向确定性（该层在 `recompute_modules=["full_attn", ...]` 下前向会执行两次）；
- sink 幅度扫描，含退化的 -1e4（此时两侧 `d_sink` 都恰好为 0）与 per-head split sink；
- 与 #1822 的 sub-tile head padding 叠加（24 / 32 head + 256 latent，即 ernielite 的实际层形状），并在两种 padding 同时生效时再叠加退化 sink；
- `>512` 的拒绝路径。

`test_csa_sparse_attn_backends.py` 补上其手搓反向 ctx 现在需要的 `kernel_hn` 字段。

本地在 `release/0.4` 最新 tip 上，`tests/single_card_tests/ai_edited_test/fusions/` 下三个 `test_csa_sparse_attn_*` 文件共 58 个用例全部通过（1 个 skip 为上游自带的跳过条件）。机器为 SM100（B30Z, CC 10.3）；**SM90 未验证**。

Merged in dev: #1235

### 是否引起精度变化

否
