### PR TITLE
[CSA] Export the DSv4 document-mask packing for the shared-metadata prebuild

### DIFF
--- a/src/paddlefleet/transformer/dsv4_hybrid_attention.py
+++ b/src/paddlefleet/transformer/dsv4_hybrid_attention.py
@@ -364,25 +364,27 @@ def _validate_dsv4_boundary_values(
             )
 
 
-def _pack_dsv4_logical_batch(
-    hidden_states: Tensor,
+def pack_dsv4_docmask(
     startend_row_indices: Tensor | None,
+    batch_size: int,
+    seqlen: int,
     *,
     cp_size: int,
     dense_mode: bool,
     max_sequence_length: int | None = None,
-) -> tuple[Tensor, Tensor | None, int, int]:
-    """Pack a logical batch into the single-sequence DSV4 representation."""
-    if len(hidden_states.shape) != 3:
-        raise ValueError(
-            "DSv4HybridAttention expects rank-3 hidden_states [B, S, H], "
-            f"got shape {hidden_states.shape}"
-        )
+) -> Tensor:
+    """Rebase a ``[b, 1, s, 1]`` document mask onto the packed ``[1, 1, b*s, 1]``.
 
-    batch_size, seqlen, _ = hidden_states.shape
-    if batch_size <= 1:
-        return hidden_states, startend_row_indices, batch_size, seqlen
+    The mask half of ``_pack_dsv4_logical_batch``, guards included, factored out
+    because the ``csa_share_docmask_meta`` prebuild has to produce exactly the
+    layout the layers will look up. A second copy of the offset arithmetic there
+    would be invisible to the registry's consistency check, which compares
+    ``(ratio, batch_size, seqlen)`` only: a drifted offset rule keeps every shape
+    right and silently serves the wrong document boundaries.
 
+    ``batch_size > 1`` is the caller's precondition -- at 1 there is nothing to
+    rebase and the mask is already in its packed form.
+    """
     if not dense_mode:
         raise NotImplementedError(
             "DSv4HybridAttention only supports batch_size > 1 in dense mode; "
@@ -432,6 +434,36 @@ def _pack_dsv4_logical_batch(
         startend_row_indices,
         batch_size * seqlen,
         "packed",
+    )
+    return startend_row_indices
+
+
+def _pack_dsv4_logical_batch(
+    hidden_states: Tensor,
+    startend_row_indices: Tensor | None,
+    *,
+    cp_size: int,
+    dense_mode: bool,
+    max_sequence_length: int | None = None,
+) -> tuple[Tensor, Tensor | None, int, int]:
+    """Pack a logical batch into the single-sequence DSV4 representation."""
+    if len(hidden_states.shape) != 3:
+        raise ValueError(
+            "DSv4HybridAttention expects rank-3 hidden_states [B, S, H], "
+            f"got shape {hidden_states.shape}"
+        )
+
+    batch_size, seqlen, _ = hidden_states.shape
+    if batch_size <= 1:
+        return hidden_states, startend_row_indices, batch_size, seqlen
+
+    startend_row_indices = pack_dsv4_docmask(
+        startend_row_indices,
+        batch_size,
+        seqlen,
+        cp_size=cp_size,
+        dense_mode=dense_mode,
+        max_sequence_length=max_sequence_length,
     )
 
     hidden_states = hidden_states.reshape([1, batch_size * seqlen, -1])

--- a/tests/single_card_tests/transformer/test_doc_mask_meta_registry.py
+++ b/tests/single_card_tests/transformer/test_doc_mask_meta_registry.py
@@ -49,6 +49,7 @@ from paddlefleet.transformer.doc_mask_meta_registry import (
 )
 from paddlefleet.transformer.dsv4_hybrid_attention import (
     DSv4HybridAttention,
+    pack_dsv4_docmask,
 )
 from paddlefleet.transformer.enums import AttnMaskType
 from paddlefleet.transformer.mqa_latent_attention import (
@@ -1162,3 +1163,60 @@ class TestLayerDocmaskSlotKwarg(unittest.TestCase):
         self.assertEqual(probe.core_attention.calls, 1)
         # the slot kwarg made it into the self-attention call (line 1920)
         self.assertEqual(fwd.call_args.kwargs["docmask_mb_idx"], 0)
+
+
+class TestPrebuildFromBatchedMicroBatch(unittest.TestCase):
+    """A ``b > 1`` micro-batch mask must be packed before it is preloaded.
+
+    The producer (the trainer's ``_docmask_meta_prebuild``) sees the micro-batch's
+    ``[b, 1, s, 1]`` mask, while the consumer looks the slot up with the shape
+    ``DSv4HybridAttention.forward`` computes after packing, ``(1, b*s)``.
+    Preloading the unpacked layout is what ``per_device_train_batch_size=4``
+    used to do, and it never reached a layer at all.
+    """
+
+    def setUp(self):
+        self.b, self.s, self.ratio = 4, 32, 4
+        self.mask = paddle.concat(
+            [_row_end([13, self.s - 13], self.s) for _ in range(self.b)]
+        )
+        doc_mask_meta_registry.begin_step(1)
+
+    def test_unpacked_preload_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "only support batch_size = 1"):
+            doc_mask_meta_registry.preload(
+                0,
+                self.ratio,
+                self.b,
+                self.s,
+                self.mask,
+                dense_mode=True,
+                mask_group=("main",),
+                window_size=WINDOW,
+            )
+
+    def test_packed_preload_is_hit_by_the_layer_shape(self):
+        packed = pack_dsv4_docmask(
+            self.mask,
+            self.b,
+            self.s,
+            cp_size=1,
+            dense_mode=True,
+            max_sequence_length=self.s,
+        )
+        total = self.b * self.s
+        doc_mask_meta_registry.preload(
+            0,
+            self.ratio,
+            1,
+            total,
+            packed,
+            dense_mode=True,
+            mask_group=("main",),
+            window_size=WINDOW,
+        )
+        meta = doc_mask_meta_registry.get(0, self.ratio, 1, total, ("main",))
+        self.assertIsNotNone(meta)
+        self.assertEqual(
+            (meta.ratio, meta.batch_size, meta.seqlen), (self.ratio, 1, total)
+        )

--- a/tests/single_card_tests/transformer/test_dsv4_document_isolation.py
+++ b/tests/single_card_tests/transformer/test_dsv4_document_isolation.py
@@ -39,6 +39,7 @@ from paddlefleet.transformer.csa_attention import (
 from paddlefleet.transformer.dsv4_hybrid_attention import (
     _pack_dsv4_logical_batch,
     _unpack_dsv4_logical_batch,
+    pack_dsv4_docmask,
 )
 from paddlefleet.transformer.transformer_config import TransformerConfig
 
@@ -866,6 +867,30 @@ class TestCompressorForwardBoundary(unittest.TestCase):
 class TestPackUnpackGuardInvariants(unittest.TestCase):
     """Test the guard/error conditions from work item 1."""
 
+    def test_guards_non_rank3_hidden_states(self):
+        # The rank check is the only guard left in _pack_dsv4_logical_batch
+        # itself; everything below it now lives in pack_dsv4_docmask.
+        startend = _make_startend_equal(2, 8)
+        for shape in ([2, 8], [2, 1, 8, 16]):
+            with self.subTest(shape=shape):
+                hs = paddle.randn(shape, dtype="bfloat16")
+                with self.assertRaisesRegex(ValueError, "rank-3"):
+                    _pack_dsv4_logical_batch(
+                        hs, startend, cp_size=1, dense_mode=True
+                    )
+
+    def test_batch_one_is_passed_through_unchanged(self):
+        # b == 1 returns before pack_dsv4_docmask: the mask is already in its
+        # packed form, so both tensors come back as the same objects.
+        startend = _make_startend_equal(1, 8)
+        hs = paddle.randn([1, 8, 16], dtype="bfloat16")
+        out_hs, out_se, b, s = _pack_dsv4_logical_batch(
+            hs, startend, cp_size=1, dense_mode=True, max_sequence_length=8
+        )
+        self.assertEqual((b, s), (1, 8))
+        self.assertIs(out_hs, hs)
+        self.assertIs(out_se, startend)
+
     def test_guards_batch_gt_one_non_dense(self):
         startend = _make_startend_equal(2, 8)
         hs = paddle.randn([2, 8, 16], dtype="bfloat16")
@@ -920,6 +945,49 @@ class TestPackUnpackGuardInvariants(unittest.TestCase):
         with self.assertRaises(ValueError):
             _pack_dsv4_logical_batch(
                 hs, startend, cp_size=1, dense_mode=True, max_sequence_length=16
+            )
+
+
+class TestPackDocmaskParity(unittest.TestCase):
+    """``pack_dsv4_docmask`` is what the layer packs with, byte for byte.
+
+    The ``csa_share_docmask_meta`` prebuild calls the standalone helper while the
+    layer reaches it through ``_pack_dsv4_logical_batch``. The registry only
+    compares ``(ratio, batch_size, seqlen)``, so a divergence in the offset rule
+    would leave every shape intact and silently serve document boundaries from
+    the wrong sample -- hence a parity test rather than a shape test.
+    """
+
+    def test_matches_logical_batch_packing(self):
+        startend = _make_startend_internal_padding([5, 8, 3, 8], 8)
+        hs = paddle.randn([4, 8, 16], dtype="bfloat16")
+        _, via_layer, _, _ = _pack_dsv4_logical_batch(
+            hs, startend, cp_size=1, dense_mode=True, max_sequence_length=8
+        )
+        via_helper = pack_dsv4_docmask(
+            startend, 4, 8, cp_size=1, dense_mode=True, max_sequence_length=8
+        )
+        self.assertEqual(list(via_helper.shape), [1, 1, 32, 1])
+        self.assertEqual(
+            via_helper.numpy().tolist(), via_layer.numpy().tolist()
+        )
+
+    def test_guards_match_layer_path(self):
+        startend = _make_startend_equal(2, 8)
+        with self.assertRaises(NotImplementedError):
+            pack_dsv4_docmask(startend, 2, 8, cp_size=1, dense_mode=False)
+        with self.assertRaises(NotImplementedError):
+            pack_dsv4_docmask(startend, 2, 8, cp_size=2, dense_mode=True)
+        with self.assertRaises(ValueError):
+            pack_dsv4_docmask(None, 2, 8, cp_size=1, dense_mode=True)
+        with self.assertRaises(ValueError):
+            pack_dsv4_docmask(
+                startend,
+                2,
+                8,
+                cp_size=1,
+                dense_mode=True,
+                max_sequence_length=16,
             )
 
 


### PR DESCRIPTION
### PR Category

Distributed Strategy

### PR Types

Improvements

### Description

`_pack_dsv4_logical_batch` rebases a `[b, 1, s, 1]` document mask onto the packed `[1, 1, b*s, 1]` single-sequence layout before `DSv4HybridAttention` builds its `CSADocMaskMetadata`. The `csa_share_docmask_meta` prebuild runs outside the layer (in the trainer, before `forward_backward_pipeline`) and has to produce exactly that layout, so the mask half of that function — guards and offset rule — is factored out as `pack_dsv4_docmask`, and `_pack_dsv4_logical_batch` now calls it.

**No behaviour change for existing callers**: the extracted code is byte-identical, the guards run in the same order, and `_pack_dsv4_logical_batch`'s signature is untouched.

Why export it instead of duplicating the arithmetic in the caller: the registry's consistency check compares `(ratio, batch_size, seqlen)` only, so a drifted offset rule would keep every shape right and silently serve document boundaries from the wrong sample. Sharing one function makes that impossible.

Same change as #1868 (release/0.4), targeting develop so the fix does not stay branch-local. `_pack_dsv4_logical_batch` is identical on both branches.

This unblocks `csa_share_docmask_meta` at `per_device_train_batch_size > 1`, which currently fails with `ValueError: only support batch_size = 1` because the prebuild passes the unpacked micro-batch mask.

Tests (`tests/single_card_tests/transformer/`):

- `TestPackDocmaskParity` — asserts the helper and `_pack_dsv4_logical_batch` agree element-wise, and that their guards match.
- `TestPrebuildFromBatchedMicroBatch` — pins the regression: preloading the unpacked `b > 1` mask is rejected by `CSADocMaskMetadata.build`, while the packed slot is hit by the `(1, b*s)` lookup the layer performs.

Verified locally on one B30Z: `test_doc_mask_meta_registry.py` 67 passed, `test_dsv4_document_isolation.py` 40 passed, `test_doc_mask_meta_cache_equivalence.py` 7 passed, `test_hybrid_mla_doc_equivalence.py` 35 passed. `pre-commit` (ruff check / ruff format / typos / copyright) clean on all three files.

### 是否引起精度变化

否
