### PR TITLE
[release/0.4][Feature] Initialize the mHC bias to the paper's A.6 static values

### DIFF
--- a/src/paddlefleet/transformer/hyper_connection.py
+++ b/src/paddlefleet/transformer/hyper_connection.py
@@ -275,7 +275,12 @@ class HyperConnectionModule(nn.Layer):
 
     Args:
         config: TransformerConfig with hyper-connection fields
-        layer_number: Current layer index for initialization
+        layer_number: mHC sub-layer index. Attention and MLP count as two
+            independent layers, so this is 2*decoder_index (+1 for the MLP
+            sub-layer). Only used to rotate the one-hot H_pre bias across the
+            n residual streams (``layer_number % n``), i.e. only when
+            ``config.mhc_single_stream_init`` is set; see
+            ``_single_stream_init_weights``.
     """
 
     def __init__(self, config: TransformerConfig, layer_number: int):
@@ -285,6 +290,7 @@ class HyperConnectionModule(nn.Layer):
         self.n = config.num_residual_streams
         self.hidden_size = config.hidden_size
         self.sinkhorn_iterations = config.mhc_sinkhorn_iterations
+        self.single_stream_init = config.mhc_single_stream_init
         self.compute_h_eps = _MHC_COMPUTE_H_EPS
 
         # Projection weights for dynamic mappings
@@ -316,7 +322,9 @@ class HyperConnectionModule(nn.Layer):
             default_initializer=nn.initializer.Constant(init_alpha),
         )
 
-        # Static bias terms
+        # Static bias terms. Stay zero unless ``mhc_single_stream_init``
+        # replaces them with the paper's A.6 values in
+        # ``_single_stream_init_weights``.
         self.bias = self.create_parameter(
             shape=[self.n * self.n + 2 * self.n],
             default_initializer=nn.initializer.Constant(0.0),
@@ -371,17 +379,21 @@ class HyperConnectionModule(nn.Layer):
 
     def _init_weights(self) -> None:
         """Initialize weights for stable training."""
-        # Xavier uniform for mapping projection.
-        # Use the model-parallel RNG tracker so that the initialization is
-        # controlled by PaddleFleet's RNG state (seeded once at model init)
-        # rather than the per-layer pipeline seed (base_seed + layer_index).
-        # This prevents layer_index shifts (e.g. from MTPEmbeddingLayer insertion
-        # in magic_send mode) from changing the weights.
-        if paddle.distributed.get_world_size() <= 1:
-            nn.initializer.XavierUniform()(self.mapping_proj.weight)
+        if self.single_stream_init:
+            self._single_stream_init_weights()
         else:
-            with get_cuda_rng_tracker().fork():
+            # Xavier uniform for the mapping projection; the bias keeps the zero
+            # from ``__init__``.
+            # Use the model-parallel RNG tracker so that the initialization is
+            # controlled by PaddleFleet's RNG state (seeded once at model init)
+            # rather than the per-layer pipeline seed (base_seed + layer_index).
+            # This prevents layer_index shifts (e.g. from MTPEmbeddingLayer
+            # insertion in magic_send mode) from changing the weights.
+            if paddle.distributed.get_world_size() <= 1:
                 nn.initializer.XavierUniform()(self.mapping_proj.weight)
+            else:
+                with get_cuda_rng_tracker().fork():
+                    nn.initializer.XavierUniform()(self.mapping_proj.weight)
 
         # Set sequence_parallel attribute on parameters for gradient synchronization
         if self.config.sequence_parallel:
@@ -390,6 +402,51 @@ class HyperConnectionModule(nn.Layer):
             self.alpha_post.is_distributed = False
             self.alpha_res.is_distributed = False
             self.bias.is_distributed = False
+
+    def _single_stream_init_weights(self) -> None:
+        """Paper mapping-head init (``mhc_single_stream_init``)."""
+        # Zero-init the fused mapping projection, following the paper: "we
+        # initialize all linear projections for the dynamic mappings to zero"
+        # (Sec. 2.2 / p.7; A.6 uses ``torch.zeros`` for ``self.weight``).
+        # ``_compute_h`` computes h = r*proj*alpha + bias, so a zero weight
+        # makes h == bias at step 0: H_pre / H_post / H_res are then exactly the
+        # static mappings encoded in ``bias`` below -- token-independent and free
+        # of the ~0.014 std logit perturbation XavierUniform adds on top of the
+        # +-3 bias. Gradients still flow (dh/dW = r*alpha*x != 0), so the
+        # projection is not pinned at zero.
+        # Deterministic, hence no model-parallel RNG tracker fork is needed.
+        self.mapping_proj.weight.set_value(
+            paddle.zeros_like(self.mapping_proj.weight)
+        )
+
+        # Static bias terms, following the paper's A.6 pseudo implementation.
+        # ``_compute_h`` computes h = r*proj*alpha + bias and slices it as
+        # [0:n] -> H_pre, [n:2n] -> H_post, [2n:] -> H_res, so:
+        #   b_pre  = -3 for every stream, except the "home stream" of this
+        #            sub-layer which is +3. H_pre = sigmoid(b_pre) is then
+        #            one-hot-ish (0.953 vs 0.047), i.e. the layer reads
+        #            essentially a single stream.
+        #   b_post = 0  =>  H_post = 2*sigmoid(0) = 1 (all-ones).
+        #   b_res  = 6*I - 3  =>  the row softmax inside Sinkhorn yields a
+        #            diagonal of e^3/(e^3+(n-1)e^-3) ~= 0.993, so H_res ~= I.
+        # Together these make the initial state equivalent to a standard
+        # residual connection while keeping the n streams distinguishable.
+        #
+        # The +3 rotates with the mHC sub-layer index: attention and MLP count
+        # as two independent layers (paper Fig. 3, see how
+        # HyperConnectionTransformerLayer numbers them), so consecutive
+        # sub-layers read stream 0, 1, ..., n-1, 0, ... Without the rotation a
+        # one-hot H_pre would leave n-1 streams write-only.
+        n = self.n
+        bias_init = paddle.concat(
+            [
+                paddle.full([n], -3.0, dtype="float32"),
+                paddle.zeros([n], dtype="float32"),
+                (6.0 * paddle.eye(n, dtype="float32") - 3.0).flatten(),
+            ]
+        )
+        bias_init[self.layer_number % n] = 3.0
+        self.bias.set_value(bias_init.astype(self.bias.dtype))
 
     def _projection_and_get_norm(self, x: Tensor) -> tuple[Tensor, Tensor]:
         """

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -862,6 +862,20 @@ class TransformerConfig(ModelParallelConfig):
     high_precision_mhc: bool = True
     """Use high precision (float32) for mHC forward and backward computation."""
 
+    mhc_single_stream_init: bool = False
+    """Initialize the mHC mapping head so each sub-layer reads a single stream.
+
+    This is what the paper does. When True the dynamic mapping projection is
+    zero-initialized and the static bias gets the paper's A.6 values (b_pre = -3
+    except +3 on the sub-layer's home stream, b_post = 0, b_res = 6I - 3), so at
+    step 0 H_pre is one-hot on the home stream, H_post = 1 and H_res ~= I --
+    equivalent to a standard residual connection, and token-independent.
+
+    When False (the historical behaviour) the projection is Xavier-uniform and
+    the bias stays at zero, which makes H_pre = sigmoid(~0) = 0.5 and H_res a
+    uniform doubly-stochastic matrix: every sub-layer reads and writes an
+    averaged mixture of the n residual streams from step 0."""
+
     ####################
     # miscellaneous
     ####################

--- a/src/paddlefleet/transformer/transformer_layer.py
+++ b/src/paddlefleet/transformer/transformer_layer.py
@@ -1335,15 +1335,44 @@ class HyperConnectionTransformerLayer(TransformerLayer):
             "HyperConnectionTransformerLayer does not support block_attention_residuals."
         )
 
+        # mHC treats attention and MLP as two independent layers (paper Fig. 3).
+        # HyperConnectionModule uses this index to rotate the one-hot H_pre bias
+        # across the n residual streams (mhc_single_stream_init only), so the two
+        # sub-layers must get distinct numbers or half of the streams would
+        # never be a "home stream".
+        #
+        # The rotation runs over the layer's logical position in the stack, which
+        # is not ``self.layer_number``:
+        #  - decoder layers are numbered index + num_empty_layers_add_in_head
+        #    (get_gpt_decoder_layers_spec), so the offset is subtracted to keep
+        #    the phase independent of the empty-head-layer count;
+        #  - MTP layers are numbered by their own 0-based index and carry no such
+        #    offset (get_gpt_mtp_layers_spec), so subtracting it would shift
+        #    their phase and, with empty head layers, make the index negative.
+        #    They keep reading and writing the n streams the backbone wrote, so
+        #    they continue the decoder's rotation rather than restarting it --
+        #    restarting would hand the first MTP sub-layer the same home stream
+        #    as the last decoder sub-layer whenever n is odd.
+        if self.is_mtp_layer:
+            mhc_logical_index = (
+                self.config.num_hidden_layers + self.layer_number
+            )
+        else:
+            head_offset = (
+                getattr(self.config, "num_empty_layers_add_in_head", 0) or 0
+            )
+            mhc_logical_index = self.layer_number - head_offset
+        mhc_sublayer_base = 2 * mhc_logical_index
+
         self.self_attention_hyper_connection = build_spec_layer(
             sublayers_spec.self_attention_hyper_connection,
             config=self.config,
-            layer_number=self.layer_number,
+            layer_number=mhc_sublayer_base,
         )
         self.mlp_hyper_connection = build_spec_layer(
             sublayers_spec.mlp_hyper_connection,
             config=self.config,
-            layer_number=self.layer_number,
+            layer_number=mhc_sublayer_base + 1,
         )
 
         # The hyper-connection submodules are created after super().__init__()

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_hyper_connection_transformer_layer.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_hyper_connection_transformer_layer.py
@@ -106,12 +106,13 @@ def _make_hc_config(**overrides):
     return _make_config(**hc_defaults)
 
 
-def _make_hc_layer(config, layer_number=1):
+def _make_hc_layer(config, layer_number=1, is_mtp_layer=False):
     spec = get_gpt_layer_local_spec(config)
     return HyperConnectionTransformerLayer(
         config=config,
         sublayers_spec=spec.sublayers_spec,
         layer_number=layer_number,
+        is_mtp_layer=is_mtp_layer,
     )
 
 
@@ -720,6 +721,44 @@ class TestHyperConnectionTransformerLayerConstruction(unittest.TestCase):
         )
         self.assertIsInstance(layer.mlp_hyper_connection, HyperConnectionModule)
 
+    def test_attention_and_mlp_are_numbered_as_two_mhc_layers(self):
+        """mHC counts attention and MLP as independent layers (paper Fig. 3).
+
+        ``mhc_single_stream_init`` rotates the one-hot H_pre bias with this
+        index, so the two modules must get consecutive numbers. Sharing one
+        would halve the rotation period and leave half of the residual streams
+        without a sub-layer that reads them.
+        """
+        config = _make_hc_config()
+        for i in range(3):
+            layer = _make_hc_layer(config, layer_number=i)
+            self.assertEqual(
+                layer.self_attention_hyper_connection.layer_number, 2 * i
+            )
+            self.assertEqual(layer.mlp_hyper_connection.layer_number, 2 * i + 1)
+
+    def test_the_two_sublayers_read_different_home_streams(self):
+        config = _make_hc_config(mhc_single_stream_init=True)
+        n = config.num_residual_streams
+        layer = _make_hc_layer(config, layer_number=0)
+        homes = (
+            int(layer.self_attention_hyper_connection.bias[:n].argmax()),
+            int(layer.mlp_hyper_connection.bias[:n].argmax()),
+        )
+        self.assertEqual(homes, (0, 1))
+
+    def test_empty_head_layers_do_not_shift_the_rotation(self):
+        """``layer_number`` counts the empty layers added in the head.
+
+        Those carry no mHC sub-layer, so the rotation phase has to be taken
+        from the logical decoder index instead, or inserting them would
+        renumber every home stream.
+        """
+        config = _make_hc_config(num_empty_layers_add_in_head=1)
+        layer = _make_hc_layer(config, layer_number=1)  # logical decoder 0
+        self.assertEqual(layer.self_attention_hyper_connection.layer_number, 0)
+        self.assertEqual(layer.mlp_hyper_connection.layer_number, 1)
+
     def test_raises_without_hc_spec(self):
         """Should raise if sublayers_spec has IdentityOp for hyper connections."""
         config = _make_hc_config()
@@ -1294,6 +1333,46 @@ class TestMTPLayerWithHCConstruction(unittest.TestCase):
         self.assertIsNone(layer.e_proj)
         self.assertIsNone(layer.h_proj)
         self.assertFalse(layer.mhc_enabled)
+
+    def test_mhc_sublayers_continue_the_decoder_rotation(self):
+        """Built through the real spec path, which is where the trap is.
+
+        ``get_gpt_mtp_layers_spec`` numbers MTP layers by their own 0-based
+        index, with no num_empty_layers_add_in_head offset -- unlike
+        ``get_gpt_decoder_layers_spec``. Applying the decoder's subtraction here
+        would shift the phase and, with empty head layers, drive the index
+        negative, silently picking the wrong home stream.
+        """
+        config = _make_mtp_hc_config(
+            mhc_single_stream_init=True, num_empty_layers_add_in_head=1
+        )
+        n = config.num_residual_streams
+        n_decoder = config.num_hidden_layers
+        for i in range(2):
+            inner = _make_mtp_layer(config, layer_number=i).transformer_layer
+            attn = inner.self_attention_hyper_connection
+            mlp = inner.mlp_hyper_connection
+            base = 2 * (n_decoder + i)
+            self.assertEqual(attn.layer_number, base)
+            self.assertEqual(mlp.layer_number, base + 1)
+            self.assertEqual(int(attn.bias[:n].argmax()), base % n)
+            self.assertEqual(int(mlp.bias[:n].argmax()), (base + 1) % n)
+
+    def test_the_mhc_seam_does_not_repeat_a_home_stream(self):
+        """The first MTP sub-layer picks up where the last decoder one left off."""
+        config = _make_mtp_hc_config(
+            mhc_single_stream_init=True, num_empty_layers_add_in_head=1
+        )
+        n = config.num_residual_streams
+        # last decoder layer: layer_number = index + head offset
+        last_decoder = _make_hc_layer(
+            config, layer_number=config.num_hidden_layers
+        )
+        mtp0 = _make_mtp_layer(config, layer_number=0).transformer_layer
+        self.assertNotEqual(
+            int(last_decoder.mlp_hyper_connection.bias[:n].argmax()),
+            int(mtp0.self_attention_hyper_connection.bias[:n].argmax()),
+        )
 
 
 class TestMTPLayerWithHCConcatEmbeddings(unittest.TestCase):

--- a/tests/single_card_tests/transformer/test_mhc_compute_h_native.py
+++ b/tests/single_card_tests/transformer/test_mhc_compute_h_native.py
@@ -277,5 +277,89 @@ class TestBdaSpanPaysOff(unittest.TestCase):
         self.assertTrue(m.bda_span_pays_off(0.0, training=True))
 
 
+class TestSingleStreamInit(unittest.TestCase):
+    """``mhc_single_stream_init`` gates the mapping-head initialization.
+
+    Off is the historical init and must stay what it was: a Xavier-uniform
+    projection and a zero bias. On is the paper's: a zero projection, so
+    h == bias at step 0, plus the A.6 bias.
+    """
+
+    def test_off_keeps_the_historical_init(self):
+        m = _module()
+        self.assertFalse(bool(paddle.all(m.mapping_proj.weight == 0)))
+        self.assertTrue(bool(paddle.all(m.bias == 0)))
+
+    def test_on_zeroes_the_projection(self):
+        m = _module(mhc_single_stream_init=True)
+        self.assertTrue(bool(paddle.all(m.mapping_proj.weight == 0)))
+
+    def test_on_writes_the_a6_bias(self):
+        """b_pre = -3 with +3 on the home stream, b_post = 0, b_res = 6I - 3."""
+        # layer_number=1 -> home stream 1
+        m = _module(mhc_single_stream_init=True)
+        b = m.bias.astype("float32").numpy()
+        expected_pre = [-3.0] * _N
+        expected_pre[1] = 3.0
+        self.assertEqual(b[:_N].tolist(), expected_pre)
+        self.assertEqual(b[_N : 2 * _N].tolist(), [0.0] * _N)
+        res = b[2 * _N :].reshape(_N, _N)
+        for i in range(_N):
+            for j in range(_N):
+                self.assertEqual(res[i][j], 3.0 if i == j else -3.0)
+
+    def test_home_stream_rotates_with_the_sub_layer_index(self):
+        """Consecutive sub-layers read stream 0, 1, ..., n-1, 0, ...
+
+        Constructed without seeding the tracker on purpose: this init is
+        deterministic, so unlike the Xavier branch it must not need the fork.
+        """
+        cfg = _config(mhc_single_stream_init=True)
+        homes = [
+            int(HyperConnectionModule(cfg, layer_number=ln).bias[:_N].argmax())
+            for ln in range(_N + 1)
+        ]
+        self.assertEqual(homes, [*range(_N), 0])
+
+    def test_step_0_mappings_are_a_standard_residual_connection(self):
+        """With W = 0 the mappings are the static ones, token-independent.
+
+        This is the whole point of the zero init, and it is a property of the
+        mappings, not of the bias: H_res only becomes ~= I after Sinkhorn.
+        """
+        m = _module(mhc_single_stream_init=True)  # layer_number=1
+        paddle.seed(23)
+        x = paddle.randn([_S, _B, _N * _C], dtype=m.mapping_proj.weight.dtype)
+        h_pre, h_post, h_res = m.compute_mappings(x)
+
+        # token-independent: every position sees the same mapping
+        for h in (h_pre, h_post, h_res):
+            self.assertLess(float((h - h[:1, :1]).abs().max()), 1e-6)
+        # one-hot-ish read of the home stream, unit write, identity mixing
+        self.assertAlmostEqual(float(h_pre[0, 0, 1]), 0.9526, places=3)
+        self.assertLess(float(h_pre[0, 0, 0]), 0.05)
+        self.assertLess(float((h_post - 1.0).abs().max()), 1e-6)
+        self.assertGreater(float(paddle.diagonal(h_res[0, 0]).min()), 0.99)
+
+    def test_the_zero_projection_still_gets_a_gradient(self):
+        """dh/dW = r*alpha*x != 0, so the projection is not pinned at zero.
+
+        A zero weight that also received no gradient would keep the mappings
+        static forever, i.e. the "dynamic" half of mHC would never turn on.
+        """
+        m = _module(mhc_single_stream_init=True)
+        paddle.seed(23)
+        x = paddle.randn([_S, _B, _N * _C], dtype=m.mapping_proj.weight.dtype)
+        h_pre, h_post, h_res = m.compute_mappings(x)
+        # weight the heads unequally so no gradient path cancels out
+        (h_pre.sum() + 2.0 * h_post.sum() + 3.0 * h_res.sum()).backward()
+        g = m.mapping_proj.weight.grad
+        self.assertIsNotNone(g)
+        self.assertEqual(g.shape, m.mapping_proj.weight.shape)
+        # ~7.6e-2 for this fixture, and the same order of magnitude as the
+        # Xavier branch gets: a zero weight does not attenuate its own gradient
+        self.assertGreater(float(g.abs().max()), 1e-4)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION

<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
 Execute Infrastructure 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
The mHC bias was left at zero, which makes H_pre = sigmoid(0) = 0.5 and H_res a uniform doubly-stochastic matrix, i.e. every sub-layer reads and writes an averaged mixture of the n residual streams from step 0.

Assign the paper's A.6 static values instead: b_pre = -3 except +3 on the sub-layer's home stream, b_post = 0, b_res = 6I - 3. The initial state is then equivalent to a standard residual connection while keeping the n streams distinguishable.

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
是

Merged dev PR: #1849 