### PR TITLE
[Deps] Bump Paddle to `7328b320bd3`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ description = "Fleet Core - Core Functional Library for Large Scale Distributed 
 requires-python = ">=3.10"
 dependencies = [
     "colorlog>=6.10.1",
-    "paddlepaddle-gpu==3.4.0.post20260826+0186b329270",
+    "paddlepaddle-gpu==3.4.0.post20260828+7328b320bd3",
     "ruamel.yaml>=0.17",
     "tilelang-paddle==0.1.12",
 ]


### PR DESCRIPTION
### PR Category
Environment Adaptation

### PR Types
Others

### Description
Bump the pinned CUDA 12.9 Paddle dependency to `paddlepaddle-gpu==3.4.0.post20260828+7328b320bd3`.

Target Paddle commit: [`7328b320bd302e6336a1692006fdc79226d8d233`](https://github.com/PaddlePaddle/Paddle/commit/7328b320bd302e6336a1692006fdc79226d8d233).

The authoritative cu129 nightly index contains the target package for CPython 3.10 through 3.13:

- [CPython 3.10 wheel](https://paddle-whl.cdn.bcebos.com/nightly/cu129/paddlepaddle-gpu/paddlepaddle_gpu-3.4.0.post20260828%2B7328b320bd3-cp310-cp310-linux_x86_64.whl)
- [CPython 3.11 wheel](https://paddle-whl.cdn.bcebos.com/nightly/cu129/paddlepaddle-gpu/paddlepaddle_gpu-3.4.0.post20260828%2B7328b320bd3-cp311-cp311-linux_x86_64.whl)
- [CPython 3.12 wheel](https://paddle-whl.cdn.bcebos.com/nightly/cu129/paddlepaddle-gpu/paddlepaddle_gpu-3.4.0.post20260828%2B7328b320bd3-cp312-cp312-linux_x86_64.whl)
- [CPython 3.13 wheel](https://paddle-whl.cdn.bcebos.com/nightly/cu129/paddlepaddle-gpu/paddlepaddle_gpu-3.4.0.post20260828%2B7328b320bd3-cp313-cp313-linux_x86_64.whl)

The CPython 3.10 wheel returned HTTP 200 and its package metadata reports version `3.4.0.post20260828+7328b320bd3`; its embedded Paddle version file reports CUDA `12.9` and the full commit `7328b320bd302e6336a1692006fdc79226d8d233`.

Validation: TOML and PEP 508 parsing, `git diff --check`, exact one-file/one-line delta, and `pre-commit run --files pyproject.toml` pass.

### 是否引起精度变化
否
