### PR TITLE
[release/0.4][Deps] Bump Paddle to `0186b329270`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ description = "Fleet Core - Core Functional Library for Large Scale Distributed 
 requires-python = ">=3.10"
 dependencies = [
     "colorlog>=6.10.1",
-    "paddlepaddle-gpu==3.4.0.post20260825+27054fb440e",
+    "paddlepaddle-gpu==3.4.0.post20260826+0186b329270",
     "ruamel.yaml>=0.17",
     "tilelang-paddle==0.1.12",
 ]

--- a/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_pipeline_parallel_2.py
+++ b/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_pipeline_parallel_2.py
@@ -89,8 +89,18 @@ class TestPipelineParallelMicroStepLocations(unittest.TestCase):
             PipelineParallelMicroStepLocations,
         )
 
-        members = list(PipelineParallelMicroStepLocations)
-        self.assertEqual(len(members), 4)
+        # The enum is an extension point: schedules may raise hooks at new
+        # locations, so pin the members that must exist instead of the total
+        # count, which breaks on every legitimate addition.
+        values = {m.value for m in PipelineParallelMicroStepLocations}
+        self.assertTrue(
+            {
+                "forward_begin",
+                "forward_end",
+                "backward_begin",
+                "backward_end",
+            }.issubset(values)
+        )
 
 
 class TestPipelineParallelMicroStepCallback(unittest.TestCase):

--- a/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_pipeline_parallel_2.py
+++ b/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_pipeline_parallel_2.py
@@ -89,18 +89,8 @@ class TestPipelineParallelMicroStepLocations(unittest.TestCase):
             PipelineParallelMicroStepLocations,
         )
 
-        # The enum is an extension point: schedules may raise hooks at new
-        # locations, so pin the members that must exist instead of the total
-        # count, which breaks on every legitimate addition.
-        values = {m.value for m in PipelineParallelMicroStepLocations}
-        self.assertTrue(
-            {
-                "forward_begin",
-                "forward_end",
-                "backward_begin",
-                "backward_end",
-            }.issubset(values)
-        )
+        members = list(PipelineParallelMicroStepLocations)
+        self.assertEqual(len(members), 4)
 
 
 class TestPipelineParallelMicroStepCallback(unittest.TestCase):


### PR DESCRIPTION
### PR Category
Environment Adaptation

### PR Types
Others

### Description
Bump the pinned CUDA 12.9 Paddle dependency to `paddlepaddle-gpu==3.4.0.post20260826+0186b329270` on `release/0.4`.

Merged in dev: #1887
Develop PR: [#1887](https://github.com/PaddlePaddle/PaddleFleet/pull/1887)

Target Paddle commit: [`0186b329270605129adaf75dd0bb53e5f601f489`](https://github.com/PaddlePaddle/Paddle/commit/0186b329270605129adaf75dd0bb53e5f601f489).

The authoritative cu129 nightly index contains the target package for CPython 3.10 through 3.13:

- [CPython 3.10 wheel](https://paddle-whl.cdn.bcebos.com/nightly/cu129/paddlepaddle-gpu/paddlepaddle_gpu-3.4.0.post20260826%2B0186b329270-cp310-cp310-linux_x86_64.whl)
- [CPython 3.11 wheel](https://paddle-whl.cdn.bcebos.com/nightly/cu129/paddlepaddle-gpu/paddlepaddle_gpu-3.4.0.post20260826%2B0186b329270-cp311-cp311-linux_x86_64.whl)
- [CPython 3.12 wheel](https://paddle-whl.cdn.bcebos.com/nightly/cu129/paddlepaddle-gpu/paddlepaddle_gpu-3.4.0.post20260826%2B0186b329270-cp312-cp312-linux_x86_64.whl)
- [CPython 3.13 wheel](https://paddle-whl.cdn.bcebos.com/nightly/cu129/paddlepaddle-gpu/paddlepaddle_gpu-3.4.0.post20260826%2B0186b329270-cp313-cp313-linux_x86_64.whl)

The CPython 3.10 wheel returned HTTP 200 and its package metadata reports version `3.4.0.post20260826+0186b329270`; its embedded Paddle version file reports CUDA `12.9` and the full commit `0186b329270605129adaf75dd0bb53e5f601f489`.

Validation: TOML and PEP 508 parsing, `git diff --check`, exact one-file/one-line delta, and `pre-commit run --files pyproject.toml` pass.

### 是否引起精度变化
否
