### PR TITLE
[Deps] Bump Paddle to `27054fb440e`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ description = "Fleet Core - Core Functional Library for Large Scale Distributed 
 requires-python = ">=3.10"
 dependencies = [
     "colorlog>=6.10.1",
-    "paddlepaddle-gpu==3.4.0.post20260820+1b89cc6828f",
+    "paddlepaddle-gpu==3.4.0.post20260825+27054fb440e",
     "ruamel.yaml>=0.17",
     "tilelang-paddle==0.1.12",
 ]


### PR DESCRIPTION
### PR Category
Environment Adaptation

### PR Types
Others

### Description
Bump the pinned CUDA 12.9 Paddle dependency to `paddlepaddle-gpu==3.4.0.post20260825+27054fb440e`.

Target Paddle commit: [`27054fb440eba8723f7a049f9c534dd0c2602814`](https://github.com/PaddlePaddle/Paddle/commit/27054fb440eba8723f7a049f9c534dd0c2602814), the live HEAD of Paddle's `release/3.4` branch at verification time.

Artifact verification uses only the cu129 nightly source: the exact CPython 3.12 Linux x86_64 [wheel](https://paddle-whl.cdn.bcebos.com/nightly/cu129/paddlepaddle-gpu/paddlepaddle_gpu-3.4.0.post20260825%2B27054fb440e-cp312-cp312-linux_x86_64.whl) appears in the index, the wheel returns HTTP 200 with `Content-Length: 3342310182`, and `Range: bytes=0-1023` returns HTTP 206 with `Content-Range: bytes 0-1023/3342310182`.

Local validation: TOML and PEP 508 parsing, `git diff --check`, exact one-file/one-line delta, and `pre-commit run --files pyproject.toml` pass.

### 是否引起精度变化
否
