### PR TITLE
Fix fused swiglu weighted clamp bwd

### DIFF
--- a/packages/paddlefleet_ops/src/paddlefleet_ops/_extensions/fuse_swiglu_scale.cu
+++ b/packages/paddlefleet_ops/src/paddlefleet_ops/_extensions/fuse_swiglu_scale.cu
@@ -379,6 +379,15 @@ static void CheckFusedSwiGLUXShape(const std::vector<int64_t>& x_shape,
            ": the last dimension of X must be divisible by 2");
 }
 
+static std::vector<int64_t> InferFusedSwiGLUOutputShape(
+    const std::vector<int64_t>& x_shape, const char* op_name) {
+  CheckFusedSwiGLUXShape(x_shape, op_name);
+  // Preserve Paddle's unknown-dimension sentinel instead of evaluating
+  // -1 / 2 as zero during static shape inference.
+  const int64_t hidden_size = x_shape[1] < 0 ? -1 : x_shape[1] / 2;
+  return {x_shape[0], hidden_size};
+}
+
 static void CheckFusedSwiGLUInputs(const paddle::Tensor& x,
                                    const paddle::Tensor& scale,
                                    const paddle::Tensor* d_out,
@@ -814,8 +823,7 @@ static std::vector<std::vector<int64_t>> FusedFwdInferShapeImpl(
     const std::vector<int64_t>& x_shape,
     const std::vector<int64_t>& scale_shape,
     const char* op_name) {
-  CheckFusedSwiGLUXShape(x_shape, op_name);
-  return {{x_shape[0], x_shape[1] / 2}};
+  return {InferFusedSwiGLUOutputShape(x_shape, op_name)};
 }
 
 std::vector<std::vector<int64_t>> FusedFwdInferShape(
@@ -919,8 +927,10 @@ std::vector<std::vector<int64_t>> WeightedBwdClampInferShape(
     std::vector<int64_t> x_shape,
     std::vector<int64_t> probs_shape,
     std::vector<int64_t> dout_shape) {
-  CheckFusedSwiGLUXShape(x_shape, "fused_swiglu_weighted_clamp_bwd");
-  return {x_shape, {x_shape[0], 1}, {x_shape[0], x_shape[1] / 2}};
+  return {x_shape,
+          {x_shape[0], 1},
+          InferFusedSwiGLUOutputShape(
+              x_shape, "fused_swiglu_weighted_clamp_bwd")};
 }
 
 PD_BUILD_OP(fused_swiglu_weighted_clamp_bwd)

--- a/packages/paddlefleet_ops/src/paddlefleet_ops/_extensions/fuse_swiglu_scale.cu
+++ b/packages/paddlefleet_ops/src/paddlefleet_ops/_extensions/fuse_swiglu_scale.cu
@@ -366,7 +366,7 @@ __global__ void VectorizedFusedSwiGLUWeightedBwd(
 }
 
 // ==========================================================================
-// SwiGLU host wrappers.
+// Host Wrappers (templated on kHasClamp; non-clamp wrappers forward 0.0)
 // ==========================================================================
 
 static void CheckFusedSwiGLUXShape(const std::vector<int64_t>& x_shape,
@@ -621,29 +621,34 @@ static std::vector<paddle::Tensor> FusedSwiGLUScaleBackwardImpl(
 // ==========================================================================
 // Weighted Backward Host Wrapper (combines forward+backward in one launch)
 // ==========================================================================
+template <bool kHasClamp>
 static std::vector<paddle::Tensor> FusedSwiGLUWeightedBackwardImpl(
     const paddle::Tensor& x,
     const paddle::Tensor& probs,
     const paddle::Tensor& d_out,
     double clamp_value) {
-  const char* op_name = "fused_swiglu_weighted_clamp_bwd";
+  const char* op_name = kHasClamp ? "fused_swiglu_weighted_clamp_bwd"
+                                  : "fused_swiglu_weighted_bwd";
   CheckFusedSwiGLUInputs(x, probs, &d_out, op_name, "Probs");
-  PD_CHECK(std::isfinite(clamp_value) && clamp_value > 0.0,
-           op_name,
-           ": clamp_value must be finite and greater than zero");
+  if constexpr (kHasClamp) {
+    PD_CHECK(std::isfinite(clamp_value) && clamp_value > 0.0,
+             op_name,
+             ": clamp_value must be finite and greater than zero");
+  }
 
   int64_t rows = x.shape()[0];
   int64_t hidden2 = x.shape()[1];
   int64_t hidden_size = hidden2 / 2;
   auto d_x = paddle::empty_like(x);
   auto out = paddle::empty({rows, hidden_size}, x.dtype(), x.place());
-  const std::vector<int64_t> d_probs_shape{rows, 1};
+  // Clamp gradients use [rows, 1]; non-clamp gradients match Probs.
+  const std::vector<int64_t> d_probs_shape =
+      kHasClamp ? std::vector<int64_t>{rows, 1} : probs.shape();
 
   if (rows == 0 || hidden_size == 0) {
     return {d_x, paddle::zeros(d_probs_shape, probs.dtype(), probs.place()), out};
   }
 
-  // DProbs follows Megatron's [rows, 1] keepdim contract.
   auto d_probs =
       paddle::empty(d_probs_shape, probs.dtype(), probs.place());
   const auto kernel_d_out =
@@ -660,7 +665,7 @@ static std::vector<paddle::Tensor> FusedSwiGLUWeightedBackwardImpl(
     using paddle_bf16 = paddle::bfloat16;
     using cuda_bf16 = __nv_bfloat16;
     if (probs.dtype() == paddle::DataType::FLOAT32) {
-      VectorizedFusedSwiGLUWeightedBwd<cuda_bf16, float, 8, true>
+      VectorizedFusedSwiGLUWeightedBwd<cuda_bf16, float, 8, kHasClamp>
           <<<grid_size, block_size, 0, stream>>>(
               reinterpret_cast<const cuda_bf16*>(x.data<paddle_bf16>()),
               probs.data<float>(),
@@ -674,7 +679,7 @@ static std::vector<paddle::Tensor> FusedSwiGLUWeightedBackwardImpl(
               hidden2,
               clamp_value);
     } else if (probs.dtype() == paddle::DataType::BFLOAT16) {
-      VectorizedFusedSwiGLUWeightedBwd<cuda_bf16, cuda_bf16, 8, true>
+      VectorizedFusedSwiGLUWeightedBwd<cuda_bf16, cuda_bf16, 8, kHasClamp>
           <<<grid_size, block_size, 0, stream>>>(
               reinterpret_cast<const cuda_bf16*>(x.data<paddle_bf16>()),
               reinterpret_cast<const cuda_bf16*>(probs.data<paddle_bf16>()),
@@ -691,7 +696,7 @@ static std::vector<paddle::Tensor> FusedSwiGLUWeightedBackwardImpl(
       PD_THROW(op_name, " does not support Probs dtype");
     }
   } else if (x.dtype() == paddle::DataType::FLOAT32) {
-    VectorizedFusedSwiGLUWeightedBwd<float, float, 4, true>
+    VectorizedFusedSwiGLUWeightedBwd<float, float, 4, kHasClamp>
         <<<grid_size, block_size, 0, stream>>>(x.data<float>(),
                                                probs.data<float>(),
                                                kernel_d_out.data<float>(),
@@ -742,7 +747,8 @@ std::vector<paddle::Tensor> FusedSwiGLUWeightedClampBackward(
     const paddle::Tensor& probs,
     const paddle::Tensor& d_out,
     double clamp_value) {
-  return FusedSwiGLUWeightedBackwardImpl(x, probs, d_out, clamp_value);
+  return FusedSwiGLUWeightedBackwardImpl</*kHasClamp=*/true>(
+      x, probs, d_out, clamp_value);
 }
 
 // ==========================================================================

--- a/packages/paddlefleet_ops/src/paddlefleet_ops/_extensions/fuse_swiglu_scale.cu
+++ b/packages/paddlefleet_ops/src/paddlefleet_ops/_extensions/fuse_swiglu_scale.cu
@@ -379,23 +379,15 @@ static void CheckFusedSwiGLUXShape(const std::vector<int64_t>& x_shape,
            ": the last dimension of X must be divisible by 2");
 }
 
-static std::vector<int64_t> InferFusedSwiGLUOutputShape(
-    const std::vector<int64_t>& x_shape, const char* op_name) {
-  CheckFusedSwiGLUXShape(x_shape, op_name);
-  // Preserve -1 for unknown hidden dimensions during static shape inference.
-  const int64_t hidden_size = x_shape[1] < 0 ? -1 : x_shape[1] / 2;
-  return {x_shape[0], hidden_size};
-}
-
 static void CheckFusedSwiGLUInputs(const paddle::Tensor& x,
                                    const paddle::Tensor& scale,
                                    const paddle::Tensor* d_out,
                                    const char* op_name,
                                    const char* scale_name) {
-  PD_CHECK(x.is_gpu() && scale.is_gpu() &&
-               (d_out == nullptr || d_out->is_gpu()),
-           op_name,
-           " expects GPU inputs");
+  PD_CHECK(
+      x.is_gpu() && scale.is_gpu() && (d_out == nullptr || d_out->is_gpu()),
+      op_name,
+      " expects GPU inputs");
   PD_CHECK(x.place() == scale.place() &&
                (d_out == nullptr || x.place() == d_out->place()),
            op_name,
@@ -413,7 +405,10 @@ static void CheckFusedSwiGLUInputs(const paddle::Tensor& x,
            op_name,
            ": ",
            scale_name,
-           " must have shape [rows] or [rows, 1]");
+           " must have shape [rows] or [rows, 1], got rank=",
+           scale_shape.size(),
+           ", numel=",
+           scale.numel());
 
   const int64_t rows = x_shape[0];
   const int64_t hidden_size = x_shape[1] / 2;
@@ -421,16 +416,29 @@ static void CheckFusedSwiGLUInputs(const paddle::Tensor& x,
            op_name,
            ": ",
            scale_name,
-           " must contain exactly one value per X row");
+           " must contain exactly one value per X row, got numel=",
+           scale.numel(),
+           ", expected ",
+           rows);
 
   if (d_out != nullptr) {
     const auto d_out_shape = d_out->shape();
     PD_CHECK(d_out_shape.size() == 2,
              op_name,
-             ": DOut must have shape [rows, hidden_size]");
+             ": DOut must have shape [rows, hidden_size], got rank=",
+             d_out_shape.size(),
+             ", numel=",
+             d_out->numel());
     PD_CHECK(d_out_shape[0] == rows && d_out_shape[1] == hidden_size,
              op_name,
-             ": DOut must have shape [X.shape[0], X.shape[1] / 2]");
+             ": DOut must have shape [X.shape[0], X.shape[1] / 2], got rows=",
+             d_out_shape[0],
+             ", hidden_size=",
+             d_out_shape[1],
+             ", expected rows=",
+             rows,
+             ", hidden_size=",
+             hidden_size);
     PD_CHECK(d_out->dtype() == x.dtype(),
              op_name,
              ": DOut dtype must match X dtype");
@@ -438,9 +446,7 @@ static void CheckFusedSwiGLUInputs(const paddle::Tensor& x,
 
   const bool x_is_bf16 = x.dtype() == paddle::DataType::BFLOAT16;
   const bool x_is_fp32 = x.dtype() == paddle::DataType::FLOAT32;
-  PD_CHECK(x_is_bf16 || x_is_fp32,
-           op_name,
-           ": X must be bfloat16 or float32");
+  PD_CHECK(x_is_bf16 || x_is_fp32, op_name, ": X must be bfloat16 or float32");
   PD_CHECK(scale.dtype() == paddle::DataType::BFLOAT16 ||
                scale.dtype() == paddle::DataType::FLOAT32,
            op_name,
@@ -462,8 +468,8 @@ static void CheckFusedSwiGLUInputs(const paddle::Tensor& x,
 template <bool kHasClamp>
 static std::vector<paddle::Tensor> FusedSwiGLUScaleForwardImpl(
     const paddle::Tensor& x, const paddle::Tensor& scale, double clamp_value) {
-  const char* op_name = kHasClamp ? "fused_swiglu_scale_clamp"
-                                  : "fused_swiglu_scale";
+  const char* op_name =
+      kHasClamp ? "fused_swiglu_scale_clamp" : "fused_swiglu_scale";
   CheckFusedSwiGLUInputs(x, scale, nullptr, op_name, "Scale");
   if constexpr (kHasClamp) {
     PD_CHECK(std::isfinite(clamp_value) && clamp_value > 0.0,
@@ -535,8 +541,8 @@ static std::vector<paddle::Tensor> FusedSwiGLUScaleBackwardImpl(
     const paddle::Tensor& scale,
     const paddle::Tensor& d_out,
     double clamp_value) {
-  const char* op_name = kHasClamp ? "fused_swiglu_scale_clamp_bwd"
-                                  : "fused_swiglu_scale_bwd";
+  const char* op_name =
+      kHasClamp ? "fused_swiglu_scale_clamp_bwd" : "fused_swiglu_scale_bwd";
   CheckFusedSwiGLUInputs(x, scale, &d_out, op_name, "Scale");
   if constexpr (kHasClamp) {
     PD_CHECK(std::isfinite(clamp_value) && clamp_value > 0.0,
@@ -559,8 +565,7 @@ static std::vector<paddle::Tensor> FusedSwiGLUScaleBackwardImpl(
   auto d_scale = paddle::empty(d_scale_shape, scale.dtype(), scale.place());
   // DOut may be strided because it is framework-produced; materialize it
   // before the kernel.
-  const auto kernel_d_out =
-      d_out.is_contiguous() ? d_out : d_out.contiguous();
+  const auto kernel_d_out = d_out.is_contiguous() ? d_out : d_out.contiguous();
 
   // Paddle extension gridDim is int. The kernel uses a grid-stride loop
   // over rows, so we cap grid_size at kMaxSwiGLUGridSize and let the kernel
@@ -646,13 +651,12 @@ static std::vector<paddle::Tensor> FusedSwiGLUWeightedBackwardImpl(
       kHasClamp ? std::vector<int64_t>{rows, 1} : probs.shape();
 
   if (rows == 0 || hidden_size == 0) {
-    return {d_x, paddle::zeros(d_probs_shape, probs.dtype(), probs.place()), out};
+    return {
+        d_x, paddle::zeros(d_probs_shape, probs.dtype(), probs.place()), out};
   }
 
-  auto d_probs =
-      paddle::empty(d_probs_shape, probs.dtype(), probs.place());
-  const auto kernel_d_out =
-      d_out.is_contiguous() ? d_out : d_out.contiguous();
+  auto d_probs = paddle::empty(d_probs_shape, probs.dtype(), probs.place());
+  const auto kernel_d_out = d_out.is_contiguous() ? d_out : d_out.contiguous();
 
   // Paddle extension gridDim is int. The kernel uses a grid-stride loop
   // over rows, so we cap grid_size at kMaxSwiGLUGridSize and let the kernel
@@ -755,29 +759,11 @@ std::vector<paddle::Tensor> FusedSwiGLUWeightedClampBackward(
 // Op Registration
 // ==========================================================================
 
-static std::vector<std::vector<int64_t>> FusedGradInferShapeImpl(
-    const std::vector<int64_t>& x_shape,
-    const std::vector<int64_t>& scale_shape,
-    const std::vector<int64_t>& dout_shape,
-    const char* op_name) {
-  CheckFusedSwiGLUXShape(x_shape, op_name);
-  return {x_shape, scale_shape};
-}
-
 std::vector<std::vector<int64_t>> FusedGradInferShape(
     std::vector<int64_t> x_shape,
     std::vector<int64_t> scale_shape,
     std::vector<int64_t> dout_shape) {
-  return FusedGradInferShapeImpl(
-      x_shape, scale_shape, dout_shape, "fused_swiglu_scale_bwd");
-}
-
-std::vector<std::vector<int64_t>> FusedScaleGradInferShape(
-    std::vector<int64_t> x_shape,
-    std::vector<int64_t> scale_shape,
-    std::vector<int64_t> dout_shape) {
-  return FusedGradInferShapeImpl(
-      x_shape, scale_shape, dout_shape, "fused_swiglu_scale_grad");
+  return {x_shape, scale_shape};
 }
 
 std::vector<paddle::DataType> FusedGradInferDtype(paddle::DataType x_dtype,
@@ -786,23 +772,17 @@ std::vector<paddle::DataType> FusedGradInferDtype(paddle::DataType x_dtype,
   return {x_dtype, scale_dtype};
 }
 
-// Forward: output is SwiGLU(x) * scale with shape {rows, hidden_size/2}
-static std::vector<std::vector<int64_t>> FusedFwdInferShapeImpl(
-    const std::vector<int64_t>& x_shape,
-    const std::vector<int64_t>& scale_shape,
-    const char* op_name) {
-  return {InferFusedSwiGLUOutputShape(x_shape, op_name)};
+static std::vector<int64_t> InferFusedSwiGLUOutputShape(
+    const std::vector<int64_t>& x_shape, const char* op_name) {
+  CheckFusedSwiGLUXShape(x_shape, op_name);
+  const int64_t hidden_size = x_shape[1] < 0 ? -1 : x_shape[1] / 2;
+  return {x_shape[0], hidden_size};
 }
 
+// Forward: output is SwiGLU(x) * scale with shape {rows, hidden_size/2}
 std::vector<std::vector<int64_t>> FusedFwdInferShape(
     std::vector<int64_t> x_shape, std::vector<int64_t> scale_shape) {
-  return FusedFwdInferShapeImpl(x_shape, scale_shape, "fused_swiglu_scale");
-}
-
-std::vector<std::vector<int64_t>> FusedClampFwdInferShape(
-    std::vector<int64_t> x_shape, std::vector<int64_t> scale_shape) {
-  return FusedFwdInferShapeImpl(
-      x_shape, scale_shape, "fused_swiglu_scale_clamp");
+  return {InferFusedSwiGLUOutputShape(x_shape, "fused_swiglu_scale_clamp")};
 }
 
 std::vector<paddle::DataType> FusedFwdInferDtype(paddle::DataType x_dtype,
@@ -821,40 +801,22 @@ PD_BUILD_OP(fused_swiglu_scale)
     .Inputs({"X", "Scale"})
     .Outputs({"Out"})
     .SetKernelFn(PD_KERNEL(FusedSwiGLUScaleForward))
-    .SetInferShapeFn(PD_INFER_SHAPE(FusedFwdInferShape))
-    .SetInferDtypeFn(PD_INFER_DTYPE(FusedFwdInferDtype));
+    .SetInferShapeFn(
+        PD_INFER_SHAPE(FusedGradInferShape))  // Reuse infer shape logic
+    .SetInferDtypeFn(PD_INFER_DTYPE(FusedGradInferDtype));
 
 PD_BUILD_GRAD_OP(fused_swiglu_scale)
     .Inputs({"X", "Scale", paddle::Grad("Out")})
     .Outputs({paddle::Grad("X"), paddle::Grad("Scale")})
-    .SetKernelFn(PD_KERNEL(FusedSwiGLUScaleBackward))
-    .SetInferShapeFn(PD_INFER_SHAPE(FusedScaleGradInferShape));
+    .SetKernelFn(PD_KERNEL(FusedSwiGLUScaleBackward));
 
 // Clamp InferShape: d_scale always [rows, 1] matching Megatron keepdim
 // semantics.
-static std::vector<std::vector<int64_t>> FusedGradClampInferShapeImpl(
-    const std::vector<int64_t>& x_shape,
-    const std::vector<int64_t>& scale_shape,
-    const std::vector<int64_t>& dout_shape,
-    const char* op_name) {
-  CheckFusedSwiGLUXShape(x_shape, op_name);
-  return {x_shape, {x_shape[0], 1}};
-}
-
 std::vector<std::vector<int64_t>> FusedGradClampInferShape(
     std::vector<int64_t> x_shape,
     std::vector<int64_t> scale_shape,
     std::vector<int64_t> dout_shape) {
-  return FusedGradClampInferShapeImpl(
-      x_shape, scale_shape, dout_shape, "fused_swiglu_scale_clamp_bwd");
-}
-
-std::vector<std::vector<int64_t>> FusedScaleClampGradInferShape(
-    std::vector<int64_t> x_shape,
-    std::vector<int64_t> scale_shape,
-    std::vector<int64_t> dout_shape) {
-  return FusedGradClampInferShapeImpl(
-      x_shape, scale_shape, dout_shape, "fused_swiglu_scale_clamp_grad");
+  return {x_shape, {x_shape[0], 1}};
 }
 
 PD_BUILD_OP(fused_swiglu_scale_clamp_bwd)
@@ -870,7 +832,7 @@ PD_BUILD_OP(fused_swiglu_scale_clamp)
     .Outputs({"Out"})
     .Attrs({"clamp_value: double"})
     .SetKernelFn(PD_KERNEL(FusedSwiGLUScaleClampForward))
-    .SetInferShapeFn(PD_INFER_SHAPE(FusedClampFwdInferShape))
+    .SetInferShapeFn(PD_INFER_SHAPE(FusedFwdInferShape))
     .SetInferDtypeFn(PD_INFER_DTYPE(FusedFwdInferDtype));
 
 PD_BUILD_GRAD_OP(fused_swiglu_scale_clamp)
@@ -878,9 +840,17 @@ PD_BUILD_GRAD_OP(fused_swiglu_scale_clamp)
     .Outputs({paddle::Grad("X"), paddle::Grad("Scale")})
     .Attrs({"clamp_value: double"})
     .SetKernelFn(PD_KERNEL(FusedSwiGLUScaleClampBackward))
-    .SetInferShapeFn(PD_INFER_SHAPE(FusedScaleClampGradInferShape));
+    .SetInferShapeFn(PD_INFER_SHAPE(FusedGradClampInferShape));
 
 // ---- Weighted backward (fused forward + backward in one launch) ----
+
+std::vector<std::vector<int64_t>> WeightedBwdInferShape(
+    std::vector<int64_t> x_shape,
+    std::vector<int64_t> probs_shape,
+    std::vector<int64_t> dout_shape) {
+  return {
+      x_shape, probs_shape, {x_shape[0], x_shape[1] / 2}};  // dx, dprobs, out
+}
 
 std::vector<paddle::DataType> WeightedBwdInferDtype(
     paddle::DataType x_dtype,
@@ -889,15 +859,16 @@ std::vector<paddle::DataType> WeightedBwdInferDtype(
   return {x_dtype, probs_dtype, x_dtype};
 }
 
-// Clamp gradients use the [rows, 1] keepdim contract.
+// Clamp InferShape: d_probs always [rows, 1] matching Megatron keepdim
+// semantics.
 std::vector<std::vector<int64_t>> WeightedBwdClampInferShape(
     std::vector<int64_t> x_shape,
     std::vector<int64_t> probs_shape,
     std::vector<int64_t> dout_shape) {
-  return {x_shape,
-          {x_shape[0], 1},
-          InferFusedSwiGLUOutputShape(
-              x_shape, "fused_swiglu_weighted_clamp_bwd")};
+  return {
+      x_shape,
+      {x_shape[0], 1},
+      InferFusedSwiGLUOutputShape(x_shape, "fused_swiglu_weighted_clamp_bwd")};
 }
 
 PD_BUILD_OP(fused_swiglu_weighted_clamp_bwd)

--- a/packages/paddlefleet_ops/src/paddlefleet_ops/_extensions/fuse_swiglu_scale.cu
+++ b/packages/paddlefleet_ops/src/paddlefleet_ops/_extensions/fuse_swiglu_scale.cu
@@ -392,11 +392,6 @@ static void CheckFusedSwiGLUInputs(const paddle::Tensor& x,
                (d_out == nullptr || x.place() == d_out->place()),
            op_name,
            " expects inputs on the same GPU");
-  PD_CHECK(x.is_contiguous() && scale.is_contiguous(),
-           op_name,
-           " expects contiguous X and ",
-           scale_name);
-
   const auto x_shape = x.shape();
   const auto scale_shape = scale.shape();
   CheckFusedSwiGLUXShape(x_shape, op_name);
@@ -468,9 +463,14 @@ static void CheckFusedSwiGLUInputs(const paddle::Tensor& x,
 
 template <bool kHasClamp>
 static std::vector<paddle::Tensor> FusedSwiGLUScaleForwardImpl(
-    const paddle::Tensor& x, const paddle::Tensor& scale, double clamp_value) {
+    const paddle::Tensor& x_input,
+    const paddle::Tensor& scale_input,
+    double clamp_value) {
   const char* op_name =
       kHasClamp ? "fused_swiglu_scale_clamp" : "fused_swiglu_scale";
+  const auto x = x_input.is_contiguous() ? x_input : x_input.contiguous();
+  const auto scale =
+      scale_input.is_contiguous() ? scale_input : scale_input.contiguous();
   CheckFusedSwiGLUInputs(x, scale, nullptr, op_name, "Scale");
   if constexpr (kHasClamp) {
     PD_CHECK(std::isfinite(clamp_value) && clamp_value > 0.0,
@@ -538,12 +538,17 @@ static std::vector<paddle::Tensor> FusedSwiGLUScaleForwardImpl(
 
 template <bool kHasClamp>
 static std::vector<paddle::Tensor> FusedSwiGLUScaleBackwardImpl(
-    const paddle::Tensor& x,
-    const paddle::Tensor& scale,
-    const paddle::Tensor& d_out,
+    const paddle::Tensor& x_input,
+    const paddle::Tensor& scale_input,
+    const paddle::Tensor& d_out_input,
     double clamp_value) {
   const char* op_name =
       kHasClamp ? "fused_swiglu_scale_clamp_bwd" : "fused_swiglu_scale_bwd";
+  const auto x = x_input.is_contiguous() ? x_input : x_input.contiguous();
+  const auto scale =
+      scale_input.is_contiguous() ? scale_input : scale_input.contiguous();
+  const auto d_out =
+      d_out_input.is_contiguous() ? d_out_input : d_out_input.contiguous();
   CheckFusedSwiGLUInputs(x, scale, &d_out, op_name, "Scale");
   if constexpr (kHasClamp) {
     PD_CHECK(std::isfinite(clamp_value) && clamp_value > 0.0,
@@ -564,9 +569,7 @@ static std::vector<paddle::Tensor> FusedSwiGLUScaleBackwardImpl(
   }
 
   auto d_scale = paddle::empty(d_scale_shape, scale.dtype(), scale.place());
-  // DOut may be strided because it is framework-produced; materialize it
-  // before the kernel.
-  const auto kernel_d_out = d_out.is_contiguous() ? d_out : d_out.contiguous();
+  const auto& kernel_d_out = d_out;
 
   // Paddle extension gridDim is int. The kernel uses a grid-stride loop
   // over rows, so we cap grid_size at kMaxSwiGLUGridSize and let the kernel
@@ -629,12 +632,17 @@ static std::vector<paddle::Tensor> FusedSwiGLUScaleBackwardImpl(
 // ==========================================================================
 template <bool kHasClamp>
 static std::vector<paddle::Tensor> FusedSwiGLUWeightedBackwardImpl(
-    const paddle::Tensor& x,
-    const paddle::Tensor& probs,
-    const paddle::Tensor& d_out,
+    const paddle::Tensor& x_input,
+    const paddle::Tensor& probs_input,
+    const paddle::Tensor& d_out_input,
     double clamp_value) {
   const char* op_name = kHasClamp ? "fused_swiglu_weighted_clamp_bwd"
                                   : "fused_swiglu_weighted_bwd";
+  const auto x = x_input.is_contiguous() ? x_input : x_input.contiguous();
+  const auto probs =
+      probs_input.is_contiguous() ? probs_input : probs_input.contiguous();
+  const auto d_out =
+      d_out_input.is_contiguous() ? d_out_input : d_out_input.contiguous();
   CheckFusedSwiGLUInputs(x, probs, &d_out, op_name, "Probs");
   if constexpr (kHasClamp) {
     PD_CHECK(std::isfinite(clamp_value) && clamp_value > 0.0,
@@ -657,7 +665,7 @@ static std::vector<paddle::Tensor> FusedSwiGLUWeightedBackwardImpl(
   }
 
   auto d_probs = paddle::empty(d_probs_shape, probs.dtype(), probs.place());
-  const auto kernel_d_out = d_out.is_contiguous() ? d_out : d_out.contiguous();
+  const auto& kernel_d_out = d_out;
 
   // Paddle extension gridDim is int. The kernel uses a grid-stride loop
   // over rows, so we cap grid_size at kMaxSwiGLUGridSize and let the kernel

--- a/packages/paddlefleet_ops/src/paddlefleet_ops/_extensions/fuse_swiglu_scale.cu
+++ b/packages/paddlefleet_ops/src/paddlefleet_ops/_extensions/fuse_swiglu_scale.cu
@@ -366,7 +366,7 @@ __global__ void VectorizedFusedSwiGLUWeightedBwd(
 }
 
 // ==========================================================================
-// Scale Host Wrappers (templated on kHasClamp; non-clamp wrappers forward 0.0)
+// SwiGLU host wrappers.
 // ==========================================================================
 
 static void CheckFusedSwiGLUXShape(const std::vector<int64_t>& x_shape,
@@ -382,8 +382,7 @@ static void CheckFusedSwiGLUXShape(const std::vector<int64_t>& x_shape,
 static std::vector<int64_t> InferFusedSwiGLUOutputShape(
     const std::vector<int64_t>& x_shape, const char* op_name) {
   CheckFusedSwiGLUXShape(x_shape, op_name);
-  // Preserve Paddle's unknown-dimension sentinel instead of evaluating
-  // -1 / 2 as zero during static shape inference.
+  // Preserve -1 for unknown hidden dimensions during static shape inference.
   const int64_t hidden_size = x_shape[1] < 0 ? -1 : x_shape[1] / 2;
   return {x_shape[0], hidden_size};
 }
@@ -453,8 +452,7 @@ static void CheckFusedSwiGLUInputs(const paddle::Tensor& x,
            ": float32 X requires float32 ",
            scale_name);
 
-  // Packed128 loads/stores require one complete vector per lane. H == 0 is
-  // allowed; the kernel's column loop is empty and performs no packed access.
+  // Packed128 accesses require a complete vector; hidden_size == 0 is valid.
   const int64_t vec_size = x_is_bf16 ? 8 : 4;
   PD_CHECK(hidden_size % vec_size == 0,
            op_name,
@@ -478,8 +476,7 @@ static std::vector<paddle::Tensor> FusedSwiGLUScaleForwardImpl(
   auto hidden_size = hidden2 / 2;
   auto out = paddle::empty({rows, hidden_size}, x.dtype(), x.place());
 
-  // Avoid passing zero-byte tensors to data<T>(); the kernel has no work for
-  // either an empty batch or an empty hidden dimension.
+  // Avoid data<T>() and kernel launch for zero-byte tensors.
   if (rows == 0 || hidden_size == 0) {
     return {out};
   }
@@ -491,8 +488,6 @@ static std::vector<paddle::Tensor> FusedSwiGLUScaleForwardImpl(
   int block_size = kSwiGLUBlockSize;
   auto stream = x.stream();
 
-  // The checks above make the fallback branches unreachable for the current
-  // dtype set; keep them explicit so a future dtype cannot skip the launch.
   if (x.dtype() == paddle::DataType::BFLOAT16) {
     using paddle_bf16 = paddle::bfloat16;
     using cuda_bf16 = __nv_bfloat16;
@@ -553,8 +548,7 @@ static std::vector<paddle::Tensor> FusedSwiGLUScaleBackwardImpl(
   auto hidden2 = x.shape()[1];
   auto hidden_size = hidden2 / 2;
   auto d_x = paddle::empty_like(x);
-  // Clamp keeps the historical [rows, 1] reduction shape; non-clamp keeps
-  // the input Scale shape.
+  // Clamp gradients use [rows, 1]; non-clamp gradients match Scale.
   const std::vector<int64_t> d_scale_shape =
       kHasClamp ? std::vector<int64_t>{rows, 1} : scale.shape();
 
@@ -563,9 +557,8 @@ static std::vector<paddle::Tensor> FusedSwiGLUScaleBackwardImpl(
   }
 
   auto d_scale = paddle::empty(d_scale_shape, scale.dtype(), scale.place());
-  // DOut is framework-produced and may be strided. Materialize it on the
-  // current custom-op stream instead of rejecting a layout callers cannot
-  // control.
+  // DOut may be strided because it is framework-produced; materialize it
+  // before the kernel.
   const auto kernel_d_out =
       d_out.is_contiguous() ? d_out : d_out.contiguous();
 
@@ -576,8 +569,6 @@ static std::vector<paddle::Tensor> FusedSwiGLUScaleBackwardImpl(
   int block_size = kSwiGLUBlockSize;
   auto stream = x.stream();
 
-  // Keep explicit fallback errors even though input validation currently
-  // makes these branches unreachable.
   if (x.dtype() == paddle::DataType::BFLOAT16) {
     using paddle_bf16 = paddle::bfloat16;
     using cuda_bf16 = __nv_bfloat16;
@@ -652,8 +643,7 @@ static std::vector<paddle::Tensor> FusedSwiGLUWeightedBackwardImpl(
     return {d_x, paddle::zeros(d_probs_shape, probs.dtype(), probs.place()), out};
   }
 
-  // DProbs intentionally follows Megatron's keepdim contract even when Probs
-  // is rank 1; the main MoE backward path normalizes Probs to [rows, 1].
+  // DProbs follows Megatron's [rows, 1] keepdim contract.
   auto d_probs =
       paddle::empty(d_probs_shape, probs.dtype(), probs.place());
   const auto kernel_d_out =
@@ -666,8 +656,6 @@ static std::vector<paddle::Tensor> FusedSwiGLUWeightedBackwardImpl(
   int block_size = kSwiGLUBlockSize;
   auto stream = x.stream();
 
-  // Keep explicit fallback errors even though input validation currently
-  // makes these branches unreachable.
   if (x.dtype() == paddle::DataType::BFLOAT16) {
     using paddle_bf16 = paddle::bfloat16;
     using cuda_bf16 = __nv_bfloat16;
@@ -895,8 +883,7 @@ std::vector<paddle::DataType> WeightedBwdInferDtype(
   return {x_dtype, probs_dtype, x_dtype};
 }
 
-// Clamp InferShape: d_probs is always [rows, 1] matching Megatron keepdim
-// semantics, even when the rank-1 Probs input is accepted.
+// Clamp gradients use the [rows, 1] keepdim contract.
 std::vector<std::vector<int64_t>> WeightedBwdClampInferShape(
     std::vector<int64_t> x_shape,
     std::vector<int64_t> probs_shape,

--- a/packages/paddlefleet_ops/src/paddlefleet_ops/_extensions/fuse_swiglu_scale.cu
+++ b/packages/paddlefleet_ops/src/paddlefleet_ops/_extensions/fuse_swiglu_scale.cu
@@ -461,32 +461,6 @@ static void CheckFusedSwiGLUInputs(const paddle::Tensor& x,
            ": hidden_size must be divisible by the vector width");
 }
 
-static void CheckFusedSwiGLUClampValue(double clamp_value,
-                                       const char* op_name) {
-  PD_CHECK(std::isfinite(clamp_value) && clamp_value > 0.0,
-           op_name,
-           ": clamp_value must be finite and greater than zero");
-}
-
-static void CheckFusedSwiGLUPreLaunch(const char* op_name) {
-  // Peek without clearing so an unrelated upstream error keeps its original
-  // owner instead of being attributed to this op.
-  const cudaError_t error = cudaPeekAtLastError();
-  PD_CHECK(error == cudaSuccess,
-           op_name,
-           " observed a CUDA error before its kernel launch: ",
-           cudaGetErrorString(error));
-}
-
-static void CheckFusedSwiGLULaunch(const char* op_name) {
-  // This reports launch/API errors, not asynchronous execution failures.
-  const cudaError_t error = cudaGetLastError();
-  PD_CHECK(error == cudaSuccess,
-           op_name,
-           " CUDA launch/API check failed: ",
-           cudaGetErrorString(error));
-}
-
 template <bool kHasClamp>
 static std::vector<paddle::Tensor> FusedSwiGLUScaleForwardImpl(
     const paddle::Tensor& x, const paddle::Tensor& scale, double clamp_value) {
@@ -494,7 +468,9 @@ static std::vector<paddle::Tensor> FusedSwiGLUScaleForwardImpl(
                                   : "fused_swiglu_scale";
   CheckFusedSwiGLUInputs(x, scale, nullptr, op_name, "Scale");
   if constexpr (kHasClamp) {
-    CheckFusedSwiGLUClampValue(clamp_value, op_name);
+    PD_CHECK(std::isfinite(clamp_value) && clamp_value > 0.0,
+             op_name,
+             ": clamp_value must be finite and greater than zero");
   }
 
   auto rows = x.shape()[0];
@@ -514,7 +490,6 @@ static std::vector<paddle::Tensor> FusedSwiGLUScaleForwardImpl(
   int grid_size = GetSwiGLURowGridSize(rows);
   int block_size = kSwiGLUBlockSize;
   auto stream = x.stream();
-  CheckFusedSwiGLUPreLaunch(op_name);
 
   // The checks above make the fallback branches unreachable for the current
   // dtype set; keep them explicit so a future dtype cannot skip the launch.
@@ -556,7 +531,6 @@ static std::vector<paddle::Tensor> FusedSwiGLUScaleForwardImpl(
   } else {
     PD_THROW(op_name, " does not support X dtype");
   }
-  CheckFusedSwiGLULaunch(op_name);
   return {out};
 }
 
@@ -570,7 +544,9 @@ static std::vector<paddle::Tensor> FusedSwiGLUScaleBackwardImpl(
                                   : "fused_swiglu_scale_bwd";
   CheckFusedSwiGLUInputs(x, scale, &d_out, op_name, "Scale");
   if constexpr (kHasClamp) {
-    CheckFusedSwiGLUClampValue(clamp_value, op_name);
+    PD_CHECK(std::isfinite(clamp_value) && clamp_value > 0.0,
+             op_name,
+             ": clamp_value must be finite and greater than zero");
   }
 
   auto rows = x.shape()[0];
@@ -599,7 +575,6 @@ static std::vector<paddle::Tensor> FusedSwiGLUScaleBackwardImpl(
   int grid_size = GetSwiGLURowGridSize(rows);
   int block_size = kSwiGLUBlockSize;
   auto stream = x.stream();
-  CheckFusedSwiGLUPreLaunch(op_name);
 
   // Keep explicit fallback errors even though input validation currently
   // makes these branches unreachable.
@@ -649,7 +624,6 @@ static std::vector<paddle::Tensor> FusedSwiGLUScaleBackwardImpl(
   } else {
     PD_THROW(op_name, " does not support X dtype");
   }
-  CheckFusedSwiGLULaunch(op_name);
   return {d_x, d_scale};
 }
 
@@ -663,7 +637,9 @@ static std::vector<paddle::Tensor> FusedSwiGLUWeightedBackwardImpl(
     double clamp_value) {
   const char* op_name = "fused_swiglu_weighted_clamp_bwd";
   CheckFusedSwiGLUInputs(x, probs, &d_out, op_name, "Probs");
-  CheckFusedSwiGLUClampValue(clamp_value, op_name);
+  PD_CHECK(std::isfinite(clamp_value) && clamp_value > 0.0,
+           op_name,
+           ": clamp_value must be finite and greater than zero");
 
   int64_t rows = x.shape()[0];
   int64_t hidden2 = x.shape()[1];
@@ -689,7 +665,6 @@ static std::vector<paddle::Tensor> FusedSwiGLUWeightedBackwardImpl(
   int grid_size = GetSwiGLURowGridSize(rows);
   int block_size = kSwiGLUBlockSize;
   auto stream = x.stream();
-  CheckFusedSwiGLUPreLaunch(op_name);
 
   // Keep explicit fallback errors even though input validation currently
   // makes these branches unreachable.
@@ -742,7 +717,6 @@ static std::vector<paddle::Tensor> FusedSwiGLUWeightedBackwardImpl(
   } else {
     PD_THROW(op_name, " does not support X dtype");
   }
-  CheckFusedSwiGLULaunch(op_name);
   return {d_x, d_probs, out};
 }
 

--- a/packages/paddlefleet_ops/src/paddlefleet_ops/_extensions/fuse_swiglu_scale.cu
+++ b/packages/paddlefleet_ops/src/paddlefleet_ops/_extensions/fuse_swiglu_scale.cu
@@ -458,9 +458,10 @@ static void CheckFusedSwiGLUInputs(const paddle::Tensor& x,
            ": float32 X requires float32 ",
            scale_name);
 
-  // Packed128 accesses require a complete vector; hidden_size == 0 is valid.
+  // Packed128 accesses require a complete vector for non-empty batches.
+  // Empty batches return before launching the packed kernel.
   const int64_t vec_size = x_is_bf16 ? 8 : 4;
-  PD_CHECK(hidden_size % vec_size == 0,
+  PD_CHECK(rows == 0 || hidden_size % vec_size == 0,
            op_name,
            ": hidden_size must be divisible by the vector width");
 }

--- a/packages/paddlefleet_ops/src/paddlefleet_ops/_extensions/fuse_swiglu_scale.cu
+++ b/packages/paddlefleet_ops/src/paddlefleet_ops/_extensions/fuse_swiglu_scale.cu
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <cuda_bf16.h>
+#include <cmath>
 #include <cstdint>
 #include <limits>
 #include <vector>
@@ -365,17 +366,135 @@ __global__ void VectorizedFusedSwiGLUWeightedBwd(
 }
 
 // ==========================================================================
-// Host Wrappers (templated on kHasClamp; non-clamp wrappers forward 0.0)
+// Scale Host Wrappers (templated on kHasClamp; non-clamp wrappers forward 0.0)
 // ==========================================================================
+
+static void CheckFusedSwiGLUXShape(const std::vector<int64_t>& x_shape,
+                                   const char* op_name) {
+  PD_CHECK(x_shape.size() == 2,
+           op_name,
+           ": X must have shape [rows, 2 * hidden_size]");
+  PD_CHECK(x_shape[1] < 0 || x_shape[1] % 2 == 0,
+           op_name,
+           ": the last dimension of X must be divisible by 2");
+}
+
+static void CheckFusedSwiGLUInputs(const paddle::Tensor& x,
+                                   const paddle::Tensor& scale,
+                                   const paddle::Tensor* d_out,
+                                   const char* op_name,
+                                   const char* scale_name) {
+  PD_CHECK(x.is_gpu() && scale.is_gpu() &&
+               (d_out == nullptr || d_out->is_gpu()),
+           op_name,
+           " expects GPU inputs");
+  PD_CHECK(x.place() == scale.place() &&
+               (d_out == nullptr || x.place() == d_out->place()),
+           op_name,
+           " expects inputs on the same GPU");
+  PD_CHECK(x.is_contiguous() && scale.is_contiguous(),
+           op_name,
+           " expects contiguous X and ",
+           scale_name);
+
+  const auto x_shape = x.shape();
+  const auto scale_shape = scale.shape();
+  CheckFusedSwiGLUXShape(x_shape, op_name);
+  PD_CHECK(scale_shape.size() == 1 ||
+               (scale_shape.size() == 2 && scale_shape[1] == 1),
+           op_name,
+           ": ",
+           scale_name,
+           " must have shape [rows] or [rows, 1]");
+
+  const int64_t rows = x_shape[0];
+  const int64_t hidden_size = x_shape[1] / 2;
+  PD_CHECK(scale.numel() == rows,
+           op_name,
+           ": ",
+           scale_name,
+           " must contain exactly one value per X row");
+
+  if (d_out != nullptr) {
+    const auto d_out_shape = d_out->shape();
+    PD_CHECK(d_out_shape.size() == 2,
+             op_name,
+             ": DOut must have shape [rows, hidden_size]");
+    PD_CHECK(d_out_shape[0] == rows && d_out_shape[1] == hidden_size,
+             op_name,
+             ": DOut must have shape [X.shape[0], X.shape[1] / 2]");
+    PD_CHECK(d_out->dtype() == x.dtype(),
+             op_name,
+             ": DOut dtype must match X dtype");
+  }
+
+  const bool x_is_bf16 = x.dtype() == paddle::DataType::BFLOAT16;
+  const bool x_is_fp32 = x.dtype() == paddle::DataType::FLOAT32;
+  PD_CHECK(x_is_bf16 || x_is_fp32,
+           op_name,
+           ": X must be bfloat16 or float32");
+  PD_CHECK(scale.dtype() == paddle::DataType::BFLOAT16 ||
+               scale.dtype() == paddle::DataType::FLOAT32,
+           op_name,
+           ": ",
+           scale_name,
+           " must be bfloat16 or float32");
+  PD_CHECK(!x_is_fp32 || scale.dtype() == paddle::DataType::FLOAT32,
+           op_name,
+           ": float32 X requires float32 ",
+           scale_name);
+
+  // Packed128 loads/stores require one complete vector per lane. H == 0 is
+  // allowed; the kernel's column loop is empty and performs no packed access.
+  const int64_t vec_size = x_is_bf16 ? 8 : 4;
+  PD_CHECK(hidden_size % vec_size == 0,
+           op_name,
+           ": hidden_size must be divisible by the vector width");
+}
+
+static void CheckFusedSwiGLUClampValue(double clamp_value,
+                                       const char* op_name) {
+  PD_CHECK(std::isfinite(clamp_value) && clamp_value > 0.0,
+           op_name,
+           ": clamp_value must be finite and greater than zero");
+}
+
+static void CheckFusedSwiGLUPreLaunch(const char* op_name) {
+  // Peek without clearing so an unrelated upstream error keeps its original
+  // owner instead of being attributed to this op.
+  const cudaError_t error = cudaPeekAtLastError();
+  PD_CHECK(error == cudaSuccess,
+           op_name,
+           " observed a CUDA error before its kernel launch: ",
+           cudaGetErrorString(error));
+}
+
+static void CheckFusedSwiGLULaunch(const char* op_name) {
+  // This reports launch/API errors, not asynchronous execution failures.
+  const cudaError_t error = cudaGetLastError();
+  PD_CHECK(error == cudaSuccess,
+           op_name,
+           " CUDA launch/API check failed: ",
+           cudaGetErrorString(error));
+}
 
 template <bool kHasClamp>
 static std::vector<paddle::Tensor> FusedSwiGLUScaleForwardImpl(
     const paddle::Tensor& x, const paddle::Tensor& scale, double clamp_value) {
+  const char* op_name = kHasClamp ? "fused_swiglu_scale_clamp"
+                                  : "fused_swiglu_scale";
+  CheckFusedSwiGLUInputs(x, scale, nullptr, op_name, "Scale");
+  if constexpr (kHasClamp) {
+    CheckFusedSwiGLUClampValue(clamp_value, op_name);
+  }
+
   auto rows = x.shape()[0];
   auto hidden2 = x.shape()[1];
   auto hidden_size = hidden2 / 2;
   auto out = paddle::empty({rows, hidden_size}, x.dtype(), x.place());
 
+  // Avoid passing zero-byte tensors to data<T>(); the kernel has no work for
+  // either an empty batch or an empty hidden dimension.
   if (rows == 0 || hidden_size == 0) {
     return {out};
   }
@@ -386,7 +505,10 @@ static std::vector<paddle::Tensor> FusedSwiGLUScaleForwardImpl(
   int grid_size = GetSwiGLURowGridSize(rows);
   int block_size = kSwiGLUBlockSize;
   auto stream = x.stream();
+  CheckFusedSwiGLUPreLaunch(op_name);
 
+  // The checks above make the fallback branches unreachable for the current
+  // dtype set; keep them explicit so a future dtype cannot skip the launch.
   if (x.dtype() == paddle::DataType::BFLOAT16) {
     using paddle_bf16 = paddle::bfloat16;
     using cuda_bf16 = __nv_bfloat16;
@@ -400,7 +522,7 @@ static std::vector<paddle::Tensor> FusedSwiGLUScaleForwardImpl(
               hidden_size,
               hidden2,
               clamp_value);
-    } else {
+    } else if (scale.dtype() == paddle::DataType::BFLOAT16) {
       VectorizedFusedSwiGLUFwd<cuda_bf16, cuda_bf16, 8, kHasClamp>
           <<<grid_size, block_size, 0, stream>>>(
               reinterpret_cast<const cuda_bf16*>(x.data<paddle_bf16>()),
@@ -410,6 +532,8 @@ static std::vector<paddle::Tensor> FusedSwiGLUScaleForwardImpl(
               hidden_size,
               hidden2,
               clamp_value);
+    } else {
+      PD_THROW(op_name, " does not support Scale dtype");
     }
   } else if (x.dtype() == paddle::DataType::FLOAT32) {
     VectorizedFusedSwiGLUFwd<float, float, 4, kHasClamp>
@@ -420,7 +544,10 @@ static std::vector<paddle::Tensor> FusedSwiGLUScaleForwardImpl(
                                                hidden_size,
                                                hidden2,
                                                clamp_value);
+  } else {
+    PD_THROW(op_name, " does not support X dtype");
   }
+  CheckFusedSwiGLULaunch(op_name);
   return {out};
 }
 
@@ -430,20 +557,32 @@ static std::vector<paddle::Tensor> FusedSwiGLUScaleBackwardImpl(
     const paddle::Tensor& scale,
     const paddle::Tensor& d_out,
     double clamp_value) {
+  const char* op_name = kHasClamp ? "fused_swiglu_scale_clamp_bwd"
+                                  : "fused_swiglu_scale_bwd";
+  CheckFusedSwiGLUInputs(x, scale, &d_out, op_name, "Scale");
+  if constexpr (kHasClamp) {
+    CheckFusedSwiGLUClampValue(clamp_value, op_name);
+  }
+
   auto rows = x.shape()[0];
   auto hidden2 = x.shape()[1];
   auto hidden_size = hidden2 / 2;
   auto d_x = paddle::empty_like(x);
-  // Align d_scale shape: keepdim semantics -> [rows, 1] for clamp path,
-  // empty_like for non-clamp (pre-existing behaviour).
-  auto d_scale = paddle::empty_like(scale);
-  if constexpr (kHasClamp) {
-    d_scale = paddle::empty({rows, 1}, scale.dtype(), x.place());
-  }
+  // Clamp keeps the historical [rows, 1] reduction shape; non-clamp keeps
+  // the input Scale shape.
+  const std::vector<int64_t> d_scale_shape =
+      kHasClamp ? std::vector<int64_t>{rows, 1} : scale.shape();
 
   if (rows == 0 || hidden_size == 0) {
-    return {d_x, d_scale};
+    return {d_x, paddle::zeros(d_scale_shape, scale.dtype(), scale.place())};
   }
+
+  auto d_scale = paddle::empty(d_scale_shape, scale.dtype(), scale.place());
+  // DOut is framework-produced and may be strided. Materialize it on the
+  // current custom-op stream instead of rejecting a layout callers cannot
+  // control.
+  const auto kernel_d_out =
+      d_out.is_contiguous() ? d_out : d_out.contiguous();
 
   // Paddle extension gridDim is int. The kernel uses a grid-stride loop
   // over rows, so we cap grid_size at kMaxSwiGLUGridSize and let the kernel
@@ -451,7 +590,10 @@ static std::vector<paddle::Tensor> FusedSwiGLUScaleBackwardImpl(
   int grid_size = GetSwiGLURowGridSize(rows);
   int block_size = kSwiGLUBlockSize;
   auto stream = x.stream();
+  CheckFusedSwiGLUPreLaunch(op_name);
 
+  // Keep explicit fallback errors even though input validation currently
+  // makes these branches unreachable.
   if (x.dtype() == paddle::DataType::BFLOAT16) {
     using paddle_bf16 = paddle::bfloat16;
     using cuda_bf16 = __nv_bfloat16;
@@ -460,63 +602,77 @@ static std::vector<paddle::Tensor> FusedSwiGLUScaleBackwardImpl(
           <<<grid_size, block_size, 0, stream>>>(
               reinterpret_cast<const cuda_bf16*>(x.data<paddle_bf16>()),
               scale.data<float>(),
-              reinterpret_cast<const cuda_bf16*>(d_out.data<paddle_bf16>()),
+              reinterpret_cast<const cuda_bf16*>(
+                  kernel_d_out.data<paddle_bf16>()),
               reinterpret_cast<cuda_bf16*>(d_x.data<paddle_bf16>()),
               d_scale.data<float>(),
               rows,
               hidden_size,
               hidden2,
               clamp_value);
-    } else {
+    } else if (scale.dtype() == paddle::DataType::BFLOAT16) {
       VectorizedFusedSwiGLUBwd<cuda_bf16, cuda_bf16, 8, kHasClamp>
           <<<grid_size, block_size, 0, stream>>>(
               reinterpret_cast<const cuda_bf16*>(x.data<paddle_bf16>()),
               reinterpret_cast<const cuda_bf16*>(scale.data<paddle_bf16>()),
-              reinterpret_cast<const cuda_bf16*>(d_out.data<paddle_bf16>()),
+              reinterpret_cast<const cuda_bf16*>(
+                  kernel_d_out.data<paddle_bf16>()),
               reinterpret_cast<cuda_bf16*>(d_x.data<paddle_bf16>()),
               reinterpret_cast<cuda_bf16*>(d_scale.data<paddle_bf16>()),
               rows,
               hidden_size,
               hidden2,
               clamp_value);
+    } else {
+      PD_THROW(op_name, " does not support Scale dtype");
     }
   } else if (x.dtype() == paddle::DataType::FLOAT32) {
     VectorizedFusedSwiGLUBwd<float, float, 4, kHasClamp>
         <<<grid_size, block_size, 0, stream>>>(x.data<float>(),
                                                scale.data<float>(),
-                                               d_out.data<float>(),
+                                               kernel_d_out.data<float>(),
                                                d_x.data<float>(),
                                                d_scale.data<float>(),
                                                rows,
                                                hidden_size,
                                                hidden2,
                                                clamp_value);
+  } else {
+    PD_THROW(op_name, " does not support X dtype");
   }
+  CheckFusedSwiGLULaunch(op_name);
   return {d_x, d_scale};
 }
 
 // ==========================================================================
 // Weighted Backward Host Wrapper (combines forward+backward in one launch)
 // ==========================================================================
-template <bool kHasClamp>
 static std::vector<paddle::Tensor> FusedSwiGLUWeightedBackwardImpl(
     const paddle::Tensor& x,
     const paddle::Tensor& probs,
     const paddle::Tensor& d_out,
     double clamp_value) {
+  const char* op_name = "fused_swiglu_weighted_clamp_bwd";
+  CheckFusedSwiGLUInputs(x, probs, &d_out, op_name, "Probs");
+  CheckFusedSwiGLUClampValue(clamp_value, op_name);
+
   int64_t rows = x.shape()[0];
   int64_t hidden2 = x.shape()[1];
   int64_t hidden_size = hidden2 / 2;
   auto d_x = paddle::empty_like(x);
-  auto d_probs = paddle::empty_like(probs);
-  if constexpr (kHasClamp) {
-    d_probs = paddle::empty({rows, 1}, probs.dtype(), x.place());
-  }
   auto out = paddle::empty({rows, hidden_size}, x.dtype(), x.place());
+  const std::vector<int64_t> d_probs_shape{rows, 1};
 
   if (rows == 0 || hidden_size == 0) {
-    return {d_x, d_probs, out};
+    return {d_x, paddle::zeros(d_probs_shape, probs.dtype(), probs.place()), out};
   }
+
+  // DProbs intentionally follows Megatron's keepdim contract even when Probs
+  // is rank 1; the main MoE backward path normalizes Probs to [rows, 1].
+  auto d_probs =
+      paddle::empty(d_probs_shape, probs.dtype(), probs.place());
+  const auto kernel_d_out =
+      d_out.is_contiguous() ? d_out : d_out.contiguous();
 
   // Paddle extension gridDim is int. The kernel uses a grid-stride loop
   // over rows, so we cap grid_size at kMaxSwiGLUGridSize and let the kernel
@@ -524,16 +680,20 @@ static std::vector<paddle::Tensor> FusedSwiGLUWeightedBackwardImpl(
   int grid_size = GetSwiGLURowGridSize(rows);
   int block_size = kSwiGLUBlockSize;
   auto stream = x.stream();
+  CheckFusedSwiGLUPreLaunch(op_name);
 
+  // Keep explicit fallback errors even though input validation currently
+  // makes these branches unreachable.
   if (x.dtype() == paddle::DataType::BFLOAT16) {
     using paddle_bf16 = paddle::bfloat16;
     using cuda_bf16 = __nv_bfloat16;
     if (probs.dtype() == paddle::DataType::FLOAT32) {
-      VectorizedFusedSwiGLUWeightedBwd<cuda_bf16, float, 8, kHasClamp>
+      VectorizedFusedSwiGLUWeightedBwd<cuda_bf16, float, 8, true>
           <<<grid_size, block_size, 0, stream>>>(
               reinterpret_cast<const cuda_bf16*>(x.data<paddle_bf16>()),
               probs.data<float>(),
-              reinterpret_cast<const cuda_bf16*>(d_out.data<paddle_bf16>()),
+              reinterpret_cast<const cuda_bf16*>(
+                  kernel_d_out.data<paddle_bf16>()),
               reinterpret_cast<cuda_bf16*>(d_x.data<paddle_bf16>()),
               d_probs.data<float>(),
               reinterpret_cast<cuda_bf16*>(out.data<paddle_bf16>()),
@@ -541,12 +701,13 @@ static std::vector<paddle::Tensor> FusedSwiGLUWeightedBackwardImpl(
               hidden_size,
               hidden2,
               clamp_value);
-    } else {
-      VectorizedFusedSwiGLUWeightedBwd<cuda_bf16, cuda_bf16, 8, kHasClamp>
+    } else if (probs.dtype() == paddle::DataType::BFLOAT16) {
+      VectorizedFusedSwiGLUWeightedBwd<cuda_bf16, cuda_bf16, 8, true>
           <<<grid_size, block_size, 0, stream>>>(
               reinterpret_cast<const cuda_bf16*>(x.data<paddle_bf16>()),
               reinterpret_cast<const cuda_bf16*>(probs.data<paddle_bf16>()),
-              reinterpret_cast<const cuda_bf16*>(d_out.data<paddle_bf16>()),
+              reinterpret_cast<const cuda_bf16*>(
+                  kernel_d_out.data<paddle_bf16>()),
               reinterpret_cast<cuda_bf16*>(d_x.data<paddle_bf16>()),
               reinterpret_cast<cuda_bf16*>(d_probs.data<paddle_bf16>()),
               reinterpret_cast<cuda_bf16*>(out.data<paddle_bf16>()),
@@ -554,12 +715,14 @@ static std::vector<paddle::Tensor> FusedSwiGLUWeightedBackwardImpl(
               hidden_size,
               hidden2,
               clamp_value);
+    } else {
+      PD_THROW(op_name, " does not support Probs dtype");
     }
   } else if (x.dtype() == paddle::DataType::FLOAT32) {
-    VectorizedFusedSwiGLUWeightedBwd<float, float, 4, kHasClamp>
+    VectorizedFusedSwiGLUWeightedBwd<float, float, 4, true>
         <<<grid_size, block_size, 0, stream>>>(x.data<float>(),
                                                probs.data<float>(),
-                                               d_out.data<float>(),
+                                               kernel_d_out.data<float>(),
                                                d_x.data<float>(),
                                                d_probs.data<float>(),
                                                out.data<float>(),
@@ -567,7 +730,10 @@ static std::vector<paddle::Tensor> FusedSwiGLUWeightedBackwardImpl(
                                                hidden_size,
                                                hidden2,
                                                clamp_value);
+  } else {
+    PD_THROW(op_name, " does not support X dtype");
   }
+  CheckFusedSwiGLULaunch(op_name);
   return {d_x, d_probs, out};
 }
 
@@ -605,19 +771,36 @@ std::vector<paddle::Tensor> FusedSwiGLUWeightedClampBackward(
     const paddle::Tensor& probs,
     const paddle::Tensor& d_out,
     double clamp_value) {
-  return FusedSwiGLUWeightedBackwardImpl</*kHasClamp=*/true>(
-      x, probs, d_out, clamp_value);
+  return FusedSwiGLUWeightedBackwardImpl(x, probs, d_out, clamp_value);
 }
 
 // ==========================================================================
 // Op Registration
 // ==========================================================================
 
+static std::vector<std::vector<int64_t>> FusedGradInferShapeImpl(
+    const std::vector<int64_t>& x_shape,
+    const std::vector<int64_t>& scale_shape,
+    const std::vector<int64_t>& dout_shape,
+    const char* op_name) {
+  CheckFusedSwiGLUXShape(x_shape, op_name);
+  return {x_shape, scale_shape};
+}
+
 std::vector<std::vector<int64_t>> FusedGradInferShape(
     std::vector<int64_t> x_shape,
     std::vector<int64_t> scale_shape,
     std::vector<int64_t> dout_shape) {
-  return {x_shape, scale_shape};
+  return FusedGradInferShapeImpl(
+      x_shape, scale_shape, dout_shape, "fused_swiglu_scale_bwd");
+}
+
+std::vector<std::vector<int64_t>> FusedScaleGradInferShape(
+    std::vector<int64_t> x_shape,
+    std::vector<int64_t> scale_shape,
+    std::vector<int64_t> dout_shape) {
+  return FusedGradInferShapeImpl(
+      x_shape, scale_shape, dout_shape, "fused_swiglu_scale_grad");
 }
 
 std::vector<paddle::DataType> FusedGradInferDtype(paddle::DataType x_dtype,
@@ -627,9 +810,23 @@ std::vector<paddle::DataType> FusedGradInferDtype(paddle::DataType x_dtype,
 }
 
 // Forward: output is SwiGLU(x) * scale with shape {rows, hidden_size/2}
+static std::vector<std::vector<int64_t>> FusedFwdInferShapeImpl(
+    const std::vector<int64_t>& x_shape,
+    const std::vector<int64_t>& scale_shape,
+    const char* op_name) {
+  CheckFusedSwiGLUXShape(x_shape, op_name);
+  return {{x_shape[0], x_shape[1] / 2}};
+}
+
 std::vector<std::vector<int64_t>> FusedFwdInferShape(
     std::vector<int64_t> x_shape, std::vector<int64_t> scale_shape) {
-  return {{x_shape[0], x_shape[1] / 2}};
+  return FusedFwdInferShapeImpl(x_shape, scale_shape, "fused_swiglu_scale");
+}
+
+std::vector<std::vector<int64_t>> FusedClampFwdInferShape(
+    std::vector<int64_t> x_shape, std::vector<int64_t> scale_shape) {
+  return FusedFwdInferShapeImpl(
+      x_shape, scale_shape, "fused_swiglu_scale_clamp");
 }
 
 std::vector<paddle::DataType> FusedFwdInferDtype(paddle::DataType x_dtype,
@@ -648,22 +845,40 @@ PD_BUILD_OP(fused_swiglu_scale)
     .Inputs({"X", "Scale"})
     .Outputs({"Out"})
     .SetKernelFn(PD_KERNEL(FusedSwiGLUScaleForward))
-    .SetInferShapeFn(
-        PD_INFER_SHAPE(FusedGradInferShape))  // Reuse infer shape logic
-    .SetInferDtypeFn(PD_INFER_DTYPE(FusedGradInferDtype));
+    .SetInferShapeFn(PD_INFER_SHAPE(FusedFwdInferShape))
+    .SetInferDtypeFn(PD_INFER_DTYPE(FusedFwdInferDtype));
 
 PD_BUILD_GRAD_OP(fused_swiglu_scale)
     .Inputs({"X", "Scale", paddle::Grad("Out")})
     .Outputs({paddle::Grad("X"), paddle::Grad("Scale")})
-    .SetKernelFn(PD_KERNEL(FusedSwiGLUScaleBackward));
+    .SetKernelFn(PD_KERNEL(FusedSwiGLUScaleBackward))
+    .SetInferShapeFn(PD_INFER_SHAPE(FusedScaleGradInferShape));
 
 // Clamp InferShape: d_scale always [rows, 1] matching Megatron keepdim
 // semantics.
+static std::vector<std::vector<int64_t>> FusedGradClampInferShapeImpl(
+    const std::vector<int64_t>& x_shape,
+    const std::vector<int64_t>& scale_shape,
+    const std::vector<int64_t>& dout_shape,
+    const char* op_name) {
+  CheckFusedSwiGLUXShape(x_shape, op_name);
+  return {x_shape, {x_shape[0], 1}};
+}
+
 std::vector<std::vector<int64_t>> FusedGradClampInferShape(
     std::vector<int64_t> x_shape,
     std::vector<int64_t> scale_shape,
     std::vector<int64_t> dout_shape) {
-  return {x_shape, {x_shape[0], 1}};
+  return FusedGradClampInferShapeImpl(
+      x_shape, scale_shape, dout_shape, "fused_swiglu_scale_clamp_bwd");
+}
+
+std::vector<std::vector<int64_t>> FusedScaleClampGradInferShape(
+    std::vector<int64_t> x_shape,
+    std::vector<int64_t> scale_shape,
+    std::vector<int64_t> dout_shape) {
+  return FusedGradClampInferShapeImpl(
+      x_shape, scale_shape, dout_shape, "fused_swiglu_scale_clamp_grad");
 }
 
 PD_BUILD_OP(fused_swiglu_scale_clamp_bwd)
@@ -679,7 +894,7 @@ PD_BUILD_OP(fused_swiglu_scale_clamp)
     .Outputs({"Out"})
     .Attrs({"clamp_value: double"})
     .SetKernelFn(PD_KERNEL(FusedSwiGLUScaleClampForward))
-    .SetInferShapeFn(PD_INFER_SHAPE(FusedFwdInferShape))
+    .SetInferShapeFn(PD_INFER_SHAPE(FusedClampFwdInferShape))
     .SetInferDtypeFn(PD_INFER_DTYPE(FusedFwdInferDtype));
 
 PD_BUILD_GRAD_OP(fused_swiglu_scale_clamp)
@@ -687,17 +902,9 @@ PD_BUILD_GRAD_OP(fused_swiglu_scale_clamp)
     .Outputs({paddle::Grad("X"), paddle::Grad("Scale")})
     .Attrs({"clamp_value: double"})
     .SetKernelFn(PD_KERNEL(FusedSwiGLUScaleClampBackward))
-    .SetInferShapeFn(PD_INFER_SHAPE(FusedGradClampInferShape));
+    .SetInferShapeFn(PD_INFER_SHAPE(FusedScaleClampGradInferShape));
 
 // ---- Weighted backward (fused forward + backward in one launch) ----
-
-std::vector<std::vector<int64_t>> WeightedBwdInferShape(
-    std::vector<int64_t> x_shape,
-    std::vector<int64_t> probs_shape,
-    std::vector<int64_t> dout_shape) {
-  return {
-      x_shape, probs_shape, {x_shape[0], x_shape[1] / 2}};  // dx, dprobs, out
-}
 
 std::vector<paddle::DataType> WeightedBwdInferDtype(
     paddle::DataType x_dtype,
@@ -706,12 +913,13 @@ std::vector<paddle::DataType> WeightedBwdInferDtype(
   return {x_dtype, probs_dtype, x_dtype};
 }
 
-// Clamp InferShape: d_probs always [rows, 1] matching Megatron keepdim
-// semantics.
+// Clamp InferShape: d_probs is always [rows, 1] matching Megatron keepdim
+// semantics, even when the rank-1 Probs input is accepted.
 std::vector<std::vector<int64_t>> WeightedBwdClampInferShape(
     std::vector<int64_t> x_shape,
     std::vector<int64_t> probs_shape,
     std::vector<int64_t> dout_shape) {
+  CheckFusedSwiGLUXShape(x_shape, "fused_swiglu_weighted_clamp_bwd");
   return {x_shape, {x_shape[0], 1}, {x_shape[0], x_shape[1] / 2}};
 }
 

--- a/tests/single_card_tests/custom_ops/test_fuse_swiglu_scale.py
+++ b/tests/single_card_tests/custom_ops/test_fuse_swiglu_scale.py
@@ -25,13 +25,23 @@ from paddlefleet.fusions.fused_swiglu_scale import fused_swiglu_scale_forward
 
 class TestFusedSwiGLUScale(unittest.TestCase):
     def setUp(self):
-        self.dtypes = ["float32", "float16", "bfloat16"]
         if not paddle.is_compiled_with_cuda():
             self.skipTest("CUDA is not available")
 
         # Set random seed for reproducibility
         np.random.seed(42)
         paddle.seed(42)
+
+    def _load_swiglu_ops(self):
+        try:
+            import paddlefleet_ops
+        except ImportError:
+            self.skipTest("SwiGLU custom ops are not available")
+        return paddlefleet_ops
+
+    def _require_bf16(self):
+        if not core.is_bfloat16_supported(base.CUDAPlace(0)):
+            self.skipTest("bf16 not supported")
 
     def get_reference_impl(self, x, scale):
         """
@@ -147,18 +157,18 @@ class TestFusedSwiGLUScale(unittest.TestCase):
         self.run_fused_op_test(32, 64, "float32", "float32")
 
     def test_fused_swiglu_bf16(self):
-        if core.is_bfloat16_supported(base.CUDAPlace(0)):
-            self.run_fused_op_test(32, 64, "bfloat16", "bfloat16")
+        self._require_bf16()
+        self.run_fused_op_test(32, 64, "bfloat16", "bfloat16")
 
     def test_fused_swiglu_mixed_precision(self):
         # Test mixed precision: Input=BF16, Scale=FP32
-        if core.is_bfloat16_supported(base.CUDAPlace(0)):
-            self.run_fused_op_test(16, 128, "bfloat16", "float32")
+        self._require_bf16()
+        self.run_fused_op_test(16, 128, "bfloat16", "float32")
 
     def test_fused_swiglu_large_shape(self):
         # Test large shape to ensure no index overflow or memory alignment issues
-        if core.is_bfloat16_supported(base.CUDAPlace(0)):
-            self.run_fused_op_test(4, 4096, "bfloat16", "float32")
+        self._require_bf16()
+        self.run_fused_op_test(4, 4096, "bfloat16", "float32")
 
     def test_fused_swiglu_int32_overflow_numel(self):
         """Forward/backward when numel of x > 2**31.
@@ -166,8 +176,7 @@ class TestFusedSwiGLUScale(unittest.TestCase):
         Exercises the int64-offset path in VectorizedFusedSwiGLUFwd/Bwd.
         Skipped on hosts without enough free GPU memory.
         """
-        if not core.is_bfloat16_supported(base.CUDAPlace(0)):
-            self.skipTest("bf16 not supported")
+        self._require_bf16()
 
         # [rows, 2*hidden] bf16 with rows * 2 * hidden > 2**31.
         # hidden must be divisible by VEC_SIZE=8 for the bf16 kernel.
@@ -178,7 +187,7 @@ class TestFusedSwiGLUScale(unittest.TestCase):
         # x + out + d_x + d_out + scale + tmp ~ 4-5x x_bytes
         try:
             free_bytes, _ = paddle.device.cuda.mem_get_info()
-        except (AttributeError, Exception):
+        except Exception:
             try:
                 import pynvml
 
@@ -306,14 +315,8 @@ class TestFusedSwiGLUScale(unittest.TestCase):
     def test_fused_swiglu_clamp_grid_stride_loop(self):
         """Same grid-stride coverage but for the clamp + weighted bwd path
         (VectorizedFusedSwiGLUWeightedBwd kernel)."""
-        if not core.is_bfloat16_supported(base.CUDAPlace(0)):
-            self.skipTest("bf16 not supported")
-        try:
-            from paddlefleet_ops import fused_swiglu_weighted_clamp_bwd
-        except ImportError:
-            self.skipTest(
-                "fused_swiglu_weighted_clamp_bwd not in installed extension"
-            )
+        self._require_bf16()
+        ops = self._load_swiglu_ops()
 
         rows, hidden = 65536, 8
         x_np = np.random.normal(0, 1.0, (rows, 2 * hidden)).astype("float32")
@@ -325,7 +328,7 @@ class TestFusedSwiGLUScale(unittest.TestCase):
         dout = paddle.to_tensor(dout_np).astype("bfloat16")
 
         clamp_value = 7.0
-        dx, dprobs, out = fused_swiglu_weighted_clamp_bwd(
+        dx, dprobs, out = ops.fused_swiglu_weighted_clamp_bwd(
             x, probs, dout, clamp_value
         )
 
@@ -365,6 +368,299 @@ class TestFusedSwiGLUScale(unittest.TestCase):
             rtol=5e-2,
             atol=5e-2,
             err_msg="weighted-clamp grid-stride dprobs mismatch",
+        )
+
+    def test_fused_swiglu_clamp_rejects_shape_mismatch(self):
+        """Reject mismatched auxiliary shapes before launching the kernel."""
+        self._require_bf16()
+        ops = self._load_swiglu_ops()
+
+        x = paddle.zeros([2, 16], dtype="bfloat16")
+        valid_dout = paddle.zeros([2, 8], dtype="bfloat16")
+        cases = {
+            "zero prob rows": (
+                paddle.zeros([0, 1], dtype="bfloat16"),
+                valid_dout,
+                "Probs must contain exactly one value per X row",
+            ),
+            "zero prob hidden": (
+                paddle.zeros([2, 0], dtype="bfloat16"),
+                valid_dout,
+                r"Probs must have shape \[rows\] or \[rows, 1\]",
+            ),
+            "zero dout rows": (
+                paddle.ones([2, 1], dtype="bfloat16"),
+                paddle.zeros([0, 8], dtype="bfloat16"),
+                r"DOut must have shape \[X.shape\[0\], X.shape\[1\] / 2\]",
+            ),
+        }
+        for name, (probs, d_out, message) in cases.items():
+            with self.subTest(name=name):
+                with self.assertRaisesRegex(OSError, message):
+                    ops.fused_swiglu_weighted_clamp_bwd(x, probs, d_out, 7.0)
+
+    def test_fused_swiglu_handles_empty_rows_and_hidden(self):
+        """Return correctly shaped outputs for empty rows and hidden width."""
+        self._require_bf16()
+        ops = self._load_swiglu_ops()
+
+        empty_hidden_forward = ops.fused_swiglu_scale(
+            paddle.zeros([2, 0], dtype="bfloat16"),
+            paddle.ones([2, 1], dtype="bfloat16"),
+        )
+        self.assertEqual(empty_hidden_forward.shape, [2, 0])
+
+        empty_rows = ops.fused_swiglu_weighted_clamp_bwd(
+            paddle.zeros([0, 16], dtype="bfloat16"),
+            paddle.zeros([0, 1], dtype="bfloat16"),
+            paddle.zeros([0, 8], dtype="bfloat16"),
+            7.0,
+        )
+        self.assertEqual(
+            [tensor.shape for tensor in empty_rows], [[0, 16], [0, 1], [0, 8]]
+        )
+
+        empty_hidden = ops.fused_swiglu_weighted_clamp_bwd(
+            paddle.zeros([2, 0], dtype="bfloat16"),
+            paddle.ones([2, 1], dtype="bfloat16"),
+            paddle.zeros([2, 0], dtype="bfloat16"),
+            7.0,
+        )
+        self.assertEqual(
+            [tensor.shape for tensor in empty_hidden], [[2, 0], [2, 1], [2, 0]]
+        )
+        np.testing.assert_array_equal(
+            empty_hidden[1].astype("float32").numpy(), np.zeros([2, 1])
+        )
+
+    def test_fused_swiglu_ops_reject_invalid_inputs(self):
+        """All five entry points reject inputs their packed kernels cannot read."""
+        self._require_bf16()
+        ops = self._load_swiglu_ops()
+
+        x = paddle.zeros([2, 16], dtype="bfloat16")
+        scale = paddle.ones([2, 1], dtype="bfloat16")
+        dout = paddle.ones([2, 8], dtype="bfloat16")
+        cases = [
+            (
+                "forward X rank",
+                lambda: ops.fused_swiglu_scale(
+                    paddle.zeros([2, 16, 1], dtype="bfloat16"), scale
+                ),
+                r"X must have shape \[rows, 2 \* hidden_size\]",
+            ),
+            (
+                "forward X odd width",
+                lambda: ops.fused_swiglu_scale(
+                    paddle.zeros([2, 15], dtype="bfloat16"), scale
+                ),
+                "last dimension of X must be divisible by 2",
+            ),
+            (
+                "forward scale shape",
+                lambda: ops.fused_swiglu_scale(
+                    x, paddle.ones([2, 2], dtype="bfloat16")
+                ),
+                r"Scale must have shape \[rows\] or \[rows, 1\]",
+            ),
+            (
+                "backward dout dtype",
+                lambda: ops.fused_swiglu_scale_bwd(
+                    x, scale, dout.astype("float32")
+                ),
+                "DOut dtype must match X dtype",
+            ),
+            (
+                "backward dout shape",
+                lambda: ops.fused_swiglu_scale_bwd(
+                    x,
+                    scale,
+                    paddle.ones([2, 4], dtype="bfloat16"),
+                ),
+                r"DOut must have shape \[X.shape\[0\], X.shape\[1\] / 2\]",
+            ),
+            (
+                "CPU inputs",
+                lambda: ops.fused_swiglu_scale(
+                    paddle.zeros(
+                        [2, 16], dtype="bfloat16", device="cpu"
+                    ),
+                    paddle.ones(
+                        [2, 1], dtype="bfloat16", device="cpu"
+                    ),
+                ),
+                "expects GPU inputs",
+            ),
+            (
+                "forward scale dtype",
+                lambda: ops.fused_swiglu_scale(
+                    x, paddle.ones([2, 1], dtype="float16")
+                ),
+                "Scale must be bfloat16 or float32",
+            ),
+            (
+                "clamp forward value",
+                lambda: ops.fused_swiglu_scale_clamp(x, scale, 0.0),
+                "clamp_value must be finite and greater than zero",
+            ),
+            (
+                "clamp backward vector width",
+                lambda: ops.fused_swiglu_scale_clamp_bwd(
+                    paddle.zeros([2, 20], dtype="bfloat16"),
+                    scale,
+                    paddle.ones([2, 10], dtype="bfloat16"),
+                    7.0,
+                ),
+                "hidden_size must be divisible by the vector width",
+            ),
+            (
+                "weighted clamp value",
+                lambda: ops.fused_swiglu_weighted_clamp_bwd(
+                    x, scale, dout, float("inf")
+                ),
+                "clamp_value must be finite and greater than zero",
+            ),
+            (
+                "weighted fp32 with bf16 probs",
+                lambda: ops.fused_swiglu_weighted_clamp_bwd(
+                    x.astype("float32"),
+                    scale,
+                    dout.astype("float32"),
+                    7.0,
+                ),
+                "float32 X requires float32 Probs",
+            ),
+            (
+                "float16 forward",
+                lambda: ops.fused_swiglu_scale(
+                    x.astype("float16"), scale.astype("float32")
+                ),
+                "X must be bfloat16 or float32",
+            ),
+        ]
+        for name, call, message in cases:
+            with self.subTest(name=name):
+                with self.assertRaisesRegex(OSError, message):
+                    call()
+
+    def test_fused_swiglu_rejects_non_contiguous_x(self):
+        """Reject caller-owned X layouts that packed loads cannot consume."""
+        self._require_bf16()
+        ops = self._load_swiglu_ops()
+        x = paddle.randn([16, 2], dtype="float32").astype("bfloat16").transpose(
+            [1, 0]
+        )
+        if x.is_contiguous():
+            self.skipTest("transpose produced a contiguous tensor")
+        with self.assertRaisesRegex(OSError, "expects contiguous X and Probs"):
+            ops.fused_swiglu_weighted_clamp_bwd(
+                x,
+                paddle.ones([2, 1], dtype="bfloat16"),
+                paddle.ones([2, 8], dtype="bfloat16"),
+                7.0,
+            )
+
+    def test_fused_swiglu_accepts_one_dimensional_scale(self):
+        """Preserve rank-1 Scale shape on the non-clamp backward path."""
+        self._require_bf16()
+        ops = self._load_swiglu_ops()
+        x = paddle.ones([2, 16], dtype="bfloat16")
+        scale = paddle.ones([2], dtype="bfloat16")
+        dout = paddle.ones([2, 8], dtype="bfloat16")
+        out = ops.fused_swiglu_scale(x, scale)
+        d_x, d_scale = ops.fused_swiglu_scale_bwd(x, scale, dout)
+        self.assertEqual(out.shape, [2, 8])
+        self.assertEqual(d_x.shape, [2, 16])
+        self.assertEqual(d_scale.shape, [2])
+
+    def test_fused_swiglu_static_shape_inference(self):
+        """Register forward, backward, clamp, and automatic-grad shapes."""
+        ops = self._load_swiglu_ops()
+        paddle.enable_static()
+        try:
+            main = paddle.static.Program()
+            with paddle.static.program_guard(main):
+                x = paddle.static.data("x", [-1, 16], dtype="bfloat16")
+                scale = paddle.static.data(
+                    "scale", [-1, 1], dtype="bfloat16"
+                )
+                dout = paddle.static.data(
+                    "dout", [-1, 8], dtype="bfloat16"
+                )
+                x.stop_gradient = False
+                scale.stop_gradient = False
+
+                out = ops.fused_swiglu_scale(x, scale)
+                backward = ops.fused_swiglu_scale_bwd(x, scale, dout)
+                clamp_out = ops.fused_swiglu_scale_clamp(x, scale, 7.0)
+                grad_x = paddle.static.gradients([out], [x])[0]
+                dynamic_x = paddle.static.data(
+                    "dynamic_x", [-1, -1], dtype="bfloat16"
+                )
+                dynamic_scale = paddle.static.data(
+                    "dynamic_scale", [-1, 1], dtype="bfloat16"
+                )
+                dynamic_out = ops.fused_swiglu_scale(dynamic_x, dynamic_scale)
+                dynamic_clamp_out = ops.fused_swiglu_scale_clamp(
+                    dynamic_x, dynamic_scale, 7.0
+                )
+
+                self.assertEqual(out.shape, [-1, 8])
+                self.assertEqual(
+                    [tensor.shape for tensor in backward], [[-1, 16], [-1, 1]]
+                )
+                self.assertEqual(clamp_out.shape, [-1, 8])
+                self.assertEqual(grad_x.shape, [-1, 16])
+                self.assertEqual(dynamic_out.shape[0], -1)
+                self.assertEqual(dynamic_clamp_out.shape[0], -1)
+        finally:
+            paddle.disable_static()
+
+    def test_fused_swiglu_backward_materializes_non_contiguous_dout(self):
+        """Strided framework gradients must match explicitly contiguous DOut."""
+        self._require_bf16()
+        ops = self._load_swiglu_ops()
+        x = paddle.randn([2, 16], dtype="float32").astype("bfloat16")
+        scale = paddle.randn([2], dtype="float32").astype("bfloat16")
+        non_contiguous_dout = paddle.randn([8, 2], dtype="float32").astype(
+            "bfloat16"
+        ).transpose([1, 0])
+        if non_contiguous_dout.is_contiguous():
+            self.skipTest("transpose produced a contiguous tensor")
+        dout_ref = non_contiguous_dout.contiguous()
+
+        dx_a, ds_a = ops.fused_swiglu_scale_bwd(
+            x, scale, non_contiguous_dout
+        )
+        dx_b, ds_b = ops.fused_swiglu_scale_bwd(x, scale, dout_ref)
+        np.testing.assert_allclose(
+            dx_a.astype("float32").numpy(),
+            dx_b.astype("float32").numpy(),
+            rtol=0,
+            atol=0,
+        )
+        np.testing.assert_allclose(
+            ds_a.astype("float32").numpy(),
+            ds_b.astype("float32").numpy(),
+            rtol=0,
+            atol=0,
+        )
+
+        dx_a, ds_a = ops.fused_swiglu_scale_clamp_bwd(
+            x, scale, non_contiguous_dout, 7.0
+        )
+        dx_b, ds_b = ops.fused_swiglu_scale_clamp_bwd(x, scale, dout_ref, 7.0)
+        np.testing.assert_allclose(
+            dx_a.astype("float32").numpy(),
+            dx_b.astype("float32").numpy(),
+            rtol=0,
+            atol=0,
+        )
+        np.testing.assert_allclose(
+            ds_a.astype("float32").numpy(),
+            ds_b.astype("float32").numpy(),
+            rtol=0,
+            atol=0,
         )
 
 

--- a/tests/single_card_tests/custom_ops/test_fuse_swiglu_scale.py
+++ b/tests/single_card_tests/custom_ops/test_fuse_swiglu_scale.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import subprocess
+import sys
 import unittest
 
 import numpy as np
@@ -395,9 +397,11 @@ class TestFusedSwiGLUScale(unittest.TestCase):
             ),
         }
         for name, (probs, d_out, message) in cases.items():
-            with self.subTest(name=name):
-                with self.assertRaisesRegex(OSError, message):
-                    ops.fused_swiglu_weighted_clamp_bwd(x, probs, d_out, 7.0)
+            with (
+                self.subTest(name=name),
+                self.assertRaisesRegex(OSError, message),
+            ):
+                ops.fused_swiglu_weighted_clamp_bwd(x, probs, d_out, 7.0)
 
     def test_fused_swiglu_handles_empty_rows_and_hidden(self):
         """Return correctly shaped outputs for empty rows and hidden width."""
@@ -482,12 +486,8 @@ class TestFusedSwiGLUScale(unittest.TestCase):
             (
                 "CPU inputs",
                 lambda: ops.fused_swiglu_scale(
-                    paddle.zeros(
-                        [2, 16], dtype="bfloat16", device="cpu"
-                    ),
-                    paddle.ones(
-                        [2, 1], dtype="bfloat16", device="cpu"
-                    ),
+                    paddle.zeros([2, 16], dtype="bfloat16", device="cpu"),
+                    paddle.ones([2, 1], dtype="bfloat16", device="cpu"),
                 ),
                 "expects GPU inputs",
             ),
@@ -539,26 +539,11 @@ class TestFusedSwiGLUScale(unittest.TestCase):
             ),
         ]
         for name, call, message in cases:
-            with self.subTest(name=name):
-                with self.assertRaisesRegex(OSError, message):
-                    call()
-
-    def test_fused_swiglu_rejects_non_contiguous_x(self):
-        """Reject caller-owned X layouts that packed loads cannot consume."""
-        self._require_bf16()
-        ops = self._load_swiglu_ops()
-        x = paddle.randn([16, 2], dtype="float32").astype("bfloat16").transpose(
-            [1, 0]
-        )
-        if x.is_contiguous():
-            self.skipTest("transpose produced a contiguous tensor")
-        with self.assertRaisesRegex(OSError, "expects contiguous X and Probs"):
-            ops.fused_swiglu_weighted_clamp_bwd(
-                x,
-                paddle.ones([2, 1], dtype="bfloat16"),
-                paddle.ones([2, 8], dtype="bfloat16"),
-                7.0,
-            )
+            with (
+                self.subTest(name=name),
+                self.assertRaisesRegex(OSError, message),
+            ):
+                call()
 
     def test_fused_swiglu_accepts_one_dimensional_scale(self):
         """Preserve rank-1 Scale shape on the non-clamp backward path."""
@@ -573,55 +558,68 @@ class TestFusedSwiGLUScale(unittest.TestCase):
         self.assertEqual(d_x.shape, [2, 16])
         self.assertEqual(d_scale.shape, [2])
 
-    def test_fused_swiglu_static_shape_inference(self):
-        """Register forward, backward, clamp, and automatic-grad shapes."""
+    def test_fused_swiglu_preserves_unknown_output_dimension(self):
+        """Keep an unknown hidden dimension unknown during shape inference."""
         ops = self._load_swiglu_ops()
         paddle.enable_static()
         try:
             main = paddle.static.Program()
             with paddle.static.program_guard(main):
-                x = paddle.static.data("x", [-1, 16], dtype="bfloat16")
-                scale = paddle.static.data(
-                    "scale", [-1, 1], dtype="bfloat16"
-                )
-                dout = paddle.static.data(
-                    "dout", [-1, 8], dtype="bfloat16"
-                )
-                x.stop_gradient = False
-                scale.stop_gradient = False
+                x = paddle.static.data("x", [-1, -1], dtype="bfloat16")
+                scale = paddle.static.data("scale", [-1, 1], dtype="bfloat16")
+                dout = paddle.static.data("dout", [-1, -1], dtype="bfloat16")
 
-                out = ops.fused_swiglu_scale(x, scale)
-                backward = ops.fused_swiglu_scale_bwd(x, scale, dout)
-                clamp_out = ops.fused_swiglu_scale_clamp(x, scale, 7.0)
-                grad_x = paddle.static.gradients([out], [x])[0]
-                dynamic_x = paddle.static.data(
-                    "dynamic_x", [-1, -1], dtype="bfloat16"
-                )
-                dynamic_scale = paddle.static.data(
-                    "dynamic_scale", [-1, 1], dtype="bfloat16"
-                )
-                dynamic_out = ops.fused_swiglu_scale(dynamic_x, dynamic_scale)
-                dynamic_clamp_out = ops.fused_swiglu_scale_clamp(
-                    dynamic_x, dynamic_scale, 7.0
-                )
-                dynamic_dout = paddle.static.data(
-                    "dynamic_dout", [-1, -1], dtype="bfloat16"
-                )
-                dynamic_weighted = ops.fused_swiglu_weighted_clamp_bwd(
-                    dynamic_x, dynamic_scale, dynamic_dout, 7.0
+                out = ops.fused_swiglu_scale_clamp(x, scale, 7.0)
+                weighted = ops.fused_swiglu_weighted_clamp_bwd(
+                    x, scale, dout, 7.0
                 )
 
-                self.assertEqual(out.shape, [-1, 8])
-                self.assertEqual(
-                    [tensor.shape for tensor in backward], [[-1, 16], [-1, 1]]
-                )
-                self.assertEqual(clamp_out.shape, [-1, 8])
-                self.assertEqual(grad_x.shape, [-1, 16])
-                self.assertEqual(dynamic_out.shape, [-1, -1])
-                self.assertEqual(dynamic_clamp_out.shape, [-1, -1])
-                self.assertEqual(dynamic_weighted[2].shape, [-1, -1])
+                self.assertEqual(out.shape, [-1, -1])
+                self.assertEqual(weighted[2].shape, [-1, -1])
         finally:
             paddle.disable_static()
+
+    def test_fused_swiglu_rejects_invalid_static_x_shape(self):
+        """Reject invalid X rank and odd width during shape inference."""
+        self._load_swiglu_ops()
+        cases = [
+            (
+                "clamp forward rank",
+                [-1],
+                "ops.fused_swiglu_scale_clamp(x, scale, 7.0)",
+                r"X must have shape \[rows, 2 \* hidden_size\]",
+            ),
+            (
+                "weighted backward odd width",
+                [-1, 15],
+                "ops.fused_swiglu_weighted_clamp_bwd(x, scale, dout, 7.0)",
+                "last dimension of X must be divisible by 2",
+            ),
+        ]
+
+        for name, x_shape, call, message in cases:
+            with self.subTest(name=name):
+                script = f"""
+import paddle
+import paddlefleet_ops as ops
+paddle.enable_static()
+main = paddle.static.Program()
+with paddle.static.program_guard(main):
+    x = paddle.static.data("x", {x_shape!r}, dtype="bfloat16")
+    scale = paddle.static.data("scale", [-1, 1], dtype="bfloat16")
+    dout = paddle.static.data("dout", [-1, -1], dtype="bfloat16")
+    {call}
+"""
+                result = subprocess.run(
+                    [sys.executable, "-c", script],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                    timeout=120,
+                )
+                output = result.stdout + result.stderr
+                self.assertNotEqual(result.returncode, 0, output)
+                self.assertRegex(output, message)
 
     def test_fused_swiglu_backward_materializes_non_contiguous_dout(self):
         """Strided framework gradients must match explicitly contiguous DOut."""
@@ -629,16 +627,16 @@ class TestFusedSwiGLUScale(unittest.TestCase):
         ops = self._load_swiglu_ops()
         x = paddle.randn([2, 16], dtype="float32").astype("bfloat16")
         scale = paddle.randn([2], dtype="float32").astype("bfloat16")
-        non_contiguous_dout = paddle.randn([8, 2], dtype="float32").astype(
-            "bfloat16"
-        ).transpose([1, 0])
+        non_contiguous_dout = (
+            paddle.randn([8, 2], dtype="float32")
+            .astype("bfloat16")
+            .transpose([1, 0])
+        )
         if non_contiguous_dout.is_contiguous():
             self.skipTest("transpose produced a contiguous tensor")
         dout_ref = non_contiguous_dout.contiguous()
 
-        dx_a, ds_a = ops.fused_swiglu_scale_bwd(
-            x, scale, non_contiguous_dout
-        )
+        dx_a, ds_a = ops.fused_swiglu_scale_bwd(x, scale, non_contiguous_dout)
         dx_b, ds_b = ops.fused_swiglu_scale_bwd(x, scale, dout_ref)
         np.testing.assert_allclose(
             dx_a.astype("float32").numpy(),

--- a/tests/single_card_tests/custom_ops/test_fuse_swiglu_scale.py
+++ b/tests/single_card_tests/custom_ops/test_fuse_swiglu_scale.py
@@ -575,7 +575,8 @@ class TestFusedSwiGLUScale(unittest.TestCase):
         out = ops.fused_swiglu_scale(x, scale)
         expected = ops.fused_swiglu_scale(x, scale.contiguous())
         np.testing.assert_array_equal(
-            out.astype("float32").numpy(), expected.astype("float32").numpy()
+            out.astype("float32").numpy(),
+            expected.astype("float32").numpy(),
         )
 
     def test_fused_swiglu_accepts_non_contiguous_probs(self):

--- a/tests/single_card_tests/custom_ops/test_fuse_swiglu_scale.py
+++ b/tests/single_card_tests/custom_ops/test_fuse_swiglu_scale.py
@@ -604,6 +604,12 @@ class TestFusedSwiGLUScale(unittest.TestCase):
                 dynamic_clamp_out = ops.fused_swiglu_scale_clamp(
                     dynamic_x, dynamic_scale, 7.0
                 )
+                dynamic_dout = paddle.static.data(
+                    "dynamic_dout", [-1, -1], dtype="bfloat16"
+                )
+                dynamic_weighted = ops.fused_swiglu_weighted_clamp_bwd(
+                    dynamic_x, dynamic_scale, dynamic_dout, 7.0
+                )
 
                 self.assertEqual(out.shape, [-1, 8])
                 self.assertEqual(
@@ -611,8 +617,9 @@ class TestFusedSwiGLUScale(unittest.TestCase):
                 )
                 self.assertEqual(clamp_out.shape, [-1, 8])
                 self.assertEqual(grad_x.shape, [-1, 16])
-                self.assertEqual(dynamic_out.shape[0], -1)
-                self.assertEqual(dynamic_clamp_out.shape[0], -1)
+                self.assertEqual(dynamic_out.shape, [-1, -1])
+                self.assertEqual(dynamic_clamp_out.shape, [-1, -1])
+                self.assertEqual(dynamic_weighted[2].shape, [-1, -1])
         finally:
             paddle.disable_static()
 

--- a/tests/single_card_tests/custom_ops/test_fuse_swiglu_scale.py
+++ b/tests/single_card_tests/custom_ops/test_fuse_swiglu_scale.py
@@ -545,6 +545,48 @@ class TestFusedSwiGLUScale(unittest.TestCase):
             ):
                 call()
 
+    def test_fused_swiglu_rejects_non_contiguous_x(self):
+        """Reject caller-owned X layouts that packed loads cannot consume."""
+        self._require_bf16()
+        ops = self._load_swiglu_ops()
+        x = (
+            paddle.randn([16, 2], dtype="float32")
+            .astype("bfloat16")
+            .transpose([1, 0])
+        )
+        if x.is_contiguous():
+            self.skipTest("transpose produced a contiguous tensor")
+        with self.assertRaisesRegex(OSError, "expects contiguous X and Probs"):
+            ops.fused_swiglu_weighted_clamp_bwd(
+                x,
+                paddle.ones([2, 1], dtype="bfloat16"),
+                paddle.ones([2, 8], dtype="bfloat16"),
+                7.0,
+            )
+
+    def test_fused_swiglu_rejects_non_contiguous_scale(self):
+        """Reject non-contiguous Scale layouts used by packed kernels."""
+        self._require_bf16()
+        ops = self._load_swiglu_ops()
+        x = paddle.ones([2, 16], dtype="bfloat16")
+        scale = paddle.ones([2, 2], dtype="bfloat16")[:, :1]
+        if scale.is_contiguous():
+            self.skipTest("column slice produced a contiguous Scale")
+        with self.assertRaisesRegex(OSError, "expects contiguous X and Scale"):
+            ops.fused_swiglu_scale(x, scale)
+
+    def test_fused_swiglu_rejects_non_contiguous_probs(self):
+        """Reject non-contiguous Probs layouts used by packed kernels."""
+        self._require_bf16()
+        ops = self._load_swiglu_ops()
+        x = paddle.ones([2, 16], dtype="bfloat16")
+        dout = paddle.ones([2, 8], dtype="bfloat16")
+        probs = paddle.ones([2, 2], dtype="bfloat16")[:, :1]
+        if probs.is_contiguous():
+            self.skipTest("column slice produced a contiguous Probs")
+        with self.assertRaisesRegex(OSError, "expects contiguous X and Probs"):
+            ops.fused_swiglu_weighted_clamp_bwd(x, probs, dout, 7.0)
+
     def test_fused_swiglu_accepts_one_dimensional_scale(self):
         """Preserve rank-1 Scale shape on the non-clamp backward path."""
         self._require_bf16()
@@ -650,6 +692,21 @@ with paddle.static.program_guard(main):
             rtol=0,
             atol=0,
         )
+
+        probs = paddle.randn([2, 1], dtype="float32").astype("bfloat16")
+        weighted_a = ops.fused_swiglu_weighted_clamp_bwd(
+            x, probs, non_contiguous_dout, 7.0
+        )
+        weighted_b = ops.fused_swiglu_weighted_clamp_bwd(
+            x, probs, dout_ref, 7.0
+        )
+        for result_a, result_b in zip(weighted_a, weighted_b):
+            np.testing.assert_allclose(
+                result_a.astype("float32").numpy(),
+                result_b.astype("float32").numpy(),
+                rtol=0,
+                atol=0,
+            )
 
         dx_a, ds_a = ops.fused_swiglu_scale_clamp_bwd(
             x, scale, non_contiguous_dout, 7.0

--- a/tests/single_card_tests/custom_ops/test_fuse_swiglu_scale.py
+++ b/tests/single_card_tests/custom_ops/test_fuse_swiglu_scale.py
@@ -545,47 +545,66 @@ class TestFusedSwiGLUScale(unittest.TestCase):
             ):
                 call()
 
-    def test_fused_swiglu_rejects_non_contiguous_x(self):
-        """Reject caller-owned X layouts that packed loads cannot consume."""
+    def test_fused_swiglu_accepts_non_contiguous_x(self):
+        """Materialize non-contiguous X before packed kernel execution."""
         self._require_bf16()
         ops = self._load_swiglu_ops()
-        x = (
-            paddle.randn([16, 2], dtype="float32")
-            .astype("bfloat16")
-            .transpose([1, 0])
+        x = paddle.randn([2, 32], dtype="float32").astype("bfloat16")[:, ::2]
+        self.assertFalse(x.is_contiguous())
+        probs = paddle.ones([2, 1], dtype="bfloat16")
+        dout = paddle.ones([2, 8], dtype="bfloat16")
+
+        result = ops.fused_swiglu_weighted_clamp_bwd(x, probs, dout, 7.0)
+        expected = ops.fused_swiglu_weighted_clamp_bwd(
+            x.contiguous(), probs, dout, 7.0
         )
-        if x.is_contiguous():
-            self.skipTest("transpose produced a contiguous tensor")
-        with self.assertRaisesRegex(OSError, "expects contiguous X and Probs"):
-            ops.fused_swiglu_weighted_clamp_bwd(
-                x,
-                paddle.ones([2, 1], dtype="bfloat16"),
-                paddle.ones([2, 8], dtype="bfloat16"),
-                7.0,
+        for actual, reference in zip(result, expected):
+            np.testing.assert_array_equal(
+                actual.astype("float32").numpy(),
+                reference.astype("float32").numpy(),
             )
 
-    def test_fused_swiglu_rejects_non_contiguous_scale(self):
-        """Reject non-contiguous Scale layouts used by packed kernels."""
+    def test_fused_swiglu_accepts_non_contiguous_scale(self):
+        """Materialize non-contiguous Scale before packed kernel execution."""
         self._require_bf16()
         ops = self._load_swiglu_ops()
         x = paddle.ones([2, 16], dtype="bfloat16")
         scale = paddle.ones([2, 2], dtype="bfloat16")[:, :1]
-        if scale.is_contiguous():
-            self.skipTest("column slice produced a contiguous Scale")
-        with self.assertRaisesRegex(OSError, "expects contiguous X and Scale"):
-            ops.fused_swiglu_scale(x, scale)
+        self.assertFalse(scale.is_contiguous())
 
-    def test_fused_swiglu_rejects_non_contiguous_probs(self):
-        """Reject non-contiguous Probs layouts used by packed kernels."""
+        out = ops.fused_swiglu_scale(x, scale)
+        expected = ops.fused_swiglu_scale(x, scale.contiguous())
+        np.testing.assert_array_equal(
+            out.astype("float32").numpy(), expected.astype("float32").numpy()
+        )
+
+    def test_fused_swiglu_accepts_non_contiguous_probs(self):
+        """Materialize non-contiguous Probs before packed kernel execution."""
         self._require_bf16()
         ops = self._load_swiglu_ops()
         x = paddle.ones([2, 16], dtype="bfloat16")
         dout = paddle.ones([2, 8], dtype="bfloat16")
         probs = paddle.ones([2, 2], dtype="bfloat16")[:, :1]
-        if probs.is_contiguous():
-            self.skipTest("column slice produced a contiguous Probs")
-        with self.assertRaisesRegex(OSError, "expects contiguous X and Probs"):
-            ops.fused_swiglu_weighted_clamp_bwd(x, probs, dout, 7.0)
+        self.assertFalse(probs.is_contiguous())
+
+        result = ops.fused_swiglu_weighted_clamp_bwd(x, probs, dout, 7.0)
+        expected = ops.fused_swiglu_weighted_clamp_bwd(
+            x, probs.contiguous(), dout, 7.0
+        )
+        for actual, reference in zip(result, expected):
+            np.testing.assert_array_equal(
+                actual.astype("float32").numpy(),
+                reference.astype("float32").numpy(),
+            )
+
+    def test_fused_swiglu_accepts_empty_rows_with_unaligned_hidden(self):
+        """Skip packed vector-width checks when no rows reach the kernel."""
+        ops = self._load_swiglu_ops()
+        out = ops.fused_swiglu_scale(
+            paddle.zeros([0, 4], dtype="float32"),
+            paddle.zeros([0], dtype="float32"),
+        )
+        self.assertEqual(out.shape, [0, 2])
 
     def test_fused_swiglu_accepts_one_dimensional_scale(self):
         """Preserve rank-1 Scale shape on the non-clamp backward path."""


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
#### 背景

`fused_swiglu_scale` 及其 backward、clamp、weighted backward 路径此前缺少统一的运行时输入校验。非法的 shape、dtype 或非对齐布局可能导致 BF16 CUDA 非对齐访问，FP16 输入静默返回未初始化结果，或者在 0-size Tensor 上触发 CUDA 错误。

#### 改动

- 抽取共享输入校验逻辑，覆盖 5 个 SwiGLU custom op 入口。
- 增加 GPU、设备一致性、连续性、X shape、Scale/Probs shape、DOut shape 和 dtype 校验。
- 增加 hidden size 与 kernel vector width 的整除校验，避免 packed 访问越界或非对齐访问。
- 为不支持的 dtype 增加显式 `PD_THROW`，避免 dtype dispatch 静默返回未初始化输出。
- 校验 clamp value 必须为有限正数。
- 在 rows 或 hidden size 为 0 时提前返回，并为 backward 的 scale/probs 梯度返回正确形状的零张量，避免访问 0-byte Tensor。
- 对框架生成的非连续 DOut 自动执行 `contiguous()`，保证 backward kernel 按连续布局读取。
- 保持非 clamp backward 的梯度形状与输入 Scale/Probs 一致，clamp 路径继续使用 `[rows, 1]` 的 keepdim 语义。
- 补充非法 shape、非法 dtype、非法 clamp value、empty Tensor、非连续输入以及非连续 DOut 数值一致性测试。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否