### PR TITLE
[CSA] Keep the sparse-attn backward on the kernel head tile, and fix two topk_length contract violations

### DIFF
--- a/src/paddlefleet/fusions/csa_sparse_attn.py
+++ b/src/paddlefleet/fusions/csa_sparse_attn.py
@@ -125,24 +125,47 @@ def _drop_padded_rows(
 def _dsa_bwd_runs_sub_tile_heads(num_heads: int) -> bool:
     """Whether the cuDNN DSA backward accepts this head count below its tile.
 
-    ``flash_attn_bwd_sm100`` derives ``num_head_blocks = ceil(num_head / 64)``
-    and predicates the partial tile, so SM100 returns exactly the same ``dq`` /
-    ``d_sink`` for ``h`` real heads as for the zero-padded problem (verified
-    bit-identical for h=24/32/40/96; ``dkv`` matches to the usual atomic noise).
-    That lets the backward -- the expensive half -- skip the padding entirely,
-    which also keeps the saved ``q``/``out`` at the real head count.
+    Running the backward -- the expensive half -- on the real head count skips
+    the padding entirely and keeps the saved ``q``/``out`` at the real width.
+    That is only safe when ``num_heads`` is a multiple of the kernel's 64-head
+    tile, so in practice it never fires below a tile and the caller pads.
 
-    Two exclusions fall back to the padded (always even, tile-wide) path:
+    ``dsa_bwd_sm100.py`` requires ``num_head % 64 == 0`` and does not check it:
 
-    * **odd head counts**: the kernel reads the ``[N, H]`` fp32 LSE / sum(OdO)
-      rows with a 2-float vector access, so an odd ``H`` leaves every other row
-      only 4-byte aligned and the kernel dies with CUDA 716 (misaligned
-      address). Measured: 31/33/35/63/65 crash, 34/62/66/96/126 are fine.
-    * **SM90**: its kernel packs heads differently
-      (``qhead_per_kvhead`` tiling) and is not validated here.
+    * ``_get_workspace_size_LSE_OdO`` (``:175-183``) sizes ``workspace_LSE_OdO``
+      as ``(b, h, round_up(q, 8), 8)`` and splits it into back-to-back
+      ``sum_OdO`` / ``scaled_lse`` views of ``H * Q * 4`` bytes each -- **zero
+      slack**, with ``scaled_lse`` ending at the allocation end.
+    * Both views declare ``cute.assume(H, divby=64)`` (``:229``/``:233``).
+      Violating a ``cute.assume`` is UB, not an error: a dynamic ``Integer``
+      goes to ``ConstrainedIntType`` unchecked, so the kernel compiles happily.
+    * ``:1176-1207`` tiles the **head** mode by 64 (``cute.flat_divide``, see
+      the ``# (64, 1, M, B)`` comment) and issues an **unpredicated**
+      32-thread x 2-value ``cp.async``, i.e. 64 fp32 / 256 B. With ``H = 24``
+      only 96 B of each tile is in bounds, so the last query token reads 160 B
+      and the second-to-last 64 B past the end of the allocation.
+
+    It is an out-of-bounds **read**, so results stay correct (shape-preserving
+    canaries on both workspaces come back untouched and ``dq`` is
+    bit-identical); the failure mode is ``CUDA error(700)`` whenever those
+    160 B happen to land on an unmapped page. That depends only on the
+    allocator layout -- deterministic per layout, a lottery across layouts --
+    which is why short runs can look clean while the access is always OOB.
+    Measured on B30Z / SM100 at ``total_S_q=32768``: ``H`` 16 / 24 / 32 / 48
+    fault, ``H`` 64 / 128 pass even with zero mapped headroom.
+    Odd ``H`` is the same access failing earlier, at 8-byte alignment
+    (``CUDA 716``), and is covered by the same condition.
+
+    Revert to ``num_heads % 2 == 0`` once the kernel either predicates those
+    two tile loads or over-allocates ``workspace_LSE_OdO`` (bumping its ``q``
+    extent by 64 -- 12 KiB at ``H=24`` -- is enough; both fixes were verified
+    to leave ``dq`` bit-identical).
+
+    SM90 is excluded separately: its kernel packs heads differently
+    (``qhead_per_kvhead`` tiling) and is not validated here.
     """
     major, _ = paddle.device.cuda.get_device_capability()
-    return major >= 10 and num_heads % 2 == 0
+    return major >= 10 and num_heads % 64 == 0
 
 
 def _pad_query_heads(query: Tensor, attn_sink: Tensor, head_tile: int):
@@ -307,9 +330,18 @@ def _csa_compute_topk_length(topk_idxs_flat: Tensor) -> Tensor:
 
     Returns ``[N]`` int32 = (index of last valid entry + 1) per row, i.e. a SAFE
     upper bound: all valid entries lie in ``[0, topk_length)``. Uses the trailing
-    bound (NOT ``sum(valid)``) so it stays correct when ``-1`` entries are
+    bound (NOT ``sum(valid)``) so the bound stays valid when ``-1`` entries are
     interleaved (multi-doc leading/interior holes). Clamped to >=1 so the kernel
     writes every dq row (dq is allocated uninitialized in the backend).
+
+    WARNING: this bound is only safe for the FORWARD kernel, which predicates
+    ``-1`` slots. Feeding it to ``csa_sparse_attn_bwd_cudnn`` together with a
+    holey ``topk_idxs`` selects the backward's compact KV-load path, which is
+    unguarded against interior ``-1`` (see ``_csa_compact_topk_idxs``) and
+    gathers ``mKV[-1]``. Observed consequences: ``CUDA error(700)``, nan/inf, or
+    a silent ~50% error in dq/dkv while the forward output stays correct. For the
+    backward, either compact the indices with ``_csa_compact_topk_idxs`` and pass
+    the exact count it returns, or pass ``topk_length=None``.
 
     Args:
         topk_idxs_flat: ``[N, W]`` int32 global indices, -1 == invalid.
@@ -457,9 +489,10 @@ class CSASparseAttention(paddle.autograd.PyLayer):
 
         # Heads the kernels are driven with. The FlashMLA forward only has 64-
         # and 128-head tiles, so a smaller layer is zero-padded up to one; the
-        # cuDNN backward takes the real count on SM100 and only needs the same
-        # padding on SM90. ``ctx.bwd_heads`` records which width the tensors
-        # saved below are in.
+        # backward needs the same padding unless the head count already is a
+        # multiple of the kernel's 64-head tile (see
+        # ``_dsa_bwd_runs_sub_tile_heads``). ``ctx.bwd_heads`` records which
+        # width the tensors saved below are in.
         head_tile = _dsa_head_tile(np_heads) if backend == "cudnn" else np_heads
         ctx.bwd_heads = (
             np_heads
@@ -508,8 +541,8 @@ class CSASparseAttention(paddle.autograd.PyLayer):
                 save_q, save_sink = query, attn_sink
                 save_out, save_lse = output_real, lse_real
             else:
-                # SM90 padded backward: the saved ``out`` must stay one head
-                # tile wide, so only the padded latent columns come off it, and
+                # Padded backward: the saved ``out`` must stay one head tile
+                # wide, so only the padded latent columns come off it, and
                 # the head rows are dropped from that narrower copy.
                 output = _drop_padded_rows(output, head_tile, head_tile, hn)
                 output_real = _drop_padded_rows(
@@ -549,8 +582,8 @@ class CSASparseAttention(paddle.autograd.PyLayer):
     def backward(ctx, grad_output):
         query, kv_full, attn_sink, topk_idxs, output, lse = ctx.saved_tensor()
         b, sq, np_heads, hn = ctx.query_shape
-        # Kernel-side head count: equal to ``np_heads`` except on the SM90
-        # padded path, where the saved tensors are one head tile wide.
+        # Kernel-side head count: equal to ``np_heads`` except on the padded
+        # path, where the saved tensors are one head tile wide.
         kh = ctx.bwd_heads
 
         if ctx.backend == "cudnn":
@@ -562,7 +595,7 @@ class CSASparseAttention(paddle.autograd.PyLayer):
             _, s_kv, dkv_dim = kv_full.shape
 
             if kh != np_heads:
-                # SM90 padded path: widen the incoming gradient to the saved
+                # Padded path: widen the incoming gradient to the saved
                 # tensors' head tile. The padded rows get a zero gradient, so
                 # they add nothing to ``dkv`` / ``d_sink``.
                 grad_output = paddle.concat(

--- a/src/paddlefleet/fusions/csa_sparse_attn.py
+++ b/src/paddlefleet/fusions/csa_sparse_attn.py
@@ -21,7 +21,8 @@ final sparse MQA attention:
   - "cudnn": FlashMLA sparse forward + cuDNN DSA backward
 
 Head counts below a kernel tile are supported by zero-padding, see
-``_pad_query_heads``.
+``_pad_query_heads``. Latent widths below 512 likewise, see
+``_pad_latent_dim``.
 """
 
 import functools
@@ -36,6 +37,10 @@ from paddle import Tensor
 # ``sm100/prefill/sparse/fwd/head64/config.h``), so a layer with fewer heads
 # cannot be given a narrower tile without a new kernel.
 _DSA_HEAD_TILES = (64, 128)
+# The only latent width the FlashMLA sparse prefill and the cuDNN DSA backward
+# accept on this symmetric path; narrower layers are zero-padded up to it, see
+# ``_pad_latent_dim``.
+_DSA_LATENT_DIM = 512
 # Sink logit that makes ``exp(sink - m) -> 0``, i.e. plain softmax. Used for the
 # padded heads so they cannot perturb the real ones.
 _NEG_SINK = -1e30
@@ -138,6 +143,53 @@ def _pad_query_heads(query: Tensor, attn_sink: Tensor, head_tile: int):
         axis=0,
     )
     return query, attn_sink
+
+
+def _dsa_latent_dim(hn: int) -> int:
+    """Latent width the "cudnn" backend must be driven at for a ``hn`` layer.
+
+    Always ``_DSA_LATENT_DIM``: the FlashMLA sparse prefill accepts
+    ``d_qk in {512, 576}`` and requires ``d_v == 512``
+    (``csrc/api/sparse_fwd.h``), and this CSA path calls it symmetrically
+    (``d_v`` defaults to the query's last dim), so 512 is the only width that
+    passes. The cuDNN DSA backward is equally 512-shaped: its SM100 kernel
+    unrolls ``dQ`` / ``dKV`` into exactly four 128-column sub-tiles.
+    """
+    if hn > _DSA_LATENT_DIM:
+        raise ValueError(
+            f"csa_sparse_attn 'cudnn' backend supports at most "
+            f"{_DSA_LATENT_DIM} latent dims, got {hn}. "
+            "Reduce v_head_dim."
+        )
+    return _DSA_LATENT_DIM
+
+
+def _pad_latent_dim(x: Tensor, latent_dim: int) -> Tensor:
+    """Zero-pad the last (latent) axis of ``x`` up to ``latent_dim``.
+
+    Applied to ``q`` and ``kv`` together, so it is numerically exact rather
+    than an approximation. ``kv`` is a single latent head shared as both key
+    and value, so with both sides zero in the padded columns:
+
+    * ``scores = q . k`` is unchanged bit-for-bit (the added terms are 0 * 0),
+      hence so are the softmax, the ``lse`` and the sink.
+    * ``out = sum_j p_j * kv_j`` has the true result in ``[:hn]`` and exactly
+      zero in the padded columns, so the caller just slices them off.
+    * backward likewise: ``dq = sum_j dp_j * kv_j`` and
+      ``dkv = sum_j p_j * dout_j`` are zero over the padded columns (``dout``
+      is padded with zeros too), and ``d_sink`` is untouched.
+
+    The cost is that both GEMMs run at ``latent_dim`` for ``hn`` real columns.
+    The ``hn == latent_dim`` path is unchanged, and no tensor is saved for
+    backward in padded form -- backward re-pads instead, so activation memory
+    stays at the real width.
+    """
+    pad = latent_dim - x.shape[-1]
+    if pad == 0:
+        return x
+    zeros_shape = list(x.shape)
+    zeros_shape[-1] = pad
+    return paddle.concat([x, paddle.zeros(zeros_shape, dtype=x.dtype)], axis=-1)
 
 
 def unfused_compressed_sparse_attn(
@@ -384,6 +436,12 @@ class CSASparseAttention(paddle.autograd.PyLayer):
             if head_tile == np_heads or _dsa_bwd_runs_sub_tile_heads(np_heads)
             else head_tile
         )
+        # Latent width the kernels are driven with. Both the FlashMLA forward
+        # and the cuDNN backward only exist at 512, so a narrower layer is
+        # zero-padded up to it on the way in and sliced back on the way out.
+        # Unlike the head padding above this never changes what is saved for
+        # backward, so it costs no activation memory.
+        ctx.kernel_hn = _dsa_latent_dim(hn) if backend == "cudnn" else hn
         if backend == "cudnn":
             from paddlefleet.cudnn_ops.attn.csa_sparse_attn_fwd_cudnn import (
                 flash_mla_sparse_attn,
@@ -394,8 +452,8 @@ class CSASparseAttention(paddle.autograd.PyLayer):
                 q_in, sink_in = _pad_query_heads(query, attn_sink, head_tile)
 
             output, lse, lse_indexer = flash_mla_sparse_attn(
-                q_in,
-                kv_full,
+                _pad_latent_dim(q_in, ctx.kernel_hn),
+                _pad_latent_dim(kv_full, ctx.kernel_hn),
                 sink_in,
                 topk_idxs,
                 sm_scale=ctx.softmax_scale,
@@ -403,6 +461,9 @@ class CSASparseAttention(paddle.autograd.PyLayer):
                 indexer_topk=indexer_topk,
                 global_kv_idx_remap_fusion=global_kv_idx_remap_fusion,
             )
+            if ctx.kernel_hn != hn:
+                # The padded latent columns of the output are exactly zero.
+                output = output[..., :hn].contiguous()
             output_real, lse_real = output, lse
             if head_tile != np_heads:
                 output_real = _drop_padded_head_rows(
@@ -487,6 +548,15 @@ class CSASparseAttention(paddle.autograd.PyLayer):
                 topk_idxs, s_kv, fused=ctx.global_kv_idx_remap_fusion
             )
 
+            if ctx.kernel_hn != hn:
+                # Same exact zero-padding the forward used (see
+                # ``_pad_latent_dim``); ``out`` is zero over the padded columns
+                # there, so re-padding the saved narrow copy reproduces it.
+                q_flat = _pad_latent_dim(q_flat, ctx.kernel_hn)
+                o_flat = _pad_latent_dim(o_flat, ctx.kernel_hn)
+                do_flat = _pad_latent_dim(do_flat, ctx.kernel_hn)
+                kv_flat = _pad_latent_dim(kv_flat, ctx.kernel_hn)
+
             # ``topk_idxs`` was already densified in the forward for the compacted
             # path (HCA, no indexer loss), so the saved indices have a dense valid
             # prefix with -1 only trailing. Recover the per-row count cheaply (a
@@ -515,6 +585,10 @@ class CSASparseAttention(paddle.autograd.PyLayer):
                 softmax_scale=ctx.softmax_scale,
                 topk_length=topk_length,
             )
+            if ctx.kernel_hn != hn:
+                # ``dq`` / ``dkv`` are exactly zero over the padded columns.
+                dq_flat = dq_flat[..., :hn].contiguous()
+                dkv_flat = dkv_flat[..., :hn].contiguous()
             dkv = dkv_flat.reshape(kv_full.shape)
             if kh != np_heads:
                 dq = _drop_padded_head_rows(dq_flat, np_heads, kh).reshape(
@@ -585,7 +659,9 @@ def csa_sparse_attn(
     ``query`` may carry any head count up to 128 on the "cudnn" backend; counts
     that are not one of the kernel's head tiles (e.g. 32 or 24) are handled
     inside ``CSASparseAttention`` by padding the forward, which is exact but
-    keeps the forward cost of the tile.
+    keeps the forward cost of the tile. The same holds for the latent width:
+    any ``v_head_dim`` up to 512 is accepted and zero-padded to 512, which is
+    the only width both the FlashMLA forward and the cuDNN backward exist at.
     """
     if backend == "unfused":
         return unfused_compressed_sparse_attn(

--- a/src/paddlefleet/fusions/csa_sparse_attn.py
+++ b/src/paddlefleet/fusions/csa_sparse_attn.py
@@ -19,12 +19,125 @@ final sparse MQA attention:
   - "unfused": pure-Paddle einsum forward + Paddle autograd backward
   - "tilelang": TileLang sparse MQA forward + TileLang backward
   - "cudnn": FlashMLA sparse forward + cuDNN DSA backward
+
+Head counts below a kernel tile are supported by zero-padding, see
+``_pad_query_heads``.
 """
 
 import functools
 
 import paddle
 from paddle import Tensor
+
+# Query-head counts the "cudnn" backend can run natively. FlashMLA's sparse
+# prefill only instantiates these two tiles (``csrc/api/sparse_fwd.h`` raises
+# "Unsupported h_q" for anything else), and the tile width is the M extent of
+# the tcgen05 / wgmma instruction behind it (``B_H`` in
+# ``sm100/prefill/sparse/fwd/head64/config.h``), so a layer with fewer heads
+# cannot be given a narrower tile without a new kernel.
+_DSA_HEAD_TILES = (64, 128)
+# Sink logit that makes ``exp(sink - m) -> 0``, i.e. plain softmax. Used for the
+# padded heads so they cannot perturb the real ones.
+_NEG_SINK = -1e30
+
+
+def _dsa_head_tile(num_heads: int) -> int:
+    """Smallest cuDNN/FlashMLA query-head tile that fits ``num_heads``."""
+    for tile in _DSA_HEAD_TILES:
+        if num_heads <= tile:
+            return tile
+    raise ValueError(
+        f"csa_sparse_attn 'cudnn' backend supports at most "
+        f"{_DSA_HEAD_TILES[-1]} query heads per rank, got {num_heads}. "
+        "Reduce num_attention_heads (per-rank after TP)."
+    )
+
+
+@functools.lru_cache(maxsize=16)
+def _real_head_rows(num_tokens: int, num_heads: int, head_tile: int) -> Tensor:
+    """Row ids of the real heads in a ``[num_tokens * head_tile, hn]`` view.
+
+    Cached because it only depends on the shape. One entry is
+    ``num_tokens * num_heads`` int32 (1 MiB at 8k tokens x 32 heads), and a
+    process only ever sees one device, so a plain shape-keyed cache is enough.
+    """
+    return (
+        (paddle.arange(num_tokens, dtype="int32") * head_tile).unsqueeze(1)
+        + paddle.arange(num_heads, dtype="int32").unsqueeze(0)
+    ).flatten()
+
+
+def _drop_padded_head_rows(x: Tensor, num_heads: int, head_tile: int) -> Tensor:
+    """Keep the first ``num_heads`` of every ``head_tile`` head-rows of ``x``.
+
+    ``x`` is any tensor whose last axis is the head dim and whose remaining
+    axes flatten to ``num_tokens * head_tile`` rows.
+
+    Implemented as a row ``gather`` rather than a slice: both move the same
+    bytes, but Paddle's strided-slice copy runs at roughly a quarter of the
+    achievable bandwidth here while ``gather`` saturates it (measured on B30Z at
+    8192 tokens x 64->32 heads x 512: 0.53 ms for ``x[:, :h*hn]``, 0.11 ms for
+    the gather).
+    """
+    hn = x.shape[-1]
+    rows = x.reshape([-1, hn])
+    num_tokens = rows.shape[0] // head_tile
+    idx = _real_head_rows(num_tokens, num_heads, head_tile)
+    return paddle.gather(rows, idx, axis=0)
+
+
+@functools.cache
+def _dsa_bwd_runs_sub_tile_heads(num_heads: int) -> bool:
+    """Whether the cuDNN DSA backward accepts this head count below its tile.
+
+    ``flash_attn_bwd_sm100`` derives ``num_head_blocks = ceil(num_head / 64)``
+    and predicates the partial tile, so SM100 returns exactly the same ``dq`` /
+    ``d_sink`` for ``h`` real heads as for the zero-padded problem (verified
+    bit-identical for h=24/32/40/96; ``dkv`` matches to the usual atomic noise).
+    That lets the backward -- the expensive half -- skip the padding entirely,
+    which also keeps the saved ``q``/``out`` at the real head count.
+
+    Two exclusions fall back to the padded (always even, tile-wide) path:
+
+    * **odd head counts**: the kernel reads the ``[N, H]`` fp32 LSE / sum(OdO)
+      rows with a 2-float vector access, so an odd ``H`` leaves every other row
+      only 4-byte aligned and the kernel dies with CUDA 716 (misaligned
+      address). Measured: 31/33/35/63/65 crash, 34/62/66/96/126 are fine.
+    * **SM90**: its kernel packs heads differently
+      (``qhead_per_kvhead`` tiling) and is not validated here.
+    """
+    major, _ = paddle.device.cuda.get_device_capability()
+    return major >= 10 and num_heads % 2 == 0
+
+
+def _pad_query_heads(query: Tensor, attn_sink: Tensor, head_tile: int):
+    """Widen ``query``/``attn_sink`` from ``h`` to ``head_tile`` heads.
+
+    The padded query rows are zeros and their sink logit is ``-1e30``, so they
+    run a plain softmax over the same columns and cannot change the real heads'
+    result; their output rows are dropped by the caller. Hence they receive a
+    zero output gradient, which makes their contribution to ``dkv`` and
+    ``d_sink`` exactly zero (both are ``dO``-weighted sums) and their ``dq``
+    rows unused. So this is numerically exact, not an approximation, and the
+    ``h == head_tile`` path stays bit-for-bit unchanged.
+
+    Padding is used instead of a narrower kernel because the tile width is the
+    MMA M extent (see ``_DSA_HEAD_TILES``): the cost is that the forward keeps
+    doing ``head_tile`` rows of work for ``h`` real heads.
+    """
+    b, sq, h, hn = query.shape
+    query = paddle.concat(
+        [query, paddle.zeros([b, sq, head_tile - h, hn], dtype=query.dtype)],
+        axis=2,
+    )
+    attn_sink = paddle.concat(
+        [
+            attn_sink.cast("float32"),
+            paddle.full([head_tile - h], _NEG_SINK, dtype="float32"),
+        ],
+        axis=0,
+    )
+    return query, attn_sink
 
 
 def unfused_compressed_sparse_attn(
@@ -260,21 +373,53 @@ class CSASparseAttention(paddle.autograd.PyLayer):
             # pre-compact (e.g. CP without cached docmask metadata).
             topk_idxs, topk_length = _csa_compact_topk_idxs(topk_idxs)
 
+        # Heads the kernels are driven with. The FlashMLA forward only has 64-
+        # and 128-head tiles, so a smaller layer is zero-padded up to one; the
+        # cuDNN backward takes the real count on SM100 and only needs the same
+        # padding on SM90. ``ctx.bwd_heads`` records which width the tensors
+        # saved below are in.
+        head_tile = _dsa_head_tile(np_heads) if backend == "cudnn" else np_heads
+        ctx.bwd_heads = (
+            np_heads
+            if head_tile == np_heads or _dsa_bwd_runs_sub_tile_heads(np_heads)
+            else head_tile
+        )
         if backend == "cudnn":
             from paddlefleet.cudnn_ops.attn.csa_sparse_attn_fwd_cudnn import (
                 flash_mla_sparse_attn,
             )
 
+            q_in, sink_in = query, attn_sink
+            if head_tile != np_heads:
+                q_in, sink_in = _pad_query_heads(query, attn_sink, head_tile)
+
             output, lse, lse_indexer = flash_mla_sparse_attn(
-                query,
+                q_in,
                 kv_full,
-                attn_sink,
+                sink_in,
                 topk_idxs,
                 sm_scale=ctx.softmax_scale,
                 topk_length=topk_length,
                 indexer_topk=indexer_topk,
                 global_kv_idx_remap_fusion=global_kv_idx_remap_fusion,
             )
+            output_real, lse_real = output, lse
+            if head_tile != np_heads:
+                output_real = _drop_padded_head_rows(
+                    output, np_heads, head_tile
+                ).reshape([b, sq, np_heads, hn])
+                lse_real = lse[:, :, :np_heads].contiguous()
+                if lse_indexer is not None:
+                    lse_indexer = lse_indexer[:, :, :np_heads].contiguous()
+            if ctx.bwd_heads == np_heads:
+                # The backward runs on the real heads, so the padded forward
+                # tensors are dropped here instead of being kept alive until
+                # backward.
+                save_q, save_sink = query, attn_sink
+                save_out, save_lse = output_real, lse_real
+            else:
+                save_q, save_sink = q_in, sink_in
+                save_out, save_lse = output, lse
             CSASparseAttention._lse_indexer = lse_indexer
         else:
             if topk_length is not None:
@@ -291,13 +436,25 @@ class CSASparseAttention(paddle.autograd.PyLayer):
                 topk_idxs,
                 sm_scale=ctx.softmax_scale,
             )
-        ctx.save_for_backward(query, kv_full, attn_sink, topk_idxs, output, lse)
-        return output.reshape([b, sq, np_heads * hn])
+            output_real = output
+            save_q, save_sink, save_out, save_lse = (
+                query,
+                attn_sink,
+                output,
+                lse,
+            )
+        ctx.save_for_backward(
+            save_q, kv_full, save_sink, topk_idxs, save_out, save_lse
+        )
+        return output_real.reshape([b, sq, np_heads * hn])
 
     @staticmethod
     def backward(ctx, grad_output):
         query, kv_full, attn_sink, topk_idxs, output, lse = ctx.saved_tensor()
         b, sq, np_heads, hn = ctx.query_shape
+        # Kernel-side head count: equal to ``np_heads`` except on the SM90
+        # padded path, where the saved tensors are one head tile wide.
+        kh = ctx.bwd_heads
 
         if ctx.backend == "cudnn":
             from paddlefleet.cudnn_ops import csa_sparse_attn_bwd_cudnn
@@ -307,11 +464,25 @@ class CSASparseAttention(paddle.autograd.PyLayer):
 
             _, s_kv, dkv_dim = kv_full.shape
 
-            q_flat = query.reshape([b * sq, np_heads, hn])
-            o_flat = output.reshape([b * sq, np_heads, hn])
-            do_flat = grad_output.reshape([b * sq, np_heads, hn])
+            if kh != np_heads:
+                # SM90 padded path: widen the incoming gradient to the saved
+                # tensors' head tile. The padded rows get a zero gradient, so
+                # they add nothing to ``dkv`` / ``d_sink``.
+                grad_output = paddle.concat(
+                    [
+                        grad_output.reshape([b, sq, np_heads, hn]),
+                        paddle.zeros(
+                            [b, sq, kh - np_heads, hn], dtype=grad_output.dtype
+                        ),
+                    ],
+                    axis=2,
+                )
+
+            q_flat = query.reshape([b * sq, kh, hn])
+            o_flat = output.reshape([b * sq, kh, hn])
+            do_flat = grad_output.reshape([b * sq, kh, hn])
             kv_flat = kv_full.reshape([b * s_kv, dkv_dim])
-            lse_flat = lse.reshape([b * sq, np_heads])
+            lse_flat = lse.reshape([b * sq, kh])
             topk_idxs_flat = local_to_global_flat(
                 topk_idxs, s_kv, fused=ctx.global_kv_idx_remap_fusion
             )
@@ -344,11 +515,15 @@ class CSASparseAttention(paddle.autograd.PyLayer):
                 softmax_scale=ctx.softmax_scale,
                 topk_length=topk_length,
             )
-            dq = dq_flat.reshape(query.shape)
             dkv = dkv_flat.reshape(kv_full.shape)
-            d_attn_sink = d_sink.reshape(attn_sink.shape).cast(
-                ctx.attn_sink_dtype
-            )
+            if kh != np_heads:
+                dq = _drop_padded_head_rows(dq_flat, np_heads, kh).reshape(
+                    [b, sq, np_heads, hn]
+                )
+                d_sink = d_sink[:np_heads]
+            else:
+                dq = dq_flat.reshape([b, sq, np_heads, hn])
+            d_attn_sink = d_sink.reshape([np_heads]).cast(ctx.attn_sink_dtype)
         else:
             from paddlefleet.tilelang_ops.attn import sparse_mqa_bwd
 
@@ -406,6 +581,11 @@ def csa_sparse_attn(
             Bit-identical either way; wired from the
             ``sparse_attn_global_kv_idx_remap_fusion`` config field. Only the
             "cudnn" backend builds that table, so it is ignored otherwise.
+
+    ``query`` may carry any head count up to 128 on the "cudnn" backend; counts
+    that are not one of the kernel's head tiles (e.g. 32 or 24) are handled
+    inside ``CSASparseAttention`` by padding the forward, which is exact but
+    keeps the forward cost of the tile.
     """
     if backend == "unfused":
         return unfused_compressed_sparse_attn(

--- a/src/paddlefleet/fusions/csa_sparse_attn.py
+++ b/src/paddlefleet/fusions/csa_sparse_attn.py
@@ -435,6 +435,7 @@ class CSASparseAttention(paddle.autograd.PyLayer):
         topk_length=None,
         indexer_topk=0,
         global_kv_idx_remap_fusion=False,
+        topk_idxs_compacted=False,
     ):
         from paddlefleet.fusions.csa_sparse_attn_utils import prepare_inputs
 
@@ -475,10 +476,20 @@ class CSASparseAttention(paddle.autograd.PyLayer):
         # Compaction can produce topk_length == 0 for all-invalid rows, which only
         # SM100 early-exits safely (SM90 would gather from a negative KV row); so
         # only compact on SM100. SM90 keeps topk_length=None (guarded full-width).
+        #
+        # ``ctx.compacted_idxs`` is what lets the BACKWARD take the compact
+        # KV-load path, which is unguarded against interior ``-1``. So it may
+        # only be set when the indices are KNOWN hole-free: either this forward
+        # compacted them, or the caller stated it already did
+        # (``topk_idxs_compacted``). A caller that supplies ``topk_length``
+        # without that promise keeps its own (possibly holey) layout, so the
+        # backward falls back to the guarded full-width path instead of
+        # gathering ``mKV[-1]`` -- correct, just without the early-stop.
         ctx.compacted_idxs = (
             backend == "cudnn"
             and indexer_topk == 0
             and _csa_bwd_honours_topk_length_holes()
+            and (topk_length is None or topk_idxs_compacted)
         )
         if ctx.compacted_idxs and topk_length is None:
             # Fallback densify: the caller (HCA) normally pre-compacts once per
@@ -711,6 +722,7 @@ def csa_sparse_attn(
     topk_length=None,
     indexer_topk=0,
     global_kv_idx_remap_fusion=False,
+    topk_idxs_compacted=False,
 ):
     """Unified CSA sparse attention entry point.
 
@@ -720,6 +732,14 @@ def csa_sparse_attn(
             row. Only the "cudnn" and "unfused" backends support it; it lets
             the kernel stop early instead of walking all ``topk`` slots, which
             is what makes the full-causal MQA layers affordable.
+        topk_idxs_compacted: assert that ``topk_idxs`` has its valid entries in
+            a contiguous prefix with no interior ``-1`` (what
+            ``_csa_compact_topk_idxs`` produces). Only consulted together with
+            ``topk_length`` on the "cudnn" backend, where it lets the backward
+            keep the compact KV-load path; that path gathers ``mKV[-1]`` on an
+            interior hole, so it defaults to False and the backward then takes
+            the guarded full-width path instead. When ``topk_length`` is None
+            this layer compacts on its own and the flag is irrelevant.
         global_kv_idx_remap_fusion: use the fused Triton local->global KV
             column index remap instead of the eager elementwise chain.
             Bit-identical either way; wired from the
@@ -757,6 +777,7 @@ def csa_sparse_attn(
         topk_length,
         indexer_topk,
         global_kv_idx_remap_fusion,
+        topk_idxs_compacted,
     )
     if CSASparseAttention._lse_indexer is not None:
         lse_indexer = CSASparseAttention._lse_indexer

--- a/src/paddlefleet/fusions/csa_sparse_attn.py
+++ b/src/paddlefleet/fusions/csa_sparse_attn.py
@@ -26,6 +26,7 @@ Head counts below a kernel tile are supported by zero-padding, see
 """
 
 import functools
+import math
 
 import paddle
 from paddle import Tensor
@@ -59,36 +60,65 @@ def _dsa_head_tile(num_heads: int) -> int:
 
 
 @functools.lru_cache(maxsize=16)
-def _real_head_rows(num_tokens: int, num_heads: int, head_tile: int) -> Tensor:
-    """Row ids of the real heads in a ``[num_tokens * head_tile, hn]`` view.
+def _real_rows(
+    num_tokens: int, num_heads: int, head_tile: int, keep: int, total: int
+) -> Tensor:
+    """Row ids of the real data in a ``[num_tokens * head_tile * total, g]`` view.
+
+    Of every ``head_tile`` head rows the first ``num_heads`` are real, and of
+    every ``total`` latent chunks the first ``keep`` are real; the rest is the
+    zero padding added on the way into the kernel.
 
     Cached because it only depends on the shape. One entry is
-    ``num_tokens * num_heads`` int32 (1 MiB at 8k tokens x 32 heads), and a
-    process only ever sees one device, so a plain shape-keyed cache is enough.
+    ``num_tokens * num_heads * keep`` int32 (0.75 MiB at 8k tokens x 24 heads
+    x 1 chunk), and a process only ever sees one device, so a plain shape-keyed
+    cache is enough.
     """
+    head_rows = (
+        paddle.arange(num_tokens, dtype="int32") * (head_tile * total)
+    ).unsqueeze(1) + (
+        paddle.arange(num_heads, dtype="int32") * total
+    ).unsqueeze(0)
     return (
-        (paddle.arange(num_tokens, dtype="int32") * head_tile).unsqueeze(1)
-        + paddle.arange(num_heads, dtype="int32").unsqueeze(0)
+        head_rows.reshape([-1, 1])
+        + paddle.arange(keep, dtype="int32").unsqueeze(0)
     ).flatten()
 
 
-def _drop_padded_head_rows(x: Tensor, num_heads: int, head_tile: int) -> Tensor:
-    """Keep the first ``num_heads`` of every ``head_tile`` head-rows of ``x``.
+def _drop_padded_rows(
+    x: Tensor, num_heads: int, head_tile: int, hn: int
+) -> Tensor:
+    """Undo ``_pad_query_heads`` / ``_pad_latent_dim`` on a kernel output.
 
-    ``x`` is any tensor whose last axis is the head dim and whose remaining
-    axes flatten to ``num_tokens * head_tile`` rows.
+    ``x`` is ``[..., head_tile, x.shape[-1]]``; the result is
+    ``[..., num_heads, hn]``, i.e. the padded head rows *and* the padded latent
+    columns are dropped. Returns ``x`` untouched when there is no padding.
 
-    Implemented as a row ``gather`` rather than a slice: both move the same
-    bytes, but Paddle's strided-slice copy runs at roughly a quarter of the
-    achievable bandwidth here while ``gather`` saturates it (measured on B30Z at
-    8192 tokens x 64->32 heads x 512: 0.53 ms for ``x[:, :h*hn]``, 0.11 ms for
-    the gather).
+    Both drops are done by a *single* row ``gather`` rather than by a strided
+    slice per axis. The slice moves the same bytes but Paddle's strided-slice
+    copy runs at roughly a quarter of the achievable bandwidth, and doing the
+    latent axis first also materialises a full-head-tile intermediate. Measured
+    on B30Z at the HCA shape (8192 tokens, 64->24 heads, 512->256 latent, so a
+    512 MiB kernel output): 0.803 ms for ``x[..., :hn].contiguous()`` followed
+    by a head-row gather (704 MiB moved), 0.045 ms for the fused gather
+    (192 MiB moved) -- a 17x saving on what is otherwise ~half of the forward.
+
+    Chunking is by ``gcd(hn, kernel_hn)`` so that keeping the first ``hn``
+    columns is expressible as keeping whole rows, which holds for any width the
+    kernel is padded from (512/256 -> one 256-wide row of two, 512/384 -> three
+    128-wide rows of four).
     """
-    hn = x.shape[-1]
-    rows = x.reshape([-1, hn])
-    num_tokens = rows.shape[0] // head_tile
-    idx = _real_head_rows(num_tokens, num_heads, head_tile)
-    return paddle.gather(rows, idx, axis=0)
+    kernel_hn = x.shape[-1]
+    if num_heads == head_tile and hn == kernel_hn:
+        return x
+    g = math.gcd(hn, kernel_hn)
+    total = kernel_hn // g
+    rows = x.reshape([-1, g])
+    num_tokens = rows.shape[0] // (head_tile * total)
+    idx = _real_rows(num_tokens, num_heads, head_tile, hn // g, total)
+    return paddle.gather(rows, idx, axis=0).reshape(
+        [*x.shape[:-2], num_heads, hn]
+    )
 
 
 @functools.cache
@@ -438,9 +468,10 @@ class CSASparseAttention(paddle.autograd.PyLayer):
         )
         # Latent width the kernels are driven with. Both the FlashMLA forward
         # and the cuDNN backward only exist at 512, so a narrower layer is
-        # zero-padded up to it on the way in and sliced back on the way out.
-        # Unlike the head padding above this never changes what is saved for
-        # backward, so it costs no activation memory.
+        # zero-padded up to it on the way in and dropped again on the way out
+        # (fused with the head-row drop, see ``_drop_padded_rows``). Unlike the
+        # head padding above this never changes what is saved for backward, so
+        # it costs no activation memory.
         ctx.kernel_hn = _dsa_latent_dim(hn) if backend == "cudnn" else hn
         if backend == "cudnn":
             from paddlefleet.cudnn_ops.attn.csa_sparse_attn_fwd_cudnn import (
@@ -461,24 +492,29 @@ class CSASparseAttention(paddle.autograd.PyLayer):
                 indexer_topk=indexer_topk,
                 global_kv_idx_remap_fusion=global_kv_idx_remap_fusion,
             )
-            if ctx.kernel_hn != hn:
-                # The padded latent columns of the output are exactly zero.
-                output = output[..., :hn].contiguous()
-            output_real, lse_real = output, lse
             if head_tile != np_heads:
-                output_real = _drop_padded_head_rows(
-                    output, np_heads, head_tile
-                ).reshape([b, sq, np_heads, hn])
                 lse_real = lse[:, :, :np_heads].contiguous()
                 if lse_indexer is not None:
                     lse_indexer = lse_indexer[:, :, :np_heads].contiguous()
+            else:
+                lse_real = lse
             if ctx.bwd_heads == np_heads:
-                # The backward runs on the real heads, so the padded forward
-                # tensors are dropped here instead of being kept alive until
-                # backward.
+                # The backward runs on the real heads, so nothing padded has to
+                # stay alive: one gather takes the kernel output straight to the
+                # real shape (see ``_drop_padded_rows``).
+                output_real = _drop_padded_rows(
+                    output, np_heads, head_tile, hn
+                ).reshape([b, sq, np_heads, hn])
                 save_q, save_sink = query, attn_sink
                 save_out, save_lse = output_real, lse_real
             else:
+                # SM90 padded backward: the saved ``out`` must stay one head
+                # tile wide, so only the padded latent columns come off it, and
+                # the head rows are dropped from that narrower copy.
+                output = _drop_padded_rows(output, head_tile, head_tile, hn)
+                output_real = _drop_padded_rows(
+                    output, np_heads, head_tile, hn
+                ).reshape([b, sq, np_heads, hn])
                 save_q, save_sink = q_in, sink_in
                 save_out, save_lse = output, lse
             CSASparseAttention._lse_indexer = lse_indexer
@@ -586,17 +622,18 @@ class CSASparseAttention(paddle.autograd.PyLayer):
                 topk_length=topk_length,
             )
             if ctx.kernel_hn != hn:
-                # ``dq`` / ``dkv`` are exactly zero over the padded columns.
-                dq_flat = dq_flat[..., :hn].contiguous()
+                # ``dkv`` is exactly zero over the padded columns. It is one
+                # latent head (no head padding to undo) and ~8 MiB, so a slice
+                # is fine here.
                 dkv_flat = dkv_flat[..., :hn].contiguous()
             dkv = dkv_flat.reshape(kv_full.shape)
+            # ``dq`` is exactly zero over the padded latent columns and its
+            # padded head rows are unused, so one gather drops both.
+            dq = _drop_padded_rows(dq_flat, np_heads, kh, hn).reshape(
+                [b, sq, np_heads, hn]
+            )
             if kh != np_heads:
-                dq = _drop_padded_head_rows(dq_flat, np_heads, kh).reshape(
-                    [b, sq, np_heads, hn]
-                )
                 d_sink = d_sink[:np_heads]
-            else:
-                dq = dq_flat.reshape([b, sq, np_heads, hn])
             d_attn_sink = d_sink.reshape([np_heads]).cast(ctx.attn_sink_dtype)
         else:
             from paddlefleet.tilelang_ops.attn import sparse_mqa_bwd

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -3059,6 +3059,13 @@ class CompressedSparseAttention(FleetLayer):
             topk_idxs,
             self.softmax_scale,
             topk_length=topk_length,
+            # Row ``i`` is ``[doc_start[i] .. i]`` followed by ``-1`` (see
+            # ``_build_mqa_causal_topk_idxs_from_doc_bounds``), so the valid
+            # entries already are a hole-free prefix -- the backward may keep
+            # the compact KV-load path without re-sorting. A padding row is all
+            # ``-1`` and the backward recounts it to length 0, hitting the
+            # kernel's empty-row fast path rather than gathering ``mKV[-1]``.
+            topk_idxs_compacted=True,
         )
 
     def _forward_cp(
@@ -3474,6 +3481,7 @@ class CompressedSparseAttention(FleetLayer):
         topk_length: Tensor | None = None,
         indexer_topk: int = 0,
         docmask_meta: CSADocMaskMetadata | None = None,
+        topk_idxs_compacted: bool = False,
     ):
         from paddlefleet.fusions.csa_sparse_attn import (
             _csa_bwd_honours_topk_length_holes,
@@ -3511,6 +3519,7 @@ class CompressedSparseAttention(FleetLayer):
             topk_idxs, topk_length = docmask_meta.compact_attn_topk_idxs(
                 topk_idxs
             )
+            topk_idxs_compacted = True
         return csa_sparse_attn(
             query,
             kv_full,
@@ -3521,4 +3530,5 @@ class CompressedSparseAttention(FleetLayer):
             topk_length=topk_length,
             indexer_topk=indexer_topk,
             global_kv_idx_remap_fusion=self.global_kv_idx_remap_fusion,
+            topk_idxs_compacted=topk_idxs_compacted,
         )

--- a/tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_backends.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_backends.py
@@ -654,3 +654,108 @@ class TestCsaBwdTopkLengthDispatch(unittest.TestCase):
         # Compacted valid count of the densified {0, 2, 5} prefix is 3 -- the
         # exact per-row early-stop bound, with interior -1 holes removed.
         self.assertEqual(topk_length.tolist(), [3] * (self.B * self.SQ))
+
+
+@unittest.skipUnless(
+    paddle.is_compiled_with_cuda(),
+    "the topk_length compaction promise test requires CUDA",
+)
+class TestTopkLengthCompactionPromise(unittest.TestCase):
+    """A caller-supplied ``topk_length`` must not enable the compact backward.
+
+    The kernel's compact KV-load path (taken for any non-None ``topk_length``)
+    gathers ``mKV[-1]`` on an interior ``-1``, so it is only valid over
+    compacted indices. ``topk_length`` on its own does not imply that: it is
+    documented as a forward-only early-stop hint and the forward predicates
+    ``-1``. So the backward may keep that path only when the caller also passes
+    ``topk_idxs_compacted=True``, which ``csa_attention.py`` does right after
+    ``compact_attn_topk_idxs``.
+
+    Here the unsafe combination is passed on purpose -- holey indices plus the
+    trailing bound of ``_csa_compute_topk_length`` -- and the backward must fall
+    back to the guarded full-width path and stay correct. Inferring the promise
+    from ``topk_length`` instead measures dq and dkv at ~5e-01, or yields nan /
+    ``CUDA error(700)``, since the gather reads uninitialised device memory.
+    """
+
+    # Against the fp32 ``unfused`` reference, so ~2x the bf16 noise floor
+    # (measured out 2.3e-3, dq 2.6e-3, dkv 3.2e-3) rather than the much tighter
+    # tilelang-vs-cuDNN ceilings above.
+    CEILING = {"out": 6e-3, "dq": 6e-3, "dkv": 6e-3, "d_sink": 8e-3}
+
+    @classmethod
+    def setUpClass(cls):
+        """Probe the real cuDNN backward instead of trusting a feature flag.
+
+        ``_HAS_CUDNN_SPARSE_BWD`` above is gated on a top-level ``import
+        cudnn``, which the ops loader has already renamed to
+        ``paddlefleet_ops.cudnn``, so it reads False even where the kernel runs
+        fine. One tiny backward settles it; anything other than a missing module
+        is re-raised so a real regression still fails loudly.
+        """
+        if not _HAS_FLASH_MLA:
+            raise unittest.SkipTest("this test requires FlashMLA")
+        try:
+            run_forward_backward(
+                *make_inputs(1, 8, 64, 64, 512, 64), backend="cudnn"
+            )
+        except Exception as exc:
+            if isinstance(exc, ImportError) or "No module named" in str(exc):
+                raise unittest.SkipTest(
+                    "the cuDNN sparse backward does not run here"
+                ) from exc
+            raise
+
+    def test_holey_idxs_with_a_bound_stay_correct(self):
+        from paddlefleet.fusions.csa_sparse_attn import (
+            _csa_compute_topk_length,
+            csa_sparse_attn,
+        )
+
+        batch, sq, s_kv, num_heads, hn, topk = 1, 128, 256, 64, 512, 64
+        paddle.seed(0)
+        q, kv, attn_sink, topk_idxs, scale = make_inputs(
+            batch, sq, s_kv, num_heads, hn, topk
+        )
+        holes = paddle.rand([batch, sq, topk]) < 0.3
+        topk_idxs = paddle.where(
+            holes, paddle.full_like(topk_idxs, -1), topk_idxs
+        )
+        # Keep column 0 valid: an all-invalid row has no reference output.
+        topk_idxs[:, :, 0] = paddle.randint(0, s_kv, [batch, sq]).cast("int32")
+        topk_length = _csa_compute_topk_length(
+            topk_idxs.reshape([batch * sq, topk])
+        ).reshape([batch, sq])
+
+        ref = run_forward_backward(
+            q, kv, attn_sink, topk_idxs, scale, backend="unfused"
+        )
+        tensors = [t.detach().clone() for t in (q, kv, attn_sink)]
+        for t in tensors:
+            t.stop_gradient = False
+        q_c, kv_c, sink_c = tensors
+        out = csa_sparse_attn(
+            q_c,
+            kv_c,
+            sink_c,
+            topk_idxs,
+            scale,
+            backend="cudnn",
+            topk_length=topk_length,
+        )
+        out.sum().backward()
+
+        got = (out, q_c.grad, kv_c.grad, sink_c.grad)
+        for name, actual, expected in zip(
+            ("out", "dq", "dkv", "d_sink"), got, ref
+        ):
+            self.assertEqual(
+                int(paddle.isfinite(actual.cast("float32")).all()),
+                1,
+                f"{name} is not finite",
+            )
+            self.assertLess(
+                rel_l2(actual, expected),
+                self.CEILING[name],
+                f"{name} diverges from the fp32 reference",
+            )

--- a/tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_backends.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_backends.py
@@ -590,6 +590,9 @@ class TestCsaBwdTopkLengthDispatch(unittest.TestCase):
             global_kv_idx_remap_fusion=False,
             compacted_idxs=compacted,
             has_topk_length=False,
+            # Head count the saved tensors are in; equal to np_heads unless the
+            # forward padded them up to a kernel head tile.
+            bwd_heads=np_heads,
             query_needs_grad=True,
             kv_full_needs_grad=True,
             attn_sink_needs_grad=True,

--- a/tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_backends.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_backends.py
@@ -593,6 +593,9 @@ class TestCsaBwdTopkLengthDispatch(unittest.TestCase):
             # Head count the saved tensors are in; equal to np_heads unless the
             # forward padded them up to a kernel head tile.
             bwd_heads=np_heads,
+            # Latent width the kernels run at; equal to hn unless the forward
+            # zero-padded a narrower latent up to 512.
+            kernel_hn=hn,
             query_needs_grad=True,
             kv_full_needs_grad=True,
             attn_sink_needs_grad=True,

--- a/tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_sub_512_latent.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_sub_512_latent.py
@@ -433,10 +433,7 @@ class TestPaddedLatentColumnsAreZero(unittest.TestCase):
         from paddlefleet.cudnn_ops.attn.csa_sparse_attn_fwd_cudnn import (
             flash_mla_sparse_attn,
         )
-        from paddlefleet.fusions.csa_sparse_attn import (
-            _csa_compute_topk_length,
-            _pad_latent_dim,
-        )
+        from paddlefleet.fusions.csa_sparse_attn import _pad_latent_dim
         from paddlefleet.fusions.csa_sparse_attn_utils import (
             _local_to_global_flat,
         )
@@ -470,7 +467,13 @@ class TestPaddedLatentColumnsAreZero(unittest.TestCase):
                     sink,
                     idxs_flat,
                     softmax_scale=scale,
-                    topk_length=_csa_compute_topk_length(idxs_flat),
+                    # Holey indices plus the trailing bound of
+                    # ``_csa_compute_topk_length`` would take the backward's
+                    # unguarded compact KV-load path; ``None`` keeps the guarded
+                    # full-width path. This case only asserts that the padded
+                    # latent columns stay zero, so the early-stop is not needed
+                    # -- use ``_csa_compact_topk_idxs`` where it is.
+                    topk_length=None,
                 )
                 self.assertEqual(
                     float(dq[:, :, hn:].abs().max()), 0.0, "bwd dq"

--- a/tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_sub_512_latent.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_sub_512_latent.py
@@ -520,5 +520,72 @@ class TestSubLatentWithSubTileHeads(unittest.TestCase):
                     )
 
 
+class TestFusedUnpad(unittest.TestCase):
+    """``_drop_padded_rows`` must equal the per-axis slice + head gather.
+
+    The un-pad is a single row ``gather`` instead of a strided latent slice
+    followed by a head-row gather, because Paddle's strided-slice copy runs at
+    roughly a quarter of the achievable bandwidth and doing the latent axis
+    first also materialises a full-head-tile intermediate (measured on B30Z at
+    the HCA shape -- 8192 tokens, 64->24 heads, 512->256 latent: 0.803 ms and
+    704 MiB moved for the two-step form, 0.045 ms and 192 MiB for the fused
+    gather). It is a pure data movement, so it must agree bit-for-bit.
+    """
+
+    @staticmethod
+    def _per_axis(x, num_heads, head_tile, hn):
+        """The straightforward form: slice the latent axis, gather head rows."""
+        if hn != x.shape[-1]:
+            x = x[..., :hn].contiguous()
+        if num_heads == head_tile:
+            return x
+        rows = x.reshape([-1, hn])
+        idx = (
+            (
+                paddle.arange(rows.shape[0] // head_tile, dtype="int32")
+                * head_tile
+            ).unsqueeze(1)
+            + paddle.arange(num_heads, dtype="int32").unsqueeze(0)
+        ).flatten()
+        return paddle.gather(rows, idx, axis=0).reshape(
+            [*x.shape[:-2], num_heads, hn]
+        )
+
+    def test_matches_the_per_axis_form(self):
+        from paddlefleet.fusions.csa_sparse_attn import _drop_padded_rows
+
+        paddle.seed(3)
+        # (num_heads, head_tile): both kernel tiles, padded and exact; latents:
+        # the divisible widths, a non-divisible one (384, which chunks by
+        # gcd(384, 512) = 128) and the native 512.
+        for num_heads, head_tile in ((24, 64), (32, 64), (64, 64), (96, 128)):
+            for hn in (*_LATENTS, _KERNEL_LATENT):
+                # 4-D as the forward sees it, 3-D as the backward's dq is.
+                for shape in (
+                    [2, 37, head_tile, _KERNEL_LATENT],
+                    [61, head_tile, _KERNEL_LATENT],
+                ):
+                    with self.subTest(heads=num_heads, hn=hn, ndim=len(shape)):
+                        x = paddle.randn(shape).cast("bfloat16")
+                        got = _drop_padded_rows(x, num_heads, head_tile, hn)
+                        ref = self._per_axis(x, num_heads, head_tile, hn)
+                        self.assertEqual(tuple(got.shape), tuple(ref.shape))
+                        self.assertEqual(
+                            float(
+                                (got.cast("float32") - ref.cast("float32"))
+                                .abs()
+                                .max()
+                            ),
+                            0.0,
+                        )
+
+    def test_unpadded_is_copy_free(self):
+        """No padding on either axis must return the input untouched."""
+        from paddlefleet.fusions.csa_sparse_attn import _drop_padded_rows
+
+        x = paddle.randn([2, 4, 64, _KERNEL_LATENT]).cast("bfloat16")
+        self.assertIs(_drop_padded_rows(x, 64, 64, _KERNEL_LATENT), x)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_sub_512_latent.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_sub_512_latent.py
@@ -1,0 +1,524 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CSA / HCA layers whose latent width is below the sparse-attn kernel's 512.
+
+The FlashMLA sparse prefill accepts ``d_qk in {512, 576}`` and requires
+``d_v == 512`` (``csrc/api/sparse_fwd.h``), and the cuDNN DSA backward unrolls
+``dQ``/``dKV`` into exactly four 128-column sub-tiles, so neither runs at
+``v_head_dim = 256``. ``_pad_latent_dim`` zero-pads ``q`` and ``kv`` up to 512
+instead. Since ``kv`` is one latent head serving as both key and value, zeros on
+both sides leave the scores bit-identical and make the padded output columns --
+and the ``dq``/``dkv`` columns over them -- exactly zero.
+
+This pins that claim: agreement with the fp32 ``unfused`` reference in fwd and
+bwd, the padded columns being exactly (not approximately) zero straight out of
+both kernels, the ``hn == 512`` path staying copy-free and therefore
+bit-for-bit unchanged, and the >512 rejection.
+"""
+
+import functools
+import unittest
+
+import paddle
+
+try:
+    import paddlefleet_ops
+
+    from paddlefleet.cudnn_ops.attn import csa_sparse_attn_fwd_cudnn
+
+    _HAS_FLASH_MLA = (
+        paddlefleet_ops.is_flash_mla_available()
+        and csa_sparse_attn_fwd_cudnn._flash_mla_sparse_fwd is not None
+    )
+except (ImportError, RuntimeError, AttributeError):
+    _HAS_FLASH_MLA = False
+
+try:
+    import paddlefleet_ops
+
+    from paddlefleet.cudnn_ops import csa_sparse_attn_bwd_cudnn
+
+    _HAS_CUDNN_FRONTEND = paddlefleet_ops.is_cudnn_frontend_available() and (
+        callable(csa_sparse_attn_bwd_cudnn)
+    )
+except (ImportError, RuntimeError, AttributeError):
+    _HAS_CUDNN_FRONTEND = False
+
+_KERNEL_LATENT = 512
+# b, sq, skv, topk, invalid_frac, name. ``invalid_frac`` seeds ``-1`` columns
+# anywhere in the row, which is what document masking produces.
+_SHAPES = [
+    (1, 128, 256, 64, 0.0, "dense"),
+    (1, 128, 256, 64, 0.3, "holes"),
+    (2, 256, 512, 192, 0.2, "batch2-topk192"),
+    (1, 64, 8192, 192, 0.1, "hca-like"),
+    (1, 1, 64, 64, 0.0, "single-token"),
+]
+# The exp2 ernielite layer shape this was added for, plus two other widths to
+# keep the padding generic rather than 256-specific.
+_LATENTS = (256, 384, 128)
+
+
+def _rel_l2(a, b):
+    a_f = a.flatten().cast("float32")
+    b_f = b.flatten().cast("float32")
+    return float(
+        paddle.linalg.norm(a_f - b_f) / (paddle.linalg.norm(b_f) + 1e-12)
+    )
+
+
+def _make_inputs(
+    b, sq, skv, num_heads, hn, topk, invalid_frac, seed=0, sink=None
+):
+    paddle.seed(seed)
+    q = paddle.randn([b, sq, num_heads, hn]).cast("bfloat16")
+    kv = paddle.randn([b, skv, hn]).cast("bfloat16")
+    attn_sink = (paddle.randn([num_heads]) * 0.5).cast("float32")
+    if sink is not None:
+        attn_sink = _make_sink(num_heads, sink)
+    topk_idxs = paddle.randint(0, skv, [b, sq, topk]).cast("int32")
+    if invalid_frac > 0:
+        holes = paddle.rand([b, sq, topk]) < invalid_frac
+        topk_idxs = paddle.where(
+            holes, paddle.full_like(topk_idxs, -1), topk_idxs
+        )
+    return q, kv, attn_sink, topk_idxs, hn**-0.5
+
+
+def _make_sink(num_heads, spec):
+    """Attention-sink bias presets.
+
+    ``"split"`` puts half the heads at +8 and half at -8 in one call, so a bug
+    that mixes head rows up cannot hide behind a uniform sink.
+    """
+    if spec == "split":
+        half = num_heads // 2
+        return paddle.concat(
+            [
+                paddle.full([half], 8.0, dtype="float32"),
+                paddle.full([num_heads - half], -8.0, dtype="float32"),
+            ]
+        )
+    return paddle.full([num_heads], float(spec), dtype="float32")
+
+
+def _run(
+    q,
+    kv,
+    attn_sink,
+    topk_idxs,
+    scale,
+    backend,
+    grad_seed=None,
+    topk_length=None,
+):
+    """One fwd+bwd through the public entry point.
+
+    ``grad_seed`` seeds a random ``dO`` instead of the all-ones one an
+    ``out.sum()`` loss gives. That matters here: with ``dO == 1`` every latent
+    column carries the same gradient, so mis-padding ``dO`` at the wrong end --
+    or slicing ``dq``/``dkv`` from the wrong side -- would not show up. The
+    reference and the kernel run re-seed identically, so both see the same
+    ``dO``.
+    """
+    from paddlefleet.fusions.csa_sparse_attn import csa_sparse_attn
+
+    b, sq, num_heads, hn = q.shape
+    q = q.detach().clone()
+    q.stop_gradient = False
+    kv = kv.detach().clone()
+    kv.stop_gradient = False
+    attn_sink = attn_sink.detach().clone()
+    attn_sink.stop_gradient = False
+
+    kwargs = {} if topk_length is None else {"topk_length": topk_length}
+    out = csa_sparse_attn(
+        q, kv, attn_sink, topk_idxs, scale, backend=backend, **kwargs
+    )
+    if grad_seed is None:
+        out.sum().backward()
+    else:
+        paddle.seed(grad_seed)
+        out.backward(paddle.randn(out.shape).cast(out.dtype))
+    return {
+        "out": out.reshape([b, sq, num_heads, hn]),
+        "dq": q.grad,
+        "dkv": kv.grad,
+        "d_sink": attn_sink.grad,
+    }
+
+
+# Worst rel-L2 measured against the fp32 reference with a random dO, over every
+# shape in ``_SHAPES`` and every latent width in 64..512: out 2.4e-3, dq 3.1e-3,
+# dkv 3.3e-3, d_sink 3.9e-3 -- and the hn=512 native case sits at 2.4/2.8/3.2/
+# 3.5e-3, i.e. the padding contributes nothing above bf16 noise. Ceilings are
+# ~2x that; ``test_no_accuracy_loss_vs_native_512`` is the part that ties the
+# padded error to the native one and so catches a real regression.
+_REL_L2_CEILING = {"out": 6e-3, "dq": 6e-3, "dkv": 6e-3, "d_sink": 8e-3}
+
+
+@functools.lru_cache(maxsize=1)
+def _cudnn_sparse_bwd_runs():
+    """Whether the cuDNN sparse backward can actually execute here.
+
+    ``is_cudnn_frontend_available()`` is not a usable proxy: some builds import
+    a top-level ``cudnn`` module while executing, which the loader has already
+    renamed to ``paddlefleet_ops.cudnn``, so the call dies with
+    ``ModuleNotFoundError`` while the probe says "available". One native-width
+    backward settles it; anything other than a missing module is re-raised so a
+    real kernel regression still fails loudly.
+    """
+    if not (_HAS_FLASH_MLA and _HAS_CUDNN_FRONTEND):
+        return False
+    try:
+        _run(
+            *_make_inputs(1, 8, 64, 64, _KERNEL_LATENT, 64, 0.0),
+            backend="cudnn",
+        )
+    except Exception as exc:
+        if isinstance(exc, ImportError) or "No module named" in str(exc):
+            return False
+        raise
+    return True
+
+
+def _skip_without_cudnn_sparse_bwd():
+    if not _cudnn_sparse_bwd_runs():
+        raise unittest.SkipTest(
+            "the cuDNN sparse backward does not run in this environment"
+        )
+
+
+@unittest.skipUnless(
+    paddle.is_compiled_with_cuda(), "sub-512 latent tests require CUDA"
+)
+class TestSubLatentDim(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        _skip_without_cudnn_sparse_bwd()
+
+    def test_matches_unfused_reference(self):
+        for hn in _LATENTS:
+            for b, sq, skv, topk, inv, name in _SHAPES:
+                with self.subTest(hn=hn, shape=name):
+                    args = _make_inputs(b, sq, skv, 64, hn, topk, inv)
+                    ref = _run(*args, backend="unfused", grad_seed=7)
+                    got = _run(*args, backend="cudnn", grad_seed=7)
+                    for key, ceiling in _REL_L2_CEILING.items():
+                        self.assertLess(
+                            _rel_l2(got[key], ref[key]),
+                            ceiling,
+                            f"{key} at hn={hn} shape={name}",
+                        )
+
+    def test_arbitrary_latent_widths(self):
+        """Any width up to 512, including ones that are not multiples of 64.
+
+        The pad target is always 512 and ``paddle.concat`` returns a fresh
+        contiguous tensor, so the kernel's alignment requirements are met by the
+        padded copy regardless of how odd the real width is. Verified for 100 /
+        200 / 260 as well as the tidy multiples.
+        """
+        for hn in (64, 100, 192, 200, 260, 320, 448):
+            with self.subTest(hn=hn):
+                args = _make_inputs(1, 64, 256, 64, hn, 64, 0.1)
+                ref = _run(*args, backend="unfused", grad_seed=7)
+                got = _run(*args, backend="cudnn", grad_seed=7)
+                for key, ceiling in _REL_L2_CEILING.items():
+                    self.assertLess(
+                        _rel_l2(got[key], ref[key]), ceiling, f"{key} hn={hn}"
+                    )
+
+    def test_sink_magnitudes(self):
+        """The learnable sink bias must survive the latent padding.
+
+        The sink enters the softmax denominator only, so a padding bug that
+        perturbed the scores would show up here first: at sink=+20 the sink
+        dominates every row, at -1e4 it drops out entirely (``d_sink`` is then
+        exactly 0 on both sides), and "split" makes neighbouring heads disagree.
+        """
+        for sink in (-8.0, 0.0, 8.0, 20.0, -1e4, "split"):
+            for hn in (256, 128):
+                with self.subTest(sink=sink, hn=hn):
+                    args = _make_inputs(
+                        1, 128, 512, 64, hn, 192, 0.2, sink=sink
+                    )
+                    ref = _run(*args, backend="unfused", grad_seed=7)
+                    got = _run(*args, backend="cudnn", grad_seed=7)
+                    for key, ceiling in _REL_L2_CEILING.items():
+                        self.assertLess(
+                            _rel_l2(got[key], ref[key]),
+                            ceiling,
+                            f"{key} at sink={sink} hn={hn}",
+                        )
+
+    def test_no_accuracy_loss_vs_native_512(self):
+        """Padding must not make a narrow latent less accurate than hn=512.
+
+        Both runs are compared to their own fp32 reference, so the ratio is
+        scale-free; a real regression (wrong columns, stale padding) blows it up
+        far past the slack allowed here.
+        """
+        b, sq, skv, topk = 1, 128, 512, 192
+        base_args = _make_inputs(b, sq, skv, 64, _KERNEL_LATENT, topk, 0.2)
+        base = {
+            k: _rel_l2(v, _run(*base_args, backend="unfused", grad_seed=7)[k])
+            for k, v in _run(*base_args, backend="cudnn", grad_seed=7).items()
+        }
+        for hn in _LATENTS:
+            with self.subTest(hn=hn):
+                args = _make_inputs(b, sq, skv, 64, hn, topk, 0.2)
+                ref = _run(*args, backend="unfused", grad_seed=7)
+                got = _run(*args, backend="cudnn", grad_seed=7)
+                for key in ("out", "dq", "dkv"):
+                    self.assertLess(
+                        _rel_l2(got[key], ref[key]),
+                        max(3.0 * base[key], 1e-4),
+                        f"{key} at hn={hn} is worse than the hn=512 baseline "
+                        f"({base[key]:.3e})",
+                    )
+
+    def test_native_512_is_copy_free(self):
+        """``hn == 512`` must stay bit-for-bit unchanged, i.e. no pad at all."""
+        from paddlefleet.fusions.csa_sparse_attn import _pad_latent_dim
+
+        x = paddle.randn([2, 4, _KERNEL_LATENT]).cast("bfloat16")
+        self.assertIs(_pad_latent_dim(x, _KERNEL_LATENT), x)
+
+    def test_kernel_sees_zero_padded_512_and_output_is_sliced_back(self):
+        """Pin the plumbing bit-exactly by spying on the kernel call itself.
+
+        Checked at the boundary rather than against a hand-rolled second
+        pipeline, because the forward also pre-compacts ``topk_idxs`` and derives
+        its own ``topk_length``; reproducing that outside would either duplicate
+        the wrapper or change the summation order and stop being bit-exact.
+
+        Asserts the kernel is handed exactly 512 columns with zeros above ``hn``
+        (so the scores cannot move), and that what the entry point returns is
+        bit-for-bit the kernel's output sliced to ``hn`` -- which a wrong axis, an
+        off-by-one, or a stale non-contiguous view would all break.
+        """
+        import paddlefleet.cudnn_ops.attn.csa_sparse_attn_fwd_cudnn as fwd_mod
+        from paddlefleet.fusions.csa_sparse_attn import csa_sparse_attn
+
+        for hn in _LATENTS:
+            with self.subTest(hn=hn):
+                q, kv, sink, idxs, scale = _make_inputs(
+                    1, 128, 512, 64, hn, 192, 0.2
+                )
+                seen = {}
+                original = fwd_mod.flash_mla_sparse_attn
+
+                def spy(q_in, kv_in, *args, **kwargs):
+                    res = original(q_in, kv_in, *args, **kwargs)
+                    seen["q"], seen["kv"], seen["out"] = q_in, kv_in, res[0]
+                    return res
+
+                fwd_mod.flash_mla_sparse_attn = spy
+                try:
+                    wrapped = csa_sparse_attn(
+                        q, kv, sink, idxs, scale, backend="cudnn"
+                    )
+                finally:
+                    fwd_mod.flash_mla_sparse_attn = original
+
+                self.assertEqual(seen["q"].shape[-1], _KERNEL_LATENT)
+                self.assertEqual(seen["kv"].shape[-1], _KERNEL_LATENT)
+                for name in ("q", "kv"):
+                    self.assertEqual(
+                        float(seen[name][..., hn:].abs().max()),
+                        0.0,
+                        f"{name} padding is not zero",
+                    )
+                sliced = seen["out"][..., :hn].reshape(wrapped.shape)
+                self.assertEqual(
+                    float(
+                        (wrapped.cast("float32") - sliced.cast("float32"))
+                        .abs()
+                        .max()
+                    ),
+                    0.0,
+                )
+
+    def test_forward_is_deterministic(self):
+        """Two identical forwards must agree bit-for-bit.
+
+        Training runs this layer under ``recompute_modules=["full_attn", ...]``,
+        so the forward executes twice and the backward differentiates the second
+        run. Zero padding is deterministic, but this pins it.
+        """
+        from paddlefleet.fusions.csa_sparse_attn import csa_sparse_attn
+
+        args = _make_inputs(1, 128, 512, 24, 256, 192, 0.2)
+        first = csa_sparse_attn(*args, backend="cudnn")
+        second = csa_sparse_attn(*args, backend="cudnn")
+        self.assertEqual(
+            float((first.cast("float32") - second.cast("float32")).abs().max()),
+            0.0,
+        )
+
+    def test_topk_length_early_stop(self):
+        """The forward early-stop hint must still be honoured under padding.
+
+        ``topk_length`` is a forward-only hint: the backward ignores it and
+        rebuilds its own bound from the ``-1`` entries in ``topk_idxs``
+        (``_csa_compute_topk_length``). So the slots beyond the prefix have to be
+        marked ``-1`` as well, or the two halves differentiate different supports
+        -- measured ``dq`` rel-L2 1.1e+01 without the ``-1`` padding, identically
+        at hn=512 and hn=256, i.e. that is the API's contract and not something
+        the latent padding introduced.
+        """
+        b, sq, skv, hn, topk = 1, 128, 512, 256, 192
+        q, kv, sink, idxs, scale = _make_inputs(b, sq, skv, 64, hn, topk, 0.0)
+        paddle.seed(11)
+        topk_length = paddle.randint(1, topk + 1, [b, sq]).cast("int32")
+        slots = paddle.arange(topk, dtype="int32").reshape([1, 1, topk])
+        idxs = paddle.where(
+            slots >= topk_length.reshape([b, sq, 1]),
+            paddle.full_like(idxs, -1),
+            idxs,
+        )
+        args = (q, kv, sink, idxs, scale)
+        ref = _run(
+            *args, backend="unfused", grad_seed=7, topk_length=topk_length
+        )
+        got = _run(*args, backend="cudnn", grad_seed=7, topk_length=topk_length)
+        for key, ceiling in _REL_L2_CEILING.items():
+            self.assertLess(_rel_l2(got[key], ref[key]), ceiling, key)
+
+    def test_rejects_latent_wider_than_512(self):
+        from paddlefleet.fusions.csa_sparse_attn import (
+            _dsa_latent_dim,
+            csa_sparse_attn,
+        )
+
+        self.assertEqual(_dsa_latent_dim(256), _KERNEL_LATENT)
+        self.assertEqual(_dsa_latent_dim(_KERNEL_LATENT), _KERNEL_LATENT)
+        with self.assertRaisesRegex(ValueError, "at most 512 latent dims"):
+            _dsa_latent_dim(576)
+        args = _make_inputs(1, 8, 64, 64, 576, 64, 0.0)
+        with self.assertRaisesRegex(ValueError, "at most 512 latent dims"):
+            csa_sparse_attn(*args, backend="cudnn")
+
+
+@unittest.skipUnless(
+    paddle.is_compiled_with_cuda(), "sub-512 latent tests require CUDA"
+)
+class TestPaddedLatentColumnsAreZero(unittest.TestCase):
+    """The claim the whole approach rests on, checked at the kernel boundary.
+
+    Exactly zero, not small: if either kernel wrote anything into the padded
+    columns the slice-back in ``CSASparseAttention`` would silently discard real
+    contributions, so this is asserted as an exact 0 rather than a tolerance.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        _skip_without_cudnn_sparse_bwd()
+
+    def test_forward_and_backward_leave_padding_at_zero(self):
+        from paddlefleet.cudnn_ops import csa_sparse_attn_bwd_cudnn
+        from paddlefleet.cudnn_ops.attn.csa_sparse_attn_fwd_cudnn import (
+            flash_mla_sparse_attn,
+        )
+        from paddlefleet.fusions.csa_sparse_attn import (
+            _csa_compute_topk_length,
+            _pad_latent_dim,
+        )
+        from paddlefleet.fusions.csa_sparse_attn_utils import (
+            _local_to_global_flat,
+        )
+
+        b, sq, skv, heads, topk = 1, 128, 512, 64, 192
+        for hn in _LATENTS:
+            with self.subTest(hn=hn):
+                q, kv, sink, idxs, scale = _make_inputs(
+                    b, sq, skv, heads, hn, topk, 0.2
+                )
+                q_pad = _pad_latent_dim(q, _KERNEL_LATENT)
+                kv_pad = _pad_latent_dim(kv, _KERNEL_LATENT)
+                out, lse, _ = flash_mla_sparse_attn(
+                    q_pad, kv_pad, sink, idxs, sm_scale=scale
+                )
+                self.assertEqual(
+                    float(out[:, :, :, hn:].abs().max()), 0.0, "fwd out"
+                )
+
+                idxs_flat = _local_to_global_flat(idxs, skv)
+                dout = _pad_latent_dim(
+                    paddle.randn([b, sq, heads, hn]).cast(out.dtype),
+                    _KERNEL_LATENT,
+                )
+                dq, dkv, _ = csa_sparse_attn_bwd_cudnn(
+                    q_pad.reshape([b * sq, heads, _KERNEL_LATENT]),
+                    kv_pad.reshape([b * skv, _KERNEL_LATENT]),
+                    out.reshape([b * sq, heads, _KERNEL_LATENT]),
+                    dout.reshape([b * sq, heads, _KERNEL_LATENT]),
+                    lse.reshape([b * sq, heads]),
+                    sink,
+                    idxs_flat,
+                    softmax_scale=scale,
+                    topk_length=_csa_compute_topk_length(idxs_flat),
+                )
+                self.assertEqual(
+                    float(dq[:, :, hn:].abs().max()), 0.0, "bwd dq"
+                )
+                self.assertEqual(float(dkv[:, hn:].abs().max()), 0.0, "bwd dkv")
+
+
+@unittest.skipUnless(
+    paddle.is_compiled_with_cuda(), "sub-512 latent tests require CUDA"
+)
+class TestSubLatentWithSubTileHeads(unittest.TestCase):
+    """The ernielite exp2 layer: 24 heads AND a 256 latent, both padded."""
+
+    @classmethod
+    def setUpClass(cls):
+        _skip_without_cudnn_sparse_bwd()
+
+    def test_head_and_latent_padding_compose(self):
+        for heads in (24, 32):
+            for b, sq, skv, topk, inv, name in _SHAPES:
+                with self.subTest(heads=heads, shape=name):
+                    args = _make_inputs(b, sq, skv, heads, 256, topk, inv)
+                    ref = _run(*args, backend="unfused", grad_seed=7)
+                    got = _run(*args, backend="cudnn", grad_seed=7)
+                    for key, ceiling in _REL_L2_CEILING.items():
+                        self.assertLess(
+                            _rel_l2(got[key], ref[key]),
+                            ceiling,
+                            f"{key} at heads={heads} shape={name}",
+                        )
+
+    def test_head_and_latent_padding_compose_with_sink_sweep(self):
+        """Both paddings active *and* a degenerate sink, which is the case where
+        a leak between the padded head rows and the padded latent columns would
+        be easiest to miss: the padded heads carry a -1e30 sink while the real
+        heads carry an extreme one."""
+        for sink in (20.0, -1e4, "split"):
+            with self.subTest(sink=sink):
+                args = _make_inputs(1, 128, 512, 24, 256, 192, 0.2, sink=sink)
+                ref = _run(*args, backend="unfused", grad_seed=7)
+                got = _run(*args, backend="cudnn", grad_seed=7)
+                for key, ceiling in _REL_L2_CEILING.items():
+                    self.assertLess(
+                        _rel_l2(got[key], ref[key]),
+                        ceiling,
+                        f"{key} at sink={sink}",
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_sub_tile_heads.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_sub_tile_heads.py
@@ -1,0 +1,464 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Query-head counts below a kernel tile on the CSA "cudnn" backend.
+
+FlashMLA's sparse prefill only instantiates 64- and 128-head tiles, so an HCA /
+CSA layer with 32 or 24 heads zero-pads the forward up to the tile and (on
+SM100) drives the backward at the real head count. Three properties are pinned:
+
+1. agreement with the fp32 ``unfused`` reference at the same error level as the
+   tile-native 64-head case -- the padding must not cost accuracy;
+2. non-interference -- whatever occupies the padded rows cannot change the real
+   heads' ``out`` / ``dq``, bit-for-bit;
+3. the backward really runs at the real head count on SM100, which is what stops
+   the padded forward from making a sub-tile layer cost more than a 64-head one.
+"""
+
+import functools
+import unittest
+
+import paddle
+
+try:
+    import paddlefleet_ops
+
+    from paddlefleet.cudnn_ops.attn import csa_sparse_attn_fwd_cudnn
+
+    _HAS_FLASH_MLA = (
+        paddlefleet_ops.is_flash_mla_available()
+        and csa_sparse_attn_fwd_cudnn._flash_mla_sparse_fwd is not None
+    )
+except (ImportError, RuntimeError, AttributeError):
+    _HAS_FLASH_MLA = False
+
+try:
+    import paddlefleet_ops
+
+    from paddlefleet.cudnn_ops import csa_sparse_attn_bwd_cudnn
+
+    _HAS_CUDNN_FRONTEND = paddlefleet_ops.is_cudnn_frontend_available() and (
+        callable(csa_sparse_attn_bwd_cudnn)
+    )
+except (ImportError, RuntimeError, AttributeError):
+    _HAS_CUDNN_FRONTEND = False
+
+_HEAD_TILE = 64
+_D = 512
+
+# b, sq, skv, topk, invalid_frac, name. ``invalid_frac`` seeds ``-1`` columns
+# anywhere in the row (not just a trailing pad), which is what document masking
+# produces and what the backward's trailing ``topk_length`` bound must survive.
+_SHAPES = [
+    (1, 128, 256, 64, 0.0, "dense"),
+    (1, 128, 256, 64, 0.3, "holes"),
+    (2, 256, 512, 192, 0.2, "batch2-topk192"),
+    (1, 64, 8192, 192, 0.1, "hca-like"),
+    (1, 1, 64, 64, 0.0, "single-token"),
+]
+
+
+def _rel_l2(a, b):
+    a_f = a.flatten().cast("float32")
+    b_f = b.flatten().cast("float32")
+    return float(
+        paddle.linalg.norm(a_f - b_f) / (paddle.linalg.norm(b_f) + 1e-12)
+    )
+
+
+def _max_abs_diff(a, b):
+    return float((a.cast("float32") - b.cast("float32")).abs().max())
+
+
+def _make_inputs(b, sq, skv, num_heads, topk, invalid_frac, seed=0, sink=None):
+    paddle.seed(seed)
+    q = paddle.randn([b, sq, num_heads, _D]).cast("bfloat16")
+    kv = paddle.randn([b, skv, _D]).cast("bfloat16")
+    attn_sink = (paddle.randn([num_heads]) * 0.5).cast("float32")
+    if sink is not None:
+        attn_sink = _make_sink(num_heads, sink)
+    topk_idxs = paddle.randint(0, skv, [b, sq, topk]).cast("int32")
+    if invalid_frac > 0:
+        holes = paddle.rand([b, sq, topk]) < invalid_frac
+        topk_idxs = paddle.where(
+            holes, paddle.full_like(topk_idxs, -1), topk_idxs
+        )
+        # Keep one valid column per row; an all-invalid row has no reference.
+        topk_idxs[:, :, 0] = paddle.randint(0, skv, [b, sq]).cast("int32")
+    return q, kv, attn_sink, topk_idxs, 1.0 / _D**0.5
+
+
+def _make_sink(num_heads, spec):
+    """``spec`` is a constant logit, or "split" for half dominant/half ignored."""
+    if spec == "split":
+        half = num_heads // 2
+        return paddle.concat(
+            [
+                paddle.full([half], 8.0, dtype="float32"),
+                paddle.full([num_heads - half], -8.0, dtype="float32"),
+            ]
+        )
+    return paddle.full([num_heads], float(spec), dtype="float32")
+
+
+def _run(q, kv, attn_sink, topk_idxs, scale, backend, junk_heads=0):
+    """One fwd+bwd. ``junk_heads`` appends random extra heads.
+
+    Returns the first ``num_heads`` heads of ``out`` and ``dq`` plus ``dkv`` and
+    ``d_sink``, so a junk-head run stays comparable to a plain one.
+    """
+    from paddlefleet.fusions.csa_sparse_attn import csa_sparse_attn
+
+    b, sq, num_heads, _ = q.shape
+    if junk_heads:
+        q = paddle.concat(
+            [q, paddle.randn([b, sq, junk_heads, _D]).cast(q.dtype)], axis=2
+        )
+        attn_sink = paddle.concat(
+            [attn_sink, (paddle.randn([junk_heads]) * 0.5).cast("float32")],
+            axis=0,
+        )
+    q = q.detach().clone()
+    q.stop_gradient = False
+    kv = kv.detach().clone()
+    kv.stop_gradient = False
+    attn_sink = attn_sink.detach().clone()
+    attn_sink.stop_gradient = False
+
+    out = csa_sparse_attn(q, kv, attn_sink, topk_idxs, scale, backend=backend)
+    out.sum().backward()
+    out = out.reshape([b, sq, num_heads + junk_heads, _D])[:, :, :num_heads, :]
+    return {
+        "out": out,
+        "dq": q.grad[:, :, :num_heads, :],
+        "dkv": kv.grad,
+        "d_sink": attn_sink.grad[:num_heads],
+    }
+
+
+# Ceilings are ~2x the worst observed bf16 error of the tile-native 64-head
+# case; ``test_no_accuracy_loss_vs_tile_native`` additionally ties the sub-tile
+# error to the 64-head one, which is the part that catches a real regression.
+_REL_L2_CEILING = {"out": 6e-3, "dq": 6e-3, "dkv": 6e-3, "d_sink": 8e-3}
+
+
+@functools.lru_cache(maxsize=1)
+def _cudnn_sparse_bwd_runs():
+    """Whether the cuDNN sparse backward can actually execute here.
+
+    ``is_cudnn_frontend_available()`` is not a usable proxy. Some builds of the
+    vendored frontend import a *top-level* ``cudnn`` module while executing,
+    which the loader has already renamed to ``paddlefleet_ops.cudnn``, so the
+    call dies with ``ModuleNotFoundError`` while the probe says "available".
+    One tile-native backward settles it; anything other than a missing module
+    is re-raised, so a real kernel regression still fails loudly.
+    """
+    if not (_HAS_FLASH_MLA and _HAS_CUDNN_FRONTEND):
+        return False
+    try:
+        _run(*_make_inputs(1, 8, 64, _HEAD_TILE, 64, 0.0), backend="cudnn")
+    except Exception as exc:
+        if isinstance(exc, ImportError) or "No module named" in str(exc):
+            return False
+        raise
+    return True
+
+
+def _skip_without_cudnn_sparse_bwd():
+    if not _cudnn_sparse_bwd_runs():
+        raise unittest.SkipTest(
+            "the cuDNN sparse backward does not run in this environment"
+        )
+
+
+@unittest.skipUnless(
+    paddle.is_compiled_with_cuda(), "sub-tile head tests require CUDA"
+)
+class TestSubTileHeads(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        _skip_without_cudnn_sparse_bwd()
+
+    def test_matches_unfused_reference(self):
+        for num_heads in (32, 24):
+            for b, sq, skv, topk, inv, name in _SHAPES:
+                with self.subTest(heads=num_heads, shape=name):
+                    args = _make_inputs(b, sq, skv, num_heads, topk, inv)
+                    ref = _run(*args, backend="unfused")
+                    got = _run(*args, backend="cudnn")
+                    for key, ceiling in _REL_L2_CEILING.items():
+                        self.assertLess(
+                            _rel_l2(got[key], ref[key]),
+                            ceiling,
+                            f"{key} diverges from the fp32 reference",
+                        )
+
+    def test_no_accuracy_loss_vs_tile_native(self):
+        """Padding must not make a sub-tile layer less accurate than h=64.
+
+        ``d_sink`` is excluded: it is one value per head, so its relative L2 is
+        a 24- to 64-element statistic that swings an order of magnitude with the
+        head count alone (measured 2.1e-3 at h=64, 2.4e-4 at h=32, 1.2e-3 at
+        h=24 on SM100, and the same numbers whether the backward runs at the
+        real head count or fully padded). A ratio against the 64-head draw
+        therefore says nothing here; the sink is bounded absolutely by
+        ``test_matches_unfused_reference`` and ``test_sink_magnitudes``, and
+        pinned bit-exactly by ``TestBackwardHeadWidth``.
+        """
+        ratio_keys = [key for key in _REL_L2_CEILING if key != "d_sink"]
+        b, sq, skv, topk, inv = 2, 256, 512, 192, 0.2
+        baseline = _make_inputs(b, sq, skv, _HEAD_TILE, topk, inv)
+        base_ref = _run(*baseline, backend="unfused")
+        base_got = _run(*baseline, backend="cudnn")
+        base_err = {
+            key: _rel_l2(base_got[key], base_ref[key]) for key in ratio_keys
+        }
+        for num_heads in (32, 24):
+            args = _make_inputs(b, sq, skv, num_heads, topk, inv)
+            ref = _run(*args, backend="unfused")
+            got = _run(*args, backend="cudnn")
+            for key in ratio_keys:
+                with self.subTest(heads=num_heads, tensor=key):
+                    self.assertLess(
+                        _rel_l2(got[key], ref[key]),
+                        2.0 * base_err[key],
+                        f"{key} is materially worse than at {_HEAD_TILE} heads",
+                    )
+
+    def test_padded_rows_cannot_leak(self):
+        """Real heads are bit-identical whatever occupies the padded rows.
+
+        The library pads with zeros; here the same call is repeated with
+        *random* q and *random* finite sinks in the trailing rows. ``out`` and
+        ``dq`` are per-head, so they must not move at all. ``dkv`` / ``d_sink``
+        are sums over heads and legitimately change, so they are not compared.
+        """
+        for num_heads in (32, 24):
+            for b, sq, skv, topk, inv, name in _SHAPES:
+                with self.subTest(heads=num_heads, shape=name):
+                    args = _make_inputs(b, sq, skv, num_heads, topk, inv)
+                    padded = _run(*args, backend="cudnn")
+                    junked = _run(
+                        *args,
+                        backend="cudnn",
+                        junk_heads=_HEAD_TILE - num_heads,
+                    )
+                    for key in ("out", "dq"):
+                        self.assertEqual(
+                            _max_abs_diff(padded[key], junked[key]),
+                            0.0,
+                            f"{key} depends on the padded rows",
+                        )
+
+    def test_sink_magnitudes(self):
+        """The learnable sink must survive the padding at any magnitude.
+
+        The padded rows carry a ``-1e30`` sink while the real ones keep the
+        learnable logit, and ``d_sink`` comes back from a differently shaped
+        kernel call, so the sink is the part of this path most likely to break
+        silently. A dominant sink (``+8``: the sink wins the denominator and the
+        output nearly vanishes) and a per-head split are the cases where a
+        leaked pad row or a mis-aligned ``d_sink`` slice would show up.
+        """
+        for num_heads in (32, 24):
+            for spec in (-8.0, 0.0, 8.0, "split"):
+                with self.subTest(heads=num_heads, sink=spec):
+                    args = _make_inputs(
+                        2, 256, 512, num_heads, 192, 0.2, sink=spec
+                    )
+                    ref = _run(*args, backend="unfused")
+                    got = _run(*args, backend="cudnn")
+                    for key, ceiling in _REL_L2_CEILING.items():
+                        self.assertLess(
+                            _rel_l2(got[key], ref[key]),
+                            ceiling,
+                            f"{key} diverges at sink={spec}",
+                        )
+
+    def test_odd_head_count_uses_the_padded_backward(self):
+        """An odd head count must still be correct, via the padded backward.
+
+        The cuDNN backward reads the ``[N, H]`` fp32 LSE with a 2-float vector
+        access and dies with CUDA 716 on an odd ``H``, so those fall back to the
+        (even) padded tile. Without the fallback this test crashes the process
+        rather than failing, which is exactly why it is here.
+        """
+        from paddlefleet.fusions.csa_sparse_attn import (
+            _dsa_bwd_runs_sub_tile_heads,
+        )
+
+        self.assertFalse(_dsa_bwd_runs_sub_tile_heads(31))
+        args = _make_inputs(1, 128, 256, 31, 64, 0.2)
+        ref = _run(*args, backend="unfused")
+        got = _run(*args, backend="cudnn")
+        for key, ceiling in _REL_L2_CEILING.items():
+            self.assertLess(_rel_l2(got[key], ref[key]), ceiling, key)
+
+
+@unittest.skipUnless(
+    paddle.is_compiled_with_cuda(), "sub-tile head tests require CUDA"
+)
+@unittest.skipUnless(
+    _HAS_FLASH_MLA, "sub-tile head forward tests require FlashMLA"
+)
+class TestSubTileHeadsForward(unittest.TestCase):
+    """Forward-only properties, so they also run where the backward cannot."""
+
+    def test_rejects_more_heads_than_the_widest_tile(self):
+        from paddlefleet.fusions.csa_sparse_attn import csa_sparse_attn
+
+        args = _make_inputs(1, 8, 64, 160, 64, 0.0)
+        with self.assertRaisesRegex(ValueError, "at most 128 query heads"):
+            csa_sparse_attn(*args, backend="cudnn")
+
+    def test_indexer_lse_is_returned_at_the_real_head_count(self):
+        """``lse_indexer`` feeds the indexer loss and must lose the pad too."""
+        from paddlefleet.fusions.csa_sparse_attn import (
+            _pad_query_heads,
+            csa_sparse_attn,
+        )
+
+        indexer_topk = 512
+        for num_heads in (32, 24):
+            with self.subTest(heads=num_heads):
+                q, kv, sink, idxs, scale = _make_inputs(
+                    1, 64, 1024, num_heads, indexer_topk + 128, 0.0
+                )
+                _, lse_indexer = csa_sparse_attn(
+                    q,
+                    kv,
+                    sink,
+                    idxs,
+                    scale,
+                    backend="cudnn",
+                    indexer_topk=indexer_topk,
+                )
+                self.assertEqual(list(lse_indexer.shape), [1, 64, num_heads])
+                q_pad, sink_pad = _pad_query_heads(q, sink, _HEAD_TILE)
+                _, lse_ref = csa_sparse_attn(
+                    q_pad,
+                    kv,
+                    sink_pad,
+                    idxs,
+                    scale,
+                    backend="cudnn",
+                    indexer_topk=indexer_topk,
+                )
+                self.assertEqual(
+                    _max_abs_diff(lse_indexer, lse_ref[:, :, :num_heads]),
+                    0.0,
+                )
+
+
+@unittest.skipUnless(
+    paddle.is_compiled_with_cuda(), "sub-tile head tests require CUDA"
+)
+class TestBackwardHeadWidth(unittest.TestCase):
+    """The backward is driven at the real head count, not the forward's tile.
+
+    That is the whole reason a 32-head layer costs about what a 64-head one does
+    instead of ~1.6x: only the forward pays for the padded tile. If the cuDNN
+    kernel ever stops predicating its partial head tile this test fails, and
+    ``_dsa_bwd_runs_sub_tile_heads`` has to be switched off for the arch.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        _skip_without_cudnn_sparse_bwd()
+
+    def _bwd(self, q, kv, out, dout, lse, sink, gidx, scale, num_heads):
+        from paddlefleet.fusions.csa_sparse_attn import _csa_compute_topk_length
+
+        b, sq = q.shape[0], q.shape[1]
+        s_kv = kv.shape[1]
+        return csa_sparse_attn_bwd_cudnn(
+            q.reshape([b * sq, num_heads, _D]),
+            kv.reshape([b * s_kv, _D]),
+            out.reshape([b * sq, num_heads, _D]),
+            dout.reshape([b * sq, num_heads, _D]),
+            lse.reshape([b * sq, num_heads]),
+            sink,
+            gidx,
+            softmax_scale=scale,
+            topk_length=_csa_compute_topk_length(gidx),
+        )
+
+    def test_real_head_count_matches_the_padded_backward(self):
+        from paddlefleet.cudnn_ops.attn.csa_sparse_attn_fwd_cudnn import (
+            flash_mla_sparse_attn,
+        )
+        from paddlefleet.fusions.csa_sparse_attn import (
+            _dsa_bwd_runs_sub_tile_heads,
+            _pad_query_heads,
+        )
+        from paddlefleet.fusions.csa_sparse_attn_utils import (
+            _local_to_global_flat,
+        )
+
+        for num_heads in (32, 24):
+            if not _dsa_bwd_runs_sub_tile_heads(num_heads):
+                self.skipTest("this arch keeps the fully padded backward")
+            for b, sq, skv, topk, inv, name in _SHAPES:
+                with self.subTest(heads=num_heads, shape=name):
+                    q, kv, sink, idxs, scale = _make_inputs(
+                        b, sq, skv, num_heads, topk, inv
+                    )
+                    dout = paddle.randn([b, sq, num_heads, _D]).cast("bfloat16")
+                    q_pad, sink_pad = _pad_query_heads(q, sink, _HEAD_TILE)
+                    dout_pad, _ = _pad_query_heads(dout, sink, _HEAD_TILE)
+                    out_pad, lse_pad, _ = flash_mla_sparse_attn(
+                        q_pad, kv, sink_pad, idxs, sm_scale=scale
+                    )
+                    gidx = _local_to_global_flat(idxs, skv)
+
+                    dq_t, dkv_t, dsink_t = self._bwd(
+                        q_pad,
+                        kv,
+                        out_pad,
+                        dout_pad,
+                        lse_pad,
+                        sink_pad,
+                        gidx,
+                        scale,
+                        _HEAD_TILE,
+                    )
+                    dq_h, dkv_h, dsink_h = self._bwd(
+                        q,
+                        kv,
+                        out_pad.reshape([b, sq, _HEAD_TILE, _D])[
+                            :, :, :num_heads, :
+                        ].contiguous(),
+                        dout,
+                        lse_pad[:, :, :num_heads].contiguous(),
+                        sink,
+                        gidx,
+                        scale,
+                        num_heads,
+                    )
+                    dq_t = dq_t.reshape([b * sq, _HEAD_TILE, _D])[
+                        :, :num_heads, :
+                    ]
+                    dq_h = dq_h.reshape([b * sq, num_heads, _D])
+                    self.assertEqual(_max_abs_diff(dq_h, dq_t), 0.0, "dq moved")
+                    self.assertEqual(
+                        _max_abs_diff(dsink_h, dsink_t[:num_heads]),
+                        0.0,
+                        "d_sink moved",
+                    )
+                    # dKV is accumulated with atomics, so only near-equal.
+                    self.assertLess(_rel_l2(dkv_h, dkv_t), 1e-3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_sub_tile_heads.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_sub_tile_heads.py
@@ -378,10 +378,17 @@ class TestBackwardHeadWidth(unittest.TestCase):
         _skip_without_cudnn_sparse_bwd()
 
     def _bwd(self, q, kv, out, dout, lse, sink, gidx, scale, num_heads):
-        from paddlefleet.fusions.csa_sparse_attn import _csa_compute_topk_length
+        from paddlefleet.fusions.csa_sparse_attn import _csa_compact_topk_idxs
 
         b, sq = q.shape[0], q.shape[1]
         s_kv = kv.shape[1]
+        # The backward's compact KV-load path is unguarded against interior -1,
+        # so ``topk_length`` must come from compacted indices (production does
+        # the same in ``csa_attention.py``). Passing the trailing bound of
+        # ``_csa_compute_topk_length`` together with holey indices corrupts
+        # dq/dkv by ~50%, or raises CUDA 700 / yields nan. Compacting is
+        # order-preserving, so the bit-exact assertions below still hold.
+        gidx, topk_length = _csa_compact_topk_idxs(gidx)
         return csa_sparse_attn_bwd_cudnn(
             q.reshape([b * sq, num_heads, _D]),
             kv.reshape([b * s_kv, _D]),
@@ -391,7 +398,7 @@ class TestBackwardHeadWidth(unittest.TestCase):
             sink,
             gidx,
             softmax_scale=scale,
-            topk_length=_csa_compute_topk_length(gidx),
+            topk_length=topk_length,
         )
 
     def test_real_head_count_matches_the_padded_backward(self):

--- a/tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_sub_tile_heads.py
+++ b/tests/single_card_tests/ai_edited_test/fusions/test_csa_sparse_attn_sub_tile_heads.py
@@ -365,12 +365,20 @@ class TestSubTileHeadsForward(unittest.TestCase):
     paddle.is_compiled_with_cuda(), "sub-tile head tests require CUDA"
 )
 class TestBackwardHeadWidth(unittest.TestCase):
-    """The backward is driven at the real head count, not the forward's tile.
+    """Direct ``csa_sparse_attn_bwd_cudnn`` calls, at both head widths.
 
-    That is the whole reason a 32-head layer costs about what a 64-head one does
-    instead of ~1.6x: only the forward pays for the padded tile. If the cuDNN
-    kernel ever stops predicating its partial head tile this test fails, and
-    ``_dsa_bwd_runs_sub_tile_heads`` has to be switched off for the arch.
+    ``_bwd`` below is the contract this class pins: the kernel's compact
+    KV-load path (selected by passing ``topk_length``) is unguarded against
+    interior ``-1``, so the length must come from *compacted* indices.
+    ``test_compacted_topk_length_matches_the_reference`` checks that at the
+    kernel's own head tile, so it runs on every arch where the backward runs at
+    all.
+
+    ``test_real_head_count_matches_the_padded_backward`` additionally pins the
+    sub-tile backward, i.e. that a 32-head layer costs about what a 64-head one
+    does instead of ~1.6x because only the forward pays for the padded tile.
+    That one is gated on ``_dsa_bwd_runs_sub_tile_heads``, which is currently
+    off below a full head tile (see its docstring).
     """
 
     @classmethod
@@ -401,6 +409,65 @@ class TestBackwardHeadWidth(unittest.TestCase):
             topk_length=topk_length,
         )
 
+    def test_compacted_topk_length_matches_the_reference(self):
+        """``topk_length`` must be paired with compacted indices.
+
+        Regression cover for ``_bwd``'s compaction, independent of
+        ``_dsa_bwd_runs_sub_tile_heads``: it runs at the kernel's own head tile,
+        so no head padding is involved and it executes wherever the cuDNN
+        backward executes. Feeding the same holey indices with the trailing
+        bound of ``_csa_compute_topk_length`` instead measures dq at 4.6e-01 and
+        dkv at 5.0e-01 (or non-finite / ``CUDA error(700)``, since the gather
+        reads uninitialised memory), i.e. about 75x the ceiling below, so
+        dropping the compaction fails here.
+        """
+        from paddlefleet.cudnn_ops.attn.csa_sparse_attn_fwd_cudnn import (
+            flash_mla_sparse_attn,
+        )
+        from paddlefleet.fusions.csa_sparse_attn_utils import (
+            _local_to_global_flat,
+        )
+
+        for b, sq, skv, topk, inv, name in _SHAPES:
+            if inv == 0.0:
+                continue  # no holes: compaction is a no-op, nothing to pin
+            with self.subTest(shape=name):
+                args = _make_inputs(b, sq, skv, _HEAD_TILE, topk, inv)
+                q, kv, sink, idxs, scale = args
+                # ``_run`` backpropagates ``out.sum()``, so match its dout.
+                ref = _run(*args, backend="unfused")
+                dout = paddle.ones([b, sq, _HEAD_TILE, _D], dtype="bfloat16")
+                out, lse, _ = flash_mla_sparse_attn(
+                    q, kv, sink, idxs, sm_scale=scale
+                )
+                dq, dkv, d_sink = self._bwd(
+                    q,
+                    kv,
+                    out,
+                    dout,
+                    lse,
+                    sink,
+                    _local_to_global_flat(idxs, skv),
+                    scale,
+                    _HEAD_TILE,
+                )
+                got = {
+                    "dq": dq.reshape([b, sq, _HEAD_TILE, _D]),
+                    "dkv": dkv.reshape(kv.shape),
+                    "d_sink": d_sink,
+                }
+                for key, value in got.items():
+                    self.assertEqual(
+                        int(paddle.isfinite(value.cast("float32")).all()),
+                        1,
+                        f"{key} is not finite",
+                    )
+                    self.assertLess(
+                        _rel_l2(value, ref[key]),
+                        _REL_L2_CEILING[key],
+                        f"{key} diverges from the fp32 reference",
+                    )
+
     def test_real_head_count_matches_the_padded_backward(self):
         from paddlefleet.cudnn_ops.attn.csa_sparse_attn_fwd_cudnn import (
             flash_mla_sparse_attn,
@@ -413,9 +480,10 @@ class TestBackwardHeadWidth(unittest.TestCase):
             _local_to_global_flat,
         )
 
-        for num_heads in (32, 24):
-            if not _dsa_bwd_runs_sub_tile_heads(num_heads):
-                self.skipTest("this arch keeps the fully padded backward")
+        widths = [h for h in (32, 24) if _dsa_bwd_runs_sub_tile_heads(h)]
+        if not widths:
+            self.skipTest("this arch keeps the fully padded backward")
+        for num_heads in widths:
             for b, sq, skv, topk, inv, name in _SHAPES:
                 with self.subTest(heads=num_heads, shape=name):
                     q, kv, sink, idxs, scale = _make_inputs(


### PR DESCRIPTION
### PR Category

Operator Mechanism

### PR Types

Bug fixes

### Description

Three fixes around the cuDNN sparse-attention backward, all in the CSA wrapper
and its tests. No kernel, no config default, and no production call site changes
behaviour.

#### 1. Keep the sparse-attn backward on the kernel head tile

`_dsa_bwd_runs_sub_tile_heads` gated the real-head-count (sub-tile) backward on
`num_heads % 2 == 0`. On SM100 that path drives the cuDNN kernel at a head count
the kernel does not support, and it reads out of bounds.

Root cause is in the kernel, not here. `dsa_bwd_sm100.py`
(cudnn-frontend submodule) sizes `workspace_LSE_OdO` as
`(b, h, round_up(q, 8), 8)` with **zero slack** for the two back-to-back
`(H, (Q, 1))` views it carves out of it (`sum_OdO`, `scaled_lse`). Both views
declare `cute.assume(H, divby=64)`. The consumer then tiles the *head* mode by
64 (`cute.flat_divide`) and issues an **unpredicated** 32-thread x 2-value
`cp.async`, i.e. an unconditional 64-element / 256-byte load. At `H = 24` only
96 bytes are in bounds, so the last query token over-reads 160 bytes past the
workspace and the second-to-last over-reads 64 bytes.

Every *other* 64-head-tiled access in that kernel goes through TMA and is
hardware-clipped against the tensormap's `globalDim`, which is why only this one
access is exposed. The SM90 kernel is fully predicated and has no such
workspace.

It is a **read**, so results stay correct; `CUDA error(700)` fires only when
those bytes land on an unmapped page, which makes it an allocator-layout
lottery. Measured at production geometry (`total_S_q = 32768`, `max_topk = 384`)
with allocator arena varied to move the workspace:

| case | ws_LSE_OdO headroom | ws_dKV headroom | result |
|---|---|---|---|
| H=24 as-is | 0 | 0 | CUDA 700 |
| H=24, ws_LSE_OdO over-allocated (view shapes unchanged) | >=256 B | 0 | pass |
| H=24, ws_dKV over-allocated | 0 | 8 MiB | CUDA 700 |
| H=128 as-is | 0 | 0 | pass |
| H=16 / H=48 as-is | 0 | 0 | CUDA 700 |

So the trigger is `num_heads % 64 != 0`, not `num_heads < 64` — H=48 faults too,
and H=128 passes at zero headroom. `compute-sanitizer memcheck --padding 512`
pins it to a single PC, 28 errors, only in blocks 32767 and 32766, offsets
0..152 step 8 (= the 160 B and 64 B above); the same command at H=64 reports 0
errors, which self-calibrates the tool. `dmesg` shows Xid 31
`FAULT_PDE ACCESS_TYPE_VIRT_READ` at a virtual address equal to the end of
`workspace_LSE_OdO`.

The existing docstring described this same access but cut the condition at odd
head counts only, and claimed the kernel "predicates the partial tile" — it does
not. Plain `memcheck` without `--padding` reports 0 violations because it pads
allocations, which perturbs the bug away.

Fix here: gate on `num_heads % 64 == 0`, so H = 16/24/32/48 fall back to the
padded (tile-width) backward. Cost is that the backward runs at 64 heads and the
padded activations stay alive, i.e. the sub-tile backward optimisation is
suspended for those head counts. The docstring records the exact revert
condition: once the kernel predicates those two tile loads, or bumps the `q`
extent of `workspace_LSE_OdO` by 64 (+12 KiB, verified sufficient), this can go
back to `% 2 == 0`.

Verified end to end on an ERNIELite MoE config (H=24, cuDNN backend, mbs=4,
8 GPUs, 12 steps, same data order as the archived baseline): `train_loss`
12.238094 vs 12.238097, max per-step deviation across 8 ranks x 12 steps
4.96e-05, 192 metrics with 0 non-finite. That residual is the dKV `atomicAdd`
floor and is consistent with only widening the backward's head extent while the
padded heads carry `sink = -1e30`. The three allocator layouts that previously
faulted 3/3 now pass 6/6 across H = 24 and 32.

Also corrected three stale comments that described the padded backward as
SM90-only; it is now the SM100 default as well.

#### 2. Two tests violated the `topk_length` calling contract

Passing `topk_length` selects the backward's compact KV-load path, which
unconditionally reads the first `length` columns and has **no guard against
interior `-1`** — it gathers `mKV[-1]`. So `topk_length` is only valid together
with **compacted** indices.

`_csa_compute_topk_length` returns a *trailing* bound, which is safe for the
forward (it predicates `-1` slots) but not for the backward. Two tests passed
that bound alongside holey indices and failed on SM100:

- `test_csa_sparse_attn_sub_tile_heads.py::TestBackwardHeadWidth::test_real_head_count_matches_the_padded_backward`
- `test_csa_sparse_attn_sub_512_latent.py::TestPaddedLatentColumnsAreZero::test_forward_and_backward_leave_padding_at_zero`

Measured, holey indices, cuDNN backward vs the fp32 `unfused` reference:

| shape | A: trailing bound + holey idxs | B: compact + exact count | C: `topk_length=None` |
|---|---|---|---|
| h=24 hn=256 | dq **non-finite** (786432 elements) , dkv 5.045e-01 | dq 2.584e-03, dkv 3.218e-03 | same as B |
| h=24 hn=512 | dq **5.008e-01**, dkv 5.094e-01 | dq 2.616e-03, dkv 3.215e-03 | same as B |
| h=64 hn=128 | dq **4.576e-01**, dkv 5.002e-01 | dq 2.503e-03, dkv 3.249e-03 | same as B |

`out` stays at ~2.3e-03 throughout, so the forward looks healthy while the
backward is wrong — and the observed failure mode varies run to run between
`CUDA error(700)`, nan, inf, and a silent ~50% error, because the gather reads
uninitialised device memory. With no holes, A == B == C, which self-calibrates
the comparison.

Fixes: the head-width test now compacts with `_csa_compact_topk_idxs` and passes
the exact count it returns (order-preserving, so its bit-exact assertions still
hold); the sub-512 test only asserts that padded latent columns stay zero, so it
passes `topk_length=None` and keeps the guarded full-width path.

Production call sites were already correct: `csa_attention.py` compacts before
passing, `csa_sparse_attn.py` only computes a length when `ctx.compacted_idxs`,
and `mqa_sparse_attn.py` passes `None` explicitly.

#### 3. Document the contract

Added a WARNING to `_csa_compute_topk_length`'s docstring stating that its bound
is forward-only, and what happens if it reaches the backward. The previous text
claimed the bound "stays correct when -1 entries are interleaved", which holds
for the forward only and contradicted the correct note further down the file.

#### 4. Make the `topk_length` contract explicit instead of implicit (review follow-up)

Item 2 fixed the two tests that violated the contract, but the wrapper still
*inferred* the promise: `ctx.compacted_idxs` was true for any SM100 cuDNN call,
so a caller passing `topk_length` over holey indices would silently take the
unguarded compact backward. `topk_length` is documented as a forward-only
early-stop hint, so it does not imply compaction.

Added an explicit `topk_idxs_compacted` kwarg, default `False`:

```python
ctx.compacted_idxs = (
    backend == "cudnn"
    and indexer_topk == 0
    and _csa_bwd_honours_topk_length_holes()
    and (topk_length is None or topk_idxs_compacted)
)
```

A caller that supplies `topk_length` without the promise keeps its own layout and
the backward falls back to the guarded full-width path — correct, just without
the early stop. Safe by default, zero runtime cost, and the production early stop
is preserved.

Rejected alternatives: validating the prefix unconditionally needs a
data-dependent branch, i.e. a host sync every forward call; always compacting in
the forward reintroduces the per-layer argsort that #1825's per-batch cache
exists to avoid; forcing `False` whenever `topk_length` is passed is safe but
loses the early stop on the main HCA path.

Both in-repo call sites now state the promise, with the proof in a comment:
`csa_attention.py` right after `docmask_meta.compact_attn_topk_idxs`, and the
MQA-causal path, whose table is `[doc_start[i] .. i]` followed by `-1` by
construction (all-`-1` padding rows are recounted to length 0 in the backward and
hit the kernel's empty-row fast path).

New regression cover runs at the kernel's own 64-head tile, so it does not depend
on `_dsa_bwd_runs_sub_tile_heads` being open. Self-calibration: dropping the
`and (topk_length is None or topk_idxs_compacted)` clause makes it measure dq at
`1432201.75` against a `6e-3` ceiling.

### Test

On SM100 (compute capability 10.x), one process per file:

| file | before | after |
|---|---|---|
| `test_csa_sparse_attn_sub_tile_heads.py` | FAIL | 8 passed, 1 skipped, 39 subtests |
| `test_csa_sparse_attn_sub_512_latent.py` | FAIL | 14 passed, 88 subtests |
| `test_csa_sparse_attn_backends.py` | pass | 19 passed, 1 skipped |
| `test_csa_sparse_attn_utils.py` | pass | 19 passed |

All four in one process after item 4: `60 passed, 2 skipped, 127 subtests`.
`ruff check` and `ruff format --check` clean.

The two remaining skips are the arch-gated cases:
`test_real_head_count_matches_the_padded_backward` only applies when the sub-tile
backward is enabled (forcing the gate open makes it run and pass), and one
backend case needs a build this machine does not have. The contract from items 2
and 4 is covered unconditionally by
`test_compacted_topk_length_matches_the_reference` and
`TestTopkLengthCompactionPromise`, which run at the kernel's own head tile.
