### PR TITLE
[DSA] Stop the cuDNN grad_loss guard from barriering the indexer backward

### DIFF
--- a/src/paddlefleet/cudnn_ops/indexer/_grad_loss_compat.py
+++ b/src/paddlefleet/cudnn_ops/indexer/_grad_loss_compat.py
@@ -1,0 +1,99 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Sync-free ``grad_loss`` validation for the cuDNN-frontend indexer backward.
+
+The frontend guards its ``grad_loss`` argument with
+
+    if grad_loss.numel() != 1 or grad_loss.dtype != torch.float32 or ...
+
+(``indexer_backward/api.py:38``), which is free under real torch because
+``Tensor.numel()`` returns a Python ``int``. ``paddlefleet_ops`` enables
+``paddle.enable_compat(scope={"cudnn"})`` so the frontend's ``torch.*`` calls
+resolve to Paddle, and Paddle's ``numel()`` is an *op* returning a 0-D Tensor.
+``!= 1`` therefore builds a device bool and the Python ``or`` forces
+``Tensor.__bool__``, which lowers to a blocking ``GpuMemcpySync`` on the CUDA
+*legacy default* stream.
+
+Paddle creates its compute and communication streams as blocking streams, so a
+legacy-default-stream copy is a bidirectional full-device barrier: it cannot
+retire until everything already in flight drains. Under
+``dsa_indexer_loss_bwd_p2p_overlap`` the launching thread hits this barrier
+between the deferred KL forward and ``compute_csa_indexer_grads``, and cannot
+resume until the pipeline's ``ncclDevKernel_SendRecv`` finishes -- so the whole
+indexer backward is enqueued only *after* the p2p window it was supposed to hide
+behind has closed. Measured on a 64k pp4/vpp3 profile: a 256-byte device-to-host
+copy stalling the launching thread for 35 ms and leaving the compute stream idle
+for 24.7 ms of a 28 ms send/recv.
+
+Same failure mode, and the same reason, as the ``d_index_k`` note in
+``csa_indexer_bwd``.
+
+The replacement below keeps the validation semantics byte-for-byte and only
+changes *how* the element count is obtained: ``shape`` is host metadata under
+both torch and Paddle, and the ``dtype`` / ``device`` comparisons already return
+Python bools. This shim can be dropped once the wheel picks up the equivalent
+fix in ``PFCCLab/cudnn-frontend``.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import paddle
+
+_API = "paddlefleet_ops.cudnn.deepseek_sparse_attention.indexer_backward.api"
+
+_PATCHED = False
+
+
+def _validate_grad_loss_tensor(grad_loss, device):
+    """Drop-in replacement for the frontend validator, without the host sync."""
+    if not paddle.is_tensor(grad_loss):
+        raise TypeError("grad_loss must be a torch.Tensor")
+    numel = 1
+    for dim in grad_loss.shape:
+        numel *= int(dim)
+    if (
+        numel != 1
+        or grad_loss.dtype != paddle.float32
+        or grad_loss.device != device
+    ):
+        raise ValueError(
+            f"grad_loss must be a single-element float32 tensor on {device}"
+        )
+    return grad_loss.detach().reshape([1])
+
+
+def patch_indexer_backward_api() -> None:
+    """Install the sync-free validator on the frontend module, once.
+
+    Call this right after importing from the frontend api module, so the module
+    is guaranteed to be in ``sys.modules``. The wrappers resolve
+    ``_validate_grad_loss_tensor`` as a module global at call time, so replacing
+    the attribute after the import is enough.
+
+    A no-op on wheels that predate the guard -- they expose
+    ``_as_grad_loss_tensor``, which never reads a scalar back to the host -- and
+    on a mocked api module, so this is safe across ``paddlefleet_ops`` versions.
+    """
+    global _PATCHED
+    if _PATCHED:
+        return
+    api_module = sys.modules.get(_API)
+    if api_module is not None and hasattr(
+        api_module, "_validate_grad_loss_tensor"
+    ):
+        api_module._validate_grad_loss_tensor = _validate_grad_loss_tensor
+        _PATCHED = True

--- a/src/paddlefleet/cudnn_ops/indexer/csa_indexer_bwd_cudnn.py
+++ b/src/paddlefleet/cudnn_ops/indexer/csa_indexer_bwd_cudnn.py
@@ -28,6 +28,8 @@ from __future__ import annotations
 import paddle
 from paddlefleet_ops import CUDNN_FRONTEND_HINT, is_cudnn_frontend_available
 
+from ._grad_loss_compat import patch_indexer_backward_api
+
 
 def _require_cudnn_frontend():
     if not is_cudnn_frontend_available():
@@ -109,6 +111,11 @@ def csa_indexer_bwd(
     from paddlefleet_ops.cudnn.deepseek_sparse_attention.indexer_backward.api import (
         indexer_backward_wrapper,
     )
+
+    # The frontend's ``grad_loss`` guard reads a scalar back to the host under
+    # Paddle's torch-compat proxy, which barriers the whole device. See
+    # ``_grad_loss_compat``.
+    patch_indexer_backward_api()
 
     out = indexer_backward_wrapper(
         index_q_bf,

--- a/src/paddlefleet/cudnn_ops/indexer/dense_indexer_kl_cudnn.py
+++ b/src/paddlefleet/cudnn_ops/indexer/dense_indexer_kl_cudnn.py
@@ -51,6 +51,8 @@ from __future__ import annotations
 import paddle
 from paddlefleet_ops import CUDNN_FRONTEND_HINT, is_cudnn_frontend_available
 
+from ._grad_loss_compat import patch_indexer_backward_api
+
 
 def _require_cudnn_frontend():
     if not is_cudnn_frontend_available():
@@ -198,6 +200,10 @@ def dense_indexer_kl_bwd(
     from paddlefleet_ops.cudnn.deepseek_sparse_attention.indexer_backward.api import (
         dense_indexer_backward_wrapper,
     )
+
+    # See ``_grad_loss_compat``: the frontend's ``grad_loss`` guard barriers the
+    # whole device under Paddle's torch-compat proxy.
+    patch_indexer_backward_api()
 
     if grad_loss is None:
         grad_loss = paddle.ones([], dtype=paddle.float32)

--- a/tests/single_card_tests/ai_edited_test/ops/test_ai_indexer_grad_loss_no_sync.py
+++ b/tests/single_card_tests/ai_edited_test/ops/test_ai_indexer_grad_loss_no_sync.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Coverage for the sync-free ``grad_loss`` validator shim.
+
+The point of the shim is that validating ``grad_loss`` must not read anything
+back to the host: under ``paddle.enable_compat`` a ``numel()`` comparison
+becomes a blocking ``GpuMemcpySync`` on the legacy default stream, which
+barriers the whole device and destroys the ``dsa_indexer_loss_bwd_p2p_overlap``
+window. ``test_never_calls_numel`` is the regression guard -- it makes
+``Tensor.numel`` explode, so any future rewrite that reintroduces the device
+read fails here rather than silently costing overlap.
+"""
+
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+import paddle
+
+from paddlefleet.cudnn_ops.indexer import _grad_loss_compat as mod
+
+
+class TestValidateGradLossTensor(unittest.TestCase):
+    def _device(self):
+        return paddle.ones([], dtype="float32").device
+
+    def test_accepts_zero_dim_and_one_element(self):
+        for shape in ([], [1], [1, 1]):
+            out = mod._validate_grad_loss_tensor(
+                paddle.ones(shape, dtype="float32"), self._device()
+            )
+            self.assertEqual(list(out.shape), [1])
+            self.assertEqual(out.dtype, paddle.float32)
+
+    def test_output_is_detached(self):
+        src = paddle.ones([], dtype="float32")
+        src.stop_gradient = False
+        self.assertTrue(
+            mod._validate_grad_loss_tensor(src, self._device()).stop_gradient
+        )
+
+    def test_rejects_multi_element(self):
+        with self.assertRaises(ValueError):
+            mod._validate_grad_loss_tensor(
+                paddle.ones([2], dtype="float32"), self._device()
+            )
+
+    def test_rejects_non_fp32(self):
+        with self.assertRaises(ValueError):
+            mod._validate_grad_loss_tensor(
+                paddle.ones([], dtype="float16"), self._device()
+            )
+
+    def test_rejects_non_tensor(self):
+        with self.assertRaises(TypeError):
+            mod._validate_grad_loss_tensor(1.0, self._device())
+
+    def test_never_calls_numel(self):
+        """``numel()`` is the device read the shim exists to avoid."""
+
+        def _boom(self, *args, **kwargs):
+            raise AssertionError("grad_loss validation must not call numel()")
+
+        grad_loss = paddle.ones([], dtype="float32")
+        device = self._device()
+        with patch.object(paddle.Tensor, "numel", _boom):
+            out = mod._validate_grad_loss_tensor(grad_loss, device)
+        self.assertEqual(list(out.shape), [1])
+
+
+class TestPatchIndexerBackwardApi(unittest.TestCase):
+    def setUp(self):
+        self._saved = mod._PATCHED
+        mod._PATCHED = False
+
+    def tearDown(self):
+        mod._PATCHED = self._saved
+
+    def test_replaces_validator_and_is_idempotent(self):
+        fake = types.ModuleType(mod._API)
+        fake._validate_grad_loss_tensor = lambda *a, **k: None
+        with patch.dict(sys.modules, {mod._API: fake}):
+            mod.patch_indexer_backward_api()
+            self.assertIs(
+                fake._validate_grad_loss_tensor,
+                mod._validate_grad_loss_tensor,
+            )
+            mod.patch_indexer_backward_api()
+        self.assertTrue(mod._PATCHED)
+
+    def test_noop_on_wheel_without_the_guard(self):
+        """Older wheels expose ``_as_grad_loss_tensor`` and never sync."""
+        fake = types.ModuleType(mod._API)
+        fake._as_grad_loss_tensor = lambda *a, **k: None
+        with patch.dict(sys.modules, {mod._API: fake}):
+            mod.patch_indexer_backward_api()
+        self.assertFalse(hasattr(fake, "_validate_grad_loss_tensor"))
+        self.assertFalse(mod._PATCHED)
+
+    def test_noop_when_api_not_imported(self):
+        saved = sys.modules.pop(mod._API, None)
+        try:
+            mod.patch_indexer_backward_api()
+        finally:
+            if saved is not None:
+                sys.modules[mod._API] = saved
+        self.assertFalse(mod._PATCHED)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`dsa_indexer_loss_bwd_p2p_overlap` (#1863) defers the indexer KL loss subgraph into the pipeline's forward `isend`/`irecv` window. The deferred **forward** does overlap. The indexer **backward** does not — it is enqueued only after the p2p window has already closed.

Root cause is a host synchronization between the two, introduced by the cuDNN-frontend `grad_loss` guard:

```python
# paddlefleet_ops/cudnn/deepseek_sparse_attention/indexer_backward/api.py:38
if grad_loss.numel() != 1 or grad_loss.dtype != torch.float32 or grad_loss.device != device:
```

Under real torch `Tensor.numel()` returns a Python `int` and this is free. But `paddlefleet_ops` enables `paddle.enable_compat(scope={"cudnn"})` (`paddlefleet_ops/__init__.py:477`) so the frontend's `torch.*` calls resolve to Paddle, and Paddle's `numel()` is an **op returning a 0-D Tensor**. `!= 1` therefore builds a device bool, and the Python `or` forces `Tensor.__bool__` → a blocking `GpuMemcpySync` on the CUDA **legacy default stream**.

Paddle creates its compute and communication streams as *blocking* streams, so a legacy-default-stream copy is a bidirectional full-device barrier: it cannot retire until everything already in flight drains.

## Evidence

nsys profile, 64k phase-3, `pp4` / `vpp3` / `cp4`, times relative to `IndexerBackward` start (ms):

| time | event |
|---|---|
| -28.975 .. -0.964 | `ncclDevKernel_SendRecv` on the p2p comm stream (28 ms window) |
| -28.882 .. -24.869 | deferred KL forward on the compute stream — **overlaps correctly** |
| -24.869 .. -0.191 | **compute stream idle for 24.7 ms** |
| -35.463 .. -0.455 | `cudaMemcpy_v3020`, launching thread **blocked 35.008 ms** |
| 0.000 .. 8.436 | `IndexerBackward` finally runs |

Device side of the blocking copy: `bytes=256`, `copyKind=DtoH`, `dstKind=pageable host`, `stream=7` (legacy default stream), activity `-0.474 .. -0.471` — i.e. it could not even begin until the NCCL send/recv drained at `-0.482`.

NVTX pins the statement: `empty` ×2 → **`numel`** (with an 8 B HtoD) → **`__ne__` (`full` int64 + `not_equal` → bool)** → the blocking DtoH → `reshape` (`.reshape([1])`) → `indexer_backward_dsl_gemm` → `ScoreGrad` → `IndexerBackward`.

## Fix

Install a sync-free replacement for the validator. Validation semantics are unchanged — the element count is derived from `shape`, which is host metadata under both torch and Paddle; the `dtype` and `device` comparisons already return Python bools and are untouched.

The patch is guarded and idempotent, and a no-op on wheels that predate the guard (those expose `_as_grad_loss_tensor`, which never reads a scalar back to the host), so it is safe across `paddlefleet_ops` versions. Applied from both the sparse (`csa_indexer_bwd`) and dense (`dense_indexer_kl_bwd`) wrappers, which share the frontend module.

This is the same failure mode, for the same reason, as the `d_index_k` note already documented in `csa_indexer_bwd` — a Paddle blocking copy landing on the legacy default stream and barriering the device.

The permanent home for this is `PFCCLab/cudnn-frontend`; the shim can be dropped once the wheel picks up the equivalent change.

## Tests

New `tests/single_card_tests/ai_edited_test/ops/test_ai_indexer_grad_loss_no_sync.py`:

- validator accepts `[]` / `[1]` / `[1, 1]` fp32, returns a detached `[1]` tensor
- rejects multi-element, non-fp32, and non-tensor inputs
- **`test_never_calls_numel`** — makes `paddle.Tensor.numel` raise, so any future rewrite that reintroduces the device read fails here instead of silently costing overlap
- `patch_indexer_backward_api` replaces the validator, is idempotent, and is a no-op on an older wheel or an un-imported / mocked api module

Verified locally against the **unpatched** wheel: the live validator on the real kernel path resolves to the shim, and `csa_indexer_bwd` returns finite gradients of the expected shapes.

```
test_ai_indexer_grad_loss_no_sync.py + test_ai_dense_indexer_kl_grad_loss.py   10 passed
test_indexer_loss_overlap.py + test_cudnn_dsa_indexer_docmask.py               109 passed, 1 skipped, 22 subtests
test_hybrid_mla_warmup_kl_cudnn.py + test_csa_loss_mask.py
  + test_hybrid_mla_grad_health.py                                             41 passed, 29 subtests
```

`ruff format` / `ruff check` clean.
