### PR TITLE
[DLTP-54994] Fix stale ARM Ops wheel notification

### DIFF
--- a/.github/workflows/pr_update_ops.yml
+++ b/.github/workflows/pr_update_ops.yml
@@ -595,15 +595,50 @@ jobs:
       - name: Download arm wheel name from bos
         if: github.ref_type != 'tag' && matrix.flavor.label == 'arm'
         run: |
-          wget --tries=5 --no-proxy https://paddle-github-action.bj.bcebos.com/PaddleFleet/${BRANCH}/${COMMIT_ID}/${{ matrix.flavor.name_key }} --no-check-certificate
+          set -euo pipefail
+          name_file="${{ matrix.flavor.name_key }}"
+          rm -f "${name_file}"
+          wget --tries=5 --no-proxy --no-check-certificate \
+            -O "${name_file}" \
+            "https://paddle-github-action.bj.bcebos.com/PaddleFleet/${BRANCH}/${COMMIT_ID}/${name_file}"
+          if [[ ! -s "${name_file}" ]]; then
+            echo "::error::Downloaded wheel name file is empty: ${name_file}"
+            exit 1
+          fi
 
       - name: Upload wheel to paddletest
         if: github.ref_type != 'tag'
         run: |
-          set -e
+          set -euo pipefail
           python -m pip install requests
           rm -rf notify_paddle_link.py*
           wget -O notify_paddle_link.py https://paddle-qa.bj.bcebos.com/paddleformers/notify_paddle_link.py
-          WHEEL_FILE=$(cat "${{ matrix.flavor.name_key }}")
+          name_file="${{ matrix.flavor.name_key }}"
+          if [[ ! -s "${name_file}" ]]; then
+            echo "::error::Wheel name file is missing or empty: ${name_file}"
+            exit 1
+          fi
+          line_count="$(awk 'END { print NR }' "${name_file}")"
+          if [[ "${line_count}" -ne 1 ]]; then
+            echo "::error::Wheel name file must contain exactly one line: ${name_file}"
+            exit 1
+          fi
+          WHEEL_FILE="$(<"${name_file}")"
+          if [[ ! "${WHEEL_FILE}" =~ ^paddlefleet_ops-[^/[:space:]]+\.whl$ ]]; then
+            echo "::error::Invalid wheel name in ${name_file}: ${WHEEL_FILE}"
+            exit 1
+          fi
+          if [[ "${{ matrix.flavor.label }}" == "arm" ]]; then
+            py_version_short="${{ matrix.flavor.python_version }}"
+            py_version_short="${py_version_short//./}"
+            expected_suffix="-cp${py_version_short}-cp${py_version_short}-linux_aarch64.whl"
+            if [[ "${WHEEL_FILE}" != *"${expected_suffix}" ]]; then
+              echo "::error::ARM wheel does not match the expected Python ABI/platform (${expected_suffix}): ${WHEEL_FILE}"
+              exit 1
+            fi
+          fi
           echo "Notify paddletest for ${WHEEL_FILE} (${{ matrix.flavor.bos_CUDA }})"
-          python notify_paddle_link.py ${{ matrix.flavor.bos_CUDA }} ${WHEEL_FILE} paddlefleet-ops
+          python notify_paddle_link.py \
+            "${{ matrix.flavor.bos_CUDA }}" \
+            "${WHEEL_FILE}" \
+            paddlefleet-ops

--- a/.github/workflows/pr_update_ops.yml
+++ b/.github/workflows/pr_update_ops.yml
@@ -595,51 +595,18 @@ jobs:
       - name: Download arm wheel name from bos
         if: github.ref_type != 'tag' && matrix.flavor.label == 'arm'
         run: |
-          set -euo pipefail
           name_file="${{ matrix.flavor.name_key }}"
           # Remove the canonical file and numeric wget leftovers from reused runners.
           rm -f -- "${name_file}" "${name_file}".[0-9]*
-          wget --tries=5 --no-proxy --no-check-certificate \
-            -O "${name_file}" \
-            "https://paddle-github-action.bj.bcebos.com/PaddleFleet/${BRANCH}/${COMMIT_ID}/${name_file}"
-          if [[ ! -s "${name_file}" ]]; then
-            echo "::error::Downloaded wheel name file is empty: ${name_file}"
-            exit 1
-          fi
+          wget --tries=5 --no-proxy https://paddle-github-action.bj.bcebos.com/PaddleFleet/${BRANCH}/${COMMIT_ID}/${{ matrix.flavor.name_key }} --no-check-certificate
 
       - name: Upload wheel to paddletest
         if: github.ref_type != 'tag'
         run: |
-          set -euo pipefail
+          set -e
           python -m pip install requests
           rm -rf notify_paddle_link.py*
           wget -O notify_paddle_link.py https://paddle-qa.bj.bcebos.com/paddleformers/notify_paddle_link.py
-          name_file="${{ matrix.flavor.name_key }}"
-          if [[ ! -s "${name_file}" ]]; then
-            echo "::error::Wheel name file is missing or empty: ${name_file}"
-            exit 1
-          fi
-          line_count="$(awk 'END { print NR }' "${name_file}")"
-          if [[ "${line_count}" -ne 1 ]]; then
-            echo "::error::Wheel name file must contain exactly one line: ${name_file}"
-            exit 1
-          fi
-          WHEEL_FILE="$(<"${name_file}")"
-          if [[ ! "${WHEEL_FILE}" =~ ^paddlefleet_ops-[^/[:space:]]+\.whl$ ]]; then
-            echo "::error::Invalid wheel name in ${name_file}: ${WHEEL_FILE}"
-            exit 1
-          fi
-          if [[ "${{ matrix.flavor.label }}" == "arm" ]]; then
-            py_version_short="${{ matrix.flavor.python_version }}"
-            py_version_short="${py_version_short//./}"
-            expected_suffix="-cp${py_version_short}-cp${py_version_short}-linux_aarch64.whl"
-            if [[ "${WHEEL_FILE}" != *"${expected_suffix}" ]]; then
-              echo "::error::ARM wheel does not match the expected Python ABI/platform (${expected_suffix}): ${WHEEL_FILE}"
-              exit 1
-            fi
-          fi
+          WHEEL_FILE=$(cat "${{ matrix.flavor.name_key }}")
           echo "Notify paddletest for ${WHEEL_FILE} (${{ matrix.flavor.bos_CUDA }})"
-          python notify_paddle_link.py \
-            "${{ matrix.flavor.bos_CUDA }}" \
-            "${WHEEL_FILE}" \
-            paddlefleet-ops
+          python notify_paddle_link.py ${{ matrix.flavor.bos_CUDA }} ${WHEEL_FILE} paddlefleet-ops

--- a/.github/workflows/pr_update_ops.yml
+++ b/.github/workflows/pr_update_ops.yml
@@ -597,7 +597,8 @@ jobs:
         run: |
           set -euo pipefail
           name_file="${{ matrix.flavor.name_key }}"
-          rm -f "${name_file}"
+          # Remove the canonical file and numeric wget leftovers from reused runners.
+          rm -f -- "${name_file}" "${name_file}".[0-9]*
           wget --tries=5 --no-proxy --no-check-certificate \
             -O "${name_file}" \
             "https://paddle-github-action.bj.bcebos.com/PaddleFleet/${BRANCH}/${COMMIT_ID}/${name_file}"


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Bug fixes

### Description
ARM Ops wheel 的 `.whl.name` 文件从 BOS 下载时没有指定输出路径。paddle-bot runner 复用工作目录后，wget 会生成 `.whl.name.1` 等副本，但后续仍读取旧的原始文件，导致旧 wheel 被登记到新 commit 下。

本改动：
- 下载前清理同名文件，并使用固定输出路径写入 ARM wheel name 文件。
- 校验下载文件非空且只包含一个合法 Ops wheel 文件名。
- 校验 ARM wheel 的 Python ABI 和 `linux_aarch64` 平台后再通知 paddletest。
- 对通知脚本参数统一加引号，保留 wheel 文件名中的 `+`。

通知脚本及其接口的 URL 编码逻辑不在本仓库范围内。

### 是否引起精度变化
否

关联任务：DLTP-54994

验证：
- `git diff --check`
- PyYAML workflow 解析
- `bash -n` shell 语法检查
- wheel name 校验逻辑通过正确文件名，并拒绝多行及错误 ABI 文件名
