### PR TITLE
[Operator Mechanism] Enable FA3 cutedsl on SM90

### DIFF
--- a/packages/paddlefleet_ops/src/paddlefleet_ops/__init__.py
+++ b/packages/paddlefleet_ops/src/paddlefleet_ops/__init__.py
@@ -176,7 +176,7 @@ else:
 
 FLASH_MASK_HINT = (
     "For developers: guard imports with `is_flash_mask_available()` and only call `paddlefleet_ops.flash_mask` when flag branch enabled.\n"
-    "For users: use a GPU with compute capability >= 10.0 (Blackwell) to enable."
+    "For users: use a GPU with compute capability >= 9.0 (Hopper or Blackwell) to enable."
 )
 
 
@@ -253,10 +253,9 @@ if paddle.is_compiled_with_cuda():
         _DEEP_EP_AVAILABLE = True
         _FLASH_MLA_AVAILABLE = True
         _MOON_EP_AVAILABLE = True
+        _FLASH_MASK_AVAILABLE = True
         if _cuda_version >= (12, 9):
             _HYBRID_EP_AVAILABLE = True
-    if paddle.cuda.get_device_capability()[0] >= 10:
-        _FLASH_MASK_AVAILABLE = True
     if (
         sys.version_info >= (3, 12)
         and paddle.cuda.get_device_capability()[0] >= 10
@@ -439,7 +438,7 @@ if paddle.is_compiled_with_cuda():
     if is_flash_mask_available():
         _safe_load_ecosystem_lib("flash_mask", ops_dir, globals())
     else:
-        warning, error = _blackwell_requirement(
+        warning, error = _hopper_requirement(
             "paddlefleet_ops.flash_mask", hint=FLASH_MASK_HINT
         )
         logger.warning(warning)

--- a/packages/paddlefleet_ops/src/paddlefleet_ops/flash_mask_facade.py
+++ b/packages/paddlefleet_ops/src/paddlefleet_ops/flash_mask_facade.py
@@ -35,13 +35,17 @@ else:
         flashmask_attention as _flashmask_attention,
     )
 
+flashmask_fa3_use_cutedsl = True
 
-def get_fa_version(
+
+def _dispatch_fa_version(
     head_dim: int,
     head_dim_v: int | None = None,
     startend_row_indices: paddle.Tensor | None = None,
 ) -> int:
     """Pick the FlashAttention version for the given head dims.
+
+    Prefer the public ``get_fa_version``, which validates what this returns.
 
     Dispatch rules:
       * XPU device -> FA2.
@@ -86,31 +90,129 @@ def get_fa_version(
         "FLAGS_cudnn_deterministic"
     ]
 
-    if fa_version == 3:
-        if deterministic and head_dim > 128:
-            return 2
+    if flashmask_fa3_use_cutedsl:
+        if fa_version in (3, 4):
+            # FA3/FA4 both run on the cutedsl backend. When ``paddlefleet_ops.
+            # flash_mask`` is not loadable (capability below 9.0, a mismatched
+            # paddlefleet_ops build, or a broken cute import) the kernels do not
+            # exist, so degrade here rather than letting call sites reference an
+            # undefined ``_flash_attn_fwd`` / ``_flash_attn_bwd``.
+            if not is_flash_mask_available():
+                return 2
+            _head_dim_v = head_dim_v if head_dim_v is not None else head_dim
+            cutedsl_hdim_ok = (
+                (head_dim <= 128 and _head_dim_v <= 128)
+                or (head_dim == 192 and _head_dim_v == 128)
+                or (head_dim == 256 and _head_dim_v == 256)
+            )
+            # FA4 additionally supports larger head dims (non-deterministic only)
+            if fa_version == 4 and not deterministic:
+                cutedsl_hdim_ok = cutedsl_hdim_ok or (
+                    (head_dim == 512 and _head_dim_v == 512)
+                    or (head_dim == 576 and _head_dim_v == 512)
+                )
+            if not cutedsl_hdim_ok:
+                return 2
+            fa4_mask_ok = (
+                startend_row_indices is None
+                or startend_row_indices.shape[-1] != 4
+            )
+            if fa_version == 4:
+                if not fa4_mask_ok:
+                    return 2
+    else:
+        if fa_version == 3:
+            if deterministic and head_dim > 128:
+                return 2
 
-    if fa_version == 4:
-        _head_dim_v = head_dim_v if head_dim_v is not None else head_dim
-        fa4_hdim_ok = (
-            (head_dim <= 128 and _head_dim_v <= 128)
-            or (head_dim == 192 and _head_dim_v == 128)
-            or (head_dim == 256 and _head_dim_v == 256)
-            # Both of these exceed 256 and so take FA4's big-head-dim backward,
-            # which asserts ``not deterministic`` (``flash_mask/cute/
-            # interface.py``: ``is_bigd_bwd`` -> "deterministic reduction is not
-            # supported by big-headdim bwd"). Degrade instead of aborting, the
-            # same way FA3 degrades above.
-            or (head_dim == 512 and _head_dim_v == 512 and not deterministic)
-            or (head_dim == 576 and _head_dim_v == 512 and not deterministic)
-        )
-        fa4_mask_ok = (
-            startend_row_indices is None or startend_row_indices.shape[-1] != 4
-        )
-        if not (fa4_hdim_ok and fa4_mask_ok):
-            return 2
+        if fa_version == 4:
+            _head_dim_v = head_dim_v if head_dim_v is not None else head_dim
+            fa4_hdim_ok = (
+                (head_dim <= 128 and _head_dim_v <= 128)
+                or (head_dim == 192 and _head_dim_v == 128)
+                or (head_dim == 256 and _head_dim_v == 256)
+                # Both of these exceed 256 and so take FA4's big-head-dim backward,
+                # which asserts ``not deterministic`` (``flash_mask/cute/
+                # interface.py``: ``is_bigd_bwd`` -> "deterministic reduction is not
+                # supported by big-headdim bwd"). Degrade instead of aborting, the
+                # same way FA3 degrades above.
+                or (
+                    head_dim == 512 and _head_dim_v == 512 and not deterministic
+                )
+                or (
+                    head_dim == 576 and _head_dim_v == 512 and not deterministic
+                )
+            )
+            fa4_mask_ok = (
+                startend_row_indices is None
+                or startend_row_indices.shape[-1] != 4
+            )
+            if not (fa4_hdim_ok and fa4_mask_ok):
+                return 2
 
     return fa_version
+
+
+def get_fa_version(
+    head_dim: int,
+    head_dim_v: int | None = None,
+    startend_row_indices: paddle.Tensor | None = None,
+) -> int:
+    """Pick the FlashAttention version, rejecting versions we cannot dispatch.
+
+    Thin validating wrapper over ``_dispatch_fa_version``; see that function for
+    the dispatch rules and argument meanings.
+
+    Returns:
+        The FlashAttention version to use (2, 3 or 4).
+
+    Raises:
+        ValueError: If the resolved version is not 2, 3 or 4 -- in practice this
+            means ``FLAGS_flash_attn_version`` was set to something unsupported,
+            since every degrade path returns 2.
+    """
+    fa_version = _dispatch_fa_version(
+        head_dim, head_dim_v, startend_row_indices
+    )
+    if fa_version not in (2, 3, 4):
+        raise ValueError(f"Invalid flash attention version: {fa_version}")
+    return fa_version
+
+
+def is_flashmask_use_cutedsl(fa_version):
+    if fa_version == 3:
+        return flashmask_fa3_use_cutedsl
+    elif fa_version == 4:
+        return True
+    else:
+        return False
+
+
+def is_value_padding_needed(
+    fa_version: int,
+    head_dim: int,
+    head_dim_v: int,
+) -> bool:
+    """Whether ``value`` must be zero-padded from ``head_dim_v`` to ``head_dim``.
+
+    Args:
+        fa_version: The version returned by :func:`get_fa_version`.
+        head_dim: Query/Key head dim.
+        head_dim_v: Value head dim.
+
+    Returns:
+        ``True`` when ``value`` needs padding.
+    """
+    fa3_native_pair = (
+        flashmask_fa3_use_cutedsl
+        and (fa_version == 3)
+        and (head_dim == 192 and head_dim_v == 128)
+    )
+    fa4_native_pair = (fa_version == 4) and (
+        (head_dim == 192 and head_dim_v == 128)
+        or (head_dim == 576 and head_dim_v == 512)
+    )
+    return head_dim != head_dim_v and not (fa3_native_pair or fa4_native_pair)
 
 
 def flashmask_attention(
@@ -155,19 +257,13 @@ def flashmask_attention(
 
     fa_version = get_fa_version(q_head_dim, v_head_dim, startend_row_indices)
 
-    need_value_padding = (
-        not (
-            fa_version == 4
-            and (
-                (q_head_dim == 192 and v_head_dim == 128)
-                or (q_head_dim == 576 and v_head_dim == 512)
-            )
-        )
-    ) and q_head_dim != v_head_dim
+    need_value_padding = is_value_padding_needed(
+        fa_version, q_head_dim, v_head_dim
+    )
 
     if need_value_padding:
         value_padding = paddle.zeros(
-            [bsz, q_len, value.shape[2], q_head_dim - v_head_dim],
+            [*value.shape[:-1], q_head_dim - v_head_dim],
             dtype=value.dtype,
         )
         value = paddle.concat([value, value_padding], axis=-1)
@@ -237,19 +333,13 @@ def flash_attention(
     # startend_row_indices is None
     fa_version = get_fa_version(q_head_dim, v_head_dim)
 
-    need_value_padding = (
-        not (
-            fa_version == 4
-            and (
-                (q_head_dim == 192 and v_head_dim == 128)
-                or (q_head_dim == 576 and v_head_dim == 512)
-            )
-        )
-    ) and q_head_dim != v_head_dim
+    need_value_padding = is_value_padding_needed(
+        fa_version, q_head_dim, v_head_dim
+    )
 
     if need_value_padding:
         value_padding = paddle.zeros(
-            [bsz, q_len, value.shape[2], q_head_dim - v_head_dim],
+            [*value.shape[:-1], q_head_dim - v_head_dim],
             dtype=value.dtype,
         )
         value = paddle.concat([value, value_padding], axis=-1)
@@ -280,4 +370,6 @@ __all__ = [
     "flashmask_attention",
     "flash_attention",
     "get_fa_version",
+    "is_value_padding_needed",
+    "is_flashmask_use_cutedsl",
 ]

--- a/src/paddlefleet/context_parallel_utils.py
+++ b/src/paddlefleet/context_parallel_utils.py
@@ -20,7 +20,10 @@ from paddle import distributed as dist
 from paddle.autograd.py_layer import PyLayer
 from paddle.distributed import fleet
 from paddle.nn.functional.flash_attention import flashmask_attention
-from paddlefleet_ops.flash_mask_facade import get_fa_version
+from paddlefleet_ops.flash_mask_facade import (
+    get_fa_version,
+    is_flashmask_use_cutedsl,
+)
 
 _flash_mask_available = False
 try:
@@ -740,7 +743,7 @@ def cp_flashmask_allgatherkv_balance_forward(
     v_head_dim = value_gathered.shape[-1]
     fa_version = get_fa_version(q_head_dim, v_head_dim, startend_row_indices)
 
-    if fa_version == 4 and _flash_mask_available:
+    if is_flashmask_use_cutedsl(fa_version):
         output, log_sum_exp = _flash_attn_fwd(
             query,
             key_gathered,
@@ -755,7 +758,7 @@ def cp_flashmask_allgatherkv_balance_forward(
     else:
         if learnable_sink is not None:
             raise NotImplementedError(
-                "learnable_sink only supported on fa_version==4 cute backend"
+                "learnable_sink only supported on cute backend"
             )
         output, log_sum_exp = flashmask_attention(
             query,
@@ -827,7 +830,7 @@ def cp_flashmask_allgatherkv_balance_backward(
     if fa_version == 2:
         if learnable_sink is not None:
             raise NotImplementedError(
-                "learnable_sink only supported on fa_version==4 cute backend"
+                "learnable_sink only supported cute backend"
             )
         if softmax_scale is not None:
             raise NotImplementedError(
@@ -853,10 +856,10 @@ def cp_flashmask_allgatherkv_balance_backward(
                 causal,
             )
         )
-    elif fa_version == 3:
+    elif not is_flashmask_use_cutedsl(fa_version):
         if learnable_sink is not None:
             raise NotImplementedError(
-                "learnable_sink only supported on fa_version==4 cute backend"
+                "learnable_sink only supported on cute backend"
             )
         sig_params = inspect.signature(flashmask_attention).parameters
         if "group" in sig_params:
@@ -911,7 +914,7 @@ def cp_flashmask_allgatherkv_balance_backward(
                     False,
                 )
             )
-    elif fa_version == 4 and _flash_mask_available:
+    else:
         if startend_row_indices is not None:
             flashmask_info = FlashMaskInfoPaddle(
                 startend_row_indices=startend_row_indices,
@@ -935,10 +938,6 @@ def cp_flashmask_allgatherkv_balance_backward(
                     "FLAGS_cudnn_deterministic"
                 ],
             )
-        )
-    else:
-        raise ValueError(
-            f"FlashAttention version {fa_version} is not supported."
         )
 
     # Reduce-scatter key and value gradients
@@ -1981,8 +1980,14 @@ def flashmask_attention_cp(
         hcg = fleet.get_hybrid_communicate_group()
         cp_group = hcg.get_context_parallel_group()
 
-        assert _flash_mask_available, (
-            "P2P SWA fast path requires flashmask installed. Please check."
+        q_head_dim = query.shape[-1]
+        v_head_dim = value.shape[-1]
+        fa_version = get_fa_version(
+            q_head_dim, v_head_dim, startend_row_indices
+        )
+
+        assert fa_version == 4, (
+            f"current fa version is {fa_version}, but P2P SWA fast path requires flashmask 4.0 installed. Please check."
         )
 
         return FlashMaskSwaP2P.apply(

--- a/src/paddlefleet/refined_recompute/flash_attn.py
+++ b/src/paddlefleet/refined_recompute/flash_attn.py
@@ -22,7 +22,10 @@ from paddle.autograd import PyLayer
 from paddle.distributed import fleet
 from paddle.nn.functional.flash_attention import flashmask_attention
 from paddlefleet_ops import is_flash_mask_available
-from paddlefleet_ops.flash_mask_facade import get_fa_version
+from paddlefleet_ops.flash_mask_facade import (
+    get_fa_version,
+    is_flashmask_use_cutedsl,
+)
 
 from paddlefleet.context_parallel_utils import (
     UlyssesAlltoAll,
@@ -123,14 +126,7 @@ class FlashAttnFunctor(PyLayer):
                 dropout,
                 causal,
             )
-        elif fa_version == 3:
-            result_attention = hold_tensors["result_attention"]
-            softmax_lse = hold_tensors["softmax_lse"]
-            causal = hold_tensors["causal"]
-            ctx.save_for_backward(
-                q, k, v, result_attention, softmax_lse, causal
-            )
-        elif fa_version == 4:
+        elif not is_flashmask_use_cutedsl(fa_version):
             result_attention = hold_tensors["result_attention"]
             softmax_lse = hold_tensors["softmax_lse"]
             causal = hold_tensors["causal"]
@@ -138,7 +134,12 @@ class FlashAttnFunctor(PyLayer):
                 q, k, v, result_attention, softmax_lse, causal
             )
         else:
-            raise ValueError(f"Invalid flash attention version: {fa_version}")
+            result_attention = hold_tensors["result_attention"]
+            softmax_lse = hold_tensors["softmax_lse"]
+            causal = hold_tensors["causal"]
+            ctx.save_for_backward(
+                q, k, v, result_attention, softmax_lse, causal
+            )
 
         # Return the actual output computed during the first forward pass.
         return result_attention
@@ -185,7 +186,7 @@ class FlashAttnFunctor(PyLayer):
                 causal,
             )
             seed_offset._clear_dataptr()
-        elif fa_version == 3:
+        elif not is_flashmask_use_cutedsl(fa_version):
             q, k, v, result_attention, softmax_lse, causal = ctx.saved_tensor()
             q_grad, k_grad, v_grad = _C_ops.flash_attn_v3_grad(
                 q.detach(),
@@ -203,7 +204,7 @@ class FlashAttnFunctor(PyLayer):
                 0.0,  # softcap
                 0,  # sm_margin
             )
-        elif fa_version == 4:
+        else:
             flashmask_info = None
             q, k, v, result_attention, softmax_lse, causal = ctx.saved_tensor()
             q_grad, k_grad, v_grad, _ = _flash_attn_bwd(
@@ -222,8 +223,6 @@ class FlashAttnFunctor(PyLayer):
                     ]
                 ),
             )
-        else:
-            raise ValueError(f"Invalid flash attention version: {fa_version}")
 
         # Manually release memory of intermediate tensors to save GPU memory.
         result_attention._clear_dataptr()
@@ -336,7 +335,7 @@ class RefinedRcomputeFlashAttention:
                 "dropout": dropout,
                 "causal": causal,
             }
-        elif fa_version == 3:
+        elif not is_flashmask_use_cutedsl(fa_version):
             (result_attention, softmax_lse) = _C_ops.flash_attn_v3(
                 query_states,
                 key_states,
@@ -364,7 +363,7 @@ class RefinedRcomputeFlashAttention:
                 "softmax_scale": softmax_scale,
             }
             result_softmax = None  # FA v3 does not return softmax.
-        elif fa_version == 4:
+        else:
             (result_attention, softmax_lse) = _flash_attn_fwd(
                 query_states,
                 key_states,
@@ -382,8 +381,6 @@ class RefinedRcomputeFlashAttention:
                 "softmax_scale": softmax_scale,
             }
             result_softmax = None
-        else:
-            raise ValueError(f"Invalid flash attention version: {fa_version}")
 
         # Put the dictionary of saved tensors into the queue.
         self._hold_tensors_queue.put(hold_tensors)
@@ -455,7 +452,7 @@ class FlashMaskAttnFunctor(PyLayer):
                 dropout,
                 causal,
             )
-        elif fa_version == 3:
+        elif not is_flashmask_use_cutedsl(fa_version):
             result_attention = hold_tensors["result_attention"]
             softmax_lse = hold_tensors["softmax_lse"]
             causal = hold_tensors["causal"]
@@ -468,7 +465,7 @@ class FlashMaskAttnFunctor(PyLayer):
                 softmax_lse,
                 causal,
             )
-        elif fa_version == 4:
+        else:
             result_attention = hold_tensors["result_attention"]
             softmax_lse = hold_tensors["softmax_lse"]
             causal = hold_tensors["causal"]
@@ -482,8 +479,6 @@ class FlashMaskAttnFunctor(PyLayer):
                 causal,
                 learnable_sink,
             )
-        else:
-            raise ValueError(f"Invalid flash attention version: {fa_version}")
 
         return result_attention
 
@@ -521,7 +516,7 @@ class FlashMaskAttnFunctor(PyLayer):
                 causal,
             )
             seed_offset._clear_dataptr()
-        elif fa_version == 3:
+        elif not is_flashmask_use_cutedsl(fa_version):
             (
                 q,
                 k,
@@ -580,7 +575,7 @@ class FlashMaskAttnFunctor(PyLayer):
                     softmax_scale,
                     causal,
                 )
-        elif fa_version == 4:
+        else:
             (
                 q,
                 k,
@@ -615,8 +610,6 @@ class FlashMaskAttnFunctor(PyLayer):
                     ]
                 ),
             )
-        else:
-            raise ValueError(f"Invalid flash attention version: {fa_version}")
 
         # Manually release memory.
         result_attention._clear_dataptr()
@@ -668,9 +661,9 @@ class RefinedRcomputeFlashMaskAttention:
                 value_states.shape[-1],
                 startend_row_indices,
             )
-            if fa_version != 4:
+            if not is_flashmask_use_cutedsl(fa_version):
                 raise NotImplementedError(
-                    "learnable_sink only supported on fa_version==4 cute backend"
+                    "learnable_sink only supported cute backend"
                 )
         if not framework._dygraph_tracer()._has_grad:
             # This is the initial, normal forward pass.
@@ -752,7 +745,7 @@ class RefinedRcomputeFlashMaskAttention:
                 "dropout": dropout,
                 "causal": causal,
             }
-        elif fa_version == 3:
+        elif not is_flashmask_use_cutedsl(fa_version):
             sig_params = inspect.signature(flashmask_attention).parameters
             scale = (
                 query_states.shape[-1] ** (-0.5)
@@ -797,7 +790,7 @@ class RefinedRcomputeFlashMaskAttention:
                 "causal": causal,
                 "softmax_scale": softmax_scale,
             }
-        elif fa_version == 4:
+        else:
             (result_attention, softmax_lse) = _flash_attn_fwd(
                 query_states,
                 key_states,
@@ -816,8 +809,6 @@ class RefinedRcomputeFlashMaskAttention:
                 "learnable_sink": learnable_sink,
                 "softmax_scale": softmax_scale,
             }
-        else:
-            raise ValueError(f"Invalid flash attention version: {fa_version}")
 
         self._hold_tensors_queue.put(hold_tensors)
         return result_attention
@@ -1044,7 +1035,7 @@ class FlashMaskUlyssesCpFunctor(PyLayer):
                 causal,
             )
             seed_offset._clear_dataptr()
-        elif ctx.fa_version == 3:
+        elif not is_flashmask_use_cutedsl(ctx.fa_version):
             sig_params = inspect.signature(flashmask_attention).parameters
             scale = (
                 q.shape[-1] ** (-0.5)
@@ -1091,7 +1082,7 @@ class FlashMaskUlyssesCpFunctor(PyLayer):
                     scale,
                     causal,
                 )
-        elif ctx.fa_version == 4:
+        else:
             if startend_row_indices is not None:
                 flashmask_info = FlashMaskInfoPaddle(
                     startend_row_indices=startend_row_indices,
@@ -1115,10 +1106,6 @@ class FlashMaskUlyssesCpFunctor(PyLayer):
                         "FLAGS_cudnn_deterministic"
                     ]
                 ),
-            )
-        else:
-            raise ValueError(
-                f"Invalid flash attention version: {ctx.fa_version}"
             )
 
         query_grad = _ulysses_single_all_to_all_rr(
@@ -1301,7 +1288,7 @@ def ulysses_local_flashmask_first_fwd(
             "dropout": 0.0,
             "causal": causal,
         }
-    elif fa_version == 3:
+    elif not is_flashmask_use_cutedsl(fa_version):
         sig_params = inspect.signature(flashmask_attention).parameters
         scale = (
             query_states.shape[-1] ** (-0.5)
@@ -1346,7 +1333,7 @@ def ulysses_local_flashmask_first_fwd(
             "causal": causal,
             "softmax_scale": softmax_scale,
         }
-    elif fa_version == 4:
+    else:
         result_attention, softmax_lse = _flash_attn_fwd(
             query_states,
             key_states,
@@ -1364,8 +1351,7 @@ def ulysses_local_flashmask_first_fwd(
             "causal": causal,
             "softmax_scale": softmax_scale,
         }
-    else:
-        raise ValueError(f"Invalid flash attention version: {fa_version}")
+
     hold_tensors["fa_version"] = fa_version
     return result_attention, hold_tensors
 
@@ -1408,9 +1394,9 @@ class RefinedRcomputeFlashMaskCpAttention:
                 value_states.shape[-1],
                 startend_row_indices,
             )
-            if not fa_version == 4:
+            if not is_flashmask_use_cutedsl(fa_version):
                 raise NotImplementedError(
-                    "learnable_sink only supported on fa_version==4 cute backend"
+                    "learnable_sink only supported cute backend"
                 )
         if not framework._dygraph_tracer()._has_grad:
             # This is the initial, normal forward pass.

--- a/src/paddlefleet/transformer/dot_product_attention.py
+++ b/src/paddlefleet/transformer/dot_product_attention.py
@@ -33,6 +33,7 @@ from paddlefleet_ops.flash_mask_facade import (
     flash_attention,
     flashmask_attention,
     get_fa_version,
+    is_value_padding_needed,
 )
 
 from paddlefleet.context_parallel_utils import (
@@ -788,22 +789,13 @@ class DotProductAttention(FleetLayer):
                 q_head_dim, v_head_dim, attn_mask_startend_row_indices
             )
 
-            need_value_padding = (
-                not (
-                    fa_version == 4
-                    and (
-                        (q_head_dim == 192 and v_head_dim == 128)
-                        or (q_head_dim == 576 and v_head_dim == 512)
-                    )
-                )
-            ) and q_head_dim != v_head_dim
+            need_value_padding = is_value_padding_needed(
+                fa_version, q_head_dim, v_head_dim
+            )
 
             if need_value_padding:
-                # Pad value to match query head_dim
-                # value: [b, s, h, v_head_dim] -> [b, s, h, q_head_dim]
-                bsz, seq_len, num_heads, _ = value.shape
                 value_padding = paddle.zeros(
-                    [bsz, seq_len, num_heads, q_head_dim - v_head_dim],
+                    [*value.shape[:-1], q_head_dim - v_head_dim],
                     dtype=value.dtype,
                 )
                 value_padded = paddle.concat([value, value_padding], axis=-1)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
在 SM90（Hopper）上启用 FA3 的 cutedsl 版本，让 FA3 与 FA4 共用同一条 kernel 路径。


### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
是