### PR TITLE
[MTP] Remove the mtp_num_layers alias, keep num_nextn_predict_layers only

### DIFF
--- a/src/paddlefleet/config_adapter/core.py
+++ b/src/paddlefleet/config_adapter/core.py
@@ -185,8 +185,8 @@ class ConfigAdapter:
 
         self._apply_auto_overrides(config, model_config, log)
 
-        # TransformerConfig rejects the removed `mtp_num_layers` key outright,
-        # so a config that still carries it cannot start training. Check *after*
+        # TransformerConfig rejects a non-zero `mtp_num_layers` outright, so a
+        # config that still carries one cannot start training. Check *after*
         # every override has been applied: `--set json:mtp_num_layers=2` (and the
         # prefix-less form routed by `_apply_auto_overrides`) would otherwise
         # re-insert the key past an earlier check, and the raise that

--- a/src/paddlefleet/config_adapter/core.py
+++ b/src/paddlefleet/config_adapter/core.py
@@ -172,13 +172,6 @@ class ConfigAdapter:
         model_config, model_dir, json_path, json_error = self._load_json(
             config, input_path
         )
-        # TransformerConfig rejects the removed `mtp_num_layers` key outright,
-        # so a JSON that still sets it cannot start training. Refuse to rewrite
-        # it rather than emitting an adapted config the framework will reject.
-        try:
-            reject_stale_mtp_key(model_config)
-        except StaleMtpKeyError as exc:
-            return False, f"{input_path.name}: {exc}"
         if self.json_overrides:
             if model_config is None:
                 return False, f"--set json: 无法应用：{json_error}"
@@ -191,6 +184,18 @@ class ConfigAdapter:
             )
 
         self._apply_auto_overrides(config, model_config, log)
+
+        # TransformerConfig rejects the removed `mtp_num_layers` key outright,
+        # so a config that still carries it cannot start training. Check *after*
+        # every override has been applied: `--set json:mtp_num_layers=2` (and the
+        # prefix-less form routed by `_apply_auto_overrides`) would otherwise
+        # re-insert the key past an earlier check, and the raise that
+        # `effective_mtp_layers` performs during PP planning escapes as a
+        # traceback rather than a clean `(False, message)`.
+        try:
+            reject_stale_mtp_key(model_config)
+        except StaleMtpKeyError as exc:
+            return False, f"{input_path.name}: {exc}"
 
         plan, err = plan_parallelism(
             config,

--- a/src/paddlefleet/config_adapter/core.py
+++ b/src/paddlefleet/config_adapter/core.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from .io_writers import JsonWriter, YamlWriter
+from .layer_fields import StaleMtpKeyError, reject_stale_mtp_key
 from .model_config_resolver import (
     ModelConfigResolveError,
     build_adapted_dir,
@@ -171,6 +172,13 @@ class ConfigAdapter:
         model_config, model_dir, json_path, json_error = self._load_json(
             config, input_path
         )
+        # TransformerConfig rejects the removed `mtp_num_layers` key outright,
+        # so a JSON that still sets it cannot start training. Refuse to rewrite
+        # it rather than emitting an adapted config the framework will reject.
+        try:
+            reject_stale_mtp_key(model_config)
+        except StaleMtpKeyError as exc:
+            return False, f"{input_path.name}: {exc}"
         if self.json_overrides:
             if model_config is None:
                 return False, f"--set json: 无法应用：{json_error}"

--- a/src/paddlefleet/config_adapter/field_spec.py
+++ b/src/paddlefleet/config_adapter/field_spec.py
@@ -21,7 +21,7 @@ The same structural quantity is spelled differently per model family::
                      num_experts (Qwen), moe_num_experts (ERNIE4.5)
     top-k          : num_experts_per_tok (most), moe_k (ERNIE4.5)
     dense prefix   : first_k_dense_replace, moe_layer_start_index
-    MTP layers     : num_nextn_predict_layers, mtp_num_layers
+    MTP layers     : num_nextn_predict_layers
 
 Centralising the aliases means supporting a new family is a one-line edit to
 :data:`FIELD_SPECS`.  The resolver also remembers which physical key matched,
@@ -65,7 +65,7 @@ FIELD_SPECS = {
         needed_by="PP",
     ),
     "num_nextn_predict_layers": FieldSpec(
-        aliases=("num_nextn_predict_layers", "mtp_num_layers"),
+        aliases=("num_nextn_predict_layers",),
         default=0,
         needed_by="PP",
     ),

--- a/src/paddlefleet/config_adapter/layer_fields.py
+++ b/src/paddlefleet/config_adapter/layer_fields.py
@@ -56,6 +56,32 @@ LAYER_FIELDS = (
 )
 
 
+class StaleMtpKeyError(ValueError):
+    """A ``model_config.json`` still carries the removed ``mtp_num_layers``."""
+
+
+def reject_stale_mtp_key(model_config):
+    """Fail loudly when the removed ``mtp_num_layers`` key is still present.
+
+    ``TransformerConfig`` rejects the key via ``renamed_config_keys``, so a JSON
+    that still sets it cannot start training. The adapter reads the same JSON and
+    would otherwise happily rewrite it while silently treating K as 0 -- handing
+    back a config the framework then refuses. Surface it here instead.
+    """
+    if model_config is None:
+        return
+    if "mtp_num_layers" not in model_config:
+        return
+    raise StaleMtpKeyError(
+        "model_config.json still sets the removed `mtp_num_layers` "
+        f"(={model_config.get('mtp_num_layers')!r}). Use "
+        "`num_nextn_predict_layers` instead: it is the only field the MTP "
+        "consumers read. TransformerConfig rejects `mtp_num_layers` outright, "
+        "so this config cannot start training until the key is removed -- "
+        "including `mtp_num_layers: 0`, which is now a no-op key."
+    )
+
+
 def effective_mtp_layers(model_config):
     """MTP layer count the framework actually uses.
 
@@ -64,6 +90,7 @@ def effective_mtp_layers(model_config):
     """
     if model_config is None:
         return 0
+    reject_stale_mtp_key(model_config)
     return int(model_config.get("num_nextn_predict_layers") or 0)
 
 

--- a/src/paddlefleet/config_adapter/layer_fields.py
+++ b/src/paddlefleet/config_adapter/layer_fields.py
@@ -59,17 +59,12 @@ LAYER_FIELDS = (
 def effective_mtp_layers(model_config):
     """MTP layer count the framework actually uses.
 
-    ``TransformerConfig`` resolves it as ``mtp_num_layers or
-    num_nextn_predict_layers``, i.e. ``mtp_num_layers`` wins whenever it is
-    non-zero.  A plain "first alias that is not None" lookup would read
-    ``num_nextn_predict_layers: 0`` and miss a valid ``mtp_num_layers: 2``,
-    which then makes every per-layer list look inconsistent.
+    ``num_nextn_predict_layers`` is the single source of truth; the historical
+    ``mtp_num_layers`` alias has been removed from ``TransformerConfig``.
     """
     if model_config is None:
         return 0
-    primary = int(model_config.get("mtp_num_layers") or 0)
-    fallback = int(model_config.get("num_nextn_predict_layers") or 0)
-    return primary or fallback
+    return int(model_config.get("num_nextn_predict_layers") or 0)
 
 
 def _csa_family(ratio):

--- a/src/paddlefleet/config_adapter/layer_fields.py
+++ b/src/paddlefleet/config_adapter/layer_fields.py
@@ -61,24 +61,29 @@ class StaleMtpKeyError(ValueError):
 
 
 def reject_stale_mtp_key(model_config):
-    """Fail loudly when the removed ``mtp_num_layers`` key is still present.
+    """Fail loudly when a *meaningful* ``mtp_num_layers`` is still present.
 
-    ``TransformerConfig`` rejects the key via ``renamed_config_keys``, so a JSON
-    that still sets it cannot start training. The adapter reads the same JSON and
-    would otherwise happily rewrite it while silently treating K as 0 -- handing
-    back a config the framework then refuses. Surface it here instead.
+    ``TransformerConfig`` rejects the key via ``renamed_config_keys_when_set``
+    whenever it is non-zero, so a JSON that still carries a real value cannot
+    start training. The adapter reads the same JSON and would otherwise happily
+    rewrite it while silently treating K as 0 -- handing back a config the
+    framework then refuses. Surface it here instead.
+
+    ``mtp_num_layers: 0`` is tolerated for the same reason the framework
+    tolerates it: it means "MTP off", which is exactly what the key's absence
+    means, and PaddleFormers stamps that default onto every config it produces.
     """
     if model_config is None:
         return
-    if "mtp_num_layers" not in model_config:
+    if not model_config.get("mtp_num_layers"):
         return
     raise StaleMtpKeyError(
         "model_config.json still sets the removed `mtp_num_layers` "
         f"(={model_config.get('mtp_num_layers')!r}). Use "
         "`num_nextn_predict_layers` instead: it is the only field the MTP "
-        "consumers read. TransformerConfig rejects `mtp_num_layers` outright, "
-        "so this config cannot start training until the key is removed -- "
-        "including `mtp_num_layers: 0`, which is now a no-op key."
+        "consumers read. TransformerConfig rejects a non-zero "
+        "`mtp_num_layers` outright, so this config cannot start training "
+        "until the key is migrated."
     )
 
 

--- a/src/paddlefleet/config_adapter/planner.py
+++ b/src/paddlefleet/config_adapter/planner.py
@@ -304,8 +304,6 @@ class ShrinkPlanner:
             field = resolved.get(name)
             return field.value if field is not None else None
 
-        # Follow the framework's effective-MTP rule rather than a single
-        # alias: mtp_num_layers wins when non-zero.
         mtp = effective_mtp_layers(model_config)
 
         # What the framework actually segments (gpt_builders.build_gpt_model

--- a/src/paddlefleet/models/gpt/gpt_layer_specs.py
+++ b/src/paddlefleet/models/gpt/gpt_layer_specs.py
@@ -119,24 +119,12 @@ LNImpl = WrappedPaddleNorm
 
 
 def _get_effective_mtp_layers(config: TransformerConfig) -> int:
-    mtp_num_layers = getattr(config, "mtp_num_layers", 0) or 0
     nextn_num_layers = getattr(config, "num_nextn_predict_layers", 0) or 0
-    if not isinstance(mtp_num_layers, int) or isinstance(mtp_num_layers, bool):
-        mtp_num_layers = 0
     if not isinstance(nextn_num_layers, int) or isinstance(
         nextn_num_layers, bool
     ):
         nextn_num_layers = 0
-    if (
-        mtp_num_layers > 0
-        and nextn_num_layers > 0
-        and mtp_num_layers != nextn_num_layers
-    ):
-        raise ValueError(
-            "mtp_num_layers and num_nextn_predict_layers must be equal when "
-            f"both are positive, got {mtp_num_layers} and {nextn_num_layers}"
-        )
-    return mtp_num_layers if mtp_num_layers > 0 else nextn_num_layers
+    return nextn_num_layers
 
 
 def _get_dsv4_hybrid_attention_layer_type(
@@ -147,10 +135,10 @@ def _get_dsv4_hybrid_attention_layer_type(
     int, Literal["multi_latent_attention", "dsv4_hybrid_attention"], int
 ]:
     if is_mtp_layer:
-        mtp_num_layers = _get_effective_mtp_layers(config)
-        if not 0 <= layer_number < mtp_num_layers:
+        mtp_layers = _get_effective_mtp_layers(config)
+        if not 0 <= layer_number < mtp_layers:
             raise IndexError(
-                f"MTP layer_number {layer_number} is outside [0, {mtp_num_layers})"
+                f"MTP layer_number {layer_number} is outside [0, {mtp_layers})"
             )
         logical_index = config.num_hidden_layers + layer_number
     else:
@@ -873,10 +861,10 @@ def get_gpt_mtp_layers_spec_for_backend(
 ) -> list[LayerSpec]:
     assert isinstance(spec, list) and isinstance(spec[-1], LayerSpec)
 
-    mtp_num_layers = _get_effective_mtp_layers(config)
+    mtp_layers = _get_effective_mtp_layers(config)
 
     mtp_layer_specs = []
-    for i in range(mtp_num_layers):
+    for i in range(mtp_layers):
         if config.use_dense_mtp and config.n_routed_experts is not None:
             num_experts = None
             moe_expert_fusion = False

--- a/src/paddlefleet/transformer/dsa_attention.py
+++ b/src/paddlefleet/transformer/dsa_attention.py
@@ -1212,9 +1212,8 @@ class DSAIndexerLossLoggingHelper:
 
     @staticmethod
     def get_total_num_layers(config):
-        mtp_num_layers = getattr(config, "mtp_num_layers", 0) or 0
         nextn_num_layers = getattr(config, "num_nextn_predict_layers", 0) or 0
-        return config.num_hidden_layers + (mtp_num_layers or nextn_num_layers)
+        return config.num_hidden_layers + nextn_num_layers
 
     @staticmethod
     def register_total_num_layers(config):

--- a/src/paddlefleet/transformer/hyper_connection.py
+++ b/src/paddlefleet/transformer/hyper_connection.py
@@ -962,9 +962,8 @@ class HyperConnectionContractLayer(FleetLayer):
         super().__init__(config)
         self.n = config.num_residual_streams
         self.mtp_enabled = (
-            getattr(config, "num_nextn_predict_layers", 0) > 0
-            or getattr(config, "mtp_num_layers", 0) > 0
-        )
+            getattr(config, "num_nextn_predict_layers", 0) or 0
+        ) > 0
 
         self.num_mtp = getattr(config, "num_nextn_predict_layers", 0) or 0
         self.magic_send = getattr(config, "enable_mtp_magic_send", False)

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -1617,6 +1617,14 @@ class TransformerConfig(ModelParallelConfig):
         ),
         "csa_train_indexer_only": "Use train_indexer_only instead.",
         "csa_indexer_init_from_scratch": "Use indexer_init_from_scratch instead.",
+        "mtp_num_layers": (
+            "Use num_nextn_predict_layers instead: it is the only field every "
+            "MTP consumer reads (GPTEmbedding's K+1 embedding chunks, the MTP "
+            "forward's hidden_states split, LanguageLoss's per-depth labels). "
+            "Set num_nextn_predict_layers to the value mtp_num_layers used to "
+            "carry, and drop mtp_num_layers -- including mtp_num_layers=0, "
+            "which is now a no-op key."
+        ),
     }
 
     @classmethod

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -63,9 +63,6 @@ class TransformerConfig(ModelParallelConfig):
     mtp_distillation_loss: bool = False
     """Whether to use distillation MTP loss."""
 
-    mtp_num_layers: int = 0
-    """MTP Layer number."""
-
     mtp_loss_scaling_factor: float = 0.1
     """Weighting factor of Multi-Token Prediction (MTP) loss."""
 
@@ -1338,7 +1335,7 @@ class TransformerConfig(ModelParallelConfig):
 
     csa_compress_ratios: list | None = None
     """Per-layer attention-kind assignment for the DSv4 hybrid attention stack.
-    Length must equal num_hidden_layers (+ mtp_num_layers if present).
+    Length must equal num_hidden_layers (+ num_nextn_predict_layers if present).
     Each entry encodes the layer kind via its integer ratio value:
       - -2: MLA layer — multi-head latent attention. How it actually runs is
         chosen by ``hybrid_mla_attention`` (``"mha"`` / ``"mqa_dsa"`` /
@@ -1771,23 +1768,8 @@ class TransformerConfig(ModelParallelConfig):
                     "enable_mtp_magic_send with vpp requires variable_seq_lengths=True"
                 )
 
-        if self.use_erndata and (
-            self.num_nextn_predict_layers > 0 or self.mtp_num_layers > 0
-        ):
+        if self.use_erndata and self.num_nextn_predict_layers > 0:
             # erndata + MTP selects the packed-doc (MCore 8c4df6b07) contract.
-            # K is read from `num_nextn_predict_layers` by every runtime
-            # consumer of that path (GPTEmbedding builds the K+1 embedding
-            # chunks from it, `_forward_megatron_style` splits hidden_states
-            # into K+1 chunks with it). The `mtp_num_layers` alias is only
-            # honored by MTP *layer construction* (`_get_effective_mtp_layers`),
-            # so configuring K through the alias alone would build MTP layers
-            # that the data path never feeds.
-            if self.num_nextn_predict_layers <= 0:
-                raise ValueError(
-                    "use_erndata=True with MTP requires "
-                    "num_nextn_predict_layers > 0; the `mtp_num_layers` alias "
-                    "is not honored by the erndata MTP data path."
-                )
             if self.enable_mtp_magic_send:
                 raise ValueError(
                     "use_erndata=True with MTP is incompatible with "
@@ -2189,26 +2171,14 @@ class TransformerConfig(ModelParallelConfig):
                     "experimental_attention_variant='dsv4_hybrid' requires "
                     "csa_compress_ratios to be set."
                 )
-            mtp_num_layers = (
-                self.mtp_num_layers or self.num_nextn_predict_layers
-            )
-            if (
-                self.mtp_num_layers > 0
-                and self.num_nextn_predict_layers > 0
-                and self.mtp_num_layers != self.num_nextn_predict_layers
-            ):
-                raise ValueError(
-                    "mtp_num_layers and num_nextn_predict_layers must be equal when "
-                    f"both are positive, got {self.mtp_num_layers} and "
-                    f"{self.num_nextn_predict_layers}"
-                )
             if (
                 len(self.csa_compress_ratios)
-                != self.num_hidden_layers + mtp_num_layers
+                != self.num_hidden_layers + self.num_nextn_predict_layers
             ):
                 raise ValueError(
                     f"csa_compress_ratios length ({len(self.csa_compress_ratios)}) "
-                    f"must equal num_hidden_layers ({self.num_hidden_layers + mtp_num_layers})."
+                    f"must equal num_hidden_layers "
+                    f"({self.num_hidden_layers + self.num_nextn_predict_layers})."
                 )
             for i, r in enumerate(self.csa_compress_ratios):
                 # Accept python int and numpy integer scalars (a ratios list
@@ -2785,10 +2755,8 @@ class TransformerConfig(ModelParallelConfig):
         if self.separate_mtp_headloss:
             import warnings as _warnings
 
-            # Resolve the effective number of MTP layers, following the same
-            # logic used elsewhere in __post_init__ (see the csa branch above).
-            mtp_num_layers = self.num_nextn_predict_layers
-            mtp_enabled = mtp_num_layers > 0
+            mtp_layers = self.num_nextn_predict_layers
+            mtp_enabled = mtp_layers > 0
             pp_enabled = self.pipeline_model_parallel_size > 1
 
             # 1. separate_mtp_headloss is only meaningful when both MTP and PP
@@ -2797,7 +2765,7 @@ class TransformerConfig(ModelParallelConfig):
                 _warnings.warn(
                     "separate_mtp_headloss=True requires both MTP and pipeline "
                     "parallel to be enabled "
-                    f"(mtp_num_layers={mtp_num_layers}, "
+                    f"(num_nextn_predict_layers={mtp_layers}, "
                     f"pipeline_model_parallel_size={self.pipeline_model_parallel_size}). "
                     "Forcing separate_mtp_headloss=False."
                 )
@@ -2837,14 +2805,14 @@ class TransformerConfig(ModelParallelConfig):
                     0, self.num_empty_layers_add_in_tail - 1
                 )
                 total_layers = (
-                    self.num_hidden_layers + mtp_num_layers + num_empty_layers
+                    self.num_hidden_layers + mtp_layers + num_empty_layers
                 )
                 denom = pp_degree * vpp_degree
                 if total_layers % denom != 0 or total_layers // denom != 1:
                     _warnings.warn(
                         "separate_mtp_headloss=True requires "
                         "(num_hidden_layers + num_mtp_layers + num_empty_layers) "
-                        f"({self.num_hidden_layers} + {mtp_num_layers} + "
+                        f"({self.num_hidden_layers} + {mtp_layers} + "
                         f"{num_empty_layers} = {total_layers}) to be divisible "
                         f"by pp_degree*vpp_degree ({pp_degree}*{vpp_degree} = "
                         f"{denom}) and the quotient to equal 1 (exactly one "

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -1617,13 +1617,28 @@ class TransformerConfig(ModelParallelConfig):
         ),
         "csa_train_indexer_only": "Use train_indexer_only instead.",
         "csa_indexer_init_from_scratch": "Use indexer_init_from_scratch instead.",
+    }
+
+    # Same intent as ``renamed_config_keys``, but only rejected when the stale
+    # key carries a value that would change behaviour. A falsy value means the
+    # feature is off in both spellings, so nothing is lost by absorbing it.
+    #
+    # ``mtp_num_layers`` needs this weaker form because PaddleFormers still owns
+    # a field of that name: ``LlmMetaConfig.mtp_attributes`` and
+    # ``TrainingArguments`` both declare it (default 0), so *every* PaddleFormers
+    # config hands it to ``register_attributes`` whether or not MTP is used.
+    # Rejecting it outright would make every Fleet-provider model in that repo
+    # fail to build. Its ">1 means autoregressive MTP" semantics there also mean
+    # ``sft/workflow.py`` swaps the value into ``num_nextn_predict_layers``
+    # before the provider is constructed, so a legitimate MTP run arrives here
+    # with ``mtp_num_layers == 0`` already.
+    renamed_config_keys_when_set = {
         "mtp_num_layers": (
             "Use num_nextn_predict_layers instead: it is the only field every "
             "MTP consumer reads (GPTEmbedding's K+1 embedding chunks, the MTP "
             "forward's hidden_states split, LanguageLoss's per-depth labels). "
             "Set num_nextn_predict_layers to the value mtp_num_layers used to "
-            "carry, and drop mtp_num_layers -- including mtp_num_layers=0, "
-            "which is now a no-op key."
+            "carry, and drop mtp_num_layers."
         ),
     }
 
@@ -1677,6 +1692,13 @@ class TransformerConfig(ModelParallelConfig):
                 f"{key} was renamed and is no longer supported. "
                 f"{self.renamed_config_keys[key]} Update the config that still "
                 f"sets {key}; it would otherwise be silently ignored."
+            )
+        elif key in self.renamed_config_keys_when_set and value:
+            raise ValueError(
+                f"{key} was renamed and is no longer supported. "
+                f"{self.renamed_config_keys_when_set[key]} Update the config "
+                f"that still sets {key}={value!r}; it would otherwise be "
+                f"silently ignored."
             )
         else:
             setattr(self, key, value)

--- a/src/paddlefleet/transformer/transformer_layer.py
+++ b/src/paddlefleet/transformer/transformer_layer.py
@@ -88,12 +88,7 @@ def is_mtp_shared_last_layer(config, layer_number, is_mtp_layer):
     if not getattr(config, "stage1_overlap", False):
         return False
     # Only re-color when MTP is actually present in the model.
-    mtp_num_layers = (
-        config.mtp_num_layers
-        if getattr(config, "mtp_num_layers", 0)
-        else (getattr(config, "num_nextn_predict_layers", 0) or 0)
-    )
-    if mtp_num_layers <= 0:
+    if (getattr(config, "num_nextn_predict_layers", 0) or 0) <= 0:
         return False
     if is_mtp_layer:
         return False

--- a/tests/multi_card_tests/transformer/test_mla_cp_contiguous_allgather.py
+++ b/tests/multi_card_tests/transformer/test_mla_cp_contiguous_allgather.py
@@ -216,7 +216,6 @@ def build_cfg(cp_size, sink=False, attn_mode="mha"):
     c.rotary_percent = 1.0
     c.apply_rope_fusion = False
     c.num_nextn_predict_layers = 0
-    c.mtp_num_layers = 0
     c.init_method = init_method_normal(0.02)
     c.output_layer_init_method = scaled_init_method_normal(0.02, 1, 1)
     c.rms_norm_eps = 1e-5

--- a/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_separate_mtp_headloss.py
+++ b/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_separate_mtp_headloss.py
@@ -28,7 +28,6 @@ class TestSeparateMtpHeadlossValidation(unittest.TestCase):
             "intermediate_size": 256,
             "num_hidden_layers": 1,
             "separate_mtp_headloss": True,
-            # MTP enabled via num_nextn_predict_layers (mtp_num_layers stays 0).
             "num_nextn_predict_layers": 1,
             "pipeline_model_parallel_size": 4,
             "num_empty_layers_add_in_head": 0,
@@ -66,7 +65,7 @@ class TestSeparateMtpHeadlossValidation(unittest.TestCase):
         """Line 1507: MTP not enabled (no mtp / nextn layers) -> force-disable."""
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
-            config = self._build(num_nextn_predict_layers=0, mtp_num_layers=0)
+            config = self._build(num_nextn_predict_layers=0)
         self.assertFalse(config.separate_mtp_headloss)
         self.assertTrue(
             any("both MTP and pipeline" in str(w.message) for w in caught)

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_layer_shared_no_hook.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_layer_shared_no_hook.py
@@ -45,7 +45,6 @@ def _make_config(**overrides):
     cfg = {
         "mtp_shared_last_layer": True,
         "stage1_overlap": True,
-        "mtp_num_layers": 0,
         "num_nextn_predict_layers": 1,
         "num_hidden_layers": 2,
         "num_empty_layers_add_in_head": 0,
@@ -78,8 +77,8 @@ class TestIsMtpSharedLastLayer(unittest.TestCase):
         self.assertFalse(is_mtp_shared_last_layer(cfg, 1, False))
 
     def test_no_mtp_layers(self):
-        """mtp_num_layers 与 num_nextn_predict_layers 均为 0 -> False"""
-        cfg = _make_config(mtp_num_layers=0, num_nextn_predict_layers=0)
+        """num_nextn_predict_layers 为 0 -> False"""
+        cfg = _make_config(num_nextn_predict_layers=0)
         self.assertFalse(is_mtp_shared_last_layer(cfg, 1, False))
 
     def test_is_mtp_layer(self):
@@ -92,13 +91,13 @@ class TestIsMtpSharedLastLayer(unittest.TestCase):
 
     def test_last_layer_via_num_nextn(self):
         """通过 num_nextn_predict_layers 判定 MTP 存在 -> True"""
-        cfg = _make_config(mtp_num_layers=0, num_nextn_predict_layers=1)
+        cfg = _make_config(num_nextn_predict_layers=1)
         self.assertTrue(is_mtp_shared_last_layer(cfg, 1, False))
 
-    def test_last_layer_via_mtp_num_layers(self):
-        """通过 mtp_num_layers 判定 MTP 存在 -> True"""
+    def test_removed_alias_does_not_enable_mtp(self):
+        """已移除的 mtp_num_layers 别名不再被识别 -> False"""
         cfg = _make_config(mtp_num_layers=2, num_nextn_predict_layers=0)
-        self.assertTrue(is_mtp_shared_last_layer(cfg, 1, False))
+        self.assertFalse(is_mtp_shared_last_layer(cfg, 1, False))
 
     def test_empty_layers_offset(self):
         """num_empty_layers_add_in_head 影响最后一层编号

--- a/tests/single_card_tests/config_adapter/test_config_adapter.py
+++ b/tests/single_card_tests/config_adapter/test_config_adapter.py
@@ -925,21 +925,25 @@ class TestLayerFieldPlanning(unittest.TestCase):
         self.assertEqual(effective_mtp_layers(None), 0)
 
     def test_effective_mtp_rejects_the_stale_key(self):
-        # TransformerConfig refuses the removed key, so a JSON that still sets
-        # it cannot start training. Fail here rather than silently reading K=0
-        # and handing back a config the framework will reject. Both a non-zero
-        # and a zero value must be refused -- `mtp_num_layers: 0` is now a
-        # no-op key that has to be deleted.
-        for stale_value in (2, 0):
-            with self.subTest(mtp_num_layers=stale_value):
-                with self.assertRaises(StaleMtpKeyError) as ctx:
-                    effective_mtp_layers(
-                        {
-                            "num_nextn_predict_layers": 0,
-                            "mtp_num_layers": stale_value,
-                        }
-                    )
-                self.assertIn("num_nextn_predict_layers", str(ctx.exception))
+        # TransformerConfig refuses a non-zero `mtp_num_layers`, so a JSON that
+        # still sets one cannot start training. Fail here rather than silently
+        # reading K=0 and handing back a config the framework will reject.
+        with self.assertRaises(StaleMtpKeyError) as ctx:
+            effective_mtp_layers(
+                {"num_nextn_predict_layers": 0, "mtp_num_layers": 2}
+            )
+        self.assertIn("num_nextn_predict_layers", str(ctx.exception))
+
+    def test_effective_mtp_tolerates_a_zero_stale_key(self):
+        # `mtp_num_layers: 0` means "MTP off", exactly what the key's absence
+        # means, and PaddleFormers stamps that default onto every config it
+        # produces. The framework accepts it, so the adapter must too.
+        self.assertEqual(
+            effective_mtp_layers(
+                {"num_nextn_predict_layers": 3, "mtp_num_layers": 0}
+            ),
+            3,
+        )
 
     def test_truncates_layer_part_and_keeps_the_mtp_tail(self):
         changes, err = plan_layer_field_shrink(self._config(), 64, 16, 1)
@@ -1670,23 +1674,36 @@ class TestLayerFields(ConfigAdapterTestBase):
         self.assertEqual(len(model_config["layer_types"]), 32)
 
     def test_stale_mtp_key_aborts_the_whole_adaptation(self):
-        # End-to-end: a JSON that still carries the removed key must make
-        # `adapt` fail with a migration hint instead of rewriting the config.
-        # TransformerConfig would refuse such a JSON anyway, so producing an
-        # adapted copy of it is worse than useless.
-        for stale_value in (2, 0):
-            with self.subTest(mtp_num_layers=stale_value):
-                self.write_json(
-                    {
-                        **MODEL_CONFIG,
-                        "num_nextn_predict_layers": 0,
-                        "mtp_num_layers": stale_value,
-                    }
-                )
-                ok, message = self.adapt(target_nodes=1)
-                self.assertFalse(ok)
-                self.assertIn("mtp_num_layers", message)
-                self.assertIn("num_nextn_predict_layers", message)
+        # End-to-end: a JSON that still carries a non-zero `mtp_num_layers` must
+        # make `adapt` fail with a migration hint instead of rewriting the
+        # config. TransformerConfig would refuse such a JSON anyway, so producing
+        # an adapted copy of it is worse than useless.
+        self.write_json(
+            {**MODEL_CONFIG, "num_nextn_predict_layers": 0, "mtp_num_layers": 2}
+        )
+        ok, message = self.adapt(target_nodes=1)
+        self.assertFalse(ok)
+        self.assertIn("mtp_num_layers", message)
+        self.assertIn("num_nextn_predict_layers", message)
+
+    def test_zero_stale_mtp_key_is_adapted_normally(self):
+        # `mtp_num_layers: 0` is what PaddleFormers stamps onto every config it
+        # produces and what the framework accepts, so it must not abort the
+        # adaptation.
+        self.write_json(
+            {
+                **MODEL_CONFIG,
+                "num_nextn_predict_layers": 2,
+                "mtp_num_layers": 0,
+                "csa_compress_ratios": [128, 128, 128, -2] * 16 + [-2, -2],
+                "layer_types": ["full_attention"] * 64,
+            }
+        )
+        ok, message = self.adapt(target_nodes=1)
+        self.assertTrue(ok, message)
+        model_config = self.load_output_json(8)
+        self.assertEqual(model_config["num_hidden_layers"], 32)
+        self.assertEqual(len(model_config["csa_compress_ratios"]), 34)
 
     def test_stale_mtp_key_via_json_override_is_refused(self):
         # `--set json:mtp_num_layers=...` re-inserts the key into an otherwise
@@ -1694,27 +1711,24 @@ class TestLayerFields(ConfigAdapterTestBase):
         # Otherwise the adapted config would carry a key TransformerConfig
         # rejects, and the raise inside effective_mtp_layers would surface as a
         # traceback during PP planning rather than a clean (False, message).
-        for stale_value in (2, 0):
-            with self.subTest(mtp_num_layers=stale_value):
-                self.write_json(dict(MODEL_CONFIG))
-                ok, message = self.adapt(
-                    target_nodes=1,
-                    json_overrides={"mtp_num_layers": stale_value},
-                )
-                self.assertFalse(ok)
-                self.assertIn("mtp_num_layers", message)
-                self.assertIn("num_nextn_predict_layers", message)
-                # Nothing may be emitted: the source JSON is clean, so a
-                # rewritten copy would be the only place the key could appear.
-                self.assertFalse(
-                    (
-                        self.output_dir
-                        / "model_config_separated"
-                        / "model_dir_adapted_8cards"
-                        / "model_config.json"
-                    ).exists(),
-                    "no adapted model_config.json may be written",
-                )
+        self.write_json(dict(MODEL_CONFIG))
+        ok, message = self.adapt(
+            target_nodes=1, json_overrides={"mtp_num_layers": 2}
+        )
+        self.assertFalse(ok)
+        self.assertIn("mtp_num_layers", message)
+        self.assertIn("num_nextn_predict_layers", message)
+        # Nothing may be emitted: the source JSON is clean, so a
+        # rewritten copy would be the only place the key could appear.
+        self.assertFalse(
+            (
+                self.output_dir
+                / "model_config_separated"
+                / "model_dir_adapted_8cards"
+                / "model_config.json"
+            ).exists(),
+            "no adapted model_config.json may be written",
+        )
 
     def test_stale_mtp_key_via_auto_override_is_refused(self):
         # The prefix-less `--set mtp_num_layers=...` form is routed to the JSON

--- a/tests/single_card_tests/config_adapter/test_config_adapter.py
+++ b/tests/single_card_tests/config_adapter/test_config_adapter.py
@@ -60,6 +60,7 @@ from paddlefleet.config_adapter.layer_fields import (
     StaleMtpKeyError,
     effective_mtp_layers,
     plan_layer_field_shrink,
+    reject_stale_mtp_key,
 )
 from paddlefleet.config_adapter.model_config_resolver import (
     ModelConfigResolveError,
@@ -923,6 +924,9 @@ class TestLayerFieldPlanning(unittest.TestCase):
         )
         self.assertEqual(effective_mtp_layers({}), 0)
         self.assertEqual(effective_mtp_layers(None), 0)
+
+    def test_reject_stale_mtp_key_accepts_missing_config(self):
+        reject_stale_mtp_key(None)
 
     def test_effective_mtp_rejects_the_stale_key(self):
         # TransformerConfig refuses a non-zero `mtp_num_layers`, so a JSON that

--- a/tests/single_card_tests/config_adapter/test_config_adapter.py
+++ b/tests/single_card_tests/config_adapter/test_config_adapter.py
@@ -57,6 +57,7 @@ from paddlefleet.config_adapter.io_writers import (
     detect_map_indent,
 )
 from paddlefleet.config_adapter.layer_fields import (
+    StaleMtpKeyError,
     effective_mtp_layers,
     plan_layer_field_shrink,
 )
@@ -920,14 +921,25 @@ class TestLayerFieldPlanning(unittest.TestCase):
         self.assertEqual(
             effective_mtp_layers({"num_nextn_predict_layers": 3}), 3
         )
-        self.assertEqual(
-            effective_mtp_layers(
-                {"mtp_num_layers": 2, "num_nextn_predict_layers": 0}
-            ),
-            0,
-        )
         self.assertEqual(effective_mtp_layers({}), 0)
         self.assertEqual(effective_mtp_layers(None), 0)
+
+    def test_effective_mtp_rejects_the_stale_key(self):
+        # TransformerConfig refuses the removed key, so a JSON that still sets
+        # it cannot start training. Fail here rather than silently reading K=0
+        # and handing back a config the framework will reject. Both a non-zero
+        # and a zero value must be refused -- `mtp_num_layers: 0` is now a
+        # no-op key that has to be deleted.
+        for stale_value in (2, 0):
+            with self.subTest(mtp_num_layers=stale_value):
+                with self.assertRaises(StaleMtpKeyError) as ctx:
+                    effective_mtp_layers(
+                        {
+                            "num_nextn_predict_layers": 0,
+                            "mtp_num_layers": stale_value,
+                        }
+                    )
+                self.assertIn("num_nextn_predict_layers", str(ctx.exception))
 
     def test_truncates_layer_part_and_keeps_the_mtp_tail(self):
         changes, err = plan_layer_field_shrink(self._config(), 64, 16, 1)
@@ -1656,6 +1668,25 @@ class TestLayerFields(ConfigAdapterTestBase):
         # 32 layers + the 2 MTP entries.
         self.assertEqual(len(model_config["csa_compress_ratios"]), 34)
         self.assertEqual(len(model_config["layer_types"]), 32)
+
+    def test_stale_mtp_key_aborts_the_whole_adaptation(self):
+        # End-to-end: a JSON that still carries the removed key must make
+        # `adapt` fail with a migration hint instead of rewriting the config.
+        # TransformerConfig would refuse such a JSON anyway, so producing an
+        # adapted copy of it is worse than useless.
+        for stale_value in (2, 0):
+            with self.subTest(mtp_num_layers=stale_value):
+                self.write_json(
+                    {
+                        **MODEL_CONFIG,
+                        "num_nextn_predict_layers": 0,
+                        "mtp_num_layers": stale_value,
+                    }
+                )
+                ok, message = self.adapt(target_nodes=1)
+                self.assertFalse(ok)
+                self.assertIn("mtp_num_layers", message)
+                self.assertIn("num_nextn_predict_layers", message)
 
 
 class TestFailureLeavesSourcesUntouched(ConfigAdapterTestBase):

--- a/tests/single_card_tests/config_adapter/test_config_adapter.py
+++ b/tests/single_card_tests/config_adapter/test_config_adapter.py
@@ -1688,6 +1688,47 @@ class TestLayerFields(ConfigAdapterTestBase):
                 self.assertIn("mtp_num_layers", message)
                 self.assertIn("num_nextn_predict_layers", message)
 
+    def test_stale_mtp_key_via_json_override_is_refused(self):
+        # `--set json:mtp_num_layers=...` re-inserts the key into an otherwise
+        # clean JSON, so the check has to run *after* the overrides are applied.
+        # Otherwise the adapted config would carry a key TransformerConfig
+        # rejects, and the raise inside effective_mtp_layers would surface as a
+        # traceback during PP planning rather than a clean (False, message).
+        for stale_value in (2, 0):
+            with self.subTest(mtp_num_layers=stale_value):
+                self.write_json(dict(MODEL_CONFIG))
+                ok, message = self.adapt(
+                    target_nodes=1,
+                    json_overrides={"mtp_num_layers": stale_value},
+                )
+                self.assertFalse(ok)
+                self.assertIn("mtp_num_layers", message)
+                self.assertIn("num_nextn_predict_layers", message)
+                # Nothing may be emitted: the source JSON is clean, so a
+                # rewritten copy would be the only place the key could appear.
+                self.assertFalse(
+                    (
+                        self.output_dir
+                        / "model_config_separated"
+                        / "model_dir_adapted_8cards"
+                        / "model_config.json"
+                    ).exists(),
+                    "no adapted model_config.json may be written",
+                )
+
+    def test_stale_mtp_key_via_auto_override_is_refused(self):
+        # The prefix-less `--set mtp_num_layers=...` form is routed to the JSON
+        # by _apply_auto_overrides when the key is present there, which is a
+        # second way past a check placed before the overrides.
+        self.write_json(
+            {**MODEL_CONFIG, "num_nextn_predict_layers": 0, "mtp_num_layers": 0}
+        )
+        ok, message = self.adapt(
+            target_nodes=1, auto_overrides={"mtp_num_layers": 2}
+        )
+        self.assertFalse(ok)
+        self.assertIn("mtp_num_layers", message)
+
 
 class TestFailureLeavesSourcesUntouched(ConfigAdapterTestBase):
     """Nothing is written until every check has passed."""

--- a/tests/single_card_tests/config_adapter/test_config_adapter.py
+++ b/tests/single_card_tests/config_adapter/test_config_adapter.py
@@ -914,16 +914,17 @@ class TestLayerFieldPlanning(unittest.TestCase):
             **overrides,
         }
 
-    def test_effective_mtp_follows_the_framework_rule(self):
-        # mtp_num_layers wins whenever it is non-zero.
+    def test_effective_mtp_reads_num_nextn_predict_layers(self):
+        # num_nextn_predict_layers is the only key; the historical
+        # mtp_num_layers alias was removed from TransformerConfig.
+        self.assertEqual(
+            effective_mtp_layers({"num_nextn_predict_layers": 3}), 3
+        )
         self.assertEqual(
             effective_mtp_layers(
                 {"mtp_num_layers": 2, "num_nextn_predict_layers": 0}
             ),
-            2,
-        )
-        self.assertEqual(
-            effective_mtp_layers({"num_nextn_predict_layers": 3}), 3
+            0,
         )
         self.assertEqual(effective_mtp_layers({}), 0)
         self.assertEqual(effective_mtp_layers(None), 0)
@@ -1637,15 +1638,13 @@ class TestLayerFields(ConfigAdapterTestBase):
         self.assertTrue(ok, message)
         self.assertEqual(self.load_output_json(8)["window_attn_skip_freq"], 4)
 
-    def test_mtp_num_layers_alias_wins_over_a_zero(self):
-        # The framework resolves the MTP count as
-        # `mtp_num_layers or num_nextn_predict_layers`, so a zero in the
-        # second key must not hide a valid value in the first.
+    def test_mtp_count_comes_from_num_nextn_predict_layers(self):
+        # The removed mtp_num_layers alias must not contribute to the layer
+        # count: only num_nextn_predict_layers does.
         self.write_json(
             {
                 **MODEL_CONFIG,
-                "num_nextn_predict_layers": 0,
-                "mtp_num_layers": 2,
+                "num_nextn_predict_layers": 2,
                 "csa_compress_ratios": [128, 128, 128, -2] * 16 + [-2, -2],
                 "layer_types": ["full_attention"] * 64,
             }

--- a/tests/single_card_tests/transformer/hybrid_mla_utils.py
+++ b/tests/single_card_tests/transformer/hybrid_mla_utils.py
@@ -218,7 +218,6 @@ def _create_mqa_config(mode="mqa", loss_coeff=0.0, num_hidden_layers=2):
     config.rotary_percent = 1.0
     config.apply_rope_fusion = False
     config.num_nextn_predict_layers = 0
-    config.mtp_num_layers = 0
     config.init_method = init_method_normal(0.02)
     config.output_layer_init_method = scaled_init_method_normal(0.02, 1, 2.0)
     config.rms_norm_eps = 1e-5

--- a/tests/single_card_tests/transformer/test_doc_mask_meta_cache_equivalence.py
+++ b/tests/single_card_tests/transformer/test_doc_mask_meta_cache_equivalence.py
@@ -309,7 +309,6 @@ def _make_csa_config():
     config = TransformerConfig(
         num_hidden_layers=1,
         num_nextn_predict_layers=1,
-        mtp_num_layers=1,
         hidden_size=128,
         num_attention_heads=4,
         params_dtype=paddle.bfloat16,

--- a/tests/single_card_tests/transformer/test_dsa_attention.py
+++ b/tests/single_card_tests/transformer/test_dsa_attention.py
@@ -975,7 +975,9 @@ class TestDSAIndexerLossLoggingHelperReduce(unittest.TestCase):
 
     def test_get_total_num_layers_treats_none_as_zero(self):
         """None nextn layer count should be treated as zero."""
-        config = SimpleNamespace(num_hidden_layers=4, mtp_num_layers=0)
+        config = SimpleNamespace(
+            num_hidden_layers=4, num_nextn_predict_layers=0
+        )
         config.num_nextn_predict_layers = None
         self.assertEqual(
             DSAIndexerLossLoggingHelper.get_total_num_layers(config), 4
@@ -984,7 +986,9 @@ class TestDSAIndexerLossLoggingHelperReduce(unittest.TestCase):
     def test_register_total_num_layers_clears_stale_tracker(self):
         DSAIndexerLossLoggingHelper.num_layers = 1
         DSAIndexerLossLoggingHelper.tracker["values"] = paddle.zeros([1])
-        config = SimpleNamespace(num_hidden_layers=4, mtp_num_layers=0)
+        config = SimpleNamespace(
+            num_hidden_layers=4, num_nextn_predict_layers=0
+        )
 
         DSAIndexerLossLoggingHelper.register_total_num_layers(config)
 

--- a/tests/single_card_tests/transformer/test_hybrid_mla_mtp_layer43_w6.py
+++ b/tests/single_card_tests/transformer/test_hybrid_mla_mtp_layer43_w6.py
@@ -66,7 +66,6 @@ class TestMTPLayer43Dispatch(unittest.TestCase):
             num_hidden_layers=43,
             csa_compress_ratios=_prod_csa_ratios(),
             num_nextn_predict_layers=1,
-            mtp_num_layers=0,
             num_empty_layers_add_in_head=0,
         )
         li, atype, ratio = _get_dsv4_hybrid_attention_layer_type(

--- a/tests/single_card_tests/transformer/test_use_erndata_config.py
+++ b/tests/single_card_tests/transformer/test_use_erndata_config.py
@@ -21,6 +21,7 @@ historical ernie5 L+K layout. Guards checked here:
 from __future__ import annotations
 
 import unittest
+from types import SimpleNamespace
 
 from paddlefleet.transformer.transformer_config import TransformerConfig
 
@@ -71,6 +72,30 @@ class TestUseErndataValidation(unittest.TestCase):
                     mtp_num_layers=2,
                 )
             )
+
+    def test_mtp_num_layers_is_rejected_via_from_config(self) -> None:
+        # The path a model_config.json actually takes. Without a
+        # renamed_config_keys entry _process_attribute's setattr fallback would
+        # absorb the key as a dead attribute and leave MTP silently off.
+        # Both a non-zero and a zero value must be refused: `mtp_num_layers: 0`
+        # is now a no-op key that has to be deleted, not tolerated.
+        for stale_value in (2, 0):
+            with self.subTest(mtp_num_layers=stale_value):
+                cfg_in = SimpleNamespace(
+                    num_hidden_layers=2,
+                    hidden_size=64,
+                    num_attention_heads=4,
+                    num_nextn_predict_layers=0,
+                    mtp_num_layers=stale_value,
+                )
+                with self.assertRaisesRegex(
+                    ValueError, r"num_nextn_predict_layers"
+                ) as ctx:
+                    TransformerConfig.from_config(cfg_in)
+                self.assertIn("mtp_num_layers", str(ctx.exception))
+
+    def test_mtp_num_layers_registered_as_renamed(self) -> None:
+        self.assertIn("mtp_num_layers", TransformerConfig.renamed_config_keys)
 
     def test_erndata_incompat_with_magic_send(self) -> None:
         # enable_mtp_magic_send also requires PP>1 (checked earlier in

--- a/tests/single_card_tests/transformer/test_use_erndata_config.py
+++ b/tests/single_card_tests/transformer/test_use_erndata_config.py
@@ -9,7 +9,8 @@
 (Energon) pipeline emits length-L tensors + cu_seqlens_q, False means the
 historical ernie5 L+K layout. Guards checked here:
   1. Default is False.
-  2. The removed `mtp_num_layers` alias is rejected outright (TypeError).
+  2. The removed `mtp_num_layers` alias is rejected as a constructor kwarg
+     (TypeError) and, via ``from_config``, whenever it is non-zero.
   3. use_erndata + MTP is incompatible with enable_mtp_magic_send.
   4. use_erndata + MTP is incompatible with experimental_dataflow.
   5. use_erndata without MTP (K == 0) trips none of the guards — the packed-doc
@@ -75,27 +76,45 @@ class TestUseErndataValidation(unittest.TestCase):
 
     def test_mtp_num_layers_is_rejected_via_from_config(self) -> None:
         # The path a model_config.json actually takes. Without a
-        # renamed_config_keys entry _process_attribute's setattr fallback would
-        # absorb the key as a dead attribute and leave MTP silently off.
-        # Both a non-zero and a zero value must be refused: `mtp_num_layers: 0`
-        # is now a no-op key that has to be deleted, not tolerated.
-        for stale_value in (2, 0):
-            with self.subTest(mtp_num_layers=stale_value):
-                cfg_in = SimpleNamespace(
-                    num_hidden_layers=2,
-                    hidden_size=64,
-                    num_attention_heads=4,
-                    num_nextn_predict_layers=0,
-                    mtp_num_layers=stale_value,
-                )
-                with self.assertRaisesRegex(
-                    ValueError, r"num_nextn_predict_layers"
-                ) as ctx:
-                    TransformerConfig.from_config(cfg_in)
-                self.assertIn("mtp_num_layers", str(ctx.exception))
+        # renamed_config_keys_when_set entry _process_attribute's setattr
+        # fallback would absorb the key as a dead attribute and leave MTP
+        # silently off.
+        cfg_in = SimpleNamespace(
+            num_hidden_layers=2,
+            hidden_size=64,
+            num_attention_heads=4,
+            num_nextn_predict_layers=0,
+            mtp_num_layers=2,
+        )
+        with self.assertRaisesRegex(
+            ValueError, r"num_nextn_predict_layers"
+        ) as ctx:
+            TransformerConfig.from_config(cfg_in)
+        self.assertIn("mtp_num_layers", str(ctx.exception))
 
-    def test_mtp_num_layers_registered_as_renamed(self) -> None:
-        self.assertIn("mtp_num_layers", TransformerConfig.renamed_config_keys)
+    def test_zero_mtp_num_layers_is_tolerated_via_from_config(self) -> None:
+        # PaddleFormers declares `mtp_num_layers` itself (LlmMetaConfig /
+        # TrainingArguments, default 0), so every config it produces hands the
+        # key over even when MTP is off. Rejecting a zero would break every
+        # Fleet-provider model in that repo, and it carries no information the
+        # key's absence does not.
+        cfg_in = SimpleNamespace(
+            num_hidden_layers=2,
+            hidden_size=64,
+            num_attention_heads=4,
+            num_nextn_predict_layers=1,
+            mtp_num_layers=0,
+        )
+        cfg = TransformerConfig.from_config(cfg_in)
+        self.assertEqual(cfg.num_nextn_predict_layers, 1)
+
+    def test_mtp_num_layers_registered_as_renamed_when_set(self) -> None:
+        self.assertIn(
+            "mtp_num_layers", TransformerConfig.renamed_config_keys_when_set
+        )
+        self.assertNotIn(
+            "mtp_num_layers", TransformerConfig.renamed_config_keys
+        )
 
     def test_erndata_incompat_with_magic_send(self) -> None:
         # enable_mtp_magic_send also requires PP>1 (checked earlier in

--- a/tests/single_card_tests/transformer/test_use_erndata_config.py
+++ b/tests/single_card_tests/transformer/test_use_erndata_config.py
@@ -9,8 +9,7 @@
 (Energon) pipeline emits length-L tensors + cu_seqlens_q, False means the
 historical ernie5 L+K layout. Guards checked here:
   1. Default is False.
-  2. use_erndata + MTP requires num_nextn_predict_layers > 0 (the
-     `mtp_num_layers` alias is deliberately NOT accepted).
+  2. The removed `mtp_num_layers` alias is rejected outright (TypeError).
   3. use_erndata + MTP is incompatible with enable_mtp_magic_send.
   4. use_erndata + MTP is incompatible with experimental_dataflow.
   5. use_erndata without MTP (K == 0) trips none of the guards — the packed-doc
@@ -61,13 +60,10 @@ class TestUseErndataValidation(unittest.TestCase):
         )
         self.assertTrue(cfg.use_erndata)
 
-    def test_erndata_rejects_mtp_num_layers_alias_only(self) -> None:
-        # `mtp_num_layers` is honored by MTP layer *construction*
-        # (_get_effective_mtp_layers) but not by the erndata data path, which
-        # reads num_nextn_predict_layers everywhere. Configuring K only through
-        # the alias would build MTP layers that never receive shifted
-        # embeddings, so it must be rejected rather than silently accepted.
-        with self.assertRaisesRegex(ValueError, r"num_nextn_predict_layers"):
+    def test_mtp_num_layers_is_rejected(self) -> None:
+        # The alias has been removed from TransformerConfig entirely; passing it
+        # must fail loudly rather than silently configure nothing.
+        with self.assertRaises(TypeError):
             TransformerConfig(
                 **self._base_kwargs(
                     use_erndata=True,


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Others

### Description
Remove the `mtp_num_layers` config field. `num_nextn_predict_layers` is now the
only way to configure the MTP depth K.


### 是否引起精度变化
否。配置解析结果不变——所有既有配置都通过 `num_nextn_predict_layers` 表达 K