### PR TITLE
Overlap the DSA indexer loss backward with the pipeline p2p send/recv

### DIFF
--- a/src/paddlefleet/cudnn_ops/indexer/csa_indexer_bwd_cudnn.py
+++ b/src/paddlefleet/cudnn_ops/indexer/csa_indexer_bwd_cudnn.py
@@ -121,6 +121,25 @@ def csa_indexer_bwd(
         loss_coeff=float(loss_coeff),
         grad_loss=grad_loss_paddle,
         block_I=int(block_I),
+        # dK is reduced with fp32 atomics whatever the buffer dtype, so the dtype
+        # only selects *how* the result lands. Left to allocate its own bf16
+        # buffer, the wrapper takes a branch ending in
+        # ``dIndexK.copy_(dIndexK_f32.astype(...))``, and Paddle's blocking
+        # ``copy_`` lowers to ``GpuMemcpySync`` on the CUDA *legacy default*
+        # stream -- a bidirectional full-device barrier, so every later kernel
+        # waits for whatever is in flight. Under
+        # ``dsa_indexer_loss_bwd_p2p_overlap`` that pushed the whole indexer
+        # projection backward out past the pipeline send/recv it was supposed to
+        # hide behind.
+        #
+        # A pre-zeroed fp32 buffer takes the wrapper's in-place path instead:
+        # same kernel, same fp32 atomicAdd, same single fp32 -> bf16 rounding,
+        # except the rounding is now the asynchronous ``grad_k.cast`` below and
+        # there is no barrier. ``zeros`` rather than ``empty`` is load-bearing --
+        # the kernel only accumulates, and on this sparse path nothing else
+        # zeroes the buffer. Same reason as the dense KL path
+        # (``dense_indexer_kl_cudnn.py``).
+        d_index_k=paddle.zeros(index_k_bf.shape, dtype=paddle.float32),
     )
 
     grad_q = out["d_index_q"]

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -1301,6 +1301,112 @@ def _compute_attn_target_on_selected_set(
 # ---------------------------------------------------------------------------
 
 
+def compute_csa_indexer_grads(
+    index_q: Tensor,
+    weights: Tensor,
+    index_k_comp: Tensor,
+    target: Tensor,
+    topk_probs: Tensor,
+    topk_indices: Tensor,
+    loss_coeff: float,
+    indexer_backend: str = "tilelang",
+    num_rows: float | None = None,
+    loss_mask: Tensor | None = None,
+) -> tuple[Tensor, Tensor, Tensor]:
+    """``(grad_index_q, grad_weights, grad_index_k)`` of the indexer KL.
+
+    The single implementation of the indexer-loss gradient, shared by
+    :class:`TileLangCSAIndexerLossAutoScaler` (the default, in-graph path) and
+    by ``indexer_loss_overlap.drain`` (the deferred path). It reads no autograd
+    state on purpose -- ``grad_output`` does not enter this gradient at all,
+    which is exactly what lets the deferred path run it during the forward.
+
+    ``num_rows`` defaults to ``target.shape[0] * target.shape[1]``, i.e. the
+    kernel's own ``1/(B*Sq)``. Passing the global valid-row count together with
+    ``loss_mask`` reproduces the masked reduction of the forward.
+    """
+    if num_rows is None:
+        num_rows = float(target.shape[0] * target.shape[1])
+
+    scale = DSAIndexerLossAutoScaler._main_loss_backward_scale
+
+    if indexer_backend == "cudnn":
+        from paddlefleet.cudnn_ops import csa_indexer_bwd
+
+        # cuDNN multiplies its internal score-grad by ``grad_loss`` in
+        # the GEMM kernel; pass the externally-set scaler as ``grad_loss``.
+        if scale is None:
+            grad_loss_arg = None
+        elif isinstance(scale, paddle.Tensor):
+            grad_loss_arg = scale
+        else:
+            grad_loss_arg = paddle.to_tensor(float(scale), dtype=paddle.float32)
+
+        # Apply loss_mask to mask out padding positions in backward
+        bwd_target = target
+        bwd_topk_probs = topk_probs
+        if loss_mask is not None:
+            lm = loss_mask.reshape(
+                [target.shape[0], target.shape[1], 1]
+            ).astype(target.dtype)
+            bwd_target = target * lm
+            bwd_topk_probs = topk_probs * lm
+
+        # cuDNN kernel internally divides by (B * S_q). When loss_mask is
+        # provided, we want 1/global_valid_count instead. Compensate by
+        # scaling loss_coeff so the kernel's internal division yields the
+        # correct normalization.
+        cudnn_loss_coeff = loss_coeff
+        if loss_mask is not None:
+            B_Sq = float(target.shape[0] * target.shape[1])
+            cudnn_loss_coeff = loss_coeff * B_Sq / max(num_rows, 1.0)
+
+        grad_q, grad_weights, grad_k = csa_indexer_bwd(
+            index_q,
+            weights,
+            index_k_comp,
+            bwd_target,
+            bwd_topk_probs,
+            topk_indices,
+            loss_coeff=cudnn_loss_coeff,
+            grad_loss=grad_loss_arg,
+        )
+    elif indexer_backend == "tilelang":
+        from paddlefleet.tilelang_ops import csa_indexer_bwd
+
+        grad_index_scores = (topk_probs - target) * (
+            loss_coeff / max(num_rows, 1.0)
+        )
+        # Apply loss_mask to zero out gradients for padding positions
+        if loss_mask is not None:
+            lm = loss_mask.reshape(
+                [grad_index_scores.shape[0], grad_index_scores.shape[1], 1]
+            ).astype(grad_index_scores.dtype)
+            grad_index_scores = grad_index_scores * lm
+        if scale is not None:
+            grad_index_scores = grad_index_scores * scale
+
+        grad_q, grad_weights, grad_k = csa_indexer_bwd(
+            index_q,
+            weights,
+            index_k_comp,
+            topk_indices,
+            grad_index_scores,
+        )
+    else:
+        raise NotImplementedError(
+            f"CSA indexer backend {indexer_backend!r} not implemented."
+        )
+
+    if grad_q.dtype != index_q.dtype:
+        grad_q = grad_q.cast(index_q.dtype)
+    if grad_weights.dtype != weights.dtype:
+        grad_weights = grad_weights.cast(weights.dtype)
+    if grad_k.dtype != index_k_comp.dtype:
+        grad_k = grad_k.cast(index_k_comp.dtype)
+    return grad_q, grad_weights, grad_k
+
+
 class TileLangCSAIndexerLossAutoScaler(paddle.autograd.PyLayer):
     """Attach TileLang CSA indexer loss gradients to the main output.
 
@@ -1357,88 +1463,18 @@ class TileLangCSAIndexerLossAutoScaler(paddle.autograd.PyLayer):
             target,
         ) = ctx.saved_tensor()
 
-        scale = DSAIndexerLossAutoScaler._main_loss_backward_scale
-
-        if ctx.indexer_backend == "cudnn":
-            from paddlefleet.cudnn_ops import csa_indexer_bwd
-
-            # cuDNN multiplies its internal score-grad by ``grad_loss`` in
-            # the GEMM kernel; pass the externally-set scaler as ``grad_loss``.
-            if scale is None:
-                grad_loss_arg = None
-            elif isinstance(scale, paddle.Tensor):
-                grad_loss_arg = scale
-            else:
-                grad_loss_arg = paddle.to_tensor(
-                    float(scale), dtype=paddle.float32
-                )
-
-            # Apply loss_mask to mask out padding positions in backward
-            bwd_target = target
-            bwd_topk_probs = topk_probs
-            if getattr(ctx, "loss_mask", None) is not None:
-                lm = ctx.loss_mask.reshape(
-                    [target.shape[0], target.shape[1], 1]
-                ).astype(target.dtype)
-                bwd_target = target * lm
-                bwd_topk_probs = topk_probs * lm
-
-            # cuDNN kernel internally divides by (B * S_q). When loss_mask is
-            # provided, we want 1/global_valid_count instead. Compensate by
-            # scaling loss_coeff so the kernel's internal division yields the
-            # correct normalization.
-            cudnn_loss_coeff = ctx.loss_coeff
-            if getattr(ctx, "loss_mask", None) is not None:
-                B_Sq = float(target.shape[0] * target.shape[1])
-                cudnn_loss_coeff = (
-                    ctx.loss_coeff
-                    * B_Sq
-                    / max(getattr(ctx, "num_rows", 1.0), 1.0)
-                )
-
-            grad_q, grad_weights, grad_k = csa_indexer_bwd(
-                index_q,
-                weights,
-                index_k_comp,
-                bwd_target,
-                bwd_topk_probs,
-                topk_indices,
-                loss_coeff=cudnn_loss_coeff,
-                grad_loss=grad_loss_arg,
-            )
-        elif ctx.indexer_backend == "tilelang":
-            from paddlefleet.tilelang_ops import csa_indexer_bwd
-
-            grad_index_scores = (topk_probs - target) * (
-                ctx.loss_coeff / max(getattr(ctx, "num_rows", 1.0), 1.0)
-            )
-            # Apply loss_mask to zero out gradients for padding positions
-            if getattr(ctx, "loss_mask", None) is not None:
-                lm = ctx.loss_mask.reshape(
-                    [grad_index_scores.shape[0], grad_index_scores.shape[1], 1]
-                ).astype(grad_index_scores.dtype)
-                grad_index_scores = grad_index_scores * lm
-            if scale is not None:
-                grad_index_scores = grad_index_scores * scale
-
-            grad_q, grad_weights, grad_k = csa_indexer_bwd(
-                index_q,
-                weights,
-                index_k_comp,
-                topk_indices,
-                grad_index_scores,
-            )
-        else:
-            raise NotImplementedError(
-                f"CSA indexer backend {ctx.indexer_backend!r} not implemented."
-            )
-
-        if grad_q.dtype != index_q.dtype:
-            grad_q = grad_q.cast(index_q.dtype)
-        if grad_weights.dtype != weights.dtype:
-            grad_weights = grad_weights.cast(weights.dtype)
-        if grad_k.dtype != index_k_comp.dtype:
-            grad_k = grad_k.cast(index_k_comp.dtype)
+        grad_q, grad_weights, grad_k = compute_csa_indexer_grads(
+            index_q,
+            weights,
+            index_k_comp,
+            target,
+            topk_probs,
+            topk_indices,
+            loss_coeff=ctx.loss_coeff,
+            indexer_backend=ctx.indexer_backend,
+            num_rows=getattr(ctx, "num_rows", None),
+            loss_mask=getattr(ctx, "loss_mask", None),
+        )
 
         grad_main = grad_output if ctx.output_needs_grad else None
         grads = (grad_main, None, grad_q, grad_weights, grad_k, None, None)

--- a/src/paddlefleet/transformer/indexer_loss_overlap.py
+++ b/src/paddlefleet/transformer/indexer_loss_overlap.py
@@ -1,0 +1,560 @@
+# Copyright (c) 2026 Baidu, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Run the DSA indexer-loss branch inside the pipeline forward send/recv.
+
+Gated by ``TransformerConfig.dsa_indexer_loss_bwd_p2p_overlap``; off by default,
+and when off nothing in this module is reached.
+
+Why the branch can move
+-----------------------
+The indexer loss is a *leaf subgraph* of the training graph:
+
+* ``MQALatentAttention._indexer_projections`` detaches ``x`` / ``qr``, so no
+  gradient reaches the backbone;
+* ``TileLangCSAIndexerLossAutoScaler`` is an identity on the layer output, so
+  the attention backward never waits on it;
+* ``csa_indexer_bwd`` never reads ``grad_output`` -- every input it needs exists
+  by the end of the layer's forward.
+
+Its only effect is a gradient on the ``DSAIndexer`` weights, so both the forward
+and the backward of the branch may run during the forward pass, at any point
+after the layer produced its inputs.
+
+Where it moves to
+-----------------
+The ``-2`` layer enqueues its inputs (:func:`enqueue`) on whichever forward pass
+belongs to the pipeline's forward phase -- the no-grad one if the layer body is
+recompute-wrapped, the only one if it is not; the choice lives in
+``MQALatentAttention._needs_indexer_loss``. :func:`drain` then computes the loss
+and the indexer gradients from Paddle's ``P2P_ISSUED`` callback, which the
+schedule raises after issuing the micro-step's ``send_forward`` /
+``send_forward_recv_forward`` and before consuming its wait handles.
+
+Why that exact point and not ``FORWARD_END``
+--------------------------------------------
+``isend`` / ``irecv`` guarantee that the tensor being sent is finished by
+recording an event on the *calculation* stream at issue time and having the
+pipeline group's NCCL stream wait on it. Anything queued before the issue is
+inside that event's reach, so draining at ``FORWARD_END`` makes the send wait for
+the branch rather than run alongside it. Raising the hook after the issue puts
+the branch's kernels behind the event record instead::
+
+    calc  [chunk fwd][meta][EventRecord ev]      [drain branch][WaitEvent comm]
+    comm                   [WaitEvent ev][SendRecv ......................]
+
+which is the "issue, compute, then wait" shape the schedule already uses for
+``WeightGradStore.pop()``.
+
+Two conditions decide whether that is real overlap:
+
+* **the p2p must not be on the compute stream.** ``overlap_p2p_comm=True``
+  forces ``use_batch_p2p_comm`` off and thereby selects ``_p2p_ops`` -- ``isend``
+  / ``irecv`` on the pipeline group's own stream -- over ``_batched_p2p_ops``,
+  which runs on the calculation stream and leaves nothing to overlap with. The
+  hook is raised either way, so only the speedup depends on this, never
+  correctness.
+* **the callback must fire on the schedule actually in use.** Only the schedules
+  taught to defer their wait raise ``P2P_ISSUED``; for any other one
+  :func:`_forward_end_hook` stays armed, so no schedule loses the loss. The latch
+  flips on the first ``P2P_ISSUED``, which costs one un-overlapped micro-step per
+  process and needs no knowledge of the schedule class. Both ways of ending up
+  without a window are reported: a Paddle whose enum lacks the location warns at
+  registration, a schedule that never raises it warns on the second fallback
+  drain (:func:`_warn_if_fallback_is_permanent`).
+
+Where the window does not exist
+-------------------------------
+In the steady 1F1B loop of ``VPPFhenBInBalancedMemory`` the last pipeline stage
+has no window: ``send_forward`` and ``recv_backward`` are both no-ops there, so a
+``-2`` layer living on it runs its branch earlier but overlaps nothing. That is a
+property of the schedule, not something this module can fix. Without pipeline
+parallelism there is no send/recv at all, which is why :func:`validate_config`
+rejects ``pipeline_model_parallel_size == 1``.
+
+Ordering guarantees
+-------------------
+The queue is drained inside the *same* micro-step that filled it, with no other
+forward in between, so it is never more than one layer deep even when a rank owns
+several ``-2`` layers -- those sit in different virtual chunks, i.e. different
+micro-steps. ``query``, the largest tensor in the branch, is therefore released
+shortly after it is produced. Nothing is carried across steps, and
+:func:`drain_all` closes the queue before the optimizer as a net for the
+non-pipeline case.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import paddle
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _PendingWork:
+    """One ``-2`` layer's forward pass, waiting for its whole loss branch.
+
+    ``owner`` is the :class:`MQALatentAttention` instance. The target definition
+    (which columns, which normalizer) and the row mask live there and must stay
+    there -- duplicating them here is how the two paths would silently drift
+    apart.
+
+    ``index_q`` / ``weights`` / ``index_k`` carry the indexer projection's
+    autograd subgraph, built by ``_indexer_projections(grad_enabled=True)``.
+    Holding a reference is what keeps that subgraph alive until :func:`drain`
+    drives it; because ``x`` / ``qr`` were detached, driving it cannot reach the
+    backbone.
+
+    ``on_done`` is set by :func:`defer_discard` when the layer's query/key came
+    out of a ``RecomputeWithoutOutput`` span whose buffers must not be freed
+    until this branch has read them. :func:`drain` calls it right after the
+    branch, i.e. still inside the same micro-step.
+    """
+
+    owner: Any
+    query: paddle.Tensor
+    kv: paddle.Tensor
+    lse_indexer: paddle.Tensor | None
+    topk_indices: paddle.Tensor
+    topk_scores: paddle.Tensor
+    index_q: paddle.Tensor
+    weights: paddle.Tensor
+    index_k: paddle.Tensor
+    input_ids: paddle.Tensor | None
+    batch: int
+    seqlen: int
+    on_done: Any = None
+
+
+_QUEUE: list[_PendingWork] = []
+_HOOKS_REGISTERED = False
+# Flips on the first ``P2P_ISSUED``. Until then ``_forward_end_hook`` keeps
+# draining, so a schedule that never raises the new location still computes the
+# loss; afterwards ``FORWARD_END`` stands down and the drain happens in the p2p
+# window instead. See the "Why that exact point" section above.
+_P2P_WINDOW_SEEN = False
+# How many times ``FORWARD_END`` has had to do the work. Only the *second* one
+# is diagnostic: see :func:`_warn_if_fallback_is_permanent`.
+_FORWARD_END_DRAINS = 0
+_FALLBACK_WARNED = False
+_STATS = {
+    "enqueued": 0,
+    "drained": 0,
+    "drained_in_hook": 0,
+    "drained_in_p2p_window": 0,
+}
+
+
+def enabled(config) -> bool:
+    """Whether the ``-2`` layers should defer their loss branch."""
+    return bool(getattr(config, "dsa_indexer_loss_bwd_p2p_overlap", False))
+
+
+def pending() -> int:
+    """Number of queued layers. Zero everywhere outside a forward pass."""
+    return len(_QUEUE)
+
+
+def stats() -> dict[str, int]:
+    """Cumulative counters, for tests and for a one-shot startup log."""
+    return dict(_STATS)
+
+
+def enqueue(work: _PendingWork) -> None:
+    _QUEUE.append(work)
+    _STATS["enqueued"] += 1
+
+
+def defer_discard(owner, span, hook_tensor) -> bool:
+    """Postpone a ``RecomputeWithoutOutput`` output discard past :func:`drain`.
+
+    With ``mla_qkv_recompute``, ``MultiLatentAttention.forward`` frees query /
+    key / value the instant ``core_attention`` returns and only restores them in
+    backward. The deferred branch reads query and kv *later in the same forward*,
+    and the ``query.detach()`` in the queue is no protection: Paddle's ``detach``
+    shares the underlying ``DenseTensor``, so clearing the original nulls the view
+    too and the branch dies on a missing holder.
+
+    The discard is therefore moved, not skipped -- skipping would leave
+    ``RecomputeWithoutOutputFunction.backward`` without the inputs/outputs that
+    only this hook registers. :func:`drain` runs it in a ``finally`` right after
+    the branch, still in the same micro-step and far ahead of any backward, so the
+    recompute saving is kept in full; the cost is that one layer's ``query``
+    survives until the drain.
+
+    Returns ``False`` when this layer has nothing pending -- the caller then
+    discards immediately, exactly as before.
+    """
+    if not _QUEUE:
+        return False
+    work = _QUEUE[-1]
+    if work.owner is not owner or work.on_done is not None:
+        return False
+    work.on_done = lambda: span.discard_output_and_register_recompute(
+        hook_tensor
+    )
+    return True
+
+
+def drain() -> int:
+    """Run every queued loss branch. Returns how many were run.
+
+    The actual work lives on the layer
+    (``MQALatentAttention._run_indexer_loss_branch``) so that the target
+    definition, the KL reduction and the constants stay in one file and cannot
+    drift from the inline path.
+
+    Failures are not swallowed: a wrong gradient here is silent, so it is better
+    to abort the run than to keep training an indexer that is no longer being
+    supervised. The ``on_done`` callback still runs on that path, because it is
+    what arms the qkv recompute hook and dropping it would replace a clear error
+    with a confusing one in backward.
+    """
+    if not _QUEUE:
+        return 0
+    ran = 0
+    while _QUEUE:
+        work = _QUEUE.pop()
+        try:
+            work.owner._run_indexer_loss_branch(work)
+        finally:
+            if work.on_done is not None:
+                work.on_done()
+                work.on_done = None
+        # Drop the references before the next item so the peak live set is one
+        # layer's inputs, not the whole queue's.
+        del work
+        ran += 1
+    _STATS["drained"] += ran
+    return ran
+
+
+def _p2p_issued_hook(**kwargs) -> None:
+    """``P2P_ISSUED`` callback. Signature is ``hook(**kwargs)``.
+
+    Kernels queued here sit *behind* the calc-stream event that gates the NCCL
+    send/recv, so they can run concurrently with it. ``output_tensor`` /
+    ``step_id`` are passed but unused -- the queue carries everything.
+
+    Firing this location disarms :func:`_forward_end_hook` for the rest of the
+    process, and the latch is set even on an empty queue: what it records is that
+    this schedule provides the window, not that this micro-step had work. Were it
+    conditional on work, a chunk with no ``-2`` layer would leave the fallback
+    armed and it would keep taking the work away from this location.
+    """
+    global _P2P_WINDOW_SEEN
+    _P2P_WINDOW_SEEN = True
+    ran = drain()
+    if ran:
+        _STATS["drained_in_hook"] += ran
+        _STATS["drained_in_p2p_window"] += ran
+
+
+def _forward_end_hook(**kwargs) -> None:
+    """``FORWARD_END`` fallback. Signature is ``hook(**kwargs)``.
+
+    Drains only while ``_P2P_WINDOW_SEEN`` is unset, i.e. exactly in these
+    situations:
+
+    * **the first micro-step of the process, always.** ``FORWARD_END`` precedes
+      the p2p issue, so it fires before the first ``P2P_ISSUED`` can flip the
+      latch. Draining here is correct but not overlapped; the cost is one
+      micro-step, once.
+    * **the Paddle in use has no ``P2P_ISSUED``**, so
+      :func:`register_pipeline_hooks` could not register the other hook at all.
+    * **the schedule in use never raises it.** Only the schedules taught to defer
+      their forward-send wait do; on any other one the location exists but stays
+      silent.
+    * **forward-only passes**, which raise ``FORWARD_END`` but not
+      ``P2P_ISSUED``. Nothing is ever queued there -- ``_needs_indexer_loss``
+      requires ``self.training`` -- so this is a no-op in practice.
+
+    The last three would lose the indexer gradient outright without this hook,
+    which is why it stays registered: draining here yields no overlap, but no
+    overlap is much cheaper than an unsupervised indexer.
+
+    Whether ``P2P_ISSUED`` will ever arrive cannot be decided in advance -- the
+    enum member existing says nothing about the schedule raising it -- so it is
+    decided by observation instead, and only the positive case is observable.
+    That asymmetry is why the safe location is armed by default and stands down
+    on evidence, rather than the other way round.
+
+    ``**kwargs`` absorbs the keywords Paddle passes (``input_tensor`` /
+    ``output_tensor`` / ``step_id``) and any it adds later.
+    """
+    global _FORWARD_END_DRAINS
+    if _P2P_WINDOW_SEEN:
+        return
+    ran = drain()
+    if not ran:
+        return
+    _STATS["drained_in_hook"] += ran
+    _FORWARD_END_DRAINS += 1
+    _warn_if_fallback_is_permanent()
+
+
+def _warn_if_fallback_is_permanent() -> None:
+    """Warn once when ``P2P_ISSUED`` is evidently never going to fire.
+
+    The first ``FORWARD_END`` drain is expected of every run, so it says nothing.
+    A *second* one does: had the location been raised at all, it would have been
+    raised within the first micro-step and the latch would have disarmed this
+    hook. So the flag is on, the loss is being computed, and none of it is
+    overlapping -- worth a warning, because that is the entire point of the flag.
+    Emitted once; per-micro-step logging would drown the training log.
+    """
+    global _FALLBACK_WARNED
+    if _FALLBACK_WARNED or _FORWARD_END_DRAINS < 2:
+        return
+    _FALLBACK_WARNED = True
+    logger.warning(
+        "indexer_loss_overlap: dsa_indexer_loss_bwd_p2p_overlap=True but this "
+        "run never reaches the P2P_ISSUED hook location, so the indexer loss "
+        "branch is draining at FORWARD_END -- before the pipeline issues its "
+        "forward send/recv, i.e. with no overlap at all. Gradients and loss are "
+        "unaffected. Either this Paddle predates the location or the pipeline "
+        "schedule in use does not raise it (only the schedules that defer their "
+        "forward-send wait do); switch schedule, upgrade Paddle, or turn the "
+        "flag off to drop the deferral machinery."
+    )
+
+
+def drain_all() -> int:
+    """Safety net: close the queue outside the callback.
+
+    Needed wherever no ``FORWARD_END`` will fire before the gradients are read:
+    ``pipeline_model_parallel_size == 1`` never enters ``_forward_step`` at all,
+    and a non-pipeline eval loop calls the layer directly. Must be called once
+    per step before the optimizer -- specifically before
+    ``hybrid_parallel_scale_param_grad``, so a deferred contribution gets the
+    same CP scaling as the inline path.
+    """
+    return drain()
+
+
+def _has_dsa_indexer(config) -> bool:
+    """Whether any layer of this model actually builds a ``DSAIndexer``.
+
+    The same predicate ``TransformerConfig.__post_init__`` uses via
+    ``has_mqa_indexer``, mirroring what ``gpt_layer_specs.py`` decides: only the
+    ``csa_compress_ratios == -2`` layers of a ``dsv4_hybrid`` model under
+    ``hybrid_mla_attention='mqa_dsa'``. The CSA indexer does not count -- its loss
+    lives in ``csa_attention.py`` and has no deferred path.
+    """
+    if getattr(config, "experimental_attention_variant", None) != "dsv4_hybrid":
+        return False
+    if getattr(config, "hybrid_mla_attention", None) != "mqa_dsa":
+        return False
+    ratios = getattr(config, "csa_compress_ratios", None) or []
+    return any(int(r) == -2 for r in ratios)
+
+
+def _recomputes_core_attn(config) -> bool:
+    """Whether ``Attention`` will wrap ``core_attention`` in its own recompute.
+
+    Mirrors the ``selective`` branch of ``attention.py``, minus the per-layer
+    ``first_n`` / ``block`` narrowing: any layer being wrapped is enough for the
+    warning, and this predicate has no layer number.  ``in`` covers both spellings
+    of ``recompute_modules`` -- the list and the ``{module: num_layers}`` dict.
+    """
+    if getattr(config, "recompute_granularity", None) != "selective":
+        return False
+    modules = getattr(config, "recompute_modules", None) or ()
+    return "core_attn" in modules
+
+
+def validate_config(config) -> None:
+    """Reject the configurations where the flag would silently do nothing.
+
+    The flag is a *scheduling* switch with one supported shape: DSA phase-3
+    layers inside a pipeline that issues its p2p asynchronously. These
+    combinations either lose the loss or are dead, so they raise:
+
+    * ``pipeline_model_parallel_size == 1`` -- no ``P2P_ISSUED`` location and no
+      micro-step callbacks, so only :func:`drain_all` would ever run the branch,
+      i.e. strictly worse than the inline path.
+    * no ``DSAIndexer`` (:func:`_has_dsa_indexer`) or
+      ``dsa_indexer_loss_coeff <= 0`` -- nothing ever enqueues, so the flag is a
+      typo or a leftover from another config.
+    * ``dsa_indexer_use_sparse_loss=False`` -- only ``_forward_sparse`` has an
+      enqueue path, so a warmup-phase run would lose its loss outright.
+
+    Recompute of the *layer body* is deliberately not checked: the enqueue
+    predicate adapts to it per layer
+    (``MQALatentAttention._needs_indexer_loss``), and a config-level gate could
+    not be right anyway, since ``recompute_method`` ``first_n`` / ``block`` leave
+    part of the layers unwrapped. Selective recompute of ``core_attn`` is the one
+    recompute shape that does cost the window, and it warns -- see below.
+
+    ``overlap_p2p_comm`` / ``batch_p2p_comm`` only warn: with the batched form the
+    send/recv runs on the calculation stream and the branch is serialised behind
+    it, which is exactly the pre-flag cost, and no number changes. Raise when the
+    config is wrong or dead, warn when only the overlap is missing.
+    """
+    if not enabled(config):
+        return
+    pp_size = getattr(config, "pipeline_model_parallel_size", 1) or 1
+    if int(pp_size) <= 1:
+        raise ValueError(
+            "dsa_indexer_loss_bwd_p2p_overlap=True requires pipeline "
+            "parallelism (pipeline_model_parallel_size > 1), got "
+            f"{pp_size}. The overlap window is the pipeline's forward "
+            "isend/irecv; without a pipeline there are no micro-step "
+            "callbacks to drain the queue and the branch would only run in "
+            "the end-of-step safety net. Turn the overlap off."
+        )
+    if not _has_dsa_indexer(config):
+        raise ValueError(
+            "dsa_indexer_loss_bwd_p2p_overlap=True but this model builds no "
+            "DSAIndexer: it needs experimental_attention_variant="
+            "'dsv4_hybrid' with hybrid_mla_attention='mqa_dsa' and at least "
+            "one csa_compress_ratios entry equal to -2, got "
+            f"experimental_attention_variant="
+            f"{getattr(config, 'experimental_attention_variant', None)!r}, "
+            f"hybrid_mla_attention="
+            f"{getattr(config, 'hybrid_mla_attention', None)!r}. Nothing "
+            "would ever be enqueued; turn the overlap off."
+        )
+    if float(getattr(config, "dsa_indexer_loss_coeff", 0.0) or 0.0) <= 0.0:
+        raise ValueError(
+            "dsa_indexer_loss_bwd_p2p_overlap=True but "
+            "dsa_indexer_loss_coeff="
+            f"{getattr(config, 'dsa_indexer_loss_coeff', 0.0)}, so no layer "
+            "computes an indexer loss at all "
+            "(MQALatentAttention._needs_indexer_loss gates on coeff > 0). "
+            "Set a positive coefficient or turn the overlap off."
+        )
+    if not getattr(config, "dsa_indexer_use_sparse_loss", False):
+        raise ValueError(
+            "dsa_indexer_loss_bwd_p2p_overlap=True is only implemented for "
+            "the sparse (phase-3) loss; set dsa_indexer_use_sparse_loss=True "
+            "or turn the overlap off."
+        )
+    if _recomputes_core_attn(config):
+        logger.warning(
+            "indexer_loss_overlap: dsa_indexer_loss_bwd_p2p_overlap=True with "
+            "recompute_granularity='selective' and 'core_attn' in "
+            "recompute_modules. That wraps the core attention itself -- the "
+            "module that owns the indexer -- in its own recompute, so the pass "
+            "that runs inside the pipeline's forward is the no-grad one of that "
+            "wrapper while the layer-level in_recompute marker stays False, and "
+            "_needs_indexer_loss therefore enqueues on the grad-enabled replay, "
+            "which happens in backward and past the p2p window. Loss and "
+            "gradient are unaffected -- a later micro-step's callback, or "
+            "drain_all() before the gradient scaling, runs the branch -- but "
+            "nothing overlaps. Drop 'core_attn' from recompute_modules to get "
+            "the speedup."
+        )
+    if not getattr(config, "overlap_p2p_comm", True) or getattr(
+        config, "batch_p2p_comm", None
+    ):
+        logger.warning(
+            "indexer_loss_overlap: dsa_indexer_loss_bwd_p2p_overlap=True but "
+            "overlap_p2p_comm=%s / batch_p2p_comm=%s selects _batched_p2p_ops, "
+            "which runs the NCCL send/recv on the calculation stream. The loss "
+            "stays correct but there is nothing for it to overlap with; set "
+            "overlap_p2p_comm=True to get the speedup.",
+            getattr(config, "overlap_p2p_comm", True),
+            getattr(config, "batch_p2p_comm", None),
+        )
+
+
+def register_pipeline_hooks(pp_model) -> bool:
+    """Attach :func:`drain` to Paddle's micro-step callbacks.
+
+    ``pp_model`` is the ``PipelineParallel`` wrapper and is only used to tell
+    pipeline from non-pipeline: the callback registry itself is a module-level
+    singleton, which is what ``register_global_pipeline_parallel_hook`` exists to
+    reach, since trainers wrap the model and cannot hold the ``PipelineParallel``
+    object.
+
+    Two locations are registered, and they are not redundant:
+
+    * ``P2P_ISSUED`` buys the overlap -- raised after the p2p is issued and before
+      the wait handles are consumed.
+    * ``FORWARD_END`` is the correctness fallback, self-disarming on the first
+      ``P2P_ISSUED``. ``_forward_step`` raises it and every schedule funnels
+      through there, and it is not gated by ``user_hooks_enabled``, so eval passes
+      and schedules with no ``P2P_ISSUED`` stay correct without depending on the
+      :func:`drain_all` net. :func:`_forward_end_hook` enumerates when it is the
+      one doing the work.
+
+    Neither is the ``PipelineHook`` family: that fires at the *top* of
+    ``_forward_step``, one micro-step after the enqueue and after the preceding
+    p2p has already been awaited, and it is suppressed on forward-only passes.
+
+    Registration is idempotent and appends, so it coexists with whatever else the
+    trainer put on the same location. A Paddle whose enum has no ``P2P_ISSUED``
+    gets ``FORWARD_END`` only -- correct, never overlapped, and warned about here
+    because the flag then buys nothing. The other way to end up with no overlap
+    (the enum member exists but the schedule never raises it) cannot be seen from
+    here; :func:`_warn_if_fallback_is_permanent` catches that one at runtime.
+
+    Returns ``False`` when there is no pipeline to hook into; the caller then
+    relies on :func:`drain_all` and gets correct-but-unoverlapped behaviour.
+    """
+    global _HOOKS_REGISTERED
+    if _HOOKS_REGISTERED:
+        return True
+    try:
+        from paddle.distributed.fleet.meta_parallel.pipeline_parallel import (
+            PipelineParallelMicroStepLocations,
+            register_global_pipeline_parallel_hook,
+        )
+    except ImportError:
+        logger.info(
+            "indexer_loss_overlap: this Paddle has no pipeline micro-step "
+            "callbacks; falling back to drain_all()"
+        )
+        return False
+    # ``_forward_step`` is what raises FORWARD_END, so its absence means the
+    # wrapper is not a pipeline model and the callback would never fire.
+    if not hasattr(pp_model, "_forward_step"):
+        logger.info(
+            "indexer_loss_overlap: %s is not a pipeline model; "
+            "falling back to drain_all()",
+            type(pp_model).__name__,
+        )
+        return False
+    p2p_location = getattr(
+        PipelineParallelMicroStepLocations, "P2P_ISSUED", None
+    )
+    if p2p_location is not None:
+        register_global_pipeline_parallel_hook(p2p_location, _p2p_issued_hook)
+    else:
+        logger.warning(
+            "indexer_loss_overlap: this Paddle's "
+            "PipelineParallelMicroStepLocations has no P2P_ISSUED, the only "
+            "location from which the loss branch can overlap the pipeline "
+            "send/recv. Registering the FORWARD_END fallback instead: the "
+            "indexer loss and its gradient stay correct, but "
+            "dsa_indexer_loss_bwd_p2p_overlap=True buys nothing on this "
+            "Paddle. Upgrade it or turn the flag off."
+        )
+    register_global_pipeline_parallel_hook(
+        PipelineParallelMicroStepLocations.FORWARD_END, _forward_end_hook
+    )
+    _HOOKS_REGISTERED = True
+    logger.info(
+        "indexer_loss_overlap: registered drain on %s of %s",
+        "P2P_ISSUED (+FORWARD_END fallback)"
+        if p2p_location is not None
+        else "FORWARD_END",
+        type(pp_model).__name__,
+    )
+    return True

--- a/src/paddlefleet/transformer/mqa_latent_attention.py
+++ b/src/paddlefleet/transformer/mqa_latent_attention.py
@@ -729,6 +729,14 @@ class MQALatentAttention(FleetLayer):
         self.indexer_use_sparse_loss = bool(
             getattr(config, "dsa_indexer_use_sparse_loss", False)
         )
+        # Gated on the sparse phase rather than read straight from the config:
+        # only ``_forward_sparse`` has an enqueue path, and the warmup phase
+        # shares ``_needs_indexer_loss`` with it, so without this ``and`` a
+        # warmup run with the flag set would flip the predicate to the no-grad
+        # pass and lose its loss.
+        self.indexer_loss_overlap = self.indexer_use_sparse_loss and bool(
+            getattr(config, "dsa_indexer_loss_bwd_p2p_overlap", False)
+        )
         # ``dsa_indexer_use_sparse_loss=False`` is the phase-2 (warmup) mode:
         # the indexer is still being learned, so attention must not consume its
         # ranking yet -- it attends to the full per-document causal set, exactly
@@ -936,19 +944,56 @@ class MQALatentAttention(FleetLayer):
             ]
         return selected, scores_out
 
-    def _needs_indexer_loss(self) -> bool:
+    def _needs_indexer_loss(self, in_recompute: bool = False) -> bool:
         """Whether this forward should build and attach the indexer loss.
 
         Both DSA phases share this predicate. ``paddle.is_grad_enabled()`` is
         what makes the loss count exactly once under recompute: the first
         (no-grad) forward only materialises the attention columns, the second one
         attaches the loss.
+
+        ``dsa_indexer_loss_bwd_p2p_overlap`` needs the opposite -- the pass that
+        runs during the pipeline's *forward* phase, because that is when the drain
+        hook fires. Which pass that is depends on whether this layer body is
+        replayed, which is exactly what ``in_recompute`` says:
+
+        =================  ======================  ==========================
+        ``in_recompute``   passes per micro-batch  enqueue on
+        =================  ======================  ==========================
+        ``True``           no-grad, then grad      ``not is_grad_enabled()``
+        ``False``          grad only               ``is_grad_enabled()``
+        =================  ======================  ==========================
+
+        Both spellings fire exactly once per ``(layer, micro-batch)``, so the
+        flag is independent of ``recompute_granularity``. Keying off the config
+        instead would be wrong twice over: it cannot see ``recompute_method``
+        ``first_n`` / ``block`` leaving *some* layers unwrapped, and it would
+        reject configurations that do not recompute at all yet overlap perfectly
+        well.
+
+        ``in_recompute`` tracks the *layer body*'s wrapper only, and two other
+        wrappers can replay this forward without it being set: selective
+        recompute of ``core_attn``, which wraps ``core_attention`` itself
+        (``MultiLatentAttention.forward``), and the ``RECOVER_STEP`` recovery
+        window, which recomputes the layer body while ``full_recompute`` is
+        ``False``. Both then take the ``False`` row, i.e. enqueue on the
+        grad-enabled replay, which runs in backward: the branch is still executed
+        exactly once, by a later micro-step's callback or by
+        ``indexer_loss_overlap.drain_all()``, but too late to overlap anything.
+        Cost only, never correctness; ``indexer_loss_overlap.validate_config``
+        warns about the ``core_attn`` one (the recovery window is a step-dependent
+        environment variable and cannot be seen from a config).
+
+        ``in_recompute`` is ignored unless the overlap is on; the default path
+        wants the grad-enabled pass either way.
         """
-        return (
-            self.training
-            and paddle.is_grad_enabled()
-            and self.indexer_loss_coeff > 0
-        )
+        if not (self.training and self.indexer_loss_coeff > 0):
+            return False
+        if self.indexer_loss_overlap:
+            if in_recompute:
+                return not paddle.is_grad_enabled()
+            return paddle.is_grad_enabled()
+        return paddle.is_grad_enabled()
 
     def _phase(self) -> str:
         """Which of the three training phases this layer runs.
@@ -997,6 +1042,7 @@ class MQALatentAttention(FleetLayer):
         v_b_proj_weight: Tensor | None = None,
         input_ids: Tensor | None = None,
         docmask_mb_idx: int = -1,
+        in_recompute: bool = False,
     ) -> Tensor:
         """Absorbed-MQA forward.
 
@@ -1016,6 +1062,11 @@ class MQALatentAttention(FleetLayer):
             input_ids: ``[b, s]`` token ids, only used to build the indexer-loss
                 row mask (``!= pad_token_id``). ``None`` falls back to the plain
                 row mean, as CSA does at ``csa_attention.py:1306``.
+            in_recompute: whether the enclosing transformer layer's body is
+                wrapped in a recompute span, i.e. whether this ``forward`` is
+                replayed. Only ``dsa_indexer_loss_bwd_p2p_overlap`` reads it,
+                to tell the real forward pass from the backward replay -- see
+                :meth:`_needs_indexer_loss`.
 
         Returns:
             ``[b, s, h * v_head_dim]`` (this rank's query slice under CP)
@@ -1160,6 +1211,7 @@ class MQALatentAttention(FleetLayer):
             input_ids,
             position_offset,
             meta=meta,
+            in_recompute=in_recompute,
         )
 
     # ------------------------------------------------------------------
@@ -1729,9 +1781,18 @@ class MQALatentAttention(FleetLayer):
         if grad_enabled:
             x_det.stop_gradient = False
             qr_det.stop_gradient = False
-            return self.indexer.forward_before_topk(
-                x_det, qr_det, position_offset, self.cp_group
-            )
+            # ``stop_gradient=False`` alone builds no graph inside
+            # ``paddle.no_grad()``, and under
+            # ``dsa_indexer_loss_bwd_p2p_overlap`` a recompute-wrapped layer
+            # reaches here on the *no-grad* pass. Without ``enable_grad`` the
+            # projection subgraph would not exist and the drain's
+            # ``paddle.autograd.backward`` would silently leave ``wq_b`` / ``wk``
+            # / ``k_norm`` / ``weights_proj`` without a gradient. A no-op
+            # wherever grad is already enabled.
+            with paddle.enable_grad():
+                return self.indexer.forward_before_topk(
+                    x_det, qr_det, position_offset, self.cp_group
+                )
         with paddle.no_grad():
             return self.indexer.forward_before_topk(
                 x_det, qr_det, position_offset, self.cp_group
@@ -2031,6 +2092,7 @@ class MQALatentAttention(FleetLayer):
         input_ids=None,
         position_offset=0,
         meta=None,
+        in_recompute=False,
     ) -> Tensor:
         """Phase 3: attention consumes window + top-k, KL on that same set.
 
@@ -2045,7 +2107,9 @@ class MQALatentAttention(FleetLayer):
         not bit-stable in every shape -- one document spanning the whole sequence
         drifts by ~2% of the emitted slots between identical calls -- but the
         selected *set* is, and any residual drift would only change which columns
-        the backward differentiates.)
+        the backward differentiates.) Under ``dsa_indexer_loss_bwd_p2p_overlap``
+        the owning pass becomes the first one whenever ``in_recompute`` says
+        there are two; :meth:`_needs_indexer_loss` holds that table.
         """
         from paddlefleet.cudnn_ops.indexer.csa_indexer_fwd_cudnn import (
             cudnn_indexer_topk_fwd,
@@ -2053,7 +2117,7 @@ class MQALatentAttention(FleetLayer):
 
         b, s = int(query.shape[0]), int(query.shape[1])
         s_global = s * self.cp_size
-        need_loss = self._needs_indexer_loss()
+        need_loss = self._needs_indexer_loss(in_recompute)
 
         with paddle.no_grad():
             if meta is not None:
@@ -2093,7 +2157,16 @@ class MQALatentAttention(FleetLayer):
         # ``DSAIndexer`` pre-bakes ``head_dim**-0.5`` into the weights, but both
         # cuDNN indexer kernels apply ``dim**-0.5`` themselves (the backward one
         # hardcodes it). Undo the pre-bake once so forward and backward agree.
-        w_idx = w_idx * (float(self.indexer.head_dim) ** 0.5)
+        #
+        # ``enable_grad`` for the same reason as in
+        # ``_indexer_projections``: under
+        # ``dsa_indexer_loss_bwd_p2p_overlap`` a recompute-wrapped layer runs
+        # this inside the wrapper's ``paddle.no_grad()``, where a bare multiply
+        # severs the subgraph just built. That cost ``weights_proj`` its gradient
+        # while ``wq_b`` / ``wk`` -- nothing rescales them -- kept theirs, i.e. an
+        # indexer that silently never learns its per-head importance.
+        with paddle.enable_grad():
+            w_idx = w_idx * (float(self.indexer.head_dim) ** 0.5)
 
         # The cuDNN top-k backward (``indexer_backward_sm100.__init__``) asserts
         # ``topk % block_I == 0`` with ``block_I = 128``, so keep the configured
@@ -2174,6 +2247,33 @@ class MQALatentAttention(FleetLayer):
             )
         output = self._deabsorb(core_out, v_b_proj_weight, self.split_kv_b)
         if not need_loss:
+            return output
+
+        if self.indexer_loss_overlap:
+            # Deferred path: hand the branch to the pipeline forward hook and
+            # return the output untouched. No PyLayer is applied, so the loss
+            # leaves no node in the backward graph at all -- which is why the
+            # ``target`` / ``topk_probs`` that the in-graph path keeps alive from
+            # the recompute until the backward are not retained here either.
+            from paddlefleet.transformer import indexer_loss_overlap
+
+            (topk_scores,) = scores_out
+            indexer_loss_overlap.enqueue(
+                indexer_loss_overlap._PendingWork(
+                    owner=self,
+                    query=query.detach(),
+                    kv=kv,
+                    lse_indexer=lse_indexer,
+                    topk_indices=topk_indices,
+                    topk_scores=topk_scores,
+                    index_q=q_idx,
+                    weights=w_idx,
+                    index_k=k_idx,
+                    input_ids=input_ids,
+                    batch=b,
+                    seqlen=s,
+                )
+            )
             return output
 
         with paddle.no_grad():
@@ -2265,6 +2365,108 @@ class MQALatentAttention(FleetLayer):
             # ``None`` (no ``input_ids``) leaves the kernel's own mean in place.
             valid_rows,
             loss_mask,
+        )
+
+    def _run_indexer_loss_branch(self, work) -> None:
+        """Run a deferred loss branch end to end (loss *and* its gradients).
+
+        Called by ``indexer_loss_overlap.drain`` from a pipeline hook. Mirrors
+        the inline tail of :meth:`_forward_sparse` term for term -- same target,
+        same reduction, same coefficient placement -- and then does what
+        ``TileLangCSAIndexerLossAutoScaler.backward`` would have done, via the
+        shared :func:`compute_csa_indexer_grads`.
+
+        The two halves are split by what they need:
+
+        * everything down to ``loss`` is pure forward arithmetic on detached
+          inputs, so it stays under ``no_grad`` exactly as the inline path does;
+        * ``paddle.autograd.backward`` then drives the indexer's own projection
+          subgraph (hadamard / RoPE / ``wq_b`` / ``wk`` / ``k_norm`` /
+          ``weights_proj``). It terminates at the five indexer weights because
+          ``_indexer_projections`` fed it detached leaves, so it cannot reach the
+          backbone no matter when it runs.
+
+        ``grad_output`` is absent from all of this on purpose: the indexer
+        gradient does not depend on it, which is precisely what makes running the
+        backward here -- during the *forward* pass -- legitimate.
+        """
+        from paddlefleet.transformer.csa_attention import (
+            compute_csa_indexer_grads,
+        )
+
+        with paddle.no_grad():
+            valid = work.topk_indices >= 0
+            scores = paddle.where(
+                valid,
+                work.topk_scores.cast("float32"),
+                paddle.full(work.topk_indices.shape, _NEG_INF, dtype="float32"),
+            )
+            topk_probs = F.softmax(scores, axis=-1)
+            topk_probs = paddle.where(
+                valid, topk_probs, paddle.zeros_like(topk_probs)
+            )
+            target = self._attn_target(
+                work.query, work.kv, work.topk_indices, work.lse_indexer
+            )
+            kl = target * (
+                paddle.log(target + _EPS) - paddle.log(topk_probs + _EPS)
+            )
+            loss_mask, valid_rows = self._indexer_loss_mask(
+                work.input_ids, work.batch, work.seqlen
+            )
+            loss_coeff = (
+                self.indexer_loss_coeff
+                if loss_mask is not None
+                else self.indexer_loss_coeff / self.cp_size
+            )
+            kl_per_pos = kl.sum(axis=-1)
+            if loss_mask is None:
+                loss = kl_per_pos.mean() * loss_coeff
+            else:
+                loss = (kl_per_pos * loss_mask).sum() / valid_rows * loss_coeff
+
+        grad_q, grad_weights, grad_k = compute_csa_indexer_grads(
+            work.index_q,
+            work.weights,
+            work.index_k,
+            target,
+            topk_probs,
+            work.topk_indices,
+            loss_coeff=loss_coeff,
+            indexer_backend=self.indexer_backend,
+            num_rows=valid_rows,
+            loss_mask=loss_mask,
+        )
+
+        outs, grads = [], []
+        for tensor, grad in (
+            (work.index_q, grad_q),
+            (work.index_k, grad_k),
+            (work.weights, grad_weights),
+        ):
+            # A frozen indexer (or a projection that tensor-parallelism turned
+            # into a no-grad view) leaves nothing to walk; skipping keeps
+            # ``paddle.autograd.backward`` from raising on it.
+            if not tensor.stop_gradient:
+                outs.append(tensor)
+                grads.append(grad)
+        if outs:
+            paddle.autograd.backward(outs, grads)
+
+        # Logging only -- ``loss`` is detached, so no data dependency on the
+        # gradients above -- but the *position* matters. The tracker update
+        # lowers to ``set_value_with_tensor_``, a device-to-device copy on the
+        # CUDA *legacy default* stream, i.e. a bidirectional full-device
+        # barrier. Ahead of the backward it makes the backward wait for the
+        # in-flight pipeline ``SendRecv``, which is the overlap this whole path
+        # exists to get. Last, the barrier coincides with the wait the schedule
+        # performs anyway.
+        DSAIndexerLossLoggingHelper.save_loss_to_tracker(
+            loss=loss,
+            layer_number=self.layer_number,
+            num_layers=DSAIndexerLossLoggingHelper.get_total_num_layers(
+                self.config
+            ),
         )
 
     def _indexer_loss_mask(self, input_ids, b, s):

--- a/src/paddlefleet/transformer/multi_latent_attention.py
+++ b/src/paddlefleet/transformer/multi_latent_attention.py
@@ -973,6 +973,20 @@ class MultiLatentAttention(Attention):
         # against the callee's signature.
         if self.mqa_latent and kwargs.get("docmask_mb_idx") is not None:
             core_attn_extra["docmask_mb_idx"] = kwargs["docmask_mb_idx"]
+        # ``dsa_indexer_loss_bwd_p2p_overlap`` must tell the real forward pass
+        # from the recompute replay, and the two differ only in whether the layer
+        # body is wrapped at all -- a per-layer property
+        # (``need_full_recompute(layer_number, config)``) that cannot be
+        # re-derived from the config here. Declared on
+        # ``MQALatentAttention.forward`` for the same kwarg-flattening reason as
+        # ``docmask_mb_idx`` above. Passed through unchanged: the
+        # ``recompute(self.core_attention, ...)`` below is a *second*, independent
+        # wrapper, and folding it in here would double-enqueue whenever both are
+        # active (both replays would then look like a no-grad first pass). It only
+        # costs the overlap, which ``indexer_loss_overlap.validate_config`` warns
+        # about; see ``MQALatentAttention._needs_indexer_loss``.
+        if self.mqa_latent:
+            core_attn_extra["in_recompute"] = in_recompute
 
         if self.mqa_latent:
             # Query is already absorbed; the core attention only needs the V-side
@@ -1110,10 +1124,19 @@ class MultiLatentAttention(Attention):
 
         if self.recompute_qkv_up_porj_and_rope and self.training:
             assert getattr(self, "_qkv_recompute", None) is not None
-            self._qkv_recompute.discard_output_and_register_recompute(
-                core_attn_out
-            )
+            span = self._qkv_recompute
             self._qkv_recompute = None
+            # ``mla_qkv_recompute`` frees query / key / value here and restores
+            # them only in backward, but ``dsa_indexer_loss_bwd_p2p_overlap``
+            # still reads query and kv later in this same forward. With both on,
+            # the discard must follow the branch; see
+            # ``indexer_loss_overlap.defer_discard``.
+            from paddlefleet.transformer import indexer_loss_overlap
+
+            if not indexer_loss_overlap.defer_discard(
+                self.core_attention, span, core_attn_out
+            ):
+                span.discard_output_and_register_recompute(core_attn_out)
 
         _log(core_attn_out, "core_attn_out", layer_num)
 

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -278,7 +278,14 @@ class TransformerConfig(ModelParallelConfig):
     ``tests/single_card_tests/test_inv_rope_vha_postmix_fusion.py``. Requires
     ``use_vha_attention`` and ``apply_rope_fusion``, and is skipped for
     ``vha_postmix_grouped``, ``high_precision_rope`` and when the postmix has its
-    own selective recompute wrapper."""
+    own selective recompute wrapper.
+
+    Because every skip falls back silently, ``__post_init__`` refuses to start
+    when no layer could ever take the fused path (wrong
+    ``experimental_attention_variant``, only ``-2`` layers, no VHA postmix, the
+    grouped topology, no ``apply_rope_fusion``, ``high_precision_rope``, or
+    ``qk_pos_emb_head_dim`` unset) and warns when ``'vha_postmix'`` is in
+    ``recompute_modules``, which disables it per layer rather than globally."""
 
     use_vha_premix: bool = False
     """If True (and use_vha_attention is also True), replaces the DSv4 hybrid Q up-projection
@@ -1290,6 +1297,50 @@ class TransformerConfig(ModelParallelConfig):
     by TransformerConfig.transform_rules.
     """
 
+    dsa_indexer_loss_bwd_p2p_overlap: bool = False
+    """Run the DSA indexer-loss branch inside the pipeline's forward send/recv.
+
+    ``False`` (default) leaves the in-place behaviour untouched: the KL target,
+    the KL and ``TileLangCSAIndexerLossAutoScaler`` all run in the grad-enabled
+    forward of the ``-2`` layer, and that PyLayer's backward produces the indexer
+    gradients.
+
+    ``True`` moves the branch out of the layer. It is sound because the branch is
+    a *leaf subgraph*: ``_indexer_projections`` detaches ``x`` / ``qr``, the loss
+    PyLayer is an identity on ``output``, and ``csa_indexer_bwd`` never reads
+    ``grad_output`` -- so nothing in the main backward waits on it and its only
+    effect is a gradient on the ``DSAIndexer`` weights. The layer enqueues its
+    inputs on whichever forward pass belongs to the pipeline's forward phase (the
+    no-grad one when the layer body is recompute-wrapped, the only one when it is
+    not), and Paddle's ``P2P_ISSUED`` callback drains the queue after the schedule
+    has issued that micro-step's p2p and before it waits on the handles, so the
+    branch runs on the compute stream while the transfer is in flight.
+    Independent of ``recompute_granularity``.
+
+    The callback must fire *after* the issue: ``isend`` / ``irecv`` gate the NCCL
+    kernel on an event recorded on the calculation stream at issue time, so
+    anything queued earlier -- as a ``FORWARD_END`` placement would be -- is
+    inside that event's reach and the send waits for it instead of running
+    alongside. ``FORWARD_END`` is still registered as a self-disarming fallback
+    for schedules that raise no ``P2P_ISSUED``.
+
+    Requires ``indexer_loss_overlap.register_pipeline_hooks(...)`` on the
+    pipeline-parallel model; without it only the ``drain_all()`` safety net drains
+    the queue and nothing is overlapped (the result is numerically identical
+    either way). The overlap also needs the p2p off the compute stream, which
+    ``overlap_p2p_comm=True`` arranges by forcing ``batch_p2p_comm`` off. The last
+    pipeline stage's steady-1F1B micro-steps have no window at all, because both
+    ``send_forward`` and ``recv_backward`` are no-ops there.
+
+    ``indexer_loss_overlap.validate_config`` refuses to start where the flag would
+    be dead or lossy: ``pipeline_model_parallel_size == 1``, a model that builds
+    no ``DSAIndexer``, ``dsa_indexer_loss_coeff <= 0``, and
+    ``dsa_indexer_use_sparse_loss=False`` (the warmup phase has no enqueue path,
+    so the loss would be dropped silently). ``overlap_p2p_comm=False`` /
+    ``batch_p2p_comm=True`` only warn: the maths is unchanged, there is just
+    nothing to overlap with.
+    """
+
     dsa_indexer_rope_fusion: bool = False
     """Whether to use the fused Triton RoPE for the DSA indexer's q/k.
 
@@ -2180,6 +2231,89 @@ class TransformerConfig(ModelParallelConfig):
                     " -2 layers. Under the default 'mha' those layers are dense "
                     "MLA and build no MQADocMeta, so the switch would be a silent "
                     "no-op. Use csa_share_docmask_meta for the HCA/CSA layers."
+                )
+        if self.fuse_inv_rope_into_vha_postmix:
+            # ``DSv4HybridAttention._can_fuse_inv_rope_postmix`` answers no by
+            # falling back to the unfused inverse-RoPE + postmix pair, which is
+            # bitwise identical. That is what makes a mis-set flag invisible:
+            # nothing fails, nothing warns, the run is simply as slow as it was
+            # before. So the conditions the predicate reads off the config are
+            # checked once here, where they can still be reported as a mistake.
+            unmet = []
+            if self.experimental_attention_variant != "dsv4_hybrid":
+                unmet.append(
+                    "experimental_attention_variant="
+                    f"{self.experimental_attention_variant!r}, but the fusion "
+                    "lives in DSv4HybridAttention, which no other variant "
+                    "builds"
+                )
+            elif all(int(r) == -2 for r in (self.csa_compress_ratios or [-2])):
+                # -2 is MLA, handled by MQALatentAttention; DSv4HybridAttention
+                # is never constructed for it, so no postmix exists to fuse into.
+                unmet.append(
+                    "every csa_compress_ratios entry is -2 (MLA), so no "
+                    "DSv4-hybrid layer is built: "
+                    f"csa_compress_ratios={self.csa_compress_ratios!r}"
+                )
+            if not self.use_vha_attention:
+                unmet.append(
+                    "use_vha_attention=False, so there is no VHA postmix GEMM "
+                    "to fold the inverse RoPE into"
+                )
+            if self.vha_postmix_grouped:
+                unmet.append(
+                    "vha_postmix_grouped=True mixes within each o_group via "
+                    "einsum; the fusion needs the ungrouped [nh, nh] GEMM it "
+                    "splits into a full-width and a pe-width part"
+                )
+            if not self.apply_rope_fusion:
+                unmet.append(
+                    "apply_rope_fusion=False keeps the eager RoPE, while the "
+                    "fusion is a Triton kernel"
+                )
+            if self.high_precision_rope:
+                unmet.append(
+                    "high_precision_rope=True computes the rotation in fp32, "
+                    "which the fused kernel does not implement"
+                )
+            if not (self.qk_pos_emb_head_dim or 0) > 0:
+                unmet.append(
+                    "qk_pos_emb_head_dim="
+                    f"{self.qk_pos_emb_head_dim!r} leaves no RoPE channels, so "
+                    "the whole inverse-RoPE step is skipped"
+                )
+            if unmet:
+                raise ValueError(
+                    "fuse_inv_rope_into_vha_postmix=True but the fusion can "
+                    "never trigger in this config, and the fallback is bitwise "
+                    "identical, so the flag would be a silent no-op: "
+                    + "; ".join(unmet)
+                    + ". Fix the listed fields or drop the flag."
+                )
+            if (
+                self.recompute_granularity == "selective"
+                and isinstance(self.recompute_modules, list)
+                and "vha_postmix" in self.recompute_modules
+            ):
+                # The postmix's own recompute wrapper would have to re-enter the
+                # fused PyLayer to save an intermediate the fusion never
+                # materialises, so those layers keep the unfused pair.
+                scope = (
+                    "every layer"
+                    if self.recompute_num_layers is None
+                    else f"the recompute_method={self.recompute_method!r} "
+                    f"window of {self.recompute_num_layers} layers"
+                )
+                logger.warning(
+                    "fuse_inv_rope_into_vha_postmix=True together with "
+                    "'vha_postmix' in recompute_modules: on the layers the "
+                    f"selective wrapper covers ({scope}) the inverse RoPE and "
+                    "the postmix stay unfused during training, because the "
+                    "fusion already avoids the intermediate that wrapper exists "
+                    "to free. Results are unaffected. Drop 'vha_postmix' from "
+                    "recompute_modules to fuse everywhere, or use "
+                    "recompute_granularity='full', under which the fusion runs "
+                    "inside the full-layer recompute."
                 )
 
         # DSv4 Hybrid Attention validation

--- a/tests/single_card_tests/transformer/test_doc_mask_meta_registry.py
+++ b/tests/single_card_tests/transformer/test_doc_mask_meta_registry.py
@@ -971,8 +971,12 @@ def _stub_indexer_loss_leaves(module):
     target / loss-mask are replaced by shape-only zeros. The two remaining
     kernel patches (the indexer topk kernel and the tilelang autoscaler) stay
     at the call site so the with-block reads linearly.
+
+    The predicate takes an ``in_recompute`` argument at the sparse call site, so
+    the stand-in swallows arguments rather than naming them: what it stands for
+    is "this layer wants the loss", which is true of every phase.
     """
-    module._needs_indexer_loss = lambda: True
+    module._needs_indexer_loss = lambda *a, **k: True
     module._indexer_projections = lambda *a, **k: (
         paddle.zeros([1, 4, 8]),
         paddle.zeros([1, 4, 8]),

--- a/tests/single_card_tests/transformer/test_indexer_loss_overlap.py
+++ b/tests/single_card_tests/transformer/test_indexer_loss_overlap.py
@@ -1,0 +1,1763 @@
+# Copyright (c) 2026 Baidu, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""``dsa_indexer_loss_bwd_p2p_overlap``: the deferred branch must match
+the inline one.
+
+The flag moves the whole indexer-loss branch out of the layer and into a
+pipeline micro-step callback. The only thing that makes that safe is an
+equivalence claim -- the five ``DSAIndexer`` gradients and the logged KL are the
+same either way -- so that claim is what most of these tests pin down. How much
+the move actually buys is a performance property and is not testable here;
+:class:`TestForwardEndRegistration` covers the part that is, namely *which*
+callback the drain is attached to.
+
+The two paths are driven differently on purpose, because that asymmetry *is* the
+feature:
+
+* off -- one grad-enabled forward, then ``out.sum().backward()`` runs
+  ``TileLangCSAIndexerLossAutoScaler.backward``;
+* on, ``in_recompute=True`` -- one ``paddle.no_grad()`` forward (what the
+  recompute wrapper's first pass looks like), which only enqueues, then an
+  explicit ``drain()`` standing in for the pipeline forward hook;
+* on, ``in_recompute=False`` -- one grad-enabled forward, which is the *only*
+  pass an unwrapped layer gets, so that is the one that enqueues. Still no
+  ``backward()``: the branch does not need one either way.
+
+The last case is why the flag does not depend on ``recompute_granularity``. Both
+spellings are asserted against the same inline baseline.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import enum
+import sys
+import types
+import unittest
+from unittest import mock
+
+import numpy as np
+import paddle
+
+from paddlefleet.transformer import indexer_loss_overlap
+from paddlefleet.transformer.dsa_attention import DSAIndexerLossLoggingHelper
+
+from .hybrid_mla_utils import (
+    _GPU,
+    _PARENT_REPO_AVAILABLE,
+    INDEX_TOPK,
+    WINDOW,
+    _add_repo_root_to_sys_path,
+    _build_module,
+    _create_mqa_config,
+    _make_inputs,
+    _row_end,
+)
+
+_INDEXER_PARAMS = (
+    "wq_b.linear.weight",
+    "wk.linear.weight",
+    "weights_proj.linear.weight",
+)
+
+_SEQLEN = WINDOW + INDEX_TOPK
+
+
+def _sparse_config(overlap: bool):
+    config = _create_mqa_config("mqa_dsa", loss_coeff=0.01)
+    # Phase 3: attention consumes window + top-k and the KL covers that same
+    # set. The overlap flag is only implemented for this phase.
+    config.dsa_indexer_use_sparse_loss = True
+    config.dsa_indexer_loss_bwd_p2p_overlap = overlap
+    # ``validate_config`` also insists on a pipeline and on the model really
+    # having a ``-2`` (DSAIndexer) layer; ``_create_mqa_config`` leaves both
+    # unset because the single-layer module fixture does not need them.
+    config.pipeline_model_parallel_size = 4
+    config.csa_compress_ratios = [-2] * config.num_hidden_layers
+    return config
+
+
+def _indexer_grads(module):
+    """``{name: fp32 numpy}`` for the indexer weights that got a gradient."""
+    out = {}
+    for name, param in module.indexer.named_parameters():
+        if param.grad is not None:
+            out[name] = param.grad.cast("float32").numpy().copy()
+    return out
+
+
+def _logged_loss():
+    values = DSAIndexerLossLoggingHelper.tracker.get("values")
+    return None if values is None else values.cast("float32").numpy().copy()
+
+
+@_GPU
+class TestOverlapEquivalence(unittest.TestCase):
+    """Deferred and inline paths agree on gradients and on the logged loss."""
+
+    def setUp(self):
+        indexer_loss_overlap.drain_all()
+        DSAIndexerLossLoggingHelper.tracker.clear()
+
+    def tearDown(self):
+        indexer_loss_overlap.drain_all()
+        DSAIndexerLossLoggingHelper.tracker.clear()
+
+    def _run_inline(self, seed=0):
+        module = _build_module(_sparse_config(overlap=False), bf16=True)
+        query, key, w_v, x, qr = _make_inputs(
+            _SEQLEN, seed=seed, with_hidden=True
+        )
+        for tensor in (query, key, x, qr):
+            tensor.stop_gradient = False
+        module.train()
+        out = module(
+            query,
+            key,
+            None,
+            None,
+            _row_end([_SEQLEN], _SEQLEN),
+            v_b_proj_weight=w_v,
+            x=x,
+            qr=qr,
+        )
+        out.cast("float32").sum().backward()
+        return module, _indexer_grads(module), _logged_loss()
+
+    def _run_deferred(self, seed=0, drain=True, in_recompute=True):
+        module = _build_module(_sparse_config(overlap=True), bf16=True)
+        query, key, w_v, x, qr = _make_inputs(
+            _SEQLEN, seed=seed, with_hidden=True
+        )
+        module.train()
+        # ``in_recompute=True`` + ``paddle.no_grad()`` is what the recompute
+        # wrapper's first pass looks like; ``in_recompute=False`` with grad on is
+        # the single forward an unwrapped layer gets. Both are the pass the
+        # deferred path claims. ``query``/``x``/``qr`` deliberately keep
+        # ``stop_gradient=True``: the branch never touches the backbone graph, so
+        # it must work without one.
+        ctx = paddle.no_grad() if in_recompute else contextlib.nullcontext()
+        with ctx:
+            out = module(
+                query,
+                key,
+                None,
+                None,
+                _row_end([_SEQLEN], _SEQLEN),
+                v_b_proj_weight=w_v,
+                x=x,
+                qr=qr,
+                in_recompute=in_recompute,
+            )
+        self.assertEqual(indexer_loss_overlap.pending(), 1)
+        if drain:
+            self.assertEqual(indexer_loss_overlap.drain(), 1)
+            self.assertEqual(indexer_loss_overlap.pending(), 0)
+        return module, out, _indexer_grads(module), _logged_loss()
+
+    def _copy_indexer_weights(self, src, dst):
+        """Make the two modules share weights so gradients are comparable."""
+        state = dict(src.indexer.state_dict())
+        dst.indexer.set_state_dict(state)
+
+    def _assert_matches_inline(self, in_recompute):
+        inline_mod, inline_grads, inline_loss = self._run_inline()
+        self.assertTrue(inline_grads, "inline path produced no indexer grads")
+
+        deferred_mod = _build_module(_sparse_config(overlap=True), bf16=True)
+        self._copy_indexer_weights(inline_mod, deferred_mod)
+        # Rebuild the whole layer from the inline one so every projection the
+        # target depends on is identical, not just the indexer's.
+        deferred_mod.set_state_dict(inline_mod.state_dict())
+        DSAIndexerLossLoggingHelper.tracker.clear()
+
+        query, key, w_v, x, qr = _make_inputs(_SEQLEN, seed=0, with_hidden=True)
+        deferred_mod.train()
+        ctx = paddle.no_grad() if in_recompute else contextlib.nullcontext()
+        with ctx:
+            deferred_mod(
+                query,
+                key,
+                None,
+                None,
+                _row_end([_SEQLEN], _SEQLEN),
+                v_b_proj_weight=w_v,
+                x=x,
+                qr=qr,
+                in_recompute=in_recompute,
+            )
+        self.assertEqual(indexer_loss_overlap.drain(), 1)
+        deferred_grads = _indexer_grads(deferred_mod)
+
+        self.assertEqual(
+            sorted(deferred_grads),
+            sorted(inline_grads),
+            "deferred path touched a different set of indexer weights",
+        )
+        for name in inline_grads:
+            self.assertTrue(
+                paddle.allclose(
+                    paddle.to_tensor(inline_grads[name]),
+                    paddle.to_tensor(deferred_grads[name]),
+                    rtol=1e-5,
+                    atol=1e-7,
+                ).item(),
+                f"{name} gradient differs between inline and deferred paths",
+            )
+
+    def test_deferred_gradients_match_the_inline_path(self):
+        """Recompute-wrapped layer: the branch is claimed by the no-grad pass."""
+        self._assert_matches_inline(in_recompute=True)
+
+    def test_deferred_gradients_match_without_recompute(self):
+        """Unwrapped layer: the single grad-enabled forward claims it instead.
+
+        The case the old ``recompute_granularity == "full"`` gate rejected
+        outright. Nothing about the branch needs the replay -- it only needs to
+        run once, during the pipeline's forward phase -- so this has to produce
+        the same five gradients as the inline path too.
+        """
+        self._assert_matches_inline(in_recompute=False)
+
+    def test_no_grad_forward_enqueues_and_produces_no_backward_node(self):
+        module, out, grads, loss = self._run_deferred(drain=True)
+        # The layer output must come back untouched and gradient-free: with the
+        # flag on there is no PyLayer wrapping it, which is the point.
+        self.assertTrue(out.stop_gradient)
+        self.assertTrue(bool(paddle.isfinite(out.cast("float32")).all()))
+        self.assertTrue(grads, "drain produced no indexer gradients")
+        for name in _INDEXER_PARAMS:
+            self.assertIn(name, grads, f"{name} received no gradient")
+            self.assertTrue(
+                bool(paddle.isfinite(paddle.to_tensor(grads[name])).all()),
+                f"{name} gradient is not finite",
+            )
+            self.assertGreater(
+                float(abs(paddle.to_tensor(grads[name])).max()),
+                0.0,
+                f"{name} gradient is all zeros",
+            )
+        self.assertIsNotNone(loss, "drain logged no loss")
+
+    def test_queue_stays_empty_until_drained(self):
+        _, _, grads, _ = self._run_deferred(drain=False)
+        # Nothing ran yet, so no gradient exists: this is what makes the
+        # ``drain_all()`` safety net mandatory rather than cosmetic.
+        self.assertFalse(grads)
+        self.assertEqual(indexer_loss_overlap.pending(), 1)
+        self.assertEqual(indexer_loss_overlap.drain_all(), 1)
+        self.assertEqual(indexer_loss_overlap.pending(), 0)
+
+    def test_grad_enabled_forward_is_a_no_op_when_deferring(self):
+        """The replay pass must not enqueue or compute a second time.
+
+        Only true for a recompute-wrapped layer (``in_recompute=True``), where the
+        no-grad pass already claimed the branch. Without the wrapper the same
+        grad-enabled forward is the one that enqueues -- see
+        ``test_deferred_gradients_match_without_recompute``.
+        """
+        module = _build_module(_sparse_config(overlap=True), bf16=True)
+        query, key, w_v, x, qr = _make_inputs(_SEQLEN, seed=0, with_hidden=True)
+        for tensor in (query, key, x, qr):
+            tensor.stop_gradient = False
+        module.train()
+        out = module(
+            query,
+            key,
+            None,
+            None,
+            _row_end([_SEQLEN], _SEQLEN),
+            v_b_proj_weight=w_v,
+            x=x,
+            qr=qr,
+            in_recompute=True,
+        )
+        self.assertEqual(indexer_loss_overlap.pending(), 0)
+        out.cast("float32").sum().backward()
+        self.assertFalse(
+            _indexer_grads(module),
+            "the grad-enabled replay attached a loss it should have skipped",
+        )
+
+    def test_the_branch_is_claimed_exactly_once_either_way(self):
+        """The enqueue predicate's truth table, straight from the layer.
+
+        Two passes when wrapped, one when not, and exactly one enqueue in both
+        cases. This is the whole reason the flag can ignore
+        ``recompute_granularity``.
+        """
+        module = _build_module(_sparse_config(overlap=True), bf16=True)
+        module.train()
+        for in_recompute, expected in (
+            # (wrapped?, which grad states enqueue)
+            (True, {False}),
+            (False, {True}),
+        ):
+            fired = {
+                grad_on
+                for grad_on in (True, False)
+                if self._predicate(module, in_recompute, grad_on)
+            }
+            self.assertEqual(
+                fired,
+                expected,
+                f"in_recompute={in_recompute} enqueues on the wrong pass",
+            )
+
+    @staticmethod
+    def _predicate(module, in_recompute, grad_on):
+        ctx = contextlib.nullcontext() if grad_on else paddle.no_grad()
+        with ctx:
+            return module._needs_indexer_loss(in_recompute)
+
+
+@_GPU
+class TestOverlapConfigValidation(unittest.TestCase):
+    """The flag must refuse the configurations where it would lose the loss."""
+
+    def test_recompute_granularity_is_not_a_constraint(self):
+        """No granularity may be rejected -- the predicate adapts per layer.
+
+        A config-level gate could not have been correct: with
+        ``recompute_method`` ``first_n`` / ``block`` some layers are wrapped and
+        some are not (``recompute_utils.py:180``), so the granularity says
+        nothing about what any individual DSA layer does.
+        """
+        for granularity in ("full", "selective", "core_attn", None):
+            config = _sparse_config(overlap=True)
+            config.recompute_granularity = granularity
+            indexer_loss_overlap.validate_config(config)
+
+    def test_requires_the_sparse_phase(self):
+        config = _sparse_config(overlap=True)
+        config.dsa_indexer_use_sparse_loss = False
+        with self.assertRaisesRegex(ValueError, "sparse"):
+            indexer_loss_overlap.validate_config(config)
+
+    def test_accepts_the_supported_combination(self):
+        indexer_loss_overlap.validate_config(_sparse_config(overlap=True))
+
+    def test_disabled_flag_validates_anything(self):
+        config = _sparse_config(overlap=False)
+        config.dsa_indexer_use_sparse_loss = False
+        indexer_loss_overlap.validate_config(config)
+
+    def test_warmup_phase_ignores_the_flag(self):
+        """The module-level gate keeps phase 2 on its own loss path."""
+        config = _create_mqa_config("mqa_dsa", loss_coeff=0.01)
+        config.dsa_indexer_use_sparse_loss = False
+        config.dsa_indexer_loss_bwd_p2p_overlap = True
+        module = _build_module(config, bf16=True)
+        self.assertFalse(module.indexer_loss_overlap)
+
+
+@_GPU
+class TestOverlapWithMainGrad(unittest.TestCase):
+    """``amp_master_grad``: the deferred write must land in ``main_grad``.
+
+    This is the interaction the flag is most likely to break, and the one a
+    plain single-card test would miss. Production runs O2 + ``amp_master_grad``,
+    where ``MixPrecisionLayer`` registers a per-parameter grad hook that asserts
+    ``param.grad is None``, accumulates into an fp32 ``param.main_grad`` and then
+    clears the incoming bf16 grad
+    (``paddle/distributed/fleet/utils/mix_precision_utils.py:44-71``).
+
+    The deferred path drives ``paddle.autograd.backward`` during the *forward*
+    pass. What has to hold is that this still goes through that hook rather than
+    around it: writing ``param.grad`` directly would trip the assert the moment
+    the real backward runs, and rebinding ``main_grad`` would silently detach the
+    parameter from the sharding fused buffer (``tensor_fusion_helper.py:711``).
+
+    Sharding bucketing itself is not exercised here and does not need to be: with
+    ``pipeline_model_parallel_size > 1`` the comm-overlap hooks are disabled and
+    ``FusedCommBuffer.add_grad`` never runs, so the collective is a single
+    ``reduce_gradients`` after every backward -- there is no per-parameter
+    check-in counter for a forward-time write to desynchronise.
+    """
+
+    def setUp(self):
+        indexer_loss_overlap.drain_all()
+        DSAIndexerLossLoggingHelper.tracker.clear()
+
+    def tearDown(self):
+        indexer_loss_overlap.drain_all()
+        DSAIndexerLossLoggingHelper.tracker.clear()
+
+    @staticmethod
+    def _wrap(module):
+        from paddle.distributed.fleet.utils.mix_precision_utils import (
+            MixPrecisionLayer,
+        )
+
+        return MixPrecisionLayer(module, dtype="bfloat16")
+
+    @staticmethod
+    def _main_grads(module):
+        out = {}
+        for name, param in module.indexer.named_parameters():
+            main_grad = getattr(param, "main_grad", None)
+            if main_grad is not None:
+                out[name] = main_grad.cast("float32").numpy().copy()
+        return out
+
+    def test_deferred_write_goes_through_the_main_grad_hook(self):
+        module = _build_module(_sparse_config(overlap=True), bf16=True)
+        wrapped = self._wrap(module)
+        query, key, w_v, x, qr = _make_inputs(_SEQLEN, seed=0, with_hidden=True)
+        module.train()
+        with paddle.no_grad():
+            wrapped(
+                query,
+                key,
+                None,
+                None,
+                _row_end([_SEQLEN], _SEQLEN),
+                v_b_proj_weight=w_v,
+                x=x,
+                qr=qr,
+                in_recompute=True,
+            )
+        self.assertEqual(indexer_loss_overlap.drain(), 1)
+
+        main_grads = self._main_grads(module)
+        for name in _INDEXER_PARAMS:
+            param = dict(module.indexer.named_parameters())[name]
+            # The assert that would fire on the next real backward.
+            self.assertIsNone(
+                param.grad,
+                f"{name}.grad is set; MixPrecisionLayer's hook would assert",
+            )
+            self.assertIn(name, main_grads, f"{name} got no main_grad")
+            self.assertEqual(main_grads[name].dtype.name, "float32")
+            self.assertGreater(
+                float(abs(paddle.to_tensor(main_grads[name])).max()),
+                0.0,
+                f"{name} main_grad is all zeros",
+            )
+
+    def test_main_grad_buffer_is_updated_in_place(self):
+        """A rebind would drop the param out of the sharding fused buffer."""
+        module = _build_module(_sparse_config(overlap=True), bf16=True)
+        wrapped = self._wrap(module)
+        params = dict(module.indexer.named_parameters())
+        # Pre-seed main_grad so the hook takes its ``add_`` branch, which is the
+        # branch production hits: the fused buffer is allocated at optimizer
+        # construction, so main_grad is never None by the time a step runs.
+        for name in _INDEXER_PARAMS:
+            params[name].main_grad = paddle.zeros_like(
+                params[name], dtype="float32"
+            )
+        addresses = {
+            name: params[name].main_grad.data_ptr() for name in _INDEXER_PARAMS
+        }
+
+        query, key, w_v, x, qr = _make_inputs(_SEQLEN, seed=0, with_hidden=True)
+        module.train()
+        with paddle.no_grad():
+            wrapped(
+                query,
+                key,
+                None,
+                None,
+                _row_end([_SEQLEN], _SEQLEN),
+                v_b_proj_weight=w_v,
+                x=x,
+                qr=qr,
+                in_recompute=True,
+            )
+        self.assertEqual(indexer_loss_overlap.drain(), 1)
+
+        for name in _INDEXER_PARAMS:
+            self.assertEqual(
+                params[name].main_grad.data_ptr(),
+                addresses[name],
+                f"{name}.main_grad was rebound instead of accumulated in place",
+            )
+            self.assertGreater(
+                float(abs(params[name].main_grad).max()),
+                0.0,
+                f"{name}.main_grad was not accumulated into",
+            )
+
+
+class TestForwardEndRegistration(unittest.TestCase):
+    """The drain must land on ``P2P_ISSUED``, with ``FORWARD_END`` as a fallback.
+
+    ``P2P_ISSUED`` is raised by the schedule *after* the micro-step's p2p has been
+    issued and before its wait handles are consumed. That side of the issue is the
+    whole overlap: ``isend``/``irecv`` gate the NCCL kernel on an event recorded
+    on the calculation stream at issue time, so a drain queued before the issue --
+    which is what ``FORWARD_END`` (``pipeline_parallel.py:1690``) gives -- lands
+    inside that event's reach and the send waits for the branch instead of running
+    alongside it.
+
+    ``FORWARD_END`` stays registered anyway, self-disarming on the first
+    ``P2P_ISSUED``, because schedules that were never taught to defer their wait
+    raise no ``P2P_ISSUED`` and losing the gradient is worse than losing the
+    speedup.
+
+    No GPU needed: this pins the wiring, not the numerics.
+    """
+
+    def setUp(self):
+        import paddle.distributed.fleet.meta_parallel.pipeline_parallel as pp
+
+        locations = pp.PipelineParallelMicroStepLocations
+        self._registry = pp.pipeline_parallel_callbacks_.hooks
+        if not hasattr(locations, "P2P_ISSUED"):
+            locations = self._synthesise_p2p_issued(pp, locations)
+        self._location = locations.FORWARD_END
+        self._p2p_location = locations.P2P_ISSUED
+        self._saved = list(self._registry[self._location])
+        self._saved_p2p = list(self._registry[self._p2p_location])
+        self._saved_flag = indexer_loss_overlap._HOOKS_REGISTERED
+        self._saved_window = indexer_loss_overlap._P2P_WINDOW_SEEN
+        self._saved_fe_drains = indexer_loss_overlap._FORWARD_END_DRAINS
+        self._saved_warned = indexer_loss_overlap._FALLBACK_WARNED
+        indexer_loss_overlap._HOOKS_REGISTERED = False
+        indexer_loss_overlap._P2P_WINDOW_SEEN = False
+        indexer_loss_overlap._FORWARD_END_DRAINS = 0
+        indexer_loss_overlap._FALLBACK_WARNED = False
+
+    def _synthesise_p2p_issued(self, pp, locations):
+        """Stand in for the location on a Paddle that predates it.
+
+        ``P2P_ISSUED`` reached Paddle together with the framework half of this
+        feature, and this repository's CI may run against an older one. Skipping
+        the class there would leave the p2p wiring -- the only thing it exists to
+        pin -- untested on the runner that gates the PR, so the member is
+        supplied instead. It behaves like the real one for these tests' purposes:
+        they raise the location themselves through Paddle's own dispatcher, and
+        the source resolves the member by name at registration time, so it picks
+        the stand-in up. An ``Enum`` cannot be extended in place, hence the
+        rebuild; the dispatcher's registry is keyed by member, so the rebuilt
+        members need their own entries.
+        """
+        locations = enum.Enum(
+            locations.__name__,
+            [(m.name, m.value) for m in locations]
+            + [("P2P_ISSUED", "p2p_issued")],
+        )
+        patcher = mock.patch.object(
+            pp, "PipelineParallelMicroStepLocations", locations
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        added = [m for m in locations if m not in self._registry]
+        for member in added:
+            self._registry[member] = []
+        self.addCleanup(lambda: [self._registry.pop(m, None) for m in added])
+        return locations
+
+    def tearDown(self):
+        self._registry[self._location] = self._saved
+        self._registry[self._p2p_location] = self._saved_p2p
+        indexer_loss_overlap._HOOKS_REGISTERED = self._saved_flag
+        indexer_loss_overlap._P2P_WINDOW_SEEN = self._saved_window
+        indexer_loss_overlap._FORWARD_END_DRAINS = self._saved_fe_drains
+        indexer_loss_overlap._FALLBACK_WARNED = self._saved_warned
+        indexer_loss_overlap.drain_all()
+
+    @staticmethod
+    def _fake_pp_model():
+        class _FakePipelineParallel:
+            def _forward_step(self, *args, **kwargs):
+                raise AssertionError("not meant to run")
+
+        return _FakePipelineParallel()
+
+    def test_registers_on_both_locations(self):
+        self.assertTrue(
+            indexer_loss_overlap.register_pipeline_hooks(self._fake_pp_model())
+        )
+        self.assertIn(
+            indexer_loss_overlap._p2p_issued_hook,
+            self._registry[self._p2p_location],
+        )
+        self.assertIn(
+            indexer_loss_overlap._forward_end_hook,
+            self._registry[self._location],
+        )
+
+    def test_registration_is_idempotent(self):
+        """The trainer may wrap the model more than once (train then eval)."""
+        model = self._fake_pp_model()
+        self.assertTrue(indexer_loss_overlap.register_pipeline_hooks(model))
+        self.assertTrue(indexer_loss_overlap.register_pipeline_hooks(model))
+        self.assertEqual(
+            self._registry[self._p2p_location].count(
+                indexer_loss_overlap._p2p_issued_hook
+            ),
+            1,
+            "the drain was registered twice; it would run the branch twice",
+        )
+        self.assertEqual(
+            self._registry[self._location].count(
+                indexer_loss_overlap._forward_end_hook
+            ),
+            1,
+            "the fallback was registered twice",
+        )
+
+    def test_a_non_pipeline_model_is_declined(self):
+        """PP=1 never enters ``_forward_step``, so the callback would never fire.
+
+        Returning ``False`` is what makes the trainer warn and fall back to
+        ``drain_all()`` instead of silently never draining.
+        """
+        self.assertFalse(indexer_loss_overlap.register_pipeline_hooks(object()))
+        self.assertEqual(self._registry[self._location], self._saved)
+        self.assertEqual(self._registry[self._p2p_location], self._saved_p2p)
+
+    def test_an_older_paddle_registers_only_the_fallback(self):
+        """No ``P2P_ISSUED`` in the enum: keep the pre-flag behaviour, but warn.
+
+        Correct, un-overlapped. The alternative -- refusing to register at all --
+        would silently stop supervising the indexer on any Paddle that predates
+        the hook location. The warning is the only signal the user gets that the
+        flag buys nothing here, so it is part of the contract.
+        """
+        import paddle.distributed.fleet.meta_parallel.pipeline_parallel as pp
+
+        class _OldLocations:
+            FORWARD_END = self._location
+
+        with (
+            mock.patch.object(
+                pp, "PipelineParallelMicroStepLocations", _OldLocations
+            ),
+            self.assertLogs(
+                indexer_loss_overlap.logger, level="WARNING"
+            ) as logs,
+        ):
+            self.assertTrue(
+                indexer_loss_overlap.register_pipeline_hooks(
+                    self._fake_pp_model()
+                )
+            )
+        self.assertIn("P2P_ISSUED", "\n".join(logs.output))
+        self.assertIn(
+            indexer_loss_overlap._forward_end_hook,
+            self._registry[self._location],
+        )
+        self.assertNotIn(
+            indexer_loss_overlap._p2p_issued_hook,
+            self._registry[self._p2p_location],
+        )
+
+    def test_no_micro_step_callbacks_at_all_declines(self):
+        """A Paddle without the callback machinery falls back to ``drain_all``."""
+        with mock.patch.dict(
+            sys.modules,
+            {"paddle.distributed.fleet.meta_parallel.pipeline_parallel": None},
+        ):
+            self.assertFalse(
+                indexer_loss_overlap.register_pipeline_hooks(
+                    self._fake_pp_model()
+                )
+            )
+        self.assertFalse(indexer_loss_overlap._HOOKS_REGISTERED)
+
+    def _enqueue_recording(self):
+        ran = []
+
+        class _RecordingOwner:
+            def _run_indexer_loss_branch(self, work):
+                ran.append(work)
+
+        work = object.__new__(indexer_loss_overlap._PendingWork)
+        work.owner = _RecordingOwner()
+        indexer_loss_overlap.enqueue(work)
+        return ran
+
+    def test_the_p2p_callback_drains_and_is_counted(self):
+        """``on_location`` must reach the queue through Paddle's own dispatch.
+
+        Driven with the keywords the schedule actually passes, so a hook
+        signature that could not accept them would fail here.
+        """
+        from paddle.distributed.fleet.meta_parallel.pipeline_parallel import (
+            pipeline_parallel_callbacks_,
+        )
+
+        indexer_loss_overlap.register_pipeline_hooks(self._fake_pp_model())
+        ran = self._enqueue_recording()
+        before = indexer_loss_overlap.stats()
+
+        pipeline_parallel_callbacks_.on_location(
+            self._p2p_location,
+            output_tensor=None,
+            step_id=0,
+        )
+
+        self.assertEqual(len(ran), 1)
+        self.assertEqual(indexer_loss_overlap.pending(), 0)
+        self.assertEqual(
+            indexer_loss_overlap.stats()["drained_in_hook"],
+            before["drained_in_hook"] + 1,
+        )
+        self.assertEqual(
+            indexer_loss_overlap.stats()["drained_in_p2p_window"],
+            before["drained_in_p2p_window"] + 1,
+        )
+
+    def test_forward_end_drains_until_the_p2p_window_appears(self):
+        """A schedule that raises no ``P2P_ISSUED`` must still get its gradient.
+
+        The fallback is armed at first, so the very first micro-step drains at
+        ``FORWARD_END`` (correct, un-overlapped); once ``P2P_ISSUED`` has fired
+        the fallback must stand down, otherwise it would drain before the p2p is
+        issued and the overlap would never happen.
+        """
+        from paddle.distributed.fleet.meta_parallel.pipeline_parallel import (
+            pipeline_parallel_callbacks_,
+        )
+
+        indexer_loss_overlap.register_pipeline_hooks(self._fake_pp_model())
+
+        armed = self._enqueue_recording()
+        pipeline_parallel_callbacks_.on_location(
+            self._location, input_tensor=None, output_tensor=None, step_id=0
+        )
+        self.assertEqual(len(armed), 1, "fallback did not drain while armed")
+        self.assertEqual(
+            indexer_loss_overlap.stats()["drained_in_p2p_window"],
+            0,
+            "a FORWARD_END drain must not be counted as an overlapped one",
+        )
+
+        pipeline_parallel_callbacks_.on_location(
+            self._p2p_location, output_tensor=None, step_id=0
+        )
+        self.assertTrue(indexer_loss_overlap._P2P_WINDOW_SEEN)
+
+        disarmed = self._enqueue_recording()
+        pipeline_parallel_callbacks_.on_location(
+            self._location, input_tensor=None, output_tensor=None, step_id=1
+        )
+        self.assertEqual(
+            len(disarmed), 0, "fallback still drained after P2P_ISSUED fired"
+        )
+        self.assertEqual(indexer_loss_overlap.pending(), 1)
+
+    def test_a_schedule_that_never_raises_p2p_issued_warns_once(self):
+        """The runtime half of the "no overlap window" diagnosis.
+
+        A Paddle whose enum lacks ``P2P_ISSUED`` is caught at registration, but a
+        schedule that simply never raises the location cannot be detected from
+        there. It shows up as a *second* ``FORWARD_END`` drain: had the location
+        been raised at all, it would have been raised inside the first micro-step
+        and the latch would already have disarmed the fallback.
+
+        Once only -- the fallback runs every micro-step, and a per-step warning
+        would bury the training log.
+        """
+        from paddle.distributed.fleet.meta_parallel.pipeline_parallel import (
+            pipeline_parallel_callbacks_,
+        )
+
+        indexer_loss_overlap.register_pipeline_hooks(self._fake_pp_model())
+
+        def _fallback_micro_step(step_id):
+            ran = self._enqueue_recording()
+            pipeline_parallel_callbacks_.on_location(
+                self._location,
+                input_tensor=None,
+                output_tensor=None,
+                step_id=step_id,
+            )
+            self.assertEqual(len(ran), 1, "fallback did not drain while armed")
+
+        with self.assertNoLogs(indexer_loss_overlap.logger, level="WARNING"):
+            _fallback_micro_step(0)
+
+        with self.assertLogs(
+            indexer_loss_overlap.logger, level="WARNING"
+        ) as logs:
+            _fallback_micro_step(1)
+        self.assertIn("P2P_ISSUED", "\n".join(logs.output))
+        self.assertTrue(indexer_loss_overlap._FALLBACK_WARNED)
+
+        with self.assertNoLogs(indexer_loss_overlap.logger, level="WARNING"):
+            _fallback_micro_step(2)
+
+
+@unittest.skipUnless(
+    _PARENT_REPO_AVAILABLE, "needs the erniebot parent repo for src.utils"
+)
+class TestConfigCheckRegistration(unittest.TestCase):
+    """``dsa_indexer_loss_bwd_p2p_overlap`` must be a registered YAML field.
+
+    ``ernie5/pretrain.py:1175`` runs
+    ``config_check._check_no_unregistered_provider_fields`` over the fields the
+    user actually configured and hard-errors on any that appear in neither list.
+    So without this registration the flag cannot be switched on at all -- setting
+    it in the YAML aborts startup.
+
+    It belongs in ``_KNOWN_YAML_PROVIDER_FIELDS`` (YAML) rather than
+    ``_MODEL_STRUCTURE_FIELDS`` (JSON) because it changes only *when* the branch
+    runs. The gradients and the logged KL are identical either way -- that is
+    what :class:`TestOverlapEquivalence` asserts -- so it is not part of the
+    architecture and must not end up in a checkpoint's model_config.json, where
+    it would make an overlap-on run look like a different model from an
+    overlap-off one.
+    """
+
+    def test_registered_as_a_yaml_provider_field(self):
+        _add_repo_root_to_sys_path()
+        from src.utils.config_check import (
+            _KNOWN_YAML_PROVIDER_FIELDS,
+            _MODEL_STRUCTURE_FIELDS,
+        )
+
+        self.assertIn(
+            "dsa_indexer_loss_bwd_p2p_overlap", _KNOWN_YAML_PROVIDER_FIELDS
+        )
+        self.assertNotIn(
+            "dsa_indexer_loss_bwd_p2p_overlap",
+            set(_MODEL_STRUCTURE_FIELDS),
+            "a scheduling switch must not be a model-structure field",
+        )
+
+
+class _RecordingOwner:
+    """Stands in for :class:`MQALatentAttention` in the queue-level tests.
+
+    The queue only ever calls ``_run_indexer_loss_branch``, so the plumbing can
+    be exercised without a GPU or a real layer -- which is the point: these are
+    the paths a numerics test cannot reach (an empty queue, a failing branch, a
+    postponed discard).
+    """
+
+    def __init__(self, events=None, boom=False):
+        self.events = events if events is not None else []
+        self._boom = boom
+
+    def _run_indexer_loss_branch(self, work):
+        self.events.append(("branch", work))
+        if self._boom:
+            raise RuntimeError("branch failed")
+
+
+class _FakeSpan:
+    """The ``RecomputeWithoutOutput`` span whose discard gets postponed."""
+
+    def __init__(self, events):
+        self.events = events
+
+    def discard_output_and_register_recompute(self, tensor):
+        self.events.append(("discard", tensor))
+
+
+def _fake_work(owner):
+    work = object.__new__(indexer_loss_overlap._PendingWork)
+    work.owner = owner
+    work.on_done = None
+    return work
+
+
+class _QueueIsolation(unittest.TestCase):
+    """Base class: keep the module-level queue and counters out of each other."""
+
+    def setUp(self):
+        self._saved_queue = list(indexer_loss_overlap._QUEUE)
+        indexer_loss_overlap._QUEUE.clear()
+
+    def tearDown(self):
+        indexer_loss_overlap._QUEUE.clear()
+        indexer_loss_overlap._QUEUE.extend(self._saved_queue)
+
+
+class TestQueueMechanics(_QueueIsolation):
+    """:func:`drain` and its counters, without a GPU or a real layer."""
+
+    def test_enqueue_is_counted_and_pending_reflects_the_queue(self):
+        before = indexer_loss_overlap.stats()["enqueued"]
+        self.assertEqual(indexer_loss_overlap.pending(), 0)
+        indexer_loss_overlap.enqueue(_fake_work(_RecordingOwner()))
+        self.assertEqual(indexer_loss_overlap.pending(), 1)
+        self.assertEqual(indexer_loss_overlap.stats()["enqueued"], before + 1)
+
+    def test_stats_hands_out_a_copy(self):
+        """Callers must not be able to reach in and reset the counters."""
+        snapshot = indexer_loss_overlap.stats()
+        snapshot["drained"] = -1
+        self.assertNotEqual(indexer_loss_overlap.stats()["drained"], -1)
+
+    def test_draining_an_empty_queue_is_a_no_op(self):
+        before = indexer_loss_overlap.stats()["drained"]
+        self.assertEqual(indexer_loss_overlap.drain(), 0)
+        self.assertEqual(indexer_loss_overlap.drain_all(), 0)
+        self.assertEqual(indexer_loss_overlap.stats()["drained"], before)
+
+    def test_drain_runs_every_queued_branch_once(self):
+        events = []
+        owner = _RecordingOwner(events)
+        for _ in range(3):
+            indexer_loss_overlap.enqueue(_fake_work(owner))
+        before = indexer_loss_overlap.stats()["drained"]
+
+        self.assertEqual(indexer_loss_overlap.drain(), 3)
+
+        self.assertEqual(len(events), 3)
+        self.assertEqual(indexer_loss_overlap.pending(), 0)
+        self.assertEqual(indexer_loss_overlap.stats()["drained"], before + 3)
+
+    def test_a_failing_branch_aborts_instead_of_training_unsupervised(self):
+        """Swallowing this would leave the indexer silently un-gradiented."""
+        events = []
+        work = _fake_work(_RecordingOwner(events, boom=True))
+        span = _FakeSpan(events)
+        indexer_loss_overlap.enqueue(work)
+        self.assertTrue(
+            indexer_loss_overlap.defer_discard(work.owner, span, "qkv")
+        )
+
+        with self.assertRaises(RuntimeError):
+            indexer_loss_overlap.drain()
+
+        # The discard still has to happen: it is what arms the qkv recompute
+        # hook, and dropping it would replace this error with a confusing one.
+        self.assertEqual([name for name, _ in events], ["branch", "discard"])
+        self.assertEqual(indexer_loss_overlap.pending(), 0)
+
+
+class TestDeferDiscard(_QueueIsolation):
+    """``mla_qkv_recompute``: the buffers the branch reads must outlive it.
+
+    ``MultiLatentAttention.forward`` frees query / key / value the instant
+    ``core_attention`` returns, and ``query.detach()`` is no protection because
+    Paddle's ``detach`` shares the DenseTensor impl. The deferred branch reads
+    them later in the same forward, so the discard is moved rather than skipped.
+    """
+
+    def test_nothing_pending_means_discard_immediately(self):
+        span = _FakeSpan([])
+        self.assertFalse(
+            indexer_loss_overlap.defer_discard(_RecordingOwner(), span, "qkv")
+        )
+        self.assertEqual(span.events, [])
+
+    def test_another_layers_pending_work_is_not_hijacked(self):
+        """Only the layer that just enqueued may postpone its own discard."""
+        indexer_loss_overlap.enqueue(_fake_work(_RecordingOwner()))
+        self.assertFalse(
+            indexer_loss_overlap.defer_discard(
+                _RecordingOwner(), _FakeSpan([]), "qkv"
+            )
+        )
+
+    def test_a_second_span_for_the_same_layer_is_declined(self):
+        """One ``on_done`` slot: the second span discards on the spot."""
+        work = _fake_work(_RecordingOwner())
+        indexer_loss_overlap.enqueue(work)
+        self.assertTrue(
+            indexer_loss_overlap.defer_discard(
+                work.owner, _FakeSpan([]), "first"
+            )
+        )
+        self.assertFalse(
+            indexer_loss_overlap.defer_discard(
+                work.owner, _FakeSpan([]), "second"
+            )
+        )
+
+    def test_the_discard_happens_after_the_branch_and_only_once(self):
+        events = []
+        work = _fake_work(_RecordingOwner(events))
+        span = _FakeSpan(events)
+        indexer_loss_overlap.enqueue(work)
+        self.assertTrue(
+            indexer_loss_overlap.defer_discard(work.owner, span, "qkv")
+        )
+        self.assertEqual(events, [], "discard was not postponed")
+
+        indexer_loss_overlap.drain()
+
+        self.assertEqual([name for name, _ in events], ["branch", "discard"])
+        self.assertEqual(events[1][1], "qkv")
+        # Cleared so a stray second drain cannot double-discard.
+        self.assertIsNone(work.on_done)
+
+
+class TestValidateConfig(unittest.TestCase):
+    """``validate_config`` raises on wrong, warns on merely useless."""
+
+    @staticmethod
+    def _config(**kwargs):
+        base = {
+            "dsa_indexer_loss_bwd_p2p_overlap": True,
+            "dsa_indexer_use_sparse_loss": True,
+            "overlap_p2p_comm": True,
+            "batch_p2p_comm": False,
+            # the one supported shape: pipelined DSv4-hybrid with mqa_dsa
+            # layers and a live indexer loss
+            "pipeline_model_parallel_size": 4,
+            "experimental_attention_variant": "dsv4_hybrid",
+            "hybrid_mla_attention": "mqa_dsa",
+            "csa_compress_ratios": [-2, 4, -1, -2],
+            "dsa_indexer_loss_coeff": 0.01,
+        }
+        base.update(kwargs)
+        return types.SimpleNamespace(**base)
+
+    def test_enabled_reads_the_flag(self):
+        self.assertTrue(indexer_loss_overlap.enabled(self._config()))
+        self.assertFalse(
+            indexer_loss_overlap.enabled(
+                self._config(dsa_indexer_loss_bwd_p2p_overlap=False)
+            )
+        )
+        # A provider config that predates the flag must not raise.
+        self.assertFalse(indexer_loss_overlap.enabled(types.SimpleNamespace()))
+
+    def test_a_disabled_flag_skips_every_check(self):
+        """Off means off: a config that would fail all four gates is fine."""
+        indexer_loss_overlap.validate_config(
+            types.SimpleNamespace(dsa_indexer_loss_bwd_p2p_overlap=False)
+        )
+        indexer_loss_overlap.validate_config(types.SimpleNamespace())
+
+    def test_batch_p2p_comm_only_warns(self):
+        """The send/recv runs on the calc stream: correct, just no overlap."""
+        with self.assertLogs(
+            indexer_loss_overlap.logger, level="WARNING"
+        ) as caught:
+            indexer_loss_overlap.validate_config(
+                self._config(batch_p2p_comm=True)
+            )
+        self.assertIn("nothing for it to overlap with", caught.output[0])
+
+    def test_overlap_p2p_comm_off_only_warns(self):
+        with self.assertLogs(indexer_loss_overlap.logger, level="WARNING"):
+            indexer_loss_overlap.validate_config(
+                self._config(overlap_p2p_comm=False)
+            )
+
+    def test_selective_core_attn_recompute_only_warns(self):
+        """The enqueue slips into backward, so the window is lost, not the loss.
+
+        ``recompute(self.core_attention, ...)`` is a second wrapper that the
+        layer-level ``in_recompute`` marker does not describe, so the layer takes
+        the grad-enabled row and enqueues on the replay. Still exactly once, and
+        still drained before the optimizer -- only too late to overlap.
+        """
+        for modules in (
+            ["core_attn", "mlp"],
+            {"core_attn": 4},
+        ):
+            with self.subTest(modules=modules):
+                with self.assertLogs(
+                    indexer_loss_overlap.logger, level="WARNING"
+                ) as caught:
+                    indexer_loss_overlap.validate_config(
+                        self._config(
+                            recompute_granularity="selective",
+                            recompute_modules=modules,
+                        )
+                    )
+                self.assertIn("nothing overlaps", caught.output[0])
+
+    def test_core_attn_outside_selective_is_not_flagged(self):
+        """``recompute_core_attention`` is only set under ``selective``."""
+        with self.assertNoLogs(indexer_loss_overlap.logger, level="WARNING"):
+            indexer_loss_overlap.validate_config(
+                self._config(
+                    recompute_granularity="full",
+                    recompute_modules=["core_attn"],
+                )
+            )
+        with self.assertNoLogs(indexer_loss_overlap.logger, level="WARNING"):
+            indexer_loss_overlap.validate_config(
+                self._config(
+                    recompute_granularity="selective",
+                    recompute_modules=["mlp"],
+                )
+            )
+
+    def test_the_supported_combination_is_silent(self):
+        with self.assertNoLogs(indexer_loss_overlap.logger, level="WARNING"):
+            indexer_loss_overlap.validate_config(self._config())
+
+    def test_the_warmup_phase_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "sparse"):
+            indexer_loss_overlap.validate_config(
+                self._config(dsa_indexer_use_sparse_loss=False)
+            )
+
+    def test_no_pipeline_is_rejected(self):
+        """The overlap window *is* the pipeline p2p; without one it is dead."""
+        for pp in (1, 0, None):
+            with (
+                self.subTest(pipeline_model_parallel_size=pp),
+                self.assertRaisesRegex(
+                    ValueError, "pipeline_model_parallel_size"
+                ),
+            ):
+                indexer_loss_overlap.validate_config(
+                    self._config(pipeline_model_parallel_size=pp)
+                )
+        # missing altogether (a provider config with no PP field) => default 1
+        cfg = self._config()
+        del cfg.pipeline_model_parallel_size
+        with self.assertRaisesRegex(ValueError, "pipeline"):
+            indexer_loss_overlap.validate_config(cfg)
+
+    def test_a_model_without_a_dsa_indexer_is_rejected(self):
+        """Only ``-2`` layers under ``mqa_dsa`` build a ``DSAIndexer``."""
+        dead = [
+            {"experimental_attention_variant": "mla"},
+            {"hybrid_mla_attention": "mha"},
+            {"hybrid_mla_attention": "mqa_full_causal"},
+            # CSA / HCA / window-only: an indexer, but not the DSA one
+            {"csa_compress_ratios": [4, -1, 128, 0]},
+            {"csa_compress_ratios": None},
+            {"csa_compress_ratios": []},
+        ]
+        for kwargs in dead:
+            with (
+                self.subTest(**kwargs),
+                self.assertRaisesRegex(ValueError, "DSAIndexer"),
+            ):
+                indexer_loss_overlap.validate_config(self._config(**kwargs))
+
+    def test_a_dead_loss_coefficient_is_rejected(self):
+        """``_needs_indexer_loss`` gates on coeff > 0, so 0 enqueues nothing."""
+        for coeff in (0.0, None, -1.0):
+            with (
+                self.subTest(dsa_indexer_loss_coeff=coeff),
+                self.assertRaisesRegex(ValueError, "dsa_indexer_loss_coeff"),
+            ):
+                indexer_loss_overlap.validate_config(
+                    self._config(dsa_indexer_loss_coeff=coeff)
+                )
+
+    def test_has_dsa_indexer_coerces_the_ratio_entries(self):
+        """``csa_compress_ratios`` may arrive as np.int64 from ``np.load``."""
+        cfg = self._config(csa_compress_ratios=[4.0, -2.0])
+        self.assertTrue(indexer_loss_overlap._has_dsa_indexer(cfg))
+
+
+class TestSharedGradientImplementation(unittest.TestCase):
+    """Both paths go through :func:`compute_csa_indexer_grads`.
+
+    The equivalence tests above assert the two paths agree numerically; this
+    pins the reason they cannot drift -- there is one implementation -- and
+    covers the backend guard, which no GPU path reaches.
+    """
+
+    def test_both_paths_call_the_same_function(self):
+        from paddlefleet.transformer import csa_attention, mqa_latent_attention
+
+        source = mqa_latent_attention.MQALatentAttention
+        self.assertTrue(
+            hasattr(csa_attention, "compute_csa_indexer_grads"),
+            "the shared gradient body is gone",
+        )
+        self.assertIn(
+            "compute_csa_indexer_grads",
+            source._run_indexer_loss_branch.__code__.co_names,
+            "the deferred path stopped using the shared gradient body",
+        )
+        self.assertIn(
+            "compute_csa_indexer_grads",
+            csa_attention.TileLangCSAIndexerLossAutoScaler.backward.__code__.co_names,
+            "the inline path stopped using the shared gradient body",
+        )
+
+    def test_an_unknown_backend_is_rejected(self):
+        from paddlefleet.transformer.csa_attention import (
+            compute_csa_indexer_grads,
+        )
+
+        with self.assertRaisesRegex(NotImplementedError, "flash"):
+            compute_csa_indexer_grads(
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                loss_coeff=1.0,
+                indexer_backend="flash",
+                num_rows=1.0,
+            )
+
+
+class _FakeIndexerBwd:
+    """Stands in for ``csa_indexer_bwd``, recording how it was called.
+
+    Both real kernels need SM100, and neither is what the tests below are
+    about: what they pin is the arithmetic :func:`compute_csa_indexer_grads`
+    does *around* the kernel. Returning float64 for float32 inputs also forces
+    the dtype normalisation at the end of the function.
+    """
+
+    def __init__(self):
+        self.args = None
+        self.kwargs = None
+
+    def __call__(self, index_q, weights, index_k_comp, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+        return (
+            paddle.zeros(index_q.shape, dtype="float64"),
+            paddle.zeros(weights.shape, dtype="float64"),
+            paddle.zeros(index_k_comp.shape, dtype="float64"),
+        )
+
+
+class TestSharedGradientBackends(unittest.TestCase):
+    """:func:`compute_csa_indexer_grads` around the kernel call.
+
+    Three things happen there that no kernel is involved in: ``loss_mask`` is
+    folded into what the kernel reduces, the externally-set main-loss scale is
+    forwarded (each backend expects it in a different place), and the kernel's
+    dtypes are brought back to the inputs'. The cuDNN half of that is
+    unreachable on any machine without the kernel, which is every CI runner.
+    """
+
+    _ROWS, _TOPK, _DIM = 4, 3, 8
+
+    def setUp(self):
+        from paddlefleet.transformer import csa_attention
+
+        self._csa = csa_attention
+        scaler = csa_attention.DSAIndexerLossAutoScaler
+        saved = scaler._main_loss_backward_scale
+        self.addCleanup(setattr, scaler, "_main_loss_backward_scale", saved)
+
+    def _scale(self, value):
+        self._csa.DSAIndexerLossAutoScaler._main_loss_backward_scale = value
+
+    def _call(self, backend, *, loss_mask=None, num_rows=None):
+        """Run one gradient computation; returns the stand-in and the grads."""
+        projections = [
+            paddle.zeros([self._ROWS, self._DIM], dtype="float32")
+            for _ in range(3)
+        ]
+        target = paddle.full(
+            [1, self._ROWS, self._TOPK], 1.0 / self._TOPK, dtype="float32"
+        )
+        fake = _FakeIndexerBwd()
+        ops = "cudnn_ops" if backend == "cudnn" else "tilelang_ops"
+        with mock.patch(f"paddlefleet.{ops}.csa_indexer_bwd", fake):
+            grads = self._csa.compute_csa_indexer_grads(
+                *projections,
+                target,
+                paddle.zeros_like(target),
+                paddle.zeros(target.shape, dtype="int32"),
+                loss_coeff=0.5,
+                indexer_backend=backend,
+                num_rows=num_rows,
+                loss_mask=loss_mask,
+            )
+        return fake, grads
+
+    def test_grads_come_back_in_the_dtypes_of_the_projections(self):
+        """The kernels do not promise the input dtype; the caller assumes it."""
+        for backend in ("cudnn", "tilelang"):
+            with self.subTest(backend=backend):
+                _, grads = self._call(backend)
+                for grad in grads:
+                    self.assertEqual(grad.dtype, paddle.float32)
+
+    def test_tilelang_gets_the_score_gradient_already_scaled(self):
+        """``num_rows=None`` means the kernel's own mean over every row."""
+        fake, _ = self._call("tilelang")
+        grad_scores = fake.args[-1]
+        # ``topk_probs - target`` is ``-target`` here, times
+        # ``loss_coeff / rows``.
+        expected = -0.5 / (1 * self._ROWS) / self._TOPK
+        np.testing.assert_allclose(
+            grad_scores.numpy(), np.full(grad_scores.shape, expected), rtol=1e-6
+        )
+
+    def test_a_row_mask_zeroes_that_rows_score_gradient(self):
+        mask = paddle.to_tensor([1.0, 0.0, 1.0, 0.0], dtype="float32")
+        fake, _ = self._call("tilelang", loss_mask=mask, num_rows=2.0)
+        grad_scores = fake.args[-1].numpy()
+        self.assertTrue((grad_scores[0, 1] == 0).all())
+        self.assertTrue((grad_scores[0, 3] == 0).all())
+        self.assertTrue((grad_scores[0, 0] != 0).all())
+
+    def test_a_row_mask_reaches_cudnn_through_its_two_reduction_inputs(self):
+        """cuDNN reduces ``target`` / ``topk_probs`` itself, so mask them."""
+        mask = paddle.to_tensor([1.0, 0.0, 1.0, 0.0], dtype="float32")
+        fake, _ = self._call("cudnn", loss_mask=mask, num_rows=2.0)
+        bwd_target = fake.args[0].numpy()
+        self.assertTrue((bwd_target[0, 1] == 0).all())
+        self.assertTrue((bwd_target[0, 0] != 0).all())
+        # The kernel divides by every row, so the coefficient carries the
+        # correction from that count to the valid-row count.
+        self.assertAlmostEqual(
+            fake.kwargs["loss_coeff"], 0.5 * self._ROWS / 2.0, places=6
+        )
+
+    def test_the_main_loss_scale_reaches_each_backend_its_own_way(self):
+        """Set by ``DSAIndexerLossAutoScaler`` outside this function's reach."""
+        self._scale(None)
+        self.assertIsNone(self._call("cudnn")[0].kwargs["grad_loss"])
+
+        self._scale(4.0)
+        as_tensor = self._call("cudnn")[0].kwargs["grad_loss"]
+        self.assertEqual(float(as_tensor), 4.0)
+
+        given = paddle.to_tensor(4.0, dtype="float32")
+        self._scale(given)
+        self.assertIs(self._call("cudnn")[0].kwargs["grad_loss"], given)
+
+    def test_tilelang_folds_the_main_loss_scale_into_the_score_gradient(self):
+        """It has no ``grad_loss`` argument, so the caller applies it."""
+        unscaled = self._call("tilelang")[0].args[-1].numpy()
+        self._scale(4.0)
+        scaled = self._call("tilelang")[0].args[-1].numpy()
+        np.testing.assert_allclose(scaled, unscaled * 4.0, rtol=1e-6)
+
+
+class _PredicateOwner:
+    """The three attributes ``_needs_indexer_loss`` reads."""
+
+    def __init__(self, training=True, coeff=0.01, overlap=False):
+        self.training = training
+        self.indexer_loss_coeff = coeff
+        self.indexer_loss_overlap = overlap
+
+
+class TestNeedsIndexerLoss(unittest.TestCase):
+    """Which forward pass owns the loss branch.
+
+    This predicate is what makes the loss happen exactly once per
+    ``(layer, micro-batch)`` under recompute, and the overlap inverts it: the
+    deferred branch has to be queued by the pass that runs while the pipeline is
+    in its forward phase, which is the *other* one. The whole table is checked
+    here because a GPU fixture can only ever demonstrate one row at a time.
+    """
+
+    def _needs(self, owner, in_recompute=False, grad=True):
+        from paddlefleet.transformer.mqa_latent_attention import (
+            MQALatentAttention,
+        )
+
+        with paddle.set_grad_enabled(grad):
+            return MQALatentAttention._needs_indexer_loss(owner, in_recompute)
+
+    def test_eval_and_a_zero_coefficient_switch_the_branch_off(self):
+        self.assertFalse(self._needs(_PredicateOwner(training=False)))
+        self.assertFalse(self._needs(_PredicateOwner(coeff=0.0)))
+
+    def test_the_inline_path_wants_the_grad_enabled_pass(self):
+        owner = _PredicateOwner()
+        for in_recompute in (False, True):
+            with self.subTest(in_recompute=in_recompute):
+                self.assertTrue(self._needs(owner, in_recompute, grad=True))
+                self.assertFalse(self._needs(owner, in_recompute, grad=False))
+
+    def test_a_wrapped_layer_queues_on_the_no_grad_pass(self):
+        """Its grad-enabled pass is the replay, which runs in backward."""
+        owner = _PredicateOwner(overlap=True)
+        self.assertTrue(self._needs(owner, in_recompute=True, grad=False))
+        self.assertFalse(self._needs(owner, in_recompute=True, grad=True))
+
+    def test_an_unwrapped_layer_queues_on_its_only_pass(self):
+        """Why the flag does not depend on ``recompute_granularity``."""
+        owner = _PredicateOwner(overlap=True)
+        self.assertTrue(self._needs(owner, in_recompute=False, grad=True))
+        self.assertFalse(self._needs(owner, in_recompute=False, grad=False))
+
+
+class _BranchOwner:
+    """The layer attributes ``_run_indexer_loss_branch`` reads.
+
+    The target definition and the row mask are the layer's, so they are stubbed
+    rather than reimplemented: what is under test is the reduction the branch
+    builds on top of them and the gradient hand-off that follows.
+    """
+
+    def __init__(self, loss_mask=None, valid_rows=None):
+        self.indexer_loss_coeff = 0.5
+        self.cp_size = 2
+        self.indexer_backend = "tilelang"
+        self.layer_number = 1
+        self.config = types.SimpleNamespace(num_hidden_layers=2)
+        self._loss_mask = loss_mask
+        self._valid_rows = valid_rows
+
+    def _attn_target(self, query, kv, topk_indices, lse_indexer):
+        return paddle.full(
+            topk_indices.shape, 1.0 / topk_indices.shape[-1], dtype="float32"
+        )
+
+    def _indexer_loss_mask(self, input_ids, batch, seqlen):
+        return self._loss_mask, self._valid_rows
+
+
+class TestDeferredBranchArithmetic(unittest.TestCase):
+    """``_run_indexer_loss_branch`` without the sparse forward in front of it.
+
+    The branch is reachable on its own -- that is the property the whole flag
+    rests on -- so it can be driven from a hand-built work item on any machine.
+    What the equivalence tests cannot show, because they need the kernels, is
+    where the two reductions differ and what happens to a frozen indexer.
+    """
+
+    _ROWS, _TOPK, _DIM = 4, 3, 8
+    _LAYER = 1
+    # Deliberately not uniform: a flat score row is exactly the target, and a
+    # zero KL would hide which of the two reductions ran.
+    _SCORES = [0.0, 1.0, 2.0]
+
+    def setUp(self):
+        DSAIndexerLossLoggingHelper.tracker.clear()
+        self.addCleanup(DSAIndexerLossLoggingHelper.tracker.clear)
+
+    def _kl_per_row(self):
+        """The reference value of one row of ``kl_per_pos``."""
+        exp = np.exp(self._SCORES)
+        probs = exp / exp.sum()
+        target = 1.0 / self._TOPK
+        return float(
+            (target * (np.log(target + 1e-10) - np.log(probs + 1e-10))).sum()
+        )
+
+    def _work(self, owner, frozen=False):
+        """A work item whose projections carry a one-op autograd subgraph."""
+        leaf = paddle.zeros([self._ROWS, self._DIM], dtype="float32")
+        leaf.stop_gradient = frozen
+        projections = [leaf * 2.0 for _ in range(3)]
+        scores = paddle.to_tensor(
+            [[self._SCORES] * self._ROWS], dtype="float32"
+        )
+        return leaf, indexer_loss_overlap._PendingWork(
+            owner=owner,
+            query=None,
+            kv=None,
+            lse_indexer=None,
+            topk_indices=paddle.zeros(scores.shape, dtype="int32"),
+            topk_scores=scores,
+            index_q=projections[0],
+            weights=projections[1],
+            index_k=projections[2],
+            input_ids=None,
+            batch=1,
+            seqlen=self._ROWS,
+        )
+
+    def _run(self, owner, frozen=False):
+        """Drive the branch with a stand-in for the gradient kernel.
+
+        The gradient it hands back is all-ones, so whatever reaches the leaf is
+        the projection subgraph's own contribution and nothing else.
+        """
+        from paddlefleet.transformer.mqa_latent_attention import (
+            MQALatentAttention,
+        )
+
+        leaf, work = self._work(owner, frozen=frozen)
+        calls = []
+
+        def fake_grads(index_q, weights, index_k, *args, **kwargs):
+            calls.append(kwargs)
+            return tuple(
+                paddle.ones(t.shape, dtype=t.dtype)
+                for t in (index_q, weights, index_k)
+            )
+
+        with mock.patch(
+            "paddlefleet.transformer.csa_attention.compute_csa_indexer_grads",
+            fake_grads,
+        ):
+            MQALatentAttention._run_indexer_loss_branch(owner, work)
+        return leaf, calls[0]
+
+    def _logged(self):
+        return float(_logged_loss()[self._LAYER - 1])
+
+    def test_without_a_row_mask_the_loss_is_the_row_mean_over_cp(self):
+        """``cp_size`` divides here because each rank means over its own rows."""
+        owner = _BranchOwner()
+        self._run(owner)
+        expected = self._kl_per_row() * owner.indexer_loss_coeff / owner.cp_size
+        self.assertAlmostEqual(self._logged(), expected, places=5)
+
+    def test_a_row_mask_replaces_the_mean_with_a_global_row_count(self):
+        """The denominator is the count, not this rank's rows, so no ``cp_size``."""
+        owner = _BranchOwner(
+            loss_mask=paddle.to_tensor([[1.0, 0.0, 1.0, 0.0]]),
+            valid_rows=2.0,
+        )
+        self._run(owner)
+        expected = self._kl_per_row() * 2 / 2.0 * owner.indexer_loss_coeff
+        self.assertAlmostEqual(self._logged(), expected, places=5)
+
+    def test_the_mask_and_its_row_count_are_forwarded_to_the_kernel(self):
+        """The loss and the gradient must reduce over the same rows."""
+        mask = paddle.to_tensor([[1.0, 0.0, 1.0, 0.0]])
+        owner = _BranchOwner(loss_mask=mask, valid_rows=2.0)
+        _, kwargs = self._run(owner)
+        self.assertIs(kwargs["loss_mask"], mask)
+        self.assertEqual(kwargs["num_rows"], 2.0)
+        self.assertEqual(kwargs["loss_coeff"], owner.indexer_loss_coeff)
+
+    def test_the_gradient_reaches_the_indexer_projections(self):
+        """What the deferral is for: the subgraph is walked here, not in backward."""
+        leaf, _ = self._run(_BranchOwner())
+        self.assertIsNotNone(leaf.grad)
+        # Three projections, each ``leaf * 2``, each handed a gradient of ones.
+        np.testing.assert_allclose(
+            leaf.grad.numpy(), np.full(leaf.shape, 6.0), rtol=1e-6
+        )
+
+    def test_a_frozen_indexer_still_produces_the_loss(self):
+        """No subgraph to walk, and ``paddle.autograd.backward`` would raise."""
+        leaf, _ = self._run(_BranchOwner(), frozen=True)
+        self.assertIsNone(leaf.grad)
+        self.assertGreater(self._logged(), 0.0)
+
+
+class TestForwardEndFallbackLatch(_QueueIsolation):
+    """``_forward_end_hook`` on the micro-steps that have nothing to do.
+
+    Every non-pipeline forward raises ``FORWARD_END``, and most of those queued
+    nothing -- eval, a stage with no DSA layer, the flag off. The hook has to
+    stay silent there: counting them would make the second drain, which is what
+    the no-overlap warning keys on, mean nothing.
+    """
+
+    def setUp(self):
+        super().setUp()
+        for name in (
+            "_P2P_WINDOW_SEEN",
+            "_FORWARD_END_DRAINS",
+            "_FALLBACK_WARNED",
+        ):
+            self.addCleanup(
+                setattr,
+                indexer_loss_overlap,
+                name,
+                getattr(indexer_loss_overlap, name),
+            )
+        indexer_loss_overlap._P2P_WINDOW_SEEN = False
+        indexer_loss_overlap._FORWARD_END_DRAINS = 0
+
+    def test_an_empty_queue_does_not_count_as_a_fallback_drain(self):
+        before = indexer_loss_overlap.stats()["drained_in_hook"]
+        indexer_loss_overlap._forward_end_hook()
+        self.assertEqual(indexer_loss_overlap._FORWARD_END_DRAINS, 0)
+        self.assertEqual(
+            indexer_loss_overlap.stats()["drained_in_hook"], before
+        )
+
+    def test_work_left_over_is_drained_and_counted(self):
+        indexer_loss_overlap.enqueue(_fake_work(_RecordingOwner()))
+        before = indexer_loss_overlap.stats()["drained_in_hook"]
+        indexer_loss_overlap._forward_end_hook()
+        self.assertEqual(indexer_loss_overlap.pending(), 0)
+        self.assertEqual(indexer_loss_overlap._FORWARD_END_DRAINS, 1)
+        self.assertEqual(
+            indexer_loss_overlap.stats()["drained_in_hook"], before + 1
+        )
+
+    def test_the_latch_hands_the_window_over_once_it_has_been_seen(self):
+        """Draining here after that would be draining before the p2p issue."""
+        indexer_loss_overlap._P2P_WINDOW_SEEN = True
+        indexer_loss_overlap.enqueue(_fake_work(_RecordingOwner()))
+        indexer_loss_overlap._forward_end_hook()
+        self.assertEqual(indexer_loss_overlap.pending(), 1)
+
+
+@_GPU
+class TestOverlapBitwiseAlignment(unittest.TestCase):
+    """Flipping the flag must not move a bit that the kernels can keep still.
+
+    :class:`TestOverlapEquivalence` checks the two paths with ``allclose``, which
+    is the wrong instrument for this flag: the branch is *moved*, not
+    reformulated, so nothing about the arithmetic changes and a 1e-5 tolerance
+    would happily accept a real drift (a scale applied twice, one gradient
+    missing its last contribution, an extra bf16 round trip). This is the strict
+    sentinel that runs on every commit.
+
+    Two of the gradient families cannot be held to bit equality, and that is a
+    property of the kernel rather than of the flag: ``csa_indexer_bwd`` reduces
+    ``d_index_k`` with fp32 ``atomicAdd``, so everything downstream of it --
+    ``wk`` (which produces ``index_k``) and the ``k_norm`` scale/bias applied to
+    it -- lands in a different order from one launch to the next. Re-running the
+    *inline* path against itself already perturbs them, so those two go through
+    a budget instead; ``wq_b`` and ``weights_proj`` (fed by ``d_index_q`` /
+    ``d_weights``, no atomics) and the KL written to the loss tracker are
+    compared bit for bit.
+
+    The budget counts *how many* elements differ, not by how much, because that
+    is what separates the two populations. The atomics touch a small fraction of
+    a large tensor and leave the small ones alone, whereas a real drift moves
+    roughly half of *every* tensor at once. Magnitude cannot discriminate:
+    perturbing ``dsa_indexer_loss_coeff`` by a fraction of a percent stays well
+    inside the house ULP bound while changing the gradient everywhere, so a
+    tolerance loose enough to absorb the reduction noise also absorbs the bug.
+    """
+
+    # Gradients that flow through ``d_index_k``, i.e. through the fp32
+    # ``atomicAdd`` reduction; see the class docstring.
+    _ATOMIC_REDUCED = ("wk.", "k_norm.")
+
+    # Fraction of elements allowed to differ in the tensors above: several times
+    # the worst reduction noise measured on this fixture, and several times below
+    # the weakest signal a real drift produces.
+    _NOISE_BUDGET = 0.10
+
+    def setUp(self):
+        indexer_loss_overlap.drain_all()
+        DSAIndexerLossLoggingHelper.tracker.clear()
+
+    def tearDown(self):
+        indexer_loss_overlap.drain_all()
+        DSAIndexerLossLoggingHelper.tracker.clear()
+
+    def _forward(self, module, seed, in_recompute):
+        """One micro-batch. ``in_recompute=None`` means the inline path."""
+        query, key, w_v, x, qr = _make_inputs(
+            _SEQLEN, seed=seed, with_hidden=True
+        )
+        inline = in_recompute is None
+        if inline:
+            # the inline branch hangs off the layer's autograd graph, so the
+            # inputs have to be differentiable for `backward()` to reach it
+            for tensor in (query, key, x, qr):
+                tensor.stop_gradient = False
+        module.train()
+        ctx = paddle.no_grad() if in_recompute else contextlib.nullcontext()
+        extra = {} if inline else {"in_recompute": in_recompute}
+        with ctx:
+            out = module(
+                query,
+                key,
+                None,
+                None,
+                _row_end([_SEQLEN], _SEQLEN),
+                v_b_proj_weight=w_v,
+                x=x,
+                qr=qr,
+                **extra,
+            )
+        if inline:
+            out.cast("float32").sum().backward()
+        else:
+            self.assertEqual(indexer_loss_overlap.drain(), 1)
+
+    def _run(self, in_recompute, seeds, state):
+        """``(grads, logged loss)`` after ``len(seeds)`` accumulated steps."""
+        module = _build_module(
+            _sparse_config(overlap=in_recompute is not None), bf16=True
+        )
+        module.set_state_dict(state)
+        DSAIndexerLossLoggingHelper.tracker.clear()
+        for seed in seeds:
+            self._forward(module, seed, in_recompute)
+        return _indexer_grads(module), _logged_loss()
+
+    def _assert_within_noise_budget(self, actual, reference, name):
+        """Only as many elements may move as the fp32 atomics can explain."""
+        differing = int((actual != reference).sum())
+        allowed = max(8, int(self._NOISE_BUDGET * reference.size))
+        if differing <= allowed:
+            return
+        a = actual.astype("float64")
+        b = reference.astype("float64")
+        relative = float(
+            np.linalg.norm((a - b).ravel())
+            / (np.linalg.norm(b.ravel()) + 1e-45)
+        )
+        self.fail(
+            f"{name}: {differing}/{reference.size} elements "
+            f"({differing / reference.size:.2%}) differ between the inline and "
+            f"the deferred path, at most {allowed} may; relative L2 "
+            f"{relative:.3e}, max abs diff {float(np.abs(a - b).max()):.3e}. "
+            "Reordering the fp32 atomicAdd in the dK reduction only ever "
+            "touches a small fraction of the elements -- a population this "
+            "large means the two paths no longer compute the same thing."
+        )
+
+    def _assert_aligned(self, seeds):
+        state = _build_module(
+            _sparse_config(overlap=False), bf16=True
+        ).state_dict()
+
+        base_grads, base_loss = self._run(None, seeds, state)
+        self.assertTrue(base_grads, "inline path produced no indexer grads")
+        self.assertIsNotNone(base_loss, "inline path logged no KL loss")
+        strict = [
+            name
+            for name in base_grads
+            if not name.startswith(self._ATOMIC_REDUCED)
+        ]
+        # If the indexer parameters are ever renamed, `_ATOMIC_REDUCED` would
+        # start matching everything (or nothing) and this test would quietly
+        # stop asserting anything. Pin that it still splits the set.
+        self.assertTrue(
+            strict, "no gradient left to compare bit for bit -- names changed?"
+        )
+        self.assertNotEqual(
+            len(strict),
+            len(base_grads),
+            "the atomicAdd-reduced gradients disappeared -- if the kernel "
+            "stopped using fp32 atomics, drop _ATOMIC_REDUCED and make every "
+            "gradient a bitwise comparison",
+        )
+
+        for in_recompute in (True, False):
+            with self.subTest(in_recompute=in_recompute):
+                grads, loss = self._run(in_recompute, seeds, state)
+                self.assertEqual(
+                    sorted(grads),
+                    sorted(base_grads),
+                    "the deferred path touched a different set of indexer "
+                    "weights",
+                )
+                for name, reference in base_grads.items():
+                    if name in strict:
+                        self.assertTrue(
+                            np.array_equal(reference, grads[name]),
+                            f"{name}: no kernel between the two paths is "
+                            "order-dependent, so this gradient has to be bit "
+                            "identical; max abs diff "
+                            f"{float(np.abs(reference - grads[name]).max()):.3e}",
+                        )
+                    else:
+                        self._assert_within_noise_budget(
+                            grads[name], reference, name
+                        )
+                self.assertTrue(
+                    np.array_equal(base_loss, loss),
+                    "the KL written to the loss tracker differs between the "
+                    "inline and the deferred path",
+                )
+
+    def test_one_micro_batch_is_bitwise_aligned(self):
+        """The single-micro-batch case, both spellings of the deferred path."""
+        self._assert_aligned(seeds=(0,))
+
+    def test_accumulation_across_micro_batches_is_bitwise_aligned(self):
+        """Two micro-batches: the accumulation order changes, the sum must not.
+
+        With the flag off, micro-batch *i*'s indexer gradient is accumulated
+        during *i*'s backward; with it on, during *i*'s forward. The visitation
+        order over micro-batches is the same either way, so ``param.grad`` has
+        to end up holding the same bits -- this is the property that a real
+        pipeline run depends on and that a single-micro-batch test cannot see.
+        """
+        self._assert_aligned(seeds=(0, 1))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/transformer/test_inv_rope_vha_postmix_layer.py
+++ b/tests/single_card_tests/transformer/test_inv_rope_vha_postmix_layer.py
@@ -108,6 +108,18 @@ def _make_config(**overrides):
     return config
 
 
+def _force_fuse_flag(config):
+    """Turn the flag on behind ``__post_init__``'s back.
+
+    The config validation rejects the combinations below outright, because a flag
+    that can never fire is a configuration mistake rather than a mode. The
+    layer-level fallback is the second line of defence and is still worth
+    pinning, so it is reached by setting the flag after validation.
+    """
+    config.fuse_inv_rope_into_vha_postmix = True
+    return config
+
+
 def _build(config, layer_number=0):
     """Build the layer with bf16 parameters (the fused RoPE path is bf16 only)."""
     model_parallel_cuda_manual_seed(_SEED)
@@ -230,10 +242,8 @@ class TestInvRopePostmixLayerBitwise(unittest.TestCase):
 
     def test_grouped_postmix_falls_back(self) -> None:
         """grouped=True has no [nh,nh] GEMM to split, so it must not fuse."""
-        config = _make_config(
-            fuse_inv_rope_into_vha_postmix=True,
-            vha_postmix_grouped=True,
-            vha_postmix_rank=1,
+        config = _force_fuse_flag(
+            _make_config(vha_postmix_grouped=True, vha_postmix_rank=1)
         )
         attn = _build(config)
         self.assertFalse(attn._can_fuse_inv_rope_postmix(False))
@@ -244,11 +254,62 @@ class TestInvRopePostmixLayerBitwise(unittest.TestCase):
         self.assertEqual(out.shape, [1, 32, HIDDEN])
 
     def test_high_precision_rope_falls_back(self) -> None:
-        config = _make_config(
-            fuse_inv_rope_into_vha_postmix=True, high_precision_rope=True
-        )
+        config = _force_fuse_flag(_make_config(high_precision_rope=True))
         attn = _build(config)
         self.assertFalse(attn._can_fuse_inv_rope_postmix(False))
+
+    def test_the_config_rejects_a_flag_that_can_never_fire(self) -> None:
+        """The fallback is bitwise identical, so nothing else would report it."""
+        for overrides, expected in (
+            ({"vha_postmix_grouped": True, "vha_postmix_rank": 1}, "grouped"),
+            ({"high_precision_rope": True}, "high_precision_rope"),
+            ({"apply_rope_fusion": False}, "apply_rope_fusion"),
+            ({"use_vha_attention": False}, "use_vha_attention"),
+            ({"qk_pos_emb_head_dim": 0}, "qk_pos_emb_head_dim"),
+            # No DSv4HybridAttention is built at all in these two, so there is
+            # no postmix to fuse into rather than a postmix of the wrong shape.
+            (
+                {"experimental_attention_variant": None},
+                "experimental_attention_variant",
+            ),
+            ({"csa_compress_ratios": [-2] * 4}, "csa_compress_ratios"),
+        ):
+            with (
+                self.subTest(**overrides),
+                self.assertRaisesRegex(ValueError, expected),
+            ):
+                _make_config(fuse_inv_rope_into_vha_postmix=True, **overrides)
+
+    def test_selective_postmix_recompute_only_warns(self) -> None:
+        """It disables the fusion per layer, so it is a choice, not a mistake."""
+        with self.assertLogs(
+            "paddlefleet.transformer.transformer_config", level="WARNING"
+        ) as caught:
+            config = _make_config(
+                fuse_inv_rope_into_vha_postmix=True,
+                recompute_granularity="selective",
+                recompute_modules=["vha_postmix"],
+            )
+        self.assertTrue(config.fuse_inv_rope_into_vha_postmix)
+        joined = "\n".join(caught.output)
+        self.assertIn("fuse_inv_rope_into_vha_postmix", joined)
+        self.assertIn("every layer", joined)
+
+    def test_a_bounded_recompute_window_is_named_in_the_warning(self) -> None:
+        """Only the covered layers lose the fusion; the message must say which."""
+        with self.assertLogs(
+            "paddlefleet.transformer.transformer_config", level="WARNING"
+        ) as caught:
+            _make_config(
+                fuse_inv_rope_into_vha_postmix=True,
+                recompute_granularity="selective",
+                recompute_modules=["vha_postmix"],
+                recompute_num_layers=2,
+                recompute_method="block",
+            )
+        joined = "\n".join(caught.output)
+        self.assertIn("block", joined)
+        self.assertIn("2 layers", joined)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### PR Category
Performance Optimization

### PR Types
Performance

### Description

新增配置项 `dsa_indexer_loss_bwd_p2p_overlap`（默认关闭）：将 DSA indexer  KL loss 的前向与indexer反向从注意力层的内联路径中剥离，改在流水线前向 p2p 通信的空档中执行，与 NCCL send/recv 并发。实现indexer loss & 反向和send_recv通信流Overlap。

**Overlap窗口位置**

`isend` / `irecv` 在发起时即在计算流上记录 event，通信流等到该 event 才开始传输，因此发起之前入队的 kernel 都在通信的等待范围内，`FORWARD_END` 等既有回调位置无法产生重叠。可用窗口只存在于 event 记录之后、wait 之前，由 Paddle 新增的 `P2P_ISSUED` 提供（#79690 已入 develop，#79692 为 release/3.4）。

```
计算流  [chunk 前向][记录 event]        [indexer loss 前向 + 反向][wait]
通信流                    [等待 event][SendRecv ......................]
```

**能够将计算流和通信流Overlap的前提**

被延后的是一整段计算：indexer 的 q / k / weights 投影 → KL loss → 这段的反向。它之所以可以从层内挪到任意位置，是因为它在计算图上是一棵**叶子子图**——只往 indexer 自己的参数上写梯度，不向主干索取任何输入。三点保证这一性质：

- **与主干输入解耦**：`_indexer_projections` 先对 `x` / `qr` 调用 `detach` 再送入 indexer，因此 loss 的梯度不会回流到 backbone 的参数。
- **不改变主干前向数值，也不在反向图中引入节点**：内联路径套在注意力层输出上的 loss PyLayer 是恒等映射，输出与不套时完全一致；开关打开后不再套该 PyLayer，反向图中不存在与 loss 相关的节点。
- **反向不依赖主干传下来的梯度**：`csa_indexer_bwd` 不读取 `grad_output`，其全部输入在该层前向结束时即已就绪，因此这段反向不必等待主干反向。

因此这段计算与主干前反向之间没有任何数据依赖，唯一的约束是在优化器读取梯度之前完成。

**队列设计**

窗口只有一处，在 chunk 的前向全部结束、p2p 发起之后；而待算的东西是分散产出的——一个 chunk 里有多少 DSA 层就有多少处产出点，每处都在各自那一层前向的中途。层不能就地开算（那就是内联路径，拿不到重叠），也无法自己等到窗口：回调由 Paddle 全局注册，与具体层之间没有调用关系，彼此都拿不到对方。两者之间因此需要一个都能访问的中转站——层把该算的东西放进去，回调在窗口打开时取出来算。

`transformer/indexer_loss_overlap.py` 就是这个中转站：一个进程级的待办列表，加两个注册到流水线上的回调。开关打开后，一个 micro-step 内的过程如下。

1. 注意力层前向走到 `MQALatentAttention._forward_sparse` 末尾——内联路径原本在这里给输出套上 loss 的 PyLayer——现在改为把该层的张量与元信息打包成一个 `_PendingWork` 追加进列表，前向输出原样返回。这一层的前向就此结束，loss 一个 kernel 都还没发出，反向图里也没有留下节点。
2. 本 chunk 余下的层继续前向，各 DSA 层依次向同一个列表追加，该 micro-step 的待办项由此攒齐。
3. chunk 前向结束，流水线发起前向 send/recv 并随即抬起 `P2P_ISSUED`。回调 `_p2p_issued_hook` 调用 `drain()`，按入队顺序取空列表，每项执行 `owner._run_indexer_loss_branch(work)`，即 loss 前向 → `paddle.autograd.backward` → 记录 loss 数值。这些 kernel 排在通信 event 之后，与 SendRecv 并行执行。
4. 每项算完立即丢掉它持有的张量引用，因此同时存活的只有一层的量，而不是整个列表的量。列表取空之后，流水线才去 wait 这次 send/recv。

配套三处机制：

- **入队判定**：`_needs_indexer_loss(in_recompute)` 保证每个 `(层, micro-batch)` 恰好入队一次。recompute 会让层前向跑两遍，需要从中挑出与回调同处一个 micro-step 的那一遍；判定按层而非按配置，因为 `first_n` / `block` 会留下未包裹的层。
- **兜底出队**：`FORWARD_END` 回调默认生效，使任何调度器下 loss 都算得出来，首次 `P2P_ISSUED` 触发后永久停用——它位于 p2p 发起之前，算得对但拿不到重叠。`drain_all()` 供不经流水线回调的路径使用（`pp_size == 1`、eval 直接调层），须早于 `hybrid_parallel_scale_param_grad`，延后算出的梯度才能得到与内联路径相同的 CP 缩放。
- **诊断**：三类拿不到窗口的情形各自告警——Paddle 枚举里没有该位置（注册时即可判定），调度器从不抬起该位置（只能在运行时判定），以及 `recompute_modules` 含 `core_attn`（core attention 自身被 recompute 包裹，入队落到反向的 replay 里）。三者都仍然恰好算一次，结果不变，只是没有重叠。

**其余改动**

- `transformer/mqa_latent_attention.py`：loss 分支抽出为 `_run_indexer_loss_branch`，按开关内联执行或入队；投影与 `w_idx` 缩放处按需 `enable_grad`，使 recompute 包裹层的 no-grad 前向仍建立反向图。
- `transformer/multi_latent_attention.py`：透传 `in_recompute`；`mla_qkv_recompute` 对 query / kv 的释放后置到分支之后。
- `transformer/transformer_config.py`：开关及生效条件校验。
- `cudnn_ops/indexer/csa_indexer_bwd_cudnn.py`：接受外部预置零的 fp32 `d_index_k`，省掉一次落在 CUDA legacy default stream 上的 `copy_`。

**顺带修复（与本开关无关）**

`fuse_inv_rope_into_vha_postmix` 此前没有任何生效条件检查。该开关不满足条件时会静默回退到未融合的 inverse RoPE + postmix，且回退结果逐位一致，因此配置写错时不报错、不告警，只是没有加速。现在在 `__post_init__` 里补上：任何一层都不可能走融合路径时（`experimental_attention_variant` 不是 `dsv4_hybrid`、`csa_compress_ratios` 全为 `-2`、无 VHA postmix、grouped postmix、未开 `apply_rope_fusion`、`high_precision_rope`、`qk_pos_emb_head_dim` 未设）直接报错并列出全部原因；`recompute_modules` 含 `'vha_postmix'` 时只按层禁用融合，给告警。

### 是否引起精度变化
否。开关开闭两侧梯度与 loss 逐位一致，由单测持续监控。其中经 `d_index_k` 的 fp32 `atomicAdd` 归约的梯度以不可复现元素占比设阈值，该不确定性源自 kernel 自身，与本开关无关。
