### PR TITLE
[release/0.4][MoE] Re-land latent-MoE RMSNorm with unit tests

### DIFF
--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -42,6 +42,7 @@ if TYPE_CHECKING:
 from paddlefleet import utils
 from paddlefleet.recompute_utils import need_recompute_in_first_n
 from paddlefleet.transformer.activations import situ
+from paddlefleet.transformer.paddle_norm import WrappedPaddleNorm
 from paddlefleet.transformer.utils import profile
 
 from .fp8_utils import fused_stack_quant_without_cache
@@ -244,6 +245,15 @@ class MoELayer(nn.Layer):
             # Override default XavierUniform with config init methods
             self.config.init_method(self.fc1_latent_proj.weight)
             self.config.output_layer_init_method(self.fc2_latent_proj.weight)
+            self.latent_norm = (
+                WrappedPaddleNorm(
+                    config=self.config,
+                    hidden_size=self.config.moe_latent_size,
+                    eps=self.config.rms_norm_eps,
+                )
+                if self.config.latent_moe_use_norm
+                else None
+            )
             # Update expert config to use latent size
             routed_expert_config.hidden_size = self.config.moe_latent_size
         # Cached latent-space projection from _maybe_pre_allgather_overlap;
@@ -925,6 +935,8 @@ class MoELayer(nn.Layer):
 
         # Latent MoE: project back from latent space to hidden_size
         if self.use_latent_moe:
+            if self.latent_norm is not None:
+                hidden_states = self.latent_norm(hidden_states)
             hidden_states = self.fc2_latent_proj(hidden_states)
 
         return hidden_states
@@ -1018,6 +1030,8 @@ class MoELayer(nn.Layer):
 
         # Latent MoE: project back from latent space to hidden_size
         if self.use_latent_moe:
+            if self.latent_norm is not None:
+                hidden_states = self.latent_norm(hidden_states)
             hidden_states = self.fc2_latent_proj(hidden_states)
 
         return hidden_states
@@ -1191,6 +1205,8 @@ class MoELayer(nn.Layer):
     def aux_loss_compute(self, args):
         hidden_states, aux_loss, z_loss, residuals = args
         if self.use_latent_moe:
+            if self.latent_norm is not None:
+                hidden_states = self.latent_norm(hidden_states)
             hidden_states = self.fc2_latent_proj(hidden_states)
         if self.training and self.router_aux_loss_coef and aux_loss is not None:
             aux_loss = aux_loss * float(self.router_aux_loss_coef)
@@ -1339,6 +1355,8 @@ class MoELayer(nn.Layer):
                 )
             # Latent MoE: project back from latent space
             if self.use_latent_moe:
+                if self.latent_norm is not None:
+                    output = self.latent_norm(output)
                 output = self.fc2_latent_proj(output)
 
         _log_moe_md5(output, "moe_routed_output", layer_idx)

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -754,6 +754,10 @@ class TransformerConfig(ModelParallelConfig):
     moe_latent_size: int | None = None
     """The latent dimension size for latent MoE. Positive values enable latent MoE."""
 
+    latent_moe_use_norm: bool = False
+    """Apply RMSNorm to routed latent-MoE output before projecting it back to
+    the model hidden size."""
+
     ##################
     # Context Parallel
     ##################

--- a/tests/single_card_tests/ai_edited_test/moe/test_latent_moe.py
+++ b/tests/single_card_tests/ai_edited_test/moe/test_latent_moe.py
@@ -128,6 +128,24 @@ def _make_moe_layer(config, pg_collection=None):
     return MoELayer(config, sublayers=sublayers, pg_collection=pg_collection)
 
 
+def _attach_tracked_latent_output_path(stub, latent_size, hidden_size):
+    """Attach a real projection and record norm/projection call order."""
+    projection = nn.Linear(latent_size, hidden_size)
+    events = []
+
+    def apply_norm(hidden_states):
+        events.append("norm")
+        return hidden_states
+
+    def apply_projection(hidden_states):
+        events.append("fc2")
+        return projection(hidden_states)
+
+    stub.latent_norm = MagicMock(side_effect=apply_norm)
+    stub.fc2_latent_proj = MagicMock(side_effect=apply_projection)
+    stub._latent_output_events = events
+
+
 # ---------------------------------------------------------------------------
 # 1. TransformerConfig – new fields
 # ---------------------------------------------------------------------------
@@ -147,6 +165,12 @@ class TestLatentMoEConfig(unittest.TestCase):
     def test_set_non_positive_moe_latent_size(self):
         config = _make_moe_config(moe_latent_size=0)
         self.assertEqual(config.moe_latent_size, 0)
+
+    def test_latent_norm_defaults_disabled_and_can_be_enabled(self):
+        self.assertFalse(_make_moe_config().latent_moe_use_norm)
+        self.assertTrue(
+            _make_moe_config(latent_moe_use_norm=True).latent_moe_use_norm
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -225,6 +249,21 @@ class TestLatentMoEInit(unittest.TestCase):
         self.assertIsInstance(layer.fc2_latent_proj, nn.Linear)
         self.assertEqual(layer.fc2_latent_proj.weight.shape[0], 32)
         self.assertEqual(layer.fc2_latent_proj.weight.shape[1], 64)
+        self.assertIsNone(layer.latent_norm)
+
+    def test_latent_moe_norm_is_created_when_enabled(self):
+        """Kimi Stable LatentMoE uses RMSNorm in the latent width."""
+        from paddlefleet.transformer.paddle_norm import RMSNorm
+
+        config = _make_moe_config(
+            moe_latent_size=32,
+            latent_moe_use_norm=True,
+            normalization="RMSNorm",
+        )
+        layer = self._run_init(config)
+
+        self.assertIsInstance(layer.latent_norm, RMSNorm)
+        self.assertEqual(list(layer.latent_norm.weight.shape), [32])
 
     def test_latent_moe_sets_expert_hidden_size(self):
         """Enabling latent MoE must reduce the expert input hidden_size."""
@@ -348,7 +387,7 @@ class TestAuxLossComputeLatent(unittest.TestCase):
         stub = MagicMock()
         stub.use_latent_moe = use_latent_moe
         if use_latent_moe:
-            stub.fc2_latent_proj = nn.Linear(latent_size, hidden_size)
+            _attach_tracked_latent_output_path(stub, latent_size, hidden_size)
         stub.training = False
         stub.router_aux_loss_coef = 0.0
         stub.shared_experts = None
@@ -373,6 +412,7 @@ class TestAuxLossComputeLatent(unittest.TestCase):
 
         # Must be expanded back to hidden_size=64
         self.assertEqual(output.shape[-1], 64)
+        self.assertEqual(stub._latent_output_events, ["norm", "fc2"])
 
     def test_aux_loss_compute_skips_fc2_when_not_latent(self):
         """Without latent MoE, hidden_states must remain unchanged."""
@@ -535,7 +575,7 @@ class TestForwardLatent(unittest.TestCase):
         stub.use_latent_moe = use_latent_moe
         if use_latent_moe:
             stub.fc1_latent_proj = nn.Linear(hidden_size, latent_size)
-            stub.fc2_latent_proj = nn.Linear(latent_size, hidden_size)
+            _attach_tracked_latent_output_path(stub, latent_size, hidden_size)
 
         # Parallel / sequence flags → single-card non-sequence path
         stub.expert_model_parallel_size = 1
@@ -609,6 +649,7 @@ class TestForwardLatent(unittest.TestCase):
             [bs, seq, 64],
             "Output must be restored to hidden_size=64",
         )
+        self.assertEqual(stub._latent_output_events, ["norm", "fc2"])
 
     def test_forward_without_latent_moe_skips_projections(self):
         """
@@ -773,7 +814,7 @@ class TestCustomForwardLatent(unittest.TestCase):
         stub.use_latent_moe = use_latent_moe
         if use_latent_moe:
             stub.fc1_latent_proj = nn.Linear(hidden_size, latent_size)
-            stub.fc2_latent_proj = nn.Linear(latent_size, hidden_size)
+            _attach_tracked_latent_output_path(stub, latent_size, hidden_size)
         stub.dispatch.return_value = (
             paddle.randn([bs_seq, expert_out_size]),
             None,
@@ -798,6 +839,7 @@ class TestCustomForwardLatent(unittest.TestCase):
         self.assertEqual(
             output.shape[-1], 64, "output must be restored to hidden_size=64"
         )
+        self.assertEqual(stub._latent_output_events, ["norm", "fc2"])
 
     def test_custom_forward_skips_projections_when_not_latent(self):
         """Without latent MoE, hidden_states flow unchanged at full hidden_size."""
@@ -827,7 +869,7 @@ class TestFusionMoeForwardLatent(unittest.TestCase):
         stub._latent_hidden = None
         if use_latent_moe:
             stub.fc1_latent_proj = nn.Linear(hidden_size, latent_size)
-            stub.fc2_latent_proj = nn.Linear(latent_size, hidden_size)
+            _attach_tracked_latent_output_path(stub, latent_size, hidden_size)
         stub.using_sonic_moe = False
         stub.fp8 = False
         stub.moe_deep_gemm = False
@@ -878,6 +920,7 @@ class TestFusionMoeForwardLatent(unittest.TestCase):
         self.assertEqual(
             output.shape[-1], 64, "output must be restored to hidden_size=64"
         )
+        self.assertEqual(stub._latent_output_events, ["norm", "fc2"])
 
     def test_fusion_moe_forward_skips_projections_when_not_latent(self):
         """Without latent MoE, hidden_states flow unchanged at full hidden_size."""


### PR DESCRIPTION
### PR Category

Operator Mechanism

### PR Types

New features

### Description

Re-lands #1847 (reverted by #1865). Merged in dev: #1632.

The feature itself is unchanged — normalize the combined routed output in the
latent width before projecting it back to the model hidden size (Kimi-K3
report, Eq. 11):

- add `latent_moe_use_norm` (default `False`)
- build `self.latent_norm` (`WrappedPaddleNorm`, width `moe_latent_size`, eps
  `rms_norm_eps`) next to the latent projections
- apply it at all four `fc2_latent_proj` call sites, so the custom-forward,
  dispatch/combine-overlap, aux-loss and single-card fusion paths stay consistent

The two source files are byte-identical to #1847. What was missing last time is
the matching unit-test update, which is why #1847 had to be reverted:

`tests/single_card_tests/ai_edited_test/moe/test_latent_moe.py` builds `MoELayer`
stubs with `MagicMock()`, so `stub.latent_norm` was auto-created as a truthy
`MagicMock` instead of `None`. The new `if self.latent_norm is not None` branch
therefore ran on the stubs and fed a `MagicMock` into the real
`fc2_latent_proj`, giving 4 failures:

```
ValueError: (InvalidArgument) linear_v2(): argument 'input' (position 0) must be Tensor, but got MagicMock
FAILED .../test_latent_moe.py::TestAuxLossComputeLatent::test_aux_loss_compute_applies_fc2_when_latent
FAILED .../test_latent_moe.py::TestForwardLatent::test_forward_with_latent_moe_applies_both_projections
FAILED .../test_latent_moe.py::TestCustomForwardLatent::test_custom_forward_applies_fc1_fc2_when_latent
FAILED .../test_latent_moe.py::TestFusionMoeForwardLatent::test_fusion_moe_forward_applies_fc1_fc2_when_latent
```

This PR therefore also cherry-picks the test file from develop, which
- stubs `latent_norm` explicitly and asserts the `norm` -> `fc2` call order on
  all four paths,
- asserts `layer.latent_norm is None` when the flag is off, and that it is an
  `RMSNorm` of width `moe_latent_size` when the flag is on,
- covers the new config flag default.

Verification on this branch:
- `test_latent_moe.py`: 30 passed (was 4 failed / 24 passed with the old test file)
- whole `tests/single_card_tests/ai_edited_test/moe/`: 439 passed, 1 skipped
- `pre-commit run --files <the 3 files>`: all hooks pass

### 是否引起精度变化

否。`latent_moe_use_norm` 默认为 `False`，此时 `self.latent_norm is None`，前向与当前 release/0.4 完全一致。