### PR TITLE
[release/0.4][CI] Disable NCCL NVLS on H-card runners

### DIFF
--- a/.github/workflows/Test-release.yml
+++ b/.github/workflows/Test-release.yml
@@ -318,6 +318,7 @@ jobs:
             -e GITHUB_TOKEN="${{ secrets.GITHUB_TOKEN }}" \
             -e GITHUB_RUN_ID="${{ github.run_id }}" \
             -e repo_flag="paddlefleet" \
+            -e NCCL_NVLS_ENABLE=0 \
             -w /paddle --network host ${docker_image}
 
       - name: Install PaddleFleet
@@ -424,6 +425,7 @@ jobs:
             -e GITHUB_TOKEN="${{ secrets.GITHUB_TOKEN }}" \
             -e GITHUB_RUN_ID="${{ github.run_id }}" \
             -e repo_flag="paddlefleet" \
+            -e NCCL_NVLS_ENABLE=0 \
             -w /paddle --network host ${docker_image}
 
       - name: Clone PaddleFleet
@@ -540,6 +542,7 @@ jobs:
             -e GITHUB_RUN_ID="${{ github.run_id }}" \
             -e PR_USER="${{ github.event.pull_request.user.login }}" \
             -e PP="rel" \
+            -e NCCL_NVLS_ENABLE=0 \
             -w /workspace --network host ${docker_image}
 
       - name: Install PaddleFleet
@@ -743,6 +746,7 @@ jobs:
             -e GITHUB_RUN_ID="${{ github.run_id }}" \
             -e PR_USER="${{ github.event.pull_request.user.login }}" \
             -e PP="rel" \
+            -e NCCL_NVLS_ENABLE=0 \
             -w /workspace --network host ${docker_image}
 
       - name: Install PaddleFleet

--- a/.github/workflows/Test-release.yml
+++ b/.github/workflows/Test-release.yml
@@ -444,7 +444,7 @@ jobs:
           python -c "import paddlefleet; print(paddlefleet.version.commit)"
           echo "paddle commit:"
           python -c "import paddle; print(paddle.version.commit)"
-          wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/local/bin/yq
+          wget -q --no-proxy https://paddle-qa.bj.bcebos.com/paddleformers/yq_linux_amd64 -O /usr/local/bin/yq
           chmod +x /usr/local/bin/yq
           '
 
@@ -560,7 +560,7 @@ jobs:
           pip install uv coverage==7.13.0 bce-python-sdk==0.8.74 wrapt
           pip install dist/${{ needs.build_whl.outputs.root_whl_name }} --extra-index-url=https://www.paddlepaddle.org.cn/packages/nightly/cu129/ --extra-index-url=https://www.paddlepaddle.org.cn/packages/stable/cu129/
           pip install dist/${{ needs.build_whl.outputs.ops_whl_name }} --extra-index-url=https://www.paddlepaddle.org.cn/packages/nightly/cu129/ --extra-index-url=https://www.paddlepaddle.org.cn/packages/stable/cu129/
-          wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/local/bin/yq
+          wget -q --no-proxy https://paddle-qa.bj.bcebos.com/paddleformers/yq_linux_amd64 -O /usr/local/bin/yq
           chmod +x /usr/local/bin/yq
           echo "paddlefleet commit:"
           python -c "import paddlefleet; print(paddlefleet.version.commit)"
@@ -763,7 +763,7 @@ jobs:
           pip install uv coverage==7.13.0 bce-python-sdk==0.8.74 wrapt
           pip install dist/${{ needs.build_whl.outputs.root_whl_name }} --extra-index-url=https://www.paddlepaddle.org.cn/packages/nightly/cu129/ --extra-index-url=https://www.paddlepaddle.org.cn/packages/stable/cu129/
           pip install dist/${{ needs.build_whl.outputs.ops_whl_name }} --extra-index-url=https://www.paddlepaddle.org.cn/packages/nightly/cu129/ --extra-index-url=https://www.paddlepaddle.org.cn/packages/stable/cu129/
-          wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/local/bin/yq
+          wget -q --no-proxy https://paddle-qa.bj.bcebos.com/paddleformers/yq_linux_amd64 -O /usr/local/bin/yq
           chmod +x /usr/local/bin/yq
           echo "paddlefleet commit:"
           python -c "import paddlefleet; print(paddlefleet.version.commit)"
@@ -1129,7 +1129,7 @@ jobs:
           pip install uv coverage==7.13.0 bce-python-sdk==0.8.74 wrapt
           pip install dist/${{ needs.build_whl.outputs.root_whl_name }} --extra-index-url=https://www.paddlepaddle.org.cn/packages/nightly/cu129/ --extra-index-url=https://www.paddlepaddle.org.cn/packages/stable/cu129/
           pip install dist/${{ needs.build_whl.outputs.ops_whl_name }} --extra-index-url=https://www.paddlepaddle.org.cn/packages/nightly/cu129/ --extra-index-url=https://www.paddlepaddle.org.cn/packages/stable/cu129/
-          wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/local/bin/yq
+          wget -q --no-proxy https://paddle-qa.bj.bcebos.com/paddleformers/yq_linux_amd64 -O /usr/local/bin/yq
           chmod +x /usr/local/bin/yq
           echo "paddlefleet commit:"
           python -c "import paddlefleet; print(paddlefleet.version.commit)"


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Devs

### Description
在 `Test-release.yml` 中给运行在 H 卡机器（`Fleet-H-single-card` / `Fleet-H-multi-card`）上的 4 个 job 的 docker 启动参数加上 `-e NCCL_NVLS_ENABLE=0`：

- `single_card_test` — Unit test (single card)
- `multi-card_test` — Unit test (multi-card)
- Integration test (H20, single card)
- Integration test (H20, multi-card)

未改动 `build_whl`（CPU 机器）和 Integration test (A100)（`Distribute` group，非 H 卡）。

### 是否引起精度变化
否
merged dev : https://github.com/PaddlePaddle/PaddleFleet/pull/1842