### PR TITLE
[release/0.4][CSA] Un-pad sparse-attn output with a single row gather

### DIFF
--- a/src/paddlefleet/fusions/csa_sparse_attn.py
+++ b/src/paddlefleet/fusions/csa_sparse_attn.py
@@ -26,6 +26,7 @@ Head counts below a kernel tile are supported by zero-padding, see
 """
 
 import functools
+import math
 
 import paddle
 from paddle import Tensor
@@ -59,36 +60,65 @@ def _dsa_head_tile(num_heads: int) -> int:
 
 
 @functools.lru_cache(maxsize=16)
-def _real_head_rows(num_tokens: int, num_heads: int, head_tile: int) -> Tensor:
-    """Row ids of the real heads in a ``[num_tokens * head_tile, hn]`` view.
+def _real_rows(
+    num_tokens: int, num_heads: int, head_tile: int, keep: int, total: int
+) -> Tensor:
+    """Row ids of the real data in a ``[num_tokens * head_tile * total, g]`` view.
+
+    Of every ``head_tile`` head rows the first ``num_heads`` are real, and of
+    every ``total`` latent chunks the first ``keep`` are real; the rest is the
+    zero padding added on the way into the kernel.
 
     Cached because it only depends on the shape. One entry is
-    ``num_tokens * num_heads`` int32 (1 MiB at 8k tokens x 32 heads), and a
-    process only ever sees one device, so a plain shape-keyed cache is enough.
+    ``num_tokens * num_heads * keep`` int32 (0.75 MiB at 8k tokens x 24 heads
+    x 1 chunk), and a process only ever sees one device, so a plain shape-keyed
+    cache is enough.
     """
+    head_rows = (
+        paddle.arange(num_tokens, dtype="int32") * (head_tile * total)
+    ).unsqueeze(1) + (
+        paddle.arange(num_heads, dtype="int32") * total
+    ).unsqueeze(0)
     return (
-        (paddle.arange(num_tokens, dtype="int32") * head_tile).unsqueeze(1)
-        + paddle.arange(num_heads, dtype="int32").unsqueeze(0)
+        head_rows.reshape([-1, 1])
+        + paddle.arange(keep, dtype="int32").unsqueeze(0)
     ).flatten()
 
 
-def _drop_padded_head_rows(x: Tensor, num_heads: int, head_tile: int) -> Tensor:
-    """Keep the first ``num_heads`` of every ``head_tile`` head-rows of ``x``.
+def _drop_padded_rows(
+    x: Tensor, num_heads: int, head_tile: int, hn: int
+) -> Tensor:
+    """Undo ``_pad_query_heads`` / ``_pad_latent_dim`` on a kernel output.
 
-    ``x`` is any tensor whose last axis is the head dim and whose remaining
-    axes flatten to ``num_tokens * head_tile`` rows.
+    ``x`` is ``[..., head_tile, x.shape[-1]]``; the result is
+    ``[..., num_heads, hn]``, i.e. the padded head rows *and* the padded latent
+    columns are dropped. Returns ``x`` untouched when there is no padding.
 
-    Implemented as a row ``gather`` rather than a slice: both move the same
-    bytes, but Paddle's strided-slice copy runs at roughly a quarter of the
-    achievable bandwidth here while ``gather`` saturates it (measured on B30Z at
-    8192 tokens x 64->32 heads x 512: 0.53 ms for ``x[:, :h*hn]``, 0.11 ms for
-    the gather).
+    Both drops are done by a *single* row ``gather`` rather than by a strided
+    slice per axis. The slice moves the same bytes but Paddle's strided-slice
+    copy runs at roughly a quarter of the achievable bandwidth, and doing the
+    latent axis first also materialises a full-head-tile intermediate. Measured
+    on B30Z at the HCA shape (8192 tokens, 64->24 heads, 512->256 latent, so a
+    512 MiB kernel output): 0.803 ms for ``x[..., :hn].contiguous()`` followed
+    by a head-row gather (704 MiB moved), 0.045 ms for the fused gather
+    (192 MiB moved) -- a 17x saving on what is otherwise ~half of the forward.
+
+    Chunking is by ``gcd(hn, kernel_hn)`` so that keeping the first ``hn``
+    columns is expressible as keeping whole rows, which holds for any width the
+    kernel is padded from (512/256 -> one 256-wide row of two, 512/384 -> three
+    128-wide rows of four).
     """
-    hn = x.shape[-1]
-    rows = x.reshape([-1, hn])
-    num_tokens = rows.shape[0] // head_tile
-    idx = _real_head_rows(num_tokens, num_heads, head_tile)
-    return paddle.gather(rows, idx, axis=0)
+    kernel_hn = x.shape[-1]
+    if num_heads == head_tile and hn == kernel_hn:
+        return x
+    g = math.gcd(hn, kernel_hn)
+    total = kernel_hn // g
+    rows = x.reshape([-1, g])
+    num_tokens = rows.shape[0] // (head_tile * total)
+    idx = _real_rows(num_tokens, num_heads, head_tile, hn // g, total)
+    return paddle.gather(rows, idx, axis=0).reshape(
+        [*x.shape[:-2], num_heads, hn]
+    )
 
 
 @functools.cache
@@ -436,9 +466,10 @@ class CSASparseAttention(paddle.autograd.PyLayer):
         )
         # Latent width the kernels are driven with. Both the FlashMLA forward
         # and the cuDNN backward only exist at 512, so a narrower layer is
-        # zero-padded up to it on the way in and sliced back on the way out.
-        # Unlike the head padding above this never changes what is saved for
-        # backward, so it costs no activation memory.
+        # zero-padded up to it on the way in and dropped again on the way out
+        # (fused with the head-row drop, see ``_drop_padded_rows``). Unlike the
+        # head padding above this never changes what is saved for backward, so
+        # it costs no activation memory.
         ctx.kernel_hn = _dsa_latent_dim(hn) if backend == "cudnn" else hn
         if backend == "cudnn":
             from paddlefleet.cudnn_ops.attn.csa_sparse_attn_fwd_cudnn import (
@@ -458,24 +489,29 @@ class CSASparseAttention(paddle.autograd.PyLayer):
                 topk_length=topk_length,
                 indexer_topk=indexer_topk,
             )
-            if ctx.kernel_hn != hn:
-                # The padded latent columns of the output are exactly zero.
-                output = output[..., :hn].contiguous()
-            output_real, lse_real = output, lse
             if head_tile != np_heads:
-                output_real = _drop_padded_head_rows(
-                    output, np_heads, head_tile
-                ).reshape([b, sq, np_heads, hn])
                 lse_real = lse[:, :, :np_heads].contiguous()
                 if lse_indexer is not None:
                     lse_indexer = lse_indexer[:, :, :np_heads].contiguous()
+            else:
+                lse_real = lse
             if ctx.bwd_heads == np_heads:
-                # The backward runs on the real heads, so the padded forward
-                # tensors are dropped here instead of being kept alive until
-                # backward.
+                # The backward runs on the real heads, so nothing padded has to
+                # stay alive: one gather takes the kernel output straight to the
+                # real shape (see ``_drop_padded_rows``).
+                output_real = _drop_padded_rows(
+                    output, np_heads, head_tile, hn
+                ).reshape([b, sq, np_heads, hn])
                 save_q, save_sink = query, attn_sink
                 save_out, save_lse = output_real, lse_real
             else:
+                # SM90 padded backward: the saved ``out`` must stay one head
+                # tile wide, so only the padded latent columns come off it, and
+                # the head rows are dropped from that narrower copy.
+                output = _drop_padded_rows(output, head_tile, head_tile, hn)
+                output_real = _drop_padded_rows(
+                    output, np_heads, head_tile, hn
+                ).reshape([b, sq, np_heads, hn])
                 save_q, save_sink = q_in, sink_in
                 save_out, save_lse = output, lse
             CSASparseAttention._lse_indexer = lse_indexer
@@ -581,17 +617,18 @@ class CSASparseAttention(paddle.autograd.PyLayer):
                 topk_length=topk_length,
             )
             if ctx.kernel_hn != hn:
-                # ``dq`` / ``dkv`` are exactly zero over the padded columns.
-                dq_flat = dq_flat[..., :hn].contiguous()
+                # ``dkv`` is exactly zero over the padded columns. It is one
+                # latent head (no head padding to undo) and ~8 MiB, so a slice
+                # is fine here.
                 dkv_flat = dkv_flat[..., :hn].contiguous()
             dkv = dkv_flat.reshape(kv_full.shape)
+            # ``dq`` is exactly zero over the padded latent columns and its
+            # padded head rows are unused, so one gather drops both.
+            dq = _drop_padded_rows(dq_flat, np_heads, kh, hn).reshape(
+                [b, sq, np_heads, hn]
+            )
             if kh != np_heads:
-                dq = _drop_padded_head_rows(dq_flat, np_heads, kh).reshape(
-                    [b, sq, np_heads, hn]
-                )
                 d_sink = d_sink[:np_heads]
-            else:
-                dq = dq_flat.reshape([b, sq, np_heads, hn])
             d_attn_sink = d_sink.reshape([np_heads]).cast(ctx.attn_sink_dtype)
         else:
             from paddlefleet.tilelang_ops.attn import sparse_mqa_bwd

--- a/tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_sub_512_latent.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_sub_512_latent.py
@@ -520,5 +520,72 @@ class TestSubLatentWithSubTileHeads(unittest.TestCase):
                     )
 
 
+class TestFusedUnpad(unittest.TestCase):
+    """``_drop_padded_rows`` must equal the per-axis slice + head gather.
+
+    The un-pad is a single row ``gather`` instead of a strided latent slice
+    followed by a head-row gather, because Paddle's strided-slice copy runs at
+    roughly a quarter of the achievable bandwidth and doing the latent axis
+    first also materialises a full-head-tile intermediate (measured on B30Z at
+    the HCA shape -- 8192 tokens, 64->24 heads, 512->256 latent: 0.803 ms and
+    704 MiB moved for the two-step form, 0.045 ms and 192 MiB for the fused
+    gather). It is a pure data movement, so it must agree bit-for-bit.
+    """
+
+    @staticmethod
+    def _per_axis(x, num_heads, head_tile, hn):
+        """The straightforward form: slice the latent axis, gather head rows."""
+        if hn != x.shape[-1]:
+            x = x[..., :hn].contiguous()
+        if num_heads == head_tile:
+            return x
+        rows = x.reshape([-1, hn])
+        idx = (
+            (
+                paddle.arange(rows.shape[0] // head_tile, dtype="int32")
+                * head_tile
+            ).unsqueeze(1)
+            + paddle.arange(num_heads, dtype="int32").unsqueeze(0)
+        ).flatten()
+        return paddle.gather(rows, idx, axis=0).reshape(
+            [*x.shape[:-2], num_heads, hn]
+        )
+
+    def test_matches_the_per_axis_form(self):
+        from paddlefleet.fusions.csa_sparse_attn import _drop_padded_rows
+
+        paddle.seed(3)
+        # (num_heads, head_tile): both kernel tiles, padded and exact; latents:
+        # the divisible widths, a non-divisible one (384, which chunks by
+        # gcd(384, 512) = 128) and the native 512.
+        for num_heads, head_tile in ((24, 64), (32, 64), (64, 64), (96, 128)):
+            for hn in (*_LATENTS, _KERNEL_LATENT):
+                # 4-D as the forward sees it, 3-D as the backward's dq is.
+                for shape in (
+                    [2, 37, head_tile, _KERNEL_LATENT],
+                    [61, head_tile, _KERNEL_LATENT],
+                ):
+                    with self.subTest(heads=num_heads, hn=hn, ndim=len(shape)):
+                        x = paddle.randn(shape).cast("bfloat16")
+                        got = _drop_padded_rows(x, num_heads, head_tile, hn)
+                        ref = self._per_axis(x, num_heads, head_tile, hn)
+                        self.assertEqual(tuple(got.shape), tuple(ref.shape))
+                        self.assertEqual(
+                            float(
+                                (got.cast("float32") - ref.cast("float32"))
+                                .abs()
+                                .max()
+                            ),
+                            0.0,
+                        )
+
+    def test_unpadded_is_copy_free(self):
+        """No padding on either axis must return the input untouched."""
+        from paddlefleet.fusions.csa_sparse_attn import _drop_padded_rows
+
+        x = paddle.randn([2, 4, 64, _KERNEL_LATENT]).cast("bfloat16")
+        self.assertIs(_drop_padded_rows(x, 64, 64, _KERNEL_LATENT), x)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### PR Category

Performance Optimization

### PR Types

Performance

### Description

接 #1822、#1832。

> 对应的 dev PR：**没有**。develop 上不存在这条代码路径 —— #1822 的 sub-tile head 支持和 #1832 的 sub-512 latent 支持目前只在 release/0.4 上（develop 的 `csa_sparse_attn.py` 里没有 `_pad_query_heads` / `_pad_latent_dim` / `_drop_padded_head_rows`），而本 PR 优化的正是其中的去 padding 环节，所以无从先合 develop 再 cherry-pick。`Validate Dev PR` 这项检查请 reviewer 判断是否 bypass；如果需要，我可以把 #1822 + #1832 + 本 PR 一并往 develop 上做一次移植。

## 问题

HCA 这条路上 sparse-attn kernel 被按比层本身更宽的形状驱动：FlashMLA 的 sparse prefill 只有 64 / 128 两种 query-head tile 且要求 `d_v == 512`，cuDNN 的 DSA 反向也是 512 形状的。于是一个 24 head、`v_head_dim = 256` 的层进 kernel 前被补零到 64 head × 512 latent，出来后每个 kernel 输出都要在两个轴上去 padding。

原来的做法是先在 latent 轴上做 strided slice，再 gather head 行。两个问题：

- Paddle 的 strided-slice 拷贝只跑到可达 HBM 带宽的约四分之一。`b=1, sq=8192` 时前向输出是 `[1, 8192, 64, 512]` bf16、512 MiB，单是 `out[..., :hn].contiguous()` 就要 0.758 ms，**占整个 1.63 ms 前向的约 47%**。
- 先切 latent 轴会物化一个整 tile 宽的中间结果，也就是补出来的 head 行被从 HBM 读出来之后才丢掉：为了产出 192 MiB 的结果搬了 704 MiB。

## 改动

`_drop_padded_rows` 取代 `_drop_padded_head_rows`，用**一次**整行 `paddle.gather` 同时完成两个轴的丢弃。行按 `gcd(hn, kernel_hn)` 切分，这样"保留前 `hn` 列"就等价于"保留整行"，对 kernel 可能补零的任意宽度都成立（512/256 → 两行 256 宽里取一行；512/384 → 四行 128 宽里取三行）。索引张量只依赖 shape，所以做了 `lru_cache`。

两处去 padding 都换掉了：前向输出，以及反向的 `dq`。`dkv` 保留 slice —— 它只有一个 latent head、约 8 MiB，不值得为它建索引。两个轴都没有 padding 时 helper 原样返回入参，所以非 HCA 层和 absorbed-MLA 层（`csa_compress_ratios = -2`，此时 `hn == kv_lora_rank == 512`）逐位不变、一次拷贝都没有。

## 性能

SM100 ，`b=1, sq=8192, skv=8256, topk=192`，bf16，24 head，`hn=256`，即 ernielite HCA 层的真实形状。

| | 改前 | 改后 |
|---|---|---|
| 前向去 padding | 0.803 ms，搬 704 MiB | **0.045 ms，搬 192 MiB** |
| 反向 `dq` 去 padding | 0.244 ms | **0.045 ms** |

`csa_sparse_attn` 端到端：

| | 改前 | 改后 | |
|---|---|---|---|
| 前向 | 3.803 ms | 2.112 ms | **-44%** |
| 反向 | 4.975 ms | 4.035 ms | **-19%** |
| 前+反 | 8.778 ms | 6.147 ms | **-30%** |

（端到端的绝对值是在 GPU 被别的任务占用的情况下测的，所以偏大；无 padding 的对照组（64 head / `hn=512`，helper 在那里是 no-op）两次运行相差 <1%，所以 A/B 有效。）

## 正确性

纯数据搬运，所以必须逐位一致，实测也是：

- `_drop_padded_rows` 与逐轴 slice+gather 的结果对比：在两种 kernel tile（64、128）、补齐与恰好的 head 数、可整除与不可整除的 latent 宽度（256/384/128/512）、3 维与 4 维输入上全部逐位相同。这就是新加的 `TestFusedUnpad`，另外还在仓库外跑了一遍 60 种 shape 的扫描。
- 端到端前反向在五种配置（HCA-exp2、`hn=384`、无 latent padding、无 head padding、无 padding）上对比改前实现：`out`、`dq`、`d_sink` 逐位相同。`dkv` 最大差 0.0156（bf16），这是 cuDNN 反向自身 atomics 累加的 run-to-run 噪声 —— 同一份代码跑两遍也是同样量级，包括 helper 完全不起作用的无 padding 对照组。
- 单卡 CSA fusion 测试通过，除了两个既有的 flaky（`TestPaddedLatentColumnsAreZero`、`TestBackwardHeadWidth`）：它们直接调 kernel、根本走不到 `_drop_padded_rows`，断言的是 cuDNN 后端**未初始化**的那部分 `dq`，因此对 allocator 状态敏感。失败数不高于改动前的干净代码。

### 是否引起精度变化

否
