### PR TITLE
[release/0.4][DLTP-54994] Clean stale ARM wheel files

### DIFF
--- a/.github/workflows/pr_update_ops.yml
+++ b/.github/workflows/pr_update_ops.yml
@@ -576,6 +576,9 @@ jobs:
       - name: Download arm wheel name from bos
         if: github.ref_type != 'tag' && matrix.flavor.label == 'arm'
         run: |
+          name_file="${{ matrix.flavor.name_key }}"
+          # Remove the canonical file and numeric wget leftovers from reused runners.
+          rm -f -- "${name_file}" "${name_file}".[0-9]*
           wget --tries=5 --no-proxy https://paddle-github-action.bj.bcebos.com/PaddleFleet/${BRANCH}/${COMMIT_ID}/${{ matrix.flavor.name_key }} --no-check-certificate
 
       - name: Upload wheel to paddletest


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Bug fixes

### Description
同步 `develop` 的 ARM Ops wheel 修复到 `release/0.4`。

ARM wheel name 文件下载前清理规范文件及 wget 产生的数字后缀副本（如 `.name.1`、`.name.13`），避免复用 runner 工作目录时后续读取旧文件。其余下载、读取和通知逻辑保持不变。
Merged in dev: #1923

### 是否引起精度变化
否

关联任务：DLTP-54994

验证：
- `git diff --check`
- PyYAML workflow 解析
- 相对 `release/0.4` 仅修改 `.github/workflows/pr_update_ops.yml` 的 3 行
