### PR TITLE
[release/0.4][MoE] Fix Gemma4 GeGLU initialization in GroupedMLP

### DIFF
--- a/src/paddlefleet/transformer/moe/moe_expert.py
+++ b/src/paddlefleet/transformer/moe/moe_expert.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+import functools
 import os
 from contextlib import nullcontext
 from copy import deepcopy
@@ -199,7 +200,12 @@ class GroupedMLPExpert(FleetLayer):
         )
 
         if self.config.gated_linear_unit:
-            if self.config.hidden_act in [F.silu, F.gelu]:
+            hidden_act = self.config.hidden_act
+            is_gelu = hidden_act is F.gelu or (
+                isinstance(hidden_act, functools.partial)
+                and hidden_act.func is F.gelu
+            )
+            if hidden_act is F.silu or is_gelu:
 
                 def glu(x):
                     x = paddle.chunk(x, 2, dim=-1)

--- a/tests/single_card_tests/transformer/test_situ_glu.py
+++ b/tests/single_card_tests/transformer/test_situ_glu.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import functools
 import os
 import subprocess
 import sys
@@ -900,6 +901,34 @@ class TestSituGLU(unittest.TestCase):
                         hidden_act(gate) * up,
                     )
                 )
+
+    def test_grouped_expert_supports_gelu_partial(self):
+        hidden_act = functools.partial(F.gelu, approximate=True)
+        config = TransformerConfig(
+            hidden_size=8,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+            intermediate_size=8,
+            moe_intermediate_size=4,
+            gated_linear_unit=True,
+            hidden_act=hidden_act,
+            params_dtype="bfloat16",
+        )
+        expert = GroupedMLPExpert(
+            num_local_experts=2,
+            config=config,
+            moe_deep_gemm=False,
+        )
+        x = paddle.linspace(-4.0, 4.0, 16).reshape([2, 8])
+        gate, up = paddle.chunk(x, chunks=2, axis=-1)
+
+        self.assertIs(config.hidden_act, hidden_act)
+        self.assertTrue(
+            paddle.allclose(
+                expert.activation_func(x),
+                F.gelu(gate, approximate=True) * up,
+            )
+        )
 
     def test_sonic_moe_rejects_non_swiglu_configurations(self):
         for hidden_act, gated_linear_unit in (


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
- 修复 `GroupedMLPExpert` 无法识别 `functools.partial(F.gelu, approximate=True)` 的问题。
- 保持 Gemma4 `gelu_pytorch_tanh` 的 GeGLU 语义，并补充回归测试。

### 是否引起精度变化
否


Cherry-pick of #1778 to `release/0.4`.

Merged in dev: #1778  <!-- For pass CI -->