### PR TITLE
[Test] Assert the required members of PipelineParallelMicroStepLocations instead of its exact count

### DIFF
--- a/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_pipeline_parallel_2.py
+++ b/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_pipeline_parallel_2.py
@@ -89,8 +89,18 @@ class TestPipelineParallelMicroStepLocations(unittest.TestCase):
             PipelineParallelMicroStepLocations,
         )
 
-        members = list(PipelineParallelMicroStepLocations)
-        self.assertEqual(len(members), 4)
+        # The enum is an extension point: schedules may raise hooks at new
+        # locations, so pin the members that must exist instead of the total
+        # count, which breaks on every legitimate addition.
+        values = {m.value for m in PipelineParallelMicroStepLocations}
+        self.assertTrue(
+            {
+                "forward_begin",
+                "forward_end",
+                "backward_begin",
+                "backward_end",
+            }.issubset(values)
+        )
 
 
 class TestPipelineParallelMicroStepCallback(unittest.TestCase):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->

Distributed Strategy

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes 

### Description
<!-- Describe what you've done -->

#### 问题

`tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_pipeline_parallel_2.py::TestPipelineParallelMicroStepLocations::test_enum_members` 报错：

```
AssertionError: 5 != 4
```

该用例把 `PipelineParallelMicroStepLocations` 的**成员总数**写死为 4：

```python
members = list(PipelineParallelMicroStepLocations)
self.assertEqual(len(members), 4)
```

#### 原因

`PipelineParallelMicroStepLocations` 是一个**扩展点**——流水并行的 schedule 会在新的时机抛出 hook，枚举成员只增不减。PaddlePaddle/Paddle#79690 新增了 `P2P_ISSUED`（在一个 micro-step 的前向 P2P 已下发、wait handle 尚未消费的窗口内触发，使 hook 中的计算能与 NCCL send/recv overlap），成员数从 4 变成 5，这条断言必然失败。

所以失败来自**断言本身过于脆弱，而不是功能回归**：同文件其余 10 个用例全部通过，且这条断言在枚举每一次合法扩展时都会挂，属于误报门禁。

#### 改法

把「个数必须等于 4」改为「这 4 个成员必须存在」：

```python
values = {m.value for m in PipelineParallelMicroStepLocations}
self.assertTrue(
    {"forward_begin", "forward_end", "backward_begin", "backward_end"}.issubset(values)
)
```

这样保留了真正需要守住的契约（原有四个位置不可删除、不可改名），同时不再阻塞合法新增。同文件的 `test_enum_values` 已经逐个校验了这四个成员的字符串取值，因此去掉「总数」一条不会降低覆盖强度。

#### 影响

- 仅修改该单测的一条断言，不涉及任何框架代码。
- 本地使用含 `P2P_ISSUED`（5 个成员）的 Paddle 运行该文件全部用例：`11 passed`。
- 本 PR 合入 `develop` 后，Paddle#79690 的 `Fleet Unit test (single card)` 才会转绿——Paddle 的 `.github/workflows/H-Coverage.yml` 中 `fleet_branch` 固定为 `develop`，修复只能落在本仓库。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->

否
