### PR TITLE
[release/0.4][MoE] Support SiTU-GLU activation on the SonicMoE FP8 expert path

### DIFF
--- a/src/paddlefleet/transformer/moe/fusion_layer_utils.py
+++ b/src/paddlefleet/transformer/moe/fusion_layer_utils.py
@@ -3360,6 +3360,7 @@ def run_sonic_moe(
     fp8_combine_grad_handle=None,
     fp8_config=None,
     release_fp8_weights=False,
+    activation_type="swiglu",
 ):
     T = hidden_states.shape[0]
     stream_id = paddle.device.current_stream()
@@ -3453,6 +3454,16 @@ def run_sonic_moe(
         )
 
     s_scatter_idx.stop_gradient = True
+    # This is the in-tree fallback used only when paddlefleet_ops.sonicmoe cannot
+    # be imported; it predates the SiTU work and has no encoded-activation
+    # plumbing, so refuse rather than silently running SwiGLU numerics.
+    if activation_type != "swiglu":
+        raise NotImplementedError(
+            "paddlefleet.transformer.moe.fusion_layer_utils.run_sonic_moe is a "
+            "SwiGLU-only fallback and got activation_type="
+            f"{activation_type!r}; install a paddlefleet_ops build that exports "
+            "sonicmoe.run_sonic_moe."
+        )
     activation_type = ActivationType("swiglu")
 
     total_expert_freq = TK_padded

--- a/src/paddlefleet/transformer/moe/fusion_layer_utils.py
+++ b/src/paddlefleet/transformer/moe/fusion_layer_utils.py
@@ -3362,6 +3362,17 @@ def run_sonic_moe(
     release_fp8_weights=False,
     activation_type="swiglu",
 ):
+    # This is the in-tree fallback used only when paddlefleet_ops.sonicmoe
+    # cannot be imported; it predates the SiTU work and has no
+    # encoded-activation plumbing, so refuse rather than silently running
+    # SwiGLU numerics.
+    if activation_type != "swiglu":
+        raise NotImplementedError(
+            "paddlefleet.transformer.moe.fusion_layer_utils.run_sonic_moe is a "
+            "SwiGLU-only fallback and got activation_type="
+            f"{activation_type!r}; install a paddlefleet_ops build that exports "
+            "sonicmoe.run_sonic_moe."
+        )
     T = hidden_states.shape[0]
     stream_id = paddle.device.current_stream()
     topk_indices_i32 = (
@@ -3454,16 +3465,6 @@ def run_sonic_moe(
         )
 
     s_scatter_idx.stop_gradient = True
-    # This is the in-tree fallback used only when paddlefleet_ops.sonicmoe cannot
-    # be imported; it predates the SiTU work and has no encoded-activation
-    # plumbing, so refuse rather than silently running SwiGLU numerics.
-    if activation_type != "swiglu":
-        raise NotImplementedError(
-            "paddlefleet.transformer.moe.fusion_layer_utils.run_sonic_moe is a "
-            "SwiGLU-only fallback and got activation_type="
-            f"{activation_type!r}; install a paddlefleet_ops build that exports "
-            "sonicmoe.run_sonic_moe."
-        )
     activation_type = ActivationType("swiglu")
 
     total_expert_freq = TK_padded

--- a/src/paddlefleet/transformer/moe/moe_expert.py
+++ b/src/paddlefleet/transformer/moe/moe_expert.py
@@ -623,12 +623,33 @@ class SonicMoEExpert(GroupedMLPExpert):
         pg_collection: ProcessGroupCollection | None = None,
         intermediate_size_per_partition: int | None = None,
     ):
-        if config.hidden_act != F.silu or not config.gated_linear_unit:
+        if (
+            config.hidden_act not in (F.silu, situ)
+            or not config.gated_linear_unit
+        ):
             raise ValueError(
-                "SonicMoE only supports SwiGLU (hidden_act=F.silu and "
-                "gated_linear_unit=True), but got "
+                "SonicMoE only supports SwiGLU (hidden_act=F.silu) and SiTU-GLU "
+                "(hidden_act=situ), both with gated_linear_unit=True, but got "
                 f"hidden_act={config.hidden_act} and "
                 f"gated_linear_unit={config.gated_linear_unit}."
+            )
+        is_situ = config.hidden_act == situ
+        if is_situ and config.fp8 is None:
+            # sonicmoe refuses this deeper down too (_gemm_activation_name), but
+            # failing here names the config knob that has to change.
+            raise ValueError(
+                "SonicMoE has no bf16 SiTU-GLU epilogue; hidden_act=situ needs "
+                "fp8 (e.g. fp8='e4m3'), or switch to the DeepGEMM expert path "
+                "(using_sonic_moe=False)."
+            )
+        if is_situ and config.activation_func_clamp_value:
+            # The gated epilogue applies the clamp to (gate, up) *before* act_fn,
+            # which is a SwiGLU-only recipe; sonicmoe raises rather than dropping
+            # it silently, so reject here with the config-level name.
+            raise ValueError(
+                "activation_func_clamp_value="
+                f"{config.activation_func_clamp_value} is not supported with "
+                "hidden_act=situ on SonicMoE: SiTU-GLU has no clamped variant."
             )
         super().__init__(
             num_local_experts=num_local_experts,
@@ -651,6 +672,38 @@ class SonicMoEExpert(GroupedMLPExpert):
         self.sonic_moe_config.swiglu_clamp_value = (
             0.0 if clamp_value is None else float(clamp_value)
         )
+
+        # Activation forwarded to run_sonic_moe(). For SiTU the two betas are
+        # part of the kernel (baked in as Constexpr), so they must reach the JIT
+        # cache key -- hence the encoded string form rather than a bare
+        # "situ_glu" plus ambient config. _FP8Config.situ_* are set as well so
+        # any cfg-based consumer (warmup signatures, logging) agrees by
+        # construction. Note the *resolved* semantics there: linear_beta=None
+        # means "no up-projection clamp", not "unset".
+        if is_situ:
+            # Imported lazily: activation_situ pulls in cutlass.cute at import
+            # time, which must not become a hard dependency of this module for
+            # the SwiGLU-only builds.
+            from paddlefleet_ops.sonicmoe.quack_utils.activation_situ import (
+                encode_situ_activation,
+            )
+
+            beta = self.config.activation_situ_beta
+            linear_beta = self.config.activation_situ_linear_beta
+            self.sonic_moe_config.situ_beta = float(beta)
+            self.sonic_moe_config.situ_linear_beta = (
+                None if linear_beta is None else float(linear_beta)
+            )
+            self._sonic_activation = encode_situ_activation(
+                self.sonic_moe_config.situ_beta,
+                self.sonic_moe_config.situ_linear_beta,
+            )
+            self._sonic_activation_kwargs = {
+                "activation_type": self._sonic_activation
+            }
+        else:
+            self._sonic_activation = "swiglu"
+            self._sonic_activation_kwargs = {}
 
         # Micro batch tracking for fp8 weight memory optimization.
         # _num_micro_batches: total forward passes per step for this layer.
@@ -852,6 +905,12 @@ class SonicMoEExpert(GroupedMLPExpert):
             fp8_combine_grad_handle=fp8_combine_grad_handle,
             fp8_config=self.sonic_moe_config,
             release_fp8_weights=release_fp8_weight_after_fwd,
+            # Forwarded only for SiTU.  ``activation_type`` is a newer
+            # run_sonic_moe kwarg, so passing it unconditionally would turn every
+            # SwiGLU SonicMoE run against an older paddlefleet_ops build into a
+            # TypeError.  SiTU already fails early and clearly on such a build:
+            # the encode_situ_activation import in __init__ raises ImportError.
+            **self._sonic_activation_kwargs,
         )
         # Release fp8 weights on last micro batch to save memory.
         # Only transposed_fp8 is kept for backward computation.

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -201,11 +201,13 @@ class MoELayer(nn.Layer):
         )
         self.moe_expert_fusion = config.moe_expert_fusion
         self._activation_type = "situ" if self.hidden_act == situ else "swiglu"
-        if self.hidden_act == situ and self.fp8 and self.using_sonic_moe:
-            raise ValueError(
-                "SiTU-GLU + fp8 is only supported on the DeepGEMM fp8 expert "
-                "path, not on SonicMoE; please disable fp8 or switch backend."
-            )
+        # SiTU-GLU + fp8 on SonicMoE is now implemented: the betas are encoded
+        # into the gated/dgated GEMM activation string and baked into the
+        # epilogue as Constexpr (see sonicmoe/quack_utils/activation_situ.py).
+        # SonicMoE's *bf16* path still has no SiTU epilogue and raises from
+        # sonicmoe/functional/__init__.py::_gemm_activation_name, so nothing can
+        # silently degrade to SwiGLU.  fp8_wgrad remains unvalidated for SiTU on
+        # both backends and is still rejected below.
         if self.hidden_act == situ and self.fp8 and self.fp8_wgrad:
             raise ValueError(
                 "SiTU-GLU + fp8 does not support fp8 expert weight gradients "

--- a/tests/single_card_tests/model/test_gpt_model_sonic_moe_situ.py
+++ b/tests/single_card_tests/model/test_gpt_model_sonic_moe_situ.py
@@ -1,0 +1,299 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Precision of the SonicMoE fp8 SiTU-GLU expert path.
+
+The reference is the *non*-SonicMoE SiTU path (``GroupedMLPExpert``, bf16,
+``moe_deep_gemm=False``), which evaluates ``situ_glu`` in fp32 outside the
+GEMM. The tolerance is not invented: the same measurement is taken for
+SwiGLU, whose fp8 SonicMoE epilogue is already validated, and SiTU is
+required to stay within a small multiple of it. That way the gate tracks
+the fp8 rounding floor of whatever hardware runs it instead of encoding
+one machine's numbers.
+
+Why the reference is bf16 rather than the fp8 non-SonicMoE path: on a
+single card, ``fp8`` + ``moe_deep_gemm=True`` produces an output that does
+not depend on the activation function nor on fp8 at all (the batched
+DeepGEMM bug that ``test_gpt_model_sonic_moe.py`` also works around), and
+``fp8`` + ``moe_deep_gemm=False`` disables weight fusion and never builds
+``grouped_gemm_experts``. Neither is a usable numeric oracle here; the fp8
+standalone-op path is only exercised end to end with EP > 1.
+"""
+
+import unittest
+
+import paddle
+import paddle.nn.functional as F
+import paddlefleet_ops
+from paddle.distributed import fleet
+from paddle.distributed.fleet.utils import mix_precision_utils
+
+import paddlefleet.parallel_state as ps
+from paddlefleet.models.gpt.gpt_layer_specs import get_gpt_layer_local_spec
+from paddlefleet.process_groups_config import ProcessGroupCollection
+from paddlefleet.tensor_parallel.random import model_parallel_cuda_manual_seed
+from paddlefleet.transformer.activations import situ
+from paddlefleet.transformer.moe.moe_layer import MoELayer
+from paddlefleet.transformer.transformer_config import TransformerConfig
+
+if paddlefleet_ops.is_sonic_moe_available():
+    from paddlefleet_ops.sonicmoe.functional import (
+        clear_all_fp8_weight_caches,
+    )
+
+
+def situ_epilogue_available():
+    """Whether the installed paddlefleet_ops ships the SiTU-GLU epilogue.
+
+    ``SonicMoEExpert.__init__`` imports ``encode_situ_activation`` lazily, so
+    an older build fails there with ImportError by design rather than running
+    SwiGLU numerics under a SiTU config.
+    """
+    if not paddlefleet_ops.is_sonic_moe_available():
+        return False
+    try:
+        from paddlefleet_ops.sonicmoe.quack_utils.activation_situ import (  # noqa: F401
+            encode_situ_activation,
+        )
+    except ImportError:
+        return False
+    return True
+
+
+def calc_diff(x: paddle.Tensor, y: paddle.Tensor):
+    x, y = x.double(), y.double()
+    denominator = (x * x + y * y).sum()
+    if denominator.item() == 0:
+        return 0.0
+    sim = 2 * (x * y).sum() / denominator
+    return (1 - sim).item()
+
+
+# ── Module-level fleet initialization (only once) ─────────────────────
+_strategy = fleet.DistributedStrategy()
+_strategy.hybrid_configs = {
+    "dp_degree": 1,
+    "mp_degree": 1,
+    "pp_degree": 1,
+    "sharding_degree": 1,
+    "sep_degree": 1,
+    "cp_degree": 1,
+    "ep_degree": 1,
+    "moe_sharding_degree": 1,
+    "order": [
+        "sharding",
+        "moe_sharding",
+        "pp",
+        "sep",
+        "cp",
+        "dp",
+        "ep",
+        "mp",
+    ],
+}
+fleet.init(is_collective=True, strategy=_strategy)
+_hcg = fleet.get_hybrid_communicate_group()
+ps.initialize_model_parallel(_hcg)
+
+
+@unittest.skipUnless(
+    paddlefleet_ops.is_sonic_moe_available(),
+    "Sonic-MoE not available (requires Python>=3.12, CUDA>=12.9, SM>=90)",
+)
+class TestSonicMoESituPrecision(unittest.TestCase):
+    """fp8 SonicMoE SiTU-GLU vs the non-SonicMoE SiTU reference."""
+
+    # Absolute ceiling, shared with test_gpt_model_sonic_moe.py.
+    fp8_tol = 5e-3
+    # SiTU is allowed this multiple of the measured SwiGLU fp8 error. SiTU-GLU
+    # is SwiGLU's shape with two extra tanh factors, both with derivative
+    # bounded by 1, so the fp8 rounding error may not grow by more than a
+    # small constant. 4x leaves room for the up-branch clamp and the beta
+    # scaling while still catching an order-of-magnitude regression.
+    situ_over_swiglu_ratio = 4.0
+
+    def setUp(self):
+        self.pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+        self.seed = 46
+        self.hidden_size = 512
+        self.n_routed_experts = 8
+
+    @staticmethod
+    def _small_init_method(tensor):
+        paddle.nn.initializer.Uniform(-0.001, 0.001)(tensor)
+
+    def _build_transformer_config(self, act, using_sonic_moe, fp8):
+        kwargs = {
+            "hidden_size": self.hidden_size,
+            "num_attention_heads": 4,
+            "n_routed_experts": self.n_routed_experts,
+            "use_cpu_initialization": False,
+            "num_experts_per_tok": 2,
+            "tensor_model_parallel_size": 1,
+            "expert_model_parallel_size": 1,
+            "sequence_parallel": False,
+            "bf16": True,
+            "params_dtype": paddle.bfloat16,
+            "moe_intermediate_size": 1024,
+            "gated_linear_unit": True,
+            "n_shared_experts": 0,
+            "hidden_act": situ if act == "situ" else F.silu,
+            "moe_expert_fusion": True,
+            "bias_activation_fusion": True,
+            "moe_token_dispatcher_type": "alltoall",
+            "moe_use_fusion_node": True,
+            "using_sonic_moe": using_sonic_moe,
+            "fp8": fp8,
+            # SiTU + fp8 rejects fp8_wgrad, so both activations run with bf16
+            # weight gradients to keep the comparison apples to apples.
+            "fp8_wgrad": False,
+            "init_method": self._small_init_method,
+            "output_layer_init_method": self._small_init_method,
+        }
+        if act == "situ":
+            kwargs["activation_situ_beta"] = 4.0
+            kwargs["activation_situ_linear_beta"] = 25.0
+        if not using_sonic_moe:
+            kwargs["moe_deep_gemm"] = False
+        return TransformerConfig(**kwargs)
+
+    def _build_moe_layer(self, act, using_sonic_moe=False, fp8=None):
+        # Same seed for every layer: SonicMoEExpert reuses GroupedMLPExpert
+        # initialization, so expert weights end up identical in both paths.
+        paddle.seed(self.seed)
+        model_parallel_cuda_manual_seed(self.seed)
+        config = self._build_transformer_config(act, using_sonic_moe, fp8)
+        transformer_layer_spec = get_gpt_layer_local_spec(
+            config,
+            num_experts=self.n_routed_experts,
+        )
+        moe_layer = MoELayer(
+            config,
+            transformer_layer_spec.sublayers_spec.mlp.extra_kwargs["sublayers"],
+            self.pg_collection,
+        )
+        mix_precision_utils.MixPrecisionLayer(moe_layer, dtype="bfloat16")
+        for param in moe_layer.parameters():
+            if hasattr(param, "main_grad") and param.main_grad is None:
+                param.main_grad = paddle.zeros_like(param, dtype=paddle.float32)
+        return moe_layer
+
+    @staticmethod
+    def _collect_grads(layer):
+        grads = {}
+        for name, param in layer.named_parameters():
+            grad = getattr(param, "main_grad", None)
+            if grad is None:
+                grad = param.grad
+            if grad is not None:
+                grads[name] = grad.detach().clone()
+        return grads
+
+    def _forward_backward(self, moe_layer, input_data):
+        hidden_states = input_data.detach().clone()
+        hidden_states.stop_gradient = False
+        with paddle.amp.auto_cast(level="O2", dtype="bfloat16"):
+            output = moe_layer(hidden_states)[0]
+            loss = output.sum()
+        loss.backward()
+        expert = getattr(moe_layer, "grouped_gemm_experts", None)
+        if hasattr(expert, "flush_to_grouped_layout"):
+            expert.flush_to_grouped_layout()
+        return (
+            loss.item(),
+            output.detach().clone(),
+            self._collect_grads(moe_layer),
+        )
+
+    def _input_data(self):
+        paddle.seed(self.seed)
+        return paddle.randn([2, 64, self.hidden_size], dtype=paddle.bfloat16)
+
+    def _measure_fp8_error(self, act):
+        """Diff of the fp8 SonicMoE path against the non-SonicMoE bf16 one.
+
+        Returns ``{"output": diff, "<param>": diff, ...}``.
+        """
+        input_data = self._input_data()
+
+        reference = self._build_moe_layer(act, using_sonic_moe=False)
+        loss_ref, output_ref, grads_ref = self._forward_backward(
+            reference, input_data
+        )
+
+        sonic = self._build_moe_layer(act, using_sonic_moe=True, fp8="e4m3")
+        sonic.grouped_gemm_experts.sonic_moe_config.enabled = True
+        sonic.grouped_gemm_experts.quant_weight()
+        loss_fp8, output_fp8, grads_fp8 = self._forward_backward(
+            sonic, input_data
+        )
+        clear_all_fp8_weight_caches()
+
+        diffs = {"output": calc_diff(output_fp8, output_ref)}
+        common = set(grads_ref) & set(grads_fp8)
+        self.assertTrue(common, f"no common grad tensors for act={act}")
+        for name in sorted(common):
+            diffs[name] = calc_diff(grads_fp8[name], grads_ref[name])
+        print(
+            f"[{act}] fp8 sonic vs bf16 non-sonic: "
+            f"loss_ref={loss_ref:.6e} loss_fp8={loss_fp8:.6e}"
+        )
+        for name, diff in diffs.items():
+            print(f"[{act}]   {name}: {diff:.6e}")
+        return diffs
+
+    def test_swiglu_fp8_error_is_within_tolerance(self):
+        """Calibration baseline, and a self-test of the harness above.
+
+        The SiTU test below is a ratio against these numbers, so they have to
+        be bounded on their own: a SwiGLU regression would otherwise let SiTU
+        pass vacuously.
+        """
+        for name, diff in self._measure_fp8_error("swiglu").items():
+            with self.subTest(tensor=name):
+                self.assertLess(diff, self.fp8_tol, f"{name} diff {diff:.6e}")
+
+    @unittest.skipUnless(
+        situ_epilogue_available(),
+        "installed paddlefleet_ops has no SiTU-GLU fp8 epilogue",
+    )
+    def test_situ_fp8_error_not_worse_than_swiglu(self):
+        """SiTU on SonicMoE must not be noisier than SwiGLU on SonicMoE.
+
+        Both are measured against their own non-SonicMoE bf16 SiTU/SwiGLU
+        reference, so the ratio isolates the epilogue's fp8 behaviour from
+        the activation's own conditioning.
+        """
+        swiglu = self._measure_fp8_error("swiglu")
+        situ_diffs = self._measure_fp8_error("situ")
+
+        for name, diff in situ_diffs.items():
+            with self.subTest(tensor=name):
+                self.assertLess(
+                    diff, self.fp8_tol, f"{name} situ diff {diff:.6e}"
+                )
+                # Floor so a degenerate zero denominator cannot turn the
+                # budget into "must match bit-exactly".
+                budget = self.situ_over_swiglu_ratio * max(swiglu[name], 1e-5)
+                self.assertLessEqual(
+                    diff,
+                    budget,
+                    f"{name}: situ fp8 diff {diff:.6e} exceeds "
+                    f"{self.situ_over_swiglu_ratio}x the swiglu fp8 diff "
+                    f"({swiglu[name]:.6e})",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/transformer/test_situ_glu.py
+++ b/tests/single_card_tests/transformer/test_situ_glu.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import functools
+import inspect
 import os
 import subprocess
 import sys
@@ -33,6 +34,7 @@ from paddlefleet.transformer.activations import (
     situ_glu_scale_forward,
 )
 from paddlefleet.transformer.mlp import MLP
+from paddlefleet.transformer.moe import fusion_layer_utils
 from paddlefleet.transformer.moe.fp8_utils import (
     ExpertsGroupGemmContiguousNode,
 )
@@ -462,17 +464,22 @@ class TestSituGLU(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "fp8_wgrad=False"):
             MoELayer(fp8_wgrad_config)
 
-        # SonicMoE has no SiTU fp8 kernel, so it must still be rejected.
-        sonic_config = TransformerConfig(
+        # SonicMoE now has a SiTU-GLU fp8 epilogue, so MoELayer must no longer
+        # carry a blanket "situ + fp8 + sonic" rejection. fp8 expert weight
+        # gradients stay unvalidated for SiTU on both backends, though, so that
+        # one combination is still rejected -- and by *this* name. Asserting the
+        # exact message is the regression guard against the blanket rejection
+        # coming back: a reinstated one would fire here first and change it.
+        sonic_wgrad_config = TransformerConfig(
             **config_kwargs,
             moe_use_fusion_node=True,
             moe_expert_fusion=True,
             fp8="e4m3",
-            fp8_wgrad=False,
             using_sonic_moe=True,
         )
-        with self.assertRaisesRegex(ValueError, "not on SonicMoE"):
-            MoELayer(sonic_config)
+        self.assertTrue(sonic_wgrad_config.fp8_wgrad)
+        with self.assertRaisesRegex(ValueError, "fp8_wgrad=False"):
+            MoELayer(sonic_wgrad_config)
 
     def test_situ_fused_grouped_deep_gemm_forward_backward(self):
         model_parallel_cuda_manual_seed(2026)
@@ -931,10 +938,15 @@ class TestSituGLU(unittest.TestCase):
         )
 
     def test_sonic_moe_rejects_non_swiglu_configurations(self):
-        for hidden_act, gated_linear_unit in (
-            (F.gelu, True),
-            (situ, True),
-            (F.silu, False),
+        # SiTU-GLU is accepted by the activation check now, so it no longer
+        # lands on "only supports SwiGLU" -- with fp8 unset it falls through to
+        # the bf16 rejection instead. All three of these fire before
+        # super().__init__(), so none of them needs a sonicmoe build that ships
+        # the SiTU epilogue.
+        for hidden_act, gated_linear_unit, message in (
+            (F.gelu, True, "only supports SwiGLU"),
+            (situ, True, "no bf16 SiTU-GLU epilogue"),
+            (F.silu, False, "only supports SwiGLU"),
         ):
             with self.subTest(
                 hidden_act=hidden_act,
@@ -950,16 +962,63 @@ class TestSituGLU(unittest.TestCase):
                     hidden_act=hidden_act,
                     params_dtype="bfloat16",
                 )
-                with self.assertRaisesRegex(
-                    ValueError,
-                    "only supports SwiGLU",
-                ):
+                with self.assertRaisesRegex(ValueError, message):
                     SonicMoEExpert(
                         num_local_experts=2,
                         topk=2,
                         config=config,
                     )
                 self.assertIs(config.hidden_act, hidden_act)
+
+    def test_sonic_moe_rejects_situ_with_activation_clamp(self):
+        # The gated epilogue applies the clamp to (gate, up) *before* act_fn,
+        # which is a SwiGLU-only recipe; there is no clamped SiTU variant, so
+        # silently dropping the clamp would change the numerics the config asked
+        # for. Fires before super().__init__(), so no SiTU epilogue needed.
+        config = TransformerConfig(
+            hidden_size=8,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+            intermediate_size=8,
+            moe_intermediate_size=4,
+            gated_linear_unit=True,
+            hidden_act=situ,
+            activation_situ_beta=4.0,
+            activation_situ_linear_beta=25.0,
+            activation_func_clamp_value=7.0,
+            fp8="e4m3",
+            params_dtype="bfloat16",
+        )
+        with self.assertRaisesRegex(ValueError, "activation_func_clamp_value"):
+            SonicMoEExpert(num_local_experts=2, topk=2, config=config)
+
+    def test_intree_run_sonic_moe_fallback_rejects_situ(self):
+        # fusion_layer_utils.run_sonic_moe is the fallback used only when
+        # paddlefleet_ops.sonicmoe is unimportable. It has no encoded-activation
+        # plumbing, so it must refuse a non-SwiGLU activation_type up front
+        # rather than run SwiGLU numerics under a SiTU config.
+        with self.assertRaisesRegex(
+            NotImplementedError, "SwiGLU-only fallback"
+        ):
+            fusion_layer_utils.run_sonic_moe(
+                hidden_states=None,
+                topk_indices=None,
+                topk_scores=None,
+                K=2,
+                E=2,
+                w1=None,
+                w2=None,
+                activation_type="situ_glu:b=4.0:lb=25.0",
+            )
+
+    def test_intree_run_sonic_moe_fallback_defaults_to_swiglu(self):
+        # The default must stay "swiglu": SonicMoEExpert forwards
+        # activation_type only for SiTU (an older paddlefleet_ops build has no
+        # such kwarg), so the SwiGLU path must reach this function without it.
+        signature = inspect.signature(fusion_layer_utils.run_sonic_moe)
+        self.assertEqual(
+            signature.parameters["activation_type"].default, "swiglu"
+        )
 
     def test_mlp_forward_backward_bypasses_swiglu_fusion(self):
         model_parallel_cuda_manual_seed(2026)


### PR DESCRIPTION
### PR Category

Operator Mechanism

### PR Types

New features

### Description

`release/0.4` version of the `develop` PR.

Merged in dev: #1921

Enable **SiTU-GLU (`hidden_act=situ`) on the SonicMoE FP8 expert path**. Until now
SonicMoE accepted only SwiGLU, so a SiTU model had to fall back to the DeepGEMM
`GroupedMLP` path (`using_sonic_moe=False`). The SiTU-GLU epilogue now exists on the
sonicmoe side, so this PR is the PaddleFleet-side wiring.

`situ_glu(gate, up) = [beta * tanh(gate/beta) * sigmoid(gate)] * [lb * tanh(up/lb)]`

#### 1. `moe_expert.py` — accept `situ` and encode the betas into the activation

`SonicMoEGroupedMLP.__init__` now accepts `hidden_act=situ` and turns
`config.activation_situ_beta` / `config.activation_situ_linear_beta` into the encoded
activation descriptor forwarded to `run_sonic_moe`, e.g. `"situ_glu:b=4.0:lb=25.0"`.

The encoding is not cosmetic: both betas are traced into the CUTLASS epilogue as
`Constexpr`, so **a different beta is a different kernel**. They therefore have to ride
inside the activation string that feeds every JIT / autotune / warmup cache key, instead
of being read from ambient config at trace time. `_FP8Config.situ_beta` /
`situ_linear_beta` are populated as well so any cfg-based consumer (warmup signatures,
logging) agrees by construction. Note the *resolved* semantics on `_FP8Config`:
`situ_linear_beta=None` means "no up-projection clamp", not "unset".

The `encode_situ_activation` import is lazy, because `quack_utils/activation_situ` pulls
in `cutlass.cute` at import time and that must not become a hard dependency of this
module for SwiGLU-only builds.

#### 2. Three explicit rejections rather than silent SwiGLU numerics

| condition | why |
|---|---|
| `hidden_act=situ` and `config.fp8 is None` | there is no bf16 SiTU epilogue; sonicmoe also refuses deeper down, but failing here names the config knob that has to change |
| `hidden_act=situ` and `activation_func_clamp_value` | the gated epilogue clamps `(gate, up)` *before* `act_fn`, which is a SwiGLU-only recipe; SiTU has no clamped variant |
| `activation_type != "swiglu"` in the in-tree `fusion_layer_utils.run_sonic_moe` | that fallback is used only when `paddlefleet_ops.sonicmoe` cannot be imported and has no encoded-activation plumbing at all |

#### 3. `moe_layer.py` — drop the blanket rejection, keep the `fp8_wgrad` one

The "SiTU + fp8 + SonicMoE is unsupported" error is removed. `fp8_wgrad` together with
SiTU is still rejected: it remains unvalidated on both backends.

#### 4. Unit tests

- `tests/single_card_tests/transformer/test_situ_glu.py`: refresh the two assertions the
  wiring commit made stale and add three contract tests. All three rejections happen
  before `super().__init__()` and before the lazy `encode_situ_activation` import, so
  they are testable without any stub and regardless of whether the installed
  `paddlefleet_ops` has the SiTU epilogue.
- `tests/single_card_tests/model/test_gpt_model_sonic_moe_situ.py`: compares SonicMoE FP8
  against non-SonicMoE bf16 at identical seed and byte-identical weights. The tolerance
  is not hand-picked — the same harness also runs SwiGLU, and SiTU only has to satisfy
  `d_situ <= 4 * d_swiglu` (plus a 5e-3 absolute cap), so the gate tracks the machine's
  own fp8 rounding floor. The SwiGLU half runs unconditionally and doubles as a harness
  self-check; the SiTU half is `skipUnless(situ_epilogue_available())`.

#### 5. Submodule bump

`packages/paddlefleet_ops/third_party/sonic-moe` moves `e4dc4bf` -> `a5870e9`
(`PFCCLab/supersonic-moe` #79). `e4dc4bf` was the pre-squash form of #78, so
`git diff e4dc4bf 6d017b6` is empty and this bump adds nothing but #79.

### Backward compatibility

`activation_type` is forwarded **only for SiTU** (`**self._sonic_activation_kwargs`,
empty for SwiGLU). It is a newer `run_sonic_moe` kwarg, so passing it unconditionally
would turn *every* SwiGLU SonicMoE run against an older `paddlefleet_ops` build into a
`TypeError`. SiTU itself fails early and clearly on such a build, because the lazy
`encode_situ_activation` import in `__init__` raises `ImportError`.

### Dependency

`PFCCLab/supersonic-moe` #79 (SiTU-GLU FP8 epilogue, `activation_situ.py` /
`situ_params.py`, the `activation_type` kwarg on `run_sonic_moe`) **has landed** as
`a5870e9` and is picked up by the submodule bump in this PR, so there is no external
blocker left.

### Validation

Numerics were validated on the sonicmoe side against a float64 torch reference on
sm_103: forward/backward activation, gated/dgated GEMM, and a precision matrix over the
full beta sweep and all production shapes (`E=512, H=2048, I=256`, gated `N=512`), gated
on scale-invariant RRMSE with measurement-derived margins over the bf16 (`2^-9/sqrt(3)`)
and e4m3 (`2^-4`) rounding floors. 550 tests green.

On the PaddleFleet side: `ruff check` / `ruff format` clean, and the two unit-test files
above pass locally. The SiTU end-to-end case is currently skipped because the installed
`paddlefleet_ops` build predates #79; a full loss comparison (`using_sonic_moe: true` vs
`false`) is planned once a build with the bumped submodule is available.
