### PR TITLE
[release/0.4] 【Execute Infrastructur】fix Csa tilelang kernel (topk128 block_i 64)

### DIFF
--- a/src/paddlefleet/tilelang_ops/attn/sparse_mqa_fwd.py
+++ b/src/paddlefleet/tilelang_ops/attn/sparse_mqa_fwd.py
@@ -155,6 +155,13 @@ def sparse_mqa_fwd(
                 for h_i, d_i in T.Parallel(H_per_block, D):
                     acc_o[h_i, d_i] = acc_o[h_i, d_i] * alpha[h_i]
 
+                # The shared-memory allocator may alias `S_shared` onto the
+                # cross-warp reduction workspace used by the reduce_max /
+                # reduce_sum above (it does for topk=128, block_I=64). Without a
+                # barrier the store below can clobber the workspace while other
+                # warps are still reading it -- a WAR race that silently
+                # corrupts `sumexp`.
+                T.sync_threads()
                 T.copy(acc_s, S_shared)
                 T.gemm(
                     S_shared, KV_shared, acc_o, policy=T.GemmWarpPolicy.FullRow


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
tilelang 在topk128 的情况下生成的kernel 没有正确的同步，导致shared_memory 复写错误。 只有在推理少于128 token的情况下会命中这个kernel , 所以之前没有发现问题

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否

Cherry-pick of #1859 to `release/0.4`.

Merged in dev: #1859  <!-- For pass CI -->