### PR TITLE
[release/0.4][Deps] Bump Paddle to `160041a4134`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ description = "Fleet Core - Core Functional Library for Large Scale Distributed 
 requires-python = ">=3.10"
 dependencies = [
     "colorlog>=6.10.1",
-    "paddlepaddle-gpu==3.4.0.post20260828+7328b320bd3",
+    "paddlepaddle-gpu==3.4.0.post20260901+160041a4134",
     "ruamel.yaml>=0.17",
     "tilelang-paddle==0.1.12",
 ]


### PR DESCRIPTION
### PR Category
Environment Adaptation

### PR Types
Others

### Description
Bump the pinned CUDA 12.9 Paddle dependency to `paddlepaddle-gpu==3.4.0.post20260901+160041a4134`.

Merged in dev: #1926
Develop PR: [#1926](https://github.com/PaddlePaddle/PaddleFleet/pull/1926)

Target Paddle commit: [`160041a413442751c4ada622372329c99ade5656`](https://github.com/PaddlePaddle/Paddle/commit/160041a413442751c4ada622372329c99ade5656).

The authoritative cu129 nightly index contains the target package for CPython 3.12:

- [CPython 3.12 wheel](https://paddle-whl.cdn.bcebos.com/nightly/cu129/paddlepaddle-gpu/paddlepaddle_gpu-3.4.0.post20260901%2B160041a4134-cp312-cp312-linux_x86_64.whl)

Validation: TOML and PEP 508 parsing, `git diff --check`, exact one-file/one-line delta, and `pre-commit run --files pyproject.toml` pass.

### 是否引起精度变化
否
