### PR TITLE
[CSA] Keep the sparse-attn backward on the kernel head tile

### DIFF
--- a/src/paddlefleet/fusions/csa_sparse_attn.py
+++ b/src/paddlefleet/fusions/csa_sparse_attn.py
@@ -125,24 +125,47 @@ def _drop_padded_rows(
 def _dsa_bwd_runs_sub_tile_heads(num_heads: int) -> bool:
     """Whether the cuDNN DSA backward accepts this head count below its tile.
 
-    ``flash_attn_bwd_sm100`` derives ``num_head_blocks = ceil(num_head / 64)``
-    and predicates the partial tile, so SM100 returns exactly the same ``dq`` /
-    ``d_sink`` for ``h`` real heads as for the zero-padded problem (verified
-    bit-identical for h=24/32/40/96; ``dkv`` matches to the usual atomic noise).
-    That lets the backward -- the expensive half -- skip the padding entirely,
-    which also keeps the saved ``q``/``out`` at the real head count.
+    Running the backward -- the expensive half -- on the real head count skips
+    the padding entirely and keeps the saved ``q``/``out`` at the real width.
+    That is only safe when ``num_heads`` is a multiple of the kernel's 64-head
+    tile, so in practice it never fires below a tile and the caller pads.
 
-    Two exclusions fall back to the padded (always even, tile-wide) path:
+    ``dsa_bwd_sm100.py`` requires ``num_head % 64 == 0`` and does not check it:
 
-    * **odd head counts**: the kernel reads the ``[N, H]`` fp32 LSE / sum(OdO)
-      rows with a 2-float vector access, so an odd ``H`` leaves every other row
-      only 4-byte aligned and the kernel dies with CUDA 716 (misaligned
-      address). Measured: 31/33/35/63/65 crash, 34/62/66/96/126 are fine.
-    * **SM90**: its kernel packs heads differently
-      (``qhead_per_kvhead`` tiling) and is not validated here.
+    * ``_get_workspace_size_LSE_OdO`` (``:175-183``) sizes ``workspace_LSE_OdO``
+      as ``(b, h, round_up(q, 8), 8)`` and splits it into back-to-back
+      ``sum_OdO`` / ``scaled_lse`` views of ``H * Q * 4`` bytes each -- **zero
+      slack**, with ``scaled_lse`` ending at the allocation end.
+    * Both views declare ``cute.assume(H, divby=64)`` (``:229``/``:233``).
+      Violating a ``cute.assume`` is UB, not an error: a dynamic ``Integer``
+      goes to ``ConstrainedIntType`` unchecked, so the kernel compiles happily.
+    * ``:1176-1207`` tiles the **head** mode by 64 (``cute.flat_divide``, see
+      the ``# (64, 1, M, B)`` comment) and issues an **unpredicated**
+      32-thread x 2-value ``cp.async``, i.e. 64 fp32 / 256 B. With ``H = 24``
+      only 96 B of each tile is in bounds, so the last query token reads 160 B
+      and the second-to-last 64 B past the end of the allocation.
+
+    It is an out-of-bounds **read**, so results stay correct (shape-preserving
+    canaries on both workspaces come back untouched and ``dq`` is
+    bit-identical); the failure mode is ``CUDA error(700)`` whenever those
+    160 B happen to land on an unmapped page. That depends only on the
+    allocator layout -- deterministic per layout, a lottery across layouts --
+    which is why short runs can look clean while the access is always OOB.
+    Measured on B30Z / SM100 at ``total_S_q=32768``: ``H`` 16 / 24 / 32 / 48
+    fault, ``H`` 64 / 128 pass even with zero mapped headroom.
+    Odd ``H`` is the same access failing earlier, at 8-byte alignment
+    (``CUDA 716``), and is covered by the same condition.
+
+    Revert to ``num_heads % 2 == 0`` once the kernel either predicates those
+    two tile loads or over-allocates ``workspace_LSE_OdO`` (bumping its ``q``
+    extent by 64 -- 12 KiB at ``H=24`` -- is enough; both fixes were verified
+    to leave ``dq`` bit-identical).
+
+    SM90 is excluded separately: its kernel packs heads differently
+    (``qhead_per_kvhead`` tiling) and is not validated here.
     """
     major, _ = paddle.device.cuda.get_device_capability()
-    return major >= 10 and num_heads % 2 == 0
+    return major >= 10 and num_heads % 64 == 0
 
 
 def _pad_query_heads(query: Tensor, attn_sink: Tensor, head_tile: int):
@@ -307,9 +330,18 @@ def _csa_compute_topk_length(topk_idxs_flat: Tensor) -> Tensor:
 
     Returns ``[N]`` int32 = (index of last valid entry + 1) per row, i.e. a SAFE
     upper bound: all valid entries lie in ``[0, topk_length)``. Uses the trailing
-    bound (NOT ``sum(valid)``) so it stays correct when ``-1`` entries are
+    bound (NOT ``sum(valid)``) so the bound stays valid when ``-1`` entries are
     interleaved (multi-doc leading/interior holes). Clamped to >=1 so the kernel
     writes every dq row (dq is allocated uninitialized in the backend).
+
+    WARNING: this bound is only safe for the FORWARD kernel, which predicates
+    ``-1`` slots. Feeding it to ``csa_sparse_attn_bwd_cudnn`` together with a
+    holey ``topk_idxs`` selects the backward's compact KV-load path, which is
+    unguarded against interior ``-1`` (see ``_csa_compact_topk_idxs``) and
+    gathers ``mKV[-1]``. Observed consequences: ``CUDA error(700)``, nan/inf, or
+    a silent ~50% error in dq/dkv while the forward output stays correct. For the
+    backward, either compact the indices with ``_csa_compact_topk_idxs`` and pass
+    the exact count it returns, or pass ``topk_length=None``.
 
     Args:
         topk_idxs_flat: ``[N, W]`` int32 global indices, -1 == invalid.
@@ -455,9 +487,10 @@ class CSASparseAttention(paddle.autograd.PyLayer):
 
         # Heads the kernels are driven with. The FlashMLA forward only has 64-
         # and 128-head tiles, so a smaller layer is zero-padded up to one; the
-        # cuDNN backward takes the real count on SM100 and only needs the same
-        # padding on SM90. ``ctx.bwd_heads`` records which width the tensors
-        # saved below are in.
+        # backward needs the same padding unless the head count already is a
+        # multiple of the kernel's 64-head tile (see
+        # ``_dsa_bwd_runs_sub_tile_heads``). ``ctx.bwd_heads`` records which
+        # width the tensors saved below are in.
         head_tile = _dsa_head_tile(np_heads) if backend == "cudnn" else np_heads
         ctx.bwd_heads = (
             np_heads
@@ -505,8 +538,8 @@ class CSASparseAttention(paddle.autograd.PyLayer):
                 save_q, save_sink = query, attn_sink
                 save_out, save_lse = output_real, lse_real
             else:
-                # SM90 padded backward: the saved ``out`` must stay one head
-                # tile wide, so only the padded latent columns come off it, and
+                # Padded backward: the saved ``out`` must stay one head tile
+                # wide, so only the padded latent columns come off it, and
                 # the head rows are dropped from that narrower copy.
                 output = _drop_padded_rows(output, head_tile, head_tile, hn)
                 output_real = _drop_padded_rows(
@@ -546,8 +579,8 @@ class CSASparseAttention(paddle.autograd.PyLayer):
     def backward(ctx, grad_output):
         query, kv_full, attn_sink, topk_idxs, output, lse = ctx.saved_tensor()
         b, sq, np_heads, hn = ctx.query_shape
-        # Kernel-side head count: equal to ``np_heads`` except on the SM90
-        # padded path, where the saved tensors are one head tile wide.
+        # Kernel-side head count: equal to ``np_heads`` except on the padded
+        # path, where the saved tensors are one head tile wide.
         kh = ctx.bwd_heads
 
         if ctx.backend == "cudnn":
@@ -559,7 +592,7 @@ class CSASparseAttention(paddle.autograd.PyLayer):
             _, s_kv, dkv_dim = kv_full.shape
 
             if kh != np_heads:
-                # SM90 padded path: widen the incoming gradient to the saved
+                # Padded path: widen the incoming gradient to the saved
                 # tensors' head tile. The padded rows get a zero gradient, so
                 # they add nothing to ``dkv`` / ``d_sink``.
                 grad_output = paddle.concat(

--- a/tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_sub_512_latent.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_sub_512_latent.py
@@ -433,10 +433,7 @@ class TestPaddedLatentColumnsAreZero(unittest.TestCase):
         from paddlefleet.cudnn_ops.attn.csa_sparse_attn_fwd_cudnn import (
             flash_mla_sparse_attn,
         )
-        from paddlefleet.fusions.csa_sparse_attn import (
-            _csa_compute_topk_length,
-            _pad_latent_dim,
-        )
+        from paddlefleet.fusions.csa_sparse_attn import _pad_latent_dim
         from paddlefleet.fusions.csa_sparse_attn_utils import (
             _local_to_global_flat,
         )
@@ -470,7 +467,13 @@ class TestPaddedLatentColumnsAreZero(unittest.TestCase):
                     sink,
                     idxs_flat,
                     softmax_scale=scale,
-                    topk_length=_csa_compute_topk_length(idxs_flat),
+                    # Holey indices plus the trailing bound of
+                    # ``_csa_compute_topk_length`` would take the backward's
+                    # unguarded compact KV-load path; ``None`` keeps the guarded
+                    # full-width path. This case only asserts that the padded
+                    # latent columns stay zero, so the early-stop is not needed
+                    # -- use ``_csa_compact_topk_idxs`` where it is.
+                    topk_length=None,
                 )
                 self.assertEqual(
                     float(dq[:, :, hn:].abs().max()), 0.0, "bwd dq"

--- a/tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_sub_tile_heads.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_sub_tile_heads.py
@@ -378,10 +378,17 @@ class TestBackwardHeadWidth(unittest.TestCase):
         _skip_without_cudnn_sparse_bwd()
 
     def _bwd(self, q, kv, out, dout, lse, sink, gidx, scale, num_heads):
-        from paddlefleet.fusions.csa_sparse_attn import _csa_compute_topk_length
+        from paddlefleet.fusions.csa_sparse_attn import _csa_compact_topk_idxs
 
         b, sq = q.shape[0], q.shape[1]
         s_kv = kv.shape[1]
+        # The backward's compact KV-load path is unguarded against interior -1,
+        # so ``topk_length`` must come from compacted indices (production does
+        # the same in ``csa_attention.py``). Passing the trailing bound of
+        # ``_csa_compute_topk_length`` together with holey indices corrupts
+        # dq/dkv by ~50%, or raises CUDA 700 / yields nan. Compacting is
+        # order-preserving, so the bit-exact assertions below still hold.
+        gidx, topk_length = _csa_compact_topk_idxs(gidx)
         return csa_sparse_attn_bwd_cudnn(
             q.reshape([b * sq, num_heads, _D]),
             kv.reshape([b * s_kv, _D]),
@@ -391,7 +398,7 @@ class TestBackwardHeadWidth(unittest.TestCase):
             sink,
             gidx,
             softmax_scale=scale,
-            topk_length=_csa_compute_topk_length(gidx),
+            topk_length=topk_length,
         )
 
     def test_real_head_count_matches_the_padded_backward(self):


### PR DESCRIPTION
### PR Category

Operator Mechanism

### PR Types

Bug fixes

### Description

Merged in dev: #1836

Backport of #1836 to `release/0.4`. Same three fixes, same files.

Three fixes around the cuDNN sparse-attention backward, all in the CSA wrapper
and its tests. No kernel, no config default, and no production call site changes
behaviour.

#### 1. Keep the sparse-attn backward on the kernel head tile

`_dsa_bwd_runs_sub_tile_heads` gated the real-head-count (sub-tile) backward on
`num_heads % 2 == 0`. On SM100 that path drives the cuDNN kernel at a head count
the kernel does not support, and it reads out of bounds.

Root cause is in the kernel, not here. `dsa_bwd_sm100.py`
(cudnn-frontend submodule) sizes `workspace_LSE_OdO` as
`(b, h, round_up(q, 8), 8)` with **zero slack** for the two back-to-back
`(H, (Q, 1))` views it carves out of it (`sum_OdO`, `scaled_lse`). Both views
declare `cute.assume(H, divby=64)`. The consumer then tiles the *head* mode by
64 (`cute.flat_divide`) and issues an **unpredicated** 32-thread x 2-value
`cp.async`, i.e. an unconditional 64-element / 256-byte load. At `H = 24` only
96 bytes are in bounds, so the last query token over-reads 160 bytes past the
workspace and the second-to-last over-reads 64 bytes.

Every *other* 64-head-tiled access in that kernel goes through TMA and is
hardware-clipped against the tensormap's `globalDim`, which is why only this one
access is exposed. The SM90 kernel is fully predicated and has no such
workspace.

It is a **read**, so results stay correct; `CUDA error(700)` fires only when
those bytes land on an unmapped page, which makes it an allocator-layout
lottery. Measured at production geometry (`total_S_q = 32768`, `max_topk = 384`)
with allocator arena varied to move the workspace:

| case | ws_LSE_OdO headroom | ws_dKV headroom | result |
|---|---|---|---|
| H=24 as-is | 0 | 0 | CUDA 700 |
| H=24, ws_LSE_OdO over-allocated (view shapes unchanged) | >=256 B | 0 | pass |
| H=24, ws_dKV over-allocated | 0 | 8 MiB | CUDA 700 |
| H=128 as-is | 0 | 0 | pass |
| H=16 / H=48 as-is | 0 | 0 | CUDA 700 |

So the trigger is `num_heads % 64 != 0`, not `num_heads < 64` — H=48 faults too,
and H=128 passes at zero headroom. `compute-sanitizer memcheck --padding 512`
pins it to a single PC, 28 errors, only in blocks 32767 and 32766, offsets
0..152 step 8 (= the 160 B and 64 B above); the same command at H=64 reports 0
errors, which self-calibrates the tool. `dmesg` shows Xid 31
`FAULT_PDE ACCESS_TYPE_VIRT_READ` at a virtual address equal to the end of
`workspace_LSE_OdO`.

The existing docstring described this same access but cut the condition at odd
head counts only, and claimed the kernel "predicates the partial tile" — it does
not. Plain `memcheck` without `--padding` reports 0 violations because it pads
allocations, which perturbs the bug away.

Fix here: gate on `num_heads % 64 == 0`, so H = 16/24/32/48 fall back to the
padded (tile-width) backward. Cost is that the backward runs at 64 heads and the
padded activations stay alive, i.e. the sub-tile backward optimisation is
suspended for those head counts. The docstring records the exact revert
condition: once the kernel predicates those two tile loads, or bumps the `q`
extent of `workspace_LSE_OdO` by 64 (+12 KiB, verified sufficient), this can go
back to `% 2 == 0`.

Verified end to end on an ERNIELite MoE config (H=24, cuDNN backend, mbs=4,
8 GPUs, 12 steps, same data order as the archived baseline): `train_loss`
12.238094 vs 12.238097, max per-step deviation across 8 ranks x 12 steps
4.96e-05, 192 metrics with 0 non-finite. That residual is the dKV `atomicAdd`
floor and is consistent with only widening the backward's head extent while the
padded heads carry `sink = -1e30`. The three allocator layouts that previously
faulted 3/3 now pass 6/6 across H = 24 and 32.

Also corrected three stale comments that described the padded backward as
SM90-only; it is now the SM100 default as well.

#### 2. Two tests violated the `topk_length` calling contract

Passing `topk_length` selects the backward's compact KV-load path, which
unconditionally reads the first `length` columns and has **no guard against
interior `-1`** — it gathers `mKV[-1]`. So `topk_length` is only valid together
with **compacted** indices.

`_csa_compute_topk_length` returns a *trailing* bound, which is safe for the
forward (it predicates `-1` slots) but not for the backward. Two tests passed
that bound alongside holey indices and failed on SM100:

- `test_csa_sparse_attn_sub_tile_heads.py::TestBackwardHeadWidth::test_real_head_count_matches_the_padded_backward`
- `test_csa_sparse_attn_sub_512_latent.py::TestPaddedLatentColumnsAreZero::test_forward_and_backward_leave_padding_at_zero`

Measured, holey indices, cuDNN backward vs the fp32 `unfused` reference:

| shape | A: trailing bound + holey idxs | B: compact + exact count | C: `topk_length=None` |
|---|---|---|---|
| h=24 hn=256 | dq **non-finite** (786432 elements) , dkv 5.045e-01 | dq 2.584e-03, dkv 3.218e-03 | same as B |
| h=24 hn=512 | dq **5.008e-01**, dkv 5.094e-01 | dq 2.616e-03, dkv 3.215e-03 | same as B |
| h=64 hn=128 | dq **4.576e-01**, dkv 5.002e-01 | dq 2.503e-03, dkv 3.249e-03 | same as B |

`out` stays at ~2.3e-03 throughout, so the forward looks healthy while the
backward is wrong — and the observed failure mode varies run to run between
`CUDA error(700)`, nan, inf, and a silent ~50% error, because the gather reads
uninitialised device memory. With no holes, A == B == C, which self-calibrates
the comparison.

Fixes: the head-width test now compacts with `_csa_compact_topk_idxs` and passes
the exact count it returns (order-preserving, so its bit-exact assertions still
hold); the sub-512 test only asserts that padded latent columns stay zero, so it
passes `topk_length=None` and keeps the guarded full-width path.

Production call sites were already correct: `csa_attention.py` compacts before
passing, `csa_sparse_attn.py` only computes a length when `ctx.compacted_idxs`,
and `mqa_sparse_attn.py` passes `None` explicitly.

#### 3. Document the contract

Added a WARNING to `_csa_compute_topk_length`'s docstring stating that its bound
is forward-only, and what happens if it reaches the backward. The previous text
claimed the bound "stays correct when -1 entries are interleaved", which holds
for the forward only and contradicted the correct note further down the file.

### Test

On SM100 (compute capability 10.x), one process per file:

| file | before | after |
|---|---|---|
| `test_csa_sparse_attn_sub_tile_heads.py` | FAIL | 7 passed, 1 skipped, 36 subtests |
| `test_csa_sparse_attn_sub_512_latent.py` | FAIL | 14 passed, 88 subtests |
| `test_csa_sparse_attn_backends.py` | pass | 18 passed, 1 skipped |
| `test_csa_sparse_attn_utils.py` | pass | 19 passed |

The skip in the first file is `TestBackwardHeadWidth`, which by construction
only applies when the sub-tile backward is enabled. Forcing the gate open makes
it run and pass, so the compaction fix in item 2 is exercised either way.
