### PR TITLE
[MTP] Use clone() instead of contiguous() to isolate the backbone input under separate_mtp_input

### DIFF
--- a/src/paddlefleet/models/gpt/gpt_embedding.py
+++ b/src/paddlefleet/models/gpt/gpt_embedding.py
@@ -990,7 +990,21 @@ class GPTEmbedding(FleetLayer):
                 # layer through a dedicated key instead. Every entry of mtp_emb_res is
                 # already CP/SP-scattered above, so stack() is a pure container op and
                 # MultiTokenPredictionLayer must not re-scatter them.
-                preproc_output["hidden_states"] = mtp_emb_res[0].contiguous()
+                #
+                # clone() -- NOT contiguous(): Paddle's Tensor.contiguous() returns
+                # `self` when the tensor is already contiguous (see
+                # paddle/fluid/pybind/eager_method.cc, tensor_contiguous), so it
+                # creates neither a new tensor nor an autograd node. The backbone
+                # would then consume mtp_emb_res[0] itself, and the layer-internal
+                # uses of its input (residual bypass + input_layernorm) would become
+                # extra consumers of mtp_emb_res[0]. Its gradient would be accumulated
+                # in a different grouping than the concat baseline -- Paddle
+                # accumulates gradients in-place one contribution at a time
+                # (GradTensorHolder::add), so a different grouping means a different
+                # bf16 rounding path and a 1-ULP mismatch in the embedding gradient.
+                # The concat branch below gets this isolation for free from concat();
+                # clone() gives the same isolation here.
+                preproc_output["hidden_states"] = mtp_emb_res[0].clone()
                 preproc_output["mtp_decoder_inputs"] = paddle.stack(
                     mtp_emb_res[1:]
                 )


### PR DESCRIPTION
### PR Category
Distributed Strategy

### PR Types
Bug fixes

### Description

`separate_mtp_input=True` 与 concat 基线（`separate_mtp_input=False`）之间存在
`embed_tokens.weight` 梯度不一致，导致 loss 从 step 3 起分叉。本 PR 将 `GPTEmbedding`
中交给主干的 `hidden_states` 从 `.contiguous()` 改为 `.clone()`。

**根因**：Paddle 的 `Tensor.contiguous()` 在张量已连续时返回 `self`
（`paddle/fluid/pybind/eager_method.cc`，`tensor_contiguous`），既不产生新张量、也不在
反向图上建节点。于是 `separate_mtp_input` 路径下主干直接消费了 `mtp_emb_res[0]` 本身，
层内部对输入的两次使用（residual 直通 + `input_layernorm`）就成了 `mtp_emb_res[0]` 的
额外消费者。它的梯度因此以与 concat 基线不同的分组被累加；而 Paddle 的梯度累加是逐笔
in-place 进行的（`GradTensorHolder::add`：第一笔直接接管张量，后续笔 `TensorAdd` 原地
相加），分组不同即 bf16 舍入路径不同，最终在 `embed_tokens.weight.grad` 上产生 1 ULP 偏差。

concat 分支通过 `concat()` 天然获得了这层隔离（第 0 层拿到的是 `split` 出来的独立张量）；
`.clone()` 在 `separate_mtp_input` 路径上提供同样的隔离。

**定位过程**：反向逐层二分确认，35 层中 34 层的输入梯度、772 个参数中其余 771 个参数的
梯度、MTP 侧的贡献（`mtp_emb_res[1]` 及其切片回 `mtp_emb_res[0]` 的那一笔）、以及第 0 层
内部全部探针（层输出、MLP 输出、两个 layernorm 输出、attention 输出、post-attention
residual）都已 bit-exact，`mtp_emb_res[0]` 是唯一的分叉点。

**验证**（8xGPU，35 层 MoE，EP=8，PP=TP=CP=1，bf16，seq 8192，`num_nextn_predict_layers=1`）：

| | 修复前 | 修复后 |
|---|---|---|
| `embed_tokens.weight` 梯度 | 1.615397215（concat 基线）vs 1.615366459（separate），相对差 1.9e-5 | bit-exact |
| 全部参数梯度 | 6176 个中 1 个不一致（8 ranks x 772 params） | **6176 / 6176 bit-exact** |
| 10 步 loss | 从 step 3 起分叉 | `loss` / `loss_cur_dp` / `mtp_1_loss` 与基线逐位相同 |

**开销**：多一次 `[b, s, h]` 的拷贝（本例约 134 MB bf16）。相比 `separate_mtp_input` 省掉的
35 层 split/concat 仍然划算。`enable_hyper_connections=True` 时其后紧跟的 `mhc_expand`
本身会产生新张量、已天然具备该隔离，此类配置不受本问题影响。

### 是否引起精度变化
是

`separate_mtp_input=True` 时 `embed_tokens.weight` 的梯度会发生 1 ULP 级别的变化（相对量
~1.9e-5），变化方向是**与 `separate_mtp_input=False` 的 concat 基线对齐**，属于修正而非引入
偏差。使用该开关训练中的作业，续训轨迹与修复前不再逐位一致。`separate_mtp_input=False`
的路径完全不受影响。
