### PR TITLE
[Operator Mechanism] Enable FA3 cutedsl on SM90

### DIFF
--- a/packages/paddlefleet_ops/src/paddlefleet_ops/__init__.py
+++ b/packages/paddlefleet_ops/src/paddlefleet_ops/__init__.py
@@ -176,7 +176,7 @@ else:
 
 FLASH_MASK_HINT = (
     "For developers: guard imports with `is_flash_mask_available()` and only call `paddlefleet_ops.flash_mask` when flag branch enabled.\n"
-    "For users: use a GPU with compute capability >= 10.0 (Blackwell) to enable."
+    "For users: use a GPU with compute capability >= 9.0 (Hopper or Blackwell) to enable."
 )
 
 
@@ -253,10 +253,9 @@ if paddle.is_compiled_with_cuda():
         _DEEP_EP_AVAILABLE = True
         _FLASH_MLA_AVAILABLE = True
         _MOON_EP_AVAILABLE = True
+        _FLASH_MASK_AVAILABLE = True
         if _cuda_version >= (12, 9):
             _HYBRID_EP_AVAILABLE = True
-    if paddle.cuda.get_device_capability()[0] >= 10:
-        _FLASH_MASK_AVAILABLE = True
     if (
         sys.version_info >= (3, 12)
         and paddle.cuda.get_device_capability()[0] >= 10
@@ -439,7 +438,7 @@ if paddle.is_compiled_with_cuda():
     if is_flash_mask_available():
         _safe_load_ecosystem_lib("flash_mask", ops_dir, globals())
     else:
-        warning, error = _blackwell_requirement(
+        warning, error = _hopper_requirement(
             "paddlefleet_ops.flash_mask", hint=FLASH_MASK_HINT
         )
         logger.warning(warning)

--- a/packages/paddlefleet_ops/src/paddlefleet_ops/flash_mask_facade.py
+++ b/packages/paddlefleet_ops/src/paddlefleet_ops/flash_mask_facade.py
@@ -18,36 +18,90 @@ import paddle
 
 from . import is_flash_mask_available
 
-if is_flash_mask_available():
-    try:
-        from .flash_mask import (
-            flash_attention as _flash_attention,
-            flashmask_attention as _flashmask_attention,
-        )
-    except (ImportError, ModuleNotFoundError):
-        from .flash_mask.cute.interface import (
-            flash_attention as _flash_attention,
-            flashmask_attention as _flashmask_attention,
-        )
-else:
-    from paddle.nn.functional.flash_attention import (
-        flash_attention as _flash_attention,
-        flashmask_attention as _flashmask_attention,
-    )
+FA3_BACKEND_CHOICES = ("cutedsl", "cpp")
+
+# Which kernel FA3 FlashMask runs on. Not an environment variable: the value
+# comes from ``TransformerConfig.flash_attn_fa3_backend`` and is handed over by
+# :func:`set_fa3_backend` in ``__post_init__``. An env switch would be fixed
+# before ``from_config`` runs, so no config could override it and the choice
+# would neither be validated nor stored alongside the config.
+#
+# Resolved once per process. Version dispatch, backend pick
+# (``uses_cutedsl_backend``) and value padding (``needs_value_padding``) all read
+# this module global, and ``PyLayer.forward``/``backward`` read it independently,
+# so a mid-process flip would pair two different kernels -- and a second config
+# would reroute a model that is already running. ``set_fa3_backend`` therefore
+# accepts the same choice any number of times and rejects a different one;
+# ``_FA3_BACKEND`` is what it has resolved so far (``None`` before the first
+# call).
+_FA3_BACKEND = None
+FLASHMASK_FA3_USE_CUTEDSL = True
 
 
-def get_fa_version(
+def set_fa3_backend(backend: str) -> None:
+    """Point FA3 FlashMask at ``backend``; called from config, not by user code.
+
+    Resolved once per process: repeating the same choice is a no-op, asking for a
+    different one raises instead of silently rerouting kernels behind models that
+    are already running.
+
+    Args:
+        backend: One of ``FA3_BACKEND_CHOICES``. ``"cutedsl"`` selects the CuTe
+            DSL kernels, ``"cpp"`` the C++ FA3 kernels behind Paddle's built-in
+            FlashMask op.
+
+    Raises:
+        ValueError: If ``backend`` is not a known choice -- the string is parsed
+            here only, so every consumer reads a plain bool -- or if it differs
+            from the choice already resolved in this process.
+    """
+    global FLASHMASK_FA3_USE_CUTEDSL, _FA3_BACKEND
+    if backend not in FA3_BACKEND_CHOICES:
+        raise ValueError(
+            f"unknown FA3 backend {backend!r}, expected one of "
+            f"{list(FA3_BACKEND_CHOICES)}"
+        )
+    if _FA3_BACKEND is not None and _FA3_BACKEND != backend:
+        raise ValueError(
+            "flash_attn_fa3_backend cannot change within a process: already "
+            f"{_FA3_BACKEND!r}, got {backend!r} -- a forward and its backward "
+            "read the choice independently, so a mid-process flip would pair "
+            "two different kernels. Give every TransformerConfig in this "
+            "process the same value."
+        )
+    _FA3_BACKEND = backend
+    FLASHMASK_FA3_USE_CUTEDSL = backend == "cutedsl"
+
+
+def _reset_fa3_backend() -> None:
+    """Drop the resolved choice so the next ``set_fa3_backend`` wins. Tests only.
+
+    Not part of the public surface: production code resolves the backend exactly
+    once, from ``TransformerConfig.flash_attn_fa3_backend``.
+    """
+    global FLASHMASK_FA3_USE_CUTEDSL, _FA3_BACKEND
+    _FA3_BACKEND = None
+    FLASHMASK_FA3_USE_CUTEDSL = True
+
+
+def _dispatch_fa_version(
     head_dim: int,
     head_dim_v: int | None = None,
     startend_row_indices: paddle.Tensor | None = None,
 ) -> int:
     """Pick the FlashAttention version for the given head dims.
 
+    Prefer the public ``get_fa_version``, which validates what this returns.
+
     Dispatch rules:
       * XPU device -> FA2.
       * Otherwise, respect ``FLAGS_flash_attn_version`` by default.
-      * If ``fa_version == 3`` and deterministic is required, FA3 only supports
-        ``head_dim <= 128``. For ``head_dim > 128``, fall back to FA2.
+      * If ``fa_version == 3`` and ``FLASHMASK_FA3_USE_CUTEDSL`` is off, FA3 runs
+        on the Paddle kernel, which only supports ``head_dim <= 128`` when
+        deterministic is required. For ``head_dim > 128``, fall back to FA2. On
+        the cutedsl backend FA3 needs no such degrade -- its backward has an
+        ordered-accumulation variant, so deterministic holds for every head dim
+        in the cutedsl whitelist below.
       * FA4 is only used when both ``hdim_ok`` and ``mask_ok`` hold:
 
         - ``hdim_ok``: one of
@@ -86,31 +140,140 @@ def get_fa_version(
         "FLAGS_cudnn_deterministic"
     ]
 
-    if fa_version == 3:
-        if deterministic and head_dim > 128:
+    if fa_version == 4 or (fa_version == 3 and FLASHMASK_FA3_USE_CUTEDSL):
+        if not is_flash_mask_available():
             return 2
 
-    if fa_version == 4:
-        _head_dim_v = head_dim_v if head_dim_v is not None else head_dim
-        fa4_hdim_ok = (
-            (head_dim <= 128 and _head_dim_v <= 128)
-            or (head_dim == 192 and _head_dim_v == 128)
-            or (head_dim == 256 and _head_dim_v == 256)
-            # Both of these exceed 256 and so take FA4's big-head-dim backward,
-            # which asserts ``not deterministic`` (``flash_mask/cute/
-            # interface.py``: ``is_bigd_bwd`` -> "deterministic reduction is not
-            # supported by big-headdim bwd"). Degrade instead of aborting, the
-            # same way FA3 degrades above.
-            or (head_dim == 512 and _head_dim_v == 512 and not deterministic)
-            or (head_dim == 576 and _head_dim_v == 512 and not deterministic)
-        )
-        fa4_mask_ok = (
-            startend_row_indices is None or startend_row_indices.shape[-1] != 4
-        )
-        if not (fa4_hdim_ok and fa4_mask_ok):
-            return 2
+    if FLASHMASK_FA3_USE_CUTEDSL:
+        if fa_version in (3, 4):
+            _head_dim_v = head_dim_v if head_dim_v is not None else head_dim
+            cutedsl_hdim_ok = (
+                (head_dim <= 128 and _head_dim_v <= 128)
+                or (head_dim == 192 and _head_dim_v == 128)
+                or (head_dim == 256 and _head_dim_v == 256)
+            )
+            # FA4 additionally supports larger head dims (non-deterministic only)
+            if fa_version == 4 and not deterministic:
+                cutedsl_hdim_ok = cutedsl_hdim_ok or (
+                    (head_dim == 512 and _head_dim_v == 512)
+                    or (head_dim == 576 and _head_dim_v == 512)
+                )
+            if not cutedsl_hdim_ok:
+                return 2
+            # Only FA4 is restricted here: the FA4 kernel does not serve a
+            # 4-column flashmask, while FA3 on cutedsl accepts it. Not a missing
+            # FA3 branch.
+            fa4_mask_ok = (
+                startend_row_indices is None
+                or startend_row_indices.shape[-1] != 4
+            )
+            if fa_version == 4:
+                if not fa4_mask_ok:
+                    return 2
+    else:
+        if fa_version == 3:
+            if deterministic and head_dim > 128:
+                return 2
+
+        if fa_version == 4:
+            _head_dim_v = head_dim_v if head_dim_v is not None else head_dim
+            fa4_hdim_ok = (
+                (head_dim <= 128 and _head_dim_v <= 128)
+                or (head_dim == 192 and _head_dim_v == 128)
+                or (head_dim == 256 and _head_dim_v == 256)
+                # Both of these exceed 256 and so take FA4's big-head-dim backward,
+                # which asserts ``not deterministic`` (``flash_mask/cute/
+                # interface.py``: ``is_bigd_bwd`` -> "deterministic reduction is not
+                # supported by big-headdim bwd"). Degrade instead of aborting, the
+                # same way FA3 degrades above.
+                or (
+                    head_dim == 512 and _head_dim_v == 512 and not deterministic
+                )
+                or (
+                    head_dim == 576 and _head_dim_v == 512 and not deterministic
+                )
+            )
+            fa4_mask_ok = (
+                startend_row_indices is None
+                or startend_row_indices.shape[-1] != 4
+            )
+            if not (fa4_hdim_ok and fa4_mask_ok):
+                return 2
 
     return fa_version
+
+
+def get_fa_version(
+    head_dim: int,
+    head_dim_v: int | None = None,
+    startend_row_indices: paddle.Tensor | None = None,
+) -> int:
+    """Pick the FlashAttention version, rejecting versions we cannot dispatch.
+
+    Thin validating wrapper over ``_dispatch_fa_version``; see that function for
+    the dispatch rules and argument meanings.
+
+    Returns:
+        The FlashAttention version to use (2, 3 or 4).
+
+    Raises:
+        ValueError: If the resolved version is not 2, 3 or 4 -- in practice this
+            means ``FLAGS_flash_attn_version`` was set to something unsupported,
+            since every degrade path returns 2.
+    """
+    fa_version = _dispatch_fa_version(
+        head_dim, head_dim_v, startend_row_indices
+    )
+    if fa_version not in (2, 3, 4):
+        raise ValueError(f"Invalid flash attention version: {fa_version}")
+    return fa_version
+
+
+def uses_cutedsl_backend(fa_version: int) -> bool:
+    """Whether ``fa_version`` runs on the cutedsl backend.
+
+    FA4 is cutedsl-only, FA3 depends on ``FLASHMASK_FA3_USE_CUTEDSL``, FA2 never
+    uses it.
+
+    Args:
+        fa_version: The version returned by :func:`get_fa_version`.
+
+    Returns:
+        ``True`` when the call site must use the cutedsl kernels.
+    """
+    if fa_version == 3:
+        return FLASHMASK_FA3_USE_CUTEDSL
+    elif fa_version == 4:
+        return True
+    else:
+        return False
+
+
+def needs_value_padding(
+    fa_version: int,
+    head_dim: int,
+    head_dim_v: int,
+) -> bool:
+    """Whether ``value`` must be zero-padded from ``head_dim_v`` to ``head_dim``.
+
+    Args:
+        fa_version: The version returned by :func:`get_fa_version`.
+        head_dim: Query/Key head dim.
+        head_dim_v: Value head dim.
+
+    Returns:
+        ``True`` when ``value`` needs padding.
+    """
+    fa3_native_pair = (
+        FLASHMASK_FA3_USE_CUTEDSL
+        and (fa_version == 3)
+        and (head_dim == 192 and head_dim_v == 128)
+    )
+    fa4_native_pair = (fa_version == 4) and (
+        (head_dim == 192 and head_dim_v == 128)
+        or (head_dim == 576 and head_dim_v == 512)
+    )
+    return head_dim != head_dim_v and not (fa3_native_pair or fa4_native_pair)
 
 
 def flashmask_attention(
@@ -133,6 +296,24 @@ def flashmask_attention(
     use_varlen: bool = False,
     learnable_sink: paddle.Tensor | None = None,
 ):
+    bsz, q_len, num_heads, q_head_dim = query.shape
+    v_head_dim = value.shape[-1]
+    fa_version = get_fa_version(q_head_dim, v_head_dim, startend_row_indices)
+
+    if uses_cutedsl_backend(fa_version):
+        try:
+            from .flash_mask import (
+                flashmask_attention as _flashmask_attention,
+            )
+        except (ImportError, ModuleNotFoundError):
+            from .flash_mask.cute.interface import (
+                flashmask_attention as _flashmask_attention,
+            )
+    else:
+        from paddle.nn.functional.flash_attention import (
+            flashmask_attention as _flashmask_attention,
+        )
+
     if use_varlen:
         assert (
             "use_varlen" in inspect.signature(_flashmask_attention).parameters
@@ -150,24 +331,11 @@ def flashmask_attention(
                 "FA4-capable device."
             )
 
-    bsz, q_len, num_heads, q_head_dim = query.shape
-    v_head_dim = value.shape[-1]
-
-    fa_version = get_fa_version(q_head_dim, v_head_dim, startend_row_indices)
-
-    need_value_padding = (
-        not (
-            fa_version == 4
-            and (
-                (q_head_dim == 192 and v_head_dim == 128)
-                or (q_head_dim == 576 and v_head_dim == 512)
-            )
-        )
-    ) and q_head_dim != v_head_dim
+    need_value_padding = needs_value_padding(fa_version, q_head_dim, v_head_dim)
 
     if need_value_padding:
         value_padding = paddle.zeros(
-            [bsz, q_len, value.shape[2], q_head_dim - v_head_dim],
+            [*value.shape[:-1], q_head_dim - v_head_dim],
             dtype=value.dtype,
         )
         value = paddle.concat([value, value_padding], axis=-1)
@@ -237,19 +405,25 @@ def flash_attention(
     # startend_row_indices is None
     fa_version = get_fa_version(q_head_dim, v_head_dim)
 
-    need_value_padding = (
-        not (
-            fa_version == 4
-            and (
-                (q_head_dim == 192 and v_head_dim == 128)
-                or (q_head_dim == 576 and v_head_dim == 512)
+    if uses_cutedsl_backend(fa_version):
+        try:
+            from .flash_mask import (
+                flash_attention as _flash_attention,
             )
+        except (ImportError, ModuleNotFoundError):
+            from .flash_mask.cute.interface import (
+                flash_attention as _flash_attention,
+            )
+    else:
+        from paddle.nn.functional.flash_attention import (
+            flash_attention as _flash_attention,
         )
-    ) and q_head_dim != v_head_dim
+
+    need_value_padding = needs_value_padding(fa_version, q_head_dim, v_head_dim)
 
     if need_value_padding:
         value_padding = paddle.zeros(
-            [bsz, q_len, value.shape[2], q_head_dim - v_head_dim],
+            [*value.shape[:-1], q_head_dim - v_head_dim],
             dtype=value.dtype,
         )
         value = paddle.concat([value, value_padding], axis=-1)
@@ -277,7 +451,11 @@ def flash_attention(
 
 
 __all__ = [
+    "FA3_BACKEND_CHOICES",
     "flashmask_attention",
     "flash_attention",
     "get_fa_version",
+    "needs_value_padding",
+    "set_fa3_backend",
+    "uses_cutedsl_backend",
 ]

--- a/src/paddlefleet/context_parallel_utils.py
+++ b/src/paddlefleet/context_parallel_utils.py
@@ -20,14 +20,14 @@ from paddle import distributed as dist
 from paddle.autograd.py_layer import PyLayer
 from paddle.distributed import fleet
 from paddle.nn.functional.flash_attention import flashmask_attention
-from paddlefleet_ops.flash_mask_facade import get_fa_version
+from paddlefleet_ops import is_flash_mask_available
+from paddlefleet_ops.flash_mask_facade import (
+    get_fa_version,
+    uses_cutedsl_backend,
+)
 
-_flash_mask_available = False
-try:
-    if (
-        paddle.cuda.is_available()
-        and paddle.cuda.get_device_capability()[0] == 10
-    ):
+if is_flash_mask_available():
+    try:
         from paddlefleet_ops.flash_mask.cute.flashmask_utils import (
             FlashMaskInfoPaddle,
         )
@@ -36,10 +36,17 @@ try:
             _flash_attn_fwd,
         )
         from paddlefleet_ops.flash_mask.utils import bshd_slice_contiguous_kv
-
-        _flash_mask_available = True
-except (ImportError, AttributeError):
-    _flash_mask_available = False
+    except (ImportError, AttributeError) as exc:
+        # Capability is high enough but the build is unusable (mismatched
+        # paddlefleet_ops, broken cute import). ``is_flash_mask_available()`` is
+        # a pure capability probe, so the FA3/FA4 dispatch below and the SWA P2P
+        # path would still reach these names and die on a bare NameError. Fail
+        # here, where the cause is still visible.
+        raise ImportError(
+            "paddlefleet_ops reports FlashMask as available on this device, but "
+            "its cute kernels cannot be imported -- reinstall paddlefleet_ops "
+            "so that paddlefleet_ops.flash_mask.cute matches it."
+        ) from exc
 
 
 def mark_context_parallel_parameter_disable_scale_grad(param_or_layer):
@@ -740,7 +747,7 @@ def cp_flashmask_allgatherkv_balance_forward(
     v_head_dim = value_gathered.shape[-1]
     fa_version = get_fa_version(q_head_dim, v_head_dim, startend_row_indices)
 
-    if fa_version == 4 and _flash_mask_available:
+    if uses_cutedsl_backend(fa_version):
         output, log_sum_exp = _flash_attn_fwd(
             query,
             key_gathered,
@@ -755,7 +762,7 @@ def cp_flashmask_allgatherkv_balance_forward(
     else:
         if learnable_sink is not None:
             raise NotImplementedError(
-                "learnable_sink only supported on fa_version==4 cute backend"
+                "learnable_sink is only supported on the cute backend"
             )
         output, log_sum_exp = flashmask_attention(
             query,
@@ -827,7 +834,7 @@ def cp_flashmask_allgatherkv_balance_backward(
     if fa_version == 2:
         if learnable_sink is not None:
             raise NotImplementedError(
-                "learnable_sink only supported on fa_version==4 cute backend"
+                "learnable_sink is only supported on the cute backend"
             )
         if softmax_scale is not None:
             raise NotImplementedError(
@@ -853,10 +860,10 @@ def cp_flashmask_allgatherkv_balance_backward(
                 causal,
             )
         )
-    elif fa_version == 3:
+    elif not uses_cutedsl_backend(fa_version):
         if learnable_sink is not None:
             raise NotImplementedError(
-                "learnable_sink only supported on fa_version==4 cute backend"
+                "learnable_sink is only supported on the cute backend"
             )
         sig_params = inspect.signature(flashmask_attention).parameters
         if "group" in sig_params:
@@ -911,7 +918,7 @@ def cp_flashmask_allgatherkv_balance_backward(
                     False,
                 )
             )
-    elif fa_version == 4 and _flash_mask_available:
+    else:
         if startend_row_indices is not None:
             flashmask_info = FlashMaskInfoPaddle(
                 startend_row_indices=startend_row_indices,
@@ -935,10 +942,6 @@ def cp_flashmask_allgatherkv_balance_backward(
                     "FLAGS_cudnn_deterministic"
                 ],
             )
-        )
-    else:
-        raise ValueError(
-            f"FlashAttention version {fa_version} is not supported."
         )
 
     # Reduce-scatter key and value gradients
@@ -1981,8 +1984,18 @@ def flashmask_attention_cp(
         hcg = fleet.get_hybrid_communicate_group()
         cp_group = hcg.get_context_parallel_group()
 
-        assert _flash_mask_available, (
-            "P2P SWA fast path requires flashmask installed. Please check."
+        q_head_dim = query.shape[-1]
+        v_head_dim = value.shape[-1]
+        fa_version = get_fa_version(
+            q_head_dim, v_head_dim, startend_row_indices
+        )
+
+        # ``FlashMaskSwaP2P`` is implemented against the FA4 kernel only -- FA3
+        # on cutedsl is not a drop-in here, so reject instead of degrading.
+        assert fa_version == 4, (
+            f"P2P SWA fast path (mode={mode!r}) only supports FA4, but "
+            f"get_fa_version returned {fa_version}. Set "
+            "FLAGS_flash_attn_version=4, or use another context-parallel mode."
         )
 
         return FlashMaskSwaP2P.apply(

--- a/src/paddlefleet/refined_recompute/flash_attn.py
+++ b/src/paddlefleet/refined_recompute/flash_attn.py
@@ -22,7 +22,10 @@ from paddle.autograd import PyLayer
 from paddle.distributed import fleet
 from paddle.nn.functional.flash_attention import flashmask_attention
 from paddlefleet_ops import is_flash_mask_available
-from paddlefleet_ops.flash_mask_facade import get_fa_version
+from paddlefleet_ops.flash_mask_facade import (
+    get_fa_version,
+    uses_cutedsl_backend,
+)
 
 from paddlefleet.context_parallel_utils import (
     UlyssesAlltoAll,
@@ -123,14 +126,7 @@ class FlashAttnFunctor(PyLayer):
                 dropout,
                 causal,
             )
-        elif fa_version == 3:
-            result_attention = hold_tensors["result_attention"]
-            softmax_lse = hold_tensors["softmax_lse"]
-            causal = hold_tensors["causal"]
-            ctx.save_for_backward(
-                q, k, v, result_attention, softmax_lse, causal
-            )
-        elif fa_version == 4:
+        elif not uses_cutedsl_backend(fa_version):
             result_attention = hold_tensors["result_attention"]
             softmax_lse = hold_tensors["softmax_lse"]
             causal = hold_tensors["causal"]
@@ -138,7 +134,12 @@ class FlashAttnFunctor(PyLayer):
                 q, k, v, result_attention, softmax_lse, causal
             )
         else:
-            raise ValueError(f"Invalid flash attention version: {fa_version}")
+            result_attention = hold_tensors["result_attention"]
+            softmax_lse = hold_tensors["softmax_lse"]
+            causal = hold_tensors["causal"]
+            ctx.save_for_backward(
+                q, k, v, result_attention, softmax_lse, causal
+            )
 
         # Return the actual output computed during the first forward pass.
         return result_attention
@@ -185,7 +186,7 @@ class FlashAttnFunctor(PyLayer):
                 causal,
             )
             seed_offset._clear_dataptr()
-        elif fa_version == 3:
+        elif not uses_cutedsl_backend(fa_version):
             q, k, v, result_attention, softmax_lse, causal = ctx.saved_tensor()
             q_grad, k_grad, v_grad = _C_ops.flash_attn_v3_grad(
                 q.detach(),
@@ -203,7 +204,7 @@ class FlashAttnFunctor(PyLayer):
                 0.0,  # softcap
                 0,  # sm_margin
             )
-        elif fa_version == 4:
+        else:
             flashmask_info = None
             q, k, v, result_attention, softmax_lse, causal = ctx.saved_tensor()
             q_grad, k_grad, v_grad, _ = _flash_attn_bwd(
@@ -222,8 +223,6 @@ class FlashAttnFunctor(PyLayer):
                     ]
                 ),
             )
-        else:
-            raise ValueError(f"Invalid flash attention version: {fa_version}")
 
         # Manually release memory of intermediate tensors to save GPU memory.
         result_attention._clear_dataptr()
@@ -336,7 +335,7 @@ class RefinedRcomputeFlashAttention:
                 "dropout": dropout,
                 "causal": causal,
             }
-        elif fa_version == 3:
+        elif not uses_cutedsl_backend(fa_version):
             (result_attention, softmax_lse) = _C_ops.flash_attn_v3(
                 query_states,
                 key_states,
@@ -364,7 +363,7 @@ class RefinedRcomputeFlashAttention:
                 "softmax_scale": softmax_scale,
             }
             result_softmax = None  # FA v3 does not return softmax.
-        elif fa_version == 4:
+        else:
             (result_attention, softmax_lse) = _flash_attn_fwd(
                 query_states,
                 key_states,
@@ -382,8 +381,6 @@ class RefinedRcomputeFlashAttention:
                 "softmax_scale": softmax_scale,
             }
             result_softmax = None
-        else:
-            raise ValueError(f"Invalid flash attention version: {fa_version}")
 
         # Put the dictionary of saved tensors into the queue.
         self._hold_tensors_queue.put(hold_tensors)
@@ -455,7 +452,7 @@ class FlashMaskAttnFunctor(PyLayer):
                 dropout,
                 causal,
             )
-        elif fa_version == 3:
+        elif not uses_cutedsl_backend(fa_version):
             result_attention = hold_tensors["result_attention"]
             softmax_lse = hold_tensors["softmax_lse"]
             causal = hold_tensors["causal"]
@@ -468,7 +465,7 @@ class FlashMaskAttnFunctor(PyLayer):
                 softmax_lse,
                 causal,
             )
-        elif fa_version == 4:
+        else:
             result_attention = hold_tensors["result_attention"]
             softmax_lse = hold_tensors["softmax_lse"]
             causal = hold_tensors["causal"]
@@ -482,8 +479,6 @@ class FlashMaskAttnFunctor(PyLayer):
                 causal,
                 learnable_sink,
             )
-        else:
-            raise ValueError(f"Invalid flash attention version: {fa_version}")
 
         return result_attention
 
@@ -521,7 +516,7 @@ class FlashMaskAttnFunctor(PyLayer):
                 causal,
             )
             seed_offset._clear_dataptr()
-        elif fa_version == 3:
+        elif not uses_cutedsl_backend(fa_version):
             (
                 q,
                 k,
@@ -580,7 +575,7 @@ class FlashMaskAttnFunctor(PyLayer):
                     softmax_scale,
                     causal,
                 )
-        elif fa_version == 4:
+        else:
             (
                 q,
                 k,
@@ -615,8 +610,6 @@ class FlashMaskAttnFunctor(PyLayer):
                     ]
                 ),
             )
-        else:
-            raise ValueError(f"Invalid flash attention version: {fa_version}")
 
         # Manually release memory.
         result_attention._clear_dataptr()
@@ -668,9 +661,9 @@ class RefinedRcomputeFlashMaskAttention:
                 value_states.shape[-1],
                 startend_row_indices,
             )
-            if fa_version != 4:
+            if not uses_cutedsl_backend(fa_version):
                 raise NotImplementedError(
-                    "learnable_sink only supported on fa_version==4 cute backend"
+                    "learnable_sink is only supported on the cute backend"
                 )
         if not framework._dygraph_tracer()._has_grad:
             # This is the initial, normal forward pass.
@@ -752,7 +745,7 @@ class RefinedRcomputeFlashMaskAttention:
                 "dropout": dropout,
                 "causal": causal,
             }
-        elif fa_version == 3:
+        elif not uses_cutedsl_backend(fa_version):
             sig_params = inspect.signature(flashmask_attention).parameters
             scale = (
                 query_states.shape[-1] ** (-0.5)
@@ -797,7 +790,7 @@ class RefinedRcomputeFlashMaskAttention:
                 "causal": causal,
                 "softmax_scale": softmax_scale,
             }
-        elif fa_version == 4:
+        else:
             (result_attention, softmax_lse) = _flash_attn_fwd(
                 query_states,
                 key_states,
@@ -816,8 +809,6 @@ class RefinedRcomputeFlashMaskAttention:
                 "learnable_sink": learnable_sink,
                 "softmax_scale": softmax_scale,
             }
-        else:
-            raise ValueError(f"Invalid flash attention version: {fa_version}")
 
         self._hold_tensors_queue.put(hold_tensors)
         return result_attention
@@ -1044,7 +1035,7 @@ class FlashMaskUlyssesCpFunctor(PyLayer):
                 causal,
             )
             seed_offset._clear_dataptr()
-        elif ctx.fa_version == 3:
+        elif not uses_cutedsl_backend(ctx.fa_version):
             sig_params = inspect.signature(flashmask_attention).parameters
             scale = (
                 q.shape[-1] ** (-0.5)
@@ -1091,7 +1082,7 @@ class FlashMaskUlyssesCpFunctor(PyLayer):
                     scale,
                     causal,
                 )
-        elif ctx.fa_version == 4:
+        else:
             if startend_row_indices is not None:
                 flashmask_info = FlashMaskInfoPaddle(
                     startend_row_indices=startend_row_indices,
@@ -1115,10 +1106,6 @@ class FlashMaskUlyssesCpFunctor(PyLayer):
                         "FLAGS_cudnn_deterministic"
                     ]
                 ),
-            )
-        else:
-            raise ValueError(
-                f"Invalid flash attention version: {ctx.fa_version}"
             )
 
         query_grad = _ulysses_single_all_to_all_rr(
@@ -1270,9 +1257,9 @@ def ulysses_local_flashmask_first_fwd(
     fa_version = get_fa_version(
         query_states.shape[-1], value_states.shape[-1], startend_row_indices
     )
-    if learnable_sink is not None and fa_version != 4:
+    if learnable_sink is not None and not uses_cutedsl_backend(fa_version):
         raise NotImplementedError(
-            "learnable_sink only supported on fa_version==4 cute backend"
+            "learnable_sink is only supported on the cute backend"
         )
     if fa_version == 2:
         if softmax_scale is not None:
@@ -1301,7 +1288,7 @@ def ulysses_local_flashmask_first_fwd(
             "dropout": 0.0,
             "causal": causal,
         }
-    elif fa_version == 3:
+    elif not uses_cutedsl_backend(fa_version):
         sig_params = inspect.signature(flashmask_attention).parameters
         scale = (
             query_states.shape[-1] ** (-0.5)
@@ -1346,7 +1333,7 @@ def ulysses_local_flashmask_first_fwd(
             "causal": causal,
             "softmax_scale": softmax_scale,
         }
-    elif fa_version == 4:
+    else:
         result_attention, softmax_lse = _flash_attn_fwd(
             query_states,
             key_states,
@@ -1364,8 +1351,7 @@ def ulysses_local_flashmask_first_fwd(
             "causal": causal,
             "softmax_scale": softmax_scale,
         }
-    else:
-        raise ValueError(f"Invalid flash attention version: {fa_version}")
+
     hold_tensors["fa_version"] = fa_version
     return result_attention, hold_tensors
 
@@ -1408,9 +1394,9 @@ class RefinedRcomputeFlashMaskCpAttention:
                 value_states.shape[-1],
                 startend_row_indices,
             )
-            if not fa_version == 4:
+            if not uses_cutedsl_backend(fa_version):
                 raise NotImplementedError(
-                    "learnable_sink only supported on fa_version==4 cute backend"
+                    "learnable_sink is only supported on the cute backend"
                 )
         if not framework._dygraph_tracer()._has_grad:
             # This is the initial, normal forward pass.

--- a/src/paddlefleet/transformer/dot_product_attention.py
+++ b/src/paddlefleet/transformer/dot_product_attention.py
@@ -33,6 +33,7 @@ from paddlefleet_ops.flash_mask_facade import (
     flash_attention,
     flashmask_attention,
     get_fa_version,
+    needs_value_padding,
 )
 
 from paddlefleet.context_parallel_utils import (
@@ -788,22 +789,13 @@ class DotProductAttention(FleetLayer):
                 q_head_dim, v_head_dim, attn_mask_startend_row_indices
             )
 
-            need_value_padding = (
-                not (
-                    fa_version == 4
-                    and (
-                        (q_head_dim == 192 and v_head_dim == 128)
-                        or (q_head_dim == 576 and v_head_dim == 512)
-                    )
-                )
-            ) and q_head_dim != v_head_dim
+            need_value_padding = needs_value_padding(
+                fa_version, q_head_dim, v_head_dim
+            )
 
             if need_value_padding:
-                # Pad value to match query head_dim
-                # value: [b, s, h, v_head_dim] -> [b, s, h, q_head_dim]
-                bsz, seq_len, num_heads, _ = value.shape
                 value_padding = paddle.zeros(
-                    [bsz, seq_len, num_heads, q_head_dim - v_head_dim],
+                    [*value.shape[:-1], q_head_dim - v_head_dim],
                     dtype=value.dtype,
                 )
                 value_padded = paddle.concat([value, value_padding], axis=-1)

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -1709,6 +1709,40 @@ class TransformerConfig(ModelParallelConfig):
     forward kernel cannot accept ``d_qk=576`` (not a power of two).
     """
 
+    flash_attn_fa3_backend: str = "cutedsl"
+    """Kernel backend for FA3 FlashMask / FlashAttention.
+
+    One of {"cutedsl", "cpp"}:
+      * "cutedsl" (default): the CuTe DSL kernels shipped in
+        ``paddlefleet_ops.flash_mask``. Its backward has an
+        ordered-accumulation variant, so ``FLAGS_cudnn_deterministic`` holds for
+        every head dim in the cutedsl whitelist and FA3 needs no degrade to FA2
+        above ``head_dim`` 128.
+      * "cpp": the C++ FA3 kernels (flash-attention ``csrc/flash_attn_v3``)
+        reached through Paddle's built-in FlashMask op
+        (``paddle.nn.functional.flash_attention`` ->
+        ``_C_ops.flashmask_attention_v2``). Deterministic runs are limited to
+        ``head_dim <= 128``; larger head dims degrade to FA2.
+
+    Only FA3 is affected: FA4 is cutedsl-only and FA2 never uses cutedsl, so
+    this switch changes nothing for them. On devices where
+    ``paddlefleet_ops.is_flash_mask_available()`` is False the dispatch degrades
+    to FA2 before this switch is consulted.
+
+    This is a temporary rollback switch for the SM90 cutedsl enablement, not a
+    long-term user interface: once cutedsl is validated on SM90 in production,
+    this field and the cpp branches behind it should be deleted. Setting it to
+    "cpp" changes numerics -- the two kernels are not bitwise equal.
+
+    The kernel choice is resolved once per process, so every
+    ``TransformerConfig`` built in one process must agree on it: constructing a
+    second config with a different value raises ``ValueError``. Repeating the
+    same value is fine. A per-model choice is not possible today because
+    ``PyLayer.forward`` and ``PyLayer.backward`` read the resolved backend
+    independently, so letting it change mid-process would pair a forward with a
+    backward from the other kernel.
+    """
+
     csa_share_docmask_meta: bool = False
     """Share one ``CSADocMaskMetadata`` per (micro-batch, ratio, mask group).
 
@@ -3287,3 +3321,21 @@ class TransformerConfig(ModelParallelConfig):
                         "Forcing separate_mtp_headloss=False."
                     )
                     self.separate_mtp_headloss = False
+
+        # Hand the FA3 kernel choice over to paddlefleet_ops. The facade cannot
+        # read this config itself (it sits below paddlefleet in the dependency
+        # order), so the string is validated and pushed down here, once per
+        # config. Imported locally to keep paddlefleet_ops off this module's
+        # import path.
+        from paddlefleet_ops.flash_mask_facade import (
+            FA3_BACKEND_CHOICES,
+            set_fa3_backend,
+        )
+
+        if self.flash_attn_fa3_backend not in FA3_BACKEND_CHOICES:
+            raise ValueError(
+                "flash_attn_fa3_backend must be one of "
+                f"{list(FA3_BACKEND_CHOICES)}, got "
+                f"{self.flash_attn_fa3_backend!r}"
+            )
+        set_fa3_backend(self.flash_attn_fa3_backend)

--- a/tests/multi_card_tests/transformer/test_flash_mask_sink_cp.py
+++ b/tests/multi_card_tests/transformer/test_flash_mask_sink_cp.py
@@ -38,8 +38,6 @@ import paddle
 import paddle.distributed as dist
 from paddle.distributed import fleet
 
-paddle.set_flags({"FLAGS_flash_attn_version": 4})
-
 from paddlefleet.context_parallel_utils import (
     flashmask_attention_cp,
     scatter_balance,
@@ -56,18 +54,27 @@ CP_SIZE = None
 CP_RANK = None
 CP_GROUP = None
 
+_FA_VERSION_KEY = "FLAGS_flash_attn_version"
+_SAVED_FA_VERSION = None
+
 
 def setUpModule():
-    # FA4 attention-sink lives only in the cute backend, built solely for
-    # compute capability >= 10 (sm100/Blackwell). Skip before fleet.init so
-    # non-sm100 ranks exit cleanly without initializing distributed.
+    # FA4 attention-sink lives only in the cute backend, which paddlefleet_ops
+    # builds for compute capability >= 9 (Hopper and Blackwell). Skip before
+    # fleet.init so ranks without it exit cleanly rather than initializing
+    # distributed first.
     from paddlefleet_ops import is_flash_mask_available
 
     if not is_flash_mask_available():
         raise unittest.SkipTest(
-            "FA4 attention-sink CP requires the cute backend "
-            "(sm100, capability >= 10)"
+            "FA4 attention-sink CP requires the cute backend (capability >= 9)"
         )
+    # Pin FA4 here, not at import time: the flag is process-global, so pinning it
+    # while this module is merely being collected would leak into every other
+    # test file in the same process.
+    global _SAVED_FA_VERSION
+    _SAVED_FA_VERSION = paddle.get_flags([_FA_VERSION_KEY])[_FA_VERSION_KEY]
+    paddle.set_flags({_FA_VERSION_KEY: 4})
     global CP_SIZE, CP_RANK, CP_GROUP
     strategy = fleet.DistributedStrategy()
     world = dist.get_world_size()
@@ -95,6 +102,12 @@ def setUpModule():
     CP_GROUP = fleet.get_hybrid_communicate_group().get_context_parallel_group()
     CP_RANK = CP_GROUP.rank
     CP_SIZE = CP_GROUP.nranks
+
+
+def tearDownModule():
+    """Hand the process-global flag back to whatever it was."""
+    if _SAVED_FA_VERSION is not None:
+        paddle.set_flags({_FA_VERSION_KEY: _SAVED_FA_VERSION})
 
 
 def _cosine_sim(actual, expected):

--- a/tests/multi_card_tests/transformer/test_mla_cp_contiguous_allgather.py
+++ b/tests/multi_card_tests/transformer/test_mla_cp_contiguous_allgather.py
@@ -429,7 +429,9 @@ class TestMLAContiguousAllgatherCP(unittest.TestCase):
         from paddlefleet_ops import is_flash_mask_available
 
         if not is_flash_mask_available():
-            self.skipTest("FA4 cute backend unavailable (needs sm100)")
+            self.skipTest(
+                "FA4 cute backend unavailable (needs capability >= 9)"
+            )
         old = paddle.get_flags("FLAGS_flash_attn_version")[
             "FLAGS_flash_attn_version"
         ]

--- a/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_context_parallel_flashmask_modes.py
+++ b/tests/single_card_tests/ai_edited_test/config_and_utils/test_ai_context_parallel_flashmask_modes.py
@@ -82,7 +82,16 @@ def assert_tensor_equal(testcase, actual, expected):
 
 
 class TestFlashMaskImportPath(unittest.TestCase):
-    def test_sm100_imports_vendored_flashmask_utils(self):
+    """The conditional import block at the top of ``context_parallel_utils``.
+
+    ``_FLASH_MASK_AVAILABLE`` is resolved once, when ``paddlefleet_ops`` is
+    first imported, so mocking ``get_device_capability`` here would change
+    nothing -- patch the accessor the module actually calls instead. The
+    capability threshold itself (SM90 vs SM100) is a ``paddlefleet_ops``
+    concern, not this module's.
+    """
+
+    def _exec_module(self, available):
         def fake_flash_attn_fwd(*args, **kwargs):
             return None
 
@@ -132,23 +141,46 @@ class TestFlashMaskImportPath(unittest.TestCase):
             REPO_ROOT, "src", "paddlefleet", "context_parallel_utils.py"
         )
         spec = importlib.util.spec_from_file_location(
-            "_test_context_parallel_utils_sm100", module_path
+            "_test_context_parallel_utils_import_path", module_path
         )
         module = importlib.util.module_from_spec(spec)
         with (
             patch.dict(sys.modules, fake_modules),
-            patch.object(paddle.cuda, "is_available", return_value=True),
-            patch.object(
-                paddle.cuda, "get_device_capability", return_value=(10, 0)
+            patch(
+                "paddlefleet_ops.is_flash_mask_available",
+                return_value=available,
             ),
         ):
             spec.loader.exec_module(module)
+        return module, (
+            fake_flash_attn_fwd,
+            fake_flash_attn_bwd,
+            fake_slice,
+        )
 
-        self.assertTrue(module._flash_mask_available)
+    def test_available_imports_vendored_flashmask_utils(self):
+        module, (fwd, bwd, slice_fn) = self._exec_module(available=True)
+
         self.assertIs(module.FlashMaskInfoPaddle, FakeFlashMaskInfoPaddle)
-        self.assertIs(module._flash_attn_fwd, fake_flash_attn_fwd)
-        self.assertIs(module._flash_attn_bwd, fake_flash_attn_bwd)
-        self.assertIs(module.bshd_slice_contiguous_kv, fake_slice)
+        self.assertIs(module._flash_attn_fwd, fwd)
+        self.assertIs(module._flash_attn_bwd, bwd)
+        self.assertIs(module.bshd_slice_contiguous_kv, slice_fn)
+
+    def test_unavailable_leaves_cute_symbols_undefined(self):
+        # The ``else`` of that import block is a bare ``pass``: the names stay
+        # undefined and every call site reaches them only after
+        # ``get_fa_version`` has resolved a cutedsl version, which dispatch
+        # refuses to do when the kernels are missing.
+        module, _ = self._exec_module(available=False)
+
+        for name in (
+            "FlashMaskInfoPaddle",
+            "_flash_attn_fwd",
+            "_flash_attn_bwd",
+            "bshd_slice_contiguous_kv",
+        ):
+            with self.subTest(symbol=name):
+                self.assertFalse(hasattr(module, name))
 
 
 class TestFlashMaskAllGatherModes(unittest.TestCase):
@@ -1055,9 +1087,46 @@ class TestFlashMaskSwaP2PPath(unittest.TestCase):
         assert_tensor_equal(self, backward_result[1], kg)
         assert_tensor_equal(self, backward_result[2], vg)
 
-    def test_flashmask_attention_cp_requires_flashmask_for_p2p_mode(self):
+    def test_flashmask_attention_cp_rejects_non_fa4_for_p2p_mode(self):
+        # The P2P fast path only guards on the resolved version now: dispatch
+        # already degrades to FA2 when the cutedsl kernels are missing, so any
+        # version other than 4 must be rejected here.
         with (
-            patch.object(cp_utils, "_flash_mask_available", False),
+            patch.object(cp_utils, "get_fa_version", lambda *a, **k: 2),
+            patch.object(
+                cp_utils.fleet,
+                "get_hybrid_communicate_group",
+                lambda: FakeHcg(self.group),
+            ),
+            self.assertRaises(AssertionError),
+        ):
+            cp_utils.flashmask_attention_cp(
+                self.query,
+                self.key,
+                self.value,
+                self.indices,
+                mode="contiguous_swap2p",
+            )
+
+    def test_flashmask_attention_cp_rejects_p2p_when_kernels_missing(self):
+        # End to end through the real dispatch: FLAGS ask for FA4, the cutedsl
+        # kernels are unavailable, so ``get_fa_version`` degrades to FA2 and the
+        # P2P assert fires instead of calling into an undefined kernel.
+        with (
+            patch(
+                "paddlefleet_ops.flash_mask_facade.is_flash_mask_available",
+                return_value=False,
+            ),
+            patch.object(
+                cp_utils.paddle.base.framework,
+                "get_flags",
+                lambda _: {"FLAGS_flash_attn_version": 4},
+            ),
+            patch.object(
+                cp_utils.paddle,
+                "get_flags",
+                lambda _: {"FLAGS_cudnn_deterministic": False},
+            ),
             patch.object(
                 cp_utils.fleet,
                 "get_hybrid_communicate_group",
@@ -1083,7 +1152,7 @@ class TestFlashMaskSwaP2PPath(unittest.TestCase):
             return result
 
         with (
-            patch.object(cp_utils, "_flash_mask_available", True),
+            patch.object(cp_utils, "get_fa_version", lambda *a, **k: 4),
             patch.object(
                 cp_utils.fleet,
                 "get_hybrid_communicate_group",

--- a/tests/single_card_tests/ai_edited_test/distributed/test_ai_context_parallel_utils_3.py
+++ b/tests/single_card_tests/ai_edited_test/distributed/test_ai_context_parallel_utils_3.py
@@ -351,8 +351,14 @@ class TestCpFlashmaskForwardDeterministicOverride(unittest.TestCase):
     cp_flashmask_allgatherkv_balance_forward, which now delegates to
     ``flash_mask_facade.get_fa_version``.
 
-    Under FA3, deterministic mode only falls back to FA2 when head_dim > 128;
-    the ``block_mask`` signature no longer affects the decision.
+    These pin the *cpp* (Paddle kernel) side of the dispatch, so they run with
+    ``FLASHMASK_FA3_USE_CUTEDSL`` off: that is both what routes the forward to
+    the mocked ``flashmask_attention`` instead of ``_flash_attn_fwd``, and what
+    makes the deterministic degrade observable at all -- FA3 on cutedsl has an
+    ordered-accumulation backward and keeps every whitelisted head dim.
+
+    Under Paddle's FA3, deterministic mode falls back to FA2 when head_dim > 128;
+    the ``block_mask`` signature does not affect the decision.
 
       A) deterministic + hdim>128 -> override to 2
       B) deterministic + hdim<=128 -> no override (stays 3)
@@ -361,6 +367,8 @@ class TestCpFlashmaskForwardDeterministicOverride(unittest.TestCase):
     """
 
     def _run_forward(self, *, has_block_mask, deterministic, hdim, fa_flag=3):
+        from paddlefleet_ops import flash_mask_facade
+
         from paddlefleet import context_parallel_utils as cpu
 
         group = mock.MagicMock()
@@ -406,6 +414,9 @@ class TestCpFlashmaskForwardDeterministicOverride(unittest.TestCase):
         flags_det = {"FLAGS_cudnn_deterministic": deterministic}
 
         with (
+            mock.patch.object(
+                flash_mask_facade, "FLASHMASK_FA3_USE_CUTEDSL", False
+            ),
             mock.patch.object(cpu, "flashmask_attention", fake_flashmask),
             mock.patch.object(
                 cpu, "all_gather_balance", side_effect=lambda t, axis, group: t

--- a/tests/single_card_tests/ai_edited_test/distributed/test_ai_flash_attn.py
+++ b/tests/single_card_tests/ai_edited_test/distributed/test_ai_flash_attn.py
@@ -16,6 +16,16 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 import paddle
+from paddlefleet_ops import flash_mask_facade
+
+
+def _cpp_flashmask():
+    """FA3 reaches the cpp ``_C_ops.flashmask_attention_v2*`` kernels only while
+    the hotfix switch is off -- with cutedsl on it takes the cute path. Every
+    ``fa_version == 3`` case here is about those cpp branches.
+    """
+    return patch.object(flash_mask_facade, "FLASHMASK_FA3_USE_CUTEDSL", False)
+
 
 # fmt: off
 # Parameters dicts used to control which branch the signature check enters.
@@ -55,6 +65,7 @@ class TestCpFlashmaskBackwardDispatch(unittest.TestCase):
         mock_v2_grad = MagicMock(return_value=(dummy, dummy, dummy))
 
         with (
+            _cpp_flashmask(),
             patch(
                 "paddlefleet.context_parallel_utils.inspect.signature"
             ) as mock_sig,
@@ -140,6 +151,7 @@ class TestFlashMaskAttnFunctorBackwardDispatch(unittest.TestCase):
         mock_v2_grad = MagicMock(return_value=(dummy, dummy, dummy))
 
         with (
+            _cpp_flashmask(),
             patch(
                 "paddlefleet.refined_recompute.flash_attn.inspect.signature"
             ) as mock_sig,
@@ -178,6 +190,7 @@ class TestRefinedRecomputeFirstFwdDispatch(unittest.TestCase):
     (fa_version==3). The "block_mask" and "else" branches are already covered
     by test_ai_flash_attn.py."""
 
+    @patch.object(flash_mask_facade, "FLASHMASK_FA3_USE_CUTEDSL", False)
     @patch("paddlefleet.refined_recompute.flash_attn.framework._dygraph_tracer")
     @patch(
         "paddlefleet.refined_recompute.flash_attn._C_ops.flashmask_attention_v2",

--- a/tests/single_card_tests/ai_edited_test/recompute/test_ai_flash_attn.py
+++ b/tests/single_card_tests/ai_edited_test/recompute/test_ai_flash_attn.py
@@ -29,6 +29,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 import paddle
+from paddlefleet_ops import flash_mask_facade
 
 _SKIP_FLASH_ATTN = False
 try:
@@ -41,27 +42,6 @@ except (ImportError, ModuleNotFoundError, AttributeError):
 
 class TestFlashattnAutoCast(unittest.TestCase):
     """Tests for flashattn_auto_cast function."""
-
-
-class TestFlashAttnFunctor(unittest.TestCase):
-    """Tests for FlashAttnFunctor PyLayer."""
-
-    def test_forward_invalid_version(self):
-        """Test that FlashAttnFunctor.forward raises for invalid fa_version."""
-        from paddlefleet.refined_recompute.flash_attn import FlashAttnFunctor
-
-        q = paddle.randn([2, 4, 8], dtype=paddle.bfloat16)
-        k = paddle.randn([2, 4, 8], dtype=paddle.bfloat16)
-        v = paddle.randn([2, 4, 8], dtype=paddle.bfloat16)
-        hold_tensors = {"result_attention": q, "causal": True, "softmax_lse": k}
-
-        with patch(
-            "paddlefleet.refined_recompute.flash_attn.get_fa_version",
-            return_value=99,
-        ):
-            with self.assertRaises(ValueError) as ctx:
-                FlashAttnFunctor.apply(q, k, v, hold_tensors)
-            self.assertIn("Invalid flash attention version", str(ctx.exception))
 
 
 class TestRefinedRcomputeFlashAttention(unittest.TestCase):
@@ -138,36 +118,7 @@ class TestRefinedRcomputeFlashMaskAttention(unittest.TestCase):
         self.assertIn("seed_offset", hold_tensors)
         self.assertIn("causal", hold_tensors)
 
-    @patch(
-        "paddlefleet.refined_recompute.flash_attn.get_fa_version",
-        return_value=99,
-    )
-    @patch(
-        "paddlefleet.refined_recompute.flash_attn._C_ops.flashmask_attention"
-    )
-    @patch("paddlefleet.refined_recompute.flash_attn.framework._dygraph_tracer")
-    def test_first_fwd_invalid_version_raises(
-        self, mock_tracer, mock_flashmask, mock_version
-    ):
-        """Test _first_fwd raises for invalid FA version."""
-        from paddlefleet.refined_recompute.flash_attn import (
-            RefinedRcomputeFlashMaskAttention,
-        )
-
-        mock_tracer_obj = MagicMock()
-        mock_tracer_obj._has_grad = False
-        mock_tracer.return_value = mock_tracer_obj
-
-        q = paddle.randn([2, 4, 8], dtype=paddle.bfloat16)
-        k = paddle.randn([2, 4, 8], dtype=paddle.bfloat16)
-        v = paddle.randn([2, 4, 8], dtype=paddle.bfloat16)
-        startend = paddle.to_tensor([0, 4, 8], dtype=paddle.int32)
-
-        attn = RefinedRcomputeFlashMaskAttention()
-        with self.assertRaises(ValueError) as ctx:
-            attn.forward(q, k, v, startend)
-        self.assertIn("Invalid flash attention version", str(ctx.exception))
-
+    @patch.object(flash_mask_facade, "FLASHMASK_FA3_USE_CUTEDSL", False)
     @patch(
         "paddlefleet.refined_recompute.flash_attn.get_fa_version",
         return_value=3,
@@ -180,7 +131,11 @@ class TestRefinedRcomputeFlashMaskAttention(unittest.TestCase):
     def test_first_fwd_version_3_with_block_mask(
         self, mock_tracer, mock_sig, mock_flashmask_v2, mock_version
     ):
-        """Test _first_fwd v3 with block_mask parameter in signature."""
+        """Test _first_fwd v3 with block_mask parameter in signature.
+
+        FA3 only lands on ``_C_ops.flashmask_attention_v2`` with the cutedsl
+        hotfix switch off.
+        """
         from paddlefleet.refined_recompute.flash_attn import (
             RefinedRcomputeFlashMaskAttention,
         )
@@ -207,6 +162,7 @@ class TestRefinedRcomputeFlashMaskAttention(unittest.TestCase):
         result = attn.forward(q, k, v, startend, causal=False)
         self.assertTrue(result is not None)
 
+    @patch.object(flash_mask_facade, "FLASHMASK_FA3_USE_CUTEDSL", False)
     @patch(
         "paddlefleet.refined_recompute.flash_attn.get_fa_version",
         return_value=3,

--- a/tests/single_card_tests/ai_edited_test/recompute/test_ai_flash_attn_2.py
+++ b/tests/single_card_tests/ai_edited_test/recompute/test_ai_flash_attn_2.py
@@ -27,6 +27,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 import paddle
+from paddlefleet_ops import flash_mask_facade
 from paddlefleet_ops.flash_mask_facade import get_fa_version
 
 from paddlefleet.refined_recompute.flash_attn import (
@@ -39,7 +40,12 @@ from paddlefleet.refined_recompute.flash_attn import (
 
 
 class TestGetFAVersion(unittest.TestCase):
-    """Tests for get_fa_version function (flash_mask_facade)."""
+    """Tests for get_fa_version function (flash_mask_facade).
+
+    ``_dispatch_fa_version`` degrades to FA2 whenever the resolved version would
+    run on cutedsl but the kernels are missing, so every case that expects FA3 or
+    FA4 has to state which side of that it is on.
+    """
 
     @patch(
         "paddlefleet_ops.flash_mask_facade.paddle.get_device",
@@ -50,12 +56,19 @@ class TestGetFAVersion(unittest.TestCase):
         result = get_fa_version(64)
         self.assertEqual(result, 2)
 
+    @patch.object(flash_mask_facade, "FLASHMASK_FA3_USE_CUTEDSL", True)
+    @patch(
+        "paddlefleet_ops.flash_mask_facade.is_flash_mask_available",
+        return_value=True,
+    )
     @patch(
         "paddlefleet_ops.flash_mask_facade.paddle.get_device",
         return_value="gpu:0",
     )
     @patch("paddlefleet_ops.flash_mask_facade.paddle.base.framework.get_flags")
-    def test_gpu_returns_flag_value(self, mock_get_flags, mock_device):
+    def test_gpu_returns_flag_value(
+        self, mock_get_flags, mock_device, mock_available
+    ):
         """Test that GPU returns the FLAGS_flash_attn_version value."""
         mock_get_flags.return_value = {"FLAGS_flash_attn_version": 3}
         with patch(
@@ -65,6 +78,36 @@ class TestGetFAVersion(unittest.TestCase):
             result = get_fa_version(64)
             self.assertEqual(result, 3)
 
+    @patch.object(flash_mask_facade, "FLASHMASK_FA3_USE_CUTEDSL", True)
+    @patch(
+        "paddlefleet_ops.flash_mask_facade.is_flash_mask_available",
+        return_value=False,
+    )
+    @patch(
+        "paddlefleet_ops.flash_mask_facade.paddle.get_device",
+        return_value="gpu:0",
+    )
+    @patch("paddlefleet_ops.flash_mask_facade.paddle.base.framework.get_flags")
+    @patch(
+        "paddlefleet_ops.flash_mask_facade.paddle.get_flags",
+        return_value={"FLAGS_cudnn_deterministic": False},
+    )
+    def test_missing_cutedsl_kernels_degrade_to_2(
+        self, mock_get_flags, mock_base_flags, mock_device, mock_available
+    ):
+        """FA3/FA4 both need the cutedsl kernels; without them, FA2."""
+        for requested in (3, 4):
+            with self.subTest(fa_version=requested):
+                mock_base_flags.return_value = {
+                    "FLAGS_flash_attn_version": requested
+                }
+                self.assertEqual(get_fa_version(64), 2)
+
+    @patch.object(flash_mask_facade, "FLASHMASK_FA3_USE_CUTEDSL", True)
+    @patch(
+        "paddlefleet_ops.flash_mask_facade.is_flash_mask_available",
+        return_value=True,
+    )
     @patch(
         "paddlefleet_ops.flash_mask_facade.paddle.get_device",
         return_value="gpu:0",
@@ -74,10 +117,31 @@ class TestGetFAVersion(unittest.TestCase):
         "paddlefleet_ops.flash_mask_facade.paddle.get_flags",
         return_value={"FLAGS_cudnn_deterministic": True},
     )
-    def test_deterministic_fa3_large_hdim_returns_2(
+    def test_deterministic_fa3_large_hdim_stays_3_on_cutedsl(
+        self, mock_get_flags, mock_base_flags, mock_device, mock_available
+    ):
+        """On cutedsl, FA3 keeps hdim>128 under deterministic.
+
+        Its backward has an ordered-accumulation variant, and (192, 128) is in
+        the cutedsl whitelist, so there is nothing to degrade for.
+        """
+        mock_base_flags.return_value = {"FLAGS_flash_attn_version": 3}
+        self.assertEqual(get_fa_version(192, 128), 3)
+
+    @patch.object(flash_mask_facade, "FLASHMASK_FA3_USE_CUTEDSL", False)
+    @patch(
+        "paddlefleet_ops.flash_mask_facade.paddle.get_device",
+        return_value="gpu:0",
+    )
+    @patch("paddlefleet_ops.flash_mask_facade.paddle.base.framework.get_flags")
+    @patch(
+        "paddlefleet_ops.flash_mask_facade.paddle.get_flags",
+        return_value={"FLAGS_cudnn_deterministic": True},
+    )
+    def test_deterministic_fa3_large_hdim_returns_2_on_paddle_kernel(
         self, mock_get_flags, mock_base_flags, mock_device
     ):
-        """Test FA3 + deterministic + hdim>128 falls back to version 2."""
+        """Paddle's FA3 kernel has no deterministic backward above hdim 128."""
         mock_base_flags.return_value = {"FLAGS_flash_attn_version": 3}
         result = get_fa_version(192)
         self.assertEqual(result, 2)
@@ -180,6 +244,7 @@ class TestFlashAttnFunctorForwardVersion4(unittest.TestCase):
 class TestRefinedRcomputeFlashAttentionFirstFwd(unittest.TestCase):
     """Tests for RefinedRcomputeFlashAttention._first_fwd."""
 
+    @patch.object(flash_mask_facade, "FLASHMASK_FA3_USE_CUTEDSL", False)
     @patch(
         "paddlefleet.refined_recompute.flash_attn.get_fa_version",
         return_value=3,
@@ -189,7 +254,10 @@ class TestRefinedRcomputeFlashAttentionFirstFwd(unittest.TestCase):
     def test_first_fwd_version_3(
         self, mock_tracer, mock_flash_v3, mock_version
     ):
-        """Test _first_fwd with version 3 puts tensors in queue."""
+        """Test _first_fwd with version 3 puts tensors in queue.
+
+        FA3 only lands on ``_C_ops.flash_attn_v3`` with the cutedsl switch off.
+        """
         mock_tracer_obj = MagicMock()
         mock_tracer_obj._has_grad = False
         mock_tracer.return_value = mock_tracer_obj
@@ -298,6 +366,7 @@ class TestFlashMaskAttnFunctorVersion4(unittest.TestCase):
 class TestRefinedRcomputeFlashMaskAttentionFirstFwdV3(unittest.TestCase):
     """Tests for RefinedRcomputeFlashMaskAttention._first_fwd with v3."""
 
+    @patch.object(flash_mask_facade, "FLASHMASK_FA3_USE_CUTEDSL", False)
     @patch(
         "paddlefleet.refined_recompute.flash_attn.get_fa_version",
         return_value=3,
@@ -310,7 +379,11 @@ class TestRefinedRcomputeFlashMaskAttentionFirstFwdV3(unittest.TestCase):
     def test_first_fwd_v3_with_block_mask(
         self, mock_tracer, mock_sig, mock_flash_v2, mock_version
     ):
-        """Test _first_fwd with v3 and block_mask parameter."""
+        """Test _first_fwd with v3 and block_mask parameter.
+
+        FA3 only lands on ``_C_ops.flashmask_attention_v2`` with the cutedsl
+        switch off.
+        """
         mock_tracer_obj = MagicMock()
         mock_tracer_obj._has_grad = False
         mock_tracer.return_value = mock_tracer_obj

--- a/tests/single_card_tests/ai_edited_test/recompute/test_ai_flash_attn_4.py
+++ b/tests/single_card_tests/ai_edited_test/recompute/test_ai_flash_attn_4.py
@@ -76,108 +76,24 @@ class TestFlashMaskCpAttentionQueryValidation(unittest.TestCase):
 @unittest.skipUnless(
     _MODULE_AVAILABLE, "paddlefleet.refined_recompute.flash_attn not available"
 )
-class TestFlashAttnFunctorForwardVersions(unittest.TestCase):
-    """Tests for FlashAttnFunctor forward with different FA versions."""
+class TestGetFAVersionValidation(unittest.TestCase):
+    """Invalid versions are rejected by get_fa_version.
 
-    def test_forward_invalid_version_raises(self):
-        """Test that invalid FA version raises ValueError in forward."""
-        from paddlefleet.refined_recompute.flash_attn import FlashAttnFunctor
+    The dispatch chains below it only tell 2 / cpp / cute apart, so an
+    unsupported FLAGS_flash_attn_version has to be caught here.
+    """
 
-        ctx = MagicMock()
-        q = paddle.randn([1, 4, 8], dtype=paddle.bfloat16)
-        k = paddle.randn([1, 4, 8], dtype=paddle.bfloat16)
-        v = paddle.randn([1, 4, 8], dtype=paddle.bfloat16)
-        hold_tensors = {
-            "result_attention": paddle.randn([1, 4, 8]),
-            "softmax_lse": paddle.randn([1, 4]),
-            "causal": True,
-        }
+    def test_invalid_version_raises(self):
+        """Test that a version outside 2/3/4 raises ValueError."""
+        from paddlefleet_ops import flash_mask_facade
 
         with (
-            patch(
-                "paddlefleet.refined_recompute.flash_attn.get_fa_version",
-                return_value=99,
+            patch.object(
+                flash_mask_facade, "_dispatch_fa_version", return_value=99
             ),
             self.assertRaises(ValueError),
         ):
-            FlashAttnFunctor.forward(ctx, q, k, v, hold_tensors)
-
-
-@unittest.skipUnless(
-    _MODULE_AVAILABLE, "paddlefleet.refined_recompute.flash_attn not available"
-)
-class TestFlashAttnFunctorBackwardVersions(unittest.TestCase):
-    """Tests for FlashAttnFunctor backward with different FA versions."""
-
-    def test_backward_invalid_version_raises(self):
-        """Test that invalid FA version raises ValueError in backward."""
-        from paddlefleet.refined_recompute.flash_attn import FlashAttnFunctor
-
-        ctx = MagicMock()
-        ctx.fa_version = 99
-        ctx.saved_tensor = MagicMock(
-            return_value=[paddle.randn([1]) for _ in range(8)]
-        )
-
-        with self.assertRaises(ValueError):
-            FlashAttnFunctor.backward(ctx, paddle.randn([1, 4, 8]))
-
-
-@unittest.skipUnless(
-    _MODULE_AVAILABLE, "paddlefleet.refined_recompute.flash_attn not available"
-)
-class TestFlashMaskAttnFunctorForwardVersions(unittest.TestCase):
-    """Tests for FlashMaskAttnFunctor forward with different FA versions."""
-
-    def test_forward_invalid_version_raises(self):
-        """Test that invalid FA version raises ValueError in forward."""
-        from paddlefleet.refined_recompute.flash_attn import (
-            FlashMaskAttnFunctor,
-        )
-
-        ctx = MagicMock()
-        q = paddle.randn([1, 4, 8], dtype=paddle.bfloat16)
-        k = paddle.randn([1, 4, 8], dtype=paddle.bfloat16)
-        v = paddle.randn([1, 4, 8], dtype=paddle.bfloat16)
-        startend = paddle.randint(0, 10, [1, 4])
-        hold_tensors = {
-            "result_attention": paddle.randn([1, 4, 8]),
-            "softmax_lse": paddle.randn([1, 4]),
-            "causal": True,
-        }
-
-        with (
-            patch(
-                "paddlefleet.refined_recompute.flash_attn.get_fa_version",
-                return_value=99,
-            ),
-            self.assertRaises(ValueError),
-        ):
-            FlashMaskAttnFunctor.forward(
-                ctx, q, k, v, startend, None, hold_tensors
-            )
-
-
-@unittest.skipUnless(
-    _MODULE_AVAILABLE, "paddlefleet.refined_recompute.flash_attn not available"
-)
-class TestFlashMaskAttnFunctorBackwardVersions(unittest.TestCase):
-    """Tests for FlashMaskAttnFunctor backward with different FA versions."""
-
-    def test_backward_invalid_version_raises(self):
-        """Test that invalid FA version raises ValueError in backward."""
-        from paddlefleet.refined_recompute.flash_attn import (
-            FlashMaskAttnFunctor,
-        )
-
-        ctx = MagicMock()
-        ctx.fa_version = 99
-        ctx.saved_tensor = MagicMock(
-            return_value=[paddle.randn([1]) for _ in range(9)]
-        )
-
-        with self.assertRaises(ValueError):
-            FlashMaskAttnFunctor.backward(ctx, paddle.randn([1, 4, 8]))
+            flash_mask_facade.get_fa_version(64)
 
 
 @unittest.skipUnless(

--- a/tests/single_card_tests/ai_edited_test/recompute/test_ai_flash_attn_7.py
+++ b/tests/single_card_tests/ai_edited_test/recompute/test_ai_flash_attn_7.py
@@ -23,10 +23,14 @@ sys.path.insert(
     ),
 )
 
+import contextlib
+import importlib
+import types
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import paddle
+from paddlefleet_ops import flash_mask_facade
 from paddlefleet_ops.flash_mask_facade import get_fa_version
 
 from paddlefleet.refined_recompute.flash_attn import flashattn_auto_cast
@@ -101,9 +105,14 @@ class TestGetFAVersionGPU(unittest.TestCase):
 class TestGetFAVersionDeterministic(unittest.TestCase):
     """Tests for get_fa_version with deterministic mode (FA3).
 
-    FA3 only falls back to FA2 under deterministic mode when head_dim > 128.
+    Which head dims survive deterministic mode depends on the backend: Paddle's
+    own FA3 kernel has no ordered-accumulation backward above head_dim 128 and
+    degrades to FA2, while FA3 on cutedsl keeps every head dim in its whitelist.
+    Both the switch and kernel availability are therefore stated explicitly --
+    otherwise the expected version would depend on the CI machine.
     """
 
+    @patch.object(flash_mask_facade, "FLASHMASK_FA3_USE_CUTEDSL", False)
     @patch(
         "paddlefleet_ops.flash_mask_facade.paddle.get_device",
         return_value="gpu:0",
@@ -113,7 +122,7 @@ class TestGetFAVersionDeterministic(unittest.TestCase):
         "paddlefleet_ops.flash_mask_facade.paddle.get_flags",
         return_value={"FLAGS_cudnn_deterministic": True},
     )
-    def test_deterministic_large_hdim_returns_2(
+    def test_deterministic_large_hdim_returns_2_on_paddle_kernel(
         self, mock_get_flags, mock_base_flags, mock_device
     ):
         """Deterministic FA3 with hdim>128 falls back to version 2."""
@@ -121,6 +130,33 @@ class TestGetFAVersionDeterministic(unittest.TestCase):
         result = get_fa_version(256)
         self.assertEqual(result, 2)
 
+    @patch.object(flash_mask_facade, "FLASHMASK_FA3_USE_CUTEDSL", True)
+    @patch(
+        "paddlefleet_ops.flash_mask_facade.is_flash_mask_available",
+        lambda: True,
+    )
+    @patch(
+        "paddlefleet_ops.flash_mask_facade.paddle.get_device",
+        return_value="gpu:0",
+    )
+    @patch("paddlefleet_ops.flash_mask_facade.paddle.base.framework.get_flags")
+    @patch(
+        "paddlefleet_ops.flash_mask_facade.paddle.get_flags",
+        return_value={"FLAGS_cudnn_deterministic": True},
+    )
+    def test_deterministic_large_hdim_keeps_3_on_cutedsl(
+        self, mock_get_flags, mock_base_flags, mock_device
+    ):
+        """(256, 256) is in the cutedsl whitelist, so nothing degrades."""
+        mock_base_flags.return_value = {"FLAGS_flash_attn_version": 3}
+        result = get_fa_version(256, 256)
+        self.assertEqual(result, 3)
+
+    @patch.object(flash_mask_facade, "FLASHMASK_FA3_USE_CUTEDSL", True)
+    @patch(
+        "paddlefleet_ops.flash_mask_facade.is_flash_mask_available",
+        lambda: True,
+    )
     @patch(
         "paddlefleet_ops.flash_mask_facade.paddle.get_device",
         return_value="gpu:0",
@@ -138,6 +174,11 @@ class TestGetFAVersionDeterministic(unittest.TestCase):
         result = get_fa_version(128)
         self.assertEqual(result, 3)
 
+    @patch.object(flash_mask_facade, "FLASHMASK_FA3_USE_CUTEDSL", True)
+    @patch(
+        "paddlefleet_ops.flash_mask_facade.is_flash_mask_available",
+        lambda: True,
+    )
     @patch(
         "paddlefleet_ops.flash_mask_facade.paddle.get_device",
         return_value="gpu:0",
@@ -179,6 +220,229 @@ class TestGetFAVersionNonDeterministic(unittest.TestCase):
         ):
             result = get_fa_version(64)
             self.assertEqual(result, 4)
+
+
+class TestCutedslHotfixSwitch(unittest.TestCase):
+    """``FLASHMASK_FA3_USE_CUTEDSL`` -- the cpp fallback it selects.
+
+    Set from ``TransformerConfig.flash_attn_fa3_backend`` via
+    ``set_fa3_backend``. The cpp kernel is on its way out, so these only pin the
+    routing decisions, not numerics.
+    """
+
+    def test_uses_cutedsl_backend_follows_switch(self):
+        with patch.object(
+            flash_mask_facade, "FLASHMASK_FA3_USE_CUTEDSL", False
+        ):
+            self.assertFalse(flash_mask_facade.uses_cutedsl_backend(3))
+            # FA4 is cutedsl-only, the switch does not reach it.
+            self.assertTrue(flash_mask_facade.uses_cutedsl_backend(4))
+            self.assertFalse(flash_mask_facade.uses_cutedsl_backend(2))
+
+        with patch.object(flash_mask_facade, "FLASHMASK_FA3_USE_CUTEDSL", True):
+            self.assertTrue(flash_mask_facade.uses_cutedsl_backend(3))
+
+    def test_needs_value_padding_follows_switch(self):
+        # (192, 128) is native on cutedsl but not on Paddle's FA3 kernel, so the
+        # switch decides whether value has to be zero-padded to 192.
+        with patch.object(flash_mask_facade, "FLASHMASK_FA3_USE_CUTEDSL", True):
+            self.assertFalse(flash_mask_facade.needs_value_padding(3, 192, 128))
+        with patch.object(
+            flash_mask_facade, "FLASHMASK_FA3_USE_CUTEDSL", False
+        ):
+            self.assertTrue(flash_mask_facade.needs_value_padding(3, 192, 128))
+
+    def test_switch_defaults_on_and_ignores_the_environment(self):
+        # The choice now comes from ``TransformerConfig.flash_attn_fa3_backend``
+        # through ``set_fa3_backend``, so a leftover environment variable of the
+        # same name must not reach it. Reload once more on cleanup so the rest of
+        # the process sees the default again.
+        self.addCleanup(importlib.reload, flash_mask_facade)
+
+        for raw in (None, "0", "1", "true"):
+            with self.subTest(env=raw):
+                env = dict(os.environ)
+                env.pop("FLASHMASK_FA3_USE_CUTEDSL", None)
+                if raw is not None:
+                    env["FLASHMASK_FA3_USE_CUTEDSL"] = raw
+                with patch.dict(os.environ, env, clear=True):
+                    reloaded = importlib.reload(flash_mask_facade)
+                    self.assertIs(reloaded.FLASHMASK_FA3_USE_CUTEDSL, True)
+
+    def test_set_fa3_backend_switches_the_flag(self):
+        # The choice is resolved once per process, so switching means dropping
+        # the resolved one first -- calling the setter with a different value
+        # would (deliberately) raise.
+        self.addCleanup(flash_mask_facade._reset_fa3_backend)
+
+        flash_mask_facade._reset_fa3_backend()
+        flash_mask_facade.set_fa3_backend("cpp")
+        self.assertFalse(flash_mask_facade.uses_cutedsl_backend(3))
+        # Repeating the resolved choice is a no-op, not a conflict.
+        flash_mask_facade.set_fa3_backend("cpp")
+        self.assertFalse(flash_mask_facade.uses_cutedsl_backend(3))
+
+        flash_mask_facade._reset_fa3_backend()
+        flash_mask_facade.set_fa3_backend("cutedsl")
+        self.assertTrue(flash_mask_facade.uses_cutedsl_backend(3))
+
+    def test_set_fa3_backend_rejects_a_conflicting_choice(self):
+        self.addCleanup(flash_mask_facade._reset_fa3_backend)
+
+        flash_mask_facade._reset_fa3_backend()
+        flash_mask_facade.set_fa3_backend("cpp")
+        with self.assertRaisesRegex(
+            ValueError, r"cannot change within a process"
+        ):
+            flash_mask_facade.set_fa3_backend("cutedsl")
+        # The resolved choice survives the rejected call.
+        self.assertFalse(flash_mask_facade.uses_cutedsl_backend(3))
+
+
+@contextlib.contextmanager
+def _pin_dispatch(fa_version, use_cutedsl):
+    """Pin every input ``get_fa_version`` reads, so routing is machine-independent."""
+    with (
+        patch.object(
+            flash_mask_facade, "FLASHMASK_FA3_USE_CUTEDSL", use_cutedsl
+        ),
+        patch(
+            "paddlefleet_ops.flash_mask_facade.is_flash_mask_available",
+            lambda: True,
+        ),
+        patch(
+            "paddlefleet_ops.flash_mask_facade.paddle.get_device",
+            return_value="gpu:0",
+        ),
+        patch(
+            "paddlefleet_ops.flash_mask_facade.paddle.base.framework.get_flags",
+            return_value={"FLAGS_flash_attn_version": fa_version},
+        ),
+        patch(
+            "paddlefleet_ops.flash_mask_facade.paddle.get_flags",
+            return_value={"FLAGS_cudnn_deterministic": False},
+        ),
+    ):
+        yield
+
+
+@contextlib.contextmanager
+def _cute_entry(name, return_value):
+    """Stand in for the cute kernel the facade imports lazily on the cutedsl path.
+
+    Injected through ``sys.modules`` rather than patched on the real module, so
+    the assertion holds whether or not ``paddlefleet_ops.flash_mask`` is
+    installed on the machine running the test. This pins routing, not numerics.
+    """
+    stub = types.ModuleType("paddlefleet_ops.flash_mask")
+    entry = MagicMock(return_value=return_value)
+    setattr(stub, name, entry)
+    with patch.dict(sys.modules, {"paddlefleet_ops.flash_mask": stub}):
+        yield entry
+
+
+class TestFacadeEntryRouting(unittest.TestCase):
+    """Which kernel the ``flash_mask_facade`` entry points actually reach.
+
+    The facade picks the implementation per call (``uses_cutedsl_backend``), and
+    the no-mask entry ``flash_attention`` -- the one
+    ``DotProductAttention._ec_compatible_flash_attention`` calls -- has no other
+    coverage. Both candidate kernels are mocked and each test asserts exactly one
+    of them ran: this pins the routing decision, not the numerics.
+    """
+
+    def setUp(self):
+        self.shape = [1, 4, 2, 64]
+        self.q = paddle.zeros(self.shape, dtype="float32")
+        self.k = paddle.zeros(self.shape, dtype="float32")
+        self.v = paddle.zeros(self.shape, dtype="float32")
+        self.out = paddle.zeros(self.shape, dtype="float32")
+        # 1 column, so the FA4 4-column mask restriction never applies here.
+        self.mask = paddle.zeros([1, 2, 4, 1], dtype="int32")
+
+    def test_flash_attention_routes_to_cpp_backend(self):
+        with (
+            _pin_dispatch(3, use_cutedsl=False),
+            _cute_entry("flash_attention", (self.out, None)) as cute_kernel,
+            patch(
+                "paddle.nn.functional.flash_attention.flash_attention",
+                return_value=(self.out, None),
+            ) as cpp_kernel,
+        ):
+            result, _ = flash_mask_facade.flash_attention(
+                self.q, self.k, self.v
+            )
+
+        cpp_kernel.assert_called_once()
+        cute_kernel.assert_not_called()
+        self.assertEqual(result.shape, self.shape)
+
+    def test_flash_attention_routes_to_cutedsl_backend(self):
+        with (
+            _pin_dispatch(3, use_cutedsl=True),
+            _cute_entry("flash_attention", (self.out, None)) as cute_kernel,
+            patch(
+                "paddle.nn.functional.flash_attention.flash_attention",
+                return_value=(self.out, None),
+            ) as cpp_kernel,
+        ):
+            result, _ = flash_mask_facade.flash_attention(
+                self.q, self.k, self.v
+            )
+
+        cute_kernel.assert_called_once()
+        cpp_kernel.assert_not_called()
+        self.assertEqual(result.shape, self.shape)
+
+    def test_flash_attention_fa2_stays_on_cpp_with_cutedsl_on(self):
+        # FA2 never uses cutedsl, so a degrade to 2 must reach the cpp kernel
+        # even while the switch is on.
+        with (
+            _pin_dispatch(2, use_cutedsl=True),
+            _cute_entry("flash_attention", (self.out, None)) as cute_kernel,
+            patch(
+                "paddle.nn.functional.flash_attention.flash_attention",
+                return_value=(self.out, None),
+            ) as cpp_kernel,
+        ):
+            flash_mask_facade.flash_attention(self.q, self.k, self.v)
+
+        cpp_kernel.assert_called_once()
+        cute_kernel.assert_not_called()
+
+    def test_flashmask_attention_routes_to_cpp_backend(self):
+        with (
+            _pin_dispatch(3, use_cutedsl=False),
+            _cute_entry("flashmask_attention", self.out) as cute_kernel,
+            patch(
+                "paddle.nn.functional.flash_attention.flashmask_attention",
+                return_value=self.out,
+            ) as cpp_kernel,
+        ):
+            result = flash_mask_facade.flashmask_attention(
+                self.q, self.k, self.v, self.mask
+            )
+
+        cpp_kernel.assert_called_once()
+        cute_kernel.assert_not_called()
+        self.assertEqual(result.shape, self.shape)
+
+    def test_flashmask_attention_routes_to_cutedsl_backend(self):
+        with (
+            _pin_dispatch(3, use_cutedsl=True),
+            _cute_entry("flashmask_attention", self.out) as cute_kernel,
+            patch(
+                "paddle.nn.functional.flash_attention.flashmask_attention",
+                return_value=self.out,
+            ) as cpp_kernel,
+        ):
+            result = flash_mask_facade.flashmask_attention(
+                self.q, self.k, self.v, self.mask
+            )
+
+        cute_kernel.assert_called_once()
+        cpp_kernel.assert_not_called()
+        self.assertEqual(result.shape, self.shape)
 
 
 class TestFlashattnAutoCastBasic(unittest.TestCase):

--- a/tests/single_card_tests/ai_edited_test/recompute/test_ai_flash_attn_cp_rr_modes.py
+++ b/tests/single_card_tests/ai_edited_test/recompute/test_ai_flash_attn_cp_rr_modes.py
@@ -26,8 +26,20 @@ _REPO_ROOT = os.path.dirname(
 sys.path.insert(0, os.path.join(_REPO_ROOT, "src"))
 
 import paddle
+from paddlefleet_ops import flash_mask_facade
 
 from paddlefleet.refined_recompute import flash_attn as fa
+
+
+def cpp_flashmask_backend():
+    """Route FA3 to Paddle's cpp kernel by flipping the hotfix switch off.
+
+    ``uses_cutedsl_backend`` reads the module global on every call and
+    ``PyLayer.backward`` reads it independently of the forward, so a forward and
+    its backward have to run inside the same context or they pick different
+    kernels.
+    """
+    return patch.object(flash_mask_facade, "FLASHMASK_FA3_USE_CUTEDSL", False)
 
 
 class FakeCtx:
@@ -137,6 +149,12 @@ class TestFlashMaskAttnFunctor(unittest.TestCase):
 
         def fake_flashmask_attention(query, key, value, block_mask=None):
             return None
+
+        # ``backward`` re-reads the switch, so it has to stay off for both halves
+        # or the FA3 forward would be paired with a cutedsl backward.
+        switch = cpp_flashmask_backend()
+        switch.start()
+        self.addCleanup(switch.stop)
 
         with patch.object(fa, "get_fa_version", return_value=3):
             self.assertIs(
@@ -285,7 +303,10 @@ class TestUlyssesHelpers(unittest.TestCase):
         self.assertIs(mock_fwd.call_args.kwargs["learnable_sink"], sink)
 
         # fa2/fa3 have no sink support, so fail loudly instead of dropping it.
+        # FA3 only counts as "no sink support" while the cutedsl switch is off --
+        # on cutedsl FA3 serves the sink just like FA4.
         with (
+            cpp_flashmask_backend(),
             patch.object(fa, "get_fa_version", return_value=3),
             self.assertRaises(NotImplementedError),
         ):
@@ -311,7 +332,13 @@ class TestUlyssesHelpers(unittest.TestCase):
         )
         for version, target, return_value in cases:
             with self.subTest(version=version):
-                with patch.object(fa, "get_fa_version", return_value=version):
+                # FA3 reaches ``_C_ops.flashmask_attention_v2`` only with the
+                # cutedsl switch off; FA2 and FA4 do not read the switch at all,
+                # so keeping it off for the whole loop is safe.
+                with (
+                    cpp_flashmask_backend(),
+                    patch.object(fa, "get_fa_version", return_value=version),
+                ):
                     if version == 4:
                         patcher = patch.object(
                             fa, target, return_value=return_value, create=True
@@ -352,14 +379,6 @@ class TestUlyssesHelpers(unittest.TestCase):
                 q, q, q, startend, False, None, 0.5
             )
 
-        with (
-            patch.object(fa, "get_fa_version", return_value=0),
-            self.assertRaises(ValueError),
-        ):
-            fa.ulysses_local_flashmask_first_fwd(
-                q, q, q, startend, False, None, None
-            )
-
     def test_ulysses_local_v3_forward_signature_variants(self):
         q = paddle.randn([1, 4, 2, 4])
         out = paddle.randn([1, 4, 2, 4])
@@ -378,6 +397,7 @@ class TestUlyssesHelpers(unittest.TestCase):
         ):
             with self.subTest(signature=fake_attention.__name__):
                 with (
+                    cpp_flashmask_backend(),
                     patch.object(fa, "get_fa_version", return_value=3),
                     patch.object(fa, "flashmask_attention", fake_attention),
                     patch.object(fa, "_C_ops") as mock_c_ops,
@@ -767,6 +787,12 @@ class TestRefinedRcomputeFlashMaskCpAttentionModes(unittest.TestCase):
     def test_ulysses_functor_backward_fa3_signature_variants(self):
         local_grad = paddle.ones_like(self.out)
 
+        # ``hold["fa_version"] == 3`` only routes to ``_C_ops`` while the cutedsl
+        # switch is off, and the switch is read again inside ``backward``.
+        switch = cpp_flashmask_backend()
+        switch.start()
+        self.addCleanup(switch.stop)
+
         def flashmask_attention_with_group(query, key, value, group=None):
             return None
 
@@ -873,25 +899,6 @@ class TestRefinedRcomputeFlashMaskCpAttentionModes(unittest.TestCase):
                 self.assertEqual(len(grads), expected_len)
                 if requires_grad:
                     self.assertIs(grads[3], sink_grad)
-
-    def test_ulysses_functor_backward_rejects_invalid_fa_version(self):
-        ctx = FakeCtx()
-        hold = self._ulysses_hold(0)
-        fa.FlashMaskUlyssesCpFunctor.forward(
-            ctx, self.q, self.k, self.v, None, hold
-        )
-        with (
-            patch.object(fa, "_ulysses_fused_supported", return_value=False),
-            patch.object(
-                fa,
-                "_ulysses_single_all_to_all",
-                return_value=paddle.ones_like(self.out),
-            ),
-            self.assertRaises(ValueError),
-        ):
-            fa.FlashMaskUlyssesCpFunctor.backward(
-                ctx, paddle.ones_like(self.out)
-            )
 
     def test_second_forward_dispatches_each_mode(self):
         attn = fa.RefinedRcomputeFlashMaskCpAttention()

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_dot_product_attention_softmax_scale.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_dot_product_attention_softmax_scale.py
@@ -564,7 +564,7 @@ class TestCpFlashmaskSoftmaxScaleNotImplemented(unittest.TestCase):
     )
     @patch("paddlefleet.context_parallel_utils.flashmask_attention")
     @patch("paddlefleet.context_parallel_utils.paddle.distributed.all_gather")
-    @patch("paddlefleet.context_parallel_utils._flash_mask_available", False)
+    @patch("paddlefleet_ops.flash_mask_facade.FLASHMASK_FA3_USE_CUTEDSL", False)
     @patch(
         "paddlefleet.context_parallel_utils.paddle.get_flags",
         return_value={"FLAGS_cudnn_deterministic": False},
@@ -634,7 +634,7 @@ class TestCpFlashmaskSoftmaxScaleNotImplemented(unittest.TestCase):
     )
     @patch("paddlefleet.context_parallel_utils.flashmask_attention")
     @patch("paddlefleet.context_parallel_utils.paddle.distributed.all_gather")
-    @patch("paddlefleet.context_parallel_utils._flash_mask_available", False)
+    @patch("paddlefleet_ops.flash_mask_facade.FLASHMASK_FA3_USE_CUTEDSL", False)
     @patch(
         "paddlefleet.context_parallel_utils.paddle.get_flags",
         return_value={"FLAGS_cudnn_deterministic": False},
@@ -705,7 +705,7 @@ class TestCpFlashmaskSoftmaxScaleNotImplemented(unittest.TestCase):
     )
     @patch("paddlefleet.context_parallel_utils.flashmask_attention")
     @patch("paddlefleet.context_parallel_utils.paddle.distributed.all_gather")
-    @patch("paddlefleet.context_parallel_utils._flash_mask_available", False)
+    @patch("paddlefleet_ops.flash_mask_facade.FLASHMASK_FA3_USE_CUTEDSL", False)
     @patch(
         "paddlefleet.context_parallel_utils.paddle.get_flags",
         return_value={"FLAGS_cudnn_deterministic": False},
@@ -776,7 +776,7 @@ class TestCpFlashmaskSoftmaxScaleNotImplemented(unittest.TestCase):
     )
     @patch("paddlefleet.context_parallel_utils.flashmask_attention")
     @patch("paddlefleet.context_parallel_utils.paddle.distributed.all_gather")
-    @patch("paddlefleet.context_parallel_utils._flash_mask_available", False)
+    @patch("paddlefleet_ops.flash_mask_facade.FLASHMASK_FA3_USE_CUTEDSL", False)
     @patch(
         "paddlefleet.context_parallel_utils.paddle.get_flags",
         return_value={"FLAGS_cudnn_deterministic": False},
@@ -851,7 +851,7 @@ class TestCpFlashmaskSoftmaxScaleNotImplemented(unittest.TestCase):
     )
     @patch("paddlefleet.context_parallel_utils.flashmask_attention")
     @patch("paddlefleet.context_parallel_utils.paddle.distributed.all_gather")
-    @patch("paddlefleet.context_parallel_utils._flash_mask_available", False)
+    @patch("paddlefleet_ops.flash_mask_facade.FLASHMASK_FA3_USE_CUTEDSL", False)
     @patch(
         "paddlefleet.context_parallel_utils.paddle.get_flags",
         return_value={"FLAGS_cudnn_deterministic": False},
@@ -922,7 +922,7 @@ class TestCpFlashmaskSoftmaxScaleNotImplemented(unittest.TestCase):
     )
     @patch("paddlefleet.context_parallel_utils.flashmask_attention")
     @patch("paddlefleet.context_parallel_utils.paddle.distributed.all_gather")
-    @patch("paddlefleet.context_parallel_utils._flash_mask_available", False)
+    @patch("paddlefleet_ops.flash_mask_facade.FLASHMASK_FA3_USE_CUTEDSL", False)
     @patch(
         "paddlefleet.context_parallel_utils.paddle.get_flags",
         return_value={"FLAGS_cudnn_deterministic": False},

--- a/tests/single_card_tests/test_transformer_config.py
+++ b/tests/single_card_tests/test_transformer_config.py
@@ -597,5 +597,64 @@ class TestYamlArguments(unittest.TestCase):
         self.assertEqual(config.deepep_buffer_configs, {"num_sms": 24})
 
 
+class TestFlashAttnFa3Backend(unittest.TestCase):
+    """``flash_attn_fa3_backend`` and its hand-off to the ops facade.
+
+    The facade resolves the choice once per process, so every test drops it again
+    to avoid leaking a backend -- or a conflict -- into the rest of the suite.
+    """
+
+    def setUp(self):
+        from paddlefleet_ops import flash_mask_facade
+
+        self.facade = flash_mask_facade
+        self.addCleanup(flash_mask_facade._reset_fa3_backend)
+        flash_mask_facade._reset_fa3_backend()
+
+    def test_default_selects_cutedsl(self):
+        config = TransformerConfig()
+
+        self.assertEqual(config.flash_attn_fa3_backend, "cutedsl")
+        self.assertTrue(self.facade.uses_cutedsl_backend(3))
+
+    def test_cpp_backend_is_pushed_down_to_facade(self):
+        TransformerConfig(flash_attn_fa3_backend="cpp")
+
+        # FA3 follows the switch; FA4 stays cutedsl-only and FA2 never uses it.
+        self.assertFalse(self.facade.uses_cutedsl_backend(3))
+        self.assertTrue(self.facade.uses_cutedsl_backend(4))
+        self.assertFalse(self.facade.uses_cutedsl_backend(2))
+
+    def test_repeating_the_same_backend_is_accepted(self):
+        TransformerConfig(flash_attn_fa3_backend="cpp")
+        TransformerConfig(flash_attn_fa3_backend="cpp")
+
+        self.assertFalse(self.facade.uses_cutedsl_backend(3))
+
+    def test_second_config_with_a_different_backend_raises(self):
+        TransformerConfig(flash_attn_fa3_backend="cpp")
+
+        with self.assertRaisesRegex(
+            ValueError, r"cannot change within a process"
+        ) as context:
+            TransformerConfig()
+        message = str(context.exception)
+        self.assertIn("'cpp'", message)
+        self.assertIn("'cutedsl'", message)
+        # The first choice stays in force rather than half-applying the second.
+        self.assertFalse(self.facade.uses_cutedsl_backend(3))
+
+    def test_unknown_backend_raises_value_error(self):
+        with self.assertRaisesRegex(
+            ValueError, r"flash_attn_fa3_backend must be one of"
+        ) as context:
+            TransformerConfig(flash_attn_fa3_backend="cute")
+        self.assertIn("'cute'", str(context.exception))
+
+    def test_set_fa3_backend_rejects_unknown_value(self):
+        with self.assertRaisesRegex(ValueError, r"unknown FA3 backend 'cute'"):
+            self.facade.set_fa3_backend("cute")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/single_card_tests/transformer/hybrid_mla_utils.py
+++ b/tests/single_card_tests/transformer/hybrid_mla_utils.py
@@ -778,21 +778,42 @@ def _flash_attn_version(value):
 def _fa4_can_serve():
     """Whether pinning ``FLAGS_flash_attn_version=4`` can actually be served.
 
-    ``flash_mask_facade.get_fa_version`` answers from the flag and the head dims
-    alone -- it never checks that a FA4 backend exists. With no cute kernel the
-    facade's ``_flashmask_attention`` is ``paddle.nn.functional``'s, which knows
-    only 2 and 3 and raises ``ValueError: Invalid flash attention version: 4``
-    (``paddle/nn/functional/flash_attention.py:2179``) for *every* head-dim pair
-    the facade whitelists, ``(256, 256)`` plain MHA included. The upstream CI
-    images are cc 9.0 without the kernel, so pinning 4 unconditionally would
-    break the ``mha`` cases, which are not ``_GPU``-gated and used to run there
-    on the image default 2.
+    ``get_fa_version`` degrades to FA2 on its own when the cutedsl kernels are
+    missing, so a pinned 4 quietly becomes 2 instead of reaching a backend that
+    cannot serve it. This probe exists so callers can tell the difference: the
+    ``mha`` cases are not ``_GPU``-gated and run on cc 9.0 CI images without the
+    kernel, where they must keep taking the image default rather than asserting
+    FA4 behaviour.
     """
     try:
         from paddlefleet_ops import is_flash_mask_available
     except ImportError:  # pragma: no cover - packaged build always has it
         return False
     return bool(is_flash_mask_available()) and _production_fa_version() == 4
+
+
+@contextlib.contextmanager
+def cpp_flashmask_backend():
+    """Route FA3 FlashMask to Paddle's cpp kernel for the duration of the block.
+
+    ``FLASHMASK_FA3_USE_CUTEDSL`` is the routing flag, set from
+    ``TransformerConfig.flash_attn_fa3_backend="cpp"`` in production.
+    ``uses_cutedsl_backend`` reads
+    it on every call and ``PyLayer.backward`` reads it independently of the
+    forward, so a forward and its backward must both run inside this context --
+    leaving the block before ``.backward()`` would pair a cpp forward with a
+    cutedsl backward.
+
+    Patching the module global is the only reliable handle: several call sites do
+    ``from ... import uses_cutedsl_backend``, so patching that function on the
+    facade would not reach their already-bound references.
+    """
+    from unittest.mock import patch
+
+    from paddlefleet_ops import flash_mask_facade
+
+    with patch.object(flash_mask_facade, "FLASHMASK_FA3_USE_CUTEDSL", False):
+        yield
 
 
 @contextlib.contextmanager

--- a/tests/single_card_tests/transformer/test_flash_mask_sink.py
+++ b/tests/single_card_tests/transformer/test_flash_mask_sink.py
@@ -28,24 +28,42 @@ Covers PR "Support FA4 sink." (ab8c450) on the non-CP paths:
 
 import math
 import unittest
+from unittest.mock import patch
 
 import numpy as np
 import paddle
-from paddlefleet_ops import is_flash_mask_available
+from paddlefleet_ops import flash_mask_facade, is_flash_mask_available
 
-# Force FA4 (cute) backend for the whole module: sink only exists there.
-paddle.set_flags({"FLAGS_flash_attn_version": 4})
+_FA_VERSION_KEY = "FLAGS_flash_attn_version"
+_SAVED_FA_VERSION = None
+
+
+def setUpModule():
+    """Force the FA4 (cute) backend for this module: sink only exists there.
+
+    ``FLAGS_flash_attn_version`` is process-global, so pinning it at import time
+    would leak into every other test file collected in the same process (a
+    ``get_fa_version`` there would see 4 no matter what that file expects).
+    """
+    global _SAVED_FA_VERSION
+    _SAVED_FA_VERSION = paddle.get_flags([_FA_VERSION_KEY])[_FA_VERSION_KEY]
+    paddle.set_flags({_FA_VERSION_KEY: 4})
+
+
+def tearDownModule():
+    """Hand the process-global flag back to whatever it was."""
+    if _SAVED_FA_VERSION is not None:
+        paddle.set_flags({_FA_VERSION_KEY: _SAVED_FA_VERSION})
+
 
 DTYPE = paddle.bfloat16
 SEED = 2026
 
-# FA4 attention-sink lives only in the cute backend, which is built solely for
-# compute capability >= 10 (sm100/Blackwell). Elsewhere the cute kernels are
-# absent and the facade falls back to a sink-less backend, so skip these tests.
+# FA4 attention-sink lives only in the cute backend, which paddlefleet_ops builds
+# for compute capability >= 9 (Hopper and Blackwell). Elsewhere the cute kernels
+# are absent, dispatch degrades to a sink-less backend, so skip these tests.
 _SINK_AVAILABLE = is_flash_mask_available()
-_SKIP_REASON = (
-    "FA4 attention-sink requires the cute backend (sm100, capability >= 10)"
-)
+_SKIP_REASON = "FA4 attention-sink requires the cute backend (capability >= 9)"
 
 
 def _startend_row_indices(batch_size, seq_len, causal):
@@ -693,8 +711,11 @@ class TestRefinedRecomputeFlashMaskSink(unittest.TestCase):
         self._run(causal=True, use_sink=True, sink_trainable=False)
 
     def test_rr_non_fa4_sink_raises(self):
-        # Sink is only supported on the fa_version==4 cute backend; forcing v3
-        # must make the rr entry point reject a non-None sink.
+        # Sink lives in the cute kernels only, and on SM90 those serve FA3 too,
+        # so pinning FLAGS_flash_attn_version=3 no longer means "no sink" by
+        # itself -- the cpp kernel is what cannot serve it. Turn the hotfix
+        # switch off as well so FA3 resolves to the cpp backend, which is the
+        # case the rr entry point must reject.
         from paddlefleet.refined_recompute.flash_attn import (
             RefinedRcomputeFlashMaskAttention,
         )
@@ -711,7 +732,12 @@ class TestRefinedRecomputeFlashMaskSink(unittest.TestCase):
         ]
         paddle.set_flags({"FLAGS_flash_attn_version": 3})
         try:
-            with self.assertRaises(NotImplementedError):
+            with (
+                patch.object(
+                    flash_mask_facade, "FLASHMASK_FA3_USE_CUTEDSL", False
+                ),
+                self.assertRaises(NotImplementedError),
+            ):
                 rr_attn.forward(q, q, q, idx, learnable_sink=sink)
         finally:
             paddle.set_flags({"FLAGS_flash_attn_version": old})

--- a/tests/single_card_tests/transformer/test_hybrid_mla_recompute_mtp_ckpt.py
+++ b/tests/single_card_tests/transformer/test_hybrid_mla_recompute_mtp_ckpt.py
@@ -28,7 +28,8 @@ Coverage map (see validation_reports/A7_recompute_mtp_ckpt.md for the analysis):
      re-derived bit-identically on the recompute forward (a mismatch would
      silently differentiate a different sparsity pattern).
   2. Refined recompute guard: ``RefinedRcomputeFlashMaskAttention`` raises for a
-     learnable sink unless ``fa_version==4``; production dims are not fa4.
+     learnable sink unless the cute backend serves the picked fa version; on
+     SM90 that means FA3 with ``FLASHMASK_FA3_USE_CUTEDSL`` on.
   3. MTP tracker slot arithmetic: MTP ``layer_number==0`` -> ``values[-1]`` is
      only accidentally correct for a 44-entry tracker; two MTP layers collide.
   4. Checkpoint key-set compat: MHA <-> MQA byte-identical; mqa_dsa adds the
@@ -69,6 +70,7 @@ from .hybrid_mla_utils import (
     _rel,
     _row_end,
     _try_use_cuda_device,
+    cpp_flashmask_backend,
 )
 
 _add_repo_root_to_sys_path()
@@ -79,9 +81,11 @@ _add_repo_root_to_sys_path()
 # ===========================================================================
 class TestRefinedRecomputeSinkGuard(unittest.TestCase):
     """``RefinedRcomputeFlashMaskAttention.forward`` refuses a learnable sink
-    unless the fa cute backend (version 4) is active. The guard sits at the top
-    of ``forward`` (flash_attn.py:665-674), before any kernel call, so it can be
-    exercised on tiny CPU tensors by forcing ``get_fa_version``'s return.
+    unless the cute backend is active. The guard sits at the top of ``forward``
+    (flash_attn.py:658-667), before any kernel call, so it can be exercised on
+    tiny CPU tensors by forcing ``get_fa_version``'s return. FA3 only misses the
+    sink while the hotfix switch routes it to the cpp kernel -- on cute it is
+    served, so version 3 is checked inside ``cpp_flashmask_backend()``.
     """
 
     def _forward_module(self):
@@ -91,7 +95,7 @@ class TestRefinedRecomputeSinkGuard(unittest.TestCase):
 
         return RefinedRcomputeFlashMaskAttention()
 
-    def test_guard_raises_for_non_fa4_versions(self):
+    def test_guard_raises_for_non_cute_versions(self):
         import paddlefleet.refined_recompute.flash_attn as fa_mod
 
         mod = self._forward_module()
@@ -101,11 +105,15 @@ class TestRefinedRecomputeSinkGuard(unittest.TestCase):
         sink = paddle.zeros([2])
         orig = fa_mod.get_fa_version
         try:
-            for version in (2, 3):
-                fa_mod.get_fa_version = lambda *a, **k_: version
-                with self.assertRaises(NotImplementedError) as ctx:
-                    mod.forward(q, k, v, None, learnable_sink=sink)
-                self.assertIn("fa_version==4", str(ctx.exception))
+            with cpp_flashmask_backend():
+                for version in (2, 3):
+                    fa_mod.get_fa_version = lambda *a, **k_: version
+                    with self.assertRaises(NotImplementedError) as ctx:
+                        mod.forward(q, k, v, None, learnable_sink=sink)
+                    self.assertIn(
+                        "learnable_sink is only supported on the cute backend",
+                        str(ctx.exception),
+                    )
         finally:
             fa_mod.get_fa_version = orig
 
@@ -135,25 +143,42 @@ class TestRefinedRecomputeSinkGuard(unittest.TestCase):
         finally:
             fa_mod.get_fa_version = orig
 
-    def test_production_dims_are_not_fa4(self):
-        """Under the default ``FLAGS_flash_attn_version`` the MHA sink path
-        (q_head_dim 256 or MLA 192, v_head_dim 128) resolves to a non-4 version,
-        so an ``mha`` + sink + refined-recompute run *would* raise. Skipped if
-        the facade cannot be imported/called on this box."""
+    def test_production_dims_sink_support_follows_the_backend(self):
+        """Under the production ``FLAGS_flash_attn_version`` the sink is served
+        exactly when the picked version lands on the cute backend.
+
+        On SM90 production picks FA3 and, with ``FLASHMASK_FA3_USE_CUTEDSL`` on
+        (the default), cute serves it -- so the MLA pair (192, 128) does get the
+        sink. (256, 128) is not in the cutedsl head-dim whitelist (256 requires
+        ``head_dim_v == 256``), so it degrades to FA2 and the guard fires.
+        Turning the hotfix switch off routes FA3 to Paddle's kernel, where the
+        sink does not exist at any head dim."""
         try:
-            from paddlefleet_ops.flash_mask_facade import get_fa_version
+            from paddlefleet_ops.flash_mask_facade import (
+                get_fa_version,
+                uses_cutedsl_backend,
+            )
         except Exception as exc:  # pragma: no cover - env dependent
             self.skipTest(f"flash_mask_facade unavailable: {exc}")
-        got = {}
-        for qd in (256, 192):
+        production = _production_fa_version()
+        if production == 2:
+            self.skipTest("FA2-only box: no cute backend to dispatch to")
+
+        def _cute(qd):
             try:
-                got[qd] = int(get_fa_version(qd, 128, None))
+                return uses_cutedsl_backend(get_fa_version(qd, 128, None))
             except Exception as exc:  # pragma: no cover
                 self.skipTest(f"get_fa_version({qd},128,None) failed: {exc}")
-        for qd, ver in got.items():
-            self.assertNotEqual(
-                ver, 4, f"q_head_dim {qd} unexpectedly resolved to fa_version 4"
-            )
+
+        with _flash_attn_version(production):
+            self.assertTrue(_cute(192), "(192, 128) should stay on cute")
+            self.assertFalse(_cute(256), "(256, 128) should degrade to FA2")
+            with cpp_flashmask_backend():
+                for qd in (192, 256):
+                    self.assertFalse(
+                        _cute(qd),
+                        f"({qd}, 128) must leave cute once the switch is off",
+                    )
 
 
 # ===========================================================================
@@ -622,9 +647,9 @@ class TestRecomputeEquivalence(unittest.TestCase):
         )
 
         # Pinned per call site rather than per module: the full-causal phase has
-        # exactly one backend and ``_assert_dense_fa4`` raises otherwise, but
-        # ``test_production_dims_are_not_fa4`` in this same file asserts on the
-        # *unpinned* resolution, so a module-wide pin would falsify it.
+        # exactly one backend and ``_assert_dense_fa4`` raises otherwise, while
+        # ``test_production_dims_sink_support_follows_the_backend`` pins the
+        # production version itself, so a module-wide pin would fight it.
         with _flash_attn_version(4):
             _CAPTURED.clear()
             out_off, g_off = self._run(

--- a/tests/single_card_tests/transformer/test_hybrid_mla_warmup_dense_fa4.py
+++ b/tests/single_card_tests/transformer/test_hybrid_mla_warmup_dense_fa4.py
@@ -129,8 +129,9 @@ def _fa4_is_the_production_kernel():
 
 _FA4 = unittest.skipUnless(
     _fa4_is_the_production_kernel(),
-    "the dense warmup path needs the FA4 (cute) kernel, which production only "
-    "selects on SM100",
+    "the dense warmup path needs the FA4 (cute) kernel, which production selects "
+    "from the compute capability -- the cutedsl kernels are available from SM90 "
+    "on, but only SM100 derives FLAGS_flash_attn_version=4",
 )
 
 
@@ -343,14 +344,12 @@ class TestBackendSelection(unittest.TestCase):
     def test_missing_flash_mask_extension_raises(self):
         """FA4 as a flag value is not FA4 as a backend.
 
-        ``get_fa_version`` reads flags and head dims only, so on an image built
-        without the flash_mask (cute) extension it still answers 4 while the
-        facade has bound ``_flashmask_attention`` to Paddle's native one
-        (``flash_mask_facade.py``, ``else`` branch of the
-        ``is_flash_mask_available()`` guard) -- which serves neither this
-        head-dim pair nor the sink. Left to the kernel the failure reads
-        ``Invalid flash attention version: 4``, from a frame that names nothing
-        about this layer, so availability is part of the check here.
+        Without the flash_mask (cute) extension ``get_fa_version`` degrades to
+        FA2, so the pinned flag value of 4 never reaches a kernel that cannot
+        serve it. The check here is that the layer says so in its own terms --
+        naming the head-dim pair, the flags and ``flash_mask_available`` --
+        instead of letting a bare ``Invalid flash attention version: 4`` surface
+        from a frame that mentions nothing about this layer.
         """
         import paddlefleet_ops
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
在 SM90（Hopper）上启用 FA3 的 cutedsl 版本，让 FA3 与 FA4 共用同一条 kernel 路径。
1. 默认开始 flashmask cutedsl sm90 版本
2. 在 yaml 中配置 flash_attn_fa3_backend: cpp 可以回退  flashmask cpp sm90 版本（1-2月彻底稳定后该代码会删除）
3. 修复 pad 相关的逻辑


flash_attn_fa3_backend 开关控制 FA3 kernel 用 cutedsl 还是 C++。
1. 没有把它做成 cp_balance_mode 那样的传参，因为 FA3 的判定点散落在下层包 paddlefleet_ops 的 facade 和 14 个 PyLayer 里，传参要凿穿 5 个文件的签名，而这是个计划删除的临时开关，不值得铺一条再拆掉。
4. 也没有用环境变量，因为评审规则禁止。
5. 现在的做法是：配置在 __post_init__ 完成的那一刻，把值 push 到下层包的一个全局 bool 里。kernel 选择本来就是进程级的，__post_init__ 又一定早于任何 forward，所以"设一次、永不改"在语义上完全够用。set_fa3_backend 还加了幂等校验——同值重复设是 no-op，不同值直接报错，防止前反向读到不同 kernel。


### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
是