### PR TITLE
[Recompute] Support per-layer selective recompute via a dict config

### DIFF
--- a/src/paddlefleet/models/common/language_loss/language_loss.py
+++ b/src/paddlefleet/models/common/language_loss/language_loss.py
@@ -38,6 +38,7 @@ from paddlefleet.parallel_state import (
     get_tensor_model_parallel_world_size,
 )
 from paddlefleet.process_groups_config import ProcessGroupCollection
+from paddlefleet.recompute_utils import module_needs_recompute
 from paddlefleet.training.global_vars import get_global_training_logs
 from paddlefleet.transformer.layer import FleetLayer
 from paddlefleet.transformer.transformer_config import TransformerConfig
@@ -480,10 +481,7 @@ class LanguageLoss(FleetLayer):
             labels = ContextParallelScatterOp.apply(
                 labels, axis=1, mode=self.config.cp_balance_mode
             )
-        if (
-            self.config.recompute_modules is not None
-            and "loss_fn" in self.config.recompute_modules
-        ):
+        if module_needs_recompute("loss_fn", None, self.config):
             return recompute(self.forward_impl, logits, labels)
         return self.forward_impl(logits, labels)
 

--- a/src/paddlefleet/models/gpt/lm_head.py
+++ b/src/paddlefleet/models/gpt/lm_head.py
@@ -71,6 +71,7 @@ from paddle.distributed.flex_checkpoint.dcp.sharded_weight import (
     build_sharded_state_dict,
 )
 
+from paddlefleet.recompute_utils import module_needs_recompute
 from paddlefleet.tensor_parallel.layers import (
     ColumnParallelLinear,
     _initialize_affine_weight_cpu,
@@ -258,10 +259,7 @@ class GPTLMHead(ColumnParallelLinear):
 
             return (hidden_states, self.weight, self.bias)
 
-        if (
-            self.config.recompute_modules is not None
-            and "lm_head" in self.config.recompute_modules
-        ):
+        if module_needs_recompute("lm_head", None, self.config):
             recompute_func = super().forward
 
             def recompute_handler(hidden_states, weight):

--- a/src/paddlefleet/recompute_utils.py
+++ b/src/paddlefleet/recompute_utils.py
@@ -177,6 +177,291 @@ def need_recompute_in_first_n(layer_number, config, recompute_num_layers):
     return False
 
 
+RECOMPUTE_ALL_LAYERS = "all"
+"""Dict value meaning "every layer" (``-1`` also works)."""
+
+LAYER_AGNOSTIC_RECOMPUTE_MODULES = frozenset({"lm_head", "loss_fn"})
+"""Single-instance modules: no layer number, so a layer list is rejected."""
+
+REFINED_RECOMPUTE_MODULES = frozenset({"flash_attn", "moe_combine"})
+"""RR modules: count-based selectors always use ``first_n``."""
+
+
+def _get_module_recompute_config(module_name, config):
+    """Return whether ``module_name`` is configured, and its layer selector.
+
+    The selector is the dict value in dict mode, or the shared
+    ``config.recompute_num_layers`` in list mode.
+    """
+    recompute_modules = config.recompute_modules
+    if recompute_modules is None:
+        return False, None
+    if isinstance(recompute_modules, dict):
+        if module_name not in recompute_modules:
+            return False, None
+        return True, recompute_modules[module_name]
+    if isinstance(recompute_modules, (list, tuple, set, frozenset)):
+        if module_name not in recompute_modules:
+            return False, None
+        return True, config.recompute_num_layers
+    raise ValueError(
+        "recompute_modules must be a sequence or dict, got "
+        f"{type(recompute_modules).__name__}"
+    )
+
+
+def normalize_recompute_layer_ids(layer_selector, module_name):
+    """Validate an explicit layer-id selector and return it as a frozenset."""
+    layer_ids = set()
+    for layer_id in layer_selector:
+        if isinstance(layer_id, bool) or not isinstance(layer_id, int):
+            raise ValueError(
+                f"recompute_modules['{module_name}'] layer ids must be ints, "
+                f"got {layer_id!r}"
+            )
+        if layer_id < 0:
+            raise ValueError(
+                f"recompute_modules['{module_name}'] layer ids must be "
+                f"non-negative, got {layer_id}"
+            )
+        layer_ids.add(layer_id)
+    return frozenset(layer_ids)
+
+
+def _selector_matches_layer(
+    layer_selector,
+    layer_number,
+    config,
+    module_name,
+    defer_if_layer_unknown=False,
+):
+    """Whether ``layer_selector`` selects ``layer_number``.
+
+    Selectors: ``None`` / ``"all"`` / negative int mean every layer; a list of
+    ints means those global 0-based layer ids; a non-negative int is a layer
+    count resolved through ``config.recompute_method``.
+
+    ``layer_number`` is ``None`` for layer-agnostic modules and for MoE
+    submodules before ``set_layer_number()``. A count then means every layer.
+    A layer list raises, unless ``defer_if_layer_unknown`` says the caller will
+    ask again with a real layer number.
+    """
+    if layer_selector is None or layer_selector == RECOMPUTE_ALL_LAYERS:
+        return True
+
+    if isinstance(layer_selector, (list, tuple, set, frozenset)):
+        layer_ids = normalize_recompute_layer_ids(layer_selector, module_name)
+        if layer_number is None:
+            if defer_if_layer_unknown:
+                return False
+            raise ValueError(
+                f"recompute_modules['{module_name}'] was given an explicit "
+                f"layer list {sorted(layer_ids)}, but '{module_name}' has no "
+                "layer number to filter on. Use "
+                f"'{RECOMPUTE_ALL_LAYERS}' to enable it everywhere."
+            )
+        return layer_number in layer_ids
+
+    if isinstance(layer_selector, bool) or not isinstance(layer_selector, int):
+        raise ValueError(
+            f"recompute_modules['{module_name}'] must be an int, a list of "
+            f"layer ids, or '{RECOMPUTE_ALL_LAYERS}', got "
+            f"{layer_selector!r}"
+        )
+
+    if layer_selector < 0:
+        return True
+    if layer_number is None:
+        return True
+    if config.recompute_method == "block":
+        return need_recompute_in_block(layer_number, config, layer_selector)
+    if config.recompute_method in ("first_n", None):
+        return need_recompute_in_first_n(layer_number, config, layer_selector)
+    raise ValueError(
+        f"recompute_modules['{module_name}']={layer_selector} needs recompute_method to "
+        f"be 'first_n' or 'block', got {config.recompute_method!r}"
+    )
+
+
+_logged_recompute_decisions = set()
+
+
+def _log_recompute_decision(kind, module_name, layer_number, enabled):
+    """Log one decision, deduped: MoE resolves its flags twice."""
+    key = (kind, module_name, layer_number)
+    if key in _logged_recompute_decisions:
+        return
+    _logged_recompute_decisions.add(key)
+    layer_text = "n/a" if layer_number is None else str(layer_number)
+    logger.info(
+        f"[RECOMPUTE-DECISION] kind={kind} module={module_name} "
+        f"layer={layer_text} enabled={enabled}"
+    )
+
+
+def module_needs_recompute(
+    module_name, layer_number, config, defer_if_layer_unknown=False
+):
+    """Whether ``module_name`` should be recomputed on layer ``layer_number``.
+
+    Single entry point for every ``recompute_modules`` lookup. Only meaningful
+    under ``recompute_granularity == "selective"``; ``lm_head`` and ``loss_fn``
+    keep ignoring the granularity, as they always did.
+
+    Pass ``defer_if_layer_unknown=True`` when ``layer_number=None`` just means
+    "not yet known" and the caller will ask again: a layer list then resolves to
+    False instead of raising. MoE submodules need this.
+    """
+    module_configured, layer_selector = _get_module_recompute_config(
+        module_name, config
+    )
+    if not module_configured:
+        # Queried on every layer, so logging these would bury the real ones.
+        return False
+    if module_name in LAYER_AGNOSTIC_RECOMPUTE_MODULES:
+        # No layer to filter on; a layer list is rejected during validation.
+        _log_recompute_decision("plain", module_name, layer_number, True)
+        return True
+    enabled = _selector_matches_layer(
+        layer_selector,
+        layer_number,
+        config,
+        module_name,
+        defer_if_layer_unknown=defer_if_layer_unknown,
+    )
+    _log_recompute_decision("plain", module_name, layer_number, enabled)
+    return enabled
+
+
+def module_needs_refined_recompute(module_name, layer_number, config):
+    """Whether ``module_name`` should use refined recompute (RR) on this layer.
+
+    RR inverts the selector: selected layers keep the plain recompute path, RR
+    runs on the rest. So ``"all"`` / ``None`` / a negative count disable RR,
+    while ``0`` selects nothing and enables it everywhere; a list-mode entry
+    carries no layer info and also enables it everywhere.
+
+    Count-based selectors always resolve with ``first_n``; only ``moe_combine``
+    rejects a different ``recompute_method``, and it does so itself.
+    """
+    module_configured, layer_selector = _get_module_recompute_config(
+        module_name, config
+    )
+    if not module_configured:
+        return False
+    if not isinstance(config.recompute_modules, dict):
+        _log_recompute_decision("rr", module_name, layer_number, True)
+        return True
+    if layer_selector is None or layer_selector == RECOMPUTE_ALL_LAYERS:
+        _log_recompute_decision("rr", module_name, layer_number, False)
+        return False
+    if isinstance(layer_selector, (list, tuple, set, frozenset)):
+        layer_ids = normalize_recompute_layer_ids(layer_selector, module_name)
+        if layer_number is None:
+            raise ValueError(
+                f"recompute_modules['{module_name}'] was given an explicit "
+                f"layer list but no layer number is available"
+            )
+        enabled = layer_number not in layer_ids
+        _log_recompute_decision("rr", module_name, layer_number, enabled)
+        return enabled
+    if isinstance(layer_selector, bool) or not isinstance(layer_selector, int):
+        raise ValueError(
+            f"recompute_modules['{module_name}'] must be an int, a list of "
+            f"layer ids, or '{RECOMPUTE_ALL_LAYERS}', got {layer_selector!r}"
+        )
+    if layer_selector < 0:
+        # Same as "all"/None. Handled here because need_recompute_in_first_n
+        # selects no layer for a negative count, which would invert into "RR
+        # everywhere" -- the exact opposite.
+        _log_recompute_decision("rr", module_name, layer_number, False)
+        return False
+    enabled = not need_recompute_in_first_n(
+        layer_number, config, layer_selector
+    )
+    _log_recompute_decision("rr", module_name, layer_number, enabled)
+    return enabled
+
+
+def validate_recompute_modules(config):
+    """Structural check of ``config.recompute_modules``, run from config init.
+
+    Fails on malformed selectors and out-of-range layer ids at startup rather
+    than deep inside a layer constructor.
+    """
+    recompute_modules = config.recompute_modules
+    if recompute_modules is None:
+        return
+    if isinstance(recompute_modules, (list, tuple, set, frozenset)):
+        for module_name in recompute_modules:
+            if not isinstance(module_name, str):
+                raise ValueError(
+                    "recompute_modules entries must be str, got "
+                    f"{module_name!r}"
+                )
+        return
+    if not isinstance(recompute_modules, dict):
+        raise ValueError(
+            "recompute_modules must be a sequence or dict, got "
+            f"{type(recompute_modules).__name__}"
+        )
+
+    total_num_hidden_layers = (
+        config.num_empty_layers_add_in_head
+        + config.num_hidden_layers
+        + config.num_empty_layers_add_in_tail
+    )
+    for module_name, layer_selector in recompute_modules.items():
+        if not isinstance(module_name, str):
+            raise ValueError(
+                f"recompute_modules keys must be str, got {module_name!r}"
+            )
+        if layer_selector is None or layer_selector == RECOMPUTE_ALL_LAYERS:
+            continue
+        if isinstance(layer_selector, (list, tuple, set, frozenset)):
+            layer_ids = normalize_recompute_layer_ids(
+                layer_selector, module_name
+            )
+            if module_name in LAYER_AGNOSTIC_RECOMPUTE_MODULES:
+                raise ValueError(
+                    f"recompute_modules['{module_name}'] does not support a "
+                    f"layer list: '{module_name}' is not a per-layer module. "
+                    f"Use '{RECOMPUTE_ALL_LAYERS}'."
+                )
+            out_of_range_layer_ids = [
+                layer_id
+                for layer_id in sorted(layer_ids)
+                if layer_id >= total_num_hidden_layers
+            ]
+            if out_of_range_layer_ids:
+                raise ValueError(
+                    f"recompute_modules['{module_name}'] layer ids "
+                    f"{out_of_range_layer_ids} are "
+                    f"out of range for {total_num_hidden_layers} layers "
+                    "(global, 0-based, including empty head/tail layers)"
+                )
+            continue
+        if isinstance(layer_selector, bool) or not isinstance(
+            layer_selector, int
+        ):
+            raise ValueError(
+                f"recompute_modules['{module_name}'] must be an int, a list "
+                f"of layer ids, or '{RECOMPUTE_ALL_LAYERS}', got "
+                f"{layer_selector!r}"
+            )
+        if layer_selector >= 0 and (
+            module_name not in REFINED_RECOMPUTE_MODULES
+            and config.recompute_method not in ("first_n", "block")
+        ):
+            raise ValueError(
+                f"recompute_modules['{module_name}']={layer_selector} is a "
+                "layer count and "
+                "needs recompute_method to be 'first_n' or 'block', got "
+                f"{config.recompute_method!r}. Use a layer list to select "
+                "layers explicitly."
+            )
+
+
 def need_full_recompute(layer_number, config):
     if config.recompute_granularity == "full":
         if config.recompute_method == "uniform":

--- a/src/paddlefleet/transformer/attention.py
+++ b/src/paddlefleet/transformer/attention.py
@@ -44,8 +44,8 @@ from paddlefleet.parallel_state import (
 )
 from paddlefleet.process_groups_config import ProcessGroupCollection
 from paddlefleet.recompute_utils import (
-    need_recompute_in_block,
-    need_recompute_in_first_n,
+    module_needs_recompute,
+    module_needs_refined_recompute,
 )
 from paddlefleet.tensor_parallel import RecomputeWithoutOutput
 from paddlefleet.tensor_parallel.mappings import (
@@ -354,44 +354,9 @@ class Attention(FleetLayer, ABC):
         self.use_rr_flash_attention = False
         self.recompute_core_attention = False
         if self.config.recompute_granularity == "selective":
-            if isinstance(self.config.recompute_modules, list):
-                if self.config.recompute_num_layers is None:
-                    # selective all submodels to recompute
-                    if "core_attn" in self.config.recompute_modules:
-                        self.recompute_core_attention = True
-                else:
-                    # selective submodels in special layers to recompute
-                    assert self.config.recompute_method in ["first_n", "block"]
-                    if "core_attn" in self.config.recompute_modules:
-                        self.recompute_core_attention = (
-                            need_recompute_in_block(
-                                self.layer_number,
-                                self.config,
-                                self.config.recompute_num_layers,
-                            )
-                            if self.config.recompute_method == "block"
-                            else need_recompute_in_first_n(
-                                self.layer_number,
-                                self.config,
-                                self.config.recompute_num_layers,
-                            )
-                        )
-            elif isinstance(self.config.recompute_modules, dict):
-                assert self.config.recompute_method in ["first_n", "block"]
-                if "core_attn" in self.config.recompute_modules:
-                    self.recompute_core_attention = (
-                        need_recompute_in_block(
-                            self.layer_number,
-                            self.config,
-                            self.config.recompute_modules["core_attn"],
-                        )
-                        if self.config.recompute_method == "block"
-                        else need_recompute_in_first_n(
-                            self.layer_number,
-                            self.config,
-                            self.config.recompute_modules["core_attn"],
-                        )
-                    )
+            self.recompute_core_attention = module_needs_recompute(
+                "core_attn", self.layer_number, self.config
+            )
         if (
             self.config.recompute_modules is not None
             and "flash_attn" in self.config.recompute_modules
@@ -399,14 +364,9 @@ class Attention(FleetLayer, ABC):
             assert self.config.recompute_granularity is not None, (
                 "rr must be used when recompute is enabled"
             )
-            if isinstance(self.config.recompute_modules, list):
-                self.use_rr_flash_attention = True
-            elif isinstance(self.config.recompute_modules, dict):
-                self.use_rr_flash_attention = not need_recompute_in_first_n(
-                    self.layer_number,
-                    self.config,
-                    self.config.recompute_modules["flash_attn"],
-                )
+            self.use_rr_flash_attention = module_needs_refined_recompute(
+                "flash_attn", self.layer_number, self.config
+            )
         # Output.
         self.o_proj = build_spec_layer(
             sublayers_spec.o_proj,
@@ -423,8 +383,9 @@ class Attention(FleetLayer, ABC):
 
         self.recompute_gated_attn = (
             self.config.recompute_granularity == "selective"
-            and self.config.recompute_modules is not None
-            and "gated_attn" in self.config.recompute_modules
+            and module_needs_recompute(
+                "gated_attn", self.layer_number, self.config
+            )
         )
 
     def _post_core_attention_hook(self, core_attn_out: Tensor) -> Tensor:

--- a/src/paddlefleet/transformer/dsv4_hybrid_attention.py
+++ b/src/paddlefleet/transformer/dsv4_hybrid_attention.py
@@ -47,8 +47,7 @@ from paddlefleet.models.common.embeddings.yarn_rotary_pos_embedding import (
 )
 from paddlefleet.recompute_utils import (
     keep_indexer_grad_path,
-    need_recompute_in_block,
-    need_recompute_in_first_n,
+    module_needs_recompute,
 )
 from paddlefleet.tensor_parallel import RecomputeWithoutOutput
 from paddlefleet.transformer.attention import Attention
@@ -770,14 +769,12 @@ class DSv4HybridAttention(Attention):
 
         self.recompute_gated_attn = (
             config.recompute_granularity == "selective"
-            and config.recompute_modules is not None
-            and "gated_attn" in config.recompute_modules
+            and module_needs_recompute("gated_attn", self.layer_number, config)
         )
 
         self.recompute_full_attn = (
             config.recompute_granularity == "selective"
-            and config.recompute_modules is not None
-            and "full_attn" in config.recompute_modules
+            and module_needs_recompute("full_attn", self.layer_number, config)
         )
         self._full_attn_recompute = None
         self._gate_recompute = None
@@ -833,33 +830,12 @@ class DSv4HybridAttention(Attention):
                 default_initializer=nn.initializer.Constant(0.0),
             )
         # Selective recompute for the VHA postmix scatter chain (independently
-        # configurable via the "vha_postmix" entry in recompute_modules). Only
-        # list configuration is supported; honours recompute_num_layers +
-        # recompute_method (first_n / block) like the other selective modules.
-        modules = config.recompute_modules
-        self.recompute_vha_postmix = False
-        if config.recompute_granularity == "selective" and modules is not None:
-            if isinstance(modules, dict) and "vha_postmix" in modules:
-                raise ValueError(
-                    "recompute_modules['vha_postmix'] only supports list "
-                    "configuration"
-                )
-            if isinstance(modules, list) and "vha_postmix" in modules:
-                n = config.recompute_num_layers
-                if n is None:
-                    self.recompute_vha_postmix = True
-                elif config.recompute_method == "block":
-                    self.recompute_vha_postmix = need_recompute_in_block(
-                        self.layer_number, config, n
-                    )
-                elif config.recompute_method == "first_n":
-                    self.recompute_vha_postmix = need_recompute_in_first_n(
-                        self.layer_number, config, n
-                    )
-                else:
-                    raise ValueError(
-                        "recompute_method must be 'first_n' or 'block'"
-                    )
+        # configurable via the "vha_postmix" entry in recompute_modules),
+        # configured like every other selective submodule.
+        self.recompute_vha_postmix = (
+            config.recompute_granularity == "selective"
+            and module_needs_recompute("vha_postmix", self.layer_number, config)
+        )
 
     def forward(
         self,

--- a/src/paddlefleet/transformer/kimi_delta_attention.py
+++ b/src/paddlefleet/transformer/kimi_delta_attention.py
@@ -41,10 +41,7 @@ from paddle.distributed.flex_checkpoint.dcp.sharded_weight import (
 
 from paddlefleet.jit import jit_fuser
 from paddlefleet.process_groups_config import ProcessGroupCollection
-from paddlefleet.recompute_utils import (
-    need_recompute_in_block,
-    need_recompute_in_first_n,
-)
+from paddlefleet.recompute_utils import module_needs_recompute
 from paddlefleet.tensor_parallel import RecomputeWithoutOutput
 from paddlefleet.transformer.identity_op import IdentityOp
 from paddlefleet.transformer.layer import FleetLayer
@@ -318,27 +315,15 @@ class KimiDeltaAttention(FleetLayer):
             _FUSED_KERNEL_LOGGED = True
             log_single_rank(logger, logging.INFO, "KDA will use fused kernel")
 
-        # Selectively recompute the gated RMSNorm in backward instead of keeping
-        # its output activation around. Uses RecomputeWithoutOutput so the norm
-        # output buffer is discarded after the forward and rebuilt just before
-        # out_proj's backward needs it. Honour the same layer-range semantics as
-        # the other selective modules (Attention.core_attn / MLA.mla_qkv): a list
-        # entry with recompute_num_layers, or a dict entry whose value is the
-        # per-module layer count, restricts recompute to first_n / block layers.
-        self.recompute_rms_norm_gated = False
-        if self.config.recompute_granularity == "selective":
-            modules = self.config.recompute_modules
-            if isinstance(modules, list) and "rms_norm_gated" in modules:
-                if self.config.recompute_num_layers is None:
-                    self.recompute_rms_norm_gated = True
-                else:
-                    self.recompute_rms_norm_gated = self._need_recompute_layer(
-                        self.config.recompute_num_layers
-                    )
-            elif isinstance(modules, dict) and "rms_norm_gated" in modules:
-                self.recompute_rms_norm_gated = self._need_recompute_layer(
-                    modules["rms_norm_gated"]
-                )
+        # Recompute the gated RMSNorm in backward instead of keeping its output
+        # around: RecomputeWithoutOutput drops the buffer after the forward and
+        # rebuilds it just before out_proj's backward needs it.
+        self.recompute_rms_norm_gated = (
+            self.config.recompute_granularity == "selective"
+            and module_needs_recompute(
+                "rms_norm_gated", self.layer_number, self.config
+            )
+        )
 
         # q/k/v/beta are all sharded by head, so both head counts must divide
         # evenly; otherwise the per-tensor split sizes in forward() silently stop
@@ -475,28 +460,6 @@ class KimiDeltaAttention(FleetLayer):
         )
 
         self.reset_parameters()
-
-    def _need_recompute_layer(self, recompute_num_layers):
-        """Whether this layer_number is in the selective-recompute set.
-
-        Mirrors Attention/MLA: recompute_method picks first_n vs block, and
-        recompute_num_layers is the per-module layer count. Uses an explicit
-        raise (not assert) so an invalid method cannot silently fall through to
-        first_n under ``python -O``, which would change the recompute set.
-        """
-        if self.config.recompute_method == "block":
-            return need_recompute_in_block(
-                self.layer_number, self.config, recompute_num_layers
-            )
-        if self.config.recompute_method == "first_n":
-            return need_recompute_in_first_n(
-                self.layer_number, self.config, recompute_num_layers
-            )
-        raise ValueError(
-            "selective recompute of rms_norm_gated with a layer count requires "
-            "recompute_method to be 'first_n' or 'block', got "
-            f"{self.config.recompute_method!r}"
-        )
 
     def _build_lora_pair(self, a_spec, b_spec):
         """hidden -> gate_lora_rank (replicated) -> v_dim (column parallel)."""

--- a/src/paddlefleet/transformer/moe/moe_expert.py
+++ b/src/paddlefleet/transformer/moe/moe_expert.py
@@ -28,6 +28,7 @@ from paddle.distributed.flex_checkpoint.dcp.sharded_weight import (
 
 from paddlefleet import utils
 from paddlefleet.process_groups_config import ProcessGroupCollection
+from paddlefleet.recompute_utils import module_needs_recompute
 from paddlefleet.tensor_parallel.random import (
     get_cuda_rng_tracker,
     get_expert_parallel_rng_tracker_name,
@@ -229,14 +230,7 @@ class GroupedMLPExpert(FleetLayer):
             self.activation_func = glu
         else:
             self.activation_func = self.config.hidden_act
-        self.activation_recompute = (
-            self.config.recompute_granularity == "selective"
-            and "moe_act" in self.config.recompute_modules
-        )
-        if self.activation_recompute and self.config.fp8:
-            raise ValueError(
-                "moe_act recompute for fp8 cannot work with the legacy GroupedMLP."
-            )
+        self.update_activation_recompute(None)
 
         # No tensor parallel - full sizes
         fc1_output_size = self.intermediate_size_per_partition
@@ -283,6 +277,26 @@ class GroupedMLPExpert(FleetLayer):
                 self.config.output_layer_init_method(self.weight2)
         self.weight1.is_distributed = self.expert_parallel
         self.weight2.is_distributed = self.expert_parallel
+
+    def update_activation_recompute(self, layer_number):
+        """Resolve the ``moe_act`` flag; re-called once the layer id is known.
+
+        ``layer_number=None`` (construction time) means a count-based selector
+        resolves to every layer and a layer list to False.
+        """
+        self.activation_recompute = (
+            self.config.recompute_granularity == "selective"
+            and module_needs_recompute(
+                "moe_act",
+                layer_number,
+                self.config,
+                defer_if_layer_unknown=True,
+            )
+        )
+        if self.activation_recompute and self.config.fp8:
+            raise ValueError(
+                "moe_act recompute for fp8 cannot work with the legacy GroupedMLP."
+            )
 
     @property
     def intermediate_ep_sharded(self):

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -40,7 +40,10 @@ if TYPE_CHECKING:
     from paddlefleet.transformer.transformer_config import TransformerConfig
 
 from paddlefleet import utils
-from paddlefleet.recompute_utils import need_recompute_in_first_n
+from paddlefleet.recompute_utils import (
+    module_needs_recompute,
+    module_needs_refined_recompute,
+)
 from paddlefleet.transformer.activations import situ
 from paddlefleet.transformer.paddle_norm import WrappedPaddleNorm
 from paddlefleet.transformer.utils import profile
@@ -547,20 +550,9 @@ class MoELayer(nn.Layer):
                     f"Unsupported moe_token_dispatcher_type {self.moe_token_dispatcher_type}"
                 )
 
-        self.recompute_moe_gate_up = getattr(
-            self.config, "recompute_moe_gate_up", False
-        ) or (
-            self.config.recompute_granularity == "selective"
-            and self.config.recompute_modules is not None
-            and "moe_gate_up" in self.config.recompute_modules
-        )
-        self.recompute_moe_premute = getattr(
-            self.config, "recompute_moe_premute", False
-        ) or (
-            self.config.recompute_granularity == "selective"
-            and self.config.recompute_modules is not None
-            and "moe_premute" in self.config.recompute_modules
-        )
+        self.recompute_moe_gate_up = False
+        self.recompute_moe_premute = False
+        self._update_layer_aware_recompute()
         self.use_auto_subbatch = getattr(
             self.config, "use_auto_subbatch", False
         )
@@ -621,6 +613,43 @@ class MoELayer(nn.Layer):
 
         self.use_rr_deepep_combine = False
 
+    def _update_layer_aware_recompute(self):
+        """(Re-)resolve the selective-recompute flags that depend on the layer id.
+
+        Runs twice: ``layer_number`` only arrives via ``set_layer_number()``.
+        While it is ``None`` a count-based selector means every layer and a layer
+        list resolves to False; the second call settles both.
+        """
+        layer_number = getattr(self, "layer_number", None)
+        selective = self.config.recompute_granularity == "selective"
+        self.recompute_moe_gate_up = getattr(
+            self.config, "recompute_moe_gate_up", False
+        ) or (
+            selective
+            and module_needs_recompute(
+                "moe_gate_up",
+                layer_number,
+                self.config,
+                defer_if_layer_unknown=True,
+            )
+        )
+        self.recompute_moe_premute = getattr(
+            self.config, "recompute_moe_premute", False
+        ) or (
+            selective
+            and module_needs_recompute(
+                "moe_premute",
+                layer_number,
+                self.config,
+                defer_if_layer_unknown=True,
+            )
+        )
+        experts = getattr(self, "grouped_gemm_experts", None)
+        if experts is not None and hasattr(
+            experts, "update_activation_recompute"
+        ):
+            experts.update_activation_recompute(layer_number)
+
     def rr_recompute_update(self, in_full_recompute, in_mlp_recompute):
         if (
             self.config.recompute_modules is not None
@@ -638,26 +667,24 @@ class MoELayer(nn.Layer):
                 raise ValueError(
                     "recompute_granularity must be set when moe_combine RR is enabled."
                 )
-            if isinstance(self.config.recompute_modules, list):
-                self.use_rr_deepep_combine = True
-            elif isinstance(self.config.recompute_modules, dict):
-                # dict mode only supports first_n: uniform applies recompute to all layers
-                # (use list mode instead), block is not yet implemented but can be extended.
-                if self.config.recompute_method != "first_n":
-                    raise ValueError(
-                        "recompute_modules dict mode for moe_combine RR requires "
-                        f"recompute_method='first_n', got '{self.config.recompute_method}'."
-                    )
+            if isinstance(self.config.recompute_modules, dict):
+                spec = self.config.recompute_modules["moe_combine"]
+                # A layer count still means first_n only; a layer list carries
+                # its own layers and needs no method.
+                if isinstance(spec, int) and not isinstance(spec, bool):
+                    if spec >= 0 and self.config.recompute_method != "first_n":
+                        raise ValueError(
+                            "recompute_modules dict mode for moe_combine RR requires "
+                            f"recompute_method='first_n', got '{self.config.recompute_method}'."
+                        )
                 if not hasattr(self, "layer_number"):
                     raise ValueError(
                         "layer_number must be set before rr_recompute_update is called in dict mode. "
                         "Ensure set_layer_number() is called first."
                     )
-                self.use_rr_deepep_combine = not need_recompute_in_first_n(
-                    self.layer_number,
-                    self.config,
-                    self.config.recompute_modules["moe_combine"],
-                )
+            self.use_rr_deepep_combine = module_needs_refined_recompute(
+                "moe_combine", getattr(self, "layer_number", None), self.config
+            )
         if (
             (not in_full_recompute)
             and (not in_mlp_recompute)
@@ -1703,6 +1730,8 @@ class MoELayer(nn.Layer):
     def set_layer_number(self, layer_number, is_mtp_layer: bool = False):
         self.layer_number = layer_number
         self.is_mtp_layer = is_mtp_layer
+        # Layer id is known now; re-resolve the layer-scoped recompute flags.
+        self._update_layer_aware_recompute()
         # Assign routed-expert 'color' now that the layer number is known. This
         # is the single place color is set for experts (Paddle forbids
         # reassigning it): the MTP-shared last layer uses the no-hook color.

--- a/src/paddlefleet/transformer/multi_latent_attention.py
+++ b/src/paddlefleet/transformer/multi_latent_attention.py
@@ -49,8 +49,7 @@ from paddlefleet.parallel_state import (
 from paddlefleet.process_groups_config import ProcessGroupCollection
 from paddlefleet.recompute_utils import (
     keep_indexer_grad_path,
-    need_recompute_in_block,
-    need_recompute_in_first_n,
+    module_needs_recompute,
 )
 from paddlefleet.tensor_parallel import RecomputeWithoutOutput
 from paddlefleet.tensor_parallel.mappings import (
@@ -696,43 +695,17 @@ class MultiLatentAttention(Attention):
 
         self.recompute_gated_attn = (
             self.config.recompute_granularity == "selective"
-            and self.config.recompute_modules is not None
-            and "gated_attn" in self.config.recompute_modules
+            and module_needs_recompute(
+                "gated_attn", self.layer_number, self.config
+            )
         )
 
-        self.recompute_qkv_up_porj_and_rope = False
-        if self.config.recompute_granularity == "selective":
-            modules = self.config.recompute_modules
-            if isinstance(modules, list) and "mla_qkv_recompute" in modules:
-                self.recompute_qkv_up_porj_and_rope = (
-                    True
-                    if self.config.recompute_num_layers is None
-                    else (
-                        need_recompute_in_block(
-                            self.layer_number,
-                            self.config,
-                            self.config.recompute_num_layers,
-                        )
-                        if self.config.recompute_method == "block"
-                        else need_recompute_in_first_n(
-                            self.layer_number,
-                            self.config,
-                            self.config.recompute_num_layers,
-                        )
-                    )
-                )
-            elif isinstance(modules, dict) and "mla_qkv_recompute" in modules:
-                assert self.config.recompute_method in ["first_n", "block"]
-                num_layers = modules["mla_qkv_recompute"]
-                self.recompute_qkv_up_porj_and_rope = (
-                    need_recompute_in_block(
-                        self.layer_number, self.config, num_layers
-                    )
-                    if self.config.recompute_method == "block"
-                    else need_recompute_in_first_n(
-                        self.layer_number, self.config, num_layers
-                    )
-                )
+        self.recompute_qkv_up_porj_and_rope = (
+            self.config.recompute_granularity == "selective"
+            and module_needs_recompute(
+                "mla_qkv_recompute", self.layer_number, self.config
+            )
+        )
 
         # VHA postmix: ungrouped low-rank cross-head mixing (I + U Vᵀ) on the head
         # axis, applied to the attention output (head space) before the output
@@ -769,36 +742,15 @@ class MultiLatentAttention(Attention):
                     0.0
                 ),  # identity at init
             )
-        # Selective recompute for the VHA postmix. Only list configuration is
-        # supported; honours recompute_num_layers + recompute_method
-        # (first_n / block) like the other selective modules.
-        modules = self.config.recompute_modules
-        self.recompute_vha_postmix = False
-        if (
+        # Selective recompute for the VHA postmix, configured like every other
+        # selective submodule (list entry, or dict entry with a layer count or
+        # an explicit layer list).
+        self.recompute_vha_postmix = (
             self.config.recompute_granularity == "selective"
-            and modules is not None
-        ):
-            if isinstance(modules, dict) and "vha_postmix" in modules:
-                raise ValueError(
-                    "recompute_modules['vha_postmix'] only supports list "
-                    "configuration"
-                )
-            if isinstance(modules, list) and "vha_postmix" in modules:
-                n = self.config.recompute_num_layers
-                if n is None:
-                    self.recompute_vha_postmix = True
-                elif self.config.recompute_method == "block":
-                    self.recompute_vha_postmix = need_recompute_in_block(
-                        self.layer_number, self.config, n
-                    )
-                elif self.config.recompute_method == "first_n":
-                    self.recompute_vha_postmix = need_recompute_in_first_n(
-                        self.layer_number, self.config, n
-                    )
-                else:
-                    raise ValueError(
-                        "recompute_method must be 'first_n' or 'block'"
-                    )
+            and module_needs_recompute(
+                "vha_postmix", self.layer_number, self.config
+            )
+        )
 
     def _apply_vha_postmix(self, attn_out, U=None, V=None):
         # attn_out: [b, sq, nh_pp * v_head_dim] (head space, pre-gate / pre output proj).

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -26,6 +26,7 @@ from typing import TYPE_CHECKING, Literal
 import paddle.nn.functional as F
 
 from ..model_parallel_config import ModelParallelConfig
+from ..recompute_utils import validate_recompute_modules
 from ..utils import (
     get_magic_init_method,
     init_method_normal,
@@ -578,9 +579,20 @@ class TransformerConfig(ModelParallelConfig):
     'selective' activation checkpointing."""
 
     recompute_modules: list[str] | dict = None
-    """The submodules to recompute.
-    list: contains all submodule need recompute
-    dict: keys contains all submodule need recompute, value means submodule in which layers need recompute
+    """Submodules to recompute under ``recompute_granularity="selective"``.
+
+    ``list[str]``: every listed submodule shares the layers picked by
+    ``recompute_num_layers`` + ``recompute_method`` (all layers if the count is
+    None). ``dict[str, spec]``: per-submodule, where ``spec`` is ``"all"``
+    (negative int / None equivalent), a list of global 0-based layer ids
+    (empty head/tail layers included), or a count resolved through
+    ``recompute_method``::
+
+        recompute_modules: {core_attn: [0, 1, 2], mlp: 2, moe_gate_up: all}
+
+    ``flash_attn`` / ``moe_combine`` are refined-recompute entries and invert
+    the spec: selected layers keep plain recompute, RR runs on the rest.
+    ``lm_head`` / ``loss_fn`` are single instances and reject a layer list.
     """
 
     decoderlayer_act_offload_settings: dict = None
@@ -1994,6 +2006,11 @@ class TransformerConfig(ModelParallelConfig):
                 raise ValueError(
                     "recompute_granularity must be one of full and selective"
                 )
+
+        # Checked outside the granularity branches: the refined-recompute
+        # entries and the lm_head / loss_fn entries are also read under
+        # recompute_granularity="full".
+        validate_recompute_modules(self)
 
         if self.use_truncated_normal_init or self.magic_init:
             self.output_layer_init_method = self.init_method

--- a/src/paddlefleet/transformer/transformer_layer.py
+++ b/src/paddlefleet/transformer/transformer_layer.py
@@ -39,9 +39,8 @@ from paddlefleet.process_groups_config import ProcessGroupCollection
 from paddlefleet.recompute_utils import (
     has_recovered,
     keep_indexer_grad_path,
+    module_needs_recompute,
     need_full_recompute,
-    need_recompute_in_block,
-    need_recompute_in_first_n,
 )
 from paddlefleet.tensor_parallel import RecomputeWithoutOutput
 from paddlefleet.transformer.dsv4_hybrid_attention import DSv4HybridAttention
@@ -351,92 +350,18 @@ class TransformerLayer(nn.Layer):
                 self.layer_number, self.config
             )
         elif self.config.recompute_granularity == "selective":
-            if isinstance(self.config.recompute_modules, list):
-                if self.config.recompute_num_layers is None:
-                    # selective all submodels to recompute
-                    if "norm" in self.config.recompute_modules:
-                        if not isinstance(self.input_layernorm, IdentityOp):
-                            self.recompute_input_layernorm = True
-
-                        if not isinstance(
-                            self.post_attention_layernorm, IdentityOp
-                        ):
-                            self.recompute_post_attention_layernorm = True
-                    if "mlp" in self.config.recompute_modules:
-                        self.recompute_mlp = True
-                else:
-                    # selective submodels in special layers to recompute
-                    assert self.config.recompute_method in ["first_n", "block"]
-                    if "norm" in self.config.recompute_modules:
-                        if not isinstance(self.input_layernorm, IdentityOp):
-                            self.recompute_input_layernorm = (
-                                need_recompute_in_block(
-                                    self.layer_number,
-                                    self.config,
-                                    self.config.recompute_num_layers,
-                                )
-                                if self.config.recompute_method == "block"
-                                else need_recompute_in_first_n(
-                                    self.layer_number,
-                                    self.config,
-                                    self.config.recompute_num_layers,
-                                )
-                            )
-                            self.recompute_post_attention_layernorm = (
-                                self.recompute_input_layernorm
-                            )
-
-                    if "mlp" in self.config.recompute_modules:
-                        self.recompute_mlp = (
-                            need_recompute_in_block(
-                                self.layer_number,
-                                self.config,
-                                self.config.recompute_num_layers,
-                            )
-                            if self.config.recompute_method == "block"
-                            else need_recompute_in_first_n(
-                                self.layer_number,
-                                self.config,
-                                self.config.recompute_num_layers,
-                            )
-                        )
-            elif isinstance(self.config.recompute_modules, dict):
-                assert self.config.recompute_method in ["first_n", "block"]
-                if "norm" in self.config.recompute_modules:
-                    if not isinstance(self.input_layernorm, IdentityOp):
-                        self.recompute_input_layernorm = (
-                            need_recompute_in_block(
-                                self.layer_number,
-                                self.config,
-                                self.config.recompute_modules["norm"],
-                            )
-                            if self.config.recompute_method == "block"
-                            else need_recompute_in_first_n(
-                                self.layer_number,
-                                self.config,
-                                self.config.recompute_modules["norm"],
-                            )
-                        )
-                        self.recompute_post_attention_layernorm = (
-                            self.recompute_input_layernorm
-                        )
-
-                if "mlp" in self.config.recompute_modules:
-                    self.recompute_mlp = (
-                        need_recompute_in_block(
-                            self.layer_number,
-                            self.config,
-                            self.config.recompute_modules["mlp"],
-                        )
-                        if self.config.recompute_method == "block"
-                        else need_recompute_in_first_n(
-                            self.layer_number,
-                            self.config,
-                            self.config.recompute_modules["mlp"],
-                        )
-                    )
-            else:
-                raise ValueError("recompute_modules must be list or dict")
+            if module_needs_recompute("norm", self.layer_number, self.config):
+                # Both norms share the "norm" entry; each is skipped when it has
+                # been specialised away to an IdentityOp.
+                self.recompute_input_layernorm = not isinstance(
+                    self.input_layernorm, IdentityOp
+                )
+                self.recompute_post_attention_layernorm = not isinstance(
+                    self.post_attention_layernorm, IdentityOp
+                )
+            self.recompute_mlp = module_needs_recompute(
+                "mlp", self.layer_number, self.config
+            )
 
         # [Layer 10: Block Attention Residuals] Optional
         self.attn_res_block_size = None
@@ -1726,46 +1651,10 @@ class HyperConnectionTransformerLayer(TransformerLayer):
             doc_mask_meta_registry.register(self._docmask_meta_key)
 
         # mHC forward recompute config
-        self.recompute_mhc_forward = False
-        if (
+        self.recompute_mhc_forward = (
             config.recompute_granularity == "selective"
-            and config.recompute_modules is not None
-        ):
-            if isinstance(config.recompute_modules, list):
-                if "mhc_forward" in config.recompute_modules:
-                    if config.recompute_num_layers is None:
-                        self.recompute_mhc_forward = True
-                    else:
-                        assert config.recompute_method in ["first_n", "block"]
-                        self.recompute_mhc_forward = (
-                            need_recompute_in_block(
-                                self.layer_number,
-                                config,
-                                config.recompute_num_layers,
-                            )
-                            if config.recompute_method == "block"
-                            else need_recompute_in_first_n(
-                                self.layer_number,
-                                config,
-                                config.recompute_num_layers,
-                            )
-                        )
-            elif isinstance(config.recompute_modules, dict):
-                if "mhc_forward" in config.recompute_modules:
-                    assert config.recompute_method in ["first_n", "block"]
-                    self.recompute_mhc_forward = (
-                        need_recompute_in_block(
-                            self.layer_number,
-                            config,
-                            config.recompute_modules["mhc_forward"],
-                        )
-                        if config.recompute_method == "block"
-                        else need_recompute_in_first_n(
-                            self.layer_number,
-                            config,
-                            config.recompute_modules["mhc_forward"],
-                        )
-                    )
+            and module_needs_recompute("mhc_forward", self.layer_number, config)
+        )
 
     def _fused_h_res_h_post_bda(
         self,

--- a/tests/single_card_tests/ai_edited_test/models/test_ai_language_loss_3.py
+++ b/tests/single_card_tests/ai_edited_test/models/test_ai_language_loss_3.py
@@ -204,6 +204,8 @@ class TestLanguageLossForwardWithListLogits(unittest.TestCase):
         # the erndata packed-doc MTP branch is taken and the L+K label trim is
         # skipped.
         mock_config.use_erndata = False
+        # recompute_modules is type-checked now, so a MagicMock is rejected.
+        mock_config.recompute_modules = None
 
         loss_fn = LanguageLoss(config=mock_config)
         vocab_size = 128
@@ -245,6 +247,8 @@ class TestLanguageLossForwardWithListLogits(unittest.TestCase):
         # the erndata packed-doc MTP branch is taken and the loss demands a
         # cu_seqlens_q stash this test never provides.
         mock_config.use_erndata = False
+        # recompute_modules is type-checked now, so a MagicMock is rejected.
+        mock_config.recompute_modules = None
 
         loss_fn = LanguageLoss(config=mock_config)
         vocab_size = 128

--- a/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_router.py
+++ b/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_router.py
@@ -2104,6 +2104,9 @@ class TestMoELayerSetLayerNumberForwardsIsMtp(unittest.TestCase):
         cfg_overrides.setdefault("actual_vocab_size", 128)
         config = _make_router_config(**cfg_overrides)
         moe = MoELayer.__new__(MoELayer)
+        # set_layer_number re-resolves the layer-scoped recompute flags, which
+        # reads config.
+        moe.config = config
         moe.gate = MagicMock()
         moe.layer_number = None
         # set_layer_number now colors expert params; EP=1 makes that a no-op.

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_layer_2.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_layer_2.py
@@ -182,9 +182,11 @@ class TestMoELayerLightweightMethods(unittest.TestCase):
         self.assertTrue(MoELayer.use_fp8(model))
 
         model.gate = Gate()
-        # set_layer_number now colors expert params; MinimalMoE is not a
-        # MoELayer subclass, so stub the coloring hook out (not under test here).
+        # MinimalMoE is not a MoELayer subclass, so stub out the hooks
+        # set_layer_number calls but that are not under test here: expert param
+        # coloring and the layer-scoped recompute re-resolve.
         model._color_expert_params = lambda: None
+        model._update_layer_aware_recompute = lambda: None
         MoELayer.set_layer_number(model, 11)
         self.assertEqual(model.layer_number, 11)
         self.assertEqual(model.gate.layer_number, 11)

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_layer_7.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_moe_layer_7.py
@@ -240,6 +240,9 @@ class TestMoELayerSetLayerNumber(unittest.TestCase):
 
     def test_set_layer_number(self):
         layer = MoELayer.__new__(MoELayer)
+        # set_layer_number re-resolves the layer-scoped recompute flags, which
+        # reads config.
+        layer.config = _make_config()
         layer.gate = MagicMock()
         # set_layer_number now colors expert params; EP=1 makes that a no-op.
         layer.expert_model_parallel_size = 1
@@ -251,6 +254,7 @@ class TestMoELayerSetLayerNumber(unittest.TestCase):
 
     def test_set_layer_number_no_set_method(self):
         layer = MoELayer.__new__(MoELayer)
+        layer.config = _make_config()
         layer.gate = MagicMock()
         layer.expert_model_parallel_size = 1
         del layer.gate.set_layer_number

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_layer.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_transformer_layer.py
@@ -208,12 +208,14 @@ class TestTransformerLayerConstructor(unittest.TestCase):
         self.assertFalse(layer.recompute_mlp)
 
     def test_selective_recompute_invalid_modules(self):
-        config = _make_config(
-            recompute_granularity="selective",
-            recompute_modules="invalid",
-        )
+        # validate_recompute_modules runs from TransformerConfig.__post_init__,
+        # so a malformed recompute_modules is rejected at config init instead of
+        # deep inside the layer constructor.
         with self.assertRaises(ValueError):
-            _make_layer(config)
+            _make_config(
+                recompute_granularity="selective",
+                recompute_modules="invalid",
+            )
 
     def test_block_attention_residuals(self):
         config = _make_config(

--- a/tests/single_card_tests/test_recompute_module_spec.py
+++ b/tests/single_card_tests/test_recompute_module_spec.py
@@ -1,0 +1,342 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The ``recompute_modules`` selector grammar.
+
+Covers the shared entry points every selective-recompute submodule now goes
+through -- ``module_needs_recompute`` and its refined-recompute (RR) sibling --
+plus the startup validation in ``validate_recompute_modules``.
+"""
+
+import unittest
+
+from paddlefleet.recompute_utils import (
+    module_needs_recompute,
+    module_needs_refined_recompute,
+    validate_recompute_modules,
+)
+from paddlefleet.transformer.transformer_config import TransformerConfig
+
+
+def _config(**kwargs):
+    kwargs.setdefault("num_hidden_layers", 8)
+    kwargs.setdefault("recompute_granularity", "selective")
+    return TransformerConfig(**kwargs)
+
+
+def _hits(module_name, config, num_layers=8):
+    return [
+        layer
+        for layer in range(num_layers)
+        if module_needs_recompute(module_name, layer, config)
+    ]
+
+
+class TestListMode(unittest.TestCase):
+    """List mode keeps its historical meaning."""
+
+    def test_no_num_layers_covers_every_layer(self):
+        config = _config(recompute_modules=["mlp", "core_attn"])
+        self.assertEqual(_hits("mlp", config), list(range(8)))
+        self.assertEqual(_hits("core_attn", config), list(range(8)))
+
+    def test_absent_module_is_off(self):
+        config = _config(recompute_modules=["mlp"])
+        self.assertEqual(_hits("core_attn", config), [])
+
+    def test_num_layers_is_shared_by_every_module(self):
+        config = _config(
+            recompute_modules=["mlp", "core_attn"],
+            recompute_method="first_n",
+            recompute_num_layers=3,
+        )
+        self.assertEqual(_hits("mlp", config), [0, 1, 2])
+        self.assertEqual(_hits("core_attn", config), [0, 1, 2])
+
+    def test_block_method(self):
+        config = _config(
+            recompute_modules=["mlp"],
+            recompute_method="block",
+            recompute_num_layers=3,
+        )
+        self.assertEqual(_hits("mlp", config), [0, 1, 2])
+
+    def test_none_modules_is_off(self):
+        config = TransformerConfig(num_hidden_layers=8)
+        self.assertEqual(_hits("mlp", config), [])
+
+
+class TestDictLayerCount(unittest.TestCase):
+    """Dict mode with an int keeps the ``recompute_num_layers`` semantics."""
+
+    def test_per_module_counts(self):
+        config = _config(
+            recompute_modules={"mlp": 2, "core_attn": 5},
+            recompute_method="first_n",
+        )
+        self.assertEqual(_hits("mlp", config), [0, 1])
+        self.assertEqual(_hits("core_attn", config), [0, 1, 2, 3, 4])
+
+    def test_block_method(self):
+        config = _config(
+            recompute_modules={"mlp": 2},
+            recompute_method="block",
+        )
+        self.assertEqual(_hits("mlp", config), [0, 1])
+
+    def test_all_and_negative_mean_every_layer(self):
+        for spec in ("all", -1, None):
+            config = _config(recompute_modules={"mlp": spec})
+            self.assertEqual(
+                _hits("mlp", config), list(range(8)), f"spec={spec!r}"
+            )
+
+
+class TestDictLayerList(unittest.TestCase):
+    """The new form: an explicit set of layers, per submodule."""
+
+    def test_exact_layers(self):
+        config = _config(recompute_modules={"mlp": [0, 3, 7]})
+        self.assertEqual(_hits("mlp", config), [0, 3, 7])
+
+    def test_independent_per_module(self):
+        config = _config(
+            recompute_modules={
+                "core_attn": [0, 1],
+                "mlp": [6, 7],
+                "moe_gate_up": "all",
+            }
+        )
+        self.assertEqual(_hits("core_attn", config), [0, 1])
+        self.assertEqual(_hits("mlp", config), [6, 7])
+        self.assertEqual(_hits("moe_gate_up", config), list(range(8)))
+
+    def test_recompute_method_is_ignored(self):
+        for method in (None, "first_n", "block"):
+            config = _config(
+                recompute_modules={"mlp": [2, 4]},
+                recompute_method=method,
+            )
+            self.assertEqual(_hits("mlp", config), [2, 4], f"method={method}")
+
+    def test_empty_list_disables_every_layer(self):
+        config = _config(recompute_modules={"mlp": []})
+        self.assertEqual(_hits("mlp", config), [])
+
+    def test_tuple_and_set_are_accepted(self):
+        for spec in ((1, 2), {1, 2}):
+            config = _config(recompute_modules={"mlp": spec})
+            self.assertEqual(_hits("mlp", config), [1, 2], f"spec={spec!r}")
+
+    def test_layer_ids_are_global(self):
+        # Empty head layers shift every backbone layer id.
+        config = _config(
+            num_hidden_layers=6,
+            num_empty_layers_add_in_head=2,
+            recompute_modules={"mlp": [0, 2]},
+        )
+        self.assertEqual(_hits("mlp", config), [0, 2])
+
+
+class TestRefinedRecompute(unittest.TestCase):
+    """RR entries invert the selector: the spec picks the non-RR layers."""
+
+    def test_list_mode_enables_rr_everywhere(self):
+        config = _config(
+            recompute_modules=["flash_attn"],
+            recompute_method="first_n",
+            recompute_num_layers=3,
+        )
+        for layer in range(8):
+            self.assertTrue(
+                module_needs_refined_recompute("flash_attn", layer, config)
+            )
+
+    def test_dict_count_keeps_first_n_on_plain_recompute(self):
+        config = _config(
+            recompute_modules={"flash_attn": 3},
+            recompute_method="first_n",
+        )
+        rr = [
+            layer
+            for layer in range(8)
+            if module_needs_refined_recompute("flash_attn", layer, config)
+        ]
+        self.assertEqual(rr, [3, 4, 5, 6, 7])
+
+    def test_dict_layer_list_inverts(self):
+        config = _config(recompute_modules={"flash_attn": [0, 1]})
+        rr = [
+            layer
+            for layer in range(8)
+            if module_needs_refined_recompute("flash_attn", layer, config)
+        ]
+        self.assertEqual(rr, [2, 3, 4, 5, 6, 7])
+
+    def test_all_disables_rr(self):
+        config = _config(recompute_modules={"flash_attn": "all"})
+        for layer in range(8):
+            self.assertFalse(
+                module_needs_refined_recompute("flash_attn", layer, config)
+            )
+
+    def test_negative_count_disables_rr_like_all(self):
+        """A negative count means every layer, so RR must be off."""
+        for spec in (-1, -8):
+            config = _config(recompute_modules={"flash_attn": spec})
+            for layer in range(8):
+                self.assertFalse(
+                    module_needs_refined_recompute("flash_attn", layer, config),
+                    msg=f"flash_attn={spec} must disable RR on layer {layer}",
+                )
+
+    def test_none_disables_rr(self):
+        config = _config(recompute_modules={"flash_attn": None})
+        for layer in range(8):
+            self.assertFalse(
+                module_needs_refined_recompute("flash_attn", layer, config)
+            )
+
+    def test_zero_and_negative_are_opposites(self):
+        """``0`` selects nothing so RR covers everything; ``-1`` is the reverse."""
+        zero = _config(
+            recompute_modules={"flash_attn": 0}, recompute_method="first_n"
+        )
+        negative = _config(recompute_modules={"flash_attn": -1})
+        for layer in range(8):
+            self.assertTrue(
+                module_needs_refined_recompute("flash_attn", layer, zero)
+            )
+            self.assertFalse(
+                module_needs_refined_recompute("flash_attn", layer, negative)
+            )
+
+    def test_negative_count_is_topology_independent(self):
+        """``need_recompute_in_first_n`` gives a negative count three different
+        meanings across PP/VPP layouts; the shortcut must not."""
+        for pp, vpp in ((1, None), (2, None), (2, 2), (4, None), (4, 2)):
+            config = _config(
+                recompute_modules={"flash_attn": -1},
+                pipeline_model_parallel_size=pp,
+                virtual_pipeline_model_parallel_size=vpp,
+            )
+            for layer in range(8):
+                self.assertFalse(
+                    module_needs_refined_recompute("flash_attn", layer, config),
+                    msg=f"pp={pp} vpp={vpp} layer={layer}",
+                )
+
+    def test_negative_count_mirrors_plain_path(self):
+        """Plain and RR paths must agree on what "every layer" means."""
+        for spec in (-1, "all", None):
+            plain = _config(recompute_modules={"core_attn": spec})
+            rr = _config(recompute_modules={"flash_attn": spec})
+            for layer in range(8):
+                self.assertTrue(
+                    module_needs_recompute("core_attn", layer, plain)
+                )
+                self.assertFalse(
+                    module_needs_refined_recompute("flash_attn", layer, rr)
+                )
+
+    def test_absent_module_is_off(self):
+        config = _config(
+            recompute_modules={"mlp": 3}, recompute_method="first_n"
+        )
+        self.assertFalse(
+            module_needs_refined_recompute("flash_attn", 0, config)
+        )
+
+
+class TestLayerAgnosticModules(unittest.TestCase):
+    """``lm_head`` / ``loss_fn`` exist once per model, not once per layer."""
+
+    def test_list_mode_ignores_num_layers(self):
+        config = _config(
+            recompute_modules=["lm_head", "loss_fn"],
+            recompute_method="first_n",
+            recompute_num_layers=3,
+        )
+        self.assertTrue(module_needs_recompute("lm_head", None, config))
+        self.assertTrue(module_needs_recompute("loss_fn", None, config))
+
+    def test_all_is_accepted(self):
+        config = _config(recompute_modules={"lm_head": "all"})
+        self.assertTrue(module_needs_recompute("lm_head", None, config))
+
+    def test_layer_list_is_rejected(self):
+        with self.assertRaises(ValueError):
+            _config(recompute_modules={"lm_head": [0, 1]})
+
+
+class TestDeferredLayerNumber(unittest.TestCase):
+    """MoE submodules resolve their flags before the layer id is known."""
+
+    def test_count_spec_defaults_to_on(self):
+        config = _config(
+            recompute_modules={"moe_gate_up": 3},
+            recompute_method="first_n",
+        )
+        self.assertTrue(module_needs_recompute("moe_gate_up", None, config))
+
+    def test_layer_list_needs_a_layer_number(self):
+        config = _config(recompute_modules={"moe_gate_up": [1, 2]})
+        with self.assertRaises(ValueError):
+            module_needs_recompute("moe_gate_up", None, config)
+
+
+class TestValidation(unittest.TestCase):
+    def test_out_of_range_layer_id(self):
+        with self.assertRaises(ValueError):
+            _config(num_hidden_layers=4, recompute_modules={"mlp": [0, 4]})
+
+    def test_empty_head_layers_extend_the_range(self):
+        # 4 backbone + 2 head layers -> id 4 is now valid.
+        _config(
+            num_hidden_layers=4,
+            num_empty_layers_add_in_head=2,
+            recompute_modules={"mlp": [0, 4]},
+        )
+
+    def test_negative_layer_id(self):
+        with self.assertRaises(ValueError):
+            _config(recompute_modules={"mlp": [-1]})
+
+    def test_non_int_layer_id(self):
+        with self.assertRaises(ValueError):
+            _config(recompute_modules={"mlp": ["0"]})
+
+    def test_bad_spec_type(self):
+        with self.assertRaises(ValueError):
+            _config(recompute_modules={"mlp": "every"})
+
+    def test_count_spec_needs_a_method(self):
+        with self.assertRaises(ValueError):
+            _config(recompute_modules={"mlp": 3}, recompute_method=None)
+
+    def test_bad_container_type(self):
+        config = TransformerConfig(num_hidden_layers=8)
+        config.recompute_modules = "mlp,core_attn"
+        with self.assertRaises(ValueError):
+            validate_recompute_modules(config)
+
+    def test_list_mode_entries_must_be_str(self):
+        config = TransformerConfig(num_hidden_layers=8)
+        config.recompute_modules = [1]
+        with self.assertRaises(ValueError):
+            validate_recompute_modules(config)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/test_rr_deepep_combine_config.py
+++ b/tests/single_card_tests/test_rr_deepep_combine_config.py
@@ -337,15 +337,82 @@ class TestRRRecomputeUpdate(unittest.TestCase):
             "meaningless when neither full_recompute", str(ctx.exception)
         )
 
-    @patch("paddlefleet.transformer.moe.moe_layer.need_recompute_in_first_n")
-    def test_dict_mode_sets_flag_via_need_recompute(self, mock_need_recompute):
-        """Dict mode uses need_recompute_in_first_n to decide use_rr_deepep_combine."""
+    def test_dict_mode_negative_count_turns_rr_off(self):
+        """``moe_combine: -1`` asks for plain recompute everywhere, not RR.
+
+        Resolving it as "RR everywhere" used to trip the "meaningless" error
+        below, reporting the opposite of what was configured.
+        """
         from paddlefleet.transformer.moe.moe_layer import MoELayer
 
-        # When need_recompute_in_first_n returns False, use_rr_deepep_combine = True
-        mock_need_recompute.return_value = False
+        for spec in (-1, "all", None):
+            mock = self._make_moe_layer_mock(
+                recompute_modules={"moe_combine": spec},
+                recompute_method="uniform",
+                layer_number=0,
+            )
+            MoELayer.rr_recompute_update(
+                mock, in_full_recompute=False, in_mlp_recompute=False
+            )
+            self.assertFalse(
+                mock.use_rr_deepep_combine,
+                msg=f"moe_combine={spec!r} must leave RR off",
+            )
+
+    def test_dict_mode_zero_count_turns_rr_on(self):
+        """``moe_combine: 0`` is the opposite of a negative count."""
+        from paddlefleet.transformer.moe.moe_layer import MoELayer
+
+        mock = self._make_moe_layer_mock(
+            recompute_modules={"moe_combine": 0},
+            recompute_method="first_n",
+            layer_number=0,
+        )
+        mock.config.num_empty_layers_add_in_head = 0
+        mock.config.num_empty_layers_add_in_tail = 0
+        mock.config.num_hidden_layers = 8
+        mock.config.pipeline_model_parallel_size = 1
+        mock.config.virtual_pipeline_model_parallel_size = None
+        MoELayer.rr_recompute_update(
+            mock, in_full_recompute=True, in_mlp_recompute=False
+        )
+        self.assertTrue(mock.use_rr_deepep_combine)
+
+    @patch(
+        "paddlefleet.transformer.moe.moe_layer.module_needs_refined_recompute"
+    )
+    def test_dict_mode_sets_flag_via_need_recompute(self, mock_needs_rr):
+        """Dict mode delegates the layer decision to the shared RR helper."""
+        from paddlefleet.transformer.moe.moe_layer import MoELayer
+
+        mock_needs_rr.return_value = True
         mock = self._make_moe_layer_mock(
             recompute_modules={"moe_combine": 4}, layer_number=5
+        )
+        MoELayer.rr_recompute_update(
+            mock, in_full_recompute=True, in_mlp_recompute=False
+        )
+        self.assertTrue(mock.use_rr_deepep_combine)
+        mock_needs_rr.assert_called_once_with("moe_combine", 5, mock.config)
+
+    def test_dict_mode_layer_list_needs_no_method(self):
+        """A layer list selects the non-RR layers directly; method is unused."""
+        from paddlefleet.transformer.moe.moe_layer import MoELayer
+
+        mock = self._make_moe_layer_mock(
+            recompute_modules={"moe_combine": [5]},
+            recompute_method="uniform",
+            layer_number=5,
+        )
+        MoELayer.rr_recompute_update(
+            mock, in_full_recompute=True, in_mlp_recompute=False
+        )
+        self.assertFalse(mock.use_rr_deepep_combine)
+
+        mock = self._make_moe_layer_mock(
+            recompute_modules={"moe_combine": [5]},
+            recompute_method="uniform",
+            layer_number=6,
         )
         MoELayer.rr_recompute_update(
             mock, in_full_recompute=True, in_mlp_recompute=False

--- a/tests/single_card_tests/transformer/test_kimi_delta_attention.py
+++ b/tests/single_card_tests/transformer/test_kimi_delta_attention.py
@@ -1168,21 +1168,103 @@ class TestGatedNormRecompute(unittest.TestCase):
         # list without a count still recomputes every layer
         self.assertTrue(flag(1, ["rms_norm_gated"]))
 
-    def test_layer_count_without_valid_method_raises(self):
-        """A layer count with no first_n/block method must raise, not silently
-        fall through to first_n (which an assert would under python -O)."""
-        # recompute_method=None is accepted by the config for selective, so the
-        # guard has to live in the layer resolver itself.
-        for modules in (["rms_norm_gated"], {"rms_norm_gated": 1}):
-            overrides = {
+    def test_invalid_recompute_method_never_resolves_silently(self):
+        """An invalid recompute_method must raise, never silently pick first_n.
+
+        The config assert is stripped under ``python -O``; the resolver's raise
+        is what still catches it there.
+        """
+        with self.assertRaises((AssertionError, ValueError)):
+            _build_kda(
+                layer_number=0,
+                config_overrides={
+                    "recompute_granularity": "selective",
+                    "recompute_modules": ["rms_norm_gated"],
+                    "recompute_num_layers": 1,
+                    "recompute_method": "uniform",
+                },
+            )
+
+    def test_dict_layer_count_without_method_rejected_at_startup(self):
+        """A dict layer count needs first_n/block, checked at config init."""
+        with self.assertRaises(ValueError):
+            _build_kda(
+                layer_number=0,
+                config_overrides={
+                    "recompute_granularity": "selective",
+                    "recompute_modules": {"rms_norm_gated": 1},
+                    "recompute_method": None,
+                },
+            )
+
+    def test_method_none_resolves_as_first_n(self):
+        """recompute_method=None is a first_n alias, like every other module."""
+
+        def flag(layer_number):
+            return _build_kda(
+                layer_number=layer_number,
+                config_overrides={
+                    "recompute_granularity": "selective",
+                    "recompute_modules": ["rms_norm_gated"],
+                    "recompute_num_layers": 1,
+                    "recompute_method": None,
+                },
+            ).recompute_rms_norm_gated
+
+        self.assertTrue(flag(0))
+        self.assertFalse(flag(1))
+
+    def test_dict_selectors(self):
+        """rms_norm_gated accepts every selector the shared resolver does."""
+
+        def flag(layer_number, spec, method=None):
+            return _build_kda(
+                layer_number=layer_number,
+                config_overrides={
+                    "recompute_granularity": "selective",
+                    "recompute_modules": {"rms_norm_gated": spec},
+                    "recompute_method": method,
+                },
+            ).recompute_rms_norm_gated
+
+        # Explicit layer list: only the listed global 0-based ids, no method
+        # needed.
+        self.assertFalse(flag(0, [1]))
+        self.assertTrue(flag(1, [1]))
+        self.assertTrue(flag(0, [0, 1]))
+
+        # "all" / None / a negative count mean every layer.
+        for spec in ("all", None, -1):
+            self.assertTrue(flag(0, spec))
+            self.assertTrue(flag(1, spec))
+
+        # A layer count still honours recompute_method.
+        self.assertTrue(flag(0, 1, method="first_n"))
+        self.assertFalse(flag(1, 1, method="first_n"))
+        self.assertTrue(flag(0, 1, method="block"))
+        self.assertFalse(flag(1, 1, method="block"))
+
+    def test_non_list_sequence_entry(self):
+        """A tuple entry behaves like a list instead of silently disabling."""
+        kda = _build_kda(
+            layer_number=0,
+            config_overrides={
                 "recompute_granularity": "selective",
-                "recompute_modules": modules,
-                "recompute_method": None,
-            }
-            if isinstance(modules, list):
-                overrides["recompute_num_layers"] = 1
-            with self.assertRaises(ValueError):
-                _build_kda(layer_number=0, config_overrides=overrides)
+                "recompute_modules": ("rms_norm_gated",),
+            },
+        )
+        self.assertTrue(kda.recompute_rms_norm_gated)
+
+    def test_out_of_range_layer_id_rejected_at_startup(self):
+        """num_hidden_layers=2 here, so layer id 5 is out of range."""
+        with self.assertRaises(ValueError):
+            _build_kda(
+                layer_number=0,
+                config_overrides={
+                    "recompute_granularity": "selective",
+                    "recompute_modules": {"rms_norm_gated": [0, 5]},
+                },
+            )
 
     def _assert_matches_baseline(self, deterministic):
         paddle.seed(0)

--- a/tests/single_card_tests/transformer/test_vha_dsv4.py
+++ b/tests/single_card_tests/transformer/test_vha_dsv4.py
@@ -259,19 +259,47 @@ class TestPostmixInit(unittest.TestCase):
         )
         self.assertFalse(attn.recompute_vha_postmix)
 
-    def test_recompute_dict_config_raises(self):
-        # dict recompute_modules is rejected for vha_postmix (a valid method is
-        # supplied so the base Attention dict-assert passes and control reaches
-        # the vha_postmix guard).
-        with self.assertRaises(ValueError):
+    def test_recompute_dict_layer_count(self):
+        # dict recompute_modules now selects layers per submodule: first_n with
+        # n=1 covers layer 0 only.
+        attn = _build(
+            _make_config(
+                use_vha_attention=True,
+                recompute_granularity="selective",
+                recompute_modules={"vha_postmix": 1},
+                recompute_method="first_n",
+            ),
+            layer_number=0,
+        )
+        self.assertTrue(attn.recompute_vha_postmix)
+        attn = _build(
+            _make_config(
+                use_vha_attention=True,
+                recompute_granularity="selective",
+                recompute_modules={"vha_postmix": 1},
+                recompute_method="first_n",
+            ),
+            layer_number=1,
+        )
+        self.assertFalse(attn.recompute_vha_postmix)
+
+    def test_recompute_dict_layer_list(self):
+        # An explicit layer list needs no recompute_method.
+        cfg_kwargs = {
+            "use_vha_attention": True,
+            "recompute_granularity": "selective",
+            "recompute_modules": {"vha_postmix": [2]},
+        }
+        self.assertTrue(
             _build(
-                _make_config(
-                    use_vha_attention=True,
-                    recompute_granularity="selective",
-                    recompute_modules={"vha_postmix": 1},
-                    recompute_method="first_n",
-                )
-            )
+                _make_config(**cfg_kwargs), layer_number=2
+            ).recompute_vha_postmix
+        )
+        self.assertFalse(
+            _build(
+                _make_config(**cfg_kwargs), layer_number=1
+            ).recompute_vha_postmix
+        )
 
 
 class TestPostmixApply(unittest.TestCase):

--- a/tests/single_card_tests/transformer/test_vha_mla.py
+++ b/tests/single_card_tests/transformer/test_vha_mla.py
@@ -268,17 +268,46 @@ class TestMLAPostmixInit(unittest.TestCase):
         )
         self.assertFalse(attn.recompute_vha_postmix)
 
-    def test_recompute_dict_config_raises(self):
-        # dict recompute_modules is rejected for vha_postmix (a valid method is
-        # supplied so the base Attention dict-assert passes and control reaches
-        # the vha_postmix guard).
-        with self.assertRaises(ValueError):
+    def test_recompute_dict_layer_count(self):
+        # dict recompute_modules now selects layers per submodule: first_n with
+        # n=1 covers layer 0 only.
+        self.assertTrue(
             _build_mla(
+                layer_number=0,
                 use_vha_attention=True,
                 recompute_granularity="selective",
                 recompute_modules={"vha_postmix": 1},
                 recompute_method="first_n",
-            )
+            ).recompute_vha_postmix
+        )
+        self.assertFalse(
+            _build_mla(
+                layer_number=1,
+                use_vha_attention=True,
+                recompute_granularity="selective",
+                recompute_modules={"vha_postmix": 1},
+                recompute_method="first_n",
+            ).recompute_vha_postmix
+        )
+
+    def test_recompute_dict_layer_list(self):
+        # An explicit layer list needs no recompute_method.
+        self.assertTrue(
+            _build_mla(
+                layer_number=1,
+                use_vha_attention=True,
+                recompute_granularity="selective",
+                recompute_modules={"vha_postmix": [1]},
+            ).recompute_vha_postmix
+        )
+        self.assertFalse(
+            _build_mla(
+                layer_number=0,
+                use_vha_attention=True,
+                recompute_granularity="selective",
+                recompute_modules={"vha_postmix": [1]},
+            ).recompute_vha_postmix
+        )
 
 
 # ===========================================================================


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
`recompute_modules` 支持 dict 形式的按层配置，可以为每个 submodule 单独指定生效的 layer
示例如下：

  ```yaml
  recompute_granularity: selective
  recompute_modules:
    core_attn: [2, 3, 4]   # 显式 layer id（注意，0代表MTP层 ）
    mlp: 4                 # layer 数，按 recompute_method 解析
    moe_gate_up: all       # 所有层（-1 / null 等价）
   ```
原有的 list 形式保持不变，配置和行为都向后兼容。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
 否