### PR TITLE
[release/0.4][MoE] Cherry-pick latent-MoE RMSNorm

### DIFF
--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -42,6 +42,7 @@ if TYPE_CHECKING:
 from paddlefleet import utils
 from paddlefleet.recompute_utils import need_recompute_in_first_n
 from paddlefleet.transformer.activations import situ
+from paddlefleet.transformer.paddle_norm import WrappedPaddleNorm
 from paddlefleet.transformer.utils import profile
 
 from .fp8_utils import fused_stack_quant_without_cache
@@ -244,6 +245,15 @@ class MoELayer(nn.Layer):
             # Override default XavierUniform with config init methods
             self.config.init_method(self.fc1_latent_proj.weight)
             self.config.output_layer_init_method(self.fc2_latent_proj.weight)
+            self.latent_norm = (
+                WrappedPaddleNorm(
+                    config=self.config,
+                    hidden_size=self.config.moe_latent_size,
+                    eps=self.config.rms_norm_eps,
+                )
+                if self.config.latent_moe_use_norm
+                else None
+            )
             # Update expert config to use latent size
             routed_expert_config.hidden_size = self.config.moe_latent_size
         # Cached latent-space projection from _maybe_pre_allgather_overlap;
@@ -925,6 +935,8 @@ class MoELayer(nn.Layer):
 
         # Latent MoE: project back from latent space to hidden_size
         if self.use_latent_moe:
+            if self.latent_norm is not None:
+                hidden_states = self.latent_norm(hidden_states)
             hidden_states = self.fc2_latent_proj(hidden_states)
 
         return hidden_states
@@ -1018,6 +1030,8 @@ class MoELayer(nn.Layer):
 
         # Latent MoE: project back from latent space to hidden_size
         if self.use_latent_moe:
+            if self.latent_norm is not None:
+                hidden_states = self.latent_norm(hidden_states)
             hidden_states = self.fc2_latent_proj(hidden_states)
 
         return hidden_states
@@ -1191,6 +1205,8 @@ class MoELayer(nn.Layer):
     def aux_loss_compute(self, args):
         hidden_states, aux_loss, z_loss, residuals = args
         if self.use_latent_moe:
+            if self.latent_norm is not None:
+                hidden_states = self.latent_norm(hidden_states)
             hidden_states = self.fc2_latent_proj(hidden_states)
         if self.training and self.router_aux_loss_coef and aux_loss is not None:
             aux_loss = aux_loss * float(self.router_aux_loss_coef)
@@ -1339,6 +1355,8 @@ class MoELayer(nn.Layer):
                 )
             # Latent MoE: project back from latent space
             if self.use_latent_moe:
+                if self.latent_norm is not None:
+                    output = self.latent_norm(output)
                 output = self.fc2_latent_proj(output)
 
         _log_moe_md5(output, "moe_routed_output", layer_idx)

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -747,6 +747,10 @@ class TransformerConfig(ModelParallelConfig):
     moe_latent_size: int | None = None
     """The latent dimension size for latent MoE. Positive values enable latent MoE."""
 
+    latent_moe_use_norm: bool = False
+    """Apply RMSNorm to routed latent-MoE output before projecting it back to
+    the model hidden size."""
+
     ##################
     # Context Parallel
     ##################


### PR DESCRIPTION
### PR Category

Operator Mechanism

### PR Types

New features

### Description

Merged in dev: #1632

Cherry-pick only the latent-MoE RMSNorm part of #1632, so that release/0.4 can
normalize the combined routed output before it is projected back to the model
hidden size (Kimi-K3 report, Eq. 11).

- add `latent_moe_use_norm` (default `False`)
- build `self.latent_norm` (`WrappedPaddleNorm`, width `moe_latent_size`, eps
  `rms_norm_eps`) next to the latent projections
- apply it at all four `fc2_latent_proj` call sites, so the custom-forward,
  dispatch/combine-overlap, aux-loss and single-card fusion paths stay consistent

The code is identical to develop; `pre-commit run` passes on both files.

### 是否引起精度变化

否。`latent_moe_use_norm` 默认为 `False`，此时 `self.latent_norm is None`，前向与当前 release/0.4 完全一致。