### PR TITLE
[mHC] Keep the mhc_forward recompute segment bit-identical

### DIFF
--- a/src/paddlefleet/transformer/hyper_connection.py
+++ b/src/paddlefleet/transformer/hyper_connection.py
@@ -259,6 +259,71 @@ def native_h_post_bda(
     return x_expanded + mixed
 
 
+class _FixedOrderMappings(paddle.autograd.PyLayer):
+    """``compute_mappings`` + ``aggregate`` with a fixed gradient sum order.
+
+    Both halves read the same ``x``: the mapping head projects it, and the
+    aggregation weights it. Composed plainly, that hands autograd two separate
+    contributions to ``dx`` and leaves it to the engine when to add them, so
+    the sum comes out differently depending on whether the segment was replayed
+    by ``RecomputeWithoutOutput`` -- which is the ``mhc_forward`` recompute
+    case. Each half is given its own detached view of ``x`` here and their
+    gradients are added explicitly below, which pins the order down.
+
+    Nothing about the mappings is reimplemented: the two halves call the
+    module's own methods, so the dtype handling, ``fuse_cast`` and the
+    accuracy-compatible paths all stay in one place.
+
+    Two details of the mechanics are worth knowing:
+
+    * ``paddle.is_grad_enabled()`` always reads False inside a
+      ``PyLayer.forward``, so whether to build the inner graph cannot be
+      decided here -- the caller reads it and passes it in. It is False on
+      ``RecomputeWithoutOutput``'s first pass, so no graph is built there,
+      which is the point of that pass; the replay runs with grad enabled.
+    * the outputs are returned detached. ``apply`` takes over the ``grad_fn``
+      of whatever it returns, so returning the inner tensors themselves would
+      make ``autograd.backward`` below re-enter this very node instead of
+      walking the inner graph. The detached views share their data, so this
+      costs nothing; ``save_for_backward`` keeps the undetached ones, whose
+      ``grad_fn`` it preserves, and those are what backward walks.
+    """
+
+    @staticmethod
+    def forward(ctx, module, x, build_graph):
+        x_map = x.detach()
+        x_agg = x.detach()
+        x_map.stop_gradient = x.stop_gradient
+        x_agg.stop_gradient = x.stop_gradient
+        with paddle.set_grad_enabled(build_graph):
+            h_pre, h_post, h_res = module.compute_mappings(x_map)
+            aggregated = module.aggregate(x_agg, h_pre)
+        ctx.x_stop_gradient = x.stop_gradient
+        ctx.build_graph = build_graph
+        if build_graph:
+            ctx.save_for_backward(x_map, x_agg, aggregated, h_res, h_post)
+        return aggregated.detach(), h_res.detach(), h_post.detach()
+
+    @staticmethod
+    def backward(ctx, *output_grads):
+        if ctx.x_stop_gradient or not ctx.build_graph:
+            return None
+        x_map, x_agg, *outputs = ctx.saved_tensor()
+        # An output the caller never used has no gradient; filtering mirrors
+        # ``RecomputeWithoutOutputFunction.backward``, as does restoring the
+        # forward's ``auto_cast`` scope, which has been left by now.
+        pairs = [
+            (out, grad)
+            for out, grad in zip(outputs, output_grads)
+            if grad is not None
+        ]
+        with paddle.amp.auto_cast(enable=False):
+            paddle.autograd.backward(
+                [out for out, _ in pairs], [grad for _, grad in pairs]
+            )
+        return x_map.grad + x_agg.grad
+
+
 class HyperConnectionModule(nn.Layer):
     """
     Unified mHC (Manifold-Constrained Hyper-Connections) module.
@@ -702,10 +767,20 @@ class HyperConnectionModule(nn.Layer):
                 and not self._widen_in_kernel
             ):
                 hidden_states = hidden_states.astype("float32")
-            h_pre, h_post, h_res = self.compute_mappings(hidden_states)
 
-            # Aggregate for layer input
-            aggregated = self.aggregate(hidden_states, h_pre)
+            if _use_accuracy_compatible_kernel():
+                h_pre, h_post, h_res = self.compute_mappings(hidden_states)
+
+                # Aggregate for layer input
+                aggregated = self.aggregate(hidden_states, h_pre)
+            else:
+                # The same two calls, with the order in which their gradients
+                # reach ``hidden_states`` pinned down; see
+                # ``_FixedOrderMappings``. ``is_grad_enabled`` has to be read
+                # out here, since it always reads False inside the node.
+                aggregated, h_res, h_post = _FixedOrderMappings.apply(
+                    self, hidden_states, paddle.is_grad_enabled()
+                )
 
         return aggregated, h_res, h_post
 

--- a/tests/single_card_tests/transformer/test_mhc_fixed_grad_order.py
+++ b/tests/single_card_tests/transformer/test_mhc_fixed_grad_order.py
@@ -1,0 +1,226 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``_FixedOrderMappings`` must be invisible from outside ``forward``.
+
+Two properties are pinned here, both bitwise (``assert_array_equal`` plus a dtype
+check):
+
+* the node returns exactly what the plain composition returns -- same forward
+  outputs, same parameter gradients, same ``dx`` -- with and without
+  ``_widen_in_kernel``. It tracks ``high_precision_mhc`` in production, and
+  ``TransformerConfig`` rejects ``high_precision_mhc=False`` outright, so it is
+  forced apart here: the reference reads it as its own condition, and with it
+  off ``forward`` also takes the up-cast in front of the node;
+* replaying the module under ``RecomputeWithoutOutput`` gives bit-identical
+  gradients. That is the whole reason the node exists: ``x`` feeds both the
+  mapping head and the aggregation, and leaving the order of the two ``dx``
+  contributions to the engine makes the sum depend on whether the segment was
+  replayed.
+
+Both comparisons drive the real ``forward``; the reference is obtained by
+swapping the node out for a direct call to the two methods it wraps, so nothing
+about ``forward`` -- the ``auto_cast`` scope, the up-cast in front of it -- is
+duplicated here.
+"""
+
+import unittest
+from unittest import mock
+
+import numpy as np
+import paddle
+
+from paddlefleet.fusions.fused_mhc_kernels import _CUTILE_AVAILABLE
+from paddlefleet.tensor_parallel.random import (
+    RecomputeWithoutOutput,
+    get_cuda_rng_tracker,
+)
+from paddlefleet.transformer.hyper_connection import (
+    HyperConnectionModule,
+    _FixedOrderMappings,
+)
+from paddlefleet.transformer.transformer_config import TransformerConfig
+
+C = 64
+N_STREAMS = 4
+S, B = 3, 2
+
+
+def _make_module(widen_in_kernel=True):
+    config = TransformerConfig(
+        hidden_size=C,
+        enable_hyper_connections=True,
+        use_fused_mhc=True,
+        high_precision_mhc=True,
+        num_residual_streams=N_STREAMS,
+        params_dtype=paddle.bfloat16,
+    )
+    module = HyperConnectionModule(config, 0)
+    module.train()
+    # ``_widen_in_kernel`` tracks ``high_precision_mhc``, which the config
+    # forces to True; overriding it is the only way to reach the branches that
+    # read it on its own.
+    module._widen_in_kernel = widen_in_kernel
+    return module
+
+
+def _collect(module, x, run_forward):
+    """Run one forward/backward pass and return everything worth comparing."""
+    x = x.detach()
+    x.stop_gradient = False
+    outputs = run_forward(module, x)
+    # Weight the outputs differently so that a mix-up cannot cancel out.
+    loss = sum((i + 1.0) * out.sum() for i, out in enumerate(outputs))
+    loss.backward()
+    grads = {
+        name: param.grad.numpy().copy()
+        for name, param in module.named_parameters()
+        if param.grad is not None
+    }
+    for param in module.parameters():
+        if param.grad is not None:
+            param.clear_gradient()
+    values = tuple(out.numpy().copy() for out in outputs)
+    return values, grads, x.grad.numpy().copy()
+
+
+def _plain(module, x):
+    return module(x)
+
+
+def _plain_apply(module, x, build_graph):
+    """What the node wraps, called directly: no detached branches, no fixed order."""
+    del build_graph  # the plain composition has no inner graph to gate
+    h_pre, h_post, h_res = module.compute_mappings(x)
+    return module.aggregate(x, h_pre), h_res, h_post
+
+
+def _reference(module, x):
+    """The real ``forward``, with the fixed-order node swapped out.
+
+    Patching ``apply`` rather than reimplementing ``forward`` keeps everything
+    around the node -- the ``auto_cast`` scope, the up-cast, the
+    accuracy-compatible check -- under test instead of duplicated here. The
+    wrapper asserts the patch was actually reached, so that a ``forward`` that
+    stops going through the node cannot make this comparison vacuous.
+    """
+    calls = []
+
+    def _counted(*args):
+        calls.append(None)
+        return _plain_apply(*args)
+
+    with mock.patch.object(
+        _FixedOrderMappings, "apply", staticmethod(_counted)
+    ):
+        outputs = module(x)
+    assert calls, "forward did not go through _FixedOrderMappings"
+    return outputs
+
+
+def _pipeline(module, x, replay):
+    """``forward`` -> BDA, as ``_forward_attention`` runs it.
+
+    With ``replay`` the module goes inside a ``RecomputeWithoutOutput`` span and
+    the span is closed on the BDA output, exactly as
+    ``HyperConnectionTransformerLayer._forward_attention`` does. Only the BDA
+    output is returned: the span's own outputs are cleared by
+    ``discard_output_and_register_recompute`` and must not be read afterwards.
+    """
+    if replay:
+        span = RecomputeWithoutOutput()
+        aggregated, h_res, h_post = span.recompute(
+            module, x, preserve_rng_state=False, share_grad_holder=True
+        )
+    else:
+        span = None
+        aggregated, h_res, h_post = module(x)
+    output = module.fused_h_res_h_post_bda(
+        h_res=h_res.clone(),
+        original_residual=x,
+        h_post=h_post.clone(),
+        layer_output_with_bias=(aggregated.to(x.dtype), None),
+        dropout_prob=0.0,
+        training=True,
+        fused=True,
+    )
+    if span is not None:
+        span.discard_output_and_register_recompute(output)
+    return (output,)
+
+
+@unittest.skipUnless(_CUTILE_AVAILABLE, "fused mHC kernels require cuTile")
+class TestFusedMhcMappings(unittest.TestCase):
+    """The fused mappings node must be invisible from outside ``forward``."""
+
+    @classmethod
+    def setUpClass(cls):
+        paddle.set_device("gpu")
+        try:
+            get_cuda_rng_tracker().add("model-parallel-rng", 12345)
+        except ValueError:
+            pass
+
+    def _assert_identical(self, first, second, label):
+        (out_a, grads_a, dx_a) = first
+        (out_b, grads_b, dx_b) = second
+        self.assertEqual(len(out_a), len(out_b), label)
+        for i, (a, b) in enumerate(zip(out_a, out_b)):
+            self.assertEqual(a.dtype, b.dtype, f"{label}: output {i} dtype")
+            np.testing.assert_array_equal(a, b, err_msg=f"{label}: output {i}")
+        self.assertEqual(set(grads_a), set(grads_b), label)
+        for name in grads_a:
+            self.assertEqual(
+                grads_a[name].dtype,
+                grads_b[name].dtype,
+                f"{label}: grad {name} dtype",
+            )
+            np.testing.assert_array_equal(
+                grads_a[name], grads_b[name], err_msg=f"{label}: grad {name}"
+            )
+        self.assertEqual(dx_a.dtype, dx_b.dtype, f"{label}: dx dtype")
+        np.testing.assert_array_equal(dx_a, dx_b, err_msg=f"{label}: dx")
+
+    def _assert_matches_reference(self, widen_in_kernel):
+        paddle.seed(2026)
+        module = _make_module(widen_in_kernel)
+        x = paddle.randn([S, B, N_STREAMS * C]).astype("bfloat16")
+        self._assert_identical(
+            _collect(module, x, _reference),
+            _collect(module, x, _plain),
+            f"widen_in_kernel={widen_in_kernel}",
+        )
+
+    def test_matches_reference_widen_in_kernel(self):
+        """The production setting: casts folded into the kernels."""
+        self._assert_matches_reference(True)
+
+    def test_matches_reference_no_widen_in_kernel(self):
+        """The caller materializes the fp32 copies instead."""
+        self._assert_matches_reference(False)
+
+    def test_recompute_replay_is_bitwise_identical(self):
+        """Replaying the module must not change a single bit of the gradients."""
+        paddle.seed(2026)
+        module = _make_module()
+        x = paddle.randn([S, B, N_STREAMS * C]).astype("bfloat16")
+        self._assert_identical(
+            _collect(module, x, lambda m, t: _pipeline(m, t, replay=False)),
+            _collect(module, x, lambda m, t: _pipeline(m, t, replay=True)),
+            "recompute off vs on",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/transformer/test_mhc_fixed_grad_order.py
+++ b/tests/single_card_tests/transformer/test_mhc_fixed_grad_order.py
@@ -18,16 +18,21 @@ Two properties are pinned here, both bitwise (``assert_array_equal`` plus a dtyp
 check):
 
 * the node returns exactly what the plain composition returns -- same forward
-  outputs, same parameter gradients, same ``dx`` -- with and without
-  ``_widen_in_kernel``. It tracks ``high_precision_mhc`` in production, and
-  ``TransformerConfig`` rejects ``high_precision_mhc=False`` outright, so it is
-  forced apart here: the reference reads it as its own condition, and with it
-  off ``forward`` also takes the up-cast in front of the node;
+  outputs, same parameter gradients, same ``dx``;
 * replaying the module under ``RecomputeWithoutOutput`` gives bit-identical
   gradients. That is the whole reason the node exists: ``x`` feeds both the
   mapping head and the aggregation, and leaving the order of the two ``dx``
   contributions to the engine makes the sum depend on whether the segment was
   replayed.
+
+Both are checked for the native op composition and, where cuTile is available,
+for the fused kernels: the node sits in ``forward``, above that choice, so
+neither implementation may notice it. Only the fused path can vary
+``_widen_in_kernel`` -- it tracks ``high_precision_mhc`` in production and
+``TransformerConfig`` rejects ``high_precision_mhc=False`` outright, so it is
+forced apart there: the reference reads it as its own condition, and with it off
+``forward`` also takes the up-cast in front of the node. The native path pins it
+to False itself, having no widening to absorb.
 
 Both comparisons drive the real ``forward``; the reference is obtained by
 swapping the node out for a direct call to the two methods it wraps, so nothing
@@ -56,22 +61,27 @@ C = 64
 N_STREAMS = 4
 S, B = 3, 2
 
+_NEEDS_CUTILE = unittest.skipUnless(
+    _CUTILE_AVAILABLE, "fused mHC kernels require cuTile"
+)
 
-def _make_module(widen_in_kernel=True):
+
+def _make_module(use_fused_mhc=True, widen_in_kernel=None):
     config = TransformerConfig(
         hidden_size=C,
         enable_hyper_connections=True,
-        use_fused_mhc=True,
+        use_fused_mhc=use_fused_mhc,
         high_precision_mhc=True,
         num_residual_streams=N_STREAMS,
         params_dtype=paddle.bfloat16,
     )
     module = HyperConnectionModule(config, 0)
     module.train()
-    # ``_widen_in_kernel`` tracks ``high_precision_mhc``, which the config
-    # forces to True; overriding it is the only way to reach the branches that
-    # read it on its own.
-    module._widen_in_kernel = widen_in_kernel
+    if widen_in_kernel is not None:
+        # ``_widen_in_kernel`` tracks ``high_precision_mhc``, which the config
+        # forces to True; overriding it is the only way to reach the branches
+        # that read it on its own.
+        module._widen_in_kernel = widen_in_kernel
     return module
 
 
@@ -160,9 +170,8 @@ def _pipeline(module, x, replay):
     return (output,)
 
 
-@unittest.skipUnless(_CUTILE_AVAILABLE, "fused mHC kernels require cuTile")
-class TestFusedMhcMappings(unittest.TestCase):
-    """The fused mappings node must be invisible from outside ``forward``."""
+class TestMhcFixedOrderMappings(unittest.TestCase):
+    """The fixed-order node must be invisible from outside ``forward``."""
 
     @classmethod
     def setUpClass(cls):
@@ -192,34 +201,48 @@ class TestFusedMhcMappings(unittest.TestCase):
         self.assertEqual(dx_a.dtype, dx_b.dtype, f"{label}: dx dtype")
         np.testing.assert_array_equal(dx_a, dx_b, err_msg=f"{label}: dx")
 
-    def _assert_matches_reference(self, widen_in_kernel):
+    def _assert_matches_reference(self, use_fused_mhc, widen_in_kernel=None):
         paddle.seed(2026)
-        module = _make_module(widen_in_kernel)
+        module = _make_module(use_fused_mhc, widen_in_kernel)
         x = paddle.randn([S, B, N_STREAMS * C]).astype("bfloat16")
         self._assert_identical(
             _collect(module, x, _reference),
             _collect(module, x, _plain),
-            f"widen_in_kernel={widen_in_kernel}",
+            f"fused={use_fused_mhc} widen_in_kernel={module._widen_in_kernel}",
         )
 
-    def test_matches_reference_widen_in_kernel(self):
-        """The production setting: casts folded into the kernels."""
-        self._assert_matches_reference(True)
-
-    def test_matches_reference_no_widen_in_kernel(self):
-        """The caller materializes the fp32 copies instead."""
-        self._assert_matches_reference(False)
-
-    def test_recompute_replay_is_bitwise_identical(self):
-        """Replaying the module must not change a single bit of the gradients."""
+    def _assert_replay_matches(self, use_fused_mhc):
         paddle.seed(2026)
-        module = _make_module()
+        module = _make_module(use_fused_mhc)
         x = paddle.randn([S, B, N_STREAMS * C]).astype("bfloat16")
         self._assert_identical(
             _collect(module, x, lambda m, t: _pipeline(m, t, replay=False)),
             _collect(module, x, lambda m, t: _pipeline(m, t, replay=True)),
-            "recompute off vs on",
+            f"recompute off vs on, fused={use_fused_mhc}",
         )
+
+    def test_matches_reference_native(self):
+        """The op composition, which needs no kernels to run."""
+        self._assert_matches_reference(False)
+
+    def test_recompute_replay_is_bitwise_identical_native(self):
+        """Replaying must not change a bit, kernels or no kernels."""
+        self._assert_replay_matches(False)
+
+    @_NEEDS_CUTILE
+    def test_matches_reference_fused_widen_in_kernel(self):
+        """The production setting: casts folded into the kernels."""
+        self._assert_matches_reference(True, widen_in_kernel=True)
+
+    @_NEEDS_CUTILE
+    def test_matches_reference_fused_no_widen_in_kernel(self):
+        """The caller materializes the fp32 copies instead."""
+        self._assert_matches_reference(True, widen_in_kernel=False)
+
+    @_NEEDS_CUTILE
+    def test_recompute_replay_is_bitwise_identical_fused(self):
+        """Replaying the module must not change a single bit of the gradients."""
+        self._assert_replay_matches(True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### PR Category

Distributed Strategy

### PR Types

Bug fixes

### Description

`hidden_states` feeds both halves of the mHC forward -- `compute_mappings` projects it, `aggregate` weights it -- so the plain composition hands autograd two separate contributions to `dx` and leaves it to the engine when to add them. The order the engine picks depends on whether the segment was replayed by `RecomputeWithoutOutput`, so putting `mhc_forward` in `recompute_modules` can shift the gradients by a few ULP, and that compounds over the layer stack.

This PR wraps the two calls in `_FixedOrderMappings`, a `PyLayer` that gives each half its own detached view of `hidden_states` and sums their gradients explicitly, pinning the order down. The mappings themselves are not reimplemented: the halves call the module's own `compute_mappings` / `aggregate`, so the dtype handling, `fuse_cast` and the accuracy-compatible paths stay in one place. The accuracy-compatible mode keeps the plain composition, as it does at the other fused sites -- its contract is bitwise alignment with Megatron, which an explicit summation order would break.

Two mechanics of the node are documented in its docstring:

- `paddle.is_grad_enabled()` always reads False inside a `PyLayer.forward`, so whether to build the inner graph is read by the caller and passed in. It is False on `RecomputeWithoutOutput`'s first pass, which is what that pass is for; the replay runs with grad enabled.
- the outputs are returned detached, because `apply` takes over the `grad_fn` of whatever it returns -- returning the inner tensors themselves makes `autograd.backward` re-enter the same node. `save_for_backward` keeps the undetached ones, whose `grad_fn` it preserves.

#### Verification

`test_mhc_fixed_grad_order` pins two properties, both bitwise (`assert_array_equal` plus a dtype check), for the native op composition and -- where cuTile is available -- for the fused kernels:

- the node reproduces the plain composition exactly: forward outputs, every parameter gradient and `dx`;
- a segment replayed under `RecomputeWithoutOutput` matches a non-replayed one exactly.

Also checked by hand on a real `HyperConnectionTransformerLayer` at 1 / 2 / 3 layers with the full `recompute_modules` list: no differing element.

#### What is not verified

No training run was done on top of this exact revision. The end-to-end evidence that motivated the PR comes from a 35-layer MLA+HCA 10-step run made against an earlier revision of the same fix, where it moved `global_grad_norm` at step 1 from `5.8480377` (recompute on) vs `5.8498297` (recompute off) onto a single value; steps 3-10 still drifted there, for an unrelated reason in that particular configuration, and aligned once that was turned off.

### 是否引起精度变化

是

`mhc_forward` recompute **off** is bit-for-bit unchanged. recompute **on** changes: it now matches the recompute-off result exactly, where before it drifted.

---

Same change as #1890 on `release/0.4`; that one unblocks the training run and should merge first.