### PR TITLE
[release/0.4][Test] Accept additive pipeline micro-step locations

### DIFF
--- a/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_pipeline_parallel_2.py
+++ b/tests/single_card_tests/ai_edited_test/pipeline_parallel/test_ai_pipeline_parallel_2.py
@@ -89,8 +89,15 @@ class TestPipelineParallelMicroStepLocations(unittest.TestCase):
             PipelineParallelMicroStepLocations,
         )
 
-        members = list(PipelineParallelMicroStepLocations)
-        self.assertEqual(len(members), 4)
+        values = {m.value for m in PipelineParallelMicroStepLocations}
+        self.assertTrue(
+            {
+                "forward_begin",
+                "forward_end",
+                "backward_begin",
+                "backward_end",
+            }.issubset(values)
+        )
 
 
 class TestPipelineParallelMicroStepCallback(unittest.TestCase):


### PR DESCRIPTION
## Why

Paddle `0186b329270` adds `PipelineParallelMicroStepLocations.P2P_ISSUED`, so the enum now has five members. The `release/0.4` test still asserts a fixed total of four and fails in `Unit test (single card)`.

## Change

Assert that the four existing required locations are present instead of asserting the enum total. This matches the fix already merged to `develop` in #1852 and keeps the release test compatible with additive enum extensions.

This is an independent release-branch test fix; it is intentionally separate from dependency PR #1892.