### PR TITLE
fix mhc param bf16 to fp32

### DIFF
--- a/src/paddlefleet/transformer/hyper_connection.py
+++ b/src/paddlefleet/transformer/hyper_connection.py
@@ -292,33 +292,45 @@ class HyperConnectionModule(nn.Layer):
         # - H_pre: n values
         # - H_post: n values
         # - H_res: n^2 values (before Sinkhorn projection)
-        self.mapping_proj = nn.Linear(
-            self.n * self.hidden_size,
-            self.n * self.n + 2 * self.n,
-            bias_attr=False,
-        )
+        # The mHC mapping parameters are stored in FP32 (mirrors Megatron
+        # hyper_connection.py mark_keep_in_fp32 on mapping_proj.weight /
+        # alpha_* / bias, and the MoE gate fp32 storage in moe_router.py):
+        # they are tiny, and keeping them out of BF16 removes the parameter
+        # rounding error from the mHC gating computation.
+        param_dtype = "float32"
+        default_dtype = paddle.get_default_dtype()
+        try:
+            paddle.set_default_dtype(param_dtype)
+            self.mapping_proj = nn.Linear(
+                self.n * self.hidden_size,
+                self.n * self.n + 2 * self.n,
+                bias_attr=False,
+            )
+        finally:
+            paddle.set_default_dtype(default_dtype)
 
         init_alpha = config.mhc_init_gating_factor
         # Learnable scaling factors (Eq. 5 in paper)
         self.alpha_pre = self.create_parameter(
             shape=[1],
-            dtype=self.config.params_dtype,
+            dtype=param_dtype,
             default_initializer=nn.initializer.Constant(init_alpha),
         )
         self.alpha_post = self.create_parameter(
             shape=[1],
-            dtype=self.config.params_dtype,
+            dtype=param_dtype,
             default_initializer=nn.initializer.Constant(init_alpha),
         )
         self.alpha_res = self.create_parameter(
             shape=[1],
-            dtype=self.config.params_dtype,
+            dtype=param_dtype,
             default_initializer=nn.initializer.Constant(init_alpha),
         )
 
         # Static bias terms
         self.bias = self.create_parameter(
             shape=[self.n * self.n + 2 * self.n],
+            dtype=param_dtype,
             default_initializer=nn.initializer.Constant(0.0),
         )
 
@@ -907,19 +919,22 @@ class HyperConnectionContractLayer(FleetLayer):
         # Learned contraction parameters (DSv4 style, always used)
         n = self.n
         hc_dim = config.hidden_size * n
+        # learned_output_contract() computes in fp32; store the parameters in
+        # fp32 as well (Megatron transformer_block.py marks hc_head_* keep_in_fp32).
+        hc_param_dtype = "float32"
         self.hc_head_fn = self.create_parameter(
             shape=[hc_dim, n],
-            dtype=self.config.params_dtype,
+            dtype=hc_param_dtype,
             default_initializer=nn.initializer.XavierUniform(),
         )
         self.hc_head_base = self.create_parameter(
             shape=[n],
-            dtype=self.config.params_dtype,
+            dtype=hc_param_dtype,
             default_initializer=nn.initializer.Constant(0.0),
         )
         self.hc_head_scale = self.create_parameter(
             shape=[1],
-            dtype=self.config.params_dtype,
+            dtype=hc_param_dtype,
             default_initializer=nn.initializer.Constant(1.0),
         )
 

--- a/src/paddlefleet/transformer/multi_token_prediction.py
+++ b/src/paddlefleet/transformer/multi_token_prediction.py
@@ -358,9 +358,13 @@ class MultiTokenPredictionLayer(FleetLayer):
             # Learned contraction parameters for MTP output
             n = config.num_residual_streams
             hc_dim = config.hidden_size * n
+            # learned_output_contract() computes in fp32; store the parameters
+            # in fp32 too (Megatron marks hc_head_* keep_in_fp32).
+
+            hc_param_dtype = "float32"
             self.hc_head_fn = self.create_parameter(
                 shape=[hc_dim, n],
-                dtype=self.config.params_dtype,
+                dtype=hc_param_dtype,
                 default_initializer=nn.initializer.Constant(0.0),
             )
             # Use model-parallel RNG tracker for Xavier init so that the
@@ -372,12 +376,12 @@ class MultiTokenPredictionLayer(FleetLayer):
                     nn.initializer.XavierUniform()(self.hc_head_fn)
             self.hc_head_base = self.create_parameter(
                 shape=[n],
-                dtype=self.config.params_dtype,
+                dtype=hc_param_dtype,
                 default_initializer=nn.initializer.Constant(0.0),
             )
             self.hc_head_scale = self.create_parameter(
                 shape=[1],
-                dtype=self.config.params_dtype,
+                dtype=hc_param_dtype,
                 default_initializer=nn.initializer.Constant(1.0),
             )
             if self.sequence_parallel:

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -1906,6 +1906,11 @@ class TransformerConfig(ModelParallelConfig):
                 raise ValueError(
                     "use_fused_mhc requires enable_hyper_connections=True."
                 )
+        if self.enable_hyper_connections:
+            if not self.high_precision_mhc:
+                raise ValueError(
+                    "enable_hyper_connections not support high_precision_mhc=False yet."
+                )
 
         # Shared document-mask metadata validation. Both switches only mean
         # something on a DSv4-hybrid model, and the MQA one additionally needs the

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_hyper_connection_transformer_layer.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_hyper_connection_transformer_layer.py
@@ -235,31 +235,23 @@ class TestHyperConnectionModule(unittest.TestCase):
         self.assertEqual(list(h_post.shape), [10, self.n])
 
     def test_forward_high_precision_mhc_switch(self):
-        """high_precision_mhc should choose float32 or bfloat16 compute output."""
-        cases = (
-            (True, paddle.float32),
-            (False, paddle.bfloat16),
+        """high_precision_mhc keeps the mHC compute output in float32."""
+        config = _make_hc_config(high_precision_mhc=True)
+        module = HyperConnectionModule(config=config, layer_number=1)
+        module = paddle.amp.decorate(
+            models=module, level="O2", dtype="bfloat16"
         )
-        for high_precision_mhc, expected_dtype in cases:
-            with self.subTest(high_precision_mhc=high_precision_mhc):
-                config = _make_hc_config(high_precision_mhc=high_precision_mhc)
-                module = HyperConnectionModule(config=config, layer_number=1)
-                module = paddle.amp.decorate(
-                    models=module, level="O2", dtype="bfloat16"
-                )
-                x = paddle.randn([2, 4, self.n * self.C]).astype("bfloat16")
+        x = paddle.randn([2, 4, self.n * self.C]).astype("bfloat16")
 
-                aggregated, h_res, h_post = module(x)
+        aggregated, h_res, h_post = module(x)
 
-                self.assertEqual(
-                    module.config.high_precision_mhc, high_precision_mhc
-                )
-                self.assertEqual(aggregated.dtype, expected_dtype)
-                self.assertEqual(h_res.dtype, expected_dtype)
-                self.assertEqual(h_post.dtype, expected_dtype)
-                self.assertEqual(list(aggregated.shape), [2, 4, self.C])
-                self.assertEqual(list(h_res.shape), [2, 4, self.n, self.n])
-                self.assertEqual(list(h_post.shape), [2, 4, self.n])
+        self.assertTrue(module.config.high_precision_mhc)
+        self.assertEqual(aggregated.dtype, paddle.float32)
+        self.assertEqual(h_res.dtype, paddle.float32)
+        self.assertEqual(h_post.dtype, paddle.float32)
+        self.assertEqual(list(aggregated.shape), [2, 4, self.C])
+        self.assertEqual(list(h_res.shape), [2, 4, self.n, self.n])
+        self.assertEqual(list(h_post.shape), [2, 4, self.n])
 
     # ---------- compute_mappings ----------
 
@@ -443,42 +435,32 @@ class TestHyperConnectionModule(unittest.TestCase):
         self.assertFalse(paddle.isnan(result).any().item())
 
     def test_fused_h_res_h_post_bda_high_precision_fast_path(self):
-        """high_precision_mhc should choose float32 or bfloat16 BDA output."""
+        """high_precision_mhc keeps the BDA output in float32."""
         B, S = 2, 4
-        cases = (
-            (True, paddle.float32),
-            (False, paddle.bfloat16),
+        config = _make_hc_config(high_precision_mhc=True)
+        module = HyperConnectionModule(config=config, layer_number=1)
+        module = paddle.amp.decorate(
+            models=module, level="O2", dtype="bfloat16"
         )
-        for high_precision_mhc, expected_dtype in cases:
-            with self.subTest(high_precision_mhc=high_precision_mhc):
-                config = _make_hc_config(high_precision_mhc=high_precision_mhc)
-                module = HyperConnectionModule(config=config, layer_number=1)
-                module = paddle.amp.decorate(
-                    models=module, level="O2", dtype="bfloat16"
-                )
-                x = paddle.randn([B, S, self.n * self.C]).astype("bfloat16")
-                _, h_res, h_post = module(x)
-                layer_output = paddle.randn([B, S, self.C]).astype("bfloat16")
-                bias = paddle.randn([self.C]).astype("bfloat16")
+        x = paddle.randn([B, S, self.n * self.C]).astype("bfloat16")
+        _, h_res, h_post = module(x)
+        layer_output = paddle.randn([B, S, self.C]).astype("bfloat16")
+        bias = paddle.randn([self.C]).astype("bfloat16")
 
-                result = module.fused_h_res_h_post_bda(
-                    h_res=h_res,
-                    original_residual=x,
-                    h_post=h_post,
-                    layer_output_with_bias=(layer_output, bias),
-                    dropout_prob=0.0,
-                    training=False,
-                    fused=False,
-                )
+        result = module.fused_h_res_h_post_bda(
+            h_res=h_res,
+            original_residual=x,
+            h_post=h_post,
+            layer_output_with_bias=(layer_output, bias),
+            dropout_prob=0.0,
+            training=False,
+            fused=False,
+        )
 
-                self.assertEqual(
-                    module.config.high_precision_mhc, high_precision_mhc
-                )
-                self.assertEqual(result.dtype, expected_dtype)
-                self.assertEqual(list(result.shape), [B, S, self.n * self.C])
-                self.assertFalse(
-                    paddle.isnan(result.astype("float32")).any().item()
-                )
+        self.assertTrue(module.config.high_precision_mhc)
+        self.assertEqual(result.dtype, paddle.float32)
+        self.assertEqual(list(result.shape), [B, S, self.n * self.C])
+        self.assertFalse(paddle.isnan(result.astype("float32")).any().item())
 
     # ---------- input_expand / output_contract ----------
 

--- a/tests/single_card_tests/transformer/test_mhc_compute_h_native.py
+++ b/tests/single_card_tests/transformer/test_mhc_compute_h_native.py
@@ -215,19 +215,15 @@ class TestOperatorDispatch(unittest.TestCase):
         self.assertIs(m._compute_h_op, fused_compute_h)
 
     def test_widen_in_kernel_follows_high_precision_mhc(self):
-        """Only high_precision_mhc has a widening for the kernel to absorb.
+        """``high_precision_mhc`` is what gives the kernel a widening to absorb.
 
-        With it off the reference keeps the arithmetic in the incoming dtype,
-        so the kernel must too, or the fusion would silently promote it.
+        Only the enabled case is exercised: ``TransformerConfig`` now rejects
+        ``high_precision_mhc=False`` together with ``enable_hyper_connections``,
+        so a module with the widening switched off can no longer be built.
         """
         self.assertTrue(
             _module(
                 use_fused_mhc=True, high_precision_mhc=True
-            )._widen_in_kernel
-        )
-        self.assertFalse(
-            _module(
-                use_fused_mhc=True, high_precision_mhc=False
             )._widen_in_kernel
         )
 
@@ -258,23 +254,19 @@ class TestBdaSpanPaysOff(unittest.TestCase):
 
     It decides whether ``_fused_h_res_h_post_bda`` is wrapped in a
     ``RecomputeWithoutOutput`` span, so a wrong answer either wastes memory or
-    pays for a replay that saves nothing. Each branch is pinned separately.
+    pays for a replay that saves nothing. Only the ``high_precision_mhc=True``
+    branches are reachable now that the config rejects the low-precision mHC
+    combination.
     """
-
-    def test_dropout_alone_is_enough(self):
-        """The mask is one byte per element of the [..., n*C] output."""
-        m = _module(use_fused_mhc=True, high_precision_mhc=False)
-        self.assertTrue(m.bda_span_pays_off(0.1, training=True))
-        # not in eval: no mask is kept
-        self.assertFalse(m.bda_span_pays_off(0.1, training=False))
-
-    def test_without_high_precision_nothing_to_hide(self):
-        m = _module(use_fused_mhc=True, high_precision_mhc=False)
-        self.assertFalse(m.bda_span_pays_off(0.0, training=True))
 
     def test_high_precision_pays(self):
         m = _module(use_fused_mhc=True, high_precision_mhc=True)
         self.assertTrue(m.bda_span_pays_off(0.0, training=True))
+
+    def test_dropout_pays_too(self):
+        """The mask is one byte per element of the [..., n*C] output."""
+        m = _module(use_fused_mhc=True, high_precision_mhc=True)
+        self.assertTrue(m.bda_span_pays_off(0.1, training=True))
 
 
 if __name__ == "__main__":

--- a/tests/single_card_tests/transformer/test_mhc_fused_h_res_h_post_bda_recompute.py
+++ b/tests/single_card_tests/transformer/test_mhc_fused_h_res_h_post_bda_recompute.py
@@ -35,7 +35,7 @@ change, so it is only bounded loosely, and it is checked at all so that the
 bitwise assertions cannot pass vacuously.
 
 Coverage: both BDA kernels (native / ``fused_h_post_bda``), bias present and
-absent, ``high_precision_mhc`` on and off, fp32 and bf16, two stacked
+absent, fp32 and bf16, two stacked
 half-layers so the second aggregate consumes the first BDA output (this is what
 caught the ``h_res``/``h_post`` ``_clear_data()`` aliasing bug), the whole layer
 through ``recompute_modules=['mhc_forward']``, and the span contract itself: a
@@ -348,21 +348,6 @@ class TestFusedHResHPostBDASpanNumerics(_CompareMixin, unittest.TestCase):
             dtype="bfloat16",
         )
 
-    def test_low_precision_mhc_is_not_wrapped(self):
-        # Without high_precision_mhc the kernel saves only live tensors (reshape
-        # is a view, no up-cast), so the helper must decline to wrap: a span
-        # there would cost a replay and save nothing.
-        self._check({"high_precision_mhc": False}, expect_span=False)
-
-    def test_low_precision_mhc_with_dropout_is_wrapped(self):
-        # ...but active dropout puts even a low-precision config on the
-        # sequential path, whose mask the span does hide, so the
-        # high_precision_mhc veto must not swallow this case.
-        self._check(
-            {"high_precision_mhc": False, "hidden_dropout_prob": 0.1},
-            with_bias=True,
-        )
-
     def test_sequential_path_with_dropout_with_bias(self):
         # Active dropout takes fused_h_res_h_post_bda down the sequential path,
         # where the span hides that path's dropout mask instead of an up-cast,
@@ -418,17 +403,6 @@ class TestFusedHResHPostBDASpanContract(_CompareMixin, unittest.TestCase):
         )
         self.assertIsNone(span)
 
-    def test_no_span_without_high_precision_mhc(self):
-        # The helper must veto the caller here: with no up-cast to hide there is
-        # nothing to save, only a replay to pay for.
-        layer, hc = self._prepare(high_precision_mhc=False)
-        resid, _, h_res, h_post, x = _bda_inputs(layer, hc, "float32")
-        out, span = layer._fused_h_res_h_post_bda(
-            hc, h_res, resid, h_post, (x, None), True
-        )
-        self.assertIsNone(span)
-        self.assertEqual(out.dtype, resid.dtype)
-
     def test_span_created_when_it_pays_off(self):
         layer, hc = self._prepare()
         resid, _, h_res, h_post, x = _bda_inputs(layer, hc, "float32")
@@ -464,19 +438,6 @@ class TestFusedHResHPostBDASpanContract(_CompareMixin, unittest.TestCase):
             span.preserve_rng_state,
             "the dropout mask cannot be reproduced without the RNG state",
         )
-
-    def test_span_created_for_low_precision_dropout(self):
-        # The mask is a byte per output element whatever the mHC precision, so
-        # the high_precision_mhc veto must not run before the dropout check
-        # (measured: same 252 KiB saving as the high-precision config).
-        layer, hc = self._prepare(
-            high_precision_mhc=False, hidden_dropout_prob=0.1
-        )
-        resid, _, h_res, h_post, x = _bda_inputs(layer, hc, "float32")
-        _, span = layer._fused_h_res_h_post_bda(
-            hc, h_res, resid, h_post, (x, None), True
-        )
-        self.assertIsInstance(span, RecomputeWithoutOutput)
 
     def test_span_created_for_accuracy_compatible_kernel_with_dropout(self):
         # Same reasoning for the other sequential-path trigger: the switch
@@ -654,11 +615,6 @@ class TestFusedHResHPostBDASpanMemory(unittest.TestCase):
 
     def test_span_shrinks_the_retained_set_on_the_sequential_path(self):
         self._assert_sequential_span_saves()
-
-    def test_span_shrinks_the_retained_set_without_high_precision_mhc(self):
-        # The mask does not care about mHC precision, so the gate must not veto
-        # this config on the high_precision_mhc check alone.
-        self._assert_sequential_span_saves(high_precision_mhc=False)
 
 
 def _span_spy(created, force_disable=False):


### PR DESCRIPTION
### PR Category
Operator Mechanism


### PR Types
Improvements


### Description
Merged in dev: #1812
升级mhc模块参数的精度，从bf16参数升级为fp32精度


### 是否引起精度变化
是
