### PR TITLE
[MLA] Keep the MLA RoPE pairing when MQA absorption is on

### DIFF
--- a/src/paddlefleet/models/common/embeddings/rope_utils.py
+++ b/src/paddlefleet/models/common/embeddings/rope_utils.py
@@ -514,6 +514,7 @@ def apply_rotary_pos_emb(
     inverse: bool = False,
     mla_output_remove_interleaving: bool = False,
     apply_rope_fusion: bool | None = None,
+    multi_latent_attention: bool | None = None,
 ):
     """
     Reroute to the appropriate apply_rotary_pos_emb function depending on
@@ -548,16 +549,30 @@ def apply_rotary_pos_emb(
             handle -- e.g. absorbed MQA, whose per-head K/V never exists --
             pass ``False`` so only their layer falls back to the eager path
             while the rest of the model keeps the fusion.
+        multi_latent_attention (bool | None): Per-call override of
+            ``config.multi_latent_attention`` for the RoPE input pairing only.
+            ``None`` (default) means "follow the config", which is what every
+            existing caller gets. Pass ``True`` to de-interleave (pair channels
+            ``2k`` / ``2k+1``) on this call alone -- absorbed-MQA layers need
+            that to keep an MLA checkpoint's channel-to-frequency map, and
+            ``config.multi_latent_attention`` cannot be used for it because it
+            also drives layer-spec selection and position-embedding
+            construction.
     """
     use_fusion = (
         config.apply_rope_fusion
         if apply_rope_fusion is None
         else apply_rope_fusion
     )
+    use_mla_pairing = (
+        config.multi_latent_attention
+        if multi_latent_attention is None
+        else multi_latent_attention
+    )
     rope_kwargs = {
         "apply_rope_fusion": use_fusion if not inverse else False,
         "rotary_interleaved": config.rotary_interleaved,
-        "multi_latent_attention": config.multi_latent_attention,
+        "multi_latent_attention": use_mla_pairing,
         "high_precision_rope": config.high_precision_rope,
         "rope_theta": config.rope_theta,
         "time_major": config.sequence_parallel,

--- a/src/paddlefleet/transformer/multi_latent_attention.py
+++ b/src/paddlefleet/transformer/multi_latent_attention.py
@@ -2062,6 +2062,17 @@ class MLASelfAttention(MultiLatentAttention):
                     rotary_pos_emb = rotary_pos_emb.transpose([1, 0, 2, 3])
 
                 k_rope_fused_with_cat = False
+                # RoPE input pairing for this layer. False -- the default, and
+                # what every pre-existing config gets -- keeps the (k, k+half)
+                # pairing both branches below have always used. True restores
+                # the (2k, 2k+1) pairing of ``fused_apply_mla_rope_for_q`` /
+                # ``_for_kv``, which absorption cannot reach (the fused branch
+                # above falls through on ``mqa_latent``), so an MLA checkpoint keeps
+                # its channel-to-frequency map. Inert on non-absorbed layers;
+                # see ``mqa_latent_rope_adjacent_pairing``.
+                mqa_rope_adjacent = self.mqa_latent and getattr(
+                    self.config, "mqa_latent_rope_adjacent_pairing", False
+                )
                 if self.config.gpt_model_use_experimental_version:
                     # EC-compatible RoPE: complex rotation, no YaRN, no mscale
                     from paddlefleet.transformer.transformer_layer import (
@@ -2106,7 +2117,13 @@ class MLASelfAttention(MultiLatentAttention):
                     # strips ``assert`` and would let the wrong layout reach
                     # ``fused_apply_rope_half`` and silently corrupt results.
                     # Matches the shape guards elsewhere in this file.
-                    if self.config.multi_latent_attention:
+                    # ``mqa_latent_rope_adjacent_pairing`` is the one case that
+                    # does implement it: ``adjacent_in=True`` below gathers
+                    # (2k, 2k+1), which is exactly the de-interleave.
+                    if (
+                        self.config.multi_latent_attention
+                        and not mqa_rope_adjacent
+                    ):
                         raise ValueError(
                             "mqa_latent_rope_fusion does not implement the "
                             "multi_latent_attention de-interleave (0::2 / 1::2)"
@@ -2170,6 +2187,7 @@ class MLASelfAttention(MultiLatentAttention):
                         rotary_pos_emb,
                         self.qk_rope_head_dim,
                         mscale,
+                        adjacent_in=mqa_rope_adjacent,
                     )
                     # Defer k's rope to ``fused_rope_cat_key`` below, which
                     # rotates and concatenates in one pass.
@@ -2187,6 +2205,13 @@ class MLASelfAttention(MultiLatentAttention):
                         cp_group=self.pg_collection.cp,
                         apply_rope_fusion=bool(self.config.apply_rope_fusion)
                         and not self.mqa_latent,
+                        # None = follow the config. True de-interleaves this
+                        # call only, because ``config.multi_latent_attention``
+                        # also drives layer-spec selection and
+                        # position-embedding construction.
+                        multi_latent_attention=True
+                        if mqa_rope_adjacent
+                        else None,
                     )
                     # k_pos_emb:[num_tokens, 1, qk_rope_head_dim]
                     k_pos_emb = apply_rotary_pos_emb(
@@ -2203,6 +2228,10 @@ class MLASelfAttention(MultiLatentAttention):
                         else None,
                         apply_rope_fusion=bool(self.config.apply_rope_fusion)
                         and not self.mqa_latent,
+                        # Must match the q side above: the two meet in q @ k^T.
+                        multi_latent_attention=True
+                        if mqa_rope_adjacent
+                        else None,
                     )
 
                 # query: [num_tokens, n, (qk_nope_head_dim + qk_rope_head_dim)]
@@ -2274,6 +2303,7 @@ class MLASelfAttention(MultiLatentAttention):
                             self.kv_lora_rank,
                             self.qk_rope_head_dim,
                             mscale,
+                            adjacent_in=mqa_rope_adjacent,
                         )
                     else:
                         key = paddle.cat(

--- a/src/paddlefleet/transformer/multi_latent_attention.py
+++ b/src/paddlefleet/transformer/multi_latent_attention.py
@@ -2073,6 +2073,16 @@ class MLASelfAttention(MultiLatentAttention):
                 mqa_rope_adjacent = self.mqa_latent and getattr(
                     self.config, "mqa_latent_rope_adjacent_pairing", False
                 )
+                # Only spelled out when the pairing is switched, so the default
+                # path calls ``apply_rotary_pos_emb`` with exactly the arguments
+                # it did before. ``True`` de-interleaves these two calls alone,
+                # because ``config.multi_latent_attention`` also drives
+                # layer-spec selection and position-embedding construction.
+                rope_pairing_kwargs = (
+                    {"multi_latent_attention": True}
+                    if mqa_rope_adjacent
+                    else {}
+                )
                 if self.config.gpt_model_use_experimental_version:
                     # EC-compatible RoPE: complex rotation, no YaRN, no mscale
                     from paddlefleet.transformer.transformer_layer import (
@@ -2205,13 +2215,7 @@ class MLASelfAttention(MultiLatentAttention):
                         cp_group=self.pg_collection.cp,
                         apply_rope_fusion=bool(self.config.apply_rope_fusion)
                         and not self.mqa_latent,
-                        # None = follow the config. True de-interleaves this
-                        # call only, because ``config.multi_latent_attention``
-                        # also drives layer-spec selection and
-                        # position-embedding construction.
-                        multi_latent_attention=True
-                        if mqa_rope_adjacent
-                        else None,
+                        **rope_pairing_kwargs,
                     )
                     # k_pos_emb:[num_tokens, 1, qk_rope_head_dim]
                     k_pos_emb = apply_rotary_pos_emb(
@@ -2229,9 +2233,7 @@ class MLASelfAttention(MultiLatentAttention):
                         apply_rope_fusion=bool(self.config.apply_rope_fusion)
                         and not self.mqa_latent,
                         # Must match the q side above: the two meet in q @ k^T.
-                        multi_latent_attention=True
-                        if mqa_rope_adjacent
-                        else None,
+                        **rope_pairing_kwargs,
                     )
 
                 # query: [num_tokens, n, (qk_nope_head_dim + qk_rope_head_dim)]

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -630,6 +630,47 @@ class TransformerConfig(ModelParallelConfig):
     asserts itself.
     """
 
+    mqa_latent_rope_adjacent_pairing: bool = False
+    """If True, the absorbed-MQA (``mqa_latent``) layers pair RoPE channels
+    ``(2k, 2k+1)`` instead of ``(k, k+half)``.
+
+    A **checkpoint-compatibility** switch, not a performance one: which two
+    channels share a frequency decides which frequency each learned channel of
+    ``q_b_proj`` / ``kv_a_proj`` gets, so the pairing is part of the meaning of
+    those weights.
+
+    An unabsorbed MLA layer under ``apply_rope_fusion`` runs
+    ``fused_apply_mla_rope_for_q`` / ``_for_kv``, which pair ``(2k, 2k+1)``.
+    Latent MQA makes the ``apply_rope_fusion and not self.mqa_latent`` test
+    in ``MLASelfAttention`` fall through, because ``_for_kv`` needs the
+    per-head K/V that absorption never materialises, and every path that
+    remains pairs
+    ``(k, k+half)``. Enabling absorption therefore silently permutes an MLA
+    checkpoint's channel-to-frequency map -- harmless where the backbone can
+    retrain, not harmless where it cannot (a frozen-backbone indexer warmup
+    distils a scrambled attention distribution; see ``train_indexer_only``).
+
+    Set it to keep the pairing across that switch. It reaches both paths: the
+    eager one via a per-call ``multi_latent_attention=True`` (the config field
+    itself cannot be flipped, since it also drives layer-spec selection and
+    position-embedding construction), the fused one via ``adjacent_in=True`` on
+    ``fused_apply_rope_half`` / ``fused_rope_cat_key``. Only the gather
+    positions move, so the arithmetic, the bf16 rounding and the half-split
+    *output* layout are identical and the two paths stay bit-exact with each
+    other. Output layout is left at half-split on purpose: it is q/k-symmetric
+    and therefore invisible to ``q @ k^T``.
+
+    Pairing is a within-head_dim property, so this is orthogonal to TP, SP, CP,
+    PP and EP.
+
+    Inert, and rejected by ``__post_init__``, where it cannot take effect: no
+    absorbed layers, or ``gpt_model_use_experimental_version``. Also rejected
+    with ``rotary_interleaved``, which expresses the same pairing by building a
+    different ``freqs`` layout; combining them would rotate twice. The HCA/CSA
+    (``ratio != -2``) layers pair ``(2k, 2k+1)`` already, via
+    ``fused_apply_mla_rope_inplace``, and are not touched.
+    """
+
     sigmoid_gate_fusion: bool = False
     """If True, use Triton fused sigmoid gate kernel."""
 
@@ -2435,6 +2476,48 @@ class TransformerConfig(ModelParallelConfig):
                     " -2 layers. Under the default 'mha' those layers are dense "
                     "MLA and build no MQADocMeta, so the switch would be a silent "
                     "no-op. Use csa_share_docmask_meta for the HCA/CSA layers."
+                )
+        if self.mqa_latent_rope_adjacent_pairing:
+            # Every failure mode here is silent: a config with no absorbed
+            # layers never reads the flag, and ``rotary_interleaved`` already
+            # expresses the same pairing through the ``freqs`` layout, so
+            # combining them rotates the (2k, 2k+1) pair twice and produces a
+            # plausible-looking but wrong result. Checked once, here.
+            ratios = [int(r) for r in (self.csa_compress_ratios or [])]
+            has_latent_mqa = (
+                self.hybrid_mla_attention in ("mqa_dsa", "mqa_full_causal")
+                and -2 in ratios
+            )
+            if not has_latent_mqa:
+                raise ValueError(
+                    "mqa_latent_rope_adjacent_pairing applies to the absorbed "
+                    "(latent) MQA layers, i.e. csa_compress_ratios entries "
+                    "equal to -2 under hybrid_mla_attention='mqa_dsa' or "
+                    "'mqa_full_causal', but this config has "
+                    f"hybrid_mla_attention={self.hybrid_mla_attention!r} and "
+                    f"{'some' if -2 in ratios else 'no'} -2 layers. Under "
+                    "'mha' those layers are unabsorbed MLA and already pair "
+                    "(2k, 2k+1) through apply_rope_fusion, so the switch would "
+                    "be a silent no-op."
+                )
+            if self.rotary_interleaved:
+                raise ValueError(
+                    "mqa_latent_rope_adjacent_pairing and rotary_interleaved "
+                    "both select the (2k, 2k+1) pairing, by different means: "
+                    "rotary_interleaved builds freqs so that channel i carries "
+                    "theta_(i//2) and _rotate_half slices 0::2 / 1::2, while "
+                    "this flag keeps the halved freqs layout and de-interleaves "
+                    "the input instead. Enabling both applies the rotation "
+                    "twice. Use rotary_interleaved alone if the whole model "
+                    "should be interleaved."
+                )
+            if self.gpt_model_use_experimental_version:
+                raise ValueError(
+                    "mqa_latent_rope_adjacent_pairing has no effect under "
+                    "gpt_model_use_experimental_version: that path routes the "
+                    "MLA layers through _ec_compatible_rope_apply, a complex "
+                    "rotation with its own pairing that neither branch of this "
+                    "switch reaches. It would be a silent no-op."
                 )
         if self.fuse_inv_rope_into_vha_postmix:
             # ``DSv4HybridAttention._can_fuse_inv_rope_postmix`` answers no by

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -631,8 +631,20 @@ class TransformerConfig(ModelParallelConfig):
     """
 
     mqa_latent_rope_adjacent_pairing: bool = False
-    """If True, the absorbed-MQA (``mqa_latent``) layers pair RoPE channels
-    ``(2k, 2k+1)`` instead of ``(k, k+half)``.
+    """Which RoPE channel pair shares a frequency in absorbed-MQA layers.
+
+    Values, both meaningful for every absorbed-MQA (``mqa_latent``) config:
+
+    - ``False`` (default) -- pair ``(k, k+half)``, exactly what both the eager
+      and the ``mqa_latent_rope_fusion`` branch have always done. The default
+      therefore leaves every pre-existing config bit-identical, and the DSA
+      indexer, which shares ``fused_apply_rope_half``, keeps this pairing too.
+      Choose it for a model trained from scratch with absorption on, or whenever
+      no checkpoint has to survive an absorption switch.
+    - ``True`` -- pair ``(2k, 2k+1)`` in the absorbed layers only. Choose it when
+      loading a checkpoint whose MLA layers were trained unabsorbed under
+      ``apply_rope_fusion``, above all when the backbone is frozen and cannot
+      adapt.
 
     A **checkpoint-compatibility** switch, not a performance one: which two
     channels share a frequency decides which frequency each learned channel of
@@ -651,7 +663,8 @@ class TransformerConfig(ModelParallelConfig):
     distils a scrambled attention distribution; see ``train_indexer_only``).
 
     Set it to keep the pairing across that switch. It reaches both paths: the
-    eager one via a per-call ``multi_latent_attention=True`` (the config field
+    eager one via a per-call ``multi_latent_attention=True`` (passed only when
+    this flag is set, so the default path's call is unchanged; the config field
     itself cannot be flipped, since it also drives layer-spec selection and
     position-embedding construction), the fused one via ``adjacent_in=True`` on
     ``fused_apply_rope_half`` / ``fused_rope_cat_key``. Only the gather

--- a/src/paddlefleet/triton_ops/mla_rope_inplace_fusion.py
+++ b/src/paddlefleet/triton_ops/mla_rope_inplace_fusion.py
@@ -469,6 +469,7 @@ def _rope_cat_key_fwd_kernel(
     stride_kpe,
     stride_out,
     stride_pe_out,
+    ADJACENT_IN: tl.constexpr,
     BLOCK_L: tl.constexpr,
 ):
     """Forward: OUT[:latent] = KV, OUT[latent:] = PE_OUT = rotate_half(KPE)."""
@@ -488,8 +489,14 @@ def _rope_cat_key_fwd_kernel(
     sin_right = tl.load(SIN + pid * pe_dim + half + tl.arange(0, half))
 
     h = tl.arange(0, half)
-    x_1 = tl.load(KPE + pid * stride_kpe + h)
-    x_2 = tl.load(KPE + pid * stride_kpe + half + h)
+    if ADJACENT_IN:
+        # Adjacent source pairing; see ``_rope_half_out_fwd_kernel``. The stores
+        # below are untouched, so the output stays half-split.
+        x_1 = tl.load(KPE + pid * stride_kpe + 2 * h)
+        x_2 = tl.load(KPE + pid * stride_kpe + 2 * h + 1)
+    else:
+        x_1 = tl.load(KPE + pid * stride_kpe + h)
+        x_2 = tl.load(KPE + pid * stride_kpe + half + h)
 
     y_left = _mul_round_bf16(x_1, cos_left).to(tl.float32) - _mul_round_bf16(
         x_2, sin_left
@@ -524,6 +531,7 @@ def _rope_cat_key_bwd_kernel(
     stride_out,
     stride_pe_out,
     HAS_DPE_OUT: tl.constexpr,
+    ADJACENT_IN: tl.constexpr,
     BLOCK_L: tl.constexpr,
 ):
     """Backward: split DOUT, passing the latent part through unchanged."""
@@ -564,15 +572,21 @@ def _rope_cat_key_bwd_kernel(
         g1, sin_left
     ).to(tl.float32)
 
-    tl.store(DKPE + pid * stride_kpe + h, dx_1)
-    tl.store(DKPE + pid * stride_kpe + half + h, dx_2)
+    if ADJACENT_IN:
+        # Mirrors the forward gather; the DOUT/DPE_OUT reads above follow the
+        # output layout and are unaffected.
+        tl.store(DKPE + pid * stride_kpe + 2 * h, dx_1)
+        tl.store(DKPE + pid * stride_kpe + 2 * h + 1, dx_2)
+    else:
+        tl.store(DKPE + pid * stride_kpe + h, dx_1)
+        tl.store(DKPE + pid * stride_kpe + half + h, dx_2)
 
 
 class RoPECatKeyFusion(paddle.autograd.PyLayer):
     """PyLayer wrapping the rope+concat absorbed-key kernels."""
 
     @staticmethod
-    def forward(ctx, kv, kpe, cos, sin, latent_dim, pe_dim):
+    def forward(ctx, kv, kpe, cos, sin, latent_dim, pe_dim, adjacent_in):
         # Input validation via explicit exceptions (not ``assert``): this is the
         # PyLayer behind the public ``fused_rope_cat_key`` entry, so under
         # ``python -O`` a stripped assert would let a wrong shape / non-contiguous
@@ -622,11 +636,13 @@ class RoPECatKeyFusion(paddle.autograd.PyLayer):
             kpe_flat.stride(0),
             out.stride(0),
             pe_out.stride(0),
+            adjacent_in,
             BLOCK_L,
         )
 
         ctx.save_for_backward(cos, sin)
         ctx.dims = (latent_dim, pe_dim, BLOCK_L)
+        ctx.adjacent_in = adjacent_in
         ctx.kv_shape = kv.shape
         ctx.kpe_shape = kpe.shape
         b, s = kv.shape[0], kv.shape[1]
@@ -666,6 +682,7 @@ class RoPECatKeyFusion(paddle.autograd.PyLayer):
             dout_flat.stride(0),
             dpe_flat.stride(0),
             has_dpe,
+            ctx.adjacent_in,
             BLOCK_L,
         )
         return (
@@ -683,6 +700,7 @@ def fused_rope_cat_key(
     latent_dim: int,
     pe_dim: int,
     mscale: float = 1.0,
+    adjacent_in: bool = False,
 ) -> tuple[paddle.Tensor, paddle.Tensor]:
     """Build the absorbed-MQA key: rotate ``k_pos_emb`` and concat, in one pass.
 
@@ -716,6 +734,10 @@ def fused_rope_cat_key(
         latent_dim: width of the value/nope block that leads the key.
         pe_dim: width of the rope block that trails it.
         mscale: scaling factor; must be 1.0 when ``freqs`` is not fp32.
+        adjacent_in: pair ``k_pos_emb``'s source channels ``(2k, 2k+1)`` instead
+            of ``(k, k+half)``. Must match the q side's ``adjacent_in``, since
+            the two meet in ``q @ k^T``. Default False leaves existing callers
+            unchanged.
 
     Returns:
         (key, k_pe) where key is [b, s, 1, latent_dim + pe_dim] with the
@@ -761,7 +783,7 @@ def fused_rope_cat_key(
 
     cos, sin = _fused_cos_sin(freqs, mscale, False, kv_compressed.dtype)
     return RoPECatKeyFusion.apply(
-        kv_compressed, k_pos_emb, cos, sin, latent_dim, pe_dim
+        kv_compressed, k_pos_emb, cos, sin, latent_dim, pe_dim, adjacent_in
     )
 
 
@@ -833,6 +855,7 @@ def _rope_half_out_fwd_kernel(
     stride_o_seq,
     stride_o_nheads,
     COPY_OTHER: tl.constexpr,
+    ADJACENT_IN: tl.constexpr,
     BLOCK_D: tl.constexpr,
     BLOCK_H: tl.constexpr,
 ):
@@ -872,8 +895,19 @@ def _rope_half_out_fwd_kernel(
         )
         tl.store(OUT + os + d, tl.load(X + xs + d, mask=other), mask=other)
 
-    off_l = xs + pe_offset + tl.arange(0, half)[None, :]
-    off_r = off_l + half
+    if ADJACENT_IN:
+        # The pair sharing a frequency is adjacent in the *source*, as in
+        # ``rotary_fwd_q_kernel`` in ``fused_mla_yarn_rope_apply.py``. Only
+        # the gather positions move: cos/sin indexing, the arithmetic below, the
+        # rounding and the half-split store positions are all unchanged, which
+        # is what keeps this bit-exact with the eager
+        # ``multi_latent_attention=True, mla_output_remove_interleaving=False``
+        # pair. 32 strided loads, no register shuffle.
+        off_l = xs + pe_offset + tl.arange(0, half)[None, :] * 2
+        off_r = off_l + 1
+    else:
+        off_l = xs + pe_offset + tl.arange(0, half)[None, :]
+        off_r = off_l + half
     out_l = os + pe_offset + tl.arange(0, half)[None, :]
     out_r = out_l + half
 
@@ -908,6 +942,7 @@ def _rope_half_out_bwd_kernel(
     stride_x_seq,
     stride_x_nheads,
     COPY_OTHER: tl.constexpr,
+    ADJACENT_IN: tl.constexpr,
     BLOCK_D: tl.constexpr,
     BLOCK_H: tl.constexpr,
 ):
@@ -946,8 +981,16 @@ def _rope_half_out_bwd_kernel(
 
     off_l = os + pe_offset + tl.arange(0, half)[None, :]
     off_r = off_l + half
-    dx_l = xs + pe_offset + tl.arange(0, half)[None, :]
-    dx_r = dx_l + half
+    if ADJACENT_IN:
+        # ``off_l``/``off_r`` follow the *output* layout, which ADJACENT_IN does
+        # not change; only the input-gradient scatter does, mirroring the
+        # forward gather. Together they still cover every channel of the block
+        # exactly once, so ``dx`` stays fully written.
+        dx_l = xs + pe_offset + tl.arange(0, half)[None, :] * 2
+        dx_r = dx_l + 1
+    else:
+        dx_l = xs + pe_offset + tl.arange(0, half)[None, :]
+        dx_r = dx_l + half
 
     g1 = tl.load(DO + off_l, mask=head_mask)
     g2 = tl.load(DO + off_r, mask=head_mask)
@@ -967,7 +1010,7 @@ class RoPEHalfOutFusion(paddle.autograd.PyLayer):
     """PyLayer wrapping the out-of-place rotate_half fwd/bwd kernels."""
 
     @staticmethod
-    def forward(ctx, t, cos, sin, pe_dim, pe_offset):
+    def forward(ctx, t, cos, sin, pe_dim, pe_offset, adjacent_in):
         # Input validation via explicit exceptions (not ``assert``): this is the
         # PyLayer behind the public ``fused_apply_rope_half`` entry, so under
         # ``python -O`` a stripped assert would let a wrong shape / non-contiguous
@@ -1018,6 +1061,7 @@ class RoPEHalfOutFusion(paddle.autograd.PyLayer):
             o_flat.stride(0),
             o_flat.stride(1),
             copy_other,
+            adjacent_in,
             block_d,
             BLOCK_H,
         )
@@ -1028,6 +1072,7 @@ class RoPEHalfOutFusion(paddle.autograd.PyLayer):
         ctx.block_h = BLOCK_H
         ctx.block_d = block_d
         ctx.copy_other = copy_other
+        ctx.adjacent_in = adjacent_in
         ctx.shape = (B, S, H, D)
         return out
 
@@ -1053,6 +1098,7 @@ class RoPEHalfOutFusion(paddle.autograd.PyLayer):
             dx.stride(0),
             dx.stride(1),
             ctx.copy_other,
+            ctx.adjacent_in,
             ctx.block_d,
             BLOCK_H,
         )
@@ -1065,6 +1111,7 @@ def fused_apply_rope_half(
     pe_dim: int,
     mscale: float = 1.0,
     pe_offset: int = 0,
+    adjacent_in: bool = False,
 ) -> paddle.Tensor:
     """Out-of-place RoPE on a contiguous rope block, rotate_half convention.
 
@@ -1087,6 +1134,13 @@ def fused_apply_rope_half(
             *already rounded* bf16 cosine by mscale while this kernel scales
             in fp32.  Those agree only at mscale == 1.0.
         pe_offset: channel offset of the rope block inside each head.
+        adjacent_in: pair source channels ``(2k, 2k+1)`` instead of
+            ``(k, k+half)``. The output still lands in halves, so this is
+            bit-exact with the eager ``multi_latent_attention=True,
+            mla_output_remove_interleaving=False`` pair (and with
+            ``fused_apply_mla_rope_for_q``) rather than with the default's
+            ``multi_latent_attention=False``. Default False leaves every
+            existing caller, including the DSA indexer, unchanged.
 
     Returns:
         A new [B, S, H, D] tensor: [..., pe_offset : pe_offset + pe_dim] is
@@ -1136,4 +1190,4 @@ def fused_apply_rope_half(
 
     cos, sin = _fused_cos_sin(freqs, mscale, False, t.dtype)
 
-    return RoPEHalfOutFusion.apply(t, cos, sin, pe_dim, pe_offset)
+    return RoPEHalfOutFusion.apply(t, cos, sin, pe_dim, pe_offset, adjacent_in)

--- a/tests/single_card_tests/test_rope_half_fusion.py
+++ b/tests/single_card_tests/test_rope_half_fusion.py
@@ -36,6 +36,7 @@ import paddle
 from paddlefleet.models.common.embeddings.rope_utils import (
     _apply_rotary_pos_emb_bshd,
 )
+from paddlefleet.transformer.transformer_config import TransformerConfig
 from paddlefleet.triton_ops import (
     fused_apply_rope_half,
     fused_rope_cat_key,
@@ -338,6 +339,215 @@ class TestFusedRopeCatKey(unittest.TestCase):
         ref, pe_ref = self._reference(kv, kpe.unsqueeze(-2), freqs)
         _check_equal(key, ref)
         _check_equal(k_pe, pe_ref)
+
+
+class TestAdjacentInPairing(unittest.TestCase):
+    """``adjacent_in``: pair source channels (2k, 2k+1), not (k, k+half).
+
+    This is the ``mqa_latent_rope_adjacent_pairing`` path. It exists so an
+    absorbed-MQA layer can keep the channel-to-frequency map an unabsorbed MLA
+    checkpoint was trained with, i.e. the one
+    ``fused_apply_mla_rope_for_q`` / ``_for_kv`` produce -- absorption cannot
+    reach those kernels, and every path that remains pairs ``(k, k+half)``.
+
+    Only the gather positions move; the *output* stays half-split. So the
+    reference is eager with ``multi_latent_attention=True`` (de-interleaves the
+    input) and ``mla_output_remove_interleaving=False`` (leaves the output in
+    halves), and the match must be bit-exact both ways.
+    """
+
+    LATENT = 512
+
+    def setUp(self) -> None:
+        paddle.seed(0)
+
+    @staticmethod
+    def _eager(x, freqs, pe_dim, pe_offset, adjacent):
+        lead = x[..., :pe_offset]
+        x_pe = x[..., pe_offset : pe_offset + pe_dim]
+        trail = x[..., pe_offset + pe_dim :]
+        x_pe = _apply_rotary_pos_emb_bshd(
+            x_pe,
+            freqs,
+            rotary_interleaved=False,
+            multi_latent_attention=adjacent,
+            mla_output_remove_interleaving=False,
+            mscale=1.0,
+        )
+        return paddle.concat([lead, x_pe, trail], axis=-1)
+
+    def _run_half(self, s, h, head_dim, pe_offset, adjacent):
+        x0 = paddle.randn([1, s, h, head_dim], "bfloat16")
+        freqs = paddle.randn([1, s, 1, PE_DIM])
+        freqs.stop_gradient = True
+
+        outs = []
+        grad = None
+        for fused in (False, True):
+            x = x0.detach()
+            x.stop_gradient = False
+            if fused:
+                out = fused_apply_rope_half(
+                    x,
+                    freqs,
+                    PE_DIM,
+                    pe_offset=pe_offset,
+                    adjacent_in=adjacent,
+                )
+            else:
+                out = self._eager(x, freqs, PE_DIM, pe_offset, adjacent)
+            if grad is None:
+                grad = paddle.randn_like(out)
+            out.backward(grad)
+            outs.append((out.detach(), x.grad))
+
+        (out_ref, grad_ref), (out_fused, grad_fused) = outs
+        _check_equal(out_fused, out_ref)
+        _check_equal(grad_fused, grad_ref)
+        return out_fused
+
+    def test_matches_eager_de_interleave(self) -> None:
+        """MLA q shape, rope block trailing: the production call site."""
+        self._run_half(512, 64, 192 + PE_DIM, 192, adjacent=True)
+
+    def test_default_still_matches_half_split_eager(self) -> None:
+        """``adjacent_in=False`` must stay exactly what it always was.
+
+        Every pre-existing caller -- the DSA indexer included -- keeps the
+        default, so a regression here would silently change trained models.
+        """
+        self._run_half(512, 64, 192 + PE_DIM, 192, adjacent=False)
+
+    def test_pe_only_and_mid_block(self) -> None:
+        """``k_pos_emb`` ([b, s, 1, 64]) and a rope block with both sides."""
+        self._run_half(256, 1, PE_DIM, 0, adjacent=True)
+        self._run_half(128, 12, 192, 64, adjacent=True)
+
+    def test_the_two_pairings_differ(self) -> None:
+        """Guard against the flag becoming a no-op.
+
+        The whole point is that the two conventions assign different
+        frequencies to the same channel, so they must not agree.
+        """
+        s, h = 128, 4
+        x = paddle.randn([1, s, h, PE_DIM], "bfloat16")
+        freqs = paddle.randn([1, s, 1, PE_DIM])
+        freqs.stop_gradient = True
+        half = fused_apply_rope_half(x, freqs, PE_DIM, adjacent_in=False)
+        adj = fused_apply_rope_half(x, freqs, PE_DIM, adjacent_in=True)
+        self.assertFalse(bool(paddle.all(half == adj)))
+
+    def test_cat_key_matches_eager_de_interleave(self) -> None:
+        """``fused_rope_cat_key`` builds the absorbed key; q/k must agree."""
+        s = 512
+        kv0 = paddle.randn([1, s, self.LATENT], "bfloat16")
+        kpe0 = paddle.randn([1, s, 1, PE_DIM], "bfloat16")
+        freqs = paddle.randn([1, s, 1, PE_DIM])
+        freqs.stop_gradient = True
+
+        outs = []
+        grads = {}
+        for fused in (False, True):
+            kv = kv0.detach()
+            kpe = kpe0.detach()
+            kv.stop_gradient = False
+            kpe.stop_gradient = False
+            if fused:
+                key, k_pe = fused_rope_cat_key(
+                    kv,
+                    kpe,
+                    freqs,
+                    self.LATENT,
+                    PE_DIM,
+                    adjacent_in=True,
+                )
+            else:
+                rot = _apply_rotary_pos_emb_bshd(
+                    kpe,
+                    freqs,
+                    rotary_interleaved=False,
+                    multi_latent_attention=True,
+                    mla_output_remove_interleaving=False,
+                    mscale=1.0,
+                )
+                key = paddle.concat([kv.unsqueeze(-2), rot], axis=-1)
+                k_pe = rot
+            if not grads:
+                grads["key"] = paddle.randn_like(key)
+                grads["k_pe"] = paddle.randn_like(k_pe)
+            loss = (key.astype("float32") * grads["key"]).sum() + (
+                k_pe.astype("float32") * grads["k_pe"]
+            ).sum()
+            loss.backward()
+            outs.append((key.detach(), k_pe.detach(), kv.grad, kpe.grad))
+
+        ref, fus = outs
+        for got, want in zip(fus, ref):
+            _check_equal(got, want)
+
+
+class TestAdjacentPairingConfigGuards(unittest.TestCase):
+    """``mqa_latent_rope_adjacent_pairing`` fails loudly where it is inert.
+
+    Every way of mis-setting it is silent at runtime -- the flag is simply never
+    read, or it is read on top of a second mechanism that already does the same
+    de-interleave -- so ``__post_init__`` is the only place a mistake can still
+    be reported.
+    """
+
+    MLA_DIMS = {
+        "hybrid_mla_q_lora_rank": 128,
+        "hybrid_mla_kv_lora_rank": 512,
+        "hybrid_mla_qk_nope_head_dim": 192,
+        "hybrid_mla_qk_rope_head_dim": 64,
+        "hybrid_mla_v_head_dim": 64,
+        "hybrid_mla_num_attention_heads": 1,
+        "hybrid_mla_num_key_value_heads": 1,
+        "dsa_index_n_heads": 64,
+        "dsa_index_head_dim": 128,
+        "dsa_index_topk": 128,
+    }
+
+    def _config(self, **kwargs):
+        base = {
+            "num_hidden_layers": 2,
+            "experimental_attention_variant": "dsv4_hybrid",
+            "csa_compress_ratios": [-2, 128],
+            "hybrid_mla_attention": "mqa_dsa",
+            "mqa_latent_rope_adjacent_pairing": True,
+            **self.MLA_DIMS,
+        }
+        base.update(kwargs)
+        return TransformerConfig(**base)
+
+    def test_default_is_off(self) -> None:
+        config = TransformerConfig(num_hidden_layers=2)
+        self.assertFalse(config.mqa_latent_rope_adjacent_pairing)
+
+    def test_happy_path(self) -> None:
+        self.assertTrue(self._config().mqa_latent_rope_adjacent_pairing)
+
+    def test_requires_absorbed_layers(self) -> None:
+        # 'mha' leaves the -2 layers as unabsorbed MLA, which already pairs
+        # (2k, 2k+1) through apply_rope_fusion.
+        with self.assertRaises(ValueError):
+            self._config(hybrid_mla_attention="mha")
+
+    def test_requires_a_minus2_ratio(self) -> None:
+        with self.assertRaises(ValueError):
+            self._config(csa_compress_ratios=[128, 128])
+
+    def test_rejects_rotary_interleaved(self) -> None:
+        # Both select the same pairing by different means; together they rotate
+        # the pair twice.
+        with self.assertRaises(ValueError):
+            self._config(rotary_interleaved=True)
+
+    def test_rejects_experimental_version(self) -> None:
+        # That path rotates in the complex domain via
+        # _ec_compatible_rope_apply, which neither branch of the switch reaches.
+        with self.assertRaises(ValueError):
+            self._config(gpt_model_use_experimental_version=True)
 
 
 class TestOptimizedModeValidation(unittest.TestCase):

--- a/tests/single_card_tests/transformer/test_mla_get_qkv_rope_cp.py
+++ b/tests/single_card_tests/transformer/test_mla_get_qkv_rope_cp.py
@@ -221,6 +221,7 @@ def _apply_rotary_pos_emb_identity(
     inverse=False,
     mla_output_remove_interleaving=False,
     apply_rope_fusion=None,
+    multi_latent_attention=None,
 ):
     return t
 

--- a/tests/single_card_tests/transformer/test_mla_get_qkv_rope_cp.py
+++ b/tests/single_card_tests/transformer/test_mla_get_qkv_rope_cp.py
@@ -221,7 +221,6 @@ def _apply_rotary_pos_emb_identity(
     inverse=False,
     mla_output_remove_interleaving=False,
     apply_rope_fusion=None,
-    multi_latent_attention=None,
 ):
     return t
 


### PR DESCRIPTION
### PR Category

Operator Mechanism

### PR Types

Bug fixes

### Description

An unabsorbed MLA layer under `apply_rope_fusion` rotates the channel pairs
`(2k, 2k+1)`, because that is what `fused_apply_mla_rope_for_q` / `_for_kv` do.
Turning on latent MQA (`hybrid_mla_attention="mqa_dsa"` /
`"mqa_full_causal"`, `csa_compress_ratios` entries equal to `-2`) makes that
branch fall through — `_for_kv` needs the per-head K/V that absorption never
materialises — and every path that remains, the eager one and
`fused_apply_rope_half` / `fused_rope_cat_key`, pairs `(k, k+half)`.

Which two channels share a frequency decides which frequency each learned
channel of `q_b_proj` / `kv_a_proj` gets, so the pairing is part of the meaning
of those weights. Enabling absorption therefore silently permutes an MLA
checkpoint's channel-to-frequency map. That is harmless where the backbone can
retrain, and not harmless where it cannot: a frozen-backbone indexer warmup
(`train_indexer_only`) distils its KL target from the backbone's post-RoPE q/k,
so it learns to rank against a scrambled attention distribution while its own
loss looks healthy.

This PR adds the opt-in `mqa_latent_rope_adjacent_pairing`:

- **Default `False`, so no existing config changes at all** — the previously
  verified `adjacent_in=False` path is bit-identical to the code before this PR,
  and the DSA indexer, which shares `fused_apply_rope_half`, keeps its
  half-split pairing.
- When set, the absorbed layers pair `(2k, 2k+1)` again. Eager path: a per-call
  `multi_latent_attention` override on `apply_rotary_pos_emb` (the config field
  itself cannot be flipped — it also drives layer-spec selection and
  position-embedding construction). Fused path: `adjacent_in` on
  `fused_apply_rope_half` / `fused_rope_cat_key`, which moves the gather
  positions only, leaving the arithmetic, the bf16 rounding and the store
  positions untouched.
- The half-split **output** layout is kept on purpose. A shared permutation `P`
  satisfies `P(q)·P(k) = q·k`, so the output layout is invisible to `q @ k^T`;
  only the input pairing carries weight semantics.
- `__post_init__` rejects the three configurations in which the flag would be a
  silent no-op or a double rotation: no absorbed layers, `rotary_interleaved`
  (which expresses the same pairing through the `freqs` layout),
  `gpt_model_use_experimental_version`.
- Pairing is a within-`head_dim` property, so the switch is orthogonal to TP,
  SP, CP, PP and EP. The override travels with `rope_kwargs`, which reaches
  `_apply_rotary_pos_emb_thd` (the `cp_group` path) as well as
  `_apply_rotary_pos_emb_bshd`.

**Precision**: no change for any existing config (default off). With the flag
on, fused and eager are bit-exact with each other, and bit-exact with eager
`multi_latent_attention=True, mla_output_remove_interleaving=False`.

Tests: 11 new cases in `tests/single_card_tests/test_rope_half_fusion.py`
(fused vs eager forward **and** backward, bit-exact, for both pairings; the two
pairings differ; the config guards fire). Whole file: 26 passed.
